### PR TITLE
JIT: support byte-reversed stores/loads

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -222,8 +222,8 @@ static GekkoOPTemplate table31[] =
 	{119, &Jit64::lXXx},                   //"lbzux", OPTYPE_LOAD, FL_OUT_D | FL_OUT_A | FL_IN_A | FL_IN_B}},
 
 	//load byte reverse
-	{534, &Jit64::FallBackToInterpreter},  //"lwbrx", OPTYPE_LOAD, FL_OUT_D | FL_IN_A0 | FL_IN_B}},
-	{790, &Jit64::FallBackToInterpreter},  //"lhbrx", OPTYPE_LOAD, FL_OUT_D | FL_IN_A0 | FL_IN_B}},
+	{534, &Jit64::lXXx},                   //"lwbrx", OPTYPE_LOAD, FL_OUT_D | FL_IN_A0 | FL_IN_B}},
+	{790, &Jit64::lXXx},                   //"lhbrx", OPTYPE_LOAD, FL_OUT_D | FL_IN_A0 | FL_IN_B}},
 
 	// Conditional load/store (Wii SMP)
 	{150, &Jit64::FallBackToInterpreter},  //"stwcxd", OPTYPE_STORE, FL_EVIL | FL_SET_CR0}},
@@ -246,8 +246,8 @@ static GekkoOPTemplate table31[] =
 	{247, &Jit64::stXx},                   //"stbux",  OPTYPE_STORE, FL_OUT_A | FL_IN_A | FL_IN_B}},
 
 	//store bytereverse
-	{662, &Jit64::FallBackToInterpreter},  //"stwbrx", OPTYPE_STORE, FL_IN_A0 | FL_IN_B}},
-	{918, &Jit64::FallBackToInterpreter},  //"sthbrx", OPTYPE_STORE, FL_IN_A | FL_IN_B}},
+	{662, &Jit64::stXx},                   //"stwbrx", OPTYPE_STORE, FL_IN_A0 | FL_IN_B}},
+	{918, &Jit64::stXx},                   //"sthbrx", OPTYPE_STORE, FL_IN_A | FL_IN_B}},
 
 	{661, &Jit64::FallBackToInterpreter},  //"stswx",  OPTYPE_STORE, FL_EVIL}},
 	{725, &Jit64::FallBackToInterpreter},  //"stswi",  OPTYPE_STORE, FL_EVIL}},

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -479,9 +479,11 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
 		                               Imm8((u8)reg_value.offset);
 	}
 
+	// TODO: support byte-swapped non-immediate fastmem stores
 	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bMMU &&
 	    SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem &&
-	    !(flags & (SAFE_LOADSTORE_NO_SWAP | SAFE_LOADSTORE_NO_FASTMEM))
+	    !(flags & SAFE_LOADSTORE_NO_FASTMEM) &&
+		(reg_value.IsImm() || !(flags & SAFE_LOADSTORE_NO_SWAP))
 #ifdef ENABLE_MEM_CHECK
 	    && !SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableDebugging
 #endif


### PR DESCRIPTION
4 more instructions down.

Store ones should be pretty well-tested; load ones seem to almost never be
used. I found them in Turok Evolution, so I was able to check code generation,
but the relevant code didn't seem to be called.
