### PR TITLE
Fix IsTriviallyCopyable for volatile (fixes Mac build).

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -28,7 +28,7 @@
 
 // ewww
 #if _LIBCPP_VERSION
-#define IsTriviallyCopyable(T) std::is_trivially_copyable<T>::value
+#define IsTriviallyCopyable(T) std::is_trivially_copyable<typename std::remove_volatile<T>::type>::value
 #elif __GNUC__
 #define IsTriviallyCopyable(T) std::has_trivial_copy_constructor<T>::value
 #elif _MSC_VER >= 1800


### PR DESCRIPTION
Between C++11 and C++14, volatile types stopped being trivially
copyable.  The serializer has no reason to care about this distinction,
so tack on remove_volatile.
