### PR TITLE
windows: remove now-extraneous NOMINMAX and WIN32_LEAN_AND_MEAN #defines

### DIFF
--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-// DO NOT EVER INCLUDE <windows.h> directly _or indirectly_ from this file
-// since it slows down the build a lot.
-
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -88,13 +85,6 @@ private:
 #endif
 
 #elif defined _WIN32
-
-// Check MSC ver
-	#if !defined _MSC_VER || _MSC_VER <= 1000
-		#error needs at least version 1000 of MSC
-	#endif
-
-	#define NOMINMAX
 
 // Memory leak checks
 	#define CHECK_HEAP_INTEGRITY()

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <windows.h>
-// The following Windows headers MUST be included after windows.h.
+// The following Windows headers must be included AFTER windows.h.
 #include <BluetoothAPIs.h> //NOLINT
 #include <dbt.h>           //NOLINT
 #include <setupapi.h>      //NOLINT

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-// windows crap
-#define NOMINMAX
-
 #include <algorithm>
 #include <cmath>
 #include <memory>

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.cpp
@@ -48,8 +48,11 @@ std::string GetDeviceName(const LPDIRECTINPUTDEVICE8 device)
 void Init(std::vector<Core::Device*>& devices, HWND hwnd)
 {
 	IDirectInput8* idi8;
-	if (FAILED(DirectInput8Create(GetModuleHandle(nullptr), DIRECTINPUT_VERSION, IID_IDirectInput8, (LPVOID*)&idi8, nullptr)))
+	if (FAILED(DirectInput8Create(GetModuleHandle(nullptr), DIRECTINPUT_VERSION,
+		IID_IDirectInput8, (LPVOID*)&idi8, nullptr)))
+	{
 		return;
+	}
 
 	InitKeyboardMouse(idi8, devices, hwnd);
 	InitJoystick(idi8, devices, hwnd);

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput.h
@@ -6,14 +6,11 @@
 
 #define DINPUT_SOURCE_NAME "DInput"
 
-#define DIRECTINPUT_VERSION 0x0800
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <dinput.h>
 #include <list>
 #include <windows.h>
 
 #include "InputCommon/ControllerInterface/Device.h"
+#include "InputCommon/ControllerInterface/DInput/DInput8.h"
 
 namespace ciface
 {

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInput8.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInput8.h
@@ -1,0 +1,8 @@
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#pragma once
+
+#define DIRECTINPUT_VERSION 0x0800
+#include <dinput.h>

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
@@ -4,13 +4,10 @@
 
 #pragma once
 
-#define DIRECTINPUT_VERSION 0x0800
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <dinput.h>
 #include <windows.h>
 
 #include "InputCommon/ControllerInterface/Device.h"
+#include "InputCommon/ControllerInterface/DInput/DInput8.h"
 
 namespace ciface
 {

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
@@ -10,11 +10,8 @@
 #include "InputCommon/ControllerInterface/Device.h"
 
 #ifdef _WIN32
-#define DIRECTINPUT_VERSION 0x0800
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
 #include <Windows.h>
-#include <dinput.h>
+#include "InputCommon/ControllerInterface/DInput/DInput8.h"
 #elif __APPLE__
 #include "InputCommon/ControllerInterface/ForceFeedback/OSX/DirectInputAdapter.h"
 #endif

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#define NOMINMAX
 #include <windows.h>
 #include <XInput.h>
 

--- a/Source/Core/InputCommon/InputCommon.vcxproj
+++ b/Source/Core/InputCommon/InputCommon.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -51,6 +51,7 @@
     <ClInclude Include="ControllerInterface\ControllerInterface.h" />
     <ClInclude Include="ControllerInterface\Device.h" />
     <ClInclude Include="ControllerInterface\DInput\DInput.h" />
+    <ClInclude Include="ControllerInterface\DInput\DInput8.h" />
     <ClInclude Include="ControllerInterface\DInput\DInputJoystick.h" />
     <ClInclude Include="ControllerInterface\DInput\DInputKeyboardMouse.h" />
     <ClInclude Include="ControllerInterface\ExpressionParser.h" />

--- a/Source/Core/InputCommon/InputCommon.vcxproj.filters
+++ b/Source/Core/InputCommon/InputCommon.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="ControllerInterface">
@@ -69,6 +69,9 @@
     </ClInclude>
     <ClInclude Include="ControllerInterface\ForceFeedback\ForceFeedbackDevice.h">
       <Filter>ControllerInterface\ForceFeedback</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\DInput\DInput8.h">
+      <Filter>ControllerInterface\DInput</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Wrap dinput.h in a header defining DIRECTINPUT_VERSION instead of repeating it multiple places.
