### PR TITLE
VideoBackends: Use unordered map for shader objects

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <d3d11.h>
-#include <map>
+#include <unordered_map>
 
 #include "VideoCommon/PixelShaderGen.h"
 
@@ -46,7 +46,7 @@ private:
 		void Destroy() { SAFE_RELEASE(shader); }
 	};
 
-	typedef std::map<PixelShaderUid, PSCacheEntry> PSCache;
+	typedef std::unordered_map<PixelShaderUid, PSCacheEntry, ::ShaderUidHasher<PixelShaderUid> > PSCache;
 
 	static PSCache PixelShaders;
 	static const PSCacheEntry* last_entry;

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <map>
+#include <unordered_map>
 
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DBlob.h"
@@ -53,7 +53,7 @@ private:
 			SAFE_RELEASE(bytecode);
 		}
 	};
-	typedef std::map<VertexShaderUid, VSCacheEntry> VSCache;
+	typedef std::unordered_map<VertexShaderUid, VSCacheEntry, ::ShaderUidHasher<VertexShaderUid> > VSCache;
 
 	static VSCache vshaders;
 	static const VSCacheEntry* last_entry;

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -32,7 +32,6 @@ LinearDiskCache<SHADERUID, u8> g_program_disk_cache;
 static GLuint CurrentProgram = 0;
 ProgramShaderCache::PCache ProgramShaderCache::pshaders;
 ProgramShaderCache::PCacheEntry* ProgramShaderCache::last_entry;
-SHADERUID ProgramShaderCache::last_uid;
 UidChecker<PixelShaderUid,PixelShaderCode> ProgramShaderCache::pixel_uid_checker;
 UidChecker<VertexShaderUid,VertexShaderCode> ProgramShaderCache::vertex_uid_checker;
 
@@ -161,19 +160,6 @@ SHADER* ProgramShaderCache::SetShader ( DSTALPHA_MODE dstAlphaMode, u32 componen
 {
 	SHADERUID uid;
 	GetShaderId(&uid, dstAlphaMode, components);
-
-	// Check if the shader is already set
-	if (last_entry)
-	{
-		if (uid == last_uid)
-		{
-			GFX_DEBUGGER_PAUSE_AT(NEXT_PIXEL_SHADER_CHANGE, true);
-			last_entry->shader.Bind();
-			return &last_entry->shader;
-		}
-	}
-
-	last_uid = uid;
 
 	// Check if shader is already in cache
 	PCache::iterator iter = pshaders.find(uid);

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include "Common/LinearDiskCache.h"
 #include "Core/ConfigManager.h"
 #include "VideoBackends/OGL/GLUtil.h"
@@ -35,8 +36,12 @@ public:
 	{
 		return puid == r.puid && vuid == r.vuid;
 	}
-};
 
+	size_t hash() const
+	{
+		return puid.hash() ^ vuid.hash();
+	}
+};
 
 struct SHADER
 {
@@ -70,7 +75,7 @@ public:
 		}
 	};
 
-	typedef std::map<SHADERUID, PCacheEntry> PCache;
+	typedef std::unordered_map<SHADERUID, PCacheEntry, ::ShaderUidHasher<SHADERUID> > PCache;
 
 	static PCacheEntry GetShaderProgram(void);
 	static GLuint GetCurrentProgram(void);
@@ -94,7 +99,6 @@ private:
 
 	static PCache pshaders;
 	static PCacheEntry* last_entry;
-	static SHADERUID last_uid;
 
 	static UidChecker<PixelShaderUid,PixelShaderCode> pixel_uid_checker;
 	static UidChecker<VertexShaderUid,VertexShaderCode> vertex_uid_checker;

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Hash.h"
 #include "VideoCommon/VideoCommon.h"
 
 /**
@@ -89,6 +90,11 @@ public:
 		return memcmp(this->values, obj.values, data.NumValues() * sizeof(*values)) < 0;
 	}
 
+	size_t hash() const
+	{
+		return GetMurmurHash3(values, data.NumValues() * sizeof(*values), 0);
+	}
+
 	template<class T>
 	inline T& GetUidData() { return data; }
 
@@ -101,6 +107,16 @@ private:
 		uid_data data;
 		u8 values[sizeof(uid_data)];
 	};
+};
+
+template<typename T>
+class ShaderUidHasher
+{
+public:
+	size_t operator()(const T& uid) const
+	{
+		return uid.hash();
+	}
 };
 
 class ShaderCode : public ShaderGeneratorInterface


### PR DESCRIPTION
atm we use the default std::map for shader object lookup. So we do log(n) memcmp(uid) to find the matching object.
This branch tried to use a hash, so that we'd have to hash and to memcmp once per lookup.

For performance test, I've also removed the precheck in OGL (to not memcmp twice, but hash more often) . This still have to be checked.
