### PR TITLE
Compile the ARAM DMA exception checks into the JIT block

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -76,6 +76,7 @@ protected:
 		JitBlock *curBlock;
 
 		std::unordered_set<u32> fifoWriteAddresses;
+		std::unordered_set<u32> dspARAMAddresses;
 	};
 
 	PPCAnalyst::CodeBlock code_block;


### PR DESCRIPTION
Compile the ARAM DMA exception checks into the JIT block in a similar style to FIFO writes.  This ensures that the ARAM DMA is handled soon after the DMA completes.  Fixes issue 7122 and issue 7342.
