### PR TITLE
Unnecessary c_str() call in WII_IPC_HLE_Device_es.cpp's OpenTitleContent function.

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -953,7 +953,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 				for (unsigned int i = 0; i < size; i++)
 					wiiMoteConnected[i] = s_Usb->m_WiiMotes[i].IsConnected();
 
-				std::string tContentFile(m_ContentFile.c_str());
+				std::string tContentFile(m_ContentFile);
 
 				WII_IPC_HLE_Interface::Reset(true);
 				WII_IPC_HLE_Interface::Init();


### PR DESCRIPTION
m_ContentFile is a string, so it's kind of pointless to pass a c_str of a string to constructor of a new string.
