### PR TITLE
Fix another protential issue with casting.

### DIFF
--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -104,7 +104,7 @@ bool CFileSystemGCWii::ExportFile(const std::string& _rFullPath, const std::stri
 	while (remainingSize)
 	{
 		// Limit read size to 128 MB
-		size_t readSize = std::min<size_t>(remainingSize, (u64)0x08000000);
+		size_t readSize = (size_t)std::min(remainingSize, (u64)0x08000000);
 
 		std::vector<u8> buffer(readSize);
 


### PR DESCRIPTION
Another issue from #334 with the casting moved from the output of
min to it's inputs.

This is a non-issue on 64 bit machines, but if dolphin is compiled
on an OS with size_t == u32 (say ARM) then remainingSize could be
truncated.

Restored the casting to the original order before #334.
