### PR TITLE
FastMem: don't let the backpatcher hit the same location twice

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -221,6 +221,8 @@ void Jit64::ClearCache()
 {
 	blocks.Clear();
 	trampolines.ClearCodeSpace();
+	jit->js.pcAtLoc.clear();
+	jit->js.registersInUseAtLoc.clear();
 	farcode.ClearCodeSpace();
 	ClearCodeSpace();
 	m_clear_cache_asap = false;

--- a/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
@@ -65,14 +65,21 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
 		return false;
 	}
 
-	auto it = registersInUseAtLoc.find(codePtr);
-	if (it == registersInUseAtLoc.end())
+	auto pc_it = jit->js.pcAtLoc.find(codePtr);
+	if (pc_it == jit->js.pcAtLoc.end())
 	{
-		PanicAlert("BackPatch: no register use entry for address %p", codePtr);
+		PanicAlert("BackPatch: no pc entry for address %p", codePtr);
+		return nullptr;
+	}
+	u32 pc = pc_it->second;
+
+	auto reguse_it = jit->js.registersInUseAtLoc.find(pc);
+	if (reguse_it == jit->js.registersInUseAtLoc.end())
+	{
+		PanicAlert("BackPatch: no register use entry for PC %x", pc);
 		return false;
 	}
-
-	u32 registersInUse = it->second;
+	u32 registersInUse = reguse_it->second;
 
 	if (!info.isMemoryWrite)
 	{
@@ -97,16 +104,7 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
 	}
 	else
 	{
-		// TODO: special case FIFO writes. Also, support 32-bit mode.
-		it = pcAtLoc.find(codePtr);
-		if (it == pcAtLoc.end())
-		{
-			PanicAlert("BackPatch: no pc entry for address %p", codePtr);
-			return nullptr;
-		}
-
-		u32 pc = it->second;
-
+		// TODO: special case FIFO writes
 		u8 *start;
 		if (info.byteSwap || info.hasImmediate)
 		{

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -98,6 +98,8 @@ protected:
 		JitBlock *curBlock;
 
 		std::unordered_set<u32> fifoWriteAddresses;
+		std::unordered_map<u32, u32> registersInUseAtLoc;
+		std::unordered_map<u8 *, u32> pcAtLoc;
 	};
 
 	PPCAnalyst::CodeBlock code_block;

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -359,14 +359,19 @@ using namespace Gen;
 				block_map.erase(it1, it2);
 			}
 
-			// If the code was actually modified, we need to clear the relevant entries from the
-			// FIFO write address cache, so we don't end up with FIFO checks in places they shouldn't
-			// be (this can clobber flags, and thus break any optimization that relies on flags
-			// being in the right place between instructions).
 			if (!forced)
 			{
 				for (u32 i = address; i < address + length; i += 4)
+				{
+					// If the code was actually modified, we need to clear the relevant entries from the
+					// FIFO write address cache, so we don't end up with FIFO checks in places they shouldn't
+					// be (this can clobber flags, and thus break any optimization that relies on flags
+					// being in the right place between instructions).
 					jit->js.fifoWriteAddresses.erase(i);
+					// We use these entries to determine whether there's a fastmem fault at this location,
+					// so clear it since the block is being replaced.
+					jit->js.registersInUseAtLoc.erase(i);
+				}
 			}
 		}
 	}

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -131,7 +131,4 @@ public:
 	void ConvertSingleToDouble(Gen::X64Reg dst, Gen::X64Reg src, bool src_is_gpr = false);
 	void ConvertDoubleToSingle(Gen::X64Reg dst, Gen::X64Reg src);
 	void SetFPRF(Gen::X64Reg xmm);
-protected:
-	std::unordered_map<u8 *, u32> registersInUseAtLoc;
-	std::unordered_map<u8 *, u32> pcAtLoc;
 };


### PR DESCRIPTION
If a location is hit by the backpatcher, don't fastmem it when recompiling the
block unless the block has actually been invalidated.
