### PR TITLE
Removed warnings by assigning to bool

### DIFF
--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -120,9 +120,9 @@ void CopyEFB(u32 dstAddr, const EFBRectangle& srcRect,
 */
 void ClearScreen(const EFBRectangle &rc)
 {
-	bool colorEnable = bpmem.blendmode.colorupdate;
-	bool alphaEnable = bpmem.blendmode.alphaupdate;
-	bool zEnable = bpmem.zmode.updateenable;
+	bool colorEnable = (bpmem.blendmode.colorupdate != 0);
+	bool alphaEnable = (bpmem.blendmode.alphaupdate != 0);
+	bool zEnable = (bpmem.zmode.updateenable != 0);
 	auto pixel_format = bpmem.zcontrol.pixel_format;
 
 	// (1): Disable unused color channels


### PR DESCRIPTION
There's no mention in the style guide of whether the `!!value` or `value != 0` syntax is preferred for casts to bool. I asked around on IRC and `value != 0` seems to be preferred.
