### PR TITLE
Change baroque static_cast<numeric type>(expr) to C style casts.

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -184,7 +184,7 @@ bool TryParse(const std::string &str, u32 *const output)
 		return false;
 #endif
 
-	*output = static_cast<u32>(value);
+	*output = (u32)value;
 	return true;
 }
 

--- a/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
@@ -282,26 +282,26 @@ void DSPJitRegCache::flushRegs(DSPJitRegCache &cache, bool emit)
 	{
 		_assert_msg_(DSPLLE,
 			     xregs[i].guest_reg == cache.xregs[i].guest_reg,
-			     "cache and current xreg guest_reg mismatch for %u", static_cast<u32>(i));
+			     "cache and current xreg guest_reg mismatch for %u", (u32)i);
 	}
 
 	for (size_t i = 0; i < regs.size(); i++)
 	{
 		_assert_msg_(DSPLLE,
 			     regs[i].loc.IsImm() == cache.regs[i].loc.IsImm(),
-			     "cache and current reg loc mismatch for %i", static_cast<u32>(i));
+			     "cache and current reg loc mismatch for %i", (int)i);
 		_assert_msg_(DSPLLE,
 			     regs[i].loc.GetSimpleReg() == cache.regs[i].loc.GetSimpleReg(),
-			     "cache and current reg loc mismatch for %i", static_cast<u32>(i));
+			     "cache and current reg loc mismatch for %i", (int)i);
 		_assert_msg_(DSPLLE,
 			     regs[i].dirty || !cache.regs[i].dirty,
-			     "cache and current reg dirty mismatch for %i", static_cast<u32>(i));
+			     "cache and current reg dirty mismatch for %i", (int)i);
 		_assert_msg_(DSPLLE,
 			     regs[i].used == cache.regs[i].used,
-			     "cache and current reg used mismatch for %i", static_cast<u32>(i));
+			     "cache and current reg used mismatch for %i", (int)i);
 		_assert_msg_(DSPLLE,
 			     regs[i].shift == cache.regs[i].shift,
-			     "cache and current reg shift mismatch for %i", static_cast<u32>(i));
+			     "cache and current reg shift mismatch for %i", (int)i);
 	}
 
 	use_ctr = cache.use_ctr;
@@ -316,7 +316,7 @@ void DSPJitRegCache::flushMemBackedRegs()
 	for (size_t i = 0; i < regs.size(); i++)
 	{
 		_assert_msg_(DSPLLE, !regs[i].used,
-			     "register %u still in use", static_cast<u32>(i));
+			     "register %u still in use", (u32)i);
 
 		if (regs[i].used)
 		{
@@ -348,7 +348,7 @@ void DSPJitRegCache::flushRegs()
 
 		_assert_msg_(DSPLLE,
 		             !regs[i].loc.IsSimpleReg(),
-		             "register %u is still a simple reg", static_cast<u32>(i));
+		             "register %u is still a simple reg", (u32)i);
 	}
 
 	_assert_msg_(DSPLLE,
@@ -434,7 +434,7 @@ void DSPJitRegCache::saveRegs()
 
 		_assert_msg_(DSPLLE,
 		             !regs[i].loc.IsSimpleReg(),
-		             "register %u is still a simple reg", static_cast<u32>(i));
+		             "register %u is still a simple reg", (u32)i);
 	}
 
 	emitter.MOV(64, R(RBP), M(&ebp_store));
@@ -453,7 +453,7 @@ void DSPJitRegCache::pushRegs()
 
 		_assert_msg_(DSPLLE,
 		             !regs[i].loc.IsSimpleReg(),
-		             "register %u is still a simple reg", static_cast<u32>(i));
+		             "register %u is still a simple reg", (u32)i);
 	}
 
 	int push_count = 0;
@@ -473,7 +473,7 @@ void DSPJitRegCache::pushRegs()
 	{
 		if (xregs[i].guest_reg == DSP_REG_USED)
 		{
-			emitter.PUSH(static_cast<X64Reg>(i));
+			emitter.PUSH((X64Reg)i);
 			xregs[i].pushed = true;
 			xregs[i].guest_reg = DSP_REG_NONE;
 		}
@@ -481,7 +481,7 @@ void DSPJitRegCache::pushRegs()
 		_assert_msg_(DSPLLE,
 		             xregs[i].guest_reg == DSP_REG_NONE ||
 		             xregs[i].guest_reg == DSP_REG_STATIC,
-		             "register %u is still used", static_cast<u32>(i));
+		             "register %u is still used", (u32)i);
 	}
 
 	emitter.MOV(64, R(RBP), M(&ebp_store));
@@ -492,13 +492,13 @@ void DSPJitRegCache::popRegs()
 	emitter.MOV(64, M(&ebp_store), R(RBP));
 
 	int push_count = 0;
-	for (int i = static_cast<int>(xregs.size() - 1); i >= 0; i--)
+	for (int i = (int)(xregs.size() - 1); i >= 0; i--)
 	{
 		if (xregs[i].pushed)
 		{
 			push_count++;
 
-			emitter.POP(static_cast<X64Reg>(i));
+			emitter.POP((X64Reg)i);
 			xregs[i].pushed = false;
 			xregs[i].guest_reg = DSP_REG_USED;
 		}
@@ -542,11 +542,11 @@ X64Reg DSPJitRegCache::makeABICallSafe(X64Reg reg)
 void DSPJitRegCache::movToHostReg(size_t reg, X64Reg host_reg, bool load)
 {
 	_assert_msg_(DSPLLE, reg < regs.size(),
-	             "bad register name %u", static_cast<u32>(reg));
+	             "bad register name %u", (u32)reg);
 	_assert_msg_(DSPLLE, regs[reg].parentReg == DSP_REG_NONE,
-	             "register %u is proxy for %d", static_cast<u32>(reg), regs[reg].parentReg);
+	             "register %u is proxy for %d", (u32)reg, regs[reg].parentReg);
 	_assert_msg_(DSPLLE, !regs[reg].used,
-	             "moving to host reg in use guest reg %u", static_cast<u32>(reg));
+	             "moving to host reg in use guest reg %u", (u32)reg);
 	X64Reg old_reg = regs[reg].loc.GetSimpleReg();
 	if (old_reg == host_reg)
 	{
@@ -588,11 +588,11 @@ void DSPJitRegCache::movToHostReg(size_t reg, X64Reg host_reg, bool load)
 void DSPJitRegCache::movToHostReg(size_t reg, bool load)
 {
 	_assert_msg_(DSPLLE, reg < regs.size(),
-	             "bad register name %u", static_cast<u32>(reg));
+	             "bad register name %u", (u32)reg);
 	_assert_msg_(DSPLLE, regs[reg].parentReg == DSP_REG_NONE,
-	             "register %u is proxy for %d", static_cast<u32>(reg), regs[reg].parentReg);
+	             "register %u is proxy for %d", (u32)reg, regs[reg].parentReg);
 	_assert_msg_(DSPLLE, !regs[reg].used,
-	             "moving to host reg in use guest reg %u", static_cast<u32>(reg));
+	             "moving to host reg in use guest reg %u", (u32)reg);
 
 	if (regs[reg].loc.IsSimpleReg())
 	{
@@ -620,13 +620,13 @@ void DSPJitRegCache::movToHostReg(size_t reg, bool load)
 void DSPJitRegCache::rotateHostReg(size_t reg, int shift, bool emit)
 {
 	_assert_msg_(DSPLLE, reg < regs.size(),
-	             "bad register name %u", static_cast<u32>(reg));
+	             "bad register name %u", (u32)reg);
 	_assert_msg_(DSPLLE, regs[reg].parentReg == DSP_REG_NONE,
-	             "register %u is proxy for %d", static_cast<u32>(reg), regs[reg].parentReg);
+	             "register %u is proxy for %d", (u32)reg, regs[reg].parentReg);
 	_assert_msg_(DSPLLE, regs[reg].loc.IsSimpleReg(),
-	             "register %u is not a simple reg", static_cast<u32>(reg));
+	             "register %u is not a simple reg", (u32)reg);
 	_assert_msg_(DSPLLE, !regs[reg].used,
-	             "rotating in use guest reg %u", static_cast<u32>(reg));
+	             "rotating in use guest reg %u", (u32)reg);
 
 	if (shift > regs[reg].shift && emit)
 	{
@@ -664,11 +664,11 @@ void DSPJitRegCache::rotateHostReg(size_t reg, int shift, bool emit)
 void DSPJitRegCache::movToMemory(size_t reg)
 {
 	_assert_msg_(DSPLLE, reg < regs.size(),
-		     "bad register name %u", static_cast<u32>(reg));
+		     "bad register name %u", (u32)reg);
 	_assert_msg_(DSPLLE, regs[reg].parentReg == DSP_REG_NONE,
-		     "register %u is proxy for %d", static_cast<u32>(reg), regs[reg].parentReg);
+		     "register %u is proxy for %d", (u32)reg, regs[reg].parentReg);
 	_assert_msg_(DSPLLE, !regs[reg].used,
-		     "moving to memory in use guest reg %u", static_cast<u32>(reg));
+		     "moving to memory in use guest reg %u", (u32)reg);
 
 	if (regs[reg].used)
 	{

--- a/Source/Core/Core/FifoPlayer/FifoDataFile.h
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.h
@@ -67,7 +67,7 @@ public:
 
 	void AddFrame(const FifoFrameInfo &frameInfo);
 	const FifoFrameInfo &GetFrame(u32 frame) const { return m_Frames[frame]; }
-	u32 GetFrameCount() { return static_cast<u32>(m_Frames.size()); }
+	u32 GetFrameCount() { return (u32)m_Frames.size(); }
 
 	bool Save(const std::string& filename);
 

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -317,7 +317,7 @@ void Update(u64 userdata, int cyclesLate)
 		const u64 Diff = CoreTiming::GetTicks() - g_LastCPUTime;
 		if (Diff > g_CPUCyclesPerSample)
 		{
-			const u32 Samples = static_cast<u32>(Diff / g_CPUCyclesPerSample);
+			const u32 Samples = (u32)(Diff / g_CPUCyclesPerSample);
 			g_LastCPUTime += Samples * g_CPUCyclesPerSample;
 			IncreaseSampleCount(Samples);
 		}

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -107,17 +107,17 @@ void GCPad::GetInput(GCPadStatus* const pad)
 
 	// sticks
 	m_main_stick->GetState(&x, &y);
-	pad->stickX = static_cast<u8>(GCPadStatus::MAIN_STICK_CENTER_X + (x * GCPadStatus::MAIN_STICK_RADIUS));
-	pad->stickY = static_cast<u8>(GCPadStatus::MAIN_STICK_CENTER_Y + (y * GCPadStatus::MAIN_STICK_RADIUS));
+	pad->stickX = (u8)(GCPadStatus::MAIN_STICK_CENTER_X + (x * GCPadStatus::MAIN_STICK_RADIUS));
+	pad->stickY = (u8)(GCPadStatus::MAIN_STICK_CENTER_Y + (y * GCPadStatus::MAIN_STICK_RADIUS));
 
 	m_c_stick->GetState(&x, &y);
-	pad->substickX = static_cast<u8>(GCPadStatus::C_STICK_CENTER_X + (x * GCPadStatus::C_STICK_RADIUS));
-	pad->substickY = static_cast<u8>(GCPadStatus::C_STICK_CENTER_Y + (y * GCPadStatus::C_STICK_RADIUS));
+	pad->substickX = (u8)(GCPadStatus::C_STICK_CENTER_X + (x * GCPadStatus::C_STICK_RADIUS));
+	pad->substickY = (u8)(GCPadStatus::C_STICK_CENTER_Y + (y * GCPadStatus::C_STICK_RADIUS));
 
 	// triggers
 	m_triggers->GetState(&pad->button, trigger_bitmasks, triggers);
-	pad->triggerLeft = static_cast<u8>(triggers[0] * 0xFF);
-	pad->triggerRight = static_cast<u8>(triggers[1] * 0xFF);
+	pad->triggerLeft = (u8)(triggers[0] * 0xFF);
+	pad->triggerRight = (u8)(triggers[1] * 0xFF);
 }
 
 void GCPad::SetMotor(const u8 on)

--- a/Source/Core/Core/HW/WiiSaveCrypted.cpp
+++ b/Source/Core/Core/HW/WiiSaveCrypted.cpp
@@ -204,7 +204,7 @@ void CWiiSaveCrypted::WriteHDR()
 	memset(&m_header, 0, HEADER_SZ);
 
 	std::string banner_file_path = m_wii_title_path + "banner.bin";
-	u32 banner_size = static_cast<u32>(File::GetSize(banner_file_path));
+	u32 banner_size = (u32)File::GetSize(banner_file_path);
 	m_header.hdr.BannerSize =  Common::swap32(banner_size);
 
 	m_header.hdr.SaveGameTitle = Common::swap64(m_title_id);
@@ -398,7 +398,7 @@ void CWiiSaveCrypted::ExportWiiSaveFiles()
 		}
 		else
 		{
-			file_size = static_cast<u32>(File::GetSize(m_files_list[i]));
+			file_size = (u32)File::GetSize(m_files_list[i]);
 			file_hdr_tmp.type = 1;
 		}
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -92,8 +92,8 @@ void Classic::GetState(u8* const data)
 	ControlState x, y;
 	m_left_stick->GetState(&x, &y);
 
-	ccdata->lx = static_cast<u8>(Classic::LEFT_STICK_CENTER_X + (x * Classic::LEFT_STICK_RADIUS));
-	ccdata->ly = static_cast<u8>(Classic::LEFT_STICK_CENTER_Y + (y * Classic::LEFT_STICK_RADIUS));
+	ccdata->lx = (u8)(Classic::LEFT_STICK_CENTER_X + (x * Classic::LEFT_STICK_RADIUS));
+	ccdata->ly = (u8)(Classic::LEFT_STICK_CENTER_Y + (y * Classic::LEFT_STICK_RADIUS));
 	}
 
 	// right stick
@@ -102,8 +102,8 @@ void Classic::GetState(u8* const data)
 	u8 x_, y_;
 	m_right_stick->GetState(&x, &y);
 
-	x_ = static_cast<u8>(Classic::RIGHT_STICK_CENTER_X + (x * Classic::RIGHT_STICK_RADIUS));
-	y_ = static_cast<u8>(Classic::RIGHT_STICK_CENTER_Y + (y * Classic::RIGHT_STICK_RADIUS));
+	x_ = (u8)(Classic::RIGHT_STICK_CENTER_X + (x * Classic::RIGHT_STICK_RADIUS));
+	y_ = (u8)(Classic::RIGHT_STICK_CENTER_Y + (y * Classic::RIGHT_STICK_RADIUS));
 
 	ccdata->rx1 = x_;
 	ccdata->rx2 = x_ >> 1;
@@ -117,8 +117,8 @@ void Classic::GetState(u8* const data)
 	u8 lt, rt;
 	m_triggers->GetState(&ccdata->bt, classic_trigger_bitmasks, trigs);
 
-	lt = static_cast<u8>(trigs[0] * Classic::LEFT_TRIGGER_RANGE);
-	rt = static_cast<u8>(trigs[1] * Classic::RIGHT_TRIGGER_RANGE);
+	lt = (u8)(trigs[0] * Classic::LEFT_TRIGGER_RANGE);
+	rt = (u8)(trigs[1] * Classic::RIGHT_TRIGGER_RANGE);
 
 	ccdata->lt1 = lt;
 	ccdata->lt2 = lt >> 3;

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -63,8 +63,8 @@ void Drums::GetState(u8* const data)
 	ControlState x, y;
 	m_stick->GetState(&x, &y);
 
-	ddata->sx = static_cast<u8>((x * 0x1F) + 0x20);
-	ddata->sy = static_cast<u8>((y * 0x1F) + 0x20);
+	ddata->sx = (u8)((x * 0x1F) + 0x20);
+	ddata->sy = (u8)((y * 0x1F) + 0x20);
 	}
 
 	// TODO: softness maybe

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -76,8 +76,8 @@ void Guitar::GetState(u8* const data)
 	ControlState x, y;
 	m_stick->GetState(&x, &y);
 
-	gdata->sx = static_cast<u8>((x * 0x1F) + 0x20);
-	gdata->sy = static_cast<u8>((y * 0x1F) + 0x20);
+	gdata->sx = (u8)((x * 0x1F) + 0x20);
+	gdata->sy = (u8)((y * 0x1F) + 0x20);
 	}
 
 	// TODO: touch bar, probably not
@@ -86,7 +86,7 @@ void Guitar::GetState(u8* const data)
 	// whammy bar
 	ControlState whammy;
 	m_whammy->GetState(&whammy);
-	gdata->whammy = static_cast<u8>(whammy * 0x1F);
+	gdata->whammy = (u8)(whammy * 0x1F);
 
 	// buttons
 	m_buttons->GetState(&gdata->bt, guitar_button_bitmasks);

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -65,8 +65,8 @@ void Turntable::GetState(u8* const data)
 	ControlState x, y;
 	m_stick->GetState(&x, &y);
 
-	ttdata->sx = static_cast<u8>((x * 0x1F) + 0x20);
-	ttdata->sy = static_cast<u8>((y * 0x1F) + 0x20);
+	ttdata->sx = (u8)((x * 0x1F) + 0x20);
+	ttdata->sy = (u8)((y * 0x1F) + 0x20);
 	}
 
 	// left table
@@ -75,7 +75,7 @@ void Turntable::GetState(u8* const data)
 	s8 tt_;
 	m_left_table->GetState(&tt);
 
-	tt_ = static_cast<s8>(tt * 0x1F);
+	tt_ = (s8)(tt * 0x1F);
 
 	ttdata->ltable1 = tt_;
 	ttdata->ltable2 = tt_ >> 5;
@@ -87,7 +87,7 @@ void Turntable::GetState(u8* const data)
 	s8 tt_;
 	m_right_table->GetState(&tt);
 
-	tt_ = static_cast<s8>(tt * 0x1F);
+	tt_ = (s8)(tt * 0x1F);
 
 	ttdata->rtable1 = tt_;
 	ttdata->rtable2 = tt_ >> 1;
@@ -101,7 +101,7 @@ void Turntable::GetState(u8* const data)
 	u8 dial_;
 	m_effect_dial->GetState(&dial);
 
-	dial_ = static_cast<u8>(dial * 0x0F);
+	dial_ = (u8)(dial * 0x0F);
 
 	ttdata->dial1 = dial_;
 	ttdata->dial2 = dial_ >> 3;
@@ -112,7 +112,7 @@ void Turntable::GetState(u8* const data)
 	ControlState cfs;
 	m_crossfade->GetState(&cfs);
 
-	ttdata->slider = static_cast<u8>((cfs * 0x07) + 0x08);
+	ttdata->slider = (u8)((cfs * 0x07) + 0x08);
 	}
 
 	// buttons

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -517,18 +517,18 @@ void Wiimote::GetIRData(u8* const data, bool use_accel)
 		{
 			if (x[i*2] < 1024 && y[i*2] < 768)
 			{
-				irdata[i].x1 = static_cast<u8>(x[i*2]);
+				irdata[i].x1 = (u8)x[i*2];
 				irdata[i].x1hi = x[i*2] >> 8;
 
-				irdata[i].y1 = static_cast<u8>(y[i*2]);
+				irdata[i].y1 = (u8)y[i*2];
 				irdata[i].y1hi = y[i*2] >> 8;
 			}
 			if (x[i*2+1] < 1024 && y[i*2+1] < 768)
 			{
-				irdata[i].x2 = static_cast<u8>(x[i*2+1]);
+				irdata[i].x2 = (u8)x[i*2+1];
 				irdata[i].x2hi = x[i*2+1] >> 8;
 
-				irdata[i].y2 = static_cast<u8>(y[i*2+1]);
+				irdata[i].y2 = (u8)y[i*2+1];
 				irdata[i].y2hi = y[i*2+1] >> 8;
 			}
 		}
@@ -542,10 +542,10 @@ void Wiimote::GetIRData(u8* const data, bool use_accel)
 		for (unsigned int i = 0; i < 4; ++i)
 			if (x[i] < 1024 && y[i] < 768)
 			{
-				irdata[i].x = static_cast<u8>(x[i]);
+				irdata[i].x = (u8)x[i];
 				irdata[i].xhi = x[i] >> 8;
 
-				irdata[i].y = static_cast<u8>(y[i]);
+				irdata[i].y = (u8)y[i];
 				irdata[i].yhi = y[i] >> 8;
 
 				irdata[i].size = 10;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -557,7 +557,7 @@ bool CWII_IPC_HLE_Device_usb_oh1_57e_305::SendEventInquiryResponse()
 
 	_dbg_assert_(WII_IPC_WIIMOTE, sizeof(SHCIEventInquiryResult) - 2 + (m_WiiMotes.size() * sizeof(hci_inquiry_response)) < 256);
 
-	SQueuedEvent Event(static_cast<u32>(sizeof(SHCIEventInquiryResult) + m_WiiMotes.size()*sizeof(hci_inquiry_response)), 0);
+	SQueuedEvent Event((u32)(sizeof(SHCIEventInquiryResult) + m_WiiMotes.size()*sizeof(hci_inquiry_response)), 0);
 
 	SHCIEventInquiryResult* pInquiryResult = (SHCIEventInquiryResult*)Event.m_buffer;
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
@@ -109,20 +109,20 @@ float Interpreter::Helper_Dequantize(const u32 _Addr, const EQuantizeType _quant
 		break;
 
 	case QUANTIZE_U8:
-		fResult = static_cast<float>(Memory::Read_U8(_Addr)) * m_dequantizeTable[_uScale];
+		fResult = (float)Memory::Read_U8(_Addr) * m_dequantizeTable[_uScale];
 		break;
 
 	case QUANTIZE_U16:
-		fResult = static_cast<float>(Memory::Read_U16(_Addr)) * m_dequantizeTable[_uScale];
+		fResult = (float)Memory::Read_U16(_Addr) * m_dequantizeTable[_uScale];
 		break;
 
 	case QUANTIZE_S8:
-		fResult = static_cast<float>((s8)Memory::Read_U8(_Addr)) * m_dequantizeTable[_uScale];
+		fResult = (float)(s8)Memory::Read_U8(_Addr) * m_dequantizeTable[_uScale];
 		break;
 
 		// used for THP player
 	case QUANTIZE_S16:
-		fResult = static_cast<float>((s16)Memory::Read_U16(_Addr)) * m_dequantizeTable[_uScale];
+		fResult = (float)(s16)Memory::Read_U16(_Addr) * m_dequantizeTable[_uScale];
 		break;
 
 	default:

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -569,8 +569,8 @@ void Jit64::boolX(UGeckoInstruction inst)
 
 	if (gpr.R(s).IsImm() && gpr.R(b).IsImm())
 	{
-		const u32 rs_offset = static_cast<u32>(gpr.R(s).offset);
-		const u32 rb_offset = static_cast<u32>(gpr.R(b).offset);
+		const u32 rs_offset = (u32)gpr.R(s).offset;
+		const u32 rb_offset = (u32)gpr.R(b).offset;
 
 		if (inst.SUBOP10 == 28)       // andx
 			gpr.SetImmediate32(a, rs_offset & rb_offset);

--- a/Source/Core/DolphinWX/TASInputDlg.cpp
+++ b/Source/Core/DolphinWX/TASInputDlg.cpp
@@ -484,42 +484,42 @@ void TASInputDlg::GetValues(u8* data, WiimoteEmu::ReportFeatures rptf)
 		if (mode == 1)
 		{
 			memset(irData, 0xFF, sizeof(wm_ir_basic) * 2);
-			wm_ir_basic* data = (wm_ir_basic*)irData;
+			wm_ir_basic* irBasic = (wm_ir_basic*)irData;
 			for (unsigned int i = 0; i < 2; ++i)
 			{
 				if (x[i*2] < 1024 && y < 768)
 				{
-					data[i].x1 = static_cast<u8>(x[i*2]);
-					data[i].x1hi = x[i*2] >> 8;
+					irBasic[i].x1 = (u8)x[i*2];
+					irBasic[i].x1hi = x[i*2] >> 8;
 
-					data[i].y1 = static_cast<u8>(y);
-					data[i].y1hi = y >> 8;
+					irBasic[i].y1 = (u8)y;
+					irBasic[i].y1hi = y >> 8;
 				}
 				if (x[i*2+1] < 1024 && y < 768)
 				{
-					data[i].x2 = static_cast<u8>(x[i*2+1]);
-					data[i].x2hi = x[i*2+1] >> 8;
+					irBasic[i].x2 = (u8)x[i*2+1];
+					irBasic[i].x2hi = x[i*2+1] >> 8;
 
-					data[i].y2 = static_cast<u8>(y);
-					data[i].y2hi = y >> 8;
+					irBasic[i].y2 = (u8)y;
+					irBasic[i].y2hi = y >> 8;
 				}
 			}
 		}
 		else
 		{
 			memset(data, 0xFF, sizeof(wm_ir_extended) * 4);
-			wm_ir_extended* const data = (wm_ir_extended*)irData;
+			wm_ir_extended* const irExtended = (wm_ir_extended*)irData;
 			for (unsigned int i = 0; i < 4; ++i)
 			{
 				if (x[i] < 1024 && y < 768)
 				{
-					data[i].x = static_cast<u8>(x[i]);
-					data[i].xhi = x[i] >> 8;
+					irExtended[i].x = (u8)x[i];
+					irExtended[i].xhi = x[i] >> 8;
 
-					data[i].y = static_cast<u8>(y);
-					data[i].yhi = y >> 8;
+					irExtended[i].y = (u8)y;
+					irExtended[i].yhi = y >> 8;
 
-					data[i].size = 10;
+					irExtended[i].size = 10;
 				}
 			}
 		}

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -1210,7 +1210,7 @@ static const char* INTENSITY_FUNC_NAMES[2] = {
 bool PSTextureEncoder::SetStaticShader(unsigned int dstFormat, PEControl::PixelFormat srcFormat,
 	bool isIntensity, bool scaleByHalf)
 {
-	size_t fetchNum = static_cast<size_t>(srcFormat);
+	size_t fetchNum = (size_t)srcFormat;
 	size_t scaledFetchNum = scaleByHalf ? 1 : 0;
 	size_t intensityNum = isIntensity ? 1 : 0;
 	size_t generatorNum = dstFormat;
@@ -1243,7 +1243,7 @@ bool PSTextureEncoder::SetStaticShader(unsigned int dstFormat, PEControl::PixelF
 		}
 
 		INFO_LOG(VIDEO, "Compiling efb encoding shader for dstFormat 0x%X, srcFormat %d, isIntensity %d, scaleByHalf %d",
-			dstFormat, static_cast<int>(srcFormat), isIntensity ? 1 : 0, scaleByHalf ? 1 : 0);
+			dstFormat, (int)srcFormat, isIntensity ? 1 : 0, scaleByHalf ? 1 : 0);
 
 		// Shader permutation not found, so compile it
 		D3DBlob* bytecode = nullptr;
@@ -1257,7 +1257,7 @@ bool PSTextureEncoder::SetStaticShader(unsigned int dstFormat, PEControl::PixelF
 		if (!D3D::CompilePixelShader(EFB_ENCODE_PS, &bytecode, macros))
 		{
 			WARN_LOG(VIDEO, "EFB encoder shader for dstFormat 0x%X, srcFormat %d, isIntensity %d, scaleByHalf %d failed to compile",
-				dstFormat, static_cast<int>(srcFormat), isIntensity ? 1 : 0, scaleByHalf ? 1 : 0);
+				dstFormat, (int)srcFormat, isIntensity ? 1 : 0, scaleByHalf ? 1 : 0);
 			// Add dummy shader to map to prevent trying to compile over and
 			// over again
 			m_staticShaders[key] = nullptr;
@@ -1370,7 +1370,7 @@ static const char* INTENSITY_CLASS_NAMES[2] = {
 bool PSTextureEncoder::SetDynamicShader(unsigned int dstFormat,
 	PEControl::PixelFormat srcFormat, bool isIntensity, bool scaleByHalf)
 {
-	size_t fetchNum = static_cast<size_t>(srcFormat);
+	size_t fetchNum = (size_t)srcFormat;
 	size_t scaledFetchNum = scaleByHalf ? 1 : 0;
 	size_t intensityNum = isIntensity ? 1 : 0;
 	size_t generatorNum = dstFormat;

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -62,7 +62,7 @@ private:
 	ComboKey MakeComboKey(unsigned int dstFormat,
 		PEControl::PixelFormat srcFormat, bool isIntensity, bool scaleByHalf)
 	{
-		return (dstFormat << 4) | (static_cast<int>(srcFormat) << 2) | (isIntensity ? (1<<1) : 0)
+		return (dstFormat << 4) | ((int)srcFormat << 2) | (isIntensity ? (1<<1) : 0)
 			| (scaleByHalf ? (1<<0) : 0);
 	}
 

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -292,7 +292,7 @@ std::string OpenGLPostProcessing::LoadShaderOptions(const std::string& code)
 		}
 		else if (it.second.m_type == PostProcessingShaderConfiguration::ConfigurationOption::OptionType::OPTION_INTEGER)
 		{
-			u32 count = static_cast<u32>(it.second.m_integer_values.size());
+			u32 count = (u32)it.second.m_integer_values.size();
 			if (count == 1)
 				glsl_options += StringFromFormat("uniform int     option_%s;\n", it.first.c_str());
 			else
@@ -300,7 +300,7 @@ std::string OpenGLPostProcessing::LoadShaderOptions(const std::string& code)
 		}
 		else if (it.second.m_type == PostProcessingShaderConfiguration::ConfigurationOption::OptionType::OPTION_FLOAT)
 		{
-			u32 count = static_cast<u32>(it.second.m_float_values.size());
+			u32 count = (u32)it.second.m_float_values.size();
 			if (count == 1)
 				glsl_options += StringFromFormat("uniform float   option_%s;\n", it.first.c_str());
 			else

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -144,7 +144,7 @@ static void ApplySSAASettings()
 			if (g_ogl_config.bSupportSampleShading)
 			{
 				glEnable(GL_SAMPLE_SHADING_ARB);
-				GLfloat min_sample_shading_value = static_cast<GLfloat>(s_MSAASamples);
+				GLfloat min_sample_shading_value = (GLfloat)s_MSAASamples;
 				glMinSampleShadingARB(min_sample_shading_value);
 			}
 			else
@@ -844,7 +844,7 @@ void Renderer::DrawDebugInfo()
 
 		s_ShowEFBCopyRegions.Bind();
 		glBindVertexArray(s_ShowEFBCopyRegions_VAO);
-		GLsizei count = static_cast<GLsizei>(stats.efb_regions.size() * 2*6);
+		GLsizei count = (GLsizei)(stats.efb_regions.size() * 2*6);
 		glDrawArrays(GL_LINES, 0, count);
 
 		// Restore Line Size
@@ -1204,7 +1204,7 @@ void Renderer::SetViewport()
 	{
 		auto iceilf = [](float f)
 		{
-			return static_cast<GLint>(ceilf(f));
+			return (GLint)ceilf(f);
 		};
 		glViewport(iceilf(X), iceilf(Y), iceilf(Width), iceilf(Height));
 	}
@@ -1431,10 +1431,10 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 
 			if (g_ActiveConfig.bUseRealXFB)
 			{
-				drawRc.top      = static_cast<float>(flipped_trc.top);
-				drawRc.bottom   = static_cast<float>(flipped_trc.bottom);
-				drawRc.left     = static_cast<float>(flipped_trc.left);
-				drawRc.right    = static_cast<float>(flipped_trc.right);
+				drawRc.top      = (float)flipped_trc.top;
+				drawRc.bottom   = (float)flipped_trc.bottom;
+				drawRc.left     = (float)flipped_trc.left;
+				drawRc.right    = (float)flipped_trc.right;
 			}
 			else
 			{
@@ -1450,10 +1450,10 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 				rect_u32.left = flipped_trc.left + (flipped_trc.GetWidth() - xfbWidth * flipped_trc.GetWidth() / fbStride)/2;
 				rect_u32.right = flipped_trc.left + (flipped_trc.GetWidth() + xfbWidth * flipped_trc.GetWidth() / fbStride)/2;
 
-				drawRc.top      = static_cast<float>(rect_u32.top);
-				drawRc.bottom   = static_cast<float>(rect_u32.bottom);
-				drawRc.left     = static_cast<float>(rect_u32.left);
-				drawRc.right    = static_cast<float>(rect_u32.right);
+				drawRc.top      = (float)rect_u32.top;
+				drawRc.bottom   = (float)rect_u32.bottom;
+				drawRc.left     = (float)rect_u32.left;
+				drawRc.right    = (float)rect_u32.right;
 
 				// The following code disables auto stretch.  Kept for reference.
 				// scale draw area for a 1 to 1 pixel mapping with the draw target

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -293,8 +293,8 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 		}
 
 		TargetRectangle R = g_renderer->ConvertEFBRectangle(srcRect);
-		glUniform4f(uniform_location, static_cast<float>(R.left), static_cast<float>(R.top),
-			static_cast<float>(R.right), static_cast<float>(R.bottom));
+		glUniform4f(uniform_location, (float)R.left, (float)R.top,
+			(float)R.right, (float)R.bottom);
 		GL_REPORT_ERRORD();
 
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -345,8 +345,8 @@ void EncodeToRamYUYV(GLuint srcTexture, const TargetRectangle& sourceRc, u8* des
 
 	s_rgbToYuyvProgram.Bind();
 
-	glUniform4f(s_rgbToYuyvUniform_loc, static_cast<float>(sourceRc.left), static_cast<float>(sourceRc.top),
-		static_cast<float>(sourceRc.right), static_cast<float>(sourceRc.bottom));
+	glUniform4f(s_rgbToYuyvUniform_loc, (float)sourceRc.left, (float)sourceRc.top,
+		(float)sourceRc.right, (float)sourceRc.bottom);
 
 	// We enable linear filtering, because the gamecube does filtering in the vertical direction when
 	// yscale is enabled.

--- a/Source/Core/VideoBackends/Software/BPMemLoader.cpp
+++ b/Source/Core/VideoBackends/Software/BPMemLoader.cpp
@@ -63,11 +63,11 @@ void SWBPWritten(int address, int newvalue)
 		break;
 	case BPMEM_PE_TOKEN_ID: // Pixel Engine Token ID
 		DEBUG_LOG(VIDEO, "SetPEToken 0x%04x", (bpmem.petoken & 0xFFFF));
-		PixelEngine::SetToken(static_cast<u16>(bpmem.petokenint & 0xFFFF), false);
+		PixelEngine::SetToken((u16)bpmem.petokenint, false);
 		break;
 	case BPMEM_PE_TOKEN_INT_ID: // Pixel Engine Interrupt Token ID
 		DEBUG_LOG(VIDEO, "SetPEToken + INT 0x%04x", (bpmem.petokenint & 0xFFFF));
-		PixelEngine::SetToken(static_cast<u16>(bpmem.petokenint & 0xFFFF), true);
+		PixelEngine::SetToken((u16)bpmem.petokenint, true);
 		break;
 	case BPMEM_TRIGGER_EFB_COPY:
 		EfbCopy::CopyEfb();
@@ -154,8 +154,8 @@ void SWBPWritten(int address, int newvalue)
 			TevReg& reg = bpmem.tevregs[regNum];
 			bool is_konst = reg.type_ra != 0;
 
-			Rasterizer::SetTevReg(regNum, Tev::ALP_C, is_konst, static_cast<s16>(reg.alpha));
-			Rasterizer::SetTevReg(regNum, Tev::RED_C, is_konst, static_cast<s16>(reg.red));
+			Rasterizer::SetTevReg(regNum, Tev::ALP_C, is_konst, (s16)reg.alpha);
+			Rasterizer::SetTevReg(regNum, Tev::RED_C, is_konst, (s16)reg.red);
 
 			break;
 		}
@@ -169,8 +169,8 @@ void SWBPWritten(int address, int newvalue)
 			TevReg& reg = bpmem.tevregs[regNum];
 			bool is_konst = reg.type_bg != 0;
 
-			Rasterizer::SetTevReg(regNum, Tev::GRN_C, is_konst, static_cast<s16>(reg.green));
-			Rasterizer::SetTevReg(regNum, Tev::BLU_C, is_konst, static_cast<s16>(reg.blue));
+			Rasterizer::SetTevReg(regNum, Tev::GRN_C, is_konst, (s16)reg.green);
+			Rasterizer::SetTevReg(regNum, Tev::BLU_C, is_konst, (s16)reg.blue);
 
 			break;
 		}

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -55,7 +55,7 @@ namespace EfbInterface
 			}
 			break;
 		default:
-			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", (int)bpmem.zcontrol.pixel_format);
 		}
 	}
 
@@ -95,7 +95,7 @@ namespace EfbInterface
 			}
 			break;
 		default:
-			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", (int)bpmem.zcontrol.pixel_format);
 		}
 	}
 
@@ -136,7 +136,7 @@ namespace EfbInterface
 			}
 			break;
 		default:
-			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", (int)bpmem.zcontrol.pixel_format);
 		}
 	}
 
@@ -172,7 +172,7 @@ namespace EfbInterface
 			}
 			break;
 		default:
-			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", (int)bpmem.zcontrol.pixel_format);
 		}
 	}
 
@@ -200,7 +200,7 @@ namespace EfbInterface
 			}
 			break;
 		default:
-			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", (int)bpmem.zcontrol.pixel_format);
 		}
 	}
 
@@ -224,7 +224,7 @@ namespace EfbInterface
 			}
 			break;
 		default:
-			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", (int)bpmem.zcontrol.pixel_format);
 		}
 
 		return depth;

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -273,7 +273,7 @@ bool AVIDump::CreateFile()
 	s_stream->codec->bit_rate = 400000;
 	s_stream->codec->width = s_width;
 	s_stream->codec->height = s_height;
-	s_stream->codec->time_base = (AVRational){1, static_cast<int>(VideoInterface::TargetRefreshRate)};
+	s_stream->codec->time_base = (AVRational){1, (int)VideoInterface::TargetRefreshRate};
 	s_stream->codec->gop_size = 12;
 	s_stream->codec->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGRA : AV_PIX_FMT_YUV420P;
 

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -212,14 +212,14 @@ void OnPixelFormatChange()
 
 	if (convtype == -1)
 	{
-		ERROR_LOG(VIDEO, "Unhandled EFB format change: %d to %d\n", static_cast<int>(old_format), static_cast<int>(new_format));
+		ERROR_LOG(VIDEO, "Unhandled EFB format change: %d to %d\n", (int)old_format, (int)new_format);
 		goto skip;
 	}
 
 	g_renderer->ReinterpretPixelData(convtype);
 
 skip:
-	DEBUG_LOG(VIDEO, "pixelfmt: pixel=%d, zc=%d", static_cast<int>(new_format), static_cast<int>(bpmem.zcontrol.zformat));
+	DEBUG_LOG(VIDEO, "pixelfmt: pixel=%d, zc=%d", (int)new_format, (int)bpmem.zcontrol.zformat);
 
 	Renderer::StorePixelFormat(new_format);
 }

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -185,12 +185,12 @@ static void BPWritten(const BPCmd& bp)
 		return;
 	case BPMEM_PE_TOKEN_ID: // Pixel Engine Token ID
 		if (!g_use_deterministic_gpu_thread)
-			PixelEngine::SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), false);
+			PixelEngine::SetToken((u16)bp.newvalue, false);
 		DEBUG_LOG(VIDEO, "SetPEToken 0x%04x", (bp.newvalue & 0xFFFF));
 		return;
 	case BPMEM_PE_TOKEN_INT_ID: // Pixel Engine Interrupt Token ID
 		if (!g_use_deterministic_gpu_thread)
-			PixelEngine::SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), true);
+			PixelEngine::SetToken((u16)bp.newvalue, true);
 		DEBUG_LOG(VIDEO, "SetPEToken + INT 0x%04x", (bp.newvalue & 0xFFFF));
 		return;
 
@@ -241,7 +241,7 @@ static void BPWritten(const BPCmd& bp)
 
 				float num_xfb_lines = ((bpmem.copyTexSrcWH.y + 1.0f) * yScale);
 
-				u32 height = static_cast<u32>(num_xfb_lines);
+				u32 height = (u32)num_xfb_lines;
 				if (height > MAX_XFB_HEIGHT)
 				{
 					INFO_LOG(VIDEO, "Tried to scale EFB to too many XFB lines: %d (%f)",

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -107,8 +107,8 @@ void PixelShaderManager::SetConstants()
 
 	if (s_bViewPortChanged)
 	{
-		constants.zbias[1][0] = static_cast<u32>(xfmem.viewport.farZ);
-		constants.zbias[1][1] = static_cast<u32>(xfmem.viewport.zRange);
+		constants.zbias[1][0] = (u32)xfmem.viewport.farZ;
+		constants.zbias[1][1] = (u32)xfmem.viewport.zRange;
 		dirty = true;
 		s_bViewPortChanged = false;
 	}

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -285,7 +285,7 @@ void VertexShaderManager::SetConstants()
 			              double(light.ddir[1]) * double(light.ddir[1]) +
 			              double(light.ddir[2]) * double(light.ddir[2]);
 			norm = 1.0 / sqrt(norm);
-			float norm_float = static_cast<float>(norm);
+			float norm_float = (float)norm;
 			dstlight.dir[0] = light.ddir[0] * norm_float;
 			dstlight.dir[1] = light.ddir[1] * norm_float;
 			dstlight.dir[2] = light.ddir[2] * norm_float;


### PR DESCRIPTION
The semantics are the same, modulo mostly warning-filled pointer to
integer conversions.  There is no point making a simple cast stand out
more than the entire rest of the line (i.e. what the casted value is
being actually used for) with all those letters and brackets.

I have not verified whether all of these casts are actually necessary.
Also, I copied a variable rename from my previous cleanup PR to avoid
merge conflicts, and changed a series of former static_casts to u32 for
a %i argument to int (didn't touch %u, since that's painful either way).
