### PR TITLE
Allow the user to enable the extended information string like the old days.

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -184,6 +184,7 @@ void SConfig::SaveSettings()
 	ini.Set("Interface", "ShowStatusbar",       m_InterfaceStatusbar);
 	ini.Set("Interface", "ShowLogWindow",       m_InterfaceLogWindow);
 	ini.Set("Interface", "ShowLogConfigWindow", m_InterfaceLogConfigWindow);
+	ini.Set("Interface", "ExtendedFPSInfo",     m_InterfaceExtendedFPSInfo);
 	ini.Set("Interface", "ThemeName40",         m_LocalCoreStartupParameter.theme_name);
 
 	// Hotkeys
@@ -331,6 +332,7 @@ void SConfig::LoadSettings()
 		ini.Get("Interface", "ShowStatusbar",           &m_InterfaceStatusbar,                          true);
 		ini.Get("Interface", "ShowLogWindow",           &m_InterfaceLogWindow,                          false);
 		ini.Get("Interface", "ShowLogConfigWindow",     &m_InterfaceLogConfigWindow,                    false);
+		ini.Get("Interface", "ExtendedFPSInfo",         &m_InterfaceExtendedFPSInfo,                    false);
 		ini.Get("Interface", "ThemeName40",             &m_LocalCoreStartupParameter.theme_name,        "Clean");
 
 		// Hotkeys

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -55,6 +55,7 @@ struct SConfig : NonCopyable
 	bool m_InterfaceStatusbar;
 	bool m_InterfaceLogWindow;
 	bool m_InterfaceLogConfigWindow;
+	bool m_InterfaceExtendedFPSInfo;
 
 	bool m_ListDrives;
 	bool m_ListWad;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -675,43 +675,42 @@ void UpdateTitle()
 	std::string SSettings = StringFromFormat("%s %s | %s | %s", cpu_core_base->GetName(), _CoreParameter.bCPUThread ? "DC" : "SC",
 		g_video_backend->GetDisplayName().c_str(), _CoreParameter.bDSPHLE ? "HLE" : "LLE");
 
-	// Use extended or summary information. The summary information does not print the ticks data,
-	// that's more of a debugging interest, it can always be optional of course if someone is interested.
-	//#define EXTENDED_INFO
-	#ifdef EXTENDED_INFO
-		static u64 ticks = 0;
-		static u64 idleTicks = 0;
-		u64 newTicks = CoreTiming::GetTicks();
-		u64 newIdleTicks = CoreTiming::GetIdleTicks();
-
-		u64 diff = (newTicks - ticks) / 1000000;
-		u64 idleDiff = (newIdleTicks - idleTicks) / 1000000;
-
-		ticks = newTicks;
-		idleTicks = newIdleTicks;
-
-		float TicksPercentage = (float)diff / (float)(SystemTimers::GetTicksPerSecond() / 1000000) * 100;
-
-		std::string SFPS = StringFromFormat("FPS: %u - VPS: %u - %u%%", FPS, VPS, Speed);
-		SFPS += StringFromFormat(" | CPU: %s%i MHz [Real: %i + IdleSkip: %i] / %i MHz (%s%3.0f%%)",
-				_CoreParameter.bSkipIdle ? "~" : "",
-				(int)(diff),
-				(int)(diff - idleDiff),
-				(int)(idleDiff),
-				SystemTimers::GetTicksPerSecond() / 1000000,
-				_CoreParameter.bSkipIdle ? "~" : "",
-				TicksPercentage);
-
-	#else // Summary information
 	std::string SFPS;
+
 	if (Movie::IsPlayingInput())
 		SFPS = StringFromFormat("VI: %u/%u - Frame: %u/%u - FPS: %.0f - VPS: %.0f - %.0f%%", (u32)Movie::g_currentFrame, (u32)Movie::g_totalFrames, (u32)Movie::g_currentInputCount, (u32)Movie::g_totalInputCount, FPS, VPS, Speed);
 	else if (Movie::IsRecordingInput())
 		SFPS = StringFromFormat("VI: %u - Frame: %u - FPS: %.0f - VPS: %.0f - %.0f%%", (u32)Movie::g_currentFrame, (u32)Movie::g_currentInputCount, FPS, VPS, Speed);
 	else
+	{
 		SFPS = StringFromFormat("FPS: %.0f - VPS: %.0f - %.0f%%", FPS, VPS, Speed);
-	#endif
+		if (SConfig::GetInstance().m_InterfaceExtendedFPSInfo)
+		{
+			// Use extended or summary information. The summary information does not print the ticks data,
+			// that's more of a debugging interest, it can always be optional of course if someone is interested.
+			static u64 ticks = 0;
+			static u64 idleTicks = 0;
+			u64 newTicks = CoreTiming::GetTicks();
+			u64 newIdleTicks = CoreTiming::GetIdleTicks();
 
+			u64 diff = (newTicks - ticks) / 1000000;
+			u64 idleDiff = (newIdleTicks - idleTicks) / 1000000;
+
+			ticks = newTicks;
+			idleTicks = newIdleTicks;
+
+			float TicksPercentage = (float)diff / (float)(SystemTimers::GetTicksPerSecond() / 1000000) * 100;
+
+			SFPS += StringFromFormat(" | CPU: %s%i MHz [Real: %i + IdleSkip: %i] / %i MHz (%s%3.0f%%)",
+					_CoreParameter.bSkipIdle ? "~" : "",
+					(int)(diff),
+					(int)(diff - idleDiff),
+					(int)(idleDiff),
+					SystemTimers::GetTicksPerSecond() / 1000000,
+					_CoreParameter.bSkipIdle ? "~" : "",
+					TicksPercentage);
+		}
+	}
 	// This is our final "frame counter" string
 	std::string SMessage = StringFromFormat("%s | %s", SSettings.c_str(), SFPS.c_str());
 	std::string TMessage = StringFromFormat("%s | %s", scm_rev_str, SMessage.c_str());


### PR DESCRIPTION
This string shows emulated CPU speed, including true mhz + idle skipping mhz

This is mostly a developer options so it is only available in the INI file, no need to throw it in the UI.
