### PR TITLE
JIT: correctly set skipNext even if conditional-continue is off

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -338,6 +338,7 @@ void Jit64::cmpXX(UGeckoInstruction inst)
 		if (merge_branch)
 		{
 			js.downcountAmount++;
+			js.skipnext = true;
 
 			gpr.Flush();
 			fpr.Flush();
@@ -382,7 +383,6 @@ void Jit64::cmpXX(UGeckoInstruction inst)
 			{
 				if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
 				{
-					js.skipnext = true;
 					WriteExit(js.next_compilerPC + 4);
 				}
 			}


### PR DESCRIPTION
Part 2: I missed the other branch-merging case in the first commit.
