### PR TITLE
Add OSD messages back to status bar.

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -123,6 +123,7 @@ void DisplayMessage(const std::string& message, int time_in_ms)
 	}
 
 	g_video_backend->Video_AddMessage(message, time_in_ms);
+	Host_UpdateTitle(message);
 }
 
 bool IsRunning()


### PR DESCRIPTION
OSD messages can be disabled, while still leaving them in the status bar. This is incredibly useful for certain users, who may wish to see the messages, but do not wish to have them cover up half of the screen. In particular TASers will generally have OSD messages on the screen 100% of the time, and they cover up useful information, making it critical to turn them off. However the messages are still very useful to them, so it's important to have them somewhere.

This reverts 4a16211bae97a42c24ed43cf4174df03d180ac4a.
