### PR TITLE
Removed old TODO comment

### DIFF
--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -56,7 +56,6 @@ public:
 private:
 	std::string m_FileName;
 
-	// TODO: eliminate this and overwrite with names from banner when available?
 	std::vector<std::string> m_volume_names;
 
 	// Stuff from banner


### PR DESCRIPTION
Dolphin already overrides the volume name with the banner name when available, so this comment is no longer needed.
