### PR TITLE
Implement ViewHolder pattern on the GameListAdapter.

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/gamelist/GameListAdapter.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/gamelist/GameListAdapter.java
@@ -41,38 +41,55 @@ public final class GameListAdapter extends ArrayAdapter<GameListItem>
 	}
 
 	@Override
-	public View getView(int position, View convertView, ViewGroup parent)
+	public View getView(int position, View gameView, ViewGroup parent)
 	{
-		if (convertView == null)
+		ViewHolder holder;
+
+		// If getView() was called without passing in a recycled view,
+		if (gameView == null)
 		{
-			LayoutInflater vi = LayoutInflater.from(context);
-			convertView = vi.inflate(id, parent, false);
+			// Inflate a new view using the appropriate XML layout.
+			LayoutInflater inflater = LayoutInflater.from(context);
+			gameView = inflater.inflate(id, parent, false);
+
+			// Instantiate a holder to contain references to the game's views.
+			holder = new ViewHolder();
+			holder.title    = (TextView) gameView.findViewById(R.id.GameListItemTitle);
+			holder.subtitle = (TextView) gameView.findViewById(R.id.GameListItemSubTitle);
+			holder.icon    = (ImageView) gameView.findViewById(R.id.GameListItemIcon);
+
+			// Attach this list of references to the view.
+			gameView.setTag(holder);
+		}
+		// If we do have a recycled view, we can use the references it already contains.
+		else
+		{
+			holder = (ViewHolder) gameView.getTag();
 		}
 
+		// Get a reference to the game represented by this row.
 		final GameListItem item = getItem(position);
+
+		// Whether this row's view is newly created or not, set the children to contain the game's data.
 		if (item != null)
 		{
-			TextView title    = (TextView) convertView.findViewById(R.id.GameListItemTitle);
-			TextView subtitle = (TextView) convertView.findViewById(R.id.GameListItemSubTitle);
-			ImageView icon    = (ImageView) convertView.findViewById(R.id.GameListItemIcon);
-
-			if (title != null)
-				title.setText(item.getName());
-
-			if (subtitle != null)
-				subtitle.setText(item.getData());
-
-			if (icon != null)
-			{
-				icon.setImageBitmap(item.getImage());
-			}
+			holder.title.setText(item.getName());
+			holder.subtitle.setText(item.getData());
+			holder.icon.setImageBitmap(item.getImage());
 		}
 
 		// Make every other game in the list grey
 		if (position % 2 == 1)
-			convertView.setBackgroundColor(0xFFE3E3E3);
+			gameView.setBackgroundColor(0xFFE3E3E3);
 
-		return convertView;
+		return gameView;
+	}
+
+	private final class ViewHolder
+	{
+		public TextView title;
+		public TextView subtitle;
+		public ImageView icon;
 	}
 }
 


### PR DESCRIPTION
An optimization to the game list screen. In the case that there are more rows than can fit on screen, when the user scrolls to make another row visible, Android recycles the pre-inflated views from the row that just scrolled off screen. This avoids inflating views every time a new game comes on screen, and should enhance performance for users with many games.

So on Android, probably not a lot of users. But it's good practice and should be done with every ListAdapter class.
