### PR TITLE
Fix fastmem in JitIL after 755bd2c4.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
@@ -58,8 +58,6 @@ public:
 
 	JitBlockCache *GetBlockCache() override { return &blocks; }
 
-	bool HandleFault(uintptr_t access_address, SContext* ctx) override { return false; }
-
 	void ClearCache() override;
 	const u8 *GetDispatcher()
 	{


### PR DESCRIPTION
That commit reorganized fastmem a bit; I wrote it before the patch to
support fastmem in JitIL landed, and forgot to edit it to account for
the fact.  Since JitILBase now derives from Jitx86Base, the HandleFault
override can just be removed.
