### PR TITLE
DolphinWX: Bind the drop handling function to the frame with Bind, not Connect

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -142,7 +142,7 @@ CRenderFrame::CRenderFrame(wxFrame* parent, wxWindowID id, const wxString& title
 	SetIcon(IconTemp);
 
 	DragAcceptFiles(true);
-	Connect(wxEVT_DROP_FILES, wxDropFilesEventHandler(CRenderFrame::OnDropFiles), nullptr, this);
+	Bind(wxEVT_DROP_FILES, &CRenderFrame::OnDropFiles, this);
 }
 
 void CRenderFrame::OnDropFiles(wxDropFilesEvent& event)


### PR DESCRIPTION
It's recommended in the wx docs to use Bind over Connect, since it's more flexible. Also this is the only instance where we use Connect and not Bind.
