### PR TITLE
Core: Get rid of calls to mem_fn in thread instantiations

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceGecko.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include <functional>
-
 #include "Core/Core.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceGecko.h"
@@ -88,7 +86,7 @@ bool GeckoSockServer::GetAvailableSock(sf::SocketTCP &sock_to_fill)
 			recv_fifo = std::deque<u8>();
 			send_fifo = std::deque<u8>();
 		}
-		clientThread = std::thread(std::mem_fn(&GeckoSockServer::ClientThread), this);
+		clientThread = std::thread(&GeckoSockServer::ClientThread, this);
 		client_count++;
 		waiting_socks.pop();
 		sock_filled = true;

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -418,7 +418,7 @@ void WiimoteScanner::StartScanning()
 	if (!m_run_thread)
 	{
 		m_run_thread = true;
-		m_scan_thread = std::thread(std::mem_fn(&WiimoteScanner::ThreadFunc), this);
+		m_scan_thread = std::thread(&WiimoteScanner::ThreadFunc, this);
 	}
 }
 
@@ -491,7 +491,7 @@ bool Wiimote::Connect()
 void Wiimote::StartThread()
 {
 	m_run_thread = true;
-	m_wiimote_thread = std::thread(std::mem_fn(&Wiimote::ThreadFunc), this);
+	m_wiimote_thread = std::thread(&Wiimote::ThreadFunc, this);
 }
 
 void Wiimote::StopThread()

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <functional>
 #include <vector>
 
 #include "Common/ChunkFile.h"

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -117,7 +117,7 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
 			is_connected = true;
 
 			m_selector.Add(m_socket);
-			m_thread = std::thread(std::mem_fn(&NetPlayClient::ThreadFunc), this);
+			m_thread = std::thread(&NetPlayClient::ThreadFunc, this);
 		}
 	}
 	else

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <functional>
 #include <map>
 #include <queue>
 #include <sstream>

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -35,7 +35,7 @@ NetPlayServer::NetPlayServer(const u16 port) : is_connected(false), m_is_running
 		is_connected = true;
 		m_do_loop = true;
 		m_selector.Add(m_socket);
-		m_thread = std::thread(std::mem_fn(&NetPlayServer::ThreadFunc), this);
+		m_thread = std::thread(&NetPlayServer::ThreadFunc, this);
 		m_target_buffer_size = 20;
 	}
 }

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <functional>
 #include <map>
 #include <queue>
 #include <sstream>


### PR DESCRIPTION
These are not necessary for the same behavior.
