### PR TITLE
Add the option to use a folder of gamecube saves instead of a memcard image [issue 6599]

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -97,9 +97,10 @@ set(SRCS	ActionReplay.cpp
 			HW/EXI_DeviceGecko.cpp
 			HW/EXI_DeviceIPL.cpp
 			HW/EXI_DeviceMemoryCard.cpp
-			HW/EXI_DeviceMemoryCardRaw.cpp
 			HW/EXI_DeviceMic.cpp
 			HW/GCMemcard.cpp
+			HW/GCMemcardDirectory.cpp
+			HW/GCMemcardRaw.cpp
 			HW/GCPad.cpp
 			HW/GCPadEmu.cpp
 			HW/GPFifo.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -135,9 +135,10 @@
     <ClCompile Include="HW\EXI_DeviceGecko.cpp" />
     <ClCompile Include="HW\EXI_DeviceIPL.cpp" />
     <ClCompile Include="HW\EXI_DeviceMemoryCard.cpp" />
-    <ClCompile Include="HW\EXI_DeviceMemoryCardRaw.cpp" />
     <ClCompile Include="HW\EXI_DeviceMic.cpp" />
     <ClCompile Include="HW\GCMemcard.cpp" />
+    <ClCompile Include="HW\GCMemcardDirectory.cpp" />
+    <ClCompile Include="HW\GCMemcardRaw.cpp" />
     <ClCompile Include="HW\GCPad.cpp" />
     <ClCompile Include="HW\GCPadEmu.cpp" />
     <ClCompile Include="HW\GPFifo.cpp" />
@@ -332,9 +333,10 @@
     <ClInclude Include="HW\EXI_DeviceGecko.h" />
     <ClInclude Include="HW\EXI_DeviceIPL.h" />
     <ClInclude Include="HW\EXI_DeviceMemoryCard.h" />
-    <ClInclude Include="HW\EXI_DeviceMemoryCardRaw.h" />
     <ClInclude Include="HW\EXI_DeviceMic.h" />
     <ClInclude Include="HW\GCMemcard.h" />
+    <ClInclude Include="HW\GCMemcardDirectory.h" />
+    <ClInclude Include="HW\GCMemcardRaw.h" />
     <ClInclude Include="HW\GCPad.h" />
     <ClInclude Include="HW\GCPadEmu.h" />
     <ClInclude Include="HW\GPFifo.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -410,6 +410,12 @@
     <ClCompile Include="HW\GCMemcard.cpp">
       <Filter>HW %28Flipper/Hollywood%29\GCMemcard</Filter>
     </ClCompile>
+    <ClCompile Include="HW\GCMemcardDirectory.cpp">
+      <Filter>HW %28Flipper/Hollywood%29\GCMemcard</Filter>
+    </ClCompile>
+    <ClCompile Include="HW\GCMemcardRaw.cpp">
+      <Filter>HW %28Flipper/Hollywood%29\GCMemcard</Filter>
+    </ClCompile>
     <ClCompile Include="HW\GCPad.cpp">
       <Filter>HW %28Flipper/Hollywood%29\GCPad</Filter>
     </ClCompile>
@@ -702,9 +708,6 @@
     <ClCompile Include="PowerPC\JitILCommon\IR.cpp">
       <Filter>PowerPC\JitILCommon</Filter>
     </ClCompile>
-    <ClCompile Include="HW\EXI_DeviceMemoryCardRaw.cpp">
-      <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BootManager.h" />
@@ -934,6 +937,12 @@
       <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface</Filter>
     </ClInclude>
     <ClInclude Include="HW\GCMemcard.h">
+      <Filter>HW %28Flipper/Hollywood%29\GCMemcard</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\GCMemcardDirectory.h">
+      <Filter>HW %28Flipper/Hollywood%29\GCMemcard</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\GCMemcardRaw.h">
       <Filter>HW %28Flipper/Hollywood%29\GCMemcard</Filter>
     </ClInclude>
     <ClInclude Include="HW\GCPadEmu.h">
@@ -1209,9 +1218,6 @@
     </ClInclude>
     <ClInclude Include="PowerPC\JitILCommon\IR.h">
       <Filter>PowerPC\JitILCommon</Filter>
-    </ClInclude>
-    <ClInclude Include="HW\EXI_DeviceMemoryCardRaw.h">
-      <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/Core/HW/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI_Device.cpp
@@ -99,9 +99,13 @@ IEXIDevice* EXIDevice_Create(TEXIDevices device_type, const int channel_num)
 		break;
 
 	case EXIDEVICE_MEMORYCARD:
-		result = new CEXIMemoryCard(channel_num);
+	case EXIDEVICE_MEMORYCARDFOLDER:
+	{
+		bool gci_folder = (device_type == EXIDEVICE_MEMORYCARDFOLDER);
+		result = new CEXIMemoryCard(channel_num, gci_folder);
+		device_type = EXIDEVICE_MEMORYCARD;
 		break;
-
+	}
 	case EXIDEVICE_MASKROM:
 		result = new CEXIIPL();
 		break;

--- a/Source/Core/Core/HW/EXI_Device.h
+++ b/Source/Core/Core/HW/EXI_Device.h
@@ -17,6 +17,8 @@ enum TEXIDevices
 	EXIDEVICE_ETH,
 	EXIDEVICE_AM_BASEBOARD,
 	EXIDEVICE_GECKO,
+	EXIDEVICE_MEMORYCARDFOLDER, // Only used when creating a device by EXIDevice_Create
+	                            // Converted to EXIDEVICE_MEMORYCARD internally
 	EXIDEVICE_NONE = (u8)-1
 };
 

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
@@ -3,11 +3,13 @@
 // Refer to the license.txt file included.
 
 #pragma once
+#include "Common/StdMakeUnique.h"
+
 class MemoryCardBase;
 class CEXIMemoryCard : public IEXIDevice
 {
 public:
-	CEXIMemoryCard(const int index);
+	CEXIMemoryCard(const int index, bool gciFolder);
 	virtual ~CEXIMemoryCard();
 	void SetCS(int cs) override;
 	bool IsInterruptSet() override;
@@ -15,8 +17,12 @@ public:
 	void DoState(PointerWrap &p) override;
 	void PauseAndLock(bool doLock, bool unpauseOnUnlock=true) override;
 	IEXIDevice* FindDevice(TEXIDevices device_type, int customIndex=-1) override;
+	void DMARead(u32 _uAddr, u32 _uSize) override;
+	void DMAWrite(u32 _uAddr, u32 _uSize) override;
 
 private:
+	void setupGciFolder(u16 sizeMb);
+	void setupRawMemcard(u16 sizeMb);
 	// This is scheduled whenever a page write is issued. The this pointer is passed
 	// through the userdata parameter, so that it can then call Flush on the right card.
 	static void FlushCallback(u64 userdata, int cyclesLate);
@@ -68,7 +74,7 @@ private:
 	unsigned int card_id;
 	unsigned int address;
 	u32 memory_card_size;
-	MemoryCardBase * memorycard;
+	std::unique_ptr<MemoryCardBase> memorycard;
 
 protected:
 	virtual void TransferByte(u8 &byte) override;

--- a/Source/Core/Core/HW/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard.h
@@ -17,6 +17,7 @@
 #define BE32(x) (Common::swap32(x))
 #define BE16(x) (Common::swap16(x))
 #define ArrayByteSwap(a) (ByteSwap(a, a+sizeof(u8)));
+
 enum
 {
 	SLOT_A = 0,
@@ -58,132 +59,263 @@ enum
 	CI8,
 };
 
+class MemoryCardBase
+{
+public:
+	MemoryCardBase(int _card_index = 0, int sizeMb = MemCard2043Mb)
+		: card_index(_card_index)
+		, nintendo_card_id(sizeMb)
+	{
+	}
+	virtual ~MemoryCardBase() {}
+	virtual void Flush(bool exiting = false) = 0;
+	virtual s32 Read(u32 address, s32 length, u8 *destaddress) = 0;
+	virtual s32 Write(u32 destaddress, s32 length, u8 *srcaddress) = 0;
+	virtual void ClearBlock(u32 address) = 0;
+	virtual void ClearAll() = 0;
+	virtual void DoState(PointerWrap &p) = 0;
+	virtual void joinThread() {};
+	u32 GetCardId() { return nintendo_card_id; }
+
+protected:
+	int card_index;
+	u16 nintendo_card_id;
+	u32 memory_card_size;
+};
+
+struct GCMBlock
+{
+	GCMBlock() { erase(); }
+	void erase() { memset(block, 0xFF, BLOCK_SIZE); }
+	u8 block[BLOCK_SIZE];
+};
+
+void calc_checksumsBE(u16 *buf, u32 length, u16 *csum, u16 *inv_csum);
+
+#pragma pack(push,1)
+struct Header {         //Offset    Size    Description
+	// Serial in libogc
+	u8 serial[12];      //0x0000    12      ?
+	u64 formatTime;     //0x000c    8       Time of format (OSTime value)
+	u32 SramBias;       //0x0014    4       SRAM bias at time of format
+	u32 SramLang;       //0x0018    4       SRAM language
+	u8 Unk2[4];         //0x001c    4       ? almost always 0
+	// end Serial in libogc
+	u8 deviceID[2];     //0x0020    2       0 if formated in slot A 1 if formated in slot B
+	u8 SizeMb[2];       //0x0022    2       Size of memcard in Mbits
+	u16 Encoding;       //0x0024    2       Encoding (ASCII or japanese)
+	u8 Unused1[468];    //0x0026    468     Unused (0xff)
+	u16 UpdateCounter;  //0x01fa    2       Update Counter (?, probably unused)
+	u16 Checksum;       //0x01fc    2       Additive Checksum
+	u16 Checksum_Inv;   //0x01fe    2       Inverse Checksum
+	u8 Unused2[7680];   //0x0200    0x1e00  Unused (0xff)
+
+
+	void CARD_GetSerialNo(u32 *serial1, u32 *serial2) const
+	{
+		u32 _serial[8];
+
+		for (int i = 0; i < 8; i++)
+		{
+			memcpy(&_serial[i], (u8 *)this + (i * 4), 4);
+		}
+
+		*serial1 = _serial[0] ^ _serial[2] ^ _serial[4] ^ _serial[6];
+		*serial2 = _serial[1] ^ _serial[3] ^ _serial[5] ^ _serial[7];
+	}
+
+	// Nintendo format algorithm.
+	// Constants are fixed by the GC SDK
+	// Changing the constants will break memorycard support
+	Header(int slot = 0, u16 sizeMb = MemCard2043Mb, bool ascii = true)
+	{
+		memset(this, 0xFF, BLOCK_SIZE);
+		*(u16 *)SizeMb = BE16(sizeMb);
+		Encoding = BE16(ascii ? 0 : 1);
+		u64 rand = CEXIIPL::GetGCTime();
+		formatTime = Common::swap64(rand);
+		for (int i = 0; i < 12; i++)
+		{
+			rand = (((rand * (u64)0x0000000041c64e6dULL) + (u64)0x0000000000003039ULL) >> 16);
+			serial[i] = (u8)(g_SRAM.flash_id[slot][i] + (u32)rand);
+			rand = (((rand * (u64)0x0000000041c64e6dULL) + (u64)0x0000000000003039ULL) >> 16);
+			rand &= (u64)0x0000000000007fffULL;
+		}
+		SramBias = g_SRAM.counter_bias;
+		SramLang = BE32(g_SRAM.lang);
+		// TODO: determine the purpose of Unk2 1 works for slot A, 0 works for both slot A and slot B
+		*(u32 *)&Unk2 = 0; // = _viReg[55];  static vu16* const _viReg = (u16*)0xCC002000;
+		*(u16 *)&deviceID = 0;
+		calc_checksumsBE((u16 *)this, 0xFE, &Checksum, &Checksum_Inv);
+	}
+};
+
+struct DEntry
+{
+	static const u8 DENTRY_SIZE = 0x40;
+	DEntry() { memset(this, 0xFF, DENTRY_SIZE); }
+	std::string GCI_FileName() const
+	{
+		return std::string((char *)Makercode, 2) + '-' + std::string((char *)Gamecode, 4) + '-' + (char *)Filename +
+			   ".gci";
+	}
+	u8 Gamecode[4];     //0x00       0x04    Gamecode
+	u8 Makercode[2];    //0x04      0x02    Makercode
+	u8 Unused1;         //0x06      0x01    reserved/unused (always 0xff, has no effect)
+	u8 BIFlags;         //0x07      0x01    banner gfx format and icon animation (Image Key)
+	                    //      Bit(s)  Description
+	                    //      2       Icon Animation 0: forward 1: ping-pong
+	                    //      1       [--0: No Banner 1: Banner present--] WRONG! YAGCD LIES!
+	                    //      0       [--Banner Color 0: RGB5A3 1: CI8--]  WRONG! YAGCD LIES!
+	                    //      bits 0 and 1: image format
+	                    //      00 no banner
+	                    //      01 CI8 banner
+	                    //      10 RGB5A3 banner
+	                    //      11 ? maybe ==00? Time Splitters 2 and 3 have it and don't have banner
+	                    //
+	u8 Filename[DENTRY_STRLEN]; //0x08      0x20     Filename
+	u8 ModTime[4];      //0x28      0x04    Time of file's last modification in seconds since 12am, January 1st, 2000
+	u8 ImageOffset[4];  //0x2c      0x04    image data offset
+	u8 IconFmt[2];      //0x30      0x02    icon gfx format (2bits per icon)
+	                    //      Bits    Description
+	                    //      00      No icon
+	                    //      01      CI8 with a shared color palette after the last frame
+	                    //      10      RGB5A3
+	                    //      11      CI8 with a unique color palette after itself
+	                    //
+	u8 AnimSpeed[2];    //0x32      0x02    Animation speed (2bits per icon) (*1)
+	                    //      Bits    Description
+	                    //      00      No icon
+	                    //      01      Icon lasts for 4 frames
+	                    //      10      Icon lasts for 8 frames
+	                    //      11      Icon lasts for 12 frames
+	                    //
+	u8 Permissions;     //0x34      0x01    File-permissions
+	                    //      Bit Permission  Description
+	                    //      4   no move     File cannot be moved by the IPL
+	                    //      3   no copy     File cannot be copied by the IPL
+	                    //      2   public      Can be read by any game
+	                    //
+	u8 CopyCounter;     //0x35      0x01    Copy counter (*2)
+	u8 FirstBlock[2];   //0x36      0x02    Block no of first block of file (0 == offset 0)
+	u8 BlockCount[2];   //0x38      0x02    File-length (number of blocks in file)
+	u8 Unused2[2];      //0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
+	u8 CommentsAddr[4]; //0x3c      0x04    Address of the two comments within the file data (*3)
+};
+
+struct Directory
+{
+	DEntry Dir[DIRLEN]; //0x0000            Directory Entries (max 127)
+	u8 Padding[0x3a];
+	u16 UpdateCounter;  //0x1ffa    2       Update Counter
+	u16 Checksum;       //0x1ffc    2       Additive Checksum
+	u16 Checksum_Inv;   //0x1ffe    2       Inverse Checksum
+	Directory()
+	{
+		memset(this, 0xFF, BLOCK_SIZE);
+		UpdateCounter = 0;
+		Checksum = BE16(0xF003);
+		Checksum_Inv = 0;
+	}
+	void Replace(DEntry d, int idx)
+	{
+		Dir[idx] = d;
+		fixChecksums();
+	}
+	void fixChecksums() { calc_checksumsBE((u16 *)this, 0xFFE, &Checksum, &Checksum_Inv); }
+};
+
+struct BlockAlloc
+{
+	u16 Checksum;       //0x0000    2       Additive Checksum
+	u16 Checksum_Inv;   //0x0002    2       Inverse Checksum
+	u16 UpdateCounter;  //0x0004    2       Update Counter
+	u16 FreeBlocks;     //0x0006    2       Free Blocks
+	u16 LastAllocated;  //0x0008    2       Last allocated Block
+	u16 Map[BAT_SIZE];  //0x000a    0x1ff8  Map of allocated Blocks
+	u16 GetNextBlock(u16 Block) const;
+	u16 NextFreeBlock(u16 MaxBlock, u16 StartingBlock = MC_FST_BLOCKS) const;
+	bool ClearBlocks(u16 StartingBlock, u16 Length);
+	void fixChecksums() { calc_checksumsBE((u16 *)&UpdateCounter, 0xFFE, &Checksum, &Checksum_Inv); }
+	BlockAlloc(u16 sizeMb = MemCard2043Mb)
+	{
+		memset(this, 0, BLOCK_SIZE);
+		// UpdateCounter = 0;
+		FreeBlocks = BE16((sizeMb * MBIT_TO_BLOCKS) - MC_FST_BLOCKS);
+		LastAllocated = BE16(4);
+		fixChecksums();
+	}
+	u16 AssignBlocksContiguous(u16 length)
+	{
+		u16 starting = BE16(LastAllocated) + 1;
+		if (length > BE16(FreeBlocks))
+			return 0xFFFF;
+		u16 current = starting;
+		while ((current - starting + 1) < length)
+		{
+			Map[current - 5] = BE16(current + 1);
+			current++;
+		}
+		Map[current - 5] = 0xFFFF;
+		LastAllocated = BE16(current);
+		FreeBlocks = BE16(BE16(FreeBlocks) - length);
+		fixChecksums();
+		return BE16(starting);
+	}
+};
+#pragma pack(pop)
+
+class GCIFile
+{
+public:
+	bool LoadSaveBlocks();
+	bool HasCopyProtection()
+	{
+		if ((strcmp((char *)m_gci_header.Filename, "PSO_SYSTEM") == 0) ||
+			(strcmp((char *)m_gci_header.Filename, "PSO3_SYSTEM") == 0) ||
+			(strcmp((char *)m_gci_header.Filename, "f_zero.dat") == 0))
+			return true;
+		return false;
+	}
+
+	void DoState(PointerWrap &p);
+	DEntry m_gci_header;
+	std::vector<GCMBlock> m_save_data;
+	std::vector<u16> m_used_blocks;
+	int UsesBlock(u16 blocknum);
+	bool m_dirty;
+	std::string m_filename;
+};
+
 class GCMemcard : NonCopyable
 {
 private:
-	friend class CMemcardManagerDebug;
 	bool m_valid;
 	std::string m_fileName;
 
 	u32 maxBlock;
 	u16 m_sizeMb;
-	struct GCMBlock
-	{
-		GCMBlock(){erase();}
-		void erase() {memset(block, 0xFF, BLOCK_SIZE);}
-		u8 block[BLOCK_SIZE];
-	};
+
+	Header hdr;
+	Directory dir, dir_backup, *CurrentDir, *PreviousDir;
+	BlockAlloc bat, bat_backup, *CurrentBat, *PreviousBat;
+
 	std::vector<GCMBlock> mc_data_blocks;
-#pragma pack(push,1)
-	struct Header {         //Offset    Size    Description
-		 // Serial in libogc
-		u8 serial[12];      //0x0000    12      ?
-		u64 formatTime;     //0x000c    8       Time of format (OSTime value)
-		u32 SramBias;       //0x0014    4       SRAM bias at time of format
-		u32 SramLang;       //0x0018    4       SRAM language
-		u8 Unk2[4];         //0x001c    4       ? almost always 0
-		// end Serial in libogc
-		u8 deviceID[2];     //0x0020    2       0 if formated in slot A 1 if formated in slot B
-		u8 SizeMb[2];       //0x0022    2       Size of memcard in Mbits
-		u16 Encoding;       //0x0024    2       Encoding (ASCII or japanese)
-		u8 Unused1[468];    //0x0026    468     Unused (0xff)
-		u16 UpdateCounter;  //0x01fa    2       Update Counter (?, probably unused)
-		u16 Checksum;       //0x01fc    2       Additive Checksum
-		u16 Checksum_Inv;   //0x01fe    2       Inverse Checksum
-		u8 Unused2[7680];   //0x0200    0x1e00  Unused (0xff)
-	} hdr;
-
-	struct DEntry
-	{
-		u8 Gamecode[4];     //0x00       0x04    Gamecode
-		u8 Makercode[2];    //0x04      0x02    Makercode
-		u8 Unused1;         //0x06      0x01    reserved/unused (always 0xff, has no effect)
-		u8 BIFlags;         //0x07      0x01    banner gfx format and icon animation (Image Key)
-		                    //      Bit(s)  Description
-		                    //      2       Icon Animation 0: forward 1: ping-pong
-		                    //      1       [--0: No Banner 1: Banner present--] WRONG! YAGCD LIES!
-		                    //      0       [--Banner Color 0: RGB5A3 1: CI8--]  WRONG! YAGCD LIES!
-		                    //      bits 0 and 1: image format
-		                    //      00 no banner
-		                    //      01 CI8 banner
-		                    //      10 RGB5A3 banner
-		                    //      11 ? maybe ==00? Time Splitters 2 and 3 have it and don't have banner
-		                    //
-		u8 Filename[DENTRY_STRLEN]; //0x08      0x20     Filename
-		u8 ModTime[4];      //0x28      0x04    Time of file's last modification in seconds since 12am, January 1st, 2000
-		u8 ImageOffset[4];  //0x2c      0x04    image data offset
-		u8 IconFmt[2];      //0x30      0x02    icon gfx format (2bits per icon)
-		                    //      Bits    Description
-		                    //      00      No icon
-		                    //      01      CI8 with a shared color palette after the last frame
-		                    //      10      RGB5A3
-		                    //      11      CI8 with a unique color palette after itself
-		                    //
-		u8 AnimSpeed[2];    //0x32      0x02    Animation speed (2bits per icon) (*1)
-		                    //      Bits    Description
-		                    //      00      No icon
-		                    //      01      Icon lasts for 4 frames
-		                    //      10      Icon lasts for 8 frames
-		                    //      11      Icon lasts for 12 frames
-		                    //
-		u8 Permissions;     //0x34      0x01    File-permissions
-		                    //      Bit Permission  Description
-		                    //      4   no move     File cannot be moved by the IPL
-		                    //      3   no copy     File cannot be copied by the IPL
-		                    //      2   public      Can be read by any game
-		                    //
-		u8 CopyCounter;     //0x35      0x01    Copy counter (*2)
-		u8 FirstBlock[2];   //0x36      0x02    Block no of first block of file (0 == offset 0)
-		u8 BlockCount[2];   //0x38      0x02    File-length (number of blocks in file)
-		u8 Unused2[2];      //0x3a      0x02    Reserved/unused (always 0xffff, has no effect)
-		u8 CommentsAddr[4]; //0x3c      0x04    Address of the two comments within the file data (*3)
-	};
-
-	struct Directory
-	{
-		DEntry Dir[DIRLEN]; //0x0000            Directory Entries (max 127)
-		u8 Padding[0x3a];
-		u16 UpdateCounter;  //0x1ffa    2       Update Counter
-		u16 Checksum;       //0x1ffc    2       Additive Checksum
-		u16 Checksum_Inv;   //0x1ffe    2       Inverse Checksum
-	} dir, dir_backup;
-
-	Directory *CurrentDir, *PreviousDir;
-	struct BlockAlloc
-	{
-		u16 Checksum;       //0x0000    2       Additive Checksum
-		u16 Checksum_Inv;   //0x0002    2       Inverse Checksum
-		u16 UpdateCounter;  //0x0004    2       Update Counter
-		u16 FreeBlocks;     //0x0006    2       Free Blocks
-		u16 LastAllocated;  //0x0008    2       Last allocated Block
-		u16 Map[BAT_SIZE];  //0x000a    0x1ff8  Map of allocated Blocks
-		u16 GetNextBlock(u16 Block) const;
-		u16 NextFreeBlock(u16 MaxBlock, u16 StartingBlock = MC_FST_BLOCKS) const;
-		bool ClearBlocks(u16 StartingBlock, u16 Length);
-	} bat,bat_backup;
-
-	BlockAlloc *CurrentBat, *PreviousBat;
-	struct GCMC_Header
-	{
-		Header *hdr;
-		Directory *dir, *dir_backup;
-		BlockAlloc *bat, *bat_backup;
-	};
-#pragma pack(pop)
 
 	u32 ImportGciInternal(FILE* gcih, const std::string& inputFile, const std::string &outputFile);
-	static void FormatInternal(GCMC_Header &GCP);
-	void initDirBatPointers() ;
+	void initDirBatPointers();
+
 public:
 
 	GCMemcard(const std::string& fileName, bool forceCreation=false, bool sjis=false);
 	bool IsValid() const { return m_valid; }
 	bool IsAsciiEncoding() const;
 	bool Save();
-	bool Format(bool sjis = false, u16 SizeMb = MemCard2043Mb);
-	static bool Format(u8 * card_data, bool sjis = false, u16 SizeMb = MemCard2043Mb);
+	bool Format(bool ascii = true, u16 SizeMb = MemCard2043Mb);
+	static bool Format(u8 *card_data, bool ascii = true, u16 SizeMb = MemCard2043Mb);
+	static s32 FZEROGX_MakeSaveGameValid(Header &cardheader, DEntry &direntry, std::vector<GCMBlock> &FileBuffer);
+	static s32 PSO_MakeSaveGameValid(Header &cardheader, DEntry &direntry, std::vector<GCMBlock> &FileBuffer);
 
-	static void calc_checksumsBE(u16 *buf, u32 length, u16 *csum, u16 *inv_csum);
 	u32 TestChecksums() const;
 	bool FixChecksums();
 
@@ -219,10 +351,6 @@ public:
 	// Copies a DEntry from u8 index to DEntry& data
 	bool GetDEntry(u8 index, DEntry &dest) const;
 
-	// assumes there's enough space in buffer
-	// old determines if function uses old or new method of copying data
-	// some functions only work with old way, some only work with new way
-	// TODO: find a function that works for all calls or split into 2 functions
 	u32 GetSaveData(u8 index, std::vector<GCMBlock> &saveBlocks) const;
 
 	// adds the file to the directory and copies its contents
@@ -249,8 +377,4 @@ public:
 
 	// reads the animation frames
 	u32 ReadAnimRGBA8(u8 index, u32* buffer, u8 *delays) const;
-
-	void CARD_GetSerialNo(u32 *serial1,u32 *serial2);
-	s32 FZEROGX_MakeSaveGameValid(DEntry& direntry, std::vector<GCMBlock> &FileBuffer);
-	s32 PSO_MakeSaveGameValid(DEntry& direntry, std::vector<GCMBlock> &FileBuffer);
 };

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -1,0 +1,614 @@
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+#include <cinttypes>
+
+#include "Common/CommonTypes.h"
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "Core/HW/GCMemcardDirectory.h"
+#include "DiscIO/Volume.h"
+
+const int NO_INDEX = -1;
+const char *MC_HDR = "MC_SYSTEM_AREA";
+int GCMemcardDirectory::LoadGCI(std::string fileName, int region)
+{
+	File::IOFile gcifile(fileName, "rb");
+	if (gcifile)
+	{
+		GCIFile gci;
+		gci.m_filename = fileName;
+		gci.m_dirty = false;
+		if (!gcifile.ReadBytes(&(gci.m_gci_header), DENTRY_SIZE))
+		{
+			ERROR_LOG(EXPANSIONINTERFACE, "%s failed to read header", fileName.c_str());
+			return NO_INDEX;
+		}
+
+		// check region
+		switch (gci.m_gci_header.Gamecode[3])
+		{
+		case 'J':
+			if (region != DiscIO::IVolume::COUNTRY_JAPAN)
+			{
+				PanicAlertT("GCI save file was not loaded because it is the wrong region for this memory card:\n%s",
+							fileName.c_str());
+				return NO_INDEX;
+			}
+			break;
+		case 'E':
+			if (region != DiscIO::IVolume::COUNTRY_USA)
+			{
+				PanicAlertT("GCI save file was not loaded because it is the wrong region for this memory card:\n%s",
+							fileName.c_str());
+				return NO_INDEX;
+			}
+			break;
+		case 'C':
+			// Used by Datel Action Replay Save
+			break;
+		default:
+			if (region != DiscIO::IVolume::COUNTRY_EUROPE)
+			{
+				PanicAlertT("GCI save file was not loaded because it is the wrong region for this memory card:\n%s",
+							fileName.c_str());
+				return NO_INDEX;
+			}
+			break;
+		}
+
+		std::string gci_filename = gci.m_gci_header.GCI_FileName();
+		for (u16 i = 0; i < m_loaded_saves.size(); ++i)
+		{
+			if (m_loaded_saves[i] == gci_filename)
+			{
+				PanicAlertT(
+					"%s\nwas not loaded because it has the same internal filename as previously loaded save\n%s",
+					gci.m_filename.c_str(), m_saves[i].m_filename.c_str());
+				return NO_INDEX;
+			}
+		}
+
+		u16 numBlocks = BE16(gci.m_gci_header.BlockCount);
+		// largest number of free blocks on a memory card
+		// in reality, there are not likely any valid gci files > 251 blocks
+		if (numBlocks > 2043)
+		{
+			PanicAlertT("%s\nwas not loaded because it is an invalid gci.\n Number of blocks claimed to be %d",
+						gci.m_filename.c_str(), numBlocks);
+			return NO_INDEX;
+		}
+
+		u32 size = numBlocks * BLOCK_SIZE;
+		u64 file_size = gcifile.GetSize();
+		if (file_size != size + DENTRY_SIZE)
+		{
+			PanicAlertT("%s\nwas not loaded because it is an invalid gci.\n File size (%" PRIx64
+						") does not match the size recorded in the header (%d)",
+						gci.m_filename.c_str(), file_size, size + DENTRY_SIZE);
+			return NO_INDEX;
+		}
+
+		if (m_GameId == BE32(gci.m_gci_header.Gamecode))
+		{
+			gci.LoadSaveBlocks();
+		}
+		u16 first_block = m_bat1.AssignBlocksContiguous(numBlocks);
+		if (first_block == 0xFFFF)
+		{
+			PanicAlertT("%s\nwas not loaded because there are not enough free blocks on virtual memorycard",
+						fileName.c_str());
+			return NO_INDEX;
+		}
+		*(u16 *)&gci.m_gci_header.FirstBlock = first_block;
+		if (gci.HasCopyProtection() && gci.LoadSaveBlocks())
+		{
+
+			GCMemcard::PSO_MakeSaveGameValid(m_hdr, gci.m_gci_header, gci.m_save_data);
+			GCMemcard::FZEROGX_MakeSaveGameValid(m_hdr, gci.m_gci_header, gci.m_save_data);
+		}
+		int idx = (int)m_saves.size();
+		m_dir1.Replace(gci.m_gci_header, idx);
+		m_saves.push_back(std::move(gci));
+		SetUsedBlocks(idx);
+
+		return idx;
+	}
+	return NO_INDEX;
+}
+
+GCMemcardDirectory::GCMemcardDirectory(std::string directory, int slot, u16 sizeMb, bool ascii, int region, int gameId)
+	: MemoryCardBase(slot, sizeMb)
+	, m_GameId(gameId)
+	, m_LastBlock(-1)
+	, m_hdr(slot, sizeMb, ascii)
+	, m_bat1(sizeMb)
+	, m_saves(0)
+	, m_SaveDirectory(directory)
+{
+	// Use existing header data if available
+	if (File::Exists(m_SaveDirectory + MC_HDR))
+	{
+		File::IOFile hdrfile((m_SaveDirectory + MC_HDR), "rb");
+		hdrfile.ReadBytes(&m_hdr, BLOCK_SIZE);
+	}
+
+	File::FSTEntry FST_Temp;
+	File::ScanDirectoryTree(m_SaveDirectory, FST_Temp);
+	for (u32 j = 0; j < FST_Temp.children.size(); j++)
+	{
+		std::string ext;
+		std::string const &name = FST_Temp.children[j].virtualName;
+		SplitPath(name, NULL, NULL, &ext);
+		if (strcasecmp(ext.c_str(), ".gci") == 0)
+		{
+			if (m_saves.size() == DIRLEN)
+			{
+				PanicAlertT("There are too many gci files in the folder\n%s\nOnly the first 127 will be available",
+							m_SaveDirectory.c_str());
+				break;
+			}
+			int index = LoadGCI(FST_Temp.children[j].physicalName, region);
+			if (index != NO_INDEX)
+			{
+				m_loaded_saves.push_back(m_saves.at(index).m_gci_header.GCI_FileName());
+			}
+		}
+	}
+	m_loaded_saves.clear();
+	m_dir1.fixChecksums();
+	m_dir2 = m_dir1;
+	m_bat2 = m_bat1;
+}
+
+s32 GCMemcardDirectory::Read(u32 address, s32 length, u8 *destaddress)
+{
+
+	s32 block = address / BLOCK_SIZE;
+	u32 offset = address % BLOCK_SIZE;
+	s32 extra = 0; // used for read calls that are across multiple blocks
+
+	if (offset + length > BLOCK_SIZE)
+	{
+		extra = length + offset - BLOCK_SIZE;
+		length -= extra;
+
+		// verify that we haven't calculated a length beyond BLOCK_SIZE
+		_dbg_assert_msg_(EXPANSIONINTERFACE, (address + length) % BLOCK_SIZE == 0,
+						 "Memcard directory Read Logic Error");
+	}
+
+	if (m_LastBlock != block)
+	{
+		switch (block)
+		{
+		case 0:
+			m_LastBlock = block;
+			m_LastBlockAddress = (u8 *)&m_hdr;
+			break;
+		case 1:
+			m_LastBlock = -1;
+			m_LastBlockAddress = (u8 *)&m_dir1;
+			break;
+		case 2:
+			m_LastBlock = -1;
+			m_LastBlockAddress = (u8 *)&m_dir2;
+			break;
+		case 3:
+			m_LastBlock = block;
+			m_LastBlockAddress = (u8 *)&m_bat1;
+			break;
+		case 4:
+			m_LastBlock = block;
+			m_LastBlockAddress = (u8 *)&m_bat2;
+			break;
+		default:
+			m_LastBlock = SaveAreaRW(block);
+
+			if (m_LastBlock == -1)
+			{
+				memset(destaddress, 0xFF, length);
+				return 0;
+			}
+		}
+	}
+
+	memcpy(destaddress, m_LastBlockAddress + offset, length);
+	if (extra)
+		extra = Read(address + length, extra, destaddress + length);
+	return length + extra;
+}
+
+s32 GCMemcardDirectory::Write(u32 destaddress, s32 length, u8 *srcaddress)
+{
+	if (length != 0x80)
+		ERROR_LOG(EXPANSIONINTERFACE, "WRITING TO %x, len %x", destaddress, length);
+	s32 block = destaddress / BLOCK_SIZE;
+	u32 offset = destaddress % BLOCK_SIZE;
+	s32 extra = 0; // used for write calls that are across multiple blocks
+
+	if (offset + length > BLOCK_SIZE)
+	{
+		extra = length + offset - BLOCK_SIZE;
+		length -= extra;
+
+		// verify that we haven't calculated a length beyond BLOCK_SIZE
+		_dbg_assert_msg_(EXPANSIONINTERFACE, (destaddress + length) % BLOCK_SIZE == 0,
+						 "Memcard directory Write Logic Error");
+	}
+
+	if (m_LastBlock != block)
+	{
+		switch (block)
+		{
+		case 0:
+			m_LastBlock = block;
+			m_LastBlockAddress = (u8 *)&m_hdr;
+			break;
+		case 1:
+		case 2:
+		{
+			m_LastBlock = -1;
+			s32 bytes_written = 0;
+			while (length > 0)
+			{
+				s32 to_write = std::min<s32>(DENTRY_SIZE, length);
+				bytes_written += DirectoryWrite(destaddress + bytes_written, to_write, srcaddress + bytes_written);
+				length -= to_write;
+			}
+			return bytes_written;
+		}
+		case 3:
+			m_LastBlock = block;
+			m_LastBlockAddress = (u8 *)&m_bat1;
+			break;
+		case 4:
+			m_LastBlock = block;
+			m_LastBlockAddress = (u8 *)&m_bat2;
+			break;
+		default:
+			m_LastBlock = SaveAreaRW(block, true);
+			if (m_LastBlock == -1)
+			{
+				PanicAlertT("Report: GCIFolder Writing to unallocated block %x", block);
+				exit(0);
+			}
+		}
+	}
+
+	memcpy(m_LastBlockAddress + offset, srcaddress, length);
+
+	if (extra)
+		extra = Write(destaddress + length, extra, srcaddress + length);
+	return length + extra;
+}
+
+void GCMemcardDirectory::ClearBlock(u32 address)
+{
+	if (address % BLOCK_SIZE)
+	{
+		PanicAlertT("GCMemcardDirectory: ClearBlock called with invalid block address");
+		return;
+	}
+
+	u32 block = address / BLOCK_SIZE;
+	switch (block)
+	{
+	case 0:
+		m_LastBlock = block;
+		m_LastBlockAddress = (u8 *)&m_hdr;
+		break;
+	case 1:
+		m_LastBlock = -1;
+		m_LastBlockAddress = (u8 *)&m_dir1;
+		break;
+	case 2:
+		m_LastBlock = -1;
+		m_LastBlockAddress = (u8 *)&m_dir2;
+		break;
+	case 3:
+		m_LastBlock = block;
+		m_LastBlockAddress = (u8 *)&m_bat1;
+		break;
+	case 4:
+		m_LastBlock = block;
+		m_LastBlockAddress = (u8 *)&m_bat2;
+		break;
+	default:
+		m_LastBlock = SaveAreaRW(block, true);
+		if (m_LastBlock == -1)
+			return;
+	}
+	((GCMBlock *)m_LastBlockAddress)->erase();
+}
+
+inline void GCMemcardDirectory::SyncSaves()
+{
+	Directory *current = &m_dir2;
+
+	if (BE16(m_dir1.UpdateCounter) > BE16(m_dir2.UpdateCounter))
+	{
+		current = &m_dir1;
+	}
+
+	for (u32 i = 0; i < DIRLEN; ++i)
+	{
+		if (*(u32 *)&(current->Dir[i]) != 0xFFFFFFFF)
+		{
+			bool added = false;
+			while (i >= m_saves.size())
+			{
+				GCIFile temp;
+				m_saves.push_back(temp);
+				added = true;
+			}
+
+			if (added || memcmp((u8 *)&(m_saves[i].m_gci_header), (u8 *)&(current->Dir[i]), DENTRY_SIZE))
+			{
+				m_saves[i].m_dirty = true;
+				memcpy((u8 *)&(m_saves[i].m_gci_header), (u8 *)&(current->Dir[i]), DENTRY_SIZE);
+			}
+		}
+		else if ((i < m_saves.size()) && (*(u32 *)&(m_saves[i].m_gci_header) != 0xFFFFFFFF))
+		{
+			*(u32 *)&(m_saves[i].m_gci_header.Gamecode) = 0xFFFFFFF;
+		}
+	}
+}
+inline s32 GCMemcardDirectory::SaveAreaRW(u32 block, bool writing)
+{
+	for (u16 i = 0; i < m_saves.size(); ++i)
+	{
+		if (BE32(m_saves[i].m_gci_header.Gamecode) != 0xFFFFFFFF)
+		{
+			if (m_saves[i].m_used_blocks.size() == 0)
+			{
+				SetUsedBlocks(i);
+			}
+
+			int idx = m_saves[i].UsesBlock(block);
+			if (idx != -1)
+			{
+				if (!m_saves[i].LoadSaveBlocks())
+				{
+					int num_blocks = BE16(m_saves[i].m_gci_header.BlockCount);
+					while (num_blocks)
+					{
+						m_saves[i].m_save_data.push_back(GCMBlock());
+						num_blocks--;
+					}
+				}
+
+				if (writing)
+				{
+					m_saves[i].m_dirty = true;
+				}
+
+				m_LastBlock = block;
+				m_LastBlockAddress = m_saves[i].m_save_data[idx].block;
+				return m_LastBlock;
+			}
+		}
+	}
+	return -1;
+}
+
+s32 GCMemcardDirectory::DirectoryWrite(u32 destaddress, u32 length, u8 *srcaddress)
+{
+	u32 block = destaddress / BLOCK_SIZE;
+	u32 offset = destaddress % BLOCK_SIZE;
+	Directory *dest = (block == 1) ? &m_dir1 : &m_dir2;
+	u16 Dnum = offset / DENTRY_SIZE;
+
+	if (Dnum == DIRLEN)
+	{
+		// first 58 bytes should always be 0xff
+		// needed to update the update ctr, checksums
+		// could check for writes to the 6 important bytes but doubtful that it improves performance noticably
+		memcpy((u8 *)(dest)+offset, srcaddress, length);
+		SyncSaves();
+	}
+	else
+		memcpy((u8 *)(dest)+offset, srcaddress, length);
+	return length;
+}
+
+bool GCMemcardDirectory::SetUsedBlocks(int saveIndex)
+{
+	BlockAlloc *currentBat;
+	if (BE16(m_bat2.UpdateCounter) > BE16(m_bat1.UpdateCounter))
+		currentBat = &m_bat2;
+	else
+		currentBat = &m_bat1;
+
+	u16 block = BE16(m_saves[saveIndex].m_gci_header.FirstBlock);
+	while (block != 0xFFFF)
+	{
+		m_saves[saveIndex].m_used_blocks.push_back(block);
+		block = currentBat->GetNextBlock(block);
+		if (block == 0)
+		{
+			PanicAlertT("BAT Incorrect, Dolphin will now exit");
+			exit(0);
+		}
+	}
+
+	u16 num_blocks = BE16(m_saves[saveIndex].m_gci_header.BlockCount);
+
+	if (m_saves[saveIndex].m_used_blocks.size() != num_blocks)
+	{
+		PanicAlertT("Warning BAT number of blocks does not match file header");
+		return false;
+	}
+
+	return true;
+}
+
+void GCMemcardDirectory::Flush(bool exiting)
+{
+	int errors = 0;
+	DEntry invalid;
+	for (u16 i = 0; i < m_saves.size(); ++i)
+	{
+		if (m_saves[i].m_dirty)
+		{
+			if (BE32(m_saves[i].m_gci_header.Gamecode) != 0xFFFFFFFF)
+			{
+				m_saves[i].m_dirty = false;
+				if (m_saves[i].m_filename.empty())
+				{
+					std::string defaultSaveName = m_SaveDirectory + m_saves[i].m_gci_header.GCI_FileName();
+
+					// Check to see if another file is using the same name
+					// This seems unlikely except in the case of file corruption
+					// otherwise what user would name another file this way?
+					for (int j = 0; File::Exists(defaultSaveName) && j < 10; ++j)
+					{
+						defaultSaveName.insert(defaultSaveName.end() - 4, '0');
+					}
+					if (File::Exists(defaultSaveName))
+						PanicAlertT("Failed to find new filename\n %s\n will be overwritten", defaultSaveName.c_str());
+					m_saves[i].m_filename = defaultSaveName;
+				}
+				File::IOFile GCI(m_saves[i].m_filename, "wb");
+				if (GCI)
+				{
+					GCI.WriteBytes(&m_saves[i].m_gci_header, DENTRY_SIZE);
+					GCI.WriteBytes(m_saves[i].m_save_data.data(), BLOCK_SIZE * m_saves[i].m_save_data.size());
+
+					if (!exiting)
+					{
+						if (GCI.IsGood())
+						{
+							Core::DisplayMessage(
+								StringFromFormat("Wrote save contents to %s", m_saves[i].m_filename.c_str()), 4000);
+						}
+						else
+						{
+							++errors;
+							Core::DisplayMessage(
+								StringFromFormat("Failed to write save contents to %s", m_saves[i].m_filename.c_str()),
+								4000);
+							ERROR_LOG(EXPANSIONINTERFACE, "Failed to save data to %s", m_saves[i].m_filename.c_str());
+						}
+					}
+				}
+			}
+			else if (m_saves[i].m_filename.length() != 0)
+			{
+				m_saves[i].m_dirty = false;
+				std::string &oldname = m_saves[i].m_filename;
+				std::string deletedname = oldname + ".deleted";
+				if (File::Exists(deletedname))
+					File::Delete(deletedname);
+				File::Rename(oldname, deletedname);
+				m_saves[i].m_filename.clear();
+				m_saves[i].m_save_data.clear();
+				m_saves[i].m_used_blocks.clear();
+			}
+		}
+
+		// Unload the save data for any game that is not running
+		// we could use !m_dirty, but some games have multiple gci files and may not write to them simultaneously
+		// this ensures that the save data for all of the current games gci files are stored in the savestate
+		u32 gamecode = BE32(m_saves[i].m_gci_header.Gamecode);
+		if (gamecode != m_GameId && gamecode != 0xFFFFFFFF && m_saves[i].m_save_data.size())
+		{
+			INFO_LOG(EXPANSIONINTERFACE, "Flushing savedata to disk for %s", m_saves[i].m_filename.c_str());
+			m_saves[i].m_save_data.clear();
+		}
+	}
+#if _WRITE_MC_HEADER
+	u8 mc[BLOCK_SIZE * MC_FST_BLOCKS];
+	Read(0, BLOCK_SIZE * MC_FST_BLOCKS, mc);
+	File::IOFile hdrfile(m_SaveDirectory + MC_HDR, "wb");
+	hdrfile.WriteBytes(mc, BLOCK_SIZE * MC_FST_BLOCKS);
+#endif
+}
+
+void GCMemcardDirectory::DoState(PointerWrap &p)
+{
+	m_LastBlock = -1;
+	m_LastBlockAddress = 0;
+	p.Do(m_SaveDirectory);
+	p.DoPOD<Header>(m_hdr);
+	p.DoPOD<Directory>(m_dir1);
+	p.DoPOD<Directory>(m_dir2);
+	p.DoPOD<BlockAlloc>(m_bat1);
+	p.DoPOD<BlockAlloc>(m_bat2);
+	int numSaves = (int)m_saves.size();
+	p.Do(numSaves);
+	m_saves.resize(numSaves);
+	for (auto itr = m_saves.begin(); itr != m_saves.end(); ++itr)
+	{
+		itr->DoState(p);
+	}
+}
+
+bool GCIFile::LoadSaveBlocks()
+{
+	if (m_save_data.size() == 0)
+	{
+		if (m_filename.empty())
+			return false;
+
+		File::IOFile savefile(m_filename, "rb");
+		if (!savefile)
+			return false;
+
+		INFO_LOG(EXPANSIONINTERFACE, "Reading savedata from disk for %s", m_filename.c_str());
+		savefile.Seek(DENTRY_SIZE, SEEK_SET);
+		u16 num_blocks = BE16(m_gci_header.BlockCount);
+		m_save_data.resize(num_blocks);
+		if (!savefile.ReadBytes(m_save_data.data(), num_blocks * BLOCK_SIZE))
+		{
+			PanicAlertT("Failed to read data from gci file %s", m_filename.c_str());
+			m_save_data.clear();
+			return false;
+		}
+	}
+	return true;
+}
+
+int GCIFile::UsesBlock(u16 blocknum)
+{
+	for (u16 i = 0; i < m_used_blocks.size(); ++i)
+	{
+		if (m_used_blocks[i] == blocknum)
+			return i;
+	}
+	return -1;
+}
+
+void GCIFile::DoState(PointerWrap &p)
+{
+	p.DoPOD<DEntry>(m_gci_header);
+	p.Do(m_dirty);
+	p.Do(m_filename);
+	int numBlocks = (int)m_save_data.size();
+	p.Do(numBlocks);
+	m_save_data.resize(numBlocks);
+	for (auto itr = m_save_data.begin(); itr != m_save_data.end(); ++itr)
+	{
+		p.DoPOD<GCMBlock>(*itr);
+	}
+	p.Do(m_used_blocks);
+}
+
+void MigrateFromMemcardFile(std::string strDirectoryName, int card_index)
+{
+	File::CreateFullPath(strDirectoryName);
+	std::string ini_memcard =
+		(card_index == 0) ? SConfig::GetInstance().m_strMemoryCardA : SConfig::GetInstance().m_strMemoryCardB;
+	if (File::Exists(ini_memcard))
+	{
+		GCMemcard memcard(ini_memcard.c_str());
+		if (memcard.IsValid())
+		{
+			for (u8 i = 0; i < DIRLEN; i++)
+			{
+				memcard.ExportGci(i, "", strDirectoryName);
+			}
+		}
+	}
+}

--- a/Source/Core/Core/HW/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcardDirectory.h
@@ -1,0 +1,46 @@
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Core/HW/GCMemcard.h"
+
+// Uncomment this to write the system data of the memorycard from directory to disc
+//#define _WRITE_MC_HEADER 1
+void MigrateFromMemcardFile(std::string strDirectoryName, int card_index);
+
+class GCMemcardDirectory : public MemoryCardBase, NonCopyable
+{
+public:
+	GCMemcardDirectory(std::string directory, int slot = 0, u16 sizeMb = MemCard2043Mb, bool ascii = true,
+					   int region = 0, int gameId = 0);
+	~GCMemcardDirectory() { Flush(true); }
+	void Flush(bool exiting = false) override;
+
+	s32 Read(u32 address, s32 length, u8 *destaddress) override;
+	s32 Write(u32 destaddress, s32 length, u8 *srcaddress) override;
+	void ClearBlock(u32 address) override;
+	void ClearAll() override { ; }
+	void DoState(PointerWrap &p) override;
+
+private:
+	int LoadGCI(std::string fileName, int region);
+	inline s32 SaveAreaRW(u32 block, bool writing = false);
+	// s32 DirectoryRead(u32 offset, u32 length, u8* destaddress);
+	s32 DirectoryWrite(u32 destaddress, u32 length, u8 *srcaddress);
+	inline void SyncSaves();
+	bool SetUsedBlocks(int saveIndex);
+
+	u32 m_GameId;
+	s32 m_LastBlock;
+	u8 *m_LastBlockAddress;
+
+	Header m_hdr;
+	Directory m_dir1, m_dir2;
+	BlockAlloc m_bat1, m_bat2;
+	std::vector<GCIFile> m_saves;
+
+	std::vector<std::string> m_loaded_saves;
+	std::string m_SaveDirectory;
+};

--- a/Source/Core/Core/HW/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcardRaw.cpp
@@ -2,12 +2,12 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 #include "Core/Core.h"
-#include "Core/HW/EXI_DeviceMemoryCardRaw.h"
 #include "Core/HW/GCMemcard.h"
+#include "Core/HW/GCMemcardRaw.h"
 #define SIZE_TO_Mb (1024 * 8 * 16)
 #define MC_HDR_SIZE 0xA000
 
-void innerFlush(FlushData* data)
+void innerFlush(FlushData *data)
 {
 	File::IOFile pFile(data->filename, "r+b");
 	if (!pFile)
@@ -22,24 +22,27 @@ void innerFlush(FlushData* data)
 	if (!pFile) // Note - pFile changed inside above if
 	{
 		PanicAlertT("Could not write memory card file %s.\n\n"
-			"Are you running Dolphin from a CD/DVD, or is the save file maybe write protected?\n\n"
-			"Are you receiving this after moving the emulator directory?\nIf so, then you may "
-			"need to re-specify your memory card location in the options.", data->filename.c_str());
+					"Are you running Dolphin from a CD/DVD, or is the save file maybe write protected?\n\n"
+					"Are you receiving this after moving the emulator directory?\nIf so, then you may "
+					"need to re-specify your memory card location in the options.",
+					data->filename.c_str());
 		return;
 	}
 
 	pFile.WriteBytes(data->memcardContent, data->memcardSize);
 
 	if (!data->bExiting)
-		Core::DisplayMessage(StringFromFormat("Wrote memory card %c contents to %s",
-		data->memcardIndex ? 'B' : 'A', data->filename.c_str()).c_str(), 4000);
+		Core::DisplayMessage(StringFromFormat("Wrote memory card %c contents to %s", data->memcardIndex ? 'B' : 'A',
+											  data->filename.c_str()).c_str(),
+							 4000);
 	return;
 }
 
-MemoryCard::MemoryCard(std::string filename, int _card_index, u16 sizeMb) : MemoryCardBase(_card_index, sizeMb), m_strFilename(filename), m_bDirty(false)
+MemoryCard::MemoryCard(std::string filename, int _card_index, u16 sizeMb)
+	: MemoryCardBase(_card_index, sizeMb)
+	, m_bDirty(false)
+	, m_strFilename(filename)
 {
-
-	std::string ;
 	File::IOFile pFile(m_strFilename, "rb");
 	if (pFile)
 	{
@@ -51,7 +54,6 @@ MemoryCard::MemoryCard(std::string filename, int _card_index, u16 sizeMb) : Memo
 
 		INFO_LOG(EXPANSIONINTERFACE, "Reading memory card %s", m_strFilename.c_str());
 		pFile.ReadBytes(memory_card_content, memory_card_size);
-
 	}
 	else
 	{
@@ -105,7 +107,7 @@ void MemoryCard::Flush(bool exiting)
 	m_bDirty = false;
 }
 
-s32 MemoryCard::Read(u32 srcaddress, s32 length, u8* destaddress)
+s32 MemoryCard::Read(u32 srcaddress, s32 length, u8 *destaddress)
 {
 	if (!memory_card_content)
 		return -1;
@@ -119,7 +121,7 @@ s32 MemoryCard::Read(u32 srcaddress, s32 length, u8* destaddress)
 	return length;
 }
 
-s32 MemoryCard::Write(u32 destaddress, s32 length, u8* srcaddress)
+s32 MemoryCard::Write(u32 destaddress, s32 length, u8 *srcaddress)
 {
 	if (!memory_card_content)
 		return -1;

--- a/Source/Core/Core/HW/GCMemcardRaw.h
+++ b/Source/Core/Core/HW/GCMemcardRaw.h
@@ -17,24 +17,6 @@ struct FlushData
 	int memcardSize, memcardIndex;
 };
 
-class MemoryCardBase
-{
-public:
-	MemoryCardBase(int _card_index = 0, int sizeMb = MemCard2043Mb) :card_index(_card_index), nintendo_card_id(sizeMb) { ; }
-	virtual void Flush(bool exiting = false) = 0;
-	virtual s32 Read(u32 address, s32 length, u8* destaddress) = 0;
-	virtual s32 Write(u32 destaddress, s32 length, u8* srcaddress) = 0;
-	virtual void ClearBlock(u32 address) = 0;
-	virtual void ClearAll() = 0;
-	virtual void DoState(PointerWrap &p) = 0;
-	virtual void joinThread() {};
-	u32 GetCardId() { return nintendo_card_id; }
-protected:
-	int card_index;
-	u16 nintendo_card_id;
-	u32 memory_card_size;
-};
-
 class MemoryCard : public MemoryCardBase
 {
 public:
@@ -42,12 +24,13 @@ public:
 	~MemoryCard() { Flush(true); }
 	void Flush(bool exiting = false) override;
 
-	s32 Read(u32 address, s32 length, u8* destaddress) override;
-	s32 Write(u32 destaddress, s32 length, u8* srcaddress) override;
+	s32 Read(u32 address, s32 length, u8 *destaddress) override;
+	s32 Write(u32 destaddress, s32 length, u8 *srcaddress) override;
 	void ClearBlock(u32 address) override;
 	void ClearAll() override;
 	void DoState(PointerWrap &p) override;
 	void joinThread() override;
+
 private:
 	u8 *memory_card_content;
 	bool m_bDirty;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -63,7 +63,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 25;
+static const u32 STATE_VERSION = 26;
 
 enum
 {

--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -116,6 +116,7 @@ static const wxLanguage langIds[] =
 #define SIDEV_AM_BB_STR     _trans("AM-Baseboard")
 
 #define EXIDEV_MEMCARD_STR  _trans("Memory Card")
+#define EXIDEV_MEMDIR_STR   _trans("GCI Folder")
 #define EXIDEV_MIC_STR      _trans("Mic")
 #define EXIDEV_BBA_STR      "BBA"
 #define EXIDEV_AM_BB_STR    _trans("AM-Baseboard")
@@ -395,6 +396,8 @@ void CConfigMain::InitializeGUIValues()
 		SlotDevices.Add(_(DEV_DUMMY_STR));
 		SlotDevices.Add(_(EXIDEV_MEMCARD_STR));
 		SlotDevices.Add(_(EXIDEV_GECKO_STR));
+		SlotDevices.Add(_(EXIDEV_MEMDIR_STR));
+
 #if HAVE_PORTAUDIO
 		SlotDevices.Add(_(EXIDEV_MIC_STR));
 #endif
@@ -432,8 +435,11 @@ void CConfigMain::InitializeGUIValues()
 		case EXIDEVICE_MEMORYCARD:
 			isMemcard = GCEXIDevice[i]->SetStringSelection(SlotDevices[2]);
 			break;
-		case EXIDEVICE_MIC:
+		case EXIDEVICE_MEMORYCARDFOLDER:
 			GCEXIDevice[i]->SetStringSelection(SlotDevices[4]);
+			break;
+		case EXIDEVICE_MIC:
+			GCEXIDevice[i]->SetStringSelection(SlotDevices[5]);
 			break;
 		case EXIDEVICE_ETH:
 			GCEXIDevice[i]->SetStringSelection(SP1Devices[2]);
@@ -1143,6 +1149,8 @@ void CConfigMain::ChooseEXIDevice(wxString deviceName, int deviceNum)
 
 	if (!deviceName.compare(_(EXIDEV_MEMCARD_STR)))
 		tempType = EXIDEVICE_MEMORYCARD;
+	else if (!deviceName.compare(_(EXIDEV_MEMDIR_STR)))
+		tempType = EXIDEVICE_MEMORYCARDFOLDER;
 	else if (!deviceName.compare(_(EXIDEV_MIC_STR)))
 		tempType = EXIDEVICE_MIC;
 	else if (!deviceName.compare(EXIDEV_BBA_STR))


### PR DESCRIPTION
Delroth requested this feature back in sept as [issue 6599](https://code.google.com/p/dolphin-emu/issues/detail?id=6599)
This includes the feature to create a virtual memorycard from a folder of gci files.
The saves that have been written to during gameplay will be stored in the savestate.

On first use of the option the users memorycard will be migrated to a folder (leaving the original memcard untouched)
After the memorycard folder exists, the user is required to synchronize the folder with a memcard image if wanted

commit includes the changes from PR 226
