### PR TITLE
Removes usage of SFML's HTTP functions in the Gecko Code Dialog.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -670,7 +670,7 @@ endif()
 
 if(NOT DISABLE_WX AND NOT ANDROID)
 	include(FindwxWidgets OPTIONAL)
-	FIND_PACKAGE(wxWidgets COMPONENTS core aui adv)
+	FIND_PACKAGE(wxWidgets COMPONENTS core aui adv net)
 
 	if(wxWidgets_FOUND)
 		EXECUTE_PROCESS(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
We should be using GUI library facilities for HTTP file acquiring.
This is the only non-socket SFML usage.

I loathe SFML.
