### PR TITLE
Common: Remove unused header from Thread.cpp

### DIFF
--- a/Source/Core/Common/Thread.cpp
+++ b/Source/Core/Common/Thread.cpp
@@ -11,10 +11,6 @@
 #include <pthread_np.h>
 #endif
 
-#ifdef USE_BEGINTHREADEX
-#include <process.h>
-#endif
-
 namespace Common
 {
 


### PR DESCRIPTION
This define isn't even used in the Windows builds.
