### PR TITLE
[Android] Return to game list instead of exiting app

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/EmulationActivity.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/EmulationActivity.java
@@ -259,7 +259,7 @@ public final class EmulationActivity extends Activity
 				builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 					public void onClick(DialogInterface dialog, int which)
 					{
-						finish();
+						onDestroy();
 					}
 				});
 				builder.show();


### PR DESCRIPTION
Preivously, finish() was being called which just ended the app. Every time a user wants to return to the game list, they would be greeted with their home screen. Calling onDestroy() instead stops the emulation and does not close the app. Makes it a lot less annoying to switch between games ;)
