### PR TITLE
Profiling: measure time on non-Windows/POSIX using clock_gettime

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SRCS BreakPoints.cpp
          NandPaths.cpp
          Network.cpp
          PcapFile.cpp
+         PerformanceCounter.cpp
          SettingsHandler.cpp
          SDCardUtil.cpp
          StringUtil.cpp

--- a/Source/Core/Common/PerformanceCounter.cpp
+++ b/Source/Core/Common/PerformanceCounter.cpp
@@ -1,0 +1,48 @@
+// Copyright 2013 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#if !defined(_WIN32)
+
+#include <cstdint>
+#include <ctime>
+
+#include <unistd.h>
+
+#include "Common/CommonTypes.h"
+#include "Common/PerformanceCounter.h"
+
+#if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
+#if defined(_POSIX_MONOTONIC_CLOCK) && _POSIX_MONOTONIC_CLOCK>0
+#define DOLPHIN_CLOCK CLOCK_MONOTONIC
+#else
+#define DOLPHIN_CLOCK CLOCK_REALTIME
+#endif
+#endif
+
+bool QueryPerformanceCounter(u64* out)
+{
+#if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
+	timespec tp;
+	if (clock_gettime(DOLPHIN_CLOCK, &tp))
+		return false;
+	*out = (u64) tp.tv_nsec + (u64) 1000000000 * (u64) tp.tv_sec;
+	return true;
+#else
+	*out = 0;
+	return false;
+#endif
+}
+
+bool QueryPerformanceFrequency(u64* out)
+{
+#if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
+	*out = 1000000000;
+	return true;
+#else
+	*out = 1;
+	return false;
+#endif
+}
+
+#endif

--- a/Source/Core/Common/PerformanceCounter.h
+++ b/Source/Core/Common/PerformanceCounter.h
@@ -1,0 +1,17 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#pragma once
+
+#if !defined(_WIN32)
+
+#include <cstdint>
+
+#include "Common/CommonTypes.h"
+
+typedef u64 LARGE_INTEGER;
+bool QueryPerformanceCounter(u64* out);
+bool QueryPerformanceFrequency(u64* lpFrequency);
+
+#endif

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -575,13 +575,9 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	{
 		MOV(64, R(RSCRATCH), Imm64((u64)&b->runCount));
 		ADD(32, MatR(RSCRATCH), Imm8(1));
-#ifdef _WIN32
 		b->ticCounter = 0;
 		b->ticStart = 0;
 		b->ticStop = 0;
-#else
-//TODO
-#endif
 		// get start tic
 		PROFILER_QUERY_PERFORMANCE_COUNTER(&b->ticStart);
 	}
@@ -625,7 +621,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 				// get end tic
 				PROFILER_QUERY_PERFORMANCE_COUNTER(&b->ticStop);
 				// tic counter += (end tic - start tic)
-				PROFILER_ADD_DIFF_LARGE_INTEGER(&b->ticCounter, &b->ticStop, &b->ticStart);
+				PROFILER_UPDATE_TIME(b);
 				PROFILER_VPOP;
 			}
 		}

--- a/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
@@ -397,7 +397,7 @@ const u8* JitArm::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlo
 				// get end tic
 				PROFILER_QUERY_PERFORMANCE_COUNTER(&b->ticStop);
 				// tic counter += (end tic - start tic)
-				PROFILER_ADD_DIFF_LARGE_INTEGER(&b->ticCounter, &b->ticStop, &b->ticStart);
+				PROFILER_UPDATE_TIME(&b);
 				PROFILER_VPOP;
 			}
 		}
@@ -467,4 +467,3 @@ const u8* JitArm::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlo
 	FlushIcache();
 	return start;
 }
-

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -51,13 +51,11 @@ struct JitBlock
 	};
 	std::vector<LinkData> linkData;
 
-#ifdef _WIN32
 	// we don't really need to save start and stop
 	// TODO (mb2): ticStart and ticStop -> "local var" mean "in block" ... low priority ;)
 	u64 ticStart;   // for profiling - time.
 	u64 ticStop;    // for profiling - time.
 	u64 ticCounter; // for profiling - time.
-#endif
 
 #ifdef USE_VTUNE
 	char blockName[32];

--- a/Source/Core/Core/PowerPC/Profiler.h
+++ b/Source/Core/Core/PowerPC/Profiler.h
@@ -5,22 +5,26 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include "Common/CommonTypes.h"
 
-#ifdef _WIN32
+#include "Common/PerformanceCounter.h"
+
+#if defined(_M_X86_64)
 
 #define PROFILER_QUERY_PERFORMANCE_COUNTER(pt) \
-	LEA(64, ABI_PARAM1, M(pt)); \
-	CALL(QueryPerformanceCounter)
+	MOV(64, R(ABI_PARAM1), Imm64((u64) pt)); \
+	CALL((const void*) QueryPerformanceCounter)
 
-// asm write : (u64) dt += t1-t0
-#define PROFILER_ADD_DIFF_LARGE_INTEGER(pdt, pt1, pt0) \
-	MOV(64, R(RSCRATCH), M(pt1)); \
-	SUB(64, R(RSCRATCH), M(pt0)); \
-	ADD(64, R(RSCRATCH), M(pdt)); \
-	MOV(64, M(pdt), R(RSCRATCH));
+// block->ticCounter += block->ticStop - block->ticStart
+#define PROFILER_UPDATE_TIME(block) \
+	MOV(64, R(RSCRATCH2), Imm64((u64) block)); \
+	MOV(64, R(RSCRATCH), MDisp(RSCRATCH2, offsetof(struct JitBlock, ticStop))); \
+	SUB(64, R(RSCRATCH), MDisp(RSCRATCH2, offsetof(struct JitBlock, ticStart))); \
+	ADD(64, R(RSCRATCH), MDisp(RSCRATCH2, offsetof(struct JitBlock, ticCounter))); \
+	MOV(64, MDisp(RSCRATCH2, offsetof(struct JitBlock, ticCounter)), R(RSCRATCH));
 
 #define PROFILER_VPUSH \
 	BitSet32 registersInUse = CallerSavedRegistersInUse(); \
@@ -32,10 +36,7 @@
 #else
 
 #define PROFILER_QUERY_PERFORMANCE_COUNTER(pt)
-
-// TODO: Implement generic ways to do this cleanly with all supported architectures
-// asm write : (u64) dt += t1-t0
-#define PROFILER_ADD_DIFF_LARGE_INTEGER(pdt, pt1, pt0)
+#define PROFILER_UPDATE_TIME(b)
 #define PROFILER_VPUSH
 #define PROFILER_VPOP
 


### PR DESCRIPTION
PowerPC CPU profiling was only enabled on Windows (using QueryPerformanceCounter). Try to do the same thing using POSIX clock_gettime.
