### PR TITLE
Remove Cache DL option from Android UI

### DIFF
--- a/Source/Android/res/values-ja/strings.xml
+++ b/Source/Android/res/values-ja/strings.xml
@@ -185,8 +185,6 @@
     <string name="external_frame_buffer_descrip">XFBをエミュレート方法を決定。</string>
     <string name="external_frame_buffer_virtual">バーチャル</string>
     <string name="external_frame_buffer_real">実機</string>
-    <string name="cache_display_lists">Cache Display Lists</string>
-    <string name="cache_display_lists_descrip">ディスプレイリストをキャッシュすることによりエミュレーション速度を向上。</string>
     <string name="disable_destination_alpha">Disable Destination Alpha</string>
     <string name="disable_destination_alpha_descrip">多くのタイトルで画面効果に使用されている、アルファ透過処理をスキップ 。</string>
     <string name="fast_depth_calculation">高速奥行き計算</string>

--- a/Source/Android/res/values/strings.xml
+++ b/Source/Android/res/values/strings.xml
@@ -187,8 +187,6 @@
     <string name="external_frame_buffer_descrip">Determines how the XFB will be emulated.</string>
     <string name="external_frame_buffer_virtual">Virtual</string>
     <string name="external_frame_buffer_real">Real</string>
-    <string name="cache_display_lists">Cache Display Lists</string>
-    <string name="cache_display_lists_descrip">Speeds up emulation a bit by caching display lists.</string>
     <string name="disable_destination_alpha">Disable Destination Alpha</string>
     <string name="disable_destination_alpha_descrip">Disables emulation of a hardware feature called destination alpha, which is used in many games for various effects.</string>
     <string name="fast_depth_calculation">Fast Depth Calculation</string>

--- a/Source/Android/res/xml/video_prefs.xml
+++ b/Source/Android/res/xml/video_prefs.xml
@@ -108,12 +108,6 @@
 
             <CheckBoxPreference
                 android:defaultValue="false"
-                android:key="cacheDisplayLists"
-                android:summary="@string/cache_display_lists_descrip"
-                android:title="@string/cache_display_lists"/>
-
-            <CheckBoxPreference
-                android:defaultValue="false"
                 android:key="disableDestinationAlpha"
                 android:summary="@string/disable_destination_alpha_descrip"
                 android:title="@string/disable_destination_alpha"/>

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/UserPreferences.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/UserPreferences.java
@@ -146,9 +146,6 @@ public final class UserPreferences
 		// External frame buffer emulation. Falls back to disabled upon error.
 		String externalFrameBuffer = prefs.getString("externalFrameBuffer", "Disabled");
 
-		// Whether or not display list caching is enabled.
-		boolean dlistCachingEnabled = prefs.getBoolean("cacheDisplayLists", false);
-
 		// Whether or not to disable destination alpha.
 		boolean disableDstAlphaPass = prefs.getBoolean("disableDestinationAlpha", false);
 


### PR DESCRIPTION
This option has been removed entirely from Dolphin, so remove the option from Android
