### PR TITLE
Remove PowerPCState::DebugCount.

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -156,8 +156,6 @@ bool CBoot::EmulatedBS2_GC()
 	// Load patches
 	PatchEngine::LoadPatches();
 
-	PowerPC::ppcState.DebugCount = 0;
-
 	// If we have any patches that need to be applied very early, here's a good place
 	PatchEngine::ApplyFramePatches();
 
@@ -417,8 +415,6 @@ bool CBoot::EmulatedBS2_Wii()
 		// return
 		PC = PowerPC::ppcState.gpr[3];
 	}
-
-	PowerPC::ppcState.DebugCount = 0;
 
 	return apploaderRan;
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -179,13 +179,6 @@ int Interpreter::SingleStepInner()
 	last_pc = PC;
 	PC = NPC;
 
-#if defined(_DEBUG) || defined(DEBUGFAST)
-	if (PowerPC::ppcState.gpr[1] == 0)
-	{
-		WARN_LOG(POWERPC, "%i Corrupt stack", PowerPC::ppcState.DebugCount);
-	}
-	PowerPC::ppcState.DebugCount++;
-#endif
 	patches();
 
 	GekkoOPInfo *opinfo = GetOpInfo(instCode);

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -9,17 +9,6 @@
 
 using namespace Gen;
 
-//static int temp32; // unused?
-
-//TODO - make an option
-//#if _DEBUG
-static bool enableDebug = false;
-//#else
-//		bool enableDebug = false;
-//#endif
-
-//static bool enableStatistics = false; //unused?
-
 //GLOBAL STATIC ALLOCATIONS x86
 //EAX - ubiquitous scratch register - EVERYBODY scratches this
 
@@ -31,7 +20,6 @@ static bool enableDebug = false;
 // PLAN: no more block numbers - crazy opcodes just contain offset within
 // dynarec buffer
 // At this offset - 4, there is an int specifying the block number.
-
 
 void Jit64AsmRoutineManager::Generate()
 {
@@ -120,11 +108,6 @@ void Jit64AsmRoutineManager::Generate()
 
 			TEST(32, R(EAX), R(EAX));
 			FixupBranch notfound = J_CC(CC_L);
-				//IDEA - we have 26 bits, why not just use offsets from base of code?
-				if (enableDebug)
-				{
-					ADD(32, M(&PowerPC::ppcState.DebugCount), Imm8(1));
-				}
 				//grab from list and jump to it
 				JMPptr(MComplex(R15, RAX, 8, 0));
 			SetJumpTarget(notfound);

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -117,7 +117,6 @@ void Init(int cpu_core)
 	FPURoundMode::SetPrecisionMode(FPURoundMode::PREC_53);
 
 	memset(ppcState.sr, 0, sizeof(ppcState.sr));
-	ppcState.DebugCount = 0;
 	ppcState.dtlb_last = 0;
 	memset(ppcState.dtlb_va, 0, sizeof(ppcState.dtlb_va));
 	memset(ppcState.dtlb_pa, 0, sizeof(ppcState.dtlb_pa));

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -66,8 +66,6 @@ struct GC_ALIGNED64(PowerPCState)
 
 	u32 sr[16];  // Segment registers.
 
-	u32 DebugCount;
-
 	// special purpose registers - controls quantizers, DMA, and lots of other misc extensions.
 	// also for power management, but we don't care about that.
 	u32 spr[1024];


### PR DESCRIPTION
This value was "helpful" for debugging when the stack got corrupted.
Helpful that if gpr[1](Which is the stack pointer with PPC ABI) is zero then the interpreter would spam huge amounts of annoy text saying that we
managed to get in to a "corrupted" state.
This is incremented every instruction on the interpreter, or every block run on the JIT64....Only if debugging is enabled(JIT64 it is a const variable)
The message is only outputted when interpreter is used and debugging is enabled.
