### PR TITLE
Fix the Not button showing up in the advanced control dialog.

### DIFF
--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -564,9 +564,6 @@ wxStaticBoxSizer* ControlDialog::CreateControlChooser(GamepadPage* const parent)
 	wxButton* const select_button = new wxButton(this, -1, _("Select"));
 	select_button->Bind(wxEVT_BUTTON, &ControlDialog::SetSelectedControl, this);
 
-	wxButton* const not_button = new  wxButton(this, -1, _("! NOT"));
-	not_button->Bind(wxEVT_BUTTON, &ControlDialog::AppendControl, this);
-
 	wxButton* const or_button = new  wxButton(this, -1, _("| OR"));
 	or_button->Bind(wxEVT_BUTTON, &ControlDialog::AppendControl, this);
 
@@ -581,9 +578,11 @@ wxStaticBoxSizer* ControlDialog::CreateControlChooser(GamepadPage* const parent)
 	{
 		// TODO: check if && is good on other OS
 		wxButton* const and_button = new  wxButton(this, -1, _("&& AND"));
+		wxButton* const not_button = new  wxButton(this, -1, _("! NOT"));
 		wxButton* const add_button = new  wxButton(this, -1, _("+ ADD"));
 
 		and_button->Bind(wxEVT_BUTTON, &ControlDialog::AppendControl, this);
+		not_button->Bind(wxEVT_BUTTON, &ControlDialog::AppendControl, this);
 		add_button->Bind(wxEVT_BUTTON, &ControlDialog::AppendControl, this);
 
 		button_sizer->Add(and_button, 1, 0, 5);


### PR DESCRIPTION
The Not button isn't supposed to show up on outputs to controllers.
When we generate the button it still shows up if it isn't added to the sizer since the parent window still owns it.

Fixes this issue report https://forums.dolphin-emu.org/Thread-linux-ui-bug-in-gc-pad-configuration-menu?pid=335269#pid335269
