### PR TITLE
Implement EFB pokes in the OpenGL backend.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1064,12 +1064,46 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		}
 
 	case POKE_COLOR:
-	case POKE_Z:
-		// TODO: Implement. One way is to draw a tiny pixel-sized rectangle at
-		// the exact location. Note: EFB pokes are susceptible to Z-buffering
-		// and perhaps blending.
-		//WARN_LOG(VIDEOINTERFACE, "This is probably some kind of software rendering");
+	{
+		ResetAPIState();
+
+		glClearColor(float((poke_data >> 16) & 0xFF) / 255.0f,
+		             float((poke_data >>  8) & 0xFF) / 255.0f,
+		             float((poke_data >>  0) & 0xFF) / 255.0f,
+		             float((poke_data >> 24) & 0xFF) / 255.0f);
+
+		glEnable(GL_SCISSOR_TEST);
+		glScissor(targetPixelRc.left, targetPixelRc.bottom, targetPixelRc.GetWidth(), targetPixelRc.GetHeight());
+
+		glClear(GL_COLOR_BUFFER_BIT);
+
+		RestoreAPIState();
+
+		// TODO: Could just update the EFB cache with the new value
+		ClearEFBCache();
+
 		break;
+	}
+
+	case POKE_Z:
+	{
+		ResetAPIState();
+
+		glDepthMask(GL_TRUE);
+		glClearDepthf(float(poke_data & 0xFFFFFF) / float(0xFFFFFF));
+
+		glEnable(GL_SCISSOR_TEST);
+		glScissor(targetPixelRc.left, targetPixelRc.bottom, targetPixelRc.GetWidth(), targetPixelRc.GetHeight());
+
+		glClear(GL_DEPTH_BUFFER_BIT);
+
+		RestoreAPIState();
+
+		// TODO: Could just update the EFB cache with the new value
+		ClearEFBCache();
+
+		break;
+	}
 
 	default:
 		break;


### PR DESCRIPTION
EFB pokes are a hardware feature used in a very small number of games to directly write data to the framebuffer from the CPU.

The feature has been emulated in the D3D backend for ages, but the code wasn't moved over to OpenGL until now. The algorithm in OpenGL uses clears instead of drawing little quads, which might be slightly faster (or not) than drawing 1x1 pixel quads, but surely the code is fairly clean. This code path is pretty much a "meh, if games use this we have a problem anyway" thing, so performance is not really a problem anyway.

This code was tested briefly and shown to work, I'll test it further against games known to use EFB pokes (Monster Hunter Tri, the GC Mario soccer game) before merging. Meanwhile, people can comment on the patch :)

A possibly important consequence of this patch is that games which make extensive use of EFB pokes (Monster Hunter Tri, and under very certain circumstances Mario Kart Wii) will get ridiculously slow. EFB pokes should probably be queued as an optimization. I'm not interested in coding this optimization though, especially since it's general enough for someone else to do. Regardless, as a workaround EFB accesses can be skipped to make things work fast (without the EFB pokes being accepted, of course).
