### PR TITLE
Make the base calculation in CheatsWindow simpler.

### DIFF
--- a/Source/Core/DolphinWX/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/CheatsWindow.cpp
@@ -647,7 +647,8 @@ void CreateCodeDialog::PressOK(wxCommandEvent& ev)
 	}
 
 	long code_value;
-	if (!textctrl_value->GetValue().ToLong(&code_value, 10 + checkbox_use_hex->GetValue()*6))
+	int base = checkbox_use_hex->IsChecked() ? 16 : 10;
+	if (!textctrl_value->GetValue().ToLong(&code_value, base))
 	{
 		PanicAlertT("Invalid Value!");
 		return;


### PR DESCRIPTION
First and foremost this should test the checked state, not its direct value.
This should never have used multiplication at all. Seriously, what the hell?

The only values it would have given is true or false, so the only cases are 0_6 and 1_6.
