### PR TITLE
CFrame: Only re-assign focus when "Render to main" is enabled.

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -479,11 +479,14 @@ void CFrame::OnActive(wxActivateEvent& event)
 	{
 		if (event.GetActive() && event.GetEventObject() == m_RenderFrame)
 		{
+			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain)
+			{
 #ifdef __WXMSW__
-			::SetFocus((HWND)m_RenderParent->GetHandle());
+				::SetFocus((HWND)m_RenderParent->GetHandle());
 #else
-			m_RenderParent->SetFocus();
+				m_RenderParent->SetFocus();
 #endif
+			}
 
 			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor &&
 					Core::GetState() == Core::CORE_RUN)


### PR DESCRIPTION
It may cause fullscreen loops and since m_RenderFrame == m_RenderParent now it's not necessary to re-assign focus anymore.

No longer conflicts with PR #683, that PR has been rewritten.
