### PR TITLE
Workaround to make Final Fantasy Crystal Chronicles PAL run without crashing after the logo screen

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -389,7 +389,14 @@ TextureCache::TCacheEntryBase* TextureCache::Load(unsigned int const stage,
 		src_data = Memory::GetPointer(address);
 
 	// TODO: This doesn't hash GB tiles for preloaded RGBA8 textures (instead, it's hashing more data from the low tmem bank than it should)
-	tex_hash = GetHash64(src_data, texture_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
+	if (src_data == nullptr)
+	{
+		ERROR_LOG(VIDEO, "TextureCache::Load has an address in Wii memory (%8x) but not in real memory (NULL)!", address);
+		return nullptr;
+	}
+	else
+		tex_hash = GetHash64(src_data, texture_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
+
 	if (isPaletteTexture)
 	{
 		const u32 palette_size = TexDecoder_GetPaletteSize(texformat);


### PR DESCRIPTION
Currently FF:CC PAL crashes in GetCRC32(nullptr), which is called indirectly from TextureCache::Load
by the line tex_hash = GetHash64(src_data, texture_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
src_data is nullptr, but address is 0x102f9320. Apparently Memory::GetPointer(0x102f9320) is returning nullptr.

This workaround doesn't fix the underlying issue, but it replaces the crash with an error log so that the game can be played.
A few menu textures will be missing, so you need to click A to load a game, or up and A to start a new game. Then press A to go through the menus.
The game itself should now work.
