### PR TITLE
Replaced KillImmediate with BindToRegister in the tw instruction.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -1883,12 +1883,16 @@ void Jit64::twx(UGeckoInstruction inst)
 
 	s32 a = inst.RA;
 
-	gpr.KillImmediate(a, true, false);
-
 	if (inst.OPCD == 3) // twi
+	{
+		gpr.KillImmediate(a, true, false);
 		CMP(32, gpr.R(a), Imm32((s32)(s16)inst.SIMM_16));
+	}
 	else // tw
+	{
+		gpr.BindToRegister(a, true, false);
 		CMP(32, gpr.R(a), gpr.R(inst.RB));
+	}
 
 	std::vector<FixupBranch> fixups;
 	CCFlags conditions[] = { CC_A, CC_B, CC_E, CC_G, CC_L };


### PR DESCRIPTION
Replaced KillImmediate with BindToRegister in the tw instruction.  Fixes the error "WriteNormalOp - a1 and a2 cannot both be memory" which appeared on starting Monopoly Streets.
