### PR TITLE
Core: Remove the unused cycle parameter from DSPHLE update calls

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -66,10 +66,8 @@ void DSPHLE::Shutdown()
 
 void DSPHLE::DSP_Update(int cycles)
 {
-	// This is called OFTEN - better not do anything expensive!
-	// ~1/6th as many cycles as the period PPC-side.
 	if (m_pUCode != nullptr)
-		m_pUCode->Update(cycles / 6);
+		m_pUCode->Update();
 }
 
 u32 DSPHLE::DSP_UpdateRate()

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -661,7 +661,7 @@ void AXUCode::CopyCmdList(u32 addr, u16 size)
 	m_cmdlist_size = size;
 }
 
-void AXUCode::Update(int cycles)
+void AXUCode::Update()
 {
 	// Used for UCode switching.
 	if (NeedsResumeMail())

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -56,7 +56,7 @@ public:
 	virtual ~AXUCode();
 
 	virtual void HandleMail(u32 mail) override;
-	virtual void Update(int cycles) override;
+	virtual void Update() override;
 	virtual void DoState(PointerWrap& p) override;
 	u32 GetUpdateMs() override;
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -23,7 +23,7 @@ CARDUCode::~CARDUCode()
 }
 
 
-void CARDUCode::Update(int cycles)
+void CARDUCode::Update()
 {
 	// check if we have to sent something
 	if (!m_mail_handler.IsEmpty())

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
@@ -14,6 +14,6 @@ public:
 	u32 GetUpdateMs() override;
 
 	void HandleMail(u32 mail) override;
-	void Update(int cycles) override;
+	void Update() override;
 };
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -18,7 +18,7 @@ GBAUCode::~GBAUCode()
 	m_mail_handler.Clear();
 }
 
-void GBAUCode::Update(int cycles)
+void GBAUCode::Update()
 {
 	// check if we have to send something
 	if (!m_mail_handler.IsEmpty())

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
@@ -13,5 +13,5 @@ struct GBAUCode : public UCodeInterface
 	u32 GetUpdateMs() override;
 
 	void HandleMail(u32 mail) override;
-	void Update(int cycles) override;
+	void Update() override;
 };

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
@@ -12,18 +12,15 @@ INITUCode::INITUCode(DSPHLE *dsphle, u32 crc)
 	DEBUG_LOG(DSPHLE, "INITUCode - initialized");
 }
 
-
 INITUCode::~INITUCode()
 {
 }
-
 
 void INITUCode::Init()
 {
 }
 
-
-void INITUCode::Update(int cycles)
+void INITUCode::Update()
 {
 	if (m_mail_handler.IsEmpty())
 	{

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
@@ -14,6 +14,6 @@ public:
 	u32 GetUpdateMs() override;
 
 	void HandleMail(u32 mail) override;
-	void Update(int cycles) override;
+	void Update() override;
 	void Init();
 };

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -26,10 +26,12 @@ ROMUCode::ROMUCode(DSPHLE *dsphle, u32 crc)
 }
 
 ROMUCode::~ROMUCode()
-{}
+{
+}
 
-void ROMUCode::Update(int cycles)
-{}
+void ROMUCode::Update()
+{
+}
 
 void ROMUCode::HandleMail(u32 mail)
 {

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
@@ -14,7 +14,7 @@ public:
 	u32 GetUpdateMs() override;
 
 	void HandleMail(u32 mail) override;
-	void Update(int cycles) override;
+	void Update() override;
 
 	void DoState(PointerWrap &p) override;
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
@@ -68,20 +68,26 @@ public:
 		, m_next_ucode()
 		, m_next_ucode_steps(0)
 		, m_needs_resume_mail(false)
-	{}
+	{
+	}
 
 	virtual ~UCodeInterface()
-	{}
+	{
+	}
 
 	virtual void HandleMail(u32 mail) = 0;
-
-	// Cycles are out of the 81/121mhz the DSP runs at.
-	virtual void Update(int cycles) = 0;
+	virtual void Update() = 0;
 	virtual u32 GetUpdateMs() = 0;
 
-	virtual void DoState(PointerWrap &p) { DoStateShared(p); }
+	virtual void DoState(PointerWrap &p)
+	{
+		DoStateShared(p);
+	}
 
-	static u32 GetCRC(UCodeInterface* ucode) { return ucode ? ucode->m_crc : UCODE_NULL; }
+	static u32 GetCRC(UCodeInterface* ucode)
+	{
+		return ucode ? ucode->m_crc : UCODE_NULL;
+	}
 
 protected:
 	void PrepareBootUCode(u32 mail);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -82,7 +82,7 @@ u8 *ZeldaUCode::GetARAMPointer(u32 address)
 		return DSP::GetARAMPtr() + address;
 }
 
-void ZeldaUCode::Update(int cycles)
+void ZeldaUCode::Update()
 {
 	if (!IsLightVersion())
 	{

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -125,7 +125,7 @@ public:
 	void HandleMail_LightVersion(u32 mail);
 	void HandleMail_SMSVersion(u32 mail);
 	void HandleMail_NormalVersion(u32 mail);
-	void Update(int cycles) override;
+	void Update() override;
 
 	void CopyPBsFromRAM();
 	void CopyPBsToRAM();


### PR DESCRIPTION
This can't be removed from the `void DSPHLE::DSP_Update(int cycles)` call, as that is part of the DSP interface (LLE uses cycles).
