### PR TITLE
MMU: properly check MEM1 range on Gamecube games

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -108,6 +108,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
 
 		// do our job at first
 		s32 offset = (s32)(s16)inst.SIMM_16;
+		gpr.BindToRegister(a, true, false);
 		gpr.BindToRegister(d, false, true);
 		SafeLoadToReg(gpr.RX(d), gpr.R(a), accessSize, offset, CallerSavedRegistersInUse(), signExtend);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -29,8 +29,7 @@ void Jit64::lfXXX(UGeckoInstruction inst)
 
 	FALLBACK_IF((!indexed && !a) || (update && a == d));
 
-	if (update)
-		gpr.BindToRegister(a, true, true);
+	gpr.BindToRegister(a, true, update);
 
 	s32 offset = 0;
 	OpArg addr = gpr.R(a);

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -76,6 +76,7 @@ public:
 	void LoadAndSwap(int size, Gen::X64Reg dst, const Gen::OpArg& src);
 	void SwapAndStore(int size, const Gen::OpArg& dst, Gen::X64Reg src);
 
+	Gen::FixupBranch CheckIfSafeAddress(Gen::X64Reg reg_value, Gen::X64Reg reg_addr, u32 registers_in_use, u32 mem_mask);
 	void UnsafeLoadRegToReg(Gen::X64Reg reg_addr, Gen::X64Reg reg_value, int accessSize, s32 offset = 0, bool signExtend = false);
 	void UnsafeLoadRegToRegNoSwap(Gen::X64Reg reg_addr, Gen::X64Reg reg_value, int accessSize, s32 offset, bool signExtend = false);
 	// these return the address of the MOV, for backpatching


### PR DESCRIPTION
Fixes at the very least Rogue Squadron II crashes.

Note to do this I refactored loads slightly so that addresses have to be a register or immediate, which should be more consistent anyways.
