### PR TITLE
[Android] User configurable input overlay scaling

### DIFF
--- a/Source/Android/res/values-ja/strings.xml
+++ b/Source/Android/res/values-ja/strings.xml
@@ -66,8 +66,11 @@
 
     <!-- Input Config Fragment -->
     <string name="input_settings">入力</string>
+    <string name="input_overlay">入力オーバーレイ</string>
+    <string name="input_overlay_desc">画面上の入力のオーバーレイを設定し。</string>
     <string name="input_overlay_layout">入力オーバーレイレイアウト</string>
     <string name="input_overlay_layout_desc">入力オーバーレイのためのボタンのレイアウト。</string>
+    <string name="controls_size">コントロールのサイズを調整し</string>
     <string name="gamecube_bindings">ゲームキューブコントローラの入力バインディング</string>
     <string name="controller_0">コントローラ1</string>
     <string name="controller_1">コントローラ2</string>

--- a/Source/Android/res/values/strings.xml
+++ b/Source/Android/res/values/strings.xml
@@ -66,8 +66,11 @@
 
     <!-- Input Config Fragment -->
     <string name="input_settings">Input</string>
+    <string name="input_overlay">Input Overlay</string>
+    <string name="input_overlay_desc">Configure the onscreen input overlay.</string>
     <string name="input_overlay_layout">Input Overlay Layout</string>
     <string name="input_overlay_layout_desc">Button layout for the input overlay.</string>
+    <string name="controls_size">Adjust the control size</string>
     <string name="gamecube_bindings">GameCube Controller Bindings</string>
     <string name="controller_0">Controller 1</string>
     <string name="controller_1">Controller 2</string>

--- a/Source/Android/res/xml/input_prefs.xml
+++ b/Source/Android/res/xml/input_prefs.xml
@@ -1,15 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
                   android:title="@string/input_settings">
-
-    <Preference
-        android:key="inputOverlayConfigPref"
-        android:summary="@string/input_overlay_layout_desc"
-        android:title="@string/input_overlay_layout">
-        <intent
-            android:targetPackage="org.dolphinemu.dolphinemu"
-            android:targetClass="org.dolphinemu.dolphinemu.settings.input.overlayconfig.OverlayConfigActivity"/>
-    </Preference>
+    <PreferenceScreen
+        android:key="input_overlay"
+        android:title="@string/input_overlay"
+        android:summary="@string/input_overlay_desc">
+        <Preference
+            android:key="inputOverlayConfigPref"
+            android:summary="@string/input_overlay_layout_desc"
+            android:title="@string/input_overlay_layout">
+            <intent
+                android:targetPackage="org.dolphinemu.dolphinemu"
+                android:targetClass="org.dolphinemu.dolphinemu.settings.input.overlayconfig.OverlayConfigActivity"/>
+        </Preference>
+        <SeekBarPreference
+           android:key="controls_size"
+           android:title="@string/controls_size"
+           android:defaultValue="25"
+           android:max="75">
+       </SeekBarPreference>
+    </PreferenceScreen>
 
     <!-- GameCube controller bindings -->
     <PreferenceScreen

--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
@@ -186,8 +186,31 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		// SharedPreference to retrieve the X and Y coordinates for the InputOverlayDrawableButton.
 		final SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 
+		// Decide scale based on button ID
+		float scale;
+		float overlaySize = sPrefs.getInt("controls_size", 25);
+		overlaySize += 25;
+		overlaySize /= 50;
+
+		switch (resId)
+		{
+		case R.drawable.gcpad_b:
+			scale = 0.13f * overlaySize;
+			break;
+		case R.drawable.gcpad_x:
+		case R.drawable.gcpad_y:
+			scale = 0.18f * overlaySize;
+			break;
+		case R.drawable.gcpad_start:
+			scale = 0.12f * overlaySize;
+			break;
+		default:
+			scale = 0.20f * overlaySize;
+			break;
+		}
+
 		// Initialize the InputOverlayDrawableButton.
-		final Bitmap bitmap = resizeBitmap(context, BitmapFactory.decodeResource(res, resId), 0.20f);
+		final Bitmap bitmap = resizeBitmap(context, BitmapFactory.decodeResource(res, resId), scale);
 		final InputOverlayDrawableButton overlayDrawable = new InputOverlayDrawableButton(res, bitmap, buttonId);
 
 		// String ID of the Drawable. This is what is passed into SharedPreferences
@@ -231,7 +254,10 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		final SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 
 		// Initialize the InputOverlayDrawableJoystick.
-		final Bitmap bitmapOuter = resizeBitmap(context, BitmapFactory.decodeResource(res, resOuter), 0.30f);
+		float overlaySize = sPrefs.getInt("controls_size", 20);
+		overlaySize += 30;
+		overlaySize /= 50;
+		final Bitmap bitmapOuter = resizeBitmap(context, BitmapFactory.decodeResource(res, resOuter), 0.30f * overlaySize);
 		final Bitmap bitmapInner = BitmapFactory.decodeResource(res, resInner);
 
 		// String ID of the Drawable. This is what is passed into SharedPreferences

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/overlayconfig/OverlayConfigButton.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/overlayconfig/OverlayConfigButton.java
@@ -76,12 +76,42 @@ public final class OverlayConfigButton extends Button implements OnTouchListener
 		// Set the button as its own OnTouchListener.
 		setOnTouchListener(this);
 
-		// Set the button's icon that represents it.
-		setBackground(resizeDrawable(getResources().getDrawable(drawableId),
-		                drawableId == R.drawable.gcpad_joystick_range ? 0.30f : 0.20f));
-
 		// Get the SharedPreferences instance.
 		sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+		// Decide scale based on button ID
+
+		// SeekBars are not able to set a minimum value, only a maximum value, which complicates
+		// things a bit. What happens here is after the SeekBar's value is retrieved, 25 is
+		// added so the value will never go below 25. It is then divided by 50 (25 + 25) so the
+		// default value will be 100%.
+		float scale;
+		float overlaySize = sharedPrefs.getInt("controls_size", 25);
+		overlaySize += 25;
+		overlaySize /= 50;
+
+		switch (drawableId)
+		{
+		case R.drawable.gcpad_b:
+			scale = 0.13f * overlaySize;
+			break;
+		case R.drawable.gcpad_x:
+		case R.drawable.gcpad_y:
+			scale = 0.18f * overlaySize;
+			break;
+		case R.drawable.gcpad_start:
+			scale = 0.12f * overlaySize;
+			break;
+		case R.drawable.gcpad_joystick_range:
+			scale = 0.30f * overlaySize;
+			break;
+		default:
+			scale = 0.20f * overlaySize;
+			break;
+		}
+
+		// Set the button's icon that represents it.
+		setBackground(resizeDrawable(getResources().getDrawable(drawableId), scale));
 
 		// Check if this button has previous values set that aren't the default.
 		final float x = sharedPrefs.getFloat(buttonId+"-X", -1f);


### PR DESCRIPTION
I extended this from simply shrinking the B button. I resized the B, X, Y and start buttons, but the main thing is user configurable scaling of the onscreen input. The minimum is 50%, the maximum is 200%, and the default is 100%.

Screenshots:
http://i.imgur.com/SBcxDsi.png
http://i.imgur.com/lv16N0Z.png
http://i.imgur.com/e2XFj08.png
http://i.imgur.com/1AJ4nQn.png
http://i.imgur.com/juhoXok.png
(This last one has a very slightly smaller B button to better match actual controller)
http://i.imgur.com/K63Zl4A.png
