### PR TITLE
AudioCommon: Get rid of now unused handle param for InitSoundStream()

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -25,7 +25,7 @@ SoundStream *soundStream = nullptr;
 
 namespace AudioCommon
 {
-	SoundStream *InitSoundStream(void *hWnd)
+	SoundStream* InitSoundStream()
 	{
 		CMixer *mixer = new CMixer(48000);
 

--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -14,7 +14,7 @@ extern SoundStream *soundStream;
 
 namespace AudioCommon
 {
-	SoundStream *InitSoundStream(void *hWnd);
+	SoundStream* InitSoundStream();
 	void ShutdownSoundStream();
 	std::vector<std::string> GetSoundBackends();
 	void PauseAndLock(bool doLock, bool unpauseOnUnlock=true);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -363,7 +363,7 @@ void EmuThread()
 
 	}
 
-	AudioCommon::InitSoundStream(g_pWindowHandle);
+	AudioCommon::InitSoundStream();
 
 	// The hardware is initialized.
 	g_bHwInit = true;


### PR DESCRIPTION
This is unused now that DirectSound is removed.
