### PR TITLE
Fix PPC_FP on non-sse4.1 code paths.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -57,8 +57,9 @@ public:
 	void ForceSinglePrecisionS(Gen::X64Reg xmm);
 	void ForceSinglePrecisionP(Gen::X64Reg xmm);
 
-	// AX might get trashed
+	// EAX might get trashed
 	void ConvertSingleToDouble(Gen::X64Reg dst, Gen::X64Reg src, bool src_is_gpr = false);
+	// EAX might get trashed
 	void ConvertDoubleToSingle(Gen::X64Reg dst, Gen::X64Reg src);
 protected:
 	std::unordered_map<u8 *, u32> registersInUseAtLoc;


### PR DESCRIPTION
The Invalid bit on the x87 fpu is sticky, so once a single NaN goes
through the old code on CPUs without sse4.1 all future floats are
mutilated.

Patch to emulate PTEST by Fiora.

Should fix [issue 7237](https://code.google.com/p/dolphin-emu/issues/detail?id=7237) and [issue 7510](https://code.google.com/p/dolphin-emu/issues/detail?id=7510).
