### PR TITLE
Make D3D Adapter selection optional.

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -237,6 +237,7 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
 	display->Set("RenderWindowAutoSize", m_LocalCoreStartupParameter.bRenderWindowAutoSize);
 	display->Set("KeepWindowOnTop", m_LocalCoreStartupParameter.bKeepWindowOnTop);
 	display->Set("ProgressiveScan", m_LocalCoreStartupParameter.bProgressive);
+	display->Set("AdapterSelection", m_LocalCoreStartupParameter.bAdapterSelection);
 	display->Set("DisableScreenSaver", m_LocalCoreStartupParameter.bDisableScreenSaver);
 	display->Set("ForceNTSCJ", m_LocalCoreStartupParameter.bForceNTSCJ);
 }
@@ -435,6 +436,7 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
 	display->Get("RenderWindowHeight",   &m_LocalCoreStartupParameter.iRenderWindowHeight,     480);
 	display->Get("RenderWindowAutoSize", &m_LocalCoreStartupParameter.bRenderWindowAutoSize,   false);
 	display->Get("KeepWindowOnTop",      &m_LocalCoreStartupParameter.bKeepWindowOnTop,        false);
+	display->Get("AdapterSelection",     &m_LocalCoreStartupParameter.bAdapterSelection,       false);
 	display->Get("ProgressiveScan",      &m_LocalCoreStartupParameter.bProgressive,            false);
 	display->Get("DisableScreenSaver",   &m_LocalCoreStartupParameter.bDisableScreenSaver,     true);
 	display->Get("ForceNTSCJ",           &m_LocalCoreStartupParameter.bForceNTSCJ,             false);

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -49,6 +49,7 @@ SCoreStartupParameter::SCoreStartupParameter()
   bRenderWindowAutoSize(false), bKeepWindowOnTop(false),
   bFullscreen(false), bRenderToMain(false),
   bProgressive(false), bDisableScreenSaver(false),
+  bAdapterSelection(false),
   iPosX(100), iPosY(100), iWidth(800), iHeight(600),
   bLoopFifoReplay(true)
 {

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -162,6 +162,7 @@ struct SCoreStartupParameter
 	bool bRenderWindowAutoSize, bKeepWindowOnTop;
 	bool bFullscreen, bRenderToMain;
 	bool bProgressive, bDisableScreenSaver;
+	bool bAdapterSelection;
 
 	int iPosX, iPosY, iWidth, iHeight;
 

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -116,6 +116,14 @@ protected:
 	}
 	void Event_Adapter(wxCommandEvent &ev) { ev.Skip(); } // TODO
 
+	void Event_AdapterSelection(wxCommandEvent &ev)
+	{
+		SConfig::GetInstance().m_LocalCoreStartupParameter.bAdapterSelection = ev.IsChecked();
+		Close();
+		g_video_backend->ShowConfig(GetParent());
+		ev.Skip();
+	}
+
 	void Event_DisplayResolution(wxCommandEvent &ev);
 
 	void Event_ProgressiveScan(wxCommandEvent &ev)


### PR DESCRIPTION
Also prevent being able to change Adapter while the Core is running

Too many people with switchable graphics would constantly select the GPU they are not supposed to select in Dolphin. However, there are cases where this feature is needed, so we shouldn't remove this.

IMO this seems like a hack, but I couldn't come up with a better way for this. Honestly I just want the "Failed to enumerate outputs" threads on the forum to stop.
