### PR TITLE
GCI Folder: no need to force reload sysmenu to get region

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -110,7 +110,7 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 	u32 CurrentGameId = 0;
 	if (strUniqueID == TITLEID_SYSMENU_STRING)
 	{
-		const DiscIO::INANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, true);
+		const DiscIO::INANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, false);
 		if (SysMenu_Loader.IsValid())
 		{
 			CountryCode = DiscIO::CountrySwitch(SysMenu_Loader.GetCountryChar());


### PR DESCRIPTION
There is no reason to force reload when we are already running the sysmenu.
The fact that it wasn't crashing before was only because it was fast enough that it reloaded before the ppc code needed the nandloader
