### PR TITLE
Fixes black screen issue on EGL+X11 systems.

### DIFF
--- a/Source/Core/DolphinWX/GLInterface/EGLX11.cpp
+++ b/Source/Core/DolphinWX/GLInterface/EGLX11.cpp
@@ -23,6 +23,16 @@ EGLNativeWindowType cInterfaceEGLX11::InitializePlatform(EGLNativeWindowType hos
 	int nVisuals;
 	vi = XGetVisualInfo(dpy, VisualIDMask, &visTemplate, &nVisuals);
 
+	XWindowAttributes attribs;
+	if (!XGetWindowAttributes(dpy, (Window)host_window, &attribs))
+	{
+		ERROR_LOG(VIDEO, "Window attribute retrieval failed");
+		return 0;
+	}
+
+	s_backbuffer_width  = attribs.width;
+	s_backbuffer_height = attribs.height;
+
 	return (EGLNativeWindowType) XWindow.CreateXWindow((Window) host_window, vi);
 }
 


### PR DESCRIPTION
We weren't setting the backbuffer dimensions on this platform when the window is created.
This required a resize event to first be fired in order to see anything.

So instead do like GLX + X11 platforms do and query the dimensions and set the backbuffer to them.

Should fix issue 7666.
