### PR TITLE
Win32: work around a 2013 CRT issue with FMA3

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -33,6 +33,11 @@
 
 #include <wx/intl.h>
 
+#if defined _WIN32 && defined _M_X64
+// required for _set_FMA3_enable in DolphinApp::OnInit
+#include <math.h>
+#endif
+
 #ifdef _WIN32
 #include <shellapi.h>
 
@@ -120,6 +125,11 @@ bool DolphinApp::Initialize(int& c, wxChar **v)
 
 bool DolphinApp::OnInit()
 {
+#if defined _WIN32 && defined _M_X64
+	// FMA3 support in the 2013 CRT is broken on Vista and Windows 7 RTM (fixed in SP1). Just disable it.
+	// This issue is documented in Microsoft Connect ID 811093.
+	_set_FMA3_enable(0);
+#endif
 	InitLanguageSupport();
 
 	// Declarations and definitions

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -25,6 +25,11 @@
 #import <Cocoa/Cocoa.h>
 #endif
 
+#if defined _WIN32 && defined _M_X64
+// required for _set_FMA3_enable in main
+#include <math.h>
+#endif
+
 #include "Core.h"
 #include "Host.h"
 #include "CPUDetect.h"
@@ -286,6 +291,10 @@ int main(int argc, char* argv[])
 	[NSApplication sharedApplication];
 	[NSApp activateIgnoringOtherApps: YES];
 	[NSApp finishLaunching];
+#elif defined _WIN32 && defined _M_X64
+	// FMA3 support in the 2013 CRT is broken on Vista and Windows 7 RTM (fixed in SP1). Just disable it.
+	// This issue is documented in Microsoft Connect ID 811093.
+	_set_FMA3_enable(0);
 #endif
 	int ch, help = 0;
 	struct option longopts[] = {


### PR DESCRIPTION
The discussion on the ML is still going atm, but since the fix is an easy one I just went ahead and did it. IMO accepting/rejecting a PR reaches more people that care than just posting on the ML, so feel free to discuss further things here.

Tbh. I have no idea how the issue looks like (being on AMD); i just did the typing/commenting/pushing work. However, it seems to be well documented how to work around it (not just on MS Connect, even ector pushed it to PPSSPP).

And, of course, anyone testing it on an affected would be appreciated.
