### PR TITLE
VideoCommon: Cache native vertex formats

### DIFF
--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -76,6 +76,15 @@ struct PortableVertexDeclaration
 	AttributeFormat colors[2];
 	AttributeFormat texcoords[8];
 	AttributeFormat posmtx;
+
+	inline bool operator<(const PortableVertexDeclaration& b) const
+	{
+		return memcmp(this, &b, sizeof(PortableVertexDeclaration)) < 0;
+	}
+	inline bool operator==(const PortableVertexDeclaration& b) const
+	{
+		return memcmp(this, &b, sizeof(PortableVertexDeclaration)) == 0;
+	}
 };
 
 // The implementation of this class is specific for GL/DX, so NativeVertexFormat.cpp

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -463,7 +463,6 @@ VertexLoader::VertexLoader(const TVtxDesc &vtx_desc, const VAT &vtx_attr)
 	m_compiledCode = nullptr;
 	m_numLoadedVertices = 0;
 	m_VertexSize = 0;
-	m_NativeFmt = nullptr;
 	loop_counter = 0;
 	VertexLoader_Normal::Init();
 	VertexLoader_Position::Init();
@@ -488,7 +487,6 @@ VertexLoader::~VertexLoader()
 	#ifdef USE_VERTEX_LOADER_JIT
 	FreeCodeSpace();
 	#endif
-	delete m_NativeFmt;
 }
 
 void VertexLoader::CompileVertexTranslator()
@@ -773,9 +771,7 @@ void VertexLoader::CompileVertexTranslator()
 	ABI_PopAllCalleeSavedRegsAndAdjustStack();
 	RET();
 #endif
-	m_NativeFmt = g_vertex_manager->CreateNativeVertexFormat();
-	m_NativeFmt->m_components = components;
-	m_NativeFmt->Initialize(vtx_decl);
+	m_NativeFmt = VertexLoaderManager::GetNativeVertexFormat(vtx_decl, components);
 }
 
 void VertexLoader::WriteCall(TPipelineFunction func)
@@ -825,9 +821,6 @@ void VertexLoader::SetupRunVertices(int vtx_attr_group, int primitive, int const
 	// Flush if our vertex format is different from the currently set.
 	if (g_nativeVertexFmt != nullptr && g_nativeVertexFmt != m_NativeFmt)
 	{
-		// We really must flush here. It's possible that the native representations
-		// of the two vtx formats are the same, but we have no way to easily check that
-		// now.
 		VertexManager::Flush();
 		// Also move the Set() here?
 	}

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Common/Common.h"
+#include "VideoCommon/NativeVertexFormat.h"
 
 namespace VertexLoaderManager
 {
@@ -20,6 +21,8 @@ namespace VertexLoaderManager
 
 	// For debugging
 	void AppendListToString(std::string *dest);
+
+	NativeVertexFormat* GetNativeVertexFormat(const PortableVertexDeclaration& format, u32 components);
 };
 
 void RecomputeCachedArraybases();


### PR DESCRIPTION
We are used to have a 1:1 mapping of GX vertex formats and the native (OGL + D3D) ones, but there are by far more GX ones.
This new cache maps them directly so that we don't flush on GX vertex format changes as long as the native one doesn't change.

The idea is stolen from galop1n.
