### PR TITLE
Adds Link Time Optimization cmake option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(USE_WAYLAND "Enables Wayland Support" OFF)
 option(USE_UPNP "Enables UPnP port mapping support" ON)
 option(DISABLE_WX "Disable wxWidgets (use CLI interface)" OFF)
 option(ENABLE_PCH "Use PCH to speed up compilation" ON)
+option(ENABLE_LTO "Enables Link Time Optimization" OFF)
 
 option(OPENMP "Enable OpenMP parallelization" ON)
 option(ENCODE_FRAMEDUMPS "Encode framedumps in AVI format" ON)
@@ -204,6 +205,10 @@ check_and_add_flag(VISIBILITY_INLINES_HIDDEN -fvisibility-inlines-hidden)
 
 if(UNIX AND NOT APPLE)
 	check_and_add_flag(VISIBILITY_HIDDEN -fvisibility=hidden)
+endif()
+
+if(ENABLE_LTO)
+	check_and_add_flag(LTO -flto)
 endif()
 
 if(APPLE)


### PR DESCRIPTION
Adds a LTO option that isn't enabled by default.
Allows building release binaries with link time optimizations without generating a -dirty build.
Not enabled by default due to concerns of memory usage and increased build time.
