### PR TITLE
Clarify that WiimoteEmu::Spy is intended for debugging purposes

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -33,6 +33,7 @@ namespace WiimoteEmu
 
 void Spy(Wiimote* wm_, const void* data_, size_t size_)
 {
+// Enable for logging and debugging purposes.
 #if 0
 	// enable log
 	bool logCom = true;


### PR DESCRIPTION
See: https://github.com/mirror/dolphin-emu/issues/45
