### PR TITLE
Fix focus detection on OS X by replacing wxGetActiveWindow with wxWindow...

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -708,7 +708,7 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
 			wxString caption = event.GetString().BeforeFirst(':');
 			wxString text = event.GetString().AfterFirst(':');
 			bPanicResult = (wxYES == wxMessageBox(text,
-						caption, event.GetInt() ? wxYES_NO : wxOK, wxGetActiveWindow()));
+						caption, event.GetInt() ? wxYES_NO : wxOK, wxWindow::FindFocus()));
 			panic_event.Set();
 		}
 		break;
@@ -805,11 +805,11 @@ bool CFrame::UIHasFocus()
 	// UIHasFocus should return true any time any one of our UI
 	// windows has the focus, including any dialogs or other windows.
 	//
-	// wxGetActiveWindow() returns the current wxWindow which has
+	// wxWindow::FindFocus() returns the current wxWindow which has
 	// focus. If it's not one of our windows, then it will return
 	// null.
 
-	wxWindow *focusWindow = wxGetActiveWindow();
+	wxWindow *focusWindow = wxWindow::FindFocus();
 	return (focusWindow != nullptr);
 }
 

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -484,7 +484,7 @@ bool wxMsgAlert(const char* caption, const char* text, bool yes_no, int /*Style*
 	if (wxIsMainThread())
 #endif
 		return wxYES == wxMessageBox(StrToWxStr(text), StrToWxStr(caption),
-				(yes_no) ? wxYES_NO : wxOK, wxGetActiveWindow());
+				(yes_no) ? wxYES_NO : wxOK, wxWindow::FindFocus());
 #ifdef __WXGTK__
 	else
 	{

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -97,7 +97,7 @@ protected:
 			if (new_backend->GetName() == "Software Renderer")
 			{
 				do_switch = (wxYES == wxMessageBox(_("Software rendering is an order of magnitude slower than using the other backends.\nIt's only useful for debugging purposes.\nDo you really want to enable software rendering? If unsure, select 'No'."),
-							_("Warning"), wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION, wxGetActiveWindow()));
+							_("Warning"), wxYES_NO | wxNO_DEFAULT | wxICON_EXCLAMATION, wxWindow::FindFocus()));
 			}
 
 			if (do_switch)


### PR DESCRIPTION
...::FindFocus.

wxGetActiveWindow is implemented as "return NULL" on OS X, while
wxWindow::FindFocus works.  On Windows, the difference is in the use of
GetActiveWindow() vs. GetForegroundWindow().  A MSDN comment says:

> A system has only one active window, which GetForegroundWindow()
> returns. GetActiveWindow() seems to return the same window as
> GetForegroundWindow() if the foreground window belongs to the current
> thread. Otherwise, it always returns null, rather than the topmost
> window of the calling thread.

Since we are on the GUI thread, it shouldn't make any difference.
