### PR TITLE
Flipped Wave File Channels for Audio Dumping

### DIFF
--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -137,8 +137,12 @@ void WaveFileWriter::AddStereoSamplesBE(const short *sample_data, u32 count)
 			return;
 	}
 
-	for (u32 i = 0; i < count * 2; i++)
-		conv_buffer[i] = Common::swap16((u16)sample_data[i]);
+	for (u32 i = 0; i < count; i++)
+	{
+		//Flip the audio channels from RL to LR
+		conv_buffer[2 * i] = Common::swap16((u16)sample_data[2 * i + 1]);
+		conv_buffer[2 * i + 1] = Common::swap16((u16)sample_data[2 * i]);
+	}
 
 	file.WriteBytes(conv_buffer, count * 4);
 	audio_size += count * 4;


### PR DESCRIPTION
This change was done because with the previous method of dumping audio, the mixer would handle switching the RL being emitted by the DSP to LR, and thus would provide the proper channel orientation. Because we're now dumping directly from PushSamples() and PushStreamingSamples(), it was writing the right channel to the left channel of the wave file and vice versa.
