### PR TITLE
Place bundled SFML include paths before others

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,7 +618,7 @@ if(SFML_FOUND AND NOT SFML_VERSION_MAJOR) # SFML 1.x doesn't define SFML_VERSION
 else()
 	message("Using static SFML ${SFML_FIND_VERSION_MAJOR}.${SFML_FIND_VERSION_MINOR} from Externals")
 	add_subdirectory(Externals/SFML)
-	include_directories(Externals/SFML/include)
+	include_directories(BEFORE Externals/SFML/include)
 endif()
 
 if(USE_UPNP)

--- a/Externals/SFML/CMakeLists.txt
+++ b/Externals/SFML/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(include)
+include_directories(BEFORE include)
 
 set(SRCS	src/SFML/Network/Ftp.cpp
 			src/SFML/Network/Http.cpp


### PR DESCRIPTION
This allows to build with bundled SFML when system SFML (of another version) is installed
