### PR TITLE
Fix OpenGL ES version detection.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -463,7 +463,7 @@ Renderer::Renderer()
 
 	if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGLES3)
 	{
-		if (strstr(g_ogl_config.glsl_version, "3.00"))
+		if (strstr(g_ogl_config.glsl_version, "3.0"))
 		{
 			g_ogl_config.eSupportedGLSLVersion = GLSLES_300;
 		}


### PR DESCRIPTION
Mesa report GLES version as "3.0" not "3.00"
Spec mandates X.Y versioning scheme, doesn't say how long the decimal place must be.
