### PR TITLE
Some cleanups for OGL/Vertexmanager.cpp

### DIFF
--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -158,8 +158,7 @@ void VertexManager::vFlush(bool useDstAlpha)
 	ProgramShaderCache::UploadConstants();
 
 	// setup the pointers
-	if (g_nativeVertexFmt)
-		g_nativeVertexFmt->SetupVertexPointers();
+	g_nativeVertexFmt->SetupVertexPointers();
 	GL_REPORT_ERRORD();
 
 	Draw(stride);


### PR DESCRIPTION
Although it is always scary to modify behavior around global variables I think 46b7cfe should be safe.
