### PR TITLE
Fixes PP-shaders on !Mesa targets.

### DIFF
--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -265,8 +265,8 @@ void OpenGLPostProcessing::CreateHeader()
 			"\tocol0 = color;\n"
 		"}\n"
 
-		"#define GetOption(x) (option_#x)\n"
-		"#define OptionEnabled(x) (option_#x != 0)\n";
+		"#define GetOption(x) (option_##x)\n"
+		"#define OptionEnabled(x) (option_##x != 0)\n";
 }
 
 std::string OpenGLPostProcessing::LoadShaderOptions(const std::string& code)


### PR DESCRIPTION
Seems mesa has a quirk where
# define THING(x) (#x)

is the same as
# define THING(x) (##x)

Didn't realize I messed it up since it just worked since I only tested on Mesa.
