### PR TITLE
FrameTools: Set focus on Windows via CFrame::SetFocus

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -973,11 +973,7 @@ void CFrame::StartGame(const std::string& filename)
 				X11Utils::XWindowFromHandle(GetHandle()), true);
 #endif
 
-#ifdef _WIN32
-		::SetFocus((HWND)m_RenderParent->GetHandle());
-#else
 		m_RenderParent->SetFocus();
-#endif
 
 		wxTheApp->Bind(wxEVT_KEY_DOWN,    &CFrame::OnKeyDown, this);
 		wxTheApp->Bind(wxEVT_KEY_UP,      &CFrame::OnKeyUp,   this);


### PR DESCRIPTION
These both work on Windows, gets rid of an ifdef.
