### PR TITLE
DSPLLE Thread: Fix a possible desync issue

### DIFF
--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -105,7 +105,9 @@ void DSPLLE::dsp_thread(DSPLLE *dsp_lle)
 		else
 		{
 			ppcEvent.Set();
-			dspEvent.Wait();
+			
+			// Only wait for the cpu thread when necessary. This fixes a possible desync issue
+			if (dsp_lle->m_cycle_count == 0) dspEvent.Wait();
 		}
 	}
 }


### PR DESCRIPTION
It might be possible for the cpu thread call:
Common::AtomicStore(m_cycle_count, dsp_cycles);
and
dspEvent.Set();
faster than the dsp thread calls:
dspEvent.Wait();

When/if that happens, the current set of dsp cycles will not be processed, and instead the dsp thread will wait for the next set.
