### PR TITLE
Add initial support for GLSL ES 3.10.

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -42,7 +42,7 @@ void SHADER::SetProgramVariables()
 	Bind();
 
 	// Bind UBO
-	if (!g_ActiveConfig.backend_info.bSupportShadingLanguage420pack)
+	if (!g_ActiveConfig.backend_info.bSupportsBindingLayout)
 	{
 		GLint PSBlock_id = glGetUniformBlockIndex(glprogid, "PSBlock");
 		GLint VSBlock_id = glGetUniformBlockIndex(glprogid, "VSBlock");
@@ -448,14 +448,14 @@ void ProgramShaderCache::Shutdown(void)
 
 void ProgramShaderCache::CreateHeader ( void )
 {
-	GLSL_VERSION v = g_ogl_config.eSupportedGLSLVersion;
+	u32 v = g_ogl_config.SupportedGLSLVersion;
 	snprintf(s_glsl_header, sizeof(s_glsl_header),
 		"%s\n"
 		"%s\n" // ubo
 		"%s\n" // early-z
 		"%s\n" // 420pack
 
-		// Precision defines for GLSLES3
+		// Precision defines for GLSL ES
 		"%s\n"
 		"%s\n"
 
@@ -478,13 +478,13 @@ void ProgramShaderCache::CreateHeader ( void )
 		"%s\n" // replace textureSize as constant
 		"%s\n" // wipe out all centroid usages
 
-		, v==GLSLES3 ? "#version 300 es" : v==GLSL_130 ? "#version 130" : v==GLSL_140 ? "#version 140" : "#version 150"
+		, (v & GLSLES_310) ? "#version 310 es" : (v & GLSLES_300) ? "#version 300 es" : v==GLSL_130 ? "#version 130" : v==GLSL_140 ? "#version 140" : "#version 150"
 		, v<GLSL_140 ? "#extension GL_ARB_uniform_buffer_object : enable" : ""
 		, g_ActiveConfig.backend_info.bSupportsEarlyZ ? "#extension GL_ARB_shader_image_load_store : enable" : ""
-		, g_ActiveConfig.backend_info.bSupportShadingLanguage420pack ? "#extension GL_ARB_shading_language_420pack : enable" : ""
+		, g_ogl_config.bSupportShadingLanguage420pack ? "#extension GL_ARB_shading_language_420pack : enable" : ""
 
-		, v==GLSLES3 ? "precision highp float;" : ""
-		, v==GLSLES3 ? "precision highp int;" : ""
+		, (v & GLSLES_300) ? "precision highp float;" : ""
+		, (v & GLSLES_300) ? "precision highp int;" : ""
 
 		, DriverDetails::HasBug(DriverDetails::BUG_BROKENTEXTURESIZE) ? "#define textureSize(x, y) ivec2(1, 1)" : ""
 		, DriverDetails::HasBug(DriverDetails::BUG_BROKENCENTROID) ? "#define centroid" : ""

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -9,10 +9,11 @@ namespace OGL
 void ClearEFBCache();
 
 enum GLSL_VERSION {
-	GLSL_130,
-	GLSL_140,
-	GLSL_150, // and above
-	GLSLES3
+	GLSL_130   = (1 << 0),
+	GLSL_140   = (1 << 1),
+	GLSL_150   = (1 << 2),  // and above
+	GLSLES_300 = (1 << 3),  // GLES 3.0
+	GLSLES_310 = (1 << 4), // GLES 3.1
 };
 
 // ogl-only config, so not in VideoConfig.h
@@ -24,9 +25,10 @@ extern struct VideoConfig {
 	bool bSupportsGLBufferStorage;
 	bool bSupportCoverageMSAA;
 	bool bSupportSampleShading;
-	GLSL_VERSION eSupportedGLSLVersion;
+	u32  SupportedGLSLVersion;
 	bool bSupportOGL31;
 	bool bSupportViewportFloat;
+	bool bSupportShadingLanguage420pack;
 
 	const char* gl_vendor;
 	const char* gl_renderer;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -223,7 +223,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	out.Write("\n");
 
 	if (ApiType == API_OPENGL)
-		out.Write("layout(std140%s) uniform PSBlock {\n", g_ActiveConfig.backend_info.bSupportShadingLanguage420pack ? ", binding = 1" : "");
+		out.Write("layout(std140%s) uniform PSBlock {\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? ", binding = 1" : "");
 
 	DeclareUniform(out, ApiType, C_COLORS, "int4", I_COLORS"[4]");
 	DeclareUniform(out, ApiType, C_KCOLORS, "int4", I_KCOLORS"[4]");

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -83,7 +83,7 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 
 	// uniforms
 	if (api_type == API_OPENGL)
-		out.Write("layout(std140%s) uniform VSBlock {\n", g_ActiveConfig.backend_info.bSupportShadingLanguage420pack ? ", binding = 2" : "");
+		out.Write("layout(std140%s) uniform VSBlock {\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? ", binding = 2" : "");
 
 	DeclareUniform(out, api_type, C_POSNORMALMATRIX, "float4", I_POSNORMALMATRIX"[6]");
 	DeclareUniform(out, api_type, C_PROJECTION, "float4", I_PROJECTION"[4]");

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -152,7 +152,7 @@ struct VideoConfig final
 		bool bSupportsSeparateAlphaFunction;
 		bool bSupportsOversizedViewports;
 		bool bSupportsEarlyZ; // needed by PixelShaderGen, so must stay in VideoCommon
-		bool bSupportShadingLanguage420pack; // needed by ShaderGen, so must stay in VideoCommon
+		bool bSupportsBindingLayout; // Needed by ShaderGen, so must stay in VideoCommon
 	} backend_info;
 
 	// Utility


### PR DESCRIPTION
GLSL ES 3.10 adds implicit support for the binding layout qualifier that we use.
Changes our GLSL version enums to bit values so we can check for both ES versions easily.
