### PR TITLE
JIT: support immediate stores

### DIFF
--- a/Source/Core/Common/x64Analyzer.cpp
+++ b/Source/Core/Common/x64Analyzer.cpp
@@ -136,6 +136,7 @@ bool DisassembleMov(const unsigned char *codePtr, InstructionInfo *info)
 		info->isMemoryWrite = true;
 		info->hasImmediate = true;
 		info->immediate = *codePtr;
+		info->operandSize = 1;
 		codePtr++;
 		break;
 

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -76,11 +76,15 @@ public:
 	void LoadAndSwap(int size, Gen::X64Reg dst, const Gen::OpArg& src);
 	void SwapAndStore(int size, const Gen::OpArg& dst, Gen::X64Reg src);
 
-	Gen::FixupBranch CheckIfSafeAddress(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, u32 registers_in_use, u32 mem_mask);
+	Gen::FixupBranch CheckIfSafeAddress(Gen::OpArg reg_value, Gen::X64Reg reg_addr, u32 registers_in_use, u32 mem_mask);
 	void UnsafeLoadRegToReg(Gen::X64Reg reg_addr, Gen::X64Reg reg_value, int accessSize, s32 offset = 0, bool signExtend = false);
 	void UnsafeLoadRegToRegNoSwap(Gen::X64Reg reg_addr, Gen::X64Reg reg_value, int accessSize, s32 offset, bool signExtend = false);
 	// these return the address of the MOV, for backpatching
-	u8 *UnsafeWriteRegToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize, s32 offset = 0, bool swap = true);
+	u8 *UnsafeWriteRegToReg(Gen::OpArg reg_value, Gen::X64Reg reg_addr, int accessSize, s32 offset = 0, bool swap = true);
+	u8 *UnsafeWriteRegToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize, s32 offset = 0, bool swap = true)
+	{
+		UnsafeWriteRegToReg(R(reg_value), reg_addr, accessSize, offset, swap);
+	}
 	u8 *UnsafeLoadToReg(Gen::X64Reg reg_value, Gen::OpArg opAddress, int accessSize, s32 offset, bool signExtend);
 
 	// Generate a load/write from the MMIO handler for a given address. Only
@@ -98,7 +102,12 @@ public:
 	void SafeLoadToReg(Gen::X64Reg reg_value, const Gen::OpArg & opAddress, int accessSize, s32 offset, u32 registersInUse, bool signExtend, int flags = 0);
 	// Clobbers RSCRATCH or reg_addr depending on the relevant flag.  Preserves
 	// reg_value if the load fails and js.memcheck is enabled.
-	void SafeWriteRegToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize, s32 offset, u32 registersInUse, int flags = 0);
+	// Works with immediate inputs and simple registers only.
+	void SafeWriteRegToReg(Gen::OpArg reg_value, Gen::X64Reg reg_addr, int accessSize, s32 offset, u32 registersInUse, int flags = 0);
+	void SafeWriteRegToReg(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, int accessSize, s32 offset, u32 registersInUse, int flags = 0)
+	{
+		SafeWriteRegToReg(R(reg_value), reg_addr, accessSize, offset, registersInUse, flags);
+	}
 
 	// applies to safe and unsafe WriteRegToReg
 	bool WriteClobbersRegValue(int accessSize, bool swap)


### PR DESCRIPTION
This is a bit of a WIP given that it.... turned out to be a lot bigger than I expected it to be, and I still need to bench it, but I'd love comments.

Basically I noticed there were tons of examples of code like this:

mov eax, 0x8
bswap eax, eax
mov [rdx+rbx], eax

This was clearly quite silly, so I decided to add support for immediate stores, a'la:

mov [rdx+rbx], 0x08000000

How hard could this be? Well, after a journey into the backpatcher, I can say "much harder than I originally thought..."
