### PR TITLE
Centralize some common banner loader class members.

### DIFF
--- a/Source/Core/DiscIO/BannerLoader.h
+++ b/Source/Core/DiscIO/BannerLoader.h
@@ -19,18 +19,27 @@ class IBannerLoader
 {
 public:
 	IBannerLoader()
+		: m_pBannerFile(nullptr)
+		, m_IsValid(false)
 	{}
 
 	virtual ~IBannerLoader()
 	{}
-
-	virtual bool IsValid() = 0;
 
 	virtual std::vector<u32> GetBanner(int* pWidth, int* pHeight) = 0;
 
 	virtual std::vector<std::string> GetNames() = 0;
 	virtual std::string GetCompany() = 0;
 	virtual std::vector<std::string> GetDescriptions() = 0;
+
+	bool IsValid()
+	{
+		return m_IsValid;
+	}
+
+protected:
+	bool m_IsValid;
+	u8* m_pBannerFile;
 };
 
 IBannerLoader* CreateBannerLoader(DiscIO::IFileSystem& _rFileSystem, DiscIO::IVolume *pVolume);

--- a/Source/Core/DiscIO/BannerLoaderGC.cpp
+++ b/Source/Core/DiscIO/BannerLoaderGC.cpp
@@ -16,9 +16,7 @@
 namespace DiscIO
 {
 CBannerLoaderGC::CBannerLoaderGC(DiscIO::IFileSystem& _rFileSystem, DiscIO::IVolume* volume)
-	: m_pBannerFile(nullptr)
-	, m_IsValid(false)
-	, m_country(volume->GetCountry())
+	: m_country(volume->GetCountry())
 {
 	// load the opening.bnr
 	size_t FileSize = (size_t) _rFileSystem.GetFileSize("opening.bnr");
@@ -47,12 +45,6 @@ CBannerLoaderGC::~CBannerLoaderGC()
 		delete [] m_pBannerFile;
 		m_pBannerFile = nullptr;
 	}
-}
-
-
-bool CBannerLoaderGC::IsValid()
-{
-	return m_IsValid;
 }
 
 std::vector<u32> CBannerLoaderGC::GetBanner(int* pWidth, int* pHeight)

--- a/Source/Core/DiscIO/BannerLoaderGC.h
+++ b/Source/Core/DiscIO/BannerLoaderGC.h
@@ -26,8 +26,6 @@ public:
 	CBannerLoaderGC(DiscIO::IFileSystem& _rFileSystem, DiscIO::IVolume* volume);
 	virtual ~CBannerLoaderGC();
 
-	virtual bool IsValid() override;
-
 	virtual std::vector<u32> GetBanner(int* pWidth, int* pHeight) override;
 
 	virtual std::vector<std::string> GetNames() override;
@@ -79,10 +77,7 @@ private:
 		return string_decoder(std::string(data, strnlen(data, sizeof(data))));
 	}
 
-	u8* m_pBannerFile;
-	bool m_IsValid;
 	BANNER_TYPE m_BNRType;
-
 	BANNER_TYPE getBannerType();
 
 	DiscIO::IVolume::ECountry const m_country;

--- a/Source/Core/DiscIO/BannerLoaderWii.cpp
+++ b/Source/Core/DiscIO/BannerLoaderWii.cpp
@@ -21,8 +21,6 @@ namespace DiscIO
 {
 
 CBannerLoaderWii::CBannerLoaderWii(DiscIO::IVolume *pVolume)
-	: m_pBannerFile(nullptr)
-	, m_IsValid(false)
 {
 	u64 TitleID;
 	pVolume->GetTitleID((u8*)&TitleID);
@@ -93,11 +91,6 @@ CBannerLoaderWii::~CBannerLoaderWii()
 		delete [] m_pBannerFile;
 		m_pBannerFile = nullptr;
 	}
-}
-
-bool CBannerLoaderWii::IsValid()
-{
-	return m_IsValid;
 }
 
 std::vector<u32> CBannerLoaderWii::GetBanner(int* pWidth, int* pHeight)

--- a/Source/Core/DiscIO/BannerLoaderWii.h
+++ b/Source/Core/DiscIO/BannerLoaderWii.h
@@ -23,8 +23,6 @@ public:
 
 	virtual ~CBannerLoaderWii();
 
-	virtual bool IsValid() override;
-
 	virtual std::vector<u32> GetBanner(int* pWidth, int* pHeight) override;
 
 	virtual std::vector<std::string> GetNames() override;
@@ -57,11 +55,7 @@ private:
 		u16 m_Comment[2][COMMENT_SIZE];
 		u8  m_BannerTexture[TEXTURE_SIZE];
 		u8  m_IconTexture[8][ICON_SIZE];
-	} ;
-
-	u8* m_pBannerFile;
-
-	bool m_IsValid;
+	};
 
 	bool GetStringFromComments(const CommentIndex index, std::string& s);
 };


### PR DESCRIPTION
Centralizes common elements that are used the same way into the base class (`IBannerLoader`)

Specifically it moves m_IsValid, IsValid() and m_pBannerFile into `IBannerLoader`
