### PR TITLE
Pass our signing information to gradle by argument.

### DIFF
--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -61,12 +61,11 @@ android {
 
 	signingConfigs {
 		release {
-			if (System.getenv("KEYSTORE") != null)
-			{
-				storeFile file(System.getenv("KEYSTORE"))
-				storePassword System.getenv("KEYSTORE_PASSWORD")
-				keyAlias System.getenv("KEY_ALIAS")
-				keyPassword System.getenv("KEY_PASSWORD")
+			if (project.hasProperty('keystore')) {
+				storeFile file(project.property('keystore'))
+				storePassword project.property('storepass')
+				keyAlias project.property('keyalias')
+				keyPassword project.property('keypass')
 			}
 		}
 	}


### PR DESCRIPTION
Changes from using environment variables that the world can see to arguments.
So we don't have to expose our keys and aliases to people
