### PR TITLE
SDL: If a controller declares it is an Nvidia Shield, skip SDL init

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -71,7 +71,8 @@ Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsi
 	    (10 == SDL_JoystickNumButtons(joystick)) &&
 	    (5 == SDL_JoystickNumAxes(joystick)) &&
 	    (1 == SDL_JoystickNumHats(joystick)) &&
-	    (0 == SDL_JoystickNumBalls(joystick)))
+		(0 == SDL_JoystickNumBalls(joystick)) ||
+		(std::string::npos != lcasename.find("nvidia shield")))
 	{
 		// this device won't be used
 		return;


### PR DESCRIPTION
For some reason, if a Shield is streaming Dolphin, Dolphin gets stuck in an infinite loop asking SDL to count how many buttons it has. This isn't a great fix, but it's similar to a hack already done for Xbox 360 controllers & it works.
