### PR TITLE
CMake: remove USE_SHARED_POLARSSL_LIBRARY

### DIFF
--- a/Externals/polarssl/library/CMakeLists.txt
+++ b/Externals/polarssl/library/CMakeLists.txt
@@ -1,5 +1,3 @@
-option(USE_SHARED_POLARSSL_LIBRARY "Build PolarSSL as a shared library." OFF)
-
 set(src
      aes.c
      aesni.c
@@ -77,16 +75,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
   set(CMAKE_C_FLAGS_CHECKFULL "${CMAKE_C_FLAGS_CHECK} -Wcast-qual")
 endif(CMAKE_COMPILER_IS_GNUCC)
 
-if(NOT USE_SHARED_POLARSSL_LIBRARY)
-
 add_library(polarssl STATIC ${src})
-
-else(NOT USE_SHARED_POLARSSL_LIBRARY)
-
-add_library(polarssl SHARED ${src})
-set_target_properties(polarssl PROPERTIES VERSION 1.3.4 SOVERSION 5)
-
-endif(NOT USE_SHARED_POLARSSL_LIBRARY)
 
 target_link_libraries(polarssl ${libs})
 


### PR DESCRIPTION
This could easily be mistaken for a Dolphin option.
