### PR TITLE
Corrected the physical memory access to MEM2 via the MMU. Fixes Toy Story 3.

### DIFF
--- a/Source/Core/Core/HW/MemmapFunctions.cpp
+++ b/Source/Core/Core/HW/MemmapFunctions.cpp
@@ -694,8 +694,6 @@ void SDRUpdated()
 
 
 // TLB cache
-//#define FAST_TLB_CACHE
-
 #define TLB_SIZE 128
 #define TLB_WAYS 2
 #define NUM_TLBS 2
@@ -715,62 +713,39 @@ struct tlb_entry
 };
 
 // TODO: tlb needs to be in ppcState for save-state purposes.
-#ifdef FAST_TLB_CACHE
 static tlb_entry tlb[NUM_TLBS][TLB_SIZE/TLB_WAYS][TLB_WAYS];
-#endif
 
 static u32 LookupTLBPageAddress(const XCheckTLBFlag _Flag, const u32 vpa, u32 *paddr)
 {
-#ifdef FAST_TLB_CACHE
 	tlb_entry *tlbe = tlb[_Flag == FLAG_OPCODE][(vpa>>HW_PAGE_INDEX_SHIFT)&HW_PAGE_INDEX_MASK];
 	if (tlbe[0].tag == (vpa & ~0xfff) && !(tlbe[0].flags & TLB_FLAG_INVALID))
 	{
-		tlbe[0].flags |= TLB_FLAG_MOST_RECENT;
-		tlbe[1].flags &= ~TLB_FLAG_MOST_RECENT;
+		if (_Flag != FLAG_NO_EXCEPTION)
+		{
+			tlbe[0].flags |= TLB_FLAG_MOST_RECENT;
+			tlbe[1].flags &= ~TLB_FLAG_MOST_RECENT;
+		}
 		*paddr = tlbe[0].paddr | (vpa & 0xfff);
 		return 1;
 	}
 	if (tlbe[1].tag == (vpa & ~0xfff) && !(tlbe[1].flags & TLB_FLAG_INVALID))
 	{
-		tlbe[1].flags |= TLB_FLAG_MOST_RECENT;
-		tlbe[0].flags &= ~TLB_FLAG_MOST_RECENT;
+		if (_Flag != FLAG_NO_EXCEPTION)
+		{
+			tlbe[1].flags |= TLB_FLAG_MOST_RECENT;
+			tlbe[0].flags &= ~TLB_FLAG_MOST_RECENT;
+		}
 		*paddr = tlbe[1].paddr | (vpa & 0xfff);
 		return 1;
 	}
 	return 0;
-#else
-	u32 _Address = vpa;
-	if (_Flag == FLAG_OPCODE)
-	{
-		for (u32 i = (PowerPC::ppcState.itlb_last); i > (PowerPC::ppcState.itlb_last - 128); i--)
-		{
-			if ((_Address & ~0xfff) == (PowerPC::ppcState.itlb_va[i & 127]))
-			{
-				*paddr = PowerPC::ppcState.itlb_pa[i & 127] | (_Address & 0xfff);
-				PowerPC::ppcState.itlb_last = i;
-				return 1;
-			}
-		}
-	}
-	else
-	{
-		for (u32 i = (PowerPC::ppcState.dtlb_last); i > (PowerPC::ppcState.dtlb_last - 128); i--)
-		{
-			if ((_Address & ~0xfff) == (PowerPC::ppcState.dtlb_va[i & 127]))
-			{
-				*paddr = PowerPC::ppcState.dtlb_pa[i & 127] | (_Address & 0xfff);
-				PowerPC::ppcState.dtlb_last = i;
-				return 1;
-			}
-		}
-	}
-	return 0;
-#endif
 }
 
 static void UpdateTLBEntry(const XCheckTLBFlag _Flag, UPTE2 PTE2, const u32 vpa)
 {
-#ifdef FAST_TLB_CACHE
+	if (_Flag != FLAG_NO_EXCEPTION)
+		return;
+
 	tlb_entry *tlbe = tlb[_Flag == FLAG_OPCODE][(vpa>>HW_PAGE_INDEX_SHIFT)&HW_PAGE_INDEX_MASK];
 	if ((tlbe[0].flags & TLB_FLAG_MOST_RECENT) == 0)
 	{
@@ -786,29 +761,10 @@ static void UpdateTLBEntry(const XCheckTLBFlag _Flag, UPTE2 PTE2, const u32 vpa)
 		tlbe[1].paddr = PTE2.RPN << HW_PAGE_INDEX_SHIFT;
 		tlbe[1].tag = vpa & ~0xfff;
 	}
-#else
-	if (_Flag == FLAG_OPCODE)
-	{
-		// ITLB cache
-		PowerPC::ppcState.itlb_last++;
-		PowerPC::ppcState.itlb_last &= 127;
-		PowerPC::ppcState.itlb_pa[PowerPC::ppcState.itlb_last] = PTE2.RPN << HW_PAGE_INDEX_SHIFT;
-		PowerPC::ppcState.itlb_va[PowerPC::ppcState.itlb_last] = vpa & ~0xfff;
-	}
-	else
-	{
-		// DTLB cache
-		PowerPC::ppcState.dtlb_last++;
-		PowerPC::ppcState.dtlb_last &= 127;
-		PowerPC::ppcState.dtlb_pa[PowerPC::ppcState.dtlb_last] = PTE2.RPN << HW_PAGE_INDEX_SHIFT;
-		PowerPC::ppcState.dtlb_va[PowerPC::ppcState.dtlb_last] = vpa & ~0xfff;
-	}
-#endif
 }
 
 void InvalidateTLBEntry(u32 vpa)
 {
-#ifdef FAST_TLB_CACHE
 	tlb_entry *tlbe = tlb[0][(vpa>>HW_PAGE_INDEX_SHIFT)&HW_PAGE_INDEX_MASK];
 	if (tlbe[0].tag == (vpa & ~0xfff))
 	{
@@ -827,22 +783,6 @@ void InvalidateTLBEntry(u32 vpa)
 	{
 		tlbe_i[1].flags |= TLB_FLAG_INVALID;
 	}
-#else
-	u32 _Address = vpa;
-	for (int i = 0; i < 128; i++)
-	{
-		if ((_Address & ~0xfff) == (PowerPC::ppcState.dtlb_va[(PowerPC::ppcState.dtlb_last + i) & 127]))
-		{
-			PowerPC::ppcState.dtlb_pa[(PowerPC::ppcState.dtlb_last + i) & 127] = 0;
-			PowerPC::ppcState.dtlb_va[(PowerPC::ppcState.dtlb_last + i) & 127] = 0;
-		}
-		if ((_Address & ~0xfff) == (PowerPC::ppcState.itlb_va[(PowerPC::ppcState.itlb_last + i) & 127]))
-		{
-			PowerPC::ppcState.itlb_pa[(PowerPC::ppcState.itlb_last + i) & 127] = 0;
-			PowerPC::ppcState.itlb_va[(PowerPC::ppcState.itlb_last + i) & 127] = 0;
-		}
-	}
-#endif
 }
 
 // Page Address Translation


### PR DESCRIPTION
Disney Infinity needs the "Skip DCBZ clearing" option enabled for it to boot.  Fixed and enabled the FAST_TLB_CACHE by default.
