### PR TITLE
Shutdown the Core before other components.

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -453,11 +453,11 @@ void DolphinApp::OnEndSession(wxCloseEvent& event)
 
 int DolphinApp::OnExit()
 {
+	Core::Shutdown();
 	WiimoteReal::Shutdown();
 	VideoBackend::ClearList();
 	SConfig::Shutdown();
 	LogManager::Shutdown();
-	Core::Shutdown();
 
 	delete m_locale;
 

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -385,11 +385,11 @@ int main(int argc, char* argv[])
 #endif
 	}
 
+	Core::Shutdown();
 	WiimoteReal::Shutdown();
 	VideoBackend::ClearList();
 	SConfig::Shutdown();
 	LogManager::Shutdown();
-	Core::Shutdown();
 
 	return 0;
 }


### PR DESCRIPTION
Other components depend on the EmuThread being stopped.
