### PR TITLE
AudioCommon/Mixer: Allow input sample rate changes

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -181,9 +181,24 @@ void CMixer::PushStreamingSamples(const short *samples, unsigned int num_samples
 	m_streaming_mixer.PushSamples(samples, num_samples);
 }
 
+void CMixer::SetDMAInputSampleRate(unsigned int rate)
+{
+	m_dma_mixer.SetInputSampleRate(rate);
+}
+
+void CMixer::SetStreamInputSampleRate(unsigned int rate)
+{
+	m_streaming_mixer.SetInputSampleRate(rate);
+}
+
 void CMixer::SetStreamingVolume(unsigned int lvolume, unsigned int rvolume)
 {
 	m_streaming_mixer.SetVolume(lvolume, rvolume);
+}
+
+void CMixer::MixerFifo::SetInputSampleRate(unsigned int rate)
+{
+	m_input_sample_rate = rate;
 }
 
 void CMixer::MixerFifo::SetVolume(unsigned int lvolume, unsigned int rvolume)

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -41,6 +41,9 @@ public:
 	virtual void PushSamples(const short* samples, unsigned int num_samples);
 	virtual void PushStreamingSamples(const short* samples, unsigned int num_samples);
 	unsigned int GetSampleRate() const { return m_sampleRate; }
+
+	void SetDMAInputSampleRate(unsigned int rate);
+	void SetStreamInputSampleRate(unsigned int rate);
 	void SetStreamingVolume(unsigned int lvolume, unsigned int rvolume);
 
 	void SetThrottle(bool use) { m_throttle = use;}
@@ -97,6 +100,7 @@ protected:
 		}
 		void PushSamples(const short* samples, unsigned int num_samples);
 		unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit = true);
+		void SetInputSampleRate(unsigned int rate);
 		void SetVolume(unsigned int lvolume, unsigned int rvolume);
 	private:
 		CMixer *m_mixer;

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -183,20 +183,22 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 			// Set frequency of streaming audio
 			if (tmpAICtrl.AISFR != m_Control.AISFR)
 			{
+				// AISFR rates below are intentionally inverted wrt yagcd
 				DEBUG_LOG(AUDIO_INTERFACE, "Change AISFR to %s", tmpAICtrl.AISFR ? "48khz":"32khz");
 				m_Control.AISFR = tmpAICtrl.AISFR;
+				g_AISSampleRate = tmpAICtrl.AISFR ? 48000 : 32000;
+				soundStream->GetMixer()->SetStreamInputSampleRate(g_AISSampleRate);
+				g_CPUCyclesPerSample = SystemTimers::GetTicksPerSecond() / g_AISSampleRate;
 			}
 			// Set frequency of DMA
 			if (tmpAICtrl.AIDFR != m_Control.AIDFR)
 			{
 				DEBUG_LOG(AUDIO_INTERFACE, "Change AIDFR to %s", tmpAICtrl.AIDFR ? "32khz":"48khz");
 				m_Control.AIDFR = tmpAICtrl.AIDFR;
+				g_AIDSampleRate = tmpAICtrl.AIDFR ? 32000 : 48000;
+				soundStream->GetMixer()->SetDMAInputSampleRate(g_AIDSampleRate);
 			}
 
-			g_AISSampleRate = tmpAICtrl.AISFR ? 48000 : 32000;
-			g_AIDSampleRate = tmpAICtrl.AIDFR ? 32000 : 48000;
-
-			g_CPUCyclesPerSample = SystemTimers::GetTicksPerSecond() / g_AISSampleRate;
 
 			// Streaming counter
 			if (tmpAICtrl.PSTAT != m_Control.PSTAT)


### PR DESCRIPTION
This patch informs the Mixer if the sampling rate is changed in AI. Fixes some issues when the DSP is used for 48000Hz audio (LLE only).

No known regressions.
