### PR TITLE
Fixes games that use the MMU to page in code(Rogue Leader).

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -406,9 +406,6 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 {
 	int blockSize = code_buf->GetSize();
 
-	// Memory exception on instruction fetch
-	bool memory_exception = false;
-
 	if (Core::g_CoreStartupParameter.bEnableDebugging)
 	{
 		// Comment out the following to disable breakpoints (speed-up)
@@ -417,21 +414,6 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 			if (GetState() == CPU_STEPPING)
 				blockSize = 1;
 			Trace();
-		}
-	}
-
-	if (em_address == 0)
-	{
-		// Memory exception occurred during instruction fetch
-		memory_exception = true;
-	}
-
-	if (Core::g_CoreStartupParameter.bMMU && (em_address & JIT_ICACHE_VMEM_BIT))
-	{
-		if (!Memory::TranslateAddress(em_address, Memory::FLAG_OPCODE))
-		{
-			// Memory exception occurred during instruction fetch
-			memory_exception = true;
 		}
 	}
 
@@ -448,9 +430,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	u32 nextPC = em_address;
 	// Analyze the block, collect all instructions it is made of (including inlining,
 	// if that is enabled), reorder instructions for optimal performance, and join joinable instructions.
-	if (!memory_exception)
-		nextPC = analyzer.Analyze(em_address, &code_block, code_buf, blockSize);
-
+	nextPC = analyzer.Analyze(em_address, &code_block, code_buf, blockSize);
 
 	PPCAnalyst::CodeOp *ops = code_buf->codebuffer;
 
@@ -678,7 +658,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 		}
 	}
 
-	if (memory_exception)
+	if (code_block.m_memory_exception)
 	{
 		// Address of instruction could not be translated
 		MOV(32, M(&NPC), Imm32(js.compilerPC));

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -501,9 +501,6 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 {
 	int blockSize = code_buf->GetSize();
 
-	// Memory exception on instruction fetch
-	bool memory_exception = false;
-
 	if (Core::g_CoreStartupParameter.bEnableDebugging)
 	{
 		// Comment out the following to disable breakpoints (speed-up)
@@ -512,21 +509,6 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 			if (GetState() == CPU_STEPPING)
 				blockSize = 1;
 			Trace();
-		}
-	}
-
-	if (em_address == 0)
-	{
-		// Memory exception occurred during instruction fetch
-		memory_exception = true;
-	}
-
-	if (Core::g_CoreStartupParameter.bMMU && (em_address & JIT_ICACHE_VMEM_BIT))
-	{
-		if (!Memory::TranslateAddress(em_address, Memory::FLAG_OPCODE))
-		{
-			// Memory exception occurred during instruction fetch
-			memory_exception = true;
 		}
 	}
 
@@ -541,8 +523,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	u32 nextPC = em_address;
 	// Analyze the block, collect all instructions it is made of (including inlining,
 	// if that is enabled), reorder instructions for optimal performance, and join joinable instructions.
-	if (!memory_exception)
-		nextPC = analyzer.Analyze(em_address, &code_block, code_buf, blockSize);
+	nextPC = analyzer.Analyze(em_address, &code_block, code_buf, blockSize);
 
 	PPCAnalyst::CodeOp *ops = code_buf->codebuffer;
 
@@ -689,7 +670,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 		}
 	}
 
-	if (memory_exception)
+	if (code_block.m_memory_exception)
 	{
 		ibuild.EmitISIException(ibuild.EmitIntConst(em_address));
 	}

--- a/Source/Core/Core/PowerPC/JitArmIL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/JitArmIL/JitIL.cpp
@@ -203,8 +203,6 @@ void STACKALIGN JitArmIL::Jit(u32 em_address)
 const u8* JitArmIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlock *b)
 {
 	int blockSize = code_buf->GetSize();
-	// Memory exception on instruction fetch
-	bool memory_exception = false;
 
 	if (Core::g_CoreStartupParameter.bEnableDebugging)
 	{
@@ -218,16 +216,6 @@ const u8* JitArmIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 		PanicAlert("ERROR: Compiling at 0. LR=%08x CTR=%08x", LR, CTR);
 	}
 
-	if (Core::g_CoreStartupParameter.bMMU && (em_address & JIT_ICACHE_VMEM_BIT))
-	{
-		if (!Memory::TranslateAddress(em_address, Memory::FLAG_OPCODE))
-		{
-			// Memory exception occurred during instruction fetch
-			memory_exception = true;
-		}
-	}
-
-
 	js.isLastInstruction = false;
 	js.blockStart = em_address;
 	js.fifoBytesThisBlock = 0;
@@ -238,8 +226,7 @@ const u8* JitArmIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 	u32 nextPC = em_address;
 	// Analyze the block, collect all instructions it is made of (including inlining,
 	// if that is enabled), reorder instructions for optimal performance, and join joinable instructions.
-	if (!memory_exception)
-		nextPC = analyzer.Analyze(em_address, &code_block, code_buf, blockSize);
+	nextPC = analyzer.Analyze(em_address, &code_block, code_buf, blockSize);
 
 	PPCAnalyst::CodeOp *ops = code_buf->codebuffer;
 
@@ -334,7 +321,7 @@ const u8* JitArmIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 				}
 		}
 	}
-	if (memory_exception)
+	if (code_block.m_memory_exception)
 		BKPT(0x500);
 
 	if (code_block.m_broken)

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -124,6 +124,9 @@ struct CodeBlock
 
 	// Are we a broken block?
 	bool m_broken;
+
+	// Did we have a memory_exception?
+	bool m_memory_exception;
 };
 
 class PPCAnalyzer


### PR DESCRIPTION
The issue was that on memory exception we wouldn't call in to PPCAnalyst and our code_block would retain the previous blocks information.
This would cause us to compile the previous blocks instructions in prior to the exception exit.
