### PR TITLE
InputCommon: Don't base default radius of analog sticks off of their name

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -5,6 +5,9 @@
 #include "Core/Host.h"
 #include "Core/HW/GCPadEmu.h"
 
+// TODO: Move to header file when VS supports constexpr.
+const ControlState GCPad::DEFAULT_PAD_STICK_RADIUS = 0.7f;
+
 const u16 button_bitmasks[] =
 {
 	PAD_BUTTON_A,
@@ -60,8 +63,8 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
 		m_buttons->controls.emplace_back(new ControlGroup::Input(named_buttons[i]));
 
 	// sticks
-	groups.emplace_back(m_main_stick = new AnalogStick(_trans("Main Stick")));
-	groups.emplace_back(m_c_stick = new AnalogStick(_trans("C-Stick")));
+	groups.emplace_back(m_main_stick = new AnalogStick(_trans("Main Stick"), DEFAULT_PAD_STICK_RADIUS));
+	groups.emplace_back(m_c_stick = new AnalogStick(_trans("C-Stick"), DEFAULT_PAD_STICK_RADIUS));
 
 	// triggers
 	groups.emplace_back(m_triggers = new MixedTriggers(_trans("Triggers")));

--- a/Source/Core/Core/HW/GCPadEmu.h
+++ b/Source/Core/Core/HW/GCPadEmu.h
@@ -35,4 +35,8 @@ private:
 
 	const unsigned int m_index;
 
+	// TODO: Make constexpr when VS supports it.
+	//
+	// Default analog stick radius for GameCube controllers.
+	static const ControlState DEFAULT_PAD_STICK_RADIUS;
 };

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
@@ -8,6 +8,9 @@
 namespace WiimoteEmu
 {
 
+// TODO: Move to header when VS supports constexpr.
+const ControlState Attachment::DEFAULT_ATTACHMENT_STICK_RADIUS = 1.0f;
+
 // Extension device IDs to be written to the last bytes of the extension reg
 // The id for nothing inserted
 static const u8 nothing_id[] = { 0x00, 0x00, 0x00, 0x00, 0x2e, 0x2e };

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.h
@@ -24,6 +24,12 @@ public:
 
 	u8 id[6];
 	u8 calibration[0x10];
+
+protected:
+	// TODO: Make constexpr when VS supports it.
+	//
+	// Default radius for attachment analog sticks.
+	static const ControlState DEFAULT_ATTACHMENT_STICK_RADIUS;
 };
 
 class None : public Attachment

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -60,8 +60,8 @@ Classic::Classic(WiimoteEmu::ExtensionReg& _reg) : Attachment(_trans("Classic"),
 		m_buttons->controls.emplace_back(new ControlGroup::Input(classic_button_name));
 
 	// sticks
-	groups.emplace_back(m_left_stick = new AnalogStick(_trans("Left Stick")));
-	groups.emplace_back(m_right_stick = new AnalogStick(_trans("Right Stick")));
+	groups.emplace_back(m_left_stick = new AnalogStick(_trans("Left Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
+	groups.emplace_back(m_right_stick = new AnalogStick(_trans("Right Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
 
 	// triggers
 	groups.emplace_back(m_triggers = new MixedTriggers("Triggers"));

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -39,7 +39,7 @@ Drums::Drums(WiimoteEmu::ExtensionReg& _reg) : Attachment(_trans("Drums"), _reg)
 		m_pads->controls.emplace_back(new ControlGroup::Input(drum_pad_name));
 
 	// stick
-	groups.emplace_back(m_stick = new AnalogStick("Stick"));
+	groups.emplace_back(m_stick = new AnalogStick("Stick", DEFAULT_ATTACHMENT_STICK_RADIUS));
 
 	// buttons
 	groups.emplace_back(m_buttons = new Buttons("Buttons"));

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -53,7 +53,7 @@ Guitar::Guitar(WiimoteEmu::ExtensionReg& _reg) : Attachment(_trans("Guitar"), _r
 	m_buttons->controls.emplace_back(new ControlGroup::Input("+"));
 
 	// stick
-	groups.emplace_back(m_stick = new AnalogStick(_trans("Stick")));
+	groups.emplace_back(m_stick = new AnalogStick(_trans("Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
 
 	// whammy
 	groups.emplace_back(m_whammy = new Triggers(_trans("Whammy")));

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -36,7 +36,7 @@ Nunchuk::Nunchuk(WiimoteEmu::ExtensionReg& _reg) : Attachment(_trans("Nunchuk"),
 	m_buttons->controls.emplace_back(new ControlGroup::Input("Z"));
 
 	// stick
-	groups.emplace_back(m_stick = new AnalogStick("Stick"));
+	groups.emplace_back(m_stick = new AnalogStick("Stick", DEFAULT_ATTACHMENT_STICK_RADIUS));
 
 	// swing
 	groups.emplace_back(m_swing = new Force("Swing"));

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -41,7 +41,7 @@ Turntable::Turntable(WiimoteEmu::ExtensionReg& _reg) : Attachment(_trans("Turnta
 	groups.emplace_back(m_right_table = new Slider(_trans("Table Right")));
 
 	// stick
-	groups.emplace_back(m_stick = new AnalogStick("Stick"));
+	groups.emplace_back(m_stick = new AnalogStick("Stick", DEFAULT_ATTACHMENT_STICK_RADIUS));
 
 	// effect dial
 	groups.emplace_back(m_effect_dial = new Triggers(_trans("Effect")));

--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -137,18 +137,14 @@ void ControllerEmu::SaveConfig(IniFile::Section *sec, const std::string& base)
 		ctrlGroup->SaveConfig(sec, defdev, base);
 }
 
-ControllerEmu::AnalogStick::AnalogStick(const char* const _name) : ControlGroup(_name, GROUP_TYPE_STICK)
+ControllerEmu::AnalogStick::AnalogStick(const char* const _name, ControlState default_radius)
+	: ControlGroup(_name, GROUP_TYPE_STICK)
 {
 	for (auto& named_direction : named_directions)
 		controls.emplace_back(new Input(named_direction));
 
 	controls.emplace_back(new Input(_trans("Modifier")));
-
-	// Default to 100 radius for everything but gcpad.
-	if (name == "Stick" || name == "Left Stick" || name == "Right Stick")
-		settings.emplace_back(new Setting(_trans("Radius"), 1.0f, 0, 100));
-	else
-		settings.emplace_back(new Setting(_trans("Radius"), 0.7f, 0, 100));
+	settings.emplace_back(new Setting(_trans("Radius"), default_radius, 0, 100));
 	settings.emplace_back(new Setting(_trans("Dead Zone"), 0, 0, 50));
 }
 

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -151,7 +151,8 @@ public:
 	class AnalogStick : public ControlGroup
 	{
 	public:
-		AnalogStick(const char* const _name);
+		// The GameCube controller and Wiimote attachments have a different default radius
+		AnalogStick(const char* const _name, ControlState default_radius);
 
 		void GetState(double* const x, double* const y)
 		{


### PR DESCRIPTION
We just directly specify what the default radius should be.

cc @magcius - Is this specifically what you mean?
