### PR TITLE
explicitly disable PIE. fixes issues on systems like gentoo-hardened.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,11 @@ endif(NOT MSVC)
 # gcc uses some optimizations which might break stuff without this flag
 add_definitions(-fno-strict-aliasing -fno-exceptions)
 
+# explicitly disable PIE, as this breaks dolphin on systems like
+# gentoo-hardened
+add_definitions(-fno-pie)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fno-pie")
+
 check_and_add_flag(VISIBILITY_INLINES_HIDDEN -fvisibility-inlines-hidden)
 
 if(UNIX AND NOT APPLE)


### PR DESCRIPTION
Adds the -fno-pie flag to compiler and linker. This resolves a problem where Dolphin, when compiled under gentoo-hardened, did not boot games, but instead showed lots of errors like the following:

WriteRest: op out of range (0x41e430ea uses 0x7f29ace312e0)

The fixed bug might(?) be the same as this one: https://code.google.com/p/dolphin-emu/issues/detail?id=7467