### PR TITLE
GCI Folder fix compatibility with games that relocate the save after first use

### DIFF
--- a/Source/Core/Core/HW/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard.h
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <algorithm>
 #include <string>
 
 #include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 
 #include "Core/HW/EXI_DeviceIPL.h"
@@ -156,9 +158,29 @@ struct DEntry
 	DEntry() { memset(this, 0xFF, DENTRY_SIZE); }
 	std::string GCI_FileName() const
 	{
-		return std::string((char *)Makercode, 2) + '-' + std::string((char *)Gamecode, 4) + '-' + (char *)Filename +
-			   ".gci";
+		std::string filename = std::string((char *)Makercode, 2) + '-' + std::string((char *)Gamecode, 4) + '-' + (char *)Filename +
+			".gci";
+		static Common::replace_v replacements;
+		if (replacements.size() == 0)
+		{
+			Common::ReadReplacements(replacements);
+			// Cannot add \r to replacements file due to it being a line ending char
+			// / might be ok, but we need to verify that this is only used on filenames
+			// as it is a dir_sep
+			replacements.push_back(std::make_pair('\r', std::string("__0d__")));
+			replacements.push_back(std::make_pair('/', std::string("__2f__")));
+
+		}
+
+		// Replaces chars that FAT32 can't support with strings defined in /sys/replace
+		for (auto& replacement : replacements)
+		{
+			for (size_t j = 0; (j = filename.find(replacement.first, j)) != filename.npos; ++j)
+				filename.replace(j, 1, replacement.second);
+		}
+		return filename;
 	}
+
 	u8 Gamecode[4];     //0x00       0x04    Gamecode
 	u8 Makercode[2];    //0x04      0x02    Makercode
 	u8 Unused1;         //0x06      0x01    reserved/unused (always 0xff, has no effect)

--- a/Source/Core/Core/HW/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcardDirectory.h
@@ -14,7 +14,7 @@ class GCMemcardDirectory : public MemoryCardBase, NonCopyable
 {
 public:
 	GCMemcardDirectory(std::string directory, int slot = 0, u16 sizeMb = MemCard2043Mb, bool ascii = true,
-					   int region = 0, int gameId = 0);
+		DiscIO::IVolume::ECountry  card_region = DiscIO::IVolume::COUNTRY_EUROPE, int gameId = 0);
 	~GCMemcardDirectory() { Flush(true); }
 	void Flush(bool exiting = false) override;
 
@@ -25,7 +25,7 @@ public:
 	void DoState(PointerWrap &p) override;
 
 private:
-	int LoadGCI(std::string fileName, int region);
+	int LoadGCI(std::string fileName, DiscIO::IVolume::ECountry card_region);
 	inline s32 SaveAreaRW(u32 block, bool writing = false);
 	// s32 DirectoryRead(u32 offset, u32 length, u8* destaddress);
 	s32 DirectoryWrite(u32 destaddress, u32 length, u8 *srcaddress);


### PR DESCRIPTION
Some games move the block location after their first use, this addresses that by correctly identifying this scenario.
Move scheduling flush to occur after a block is written, flush to disc is scheduled .5s after last block to card is written for both 'raw memcard' and gci folder  options
strip '\r' from the internal filename when generating gci filenames, tmnt failed to flush to disc because of this

ready for review
