### PR TITLE
FPS counter cleanup

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -181,7 +181,7 @@ Renderer::Renderer(void *&window_handle)
 {
 	int x, y, w_temp, h_temp;
 
-	InitFPSCounter();
+	FPSCounter::Initialize();
 
 	Host_GetRenderWindowSize(x, y, w_temp, h_temp);
 
@@ -954,7 +954,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbHeight,const EFBRectangl
 
 	// update FPS counter
 	if (XFBWrited)
-		s_fps = UpdateFPSCounter();
+		s_fps = FPSCounter::Update();
 
 	// Flip/present backbuffer to frontbuffer here
 	D3D::Present();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -340,7 +340,7 @@ Renderer::Renderer()
 	s_fps=0;
 	s_ShowEFBCopyRegions_VBO = 0;
 	s_blendMode = 0;
-	InitFPSCounter();
+	FPSCounter::Initialize();
 
 	bool bSuccess = true;
 
@@ -1584,7 +1584,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbHeight,const EFBRectangl
 	}
 
 	if (XFBWrited)
-		s_fps = UpdateFPSCounter();
+		s_fps = FPSCounter::Update();
 	// ---------------------------------------------------------------------
 	if (!DriverDetails::HasBug(DriverDetails::BUG_BROKENSWAP))
 	{

--- a/Source/Core/VideoCommon/FPSCounter.cpp
+++ b/Source/Core/VideoCommon/FPSCounter.cpp
@@ -2,41 +2,43 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/FileUtil.h"
-#include "Common/Timer.h"
+#include <fstream>
 
+#include "Common/FileUtil.h"
+#include "Common/StringUtil.h"
+#include "Common/Timer.h"
 #include "VideoCommon/FPSCounter.h"
 #include "VideoCommon/VideoConfig.h"
 
+namespace FPSCounter
+{
 #define FPS_REFRESH_INTERVAL 1000
 
 static unsigned int s_counter = 0;
 static unsigned int s_fps = 0;
 static unsigned int s_fps_last_counter = 0;
 static unsigned long s_last_update_time = 0;
-static File::IOFile s_bench_file;
+static std::ofstream s_bench_file;
 
-void InitFPSCounter()
+void Initialize()
 {
 	s_counter = s_fps_last_counter = 0;
 	s_fps = 0;
 	s_last_update_time = Common::Timer::GetTimeMs();
 
-	if (s_bench_file.IsOpen())
-		s_bench_file.Close();
+	if (s_bench_file.is_open())
+		s_bench_file.close();
 }
 
 static void LogFPSToFile(unsigned long val)
 {
-	if (!s_bench_file.IsOpen())
-		s_bench_file.Open(File::GetUserPath(D_LOGS_IDX) + "fps.txt", "w");
+	if (!s_bench_file.is_open())
+		s_bench_file.open(File::GetUserPath(D_LOGS_IDX) + "fps.txt");
 
-	char buffer[256];
-	snprintf(buffer, 256, "%lu\n", val);
-	s_bench_file.WriteArray(buffer, strlen(buffer));
+	s_bench_file << StringFromFormat("%lu\n", val);
 }
 
-int UpdateFPSCounter()
+int Update()
 {
 	if (Common::Timer::GetTimeMs() - s_last_update_time >= FPS_REFRESH_INTERVAL)
 	{
@@ -49,4 +51,5 @@ int UpdateFPSCounter()
 
 	s_counter++;
 	return s_fps;
+}
 }

--- a/Source/Core/VideoCommon/FPSCounter.h
+++ b/Source/Core/VideoCommon/FPSCounter.h
@@ -4,9 +4,12 @@
 
 #pragma once
 
+namespace FPSCounter
+{
 // Initializes the FPS counter.
-void InitFPSCounter();
+void Initialize();
 
 // Called when a frame is rendered. Returns the value to be displayed on
 // screen as the FPS counter (updated every second).
-int UpdateFPSCounter();
+int Update();
+}


### PR DESCRIPTION
- Isolate it into it's own namespace
- Shorten function names, the namespace self-documents.
- Just use the std I/O, we can just write directly to the stream for logging, rather than calling WriteArray.
