### PR TITLE
D3D: Use std::strings for Compile[x]Shader and CompileAndCreate[x]Shader

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DShader.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DShader.cpp
@@ -27,7 +27,7 @@ ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, unsigne
 }
 
 // code->bytecode
-bool CompileVertexShader(const char* code, unsigned int len, D3DBlob** blob)
+bool CompileVertexShader(const std::string& code, D3DBlob** blob)
 {
 	ID3D10Blob* shaderBuffer = nullptr;
 	ID3D10Blob* errorBuffer = nullptr;
@@ -37,7 +37,7 @@ bool CompileVertexShader(const char* code, unsigned int len, D3DBlob** blob)
 #else
 	UINT flags = D3D10_SHADER_ENABLE_BACKWARDS_COMPATIBILITY|D3D10_SHADER_OPTIMIZATION_LEVEL3|D3D10_SHADER_SKIP_VALIDATION;
 #endif
-	HRESULT hr = PD3DCompile(code, len, nullptr, nullptr, nullptr, "main", D3D::VertexShaderVersionString(),
+	HRESULT hr = PD3DCompile(code.c_str(), code.length(), nullptr, nullptr, nullptr, "main", D3D::VertexShaderVersionString(),
 							flags, 0, &shaderBuffer, &errorBuffer);
 	if (errorBuffer)
 	{
@@ -82,8 +82,7 @@ ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, uns
 }
 
 // code->bytecode
-bool CompileGeometryShader(const char* code, unsigned int len, D3DBlob** blob,
-	const D3D_SHADER_MACRO* pDefines)
+bool CompileGeometryShader(const std::string& code, D3DBlob** blob, const D3D_SHADER_MACRO* pDefines)
 {
 	ID3D10Blob* shaderBuffer = nullptr;
 	ID3D10Blob* errorBuffer = nullptr;
@@ -93,7 +92,7 @@ bool CompileGeometryShader(const char* code, unsigned int len, D3DBlob** blob,
 #else
 	UINT flags = D3D10_SHADER_ENABLE_BACKWARDS_COMPATIBILITY|D3D10_SHADER_OPTIMIZATION_LEVEL3|D3D10_SHADER_SKIP_VALIDATION;
 #endif
-	HRESULT hr = PD3DCompile(code, len, nullptr, pDefines, nullptr, "main", D3D::GeometryShaderVersionString(),
+	HRESULT hr = PD3DCompile(code.c_str(), code.length(), nullptr, pDefines, nullptr, "main", D3D::GeometryShaderVersionString(),
 							flags, 0, &shaderBuffer, &errorBuffer);
 
 	if (errorBuffer)
@@ -141,8 +140,7 @@ ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, unsigned 
 }
 
 // code->bytecode
-bool CompilePixelShader(const char* code, unsigned int len, D3DBlob** blob,
-	const D3D_SHADER_MACRO* pDefines)
+bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADER_MACRO* pDefines)
 {
 	ID3D10Blob* shaderBuffer = nullptr;
 	ID3D10Blob* errorBuffer = nullptr;
@@ -152,7 +150,7 @@ bool CompilePixelShader(const char* code, unsigned int len, D3DBlob** blob,
 #else
 	UINT flags = D3D10_SHADER_OPTIMIZATION_LEVEL3;
 #endif
-	HRESULT hr = PD3DCompile(code, len, nullptr, pDefines, nullptr, "main", D3D::PixelShaderVersionString(),
+	HRESULT hr = PD3DCompile(code.c_str(), code.length(), nullptr, pDefines, nullptr, "main", D3D::PixelShaderVersionString(),
 							flags, 0, &shaderBuffer, &errorBuffer);
 
 	if (errorBuffer)
@@ -187,11 +185,10 @@ bool CompilePixelShader(const char* code, unsigned int len, D3DBlob** blob,
 	return SUCCEEDED(hr);
 }
 
-ID3D11VertexShader* CompileAndCreateVertexShader(const char* code,
-	unsigned int len)
+ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code)
 {
 	D3DBlob* blob = nullptr;
-	if (CompileVertexShader(code, len, &blob))
+	if (CompileVertexShader(code, &blob))
 	{
 		ID3D11VertexShader* v_shader = CreateVertexShaderFromByteCode(blob);
 		blob->Release();
@@ -200,11 +197,10 @@ ID3D11VertexShader* CompileAndCreateVertexShader(const char* code,
 	return nullptr;
 }
 
-ID3D11GeometryShader* CompileAndCreateGeometryShader(const char* code,
-	unsigned int len, const D3D_SHADER_MACRO* pDefines)
+ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines)
 {
 	D3DBlob* blob = nullptr;
-	if (CompileGeometryShader(code, len, &blob, pDefines))
+	if (CompileGeometryShader(code, &blob, pDefines))
 	{
 		ID3D11GeometryShader* g_shader = CreateGeometryShaderFromByteCode(blob);
 		blob->Release();
@@ -213,11 +209,10 @@ ID3D11GeometryShader* CompileAndCreateGeometryShader(const char* code,
 	return nullptr;
 }
 
-ID3D11PixelShader* CompileAndCreatePixelShader(const char* code,
-	unsigned int len)
+ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code)
 {
 	D3DBlob* blob = nullptr;
-	CompilePixelShader(code, len, &blob);
+	CompilePixelShader(code, &blob);
 	if (blob)
 	{
 		ID3D11PixelShader* p_shader = CreatePixelShaderFromByteCode(blob);

--- a/Source/Core/VideoBackends/D3D/D3DShader.h
+++ b/Source/Core/VideoBackends/D3D/D3DShader.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DBlob.h"
 
@@ -20,20 +22,14 @@ namespace D3D
 	ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len);
 
 	// The returned bytecode buffers should be Release()d.
-	bool CompileVertexShader(const char* code, unsigned int len,
-		D3DBlob** blob);
-	bool CompileGeometryShader(const char* code, unsigned int len,
-		D3DBlob** blob, const D3D_SHADER_MACRO* pDefines = nullptr);
-	bool CompilePixelShader(const char* code, unsigned int len,
-		D3DBlob** blob, const D3D_SHADER_MACRO* pDefines = nullptr);
+	bool CompileVertexShader(const std::string& code, D3DBlob** blob);
+	bool CompileGeometryShader(const std::string& code, D3DBlob** blob, const D3D_SHADER_MACRO* pDefines = nullptr);
+	bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADER_MACRO* pDefines = nullptr);
 
 	// Utility functions
-	ID3D11VertexShader* CompileAndCreateVertexShader(const char* code,
-		unsigned int len);
-	ID3D11GeometryShader* CompileAndCreateGeometryShader(const char* code,
-		unsigned int len, const D3D_SHADER_MACRO* pDefines = nullptr);
-	ID3D11PixelShader* CompileAndCreatePixelShader(const char* code,
-		unsigned int len);
+	ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code);
+	ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines = nullptr);
+	ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code);
 
 	inline ID3D11VertexShader* CreateVertexShaderFromByteCode(D3DBlob* bytecode)
 	{ return CreateVertexShaderFromByteCode(bytecode->Data(), bytecode->Size()); }
@@ -43,11 +39,19 @@ namespace D3D
 	{ return CreatePixelShaderFromByteCode(bytecode->Data(), bytecode->Size()); }
 
 	inline ID3D11VertexShader* CompileAndCreateVertexShader(D3DBlob* code)
-	{ return CompileAndCreateVertexShader((const char*)code->Data(), code->Size()); }
+	{
+		return CompileAndCreateVertexShader((const char*)code->Data());
+	}
+
 	inline ID3D11GeometryShader* CompileAndCreateGeometryShader(D3DBlob* code, const D3D_SHADER_MACRO* pDefines = nullptr)
-	{ return CompileAndCreateGeometryShader((const char*)code->Data(), code->Size(), pDefines); }
+	{
+		return CompileAndCreateGeometryShader((const char*)code->Data(), pDefines);
+	}
+
 	inline ID3D11PixelShader* CompileAndCreatePixelShader(D3DBlob* code)
-	{ return CompileAndCreatePixelShader((const char*)code->Data(), code->Size()); }
+	{
+		return CompileAndCreatePixelShader((const char*)code->Data());
+	}
 }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -253,12 +253,12 @@ int CD3DFont::Init()
 	DeleteObject(hFont);
 
 	// setup device objects for drawing
-	m_pshader = D3D::CompileAndCreatePixelShader(fontpixshader, sizeof(fontpixshader));
+	m_pshader = D3D::CompileAndCreatePixelShader(fontpixshader);
 	if (m_pshader == nullptr) PanicAlert("Failed to create pixel shader, %s %d\n", __FILE__, __LINE__);
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_pshader, "pixel shader of a CD3DFont object");
 
 	D3DBlob* vsbytecode;
-	D3D::CompileVertexShader(fontvertshader, sizeof(fontvertshader), &vsbytecode);
+	D3D::CompileVertexShader(fontvertshader, &vsbytecode);
 	if (vsbytecode == nullptr) PanicAlert("Failed to compile vertex shader, %s %d\n", __FILE__, __LINE__);
 	m_vshader = D3D::CreateVertexShaderFromByteCode(vsbytecode);
 	if (m_vshader == nullptr) PanicAlert("Failed to create vertex shader, %s %d\n", __FILE__, __LINE__);

--- a/Source/Core/VideoBackends/D3D/LineGeometryShader.cpp
+++ b/Source/Core/VideoBackends/D3D/LineGeometryShader.cpp
@@ -186,7 +186,7 @@ bool LineGeometryShader::SetShader(u32 components, float lineWidth,
 			{ "NUM_TEXCOORDS", numTexCoordsStr.c_str() },
 			{ nullptr, nullptr }
 		};
-		ID3D11GeometryShader* newShader = D3D::CompileAndCreateGeometryShader(code.GetBuffer(), unsigned int(strlen(code.GetBuffer())), macros);
+		ID3D11GeometryShader* newShader = D3D::CompileAndCreateGeometryShader(code.GetBuffer(), macros);
 		if (!newShader)
 		{
 			WARN_LOG(VIDEO, "Line geometry shader for components 0x%.08X failed to compile", components);

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -929,7 +929,7 @@ void PSTextureEncoder::Init()
 	// Create vertex shader
 
 	D3DBlob* bytecode = nullptr;
-	if (!D3D::CompileVertexShader(EFB_ENCODE_VS, sizeof(EFB_ENCODE_VS), &bytecode))
+	if (!D3D::CompileVertexShader(EFB_ENCODE_VS, &bytecode))
 	{
 		ERROR_LOG(VIDEO, "EFB encode vertex shader failed to compile");
 		return;
@@ -1254,7 +1254,7 @@ bool PSTextureEncoder::SetStaticShader(unsigned int dstFormat, PEControl::PixelF
 			{ "IMP_GENERATOR", generatorFuncName },
 			{ nullptr, nullptr }
 		};
-		if (!D3D::CompilePixelShader(EFB_ENCODE_PS, sizeof(EFB_ENCODE_PS), &bytecode, macros))
+		if (!D3D::CompilePixelShader(EFB_ENCODE_PS, &bytecode, macros))
 		{
 			WARN_LOG(VIDEO, "EFB encoder shader for dstFormat 0x%X, srcFormat %d, isIntensity %d, scaleByHalf %d failed to compile",
 				dstFormat, static_cast<int>(srcFormat), isIntensity ? 1 : 0, scaleByHalf ? 1 : 0);
@@ -1296,7 +1296,7 @@ bool PSTextureEncoder::InitDynamicMode()
 	};
 
 	D3DBlob* bytecode = nullptr;
-	if (!D3D::CompilePixelShader(EFB_ENCODE_PS, sizeof(EFB_ENCODE_PS), &bytecode, macros))
+	if (!D3D::CompilePixelShader(EFB_ENCODE_PS, &bytecode, macros))
 	{
 		ERROR_LOG(VIDEO, "EFB encode pixel shader failed to compile");
 		return false;

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -238,7 +238,7 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGBA6ToRGB8(bool multisampled)
 	{
 		if (!s_rgba6_to_rgb8[0])
 		{
-			s_rgba6_to_rgb8[0] = D3D::CompileAndCreatePixelShader(reint_rgba6_to_rgb8, sizeof(reint_rgba6_to_rgb8));
+			s_rgba6_to_rgb8[0] = D3D::CompileAndCreatePixelShader(reint_rgba6_to_rgb8);
 			CHECK(s_rgba6_to_rgb8[0], "Create RGBA6 to RGB8 pixel shader");
 			D3D::SetDebugObjectName(s_rgba6_to_rgb8[0], "RGBA6 to RGB8 pixel shader");
 		}
@@ -247,10 +247,8 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGBA6ToRGB8(bool multisampled)
 	else if (!s_rgba6_to_rgb8[1])
 	{
 		// create MSAA shader for current AA mode
-		char buf[1024];
-		const int l = sprintf_s(buf, 1024, reint_rgba6_to_rgb8_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
-
-		s_rgba6_to_rgb8[1] = D3D::CompileAndCreatePixelShader(buf, l);
+		std::string buf = StringFromFormat(reint_rgba6_to_rgb8_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
+		s_rgba6_to_rgb8[1] = D3D::CompileAndCreatePixelShader(buf);
 
 		CHECK(s_rgba6_to_rgb8[1], "Create RGBA6 to RGB8 MSAA pixel shader");
 		D3D::SetDebugObjectName(s_rgba6_to_rgb8[1], "RGBA6 to RGB8 MSAA pixel shader");
@@ -264,7 +262,7 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
 	{
 		if (!s_rgb8_to_rgba6[0])
 		{
-			s_rgb8_to_rgba6[0] = D3D::CompileAndCreatePixelShader(reint_rgb8_to_rgba6, sizeof(reint_rgb8_to_rgba6));
+			s_rgb8_to_rgba6[0] = D3D::CompileAndCreatePixelShader(reint_rgb8_to_rgba6);
 			CHECK(s_rgb8_to_rgba6[0], "Create RGB8 to RGBA6 pixel shader");
 			D3D::SetDebugObjectName(s_rgb8_to_rgba6[0], "RGB8 to RGBA6 pixel shader");
 		}
@@ -273,10 +271,8 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
 	else if (!s_rgb8_to_rgba6[1])
 	{
 		// create MSAA shader for current AA mode
-		char buf[1024];
-		const int l = sprintf_s(buf, 1024, reint_rgb8_to_rgba6_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
-
-		s_rgb8_to_rgba6[1] = D3D::CompileAndCreatePixelShader(buf, l);
+		std::string buf = StringFromFormat(reint_rgb8_to_rgba6_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
+		s_rgb8_to_rgba6[1] = D3D::CompileAndCreatePixelShader(buf);
 
 		CHECK(s_rgb8_to_rgba6[1], "Create RGB8 to RGBA6 MSAA pixel shader");
 		D3D::SetDebugObjectName(s_rgb8_to_rgba6[1], "RGB8 to RGBA6 MSAA pixel shader");
@@ -286,14 +282,19 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
 
 ID3D11PixelShader* PixelShaderCache::GetColorCopyProgram(bool multisampled)
 {
-	if (!multisampled || D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count == 1) return s_ColorCopyProgram[0];
-	else if (s_ColorCopyProgram[1]) return s_ColorCopyProgram[1];
+	if (!multisampled || D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count == 1)
+	{
+		return s_ColorCopyProgram[0];
+	}
+	else if (s_ColorCopyProgram[1])
+	{
+		return s_ColorCopyProgram[1];
+	}
 	else
 	{
 		// create MSAA shader for current AA mode
-		char buf[1024];
-		int l = sprintf_s(buf, 1024, color_copy_program_code_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
-		s_ColorCopyProgram[1] = D3D::CompileAndCreatePixelShader(buf, l);
+		std::string buf = StringFromFormat(color_copy_program_code_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
+		s_ColorCopyProgram[1] = D3D::CompileAndCreatePixelShader(buf);
 		CHECK(s_ColorCopyProgram[1]!=nullptr, "Create color copy MSAA pixel shader");
 		D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[1], "color copy MSAA pixel shader");
 		return s_ColorCopyProgram[1];
@@ -302,14 +303,19 @@ ID3D11PixelShader* PixelShaderCache::GetColorCopyProgram(bool multisampled)
 
 ID3D11PixelShader* PixelShaderCache::GetColorMatrixProgram(bool multisampled)
 {
-	if (!multisampled || D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count == 1) return s_ColorMatrixProgram[0];
-	else if (s_ColorMatrixProgram[1]) return s_ColorMatrixProgram[1];
+	if (!multisampled || D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count == 1)
+	{
+		return s_ColorMatrixProgram[0];
+	}
+	else if (s_ColorMatrixProgram[1])
+	{
+		return s_ColorMatrixProgram[1];
+	}
 	else
 	{
 		// create MSAA shader for current AA mode
-		char buf[1024];
-		int l = sprintf_s(buf, 1024, color_matrix_program_code_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
-		s_ColorMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf, l);
+		std::string buf = StringFromFormat(color_matrix_program_code_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
+		s_ColorMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
 		CHECK(s_ColorMatrixProgram[1]!=nullptr, "Create color matrix MSAA pixel shader");
 		D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[1], "color matrix MSAA pixel shader");
 		return s_ColorMatrixProgram[1];
@@ -318,14 +324,19 @@ ID3D11PixelShader* PixelShaderCache::GetColorMatrixProgram(bool multisampled)
 
 ID3D11PixelShader* PixelShaderCache::GetDepthMatrixProgram(bool multisampled)
 {
-	if (!multisampled || D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count == 1) return s_DepthMatrixProgram[0];
-	else if (s_DepthMatrixProgram[1]) return s_DepthMatrixProgram[1];
+	if (!multisampled || D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count == 1)
+	{
+		return s_DepthMatrixProgram[0];
+	}
+	else if (s_DepthMatrixProgram[1])
+	{
+		return s_DepthMatrixProgram[1];
+	}
 	else
 	{
 		// create MSAA shader for current AA mode
-		char buf[1024];
-		int l = sprintf_s(buf, 1024, depth_matrix_program_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
-		s_DepthMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf, l);
+		std::string buf = StringFromFormat(depth_matrix_program_msaa, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
+		s_DepthMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
 		CHECK(s_DepthMatrixProgram[1]!=nullptr, "Create depth matrix MSAA pixel shader");
 		D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[1], "depth matrix MSAA pixel shader");
 		return s_DepthMatrixProgram[1];
@@ -372,22 +383,22 @@ void PixelShaderCache::Init()
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)pscbuf, "pixel shader constant buffer used to emulate the GX pipeline");
 
 	// used when drawing clear quads
-	s_ClearProgram = D3D::CompileAndCreatePixelShader(clear_program_code, sizeof(clear_program_code));
+	s_ClearProgram = D3D::CompileAndCreatePixelShader(clear_program_code);
 	CHECK(s_ClearProgram!=nullptr, "Create clear pixel shader");
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ClearProgram, "clear pixel shader");
 
 	// used when copying/resolving the color buffer
-	s_ColorCopyProgram[0] = D3D::CompileAndCreatePixelShader(color_copy_program_code, sizeof(color_copy_program_code));
+	s_ColorCopyProgram[0] = D3D::CompileAndCreatePixelShader(color_copy_program_code);
 	CHECK(s_ColorCopyProgram[0]!=nullptr, "Create color copy pixel shader");
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[0], "color copy pixel shader");
 
 	// used for color conversion
-	s_ColorMatrixProgram[0] = D3D::CompileAndCreatePixelShader(color_matrix_program_code, sizeof(color_matrix_program_code));
+	s_ColorMatrixProgram[0] = D3D::CompileAndCreatePixelShader(color_matrix_program_code);
 	CHECK(s_ColorMatrixProgram[0]!=nullptr, "Create color matrix pixel shader");
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[0], "color matrix pixel shader");
 
 	// used for depth copy
-	s_DepthMatrixProgram[0] = D3D::CompileAndCreatePixelShader(depth_matrix_program, sizeof(depth_matrix_program));
+	s_DepthMatrixProgram[0] = D3D::CompileAndCreatePixelShader(depth_matrix_program);
 	CHECK(s_DepthMatrixProgram[0]!=nullptr, "Create depth matrix pixel shader");
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[0], "depth matrix pixel shader");
 
@@ -490,7 +501,7 @@ bool PixelShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode, u32 components)
 	GeneratePixelShaderCode(code, dstAlphaMode, API_D3D, components);
 
 	D3DBlob* pbytecode;
-	if (!D3D::CompilePixelShader(code.GetBuffer(), (unsigned int)strlen(code.GetBuffer()), &pbytecode))
+	if (!D3D::CompilePixelShader(code.GetBuffer(), &pbytecode))
 	{
 		GFX_DEBUGGER_PAUSE_AT(NEXT_ERROR, true);
 		return false;

--- a/Source/Core/VideoBackends/D3D/PointGeometryShader.cpp
+++ b/Source/Core/VideoBackends/D3D/PointGeometryShader.cpp
@@ -180,7 +180,7 @@ bool PointGeometryShader::SetShader(u32 components, float pointSize,
 			{ "NUM_TEXCOORDS", numTexCoordsStr.c_str() },
 			{ nullptr, nullptr }
 		};
-		ID3D11GeometryShader* newShader = D3D::CompileAndCreateGeometryShader(code.GetBuffer(), unsigned int(strlen(code.GetBuffer())), macros);
+		ID3D11GeometryShader* newShader = D3D::CompileAndCreateGeometryShader(code.GetBuffer(), macros);
 		if (!newShader)
 		{
 			WARN_LOG(VIDEO, "Point geometry shader for components 0x%.08X failed to compile", components);

--- a/Source/Core/VideoBackends/D3D/Television.cpp
+++ b/Source/Core/VideoBackends/D3D/Television.cpp
@@ -98,7 +98,7 @@ void Television::Init()
 
 	// Create YUYV-decoding pixel shader
 
-	m_pShader = D3D::CompileAndCreatePixelShader(YUYV_DECODER_PS, sizeof(YUYV_DECODER_PS));
+	m_pShader = D3D::CompileAndCreatePixelShader(YUYV_DECODER_PS);
 	CHECK(m_pShader != nullptr, "compile and create yuyv decoder pixel shader");
 	D3D::SetDebugObjectName(m_pShader, "yuyv decoder pixel shader");
 

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -122,7 +122,7 @@ void VertexShaderCache::Init()
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)vscbuf, "vertex shader constant buffer used to emulate the GX pipeline");
 
 	D3DBlob* blob;
-	D3D::CompileVertexShader(simple_shader_code, sizeof(simple_shader_code), &blob);
+	D3D::CompileVertexShader(simple_shader_code, &blob);
 	D3D::device->CreateInputLayout(simpleelems, 2, blob->Data(), blob->Size(), &SimpleLayout);
 	SimpleVertexShader = D3D::CreateVertexShaderFromByteCode(blob);
 	if (SimpleLayout == nullptr || SimpleVertexShader == nullptr) PanicAlert("Failed to create simple vertex shader or input layout at %s %d\n", __FILE__, __LINE__);
@@ -130,7 +130,7 @@ void VertexShaderCache::Init()
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)SimpleVertexShader, "simple vertex shader");
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)SimpleLayout, "simple input layout");
 
-	D3D::CompileVertexShader(clear_shader_code, sizeof(clear_shader_code), &blob);
+	D3D::CompileVertexShader(clear_shader_code, &blob);
 	D3D::device->CreateInputLayout(clearelems, 2, blob->Data(), blob->Size(), &ClearLayout);
 	ClearVertexShader = D3D::CreateVertexShaderFromByteCode(blob);
 	if (ClearLayout == nullptr || ClearVertexShader == nullptr) PanicAlert("Failed to create clear vertex shader or input layout at %s %d\n", __FILE__, __LINE__);
@@ -218,7 +218,7 @@ bool VertexShaderCache::SetShader(u32 components)
 	GenerateVertexShaderCode(code, components, API_D3D);
 
 	D3DBlob* pbytecode = nullptr;
-	D3D::CompileVertexShader(code.GetBuffer(), (int)strlen(code.GetBuffer()), &pbytecode);
+	D3D::CompileVertexShader(code.GetBuffer(), &pbytecode);
 
 	if (pbytecode == nullptr)
 	{

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
@@ -189,7 +189,7 @@ void XFBEncoder::Init()
 	// Create vertex shader
 
 	D3DBlob* bytecode = nullptr;
-	if (!D3D::CompileVertexShader(XFB_ENCODE_VS, sizeof(XFB_ENCODE_VS), &bytecode))
+	if (!D3D::CompileVertexShader(XFB_ENCODE_VS, &bytecode))
 	{
 		ERROR_LOG(VIDEO, "XFB encode vertex shader failed to compile");
 		return;
@@ -211,7 +211,7 @@ void XFBEncoder::Init()
 
 	// Create pixel shader
 
-	m_pShader = D3D::CompileAndCreatePixelShader(XFB_ENCODE_PS, sizeof(XFB_ENCODE_PS));
+	m_pShader = D3D::CompileAndCreatePixelShader(XFB_ENCODE_PS);
 	if (!m_pShader)
 	{
 		ERROR_LOG(VIDEO, "XFB encode pixel shader failed to compile");


### PR DESCRIPTION
With strings, we don't need to care about passing in a length, since it internally stores it. So now, we don't even need a length parameter for these functions anymore as well.
This also kills off some sprintf_s calls.
