### PR TITLE
DolphinWX: Ensure the code view string vector is always a size of two.

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -478,9 +478,10 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 		{
 			std::vector<std::string> dis;
 			SplitString(m_debugger->Disassemble(address), '\t', dis);
+			dis.resize(2);
 
 			static const size_t VALID_BRANCH_LENGTH = 10;
-			const std::string& opcode = dis[0];
+			const std::string& opcode   = dis[0];
 			const std::string& operands = dis[1];
 			std::string desc;
 


### PR DESCRIPTION
This way if any entries are not populated, then an empty string will be used.

This fixes an assert that throws on stopping a game. I should have originally caught this, my bad.
