### PR TITLE
PixelShaderGen: Color combiner compare mode fix and simplification

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -782,7 +782,7 @@ static inline void WriteStage(T& out, pixel_shader_uid_data& uid_data, int n, AP
 			"((idot(tevin_a.rgb, comp24) >  idot(tevin_b.rgb, comp24)) ? tevin_c.rgb : int3(0,0,0))", // TEVCMP_BGR24_GT
 			"((idot(tevin_a.rgb, comp24) == idot(tevin_b.rgb, comp24)) ? tevin_c.rgb : int3(0,0,0))", // TEVCMP_BGR24_EQ
 			"(max(sign(tevin_a.rgb - tevin_b.rgb), int3(0,0,0)) * tevin_c.rgb)", // TEVCMP_RGB8_GT
-			"((int3(255,255,255) - max(sign(abs(tevin_a.rgb - tevin_b.rgb)), int3(0,0,0))) * tevin_c.rgb)" // TEVCMP_RGB8_EQ
+			"((int3(1,1,1) - sign(abs(tevin_a.rgb - tevin_b.rgb))) * tevin_c.rgb)" // TEVCMP_RGB8_EQ
 		};
 
 		int mode = (cc.shift<<1)|cc.op;


### PR DESCRIPTION
Changed `int3(255,255,255)` to `int3(1,1,1)` and removed the redundant `max()`.

Fixes issue 7178.
