### PR TITLE
Add Travis OS X support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: objective-c
+
+script:
+  - mkdir Build
+  - cd Build
+  - cmake ..
+  - make


### PR DESCRIPTION
If Travis-CI is set up for the repo, you can use this script to test the build on OS X. Not sure if it can integrate with your current automated build system, but it can help prevent future compilation regressions.
