### PR TITLE
Re-enable the vertex loader JIT on OS X.

### DIFF
--- a/Source/Core/VideoCommon/VertexLoader.h
+++ b/Source/Core/VideoCommon/VertexLoader.h
@@ -18,9 +18,7 @@
 #include "VideoCommon/NativeVertexFormat.h"
 
 #ifdef _M_X86
-#ifndef __APPLE__
 #define USE_VERTEX_LOADER_JIT
-#endif
 #endif
 
 // They are used for the communication with the loader functions


### PR DESCRIPTION
I can't track down its disabling any further than the following merge.  Frankly, it's so simple that I can't see why it would possibly be broken on OS X, and it seems to work fine for me.

```
commit 5dd502df3b678e04ecc5a5a79af43ecf047b9f92
Merge: 03511d5 7158c14
Author: degasus <wickmarkus@web.de>
Date:   Wed Mar 6 19:07:15 2013 +0100

    Merge branch 'master' into GLSL-master

    the only commit on master is to fix vertexloader, so disable jit for osx

diff --cc Source/Core/VideoCommon/Src/VertexLoader.cpp
index 6c85324,dd8f41c..5e4fbc6a
--- a/Source/Core/VideoCommon/Src/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/Src/VertexLoader.cpp
@@@ -44,8 -44,8 +44,10 @@@
  #include "XFMemory.h"
  extern float GC_ALIGNED16(g_fProjectionMatrix[16]);
  #ifndef _M_GENERIC
++#ifndef __APPLE__
  #define USE_JIT
  #endif
++#endif

  #define COMPILED_CODE_SIZE 4096
```
