### PR TITLE
OGL-StreamBuffer: don't use coherent mapping

### DIFF
--- a/Source/Core/VideoBackends/OGL/StreamBuffer.cpp
+++ b/Source/Core/VideoBackends/OGL/StreamBuffer.cpp
@@ -223,9 +223,9 @@ public:
 		// COHERENT_BIT is set so we don't have to use a MemoryBarrier on write
 		// CLIENT_STORAGE_BIT is set since we access the buffer more frequently on the client side then server side
 		glBufferStorage(m_buffertype, m_size, nullptr,
-			GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT | GL_CLIENT_STORAGE_BIT);
+			GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT);
 		m_pointer = (u8*)glMapBufferRange(m_buffertype, 0, m_size,
-			GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
+			GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_FLUSH_EXPLICIT_BIT);
 	}
 
 	~BufferStorage() {
@@ -241,6 +241,7 @@ public:
 	}
 
 	void Unmap(size_t used_size) override {
+		glFlushMappedBufferRange(m_buffertype, m_iterator, used_size);
 		m_iterator += used_size;
 	}
 


### PR DESCRIPTION
Coherent mapping seems to be much slower on fermi gpus.
