### PR TITLE
MemcardManager: Fix "export all saves"

### DIFF
--- a/Source/Core/Core/HW/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard.cpp
@@ -904,17 +904,26 @@ u32 GCMemcard::ExportGci(u8 index, const std::string& fileName, const std::strin
 	File::IOFile gci;
 	int offset = GCI;
 
-	gci.Open(fileName, "wb");
-
-	std::string fileType;
-	SplitPath(fileName, nullptr, nullptr, &fileType);
-	if (!strcasecmp(fileType.c_str(), ".gcs"))
+	if (!fileName.length())
 	{
-		offset = GCS;
+		std::string gciFilename;
+		// GCI_FileName should only fail if the gamecode is 0xFFFFFFFF
+		if (!GCI_FileName(index, gciFilename)) return SUCCESS;
+		gci.Open(directory + DIR_SEP + gciFilename, "wb");
 	}
-	else if (!strcasecmp(fileType.c_str(), ".sav"))
+	else
 	{
-		offset = SAV;
+		std::string fileType;
+		gci.Open(fileName, "wb");
+		SplitPath(fileName, nullptr, nullptr, &fileType);
+		if (!strcasecmp(fileType.c_str(), ".gcs"))
+		{
+			offset = GCS;
+		}
+		else if (!strcasecmp(fileType.c_str(), ".sav"))
+		{
+			offset = SAV;
+		}
 	}
 
 	if (!gci)

--- a/Source/Core/DolphinWX/MemcardManager.cpp
+++ b/Source/Core/DolphinWX/MemcardManager.cpp
@@ -605,7 +605,7 @@ void CMemcardManager::CopyDeleteClick(wxCommandEvent& event)
 		                "%s\nand have the same name as a file on your memcard\nContinue?", path1.c_str()))
 		for (int i = 0; i < DIRLEN; i++)
 		{
-			CopyDeleteSwitch(memoryCard[slot]->ExportGci(i, nullptr, path1), -1);
+			CopyDeleteSwitch(memoryCard[slot]->ExportGci(i, "", path1), -1);
 		}
 		break;
 	}


### PR DESCRIPTION
The export all saves feature was broken by revision a82675b7d581421fa80d5d5c53253cf1d5c1a26d
This commit fixes the feature
