### PR TITLE
Revert "Don't add segfault handler in interpreter mode"

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -113,7 +113,7 @@ unsigned int CMixer::Mix(short* samples, unsigned int num_samples, bool consider
 
 	memset(samples, 0, num_samples * 2 * sizeof(short));
 
-	if (PowerPC::GetState() != PowerPC::STATE_RUNNING)
+	if (PowerPC::GetState() != PowerPC::CPU_RUNNING)
 	{
 		// Silence
 		return num_samples;
@@ -138,7 +138,7 @@ void CMixer::MixerFifo::PushSamples(const short *samples, unsigned int num_sampl
 		// The auto throttle function. This loop will put a ceiling on the CPU MHz.
 		while (num_samples * 2 + ((indexW - Common::AtomicLoad(m_indexR)) & INDEX_MASK) >= MAX_SAMPLES * 2)
 		{
-			if (*PowerPC::GetStatePtr() != PowerPC::STATE_RUNNING || soundStream->IsMuted())
+			if (*PowerPC::GetStatePtr() != PowerPC::CPU_RUNNING || soundStream->IsMuted())
 				break;
 			// Shortcut key for Throttle Skipping
 			if (Core::GetIsFramelimiterTempDisabled())

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -49,8 +49,7 @@ struct ConfigCache
 {
 	bool valid, bCPUThread, bSkipIdle, bEnableFPRF, bMMU, bDCBZOFF, m_EnableJIT, bDSPThread,
 	     bVBeamSpeedHack, bSyncGPU, bFastDiscSpeed, bMergeBlocks, bDSPHLE, bHLE_BS2, bTLBHack, bProgressive;
-	CPUBackend iCPUCore;
-	int Volume;
+	int iCPUCore, Volume;
 	int iWiimoteSource[MAX_BBMOTES];
 	SIDevices Pads[MAX_SI_CHANNELS];
 	unsigned int framelimit, frameSkip;
@@ -155,7 +154,7 @@ bool BootCore(const std::string& _rFilename)
 		core_section->Get("DSPHLE",           &StartUp.bDSPHLE, StartUp.bDSPHLE);
 		core_section->Get("DSPThread",        &StartUp.bDSPThread, StartUp.bDSPThread);
 		core_section->Get("GFXBackend",       &StartUp.m_strVideoBackend, StartUp.m_strVideoBackend);
-		core_section->Get("CPUCore",          (int*)&StartUp.iCPUCore, StartUp.iCPUCore);
+		core_section->Get("CPUCore",          &StartUp.iCPUCore, StartUp.iCPUCore);
 		core_section->Get("HLE_BS2",          &StartUp.bHLE_BS2, StartUp.bHLE_BS2);
 		core_section->Get("ProgressiveScan",  &StartUp.bProgressive, StartUp.bProgressive);
 		if (core_section->Get("FrameLimit",   &SConfig::GetInstance().m_Framelimit, SConfig::GetInstance().m_Framelimit))

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -479,11 +479,11 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 
 	core->Get("HLE_BS2",      &m_LocalCoreStartupParameter.bHLE_BS2, false);
 #ifdef _M_X86
-	core->Get("CPUCore",      (int*)&m_LocalCoreStartupParameter.iCPUCore, CPU_JIT_X64);
+	core->Get("CPUCore",      &m_LocalCoreStartupParameter.iCPUCore, 1);
 #elif _M_ARM_32
-	core->Get("CPUCore",      (int*)&m_LocalCoreStartupParameter.iCPUCore, CPU_JIT_ARM);
+	core->Get("CPUCore",      &m_LocalCoreStartupParameter.iCPUCore, 3);
 #else
-	core->Get("CPUCore",      (int*)&m_LocalCoreStartupParameter.iCPUCore, CPU_INTERPRETER);
+	core->Get("CPUCore",      &m_LocalCoreStartupParameter.iCPUCore, 0);
 #endif
 	core->Get("Fastmem",           &m_LocalCoreStartupParameter.bFastmem,      true);
 	core->Get("DSPThread",         &m_LocalCoreStartupParameter.bDSPThread,    false);

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -65,7 +65,7 @@ void SCoreStartupParameter::LoadDefaults()
 	iGDBPort = -1;
 	#endif
 
-	iCPUCore = CPU_JIT_X64;
+	iCPUCore = 1;
 	bCPUThread = false;
 	bSkipIdle = false;
 	bRunCompareServer = false;

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -83,15 +83,6 @@ enum Hotkey
 	NUM_HOTKEYS,
 };
 
-enum CPUBackend : u8
-{
-	CPU_INTERPRETER = 0,
-	CPU_JIT_X64     = 1,
-	CPU_JIT_IL_X64  = 2,
-	CPU_JIT_ARM     = 3,
-	CPU_JIT_IL_ARM  = 4,
-};
-
 struct SCoreStartupParameter
 {
 	void* hInstance;  // HINSTANCE but we don't want to include <windows.h>
@@ -104,7 +95,11 @@ struct SCoreStartupParameter
 	bool bAutomaticStart;
 	bool bBootToPause;
 
-	CPUBackend iCPUCore;
+	// 0 = Interpreter
+	// 1 = Jit
+	// 2 = JitIL
+	// 3 = JIT ARM
+	int iCPUCore;
 
 	// JIT (shared between JIT and JITIL)
 	bool bJITNoBlockCache, bJITBlockLinking;

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -18,8 +18,7 @@
 void PPCDebugInterface::Disassemble(unsigned int address, char *dest, int max_size)
 {
 	// Memory::ReadUnchecked_U32 seemed to crash on shutdown
-	if (PowerPC::GetState() == PowerPC::STATE_POWERDOWN)
-		return;
+	if (PowerPC::GetState() == PowerPC::CPU_POWERDOWN) return;
 
 	if (Core::GetState() != Core::CORE_UNINITIALIZED)
 	{

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -64,9 +64,9 @@ bool FifoPlayer::Play()
 	LoadMemory();
 
 	// This loop replaces the CPU loop that occurs when a game is run
-	while (PowerPC::GetState() != PowerPC::STATE_POWERDOWN)
+	while (PowerPC::GetState() != PowerPC::CPU_POWERDOWN)
 	{
-		if (PowerPC::GetState() == PowerPC::STATE_RUNNING)
+		if (PowerPC::GetState() == PowerPC::CPU_RUNNING)
 		{
 			if (m_CurrentFrame >= m_FrameRangeEnd)
 			{

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -47,21 +47,21 @@ void CCPU::Run()
 reswitch:
 		switch (PowerPC::GetState())
 		{
-		case PowerPC::STATE_RUNNING:
+		case PowerPC::CPU_RUNNING:
 			//1: enter a fast runloop
 			PowerPC::RunLoop();
 			break;
 
-		case PowerPC::STATE_STEPPING:
+		case PowerPC::CPU_STEPPING:
 			m_csCpuOccupied.unlock();
 
 			//1: wait for step command..
 			m_StepEvent.Wait();
 
 			m_csCpuOccupied.lock();
-			if (PowerPC::GetState() == PowerPC::STATE_POWERDOWN)
+			if (PowerPC::GetState() == PowerPC::CPU_POWERDOWN)
 				return;
-			if (PowerPC::GetState() != PowerPC::STATE_STEPPING)
+			if (PowerPC::GetState() != PowerPC::CPU_STEPPING)
 				goto reswitch;
 
 			//3: do a step
@@ -76,7 +76,7 @@ reswitch:
 			Host_UpdateDisasmDialog();
 			break;
 
-		case PowerPC::STATE_POWERDOWN:
+		case PowerPC::CPU_POWERDOWN:
 			//1: Exit loop!!
 			return;
 		}
@@ -91,7 +91,7 @@ void CCPU::Stop()
 
 bool CCPU::IsStepping()
 {
-	return PowerPC::GetState() == PowerPC::STATE_STEPPING;
+	return PowerPC::GetState() == PowerPC::CPU_STEPPING;
 }
 
 void CCPU::Reset()
@@ -102,7 +102,7 @@ void CCPU::Reset()
 void CCPU::StepOpcode(Common::Event *event)
 {
 	m_StepEvent.Set();
-	if (PowerPC::GetState() == PowerPC::STATE_STEPPING)
+	if (PowerPC::GetState() == PowerPC::CPU_STEPPING)
 	{
 		m_SyncEvent = event;
 	}

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -61,7 +61,7 @@ u64 g_recordingStartTime; // seconds since 1970 that recording started
 bool bSaveConfig = false, bSkipIdle = false, bDualCore = false, bProgressive = false, bDSPHLE = false, bFastDiscSpeed = false;
 bool g_bClearSave = false, bSyncGPU = false, bNetPlay = false;
 std::string videoBackend = "unknown";
-CPUBackend iCPUCore = CPU_JIT_X64;
+int iCPUCore = 1;
 bool g_bDiscChange = false;
 std::string g_discChange = "";
 std::string author = "";
@@ -143,9 +143,9 @@ void FrameUpdate()
 	}
 
 	// ("framestop") the only purpose of this is to cause interpreter/jit Run() to return temporarily.
-	// after that we set it back to STATE_RUNNING and continue as normal.
+	// after that we set it back to CPU_RUNNING and continue as normal.
 	if (g_bFrameStop)
-		*PowerPC::GetStatePtr() = PowerPC::STATE_STEPPING;
+		*PowerPC::GetStatePtr() = PowerPC::CPU_STEPPING;
 
 	if (g_framesToSkip)
 		FrameSkipping();
@@ -356,7 +356,7 @@ bool IsFastDiscSpeed()
 	return bFastDiscSpeed;
 }
 
-CPUBackend GetCPUMode()
+int GetCPUMode()
 {
 	return iCPUCore;
 }

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -8,7 +8,7 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/Common.h"
-#include "Core/CoreParameter.h"
+
 #include "InputCommon/GCPadStatus.h"
 
 namespace WiimoteEmu
@@ -99,7 +99,7 @@ struct DTMHeader
 	bool bProgressive;
 	bool bDSPHLE;
 	bool bFastDiscSpeed;
-	CPUBackend CPUCore;
+	u8  CPUCore;            // 0 = interpreter, 1 = JIT, 2 = JITIL
 	bool bEFBAccessEnable;
 	bool bEFBCopyEnable;
 	bool bCopyEFBToTexture;
@@ -144,7 +144,7 @@ bool IsProgressive();
 bool IsSkipIdle();
 bool IsDSPHLE();
 bool IsFastDiscSpeed();
-CPUBackend GetCPUMode();
+int  GetCPUMode();
 bool IsStartingFromClearSave();
 bool IsUsingMemcard(int memcard);
 bool IsSyncGPU();

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -266,7 +266,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
 			std::lock_guard<std::recursive_mutex> lkg(m_crit.game);
 			packet >> m_current_game;
 			packet >> g_NetPlaySettings.m_CPUthread;
-			packet >> (u8&)g_NetPlaySettings.m_CPUcore;
+			packet >> g_NetPlaySettings.m_CPUcore;
 			packet >> g_NetPlaySettings.m_DSPEnableJIT;
 			packet >> g_NetPlaySettings.m_DSPHLE;
 			packet >> g_NetPlaySettings.m_WriteToMemcard;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -6,13 +6,13 @@
 
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
-#include "Core/CoreParameter.h"
+
 #include "Core/HW/EXI_Device.h"
 
 struct NetSettings
 {
 	bool m_CPUthread;
-	CPUBackend m_CPUcore;
+	int m_CPUcore;
 	bool m_DSPHLE;
 	bool m_DSPEnableJIT;
 	bool m_WriteToMemcard;
@@ -28,7 +28,7 @@ struct Rpt : public std::vector<u8>
 
 typedef std::vector<u8> NetWiimote;
 
-#define NETPLAY_VERSION  "Dolphin NetPlay 2014-06-13"
+#define NETPLAY_VERSION  "Dolphin NetPlay 2014-01-08"
 
 const int NETPLAY_INITIAL_GCTIME = 1272737767;
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -548,7 +548,7 @@ bool NetPlayServer::StartGame(const std::string &path)
 	spac << (MessageId)NP_MSG_START_GAME;
 	spac << m_current_game;
 	spac << m_settings.m_CPUthread;
-	spac << (u8)m_settings.m_CPUcore;
+	spac << m_settings.m_CPUcore;
 	spac << m_settings.m_DSPEnableJIT;
 	spac << m_settings.m_DSPHLE;
 	spac << m_settings.m_WriteToMemcard;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -409,7 +409,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 		// Comment out the following to disable breakpoints (speed-up)
 		if (!Profiler::g_ProfileBlocks)
 		{
-			if (GetState() == STATE_STEPPING)
+			if (GetState() == CPU_STEPPING)
 				blockSize = 1;
 			Trace();
 		}
@@ -583,7 +583,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 				SetJumpTarget(clearInt);
 			}
 
-			if (Core::g_CoreStartupParameter.bEnableDebugging && breakpoints.IsAddressBreakPoint(ops[i].address) && GetState() != STATE_STEPPING)
+			if (Core::g_CoreStartupParameter.bEnableDebugging && breakpoints.IsAddressBreakPoint(ops[i].address) && GetState() != CPU_STEPPING)
 			{
 				gpr.Flush();
 				fpr.Flush();

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -54,7 +54,7 @@ void Jit64AsmRoutineManager::Generate()
 
 			if (Core::g_CoreStartupParameter.bEnableDebugging)
 			{
-				TEST(32, M((void*)PowerPC::GetStatePtr()), Imm32(PowerPC::STATE_STEPPING));
+				TEST(32, M((void*)PowerPC::GetStatePtr()), Imm32(PowerPC::CPU_STEPPING));
 				FixupBranch notStepping = J_CC(CC_Z);
 				ABI_CallFunction(reinterpret_cast<void *>(&PowerPC::CheckBreakPoints));
 				TEST(32, M((void*)PowerPC::GetStatePtr()), Imm32(0xFFFFFFFF));

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -508,7 +508,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 		// Comment out the following to disable breakpoints (speed-up)
 		if (!Profiler::g_ProfileBlocks)
 		{
-			if (GetState() == STATE_STEPPING)
+			if (GetState() == CPU_STEPPING)
 				blockSize = 1;
 			Trace();
 		}
@@ -642,7 +642,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 				ibuild.EmitExtExceptionCheck(ibuild.EmitIntConst(ops[i].address));
 			}
 
-			if (Core::g_CoreStartupParameter.bEnableDebugging && breakpoints.IsAddressBreakPoint(ops[i].address) && GetState() != STATE_STEPPING)
+			if (Core::g_CoreStartupParameter.bEnableDebugging && breakpoints.IsAddressBreakPoint(ops[i].address) && GetState() != CPU_STEPPING)
 			{
 				ibuild.EmitBreakPointCheck(ibuild.EmitIntConst(ops[i].address));
 			}

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -30,7 +30,7 @@ namespace PowerPC
 
 // STATE_TO_SAVE
 PowerPCState GC_ALIGNED16(ppcState);
-volatile CPUState state = STATE_STEPPING;
+volatile CPUState state = CPU_STEPPING;
 
 Interpreter * const interpreter = Interpreter::getInstance();
 CoreMode mode;
@@ -135,7 +135,7 @@ void Init(int cpu_core)
 
 	switch (cpu_core)
 	{
-		case CPU_INTERPRETER:
+		case 0:
 		{
 			cpu_core_base = interpreter;
 			break;
@@ -158,7 +158,7 @@ void Init(int cpu_core)
 	{
 		mode = MODE_INTERPRETER;
 	}
-	state = STATE_STEPPING;
+	state = CPU_STEPPING;
 
 	ppcState.iCache.Init();
 }
@@ -168,7 +168,7 @@ void Shutdown()
 	JitInterface::Shutdown();
 	interpreter->Shutdown();
 	cpu_core_base = nullptr;
-	state = STATE_POWERDOWN;
+	state = CPU_POWERDOWN;
 }
 
 CoreMode GetMode()
@@ -205,7 +205,7 @@ void SingleStep()
 
 void RunLoop()
 {
-	state = STATE_RUNNING;
+	state = CPU_RUNNING;
 	cpu_core_base->Run();
 	Host_UpdateDisasmDialog();
 }
@@ -222,19 +222,19 @@ volatile CPUState *GetStatePtr()
 
 void Start()
 {
-	state = STATE_RUNNING;
+	state = CPU_RUNNING;
 	Host_UpdateDisasmDialog();
 }
 
 void Pause()
 {
-	state = STATE_STEPPING;
+	state = CPU_STEPPING;
 	Host_UpdateDisasmDialog();
 }
 
 void Stop()
 {
-	state = STATE_POWERDOWN;
+	state = CPU_POWERDOWN;
 	Host_UpdateDisasmDialog();
 }
 

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -75,9 +75,9 @@ struct GC_ALIGNED64(PowerPCState)
 
 enum CPUState
 {
-	STATE_RUNNING = 0,
-	STATE_STEPPING = 2,
-	STATE_POWERDOWN = 3,
+	CPU_RUNNING = 0,
+	CPU_STEPPING = 2,
+	CPU_POWERDOWN = 3,
 };
 
 extern PowerPCState ppcState;

--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -32,7 +32,6 @@
 
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
-#include "Core/CoreParameter.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
 #include "Core/HW/EXI.h"
@@ -58,17 +57,17 @@
 
 struct CPUCore
 {
-	CPUBackend CPUid;
+	int CPUid;
 	const char *name;
 };
 const CPUCore CPUCores[] = {
-	{CPU_INTERPRETER, wxTRANSLATE("Interpreter (VERY slow)")},
+	{0, wxTRANSLATE("Interpreter (VERY slow)")},
 #ifdef _M_ARM
-	{CPU_JIT_ARM, wxTRANSLATE("Arm JIT (experimental)")},
-	{CPU_JIT_IL_ARM, wxTRANSLATE("Arm JITIL (experimental)")},
+	{3, wxTRANSLATE("Arm JIT (experimental)")},
+	{4, wxTRANSLATE("Arm JITIL (experimental)")},
 #else
-	{CPU_JIT_X64, wxTRANSLATE("JIT Recompiler (recommended)")},
-	{CPU_JIT_IL_X64, wxTRANSLATE("JITIL Recompiler (slower, experimental)")},
+	{1, wxTRANSLATE("JIT Recompiler (recommended)")},
+	{2, wxTRANSLATE("JITIL Recompiler (slower, experimental)")},
 #endif
 };
 
@@ -908,7 +907,7 @@ void CConfigMain::CoreSettingsChanged(wxCommandEvent& event)
 		SConfig::GetInstance().m_LocalCoreStartupParameter.iCPUCore = CPUCores[CPUEngine->GetSelection()].CPUid;
 		if (main_frame->g_pCodeWindow)
 			main_frame->g_pCodeWindow->GetMenuBar()->Check(IDM_INTERPRETER,
-				SConfig::GetInstance().m_LocalCoreStartupParameter.iCPUCore == CPU_INTERPRETER);
+				SConfig::GetInstance().m_LocalCoreStartupParameter.iCPUCore?false:true);
 		break;
 	case ID_NTSCJ:
 		SConfig::GetInstance().m_LocalCoreStartupParameter.bForceNTSCJ = _NTSCJ->IsChecked();

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -369,7 +369,7 @@ void CCodeWindow::CreateMenu(const SCoreStartupParameter& _LocalCoreStartupParam
 		" and stepping to work as explained in the Developer Documentation. But it can be very"
 		" slow, perhaps slower than 1 fps."),
 		wxITEM_CHECK);
-	interpreter->Check(_LocalCoreStartupParameter.iCPUCore == CPU_INTERPRETER);
+	interpreter->Check(_LocalCoreStartupParameter.iCPUCore == 0);
 	pCoreMenu->AppendSeparator();
 
 	pCoreMenu->Append(IDM_JITBLOCKLINKING, _("&JIT Block Linking off"),

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -370,7 +370,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Run(JNIEnv *
 
 	// No use running the loop when booting fails
 	if ( BootManager::BootCore( g_filename.c_str() ) )
-		while (PowerPC::GetState() != PowerPC::STATE_POWERDOWN)
+		while (PowerPC::GetState() != PowerPC::CPU_POWERDOWN)
 			updateMainFrameEvent.Wait();
 
 	WiimoteReal::Shutdown();

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -380,7 +380,7 @@ int main(int argc, char* argv[])
 		[event release];
 		[pool release];
 #else
-		while (PowerPC::GetState() != PowerPC::STATE_POWERDOWN)
+		while (PowerPC::GetState() != PowerPC::CPU_POWERDOWN)
 			updateMainFrameEvent.Wait();
 #endif
 	}


### PR DESCRIPTION
Reverts dolphin-emu/dolphin#328

Several reported regressions, including Dolphin defaulting to interpreter mode.
