### PR TITLE
Core: Get rid of C-style struct typedefs

### DIFF
--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -38,14 +38,15 @@ static u32 state_checksum(u32 *buf, int len)
 	return checksum;
 }
 
-typedef struct {
+struct StateFlags
+{
 	u32 checksum;
 	u8 flags;
 	u8 type;
 	u8 discstate;
 	u8 returnto;
 	u32 unknown[6];
-} StateFlags;
+};
 
 bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
 {

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -184,7 +184,8 @@
 #define EXP_6           6 // 0x000c
 #define EXP_INT         7 // 0x000e external int (message from cpu)
 
-typedef struct {
+struct DSP_Regs
+{
 	u16 ar[4];
 	u16 ix[4];
 	u16 wr[4];
@@ -215,7 +216,7 @@ typedef struct {
 			u16 h;
 		};
 	} ac[2];
-} DSP_Regs;
+};
 
 // All the state of the DSP should be in this struct. Any DSP state that is not filled on init
 // should be moved here.

--- a/Source/Core/Core/Debugger/GCELF.h
+++ b/Source/Core/Core/Debugger/GCELF.h
@@ -44,7 +44,7 @@
 #define SHT_DYNSYM      11
 
 
-typedef struct
+struct ELF_Header
 {
 	unsigned char ID[4];
 	unsigned char clazz;
@@ -64,9 +64,9 @@ typedef struct
 	unsigned short e_shentsize;
 	unsigned short e_shnum;
 	unsigned short e_shtrndx;
-} ELF_Header;
+};
 
-typedef struct
+struct Program_Header
 {
 	unsigned int type;
 	unsigned int offset;
@@ -76,9 +76,9 @@ typedef struct
 	unsigned int memsz;
 	unsigned int flags;
 	unsigned int align;
-} Program_Header;
+};
 
-typedef struct
+struct Section_Header
 {
 	unsigned int name;
 	unsigned int type;
@@ -90,9 +90,9 @@ typedef struct
 	unsigned int info;
 	unsigned int addralign;
 	unsigned int entsize;
-} Section_Header;
+};
 
-typedef struct
+struct Symbol_Header
 {
 	unsigned int name;
 	unsigned int value;
@@ -100,13 +100,13 @@ typedef struct
 	unsigned char info;
 	unsigned char other;
 	unsigned short shndx;
-} Symbol_Header;
+};
 
-typedef struct
+struct Rela_Header
 {
 	unsigned int offset;
 	unsigned int info;
 	signed int addend;
-} Rela_Header;
+};
 
 const char ELFID[4] = {0x7F, 'E', 'L', 'F'};

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -46,9 +46,9 @@ private:
 	};
 
 	/* Device descriptor */
-	typedef struct
+	struct WiiHIDDeviceDescriptor
 	{
-		 u8 bLength;
+		u8 bLength;
 		u8 bDescriptorType;
 		u16 bcdUSB;
 		u8 bDeviceClass;
@@ -63,9 +63,9 @@ private:
 		u8 iSerialNumber;
 		u8 bNumConfigurations;
 		u8 pad[2];
-	} WiiHIDDeviceDescriptor;
+	};
 
-	typedef struct
+	struct WiiHIDConfigDescriptor
 	{
 		u8 bLength;
 		u8 bDescriptorType;
@@ -76,9 +76,9 @@ private:
 		u8 bmAttributes;
 		u8 MaxPower;
 		u8 pad[3];
-	} WiiHIDConfigDescriptor;
+	};
 
-	typedef struct
+	struct WiiHIDInterfaceDescriptor
 	{
 		u8 bLength;
 		u8 bDescriptorType;
@@ -90,9 +90,9 @@ private:
 		u8 bInterfaceProtocol;
 		u8 iInterface;
 		u8 pad[3];
-	} WiiHIDInterfaceDescriptor;
+	};
 
-	typedef struct
+	struct WiiHIDEndpointDescriptor
 	{
 		u8 bLength;
 		u8 bDescriptorType;
@@ -103,7 +103,7 @@ private:
 		u8 bRefresh;
 		u8 bSynchAddress;
 		u8 pad[1];
-	} WiiHIDEndpointDescriptor;
+	};
 
 	u32 deviceCommandAddress;
 	void FillOutDevices(u32 BufferOut, u32 BufferOutSize);


### PR DESCRIPTION
Could have sworn I had gotten rid of these, but I guess I must have missed them.
