### PR TITLE
Fix BLR optimization (sorry)

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -116,8 +116,7 @@ using namespace PowerPC;
 // accessed, immediately turn into regular pages but cause a trap... but
 // putting them in the path of RSP just leads to something (in the kernel?)
 // thinking a regular stack extension is required.  So this protection is not
-// supported on Windows yet...  We still use a separate stack for the sake of
-// simplicity.
+// supported on Windows yet...
 
 enum
 {


### PR DESCRIPTION
In which I spend an hour and a half tracking down a bug where I wrote #ifdef instead of #ifndef.

(As I mentioned in the original pull request, stack overflow checking - and therefore, in the final version, using a custom stack - is disabled on Windows because the kernel is too opinionated about RSP.  Except I accidentally disabled it on non-Windows, at which point Windows started complaining because, even though the stack didn't actually overflow, in this version I removed the TIB stack limit adjustment so it thought it did.)
