### PR TITLE
OGL: force enable postprocessing

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -385,19 +385,6 @@ XFBSource::~XFBSource()
 	glDeleteTextures(1, &texture);
 }
 
-
-void XFBSource::Draw(const MathUtil::Rectangle<int> &sourcerc,
-		const MathUtil::Rectangle<float> &drawrc) const
-{
-	// Texture map xfbSource->texture onto the main buffer
-	glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
-	glBlitFramebuffer(sourcerc.left, sourcerc.bottom, sourcerc.right, sourcerc.top,
-		(int)drawrc.left, (int)drawrc.bottom, (int)drawrc.right, (int)drawrc.top,
-		GL_COLOR_BUFFER_BIT, GL_LINEAR);
-
-	GL_REPORT_ERRORD();
-}
-
 void XFBSource::DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight)
 {
 	TextureConverter::DecodeToTexture(xfbAddr, fbWidth, fbHeight, texture);

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.h
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.h
@@ -52,8 +52,6 @@ struct XFBSource : public XFBSourceBase
 
 	void CopyEFB(float Gamma) override;
 	void DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight) override;
-	void Draw(const MathUtil::Rectangle<int> &sourcerc,
-		const MathUtil::Rectangle<float> &drawrc) const override;
 
 	const GLuint texture;
 };

--- a/Source/Core/VideoBackends/OGL/PostProcessing.h
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.h
@@ -21,16 +21,15 @@ public:
 	OpenGLPostProcessing();
 	~OpenGLPostProcessing();
 
-	void BindTargetFramebuffer() override;
-	void BlitToScreen() override;
-	void Update(u32 width, u32 height) override;
+	void BlitFromTexture(TargetRectangle src, TargetRectangle dst,
+	                     int src_texture, int src_width, int src_height) override;
 	void ApplyShader() override;
 
 private:
-	GLuint m_fbo;
-	GLuint m_texture;
+	bool m_initialized;
 	SHADER m_shader;
 	GLuint m_uniform_resolution;
+	GLuint m_uniform_src_rect;
 	GLuint m_uniform_time;
 	std::string m_glsl_header;
 

--- a/Source/Core/VideoCommon/FramebufferManagerBase.h
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.h
@@ -14,7 +14,7 @@ struct XFBSourceBase
 	virtual ~XFBSourceBase() {}
 
 	virtual void Draw(const MathUtil::Rectangle<int> &sourcerc,
-		const MathUtil::Rectangle<float> &drawrc) const = 0;
+		const MathUtil::Rectangle<float> &drawrc) const {};
 
 	virtual void DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight) = 0;
 

--- a/Source/Core/VideoCommon/PostProcessing.h
+++ b/Source/Core/VideoCommon/PostProcessing.h
@@ -11,6 +11,8 @@
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
 
+#include "VideoCommon/VideoCommon.h"
+
 class PostProcessingShaderConfiguration
 {
 public:
@@ -88,15 +90,11 @@ public:
 	PostProcessingShaderConfiguration* GetConfig() { return &m_config; }
 
 	// Should be implemented by the backends for backend specific code
-	virtual void BindTargetFramebuffer() = 0;
-	virtual void BlitToScreen() = 0;
-	virtual void Update(u32 width, u32 height) = 0;
+	virtual void BlitFromTexture(TargetRectangle src, TargetRectangle dst,
+	                             int src_texture, int src_width, int src_height) = 0;
 	virtual void ApplyShader() = 0;
 
 protected:
-	bool m_enable;
-	u32 m_width;
-	u32 m_height;
 	// Timer for determining our time value
 	Common::Timer m_timer;
 


### PR DESCRIPTION
This commit removes the duplicated blit. Now the postprocessing framework directly reads from EFB/XFB and draws to the default framebuffer.
