### PR TITLE
Fix hotkeys in Linux and Mac OS X (properly this time).

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -973,7 +973,14 @@ void CFrame::StartGame(const std::string& filename)
 		m_RenderFrame->Bind(wxEVT_CLOSE_WINDOW, &CFrame::OnRenderParentClose, this);
 		m_RenderFrame->Bind(wxEVT_ACTIVATE, &CFrame::OnActive, this);
 		m_RenderFrame->Bind(wxEVT_MOVE, &CFrame::OnRenderParentMove, this);
+#ifdef _WIN32
+		// The renderer should use a top-level window for exclusive fullscreen support.
 		m_RenderParent = m_RenderFrame;
+#else
+		// To capture key events on Linux and Mac OS X the frame needs at least one child.
+		m_RenderParent = new wxPanel(m_RenderFrame, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
+#endif
+
 		m_RenderFrame->Show();
 	}
 


### PR DESCRIPTION
This is needed to fix the hotkeys on those platforms.

Proper fix this time, in the end I was unable to merge the two code paths since the behaviour is very different between these platforms.

Note that the panel is now actually used for rendering instead of obscuring the renderer. So there is no way for the same problem to happen on Linux and Mac OS X.
