### PR TITLE
Revert "DolphinWX: Use non-deprecated flags for the monospace debugger f...

### DIFF
--- a/Source/Core/DolphinWX/Debugger/DebuggerUIUtil.cpp
+++ b/Source/Core/DolphinWX/Debugger/DebuggerUIUtil.cpp
@@ -9,5 +9,5 @@
 #include "DolphinWX/Debugger/DebuggerUIUtil.h"
 
 // The default font
-wxFont DebuggerFont = wxFont(9, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+wxFont DebuggerFont = wxFont(9, wxMODERN, wxNORMAL, wxNORMAL, false, "monospace");
 


### PR DESCRIPTION
...ont"

Same thing, but causes segfaults on some linux systems.

See: https://forums.dolphin-emu.org/Thread-latest-build-of-dolphin-emu-crashes
