### PR TITLE
DolphinWX: Get rid of an unneccessary cast in CodeWindow

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -87,7 +87,7 @@ END_EVENT_TABLE()
 // Class
 CCodeWindow::CCodeWindow(const SCoreStartupParameter& _LocalCoreStartupParameter, CFrame *parent,
 	wxWindowID id, const wxPoint& position, const wxSize& size, long style, const wxString& name)
-	: wxPanel((wxWindow*)parent, id, position, size, style, name)
+	: wxPanel(parent, id, position, size, style, name)
 	, Parent(parent)
 	, m_RegisterWindow(nullptr)
 	, m_BreakpointWindow(nullptr)


### PR DESCRIPTION
`CFrame` inherits from `CRenderFrame` which inherits from `wxFrame` which eventually inherits from `wxWindow`, so this cast is not required.
