### PR TITLE
Fix "warning: unused variable 'skipFrames'"

### DIFF
--- a/Source/Core/VideoBackends/Software/DebugUtil.cpp
+++ b/Source/Core/VideoBackends/Software/DebugUtil.cpp
@@ -21,7 +21,6 @@
 namespace DebugUtil
 {
 
-static u32 skipFrames = 0;
 static bool drawingHwTriangles = false;
 
 enum { NumObjectBuffers = 40};


### PR DESCRIPTION
Rocket Science.
