### PR TITLE
Remove bFlushToZero

### DIFF
--- a/Source/Core/Common/CPUDetect.h
+++ b/Source/Core/Common/CPUDetect.h
@@ -45,10 +45,6 @@ struct CPUInfo
 	// FXSAVE/FXRSTOR
 	bool bFXSR;
 	bool bMOVBE;
-	// This flag indicates that the hardware supports some mode
-	// in which denormal inputs _and_ outputs are automatically set to (signed) zero.
-	// TODO: ARM
-	bool bFlushToZero;
 	bool bLAHFSAHF64;
 	bool bLongMode;
 

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -183,8 +183,6 @@ void CPUInfo::Detect()
 		}
 	}
 
-	bFlushToZero = bSSE;
-
 	if (max_ex_fn >= 0x80000004) {
 		// Extract brand string
 		__cpuid(cpu_id, 0x80000002);
@@ -231,12 +229,7 @@ std::string CPUInfo::Summarize()
 {
 	std::string sum(cpu_string);
 	if (bSSE) sum += ", SSE";
-	if (bSSE2)
-	{
-		sum += ", SSE2";
-		if (!bFlushToZero)
-			sum += " (but not DAZ!)";
-	}
+	if (bSSE2) sum += ", SSE2";
 	if (bSSE3) sum += ", SSE3";
 	if (bSSSE3) sum += ", SSSE3";
 	if (bSSE4_1) sum += ", SSE4.1";

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -78,7 +78,7 @@ inline double ForceSingle(double _x)
 {
 	// convert to float...
 	float x = (float) _x;
-	if (!cpu_info.bFlushToZero && FPSCR.NI)
+	if (FPSCR.NI)
 	{
 		x = FlushToZero(x);
 	}
@@ -88,7 +88,7 @@ inline double ForceSingle(double _x)
 
 inline double ForceDouble(double d)
 {
-	if (!cpu_info.bFlushToZero && FPSCR.NI)
+	if (FPSCR.NI)
 	{
 		d = FlushToZero(d);
 	}


### PR DESCRIPTION
The interpreter should not rely on anything hardware-specific.
