### PR TITLE
Kill off some usages of the ArraySize macro.

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -111,7 +111,7 @@ bool CompareValues(const u32 val1, const u32 val2, const int type);
 
 // ----------------------
 // AR Remote Functions
-void LoadCodes(IniFile &globalIni, IniFile &localIni, bool forceLoad)
+void LoadCodes(const IniFile& globalIni, const IniFile& localIni, bool forceLoad)
 {
 	// Parses the Action Replay section of a game ini file.
 	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats
@@ -132,22 +132,17 @@ void LoadCodes(IniFile &globalIni, IniFile &localIni, bool forceLoad)
 		}
 	}
 
-	IniFile* inis[] = {&globalIni, &localIni};
-	for (size_t i = 0; i < ArraySize(inis); ++i)
+	const IniFile* inis[2] = {&globalIni, &localIni};
+	for (const IniFile* ini : inis)
 	{
 		std::vector<std::string> lines;
 		std::vector<std::string> encryptedLines;
 		ARCode currentCode;
 
-		inis[i]->GetLines("ActionReplay", lines);
+		ini->GetLines("ActionReplay", lines);
 
-		std::vector<std::string>::const_iterator
-			it = lines.begin(),
-			lines_end = lines.end();
-		for (; it != lines_end; ++it)
+		for (std::string line : lines)
 		{
-			const std::string line = *it;
-
 			if (line.empty())
 				continue;
 
@@ -171,7 +166,7 @@ void LoadCodes(IniFile &globalIni, IniFile &localIni, bool forceLoad)
 
 				currentCode.name = line.substr(1, line.size() - 1);
 				currentCode.active = enabledNames.find(currentCode.name) != enabledNames.end();
-				currentCode.user_defined = (i == 1);
+				currentCode.user_defined = (ini == &localIni);
 			}
 			else
 			{

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -27,7 +27,7 @@ struct ARCode
 
 void RunAllActive();
 bool RunCode(const ARCode &arcode);
-void LoadCodes(IniFile &globalini, IniFile &localIni, bool forceLoad);
+void LoadCodes(const IniFile &globalini, const IniFile &localIni, bool forceLoad);
 void LoadCodes(std::vector<ARCode> &_arCodes, IniFile &globalini, IniFile &localIni);
 size_t GetCodeListSize();
 ARCode GetARCode(size_t index);

--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -15,11 +15,12 @@ namespace Gecko
 
 void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<GeckoCode>& gcodes)
 {
-	const IniFile* inis[] = {&globalIni, &localIni};
-	for (size_t i = 0; i < ArraySize(inis); ++i)
+	const IniFile* inis[2] = { &globalIni, &localIni };
+
+	for (const IniFile* ini : inis)
 	{
 		std::vector<std::string> lines;
-		inis[i]->GetLines("Gecko", lines, false);
+		ini->GetLines("Gecko", lines, false);
 
 		GeckoCode gcode;
 
@@ -40,11 +41,11 @@ void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<Ge
 				if (gcode.name.size())
 					gcodes.push_back(gcode);
 				gcode = GeckoCode();
-				gcode.enabled = (1 == ss.tellg());	// silly
-				gcode.user_defined = i == 1;
+				gcode.enabled = (1 == ss.tellg());  // silly
+				gcode.user_defined = (ini == &localIni);
 				ss.seekg(1, std::ios_base::cur);
 				// read the code name
-				std::getline(ss, gcode.name, '[');	// stop at [ character (beginning of contributor name)
+				std::getline(ss, gcode.name, '[');  // stop at [ character (beginning of contributor name)
 				gcode.name = StripSpaces(gcode.name);
 				// read the code creator name
 				std::getline(ss, gcode.creator, ']');
@@ -73,7 +74,7 @@ void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<Ge
 		if (gcode.name.size())
 			gcodes.push_back(gcode);
 
-		inis[i]->GetLines("Gecko_Enabled", lines, false);
+		ini->GetLines("Gecko_Enabled", lines, false);
 
 		for (auto line : lines)
 		{

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -46,8 +46,8 @@ std::vector<Patch> onFrame;
 std::map<u32, int> speedHacks;
 std::vector<std::string> discList;
 
-void LoadPatchSection(const char *section, std::vector<Patch> &patches,
-                      IniFile &globalIni, IniFile &localIni)
+void LoadPatchSection(const char *section, std::vector<Patch>& patches,
+                      IniFile& globalIni, IniFile& localIni)
 {
 	// Load the name of all enabled patches
 	std::string enabledSectionName = std::string(section) + "_Enabled";
@@ -63,13 +63,13 @@ void LoadPatchSection(const char *section, std::vector<Patch> &patches,
 		}
 	}
 
-	IniFile* inis[] = {&globalIni, &localIni};
+	const IniFile* inis[2] = {&globalIni, &localIni};
 
-	for (size_t i = 0; i < ArraySize(inis); ++i)
+	for (const IniFile* ini : inis)
 	{
 		std::vector<std::string> lines;
 		Patch currentPatch;
-		inis[i]->GetLines(section, lines);
+		ini->GetLines(section, lines);
 
 		for (std::string& line : lines)
 		{
@@ -86,7 +86,7 @@ void LoadPatchSection(const char *section, std::vector<Patch> &patches,
 				// Set active and name
 				currentPatch.name = line.substr(1, line.size() - 1);
 				currentPatch.active = enabledNames.find(currentPatch.name) != enabledNames.end();
-				currentPatch.user_defined = (i == 1);
+				currentPatch.user_defined = (ini == &localIni);
 			}
 			else
 			{

--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -9,20 +9,21 @@ PerfQuery::PerfQuery()
 	: m_query_read_pos()
 	, m_query_count()
 {
-	for (int i = 0; i != ArraySize(m_query_buffer); ++i)
+	for (ActiveQuery& entry : m_query_buffer)
 	{
 		D3D11_QUERY_DESC qdesc = CD3D11_QUERY_DESC(D3D11_QUERY_OCCLUSION, 0);
-		D3D::device->CreateQuery(&qdesc, &m_query_buffer[i].query);
+		D3D::device->CreateQuery(&qdesc, &entry.query);
 	}
+
 	ResetQuery();
 }
 
 PerfQuery::~PerfQuery()
 {
-	for (int i = 0; i != ArraySize(m_query_buffer); ++i)
+	for (ActiveQuery& entry : m_query_buffer)
 	{
 		// TODO: EndQuery?
-		m_query_buffer[i].query->Release();
+		entry.query->Release();
 	}
 }
 
@@ -32,10 +33,10 @@ void PerfQuery::EnableQuery(PerfQueryGroup type)
 		return;
 
 	// Is this sane?
-	if (m_query_count > ArraySize(m_query_buffer) / 2)
+	if (m_query_count > m_query_buffer.size() / 2)
 		WeakFlush();
 
-	if (ArraySize(m_query_buffer) == m_query_count)
+	if (m_query_buffer.size() == m_query_count)
 	{
 		// TODO
 		FlushOne();
@@ -45,7 +46,7 @@ void PerfQuery::EnableQuery(PerfQueryGroup type)
 	// start query
 	if (type == PQG_ZCOMP_ZCOMPLOC || type == PQG_ZCOMP)
 	{
-		auto& entry = m_query_buffer[(m_query_read_pos + m_query_count) % ArraySize(m_query_buffer)];
+		auto& entry = m_query_buffer[(m_query_read_pos + m_query_count) % m_query_buffer.size()];
 
 		D3D::context->Begin(entry.query);
 		entry.query_type = type;
@@ -62,7 +63,7 @@ void PerfQuery::DisableQuery(PerfQueryGroup type)
 	// stop query
 	if (type == PQG_ZCOMP_ZCOMPLOC || type == PQG_ZCOMP)
 	{
-		auto& entry = m_query_buffer[(m_query_read_pos + m_query_count + ArraySize(m_query_buffer)-1) % ArraySize(m_query_buffer)];
+		auto& entry = m_query_buffer[(m_query_read_pos + m_query_count + m_query_buffer.size()-1) % m_query_buffer.size()];
 		D3D::context->End(entry.query);
 	}
 }
@@ -118,7 +119,7 @@ void PerfQuery::FlushOne()
 	// NOTE: Reported pixel metrics should be referenced to native resolution
 	m_results[entry.query_type] += (u32)(result * EFB_WIDTH / g_renderer->GetTargetWidth() * EFB_HEIGHT / g_renderer->GetTargetHeight());
 
-	m_query_read_pos = (m_query_read_pos + 1) % ArraySize(m_query_buffer);
+	m_query_read_pos = (m_query_read_pos + 1) % m_query_buffer.size();
 	--m_query_count;
 }
 
@@ -149,7 +150,7 @@ void PerfQuery::WeakFlush()
 			// NOTE: Reported pixel metrics should be referenced to native resolution
 			m_results[entry.query_type] += (u32)(result * EFB_WIDTH / g_renderer->GetTargetWidth() * EFB_HEIGHT / g_renderer->GetTargetHeight());
 
-			m_query_read_pos = (m_query_read_pos + 1) % ArraySize(m_query_buffer);
+			m_query_read_pos = (m_query_read_pos + 1) % m_query_buffer.size();
 			--m_query_count;
 		}
 		else

--- a/Source/Core/VideoBackends/D3D/PerfQuery.h
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include "PerfQueryBase.h"
 
 namespace DX11 {
@@ -32,7 +33,7 @@ private:
 	// when testing in SMS: 64 was too small, 128 was ok
 	static const int PERF_QUERY_BUFFER_SIZE = 512;
 
-	ActiveQuery m_query_buffer[PERF_QUERY_BUFFER_SIZE];
+	std::array<ActiveQuery, PERF_QUERY_BUFFER_SIZE> m_query_buffer;
 	int m_query_read_pos;
 
 	// TODO: sloppy

--- a/Source/Core/VideoBackends/OGL/PerfQuery.h
+++ b/Source/Core/VideoBackends/OGL/PerfQuery.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include "PerfQueryBase.h"
 
 namespace OGL {
@@ -32,7 +33,7 @@ private:
 	void FlushOne();
 
 	// This contains gl query objects with unretrieved results.
-	ActiveQuery m_query_buffer[PERF_QUERY_BUFFER_SIZE];
+	std::array<ActiveQuery, PERF_QUERY_BUFFER_SIZE> m_query_buffer;
 	u32 m_query_read_pos;
 
 	// TODO: sloppy


### PR DESCRIPTION
This required the use of std::array in some cases.

Blame Windows case-insensitivity in cmd for closing the other similar named PR.
