### PR TITLE
DolphinWX: Implement scrolling in the memory views

### DIFF
--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -50,6 +50,7 @@ BEGIN_EVENT_TABLE(CMemoryView, wxControl)
 	EVT_LEFT_UP(CMemoryView::OnMouseUpL)
 	EVT_MOTION(CMemoryView::OnMouseMove)
 	EVT_RIGHT_DOWN(CMemoryView::OnMouseDownR)
+	EVT_MOUSEWHEEL(CMemoryView::OnScrollWheel)
 	EVT_MENU(-1, CMemoryView::OnPopupMenu)
 	EVT_SIZE(CMemoryView::OnResize)
 END_EVENT_TABLE()
@@ -134,6 +135,24 @@ void CMemoryView::OnMouseUpL(wxMouseEvent& event)
 		Refresh();
 	}
 
+	event.Skip();
+}
+
+void CMemoryView::OnScrollWheel(wxMouseEvent& event)
+{
+	const bool scroll_down = (event.GetWheelRotation() < 0);
+	const int num_lines = event.GetLinesPerAction();
+
+	if (scroll_down)
+	{
+		curAddress += num_lines;
+	}
+	else
+	{
+		curAddress -= num_lines;
+	}
+
+	Refresh();
 	event.Skip();
 }
 

--- a/Source/Core/DolphinWX/Debugger/MemoryView.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.h
@@ -21,6 +21,7 @@ public:
 	void OnMouseMove(wxMouseEvent& event);
 	void OnMouseUpL(wxMouseEvent& event);
 	void OnMouseDownR(wxMouseEvent& event);
+	void OnScrollWheel(wxMouseEvent& event);
 	void OnPopupMenu(wxCommandEvent& event);
 
 	u32 GetSelection() { return selection ; }


### PR DESCRIPTION
This should have been in my prior commit that implemented scrolling. This makes it work in the memory views as well
