### PR TITLE
JIT+Emitter: support locking flags

### DIFF
--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -261,6 +261,9 @@ class XEmitter
 	friend struct OpArg;  // for Write8 etc
 private:
 	u8 *code;
+	bool flags_locked;
+
+	void CheckFlags();
 
 	void Rex(int w, int r, int x, int b);
 	void WriteSimple1Byte(int bits, u8 byte, X64Reg reg);
@@ -290,8 +293,8 @@ protected:
 	inline void Write64(u64 value) {*(u64*)code = (value); code += 8;}
 
 public:
-	XEmitter() { code = nullptr; }
-	XEmitter(u8 *code_ptr) { code = code_ptr; }
+	XEmitter() { code = nullptr; flags_locked = false; }
+	XEmitter(u8 *code_ptr) { code = code_ptr; flags_locked = false; }
 	virtual ~XEmitter() {}
 
 	void WriteModRM(int mod, int rm, int reg);
@@ -304,6 +307,9 @@ public:
 	const u8 *AlignCodePage();
 	const u8 *GetCodePtr() const;
 	u8 *GetWritableCodePtr();
+
+	void LockFlags() { flags_locked = true; }
+	void UnlockFlags() { flags_locked = false; }
 
 	// Looking for one of these? It's BANNED!! Some instructions are slow on modern CPU
 	// INC, DEC, LOOP, LOOPNE, LOOPE, ENTER, LEAVE, XCHG, XLAT, REP MOVSB/MOVSD, REP SCASD + other string instr.,

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -40,9 +40,13 @@ void Jit64::GenerateOverflow()
 	FixupBranch exit = J();
 	SetJumpTarget(jno);
 	//XER[OV] = 0
-	PUSHF();
-	AND(8, PPCSTATE(xer_so_ov), Imm8(~XER_OV_MASK));
-	POPF();
+	//We need to do this without modifying flags so as not to break stuff that assumes flags
+	//aren't clobbered (carry, branch merging): speed doesn't really matter here (this is really
+	//rare).
+	static const u8 ovtable[4] = {0, 0, XER_SO_MASK, XER_SO_MASK};
+	MOVZX(32, 8, RSCRATCH, PPCSTATE(xer_so_ov));
+	MOV(8, R(RSCRATCH), MDisp(RSCRATCH, (u32)(u64)ovtable));
+	MOV(8, PPCSTATE(xer_so_ov), R(RSCRATCH));
 	SetJumpTarget(exit);
 }
 
@@ -64,6 +68,7 @@ void Jit64::FinalizeCarry(CCFlags cond)
 				SETcc(cond, R(RSCRATCH));
 				SHR(8, R(RSCRATCH), Imm8(1));
 			}
+			LockFlags();
 			js.carryFlagSet = true;
 		}
 		else
@@ -86,6 +91,7 @@ void Jit64::FinalizeCarry(bool ca)
 				STC();
 			else
 				CLC();
+			LockFlags();
 			js.carryFlagSet = true;
 		}
 		else if (ca)
@@ -1265,6 +1271,8 @@ void Jit64::arithXex(UGeckoInstruction inst)
 	gpr.BindToRegister(d, !same_input_sub && (d == a || d == b));
 	if (!js.carryFlagSet)
 		JitGetAndClearCAOV(inst.OE);
+	else
+		UnlockFlags();
 
 	bool invertedCarry = false;
 	// Special case: subfe A, B, B is a common compiler idiom


### PR DESCRIPTION
This helps us avoid accidentally clobbering flags between two instructions
when the flags are expected to be maintained. Dolphin will of course crash
immediately, but at least it will crash loudly and alert us of the mistake,
instead of forcing hours of bisecting to find the subtle way in which the JIT
has managed to sneak a flag-modifying instruction where there shouldn't be one.
