### PR TITLE
Fix building ARMv7 on the 64bit Android NDK.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.h
@@ -84,8 +84,9 @@ const int BACKPATCH_SIZE = 5;
 		#define CTX_R15 gregs[REG_R15]
 		#define CTX_RIP gregs[REG_RIP]
 	#elif _M_ARM_32
+		#include <asm/sigcontext.h>
 		// Add others if required.
-		typedef struct sigcontext SContext;
+		typedef sigcontext SContext;
 		#define CTX_PC  arm_pc
 	#else
 		#warning No context definition for OS


### PR DESCRIPTION
Google has gotten their act together and fixes a few of the signal handling headers.
Change over to a header that works on both r10 32bit and r10 64bit.
32bit has the old "broken" headers as in some didn't even exist.
64bit has the "fixed" headers that one would expect on any regular unix system.
