### PR TITLE
Remove two references to the obsoleted DX9 backend in VideoCommon.

### DIFF
--- a/Source/Core/VideoCommon/EmuWindow.cpp
+++ b/Source/Core/VideoCommon/EmuWindow.cpp
@@ -155,8 +155,7 @@ HWND Create(HWND hParent, HINSTANCE hInstance, const TCHAR *title)
 {
 	// TODO:
 	// 1. Remove redundant window manipulation,
-	// 2. Make DX9 in fullscreen can be overlapped by other dialogs
-	// 3. Request window sizes which actually make the client area map to a common resolution
+	// 2. Request window sizes which actually make the client area map to a common resolution
 	HWND Ret;
 	int x=0, y=0, width=640, height=480;
 	Host_GetRenderWindowSize(x, y, width, height);

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -459,7 +459,7 @@ void VertexShaderManager::SetConstants()
 			projection hack for metroid other m...attempt to remove black projection layer from cut scenes.
 			g_fProjectionMatrix[15] = 1.0f was the default setting before
 			this hack was added...setting g_fProjectionMatrix[14] to -1 might make the hack more stable, needs more testing.
-			Only works for OGL and DX9...this is not helping DX11
+			Only works for OGL...this is not helping DX11
 			*/
 
 			g_fProjectionMatrix[14] = 0.0f;


### PR DESCRIPTION
DX9 isn't a backend anymore, so may as well get rid of them
