### PR TITLE
JIT: change eieio and tlbsync to DoNothing

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -284,10 +284,10 @@ static GekkoOPTemplate table31[] =
 	// Unused instructions on GC
 	{310, &Jit64::FallBackToInterpreter},  //"eciwx",   OPTYPE_INTEGER, FL_RC_BIT}},
 	{438, &Jit64::FallBackToInterpreter},  //"ecowx",   OPTYPE_INTEGER, FL_RC_BIT}},
-	{854, &Jit64::FallBackToInterpreter},  //"eieio",   OPTYPE_INTEGER, FL_RC_BIT}},
+	{854, &Jit64::DoNothing},              //"eieio",   OPTYPE_INTEGER, FL_RC_BIT}},
 	{306, &Jit64::FallBackToInterpreter},  //"tlbie",   OPTYPE_SYSTEM, 0}},
 	{370, &Jit64::FallBackToInterpreter},  //"tlbia",   OPTYPE_SYSTEM, 0}},
-	{566, &Jit64::FallBackToInterpreter},  //"tlbsync", OPTYPE_SYSTEM, 0}},
+	{566, &Jit64::DoNothing},              //"tlbsync", OPTYPE_SYSTEM, 0}},
 };
 
 static GekkoOPTemplate table31_2[] =

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL_Tables.cpp
@@ -285,10 +285,10 @@ static GekkoOPTemplate table31[] =
 	// Unused instructions on GC
 	{310, &JitIL::FallBackToInterpreter},  //"eciwx",   OPTYPE_INTEGER, FL_RC_BIT}},
 	{438, &JitIL::FallBackToInterpreter},  //"ecowx",   OPTYPE_INTEGER, FL_RC_BIT}},
-	{854, &JitIL::FallBackToInterpreter},  //"eieio",   OPTYPE_INTEGER, FL_RC_BIT}},
+	{854, &JitIL::DoNothing},              //"eieio",   OPTYPE_INTEGER, FL_RC_BIT}},
 	{306, &JitIL::FallBackToInterpreter},  //"tlbie",   OPTYPE_SYSTEM, 0}},
 	{370, &JitIL::FallBackToInterpreter},  //"tlbia",   OPTYPE_SYSTEM, 0}},
-	{566, &JitIL::FallBackToInterpreter},  //"tlbsync", OPTYPE_SYSTEM, 0}},
+	{566, &JitIL::DoNothing},              //"tlbsync", OPTYPE_SYSTEM, 0}},
 };
 
 static GekkoOPTemplate table31_2[] =

--- a/Source/Core/Core/PowerPC/JitArm32/JitArm_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitArm_Tables.cpp
@@ -286,10 +286,10 @@ static GekkoOPTemplate table31[] =
 	// Unused instructions on GC
 	{310, &JitArm::FallBackToInterpreter},  //"eciwx",   OPTYPE_INTEGER, FL_RC_BIT}},
 	{438, &JitArm::FallBackToInterpreter},  //"ecowx",   OPTYPE_INTEGER, FL_RC_BIT}},
-	{854, &JitArm::FallBackToInterpreter},  //"eieio",   OPTYPE_INTEGER, FL_RC_BIT}},
+	{854, &JitArm::DoNothing},              //"eieio",   OPTYPE_INTEGER, FL_RC_BIT}},
 	{306, &JitArm::FallBackToInterpreter},  //"tlbie",   OPTYPE_SYSTEM, 0}},
 	{370, &JitArm::FallBackToInterpreter},  //"tlbia",   OPTYPE_SYSTEM, 0}},
-	{566, &JitArm::FallBackToInterpreter},  //"tlbsync", OPTYPE_SYSTEM, 0}},
+	{566, &JitArm::DoNothing},              //"tlbsync", OPTYPE_SYSTEM, 0}},
 };
 
 static GekkoOPTemplate table31_2[] =

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -171,7 +171,7 @@ static GekkoOPTemplate table19[] =
 	{417, &JitArm64::FallBackToInterpreter},    //"crorc",  OPTYPE_CR, FL_EVIL}},
 	{193, &JitArm64::FallBackToInterpreter},    //"crxor",  OPTYPE_CR, FL_EVIL}},
 
-	{150, &JitArm64::FallBackToInterpreter},    //"isync",  OPTYPE_ICACHE, FL_EVIL}},
+	{150, &JitArm64::DoNothing},                //"isync",  OPTYPE_ICACHE, FL_EVIL}},
 	{0,   &JitArm64::FallBackToInterpreter},    //"mcrf",   OPTYPE_SYSTEM, FL_EVIL}},
 
 	{50,  &JitArm64::rfi},                      //"rfi",    OPTYPE_SYSTEM, FL_ENDBLOCK | FL_CHECKEXCEPTIONS, 1}},
@@ -181,7 +181,7 @@ static GekkoOPTemplate table19[] =
 
 static GekkoOPTemplate table31[] =
 {
-	{28,  &JitArm64::FallBackToInterpreter},	  //"andx",   OPTYPE_INTEGER, FL_OUT_A | FL_IN_SB | FL_RC_BIT}},
+	{28,  &JitArm64::FallBackToInterpreter},	//"andx",   OPTYPE_INTEGER, FL_OUT_A | FL_IN_SB | FL_RC_BIT}},
 	{60,  &JitArm64::FallBackToInterpreter},    //"andcx",  OPTYPE_INTEGER, FL_OUT_A | FL_IN_SB | FL_RC_BIT}},
 	{444, &JitArm64::FallBackToInterpreter},    //"orx",    OPTYPE_INTEGER, FL_OUT_A | FL_IN_SB | FL_RC_BIT}},
 	{124, &JitArm64::FallBackToInterpreter},    //"norx",   OPTYPE_INTEGER, FL_OUT_A | FL_IN_SB | FL_RC_BIT}},
@@ -201,10 +201,10 @@ static GekkoOPTemplate table31[] =
 
 	{54,   &JitArm64::FallBackToInterpreter},   //"dcbst",  OPTYPE_DCACHE, 0, 4}},
 	{86,   &JitArm64::FallBackToInterpreter},   //"dcbf",   OPTYPE_DCACHE, 0, 4}},
-	{246,  &JitArm64::FallBackToInterpreter},   //"dcbtst", OPTYPE_DCACHE, 0, 1}},
-	{278,  &JitArm64::FallBackToInterpreter},   //"dcbt",   OPTYPE_DCACHE, 0, 1}},
+	{246,  &JitArm64::DoNothing},               //"dcbtst", OPTYPE_DCACHE, 0, 1}},
+	{278,  &JitArm64::DoNothing},               //"dcbt",   OPTYPE_DCACHE, 0, 1}},
 	{470,  &JitArm64::FallBackToInterpreter},   //"dcbi",   OPTYPE_DCACHE, 0, 4}},
-	{758,  &JitArm64::FallBackToInterpreter},   //"dcba",   OPTYPE_DCACHE, 0, 4}},
+	{758,  &JitArm64::DoNothing},               //"dcba",   OPTYPE_DCACHE, 0, 4}},
 	{1014, &JitArm64::FallBackToInterpreter},   //"dcbz",   OPTYPE_DCACHE, 0, 4}},
 
 	//load word
@@ -280,16 +280,16 @@ static GekkoOPTemplate table31[] =
 	{659, &JitArm64::FallBackToInterpreter},    //"mfsrin", OPTYPE_SYSTEM, FL_OUT_D, 2}},
 
 	{4,   &JitArm64::Break},                    //"tw",     OPTYPE_SYSTEM, FL_ENDBLOCK, 1}},
-	{598, &JitArm64::FallBackToInterpreter},    //"sync",   OPTYPE_SYSTEM, 0, 2}},
+	{598, &JitArm64::DoNothing},                //"sync",   OPTYPE_SYSTEM, 0, 2}},
 	{982, &JitArm64::icbi},                     //"icbi",   OPTYPE_SYSTEM, FL_ENDBLOCK, 3}},
 
 	// Unused instructions on GC
 	{310, &JitArm64::FallBackToInterpreter},    //"eciwx",   OPTYPE_INTEGER, FL_RC_BIT}},
 	{438, &JitArm64::FallBackToInterpreter},    //"ecowx",   OPTYPE_INTEGER, FL_RC_BIT}},
-	{854, &JitArm64::FallBackToInterpreter},    //"eieio",   OPTYPE_INTEGER, FL_RC_BIT}},
+	{854, &JitArm64::DoNothing},                //"eieio",   OPTYPE_INTEGER, FL_RC_BIT}},
 	{306, &JitArm64::FallBackToInterpreter},    //"tlbie",   OPTYPE_SYSTEM, 0}},
 	{370, &JitArm64::FallBackToInterpreter},    //"tlbia",   OPTYPE_SYSTEM, 0}},
-	{566, &JitArm64::FallBackToInterpreter},    //"tlbsync", OPTYPE_SYSTEM, 0}},
+	{566, &JitArm64::DoNothing},                //"tlbsync", OPTYPE_SYSTEM, 0}},
 };
 
 static GekkoOPTemplate table31_2[] =


### PR DESCRIPTION
The interpreter functions for these are no-ops anyways.
