### PR TITLE
Update for Android Play Store

### DIFF
--- a/Source/Android/AndroidManifest.xml
+++ b/Source/Android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.dolphinemu.dolphinemu"
-    android:versionCode="13"
-    android:versionName="0.13"
+    android:versionCode="14"
+    android:versionName="0.14"
     android:installLocation="auto">
 
     <uses-sdk


### PR DESCRIPTION
A new release in the Play Store is long overdue, the current Play Store release is outdated and does not work at ALL with Adreno GPUs. Most people who find the Android port find it on the Play Store, and when they see it hasn't been updated since December, they will probably assume it is not being worked on anymore. A lot of important Android fixes have been made, like multitouch and trigger fixes. Also, a link to the buildbot should have a place in the app description, people should be able to find it easier. I was thinking about this before, and a thread in the forums reminded me about it.
