### PR TITLE
Gameini update for FINAL FANTASY FABLES: Chocobo's Dungeon.

### DIFF
--- a/Data/Sys/GameSettings/R7FEGD.ini
+++ b/Data/Sys/GameSettings/R7FEGD.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Map is a bit broken.
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/R7FJGD.ini
+++ b/Data/Sys/GameSettings/R7FJGD.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Map is a bit broken.
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -24,4 +24,3 @@ PH_SZFar = 0
 PH_ExtraParam = 0
 PH_ZNear =
 PH_ZFar =
-

--- a/Data/Sys/GameSettings/R7FPGD.ini
+++ b/Data/Sys/GameSettings/R7FPGD.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Map is a bit broken.
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
Minimap is fixed for the game in latest dev, so removing the emu issue
notes. Testing commit.
