### PR TITLE
Slightly rewrite depth calculations to store 3 bytes of data without approximation.

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -206,7 +206,7 @@ static const char EFB_ENCODE_PS[] =
 "{\n"
 	"float2 texCoord = CalcTexCoord(coord);\n"
 
-	"uint depth24 = 0xFFFFFF * EFBTexture.Sample(EFBSampler, texCoord).r;\n"
+	"uint depth24 = 0x1000000 * EFBTexture.Sample(EFBSampler, texCoord).r;\n"
 	"uint4 bytes = uint4(\n"
 		"(depth24 >> 16) & 0xFF,\n" // r
 		"(depth24 >> 8) & 0xFF,\n"  // g

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -120,8 +120,12 @@ const char depth_matrix_program[] = {
 	" in float2 uv0 : TEXCOORD0){\n"
 	"	float4 texcol = Tex0.Sample(samp0,uv0);\n"
 
-	// 255.99998474121 = 16777215/16777216*256
-	"	float workspace = texcol.x * 255.99998474121;\n"
+	// texcol.x contains depth as a float
+	// This depth has 3 bytes (x,y,z) encoded into it.
+	// Encode method:
+	// depth = ((x << 16) + (y << 8) + z) / 256^3
+	// Here we extract those 3 bytes by reversing the encoding.
+	"	float workspace = texcol.x * 256.0;\n"
 
 	"	texcol.x = floor(workspace);\n"         // x component
 
@@ -160,8 +164,12 @@ const char depth_matrix_program_msaa[] = {
 	"		texcol += Tex0.Load(int2(uv0.x*(width), uv0.y*(height)), i);\n"
 	"	texcol /= samples;\n"
 
-	// 255.99998474121 = 16777215/16777216*256
-	"	float workspace = texcol.x * 255.99998474121;\n"
+	// texcol.x contains depth as a float
+	// This depth has 3 bytes (x,y,z) encoded into it.
+	// Encode method:
+	// depth = ((x << 16) + (y << 8) + z) / 256^3
+	// Here we extract those 3 bytes by reversing the encoding.
+	"	float workspace = texcol.x * 256.0;\n"
 
 	"	texcol.x = floor(workspace);\n"         // x component
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -394,11 +394,11 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		if (bpmem.zcontrol.pixel_format == PEControl::RGB565_Z16)
 		{
 			// if Z is in 16 bit format you must return a 16 bit integer
-			ret = ((u32)(val * 0xffff));
+			ret = ((u32)(val * 0x10000));
 		}
 		else
 		{
-			ret = ((u32)(val * 0xffffff));
+			ret = ((u32)(val * 0x1000000));
 		}
 		D3D::context->Unmap(read_tex, 0);
 
@@ -524,7 +524,7 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaE
 
 	// Color is passed in bgra mode so we need to convert it to rgba
 	u32 rgbaColor = (color & 0xFF00FF00) | ((color >> 16) & 0xFF) | ((color << 16) & 0xFF0000);
-	D3D::drawClearQuad(rgbaColor, (z & 0xFFFFFF) / float(0xFFFFFF), PixelShaderCache::GetClearProgram(), VertexShaderCache::GetClearVertexShader(), VertexShaderCache::GetClearInputLayout());
+	D3D::drawClearQuad(rgbaColor, (z & 0xFFFFFF) / float(0x1000000), PixelShaderCache::GetClearProgram(), VertexShaderCache::GetClearVertexShader(), VertexShaderCache::GetClearInputLayout());
 
 	D3D::stateman->PopDepthState();
 	D3D::stateman->PopBlendState();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1122,7 +1122,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		ResetAPIState();
 
 		glDepthMask(GL_TRUE);
-		glClearDepthf(float(poke_data & 0xFFFFFF) / float(0xFFFFFF));
+		glClearDepthf(float(poke_data & 0xFFFFFF) / float(0x1000000));
 
 		glEnable(GL_SCISSOR_TEST);
 		glScissor(targetPixelRc.left, targetPixelRc.bottom, targetPixelRc.GetWidth(), targetPixelRc.GetHeight());
@@ -1210,7 +1210,7 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaE
 	// depth
 	glDepthMask(zEnable ? GL_TRUE : GL_FALSE);
 
-	glClearDepthf(float(z & 0xFFFFFF) / float(0xFFFFFF));
+	glClearDepthf(float(z & 0xFFFFFF) / float(0x1000000));
 
 	// Update rect for clearing the picture
 	glEnable(GL_SCISSOR_TEST);

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -362,8 +362,12 @@ TextureCache::TextureCache()
 		"void main(){\n"
 		"	vec4 texcol = texture(samp9, uv0);\n"
 
-		// 255.99998474121 = 16777215/16777216*256
-		"	float workspace = texcol.x * 255.99998474121;\n"
+		// texcol.x contains depth as a float
+		// This depth has 3 bytes (x,y,z) encoded into it.
+		// Encode method:
+		// depth = ((x << 16) + (y << 8) + z) / 256^3
+		// Here we extract those 3 bytes by reversing the encoding.
+		"	float workspace = texcol.x * 256.0;\n"
 
 		"	texcol.x = floor(workspace);\n"         // x component
 

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -492,7 +492,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	// The performance impact of this additional calculation doesn't matter, but it prevents
 	// the host GPU driver from performing any early depth test optimizations.
 	if (g_ActiveConfig.bFastDepthCalc)
-		out.Write("\tint zCoord = iround(rawpos.z * float(0xFFFFFF));\n");
+		out.Write("\tint zCoord = iround(rawpos.z * float(0x1000000));\n");
 	else
 	{
 		out.SetConstantsUsed(C_ZBIAS+1, C_ZBIAS+1);
@@ -512,7 +512,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 
 	// Note: z-textures are not written to depth buffer if early depth test is used
 	if (per_pixel_depth && bpmem.UseEarlyDepthTest())
-		out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+		out.Write("\tdepth = float(zCoord) / float(0x1000000);\n");
 
 	// Note: depth texture output is only written to depth buffer if late depth test is used
 	// theoretical final depth value is used for fog calculation, though, so we have to emulate ztextures anyway
@@ -526,7 +526,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	}
 
 	if (per_pixel_depth && bpmem.UseLateDepthTest())
-		out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+		out.Write("\tdepth = float(zCoord) / float(0x1000000);\n");
 
 	if (dstAlphaMode == DSTALPHA_ALPHA_PASS)
 	{


### PR DESCRIPTION
I changed the depth calculations to use powers of two when multiplying and dividing, so that the calculated depth will represent the 3 bytes it is composed from without approximation. A side effect of this change is that the depth value is now scaled from `0.0..0.99999994039` instead of from `0.0..1.0`.

If games only use the decoded bytes and never see the floating point value, this should be a safe change. If games use the floating point depth value, there is a risk of regressions. My current understanding of the code is that games never directly use the floating point value, meaning this is a safe change, but I am not 100% sure.

Decoding the 3 bytes from a float _might_ be completely correct in the current implementation. This change is meant to guarantee that the decoding is correct.
#### Reasoning/Explanation

Depth is calculated by combining 3 bytes of data (x, y, z) into a 24 bit integer, and then mapping that integer to a depth value between `0.0` and `1.0`.

The 3 bytes of data are represented by an integer, `zCoord`, with a value between `0x0` and `0xFFFFFF`. Logically, to map `zCoord` to a depth value between `0.0` and `1.0`:

``` c++
depth = (float)zCoord / (float)0xFFFFFF;
```

However, floats cannot perfectly represent most of these results, because floats can only accurately represent fractions that can be completely composed of powers of 2, and floats have only 24 bits of significand to work with. The result is that `depth` will only be an approximation.

To correct this, the calculation is changed to instead be:

``` c++
depth = (float)zCoord / (float)0x1000000;
```

`depth` can now represent the calculation without any approximation, since this operation is essentially just a bit shift operation for floats. In exchange for perfect representation, depth is now a value between `0.0..0.99999994039`.
