### PR TITLE
JIT: fix profiler on non-Windows OSs

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -568,7 +568,8 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	// Conditionally add profiling code.
 	if (Profiler::g_ProfileBlocks)
 	{
-		ADD(32, M(&b->runCount), Imm8(1));
+		MOV(64, R(RSCRATCH), Imm64((u64)&b->runCount));
+		ADD(32, MatR(RSCRATCH), Imm8(1));
 #ifdef _WIN32
 		b->ticCounter = 0;
 		b->ticStart = 0;


### PR DESCRIPTION
Still doesn't support timing code (since that's Windows-only), but run counts
will at least work without crashing.
