### PR TITLE
buildbot: reset to upstream known revision

### DIFF
--- a/Tools/buildbot-try.sh
+++ b/Tools/buildbot-try.sh
@@ -28,8 +28,11 @@ shortrev=$(git describe --always --long --dirty=+ | sed 's/-g[0-9a-f]*\(+*\)$/\1
 
 author=$(grep try_username "$opt_file" | cut -d "'" -f 2)
 
+baserev=$(git merge-base HEAD origin/master)
+
 echo "Branch name: $branchname"
 echo "Change author: $author"
 echo "Short rev: $shortrev"
+echo "Base rev: $baserev"
 
-buildbot try --properties=branchname=$branchname,author=$author,shortrev=$shortrev $*
+git diff -r $baserev | buildbot try --properties=branchname=$branchname,author=$author,shortrev=$shortrev --diff=- -p1 --baserev $baserev $*


### PR DESCRIPTION
The current head is often not available in the main repo. So this scripts search for a common base revision and reset to this one.
Please keep care, pressing strg-c now may result in a git reset --soft
