### PR TITLE
If the stack overflow trap region has already been tripped, don't continue to ignore faults there.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -150,7 +150,7 @@ bool Jit64::HandleFault(uintptr_t access_address, SContext* ctx)
 {
 	uintptr_t stack = (uintptr_t)m_stack, diff = access_address - stack;
 	// In the trap region?
-	if (stack && diff >= GUARD_OFFSET && diff < GUARD_OFFSET + GUARD_SIZE)
+	if (m_enable_blr_optimization && diff >= GUARD_OFFSET && diff < GUARD_OFFSET + GUARD_SIZE)
 	{
 		WARN_LOG(POWERPC, "BLR cache disabled due to excessive BL in the emulated program.");
 		m_enable_blr_optimization = false;


### PR DESCRIPTION
In the unlikely case that it tripped and then, due to a bug, some other
fault occurred (e.g. stack misalignment), Dolphin would go into an
infinite loop rather than crashing.
