### PR TITLE
Defer processing of expansion interface interrupts (fixes audio in Super Mario Sunshine on lower-end systems)

### DIFF
--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -20,6 +20,7 @@ namespace ExpansionInterface
 {
 
 static int changeDevice;
+static int updateInterrupts;
 
 static CEXIChannel *g_Channels[MAX_EXI_CHANNELS];
 void Init()
@@ -43,6 +44,7 @@ void Init()
 	g_Channels[2]->AddDevice(EXIDEVICE_AD16,                            0);
 
 	changeDevice = CoreTiming::RegisterEvent("ChangeEXIDevice", ChangeDeviceCallback);
+	updateInterrupts = CoreTiming::RegisterEvent("EXIUpdateInterrupts", UpdateInterruptsCallback);
 }
 
 void Shutdown()
@@ -114,6 +116,11 @@ IEXIDevice* FindDevice(TEXIDevices device_type, int customIndex)
 }
 
 void UpdateInterrupts()
+{
+	CoreTiming::ScheduleEvent_Threadsafe(0, updateInterrupts, 0);
+}
+
+void UpdateInterruptsCallback(u64 userdata, int cyclesLate)
 {
 	// Interrupts are mapped a bit strangely:
 	// Channel 0 Device 0 generates interrupt on channel 0

--- a/Source/Core/Core/HW/EXI.h
+++ b/Source/Core/Core/HW/EXI.h
@@ -27,6 +27,7 @@ void PauseAndLock(bool doLock, bool unpauseOnUnlock);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
+void UpdateInterruptsCallback(u64 userdata, int cyclesLate);
 void UpdateInterrupts();
 
 void ChangeDeviceCallback(u64 userdata, int cyclesLate);


### PR DESCRIPTION
(Resubmitting after un-horking my git setup, and incorporating feedback from earlier submission.)

Issue 4940; fixes the introduction of what seems to be a non-thread-safe call to ExpansionInterface::UpdateInterrupts() from PowerPC.cpp that was introduced back in the gc-mic branch merge, by making ExpansionInterface::UpdateInterrupts() thread-safe. Tested on two mid-range systems that reliably would completely lose audio on Super Mario Sunshine previously, and it's now rock-solid. Also confirmed the mic test in Mario Party 7 still works with this change.

Tested a few Wii and GC games with this change and no side effects so far that I can see.
