### PR TITLE
Windows: Enable /Zc:rvalueCast solution-wide.

### DIFF
--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -57,7 +57,9 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <MinimalRebuild>false</MinimalRebuild>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Zc:inline /Zo /volatile:iso /D PSAPI_VERSION=1 /D _M_X86=1 %(AdditionalOptions)</AdditionalOptions>
+      <!--Enforce some behaviors as standards-conformant when they don't default as such-->
+      <AdditionalOptions>/Zc:inline /Zc:rvalueCast /volatile:iso %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zo /D PSAPI_VERSION=1 /D _M_X86=1 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Platform)'=='x64'">/D _ARCH_64=1 /D _M_X86_64=1 %(AdditionalOptions)</AdditionalOptions>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <!--


### PR DESCRIPTION
/Zc:rvalueCast: http://msdn.microsoft.com/en-us/library/dn449507.aspx
The only other interesting /Zc flag is strictStrings: http://msdn.microsoft.com/en-us/library/dn449508.aspx
Amazingly, the entire codebase (including all Externals!) builds fine with strictStrings, except for DInput headers included from dolphin's InputCommon...I'm not sure it's worth implementing an elegant way to disable strictStrings only for those files...
