### PR TITLE
Remove the extra parameters field from the PH.

### DIFF
--- a/Data/Sys/GameSettings/PH_PRESETS.ini
+++ b/Data/Sys/GameSettings/PH_PRESETS.ini
@@ -3,7 +3,7 @@
 # IMPORTANT: Incremental Sections only are allowed and without jumps.
 # IMPORTANT: Each Section REQUIRES "Title" entry existing. Other entries are optionals.
 
-# ENTRIES LIST: Title, PH_SZNear, PH_ZNear, PH_ZSFar, PH_ZFar, PH_ExtraParam
+# ENTRIES LIST: Title, PH_SZNear, PH_ZNear, PH_ZSFar, PH_ZFar
 
 [0]
 Title = Zelda Twilight Princess (Bloom hack)
@@ -28,10 +28,6 @@ PH_SZFar = 1
 PH_ZFar = 0.4
 
 [4]
-Title = Metroid: Other M
-PH_ExtraParam = 1
-
-[5]
 Title = Tales of Symphonia GC
 PH_ZNear = 0.00026
 

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -1038,9 +1038,6 @@ void CISOProperties::LoadGameConfig()
 	GameIniDefault.Get("Video", "PH_SZFar", &PHack_Data.PHackSZFar);
 	if (GameIniLocal.GetIfExists("Video", "PH_SZFar", &iTemp))
 		PHack_Data.PHackSZFar = !!iTemp;
-	GameIniDefault.Get("Video", "PH_ExtraParam", &PHack_Data.PHackExP);
-	if (GameIniLocal.GetIfExists("Video", "PH_ExtraParam", &iTemp))
-		PHack_Data.PHackExP = !!iTemp;
 
 	std::string sTemp;
 	GameIniDefault.Get("Video", "PH_ZNear", &PHack_Data.PHZNear);
@@ -1122,7 +1119,6 @@ bool CISOProperties::SaveGameConfig()
 	SAVE_IF_NOT_DEFAULT("Video", "ProjectionHack", (int)PHackEnable->GetValue(), 0);
 	SAVE_IF_NOT_DEFAULT("Video", "PH_SZNear", (PHack_Data.PHackSZNear ? 1 : 0), 0);
 	SAVE_IF_NOT_DEFAULT("Video", "PH_SZFar", (PHack_Data.PHackSZFar ? 1 : 0), 0);
-	SAVE_IF_NOT_DEFAULT("Video", "PH_ExtraParam", (PHack_Data.PHackExP ? 1 : 0), 0);
 	SAVE_IF_NOT_DEFAULT("Video", "PH_ZNear", PHack_Data.PHZNear, "");
 	SAVE_IF_NOT_DEFAULT("Video", "PH_ZFar", PHack_Data.PHZFar, "");
 	SAVE_IF_NOT_DEFAULT("EmuState", "EmulationStateId", EmuState->GetSelection(), 0);

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -36,7 +36,6 @@ struct PHackData
 {
 	bool PHackSZNear;
 	bool PHackSZFar;
-	bool PHackExP;
 	std::string PHZNear;
 	std::string PHZFar;
 };

--- a/Source/Core/DolphinWX/PHackSettings.cpp
+++ b/Source/Core/DolphinWX/PHackSettings.cpp
@@ -63,8 +63,6 @@ void CPHackSettings::CreateGUIControls()
 	PHackZFar->SetToolTip(_("Adds the specified value to zFar Parameter.\nTwo ways to express the floating point values.\nExample: entering '\'200'\' or '\'0.0002'\' directly, it produces equal effects, the acquired value will be '\'0.0002'\'.\nValues: (0->+/-Integer) or (0->+/-FP[6 digits of precision])\n\nNOTE: Check LogWindow/Console for the acquired values."));
 	PHackSZFar = new wxCheckBox(this, ID_PHACK_SZFAR, _("(-)+zFar"));
 	PHackSZFar->SetToolTip(_("Changes sign to zFar Parameter (after correction)"));
-	PHackExP = new wxCheckBox(this, ID_PHACK_EXP, _("Extra Parameter"));
-	PHackExP->SetToolTip(_("Extra Parameter useful in '\'Metroid: Other M'\' only."));
 
 	wxStaticBoxSizer *sbPHackSettings = new wxStaticBoxSizer(wxVERTICAL, this, _("Parameters"));
 	wxFlexGridSizer *szrPHackSettings = new wxFlexGridSizer(3, 5, 5);
@@ -75,7 +73,6 @@ void CPHackSettings::CreateGUIControls()
 	szrPHackSettings->Add(PHackZFarText, 0, wxALIGN_CENTER_VERTICAL);
 	szrPHackSettings->Add(PHackZFar, 1, wxEXPAND);
 	szrPHackSettings->Add(PHackSZFar, 0, wxEXPAND|wxLEFT, 5);
-	szrPHackSettings->Add(PHackExP, 0, wxEXPAND|wxTOP|wxBOTTOM, 5);
 
 	wxBoxSizer* sPHack = new wxBoxSizer(wxVERTICAL);
 	sPHack->Add(PHackChoiceText, 0, wxEXPAND|wxLEFT|wxRIGHT|wxTOP, 5);
@@ -110,7 +107,6 @@ void CPHackSettings::LoadPHackData()
 
 	PHackSZNear->Set3StateValue((wxCheckBoxState)PHack_Data.PHackSZNear);
 	PHackSZFar->Set3StateValue((wxCheckBoxState)PHack_Data.PHackSZFar);
-	PHackExP->Set3StateValue((wxCheckBoxState)PHack_Data.PHackExP);
 
 	PHackZNear->SetValue(StrToWxStr(PHack_Data.PHZNear));
 	PHackZFar->SetValue(StrToWxStr(PHack_Data.PHZFar));
@@ -131,8 +127,6 @@ void CPHackSettings::SetRefresh(wxCommandEvent& event)
 		PHackSZNear->Set3StateValue((wxCheckBoxState)bTemp);
 		PHPresetsIni.Get(sIndex, "PH_SZFar", &bTemp);
 		PHackSZFar->Set3StateValue((wxCheckBoxState)bTemp);
-		PHPresetsIni.Get(sIndex, "PH_ExtraParam", &bTemp);
-		PHackExP->Set3StateValue((wxCheckBoxState)bTemp);
 		PHPresetsIni.Get(sIndex, "PH_ZNear", &sTemp);
 		PHackZNear->SetValue(StrToWxStr(sTemp));
 		PHPresetsIni.Get(sIndex, "PH_ZFar", &sTemp);
@@ -144,7 +138,6 @@ void CPHackSettings::SavePHackData(wxCommandEvent& event)
 {
 	PHack_Data.PHackSZNear = PHackSZNear->GetValue();
 	PHack_Data.PHackSZFar = PHackSZFar->GetValue();
-	PHack_Data.PHackExP = PHackExP->GetValue();
 
 	PHack_Data.PHZNear = PHackZNear->GetValue().char_str();
 	PHack_Data.PHZFar = PHackZFar->GetValue().char_str();

--- a/Source/Core/DolphinWX/PHackSettings.h
+++ b/Source/Core/DolphinWX/PHackSettings.h
@@ -35,7 +35,6 @@ class CPHackSettings : public wxDialog
 		wxChoice *PHackChoice;
 		wxCheckBox *PHackSZNear;
 		wxCheckBox *PHackSZFar;
-		wxCheckBox *PHackExP;
 		wxTextCtrl *PHackZNear;
 		wxTextCtrl *PHackZFar;
 
@@ -45,7 +44,6 @@ class CPHackSettings : public wxDialog
 			ID_PHACK_SZFAR,
 			ID_PHACK_ZNEAR,
 			ID_PHACK_ZFAR,
-			ID_PHACK_EXP
 		};
 
 		IniFile PHPresetsIni;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -51,7 +51,6 @@ namespace
 // Control Variables
 static ProjectionHack g_ProjHack1;
 static ProjectionHack g_ProjHack2;
-static bool g_ProjHack3;
 } // Namespace
 
 float PHackValue(std::string sValue)
@@ -90,7 +89,6 @@ void UpdateProjectionHack(int iPhackvalue[], std::string sPhackvalue[])
 {
 	float fhackvalue1 = 0, fhackvalue2 = 0;
 	float fhacksign1 = 1.0, fhacksign2 = 1.0;
-	bool bProjHack3 = false;
 	const char *sTemp[2];
 
 	if (iPhackvalue[0] == 1)
@@ -108,17 +106,11 @@ void UpdateProjectionHack(int iPhackvalue[], std::string sPhackvalue[])
 		fhackvalue2 = PHackValue(sPhackvalue[1]);
 		NOTICE_LOG(VIDEO, "- zFar Correction =  (%f + zFar)%s", fhackvalue2, sTemp[1]);
 
-		sTemp[0] = "DISABLED";
-		bProjHack3 = (iPhackvalue[3] == 1) ? true : bProjHack3;
-		if (bProjHack3)
-			sTemp[0] = "ENABLED";
-		NOTICE_LOG(VIDEO, "- Extra Parameter: %s", sTemp[0]);
 	}
 
 	// Set the projections hacks
 	g_ProjHack1 = ProjectionHack(fhacksign1, fhackvalue1);
 	g_ProjHack2 = ProjectionHack(fhacksign2, fhackvalue2);
-	g_ProjHack3 = bProjHack3;
 }
 
 
@@ -452,15 +444,8 @@ void VertexShaderManager::SetConstants()
 			g_fProjectionMatrix[12] = 0.0f;
 			g_fProjectionMatrix[13] = 0.0f;
 
-			/*
-			projection hack for metroid other m...attempt to remove black projection layer from cut scenes.
-			g_fProjectionMatrix[15] = 1.0f was the default setting before
-			this hack was added...setting g_fProjectionMatrix[14] to -1 might make the hack more stable, needs more testing.
-			Only works for OGL...this is not helping DX11
-			*/
-
 			g_fProjectionMatrix[14] = 0.0f;
-			g_fProjectionMatrix[15] = (g_ProjHack3 && rawProjection[0] == 2.0f ? 0.0f : 1.0f);  //causes either the efb copy or bloom layer not to show if proj hack enabled
+			g_fProjectionMatrix[15] = 1.0f;
 
 			SETSTAT_FT(stats.g2proj_0, g_fProjectionMatrix[0]);
 			SETSTAT_FT(stats.g2proj_1, g_fProjectionMatrix[1]);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -197,7 +197,6 @@ void VideoConfig::GameIniLoad()
 	CHECK_SETTING("Video", "ProjectionHack", iPhackvalue[0]);
 	CHECK_SETTING("Video", "PH_SZNear", iPhackvalue[1]);
 	CHECK_SETTING("Video", "PH_SZFar", iPhackvalue[2]);
-	CHECK_SETTING("Video", "PH_ExtraParam", iPhackvalue[3]);
 	CHECK_SETTING("Video", "PH_ZNear", sPhackvalue[0]);
 	CHECK_SETTING("Video", "PH_ZFar", sPhackvalue[1]);
 	CHECK_SETTING("Video", "UseBBox", bUseBBox);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -114,7 +114,7 @@ struct VideoConfig
 	bool bCopyEFBToTexture;
 	bool bCopyEFBScaled;
 	int iSafeTextureCache_ColorSamples;
-	int iPhackvalue[4];
+	int iPhackvalue[3];
 	std::string sPhackvalue[2];
 	float fAspectRatioHackW, fAspectRatioHackH;
 	bool bUseBBox;


### PR DESCRIPTION
Metroid: Other M was the only game which required this field, but the
issue in that game can be fixed properly by enabling format change
emulation. Hence, there's no point in having this around anymore.
Fixes issue 6644.
