### PR TITLE
Common: Fix AsciiToHex returning true on overflow values

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -28,10 +28,16 @@
 // faster than sscanf
 bool AsciiToHex(const std::string& _szValue, u32& result)
 {
+	// Set errno to a good state.
+	errno = 0;
+
 	char *endptr = nullptr;
 	const u32 value = strtoul(_szValue.c_str(), &endptr, 16);
 
 	if (!endptr || *endptr)
+		return false;
+
+	if (errno == ERANGE)
 		return false;
 
 	result = value;


### PR DESCRIPTION
We should be checking `errno` against `ERANGE`.
