### PR TITLE
DolphinWX: Move a public variable to be private in CodeView

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Debugger/CodeView.h
@@ -45,13 +45,6 @@ public:
 		return m_selection;
 	}
 
-	struct BlrStruct // for IDM_INSERTBLR
-	{
-		u32 address;
-		u32 oldValue;
-	};
-	std::vector<BlrStruct> m_blrList;
-
 	void Center(u32 addr)
 	{
 		m_curAddress = addr;
@@ -79,6 +72,12 @@ private:
 
 	void LineTo(wxPaintDC &dc, int x, int y);
 
+	struct BlrStruct // for IDM_INSERTBLR
+	{
+		u32 address;
+		u32 oldValue;
+	};
+	std::vector<BlrStruct> m_blrList;
 
 	DebugInterface* m_debugger;
 	SymbolDB* m_symbol_db;


### PR DESCRIPTION
It's not used outside of the class, and it also shouldn't be modified outside of it either (considering it holds all the blr instructions inserted by the user).
