### PR TITLE
Fix a typo in EGL.h for setting mode.

### DIFF
--- a/Source/Core/DolphinWX/GLInterface/EGL.h
+++ b/Source/Core/DolphinWX/GLInterface/EGL.h
@@ -52,7 +52,7 @@ public:
 	friend class cPlatform;
 	void SwapInterval(int Interval);
 	void Swap();
-	void SetMode(u32 mode) { s_opengl_mode = GLInterfaceMode::MODE_DETECT; }
+	void SetMode(u32 mode) { s_opengl_mode = mode; }
 	void UpdateFPSDisplay(const char *Text);
 	void* GetFuncAddress(std::string name);
 	bool Create(void *&window_handle);


### PR DESCRIPTION
Seems to have been a copy and paste issue where SetMode would always set to DETECT
This isn't right since mode should be set correctly by SetMode
