### PR TITLE
Common: Make DoContainer within PointerWrap private.

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -128,17 +128,6 @@ public:
 	}
 
 	template <typename T>
-	void DoContainer(T& x)
-	{
-		u32 size = (u32)x.size();
-		Do(size);
-		x.resize(size);
-
-		for (auto& elem : x)
-			Do(elem);
-	}
-
-	template <typename T>
 	void Do(std::vector<T>& x)
 	{
 		DoContainer(x);
@@ -276,6 +265,17 @@ public:
 	}
 
 private:
+	template <typename T>
+	void DoContainer(T& x)
+	{
+		size_t size = x.size();
+		Do(size);
+		x.resize(size);
+
+		for (auto& elem : x)
+			Do(elem);
+	}
+
 	__forceinline void DoByte(u8& x)
 	{
 		switch (mode)


### PR DESCRIPTION
This shouldn't really be exposed as a public function and should only be called through other Do class functions that take a container type as a parameter. This is pretty unsafe otherwise (it'll fail on compilation, but still).

Also got rid of the cast and just used `size_t` as the size. 
