### PR TITLE
VideoBackendBase: Remove unused stub Initialize implementation

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -127,7 +127,6 @@ extern VideoBackend* g_video_backend;
 class VideoBackendHardware : public VideoBackend
 {
 	void RunLoop(bool enable) override;
-	bool Initialize(void *&) override { InitializeShared(); return true; }
 
 	void EmuStateChange(EMUSTATE_CHANGE) override;
 


### PR DESCRIPTION
Both D3D and OGL have their own overrides, so this isn't used.
