### PR TITLE
Allow user to quit Android app with back button.

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/gamelist/GameListActivity.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/gamelist/GameListActivity.java
@@ -298,6 +298,13 @@ public final class GameListActivity extends Activity
 	@Override
 	public void onBackPressed()
 	{
-		SwitchPage(0);
+		if (mCurFragmentNum == 0)
+		{
+			finish();
+		}
+		else
+		{
+			SwitchPage(0);
+		}
 	}
 }


### PR DESCRIPTION
As far as I could tell this wasn't intentionally disabled. It seems a bit of a pain to have to use the home button to leave the main menu; this commit should fix that.
