### PR TITLE
Fix Fastmem in JitIL for massive speed gains.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
@@ -577,7 +577,7 @@ static void regEmitMemLoad(RegInfo& RI, InstLoc I, unsigned Size)
 	X64Reg reg;
 	auto info = regBuildMemAddress(RI, I, getOp1(I), 1, Size, &reg);
 
-	RI.Jit->SafeLoadToReg(reg, info.first, Size, info.second, regsInUse(RI), false, EmuCodeBlock::SAFE_LOADSTORE_NO_FASTMEM);
+	RI.Jit->SafeLoadToReg(reg, info.first, Size, info.second, regsInUse(RI), false);
 	if (regReadUse(RI, I))
 		RI.regs[reg] = I;
 }
@@ -619,7 +619,7 @@ static void regEmitMemStore(RegInfo& RI, InstLoc I, unsigned Size)
 		RI.Jit->MOV(32, R(RSCRATCH), regLocForInst(RI, getOp1(I)));
 	}
 
-	RI.Jit->SafeWriteRegToReg(RSCRATCH, RSCRATCH2, Size, 0, regsInUse(RI), EmuCodeBlock::SAFE_LOADSTORE_NO_FASTMEM);
+	RI.Jit->SafeWriteRegToReg(RSCRATCH, RSCRATCH2, Size, 0, regsInUse(RI));
 	if (RI.IInfo[I - RI.FirstI] & 4)
 		regClearInst(RI, getOp1(I));
 }
@@ -1557,7 +1557,7 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 
 			X64Reg reg = fregFindFreeReg(RI);
 			Jit->MOV(32, R(RSCRATCH2), regLocForInst(RI, getOp1(I)));
-			RI.Jit->SafeLoadToReg(RSCRATCH2, R(RSCRATCH2), 32, 0, regsInUse(RI), false, EmuCodeBlock::SAFE_LOADSTORE_NO_FASTMEM);
+			RI.Jit->SafeLoadToReg(RSCRATCH2, R(RSCRATCH2), 32, 0, regsInUse(RI), false);
 			Jit->MOVD_xmm(reg, R(RSCRATCH2));
 			RI.fregs[reg] = I;
 			regNormalRegClear(RI, I);
@@ -1571,7 +1571,7 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 			X64Reg reg = fregFindFreeReg(RI);
 			const OpArg loc = regLocForInst(RI, getOp1(I));
 			Jit->MOV(32, R(RSCRATCH2), loc);
-			RI.Jit->SafeLoadToReg(RSCRATCH2, R(RSCRATCH2), 64, 0, regsInUse(RI), false, EmuCodeBlock::SAFE_LOADSTORE_NO_FASTMEM);
+			RI.Jit->SafeLoadToReg(RSCRATCH2, R(RSCRATCH2), 64, 0, regsInUse(RI), false);
 			Jit->MOVQ_xmm(reg, R(RSCRATCH2));
 			RI.fregs[reg] = I;
 			regNormalRegClear(RI, I);
@@ -1612,7 +1612,7 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 				Jit->MOV(32, R(RSCRATCH), loc1);
 
 			Jit->MOV(32, R(RSCRATCH2), regLocForInst(RI, getOp2(I)));
-			RI.Jit->SafeWriteRegToReg(RSCRATCH, RSCRATCH2, 32, 0, regsInUse(RI), EmuCodeBlock::SAFE_LOADSTORE_NO_FASTMEM);
+			RI.Jit->SafeWriteRegToReg(RSCRATCH, RSCRATCH2, 32, 0, regsInUse(RI));
 			if (RI.IInfo[I - RI.FirstI] & 4)
 				fregClearInst(RI, getOp1(I));
 			if (RI.IInfo[I - RI.FirstI] & 8)
@@ -1628,7 +1628,7 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 			Jit->MOVAPD(XMM0, value);
 			Jit->MOVQ_xmm(R(RSCRATCH), XMM0);
 			Jit->MOV(32, R(RSCRATCH2), address);
-			RI.Jit->SafeWriteRegToReg(RSCRATCH, RSCRATCH2, 64, 0, regsInUse(RI), EmuCodeBlock::SAFE_LOADSTORE_NO_FASTMEM);
+			RI.Jit->SafeWriteRegToReg(RSCRATCH, RSCRATCH2, 64, 0, regsInUse(RI));
 
 			if (RI.IInfo[I - RI.FirstI] & 4)
 				fregClearInst(RI, getOp1(I));

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
@@ -36,12 +36,8 @@
 #include "Core/PowerPC/JitILCommon/IR.h"
 #include "Core/PowerPC/JitILCommon/JitILBase.h"
 
-class JitIL : public JitILBase, public EmuCodeBlock
+class JitIL : public JitILBase
 {
-private:
-	JitBlockCache blocks;
-	TrampolineCache trampolines;
-
 public:
 	Jit64AsmRoutineManager asm_routines;
 
@@ -59,12 +55,6 @@ public:
 	const u8* DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buffer, JitBlock *b);
 
 	void Trace();
-
-	JitBlockCache *GetBlockCache() override { return &blocks; }
-
-	const u8 *BackPatch(u8 *codePtr, u32 em_address, void *ctx) override { return nullptr; };
-
-	bool IsInCodeSpace(u8 *ptr) override { return IsInSpace(ptr); }
 
 	void ClearCache() override;
 	const u8 *GetDispatcher()

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase.h
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase.h
@@ -15,7 +15,7 @@
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/JitILCommon/IR.h"
 
-class JitILBase : public JitBase
+class JitILBase : public Jitx86Base
 {
 protected:
 	// The default code buffer. We keep it around to not have to alloc/dealloc a
@@ -27,15 +27,9 @@ public:
 
 	IREmitter::IRBuilder ibuild;
 
-	virtual JitBaseBlockCache *GetBlockCache() = 0;
-
 	virtual void Jit(u32 em_address) = 0;
 
-	virtual const u8 *BackPatch(u8 *codePtr, u32 em_address, void *ctx) = 0;
-
 	virtual const CommonAsmRoutinesBase *GetAsmRoutines() = 0;
-
-	virtual bool IsInCodeSpace(u8 *ptr) = 0;
 
 	// OPCODES
 	virtual void unknown_instruction(UGeckoInstruction inst) = 0;


### PR DESCRIPTION
JitIL's fastmem was stubbed out when @Sonicadvance1 merged JitARMIL
into the tree. Since JitARMIL has been deleted, I simply re-arrange
the inheritance to base JitIL on Jitx86Base, so it can inherit the
backpatch function.

Povray Benchmark: 1985 seconds to 1316 seconds.
