### PR TITLE
AVIDump: fix FFV1 encoding

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -328,6 +328,10 @@ void AVIDump::AddFrame(const u8* data, int width, int height)
 		          height, s_scaled_frame->data, s_scaled_frame->linesize);
 	}
 
+	s_scaled_frame->format = s_stream->codec->pix_fmt;
+	s_scaled_frame->width = s_width;
+	s_scaled_frame->height = s_height;
+
 	// Encode and write the image.
 	AVPacket pkt;
 	PreparePacket(&pkt);


### PR DESCRIPTION
ffmpeg 2.0 changed requirements for the FFV1 encoder and made them more strict,
requiring more fields of the input frame to be initialized. Explicitly setting
pixfmt, width and height solve the EINVAL issues with FFV1 encoding.

Original fix from http://ffmpeg.org/pipermail/libav-user/2013-October/005759.html
