### PR TITLE
Pass 1, not false to MixAUXSamples as the aux ID in UCode_AX.cpp.

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCode_AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCode_AX.cpp
@@ -208,7 +208,7 @@ void CUCode_AX::HandleCommandList()
 			case CMD_MIX_AUXB_NOWRITE:
 				addr_hi = m_cmdlist[curr_idx++];
 				addr_lo = m_cmdlist[curr_idx++];
-				MixAUXSamples(false, 0, HILO_TO_32(addr));
+				MixAUXSamples(1, 0, HILO_TO_32(addr));
 				break;
 
 			case CMD_COMPRESSOR_TABLE_ADDR: curr_idx += 2; break;


### PR DESCRIPTION
An AUX ID of 1 means to use AUX B, however in the previous case, we'd be using AUX A (id of 0). Considering the case is "CMD_MIX_AUXB_NOWRITE" we don't want this.
