### PR TITLE
DolphinWX: Fix scrolling in hex mode for the memory view

### DIFF
--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -377,7 +377,6 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
 					}
 					strcat(dis, buf);
 				}
-				curAddress += 32;
 			}
 			else
 			{


### PR DESCRIPTION
Prior to this after painting the hex values, it would increment the curAddress by 32, making scrolling backwards impossible. This is not only a bug, but unnecessary, since the OnMouseDownL and OnScrollWheel functions should be the only things to handle address incrementing for scrolling purposes.
