### PR TITLE
Fix hotkeys in Linux and Mac OS X

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -970,12 +970,16 @@ void CFrame::StartGame(const std::string& filename)
 		else
 			m_RenderFrame->SetWindowStyle(m_RenderFrame->GetWindowStyle() & ~wxSTAY_ON_TOP);
 
-		m_RenderFrame->SetBackgroundColour(*wxBLACK);
 		m_RenderFrame->SetClientSize(size.GetWidth(), size.GetHeight());
 		m_RenderFrame->Bind(wxEVT_CLOSE_WINDOW, &CFrame::OnRenderParentClose, this);
 		m_RenderFrame->Bind(wxEVT_ACTIVATE, &CFrame::OnActive, this);
 		m_RenderFrame->Bind(wxEVT_MOVE, &CFrame::OnRenderParentMove, this);
 		m_RenderParent = m_RenderFrame;
+
+		// To capture key events the frame needs at least one child.
+		wxPanel* panel = new wxPanel(m_RenderFrame, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
+		panel->SetBackgroundColour(*wxBLACK);
+
 		m_RenderFrame->Show();
 	}
 


### PR DESCRIPTION
Needed for hotkeys to function correctly on Linux and OS X.

The reason this is necessary is because a wxFrame will only receive keyboard focus if it has at least one child.
