### PR TITLE
Fix ARMv7 JIT from XER optimization.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm32/JitArm_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitArm_Integer.cpp
@@ -47,9 +47,9 @@ void JitArm::ComputeCarry()
 {
 	ARMReg tmp = gpr.GetReg();
 	SetCC(CC_CS);
-	ORR(tmp, tmp, 1);
+	MOV(tmp, 1);
 	SetCC(CC_CC);
-	BIC(tmp, tmp, 1);
+	EOR(tmp, tmp, tmp);
 	SetCC();
 	STRB(tmp, R9, PPCSTATE_OFF(xer_ca));
 	gpr.Unlock(tmp);
@@ -58,11 +58,10 @@ void JitArm::ComputeCarry()
 void JitArm::ComputeCarry(bool Carry)
 {
 	ARMReg tmp = gpr.GetReg();
-	LDRB(tmp, R9, PPCSTATE_OFF(xer_ca));
 	if (Carry)
-		ORR(tmp, tmp, 1);
+		MOV(tmp, 1);
 	else
-		BIC(tmp, tmp, 1);
+		EOR(tmp, tmp, tmp);
 	STRB(tmp, R9, PPCSTATE_OFF(xer_ca));
 	gpr.Unlock(tmp);
 }


### PR DESCRIPTION
This was a subtle bug I introduced since I removed a LDR in one of the ComputeCarry functions.
Basically since I wasn't loading the XER value prior to operations when I did a BIC tmp, tmp, 1 it would clear the first bit in our temp register but
retain the rest of the "random" data from that temp register. This would then save in to xer_ca, which the Interpreter will use later without any
masking to generate the XER value. Our XER generation helper functions don't do any masking since they were only expecting a single bit worth of data
in xer_ca with the rest being zero.
So now we only have one bit of data being stored in xer_ca from the ARMv7 JIT recompiler, and also a slight optimization in the ComputeCarry function
that is used on the immediate path. There wasn't any reason to load xer_ca since it only contains one bit of data now.
