### PR TITLE
Fixes our post processing shaders so they work under OpenGL ES 3.0

### DIFF
--- a/Data/Sys/Shaders/16bit.glsl
+++ b/Data/Sys/Shaders/16bit.glsl
@@ -8,7 +8,7 @@ uniform vec4 resolution;
 void main()
 {
   //Change this number to increase the pixel size.
-  float pixelSize = 3;
+  float pixelSize = 3.0;
 
   float red   = 0.0;
   float green = 0.0;

--- a/Data/Sys/Shaders/32bit.glsl
+++ b/Data/Sys/Shaders/32bit.glsl
@@ -8,7 +8,7 @@ uniform vec4 resolution;
 void main()
 {
   //Change this number to increase the pixel size.
-  float pixelSize = 2;
+  float pixelSize = 2.0;
 
   float red   = 0.0;
   float green = 0.0;

--- a/Data/Sys/Shaders/acidtrip.glsl
+++ b/Data/Sys/Shaders/acidtrip.glsl
@@ -7,5 +7,5 @@ uniform vec4 resolution;
 
 void main()
 {
-  ocol0 = (texture(samp9, uv0+resolution.zw) - texture(samp9, uv0-resolution.zw))*8;
+  ocol0 = (texture(samp9, uv0+resolution.zw) - texture(samp9, uv0-resolution.zw)) * 8.0;
 }

--- a/Data/Sys/Shaders/acidtrip2.glsl
+++ b/Data/Sys/Shaders/acidtrip2.glsl
@@ -9,5 +9,5 @@ void main()
 {
   vec4 a = texture(samp9, uv0+resolution.zw);
   vec4 b = texture(samp9, uv0-resolution.zw);
-  ocol0 = ( a*a*1.3 - b )*8;
+  ocol0 = ( a*a*1.3 - b ) * 8.0;
 }

--- a/Data/Sys/Shaders/asciiart.glsl
+++ b/Data/Sys/Shaders/asciiart.glsl
@@ -6,7 +6,7 @@ const int char_height = 13;
 const int char_count = 95;
 const int char_pixels = char_width*char_height;
 const vec2 char_dim = vec2(char_width, char_height);
-const vec2 font_scale = vec2(1.0/char_width/char_count, 1.0/char_height);
+const vec2 font_scale = vec2(1.0/float(char_width)/float(char_count), 1.0/float(char_height));
 
 out vec4 ocol0;
 in vec2 uv0;
@@ -18,7 +18,7 @@ void main()
   vec2 char_pos = floor(uv0*resolution.xy/char_dim);
   vec2 pixel_offset = floor(uv0*resolution.xy) - char_pos*char_dim;
 
-  float mindiff = char_width*char_height*100; // just a big number
+  float mindiff = float(char_width*char_height) * 100.0; // just a big number
   float minc = 0.0;
   vec4 mina = vec4(0.0, 0.0, 0.0, 0.0);
   vec4 minb = vec4(0.0, 0.0, 0.0, 0.0);
@@ -74,21 +74,21 @@ void main()
       
       So, both equations must be zero at minimum and there is only one solution.
     */
-    vec4 a = (f*ft - ff*t + f*t - ft*char_pixels) / (f*f  - ff*char_pixels);
-    vec4 b = (f*ft - ff*t)                        / (f*f  - ff*char_pixels);
+    vec4 a = (f*ft - ff*t + f*t - ft*float(char_pixels)) / (f*f  - ff*float(char_pixels));
+    vec4 b = (f*ft - ff*t)                        / (f*f  - ff*float(char_pixels));
     
-    vec4 diff = a*a*ff + 2.0*a*b*f - 2.0*a*b*ff - 2.0*a*ft + b*b *(-2.0*f + ff + char_pixels) + 2.0*b*ft - 2.0*b*t + tt;
+    vec4 diff = a*a*ff + 2.0*a*b*f - 2.0*a*b*ff - 2.0*a*ft + b*b *(-2.0*f + ff + float(char_pixels)) + 2.0*b*ft - 2.0*b*t + tt;
     float diff_f = dot(diff, vec4(1.0, 1.0, 1.0, 1.0));
     
     if(diff_f < mindiff) {
       mindiff = diff_f;
-      minc = i;
+      minc = float(i);
       mina = a;
       minb = b;
     }
   }
   
-  vec2 font_pos_res = vec2(minc*char_width, 0) + pixel_offset + 0.5;
+  vec2 font_pos_res = vec2(minc * float(char_width), 0.0) + pixel_offset + 0.5;
 
   vec4 col = texture(samp8, font_pos_res * font_scale);
   ocol0 = mina * col + minb * (vec4(1.0,1.0,1.0,1.0) - col);

--- a/Data/Sys/Shaders/auto_toon2.glsl
+++ b/Data/Sys/Shaders/auto_toon2.glsl
@@ -18,7 +18,7 @@ void main()
   float edge = (x1 - x0) * (x1 - x0) + (x3 - x2) * (x3 - x2);
   float4 color = texture(samp9, uv0).rgba;
 
-  float4 c0 = color - float4(edge, edge, edge, edge) * 12;
+  float4 c0 = color - float4(edge, edge, edge, edge) * 12.0;
 
  
 
@@ -35,7 +35,7 @@ void main()
 
 	 
 	 for(count = 1; count <= numColors ; count++){
-		 colorN = count / numColors;
+		 colorN = float(count / numColors);
 		 
 		 if ( c0.r <= colorN && c0.r >= colorB && rr == false ){
 			if (count == 1){
@@ -81,7 +81,7 @@ void main()
 			 gg = true;
 		}
 			
-		colorB = count / numColors;
+		colorB = float(count / numColors);
 		if(rr == true && bb == true && gg == true)
 			break;
 	}

--- a/Data/Sys/Shaders/bad_bloom.glsl
+++ b/Data/Sys/Shaders/bad_bloom.glsl
@@ -13,31 +13,31 @@ void main()
   vec2 pos = uv0 + float2(0.3, 0.3) * resolution.zw;
   float2 radius1 = 1.3 * resolution.zw;
   bloom_sum += texture(samp9, pos + float2(-1.5, -1.5) * radius1);
-  bloom_sum += texture(samp9, pos + float2(-2.5, 0)  * radius1);
+  bloom_sum += texture(samp9, pos + float2(-2.5, 0.0)  * radius1);
   bloom_sum += texture(samp9, pos + float2(-1.5, 1.5) * radius1);
-  bloom_sum += texture(samp9, pos + float2(0, 2.5) * radius1);
+  bloom_sum += texture(samp9, pos + float2(0.0, 2.5) * radius1);
   bloom_sum += texture(samp9, pos + float2(1.5, 1.5) * radius1);
-  bloom_sum += texture(samp9, pos + float2(2.5, 0) * radius1);
+  bloom_sum += texture(samp9, pos + float2(2.5, 0.0) * radius1);
   bloom_sum += texture(samp9, pos + float2(1.5, -1.5) * radius1);
-  bloom_sum += texture(samp9, pos + float2(0, -2.5) * radius1);
+  bloom_sum += texture(samp9, pos + float2(0.0, -2.5) * radius1);
 
   float2 radius2 = 4.6 * resolution.zw;
   bloom_sum += texture(samp9, pos + float2(-1.5, -1.5) * radius2);
-  bloom_sum += texture(samp9, pos + float2(-2.5, 0)  * radius2);
+  bloom_sum += texture(samp9, pos + float2(-2.5, 0.0)  * radius2);
   bloom_sum += texture(samp9, pos + float2(-1.5, 1.5)  * radius2);
-  bloom_sum += texture(samp9, pos + float2(0, 2.5)  * radius2);
+  bloom_sum += texture(samp9, pos + float2(0.0, 2.5)  * radius2);
   bloom_sum += texture(samp9, pos + float2(1.5, 1.5)  * radius2);
-  bloom_sum += texture(samp9, pos + float2(2.5, 0)  * radius2);
+  bloom_sum += texture(samp9, pos + float2(2.5, 0.0)  * radius2);
   bloom_sum += texture(samp9, pos + float2(1.5, -1.5)  * radius2);
-  bloom_sum += texture(samp9, pos + float2(0, -2.5)  * radius2);
+  bloom_sum += texture(samp9, pos + float2(0.0, -2.5)  * radius2);
 
   bloom_sum *= 0.07;
   bloom_sum -= float4(0.3, 0.3, 0.3, 0.3);
-  bloom_sum = max(bloom_sum, float4(0,0,0,0));
+  bloom_sum = max(bloom_sum, float4(0.0, 0.0, 0.0, 0.0));
 
-  float2 vpos = (uv0 - float2(.5, .5)) * 2;
+  float2 vpos = (uv0 - float2(0.5, 0.5)) * 2.0;
   float dist = (dot(vpos, vpos));
-  dist = 1 - 0.4*dist;
+  dist = 1.0 - 0.4*dist;
 
   ocol0 = (c_center * 0.7 + bloom_sum) * dist;
 }

--- a/Data/Sys/Shaders/brighten.glsl
+++ b/Data/Sys/Shaders/brighten.glsl
@@ -5,5 +5,5 @@ in vec2 uv0;
 
 void main()
 {
-	ocol0 = texture(samp9, uv0) * 3;
+	ocol0 = texture(samp9, uv0) * 3.0;
 }

--- a/Data/Sys/Shaders/chrismas.glsl
+++ b/Data/Sys/Shaders/chrismas.glsl
@@ -10,7 +10,7 @@ void main()
 	float green = 0.0;
 
 	if (c0.r < 0.35 || c0.b > 0.35)
-		green = c0.g + (c0.b / 2);
+		green = c0.g + (c0.b / 2.0);
 	else
 		red = c0.r + 0.4;
 	ocol0 = vec4(red, green, 0.0, 1.0);

--- a/Data/Sys/Shaders/darkerbrighter.glsl
+++ b/Data/Sys/Shaders/darkerbrighter.glsl
@@ -8,34 +8,34 @@ uniform vec4 resolution;
 void main()
 {
   float4 c0 = texture(samp9, uv0);
-  float4 c1 = texture(samp9, uv0 - float2(1, 0)*resolution.zw);
-  float4 c2 = texture(samp9, uv0 - float2(0, 1)*resolution.zw);
-  float4 c3 = texture(samp9, uv0 + float2(1, 0)*resolution.zw);
-  float4 c4 = texture(samp9, uv0 + float2(0, 1)*resolution.zw);
+  float4 c1 = texture(samp9, uv0 - float2(1.0, 0.0)*resolution.zw);
+  float4 c2 = texture(samp9, uv0 - float2(0.0, 1.0)*resolution.zw);
+  float4 c3 = texture(samp9, uv0 + float2(1.0, 0.0)*resolution.zw);
+  float4 c4 = texture(samp9, uv0 + float2(0.0, 1.0)*resolution.zw);
 
   float red = c0.r;
   float blue = c0.b;
   float green = c0.g;
 
-  float red2 = (c1.r + c2.r + c3.r + c4.r) / 4;
-  float blue2 = (c1.b + c2.b + c3.b + c4.b) / 4;
-  float green2 = (c1.g + c2.g + c3.g + c4.g) / 4;
+  float red2 = (c1.r + c2.r + c3.r + c4.r) / 4.0;
+  float blue2 = (c1.b + c2.b + c3.b + c4.b) / 4.0;
+  float green2 = (c1.g + c2.g + c3.g + c4.g) / 4.0;
 
  	if(red2 > 0.3)
-		red = c0.r + c0.r /  2 ;
+		red = c0.r + c0.r /  2.0;
 	 else
-		red = c0.r - c0.r /  2 ;
+		red = c0.r - c0.r /  2.0;
 
 	if(green2 >  0.3)
-		green = c0.g+ c0.g / 2;
+		green = c0.g+ c0.g / 2.0;
 	 else
-		green = c0.g - c0.g / 2;
+		green = c0.g - c0.g / 2.0;
 	
 		
 	if(blue2  >  0.3)
-		blue = c0.b+ c0.b / 2 ;
+		blue = c0.b+ c0.b / 2.0;
 	  else
-		blue = c0.b - c0.b / 2 ;
+		blue = c0.b - c0.b / 2.0;
 	
   ocol0 = float4(red, green, blue, c0.a);
 }

--- a/Data/Sys/Shaders/emboss.glsl
+++ b/Data/Sys/Shaders/emboss.glsl
@@ -8,17 +8,17 @@ uniform vec4 resolution;
 void main()
 {
   float4 c0 = texture(samp9, uv0).rgba;
-  float4 c1 = texture(samp9, uv0 + float2(5,5)*resolution.zw).rgba;
+  float4 c1 = texture(samp9, uv0 + float2(5.0,5.0)*resolution.zw).rgba;
   float y = (0.222 * c1.r) + (0.707 * c1.g) + (0.071 * c1.b);
-  float y2 = ((0.222 * c0.r) + (0.707 * c0.g) + (0.071 * c0.b)) / 3;
+  float y2 = ((0.222 * c0.r) + (0.707 * c0.g) + (0.071 * c0.b)) / 3.0;
   float red   = c0.r;
   float green = c0.g;
   float blue  = c0.b;
   float alpha = c0.a;
   
-  red   = y2 + (1 - y);
-  green = y2 + (1 - y);
-  blue  = y2 + (1 - y);
+  red   = y2 + (1.0 - y);
+  green = y2 + (1.0 - y);
+  blue  = y2 + (1.0 - y);
 
   ocol0 = float4(red, green, blue, alpha);
 }

--- a/Data/Sys/Shaders/fire.glsl
+++ b/Data/Sys/Shaders/fire.glsl
@@ -15,22 +15,22 @@ void main()
 
 	if (c0.r > 0.0)
 	if (c0.g > c0.r)
-		green = (c0.g - (c0.g - c0.r)) / 3;
+		green = (c0.g - (c0.g - c0.r)) / 3.0;
 
 	if (c0.b > 0.0 && c0.r < 0.25)
 	{
 		red = c0.b;
-		green = c0.b / 3;
+		green = c0.b / 3.0;
 	}
 
 	if (c0.g > 0.0 && c0.r < 0.25)
 	{
 		red = c0.g;
-		green = c0.g / 3;
+		green = c0.g / 3.0;
 	}
 
-	if (((c0.r + c0.g + c0.b) / 3) > 0.9)
-		green = c0.r / 3;
+	if (((c0.r + c0.g + c0.b) / 3.0) > 0.9)
+		green = c0.r / 3.0;
 
 	ocol0 = vec4(red, green, blue, 1.0);
 }

--- a/Data/Sys/Shaders/fire2.glsl
+++ b/Data/Sys/Shaders/fire2.glsl
@@ -9,10 +9,10 @@ void main()
 	float red   = 0.0;
 	float green = 0.0;
 	float blue  = 0.0;
-	float avg = (c0.r + c0.g + c0.b) / 3;
+	float avg = (c0.r + c0.g + c0.b) / 3.0;
 
-	red = c0.r + (c0.g / 2) + (c0.b / 3);
-	green = c0.r / 3;
+	red = c0.r + (c0.g / 2.0) + (c0.b / 3.0);
+	green = c0.r / 3.0;
 
 	ocol0 = vec4(red, green, blue, 1.0);
 }

--- a/Data/Sys/Shaders/nightvision2.glsl
+++ b/Data/Sys/Shaders/nightvision2.glsl
@@ -8,19 +8,19 @@ uniform vec4 resolution;
 void main()
 {
   //variables
-  int internalresolution = 1278;
+  float internalresolution = 1278.0;
   float4 c0 = texture(samp9, uv0).rgba;
   //blur
-  float4 blurtotal = float4(0, 0, 0, 0);
+  float4 blurtotal = float4(0.0, 0.0, 0.0, 0.0);
   float blursize = 1.5;
   blurtotal += texture(samp9, uv0 + float2(-blursize, -blursize)*resolution.zw);
   blurtotal += texture(samp9, uv0 + float2(-blursize,  blursize)*resolution.zw);
   blurtotal += texture(samp9, uv0 + float2( blursize, -blursize)*resolution.zw);
   blurtotal += texture(samp9, uv0 + float2( blursize,  blursize)*resolution.zw);
-  blurtotal += texture(samp9, uv0 + float2(-blursize,  0)*resolution.zw);
-  blurtotal += texture(samp9, uv0 + float2( blursize,  0)*resolution.zw);
-  blurtotal += texture(samp9, uv0 + float2( 0, -blursize)*resolution.zw);
-  blurtotal += texture(samp9, uv0 + float2( 0,  blursize)*resolution.zw);
+  blurtotal += texture(samp9, uv0 + float2(-blursize,  0.0)*resolution.zw);
+  blurtotal += texture(samp9, uv0 + float2( blursize,  0.0)*resolution.zw);
+  blurtotal += texture(samp9, uv0 + float2( 0.0, -blursize)*resolution.zw);
+  blurtotal += texture(samp9, uv0 + float2( 0.0,  blursize)*resolution.zw);
   blurtotal *= 0.125;
   c0 = blurtotal;
   //greyscale
@@ -30,27 +30,27 @@ void main()
   // darken edges
   float x = uv0.x * resolution.x;
   float y = uv0.y * resolution.y;
-  if (x > internalresolution/2) x = internalresolution-x;
-  if (y > internalresolution/2) y = internalresolution-y;
-  if (x > internalresolution/2*0.95) x = internalresolution/2*0.95;
-  if (y > internalresolution/2*0.95) y = internalresolution/2*0.95;
-  x = -x+641;
-  y = -y+641;
+  if (x > internalresolution/2.0) x = internalresolution-x;
+  if (y > internalresolution/2.0) y = internalresolution-y;
+  if (x > internalresolution/2.0*0.95) x = internalresolution/2.0*0.95;
+  if (y > internalresolution/2.0*0.95) y = internalresolution/2.0*0.95;
+  x = -x+641.0;
+  y = -y+641.0;
   /*****inline square root routines*****/
   // bit of a performance bottleneck.
   // neccessary to make the darkened area rounded
   // instead of rhombus-shaped.
-  float sqrt=x/10;
+  float sqrt = x / 10.0;
   while((sqrt*sqrt) < x) sqrt+=0.1;
   x = sqrt;
-  sqrt=y/10;
+  sqrt = y / 10.0;
   while((sqrt*sqrt) < y) sqrt+=0.1;
   y = sqrt;
   /*****end of inline square root routines*****/
-  x *= 2;
-  y *= 2;
-  grey -= x/200;
-  grey -= y/200;
+  x *= 2.0;
+  y *= 2.0;
+  grey -= x / 200.0;
+  grey -= y / 200.0;
   // output
-  ocol0 = float4(0, grey, 0, 1.0);
+  ocol0 = float4(0.0, grey, 0.0, 1.0);
 }

--- a/Data/Sys/Shaders/nightvision2scanlines.glsl
+++ b/Data/Sys/Shaders/nightvision2scanlines.glsl
@@ -8,19 +8,19 @@ uniform vec4 resolution;
 void main()
 {
   //variables
-  int internalresolution = 1278;
+  float internalresolution = 1278.0;
   float4 c0 = texture(samp9, uv0).rgba;
   //blur
-  float4 blurtotal = float4(0, 0, 0, 0);
+  float4 blurtotal = float4(0.0, 0.0, 0.0, 0.0);
   float blursize = 1.5;
   blurtotal += texture(samp9, uv0 + float2(-blursize, -blursize)*resolution.zw);
   blurtotal += texture(samp9, uv0 + float2(-blursize,  blursize)*resolution.zw);
   blurtotal += texture(samp9, uv0 + float2( blursize, -blursize)*resolution.zw);
   blurtotal += texture(samp9, uv0 + float2( blursize,  blursize)*resolution.zw);
-  blurtotal += texture(samp9, uv0 + float2(-blursize,  0)*resolution.zw);
-  blurtotal += texture(samp9, uv0 + float2( blursize,  0)*resolution.zw);
-  blurtotal += texture(samp9, uv0 + float2( 0, -blursize)*resolution.zw);
-  blurtotal += texture(samp9, uv0 + float2( 0,  blursize)*resolution.zw);
+  blurtotal += texture(samp9, uv0 + float2(-blursize,  0.0)*resolution.zw);
+  blurtotal += texture(samp9, uv0 + float2( blursize,  0.0)*resolution.zw);
+  blurtotal += texture(samp9, uv0 + float2( 0.0, -blursize)*resolution.zw);
+  blurtotal += texture(samp9, uv0 + float2( 0.0,  blursize)*resolution.zw);
   blurtotal *= 0.125;
   c0 = blurtotal;
   //greyscale
@@ -29,33 +29,33 @@ void main()
   // This would have been much simpler if I could get the stupid modulo (%) to work
   // If anyone who is more well versed in Cg knows how to do this it'd be slightly more efficient
   // float lineIntensity = ((uv0[1] % 9) - 4) / 40;
-  float vPos = uv0.y*resolution.y / 9;
-  float lineIntensity = (((vPos - floor(vPos)) * 9) - 4) / 40;
+  float vPos = uv0.y*resolution.y / 9.0;
+  float lineIntensity = (((vPos - floor(vPos)) * 9.0) - 4.0) / 40.0;
   grey = grey * 0.5 + 0.7 + lineIntensity;
   // darken edges
   float x = uv0.x * resolution.x;
   float y = uv0.y * resolution.y;
-  if (x > internalresolution/2) x = internalresolution-x;
-  if (y > internalresolution/2) y = internalresolution-y;
-  if (x > internalresolution/2*0.95) x = internalresolution/2*0.95;
-  if (y > internalresolution/2*0.95) y = internalresolution/2*0.95;
-  x = -x+641;
-  y = -y+641;
+  if (x > internalresolution/2.0) x = internalresolution-x;
+  if (y > internalresolution/2.0) y = internalresolution-y;
+  if (x > internalresolution/2.0*0.95) x = internalresolution/2.0*0.95;
+  if (y > internalresolution/2.0*0.95) y = internalresolution/2.0*0.95;
+  x = -x + 641.0;
+  y = -y + 641.0;
   /*****inline square root routines*****/
   // bit of a performance bottleneck.
   // neccessary to make the darkened area rounded
   // instead of rhombus-shaped.
-  float sqrt=x/10;
+  float sqrt = x / 10.0;
   while((sqrt*sqrt) < x) sqrt+=0.1;
   x = sqrt;
-  sqrt=y/10;
+  sqrt = y / 10.0;
   while((sqrt*sqrt) < y) sqrt+=0.1;
   y = sqrt;
   /*****end of inline square root routines*****/
-  x *= 2;
-  y *= 2;
-  grey -= x/200;
-  grey -= y/200;
+  x *= 2.0;
+  y *= 2.0;
+  grey -= x / 200.0;
+  grey -= y / 200.0;
   // output
-  ocol0 = float4(0, grey, 0, 1.0);
+  ocol0 = float4(0.0, grey, 0.0, 1.0);
 }

--- a/Data/Sys/Shaders/primarycolors.glsl
+++ b/Data/Sys/Shaders/primarycolors.glsl
@@ -9,7 +9,7 @@ void main()
 	float red = c0.r;
 	float blue = c0.b;
 	float green = c0.g;
-	float factor = 2;
+	float factor = 2.0;
 	float max = 0.8;
 	float min = 0.3;
 

--- a/Data/Sys/Shaders/sketchy.glsl
+++ b/Data/Sys/Shaders/sketchy.glsl
@@ -8,15 +8,15 @@ uniform vec4 resolution;
 void main()
 {
   float4 c0 = texture(samp9, uv0).rgba;
-  float4 tmp = float4(0, 0, 0, 0);
-  tmp += c0 - texture(samp9, uv0 + float2(2, 2)*resolution.zw).rgba;
-  tmp += c0 - texture(samp9, uv0 - float2(2, 2)*resolution.zw).rgba;
-  tmp += c0 - texture(samp9, uv0 + float2(2, -2)*resolution.zw).rgba;
-  tmp += c0 - texture(samp9, uv0 - float2(2, -2)*resolution.zw).rgba;
+  float4 tmp = float4(0.0, 0.0, 0.0, 0.0);
+  tmp += c0 - texture(samp9, uv0 + float2(2.0, 2.0)*resolution.zw).rgba;
+  tmp += c0 - texture(samp9, uv0 - float2(2.0, 2.0)*resolution.zw).rgba;
+  tmp += c0 - texture(samp9, uv0 + float2(2.0, -2.0)*resolution.zw).rgba;
+  tmp += c0 - texture(samp9, uv0 - float2(2.0, -2.0)*resolution.zw).rgba;
   float grey = ((0.222 * tmp.r) + (0.707 * tmp.g) + (0.071 * tmp.b));
   // get rid of the bottom line, as it is incorrect.
-  if (uv0.y*resolution.y < 163)
+  if (uv0.y*resolution.y < 163.0)
     tmp = float4(1.0, 1.0, 1.0, 1.0);
-  c0 = c0+1-grey*7.0;
-  ocol0 = float4(c0.r, c0.g, c0.b, 1);
+  c0 = c0 + 1.0 - grey * 7.0;
+  ocol0 = float4(c0.r, c0.g, c0.b, 1.0);
 }

--- a/Data/Sys/Shaders/stereoscopic.glsl
+++ b/Data/Sys/Shaders/stereoscopic.glsl
@@ -11,19 +11,19 @@ uniform vec4 resolution;
 void main()
 {
   float4 c0 = texture(samp9, uv0).rgba; // Source Color
-  float sep = 5;
+  float sep = 5.0;
   float red   = c0.r;
   float green = c0.g;
   float blue  = c0.b;
  
   
   // Left Eye (Red)
-  float4 c1 = texture(samp9, uv0 + float2(sep,0)*resolution.zw).rgba;
+  float4 c1 = texture(samp9, uv0 + float2(sep,0.0)*resolution.zw).rgba;
   red = max(c0.r, c1.r);
 
   // Right Eye (Cyan)
-  float4 c2 = texture(samp9, uv0 + float2(-sep,0)*resolution.zw).rgba;
-  float cyan = (c2.g + c2.b) / 2;
+  float4 c2 = texture(samp9, uv0 + float2(-sep,0.0)*resolution.zw).rgba;
+  float cyan = (c2.g + c2.b) / 2.0;
   green = max(c0.g, cyan);
   blue = max(c0.b, cyan);
 

--- a/Data/Sys/Shaders/stereoscopic2.glsl
+++ b/Data/Sys/Shaders/stereoscopic2.glsl
@@ -11,20 +11,20 @@ uniform vec4 resolution;
 void main()
 {
   float4 c0 = texture(samp9, uv0).rgba; // Source Color
-  float sep = 5;
+  float sep = 5.0;
   float red   = c0.r;
   float green = c0.g;
   float blue  = c0.b;
 
   
   // Left Eye (Amber)
-  float4 c2 = texture(samp9, uv0 + float2(sep,0)*resolution.zw).rgba;
-  float amber = (c2.r + c2.g) / 2;
+  float4 c2 = texture(samp9, uv0 + float2(sep,0.0)*resolution.zw).rgba;
+  float amber = (c2.r + c2.g) / 2.0;
   red = max(c0.r, amber);
   green = max(c0.g, amber);
 
   // Right Eye (Blue)
-  float4 c1 = texture(samp9, uv0 + float2(-sep,0)*resolution.zw).rgba;
+  float4 c1 = texture(samp9, uv0 + float2(-sep,0.0)*resolution.zw).rgba;
   blue = max(c0.b, c1.b);
 
   

--- a/Data/Sys/Shaders/sunset.glsl
+++ b/Data/Sys/Shaders/sunset.glsl
@@ -6,5 +6,5 @@ in vec2 uv0;
 void main()
 {
 	vec4 c0 = texture(samp9, uv0);
-	ocol0 = vec4(c0.r * 1.5, c0.g * 1, c0.b * 0.5, c0.a);
+	ocol0 = vec4(c0.r * 1.5, c0.g, c0.b * 0.5, c0.a);
 }

--- a/Data/Sys/Shaders/toxic.glsl
+++ b/Data/Sys/Shaders/toxic.glsl
@@ -13,7 +13,7 @@ void main()
 	if (c0.r < 0.3 || c0.b > 0.5)
 	{
 		blue = c0.r + c0.b;
-		red = c0.g + c0.b / 2;
+		red = c0.g + c0.b / 2.0;
 	}
 	else
 	{


### PR DESCRIPTION
Most of our shaders relied on implicit int->float conversions.
This fixes the assumption that this is allowed
