### PR TITLE
Fix "bad wxCheckListBox index" warning when trying to create AR Code

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -1374,7 +1374,7 @@ void CISOProperties::ActionReplayList_Save()
 	u32 cheats_chkbox_count = Cheats->GetCount();
 	for (const ActionReplay::ARCode& code : arCodes)
 	{
-		//Check the index against the count because of the hacky way codes are added from the "Cheat Search" dialog
+		// Check the index against the count because of the hacky way codes are added from the "Cheat Search" dialog
 		if ((index < cheats_chkbox_count) && Cheats->IsChecked(index))
 			enabledLines.push_back("$" + code.name);
 


### PR DESCRIPTION
Fixes issue [7060](https://code.google.com/p/dolphin-emu/issues/detail?id=7060)

Since the "Create AR Code" dialog adds an AR code to arCodes but doesn't add a checkbox to the cheat list, an error occurs during saving when trying to access the checkbox associated with the added code. To fix this, the save method now checks the index before it tries to access the checkbox.
