### PR TITLE
[WIP] Adds support for forward jumps within blocks.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -18,6 +18,9 @@
 // ----------
 #pragma once
 
+#include <map>
+#include <vector>
+
 #include "Common/x64ABI.h"
 #include "Common/x64Analyzer.h"
 #include "Common/x64Emitter.h"
@@ -47,6 +50,12 @@ private:
 	// large chunk of memory for each recompiled block.
 	PPCAnalyst::CodeBuffer code_buffer;
 	Jit64AsmRoutineManager asm_routines;
+
+	// For OPTION_FORWARD_JUMP
+	std::map<u32, FixupBranch> jump_to;
+	std::map<u32, std::vector<u32>> jumps_from;
+
+	void SetForwardJump(u32 destination);
 
 public:
 	Jit64() : code_buffer(32000) {}

--- a/Source/Core/Core/PowerPC/JitArm32/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.h
@@ -18,6 +18,9 @@
 // ----------
 #pragma once
 
+#include <map>
+#include <vector>
+
 #include "Core/PowerPC/CPUCoreBase.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/JitArm32/JitArmCache.h"
@@ -43,6 +46,10 @@ private:
 
 	PPCAnalyst::CodeBuffer code_buffer;
 
+	// For OPTION_FORWARD_JUMP
+	std::map<u32, FixupBranch> jump_to;
+	std::map<u32, std::vector<u32>> jumps_from;
+
 	void DoDownCount();
 
 	void PrintDebug(UGeckoInstruction inst, u32 level);
@@ -50,6 +57,9 @@ private:
 	void Helper_UpdateCR1(ARMReg fpscr, ARMReg temp);
 
 	void SetFPException(ARMReg Reg, u32 Exception);
+
+	void SetForwardJump(u32 destination);
+
 public:
 	JitArm() : code_buffer(32000) {}
 	~JitArm() {}


### PR DESCRIPTION
This is the base implementation of forward jumps within blocks. Currently causes a bit of register cache churn, but it's the first step in the
process. The next option will require a bit of register cache involvement so it'll be another option linked to this one.
Breaks ARM currently, probably due to some issue with overly large jumps.

Good chance that this is still buggy on x86 as well, but I wanted to get some further testing done on it so I'm pushing it out in a WIP state.
