### PR TITLE
VertexShaderGen: fix D3D posmtx attribute regression by VertexLoaderCleanup merge

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -168,7 +168,7 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 				out.Write("  float%d tex%d : TEXCOORD%d,\n", hastexmtx ? 3 : 2, i, i);
 		}
 		if (components & VB_HAS_POSMTXIDX)
-			out.Write("  float4 fposmtx : BLENDINDICES,\n");
+			out.Write("  float fposmtx : BLENDINDICES,\n");
 		out.Write("  float4 rawpos : POSITION) {\n");
 	}
 	out.Write("VS_OUTPUT o;\n");


### PR DESCRIPTION
Sorry, I'm too dumb too test my code. I hope this will work fine now.
