### PR TITLE
Rename unittest targets to Tests_*

### DIFF
--- a/Source/UnitTests/CMakeLists.txt
+++ b/Source/UnitTests/CMakeLists.txt
@@ -4,12 +4,13 @@ macro(add_dolphin_test target srcs)
 	# core, but before other core dependencies like videocommon which also use
 	# Host_ functions.
 	set(srcs2 ${srcs} ${CMAKE_SOURCE_DIR}/Source/UnitTests/TestUtils/StubHost.cpp)
-	add_executable(Tests/${target} EXCLUDE_FROM_ALL ${srcs2})
-	add_custom_command(TARGET Tests/${target}
+	add_executable(Test_${target} EXCLUDE_FROM_ALL ${srcs2})
+	set_target_properties(Test_${target} PROPERTIES OUTPUT_NAME Tests/${target})
+	add_custom_command(TARGET Test_${target}
 	                   PRE_LINK
 	                   COMMAND mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Tests)
-	target_link_libraries(Tests/${target} core gtest)
-	add_dependencies(unittests Tests/${target})
+	target_link_libraries(Test_${target} core gtest)
+	add_dependencies(unittests Test_${target})
 	add_test(NAME ${target} COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Tests/${target})
 endmacro(add_dolphin_test)
 


### PR DESCRIPTION
This fixes an annoying CMake warning about using slashes in the names of targets.
