### PR TITLE
Core: Removed blank headers Boot_ELF.h and Boot_WiiWAD.h

### DIFF
--- a/Source/Core/Core/Boot/Boot_ELF.cpp
+++ b/Source/Core/Core/Boot/Boot_ELF.cpp
@@ -5,7 +5,6 @@
 #include "Common/FileUtil.h"
 
 #include "Core/Boot/Boot.h"
-#include "Core/Boot/Boot_ELF.h"
 #include "Core/Boot/ElfReader.h"
 #include "Core/HLE/HLE.h"
 #include "Core/PowerPC/PowerPC.h"

--- a/Source/Core/Core/Boot/Boot_ELF.h
+++ b/Source/Core/Core/Boot/Boot_ELF.h
@@ -1,5 +1,0 @@
-// Copyright 2013 Dolphin Emulator Project
-// Licensed under GPLv2
-// Refer to the license.txt file included.
-
-#pragma once

--- a/Source/Core/Core/Boot/Boot_WiiWAD.h
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.h
@@ -1,6 +1,0 @@
-// Copyright 2014 Dolphin Emulator Project
-// Licensed under GPLv2
-// Refer to the license.txt file included.
-
-#pragma once
-

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -246,8 +246,6 @@
     <ClInclude Include="BootManager.h" />
     <ClInclude Include="Boot\Boot.h" />
     <ClInclude Include="Boot\Boot_DOL.h" />
-    <ClInclude Include="Boot\Boot_ELF.h" />
-    <ClInclude Include="Boot\Boot_WiiWAD.h" />
     <ClInclude Include="Boot\ElfReader.h" />
     <ClInclude Include="Boot\ElfTypes.h" />
     <ClInclude Include="ConfigManager.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -732,12 +732,6 @@
     <ClInclude Include="Boot\Boot_DOL.h">
       <Filter>Boot</Filter>
     </ClInclude>
-    <ClInclude Include="Boot\Boot_ELF.h">
-      <Filter>Boot</Filter>
-    </ClInclude>
-    <ClInclude Include="Boot\Boot_WiiWAD.h">
-      <Filter>Boot</Filter>
-    </ClInclude>
     <ClInclude Include="Boot\ElfReader.h">
       <Filter>Boot</Filter>
     </ClInclude>


### PR DESCRIPTION
No point in keeping around the blank headers.
