### PR TITLE
DolphinWX: Get rid of an explicit delete in WiiSaveCrypted.cpp

### DIFF
--- a/Source/Core/DolphinWX/MemoryCards/WiiSaveCrypted.cpp
+++ b/Source/Core/DolphinWX/MemoryCards/WiiSaveCrypted.cpp
@@ -89,10 +89,10 @@ void CWiiSaveCrypted::ExportAllSaves()
 	u32 success = 0;
 	for (const u64& title : titles)
 	{
-		CWiiSaveCrypted* exportSave = new CWiiSaveCrypted("", title);
-		if (exportSave->b_valid)
+		CWiiSaveCrypted exportSave("", title);
+
+		if (exportSave.b_valid)
 			success++;
-		delete exportSave;
 	}
 	SuccessAlertT("Sucessfully exported %u saves to %s", success, (File::GetUserPath(D_USER_IDX) + "private/wii/title/").c_str());
 }


### PR DESCRIPTION
Does the same thing, except it lets the iteration scope take care of destruction.
