### PR TITLE
Don't switch to a vertex array object of 0.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1734,7 +1734,8 @@ void Renderer::RestoreAPIState()
 
 	VertexManager *vm = (OGL::VertexManager*)g_vertex_manager;
 	glBindBuffer(GL_ARRAY_BUFFER, vm->m_vertex_buffers);
-	glBindVertexArray(vm->m_last_vao);
+	if (vm->m_last_vao)
+		glBindVertexArray(vm->m_last_vao);
 
 	TextureCache::SetStage();
 }


### PR DESCRIPTION
This causes glDrawArrays to fail in core profile, and thus on OS X, see:

http://renderingpipeline.com/2012/03/attribute-less-rendering/

There must be something bound, even though it is not used.

Fixes #7599.  I'm not sure this is actually the best way to fix it,
since AFAICT it makes a nonobvious assumption that _something_ will be
bound before the first attributeless rendering in
TextureConverter::DecodeToTexture, but it's what degasus suggested and
seems to work.
