### PR TITLE
DolphinWX: Allow short-hand searching in the code window

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -60,7 +60,7 @@ class CCodeWindow
 		bool AutomaticStart();
 		bool JITNoBlockCache();
 		bool JITBlockLinking();
-		void JumpToAddress(u32 _Address);
+		bool JumpToAddress(u32 address);
 
 		void Update() override;
 		void NotifyMapLoaded();


### PR DESCRIPTION
Lessens the restrictions on the searching in the code view.
Now typing out the full 8 digit hex number isn't needed. For example, you don't need to type `000000FF` to go to FF, you just literally type `FF`.

Also makes `JumpToAddress` a boolean function to remain consistent with the DSP code view.

This will also change the address search box to have a red background if either an invalid hex number is given, or if it's longer than 8 characters. This is similar to how the DSP address box works as well.
