### PR TITLE
Rename the poorly named {Read,Write}BigEData to Copy{From,To}Emu -

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -184,8 +184,8 @@ bool CBoot::Load_BS2(const std::string& _rBootROMFilename)
 	// Run the descrambler over the encrypted section containing BS1/BS2
 	CEXIIPL::Descrambler((u8*)data.data()+0x100, 0x1AFE00);
 
-	Memory::WriteBigEData((const u8*)data.data() + 0x100, 0x81200000, 0x700);
-	Memory::WriteBigEData((const u8*)data.data() + 0x820, 0x81300000, 0x1AFE00);
+	Memory::CopyToEmu(0x81200000, data.data() + 0x100, 0x700);
+	Memory::CopyToEmu(0x81300000, data.data() + 0x820, 0x1AFE00);
 	PC = 0x81200000;
 	return true;
 }
@@ -428,8 +428,7 @@ bool CBoot::BootUp()
 	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats)
 	{
 		HLE::Patch(0x80001800, "HBReload");
-		const u8 stubstr[] = { 'S', 'T', 'U', 'B', 'H', 'A', 'X', 'X' };
-		Memory::WriteBigEData(stubstr, 0x80001804, 8);
+		Memory::CopyToEmu(0x80001804, "STUBHAXX", 8);
 	}
 
 	// Not part of the binary itself, but either we or Gecko OS might insert

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -226,7 +226,7 @@ bool CBoot::SetupWiiMemory(IVolume::ECountry country)
 			return false;
 		}
 		// Write the 256 byte setting.txt to memory.
-		Memory::WriteBigEData(gen.GetData(), 0x3800, SettingsHandler::SETTINGS_SIZE);
+		Memory::CopyToEmu(0x3800, gen.GetData(), SettingsHandler::SETTINGS_SIZE);
 	}
 
 	INFO_LOG(BOOT, "Setup Wii Memory...");

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -90,7 +90,7 @@ static bool InstallCodeHandler()
 	}
 
 	// Install code handler
-	Memory::WriteBigEData((const u8*)data.data(), INSTALLER_BASE_ADDRESS, data.length());
+	Memory::CopyToEmu(INSTALLER_BASE_ADDRESS, data.data(), data.length());
 
 	// Patch the code handler to the system starting up
 	for (unsigned int h = 0; h < data.length(); h += 4)

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -215,9 +215,14 @@ u32 Read_Instruction(const u32 em_address)
 	return inst.hex;
 }
 
-void WriteBigEData(const u8 *_pData, const u32 _Address, const size_t _iSize)
+void CopyFromEmu(void* data, u32 address, size_t size)
 {
-	memcpy(GetPointer(_Address), _pData, _iSize);
+	memcpy(data, GetPointer(address), size);
+}
+
+void CopyToEmu(u32 address, const void* data, size_t size)
+{
+	memcpy(GetPointer(address), data, size);
 }
 
 void Memset(const u32 _Address, const u8 _iValue, const u32 _iLength)
@@ -284,12 +289,6 @@ void DMA_MemoryToLC(const u32 _CacheAddr, const u32 _MemAddr, const u32 _iNumBlo
 			Write_U8(Temp, _CacheAddr + i);
 		}
 	}
-}
-
-void ReadBigEData(u8 *data, const u32 em_address, const u32 size)
-{
-	u8 *src = GetPointer(em_address);
-	memcpy(data, src, size);
 }
 
 std::string GetString(u32 em_address)

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -120,11 +120,11 @@ void Write_F64(const double _Data, const u32 _Address);
 
 std::string GetString(u32 em_address);
 
-void WriteBigEData(const u8 *_pData, const u32 _Address, const size_t size);
-void ReadBigEData(u8 *_pDest, const u32 _Address, const u32 size);
 u8* GetPointer(const u32 _Address);
 void DMA_LCToMemory(const u32 _iMemAddr, const u32 _iCacheAddr, const u32 _iNumBlocks);
 void DMA_MemoryToLC(const u32 _iCacheAddr, const u32 _iMemAddr, const u32 _iNumBlocks);
+void CopyFromEmu(void* data, u32 address, size_t size);
+void CopyToEmu(u32 address, const void* data, size_t size);
 void Memset(const u32 _Address, const u8 _Data, const u32 _iLength);
 void ClearCacheLine(const u32 _Address); // Zeroes 32 bytes; address should be 32-byte-aligned
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -639,8 +639,8 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 				for (unsigned int View = 0; View != maxViews && View < viewCnt; ++View)
 				{
 					Memory::Write_U32(View, Buffer.PayloadBuffer[0].m_Address + View * 0xD8);
-					Memory::WriteBigEData(Ticket + 0x1D0 + (View * DiscIO::INANDContentLoader::TICKET_SIZE),
-						Buffer.PayloadBuffer[0].m_Address + 4 + View * 0xD8, 212);
+					Memory::CopyToEmu(Buffer.PayloadBuffer[0].m_Address + 4 + View * 0xD8,
+						Ticket + 0x1D0 + (View * DiscIO::INANDContentLoader::TICKET_SIZE), 212);
 				}
 			}
 			else
@@ -655,7 +655,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 						for (unsigned int View = 0; View != maxViews && pFile.ReadBytes(FileTicket, DiscIO::INANDContentLoader::TICKET_SIZE); ++View)
 						{
 							Memory::Write_U32(View, Buffer.PayloadBuffer[0].m_Address + View * 0xD8);
-							Memory::WriteBigEData(FileTicket+0x1D0, Buffer.PayloadBuffer[0].m_Address + 4 + View * 0xD8, 212);
+							Memory::CopyToEmu(Buffer.PayloadBuffer[0].m_Address + 4 + View * 0xD8, FileTicket+0x1D0, 212);
 						}
 					}
 				}
@@ -727,7 +727,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			{
 				u32 Address = Buffer.PayloadBuffer[0].m_Address;
 
-				Memory::WriteBigEData(Loader.GetTMDView(), Address, DiscIO::INANDContentLoader::TMD_VIEW_SIZE);
+				Memory::CopyToEmu(Address, Loader.GetTMDView(), DiscIO::INANDContentLoader::TMD_VIEW_SIZE);
 				Address += DiscIO::INANDContentLoader::TMD_VIEW_SIZE;
 
 				Memory::Write_U16(Loader.GetTitleVersion(), Address); Address += 2;
@@ -835,13 +835,13 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			{
 				u32 Address = Buffer.PayloadBuffer[0].m_Address;
 
-				Memory::WriteBigEData(Loader.GetTMDHeader(), Address, DiscIO::INANDContentLoader::TMD_HEADER_SIZE);
+				Memory::CopyToEmu(Address, Loader.GetTMDHeader(), DiscIO::INANDContentLoader::TMD_HEADER_SIZE);
 				Address += DiscIO::INANDContentLoader::TMD_HEADER_SIZE;
 
 				const std::vector<DiscIO::SNANDContent>& rContent = Loader.GetContent();
 				for (size_t i=0; i<Loader.GetContentSize(); i++)
 				{
-					Memory::WriteBigEData(rContent[i].m_Header, Address, DiscIO::INANDContentLoader::CONTENT_HEADER_SIZE);
+					Memory::CopyToEmu(Address, rContent[i].m_Header, DiscIO::INANDContentLoader::CONTENT_HEADER_SIZE);
 					Address += DiscIO::INANDContentLoader::CONTENT_HEADER_SIZE;
 				}
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -388,7 +388,7 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 
 		WiiHIDDeviceDescriptor wii_device;
 		ConvertDeviceToWii(&wii_device, &desc);
-		Memory::WriteBigEData((const u8*)&wii_device, OffsetBuffer, Align(wii_device.bLength, 4));
+		Memory::CopyToEmu(OffsetBuffer, &wii_device, Align(wii_device.bLength, 4));
 		OffsetBuffer += Align(wii_device.bLength, 4);
 		bool deviceValid = true;
 		bool isHID = false;
@@ -402,7 +402,7 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 			{
 				WiiHIDConfigDescriptor wii_config;
 				ConvertConfigToWii(&wii_config, config);
-				Memory::WriteBigEData((const u8*)&wii_config, OffsetBuffer, Align(wii_config.bLength, 4));
+				Memory::CopyToEmu(OffsetBuffer, &wii_config, Align(wii_config.bLength, 4));
 				OffsetBuffer += Align(wii_config.bLength, 4);
 
 				for (ic = 0; ic < config->bNumInterfaces; ic++)
@@ -418,7 +418,7 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 
 						WiiHIDInterfaceDescriptor wii_interface;
 						ConvertInterfaceToWii(&wii_interface, interface);
-						Memory::WriteBigEData((const u8*)&wii_interface, OffsetBuffer, Align(wii_interface.bLength, 4));
+						Memory::CopyToEmu(OffsetBuffer, &wii_interface, Align(wii_interface.bLength, 4));
 						OffsetBuffer += Align(wii_interface.bLength, 4);
 
 						for (e = 0; e < interface->bNumEndpoints; e++)
@@ -427,7 +427,7 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 
 							WiiHIDEndpointDescriptor wii_endpoint;
 							ConvertEndpointToWii(&wii_endpoint, endpoint);
-							Memory::WriteBigEData((const u8*)&wii_endpoint, OffsetBuffer, Align(wii_endpoint.bLength, 4));
+							Memory::CopyToEmu(OffsetBuffer, &wii_endpoint, Align(wii_endpoint.bLength, 4));
 							OffsetBuffer += Align(wii_endpoint.bLength, 4);
 
 						} //endpoints

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -357,12 +357,12 @@ public:
 
 	void WriteToMem(const u32 address)
 	{
-		Memory::WriteBigEData((const u8*)&config, address, sizeof(config));
+		Memory::CopyToEmu(address, &config, sizeof(config));
 	}
 
 	void ReadFromMem(const u32 address)
 	{
-		Memory::ReadBigEData((u8*)&config, address, sizeof(config));
+		Memory::CopyFromEmu(&config, address, sizeof(config));
 	}
 
 	void ReadConfig()


### PR DESCRIPTION
and change argument order to match memcpy.

Oh, and fix a lulzy buffer overflow in IOS emulation while I'm at it.
