### PR TITLE
Revert "Jit64: Fix immediates being zero-extended to cr_val instead of s...

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -122,7 +122,7 @@ void Jit64::ComputeRC(const Gen::OpArg & arg)
 {
 	if (arg.IsImm())
 	{
-		MOV(64, R(RAX), Imm32((s32)arg.offset));
+		MOV(32, R(EAX), Imm32((s32)arg.offset));
 		MOV(64, M(&PowerPC::ppcState.cr_val[0]), R(RAX));
 	}
 	else
@@ -394,7 +394,7 @@ void Jit64::cmpXX(UGeckoInstruction inst)
 		if (signedCompare)
 		{
 			if (gpr.R(a).IsImm())
-				MOV(64, R(RAX), Imm32((s32)gpr.R(a).offset));
+				MOV(64, R(RAX), gpr.R(a));
 			else
 				MOVSX(64, 32, RAX, gpr.R(a));
 			if (!comparand.IsImm())


### PR DESCRIPTION
Reverts dolphin-emu/dolphin#727

As expected, this was broken, and people merged it way too early without getting anyone to test it.
