### PR TITLE
JIT64: try enabling dcbz again

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -235,6 +235,20 @@ void Memset(const u32 _Address, const u8 _iValue, const u32 _iLength)
 	}
 }
 
+void ClearCacheLine(const u32 _Address)
+{
+	u8 *ptr = GetPointer(_Address);
+	if (ptr != nullptr)
+	{
+		memset(ptr, 0, 32);
+	}
+	else
+	{
+		for (u32 i = 0; i < 32; i += 8)
+			Write_U64(0, _Address + i);
+	}
+}
+
 void DMA_LCToMemory(const u32 _MemAddr, const u32 _CacheAddr, const u32 _iNumBlocks)
 {
 	const u8 *src = m_pL1Cache + (_CacheAddr & 0x3FFFF);

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -126,6 +126,7 @@ u8* GetPointer(const u32 _Address);
 void DMA_LCToMemory(const u32 _iMemAddr, const u32 _iCacheAddr, const u32 _iNumBlocks);
 void DMA_MemoryToLC(const u32 _iCacheAddr, const u32 _iMemAddr, const u32 _iNumBlocks);
 void Memset(const u32 _Address, const u8 _Data, const u32 _iLength);
+void ClearCacheLine(const u32 _Address); // Zeroes 32 bytes; address should be 32-byte-aligned
 
 // TLB functions
 void SDRUpdated();

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -376,7 +376,7 @@ void Interpreter::dcbz(UGeckoInstruction _inst)
 {
 	// HACK but works... we think
 	if (!Core::g_CoreStartupParameter.bDCBZOFF)
-		Memory::Memset(Helper_Get_EA_X(_inst) & (~31), 0, 32);
+		Memory::ClearCacheLine(Helper_Get_EA_X(_inst) & (~31));
 	if (!JitInterface::GetCore())
 		PowerPC::CheckExceptions();
 }


### PR DESCRIPTION
This time, check the address carefully beforehand, since apparently some games do horrible things like running it on non-RAM addresses, or at the very least virtual addresses.

Kinda like https://github.com/dolphin-emu/dolphin/pull/400, but trying to be extra safe here.
