### PR TITLE
Fixed issue with DSP Dump not closing files.

### DIFF
--- a/Source/DSPSpy/main_spy.cpp
+++ b/Source/DSPSpy/main_spy.cpp
@@ -224,19 +224,23 @@ void DumpDSP_ROMs(const u16* rom, const u16* coef)
 	FILE *fROM = fopen(filename, "wb");
 	sprintf(filename, "sd:/dsp_coef.bin");
 	FILE *fCOEF = fopen(filename, "wb");
+
 	if (fROM && fCOEF)
 	{
 		fwrite(MEM_PHYSICAL_TO_K0(rom), 0x2000, 1, fROM);
-		fclose(fROM);
+		fwrite(MEM_PHYSICAL_TO_K0(coef), 0x1000, 1, fCOEF);
 
- 		fwrite(MEM_PHYSICAL_TO_K0(coef), 0x1000, 1, fCOEF);
- 		fclose(fCOEF);
 		UpdateLastMessage("DSP ROMs dumped to SD");
 	}
 	else
 	{
 		UpdateLastMessage("SD Write Error");
 	}
+
+	if (fROM)
+		fclose(fROM);
+	if (fCOEF)
+		fclose(fCOEF);
 #else
 	// Allow to connect to gdb (dump ram... :s)
 	_break();


### PR DESCRIPTION
When dumping the two DSP ROMs to file, if it failed to open one of them, neither will be closed. It should now close any that were opened.
