### PR TITLE
Vertex loader: reduce dependency on global state

### DIFF
--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -24,7 +24,7 @@
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/Statistics.h"
-#include "VideoCommon/VertexLoader.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderGen.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
@@ -126,7 +126,7 @@ void VertexManager::Draw(u32 stride)
 
 void VertexManager::vFlush(bool useDstAlpha)
 {
-	GLVertexFormat *nativeVertexFmt = (GLVertexFormat*)g_nativeVertexFmt;
+	GLVertexFormat *nativeVertexFmt = (GLVertexFormat*)VertexLoaderManager::GetCurrentVertexFormat();
 	u32 stride  = nativeVertexFmt->GetVertexStride();
 
 	if (m_last_vao != nativeVertexFmt->VAO) {
@@ -144,18 +144,18 @@ void VertexManager::vFlush(bool useDstAlpha)
 	// the same pass as regular rendering.
 	if (useDstAlpha && dualSourcePossible)
 	{
-		ProgramShaderCache::SetShader(DSTALPHA_DUAL_SOURCE_BLEND, g_nativeVertexFmt->m_components);
+		ProgramShaderCache::SetShader(DSTALPHA_DUAL_SOURCE_BLEND, nativeVertexFmt->m_components);
 	}
 	else
 	{
-		ProgramShaderCache::SetShader(DSTALPHA_NONE,g_nativeVertexFmt->m_components);
+		ProgramShaderCache::SetShader(DSTALPHA_NONE, nativeVertexFmt->m_components);
 	}
 
 	// upload global constants
 	ProgramShaderCache::UploadConstants();
 
 	// setup the pointers
-	g_nativeVertexFmt->SetupVertexPointers();
+	nativeVertexFmt->SetupVertexPointers();
 	GL_REPORT_ERRORD();
 
 	Draw(stride);
@@ -163,7 +163,7 @@ void VertexManager::vFlush(bool useDstAlpha)
 	// run through vertex groups again to set alpha
 	if (useDstAlpha && !dualSourcePossible)
 	{
-		ProgramShaderCache::SetShader(DSTALPHA_ALPHA_PASS,g_nativeVertexFmt->m_components);
+		ProgramShaderCache::SetShader(DSTALPHA_ALPHA_PASS, nativeVertexFmt->m_components);
 
 		// only update alpha
 		glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);

--- a/Source/Core/VideoCommon/VertexLoader.h
+++ b/Source/Core/VideoCommon/VertexLoader.h
@@ -24,7 +24,6 @@
 #endif
 
 // They are used for the communication with the loader functions
-extern NativeVertexFormat *g_nativeVertexFmt;
 extern int tcIndex;
 extern int colIndex;
 extern int colElements[2];
@@ -106,6 +105,9 @@ public:
 	~VertexLoader();
 
 	int GetVertexSize() const {return m_VertexSize;}
+	u32 GetNativeComponents() const { return m_native_components; }
+	const PortableVertexDeclaration& GetNativeVertexDeclaration() const
+		{ return m_native_vtx_decl; }
 
 	void SetupRunVertices(const VAT& vat, int primitive, int const count);
 	void RunVertices(const VAT& vat, int primitive, int count);
@@ -122,8 +124,8 @@ private:
 	TVtxDesc m_VtxDesc;  // Not really used currently - or well it is, but could be easily avoided.
 
 	// PC vertex format
-	NativeVertexFormat *m_NativeFmt;
-	int native_stride;
+	u32 m_native_components;
+	PortableVertexDeclaration m_native_vtx_decl;
 
 #ifndef USE_VERTEX_LOADER_JIT
 	// Pipeline.

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -12,11 +12,13 @@
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoaderManager.h"
+#include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoCommon.h"
 
 static int s_attr_dirty;  // bitfield
 
+static NativeVertexFormat* s_current_vtx_fmt;
 static VertexLoader *g_VertexLoaders[8];
 
 namespace std
@@ -122,10 +124,34 @@ static VertexLoader* RefreshLoader(int vtx_attr_group)
 	return g_VertexLoaders[vtx_attr_group];
 }
 
+static NativeVertexFormat* GetNativeVertexFormat(const PortableVertexDeclaration& format,
+                                                 u32 components)
+{
+	auto& native = s_native_vertex_map[format];
+	if (!native)
+	{
+		auto raw_pointer = g_vertex_manager->CreateNativeVertexFormat();
+		native = std::unique_ptr<NativeVertexFormat>(raw_pointer);
+		native->Initialize(format);
+		native->m_components = components;
+	}
+	return native.get();
+}
+
 void RunVertices(int vtx_attr_group, int primitive, int count)
 {
 	if (!count)
 		return;
+	VertexLoader* loader = RefreshLoader(vtx_attr_group);
+
+	// If the native vertex format changed, force a flush.
+	NativeVertexFormat* required_vtx_fmt = GetNativeVertexFormat(
+			loader->GetNativeVertexDeclaration(),
+			loader->GetNativeComponents());
+	if (required_vtx_fmt != s_current_vtx_fmt)
+		VertexManager::Flush();
+	s_current_vtx_fmt = required_vtx_fmt;
+
 	RefreshLoader(vtx_attr_group)->RunVertices(g_VtxAttr[vtx_attr_group], primitive, count);
 }
 
@@ -134,17 +160,9 @@ int GetVertexSize(int vtx_attr_group)
 	return RefreshLoader(vtx_attr_group)->GetVertexSize();
 }
 
-NativeVertexFormat* GetNativeVertexFormat(const PortableVertexDeclaration& format, u32 components)
+NativeVertexFormat* GetCurrentVertexFormat()
 {
-	auto& native = s_native_vertex_map[format];
-	if (!native)
-	{
-		auto raw_pointer = g_vertex_manager->CreateNativeVertexFormat();
-		native = std::unique_ptr<NativeVertexFormat>(raw_pointer);
-		native->m_components = components;
-		native->Initialize(format);
-	}
-	return native.get();
+	return s_current_vtx_fmt;
 }
 
 }  // namespace

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -22,7 +22,7 @@ namespace VertexLoaderManager
 	// For debugging
 	void AppendListToString(std::string *dest);
 
-	NativeVertexFormat* GetNativeVertexFormat(const PortableVertexDeclaration& format, u32 components);
+	NativeVertexFormat* GetCurrentVertexFormat();
 };
 
 void RecomputeCachedArraybases();


### PR DESCRIPTION
Requirement to make VertexLoader more testable. Now it can be tested in isolation without requiring a NativeVertexFormat implementation and without having to setup fake global VAT stuff.

Still remaining (but not critical):
- Input/output memory regions are currently defined as globals in DataReader.h. Difficult to make non global in the current code.
- BBOX emulation stuff uses tons of globals, but really it should be out of there in its own module (SWRenderer has something called "VertexTransform" which sounds like a good place to implement BBOX and a software vertex shader).
