### PR TITLE
FPSCounter: Change format string to match value.

### DIFF
--- a/Source/Core/VideoCommon/FPSCounter.cpp
+++ b/Source/Core/VideoCommon/FPSCounter.cpp
@@ -39,7 +39,7 @@ static void LogRenderTimeToFile(u64 val)
 	if (!s_bench_file.is_open())
 		s_bench_file.open(File::GetUserPath(D_LOGS_IDX) + "render_time.txt");
 
-	s_bench_file << StringFromFormat("%lu\n", val);
+	s_bench_file << val << std::endl;
 }
 
 int Update()


### PR DESCRIPTION
For some reason only OS X warned about this, I should've checked all build bots before I merged.
