### PR TITLE
JIT: flush *after* the merged branch, not before

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -430,17 +430,18 @@ void Jit64::cmpXX(UGeckoInstruction inst)
 			//     std::swap(destination1, destination2), condition = !condition;
 
 			gpr.UnlockAll();
-			gpr.Flush(FLUSH_MAINTAIN_STATE);
-			fpr.Flush(FLUSH_MAINTAIN_STATE);
 			FixupBranch pDontBranch;
 			if (test_bit & 8)
-				pDontBranch = J_CC(condition ? CC_GE : CC_L);  // Test < 0, so jump over if >= 0.
+				pDontBranch = J_CC(condition ? CC_GE : CC_L, true);  // Test < 0, so jump over if >= 0.
 			else if (test_bit & 4)
-				pDontBranch = J_CC(condition ? CC_LE : CC_G);  // Test > 0, so jump over if <= 0.
+				pDontBranch = J_CC(condition ? CC_LE : CC_G, true);  // Test > 0, so jump over if <= 0.
 			else if (test_bit & 2)
-				pDontBranch = J_CC(condition ? CC_NE : CC_E);  // Test = 0, so jump over if != 0.
+				pDontBranch = J_CC(condition ? CC_NE : CC_E, true);  // Test = 0, so jump over if != 0.
 			else  // SO bit, do not branch (we don't emulate SO for cmp).
-				pDontBranch = J();
+				pDontBranch = J(true);
+
+			gpr.Flush(FLUSH_MAINTAIN_STATE);
+			fpr.Flush(FLUSH_MAINTAIN_STATE);
 
 			// Code that handles successful PPC branching.
 			if (js.next_inst.OPCD == 16) // bcx
@@ -480,6 +481,8 @@ void Jit64::cmpXX(UGeckoInstruction inst)
 
 			if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
 			{
+				gpr.Flush();
+				fpr.Flush();
 				WriteExit(js.next_compilerPC + 4);
 			}
 		}


### PR DESCRIPTION
More correct and should avoid lots of redundant stores.
