### PR TITLE
JIT: fix RAM check in load-from-constant-address

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -297,7 +297,7 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg & opAddress,
 			//    MMIO handler and generate the code to load using the handler.
 			// 3. Otherwise, just generate a call to Memory::Read_* with the
 			//    address hardcoded.
-			if ((address & mem_mask) == 0)
+			if (Memory::IsRAMAddress(address))
 			{
 				UnsafeLoadToReg(reg_value, opAddress, accessSize, offset, signExtend);
 			}


### PR DESCRIPTION
A bug that seems to have been uncovered by allowing immediate-address loads.
Super Monkey Ball 2 crashes without this change -- it's possible, however, that
the game actually requires the MMU hack, since it crashed due to accessing an
address in the 0x20000000-0x3fffffff range.
