### PR TITLE
Remove useless STACKALIGN macro.

### DIFF
--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -56,8 +56,6 @@ extern const char *netplay_dolphin_ver;
 	#endif
 #endif
 
-#define STACKALIGN
-
 // An inheritable class to disallow the copy constructor and operator= functions
 class NonCopyable
 {
@@ -70,15 +68,7 @@ private:
 	NonCopyable& operator=(NonCopyable& other);
 };
 
-#ifdef __APPLE__
-// The Darwin ABI requires that stack frames be aligned to 16-byte boundaries.
-// This is only needed on i386 gcc - x86_64 already aligns to 16 bytes.
-#if defined __i386__ && defined __GNUC__
-#undef STACKALIGN
-#define STACKALIGN __attribute__((__force_align_arg_pointer__))
-#endif
-
-#elif defined _WIN32
+#if defined _WIN32
 
 // Memory leak checks
 	#define CHECK_HEAP_INTEGRITY()

--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -55,7 +55,7 @@ void ResetGatherPipe()
 	m_gatherPipeCount = 0;
 }
 
-void STACKALIGN CheckGatherPipe()
+void CheckGatherPipe()
 {
 	if (m_gatherPipeCount >= GATHER_PIPE_SIZE)
 	{

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -463,7 +463,7 @@ void Jit64::WriteExternalExceptionExit()
 	JMP(asm_routines.dispatcher, true);
 }
 
-void STACKALIGN Jit64::Run()
+void Jit64::Run()
 {
 	CompiledCode pExecAddr = (CompiledCode)asm_routines.enterCode;
 	pExecAddr();
@@ -498,7 +498,7 @@ void Jit64::Trace()
 		PC, SRR0, SRR1, PowerPC::ppcState.fpscr, PowerPC::ppcState.msr, PowerPC::ppcState.spr[8], regs.c_str(), fregs.c_str());
 }
 
-void STACKALIGN Jit64::Jit(u32 em_address)
+void Jit64::Jit(u32 em_address)
 {
 	if (GetSpaceLeft() < 0x10000 ||
 	    farcode.GetSpaceLeft() < 0x10000 ||

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -463,7 +463,7 @@ void JitIL::WriteExceptionExit()
 	JMP(asm_routines.dispatcher, true);
 }
 
-void STACKALIGN JitIL::Run()
+void JitIL::Run()
 {
 	CompiledCode pExecAddr = (CompiledCode)asm_routines.enterCode;
 	pExecAddr();
@@ -502,7 +502,7 @@ void JitIL::Trace()
 		PowerPC::ppcState.spr[8], regs.c_str(), fregs.c_str());
 }
 
-void STACKALIGN JitIL::Jit(u32 em_address)
+void JitIL::Jit(u32 em_address)
 {
 	if (GetSpaceLeft() < 0x10000 || farcode.GetSpaceLeft() < 0x10000 || blocks.IsFull() ||
 		SConfig::GetInstance().m_LocalCoreStartupParameter.bJITNoBlockCache)

--- a/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
@@ -220,7 +220,7 @@ void JitArm::WriteExit(u32 destination)
 	b->linkData.push_back(linkData);
 }
 
-void STACKALIGN JitArm::Run()
+void JitArm::Run()
 {
 	CompiledCode pExecAddr = (CompiledCode)asm_routines.enterCode;
 	pExecAddr();
@@ -282,7 +282,7 @@ void JitArm::PrintDebug(UGeckoInstruction inst, u32 level)
 	}
 }
 
-void STACKALIGN JitArm::Jit(u32 em_address)
+void JitArm::Jit(u32 em_address)
 {
 	if (GetSpaceLeft() < 0x10000 || blocks.IsFull() || SConfig::GetInstance().m_LocalCoreStartupParameter.bJITNoBlockCache)
 	{

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -151,7 +151,7 @@ void JitArm64::WriteExitDestInR(ARM64Reg Reg)
 	BR(EncodeRegTo64(Reg));
 }
 
-void STACKALIGN JitArm64::Run()
+void JitArm64::Run()
 {
 	CompiledCode pExecAddr = (CompiledCode)asm_routines.enterCode;
 	pExecAddr();
@@ -163,7 +163,7 @@ void JitArm64::SingleStep()
 	pExecAddr();
 }
 
-void STACKALIGN JitArm64::Jit(u32 em_address)
+void JitArm64::Jit(u32 em_address)
 {
 	if (GetSpaceLeft() < 0x10000 || blocks.IsFull() || SConfig::GetInstance().m_LocalCoreStartupParameter.bJITNoBlockCache)
 	{

--- a/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
+++ b/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
@@ -174,7 +174,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 	);
 }
 
-void STACKALIGN GatherPipeBursted()
+void GatherPipeBursted()
 {
 	if (cpreg.ctrl.GPLinkEnable)
 	{

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -302,7 +302,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 	);
 }
 
-void STACKALIGN GatherPipeBursted()
+void GatherPipeBursted()
 {
 	ProcessFifoEvents();
 	// if we aren't linked, we don't care about gather pipe data


### PR DESCRIPTION
It only ever did anything on 32-bit OS X.

Anyway, it wasn't even on the right functions, and these days
ABI_PushRegistersAndAdjustStack should handle maintaining the ABI
correctly.
