### PR TITLE
JIT: add basic register allocation heuristics

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -603,6 +603,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 		js.compilerPC = ops[i].address;
 		js.op = &ops[i];
 		js.instructionNumber = i;
+		js.instructionsLeft = (code_block.m_num_instructions - 1) - i;
 		const GekkoOPInfo *opinfo = ops[i].opinfo;
 		js.downcountAmount += opinfo->numCycles;
 
@@ -737,7 +738,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 			for (int k = 0; k < 3 && gpr.NumFreeRegisters() >= 2; k++)
 			{
 				int reg = ops[i].regsIn[k];
-				if (reg >= 0 && (ops[i].gprInUse & (1 << reg)) && !gpr.R(reg).IsImm())
+				if (reg >= 0 && (ops[i].gprInReg & (1 << reg)) && !gpr.R(reg).IsImm())
 					gpr.BindToRegister(reg, true, false);
 			}
 			for (int k = 0; k < 4 && fpr.NumFreeRegisters() >= 2; k++)

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -20,7 +20,6 @@ struct PPCCachedReg
 	Gen::OpArg location;
 	bool away;  // value not in source register
 	bool locked;
-	u32 last_used_quantum;
 };
 
 struct X64CachedReg
@@ -44,9 +43,12 @@ protected:
 
 	virtual const int *GetAllocationOrder(size_t& count) = 0;
 
+	virtual u32 GetRegUtilization() = 0;
+	virtual u32 CountRegsIn(size_t preg, u32 lookahead) = 0;
+
 	Gen::XEmitter *emit;
 
-	u32 cur_use_quantum;
+	float ScoreRegister(Gen::X64Reg xreg);
 
 public:
 	RegCache();
@@ -134,6 +136,8 @@ public:
 	Gen::OpArg GetDefaultLocation(size_t reg) const override;
 	const int* GetAllocationOrder(size_t& count) override;
 	void SetImmediate32(size_t preg, u32 immValue);
+	u32 GetRegUtilization();
+	u32 CountRegsIn(size_t preg, u32 lookahead);
 };
 
 
@@ -144,4 +148,6 @@ public:
 	void LoadRegister(size_t preg, Gen::X64Reg newLoc) override;
 	const int* GetAllocationOrder(size_t& count) override;
 	Gen::OpArg GetDefaultLocation(size_t reg) const override;
+	u32 GetRegUtilization();
+	u32 CountRegsIn(size_t preg, u32 lookahead);
 };

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -74,6 +74,7 @@ protected:
 		u32 blockStart;
 		UGeckoInstruction next_inst;  // for easy peephole opt.
 		int instructionNumber;
+		int instructionsLeft;
 		int downcountAmount;
 		u32 numLoadStoreInst;
 		u32 numFloatingPointInst;

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -43,8 +43,10 @@ struct CodeOp //16B
 	bool canEndBlock;
 	bool skip;  // followed BL-s for example
 	// which registers are still needed after this instruction in this block
-	u32 gprInUse;
 	u32 fprInUse;
+	u32 gprInUse;
+	// just because a register is in use doesn't mean we actually need or want it in an x86 register.
+	u32 gprInReg;
 	// we do double stores from GPRs, so we don't want to load a PowerPC floating point register into
 	// an XMM only to move it again to a GPR afterwards.
 	u32 fprInXmm;


### PR DESCRIPTION
Should be at least a bit better than the previous LRU approach. Currently
has two basic components: whether a register is dirty (dirty registers need
to be stored, so clobbering them hurts more) and how many other registers will
be used between now and the next time a register gets used.

Also don't pre-load values that don't need to be in registers.
