### PR TITLE
Move the header guard before the includes in VideoCommon's Statistics.h

### DIFF
--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -2,12 +2,12 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <vector>
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/VideoCommon.h"
-
-#pragma once
 
 struct Statistics
 {


### PR DESCRIPTION
Just a consistency thing.
