### PR TITLE
Fix banner scaling using a different method.

### DIFF
--- a/Source/Android/res/layout/gamelist_folderbrowser_list_item.xml
+++ b/Source/Android/res/layout/gamelist_folderbrowser_list_item.xml
@@ -7,8 +7,8 @@
 
     <ImageView
         android:id="@+id/ListItemIcon"
-        android:layout_width="wrap_content"
-        android:layout_height="fill_parent"
+        android:layout_width="100dp"
+        android:layout_height="wrap_content"
 
         tools:src="@drawable/ic_launcher"
 

--- a/Source/Android/src/org/dolphinemu/dolphinemu/gamelist/GameListAdapter.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/gamelist/GameListAdapter.java
@@ -65,8 +65,6 @@ public final class GameListAdapter extends ArrayAdapter<GameListItem>
 			if (icon != null)
 			{
 				icon.setImageBitmap(item.getImage());
-				icon.getLayoutParams().width = (int) ((860 / context.getResources().getDisplayMetrics().density) + 0.5);
-				icon.getLayoutParams().height = (int)((340 / context.getResources().getDisplayMetrics().density) + 0.5);
 			}
 		}
 


### PR DESCRIPTION
As I commented in PR #517, Lioncash's issue is not incorrect, but is doing extra work. This fix relies more on android's built-in scaling.

I've tested the fix on an HTC Amaze, a phone wholly incapable of running Dolphin but with a low screen resolution, which exacerbates the original issue:

![amaze-issue](https://cloud.githubusercontent.com/assets/1912034/3349345/c067276a-f95d-11e3-9233-02dc6160685e.png)

The code in GameListAdapter.java causes this incorrect scaling. I can't explain why that is since I don't really know what the logic of those two lines was supposed to be (if I had to guess, the 860 should probably be a 640, and the 0.5 addition is probably not necessary either.) If you were to make just the changes I made to the layout XML, the output would be the same, because this code overrides the XML's contents. If you take those two lines out as I did, you have the following output:

![amaze-java-removed](https://cloud.githubusercontent.com/assets/1912034/3349352/2fcbd7f4-f95e-11e3-9a51-cabac120e7a3.png)

As Lioncash commented, this is not a great case either - on this phone it looks decent, but on a Nexus 5 it would be unreadably small. If you then add in the changes from the XML file, you get a much more desirable result.

![amaze-100dp](https://cloud.githubusercontent.com/assets/1912034/3349354/58f66d38-f95e-11e3-9158-4294278c764b.png)![nexus-5-fixed](https://cloud.githubusercontent.com/assets/1912034/3349356/5f1cae66-f95e-11e3-9c88-8752ed90bcb6.png)

In these screenshots (one from the Amaze and one from Nexus 5) the banners are proportionally the same size (100 density-independent pixels; for most phones this translates to roughly 27% of screen width, regardless of pixel density). We can tweak this 100dp number up or down as desired if further adjustments are necessary.
