### PR TITLE
MMIO: Cleanup Mapping class by using templates instead of macros.

### DIFF
--- a/Source/Core/Core/HW/MMIO.cpp
+++ b/Source/Core/Core/HW/MMIO.cpp
@@ -224,10 +224,8 @@ ReadHandlingMethod<T>* ReadToSmaller(Mapping* mmio, u32 high_part_addr, u32 low_
 {
 	typedef typename SmallerAccessSize<T>::value ST;
 
-	ReadHandler<ST>* high_part;
-	ReadHandler<ST>* low_part;
-	mmio->GetHandlerForRead(high_part_addr, &high_part);
-	mmio->GetHandlerForRead(low_part_addr, &low_part);
+	ReadHandler<ST>* high_part = &mmio->GetHandlerForRead<ST>(high_part_addr);
+	ReadHandler<ST>* low_part = &mmio->GetHandlerForRead<ST>(low_part_addr);
 
 	// TODO(delroth): optimize
 	return ComplexRead<T>([=](u32 addr) {
@@ -241,10 +239,8 @@ WriteHandlingMethod<T>* WriteToSmaller(Mapping* mmio, u32 high_part_addr, u32 lo
 {
 	typedef typename SmallerAccessSize<T>::value ST;
 
-	WriteHandler<ST>* high_part;
-	WriteHandler<ST>* low_part;
-	mmio->GetHandlerForWrite(high_part_addr, &high_part);
-	mmio->GetHandlerForWrite(low_part_addr, &low_part);
+	WriteHandler<ST>* high_part = &mmio->GetHandlerForWrite<ST>(high_part_addr);
+	WriteHandler<ST>* low_part = &mmio->GetHandlerForWrite<ST>(low_part_addr);
 
 	// TODO(delroth): optimize
 	return ComplexWrite<T>([=](u32 addr, T val) {
@@ -258,8 +254,7 @@ ReadHandlingMethod<T>* ReadToLarger(Mapping* mmio, u32 larger_addr, u32 shift)
 {
 	typedef typename LargerAccessSize<T>::value LT;
 
-	ReadHandler<LT>* large;
-	mmio->GetHandlerForRead(larger_addr, &large);
+	ReadHandler<LT>* large = &mmio->GetHandlerForRead<LT>(larger_addr);
 
 	// TODO(delroth): optimize
 	return ComplexRead<T>([large, shift](u32 addr) {

--- a/Source/Core/Core/HW/MemmapFunctions.cpp
+++ b/Source/Core/Core/HW/MemmapFunctions.cpp
@@ -92,7 +92,7 @@ inline void ReadFromHardware(T &_var, const u32 em_address, const u32 effective_
 		if (em_address < 0xcc000000)
 			_var = EFB_Read(em_address);
 		else
-			mmio_mapping->Read(em_address, &_var);
+			_var = mmio_mapping->Read<T>(em_address);
 	}
 	else if (((em_address & 0xF0000000) == 0x80000000) ||
 		((em_address & 0xF0000000) == 0xC0000000) ||

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -253,21 +253,21 @@ void EmuCodeBlock::MMIOLoadToReg(MMIO::Mapping* mmio, Gen::X64Reg reg_value,
 		{
 			MMIOReadCodeGenerator<u8> gen(this, registers_in_use, reg_value,
 			                              address, sign_extend);
-			mmio->GetHandlerForRead8(address).Visit(gen);
+			mmio->GetHandlerForRead<u8>(address).Visit(gen);
 			break;
 		}
 	case 16:
 		{
 			MMIOReadCodeGenerator<u16> gen(this, registers_in_use, reg_value,
 			                               address, sign_extend);
-			mmio->GetHandlerForRead16(address).Visit(gen);
+			mmio->GetHandlerForRead<u16>(address).Visit(gen);
 			break;
 		}
 	case 32:
 		{
 			MMIOReadCodeGenerator<u32> gen(this, registers_in_use, reg_value,
 			                               address, sign_extend);
-			mmio->GetHandlerForRead32(address).Visit(gen);
+			mmio->GetHandlerForRead<u32>(address).Visit(gen);
 			break;
 		}
 	}

--- a/Source/UnitTests/Core/MMIOTest.cpp
+++ b/Source/UnitTests/Core/MMIOTest.cpp
@@ -54,9 +54,9 @@ TEST_F(MappingTest, ReadConstant)
 	m_mapping->Register(0xCC001234, MMIO::Constant<u16>(0x1234), MMIO::Nop<u16>());
 	m_mapping->Register(0xCC001234, MMIO::Constant<u32>(0xdeadbeef), MMIO::Nop<u32>());
 
-	u8 val8;   m_mapping->Read(0xCC001234, &val8);
-	u16 val16; m_mapping->Read(0xCC001234, &val16);
-	u32 val32; m_mapping->Read(0xCC001234, &val32);
+	u8 val8 = m_mapping->Read<u8>(0xCC001234);
+	u16 val16 = m_mapping->Read<u16>(0xCC001234);
+	u32 val32 = m_mapping->Read<u32>(0xCC001234);
 
 	EXPECT_EQ(0x42, val8);
 	EXPECT_EQ(0x1234, val16);
@@ -75,9 +75,9 @@ TEST_F(MappingTest, ReadWriteDirect)
 
 	for (u32 i = 0; i < 100; ++i)
 	{
-		u8 val8;   m_mapping->Read(0xCC001234, &val8);  EXPECT_EQ(i, val8);
-		u16 val16; m_mapping->Read(0xCC001234, &val16); EXPECT_EQ(i, val16);
-		u32 val32; m_mapping->Read(0xCC001234, &val32); EXPECT_EQ(i, val32);
+		u8 val8 = m_mapping->Read<u8>(0xCC001234);  EXPECT_EQ(i, val8);
+		u16 val16 = m_mapping->Read<u16>(0xCC001234); EXPECT_EQ(i, val16);
+		u32 val32 = m_mapping->Read<u32>(0xCC001234); EXPECT_EQ(i, val32);
 
 		val8 += 1; m_mapping->Write(0xCC001234, val8);
 		val16 += 1; m_mapping->Write(0xCC001234, val16);
@@ -102,7 +102,7 @@ TEST_F(MappingTest, ReadWriteComplex)
 		})
 	);
 
-	u8 val; m_mapping->Read(0xCC001234, &val); EXPECT_EQ(0x12, val);
+	u8 val = m_mapping->Read<u8>(0xCC001234); EXPECT_EQ(0x12, val);
 	m_mapping->Write(0xCC001234, (u8)0x34);
 
 	EXPECT_TRUE(read_called);


### PR DESCRIPTION
The MMIO mapping interface was using lots of macros before to use the same code for different MMIO register sizes. This branch replaces the macro usage with templates.

Macros aren't a particular modern way of using C++ to begin with, but in this case I think using templates instead of macros indeed makes the code a lot more readable. Additionally, I was able to clean up the interface a lot because the C++ overloading restrictions don't affect templated code.

For what it's worth, I'm not sure if

```
template<typename Unit>
struct HandlerArray
{
    using Read = std::array<ReadHandler<Unit>, NUM_MMIOS / sizeof(Unit)>;
    using Write = std::array<WriteHandler<Unit>, NUM_MMIOS / sizeof(Unit)>;
};

HandlerArray<u8>::Read m_read_handlers8;
HandlerArray<u16>::Read m_read_handlers16;
HandlerArray<u32>::Read m_read_handlers32;

HandlerArray<u8>::Write m_write_handlers8;
HandlerArray<u16>::Write m_write_handlers16;
HandlerArray<u32>::Write m_write_handlers32;
```

is any cleaner than

```
std::array<ReadHandler<u8>, NUM_MMIOS / sizeof(Unit)> m_read_handlers8;
std::array<ReadHandler<u16>, NUM_MMIOS / sizeof(Unit)> m_read_handlers16;
std::array<ReadHandler<u32>, NUM_MMIOS / sizeof(Unit)> m_read_handlers32;

std::array<WriteHandler<u8>, NUM_MMIOS / sizeof(Unit)> m_write_handlers8;
std::array<WriteHandler<u16>, NUM_MMIOS / sizeof(Unit)> m_write_handlers16;
std::array<WriteHandler<u32>, NUM_MMIOS / sizeof(Unit)> m_write_handlers32;
```

Opinions on that? (having written this in comparison, I got to say myself that the second version is probably better)

For reference, the version of this code living in current master is

```
#define HANDLERS(Size) \
std::array<ReadHandler<u##Size>, NUM_MMIOS / sizeof (u##Size)> m_Read##Size##Handlers; \
std::array<WriteHandler<u##Size>, NUM_MMIOS / sizeof (u##Size)> m_Write##Size##Handlers;
HANDLERS(8) HANDLERS(16) HANDLERS(32)
#undef HANDLERS
```
