### PR TITLE
Update shown CPU cores in the Android UI.

### DIFF
--- a/Source/Android/res/values-ja/strings.xml
+++ b/Source/Android/res/values-ja/strings.xml
@@ -137,6 +137,7 @@
     <string name="jit64_recompiler">JIT64 Recompiler</string>
     <string name="jitil_recompiler">JITIL Recompiler</string>
     <string name="jit_arm_recompiler">JIT ARM Recompiler</string>
+    <string name="jit_arm64_recompiler">JIT ARM64 Recompiler</string>
     <string name="cpu_settings">CPU</string>
     <string name="cpu_core">CPUコア</string>
     <string name="cpu_core_desc">%s</string>

--- a/Source/Android/res/values/arrays.xml
+++ b/Source/Android/res/values/arrays.xml
@@ -3,13 +3,13 @@
 <!-- All lists for ListPreference keys/values are placed here -->
 <resources>
     
-    <!-- CPU core selection - X86 -->
-    <string-array name="emuCoreEntriesX86" translatable="false">
+    <!-- CPU core selection - X86_64 -->
+    <string-array name="emuCoreEntriesX86_64" translatable="false">
         <item>@string/interpreter</item>
         <item>@string/jit64_recompiler</item>
         <item>@string/jitil_recompiler</item>
     </string-array>
-    <string-array name="emuCoreValuesX86" translatable="false">
+    <string-array name="emuCoreValuesX86_64" translatable="false">
         <item>0</item>
         <item>1</item>
         <item>2</item>
@@ -23,6 +23,16 @@
     <string-array name="emuCoreValuesARM" translatable="false">
         <item>0</item>
         <item>3</item>
+    </string-array>
+
+    <!-- CPU core selection - ARM64 -->
+    <string-array name="emuCoreEntriesARM64" translatable="false">
+        <item>@string/interpreter</item>
+        <item>@string/jit_arm64_recompiler</item>
+    </string-array>
+    <string-array name="emuCoreValuesARM64" translatable="false">
+        <item>0</item>
+        <item>4</item>
     </string-array>
     
     <!-- CPU core selection - Other -->

--- a/Source/Android/res/values/strings.xml
+++ b/Source/Android/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="jit64_recompiler">JIT64 Recompiler</string>
     <string name="jitil_recompiler">JITIL Recompiler</string>
     <string name="jit_arm_recompiler">JIT ARM Recompiler</string>
+    <string name="jit_arm64_recompiler">JIT ARM64 Recompiler</string>
     <string name="cpu_settings">CPU</string>
     <string name="cpu_core">CPU Core</string>
     <string name="cpu_core_desc">%s</string>

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/cpu/CPUSettingsFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/cpu/CPUSettingsFragment.java
@@ -32,10 +32,15 @@ public final class CPUSettingsFragment extends PreferenceFragment
 		// Set valid emulation cores depending on the CPU architecture
 		// that the Android device is running on.
 		//
-		if (Build.CPU_ABI.contains("x86"))
+		if (Build.CPU_ABI.contains("x86-64"))
 		{
-			cpuCores.setEntries(R.array.emuCoreEntriesX86);
-			cpuCores.setEntryValues(R.array.emuCoreValuesX86);
+			cpuCores.setEntries(R.array.emuCoreEntriesX86_64);
+			cpuCores.setEntryValues(R.array.emuCoreValuesX86_64);
+		}
+		else if (Build.CPU_ABI.contains("arm64"))
+		{
+			cpuCores.setEntries(R.array.emuCoreEntriesARM64);
+			cpuCores.setEntryValues(R.array.emuCoreValuesARM64);
 		}
 		else if (Build.CPU_ABI.contains("arm"))
 		{


### PR DESCRIPTION
Only show the JIT cores on x86_64(Will have its own issues once we reach that point)
Show AArch64 JIT if running on a AArch64 device(Good luck with that for now. Future proofing though)
