### PR TITLE
Fix interpreter's implementations of mtfsfi, mtfsb0, and mtfsb1.

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -49,7 +49,11 @@ inline void SetFI(int FI)
 inline void UpdateFPSCR()
 {
 	FPSCR.VX = (FPSCR.Hex & FPSCR_VX_ANY) != 0;
-	FPSCR.FEX = 0; // we assume that "?E" bits are always 0
+	FPSCR.FEX = (FPSCR.VX & FPSCR.VE) ^
+	            (FPSCR.OX & FPSCR.OE) ^
+	            (FPSCR.UX & FPSCR.UE) ^
+	            (FPSCR.ZX & FPSCR.ZE) ^
+	            (FPSCR.XX & FPSCR.XE);
 }
 
 inline double ForceSingle(double _x)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -46,6 +46,12 @@ static void FPSCRtoFPUSettings(UReg_FPSCR fp)
 
 void Interpreter::mtfsb0x(UGeckoInstruction _inst)
 {
+	// mtfsb0 can't clear bits 1, 2, and 20
+	if (_inst.CRBD == 1 ||
+	    _inst.CRBD == 2 ||
+	    _inst.CRBD == 20)
+		return;
+
 	u32 b = 0x80000000 >> _inst.CRBD;
 
 	/*if (b & 0x9ff80700)
@@ -60,12 +66,19 @@ void Interpreter::mtfsb0x(UGeckoInstruction _inst)
 
 void Interpreter::mtfsb1x(UGeckoInstruction _inst)
 {
+	// mtfsb1 can't set bits 1, 2, and 20
+	if (_inst.CRBD == 1 ||
+	    _inst.CRBD == 2 ||
+	    _inst.CRBD == 20)
+		return;
+
 	// this instruction can affect FX
 	u32 b = 0x80000000 >> _inst.CRBD;
 	if (b & FPSCR_ANY_X)
 		SetFPException(b);
 	else
 		FPSCR.Hex |= b;
+
 	FPSCRtoFPUSettings(FPSCR);
 
 	if (_inst.Rc)
@@ -77,11 +90,10 @@ void Interpreter::mtfsfix(UGeckoInstruction _inst)
 	u32 mask = (0xF0000000 >> (4 * _inst.CRFD));
 	u32 imm = (_inst.hex << 16) & 0xF0000000;
 
-	/*u32 cleared = ~(imm >> (4 * _inst.CRFD)) & FPSCR.Hex & mask;
-	if (cleared & 0x9ff80700)
-		PanicAlert("mtfsfi clears %08x, PC=%x", cleared, PC);*/
-
 	FPSCR.Hex = (FPSCR.Hex & ~mask) | (imm >> (4 * _inst.CRFD));
+
+	// FPSCR bit 20 is reserved and is /always/ zero
+	FPSCR.Hex &= ~0x00000800;
 
 	FPSCRtoFPUSettings(FPSCR);
 


### PR DESCRIPTION
6xx_pem states that bits 1 and 2 of the FPSCR aren't set via mtfsfi.
With a hardware test this has been proven false, mtfsfi can set them to whatever it wants.

6xx_pem also states that bits 1 and 2 of the FPSCR can't be set via mtfsb0/1.
With a hardware test this has been proven to be true, these instructions can not set/clear these bits.

6xx_pem states that bit 20 is a reserved bit, that's all it says.
With a hardware test, this bit has been proven to only ever be zero and can't be set to anything else with any of these instructions.

Interpreter wrongly assumed that FEX will /always/ be zero, so it would set it to zero on a mffs instruction.
This has been rectified.