### PR TITLE
Removes unused argument in Helper_UpdateCR1.

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -304,8 +304,7 @@ public:
 private:
 	// flag helper
 	static void Helper_UpdateCR0(u32 _uValue);
-	static void Helper_UpdateCR1(double _fValue);
-	static void Helper_UpdateCR1(float _fValue);
+	static void Helper_UpdateCR1();
 	static void Helper_UpdateCRx(int _x, u32 _uValue);
 
 	// address helper

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -28,7 +28,7 @@ void UpdateSSEState();
 
 // Extremely rare - actually, never seen.
 // Star Wars : Rogue Leader spams that at some point :|
-void Interpreter::Helper_UpdateCR1(double _fValue)
+void Interpreter::Helper_UpdateCR1()
 {
 	SetCRField(1, (FPSCR.FX << 4) | (FPSCR.FEX << 3) | (FPSCR.VX << 2) | FPSCR.OX);
 }
@@ -172,7 +172,7 @@ void Interpreter::fctiwx(UGeckoInstruction _inst)
 	if (value == 0 && ( (*(u64*)&b) & DOUBLE_SIGN ))
 		riPS0(_inst.FD) |= 0x100000000ull;
 	if (_inst.Rc)
-		Helper_UpdateCR1(rPS0(_inst.FD));
+		Helper_UpdateCR1();
 }
 
 // Always round toward zero
@@ -216,42 +216,42 @@ void Interpreter::fctiwzx(UGeckoInstruction _inst)
 	if (value == 0 && ( (*(u64*)&b) & DOUBLE_SIGN ))
 		riPS0(_inst.FD) |= 0x100000000ull;
 	if (_inst.Rc)
-		Helper_UpdateCR1(rPS0(_inst.FD));
+		Helper_UpdateCR1();
 }
 
 void Interpreter::fmrx(UGeckoInstruction _inst)
 {
 	riPS0(_inst.FD) = riPS0(_inst.FB);
 	// This is a binary instruction. Does not alter FPSCR
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fabsx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = fabs(rPS0(_inst.FB));
 	// This is a binary instruction. Does not alter FPSCR
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fnabsx(UGeckoInstruction _inst)
 {
 	riPS0(_inst.FD) = riPS0(_inst.FB) | (1ULL << 63);
 	// This is a binary instruction. Does not alter FPSCR
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fnegx(UGeckoInstruction _inst)
 {
 	riPS0(_inst.FD) = riPS0(_inst.FB) ^ (1ULL << 63);
 	// This is a binary instruction. Does not alter FPSCR
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fselx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = (rPS0(_inst.FA) >= -0.0) ? rPS0(_inst.FC) : rPS0(_inst.FB);
 	// This is a binary instruction. Does not alter FPSCR
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 // !!! warning !!!
@@ -275,7 +275,7 @@ void Interpreter::fmulx(UGeckoInstruction _inst)
 	FPSCR.FI = 0; // are these flags important?
 	FPSCR.FR = 0;
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 void Interpreter::fmulsx(UGeckoInstruction _inst)
 {
@@ -285,7 +285,7 @@ void Interpreter::fmulsx(UGeckoInstruction _inst)
 	FPSCR.FI = 0;
 	FPSCR.FR = 0;
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fmaddx(UGeckoInstruction _inst)
@@ -293,7 +293,7 @@ void Interpreter::fmaddx(UGeckoInstruction _inst)
 	double result = ForceDouble(NI_madd( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ));
 	rPS0(_inst.FD) = result;
 	UpdateFPRF(result);
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fmaddsx(UGeckoInstruction _inst)
@@ -303,7 +303,7 @@ void Interpreter::fmaddsx(UGeckoInstruction _inst)
 	FPSCR.FI = d_value != rPS0(_inst.FD);
 	FPSCR.FR = 0;
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 
@@ -311,13 +311,13 @@ void Interpreter::faddx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = ForceDouble(NI_add(rPS0(_inst.FA), rPS0(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 void Interpreter::faddsx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = rPS1(_inst.FD) = ForceSingle(NI_add(rPS0(_inst.FA), rPS0(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fdivx(UGeckoInstruction _inst)
@@ -349,7 +349,7 @@ void Interpreter::fdivx(UGeckoInstruction _inst)
 	}
 	UpdateFPRF(rPS0(_inst.FD));
 	// FR,FI,OX,UX???
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 void Interpreter::fdivsx(UGeckoInstruction _inst)
 {
@@ -381,7 +381,7 @@ void Interpreter::fdivsx(UGeckoInstruction _inst)
 	}
 	rPS0(_inst.FD) = rPS1(_inst.FD) = res;
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 // Single precision only.
@@ -406,7 +406,7 @@ void Interpreter::fresx(UGeckoInstruction _inst)
 		SetFPException(FPSCR_ZX);
 	}
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::frsqrtex(UGeckoInstruction _inst)
@@ -449,14 +449,14 @@ void Interpreter::frsqrtex(UGeckoInstruction _inst)
 #endif
 	}
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fmsubx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = ForceDouble(NI_msub( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fmsubsx(UGeckoInstruction _inst)
@@ -464,28 +464,28 @@ void Interpreter::fmsubsx(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = rPS1(_inst.FD) =
 		ForceSingle( NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fnmaddx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = ForceDouble(-NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 void Interpreter::fnmaddsx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = rPS1(_inst.FD) =
 		ForceSingle(-NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fnmsubx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = ForceDouble(-NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 // fnmsubsx does not handle QNAN properly - see NI_msub
@@ -494,21 +494,21 @@ void Interpreter::fnmsubsx(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = rPS1(_inst.FD) =
 		ForceSingle(-NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fsubx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = ForceDouble(NI_sub(rPS0(_inst.FA), rPS0(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fsubsx(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = rPS1(_inst.FD) = ForceSingle(NI_sub(rPS0(_inst.FA), rPS0(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fsqrtx(UGeckoInstruction _inst)
@@ -521,5 +521,5 @@ void Interpreter::fsqrtx(UGeckoInstruction _inst)
 	}
 	rPS0(_inst.FD) = sqrt(b);
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -15,35 +15,35 @@ void Interpreter::ps_sel(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = rPS0(_inst.FA) >= -0.0 ? rPS0(_inst.FC) : rPS0(_inst.FB);
 	rPS1(_inst.FD) = rPS1(_inst.FA) >= -0.0 ? rPS1(_inst.FC) : rPS1(_inst.FB);
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_neg(UGeckoInstruction _inst)
 {
 	riPS0(_inst.FD) = riPS0(_inst.FB) ^ (1ULL << 63);
 	riPS1(_inst.FD) = riPS1(_inst.FB) ^ (1ULL << 63);
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_mr(UGeckoInstruction _inst)
 {
 	rPS0(_inst.FD) = rPS0(_inst.FB);
 	rPS1(_inst.FD) = rPS1(_inst.FB);
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_nabs(UGeckoInstruction _inst)
 {
 	riPS0(_inst.FD) = riPS0(_inst.FB) | (1ULL << 63);
 	riPS1(_inst.FD) = riPS1(_inst.FB) | (1ULL << 63);
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_abs(UGeckoInstruction _inst)
 {
 	riPS0(_inst.FD) = riPS0(_inst.FB) &~ (1ULL << 63);
 	riPS1(_inst.FD) = riPS1(_inst.FB) &~ (1ULL << 63);
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 // These are just moves, double is OK.
@@ -53,7 +53,7 @@ void Interpreter::ps_merge00(UGeckoInstruction _inst)
 	double p1 = rPS0(_inst.FB);
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_merge01(UGeckoInstruction _inst)
@@ -62,7 +62,7 @@ void Interpreter::ps_merge01(UGeckoInstruction _inst)
 	double p1 = rPS1(_inst.FB);
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_merge10(UGeckoInstruction _inst)
@@ -71,7 +71,7 @@ void Interpreter::ps_merge10(UGeckoInstruction _inst)
 	double p1 = rPS0(_inst.FB);
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_merge11(UGeckoInstruction _inst)
@@ -80,7 +80,7 @@ void Interpreter::ps_merge11(UGeckoInstruction _inst)
 	double p1 = rPS1(_inst.FB);
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 // From here on, the real deal.
@@ -166,7 +166,7 @@ void Interpreter::ps_div(UGeckoInstruction _inst)
 
 	SetFPException(ex_mask);
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_res(UGeckoInstruction _inst)
@@ -195,7 +195,7 @@ void Interpreter::ps_res(UGeckoInstruction _inst)
 			riPS1(_inst.FD) = MIN_SINGLE;
 	}
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_rsqrte(UGeckoInstruction _inst)
@@ -231,7 +231,7 @@ void Interpreter::ps_rsqrte(UGeckoInstruction _inst)
 	}
 
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 
@@ -240,7 +240,7 @@ void Interpreter::ps_sub(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = ForceSingle(NI_sub(rPS0(_inst.FA), rPS0(_inst.FB)));
 	rPS1(_inst.FD) = ForceSingle(NI_sub(rPS1(_inst.FA), rPS1(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_add(UGeckoInstruction _inst)
@@ -248,7 +248,7 @@ void Interpreter::ps_add(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = ForceSingle(NI_add(rPS0(_inst.FA), rPS0(_inst.FB)));
 	rPS1(_inst.FD) = ForceSingle(NI_add(rPS1(_inst.FA), rPS1(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_mul(UGeckoInstruction _inst)
@@ -256,7 +256,7 @@ void Interpreter::ps_mul(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = ForceSingle(NI_mul(rPS0(_inst.FA), rPS0(_inst.FC)));
 	rPS1(_inst.FD) = ForceSingle(NI_mul(rPS1(_inst.FA), rPS1(_inst.FC)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 
@@ -265,7 +265,7 @@ void Interpreter::ps_msub(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = ForceSingle(NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
 	rPS1(_inst.FD) = ForceSingle(NI_msub(rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_madd(UGeckoInstruction _inst)
@@ -273,7 +273,7 @@ void Interpreter::ps_madd(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = ForceSingle(NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
 	rPS1(_inst.FD) = ForceSingle(NI_madd(rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB)));
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_nmsub(UGeckoInstruction _inst)
@@ -281,7 +281,7 @@ void Interpreter::ps_nmsub(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = ForceSingle( -NI_msub( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ) );
 	rPS1(_inst.FD) = ForceSingle( -NI_msub( rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB) ) );
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_nmadd(UGeckoInstruction _inst)
@@ -289,7 +289,7 @@ void Interpreter::ps_nmadd(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = ForceSingle( -NI_madd( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ) );
 	rPS1(_inst.FD) = ForceSingle( -NI_madd( rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB) ) );
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_sum0(UGeckoInstruction _inst)
@@ -299,7 +299,7 @@ void Interpreter::ps_sum0(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_sum1(UGeckoInstruction _inst)
@@ -309,7 +309,7 @@ void Interpreter::ps_sum1(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
 	UpdateFPRF(rPS1(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_muls0(UGeckoInstruction _inst)
@@ -319,7 +319,7 @@ void Interpreter::ps_muls0(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_muls1(UGeckoInstruction _inst)
@@ -329,7 +329,7 @@ void Interpreter::ps_muls1(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_madds0(UGeckoInstruction _inst)
@@ -339,7 +339,7 @@ void Interpreter::ps_madds0(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_madds1(UGeckoInstruction _inst)
@@ -349,7 +349,7 @@ void Interpreter::ps_madds1(UGeckoInstruction _inst)
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
 	UpdateFPRF(rPS0(_inst.FD));
-	if (_inst.Rc) Helper_UpdateCR1(rPS0(_inst.FD));
+	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_cmpu0(UGeckoInstruction _inst)


### PR DESCRIPTION
Interpreter::Helper_UpdateCR1 doesn't use the argument passed to UpdateCR1. It pulls its value from the FPSCR register.
Also there was a Interpreter::Helper_UpdateCR1(float) in addition to Helper_UpdateCR1(double) that hasn't ever existed. Remove the function
declaration.
