### PR TITLE
Remove function Xchg from SWStatistics.cpp. 

### DIFF
--- a/Source/Core/VideoBackends/Software/SWStatistics.cpp
+++ b/Source/Core/VideoBackends/Software/SWStatistics.cpp
@@ -6,14 +6,6 @@
 
 SWStatistics swstats;
 
-template <class T>
-void Xchg(T& a, T&b)
-{
-	T c = a;
-	a = b;
-	b = c;
-}
-
 SWStatistics::SWStatistics()
 {
 	frameCount = 0;


### PR DESCRIPTION
Like the one previous, this can be replaced with std::swap (however it's not used at all in this case).

Also this makes me wonder how much of the SW renderer was just copy/pasted, because there's a bunch of other things that can be culled out for stuff that exists in VideoCommon.
