### PR TITLE
commit 1a428de189eb9456695429adc11b606936218924 introduced a bug by usin...

### DIFF
--- a/Source/Core/Common/FPURoundMode.h
+++ b/Source/Core/Common/FPURoundMode.h
@@ -8,14 +8,15 @@
 
 namespace FPURoundMode
 {
-	enum RoundModes
+	enum RoundModes : u32
 	{
 		ROUND_NEAR = 0,
 		ROUND_CHOP = 1,
 		ROUND_UP   = 2,
 		ROUND_DOWN = 3
 	};
-	enum PrecisionModes {
+	enum PrecisionModes : u32
+	{
 		PREC_24 = 0,
 		PREC_53 = 1,
 		PREC_64 = 2

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -390,7 +390,7 @@ union UReg_FPSCR
 	struct
 	{
 		// Rounding mode (towards: nearest, zero, +inf, -inf)
-		enum FPURoundMode::RoundModes RN : 2;
+		FPURoundMode::RoundModes RN : 2;
 		// Non-IEEE mode enable (aka flush-to-zero)
 		u32 NI      : 1;
 		// Inexact exception enable


### PR DESCRIPTION
...g a signed enum in a bitfield, the value of which is then used in a ldmxcsr instruction. The sign-extension corrupts the value, causing an exception by attempting to load mxcsr with an invalid value.
