### PR TITLE
Android: Copy GCPadNew.ini on startup

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/DolphinEmulator.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/DolphinEmulator.java
@@ -66,6 +66,7 @@ public final class DolphinEmulator extends Activity
 
 			// Copy assets if needed
 			File file = new File(GCDir + File.separator + "font_sjis.bin");
+			// Update this file on startup so changes to it can be applied
 			CopyAsset("GCPadNew.ini",    ConfigDir + File.separator + "GCPadNew.ini");
 			if(!file.exists())
 			{


### PR DESCRIPTION
There should never be a time where an end user will need to modify GCPadNew.ini. There are however times when it will be modified in the code. This way, whenever GCPadNew.ini is modified it will be automatically updated for users. Fixes the issue I thought of with #291 where the buttons would still not work unless GCPadNew.ini was updated.
