### PR TITLE
Change a bunch of reference function arguments to pointers.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -168,15 +168,15 @@ KeyboardMouse::KeyboardMouse(Window window, int opcode, int pointer, int keyboar
 
 	// Mouse Buttons
 	for (int i = 0; i < 5; i++)
-		AddInput(new Button(i, m_state.buttons));
+		AddInput(new Button(i, &m_state.buttons));
 
 	// Mouse Cursor, X-/+ and Y-/+
 	for (int i = 0; i != 4; ++i)
-		AddInput(new Cursor(!!(i & 2), !!(i & 1), (&m_state.cursor.x)[!!(i & 2)]));
+		AddInput(new Cursor(!!(i & 2), !!(i & 1), (i & 2) ? &m_state.cursor.y : &m_state.cursor.x));
 
 	// Mouse Axis, X-/+ and Y-/+
 	for (int i = 0; i != 4; ++i)
-		AddInput(new Axis(!!(i & 2), !!(i & 1), (&m_state.axis.x)[!!(i & 2)]));
+		AddInput(new Axis(!!(i & 2), !!(i & 1), (i & 2) ? &m_state.axis.y : &m_state.axis.x));
 }
 
 KeyboardMouse::~KeyboardMouse()
@@ -338,7 +338,7 @@ ControlState KeyboardMouse::Key::GetState() const
 	return (m_keyboard[m_keycode / 8] & (1 << (m_keycode % 8))) != 0;
 }
 
-KeyboardMouse::Button::Button(unsigned int index, unsigned int& buttons)
+KeyboardMouse::Button::Button(unsigned int index, unsigned int* buttons)
 	: m_buttons(buttons), m_index(index)
 {
 	// this will be a problem if we remove the hardcoded five-button limit
@@ -347,10 +347,10 @@ KeyboardMouse::Button::Button(unsigned int index, unsigned int& buttons)
 
 ControlState KeyboardMouse::Button::GetState() const
 {
-	return ((m_buttons & (1 << m_index)) != 0);
+	return ((*m_buttons & (1 << m_index)) != 0);
 }
 
-KeyboardMouse::Cursor::Cursor(u8 index, bool positive, const float& cursor)
+KeyboardMouse::Cursor::Cursor(u8 index, bool positive, const float* cursor)
 	: m_cursor(cursor), m_index(index), m_positive(positive)
 {
 	name = std::string("Cursor ") + (char)('X' + m_index) + (m_positive ? '+' : '-');
@@ -358,10 +358,10 @@ KeyboardMouse::Cursor::Cursor(u8 index, bool positive, const float& cursor)
 
 ControlState KeyboardMouse::Cursor::GetState() const
 {
-	return std::max(0.0f, m_cursor / (m_positive ? 1.0f : -1.0f));
+	return std::max(0.0f, *m_cursor / (m_positive ? 1.0f : -1.0f));
 }
 
-KeyboardMouse::Axis::Axis(u8 index, bool positive, const float& axis)
+KeyboardMouse::Axis::Axis(u8 index, bool positive, const float* axis)
 	: m_axis(axis), m_index(index), m_positive(positive)
 {
 	name = std::string("Axis ") + (char)('X' + m_index) + (m_positive ? '+' : '-');
@@ -369,7 +369,7 @@ KeyboardMouse::Axis::Axis(u8 index, bool positive, const float& axis)
 
 ControlState KeyboardMouse::Axis::GetState() const
 {
-	return std::max(0.0f, m_axis / (m_positive ? MOUSE_AXIS_SENSITIVITY : -MOUSE_AXIS_SENSITIVITY));
+	return std::max(0.0f, *m_axis / (m_positive ? MOUSE_AXIS_SENSITIVITY : -MOUSE_AXIS_SENSITIVITY));
 }
 
 }

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -54,11 +54,11 @@ private:
 	{
 	public:
 		std::string GetName() const override { return name; }
-		Button(unsigned int index, unsigned int& buttons);
+		Button(unsigned int index, unsigned int* buttons);
 		ControlState GetState() const override;
 
 	private:
-		const unsigned int& m_buttons;
+		const unsigned int* m_buttons;
 		const unsigned int m_index;
 		std::string name;
 	};
@@ -68,11 +68,11 @@ private:
 	public:
 		std::string GetName() const override { return name; }
 		bool IsDetectable() override { return false; }
-		Cursor(u8 index, bool positive, const float& cursor);
+		Cursor(u8 index, bool positive, const float* cursor);
 		ControlState GetState() const override;
 
 	private:
-		const float& m_cursor;
+		const float* m_cursor;
 		const u8     m_index;
 		const bool   m_positive;
 		std::string  name;
@@ -83,11 +83,11 @@ private:
 	public:
 		std::string GetName() const override { return name; }
 		bool IsDetectable() override { return false; }
-		Axis(u8 index, bool positive, const float& axis);
+		Axis(u8 index, bool positive, const float* axis);
 		ControlState GetState() const override;
 
 	private:
-		const float& m_axis;
+		const float* m_axis;
 		const u8     m_index;
 		const bool   m_positive;
 		std::string  name;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -721,7 +721,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 	}
 
 	u32 xfbCount = 0;
-	const XFBSourceBase* const* xfbSourceList = FramebufferManager::GetXFBSource(xfbAddr, fbWidth, fbHeight, xfbCount);
+	const XFBSourceBase* const* xfbSourceList = FramebufferManager::GetXFBSource(xfbAddr, fbWidth, fbHeight, &xfbCount);
 	if ((!xfbSourceList || xfbCount == 0) && g_ActiveConfig.bUseXFB && !g_ActiveConfig.bUseRealXFB)
 	{
 		if (g_ActiveConfig.bDumpFrames && !frame_data.empty())

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1370,7 +1370,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 	}
 
 	u32 xfbCount = 0;
-	const XFBSourceBase* const* xfbSourceList = FramebufferManager::GetXFBSource(xfbAddr, fbStride, fbHeight, xfbCount);
+	const XFBSourceBase* const* xfbSourceList = FramebufferManager::GetXFBSource(xfbAddr, fbStride, fbHeight, &xfbCount);
 	if (g_ActiveConfig.VirtualXFBEnabled() && (!xfbSourceList || xfbCount == 0))
 	{
 		DumpFrame(frame_data, w, h);

--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -113,10 +113,9 @@ namespace Clipper
 		return cmask;
 	}
 
-	static inline void AddInterpolatedVertex(float t, int out, int in, int& numVertices)
+	static inline void AddInterpolatedVertex(float t, int out, int in, int* numVertices)
 	{
-		Vertices[numVertices]->Lerp(t, Vertices[out], Vertices[in]);
-		numVertices++;
+		Vertices[(*numVertices)++]->Lerp(t, Vertices[out], Vertices[in]);
 	}
 
 	#define DIFFERENT_SIGNS(x,y) ((x <= 0 && y > 0) || (x > 0 && y <= 0))
@@ -142,10 +141,10 @@ namespace Clipper
 				if (DIFFERENT_SIGNS(dp, dpPrev)) {						\
 					if (dp < 0) {										\
 						float t = dp / (dp - dpPrev);					\
-						AddInterpolatedVertex(t, idx, idxPrev, numVertices);		\
+						AddInterpolatedVertex(t, idx, idxPrev, &numVertices);		\
 					} else {											\
 						float t = dpPrev / (dpPrev - dp);				\
-						AddInterpolatedVertex(t, idxPrev, idx, numVertices);		\
+						AddInterpolatedVertex(t, idxPrev, idx, &numVertices);		\
 					}													\
 					outlist[outcount++] = numVertices - 1;				\
 				}														\
@@ -187,7 +186,7 @@ namespace Clipper
 		}														\
 	}
 
-	static void ClipTriangle(int *indices, int &numIndices)
+	static void ClipTriangle(int *indices, int* numIndices)
 	{
 		int mask = 0;
 
@@ -229,9 +228,9 @@ namespace Clipper
 				indices[2] = inlist[2];
 				for (int j = 3; j < n; ++j)
 				{
-					indices[numIndices++] = inlist[0];
-					indices[numIndices++] = inlist[j - 1];
-					indices[numIndices++] = inlist[j];
+					indices[(*numIndices)++] = inlist[0];
+					indices[(*numIndices)++] = inlist[j - 1];
+					indices[(*numIndices)++] = inlist[j];
 				}
 			}
 		}
@@ -276,13 +275,13 @@ namespace Clipper
 		if (clip_mask[0])
 		{
 			indices[0] = numVertices;
-			AddInterpolatedVertex(t0, 0, 1, numVertices);
+			AddInterpolatedVertex(t0, 0, 1, &numVertices);
 		}
 
 		if (clip_mask[1])
 		{
 			indices[1] = numVertices;
-			AddInterpolatedVertex(t1, 1, 0, numVertices);
+			AddInterpolatedVertex(t1, 1, 0, &numVertices);
 		}
 	}
 
@@ -315,7 +314,7 @@ namespace Clipper
 			Vertices[2] = v2;
 		}
 
-		ClipTriangle(indices, numIndices);
+		ClipTriangle(indices, &numIndices);
 
 		for (int i = 0; i+3 <= numIndices; i+=3)
 		{

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -334,57 +334,57 @@ namespace EfbInterface
 		}
 	}
 
-	static void LogicBlend(u32 srcClr, u32 &dstClr, BlendMode::LogicOp op)
+	static void LogicBlend(u32 srcClr, u32* dstClr, BlendMode::LogicOp op)
 	{
 		switch (op)
 		{
 		case BlendMode::CLEAR:
-			dstClr = 0;
+			*dstClr = 0;
 			break;
 		case BlendMode::AND:
-			dstClr = srcClr & dstClr;
+			*dstClr = srcClr & *dstClr;
 			break;
 		case BlendMode::AND_REVERSE:
-			dstClr = srcClr & (~dstClr);
+			*dstClr = srcClr & (~*dstClr);
 			break;
 		case BlendMode::COPY:
-			dstClr = srcClr;
+			*dstClr = srcClr;
 			break;
 		case BlendMode::AND_INVERTED:
-			dstClr = (~srcClr) & dstClr;
+			*dstClr = (~srcClr) & *dstClr;
 			break;
 		case BlendMode::NOOP:
 			// Do nothing
 			break;
 		case BlendMode::XOR:
-			dstClr = srcClr ^ dstClr;
+			*dstClr = srcClr ^ *dstClr;
 			break;
 		case BlendMode::OR:
-			dstClr = srcClr | dstClr;
+			*dstClr = srcClr | *dstClr;
 			break;
 		case BlendMode::NOR:
-			dstClr = ~(srcClr | dstClr);
+			*dstClr = ~(srcClr | *dstClr);
 			break;
 		case BlendMode::EQUIV:
-			dstClr = ~(srcClr ^ dstClr);
+			*dstClr = ~(srcClr ^ *dstClr);
 			break;
 		case BlendMode::INVERT:
-			dstClr = ~dstClr;
+			*dstClr = ~*dstClr;
 			break;
 		case BlendMode::OR_REVERSE:
-			dstClr = srcClr | (~dstClr);
+			*dstClr = srcClr | (~*dstClr);
 			break;
 		case BlendMode::COPY_INVERTED:
-			dstClr = ~srcClr;
+			*dstClr = ~srcClr;
 			break;
 		case BlendMode::OR_INVERTED:
-			dstClr = (~srcClr) | dstClr;
+			*dstClr = (~srcClr) | *dstClr;
 			break;
 		case BlendMode::NAND:
-			dstClr = ~(srcClr & dstClr);
+			*dstClr = ~(srcClr & *dstClr);
 			break;
 		case BlendMode::SET:
-			dstClr = 0xffffffff;
+			*dstClr = 0xffffffff;
 			break;
 		}
 	}
@@ -416,7 +416,7 @@ namespace EfbInterface
 		}
 		else if (bpmem.blendmode.logicopenable)
 		{
-			LogicBlend(*((u32*)color), dstClr, bpmem.blendmode.logicmode);
+			LogicBlend(*((u32*)color), &dstClr, bpmem.blendmode.logicmode);
 		}
 		else
 		{

--- a/Source/Core/VideoBackends/Software/TextureEncoder.cpp
+++ b/Source/Core/VideoBackends/Software/TextureEncoder.cpp
@@ -13,21 +13,21 @@
 namespace TextureEncoder
 {
 
-static inline void RGBA_to_RGBA8(u8 *src, u8 &r, u8 &g, u8 &b, u8 &a)
+static inline void RGBA_to_RGBA8(const u8 *src, u8* r, u8* g, u8* b, u8* a)
 {
 	u32 srcColor = *(u32*)src;
-	a = Convert6To8(srcColor & 0x3f);
-	b = Convert6To8((srcColor >> 6) & 0x3f);
-	g = Convert6To8((srcColor >> 12)& 0x3f);
-	r = Convert6To8((srcColor >> 18)& 0x3f);
+	*a = Convert6To8(srcColor & 0x3f);
+	*b = Convert6To8((srcColor >> 6) & 0x3f);
+	*g = Convert6To8((srcColor >> 12)& 0x3f);
+	*r = Convert6To8((srcColor >> 18)& 0x3f);
 }
 
-static inline void RGBA_to_RGB8(u8 *src, u8 &r, u8 &g, u8 &b)
+static inline void RGBA_to_RGB8(const u8 *src, u8* r, u8* g, u8* b)
 {
 	u32 srcColor = *(u32*)src;
-	b = Convert6To8((srcColor >> 6) & 0x3f);
-	g = Convert6To8((srcColor >> 12)& 0x3f);
-	r = Convert6To8((srcColor >> 18)& 0x3f);
+	*b = Convert6To8((srcColor >> 6) & 0x3f);
+	*g = Convert6To8((srcColor >> 12)& 0x3f);
+	*r = Convert6To8((srcColor >> 18)& 0x3f);
 }
 
 static inline u8 RGB8_to_I(u8 r, u8 g, u8 b)
@@ -40,7 +40,7 @@ static inline u8 RGB8_to_I(u8 r, u8 g, u8 b)
 // box filter sampling averages 4 samples with the source texel being the top left of the box
 // components are scaled to the range 0-255 after all samples are taken
 
-static inline void BoxfilterRGBA_to_RGBA8(u8 *src, u8 &r, u8 &g, u8 &b, u8 &a)
+static inline void BoxfilterRGBA_to_RGBA8(const u8* src, u8* r, u8* g, u8* b, u8* a)
 {
 	u16 r16 = 0, g16 = 0, b16 = 0, a16 = 0;
 
@@ -60,13 +60,13 @@ static inline void BoxfilterRGBA_to_RGBA8(u8 *src, u8 &r, u8 &g, u8 &b, u8 &a)
 		src += (640 - 2) * 3; // move to next line
 	}
 
-	r = r16 + (r16 >> 6);
-	g = g16 + (g16 >> 6);
-	b = b16 + (b16 >> 6);
-	a = a16 + (a16 >> 6);
+	*r = r16 + (r16 >> 6);
+	*g = g16 + (g16 >> 6);
+	*b = b16 + (b16 >> 6);
+	*a = a16 + (a16 >> 6);
 }
 
-static inline void BoxfilterRGBA_to_RGB8(u8 *src, u8 &r, u8 &g, u8 &b)
+static inline void BoxfilterRGBA_to_RGB8(const u8* src, u8* r, u8* g, u8* b)
 {
 	u16 r16 = 0, g16 = 0, b16 = 0;
 
@@ -85,12 +85,12 @@ static inline void BoxfilterRGBA_to_RGB8(u8 *src, u8 &r, u8 &g, u8 &b)
 		src += (640 - 2) * 3; // move to next line
 	}
 
-	r = r16 + (r16 >> 6);
-	g = g16 + (g16 >> 6);
-	b = b16 + (b16 >> 6);
+	*r = r16 + (r16 >> 6);
+	*g = g16 + (g16 >> 6);
+	*b = b16 + (b16 >> 6);
 }
 
-static inline void BoxfilterRGBA_to_x8(u8 *src, u8 &x8, int shift)
+static inline void BoxfilterRGBA_to_x8(const u8* src, u8* x8, int shift)
 {
 	u16 x16 = 0;
 
@@ -107,10 +107,10 @@ static inline void BoxfilterRGBA_to_x8(u8 *src, u8 &x8, int shift)
 		src += (640 - 2) * 3; // move to next line
 	}
 
-	x8 = x16 + (x16 >> 6);
+	*x8 = x16 + (x16 >> 6);
 }
 
-static inline void BoxfilterRGBA_to_xx8(u8 *src, u8 &x1, u8 &x2, int shift1, int shift2)
+static inline void BoxfilterRGBA_to_xx8(const u8* src, u8* x1, u8* x2, int shift1, int shift2)
 {
 	u16 x16_1 = 0;
 	u16 x16_2 = 0;
@@ -129,11 +129,11 @@ static inline void BoxfilterRGBA_to_xx8(u8 *src, u8 &x1, u8 &x2, int shift1, int
 		src += (640 - 2) * 3; // move to next line
 	}
 
-	x1 = x16_1 + (x16_1 >> 6);
-	x2 = x16_2 + (x16_2 >> 6);
+	*x1 = x16_1 + (x16_1 >> 6);
+	*x2 = x16_2 + (x16_2 >> 6);
 }
 
-static inline void BoxfilterRGB_to_RGB8(u8 *src, u8 &r, u8 &g, u8 &b)
+static inline void BoxfilterRGB_to_RGB8(const u8* src, u8* r, u8* g, u8* b)
 {
 	u16 r16 = 0, g16 = 0, b16 = 0;
 
@@ -150,12 +150,12 @@ static inline void BoxfilterRGB_to_RGB8(u8 *src, u8 &r, u8 &g, u8 &b)
 		src += (640 - 2) * 3; // move to next line
 	}
 
-	r = r16 >> 2;
-	g = g16 >> 2;
-	b = b16 >> 2;
+	*r = r16 >> 2;
+	*g = g16 >> 2;
+	*b = b16 >> 2;
 }
 
-static inline void BoxfilterRGB_to_x8(u8 *src, u8 &x8, int comp)
+static inline void BoxfilterRGB_to_x8(u8 *src, u8* x8, int comp)
 {
 	u16 x16 = 0;
 
@@ -171,10 +171,10 @@ static inline void BoxfilterRGB_to_x8(u8 *src, u8 &x8, int comp)
 		src += (640 - 2) * 3; // move to next line
 	}
 
-	x8 = x16 >> 2;
+	*x8 = x16 >> 2;
 }
 
-static inline void BoxfilterRGB_to_xx8(u8 *src, u8 &x1, u8 &x2, int comp1, int comp2)
+static inline void BoxfilterRGB_to_xx8(const u8* src, u8* x1, u8* x2, int comp1, int comp2)
 {
 	u16 x16_1 = 0;
 	u16 x16_2 = 0;
@@ -192,24 +192,24 @@ static inline void BoxfilterRGB_to_xx8(u8 *src, u8 &x1, u8 &x2, int comp1, int c
 		src += (640 - 2) * 3; // move to next line
 	}
 
-	x1 = x16_1 >> 2;
-	x2 = x16_2 >> 2;
+	*x1 = x16_1 >> 2;
+	*x2 = x16_2 >> 2;
 }
 
-static void SetBlockDimensions(int blkWidthLog2, int blkHeightLog2, u16 &sBlkCount, u16 &tBlkCount, u16 &sBlkSize, u16 &tBlkSize)
+static void SetBlockDimensions(int blkWidthLog2, int blkHeightLog2, u16* sBlkCount, u16* tBlkCount, u16* sBlkSize, u16* tBlkSize)
 {
 	// if half_scale is 1 then the size is cut in half
 	u32 width = bpmem.copyTexSrcWH.x >> bpmem.triggerEFBCopy.half_scale;
 	u32 height = bpmem.copyTexSrcWH.y >> bpmem.triggerEFBCopy.half_scale;
 
-	sBlkCount = (width >> blkWidthLog2) + 1;
-	tBlkCount = (height >> blkHeightLog2) + 1;
+	*sBlkCount = (width >> blkWidthLog2) + 1;
+	*tBlkCount = (height >> blkHeightLog2) + 1;
 
-	sBlkSize = 1 << blkWidthLog2;
-	tBlkSize = 1 << blkHeightLog2;
+	*sBlkSize = 1 << blkWidthLog2;
+	*tBlkSize = 1 << blkHeightLog2;
 }
 
-static void SetSpans(int sBlkSize, int tBlkSize, s32 &tSpan, s32 &sBlkSpan, s32 &tBlkSpan, s32 &writeStride)
+static void SetSpans(int sBlkSize, int tBlkSize, s32* tSpan, s32* sBlkSpan, s32* tBlkSpan, s32* writeStride)
 {
 	// width is 1 less than the number of pixels of width
 	u32 width = bpmem.copyTexSrcWH.x >> bpmem.triggerEFBCopy.half_scale;
@@ -217,11 +217,11 @@ static void SetSpans(int sBlkSize, int tBlkSize, s32 &tSpan, s32 &sBlkSpan, s32 
 
 	u32 readStride = 3 << bpmem.triggerEFBCopy.half_scale;
 
-	tSpan = (640 - sBlkSize) * readStride; // bytes to advance src pointer after each row of texels in a block
-	sBlkSpan = ((-640 * tBlkSize) + sBlkSize) * readStride; // bytes to advance src pointer after each block
-	tBlkSpan = ((640 * tBlkSize) - alignedWidth) * readStride; // bytes to advance src pointer after each row of blocks
+	*tSpan = (640 - sBlkSize) * readStride; // bytes to advance src pointer after each row of texels in a block
+	*sBlkSpan = ((-640 * tBlkSize) + sBlkSize) * readStride; // bytes to advance src pointer after each block
+	*tBlkSpan = ((640 * tBlkSize) - alignedWidth) * readStride; // bytes to advance src pointer after each row of blocks
 
-	writeStride = bpmem.copyMipMapStrideChannels * 32;
+	*writeStride = bpmem.copyMipMapStrideChannels * 32;
 }
 
 #define ENCODE_LOOP_BLOCKS									\
@@ -264,16 +264,16 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 	switch (format)
 	{
 	case GX_TF_I4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
-			RGBA_to_RGB8(src, r, g, b);
+			RGBA_to_RGB8(src, &r, &g, &b);
 			src += readStride;
 			*dst = RGB8_to_I(r, g, b) & 0xf0;
 
-			RGBA_to_RGB8(src, r, g, b);
+			RGBA_to_RGB8(src, &r, &g, &b);
 			src += readStride;
 			*dst |= RGB8_to_I(r, g, b) >> 4;
 			dst++;
@@ -282,11 +282,11 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_I8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			RGBA_to_RGB8(src, r, g, b);
+			RGBA_to_RGB8(src, &r, &g, &b);
 			src += readStride;
 			*dst++ = RGB8_to_I(r, g, b);
 		}
@@ -294,11 +294,11 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_IA4:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			RGBA_to_RGBA8(src, r, g, b, a);
+			RGBA_to_RGBA8(src, &r, &g, &b, &a);
 			src += readStride;
 			*dst++ = (a & 0xf0) | (RGB8_to_I(r, g, b) >> 4);
 		}
@@ -306,11 +306,11 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_IA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			RGBA_to_RGBA8(src, r, g, b, a);
+			RGBA_to_RGBA8(src, &r, &g, &b, &a);
 			src += readStride;
 			*dst++ = a;
 			*dst++ = RGB8_to_I(r, g, b);
@@ -319,8 +319,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGB565:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -334,8 +334,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGB5A3:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -355,11 +355,11 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGBA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			RGBA_to_RGBA8(src, dst[1], dst[32], dst[33], dst[0]);
+			RGBA_to_RGBA8(src, &dst[1], &dst[32], &dst[33], &dst[0]);
 			src += readStride;
 			dst += 2;
 		}
@@ -367,8 +367,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_R4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
@@ -385,8 +385,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RA4:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -397,8 +397,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -410,8 +410,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_A8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -422,8 +422,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_R8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -434,8 +434,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_G8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -446,8 +446,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_B8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -458,8 +458,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RG8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -471,8 +471,8 @@ static void EncodeRGBA6(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_GB8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u32 srcColor = *(u32*)src;
@@ -501,16 +501,16 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 	switch (format)
 	{
 	case GX_TF_I4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_RGB8(src, r, g, b);
+			BoxfilterRGBA_to_RGB8(src, &r, &g, &b);
 			src += readStride;
 			*dst = RGB8_to_I(r, g, b) & 0xf0;
 
-			BoxfilterRGBA_to_RGB8(src, r, g, b);
+			BoxfilterRGBA_to_RGB8(src, &r, &g, &b);
 			src += readStride;
 			*dst |= RGB8_to_I(r, g, b) >> 4;
 			dst++;
@@ -519,11 +519,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_I8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_RGB8(src, r, g, b);
+			BoxfilterRGBA_to_RGB8(src, &r, &g, &b);
 			src += readStride;
 			*dst++ = RGB8_to_I(r, g, b);
 		}
@@ -531,11 +531,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_IA4:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_RGBA8(src, r, g, b, a);
+			BoxfilterRGBA_to_RGBA8(src, &r, &g, &b, &a);
 			src += readStride;
 			*dst++ = (a & 0xf0) | (RGB8_to_I(r, g, b) >> 4);
 		}
@@ -543,11 +543,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_IA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_RGBA8(src, r, g, b, a);
+			BoxfilterRGBA_to_RGBA8(src, &r, &g, &b, &a);
 			src += readStride;
 			*dst++ = a;
 			*dst++ = RGB8_to_I(r, g, b);
@@ -556,11 +556,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGB565:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_RGB8(src, r, g, b);
+			BoxfilterRGBA_to_RGB8(src, &r, &g, &b);
 			src += readStride;
 
 			u16 val = ((r << 8) & 0xf800) | ((g << 3) & 0x07e0) | ((b >> 3) & 0x001e);
@@ -571,11 +571,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGB5A3:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_RGBA8(src, r, g, b, a);
+			BoxfilterRGBA_to_RGBA8(src, &r, &g, &b, &a);
 			src += readStride;
 
 			u16 val;
@@ -591,11 +591,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGBA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_RGBA8(src, dst[1], dst[32], dst[33], dst[0]);
+			BoxfilterRGBA_to_RGBA8(src, &dst[1], &dst[32], &dst[33], &dst[0]);
 			src += readStride;
 			dst += 2;
 		}
@@ -603,16 +603,16 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_R4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_x8(src, r, 18);
+			BoxfilterRGBA_to_x8(src, &r, 18);
 			src += readStride;
 			*dst = r & 0xf0;
 
-			BoxfilterRGBA_to_x8(src, r, 18);
+			BoxfilterRGBA_to_x8(src, &r, 18);
 			src += readStride;
 			*dst |= r >> 4;
 			dst++;
@@ -621,11 +621,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RA4:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_xx8(src, r, a, 18, 0);
+			BoxfilterRGBA_to_xx8(src, &r, &a, 18, 0);
 			src += readStride;
 			*dst++ = (a & 0xf0) | (r >> 4);
 		}
@@ -633,11 +633,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_xx8(src, r, a, 18, 0);
+			BoxfilterRGBA_to_xx8(src, &r, &a, 18, 0);
 			src += readStride;
 			*dst++ = a;
 			*dst++ = r;
@@ -646,11 +646,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_A8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_x8(src, a, 0);
+			BoxfilterRGBA_to_x8(src, &a, 0);
 			*dst++ = a;
 			src += readStride;
 		}
@@ -658,11 +658,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_R8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_x8(src, r, 18);
+			BoxfilterRGBA_to_x8(src, &r, 18);
 			*dst++ = r;
 			src += readStride;
 		}
@@ -670,11 +670,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_G8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_x8(src, g, 12);
+			BoxfilterRGBA_to_x8(src, &g, 12);
 			*dst++ = g;
 			src += readStride;
 		}
@@ -682,11 +682,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_B8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_x8(src, b, 6);
+			BoxfilterRGBA_to_x8(src, &b, 6);
 			*dst++ = b;
 			src += readStride;
 		}
@@ -694,11 +694,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RG8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_xx8(src, r, g, 18, 12);
+			BoxfilterRGBA_to_xx8(src, &r, &g, 18, 12);
 			src += readStride;
 			*dst++ = g;
 			*dst++ = r;
@@ -707,11 +707,11 @@ static void EncodeRGBA6halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_GB8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGBA_to_xx8(src, g, b, 12, 6);
+			BoxfilterRGBA_to_xx8(src, &g, &b, 12, 6);
 			src += readStride;
 			*dst++ = b;
 			*dst++ = g;
@@ -735,8 +735,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 	switch (format)
 	{
 	case GX_TF_I4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
@@ -751,8 +751,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_I8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = RGB8_to_I(src[2], src[1], src[0]);
@@ -762,8 +762,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_IA4:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = 0xf0 | (RGB8_to_I(src[2], src[1], src[0]) >> 4);
@@ -773,8 +773,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_IA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = 0xff;
@@ -786,8 +786,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGB565:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u16 val = ((src[2] << 8) & 0xf800) | ((src[1] << 3) & 0x07e0) | ((src[0] >> 3) & 0x001e);
@@ -799,8 +799,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGB5A3:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			u16 val = 0x8000 | ((src[2] << 7) & 0x7c00) | ((src[1] << 2) & 0x03e0) | ((src[0] >> 3) & 0x001e);
@@ -812,8 +812,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGBA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			dst[0] = 0xff;
@@ -827,8 +827,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_R4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
@@ -844,8 +844,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RA4:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = 0xf0 | (src[2] >> 4);
@@ -855,8 +855,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = 0xff;
@@ -867,8 +867,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_A8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = 0xff;
@@ -877,8 +877,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_R8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[2];
@@ -888,8 +888,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_G8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[1];
@@ -899,8 +899,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_B8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[0];
@@ -910,8 +910,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RG8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[1];
@@ -922,8 +922,8 @@ static void EncodeRGB8(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_GB8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[0];
@@ -950,16 +950,16 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 	switch (format)
 	{
 	case GX_TF_I4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_RGB8(src, r, g, b);
+			BoxfilterRGB_to_RGB8(src, &r, &g, &b);
 			*dst = RGB8_to_I(r, g, b) & 0xf0;
 			src += readStride;
 
-			BoxfilterRGB_to_RGB8(src, r, g, b);
+			BoxfilterRGB_to_RGB8(src, &r, &g, &b);
 			*dst |= RGB8_to_I(r, g, b) >> 4;
 			src += readStride;
 			dst++;
@@ -968,11 +968,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_I8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_RGB8(src, r, g, b);
+			BoxfilterRGB_to_RGB8(src, &r, &g, &b);
 			*dst++ = RGB8_to_I(r, g, b);
 			src += readStride;
 		}
@@ -980,11 +980,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_IA4:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_RGB8(src, r, g, b);
+			BoxfilterRGB_to_RGB8(src, &r, &g, &b);
 			*dst++ = 0xf0 | (RGB8_to_I(r, g, b) >> 4);
 			src += readStride;
 		}
@@ -992,11 +992,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_IA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_RGB8(src, r, g, b);
+			BoxfilterRGB_to_RGB8(src, &r, &g, &b);
 			*dst++ = 0xff;
 			*dst++ = RGB8_to_I(r, g, b);
 			src += readStride;
@@ -1005,11 +1005,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGB565:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_RGB8(src, r, g, b);
+			BoxfilterRGB_to_RGB8(src, &r, &g, &b);
 			u16 val = ((r << 8) & 0xf800) | ((g << 3) & 0x07e0) | ((b >> 3) & 0x001e);
 			*(u16*)dst = Common::swap16(val);
 			src += readStride;
@@ -1019,11 +1019,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGB5A3:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_RGB8(src, r, g, b);
+			BoxfilterRGB_to_RGB8(src, &r, &g, &b);
 			u16 val = 0x8000 | ((r << 7) & 0x7c00) | ((g << 2) & 0x03e0) | ((b >> 3) & 0x001e);
 			*(u16*)dst = Common::swap16(val);
 			src += readStride;
@@ -1033,11 +1033,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_RGBA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_RGB8(src, r, g, b);
+			BoxfilterRGB_to_RGB8(src, &r, &g, &b);
 			dst[0] = 0xff;
 			dst[1] = r;
 			dst[32] = g;
@@ -1049,16 +1049,16 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_R4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, r, 2);
+			BoxfilterRGB_to_x8(src, &r, 2);
 			*dst = r & 0xf0;
 			src += readStride;
 
-			BoxfilterRGB_to_x8(src, r, 2);
+			BoxfilterRGB_to_x8(src, &r, 2);
 			*dst |= r >> 4;
 			src += readStride;
 
@@ -1068,11 +1068,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RA4:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, r, 2);
+			BoxfilterRGB_to_x8(src, &r, 2);
 			*dst++ = 0xf0 | (r >> 4);
 			src += readStride;
 		}
@@ -1080,11 +1080,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RA8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, r, 2);
+			BoxfilterRGB_to_x8(src, &r, 2);
 			*dst++ = 0xff;
 			*dst++ = r;
 			src += readStride;
@@ -1093,8 +1093,8 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_A8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = 0xff;
@@ -1103,11 +1103,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_R8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, r, 2);
+			BoxfilterRGB_to_x8(src, &r, 2);
 			*dst++ = r;
 			src += readStride;
 		}
@@ -1115,11 +1115,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_G8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, g, 1);
+			BoxfilterRGB_to_x8(src, &g, 1);
 			*dst++ = g;
 			src += readStride;
 		}
@@ -1127,11 +1127,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_B8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, b, 0);
+			BoxfilterRGB_to_x8(src, &b, 0);
 			*dst++ = b;
 			src += readStride;
 		}
@@ -1139,11 +1139,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_RG8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_xx8(src, r, g, 2, 1);
+			BoxfilterRGB_to_xx8(src, &r, &g, 2, 1);
 			*dst++ = g;
 			*dst++ = r;
 			src += readStride;
@@ -1152,11 +1152,11 @@ static void EncodeRGB8halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_GB8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_xx8(src, g, b, 1, 0);
+			BoxfilterRGB_to_xx8(src, &g, &b, 1, 0);
 			*dst++ = b;
 			*dst++ = g;
 			src += readStride;
@@ -1180,8 +1180,8 @@ static void EncodeZ24(u8 *dst, u8 *src, u32 format)
 	switch (format)
 	{
 	case GX_TF_Z8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[2];
@@ -1191,8 +1191,8 @@ static void EncodeZ24(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_Z16:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[1];
@@ -1203,8 +1203,8 @@ static void EncodeZ24(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_Z24X8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			dst[0] = 0xff;
@@ -1218,8 +1218,8 @@ static void EncodeZ24(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_Z4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
@@ -1235,8 +1235,8 @@ static void EncodeZ24(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_Z8M:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[1];
@@ -1246,8 +1246,8 @@ static void EncodeZ24(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_Z8L:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[0];
@@ -1257,8 +1257,8 @@ static void EncodeZ24(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_Z16L:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
 			*dst++ = src[0];
@@ -1285,11 +1285,11 @@ static void EncodeZ24halfscale(u8 *dst, u8 *src, u32 format)
 	switch (format)
 	{
 	case GX_TF_Z8:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, b, 2);
+			BoxfilterRGB_to_x8(src, &b, 2);
 			*dst++ = b;
 			src += readStride;
 		}
@@ -1297,11 +1297,11 @@ static void EncodeZ24halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_Z16:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_xx8(src, g, b, 1, 2);
+			BoxfilterRGB_to_xx8(src, &g, &b, 1, 2);
 			*dst++ = b;
 			*dst++ = g;
 			src += readStride;
@@ -1310,11 +1310,11 @@ static void EncodeZ24halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_TF_Z24X8:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_RGB8(src, dst[33], dst[32], dst[1]);
+			BoxfilterRGB_to_RGB8(src, &dst[33], &dst[32], &dst[1]);
 			dst[0] = 255;
 			src += readStride;
 			dst += 2;
@@ -1323,16 +1323,16 @@ static void EncodeZ24halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_Z4:
-		SetBlockDimensions(3, 3, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 3, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		sBlkSize /= 2;
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, b, 2);
+			BoxfilterRGB_to_x8(src, &b, 2);
 			*dst = b & 0xf0;
 			src += readStride;
 
-			BoxfilterRGB_to_x8(src, b, 2);
+			BoxfilterRGB_to_x8(src, &b, 2);
 			*dst |= b >> 4;
 			src += readStride;
 
@@ -1342,11 +1342,11 @@ static void EncodeZ24halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_Z8M:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, g, 1);
+			BoxfilterRGB_to_x8(src, &g, 1);
 			*dst++ = g;
 			src += readStride;
 		}
@@ -1354,11 +1354,11 @@ static void EncodeZ24halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_Z8L:
-		SetBlockDimensions(3, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(3, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_x8(src, r, 0);
+			BoxfilterRGB_to_x8(src, &r, 0);
 			*dst++ = r;
 			src += readStride;
 		}
@@ -1366,11 +1366,11 @@ static void EncodeZ24halfscale(u8 *dst, u8 *src, u32 format)
 		break;
 
 	case GX_CTF_Z16L:
-		SetBlockDimensions(2, 2, sBlkCount, tBlkCount, sBlkSize, tBlkSize);
-		SetSpans(sBlkSize, tBlkSize, tSpan, sBlkSpan, tBlkSpan, writeStride);
+		SetBlockDimensions(2, 2, &sBlkCount, &tBlkCount, &sBlkSize, &tBlkSize);
+		SetSpans(sBlkSize, tBlkSize, &tSpan, &sBlkSpan, &tBlkSpan, &writeStride);
 		ENCODE_LOOP_BLOCKS
 		{
-			BoxfilterRGB_to_xx8(src, r, g, 0, 1);
+			BoxfilterRGB_to_xx8(src, &r, &g, 0, 1);
 			*dst++ = g;
 			*dst++ = r;
 			src += readStride;

--- a/Source/Core/VideoBackends/Software/TextureSampler.cpp
+++ b/Source/Core/VideoBackends/Software/TextureSampler.cpp
@@ -16,8 +16,9 @@
 namespace TextureSampler
 {
 
-static inline void WrapCoord(int &coord, int wrapMode, int imageSize)
+static inline void WrapCoord(int* coordp, int wrapMode, int imageSize)
 {
+	int coord = *coordp;
 	switch (wrapMode)
 	{
 		case 0: // clamp
@@ -37,6 +38,7 @@ static inline void WrapCoord(int &coord, int wrapMode, int imageSize)
 			}
 			break;
 	}
+	*coordp = coord;
 }
 
 static inline void SetTexel(u8 *inTexel, u32 *outTexel, u32 fract)
@@ -177,10 +179,10 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8 *sample)
 		u8 sampledTex[4];
 		u32 texel[4];
 
-		WrapCoord(imageS, tm0.wrap_s, imageWidth);
-		WrapCoord(imageT, tm0.wrap_t, imageHeight);
-		WrapCoord(imageSPlus1, tm0.wrap_s, imageWidth);
-		WrapCoord(imageTPlus1, tm0.wrap_t, imageHeight);
+		WrapCoord(&imageS, tm0.wrap_s, imageWidth);
+		WrapCoord(&imageT, tm0.wrap_t, imageHeight);
+		WrapCoord(&imageSPlus1, tm0.wrap_s, imageWidth);
+		WrapCoord(&imageTPlus1, tm0.wrap_t, imageHeight);
 
 		if (!(ti0.format == GX_TF_RGBA8 && texUnit.texImage1[subTexmap].image_type))
 		{
@@ -223,8 +225,8 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8 *sample)
 		int imageT = t >> 7;
 
 		// nearest neighbor sampling
-		WrapCoord(imageS, tm0.wrap_s, imageWidth);
-		WrapCoord(imageT, tm0.wrap_t, imageHeight);
+		WrapCoord(&imageS, tm0.wrap_s, imageWidth);
+		WrapCoord(&imageT, tm0.wrap_t, imageHeight);
 
 		if (!(ti0.format == GX_TF_RGBA8 && texUnit.texImage1[subTexmap].image_type))
 			TexDecoder_DecodeTexel(sample, imageSrc, imageS, imageT, imageWidth, ti0.format, tlut, tlutfmt);

--- a/Source/Core/VideoCommon/FramebufferManagerBase.cpp
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.cpp
@@ -31,20 +31,20 @@ FramebufferManagerBase::~FramebufferManagerBase()
 	delete m_realXFBSource;
 }
 
-const XFBSourceBase* const* FramebufferManagerBase::GetXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32 &xfbCount)
+const XFBSourceBase* const* FramebufferManagerBase::GetXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32* xfbCountP)
 {
 	if (!g_ActiveConfig.bUseXFB)
 		return nullptr;
 
 	if (g_ActiveConfig.bUseRealXFB)
-		return GetRealXFBSource(xfbAddr, fbWidth, fbHeight, xfbCount);
+		return GetRealXFBSource(xfbAddr, fbWidth, fbHeight, xfbCountP);
 	else
-		return GetVirtualXFBSource(xfbAddr, fbWidth, fbHeight, xfbCount);
+		return GetVirtualXFBSource(xfbAddr, fbWidth, fbHeight, xfbCountP);
 }
 
-const XFBSourceBase* const* FramebufferManagerBase::GetRealXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32 &xfbCount)
+const XFBSourceBase* const* FramebufferManagerBase::GetRealXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32* xfbCountP)
 {
-	xfbCount = 1;
+	*xfbCountP = 1;
 
 	// recreate if needed
 	if (m_realXFBSource && (m_realXFBSource->texWidth != fbWidth || m_realXFBSource->texHeight != fbHeight))
@@ -79,9 +79,9 @@ const XFBSourceBase* const* FramebufferManagerBase::GetRealXFBSource(u32 xfbAddr
 	return &m_overlappingXFBArray[0];
 }
 
-const XFBSourceBase* const* FramebufferManagerBase::GetVirtualXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32 &xfbCount)
+const XFBSourceBase* const* FramebufferManagerBase::GetVirtualXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32* xfbCountP)
 {
-	xfbCount = 0;
+	u32 xfbCount = 0;
 
 	if (m_virtualXFBList.empty())  // no Virtual XFBs available
 		return nullptr;
@@ -106,6 +106,7 @@ const XFBSourceBase* const* FramebufferManagerBase::GetVirtualXFBSource(u32 xfbA
 		}
 	}
 
+	*xfbCountP = xfbCount;
 	return &m_overlappingXFBArray[0];
 }
 

--- a/Source/Core/VideoCommon/FramebufferManagerBase.h
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.h
@@ -45,7 +45,7 @@ public:
 	virtual ~FramebufferManagerBase();
 
 	static void CopyToXFB(u32 xfbAddr, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc,float Gamma);
-	static const XFBSourceBase* const* GetXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32 &xfbCount);
+	static const XFBSourceBase* const* GetXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32* xfbCount);
 
 	static void SetLastXfbWidth(unsigned int width) { s_last_xfb_width = width; }
 	static void SetLastXfbHeight(unsigned int height) { s_last_xfb_height = height; }
@@ -83,8 +83,8 @@ private:
 	virtual void CopyToRealXFB(u32 xfbAddr, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc,float Gamma = 1.0f) = 0;
 	static void CopyToVirtualXFB(u32 xfbAddr, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc,float Gamma = 1.0f);
 
-	static const XFBSourceBase* const* GetRealXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32 &xfbCount);
-	static const XFBSourceBase* const* GetVirtualXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32 &xfbCount);
+	static const XFBSourceBase* const* GetRealXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32* xfbCount);
+	static const XFBSourceBase* const* GetVirtualXFBSource(u32 xfbAddr, u32 fbWidth, u32 fbHeight, u32* xfbCount);
 
 	static XFBSourceBase *m_realXFBSource; // Only used in Real XFB mode
 	static VirtualXFBListType m_virtualXFBList; // Only used in Virtual XFB mode

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -151,17 +151,17 @@ int Renderer::EFBToScaledY(int y)
 	};
 }
 
-void Renderer::CalculateTargetScale(int x, int y, int &scaledX, int &scaledY)
+void Renderer::CalculateTargetScale(int x, int y, int* scaledX, int* scaledY)
 {
 	if (g_ActiveConfig.iEFBScale == SCALE_AUTO || g_ActiveConfig.iEFBScale == SCALE_AUTO_INTEGRAL)
 	{
-		scaledX = x;
-		scaledY = y;
+		*scaledX = x;
+		*scaledY = y;
 	}
 	else
 	{
-		scaledX = x * (int)efb_scale_numeratorX / (int)efb_scale_denominatorX;
-		scaledY = y * (int)efb_scale_numeratorY / (int)efb_scale_denominatorY;
+		*scaledX = x * (int)efb_scale_numeratorX / (int)efb_scale_denominatorX;
+		*scaledY = y * (int)efb_scale_numeratorY / (int)efb_scale_denominatorY;
 	}
 }
 
@@ -228,7 +228,7 @@ bool Renderer::CalculateTargetSize(unsigned int framebuffer_width, unsigned int 
 			break;
 	}
 	if (s_LastEFBScale > SCALE_AUTO_INTEGRAL)
-		CalculateTargetScale(EFB_WIDTH, EFB_HEIGHT, newEFBWidth, newEFBHeight);
+		CalculateTargetScale(EFB_WIDTH, EFB_HEIGHT, &newEFBWidth, &newEFBHeight);
 
 	if (newEFBWidth != s_target_width || newEFBHeight != s_target_height)
 	{
@@ -477,7 +477,7 @@ void Renderer::SetWindowSize(int width, int height)
 		height = 1;
 
 	// Scale the window size by the EFB scale.
-	CalculateTargetScale(width, height, width, height);
+	CalculateTargetScale(width, height, &width, &height);
 
 	Host_RequestRenderWindowSize(width, height);
 }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -123,7 +123,7 @@ public:
 
 protected:
 
-	static void CalculateTargetScale(int x, int y, int &scaledX, int &scaledY);
+	static void CalculateTargetScale(int x, int y, int* scaledX, int* scaledY);
 	bool CalculateTargetSize(unsigned int framebuffer_width, unsigned int framebuffer_height);
 
 	static void CheckFifoRecording();

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -267,7 +267,7 @@ bool TextureCache::CheckForCustomTextureLODs(u64 tex_hash, int texformat, unsign
 	return true;
 }
 
-PC_TexFormat TextureCache::LoadCustomTexture(u64 tex_hash, int texformat, unsigned int level, unsigned int& width, unsigned int& height)
+PC_TexFormat TextureCache::LoadCustomTexture(u64 tex_hash, int texformat, unsigned int level, unsigned int* widthp, unsigned int* heightp)
 {
 	std::string texPathTemp;
 	unsigned int newWidth = 0;
@@ -293,6 +293,7 @@ PC_TexFormat TextureCache::LoadCustomTexture(u64 tex_hash, int texformat, unsign
 
 	if (ret != PC_TEX_FMT_NONE)
 	{
+		unsigned int width = *widthp, height = *heightp;
 		if (level > 0 && (newWidth != width || newHeight != height))
 			ERROR_LOG(VIDEO, "Invalid custom texture size %dx%d for texture %s. This mipmap layer _must_ be %dx%d.", newWidth, newHeight, texPathTemp.c_str(), width, height);
 		if (newWidth * height != newHeight * width)
@@ -300,8 +301,8 @@ PC_TexFormat TextureCache::LoadCustomTexture(u64 tex_hash, int texformat, unsign
 		if (newWidth % width || newHeight % height)
 			WARN_LOG(VIDEO, "Invalid custom texture size %dx%d for texture %s. Please use an integer upscaling factor based on the native size %dx%d.", newWidth, newHeight, texPathTemp.c_str(), width, height);
 
-		width = newWidth;
-		height = newHeight;
+		*widthp = newWidth;
+		*heightp = newHeight;
 	}
 	return ret;
 }
@@ -466,8 +467,7 @@ TextureCache::TCacheEntryBase* TextureCache::Load(unsigned int const stage,
 
 	if (g_ActiveConfig.bHiresTextures)
 	{
-		// This function may modify width/height.
-		pcfmt = LoadCustomTexture(tex_hash, texformat, 0, width, height);
+		pcfmt = LoadCustomTexture(tex_hash, texformat, 0, &width, &height);
 		if (pcfmt != PC_TEX_FMT_NONE)
 		{
 			if (expandedWidth != width || expandedHeight != height)
@@ -584,7 +584,7 @@ TextureCache::TCacheEntryBase* TextureCache::Load(unsigned int const stage,
 				unsigned int mip_width = CalculateLevelSize(width, level);
 				unsigned int mip_height = CalculateLevelSize(height, level);
 
-				LoadCustomTexture(tex_hash, texformat, level, mip_width, mip_height);
+				LoadCustomTexture(tex_hash, texformat, level, &mip_width, &mip_height);
 				entry->Load(mip_width, mip_height, mip_width, level);
 			}
 		}

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -116,7 +116,7 @@ protected:
 
 private:
 	static bool CheckForCustomTextureLODs(u64 tex_hash, int texformat, unsigned int levels);
-	static PC_TexFormat LoadCustomTexture(u64 tex_hash, int texformat, unsigned int level, unsigned int& width, unsigned int& height);
+	static PC_TexFormat LoadCustomTexture(u64 tex_hash, int texformat, unsigned int level, unsigned int* width, unsigned int* height);
 	static void DumpTexture(TCacheEntryBase* entry, unsigned int level);
 
 	static TCacheEntryBase* AllocateRenderTarget(unsigned int width, unsigned int height);


### PR DESCRIPTION
Per the coding style and sanity.

Edit: Diff now features the following amazing expression with a red background:

```
(&m_state.cursor.x)[!!(i & 2)]
```

(where `cursor` is `struct { float x, y; }`)
