### PR TITLE
Adds support to ARMv7's register cache for not loading a destination register prior to overwriting.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm32/JitArm_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitArm_Integer.cpp
@@ -143,6 +143,7 @@ void JitArm::subfic(UGeckoInstruction inst)
 	else
 	{
 		ARMReg tmp = gpr.GetReg();
+		gpr.BindToRegister(d, false);
 		MOVI2R(gpr.R(d), imm);
 		LDRB(tmp, R9, PPCSTATE_OFF(xer_ca));
 		BIC(tmp, tmp, 1);
@@ -445,6 +446,7 @@ void JitArm::arith(UGeckoInstruction inst)
 	{
 		case 7:
 		{
+			gpr.BindToRegister(d, d == a);
 			ARMReg rA = gpr.GetReg();
 			RD = gpr.R(d);
 			RA = gpr.R(a);
@@ -456,6 +458,7 @@ void JitArm::arith(UGeckoInstruction inst)
 		case 12:
 		case 13:
 		{
+			gpr.BindToRegister(d, d == a);
 			ARMReg rA = gpr.GetReg();
 			RD = gpr.R(d);
 			RA = gpr.R(a);
@@ -468,6 +471,7 @@ void JitArm::arith(UGeckoInstruction inst)
 		case 15: // Arg2 is always Imm
 			if (!isImm[0])
 			{
+				gpr.BindToRegister(d, d == a);
 				ARMReg rA = gpr.GetReg();
 				RD = gpr.R(d);
 				RA = gpr.R(a);
@@ -484,6 +488,7 @@ void JitArm::arith(UGeckoInstruction inst)
 		case 25:
 		{
 			dest = a;
+			gpr.BindToRegister(a, s == a);
 			ARMReg rA = gpr.GetReg();
 			RS = gpr.R(s);
 			RA = gpr.R(a);
@@ -496,6 +501,7 @@ void JitArm::arith(UGeckoInstruction inst)
 		case 27:
 		{
 			dest = a;
+			gpr.BindToRegister(a, s == a);
 			ARMReg rA = gpr.GetReg();
 			RS = gpr.R(s);
 			RA = gpr.R(a);
@@ -509,6 +515,7 @@ void JitArm::arith(UGeckoInstruction inst)
 		case 29:
 		{
 			dest = a;
+			gpr.BindToRegister(a, s == a);
 			ARMReg rA = gpr.GetReg();
 			RS = gpr.R(s);
 			RA = gpr.R(a);
@@ -522,6 +529,7 @@ void JitArm::arith(UGeckoInstruction inst)
 			{
 				case 24:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -529,12 +537,14 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 28:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
 					ANDS(RA, RS, RB);
 				break;
 				case 40: // subfx
+					gpr.BindToRegister(d, d == s || d == b);
 					RD = gpr.R(d);
 					RA = gpr.R(a);
 					RB = gpr.R(b);
@@ -542,6 +552,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 60:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -549,6 +560,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 124:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -557,6 +569,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 747:
 				case 235:
+					gpr.BindToRegister(d, d == a || d == b);
 					RD = gpr.R(d);
 					RA = gpr.R(a);
 					RB = gpr.R(b);
@@ -564,6 +577,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 284:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -572,6 +586,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 316:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -581,6 +596,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				{
 					dest = a;
 					ARMReg rA = gpr.GetReg();
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -591,6 +607,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 444:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -598,6 +615,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 476:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -606,6 +624,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 536:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -613,6 +632,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				break;
 				case 792:
 					dest = a;
+					gpr.BindToRegister(a, a == s || a == b);
 					RA = gpr.R(a);
 					RS = gpr.R(s);
 					RB = gpr.R(b);
@@ -621,6 +641,7 @@ void JitArm::arith(UGeckoInstruction inst)
 				case 10: // addcx
 				case 266:
 				case 778: // both addx
+					gpr.BindToRegister(d, d == a || d == b);
 					RD = gpr.R(d);
 					RA = gpr.R(a);
 					RB = gpr.R(b);
@@ -666,6 +687,7 @@ void JitArm::cntlzwx(UGeckoInstruction inst)
 	JITDISABLE(bJITIntegerOff);
 	u32 a = inst.RA, s = inst.RS;
 
+	gpr.BindToRegister(a, a == s);
 	ARMReg RA = gpr.R(a);
 	ARMReg RS = gpr.R(s);
 	CLZ(RA, RS);
@@ -705,6 +727,8 @@ void JitArm::extshx(UGeckoInstruction inst)
 
 		return;
 	}
+
+	gpr.BindToRegister(a, a == s);
 	ARMReg rA = gpr.R(a);
 	ARMReg rS = gpr.R(s);
 	SXTH(rA, rS);
@@ -726,6 +750,8 @@ void JitArm::extsbx(UGeckoInstruction inst)
 
 		return;
 	}
+
+	gpr.BindToRegister(a, a == s);
 	ARMReg rA = gpr.R(a);
 	ARMReg rS = gpr.R(s);
 	SXTB(rA, rS);
@@ -768,6 +794,7 @@ void JitArm::negx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITIntegerOff);
 
+	gpr.BindToRegister(inst.RD, inst.RD == inst.RA);
 	ARMReg RA = gpr.R(inst.RA);
 	ARMReg RD = gpr.R(inst.RD);
 
@@ -787,6 +814,7 @@ void JitArm::rlwimix(UGeckoInstruction inst)
 	JITDISABLE(bJITIntegerOff);
 
 	u32 mask = Helper_Mask(inst.MB,inst.ME);
+	gpr.BindToRegister(inst.RA, inst.RA == inst.RS);
 	ARMReg RA = gpr.R(inst.RA);
 	ARMReg RS = gpr.R(inst.RS);
 	ARMReg rA = gpr.GetReg();
@@ -809,6 +837,7 @@ void JitArm::rlwinmx(UGeckoInstruction inst)
 	JITDISABLE(bJITIntegerOff);
 
 	u32 mask = Helper_Mask(inst.MB,inst.ME);
+	gpr.BindToRegister(inst.RA, inst.RA == inst.RS);
 	ARMReg RA = gpr.R(inst.RA);
 	ARMReg RS = gpr.R(inst.RS);
 	ARMReg rA = gpr.GetReg();
@@ -829,6 +858,7 @@ void JitArm::rlwnmx(UGeckoInstruction inst)
 	JITDISABLE(bJITIntegerOff);
 
 	u32 mask = Helper_Mask(inst.MB,inst.ME);
+	gpr.BindToRegister(inst.RA, inst.RA == inst.RS || inst.RA == inst.RB);
 	ARMReg RA = gpr.R(inst.RA);
 	ARMReg RS = gpr.R(inst.RS);
 	ARMReg RB = gpr.R(inst.RB);
@@ -856,6 +886,7 @@ void JitArm::srawix(UGeckoInstruction inst)
 	int s = inst.RS;
 	int amount = inst.SH;
 
+	gpr.BindToRegister(a, a == s);
 	if (amount != 0)
 	{
 		ARMReg RA = gpr.R(a);

--- a/Source/Core/Core/PowerPC/JitArm32/JitArm_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitArm_SystemRegisters.cpp
@@ -132,6 +132,7 @@ void JitArm::mfspr(UGeckoInstruction inst)
 	{
 	case SPR_XER:
 	{
+		gpr.BindToRegister(inst.RD, false);
 		ARMReg RD = gpr.R(inst.RD);
 		ARMReg tmp = gpr.GetReg();
 		LDRH(RD, R9, PPCSTATE_OFF(xer_stringctrl));
@@ -150,6 +151,7 @@ void JitArm::mfspr(UGeckoInstruction inst)
 	case SPR_TU:
 		FALLBACK_IF(true);
 	default:
+		gpr.BindToRegister(inst.RD, false);
 		ARMReg RD = gpr.R(inst.RD);
 		LDR(RD, R9, PPCSTATE_OFF(spr) + iIndex * 4);
 		break;
@@ -169,6 +171,7 @@ void JitArm::mfsr(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITSystemRegistersOff);
 
+	gpr.BindToRegister(inst.RD, false);
 	LDR(gpr.R(inst.RD), R9, PPCSTATE_OFF(sr[inst.SR]));
 }
 
@@ -191,6 +194,7 @@ void JitArm::mfmsr(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITSystemRegistersOff);
 
+	gpr.BindToRegister(inst.RD, false);
 	LDR(gpr.R(inst.RD), R9, PPCSTATE_OFF(msr));
 }
 

--- a/Source/Core/Core/PowerPC/JitArm32/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm32/JitRegCache.h
@@ -110,6 +110,10 @@ private:
 
 	u32 GetLeastUsedRegister(bool increment);
 	bool FindFreeRegister(u32 &regindex);
+
+	// Private function can kill immediates
+	ArmGen::ARMReg BindToRegister(u32 preg, bool doLoad, bool kill_imm);
+
 protected:
 	ArmGen::ARMXEmitter *emit;
 
@@ -127,5 +131,8 @@ public:
 	bool IsImm(u32 preg) { return regs[preg].GetType() == REG_IMM; }
 	u32 GetImm(u32 preg) { return regs[preg].GetImm(); }
 	void SetImmediate(u32 preg, u32 imm);
-	ArmGen::ARMReg BindToRegister(u32 preg);
+
+	// Public function doesn't kill immediates
+	// In reality when you call R(u32) it'll bind an immediate there
+	void BindToRegister(u32 preg, bool doLoad = true);
 };


### PR DESCRIPTION
This extends the register cache's BindToRegister function with a doLoad argument just like x86's.
The speedup is minor for these implemented integer instructions.
