### PR TITLE
Fixes ARM CPU detection routine for the hardware.

### DIFF
--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -30,7 +30,6 @@ static std::string GetCPUString()
 		if (line.find(marker) != std::string::npos)
 		{
 			cpu_string = line.substr(marker.length());
-			cpu_string.pop_back(); // Drop the new-line character
 			break;
 		}
 	}


### PR DESCRIPTION
We weren't dropping a newline character from the string, we were cutting off the last character of the hardware name.
This fixes my TK1 being called 'lagun' when it's name is 'laguna'
