### PR TITLE
Add a namespace to DSPHost.

### DIFF
--- a/Source/Core/Core/DSP/DSPAccelerator.cpp
+++ b/Source/Core/Core/DSP/DSPAccelerator.cpp
@@ -17,7 +17,7 @@ static s16 ADPCM_Step(u32& _rSamplePos)
 
 	if (((_rSamplePos) & 15) == 0)
 	{
-		g_dsp.ifx_regs[DSP_PRED_SCALE] = DSPHost_ReadHostMemory((_rSamplePos & ~15) >> 1);
+		g_dsp.ifx_regs[DSP_PRED_SCALE] = DSPHost::ReadHostMemory((_rSamplePos & ~15) >> 1);
 		_rSamplePos += 2;
 	}
 
@@ -28,8 +28,8 @@ static s16 ADPCM_Step(u32& _rSamplePos)
 	s32 coef2 = pCoefTable[coef_idx * 2 + 1];
 
 	int temp = (_rSamplePos & 1) ?
-		   (DSPHost_ReadHostMemory(_rSamplePos >> 1) & 0xF) :
-		   (DSPHost_ReadHostMemory(_rSamplePos >> 1) >> 4);
+	       (DSPHost::ReadHostMemory(_rSamplePos >> 1) & 0xF) :
+	       (DSPHost::ReadHostMemory(_rSamplePos >> 1) >> 4);
 
 	if (temp >= 8)
 		temp -= 16;
@@ -56,13 +56,14 @@ u16 dsp_read_aram_d3()
 	u32 Address = (g_dsp.ifx_regs[DSP_ACCAH] << 16) | g_dsp.ifx_regs[DSP_ACCAL];
 	u16 val = 0;
 
-	switch (g_dsp.ifx_regs[DSP_FORMAT]) {
+	switch (g_dsp.ifx_regs[DSP_FORMAT])
+	{
 		case 0x5:   // u8 reads
-			val = DSPHost_ReadHostMemory(Address);
+			val = DSPHost::ReadHostMemory(Address);
 			Address++;
 			break;
 		case 0x6:   // u16 reads
-			val = (DSPHost_ReadHostMemory(Address*2) << 8) | DSPHost_ReadHostMemory(Address*2 + 1);
+			val = (DSPHost::ReadHostMemory(Address*2) << 8) | DSPHost::ReadHostMemory(Address*2 + 1);
 			Address++;
 			break;
 		default:
@@ -89,10 +90,11 @@ void dsp_write_aram_d3(u16 value)
 	// Zelda TP WII writes non-stop to 0x10000000-0x1000001f (non-zero values too)
 	u32 Address = (g_dsp.ifx_regs[DSP_ACCAH] << 16) | g_dsp.ifx_regs[DSP_ACCAL];
 
-	switch (g_dsp.ifx_regs[DSP_FORMAT]) {
+	switch (g_dsp.ifx_regs[DSP_FORMAT])
+	{
 		case 0xA:   // u16 writes
-			DSPHost_WriteHostMemory(value >> 8, Address*2);
-			DSPHost_WriteHostMemory(value & 0xFF, Address*2 + 1);
+			DSPHost::WriteHostMemory(value >> 8, Address*2);
+			DSPHost::WriteHostMemory(value & 0xFF, Address*2 + 1);
 			Address++;
 			break;
 		default:
@@ -122,13 +124,13 @@ u16 dsp_read_accelerator()
 			val = ADPCM_Step(Address);
 			break;
 		case 0x0A:  // 16-bit PCM audio
-			val = (DSPHost_ReadHostMemory(Address*2) << 8) | DSPHost_ReadHostMemory(Address*2 + 1);
+			val = (DSPHost::ReadHostMemory(Address*2) << 8) | DSPHost::ReadHostMemory(Address*2 + 1);
 			g_dsp.ifx_regs[DSP_YN2] = g_dsp.ifx_regs[DSP_YN1];
 			g_dsp.ifx_regs[DSP_YN1] = val;
 			Address++;
 			break;
 		case 0x19:  // 8-bit PCM audio
-			val = DSPHost_ReadHostMemory(Address) << 8;
+			val = DSPHost::ReadHostMemory(Address) << 8;
 			g_dsp.ifx_regs[DSP_YN2] = g_dsp.ifx_regs[DSP_YN1];
 			g_dsp.ifx_regs[DSP_YN1] = val;
 			Address++;

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -114,15 +114,14 @@ static bool VerifyRoms(const char *irom_filename, const char *coef_filename)
 
 	if (rom_idx == 1)
 	{
-		DSPHost_OSD_AddMessage("You are using an old free DSP ROM made by the Dolphin Team.", 6000);
-		DSPHost_OSD_AddMessage("Only games using the Zelda UCode will work correctly.", 6000);
+		DSPHost::OSD_AddMessage("You are using an old free DSP ROM made by the Dolphin Team.", 6000);
+		DSPHost::OSD_AddMessage("Only games using the Zelda UCode will work correctly.", 6000);
 	}
-
-	if (rom_idx == 2)
+	else if (rom_idx == 2)
 	{
-		DSPHost_OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
-		DSPHost_OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
-		DSPHost_OSD_AddMessage("also work fine, but the GBA/IPL/CARD UCodes will not work.\n", 8000);
+		DSPHost::OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
+		DSPHost::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
+		DSPHost::OSD_AddMessage("also work fine, but the GBA/IPL/CARD UCodes will not work.\n", 8000);
 	}
 
 	return true;
@@ -339,7 +338,7 @@ int DSPCore_RunCycles(int cycles)
 			DSPInterpreter::Step();
 			cycles--;
 
-			DSPHost_UpdateDebugger();
+			DSPHost::UpdateDebugger();
 			break;
 		case DSPCORE_STOP:
 			break;
@@ -355,7 +354,7 @@ void DSPCore_SetState(DSPCoreState new_state)
 	if (new_state == DSPCORE_RUNNING)
 		step_event.Set();
 	// Sleep(10);
-	DSPHost_UpdateDebugger();
+	DSPHost::UpdateDebugger();
 }
 
 DSPCoreState DSPCore_GetState()

--- a/Source/Core/Core/DSP/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/DSPEmitter.cpp
@@ -264,7 +264,7 @@ void DSPEmitter::Compile(u16 start_addr)
 			DSPJitRegCache c(gpr);
 			HandleLoop();
 			gpr.saveRegs();
-			if (!DSPHost_OnThread() && DSPAnalyzer::code_flags[start_addr] & DSPAnalyzer::CODE_IDLE_SKIP)
+			if (!DSPHost::OnThread() && DSPAnalyzer::code_flags[start_addr] & DSPAnalyzer::CODE_IDLE_SKIP)
 			{
 				MOV(16, R(EAX), Imm16(DSP_IDLE_SKIP_CYCLES));
 			}
@@ -298,7 +298,7 @@ void DSPEmitter::Compile(u16 start_addr)
 				DSPJitRegCache c(gpr);
 				//don't update g_dsp.pc -- the branch insn already did
 				gpr.saveRegs();
-				if (!DSPHost_OnThread() && DSPAnalyzer::code_flags[start_addr] & DSPAnalyzer::CODE_IDLE_SKIP)
+				if (!DSPHost::OnThread() && DSPAnalyzer::code_flags[start_addr] & DSPAnalyzer::CODE_IDLE_SKIP)
 				{
 					MOV(16, R(EAX), Imm16(DSP_IDLE_SKIP_CYCLES));
 				}
@@ -361,7 +361,7 @@ void DSPEmitter::Compile(u16 start_addr)
 	}
 
 	gpr.saveRegs();
-	if (!DSPHost_OnThread() && DSPAnalyzer::code_flags[start_addr] & DSPAnalyzer::CODE_IDLE_SKIP)
+	if (!DSPHost::OnThread() && DSPAnalyzer::code_flags[start_addr] & DSPAnalyzer::CODE_IDLE_SKIP)
 	{
 		MOV(16, R(EAX), Imm16(DSP_IDLE_SKIP_CYCLES));
 	}
@@ -389,7 +389,7 @@ void DSPEmitter::CompileDispatcher()
 	const u8 *dispatcherLoop = GetCodePtr();
 
 	FixupBranch exceptionExit;
-	if (DSPHost_OnThread())
+	if (DSPHost::OnThread())
 	{
 		CMP(8, M(const_cast<bool*>(&g_dsp.external_interrupt_waiting)), Imm8(0));
 		exceptionExit = J_CC(CC_NE);
@@ -420,7 +420,7 @@ void DSPEmitter::CompileDispatcher()
 
 	// DSP gave up the remaining cycles.
 	SetJumpTarget(_halt);
-	if (DSPHost_OnThread())
+	if (DSPHost::OnThread())
 	{
 		SetJumpTarget(exceptionExit);
 	}

--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -119,7 +119,7 @@ void gdsp_ifx_write(u32 addr, u32 val)
 	{
 		case DSP_DIRQ:
 			if (val & 0x1)
-				DSPHost_InterruptRequest();
+				DSPHost::InterruptRequest();
 			else
 				INFO_LOG(DSPLLE, "Unknown Interrupt Request pc=%04x (%04x)", g_dsp.pc, val);
 			break;
@@ -246,7 +246,7 @@ static void gdsp_idma_in(u16 dsp_addr, u32 addr, u32 size)
 	}
 	WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
 
-	DSPHost_CodeLoaded((const u8*)g_dsp.iram + dsp_addr, size);
+	DSPHost::CodeLoaded((const u8*)g_dsp.iram + dsp_addr, size);
 
 	NOTICE_LOG(DSPLLE, "*** Copy new UCode from 0x%08x to 0x%04x (crc: %8x)", addr, dsp_addr, g_dsp.iram_crc);
 }

--- a/Source/Core/Core/DSP/DSPHost.h
+++ b/Source/Core/Core/DSP/DSPHost.h
@@ -9,11 +9,14 @@
 // core isn't used, for example in an asm/disasm tool, then most of these
 // can be stubbed out.
 
-u8 DSPHost_ReadHostMemory(u32 addr);
-void DSPHost_WriteHostMemory(u8 value, u32 addr);
-void DSPHost_OSD_AddMessage(const std::string& str, u32 ms);
-bool DSPHost_OnThread();
-bool DSPHost_Wii();
-void DSPHost_InterruptRequest();
-void DSPHost_CodeLoaded(const u8 *ptr, int size);
-void DSPHost_UpdateDebugger();
+namespace DSPHost
+{
+u8 ReadHostMemory(u32 addr);
+void WriteHostMemory(u8 value, u32 addr);
+void OSD_AddMessage(const std::string& str, u32 ms);
+bool OnThread();
+bool IsWiiHost();
+void InterruptRequest();
+void CodeLoaded(const u8 *ptr, int size);
+void UpdateDebugger();
+}

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -21,40 +21,43 @@
 // core isn't used, for example in an asm/disasm tool, then most of these
 // can be stubbed out.
 
-u8 DSPHost_ReadHostMemory(u32 addr)
+namespace DSPHost
+{
+
+u8 ReadHostMemory(u32 addr)
 {
 	return DSP::ReadARAM(addr);
 }
 
-void DSPHost_WriteHostMemory(u8 value, u32 addr)
+void WriteHostMemory(u8 value, u32 addr)
 {
 	DSP::WriteARAM(value, addr);
 }
 
-void DSPHost_OSD_AddMessage(const std::string& str, u32 ms)
+void OSD_AddMessage(const std::string& str, u32 ms)
 {
 	OSD::AddMessage(str, ms);
 }
 
-bool DSPHost_OnThread()
+bool OnThread()
 {
 	const SCoreStartupParameter& _CoreParameter = SConfig::GetInstance().m_LocalCoreStartupParameter;
 	return  _CoreParameter.bDSPThread;
 }
 
-bool DSPHost_Wii()
+bool IsWiiHost()
 {
 	const SCoreStartupParameter& _CoreParameter = SConfig::GetInstance().m_LocalCoreStartupParameter;
 	return  _CoreParameter.bWii;
 }
 
-void DSPHost_InterruptRequest()
+void InterruptRequest()
 {
 	// Fire an interrupt on the PPC ASAP.
 	DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
 }
 
-void DSPHost_CodeLoaded(const u8 *ptr, int size)
+void CodeLoaded(const u8 *ptr, int size)
 {
 	g_dsp.iram_crc = HashEctor(ptr, size);
 
@@ -93,7 +96,7 @@ void DSPHost_CodeLoaded(const u8 *ptr, int size)
 	// Always add the ROM.
 	DSPSymbols::AutoDisassembly(0x8000, 0x9000);
 
-	DSPHost_UpdateDebugger();
+	UpdateDebugger();
 
 	if (dspjit)
 		dspjit->ClearIRAM();
@@ -101,7 +104,9 @@ void DSPHost_CodeLoaded(const u8 *ptr, int size)
 	DSPAnalyzer::Analyze();
 }
 
-void DSPHost_UpdateDebugger()
+void UpdateDebugger()
 {
 	Host_RefreshDSPDebuggerWindow();
+}
+
 }

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -75,7 +75,7 @@ void DSPLLE::DoState(PointerWrap &p)
 	p.DoArray(g_dsp.iram, DSP_IRAM_SIZE);
 	WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
 	if (p.GetMode() == PointerWrap::MODE_READ)
-		DSPHost_CodeLoaded((const u8*)g_dsp.iram, DSP_IRAM_BYTE_SIZE);
+		DSPHost::CodeLoaded((const u8*)g_dsp.iram, DSP_IRAM_BYTE_SIZE);
 	p.DoArray(g_dsp.dram, DSP_DRAM_SIZE);
 	p.Do(cyclesLeft);
 	p.Do(init_hax);


### PR DESCRIPTION
Gets rid of the "DSPHost_" prefix in function names.
