### PR TITLE
[Android] Enable filtering onscreen buttons

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/overlay/InputOverlay.java
@@ -54,7 +54,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		Bitmap bitmapResized = Bitmap.createScaledBitmap(bitmap,
 				(int)(dm.heightPixels * scale),
 				(int)(dm.heightPixels * scale),
-				false);
+				true);
 		return bitmapResized;
 	}
 

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/overlayconfig/OverlayConfigButton.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/overlayconfig/OverlayConfigButton.java
@@ -54,7 +54,7 @@ public final class OverlayConfigButton extends Button implements OnTouchListener
 		Bitmap bitmapResized = Bitmap.createScaledBitmap(b,
 				(int)(displayMetrics.heightPixels * scale),
 				(int)(displayMetrics.heightPixels * scale),
-				false);
+				true);
 
 		return new BitmapDrawable(getResources(), bitmapResized);
 	}


### PR DESCRIPTION
Why was this set to false? It looks much better now.

Before: http://i.imgur.com/8iUwyHR.png
After: http://i.imgur.com/XAKd7hm.png
