### PR TITLE
VertexShaderGen: Correct vertex shader output to consider shifted pixel centers.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -419,6 +419,14 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 		//seems to get rather complicated
 	}
 
+	// The console GPU places the pixel center at 7/12 in screen space unless
+	// antialiasing is enabled, while D3D and OpenGL place it at 0.5. This results
+	// in some primitives being placed one pixel too far to the bottom-right,
+	// which in turn can be critical if it happens for clear quads.
+	// Hence, we compensate for this pixel center difference so that primitives
+	// get rasterized correctly.
+	out.Write("o.pos.xy = o.pos.xy - " I_DEPTHPARAMS".zw;\n");
+
 	if (api_type == API_OPENGL)
 	{
 		// Bit ugly here

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -360,6 +360,17 @@ void VertexShaderManager::SetConstants()
 		bViewportChanged = false;
 		constants.depthparams[0] = xfregs.viewport.farZ / 16777216.0f;
 		constants.depthparams[1] = xfregs.viewport.zRange / 16777216.0f;
+
+		// The console GPU places the pixel center at 7/12 unless antialiasing
+		// is enabled, while D3D and OpenGL place it at 0.5. See the comment
+		// in VertexShaderGen.cpp for details.
+		// NOTE: If we ever emulate antialiasing, the sample locations set by
+		// BP registers 0x01-0x04 need to be considered here.
+		const float pixel_center_correction = 7.0f / 12.0f - 0.5f;
+		const float pixel_size_x = 2.f / Renderer::EFBToScaledXf(2.f * xfregs.viewport.wd);
+		const float pixel_size_y = 2.f / Renderer::EFBToScaledXf(2.f * xfregs.viewport.ht);
+		constants.depthparams[2] = pixel_center_correction * pixel_size_x;
+		constants.depthparams[3] = pixel_center_correction * pixel_size_y;
 		dirty = true;
 		// This is so implementation-dependent that we can't have it here.
 		g_renderer->SetViewport();


### PR DESCRIPTION
On the console GPU, pixel centers are located at 0.58333 in screen space, rather than 0.5 as for common GPUs. Hence, primitives get rasterized incorrectly such that they may get offset by one pixel to the bottom-right.

Explanation of the discovery of this issue in bug report 267 - http://code.google.com/p/dolphin-emu/issues/detail?id=267 . This issue caused a clear quad to function improperly there, hence creating artifacts in an EFB copy which showed up as the oddly colored ground texture.

A hwtest was written for this behavior at https://github.com/dolphin-emu/hwtests/blob/872cd517cc3f8edb20161506109344652bbd02b5/gxtest/source/main.cpp#L500 and indeed it shows that indeed the pixel center is (roughly) at 7/12th in screen space. There's no real confirmation, but at least it's very close to that value, and it just makes a lot of sense given that each pixel is divided into a 12x12 grid of subsamples.
