### PR TITLE
Debugger: fix JIT block viewer PPC view

### DIFF
--- a/Source/Core/DolphinWX/Debugger/JitWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.cpp
@@ -150,6 +150,7 @@ void CJitWindow::Compare(u32 em_address)
 	PPCAnalyst::BlockRegStats fpa;
 	PPCAnalyst::CodeBlock code_block;
 	PPCAnalyst::PPCAnalyzer analyzer;
+	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
 
 	code_block.m_stats = &st;
 	code_block.m_gpa = &gpa;


### PR DESCRIPTION
The JIT block compare code didn't set the same options for the PPCAnalyzer
as the actual JIT did, which made the PPC side of the JIT block viewer stop
at the first branch instead of the end of the block.
