### PR TITLE
Make some OSX-only functions static

### DIFF
--- a/Source/Core/Core/HW/BBA-TAP/TAP_Apple.cpp
+++ b/Source/Core/Core/HW/BBA-TAP/TAP_Apple.cpp
@@ -61,7 +61,7 @@ bool CEXIETHERNET::SendFrame(u8* frame, u32 size)
 	}
 }
 
-void ReadThreadHandler(CEXIETHERNET* self)
+static void ReadThreadHandler(CEXIETHERNET* self)
 {
 	while (true)
 	{

--- a/Source/Core/Core/x64MemTools.cpp
+++ b/Source/Core/Core/x64MemTools.cpp
@@ -91,7 +91,7 @@ void UninstallExceptionHandler() {}
 
 #elif defined(__APPLE__) && !defined(USE_SIGACTION_ON_APPLE)
 
-void CheckKR(const char* name, kern_return_t kr)
+static void CheckKR(const char* name, kern_return_t kr)
 {
 	if (kr)
 	{
@@ -99,7 +99,7 @@ void CheckKR(const char* name, kern_return_t kr)
 	}
 }
 
-void ExceptionThread(mach_port_t port)
+static void ExceptionThread(mach_port_t port)
 {
 	Common::SetCurrentThreadName("Mach exception thread");
 	#pragma pack(4)

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
@@ -108,7 +108,7 @@ void DeviceElementDebugPrint(const void *value, void *context)
 	}
 }
 
-void DeviceDebugPrint(IOHIDDeviceRef device)
+static void DeviceDebugPrint(IOHIDDeviceRef device)
 {
 #if 0
 #define shortlog(x) NSLog(@"%s: %@", \


### PR DESCRIPTION
Gets rid of function prototype warnings.
