### PR TITLE
OGL StreamBuffer optimization

### DIFF
--- a/Source/Core/VideoBackends/OGL/StreamBuffer.h
+++ b/Source/Core/VideoBackends/OGL/StreamBuffer.h
@@ -15,7 +15,7 @@ namespace OGL
 class StreamBuffer {
 
 public:
-	static StreamBuffer* Create(u32 type, size_t size);
+	static StreamBuffer* Create(u32 type, u32 size);
 	virtual ~StreamBuffer();
 
 	/* This mapping function will return a pair of:
@@ -26,10 +26,10 @@ public:
 	 * Mapping invalidates the current buffer content,
 	 * so it isn't allowed to access the old content any more.
 	 */
-	virtual std::pair<u8*, size_t> Map(size_t size) = 0;
-	virtual void Unmap(size_t used_size) = 0;
+	virtual std::pair<u8*, u32> Map(u32 size) = 0;
+	virtual void Unmap(u32 used_size) = 0;
 
-	inline std::pair<u8*, size_t> Map(size_t size, u32 stride)
+	inline std::pair<u8*, u32> Map(u32 size, u32 stride)
 	{
 		u32 padding = m_iterator % stride;
 		if (padding)
@@ -42,21 +42,21 @@ public:
 	const u32 m_buffer;
 
 protected:
-	StreamBuffer(u32 type, size_t size);
+	StreamBuffer(u32 type, u32 size);
 	void CreateFences();
 	void DeleteFences();
-	void AllocMemory(size_t size);
+	void AllocMemory(u32 size);
 
 	const u32 m_buffertype;
-	const size_t m_size;
+	const u32 m_size;
 
-	size_t m_iterator;
-	size_t m_used_iterator;
-	size_t m_free_iterator;
+	u32 m_iterator;
+	u32 m_used_iterator;
+	u32 m_free_iterator;
 
 private:
 	static const int SYNC_POINTS = 16;
-	inline int SLOT(size_t x) const { return x >> m_bit_per_slot; }
+	inline int SLOT(u32 x) const { return x >> m_bit_per_slot; }
 	const int m_bit_per_slot;
 
 	GLsync fences[SYNC_POINTS];


### PR DESCRIPTION
OGL::StreamBuffer was very high in profilation (2.5%), so here are some optimization for it.
- Alloc fences directly in the StreamBuffer class, so they can't alias other member variables
- Align the size by power of two and use shifting instead of divisions for slot calculation
- Move alignment to the caller, so it can be skipped if not needed (eg indexbuffer)
- Reduce index size to 32bit, faster alignment division
