### PR TITLE
OGL/VertexManager: Remove unnused m_CurrentVertexFmt

### DIFF
--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -59,7 +59,6 @@ void VertexManager::CreateDeviceObjects()
 	s_indexBuffer = StreamBuffer::Create(GL_ELEMENT_ARRAY_BUFFER, MAX_IBUFFER_SIZE);
 	m_index_buffers = s_indexBuffer->m_buffer;
 
-	m_CurrentVertexFmt = nullptr;
 	m_last_vao = 0;
 }
 

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -44,7 +44,6 @@ private:
 	void Draw(u32 stride);
 	void vFlush(bool useDstAlpha) override;
 	void PrepareDrawBuffers(u32 stride);
-	NativeVertexFormat *m_CurrentVertexFmt;
 };
 
 }


### PR DESCRIPTION
Doesn't seem to be used anywhere. Untested.
