### PR TITLE
Frame: Actually call UpdateTitle

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -657,7 +657,7 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
 		break;
 
 	case IDM_UPDATETITLE:
-		SetTitle(event.GetString());
+		UpdateTitle(WxStrToStr(event.GetString()));
 		break;
 
 	case IDM_WINDOWSIZEREQUEST:


### PR DESCRIPTION
This was obviously what I meant to do, but due to a typo, called
SetTitle instead, causing the main game list title to be set instead.
