### PR TITLE
Use double braces for std:array initialization to avoid clang warning.

### DIFF
--- a/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
@@ -42,7 +42,7 @@ CheatSearchTab::CheatSearchTab(wxWindow* const parent)
 	m_btn_next_scan->Disable();
 
 	// data sizes radiobox
-	std::array<wxString, 3> data_size_names = { _("8-bit"), _("16-bit"), _("32-bit") };
+	std::array<wxString, 3> data_size_names = {{ _("8-bit"), _("16-bit"), _("32-bit") }};
 	m_data_sizes = new wxRadioBox(this, wxID_ANY, _("Data Size"), wxDefaultPosition, wxDefaultSize, static_cast<int>(data_size_names.size()), data_size_names.data());
 
 	// result controls


### PR DESCRIPTION
std::array does not have an initializer list constructor, instead (for
some reason) being defined to contain one public array member, allowing
it to be directly initialized.  Thus the most explicit way to initialize
it is with two braces, one for the struct and one for the array.  C++
allows the second pair of braces to be omitted, but clang complains
about it.
