### PR TITLE
Render: Fix lighting bug with specular attenuation, the gx normalize the light direction and it is expected to receive from the game vectors with norm>1 ( probably better for precision ).

### DIFF
--- a/Source/Core/VideoCommon/LightingShaderGen.h
+++ b/Source/Core/VideoCommon/LightingShaderGen.h
@@ -73,7 +73,7 @@ static void GenerateLightShader(T& object, LightingUidData& uid_data, int index,
 			object.Write("dist2 = dot(ldir, ldir);\n"
 			             "dist = sqrt(dist2);\n"
 			             "ldir = ldir / dist;\n"
-			             "attn = max(0.0, dot(ldir, " LIGHT_DIR".xyz));\n",
+			             "attn = max(0.0, dot(ldir, normalize(" LIGHT_DIR".xyz)));\n",
 			             LIGHT_DIR_PARAMS(lightsName, index));
 			// attn*attn may overflow
 			object.Write("attn = max(0.0, " LIGHT_COSATT".x + " LIGHT_COSATT".y*attn + " LIGHT_COSATT".z*attn*attn) / dot(" LIGHT_DISTATT".xyz, float3(1.0,dist,dist2));\n",
@@ -82,7 +82,7 @@ static void GenerateLightShader(T& object, LightingUidData& uid_data, int index,
 		else if (chan.attnfunc == 1)
 		{ // specular
 			object.Write("ldir = normalize(" LIGHT_POS".xyz);\n", LIGHT_POS_PARAMS(lightsName, index));
-			object.Write("attn = (dot(_norm0,ldir) >= 0.0) ? max(0.0, dot(_norm0, " LIGHT_DIR".xyz)) : 0.0;\n", LIGHT_DIR_PARAMS(lightsName, index));
+			object.Write("attn = (dot(_norm0,ldir) >= 0.0) ? max(0.0, dot(_norm0, normalize(" LIGHT_DIR".xyz))) : 0.0;\n", LIGHT_DIR_PARAMS(lightsName, index));
 			// attn*attn may overflow
 			object.Write("attn = max(0.0, " LIGHT_COSATT".x + " LIGHT_COSATT".y*attn + " LIGHT_COSATT".z*attn*attn) / (" LIGHT_DISTATT".x + " LIGHT_DISTATT".y*attn + " LIGHT_DISTATT".z*attn*attn);\n",
 			             LIGHT_COSATT_PARAMS(lightsName, index), LIGHT_COSATT_PARAMS(lightsName, index), LIGHT_COSATT_PARAMS(lightsName, index),


### PR DESCRIPTION
The GX normalize the element in the light parameters only in some cases with specular enable. So the simplest was to normalize in the shader. Even if it would be possible to normalize in the constant buffer, it would create more constant buffer update. To keep in mind for future optimization.
