### PR TITLE
Fix D3D Real XFB texture sampling.

### DIFF
--- a/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
@@ -97,7 +97,8 @@ static const char XFB_ENCODE_PS[] =
 
 "void main(out float4 ocol0 : SV_Target, in float4 Pos : SV_Position, in float2 Coord : ENCODECOORD)\n"
 "{\n"
-	"float2 baseCoord = Coord * float2(2,1);\n"
+	// Multiplying X by 2, moves pixel centers from (x+0.5) to (2x+1) instead of (2x+0.5), so subtract 0.5 to compensate
+	"float2 baseCoord = Coord * float2(2,1) - float2(0.5,0);\n"
 	// FIXME: Shall we apply gamma here, or apply it below to the Y components?
 	// Be careful if you apply it to Y! The Y components are in the range (16..235) / 255.
 	"float3 sampleL = pow(abs(SampleEFB(baseCoord+float2(-1,0))), Params.Gamma);\n" // Left


### PR DESCRIPTION
Under the current D3D Real XFB system (which I don't really understand), when the texture lookup takes place, the x-coordinates passed in (x.5) are multiplied by 2, resulting in looking up each pixel about half a pixel too far to the right. This causes graphical errors on NVIDIA hardware due to every fifth column rounding up and choosing the wrong pixel. This fork compensates for incorrect texture coordinates by subtracting one half afterwards.
