### PR TITLE
Fix the vertexloader on non-x86 targets.

### DIFF
--- a/Source/Core/VideoCommon/VertexLoader.h
+++ b/Source/Core/VideoCommon/VertexLoader.h
@@ -17,7 +17,7 @@
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/NativeVertexFormat.h"
 
-#ifndef _M_GENERIC
+#ifdef _M_X86
 #ifndef __APPLE__
 #define USE_VERTEX_LOADER_JIT
 #endif


### PR DESCRIPTION
When I dropped ARM from a generic target, this caused the vertexloader to try using the JIT path.
Instead of !_M_GENERIC, check for _M_X86 instead. Since it is only for the x86 target
