### PR TITLE
Fix a gcc compiler error on Archlinux 64bits (GCC 4.9.1)

### DIFF
--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -126,31 +126,10 @@ void CRegTable::UpdateCachedRegs()
 		m_CachedRegHasChanged[i] = (m_CachedRegs[i] != GPR(i));
 		m_CachedRegs[i] = GPR(i);
 
-#if __GNUC__ == 4 && __GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ <= 1
-		/*
-		Workaround There is a bug on GCC 4.9.0-1
-		The compiler has problems with m_CachedFRegs[i][1]
-		We use a loop to avoid this problem
-		*/
-		for (u8 j = 0; j < 2; j++)
-		{
-			if (j == 0)
-			{
-				m_CachedFRegHasChanged[i][j] = (m_CachedFRegs[i][j] != riPS0(i));
-				m_CachedFRegs[i][j] = riPS0(i);
-			}
-			else if (j == 1)
-			{
-				m_CachedFRegHasChanged[i][j] = (m_CachedFRegs[i][j] != riPS1(i));
-				m_CachedFRegs[i][j] = riPS1(i);
-			}
-		}
-#else
 		m_CachedFRegHasChanged[i][0] = (m_CachedFRegs[i][0] != riPS0(i));
 		m_CachedFRegs[i][0] = riPS0(i);
 		m_CachedFRegHasChanged[i][1] = (m_CachedFRegs[i][1] != riPS1(i));
 		m_CachedFRegs[i][1] = riPS1(i);
-#endif
 	}
 	for (int i = 0; i < NUM_SPECIALS; ++i)
 	{


### PR DESCRIPTION
When i was compiling dolphin on Archlinux/testing i have an issue where the offset 1 into m_CachedFRegs[i][1] was unable to compile.
Exactly:
m_CachedFRegHasChanged[i][1] = (m_CachedFRegs[i][1] != riPS1(i));

When i use a loop the compiler hasn't any problem.

Here is the technical problem:

 Scanning dependencies of target dolphin-emu
[ 84%] Building CXX object Source/Core/DolphinWX/CMakeFiles/dolphin-emu.dir/Debugger/RegisterView.cpp.o
/home/nerzhul/Devel/dolphin/Source/Core/DolphinWX/Debugger/RegisterView.cpp: In member function ‘virtual void CRegisterView::Update()’:
/home/nerzhul/Devel/dolphin/Source/Core/DolphinWX/Debugger/RegisterView.cpp:186:6: erreur interne du compilateur: dans vect_get_vec_def_for_operand, à tree-vect-stmts.c:1449
 void CRegisterView::Update()
      ^
Please submit a full bug report,
with preprocessed source if appropriate.
See https://bugs.archlinux.org/ for instructions.
Source/Core/DolphinWX/CMakeFiles/dolphin-emu.dir/build.make:560: recipe for target 'Source/Core/DolphinWX/CMakeFiles/dolphin-emu.dir/Debugger/RegisterView.cpp.o' failed
make[2]: **\* [Source/Core/DolphinWX/CMakeFiles/dolphin-emu.dir/Debugger/RegisterView.cpp.o] Error 1
CMakeFiles/Makefile2:679: recipe for target 'Source/Core/DolphinWX/CMakeFiles/dolphin-emu.dir/all' failed
make[1]: **\* [Source/Core/DolphinWX/CMakeFiles/dolphin-emu.dir/all] Error 2
Makefile:147: recipe for target 'all' failed
make: **\* [all] Error 2
# pacman -Q|grep gcc

40:avr-gcc 4.9.1-1
193:gcc-ada 4.9.1-1
194:gcc-libs-multilib 4.9.1-1
195:gcc-multilib 4.9.1-1
428:lib32-gcc-libs 4.9.1-1
