### PR TITLE
move the decision to delay raw memcard flushes out of the thread.

### DIFF
--- a/Source/Core/Core/HW/GCMemcardRaw.h
+++ b/Source/Core/Core/HW/GCMemcardRaw.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include "Common/Event.h"
 #include "Common/Flag.h"
@@ -34,4 +35,6 @@ private:
 	Common::Event m_flush_trigger;
 	Common::Flag m_is_exiting;
 	std::unique_ptr<u8[]> m_flush_buffer;
+	std::chrono::steady_clock::time_point m_last_flush;
+	static const std::chrono::seconds s_flush_interval;
 };


### PR DESCRIPTION
This allows the flush to work better with games which hammer
memcard accesses over short periods as it delays more of the work.
