### PR TITLE
DSP: DMA behaviour adjustments to fix regressions

### DIFF
--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -406,8 +406,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 				// We make the samples ready as soon as possible
 				void *address = Memory::GetPointer(g_audioDMA.SourceAddress);
 				AudioCommon::SendAIBuffer((short*)address, g_audioDMA.AudioDMAControl.NumBlocks * 8);
-
-				GenerateDSPInterrupt(DSP::INT_AID);
+				CoreTiming::ScheduleEvent_Threadsafe(80, et_GenerateDSPInterrupt, INT_AID | (1 << 16));
 			}
 		})
 	);


### PR DESCRIPTION
This is meant to address the regressions in that were introduced by some of the recent audio changes. (particularly Pokemon Snap and Final Fantasy Crystal Chronicles)

It'd be great if this could get some testing to verify no further regressions.
