### PR TITLE
videosoftware: Added hack to bypass xfb just so fifoplayer works.

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbCopy.cpp
+++ b/Source/Core/VideoBackends/Software/EfbCopy.cpp
@@ -45,6 +45,10 @@ namespace EfbCopy
 				EfbInterface::BypassXFB(colorTexture, fbWidth, fbHeight, sourceRc, Gamma);
 
 				SWRenderer::swapColorTexture(); // Tell SWRenderer we are now finished with it.
+
+				// And since fifo player is broken and never calls BeginFrame/EndFrame
+				// We will do this swap now.
+				SWRenderer::Swap(fbWidth, fbHeight);
 			}
 		}
 	}

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -231,11 +231,13 @@ void VideoSoftware::Video_EndField()
 	// messy when the Hardware Rasterizer is enabled.
 	// And Neobrain loves his Hardware Rasterizer
 
-	// If we are runing dual core, Signal the GPU thread about the new colour texture.
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
-		Common::AtomicStoreRelease(s_swapRequested, true);
-	else
-		SWRenderer::Swap(s_beginFieldArgs.fbWidth, s_beginFieldArgs.fbHeight);
+	if (!g_SWVideoConfig.bBypassXFB) { // BypassXFB has already done a swap, so skip this.
+		// If we are runing dual core, Signal the GPU thread about the new colour texture.
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
+			Common::AtomicStoreRelease(s_swapRequested, true);
+		else
+			SWRenderer::Swap(s_beginFieldArgs.fbWidth, s_beginFieldArgs.fbHeight);
+	}
 }
 
 u32 VideoSoftware::Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)


### PR DESCRIPTION
Fifoplayer depends on the old behaviour of videosoftware (and the other
hardware backends in non virtual/real xfb modes) where the framebuffer
gets rendered directly to the screen.

Really fifoplayer should call BeginFrame/EndFrame when it finished
rendering a frame, but adding this hack back in is simpler.
