### PR TITLE
Move bn.h and ec.h into the correct filter section for Visual Studio.

### DIFF
--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -63,8 +63,12 @@
       <Filter>Logging</Filter>
     </ClInclude>
     <ClInclude Include="stdafx.h" />
-    <ClInclude Include="Crypto\bn.h" />
-    <ClInclude Include="Crypto\ec.h" />
+    <ClInclude Include="Crypto\ec.h">
+      <Filter>Crypto</Filter>
+    </ClInclude>
+    <ClInclude Include="Crypto\bn.h">
+      <Filter>Crypto</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BreakPoints.cpp" />


### PR DESCRIPTION
In VS it these two files are currently shown as being in the root of the Common project. They should be shown as being present within Common/Crypto instead.
