### PR TITLE
Intel driver doesn't like signed integer division.

### DIFF
--- a/Source/Core/VideoCommon/LightingShaderGen.h
+++ b/Source/Core/VideoCommon/LightingShaderGen.h
@@ -255,7 +255,7 @@ static void GenerateLightingShader(T& object, LightingUidData& uid_data, int com
 					GenerateLightShader<T>(object, uid_data, i, lit_index, lightsColName, lightsName, coloralpha);
 			}
 		}
-		object.Write("%s%d = float4(mat * clamp(lacc, 0, 255) / 255) / 255.0;\n", dest, j);
+		object.Write("%s%d = float4(uint4(mat * clamp(lacc, 0, 255)) / 255) / 255.0;\n", dest, j);
 		object.Write("}\n");
 	}
 }

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -791,7 +791,7 @@ static inline void WriteStage(T& out, pixel_shader_uid_data& uid_data, int n, AP
 		if (!(cc.d == TEVCOLORARG_ZERO && cc.op == TEVOP_ADD))
 			out.Write("%s %s ", tevCInputTable[cc.d], tevOpTable[cc.op]);
 
-		out.Write("((%s&255) * (int3(255,255,255) - (%s&255)) + (%s&255) * (%s&255)) / 255", tevCInputTable[cc.a], tevCInputTable[cc.c], tevCInputTable[cc.b], tevCInputTable[cc.c]);
+		out.Write("uint3((%s&255) * (int3(255,255,255) - (%s&255)) + (%s&255) * (%s&255)) / 255", tevCInputTable[cc.a], tevCInputTable[cc.c], tevCInputTable[cc.b], tevCInputTable[cc.c]);
 
 		out.Write(" %s", tevBiasTable[cc.bias]);
 
@@ -835,7 +835,7 @@ static inline void WriteStage(T& out, pixel_shader_uid_data& uid_data, int n, AP
 		if (!(ac.d == TEVALPHAARG_ZERO && ac.op == TEVOP_ADD))
 			out.Write("%s.a %s ", tevAInputTable[ac.d], tevOpTable[ac.op]);
 
-		out.Write("((%s.a&255) * (255 - (%s.a&255)) + (%s.a&255) * (%s.a&255)) / 255", tevAInputTable[ac.a], tevAInputTable[ac.c], tevAInputTable[ac.b], tevAInputTable[ac.c]);
+		out.Write("uint((%s.a&255) * (255 - (%s.a&255)) + (%s.a&255) * (%s.a&255)) / 255", tevAInputTable[ac.a], tevAInputTable[ac.c], tevAInputTable[ac.b], tevAInputTable[ac.c]);
 
 		out.Write(" %s",tevBiasTable[ac.bias]);
 


### PR DESCRIPTION
If you use signed integer division with the Intel HD 4000
driver, it prints a warning (which gets turned into an error) suggesting
that signed integer division should be avoided in favor of unsigned division.

I'm not sure this patch is the right way to fix this issue; maybe some of the other variables should have type uint?
