### PR TITLE
X11_Util: Fix build when using EGL

### DIFF
--- a/Source/Core/DolphinWX/GLInterface/X11_Util.cpp
+++ b/Source/Core/DolphinWX/GLInterface/X11_Util.cpp
@@ -83,8 +83,6 @@ void *cXInterface::CreateWindow(void)
 	XSync(GLWin.evdpy, True);
 
 	GLWin.xEventThread = std::thread(&cXInterface::XEventThread, this);
-	// Control window size and picture scaling
-	GLInterface->SetBackBufferDimensions(GLWin.width, GLWin.height);
 
 	return (void *) GLWin.win;
 }


### PR DESCRIPTION
We forgot to remove the reference to GLWin.width / GLWin.height here.
