### PR TITLE
Disable Debugger's PPC vs x86 menu option in interpreter mode

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -35,6 +35,7 @@
 #include "Common/SymbolDB.h"
 #include "Core/Core.h"
 #include "Core/Host.h"
+#include "Core/ConfigManager.h"
 #include "DolphinWX/Globals.h"
 #include "DolphinWX/WxUtils.h"
 #include "DolphinWX/Debugger/CodeView.h"
@@ -382,7 +383,8 @@ void CCodeView::OnMouseUpR(wxMouseEvent& event)
 	menu->AppendSeparator();
 	menu->Append(IDM_RUNTOHERE, _("&Run To Here"))->Enable(Core::IsRunning());
 	menu->Append(IDM_ADDFUNCTION, _("&Add function"))->Enable(Core::IsRunning());
-	menu->Append(IDM_JITRESULTS, _("PPC vs X86"))->Enable(Core::IsRunning());
+	menu->Append(IDM_JITRESULTS, _("PPC vs X86"))->Enable(Core::IsRunning() &&
+		SConfig::GetInstance().m_LocalCoreStartupParameter.iCPUCore != 0);
 	menu->Append(IDM_INSERTBLR, _("Insert &blr"))->Enable(Core::IsRunning());
 	menu->Append(IDM_INSERTNOP, _("Insert &nop"))->Enable(Core::IsRunning());
 	menu->Append(IDM_PATCHALERT, _("Patch alert"))->Enable(Core::IsRunning());


### PR DESCRIPTION
When the interpreter core is selected, choosing "PPC vs x86" in the debugger's code view leads to a crash.

This PR checks if the current JIT implementation is null and disable the menu option accordingly.

(I'm not sure pulling in the JitBase header just for the jit variable is a good idea... should I change it to an extern?)
