### PR TITLE
Added projection matrix epsilon that fixes depth clipping issues in some games

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -87,7 +87,7 @@ static float PHackValue(std::string sValue)
 
 void UpdateProjectionHack(int iPhackvalue[], std::string sPhackvalue[])
 {
-	float fhackvalue1 = 0, fhackvalue2 = 0;
+	float fhackvalue1 = 0, fhackvalue2 = FLT_EPSILON; // hack to fix depth clipping precision issues (such as Sonic Unleashed UI)
 	float fhacksign1 = 1.0, fhacksign2 = 1.0;
 	const char *sTemp[2];
 
@@ -475,7 +475,7 @@ void VertexShaderManager::SetConstants()
 			g_fProjectionMatrix[13] = 0.0f;
 
 			g_fProjectionMatrix[14] = 0.0f;
-			g_fProjectionMatrix[15] = 1.0f + FLT_EPSILON; // hack to fix depth clipping precision issues (such as Sonic Unleashed UI)
+			g_fProjectionMatrix[15] = 1.0f;
 
 			SETSTAT_FT(stats.g2proj_0, g_fProjectionMatrix[0]);
 			SETSTAT_FT(stats.g2proj_1, g_fProjectionMatrix[1]);


### PR DESCRIPTION
I looked more closely at what values we in the projection matrix in Sonic, rawProjection 4 and 5 (3rd row z and w). They are -0.0101010110 and -1.01010108. From those, we can reconstruct near and far values. They turn out to be 1.00000012 and 100.000000. I found 1.00000012 to be suspicious. It happens to be 1 ULP over 1.0f. We can probably assume that the programmer wanted near and far to be exactly 1.0 and 100.0.

If we calculate what z and w should be for those near and far values, they come out as -0.0101010110 and -1.01010108 (0xbc257eb5 and 0xbf814afd). Values that we see coming in from Sonic are -0.0101010110 and -1.01010108 (0xbc257eb6 and 0xbf814afe), 1 ULP off.

I wrote a quick test that calculates and sets a projection matrix with those near and far values. I found that xfmem.projection was correct. 

I don't understand how SU manages to produce a slightly-off matrix. It is also unclear why exactly it works on real hardware. Most likely, there is rounding happening somewhere that makes 1 ULP difference not important. It would be good to understand _exactly_ what's going on....

There is a workaround/hack, though. It works in D3D and OGL.
