### PR TITLE
Update debugger button states at startup to disable non-functional JIT menu items

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -440,6 +440,8 @@ CFrame::CFrame(wxFrame* parent,
 
 	// Update controls
 	UpdateGUI();
+	if (g_pCodeWindow)
+		g_pCodeWindow->UpdateButtonStates();
 }
 // Destructor
 CFrame::~CFrame()


### PR DESCRIPTION
There is a bug with the JIT menu items: they are not disabled at startup, even though the JIT isn't initialized at the time. When someone toggles an item (e.g. JIT LoadStore Off) before loading a game, the checkbox is checked, but the option isn't actually enabled, and will not be enabled once a game is loaded.

This patch calls the update button states function after the main window is created to allow the debugger to disable non-functional menu items and buttons.
