### PR TITLE
Change default gcpad radius to 100.

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -6,7 +6,7 @@
 #include "Core/HW/GCPadEmu.h"
 
 // TODO: Move to header file when VS supports constexpr.
-const ControlState GCPad::DEFAULT_PAD_STICK_RADIUS = 0.7f;
+const ControlState GCPad::DEFAULT_PAD_STICK_RADIUS = 1.0;
 
 const u16 button_bitmasks[] =
 {


### PR DESCRIPTION
Official gc controllers need it to be 100 to work properly, and it is better to have it set too high than too low.

See issue 7762.
