### PR TITLE
Remove the ability to disable PanicHandlers.

### DIFF
--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -11,7 +11,6 @@
 
 bool DefaultMsgHandler(const char* caption, const char* text, bool yes_no, int Style);
 static MsgAlertHandler msg_handler = DefaultMsgHandler;
-static bool AlertEnabled = true;
 
 std::string DefaultStringTranslator(const char* text);
 static StringTranslator str_translator = DefaultStringTranslator;
@@ -27,12 +26,6 @@ void RegisterMsgAlertHandler(MsgAlertHandler handler)
 void RegisterStringTranslator(StringTranslator translator)
 {
 	str_translator = translator;
-}
-
-// enable/disable the alert handler
-void SetEnableAlert(bool enable)
-{
-	AlertEnabled = enable;
 }
 
 // This is the first stop for gui alerts where the log is updated and the
@@ -80,7 +73,7 @@ bool MsgAlert(bool yes_no, int Style, const char* format, ...)
 	ERROR_LOG(MASTER_LOG, "%s: %s", caption.c_str(), buffer);
 
 	// Don't ignore questions, especially AskYesNo, PanicYesNo could be ignored
-	if (msg_handler && (AlertEnabled || Style == QUESTION || Style == CRITICAL))
+	if (msg_handler)
 		return msg_handler(caption.c_str(), buffer, yes_no, Style);
 
 	return true;

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -27,7 +27,6 @@ bool MsgAlert(bool yes_no, int Style, const char* format, ...)
 	__attribute__((format(printf, 3, 4)))
 #endif
 	;
-void SetEnableAlert(bool enable);
 
 #ifndef GEKKO
 #ifdef _WIN32

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -195,7 +195,6 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
 	IniFile::Section* interface = ini.GetOrCreateSection("Interface");
 
 	interface->Set("ConfirmStop", m_LocalCoreStartupParameter.bConfirmStop);
-	interface->Set("UsePanicHandlers", m_LocalCoreStartupParameter.bUsePanicHandlers);
 	interface->Set("OnScreenDisplayMessages", m_LocalCoreStartupParameter.bOnScreenDisplayMessages);
 	interface->Set("HideCursor", m_LocalCoreStartupParameter.bHideCursor);
 	interface->Set("AutoHideCursor", m_LocalCoreStartupParameter.bAutoHideCursor);
@@ -401,7 +400,6 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
 	IniFile::Section* interface = ini.GetOrCreateSection("Interface");
 
 	interface->Get("ConfirmStop",             &m_LocalCoreStartupParameter.bConfirmStop,      true);
-	interface->Get("UsePanicHandlers",        &m_LocalCoreStartupParameter.bUsePanicHandlers, true);
 	interface->Get("OnScreenDisplayMessages", &m_LocalCoreStartupParameter.bOnScreenDisplayMessages, true);
 	interface->Get("HideCursor",              &m_LocalCoreStartupParameter.bHideCursor,       false);
 	interface->Get("AutoHideCursor",          &m_LocalCoreStartupParameter.bAutoHideCursor,   false);

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -42,7 +42,7 @@ SCoreStartupParameter::SCoreStartupParameter()
   bSyncGPU(false), bFastDiscSpeed(false),
   SelectedLanguage(0), bWii(false),
   bConfirmStop(false), bHideCursor(false),
-  bAutoHideCursor(false), bUsePanicHandlers(true), bOnScreenDisplayMessages(true),
+  bAutoHideCursor(false), bOnScreenDisplayMessages(true),
   iRenderWindowXPos(-1), iRenderWindowYPos(-1),
   iRenderWindowWidth(640), iRenderWindowHeight(480),
   bRenderWindowAutoSize(false), bKeepWindowOnTop(false),

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -146,7 +146,7 @@ struct SCoreStartupParameter
 	bool bWii;
 
 	// Interface settings
-	bool bConfirmStop, bHideCursor, bAutoHideCursor, bUsePanicHandlers, bOnScreenDisplayMessages;
+	bool bConfirmStop, bHideCursor, bAutoHideCursor, bOnScreenDisplayMessages;
 	std::string theme_name;
 
 	// Hotkeys

--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -151,7 +151,6 @@ EVT_CHOICE(ID_BACKEND, CConfigMain::AudioSettingsChanged)
 EVT_SLIDER(ID_VOLUME, CConfigMain::AudioSettingsChanged)
 
 EVT_CHECKBOX(ID_INTERFACE_CONFIRMSTOP, CConfigMain::DisplaySettingsChanged)
-EVT_CHECKBOX(ID_INTERFACE_USEPANICHANDLERS, CConfigMain::DisplaySettingsChanged)
 EVT_CHECKBOX(ID_INTERFACE_ONSCREENDISPLAYMESSAGES, CConfigMain::DisplaySettingsChanged)
 EVT_CHOICE(ID_INTERFACE_LANG, CConfigMain::DisplaySettingsChanged)
 EVT_BUTTON(ID_HOTKEY_CONFIG, CConfigMain::DisplaySettingsChanged)
@@ -351,7 +350,6 @@ void CConfigMain::InitializeGUIValues()
 
 	// Display - Interface
 	ConfirmStop->SetValue(startup_params.bConfirmStop);
-	UsePanicHandlers->SetValue(startup_params.bUsePanicHandlers);
 	OnScreenDisplayMessages->SetValue(startup_params.bOnScreenDisplayMessages);
 	// need redesign
 	for (unsigned int i = 0; i < sizeof(langIds) / sizeof(wxLanguage); i++)
@@ -519,7 +517,6 @@ void CConfigMain::InitializeGUITooltips()
 
 	// Display - Interface
 	ConfirmStop->SetToolTip(_("Show a confirmation box before stopping a game."));
-	UsePanicHandlers->SetToolTip(_("Show a message box when a potentially serious error has occurred.\nDisabling this may avoid annoying and non-fatal messages, but it may also mean that Dolphin suddenly crashes without any explanation at all."));
 	OnScreenDisplayMessages->SetToolTip(_("Show messages on the emulation screen area.\nThese messages include memory card writes, video backend and CPU information, and JIT cache clearing."));
 
 	InterfaceLang->SetToolTip(_("Change the language of the user interface.\nRequires restart."));
@@ -599,7 +596,6 @@ void CConfigMain::CreateGUIControls()
 	HotkeyConfig = new wxButton(DisplayPage, ID_HOTKEY_CONFIG, _("Hotkeys"), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
 	// Interface settings
 	ConfirmStop = new wxCheckBox(DisplayPage, ID_INTERFACE_CONFIRMSTOP, _("Confirm on Stop"));
-	UsePanicHandlers = new wxCheckBox(DisplayPage, ID_INTERFACE_USEPANICHANDLERS, _("Use Panic Handlers"));
 	OnScreenDisplayMessages = new wxCheckBox(DisplayPage, ID_INTERFACE_ONSCREENDISPLAYMESSAGES, _("On-Screen Display Messages"));
 
 	wxBoxSizer* sInterface = new wxBoxSizer(wxHORIZONTAL);
@@ -645,7 +641,6 @@ void CConfigMain::CreateGUIControls()
 
 	sbInterface = new wxStaticBoxSizer(wxVERTICAL, DisplayPage, _("Interface Settings"));
 	sbInterface->Add(ConfirmStop, 0, wxALL, 5);
-	sbInterface->Add(UsePanicHandlers, 0, wxALL, 5);
 	sbInterface->Add(OnScreenDisplayMessages, 0, wxALL, 5);
 	sbInterface->Add(scInterface, 0, wxEXPAND | wxALL, 5);
 	sbInterface->Add(sInterface, 0, wxEXPAND | wxALL, 5);
@@ -920,13 +915,8 @@ void CConfigMain::DisplaySettingsChanged(wxCommandEvent& event)
 	case ID_INTERFACE_CONFIRMSTOP:
 		SConfig::GetInstance().m_LocalCoreStartupParameter.bConfirmStop = ConfirmStop->IsChecked();
 		break;
-	case ID_INTERFACE_USEPANICHANDLERS:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bUsePanicHandlers = UsePanicHandlers->IsChecked();
-		SetEnableAlert(UsePanicHandlers->IsChecked());
-		break;
 	case ID_INTERFACE_ONSCREENDISPLAYMESSAGES:
 		SConfig::GetInstance().m_LocalCoreStartupParameter.bOnScreenDisplayMessages = OnScreenDisplayMessages->IsChecked();
-		SetEnableAlert(OnScreenDisplayMessages->IsChecked());
 		break;
 	case ID_INTERFACE_LANG:
 		if (SConfig::GetInstance().m_InterfaceLanguage != langIds[InterfaceLang->GetSelection()])

--- a/Source/Core/DolphinWX/ConfigMain.h
+++ b/Source/Core/DolphinWX/ConfigMain.h
@@ -96,7 +96,6 @@ private:
 
 		// Interface settings
 		ID_INTERFACE_CONFIRMSTOP,
-		ID_INTERFACE_USEPANICHANDLERS,
 		ID_INTERFACE_ONSCREENDISPLAYMESSAGES,
 		ID_INTERFACE_LANG,
 		ID_HOTKEY_CONFIG,
@@ -171,7 +170,6 @@ private:
 
 	// Interface
 	wxCheckBox* ConfirmStop;
-	wxCheckBox* UsePanicHandlers;
 	wxCheckBox* OnScreenDisplayMessages;
 	wxChoice* InterfaceLang;
 	wxButton* HotkeyConfig;

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -310,8 +310,6 @@ bool DolphinApp::OnInit()
 	// Enable the PNG image handler for screenshots
 	wxImage::AddHandler(new wxPNGHandler);
 
-	SetEnableAlert(SConfig::GetInstance().m_LocalCoreStartupParameter.bUsePanicHandlers);
-
 	int x = SConfig::GetInstance().m_LocalCoreStartupParameter.iPosX;
 	int y = SConfig::GetInstance().m_LocalCoreStartupParameter.iPosY;
 	int w = SConfig::GetInstance().m_LocalCoreStartupParameter.iWidth;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -101,9 +101,6 @@ void VideoConfig::Load(const std::string& ini_file)
 	// Load common settings
 	iniFile.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
 	IniFile::Section* interface = iniFile.GetOrCreateSection("Interface");
-	bool bTmp;
-	interface->Get("UsePanicHandlers", &bTmp, true);
-	SetEnableAlert(bTmp);
 
 	// Shader Debugging causes a huge slowdown and it's easy to forget about it
 	// since it's not exposed in the settings dialog. It's only used by


### PR DESCRIPTION
PanicAlerts are, or should be, fatal conditions that shouldn't be skipped over.

Also found a bug in DolphinWX/ConfigMain.cpp:925 that both OSD and PanicAlert options were setting if PanicAlerts should be set.
I assume this issue is a copy and paste issue that went unnoticed.
