### PR TITLE
Gameini cleanup.

### DIFF
--- a/Data/Sys/GameSettings/D43P01.ini
+++ b/Data/Sys/GameSettings/D43P01.ini
@@ -6,7 +6,6 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Dolphin doesn't support soft reset"
 EmulationIssues =
 
 [OnLoad]

--- a/Data/Sys/GameSettings/G63P41.ini
+++ b/Data/Sys/GameSettings/G63P41.ini
@@ -7,7 +7,7 @@ TLBHack=1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-Issues="Needs Projection Hack R844 and Copy EFB to GL texture"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/G8OJ18.ini
+++ b/Data/Sys/GameSettings/G8OJ18.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Bad Sound, Needs to disable or downlevel"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GANE7U.ini
+++ b/Data/Sys/GameSettings/GANE7U.ini
@@ -7,7 +7,6 @@ TLBHack = 1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="TLB Error"
 EmulationIssues =
 
 [OnLoad]

--- a/Data/Sys/GameSettings/GBDS7D.ini
+++ b/Data/Sys/GameSettings/GBDS7D.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Graphics glitches"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GCLP69.ini
+++ b/Data/Sys/GameSettings/GCLP69.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-Issues="Graphics Errors... Not Playable"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GCNE7D.ini
+++ b/Data/Sys/GameSettings/GCNE7D.ini
@@ -7,7 +7,6 @@ TLBHack = 1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues =
 EmulationIssues = Disable "Panic Handlers". Needs "Real Xfb" to display videos.
 
 [OnLoad]

--- a/Data/Sys/GameSettings/GCOE52.ini
+++ b/Data/Sys/GameSettings/GCOE52.ini
@@ -8,7 +8,7 @@ Patch region = 0x7e000004
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Slowwwwwwww and desync but playable"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GFUE4Z.ini
+++ b/Data/Sys/GameSettings/GFUE4Z.ini
@@ -7,7 +7,7 @@ TLBHack=1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Corrupt Graphics"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GLME01.ini
+++ b/Data/Sys/GameSettings/GLME01.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Some controls may not work correctly"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GMPE01.ini
+++ b/Data/Sys/GameSettings/GMPE01.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="The bubbles in into scene when starting a game are not shaded right?"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GMTP69.ini
+++ b/Data/Sys/GameSettings/GMTP69.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Needs Projectin Before R945"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GRFE78.ini
+++ b/Data/Sys/GameSettings/GRFE78.ini
@@ -7,7 +7,7 @@ TLBHack=1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Graphics Errors"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GROP7J.ini
+++ b/Data/Sys/GameSettings/GROP7J.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Needs Projection Before R945, crappy sound"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GUVE51.ini
+++ b/Data/Sys/GameSettings/GUVE51.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Corrupt Graphics"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GUZE41.ini
+++ b/Data/Sys/GameSettings/GUZE41.ini
@@ -7,8 +7,7 @@ TLBHack = 1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="TLB Error"
-EmulationIssues = Needs real XFB for videos to show up.(r6898)
+EmulationIssues = Needs real XFB for videos to show up.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GUZP41.ini
+++ b/Data/Sys/GameSettings/GUZP41.ini
@@ -7,8 +7,7 @@ TLBHack = 1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="TLB Error"
-EmulationIssues = Needs real XFB for videos to show up.(r6898)
+EmulationIssues = Needs real XFB for videos to show up.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GWJE52.ini
+++ b/Data/Sys/GameSettings/GWJE52.ini
@@ -5,7 +5,6 @@ MMU = 1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-Issues="Error to compile...DC error?"
 EmulationIssues = Slow because it needs mmu to run.
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GWKP41.ini
+++ b/Data/Sys/GameSettings/GWKP41.ini
@@ -7,7 +7,7 @@ TLBHack=1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Very Very Darkening"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GZ2E01.ini
+++ b/Data/Sys/GameSettings/GZ2E01.ini
@@ -1531,5 +1531,3 @@ SafeTextureCacheColorSamples = 512
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
-

--- a/Data/Sys/GameSettings/GZ2J01.ini
+++ b/Data/Sys/GameSettings/GZ2J01.ini
@@ -32,5 +32,3 @@ SafeTextureCacheColorSamples = 512
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
-

--- a/Data/Sys/GameSettings/GZ2P01.ini
+++ b/Data/Sys/GameSettings/GZ2P01.ini
@@ -127,7 +127,6 @@ SafeTextureCacheColorSamples = 512
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 
 [Speedhacks]
 0x803420bc=200

--- a/Data/Sys/GameSettings/GZ3PB2.ini
+++ b/Data/Sys/GameSettings/GZ3PB2.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="FullSpeed ingame But half Screen view...Bug?"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GZEE70.ini
+++ b/Data/Sys/GameSettings/GZEE70.ini
@@ -7,7 +7,6 @@ TLBHack = 1
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-Issues="Playable,but sometimes slowdown FPS maybe is patched"
 EmulationIssues =
 
 [OnLoad]

--- a/Data/Sys/GameSettings/GZSE70.ini
+++ b/Data/Sys/GameSettings/GZSE70.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Bad sound, Repeat constantly"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/PRJE01.ini
+++ b/Data/Sys/GameSettings/PRJE01.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 2
-Issues="Needs GameBoy controller on slot 4"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RBTP8P.ini
+++ b/Data/Sys/GameSettings/RBTP8P.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Works Fine and with sound, but graphics glitches.Does not playable"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RELS01.ini
+++ b/Data/Sys/GameSettings/RELS01.ini
@@ -6,7 +6,6 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Boots then hangs, stuck on nop opcode?"
 EmulationIssues =
 
 [OnLoad]

--- a/Data/Sys/GameSettings/RG5PWR.ini
+++ b/Data/Sys/GameSettings/RG5PWR.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Need Projection before 945 - be activated"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RLEEFS.ini
+++ b/Data/Sys/GameSettings/RLEEFS.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-Issues="Needs Projection Before to 945 to see graphics.Slow but Fully playable!"
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RMHE08.ini
+++ b/Data/Sys/GameSettings/RMHE08.ini
@@ -37,5 +37,4 @@ UseRealXFB = False
 EFBAccessEnable = False
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 

--- a/Data/Sys/GameSettings/RMHJ08.ini
+++ b/Data/Sys/GameSettings/RMHJ08.ini
@@ -37,5 +37,4 @@ UseRealXFB = False
 EFBAccessEnable = False
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 

--- a/Data/Sys/GameSettings/RMHP08.ini
+++ b/Data/Sys/GameSettings/RMHP08.ini
@@ -32,5 +32,3 @@ UseRealXFB = False
 EFBAccessEnable = False
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
-

--- a/Data/Sys/GameSettings/RZDE01.ini
+++ b/Data/Sys/GameSettings/RZDE01.ini
@@ -64,5 +64,3 @@ SafeTextureCacheColorSamples = 512
 EFBAccessEnable = True
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
-

--- a/Data/Sys/GameSettings/RZDJ01.ini
+++ b/Data/Sys/GameSettings/RZDJ01.ini
@@ -32,5 +32,3 @@ SafeTextureCacheColorSamples = 512
 EFBAccessEnable = True
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
-

--- a/Data/Sys/GameSettings/RZDK01.ini
+++ b/Data/Sys/GameSettings/RZDK01.ini
@@ -32,5 +32,4 @@ SafeTextureCacheColorSamples = 512
 EFBAccessEnable = True
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 

--- a/Data/Sys/GameSettings/RZDP01.ini
+++ b/Data/Sys/GameSettings/RZDP01.ini
@@ -64,5 +64,4 @@ SafeTextureCacheColorSamples = 512
 EFBAccessEnable = True
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 

--- a/Data/Sys/GameSettings/S2LE01.ini
+++ b/Data/Sys/GameSettings/S2LE01.ini
@@ -28,5 +28,3 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
-

--- a/Data/Sys/GameSettings/S2LJ01.ini
+++ b/Data/Sys/GameSettings/S2LJ01.ini
@@ -28,5 +28,3 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
-

--- a/Data/Sys/GameSettings/S2LP01.ini
+++ b/Data/Sys/GameSettings/S2LP01.ini
@@ -28,5 +28,3 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
-

--- a/Data/Sys/GameSettings/SH6E52.ini
+++ b/Data/Sys/GameSettings/SH6E52.ini
@@ -29,5 +29,4 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 

--- a/Data/Sys/GameSettings/SLSEXJ.ini
+++ b/Data/Sys/GameSettings/SLSEXJ.ini
@@ -28,5 +28,4 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 

--- a/Data/Sys/GameSettings/SLSJ01.ini
+++ b/Data/Sys/GameSettings/SLSJ01.ini
@@ -28,5 +28,3 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
-

--- a/Data/Sys/GameSettings/SLSP01.ini
+++ b/Data/Sys/GameSettings/SLSP01.ini
@@ -28,5 +28,4 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 

--- a/Data/Sys/GameSettings/SSQE01.ini
+++ b/Data/Sys/GameSettings/SSQE01.ini
@@ -28,5 +28,4 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 

--- a/Data/Sys/GameSettings/SSQJ01.ini
+++ b/Data/Sys/GameSettings/SSQJ01.ini
@@ -28,5 +28,4 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 

--- a/Data/Sys/GameSettings/SSQP01.ini
+++ b/Data/Sys/GameSettings/SSQP01.ini
@@ -28,5 +28,4 @@ PH_ZFar =
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True
-EFBCopyCacheEnable = True
 


### PR DESCRIPTION
This is a cleanup of the gameini database. Specifically:
It removes the "Issues=..." lines and their respective comments since
they don't show up in the gui, are very old and wrong in most cases.
They contain probably more than 4 year old comments (i don't even have a clue
who or when wrote them).
Also remove the "EFBCopyCacheEnable = True" lines from the database.
These were put at a time that Efb to Ram had resolution issues without
cache being enabled, safe texture cache could be disabled and speed was
detrimental. Now that efb to ram doesn't have the same res issues as
back then, safe texture cache can't be disabled with speed gains being
non existent (you can even get a speed hit if texture cache is put to safe)
i think it should be removed from the database.
