### PR TITLE
Export wii saves to the "User" directory

### DIFF
--- a/Source/Core/DolphinWX/MemoryCards/WiiSaveCrypted.cpp
+++ b/Source/Core/DolphinWX/MemoryCards/WiiSaveCrypted.cpp
@@ -572,7 +572,9 @@ bool CWiiSaveCrypted::getPaths(bool forExport)
 			return false;
 		}
 		if (encryptedSavePath.length() == 0)
-			encryptedSavePath = "."; // If no path was passed, use current dir
+		{
+			encryptedSavePath = File::GetUserPath(D_USER_IDX); // If no path was passed, use User folder
+		}
 		encryptedSavePath += StringFromFormat("/private/wii/title/%s/data.bin", GameID);
 		File::CreateFullPath(encryptedSavePath);
 	}


### PR DESCRIPTION
relying on the cwd for export lead to possible confusion as to where the files end up.
example on mac https://forums.dolphin-emu.org/Thread-where-are-exported-wii-saves-mac
In the past there were also instances of a wx issue where the cwd was changed

remove this possible confusion by simply using the "User" directory
