### PR TITLE
ControllerInterface: Get rid of SetHwnd(), introduce Reinitialize()

### DIFF
--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -40,8 +40,7 @@ void Initialize(void* const hwnd)
 	for (unsigned int i=0; i<4; ++i)
 		s_config.controllers.push_back(new GCPad(i));
 
-	g_controller_interface.SetHwnd(hwnd);
-	g_controller_interface.Initialize();
+	g_controller_interface.Initialize(hwnd);
 
 	// load the saved controller config
 	s_config.LoadConfig(true);

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -44,9 +44,7 @@ void Initialize(void* const hwnd, bool wait)
 	for (unsigned int i = WIIMOTE_CHAN_0; i<MAX_BBMOTES; ++i)
 		s_config.controllers.push_back(new WiimoteEmu::Wiimote(i));
 
-
-	g_controller_interface.SetHwnd(hwnd);
-	g_controller_interface.Initialize();
+	g_controller_interface.Initialize(hwnd);
 
 	s_config.LoadConfig(false);
 

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -745,8 +745,7 @@ void GamepadPage::RefreshDevices(wxCommandEvent&)
 	std::lock_guard<std::recursive_mutex> lk(m_config.controls_lock);
 
 	// refresh devices
-	g_controller_interface.Shutdown();
-	g_controller_interface.Initialize();
+	g_controller_interface.Reinitialize();
 
 	// update all control references
 	m_config_dialog->UpdateControlReferences();

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -41,25 +41,27 @@ ControllerInterface g_controller_interface;
 //
 // Detect devices and inputs outputs / will make refresh function later
 //
-void ControllerInterface::Initialize()
+void ControllerInterface::Initialize(void* const hwnd)
 {
 	if (m_is_init)
 		return;
 
+	m_hwnd = hwnd;
+
 #ifdef CIFACE_USE_DINPUT
-	ciface::DInput::Init(m_devices, (HWND)m_hwnd);
+	ciface::DInput::Init(m_devices, (HWND)hwnd);
 #endif
 #ifdef CIFACE_USE_XINPUT
 	ciface::XInput::Init(m_devices);
 #endif
 #ifdef CIFACE_USE_XLIB
-	ciface::Xlib::Init(m_devices, m_hwnd);
+	ciface::Xlib::Init(m_devices, hwnd);
 	#ifdef CIFACE_USE_X11_XINPUT2
-	ciface::XInput2::Init(m_devices, m_hwnd);
+	ciface::XInput2::Init(m_devices, hwnd);
 	#endif
 #endif
 #ifdef CIFACE_USE_OSX
-	ciface::OSX::Init(m_devices, m_hwnd);
+	ciface::OSX::Init(m_devices, hwnd);
 #endif
 #ifdef CIFACE_USE_SDL
 	ciface::SDL::Init(m_devices);
@@ -69,6 +71,15 @@ void ControllerInterface::Initialize()
 #endif
 
 	m_is_init = true;
+}
+
+void ControllerInterface::Reinitialize()
+{
+	if (!m_is_init)
+		return;
+
+	Shutdown();
+	Initialize(m_hwnd);
 }
 
 //
@@ -117,16 +128,6 @@ void ControllerInterface::Shutdown()
 #endif
 
 	m_is_init = false;
-}
-
-//
-// SetHwnd
-//
-// Sets the hwnd used for some crap when initializing, use before calling Init
-//
-void ControllerInterface::SetHwnd( void* const hwnd )
-{
-	m_hwnd = hwnd;
 }
 
 //

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -114,8 +114,8 @@ public:
 
 	ControllerInterface() : m_is_init(false), m_hwnd(nullptr) {}
 
-	void SetHwnd(void* const hwnd);
-	void Initialize();
+	void Initialize(void* const hwnd);
+	void Reinitialize();
 	void Shutdown();
 	bool IsInit() const { return m_is_init; }
 


### PR DESCRIPTION
Initialize now just takes the handle directly. Reinitialize is added because it is much more straightforward in comparison to doing the Shutdown-Initialize process manually.
