### PR TITLE
Remove a pointless c_str() call in FileUtil.cpp.

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -496,7 +496,7 @@ u32 ScanDirectoryTree(const std::string &directory, FSTEntry& parentEntry)
 		entry.physicalName = directory;
 		entry.physicalName += DIR_SEP + entry.virtualName;
 
-		if (IsDirectory(entry.physicalName.c_str()))
+		if (IsDirectory(entry.physicalName))
 		{
 			entry.isDirectory = true;
 			// is a directory, lets go inside


### PR DESCRIPTION
Function takes a string as it's parameter so its pointless to do a c_str() call.
