### PR TITLE
Software backend: buffer overflow in Clipper.

### DIFF
--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -45,7 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Clipper
 {
-	enum { NUM_CLIPPED_VERTICES = 33, NUM_INDICES = NUM_CLIPPED_VERTICES + 3 };
+	enum { NUM_CLIPPED_VERTICES = 60, NUM_INDICES = NUM_CLIPPED_VERTICES + 3 };
 
 	float m_ViewOffset[2];
 
@@ -181,7 +181,7 @@ namespace Clipper
 		{
 			for (int i = 0; i < 3; i += 3)
 			{
-				int vlist[2][2*6+1];
+				int vlist[2][2*6+1+100];
 				int *inlist = vlist[0], *outlist = vlist[1];
 				int n = 3;
 				int numVertices = 3;
@@ -278,7 +278,15 @@ namespace Clipper
 
 		int indices[NUM_INDICES] = { 0, 1, 2, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
 										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
-										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG };
+										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
+										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
+										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
+										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
+										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
+										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
+										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
+										SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG, SKIP_FLAG,
+		};
 		int numIndices = 3;
 
 		if (backface)


### PR DESCRIPTION
I'm not sure these values are correct, (actually, they're basically arbitrary) but the current values appear to be too small.

See http://www.mediafire.com/download/tzedi36ts7746ze/beyondgoodandevilfifolog.7z to reproduce overflow.

Not really ready to be pulled without a real justification for the bounds, but I don't want to forget about this.
