### PR TITLE
JIT: re-add profiling support on x86_64

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -614,7 +614,6 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 			js.next_inst_bp = false;
 			if (Profiler::g_ProfileBlocks)
 			{
-				// CAUTION!!! push on stack regs you use, do your stuff, then pop
 				PROFILER_VPUSH;
 				// get end tic
 				PROFILER_QUERY_PERFORMANCE_COUNTER(&b->ticStop);

--- a/Source/Core/Core/PowerPC/Profiler.h
+++ b/Source/Core/Core/PowerPC/Profiler.h
@@ -7,6 +7,28 @@
 
 #include <string>
 
+#ifdef _WIN32
+
+#define PROFILER_QUERY_PERFORMANCE_COUNTER(pt) \
+	LEA(64, ABI_PARAM1, M(pt)); \
+	CALL(QueryPerformanceCounter)
+
+// asm write : (u64) dt += t1-t0
+#define PROFILER_ADD_DIFF_LARGE_INTEGER(pdt, pt1, pt0) \
+	MOV(64, R(RSCRATCH), M(pt1)); \
+	SUB(64, R(RSCRATCH), M(pt0)); \
+	ADD(64, R(RSCRATCH), M(pdt)); \
+	MOV(64, M(pdt), R(RSCRATCH));
+
+#define PROFILER_VPUSH \
+	u32 registersInUse = CallerSavedRegistersInUse(); \
+	ABI_PushRegistersAndAdjustStack(registersInUse, 0);
+
+#define PROFILER_VPOP \
+	ABI_PopRegistersAndAdjustStack(registersInUse, 0);
+
+#else
+
 #define PROFILER_QUERY_PERFORMANCE_COUNTER(pt)
 
 // TODO: Implement generic ways to do this cleanly with all supported architectures
@@ -14,6 +36,8 @@
 #define PROFILER_ADD_DIFF_LARGE_INTEGER(pdt, pt1, pt0)
 #define PROFILER_VPUSH
 #define PROFILER_VPOP
+
+#endif
 
 struct BlockStat
 {


### PR DESCRIPTION
Still gives rather inaccurate results with conditional continue and/or
branch merging on, so those should probably be turned off when using it.
