### PR TITLE
Fix LTO with GCC 4.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,10 @@ endif()
 
 if(ENABLE_LTO)
 	check_and_add_flag(LTO -flto)
+	if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+		set(CMAKE_AR gcc-ar)
+		set(CMAKE_RANLIB gcc-ranlib)
+	endif()
 endif()
 
 if(APPLE)


### PR DESCRIPTION
For LTO to work, GCC 4.9 requires using the wrappers gcc-ar and gcc-ranlibs:
http://gcc.gnu.org/gcc-4.9/changes.html

CMake doesn't account for this yet:
http://public.kitware.com/pipermail/cmake-developers/2014-January/009344.html
