### PR TITLE
Fix various issues with the twi/tw instructions

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -413,7 +413,7 @@ void Interpreter::tw(UGeckoInstruction _inst)
 	s32 b = m_GPR[_inst.RB];
 	s32 TO = _inst.TO;
 
-	ERROR_LOG(POWERPC, "tw rA %0x rB %0x TO %0x", a, b, TO);
+	DEBUG_LOG(POWERPC, "tw rA %0x rB %0x TO %0x", a, b, TO);
 
 	if (((a < b) && (TO & 0x10)) ||
 	    ((a > b) && (TO & 0x08)) ||

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -2000,9 +2000,9 @@ void Jit64::twx(UGeckoInstruction inst)
 	gpr.KillImmediate(a, true, false);
 
 	if (inst.OPCD == 3) // twi
-		CMP(32, gpr.R(a), gpr.R(inst.RB));
-	else // tw
 		CMP(32, gpr.R(a), Imm32((s32)(s16)inst.SIMM_16));
+	else // tw
+		CMP(32, gpr.R(a), gpr.R(inst.RB));
 
 	std::vector<FixupBranch> fixups;
 	CCFlags conditions[] = { CC_A, CC_B, CC_E, CC_G, CC_L };

--- a/Source/Core/Core/PowerPC/JitArm32/JitArm_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitArm_Integer.cpp
@@ -915,12 +915,12 @@ void JitArm::twx(UGeckoInstruction inst)
 
 	if (inst.OPCD == 3) // twi
 	{
-		CMP(gpr.R(a), gpr.R(inst.RB));
+		MOVI2R(RB, (s32)(s16)inst.SIMM_16);
+		CMP(gpr.R(a), RB);
 	}
 	else // tw
 	{
-		MOVI2R(RB, (s32)(s16)inst.SIMM_16);
-		CMP(gpr.R(a), RB);
+		CMP(gpr.R(a), gpr.R(inst.RB));
 	}
 
 	FixupBranch al = B_CC(CC_LT);


### PR DESCRIPTION
This patch fixes three issues with tw/twi emulation:

1: force propagated constant into register to avoid "a1 cannot be immediate" errors

Tw/twi is a "trap if comparison is true" instruction, which means that a cmp instruction is generated.
The emitter wants a register in the first argument to cmp, but constant propagation may try to pass in a constant instead.
For now, fall back to interpreter instead of displaying error: a proper way to translate this would be to load constant into a scratch register first like cmpXX does. 

Do games actually use these two instructions? I ran into this error when attempting to run Wii Linux.

2: tw/twi instruction are switched in Jit64 and JitArm
the twi instruction was generating the comparison instruction for tw, and vise versa. This corrects that mistake.

3: fix another potential logging spam in the interpreter when tw is run
#1011 got rid of the ERROR_LOG printed when twi is run in interpreter, but I missed the same logging that was present in tw. This downgrades that log to DEBUG_LOG also.
