### PR TITLE
Revert "PPCAnalyst now detects internal branches better"

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -172,22 +172,11 @@ bool AnalyzeFunction(u32 startAddr, Symbol &func, int max_size)
 				else
 				{
 					u32 target = EvaluateBranchTarget(instr, addr);
-					if (target != INVALID_TARGET)
+					if (target != INVALID_TARGET && instr.LK)
 					{
-						if (instr.LK)
-						{
-							//we found a branch-n-link!
-							func.calls.push_back(SCall(target, addr));
-							func.flags &= ~FFLAG_LEAF;
-						}
-						else
-						{
-							if (target > farthestInternalBranchTarget)
-							{
-								farthestInternalBranchTarget = target;
-							}
-							numInternalBranches++;
-						}
+						//we found a branch-n-link!
+						func.calls.push_back(SCall(target,addr));
+						func.flags &= ~FFLAG_LEAF;
 					}
 				}
 			}


### PR DESCRIPTION
This reverts commit 31ec57ab81790b4fd8f7237adc60279535416166.

This causes abnormally long game boot times.
Until we get away from a terrible linear search this is way too long for us.
