### PR TITLE
DSP cleanup

### DIFF
--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -15,9 +15,9 @@ namespace DSP
 
 enum DSPInterruptType
 {
-	INT_DSP  = 0,
-	INT_ARAM = 1,
-	INT_AID  = 2
+	INT_DSP  = 0x80,
+	INT_ARAM = 0x20,
+	INT_AID  = 0x08,
 };
 
 // aram size and mask
@@ -65,8 +65,7 @@ DSPEmulator *GetDSPEmulator();
 
 void DoState(PointerWrap &p);
 
-void GenerateDSPInterrupt(DSPInterruptType _DSPInterruptType, bool _bSet = true);
-void GenerateDSPInterruptFromDSPEmu(DSPInterruptType _DSPInterruptType, bool _bSet = true);
+void GenerateDSPInterruptFromDSPEmu(DSPInterruptType _DSPInterruptType);
 
 // Audio/DSP Helper
 u8 ReadARAM(const u32 _uAddress);


### PR DESCRIPTION
Some general DSP cleanup:
- Making functions static if possible
- Removing branchiness from Interrupt setting functions
- Drop the bSet parameter because those functions were only ever used to set the interrupts

I've done some limited testing; seems fine but it'd be good to get some confirmation from others.
