### PR TITLE
Remove setting to enable or disable Bounding Box calculation.

### DIFF
--- a/Data/Sys/GameSettings/G8ME01.ini
+++ b/Data/Sys/GameSettings/G8ME01.ini
@@ -47,7 +47,6 @@ $Max Shop Points
 026EE7F0 000003E7
 
 [Video]
-UseBBox = 1
 ProjectionHack = 0
 PH_SZNear = 0
 PH_SZFar = 0

--- a/Data/Sys/GameSettings/G8MJ01.ini
+++ b/Data/Sys/GameSettings/G8MJ01.ini
@@ -17,9 +17,6 @@ EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-UseBBox = True
-
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True

--- a/Data/Sys/GameSettings/G8MP01.ini
+++ b/Data/Sys/GameSettings/G8MP01.ini
@@ -17,9 +17,6 @@ EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-UseBBox = True
-
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBCopyEnable = True

--- a/Data/Sys/GameSettings/GDME01.ini
+++ b/Data/Sys/GameSettings/GDME01.ini
@@ -8,9 +8,6 @@
 EmulationStateId = 3
 EmulationIssues =
 
-[Video]
-UseBBox = True
-
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 

--- a/Data/Sys/GameSettings/GDMJ01.ini
+++ b/Data/Sys/GameSettings/GDMJ01.ini
@@ -8,9 +8,6 @@
 EmulationStateId = 3
 EmulationIssues =
 
-[Video]
-UseBBox = True
-
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 

--- a/Data/Sys/GameSettings/GDMP01.ini
+++ b/Data/Sys/GameSettings/GDMP01.ini
@@ -8,9 +8,6 @@
 EmulationStateId = 3
 EmulationIssues =
 
-[Video]
-UseBBox = True
-
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 

--- a/Data/Sys/GameSettings/GHVE08.ini
+++ b/Data/Sys/GameSettings/GHVE08.ini
@@ -8,9 +8,6 @@
 EmulationStateId = 4
 EmulationIssues =
 
-[Video]
-UseBBox = True
-
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 

--- a/Data/Sys/GameSettings/GHVP08.ini
+++ b/Data/Sys/GameSettings/GHVP08.ini
@@ -8,9 +8,6 @@
 EmulationStateId = 4
 EmulationIssues = 
 
-[Video]
-UseBBox = True
-
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 

--- a/Data/Sys/GameSettings/GSZP41.ini
+++ b/Data/Sys/GameSettings/GSZP41.ini
@@ -25,5 +25,3 @@ PH_SZFar = 0
 PH_ExtraParam = 0
 PH_ZNear =
 PH_ZFar =
-UseBBox = 1
-

--- a/Data/Sys/GameSettings/R8PE01.ini
+++ b/Data/Sys/GameSettings/R8PE01.ini
@@ -19,7 +19,6 @@ EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
 # Add action replay cheats here.
 
 [Video]
-UseBBox = True
 ProjectionHack = 0
 
 [Video_Hacks]

--- a/Data/Sys/GameSettings/R8PJ01.ini
+++ b/Data/Sys/GameSettings/R8PJ01.ini
@@ -18,7 +18,6 @@ EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
 # Add action replay cheats here.
 
 [Video]
-UseBBox = True
 ProjectionHack = 0
 
 [Video_Hacks]

--- a/Data/Sys/GameSettings/R8PK01.ini
+++ b/Data/Sys/GameSettings/R8PK01.ini
@@ -18,7 +18,6 @@ EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
 # Add action replay cheats here.
 
 [Video]
-UseBBox = True
 ProjectionHack = 0
 
 [Video_Hacks]

--- a/Data/Sys/GameSettings/R8PP01.ini
+++ b/Data/Sys/GameSettings/R8PP01.ini
@@ -18,7 +18,6 @@ EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
 # Add action replay cheats here.
 
 [Video]
-UseBBox = True
 ProjectionHack = 0
 
 [Video_Hacks]

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -403,10 +403,6 @@ void CISOProperties::CreateGUIControls(bool IsWad)
 	// Wii Console
 	EnableWideScreen = new wxCheckBox(m_GameConfig, ID_ENABLEWIDESCREEN, _("Enable WideScreen"), wxDefaultPosition, wxDefaultSize, GetElementStyle("Wii", "Widescreen"));
 
-	// Video
-	UseBBox = new wxCheckBox(m_GameConfig, ID_USE_BBOX, _("Enable Bounding Box Calculation"), wxDefaultPosition, wxDefaultSize, GetElementStyle("Video", "UseBBox"));
-	UseBBox->SetToolTip(_("If checked, the bounding box registers will be updated. Used by the Paper Mario games."));
-
 	wxBoxSizer* const sEmuState = new wxBoxSizer(wxHORIZONTAL);
 	wxStaticText* const EmuStateText = new wxStaticText(m_GameConfig, wxID_ANY, _("Emulation State: "));
 	arrayStringFor_EmuState.Add(_("Not Set"));
@@ -439,14 +435,10 @@ void CISOProperties::CreateGUIControls(bool IsWad)
 	}
 	sbWiiOverrides->Add(EnableWideScreen, 0, wxLEFT, 5);
 
-	wxStaticBoxSizer * const sbVideoOverrides = new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Video"));
-	sbVideoOverrides->Add(UseBBox, 0, wxLEFT, 5);
-
 	wxStaticBoxSizer * const sbGameConfig = new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Game-Specific Settings"));
 	sbGameConfig->Add(OverrideText, 0, wxEXPAND|wxALL, 5);
 	sbGameConfig->Add(sbCoreOverrides, 0, wxEXPAND);
 	sbGameConfig->Add(sbWiiOverrides, 0, wxEXPAND);
-	sbGameConfig->Add(sbVideoOverrides, 0, wxEXPAND);
 	sConfigPage->Add(sbGameConfig, 0, wxEXPAND|wxALL, 5);
 	sEmuState->Add(EmuStateText, 0, wxALIGN_CENTER_VERTICAL);
 	sEmuState->Add(EmuState, 0, wxEXPAND);
@@ -1017,7 +1009,6 @@ void CISOProperties::LoadGameConfig()
 	SetCheckboxValueFromGameini("Core", "BlockMerging", BlockMerging);
 	SetCheckboxValueFromGameini("Core", "DSPHLE", DSPHLE);
 	SetCheckboxValueFromGameini("Wii", "Widescreen", EnableWideScreen);
-	SetCheckboxValueFromGameini("Video", "UseBBox", UseBBox);
 
 	IniFile::Section* default_video = GameIniDefault.GetOrCreateSection("Video");
 
@@ -1091,7 +1082,6 @@ bool CISOProperties::SaveGameConfig()
 	SaveGameIniValueFrom3StateCheckbox("Core", "BlockMerging", BlockMerging);
 	SaveGameIniValueFrom3StateCheckbox("Core", "DSPHLE", DSPHLE);
 	SaveGameIniValueFrom3StateCheckbox("Wii", "Widescreen", EnableWideScreen);
-	SaveGameIniValueFrom3StateCheckbox("Video", "UseBBox", UseBBox);
 
 	#define SAVE_IF_NOT_DEFAULT(section, key, val, def) do { \
 		if (GameIniDefault.Exists((section), (key))) { \

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -71,8 +71,6 @@ private:
 	wxCheckBox *VBeam, *SyncGPU, *FastDiscSpeed, *BlockMerging, *DSPHLE;
 	// Wii
 	wxCheckBox *EnableWideScreen;
-	// Video
-	wxCheckBox *UseBBox;
 
 	wxArrayString arrayStringFor_EmuState;
 	wxChoice *EmuState;

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -171,8 +171,7 @@ void VertexLoader::CompileVertexTranslator()
 #endif
 
 	// Get the pointer to this vertex's buffer data for the bounding box
-	if (g_ActiveConfig.bUseBBox)
-		WriteCall(BoundingBox::SetVertexBufferPosition);
+	WriteCall(BoundingBox::SetVertexBufferPosition);
 
 	// Colors
 	const u64 col[2] = {m_VtxDesc.Color0, m_VtxDesc.Color1};
@@ -382,8 +381,7 @@ void VertexLoader::CompileVertexTranslator()
 	}
 
 	// Update the bounding box
-	if (g_ActiveConfig.bUseBBox)
-		WriteCall(BoundingBox::Update);
+	WriteCall(BoundingBox::Update);
 
 	if (m_VtxDesc.PosMatIdx)
 	{

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -195,7 +195,6 @@ void VideoConfig::GameIniLoad()
 	CHECK_SETTING("Video", "PH_SZFar", iPhackvalue[2]);
 	CHECK_SETTING("Video", "PH_ZNear", sPhackvalue[0]);
 	CHECK_SETTING("Video", "PH_ZFar", sPhackvalue[1]);
-	CHECK_SETTING("Video", "UseBBox", bUseBBox);
 	CHECK_SETTING("Video", "PerfQueriesEnable", bPerfQueriesEnable);
 
 	if (gfx_override_exists)

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -114,7 +114,6 @@ struct VideoConfig final
 	int iPhackvalue[3];
 	std::string sPhackvalue[2];
 	float fAspectRatioHackW, fAspectRatioHackH;
-	bool bUseBBox;
 	bool bEnablePixelLighting;
 	bool bFastDepthCalc;
 	int iLog; // CONF_ bits


### PR DESCRIPTION
This shouldn't be needed anymore as bounding box is working properly and isn't crashing any games that use it.

This shouldn't have any performance or gameplay impact on games that don't use bbox (i. e. all but 4 GC/Wii games). I tested a few games and noticed no impact.
