### PR TITLE
GCI Folder: correctly identify region of sysmenu

### DIFF
--- a/Source/Core/Common/NandPaths.h
+++ b/Source/Core/Common/NandPaths.h
@@ -11,6 +11,7 @@
 #include "Common/CommonTypes.h"
 
 #define TITLEID_SYSMENU 0x0000000100000002ull
+const static std::string TITLEID_SYSMENU_STRING = "0000000100000002";
 
 namespace Common
 {

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -4,6 +4,7 @@
 
 #include "Common/Common.h"
 #include "Common/FileUtil.h"
+#include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -17,6 +18,7 @@
 #include "Core/HW/GCMemcardRaw.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/Sram.h"
+#include "DiscIO/NANDContentLoader.h"
 
 #define MC_STATUS_BUSY              0x80
 #define MC_STATUS_UNLOCKED          0x40
@@ -100,8 +102,17 @@ void CEXIMemoryCard::setupGciFolder(u16 sizeMb)
 
 	DiscIO::IVolume::ECountry CountryCode = DiscIO::IVolume::COUNTRY_UNKNOWN;
 	auto strUniqueID = Core::g_CoreStartupParameter.m_strUniqueID;
+
 	u32 CurrentGameId = 0;
-	if (strUniqueID.length() >= 4)
+	if (strUniqueID == TITLEID_SYSMENU_STRING)
+	{
+		const DiscIO::INANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, true);
+		if (SysMenu_Loader.IsValid())
+		{
+			CountryCode = DiscIO::CountrySwitch(SysMenu_Loader.GetCountryChar());
+		}
+	}
+	else if (strUniqueID.length() >= 4)
 	{
 		CountryCode = DiscIO::CountrySwitch(strUniqueID.at(3));
 		memcpy((u8 *)&CurrentGameId, strUniqueID.c_str(), 4);


### PR DESCRIPTION
JMC47  identified that the wii system menu region was not correctly identified, this correctly identifies the region for the special case of the sysmenu,
gc/wii disc/wiiware/vc are all correctly identified by the original
homebrew will always use europe as is done everywhere else
