### PR TITLE
[Android] Remove unnecessary comment from VideoSettingsFragment.

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/video/VideoSettingsFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/video/VideoSettingsFragment.java
@@ -98,7 +98,6 @@ public final class VideoSettingsFragment extends PreferenceFragment
 						mainScreen.getPreference(0).setEnabled(true);
 						mainScreen.getPreference(1).setEnabled(true);
 						mainScreen.getPreference(3).setEnabled(true);
-						//mainScreen.getPreference(4).setEnabled(false);
 
 						// Create an alert telling them that their phone sucks
 						if (eglHelper.supportsGLES3()


### PR DESCRIPTION
Misleading comment. We won't need to access index four for anything.
