### PR TITLE
Fix compilation error of Wayland_Util.h

### DIFF
--- a/Source/Core/DolphinWX/GLInterface/Wayland_Util.h
+++ b/Source/Core/DolphinWX/GLInterface/Wayland_Util.h
@@ -27,5 +27,3 @@ public:
 	void ToggleFullscreen(bool fullscreen);
 	void SwapBuffers();
 };
-
-#endif


### PR DESCRIPTION
Remove unneeded #endif to fix the following error: #endif without #if
This compilation error occurs when Wayland support is enabled.
