### PR TITLE
Interpreter: return single-precision results for ps_rsqrte.

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -196,8 +196,8 @@ void Interpreter::ps_rsqrte(UGeckoInstruction _inst)
 		SetFPException(FPSCR_VXSQRT);
 	}
 
-	rPS0(_inst.FD) = ApproximateReciprocalSquareRoot(rPS0(_inst.FB));
-	rPS1(_inst.FD) = ApproximateReciprocalSquareRoot(rPS1(_inst.FB));
+	rPS0(_inst.FD) = ForceSingle(ApproximateReciprocalSquareRoot(rPS0(_inst.FB)));
+	rPS1(_inst.FD) = ForceSingle(ApproximateReciprocalSquareRoot(rPS1(_inst.FB)));
 
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();


### PR DESCRIPTION
Should be obvious; the approximation should always fit into a float, but range of the result wasn't correctly restricted.
