### PR TITLE
make IOCTL_SO_GETHOSTID more accurate on Windows

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -860,7 +860,7 @@ bool CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 		DWORD ifIndex = -1;
 		std::unique_ptr<MIB_IPFORWARDTABLE> forwardTable;
 		std::unique_ptr<MIB_IPADDRTABLE> ipTable;
-		
+
 		forwardTableSize = 0;
 		if (GetIpForwardTable(nullptr, &forwardTableSize, FALSE) == ERROR_INSUFFICIENT_BUFFER)
 		{


### PR DESCRIPTION
This is done by looking up the default route and using the IP of the interface attached to it. This allows people on the same network to connect through WFC games.

There should be a Mac/Linux equivalent but I'm not knowledgeable enough to implement that, plus not being able to test it.
