### PR TITLE
Adds a StdBasicString.h header to Common

### DIFF
--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -81,6 +81,7 @@
     <ClInclude Include="SDCardUtil.h" />
     <ClInclude Include="SettingsHandler.h" />
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="StdBasicString.h" />
     <ClInclude Include="StdConditionVariable.h" />
     <ClInclude Include="StdMutex.h" />
     <ClInclude Include="StdThread.h" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -41,6 +41,7 @@
     <ClInclude Include="Network.h" />
     <ClInclude Include="SDCardUtil.h" />
     <ClInclude Include="SettingsHandler.h" />
+    <ClInclude Include="StdBasicString.h" />
     <ClInclude Include="StdConditionVariable.h" />
     <ClInclude Include="StdMutex.h" />
     <ClInclude Include="StdThread.h" />

--- a/Source/Core/Common/StdBasicString.h
+++ b/Source/Core/Common/StdBasicString.h
@@ -1,0 +1,198 @@
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#pragma once
+
+#ifdef ANDROID
+#include <wchar.h>
+#include <ext/string_conversions.h>
+
+// This header is mainly for Android
+// It has broken C99 support
+// Once the Android NDK has fixed C99 this header can be removed.
+// These are copied from basic_string.h
+// The functions that Android can't use are removed
+// These include any usage of:
+// stoull -> strtoull
+// stoll -> strtoll
+// stold -> strtold
+
+namespace std
+{
+  // 21.4 Numeric Conversions [string.conversions].
+  inline int
+  stoi(const string& __str, size_t* __idx = 0, int __base = 10)
+  { return __gnu_cxx::__stoa<long, int>(&std::strtol, "stoi", __str.c_str(),
+					__idx, __base); }
+
+  inline long
+  stol(const string& __str, size_t* __idx = 0, int __base = 10)
+  { return __gnu_cxx::__stoa(&std::strtol, "stol", __str.c_str(),
+			     __idx, __base); }
+
+  inline unsigned long
+  stoul(const string& __str, size_t* __idx = 0, int __base = 10)
+  { return __gnu_cxx::__stoa(&std::strtoul, "stoul", __str.c_str(),
+			     __idx, __base); }
+
+  // NB: strtof vs strtod.
+  inline float
+  stof(const string& __str, size_t* __idx = 0)
+  { return __gnu_cxx::__stoa(&strtof, "stof", __str.c_str(), __idx); }
+
+  inline double
+  stod(const string& __str, size_t* __idx = 0)
+  { return __gnu_cxx::__stoa(&strtod, "stod", __str.c_str(), __idx); }
+
+  // NB: (v)snprintf vs sprintf.
+
+  // DR 1261.
+  inline string
+  to_string(int __val)
+  { return __gnu_cxx::__to_xstring<string>(&vsnprintf, 4 * sizeof(int),
+					   "%d", __val); }
+
+  inline string
+  to_string(unsigned __val)
+  { return __gnu_cxx::__to_xstring<string>(&vsnprintf,
+					   4 * sizeof(unsigned),
+					   "%u", __val); }
+
+  inline string
+  to_string(long __val)
+  { return __gnu_cxx::__to_xstring<string>(&vsnprintf, 4 * sizeof(long),
+					   "%ld", __val); }
+
+  inline string
+  to_string(unsigned long __val)
+  { return __gnu_cxx::__to_xstring<string>(&vsnprintf,
+					   4 * sizeof(unsigned long),
+					   "%lu", __val); }
+
+  inline string
+  to_string(long long __val)
+  { return __gnu_cxx::__to_xstring<string>(&vsnprintf,
+					   4 * sizeof(long long),
+					   "%lld", __val); }
+
+  inline string
+  to_string(unsigned long long __val)
+  { return __gnu_cxx::__to_xstring<string>(&vsnprintf,
+					   4 * sizeof(unsigned long long),
+					   "%llu", __val); }
+
+  inline string
+  to_string(float __val)
+  {
+    const int __n =
+      __gnu_cxx::__numeric_traits<float>::__max_exponent10 + 20;
+    return __gnu_cxx::__to_xstring<string>(&vsnprintf, __n,
+					   "%f", __val);
+  }
+
+  inline string
+  to_string(double __val)
+  {
+    const int __n =
+      __gnu_cxx::__numeric_traits<double>::__max_exponent10 + 20;
+    return __gnu_cxx::__to_xstring<string>(&vsnprintf, __n,
+					   "%f", __val);
+  }
+
+  inline string
+  to_string(long double __val)
+  {
+    const int __n =
+      __gnu_cxx::__numeric_traits<long double>::__max_exponent10 + 20;
+    return __gnu_cxx::__to_xstring<string>(&vsnprintf, __n,
+					   "%Lf", __val);
+  }
+
+#ifdef _GLIBCXX_USE_WCHAR_T
+  inline int
+  stoi(const wstring& __str, size_t* __idx = 0, int __base = 10)
+  { return __gnu_cxx::__stoa<long, int>(&std::wcstol, "stoi", __str.c_str(),
+					__idx, __base); }
+
+  inline long
+  stol(const wstring& __str, size_t* __idx = 0, int __base = 10)
+  { return __gnu_cxx::__stoa(&std::wcstol, "stol", __str.c_str(),
+			     __idx, __base); }
+
+  inline unsigned long
+  stoul(const wstring& __str, size_t* __idx = 0, int __base = 10)
+  { return __gnu_cxx::__stoa(&std::wcstoul, "stoul", __str.c_str(),
+			     __idx, __base); }
+
+  // NB: wcstof vs wcstod.
+  inline double
+  stod(const wstring& __str, size_t* __idx = 0)
+  { return __gnu_cxx::__stoa(&wcstod, "stod", __str.c_str(), __idx); }
+
+  // DR 1261.
+  inline wstring
+  to_wstring(int __val)
+  { return __gnu_cxx::__to_xstring<wstring>(&std::vswprintf, 4 * sizeof(int),
+					    L"%d", __val); }
+
+  inline wstring
+  to_wstring(unsigned __val)
+  { return __gnu_cxx::__to_xstring<wstring>(&std::vswprintf,
+					    4 * sizeof(unsigned),
+					    L"%u", __val); }
+
+  inline wstring
+  to_wstring(long __val)
+  { return __gnu_cxx::__to_xstring<wstring>(&std::vswprintf, 4 * sizeof(long),
+					    L"%ld", __val); }
+
+  inline wstring
+  to_wstring(unsigned long __val)
+  { return __gnu_cxx::__to_xstring<wstring>(&std::vswprintf,
+					    4 * sizeof(unsigned long),
+					    L"%lu", __val); }
+
+  inline wstring
+  to_wstring(long long __val)
+  { return __gnu_cxx::__to_xstring<wstring>(&std::vswprintf,
+					    4 * sizeof(long long),
+					    L"%lld", __val); }
+
+  inline wstring
+  to_wstring(unsigned long long __val)
+  { return __gnu_cxx::__to_xstring<wstring>(&std::vswprintf,
+					    4 * sizeof(unsigned long long),
+					    L"%llu", __val); }
+
+  inline wstring
+  to_wstring(float __val)
+  {
+    const int __n =
+      __gnu_cxx::__numeric_traits<float>::__max_exponent10 + 20;
+    return __gnu_cxx::__to_xstring<wstring>(&std::vswprintf, __n,
+					    L"%f", __val);
+  }
+
+  inline wstring
+  to_wstring(double __val)
+  {
+    const int __n =
+      __gnu_cxx::__numeric_traits<double>::__max_exponent10 + 20;
+    return __gnu_cxx::__to_xstring<wstring>(&std::vswprintf, __n,
+					    L"%f", __val);
+  }
+
+  inline wstring
+  to_wstring(long double __val)
+  {
+    const int __n =
+      __gnu_cxx::__numeric_traits<long double>::__max_exponent10 + 20;
+    return __gnu_cxx::__to_xstring<wstring>(&std::vswprintf, __n,
+					    L"%Lf", __val);
+  }
+#endif
+}
+
+#endif
+


### PR DESCRIPTION
Android has broken C99 support in it's NDK. This hasn't been too much of an issue since most uses of the disabled features have been in the WX GUI.
This has become a bit more of an issue since we can't use std::to_string in common code due to it being disabled in basic_string.h due to the
_GLIBCXX_USE_C99 define not being set.

This StdBasicString header adds the disabled code block back in with the few functions removed that we can't use without C99.
Once/If the Android NDK fully supports C99, this header can be removed.
This PR is required for PR #331 as it is trying to use to_string in Source/Core/VideoBackends/OGL/FramebufferManager.cpp
