### PR TITLE
Core: Get rid of the void handle parameter for DSP initialization

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -362,8 +362,7 @@ void EmuThread()
 
 	OSD::AddMessage("Dolphin " + g_video_backend->GetName() + " Video Backend.", 5000);
 
-	if (!DSP::GetDSPEmulator()->Initialize(g_pWindowHandle,
-		_CoreParameter.bWii, _CoreParameter.bDSPThread))
+	if (!DSP::GetDSPEmulator()->Initialize(_CoreParameter.bWii, _CoreParameter.bDSPThread))
 	{
 		HW::Shutdown();
 		g_video_backend->Shutdown();

--- a/Source/Core/Core/DSPEmulator.h
+++ b/Source/Core/Core/DSPEmulator.h
@@ -13,7 +13,7 @@ public:
 
 	virtual bool IsLLE() = 0;
 
-	virtual bool Initialize(void *hWnd, bool bWii, bool bDSPThread) = 0;
+	virtual bool Initialize(bool bWii, bool bDSPThread) = 0;
 	virtual void Shutdown() = 0;
 
 	virtual void DoState(PointerWrap &p) = 0;

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -39,7 +39,7 @@ struct DSPState
 	}
 };
 
-bool DSPHLE::Initialize(void *hWnd, bool bWii, bool bDSPThread)
+bool DSPHLE::Initialize(bool bWii, bool bDSPThread)
 {
 	m_bWii = bWii;
 	m_pUCode = nullptr;

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -14,7 +14,7 @@ class DSPHLE : public DSPEmulator {
 public:
 	DSPHLE();
 
-	virtual bool Initialize(void *hWnd, bool bWii, bool bDSPThread) override;
+	virtual bool Initialize(bool bWii, bool bDSPThread) override;
 	virtual void Shutdown() override;
 	virtual bool IsLLE() override { return false ; }
 

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -156,7 +156,7 @@ static bool FillDSPInitOptions(DSPInitOptions* opts)
 	return true;
 }
 
-bool DSPLLE::Initialize(void *hWnd, bool bWii, bool bDSPThread)
+bool DSPLLE::Initialize(bool bWii, bool bDSPThread)
 {
 	m_bWii = bWii;
 	m_bDSPThread = bDSPThread;

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.h
@@ -14,7 +14,7 @@ class DSPLLE : public DSPEmulator
 public:
 	DSPLLE();
 
-	virtual bool Initialize(void *hWnd, bool bWii, bool bDSPThread) override;
+	virtual bool Initialize(bool bWii, bool bDSPThread) override;
 	virtual void Shutdown() override;
 	virtual bool IsLLE() override { return true; }
 


### PR DESCRIPTION
I don't even know why we would want to pass window information to the DSP in the first place.
