### PR TITLE
Change libav* autodetection to support framedumping on Ubuntu 14.04

### DIFF
--- a/CMakeTests/CheckLib.cmake
+++ b/CMakeTests/CheckLib.cmake
@@ -55,8 +55,8 @@ endmacro()
 
 macro(check_libav)
 	if(PKG_CONFIG_FOUND)
-		pkg_check_modules(LIBAV libavcodec>=55.52.102 libavformat>=55.33.100
-			libswscale>=2.5.102 libavutil>=52.66.100)
+		pkg_check_modules(LIBAV libavcodec>=54.35.0 libavformat>=54.20.4
+			libswscale>=2.1.1 libavutil>=52.3.0)
 	else()
 		message("pkg-config is required to check for libav/ffmpeg")
 	endif()

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -215,6 +215,11 @@ extern "C" {
 #include <libavutil/mathematics.h>
 }
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 28, 1)
+#define av_frame_alloc avcodec_alloc_frame
+#define av_frame_free avcodec_free_frame
+#endif
+
 static AVFormatContext* s_format_context = nullptr;
 static AVStream* s_stream = nullptr;
 static AVFrame* s_src_frame = nullptr;


### PR DESCRIPTION
Add an "ugly" workaround in the AVIDump code, but looking at other project this
seems to be the most common way to handle this API change.
