### PR TITLE
Create userdir/Dump/Frames as needed.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1557,6 +1557,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 			if (!bLastFrameDumped)
 			{
 				movie_file_name = File::GetUserPath(D_DUMPFRAMES_IDX) + "framedump.raw";
+				File::CreateFullPath(movie_file_name);
 				pFrameDump.Open(movie_file_name, "wb");
 				if (!pFrameDump)
 				{


### PR DESCRIPTION
This is used for framedump.raw in non-Windows builds without libav support.

There should probably be a warning for choosing this menu item, actually, considering the way it guzzles disk space, but in any case not creating the directory is wrong.
