### PR TITLE
X11Utils: Remove unneeded SendButtonEvent / SendKeyEvent utilities

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1123,18 +1123,6 @@ void CFrame::OnKeyUp(wxKeyEvent& event)
 
 void CFrame::OnMouse(wxMouseEvent& event)
 {
-#if defined(HAVE_X11) && HAVE_X11
-	if (Core::GetState() != Core::CORE_UNINITIALIZED)
-	{
-		if (event.Dragging())
-			X11Utils::SendMotionEvent(X11Utils::XDisplayFromHandle(GetHandle()),
-					event.GetPosition().x, event.GetPosition().y);
-		else
-			X11Utils::SendButtonEvent(X11Utils::XDisplayFromHandle(GetHandle()), event.GetButton(),
-					event.GetPosition().x, event.GetPosition().y, event.ButtonDown());
-	}
-#endif
-
 	// next handlers are all for FreeLook, so we don't need to check them if disabled
 	if (!g_Config.bFreeLook)
 	{

--- a/Source/Core/DolphinWX/X11Utils.cpp
+++ b/Source/Core/DolphinWX/X11Utils.cpp
@@ -24,37 +24,6 @@ extern char **environ;
 namespace X11Utils
 {
 
-void SendButtonEvent(Display *dpy, int button, int x, int y, bool pressed)
-{
-	XEvent event;
-	Window win = (Window)Core::GetWindowHandle();
-
-	// Init X event structure for mouse button press event
-	event.xbutton.type = pressed ? ButtonPress : ButtonRelease;
-	event.xbutton.x = x;
-	event.xbutton.y = y;
-	event.xbutton.button = button;
-
-	// Send the event
-	if (!XSendEvent(dpy, win, False, False, &event))
-		ERROR_LOG(VIDEO, "Failed to send mouse button event to the emulator window.");
-}
-
-void SendMotionEvent(Display *dpy, int x, int y)
-{
-	XEvent event;
-	Window win = (Window)Core::GetWindowHandle();
-
-	// Init X event structure for mouse motion
-	event.xmotion.type = MotionNotify;
-	event.xmotion.x = x;
-	event.xmotion.y = y;
-
-	// Send the event
-	if (!XSendEvent(dpy, win, False, False, &event))
-		ERROR_LOG(VIDEO, "Failed to send mouse button event to the emulator window.");
-}
-
 void EWMH_Fullscreen(Display *dpy, int action)
 {
 	_assert_(action == _NET_WM_STATE_REMOVE ||

--- a/Source/Core/DolphinWX/X11Utils.h
+++ b/Source/Core/DolphinWX/X11Utils.h
@@ -34,8 +34,6 @@
 namespace X11Utils
 {
 
-void SendButtonEvent(Display *dpy, int button, int x, int y, bool pressed);
-void SendMotionEvent(Display *dpy, int x, int y);
 void EWMH_Fullscreen(Display *dpy, int action);
 #if defined(HAVE_WX) && HAVE_WX
 Window XWindowFromHandle(void *Handle);


### PR DESCRIPTION
This was used to send fake button or key events to every backend to
implement freelook. When I ported these to be based on wx events in
commit 5248211, I didn't realize that these were now unused, so I didn't
remove them. Do that now.
