### PR TITLE
OpenGL config: clear backend_info.Adapters on init

### DIFF
--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -150,6 +150,8 @@ void InitBackendInfo()
 	//g_Config.backend_info.bSupportsEarlyZ = true; // is gpu dependent and must be set in renderer
 	g_Config.backend_info.bSupportsOversizedViewports = true;
 
+	g_Config.backend_info.Adapters.clear();
+
 	// aamodes
 	const char* caamodes[] = {_trans("None"), "2x", "4x", "8x", "8x CSAA", "8xQ CSAA", "16x CSAA", "16xQ CSAA", "4x SSAA"};
 	g_Config.backend_info.AAModes.assign(caamodes, caamodes + sizeof(caamodes)/sizeof(*caamodes));


### PR DESCRIPTION
Fixes a minor UI glitch where if you switch from Direct3D to OpenGL, the
OpenGL config page would appear to have an adapter choice available.
