### PR TITLE
Fix bbox related performance issue in some games.

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -385,7 +385,12 @@ static void BPWritten(const BPCmd& bp)
 
 			BoundingBox::coords[offset]     = bp.newvalue & 0x3ff;
 			BoundingBox::coords[offset + 1] = bp.newvalue >> 10;
-			BoundingBox::active = true;
+
+			if (BoundingBox::tolerance > 0)
+			{
+				BoundingBox::active = true;
+				--BoundingBox::tolerance;
+			}
 		}
 		return;
 	case BPMEM_TEXINVALIDATE:

--- a/Source/Core/VideoCommon/BoundingBox.cpp
+++ b/Source/Core/VideoCommon/BoundingBox.cpp
@@ -17,6 +17,7 @@ namespace BoundingBox
 
 // External vars
 bool active = false;
+int  tolerance = 3;
 u16 coords[4] = { 0x80, 0xA0, 0x80, 0xA0 };
 u8 posMtxIdx;
 u8 texMtxIdx[8];

--- a/Source/Core/VideoCommon/BoundingBox.h
+++ b/Source/Core/VideoCommon/BoundingBox.h
@@ -14,6 +14,9 @@ namespace BoundingBox
 // Determines if bounding box is active
 extern bool active;
 
+// Number of consecutive times that bbox regs can be cleared and not used before being disabled
+extern int tolerance;
+
 // Bounding box current coordinates
 extern u16 coords[4];
 

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -233,6 +233,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 		mmio->Register(base | (PE_BBOX_LEFT + 2 * i),
 			MMIO::ComplexRead<u16>([i](u32) {
 				BoundingBox::active = false;
+				BoundingBox::tolerance = 3;
 				return BoundingBox::coords[i];
 			}),
 			MMIO::InvalidWrite<u16>()


### PR DESCRIPTION
Some games, such as Resident Evil Archives, clear the Bounding Box registers, thus turning on bbox, but never read those registers, which results in very slow performance for no benefit.

This PR fixes that by disabling bbox calculation when the bbox registers have been cleared but not read for three consecutive times, and by re-enabling bbox any time the registers are read.

The reason for allowing bbox regs to be cleared three times before disabling calculation is due to the fact that during boot every game clears the bbox registers twice without reading them. This allows games to clear bbox one final time, when already ingame, before disabling calculations.

This PR should fix issue #7774 without any impact on games that do use bbox.