### PR TITLE
Fix DSPTool string output for disassembly.

### DIFF
--- a/Source/DSPTool/DSPTool.cpp
+++ b/Source/DSPTool/DSPTool.cpp
@@ -486,8 +486,15 @@ int main(int argc, const char *argv[])
 		source.clear();
 	}
 
-	if(!outputSize)
-		printf("Assembly completed successfully!\n");
+	if (disassemble)
+	{
+		printf("Disassembly completed successfully!\n");
+	}
+	else
+	{
+		if (!outputSize)
+			printf("Assembly completed successfully!\n");
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Would previously print that assembly had succeeded.
