### PR TITLE
DolphinWX: Make WXInputBase part of the WxUtils namespace.

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -511,8 +511,8 @@ wxString CFrame::GetMenuLabel(int Id)
 
 	hotkeymodifier &= wxMOD_CONTROL | wxMOD_ALT | wxMOD_SHIFT;
 
-	Modifier = InputCommon::WXKeymodToString(hotkeymodifier);
-	Hotkey = InputCommon::WXKeyToString(hotkey);
+	Modifier = WxUtils::WXKeymodToString(hotkeymodifier);
+	Hotkey = WxUtils::WXKeyToString(hotkey);
 	if (Modifier.Len() + Hotkey.Len() > 0)
 		Label += '\t';
 

--- a/Source/Core/DolphinWX/HotkeyDlg.cpp
+++ b/Source/Core/DolphinWX/HotkeyDlg.cpp
@@ -97,8 +97,8 @@ void HotkeyConfigDialog::OnKeyDown(wxKeyEvent& event)
 				// We compare against this to see if we have a duplicate bind attempt.
 				wxString existingHotkey = btn->GetLabel();
 
-				wxString tentativeModKey = InputCommon::WXKeymodToString(g_Modkey);
-				wxString tentativePressedKey = InputCommon::WXKeyToString(g_Pressed);
+				wxString tentativeModKey = WxUtils::WXKeymodToString(g_Modkey);
+				wxString tentativePressedKey = WxUtils::WXKeyToString(g_Pressed);
 				wxString tentativeHotkey(tentativeModKey + tentativePressedKey);
 
 				// Found a button that already has this binding. Unbind it.
@@ -111,8 +111,8 @@ void HotkeyConfigDialog::OnKeyDown(wxKeyEvent& event)
 
 			// Proceed to apply the binding to the selected button.
 			SetButtonText(ClickedButton->GetId(),
-					InputCommon::WXKeyToString(g_Pressed),
-					InputCommon::WXKeymodToString(g_Modkey));
+					WxUtils::WXKeyToString(g_Pressed),
+					WxUtils::WXKeymodToString(g_Modkey));
 			SaveButtonMapping(ClickedButton->GetId(), g_Pressed, g_Modkey);
 		}
 		EndGetButtons();
@@ -322,8 +322,8 @@ void HotkeyConfigDialog::CreateHotkeyGUIControls()
 			m_Button_Hotkeys[i]->SetFont(m_SmallFont);
 			m_Button_Hotkeys[i]->SetToolTip(_("Left click to detect hotkeys.\nEnter space to clear."));
 			SetButtonText(i,
-					InputCommon::WXKeyToString(SConfig::GetInstance().m_LocalCoreStartupParameter.iHotkey[i]),
-					InputCommon::WXKeymodToString(
+					WxUtils::WXKeyToString(SConfig::GetInstance().m_LocalCoreStartupParameter.iHotkey[i]),
+					WxUtils::WXKeymodToString(
 						SConfig::GetInstance().m_LocalCoreStartupParameter.iHotkeyModifier[i]));
 
 			wxBoxSizer *sHotkey = new wxBoxSizer(wxHORIZONTAL);

--- a/Source/Core/DolphinWX/WXInputBase.cpp
+++ b/Source/Core/DolphinWX/WXInputBase.cpp
@@ -9,7 +9,7 @@
 
 #include "DolphinWX/WXInputBase.h"
 
-namespace InputCommon
+namespace WxUtils
 {
 
 const wxString WXKeyToString(int keycode)

--- a/Source/Core/DolphinWX/WXInputBase.h
+++ b/Source/Core/DolphinWX/WXInputBase.h
@@ -4,14 +4,10 @@
 
 #pragma once
 
-#if defined(HAVE_WX) && HAVE_WX
 #include <wx/string.h>
-#endif
 
-namespace InputCommon
+namespace WxUtils
 {
-#if defined(HAVE_WX) && HAVE_WX
 const wxString WXKeyToString(int keycode);
 const wxString WXKeymodToString(int modifier);
-#endif
 }


### PR DESCRIPTION
There's no need for the preprocessor checks for wx, since this is used in wx code. Also, this being a part of the InputCommon namespace is kind of wrong.
