### PR TITLE
JIT: make backpatch handle sign-extend from 8 bits correctly.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
@@ -86,7 +86,12 @@ const u8 *TrampolineCache::GetReadTrampoline(const InstructionInfo &info, u32 re
 		break;
 	}
 
-	if (dataReg != EAX)
+	if (info.signExtend && info.operandSize == 1)
+	{
+		// Need to sign extend value from Read_U8.
+		MOVSX(32, 8, dataReg, R(EAX));
+	}
+	else if (dataReg != EAX)
 	{
 		MOV(32, R(dataReg), R(EAX));
 	}


### PR DESCRIPTION
I don't think this is actually possible to trigger at the moment... but
it matches the implementation of SafeLoadToReg.
