### PR TITLE
Common: Make TITLEID_SYSMENU a static const variable in NandPaths.h

### DIFF
--- a/Source/Core/Common/NandPaths.h
+++ b/Source/Core/Common/NandPaths.h
@@ -10,8 +10,8 @@
 
 #include "Common/CommonTypes.h"
 
-#define TITLEID_SYSMENU 0x0000000100000002ull
-const static std::string TITLEID_SYSMENU_STRING = "0000000100000002";
+static const u64 TITLEID_SYSMENU = 0x0000000100000002;
+static const std::string TITLEID_SYSMENU_STRING = "0000000100000002";
 
 namespace Common
 {


### PR DESCRIPTION
May as well just reify it into a u64 instead of tacking on ULL to the definition.
