### PR TITLE
Fix a crash that got recently introduced.

### DIFF
--- a/Source/Core/DiscIO/FileMonitor.cpp
+++ b/Source/Core/DiscIO/FileMonitor.cpp
@@ -143,6 +143,9 @@ void FindFilename(u64 offset)
 	}
 
 	const std::string filename = pFileSystem->GetFileName(offset);
+	
+	if (filename.empty())
+		return;
 
 	CheckFile(filename, pFileSystem->GetFileSize(filename));
 }

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -60,7 +60,7 @@ const std::string CFileSystemGCWii::GetFileName(u64 _Address)
 		}
 	}
 
-	return nullptr;
+	return "";
 }
 
 u64 CFileSystemGCWii::ReadFile(const std::string& _rFullPath, u8* _pBuffer, size_t _MaxBufferSize)


### PR DESCRIPTION
When CFileSystemGCWii::GetFileName can't find a valid filename it would return nullptr.
nullptr as a std::string throws an assert within the std lib.
So return an empty string and check if it is empty or not
