### PR TITLE
Keep device type EXIDEVICE_MEMORYCARDFOLDER for gci folder.

### DIFF
--- a/Source/Core/Core/HW/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI_Device.cpp
@@ -103,7 +103,6 @@ IEXIDevice* EXIDevice_Create(TEXIDevices device_type, const int channel_num)
 	{
 		bool gci_folder = (device_type == EXIDEVICE_MEMORYCARDFOLDER);
 		result = new CEXIMemoryCard(channel_num, gci_folder);
-		device_type = EXIDEVICE_MEMORYCARD;
 		break;
 	}
 	case EXIDEVICE_MASKROM:

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -33,6 +33,8 @@ void CEXIMemoryCard::FlushCallback(u64 userdata, int cyclesLate)
 	// note that userdata is forbidden to be a pointer, due to the implementation of EventDoState
 	int card_index = (int)userdata;
 	CEXIMemoryCard* pThis = (CEXIMemoryCard*)ExpansionInterface::FindDevice(EXIDEVICE_MEMORYCARD, card_index);
+	if (pThis == nullptr)
+		pThis = (CEXIMemoryCard*)ExpansionInterface::FindDevice(EXIDEVICE_MEMORYCARDFOLDER, card_index);
 	if (pThis && pThis->memorycard)
 		pThis->memorycard->Flush();
 }
@@ -41,6 +43,8 @@ void CEXIMemoryCard::CmdDoneCallback(u64 userdata, int cyclesLate)
 {
 	int card_index = (int)userdata;
 	CEXIMemoryCard* pThis = (CEXIMemoryCard*)ExpansionInterface::FindDevice(EXIDEVICE_MEMORYCARD, card_index);
+	if (pThis == nullptr)
+		pThis = (CEXIMemoryCard*)ExpansionInterface::FindDevice(EXIDEVICE_MEMORYCARDFOLDER, card_index);
 	if (pThis)
 		pThis->CmdDone();
 }

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -63,7 +63,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 27;
+static const u32 STATE_VERSION = 28;
 
 enum
 {


### PR DESCRIPTION
This fixes loading save states when type mismatches.
