### PR TITLE
Android: Allow finger movement while pressing button

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
@@ -116,7 +116,8 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		//
 		// TODO: Refactor this so we detect either Axis movements or button presses so we don't run two loops all the time.
 		//
-		int buttonState = (event.getAction() == MotionEvent.ACTION_DOWN) ? ButtonState.PRESSED : ButtonState.RELEASED;
+		int buttonState = (event.getAction() == MotionEvent.ACTION_DOWN || event.getAction() == MotionEvent.ACTION_MOVE)
+				? ButtonState.PRESSED : ButtonState.RELEASED;
 		// Check if there was a touch within the bounds of a drawable.
 		for (InputOverlayDrawableButton button : overlayButtons)
 		{


### PR DESCRIPTION
Previously when pressing an on-screen button, as soon as your finger moved the slightest, the button would be released. This made it very hard to hold buttons down. With this patch, the button will stay pressed until you let go.
