### PR TITLE
Common: Remove unnecessary define check in Log2

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -180,7 +180,7 @@ inline int Log2(u64 val)
 #if defined(__GNUC__)
 	return 63 - __builtin_clzll(val);
 
-#elif defined(_MSC_VER) && _ARCH_64
+#elif defined(_MSC_VER)
 	unsigned long result = -1;
 	_BitScanReverse64(&result, val);
 	return result;


### PR DESCRIPTION
We don't support 32-bit versions of Windows anymore, so this define check is not needed.
