### PR TITLE
Core: Default initialize a pointer to nullptr in gdsp_do_dma()

### DIFF
--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -341,7 +341,7 @@ static void gdsp_do_dma()
 	DEBUG_LOG(DSPLLE, "DMA pc: %04x, Control: %04x, Address: %08x, DSP Address: %04x, Size: %04x", g_dsp.pc, ctl, addr, dsp_addr, len);
 #endif
 
-	const u8* copied_data_ptr;
+	const u8* copied_data_ptr = nullptr;
 	switch (ctl & 0x3)
 	{
 		case (DSP_CR_DMEM | DSP_CR_TO_CPU):


### PR DESCRIPTION
The if-statement implies that this could fail comparison for a case in the switch statement somehow. If it does fail, then we'd be comparing for nullity with an uninitialized pointer.

Even if this isn't possible, Clang still warns about potential uninitialized values.
