### PR TITLE
Revert "Remove an unnecessary wx translation underscore macro from PHackSettings."

### DIFF
--- a/Source/Core/DolphinWX/PHackSettings.cpp
+++ b/Source/Core/DolphinWX/PHackSettings.cpp
@@ -90,7 +90,7 @@ void CPHackSettings::LoadPHackData()
 	std::string sIndex;
 
 	PHackChoice->Clear();
-	PHackChoice->Append("[Custom]");
+	PHackChoice->Append(_("[Custom]"));
 	for (int i = 0; ; i++)
 	{
 		sIndex = std::to_string(i);
@@ -104,7 +104,7 @@ void CPHackSettings::LoadPHackData()
 			sTemp = WxStrToStr(_("(UNKNOWN)"));
 
 		if (i == 0)
-			PHackChoice->Append("-------------");
+			PHackChoice->Append(StrToWxStr("-------------"));
 
 		PHackChoice->Append(StrToWxStr(sTemp));
 	}


### PR DESCRIPTION
This reverts commit 110f603cb68ef7eadd0704c8419ec0a06737af98.
