### PR TITLE
Adds support for the PP shaders in the Android UI.

### DIFF
--- a/Source/Android/res/values/strings.xml
+++ b/Source/Android/res/values/strings.xml
@@ -157,6 +157,8 @@
     <string name="FSAA_descrip">Reduces the amount of aliasing caused by rasterizing 3D graphics. This makes the rendered picture look less blocky. Heavily decreases emulation speed and sometimes causes issues.</string>
     <string name="anisotropic_filtering">Anisotropic Filtering</string>
     <string name="anisotropic_filtering_descrip">Enhances visual quality of textures that are at oblique viewing angles. Might cause issues in a small number of games.</string>
+    <string name="postprocessing_shader">Post Processing Shader</string>
+    <string name="postprocessing_shader_descrip">Apply a post-processing effect after finishing a frame.</string>
     <string name="scaled_efb_copy">Scaled EFB Copy</string>
     <string name="scaled_efb_copy_descrip">Greatly increases quality of textures generated using render to texture effects. Raising the internal resolution will improve the effect of this setting. Slightly decreases performance and possibly causes issues (although unlikely).</string>
     <string name="per_pixel_lighting">Per-Pixel Lighting</string>

--- a/Source/Android/res/xml/video_prefs.xml
+++ b/Source/Android/res/xml/video_prefs.xml
@@ -28,6 +28,11 @@
             android:summary="@string/anisotropic_filtering_descrip"
             android:title="@string/anisotropic_filtering"/>
 
+        <ListPreference
+            android:key="postProcessingShader"
+            android:summary="@string/postprocessing_shader_descrip"
+            android:title="@string/postprocessing_shader"/>
+
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="scaledEFBCopy"

--- a/Source/Android/src/org/dolphinemu/dolphinemu/DolphinEmulator.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/DolphinEmulator.java
@@ -40,6 +40,21 @@ public final class DolphinEmulator extends Activity
 		}
 	}
 
+	private void CopyAssetFolder(String assetFolder, String outputFolder)
+	{
+		try
+		{
+			for (String file : getAssets().list(assetFolder))
+			{
+				CopyAsset(assetFolder + File.separator + file, outputFolder + File.separator + file);
+			}
+		}
+		catch (IOException e)
+		{
+			Log.e("DolphinEmulator", "Failed to copy asset folder: " + assetFolder, e);
+		}
+	}
+
 	private void copyFile(InputStream in, OutputStream out) throws IOException
 	{
 		byte[] buffer = new byte[1024];
@@ -75,6 +90,7 @@ public final class DolphinEmulator extends Activity
 				CopyAsset("dsp_rom.bin",     GCDir + File.separator + "dsp_rom.bin");
 				CopyAsset("font_ansi.bin",   GCDir + File.separator + "font_ansi.bin");
 				CopyAsset("font_sjis.bin",   GCDir + File.separator + "font_sjis.bin");
+				CopyAssetFolder("Shaders", BaseDir + File.separator + "Shaders");
 			}
 
 			// Load the configuration keys set in the Dolphin ini and gfx ini files

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/UserPreferences.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/UserPreferences.java
@@ -45,6 +45,7 @@ public final class UserPreferences
 		editor.putString("internalResolution",     getConfig("gfx_opengl.ini", "Settings", "EFBScale", "2") );
 		editor.putString("FSAA",                   getConfig("gfx_opengl.ini", "Settings", "MSAA", "0"));
 		editor.putString("anisotropicFiltering",   getConfig("gfx_opengl.ini", "Enhancements", "MaxAnisotropy", "0"));
+		editor.putString("postProcessingShader",   getConfig("gfx_opengl.ini", "Enhancements", "PostProcessingShader", ""));
 		editor.putBoolean("scaledEFBCopy",         getConfig("gfx_opengl.ini", "Hacks", "EFBScaledCopy", "True").equals("True"));
 		editor.putBoolean("perPixelLighting",      getConfig("gfx_opengl.ini", "Settings", "EnablePixelLighting", "False").equals("True"));
 		editor.putBoolean("forceTextureFiltering", getConfig("gfx_opengl.ini", "Enhancements", "ForceFiltering", "False").equals("True"));
@@ -161,6 +162,9 @@ public final class UserPreferences
 		// Anisotropic Filtering Level. Falls back to 1x upon error.
 		String anisotropicFiltLevel = prefs.getString("anisotropicFiltering", "0");
 
+		// Post processing shader setting
+		String postProcessing = prefs.getString("postProcessingShader", "");
+
 		// Whether or not Scaled EFB copies are used.
 		boolean usingScaledEFBCopy = prefs.getBoolean("scaledEFBCopy", true);
 
@@ -237,6 +241,7 @@ public final class UserPreferences
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Settings", "EFBScale", internalResolution);
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Settings", "MSAA", FSAALevel);
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Enhancements", "MaxAnisotropy", anisotropicFiltLevel);
+		NativeLibrary.SetConfig("gfx_opengl.ini", "Enhancements", "PostProcessingShader", postProcessing);
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Hacks", "EFBScaledCopy", usingScaledEFBCopy ? "True" : "False");
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Settings", "EnablePixelLighting", usingPerPixelLighting ? "True" : "False");
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Enhancements", "ForceFiltering", isForcingTextureFiltering ? "True" : "False");

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/video/VideoSettingsFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/video/VideoSettingsFragment.java
@@ -11,6 +11,7 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.os.Bundle;
+import android.os.Environment;
 import android.preference.ListPreference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
@@ -18,6 +19,10 @@ import android.preference.PreferenceScreen;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.utils.EGLHelper;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.microedition.khronos.opengles.GL10;
 
@@ -54,7 +59,36 @@ public final class VideoSettingsFragment extends PreferenceFragment
 			videoBackends.setEntries(R.array.videoBackendEntriesNoGLES3);
 			videoBackends.setEntryValues(R.array.videoBackendValuesNoGLES3);
 		}
-		
+
+		//
+		// Set available post processing shaders
+		//
+		File[] shaders = new File(Environment.getExternalStorageDirectory()+ File.separator+"dolphin-emu"+ File.separator+"Shaders").listFiles();
+		List<CharSequence> shader_names = new ArrayList<CharSequence>();
+		List<CharSequence> shader_values = new ArrayList<CharSequence>();
+
+		// Disabled option
+		shader_names.add("Disabled");
+		shader_values.add("");
+
+		for (File file : shaders)
+		{
+			if (file.isFile())
+			{
+				String filename = file.getName();
+				if (filename.contains(".glsl"))
+				{
+					// Strip the extension and put it in to the list
+					shader_names.add(filename.substring(0, filename.lastIndexOf('.')));
+					shader_values.add(filename.substring(0, filename.lastIndexOf('.')));
+				}
+			}
+		}
+
+		final ListPreference shader_preference = (ListPreference) findPreference("postProcessingShader");
+		shader_preference.setEntries(shader_names.toArray(new CharSequence[shader_names.size()]));
+		shader_preference.setEntryValues(shader_values.toArray(new CharSequence[shader_values.size()]));
+
 		//
 		// Disable all options if Software Rendering is used.
 		//

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -205,6 +205,9 @@ if(ANDROID)
 	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
 		COMMAND cp ARGS ${CMAKE_SOURCE_DIR}/Data/Sys/GC/* ${CMAKE_SOURCE_DIR}/Source/Android/assets/
 	)
+	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
+		COMMAND cp ARGS -r ${CMAKE_SOURCE_DIR}/Data/Sys/Shaders ${CMAKE_SOURCE_DIR}/Source/Android/assets/
+	)
 else()
 	add_executable(${DOLPHIN_EXE} ${SRCS})
 	target_link_libraries(${DOLPHIN_EXE} ${LIBS} ${WXLIBS})

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -357,6 +357,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_CreateUserFo
 	File::CreateFullPath(File::GetUserPath(D_SCREENSHOTS_IDX));
 	File::CreateFullPath(File::GetUserPath(D_STATESAVES_IDX));
 	File::CreateFullPath(File::GetUserPath(D_MAILLOGS_IDX));
+	File::CreateFullPath(File::GetUserPath(D_SHADERS_IDX));
 	File::CreateFullPath(File::GetUserPath(D_GCUSER_IDX) + USA_DIR DIR_SEP);
 	File::CreateFullPath(File::GetUserPath(D_GCUSER_IDX) + EUR_DIR DIR_SEP);
 	File::CreateFullPath(File::GetUserPath(D_GCUSER_IDX) + JAP_DIR DIR_SEP);


### PR DESCRIPTION
Copies over the PP shaders to the APK's assets and installs them on run.
Exposes them via the video settings UI.

This is in anticipation of dropping the workaround for rotated blits on Adreno and instead forcing shader usage by the user.
