### PR TITLE
Fix a race condition in our OpenSL ES audio backend.

### DIFF
--- a/Source/Core/AudioCommon/OpenSLESStream.cpp
+++ b/Source/Core/AudioCommon/OpenSLESStream.cpp
@@ -45,7 +45,6 @@ static void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void *context)
 	// which for this code example would indicate a programming error
 	_assert_msg_(AUDIO, SL_RESULT_SUCCESS == result, "Couldn't enqueue audio stream.");
 
-
 	curBuffer ^= 1; // Switch buffer
 	// Render to the fresh buffer
 	g_mixer->Mix(reinterpret_cast<short *>(buffer[curBuffer]), BUFFER_SIZE_IN_SAMPLES);
@@ -101,17 +100,14 @@ bool OpenSLESStream::Start()
 	result = (*bqPlayerPlay)->SetPlayState(bqPlayerPlay, SL_PLAYSTATE_PLAYING);
 	assert(SL_RESULT_SUCCESS == result);
 
-	// Render and enqueue a first buffer. (or should we just play the buffer empty?)
-	curBuffer = 0;
-
-	result = (*bqPlayerBufferQueue)->Enqueue(bqPlayerBufferQueue, buffer[curBuffer], sizeof(buffer[curBuffer]));
-	if (SL_RESULT_SUCCESS != result)
-	{
-		return false;
-	}
-
+	// Render and enqueue a first buffer.
 	curBuffer ^= 1;
 	g_mixer = m_mixer;
+
+	result = (*bqPlayerBufferQueue)->Enqueue(bqPlayerBufferQueue, buffer[0], sizeof(buffer[0]));
+	if (SL_RESULT_SUCCESS != result)
+		return false;
+
 	return true;
 }
 


### PR DESCRIPTION
After calling enqueue the callback would fire before we had assigned g_mixer a value.
This would cause a fun crash to happen.
