### PR TITLE
VertexLoader: do not prepare for vertices if we need to skip them

### DIFF
--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -10,7 +10,6 @@
 
 #include "Core/Host.h"
 
-#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/PixelEngine.h"
@@ -840,12 +839,6 @@ void VertexLoader::ConvertVertices ( int count )
 
 void VertexLoader::RunVertices(const VAT& vat, int primitive, int const count)
 {
-	if (bpmem.genMode.cullmode == 3 && primitive < 5)
-	{
-		// if cull mode is none, ignore triangles and quads
-		DataSkip(count * m_VertexSize);
-		return;
-	}
 	SetupRunVertices(vat, primitive, count);
 	ConvertVertices(count);
 }

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -9,6 +9,7 @@
 
 #include "Core/HW/Memmap.h"
 
+#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoader.h"
@@ -144,6 +145,13 @@ void RunVertices(int vtx_attr_group, int primitive, int count)
 	if (!count)
 		return;
 	VertexLoader* loader = RefreshLoader(vtx_attr_group);
+
+	if (bpmem.genMode.cullmode == GenMode::CULL_ALL && primitive < 5)
+	{
+		// if cull mode is CULL_ALL, ignore triangles and quads
+		DataSkip(count * loader->GetVertexSize());
+		return;
+	}
 
 	// If the native vertex format changed, force a flush.
 	NativeVertexFormat* required_vtx_fmt = GetNativeVertexFormat(


### PR DESCRIPTION
Fixes a recent regression from #716. Not a big fan of doing the DataSkip in VertexLoaderManager, but tbh it isn't much worse than doing it in VertexLoader. It also removes the dependency of VertexLoader on bpmem, which makes me happy.
