### PR TITLE
Android: Allow finger movement while pressing button

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
@@ -122,12 +122,16 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		for (InputOverlayDrawableButton button : overlayButtons)
 		{
 			if (button.getBounds().contains((int)event.getX(), (int)event.getY()))
+			{
 				NativeLibrary.onTouchEvent(0, button.getId(), buttonState);
+			}
 			else
+			{
 				// Because the above code only changes the state for the button that is being touched, sliding off the
 				// button does not allow for it to be released. Release the button as soon as the touch coordinates leave
 				// the button bounds.
 				NativeLibrary.onTouchEvent(0, button.getId(), ButtonState.RELEASED);
+			}
 		}
 
 


### PR DESCRIPTION
Previously when pressing an on-screen button, as soon as your finger moved the slightest, the button would be released. This made it very hard to hold buttons down. With this patch, the button will stay pressed until you let go.

Resubmitted because the previous PR changed the permission of the file due to whatever I did to cause it.
