### PR TITLE
D3D: Fixed anisotropic filtering

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -1003,8 +1003,7 @@ void Renderer::ApplyState(bool bUseDstAlpha)
 	ID3D11SamplerState* samplerstate[8];
 	for (unsigned int stage = 0; stage < 8; stage++)
 	{
-		SamplerState state = gx_state.sampler[stage];
-		state.max_anisotropy = g_ActiveConfig.iMaxAnisotropy;
+		gx_state.sampler[stage].max_anisotropy = g_ActiveConfig.iMaxAnisotropy;
 		samplerstate[stage] = gx_state_cache.Get(gx_state.sampler[stage]);
 	}
 	D3D::context->PSSetSamplers(0, 8, samplerstate);


### PR DESCRIPTION
This got broken when d3d state cache was implemented.
