### PR TITLE
Don't sleep in the event thread

### DIFF
--- a/Source/Core/DolphinWX/GLInterface/X11_Util.cpp
+++ b/Source/Core/DolphinWX/GLInterface/X11_Util.cpp
@@ -57,19 +57,15 @@ void cX11Window::XEventThread()
 	while (win)
 	{
 		XEvent event;
-		for (int num_events = XPending(dpy); num_events > 0; num_events--)
+		XNextEvent(dpy, &event);
+		switch (event.type)
 		{
-			XNextEvent(dpy, &event);
-			switch (event.type)
-			{
-			case ConfigureNotify:
-				XResizeWindow(dpy, win, event.xconfigure.width, event.xconfigure.height);
-				GLInterface->SetBackBufferDimensions(event.xconfigure.width, event.xconfigure.height);
-				break;
-			default:
-				break;
-			}
+		case ConfigureNotify:
+			XResizeWindow(dpy, win, event.xconfigure.width, event.xconfigure.height);
+			GLInterface->SetBackBufferDimensions(event.xconfigure.width, event.xconfigure.height);
+			break;
+		default:
+			break;
 		}
-		Common::SleepCurrentThread(20);
 	}
 }

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -199,72 +199,69 @@ class PlatformX11 : public Platform
 		{
 			XEvent event;
 			KeySym key;
-			for (int num_events = XPending(dpy); num_events > 0; num_events--)
+			XNextEvent(dpy, &event);
+			switch (event.type)
 			{
-				XNextEvent(dpy, &event);
-				switch (event.type)
+			case KeyPress:
+				key = XLookupKeysym((XKeyEvent*)&event, 0);
+				if (key == XK_Escape)
 				{
-				case KeyPress:
-					key = XLookupKeysym((XKeyEvent*)&event, 0);
-					if (key == XK_Escape)
+					if (Core::GetState() == Core::CORE_RUN)
 					{
-						if (Core::GetState() == Core::CORE_RUN)
-						{
-							if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
-								XUndefineCursor(dpy, win);
-							Core::SetState(Core::CORE_PAUSE);
-						}
-						else
-						{
-							if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
-								XDefineCursor(dpy, win, blankCursor);
-							Core::SetState(Core::CORE_RUN);
-						}
+						if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+							XUndefineCursor(dpy, win);
+						Core::SetState(Core::CORE_PAUSE);
 					}
-					else if ((key == XK_Return) && (event.xkey.state & Mod1Mask))
+					else
 					{
-						fullscreen = !fullscreen;
-						X11Utils::ToggleFullscreen(dpy, win);
-#if defined(HAVE_XRANDR) && HAVE_XRANDR
-						XRRConfig->ToggleDisplayMode(fullscreen);
-#endif
+						if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+							XDefineCursor(dpy, win, blankCursor);
+						Core::SetState(Core::CORE_RUN);
 					}
-					else if (key >= XK_F1 && key <= XK_F8)
-					{
-						int slot_number = key - XK_F1 + 1;
-						if (event.xkey.state & ShiftMask)
-							State::Save(slot_number);
-						else
-							State::Load(slot_number);
-					}
-					else if (key == XK_F9)
-						Core::SaveScreenShot();
-					else if (key == XK_F11)
-						State::LoadLastSaved();
-					else if (key == XK_F12)
-					{
-						if (event.xkey.state & ShiftMask)
-							State::UndoLoadState();
-						else
-							State::UndoSaveState();
-					}
-					break;
-				case FocusIn:
-					rendererHasFocus = true;
-					if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor &&
-					    Core::GetState() != Core::CORE_PAUSE)
-						XDefineCursor(dpy, win, blankCursor);
-					break;
-				case FocusOut:
-					rendererHasFocus = false;
-					if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
-						XUndefineCursor(dpy, win);
-					break;
-				case ClientMessage:
-					if ((unsigned long) event.xclient.data.l[0] == XInternAtom(dpy, "WM_DELETE_WINDOW", False))
-						running = false;
-					break;
 				}
+				else if ((key == XK_Return) && (event.xkey.state & Mod1Mask))
+				{
+					fullscreen = !fullscreen;
+					X11Utils::ToggleFullscreen(dpy, win);
+#if defined(HAVE_XRANDR) && HAVE_XRANDR
+					XRRConfig->ToggleDisplayMode(fullscreen);
+#endif
+				}
+				else if (key >= XK_F1 && key <= XK_F8)
+				{
+					int slot_number = key - XK_F1 + 1;
+					if (event.xkey.state & ShiftMask)
+						State::Save(slot_number);
+					else
+						State::Load(slot_number);
+				}
+				else if (key == XK_F9)
+					Core::SaveScreenShot();
+				else if (key == XK_F11)
+					State::LoadLastSaved();
+				else if (key == XK_F12)
+				{
+					if (event.xkey.state & ShiftMask)
+						State::UndoLoadState();
+					else
+						State::UndoSaveState();
+				}
+				break;
+			case FocusIn:
+				rendererHasFocus = true;
+				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor &&
+				    Core::GetState() != Core::CORE_PAUSE)
+					XDefineCursor(dpy, win, blankCursor);
+				break;
+			case FocusOut:
+				rendererHasFocus = false;
+				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+					XUndefineCursor(dpy, win);
+				break;
+			case ClientMessage:
+				if ((unsigned long) event.xclient.data.l[0] == XInternAtom(dpy, "WM_DELETE_WINDOW", False))
+					running = false;
+				break;
 			}
 			if (!fullscreen)
 			{
@@ -277,7 +274,6 @@ class PlatformX11 : public Platform
 					     (unsigned int *)&SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowHeight,
 					     &borderDummy, &depthDummy);
 			}
-			usleep(100000);
 		}
 	}
 


### PR DESCRIPTION
The person who wrote this seemed to misunderstand how XPending and
XNextEvent actually work. XNextEvent will wait in poll if there's
no event yet, meaning that we don't need to sleep after we process
all the events; the kernel will sleep for us.

This changes indentation, so view with -w or a similar feature to
understand what's actually changed here.
