### PR TITLE
Make MemoryUtil.cpp use the correct x86_64 define.

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -17,7 +17,7 @@
 #include <sys/mman.h>
 #endif
 
-#if !defined(_WIN32) && defined(__x86_64__) && !defined(MAP_32BIT)
+#if !defined(_WIN32) && defined(_M_X86_64) && !defined(MAP_32BIT)
 #include <unistd.h>
 #define PAGE_MASK     (getpagesize() - 1)
 #define round_page(x) ((((unsigned long)(x)) + PAGE_MASK) & ~(PAGE_MASK))
@@ -32,7 +32,7 @@ void* AllocateExecutableMemory(size_t size, bool low)
 	void* ptr = VirtualAlloc(0, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 #else
 	static char *map_hint = nullptr;
-#if defined(__x86_64__) && !defined(MAP_32BIT)
+#if defined(_M_X86_64) && !defined(MAP_32BIT)
 	// This OS has no flag to enforce allocation below the 4 GB boundary,
 	// but if we hint that we want a low address it is very likely we will
 	// get one.
@@ -44,7 +44,7 @@ void* AllocateExecutableMemory(size_t size, bool low)
 #endif
 	void* ptr = mmap(map_hint, size, PROT_READ | PROT_WRITE | PROT_EXEC,
 		MAP_ANON | MAP_PRIVATE
-#if defined(__x86_64__) && defined(MAP_32BIT)
+#if defined(_M_X86_64) && defined(MAP_32BIT)
 		| (low ? MAP_32BIT : 0)
 #endif
 		, -1, 0);
@@ -63,7 +63,7 @@ void* AllocateExecutableMemory(size_t size, bool low)
 #endif
 		PanicAlert("Failed to allocate executable memory");
 	}
-#if !defined(_WIN32) && defined(__x86_64__) && !defined(MAP_32BIT)
+#if !defined(_WIN32) && defined(_M_X86_64) && !defined(MAP_32BIT)
 	else
 	{
 		if (low)
@@ -75,7 +75,7 @@ void* AllocateExecutableMemory(size_t size, bool low)
 	}
 #endif
 
-#if _ARCH_64
+#if _M_X86_64
 	if ((u64)ptr >= 0x80000000 && low == true)
 		PanicAlert("Executable memory ended up above 2GB!");
 #endif


### PR DESCRIPTION
MemoryUtil.cpp was incorrectly using the old **x86_64** define when it should be using _M_X86_64.
It was also using _ARCH_64 when it shouldn't have which was causing an errant PanicAlert to come up in my development.
