### PR TITLE
Fix a typo in a function prototype in PowerPCDisasm.h

### DIFF
--- a/Externals/Bochs_disasm/PowerPCDisasm.h
+++ b/Externals/Bochs_disasm/PowerPCDisasm.h
@@ -22,7 +22,8 @@
 #ifndef _POWERPC_DISASM
 #define _POWERPC_DISASM
 
-void DisassembleGekko(unsigned int opcode, unsigned int curInstAddr, char *dest, int max_size);
-const char *GetGRPName(unsigned int index);
+void DisassembleGekko(unsigned int opcode, unsigned int curInstAddr, char* dest, int max_size);
+const char* GetGPRName(unsigned int index);
+const char* GetFPRName(unsigned int index);
 
 #endif

--- a/Source/Core/DolphinWX/Debugger/RegisterWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterWindow.cpp
@@ -16,8 +16,6 @@
 
 class wxWindow;
 
-extern const char* GetGRPName(unsigned int index);
-
 BEGIN_EVENT_TABLE(CRegisterWindow, wxPanel)
 END_EVENT_TABLE()
 


### PR DESCRIPTION
Should have been GetGPRName, not GetGRPName.

Also added GetFPRName to the PowerPCDisasm header for consistency.

Yes this modifies an external, however PowerPCDisasm isn't actually a part of Bochs. It's just grouped in with it.
