### PR TITLE
Fixed the step_size_bytes in the ADPCM Accelerator loop

### DIFF
--- a/Source/Core/Core/DSP/DSPAccelerator.cpp
+++ b/Source/Core/Core/DSP/DSPAccelerator.cpp
@@ -15,7 +15,7 @@ static s16 ADPCM_Step(u32& _rSamplePos)
 {
 	const s16 *pCoefTable = (const s16 *)&g_dsp.ifx_regs[DSP_COEF_A1_0];
 
-	if (((_rSamplePos)& 15) == 0)
+	if ((_rSamplePos & 15) == 0)
 	{
 		g_dsp.ifx_regs[DSP_PRED_SCALE] = DSPHost::ReadHostMemory((_rSamplePos & ~15) >> 1);
 		_rSamplePos += 2;
@@ -122,10 +122,10 @@ u16 dsp_read_accelerator()
 	switch (g_dsp.ifx_regs[DSP_FORMAT])
 	{
 		case 0x00:  // ADPCM audio
-			if ((Address & 15) == 0)
-				step_size_bytes = 2;
-			else
+			if ((EndAddress & 15) == 0)
 				step_size_bytes = 1;
+			else
+				step_size_bytes = 2;
 			val = ADPCM_Step(Address);
 			break;
 		case 0x0A:  // 16-bit PCM audio
@@ -139,12 +139,12 @@ u16 dsp_read_accelerator()
 			val = DSPHost::ReadHostMemory(Address) << 8;
 			g_dsp.ifx_regs[DSP_YN2] = g_dsp.ifx_regs[DSP_YN1];
 			g_dsp.ifx_regs[DSP_YN1] = val;
-			step_size_bytes = 1;
+			step_size_bytes = 2;
 			Address++;
 			break;
 		default:
 			ERROR_LOG(DSPLLE, "dsp_read_accelerator() - unknown format 0x%x", g_dsp.ifx_regs[DSP_FORMAT]);
-			step_size_bytes = 1;
+			step_size_bytes = 2;
 			Address++;
 			val = 0;
 			break;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -163,13 +163,14 @@ u16 AcceleratorGetSample()
 			if ((*acc_cur_addr & 15) == 0)
 			{
 				acc_pb->adpcm.pred_scale = DSP::ReadARAM((*acc_cur_addr & ~15) >> 1);
-				step_size_bytes = 2;
 				*acc_cur_addr += 2;
 			}
-			else
-			{
+
+			if ((acc_end_addr & 15) == 0)
 				step_size_bytes = 1;
-			}
+			else
+				step_size_bytes = 2;
+
 			int scale = 1 << (acc_pb->adpcm.pred_scale & 0xF);
 			int coef_idx = (acc_pb->adpcm.pred_scale >> 4) & 0x7;
 
@@ -205,7 +206,7 @@ u16 AcceleratorGetSample()
 			ret = DSP::ReadARAM(*acc_cur_addr) << 8;
 			acc_pb->adpcm.yn2 = acc_pb->adpcm.yn1;
 			acc_pb->adpcm.yn1 = ret;
-			step_size_bytes = 1;
+			step_size_bytes = 2;
 			*acc_cur_addr += 1;
 			break;
 


### PR DESCRIPTION
Fixed the step_size_bytes in the ADPCM Accelerator loop taking into account the varying number of bytes that ADPCM steps by.
