### PR TITLE
D3D: Enabled depth clipping

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -262,7 +262,7 @@ ID3D11RasterizerState* StateCache::Get(RasterizerState state)
 
 	D3D11_RASTERIZER_DESC rastdc = CD3D11_RASTERIZER_DESC(state.wireframe ? D3D11_FILL_WIREFRAME : D3D11_FILL_SOLID,
 		state.cull_mode,
-		false, 0, 0.f, 0, false, true, false, false);
+		false, 0, 0.f, 0, true, true, false, false);
 
 	ID3D11RasterizerState* res = nullptr;
 


### PR DESCRIPTION
This fixes some of the inconsistencies between OGL and D3D. Some games are now rendered correctly, few others are consistently broken in both back-ends.
