### PR TITLE
WriteToConstRamAddress: support swap on 32 bit too

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -547,7 +547,10 @@ void EmuCodeBlock::WriteToConstRamAddress(int accessSize, Gen::X64Reg arg, u32 a
 	else
 		MOV(accessSize, MDisp(RBX, address & 0x3FFFFFFF), R(arg));
 #else
-	MOV(accessSize, M((void*)(Memory::base + (address & Memory::MEMVIEW32_MASK))), R(arg));
+	if (swap)
+		SwapAndStore(accessSize, M((void*)(Memory::base + (address & Memory::MEMVIEW32_MASK))), arg);
+	else
+		MOV(accessSize, M((void*)(Memory::base + (address & Memory::MEMVIEW32_MASK))), R(arg));
 #endif
 }
 


### PR DESCRIPTION
Fixes issue 7195 (JIT32 being broken).
