### PR TITLE
Explicitly center the X and Y joystick values.

### DIFF
--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -58,7 +58,10 @@ void GetStatus(u8 _numPAD, SPADStatus* _pPADStatus)
 	{
 		// if gui has lock (messing with controls), skip this input cycle
 		// center axes and return
-		memset(&_pPADStatus->stickX, 0x80, 4);
+		_pPADStatus->stickX = 0x80;
+		_pPADStatus->stickY = 0x80;
+		_pPADStatus->substickX = 0x80;
+		_pPADStatus->substickY = 0x80;
 		return;
 	}
 

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -112,7 +112,10 @@ void GCPad::GetInput(SPADStatus* const pad)
 	else
 	{
 		// center sticks
-		memset(&pad->stickX, 0x80, 4);
+		pad->stickX = 0x80;
+		pad->stickY = 0x80;
+		pad->substickX = 0x80;
+		pad->substickY = 0x80;
 	}
 }
 


### PR DESCRIPTION
More self-explanatory at a glance than a memset.
