### PR TITLE
SWCommandProcessor: fix the CPReg structure fields

### DIFF
--- a/Source/Core/VideoBackends/Software/SWCommandProcessor.h
+++ b/Source/Core/VideoBackends/Software/SWCommandProcessor.h
@@ -98,14 +98,15 @@ namespace SWCommandProcessor
 		UCPStatusReg status;    // 0x00
 		UCPCtrlReg ctrl;        // 0x02
 		UCPClearReg clear;      // 0x04
-		u32 unk0;               // 0x06
-		u32 unk1;               // 0x0a
+		u32 unk0;               // 0x08
+		u16 unk1;               // 0x0c
 		u16 token;              // 0x0e
 		u16 bboxleft;           // 0x10
 		u16 bboxtop;            // 0x12
 		u16 bboxright;          // 0x14
 		u16 bboxbottom;         // 0x16
-		u16 unk2;               // 0x18
+		u32 unk2;               // 0x18
+		u32 unk3;               // 0x1c
 		u32 fifobase;           // 0x20
 		u32 fifoend;            // 0x24
 		u32 hiwatermark;        // 0x28


### PR DESCRIPTION
This structure fields should match byte-to-byte the layout of MMIO registers:
it is addressed using the MMIO reg address when doing a CP MMIO read. This was
unfortunately not the case, causing CP reads to be mostly broken with the
software renderer.
