### PR TITLE
Add extract dol/apploader options back for gc disks.

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -694,12 +694,18 @@ void CISOProperties::OnRightClickOnTree(wxTreeEvent& event)
 
 	popupMenu->Append(IDM_EXTRACTALL, _("Extract All Files..."));
 
-	if (m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 0 &&
-	    m_Treectrl->GetFirstVisibleItem() != m_Treectrl->GetSelection())
+	if (!DiscIO::IsVolumeWiiDisc(OpenISO) ||
+		(m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 0 &&
+		m_Treectrl->GetFirstVisibleItem() != m_Treectrl->GetSelection()))
 	{
 		popupMenu->AppendSeparator();
 		popupMenu->Append(IDM_EXTRACTAPPLOADER, _("Extract Apploader..."));
 		popupMenu->Append(IDM_EXTRACTDOL, _("Extract DOL..."));
+	}
+
+	if (m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 0 &&
+		m_Treectrl->GetFirstVisibleItem() != m_Treectrl->GetSelection())
+	{
 		popupMenu->AppendSeparator();
 		popupMenu->Append(IDM_CHECKINTEGRITY, _("Check Partition Integrity"));
 	}


### PR DESCRIPTION
It was removed from the menu for the disk item in 868c6278, but we want to keep it there for gc games, since they don't have separate partitions.
