### PR TITLE
Debugger: scroll by multiples of 4 bytes

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -127,11 +127,11 @@ void CCodeView::OnScrollWheel(wxMouseEvent& event)
 
 	if (scroll_down)
 	{
-		m_curAddress += num_lines;
+		m_curAddress += num_lines * 4;
 	}
 	else
 	{
-		m_curAddress -= num_lines;
+		m_curAddress -= num_lines * 4;
 	}
 
 	Refresh();

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -147,11 +147,11 @@ void CMemoryView::OnScrollWheel(wxMouseEvent& event)
 
 	if (scroll_down)
 	{
-		curAddress += num_lines;
+		curAddress += num_lines * 4;
 	}
 	else
 	{
-		curAddress -= num_lines;
+		curAddress -= num_lines * 4;
 	}
 
 	Refresh();


### PR DESCRIPTION
Avoids that weird effect where scrolling offsets code from 4-byte boundaries,
showing nonsense 75% of the time.
