### PR TITLE
Removal of fast texture cache setting.

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -475,19 +475,17 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	wxStaticBoxSizer* const szr_safetex = new wxStaticBoxSizer(wxHORIZONTAL, page_hacks, _("Texture Cache"));
 
 	// TODO: Use wxSL_MIN_MAX_LABELS or wxSL_VALUE_LABEL with wx 2.9.1
-	wxSlider* const stc_slider = new wxSlider(page_hacks, wxID_ANY, 0, 0, 2, wxDefaultPosition, wxDefaultSize, wxSL_HORIZONTAL|wxSL_BOTTOM);
+	wxSlider* const stc_slider = new wxSlider(page_hacks, wxID_ANY, 0, 0, 1, wxDefaultPosition, wxDefaultSize, wxSL_HORIZONTAL|wxSL_BOTTOM);
 	stc_slider->Bind(wxEVT_SLIDER, &VideoConfigDiag::Event_Stc, this);
 	RegisterControl(stc_slider, wxGetTranslation(stc_desc));
 
 	if (vconfig.iSafeTextureCache_ColorSamples == 0) stc_slider->SetValue(0);
-	else if (vconfig.iSafeTextureCache_ColorSamples == 512) stc_slider->SetValue(1);
-	else if (vconfig.iSafeTextureCache_ColorSamples == 128) stc_slider->SetValue(2);
-	else stc_slider->Disable(); // Using custom number of samples; TODO: Inform the user why this is disabled..
+	else if (vconfig.iSafeTextureCache_ColorSamples == 512) stc_slider->SetValue(1);	
 
 	szr_safetex->Add(new wxStaticText(page_hacks, wxID_ANY, _("Accuracy:")), 0, wxALL, 5);
 	szr_safetex->AddStretchSpacer(1);
 	szr_safetex->Add(new wxStaticText(page_hacks, wxID_ANY, _("Safe")), 0, wxLEFT|wxTOP|wxBOTTOM, 5);
-	szr_safetex->Add(stc_slider, 2, wxRIGHT, 0);
+	szr_safetex->Add(stc_slider, 1, wxRIGHT, 0);
 	szr_safetex->Add(new wxStaticText(page_hacks, wxID_ANY, _("Fast")), 0, wxRIGHT|wxTOP|wxBOTTOM, 5);
 	szr_hacks->Add(szr_safetex, 0, wxEXPAND | wxALL, 5);
 	}

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -55,7 +55,7 @@ void VideoConfig::Load(const std::string& ini_file)
 	settings->Get("Crop", &bCrop, false);
 	settings->Get("UseXFB", &bUseXFB, 0);
 	settings->Get("UseRealXFB", &bUseRealXFB, 0);
-	settings->Get("SafeTextureCacheColorSamples", &iSafeTextureCache_ColorSamples,128);
+	settings->Get("SafeTextureCacheColorSamples", &iSafeTextureCache_ColorSamples,512);
 	settings->Get("ShowFPS", &bShowFPS, false);
 	settings->Get("LogRenderTimeToFile", &bLogRenderTimeToFile, false);
 	settings->Get("ShowInputDisplay", &bShowInputDisplay, false);


### PR DESCRIPTION
This is an attempt to remove the fast texcache option from the gui and rename the normal setting to fast. See issue 7472 https://code.google.com/p/dolphin-emu/issues/detail?id=7472 for more info. 
The fast value can still be set via gameini as a workaround for texture packs that depend on the option.
