### PR TITLE
PPCAnalyst now detects internal branches better

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -172,11 +172,22 @@ bool AnalyzeFunction(u32 startAddr, Symbol &func, int max_size)
 				else
 				{
 					u32 target = EvaluateBranchTarget(instr, addr);
-					if (target != INVALID_TARGET && instr.LK)
+					if (target != INVALID_TARGET)
 					{
-						//we found a branch-n-link!
-						func.calls.push_back(SCall(target,addr));
-						func.flags &= ~FFLAG_LEAF;
+						if (instr.LK)
+						{
+							//we found a branch-n-link!
+							func.calls.push_back(SCall(target, addr));
+							func.flags &= ~FFLAG_LEAF;
+						}
+						else
+						{
+							if (target > farthestInternalBranchTarget)
+							{
+								farthestInternalBranchTarget = target;
+							}
+							numInternalBranches++;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
For example:

```
addr     opcode    disasm
80026584 48000054  b    ->0x800265D8 
```
