### PR TITLE
Fix a type-conversion warning in Movie.cpp

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -368,7 +368,7 @@ bool IsStartingFromClearSave()
 
 bool IsUsingMemcard(int memcard)
 {
-	return memcards & (1 << memcard);
+	return (memcards & (1 << memcard)) != 0;
 }
 bool IsSyncGPU()
 {


### PR DESCRIPTION
Fixes a C4800 warning. `'int' : forcing value to bool 'true' or 'false'(performance warning)`
