### PR TITLE
Downgrade the ERROR log printed when twi is executed in interpreter to DEBUG

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -149,7 +149,7 @@ void Interpreter::twi(UGeckoInstruction _inst)
 	s32 b = _inst.SIMM_16;
 	s32 TO = _inst.TO;
 
-	ERROR_LOG(POWERPC, "twi rA %x SIMM %x TO %0x", a, b, TO);
+	DEBUG_LOG(POWERPC, "twi rA %x SIMM %x TO %0x", a, b, TO);
 
 	if (((a < b) && (TO & 0x10)) ||
 	    ((a > b) && (TO & 0x08)) ||


### PR DESCRIPTION
Currently in interpreter, whenever a twi (trap if...) instruction is encountered in interpreter mode, a log message of severity ERROR is printed. This quickly fills up the log area when log level is set to ERROR or WARNING.

Since this isn't a severe error but merely a debug message, switch the log level to DEBUG instead.
