### PR TITLE
DolphinWX: Use non-deprecated flags for the monospace debugger font

### DIFF
--- a/Source/Core/DolphinWX/Debugger/DebuggerUIUtil.cpp
+++ b/Source/Core/DolphinWX/Debugger/DebuggerUIUtil.cpp
@@ -9,5 +9,5 @@
 #include "DolphinWX/Debugger/DebuggerUIUtil.h"
 
 // The default font
-wxFont DebuggerFont = wxFont(9, wxMODERN, wxNORMAL, wxNORMAL, false, "monospace");
+wxFont DebuggerFont = wxFont(9, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
 


### PR DESCRIPTION
Same thing, but non-deprecated.
