### PR TITLE
VideoCommon: fix ifdef expression

### DIFF
--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -28,7 +28,7 @@
 
 // This avoids a harmless warning from a system header in Clang;
 // see http://llvm.org/bugs/show_bug.cgi?id=16093
-#ifdef __clang__ && (__clang_major__ * 100 + __clang_minor__ < 304)
+#if defined(__clang__) && (__clang_major__ * 100 + __clang_minor__ < 304)
 #pragma clang diagnostic ignored "-Wshadow"
 #endif
 


### PR DESCRIPTION
How many ways are there to fuck up a single line of code? You can't make that shit up.
