### PR TITLE
Core: Remove the ratio parameter in Zelda UCode's SizeForResampling func

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -285,7 +285,7 @@ private:
 	void Resample(ZeldaVoicePB &PB, int size, s16 *in, s32 *out, bool do_resample = false);
 
 	int ConvertRatio(int pb_ratio);
-	int SizeForResampling(ZeldaVoicePB &PB, int size, int ratio);
+	int SizeForResampling(ZeldaVoicePB &PB, int size);
 
 	// Renders a voice and mixes it into LeftBuffer, RightBuffer
 	void RenderAddVoice(ZeldaVoicePB& PB, s32* _LeftBuffer, s32* _RightBuffer, int _Size);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ZeldaVoice.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ZeldaVoice.cpp
@@ -50,7 +50,8 @@ int ZeldaUCode::ConvertRatio(int pb_ratio)
 	return pb_ratio * 16;
 }
 
-int ZeldaUCode::SizeForResampling(ZeldaVoicePB &PB, int size, int ratio) {
+int ZeldaUCode::SizeForResampling(ZeldaVoicePB &PB, int size)
+{
 	// This is the little calculation at the start of every sample decoder
 	// in the ucode.
 	return (PB.CurSampleFrac + size * ConvertRatio(PB.RatioInt)) >> 16;
@@ -73,7 +74,7 @@ void ZeldaUCode::Resample(ZeldaVoicePB &PB, int size, s16 *in, s32 *out, bool do
 	}
 
 	int ratio = ConvertRatio(PB.RatioInt);
-	int in_size = SizeForResampling(PB, size, ratio);
+	int in_size = SizeForResampling(PB, size);
 
 	int position = PB.CurSampleFrac;
 	for (int i = 0; i < size; i++)
@@ -100,7 +101,7 @@ static void UpdateSampleCounters10(ZeldaVoicePB &PB)
 
 void ZeldaUCode::RenderVoice_PCM16(ZeldaVoicePB &PB, s16 *_Buffer, int _Size)
 {
-	int _RealSize = SizeForResampling(PB, _Size, PB.RatioInt);
+	int _RealSize = SizeForResampling(PB, _Size);
 	u32 rem_samples = _RealSize;
 	if (PB.KeyOff)
 		goto clear_buffer;
@@ -158,7 +159,7 @@ static void UpdateSampleCounters8(ZeldaVoicePB &PB)
 
 void ZeldaUCode::RenderVoice_PCM8(ZeldaVoicePB &PB, s16 *_Buffer, int _Size)
 {
-	int _RealSize = SizeForResampling(PB, _Size, PB.RatioInt);
+	int _RealSize = SizeForResampling(PB, _Size);
 	u32 rem_samples = _RealSize;
 	if (PB.KeyOff)
 		goto clear_buffer;
@@ -238,7 +239,7 @@ void ZeldaUCode::RenderVoice_AFC(ZeldaVoicePB &PB, s16 *_Buffer, int _Size)
 	PrintObject(PB);
 #endif
 
-	int _RealSize = SizeForResampling(PB, _Size, PB.RatioInt);
+	int _RealSize = SizeForResampling(PB, _Size);
 
 	// initialize "decoder" if the sample is played the first time
 	if (PB.NeedsReset != 0)
@@ -382,7 +383,7 @@ void Decoder21_ReadAudio(ZeldaVoicePB &PB, int size, s16 *_Buffer);
 void ZeldaUCode::RenderVoice_Raw(ZeldaVoicePB &PB, s16 *_Buffer, int _Size)
 {
 	// Decoder0x21 starts here.
-	u32 _RealSize = SizeForResampling(PB, _Size, PB.RatioInt);
+	u32 _RealSize = SizeForResampling(PB, _Size);
 
 	// Decoder0x21Core starts here.
 	u32 AX0 = _RealSize;


### PR DESCRIPTION
It's only ever passed PB.RatioInt
