### PR TITLE
Remove unused variable m_zero.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -541,8 +541,6 @@ void EmuCodeBlock::Force25BitPrecision(X64Reg xmm, X64Reg tmp)
 static u32 GC_ALIGNED16(temp32);
 static u64 GC_ALIGNED16(temp64);
 
-static const float GC_ALIGNED16(m_zero[]) = { 0.0f, 0.0f, 0.0f, 0.0f };
-
 // Since the following float conversion functions are used in non-arithmetic PPC float instructions,
 // they must convert floats bitexact and never flush denormals to zero or turn SNaNs into QNaNs.
 // This means we can't use CVTSS2SD/CVTSD2SS :(


### PR DESCRIPTION
Since 4f18f6078fdb097a927319ae7b12a0dacf4b42f5 it is no longer used.
