### PR TITLE
Remove unused mojs array from ppcState.

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -115,7 +115,6 @@ void Init(int cpu_core)
 {
 	FPURoundMode::SetPrecisionMode(FPURoundMode::PREC_53);
 
-	memset(ppcState.mojs, 0, sizeof(ppcState.mojs));
 	memset(ppcState.sr, 0, sizeof(ppcState.sr));
 	ppcState.DebugCount = 0;
 	ppcState.dtlb_last = 0;

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -28,7 +28,6 @@ enum CoreMode
 // This contains the entire state of the emulated PowerPC "Gekko" CPU.
 struct GC_ALIGNED64(PowerPCState)
 {
-	u32 mojs[128];  // Try to isolate the regs from other variables in the cache.
 	u32 gpr[32];    // General purpose registers. r1 = stack pointer.
 
 	// The paired singles are strange : PS0 is stored in the full 64 bits of each FPR


### PR DESCRIPTION
This was some unused array just sitting in our global ppcState struct.
I've got no idea what its use was /supposed/ to be used for if ever implemented.
