### PR TITLE
fixed toolbar pointer in FrameTools.cpp

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -552,6 +552,7 @@ void CFrame::RecreateToolbar()
 	{
 		m_Mgr->DetachPane(m_ToolBar);
 		m_ToolBar->Destroy();
+		m_ToolBar = nullptr;		// sets toolbar to null so that if-statement below can run
 	}
 
 	long TOOLBAR_STYLE = wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_TEXT  /*wxAUI_TB_OVERFLOW overflow visible*/;


### PR DESCRIPTION
RecreateToolbar was not resetting m_ToolBar on Destroy().
