### PR TITLE
[ARM] Implements more fastmem instructions in lXX.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm32/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.h
@@ -108,7 +108,7 @@ public:
 	void UnsafeStoreFromReg(ARMReg dest, ARMReg value, int accessSize, s32 offset);
 	void SafeStoreFromReg(bool fastmem, s32 dest, u32 value, s32 offsetReg, int accessSize, s32 offset);
 
-	void UnsafeLoadToReg(ARMReg dest, ARMReg addr, int accessSize, s32 offset);
+	void UnsafeLoadToReg(ARMReg dest, ARMReg addr, int accessSize, s32 offsetReg, s32 offset);
 	void SafeLoadToReg(bool fastmem, u32 dest, s32 addr, s32 offsetReg, int accessSize, s32 offset, bool signExtend, bool reverse);
 
 


### PR DESCRIPTION
There are a few instructions in lXX that aren't currently fastmem capable due to using a register offset.
This implements fastmem for those few instructions.
Really I'll be changing how ARMv7 fastmem works in the future so this is really temporary code.
Just don't know how long it'll stay.
This relies on PR #257
