### PR TITLE
Fixes Wiimotes for libogc.

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -557,6 +557,9 @@ void EnqRequest(u32 _Address)
 }
 
 // Called when IOS module has some reply
+// NOTE: Only call this if you have correctly handled
+//       CommandAddress+0 and CommandAddress+8.
+//       Please search for examples of this being called elsewhere.
 void EnqReply(u32 _Address, int cycles_in_future)
 {
 	CoreTiming::ScheduleEvent(cycles_in_future, enque_reply, _Address);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -995,7 +995,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			// executed. We write 8 which is not any valid command, and what IOS does
 			Memory::Write_U32(8, _CommandAddress);
 			// IOS seems to write back the command that was responded to
-			Memory::Write_U32(7, _CommandAddress + 8);
+			Memory::Write_U32(/*COMMAND_IOCTLV*/ 7, _CommandAddress + 8);
 
 			// Generate a reply to the IPC command
 			WII_IPC_HLE_Interface::EnqReply(_CommandAddress, 0);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -12,6 +12,17 @@
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h"
 
+void CWII_IPC_HLE_Device_sdio_slot0::EnqueueReply(u32 CommandAddress, u32 ReturnValue)
+{
+	// IOS seems to write back the command that was responded to, this class does not
+	// overwrite the command so it is safe to read.
+	Memory::Write_U32(Memory::Read_U32(CommandAddress), CommandAddress + 8);
+	Memory::Write_U32(8, CommandAddress);
+
+	Memory::Write_U32(ReturnValue, CommandAddress + 4);
+
+	WII_IPC_HLE_Interface::EnqReply(CommandAddress);
+}
 
 CWII_IPC_HLE_Device_sdio_slot0::CWII_IPC_HLE_Device_sdio_slot0(u32 _DeviceID, const std::string& _rDeviceName)
 	: IWII_IPC_HLE_Device(_DeviceID, _rDeviceName)
@@ -39,8 +50,7 @@ void CWII_IPC_HLE_Device_sdio_slot0::EventNotify()
 	if ((SConfig::GetInstance().m_WiiSDCard && m_event.type == EVENT_INSERT) ||
 		(!SConfig::GetInstance().m_WiiSDCard && m_event.type == EVENT_REMOVE))
 	{
-		Memory::Write_U32(m_event.type, m_event.addr + 4);
-		WII_IPC_HLE_Interface::EnqReply(m_event.addr);
+		EnqueueReply(m_event.addr, m_event.type);
 		m_event.addr = 0;
 		m_event.type = EVENT_NONE;
 	}
@@ -222,8 +232,7 @@ bool CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
 		// release returns 0
 		// unknown sd int
 		// technically we do it out of order, oh well
-		Memory::Write_U32(EVENT_INVALID, m_event.addr + 4);
-		WII_IPC_HLE_Interface::EnqReply(m_event.addr);
+		EnqueueReply(m_event.addr, EVENT_INVALID);
 		m_event.addr = 0;
 		m_event.type = EVENT_NONE;
 		Memory::Write_U32(0, _CommandAddress + 0x4);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
@@ -21,6 +21,7 @@ public:
 	bool IOCtl(u32 _CommandAddress) override;
 	bool IOCtlV(u32 _CommandAddress) override;
 
+	static void EnqueueReply(u32 CommandAddress, u32 ReturnValue);
 	void EventNotify();
 
 private:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
@@ -39,6 +39,8 @@ struct SQueuedEvent
 	}
 };
 
+using WII_IPC_HLE_Interface::ECommandType;
+
 // Important to remember that this class is for /dev/usb/oh1/57e/305 ONLY
 // /dev/usb/oh1 -> internal usb bus
 // 57e/305 -> VendorID/ProductID of device on usb bus
@@ -57,6 +59,8 @@ public:
 	virtual bool IOCtl(u32 _CommandAddress) override;
 
 	virtual u32 Update() override;
+
+	static void EnqueueReply(u32 CommandAddress);
 
 	// Send ACL data back to bt stack
 	void SendACLPacket(u16 _ConnectionHandle, u8* _pData, u32 _Size);

--- a/Source/Core/Core/IPC_HLE/WII_Socket.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.cpp
@@ -8,8 +8,6 @@
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 #include "Core/IPC_HLE/WII_Socket.h" // No Wii socket support while using NetPlay or TAS
 
-
-using WII_IPC_HLE_Interface::ECommandType;
 using WII_IPC_HLE_Interface::COMMAND_IOCTL;
 using WII_IPC_HLE_Interface::COMMAND_IOCTLV;
 
@@ -523,7 +521,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
 			DEBUG_LOG(WII_IPC_NET,
 			          "IOCTL(V) Sock: %08x ioctl/v: %d returned: %d nonBlock: %d forceNonBlock: %d",
 			          fd, it->is_ssl ? (int) it->ssl_type : (int) it->net_type, ReturnValue, nonBlock, forceNonBlock);
-			WiiSockMan::EnqueueReply(it->_CommandAddress, ReturnValue);
+			WiiSockMan::EnqueueReply(it->_CommandAddress, ReturnValue, ct);
 			it = pending_sockops.erase(it);
 		}
 		else
@@ -625,11 +623,11 @@ void WiiSockMan::Update()
 	}
 }
 
-void WiiSockMan::EnqueueReply(u32 CommandAddress, s32 ReturnValue)
+void WiiSockMan::EnqueueReply(u32 CommandAddress, s32 ReturnValue, ECommandType CommandType)
 {
-	Memory::Write_U32(8, CommandAddress);
 	// IOS seems to write back the command that was responded to
-	Memory::Write_U32(Memory::Read_U32(CommandAddress), CommandAddress + 8);
+	Memory::Write_U32(CommandType, CommandAddress + 8);
+	Memory::Write_U32(8, CommandAddress);
 
 	// Return value
 	Memory::Write_U32(ReturnValue, CommandAddress + 4);

--- a/Source/Core/Core/IPC_HLE/WII_Socket.h
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.h
@@ -192,6 +192,8 @@ public:
 
 };
 
+using WII_IPC_HLE_Interface::ECommandType;
+
 class WiiSockMan
 {
 public:
@@ -204,7 +206,7 @@ public:
 		return instance;            // Instantiated on first use.
 	}
 	void Update();
-	static void EnqueueReply(u32 CommandAddress, s32 ReturnValue);
+	static void EnqueueReply(u32 CommandAddress, s32 ReturnValue, ECommandType CommandType);
 	static void Convert(WiiSockAddrIn const & from, sockaddr_in& to);
 	static void Convert(sockaddr_in const & from, WiiSockAddrIn& to, s32 addrlen=-1);
 	// NON-BLOCKING FUNCTIONS
@@ -224,10 +226,11 @@ public:
 	{
 		if (WiiSockets.find(sock) == WiiSockets.end())
 		{
+			ECommandType ct = static_cast<ECommandType>(Memory::Read_U32(CommandAddress));
 			ERROR_LOG(WII_IPC_NET,
 				"DoSock: Error, fd not found (%08x, %08X, %08X)",
 				sock, CommandAddress, type);
-			EnqueueReply(CommandAddress, -SO_EBADF);
+			EnqueueReply(CommandAddress, -SO_EBADF, ct);
 		}
 		else
 		{


### PR DESCRIPTION
Caused by USB not writing back expected values.
Fixes Issue 7109
