### PR TITLE
Adds support for textureGather to the PP shader system.

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -54,6 +54,8 @@ static std::string GetGLSLVersionString()
 			return "#version 140";
 		case GLSL_150:
 			return "#version 150";
+		case GLSL_400:
+			return "#version 400";
 	}
 	// Shouldn't ever hit this
 	return "#version ERROR";

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -494,22 +494,36 @@ Renderer::Renderer()
 	}
 	else
 	{
-		if (strstr(g_ogl_config.glsl_version, "1.00") || strstr(g_ogl_config.glsl_version, "1.10") || strstr(g_ogl_config.glsl_version, "1.20"))
+		// Grab the GLSL version as a integer
+		u32 glsl_version = 0;
+		u32 glsl_major = 0;
+		u32 glsl_minor = 0;
+		std::string glsl_version_string;
+		std::istringstream buffer(g_ogl_config.glsl_version);
+		buffer >> glsl_version_string;
+		sscanf(glsl_version_string.c_str(), "%d.%d", &glsl_major, &glsl_minor);
+		glsl_version = glsl_major * 100 + glsl_minor;
+
+		if (glsl_version <= 120)
 		{
 			PanicAlert("GPU: OGL ERROR: Need at least GLSL 1.30\n"
 					"GPU: Does your video card support OpenGL 3.0?\n"
 					"GPU: Your driver supports GLSL %s", g_ogl_config.glsl_version);
 			bSuccess = false;
 		}
-		else if (strstr(g_ogl_config.glsl_version, "1.30"))
+		else if (glsl_version == 130)
 		{
 			g_ogl_config.eSupportedGLSLVersion = GLSL_130;
 			g_Config.backend_info.bSupportsEarlyZ = false; // layout keyword is only supported on glsl150+
 		}
-		else if (strstr(g_ogl_config.glsl_version, "1.40"))
+		else if (glsl_version == 140)
 		{
 			g_ogl_config.eSupportedGLSLVersion = GLSL_140;
 			g_Config.backend_info.bSupportsEarlyZ = false; // layout keyword is only supported on glsl150+
+		}
+		else if (glsl_version >= 400)
+		{
+			g_ogl_config.eSupportedGLSLVersion = GLSL_400;
 		}
 		else
 		{

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -12,7 +12,8 @@ enum GLSL_VERSION
 {
 	GLSL_130,
 	GLSL_140,
-	GLSL_150,  // and above
+	GLSL_150,
+	GLSL_400, // and above
 	GLSLES_300,  // GLES 3.0
 	GLSLES_310, // GLES 3.1
 };


### PR DESCRIPTION
This adds two new functions to the PP shader system, SampleGather and SampleGatherOffset.

These two functions use textureGather and textureGatherOffset if the graphics drivers support GLSL 4.00 or GLSL ES 3.10.
If a system doesn't support GLSL 4.00 but supports GL_ARB_texture_gather then it will attempt to use textureGather if you only need the red component.
In the event that the system doesn't support anything, it will fall back to a costly operation of many texture fetch instructions.