### PR TITLE
Re-added the change to make the dsp remaining block count zero-based.

### DIFF
--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -435,7 +435,10 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 	// Audio DMA blocks remaining is invalid to write to, and requires logic on
 	// the read side.
 	mmio->Register(base | AUDIO_DMA_BLOCKS_LEFT,
-		MMIO::DirectRead<u16>(&g_audioDMA.remaining_blocks_count),
+		MMIO::ComplexRead<u16>([](u32) {
+			// remaining_blocks_count is zero-based.  DreamMix World Fighters will hang if it never reaches zero.
+			return (g_audioDMA.remaining_blocks_count > 0 ? g_audioDMA.remaining_blocks_count - 1 : 0);
+		}),
 		MMIO::InvalidWrite<u16>()
 	);
 


### PR DESCRIPTION
Re-added the change to make the dsp remaining block count zero-based.  Fixes Dream Mix TV World Fighters.

Harvest Moon: Magical Melody and Pokemon Snap (VC) should be retested with this change.
