### PR TITLE
Revert "DSound: use DSound notifications to produce sound."

### DIFF
--- a/Source/Core/AudioCommon/DSoundStream.cpp
+++ b/Source/Core/AudioCommon/DSoundStream.cpp
@@ -29,7 +29,7 @@ bool DSound::CreateBuffer()
 
 	// Fill out DSound buffer description.
 	dsbdesc.dwSize  = sizeof(DSBUFFERDESC);
-	dsbdesc.dwFlags = DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_CTRLVOLUME | DSBCAPS_GLOBALFOCUS | DSBCAPS_CTRLPOSITIONNOTIFY;
+	dsbdesc.dwFlags = DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_CTRLVOLUME | DSBCAPS_GLOBALFOCUS;
 	dsbdesc.dwBufferBytes = bufferSize = BUFSIZE;
 	dsbdesc.lpwfxFormat = (WAVEFORMATEX *)&pcmwf;
 	dsbdesc.guid3DAlgorithm = DS3DALG_DEFAULT;
@@ -39,20 +39,6 @@ bool DSound::CreateBuffer()
 	{
 		dsBuffer->SetCurrentPosition(0);
 		dsBuffer->SetVolume(m_volume);
-
-		soundSyncEvent = CreateEvent(NULL, TRUE, FALSE, TEXT("DSound Buffer Notification"));
-
-		IDirectSoundNotify *dsnotify;
-		dsBuffer->QueryInterface(IID_IDirectSoundNotify, (void**)&dsnotify);
-		DSBPOSITIONNOTIFY notify_positions[3];
-		for (unsigned i = 0; i < ARRAYSIZE(notify_positions); ++i)
-		{
-			notify_positions[i].dwOffset = i * (BUFSIZE / ARRAYSIZE(notify_positions));
-			notify_positions[i].hEventNotify = soundSyncEvent;
-		}
-		dsnotify->SetNotificationPositions(ARRAYSIZE(notify_positions), notify_positions);
-		dsnotify->Release();
-
 		return true;
 	}
 	else
@@ -117,7 +103,7 @@ void DSound::SoundLoop()
 			WriteDataToBuffer(lastPos, (char*)realtimeBuffer, numBytesToRender);
 			lastPos = ModBufferSize(lastPos + numBytesToRender);
 		}
-		WaitForSingleObject(soundSyncEvent, INFINITE);
+		soundSyncEvent.Wait();
 	}
 }
 
@@ -150,6 +136,11 @@ void DSound::SetVolume(int volume)
 		dsBuffer->SetVolume(m_volume);
 }
 
+void DSound::Update()
+{
+	soundSyncEvent.Set();
+}
+
 void DSound::Clear(bool mute)
 {
 	m_muted = mute;
@@ -171,12 +162,11 @@ void DSound::Stop()
 {
 	threadData = 1;
 	// kick the thread if it's waiting
-	SetEvent(soundSyncEvent);
+	soundSyncEvent.Set();
 
 	thread.join();
 	dsBuffer->Stop();
 	dsBuffer->Release();
 	ds->Release();
-	CloseHandle(soundSyncEvent);
 }
 

--- a/Source/Core/AudioCommon/DSoundStream.h
+++ b/Source/Core/AudioCommon/DSoundStream.h
@@ -13,14 +13,14 @@
 #include <mmsystem.h>
 #include <dsound.h>
 
-#define BUFSIZE (256 * 8 * 4)
+#define BUFSIZE (1024 * 8 * 4)
 #endif
 
 class DSound final : public SoundStream
 {
 #ifdef _WIN32
 	std::thread thread;
-	HANDLE soundSyncEvent;
+	Common::Event soundSyncEvent;
 	void  *hWnd;
 
 	IDirectSound8* ds;
@@ -66,6 +66,7 @@ public:
 	virtual void Stop();
 	virtual void Clear(bool mute);
 	static bool isValid() { return true; }
+	virtual void Update();
 
 #else
 public:


### PR DESCRIPTION
This reverts commit 4990b8910bc0fe5d576f92396f761a79b3f1a7e3.

The commit is causing substantial performance issues for the DSound backend which I somehow didn't catch during testing.  (By performance here, I mean CPU usage.)
