### PR TITLE
Add .clang-format configuration

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -38,7 +38,7 @@ ColumnLimit:     120
 #Standard:        Cpp11
 IndentWidth:     4
 TabWidth:        4
-UseTab:          Always 
+UseTab:          ForIndentation 
 BreakBeforeBraces: Allman
 #IndentFunctionDeclarationAfterType: false
 #SpacesInParentheses: false


### PR DESCRIPTION
This is a first draft of a .clang-format configuration file, which I believe is close to the dolphin style.
Wanting feedback/updates to eventually have a config that matches the dolphin style
Issues that I've noticed:

end of line comments are not aligned by formatter when within struct
# defines are not aligned

```
#define foo  bar
#define fooo bar
```

are restyled as 

```
#define foo bar
#define fooo bar
```

const initializer and enum brace style is incorrect

```
enum name
{
   VALUE0,
  ...
  VALUE9
}
```

is restyled as

```
enum name
{ VALUE0,
  ...
  VALUE9 }
```
