### PR TITLE
Fix incorrect clamping in SWRenderer.

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -20,6 +20,14 @@ inline void Clamp(T* val, const T& min, const T& max)
 		*val = max;
 }
 
+template<class T>
+inline T Clamp(const T val, const T& min, const T& max)
+{
+	T ret = val;
+	Clamp(&ret, min, max);
+	return ret;
+}
+
 // The most significant bit of the fraction is an is-quiet bit on all architectures we care about.
 
 static const u64 DOUBLE_SIGN = 0x8000000000000000ULL,

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -182,14 +182,14 @@ void SWRenderer::UpdateColorTexture(EfbInterface::yuv422_packed *xfb, u32 fbWidt
 
 			// We do the inverse BT.601 conversion for YCbCr to RGB
 			// http://www.equasys.de/colorconversion.html#YCbCr-RGBColorFormatConversion
-			TexturePointer[offset++] = std::min<u8>(255.0f, std::max(0.0f, 1.164f * Y1              + 1.596f * V));
-			TexturePointer[offset++] = std::min<u8>(255.0f, std::max(0.0f, 1.164f * Y1 - 0.392f * U - 0.813f * V));
-			TexturePointer[offset++] = std::min<u8>(255.0f, std::max(0.0f, 1.164f * Y1 + 2.017f * U             ));
+			TexturePointer[offset++] = MathUtil::Clamp(int(1.164f * Y1              + 1.596f * V), 0, 255);
+			TexturePointer[offset++] = MathUtil::Clamp(int(1.164f * Y1 - 0.392f * U - 0.813f * V), 0, 255);
+			TexturePointer[offset++] = MathUtil::Clamp(int(1.164f * Y1 + 2.017f * U             ), 0, 255);
 			TexturePointer[offset++] = 255;
 
-			TexturePointer[offset++] = std::min<u8>(255.0f, std::max(0.0f, 1.164f * Y2              + 1.596f * V));
-			TexturePointer[offset++] = std::min<u8>(255.0f, std::max(0.0f, 1.164f * Y2 - 0.392f * U - 0.813f * V));
-			TexturePointer[offset++] = std::min<u8>(255.0f, std::max(0.0f, 1.164f * Y2 + 2.017f * U             ));
+			TexturePointer[offset++] = MathUtil::Clamp(int(1.164f * Y2              + 1.596f * V), 0, 255);
+			TexturePointer[offset++] = MathUtil::Clamp(int(1.164f * Y2 - 0.392f * U - 0.813f * V), 0, 255);
+			TexturePointer[offset++] = MathUtil::Clamp(int(1.164f * Y2 + 2.017f * U             ), 0, 255);
 			TexturePointer[offset++] = 255;
 		}
 		xfb += fbWidth;

--- a/Source/UnitTests/Common/MathUtilTest.cpp
+++ b/Source/UnitTests/Common/MathUtilTest.cpp
@@ -8,24 +8,16 @@
 
 #include "Common/MathUtil.h"
 
-template <typename T>
-T ClampAndReturn(const T& val, const T& min, const T& max)
-{
-	T ret = val;
-	MathUtil::Clamp(&ret, min, max);
-	return ret;
-}
-
 TEST(MathUtil, Clamp)
 {
-	EXPECT_EQ(1, ClampAndReturn(1, 0, 2));
-	EXPECT_EQ(1.0, ClampAndReturn(1.0, 0.0, 2.0));
+	EXPECT_EQ(1, MathUtil::Clamp(1, 0, 2));
+	EXPECT_EQ(1.0, MathUtil::Clamp(1.0, 0.0, 2.0));
 
-	EXPECT_EQ(2, ClampAndReturn(4, 0, 2));
-	EXPECT_EQ(2.0, ClampAndReturn(4.0, 0.0, 2.0));
+	EXPECT_EQ(2, MathUtil::Clamp(4, 0, 2));
+	EXPECT_EQ(2.0, MathUtil::Clamp(4.0, 0.0, 2.0));
 
-	EXPECT_EQ(0, ClampAndReturn(-1, 0, 2));
-	EXPECT_EQ(0.0, ClampAndReturn(-1.0, 0.0, 2.0));
+	EXPECT_EQ(0, MathUtil::Clamp(-1, 0, 2));
+	EXPECT_EQ(0.0, MathUtil::Clamp(-1.0, 0.0, 2.0));
 }
 
 TEST(MathUtil, IsINF)


### PR DESCRIPTION
A previous PR changed a whole lot of min/maxes to std::min/std::max
but made a mistake here and used a templated min which cast it's
arguments to unsigned instead of casting return value.

This resulted in glitchy artifacts in bright areas (See [issue 7439](https://code.google.com/p/dolphin-emu/issues/detail?id=7439))

I rewrote the code to use a proper clamping function so it's cleaner
to read.
