### PR TITLE
Start/Stop Audio Dump During Emulation

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -21,4 +21,6 @@ namespace AudioCommon
 	void UpdateSoundStream();
 	void ClearAudioBuffer(bool mute);
 	void SendAIBuffer(short* samples, unsigned int num_samples);
+	void StartAudioDump();
+	void StopAudioDump();
 }


### PR DESCRIPTION
Allows the user to start and stop audio dumping during emulation, helpful for those trying to record video and audio during a certain part of the game.
