### PR TITLE
Fix a struct overflow case in WII_IPC_HLE_Device_hid.cpp

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -329,11 +329,20 @@ bool CWII_IPC_HLE_Device_hid::IOCtlV(u32 _CommandAddress)
 
 void CWII_IPC_HLE_Device_hid::ConvertDeviceToWii(WiiHIDDeviceDescriptor *dest, const struct libusb_device_descriptor *src)
 {
-	memcpy(dest,src,sizeof(WiiHIDDeviceDescriptor));
-	dest->bcdUSB = Common::swap16(dest->bcdUSB);
-	dest->idVendor = Common::swap16(dest->idVendor);
-	dest->idProduct = Common::swap16(dest->idProduct);
-	dest->bcdDevice = Common::swap16(dest->bcdDevice);
+	dest->bLength            = src->bLength;
+	dest->bDescriptorType    = src->bDescriptorType;
+	dest->bcdUSB             = Common::swap16(src->bcdUSB);
+	dest->bDeviceClass       = src->bDeviceClass;
+	dest->bDeviceSubClass    = src->bDeviceSubClass;
+	dest->bDeviceProtocol    = src->bDeviceProtocol;
+	dest->bMaxPacketSize0    = src->bMaxPacketSize0;
+	dest->idVendor           = Common::swap16(src->idVendor);
+	dest->idProduct          = Common::swap16(src->idProduct);
+	dest->bcdDevice          = Common::swap16(src->bcdDevice);
+	dest->iManufacturer      = src->iManufacturer;
+	dest->iProduct           = src->iProduct;
+	dest->iSerialNumber      = src->iSerialNumber;
+	dest->bNumConfigurations = src->bNumConfigurations;
 }
 
 void CWII_IPC_HLE_Device_hid::ConvertConfigToWii(WiiHIDConfigDescriptor *dest, const struct libusb_config_descriptor *src)


### PR DESCRIPTION
`WiiHIDDeviceDescriptor` is 20 bytes in size (2 of which are padding bytes)

`libusb_device_descriptor` on the other hand is 18 bytes (does not have the 2 padding bytes).

So we were pulling 20 bytes out of an 18 byte struct, which isn't really correct.
