### PR TITLE
[Android] Fix deformed buttons with a small scale

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/overlayconfig/OverlayConfigButton.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/overlayconfig/OverlayConfigButton.java
@@ -113,6 +113,11 @@ public final class OverlayConfigButton extends Button implements OnTouchListener
 		// Set the button's icon that represents it.
 		setBackground(resizeDrawable(getResources().getDrawable(drawableId), scale));
 
+		// Fix for deformed buttons with a small scale. (This does not happen outside of edit mode)
+		// The cause of this bug is unknown, except that it likely has something to do with the
+		// above line of code. At some point I will find the exact cause and remove this.
+		setHeight(getWidth());
+
 		// Check if this button has previous values set that aren't the default.
 		final float x = sharedPrefs.getFloat(buttonId+"-X", -1f);
 		final float y = sharedPrefs.getFloat(buttonId+"-Y", -1f);


### PR DESCRIPTION
For some reason, small button scales in edit mode caused buttons' heights to increase. This is simply a quick fix so people don't experience the bug. Once I find the exact cause of the problem I will create a more permanent fix.

Without patch: http://i.imgur.com/DgiARX1.png
With patch: http://i.imgur.com/QB4gXHa.png
