### PR TITLE
DolphinWX: Mild readability clean up of CodeView.

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Debugger/CodeView.h
@@ -38,26 +38,30 @@ public:
 	void OnPopupMenu(wxCommandEvent& event);
 	void InsertBlrNop(int);
 
-	u32 GetSelection() {return(selection);}
 	void ToggleBreakpoint(u32 address);
+
+	u32 GetSelection()
+	{
+		return m_selection;
+	}
 
 	struct BlrStruct // for IDM_INSERTBLR
 	{
-		u32 Address;
-		u32 OldValue;
+		u32 address;
+		u32 oldValue;
 	};
-	std::vector<BlrStruct> BlrList;
+	std::vector<BlrStruct> m_blrList;
 
 	void Center(u32 addr)
 	{
-		curAddress = addr;
-		selection = addr;
+		m_curAddress = addr;
+		m_selection = addr;
 		Refresh();
 	}
 
 	void SetPlain()
 	{
-		plain = true;
+		m_plain = true;
 	}
 
 private:
@@ -67,22 +71,29 @@ private:
 	u32 AddrToBranch(u32 addr);
 	void OnResize(wxSizeEvent& event);
 
-	DebugInterface* debugger;
-	SymbolDB* symbol_db;
+	void MoveTo(int x, int y)
+	{
+		m_lx = x;
+		m_ly = y;
+	}
 
-	bool plain;
+	void LineTo(wxPaintDC &dc, int x, int y);
 
-	int curAddress;
-	int align;
-	int rowHeight;
 
-	u32 selection;
-	u32 oldSelection;
-	bool selecting;
+	DebugInterface* m_debugger;
+	SymbolDB* m_symbol_db;
 
-	int lx, ly;
-	void _MoveTo(int x, int y) {lx = x; ly = y;}
-	void _LineTo(wxPaintDC &dc, int x, int y);
+	bool m_plain;
+
+	int m_curAddress;
+	int m_align;
+	int m_rowHeight;
+
+	u32 m_selection;
+	u32 m_oldSelection;
+	bool m_selecting;
+
+	int m_lx, m_ly;
 
 	DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
- Gets rid of the underscore in some function names
- Appends the `m_` prefix to class member variables.

Now it isn't a pain to see what is being modified in terms of state. Especially in the `OnPaint` call.
