### PR TITLE
VideoBackend: remove unused config vars.

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -421,7 +421,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	// Scaled copy, PL, Bilinear filter, 3D Vision
 	szr_enh->Add(CreateCheckBox(page_enh, _("Scaled EFB Copy"), wxGetTranslation(scaled_efb_copy_desc), vconfig.bCopyEFBScaled));
-	szr_enh->Add(pixel_lighting = CreateCheckBox(page_enh, _("Per-Pixel Lighting"), wxGetTranslation(pixel_lighting_desc), vconfig.bEnablePixelLighting));
+	szr_enh->Add(CreateCheckBox(page_enh, _("Per-Pixel Lighting"), wxGetTranslation(pixel_lighting_desc), vconfig.bEnablePixelLighting));
 	szr_enh->Add(CreateCheckBox(page_enh, _("Force Texture Filtering"), wxGetTranslation(force_filtering_desc), vconfig.bForceFiltering));
 
 	szr_enh->Add(CreateCheckBox(page_enh, _("Widescreen Hack"), wxGetTranslation(ws_hack_desc), vconfig.bWidescreenHack));
@@ -453,9 +453,6 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	// - EFB hacks
 	wxStaticBoxSizer* const szr_efb = new wxStaticBoxSizer(wxVERTICAL, page_hacks, _("Embedded Frame Buffer"));
 
-	// format change emulation
-	emulate_efb_format_changes = CreateCheckBox(page_hacks, _("Ignore Format Changes"), wxGetTranslation(efb_emulate_format_changes_desc), vconfig.bEFBEmulateFormatChanges, true);
-
 	// EFB copies
 	wxStaticBoxSizer* const group_efbcopy = new wxStaticBoxSizer(wxHORIZONTAL, page_hacks, _("EFB Copies"));
 
@@ -471,7 +468,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	group_efbcopy->Add(cache_efb_copies, 0, wxRIGHT, 5);
 
 	szr_efb->Add(CreateCheckBox(page_hacks, _("Skip EFB Access from CPU"), wxGetTranslation(efb_access_desc), vconfig.bEFBAccessEnable, true), 0, wxBOTTOM | wxLEFT, 5);
-	szr_efb->Add(emulate_efb_format_changes, 0, wxBOTTOM | wxLEFT, 5);
+	szr_efb->Add(CreateCheckBox(page_hacks, _("Ignore Format Changes"), wxGetTranslation(efb_emulate_format_changes_desc), vconfig.bEFBEmulateFormatChanges, true), 0, wxBOTTOM | wxLEFT, 5);
 	szr_efb->Add(group_efbcopy, 0, wxEXPAND | wxALL, 5);
 	szr_hacks->Add(szr_efb, 0, wxEXPAND | wxALL, 5);
 

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -154,9 +154,6 @@ protected:
 		choice_aamode->Enable(vconfig.backend_info.AAModes.size() > 1);
 		text_aamode->Enable(vconfig.backend_info.AAModes.size() > 1);
 
-		// pixel lighting
-		pixel_lighting->Enable(vconfig.backend_info.bSupportsPixelLighting);
-
 		// 3D vision
 		_3d_vision->Enable(vconfig.backend_info.bSupports3DVision);
 		_3d_vision->Show(vconfig.backend_info.bSupports3DVision);
@@ -165,9 +162,6 @@ protected:
 		efbcopy_texture->Enable(vconfig.bEFBCopyEnable);
 		efbcopy_ram->Enable(vconfig.bEFBCopyEnable);
 		cache_efb_copies->Enable(vconfig.bEFBCopyEnable && !vconfig.bCopyEFBToTexture);
-
-		// EFB format change emulation
-		emulate_efb_format_changes->Enable(vconfig.backend_info.bSupportsFormatReinterpretation);
 
 		// XFB
 		virtual_xfb->Enable(vconfig.bUseXFB);
@@ -193,14 +187,11 @@ protected:
 	wxStaticText* text_aamode;
 	SettingChoice* choice_aamode;
 
-	SettingCheckBox* pixel_lighting;
-
 	SettingCheckBox* _3d_vision;
 
 	SettingRadioButton* efbcopy_texture;
 	SettingRadioButton* efbcopy_ram;
 	SettingCheckBox* cache_efb_copies;
-	SettingCheckBox* emulate_efb_format_changes;
 
 	SettingRadioButton* virtual_xfb;
 	SettingRadioButton* real_xfb;

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -86,8 +86,6 @@ void InitBackendInfo()
 	g_Config.backend_info.bUseMinimalMipCount = true;
 	g_Config.backend_info.bSupports3DVision = false;
 	g_Config.backend_info.bSupportsDualSourceBlend = true;
-	g_Config.backend_info.bSupportsFormatReinterpretation = true;
-	g_Config.backend_info.bSupportsPixelLighting = true;
 	g_Config.backend_info.bSupportsPrimitiveRestart = true;
 	g_Config.backend_info.bSupportsOversizedViewports = false;
 

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -147,8 +147,6 @@ void InitBackendInfo()
 	g_Config.backend_info.bUseMinimalMipCount = false;
 	g_Config.backend_info.bSupports3DVision = false;
 	//g_Config.backend_info.bSupportsDualSourceBlend = true; // is gpu dependent and must be set in renderer
-	g_Config.backend_info.bSupportsFormatReinterpretation = true;
-	g_Config.backend_info.bSupportsPixelLighting = true;
 	//g_Config.backend_info.bSupportsEarlyZ = true; // is gpu dependent and must be set in renderer
 	g_Config.backend_info.bSupportsOversizedViewports = true;
 

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -153,8 +153,7 @@ void OnPixelFormatChange()
 	 * Since we are always using an RGBA8 buffer though, this causes issues in some games.
 	 * Thus, we reinterpret the old EFB data with the new format here.
 	 */
-	if (!g_ActiveConfig.bEFBEmulateFormatChanges ||
-		!g_ActiveConfig.backend_info.bSupportsFormatReinterpretation)
+	if (!g_ActiveConfig.bEFBEmulateFormatChanges)
 		return;
 
 	auto old_format = Renderer::GetPrevPixelFormat();

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -263,7 +263,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 			out.Write("centroid in float3 uv%d_2;\n", i);
 		}
 		out.Write("centroid in float4 clipPos_2;\n");
-		if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)
+		if (g_ActiveConfig.bEnablePixelLighting)
 		{
 			out.Write("centroid in float4 Normal_2;\n");
 		}
@@ -313,7 +313,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 		for (unsigned int i = 0; i < numTexgen; ++i)
 			out.Write(",\n  in %s float3 uv%d : TEXCOORD%d", optCentroid, i, i);
 		out.Write(",\n  in %s float4 clipPos : TEXCOORD%d", optCentroid, numTexgen);
-		if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)
+		if (g_ActiveConfig.bEnablePixelLighting)
 			out.Write(",\n  in %s float4 Normal : TEXCOORD%d", optCentroid, numTexgen + 1);
 		out.Write("        ) {\n");
 	}
@@ -343,13 +343,13 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 			}
 		}
 		out.Write("\tfloat4 clipPos = clipPos_2;\n");
-		if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)
+		if (g_ActiveConfig.bEnablePixelLighting)
 		{
 			out.Write("\tfloat4 Normal = Normal_2;\n");
 		}
 	}
 
-	if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)
+	if (g_ActiveConfig.bEnablePixelLighting)
 	{
 		out.Write("\tfloat3 _norm0 = normalize(Normal.xyz);\n\n");
 		out.Write("\tfloat3 pos = float3(clipPos.x,clipPos.y,Normal.w);\n");
@@ -439,7 +439,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 		WriteStage<T>(out, uid_data, i, ApiType, swapModeTable); // build the equation for this stage
 
 #define MY_STRUCT_OFFSET(str,elem) ((u32)((u64)&(str).elem-(u64)&(str)))
-	bool enable_pl = g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting;
+	bool enable_pl = g_ActiveConfig.bEnablePixelLighting;
 	uid_data.num_values = (enable_pl) ? sizeof(uid_data) : MY_STRUCT_OFFSET(uid_data,stagehash[numStages]);
 
 

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -100,7 +100,7 @@ void PixelShaderManager::SetConstants()
 		s_bFogRangeAdjustChanged = false;
 	}
 
-	if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)  // config check added because the code in here was crashing for me inside SetPSConstant4f
+	if (g_ActiveConfig.bEnablePixelLighting)  // config check added because the code in here was crashing for me inside SetPSConstant4f
 	{
 		if (nLightsChanged[0] >= 0)
 		{
@@ -320,7 +320,7 @@ void PixelShaderManager::InvalidateXFRange(int start, int end)
 
 void PixelShaderManager::SetMaterialColorChanged(int index, u32 color)
 {
-	if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)
+	if (g_ActiveConfig.bEnablePixelLighting)
 	{
 		constants.pmaterials[index][0] = (color >> 24) & 0xFF;
 		constants.pmaterials[index][1] = (color >> 16) & 0xFF;

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -49,7 +49,7 @@ static inline void GenerateVSOutputStruct(T& object, API_TYPE api_type)
 
 	DefineVSOutputStructMember(object, api_type, "float4", "clipPos", -1, "TEXCOORD", xfregs.numTexGen.numTexGens);
 
-	if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)
+	if (g_ActiveConfig.bEnablePixelLighting)
 		DefineVSOutputStructMember(object, api_type, "float4", "Normal", -1, "TEXCOORD", xfregs.numTexGen.numTexGens + 1);
 
 	object.Write("};\n");
@@ -103,7 +103,7 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 
 	uid_data.numTexGens = xfregs.numTexGen.numTexGens;
 	uid_data.components = components;
-	uid_data.pixel_lighting = (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting);
+	uid_data.pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
 
 	if (api_type == API_OPENGL)
 	{
@@ -138,7 +138,7 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 			}
 		}
 		out.Write("centroid out   float4 clipPos_2;\n");
-		if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)
+		if (g_ActiveConfig.bEnablePixelLighting)
 			out.Write("centroid out   float4 Normal_2;\n");
 
 		out.Write("centroid out   float4 colors_02;\n");
@@ -385,7 +385,7 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 	// clipPos/w needs to be done in pixel shader, not here
 	out.Write("o.clipPos = float4(pos.x,pos.y,o.pos.z,o.pos.w);\n");
 
-	if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)
+	if (g_ActiveConfig.bEnablePixelLighting)
 	{
 		out.Write("o.Normal = float4(_norm0.x,_norm0.y,_norm0.z,pos.z);\n");
 
@@ -429,7 +429,7 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 		for (unsigned int i = 0; i < xfregs.numTexGen.numTexGens; ++i)
 			out.Write(" uv%d_2.xyz =  o.tex%d;\n", i, i);
 		out.Write("  clipPos_2 = o.clipPos;\n");
-		if (g_ActiveConfig.bEnablePixelLighting && g_ActiveConfig.backend_info.bSupportsPixelLighting)
+		if (g_ActiveConfig.bEnablePixelLighting)
 			out.Write("  Normal_2 = o.Normal;\n");
 
 		out.Write("colors_02 = o.colors_0;\n");

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -212,8 +212,6 @@ void VideoConfig::VerifyValidity()
 	if (iAdapter < 0 || iAdapter > ((int)backend_info.Adapters.size() - 1)) iAdapter = 0;
 	if (iMultisampleMode < 0 || iMultisampleMode >= (int)backend_info.AAModes.size()) iMultisampleMode = 0;
 	if (!backend_info.bSupports3DVision) b3DVision = false;
-	if (!backend_info.bSupportsFormatReinterpretation) bEFBEmulateFormatChanges = false;
-	if (!backend_info.bSupportsPixelLighting) bEnablePixelLighting = false;
 }
 
 void VideoConfig::Save(const std::string& ini_file)

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -146,10 +146,7 @@ struct VideoConfig final
 		bool bUseMinimalMipCount;
 		bool bSupports3DVision;
 		bool bSupportsDualSourceBlend;
-		bool bSupportsFormatReinterpretation;
-		bool bSupportsPixelLighting;
 		bool bSupportsPrimitiveRestart;
-		bool bSupportsSeparateAlphaFunction;
 		bool bSupportsOversizedViewports;
 		bool bSupportsEarlyZ; // needed by PixelShaderGen, so must stay in VideoCommon
 		bool bSupportsBindingLayout; // Needed by ShaderGen, so must stay in VideoCommon


### PR DESCRIPTION
No point to keeping around variables which are always "true".
