### PR TITLE
NoGUI: Add missing call to Core::Shutdown().

### DIFF
--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -389,6 +389,7 @@ int main(int argc, char* argv[])
 	VideoBackend::ClearList();
 	SConfig::Shutdown();
 	LogManager::Shutdown();
+	Core::Shutdown();
 
 	return 0;
 }


### PR DESCRIPTION
Fixes a crash when exiting the application.
