### PR TITLE
Revert "Soften up some of the UI elements on Android"

### DIFF
--- a/Source/Android/res/layout/gamelist_folderbrowser_list_item.xml
+++ b/Source/Android/res/layout/gamelist_folderbrowser_list_item.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="?android:attr/listPreferredItemHeight"
     android:padding="3dp">
@@ -10,40 +9,26 @@
         android:layout_width="wrap_content"
         android:layout_height="fill_parent"
 
-        tools:src="@drawable/ic_launcher"
-
         android:layout_alignParentTop="true"
         android:layout_alignParentBottom="true"
         android:layout_marginRight="6dip"/>
 
-    <!-- Properties in the 'tools' namespace are only visible in the UI editor, not at runtime. -->
-    <TextView tools:text="@string/file_size"
+    <TextView
         android:id="@+id/ListItemSubTitle"
         android:layout_width="fill_parent"
-        android:layout_height="26dip"
-
-        android:textColor="#bbbbbb"
+        android:layout_height="26dip" 
 
         android:layout_toRightOf="@id/ListItemIcon"
         android:layout_alignParentBottom="true"
         android:layout_alignParentRight="true"
 
         android:singleLine="true"
-        android:ellipsize="marquee"
-        />
+        android:ellipsize="marquee"/>
 
-    <!-- Properties in the 'tools' namespace are only visible in the UI editor, not at runtime. -->
-    <TextView tools:text="Name of Game"
+    <TextView
         android:id="@+id/ListItemTitle"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-
-        android:fontFamily="sans-serif-light"
-        android:textSize="22sp"
-        android:textColor="#555555"
-
-        android:singleLine="true"
-        android:ellipsize="end"
 
         android:layout_toRightOf="@id/ListItemIcon"
         android:layout_alignParentRight="true"
@@ -52,6 +37,6 @@
         android:layout_alignWithParentIfMissing="true"
 
         android:gravity="center_vertical"
-        />
+        android:textStyle="bold" />
 
 </RelativeLayout>

--- a/Source/Android/res/layout/gamelist_listview.xml
+++ b/Source/Android/res/layout/gamelist_listview.xml
@@ -1,8 +1,6 @@
 <ListView xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          android:id="@+id/gamelist"
+    android:id="@+id/gamelist"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:choiceMode="singleChoice"
-    android:dividerHeight="1dp"
-    tools:listitem="@layout/gamelist_folderbrowser_list_item"/>
+    android:dividerHeight="1dp"/>

--- a/Source/Android/res/layout/sidemenu.xml
+++ b/Source/Android/res/layout/sidemenu.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="48dp"
+    android:layout_height="match_parent"
     android:gravity="left"
     android:orientation="vertical" >
 
@@ -10,11 +9,12 @@
         android:id="@+id/SideMenuTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="4dp"
+        android:layout_marginLeft="5dip"
+        android:layout_marginTop="5dip"
         android:singleLine="true"
-        tools:text="Menu Option"
-        android:textAppearance="?android:attr/textAppearanceLarge"
-        android:fontFamily="sans-serif-light"
+        android:text="@+id/TextView01"
+        android:textAppearance="?android:attr/textAppearanceLarge" 
+        android:textStyle="bold"
         android:textColor="#FFFFFF" />
 
 </LinearLayout>


### PR DESCRIPTION
My main reason for wanting this reverted is this: http://i.imgur.com/LmeWY1p.png?1

On a 4.5"@720p screen, there's barely enough room to show half the title of most games in portrait mode. It may work better on larger screens, for example the person who submitted this code used screenshots that represented what it would look like on a Nexus 5. The thing is, a lot of devices do not have the larger screen that this was designed for. If anyone really wants the fonts used in this, we can at least decrease the size and re-enable text on more than one line.
