### PR TITLE
JIT: make fused multiply-add rounding more correct

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -149,7 +149,7 @@ inline double NI_sub(const double a, const double b)
 #endif
 }
 
-inline double NI_madd(const double a, const double b, const double c)
+inline double NI_madd(const double a, const double b, const double c, bool single)
 {
 #ifdef VERY_ACCURATE_FP
 	if (a != a) return a;
@@ -169,11 +169,14 @@ inline double NI_madd(const double a, const double b, const double c)
 	}
 	return t;
 #else
-	return NI_add(NI_mul(a, b), c);
+	if (single)
+		return ForceSingle(NI_add(ForceSingle(NI_mul(a, b)), c));
+	else
+		return ForceDouble(NI_add(ForceDouble(NI_mul(a, b)), c));
 #endif
 }
 
-inline double NI_msub(const double a, const double b, const double c)
+inline double NI_msub(const double a, const double b, const double c, bool single)
 {
 //#ifdef VERY_ACCURATE_FP
 //  This code does not produce accurate fp!  NAN's are not calculated correctly, nor negative zero.
@@ -198,7 +201,10 @@ inline double NI_msub(const double a, const double b, const double c)
 //	return t;
 //#else
 //	This code does not calculate QNAN's correctly but calculates negative zero correctly.
-	return NI_sub(NI_mul(a, b), c);
+	if (single)
+		return ForceSingle(NI_sub(ForceSingle(NI_mul(a, b)), c));
+	else
+		return ForceDouble(NI_sub(ForceDouble(NI_mul(a, b)), c));
 // #endif
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -289,7 +289,7 @@ void Interpreter::fmulsx(UGeckoInstruction _inst)
 
 void Interpreter::fmaddx(UGeckoInstruction _inst)
 {
-	double result = ForceDouble(NI_madd( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ));
+	double result = ForceDouble(NI_madd( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), false ));
 	rPS0(_inst.FD) = result;
 	UpdateFPRF(result);
 	if (_inst.Rc) Helper_UpdateCR1();
@@ -297,8 +297,8 @@ void Interpreter::fmaddx(UGeckoInstruction _inst)
 
 void Interpreter::fmaddsx(UGeckoInstruction _inst)
 {
-	double d_value = NI_madd( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) );
-	rPS0(_inst.FD) = rPS1(_inst.FD) = ForceSingle(d_value);
+	double d_value = NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), true);
+	rPS0(_inst.FD) = rPS1(_inst.FD) = d_value;
 	FPSCR.FI = d_value != rPS0(_inst.FD);
 	FPSCR.FR = 0;
 	UpdateFPRF(rPS0(_inst.FD));
@@ -414,36 +414,34 @@ void Interpreter::frsqrtex(UGeckoInstruction _inst)
 
 void Interpreter::fmsubx(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = ForceDouble(NI_msub( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ));
+	rPS0(_inst.FD) = NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), false);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fmsubsx(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = rPS1(_inst.FD) =
-		ForceSingle( NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ));
+	rPS0(_inst.FD) = rPS1(_inst.FD) = NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), true);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fnmaddx(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = ForceDouble(-NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
+	rPS0(_inst.FD) = -NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), false);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }
 void Interpreter::fnmaddsx(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = rPS1(_inst.FD) =
-		ForceSingle(-NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
+	rPS0(_inst.FD) = rPS1(_inst.FD) = -NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), true);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::fnmsubx(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = ForceDouble(-NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
+	rPS0(_inst.FD) = -NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), false);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }
@@ -451,8 +449,7 @@ void Interpreter::fnmsubx(UGeckoInstruction _inst)
 // fnmsubsx does not handle QNAN properly - see NI_msub
 void Interpreter::fnmsubsx(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = rPS1(_inst.FD) =
-		ForceSingle(-NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
+	rPS0(_inst.FD) = rPS1(_inst.FD) = -NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), true);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -231,32 +231,32 @@ void Interpreter::ps_mul(UGeckoInstruction _inst)
 
 void Interpreter::ps_msub(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = ForceSingle(NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
-	rPS1(_inst.FD) = ForceSingle(NI_msub(rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB)));
+	rPS0(_inst.FD) = NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), true);
+	rPS1(_inst.FD) = NI_msub(rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB), true);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_madd(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = ForceSingle(NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)));
-	rPS1(_inst.FD) = ForceSingle(NI_madd(rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB)));
+	rPS0(_inst.FD) = NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), true);
+	rPS1(_inst.FD) = NI_madd(rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB), true);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_nmsub(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = ForceSingle( -NI_msub( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ) );
-	rPS1(_inst.FD) = ForceSingle( -NI_msub( rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB) ) );
+	rPS0(_inst.FD) = -NI_msub(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), true);
+	rPS1(_inst.FD) = -NI_msub(rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB), true);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }
 
 void Interpreter::ps_nmadd(UGeckoInstruction _inst)
 {
-	rPS0(_inst.FD) = ForceSingle( -NI_madd( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB) ) );
-	rPS1(_inst.FD) = ForceSingle( -NI_madd( rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB) ) );
+	rPS0(_inst.FD) = -NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), true);
+	rPS1(_inst.FD) = -NI_madd(rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB), true);
 	UpdateFPRF(rPS0(_inst.FD));
 	if (_inst.Rc) Helper_UpdateCR1();
 }
@@ -303,8 +303,8 @@ void Interpreter::ps_muls1(UGeckoInstruction _inst)
 
 void Interpreter::ps_madds0(UGeckoInstruction _inst)
 {
-	double p0 = ForceSingle( NI_madd( rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB)) );
-	double p1 = ForceSingle( NI_madd( rPS1(_inst.FA), rPS0(_inst.FC), rPS1(_inst.FB)) );
+	double p0 = NI_madd(rPS0(_inst.FA), rPS0(_inst.FC), rPS0(_inst.FB), true);
+	double p1 = NI_madd(rPS1(_inst.FA), rPS0(_inst.FC), rPS1(_inst.FB), true);
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
 	UpdateFPRF(rPS0(_inst.FD));
@@ -313,8 +313,8 @@ void Interpreter::ps_madds0(UGeckoInstruction _inst)
 
 void Interpreter::ps_madds1(UGeckoInstruction _inst)
 {
-	double p0 = ForceSingle( NI_madd( rPS0(_inst.FA), rPS1(_inst.FC), rPS0(_inst.FB)) );
-	double p1 = ForceSingle( NI_madd( rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB)) );
+	double p0 = NI_madd(rPS0(_inst.FA), rPS1(_inst.FC), rPS0(_inst.FB), true);
+	double p1 = NI_madd(rPS1(_inst.FA), rPS1(_inst.FC), rPS1(_inst.FB), true);
 	rPS0(_inst.FD) = p0;
 	rPS1(_inst.FD) = p1;
 	UpdateFPRF(rPS0(_inst.FD));

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -114,19 +114,27 @@ void Jit64::fmaddXX(UGeckoInstruction inst)
 	{
 	case 28: //msub
 		MULSD(XMM0, fpr.R(c));
+		if (single_precision)
+			ForceSinglePrecisionS(XMM0);
 		SUBSD(XMM0, fpr.R(b));
 		break;
 	case 29: //madd
 		MULSD(XMM0, fpr.R(c));
+		if (single_precision)
+			ForceSinglePrecisionS(XMM0);
 		ADDSD(XMM0, fpr.R(b));
 		break;
 	case 30: //nmsub
 		MULSD(XMM0, fpr.R(c));
+		if (single_precision)
+			ForceSinglePrecisionS(XMM0);
 		SUBSD(XMM0, fpr.R(b));
 		PXOR(XMM0, M((void*)&psSignBits2));
 		break;
 	case 31: //nmadd
 		MULSD(XMM0, fpr.R(c));
+		if (single_precision)
+			ForceSinglePrecisionS(XMM0);
 		ADDSD(XMM0, fpr.R(b));
 		PXOR(XMM0, M((void*)&psSignBits2));
 		break;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -297,29 +297,35 @@ void Jit64::ps_maddXX(UGeckoInstruction inst)
 	case 14: //madds0
 		MOVDDUP(XMM1, fpr.R(c));
 		MULPD(XMM0, R(XMM1));
+		ForceSinglePrecisionP(XMM0);
 		ADDPD(XMM0, fpr.R(b));
 		break;
 	case 15: //madds1
 		MOVAPD(XMM1, fpr.R(c));
 		SHUFPD(XMM1, R(XMM1), 3); // copy higher to lower
 		MULPD(XMM0, R(XMM1));
+		ForceSinglePrecisionP(XMM0);
 		ADDPD(XMM0, fpr.R(b));
 		break;
 	case 28: //msub
 		MULPD(XMM0, fpr.R(c));
+		ForceSinglePrecisionP(XMM0);
 		SUBPD(XMM0, fpr.R(b));
 		break;
 	case 29: //madd
 		MULPD(XMM0, fpr.R(c));
+		ForceSinglePrecisionP(XMM0);
 		ADDPD(XMM0, fpr.R(b));
 		break;
 	case 30: //nmsub
 		MULPD(XMM0, fpr.R(c));
+		ForceSinglePrecisionP(XMM0);
 		SUBPD(XMM0, fpr.R(b));
 		PXOR(XMM0, M((void*)&psSignBits));
 		break;
 	case 31: //nmadd
 		MULPD(XMM0, fpr.R(c));
+		ForceSinglePrecisionP(XMM0);
 		ADDPD(XMM0, fpr.R(b));
 		PXOR(XMM0, M((void*)&psSignBits));
 		break;


### PR DESCRIPTION
At least going by the softfp branch, it looks like the Gamecube CPU doesn't
keep extra precision between steps, so we need to clamp to approximate its
behavior.

Also fix the interpreter and paired instructions to match, though I don't
know if the latter is necessary for any games.

As far as I can tell, if I'm not totally crazy, this fixes Mario Kart Wii's replays.
