### PR TITLE
Ensure (Get|Set)ColumnWidth is not called on a non existant column.

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -1285,7 +1285,7 @@ void CGameListCtrl::AutomaticColumnWidth()
 	{
 		SetColumnWidth(0, rc.GetWidth());
 	}
-	else
+	else if (GetColumnCount() > 0)
 	{
 
 		int resizable = rc.GetWidth() - (


### PR DESCRIPTION
The AutomaticColumnWidth method can be called when the game list does not have any columns (for example when dolphin is starting).  In this case wxWidgets assertions fail when (Get|Set)ColumnWidth are called on columns that do not exist.  So check to make sure there are columns to prevent this.
