### PR TITLE
Android: Initial on-screen multitouch

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
@@ -110,27 +110,24 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 	@Override
 	public boolean onTouch(View v, MotionEvent event)
 	{
-		// Determine the button state to apply based on the MotionEvent action flag.
-		// TODO: This will not work when Axis support is added. Make sure to refactor this when that time comes
-		// The reason it won't work is that when moving an axis, you would get the event MotionEvent.ACTION_MOVE.
-		//
-		// TODO: Refactor this so we detect either Axis movements or button presses so we don't run two loops all the time.
-		//
-		int buttonState = (event.getAction() == MotionEvent.ACTION_DOWN || event.getAction() == MotionEvent.ACTION_MOVE)
-				? ButtonState.PRESSED : ButtonState.RELEASED;
-		// Check if there was a touch within the bounds of a drawable.
+		int pointerIndex = event.getActionIndex();	
 		for (InputOverlayDrawableButton button : overlayButtons)
 		{
-			if (button.getBounds().contains((int)event.getX(), (int)event.getY()))
+			// Determine the button state to apply based on the MotionEvent action flag.
+			switch(event.getAction() & MotionEvent.ACTION_MASK)
 			{
-				NativeLibrary.onTouchEvent(0, button.getId(), buttonState);
-			}
-			else
-			{
-				// Because the above code only changes the state for the button that is being touched, sliding off the
-				// button does not allow for it to be released. Release the button as soon as the touch coordinates leave
-				// the button bounds.
+			case MotionEvent.ACTION_DOWN:
+			case MotionEvent.ACTION_MOVE:
+			case MotionEvent.ACTION_POINTER_DOWN:
+				// Check if there was a touch within the bounds of a drawable.
+				if (button.getBounds().contains((int)event.getX(pointerIndex), (int)event.getY(pointerIndex)))
+					NativeLibrary.onTouchEvent(0, button.getId(), ButtonState.PRESSED);
+				else
+					NativeLibrary.onTouchEvent(0, button.getId(), ButtonState.RELEASED);
+				break;
+			default:
 				NativeLibrary.onTouchEvent(0, button.getId(), ButtonState.RELEASED);
+				break;
 			}
 		}
 

--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlayDrawableJoystick.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlayDrawableJoystick.java
@@ -61,6 +61,7 @@ public final class InputOverlayDrawableJoystick extends BitmapDrawable
 
 	public void TrackEvent(MotionEvent event)
 	{
+		//TODO: Allow joysticks to be used with a finger other than the one that first touches screen
 		int pointerIndex = event.getActionIndex();
 		if (trackid == -1)
 		{


### PR DESCRIPTION
Initial implementation of on-screen multitouch. I say initial because right now joysticks still will not work unless they are used by the first touch that enters the screen. I got rid of buttonState; it could not be used with multitouch since it could only hold the state of one button. This caused a revamp of that section of code.

This conflicts with #300; if it is merged before this I will rebase.
