### PR TITLE
Workaround Intel driver bug computing TEV

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -140,7 +140,7 @@ static const char *tevAOutputTable[]  = { "prev.a", "c0.a", "c1.a", "c2.a" };
 static char text[16384];
 
 template<class T> static inline void WriteStage(T& out, pixel_shader_uid_data& uid_data, int n, API_TYPE ApiType, const char swapModeTable[4][5]);
-template<class T> static inline void WriteTevRegular(T& out, const char* components, int bias, int op, int clamp, int shift);
+template<class T> static inline void WriteTevRegular(T& out, const char* components, int bias, int op, int clamp, int shift, API_TYPE ApiType);
 template<class T> static inline void SampleTexture(T& out, const char *texcoords, const char *texswap, int texmap, API_TYPE ApiType);
 template<class T> static inline void WriteAlphaTest(T& out, pixel_shader_uid_data& uid_data, API_TYPE ApiType,DSTALPHA_MODE dstAlphaMode, bool per_pixel_depth);
 template<class T> static inline void WriteFog(T& out, pixel_shader_uid_data& uid_data);
@@ -763,7 +763,7 @@ static inline void WriteStage(T& out, pixel_shader_uid_data& uid_data, int n, AP
 	out.Write("\t%s = clamp(", tevCOutputTable[cc.dest]);
 	if (cc.bias != TevBias_COMPARE)
 	{
-		WriteTevRegular(out, "rgb", cc.bias, cc.op, cc.clamp, cc.shift);
+		WriteTevRegular(out, "rgb", cc.bias, cc.op, cc.clamp, cc.shift, ApiType);
 	}
 	else
 	{
@@ -793,7 +793,7 @@ static inline void WriteStage(T& out, pixel_shader_uid_data& uid_data, int n, AP
 	out.Write("\t%s = clamp(", tevAOutputTable[ac.dest]);
 	if (ac.bias != TevBias_COMPARE)
 	{
-		WriteTevRegular(out, "a", ac.bias, ac.op, ac.clamp, ac.shift);
+		WriteTevRegular(out, "a", ac.bias, ac.op, ac.clamp, ac.shift, ApiType);
 	}
 	else
 	{
@@ -822,7 +822,7 @@ static inline void WriteStage(T& out, pixel_shader_uid_data& uid_data, int n, AP
 }
 
 template<class T>
-static inline void WriteTevRegular(T& out, const char* components, int bias, int op, int clamp, int shift)
+static inline void WriteTevRegular(T& out, const char* components, int bias, int op, int clamp, int shift, API_TYPE ApiType)
 {
 	const char *tevScaleTableLeft[] =
 	{
@@ -868,9 +868,26 @@ static inline void WriteTevRegular(T& out, const char* components, int bias, int
 	// - a rounding bias is added before dividing by 256
 	out.Write("(((tevin_d.%s%s)%s)", components, tevBiasTable[bias], tevScaleTableLeft[shift]);
 	out.Write(" %s ", tevOpTable[op]);
-	out.Write("((((tevin_a.%s*256 + (tevin_b.%s-tevin_a.%s)*(tevin_c.%s+(tevin_c.%s>>7)))%s)%s)>>8)",
-	          components, components, components, components, components,
-	          tevScaleTableLeft[shift], tevLerpBias[2*op+(shift!=3)]);
+	if (ApiType == API_D3D)
+	{
+		// There's a bug in the Intel shader compiler for Intel HD 4000 graphics
+		// under D3D which incorrectly processes a right shift in certain situations.
+		// The result is pixels randomly turning different colors. It is not known
+		// exactly what is required for a shader to trigger the issue. We work around
+		// the issue here by writing the TEV formula a bit differently.  It computes
+		// the same result as the original formula. (This fix is used for all D3D drivers.
+		// The D3D shader cache is independent of the driver version, so there
+		// isn't any way to reliably check for Intel graphics here at the moment.)
+		out.Write("((((tevin_a.%s*256 + (tevin_b.%s-tevin_a.%s)*(tevin_c.%s+(tevin_c.%s>=128?1:0)))%s)%s)>>8)",
+			components, components, components, components, components,
+			tevScaleTableLeft[shift], tevLerpBias[2 * op + (shift != 3)]);
+	}
+	else
+	{
+		out.Write("((((tevin_a.%s*256 + (tevin_b.%s-tevin_a.%s)*(tevin_c.%s+(tevin_c.%s>>7)))%s)%s)>>8)",
+			components, components, components, components, components,
+			tevScaleTableLeft[shift], tevLerpBias[2 * op + (shift != 3)]);
+	}
 	out.Write(")%s", tevScaleTableRight[shift]);
 }
 


### PR DESCRIPTION
Apparently switching around the formula a bit is enough to make the Intel driver happy.  It isn't known why.

I'm not really satisfied with this solution, but I don't have any other ideas. Fixes Issue 7167.
