### PR TITLE
Include CommonTypes.h instead of Common.h.

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.cpp
+++ b/Source/Core/AudioCommon/AlsaSoundStream.cpp
@@ -5,7 +5,7 @@
 #include <functional>
 
 #include "AudioCommon/AlsaSoundStream.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 
 #define FRAME_COUNT_MIN 256

--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -9,7 +9,7 @@
 #endif
 
 #include "AudioCommon/SoundStream.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 
 class AlsaSound final : public SoundStream

--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "AudioCommon/SoundStream.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 
 class CMixer;

--- a/Source/Core/AudioCommon/OpenSLESStream.cpp
+++ b/Source/Core/AudioCommon/OpenSLESStream.cpp
@@ -9,7 +9,7 @@
 #include <SLES/OpenSLES_Android.h>
 
 #include "AudioCommon/OpenSLESStream.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // engine interfaces
 static SLObjectItf engineObject;

--- a/Source/Core/AudioCommon/PulseAudioStream.cpp
+++ b/Source/Core/AudioCommon/PulseAudioStream.cpp
@@ -5,7 +5,7 @@
 #include <functional>
 
 #include "AudioCommon/PulseAudioStream.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 
 namespace

--- a/Source/Core/AudioCommon/PulseAudioStream.h
+++ b/Source/Core/AudioCommon/PulseAudioStream.h
@@ -11,7 +11,7 @@
 #include <atomic>
 
 #include "AudioCommon/SoundStream.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 
 class PulseAudio final : public SoundStream

--- a/Source/Core/AudioCommon/SoundStream.h
+++ b/Source/Core/AudioCommon/SoundStream.h
@@ -6,7 +6,7 @@
 
 #include "AudioCommon/Mixer.h"
 #include "AudioCommon/WaveFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class SoundStream
 {

--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -5,7 +5,7 @@
 #include <string>
 
 #include "AudioCommon/WaveFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/ConfigManager.h"
 
 enum {BUF_SIZE = 32*1024};

--- a/Source/Core/AudioCommon/WaveFile.h
+++ b/Source/Core/AudioCommon/WaveFile.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <string>
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 
 class WaveFileWriter : NonCopyable

--- a/Source/Core/AudioCommon/aldlist.cpp
+++ b/Source/Core/AudioCommon/aldlist.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "AudioCommon/aldlist.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #ifdef _WIN32
 #include "../../../Externals/OpenAL/include/al.h"
 #include "../../../Externals/OpenAL/include/alc.h"

--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Common/ArmEmitter.h
+++ b/Source/Core/Common/ArmEmitter.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "Common/CodeBlock.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #if defined(__SYMBIAN32__) || defined(PANDORA)
 #include <signal.h>

--- a/Source/Core/Common/BreakPoints.cpp
+++ b/Source/Core/Common/BreakPoints.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "Common/BreakPoints.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/JitCommon/JitCache.h"

--- a/Source/Core/Common/CDUtils.cpp
+++ b/Source/Core/Common/CDUtils.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "Common/CDUtils.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
 #ifdef _WIN32

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Flag.h"
 

--- a/Source/Core/Common/ColorUtil.cpp
+++ b/Source/Core/Common/ColorUtil.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ColorUtil.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace ColorUtil
 {

--- a/Source/Core/Common/Crypto/bn.cpp
+++ b/Source/Core/Common/Crypto/bn.cpp
@@ -5,7 +5,7 @@
 #include <cstdio>
 #include <string.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Crypto/bn.h"
 
 static void bn_zero(u8 *d, u32 n)

--- a/Source/Core/Common/Crypto/ec.cpp
+++ b/Source/Core/Common/Crypto/ec.cpp
@@ -11,7 +11,7 @@
 #include <ctime>
 #include <string.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Crypto/bn.h"
 #include "Common/Crypto/ec.h"
 

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -12,8 +12,8 @@
 #include <vector>
 #include <sys/stat.h>
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 
 #ifdef _WIN32

--- a/Source/Core/Common/Hash.h
+++ b/Source/Core/Common/Hash.h
@@ -6,7 +6,7 @@
 
 #include <cstddef>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 u32 HashFletcher(const u8* data_u8, size_t length);  // FAST. Length & 1 == 0.
 u32 HashAdler32(const u8* data, size_t len);         // Fairly accurate, slightly slower

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -8,7 +8,7 @@
 #include <fstream>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 
 // On disk format:

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -7,7 +7,7 @@
 #include <cstdlib>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace MathUtil
 {

--- a/Source/Core/Common/MemArena.cpp
+++ b/Source/Core/Common/MemArena.cpp
@@ -7,7 +7,7 @@
 #include <set>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MemArena.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Common/MemArena.h
+++ b/Source/Core/Common/MemArena.h
@@ -10,7 +10,7 @@
 #include <windows.h>
 #endif
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // This class lets you create a block of anonymous RAM, and then arbitrarily map views into it.
 // Multiple views can mirror the same section of the block, which makes it very convenient for emulating

--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -6,7 +6,7 @@
 #include <cstdlib>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MemoryUtil.h"
 
 #ifdef _WIN32

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -6,7 +6,7 @@
 #include <cstdio>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
 bool DefaultMsgHandler(const char* caption, const char* text, bool yes_no, int Style);

--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <utility>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/Common/SDCardUtil.cpp
+++ b/Source/Core/Common/SDCardUtil.cpp
@@ -35,7 +35,7 @@
 #include <ctime>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/SDCardUtil.h"
 

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -14,8 +14,8 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
 #ifdef _WIN32

--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <utility>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/SymbolDB.h"
 
 void SymbolDB::List()

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -12,7 +12,7 @@
 #include <utility>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 struct SCall
 {

--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/SysConf.h"
 

--- a/Source/Core/Common/Thread.cpp
+++ b/Source/Core/Common/Thread.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 
 #ifdef __APPLE__

--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "scmrev.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #ifdef _DEBUG
 	#define BUILD_TYPE_STR "Debug "

--- a/Source/Core/Common/x64ABI.cpp
+++ b/Source/Core/Common/x64ABI.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/x64ABI.h"
 #include "Common/x64Emitter.h"
 

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 
 #ifdef _WIN32

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -4,7 +4,7 @@
 
 #include <cinttypes>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Common/x64Emitter.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -11,7 +11,7 @@
 #include <functional>
 
 #include "Common/CodeBlock.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace Gen
 {

--- a/Source/Core/Common/x64FPURoundMode.cpp
+++ b/Source/Core/Common/x64FPURoundMode.cpp
@@ -4,7 +4,7 @@
 
 #include <cfenv>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Common/FPURoundMode.h"
 

--- a/Source/Core/Core/ARDecrypt.h
+++ b/Source/Core/Core/ARDecrypt.h
@@ -6,7 +6,7 @@
 
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/ActionReplay.h"
 
 namespace ActionReplay

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Common/Logging/LogManager.h"
 

--- a/Source/Core/Core/ArmMemTools.cpp
+++ b/Source/Core/Core/ArmMemTools.cpp
@@ -12,7 +12,7 @@
 #include <sys/ucontext.h>   // Look in here for the context definition.
 #endif
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/MemTools.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/JitInterface.h"

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -3,8 +3,8 @@
 // Refer to the license.txt file included.
 
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/MathUtil.h"

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
 #include "Common/SettingsHandler.h"

--- a/Source/Core/Core/Boot/ElfReader.cpp
+++ b/Source/Core/Core/Boot/ElfReader.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/Boot/ElfReader.h"

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -11,8 +11,8 @@
 #include "AudioCommon/AudioCommon.h"
 
 #include "Common/Atomic.h"
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Common/MathUtil.h"
 #include "Common/MemoryUtil.h"

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -5,8 +5,8 @@
 #include <cinttypes>
 
 #include "Common/CDUtils.h"
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -18,7 +18,7 @@
 //   ScheduleEvent(periodInCycles - cyclesLate, callback, "whatever")
 
 #include <string>
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class PointerWrap;
 

--- a/Source/Core/Core/DSP/DSPAccelerator.cpp
+++ b/Source/Core/Core/DSP/DSPAccelerator.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 
 #include "Core/DSP/DSPAccelerator.h"

--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -44,7 +44,7 @@ Initial import
 #include <map>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 
 #include "Core/DSP/DSPAssembler.h"

--- a/Source/Core/Core/DSP/DSPAssembler.h
+++ b/Source/Core/Core/DSP/DSPAssembler.h
@@ -27,7 +27,7 @@
 #include <map>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/DSP/DSPDisassembler.h"
 #include "Core/DSP/DSPTables.h"

--- a/Source/Core/Core/DSP/DSPBreakpoints.h
+++ b/Source/Core/Core/DSP/DSPBreakpoints.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // super fast breakpoints for a limited range.
 // To be used interchangeably with the BreakPoints class.

--- a/Source/Core/Core/DSP/DSPCodeUtil.cpp
+++ b/Source/Core/Core/DSP/DSPCodeUtil.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Core/DSP/DSPCodeUtil.h
+++ b/Source/Core/Core/DSP/DSPCodeUtil.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 bool Assemble(const std::string& text, std::vector<u16> &code, bool force = false);
 bool Disassemble(const std::vector<u16> &code, bool line_numbers, std::string &text);

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -23,7 +23,7 @@
 
    ====================================================================*/
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/FileUtil.h"
 #include "Common/Hash.h"

--- a/Source/Core/Core/DSP/DSPDisassembler.cpp
+++ b/Source/Core/Core/DSP/DSPDisassembler.cpp
@@ -28,7 +28,7 @@
 #include <fstream>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Core/DSP/DSPDisassembler.h
+++ b/Source/Core/Core/DSP/DSPDisassembler.h
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/DSP/DSPTables.h"
 #include "Core/DSP/LabelMap.h"

--- a/Source/Core/Core/DSP/DSPHWInterface.h
+++ b/Source/Core/Core/DSP/DSPHWInterface.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #define GDSP_MBOX_CPU   0
 #define GDSP_MBOX_DSP   1

--- a/Source/Core/Core/DSP/DSPIntCCUtil.h
+++ b/Source/Core/Core/DSP/DSPIntCCUtil.h
@@ -8,7 +8,7 @@
 
 // Anything to do with SR and conditions goes here.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace DSPInterpreter
 {

--- a/Source/Core/Core/DSP/DSPIntUtil.h
+++ b/Source/Core/Core/DSP/DSPIntUtil.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPInterpreter.h"

--- a/Source/Core/Core/DSP/DSPMemoryMap.h
+++ b/Source/Core/Core/DSP/DSPMemoryMap.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPInterpreter.h"

--- a/Source/Core/Core/DSP/DSPStacks.cpp
+++ b/Source/Core/Core/DSP/DSPStacks.cpp
@@ -23,7 +23,7 @@
 
    ====================================================================*/
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPStacks.h"

--- a/Source/Core/Core/DSP/DSPStacks.h
+++ b/Source/Core/Core/DSP/DSPStacks.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 void dsp_reg_store_stack(int stack_reg, u16 val);
 u16 dsp_reg_load_stack(int stack_reg);

--- a/Source/Core/Core/DSP/DSPTables.cpp
+++ b/Source/Core/Core/DSP/DSPTables.cpp
@@ -4,7 +4,7 @@
 
 // Additional copyrights go to Duddie (c) 2005 (duddie@walla.com)
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/DSP/DSPEmitter.h"
 #include "Core/DSP/DSPInterpreter.h"

--- a/Source/Core/Core/DSP/LabelMap.h
+++ b/Source/Core/Core/DSP/LabelMap.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 enum LabelType
 {

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.cpp
@@ -5,7 +5,7 @@
 #include <functional>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Core.h"

--- a/Source/Core/Core/Debugger/Debugger_SymbolMap.h
+++ b/Source/Core/Core/Debugger/Debugger_SymbolMap.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace Dolphin_Debugger
 {

--- a/Source/Core/Core/Debugger/Dump.cpp
+++ b/Source/Core/Core/Debugger/Dump.cpp
@@ -5,7 +5,7 @@
 #include <cstdio>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 
 #include "Core/Debugger/Dump.h"

--- a/Source/Core/Core/Debugger/Dump.h
+++ b/Source/Core/Core/Debugger/Dump.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <string>
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class CDump
 {

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/CPMemory.h"

--- a/Source/Core/Core/FifoPlayer/FifoDataFile.h
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace File
 {

--- a/Source/Core/Core/FifoPlayer/FifoFileStruct.h
+++ b/Source/Core/Core/FifoPlayer/FifoFileStruct.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace FifoFileStruct
 {

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 #include "Core/FifoPlayer/FifoDataFile.h"

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/FifoPlayer/FifoAnalyzer.h"
 

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace Gecko
 {

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"

--- a/Source/Core/Core/HLE/HLE_Misc.cpp
+++ b/Source/Core/Core/HLE/HLE_Misc.cpp
@@ -4,8 +4,8 @@
 
 #include <cmath>
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/Host.h"

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
 #include "Core/HLE/HLE_OS.h"

--- a/Source/Core/Core/HLE/HLE_OS.h
+++ b/Source/Core/Core/HLE/HLE_OS.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace HLE_OS
 {

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -53,7 +53,7 @@ This file mainly deals with the [Drive I/F], however [AIDFR] controls
 #include "AudioCommon/AudioCommon.h"
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 
 #include "Core/CoreTiming.h"

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -5,7 +5,7 @@
 #include <mutex>
 
 #include "AudioCommon/AudioCommon.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Core/Core.h"
 #include "Core/DSPEmulator.h"

--- a/Source/Core/Core/HW/CPU.h
+++ b/Source/Core/Core/HW/CPU.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace Common {
 	class Event;

--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class PointerWrap;
 class DSPEmulator;

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.h
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <queue>
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class PointerWrap;
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -14,7 +14,7 @@
 
 #include <functional>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/Memmap.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 
 #include "Core/HW/Memmap.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 // Obviously missing things that must be in here, somewhere among the "unknown":

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ZeldaADPCM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ZeldaADPCM.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Core/HW/DSPHLE/UCodes/Zelda.h"
 

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
 
 class DSPDebugInterface final : public DebugInterface

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Hash.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -7,8 +7,8 @@
 
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Common/Event.h"
 #include "Common/IniFile.h"

--- a/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.cpp
@@ -4,7 +4,7 @@
 
 #include <cinttypes>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 
 #include "Core/DSP/DSPCore.h"

--- a/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // TODO: Get rid of this file.
 

--- a/Source/Core/Core/HW/DSPLLE/DSPLLETools.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLETools.cpp
@@ -10,7 +10,7 @@
 #include <cstdlib>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -7,7 +7,7 @@
 #include <map>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/SymbolDB.h"
 
 namespace DSPSymbols

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -7,7 +7,7 @@
 #include "AudioCommon/AudioCommon.h"
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"

--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MemoryUtil.h"
 #include "Common/Timer.h"

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/Core/HW/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMic.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #if HAVE_PORTAUDIO
 

--- a/Source/Core/Core/HW/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard.h
@@ -7,8 +7,8 @@
 #include <algorithm>
 #include <string>
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/HW/GCPad.h"

--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/Memmap.h"

--- a/Source/Core/Core/HW/GPFifo.h
+++ b/Source/Core/Core/HW/GPFifo.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 class PointerWrap;
 
 namespace GPFifo

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"

--- a/Source/Core/Core/HW/MMIOHandlers.h
+++ b/Source/Core/Core/HW/MMIOHandlers.h
@@ -7,7 +7,7 @@
 #include <functional>
 #include <memory>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // All the templated and very repetitive MMIO-related code is isolated in this
 // file for easier reading. It mostly contains code related to handling methods

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -9,7 +9,7 @@
 // may be redirected here (for example to Read_U32()).
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MemArena.h"
 #include "Common/MemoryUtil.h"
 

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // Enable memory checks in the Debug/DebugFast builds, but NOT in release
 #if defined(_DEBUG) || defined(DEBUGFAST)

--- a/Source/Core/Core/HW/MemmapFunctions.cpp
+++ b/Source/Core/Core/HW/MemmapFunctions.cpp
@@ -16,7 +16,7 @@
 // http://code.google.com/p/dolphin-emu/
 
 #include "Common/Atomic.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/Core.h"
 #include "Core/HW/GPFifo.h"

--- a/Source/Core/Core/HW/MemoryInterface.cpp
+++ b/Source/Core/Core/HW/MemoryInterface.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/HW/MemoryInterface.h"
 #include "Core/HW/MMIO.h"

--- a/Source/Core/Core/HW/MemoryInterface.h
+++ b/Source/Core/Core/HW/MemoryInterface.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace MMIO { class Mapping; }
 class PointerWrap;

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -6,7 +6,7 @@
 
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/CoreTiming.h"
 #include "Core/HW/CPU.h"

--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"

--- a/Source/Core/Core/HW/SI.h
+++ b/Source/Core/Core/HW/SI.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/SI_Device.h"
 
 class PointerWrap;

--- a/Source/Core/Core/HW/SI_Device.h
+++ b/Source/Core/Core/HW/SI_Device.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class PointerWrap;
 

--- a/Source/Core/Core/HW/StreamADPCM.h
+++ b/Source/Core/Core/HW/StreamADPCM.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class NGCADPCM
 {

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -43,7 +43,7 @@ IPC_HLE_PERIOD: For the Wiimote this is the call schedule:
 */
 
 #include "Common/Atomic.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"
 

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Core.h"

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/CoreTiming.h"
 #include "Core/HW/CPU.h"

--- a/Source/Core/Core/HW/WII_IPC.h
+++ b/Source/Core/Core/HW/WII_IPC.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class PointerWrap;
 namespace MMIO { class Mapping; }

--- a/Source/Core/Core/HW/WiiSaveCrypted.cpp
+++ b/Source/Core/Core/HW/WiiSaveCrypted.cpp
@@ -17,7 +17,7 @@
 #include <polarssl/md5.h>
 #include <polarssl/sha1.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
 #include "Common/NandPaths.h"

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/Movie.h"

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/Attachment/Attachment.h"
 
 namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"

--- a/Source/Core/Core/HW/WiimoteEmu/Encryption.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Encryption.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) Hector Martin "marcan" (hector@marcansoft.com)
 
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/Encryption.h"
 
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -4,7 +4,7 @@
 
 #include <cmath>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Timer.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/HW/WiimoteReal/IODummy.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IODummy.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 
 namespace WiimoteReal

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -6,7 +6,7 @@
 #include <cstdlib>
 #include <queue>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"

--- a/Source/Core/Core/IPC_HLE/ICMP.h
+++ b/Source/Core/Core/IPC_HLE/ICMP.h
@@ -6,7 +6,7 @@
 #include <netinet/in.h>
 #endif
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 int icmp_echo_req(const u32 s, const sockaddr_in *addr, const u8 *data, const u32 data_length);
 int icmp_echo_rep(const u32 s, sockaddr_in *addr, const u32 timeout, const u32 data_length);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -25,8 +25,8 @@ They will also generate a true or false return for UpdateInterrupts() in WII_IPC
 #include <string>
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Thread.h"
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -4,7 +4,7 @@
 
 #include <cinttypes>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Logging/LogManager.h"
 
 #include "Core/Core.h"

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -3,8 +3,8 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/SDCardUtil.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_WiiMote.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_WiiMote.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/IPC_HLE/WiiMote_HID_Attr.cpp
+++ b/Source/Core/Core/IPC_HLE/WiiMote_HID_Attr.cpp
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/IPC_HLE/WiiMote_HID_Attr.h"
 
 #if 0

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 struct GCPadStatus;
 class PointerWrap;

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -10,7 +10,6 @@
 
 #include <SFML/Network.hpp>
 
-#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/FifoQueue.h"
 #include "Common/Thread.h"

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/HW/EXI_Device.h"

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -10,7 +10,7 @@
 
 #include <SFML/Network.hpp>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"

--- a/Source/Core/Core/PowerPC/GDBStub.h
+++ b/Source/Core/Core/PowerPC/GDBStub.h
@@ -8,7 +8,7 @@
 
 #include <signal.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 
 #include "Core/HW/CPU.h"

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // --- Gekko Instruction ---
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 
 #include "Core/PowerPC/JitInterface.h"

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Paired.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -10,7 +10,7 @@
 #include <windows.h>
 #endif
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Core/PatchEngine.h"
 #include "Core/HLE/HLE.h"

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64/JitAsm.h"

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 
 #include "Core/PowerPC/Jit64/Jit.h"

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -5,7 +5,7 @@
 // TODO(ector): Tons of pshufb optimization of the loads/stores, for SSSE3+, possibly SSE4, only.
 // Should give a very noticable speed boost to paired single heavy code.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64/JitAsm.h"

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 
 #include "Core/PowerPC/Jit64/Jit.h"

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -5,7 +5,7 @@
 // TODO(ector): Tons of pshufb optimization of the loads/stores, for SSSE3+, possibly SSE4, only.
 // Should give a very noticeable speed boost to paired single heavy code.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 
 #include "Core/PowerPC/Jit64/Jit.h"

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64/JitRegCache.h"

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SystemTimers.h"

--- a/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
@@ -7,7 +7,7 @@
 
 #include "disasm.h"
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Core/PowerPC/JitCommon/JitBackpatch.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"

--- a/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/x64Analyzer.h"
 #include "Common/x64Emitter.h"
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -11,7 +11,7 @@
 
 #include "disasm.h"
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MemoryUtil.h"
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -4,7 +4,7 @@
 
 #include <emmintrin.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 
 #include "Core/HW/MMIO.h"

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Branch.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 
 

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_FloatingPoint.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 
 void JitILBase::fp_arith_s(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStore.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 
 void JitILBase::lhax(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStoreFloating.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 
 // TODO: Add peephole optimizations for multiple consecutive lfd/lfs/stfd/stfs since they are so common,

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStorePaired.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 
 void JitILBase::psq_st(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Paired.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 
 void JitILBase::ps_arith(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_SystemRegisters.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/PowerPC/PPCTables.h"
 
 class PPCSymbolDB;

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -6,7 +6,7 @@
 #include <cinttypes>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -4,7 +4,7 @@
 
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FPURoundMode.h"
 #include "Common/MathUtil.h"
 

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -7,7 +7,7 @@
 #include <tuple>
 
 #include "Common/BreakPoints.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/Debugger/PPCDebugInterface.h"
 #include "Core/PowerPC/CPUCoreBase.h"

--- a/Source/Core/Core/PowerPC/SignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 
 #include "Core/HW/Memmap.h"

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 #include <lzo/lzo1x.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"

--- a/Source/Core/Core/ec_wii.h
+++ b/Source/Core/Core/ec_wii.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 void get_ng_cert(u8* ng_cert_out, u32 NG_id, u32 NG_key_id, const u8* NG_priv, const u8* NG_sig);
 void get_ap_sig_and_cert(u8 *sig_out, u8 *ap_cert_out, u64 title_id, u8 *data, u32 data_size, const u8 *NG_priv, u32 NG_id);

--- a/Source/Core/Core/x64MemTools.cpp
+++ b/Source/Core/Core/x64MemTools.cpp
@@ -9,7 +9,7 @@
 #include "Common/Thread.h"
 #endif
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/x64Analyzer.h"
 
 #include "Core/MemTools.h"

--- a/Source/Core/DiscIO/BannerLoaderGC.cpp
+++ b/Source/Core/DiscIO/BannerLoaderGC.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "Common/ColorUtil.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "DiscIO/BannerLoaderGC.h"
 #include "DiscIO/Filesystem.h"

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <zlib.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "DiscIO/DiscScrubber.h"
 #include "DiscIO/Filesystem.h"

--- a/Source/Core/DiscIO/DriveBlob.cpp
+++ b/Source/Core/DiscIO/DriveBlob.cpp
@@ -6,7 +6,7 @@
 #include <cstring>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/DriveBlob.h"

--- a/Source/Core/DiscIO/FileMonitor.cpp
+++ b/Source/Core/DiscIO/FileMonitor.cpp
@@ -9,7 +9,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Common/Logging/LogManager.h"
 

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -12,7 +12,7 @@
 #include <vector>
 #include <polarssl/aes.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
 #include "Common/NandPaths.h"

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "DiscIO/Volume.h"
 
 namespace DiscIO

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace DiscIO
 {

--- a/Source/Core/DiscIO/VolumeCommon.cpp
+++ b/Source/Core/DiscIO/VolumeCommon.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "DiscIO/Volume.h"
 
 namespace DiscIO

--- a/Source/Core/DiscIO/VolumeCreator.cpp
+++ b/Source/Core/DiscIO/VolumeCreator.cpp
@@ -9,7 +9,7 @@
 
 #include <polarssl/aes.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
 #include "DiscIO/Blob.h"

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -11,8 +11,8 @@
 #include <utility>
 #include <vector>
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
 #include "DiscIO/FileBlob.h"

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/FileMonitor.h"

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Common/StringUtil.h"
 #include "DiscIO/Blob.h"

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -9,7 +9,7 @@
 #include <polarssl/aes.h>
 #include <polarssl/sha1.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeGC.h"

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "DiscIO/WbfsBlob.h"
 

--- a/Source/Core/DiscIO/WiiWad.cpp
+++ b/Source/Core/DiscIO/WiiWad.cpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/DolphinWX/ARCodeAddEdit.cpp
+++ b/Source/Core/DolphinWX/ARCodeAddEdit.cpp
@@ -21,7 +21,7 @@
 #include <wx/translation.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Core/ActionReplay.h"
 #include "Core/ARDecrypt.h"

--- a/Source/Core/DolphinWX/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/CheatsWindow.cpp
@@ -31,7 +31,7 @@
 #include <wx/translation.h>
 #include <wx/validate.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 #include "Core/ActionReplay.h"

--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -25,8 +25,8 @@
 
 #include "AudioCommon/AudioCommon.h"
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileSearch.h"
 #include "Common/SysConf.h"
 

--- a/Source/Core/DolphinWX/Debugger/BreakpointDlg.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointDlg.cpp
@@ -14,7 +14,7 @@
 #include <wx/textctrl.h>
 
 #include "Common/BreakPoints.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "DolphinWX/WxUtils.h"

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -29,7 +29,7 @@
 #include <wx/translation.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
 #include "Common/StringUtil.h"
 #include "Common/SymbolDB.h"

--- a/Source/Core/DolphinWX/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Debugger/CodeView.h
@@ -16,7 +16,7 @@
 #include <wx/graphics.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 wxDECLARE_EVENT(wxEVT_CODEVIEW_CHANGE, wxCommandEvent);
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -27,7 +27,7 @@
 #include <wx/aui/auibar.h>
 
 #include "Common/BreakPoints.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Common/SymbolDB.h"
 #include "Core/Core.h"

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -23,8 +23,8 @@
 #include <wx/translation.h>
 #include <wx/utils.h>
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/SymbolDB.h"

--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
@@ -20,7 +20,7 @@
 #include <wx/aui/auibook.h>
 #include <wx/aui/framemanager.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Common/SymbolDB.h"
 #include "Core/Host.h"

--- a/Source/Core/DolphinWX/Debugger/JitWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.cpp
@@ -20,7 +20,7 @@
 #include <wx/window.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/GekkoDisassembler.h"
 #include "Common/StringUtil.h"
 #include "Core/PowerPC/Gekko.h"

--- a/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.cpp
@@ -16,7 +16,7 @@
 #include <wx/translation.h>
 
 #include "Common/BreakPoints.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "DolphinWX/WxUtils.h"

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -21,7 +21,7 @@
 #include <wx/string.h>
 #include <wx/window.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
 #include "Common/StringUtil.h"
 #include "DolphinWX/Globals.h"

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -24,7 +24,7 @@
 #include <wx/windowid.h>
 #include <wx/wxcrtvararg.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/DolphinWX/Debugger/RegisterView.h
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.h
@@ -10,7 +10,7 @@
 #include <wx/string.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class wxWindow;
 

--- a/Source/Core/DolphinWX/FifoPlayerDlg.cpp
+++ b/Source/Core/DolphinWX/FifoPlayerDlg.cpp
@@ -33,7 +33,7 @@
 #include <wx/translation.h>
 #include <wx/utils.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/FifoPlayer/FifoDataFile.h"
 #include "Core/FifoPlayer/FifoPlaybackAnalyzer.h"
 #include "Core/FifoPlayer/FifoPlayer.h"

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -36,7 +36,7 @@
 #include <wx/aui/auibook.h>
 #include <wx/aui/framemanager.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Thread.h"
 #include "Common/Logging/ConsoleListener.h"

--- a/Source/Core/DolphinWX/FrameAui.cpp
+++ b/Source/Core/DolphinWX/FrameAui.cpp
@@ -30,7 +30,7 @@
 #include <wx/aui/auibook.h>
 #include <wx/aui/framemanager.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/MathUtil.h"

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -36,7 +36,7 @@
 #endif
 
 #include "Common/CDUtils.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -40,7 +40,7 @@
 #include <wx/windowid.h>
 
 #include "Common/CDUtils.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"

--- a/Source/Core/DolphinWX/GeckoCodeDiag.cpp
+++ b/Source/Core/DolphinWX/GeckoCodeDiag.cpp
@@ -22,7 +22,7 @@
 #include <wx/translation.h>
 #include <wx/window.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Core/Core.h"
 #include "Core/GeckoCode.h"

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -14,8 +14,8 @@
 #include <wx/string.h>
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/IniFile.h"

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "DiscIO/Volume.h"
 
 #if defined(HAVE_WX) && HAVE_WX

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -53,8 +53,8 @@
 #include <wx/validate.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/DolphinWX/LogWindow.cpp
+++ b/Source/Core/DolphinWX/LogWindow.cpp
@@ -28,7 +28,7 @@
 #include <wx/windowid.h>
 #include <wx/aui/framemanager.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/ConsoleListener.h"

--- a/Source/Core/DolphinWX/LogWindow.h
+++ b/Source/Core/DolphinWX/LogWindow.h
@@ -17,7 +17,7 @@
 #include <wx/translation.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Logging/LogManager.h"
 
 class CFrame;

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -28,8 +28,8 @@
 #include <wx/utils.h>
 #include <wx/window.h>
 
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -24,8 +24,8 @@
 #include <EGL/egl.h>
 
 #include "Android/ButtonManager.h"
-#include "Common/Common.h"
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Common/Event.h"
 #include "Common/FileUtil.h"

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -9,7 +9,7 @@
 #include <getopt.h>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/Logging/LogManager.h"
 

--- a/Source/Core/DolphinWX/MemcardManager.cpp
+++ b/Source/Core/DolphinWX/MemcardManager.cpp
@@ -27,7 +27,7 @@
 #include <wx/window.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/DolphinWX/MemcardManager.h
+++ b/Source/Core/DolphinWX/MemcardManager.h
@@ -16,7 +16,7 @@
 #include <wx/translation.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 
 class GCMemcard;

--- a/Source/Core/DolphinWX/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetWindow.cpp
@@ -28,7 +28,7 @@
 #include <wx/textctrl.h>
 #include <wx/translation.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FifoQueue.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"

--- a/Source/Core/DolphinWX/PatchAddEdit.cpp
+++ b/Source/Core/DolphinWX/PatchAddEdit.cpp
@@ -23,7 +23,7 @@
 #include <wx/translation.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/PatchEngine.h"
 #include "DolphinWX/PatchAddEdit.h"
 #include "DolphinWX/WxUtils.h"

--- a/Source/Core/DolphinWX/TASInputDlg.h
+++ b/Source/Core/DolphinWX/TASInputDlg.h
@@ -14,7 +14,7 @@
 #include <wx/translation.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "InputCommon/GCPadStatus.h"
 
 class wxCheckBox;

--- a/Source/Core/DolphinWX/WiimoteConfigDiag.cpp
+++ b/Source/Core/DolphinWX/WiimoteConfigDiag.cpp
@@ -16,7 +16,7 @@
 #include <wx/window.h>
 #include <wx/windowid.h>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/SysConf.h"

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 #include "InputCommon/ControllerInterface/Device.h"
 #include "InputCommon/ControllerInterface/ExpressionParser.h"

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // idk in case I wanted to change it to double or something, idk what's best
 typedef double ControlState;

--- a/Source/Core/VideoBackends/OGL/GLInterfaceBase.h
+++ b/Source/Core/VideoBackends/OGL/GLInterfaceBase.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 enum GLInterfaceMode {
 	MODE_DETECT = 0,

--- a/Source/Core/VideoBackends/Software/BPMemLoader.h
+++ b/Source/Core/VideoBackends/Software/BPMemLoader.h
@@ -5,7 +5,7 @@
 #pragma once
 
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/BPMemory.h"
 
 void InitBPMemory();

--- a/Source/Core/VideoBackends/Software/CPMemLoader.h
+++ b/Source/Core/VideoBackends/Software/CPMemLoader.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/CPMemory.h"
 
 void SWLoadCPReg(u32 sub_cmd, u32 value);

--- a/Source/Core/VideoBackends/Software/DebugUtil.cpp
+++ b/Source/Core/VideoBackends/Software/DebugUtil.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/VideoBackends/Software/EfbCopy.h
+++ b/Source/Core/VideoBackends/Software/EfbCopy.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace EfbCopy
 {

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/Memmap.h"
 
 #include "VideoBackends/Software/BPMemLoader.h"

--- a/Source/Core/VideoBackends/Software/HwRasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/HwRasterizer.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MemoryUtil.h"
 
 #include "VideoBackends/OGL/GLInterfaceBase.h"

--- a/Source/Core/VideoBackends/Software/OpcodeDecoder.cpp
+++ b/Source/Core/VideoBackends/Software/OpcodeDecoder.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/Memmap.h"
 #include "VideoBackends/Software/BPMemLoader.h"
 #include "VideoBackends/Software/CPMemLoader.h"

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoBackends/Software/BPMemLoader.h"
 #include "VideoBackends/Software/EfbInterface.h"
 #include "VideoBackends/Software/HwRasterizer.h"

--- a/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
+++ b/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
@@ -4,7 +4,7 @@
 
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FPURoundMode.h"
 #include "Common/MathUtil.h"
 #include "Common/Thread.h"

--- a/Source/Core/VideoBackends/Software/SWCommandProcessor.h
+++ b/Source/Core/VideoBackends/Software/SWCommandProcessor.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "VideoCommon/CommandProcessor.h"
 

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Core/Core.h"
 #include "VideoBackends/OGL/GLInterfaceBase.h"

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "VideoBackends/Software/CPMemLoader.h"
 #include "VideoBackends/Software/SetupUnit.h"

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.h
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "VideoBackends/Software/CPMemLoader.h"
 #include "VideoBackends/Software/NativeVertexFormat.h"

--- a/Source/Core/VideoBackends/Software/SWVideoConfig.h
+++ b/Source/Core/VideoBackends/Software/SWVideoConfig.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #define STATISTICS 1
 

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -5,7 +5,7 @@
 #include <string>
 
 #include "Common/Atomic.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 #include "Common/Logging/LogManager.h"

--- a/Source/Core/VideoBackends/Software/SetupUnit.h
+++ b/Source/Core/VideoBackends/Software/SetupUnit.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoBackends/Software/NativeVertexFormat.h"
 
 class PointerWrap;

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoBackends/Software/DebugUtil.h"
 #include "VideoBackends/Software/EfbInterface.h"
 #include "VideoBackends/Software/SWStatistics.h"

--- a/Source/Core/VideoBackends/Software/TextureEncoder.h
+++ b/Source/Core/VideoBackends/Software/TextureEncoder.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace TextureEncoder
 {

--- a/Source/Core/VideoBackends/Software/TextureSampler.h
+++ b/Source/Core/VideoBackends/Software/TextureSampler.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 namespace TextureSampler
 {

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <cmath>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 
 #include "VideoBackends/Software/BPMemLoader.h"

--- a/Source/Core/VideoBackends/Software/XFMemLoader.h
+++ b/Source/Core/VideoBackends/Software/XFMemLoader.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "VideoCommon/XFMemory.h"
 

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/HW/Memmap.h"

--- a/Source/Core/VideoCommon/BPMemory.cpp
+++ b/Source/Core/VideoCommon/BPMemory.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/BPMemory.h"
 
 // BP state

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -7,7 +7,7 @@
 #include <string>
 
 #include "Common/BitField.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #pragma pack(4)
 

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/CPMemory.h"
 
 // CP state

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // Vertex array numbers
 enum

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -4,7 +4,7 @@
 
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Common/Thread.h"
 #include "Core/ConfigManager.h"

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/VideoBackendBase.h"
 
 class PointerWrap;

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/VideoBackendBase.h"
 
 class PointerWrap;

--- a/Source/Core/VideoCommon/ImageWrite.h
+++ b/Source/Core/VideoCommon/ImageWrite.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <string>
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 bool SaveData(const std::string& filename, const char* pdata);
 bool TextureToPng(u8* data, int row_stride, const std::string& filename, int width, int height, bool saveAlpha = true);

--- a/Source/Core/VideoCommon/IndexGenerator.cpp
+++ b/Source/Core/VideoCommon/IndexGenerator.cpp
@@ -4,7 +4,7 @@
 
 #include <cstddef>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoCommon/LookUpTables.h
+++ b/Source/Core/VideoCommon/LookUpTables.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 inline u8 Convert3To8(u8 v)
 {

--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // m_components
 enum

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -6,7 +6,7 @@
 #include <map>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/Timer.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -12,7 +12,7 @@
 // while interpreting them, and hope that the vertex format doesn't change, though, if you do it right
 // when they are called. The reason is that the vertex format affects the sizes of the vertices.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Core/Core.h"
 #include "Core/Host.h"

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -8,7 +8,7 @@
 
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/State.h"

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -4,7 +4,7 @@
 
 #include <cmath>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/RenderBase.h"

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoCommon.h"
 

--- a/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <cmath>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/TextureDecoder.h"

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <cmath>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 //#include "VideoCommon.h" // to get debug logs
 #include "Common/CPUDetect.h"
 

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MemoryUtil.h"
 #include "Common/StringUtil.h"
 #include "Common/x64ABI.h"

--- a/Source/Core/VideoCommon/VertexLoader.h
+++ b/Source/Core/VideoCommon/VertexLoader.h
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/x64Emitter.h"
 
 #include "VideoCommon/CPMemory.h"

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/NativeVertexFormat.h"
 
 namespace VertexLoaderManager

--- a/Source/Core/VideoCommon/VertexLoader_Color.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Color.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/VertexLoader.h"

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <limits>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 
 #include "VideoCommon/VertexLoader.h"

--- a/Source/Core/VideoCommon/VertexLoader_Normal.h
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class VertexLoader_Normal
 {

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -4,7 +4,7 @@
 
 #include <limits>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 
 #include "VideoCommon/VertexLoader.h"

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 
 #include "VideoCommon/VertexLoader.h"

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -1,4 +1,4 @@
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 #include "VideoCommon/BPStructs.h"
 #include "VideoCommon/Debugger.h"
@@ -144,7 +144,8 @@ u32 VertexManager::GetRemainingIndices(int primitive)
 
 void VertexManager::Flush()
 {
-	if (IsFlushed) return;
+	if (IsFlushed)
+		return;
 
 	// loading a state will invalidate BP, so check for it
 	g_video_backend->CheckInvalidState();

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <vector>
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 class NativeVertexFormat;
 class PointerWrap;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <sstream>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/CPMemory.h"

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -8,7 +8,7 @@
 #include <windows.h>
 #endif
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "VideoCommon/VideoBackendBase.h"
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -4,7 +4,7 @@
 
 #include <cmath>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/VideoCommon.h"
 
 // Log in two categories, and save three other options in the same byte

--- a/Source/Core/VideoCommon/XFMemory.h
+++ b/Source/Core/VideoCommon/XFMemory.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/CPMemory.h"
 
 

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/Memmap.h"
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/DataReader.h"


### PR DESCRIPTION
Many files don't need to include the larger parent header file.
