### PR TITLE
Store ini sections in a std::list to prevent pointer invalidation.

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -233,7 +233,7 @@ IniFile::Section* IniFile::GetOrCreateSection(const std::string& sectionName)
 	if (!section)
 	{
 		sections.push_back(Section(sectionName));
-		section = &sections[sections.size() - 1];
+		section = &sections.back();
 	}
 	return section;
 }
@@ -323,7 +323,7 @@ bool IniFile::GetLines(const std::string& sectionName, std::vector<std::string>*
 
 void IniFile::SortSections()
 {
-	std::sort(sections.begin(), sections.end());
+	sections.sort();
 }
 
 bool IniFile::Load(const std::string& filename, bool keep_current_data)

--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstring>
+#include <list>
 #include <map>
 #include <string>
 #include <vector>
@@ -116,7 +117,7 @@ public:
 	Section* GetOrCreateSection(const std::string& section);
 
 private:
-	std::vector<Section> sections;
+	std::list<Section> sections;
 
 	const Section* GetSection(const std::string& section) const;
 	Section* GetSection(const std::string& section);


### PR DESCRIPTION
Store ini sections in a std::list (rather than vector) to prevent unexpected pointer invalidation with use of GetOrCreateSection.
