### PR TITLE
Fix a crash on Android when unplugging a controller during emulation.

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/EmulationActivity.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/EmulationActivity.java
@@ -313,6 +313,10 @@ public final class EmulationActivity extends Activity
 			return super.dispatchGenericMotionEvent(event);
 		}
 
+		// Don't attempt to do anything if we are disconnecting a device.
+		if (event.getActionMasked() == MotionEvent.ACTION_CANCEL)
+			return true;
+
 		InputDevice input = event.getDevice();
 		List<InputDevice.MotionRange> motions = input.getMotionRanges();
 


### PR DESCRIPTION
If the action we are getting is a ACTION_CANCEL, it means that the "gesture" is aborted and we shouldn't perform any more actions on it.
