### PR TITLE
Update Pokemon Snap PAL ini to match NTSC.

### DIFF
--- a/Data/Sys/GameSettings/NAKP01.ini
+++ b/Data/Sys/GameSettings/NAKP01.ini
@@ -16,4 +16,6 @@ EmulationIssues = Controlls won't work in-game
 
 [ActionReplay]
 # Add action replay cheats here.
-
+[Video_Hacks]
+EFBToTextureEnable = False
+EFBCopyEnable = True


### PR DESCRIPTION
This Game is extremely broken without EFB2ram.

Now it's only very broken.
