### PR TITLE
Texcache cleanup

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -931,7 +931,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbHeight,const EFBRectangl
 	OSD::DrawMessages();
 	D3D::EndFrame();
 
-	TextureCache::Cleanup();
+	TextureCache::Cleanup(frameCount);
 
 	// Enable configuration changes
 	UpdateActiveConfig();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1623,7 +1623,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbHeight,const EFBRectangl
 	}
 
 	// Clean out old stuff from caches. It's not worth it to clean out the shader caches.
-	TextureCache::Cleanup();
+	TextureCache::Cleanup(frameCount);
 
 	// Render to the framebuffer.
 	FramebufferManager::SetFramebuffer(0);

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -100,19 +100,12 @@ void TextureCache::OnConfigChanged(VideoConfig& config)
 
 			invalidate_texture_cache_requested = false;
 		}
-
-		// TODO: Probably shouldn't clear all render targets here, just mark them dirty or something.
-		if (config.bEFBCopyCacheEnable != backup_config.s_copy_cache_enable) // TODO: not sure if this is needed?
-		{
-			g_texture_cache->ClearRenderTargets();
-		}
 	}
 
 	backup_config.s_colorsamples = config.iSafeTextureCache_ColorSamples;
 	backup_config.s_texfmt_overlay = config.bTexFmtOverlayEnable;
 	backup_config.s_texfmt_overlay_center = config.bTexFmtOverlayCenter;
 	backup_config.s_hires_textures = config.bHiresTextures;
-	backup_config.s_copy_cache_enable = config.bEFBCopyCacheEnable;
 }
 
 void TextureCache::Cleanup()
@@ -191,26 +184,6 @@ bool TextureCache::TCacheEntryBase::OverlapsMemoryRange(u32 range_address, u32 r
 		return false;
 
 	return true;
-}
-
-void TextureCache::ClearRenderTargets()
-{
-	TexCache::iterator
-		iter = textures.begin(),
-		tcend = textures.end();
-
-	while (iter != tcend)
-	{
-		if (iter->second->type == TCET_EC_VRAM)
-		{
-			delete iter->second;
-			textures.erase(iter++);
-		}
-		else
-		{
-			++iter;
-		}
-	}
 }
 
 bool TextureCache::CheckForCustomTextureLODs(u64 tex_hash, int texformat, unsigned int levels)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -372,13 +372,8 @@ TextureCache::TCacheEntryBase* TextureCache::Load(unsigned int const stage,
 	TCacheEntryBase *entry = textures[address];
 	if (entry)
 	{
-		// 1. Calculate reference hash:
-		// calculated from RAM texture data for normal textures. Hashes for paletted textures are modified by tlut_hash. 0 for virtual EFB copies.
-		if (g_ActiveConfig.bCopyEFBToTexture && entry->IsEfbCopy())
-			tex_hash = TEXHASH_INVALID;
-
-		// 2. a) For EFB copies, only the hash and the texture address need to match
-		if (entry->IsEfbCopy() && tex_hash == entry->hash && address == entry->addr)
+		// 1. For EFB copies, only the texture address need to match. For hybrid copies, also the hash must match.
+		if (entry->IsEfbCopy() && (tex_hash == entry->hash || TEXHASH_INVALID == entry->hash) && address == entry->addr)
 		{
 			entry->type = TCET_EC_VRAM;
 
@@ -388,7 +383,7 @@ TextureCache::TCacheEntryBase* TextureCache::Load(unsigned int const stage,
 			return ReturnEntry(stage, entry);
 		}
 
-		// 2. b) For normal textures, all texture parameters need to match
+		// 2. For normal textures, all texture parameters need to match
 		if (address == entry->addr && tex_hash == entry->hash && full_format == entry->format &&
 			entry->num_mipmaps > maxlevel && entry->native_width == nativeW && entry->native_height == nativeH)
 		{

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -79,10 +79,15 @@ void TextureCache::OnConfigChanged(VideoConfig& config)
 {
 	if (g_texture_cache)
 	{
-		// TODO: Invalidating texcache is really stupid in some of these cases
-		if (config.iSafeTextureCache_ColorSamples != backup_config.s_colorsamples ||
+		if (// This affects the hash, so we have to invalidate everything.
+			config.iSafeTextureCache_ColorSamples != backup_config.s_colorsamples ||
+
+			// We want the format to be displayed on all textures, not only on new textures.
 			config.bTexFmtOverlayEnable != backup_config.s_texfmt_overlay ||
 			config.bTexFmtOverlayCenter != backup_config.s_texfmt_overlay_center ||
+
+			// Without invalidation, we'd only display the overlay / custom
+			// texture for new textures.
 			config.bHiresTextures != backup_config.s_hires_textures ||
 			invalidate_texture_cache_requested)
 		{

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -124,7 +124,7 @@ void TextureCache::Cleanup(int frameCount)
 		    !iter->second->IsEfbCopy())
 		{
 			delete iter->second;
-			textures.erase(iter++);
+			iter = textures.erase(iter);
 		}
 		else
 		{

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -142,8 +142,7 @@ void TextureCache::InvalidateRange(u32 start_address, u32 size)
 		tcend = textures.end();
 	while (iter != tcend)
 	{
-		const int rangePosition = iter->second->IntersectsMemoryRange(start_address, size);
-		if (0 == rangePosition)
+		if (iter->second->OverlapsMemoryRange(start_address, size))
 		{
 			delete iter->second;
 			textures.erase(iter++);
@@ -166,8 +165,7 @@ void TextureCache::MakeRangeDynamic(u32 start_address, u32 size)
 
 	for (; iter != tcend; ++iter)
 	{
-		const int rangePosition = iter->second->IntersectsMemoryRange(start_address, size);
-		if (0 == rangePosition)
+		if (iter->second->OverlapsMemoryRange(start_address, size))
 		{
 			iter->second->SetHashes(TEXHASH_INVALID);
 		}
@@ -184,15 +182,15 @@ bool TextureCache::Find(u32 start_address, u64 hash)
 	return false;
 }
 
-int TextureCache::TCacheEntryBase::IntersectsMemoryRange(u32 range_address, u32 range_size) const
+bool TextureCache::TCacheEntryBase::OverlapsMemoryRange(u32 range_address, u32 range_size) const
 {
 	if (addr + size_in_bytes < range_address)
-		return -1;
+		return false;
 
 	if (addr >= range_address + range_size)
-		return 1;
+		return false;
 
-	return 0;
+	return true;
 }
 
 void TextureCache::ClearRenderTargets()

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -36,7 +36,7 @@ TextureCache::TexCache TextureCache::textures;
 
 TextureCache::BackupConfig TextureCache::backup_config;
 
-bool invalidate_texture_cache_requested;
+static bool invalidate_texture_cache_requested;
 
 TextureCache::TCacheEntryBase::~TCacheEntryBase()
 {
@@ -102,21 +102,13 @@ void TextureCache::OnConfigChanged(VideoConfig& config)
 		}
 
 		// TODO: Probably shouldn't clear all render targets here, just mark them dirty or something.
-		if (config.bEFBCopyCacheEnable != backup_config.s_copy_cache_enable || // TODO: not sure if this is needed?
-			config.bCopyEFBToTexture != backup_config.s_copy_efb_to_texture ||
-			config.bCopyEFBScaled != backup_config.s_copy_efb_scaled ||
-			config.bEFBCopyEnable != backup_config.s_copy_efb ||
-			config.iEFBScale != backup_config.s_efb_scale)
+		if (config.bEFBCopyCacheEnable != backup_config.s_copy_cache_enable) // TODO: not sure if this is needed?
 		{
 			g_texture_cache->ClearRenderTargets();
 		}
 	}
 
 	backup_config.s_colorsamples = config.iSafeTextureCache_ColorSamples;
-	backup_config.s_copy_efb_to_texture = config.bCopyEFBToTexture;
-	backup_config.s_copy_efb_scaled = config.bCopyEFBScaled;
-	backup_config.s_copy_efb = config.bEFBCopyEnable;
-	backup_config.s_efb_scale = config.iEFBScale;
 	backup_config.s_texfmt_overlay = config.bTexFmtOverlayEnable;
 	backup_config.s_texfmt_overlay_center = config.bTexFmtOverlayCenter;
 	backup_config.s_hires_textures = config.bHiresTextures;
@@ -130,7 +122,7 @@ void TextureCache::Cleanup()
 	while (iter != tcend)
 	{
 		if (frameCount > TEXTURE_KILL_THRESHOLD + iter->second->frameCount &&
-            // EFB copies living on the host GPU are unrecoverable and thus shouldn't be deleted
+		    // EFB copies living on the host GPU are unrecoverable and thus shouldn't be deleted
 		    !iter->second->IsEfbCopy())
 		{
 			delete iter->second;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -128,25 +128,6 @@ void TextureCache::Cleanup()
 	}
 }
 
-void TextureCache::InvalidateRange(u32 start_address, u32 size)
-{
-	TexCache::iterator
-		iter = textures.begin(),
-		tcend = textures.end();
-	while (iter != tcend)
-	{
-		if (iter->second->OverlapsMemoryRange(start_address, size))
-		{
-			delete iter->second;
-			textures.erase(iter++);
-		}
-		else
-		{
-			++iter;
-		}
-	}
-}
-
 void TextureCache::MakeRangeDynamic(u32 start_address, u32 size)
 {
 	TexCache::iterator

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -22,10 +22,8 @@
 // ugly
 extern int frameCount;
 
-enum
-{
-	TEXTURE_KILL_THRESHOLD = 200,
-};
+static const u64 TEXHASH_INVALID = 0;
+static const int TEXTURE_KILL_THRESHOLD = 200;
 
 TextureCache *g_texture_cache;
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -27,8 +27,6 @@ public:
 
 	struct TCacheEntryBase
 	{
-#define TEXHASH_INVALID 0
-
 		// common members
 		u32 addr;
 		u32 size_in_bytes;

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -81,7 +81,7 @@ public:
 			bool isIntensity, bool scaleByHalf, unsigned int cbufid,
 			const float *colmat) = 0;
 
-		int IntersectsMemoryRange(u32 range_address, u32 range_size) const;
+		bool OverlapsMemoryRange(u32 range_address, u32 range_size) const;
 
 		bool IsEfbCopy() { return (type == TCET_EC_VRAM || type == TCET_EC_DYNAMIC); }
 	};

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -85,7 +85,10 @@ public:
 	virtual ~TextureCache(); // needs virtual for DX11 dtor
 
 	static void OnConfigChanged(VideoConfig& config);
-	static void Cleanup();
+
+	// Removes textures which aren't used for more than TEXTURE_KILL_THRESHOLD frames,
+	// frameCount is the current frame number.
+	static void Cleanup(int frameCount);
 
 	static void Invalidate();
 	static void MakeRangeDynamic(u32 start_address, u32 size);

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -33,7 +33,6 @@ public:
 		u32 addr;
 		u32 size_in_bytes;
 		u64 hash;
-		//u32 pal_hash;
 		u32 format;
 
 		enum TexCacheEntryType type;
@@ -62,10 +61,9 @@ public:
 			virtual_height = _virtual_height;
 		}
 
-		void SetHashes(u64 _hash/*, u32 _pal_hash*/)
+		void SetHashes(u64 _hash)
 		{
 			hash = _hash;
-			//pal_hash = _pal_hash;
 		}
 
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -127,10 +127,6 @@ private:
 	static struct BackupConfig
 	{
 		int s_colorsamples;
-		bool s_copy_efb_to_texture;
-		bool s_copy_efb_scaled;
-		bool s_copy_efb;
-		int s_efb_scale;
 		bool s_texfmt_overlay;
 		bool s_texfmt_overlay_center;
 		bool s_hires_textures;

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -92,7 +92,6 @@ public:
 	static void Invalidate();
 	static void InvalidateRange(u32 start_address, u32 size);
 	static void MakeRangeDynamic(u32 start_address, u32 size);
-	static void ClearRenderTargets(); // currently only used by OGL
 	static bool Find(u32 start_address, u64 hash);
 
 	virtual TCacheEntryBase* CreateTexture(unsigned int width, unsigned int height,
@@ -128,7 +127,6 @@ private:
 		bool s_texfmt_overlay;
 		bool s_texfmt_overlay_center;
 		bool s_hires_textures;
-		bool s_copy_cache_enable;
 	} backup_config;
 };
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -90,7 +90,6 @@ public:
 	static void Cleanup();
 
 	static void Invalidate();
-	static void InvalidateRange(u32 start_address, u32 size);
 	static void MakeRangeDynamic(u32 start_address, u32 size);
 	static bool Find(u32 start_address, u64 hash);
 


### PR DESCRIPTION
This PR changes two parts:
- The texcache isn't invalidated on lots of config changes (eg IR)
- The tlut isn't in the texID any more. This reverts a speedhack for Metroid Prime's fonts but display some (likely wrong) data on efb2tex where efb2ram was needed before.