### PR TITLE
Set the default radius to 100 for non-gcpad analog sticks.

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -144,7 +144,11 @@ ControllerEmu::AnalogStick::AnalogStick(const char* const _name) : ControlGroup(
 
 	controls.emplace_back(new Input(_trans("Modifier")));
 
-	settings.emplace_back(new Setting(_trans("Radius"), 0.7f, 0, 100));
+	// Default to 100 radius for everything but gcpad.
+	if (name == "Stick" || name == "Left Stick" || name == "Right Stick")
+		settings.emplace_back(new Setting(_trans("Radius"), 1.0f, 0, 100));
+	else
+		settings.emplace_back(new Setting(_trans("Radius"), 0.7f, 0, 100));
 	settings.emplace_back(new Setting(_trans("Dead Zone"), 0, 0, 50));
 }
 


### PR DESCRIPTION
The previous default of 70 was determined based on gc controllers, and is not right at all for the wii extensions.
