### PR TITLE
Android: Attach '.debug' to the end of the app's package name, if built in Debug configuration.

### DIFF
--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -71,8 +71,16 @@ android {
 	}
 
 	buildTypes {
+		// Signed by release key, allowing for upload to Play Store.
 		release {
 			signingConfig signingConfigs.release
+		}
+
+		// Signed by debug key disallowing distribution on Play Store.
+		// Attaches 'debug' suffix to version and package name, allowing installation alongside the release build.
+		debug {
+			packageNameSuffix '.debug'
+			versionNameSuffix '-debug'
 		}
 	}
 }


### PR DESCRIPTION
This allows for installation of debug and release builds on the same device.
