### PR TITLE
When reading an ini file, if there is an error, check if it is simply be...

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -347,9 +347,16 @@ bool IniFile::Load(const std::string& filename, bool keep_current_data)
 		char templine[MAX_BYTES];
 		std::string line;
 		if (in.getline(templine, MAX_BYTES))
+		{
 			line = templine;
+		}
 		else
-			return false;
+		{
+			if (in.eof())
+				return true;
+			else
+				return false;
+		}
 
 #ifndef _WIN32
 		// Check for CRLF eol and convert it to LF


### PR DESCRIPTION
...cause the eof was reached.
