### PR TITLE
JIT: improve handling of stores with a known address

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -186,8 +186,6 @@ void Jit64AsmRoutineManager::GenerateCommon()
 	GenFifoWrite(16);
 	fifoDirectWrite32 = AlignCode4();
 	GenFifoWrite(32);
-	fifoDirectWriteFloat = AlignCode4();
-	GenFifoFloatWrite();
 	frsqrte = AlignCode4();
 	GenFrsqrte();
 	fres = AlignCode4();

--- a/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.cpp
@@ -22,31 +22,13 @@ static int temp32;
 
 void CommonAsmRoutines::GenFifoWrite(int size)
 {
-	// Assume value in RSCRATCH2
-	PUSH(ESI);
-	MOV(32, R(RSCRATCH), Imm32((u32)(u64)GPFifo::m_gatherPipe));
-	MOV(32, R(ESI), M(&GPFifo::m_gatherPipeCount));
-
-	SwapAndStore(size, MComplex(RSCRATCH, ESI, 1, 0), RSCRATCH2);
-
-	ADD(32, R(ESI), Imm8(size >> 3));
-	MOV(32, M(&GPFifo::m_gatherPipeCount), R(ESI));
-	POP(ESI);
-	RET();
-}
-
-void CommonAsmRoutines::GenFifoFloatWrite()
-{
-	// Assume value in XMM0
-	PUSH(ESI);
-	MOVSS(M(&temp32), XMM0);
-	MOV(32, R(RSCRATCH2), M(&temp32));
-	MOV(32, R(RSCRATCH), Imm32((u32)(u64)GPFifo::m_gatherPipe));
-	MOV(32, R(ESI), M(&GPFifo::m_gatherPipeCount));
-	SwapAndStore(32, MComplex(RSCRATCH, RSI, 1, 0), RSCRATCH2);
-	ADD(32, R(ESI), Imm8(4));
-	MOV(32, M(&GPFifo::m_gatherPipeCount), R(ESI));
-	POP(ESI);
+	// Assume value in RSCRATCH
+	u32 gather_pipe = (u32)(u64)GPFifo::m_gatherPipe;
+	_assert_msg_(DYNA_REC, gather_pipe <= 0x7FFFFFFF, "Gather pipe not in low 2GB of memory!");
+	MOV(32, R(RSCRATCH2), M(&GPFifo::m_gatherPipeCount));
+	SwapAndStore(size, MDisp(RSCRATCH2, gather_pipe), RSCRATCH);
+	ADD(32, R(RSCRATCH2), Imm8(size >> 3));
+	MOV(32, M(&GPFifo::m_gatherPipeCount), R(RSCRATCH2));
 	RET();
 }
 
@@ -173,8 +155,8 @@ void CommonAsmRoutines::GenFres()
 
 // Safe + Fast Quantizers, originally from JITIL by magumagu
 
-static const u8 GC_ALIGNED16(pbswapShuffle1x4[16]) = {3, 2, 1, 0, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-static const u8 GC_ALIGNED16(pbswapShuffle2x4[16]) = {3, 2, 1, 0, 7, 6, 5, 4, 8, 9, 10, 11, 12, 13, 14, 15};
+static const u8 GC_ALIGNED16(pbswapShuffle1x4[16]) = { 3, 2, 1, 0, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+static const u8 GC_ALIGNED16(pbswapShuffle2x4[16]) = { 3, 2, 1, 0, 7, 6, 5, 4, 8, 9, 10, 11, 12, 13, 14, 15 };
 
 static const float GC_ALIGNED16(m_quantizeTableS[]) =
 {
@@ -386,7 +368,8 @@ void CommonAsmRoutines::GenQuantizedSingleStores()
 
 	// Easy!
 	const u8* storeSingleFloat = AlignCode4();
-	SafeWriteF32ToReg(XMM0, RSCRATCH_EXTRA, 0, QUANTIZED_REGS_TO_SAVE, SAFE_LOADSTORE_NO_PROLOG | SAFE_LOADSTORE_NO_FASTMEM);
+	MOVD_xmm(R(RSCRATCH), XMM0);
+	SafeWriteRegToReg(RSCRATCH, RSCRATCH_EXTRA, 32, 0, QUANTIZED_REGS_TO_SAVE, SAFE_LOADSTORE_NO_PROLOG | SAFE_LOADSTORE_NO_FASTMEM);
 	RET();
 	/*
 	if (cpu_info.bSSSE3)

--- a/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
@@ -13,7 +13,6 @@ public:
 	const u8 *fifoDirectWrite8;
 	const u8 *fifoDirectWrite16;
 	const u8 *fifoDirectWrite32;
-	const u8 *fifoDirectWriteFloat;
 
 	const u8 *enterCode;
 

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -422,6 +422,16 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg & opAddress,
 	}
 }
 
+static OpArg SwapImmediate(int accessSize, OpArg reg_value)
+{
+	if (accessSize == 32)
+		return Imm32(Common::swap32((u32)reg_value.offset));
+	else if (accessSize == 16)
+		return Imm16(Common::swap16((u16)reg_value.offset));
+	else
+		return Imm8((u8)reg_value.offset);
+}
+
 u8 *EmuCodeBlock::UnsafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int accessSize, s32 offset, bool swap)
 {
 	u8* result = GetWritableCodePtr();
@@ -429,14 +439,7 @@ u8 *EmuCodeBlock::UnsafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acce
 	if (reg_value.IsImm())
 	{
 		if (swap)
-		{
-			if (accessSize == 32)
-				reg_value = Imm32(Common::swap32((u32)reg_value.offset));
-			else if (accessSize == 16)
-				reg_value = Imm16(Common::swap16((u16)reg_value.offset));
-			else
-				reg_value = Imm8((u8)reg_value.offset);
-		}
+			reg_value = SwapImmediate(accessSize, reg_value);
 		MOV(accessSize, dest, reg_value);
 	}
 	else if (swap)
@@ -459,6 +462,68 @@ u8 *EmuCodeBlock::UnsafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acce
 	}
 
 	return result;
+}
+
+void EmuCodeBlock::UnsafeWriteGatherPipe(int accessSize)
+{
+	// No need to protect these, they don't touch any state
+	// question - should we inline them instead? Pro: Lose a CALL   Con: Code bloat
+	switch (accessSize)
+	{
+	case 8:
+		CALL((void *)jit->GetAsmRoutines()->fifoDirectWrite8);
+		break;
+	case 16:
+		CALL((void *)jit->GetAsmRoutines()->fifoDirectWrite16);
+		break;
+	case 32:
+		CALL((void *)jit->GetAsmRoutines()->fifoDirectWrite32);
+		break;
+	}
+	jit->js.fifoBytesThisBlock += accessSize >> 3;
+}
+
+bool EmuCodeBlock::WriteToConstAddress(int accessSize, OpArg arg, u32 address, BitSet32 registersInUse)
+{
+	// If we already know the address through constant folding, we can do some
+	// fun tricks...
+	if ((address & 0xFFFFF000) == 0xCC008000 && jit->jo.optimizeGatherPipe && accessSize <= 32)
+	{
+		if (!arg.IsSimpleReg() || arg.GetSimpleReg() != RSCRATCH)
+			MOV(32, R(RSCRATCH), arg);
+
+		UnsafeWriteGatherPipe(accessSize);
+		return false;
+	}
+	else if (Memory::IsRAMAddress(address))
+	{
+		WriteToConstRamAddress(accessSize, arg, address);
+		return false;
+	}
+	else
+	{
+		// Helps external systems know which instruction triggered the write
+		MOV(32, PPCSTATE(pc), Imm32(jit->js.compilerPC));
+
+		ABI_PushRegistersAndAdjustStack(registersInUse, 0);
+		switch (accessSize)
+		{
+		case 64:
+			ABI_CallFunctionAC((void *)&Memory::Write_U64, arg, address);
+			break;
+		case 32:
+			ABI_CallFunctionAC((void *)&Memory::Write_U32, arg, address);
+			break;
+		case 16:
+			ABI_CallFunctionAC((void *)&Memory::Write_U16, arg, address);
+			break;
+		case 8:
+			ABI_CallFunctionAC((void *)&Memory::Write_U8, arg, address);
+			break;
+		}
+		ABI_PopRegistersAndAdjustStack(registersInUse, 0);
+		return true;
+	}
 }
 
 void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int accessSize, s32 offset, BitSet32 registersInUse, int flags)
@@ -565,20 +630,30 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
 	SetJumpTarget(exit);
 }
 
-// Destroys the same as SafeWrite plus RSCRATCH.  TODO: see if we can avoid temporaries here
-void EmuCodeBlock::SafeWriteF32ToReg(X64Reg xmm_value, X64Reg reg_addr, s32 offset, BitSet32 registersInUse, int flags)
+void EmuCodeBlock::WriteToConstRamAddress(int accessSize, OpArg arg, u32 address, bool swap)
 {
-	// TODO: PSHUFB might be faster if fastmem supported MOVSS.
-	MOVD_xmm(R(RSCRATCH), xmm_value);
-	SafeWriteRegToReg(RSCRATCH, reg_addr, 32, offset, registersInUse, flags);
-}
+	X64Reg reg;
+	if (arg.IsImm())
+	{
+		arg = SwapImmediate(accessSize, arg);
+		MOV(accessSize, MDisp(RMEM, address & 0x3FFFFFFF), arg);
+		return;
+	}
 
-void EmuCodeBlock::WriteToConstRamAddress(int accessSize, Gen::X64Reg arg, u32 address, bool swap)
-{
-	if (swap)
-		SwapAndStore(accessSize, MDisp(RMEM, address & 0x3FFFFFFF), arg);
+	if (!arg.IsSimpleReg() || (!cpu_info.bMOVBE && swap && arg.GetSimpleReg() != RSCRATCH))
+	{
+		MOV(accessSize, R(RSCRATCH), arg);
+		reg = RSCRATCH;
+	}
 	else
-		MOV(accessSize, MDisp(RMEM, address & 0x3FFFFFFF), R(arg));
+	{
+		reg = arg.GetSimpleReg();
+	}
+
+	if (swap)
+		SwapAndStore(accessSize, MDisp(RMEM, address & 0x3FFFFFFF), reg);
+	else
+		MOV(accessSize, MDisp(RMEM, address & 0x3FFFFFFF), R(reg));
 }
 
 void EmuCodeBlock::ForceSinglePrecisionS(X64Reg xmm)

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -87,6 +87,7 @@ public:
 		return UnsafeWriteRegToReg(R(reg_value), reg_addr, accessSize, offset, swap);
 	}
 	u8 *UnsafeLoadToReg(Gen::X64Reg reg_value, Gen::OpArg opAddress, int accessSize, s32 offset, bool signExtend);
+	void UnsafeWriteGatherPipe(int accessSize);
 
 	// Generate a load/write from the MMIO handler for a given address. Only
 	// call for known addresses in MMIO range (MMIO::IsMMIOAddress).
@@ -116,9 +117,9 @@ public:
 		return swap && !cpu_info.bMOVBE && accessSize > 8;
 	}
 
-	void SafeWriteF32ToReg(Gen::X64Reg xmm_value, Gen::X64Reg reg_addr, s32 offset, BitSet32 registersInUse, int flags = 0);
-
-	void WriteToConstRamAddress(int accessSize, Gen::X64Reg arg, u32 address, bool swap = false);
+	void WriteToConstRamAddress(int accessSize, Gen::OpArg arg, u32 address, bool swap = true);
+	// returns true if an exception could have been caused
+	bool WriteToConstAddress(int accessSize, Gen::OpArg arg, u32 address, BitSet32 registersInUse);
 	void JitGetAndClearCAOV(bool oe);
 	void JitSetCA();
 	void JitSetCAIf(Gen::CCFlags conditionCode);


### PR DESCRIPTION
1. Genericize the immediate-address handling, and make it apply to float stores too. Optimize some of the FIFO stores, etc a bit.
2. If the offset of a store is 0x8000, the write is almost always a FIFO store; optimize this case (and set up a fallback path if we're wrong). (this has been dropped, because I can't get it to not break with NBA 2k11)
