### PR TITLE
D3DBackend: Don't recompute ID3D11InputLayout for different shaders.

### DIFF
--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -16,12 +16,11 @@ class D3DVertexFormat : public NativeVertexFormat
 	D3D11_INPUT_ELEMENT_DESC m_elems[32];
 	UINT m_num_elems;
 
-	DX11::D3DBlob* m_vs_bytecode;
 	ID3D11InputLayout* m_layout;
 
 public:
-	D3DVertexFormat() : m_num_elems(0), m_vs_bytecode(nullptr), m_layout(nullptr) {}
-	~D3DVertexFormat() { SAFE_RELEASE(m_vs_bytecode); SAFE_RELEASE(m_layout); }
+	D3DVertexFormat() : m_num_elems(0), m_layout(nullptr) {}
+	~D3DVertexFormat() { SAFE_RELEASE(m_layout); }
 
 	void Initialize(const PortableVertexDeclaration &_vtx_decl);
 	void SetupVertexPointers();
@@ -127,15 +126,14 @@ void D3DVertexFormat::Initialize(const PortableVertexDeclaration &_vtx_decl)
 
 void D3DVertexFormat::SetupVertexPointers()
 {
-	if (m_vs_bytecode != DX11::VertexShaderCache::GetActiveShaderBytecode())
+	if (!m_layout)
 	{
-		SAFE_RELEASE(m_vs_bytecode);
-		SAFE_RELEASE(m_layout);
+		// CreateInputLayout requires a shader input, but it only looks at the
+		// signature of the shader, so we don't need to recompute it if the shader
+		// changes.
+		D3DBlob* vs_bytecode = DX11::VertexShaderCache::GetActiveShaderBytecode();
 
-		m_vs_bytecode = DX11::VertexShaderCache::GetActiveShaderBytecode();
-		m_vs_bytecode->AddRef();
-
-		HRESULT hr = DX11::D3D::device->CreateInputLayout(m_elems, m_num_elems, m_vs_bytecode->Data(), m_vs_bytecode->Size(), &m_layout);
+		HRESULT hr = DX11::D3D::device->CreateInputLayout(m_elems, m_num_elems, vs_bytecode->Data(), vs_bytecode->Size(), &m_layout);
 		if (FAILED(hr)) PanicAlert("Failed to create input layout, %s %d\n", __FILE__, __LINE__);
 		DX11::D3D::SetDebugObjectName((ID3D11DeviceChild*)m_layout, "input layout used to emulate the GX pipeline");
 	}


### PR DESCRIPTION
Rebuilding the layout isn't free, so cache it instead.  My measurements show approximately a 5% performance improvement on a fifoplayer testcase on an Intel HD4000.

I'm not very familiar with the D3D backend, so I'm not sure if this fix is correct, or if there's a better approach.
