### PR TITLE
MMU: disable BAT resolution

### DIFF
--- a/Source/Core/Core/HW/MemmapFunctions.cpp
+++ b/Source/Core/Core/HW/MemmapFunctions.cpp
@@ -967,20 +967,12 @@ u32 TranslateAddress(const u32 _Address, const XCheckTLBFlag _Flag)
 	// Check MSR[DR] bit before translating data addresses
 	//if (((_Flag == FLAG_READ) || (_Flag == FLAG_WRITE)) && !(MSR & (1 << (31 - 27)))) return _Address;
 
-	u32 tlb_addr = TranslateBlockAddress(_Address, _Flag);
-	if (tlb_addr == 0)
-	{
-		tlb_addr = TranslatePageAddress(_Address, _Flag);
-		if (tlb_addr != 0)
-		{
-			return tlb_addr;
-		}
-	}
-	else
-	{
-		return tlb_addr;
-	}
-
-	return 0;
+	// Technically we should do this, but no known games, even heavy MMU ones, use any custom BATs whatsoever,
+	// so it's a waste of time and should never succeed (given the default BATs are already handled in
+	// ReadFromHardware/WriteToHardware).
+	//u32 tlb_addr = TranslateBlockAddress(_Address, _Flag);
+	//if (!tlb_addr)
+	//	return tlb_addr;
+	return TranslatePageAddress(_Address, _Flag);
 }
 } // namespace


### PR DESCRIPTION
No known games, not even Wii MMU games like Cars 2 and Toy Story 3, use custom
BATs. This makes BAT resolution a waste of time. BAT handling could be
optimized significantly, but as long as nothing uses it, it's easier to just
disable it.

Should significantly improve performance in MMU-heavy games.
