### PR TITLE
FPSCounter: Add "Log render time to file" feature.

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -126,7 +126,6 @@ wxString wireframe_desc = wxTRANSLATE("Render the scene as a wireframe.\n\nIf un
 wxString disable_fog_desc = wxTRANSLATE("Makes distant objects more visible by removing fog, thus increasing the overall detail.\nDisabling fog will break some games which rely on proper fog emulation.\n\nIf unsure, leave this unchecked.");
 wxString disable_dstalpha_desc = wxTRANSLATE("Disables emulation of a hardware feature called destination alpha, which is used in many games for various graphical effects.\n\nIf unsure, leave this unchecked.");
 wxString show_fps_desc = wxTRANSLATE("Show the number of frames rendered per second as a measure of emulation speed.\n\nIf unsure, leave this unchecked.");
-wxString log_fps_to_file_desc = wxTRANSLATE("Log the number of frames rendered per second to User/Logs/fps.txt. Use this feature when you want to measure the performance of Dolphin.\n\nIf unsure, leave this unchecked.");
 wxString log_render_time_to_file_desc = wxTRANSLATE("Log the render time of every frame to User/Logs/render_time.txt. Use this feature when you want to measure the performance of Dolphin.\n\nIf unsure, leave this unchecked.");
 wxString show_input_display_desc = wxTRANSLATE("Display the inputs read by the emulator.\n\nIf unsure, leave this unchecked.");
 wxString show_stats_desc = wxTRANSLATE("Show various statistics.\n\nIf unsure, leave this unchecked.");
@@ -323,7 +322,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	{
 	SettingCheckBox* render_to_main_cb;
 	szr_other->Add(CreateCheckBox(page_general, _("Show FPS"), wxGetTranslation(show_fps_desc), vconfig.bShowFPS));
-	szr_other->Add(CreateCheckBox(page_general, _("Log FPS to file"), wxGetTranslation(log_fps_to_file_desc), vconfig.bLogFPSToFile));
+	szr_other->Add(CreateCheckBox(page_general, _("Log render time to file"), wxGetTranslation(log_render_time_to_file_desc), vconfig.bLogRenderTimeToFile));
 	szr_other->Add(CreateCheckBox(page_general, _("Auto adjust Window Size"), wxGetTranslation(auto_window_size_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderWindowAutoSize));
 	szr_other->Add(CreateCheckBox(page_general, _("Keep window on top"), wxGetTranslation(keep_window_on_top_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.bKeepWindowOnTop));
 	szr_other->Add(CreateCheckBox(page_general, _("Hide Mouse Cursor"), wxGetTranslation(hide_mouse_cursor_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor));
@@ -586,8 +585,6 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	szr_misc->Add(cb_prog_scan);
 	}
-
-	szr_misc->Add(CreateCheckBox(page_advanced, _("Log render time to file"), wxGetTranslation(log_render_time_to_file_desc), vconfig.bLogRenderTimeToFile));
 
 	wxStaticBoxSizer* const group_misc = new wxStaticBoxSizer(wxVERTICAL, page_advanced, _("Misc"));
 	szr_advanced->Add(group_misc, 0, wxEXPAND | wxALL, 5);

--- a/Source/Core/VideoCommon/FPSCounter.cpp
+++ b/Source/Core/VideoCommon/FPSCounter.cpp
@@ -18,10 +18,9 @@ static unsigned int s_counter = 0;
 static unsigned int s_fps = 0;
 static unsigned int s_fps_last_counter = 0;
 static Common::Timer s_update_time;
-static std::ofstream s_bench_file;
 
 static Common::Timer s_render_time;
-static std::ofstream s_time_file;
+static std::ofstream s_bench_file;
 
 void Initialize()
 {
@@ -33,24 +32,14 @@ void Initialize()
 
 	if (s_bench_file.is_open())
 		s_bench_file.close();
-	if (s_time_file.is_open())
-		s_time_file.close();
-}
-
-static void LogFPSToFile(u64 val)
-{
-	if (!s_bench_file.is_open())
-		s_bench_file.open(File::GetUserPath(D_LOGS_IDX) + "fps.txt");
-
-	s_bench_file << StringFromFormat("%lu\n", val);
 }
 
 static void LogRenderTimeToFile(u64 val)
 {
-	if (!s_time_file.is_open())
-		s_time_file.open(File::GetUserPath(D_LOGS_IDX) + "render_time.txt");
+	if (!s_bench_file.is_open())
+		s_bench_file.open(File::GetUserPath(D_LOGS_IDX) + "render_time.txt");
 
-	s_time_file << StringFromFormat("%lu\n", val);
+	s_bench_file << StringFromFormat("%lu\n", val);
 }
 
 int Update()
@@ -60,8 +49,6 @@ int Update()
 		s_update_time.Update();
 		s_fps = s_counter - s_fps_last_counter;
 		s_fps_last_counter = s_counter;
-		if (g_ActiveConfig.bLogFPSToFile)
-			LogFPSToFile(s_fps);
 	}
 
 	if (g_ActiveConfig.bLogRenderTimeToFile)

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -57,7 +57,6 @@ void VideoConfig::Load(const std::string& ini_file)
 	settings->Get("UseRealXFB", &bUseRealXFB, 0);
 	settings->Get("SafeTextureCacheColorSamples", &iSafeTextureCache_ColorSamples,128);
 	settings->Get("ShowFPS", &bShowFPS, false);
-	settings->Get("LogFPSToFile", &bLogFPSToFile, false);
 	settings->Get("LogRenderTimeToFile", &bLogRenderTimeToFile, false);
 	settings->Get("ShowInputDisplay", &bShowInputDisplay, false);
 	settings->Get("OverlayStats", &bOverlayStats, false);
@@ -230,7 +229,6 @@ void VideoConfig::Save(const std::string& ini_file)
 	settings->Set("UseRealXFB", bUseRealXFB);
 	settings->Set("SafeTextureCacheColorSamples", iSafeTextureCache_ColorSamples);
 	settings->Set("ShowFPS", bShowFPS);
-	settings->Set("LogFPSToFile", bLogFPSToFile);
 	settings->Set("LogRenderTimeToFile", bLogRenderTimeToFile);
 	settings->Set("ShowInputDisplay", bShowInputDisplay);
 	settings->Set("OverlayStats", bOverlayStats);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -83,7 +83,6 @@ struct VideoConfig final
 	bool bTexFmtOverlayEnable;
 	bool bTexFmtOverlayCenter;
 	bool bShowEFBCopyRegions;
-	bool bLogFPSToFile;
 	bool bLogRenderTimeToFile;
 
 	// Render


### PR DESCRIPTION
Allows for a more accurate performance measurement than the FPS log feature.
