### PR TITLE
DolphinWX: Fix the video dialog crashing Dolphin on OSX

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -201,7 +201,7 @@ protected:
 				label_adapter->Disable();
 			}
 
-#if !defined(_APPLE_)
+#ifndef __APPLE__
 			// This isn't supported on OSX.
 
 			choice_display_resolution->Disable();


### PR DESCRIPTION
When a game was running and someone opened the video dialog, it would crash. This is because the preprocessor macro should have been `__APPLE__` not `_APPLE_`

Fixes issue [7644](https://code.google.com/p/dolphin-emu/issues/detail?id=7644).
