### PR TITLE
PixelShaderGen: replace multiplication with shift

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -894,7 +894,7 @@ static inline void WriteTevRegular(T& out, const char* components, int bias, int
 	// - a rounding bias is added before dividing by 256
 	out.Write("(((tevin_d.%s%s)%s)", components, tevBiasTable[bias], tevScaleTableLeft[shift]);
 	out.Write(" %s ", tevOpTable[op]);
-	out.Write("((((tevin_a.%s*256 + (tevin_b.%s-tevin_a.%s)*(tevin_c.%s+(tevin_c.%s>>7)))%s)%s)>>8)",
+	out.Write("(((((tevin_a.%s<<8) + (tevin_b.%s-tevin_a.%s)*(tevin_c.%s+(tevin_c.%s>>7)))%s)%s)>>8)",
 	          components, components, components, components, components,
 	          tevScaleTableLeft[shift], tevLerpBias[2*op+(shift!=3)]);
 	out.Write(")%s", tevScaleTableRight[shift]);


### PR DESCRIPTION
iirc both nvidia and i965 doesn't optimize this
