### PR TITLE
x64Emitter: add BMI1/BMI2 support

### DIFF
--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -127,8 +127,8 @@ struct OpArg
 		offset = _offset;
 	}
 	void WriteRex(XEmitter *emit, int opBits, int bits, int customOp = -1) const;
-	void WriteVex(XEmitter* emit, int size, bool packed, X64Reg regOp1, X64Reg regOp2) const;
-	void WriteRest(XEmitter *emit, int extraBytes=0, X64Reg operandReg=(X64Reg)0xFF, bool warn_64bit_offset = true) const;
+	void WriteVex(XEmitter* emit, X64Reg regOp1, X64Reg regOp2, int L, int pp, int mmmmm, int W = 0) const;
+	void WriteRest(XEmitter *emit, int extraBytes=0, X64Reg operandReg=INVALID_REG, bool warn_64bit_offset = true) const;
 	void WriteFloatModRM(XEmitter *emit, FloatOp op);
 	void WriteSingleByteOp(XEmitter *emit, u8 op, X64Reg operandReg, int bits);
 	// This one is public - must be written to
@@ -275,6 +275,9 @@ private:
 	void WriteSSE41Op(int size, u16 sseOp, bool packed, X64Reg regOp, OpArg arg, int extrabytes = 0);
 	void WriteAVXOp(int size, u16 sseOp, bool packed, X64Reg regOp, OpArg arg, int extrabytes = 0);
 	void WriteAVXOp(int size, u16 sseOp, bool packed, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes = 0);
+	void WriteVEXOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes = 0);
+	void WriteBMI1Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes = 0);
+	void WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes = 0);
 	void WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, OpArg arg);
 	void WriteNormalOp(XEmitter *emit, int bits, NormalOp op, const OpArg &a1, const OpArg &a2);
 
@@ -707,6 +710,21 @@ public:
 	void VSQRTSD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
 	void VPAND(X64Reg regOp1, X64Reg regOp2, OpArg arg);
 	void VPANDN(X64Reg regOp1, X64Reg regOp2, OpArg arg);
+
+	// VEX GPR instructions
+	void SARX(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
+	void SHLX(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
+	void SHRX(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
+	void RORX(int bits, X64Reg regOp, OpArg arg, u8 rotate);
+	void PEXT(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);
+	void PDEP(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);
+	void MULX(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);
+	void BZHI(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
+	void BLSR(int bits, X64Reg regOp, OpArg arg);
+	void BLSMSK(int bits, X64Reg regOp, OpArg arg);
+	void BLSI(int bits, X64Reg regOp, OpArg arg);
+	void BEXTR(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
+	void ANDN(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);
 
 	void RDTSC();
 

--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -833,4 +833,121 @@ TWO_OP_SSE_TEST(PMOVZXDQ, "qword")
 
 // TODO: AVX
 
+// for VEX GPR instructions that take the form op reg, r/m, reg
+#define VEX_RMR_TEST(Name) \
+	TEST_F(x64EmitterTest, Name) \
+	{ \
+		struct { \
+			int bits; \
+			std::vector<NamedReg> regs; \
+			std::string out_name; \
+			std::string size; \
+		} regsets[] = { \
+			{ 32, reg32names, "eax", "dword" }, \
+			{ 64, reg64names, "rax", "qword" }, \
+		}; \
+		for (const auto& regset : regsets) \
+			for (const auto& r : regset.regs) \
+			{ \
+				emitter->Name(regset.bits, r.reg, R(RAX), RAX); \
+				emitter->Name(regset.bits, RAX, R(r.reg), RAX); \
+				emitter->Name(regset.bits, RAX, MatR(R12), r.reg); \
+				ExpectDisassembly(#Name " " + r.name + ", " + regset.out_name + ", " + regset.out_name + " " \
+				                  #Name " " + regset.out_name + ", " + r.name + ", " + regset.out_name + " " \
+				                  #Name " " + regset.out_name + ", " + regset.size + " ptr ds:[r12], " + r.name + " "); \
+			} \
+	}
+
+VEX_RMR_TEST(SHRX)
+VEX_RMR_TEST(SARX)
+VEX_RMR_TEST(SHLX)
+VEX_RMR_TEST(BEXTR)
+VEX_RMR_TEST(BZHI)
+
+// for VEX GPR instructions that take the form op reg, reg, r/m
+#define VEX_RRM_TEST(Name) \
+	TEST_F(x64EmitterTest, Name) \
+	{ \
+		struct { \
+			int bits; \
+			std::vector<NamedReg> regs; \
+			std::string out_name; \
+			std::string size; \
+		} regsets[] = { \
+			{ 32, reg32names, "eax", "dword" }, \
+			{ 64, reg64names, "rax", "qword" }, \
+		}; \
+		for (const auto& regset : regsets) \
+			for (const auto& r : regset.regs) \
+			{ \
+				emitter->Name(regset.bits, r.reg, RAX, R(RAX)); \
+				emitter->Name(regset.bits, RAX, RAX, R(r.reg)); \
+				emitter->Name(regset.bits, RAX, r.reg, MatR(R12)); \
+				ExpectDisassembly(#Name " " + r.name+ ", " + regset.out_name + ", " + regset.out_name  + " " \
+				                  #Name " " + regset.out_name + ", " + regset.out_name + ", " + r.name + " " \
+				                  #Name " " + regset.out_name + ", " + r.name + ", " + regset.size + " ptr ds:[r12] "); \
+			} \
+	}
+
+VEX_RRM_TEST(PEXT)
+VEX_RRM_TEST(PDEP)
+VEX_RRM_TEST(MULX)
+VEX_RRM_TEST(ANDN)
+
+// for VEX GPR instructions that take the form op reg, r/m
+#define VEX_RM_TEST(Name) \
+	TEST_F(x64EmitterTest, Name) \
+	{ \
+		struct { \
+			int bits; \
+			std::vector<NamedReg> regs; \
+			std::string out_name; \
+			std::string size; \
+		} regsets[] = { \
+			{ 32, reg32names, "eax", "dword" }, \
+			{ 64, reg64names, "rax", "qword" }, \
+		}; \
+		for (const auto& regset : regsets) \
+			for (const auto& r : regset.regs) \
+			{ \
+				emitter->Name(regset.bits, r.reg, R(RAX)); \
+				emitter->Name(regset.bits, RAX, R(r.reg)); \
+				emitter->Name(regset.bits, r.reg, MatR(R12)); \
+				ExpectDisassembly(#Name " " + r.name+ ", " + regset.out_name  + " " \
+				                  #Name " " + regset.out_name + ", " + r.name + " " \
+				                  #Name " " + r.name + ", " + regset.size + " ptr ds:[r12] "); \
+			} \
+	}
+
+VEX_RM_TEST(BLSR)
+VEX_RM_TEST(BLSMSK)
+VEX_RM_TEST(BLSI)
+
+// for VEX GPR instructions that take the form op reg, r/m, imm
+#define VEX_RMI_TEST(Name) \
+	TEST_F(x64EmitterTest, Name) \
+	{ \
+		struct { \
+			int bits; \
+			std::vector<NamedReg> regs; \
+			std::string out_name; \
+			std::string size; \
+		} regsets[] = { \
+			{ 32, reg32names, "eax", "dword" }, \
+			{ 64, reg64names, "rax", "qword" }, \
+		}; \
+		for (const auto& regset : regsets) \
+			for (const auto& r : regset.regs) \
+						{ \
+				emitter->Name(regset.bits, r.reg, R(RAX), 4); \
+				emitter->Name(regset.bits, RAX, R(r.reg), 4); \
+				emitter->Name(regset.bits, r.reg, MatR(R12), 4); \
+				ExpectDisassembly(#Name " " + r.name+ ", " + regset.out_name  + ", 0x04 " \
+				                  #Name " " + regset.out_name + ", " + r.name + ", 0x04 " \
+				                  #Name " " + r.name + ", " + regset.size + " ptr ds:[r12], 0x04 "); \
+						} \
+	}
+
+VEX_RMI_TEST(RORX)
+
 }  // namespace Gen


### PR DESCRIPTION
TZCNT and LZCNT use a completely different encoding scheme, so they should
probably go in a separate patch.
