### PR TITLE
Refactored SCoreStartupParameter to remove Hungarian notation and adhere...

### DIFF
--- a/Externals/wxWidgets3/include/wx/confbase.h
+++ b/Externals/wxWidgets3/include/wx/confbase.h
@@ -419,7 +419,7 @@ public:
  ~wxConfigPathChanger();
 
   // get the key name
-  const wxString& Name() const { return m_strName; }
+  const wxString& Name() const { return m_name; }
 
   // this method must be called if the original path (i.e. the current path at
   // the moment of creation of this object) could have been deleted to prevent
@@ -431,7 +431,7 @@ public:
 
 private:
   wxConfigBase *m_pContainer;   // object we live in
-  wxString      m_strName,      // name of entry (i.e. name only)
+  wxString      m_name,      // name of entry (i.e. name only)
                 m_strOldPath;   // saved path
   bool          m_bChanged;     // was the path changed?
 

--- a/Externals/wxWidgets3/include/wx/file.h
+++ b/Externals/wxWidgets3/include/wx/file.h
@@ -167,7 +167,7 @@ public:
   bool Flush() { return m_file.Flush(); }
 
   // different ways to close the file
-    // validate changes and delete the old file of name m_strName
+    // validate changes and delete the old file of name m_name
   bool Commit();
     // discard changes
   void Discard();
@@ -180,7 +180,7 @@ private:
   wxTempFile(const wxTempFile&);
   wxTempFile& operator=(const wxTempFile&);
 
-  wxString  m_strName,  // name of the file to replace in Commit()
+  wxString  m_name,  // name of the file to replace in Commit()
             m_strTemp;  // temporary file name
   wxFile    m_file;     // the temporary file
 };

--- a/Externals/wxWidgets3/src/common/config.cpp
+++ b/Externals/wxWidgets3/src/common/config.cpp
@@ -291,7 +291,7 @@ wxConfigPathChanger::wxConfigPathChanger(const wxConfigBase *pContainer,
 
   // the path is everything which precedes the last slash and the name is
   // everything after it -- and this works correctly if there is no slash too
-  wxString strPath = strEntry.BeforeLast(wxCONFIG_PATH_SEPARATOR, &m_strName);
+  wxString strPath = strEntry.BeforeLast(wxCONFIG_PATH_SEPARATOR, &m_name);
 
   // except in the special case of "/keyname" when there is nothing before "/"
   if ( strPath.empty() &&

--- a/Externals/wxWidgets3/src/common/file.cpp
+++ b/Externals/wxWidgets3/src/common/file.cpp
@@ -532,7 +532,7 @@ bool wxTempFile::Open(const wxString& strName)
     // we must have an absolute filename because otherwise CreateTempFileName()
     // would create the temp file in $TMP (i.e. the system standard location
     // for the temp files) which might be on another volume/drive/mount and
-    // wxRename()ing it later to m_strName from Commit() would then fail
+    // wxRename()ing it later to m_name from Commit() would then fail
     //
     // with the absolute filename, the temp file is created in the same
     // directory as this one which ensures that wxRename() may work later
@@ -542,9 +542,9 @@ bool wxTempFile::Open(const wxString& strName)
         fn.Normalize(wxPATH_NORM_ABSOLUTE);
     }
 
-    m_strName = fn.GetFullPath();
+    m_name = fn.GetFullPath();
 
-    m_strTemp = wxFileName::CreateTempFileName(m_strName, &m_file);
+    m_strTemp = wxFileName::CreateTempFileName(m_name, &m_file);
 
     if ( m_strTemp.empty() )
     {
@@ -557,7 +557,7 @@ bool wxTempFile::Open(const wxString& strName)
     mode_t mode;
 
     wxStructStat st;
-    if ( stat( (const char*) m_strName.fn_str(), &st) == 0 )
+    if ( stat( (const char*) m_name.fn_str(), &st) == 0 )
     {
         mode = st.st_mode;
     }
@@ -595,13 +595,13 @@ bool wxTempFile::Commit()
 {
     m_file.Close();
 
-    if ( wxFile::Exists(m_strName) && wxRemove(m_strName) != 0 ) {
-        wxLogSysError(_("can't remove file '%s'"), m_strName.c_str());
+    if ( wxFile::Exists(m_name) && wxRemove(m_name) != 0 ) {
+        wxLogSysError(_("can't remove file '%s'"), m_name.c_str());
         return false;
     }
 
-    if ( !wxRenameFile(m_strTemp, m_strName)  ) {
-        wxLogSysError(_("can't commit changes to file '%s'"), m_strName.c_str());
+    if ( !wxRenameFile(m_strTemp, m_name)  ) {
+        wxLogSysError(_("can't commit changes to file '%s'"), m_name.c_str());
         return false;
     }
 

--- a/Externals/wxWidgets3/src/common/fileconf.cpp
+++ b/Externals/wxWidgets3/src/common/fileconf.cpp
@@ -143,7 +143,7 @@ class wxFileConfigEntry
 private:
   wxFileConfigGroup *m_pParent; // group that contains us
 
-  wxString      m_strName,      // entry name
+  wxString      m_name,      // entry name
                 m_strValue;     //       value
   bool          m_bImmutable:1, // can be overridden locally?
                 m_bHasValue:1;  // set after first call to SetValue()
@@ -159,7 +159,7 @@ public:
                     const wxString& strName, int nLine);
 
   // simple accessors
-  const wxString& Name()        const { return m_strName;    }
+  const wxString& Name()        const { return m_name;    }
   const wxString& Value()       const { return m_strValue;   }
   wxFileConfigGroup *Group()    const { return m_pParent;    }
   bool            IsImmutable() const { return m_bImmutable; }
@@ -186,7 +186,7 @@ private:
   wxFileConfigGroup  *m_pParent;    // parent group (NULL for root group)
   ArrayEntries  m_aEntries;         // entries in this group
   ArrayGroups   m_aSubgroups;       // subgroups
-  wxString      m_strName;          // group's name
+  wxString      m_name;          // group's name
   wxFileConfigLineList *m_pLine;    // pointer to our line in the linked list
   wxFileConfigEntry *m_pLastEntry;  // last entry/subgroup of this group in the
   wxFileConfigGroup *m_pLastGroup;  // local file (we insert new ones after it)
@@ -205,7 +205,7 @@ public:
   ~wxFileConfigGroup();
 
   // simple accessors
-  const wxString& Name()    const { return m_strName; }
+  const wxString& Name()    const { return m_name; }
   wxFileConfigGroup    *Parent()  const { return m_pParent; }
   wxFileConfig   *Config()  const { return m_pConfig; }
 
@@ -1345,7 +1345,7 @@ wxFileConfigGroup::wxFileConfigGroup(wxFileConfigGroup *pParent,
                                        wxFileConfig *pConfig)
                          : m_aEntries(CompareEntries),
                            m_aSubgroups(CompareGroups),
-                           m_strName(strName)
+                           m_name(strName)
 {
   m_pConfig = pConfig;
   m_pParent = pParent;
@@ -1538,14 +1538,14 @@ void wxFileConfigGroup::Rename(const wxString& newName)
 {
     wxCHECK_RET( m_pParent, wxT("the root group can't be renamed") );
 
-    if ( newName == m_strName )
+    if ( newName == m_name )
         return;
 
     // we need to remove the group from the parent and it back under the new
     // name to keep the parents array of subgroups alphabetically sorted
     m_pParent->m_aSubgroups.Remove(this);
 
-    m_strName = newName;
+    m_name = newName;
 
     m_pParent->m_aSubgroups.Add(this);
 
@@ -1843,7 +1843,7 @@ bool wxFileConfigGroup::DeleteEntry(const wxString& name)
 wxFileConfigEntry::wxFileConfigEntry(wxFileConfigGroup *pParent,
                                        const wxString& strName,
                                        int nLine)
-                         : m_strName(strName)
+                         : m_name(strName)
 {
   wxASSERT( !strName.empty() );
 
@@ -1855,7 +1855,7 @@ wxFileConfigEntry::wxFileConfigEntry(wxFileConfigGroup *pParent,
 
   m_bImmutable = strName[0] == wxCONFIG_IMMUTABLE_PREFIX;
   if ( m_bImmutable )
-    m_strName.erase(0, 1);  // remove first character
+    m_name.erase(0, 1);  // remove first character
 }
 
 // ----------------------------------------------------------------------------
@@ -1905,7 +1905,7 @@ void wxFileConfigEntry::SetValue(const wxString& strValue, bool bUser)
         }
 
         wxString    strLine;
-        strLine << FilterOutEntryName(m_strName) << wxT('=') << strValFiltered;
+        strLine << FilterOutEntryName(m_name) << wxT('=') << strValFiltered;
 
         if ( m_pLine )
         {

--- a/Externals/wxWidgets3/src/common/imagpng.cpp
+++ b/Externals/wxWidgets3/src/common/imagpng.cpp
@@ -773,8 +773,8 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
     //     explanation why this line is mandatory
     png_set_write_fn( png_ptr, &wxinfo, wx_PNG_stream_writer, NULL);
 
-    const int iHeight = image->GetHeight();
-    const int iWidth = image->GetWidth();
+    const int m_height = image->GetHeight();
+    const int m_width = image->GetWidth();
 
     const bool bHasPngFormatOption
         = image->HasOption(wxIMAGE_OPTION_PNG_FORMAT);
@@ -817,9 +817,9 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
             PaletteAdd(&palette, mask);
         }
 
-        for (int y = 0; y < iHeight; y++)
+        for (int y = 0; y < m_height; y++)
         {
-            for (int x = 0; x < iWidth; x++)
+            for (int x = 0; x < m_width; x++)
             {
                 png_color_8 rgba;
 
@@ -988,10 +988,10 @@ bool wxPNGHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbos
 
     const unsigned char *pColors = image->GetData();
 
-    for (int y = 0; y != iHeight; ++y)
+    for (int y = 0; y != m_height; ++y)
     {
         unsigned char *pData = data;
-        for (int x = 0; x != iWidth; x++)
+        for (int x = 0; x != m_width; x++)
         {
             png_color_8 clr;
             clr.red   = *pColors++;

--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -123,7 +123,7 @@ void OpenALStream::SoundLoop()
 {
 	Common::SetCurrentThreadName("Audio thread - openal");
 
-	bool surround_capable = Core::g_CoreStartupParameter.bDPL2Decoder;
+	bool surround_capable = Core::g_CoreStartupParameter.m_DPL2_decoder;
 #if defined(__APPLE__)
 	bool float32_capable = false;
 	const ALenum AL_FORMAT_STEREO_FLOAT32 = 0;
@@ -135,7 +135,7 @@ void OpenALStream::SoundLoop()
 #endif
 
 	u32 ulFrequency = m_mixer->GetSampleRate();
-	numBuffers = Core::g_CoreStartupParameter.iLatency + 2; // OpenAL requires a minimum of two buffers
+	numBuffers = Core::g_CoreStartupParameter.m_latency + 2; // OpenAL requires a minimum of two buffers
 
 	memset(uiBuffers, 0, numBuffers * sizeof(ALuint));
 	uiSource = 0;

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -926,13 +926,13 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string &new
 	return paths[DirIDX];
 }
 
-std::string GetThemeDir(const std::string& theme_name)
+std::string GetThemeDir(const std::string& m_theme_name)
 {
-	std::string dir = File::GetUserPath(D_THEMES_IDX) + theme_name + "/";
+	std::string dir = File::GetUserPath(D_THEMES_IDX) + m_theme_name + "/";
 
 	// If theme does not exist in user's dir load from shared directory
 	if (!File::Exists(dir))
-		dir = GetSysDirectory() + THEMES_DIR "/" + theme_name + "/";
+		dir = GetSysDirectory() + THEMES_DIR "/" + m_theme_name + "/";
 
 	return dir;
 }

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -130,7 +130,7 @@ std::string GetTempFilenameForAtomicWrite(const std::string &path);
 const std::string& GetUserPath(const unsigned int DirIDX, const std::string &newPath="");
 
 // probably doesn't belong here
-std::string GetThemeDir(const std::string& theme_name);
+std::string GetThemeDir(const std::string& m_theme_name);
 
 // Returns the path to where the sys file are
 std::string GetSysDirectory();

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -104,7 +104,7 @@ struct ARAddr
 void LoadCodes(const IniFile& globalIni, const IniFile& localIni, bool forceLoad)
 {
 	// Parses the Action Replay section of a game ini file.
-	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats &&
+	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.m_enable_cheats &&
 		!forceLoad)
 		return;
 
@@ -269,8 +269,8 @@ void SetARCode_IsActive(bool active, size_t index)
 
 void UpdateActiveList()
 {
-	bool old_value = SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats;
-	SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats = false;
+	bool old_value = SConfig::GetInstance().m_LocalCoreStartupParameter.m_enable_cheats;
+	SConfig::GetInstance().m_LocalCoreStartupParameter.m_enable_cheats = false;
 	b_RanOnce = false;
 	activeCodes.clear();
 	for (auto& arCode : arCodes)
@@ -278,7 +278,7 @@ void UpdateActiveList()
 		if (arCode.active)
 			activeCodes.push_back(arCode);
 	}
-	SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats = old_value;
+	SConfig::GetInstance().m_LocalCoreStartupParameter.m_enable_cheats = old_value;
 }
 
 void EnableSelfLogging(bool enable)
@@ -753,7 +753,7 @@ static bool ConditionalCode(const ARAddr& addr, const u32 data, int* const pSkip
 
 void RunAllActive()
 {
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_enable_cheats)
 	{
 		for (auto& activeCode : activeCodes)
 		{

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -63,7 +63,7 @@ bool CBoot::EmulatedBS2_GC()
 	// TODO determine why some games fail when using a retail ID. (Seem to take different EXI paths, see Ikaruga for example)
 	Memory::Write_U32(0x10000006, 0x8000002C); // Console type - DevKit  (retail ID == 0x00000003) see YAGCD 4.2.1.1.2
 
-	Memory::Write_U32(SConfig::GetInstance().m_LocalCoreStartupParameter.bNTSC
+	Memory::Write_U32(SConfig::GetInstance().m_LocalCoreStartupParameter.m_NTSC
 						 ? 0 : 1, 0x800000CC); // Fake the VI Init of the IPL (YAGCD 4.2.1.4)
 
 	Memory::Write_U32(0x01000000, 0x800000d0); // ARAM Size. 16MB main + 4/16/32MB external (retail consoles have no external ARAM)
@@ -94,7 +94,7 @@ bool CBoot::EmulatedBS2_GC()
 	VolumeHandler::ReadToPtr(Memory::GetPointer(0x81200000), iAppLoaderOffset + 0x20, iAppLoaderSize);
 
 	// Setup pointers like real BS2 does
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bNTSC)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_NTSC)
 	{
 		PowerPC::ppcState.gpr[1] = 0x81566550;  // StackPointer, used to be set to 0x816ffff0
 		PowerPC::ppcState.gpr[2] = 0x81465cc0;  // Global pointer to Small Data Area 2 Base (haven't seen anything use it...meh)
@@ -289,7 +289,7 @@ bool CBoot::SetupWiiMemory(IVolume::ECountry country)
 	Memory::Write_U32(0x80000000, 0x00003184);           // GameID Address
 
 	// Fake the VI Init of the IPL
-	Memory::Write_U32(SConfig::GetInstance().m_LocalCoreStartupParameter.bNTSC ? 0 : 1, 0x000000CC);
+	Memory::Write_U32(SConfig::GetInstance().m_LocalCoreStartupParameter.m_NTSC ? 0 : 1, 0x000000CC);
 
 	// Clear exception handler. Why? Don't we begin with only zeros?
 	for (int i = 0x3000; i <= 0x3038; i += 4)

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -47,9 +47,9 @@ namespace BootManager
 // Apply fire liberally
 struct ConfigCache
 {
-	bool valid, bCPUThread, bSkipIdle, bEnableFPRF, bMMU, bDCBZOFF, m_EnableJIT, bDSPThread,
-	     bVBeamSpeedHack, bSyncGPU, bFastDiscSpeed, bMergeBlocks, bDSPHLE, bHLE_BS2, bTLBHack, bProgressive;
-	int iCPUCore, Volume;
+	bool valid, m_CPU_thread, m_skip_idle, m_enable_FPRF, m_MMU, m_DCBZOFF, m_EnableJIT, m_DSP_thread,
+	     m_vbeam_speed_hack, m_sync_GPU, m_fast_disc_speed, m_merge_blocks, m_DSPHLE, m_HLE_BS2, m_TLB_hack, m_progressive;
+	int m_CPU_core, Volume;
 	int iWiimoteSource[MAX_BBMOTES];
 	SIDevices Pads[MAX_SI_CHANNELS];
 	unsigned int framelimit, frameSkip;
@@ -62,60 +62,60 @@ static ConfigCache config_cache;
 // Boot the ISO or file
 bool BootCore(const std::string& _rFilename)
 {
-	SCoreStartupParameter& StartUp = SConfig::GetInstance().m_LocalCoreStartupParameter;
+	CoreStartupParameter& StartUp = SConfig::GetInstance().m_LocalCoreStartupParameter;
 
 	// Use custom settings for debugging mode
 	Host_SetStartupDebuggingParameters();
 
-	StartUp.m_BootType = SCoreStartupParameter::BOOT_ISO;
-	StartUp.m_strFilename = _rFilename;
+	StartUp.m_boot_type = CoreStartupParameter::BOOT_ISO;
+	StartUp.m_filename = _rFilename;
 	SConfig::GetInstance().m_LastFilename = _rFilename;
 	SConfig::GetInstance().SaveSettings();
-	StartUp.bRunCompareClient = false;
-	StartUp.bRunCompareServer = false;
+	StartUp.m_run_compare_client = false;
+	StartUp.m_run_compare_server = false;
 
 	// This is saved seperately from everything because it can be changed in SConfig::AutoSetup()
-	config_cache.bHLE_BS2 = StartUp.bHLE_BS2;
+	config_cache.m_HLE_BS2 = StartUp.m_HLE_BS2;
 
 	// If for example the ISO file is bad we return here
-	if (!StartUp.AutoSetup(SCoreStartupParameter::BOOT_DEFAULT))
+	if (!StartUp.AutoSetup(CoreStartupParameter::BOOT_DEFAULT))
 		return false;
 
 	// Load game specific settings
 	std::string unique_id = StartUp.GetUniqueID();
-	std::string revision_specific = StartUp.m_strRevisionSpecificUniqueID;
-	StartUp.m_strGameIniDefault = File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + unique_id + ".ini";
+	std::string revision_specific = StartUp.m_revision_specific_unique_ID;
+	StartUp.m_game_ini_default = File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + unique_id + ".ini";
 	if (revision_specific != "")
-		StartUp.m_strGameIniDefaultRevisionSpecific = File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + revision_specific + ".ini";
+		StartUp.m_game_ini_default_revision_specific = File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + revision_specific + ".ini";
 	else
-		StartUp.m_strGameIniDefaultRevisionSpecific = "";
-	StartUp.m_strGameIniLocal = File::GetUserPath(D_GAMESETTINGS_IDX) + unique_id + ".ini";
+		StartUp.m_game_ini_default_revision_specific = "";
+	StartUp.m_game_ini_local = File::GetUserPath(D_GAMESETTINGS_IDX) + unique_id + ".ini";
 
 	if (unique_id.size() == 6)
 	{
 		IniFile game_ini = StartUp.LoadGameIni();
 
 		config_cache.valid = true;
-		config_cache.bCPUThread = StartUp.bCPUThread;
-		config_cache.bSkipIdle = StartUp.bSkipIdle;
-		config_cache.iCPUCore = StartUp.iCPUCore;
-		config_cache.bEnableFPRF = StartUp.bEnableFPRF;
-		config_cache.bMMU = StartUp.bMMU;
-		config_cache.bDCBZOFF = StartUp.bDCBZOFF;
-		config_cache.bTLBHack = StartUp.bTLBHack;
-		config_cache.bVBeamSpeedHack = StartUp.bVBeamSpeedHack;
-		config_cache.bSyncGPU = StartUp.bSyncGPU;
-		config_cache.bFastDiscSpeed = StartUp.bFastDiscSpeed;
-		config_cache.bMergeBlocks = StartUp.bMergeBlocks;
-		config_cache.bDSPHLE = StartUp.bDSPHLE;
-		config_cache.strBackend = StartUp.m_strVideoBackend;
+		config_cache.m_CPU_thread = StartUp.m_CPU_thread;
+		config_cache.m_skip_idle = StartUp.m_skip_idle;
+		config_cache.m_CPU_core = StartUp.m_CPU_core;
+		config_cache.m_enable_FPRF = StartUp.m_enable_FPRF;
+		config_cache.m_MMU = StartUp.m_MMU;
+		config_cache.m_DCBZOFF = StartUp.m_DCBZOFF;
+		config_cache.m_TLB_hack = StartUp.m_TLB_hack;
+		config_cache.m_vbeam_speed_hack = StartUp.m_vbeam_speed_hack;
+		config_cache.m_sync_GPU = StartUp.m_sync_GPU;
+		config_cache.m_fast_disc_speed = StartUp.m_fast_disc_speed;
+		config_cache.m_merge_blocks = StartUp.m_merge_blocks;
+		config_cache.m_DSPHLE = StartUp.m_DSPHLE;
+		config_cache.strBackend = StartUp.m_video_backend;
 		config_cache.m_EnableJIT = SConfig::GetInstance().m_DSPEnableJIT;
-		config_cache.bDSPThread = StartUp.bDSPThread;
+		config_cache.m_DSP_thread = StartUp.m_DSP_thread;
 		config_cache.Volume = SConfig::GetInstance().m_Volume;
 		config_cache.sBackend = SConfig::GetInstance().sBackend;
 		config_cache.framelimit = SConfig::GetInstance().m_Framelimit;
 		config_cache.frameSkip = SConfig::GetInstance().m_FrameSkip;
-		config_cache.bProgressive = StartUp.bProgressive;
+		config_cache.m_progressive = StartUp.m_progressive;
 		for (unsigned int i = 0; i < MAX_BBMOTES; ++i)
 		{
 			config_cache.iWiimoteSource[i] = g_wiimote_sources[i];
@@ -139,22 +139,22 @@ bool BootCore(const std::string& _rFilename)
 		IniFile::Section* dsp_section      = game_ini.GetOrCreateSection("DSP");
 		IniFile::Section* controls_section = game_ini.GetOrCreateSection("Controls");
 
-		core_section->Get("CPUThread",        &StartUp.bCPUThread, StartUp.bCPUThread);
-		core_section->Get("SkipIdle",         &StartUp.bSkipIdle, StartUp.bSkipIdle);
-		core_section->Get("EnableFPRF",       &StartUp.bEnableFPRF, StartUp.bEnableFPRF);
-		core_section->Get("MMU",              &StartUp.bMMU, StartUp.bMMU);
-		core_section->Get("TLBHack",          &StartUp.bTLBHack, StartUp.bTLBHack);
-		core_section->Get("DCBZ",             &StartUp.bDCBZOFF, StartUp.bDCBZOFF);
-		core_section->Get("VBeam",            &StartUp.bVBeamSpeedHack, StartUp.bVBeamSpeedHack);
-		core_section->Get("SyncGPU",          &StartUp.bSyncGPU, StartUp.bSyncGPU);
-		core_section->Get("FastDiscSpeed",    &StartUp.bFastDiscSpeed, StartUp.bFastDiscSpeed);
-		core_section->Get("BlockMerging",     &StartUp.bMergeBlocks, StartUp.bMergeBlocks);
-		core_section->Get("DSPHLE",           &StartUp.bDSPHLE, StartUp.bDSPHLE);
-		core_section->Get("DSPThread",        &StartUp.bDSPThread, StartUp.bDSPThread);
-		core_section->Get("GFXBackend",       &StartUp.m_strVideoBackend, StartUp.m_strVideoBackend);
-		core_section->Get("CPUCore",          &StartUp.iCPUCore, StartUp.iCPUCore);
-		core_section->Get("HLE_BS2",          &StartUp.bHLE_BS2, StartUp.bHLE_BS2);
-		core_section->Get("ProgressiveScan",  &StartUp.bProgressive, StartUp.bProgressive);
+		core_section->Get("CPUThread",        &StartUp.m_CPU_thread, StartUp.m_CPU_thread);
+		core_section->Get("SkipIdle",         &StartUp.m_skip_idle, StartUp.m_skip_idle);
+		core_section->Get("EnableFPRF",       &StartUp.m_enable_FPRF, StartUp.m_enable_FPRF);
+		core_section->Get("MMU",              &StartUp.m_MMU, StartUp.m_MMU);
+		core_section->Get("TLBHack",          &StartUp.m_TLB_hack, StartUp.m_TLB_hack);
+		core_section->Get("DCBZ",             &StartUp.m_DCBZOFF, StartUp.m_DCBZOFF);
+		core_section->Get("VBeam",            &StartUp.m_vbeam_speed_hack, StartUp.m_vbeam_speed_hack);
+		core_section->Get("SyncGPU",          &StartUp.m_sync_GPU, StartUp.m_sync_GPU);
+		core_section->Get("FastDiscSpeed",    &StartUp.m_fast_disc_speed, StartUp.m_fast_disc_speed);
+		core_section->Get("BlockMerging",     &StartUp.m_merge_blocks, StartUp.m_merge_blocks);
+		core_section->Get("DSPHLE",           &StartUp.m_DSPHLE, StartUp.m_DSPHLE);
+		core_section->Get("DSPThread",        &StartUp.m_DSP_thread, StartUp.m_DSP_thread);
+		core_section->Get("GFXBackend",       &StartUp.m_video_backend, StartUp.m_video_backend);
+		core_section->Get("CPUCore",          &StartUp.m_CPU_core, StartUp.m_CPU_core);
+		core_section->Get("HLE_BS2",          &StartUp.m_HLE_BS2, StartUp.m_HLE_BS2);
+		core_section->Get("ProgressiveScan",  &StartUp.m_progressive, StartUp.m_progressive);
 		if (core_section->Get("FrameLimit",   &SConfig::GetInstance().m_Framelimit, SConfig::GetInstance().m_Framelimit))
 			config_cache.bSetFramelimit = true;
 		if (core_section->Get("FrameSkip",    &SConfig::GetInstance().m_FrameSkip))
@@ -167,7 +167,7 @@ bool BootCore(const std::string& _rFilename)
 			config_cache.bSetVolume = true;
 		dsp_section->Get("EnableJIT",         &SConfig::GetInstance().m_DSPEnableJIT, SConfig::GetInstance().m_DSPEnableJIT);
 		dsp_section->Get("Backend",           &SConfig::GetInstance().sBackend, SConfig::GetInstance().sBackend);
-		VideoBackend::ActivateBackend(StartUp.m_strVideoBackend);
+		VideoBackend::ActivateBackend(StartUp.m_video_backend);
 
 		for (unsigned int i = 0; i < MAX_SI_CHANNELS; ++i)
 		{
@@ -181,7 +181,7 @@ bool BootCore(const std::string& _rFilename)
 		}
 
 		// Wii settings
-		if (StartUp.bWii)
+		if (StartUp.m_wii)
 		{
 			// Flush possible changes to SYSCONF to file
 			SConfig::GetInstance().m_SYSCONF->Save();
@@ -210,16 +210,16 @@ bool BootCore(const std::string& _rFilename)
 	// Movie settings
 	if (Movie::IsPlayingInput() && Movie::IsConfigSaved())
 	{
-		StartUp.bCPUThread = Movie::IsDualCore();
-		StartUp.bSkipIdle = Movie::IsSkipIdle();
-		StartUp.bDSPHLE = Movie::IsDSPHLE();
-		StartUp.bProgressive = Movie::IsProgressive();
-		StartUp.bFastDiscSpeed = Movie::IsFastDiscSpeed();
-		StartUp.iCPUCore = Movie::GetCPUMode();
-		StartUp.bSyncGPU = Movie::IsSyncGPU();
+		StartUp.m_CPU_thread = Movie::IsDualCore();
+		StartUp.m_skip_idle = Movie::IsSkipIdle();
+		StartUp.m_DSPHLE = Movie::IsDSPHLE();
+		StartUp.m_progressive = Movie::IsProgressive();
+		StartUp.m_fast_disc_speed = Movie::IsFastDiscSpeed();
+		StartUp.m_CPU_core = Movie::GetCPUMode();
+		StartUp.m_sync_GPU = Movie::IsSyncGPU();
 		for (int i = 0; i < 2; ++i)
 		{
-			if (Movie::IsUsingMemcard(i) && Movie::IsStartingFromClearSave() && !StartUp.bWii)
+			if (Movie::IsUsingMemcard(i) && Movie::IsStartingFromClearSave() && !StartUp.m_wii)
 			{
 				if (File::Exists(File::GetUserPath(D_GCUSER_IDX) + StringFromFormat("Movie%s.raw", (i == 0) ? "A" : "B")))
 					File::Delete(File::GetUserPath(D_GCUSER_IDX) + StringFromFormat("Movie%s.raw", (i == 0) ? "A" : "B"));
@@ -229,10 +229,10 @@ bool BootCore(const std::string& _rFilename)
 
 	if (NetPlay::IsNetPlayRunning())
 	{
-		StartUp.bCPUThread = g_NetPlaySettings.m_CPUthread;
-		StartUp.bDSPHLE = g_NetPlaySettings.m_DSPHLE;
-		StartUp.bEnableMemcardSaving = g_NetPlaySettings.m_WriteToMemcard;
-		StartUp.iCPUCore = g_NetPlaySettings.m_CPUcore;
+		StartUp.m_CPU_thread = g_NetPlaySettings.m_CPUthread;
+		StartUp.m_DSPHLE = g_NetPlaySettings.m_DSPHLE;
+		StartUp.m_enable_memcard_saving = g_NetPlaySettings.m_WriteToMemcard;
+		StartUp.m_CPU_core = g_NetPlaySettings.m_CPUcore;
 		SConfig::GetInstance().m_DSPEnableJIT = g_NetPlaySettings.m_DSPEnableJIT;
 		SConfig::GetInstance().m_EXIDevice[0] = g_NetPlaySettings.m_EXIDevice[0];
 		SConfig::GetInstance().m_EXIDevice[1] = g_NetPlaySettings.m_EXIDevice[1];
@@ -240,7 +240,7 @@ bool BootCore(const std::string& _rFilename)
 		config_cache.bSetEXIDevice[1] = true;
 	}
 
-	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", StartUp.bProgressive);
+	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", StartUp.m_progressive);
 
 	// Run the game
 	// Init the core
@@ -257,32 +257,32 @@ void Stop()
 {
 	Core::Stop();
 
-	SCoreStartupParameter& StartUp = SConfig::GetInstance().m_LocalCoreStartupParameter;
+	CoreStartupParameter& StartUp = SConfig::GetInstance().m_LocalCoreStartupParameter;
 
-	StartUp.m_strUniqueID = "00000000";
+	StartUp.m_unique_ID = "00000000";
 	if (config_cache.valid)
 	{
 		config_cache.valid = false;
-		StartUp.bCPUThread = config_cache.bCPUThread;
-		StartUp.bSkipIdle = config_cache.bSkipIdle;
-		StartUp.iCPUCore = config_cache.iCPUCore;
-		StartUp.bEnableFPRF = config_cache.bEnableFPRF;
-		StartUp.bMMU = config_cache.bMMU;
-		StartUp.bDCBZOFF = config_cache.bDCBZOFF;
-		StartUp.bTLBHack = config_cache.bTLBHack;
-		StartUp.bVBeamSpeedHack = config_cache.bVBeamSpeedHack;
-		StartUp.bSyncGPU = config_cache.bSyncGPU;
-		StartUp.bFastDiscSpeed = config_cache.bFastDiscSpeed;
-		StartUp.bMergeBlocks = config_cache.bMergeBlocks;
-		StartUp.bDSPHLE = config_cache.bDSPHLE;
-		StartUp.bDSPThread = config_cache.bDSPThread;
-		StartUp.m_strVideoBackend = config_cache.strBackend;
-		VideoBackend::ActivateBackend(StartUp.m_strVideoBackend);
-		StartUp.bHLE_BS2 = config_cache.bHLE_BS2;
+		StartUp.m_CPU_thread = config_cache.m_CPU_thread;
+		StartUp.m_skip_idle = config_cache.m_skip_idle;
+		StartUp.m_CPU_core = config_cache.m_CPU_core;
+		StartUp.m_enable_FPRF = config_cache.m_enable_FPRF;
+		StartUp.m_MMU = config_cache.m_MMU;
+		StartUp.m_DCBZOFF = config_cache.m_DCBZOFF;
+		StartUp.m_TLB_hack = config_cache.m_TLB_hack;
+		StartUp.m_vbeam_speed_hack = config_cache.m_vbeam_speed_hack;
+		StartUp.m_sync_GPU = config_cache.m_sync_GPU;
+		StartUp.m_fast_disc_speed = config_cache.m_fast_disc_speed;
+		StartUp.m_merge_blocks = config_cache.m_merge_blocks;
+		StartUp.m_DSPHLE = config_cache.m_DSPHLE;
+		StartUp.m_DSP_thread = config_cache.m_DSP_thread;
+		StartUp.m_video_backend = config_cache.strBackend;
+		VideoBackend::ActivateBackend(StartUp.m_video_backend);
+		StartUp.m_HLE_BS2 = config_cache.m_HLE_BS2;
 		SConfig::GetInstance().sBackend = config_cache.sBackend;
 		SConfig::GetInstance().m_DSPEnableJIT = config_cache.m_EnableJIT;
-		StartUp.bProgressive = config_cache.bProgressive;
-		SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", config_cache.bProgressive);
+		StartUp.m_progressive = config_cache.m_progressive;
+		SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", config_cache.m_progressive);
 
 		// Only change these back if they were actually set by game ini, since they can be changed while a game is running.
 		if (config_cache.bSetFramelimit)
@@ -310,7 +310,7 @@ void Stop()
 				SConfig::GetInstance().m_EXIDevice[i] = config_cache.m_EXIDevice[i];
 			}
 		}
-		if (StartUp.bWii)
+		if (StartUp.m_wii)
 		{
 			for (unsigned int i = 0; i < MAX_BBMOTES; ++i)
 			{

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -186,7 +186,7 @@ void SConfig::SaveGeneralSettings(IniFile& ini)
 	general->Set("WirelessMac", m_WirelessMac);
 
 #ifdef USE_GDBSTUB
-	general->Set("GDBPort", m_LocalCoreStartupParameter.iGDBPort);
+	general->Set("GDBPort", m_LocalCoreStartupParameter.m_GDB_port);
 #endif
 }
 
@@ -194,22 +194,22 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
 {
 	IniFile::Section* interface = ini.GetOrCreateSection("Interface");
 
-	interface->Set("ConfirmStop", m_LocalCoreStartupParameter.bConfirmStop);
-	interface->Set("UsePanicHandlers", m_LocalCoreStartupParameter.bUsePanicHandlers);
-	interface->Set("OnScreenDisplayMessages", m_LocalCoreStartupParameter.bOnScreenDisplayMessages);
-	interface->Set("HideCursor", m_LocalCoreStartupParameter.bHideCursor);
-	interface->Set("AutoHideCursor", m_LocalCoreStartupParameter.bAutoHideCursor);
-	interface->Set("MainWindowPosX", (m_LocalCoreStartupParameter.iPosX == -32000) ? 0 : m_LocalCoreStartupParameter.iPosX); // TODO - HAX
-	interface->Set("MainWindowPosY", (m_LocalCoreStartupParameter.iPosY == -32000) ? 0 : m_LocalCoreStartupParameter.iPosY); // TODO - HAX
-	interface->Set("MainWindowWidth", m_LocalCoreStartupParameter.iWidth);
-	interface->Set("MainWindowHeight", m_LocalCoreStartupParameter.iHeight);
+	interface->Set("ConfirmStop", m_LocalCoreStartupParameter.m_confirm_stop);
+	interface->Set("UsePanicHandlers", m_LocalCoreStartupParameter.m_use_panic_handlers);
+	interface->Set("OnScreenDisplayMessages", m_LocalCoreStartupParameter.m_on_screen_display_messages);
+	interface->Set("HideCursor", m_LocalCoreStartupParameter.m_hide_cursor);
+	interface->Set("AutoHideCursor", m_LocalCoreStartupParameter.m_auto_hide_cursor);
+	interface->Set("MainWindowPosX", (m_LocalCoreStartupParameter.m_posx == -32000) ? 0 : m_LocalCoreStartupParameter.m_posx); // TODO - HAX
+	interface->Set("MainWindowPosY", (m_LocalCoreStartupParameter.m_posy == -32000) ? 0 : m_LocalCoreStartupParameter.m_posy); // TODO - HAX
+	interface->Set("MainWindowWidth", m_LocalCoreStartupParameter.m_width);
+	interface->Set("MainWindowHeight", m_LocalCoreStartupParameter.m_height);
 	interface->Set("Language", m_InterfaceLanguage);
 	interface->Set("ShowToolbar", m_InterfaceToolbar);
 	interface->Set("ShowStatusbar", m_InterfaceStatusbar);
 	interface->Set("ShowLogWindow", m_InterfaceLogWindow);
 	interface->Set("ShowLogConfigWindow", m_InterfaceLogConfigWindow);
 	interface->Set("ExtendedFPSInfo", m_InterfaceExtendedFPSInfo);
-	interface->Set("ThemeName40", m_LocalCoreStartupParameter.theme_name);
+	interface->Set("ThemeName40", m_LocalCoreStartupParameter.m_theme_name);
 }
 
 void SConfig::SaveHotkeySettings(IniFile& ini)
@@ -218,9 +218,9 @@ void SConfig::SaveHotkeySettings(IniFile& ini)
 
 	for (int i = 0; i < NUM_HOTKEYS; i++)
 	{
-		hotkeys->Set(g_HKData[i].IniText, m_LocalCoreStartupParameter.iHotkey[i]);
+		hotkeys->Set(g_HKData[i].IniText, m_LocalCoreStartupParameter.m_hotkey[i]);
 		hotkeys->Set(std::string(g_HKData[i].IniText) + "Modifier",
-			m_LocalCoreStartupParameter.iHotkeyModifier[i]);
+			m_LocalCoreStartupParameter.m_hotkey_modifier[i]);
 	}
 }
 
@@ -228,18 +228,18 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
 {
 	IniFile::Section* display = ini.GetOrCreateSection("Display");
 
-	display->Set("FullscreenResolution", m_LocalCoreStartupParameter.strFullscreenResolution);
-	display->Set("Fullscreen", m_LocalCoreStartupParameter.bFullscreen);
-	display->Set("RenderToMain", m_LocalCoreStartupParameter.bRenderToMain);
-	display->Set("RenderWindowXPos", m_LocalCoreStartupParameter.iRenderWindowXPos);
-	display->Set("RenderWindowYPos", m_LocalCoreStartupParameter.iRenderWindowYPos);
-	display->Set("RenderWindowWidth", m_LocalCoreStartupParameter.iRenderWindowWidth);
-	display->Set("RenderWindowHeight", m_LocalCoreStartupParameter.iRenderWindowHeight);
-	display->Set("RenderWindowAutoSize", m_LocalCoreStartupParameter.bRenderWindowAutoSize);
-	display->Set("KeepWindowOnTop", m_LocalCoreStartupParameter.bKeepWindowOnTop);
-	display->Set("ProgressiveScan", m_LocalCoreStartupParameter.bProgressive);
-	display->Set("DisableScreenSaver", m_LocalCoreStartupParameter.bDisableScreenSaver);
-	display->Set("ForceNTSCJ", m_LocalCoreStartupParameter.bForceNTSCJ);
+	display->Set("FullscreenResolution", m_LocalCoreStartupParameter.m_fullscreen_resolution);
+	display->Set("Fullscreen", m_LocalCoreStartupParameter.m_fullscreen);
+	display->Set("RenderToMain", m_LocalCoreStartupParameter.m_render_to_main);
+	display->Set("RenderWindowXPos", m_LocalCoreStartupParameter.m_render_window_xpos);
+	display->Set("RenderWindowYPos", m_LocalCoreStartupParameter.m_render_window_ypos);
+	display->Set("RenderWindowWidth", m_LocalCoreStartupParameter.m_render_window_width);
+	display->Set("RenderWindowHeight", m_LocalCoreStartupParameter.m_render_window_height);
+	display->Set("RenderWindowAutoSize", m_LocalCoreStartupParameter.m_render_window_auto_size);
+	display->Set("KeepWindowOnTop", m_LocalCoreStartupParameter.m_keep_window_on_top);
+	display->Set("ProgressiveScan", m_LocalCoreStartupParameter.m_progressive);
+	display->Set("DisableScreenSaver", m_LocalCoreStartupParameter.m_disable_screen_saver);
+	display->Set("ForceNTSCJ", m_LocalCoreStartupParameter.m_force_NTSCJ);
 }
 
 void SConfig::SaveGameListSettings(IniFile& ini)
@@ -276,20 +276,20 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 {
 	IniFile::Section* core = ini.GetOrCreateSection("Core");
 
-	core->Set("HLE_BS2", m_LocalCoreStartupParameter.bHLE_BS2);
-	core->Set("CPUCore", m_LocalCoreStartupParameter.iCPUCore);
-	core->Set("Fastmem", m_LocalCoreStartupParameter.bFastmem);
-	core->Set("CPUThread", m_LocalCoreStartupParameter.bCPUThread);
-	core->Set("DSPThread", m_LocalCoreStartupParameter.bDSPThread);
-	core->Set("DSPHLE", m_LocalCoreStartupParameter.bDSPHLE);
-	core->Set("SkipIdle", m_LocalCoreStartupParameter.bSkipIdle);
-	core->Set("DefaultGCM", m_LocalCoreStartupParameter.m_strDefaultGCM);
-	core->Set("DVDRoot", m_LocalCoreStartupParameter.m_strDVDRoot);
-	core->Set("Apploader", m_LocalCoreStartupParameter.m_strApploader);
-	core->Set("EnableCheats", m_LocalCoreStartupParameter.bEnableCheats);
-	core->Set("SelectedLanguage", m_LocalCoreStartupParameter.SelectedLanguage);
-	core->Set("DPL2Decoder", m_LocalCoreStartupParameter.bDPL2Decoder);
-	core->Set("Latency", m_LocalCoreStartupParameter.iLatency);
+	core->Set("HLE_BS2", m_LocalCoreStartupParameter.m_HLE_BS2);
+	core->Set("CPUCore", m_LocalCoreStartupParameter.m_CPU_core);
+	core->Set("Fastmem", m_LocalCoreStartupParameter.m_fastmem);
+	core->Set("CPUThread", m_LocalCoreStartupParameter.m_CPU_thread);
+	core->Set("DSPThread", m_LocalCoreStartupParameter.m_DSP_thread);
+	core->Set("DSPHLE", m_LocalCoreStartupParameter.m_DSPHLE);
+	core->Set("SkipIdle", m_LocalCoreStartupParameter.m_skip_idle);
+	core->Set("DefaultGCM", m_LocalCoreStartupParameter.m_default_GCM);
+	core->Set("DVDRoot", m_LocalCoreStartupParameter.m_DVD_root);
+	core->Set("Apploader", m_LocalCoreStartupParameter.m_apploader);
+	core->Set("EnableCheats", m_LocalCoreStartupParameter.m_enable_cheats);
+	core->Set("m_selected_language", m_LocalCoreStartupParameter.m_selected_language);
+	core->Set("DPL2Decoder", m_LocalCoreStartupParameter.m_DPL2_decoder);
+	core->Set("Latency", m_LocalCoreStartupParameter.m_latency);
 	core->Set("MemcardAPath", m_strMemoryCardA);
 	core->Set("MemcardBPath", m_strMemoryCardB);
 	core->Set("SlotA", m_EXIDevice[0]);
@@ -304,11 +304,11 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("WiiKeyboard", m_WiiKeyboard);
 	core->Set("WiimoteContinuousScanning", m_WiimoteContinuousScanning);
 	core->Set("WiimoteEnableSpeaker", m_WiimoteEnableSpeaker);
-	core->Set("RunCompareServer", m_LocalCoreStartupParameter.bRunCompareServer);
-	core->Set("RunCompareClient", m_LocalCoreStartupParameter.bRunCompareClient);
+	core->Set("RunCompareServer", m_LocalCoreStartupParameter.m_run_compare_server);
+	core->Set("RunCompareClient", m_LocalCoreStartupParameter.m_run_compare_client);
 	core->Set("FrameLimit", m_Framelimit);
 	core->Set("FrameSkip", m_FrameSkip);
-	core->Set("GFXBackend", m_LocalCoreStartupParameter.m_strVideoBackend);
+	core->Set("GFXBackend", m_LocalCoreStartupParameter.m_video_backend);
 }
 
 void SConfig::SaveMovieSettings(IniFile& ini)
@@ -341,7 +341,7 @@ void SConfig::SaveFifoPlayerSettings(IniFile& ini)
 {
 	IniFile::Section* fifoplayer = ini.GetOrCreateSection("FifoPlayer");
 
-	fifoplayer->Set("LoopReplay", m_LocalCoreStartupParameter.bLoopFifoReplay);
+	fifoplayer->Set("LoopReplay", m_LocalCoreStartupParameter.m_loop_fifo_replay);
 }
 
 void SConfig::LoadSettings()
@@ -371,7 +371,7 @@ void SConfig::LoadGeneralSettings(IniFile& ini)
 	general->Get("LastFilename", &m_LastFilename);
 	general->Get("ShowLag", &m_ShowLag, false);
 #ifdef USE_GDBSTUB
-	general->Get("GDBPort", &(m_LocalCoreStartupParameter.iGDBPort), -1);
+	general->Get("GDBPort", &(m_LocalCoreStartupParameter.m_GDB_port), -1);
 #endif
 
 	m_ISOFolder.clear();
@@ -400,22 +400,22 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
 {
 	IniFile::Section* interface = ini.GetOrCreateSection("Interface");
 
-	interface->Get("ConfirmStop",             &m_LocalCoreStartupParameter.bConfirmStop,      true);
-	interface->Get("UsePanicHandlers",        &m_LocalCoreStartupParameter.bUsePanicHandlers, true);
-	interface->Get("OnScreenDisplayMessages", &m_LocalCoreStartupParameter.bOnScreenDisplayMessages, true);
-	interface->Get("HideCursor",              &m_LocalCoreStartupParameter.bHideCursor,       false);
-	interface->Get("AutoHideCursor",          &m_LocalCoreStartupParameter.bAutoHideCursor,   false);
-	interface->Get("MainWindowPosX",          &m_LocalCoreStartupParameter.iPosX,             100);
-	interface->Get("MainWindowPosY",          &m_LocalCoreStartupParameter.iPosY,             100);
-	interface->Get("MainWindowWidth",         &m_LocalCoreStartupParameter.iWidth,            800);
-	interface->Get("MainWindowHeight",        &m_LocalCoreStartupParameter.iHeight,           600);
+	interface->Get("ConfirmStop",             &m_LocalCoreStartupParameter.m_confirm_stop,      true);
+	interface->Get("UsePanicHandlers",        &m_LocalCoreStartupParameter.m_use_panic_handlers, true);
+	interface->Get("OnScreenDisplayMessages", &m_LocalCoreStartupParameter.m_on_screen_display_messages, true);
+	interface->Get("HideCursor",              &m_LocalCoreStartupParameter.m_hide_cursor,       false);
+	interface->Get("AutoHideCursor",          &m_LocalCoreStartupParameter.m_auto_hide_cursor,   false);
+	interface->Get("MainWindowPosX",          &m_LocalCoreStartupParameter.m_posx,             100);
+	interface->Get("MainWindowPosY",          &m_LocalCoreStartupParameter.m_posy,             100);
+	interface->Get("MainWindowWidth",         &m_LocalCoreStartupParameter.m_width,            800);
+	interface->Get("MainWindowHeight",        &m_LocalCoreStartupParameter.m_height,           600);
 	interface->Get("Language",                &m_InterfaceLanguage,                           0);
 	interface->Get("ShowToolbar",             &m_InterfaceToolbar,                            true);
 	interface->Get("ShowStatusbar",           &m_InterfaceStatusbar,                          true);
 	interface->Get("ShowLogWindow",           &m_InterfaceLogWindow,                          false);
 	interface->Get("ShowLogConfigWindow",     &m_InterfaceLogConfigWindow,                    false);
 	interface->Get("ExtendedFPSInfo",         &m_InterfaceExtendedFPSInfo,                    false);
-	interface->Get("ThemeName40",             &m_LocalCoreStartupParameter.theme_name,        "Clean");
+	interface->Get("ThemeName40",             &m_LocalCoreStartupParameter.m_theme_name,        "Clean");
 }
 
 void SConfig::LoadHotkeySettings(IniFile& ini)
@@ -425,9 +425,9 @@ void SConfig::LoadHotkeySettings(IniFile& ini)
 	for (int i = 0; i < NUM_HOTKEYS; i++)
 	{
 		hotkeys->Get(g_HKData[i].IniText,
-		    &m_LocalCoreStartupParameter.iHotkey[i], g_HKData[i].DefaultKey);
+		    &m_LocalCoreStartupParameter.m_hotkey[i], g_HKData[i].DefaultKey);
 		hotkeys->Get(std::string(g_HKData[i].IniText) + "Modifier",
-		    &m_LocalCoreStartupParameter.iHotkeyModifier[i], g_HKData[i].DefaultModifier);
+		    &m_LocalCoreStartupParameter.m_hotkey_modifier[i], g_HKData[i].DefaultModifier);
 	}
 }
 
@@ -435,18 +435,18 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
 {
 	IniFile::Section* display = ini.GetOrCreateSection("Display");
 
-	display->Get("Fullscreen",           &m_LocalCoreStartupParameter.bFullscreen,             false);
-	display->Get("FullscreenResolution", &m_LocalCoreStartupParameter.strFullscreenResolution, "Auto");
-	display->Get("RenderToMain",         &m_LocalCoreStartupParameter.bRenderToMain,           false);
-	display->Get("RenderWindowXPos",     &m_LocalCoreStartupParameter.iRenderWindowXPos,       -1);
-	display->Get("RenderWindowYPos",     &m_LocalCoreStartupParameter.iRenderWindowYPos,       -1);
-	display->Get("RenderWindowWidth",    &m_LocalCoreStartupParameter.iRenderWindowWidth,      640);
-	display->Get("RenderWindowHeight",   &m_LocalCoreStartupParameter.iRenderWindowHeight,     480);
-	display->Get("RenderWindowAutoSize", &m_LocalCoreStartupParameter.bRenderWindowAutoSize,   false);
-	display->Get("KeepWindowOnTop",      &m_LocalCoreStartupParameter.bKeepWindowOnTop,        false);
-	display->Get("ProgressiveScan",      &m_LocalCoreStartupParameter.bProgressive,            false);
-	display->Get("DisableScreenSaver",   &m_LocalCoreStartupParameter.bDisableScreenSaver,     true);
-	display->Get("ForceNTSCJ",           &m_LocalCoreStartupParameter.bForceNTSCJ,             false);
+	display->Get("Fullscreen",           &m_LocalCoreStartupParameter.m_fullscreen,             false);
+	display->Get("FullscreenResolution", &m_LocalCoreStartupParameter.m_fullscreen_resolution, "Auto");
+	display->Get("RenderToMain",         &m_LocalCoreStartupParameter.m_render_to_main,           false);
+	display->Get("RenderWindowXPos",     &m_LocalCoreStartupParameter.m_render_window_xpos,       -1);
+	display->Get("RenderWindowYPos",     &m_LocalCoreStartupParameter.m_render_window_ypos,       -1);
+	display->Get("RenderWindowWidth",    &m_LocalCoreStartupParameter.m_render_window_width,      640);
+	display->Get("RenderWindowHeight",   &m_LocalCoreStartupParameter.m_render_window_height,     480);
+	display->Get("RenderWindowAutoSize", &m_LocalCoreStartupParameter.m_render_window_auto_size,   false);
+	display->Get("KeepWindowOnTop",      &m_LocalCoreStartupParameter.m_keep_window_on_top,        false);
+	display->Get("ProgressiveScan",      &m_LocalCoreStartupParameter.m_progressive,            false);
+	display->Get("DisableScreenSaver",   &m_LocalCoreStartupParameter.m_disable_screen_saver,     true);
+	display->Get("ForceNTSCJ",           &m_LocalCoreStartupParameter.m_force_NTSCJ,             false);
 }
 
 void SConfig::LoadGameListSettings(IniFile& ini)
@@ -486,34 +486,34 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 {
 	IniFile::Section* core = ini.GetOrCreateSection("Core");
 
-	core->Get("HLE_BS2",      &m_LocalCoreStartupParameter.bHLE_BS2, false);
+	core->Get("HLE_BS2",      &m_LocalCoreStartupParameter.m_HLE_BS2, false);
 #ifdef _M_X86
-	core->Get("CPUCore",      &m_LocalCoreStartupParameter.iCPUCore, 1);
+	core->Get("CPUCore",      &m_LocalCoreStartupParameter.m_CPU_core, 1);
 #elif _M_ARM_32
-	core->Get("CPUCore",      &m_LocalCoreStartupParameter.iCPUCore, 3);
+	core->Get("CPUCore",      &m_LocalCoreStartupParameter.m_CPU_core, 3);
 #else
-	core->Get("CPUCore",      &m_LocalCoreStartupParameter.iCPUCore, 0);
+	core->Get("CPUCore",      &m_LocalCoreStartupParameter.m_CPU_core, 0);
 #endif
-	core->Get("Fastmem",           &m_LocalCoreStartupParameter.bFastmem,      true);
-	core->Get("DSPThread",         &m_LocalCoreStartupParameter.bDSPThread,    false);
-	core->Get("DSPHLE",            &m_LocalCoreStartupParameter.bDSPHLE,       true);
-	core->Get("CPUThread",         &m_LocalCoreStartupParameter.bCPUThread,    true);
-	core->Get("SkipIdle",          &m_LocalCoreStartupParameter.bSkipIdle,     true);
-	core->Get("DefaultGCM",        &m_LocalCoreStartupParameter.m_strDefaultGCM);
-	core->Get("DVDRoot",           &m_LocalCoreStartupParameter.m_strDVDRoot);
-	core->Get("Apploader",         &m_LocalCoreStartupParameter.m_strApploader);
-	core->Get("EnableCheats",      &m_LocalCoreStartupParameter.bEnableCheats, false);
-	core->Get("SelectedLanguage",  &m_LocalCoreStartupParameter.SelectedLanguage, 0);
-	core->Get("DPL2Decoder",       &m_LocalCoreStartupParameter.bDPL2Decoder, false);
-	core->Get("Latency",           &m_LocalCoreStartupParameter.iLatency, 2);
+	core->Get("Fastmem",           &m_LocalCoreStartupParameter.m_fastmem,      true);
+	core->Get("DSPThread",         &m_LocalCoreStartupParameter.m_DSP_thread,    false);
+	core->Get("DSPHLE",            &m_LocalCoreStartupParameter.m_DSPHLE,       true);
+	core->Get("CPUThread",         &m_LocalCoreStartupParameter.m_CPU_thread,    true);
+	core->Get("SkipIdle",          &m_LocalCoreStartupParameter.m_skip_idle,     true);
+	core->Get("DefaultGCM",        &m_LocalCoreStartupParameter.m_default_GCM);
+	core->Get("DVDRoot",           &m_LocalCoreStartupParameter.m_DVD_root);
+	core->Get("Apploader",         &m_LocalCoreStartupParameter.m_apploader);
+	core->Get("EnableCheats",      &m_LocalCoreStartupParameter.m_enable_cheats, false);
+	core->Get("m_selected_language",  &m_LocalCoreStartupParameter.m_selected_language, 0);
+	core->Get("DPL2Decoder",       &m_LocalCoreStartupParameter.m_DPL2_decoder, false);
+	core->Get("Latency",           &m_LocalCoreStartupParameter.m_latency, 2);
 	core->Get("MemcardAPath",      &m_strMemoryCardA);
 	core->Get("MemcardBPath",      &m_strMemoryCardB);
 	core->Get("SlotA",       (int*)&m_EXIDevice[0], EXIDEVICE_MEMORYCARD);
 	core->Get("SlotB",       (int*)&m_EXIDevice[1], EXIDEVICE_NONE);
 	core->Get("SerialPort1", (int*)&m_EXIDevice[2], EXIDEVICE_NONE);
 	core->Get("BBA_MAC",           &m_bba_mac);
-	core->Get("TimeProfiling",     &m_LocalCoreStartupParameter.bJITILTimeProfiling, false);
-	core->Get("OutputIR",          &m_LocalCoreStartupParameter.bJITILOutputIR,      false);
+	core->Get("TimeProfiling",     &m_LocalCoreStartupParameter.m_JITIL_time_profiling, false);
+	core->Get("OutputIR",          &m_LocalCoreStartupParameter.m_JITIL_output_IR,      false);
 	for (int i = 0; i < MAX_SI_CHANNELS; ++i)
 	{
 		core->Get(StringFromFormat("SIDevice%i", i), (u32*)&m_SIDevice[i], (i == 0) ? SIDEVICE_GC_CONTROLLER : SIDEVICE_NONE);
@@ -522,18 +522,18 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("WiiKeyboard",               &m_WiiKeyboard,                                 false);
 	core->Get("WiimoteContinuousScanning", &m_WiimoteContinuousScanning,                   false);
 	core->Get("WiimoteEnableSpeaker",      &m_WiimoteEnableSpeaker,                        true);
-	core->Get("RunCompareServer",          &m_LocalCoreStartupParameter.bRunCompareServer, false);
-	core->Get("RunCompareClient",          &m_LocalCoreStartupParameter.bRunCompareClient, false);
-	core->Get("MMU",                       &m_LocalCoreStartupParameter.bMMU,              false);
-	core->Get("TLBHack",                   &m_LocalCoreStartupParameter.bTLBHack,          false);
-	core->Get("BBDumpPort",                &m_LocalCoreStartupParameter.iBBDumpPort,       -1);
-	core->Get("VBeam",                     &m_LocalCoreStartupParameter.bVBeamSpeedHack,   false);
-	core->Get("SyncGPU",                   &m_LocalCoreStartupParameter.bSyncGPU,          false);
-	core->Get("FastDiscSpeed",             &m_LocalCoreStartupParameter.bFastDiscSpeed,    false);
-	core->Get("DCBZ",                      &m_LocalCoreStartupParameter.bDCBZOFF,          false);
+	core->Get("RunCompareServer",          &m_LocalCoreStartupParameter.m_run_compare_server, false);
+	core->Get("RunCompareClient",          &m_LocalCoreStartupParameter.m_run_compare_client, false);
+	core->Get("MMU",                       &m_LocalCoreStartupParameter.m_MMU,              false);
+	core->Get("TLBHack",                   &m_LocalCoreStartupParameter.m_TLB_hack,          false);
+	core->Get("BBDumpPort",                &m_LocalCoreStartupParameter.m_BB_dump_port,       -1);
+	core->Get("VBeam",                     &m_LocalCoreStartupParameter.m_vbeam_speed_hack,   false);
+	core->Get("SyncGPU",                   &m_LocalCoreStartupParameter.m_sync_GPU,          false);
+	core->Get("FastDiscSpeed",             &m_LocalCoreStartupParameter.m_fast_disc_speed,    false);
+	core->Get("DCBZ",                      &m_LocalCoreStartupParameter.m_DCBZOFF,          false);
 	core->Get("FrameLimit",                &m_Framelimit,                                  1); // auto frame limit by default
 	core->Get("FrameSkip",                 &m_FrameSkip,                                   0);
-	core->Get("GFXBackend",                &m_LocalCoreStartupParameter.m_strVideoBackend, "");
+	core->Get("GFXBackend",                &m_LocalCoreStartupParameter.m_video_backend, "");
 }
 
 void SConfig::LoadMovieSettings(IniFile& ini)
@@ -576,5 +576,5 @@ void SConfig::LoadFifoPlayerSettings(IniFile& ini)
 {
 	IniFile::Section* fifoplayer = ini.GetOrCreateSection("FifoPlayer");
 
-	fifoplayer->Get("LoopReplay", &m_LocalCoreStartupParameter.bLoopFifoReplay, true);
+	fifoplayer->Get("LoopReplay", &m_LocalCoreStartupParameter.m_loop_fifo_replay, true);
 }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -37,7 +37,7 @@ struct SConfig : NonCopyable
 	std::vector<std::string> m_ISOFolder;
 	bool m_RecursiveISOFolder;
 
-	SCoreStartupParameter m_LocalCoreStartupParameter;
+	CoreStartupParameter m_LocalCoreStartupParameter;
 	std::string m_NANDPath;
 
 	std::string m_strMemoryCardA;

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -25,7 +25,7 @@ namespace Core
 
 // Get core parameters
 // TODO: kill, use SConfig instead
-extern SCoreStartupParameter g_CoreStartupParameter;
+extern CoreStartupParameter g_CoreStartupParameter;
 
 bool GetIsFramelimiterTempDisabled();
 void SetIsFramelimiterTempDisabled(bool disable);

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -11,7 +11,7 @@
 #include "Common/StringUtil.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Core.h" // for bWii
+#include "Core/Core.h" // for m_wii
 #include "Core/CoreParameter.h"
 #include "Core/Boot/Boot.h"
 #include "Core/Boot/Boot_DOL.h"
@@ -20,345 +20,345 @@
 #include "DiscIO/NANDContentLoader.h"
 #include "DiscIO/VolumeCreator.h"
 
-SCoreStartupParameter::SCoreStartupParameter()
-: bEnableDebugging(false), bAutomaticStart(false), bBootToPause(false),
-  bJITNoBlockCache(false), bJITBlockLinking(true),
-  bJITOff(false),
-  bJITLoadStoreOff(false), bJITLoadStorelXzOff(false),
-  bJITLoadStorelwzOff(false), bJITLoadStorelbzxOff(false),
-  bJITLoadStoreFloatingOff(false), bJITLoadStorePairedOff(false),
-  bJITFloatingPointOff(false), bJITIntegerOff(false),
-  bJITPairedOff(false), bJITSystemRegistersOff(false),
-  bJITBranchOff(false),
-  bJITILTimeProfiling(false), bJITILOutputIR(false),
-  bEnableFPRF(false),
-  bCPUThread(true), bDSPThread(false), bDSPHLE(true),
-  bSkipIdle(true), bNTSC(false), bForceNTSCJ(false),
-  bHLE_BS2(true), bEnableCheats(false),
-  bMergeBlocks(false), bEnableMemcardSaving(true),
-  bDPL2Decoder(false), iLatency(14),
-  bRunCompareServer(false), bRunCompareClient(false),
-  bMMU(false), bDCBZOFF(false), bTLBHack(false), iBBDumpPort(0), bVBeamSpeedHack(false),
-  bSyncGPU(false), bFastDiscSpeed(false),
-  SelectedLanguage(0), bWii(false),
-  bConfirmStop(false), bHideCursor(false),
-  bAutoHideCursor(false), bUsePanicHandlers(true), bOnScreenDisplayMessages(true),
-  iRenderWindowXPos(-1), iRenderWindowYPos(-1),
-  iRenderWindowWidth(640), iRenderWindowHeight(480),
-  bRenderWindowAutoSize(false), bKeepWindowOnTop(false),
-  bFullscreen(false), bRenderToMain(false),
-  bProgressive(false), bDisableScreenSaver(false),
-  iPosX(100), iPosY(100), iWidth(800), iHeight(600),
-  bLoopFifoReplay(true)
+CoreStartupParameter::CoreStartupParameter()
+: m_enable_debugging(false), m_automatic_start(false), m_boot_to_pause(false),
+  m_JIT_no_block_cache(false), m_JIT_block_linking(true),
+  m_JIT_off(false),
+  m_JIT_load_store_off(false), m_JIT_load_store_lxz_off(false),
+  m_JIT_load_store_lwz_off(false), m_JIT_load_store_lbzx_off(false),
+  m_JIT_load_store_floating_off(false), m_JIT_load_store_paired_off(false),
+  m_JIT_floating_point_off(false), m_JIT_integer_off(false),
+  m_JIT_paired_off(false), m_JIT_system_registers_off(false),
+  m_JIT_branch_off(false),
+  m_JITIL_time_profiling(false), m_JITIL_output_IR(false),
+  m_enable_FPRF(false),
+  m_CPU_thread(true), m_DSP_thread(false), m_DSPHLE(true),
+  m_skip_idle(true), m_NTSC(false), m_force_NTSCJ(false),
+  m_HLE_BS2(true), m_enable_cheats(false),
+  m_merge_blocks(false), m_enable_memcard_saving(true),
+  m_DPL2_decoder(false), m_latency(14),
+  m_run_compare_server(false), m_run_compare_client(false),
+  m_MMU(false), m_DCBZOFF(false), m_TLB_hack(false), m_BB_dump_port(0), m_vbeam_speed_hack(false),
+  m_sync_GPU(false), m_fast_disc_speed(false),
+  m_selected_language(0), m_wii(false),
+  m_confirm_stop(false), m_hide_cursor(false),
+  m_auto_hide_cursor(false), m_use_panic_handlers(true), m_on_screen_display_messages(true),
+  m_render_window_xpos(-1), m_render_window_ypos(-1),
+  m_render_window_width(640), m_render_window_height(480),
+  m_render_window_auto_size(false), m_keep_window_on_top(false),
+  m_fullscreen(false), m_render_to_main(false),
+  m_progressive(false), m_disable_screen_saver(false),
+  m_posx(100), m_posy(100), m_width(800), m_height(600),
+  m_loop_fifo_replay(true)
 {
 	LoadDefaults();
 }
 
-void SCoreStartupParameter::LoadDefaults()
+void CoreStartupParameter::LoadDefaults()
 {
-	bEnableDebugging = false;
-	bAutomaticStart = false;
-	bBootToPause = false;
+	m_enable_debugging = false;
+	m_automatic_start = false;
+	m_boot_to_pause = false;
 
 	#ifdef USE_GDBSTUB
-	iGDBPort = -1;
+	m_GDB_port = -1;
 	#endif
 
-	iCPUCore = 1;
-	bCPUThread = false;
-	bSkipIdle = false;
-	bRunCompareServer = false;
-	bDSPHLE = true;
-	bDSPThread = true;
-	bFastmem = true;
-	bEnableFPRF = false;
-	bMMU = false;
-	bDCBZOFF = false;
-	bTLBHack = false;
-	iBBDumpPort = -1;
-	bVBeamSpeedHack = false;
-	bSyncGPU = false;
-	bFastDiscSpeed = false;
-	bMergeBlocks = false;
-	bEnableMemcardSaving = true;
-	SelectedLanguage = 0;
-	bWii = false;
-	bDPL2Decoder = false;
-	iLatency = 14;
+	m_CPU_core = 1;
+	m_CPU_thread = false;
+	m_skip_idle = false;
+	m_run_compare_server = false;
+	m_DSPHLE = true;
+	m_DSP_thread = true;
+	m_fastmem = true;
+	m_enable_FPRF = false;
+	m_MMU = false;
+	m_DCBZOFF = false;
+	m_TLB_hack = false;
+	m_BB_dump_port = -1;
+	m_vbeam_speed_hack = false;
+	m_sync_GPU = false;
+	m_fast_disc_speed = false;
+	m_merge_blocks = false;
+	m_enable_memcard_saving = true;
+	m_selected_language = 0;
+	m_wii = false;
+	m_DPL2_decoder = false;
+	m_latency = 14;
 
-	iPosX = 100;
-	iPosY = 100;
-	iWidth = 800;
-	iHeight = 600;
+	m_posx = 100;
+	m_posy = 100;
+	m_width = 800;
+	m_height = 600;
 
-	bLoopFifoReplay = true;
+	m_loop_fifo_replay = true;
 
-	bJITOff = false; // debugger only settings
-	bJITLoadStoreOff = false;
-	bJITLoadStoreFloatingOff = false;
-	bJITLoadStorePairedOff = false; // XXX not 64-bit clean
-	bJITFloatingPointOff = false;
-	bJITIntegerOff = false;
-	bJITPairedOff = false;
-	bJITSystemRegistersOff = false;
+	m_JIT_off = false; // debugger only settings
+	m_JIT_load_store_off = false;
+	m_JIT_load_store_floating_off = false;
+	m_JIT_load_store_paired_off = false; // XXX not 64-bit clean
+	m_JIT_floating_point_off = false;
+	m_JIT_integer_off = false;
+	m_JIT_paired_off = false;
+	m_JIT_system_registers_off = false;
 
-	m_strName = "NONE";
-	m_strUniqueID = "00000000";
+	m_name = "NONE";
+	m_unique_ID = "00000000";
 }
 
-bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
+bool CoreStartupParameter::AutoSetup(BootBS2 boot_BS2)
 {
-	std::string Region(EUR_DIR);
+	std::string region(EUR_DIR);
 
-	switch (_BootBS2)
+	switch (boot_BS2)
 	{
 	case BOOT_DEFAULT:
 		{
-			bool bootDrive = cdio_is_cdrom(m_strFilename);
+			bool boot_drive = cdio_is_cdrom(m_filename);
 			// Check if the file exist, we may have gotten it from a --elf command line
 			// that gave an incorrect file name
-			if (!bootDrive && !File::Exists(m_strFilename))
+			if (!boot_drive && !File::Exists(m_filename))
 			{
-				PanicAlertT("The specified file \"%s\" does not exist", m_strFilename.c_str());
+				PanicAlertT("The specified file \"%s\" does not exist", m_filename.c_str());
 				return false;
 			}
 
-			std::string Extension;
-			SplitPath(m_strFilename, nullptr, nullptr, &Extension);
-			if (!strcasecmp(Extension.c_str(), ".gcm") ||
-				!strcasecmp(Extension.c_str(), ".iso") ||
-				!strcasecmp(Extension.c_str(), ".wbfs") ||
-				!strcasecmp(Extension.c_str(), ".ciso") ||
-				!strcasecmp(Extension.c_str(), ".gcz") ||
-				bootDrive)
+			std::string extension;
+			SplitPath(m_filename, nullptr, nullptr, &extension);
+			if (!strcasecmp(extension.c_str(), ".gcm") ||
+				!strcasecmp(extension.c_str(), ".iso") ||
+				!strcasecmp(extension.c_str(), ".wbfs") ||
+				!strcasecmp(extension.c_str(), ".ciso") ||
+				!strcasecmp(extension.c_str(), ".gcz") ||
+				boot_drive)
 			{
-				m_BootType = BOOT_ISO;
-				DiscIO::IVolume* pVolume = DiscIO::CreateVolumeFromFilename(m_strFilename);
-				if (pVolume == nullptr)
+				m_boot_type = BOOT_ISO;
+				DiscIO::IVolume* p_volume = DiscIO::CreateVolumeFromFilename(m_filename);
+				if (p_volume == nullptr)
 				{
-					if (bootDrive)
+					if (boot_drive)
 						PanicAlertT("Could not read \"%s\".  "
 								"There is no disc in the drive, or it is not a GC/Wii backup.  "
 								"Please note that original GameCube and Wii discs cannot be read "
-								"by most PC DVD drives.", m_strFilename.c_str());
+								"by most PC DVD drives.", m_filename.c_str());
 					else
 						PanicAlertT("\"%s\" is an invalid GCM/ISO file, or is not a GC/Wii ISO.",
-								m_strFilename.c_str());
+								m_filename.c_str());
 					return false;
 				}
-				m_strName = pVolume->GetName();
-				m_strUniqueID = pVolume->GetUniqueID();
-				m_strRevisionSpecificUniqueID = pVolume->GetRevisionSpecificUniqueID();
+				m_name = p_volume->GetName();
+				m_unique_ID = p_volume->GetUniqueID();
+				m_revision_specific_unique_ID = p_volume->GetRevisionSpecificUniqueID();
 
 				// Check if we have a Wii disc
-				bWii = DiscIO::IsVolumeWiiDisc(pVolume);
-				switch (pVolume->GetCountry())
+				m_wii = DiscIO::IsVolumeWiiDisc(p_volume);
+				switch (p_volume->GetCountry())
 				{
 				case DiscIO::IVolume::COUNTRY_USA:
-					bNTSC = true;
-					Region = USA_DIR;
+					m_NTSC = true;
+					region = USA_DIR;
 					break;
 
 				case DiscIO::IVolume::COUNTRY_TAIWAN:
 				case DiscIO::IVolume::COUNTRY_KOREA:
 					// TODO: Should these have their own Region Dir?
 				case DiscIO::IVolume::COUNTRY_JAPAN:
-					bNTSC = true;
-					Region = JAP_DIR;
+					m_NTSC = true;
+					region = JAP_DIR;
 					break;
 
 				case DiscIO::IVolume::COUNTRY_EUROPE:
 				case DiscIO::IVolume::COUNTRY_FRANCE:
 				case DiscIO::IVolume::COUNTRY_ITALY:
 				case DiscIO::IVolume::COUNTRY_RUSSIA:
-					bNTSC = false;
-					Region = EUR_DIR;
+					m_NTSC = false;
+					region = EUR_DIR;
 					break;
 
 				default:
 					if (PanicYesNoT("Your GCM/ISO file seems to be invalid (invalid country)."
 								   "\nContinue with PAL region?"))
 					{
-						bNTSC = false;
-						Region = EUR_DIR;
+						m_NTSC = false;
+						region = EUR_DIR;
 						break;
 					}else return false;
 				}
 
-				delete pVolume;
+				delete p_volume;
 			}
-			else if (!strcasecmp(Extension.c_str(), ".elf"))
+			else if (!strcasecmp(extension.c_str(), ".elf"))
 			{
-				bWii = CBoot::IsElfWii(m_strFilename);
-				Region = USA_DIR;
-				m_BootType = BOOT_ELF;
-				bNTSC = true;
+				m_wii = CBoot::IsElfWii(m_filename);
+				region = USA_DIR;
+				m_boot_type = BOOT_ELF;
+				m_NTSC = true;
 			}
-			else if (!strcasecmp(Extension.c_str(), ".dol"))
+			else if (!strcasecmp(extension.c_str(), ".dol"))
 			{
-				CDolLoader dolfile(m_strFilename);
-				bWii = dolfile.IsWii();
-				Region = USA_DIR;
-				m_BootType = BOOT_DOL;
-				bNTSC = true;
+				CDolLoader dolfile(m_filename);
+				m_wii = dolfile.IsWii();
+				region = USA_DIR;
+				m_boot_type = BOOT_DOL;
+				m_NTSC = true;
 			}
-			else if (!strcasecmp(Extension.c_str(), ".dff"))
+			else if (!strcasecmp(extension.c_str(), ".dff"))
 			{
-				bWii = true;
-				Region = USA_DIR;
-				bNTSC = true;
-				m_BootType = BOOT_DFF;
+				m_wii = true;
+				region = USA_DIR;
+				m_NTSC = true;
+				m_boot_type = BOOT_DFF;
 
-				FifoDataFile *ddfFile = FifoDataFile::Load(m_strFilename, true);
+				FifoDataFile* ddf_file = FifoDataFile::Load(m_filename, true);
 
-				if (ddfFile)
+				if (ddf_file)
 				{
-					bWii = ddfFile->GetIsWii();
-					delete ddfFile;
+					m_wii = ddf_file->GetIsWii();
+					delete ddf_file;
 				}
 			}
-			else if (DiscIO::CNANDContentManager::Access().GetNANDLoader(m_strFilename).IsValid())
+			else if (DiscIO::CNANDContentManager::Access().GetNANDLoader(m_filename).IsValid())
 			{
-				const DiscIO::IVolume* pVolume = DiscIO::CreateVolumeFromFilename(m_strFilename);
-				const DiscIO::INANDContentLoader& ContentLoader = DiscIO::CNANDContentManager::Access().GetNANDLoader(m_strFilename);
+				const DiscIO::IVolume* p_volume = DiscIO::CreateVolumeFromFilename(m_filename);
+				const DiscIO::INANDContentLoader& content_loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(m_filename);
 
-				if (ContentLoader.GetContentByIndex(ContentLoader.GetBootIndex()) == nullptr)
+				if (content_loader.GetContentByIndex(content_loader.GetBootIndex()) == nullptr)
 				{
 					//WAD is valid yet cannot be booted. Install instead.
-					u64 installed = DiscIO::CNANDContentManager::Access().Install_WiiWAD(m_strFilename);
+					u64 installed = DiscIO::CNANDContentManager::Access().Install_WiiWAD(m_filename);
 					if (installed)
 						SuccessAlertT("The WAD has been installed successfully");
 					return false; //do not boot
 				}
 
-				switch (ContentLoader.GetCountry())
+				switch (content_loader.GetCountry())
 				{
 				case DiscIO::IVolume::COUNTRY_USA:
-					bNTSC = true;
-					Region = USA_DIR;
+					m_NTSC = true;
+					region = USA_DIR;
 					break;
 
 				case DiscIO::IVolume::COUNTRY_TAIWAN:
 				case DiscIO::IVolume::COUNTRY_KOREA:
 					// TODO: Should these have their own Region Dir?
 				case DiscIO::IVolume::COUNTRY_JAPAN:
-					bNTSC = true;
-					Region = JAP_DIR;
+					m_NTSC = true;
+					region = JAP_DIR;
 					break;
 
 				case DiscIO::IVolume::COUNTRY_EUROPE:
 				case DiscIO::IVolume::COUNTRY_FRANCE:
 				case DiscIO::IVolume::COUNTRY_ITALY:
 				case DiscIO::IVolume::COUNTRY_RUSSIA:
-					bNTSC = false;
-					Region = EUR_DIR;
+					m_NTSC = false;
+					region = EUR_DIR;
 					break;
 
 				default:
-					bNTSC = false;
-					Region = EUR_DIR;
+					m_NTSC = false;
+					region = EUR_DIR;
 						break;
 				}
 
-				bWii = true;
-				m_BootType = BOOT_WII_NAND;
+				m_wii = true;
+				m_boot_type = BOOT_WII_NAND;
 
-				if (pVolume)
+				if (p_volume)
 				{
-					m_strName = pVolume->GetName();
-					m_strUniqueID = pVolume->GetUniqueID();
-					delete pVolume;
+					m_name = p_volume->GetName();
+					m_unique_ID = p_volume->GetUniqueID();
+					delete p_volume;
 				}
 				else
 				{
 					// null pVolume means that we are loading from nand folder (Most Likely Wii Menu)
 					// if this is the second boot we would be using the Name and id of the last title
-					m_strName.clear();
-					m_strUniqueID.clear();
+					m_name.clear();
+					m_unique_ID.clear();
 				}
 
 				// Use the TitleIDhex for name and/or unique ID if launching from nand folder
 				// or if it is not ascii characters (specifically sysmenu could potentially apply to other things)
 				char titleidstr[17];
-				snprintf(titleidstr, 17, "%016" PRIx64, ContentLoader.GetTitleID());
+				snprintf(titleidstr, 17, "%016" PRIx64, content_loader.GetTitleID());
 
-				if (!m_strName.length())
+				if (!m_name.length())
 				{
-					m_strName = titleidstr;
+					m_name = titleidstr;
 				}
-				if (!m_strUniqueID.length())
+				if (!m_unique_ID.length())
 				{
-					m_strUniqueID = titleidstr;
+					m_unique_ID = titleidstr;
 				}
 
 			}
 			else
 			{
-				PanicAlertT("Could not recognize ISO file %s", m_strFilename.c_str());
+				PanicAlertT("Could not recognize ISO file %s", m_filename.c_str());
 				return false;
 			}
 		}
 		break;
 
 	case BOOT_BS2_USA:
-		Region = USA_DIR;
-		m_strFilename.clear();
-		bNTSC = true;
+		region = USA_DIR;
+		m_filename.clear();
+		m_NTSC = true;
 		break;
 
 	case BOOT_BS2_JAP:
-		Region = JAP_DIR;
-		m_strFilename.clear();
-		bNTSC = true;
+		region = JAP_DIR;
+		m_filename.clear();
+		m_NTSC = true;
 		break;
 
 	case BOOT_BS2_EUR:
-		Region = EUR_DIR;
-		m_strFilename.clear();
-		bNTSC = false;
+		region = EUR_DIR;
+		m_filename.clear();
+		m_NTSC = false;
 		break;
 	}
 
 	// Setup paths
-	CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardA, Region, true);
-	CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardB, Region, false);
-	m_strSRAM = File::GetUserPath(F_GCSRAM_IDX);
-	if (!bWii)
+	CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardA, region, true);
+	CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardB, region, false);
+	m_SRAM = File::GetUserPath(F_GCSRAM_IDX);
+	if (!m_wii)
 	{
-		m_strBootROM = File::GetUserPath(D_GCUSER_IDX) + DIR_SEP + Region + DIR_SEP GC_IPL;
-		if (!File::Exists(m_strBootROM))
-			m_strBootROM = File::GetSysDirectory() + GC_SYS_DIR + DIR_SEP + Region + DIR_SEP GC_IPL;
+		m_boot_ROM = File::GetUserPath(D_GCUSER_IDX) + DIR_SEP + region + DIR_SEP GC_IPL;
+		if (!File::Exists(m_boot_ROM))
+			m_boot_ROM = File::GetSysDirectory() + GC_SYS_DIR + DIR_SEP + region + DIR_SEP GC_IPL;
 
-		if (!bHLE_BS2)
+		if (!m_HLE_BS2)
 		{
-			if (!File::Exists(m_strBootROM))
+			if (!File::Exists(m_boot_ROM))
 			{
-				WARN_LOG(BOOT, "Bootrom file %s not found - using HLE.", m_strBootROM.c_str());
-				bHLE_BS2 = true;
+				WARN_LOG(BOOT, "Bootrom file %s not found - using HLE.", m_boot_ROM.c_str());
+				m_HLE_BS2 = true;
 			}
 		}
 	}
-	else if (bWii && !bHLE_BS2)
+	else if (m_wii && !m_HLE_BS2)
 	{
 		WARN_LOG(BOOT, "GC bootrom file will not be loaded for Wii mode.");
-		bHLE_BS2 = true;
+		m_HLE_BS2 = true;
 	}
 
 	return true;
 }
 
-void SCoreStartupParameter::CheckMemcardPath(std::string& memcardPath, std::string gameRegion, bool isSlotA)
+void CoreStartupParameter::CheckMemcardPath(std::string& memcard_path, std::string game_region, bool is_slot_a)
 {
-	std::string ext("." + gameRegion + ".raw");
-	if (memcardPath.empty())
+	std::string ext("." + game_region + ".raw");
+	if (memcard_path.empty())
 	{
 		// Use default memcard path if there is no user defined name
-		std::string defaultFilename = isSlotA ? GC_MEMCARDA : GC_MEMCARDB;
-		memcardPath = File::GetUserPath(D_GCUSER_IDX) + defaultFilename + ext;
+		std::string default_filename = is_slot_a ? GC_MEMCARDA : GC_MEMCARDB;
+		memcard_path = File::GetUserPath(D_GCUSER_IDX) + default_filename + ext;
 	}
 	else
 	{
-		std::string filename = memcardPath;
+		std::string filename = memcard_path;
 		std::string region = filename.substr(filename.size()-7, 3);
 		bool hasregion = false;
 		hasregion |= region.compare(USA_DIR) == 0;
@@ -370,52 +370,52 @@ void SCoreStartupParameter::CheckMemcardPath(std::string& memcardPath, std::stri
 			if (File::Exists(filename))
 			{
 				// If the old file exists we are polite and ask if we should copy it
-				std::string oldFilename = filename;
+				std::string old_filename = filename;
 				filename.replace(filename.size()-4, 4, ext);
 				if (PanicYesNoT("Memory Card filename in Slot %c is incorrect\n"
 					"Region not specified\n\n"
 					"Slot %c path was changed to\n"
 					"%s\n"
 					"Would you like to copy the old file to this new location?\n",
-					isSlotA ? 'A':'B', isSlotA ? 'A':'B', filename.c_str()))
+					is_slot_a ? 'A':'B', is_slot_a ? 'A':'B', filename.c_str()))
 				{
-					if (!File::Copy(oldFilename, filename))
+					if (!File::Copy(old_filename, filename))
 						PanicAlertT("Copy failed");
 				}
 			}
-			memcardPath = filename; // Always correct the path!
+			memcard_path = filename; // Always correct the path!
 		}
-		else if (region.compare(gameRegion) != 0)
+		else if (region.compare(game_region) != 0)
 		{
 			// filename has region, but it's not == gameRegion
 			// Just set the correct filename, the EXI Device will create it if it doesn't exist
-			memcardPath = filename.replace(filename.size()-ext.size(), ext.size(), ext);;
+			memcard_path = filename.replace(filename.size()-ext.size(), ext.size(), ext);;
 		}
 	}
 }
 
-IniFile SCoreStartupParameter::LoadGameIni() const
+IniFile CoreStartupParameter::LoadGameIni() const
 {
 	IniFile game_ini;
-	game_ini.Load(m_strGameIniDefault);
-	if (m_strGameIniDefaultRevisionSpecific != "")
-		game_ini.Load(m_strGameIniDefaultRevisionSpecific, true);
-	game_ini.Load(m_strGameIniLocal, true);
+	game_ini.Load(m_game_ini_default);
+	if (m_game_ini_default_revision_specific != "")
+		game_ini.Load(m_game_ini_default_revision_specific, true);
+	game_ini.Load(m_game_ini_local, true);
 	return game_ini;
 }
 
-IniFile SCoreStartupParameter::LoadDefaultGameIni() const
+IniFile CoreStartupParameter::LoadDefaultGameIni() const
 {
 	IniFile game_ini;
-	game_ini.Load(m_strGameIniDefault);
-	if (m_strGameIniDefaultRevisionSpecific != "")
-		game_ini.Load(m_strGameIniDefaultRevisionSpecific, true);
+	game_ini.Load(m_game_ini_default);
+	if (m_game_ini_default_revision_specific != "")
+		game_ini.Load(m_game_ini_default_revision_specific, true);
 	return game_ini;
 }
 
-IniFile SCoreStartupParameter::LoadLocalGameIni() const
+IniFile CoreStartupParameter::LoadLocalGameIni() const
 {
 	IniFile game_ini;
-	game_ini.Load(m_strGameIniLocal);
+	game_ini.Load(m_game_ini_local);
 	return game_ini;
 }

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -83,90 +83,90 @@ enum Hotkey
 	NUM_HOTKEYS,
 };
 
-struct SCoreStartupParameter
+struct CoreStartupParameter
 {
 	// Settings
-	bool bEnableDebugging;
+	bool m_enable_debugging;
 	#ifdef USE_GDBSTUB
-	int  iGDBPort;
+	int  m_GDB_port;
 	#endif
-	bool bAutomaticStart;
-	bool bBootToPause;
+	bool m_automatic_start;
+	bool m_boot_to_pause;
 
 	// 0 = Interpreter
 	// 1 = Jit
 	// 2 = JitIL
 	// 3 = JIT ARM
-	int iCPUCore;
+	int m_CPU_core;
 
 	// JIT (shared between JIT and JITIL)
-	bool bJITNoBlockCache, bJITBlockLinking;
-	bool bJITOff;
-	bool bJITLoadStoreOff, bJITLoadStorelXzOff, bJITLoadStorelwzOff, bJITLoadStorelbzxOff;
-	bool bJITLoadStoreFloatingOff;
-	bool bJITLoadStorePairedOff;
-	bool bJITFloatingPointOff;
-	bool bJITIntegerOff;
-	bool bJITPairedOff;
-	bool bJITSystemRegistersOff;
-	bool bJITBranchOff;
-	bool bJITILTimeProfiling;
-	bool bJITILOutputIR;
+	bool m_JIT_no_block_cache, m_JIT_block_linking;
+	bool m_JIT_off;
+	bool m_JIT_load_store_off, m_JIT_load_store_lxz_off, m_JIT_load_store_lwz_off, m_JIT_load_store_lbzx_off;
+	bool m_JIT_load_store_floating_off;
+	bool m_JIT_load_store_paired_off;
+	bool m_JIT_floating_point_off;
+	bool m_JIT_integer_off;
+	bool m_JIT_paired_off;
+	bool m_JIT_system_registers_off;
+	bool m_JIT_branch_off;
+	bool m_JITIL_time_profiling;
+	bool m_JITIL_output_IR;
 
-	bool bFastmem;
-	bool bEnableFPRF;
+	bool m_fastmem;
+	bool m_enable_FPRF;
 
-	bool bCPUThread;
-	bool bDSPThread;
-	bool bDSPHLE;
-	bool bSkipIdle;
-	bool bNTSC;
-	bool bForceNTSCJ;
-	bool bHLE_BS2;
-	bool bEnableCheats;
-	bool bMergeBlocks;
-	bool bEnableMemcardSaving;
+	bool m_CPU_thread;
+	bool m_DSP_thread;
+	bool m_DSPHLE;
+	bool m_skip_idle;
+	bool m_NTSC;
+	bool m_force_NTSCJ;
+	bool m_HLE_BS2;
+	bool m_enable_cheats;
+	bool m_merge_blocks;
+	bool m_enable_memcard_saving;
 
-	bool bDPL2Decoder;
-	int iLatency;
+	bool m_DPL2_decoder;
+	int m_latency;
 
-	bool bRunCompareServer;
-	bool bRunCompareClient;
+	bool m_run_compare_server;
+	bool m_run_compare_client;
 
-	bool bMMU;
-	bool bDCBZOFF;
-	bool bTLBHack;
-	int iBBDumpPort;
-	bool bVBeamSpeedHack;
-	bool bSyncGPU;
-	bool bFastDiscSpeed;
+	bool m_MMU;
+	bool m_DCBZOFF;
+	bool m_TLB_hack;
+	int m_BB_dump_port;
+	bool m_vbeam_speed_hack;
+	bool m_sync_GPU;
+	bool m_fast_disc_speed;
 
-	int SelectedLanguage;
+	int m_selected_language;
 
-	bool bWii;
+	bool m_wii;
 
 	// Interface settings
-	bool bConfirmStop, bHideCursor, bAutoHideCursor, bUsePanicHandlers, bOnScreenDisplayMessages;
-	std::string theme_name;
+	bool m_confirm_stop, m_hide_cursor, m_auto_hide_cursor, m_use_panic_handlers, m_on_screen_display_messages;
+	std::string m_theme_name;
 
 	// Hotkeys
-	int iHotkey[NUM_HOTKEYS];
-	int iHotkeyModifier[NUM_HOTKEYS];
+	int m_hotkey[NUM_HOTKEYS];
+	int m_hotkey_modifier[NUM_HOTKEYS];
 
 	// Display settings
-	std::string strFullscreenResolution;
-	int iRenderWindowXPos, iRenderWindowYPos;
-	int iRenderWindowWidth, iRenderWindowHeight;
-	bool bRenderWindowAutoSize, bKeepWindowOnTop;
-	bool bFullscreen, bRenderToMain;
-	bool bProgressive, bDisableScreenSaver;
+	std::string m_fullscreen_resolution;
+	int m_render_window_xpos, m_render_window_ypos;
+	int m_render_window_width, m_render_window_height;
+	bool m_render_window_auto_size, m_keep_window_on_top;
+	bool m_fullscreen, m_render_to_main;
+	bool m_progressive, m_disable_screen_saver;
 
-	int iPosX, iPosY, iWidth, iHeight;
+	int m_posx, m_posy, m_width, m_height;
 
 	// Fifo Player related settings
-	bool bLoopFifoReplay;
+	bool m_loop_fifo_replay;
 
-	enum EBootBS2
+	enum BootBS2
 	{
 		BOOT_DEFAULT,
 		BOOT_BS2_JAP,
@@ -174,7 +174,7 @@ struct SCoreStartupParameter
 		BOOT_BS2_EUR,
 	};
 
-	enum EBootType
+	enum BootType
 	{
 		BOOT_ISO,
 		BOOT_ELF,
@@ -183,31 +183,32 @@ struct SCoreStartupParameter
 		BOOT_BS2,
 		BOOT_DFF
 	};
-	EBootType m_BootType;
+	BootType m_boot_type;
 
-	std::string m_strVideoBackend;
+	std::string m_video_backend;
 
 	// files
-	std::string m_strFilename;
-	std::string m_strBootROM;
-	std::string m_strSRAM;
-	std::string m_strDefaultGCM;
-	std::string m_strDVDRoot;
-	std::string m_strApploader;
-	std::string m_strUniqueID;
-	std::string m_strRevisionSpecificUniqueID;
-	std::string m_strName;
-	std::string m_strGameIniDefault;
-	std::string m_strGameIniDefaultRevisionSpecific;
-	std::string m_strGameIniLocal;
+
+	std::string m_filename;
+	std::string m_boot_ROM;
+	std::string m_SRAM;
+	std::string m_default_GCM;
+	std::string m_DVD_root;
+	std::string m_apploader;
+	std::string m_unique_ID;
+	std::string m_revision_specific_unique_ID;
+	std::string m_name;
+	std::string m_game_ini_default;
+	std::string m_game_ini_default_revision_specific;
+	std::string m_game_ini_local;
 
 	// Constructor just calls LoadDefaults
-	SCoreStartupParameter();
+	CoreStartupParameter();
 
 	void LoadDefaults();
-	bool AutoSetup(EBootBS2 _BootBS2);
-	const std::string &GetUniqueID() const { return m_strUniqueID; }
-	void CheckMemcardPath(std::string& memcardPath, std::string Region, bool isSlotA);
+	bool AutoSetup(BootBS2 boot_BS2);
+	const std::string &GetUniqueID() const { return m_unique_ID; }
+	void CheckMemcardPath(std::string& memcard_path, std::string region, bool is_slot_a);
 	IniFile LoadDefaultGameIni() const;
 	IniFile LoadLocalGameIni() const;
 	IniFile LoadGameIni() const;

--- a/Source/Core/Core/DSPEmulator.h
+++ b/Source/Core/Core/DSPEmulator.h
@@ -13,7 +13,7 @@ public:
 
 	virtual bool IsLLE() = 0;
 
-	virtual bool Initialize(bool bWii, bool bDSPThread) = 0;
+	virtual bool Initialize(bool m_wii, bool m_DSP_thread) = 0;
 	virtual void Shutdown() = 0;
 
 	virtual void DoState(PointerWrap &p) = 0;

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -75,7 +75,7 @@ void GetTlutLoadData(u32 &tlutAddr, u32 &memAddr, u32 &tlutXferCount, BPMemory &
 	tlutXferCount = (bpMem.tmem_config.tlut_dest & 0x1FFC00) >> 5;
 
 	// TODO - figure out a cleaner way.
-	if (Core::g_CoreStartupParameter.bWii)
+	if (Core::g_CoreStartupParameter.m_wii)
 		memAddr = bpMem.tmem_config.tlut_src << 5;
 	else
 		memAddr = (bpMem.tmem_config.tlut_src & 0xFFFFF) << 5;

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -162,7 +162,7 @@ FifoPlayer::FifoPlayer() :
 	m_FrameWrittenCb(nullptr),
 	m_File(nullptr)
 {
-	m_Loop = SConfig::GetInstance().m_LocalCoreStartupParameter.bLoopFifoReplay;
+	m_Loop = SConfig::GetInstance().m_LocalCoreStartupParameter.m_loop_fifo_replay;
 }
 
 void FifoPlayer::WriteFrame(const FifoFrameInfo &frame, const AnalyzedFrameInfo &info)

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -48,7 +48,7 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
 	memset(m_Ram, 0, Memory::RAM_SIZE);
 	memset(m_ExRam, 0, Memory::EXRAM_SIZE);
 
-	m_File->SetIsWii(SConfig::GetInstance().m_LocalCoreStartupParameter.bWii);
+	m_File->SetIsWii(SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii);
 
 	if (!m_IsRecording)
 	{

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -130,7 +130,7 @@ static bool InstallCodeHandler()
 
 void RunCodeHandler()
 {
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats && active_codes.size() > 0)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_enable_cheats && active_codes.size() > 0)
 	{
 		if (!code_handler_installed || Memory::Read_U32(0x80001800) - 0xd01f1bad > 5)
 			code_handler_installed = InstallCodeHandler();

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -94,7 +94,7 @@ void PatchFunctions()
 		}
 	}
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableDebugging)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_enable_debugging)
 	{
 		for (size_t i = 1; i < sizeof(OSBreakPoints) / sizeof(SPatch); i++)
 		{
@@ -143,10 +143,10 @@ int GetFunctionFlagsByIndex(u32 index)
 
 bool IsEnabled(int flags)
 {
-	if (flags == HLE::HLE_TYPE_MEMORY && Core::g_CoreStartupParameter.bMMU)
+	if (flags == HLE::HLE_TYPE_MEMORY && Core::g_CoreStartupParameter.m_MMU)
 		return false;
 
-	if (flags == HLE::HLE_TYPE_DEBUG && !Core::g_CoreStartupParameter.bEnableDebugging && PowerPC::GetMode() != MODE_INTERPRETER)
+	if (flags == HLE::HLE_TYPE_DEBUG && !Core::g_CoreStartupParameter.m_enable_debugging && PowerPC::GetMode() != MODE_INTERPRETER)
 		return false;
 
 	return true;

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -223,7 +223,7 @@ void Init(bool hle)
 	dsp_emulator = CreateDSPEmulator(hle);
 	dsp_is_lle = dsp_emulator->IsLLE();
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 	{
 		g_ARAM.wii_mode = true;
 		g_ARAM.size = Memory::EXRAM_SIZE;

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -39,9 +39,9 @@ struct DSPState
 	}
 };
 
-bool DSPHLE::Initialize(bool bWii, bool bDSPThread)
+bool DSPHLE::Initialize(bool m_wii, bool m_DSP_thread)
 {
-	m_bWii = bWii;
+	m_bWii = m_wii;
 	m_pUCode = nullptr;
 	m_lastUCode = nullptr;
 	m_bHalt = false;

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -14,7 +14,7 @@ class DSPHLE : public DSPEmulator {
 public:
 	DSPHLE();
 
-	virtual bool Initialize(bool bWii, bool bDSPThread) override;
+	virtual bool Initialize(bool m_wii, bool m_DSP_thread) override;
 	virtual void Shutdown() override;
 	virtual bool IsLLE() override { return false ; }
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -34,7 +34,7 @@ void CARDUCode::Update()
 
 u32 CARDUCode::GetUpdateMs()
 {
-	return SConfig::GetInstance().m_LocalCoreStartupParameter.bWii ? 3 : 5;
+	return SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii ? 3 : 5;
 }
 
 void CARDUCode::HandleMail(u32 mail)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -29,7 +29,7 @@ void GBAUCode::Update()
 
 u32 GBAUCode::GetUpdateMs()
 {
-	return SConfig::GetInstance().m_LocalCoreStartupParameter.bWii ? 3 : 5;
+	return SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii ? 3 : 5;
 }
 
 void GBAUCode::HandleMail(u32 mail)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
@@ -31,7 +31,7 @@ void INITUCode::Update()
 
 u32 INITUCode::GetUpdateMs()
 {
-	return SConfig::GetInstance().m_LocalCoreStartupParameter.bWii ? 3 : 5;
+	return SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii ? 3 : 5;
 }
 
 void INITUCode::HandleMail(u32 mail)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -116,7 +116,7 @@ void ROMUCode::BootUCode()
 
 u32 ROMUCode::GetUpdateMs()
 {
-	return SConfig::GetInstance().m_LocalCoreStartupParameter.bWii ? 3 : 5;
+	return SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii ? 3 : 5;
 }
 
 void ROMUCode::DoState(PointerWrap &p)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -516,7 +516,7 @@ void ZeldaUCode::ExecuteList()
 
 u32 ZeldaUCode::GetUpdateMs()
 {
-	return SConfig::GetInstance().m_LocalCoreStartupParameter.bWii ? 3 : 5;
+	return SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii ? 3 : 5;
 }
 
 void ZeldaUCode::DoState(PointerWrap &p)

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -41,14 +41,14 @@ void OSD_AddMessage(const std::string& str, u32 ms)
 
 bool OnThread()
 {
-	const SCoreStartupParameter& _CoreParameter = SConfig::GetInstance().m_LocalCoreStartupParameter;
-	return  _CoreParameter.bDSPThread;
+	const CoreStartupParameter& _CoreParameter = SConfig::GetInstance().m_LocalCoreStartupParameter;
+	return  _CoreParameter.m_DSP_thread;
 }
 
 bool IsWiiHost()
 {
-	const SCoreStartupParameter& _CoreParameter = SConfig::GetInstance().m_LocalCoreStartupParameter;
-	return  _CoreParameter.bWii;
+	const CoreStartupParameter& _CoreParameter = SConfig::GetInstance().m_LocalCoreStartupParameter;
+	return  _CoreParameter.m_wii;
 }
 
 void InterruptRequest()

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -157,10 +157,10 @@ static bool FillDSPInitOptions(DSPInitOptions* opts)
 	return true;
 }
 
-bool DSPLLE::Initialize(bool bWii, bool bDSPThread)
+bool DSPLLE::Initialize(bool m_wii, bool m_DSP_thread)
 {
-	m_bWii = bWii;
-	m_bDSPThread = bDSPThread;
+	m_bWii = m_wii;
+	m_m_DSP_thread = m_DSP_thread;
 
 	DSPInitOptions opts;
 	if (!FillDSPInitOptions(&opts))
@@ -175,7 +175,7 @@ bool DSPLLE::Initialize(bool bWii, bool bDSPThread)
 
 	InitInstructionTable();
 
-	if (m_bDSPThread)
+	if (m_m_DSP_thread)
 		m_hDSPThread = std::thread(dsp_thread, this);
 
 	Host_RefreshDSPDebuggerWindow();
@@ -187,7 +187,7 @@ void DSPLLE::DSP_StopSoundStream()
 {
 	DSPInterpreter::Stop();
 	m_bIsRunning = false;
-	if (m_bDSPThread)
+	if (m_m_DSP_thread)
 	{
 		ppcEvent.Set();
 		dspEvent.Set();
@@ -208,7 +208,7 @@ u16 DSPLLE::DSP_WriteControlRegister(u16 _uFlag)
 	// and immediately process it, if it has.
 	if (_uFlag & 2)
 	{
-		if (!m_bDSPThread)
+		if (!m_m_DSP_thread)
 		{
 			DSPCore_CheckExternalInterrupt();
 			DSPCore_CheckExceptions();
@@ -291,7 +291,7 @@ void DSPLLE::DSP_Update(int cycles)
 	// This gets called VERY OFTEN. The soundstream update might be expensive so only do it 200 times per second or something.
 	int cycles_between_ss_update;
 
-	if (g_dspInitialize.bWii)
+	if (g_dspInitialize.m_wii)
 		cycles_between_ss_update = 121500000 / 200;
 	else
 		cycles_between_ss_update = 81000000 / 200;
@@ -305,7 +305,7 @@ void DSPLLE::DSP_Update(int cycles)
 	}
 */
 	// If we're not on a thread, run cycles here.
-	if (!m_bDSPThread)
+	if (!m_m_DSP_thread)
 	{
 		// ~1/6th as many cycles as the period PPC-side.
 		DSPCore_RunCycles(dsp_cycles);

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.h
@@ -14,7 +14,7 @@ class DSPLLE : public DSPEmulator
 public:
 	DSPLLE();
 
-	virtual bool Initialize(bool bWii, bool bDSPThread) override;
+	virtual bool Initialize(bool m_wii, bool m_DSP_thread) override;
 	virtual void Shutdown() override;
 	virtual bool IsLLE() override { return true; }
 
@@ -37,7 +37,7 @@ private:
 	std::thread m_hDSPThread;
 	std::mutex m_csDSPThreadActive;
 	bool m_bWii;
-	bool m_bDSPThread;
+	bool m_m_DSP_thread;
 	bool m_bIsRunning;
 	volatile u32 m_cycle_count;
 };

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -386,7 +386,7 @@ void EjectDiscCallback(u64 userdata, int cyclesLate)
 
 void InsertDiscCallback(u64 userdata, int cyclesLate)
 {
-	std::string& SavedFileName = SConfig::GetInstance().m_LocalCoreStartupParameter.m_strFilename;
+	std::string& SavedFileName = SConfig::GetInstance().m_LocalCoreStartupParameter.m_filename;
 	std::string *_FileName = (std::string *)userdata;
 
 	if (!VolumeHandler::SetVolumeName(*_FileName))
@@ -748,7 +748,7 @@ void ExecuteCommand()
 					}
 					g_last_read_offset = (iDVDOffset + m_DILENGTH.Length - 2048) & ~2047;
 
-					if (SConfig::GetInstance().m_LocalCoreStartupParameter.bFastDiscSpeed)
+					if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_fast_disc_speed)
 					{
 						// Make sure fast disc speed performs "instant" reads; in addition
 						// to being used to speed up games, fast disc speed is used as a

--- a/Source/Core/Core/HW/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI_Device.cpp
@@ -68,22 +68,22 @@ void IEXIDevice::DMARead(u32 _uAddr, u32 _uSize)
 // DOES NOT FUNCTION AS "NO DEVICE INSERTED" -> Appears as unknown device
 class CEXIDummy : public IEXIDevice
 {
-	std::string m_strName;
+	std::string m_name;
 
 	void TransferByte(u8& _byte) override {}
 
 public:
 	CEXIDummy(const std::string& _strName) :
-	  m_strName(_strName)
+	  m_name(_strName)
 	{
 	}
 
 	virtual ~CEXIDummy(){}
 
-	void ImmWrite(u32 data, u32 size) override {INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s ImmWrite: %08x", m_strName.c_str(), data);}
-	u32  ImmRead (u32 size) override           {INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s ImmRead", m_strName.c_str()); return 0;}
-	void DMAWrite(u32 addr, u32 size) override {INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s DMAWrite: %08x bytes, from %08x to device", m_strName.c_str(), size, addr);}
-	void DMARead (u32 addr, u32 size) override {INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s DMARead:  %08x bytes, from device to %08x", m_strName.c_str(), size, addr);}
+	void ImmWrite(u32 data, u32 size) override {INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s ImmWrite: %08x", m_name.c_str(), data);}
+	u32  ImmRead (u32 size) override           {INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s ImmRead", m_name.c_str()); return 0;}
+	void DMAWrite(u32 addr, u32 size) override {INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s DMAWrite: %08x bytes, from %08x to device", m_name.c_str(), size, addr);}
+	void DMARead (u32 addr, u32 size) override {INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s DMARead:  %08x bytes, from device to %08x", m_name.c_str(), size, addr);}
 };
 
 

--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -85,12 +85,12 @@ CEXIIPL::CEXIIPL() :
 	m_FontsLoaded(false)
 {
 	// Determine region
-	m_bNTSC = SConfig::GetInstance().m_LocalCoreStartupParameter.bNTSC;
+	m_bNTSC = SConfig::GetInstance().m_LocalCoreStartupParameter.m_NTSC;
 
 	// Create the IPL
 	m_pIPL = (u8*)AllocateMemoryPages(ROM_SIZE);
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHLE_BS2)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_HLE_BS2)
 	{
 		// Copy header
 		memcpy(m_pIPL, m_bNTSC ? iplverNTSC : iplverPAL, m_bNTSC ? sizeof(iplverNTSC) : sizeof(iplverPAL));
@@ -102,7 +102,7 @@ CEXIIPL::CEXIIPL() :
 	else
 	{
 		// Load whole ROM dump
-		LoadFileToIPL(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strBootROM, 0);
+		LoadFileToIPL(SConfig::GetInstance().m_LocalCoreStartupParameter.m_boot_ROM, 0);
 		// Descramble the encrypted section (contains BS1 and BS2)
 		Descrambler(m_pIPL + 0x100, 0x1aff00);
 		INFO_LOG(BOOT, "Loaded bootrom: %s", m_pIPL); // yay for null-terminated strings ;p
@@ -112,7 +112,7 @@ CEXIIPL::CEXIIPL() :
 	memset(m_RTC, 0, sizeof(m_RTC));
 
 	// We Overwrite language selection here since it's possible on the GC to change the language as you please
-	g_SRAM.lang = SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage;
+	g_SRAM.lang = SConfig::GetInstance().m_LocalCoreStartupParameter.m_selected_language;
 
 	WriteProtectMemory(m_pIPL, ROM_SIZE);
 	m_uAddress = 0;
@@ -124,7 +124,7 @@ CEXIIPL::~CEXIIPL()
 	m_pIPL = nullptr;
 
 	// SRAM
-	File::IOFile file(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strSRAM, "wb");
+	File::IOFile file(SConfig::GetInstance().m_LocalCoreStartupParameter.m_SRAM, "wb");
 	file.WriteArray(&g_SRAM, 1);
 }
 void CEXIIPL::DoState(PointerWrap &p)
@@ -183,7 +183,7 @@ void CEXIIPL::TransferByte(u8& _uByte)
 		{
 			// Get the time ...
 			u32 &rtc = *((u32 *)&m_RTC);
-			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+			if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 			{
 				// Subtract Wii bias
 				rtc = Common::swap32(CEXIIPL::GetGCTime() - cWiiBias);

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -138,7 +138,7 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 {
 
 	DiscIO::IVolume::ECountry CountryCode = DiscIO::IVolume::COUNTRY_UNKNOWN;
-	auto strUniqueID = Core::g_CoreStartupParameter.m_strUniqueID;
+	auto strUniqueID = Core::g_CoreStartupParameter.m_unique_ID;
 
 	u32 CurrentGameId = 0;
 	if (strUniqueID == TITLEID_SYSMENU_STRING)
@@ -168,7 +168,7 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 	case DiscIO::IVolume::COUNTRY_UNKNOWN:
 	{
 		// The current game's region is not passed down to the EXI device level.
-		// Usually, we can retrieve the region from Core::g_CoreStartupParameter.m_strUniqueId.
+		// Usually, we can retrieve the region from Core::g_CoreStartupParameter.m_unique_ID.
 		// The Wii System Menu requires a lookup based on the version number.
 		// This is not possible in some cases ( e.g. FIFO logs, homebrew elf/dol files).
 		// Instead, we then lookup the region from the memory card name

--- a/Source/Core/Core/HW/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcardRaw.cpp
@@ -67,7 +67,7 @@ MemoryCard::~MemoryCard()
 
 void MemoryCard::FlushThread()
 {
-	if (!Core::g_CoreStartupParameter.bEnableMemcardSaving)
+	if (!Core::g_CoreStartupParameter.m_enable_memcard_saving)
 	{
 		return;
 	}

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -42,13 +42,13 @@ namespace HW
 		ProcessorInterface::Init();
 		ExpansionInterface::Init(); // Needs to be initialized before Memory
 		Memory::Init();
-		DSP::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.bDSPHLE);
+		DSP::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.m_DSPHLE);
 		DVDInterface::Init();
 		GPFifo::Init();
-		CCPU::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.iCPUCore);
+		CCPU::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_core);
 		SystemTimers::Init();
 
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 		{
 			WII_IPCInterface::Init();
 			WII_IPC_HLE_Interface::Init();
@@ -66,7 +66,7 @@ namespace HW
 		SerialInterface::Shutdown();
 		AudioInterface::Shutdown();
 
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 		{
 			WII_IPCInterface::Shutdown();
 			WII_IPC_HLE_Interface::Shutdown();
@@ -97,7 +97,7 @@ namespace HW
 		AudioInterface::DoState(p);
 		p.DoMarker("AudioInterface");
 
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 		{
 			WII_IPCInterface::DoState(p);
 			p.DoMarker("WII_IPCInterface");

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -46,7 +46,7 @@ namespace Memory
 /* Enable the Translation Lookaside Buffer functions. TLBHack = 1 in Dolphin.ini or a
    <GameID>.ini file will set this to true */
 bool bFakeVMEM = false;
-static bool bMMU = false;
+static bool m_MMU = false;
 // ==============
 
 
@@ -142,9 +142,9 @@ static const int num_views = sizeof(views) / sizeof(MemoryView);
 
 void Init()
 {
-	bool wii = SConfig::GetInstance().m_LocalCoreStartupParameter.bWii;
-	bFakeVMEM = SConfig::GetInstance().m_LocalCoreStartupParameter.bTLBHack == true;
-	bMMU = SConfig::GetInstance().m_LocalCoreStartupParameter.bMMU;
+	bool wii = SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii;
+	bFakeVMEM = SConfig::GetInstance().m_LocalCoreStartupParameter.m_TLB_hack == true;
+	m_MMU = SConfig::GetInstance().m_LocalCoreStartupParameter.m_MMU;
 
 	u32 flags = 0;
 	if (wii) flags |= MV_WII_ONLY;
@@ -165,7 +165,7 @@ void Init()
 
 void DoState(PointerWrap &p)
 {
-	bool wii = SConfig::GetInstance().m_LocalCoreStartupParameter.bWii;
+	bool wii = SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii;
 	p.DoArray(m_pPhysicalRAM, RAM_SIZE);
 	//p.DoArray(m_pVirtualEFB, EFB_SIZE);
 	p.DoArray(m_pVirtualL1Cache, L1_CACHE_SIZE);
@@ -182,7 +182,7 @@ void Shutdown()
 {
 	m_IsInitialized = false;
 	u32 flags = 0;
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii) flags |= MV_WII_ONLY;
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii) flags |= MV_WII_ONLY;
 	if (bFakeVMEM) flags |= MV_FAKE_VMEM;
 	MemoryMap_Shutdown(views, num_views, flags, &g_arena);
 	g_arena.ReleaseSpace();
@@ -197,7 +197,7 @@ void Clear()
 		memset(m_pRAM, 0, RAM_SIZE);
 	if (m_pL1Cache)
 		memset(m_pL1Cache, 0, L1_CACHE_SIZE);
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii && m_pEXRAM)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii && m_pEXRAM)
 		memset(m_pEXRAM, 0, EXRAM_SIZE);
 }
 
@@ -323,7 +323,7 @@ u8 *GetPointer(const u32 _Address)
 	case 0x1:
 	case 0x9:
 	case 0xd:
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 		{
 			if ((_Address & 0xfffffff) < EXRAM_SIZE)
 				return m_pPhysicalEXRAM + (_Address & EXRAM_MASK);
@@ -362,7 +362,7 @@ bool IsRAMAddress(const u32 addr, bool allow_locked_cache, bool allow_fake_vmem)
 	case 0x10:
 	case 0x90:
 	case 0xD0:
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii && (addr & 0x0FFFFFFF) < EXRAM_SIZE)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii && (addr & 0x0FFFFFFF) < EXRAM_SIZE)
 			return true;
 		else
 			return false;

--- a/Source/Core/Core/HW/MemmapFunctions.cpp
+++ b/Source/Core/Core/HW/MemmapFunctions.cpp
@@ -237,8 +237,8 @@ u32 Read_Opcode(u32 _Address)
 		return 0x00000000;
 	}
 
-	if (Core::g_CoreStartupParameter.bMMU &&
-		!Core::g_CoreStartupParameter.bTLBHack &&
+	if (Core::g_CoreStartupParameter.m_MMU &&
+		!Core::g_CoreStartupParameter.m_TLB_hack &&
 		(_Address & ADDR_MASK_MEM1))
 	{
 		// TODO: Check for MSR instruction address translation flag before translating
@@ -848,7 +848,7 @@ static u32 TranslateBlockAddress(const u32 addr, const XCheckTLBFlag _Flag)
 	UReg_MSR& m_MSR = ((UReg_MSR&)PowerPC::ppcState.msr);
 
 	// Check for enhanced mode (secondary BAT enable) using 8 BATs
-	int bats = (Core::g_CoreStartupParameter.bWii && HID4.SBE)?8:4;
+	int bats = (Core::g_CoreStartupParameter.m_wii && HID4.SBE)?8:4;
 
 	for (int i = 0; i < bats; i++)
 	{

--- a/Source/Core/Core/HW/Sram.cpp
+++ b/Source/Core/Core/HW/Sram.cpp
@@ -59,7 +59,7 @@ SRAM sram_dump_german = {{
 
 void InitSRAM()
 {
-	File::IOFile file(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strSRAM, "rb");
+	File::IOFile file(SConfig::GetInstance().m_LocalCoreStartupParameter.m_SRAM, "rb");
 	if (file)
 	{
 		if (!file.ReadArray(&g_SRAM, 1))

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -144,7 +144,7 @@ static void AudioDMACallback(u64 userdata, int cyclesLate)
 
 static void IPC_HLE_UpdateCallback(u64 userdata, int cyclesLate)
 {
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 	{
 		WII_IPC_HLE_Interface::UpdateDevices();
 		CoreTiming::ScheduleEvent(IPC_HLE_PERIOD - cyclesLate, et_IPC_HLE);
@@ -240,7 +240,7 @@ static void ThrottleCallback(u64 last_time, int cyclesLate)
 // split from Init to break a circular dependency between VideoInterface::Init and SystemTimers::Init
 void PreInit()
 {
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 		CPU_CORE_CLOCK = 729000000u;
 	else
 		CPU_CORE_CLOCK = 486000000u;
@@ -248,7 +248,7 @@ void PreInit()
 
 void Init()
 {
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 	{
 		// AyuanX: TO BE TWEAKED
 		// Now the 1500 is a pure assumption
@@ -276,7 +276,7 @@ void Init()
 	et_Dec = CoreTiming::RegisterEvent("DecCallback", DecrementerCallback);
 	et_VI = CoreTiming::RegisterEvent("VICallback", VICallback);
 	et_SI = CoreTiming::RegisterEvent("SICallback", SICallback);
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bSyncGPU)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_sync_GPU)
 		et_CP = CoreTiming::RegisterEvent("CPCallback", CPCallback);
 	et_DSP = CoreTiming::RegisterEvent("DSPCallback", DSPCallback);
 	et_AudioDMA = CoreTiming::RegisterEvent("AudioDMACallback", AudioDMACallback);
@@ -289,12 +289,12 @@ void Init()
 	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerFrame(), et_SI);
 	CoreTiming::ScheduleEvent(AUDIO_DMA_PERIOD, et_AudioDMA);
 	CoreTiming::ScheduleEvent(0, et_Throttle, Common::Timer::GetTimeMs());
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bSyncGPU)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_sync_GPU)
 		CoreTiming::ScheduleEvent(CP_PERIOD, et_CP);
 
 	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerFrame(), et_PatchEngine);
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 		CoreTiming::ScheduleEvent(IPC_HLE_PERIOD, et_IPC_HLE);
 }
 

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -136,10 +136,10 @@ void Preset(bool _bNTSC)
 	m_VBeamPos = 0; // RG4JC0 checks for a zero VBeamPos
 
 	// 54MHz, capable of progressive scan
-	m_Clock = Core::g_CoreStartupParameter.bProgressive;
+	m_Clock = Core::g_CoreStartupParameter.m_progressive;
 
 	// Say component cable is plugged
-	m_DTVStatus.component_plugged = Core::g_CoreStartupParameter.bProgressive;
+	m_DTVStatus.component_plugged = Core::g_CoreStartupParameter.m_progressive;
 
 	UpdateParameters();
 }
@@ -171,7 +171,7 @@ void Init()
 
 	fields = 1;
 
-	m_DTVStatus.ntsc_j = Core::g_CoreStartupParameter.bForceNTSCJ;
+	m_DTVStatus.ntsc_j = Core::g_CoreStartupParameter.m_force_NTSCJ;
 
 	for (UVIInterruptRegister& reg : m_InterruptRegister)
 	{
@@ -399,7 +399,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 
 void SetRegionReg(char region)
 {
-	if (!Core::g_CoreStartupParameter.bForceNTSCJ)
+	if (!Core::g_CoreStartupParameter.m_force_NTSCJ)
 		m_DTVStatus.ntsc_j = region == 'J';
 }
 
@@ -477,7 +477,7 @@ void UpdateParameters()
 
 int GetNumFields()
 {
-	if (Core::g_CoreStartupParameter.bVBeamSpeedHack)
+	if (Core::g_CoreStartupParameter.m_vbeam_speed_hack)
 		return (2 / fields);
 	else
 		return 1;
@@ -491,7 +491,7 @@ unsigned int GetTicksPerLine()
 	}
 	else
 	{
-		if (Core::g_CoreStartupParameter.bVBeamSpeedHack)
+		if (Core::g_CoreStartupParameter.m_vbeam_speed_hack)
 			return TicksPerFrame / s_lineCount;
 		else
 			return TicksPerFrame / (s_lineCount / (2 / fields)) ;

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -200,14 +200,14 @@ bool Wiimote::Read()
 
 	if (result > 0 && m_channel > 0)
 	{
-		if (Core::g_CoreStartupParameter.iBBDumpPort > 0 &&
+		if (Core::g_CoreStartupParameter.m_BB_dump_port > 0 &&
 		    index == WIIMOTE_BALANCE_BOARD)
 		{
 			static sf::SocketUDP Socket;
 			Socket.Send((char*)rpt.data(),
 			            rpt.size(),
 			            sf::IPAddress::LocalHost,
-		                Core::g_CoreStartupParameter.iBBDumpPort);
+		                Core::g_CoreStartupParameter.m_BB_dump_port);
 		}
 
 		// Add it to queue
@@ -234,10 +234,10 @@ bool Wiimote::Write()
 
 		if (!is_speaker_data || m_last_audio_report.GetTimeDifference() > 5)
 		{
-			if (Core::g_CoreStartupParameter.iBBDumpPort > 0 && index == WIIMOTE_BALANCE_BOARD)
+			if (Core::g_CoreStartupParameter.m_BB_dump_port > 0 && index == WIIMOTE_BALANCE_BOARD)
 			{
 				static sf::SocketUDP Socket;
-				Socket.Send((char*)rpt.data(), rpt.size(), sf::IPAddress::LocalHost, Core::g_CoreStartupParameter.iBBDumpPort);
+				Socket.Send((char*)rpt.data(), rpt.size(), sf::IPAddress::LocalHost, Core::g_CoreStartupParameter.m_BB_dump_port);
 			}
 			IOWrite(rpt.data(), rpt.size());
 

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -57,11 +57,11 @@ static u64 g_totalLagCount = 0; // just stats
 u64 g_currentInputCount = 0, g_totalInputCount = 0; // just stats
 static u64 g_totalTickCount = 0, g_tickCountAtLastInput = 0; // just stats
 static u64 g_recordingStartTime; // seconds since 1970 that recording started
-static bool bSaveConfig = false, bSkipIdle = false, bDualCore = false, bProgressive = false, bDSPHLE = false, bFastDiscSpeed = false;
+static bool bSaveConfig = false, m_skip_idle = false, bDualCore = false, m_progressive = false, m_DSPHLE = false, m_fast_disc_speed = false;
 bool g_bClearSave = false;
-static bool bSyncGPU = false, bNetPlay = false;
+static bool m_sync_GPU = false, bNetPlay = false;
 static std::string videoBackend = "unknown";
-static int iCPUCore = 1;
+static int m_CPU_core = 1;
 bool g_bDiscChange = false;
 std::string g_discChange = "";
 static std::string author = "";
@@ -161,7 +161,7 @@ void Init()
 	g_bFrameStep = false;
 	g_bFrameStop = false;
 	bSaveConfig = false;
-	iCPUCore = SConfig::GetInstance().m_LocalCoreStartupParameter.iCPUCore;
+	m_CPU_core = SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_core;
 	if (IsPlayingInput())
 	{
 		ReadHeader();
@@ -338,27 +338,27 @@ bool IsDualCore()
 
 bool IsProgressive()
 {
-	return bProgressive;
+	return m_progressive;
 }
 
 bool IsSkipIdle()
 {
-	return bSkipIdle;
+	return m_skip_idle;
 }
 
 bool IsDSPHLE()
 {
-	return bDSPHLE;
+	return m_DSPHLE;
 }
 
 bool IsFastDiscSpeed()
 {
-	return bFastDiscSpeed;
+	return m_fast_disc_speed;
 }
 
 int GetCPUMode()
 {
-	return iCPUCore;
+	return m_CPU_core;
 }
 
 bool IsStartingFromClearSave()
@@ -372,7 +372,7 @@ bool IsUsingMemcard(int memcard)
 }
 bool IsSyncGPU()
 {
-	return bSyncGPU;
+	return m_sync_GPU;
 }
 
 bool IsNetPlayRecording()
@@ -454,7 +454,7 @@ bool BeginRecordingInput(int controllers)
 
 		// This is only done here if starting from save state because otherwise we won't have the titleid. Otherwise it's set in WII_IPC_HLE_Device_es.cpp.
 		// TODO: find a way to GetTitleDataPath() from Movie::Init()
-		if (Core::g_CoreStartupParameter.bWii)
+		if (Core::g_CoreStartupParameter.m_wii)
 		{
 			if (File::Exists(Common::GetTitleDataPath(g_titleID) + "banner.bin"))
 				Movie::g_bClearSave = false;
@@ -689,16 +689,16 @@ void ReadHeader()
 	if (tmpHeader.bSaveConfig)
 	{
 		bSaveConfig = true;
-		bSkipIdle = tmpHeader.bSkipIdle;
+		m_skip_idle = tmpHeader.m_skip_idle;
 		bDualCore = tmpHeader.bDualCore;
-		bProgressive = tmpHeader.bProgressive;
-		bDSPHLE = tmpHeader.bDSPHLE;
-		bFastDiscSpeed = tmpHeader.bFastDiscSpeed;
-		iCPUCore = tmpHeader.CPUCore;
+		m_progressive = tmpHeader.m_progressive;
+		m_DSPHLE = tmpHeader.m_DSPHLE;
+		m_fast_disc_speed = tmpHeader.m_fast_disc_speed;
+		m_CPU_core = tmpHeader.CPUCore;
 		g_bClearSave = tmpHeader.bClearSave;
 		memcards = tmpHeader.memcards;
 		bongos = tmpHeader.bongos;
-		bSyncGPU = tmpHeader.bSyncGPU;
+		m_sync_GPU = tmpHeader.m_sync_GPU;
 		bNetPlay = tmpHeader.bNetPlay;
 		memcpy(revision, tmpHeader.revision, ArraySize(revision));
 	}
@@ -816,7 +816,7 @@ void LoadInput(const std::string& filename)
 	}
 
 	ChangePads(true);
-	if (Core::g_CoreStartupParameter.bWii)
+	if (Core::g_CoreStartupParameter.m_wii)
 		ChangeWiiPads(true);
 
 	u64 totalSavedBytes = t_record.GetSize() - 256;
@@ -1109,8 +1109,8 @@ void SaveRecording(const std::string& filename)
 
 	header.filetype[0] = 'D'; header.filetype[1] = 'T'; header.filetype[2] = 'M'; header.filetype[3] = 0x1A;
 	strncpy((char *)header.gameID, Core::g_CoreStartupParameter.GetUniqueID().c_str(), 6);
-	header.bWii = Core::g_CoreStartupParameter.bWii;
-	header.numControllers = g_numPads & (Core::g_CoreStartupParameter.bWii ? 0xFF : 0x0F);
+	header.m_wii = Core::g_CoreStartupParameter.m_wii;
+	header.numControllers = g_numPads & (Core::g_CoreStartupParameter.m_wii ? 0xFF : 0x0F);
 
 	header.bFromSaveState = g_bRecordingFromSaveState;
 	header.frameCount = g_totalFrames;
@@ -1120,13 +1120,13 @@ void SaveRecording(const std::string& filename)
 	header.recordingStartTime = g_recordingStartTime;
 
 	header.bSaveConfig = true;
-	header.bSkipIdle = bSkipIdle;
+	header.m_skip_idle = m_skip_idle;
 	header.bDualCore = bDualCore;
-	header.bProgressive = bProgressive;
-	header.bDSPHLE = bDSPHLE;
-	header.bFastDiscSpeed = bFastDiscSpeed;
+	header.m_progressive = m_progressive;
+	header.m_DSPHLE = m_DSPHLE;
+	header.m_fast_disc_speed = m_fast_disc_speed;
 	strncpy((char *)header.videoBackend, videoBackend.c_str(),ArraySize(header.videoBackend));
-	header.CPUCore = iCPUCore;
+	header.CPUCore = m_CPU_core;
 	header.bEFBAccessEnable = g_ActiveConfig.bEFBAccessEnable;
 	header.bEFBCopyEnable = g_ActiveConfig.bEFBCopyEnable;
 	header.bCopyEFBToTexture = g_ActiveConfig.bCopyEFBToTexture;
@@ -1136,7 +1136,7 @@ void SaveRecording(const std::string& filename)
 	header.bUseRealXFB = g_ActiveConfig.bUseRealXFB;
 	header.memcards = memcards;
 	header.bClearSave = g_bClearSave;
-	header.bSyncGPU = bSyncGPU;
+	header.m_sync_GPU = m_sync_GPU;
 	header.bNetPlay = bNetPlay;
 	strncpy((char *)header.discChange, g_discChange.c_str(),ArraySize(header.discChange));
 	strncpy((char *)header.author, author.c_str(),ArraySize(header.author));
@@ -1192,16 +1192,16 @@ void SetGraphicsConfig()
 void GetSettings()
 {
 	bSaveConfig = true;
-	bSkipIdle = SConfig::GetInstance().m_LocalCoreStartupParameter.bSkipIdle;
-	bDualCore = SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread;
-	bProgressive = SConfig::GetInstance().m_LocalCoreStartupParameter.bProgressive;
-	bDSPHLE = SConfig::GetInstance().m_LocalCoreStartupParameter.bDSPHLE;
-	bFastDiscSpeed = SConfig::GetInstance().m_LocalCoreStartupParameter.bFastDiscSpeed;
+	m_skip_idle = SConfig::GetInstance().m_LocalCoreStartupParameter.m_skip_idle;
+	bDualCore = SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_thread;
+	m_progressive = SConfig::GetInstance().m_LocalCoreStartupParameter.m_progressive;
+	m_DSPHLE = SConfig::GetInstance().m_LocalCoreStartupParameter.m_DSPHLE;
+	m_fast_disc_speed = SConfig::GetInstance().m_LocalCoreStartupParameter.m_fast_disc_speed;
 	videoBackend = g_video_backend->GetName();
-	bSyncGPU = SConfig::GetInstance().m_LocalCoreStartupParameter.bSyncGPU;
-	iCPUCore = SConfig::GetInstance().m_LocalCoreStartupParameter.iCPUCore;
+	m_sync_GPU = SConfig::GetInstance().m_LocalCoreStartupParameter.m_sync_GPU;
+	m_CPU_core = SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_core;
 	bNetPlay = NetPlay::IsNetPlayRunning();
-	if (!Core::g_CoreStartupParameter.bWii)
+	if (!Core::g_CoreStartupParameter.m_wii)
 		g_bClearSave = !File::Exists(SConfig::GetInstance().m_strMemoryCardA);
 	memcards |= (SConfig::GetInstance().m_EXIDevice[0] == EXIDEVICE_MEMORYCARD) << 0;
 	memcards |= (SConfig::GetInstance().m_EXIDevice[1] == EXIDEVICE_MEMORYCARD) << 1;
@@ -1211,7 +1211,7 @@ void GetSettings()
 		sscanf(&scm_rev_git_str[2 * i], "%02x", &tmp);
 		revision[i] = tmp;
 	}
-	if (!bDSPHLE)
+	if (!m_DSPHLE)
 	{
 		std::string irom_file = File::GetUserPath(D_GCUSER_IDX) + DSP_IROM;
 		std::string coef_file = File::GetUserPath(D_GCUSER_IDX) + DSP_COEF;
@@ -1259,7 +1259,7 @@ void CheckMD5()
 
 	unsigned char gameMD5[16];
 	char game[255];
-	memcpy(game, SConfig::GetInstance().m_LocalCoreStartupParameter.m_strFilename.c_str(), SConfig::GetInstance().m_LocalCoreStartupParameter.m_strFilename.size());
+	memcpy(game, SConfig::GetInstance().m_LocalCoreStartupParameter.m_filename.c_str(), SConfig::GetInstance().m_LocalCoreStartupParameter.m_filename.size());
 	md5_file(game, gameMD5);
 
 	if (memcmp(gameMD5,MD5,16) == 0)
@@ -1273,7 +1273,7 @@ void GetMD5()
 	Core::DisplayMessage("Calculating checksum of game file...", 2000);
 	memset(MD5, 0, sizeof(MD5));
 	char game[255];
-	memcpy(game, SConfig::GetInstance().m_LocalCoreStartupParameter.m_strFilename.c_str(),SConfig::GetInstance().m_LocalCoreStartupParameter.m_strFilename.size());
+	memcpy(game, SConfig::GetInstance().m_LocalCoreStartupParameter.m_filename.c_str(),SConfig::GetInstance().m_LocalCoreStartupParameter.m_filename.size());
 	md5_file(game, MD5);
 	Core::DisplayMessage("Finished calculating checksum.", 2000);
 }

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -63,7 +63,7 @@ struct DTMHeader
 	u8 filetype[4];         // Unique Identifier (always "DTM"0x1A)
 
 	u8 gameID[6];           // The Game ID
-	bool bWii;              // Wii game
+	bool m_wii;              // Wii game
 
 	u8  numControllers;     // The number of connected controllers (1-4)
 
@@ -82,11 +82,11 @@ struct DTMHeader
 	u64 recordingStartTime; // seconds since 1970 that recording started (used for RTC)
 
 	bool bSaveConfig;       // Loads the settings below on startup if true
-	bool bSkipIdle;
+	bool m_skip_idle;
 	bool bDualCore;
-	bool bProgressive;
-	bool bDSPHLE;
-	bool bFastDiscSpeed;
+	bool m_progressive;
+	bool m_DSPHLE;
+	bool m_fast_disc_speed;
 	u8  CPUCore;            // 0 = interpreter, 1 = JIT, 2 = JITIL
 	bool bEFBAccessEnable;
 	bool bEFBCopyEnable;
@@ -98,7 +98,7 @@ struct DTMHeader
 	u8   memcards;
 	bool bClearSave;        // Create a new memory card when playing back a movie if true
 	u8 bongos;
-	bool bSyncGPU;
+	bool m_sync_GPU;
 	bool bNetPlay;
 	u8 reserved[13];        // Padding for any new config options
 	u8 discChange[40];      // Name of iso file to switch to, for two disc games.

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -506,7 +506,7 @@ bool NetPlayClient::StartGame(const std::string &path)
 
 	UpdateDevices();
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 	{
 		for (unsigned int i = 0; i < 4; ++i)
 			WiimoteReal::ChangeWiimoteSource(i, m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -221,7 +221,7 @@ void Interpreter::Run()
 	while (!PowerPC::GetState())
 	{
 		//we have to check exceptions at branches apparently (or maybe just rfi?)
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableDebugging)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_enable_debugging)
 		{
 			#ifdef SHOW_HISTORY
 				PCBlockVec.push_back(PC);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -375,7 +375,7 @@ void Interpreter::dcbtst(UGeckoInstruction _inst)
 void Interpreter::dcbz(UGeckoInstruction _inst)
 {
 	// HACK but works... we think
-	if (!Core::g_CoreStartupParameter.bDCBZOFF)
+	if (!Core::g_CoreStartupParameter.m_DCBZOFF)
 		Memory::Memset(Helper_Get_EA_X(_inst) & (~31), 0, 32);
 	if (!JitInterface::GetCore())
 		PowerPC::CheckExceptions();

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -150,25 +150,25 @@ void Jit64::Init()
 	   where this cause problems, so I'm enabling this by default, since I seem to get perhaps as much as 20% more
 	   fps with this option enabled. If you suspect that this option cause problems you can also disable it from the
 	   debugging window. */
-	if (Core::g_CoreStartupParameter.bEnableDebugging)
+	if (Core::g_CoreStartupParameter.m_enable_debugging)
 	{
 		jo.enableBlocklink = false;
-		Core::g_CoreStartupParameter.bSkipIdle = false;
+		Core::g_CoreStartupParameter.m_skip_idle = false;
 	}
 	else
 	{
-		if (!Core::g_CoreStartupParameter.bJITBlockLinking)
+		if (!Core::g_CoreStartupParameter.m_JIT_block_linking)
 		{
 			jo.enableBlocklink = false;
 		}
 		else
-			jo.enableBlocklink = !Core::g_CoreStartupParameter.bMMU;
+			jo.enableBlocklink = !Core::g_CoreStartupParameter.m_MMU;
 	}
-	jo.fpAccurateFcmp = Core::g_CoreStartupParameter.bEnableFPRF;
+	jo.fpAccurateFcmp = Core::g_CoreStartupParameter.m_enable_FPRF;
 	jo.optimizeGatherPipe = true;
 	jo.fastInterrupts = false;
 	jo.accurateSinglePrecision = true;
-	js.memcheck = Core::g_CoreStartupParameter.bMMU;
+	js.memcheck = Core::g_CoreStartupParameter.m_MMU;
 
 	gpr.SetEmitter(this);
 	fpr.SetEmitter(this);
@@ -378,7 +378,7 @@ void Jit64::Trace()
 
 void STACKALIGN Jit64::Jit(u32 em_address)
 {
-	if (GetSpaceLeft() < 0x10000 || blocks.IsFull() || Core::g_CoreStartupParameter.bJITNoBlockCache)
+	if (GetSpaceLeft() < 0x10000 || blocks.IsFull() || Core::g_CoreStartupParameter.m_JIT_no_block_cache)
 	{
 		ClearCache();
 	}
@@ -392,7 +392,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 {
 	int blockSize = code_buf->GetSize();
 
-	if (Core::g_CoreStartupParameter.bEnableDebugging)
+	if (Core::g_CoreStartupParameter.m_enable_debugging)
 	{
 		// Comment out the following to disable breakpoints (speed-up)
 		if (!Profiler::g_ProfileBlocks)
@@ -458,7 +458,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	fpr.Start();
 
 	js.downcountAmount = 0;
-	if (!Core::g_CoreStartupParameter.bEnableDebugging)
+	if (!Core::g_CoreStartupParameter.m_enable_debugging)
 		js.downcountAmount += PatchEngine::GetSpeedhackCycles(code_block.m_address);
 
 	js.skipnext = false;
@@ -571,7 +571,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 				SetJumpTarget(clearInt);
 			}
 
-			if (Core::g_CoreStartupParameter.bEnableDebugging && breakpoints.IsAddressBreakPoint(ops[i].address) && GetState() != CPU_STEPPING)
+			if (Core::g_CoreStartupParameter.m_enable_debugging && breakpoints.IsAddressBreakPoint(ops[i].address) && GetState() != CPU_STEPPING)
 			{
 				gpr.Flush();
 				fpr.Flush();

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -51,7 +51,7 @@ void Jit64AsmRoutineManager::Generate()
 			// IMPORTANT - We jump on negative, not carry!!!
 			FixupBranch bail = J_CC(CC_BE, true);
 
-			if (Core::g_CoreStartupParameter.bEnableDebugging)
+			if (Core::g_CoreStartupParameter.m_enable_debugging)
 			{
 				TEST(32, M((void*)PowerPC::GetStatePtr()), Imm32(PowerPC::CPU_STEPPING));
 				FixupBranch notStepping = J_CC(CC_Z);
@@ -74,11 +74,11 @@ void Jit64AsmRoutineManager::Generate()
 			FixupBranch no_mem;
 			FixupBranch exit_mem;
 			FixupBranch exit_vmem;
-			if (Core::g_CoreStartupParameter.bWii)
+			if (Core::g_CoreStartupParameter.m_wii)
 				mask = JIT_ICACHE_EXRAM_BIT;
-			if (Core::g_CoreStartupParameter.bMMU || Core::g_CoreStartupParameter.bTLBHack)
+			if (Core::g_CoreStartupParameter.m_MMU || Core::g_CoreStartupParameter.m_TLB_hack)
 				mask |= JIT_ICACHE_VMEM_BIT;
-			if (Core::g_CoreStartupParameter.bWii || Core::g_CoreStartupParameter.bMMU || Core::g_CoreStartupParameter.bTLBHack)
+			if (Core::g_CoreStartupParameter.m_wii || Core::g_CoreStartupParameter.m_MMU || Core::g_CoreStartupParameter.m_TLB_hack)
 			{
 				TEST(32, R(EAX), Imm32(mask));
 				no_mem = J_CC(CC_NZ);
@@ -87,12 +87,12 @@ void Jit64AsmRoutineManager::Generate()
 			MOV(64, R(RSI), Imm64((u64)jit->GetBlockCache()->iCache));
 			MOV(32, R(EAX), MComplex(RSI, EAX, SCALE_1, 0));
 
-			if (Core::g_CoreStartupParameter.bWii || Core::g_CoreStartupParameter.bMMU || Core::g_CoreStartupParameter.bTLBHack)
+			if (Core::g_CoreStartupParameter.m_wii || Core::g_CoreStartupParameter.m_MMU || Core::g_CoreStartupParameter.m_TLB_hack)
 			{
 				exit_mem = J();
 				SetJumpTarget(no_mem);
 			}
-			if (Core::g_CoreStartupParameter.bMMU || Core::g_CoreStartupParameter.bTLBHack)
+			if (Core::g_CoreStartupParameter.m_MMU || Core::g_CoreStartupParameter.m_TLB_hack)
 			{
 				TEST(32, R(EAX), Imm32(JIT_ICACHE_VMEM_BIT));
 				FixupBranch no_vmem = J_CC(CC_Z);
@@ -100,10 +100,10 @@ void Jit64AsmRoutineManager::Generate()
 				MOV(64, R(RSI), Imm64((u64)jit->GetBlockCache()->iCacheVMEM));
 				MOV(32, R(EAX), MComplex(RSI, EAX, SCALE_1, 0));
 
-				if (Core::g_CoreStartupParameter.bWii) exit_vmem = J();
+				if (Core::g_CoreStartupParameter.m_wii) exit_vmem = J();
 				SetJumpTarget(no_vmem);
 			}
-			if (Core::g_CoreStartupParameter.bWii)
+			if (Core::g_CoreStartupParameter.m_wii)
 			{
 				TEST(32, R(EAX), Imm32(JIT_ICACHE_EXRAM_BIT));
 				FixupBranch no_exram = J_CC(CC_Z);
@@ -113,9 +113,9 @@ void Jit64AsmRoutineManager::Generate()
 
 				SetJumpTarget(no_exram);
 			}
-			if (Core::g_CoreStartupParameter.bWii || Core::g_CoreStartupParameter.bMMU || Core::g_CoreStartupParameter.bTLBHack)
+			if (Core::g_CoreStartupParameter.m_wii || Core::g_CoreStartupParameter.m_MMU || Core::g_CoreStartupParameter.m_TLB_hack)
 				SetJumpTarget(exit_mem);
-			if (Core::g_CoreStartupParameter.bWii && (Core::g_CoreStartupParameter.bMMU || Core::g_CoreStartupParameter.bTLBHack))
+			if (Core::g_CoreStartupParameter.m_wii && (Core::g_CoreStartupParameter.m_MMU || Core::g_CoreStartupParameter.m_TLB_hack))
 				SetJumpTarget(exit_vmem);
 
 			TEST(32, R(EAX), R(EAX));

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -24,7 +24,7 @@ using namespace Gen;
 void Jit64::sc(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITBranchOff);
+	JITDISABLE(m_JIT_branch_off);
 
 	gpr.Flush();
 	fpr.Flush();
@@ -37,7 +37,7 @@ void Jit64::sc(UGeckoInstruction inst)
 void Jit64::rfi(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITBranchOff);
+	JITDISABLE(m_JIT_branch_off);
 
 	gpr.Flush();
 	fpr.Flush();
@@ -57,7 +57,7 @@ void Jit64::rfi(UGeckoInstruction inst)
 void Jit64::bx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITBranchOff);
+	JITDISABLE(m_JIT_branch_off);
 
 	// We must always process the following sentence
 	// even if the blocks are merged by PPCAnalyst::Flatten().
@@ -100,7 +100,7 @@ void Jit64::bx(UGeckoInstruction inst)
 void Jit64::bcx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITBranchOff);
+	JITDISABLE(m_JIT_branch_off);
 
 	// USES_CR
 
@@ -150,7 +150,7 @@ void Jit64::bcx(UGeckoInstruction inst)
 void Jit64::bcctrx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITBranchOff);
+	JITDISABLE(m_JIT_branch_off);
 
 	// bcctrx doesn't decrement and/or test CTR
 	_dbg_assert_msg_(POWERPC, inst.BO_2 & BO_DONT_DECREMENT_FLAG, "bcctrx with decrement and test CTR option is invalid!");
@@ -198,7 +198,7 @@ void Jit64::bcctrx(UGeckoInstruction inst)
 void Jit64::bclrx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITBranchOff);
+	JITDISABLE(m_JIT_branch_off);
 
 	FixupBranch pCTRDontBranch;
 	if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -76,11 +76,11 @@ void Jit64::fp_tri_op(int d, int a, int b, bool reversible, bool single, void (X
 void Jit64::fp_arith(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	FALLBACK_IF(inst.Rc);
 
 	// Only the interpreter has "proper" support for (some) FP flags
-	FALLBACK_IF(inst.SUBOP5 == 25 && Core::g_CoreStartupParameter.bEnableFPRF);
+	FALLBACK_IF(inst.SUBOP5 == 25 && Core::g_CoreStartupParameter.m_enable_FPRF);
 
 	bool single = inst.OPCD == 59;
 	switch (inst.SUBOP5)
@@ -97,11 +97,11 @@ void Jit64::fp_arith(UGeckoInstruction inst)
 void Jit64::fmaddXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	FALLBACK_IF(inst.Rc);
 
 	// Only the interpreter has "proper" support for (some) FP flags
-	FALLBACK_IF(inst.SUBOP5 == 29 && Core::g_CoreStartupParameter.bEnableFPRF);
+	FALLBACK_IF(inst.SUBOP5 == 29 && Core::g_CoreStartupParameter.m_enable_FPRF);
 
 	bool single_precision = inst.OPCD == 59;
 
@@ -151,7 +151,7 @@ void Jit64::fmaddXX(UGeckoInstruction inst)
 void Jit64::fsign(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	FALLBACK_IF(inst.Rc);
 
 	int d = inst.FD;
@@ -180,7 +180,7 @@ void Jit64::fsign(UGeckoInstruction inst)
 void Jit64::fmrx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	FALLBACK_IF(inst.Rc);
 
 	int d = inst.FD;
@@ -206,7 +206,7 @@ void Jit64::fmrx(UGeckoInstruction inst)
 void Jit64::fcmpx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	FALLBACK_IF(jo.fpAccurateFcmp);
 
 	//bool ordered = inst.SUBOP10 == 32;
@@ -271,7 +271,7 @@ void Jit64::fcmpx(UGeckoInstruction inst)
 void Jit64::fctiwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	FALLBACK_IF(inst.Rc);
 
 	int d = inst.RD;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -192,7 +192,7 @@ void Jit64::regimmop(int d, int a, bool binary, u32 value, Operation doop, void 
 void Jit64::reg_imm(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	u32 d = inst.RD, a = inst.RA, s = inst.RS;
 	switch (inst.OPCD)
 	{
@@ -218,7 +218,7 @@ void Jit64::reg_imm(UGeckoInstruction inst)
 		if (a == 0) // lis
 		{
 			// Merge with next instruction if loading a 32-bits immediate value (lis + addi, lis + ori)
-			if (!js.isLastInstruction && !Core::g_CoreStartupParameter.bEnableDebugging)
+			if (!js.isLastInstruction && !Core::g_CoreStartupParameter.m_enable_debugging)
 			{
 				if ((js.next_inst.OPCD == 14) && (js.next_inst.RD == d) && (js.next_inst.RA == d)) // addi
 				{
@@ -265,7 +265,7 @@ void Jit64::cmpXX(UGeckoInstruction inst)
 {
 	// USES_CR
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA;
 	int b = inst.RB;
 	int crf = inst.CRFD;
@@ -500,7 +500,7 @@ void Jit64::cmpXX(UGeckoInstruction inst)
 void Jit64::boolX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, s = inst.RS, b = inst.RB;
 	_dbg_assert_msg_(DYNA_REC, inst.OPCD == 31, "Invalid boolX");
 
@@ -701,7 +701,7 @@ void Jit64::boolX(UGeckoInstruction inst)
 void Jit64::extsbx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, s = inst.RS;
 
 	if (gpr.R(s).IsImm())
@@ -729,7 +729,7 @@ void Jit64::extsbx(UGeckoInstruction inst)
 void Jit64::extshx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, s = inst.RS;
 
 	if (gpr.R(s).IsImm())
@@ -757,7 +757,7 @@ void Jit64::extshx(UGeckoInstruction inst)
 void Jit64::subfic(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, d = inst.RD;
 	gpr.Lock(a, d);
 	gpr.BindToRegister(d, a == d, true);
@@ -808,7 +808,7 @@ void Jit64::subfic(UGeckoInstruction inst)
 void Jit64::subfcx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START;
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 	gpr.Lock(a, b, d);
 	gpr.BindToRegister(d, (d == a || d == b), true);
@@ -839,7 +839,7 @@ void Jit64::subfcx(UGeckoInstruction inst)
 void Jit64::subfex(UGeckoInstruction inst)
 {
 	INSTRUCTION_START;
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 	gpr.Lock(a, b, d);
 	gpr.BindToRegister(d, (d == a || d == b), true);
@@ -876,7 +876,7 @@ void Jit64::subfmex(UGeckoInstruction inst)
 {
 	// USES_XER
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, d = inst.RD;
 	gpr.Lock(a, d);
 	gpr.BindToRegister(d, d == a);
@@ -898,7 +898,7 @@ void Jit64::subfzex(UGeckoInstruction inst)
 {
 	// USES_XER
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, d = inst.RD;
 
 	gpr.Lock(a, d);
@@ -921,7 +921,7 @@ void Jit64::subfzex(UGeckoInstruction inst)
 void Jit64::subfx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 
 	if (gpr.R(a).IsImm() && gpr.R(b).IsImm())
@@ -967,7 +967,7 @@ void Jit64::subfx(UGeckoInstruction inst)
 void Jit64::mulli(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, d = inst.RD;
 	u32 imm = inst.SIMM_16;
 
@@ -1014,7 +1014,7 @@ void Jit64::mulli(UGeckoInstruction inst)
 void Jit64::mullwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 
 	if (gpr.R(a).IsImm() && gpr.R(b).IsImm())
@@ -1090,7 +1090,7 @@ void Jit64::mullwx(UGeckoInstruction inst)
 void Jit64::mulhwux(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 
 	if (gpr.R(a).IsImm() && gpr.R(b).IsImm())
@@ -1121,7 +1121,7 @@ void Jit64::mulhwux(UGeckoInstruction inst)
 void Jit64::divwux(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 
 	if (gpr.R(a).IsImm() && gpr.R(b).IsImm())
@@ -1252,7 +1252,7 @@ void Jit64::divwux(UGeckoInstruction inst)
 void Jit64::divwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 
 	if (gpr.R(a).IsImm() && gpr.R(b).IsImm())
@@ -1326,7 +1326,7 @@ void Jit64::divwx(UGeckoInstruction inst)
 void Jit64::addx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 
 	if (gpr.R(a).IsImm() && gpr.R(b).IsImm())
@@ -1379,7 +1379,7 @@ void Jit64::addex(UGeckoInstruction inst)
 {
 	// USES_XER
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 
 	if ((d == a) || (d == b))
@@ -1412,7 +1412,7 @@ void Jit64::addex(UGeckoInstruction inst)
 void Jit64::addcx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 
 	if ((d == a) || (d == b))
@@ -1445,7 +1445,7 @@ void Jit64::addmex(UGeckoInstruction inst)
 {
 	// USES_XER
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, d = inst.RD;
 
 	if (d == a)
@@ -1479,7 +1479,7 @@ void Jit64::addzex(UGeckoInstruction inst)
 {
 	// USES_XER
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, d = inst.RD;
 
 	if (d == a)
@@ -1512,7 +1512,7 @@ void Jit64::addzex(UGeckoInstruction inst)
 void Jit64::rlwinmx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA;
 	int s = inst.RS;
 	if (gpr.R(s).IsImm())
@@ -1573,7 +1573,7 @@ void Jit64::rlwinmx(UGeckoInstruction inst)
 void Jit64::rlwimix(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA;
 	int s = inst.RS;
 
@@ -1655,7 +1655,7 @@ void Jit64::rlwimix(UGeckoInstruction inst)
 void Jit64::rlwnmx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA, b = inst.RB, s = inst.RS;
 
 	u32 mask = Helper_Mask(inst.MB, inst.ME);
@@ -1689,7 +1689,7 @@ void Jit64::rlwnmx(UGeckoInstruction inst)
 void Jit64::negx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA;
 	int d = inst.RD;
 
@@ -1723,7 +1723,7 @@ void Jit64::negx(UGeckoInstruction inst)
 void Jit64::srwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA;
 	int b = inst.RB;
 	int s = inst.RS;
@@ -1757,7 +1757,7 @@ void Jit64::srwx(UGeckoInstruction inst)
 void Jit64::slwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA;
 	int b = inst.RB;
 	int s = inst.RS;
@@ -1800,7 +1800,7 @@ void Jit64::srawx(UGeckoInstruction inst)
 {
 	// USES_XER
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA;
 	int b = inst.RB;
 	int s = inst.RS;
@@ -1829,7 +1829,7 @@ void Jit64::srawx(UGeckoInstruction inst)
 void Jit64::srawix(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA;
 	int s = inst.RS;
 	int amount = inst.SH;
@@ -1879,7 +1879,7 @@ void Jit64::srawix(UGeckoInstruction inst)
 void Jit64::cntlzwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int a = inst.RA;
 	int s = inst.RS;
 
@@ -1915,7 +1915,7 @@ void Jit64::cntlzwx(UGeckoInstruction inst)
 void Jit64::twx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 
 	s32 a = inst.RA;
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -16,14 +16,14 @@ using namespace Gen;
 void Jit64::lXXx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 
 	int a = inst.RA, b = inst.RB, d = inst.RD;
 
 	// Skip disabled JIT instructions
-	FALLBACK_IF(Core::g_CoreStartupParameter.bJITLoadStorelbzxOff && (inst.OPCD == 31) && (inst.SUBOP10 == 87));
-	FALLBACK_IF(Core::g_CoreStartupParameter.bJITLoadStorelXzOff && ((inst.OPCD == 34) || (inst.OPCD == 40) || (inst.OPCD == 32)));
-	FALLBACK_IF(Core::g_CoreStartupParameter.bJITLoadStorelwzOff && (inst.OPCD == 32));
+	FALLBACK_IF(Core::g_CoreStartupParameter.m_JIT_load_store_lbzx_off && (inst.OPCD == 31) && (inst.SUBOP10 == 87));
+	FALLBACK_IF(Core::g_CoreStartupParameter.m_JIT_load_store_lxz_off && ((inst.OPCD == 34) || (inst.OPCD == 40) || (inst.OPCD == 32)));
+	FALLBACK_IF(Core::g_CoreStartupParameter.m_JIT_load_store_lwz_off && (inst.OPCD == 32));
 
 	// Determine memory access size and sign extend
 	int accessSize = 0;
@@ -95,11 +95,11 @@ void Jit64::lXXx(UGeckoInstruction inst)
 	// IMHO those Idles should always be skipped and replaced by a more controllable "native" Idle methode
 	// ... maybe the throttle one already do that :p
 	// if (CommandProcessor::AllowIdleSkipping() && PixelEngine::AllowIdleSkipping())
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bSkipIdle &&
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_skip_idle &&
 		inst.OPCD == 32 &&
 		(inst.hex & 0xFFFF0000) == 0x800D0000 &&
 		(Memory::ReadUnchecked_U32(js.compilerPC + 4) == 0x28000000 ||
-		(SConfig::GetInstance().m_LocalCoreStartupParameter.bWii && Memory::ReadUnchecked_U32(js.compilerPC + 4) == 0x2C000000)) &&
+		(SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii && Memory::ReadUnchecked_U32(js.compilerPC + 4) == 0x2C000000)) &&
 		Memory::ReadUnchecked_U32(js.compilerPC + 8) == 0x4182fff8)
 	{
 		// TODO(LinesPrower):
@@ -216,7 +216,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
 void Jit64::dcbst(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 
 	// If the dcbst instruction is preceded by dcbt, it is flushing a prefetched
 	// memory location.  Do not invalidate the JIT cache in this case as the memory
@@ -229,7 +229,7 @@ void Jit64::dcbst(UGeckoInstruction inst)
 void Jit64::dcbz(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 
 	// FIXME
 	FALLBACK_IF(true);
@@ -246,7 +246,7 @@ void Jit64::dcbz(UGeckoInstruction inst)
 void Jit64::stX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 
 	int s = inst.RS;
 	int a = inst.RA;
@@ -344,7 +344,7 @@ void Jit64::stX(UGeckoInstruction inst)
 void Jit64::stXx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 
 	int a = inst.RA, b = inst.RB, s = inst.RS;
 	FALLBACK_IF(!a || a == s || a == b);
@@ -383,7 +383,7 @@ void Jit64::stXx(UGeckoInstruction inst)
 void Jit64::lmw(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 
 	// TODO: This doesn't handle rollback on DSI correctly
 	gpr.FlushLockX(ECX);
@@ -402,7 +402,7 @@ void Jit64::lmw(UGeckoInstruction inst)
 void Jit64::stmw(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 
 	// TODO: This doesn't handle rollback on DSI correctly
 	gpr.FlushLockX(ECX);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -17,7 +17,7 @@ using namespace Gen;
 void Jit64::lfs(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 
 	int d = inst.RD;
 	int a = inst.RA;
@@ -41,7 +41,7 @@ void Jit64::lfs(UGeckoInstruction inst)
 void Jit64::lfd(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 	FALLBACK_IF(!inst.RA);
 
 	int d = inst.RD;
@@ -66,7 +66,7 @@ void Jit64::lfd(UGeckoInstruction inst)
 void Jit64::stfd(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 	FALLBACK_IF(!inst.RA);
 
 	int s = inst.RS;
@@ -89,7 +89,7 @@ void Jit64::stfd(UGeckoInstruction inst)
 void Jit64::stfs(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 	FALLBACK_IF(!inst.RA);
 
 	int s = inst.RS;
@@ -108,7 +108,7 @@ void Jit64::stfs(UGeckoInstruction inst)
 void Jit64::stfsx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 
 	gpr.FlushLockX(ABI_PARAM1);
 	MOV(32, R(ABI_PARAM1), gpr.R(inst.RB));
@@ -127,7 +127,7 @@ void Jit64::stfsx(UGeckoInstruction inst)
 void Jit64::lfsx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 
 	MOV(32, R(EAX), gpr.R(inst.RB));
 	if (inst.RA)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -19,7 +19,7 @@ using namespace Gen;
 void Jit64::psq_st(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStorePairedOff);
+	JITDISABLE(m_JIT_load_store_paired_off);
 	FALLBACK_IF(js.memcheck || !inst.RA);
 
 	bool update = inst.OPCD == 61;
@@ -64,7 +64,7 @@ void Jit64::psq_st(UGeckoInstruction inst)
 void Jit64::psq_l(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStorePairedOff);
+	JITDISABLE(m_JIT_load_store_paired_off);
 	FALLBACK_IF(js.memcheck || !inst.RA);
 
 	bool update = inst.OPCD == 57;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -22,7 +22,7 @@ static const u64 GC_ALIGNED16(psAbsMask[2])  = {0x7FFFFFFFFFFFFFFFULL, 0x7FFFFFF
 void Jit64::ps_mr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	int d = inst.FD;
@@ -40,7 +40,7 @@ void Jit64::ps_sel(UGeckoInstruction inst)
 	// but we need -0 = +0
 
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	int d = inst.FD;
@@ -65,7 +65,7 @@ void Jit64::ps_sel(UGeckoInstruction inst)
 void Jit64::ps_sign(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	int d = inst.FD;
@@ -151,7 +151,7 @@ void Jit64::tri_op(int d, int a, int b, bool reversible, void (XEmitter::*op)(X6
 void Jit64::ps_arith(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	switch (inst.SUBOP5)
@@ -168,7 +168,7 @@ void Jit64::ps_arith(UGeckoInstruction inst)
 void Jit64::ps_sum(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	int d = inst.FD;
@@ -208,7 +208,7 @@ void Jit64::ps_sum(UGeckoInstruction inst)
 void Jit64::ps_muls(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	int d = inst.FD;
@@ -246,7 +246,7 @@ void Jit64::ps_muls(UGeckoInstruction inst)
 void Jit64::ps_mergeXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	int d = inst.FD;
@@ -282,7 +282,7 @@ void Jit64::ps_mergeXX(UGeckoInstruction inst)
 void Jit64::ps_maddXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	int a = inst.FA;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -109,7 +109,7 @@ FixupBranch Jit64::JumpIfCRFieldBit(int field, int bit, bool jump_if_set)
 void Jit64::mtspr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 	u32 iIndex = (inst.SPRU << 5) | (inst.SPRL & 0x1F);
 	int d = inst.RD;
 
@@ -161,7 +161,7 @@ void Jit64::mtspr(UGeckoInstruction inst)
 void Jit64::mfspr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 	u32 iIndex = (inst.SPRU << 5) | (inst.SPRL & 0x1F);
 	int d = inst.RD;
 	switch (iIndex)
@@ -188,7 +188,7 @@ void Jit64::mtmsr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	// Don't interpret this, if we do we get thrown out
-	//JITDISABLE(bJITSystemRegistersOff);
+	//JITDISABLE(m_JIT_system_registers_off);
 	if (!gpr.R(inst.RS).IsImm())
 	{
 		gpr.Lock(inst.RS);
@@ -227,7 +227,7 @@ void Jit64::mtmsr(UGeckoInstruction inst)
 void Jit64::mfmsr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 	//Privileged?
 	gpr.Lock(inst.RD);
 	gpr.BindToRegister(inst.RD, false, true);
@@ -238,14 +238,14 @@ void Jit64::mfmsr(UGeckoInstruction inst)
 void Jit64::mftb(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 	mfspr(inst);
 }
 
 void Jit64::mfcr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 	// USES_CR
 	int d = inst.RD;
 	gpr.BindToRegister(d, false, true);
@@ -296,7 +296,7 @@ static const u64 m_crTable[16] =
 void Jit64::mtcrf(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 
 	// USES_CR
 	u32 crm = inst.CRM;
@@ -347,7 +347,7 @@ void Jit64::mtcrf(UGeckoInstruction inst)
 void Jit64::mcrf(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 
 	// USES_CR
 	if (inst.CRFS != inst.CRFD)
@@ -360,7 +360,7 @@ void Jit64::mcrf(UGeckoInstruction inst)
 void Jit64::mcrxr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 
 	// USES_CR
 
@@ -378,7 +378,7 @@ void Jit64::mcrxr(UGeckoInstruction inst)
 void Jit64::crXXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 	_dbg_assert_msg_(DYNA_REC, inst.OPCD == 19, "Invalid crXXX");
 
 	// TODO(delroth): Potential optimizations could be applied here. For

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -238,25 +238,25 @@ void JitIL::Init()
 {
 	jo.optimizeStack = true;
 
-	if (Core::g_CoreStartupParameter.bEnableDebugging)
+	if (Core::g_CoreStartupParameter.m_enable_debugging)
 	{
 		jo.enableBlocklink = false;
-		Core::g_CoreStartupParameter.bSkipIdle = false;
+		Core::g_CoreStartupParameter.m_skip_idle = false;
 	}
 	else
 	{
-		if (!Core::g_CoreStartupParameter.bJITBlockLinking)
+		if (!Core::g_CoreStartupParameter.m_JIT_block_linking)
 			jo.enableBlocklink = false;
 		else
 			// Speed boost, but not 100% safe
-			jo.enableBlocklink = !Core::g_CoreStartupParameter.bMMU;
+			jo.enableBlocklink = !Core::g_CoreStartupParameter.m_MMU;
 	}
 
 	jo.fpAccurateFcmp = false;
 	jo.optimizeGatherPipe = true;
 	jo.fastInterrupts = false;
 	jo.accurateSinglePrecision = false;
-	js.memcheck = Core::g_CoreStartupParameter.bMMU;
+	js.memcheck = Core::g_CoreStartupParameter.m_MMU;
 
 	trampolines.Init();
 	AllocCodeSpace(CODE_SIZE);
@@ -268,7 +268,7 @@ void JitIL::Init()
 	code_block.m_gpa = &js.gpa;
 	code_block.m_fpa = &js.fpa;
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILTimeProfiling) {
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_time_profiling) {
 		JitILProfiler::Init();
 	}
 }
@@ -282,7 +282,7 @@ void JitIL::ClearCache()
 
 void JitIL::Shutdown()
 {
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILTimeProfiling) {
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_time_profiling) {
 		JitILProfiler::Shutdown();
 	}
 
@@ -376,7 +376,7 @@ void JitIL::Cleanup()
 void JitIL::WriteExit(u32 destination)
 {
 	Cleanup();
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILTimeProfiling) {
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_time_profiling) {
 		ABI_CallFunction((void *)JitILProfiler::End);
 	}
 	SUB(32, M(&PowerPC::ppcState.downcount), Imm32(js.downcountAmount));
@@ -408,7 +408,7 @@ void JitIL::WriteExitDestInOpArg(const Gen::OpArg& arg)
 {
 	MOV(32, M(&PC), arg);
 	Cleanup();
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILTimeProfiling) {
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_time_profiling) {
 		ABI_CallFunction((void *)JitILProfiler::End);
 	}
 	SUB(32, M(&PowerPC::ppcState.downcount), Imm32(js.downcountAmount));
@@ -420,7 +420,7 @@ void JitIL::WriteRfiExitDestInOpArg(const Gen::OpArg& arg)
 	MOV(32, M(&PC), arg);
 	MOV(32, M(&NPC), arg);
 	Cleanup();
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILTimeProfiling) {
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_time_profiling) {
 		ABI_CallFunction((void *)JitILProfiler::End);
 	}
 	ABI_CallFunction(reinterpret_cast<void *>(&PowerPC::CheckExceptions));
@@ -431,7 +431,7 @@ void JitIL::WriteRfiExitDestInOpArg(const Gen::OpArg& arg)
 void JitIL::WriteExceptionExit()
 {
 	Cleanup();
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILTimeProfiling) {
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_time_profiling) {
 		ABI_CallFunction((void *)JitILProfiler::End);
 	}
 	MOV(32, R(EAX), M(&PC));
@@ -481,7 +481,7 @@ void JitIL::Trace()
 
 void STACKALIGN JitIL::Jit(u32 em_address)
 {
-	if (GetSpaceLeft() < 0x10000 || blocks.IsFull() || Core::g_CoreStartupParameter.bJITNoBlockCache)
+	if (GetSpaceLeft() < 0x10000 || blocks.IsFull() || Core::g_CoreStartupParameter.m_JIT_no_block_cache)
 	{
 		ClearCache();
 	}
@@ -494,7 +494,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 {
 	int blockSize = code_buf->GetSize();
 
-	if (Core::g_CoreStartupParameter.bEnableDebugging)
+	if (Core::g_CoreStartupParameter.m_enable_debugging)
 	{
 		// Comment out the following to disable breakpoints (speed-up)
 		if (!Profiler::g_ProfileBlocks)
@@ -553,8 +553,8 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	js.rewriteStart = (u8*)GetCodePtr();
 
 	u64 codeHash = -1;
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILTimeProfiling ||
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILOutputIR)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_time_profiling ||
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_output_IR)
 	{
 		// For profiling and IR Writer
 		for (u32 i = 0; i < code_block.m_num_instructions; i++)
@@ -565,7 +565,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 		}
 	}
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILTimeProfiling)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_time_profiling)
 	{
 		JitILProfiler::Block& block = JitILProfiler::Add(codeHash);
 		ABI_CallFunctionC((void *)JitILProfiler::Begin, block.index);
@@ -576,7 +576,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	ibuild.Reset();
 
 	js.downcountAmount = 0;
-	if (!Core::g_CoreStartupParameter.bEnableDebugging)
+	if (!Core::g_CoreStartupParameter.m_enable_debugging)
 			js.downcountAmount += PatchEngine::GetSpeedhackCycles(code_block.m_address);
 
 	// Translate instructions
@@ -633,7 +633,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 				ibuild.EmitExtExceptionCheck(ibuild.EmitIntConst(ops[i].address));
 			}
 
-			if (Core::g_CoreStartupParameter.bEnableDebugging && breakpoints.IsAddressBreakPoint(ops[i].address) && GetState() != CPU_STEPPING)
+			if (Core::g_CoreStartupParameter.m_enable_debugging && breakpoints.IsAddressBreakPoint(ops[i].address) && GetState() != CPU_STEPPING)
 			{
 				ibuild.EmitBreakPointCheck(ibuild.EmitIntConst(ops[i].address));
 			}
@@ -682,7 +682,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	LogGeneratedX86(code_block.m_num_instructions, code_buf, normalEntry, b);
 #endif
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILOutputIR)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_JITIL_output_IR)
 	{
 		ibuild.WriteToFile(codeHash);
 	}

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -34,7 +34,7 @@
 
 #define FALLBACK_IF(cond) do { if (cond) { FallBackToInterpreter(inst); return; } } while (0)
 
-#define JITDISABLE(setting) FALLBACK_IF(Core::g_CoreStartupParameter.bJITOff || \
+#define JITDISABLE(setting) FALLBACK_IF(Core::g_CoreStartupParameter.m_JIT_off || \
                                         Core::g_CoreStartupParameter.setting)
 
 class JitBase : public CPUCoreBase

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -249,8 +249,8 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg & opAddress,
 	{
 		registersInUse &= ~(1 << RAX | 1 << reg_value);
 	}
-	if (!Core::g_CoreStartupParameter.bMMU &&
-	    Core::g_CoreStartupParameter.bFastmem &&
+	if (!Core::g_CoreStartupParameter.m_MMU &&
+	    Core::g_CoreStartupParameter.m_fastmem &&
 	    !opAddress.IsImm() &&
 	    !(flags & (SAFE_LOADSTORE_NO_SWAP | SAFE_LOADSTORE_NO_FASTMEM))
 #ifdef ENABLE_MEM_CHECK
@@ -265,13 +265,13 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg & opAddress,
 	else
 	{
 		u32 mem_mask = Memory::ADDR_MASK_HW_ACCESS;
-		if (Core::g_CoreStartupParameter.bMMU || Core::g_CoreStartupParameter.bTLBHack)
+		if (Core::g_CoreStartupParameter.m_MMU || Core::g_CoreStartupParameter.m_TLB_hack)
 		{
 			mem_mask |= Memory::ADDR_MASK_MEM1;
 		}
 
 #ifdef ENABLE_MEM_CHECK
-		if (Core::g_CoreStartupParameter.bEnableDebugging)
+		if (Core::g_CoreStartupParameter.m_enable_debugging)
 		{
 			mem_mask |= Memory::EXRAM_MASK;
 		}
@@ -294,7 +294,7 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg & opAddress,
 			{
 				UnsafeLoadToReg(reg_value, opAddress, accessSize, offset, signExtend);
 			}
-			else if (!Core::g_CoreStartupParameter.bMMU && MMIO::IsMMIOAddress(address) && accessSize != 64)
+			else if (!Core::g_CoreStartupParameter.m_MMU && MMIO::IsMMIOAddress(address) && accessSize != 64)
 			{
 				MMIOLoadToReg(Memory::mmio_mapping, reg_value, registersInUse,
 				              address, accessSize, signExtend);
@@ -403,11 +403,11 @@ u8 *EmuCodeBlock::UnsafeWriteRegToReg(X64Reg reg_value, X64Reg reg_addr, int acc
 void EmuCodeBlock::SafeWriteRegToReg(X64Reg reg_value, X64Reg reg_addr, int accessSize, s32 offset, u32 registersInUse, int flags)
 {
 	registersInUse &= ~(1 << RAX);
-	if (!Core::g_CoreStartupParameter.bMMU &&
-	    Core::g_CoreStartupParameter.bFastmem &&
+	if (!Core::g_CoreStartupParameter.m_MMU &&
+	    Core::g_CoreStartupParameter.m_fastmem &&
 	    !(flags & (SAFE_LOADSTORE_NO_SWAP | SAFE_LOADSTORE_NO_FASTMEM))
 #ifdef ENABLE_MEM_CHECK
-	    && !Core::g_CoreStartupParameter.bEnableDebugging
+	    && !Core::g_CoreStartupParameter.m_enable_debugging
 #endif
 	    )
 	{
@@ -429,13 +429,13 @@ void EmuCodeBlock::SafeWriteRegToReg(X64Reg reg_value, X64Reg reg_addr, int acce
 
 	u32 mem_mask = Memory::ADDR_MASK_HW_ACCESS;
 
-	if (Core::g_CoreStartupParameter.bMMU || Core::g_CoreStartupParameter.bTLBHack)
+	if (Core::g_CoreStartupParameter.m_MMU || Core::g_CoreStartupParameter.m_TLB_hack)
 	{
 		mem_mask |= Memory::ADDR_MASK_MEM1;
 	}
 
 #ifdef ENABLE_MEM_CHECK
-	if (Core::g_CoreStartupParameter.bEnableDebugging)
+	if (Core::g_CoreStartupParameter.m_enable_debugging)
 	{
 		mem_mask |= Memory::EXRAM_MASK;
 	}

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Branch.cpp
@@ -133,11 +133,11 @@ void JitILBase::bcx(UGeckoInstruction inst)
 	else
 		destination = js.compilerPC + SignExt16(inst.BD << 2);
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bSkipIdle &&
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_skip_idle &&
 		inst.hex == 0x4182fff8 &&
 		(Memory::ReadUnchecked_U32(js.compilerPC - 8) & 0xFFFF0000) == 0x800D0000 &&
 		(Memory::ReadUnchecked_U32(js.compilerPC - 4) == 0x28000000 ||
-		(SConfig::GetInstance().m_LocalCoreStartupParameter.bWii && Memory::ReadUnchecked_U32(js.compilerPC - 4) == 0x2C000000))
+		(SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii && Memory::ReadUnchecked_U32(js.compilerPC - 4) == 0x2C000000))
 		)
 	{
 		ibuild.EmitIdleBranch(Test, ibuild.EmitIntConst(destination));

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_FloatingPoint.cpp
@@ -8,11 +8,11 @@
 void JitILBase::fp_arith_s(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	FALLBACK_IF(inst.Rc || (inst.SUBOP5 != 25 && inst.SUBOP5 != 20 && inst.SUBOP5 != 21));
 
 	// Only the interpreter has "proper" support for (some) FP flags
-	FALLBACK_IF(inst.SUBOP5 == 25 && Core::g_CoreStartupParameter.bEnableFPRF);
+	FALLBACK_IF(inst.SUBOP5 == 25 && Core::g_CoreStartupParameter.m_enable_FPRF);
 
 	IREmitter::InstLoc val = ibuild.EmitLoadFReg(inst.FA);
 	switch (inst.SUBOP5)
@@ -42,11 +42,11 @@ void JitILBase::fp_arith_s(UGeckoInstruction inst)
 void JitILBase::fmaddXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	FALLBACK_IF(inst.Rc);
 
 	// Only the interpreter has "proper" support for (some) FP flags
-	FALLBACK_IF(inst.SUBOP5 == 29 && Core::g_CoreStartupParameter.bEnableFPRF);
+	FALLBACK_IF(inst.SUBOP5 == 29 && Core::g_CoreStartupParameter.m_enable_FPRF);
 
 	IREmitter::InstLoc val = ibuild.EmitLoadFReg(inst.FA);
 	val = ibuild.EmitFDMul(val, ibuild.EmitLoadFReg(inst.FC));
@@ -68,7 +68,7 @@ void JitILBase::fmaddXX(UGeckoInstruction inst)
 void JitILBase::fmrx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	FALLBACK_IF(inst.Rc);
 
 	IREmitter::InstLoc val = ibuild.EmitLoadFReg(inst.FB);
@@ -79,7 +79,7 @@ void JitILBase::fmrx(UGeckoInstruction inst)
 void JitILBase::fcmpx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 	IREmitter::InstLoc lhs, rhs, res;
 	lhs = ibuild.EmitLoadFReg(inst.FA);
 	rhs = ibuild.EmitLoadFReg(inst.FB);
@@ -92,7 +92,7 @@ void JitILBase::fcmpx(UGeckoInstruction inst)
 void JitILBase::fsign(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITFloatingPointOff);
+	JITDISABLE(m_JIT_floating_point_off);
 
 	FALLBACK_IF(true);
 

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Integer.cpp
@@ -18,7 +18,7 @@ static void ComputeRC(IREmitter::IRBuilder& ibuild, IREmitter::InstLoc val)
 void JitILBase::reg_imm(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	int d = inst.RD, a = inst.RA, s = inst.RS;
 	IREmitter::InstLoc val, test, c;
 	switch (inst.OPCD)
@@ -85,7 +85,7 @@ void JitILBase::reg_imm(UGeckoInstruction inst)
 void JitILBase::cmpXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc lhs, rhs, res;
 	lhs = ibuild.EmitLoadGReg(inst.RA);
 
@@ -120,7 +120,7 @@ void JitILBase::cmpXX(UGeckoInstruction inst)
 void JitILBase::boolX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 
 	IREmitter::InstLoc a = nullptr;
 	IREmitter::InstLoc s = ibuild.EmitLoadGReg(inst.RS);
@@ -173,7 +173,7 @@ void JitILBase::boolX(UGeckoInstruction inst)
 void JitILBase::extsbx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RS);
 	val = ibuild.EmitSExt8(val);
 	ibuild.EmitStoreGReg(val, inst.RA);
@@ -184,7 +184,7 @@ void JitILBase::extsbx(UGeckoInstruction inst)
 void JitILBase::extshx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RS);
 	val = ibuild.EmitSExt16(val);
 	ibuild.EmitStoreGReg(val, inst.RA);
@@ -195,7 +195,7 @@ void JitILBase::extshx(UGeckoInstruction inst)
 void JitILBase::subfic(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc nota, lhs, val, test;
 	nota = ibuild.EmitXor(ibuild.EmitLoadGReg(inst.RA),
 			      ibuild.EmitIntConst(-1));
@@ -219,7 +219,7 @@ void JitILBase::subfic(UGeckoInstruction inst)
 void JitILBase::subfcx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	if (inst.OE) PanicAlert("OE: subfcx");
 	IREmitter::InstLoc val, test, lhs, rhs;
 	lhs = ibuild.EmitLoadGReg(inst.RB);
@@ -236,7 +236,7 @@ void JitILBase::subfcx(UGeckoInstruction inst)
 void JitILBase::subfex(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	if (inst.OE) PanicAlert("OE: subfex");
 	IREmitter::InstLoc val, test, lhs, rhs, carry;
 	rhs = ibuild.EmitLoadGReg(inst.RA);
@@ -257,7 +257,7 @@ void JitILBase::subfex(UGeckoInstruction inst)
 void JitILBase::subfx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	if (inst.OE) PanicAlert("OE: subfx");
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RB);
 	val = ibuild.EmitSub(val, ibuild.EmitLoadGReg(inst.RA));
@@ -269,7 +269,7 @@ void JitILBase::subfx(UGeckoInstruction inst)
 void JitILBase::mulli(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RA);
 	val = ibuild.EmitMul(val, ibuild.EmitIntConst(inst.SIMM_16));
 	ibuild.EmitStoreGReg(val, inst.RD);
@@ -278,7 +278,7 @@ void JitILBase::mulli(UGeckoInstruction inst)
 void JitILBase::mullwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RB);
 	val = ibuild.EmitMul(ibuild.EmitLoadGReg(inst.RA), val);
 	ibuild.EmitStoreGReg(val, inst.RD);
@@ -289,7 +289,7 @@ void JitILBase::mullwx(UGeckoInstruction inst)
 void JitILBase::mulhwux(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 
 	IREmitter::InstLoc a = ibuild.EmitLoadGReg(inst.RA);
 	IREmitter::InstLoc b = ibuild.EmitLoadGReg(inst.RB);
@@ -335,7 +335,7 @@ void JitILBase::divwux(UGeckoInstruction inst)
 void JitILBase::addx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RB);
 	val = ibuild.EmitAdd(ibuild.EmitLoadGReg(inst.RA), val);
 	ibuild.EmitStoreGReg(val, inst.RD);
@@ -346,7 +346,7 @@ void JitILBase::addx(UGeckoInstruction inst)
 void JitILBase::addzex(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc lhs = ibuild.EmitLoadGReg(inst.RA),
 	                   val, newcarry;
 	val = ibuild.EmitAdd(lhs, ibuild.EmitLoadCarry());
@@ -360,7 +360,7 @@ void JitILBase::addzex(UGeckoInstruction inst)
 void JitILBase::addex(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 
 	IREmitter::InstLoc a = ibuild.EmitLoadGReg(inst.RA);
 	IREmitter::InstLoc b = ibuild.EmitLoadGReg(inst.RB);
@@ -383,7 +383,7 @@ void JitILBase::addex(UGeckoInstruction inst)
 void JitILBase::rlwinmx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	unsigned mask = Helper_Mask(inst.MB, inst.ME);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RS);
 	val = ibuild.EmitRol(val, ibuild.EmitIntConst(inst.SH));
@@ -397,7 +397,7 @@ void JitILBase::rlwinmx(UGeckoInstruction inst)
 void JitILBase::rlwimix(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	unsigned mask = Helper_Mask(inst.MB, inst.ME);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RS);
 	val = ibuild.EmitRol(val, ibuild.EmitIntConst(inst.SH));
@@ -413,7 +413,7 @@ void JitILBase::rlwimix(UGeckoInstruction inst)
 void JitILBase::rlwnmx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	unsigned int mask = Helper_Mask(inst.MB, inst.ME);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RS);
 	val = ibuild.EmitRol(val, ibuild.EmitLoadGReg(inst.RB));
@@ -426,7 +426,7 @@ void JitILBase::rlwnmx(UGeckoInstruction inst)
 void JitILBase::negx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RA);
 	val = ibuild.EmitSub(ibuild.EmitIntConst(0), val);
 	ibuild.EmitStoreGReg(val, inst.RD);
@@ -437,7 +437,7 @@ void JitILBase::negx(UGeckoInstruction inst)
 void JitILBase::srwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RS),
 		           samt = ibuild.EmitLoadGReg(inst.RB),
 		           corr;
@@ -456,7 +456,7 @@ void JitILBase::srwx(UGeckoInstruction inst)
 void JitILBase::slwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RS),
 		           samt = ibuild.EmitLoadGReg(inst.RB),
 		           corr;
@@ -475,7 +475,7 @@ void JitILBase::slwx(UGeckoInstruction inst)
 void JitILBase::srawx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	// FIXME: We can do a lot better on 64-bit
 	IREmitter::InstLoc val, samt, mask, mask2, test;
 	val = ibuild.EmitLoadGReg(inst.RS);
@@ -501,7 +501,7 @@ void JitILBase::srawx(UGeckoInstruction inst)
 void JitILBase::srawix(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	// Shift right by two
 	IREmitter::InstLoc input = ibuild.EmitLoadGReg(inst.RS);
 	IREmitter::InstLoc output = ibuild.EmitSarl(input, ibuild.EmitIntConst(inst.SH));
@@ -520,7 +520,7 @@ void JitILBase::srawix(UGeckoInstruction inst)
 void JitILBase::cntlzwx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
+	JITDISABLE(m_JIT_integer_off);
 	IREmitter::InstLoc val = ibuild.EmitLoadGReg(inst.RS);
 	val = ibuild.EmitCntlzw(val);
 	ibuild.EmitStoreGReg(val, inst.RA);

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStore.cpp
@@ -8,7 +8,7 @@
 void JitILBase::lhax(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitLoadGReg(inst.RB);
@@ -23,7 +23,7 @@ void JitILBase::lhax(UGeckoInstruction inst)
 void JitILBase::lXz(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_16);
@@ -46,7 +46,7 @@ void JitILBase::lXz(UGeckoInstruction inst)
 void JitILBase::lbzu(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 	const IREmitter::InstLoc uAddress = ibuild.EmitAdd(ibuild.EmitLoadGReg(inst.RA), ibuild.EmitIntConst((int)inst.SIMM_16));
 	const IREmitter::InstLoc temp = ibuild.EmitLoad8(uAddress);
 	ibuild.EmitStoreGReg(temp, inst.RD);
@@ -56,7 +56,7 @@ void JitILBase::lbzu(UGeckoInstruction inst)
 void JitILBase::lha(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst((s32)(s16)inst.SIMM_16);
@@ -72,7 +72,7 @@ void JitILBase::lha(UGeckoInstruction inst)
 void JitILBase::lXzx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitLoadGReg(inst.RB);
@@ -98,7 +98,7 @@ void JitILBase::lXzx(UGeckoInstruction inst)
 void JitILBase::dcbst(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 
 	// If the dcbst instruction is preceded by dcbt, it is flushing a prefetched
 	// memory location.  Do not invalidate the JIT cache in this case as the memory
@@ -114,7 +114,7 @@ void JitILBase::dcbz(UGeckoInstruction inst)
 
 	// TODO!
 #if 0
-	if (Core::g_CoreStartupParameter.bJITOff || Core::g_CoreStartupParameter.bJITLoadStoreOff)
+	if (Core::g_CoreStartupParameter.m_JIT_off || Core::g_CoreStartupParameter.m_JIT_load_store_off)
 		{Default(inst); return;} // turn off from debugger
 	INSTRUCTION_START;
 		MOV(32, R(EAX), gpr.R(inst.RB));
@@ -136,7 +136,7 @@ void JitILBase::dcbz(UGeckoInstruction inst)
 void JitILBase::stX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_16);
@@ -159,7 +159,7 @@ void JitILBase::stX(UGeckoInstruction inst)
 void JitILBase::stXx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitLoadGReg(inst.RB);
@@ -183,7 +183,7 @@ void JitILBase::stXx(UGeckoInstruction inst)
 void JitILBase::lmw(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_16);
@@ -202,7 +202,7 @@ void JitILBase::lmw(UGeckoInstruction inst)
 void JitILBase::stmw(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreOff);
+	JITDISABLE(m_JIT_load_store_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_16);

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStoreFloating.cpp
@@ -12,7 +12,7 @@
 void JitILBase::lfs(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_16), val;
@@ -29,7 +29,7 @@ void JitILBase::lfs(UGeckoInstruction inst)
 void JitILBase::lfd(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_16), val;
@@ -46,7 +46,7 @@ void JitILBase::lfd(UGeckoInstruction inst)
 void JitILBase::stfd(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_16);
@@ -64,7 +64,7 @@ void JitILBase::stfd(UGeckoInstruction inst)
 void JitILBase::stfs(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_16);
@@ -83,7 +83,7 @@ void JitILBase::stfs(UGeckoInstruction inst)
 void JitILBase::stfsx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitLoadGReg(inst.RB);
@@ -100,7 +100,7 @@ void JitILBase::stfsx(UGeckoInstruction inst)
 void JitILBase::lfsx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStoreFloatingOff);
+	JITDISABLE(m_JIT_load_store_floating_off);
 	FALLBACK_IF(js.memcheck);
 
 	IREmitter::InstLoc addr = ibuild.EmitLoadGReg(inst.RB), val;

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStorePaired.cpp
@@ -8,7 +8,7 @@
 void JitILBase::psq_st(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStorePairedOff);
+	JITDISABLE(m_JIT_load_store_paired_off);
 	FALLBACK_IF(js.memcheck || inst.W);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_12);
@@ -28,7 +28,7 @@ void JitILBase::psq_st(UGeckoInstruction inst)
 void JitILBase::psq_l(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITLoadStorePairedOff);
+	JITDISABLE(m_JIT_load_store_paired_off);
 	FALLBACK_IF(js.memcheck || inst.W);
 
 	IREmitter::InstLoc addr = ibuild.EmitIntConst(inst.SIMM_12);

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Paired.cpp
@@ -8,7 +8,7 @@
 void JitILBase::ps_arith(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc || (inst.SUBOP5 != 21 && inst.SUBOP5 != 20 && inst.SUBOP5 != 25));
 
 	IREmitter::InstLoc val = ibuild.EmitLoadFReg(inst.FA);
@@ -45,7 +45,7 @@ void JitILBase::ps_sum(UGeckoInstruction inst)
 	FALLBACK_IF(true);
 
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc || inst.SUBOP5 != 10);
 
 	IREmitter::InstLoc val = ibuild.EmitLoadFReg(inst.FA);
@@ -65,7 +65,7 @@ void JitILBase::ps_sum(UGeckoInstruction inst)
 void JitILBase::ps_muls(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	IREmitter::InstLoc val = ibuild.EmitLoadFReg(inst.FA);
@@ -89,7 +89,7 @@ void JitILBase::ps_muls(UGeckoInstruction inst)
 void JitILBase::ps_mergeXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	IREmitter::InstLoc val = ibuild.EmitCompactMRegToPacked(ibuild.EmitLoadFReg(inst.FA));
@@ -121,7 +121,7 @@ void JitILBase::ps_mergeXX(UGeckoInstruction inst)
 void JitILBase::ps_maddXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITPairedOff);
+	JITDISABLE(m_JIT_paired_off);
 	FALLBACK_IF(inst.Rc);
 
 	IREmitter::InstLoc val = ibuild.EmitLoadFReg(inst.FA), op2, op3;

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_SystemRegisters.cpp
@@ -9,7 +9,7 @@
 void JitILBase::mtspr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 	u32 iIndex = (inst.SPRU << 5) | (inst.SPRL & 0x1F);
 
 	switch (iIndex)
@@ -45,7 +45,7 @@ void JitILBase::mtspr(UGeckoInstruction inst)
 void JitILBase::mfspr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-		JITDISABLE(bJITSystemRegistersOff);
+		JITDISABLE(m_JIT_system_registers_off);
 		u32 iIndex = (inst.SPRU << 5) | (inst.SPRL & 0x1F);
 	switch (iIndex)
 	{
@@ -88,21 +88,21 @@ void JitILBase::mtmsr(UGeckoInstruction inst)
 void JitILBase::mfmsr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-		JITDISABLE(bJITSystemRegistersOff);
+		JITDISABLE(m_JIT_system_registers_off);
 		ibuild.EmitStoreGReg(ibuild.EmitLoadMSR(), inst.RD);
 }
 
 void JitILBase::mftb(UGeckoInstruction inst)
 {
 	INSTRUCTION_START;
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 		mfspr(inst);
 }
 
 void JitILBase::mfcr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START;
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 
 	IREmitter::InstLoc d = ibuild.EmitIntConst(0);
 	for (int i = 0; i < 8; ++i)
@@ -118,7 +118,7 @@ void JitILBase::mfcr(UGeckoInstruction inst)
 void JitILBase::mtcrf(UGeckoInstruction inst)
 {
 	INSTRUCTION_START;
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 
 	IREmitter::InstLoc s = ibuild.EmitLoadGReg(inst.RS);
 	for (int i = 0; i < 8; ++i)
@@ -137,7 +137,7 @@ void JitILBase::mtcrf(UGeckoInstruction inst)
 void JitILBase::mcrf(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 
 	if (inst.CRFS != inst.CRFD)
 	{
@@ -148,7 +148,7 @@ void JitILBase::mcrf(UGeckoInstruction inst)
 void JitILBase::crXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITSystemRegistersOff);
+	JITDISABLE(m_JIT_system_registers_off);
 
 	// Get bit CRBA in EAX aligned with bit CRBD
 	const int shiftA = (inst.CRBD & 3) - (inst.CRBA & 3);

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -30,7 +30,7 @@
 #endif
 
 static bool bFakeVMEM = false;
-bool bMMU = false;
+bool m_MMU = false;
 
 namespace JitInterface
 {
@@ -41,8 +41,8 @@ namespace JitInterface
 	}
 	CPUCoreBase *InitJitCore(int core)
 	{
-		bFakeVMEM = SConfig::GetInstance().m_LocalCoreStartupParameter.bTLBHack == true;
-		bMMU = SConfig::GetInstance().m_LocalCoreStartupParameter.bMMU;
+		bFakeVMEM = SConfig::GetInstance().m_LocalCoreStartupParameter.m_TLB_hack == true;
+		m_MMU = SConfig::GetInstance().m_LocalCoreStartupParameter.m_MMU;
 
 		CPUCoreBase *ptr = nullptr;
 		switch (core)
@@ -203,7 +203,7 @@ namespace JitInterface
 
 	u32 Read_Opcode_JIT(u32 _Address)
 	{
-		if (bMMU && !bFakeVMEM && (_Address & Memory::ADDR_MASK_MEM1))
+		if (m_MMU && !bFakeVMEM && (_Address & Memory::ADDR_MASK_MEM1))
 		{
 			_Address = Memory::TranslateAddress(_Address, Memory::FLAG_OPCODE);
 			if (_Address == 0)

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -35,5 +35,5 @@ namespace JitInterface
 
 	void Shutdown();
 }
-extern bool bMMU;
+extern bool m_MMU;
 

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -551,7 +551,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 		return address;
 	}
 
-	if (Core::g_CoreStartupParameter.bMMU && (address & JIT_ICACHE_VMEM_BIT))
+	if (Core::g_CoreStartupParameter.m_MMU && (address & JIT_ICACHE_VMEM_BIT))
 	{
 		if (!Memory::TranslateAddress(address, Memory::FLAG_OPCODE))
 		{

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -104,7 +104,7 @@ static void DoState(PointerWrap &p)
 	g_video_backend->DoState(p);
 	p.DoMarker("video_backend");
 
-	if (Core::g_CoreStartupParameter.bWii)
+	if (Core::g_CoreStartupParameter.m_wii)
 		Wiimote::DoState(p.GetPPtr(), p.GetMode());
 	p.DoMarker("Wiimote");
 

--- a/Source/Core/DolphinWX/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/CheatsWindow.cpp
@@ -278,7 +278,7 @@ void wxCheatsWindow::UpdateGUI()
 	// load code
 	m_gameini_default = Core::g_CoreStartupParameter.LoadDefaultGameIni();
 	m_gameini_local = Core::g_CoreStartupParameter.LoadLocalGameIni();
-	m_gameini_local_path = Core::g_CoreStartupParameter.m_strGameIniLocal;
+	m_gameini_local_path = Core::g_CoreStartupParameter.m_game_ini_local;
 	Load_ARCodes();
 	Load_GeckoCodes();
 
@@ -289,7 +289,7 @@ void wxCheatsWindow::UpdateGUI()
 
 	// write the ISO name in the title
 	if (Core::IsRunning())
-		SetTitle(title + ": " + Core::g_CoreStartupParameter.GetUniqueID() + " - " + Core::g_CoreStartupParameter.m_strName);
+		SetTitle(title + ": " + Core::g_CoreStartupParameter.GetUniqueID() + " - " + Core::g_CoreStartupParameter.m_name);
 	else
 		SetTitle(title);
 }

--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -334,25 +334,25 @@ void CConfigMain::InitializeGUILists()
 
 void CConfigMain::InitializeGUIValues()
 {
-	const SCoreStartupParameter& startup_params = SConfig::GetInstance().m_LocalCoreStartupParameter;
+	const CoreStartupParameter& startup_params = SConfig::GetInstance().m_LocalCoreStartupParameter;
 
 	// General - Basic
-	CPUThread->SetValue(startup_params.bCPUThread);
-	SkipIdle->SetValue(startup_params.bSkipIdle);
-	EnableCheats->SetValue(startup_params.bEnableCheats);
+	CPUThread->SetValue(startup_params.m_CPU_thread);
+	SkipIdle->SetValue(startup_params.m_skip_idle);
+	EnableCheats->SetValue(startup_params.m_enable_cheats);
 	Framelimit->SetSelection(SConfig::GetInstance().m_Framelimit);
 
 	// General - Advanced
 	for (unsigned int a = 0; a < (sizeof(CPUCores) / sizeof(CPUCore)); ++a)
-		if (CPUCores[a].CPUid == startup_params.iCPUCore)
+		if (CPUCores[a].CPUid == startup_params.m_CPU_core)
 			CPUEngine->SetSelection(a);
-	_NTSCJ->SetValue(startup_params.bForceNTSCJ);
+	_NTSCJ->SetValue(startup_params.m_force_NTSCJ);
 
 
 	// Display - Interface
-	ConfirmStop->SetValue(startup_params.bConfirmStop);
-	UsePanicHandlers->SetValue(startup_params.bUsePanicHandlers);
-	OnScreenDisplayMessages->SetValue(startup_params.bOnScreenDisplayMessages);
+	ConfirmStop->SetValue(startup_params.m_confirm_stop);
+	UsePanicHandlers->SetValue(startup_params.m_use_panic_handlers);
+	OnScreenDisplayMessages->SetValue(startup_params.m_on_screen_display_messages);
 	// need redesign
 	for (unsigned int i = 0; i < sizeof(langIds) / sizeof(wxLanguage); i++)
 	{
@@ -364,7 +364,7 @@ void CConfigMain::InitializeGUIValues()
 	}
 
 	// Audio DSP Engine
-	if (startup_params.bDSPHLE)
+	if (startup_params.m_DSPHLE)
 		DSPEngine->SetSelection(0);
 	else
 		DSPEngine->SetSelection(SConfig::GetInstance().m_DSPEnableJIT ? 1 : 2);
@@ -373,19 +373,19 @@ void CConfigMain::InitializeGUIValues()
 	VolumeSlider->Enable(SupportsVolumeChanges(SConfig::GetInstance().sBackend));
 	VolumeSlider->SetValue(SConfig::GetInstance().m_Volume);
 	VolumeText->SetLabel(wxString::Format("%d %%", SConfig::GetInstance().m_Volume));
-	DSPThread->SetValue(startup_params.bDSPThread);
+	DSPThread->SetValue(startup_params.m_DSP_thread);
 	DumpAudio->SetValue(SConfig::GetInstance().m_DumpAudio ? true : false);
 	DPL2Decoder->Enable(std::string(SConfig::GetInstance().sBackend) == BACKEND_OPENAL);
-	DPL2Decoder->SetValue(startup_params.bDPL2Decoder);
+	DPL2Decoder->SetValue(startup_params.m_DPL2_decoder);
 	Latency->Enable(std::string(SConfig::GetInstance().sBackend) == BACKEND_OPENAL);
-	Latency->SetValue(startup_params.iLatency);
+	Latency->SetValue(startup_params.m_latency);
 	// add backends to the list
 	AddAudioBackends();
 
 
 	// GameCube - IPL
-	GCSystemLang->SetSelection(startup_params.SelectedLanguage);
-	GCAlwaysHLE_BS2->SetValue(startup_params.bHLE_BS2);
+	GCSystemLang->SetSelection(startup_params.m_selected_language);
+	GCAlwaysHLE_BS2->SetValue(startup_params.m_HLE_BS2);
 
 	// GameCube - Devices
 	wxArrayString SlotDevices;
@@ -502,9 +502,9 @@ void CConfigMain::InitializeGUIValues()
 
 	// Paths
 	RecursiveISOPath->SetValue(SConfig::GetInstance().m_RecursiveISOFolder);
-	DefaultISO->SetPath(StrToWxStr(startup_params.m_strDefaultGCM));
-	DVDRoot->SetPath(StrToWxStr(startup_params.m_strDVDRoot));
-	ApploaderPath->SetPath(StrToWxStr(startup_params.m_strApploader));
+	DefaultISO->SetPath(StrToWxStr(startup_params.m_default_GCM));
+	DVDRoot->SetPath(StrToWxStr(startup_params.m_DVD_root));
+	ApploaderPath->SetPath(StrToWxStr(startup_params.m_apploader));
 	NANDRoot->SetPath(StrToWxStr(SConfig::GetInstance().m_NANDPath));
 }
 
@@ -628,12 +628,12 @@ void CConfigMain::CreateGUIControls()
 			theme_selection->Append(wxname);
 	});
 
-	theme_selection->SetStringSelection(StrToWxStr(SConfig::GetInstance().m_LocalCoreStartupParameter.theme_name));
+	theme_selection->SetStringSelection(StrToWxStr(SConfig::GetInstance().m_LocalCoreStartupParameter.m_theme_name));
 
 	// std::function = avoid error on msvc
 	theme_selection->Bind(wxEVT_CHOICE, std::function<void(wxEvent&)>([theme_selection](wxEvent&)
 	{
-		SConfig::GetInstance().m_LocalCoreStartupParameter.theme_name = WxStrToStr(theme_selection->GetStringSelection());
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_theme_name = WxStrToStr(theme_selection->GetStringSelection());
 		main_frame->InitBitmaps();
 		main_frame->UpdateGameList();
 	}));
@@ -887,26 +887,26 @@ void CConfigMain::CoreSettingsChanged(wxCommandEvent& event)
 	case ID_CPUTHREAD:
 		if (Core::IsRunning())
 			return;
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread = CPUThread->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_thread = CPUThread->IsChecked();
 		break;
 	case ID_IDLESKIP:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bSkipIdle = SkipIdle->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_skip_idle = SkipIdle->IsChecked();
 		break;
 	case ID_ENABLECHEATS:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats = EnableCheats->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_enable_cheats = EnableCheats->IsChecked();
 		break;
 	case ID_FRAMELIMIT:
 		SConfig::GetInstance().m_Framelimit = Framelimit->GetSelection();
 		break;
 	// Core - Advanced
 	case ID_CPUENGINE:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.iCPUCore = CPUCores[CPUEngine->GetSelection()].CPUid;
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_core = CPUCores[CPUEngine->GetSelection()].CPUid;
 		if (main_frame->g_pCodeWindow)
 			main_frame->g_pCodeWindow->GetMenuBar()->Check(IDM_INTERPRETER,
-				SConfig::GetInstance().m_LocalCoreStartupParameter.iCPUCore?false:true);
+				SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_core?false:true);
 		break;
 	case ID_NTSCJ:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bForceNTSCJ = _NTSCJ->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_force_NTSCJ = _NTSCJ->IsChecked();
 		break;
 	}
 }
@@ -918,14 +918,14 @@ void CConfigMain::DisplaySettingsChanged(wxCommandEvent& event)
 	{
 	// Display - Interface
 	case ID_INTERFACE_CONFIRMSTOP:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bConfirmStop = ConfirmStop->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_confirm_stop = ConfirmStop->IsChecked();
 		break;
 	case ID_INTERFACE_USEPANICHANDLERS:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bUsePanicHandlers = UsePanicHandlers->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_use_panic_handlers = UsePanicHandlers->IsChecked();
 		SetEnableAlert(UsePanicHandlers->IsChecked());
 		break;
 	case ID_INTERFACE_ONSCREENDISPLAYMESSAGES:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bOnScreenDisplayMessages = OnScreenDisplayMessages->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_on_screen_display_messages = OnScreenDisplayMessages->IsChecked();
 		SetEnableAlert(OnScreenDisplayMessages->IsChecked());
 		break;
 	case ID_INTERFACE_LANG:
@@ -949,7 +949,7 @@ void CConfigMain::AudioSettingsChanged(wxCommandEvent& event)
 	switch (event.GetId())
 	{
 	case ID_DSPENGINE:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bDSPHLE = DSPEngine->GetSelection() == 0;
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_DSPHLE = DSPEngine->GetSelection() == 0;
 		SConfig::GetInstance().m_DSPEnableJIT = DSPEngine->GetSelection() == 1;
 		AudioCommon::UpdateSoundStream();
 		break;
@@ -961,11 +961,11 @@ void CConfigMain::AudioSettingsChanged(wxCommandEvent& event)
 		break;
 
 	case ID_DSPTHREAD:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bDSPThread = DSPThread->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_DSP_thread = DSPThread->IsChecked();
 		break;
 
 	case ID_DPL2DECODER:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bDPL2Decoder = DPL2Decoder->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_DPL2_decoder = DPL2Decoder->IsChecked();
 		break;
 
 	case ID_BACKEND:
@@ -979,7 +979,7 @@ void CConfigMain::AudioSettingsChanged(wxCommandEvent& event)
 		break;
 
 	case ID_LATENCY:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.iLatency = Latency->GetValue();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_latency = Latency->GetValue();
 		break;
 
 	default:
@@ -1021,12 +1021,12 @@ void CConfigMain::GCSettingsChanged(wxCommandEvent& event)
 	{
 	// GameCube - IPL
 	case ID_GC_SRAM_LNG:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage = GCSystemLang->GetSelection();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_selected_language = GCSystemLang->GetSelection();
 		bRefreshList = true;
 		break;
 	// GameCube - IPL Settings
 	case ID_GC_ALWAYS_HLE_BS2:
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bHLE_BS2 = GCAlwaysHLE_BS2->IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_HLE_BS2 = GCAlwaysHLE_BS2->IsChecked();
 		break;
 	// GameCube - Devices
 	case ID_GC_EXIDEVICE_SP1:
@@ -1273,17 +1273,17 @@ void CConfigMain::RecursiveDirectoryChanged(wxCommandEvent& WXUNUSED (event))
 
 void CConfigMain::DefaultISOChanged(wxFileDirPickerEvent& WXUNUSED (event))
 {
-	SConfig::GetInstance().m_LocalCoreStartupParameter.m_strDefaultGCM = WxStrToStr(DefaultISO->GetPath());
+	SConfig::GetInstance().m_LocalCoreStartupParameter.m_default_GCM = WxStrToStr(DefaultISO->GetPath());
 }
 
 void CConfigMain::DVDRootChanged(wxFileDirPickerEvent& WXUNUSED (event))
 {
-	SConfig::GetInstance().m_LocalCoreStartupParameter.m_strDVDRoot = WxStrToStr(DVDRoot->GetPath());
+	SConfig::GetInstance().m_LocalCoreStartupParameter.m_DVD_root = WxStrToStr(DVDRoot->GetPath());
 }
 
 void CConfigMain::ApploaderPathChanged(wxFileDirPickerEvent& WXUNUSED (event))
 {
-	SConfig::GetInstance().m_LocalCoreStartupParameter.m_strApploader = WxStrToStr(ApploaderPath->GetPath());
+	SConfig::GetInstance().m_LocalCoreStartupParameter.m_apploader = WxStrToStr(ApploaderPath->GetPath());
 }
 
 void CConfigMain::NANDRootChanged(wxFileDirPickerEvent& WXUNUSED (event))
@@ -1302,7 +1302,7 @@ void CConfigMain::NANDRootChanged(wxFileDirPickerEvent& WXUNUSED (event))
 void CConfigMain::OnSelectionChanged(wxCommandEvent& ev)
 {
 	g_video_backend = g_available_video_backends[ev.GetInt()];
-	SConfig::GetInstance().m_LocalCoreStartupParameter.m_strVideoBackend = g_video_backend->GetName();
+	SConfig::GetInstance().m_LocalCoreStartupParameter.m_video_backend = g_video_backend->GetName();
 }
 
 void CConfigMain::OnConfig(wxCommandEvent&)

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -87,7 +87,7 @@ BEGIN_EVENT_TABLE(CCodeWindow, wxPanel)
 END_EVENT_TABLE()
 
 // Class
-CCodeWindow::CCodeWindow(const SCoreStartupParameter& _LocalCoreStartupParameter, CFrame *parent,
+CCodeWindow::CCodeWindow(const CoreStartupParameter& _LocalCoreStartupParameter, CFrame *parent,
 	wxWindowID id, const wxPoint& position, const wxSize& size, long style, const wxString& name)
 	: wxPanel(parent, id, position, size, style, name)
 	, Parent(parent)
@@ -384,7 +384,7 @@ void CCodeWindow::UpdateCallstack()
 }
 
 // Create CPU Mode menus
-void CCodeWindow::CreateMenu(const SCoreStartupParameter& _LocalCoreStartupParameter, wxMenuBar *pMenuBar)
+void CCodeWindow::CreateMenu(const CoreStartupParameter& _LocalCoreStartupParameter, wxMenuBar *pMenuBar)
 {
 	// CPU Mode
 	wxMenu* pCoreMenu = new wxMenu;
@@ -394,7 +394,7 @@ void CCodeWindow::CreateMenu(const SCoreStartupParameter& _LocalCoreStartupParam
 		" and stepping to work as explained in the Developer Documentation. But it can be very"
 		" slow, perhaps slower than 1 fps."),
 		wxITEM_CHECK);
-	interpreter->Check(_LocalCoreStartupParameter.iCPUCore == 0);
+	interpreter->Check(_LocalCoreStartupParameter.m_CPU_core == 0);
 	pCoreMenu->AppendSeparator();
 
 	pCoreMenu->Append(IDM_JITBLOCKLINKING, _("&JIT Block Linking off"),
@@ -471,7 +471,7 @@ void CCodeWindow::CreateMenuOptions(wxMenu* pMenu)
 	wxMenuItem* boottopause = pMenu->Append(IDM_BOOTTOPAUSE, _("Boot to pause"),
 		_("Start the game directly instead of booting to pause"),
 		wxITEM_CHECK);
-	boottopause->Check(bBootToPause);
+	boottopause->Check(m_boot_to_pause);
 
 	wxMenuItem* automaticstart = pMenu->Append(IDM_AUTOMATICSTART, _("&Automatic start"),
 		_(
@@ -481,7 +481,7 @@ void CCodeWindow::CreateMenuOptions(wxMenu* pMenu)
 		" and retry it several times, either with changes to Dolphin or if you are"
 		" developing a homebrew game.]"),
 		wxITEM_CHECK);
-	automaticstart->Check(bAutomaticStart);
+	automaticstart->Check(m_automatic_start);
 
 	pMenu->Append(IDM_FONTPICKER, _("&Font..."));
 }
@@ -495,43 +495,43 @@ void CCodeWindow::OnCPUMode(wxCommandEvent& event)
 			PowerPC::SetMode(UseInterpreter() ? PowerPC::MODE_INTERPRETER : PowerPC::MODE_JIT);
 			break;
 		case IDM_BOOTTOPAUSE:
-			bBootToPause = !bBootToPause;
+			m_boot_to_pause = !m_boot_to_pause;
 			return;
 		case IDM_AUTOMATICSTART:
-			bAutomaticStart = !bAutomaticStart;
+			m_automatic_start = !m_automatic_start;
 			return;
 		case IDM_JITOFF:
-			Core::g_CoreStartupParameter.bJITOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_off = event.IsChecked();
 			break;
 		case IDM_JITLSOFF:
-			Core::g_CoreStartupParameter.bJITLoadStoreOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_load_store_off = event.IsChecked();
 			break;
 		case IDM_JITLSLXZOFF:
-			Core::g_CoreStartupParameter.bJITLoadStorelXzOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_load_store_lxz_off = event.IsChecked();
 			break;
 		case IDM_JITLSLWZOFF:
-			Core::g_CoreStartupParameter.bJITLoadStorelwzOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_load_store_lwz_off = event.IsChecked();
 			break;
 		case IDM_JITLSLBZXOFF:
-			Core::g_CoreStartupParameter.bJITLoadStorelbzxOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_load_store_lbzx_off = event.IsChecked();
 			break;
 		case IDM_JITLSFOFF:
-			Core::g_CoreStartupParameter.bJITLoadStoreFloatingOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_load_store_floating_off = event.IsChecked();
 			break;
 		case IDM_JITLSPOFF:
-			Core::g_CoreStartupParameter.bJITLoadStorePairedOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_load_store_paired_off = event.IsChecked();
 			break;
 		case IDM_JITFPOFF:
-			Core::g_CoreStartupParameter.bJITFloatingPointOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_floating_point_off = event.IsChecked();
 			break;
 		case IDM_JITIOFF:
-			Core::g_CoreStartupParameter.bJITIntegerOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_integer_off = event.IsChecked();
 			break;
 		case IDM_JITPOFF:
-			Core::g_CoreStartupParameter.bJITPairedOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_paired_off = event.IsChecked();
 			break;
 		case IDM_JITSROFF:
-			Core::g_CoreStartupParameter.bJITSystemRegistersOff = event.IsChecked();
+			Core::g_CoreStartupParameter.m_JIT_system_registers_off = event.IsChecked();
 			break;
 	}
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -25,7 +25,7 @@ class CJitWindow;
 class CCodeView;
 class DSPDebuggerLLE;
 class GFXDebuggerPanel;
-struct SCoreStartupParameter;
+struct CoreStartupParameter;
 
 class wxToolBar;
 class wxListBox;
@@ -37,7 +37,7 @@ class CCodeWindow
 {
 	public:
 
-		CCodeWindow(const SCoreStartupParameter& _LocalCoreStartupParameter,
+		CCodeWindow(const CoreStartupParameter& _LocalCoreStartupParameter,
 			CFrame * parent,
 			wxWindowID id = wxID_ANY,
 			const wxPoint& pos = wxDefaultPosition,
@@ -64,7 +64,7 @@ class CCodeWindow
 
 		void Update() override;
 		void NotifyMapLoaded();
-		void CreateMenu(const SCoreStartupParameter& _LocalCoreStartupParameter, wxMenuBar *pMenuBar);
+		void CreateMenu(const CoreStartupParameter& _LocalCoreStartupParameter, wxMenuBar *pMenuBar);
 		void CreateMenuOptions(wxMenu *pMenu);
 		void CreateMenuSymbols(wxMenuBar *pMenuBar);
 		void RecreateToolbar(wxToolBar*);
@@ -103,7 +103,7 @@ class CCodeWindow
 		GFXDebuggerPanel* m_VideoWindow;
 
 		// Settings
-		bool bAutomaticStart; bool bBootToPause;
+		bool m_automatic_start; bool m_boot_to_pause;
 		bool bShowOnStart[IDM_VIDEOWINDOW - IDM_LOGWINDOW + 1];
 		int iNbAffiliation[IDM_CODEWINDOW - IDM_LOGWINDOW + 1];
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -65,8 +65,8 @@ void CCodeWindow::Load()
 
 	IniFile::Section* general = ini.GetOrCreateSection("General");
 	general->Get("DebuggerFont", &fontDesc);
-	general->Get("AutomaticStart", &bAutomaticStart, false);
-	general->Get("BootToPause", &bBootToPause, true);
+	general->Get("AutomaticStart", &m_automatic_start, false);
+	general->Get("BootToPause", &m_boot_to_pause, true);
 
 	if (!fontDesc.empty())
 		DebuggerFont.SetNativeFontInfoUserDesc(StrToWxStr(fontDesc));

--- a/Source/Core/DolphinWX/Debugger/DebuggerPanel.cpp
+++ b/Source/Core/DolphinWX/Debugger/DebuggerPanel.cpp
@@ -273,7 +273,7 @@ void GFXDebuggerPanel::OnPauseAtNextFrameButton(wxCommandEvent& event)
 void GFXDebuggerPanel::OnDumpButton(wxCommandEvent& event)
 {
 	std::string dump_path = File::GetUserPath(D_DUMP_IDX) + "Debug/" +
-		SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID + "/";
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID + "/";
 	if (!File::CreateFullPath(dump_path))
 		return;
 

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -102,7 +102,7 @@ CMemoryWindow::CMemoryWindow(wxWindow* parent, wxWindowID id,
 	sizerRight->Add(new wxButton(this, IDM_DUMP_MEMORY, _("&Dump MRAM")));
 	sizerRight->Add(new wxButton(this, IDM_DUMP_MEM2, _("&Dump EXRAM")));
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bTLBHack == true)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_TLB_hack == true)
 		sizerRight->Add(new wxButton(this, IDM_DUMP_FAKEVMEM, _("&Dump FakeVMEM")));
 
 	wxStaticBoxSizer* sizerSearchType = new wxStaticBoxSizer(wxVERTICAL, this, _("Search"));
@@ -265,7 +265,7 @@ void CMemoryWindow::OnDumpMemory( wxCommandEvent& event )
 // Write exram (aram or mem2) to file
 void CMemoryWindow::OnDumpMem2( wxCommandEvent& event )
 {
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_wii)
 	{
 		DumpArray(File::GetUserPath(F_ARAMDUMP_IDX), Memory::m_pEXRAM, Memory::EXRAM_SIZE);
 	}

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -154,7 +154,7 @@ WXLRESULT CRenderFrame::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lPa
 			{
 				case SC_SCREENSAVE:
 				case SC_MONITORPOWER:
-					if (Core::GetState() == Core::CORE_RUN && SConfig::GetInstance().m_LocalCoreStartupParameter.bDisableScreenSaver)
+					if (Core::GetState() == Core::CORE_RUN && SConfig::GetInstance().m_LocalCoreStartupParameter.m_disable_screen_saver)
 						break;
 				default:
 					return wxFrame::MSWWindowProc(nMsg, wParam, lParam);
@@ -169,7 +169,7 @@ WXLRESULT CRenderFrame::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lPa
 				break;
 
 			case WM_USER_SETCURSOR:
-				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor &&
+				if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor &&
 					main_frame->RendererHasFocus() && Core::GetState() == Core::CORE_RUN)
 					SetCursor(wxCURSOR_BLANK);
 				else
@@ -495,7 +495,7 @@ void CFrame::OnActive(wxActivateEvent& event)
 	{
 		if (event.GetActive() && event.GetEventObject() == m_RenderFrame)
 		{
-			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain)
+			if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main)
 			{
 #ifdef __WXMSW__
 				::SetFocus((HWND)m_RenderParent->GetHandle());
@@ -504,13 +504,13 @@ void CFrame::OnActive(wxActivateEvent& event)
 #endif
 			}
 
-			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor &&
+			if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor &&
 					Core::GetState() == Core::CORE_RUN)
 				m_RenderParent->SetCursor(wxCURSOR_BLANK);
 		}
 		else
 		{
-			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+			if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor)
 				m_RenderParent->SetCursor(wxNullCursor);
 		}
 	}
@@ -580,10 +580,10 @@ void CFrame::OnMove(wxMoveEvent& event)
 	event.Skip();
 
 	if (!IsMaximized() &&
-		!(SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain && RendererIsFullscreen()))
+		!(SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main && RendererIsFullscreen()))
 	{
-		SConfig::GetInstance().m_LocalCoreStartupParameter.iPosX = GetPosition().x;
-		SConfig::GetInstance().m_LocalCoreStartupParameter.iPosY = GetPosition().y;
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_posx = GetPosition().x;
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_posy = GetPosition().y;
 	}
 }
 
@@ -592,13 +592,13 @@ void CFrame::OnResize(wxSizeEvent& event)
 	event.Skip();
 
 	if (!IsMaximized() &&
-		!(SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain && RendererIsFullscreen()) &&
+		!(SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main && RendererIsFullscreen()) &&
 		!(Core::GetState() != Core::CORE_UNINITIALIZED &&
-			SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain &&
-			SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderWindowAutoSize))
+			SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main &&
+			SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_auto_size))
 	{
-		SConfig::GetInstance().m_LocalCoreStartupParameter.iWidth = GetSize().GetWidth();
-		SConfig::GetInstance().m_LocalCoreStartupParameter.iHeight = GetSize().GetHeight();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_width = GetSize().GetWidth();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_height = GetSize().GetHeight();
 	}
 
 	// Make sure the logger pane is a sane size
@@ -678,7 +678,7 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
 		break;
 
 	case WM_USER_CREATE:
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor)
 			m_RenderParent->SetCursor(wxCURSOR_BLANK);
 		break;
 
@@ -724,7 +724,7 @@ void CFrame::GetRenderWindowSize(int& x, int& y, int& width, int& height)
 void CFrame::OnRenderWindowSizeRequest(int width, int height)
 {
 	if (!Core::IsRunning() ||
-			!SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderWindowAutoSize ||
+			!SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_auto_size ||
 			RendererIsFullscreen() || m_RenderFrame->IsMaximized())
 		return;
 
@@ -732,7 +732,7 @@ void CFrame::OnRenderWindowSizeRequest(int width, int height)
 	m_RenderFrame->GetClientSize(&old_width, &old_height);
 
 	// Add space for the log/console/debugger window
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain &&
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main &&
 			(SConfig::GetInstance().m_InterfaceLogWindow ||
 			 SConfig::GetInstance().m_InterfaceLogConfigWindow) &&
 			!m_Mgr->GetPane("Pane 1").IsFloating())
@@ -850,8 +850,8 @@ void CFrame::OnGameListCtrl_ItemActivated(wxListEvent& WXUNUSED (event))
 static bool IsHotkey(wxKeyEvent &event, int Id)
 {
 	return (event.GetKeyCode() != WXK_NONE &&
-			event.GetKeyCode() == SConfig::GetInstance().m_LocalCoreStartupParameter.iHotkey[Id] &&
-			event.GetModifiers() == SConfig::GetInstance().m_LocalCoreStartupParameter.iHotkeyModifier[Id]);
+			event.GetKeyCode() == SConfig::GetInstance().m_LocalCoreStartupParameter.m_hotkey[Id] &&
+			event.GetModifiers() == SConfig::GetInstance().m_LocalCoreStartupParameter.m_hotkey_modifier[Id]);
 }
 
 int GetCmdForHotkey(unsigned int key)
@@ -1040,7 +1040,7 @@ void CFrame::OnKeyDown(wxKeyEvent& event)
 		else
 		{
 			unsigned int i = NUM_HOTKEYS;
-			if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain || TASInputHasFocus())
+			if (!SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main || TASInputHasFocus())
 			{
 				for (i = 0; i < NUM_HOTKEYS; i++)
 				{
@@ -1200,7 +1200,7 @@ void CFrame::OnMouse(wxMouseEvent& event)
 void CFrame::DoFullscreen(bool enable_fullscreen)
 {
 	if (!g_Config.BorderlessFullscreenEnabled() &&
-		!SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain &&
+		!SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main &&
 		Core::GetState() == Core::CORE_PAUSE)
 	{
 		// A responsive renderer is required for exclusive fullscreen, but the
@@ -1227,7 +1227,7 @@ void CFrame::DoFullscreen(bool enable_fullscreen)
 		m_RenderFrame->ShowFullScreen(true, wxFULLSCREEN_ALL);
 	}
 	else if (g_Config.BorderlessFullscreenEnabled() ||
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain)
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main)
 	{
 		// Exiting exclusive fullscreen should be done from a Renderer callback.
 		// Therefore we don't exit fullscreen from here if we support exclusive mode.
@@ -1235,7 +1235,7 @@ void CFrame::DoFullscreen(bool enable_fullscreen)
 	}
 #endif
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main)
 	{
 		if (enable_fullscreen)
 		{
@@ -1266,8 +1266,8 @@ void CFrame::DoFullscreen(bool enable_fullscreen)
 		m_RenderFrame->Raise();
 	}
 
-	g_Config.bFullscreen = (g_Config.BorderlessFullscreenEnabled() ||
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain) ? false : enable_fullscreen;
+	g_Config.m_fullscreen = (g_Config.BorderlessFullscreenEnabled() ||
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main) ? false : enable_fullscreen;
 }
 
 const CGameListCtrl *CFrame::GetGameListCtrl() const

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -122,7 +122,7 @@ public:
 	bool RendererHasFocus();
 	bool UIHasFocus();
 	void DoFullscreen(bool bF);
-	void ToggleDisplayMode (bool bFullscreen);
+	void ToggleDisplayMode (bool m_fullscreen);
 	void UpdateWiiMenuChoice(wxMenuItem *WiiMenuItem=nullptr);
 	void PopulateSavedPerspectives();
 	static void ConnectWiimote(int wm_idx, bool connect);

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -107,7 +107,7 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
 	}
 	else // GC
 	{
-		indexOne = SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage;
+		indexOne = SConfig::GetInstance().m_LocalCoreStartupParameter.m_selected_language;
 	}
 
 	if (iso2->GetPlatform() == GameListItem::WII_WAD)
@@ -116,7 +116,7 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
 	}
 	else // GC
 	{
-		indexOther = SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage;
+		indexOther = SConfig::GetInstance().m_LocalCoreStartupParameter.m_selected_language;
 	}
 
 	switch (sortData)
@@ -429,21 +429,21 @@ void CGameListCtrl::InsertItemInReportView(long _Index)
 	// Set the game's banner in the second column
 	SetItemColumnImage(_Index, COLUMN_BANNER, ImageIndex);
 
-	int SelectedLanguage = SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage;
+	int m_selected_language = SConfig::GetInstance().m_LocalCoreStartupParameter.m_selected_language;
 
 	// Is this sane?
 	if  (rISOFile.GetPlatform() == GameListItem::WII_WAD)
 	{
-		SelectedLanguage = SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG");
+		m_selected_language = SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG");
 	}
 
-	std::string const name = rISOFile.GetName(SelectedLanguage);
+	std::string const name = rISOFile.GetName(m_selected_language);
 	SetItem(_Index, COLUMN_TITLE, StrToWxStr(name), -1);
 
 	// We show the company string on GameCube only
 	// On Wii we show the description instead as the company string is empty
 	std::string const notes = (rISOFile.GetPlatform() == GameListItem::GAMECUBE_DISC) ?
-		rISOFile.GetCompany() : rISOFile.GetDescription(SelectedLanguage);
+		rISOFile.GetCompany() : rISOFile.GetDescription(m_selected_language);
 	SetItem(_Index, COLUMN_NOTES, StrToWxStr(notes), -1);
 
 	// Emulation state
@@ -876,7 +876,7 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
 
 			// First we have to decide a starting value when we append it
 			if (selected_iso->GetFileName() == SConfig::GetInstance().
-				m_LocalCoreStartupParameter.m_strDefaultGCM)
+				m_LocalCoreStartupParameter.m_default_GCM)
 				popupMenu->FindItem(IDM_SETDEFAULTGCM)->Check();
 
 			popupMenu->AppendSeparator();
@@ -994,14 +994,14 @@ void CGameListCtrl::OnSetDefaultGCM(wxCommandEvent& event)
 	if (event.IsChecked())
 	{
 		// Write the new default value and save it the ini file
-		SConfig::GetInstance().m_LocalCoreStartupParameter.m_strDefaultGCM =
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_default_GCM =
 			iso->GetFileName();
 		SConfig::GetInstance().SaveSettings();
 	}
 	else
 	{
 		// Otherwise blank the value and save it
-		SConfig::GetInstance().m_LocalCoreStartupParameter.m_strDefaultGCM = "";
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_default_GCM = "";
 		SConfig::GetInstance().SaveSettings();
 	}
 }

--- a/Source/Core/DolphinWX/HotkeyDlg.cpp
+++ b/Source/Core/DolphinWX/HotkeyDlg.cpp
@@ -58,8 +58,8 @@ HotkeyConfigDialog::~HotkeyConfigDialog()
 // Save keyboard key mapping
 void HotkeyConfigDialog::SaveButtonMapping(int Id, int Key, int Modkey)
 {
-	SConfig::GetInstance().m_LocalCoreStartupParameter.iHotkey[Id] = Key;
-	SConfig::GetInstance().m_LocalCoreStartupParameter.iHotkeyModifier[Id] = Modkey;
+	SConfig::GetInstance().m_LocalCoreStartupParameter.m_hotkey[Id] = Key;
+	SConfig::GetInstance().m_LocalCoreStartupParameter.m_hotkey_modifier[Id] = Modkey;
 }
 
 void HotkeyConfigDialog::EndGetButtons(void)
@@ -313,9 +313,9 @@ void HotkeyConfigDialog::CreateHotkeyGUIControls(void)
 			m_Button_Hotkeys[i]->SetFont(m_SmallFont);
 			m_Button_Hotkeys[i]->SetToolTip(_("Left click to detect hotkeys.\nEnter space to clear."));
 			SetButtonText(i,
-					InputCommon::WXKeyToString(SConfig::GetInstance().m_LocalCoreStartupParameter.iHotkey[i]),
+					InputCommon::WXKeyToString(SConfig::GetInstance().m_LocalCoreStartupParameter.m_hotkey[i]),
 					InputCommon::WXKeymodToString(
-						SConfig::GetInstance().m_LocalCoreStartupParameter.iHotkeyModifier[i]));
+						SConfig::GetInstance().m_LocalCoreStartupParameter.m_hotkey_modifier[i]));
 
 			wxBoxSizer *sHotkey = new wxBoxSizer(wxHORIZONTAL);
 			sHotkey->Add(stHotkeys, 1, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxALL, 2);

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -149,7 +149,7 @@ GameListItem::GameListItem(const std::string& _rFileName)
 	else
 	{
 		// default banner
-		m_Bitmap.LoadFile(StrToWxStr(File::GetThemeDir(SConfig::GetInstance().m_LocalCoreStartupParameter.theme_name)) + "nobanner.png", wxBITMAP_TYPE_PNG);
+		m_Bitmap.LoadFile(StrToWxStr(File::GetThemeDir(SConfig::GetInstance().m_LocalCoreStartupParameter.m_theme_name)) + "nobanner.png", wxBITMAP_TYPE_PNG);
 	}
 }
 

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -265,7 +265,7 @@ CISOProperties::CISOProperties(const std::string fileName, wxWindow* parent, wxW
 	// Here we set all the info to be shown (be it SJIS or Ascii) + we set the window title
 	if (!IsWad)
 	{
-		ChangeBannerDetails(SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage);
+		ChangeBannerDetails(SConfig::GetInstance().m_LocalCoreStartupParameter.m_selected_language);
 	}
 	else
 	{
@@ -527,7 +527,7 @@ void CISOProperties::CreateGUIControls(bool IsWad)
 	arrayStringFor_Lang.Add(_("Spanish"));
 	arrayStringFor_Lang.Add(_("Italian"));
 	arrayStringFor_Lang.Add(_("Dutch"));
-	int language = SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage;
+	int language = SConfig::GetInstance().m_LocalCoreStartupParameter.m_selected_language;
 	if (IsWad)
 	{
 		arrayStringFor_Lang.Insert(_("Japanese"), 0);

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -294,28 +294,28 @@ bool DolphinApp::OnInit()
 	WiimoteReal::LoadSettings();
 
 	if (selectVideoBackend && videoBackendName != wxEmptyString)
-		SConfig::GetInstance().m_LocalCoreStartupParameter.m_strVideoBackend =
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_video_backend =
 			WxStrToStr(videoBackendName);
 
 	if (selectAudioEmulation)
 	{
 		if (audioEmulationName == "HLE")
-			SConfig::GetInstance().m_LocalCoreStartupParameter.bDSPHLE = true;
+			SConfig::GetInstance().m_LocalCoreStartupParameter.m_DSPHLE = true;
 		else if (audioEmulationName == "LLE")
-			SConfig::GetInstance().m_LocalCoreStartupParameter.bDSPHLE = false;
+			SConfig::GetInstance().m_LocalCoreStartupParameter.m_DSPHLE = false;
 	}
 
-	VideoBackend::ActivateBackend(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strVideoBackend);
+	VideoBackend::ActivateBackend(SConfig::GetInstance().m_LocalCoreStartupParameter.m_video_backend);
 
 	// Enable the PNG image handler for screenshots
 	wxImage::AddHandler(new wxPNGHandler);
 
-	SetEnableAlert(SConfig::GetInstance().m_LocalCoreStartupParameter.bUsePanicHandlers);
+	SetEnableAlert(SConfig::GetInstance().m_LocalCoreStartupParameter.m_use_panic_handlers);
 
-	int x = SConfig::GetInstance().m_LocalCoreStartupParameter.iPosX;
-	int y = SConfig::GetInstance().m_LocalCoreStartupParameter.iPosY;
-	int w = SConfig::GetInstance().m_LocalCoreStartupParameter.iWidth;
-	int h = SConfig::GetInstance().m_LocalCoreStartupParameter.iHeight;
+	int x = SConfig::GetInstance().m_LocalCoreStartupParameter.m_posx;
+	int y = SConfig::GetInstance().m_LocalCoreStartupParameter.m_posy;
+	int w = SConfig::GetInstance().m_LocalCoreStartupParameter.m_width;
+	int h = SConfig::GetInstance().m_LocalCoreStartupParameter.m_height;
 
 #ifdef _WIN32
 	if (File::Exists("www.dolphin-emulator.com.txt"))
@@ -592,19 +592,19 @@ void Host_RequestFullscreen(bool enable_fullscreen)
 
 void Host_SetStartupDebuggingParameters()
 {
-	SCoreStartupParameter& StartUp = SConfig::GetInstance().m_LocalCoreStartupParameter;
+	CoreStartupParameter& StartUp = SConfig::GetInstance().m_LocalCoreStartupParameter;
 	if (main_frame->g_pCodeWindow)
 	{
-		StartUp.bBootToPause = main_frame->g_pCodeWindow->BootToPause();
-		StartUp.bAutomaticStart = main_frame->g_pCodeWindow->AutomaticStart();
-		StartUp.bJITNoBlockCache = main_frame->g_pCodeWindow->JITNoBlockCache();
-		StartUp.bJITBlockLinking = main_frame->g_pCodeWindow->JITBlockLinking();
+		StartUp.m_boot_to_pause = main_frame->g_pCodeWindow->BootToPause();
+		StartUp.m_automatic_start = main_frame->g_pCodeWindow->AutomaticStart();
+		StartUp.m_JIT_no_block_cache = main_frame->g_pCodeWindow->JITNoBlockCache();
+		StartUp.m_JIT_block_linking = main_frame->g_pCodeWindow->JITBlockLinking();
 	}
 	else
 	{
-		StartUp.bBootToPause = false;
+		StartUp.m_boot_to_pause = false;
 	}
-	StartUp.bEnableDebugging = main_frame->g_pCodeWindow ? true : false; // RUNNING_DEBUG
+	StartUp.m_enable_debugging = main_frame->g_pCodeWindow ? true : false; // RUNNING_DEBUG
 }
 
 void Host_UpdateStatusBar(const std::string& text, int Field)

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -74,10 +74,10 @@ void Host_UpdateMainFrame()
 
 void Host_GetRenderWindowSize(int& x, int& y, int& width, int& height)
 {
-	x = SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowXPos;
-	y = SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowYPos;
-	width = SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowWidth;
-	height = SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowHeight;
+	x = SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_xpos;
+	y = SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_ypos;
+	width = SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_width;
+	height = SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_height;
 }
 
 void Host_RequestRenderWindowSize(int width, int height) {}
@@ -86,9 +86,9 @@ void Host_RequestFullscreen(bool enable_fullscreen) {}
 
 void Host_SetStartupDebuggingParameters()
 {
-	SCoreStartupParameter& StartUp = SConfig::GetInstance().m_LocalCoreStartupParameter;
+	CoreStartupParameter& StartUp = SConfig::GetInstance().m_LocalCoreStartupParameter;
 	StartUp.bEnableDebugging = false;
-	StartUp.bBootToPause = false;
+	StartUp.m_boot_to_pause = false;
 }
 
 bool Host_UIHasFocus()
@@ -131,7 +131,7 @@ void Host_ShowVideoConfig(void*, const std::string&, const std::string&) {}
 #if HAVE_X11
 static void X11_MainLoop()
 {
-	bool fullscreen = SConfig::GetInstance().m_LocalCoreStartupParameter.bFullscreen;
+	bool fullscreen = SConfig::GetInstance().m_LocalCoreStartupParameter.m_fullscreen;
 	while (!Core::IsRunning())
 		updateMainFrameEvent.Wait();
 
@@ -139,7 +139,7 @@ static void X11_MainLoop()
 	Window win = (Window)Core::GetWindowHandle();
 	XSelectInput(dpy, win, KeyPressMask | FocusChangeMask);
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bDisableScreenSaver)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_disable_screen_saver)
 		X11Utils::InhibitScreensaver(dpy, win, true);
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
@@ -147,7 +147,7 @@ static void X11_MainLoop()
 #endif
 
 	Cursor blankCursor = None;
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor)
 	{
 		// make a blank cursor
 		Pixmap Blank;
@@ -183,13 +183,13 @@ static void X11_MainLoop()
 					{
 						if (Core::GetState() == Core::CORE_RUN)
 						{
-							if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+							if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor)
 								XUndefineCursor(dpy, win);
 							Core::SetState(Core::CORE_PAUSE);
 						}
 						else
 						{
-							if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+							if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor)
 								XDefineCursor(dpy, win, blankCursor);
 							Core::SetState(Core::CORE_RUN);
 						}
@@ -224,13 +224,13 @@ static void X11_MainLoop()
 					break;
 				case FocusIn:
 					rendererHasFocus = true;
-					if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor &&
+					if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor &&
 							Core::GetState() != Core::CORE_PAUSE)
 						XDefineCursor(dpy, win, blankCursor);
 					break;
 				case FocusOut:
 					rendererHasFocus = false;
-					if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+					if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor)
 						XUndefineCursor(dpy, win);
 					break;
 			}
@@ -240,10 +240,10 @@ static void X11_MainLoop()
 			Window winDummy;
 			unsigned int borderDummy, depthDummy;
 			XGetGeometry(dpy, win, &winDummy,
-					&SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowXPos,
-					&SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowYPos,
-					(unsigned int *)&SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowWidth,
-					(unsigned int *)&SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowHeight,
+					&SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_xpos,
+					&SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_ypos,
+					(unsigned int *)&SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_width,
+					(unsigned int *)&SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_height,
 					&borderDummy, &depthDummy);
 		}
 		usleep(100000);
@@ -252,10 +252,10 @@ static void X11_MainLoop()
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
 	delete XRRConfig;
 #endif
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bDisableScreenSaver)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_disable_screen_saver)
 		X11Utils::InhibitScreensaver(dpy, win, false);
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor)
 		XFreeCursor(dpy, blankCursor);
 	XCloseDisplay(dpy);
 	Core::Stop();
@@ -327,7 +327,7 @@ int main(int argc, char* argv[])
 	SConfig::Init();
 	VideoBackend::PopulateList();
 	VideoBackend::ActivateBackend(SConfig::GetInstance().
-		m_LocalCoreStartupParameter.m_strVideoBackend);
+		m_LocalCoreStartupParameter.m_video_backend);
 	WiimoteReal::LoadSettings();
 
 #if USE_EGL

--- a/Source/Core/DolphinWX/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetWindow.cpp
@@ -444,9 +444,9 @@ void NetPlayDiag::OnChat(wxCommandEvent&)
 void NetPlayDiag::GetNetSettings(NetSettings &settings)
 {
 	SConfig &instance = SConfig::GetInstance();
-	settings.m_CPUthread = instance.m_LocalCoreStartupParameter.bCPUThread;
-	settings.m_CPUcore = instance.m_LocalCoreStartupParameter.iCPUCore;
-	settings.m_DSPHLE = instance.m_LocalCoreStartupParameter.bDSPHLE;
+	settings.m_CPUthread = instance.m_LocalCoreStartupParameter.m_CPU_thread;
+	settings.m_CPUcore = instance.m_LocalCoreStartupParameter.m_CPU_core;
+	settings.m_DSPHLE = instance.m_LocalCoreStartupParameter.m_DSPHLE;
 	settings.m_DSPEnableJIT = instance.m_DSPEnableJIT;
 	settings.m_WriteToMemcard = m_memcard_write->GetValue();
 	settings.m_EXIDevice[0] = instance.m_EXIDevice[0];

--- a/Source/Core/DolphinWX/SoftwareVideoConfigDialog.h
+++ b/Source/Core/DolphinWX/SoftwareVideoConfigDialog.h
@@ -38,7 +38,7 @@ public:
 			Close();
 
 			g_video_backend = new_backend;
-			SConfig::GetInstance().m_LocalCoreStartupParameter.m_strVideoBackend = g_video_backend->GetName();
+			SConfig::GetInstance().m_LocalCoreStartupParameter.m_video_backend = g_video_backend->GetName();
 
 			g_video_backend->ShowConfig(GetParent());
 		}

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -294,7 +294,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 		RegisterControl(choice_display_resolution, wxGetTranslation(display_res_desc));
 		choice_display_resolution->Bind(wxEVT_CHOICE, &VideoConfigDiag::Event_DisplayResolution, this);
 
-		choice_display_resolution->SetStringSelection(StrToWxStr(SConfig::GetInstance().m_LocalCoreStartupParameter.strFullscreenResolution));
+		choice_display_resolution->SetStringSelection(StrToWxStr(SConfig::GetInstance().m_LocalCoreStartupParameter.m_fullscreen_resolution));
 
 		szr_display->Add(label_display_resolution, 1, wxALIGN_CENTER_VERTICAL, 0);
 		szr_display->Add(choice_display_resolution);
@@ -320,7 +320,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	// various other display options
 	{
 	szr_display->Add(CreateCheckBox(page_general, _("V-Sync"), wxGetTranslation(vsync_desc), vconfig.bVSync));
-	szr_display->Add(CreateCheckBox(page_general, _("Use Fullscreen"), wxGetTranslation(use_fullscreen_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.bFullscreen));
+	szr_display->Add(CreateCheckBox(page_general, _("Use Fullscreen"), wxGetTranslation(use_fullscreen_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.m_fullscreen));
 	}
 	}
 
@@ -331,10 +331,10 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	SettingCheckBox* render_to_main_cb;
 	szr_other->Add(CreateCheckBox(page_general, _("Show FPS"), wxGetTranslation(show_fps_desc), vconfig.bShowFPS));
 	szr_other->Add(CreateCheckBox(page_general, _("Log Render Time to File"), wxGetTranslation(log_render_time_to_file_desc), vconfig.bLogRenderTimeToFile));
-	szr_other->Add(CreateCheckBox(page_general, _("Auto adjust Window Size"), wxGetTranslation(auto_window_size_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderWindowAutoSize));
-	szr_other->Add(CreateCheckBox(page_general, _("Keep Window on Top"), wxGetTranslation(keep_window_on_top_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.bKeepWindowOnTop));
-	szr_other->Add(CreateCheckBox(page_general, _("Hide Mouse Cursor"), wxGetTranslation(hide_mouse_cursor_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor));
-	szr_other->Add(render_to_main_cb = CreateCheckBox(page_general, _("Render to Main Window"), wxGetTranslation(render_to_main_win_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain));
+	szr_other->Add(CreateCheckBox(page_general, _("Auto adjust Window Size"), wxGetTranslation(auto_window_size_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_window_auto_size));
+	szr_other->Add(CreateCheckBox(page_general, _("Keep Window on Top"), wxGetTranslation(keep_window_on_top_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.m_keep_window_on_top));
+	szr_other->Add(CreateCheckBox(page_general, _("Hide Mouse Cursor"), wxGetTranslation(hide_mouse_cursor_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.m_hide_cursor));
+	szr_other->Add(render_to_main_cb = CreateCheckBox(page_general, _("Render to Main Window"), wxGetTranslation(render_to_main_win_desc), SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main));
 
 	if (Core::IsRunning())
 		render_to_main_cb->Disable();
@@ -591,9 +591,9 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	if (Core::IsRunning())
 		cb_prog_scan->Disable();
 
-	cb_prog_scan->SetValue(SConfig::GetInstance().m_LocalCoreStartupParameter.bProgressive);
+	cb_prog_scan->SetValue(SConfig::GetInstance().m_LocalCoreStartupParameter.m_progressive);
 	// A bit strange behavior, but this needs to stay in sync with the main progressive boolean; TODO: Is this still necessary?
-	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", SConfig::GetInstance().m_LocalCoreStartupParameter.bProgressive);
+	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", SConfig::GetInstance().m_LocalCoreStartupParameter.m_progressive);
 
 	szr_misc->Add(cb_prog_scan);
 	}
@@ -631,7 +631,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 void VideoConfigDiag::Event_DisplayResolution(wxCommandEvent &ev)
 {
-	SConfig::GetInstance().m_LocalCoreStartupParameter.strFullscreenResolution =
+	SConfig::GetInstance().m_LocalCoreStartupParameter.m_fullscreen_resolution =
 		WxStrToStr(choice_display_resolution->GetStringSelection());
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
 	main_frame->m_XRRConfig->Update();

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -108,7 +108,7 @@ protected:
 				Close();
 
 				g_video_backend = new_backend;
-				SConfig::GetInstance().m_LocalCoreStartupParameter.m_strVideoBackend = g_video_backend->GetName();
+				SConfig::GetInstance().m_LocalCoreStartupParameter.m_video_backend = g_video_backend->GetName();
 
 				g_video_backend->ShowConfig(GetParent());
 			}
@@ -128,7 +128,7 @@ protected:
 	void Event_ProgressiveScan(wxCommandEvent &ev)
 	{
 		SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", ev.GetInt());
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bProgressive = ev.IsChecked();
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_progressive = ev.IsChecked();
 
 		ev.Skip();
 	}

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -264,7 +264,7 @@ HRESULT Create(HWND wnd)
 	swap_chain_desc.OutputWindow = wnd;
 	swap_chain_desc.SampleDesc.Count = 1;
 	swap_chain_desc.SampleDesc.Quality = 0;
-	swap_chain_desc.Windowed = !g_ActiveConfig.bFullscreen;
+	swap_chain_desc.Windowed = !g_ActiveConfig.m_fullscreen;
 
 	DXGI_OUTPUT_DESC out_desc;
 	memset(&out_desc, 0, sizeof(out_desc));

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -448,7 +448,7 @@ void PixelShaderCache::Init()
 	SETSTAT(stats.numPixelShadersAlive, 0);
 
 	std::string cache_filename = StringFromFormat("%sdx11-%s-ps.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-			SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str());
+			SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID.c_str());
 	PixelShaderCacheInserter inserter;
 	g_ps_disk_cache.OpenAndRead(cache_filename, inserter);
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -191,7 +191,7 @@ Renderer::Renderer(void *&window_handle)
 
 	s_LastAA = g_ActiveConfig.iMultisampleMode;
 	s_LastEFBScale = g_ActiveConfig.iEFBScale;
-	s_last_fullscreen_mode = g_ActiveConfig.bFullscreen;
+	s_last_fullscreen_mode = g_ActiveConfig.m_fullscreen;
 	CalculateTargetSize(s_backbuffer_width, s_backbuffer_height);
 
 	SetupDeviceObjects();
@@ -935,8 +935,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbHeight,const EFBRectangl
 	SetWindowSize(fbWidth, fbHeight);
 
 	const bool windowResized = CheckForResize();
-	const bool fullscreen = g_ActiveConfig.bFullscreen &&
-		!SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain;
+	const bool fullscreen = g_ActiveConfig.m_fullscreen &&
+		!SConfig::GetInstance().m_LocalCoreStartupParameter.m_render_to_main;
 
 	bool fullscreen_changed = s_last_fullscreen_mode != fullscreen;
 

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -147,7 +147,7 @@ void VertexShaderCache::Init()
 	SETSTAT(stats.numVertexShadersAlive, 0);
 
 	std::string cache_filename = StringFromFormat("%sdx11-%s-vs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-			SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str());
+			SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID.c_str());
 	VertexShaderCacheInserter inserter;
 	g_vs_disk_cache.OpenAndRead(cache_filename, inserter);
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -413,7 +413,7 @@ void ProgramShaderCache::Init()
 				File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
 
 			std::string cache_filename = StringFromFormat("%sogl-%s-shaders.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-				SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str());
+				SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID.c_str());
 
 			ProgramShaderCacheInserter inserter;
 			g_program_disk_cache.OpenAndRead(cache_filename, inserter);

--- a/Source/Core/VideoBackends/Software/BPMemLoader.cpp
+++ b/Source/Core/VideoBackends/Software/BPMemLoader.cpp
@@ -93,7 +93,7 @@ void SWBPWritten(int address, int newvalue)
 			u8 *ptr = nullptr;
 
 			// TODO - figure out a cleaner way.
-			if (Core::g_CoreStartupParameter.bWii)
+			if (Core::g_CoreStartupParameter.m_wii)
 				ptr = Memory::GetPointer(bpmem.tmem_config.tlut_src << 5);
 			else
 				ptr = Memory::GetPointer((bpmem.tmem_config.tlut_src & 0xFFFFF) << 5);

--- a/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
+++ b/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
@@ -124,7 +124,7 @@ void Shutdown()
 
 void RunGpu()
 {
-	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
+	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_thread)
 	{
 		// We are going to do FP math on the main thread so have to save the current state
 		FPURoundMode::SaveSIMDState();
@@ -307,7 +307,7 @@ static void SetStatus()
 	if (interrupt != interruptSet && !interruptWaiting)
 	{
 		u64 userdata = interrupt?1:0;
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_thread)
 		{
 			interruptWaiting = true;
 			SWCommandProcessor::UpdateInterruptsFromVideoBackend(userdata);

--- a/Source/Core/VideoBackends/Software/SWVideoConfig.cpp
+++ b/Source/Core/VideoBackends/Software/SWVideoConfig.cpp
@@ -10,8 +10,8 @@ SWVideoConfig g_SWVideoConfig;
 
 SWVideoConfig::SWVideoConfig()
 {
-	bFullscreen = false;
-	bHideCursor = false;
+	m_fullscreen = false;
+	m_hide_cursor = false;
 	renderToMainframe = false;
 
 	bHwRasterizer = false;
@@ -39,7 +39,7 @@ void SWVideoConfig::Load(const char* ini_file)
 	iniFile.Load(ini_file);
 
 	IniFile::Section* hardware = iniFile.GetOrCreateSection("Hardware");
-	hardware->Get("Fullscreen", &bFullscreen, 0); // Hardware
+	hardware->Get("Fullscreen", &m_fullscreen, 0); // Hardware
 	hardware->Get("RenderToMainframe", &renderToMainframe, false);
 
 	IniFile::Section* rendering = iniFile.GetOrCreateSection("Rendering");
@@ -69,7 +69,7 @@ void SWVideoConfig::Save(const char* ini_file)
 	iniFile.Load(ini_file);
 
 	IniFile::Section* hardware = iniFile.GetOrCreateSection("Hardware");
-	hardware->Set("Fullscreen", bFullscreen);
+	hardware->Set("Fullscreen", m_fullscreen);
 	hardware->Set("RenderToMainframe", renderToMainframe);
 
 	IniFile::Section* rendering = iniFile.GetOrCreateSection("Rendering");

--- a/Source/Core/VideoBackends/Software/SWVideoConfig.h
+++ b/Source/Core/VideoBackends/Software/SWVideoConfig.h
@@ -16,8 +16,8 @@ struct SWVideoConfig : NonCopyable
 	void Save(const char* ini_file);
 
 	// General
-	bool bFullscreen;
-	bool bHideCursor;
+	bool m_fullscreen;
+	bool m_hide_cursor;
 	bool renderToMainframe;
 
 	bool bHwRasterizer;

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -243,7 +243,7 @@ void VideoSoftware::Video_EndField()
 		DebugUtil::OnFrameEnd(s_beginFieldArgs.fbWidth, s_beginFieldArgs.fbHeight);
 
 		// If we are in dual core mode, notify the GPU thread about the new color texture.
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_thread)
 			Common::AtomicStoreRelease(s_swapRequested, true);
 		else
 			SWRenderer::Swap(s_beginFieldArgs.fbWidth, s_beginFieldArgs.fbHeight);

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -268,7 +268,7 @@ static void BPWritten(const BPCmd& bp)
 			u8 *ptr = nullptr;
 
 			// TODO - figure out a cleaner way.
-			if (Core::g_CoreStartupParameter.bWii)
+			if (Core::g_CoreStartupParameter.m_wii)
 				ptr = Memory::GetPointer(bpmem.tmem_config.tlut_src << 5);
 			else
 				ptr = Memory::GetPointer((bpmem.tmem_config.tlut_src & 0xFFFFF) << 5);

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -50,7 +50,7 @@ volatile u32 VITicks = CommandProcessor::m_cpClockOrigin;
 
 static bool IsOnThread()
 {
-	return SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread;
+	return SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_thread;
 }
 
 static void UpdateInterrupts_Wrapper(u64 userdata, int cyclesLate)

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -158,7 +158,7 @@ void RunGpuLoop()
 			fifo.isGpuReadingData = true;
 			CommandProcessor::isPossibleWaitingSetDrawDone = fifo.bFF_GPLinkEnable ? true : false;
 
-			if (!Core::g_CoreStartupParameter.bSyncGPU || Common::AtomicLoad(CommandProcessor::VITicks) > CommandProcessor::m_cpClockOrigin)
+			if (!Core::g_CoreStartupParameter.m_sync_GPU || Common::AtomicLoad(CommandProcessor::VITicks) > CommandProcessor::m_cpClockOrigin)
 			{
 				u32 readPtr = fifo.CPReadPointer;
 				u8 *uData = Memory::GetPointer(readPtr);
@@ -175,7 +175,7 @@ void RunGpuLoop()
 
 				cyclesExecuted = OpcodeDecoder_Run(g_bSkipCurrentFrame);
 
-				if (Core::g_CoreStartupParameter.bSyncGPU && Common::AtomicLoad(CommandProcessor::VITicks) > cyclesExecuted)
+				if (Core::g_CoreStartupParameter.m_sync_GPU && Common::AtomicLoad(CommandProcessor::VITicks) > cyclesExecuted)
 					Common::AtomicAdd(CommandProcessor::VITicks, -(s32)cyclesExecuted);
 
 				Common::AtomicStore(fifo.CPReadPointer, readPtr);

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -102,7 +102,7 @@ void VideoBackendHardware::Video_BeginField(u32 xfbAddr, u32 fbWidth, u32 fbHeig
 {
 	if (s_BackendInitialized && g_ActiveConfig.bUseXFB)
 	{
-		if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
+		if (!SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_thread)
 			VideoFifo_CheckSwapRequest();
 		s_beginFieldArgs.xfbAddr = xfbAddr;
 		s_beginFieldArgs.fbWidth = fbWidth;
@@ -157,7 +157,7 @@ u32 VideoBackendHardware::Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 
 
 		Common::AtomicStoreRelease(s_efbAccessRequested, true);
 
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_thread)
 		{
 			while (Common::AtomicLoadAcquire(s_efbAccessRequested) && !s_FifoShuttingDown)
 				//Common::SleepCurrentThread(1);
@@ -202,7 +202,7 @@ u32 VideoBackendHardware::Video_GetQueryResult(PerfQueryType type)
 	// TODO: Is this check sane?
 	if (!g_perf_query->IsFlushed())
 	{
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.m_CPU_thread)
 		{
 			s_perf_query_requested = true;
 			std::unique_lock<std::mutex> lk(s_perf_query_lock);

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -37,7 +37,7 @@ void AddMessage(const std::string& str, u32 ms)
 
 void DrawMessages()
 {
-	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bOnScreenDisplayMessages)
+	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.m_on_screen_display_messages)
 		return;
 
 	int left = 25, top = 15;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -462,14 +462,14 @@ void Renderer::UpdateDrawRectangle(int backbuffer_width, int backbuffer_height)
 	int XOffset = (int)(FloatXOffset + 0.5f);
 	int YOffset = (int)(FloatYOffset + 0.5f);
 	int iWhidth = (int)ceil(FloatGLWidth);
-	int iHeight = (int)ceil(FloatGLHeight);
+	int m_height = (int)ceil(FloatGLHeight);
 	iWhidth -= iWhidth % 4; // ensure divisibility by 4 to make it compatible with all the video encoders
-	iHeight -= iHeight % 4;
+	m_height -= m_height % 4;
 
 	target_rc.left = XOffset;
 	target_rc.top = YOffset;
 	target_rc.right = XOffset + iWhidth;
-	target_rc.bottom = YOffset + iHeight;
+	target_rc.bottom = YOffset + m_height;
 }
 
 void Renderer::SetWindowSize(int width, int height)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -48,7 +48,7 @@ TextureCache::TextureCache()
 	TexDecoder_SetTexFmtOverlayOptions(g_ActiveConfig.bTexFmtOverlayEnable, g_ActiveConfig.bTexFmtOverlayCenter);
 
 	if (g_ActiveConfig.bHiresTextures && !g_ActiveConfig.bDumpTextures)
-		HiresTextures::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID);
+		HiresTextures::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID);
 
 	SetHash64Function(g_ActiveConfig.bHiresTextures || g_ActiveConfig.bDumpTextures);
 
@@ -90,7 +90,7 @@ void TextureCache::OnConfigChanged(VideoConfig& config)
 			g_texture_cache->Invalidate();
 
 			if (g_ActiveConfig.bHiresTextures)
-				HiresTextures::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID);
+				HiresTextures::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID);
 
 			SetHash64Function(g_ActiveConfig.bHiresTextures || g_ActiveConfig.bDumpTextures);
 			TexDecoder_SetTexFmtOverlayOptions(g_ActiveConfig.bTexFmtOverlayEnable, g_ActiveConfig.bTexFmtOverlayCenter);
@@ -226,7 +226,7 @@ bool TextureCache::CheckForCustomTextureLODs(u64 tex_hash, int texformat, unsign
 		return false;
 
 	// Just checking if the necessary files exist, if they can't be loaded or have incorrect dimensions LODs will be black
-	std::string texBasePathTemp = StringFromFormat("%s_%08x_%i", SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str(), (u32) (tex_hash & 0x00000000FFFFFFFFLL), texformat);
+	std::string texBasePathTemp = StringFromFormat("%s_%08x_%i", SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID.c_str(), (u32) (tex_hash & 0x00000000FFFFFFFFLL), texformat);
 
 	for (unsigned int level = 1; level < levels; ++level)
 	{
@@ -251,9 +251,9 @@ PC_TexFormat TextureCache::LoadCustomTexture(u64 tex_hash, int texformat, unsign
 	u32 tex_hash_u32 = tex_hash & 0x00000000FFFFFFFFLL;
 
 	if (level == 0)
-		texPathTemp = StringFromFormat("%s_%08x_%i", SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str(), tex_hash_u32, texformat);
+		texPathTemp = StringFromFormat("%s_%08x_%i", SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID.c_str(), tex_hash_u32, texformat);
 	else
-		texPathTemp = StringFromFormat("%s_%08x_%i_mip%u", SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str(), tex_hash_u32, texformat, level);
+		texPathTemp = StringFromFormat("%s_%08x_%i_mip%u", SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID.c_str(), tex_hash_u32, texformat, level);
 
 	unsigned int required_size = 0;
 	PC_TexFormat ret = HiresTextures::GetHiresTex(texPathTemp, &newWidth, &newHeight, &required_size, texformat, temp_size, temp);
@@ -286,7 +286,7 @@ void TextureCache::DumpTexture(TCacheEntryBase* entry, unsigned int level)
 {
 	std::string filename;
 	std::string szDir = File::GetUserPath(D_DUMPTEXTURES_IDX) +
-		SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID;
+		SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID;
 
 	// make sure that the directory exists
 	if (!File::Exists(szDir) || !File::IsDirectory(szDir))
@@ -297,13 +297,13 @@ void TextureCache::DumpTexture(TCacheEntryBase* entry, unsigned int level)
 	if (level == 0)
 	{
 		filename = StringFromFormat("%s/%s_%08x_%i.png", szDir.c_str(),
-			SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str(),
+			SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID.c_str(),
 			(u32)(entry->hash & 0x00000000FFFFFFFFLL), entry->format & 0xFFFF);
 	}
 	else
 	{
 		filename = StringFromFormat("%s/%s_%08x_%i_mip%i.png", szDir.c_str(),
-				SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str(),
+				SConfig::GetInstance().m_LocalCoreStartupParameter.m_unique_ID.c_str(),
 				(u32) (entry->hash & 0x00000000FFFFFFFFLL), entry->format & 0xFFFF, level);
 	}
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -28,7 +28,7 @@ void UpdateActiveConfig()
 VideoConfig::VideoConfig()
 {
 	bRunning = false;
-	bFullscreen = false;
+	m_fullscreen = false;
 
 	// Needed for the first frame, I think
 	fAspectRatioHackW = 1;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -57,7 +57,7 @@ struct VideoConfig final
 
 	// General
 	bool bVSync;
-	bool bFullscreen;
+	bool m_fullscreen;
 	bool bRunning;
 	bool bWidescreenHack;
 	int iAspectRatio;


### PR DESCRIPTION
... to style guide

I got rid of all the Hungarian notation being used in the CoreStatupParameter struct. It builds, and I already reviewed it a couple of times for problems, but it probably still needs another set of eyes. 

Should this be split into more commits? It produced a huge diff, yet it didn't feel like there was any logical way to split the commit without potentially creating build errors.
