### PR TITLE
Debugger: make "PPC to x86" open JIT window

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -555,8 +555,12 @@ void Host_UpdateDisasmDialog()
 
 void Host_ShowJitResults(unsigned int address)
 {
-	if (main_frame->g_pCodeWindow && main_frame->g_pCodeWindow->m_JitWindow)
+	if (main_frame->g_pCodeWindow)
+	{
+		if (!main_frame->g_pCodeWindow->m_JitWindow)
+			main_frame->g_pCodeWindow->ToggleJitWindow(true);
 		main_frame->g_pCodeWindow->m_JitWindow->ViewAddr(address);
+	}
 }
 
 void Host_UpdateMainFrame()


### PR DESCRIPTION
The button just silently did nothing if the window wasn't open, with no hint
as to how to make it work.
