### PR TITLE
[Android] Add a bunch of gradle/AS related stuff to gitignore.

### DIFF
--- a/Source/Android/.gitignore
+++ b/Source/Android/.gitignore
@@ -1,7 +1,34 @@
-gen
-obj
-#ui_atlas.zim
-ui_atlas.zim.png
-#assets/ui_atlas.zim
-#jni/ui_atlas.cpp
-#jni/ui_atlas.h
+# built application files
+*.apk
+*.ap_
+
+# files for the dex VM
+*.dex
+
+# Java class files
+*.class
+
+# generated files
+bin/
+gen/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Eclipse project files
+.classpath
+.project
+
+# Android Studio
+/*/local.properties
+/*/out
+/*/*/build
+/*/*/production
+*.iws
+*~
+*.swp
+workspace.xml
+tasks.xml
+.gradle/*
+.idea
+gradle/


### PR DESCRIPTION
There are a LOT of files in the repository that probably shouldn't be. it seems like every time I fire up Android Studio, some metadata file indicating which tab I clicked on last Thursday is being edited, and I have to manually remove them from my commits.

What I've added to gitignore should suffice for most Android Studio projects. I know that just adding it to gitignore won't take it out of the repository, but I think someone who's better at Git than me should handle that.
