### PR TITLE
Fix Fastmem on CPUs without MOVBE

### DIFF
--- a/Source/Core/Common/x64Analyzer.cpp
+++ b/Source/Core/Common/x64Analyzer.cpp
@@ -154,6 +154,7 @@ bool DisassembleMov(const unsigned char *codePtr, InstructionInfo *info)
 			info->immediate = *(u32*)codePtr;
 			codePtr += 4;
 			break;
+
 		case 8:
 			info->zeroExtend = true;
 			info->immediate = *(u32*)codePtr;

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -428,13 +428,23 @@ u8 *EmuCodeBlock::UnsafeWriteRegToReg(X64Reg reg_value, X64Reg reg_addr, int acc
 	}
 #if _M_X86_64
 	result = GetWritableCodePtr();
+	OpArg dest = MComplex(RBX, reg_addr, SCALE_1, offset);
 	if (swap)
 	{
-		SwapAndStore(accessSize, MComplex(RBX, reg_addr, SCALE_1, offset), reg_value);
+		if (cpu_info.bMOVBE)
+		{
+			MOVBE(accessSize, dest, R(reg_value));
+		}
+		else
+		{
+			BSWAP(accessSize, reg_value);
+			result = GetWritableCodePtr();
+			MOV(accessSize, dest, R(reg_value));
+		}
 	}
 	else
 	{
-		MOV(accessSize, MComplex(RBX, reg_addr, SCALE_1, offset), R(reg_value));
+		MOV(accessSize, dest, R(reg_value));
 	}
 #else
 	if (swap)


### PR DESCRIPTION
The problem was that when BSWAP was used, UnsafeWriteRegToReg() returned the address of that instead of the MOV.
