### PR TITLE
Remove "EFB Copies Disabled" option from hotkey toggling cycle.

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -59,6 +59,7 @@
 
 #include "InputCommon/GCPadStatus.h"
 
+#include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
@@ -1014,7 +1015,14 @@ void CFrame::OnKeyDown(wxKeyEvent& event)
 		{
 			OSDChoice = 3;
 			// Toggle EFB copies between EFB2RAM and EFB2Texture
-			g_Config.bCopyEFBToTexture = !g_Config.bCopyEFBToTexture;
+			if (!g_Config.bEFBCopyEnable)
+			{
+				OSD::AddMessage("EFB Copies are disabled, enable them in Graphics settings for toggling", 6000);
+			}
+			else
+			{
+				g_Config.bCopyEFBToTexture = !g_Config.bCopyEFBToTexture;
+			}
 		}
 		else if (IsHotkey(event, HK_TOGGLE_FOG))
 		{


### PR DESCRIPTION
I would imagine "EFB Copies" hotkey is 99% of the time used to toggle between EFB2RAM and EFM2Texture by users that have less-than-optimal Dolphin hardware and can't use EFB2RAM all the time in games that require it (often only for short periods). So the toggling workflow could be streamlined if there wasn't "EFB Copies = Disabled" option in the cycle.

This commit removes the "Disable EFB Copies" option from the hotkey toggling behaviour. It can still be chosen from the GUI if someone enjoys looking at broken graphics. And if Disabled _is_ chosen, the hotkey won't have apparent effect.

And please correct me (and close the PR) if I'm totally off with the initial assumption of the need for the hotkey.
