### PR TITLE
OS X likes to be different. It reports the host processor type as i386 i...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ else()
 	add_definitions(-D_ARCH_32=1)
 endif()
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^x86")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^x86" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	add_definitions(-msse2)
 	set(_M_X86 1)
 	add_definitions(-D_M_X86=1)


### PR DESCRIPTION
...nstead of x86 or x86_64 like a typical sane system.
