### PR TITLE
Fixes warnings that Clang 3.4 exposes on Android.

### DIFF
--- a/Source/Core/DolphinWX/GLInterface/GLX.cpp
+++ b/Source/Core/DolphinWX/GLInterface/GLX.cpp
@@ -27,7 +27,7 @@ void cInterfaceGLX::SwapInterval(int Interval)
 	else
 		ERROR_LOG(VIDEO, "No support for SwapInterval (framerate clamped to monitor refresh rate).");
 }
-void* cInterfaceGLX::GetFuncAddress(std::string name)
+void* cInterfaceGLX::GetFuncAddress(const std::string& name)
 {
 	return (void*)glXGetProcAddress((const GLubyte*)name.c_str());
 }

--- a/Source/Core/DolphinWX/GLInterface/GLX.h
+++ b/Source/Core/DolphinWX/GLInterface/GLX.h
@@ -18,7 +18,7 @@ public:
 	void SwapInterval(int Interval) override;
 	void Swap() override;
 	void UpdateFPSDisplay(const std::string& text) override;
-	void* GetFuncAddress(std::string name) override;
+	void* GetFuncAddress(const std::string& name) override;
 	bool Create(void *&window_handle) override;
 	bool MakeCurrent() override;
 	bool ClearCurrent() override;

--- a/Source/Core/DolphinWX/GLInterface/InterfaceBase.h
+++ b/Source/Core/DolphinWX/GLInterface/InterfaceBase.h
@@ -28,7 +28,7 @@ public:
 	virtual void UpdateFPSDisplay(const std::string& text) {}
 	virtual void SetMode(u32 mode) { s_opengl_mode = GLInterfaceMode::MODE_OPENGL; }
 	virtual u32 GetMode() { return s_opengl_mode; }
-	virtual void* GetFuncAddress(std::string name) { return nullptr; }
+	virtual void* GetFuncAddress(const std::string& name) { return nullptr; }
 	virtual bool Create(void *&window_handle) { return true; }
 	virtual bool MakeCurrent() { return true; }
 	virtual bool ClearCurrent() { return true; }

--- a/Source/Core/DolphinWX/GLInterface/WGL.cpp
+++ b/Source/Core/DolphinWX/GLInterface/WGL.cpp
@@ -33,7 +33,7 @@ void cInterfaceWGL::Swap()
 	SwapBuffers(hDC);
 }
 
-void* cInterfaceWGL::GetFuncAddress(std::string name)
+void* cInterfaceWGL::GetFuncAddress(const std::string& name)
 {
 	void* func = (void*)wglGetProcAddress((LPCSTR)name.c_str());
 	if (func == nullptr)

--- a/Source/Core/DolphinWX/GLInterface/WGL.h
+++ b/Source/Core/DolphinWX/GLInterface/WGL.h
@@ -13,7 +13,7 @@ public:
 	void SwapInterval(int Interval);
 	void Swap();
 	void UpdateFPSDisplay(const std::string& text);
-	void* GetFuncAddress(std::string name);
+	void* GetFuncAddress(const std::string& name);
 	bool Create(void *&window_handle);
 	bool MakeCurrent();
 	bool ClearCurrent();

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -51,7 +51,7 @@ int g_width, g_height;
 std::string g_filename;
 static std::thread g_run_thread;
 
-#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, "Dolphinemu", __VA_ARGS__))
+#define DOLPHIN_TAG "Dolphinemu"
 
 void Host_NotifyMapLoaded() {}
 void Host_RefreshDSPDebuggerWindow() {}
@@ -72,8 +72,8 @@ void* Host_GetInstance() { return nullptr; }
 
 void Host_UpdateTitle(const std::string& title)
 {
-	LOGI(title.c_str());
-};
+	__android_log_write(ANDROID_LOG_INFO, DOLPHIN_TAG, title.c_str());
+}
 
 void Host_UpdateLogDisplay(){}
 
@@ -116,19 +116,11 @@ void Host_UpdateStatusBar(const std::string& text, int filed){}
 
 void Host_SysMessage(const char *fmt, ...)
 {
-	va_list list;
-	char msg[512];
+	va_list args;
 
-	va_start(list, fmt);
-	vsnprintf(msg, 512, fmt, list);
-	va_end(list);
-
-	size_t len = strlen(msg);
-	if (msg[len - 1] != '\n') {
-		msg[len - 1] = '\n';
-		msg[len] = '\0';
-	}
-	LOGI(msg);
+	va_start(args, fmt);
+	__android_log_vprint(ANDROID_LOG_INFO, DOLPHIN_TAG, fmt, args); 
+	va_end(args);
 }
 
 void Host_SetWiiMoteConnectionState(int _State) {}

--- a/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
@@ -170,13 +170,6 @@ int TexDecoder_GetPaletteSize(int format)
 	}
 }
 
-static inline u32 decodeIA8(u16 val)
-{
-	int a = val >> 8;
-	int i = val & 0xFF;
-	return (a << 24) | (i << 16) | (i << 8) | i;
-}
-
 static inline u32 decode5A3(u16 val)
 {
 	int r,g,b,a;


### PR DESCRIPTION
Fixes all warnings on Android build except for what is in externals.
Removes a function from TextureDecoder_Generic since it is unused and generates a warning.
