### PR TITLE
Make GetBPRegInfo just take two strings as parameters

### DIFF
--- a/Source/Core/DolphinWX/FifoPlayerDlg.cpp
+++ b/Source/Core/DolphinWX/FifoPlayerDlg.cpp
@@ -789,16 +789,18 @@ void FifoPlayerDlg::OnObjectCmdListSelectionChanged(wxCommandEvent& event)
 	wxString newLabel;
 	if (*cmddata == GX_LOAD_BP_REG)
 	{
-		char name[64]="\0", desc[512]="\0";
-		GetBPRegInfo(cmddata+1, name, sizeof(name), desc, sizeof(desc));
+		std::string name;
+		std::string desc;
+		GetBPRegInfo(cmddata+1, &name, &desc);
+
 		newLabel = _("BP register ");
-		newLabel += (name[0] != '\0') ? StrToWxStr(name) : wxString::Format(_("UNKNOWN_%02X"), *(cmddata+1));
+		newLabel += (name.empty()) ? wxString::Format(_("UNKNOWN_%02X"), *(cmddata+1)) : StrToWxStr(name);
 		newLabel += ":\n";
 
-		if (desc[0] != '\0')
-			newLabel += StrToWxStr(desc);
-		else
+		if (desc.empty())
 			newLabel += _("No description available");
+		else
+			newLabel += StrToWxStr(desc);
 	}
 	else if (*cmddata == GX_LOAD_CP_REG)
 	{

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "Common/BitField.h"
 #include "Common/Common.h"
 
@@ -1081,4 +1083,4 @@ extern BPMemory bpmem;
 
 void LoadBPReg(u32 value0);
 
-void GetBPRegInfo(const u8* data, char* name, size_t name_size, char* desc, size_t desc_size);
+void GetBPRegInfo(const u8* data, std::string* name, std::string* desc);


### PR DESCRIPTION
Gets rid of the size parameters.
