### PR TITLE
JIT: reuse trampolines when possible

### DIFF
--- a/Source/Core/Common/x64Analyzer.cpp
+++ b/Source/Core/Common/x64Analyzer.cpp
@@ -223,3 +223,19 @@ bool DisassembleMov(const unsigned char *codePtr, InstructionInfo *info)
 	info->instructionSize = (int)(codePtr - startCodePtr);
 	return true;
 }
+
+bool InstructionInfo::operator==(const InstructionInfo &other) const
+{
+	return operandSize     == other.operandSize     &&
+	       instructionSize == other.instructionSize &&
+	       regOperandReg   == other.regOperandReg   &&
+	       otherReg        == other.otherReg        &&
+	       scaledReg       == other.scaledReg       &&
+	       zeroExtend      == other.zeroExtend      &&
+	       signExtend      == other.signExtend      &&
+	       hasImmediate    == other.hasImmediate    &&
+	       isMemoryWrite   == other.isMemoryWrite   &&
+	       byteSwap        == other.byteSwap        &&
+	       immediate       == other.immediate       &&
+	       displacement    == other.displacement;
+}

--- a/Source/Core/Common/x64Analyzer.h
+++ b/Source/Core/Common/x64Analyzer.h
@@ -20,6 +20,8 @@ struct InstructionInfo
 	bool byteSwap;
 	u64 immediate;
 	s32 displacement;
+
+	bool operator==(const InstructionInfo &other) const;
 };
 
 struct ModRM

--- a/Source/Core/Core/PowerPC/JitCommon/TrampolineCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/TrampolineCache.h
@@ -11,12 +11,33 @@
 // We need at least this many bytes for backpatching.
 const int BACKPATCH_SIZE = 5;
 
+struct TrampolineCacheKey
+{
+	u32 registersInUse;
+	u32 pc;
+	InstructionInfo info;
+
+	bool operator==(const TrampolineCacheKey &other) const;
+};
+
+struct TrampolineCacheKeyHasher
+{
+	size_t operator()(const TrampolineCacheKey& k) const;
+};
+
 class TrampolineCache : public Gen::X64CodeBlock
 {
 public:
 	void Init();
 	void Shutdown();
 
-	const u8 *GetReadTrampoline(const InstructionInfo &info, u32 registersInUse);
-	const u8 *GetWriteTrampoline(const InstructionInfo &info, u32 registersInUse, u32 pc);
+	const u8* GetReadTrampoline(const InstructionInfo &info, u32 registersInUse);
+	const u8* GetWriteTrampoline(const InstructionInfo &info, u32 registersInUse, u32 pc);
+	void ClearCodeSpace();
+
+private:
+	const u8* GenerateReadTrampoline(const InstructionInfo &info, u32 registersInUse);
+	const u8* GenerateWriteTrampoline(const InstructionInfo &info, u32 registersInUse, u32 pc);
+
+	std::unordered_map<TrampolineCacheKey, const u8*, TrampolineCacheKeyHasher> cachedTrampolines;
 };


### PR DESCRIPTION
In tests, this showed hundreds of cache hits. A huge number of hits were, to my surprise, write trampolines with the same PC. I'm inferring from this that JIT code may be repeatedly invalidated and re-generated.

It seems this could easily lead to a trampoline-memory-leak causing the "Trampoline cache full" issue: https://code.google.com/p/dolphin-emu/issues/detail?id=7661

However, I was unable to reproduce that issue, so I'm not sure if this fixes it or not.
