### PR TITLE
Make the common "Failed to enumerate outputs" message much more useful.

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -243,7 +243,10 @@ HRESULT Create(HWND wnd)
 	{
 		// try using the first one
 		hr = adapter->EnumOutputs(0, &output);
-		if (FAILED(hr)) MessageBox(wnd, _T("Failed to enumerate outputs"), _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
+		if (FAILED(hr)) MessageBox(wnd, _T("Failed to enumerate outputs!\n")
+		                                _T("This usually happens when you've set your video adapter to the Nvidia GPU in an Optimus-equipped system.\n")
+		                                _T("Set Dolphin to use the high-performance graphics in Nvidia's drivers instead and leave Dolphin's video adapter set to the Intel GPU."),
+		                                _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
 	}
 
 	// get supported AA modes


### PR DESCRIPTION
Now it includes its most common cause, a simply-worded solution, and an exclamation point. Grammar/wording nitpicks welcome.

I used tabs for consistency with the PanicAlerts in OpenGL's Render.cpp; if spaces are preferred, I'll fix it.

I also have no way to test if this compiles/works/looks good without a Windows installation or a laptop with switchable graphics, so tests from the buildbot and anyone with those two things would be nice.
