### PR TITLE
Evict registers from the cache based on LRU.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -20,6 +20,7 @@ struct PPCCachedReg
 	Gen::OpArg location;
 	bool away;  // value not in source register
 	bool locked;
+	u32 last_used_quantum;
 };
 
 struct X64CachedReg
@@ -44,6 +45,8 @@ protected:
 	virtual const int *GetAllocationOrder(size_t& count) = 0;
 
 	Gen::XEmitter *emit;
+
+	u32 cur_use_quantum;
 
 public:
 	RegCache();


### PR DESCRIPTION
The old method would always evict the first suitable register, i.e. the
same register every time once the cache got full.  The cache doesn't get
full terribly often, but the result is pathological...
