### PR TITLE
DolphinWX: Fix exporting of Wii save files

### DIFF
--- a/Source/Core/DolphinWX/MemoryCards/WiiSaveCrypted.cpp
+++ b/Source/Core/DolphinWX/MemoryCards/WiiSaveCrypted.cpp
@@ -445,10 +445,9 @@ void CWiiSaveCrypted::ExportWiiSaveFiles()
 				m_valid = false;
 			}
 
-			std::vector<u8> file_data, file_data_enc;
-			file_data.reserve(file_size_rounded);
-			file_data_enc.reserve(file_size_rounded);
-			memset(&file_data[0], 0, file_size_rounded);
+			std::vector<u8> file_data(file_size_rounded);
+			std::vector<u8> file_data_enc(file_size_rounded);
+
 			if (!raw_save_file.ReadBytes(&file_data[0], file_size))
 			{
 				ERROR_LOG(CONSOLE, "Failed to read data from file: %s",


### PR DESCRIPTION
This would trip an out of bounds assert due the fact that the size is reserved, but the vector is not actually resized.
