### PR TITLE
Update build.gradle to newer buildtools.

### DIFF
--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:0.8.+'
+		classpath 'com.android.tools.build:gradle:0.12.+'
 	}
 }
 apply plugin: 'android'
@@ -15,7 +15,7 @@ dependencies {
 
 android {
 	compileSdkVersion 19
-	buildToolsVersion "19.0.1"
+	buildToolsVersion "20.0.0"
 
 	task nativeLibsToJar(type: Zip, description: 'create a jar archive of the native libs') {
 		destinationDir file("$buildDir/native-libs")


### PR DESCRIPTION
Newer android studio versions now mandate at least build tools 20.0.0 and gradle 0.12+
So update the gradle file for this.

Requires Matt_P to update the buildbot to newer buildtools version
