### PR TITLE
Common: Using size_t in PointerWrap's DoContainer apparently causes crashes

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -268,7 +268,7 @@ private:
 	template <typename T>
 	void DoContainer(T& x)
 	{
-		size_t size = x.size();
+		u32 size = (u32)x.size();
 		Do(size);
 		x.resize(size);
 


### PR DESCRIPTION
Fixes this.
