### PR TITLE
ARM: Fix Wii games on JIT

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm32/JitArm_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitArm_Tables.cpp
@@ -209,7 +209,7 @@ static GekkoOPTemplate table31[] =
 
 	//load word
 	{23,  &JitArm::lXX},                    //"lwzx",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A0 | FL_IN_B}},
-	{55,  &JitArm::lXX},                    //"lwzux", OPTYPE_LOAD, FL_OUT_D | FL_OUT_A | FL_IN_A | FL_IN_B}},
+	{55,  &JitArm::FallBackToInterpreter},  //"lwzux", OPTYPE_LOAD, FL_OUT_D | FL_OUT_A | FL_IN_A | FL_IN_B}},
 
 	//load halfword
 	{279, &JitArm::lXX},                    //"lhzx",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A0 | FL_IN_B}},


### PR DESCRIPTION
While this is likely not a permanent fix, until lwzux for JIT is actually fixed we should at least have a way for it to actually be used with JIT ARM.

Fixes issue 7130.
