### PR TITLE
Core: Fix case where a panic alert wouldn't be shown in MemoryUtil.cpp

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -129,14 +129,20 @@ void FreeMemoryPages(void* ptr, size_t size)
 {
 	if (ptr)
 	{
+		bool error_occurred = false;
+
 #ifdef _WIN32
 		if (!VirtualFree(ptr, 0, MEM_RELEASE))
-		{
-			PanicAlert("FreeMemoryPages failed!\n%s", GetLastErrorMsg());
-		}
+			error_occurred = true;
 #else
-		munmap(ptr, size);
+		int retval = munmap(ptr, size);
+
+		if (retval != 0)
+			error_occurred = true;
 #endif
+
+		if (error_occurred)
+			PanicAlert("FreeMemoryPages failed!\n%s", GetLastErrorMsg());
 	}
 }
 
@@ -154,24 +160,40 @@ void FreeAlignedMemory(void* ptr)
 
 void WriteProtectMemory(void* ptr, size_t size, bool allowExecute)
 {
+	bool error_occurred = false;
+
 #ifdef _WIN32
 	DWORD oldValue;
 	if (!VirtualProtect(ptr, size, allowExecute ? PAGE_EXECUTE_READ : PAGE_READONLY, &oldValue))
-		PanicAlert("WriteProtectMemory failed!\n%s", GetLastErrorMsg());
+		error_occurred = true;
 #else
-	mprotect(ptr, size, allowExecute ? (PROT_READ | PROT_EXEC) : PROT_READ);
+	int retval = mprotect(ptr, size, allowExecute ? (PROT_READ | PROT_EXEC) : PROT_READ);
+
+	if (retval != 0)
+		error_occurred = true;
 #endif
+
+	if (error_occurred)
+		PanicAlert("WriteProtectMemory failed!\n%s", GetLastErrorMsg());
 }
 
 void UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute)
 {
+	bool error_occurred = false;
+
 #ifdef _WIN32
 	DWORD oldValue;
 	if (!VirtualProtect(ptr, size, allowExecute ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE, &oldValue))
-		PanicAlert("UnWriteProtectMemory failed!\n%s", GetLastErrorMsg());
+		error_occurred = true;
 #else
-	mprotect(ptr, size, allowExecute ? (PROT_READ | PROT_WRITE | PROT_EXEC) : PROT_WRITE | PROT_READ);
+	int retval = mprotect(ptr, size, allowExecute ? (PROT_READ | PROT_WRITE | PROT_EXEC) : PROT_WRITE | PROT_READ);
+
+	if (retval != 0)
+		error_occurred = true;
 #endif
+
+	if (error_occurred)
+		PanicAlert("UnWriteProtectMemory failed!\n%s", GetLastErrorMsg());
 }
 
 std::string MemUsage()


### PR DESCRIPTION
On Linux failed mmap calls return `MAP_FAILED` and not `nullptr`. 

This also fixes any checks against nullptr for pointer variables that call this function on Linux.
