### PR TITLE
CommonFuncs: Set the locale conventions in uselocale().

### DIFF
--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -141,8 +141,12 @@ inline u64 _rotr64(u64 x, unsigned int shift)
 			_configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
 
 			// Set all locale categories
+			// FIXME: newlocale() always returns empty categories.
 			for (int i = LC_MIN; i <= LC_MAX; i++)
 				setlocale(i, new_locale->locinfo->lc_category[i].locale);
+
+			// Set the locale conventions
+			*(localeconv()) = *(new_locale->locinfo->lconv);
 		}
 
 		return old_locale;


### PR DESCRIPTION
newlocale() no longer sets the locale categories, so we have to set the locale conventions manually. This fixes LC_NUMERIC_MASK and LC_MONETARY_MASK, but all other masks are still broken.

Though I think it would be a cleaner solution to stop trying to write a POSIX compatibility layer and just provide a thread-safe SetLocale implementation, so that we don't have to use the badly supported locale_t structs on Windows.
