### PR TITLE
Change the DebugInterface, PPCDebugInterface, and DSPDebugInterface to use CamelCase function names.

### DIFF
--- a/Source/Core/Common/BreakPoints.cpp
+++ b/Source/Core/Common/BreakPoints.cpp
@@ -17,6 +17,7 @@ bool BreakPoints::IsAddressBreakPoint(u32 _iAddress)
 	for (const TBreakPoint& bp : m_BreakPoints)
 		if (bp.iAddress == _iAddress)
 			return true;
+
 	return false;
 }
 
@@ -25,6 +26,7 @@ bool BreakPoints::IsTempBreakPoint(u32 _iAddress)
 	for (const TBreakPoint& bp : m_BreakPoints)
 		if (bp.iAddress == _iAddress && bp.bTemporary)
 			return true;
+
 	return false;
 }
 
@@ -176,27 +178,29 @@ TMemCheck *MemChecks::GetMemCheck(u32 address)
 				return &(bp);
 		}
 		else if (bp.StartAddress == address)
+		{
 			return &(bp);
+		}
 	}
 
 	// none found
 	return 0;
 }
 
-void TMemCheck::Action(DebugInterface *debug_interface, u32 iValue, u32 addr,
-						bool write, int size, u32 pc)
+void TMemCheck::Action(DebugInterface *debug_interface, u32 iValue, u32 addr, bool write, int size, u32 pc)
 {
 	if ((write && OnWrite) || (!write && OnRead))
 	{
 		if (Log)
 		{
 			INFO_LOG(MEMMAP, "CHK %08x (%s) %s%i %0*x at %08x (%s)",
-				pc, debug_interface->getDescription(pc).c_str(),
+				pc, debug_interface->GetDescription(pc).c_str(),
 				write ? "Write" : "Read", size*8, size*2, iValue, addr,
-				debug_interface->getDescription(addr).c_str()
+				debug_interface->GetDescription(addr).c_str()
 				);
 		}
+
 		if (Break)
-			debug_interface->breakNow();
+			debug_interface->BreakNow();
 	}
 }

--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -9,28 +9,28 @@ protected:
 	virtual ~DebugInterface() {}
 
 public:
-	virtual void disasm(unsigned int /*address*/, char *dest, int /*max_size*/) {strcpy(dest, "NODEBUGGER");}
-	virtual void getRawMemoryString(int /*memory*/, unsigned int /*address*/, char *dest, int /*max_size*/) {strcpy(dest, "NODEBUGGER");}
-	virtual int getInstructionSize(int /*instruction*/) {return 1;}
-	virtual bool isAlive() {return true;}
-	virtual bool isBreakpoint(unsigned int /*address*/) {return false;}
-	virtual void setBreakpoint(unsigned int /*address*/){}
-	virtual void clearBreakpoint(unsigned int /*address*/){}
-	virtual void clearAllBreakpoints() {}
-	virtual void toggleBreakpoint(unsigned int /*address*/){}
-	virtual bool isMemCheck(unsigned int /*address*/) {return false;}
-	virtual void toggleMemCheck(unsigned int /*address*/){}
-	virtual unsigned int readMemory(unsigned int /*address*/){return 0;}
-	virtual void writeExtraMemory(int /*memory*/, unsigned int /*value*/, unsigned int /*address*/) {}
-	virtual unsigned int readExtraMemory(int /*memory*/, unsigned int /*address*/){return 0;}
-	virtual unsigned int readInstruction(unsigned int /*address*/){return 0;}
-	virtual unsigned int getPC() {return 0;}
-	virtual void setPC(unsigned int /*address*/) {}
-	virtual void step() {}
-	virtual void runToBreakpoint() {}
-	virtual void breakNow() {}
-	virtual void insertBLR(unsigned int /*address*/, unsigned int /*value*/) {}
-	virtual void showJitResults(unsigned int /*address*/) {};
-	virtual int getColor(unsigned int /*address*/){return 0xFFFFFFFF;}
-	virtual std::string getDescription(unsigned int /*address*/) = 0;
+	virtual void Disassemble(unsigned int /*address*/, char *dest, int /*max_size*/) {strcpy(dest, "NODEBUGGER");}
+	virtual void GetRawMemoryString(int /*memory*/, unsigned int /*address*/, char *dest, int /*max_size*/) {strcpy(dest, "NODEBUGGER");}
+	virtual int GetInstructionSize(int /*instruction*/) {return 1;}
+	virtual bool IsAlive() {return true;}
+	virtual bool IsBreakpoint(unsigned int /*address*/) {return false;}
+	virtual void SetBreakpoint(unsigned int /*address*/){}
+	virtual void ClearBreakpoint(unsigned int /*address*/){}
+	virtual void ClearAllBreakpoints() {}
+	virtual void ToggleBreakpoint(unsigned int /*address*/){}
+	virtual bool IsMemCheck(unsigned int /*address*/) {return false;}
+	virtual void ToggleMemCheck(unsigned int /*address*/){}
+	virtual unsigned int ReadMemory(unsigned int /*address*/){return 0;}
+	virtual void WriteExtraMemory(int /*memory*/, unsigned int /*value*/, unsigned int /*address*/) {}
+	virtual unsigned int ReadExtraMemory(int /*memory*/, unsigned int /*address*/){return 0;}
+	virtual unsigned int ReadInstruction(unsigned int /*address*/){return 0;}
+	virtual unsigned int GetPC() {return 0;}
+	virtual void SetPC(unsigned int /*address*/) {}
+	virtual void Step() {}
+	virtual void RunToBreakpoint() {}
+	virtual void BreakNow() {}
+	virtual void InsertBLR(unsigned int /*address*/, unsigned int /*value*/) {}
+	virtual void ShowJitResults(unsigned int /*address*/) {};
+	virtual int GetColor(unsigned int /*address*/){return 0xFFFFFFFF;}
+	virtual std::string GetDescription(unsigned int /*address*/) = 0;
 };

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -15,7 +15,7 @@
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 
-void PPCDebugInterface::disasm(unsigned int address, char *dest, int max_size)
+void PPCDebugInterface::Disassemble(unsigned int address, char *dest, int max_size)
 {
 	// Memory::ReadUnchecked_U32 seemed to crash on shutdown
 	if (PowerPC::GetState() == PowerPC::CPU_POWERDOWN) return;
@@ -43,13 +43,13 @@ void PPCDebugInterface::disasm(unsigned int address, char *dest, int max_size)
 	}
 }
 
-void PPCDebugInterface::getRawMemoryString(int memory, unsigned int address, char *dest, int max_size)
+void PPCDebugInterface::GetRawMemoryString(int memory, unsigned int address, char *dest, int max_size)
 {
 	if (Core::GetState() != Core::CORE_UNINITIALIZED)
 	{
 		if (memory || Memory::IsRAMAddress(address, true, true))
 		{
-			snprintf(dest, max_size, "%08X%s", readExtraMemory(memory, address), memory ? " (ARAM)" : "");
+			snprintf(dest, max_size, "%08X%s", ReadExtraMemory(memory, address), memory ? " (ARAM)" : "");
 		}
 		else
 		{
@@ -62,12 +62,12 @@ void PPCDebugInterface::getRawMemoryString(int memory, unsigned int address, cha
 	}
 }
 
-unsigned int PPCDebugInterface::readMemory(unsigned int address)
+unsigned int PPCDebugInterface::ReadMemory(unsigned int address)
 {
 	return Memory::ReadUnchecked_U32(address);
 }
 
-unsigned int PPCDebugInterface::readExtraMemory(int memory, unsigned int address)
+unsigned int PPCDebugInterface::ReadExtraMemory(int memory, unsigned int address)
 {
 	switch (memory)
 	{
@@ -83,34 +83,34 @@ unsigned int PPCDebugInterface::readExtraMemory(int memory, unsigned int address
 	}
 }
 
-unsigned int PPCDebugInterface::readInstruction(unsigned int address)
+unsigned int PPCDebugInterface::ReadInstruction(unsigned int address)
 {
 	return Memory::Read_Instruction(address);
 }
 
-bool PPCDebugInterface::isAlive()
+bool PPCDebugInterface::IsAlive()
 {
 	return Core::GetState() != Core::CORE_UNINITIALIZED;
 }
 
-bool PPCDebugInterface::isBreakpoint(unsigned int address)
+bool PPCDebugInterface::IsBreakpoint(unsigned int address)
 {
 	return PowerPC::breakpoints.IsAddressBreakPoint(address);
 }
 
-void PPCDebugInterface::setBreakpoint(unsigned int address)
+void PPCDebugInterface::SetBreakpoint(unsigned int address)
 {
 	PowerPC::breakpoints.Add(address);
 }
 
-void PPCDebugInterface::clearBreakpoint(unsigned int address)
+void PPCDebugInterface::ClearBreakpoint(unsigned int address)
 {
 	PowerPC::breakpoints.Remove(address);
 }
 
-void PPCDebugInterface::clearAllBreakpoints() {}
+void PPCDebugInterface::ClearAllBreakpoints() {}
 
-void PPCDebugInterface::toggleBreakpoint(unsigned int address)
+void PPCDebugInterface::ToggleBreakpoint(unsigned int address)
 {
 	if (PowerPC::breakpoints.IsAddressBreakPoint(address))
 		PowerPC::breakpoints.Remove(address);
@@ -118,13 +118,13 @@ void PPCDebugInterface::toggleBreakpoint(unsigned int address)
 		PowerPC::breakpoints.Add(address);
 }
 
-bool PPCDebugInterface::isMemCheck(unsigned int address)
+bool PPCDebugInterface::IsMemCheck(unsigned int address)
 {
 	return (Memory::AreMemoryBreakpointsActivated()
 		&& PowerPC::memchecks.GetMemCheck(address));
 }
 
-void PPCDebugInterface::toggleMemCheck(unsigned int address)
+void PPCDebugInterface::ToggleMemCheck(unsigned int address)
 {
 	if (Memory::AreMemoryBreakpointsActivated()
 		&& !PowerPC::memchecks.GetMemCheck(address))
@@ -145,12 +145,12 @@ void PPCDebugInterface::toggleMemCheck(unsigned int address)
 		PowerPC::memchecks.Remove(address);
 }
 
-void PPCDebugInterface::insertBLR(unsigned int address, unsigned int value)
+void PPCDebugInterface::InsertBLR(unsigned int address, unsigned int value)
 {
 	Memory::Write_U32(value, address);
 }
 
-void PPCDebugInterface::breakNow()
+void PPCDebugInterface::BreakNow()
 {
 	CCPU::Break();
 }
@@ -159,7 +159,7 @@ void PPCDebugInterface::breakNow()
 // =======================================================
 // Separate the blocks with colors.
 // -------------
-int PPCDebugInterface::getColor(unsigned int address)
+int PPCDebugInterface::GetColor(unsigned int address)
 {
 	if (!Memory::IsRAMAddress(address, true, true))
 		return 0xeeeeee;
@@ -182,27 +182,27 @@ int PPCDebugInterface::getColor(unsigned int address)
 // =============
 
 
-std::string PPCDebugInterface::getDescription(unsigned int address)
+std::string PPCDebugInterface::GetDescription(unsigned int address)
 {
 	return g_symbolDB.GetDescription(address);
 }
 
-unsigned int PPCDebugInterface::getPC()
+unsigned int PPCDebugInterface::GetPC()
 {
 	return PowerPC::ppcState.pc;
 }
 
-void PPCDebugInterface::setPC(unsigned int address)
+void PPCDebugInterface::SetPC(unsigned int address)
 {
 	PowerPC::ppcState.pc = address;
 }
 
-void PPCDebugInterface::showJitResults(unsigned int address)
+void PPCDebugInterface::ShowJitResults(unsigned int address)
 {
 	Host_ShowJitResults(address);
 }
 
-void PPCDebugInterface::runToBreakpoint()
+void PPCDebugInterface::RunToBreakpoint()
 {
 
 }

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -14,31 +14,31 @@ class PPCDebugInterface : public DebugInterface
 {
 public:
 	PPCDebugInterface(){}
-	virtual void disasm(unsigned int address, char *dest, int max_size) override;
-	virtual void getRawMemoryString(int memory, unsigned int address, char *dest, int max_size) override;
-	virtual int getInstructionSize(int /*instruction*/) override {return 4;}
-	virtual bool isAlive() override;
-	virtual bool isBreakpoint(unsigned int address) override;
-	virtual void setBreakpoint(unsigned int address) override;
-	virtual void clearBreakpoint(unsigned int address) override;
-	virtual void clearAllBreakpoints() override;
-	virtual void toggleBreakpoint(unsigned int address) override;
-	virtual bool isMemCheck(unsigned int address) override;
-	virtual void toggleMemCheck(unsigned int address) override;
-	virtual unsigned int readMemory(unsigned int address) override;
+	virtual void Disassemble(unsigned int address, char *dest, int max_size) override;
+	virtual void GetRawMemoryString(int memory, unsigned int address, char *dest, int max_size) override;
+	virtual int GetInstructionSize(int /*instruction*/) override {return 4;}
+	virtual bool IsAlive() override;
+	virtual bool IsBreakpoint(unsigned int address) override;
+	virtual void SetBreakpoint(unsigned int address) override;
+	virtual void ClearBreakpoint(unsigned int address) override;
+	virtual void ClearAllBreakpoints() override;
+	virtual void ToggleBreakpoint(unsigned int address) override;
+	virtual bool IsMemCheck(unsigned int address) override;
+	virtual void ToggleMemCheck(unsigned int address) override;
+	virtual unsigned int ReadMemory(unsigned int address) override;
 
 	enum {
 		EXTRAMEM_ARAM = 1,
 	};
-	virtual unsigned int readExtraMemory(int memory, unsigned int address) override;
-	virtual unsigned int readInstruction(unsigned int address) override;
-	virtual unsigned int getPC() override;
-	virtual void setPC(unsigned int address) override;
-	virtual void step() override {}
-	virtual void breakNow() override;
-	virtual void runToBreakpoint() override;
-	virtual void insertBLR(unsigned int address, unsigned int value) override;
-	virtual int getColor(unsigned int address) override;
-	virtual std::string getDescription(unsigned int address) override;
-	virtual void showJitResults(u32 address) override;
+	virtual unsigned int ReadExtraMemory(int memory, unsigned int address) override;
+	virtual unsigned int ReadInstruction(unsigned int address) override;
+	virtual unsigned int GetPC() override;
+	virtual void SetPC(unsigned int address) override;
+	virtual void Step() override {}
+	virtual void BreakNow() override;
+	virtual void RunToBreakpoint() override;
+	virtual void InsertBLR(unsigned int address, unsigned int value) override;
+	virtual int GetColor(unsigned int address) override;
+	virtual std::string GetDescription(unsigned int address) override;
+	virtual void ShowJitResults(u32 address) override;
 };

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -8,14 +8,14 @@
 #include "Core/HW/DSPLLE/DSPDebugInterface.h"
 #include "Core/HW/DSPLLE/DSPSymbols.h"
 
-void DSPDebugInterface::disasm(unsigned int address, char *dest, int max_size)
+void DSPDebugInterface::Disassemble(unsigned int address, char *dest, int max_size)
 {
 	// we'll treat addresses as line numbers.
 	strncpy(dest, DSPSymbols::GetLineText(address), max_size);
 	dest[max_size-1] = 0;
 }
 
-void DSPDebugInterface::getRawMemoryString(int memory, unsigned int address, char *dest, int max_size)
+void DSPDebugInterface::GetRawMemoryString(int memory, unsigned int address, char *dest, int max_size)
 {
 	if (DSPCore_GetState() == DSPCORE_STOP)
 	{
@@ -55,22 +55,22 @@ void DSPDebugInterface::getRawMemoryString(int memory, unsigned int address, cha
 	}
 }
 
-unsigned int DSPDebugInterface::readMemory(unsigned int address)
+unsigned int DSPDebugInterface::ReadMemory(unsigned int address)
 {
 	return 0; //Memory::ReadUnchecked_U32(address);
 }
 
-unsigned int DSPDebugInterface::readInstruction(unsigned int address)
+unsigned int DSPDebugInterface::ReadInstruction(unsigned int address)
 {
 	return 0; //Memory::Read_Instruction(address);
 }
 
-bool DSPDebugInterface::isAlive()
+bool DSPDebugInterface::IsAlive()
 {
 	return true; //Core::GetState() != Core::CORE_UNINITIALIZED;
 }
 
-bool DSPDebugInterface::isBreakpoint(unsigned int address)
+bool DSPDebugInterface::IsBreakpoint(unsigned int address)
 {
 	int real_addr = DSPSymbols::Line2Addr(address);
 	if (real_addr >= 0)
@@ -79,7 +79,7 @@ bool DSPDebugInterface::isBreakpoint(unsigned int address)
 		return false;
 }
 
-void DSPDebugInterface::setBreakpoint(unsigned int address)
+void DSPDebugInterface::SetBreakpoint(unsigned int address)
 {
 	int real_addr = DSPSymbols::Line2Addr(address);
 
@@ -92,7 +92,7 @@ void DSPDebugInterface::setBreakpoint(unsigned int address)
 	}
 }
 
-void DSPDebugInterface::clearBreakpoint(unsigned int address)
+void DSPDebugInterface::ClearBreakpoint(unsigned int address)
 {
 	int real_addr = DSPSymbols::Line2Addr(address);
 
@@ -105,12 +105,12 @@ void DSPDebugInterface::clearBreakpoint(unsigned int address)
 	}
 }
 
-void DSPDebugInterface::clearAllBreakpoints()
+void DSPDebugInterface::ClearAllBreakpoints()
 {
 	dsp_breakpoints.Clear();
 }
 
-void DSPDebugInterface::toggleBreakpoint(unsigned int address)
+void DSPDebugInterface::ToggleBreakpoint(unsigned int address)
 {
 	int real_addr = DSPSymbols::Line2Addr(address);
 	if (real_addr >= 0)
@@ -122,17 +122,17 @@ void DSPDebugInterface::toggleBreakpoint(unsigned int address)
 	}
 }
 
-bool DSPDebugInterface::isMemCheck(unsigned int address)
+bool DSPDebugInterface::IsMemCheck(unsigned int address)
 {
 	return false;
 }
 
-void DSPDebugInterface::toggleMemCheck(unsigned int address)
+void DSPDebugInterface::ToggleMemCheck(unsigned int address)
 {
 	PanicAlert("MemCheck functionality not supported in DSP module.");
 }
 
-void DSPDebugInterface::insertBLR(unsigned int address, unsigned int value)
+void DSPDebugInterface::InsertBLR(unsigned int address, unsigned int value)
 {
 	PanicAlert("insertBLR functionality not supported in DSP module.");
 }
@@ -140,7 +140,7 @@ void DSPDebugInterface::insertBLR(unsigned int address, unsigned int value)
 // =======================================================
 // Separate the blocks with colors.
 // -------------
-int DSPDebugInterface::getColor(unsigned int address)
+int DSPDebugInterface::GetColor(unsigned int address)
 {
 	static const int colors[6] =
 	{
@@ -173,24 +173,24 @@ int DSPDebugInterface::getColor(unsigned int address)
 // =============
 
 
-std::string DSPDebugInterface::getDescription(unsigned int address)
+std::string DSPDebugInterface::GetDescription(unsigned int address)
 {
 	return "";  // g_symbolDB.GetDescription(address);
 }
 
-unsigned int DSPDebugInterface::getPC()
+unsigned int DSPDebugInterface::GetPC()
 {
 	return DSPSymbols::Addr2Line(g_dsp.pc);
 }
 
-void DSPDebugInterface::setPC(unsigned int address)
+void DSPDebugInterface::SetPC(unsigned int address)
 {
 	int new_pc = DSPSymbols::Line2Addr(address);
 	if (new_pc > 0)
 		g_dsp.pc = new_pc;
 }
 
-void DSPDebugInterface::runToBreakpoint()
+void DSPDebugInterface::RunToBreakpoint()
 {
 
 }

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -14,24 +14,24 @@ class DSPDebugInterface : public DebugInterface
 {
 public:
 	DSPDebugInterface(){}
-	virtual void disasm(unsigned int address, char *dest, int max_size);
-	virtual void getRawMemoryString(int memory, unsigned int address, char *dest, int max_size);
-	virtual int getInstructionSize(int instruction) {return 1;}
-	virtual bool isAlive();
-	virtual bool isBreakpoint(unsigned int address);
-	virtual void setBreakpoint(unsigned int address);
-	virtual void clearBreakpoint(unsigned int address);
-	virtual void clearAllBreakpoints();
-	virtual void toggleBreakpoint(unsigned int address);
-	virtual bool isMemCheck(unsigned int address);
-	virtual void toggleMemCheck(unsigned int address);
-	virtual unsigned int readMemory(unsigned int address);
-	virtual unsigned int readInstruction(unsigned int address);
-	virtual unsigned int getPC();
-	virtual void setPC(unsigned int address);
-	virtual void step() {}
-	virtual void runToBreakpoint();
-	virtual void insertBLR(unsigned int address, unsigned int value);
-	virtual int getColor(unsigned int address);
-	virtual std::string getDescription(unsigned int address);
+	virtual void Disassemble(unsigned int address, char *dest, int max_size);
+	virtual void GetRawMemoryString(int memory, unsigned int address, char *dest, int max_size);
+	virtual int GetInstructionSize(int instruction) {return 1;}
+	virtual bool IsAlive();
+	virtual bool IsBreakpoint(unsigned int address);
+	virtual void SetBreakpoint(unsigned int address);
+	virtual void ClearBreakpoint(unsigned int address);
+	virtual void ClearAllBreakpoints();
+	virtual void ToggleBreakpoint(unsigned int address);
+	virtual bool IsMemCheck(unsigned int address);
+	virtual void ToggleMemCheck(unsigned int address);
+	virtual unsigned int ReadMemory(unsigned int address);
+	virtual unsigned int ReadInstruction(unsigned int address);
+	virtual unsigned int GetPC();
+	virtual void SetPC(unsigned int address);
+	virtual void Step() {}
+	virtual void RunToBreakpoint();
+	virtual void InsertBLR(unsigned int address, unsigned int value);
+	virtual int GetColor(unsigned int address);
+	virtual std::string GetDescription(unsigned int address);
 };

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -332,7 +332,7 @@ bool PPCSymbolDB::SaveMap(const char *filename, bool WithCodes) const
 			{
 				int Address = LastAddress + i;
 				char disasm[256];
-				debugger->disasm(Address, disasm, 256);
+				debugger->Disassemble(Address, disasm, 256);
 				fprintf(f.GetHandle(),"%08x %i %20s %s\n", Address, 0, TempSym.c_str(), disasm);
 			}
 			// Write a blank line after each block

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -71,8 +71,8 @@ CCodeView::CCodeView(DebugInterface* debuginterface, SymbolDB *symboldb,
 	  debugger(debuginterface),
 	  symbol_db(symboldb),
 	  plain(false),
-	  curAddress(debuginterface->getPC()),
-	  align(debuginterface->getInstructionSize(0)),
+	  curAddress(debuginterface->GetPC()),
+	  align(debuginterface->GetInstructionSize(0)),
 	  rowHeight(13),
 	  selection(0),
 	  oldSelection(0),
@@ -116,7 +116,7 @@ void CCodeView::OnMouseDown(wxMouseEvent& event)
 
 void CCodeView::ToggleBreakpoint(u32 address)
 {
-	debugger->toggleBreakpoint(address);
+	debugger->ToggleBreakpoint(address);
 	Refresh();
 	Host_UpdateBreakPointView();
 }
@@ -169,7 +169,7 @@ void CCodeView::OnMouseUpL(wxMouseEvent& event)
 u32 CCodeView::AddrToBranch(u32 addr)
 {
 	char disasm[256];
-	debugger->disasm(addr, disasm, 256);
+	debugger->Disassemble(addr, disasm, 256);
 	const char *mojs = strstr(disasm, "->0x");
 	if (mojs)
 	{
@@ -196,19 +196,19 @@ void CCodeView::InsertBlrNop(int Blr)
 	// Save the old value
 	if (find >= 0)
 	{
-		debugger->writeExtraMemory(0, BlrList.at(find).OldValue, selection);
+		debugger->WriteExtraMemory(0, BlrList.at(find).OldValue, selection);
 		BlrList.erase(BlrList.begin() + find);
 	}
 	else
 	{
 		BlrStruct Temp;
 		Temp.Address = selection;
-		Temp.OldValue = debugger->readMemory(selection);
+		Temp.OldValue = debugger->ReadMemory(selection);
 		BlrList.push_back(Temp);
 		if (Blr == 0)
-			debugger->insertBLR(selection, 0x4e800020);
+			debugger->InsertBLR(selection, 0x4e800020);
 		else
-			debugger->insertBLR(selection, 0x60000000);
+			debugger->InsertBLR(selection, 0x60000000);
 	}
 	Refresh();
 }
@@ -233,7 +233,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 		case IDM_COPYCODE:
 			{
 				char disasm[256];
-				debugger->disasm(selection, disasm, 256);
+				debugger->Disassemble(selection, disasm, 256);
 				wxTheClipboard->SetData(new wxTextDataObject(StrToWxStr(disasm)));
 			}
 			break;
@@ -241,7 +241,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 		case IDM_COPYHEX:
 			{
 				char temp[24];
-				sprintf(temp, "%08x", debugger->readInstruction(selection));
+				sprintf(temp, "%08x", debugger->ReadInstruction(selection));
 				wxTheClipboard->SetData(new wxTextDataObject(StrToWxStr(temp)));
 			}
 			break;
@@ -260,7 +260,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 					for (u32 addr = start; addr != end; addr += 4)
 					{
 						char disasm[256];
-						debugger->disasm(addr, disasm, 256);
+						debugger->Disassemble(addr, disasm, 256);
 						text = text + StringFromFormat("%08x: ", addr) + disasm + "\r\n";
 					}
 					wxTheClipboard->SetData(new wxTextDataObject(StrToWxStr(text)));
@@ -270,8 +270,8 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 #endif
 
 		case IDM_RUNTOHERE:
-			debugger->setBreakpoint(selection);
-			debugger->runToBreakpoint();
+			debugger->SetBreakpoint(selection);
+			debugger->RunToBreakpoint();
 			Refresh();
 			break;
 
@@ -286,7 +286,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 			break;
 
 		case IDM_JITRESULTS:
-			debugger->showJitResults(selection);
+			debugger->ShowJitResults(selection);
 			break;
 
 		case IDM_FOLLOWBRANCH:
@@ -430,7 +430,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 		int rowY2 = rc.height / 2 + rowHeight * i + rowHeight / 2;
 
 		wxString temp = wxString::Format(_T("%08x"), address);
-		u32 col = debugger->getColor(address);
+		u32 col = debugger->GetColor(address);
 		wxBrush rowBrush(wxColor(col >> 16, col >> 8, col));
 		dc.SetBrush(nullBrush);
 		dc.SetPen(nullPen);
@@ -441,7 +441,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 		else
 			dc.SetPen(i == 0 ? currentPen : nullPen);
 
-		if (address == debugger->getPC())
+		if (address == debugger->GetPC())
 			dc.SetBrush(pcBrush);
 		else
 			dc.SetBrush(rowBrush);
@@ -456,10 +456,10 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 		}
 
 		// If running
-		if (debugger->isAlive())
+		if (debugger->IsAlive())
 		{
 			char dis[256];
-			debugger->disasm(address, dis, 256);
+			debugger->Disassemble(address, dis, 256);
 			char* dis2 = strchr(dis, '\t');
 			char desc[256] = "";
 
@@ -494,7 +494,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 					branches[numBranches].src = rowY1 + rowHeight / 2;
 					branches[numBranches].srcAddr = address / align;
 					branches[numBranches++].dst = (int)(rowY1 + ((s64)(u32)offs - (s64)(u32)address) * rowHeight / align + rowHeight / 2);
-					sprintf(desc, "-->%s", debugger->getDescription(offs).c_str());
+					sprintf(desc, "-->%s", debugger->GetDescription(offs).c_str());
 					dc.SetTextForeground(_T("#600060")); // the -> arrow illustrations are purple
 				}
 				else
@@ -516,7 +516,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 
 			if (desc[0] == 0)
 			{
-				strcpy(desc, debugger->getDescription(address).c_str());
+				strcpy(desc, debugger->GetDescription(address).c_str());
 			}
 
 			if (!plain)
@@ -532,7 +532,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 			}
 
 			// Show red breakpoint dot
-			if (debugger->isBreakpoint(address))
+			if (debugger->IsBreakpoint(address))
 			{
 				dc.SetBrush(bpBrush);
 				dc.DrawRectangle(2, rowY1 + 1, 11, 11);

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -56,9 +56,9 @@ END_EVENT_TABLE()
 
 CMemoryView::CMemoryView(DebugInterface* debuginterface, wxWindow* parent)
 	: wxControl(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize)
-	, curAddress(debuginterface->getPC())
+	, curAddress(debuginterface->GetPC())
 	, debugger(debuginterface)
-	, align(debuginterface->getInstructionSize(0))
+	, align(debuginterface->GetInstructionSize(0))
 	, rowHeight(13)
 	, selection(0)
 	, oldSelection(0)
@@ -93,7 +93,7 @@ void CMemoryView::OnMouseDownL(wxMouseEvent& event)
 	}
 	else
 	{
-		debugger->toggleMemCheck(YToAddress(y));
+		debugger->ToggleMemCheck(YToAddress(y));
 
 		Refresh();
 		Host_UpdateBreakPointView();
@@ -153,7 +153,7 @@ void CMemoryView::OnPopupMenu(wxCommandEvent& event)
 		case IDM_COPYHEX:
 			{
 			char temp[24];
-			sprintf(temp, "%08x", debugger->readExtraMemory(memory, selection));
+			sprintf(temp, "%08x", debugger->ReadExtraMemory(memory, selection));
 			wxTheClipboard->SetData(new wxTextDataObject(StrToWxStr(temp)));
 			}
 			break;
@@ -260,7 +260,7 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
 		int rowY2 = rc.height / 2 + rowHeight * row + rowHeight / 2;
 
 		wxString temp = wxString::Format(_T("%08x"), address);
-		u32 col = debugger->getColor(address);
+		u32 col = debugger->GetColor(address);
 		wxBrush rowBrush(wxColor(col >> 16, col >> 8, col));
 		dc.SetBrush(nullBrush);
 		dc.SetPen(nullPen);
@@ -271,7 +271,7 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
 		else
 			dc.SetPen(row == 0 ? currentPen : nullPen);
 
-		if (address == debugger->getPC())
+		if (address == debugger->GetPC())
 			dc.SetBrush(pcBrush);
 		else
 			dc.SetBrush(rowBrush);
@@ -284,16 +284,16 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
 		if (viewAsType != VIEWAS_HEX)
 		{
 			char mem[256];
-			debugger->getRawMemoryString(memory, address, mem, 256);
+			debugger->GetRawMemoryString(memory, address, mem, 256);
 			dc.SetTextForeground(_T("#000080"));
 			dc.DrawText(StrToWxStr(mem), 17+fontSize*(8), rowY1);
 			dc.SetTextForeground(_T("#000000"));
 		}
 
-		if (debugger->isAlive())
+		if (debugger->IsAlive())
 		{
 			char dis[256] = {0};
-			u32 mem_data = debugger->readExtraMemory(memory, address);
+			u32 mem_data = debugger->ReadExtraMemory(memory, address);
 
 			if (viewAsType == VIEWAS_FP)
 			{
@@ -316,14 +316,14 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
 				dis[0] = 0;
 				dis[1] = 0;
 				u32 mema[8] = {
-					debugger->readExtraMemory(memory, address),
-					debugger->readExtraMemory(memory, address+4),
-					debugger->readExtraMemory(memory, address+8),
-					debugger->readExtraMemory(memory, address+12),
-					debugger->readExtraMemory(memory, address+16),
-					debugger->readExtraMemory(memory, address+20),
-					debugger->readExtraMemory(memory, address+24),
-					debugger->readExtraMemory(memory, address+28)
+					debugger->ReadExtraMemory(memory, address),
+					debugger->ReadExtraMemory(memory, address+4),
+					debugger->ReadExtraMemory(memory, address+8),
+					debugger->ReadExtraMemory(memory, address+12),
+					debugger->ReadExtraMemory(memory, address+16),
+					debugger->ReadExtraMemory(memory, address+20),
+					debugger->ReadExtraMemory(memory, address+24),
+					debugger->ReadExtraMemory(memory, address+28)
 				};
 
 				for (auto& word : mema)
@@ -369,7 +369,7 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
 				dc.DrawText(StrToWxStr(dis), textPlacement, rowY1);
 
 			if (desc[0] == 0)
-				strcpy(desc, debugger->getDescription(address).c_str());
+				strcpy(desc, debugger->GetDescription(address).c_str());
 
 			dc.SetTextForeground(_T("#0000FF"));
 
@@ -377,7 +377,7 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
 				dc.DrawText(StrToWxStr(desc), 17+fontSize*((8+8+8+30)*2), rowY1);
 
 			// Show blue memory check dot
-			if (debugger->isMemCheck(address))
+			if (debugger->IsMemCheck(address))
 			{
 				dc.SetBrush(mcBrush);
 				dc.DrawRectangle(8, rowY1 + 1, 11, 11);


### PR DESCRIPTION
This is the standard coding convention in the codebase, so our interfaces should use it too.
