### PR TITLE
DolphinWX: Get rid of unnecessary hotkey code.

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -482,12 +482,6 @@ wxString CFrame::GetMenuLabel(int Id)
 			Label = wxString::Format(_("Undefined %i"), Id);
 	}
 
-	// wxWidgets only accepts Ctrl/Alt/Shift as menu accelerator
-	// modifiers. On OS X, "Ctrl+" is mapped to the Command key.
-#ifdef __APPLE__
-	if (hotkeymodifier & wxMOD_CMD)
-		hotkeymodifier |= wxMOD_CONTROL;
-#endif
 	hotkeymodifier &= wxMOD_CONTROL | wxMOD_ALT | wxMOD_SHIFT;
 
 	Modifier = InputCommon::WXKeymodToString(hotkeymodifier);


### PR DESCRIPTION
wx handles this for us automatically, there's no need to keep this around.

Tested by @archshift.
