### PR TITLE
Fix dragging and dropping savestates in the render window

### DIFF
--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -80,6 +80,7 @@ class CRenderFrame : public wxFrame
 
 	private:
 		void OnDropFiles(wxDropFilesEvent& event);
+		static bool IsValidSavestateDropped(const std::string& filepath);
 		#ifdef _WIN32
 			// Receive WndProc messages
 			WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam);


### PR DESCRIPTION
Attempts to sanitize and correctly load drag & dropped save-state files now.

Since the save-states are actually not appended with some sort of header ID (eww), we match the IDs.
