### PR TITLE
Silence some Windows compiler warnings

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -473,9 +473,9 @@ namespace EfbInterface
 
 		// GameCube/Wii uses the BT.601 standard algorithm for converting to YCbCr; see
 		// http://www.equasys.de/colorconversion.html#YCbCr-RGBColorFormatConversion
-		out->Y =  0.257f * color[RED_C] +  0.504f * color[GRN_C] +  0.098f * color[BLU_C];
-		out->U = -0.148f * color[RED_C] + -0.291f * color[GRN_C] +  0.439f * color[BLU_C];
-		out->V =  0.439f * color[RED_C] + -0.368f * color[GRN_C] + -0.071f * color[BLU_C];
+		out->Y = (u8)( 0.257f * color[RED_C] +  0.504f * color[GRN_C] +  0.098f * color[BLU_C]);
+		out->U = (u8)(-0.148f * color[RED_C] + -0.291f * color[GRN_C] +  0.439f * color[BLU_C]);
+		out->V = (u8)( 0.439f * color[RED_C] + -0.368f * color[GRN_C] + -0.071f * color[BLU_C]);
 	}
 
 	u32 GetDepth(u16 x, u16 y)

--- a/Source/Core/VideoBackends/Software/HwRasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/HwRasterizer.cpp
@@ -163,8 +163,8 @@ namespace HwRasterizer
 		// While GLES uses texture coordinates
 		if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGL)
 		{
-			width = texUnit.texImage0[0].width;
-			height = texUnit.texImage0[0].height;
+			width = (float)texUnit.texImage0[0].width;
+			height = (float)texUnit.texImage0[0].height;
 		}
 		else
 		{

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -182,14 +182,14 @@ void SWRenderer::UpdateColorTexture(EfbInterface::yuv422_packed *xfb, u32 fbWidt
 
 			// We do the inverse BT.601 conversion for YCbCr to RGB
 			// http://www.equasys.de/colorconversion.html#YCbCr-RGBColorFormatConversion
-			TexturePointer[offset++] = min(255.0f, max(0.0f, 1.164f * Y1              + 1.596f * V));
-			TexturePointer[offset++] = min(255.0f, max(0.0f, 1.164f * Y1 - 0.392f * U - 0.813f * V));
-			TexturePointer[offset++] = min(255.0f, max(0.0f, 1.164f * Y1 + 2.017f * U             ));
+			TexturePointer[offset++] = (u8)min(255.0f, max(0.0f, 1.164f * Y1              + 1.596f * V));
+			TexturePointer[offset++] = (u8)min(255.0f, max(0.0f, 1.164f * Y1 - 0.392f * U - 0.813f * V));
+			TexturePointer[offset++] = (u8)min(255.0f, max(0.0f, 1.164f * Y1 + 2.017f * U             ));
 			TexturePointer[offset++] = 255;
 
-			TexturePointer[offset++] = min(255.0f, max(0.0f, 1.164f * Y2              + 1.596f * V));
-			TexturePointer[offset++] = min(255.0f, max(0.0f, 1.164f * Y2 - 0.392f * U - 0.813f * V));
-			TexturePointer[offset++] = min(255.0f, max(0.0f, 1.164f * Y2 + 2.017f * U             ));
+			TexturePointer[offset++] = (u8)min(255.0f, max(0.0f, 1.164f * Y2              + 1.596f * V));
+			TexturePointer[offset++] = (u8)min(255.0f, max(0.0f, 1.164f * Y2 - 0.392f * U - 0.813f * V));
+			TexturePointer[offset++] = (u8)min(255.0f, max(0.0f, 1.164f * Y2 + 2.017f * U             ));
 			TexturePointer[offset++] = 255;
 		}
 		xfb += fbWidth;


### PR DESCRIPTION
by adding explicit type casts.
