### PR TITLE
Jit64: Fix immediates being zero-extended to cr_val instead of sign-extended.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -122,7 +122,7 @@ void Jit64::ComputeRC(const Gen::OpArg & arg)
 {
 	if (arg.IsImm())
 	{
-		MOV(32, R(EAX), Imm32((s32)arg.offset));
+		MOV(64, R(RAX), Imm32((s32)arg.offset));
 		MOV(64, M(&PowerPC::ppcState.cr_val[0]), R(RAX));
 	}
 	else
@@ -394,7 +394,7 @@ void Jit64::cmpXX(UGeckoInstruction inst)
 		if (signedCompare)
 		{
 			if (gpr.R(a).IsImm())
-				MOV(64, R(RAX), gpr.R(a));
+				MOV(64, R(RAX), Imm32((s32)gpr.R(a).offset));
 			else
 				MOVSX(64, 32, RAX, gpr.R(a));
 			if (!comparand.IsImm())


### PR DESCRIPTION
Thanks to konpie for finding this issue. See https://code.google.com/p/dolphin-emu/issues/detail?id=7538 .
