### PR TITLE
Remove unused "using namespace" in header.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm32/JitFPRCache.h
+++ b/Source/Core/Core/PowerPC/JitArm32/JitFPRCache.h
@@ -10,7 +10,6 @@
 #include "Core/PowerPC/JitArm32/JitRegCache.h"
 
 #define ARMFPUREGS 32
-using namespace ArmGen;
 
 class ArmFPRCache
 {


### PR DESCRIPTION
At least, compiling with the Android NDK didn't have issues.
