### PR TITLE
AudioCommon: Get rid of some unnecessary mem_fn calls

### DIFF
--- a/Source/Core/AudioCommon/DSoundStream.cpp
+++ b/Source/Core/AudioCommon/DSoundStream.cpp
@@ -3,9 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
-#include <functional>
-
-#include <windows.h>
+#include <Windows.h>
 
 #include "AudioCommon/AudioCommon.h"
 #include "AudioCommon/DSoundStream.h"
@@ -123,7 +121,7 @@ bool DSound::Start()
 	dsBuffer->Lock(0, bufferSize, (void* *)&p1, &num1, 0, 0, DSBLOCK_ENTIREBUFFER);
 	memset(p1, 0, num1);
 	dsBuffer->Unlock(p1, num1, 0, 0);
-	thread = std::thread(std::mem_fn(&DSound::SoundLoop), this);
+	thread = std::thread(&DSound::SoundLoop, this);
 	return true;
 }
 

--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -38,7 +38,7 @@ bool OpenALStream::Start()
 				//period_size_in_millisec = 1000 / refresh;
 
 				alcMakeContextCurrent(pContext);
-				thread = std::thread(std::mem_fn(&OpenALStream::SoundLoop), this);
+				thread = std::thread(&OpenALStream::SoundLoop, this);
 				bReturn = true;
 			}
 			else


### PR DESCRIPTION
`mem_fn` is not needed in this instance for binding the function to the thread, it can just be done directly.
