### PR TITLE
Fix the Android OpenGL About tab.

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -200,6 +200,9 @@ public final class NativeLibrary
 	/** Stops emulation. */
 	public static native void StopEmulation();
 
+	/** Native EGL functions not exposed by Java bindings **/
+	public static native void eglBindAPI(int api);
+
 	static
 	{
 		try

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/GLES2InfoFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/GLES2InfoFragment.java
@@ -28,8 +28,6 @@ import java.util.List;
  */
 public final class GLES2InfoFragment extends ListFragment
 {
-	private final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_ES2_BIT);
-
 	private final Limit[] Limits = {
 			new Limit("Vendor", GLES20.GL_VENDOR, Type.STRING),
 			new Limit("Version", GLES20.GL_VERSION, Type.STRING),
@@ -56,6 +54,8 @@ public final class GLES2InfoFragment extends ListFragment
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 	{
+		final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_ES2_BIT);
+
 		ListView rootView = (ListView) inflater.inflate(R.layout.gamelist_listview, container, false);
 		List<AboutActivity.AboutFragmentItem> Input = new ArrayList<AboutActivity.AboutFragmentItem>();
 

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/GLES3InfoFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/GLES3InfoFragment.java
@@ -28,8 +28,6 @@ import java.util.List;
  */
 public final class GLES3InfoFragment extends ListFragment
 {
-	private final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_ES3_BIT_KHR);
-
 	private final Limit[] Limits = {
 			new Limit("Vendor", GLES30.GL_VENDOR, Type.STRING),
 			new Limit("Version", GLES30.GL_VERSION, Type.STRING),
@@ -88,6 +86,8 @@ public final class GLES3InfoFragment extends ListFragment
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 	{
+		final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_ES3_BIT_KHR);
+
 		ListView rootView = (ListView) inflater.inflate(R.layout.gamelist_listview, container, false);
 		List<AboutActivity.AboutFragmentItem> Input = new ArrayList<AboutActivity.AboutFragmentItem>();
 

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/GLInfoFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/GLInfoFragment.java
@@ -31,8 +31,6 @@ import javax.microedition.khronos.opengles.GL10;
  */
 public final class GLInfoFragment extends ListFragment
 {
-	private final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_BIT);
-
 	private final Limit[] Limits = {
 			new Limit("Vendor", GL10.GL_VENDOR, Type.STRING),
 			new Limit("Version", GL10.GL_VERSION, Type.STRING),
@@ -43,6 +41,8 @@ public final class GLInfoFragment extends ListFragment
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 	{
+		final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_BIT);
+
 		ListView rootView = (ListView) inflater.inflate(R.layout.gamelist_listview, container, false);
 		List<AboutActivity.AboutFragmentItem> Input = new ArrayList<AboutActivity.AboutFragmentItem>();
 

--- a/Source/Android/src/org/dolphinemu/dolphinemu/utils/EGLHelper.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/utils/EGLHelper.java
@@ -16,6 +16,8 @@ import javax.microedition.khronos.opengles.GL10;
 import android.opengl.GLES30;
 import android.util.Log;
 
+import org.dolphinemu.dolphinemu.NativeLibrary;
+
 /**
  * Utility class that abstracts all the stuff about
  * EGL initialization out of the way if all that is 
@@ -40,6 +42,10 @@ public final class EGLHelper
 	public static final int EGL_OPENGL_ES2_BIT     = 0x0004;
 	public static final int EGL_OPENGL_BIT         = 0x0008;
 	public static final int EGL_OPENGL_ES3_BIT_KHR = 0x0040;
+
+	// API types
+	public static final int EGL_OPENGL_ES_API = 0x30A0;
+	public static final int EGL_OPENGL_API    = 0x30A2;
 
 	/**
 	 * Constructor
@@ -295,6 +301,10 @@ public final class EGLHelper
 				ctx_attribs[1] = 2;
 				break;
 		}
+		if (renderableType == EGL_OPENGL_BIT)
+			NativeLibrary.eglBindAPI(EGL_OPENGL_API);
+		else
+			NativeLibrary.eglBindAPI(EGL_OPENGL_ES_API);
 
 		mEGLContext = mEGL.eglCreateContext(mDisplay, mEGLConfigs[0], EGL10.EGL_NO_CONTEXT, ctx_attribs);
 		mEGLSurface = mEGL.eglCreatePbufferSurface(mDisplay, mEGLConfigs[0], attribs);

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -21,6 +21,7 @@
 #include <jni.h>
 #include <android/log.h>
 #include <android/native_window_jni.h>
+#include <EGL/egl.h>
 
 #include "Android/ButtonManager.h"
 #include "Common/Common.h"
@@ -295,6 +296,11 @@ JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Supports
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveScreenShot(JNIEnv *env, jobject obj)
 {
 	Core::SaveScreenShot();
+}
+
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_eglBindAPI(JNIEnv *env, jobject obj, jint api)
+{
+	eglBindAPI(api);
 }
 
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetConfig(JNIEnv *env, jobject obj, jstring jFile, jstring jKey, jstring jValue, jstring jDefault)


### PR DESCRIPTION
Move EGLHelper to be local to the creation of the about GL/GLES tabs so we don't have 3 EGL contexts running at a time.
Fix issues with OpenGL context creation here so we show the correct information.
This requires adding an EGL function to the NativeLibrary since Android's JAVA bindings don't expose eglBindAPI.
