### PR TITLE
JIT: merge lbz + extsb

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -94,6 +94,15 @@ void Jit64::lXXx(UGeckoInstruction inst)
 		PanicAlert("Invalid instruction");
 	}
 
+	// PowerPC has no 8-bit sign extended load, but x86 does, so merge extsb with the load if we find it.
+	if (accessSize == 8 && js.next_inst.OPCD == 31 && js.next_inst.SUBOP10 == 954 &&
+	    js.next_inst.RS == inst.RD && js.next_inst.RA == inst.RD && !js.next_inst.Rc)
+	{
+		js.downcountAmount++;
+		js.skipnext = true;
+		signExtend = true;
+	}
+
 	// TODO(ector): Make it dynamically enable/disable idle skipping where appropriate
 	// Will give nice boost to dual core mode
 	// (mb2): I agree,


### PR DESCRIPTION
PPC has no 8-bit sign-extended load, so this instruction pair is very common.
x86 can do it in one op (movsx), so merge them when possible.
