### PR TITLE
JIT: remove "accurate fcmp" option

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -176,7 +176,6 @@ void Jit64::Init()
 	jo.optimizeStack = true;
 	EnableBlockLink();
 
-	jo.fpAccurateFcmp = SConfig::GetInstance().m_LocalCoreStartupParameter.bFPRF;
 	jo.optimizeGatherPipe = true;
 	jo.fastInterrupts = false;
 	jo.accurateSinglePrecision = true;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -369,7 +369,6 @@ void Jit64::fcmpx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
-	FALLBACK_IF(jo.fpAccurateFcmp);
 
 	FloatCompare(inst);
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -386,7 +386,6 @@ void Jit64::ps_cmpXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
-	FALLBACK_IF(jo.fpAccurateFcmp);
 
 	FloatCompare(inst, !!(inst.SUBOP10 & 64));
 }

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -246,7 +246,6 @@ void JitIL::Init()
 	jo.optimizeStack = true;
 	EnableBlockLink();
 
-	jo.fpAccurateFcmp = false;
 	jo.optimizeGatherPipe = true;
 	jo.fastInterrupts = false;
 	jo.accurateSinglePrecision = false;

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -62,7 +62,6 @@ protected:
 	{
 		bool optimizeStack;
 		bool enableBlocklink;
-		bool fpAccurateFcmp;
 		bool optimizeGatherPipe;
 		bool fastInterrupts;
 		bool accurateSinglePrecision;


### PR DESCRIPTION
Needs testing to be sure nothing actually breaks, but this shouldn't be
necessary anymore.

TODO: do we need the sNAN exceptiony stuff to be implemented in the JIT?
