### PR TITLE
Make our shadercache one file in size.

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -397,8 +397,7 @@ void PixelShaderCache::Init()
 	SETSTAT(stats.numPixelShadersAlive, 0);
 
 	char cache_filename[MAX_PATH];
-	sprintf(cache_filename, "%sdx11-%s-ps.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-			SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str());
+	sprintf(cache_filename, "%sdx11-ps.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str());
 	PixelShaderCacheInserter inserter;
 	g_ps_disk_cache.OpenAndRead(cache_filename, inserter);
 

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -144,8 +144,7 @@ void VertexShaderCache::Init()
 	SETSTAT(stats.numVertexShadersAlive, 0);
 
 	char cache_filename[MAX_PATH];
-	sprintf(cache_filename, "%sdx11-%s-vs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-			SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str());
+	sprintf(cache_filename, "%sdx11-vs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str());
 	VertexShaderCacheInserter inserter;
 	g_vs_disk_cache.OpenAndRead(cache_filename, inserter);
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -384,8 +384,7 @@ void ProgramShaderCache::Init(void)
 				File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
 
 			char cache_filename[MAX_PATH];
-			sprintf(cache_filename, "%sogl-%s-shaders.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-				SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str());
+			sprintf(cache_filename, "%sogl-shaders.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str());
 
 			ProgramShaderCacheInserter inserter;
 			g_program_disk_cache.OpenAndRead(cache_filename, inserter);


### PR DESCRIPTION
Instead of generating different shader cache files per game, create only one(2 in D3D) combined cache file for all games.
This is an improvement over the other way since if someone plays hundreds of games the size grows absurdly large(>350MB)
It's also an improvement since even if someone hasn't played a game before, there is a high chance it'll use shaders with the same UID and not have to
generate them again, removing microstutters before the problem even occurs.

The reason why this wasn't how we did it initially was out of concerns that one game could generate a million shaders, while another one wouldn't
generate much at all. Thus having a bunch of programs in vram that weren't in use.
1) This isn't much of an issue since program size in RAM is absurdly small
2) The new shader UID generation has significantly lowered how many programs are generated.
