### PR TITLE
Common: State OS instead of 32/64 bit in the netplay lobby

### DIFF
--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -24,24 +24,12 @@ const char *scm_rev_str = "Dolphin "
 	BUILD_TYPE_STR SCM_DESC_STR;
 #endif
 
-#if _M_X86_64
-#define NP_ARCH "x64"
-#elif _M_ARM_32
-#define NP_ARCH "ARM32"
-#elif _M_ARM_64
-#define NP_ARCH "ARM64"
-#elif _M_X86_32
-#define NP_ARCH "x86"
-#else
-#define NP_ARCH "Unk"
-#endif
-
 #ifdef _WIN32
-const char *netplay_dolphin_ver = SCM_DESC_STR " W" NP_ARCH;
+const char *netplay_dolphin_ver = SCM_DESC_STR " Win";
 #elif __APPLE__
-const char *netplay_dolphin_ver = SCM_DESC_STR " M" NP_ARCH;
+const char *netplay_dolphin_ver = SCM_DESC_STR " Mac";
 #else
-const char *netplay_dolphin_ver = SCM_DESC_STR " L" NP_ARCH;
+const char *netplay_dolphin_ver = SCM_DESC_STR " Lin";
 #endif
 
 const char *scm_rev_git_str = SCM_REV_STR;


### PR DESCRIPTION
Addresses issue [7522](https://code.google.com/p/dolphin-emu/issues/detail?id=7522)

IMO, it really shouldn't matter what arch a user is on, so I just removed the NP_ARCH string.
