### PR TITLE
Fix Idle Skipping in JitIL.

### DIFF
--- a/Source/Core/Core/PowerPC/JitILCommon/IR.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/IR.cpp
@@ -1083,11 +1083,6 @@ InstLoc IRBuilder::FoldBranchCond(InstLoc Op1, InstLoc Op2)
 	return EmitBiOp(BranchCond, Op1, Op2);
 }
 
-InstLoc IRBuilder::FoldIdleBranch(InstLoc Op1, InstLoc Op2)
-{
-	return EmitBiOp(IdleBranch, EmitICmpEq(getOp1(getOp1(Op1)), getOp2(getOp1(Op1))), Op2);
-}
-
 InstLoc IRBuilder::FoldICmp(unsigned Opcode, InstLoc Op1, InstLoc Op2)
 {
 	if (isImm(*Op1))
@@ -1245,8 +1240,6 @@ InstLoc IRBuilder::FoldBiOp(unsigned Opcode, InstLoc Op1, InstLoc Op2, unsigned 
 			return FoldRol(Op1, Op2);
 		case BranchCond:
 			return FoldBranchCond(Op1, Op2);
-		case IdleBranch:
-			return FoldIdleBranch(Op1, Op2);
 		case ICmpEq: case ICmpNe:
 		case ICmpUgt: case ICmpUlt: case ICmpUge: case ICmpUle:
 		case ICmpSgt: case ICmpSlt: case ICmpSge: case ICmpSle:

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_Branch.cpp
@@ -138,14 +138,18 @@ void JitILBase::bcx(UGeckoInstruction inst)
 	else
 		destination = js.compilerPC + SignExt16(inst.BD << 2);
 
+	// Idle skipping:
+	// The main Idle skipping is done in the LoadStore code, but there is an optimization here.
+	// If idle skipping is enabled, then this branch will only be reached when the branch is not
+	// taken.
 	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bSkipIdle &&
-	    inst.hex == 0x4182fff8 &&
-	    (Memory::ReadUnchecked_U32(js.compilerPC - 8) & 0xFFFF0000) == 0x800D0000 &&
-	    (Memory::ReadUnchecked_U32(js.compilerPC - 4) == 0x28000000 ||
-	    (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii && Memory::ReadUnchecked_U32(js.compilerPC - 4) == 0x2C000000))
-	    )
+		inst.hex == 0x4182fff8 &&
+		(Memory::ReadUnchecked_U32(js.compilerPC - 8) & 0xFFFF0000) == 0x800D0000 &&
+		(Memory::ReadUnchecked_U32(js.compilerPC - 4) == 0x28000000 ||
+		(SConfig::GetInstance().m_LocalCoreStartupParameter.bWii && Memory::ReadUnchecked_U32(js.compilerPC - 4) == 0x2C000000))
+		)
 	{
-		ibuild.EmitIdleBranch(Test, ibuild.EmitIntConst(destination));
+		// Uh, Do nothing.
 	}
 	else
 	{


### PR DESCRIPTION
Has been broken since the flags-opt merge. The idle skipping code in
JitIL was very brittle and depended on the IL of it's inputs not
changing in any way.

flags-opt changed the IR generated by the cmp instruction, which is part
of the idle loop, causing JitIL to break in really weird ways, which
were almost impossible to track down.

This Fixes various wii games crashing/not booting and the Regspill
error on (all?) gamecube mmu games.

@JMC47 Could you do some testing on this?
