### PR TITLE
AudioCommon: Remove an unnecessary parameter from the OpenALStream constructor

### DIFF
--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -45,7 +45,7 @@ class OpenALStream final : public SoundStream
 {
 #if defined HAVE_OPENAL && HAVE_OPENAL
 public:
-	OpenALStream(CMixer *mixer, void *hWnd = nullptr)
+	OpenALStream(CMixer *mixer)
 		: SoundStream(mixer)
 		, uiSource(0)
 	{}


### PR DESCRIPTION
This wouldn't even be assigned to anything.
