### PR TITLE
Revert "If one argument is given, assume it is a game, and run it."

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -213,20 +213,14 @@ bool DolphinApp::OnInit()
 
 	// Gets the command line parameters
 	wxCmdLineParser parser(cmdLineDesc, argc, argv);
-	if (argc == 2)
-	{
-		LoadFile = true;
-		FileToLoad = argv[1];
-	}
-	else if (parser.Parse() != 0)
+	if (parser.Parse() != 0)
 	{
 		return false;
 	}
 
 	UseDebugger = parser.Found("debugger");
 	UseLogger = parser.Found("logger");
-	if (!LoadFile)
-		LoadFile = parser.Found("exec", &FileToLoad);
+	LoadFile = parser.Found("exec", &FileToLoad);
 	BatchMode = parser.Found("batch");
 	selectVideoBackend = parser.Found("video_backend", &videoBackendName);
 	selectAudioEmulation = parser.Found("audio_emulation", &audioEmulationName);


### PR DESCRIPTION
This completely breaks running Dolphin (GUI) with any flags at all. Most prominently, running `dolphin-emu -d` doesn't work. 

Reverts #1194 
