### PR TITLE
x64: drop instructions that don't exist

### DIFF
--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -446,14 +446,6 @@ public:
 	// SSE/SSE2: Floating point bitwise (yes)
 	void CMPSS(X64Reg regOp, OpArg arg, u8 compare);
 	void CMPSD(X64Reg regOp, OpArg arg, u8 compare);
-	void ANDSS(X64Reg regOp, OpArg arg);
-	void ANDSD(X64Reg regOp, OpArg arg);
-	void ANDNSS(X64Reg regOp, OpArg arg);
-	void ANDNSD(X64Reg regOp, OpArg arg);
-	void ORSS(X64Reg regOp, OpArg arg);
-	void ORSD(X64Reg regOp, OpArg arg);
-	void XORSS(X64Reg regOp, OpArg arg);
-	void XORSD(X64Reg regOp, OpArg arg);
 
 	// SSE/SSE2: Floating point packed arithmetic (x4 for float, x2 for double)
 	void ADDPS(X64Reg regOp, OpArg arg);


### PR DESCRIPTION
These instructions don't exist in hardware although I agree that they
would be useful for our purposes ;)
