### PR TITLE
Core: Fix warnings on Linux related to the JIT

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -305,7 +305,7 @@ void FPURegCache::LoadRegister(size_t preg, X64Reg newLoc)
 {
 	if (!regs[preg].location.IsImm() && (regs[preg].location.offset & 0xF))
 	{
-		PanicAlert("WARNING - misaligned fp register location %i", preg);
+		PanicAlert("WARNING - misaligned fp register location %" PRIx64, preg);
 	}
 	emit->MOVAPD(newLoc, regs[preg].location);
 }
@@ -320,7 +320,7 @@ void RegCache::Flush(FlushMode mode)
 	for (size_t i = 0; i < xregs.size(); i++)
 	{
 		if (xregs[i].locked)
-			PanicAlert("Someone forgot to unlock X64 reg %zu.", i);
+			PanicAlert("Someone forgot to unlock X64 reg %" PRIx64, i);
 	}
 
 	for (size_t i = 0; i < regs.size(); i++)

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <cinttypes>
 
 #include "Common/x64Emitter.h"
 
@@ -85,7 +86,7 @@ public:
 		if (IsBound(preg))
 			return regs[preg].location.GetSimpleReg();
 
-		PanicAlert("Not so simple - %i", preg);
+		PanicAlert("Not so simple - %" PRIx64, preg);
 		return Gen::INVALID_REG;
 	}
 	virtual Gen::OpArg GetDefaultLocation(size_t reg) const = 0;

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -34,7 +34,7 @@ using namespace std;
 
 static const int CODEBUFFER_SIZE = 32000;
 // 0 does not perform block merging
-static const int FUNCTION_FOLLOWING_THRESHOLD = 16;
+static const u32 FUNCTION_FOLLOWING_THRESHOLD = 16;
 
 CodeBuffer::CodeBuffer(int size)
 {


### PR DESCRIPTION
Prior to this, you'd have pretty large warning spam when compiling the JIT related files.

Changing `FUNCTION_FOLLOWING_THRESHOLD` to a `u32` is fine, since it's only used in one place (which prior to this would have an equality comparison sign mismatch.
