### PR TITLE
VertexLoader: Change VtxDesc to use u64 instead of u32

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -139,7 +139,7 @@ void CalculateVertexElementSizes(int sizes[], int vatIndex, const CPMemory &cpMe
 	const VAT &vtxAttr = cpMem.vtxAttr[vatIndex];
 
 	// Colors
-	const u32 colDesc[2] = {vtxDesc.Color0, vtxDesc.Color1};
+	const u64 colDesc[2] = {vtxDesc.Color0, vtxDesc.Color1};
 	const u32 colComp[2] = {vtxAttr.g0.Color0Comp, vtxAttr.g0.Color1Comp};
 
 	const u32 tcElements[8] =

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -52,21 +52,21 @@ void SWVertexLoader::SetFormat(u8 attributeIndex, u8 primitiveType)
 	tcScale[7] = 1.0f / float(1 << m_CurrentVat->g2.Tex7Frac);
 
 	//TexMtx
-	const u32 tmDesc[8] = {
+	const u64 tmDesc[8] = {
 		g_VtxDesc.Tex0MatIdx, g_VtxDesc.Tex1MatIdx, g_VtxDesc.Tex2MatIdx, g_VtxDesc.Tex3MatIdx,
 		g_VtxDesc.Tex4MatIdx, g_VtxDesc.Tex5MatIdx, g_VtxDesc.Tex6MatIdx, g_VtxDesc.Tex7MatIdx
 	};
 
 	// Colors
-	const u32 colDesc[2] = {g_VtxDesc.Color0, g_VtxDesc.Color1};
+	const u64 colDesc[2] = {g_VtxDesc.Color0, g_VtxDesc.Color1};
 	colElements[0] = m_CurrentVat->g0.Color0Elements;
 	colElements[1] = m_CurrentVat->g0.Color1Elements;
 	const u32 colComp[2] = {m_CurrentVat->g0.Color0Comp, m_CurrentVat->g0.Color1Comp};
 
 	// TextureCoord
-	const u32 tcDesc[8] = {
+	const u64 tcDesc[8] = {
 		g_VtxDesc.Tex0Coord, g_VtxDesc.Tex1Coord, g_VtxDesc.Tex2Coord, g_VtxDesc.Tex3Coord,
-		g_VtxDesc.Tex4Coord, g_VtxDesc.Tex5Coord, g_VtxDesc.Tex6Coord, (const u32)((g_VtxDesc.Hex >> 31) & 3)
+		g_VtxDesc.Tex4Coord, g_VtxDesc.Tex5Coord, g_VtxDesc.Tex6Coord, g_VtxDesc.Tex7Coord
 	};
 	const u32 tcElements[8] = {
 		m_CurrentVat->g0.Tex0CoordElements, m_CurrentVat->g1.Tex1CoordElements, m_CurrentVat->g1.Tex2CoordElements,
@@ -219,7 +219,7 @@ void SWVertexLoader::SetFormat(u8 attributeIndex, u8 primitiveType)
 	// Texture matrix indices (remove if corresponding texture coordinate isn't enabled)
 	for (int i = 0; i < 8; i++)
 	{
-		const int desc = tcDesc[i];
+		const int desc = (int)tcDesc[i];
 		const int format = tcFormat[i];
 		const int elements = tcElements[i];
 		_assert_msg_(VIDEO, NOT_PRESENT <= desc && desc <= INDEX16, "Invalid texture coordinates description!\n(desc = %d)", desc);

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -59,33 +59,33 @@ union TVtxDesc
 	{
 		// 0: not present
 		// 1: present
-		u32 PosMatIdx   : 1;
-		u32 Tex0MatIdx  : 1;
-		u32 Tex1MatIdx  : 1;
-		u32 Tex2MatIdx  : 1;
-		u32 Tex3MatIdx  : 1;
-		u32 Tex4MatIdx  : 1;
-		u32 Tex5MatIdx  : 1;
-		u32 Tex6MatIdx  : 1;
-		u32 Tex7MatIdx  : 1;
+		u64 PosMatIdx   : 1;
+		u64 Tex0MatIdx  : 1;
+		u64 Tex1MatIdx  : 1;
+		u64 Tex2MatIdx  : 1;
+		u64 Tex3MatIdx  : 1;
+		u64 Tex4MatIdx  : 1;
+		u64 Tex5MatIdx  : 1;
+		u64 Tex6MatIdx  : 1;
+		u64 Tex7MatIdx  : 1;
 
 		// 00: not present
 		// 01: direct
 		// 10: 8 bit index
 		// 11: 16 bit index
-		u32 Position    : 2;
-		u32 Normal      : 2;
-		u32 Color0      : 2;
-		u32 Color1      : 2;
-		u32 Tex0Coord   : 2;
-		u32 Tex1Coord   : 2;
-		u32 Tex2Coord   : 2;
-		u32 Tex3Coord   : 2;
-		u32 Tex4Coord   : 2;
-		u32 Tex5Coord   : 2;
-		u32 Tex6Coord   : 2;
-		u32 Tex7Coord   : 2;
-		u32             :31;
+		u64 Position    : 2;
+		u64 Normal      : 2;
+		u64 Color0      : 2;
+		u64 Color1      : 2;
+		u64 Tex0Coord   : 2;
+		u64 Tex1Coord   : 2;
+		u64 Tex2Coord   : 2;
+		u64 Tex3Coord   : 2;
+		u64 Tex4Coord   : 2;
+		u64 Tex5Coord   : 2;
+		u64 Tex6Coord   : 2;
+		u64 Tex7Coord   : 2;
+		u64             :31;
 	};
 
 	struct

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -518,14 +518,11 @@ void VertexLoader::CompileVertexTranslator()
 #endif
 
 	// Colors
-	const u32 col[2] = {m_VtxDesc.Color0, m_VtxDesc.Color1};
+	const u64 col[2] = {m_VtxDesc.Color0, m_VtxDesc.Color1};
 	// TextureCoord
-	// Since m_VtxDesc.Text7Coord is broken across a 32 bit word boundary, retrieve its value manually.
-	// If we didn't do this, the vertex format would be read as one bit offset from where it should be, making
-	// 01 become 00, and 10/11 become 01
-	const u32 tc[8] = {
+	const u64 tc[8] = {
 		m_VtxDesc.Tex0Coord, m_VtxDesc.Tex1Coord, m_VtxDesc.Tex2Coord, m_VtxDesc.Tex3Coord,
-		m_VtxDesc.Tex4Coord, m_VtxDesc.Tex5Coord, m_VtxDesc.Tex6Coord, (const u32)((m_VtxDesc.Hex >> 31) & 3)
+		m_VtxDesc.Tex4Coord, m_VtxDesc.Tex5Coord, m_VtxDesc.Tex6Coord, m_VtxDesc.Tex7Coord
 	};
 
 	u32 components = 0;
@@ -583,7 +580,7 @@ void VertexLoader::CompileVertexTranslator()
 		{
 			Host_SysMessage(
 				StringFromFormat("VertexLoader_Normal::GetFunction(%i %i %i %i) returned zero!",
-				m_VtxDesc.Normal, m_VtxAttr.NormalFormat,
+				(u32)m_VtxDesc.Normal, m_VtxAttr.NormalFormat,
 				m_VtxAttr.NormalElements, m_VtxAttr.NormalIndex3).c_str());
 		}
 		WriteCall(pFunc);
@@ -677,7 +674,7 @@ void VertexLoader::CompileVertexTranslator()
 		}
 		else
 		{
-			_assert_msg_(VIDEO, DIRECT <= tc[i] && tc[i] <= INDEX16, "Invalid texture coordinates!\n(tc[i] = %d)", tc[i]);
+			_assert_msg_(VIDEO, DIRECT <= tc[i] && tc[i] <= INDEX16, "Invalid texture coordinates!\n(tc[i] = %d)", (u32)tc[i]);
 			_assert_msg_(VIDEO, FORMAT_UBYTE <= format && format <= FORMAT_FLOAT, "Invalid texture coordinates format!\n(format = %d)", format);
 			_assert_msg_(VIDEO, 0 <= elements && elements <= 1, "Invalid number of texture coordinates elements!\n(elements = %d)", elements);
 
@@ -913,7 +910,7 @@ void VertexLoader::AppendToString(std::string *dest) const
 	};
 
 	dest->append(StringFromFormat("%ib skin: %i P: %i %s-%s ",
-		m_VertexSize, m_VtxDesc.PosMatIdx,
+		m_VertexSize, (u32)m_VtxDesc.PosMatIdx,
 		m_VtxAttr.PosElements ? 3 : 2, posMode[m_VtxDesc.Position], posFormats[m_VtxAttr.PosFormat]));
 
 	if (m_VtxDesc.Normal)
@@ -922,7 +919,7 @@ void VertexLoader::AppendToString(std::string *dest) const
 			m_VtxAttr.NormalElements, posMode[m_VtxDesc.Normal], posFormats[m_VtxAttr.NormalFormat]));
 	}
 
-	u32 color_mode[2] = {m_VtxDesc.Color0, m_VtxDesc.Color1};
+	u64 color_mode[2] = {m_VtxDesc.Color0, m_VtxDesc.Color1};
 	for (int i = 0; i < 2; i++)
 	{
 		if (color_mode[i])
@@ -930,7 +927,7 @@ void VertexLoader::AppendToString(std::string *dest) const
 			dest->append(StringFromFormat("C%i: %i %s-%s ", i, m_VtxAttr.color[i].Elements, posMode[color_mode[i]], colorFormat[m_VtxAttr.color[i].Comp]));
 		}
 	}
-	u32 tex_mode[8] = {
+	u64 tex_mode[8] = {
 		m_VtxDesc.Tex0Coord, m_VtxDesc.Tex1Coord, m_VtxDesc.Tex2Coord, m_VtxDesc.Tex3Coord,
 		m_VtxDesc.Tex4Coord, m_VtxDesc.Tex5Coord, m_VtxDesc.Tex6Coord, m_VtxDesc.Tex7Coord
 	};

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -182,13 +182,13 @@ void VertexLoader_Normal::Init()
 	m_Table[NRM_INDEX16][NRM_INDICES3][NRM_NBT3][FORMAT_FLOAT]  = Normal_Index_Indices3<u16, float>();
 }
 
-unsigned int VertexLoader_Normal::GetSize(unsigned int _type,
+unsigned int VertexLoader_Normal::GetSize(u64 _type,
 	unsigned int _format, unsigned int _elements, unsigned int _index3)
 {
 	return m_Table[_type][_index3][_elements][_format].gc_size;
 }
 
-TPipelineFunction VertexLoader_Normal::GetFunction(unsigned int _type,
+TPipelineFunction VertexLoader_Normal::GetFunction(u64 _type,
 	unsigned int _format, unsigned int _elements, unsigned int _index3)
 {
 	TPipelineFunction pFunc = m_Table[_type][_index3][_elements][_format].function;

--- a/Source/Core/VideoCommon/VertexLoader_Normal.h
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.h
@@ -14,11 +14,11 @@ public:
 	static void Init();
 
 	// GetSize
-	static unsigned int GetSize(unsigned int _type, unsigned int _format,
+	static unsigned int GetSize(u64 _type, unsigned int _format,
 		unsigned int _elements, unsigned int _index3);
 
 	// GetFunction
-	static TPipelineFunction GetFunction(unsigned int _type,
+	static TPipelineFunction GetFunction(u64 _type,
 		unsigned int _format, unsigned int _elements, unsigned int _index3);
 
 private:

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -182,12 +182,12 @@ void VertexLoader_Position::Init()
 
 }
 
-unsigned int VertexLoader_Position::GetSize(unsigned int _type, unsigned int _format, unsigned int _elements)
+unsigned int VertexLoader_Position::GetSize(u64 _type, unsigned int _format, unsigned int _elements)
 {
 	return tableReadPositionVertexSize[_type][_format][_elements];
 }
 
-TPipelineFunction VertexLoader_Position::GetFunction(unsigned int _type, unsigned int _format, unsigned int _elements)
+TPipelineFunction VertexLoader_Position::GetFunction(u64 _type, unsigned int _format, unsigned int _elements)
 {
 	return tableReadPosition[_type][_format][_elements];
 }

--- a/Source/Core/VideoCommon/VertexLoader_Position.h
+++ b/Source/Core/VideoCommon/VertexLoader_Position.h
@@ -11,9 +11,9 @@ public:
 	static void Init();
 
 	// GetSize
-	static unsigned int GetSize(unsigned int _type, unsigned int _format, unsigned int _elements);
+	static unsigned int GetSize(u64 _type, unsigned int _format, unsigned int _elements);
 
 	// GetFunction
-	static TPipelineFunction GetFunction(unsigned int _type, unsigned int _format, unsigned int _elements);
+	static TPipelineFunction GetFunction(u64 _type, unsigned int _format, unsigned int _elements);
 };
 

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -198,12 +198,12 @@ void VertexLoader_TextCoord::Init()
 
 }
 
-unsigned int VertexLoader_TextCoord::GetSize(unsigned int _type, unsigned int _format, unsigned int _elements)
+unsigned int VertexLoader_TextCoord::GetSize(u64 _type, unsigned int _format, unsigned int _elements)
 {
 	return tableReadTexCoordVertexSize[_type][_format][_elements];
 }
 
-TPipelineFunction VertexLoader_TextCoord::GetFunction(unsigned int _type, unsigned int _format, unsigned int _elements)
+TPipelineFunction VertexLoader_TextCoord::GetFunction(u64 _type, unsigned int _format, unsigned int _elements)
 {
 	return tableReadTexCoord[_type][_format][_elements];
 }

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.h
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.h
@@ -14,10 +14,10 @@ public:
 	static void Init();
 
 	// GetSize
-	static unsigned int GetSize(unsigned int _type, unsigned int _format, unsigned int _elements);
+	static unsigned int GetSize(u64 _type, unsigned int _format, unsigned int _elements);
 
 	// GetFunction
-	static TPipelineFunction GetFunction(unsigned int _type, unsigned int _format, unsigned int _elements);
+	static TPipelineFunction GetFunction(u64 _type, unsigned int _format, unsigned int _elements);
 
 	// GetDummyFunction
 	// It is important to synchronize tcIndex.


### PR DESCRIPTION
This is required to make packing consistent between compilers: with u32, MSVC
would not allocate a bitfield that spans two u32s (it would leave a "hole").
