### PR TITLE
Vertex loader cleanup

### DIFF
--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -114,11 +114,12 @@ void D3DVertexFormat::Initialize(const PortableVertexDeclaration &_vtx_decl)
 		}
 	}
 
-	if (_vtx_decl.posmtx_offset != -1)
+	format = &_vtx_decl.posmtx;
+	if (format->enable)
 	{
 		m_elems[m_num_elems].SemanticName = "BLENDINDICES";
-		m_elems[m_num_elems].AlignedByteOffset = _vtx_decl.posmtx_offset;
-		m_elems[m_num_elems].Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		m_elems[m_num_elems].AlignedByteOffset = format->offset;
+		m_elems[m_num_elems].Format = VarToD3D(format->type, format->components, format->integer);
 		m_elems[m_num_elems].InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA;
 		++m_num_elems;
 	}

--- a/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
@@ -86,10 +86,7 @@ void GLVertexFormat::Initialize(const PortableVertexDeclaration &_vtx_decl)
 		SetPointer(SHADER_TEXTURE0_ATTRIB+i, vertex_stride, vtx_decl.texcoords[i]);
 	}
 
-	if (vtx_decl.posmtx_offset != -1) {
-		glEnableVertexAttribArray(SHADER_POSMTX_ATTRIB);
-		glVertexAttribPointer(SHADER_POSMTX_ATTRIB, 4, GL_UNSIGNED_BYTE, GL_FALSE, vtx_decl.stride, (u8*)NULL + vtx_decl.posmtx_offset);
-	}
+	SetPointer(SHADER_POSMTX_ATTRIB, vertex_stride, vtx_decl.posmtx);
 
 	vm->m_last_vao = VAO;
 }

--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -89,8 +89,7 @@ struct PortableVertexDeclaration
 	AttributeFormat normals[3];
 	AttributeFormat colors[2];
 	AttributeFormat texcoords[8];
-
-	int posmtx_offset;
+	AttributeFormat posmtx;
 };
 
 // The implementation of this class is specific for GL/DX, so NativeVertexFormat.cpp

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -756,12 +756,12 @@ void VertexLoader::CompileVertexTranslator()
 	if (m_VtxDesc.PosMatIdx)
 	{
 		WriteCall(PosMtx_Write);
-		vtx_decl.posmtx_offset = nat_offset;
+		vtx_decl.posmtx.components = 4;
+		vtx_decl.posmtx.enable = true;
+		vtx_decl.posmtx.offset = nat_offset;
+		vtx_decl.posmtx.type = VAR_UNSIGNED_BYTE;
+		vtx_decl.posmtx.integer = false;
 		nat_offset += 4;
-	}
-	else
-	{
-		vtx_decl.posmtx_offset = -1;
 	}
 
 	native_stride = nat_offset;

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -168,7 +168,7 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 				out.Write("  float%d tex%d : TEXCOORD%d,\n", hastexmtx ? 3 : 2, i, i);
 		}
 		if (components & VB_HAS_POSMTXIDX)
-			out.Write("  float4 blend_indices : BLENDINDICES,\n");
+			out.Write("  float4 fposmtx : BLENDINDICES,\n");
 		out.Write("  float4 rawpos : POSITION) {\n");
 	}
 	out.Write("VS_OUTPUT o;\n");
@@ -176,10 +176,7 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 	// transforms
 	if (components & VB_HAS_POSMTXIDX)
 	{
-		if (api_type == API_D3D)
-			out.Write("int posmtx = blend_indices.x * 255.0;\n"); // TODO: Ugly, should use an integer instead
-		else
-			out.Write("int posmtx = int(fposmtx);\n");
+		out.Write("int posmtx = int(fposmtx * 255.0);\n"); // TODO: Ugly, should use an integer instead
 
 		if (is_writing_shadercode && (DriverDetails::HasBug(DriverDetails::BUG_NODYNUBOACCESS) && !DriverDetails::HasBug(DriverDetails::BUG_ANNIHILATEDUBOS)) )
 		{


### PR DESCRIPTION
This branch was designed to move all vertex attributes information into VideoCommon. So now they are defined by the VertexLoader and the backends are supposed to just pass them through.

But as VideoSW also uses the VertexLoader in a _very_ hacky way, we aren' t allowed to use any new feature now. So in the end, it's a cleanup and a feature preparation.
