### PR TITLE
DolphinWX: Remove unnecessary true within event Skip calls

### DIFF
--- a/Source/Core/DolphinWX/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/CheatsWindow.cpp
@@ -529,7 +529,7 @@ void CheatSearchTab::FilterCheatSearchResults(wxCommandEvent&)
 
 void CheatSearchTab::ApplyFocus(wxEvent& ev)
 {
-	ev.Skip(true);
+	ev.Skip();
 	value_x_radiobtn.rad_uservalue->SetValue(true);
 }
 

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -111,7 +111,7 @@ void CCodeView::OnMouseDown(wxMouseEvent& event)
 		ToggleBreakpoint(YToAddress(y));
 	}
 
-	event.Skip(true);
+	event.Skip();
 }
 
 void CCodeView::ToggleBreakpoint(u32 address)
@@ -143,7 +143,7 @@ void CCodeView::OnMouseMove(wxMouseEvent& event)
 		}
 	}
 
-	event.Skip(true);
+	event.Skip();
 }
 
 void CCodeView::RaiseEvent()
@@ -163,7 +163,7 @@ void CCodeView::OnMouseUpL(wxMouseEvent& event)
 		Refresh();
 	}
 	RaiseEvent();
-	event.Skip(true);
+	event.Skip();
 }
 
 u32 CCodeView::AddrToBranch(u32 addr)
@@ -330,7 +330,7 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 #if wxUSE_CLIPBOARD
 	wxTheClipboard->Close();
 #endif
-	event.Skip(true);
+	event.Skip();
 }
 
 void CCodeView::OnMouseUpR(wxMouseEvent& event)
@@ -357,7 +357,7 @@ void CCodeView::OnMouseUpR(wxMouseEvent& event)
 	menu->Append(IDM_INSERTNOP, _("Insert &nop"));
 	menu->Append(IDM_PATCHALERT, _("Patch alert"));
 	PopupMenu(menu);
-	event.Skip(true);
+	event.Skip();
 }
 
 void CCodeView::OnErase(wxEraseEvent& event)

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -222,7 +222,7 @@ void CCodeWindow::OnAddrBoxChange(wxCommandEvent& event)
 		JumpToAddress(addr);
 	}
 
-	event.Skip(1);
+	event.Skip();
 }
 
 void CCodeWindow::OnCallstackListChange(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -99,7 +99,7 @@ void CMemoryView::OnMouseDownL(wxMouseEvent& event)
 		Host_UpdateBreakPointView();
 	}
 
-	event.Skip(true);
+	event.Skip();
 }
 
 void CMemoryView::OnMouseMove(wxMouseEvent& event)
@@ -122,7 +122,7 @@ void CMemoryView::OnMouseMove(wxMouseEvent& event)
 			OnMouseDownL(event);
 	}
 
-	event.Skip(true);
+	event.Skip();
 }
 
 void CMemoryView::OnMouseUpL(wxMouseEvent& event)
@@ -134,7 +134,7 @@ void CMemoryView::OnMouseUpL(wxMouseEvent& event)
 		Refresh();
 	}
 
-	event.Skip(true);
+	event.Skip();
 }
 
 void CMemoryView::OnPopupMenu(wxCommandEvent& event)
@@ -182,7 +182,7 @@ void CMemoryView::OnPopupMenu(wxCommandEvent& event)
 #if wxUSE_CLIPBOARD
 	wxTheClipboard->Close();
 #endif
-	event.Skip(true);
+	event.Skip();
 }
 
 void CMemoryView::OnMouseDownR(wxMouseEvent& event)

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -191,7 +191,7 @@ void CMemoryWindow::OnAddrBoxChange(wxCommandEvent& event)
 		memview->Center(addr & ~3);
 	}
 
-	event.Skip(1);
+	event.Skip();
 }
 
 void CMemoryWindow::Update()

--- a/Source/Core/DolphinWX/TASInputDlg.cpp
+++ b/Source/Core/DolphinWX/TASInputDlg.cpp
@@ -806,8 +806,7 @@ void TASInputDlg::OnMouseUpR(wxMouseEvent& event)
 
 	sliderX->SetValue(*x);
 	sliderY->SetValue(256 - *y);
-	event.Skip(true);
-
+	event.Skip();
 }
 
 void TASInputDlg::OnMouseDownL(wxMouseEvent& event)
@@ -863,7 +862,7 @@ void TASInputDlg::OnMouseDownL(wxMouseEvent& event)
 
 	sliderX->SetValue(*x);
 	sliderY->SetValue(256 - *y);
-	event.Skip(true);
+	event.Skip();
 }
 
 void TASInputDlg::SetTurboFalse(wxMouseEvent& event)
@@ -922,7 +921,7 @@ void TASInputDlg::SetTurboFalse(wxMouseEvent& event)
 			return;
 	}
 
-	event.Skip(true);
+	event.Skip();
 }
 
 void TASInputDlg::SetTurbo(wxMouseEvent& event)


### PR DESCRIPTION
Calling `Skip` with no args is the same thing as `Skip(true)`
