### PR TITLE
Move two macros (JITDISABLE and INSTRUCTION_START) into JitBase.h.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -37,16 +37,6 @@
 #include "x64Analyzer.h"
 #include "x64Emitter.h"
 
-// Use these to control the instruction selection
-// #define INSTRUCTION_START Default(inst); return;
-// #define INSTRUCTION_START PPCTables::CountInstruction(inst);
-#define INSTRUCTION_START
-
-#define JITDISABLE(setting) \
-	if (Core::g_CoreStartupParameter.bJITOff || \
-	Core::g_CoreStartupParameter.setting) \
-	{Default(inst); return;}
-
 class Jit64 : public Jitx86Base
 {
 private:

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
@@ -36,15 +36,6 @@
 #include "../../HW/Memmap.h"
 #include "../../HW/GPFifo.h"
 
-// #define INSTRUCTION_START Default(inst); return;
-// #define INSTRUCTION_START PPCTables::CountInstruction(inst);
-#define INSTRUCTION_START
-
-#define JITDISABLE(setting) \
-	if (Core::g_CoreStartupParameter.bJITOff || \
-		Core::g_CoreStartupParameter.setting) \
-		{Default(inst); return;}
-
 #ifdef _M_X64
 #define DISABLE64 \
 	{Default(inst); return;}

--- a/Source/Core/Core/PowerPC/JitArm32/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.h
@@ -39,14 +39,6 @@
 #include "JitAsm.h"
 #include "../JitCommon/JitBase.h"
 
-// Use these to control the instruction selection
-// #define INSTRUCTION_START Default(inst); return;
-// #define INSTRUCTION_START PPCTables::CountInstruction(inst);
-#define INSTRUCTION_START
-#define JITDISABLE(setting) \
-	if (Core::g_CoreStartupParameter.bJITOff || \
-	Core::g_CoreStartupParameter.setting) \
-	{Default(inst); return;}
 #define PPCSTATE_OFF(elem) ((s32)STRUCT_OFF(PowerPC::ppcState, elem) - (s32)STRUCT_OFF(PowerPC::ppcState, spr[0]))
 class JitArm : public JitBase, public ArmGen::ARMXCodeBlock
 {

--- a/Source/Core/Core/PowerPC/JitArmIL/JitIL.h
+++ b/Source/Core/Core/PowerPC/JitArmIL/JitIL.h
@@ -13,11 +13,6 @@
 #include "../JitCommon/JitBase.h"
 #include "JitILAsm.h"
 
-#define JITDISABLE(setting) \
-	if (Core::g_CoreStartupParameter.bJITOff || \
-		Core::g_CoreStartupParameter.setting) \
-		{Default(inst); return;}
-
 #define PPCSTATE_OFF(elem) ((s32)STRUCT_OFF(PowerPC::ppcState, elem) - (s32)STRUCT_OFF(PowerPC::ppcState, spr[0]))
 class JitArmIL : public JitILBase, public ArmGen::ARMXCodeBlock
 {

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -27,6 +27,16 @@
 
 #include <unordered_set>
 
+// Use these to control the instruction selection
+// #define INSTRUCTION_START Default(inst); return;
+// #define INSTRUCTION_START PPCTables::CountInstruction(inst);
+#define INSTRUCTION_START
+
+#define JITDISABLE(setting)                     \
+	if (Core::g_CoreStartupParameter.bJITOff || \
+		Core::g_CoreStartupParameter.setting)   \
+	{ Default(inst); return; }
+
 class JitBase : public CPUCoreBase
 {
 protected:

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase.h
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase.h
@@ -16,13 +16,6 @@
 #include "../../HW/GPFifo.h"
 #include "../../HW/Memmap.h"
 
-#define INSTRUCTION_START
-
-#define JITDISABLE(setting) \
-	if (Core::g_CoreStartupParameter.bJITOff || \
-		Core::g_CoreStartupParameter.setting) \
-		{Default(inst); return;}
-
 class JitILBase : public JitBase
 {
 protected:


### PR DESCRIPTION
Reduces 'copypasta' of macros across JIT platforms.

Keeps it nice and centralized on one macro set.
