### PR TITLE
JIT: use XCHG in MOVTwo

### DIFF
--- a/Source/Core/Common/x64ABI.cpp
+++ b/Source/Core/Common/x64ABI.cpp
@@ -321,7 +321,7 @@ void XEmitter::ABI_CallFunctionR(void *func, X64Reg reg1)
 // Pass two registers as parameters.
 void XEmitter::ABI_CallFunctionRR(void *func, X64Reg reg1, X64Reg reg2)
 {
-	MOVTwo(64, ABI_PARAM1, reg1, ABI_PARAM2, reg2, ABI_PARAM3);
+	MOVTwo(64, ABI_PARAM1, reg1, ABI_PARAM2, reg2);
 	u64 distance = u64(func) - (u64(code) + 5);
 	if (distance >= 0x0000000080000000ULL &&
 	    distance <  0xFFFFFFFF80000000ULL)
@@ -336,15 +336,13 @@ void XEmitter::ABI_CallFunctionRR(void *func, X64Reg reg1, X64Reg reg2)
 	}
 }
 
-void XEmitter::MOVTwo(int bits, Gen::X64Reg dst1, Gen::X64Reg src1, Gen::X64Reg dst2, Gen::X64Reg src2, X64Reg temp)
+void XEmitter::MOVTwo(int bits, Gen::X64Reg dst1, Gen::X64Reg src1, Gen::X64Reg dst2, Gen::X64Reg src2)
 {
 	if (dst1 == src2 && dst2 == src1)
 	{
-		// need a temporary
-		MOV(bits, R(temp), R(src1));
-		src1 = temp;
+		XCHG(bits, R(src1), R(src2));
 	}
-	if (src2 != dst1)
+	else if (src2 != dst1)
 	{
 		if (dst1 != src1)
 			MOV(bits, R(dst1), R(src1));

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -756,7 +756,7 @@ public:
 	void ABI_CallFunctionRR(void *func, X64Reg reg1, X64Reg reg2);
 
 	// Helper method for the above, or can be used separately.
-	void MOVTwo(int bits, Gen::X64Reg dst1, Gen::X64Reg src1, Gen::X64Reg dst2, Gen::X64Reg src2, Gen::X64Reg temp);
+	void MOVTwo(int bits, Gen::X64Reg dst1, Gen::X64Reg src1, Gen::X64Reg dst2, Gen::X64Reg src2);
 
 	// Saves/restores the registers and adjusts the stack to be aligned as
 	// required by the ABI, where the previous alignment was as specified.

--- a/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
@@ -115,7 +115,7 @@ const u8 *TrampolineCache::GetWriteTrampoline(const InstructionInfo &info, u32 r
 
 	ABI_PushRegistersAndAdjustStack(registersInUse, 8);
 
-	MOVTwo(64, ABI_PARAM1, dataReg, ABI_PARAM2, addrReg, ABI_PARAM3);
+	MOVTwo(64, ABI_PARAM1, dataReg, ABI_PARAM2, addrReg);
 
 	if (info.displacement)
 	{


### PR DESCRIPTION
Roughly the same speed or slightly faster depending on CPU; mostly just cleaner
since we don't have to pass in a temp.
