### PR TITLE
AGL: Use NSOpenGLContext's clearCurrentContext in ClearCurrent

### DIFF
--- a/Source/Core/DolphinWX/GLInterface/AGL.cpp
+++ b/Source/Core/DolphinWX/GLInterface/AGL.cpp
@@ -71,8 +71,7 @@ bool cInterfaceAGL::MakeCurrent()
 
 bool cInterfaceAGL::ClearCurrent()
 {
-	// not tested at all
-	//clearCurrentContext();
+	[NSOpenGLContext clearCurrentContext];
 	return true;
 }
 


### PR DESCRIPTION
This causes no noticeable issues through testing.
