### PR TITLE
Use a bool instead of an int to represent the initialized state in IOWin.cpp

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -71,7 +71,7 @@ PBth_BluetoothEnumerateInstalledServices Bth_BluetoothEnumerateInstalledServices
 HINSTANCE hid_lib = nullptr;
 HINSTANCE bthprops_lib = nullptr;
 
-static int initialized = 0;
+static bool initialized = false;
 
 std::unordered_map<BTH_ADDR, std::time_t> g_connect_times;
 


### PR DESCRIPTION
It's only used like a boolean as well,

at line 135 it was assigned `true` despite being an int. 
