### PR TITLE
Parse input as hex instead of decimal to match display values in the register view

### DIFF
--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -98,7 +98,7 @@ static void SetSpecialRegValue(int reg, u32 value)
 void CRegTable::SetValue(int row, int col, const wxString& strNewVal)
 {
 	u32 newVal = 0;
-	if (TryParse(WxStrToStr(strNewVal), &newVal))
+	if (TryParse("0x" + WxStrToStr(strNewVal), &newVal))
 	{
 		if (row < 32)
 		{


### PR DESCRIPTION
Currently, entering a value into a register's textbox in the debugger's registers view will parse that value with base 10. However, all values are displayed using base 16. Thus, if I enter 1500000, PC would get set to 0016e360, which is not what I expect.
