### PR TITLE
Revert "Two small JIT optimizations"

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -103,7 +103,7 @@ public:
 	void FinalizeCarryOverflow(bool oe, bool inv = false);
 	void FinalizeCarry(Gen::CCFlags cond);
 	void FinalizeCarry(bool ca);
-	void ComputeRC(const Gen::OpArg & arg, bool sign_extend = true);
+	void ComputeRC(const Gen::OpArg & arg);
 
 	// Use to extract bytes from a register using the regcache. offset is in bytes.
 	Gen::OpArg ExtractFromReg(int reg, int offset);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -116,20 +116,16 @@ void Jit64::FinalizeCarryOverflow(bool oe, bool inv)
 	FinalizeCarry(inv ? CC_NC : CC_C);
 }
 
-void Jit64::ComputeRC(const Gen::OpArg & arg, bool sign_extend)
+void Jit64::ComputeRC(const Gen::OpArg & arg)
 {
 	if (arg.IsImm())
 	{
 		MOV(64, PPCSTATE(cr_val[0]), Imm32((s32)arg.offset));
 	}
-	else if (sign_extend)
+	else
 	{
 		MOVSX(64, 32, RSCRATCH, arg);
 		MOV(64, PPCSTATE(cr_val[0]), R(RSCRATCH));
-	}
-	else
-	{
-		MOV(64, PPCSTATE(cr_val[0]), arg);
 	}
 }
 
@@ -210,7 +206,7 @@ void Jit64::regimmop(int d, int a, bool binary, u32 value, Operation doop, void 
 		if (carry)
 			FinalizeCarry(CC_C);
 		if (Rc)
-			ComputeRC(gpr.R(d), doop != And || (value & 0x80000000));
+			ComputeRC(gpr.R(d));
 	}
 	else if (doop == Add)
 	{

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -95,8 +95,10 @@ void Jit64::psq_l(UGeckoInstruction inst)
 	MOV(32, R(RSCRATCH2), Imm32(0x3F07));
 	AND(32, R(RSCRATCH2), M(((char *)&GQR(inst.I)) + 2));
 	MOVZX(32, 8, RSCRATCH, R(RSCRATCH2));
+	if (inst.W)
+		OR(32, R(RSCRATCH), Imm8(8));
 
-	CALLptr(MScaled(RSCRATCH, SCALE_8, (u32)(u64)(asm_routines.pairedLoadQuantized + inst.W * 8)));
+	CALLptr(MScaled(RSCRATCH, SCALE_8, (u32)(u64)asm_routines.pairedLoadQuantized));
 
 	MEMCHECK_START(false)
 	CVTPS2PD(fpr.RX(s), R(XMM0));


### PR DESCRIPTION
I'm pretty sure I know what went wrong here ^^;

(if it's what I'm thinking, I discovered the problem when doing my other branch; some instructions were passing computeRC a memory operand, which broke some of my assumptions)
