### PR TITLE
OGL: Correctly guard against array bounds of s_encodingPrograms

### DIFF
--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -134,7 +134,7 @@ static void CreatePrograms()
 
 static SHADER &GetOrCreateEncodingShader(u32 format)
 {
-	if (format > NUM_ENCODING_PROGRAMS)
+	if (format >= NUM_ENCODING_PROGRAMS)
 	{
 		PanicAlert("Unknown texture copy format: 0x%x\n", format);
 		return s_encodingPrograms[0];


### PR DESCRIPTION
s_encodingPrograms is defined as an array with a length of 64. NUM_ENCODING_PROGRAMS is also defined as 64.

However 64 is out of bounds (0 - 63 only), so we want to be comparing for `>=` here
Even if "64" will never happen as a value, it should still be validated against.
