### PR TITLE
Gcifolder use correct region for fifologs

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -132,6 +132,36 @@ void CEXIMemoryCard::setupGciFolder(u16 sizeMb)
 	case DiscIO::IVolume::COUNTRY_USA:
 		strDirectoryName += USA_DIR DIR_SEP;
 		break;
+	case DiscIO::IVolume::COUNTRY_UNKNOWN:
+	{
+		// The current game's region is not passed down to the EXI device level.
+		// Usually, we can retrieve the region from Core::g_CoreStartupParameter.m_strUniqueId.
+		// The Wii System Menu requires a lookup based on the version number.
+		// This is not possible in some cases ( e.g. FIFO logs, homebrew elf/dol files).
+		// Instead, we then lookup the region from the memory card name
+		// Earlier in the boot process the region is added to the memory card name (This is done by the function checkMemcardPath)
+		// For now take advantage of this.
+		// Future options:
+		// 			Set memory card directory path in the checkMemcardPath function.
+		// 	or		Add region to Core::g_CoreStartupParameter.
+		// 	or		Pass region down to the EXI device creation.
+
+		std::string memcardFilename = (card_index == 0) ? SConfig::GetInstance().m_strMemoryCardA : SConfig::GetInstance().m_strMemoryCardB;
+		std::string region = memcardFilename.substr(memcardFilename.size() - 7, 3);
+		if (region == JAP_DIR)
+		{
+			CountryCode = DiscIO::IVolume::COUNTRY_JAPAN;
+			ascii = false;
+			strDirectoryName += JAP_DIR DIR_SEP;
+			break;
+		}
+		else if (region == USA_DIR)
+		{
+			CountryCode = DiscIO::IVolume::COUNTRY_USA;
+			strDirectoryName += USA_DIR DIR_SEP;
+			break;
+		}
+	}
 	default:
 		CountryCode = DiscIO::IVolume::COUNTRY_EUROPE;
 		strDirectoryName += EUR_DIR DIR_SEP;


### PR DESCRIPTION
the region is not passed down to the exi level.
The checkmemcardpath sets the correct region earlier in the game startup, take advantage of this for now.

it would be nice to have the region passed down to exi level, but it seemed to be out of scope of this problem
the checkmemcardpath function may need to be refactored down to the exi level, but this would also require passing the region down
