### PR TITLE
[Android] Split the AboutFragmentItem and InfoFragmentAdapter into their own class files.

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/AboutActivity.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/AboutActivity.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright 2014 Dolphin Emulator Project
+ * Licensed under GPLv2
+ * Refer to the license.txt file included.
+ */
+
 package org.dolphinemu.dolphinemu.about;
 
 import org.dolphinemu.dolphinemu.R;
@@ -10,17 +16,10 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
-import android.content.Context;
 import android.os.Bundle;
 import android.support.v13.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
-import android.widget.TextView;
 
-import java.util.List;
 
 /**
  * Activity for the about menu, which displays info
@@ -30,75 +29,6 @@ public final class AboutActivity extends Activity implements TabListener
 {
 	private ViewPager viewPager;
 	private final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_ES2_BIT);
-
-	// Represents an item in the multiple About fragments.
-	public static final class AboutFragmentItem
-	{
-		private final String title;
-		private final String subtitle;
-
-		public AboutFragmentItem(String title, String subtitle)
-		{
-			this.title = title;
-			this.subtitle = subtitle;
-		}
-
-		public String getTitle()
-		{
-			return title;
-		}
-
-		public String getSubTitle()
-		{
-			return subtitle;
-		}
-	}
-
-	// The adapter that manages the displaying of items in multiple About fragments.
-	public static final class InfoFragmentAdapter extends ArrayAdapter<AboutFragmentItem>
-	{
-		private final int id;
-		private final List<AboutFragmentItem> items;
-
-		public InfoFragmentAdapter(Context ctx, int id, List<AboutFragmentItem> items)
-		{
-			super(ctx, id, items);
-
-			this.id = id;
-			this.items = items;
-		}
-
-		@Override
-		public AboutFragmentItem getItem(int index)
-		{
-			return items.get(index);
-		}
-
-		@Override
-		public View getView(int position, View convertView, ViewGroup parent)
-		{
-			if (convertView == null)
-			{
-				LayoutInflater vi = LayoutInflater.from(getContext());
-				convertView = vi.inflate(id, parent, false);
-			}
-
-			final AboutFragmentItem item = items.get(position);
-			if (item != null)
-			{
-				TextView title    = (TextView) convertView.findViewById(R.id.AboutItemTitle);
-				TextView subtitle = (TextView) convertView.findViewById(R.id.AboutItemSubTitle);
-
-				if (title != null)
-					title.setText(item.getTitle());
-
-				if (subtitle != null)
-					subtitle.setText(item.getSubTitle());
-			}
-
-			return convertView;
-		}
-	}
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState)

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/AboutFragmentItem.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/AboutFragmentItem.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2014 Dolphin Emulator Project
+ * Licensed under GPLv2
+ * Refer to the license.txt file included.
+ */
+
+package org.dolphinemu.dolphinemu.about;
+
+/**
+ * Represents an item within an info
+ * {@list Fragment} in the About menu.
+ */
+final class AboutFragmentItem
+{
+	private final String title;
+	private final String subtitle;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param title    The title of this item.
+	 * @param subtitle The subtitle for this item.
+	 */
+	public AboutFragmentItem(String title, String subtitle)
+	{
+		this.title = title;
+		this.subtitle = subtitle;
+	}
+
+	/**
+	 * Gets the title of this item.
+	 * 
+	 * @return the title of this item.
+	 */
+	public String getTitle()
+	{
+		return title;
+	}
+
+	/**
+	 * Gets the subtitle of this item.
+	 * 
+	 * @return the subtitle of this item.
+	 */
+	public String getSubTitle()
+	{
+		return subtitle;
+	}
+}

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/AboutInfoFragmentAdapter.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/AboutInfoFragmentAdapter.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2014 Dolphin Emulator Project
+ * Licensed under GPLv2
+ * Refer to the license.txt file included.
+ */
+
+package org.dolphinemu.dolphinemu.about;
+
+import java.util.List;
+
+import org.dolphinemu.dolphinemu.R;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+/**
+ * {@link ArrayAdapter} subclass specifically for the
+ * information fragments within the about menu.
+ */
+final class AboutInfoFragmentAdapter extends ArrayAdapter<AboutFragmentItem>
+{
+	private final int id;
+	private final List<AboutFragmentItem> items;
+
+	public AboutInfoFragmentAdapter(Context ctx, int id, List<AboutFragmentItem> items)
+	{
+		super(ctx, id, items);
+
+		this.id = id;
+		this.items = items;
+	}
+
+	@Override
+	public AboutFragmentItem getItem(int index)
+	{
+		return items.get(index);
+	}
+
+	@Override
+	public View getView(int position, View convertView, ViewGroup parent)
+	{
+		if (convertView == null)
+		{
+			LayoutInflater vi = LayoutInflater.from(getContext());
+			convertView = vi.inflate(id, parent, false);
+		}
+
+		final AboutFragmentItem item = items.get(position);
+		if (item != null)
+		{
+			TextView title    = (TextView) convertView.findViewById(R.id.AboutItemTitle);
+			TextView subtitle = (TextView) convertView.findViewById(R.id.AboutItemSubTitle);
+
+			if (title != null)
+				title.setText(item.getTitle());
+
+			if (subtitle != null)
+				subtitle.setText(item.getSubTitle());
+		}
+
+		return convertView;
+	}
+}

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/CPUInfoFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/CPUInfoFragment.java
@@ -1,10 +1,15 @@
+/**
+ * Copyright 2014 Dolphin Emulator Project
+ * Licensed under GPLv2
+ * Refer to the license.txt file included.
+ */
+
 package org.dolphinemu.dolphinemu.about;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.dolphinemu.dolphinemu.R;
-import org.dolphinemu.dolphinemu.about.AboutActivity.AboutFragmentItem;
 import org.dolphinemu.dolphinemu.utils.CPUHelper;
 
 import android.app.ListFragment;
@@ -25,7 +30,7 @@ public final class CPUInfoFragment extends ListFragment
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 	{
 		ListView rootView = (ListView) inflater.inflate(R.layout.gamelist_listview, container, false);
-		List<AboutActivity.AboutFragmentItem> items = new ArrayList<AboutActivity.AboutFragmentItem>();
+		List<AboutFragmentItem> items = new ArrayList<AboutFragmentItem>();
 
 		CPUHelper cpuHelper = new CPUHelper(getActivity());
 
@@ -39,7 +44,7 @@ public final class CPUInfoFragment extends ListFragment
 		if (CPUHelper.isARM())
 			items.add(new AboutFragmentItem(getString(R.string.cpu_implementer), cpuHelper.getImplementer()));
 
-		AboutActivity.InfoFragmentAdapter adapter = new AboutActivity.InfoFragmentAdapter(getActivity(), R.layout.about_layout, items);
+		AboutInfoFragmentAdapter adapter = new AboutInfoFragmentAdapter(getActivity(), R.layout.about_layout, items);
 		rootView.setAdapter(adapter);
 
 		return rootView;

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/DolphinInfoFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/DolphinInfoFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Dolphin Emulator Project
+ * Copyright 2014 Dolphin Emulator Project
  * Licensed under GPLv2
  * Refer to the license.txt file included.
  */
@@ -18,8 +18,6 @@ import java.util.List;
 
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
-import org.dolphinemu.dolphinemu.about.AboutActivity.AboutFragmentItem;
-import org.dolphinemu.dolphinemu.about.AboutActivity.InfoFragmentAdapter;
 import org.dolphinemu.dolphinemu.utils.EGLHelper;
 
 /**
@@ -41,7 +39,7 @@ public final class DolphinInfoFragment extends ListFragment
 		Input.add(new AboutFragmentItem(getString(R.string.supports_gles3), eglHelper.supportsGLES3() ? yes : no));
 		Input.add(new AboutFragmentItem(getString(R.string.supports_neon),  NativeLibrary.SupportsNEON() ? yes : no));
 
-		InfoFragmentAdapter adapter = new InfoFragmentAdapter(getActivity(), R.layout.about_layout, Input);
+		AboutInfoFragmentAdapter adapter = new AboutInfoFragmentAdapter(getActivity(), R.layout.about_layout, Input);
 		rootView.setAdapter(adapter);
 		rootView.setEnabled(false);  // Makes the list view non-clickable.
 

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/GLES2InfoFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/GLES2InfoFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Dolphin Emulator Project
+ * Copyright 2014 Dolphin Emulator Project
  * Licensed under GPLv2
  * Refer to the license.txt file included.
  */
@@ -57,12 +57,12 @@ public final class GLES2InfoFragment extends ListFragment
 		final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_ES2_BIT);
 
 		ListView rootView = (ListView) inflater.inflate(R.layout.gamelist_listview, container, false);
-		List<AboutActivity.AboutFragmentItem> Input = new ArrayList<AboutActivity.AboutFragmentItem>();
+		List<AboutFragmentItem> Input = new ArrayList<AboutFragmentItem>();
 
 		for (Limit limit : Limits)
 		{
 			Log.i("GLES2InfoFragment", "Getting enum " + limit.name);
-			Input.add(new AboutActivity.AboutFragmentItem(limit.name, limit.GetValue(eglHelper)));
+			Input.add(new AboutFragmentItem(limit.name, limit.GetValue(eglHelper)));
 		}
 
 		// Get extensions manually
@@ -72,9 +72,9 @@ public final class GLES2InfoFragment extends ListFragment
 		{
 			extensionsBuilder.append(extension).append('\n');
 		}
-		Input.add(new AboutActivity.AboutFragmentItem("OpenGL ES 2.0 Extensions", extensionsBuilder.toString()));
+		Input.add(new AboutFragmentItem("OpenGL ES 2.0 Extensions", extensionsBuilder.toString()));
 
-		AboutActivity.InfoFragmentAdapter adapter = new AboutActivity.InfoFragmentAdapter(getActivity(), R.layout.about_layout, Input);
+		AboutInfoFragmentAdapter adapter = new AboutInfoFragmentAdapter(getActivity(), R.layout.about_layout, Input);
 		rootView.setAdapter(adapter);
 
 		return rootView;

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/GLES3InfoFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/GLES3InfoFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Dolphin Emulator Project
+ * Copyright 2014 Dolphin Emulator Project
  * Licensed under GPLv2
  * Refer to the license.txt file included.
  */
@@ -89,12 +89,12 @@ public final class GLES3InfoFragment extends ListFragment
 		final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_ES3_BIT_KHR);
 
 		ListView rootView = (ListView) inflater.inflate(R.layout.gamelist_listview, container, false);
-		List<AboutActivity.AboutFragmentItem> Input = new ArrayList<AboutActivity.AboutFragmentItem>();
+		List<AboutFragmentItem> Input = new ArrayList<AboutFragmentItem>();
 
 		for (Limit limit : Limits)
 		{
 			Log.i("GLES3InfoFragment", "Getting enum " + limit.name);
-			Input.add(new AboutActivity.AboutFragmentItem(limit.name, limit.GetValue(eglHelper)));
+			Input.add(new AboutFragmentItem(limit.name, limit.GetValue(eglHelper)));
 		}
 
 		// Get extensions manually
@@ -104,9 +104,9 @@ public final class GLES3InfoFragment extends ListFragment
 		{
 			extensionsBuilder.append(eglHelper.glGetStringi(GLES30.GL_EXTENSIONS, i)).append('\n');
 		}
-		Input.add(new AboutActivity.AboutFragmentItem("OpenGL ES 3.0 Extensions", extensionsBuilder.toString()));
+		Input.add(new AboutFragmentItem("OpenGL ES 3.0 Extensions", extensionsBuilder.toString()));
 
-		AboutActivity.InfoFragmentAdapter adapter = new AboutActivity.InfoFragmentAdapter(getActivity(), R.layout.about_layout, Input);
+		AboutInfoFragmentAdapter adapter = new AboutInfoFragmentAdapter(getActivity(), R.layout.about_layout, Input);
 		rootView.setAdapter(adapter);
 
 		return rootView;

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/GLInfoFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/GLInfoFragment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Dolphin Emulator Project
+ * Copyright 2014 Dolphin Emulator Project
  * Licensed under GPLv2
  * Refer to the license.txt file included.
  */
@@ -44,12 +44,12 @@ public final class GLInfoFragment extends ListFragment
 		final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_BIT);
 
 		ListView rootView = (ListView) inflater.inflate(R.layout.gamelist_listview, container, false);
-		List<AboutActivity.AboutFragmentItem> Input = new ArrayList<AboutActivity.AboutFragmentItem>();
+		List<AboutFragmentItem> Input = new ArrayList<AboutFragmentItem>();
 
 		for (Limit limit : Limits)
 		{
 			Log.i("GLInfoFragment", "Getting enum " + limit.name);
-			Input.add(new AboutActivity.AboutFragmentItem(limit.name, limit.GetValue(eglHelper)));
+			Input.add(new AboutFragmentItem(limit.name, limit.GetValue(eglHelper)));
 		}
 
 		// Get extensions manually
@@ -59,9 +59,9 @@ public final class GLInfoFragment extends ListFragment
 		{
 			extensionsBuilder.append(eglHelper.glGetStringi(GL10.GL_EXTENSIONS, i)).append('\n');
 		}
-		Input.add(new AboutActivity.AboutFragmentItem("OpenGL Extensions", extensionsBuilder.toString()));
+		Input.add(new AboutFragmentItem("OpenGL Extensions", extensionsBuilder.toString()));
 
-		AboutActivity.InfoFragmentAdapter adapter = new AboutActivity.InfoFragmentAdapter(getActivity(), R.layout.about_layout, Input);
+		AboutInfoFragmentAdapter adapter = new AboutInfoFragmentAdapter(getActivity(), R.layout.about_layout, Input);
 		rootView.setAdapter(adapter);
 
 		return rootView;

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/Limit.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/Limit.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright 2014 Dolphin Emulator Project
+ * Licensed under GPLv2
+ * Refer to the license.txt file included.
+ */
+
 package org.dolphinemu.dolphinemu.about;
 
 import org.dolphinemu.dolphinemu.utils.EGLHelper;


### PR DESCRIPTION
It doesn't make sense conceptually to keep them within the AboutActivity, as they are entirely self-contained classes.
