### PR TITLE
Fixes a check for what mmap returns.

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -54,13 +54,13 @@ void* AllocateExecutableMemory(size_t size, bool low)
 	// printf("Mapped executable memory at %p (size %ld)\n", ptr,
 	//	(unsigned long)size);
 
-#if defined(__FreeBSD__)
+#ifdef _WIN32
+	if (ptr == nullptr)
+	{
+#else
 	if (ptr == MAP_FAILED)
 	{
 		ptr = nullptr;
-#else
-	if (ptr == nullptr)
-	{
 #endif
 		PanicAlert("Failed to allocate executable memory");
 	}


### PR DESCRIPTION
On error mmap returns MAP_FAILED(-1) not null.
FreeBSD was checking the return correctly, Linux was not.
This was noticed by triad attempting to run Dolphin under valgrind and not getting a memory space under the 2GB limit(Because -1 wraps around on
unsigned obviously)
