### PR TITLE
audio latency fix

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -20,7 +20,7 @@
 #endif
 
 // Executed from sound stream thread
-unsigned int CMixer::Mix(short* samples, unsigned int numSamples)
+unsigned int CMixer::Mix(short* samples, unsigned int numSamples, bool consider_framelimit)
 {
 	if (!samples)
 		return 0;
@@ -58,7 +58,7 @@ unsigned int CMixer::Mix(short* samples, unsigned int numSamples)
 
 	u32 framelimit = SConfig::GetInstance().m_Framelimit;
 	float aid_sample_rate = AudioInterface::GetAIDSampleRate() + offset;
-	if (framelimit > 2)
+	if (consider_framelimit && framelimit > 2)
 	{
 		aid_sample_rate = aid_sample_rate * (framelimit - 1) * 5 / VideoInterface::TargetRefreshRate;
 	}

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -42,7 +42,7 @@ public:
 	virtual ~CMixer() {}
 
 	// Called from audio threads
-	virtual unsigned int Mix(short* samples, unsigned int numSamples);
+	virtual unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit = true);
 	virtual void Premix(short * /*samples*/, unsigned int /*numSamples*/) {}
 
 	// Called from main thread

--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -192,7 +192,7 @@ void OpenALStream::SoundLoop()
 		unsigned int minSamples = surround_capable ? 240 : 0; // DPL2 accepts 240 samples minimum (FWRDURATION)
 
 		numSamples = (numSamples > OAL_MAX_SAMPLES) ? OAL_MAX_SAMPLES : numSamples;
-		numSamples = m_mixer->Mix(realtimeBuffer, numSamples);
+		numSamples = m_mixer->Mix(realtimeBuffer, numSamples, false);
 
 		// Convert the samples from short to float
 		float dest[OAL_MAX_SAMPLES * STEREO_CHANNELS];


### PR DESCRIPTION
This branch will control the interpolation to reduce the latency as much as possible. The current setting are 50ms, but the need to be tested on different plattforms.
