### PR TITLE
CheatsWindow: Remove unnecessary header includes and forward decls

### DIFF
--- a/Source/Core/DolphinWX/Cheats/CheatSearchTab.h
+++ b/Source/Core/DolphinWX/Cheats/CheatSearchTab.h
@@ -13,6 +13,7 @@ class wxCommandEvent;
 class wxEvent;
 class wxListBox;
 class wxRadioBox;
+class wxRadioButton;
 class wxStaticText;
 class wxTextCtrl;
 class wxWindow;

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
@@ -12,14 +12,12 @@
 #include <wx/chartype.h>
 #include <wx/checkbox.h>
 #include <wx/checklst.h>
-#include <wx/choice.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/listbox.h>
 #include <wx/msgdlg.h>
 #include <wx/notebook.h>
 #include <wx/panel.h>
-#include <wx/radiobut.h>
 #include <wx/sizer.h>
 #include <wx/statbox.h>
 #include <wx/stattext.h>

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.h
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.h
@@ -17,13 +17,10 @@
 class wxButton;
 class wxCheckBox;
 class wxCheckListBox;
-class wxChoice;
 class wxCloseEvent;
 class wxCommandEvent;
-class wxEvent;
 class wxListBox;
 class wxNotebook;
-class wxRadioButton;
 class wxStaticBox;
 class wxStaticText;
 class wxTextCtrl;


### PR DESCRIPTION
Adds a forward declaration to CheatSearchTab as well so that it doesn't rely on CheatsWindow to compile properly.
