### PR TITLE
Fixed bug introduced in PR#803 caused by casting

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -106,22 +106,22 @@ void GCPad::GetInput(GCPadStatus* const pad)
 
 	// sticks
 	m_main_stick->GetState(&x, &y);
-	pad->stickX = GCPadStatus::MAIN_STICK_CENTER_X + (u8)(x * GCPadStatus::MAIN_STICK_RADIUS);
-	pad->stickY = GCPadStatus::MAIN_STICK_CENTER_Y + (u8)(y * GCPadStatus::MAIN_STICK_RADIUS);
+	pad->stickX = static_cast<u8>(GCPadStatus::MAIN_STICK_CENTER_X + (x * GCPadStatus::MAIN_STICK_RADIUS));
+	pad->stickY = static_cast<u8>(GCPadStatus::MAIN_STICK_CENTER_Y + (y * GCPadStatus::MAIN_STICK_RADIUS));
 
 	m_c_stick->GetState(&x, &y);
-	pad->substickX = GCPadStatus::C_STICK_CENTER_X + (u8)(x * GCPadStatus::C_STICK_RADIUS);
-	pad->substickY = GCPadStatus::C_STICK_CENTER_Y + (u8)(y * GCPadStatus::C_STICK_RADIUS);
+	pad->substickX = static_cast<u8>(GCPadStatus::C_STICK_CENTER_X + (x * GCPadStatus::C_STICK_RADIUS));
+	pad->substickY = static_cast<u8>(GCPadStatus::C_STICK_CENTER_Y + (y * GCPadStatus::C_STICK_RADIUS));
 
 	// triggers
 	m_triggers->GetState(&pad->button, trigger_bitmasks, triggers);
-	pad->triggerLeft = (u8)(triggers[0] * 0xFF);
-	pad->triggerRight = (u8)(triggers[1] * 0xFF);
+	pad->triggerLeft = static_cast<u8>(triggers[0] * 0xFF);
+	pad->triggerRight = static_cast<u8>(triggers[1] * 0xFF);
 }
 
 void GCPad::SetMotor(const u8 on)
 {
-	float state = (float)on / 255;
+	float state = static_cast<float>(on) / 255;
 	float force = abs(state - 0.5f) * 2;
 	if (state < 0.5)
 		force = -force;

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -92,8 +92,8 @@ void Classic::GetState(u8* const data)
 	double x, y;
 	m_left_stick->GetState(&x, &y);
 
-	ccdata->lx = Classic::LEFT_STICK_CENTER_X + (u8)(x * Classic::LEFT_STICK_RADIUS);
-	ccdata->ly = Classic::LEFT_STICK_CENTER_Y + (u8)(y * Classic::LEFT_STICK_RADIUS);
+	ccdata->lx = static_cast<u8>(Classic::LEFT_STICK_CENTER_X + (x * Classic::LEFT_STICK_RADIUS));
+	ccdata->ly = static_cast<u8>(Classic::LEFT_STICK_CENTER_Y + (y * Classic::LEFT_STICK_RADIUS));
 	}
 
 	// right stick
@@ -102,8 +102,8 @@ void Classic::GetState(u8* const data)
 	u8 x_, y_;
 	m_right_stick->GetState(&x, &y);
 
-	x_ = Classic::RIGHT_STICK_CENTER_X + (u8)(x * Classic::RIGHT_STICK_RADIUS);
-	y_ = Classic::RIGHT_STICK_CENTER_Y + (u8)(y * Classic::RIGHT_STICK_RADIUS);
+	x_ = static_cast<u8>(Classic::RIGHT_STICK_CENTER_X + (x * Classic::RIGHT_STICK_RADIUS));
+	y_ = static_cast<u8>(Classic::RIGHT_STICK_CENTER_Y + (y * Classic::RIGHT_STICK_RADIUS));
 
 	ccdata->rx1 = x_;
 	ccdata->rx2 = x_ >> 1;
@@ -117,8 +117,8 @@ void Classic::GetState(u8* const data)
 	u8 lt, rt;
 	m_triggers->GetState(&ccdata->bt, classic_trigger_bitmasks, trigs);
 
-	lt = (u8)(trigs[0] * Classic::LEFT_TRIGGER_RANGE);
-	rt = (u8)(trigs[1] * Classic::RIGHT_TRIGGER_RANGE);
+	lt = static_cast<u8>(trigs[0] * Classic::LEFT_TRIGGER_RANGE);
+	rt = static_cast<u8>(trigs[1] * Classic::RIGHT_TRIGGER_RANGE);
 
 	ccdata->lt1 = lt;
 	ccdata->lt2 = lt >> 3;

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -63,8 +63,8 @@ void Drums::GetState(u8* const data)
 	double x, y;
 	m_stick->GetState(&x, &y);
 
-	ddata->sx = (u8)(x * 0x1F) + 0x20;
-	ddata->sy = (u8)(y * 0x1F) + 0x20;
+	ddata->sx = static_cast<u8>((x * 0x1F) + 0x20);
+	ddata->sy = static_cast<u8>((y * 0x1F) + 0x20);
 	}
 
 	// TODO: softness maybe

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -76,8 +76,8 @@ void Guitar::GetState(u8* const data)
 	double x, y;
 	m_stick->GetState(&x, &y);
 
-	gdata->sx = (u8)(x * 0x1F) + 0x20;
-	gdata->sy = (u8)(y * 0x1F) + 0x20;
+	gdata->sx = static_cast<u8>((x * 0x1F) + 0x20);
+	gdata->sy = static_cast<u8>((y * 0x1F) + 0x20);
 	}
 
 	// TODO: touch bar, probably not
@@ -86,7 +86,7 @@ void Guitar::GetState(u8* const data)
 	// whammy bar
 	double whammy;
 	m_whammy->GetState(&whammy);
-	gdata->whammy = (u8)(whammy * 0x1F);
+	gdata->whammy = static_cast<u8>(whammy * 0x1F);
 
 	// buttons
 	m_buttons->GetState(&gdata->bt, guitar_button_bitmasks);

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -65,8 +65,8 @@ void Turntable::GetState(u8* const data)
 	double x, y;
 	m_stick->GetState(&x, &y);
 
-	ttdata->sx = (u8)(x * 0x1F) + 0x20;
-	ttdata->sy = (u8)(y * 0x1F) + 0x20;
+	ttdata->sx = static_cast<u8>((x * 0x1F) + 0x20);
+	ttdata->sy = static_cast<u8>((y * 0x1F) + 0x20);
 	}
 
 	// left table
@@ -75,7 +75,7 @@ void Turntable::GetState(u8* const data)
 	s8 tt_;
 	m_left_table->GetState(&tt);
 
-	tt_ = (s8)(tt * 0x1F);
+	tt_ = static_cast<s8>(tt * 0x1F);
 
 	ttdata->ltable1 = tt_;
 	ttdata->ltable2 = tt_ >> 5;
@@ -87,7 +87,7 @@ void Turntable::GetState(u8* const data)
 	s8 tt_;
 	m_right_table->GetState(&tt);
 
-	tt_ = (s8)(tt * 0x1F);
+	tt_ = static_cast<s8>(tt * 0x1F);
 
 	ttdata->rtable1 = tt_;
 	ttdata->rtable2 = tt_ >> 1;
@@ -101,7 +101,7 @@ void Turntable::GetState(u8* const data)
 	u8 dial_;
 	m_effect_dial->GetState(&dial);
 
-	dial_ = (u8)(dial * 0x0F);
+	dial_ = static_cast<u8>(dial * 0x0F);
 
 	ttdata->dial1 = dial_;
 	ttdata->dial2 = dial_ >> 3;
@@ -112,7 +112,7 @@ void Turntable::GetState(u8* const data)
 	double cfs;
 	m_crossfade->GetState(&cfs);
 
-	ttdata->slider = (u8)(cfs * 0x07) + 0x08;
+	ttdata->slider = static_cast<u8>((cfs * 0x07) + 0x08);
 	}
 
 	// buttons


### PR DESCRIPTION
Also changed casts to C++ style casts to removed some of the ambiguity. 

[PR#803](https://github.com/dolphin-emu/dolphin/pull/803)
Sorry about introducing this bug. Hopefully this fixes it correctly. The original code had one of the addends being promoted to a double. This means it could have been negative. My original change removed the possibility for this addend to be negative, introducing the bug. This fix also doesn't introduce any warnings on VS2013, but I haven't had a chance to check it on Linux. 

I also took this opportunity to change the casts to C++ style casts on archshift's recommendation. 
