### PR TITLE
Fix building the release APK with gradle.

### DIFF
--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -29,6 +29,12 @@ android {
 		compileTask -> compileTask.dependsOn(nativeLibsToJar)
 	}
 
+	lintOptions {
+		// This is important as it will run lint but not abort on error
+		// Lint has some overly obnoxious "errors" that should really be warnings
+		abortOnError false
+	}
+
 	sourceSets {
 		main {
 			manifest.srcFile 'AndroidManifest.xml'


### PR DESCRIPTION
In release build all warnings are errors, and lint has some obnoxious warnings.
