### PR TITLE
Use std::string in LogContainer's constructor.

### DIFF
--- a/Source/Core/Common/LogManager.cpp
+++ b/Source/Core/Common/LogManager.cpp
@@ -82,7 +82,7 @@ LogManager::LogManager()
 	m_Log[LogTypes::MEMCARD_MANAGER]    = new LogContainer("MemCard Manager", "MemCard Manager");
 	m_Log[LogTypes::NETPLAY]            = new LogContainer("NETPLAY",         "Netplay");
 
-	m_fileLog = new FileLogListener(File::GetUserPath(F_MAINLOG_IDX).c_str());
+	m_fileLog = new FileLogListener(File::GetUserPath(F_MAINLOG_IDX));
 	m_consoleLog = new ConsoleListener();
 	m_debuggerLog = new DebuggerLogListener();
 
@@ -130,7 +130,7 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type,
 	                                   Common::Timer::GetTimeFormatted().c_str(),
 	                                   file, line,
 	                                   LogTypes::LOG_LEVEL_TO_CHAR[(int)level],
-	                                   log->GetShortName(), temp);
+	                                   log->GetShortName().c_str(), temp);
 #ifdef ANDROID
 	Host_SysMessage(msg.c_str());
 #endif
@@ -148,12 +148,12 @@ void LogManager::Shutdown()
 	m_logManager = nullptr;
 }
 
-LogContainer::LogContainer(const char* shortName, const char* fullName, bool enable)
-	: m_enable(enable)
+LogContainer::LogContainer(const std::string& shortName, const std::string& fullName, bool enable)
+	: m_fullName(fullName),
+	  m_shortName(shortName),
+	  m_enable(enable),
+	  m_level(LogTypes::LWARNING)
 {
-	strncpy(m_fullName, fullName, 128);
-	strncpy(m_shortName, shortName, 32);
-	m_level = LogTypes::LWARNING;
 }
 
 // LogContainer
@@ -179,7 +179,7 @@ void LogContainer::Trigger(LogTypes::LOG_LEVELS level, const char *msg)
 	}
 }
 
-FileLogListener::FileLogListener(const char *filename)
+FileLogListener::FileLogListener(const std::string& filename)
 {
 	OpenFStream(m_logfile, filename, std::ios::app);
 	SetEnable(true);

--- a/Source/Core/Common/LogManager.h
+++ b/Source/Core/Common/LogManager.h
@@ -7,6 +7,7 @@
 #include <cstdarg>
 #include <fstream>
 #include <set>
+#include <string>
 
 #include "Common/Common.h"
 #include "Common/StdMutex.h"
@@ -27,7 +28,7 @@ public:
 class FileLogListener : public LogListener
 {
 public:
-	FileLogListener(const char *filename);
+	FileLogListener(const std::string& filename);
 
 	void Log(LogTypes::LOG_LEVELS, const char *msg) override;
 
@@ -52,10 +53,10 @@ public:
 class LogContainer
 {
 public:
-	LogContainer(const char* shortName, const char* fullName, bool enable = false);
+	LogContainer(const std::string& shortName, const std::string& fullName, bool enable = false);
 
-	const char* GetShortName() const { return m_shortName; }
-	const char* GetFullName() const { return m_fullName; }
+	std::string GetShortName() const { return m_shortName; }
+	std::string GetFullName() const { return m_fullName; }
 
 	void AddListener(LogListener* listener);
 	void RemoveListener(LogListener* listener);
@@ -72,8 +73,8 @@ public:
 	bool HasListeners() const { return !m_listeners.empty(); }
 
 private:
-	char m_fullName[128];
-	char m_shortName[32];
+	std::string m_fullName;
+	std::string m_shortName;
 	bool m_enable;
 	LogTypes::LOG_LEVELS m_level;
 	std::mutex m_listeners_lock;
@@ -115,12 +116,12 @@ public:
 		return m_Log[type]->IsEnabled();
 	}
 
-	const char* GetShortName(LogTypes::LOG_TYPE type) const
+	std::string GetShortName(LogTypes::LOG_TYPE type) const
 	{
 		return m_Log[type]->GetShortName();
 	}
 
-	const char* GetFullName(LogTypes::LOG_TYPE type) const
+	std::string GetFullName(LogTypes::LOG_TYPE type) const
 	{
 		return m_Log[type]->GetFullName();
 	}


### PR DESCRIPTION
This allows for removal of the strcpy calls, also it's technically way more safe, though I doubt we'll ever have a log name larger than 128 characters or a short description larger than 32 characters. Moved these assignments into the constructor's initializer list.

Also changed the file logger to take a string instead of const char*. Kills off a c_str call.
