### PR TITLE
Android: Use apply() instead of commit() for SharedPreference changes.

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/EmulationActivity.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/EmulationActivity.java
@@ -190,13 +190,13 @@ public final class EmulationActivity extends Activity
 				{
 					overlay.setVisibility(View.VISIBLE);
 					item.setTitle(R.string.disable_input_overlay);
-					sharedPrefs.edit().putBoolean("showInputOverlay", true).commit();
+					sharedPrefs.edit().putBoolean("showInputOverlay", true).apply();
 				}
 				else // Hide the overlay
 				{
 					overlay.setVisibility(View.INVISIBLE);
 					item.setTitle(R.string.enable_input_overlay);
-					sharedPrefs.edit().putBoolean("showInputOverlay", false).commit();
+					sharedPrefs.edit().putBoolean("showInputOverlay", false).apply();
 				}
 
 				return true;

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/UserPreferences.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/UserPreferences.java
@@ -96,7 +96,7 @@ public final class UserPreferences
 		editor.putBoolean("fastDepthCalculation",    getConfig("gfx_opengl.ini", "Settings", "FastDepthCalc", "True").equals("True"));
 
 		// Apply the changes.
-		editor.commit();
+		editor.apply();
 	}
 
 	// Small utility method that shortens calls to NativeLibrary.GetConfig.

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/overlayconfig/OverlayConfigButton.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/overlayconfig/OverlayConfigButton.java
@@ -156,7 +156,7 @@ public final class OverlayConfigButton extends Button implements OnTouchListener
 				SharedPreferences.Editor editor = sharedPrefs.edit();
 				editor.putFloat(buttonId+"-X", getX());
 				editor.putFloat(buttonId+"-Y", getY());
-				editor.commit();
+				editor.apply();
 				return true;
 			}
 		}

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/video/VideoSettingsFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/video/VideoSettingsFragment.java
@@ -159,7 +159,7 @@ public final class VideoSettingsFragment extends PreferenceFragment
 									// Get an editor.
 									SharedPreferences.Editor editor = sPrefs.edit();
 									editor.putString("gpuPref", "Software Renderer");
-									editor.commit();
+									editor.apply();
 									videoBackends.setValue("Software Renderer");
 									videoBackends.setSummary("Software Renderer");
 								}


### PR DESCRIPTION
apply() changes the in-memory instance of SharedPreferences and writes to the disk asynchronously, rather than synchronously, which commit() does. Since these are done on the UI thread, they should be asynchronous (doing blocking IO on it isn't a neat idea).
