### PR TITLE
JIT: remove op merging code that served no purpose

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -199,35 +199,8 @@ void Jit64::reg_imm(UGeckoInstruction inst)
 			regimmop(d, a, false, (u32)(s32)inst.SIMM_16,  Add, &XEmitter::ADD); //addi
 		}
 		break;
-	case 15:
-		if (a == 0) // lis
-		{
-			// Merge with next instruction if loading a 32-bits immediate value (lis + addi, lis + ori)
-			if (!js.isLastInstruction && !SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableDebugging)
-			{
-				if ((js.next_inst.OPCD == 14) && (js.next_inst.RD == d) && (js.next_inst.RA == d)) // addi
-				{
-					gpr.SetImmediate32(d, ((u32)inst.SIMM_16 << 16) + (u32)(s32)js.next_inst.SIMM_16);
-					js.downcountAmount++;
-					js.skipnext = true;
-					break;
-				}
-				else if ((js.next_inst.OPCD == 24) && (js.next_inst.RA == d) && (js.next_inst.RS == d)) // ori
-				{
-					gpr.SetImmediate32(d, ((u32)inst.SIMM_16 << 16) | (u32)js.next_inst.UIMM);
-					js.downcountAmount++;
-					js.skipnext = true;
-					break;
-				}
-			}
-
-			// Not merged
-			regimmop(d, a, false, (u32)inst.SIMM_16 << 16, Add, &XEmitter::ADD);
-		}
-		else // addis
-		{
-			regimmop(d, a, false, (u32)inst.SIMM_16 << 16, Add, &XEmitter::ADD);
-		}
+	case 15: // addis
+		regimmop(d, a, false, (u32)inst.SIMM_16 << 16, Add, &XEmitter::ADD);
 		break;
 	case 24: // ori
 		if (a == 0 && s == 0 && inst.UIMM == 0 && !inst.Rc)  //check for nop


### PR DESCRIPTION
Dolphin already tracks propagation of immediates, so this code didn't really do
anything useful.
