### PR TITLE
VideoSoftware: remove duplicated CommandProcessor structures.

### DIFF
--- a/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
+++ b/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
@@ -152,8 +152,12 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 	// The low part of MMIO regs for FIFO addresses needs to be aligned to 32
 	// bytes.
 	u32 fifo_addr_lo_regs[] = {
-		FIFO_BASE_LO, FIFO_END_LO, FIFO_WRITE_POINTER_LO,
-		FIFO_READ_POINTER_LO, FIFO_BP_LO, FIFO_RW_DISTANCE_LO,
+		CommandProcessor::FIFO_BASE_LO,
+		CommandProcessor::FIFO_END_LO,
+		CommandProcessor::FIFO_WRITE_POINTER_LO,
+		CommandProcessor::FIFO_READ_POINTER_LO,
+		CommandProcessor::FIFO_BP_LO,
+		CommandProcessor::FIFO_RW_DISTANCE_LO,
 	};
 	for (u32 reg : fifo_addr_lo_regs)
 	{
@@ -164,7 +168,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 
 	// The clear register needs to perform some more complicated operations on
 	// writes.
-	mmio->RegisterWrite(base | CLEAR_REGISTER,
+	mmio->RegisterWrite(base | CommandProcessor::CLEAR_REGISTER,
 		MMIO::ComplexWrite<u16>([](u32, u16 val) {
 			UCPClearReg tmpClear(val);
 
@@ -281,7 +285,7 @@ void SetStatus()
 
 	cpreg.status.ReadIdle = cpreg.readptr == cpreg.writeptr;
 
-	bool bpInt = cpreg.status.Breakpoint && cpreg.ctrl.BreakPointIntEnable;
+	bool bpInt = cpreg.status.Breakpoint && cpreg.ctrl.BPInt;
 	bool ovfInt = cpreg.status.OverflowHiWatermark && cpreg.ctrl.FifoOverflowIntEnable;
 	bool undfInt = cpreg.status.UnderflowLoWatermark && cpreg.ctrl.FifoUnderflowIntEnable;
 

--- a/Source/Core/VideoBackends/Software/SWCommandProcessor.h
+++ b/Source/Core/VideoBackends/Software/SWCommandProcessor.h
@@ -6,6 +6,8 @@
 
 #include "Common/Common.h"
 
+#include "VideoCommon/CommandProcessor.h"
+
 class PointerWrap;
 namespace MMIO { class Mapping; }
 
@@ -14,84 +16,9 @@ extern u8* g_pVideoData;
 
 namespace SWCommandProcessor
 {
-	// internal hardware addresses
-	enum
-	{
-		STATUS_REGISTER          = 0x00,
-		CTRL_REGISTER            = 0x02,
-		CLEAR_REGISTER           = 0x04,
-		FIFO_TOKEN_REGISTER      = 0x0E,
-		FIFO_BOUNDING_BOX_LEFT   = 0x10,
-		FIFO_BOUNDING_BOX_RIGHT  = 0x12,
-		FIFO_BOUNDING_BOX_TOP    = 0x14,
-		FIFO_BOUNDING_BOX_BOTTOM = 0x16,
-		FIFO_BASE_LO             = 0x20,
-		FIFO_BASE_HI             = 0x22,
-		FIFO_END_LO              = 0x24,
-		FIFO_END_HI              = 0x26,
-		FIFO_HI_WATERMARK_LO     = 0x28,
-		FIFO_HI_WATERMARK_HI     = 0x2a,
-		FIFO_LO_WATERMARK_LO     = 0x2c,
-		FIFO_LO_WATERMARK_HI     = 0x2e,
-		FIFO_RW_DISTANCE_LO      = 0x30,
-		FIFO_RW_DISTANCE_HI      = 0x32,
-		FIFO_WRITE_POINTER_LO    = 0x34,
-		FIFO_WRITE_POINTER_HI    = 0x36,
-		FIFO_READ_POINTER_LO     = 0x38,
-		FIFO_READ_POINTER_HI     = 0x3A,
-		FIFO_BP_LO               = 0x3C,
-		FIFO_BP_HI               = 0x3E
-	};
-
-	// Fifo Status Register
-	union UCPStatusReg
-	{
-		struct
-		{
-			u16 OverflowHiWatermark  : 1;
-			u16 UnderflowLoWatermark : 1;
-			u16 ReadIdle             : 1; // done reading
-			u16 CommandIdle          : 1; // done processing commands
-			u16 Breakpoint           : 1;
-			u16                      : 11;
-		};
-		u16 Hex;
-		UCPStatusReg() {Hex = 0; }
-		UCPStatusReg(u16 _hex) {Hex = _hex; }
-	};
-
-	// Fifo Control Register
-	union UCPCtrlReg
-	{
-		struct
-		{
-			u16 GPReadEnable           : 1;
-			u16 BPEnable               : 1;
-			u16 FifoOverflowIntEnable  : 1;
-			u16 FifoUnderflowIntEnable : 1;
-			u16 GPLinkEnable           : 1;
-			u16 BreakPointIntEnable    : 1;
-			u16                        : 10;
-		};
-		u16 Hex;
-		UCPCtrlReg() {Hex = 0; }
-		UCPCtrlReg(u16 _hex) {Hex = _hex; }
-	};
-
-	// Fifo Control Register
-	union UCPClearReg
-	{
-		struct
-		{
-			u16 ClearFifoOverflow  : 1;
-			u16 ClearFifoUnderflow : 1;
-			u16 ClearMetrices      : 1;
-			u16                    : 13;
-		};
-		u16 Hex;
-		UCPClearReg() {Hex = 0; }
-		UCPClearReg(u16 _hex) {Hex = _hex; }
-	};
+	using UCPStatusReg = CommandProcessor::UCPStatusReg;
+	using UCPCtrlReg = CommandProcessor::UCPCtrlReg;
+	using UCPClearReg = CommandProcessor::UCPClearReg;
 
 	struct CPReg
 	{


### PR DESCRIPTION
No functional change; the structs/enums are identical.
