### PR TITLE
InputCommon: Use enums instead of defines within GCPadStatus.h

### DIFF
--- a/Source/Core/InputCommon/GCPadStatus.h
+++ b/Source/Core/InputCommon/GCPadStatus.h
@@ -4,25 +4,34 @@
 
 #pragma once
 
-#define PAD_ERR_NONE            0
-#define PAD_ERR_NO_CONTROLLER   -1
-#define PAD_ERR_NOT_READY       -2
-#define PAD_ERR_TRANSFER        -3
+enum PadError
+{
+	PAD_ERR_NONE          = 0,
+	PAD_ERR_NO_CONTROLLER = -1,
+	PAD_ERR_NOT_READY     = -2,
+	PAD_ERR_TRANSFER      = -3,
+};
 
-#define PAD_USE_ORIGIN          0x0080
+enum
+{
+	PAD_USE_ORIGIN = 0x0080,
+};
 
-#define PAD_BUTTON_LEFT         0x0001
-#define PAD_BUTTON_RIGHT        0x0002
-#define PAD_BUTTON_DOWN         0x0004
-#define PAD_BUTTON_UP           0x0008
-#define PAD_TRIGGER_Z           0x0010
-#define PAD_TRIGGER_R           0x0020
-#define PAD_TRIGGER_L           0x0040
-#define PAD_BUTTON_A            0x0100
-#define PAD_BUTTON_B            0x0200
-#define PAD_BUTTON_X            0x0400
-#define PAD_BUTTON_Y            0x0800
-#define PAD_BUTTON_START        0x1000
+enum PadButton
+{
+	PAD_BUTTON_LEFT  = 0x0001,
+	PAD_BUTTON_RIGHT = 0x0002,
+	PAD_BUTTON_DOWN  = 0x0004,
+	PAD_BUTTON_UP    = 0x0008,
+	PAD_TRIGGER_Z    = 0x0010,
+	PAD_TRIGGER_R    = 0x0020,
+	PAD_TRIGGER_L    = 0x0040,
+	PAD_BUTTON_A     = 0x0100,
+	PAD_BUTTON_B     = 0x0200,
+	PAD_BUTTON_X     = 0x0400,
+	PAD_BUTTON_Y     = 0x0800,
+	PAD_BUTTON_START = 0x1000,
+};
 
 struct GCPadStatus
 {


### PR DESCRIPTION
Keeps variable names preserved when debugging, more nicely grouped, etc.
