### PR TITLE
Core: Remove using namespace statements from the Jit and Interpreter headers

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -10,8 +10,6 @@
 #include "Common/MathUtil.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 
-using namespace MathUtil;
-
 // warning! very slow! This setting fixes NAN
 //#define VERY_ACCURATE_FP
 
@@ -80,7 +78,7 @@ inline double ForceSingle(double _x)
 	float x = (float) _x;
 	if (!cpu_info.bFlushToZero && FPSCR.NI)
 	{
-		x = FlushToZero(x);
+		x = MathUtil::FlushToZero(x);
 	}
 	// ...and back to double:
 	return x;
@@ -90,7 +88,7 @@ inline double ForceDouble(double d)
 {
 	if (!cpu_info.bFlushToZero && FPSCR.NI)
 	{
-		d = FlushToZero(d);
+		d = MathUtil::FlushToZero(d);
 	}
 	return d;
 }
@@ -206,13 +204,13 @@ inline double NI_msub(const double a, const double b, const double c)
 inline u32 ConvertToSingle(u64 x)
 {
 	u32 exp = (x >> 52) & 0x7ff;
-	if (exp > 896 || (x & ~DOUBLE_SIGN) == 0)
+	if (exp > 896 || (x & ~MathUtil::DOUBLE_SIGN) == 0)
 	{
 		return ((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff);
 	}
 	else if (exp >= 874)
 	{
-		u32 t = (u32)(0x80000000 | ((x & DOUBLE_FRAC) >> 21));
+		u32 t = (u32)(0x80000000 | ((x & MathUtil::DOUBLE_FRAC) >> 21));
 		t = t >> (905 - exp);
 		t |= (x >> 32) & 0x80000000;
 		return t;
@@ -229,7 +227,7 @@ inline u32 ConvertToSingle(u64 x)
 inline u32 ConvertToSingleFTZ(u64 x)
 {
 	u32 exp = (x >> 52) & 0x7ff;
-	if (exp > 896 || (x & ~DOUBLE_SIGN) == 0)
+	if (exp > 896 || (x & ~MathUtil::DOUBLE_SIGN) == 0)
 	{
 		return ((x >> 32) & 0xc0000000) | ((x >> 29) & 0x3fffffff);
 	}

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -114,12 +114,12 @@ public:
 
 	// Generates a branch that will check if a given bit of a CR register part
 	// is set or not.
-	FixupBranch JumpIfCRFieldBit(int field, int bit, bool jump_if_set = true);
+	Gen::FixupBranch JumpIfCRFieldBit(int field, int bit, bool jump_if_set = true);
 
-	void tri_op(int d, int a, int b, bool reversible, void (XEmitter::*op)(Gen::X64Reg, Gen::OpArg));
+	void tri_op(int d, int a, int b, bool reversible, void (Gen::XEmitter::*op)(Gen::X64Reg, Gen::OpArg));
 	typedef u32 (*Operation)(u32 a, u32 b);
-	void regimmop(int d, int a, bool binary, u32 value, Operation doop, void (XEmitter::*op)(int, const Gen::OpArg&, const Gen::OpArg&), bool Rc = false, bool carry = false);
-	void fp_tri_op(int d, int a, int b, bool reversible, bool single, void (XEmitter::*op)(Gen::X64Reg, Gen::OpArg));
+	void regimmop(int d, int a, bool binary, u32 value, Operation doop, void (Gen::XEmitter::*op)(int, const Gen::OpArg&, const Gen::OpArg&), bool Rc = false, bool carry = false);
+	void fp_tri_op(int d, int a, int b, bool reversible, bool single, void (Gen::XEmitter::*op)(Gen::X64Reg, Gen::OpArg));
 
 	// OPCODES
 	void unknown_instruction(UGeckoInstruction _inst);

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -8,8 +8,6 @@
 
 #include "Common/x64Emitter.h"
 
-using namespace Gen;
-
 enum FlushMode
 {
 	FLUSH_ALL,
@@ -18,7 +16,7 @@ enum FlushMode
 
 struct PPCCachedReg
 {
-	OpArg location;
+	Gen::OpArg location;
 	bool away;  // value not in source register
 	bool locked;
 };
@@ -48,7 +46,7 @@ protected:
 
 	virtual const int *GetAllocationOrder(size_t& count) = 0;
 
-	XEmitter *emit;
+	Gen::XEmitter *emit;
 
 public:
 	RegCache();
@@ -57,15 +55,15 @@ public:
 	void Start();
 
 	void DiscardRegContentsIfCached(size_t preg);
-	void SetEmitter(XEmitter *emitter) {emit = emitter;}
+	void SetEmitter(Gen::XEmitter *emitter) {emit = emitter;}
 
-	void FlushR(X64Reg reg);
-	void FlushR(X64Reg reg, X64Reg reg2) {FlushR(reg); FlushR(reg2);}
-	void FlushLockX(X64Reg reg) {
+	void FlushR(Gen::X64Reg reg);
+	void FlushR(Gen::X64Reg reg, Gen::X64Reg reg2) {FlushR(reg); FlushR(reg2);}
+	void FlushLockX(Gen::X64Reg reg) {
 		FlushR(reg);
 		LockX(reg);
 	}
-	void FlushLockX(X64Reg reg1, X64Reg reg2) {
+	void FlushLockX(Gen::X64Reg reg1, Gen::X64Reg reg2) {
 		FlushR(reg1); FlushR(reg2);
 		LockX(reg1); LockX(reg2);
 	}
@@ -78,19 +76,19 @@ public:
 	//read only will not set dirty flag
 	void BindToRegister(size_t preg, bool doLoad = true, bool makeDirty = true);
 	void StoreFromRegister(size_t preg, FlushMode mode = FLUSH_ALL);
-	virtual void StoreRegister(size_t preg, OpArg newLoc) = 0;
-	virtual void LoadRegister(size_t preg, X64Reg newLoc) = 0;
+	virtual void StoreRegister(size_t preg, Gen::OpArg newLoc) = 0;
+	virtual void LoadRegister(size_t preg, Gen::X64Reg newLoc) = 0;
 
-	const OpArg &R(size_t preg) const {return regs[preg].location;}
-	X64Reg RX(size_t preg) const
+	const Gen::OpArg &R(size_t preg) const {return regs[preg].location;}
+	Gen::X64Reg RX(size_t preg) const
 	{
 		if (IsBound(preg))
 			return regs[preg].location.GetSimpleReg();
 
 		PanicAlert("Not so simple - %i", preg);
-		return INVALID_REG;
+		return Gen::INVALID_REG;
 	}
-	virtual OpArg GetDefaultLocation(size_t reg) const = 0;
+	virtual Gen::OpArg GetDefaultLocation(size_t reg) const = 0;
 
 	// Register locking.
 	void Lock(int p1, int p2=0xff, int p3=0xff, int p4=0xff);
@@ -109,15 +107,15 @@ public:
 	}
 
 
-	X64Reg GetFreeXReg();
+	Gen::X64Reg GetFreeXReg();
 };
 
 class GPRRegCache : public RegCache
 {
 public:
-	void StoreRegister(size_t preg, OpArg newLoc) override;
-	void LoadRegister(size_t preg, X64Reg newLoc) override;
-	OpArg GetDefaultLocation(size_t reg) const override;
+	void StoreRegister(size_t preg, Gen::OpArg newLoc) override;
+	void LoadRegister(size_t preg, Gen::X64Reg newLoc) override;
+	Gen::OpArg GetDefaultLocation(size_t reg) const override;
 	const int* GetAllocationOrder(size_t& count) override;
 	void SetImmediate32(size_t preg, u32 immValue);
 };
@@ -126,8 +124,8 @@ public:
 class FPURegCache : public RegCache
 {
 public:
-	void StoreRegister(size_t preg, OpArg newLoc) override;
-	void LoadRegister(size_t preg, X64Reg newLoc) override;
+	void StoreRegister(size_t preg, Gen::OpArg newLoc) override;
+	void LoadRegister(size_t preg, Gen::X64Reg newLoc) override;
 	const int* GetAllocationOrder(size_t& count) override;
-	OpArg GetDefaultLocation(size_t reg) const override;
+	Gen::OpArg GetDefaultLocation(size_t reg) const override;
 };

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -8,6 +8,8 @@
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64/JitRegCache.h"
 
+using namespace Gen;
+
 static const u64 GC_ALIGNED16(psSignBits2[2]) = {0x8000000000000000ULL, 0x8000000000000000ULL};
 static const u64 GC_ALIGNED16(psAbsMask2[2])  = {0x7FFFFFFFFFFFFFFFULL, 0x7FFFFFFFFFFFFFFFULL};
 static const double GC_ALIGNED16(half_qnan_and_s32_max[2]) = {0x7FFFFFFF, -0x80000};

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -8,6 +8,8 @@
 #include "Core/PowerPC/Jit64/JitAsm.h"
 #include "Core/PowerPC/Jit64/JitRegCache.h"
 
+using namespace Gen;
+
 void Jit64::GenerateConstantOverflow(bool overflow)
 {
 	if (overflow)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -11,6 +11,8 @@
 #include "Core/PowerPC/Jit64/JitAsm.h"
 #include "Core/PowerPC/Jit64/JitRegCache.h"
 
+using namespace Gen;
+
 void Jit64::lXXx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -9,6 +9,8 @@
 #include "Core/PowerPC/Jit64/JitAsm.h"
 #include "Core/PowerPC/Jit64/JitRegCache.h"
 
+using namespace Gen;
+
 // TODO: Add peephole optimizations for multiple consecutive lfd/lfs/stfd/stfs since they are so common,
 // and pshufb could help a lot.
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -12,6 +12,8 @@
 #include "Core/PowerPC/Jit64/JitAsm.h"
 #include "Core/PowerPC/Jit64/JitRegCache.h"
 
+using namespace Gen;
+
 // The big problem is likely instructions that set the quantizers in the same block.
 // We will have to break block after quantizers are written to.
 void Jit64::psq_st(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -7,6 +7,8 @@
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64/JitRegCache.h"
 
+using namespace Gen;
+
 // TODO
 // ps_madds0
 // ps_muls0

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -6,9 +6,10 @@
 
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SystemTimers.h"
-
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64/JitRegCache.h"
+
+using namespace Gen;
 
 void Jit64::GetCRFieldBit(int field, int bit, Gen::X64Reg out)
 {

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -11,10 +11,10 @@
 namespace MMIO { class Mapping; }
 
 #define MEMCHECK_START \
-	FixupBranch memException; \
+	Gen::FixupBranch memException; \
 	if (jit->js.memcheck) \
-	{ TEST(32, M((void *)&PowerPC::ppcState.Exceptions), Imm32(EXCEPTION_DSI)); \
-	memException = J_CC(CC_NZ, true); }
+	{ TEST(32, Gen::M((void *)&PowerPC::ppcState.Exceptions), Gen::Imm32(EXCEPTION_DSI)); \
+	memException = J_CC(Gen::CC_NZ, true); }
 
 #define MEMCHECK_END \
 	if (jit->js.memcheck) \


### PR DESCRIPTION
Moves them to the cpp files so we don't have these sort of things drift via header.
