### PR TITLE
Fix OpenGL video backend when using "render to main" on Windows.

### DIFF
--- a/Source/Core/DolphinWX/GLInterface/WGL.cpp
+++ b/Source/Core/DolphinWX/GLInterface/WGL.cpp
@@ -145,32 +145,11 @@ bool cInterfaceWGL::ClearCurrent()
 void cInterfaceWGL::Update()
 {
 	RECT rcWindow;
-	HWND parent = GetParent((HWND)m_window_handle);
-	if (!parent)
-	{
-		// We are not rendering to a child window - use client size.
-		GetClientRect((HWND)m_window_handle, &rcWindow);
-	}
-	else
-	{
-		// We are rendering to a child window - use parent size.
-		GetWindowRect(parent, &rcWindow);
-	}
+	GetClientRect((HWND)m_window_handle, &rcWindow);
 
 	// Get the new window width and height
-	// See below for documentation
-	int width = rcWindow.right - rcWindow.left;
-	int height = rcWindow.bottom - rcWindow.top;
-
-	// If we are rendering to a child window
-	if (GetParent((HWND)m_window_handle) != 0 &&
-			(s_backbuffer_width != width || s_backbuffer_height != height) &&
-			width >= 4 && height >= 4)
-	{
-		::MoveWindow((HWND)m_window_handle, 0, 0, width, height, FALSE);
-		s_backbuffer_width = width;
-		s_backbuffer_height = height;
-	}
+	s_backbuffer_width = rcWindow.right - rcWindow.left;
+	s_backbuffer_height = rcWindow.bottom - rcWindow.top;
 }
 
 // Close backend


### PR DESCRIPTION
> <Armada> now that the renderer doesn't create it's own window anymore it doesn't have to care about who is the parent of who and how the window should be sized, that's now handled by the GUI like it should be
> <Armada> but even with the previous code, what was done in OGL really should've been the responsibility of the EmuWindow
