### PR TITLE
Change driver details to reflect Qualcomm's changes with their v95 driver

### DIFF
--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -40,7 +40,7 @@ namespace DriverDetails
 	// This is a list of all known bugs for each vendor
 	// We use this to check if the device and driver has a issue
 	static BugInfo m_known_bugs[] = {
-		{OS_ALL,    VENDOR_QUALCOMM, DRIVER_QUALCOMM_3XX, -1, BUG_NODYNUBOACCESS,      14.0, -1.0, true},
+		{OS_ALL,    VENDOR_QUALCOMM, DRIVER_QUALCOMM_3XX, -1, BUG_NODYNUBOACCESS,      14.0, 94.0, true},
 		{OS_ALL,    VENDOR_QUALCOMM, DRIVER_QUALCOMM_3XX, -1, BUG_BROKENCENTROID,      14.0, 46.0, true},
 		{OS_ALL,    VENDOR_QUALCOMM, DRIVER_QUALCOMM_3XX, -1, BUG_BROKENINFOLOG,       -1.0, 46.0, true},
 		{OS_ALL,    VENDOR_QUALCOMM, DRIVER_QUALCOMM_3XX, -1, BUG_ANNIHILATEDUBOS,     41.0, 46.0, true},

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -62,14 +62,11 @@ namespace DriverDetails
 		// Bug: No Dynamic UBO array object access
 		// Affected Devices: Qualcomm/Adreno
 		// Started Version: 14
-		// Ended Version: 53
+		// Ended Version: 95
 		// Accessing UBO array members dynamically causes the Adreno shader compiler to crash
 		// Errors out with "Internal Error"
-		// With v53 video drivers, dynamic member access works. But there is a new bug
-		// The only time we access UBO array members dynamically is with a conversion
-		// int posmtx = int(fposmtx);
-		// This line will will posmtx with a seemingly random number and cause issues.
-		// Bug still active with v53 until we switch to using integers for the fposmtx attribute
+		// With v53 video drivers, dynamic member access "works." It works to the extent that it doesn't crash.
+		// With v95 drivers everything works as it should.
 		BUG_NODYNUBOACCESS = 0,
 		// Bug: Centroid is broken in shaders
 		// Affected devices: Qualcomm/Adreno


### PR DESCRIPTION
They fixed their issues with dynamic UBO array member access.
There are many other issues though.
