### PR TITLE
Support Sampler binding in the shader.

### DIFF
--- a/Data/Sys/Shaders/16bit.glsl
+++ b/Data/Sys/Shaders/16bit.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/32bit.glsl
+++ b/Data/Sys/Shaders/32bit.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/FXAA.glsl
+++ b/Data/Sys/Shaders/FXAA.glsl
@@ -12,7 +12,7 @@
 
 // 0. You just DO WHAT THE FUCK YOU WANT TO.
 
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/README.txt
+++ b/Data/Sys/Shaders/README.txt
@@ -1,5 +1,5 @@
 //dummy shader:
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/acidmetal.glsl
+++ b/Data/Sys/Shaders/acidmetal.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/acidtrip.glsl
+++ b/Data/Sys/Shaders/acidtrip.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/acidtrip2.glsl
+++ b/Data/Sys/Shaders/acidtrip2.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/asciiart.glsl
+++ b/Data/Sys/Shaders/asciiart.glsl
@@ -1,6 +1,6 @@
 // textures
-uniform sampler2D samp8;
-uniform sampler2D samp9;
+SAMPLER_BINDING(8) uniform sampler2D samp8;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 const int char_width = 8;
 const int char_height = 13;

--- a/Data/Sys/Shaders/auto_toon.glsl
+++ b/Data/Sys/Shaders/auto_toon.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/auto_toon2.glsl
+++ b/Data/Sys/Shaders/auto_toon2.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/bad_bloom.glsl
+++ b/Data/Sys/Shaders/bad_bloom.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/brighten.glsl
+++ b/Data/Sys/Shaders/brighten.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/chrismas.glsl
+++ b/Data/Sys/Shaders/chrismas.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/cool1.glsl
+++ b/Data/Sys/Shaders/cool1.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/darkerbrighter.glsl
+++ b/Data/Sys/Shaders/darkerbrighter.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/emboss.glsl
+++ b/Data/Sys/Shaders/emboss.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/fire.glsl
+++ b/Data/Sys/Shaders/fire.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/fire2.glsl
+++ b/Data/Sys/Shaders/fire2.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/firewater.glsl
+++ b/Data/Sys/Shaders/firewater.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/grayscale.glsl
+++ b/Data/Sys/Shaders/grayscale.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/grayscale2.glsl
+++ b/Data/Sys/Shaders/grayscale2.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/invert.glsl
+++ b/Data/Sys/Shaders/invert.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/invert_blue.glsl
+++ b/Data/Sys/Shaders/invert_blue.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/invertedoutline.glsl
+++ b/Data/Sys/Shaders/invertedoutline.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/mad_world.glsl
+++ b/Data/Sys/Shaders/mad_world.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/nightvision.glsl
+++ b/Data/Sys/Shaders/nightvision.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/nightvision2.glsl
+++ b/Data/Sys/Shaders/nightvision2.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/nightvision2scanlines.glsl
+++ b/Data/Sys/Shaders/nightvision2scanlines.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/posterize.glsl
+++ b/Data/Sys/Shaders/posterize.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/posterize2.glsl
+++ b/Data/Sys/Shaders/posterize2.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/primarycolors.glsl
+++ b/Data/Sys/Shaders/primarycolors.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/sepia.glsl
+++ b/Data/Sys/Shaders/sepia.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/sketchy.glsl
+++ b/Data/Sys/Shaders/sketchy.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/spookey1.glsl
+++ b/Data/Sys/Shaders/spookey1.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/spookey2.glsl
+++ b/Data/Sys/Shaders/spookey2.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/stereoscopic.glsl
+++ b/Data/Sys/Shaders/stereoscopic.glsl
@@ -1,7 +1,7 @@
 // Omega's 3D Stereoscopic filtering
 // TODO: Need depth info!
 
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/stereoscopic2.glsl
+++ b/Data/Sys/Shaders/stereoscopic2.glsl
@@ -1,7 +1,7 @@
 // Omega's 3D Stereoscopic filtering (Amber/Blue)
 // TODO: Need depth info!
 
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/sunset.glsl
+++ b/Data/Sys/Shaders/sunset.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/swap_RGB_BGR.glsl
+++ b/Data/Sys/Shaders/swap_RGB_BGR.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/swap_RGB_BRG.glsl
+++ b/Data/Sys/Shaders/swap_RGB_BRG.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/swap_RGB_GBR.glsl
+++ b/Data/Sys/Shaders/swap_RGB_GBR.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/swap_RGB_GRB.glsl
+++ b/Data/Sys/Shaders/swap_RGB_GRB.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/swap_RGB_RBG.glsl
+++ b/Data/Sys/Shaders/swap_RGB_RBG.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Data/Sys/Shaders/toxic.glsl
+++ b/Data/Sys/Shaders/toxic.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D samp9;
+SAMPLER_BINDING(9) uniform sampler2D samp9;
 
 out vec4 ocol0;
 in vec2 uv0;

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -169,7 +169,7 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
 	{
 		// non-msaa, so just fetch the pixel
 		sampler =
-			"uniform sampler2D samp9;\n"
+			"SAMPLER_BINDING(9) uniform sampler2D samp9;\n"
 			"vec4 sampleEFB(ivec2 pos) {\n"
 			"	return texelFetch(samp9, pos, 0);\n"
 			"}\n";
@@ -180,7 +180,7 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
 		// This will lead to sample shading, but it's the only way to not loose
 		// the values of each sample.
 		sampler =
-			"uniform sampler2DMS samp9;\n"
+			"SAMPLER_BINDING(9) uniform sampler2DMS samp9;\n"
 			"vec4 sampleEFB(ivec2 pos) {\n"
 			"	return texelFetch(samp9, pos, gl_SampleID);\n"
 			"}\n";
@@ -191,7 +191,7 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
 		std::stringstream samples;
 		samples << m_msaaSamples;
 		sampler =
-			"uniform sampler2DMS samp9;\n"
+			"SAMPLER_BINDING(9) uniform sampler2DMS samp9;\n"
 			"vec4 sampleEFB(ivec2 pos) {\n"
 			"	vec4 color = vec4(0.0, 0.0, 0.0, 0.0);\n"
 			"	for(int i=0; i<" + samples.str() + "; i++)\n"

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -61,12 +61,12 @@ static std::string GetGLSLVersionString()
 
 void SHADER::SetProgramVariables()
 {
-	// glsl shader must be bind to set samplers
-	Bind();
-
-	// Bind UBO
+	// Bind UBO and texture samplers
 	if (!g_ActiveConfig.backend_info.bSupportsBindingLayout)
 	{
+		// glsl shader must be bind to set samplers if we don't support binding layout
+		Bind();
+
 		GLint PSBlock_id = glGetUniformBlockIndex(glprogid, "PSBlock");
 		GLint VSBlock_id = glGetUniformBlockIndex(glprogid, "VSBlock");
 
@@ -74,20 +74,19 @@ void SHADER::SetProgramVariables()
 			glUniformBlockBinding(glprogid, PSBlock_id, 1);
 		if (VSBlock_id != -1)
 			glUniformBlockBinding(glprogid, VSBlock_id, 2);
+
+		// Bind Texture Sampler
+		for (int a = 0; a <= 9; ++a)
+		{
+			char name[8];
+			snprintf(name, 8, "samp%d", a);
+
+			// Still need to get sampler locations since we aren't binding them statically in the shaders
+			int loc = glGetUniformLocation(glprogid, name);
+			if (loc != -1)
+				glUniform1i(loc, a);
+		}
 	}
-
-	// Bind Texture Sampler
-	for (int a = 0; a <= 9; ++a)
-	{
-		char name[8];
-		snprintf(name, 8, "samp%d", a);
-
-		// Still need to get sampler locations since we aren't binding them statically in the shaders
-		int loc = glGetUniformLocation(glprogid, name);
-		if (loc != -1)
-			glUniform1i(loc, a);
-	}
-
 }
 
 void SHADER::SetProgramBindings()
@@ -479,6 +478,7 @@ void ProgramShaderCache::CreateHeader ( void )
 		"%s\n" // 420pack
 		"%s\n" // msaa
 		"%s\n" // sample shading
+		"%s\n" // Sampler binding
 
 		// Precision defines for GLSL ES
 		"%s\n"
@@ -509,6 +509,7 @@ void ProgramShaderCache::CreateHeader ( void )
 		, (g_ActiveConfig.backend_info.bSupportsBindingLayout && v < GLSLES_310) ? "#extension GL_ARB_shading_language_420pack : enable" : ""
 		, (g_ogl_config.bSupportsMSAA && v < GLSL_150) ? "#extension GL_ARB_texture_multisample : enable" : ""
 		, (g_ogl_config.bSupportSampleShading) ? "#extension GL_ARB_sample_shading : enable" : ""
+		, g_ActiveConfig.backend_info.bSupportsBindingLayout ? "#define SAMPLER_BINDING(x) layout(binding = x)" : "#define SAMPLER_BINDING(x)"
 
 		, v>=GLSLES_300 ? "precision highp float;" : ""
 		, v>=GLSLES_300 ? "precision highp int;" : ""

--- a/Source/Core/VideoBackends/OGL/RasterFont.cpp
+++ b/Source/Core/VideoBackends/OGL/RasterFont.cpp
@@ -124,7 +124,7 @@ static const char *s_vertexShaderSrc =
 	"}\n";
 
 static const char *s_fragmentShaderSrc =
-	"uniform sampler2D samp8;\n"
+	"SAMPLER_BINDING(8) uniform sampler2D samp8;\n"
 	"uniform vec4 color;\n"
 	"in vec2 uv0;\n"
 	"out vec4 ocol0;\n"

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -346,7 +346,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 TextureCache::TextureCache()
 {
 	const char *pColorMatrixProg =
-		"uniform sampler2D samp9;\n"
+		"SAMPLER_BINDING(9) uniform sampler2D samp9;\n"
 		"uniform vec4 colmat[7];\n"
 		"in vec2 uv0;\n"
 		"out vec4 ocol0;\n"
@@ -358,7 +358,7 @@ TextureCache::TextureCache()
 		"}\n";
 
 	const char *pDepthMatrixProg =
-		"uniform sampler2D samp9;\n"
+		"SAMPLER_BINDING(9) uniform sampler2D samp9;\n"
 		"uniform vec4 colmat[5];\n"
 		"in vec2 uv0;\n"
 		"out vec4 ocol0;\n"
@@ -372,7 +372,7 @@ TextureCache::TextureCache()
 
 	const char *VProgram =
 		"out vec2 uv0;\n"
-		"uniform sampler2D samp9;\n"
+		"SAMPLER_BINDING(9) uniform sampler2D samp9;\n"
 		"uniform vec4 copy_position;\n" // left, top, right, bottom
 		"void main()\n"
 		"{\n"

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -72,7 +72,7 @@ static void CreatePrograms()
 	const char *VProgramRgbToYuyv =
 		"out vec2 uv0;\n"
 		"uniform vec4 copy_position;\n" // left, top, right, bottom
-		"uniform sampler2D samp9;\n"
+		"SAMPLER_BINDING(9) uniform sampler2D samp9;\n"
 		"void main()\n"
 		"{\n"
 		"	vec2 rawpos = vec2(gl_VertexID&1, gl_VertexID&2);\n"
@@ -80,7 +80,7 @@ static void CreatePrograms()
 		"	uv0 = mix(copy_position.xy, copy_position.zw, rawpos) / vec2(textureSize(samp9, 0));\n"
 		"}\n";
 	const char *FProgramRgbToYuyv =
-		"uniform sampler2D samp9;\n"
+		"SAMPLER_BINDING(9) uniform sampler2D samp9;\n"
 		"in vec2 uv0;\n"
 		"out vec4 ocol0;\n"
 		"void main()\n"
@@ -111,7 +111,7 @@ static void CreatePrograms()
 		"	gl_Position = vec4(rawpos*2.0-1.0, 0.0, 1.0);\n"
 		"}\n";
 	const char *FProgramYuyvToRgb =
-		"uniform sampler2D samp9;\n"
+		"SAMPLER_BINDING(9) uniform sampler2D samp9;\n"
 		"in vec2 uv0;\n"
 		"out vec4 ocol0;\n"
 		"void main()\n"

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -204,7 +204,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	{
 		// Declare samplers
 		for (int i = 0; i < 8; ++i)
-			out.Write("uniform sampler2D samp%d;\n", i);
+			out.Write("SAMPLER_BINDING(%d) uniform sampler2D samp%d;\n", i, i);
 	}
 	else // D3D
 	{

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -70,7 +70,7 @@ static void WriteSwizzler(char*& p, u32 format, API_TYPE ApiType)
 	if (ApiType == API_OPENGL)
 	{
 		WRITE(p, "#define samp0 samp9\n");
-		WRITE(p, "uniform sampler2D samp0;\n");
+		WRITE(p, "SAMPLER_BINDING(9) uniform sampler2D samp0;\n");
 
 		WRITE(p, "  out vec4 ocol0;\n");
 		WRITE(p, "void main()\n");


### PR DESCRIPTION
In the cases where we support the binding layout keyword, use it for more than binding UBO location.
This changes it so it is supported for samplers as well.

Instances when this is enabled is if a device supports GL_ARB_shading_language_420pack, or if it supports GLES 3.10.
