### PR TITLE
D3D: fix efb2ram for z textures with msaa

### DIFF
--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -40,8 +40,8 @@ D3DTexture2D* &FramebufferManager::GetResolvedEFBDepthTexture()
 {
 	if (g_ActiveConfig.iMultisampleMode)
 	{
-		D3D::context->ResolveSubresource(m_efb.resolved_color_tex->GetTex(), 0, m_efb.color_tex->GetTex(), 0, DXGI_FORMAT_R8G8B8A8_UNORM);
-		return m_efb.resolved_color_tex;
+		D3D::context->ResolveSubresource(m_efb.resolved_depth_tex->GetTex(), 0, m_efb.depth_tex->GetTex(), 0, DXGI_FORMAT_R24_UNORM_X8_TYPELESS);
+		return m_efb.resolved_depth_tex;
 	}
 	else
 		return m_efb.depth_tex;

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -1122,7 +1122,7 @@ size_t PSTextureEncoder::Encode(u8* dst, unsigned int dstFormat,
 		D3D::context->OMSetRenderTargets(1, &m_outRTV, nullptr);
 
 		ID3D11ShaderResourceView* pEFB = (srcFormat == PEControl::Z24) ?
-			FramebufferManager::GetEFBDepthTexture()->GetSRV() :
+			FramebufferManager::GetResolvedEFBDepthTexture()->GetSRV() :
 			// FIXME: Instead of resolving EFB, it would be better to pick out a
 			// single sample from each pixel. The game may break if it isn't
 			// expecting the blurred edges around multisampled shapes.


### PR DESCRIPTION
Fix D3D efb2ram from z textures with MSAA

Thx @ galop1n for reporting this issue

_untested_
