### PR TITLE
JIT: simpler fallback conditions for load/store float

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -27,7 +27,7 @@ void Jit64::lfXXX(UGeckoInstruction inst)
 	int a = inst.RA;
 	int b = inst.RB;
 
-	FALLBACK_IF((!indexed && !a) || (update && a == d));
+	FALLBACK_IF(!indexed && !a);
 
 	gpr.BindToRegister(a, true, update);
 
@@ -102,7 +102,7 @@ void Jit64::stfXXX(UGeckoInstruction inst)
 	int a = inst.RA;
 	int b = inst.RB;
 
-	FALLBACK_IF((!indexed && !a) || (update && (a == s || a == b)));
+	FALLBACK_IF((!indexed && !a) || (update && js.memcheck && a == b));
 
 	s32 offset = 0;
 	s32 imm = (s16)inst.SIMM_16;


### PR DESCRIPTION
I wasn't really thinking when I wrote these; d/s are for float registers, not
gprs.
