### PR TITLE
Opcode decoding: 0xC0 isn't a valid command.

### DIFF
--- a/Source/Core/VideoBackends/Software/OpcodeDecoder.cpp
+++ b/Source/Core/VideoBackends/Software/OpcodeDecoder.cpp
@@ -201,7 +201,7 @@ void DecodeStandard(u32 bufferSize)
 
 	// draw primitives
 	default:
-		if (Cmd & 0x80)
+		if ((Cmd & 0xC0) == 0x80)
 		{
 			u8 vatIndex = Cmd & GX_VAT_MASK;
 			u8 primitiveType = (Cmd & GX_PRIMITIVE_MASK) >> GX_PRIMITIVE_SHIFT;
@@ -283,7 +283,7 @@ bool CommandRunnable(u32 iBufferSize)
 
 		// draw primitives
 		default:
-			if (Cmd & 0x80)
+			if ((Cmd & 0xC0) == 0x80)
 				minSize = 3;
 			break;
 		}

--- a/Source/Core/VideoBackends/Software/OpcodeDecoder.h
+++ b/Source/Core/VideoBackends/Software/OpcodeDecoder.h
@@ -23,7 +23,7 @@ namespace OpcodeDecoder
 	#define GX_CMD_CALL_DL              0x40
 	#define GX_CMD_INVL_VC              0x48
 
-	#define GX_PRIMITIVE_MASK           0x78
+	#define GX_PRIMITIVE_MASK           0x38
 	#define GX_PRIMITIVE_SHIFT          3
 	#define GX_VAT_MASK                 0x07
 

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -201,7 +201,7 @@ u32 FifoCommandRunnable(u32 &command_size)
 		break;
 
 	default:
-		if (cmd_byte & 0x80)
+		if ((cmd_byte & 0xC0) == 0x80)
 		{
 			// check if we can read the header
 			if (buffer_size >= 3)
@@ -346,7 +346,7 @@ static void Decode()
 
 	// draw primitives
 	default:
-		if (cmd_byte & 0x80)
+		if ((cmd_byte & 0xC0) == 0x80)
 		{
 			// load vertices (use computed vertex size from FifoCommandRunnable above)
 			u16 numVertices = DataReadU16();
@@ -434,7 +434,7 @@ static void DecodeSemiNop()
 
 	// draw primitives
 	default:
-		if (cmd_byte & 0x80)
+		if ((cmd_byte & 0xC0) == 0x80)
 		{
 			// load vertices (use computed vertex size from FifoCommandRunnable above)
 			u16 numVertices = DataReadU16();


### PR DESCRIPTION
Fix our opcode decoders to handle this appropriately.

Redone version of #321.
