### PR TITLE
Place pinned memory as top priority.

### DIFF
--- a/Source/Core/VideoBackends/OGL/StreamBuffer.cpp
+++ b/Source/Core/VideoBackends/OGL/StreamBuffer.cpp
@@ -346,15 +346,15 @@ StreamBuffer* StreamBuffer::Create(u32 type, u32 size)
 	// Prefer the syncing buffers over the orphaning one
 	if (g_ogl_config.bSupportsGLSync)
 	{
-		// try to use buffer storage whenever possible
-		if (g_ogl_config.bSupportsGLBufferStorage &&
-			!(DriverDetails::HasBug(DriverDetails::BUG_BROKENBUFFERSTORAGE) && type == GL_ARRAY_BUFFER))
-			return new BufferStorage(type, size);
-
-		// pinned memory is almost as fine
+		// pinned memory is much faster on amd cards
 		if (g_ogl_config.bSupportsGLPinnedMemory &&
 			!(DriverDetails::HasBug(DriverDetails::BUG_BROKENPINNEDMEMORY) && type == GL_ELEMENT_ARRAY_BUFFER))
 			return new PinnedMemory(type, size);
+
+		// buffer storage works well in most situations
+		if (g_ogl_config.bSupportsGLBufferStorage &&
+			!(DriverDetails::HasBug(DriverDetails::BUG_BROKENBUFFERSTORAGE) && type == GL_ARRAY_BUFFER))
+			return new BufferStorage(type, size);
 
 		// don't fall back to MapAnd* for nvidia drivers
 		if (DriverDetails::HasBug(DriverDetails::BUG_BROKENUNSYNCMAPPING))


### PR DESCRIPTION
Was doing some testing with buffer storage, coherent mapping, and pinned memory, and found out that Pinned Memory was faster on AMD cards even with coherent mapping on.  As such, if we move Pinned Memory to the first priority, it makes both NVIDIA and AMD get maximum performance.

On my Radeon HD5850, this is an 8% boost compared to before the performance regression.   This should probably be tested on a variety of graphics cards even though it's a minor change.  I do know it works fine on my GTX 760 and my Radeon HD5850.

Implementation is based on what Sonicadvance1 told me to do plus the fact only AMD supports Pinned Memory, no one else.
