### PR TITLE
Fix crash when pressing Tab

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -706,13 +706,16 @@ bool CFrame::RendererHasFocus()
 	if (m_RenderParent->GetParent()->GetHWND() == GetForegroundWindow())
 		return true;
 #else
-	if (wxWindow::FindFocus() == nullptr)
+	wxWindow *window = wxWindow::FindFocus();
+	if (window == nullptr)
 		return false;
 	// Why these different cases?
-	if (m_RenderParent == wxWindow::FindFocus() ||
-			m_RenderParent == wxWindow::FindFocus()->GetParent() ||
-			m_RenderParent->GetParent() == wxWindow::FindFocus()->GetParent())
+	if (m_RenderParent == window ||
+	    m_RenderParent == window->GetParent() ||
+	    m_RenderParent->GetParent() == window->GetParent())
+	{
 		return true;
+	}
 #endif
 	return false;
 }


### PR DESCRIPTION
When pressing Tab for a long time, Dolphin will sooner or later crash because the result of FindFocus() has become NULL (toctou). No idea why that happens. Obviously, we are passing key events to WX even after handling them ourselves. I don't think we should do that. In any case, this fix makes the code cleaner.
