### PR TITLE
DSPHLE: fields variable is only called one time. Remove the variable all...

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -79,7 +79,9 @@ u32 DSPHLE::DSP_UpdateRate()
 		return (SystemTimers::GetTicksPerSecond() / 1000) * m_pUCode->GetUpdateMs() / VideoInterface::GetNumFields();
 	}
 	else
+	{
 		return SystemTimers::GetTicksPerSecond() / 1000;
+	}
 }
 
 void DSPHLE::SendMailToDSP(u32 _uMail)


### PR DESCRIPTION
...ocation.

This little fix remove a useless variable on DSPHLE.
