### PR TITLE
DolphinWX: Don't use the windows-specific SetFocus call in Frame.cpp

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -514,11 +514,7 @@ void CFrame::OnActive(wxActivateEvent& event)
 	{
 		if (event.GetActive() && event.GetEventObject() == m_RenderFrame)
 		{
-#ifdef __WXMSW__
-			::SetFocus((HWND)m_RenderParent->GetHandle());
-#else
 			m_RenderParent->SetFocus();
-#endif
 
 			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor &&
 					Core::GetState() == Core::CORE_RUN)


### PR DESCRIPTION
The regular wx system-independent one works fine.
