### PR TITLE
Kill off the wx casts within InputCommon and GLInterface.

### DIFF
--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -87,12 +87,10 @@ public:
 
 	void* GetRenderHandle()
 	{
-		#ifdef _WIN32
-			return (void *)m_RenderParent->GetHandle();
-		#elif defined(HAVE_X11) && HAVE_X11
-			return (void *)X11Utils::XWindowFromHandle(m_RenderParent->GetHandle());
+		#if defined(HAVE_X11) && HAVE_X11
+			return reinterpret_cast<void*>(X11Utils::XWindowFromHandle(m_RenderParent->GetHandle()));
 		#else
-			return m_RenderParent;
+			return reinterpret_cast<void*>(m_RenderParent->GetHandle());
 		#endif
 	}
 

--- a/Source/Core/DolphinWX/GLInterface/AGL.cpp
+++ b/Source/Core/DolphinWX/GLInterface/AGL.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include <wx/panel.h>
-
 #include "DolphinWX/GLInterface/AGL.h"
 
 #include "VideoCommon/RenderBase.h"
@@ -19,8 +17,7 @@ void cInterfaceAGL::Swap()
 // Call browser: Core.cpp:EmuThread() > main.cpp:Video_Initialize()
 bool cInterfaceAGL::Create(void *window_handle)
 {
-	// FIXME: Get rid of the explicit use of wxPanel here. This shouldn't be necessary.
-	cocoaWin = reinterpret_cast<NSView*>(((wxPanel*)window_handle)->GetHandle());
+	cocoaWin = reinterpret_cast<NSView*>(window_handle);
 	NSSize size = [cocoaWin frame].size;
 
 	// Enable high-resolution display support.

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXKeyboard.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXKeyboard.mm
@@ -7,7 +7,6 @@
 #include <Foundation/Foundation.h>
 #include <IOKit/hid/IOHIDLib.h>
 #include <Cocoa/Cocoa.h>
-#include <wx/wx.h> // wxWidgets
 
 #include "InputCommon/ControllerInterface/OSX/OSXKeyboard.h"
 
@@ -45,7 +44,7 @@ Keyboard::Keyboard(IOHIDDeviceRef device, std::string name, int index, void *win
 		CFRelease(elements);
 	}
 
-	m_windowid = [[(NSView *)(((wxWindow *)window)->GetHandle()) window] windowNumber];
+	m_windowid = [[reinterpret_cast<NSView*>(window) window] windowNumber];
 
 	// cursor, with a hax for-loop
 	for (unsigned int i=0; i<4; ++i)


### PR DESCRIPTION
All because someone didn't actually return the wxWindow handle for the edge case.
