### PR TITLE
DolphinWX: Get rid of unnecessary getName function in LogWindow

### DIFF
--- a/Source/Core/DolphinWX/LogWindow.h
+++ b/Source/Core/DolphinWX/LogWindow.h
@@ -87,7 +87,4 @@ private:
 	void OnClear(wxCommandEvent& event);
 	void OnLogTimer(wxTimerEvent& WXUNUSED(event));
 	void UpdateLog();
-
-	// LogListener
-	const char *getName() const { return "LogWindow"; }
 };


### PR DESCRIPTION
This isn't used at all, and is probably from when this was actually part of LogListener, which it isn't anymore.
