### PR TITLE
Add initial support for GLSL ES 3.10.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -459,7 +459,10 @@ Renderer::Renderer()
 	g_Config.backend_info.bSupportsPrimitiveRestart = !DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVERESTART) &&
 				((GLExtensions::Version() >= 310) || GLExtensions::Supports("GL_NV_primitive_restart"));
 	g_Config.backend_info.bSupportsEarlyZ = GLExtensions::Supports("GL_ARB_shader_image_load_store");
-	g_Config.backend_info.bSupportShadingLanguage420pack = GLExtensions::Supports("GL_ARB_shading_language_420pack");
+
+	// Desktop OpenGL supports the binding layout if it supports 420pack
+	// OpenGL ES 3.1 supports it implicitly without an extension
+	g_Config.backend_info.bSupportsBindingLayout = GLExtensions::Supports("GL_ARB_shading_language_420pack");
 
 	g_ogl_config.bSupportsGLSLCache = GLExtensions::Supports("GL_ARB_get_program_binary");
 	g_ogl_config.bSupportsGLPinnedMemory = GLExtensions::Supports("GL_AMD_pinned_memory");
@@ -472,7 +475,17 @@ Renderer::Renderer()
 	g_ogl_config.bSupportViewportFloat = GLExtensions::Supports("GL_ARB_viewport_array");
 
 	if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGLES3)
-		g_ogl_config.eSupportedGLSLVersion = GLSLES3;
+	{
+		if (strstr(g_ogl_config.glsl_version, "3.00"))
+		{
+			g_ogl_config.eSupportedGLSLVersion = GLSLES_300;
+		}
+		else
+		{
+			g_ogl_config.eSupportedGLSLVersion = GLSLES_310;
+			g_Config.backend_info.bSupportsBindingLayout = true;
+		}
+	}
 	else
 	{
 		if (strstr(g_ogl_config.glsl_version, "1.00") || strstr(g_ogl_config.glsl_version, "1.10") || strstr(g_ogl_config.glsl_version, "1.20"))

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -11,8 +11,9 @@ void ClearEFBCache();
 enum GLSL_VERSION {
 	GLSL_130,
 	GLSL_140,
-	GLSL_150, // and above
-	GLSLES3
+	GLSL_150,  // and above
+	GLSLES_300,  // GLES 3.0
+	GLSLES_310, // GLES 3.1
 };
 
 // ogl-only config, so not in VideoConfig.h

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -223,7 +223,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	out.Write("\n");
 
 	if (ApiType == API_OPENGL)
-		out.Write("layout(std140%s) uniform PSBlock {\n", g_ActiveConfig.backend_info.bSupportShadingLanguage420pack ? ", binding = 1" : "");
+		out.Write("layout(std140%s) uniform PSBlock {\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? ", binding = 1" : "");
 
 	DeclareUniform(out, ApiType, C_COLORS, "int4", I_COLORS"[4]");
 	DeclareUniform(out, ApiType, C_KCOLORS, "int4", I_KCOLORS"[4]");

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -83,7 +83,7 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 
 	// uniforms
 	if (api_type == API_OPENGL)
-		out.Write("layout(std140%s) uniform VSBlock {\n", g_ActiveConfig.backend_info.bSupportShadingLanguage420pack ? ", binding = 2" : "");
+		out.Write("layout(std140%s) uniform VSBlock {\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? ", binding = 2" : "");
 
 	DeclareUniform(out, api_type, C_POSNORMALMATRIX, "float4", I_POSNORMALMATRIX"[6]");
 	DeclareUniform(out, api_type, C_PROJECTION, "float4", I_PROJECTION"[4]");

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -152,7 +152,7 @@ struct VideoConfig final
 		bool bSupportsSeparateAlphaFunction;
 		bool bSupportsOversizedViewports;
 		bool bSupportsEarlyZ; // needed by PixelShaderGen, so must stay in VideoCommon
-		bool bSupportShadingLanguage420pack; // needed by ShaderGen, so must stay in VideoCommon
+		bool bSupportsBindingLayout; // Needed by ShaderGen, so must stay in VideoCommon
 	} backend_info;
 
 	// Utility


### PR DESCRIPTION
GLSL ES 3.10 adds implicit support for the binding layout qualifier that we use.
Changes our GLSL version enums to bit values so we can check for both ES versions easily.
