### PR TITLE
Fixed Issue 7284

### DIFF
--- a/Source/Core/DolphinWX/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetWindow.cpp
@@ -543,7 +543,10 @@ void NetPlayDiag::OnThread(wxCommandEvent& event)
 	while (std::getline(ss, tmps))
 		m_player_lbox->Append(StrToWxStr(tmps));
 
-	m_player_lbox->SetSelection(selection);
+	const int count = m_player_lbox->GetCount();
+
+	if (selection < count)
+		m_player_lbox->SetSelection(selection);
 
 	switch (event.GetId())
 	{


### PR DESCRIPTION
We were not checking to see if the selection was still valid after repopulated the list.
