### PR TITLE
Update frametools.cpp to fix crashing when changing themes.

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -536,6 +536,7 @@ void CFrame::RecreateToolbar()
 	{
 		m_Mgr->DetachPane(m_ToolBar);
 		m_ToolBar->Destroy();
+		m_ToolBar = nullptr;
 	}
 
 	long TOOLBAR_STYLE = wxTB_DEFAULT_STYLE | wxTB_TEXT;


### PR DESCRIPTION
m_ToolBar was not being reset to nullptr after being calling Destroy()
