### PR TITLE
JIT: remove srawix fallback

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1934,9 +1934,6 @@ void Jit64::srawix(UGeckoInstruction inst)
 	}
 	else
 	{
-		// FIXME
-		FALLBACK_IF(true);
-
 		gpr.Lock(a, s);
 		JitClearCA();
 		gpr.BindToRegister(a, a == s, true);


### PR DESCRIPTION
As far as I can tell, this has literally been here since the start of the git
history; maybe it was stubbed out because the author wasn't sure it was right?

It matches the PPC/Broadway manuals perfectly, though.
