### PR TITLE
AVIDump: Add missing CoreTiming header

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -13,6 +13,7 @@
 #include "Common/StringUtil.h"
 #include "Common/Logging/Log.h"
 
+#include "Core/CoreTiming.h"
 #include "Core/HW/VideoInterface.h" //for TargetRefreshRate
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/VideoConfig.h"


### PR DESCRIPTION
Fixes build on the mesa buildbot
