### PR TITLE
DolphinWX: Use a regular wxMessageBox instead of a PanicAlert for non-panic errors.

### DIFF
--- a/Source/Core/DolphinWX/ARCodeAddEdit.cpp
+++ b/Source/Core/DolphinWX/ARCodeAddEdit.cpp
@@ -12,6 +12,7 @@
 #include <wx/event.h>
 #include <wx/gbsizer.h>
 #include <wx/gdicmn.h>
+#include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/spinbutt.h>
 #include <wx/stattext.h>
@@ -148,7 +149,7 @@ void CARCodeAddEdit::SaveCheatData(wxCommandEvent& WXUNUSED (event))
 	// Codes with no lines appear to be deleted/hidden from the list.  Let's prevent that.
 	if (!decryptedLines.size())
 	{
-		PanicAlertT("The resulting decrypted AR code doesn't contain any lines.");
+		WxUtils::ShowErrorDialog(_("The resulting decrypted AR code doesn't contain any lines."));
 		return;
 	}
 

--- a/Source/Core/DolphinWX/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/CheatsWindow.cpp
@@ -18,6 +18,7 @@
 #include <wx/event.h>
 #include <wx/gdicmn.h>
 #include <wx/listbox.h>
+#include <wx/msgdlg.h>
 #include <wx/notebook.h>
 #include <wx/panel.h>
 #include <wx/radiobut.h>
@@ -398,7 +399,7 @@ void CheatSearchTab::StartNewSearch(wxCommandEvent& WXUNUSED (event))
 	const u8* const memptr = Memory::GetPointer(0);
 	if (nullptr == memptr)
 	{
-		PanicAlertT("A game is not currently running.");
+		WxUtils::ShowErrorDialog(_("A game is not currently running."));
 		return;
 	}
 
@@ -432,7 +433,7 @@ void CheatSearchTab::FilterCheatSearchResults(wxCommandEvent&)
 	const u8* const memptr = Memory::GetPointer(0);
 	if (nullptr == memptr)
 	{
-		PanicAlertT("A game is not currently running.");
+		WxUtils::ShowErrorDialog(_("A game is not currently running."));
 		return;
 	}
 
@@ -479,7 +480,7 @@ void CheatSearchTab::FilterCheatSearchResults(wxCommandEvent&)
 
 			if (!x_val.ToULong(&parsed_x_val, 0))
 			{
-				PanicAlertT("You must enter a valid decimal, hexadecimal or octal value.");
+				WxUtils::ShowErrorDialog(_("You must enter a valid decimal, hexadecimal or octal value."));
 				return;
 			}
 
@@ -629,7 +630,7 @@ void CreateCodeDialog::PressOK(wxCommandEvent& ev)
 	const wxString code_name = textctrl_name->GetValue();
 	if (code_name.empty())
 	{
-		PanicAlertT("You must enter a name!");
+		WxUtils::ShowErrorDialog(_("You must enter a name."));
 		return;
 	}
 
@@ -637,7 +638,7 @@ void CreateCodeDialog::PressOK(wxCommandEvent& ev)
 	int base = checkbox_use_hex->IsChecked() ? 16 : 10;
 	if (!textctrl_value->GetValue().ToLong(&code_value, base))
 	{
-		PanicAlertT("Invalid Value!");
+		WxUtils::ShowErrorDialog(_("Invalid value."));
 		return;
 	}
 

--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -1070,8 +1070,8 @@ void CConfigMain::ChooseMemcardPath(std::string& strMemcard, bool isSlotA)
 			GCMemcard memorycard(filename);
 			if (!memorycard.IsValid())
 			{
-				PanicAlertT("Cannot use that file as a memory card.\n%s\n" \
-							"is not a valid gamecube memory card file", filename.c_str());
+				WxUtils::ShowErrorDialog(wxString::Format(_("Cannot use that file as a memory card.\n%s\n" \
+				            "is not a valid gamecube memory card file"), filename.c_str()));
 				return;
 			}
 		}
@@ -1106,8 +1106,8 @@ void CConfigMain::ChooseMemcardPath(std::string& strMemcard, bool isSlotA)
 		}
 		else
 		{
-			PanicAlertT("Cannot use that file as a memory card.\n" \
-					"Are you trying to use the same file in both slots?");
+			WxUtils::ShowErrorDialog(_("Cannot use that file as a memory card.\n"
+			                           "Are you trying to use the same file in both slots?"));
 		}
 	}
 }
@@ -1204,7 +1204,7 @@ void CConfigMain::WiiSettingsChanged(wxCommandEvent& event)
 		u8 country_code = GetSADRCountryCode(wii_system_lang);
 		if (!SConfig::GetInstance().m_SYSCONF->SetArrayData("IPL.SADR", &country_code, 1))
 		{
-			PanicAlertT("Failed to update country code in SYSCONF");
+			WxUtils::ShowErrorDialog(_("Failed to update country code in SYSCONF"));
 		}
 		break;
 	}
@@ -1238,7 +1238,7 @@ void CConfigMain::AddRemoveISOPaths(wxCommandEvent& event)
 		{
 			if (ISOPaths->FindString(dialog.GetPath()) != -1)
 			{
-				wxMessageBox(_("The chosen directory is already in the list"), _("Error"), wxOK);
+				WxUtils::ShowErrorDialog(_("The chosen directory is already in the list."));
 			}
 			else
 			{

--- a/Source/Core/DolphinWX/Debugger/BreakpointDlg.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointDlg.cpp
@@ -8,6 +8,7 @@
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/gdicmn.h>
+#include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/string.h>
 #include <wx/textctrl.h>
@@ -50,7 +51,7 @@ void BreakPointDlg::OnOK(wxCommandEvent& event)
 	}
 	else
 	{
-		PanicAlertT("The address %s is invalid.", WxStrToStr(AddressString).c_str());
+		WxUtils::ShowErrorDialog(wxString::Format(_("The address %s is invalid."), WxStrToStr(AddressString).c_str()));
 	}
 
 	event.Skip();

--- a/Source/Core/DolphinWX/Debugger/DebuggerPanel.cpp
+++ b/Source/Core/DolphinWX/Debugger/DebuggerPanel.cpp
@@ -23,6 +23,7 @@
 #include "Common/IniFile.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreParameter.h"
+#include "DolphinWX/WxUtils.h"
 #include "DolphinWX/Debugger/DebuggerPanel.h"
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/TextureCacheBase.h"
@@ -288,42 +289,42 @@ void GFXDebuggerPanel::OnDumpButton(wxCommandEvent& event)
 
 		case 2: // Pixel Shader Constants
 			DumpPixelShaderConstants(dump_path);
-			wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+			WxUtils::ShowErrorDialog(_("Not implemented"));
 			break;
 
 		case 3: // Vertex Shader Constants
 			DumpVertexShaderConstants(dump_path);
-			wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+			WxUtils::ShowErrorDialog(_("Not implemented"));
 			break;
 
 		case 4: // Textures
 			DumpTextures(dump_path);
-			wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+			WxUtils::ShowErrorDialog(_("Not implemented"));
 			break;
 
 		case 5: // Frame Buffer
 			DumpFrameBuffer(dump_path);
-			wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+			WxUtils::ShowErrorDialog(_("Not implemented"));
 			break;
 
 		case 6: // Geometry
 			DumpGeometry(dump_path);
-			wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+			WxUtils::ShowErrorDialog(_("Not implemented"));
 			break;
 
 		case 7: // Vertex Description
 			DumpVertexDecl(dump_path);
-			wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+			WxUtils::ShowErrorDialog(_("Not implemented"));
 			break;
 
 		case 8: // Vertex Matrices
 			DumpMatrices(dump_path);
-			wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+			WxUtils::ShowErrorDialog(_("Not implemented"));
 			break;
 
 		case 9: // Statistics
 			DumpStats(dump_path);
-			wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+			WxUtils::ShowErrorDialog(_("Not implemented"));
 			break;
 	}
 }
@@ -337,7 +338,7 @@ void GFXDebuggerPanel::OnContButton(wxCommandEvent& event)
 void GFXDebuggerPanel::OnClearScreenButton(wxCommandEvent& event)
 {
 	// TODO
-	wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+	WxUtils::ShowErrorDialog(_("Not implemented"));
 }
 
 void GFXDebuggerPanel::OnClearTextureCacheButton(wxCommandEvent& event)
@@ -348,17 +349,17 @@ void GFXDebuggerPanel::OnClearTextureCacheButton(wxCommandEvent& event)
 void GFXDebuggerPanel::OnClearVertexShaderCacheButton(wxCommandEvent& event)
 {
 	// TODO
-	wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+	WxUtils::ShowErrorDialog(_("Not implemented"));
 }
 
 void GFXDebuggerPanel::OnClearPixelShaderCacheButton(wxCommandEvent& event)
 {
 	// TODO
-	wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+	WxUtils::ShowErrorDialog(_("Not implemented"));
 }
 
 void GFXDebuggerPanel::OnUpdateScreenButton(wxCommandEvent& event)
 {
-	wxMessageBox(_("Not implemented"), _("Error"), wxOK);
+	WxUtils::ShowErrorDialog(_("Not implemented"));
 	GFXDebuggerUpdateScreen();
 }

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -162,7 +162,7 @@ void CMemoryWindow::SetMemoryValue(wxCommandEvent& event)
 {
 	if (!Memory::IsInitialized())
 	{
-		PanicAlertT("Cannot set uninitialized memory.");
+		WxUtils::ShowErrorDialog(_("Cannot set uninitialized memory."));
 		return;
 	}
 
@@ -173,13 +173,13 @@ void CMemoryWindow::SetMemoryValue(wxCommandEvent& event)
 
 	if (!TryParse(std::string("0x") + str_addr, &addr))
 	{
-		PanicAlertT("Invalid Address: %s", str_addr.c_str());
+		WxUtils::ShowErrorDialog(wxString::Format(_("Invalid address: %s"), str_addr.c_str()));
 		return;
 	}
 
 	if (!TryParse(std::string("0x") + str_val, &val))
 	{
-		PanicAlertT("Invalid Value: %s", str_val.c_str());
+		WxUtils::ShowErrorDialog(wxString::Format(_("Invalid value: %s"), str_val.c_str()));
 		return;
 	}
 

--- a/Source/Core/DolphinWX/FifoPlayerDlg.cpp
+++ b/Source/Core/DolphinWX/FifoPlayerDlg.cpp
@@ -20,6 +20,7 @@
 #include <wx/filedlg.h>
 #include <wx/gdicmn.h>
 #include <wx/listbox.h>
+#include <wx/msgdlg.h>
 #include <wx/notebook.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>
@@ -418,7 +419,7 @@ void FifoPlayerDlg::OnSaveFile(wxCommandEvent& WXUNUSED(event))
 
 			// Wasn't able to save the file, shit's whack, yo.
 			if (!result)
-				PanicAlertT("Error saving file");
+				WxUtils::ShowErrorDialog(_("Error saving file."));
 		}
 	}
 }

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -750,9 +750,7 @@ void CFrame::OnRecord(wxCommandEvent& WXUNUSED (event))
 
 	if (Movie::IsReadOnly())
 	{
-		//PanicAlertT("Cannot record movies in read-only mode.");
-		//return;
-		// the user just chose to record a movie, so that should take precedence
+		// The user just chose to record a movie, so that should take precedence
 		Movie::SetReadOnly(false);
 		GetMenuBar()->FindItem(IDM_RECORDREADONLY)->Check(false);
 	}

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -1169,7 +1169,7 @@ void CGameListCtrl::CompressSelection(bool _compress)
 	}
 
 	if (!all_good)
-		wxMessageBox(_("Dolphin was unable to complete the requested action."));
+		WxUtils::ShowErrorDialog(_("Dolphin was unable to complete the requested action."));
 
 	Update();
 }
@@ -1255,7 +1255,7 @@ void CGameListCtrl::OnCompressGCM(wxCommandEvent& WXUNUSED (event))
 	}
 
 	if (!all_good)
-		wxMessageBox(_("Dolphin was unable to complete the requested action."));
+		WxUtils::ShowErrorDialog(_("Dolphin was unable to complete the requested action."));
 
 	Update();
 }

--- a/Source/Core/DolphinWX/GeckoCodeDiag.cpp
+++ b/Source/Core/DolphinWX/GeckoCodeDiag.cpp
@@ -13,6 +13,7 @@
 #include <wx/event.h>
 #include <wx/gdicmn.h>
 #include <wx/listbox.h>
+#include <wx/msgdlg.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -188,16 +189,7 @@ void CodeConfigPanel::DownloadCodes(wxCommandEvent&)
 		// parse the codes
 		std::istringstream ss(resp.GetBody());
 
-		// debug
-		//PanicAlert("File size is %i bytes.", ss.str().size());
-
 		std::string line;
-
-		// make sure the txt file is for this game
-		// eh w/e
-		//std::getline(ss, line);
-		//if (line != m_gameid)
-		//    PanicAlert("Bad code file.");
 
 		// seek past the header, get to the first code
 		std::getline(ss, line);
@@ -300,20 +292,20 @@ void CodeConfigPanel::DownloadCodes(wxCommandEvent&)
 				}
 			}
 
-			PanicAlertT("Downloaded %lu codes. (added %lu)",
-				(unsigned long)gcodes.size(), added_count);
+			wxMessageBox(wxString::Format(_("Downloaded %lu codes. (added %lu)"),
+				(unsigned long)gcodes.size(), added_count));
 
 			// refresh the list
 			UpdateCodeList();
 		}
 		else
 		{
-			PanicAlertT("File contained no codes.");
+			wxMessageBox(_("File contained no codes."));
 		}
 	}
 	else
 	{
-		PanicAlertT("Failed to download codes.");
+		WxUtils::ShowErrorDialog(_("Failed to download codes."));
 	}
 }
 

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -642,7 +642,7 @@ void CISOProperties::CreateGUIControls(bool IsWad)
 void CISOProperties::OnClose(wxCloseEvent& WXUNUSED (event))
 {
 	if (!SaveGameConfig())
-		PanicAlertT("Could not save %s", GameIniFileLocal.c_str());
+		WxUtils::ShowErrorDialog(wxString::Format(_("Could not save %s."), GameIniFileLocal.c_str()));
 
 	EndModal(bRefreshList ? wxID_OK : wxID_CANCEL);
 }
@@ -903,7 +903,7 @@ void CISOProperties::OnExtractDataFromHeader(wxCommandEvent& event)
 		}
 		else
 		{
-			PanicAlertT("Partition doesn't exist: %d", partitionNum);
+			WxUtils::ShowErrorDialog(wxString::Format(_("Partition doesn't exist: %d"), partitionNum));
 			return;
 		}
 	}
@@ -923,7 +923,7 @@ void CISOProperties::OnExtractDataFromHeader(wxCommandEvent& event)
 	}
 
 	if (!ret)
-		PanicAlertT("Failed to extract to %s!", WxStrToStr(Path).c_str());
+		WxUtils::ShowErrorDialog(wxString::Format(_("Failed to extract to %s!"), WxStrToStr(Path).c_str()));
 }
 
 class IntegrityCheckThread : public wxThread
@@ -1153,17 +1153,21 @@ void CISOProperties::LaunchExternalEditor(const std::string& filename)
 		filetype = wxTheMimeTypesManager->GetFileTypeFromMimeType("text/plain");
 		if (filetype == nullptr) // MIME type failed, aborting mission
 		{
-			PanicAlertT("Filetype 'ini' is unknown! Will not open!");
+			WxUtils::ShowErrorDialog(_("Filetype 'ini' is unknown! Will not open!"));
 			return;
 		}
 	}
-	wxString OpenCommand;
-	OpenCommand = filetype->GetOpenCommand(StrToWxStr(filename));
+
+	wxString OpenCommand = filetype->GetOpenCommand(StrToWxStr(filename));
 	if (OpenCommand.IsEmpty())
-		PanicAlertT("Couldn't find open command for extension 'ini'!");
+	{
+		WxUtils::ShowErrorDialog(_("Couldn't find open command for extension 'ini'!"));
+	}
 	else
+	{
 		if (wxExecute(OpenCommand, wxEXEC_SYNC) == -1)
-			PanicAlertT("wxExecute returned -1 on application run!");
+			WxUtils::ShowErrorDialog(_("wxExecute returned -1 on application run!"));
+	}
 #endif
 
 	bRefreshList = true; // Just in case

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -25,6 +25,7 @@
 #include <wx/font.h>
 #include <wx/gdicmn.h>
 #include <wx/listbox.h>
+#include <wx/msgdlg.h>
 #include <wx/notebook.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>
@@ -676,7 +677,7 @@ void GamepadPage::SaveProfile(wxCommandEvent&)
 	}
 	else
 	{
-		PanicAlertT("You must enter a valid profile name.");
+		WxUtils::ShowErrorDialog(_("You must enter a valid profile name."));
 	}
 }
 

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -430,14 +430,14 @@ void DolphinApp::InitLanguageSupport()
 
 		if (!m_locale->IsOk())
 		{
-			PanicAlertT("Error loading selected language. Falling back to system default.");
+			wxMessageBox(_("Error loading selected language. Falling back to system default."), _("Error"));
 			delete m_locale;
 			m_locale = new wxLocale(wxLANGUAGE_DEFAULT);
 		}
 	}
 	else
 	{
-		PanicAlertT("The selected language is not supported by your system. Falling back to system default.");
+		wxMessageBox(_("The selected language is not supported by your system. Falling back to system default."), _("Error"));
 		m_locale = new wxLocale(wxLANGUAGE_DEFAULT);
 	}
 }

--- a/Source/Core/DolphinWX/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetWindow.cpp
@@ -18,6 +18,7 @@
 #include <wx/frame.h>
 #include <wx/gdicmn.h>
 #include <wx/listbox.h>
+#include <wx/msgdlg.h>
 #include <wx/notebook.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>
@@ -256,13 +257,13 @@ void NetPlaySetupDiag::OnHost(wxCommandEvent&)
 	NetPlayDiag *&npd = NetPlayDiag::GetInstance();
 	if (npd)
 	{
-		PanicAlertT("A NetPlay window is already open!!");
+		WxUtils::ShowErrorDialog(_("A NetPlay window is already open!"));
 		return;
 	}
 
 	if (-1 == m_game_lbox->GetSelection())
 	{
-		PanicAlertT("You must choose a game!!");
+		WxUtils::ShowErrorDialog(_("You must choose a game!"));
 		return;
 	}
 
@@ -283,7 +284,7 @@ void NetPlaySetupDiag::OnHost(wxCommandEvent&)
 	}
 	else
 	{
-		PanicAlertT("Failed to listen.  Is another instance of the NetPlay server running?");
+		WxUtils::ShowErrorDialog(_("Failed to listen. Is another instance of the NetPlay server running?"));
 	}
 }
 
@@ -292,7 +293,7 @@ void NetPlaySetupDiag::OnJoin(wxCommandEvent&)
 	NetPlayDiag *&npd = NetPlayDiag::GetInstance();
 	if (npd)
 	{
-		PanicAlertT("A NetPlay window is already open!!");
+		WxUtils::ShowErrorDialog(_("A NetPlay window is already open!"));
 		return;
 	}
 
@@ -459,7 +460,7 @@ std::string NetPlayDiag::FindGame()
 		if (m_selected_game == BuildGameName(*game))
 			return game->GetFileName();
 
-	PanicAlertT("Game not found!");
+	WxUtils::ShowErrorDialog(_("Game not found!"));
 	return "";
 }
 

--- a/Source/Core/DolphinWX/PatchAddEdit.cpp
+++ b/Source/Core/DolphinWX/PatchAddEdit.cpp
@@ -12,6 +12,7 @@
 #include <wx/event.h>
 #include <wx/gbsizer.h>
 #include <wx/gdicmn.h>
+#include <wx/msgdlg.h>
 #include <wx/radiobox.h>
 #include <wx/sizer.h>
 #include <wx/spinbutt.h>
@@ -233,7 +234,7 @@ bool CPatchAddEdit::UpdateTempEntryData(std::vector<PatchEngine::PatchEntry>::it
 
 	if (!parsed_ok)
 	{
-		PanicAlertT("Unable to create patch from given values.\nEntry not modified.");
+		wxMessageBox(_("Unable to create patch from given values.\nEntry not modified."), _("Error"));
 	}
 
 	return parsed_ok;

--- a/Source/Core/DolphinWX/WxUtils.cpp
+++ b/Source/Core/DolphinWX/WxUtils.cpp
@@ -7,6 +7,7 @@
 #include <wx/chartype.h>
 #include <wx/gdicmn.h>
 #include <wx/image.h>
+#include <wx/msgdlg.h>
 #include <wx/mstream.h>
 #include <wx/string.h>
 #include <wx/utils.h>
@@ -49,6 +50,11 @@ void Explore(const std::string& path)
 	{
 		// WARN_LOG
 	}
+}
+
+void ShowErrorDialog(const wxString& error_msg)
+{
+	wxMessageBox(error_msg, _("Error"), wxOK | wxICON_ERROR);
 }
 
 double GetCurrentBitmapLogicalScale()

--- a/Source/Core/DolphinWX/WxUtils.h
+++ b/Source/Core/DolphinWX/WxUtils.h
@@ -21,6 +21,9 @@ void Launch(const std::string& filename);
 // Launch an file explorer window on a certain path
 void Explore(const std::string& path);
 
+// Displays a wxMessageBox geared for errors
+void ShowErrorDialog(const wxString& error_msg);
+
 double GetCurrentBitmapLogicalScale();
 
 wxBitmap _wxGetBitmapFromMemory(const unsigned char* data, int length);


### PR DESCRIPTION
Panic alerts should be reserved for critical unrecoverable errors.
