### PR TITLE
Core: Use a std::string in EXI_DeviceIPL instead of a char buffer

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -82,11 +82,8 @@ CEXIIPL::CEXIIPL() :
 	m_uPosition(0),
 	m_uAddress(0),
 	m_uRWOffset(0),
-	m_count(0),
 	m_FontsLoaded(false)
 {
-	memset(m_szBuffer,0,sizeof(m_szBuffer));
-
 	// Determine region
 	m_bNTSC = SConfig::GetInstance().m_LocalCoreStartupParameter.bNTSC;
 
@@ -114,7 +111,6 @@ CEXIIPL::CEXIIPL() :
 	// Clear RTC
 	memset(m_RTC, 0, sizeof(m_RTC));
 
-
 	// We Overwrite language selection here since it's possible on the GC to change the language as you please
 	g_SRAM.lang = SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage;
 
@@ -124,11 +120,6 @@ CEXIIPL::CEXIIPL() :
 
 CEXIIPL::~CEXIIPL()
 {
-	if (m_count > 0)
-	{
-		m_szBuffer[m_count] = 0x00;
-	}
-
 	FreeMemoryPages(m_pIPL, ROM_SIZE);
 	m_pIPL = nullptr;
 
@@ -142,8 +133,7 @@ void CEXIIPL::DoState(PointerWrap &p)
 	p.Do(m_uPosition);
 	p.Do(m_uAddress);
 	p.Do(m_uRWOffset);
-	p.Do(m_szBuffer);
-	p.Do(m_count);
+	p.Do(m_buffer);
 	p.Do(m_FontsLoaded);
 }
 
@@ -274,13 +264,12 @@ void CEXIIPL::TransferByte(u8& _uByte)
 			if (IsWriteCommand())
 			{
 				if (_uByte != '\0')
-					m_szBuffer[m_count++] = _uByte;
-				if (m_count >= 255 || _uByte == '\r')
+					m_buffer += _uByte;
+
+				if (_uByte == '\r')
 				{
-					m_szBuffer[m_count] = '\0';
-					NOTICE_LOG(OSREPORT, "%s", m_szBuffer);
-					memset(m_szBuffer, 0, sizeof(m_szBuffer));
-					m_count = 0;
+					NOTICE_LOG(OSREPORT, "%s", m_buffer.c_str());
+					m_buffer.clear();
 				}
 			}
 			else

--- a/Source/Core/Core/HW/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/Sram.h"
 
@@ -58,8 +60,7 @@ private:
 	u32 m_uAddress;
 	u32 m_uRWOffset;
 
-	char m_szBuffer[256];
-	int m_count;
+	std::string m_buffer;
 	bool m_FontsLoaded;
 
 	virtual void TransferByte(u8 &_uByte) override;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -63,7 +63,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 29;
+static const u32 STATE_VERSION = 30;
 
 enum
 {


### PR DESCRIPTION
Allows getting rid of extra code.
