### PR TITLE
Interpreter: Remove a redundant macro

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.h
@@ -34,8 +34,6 @@ public:
 
 	void Log();
 
-	// to keep the code cleaner
-	#define m_GPR (PowerPC::ppcState.gpr)
 	static bool m_EndBlock;
 
 	static void unknown_instruction(UGeckoInstruction _inst);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -45,54 +45,54 @@ u32 Interpreter::Helper_Mask(int mb, int me)
 void Interpreter::addi(UGeckoInstruction _inst)
 {
 	if (_inst.RA)
-		m_GPR[_inst.RD] = m_GPR[_inst.RA] + _inst.SIMM_16;
+		rGPR[_inst.RD] = rGPR[_inst.RA] + _inst.SIMM_16;
 	else
-		m_GPR[_inst.RD] = _inst.SIMM_16;
+		rGPR[_inst.RD] = _inst.SIMM_16;
 }
 
 void Interpreter::addic(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
+	u32 a = rGPR[_inst.RA];
 	u32 imm = (u32)(s32)_inst.SIMM_16;
 	// TODO(ector): verify this thing
-	m_GPR[_inst.RD] = a + imm;
+	rGPR[_inst.RD] = a + imm;
 	SetCarry(Helper_Carry(a, imm));
 }
 
 void Interpreter::addic_rc(UGeckoInstruction _inst)
 {
 	addic(_inst);
-	Helper_UpdateCR0(m_GPR[_inst.RD]);
+	Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::addis(UGeckoInstruction _inst)
 {
 	if (_inst.RA)
-		m_GPR[_inst.RD] = m_GPR[_inst.RA] + (_inst.SIMM_16 << 16);
+		rGPR[_inst.RD] = rGPR[_inst.RA] + (_inst.SIMM_16 << 16);
 	else
-		m_GPR[_inst.RD] = (_inst.SIMM_16 << 16);
+		rGPR[_inst.RD] = (_inst.SIMM_16 << 16);
 }
 
 void Interpreter::andi_rc(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] & _inst.UIMM;
-	Helper_UpdateCR0(m_GPR[_inst.RA]);
+	rGPR[_inst.RA] = rGPR[_inst.RS] & _inst.UIMM;
+	Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::andis_rc(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] & ((u32)_inst.UIMM<<16);
-	Helper_UpdateCR0(m_GPR[_inst.RA]);
+	rGPR[_inst.RA] = rGPR[_inst.RS] & ((u32)_inst.UIMM<<16);
+	Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::cmpi(UGeckoInstruction _inst)
 {
-	Helper_UpdateCRx(_inst.CRFD, m_GPR[_inst.RA] - _inst.SIMM_16);
+	Helper_UpdateCRx(_inst.CRFD, rGPR[_inst.RA] - _inst.SIMM_16);
 }
 
 void Interpreter::cmpli(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
+	u32 a = rGPR[_inst.RA];
 	u32 b = _inst.UIMM;
 	int f;
 
@@ -111,22 +111,22 @@ void Interpreter::cmpli(UGeckoInstruction _inst)
 
 void Interpreter::mulli(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RD] = (s32)m_GPR[_inst.RA] * _inst.SIMM_16;
+	rGPR[_inst.RD] = (s32)rGPR[_inst.RA] * _inst.SIMM_16;
 }
 
 void Interpreter::ori(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] | _inst.UIMM;
+	rGPR[_inst.RA] = rGPR[_inst.RS] | _inst.UIMM;
 }
 
 void Interpreter::oris(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] | (_inst.UIMM << 16);
+	rGPR[_inst.RA] = rGPR[_inst.RS] | (_inst.UIMM << 16);
 }
 
 void Interpreter::subfic(UGeckoInstruction _inst)
 {
-/*	u32 rra = ~m_GPR[_inst.RA];
+/*	u32 rra = ~rGPR[_inst.RA];
 	s32 immediate = (s16)_inst.SIMM_16 + 1;
 
 //	#define CALC_XER_CA(X,Y) (((X) + (Y) < X) ? SET_XER_CA : CLEAR_XER_CA)
@@ -135,17 +135,17 @@ void Interpreter::subfic(UGeckoInstruction _inst)
 	else
 		SetCarry(0);
 
-	m_GPR[_inst.RD] = rra - immediate;
+	rGPR[_inst.RD] = rra - immediate;
 */
 
 	s32 immediate = _inst.SIMM_16;
-	m_GPR[_inst.RD] = immediate - (signed)m_GPR[_inst.RA];
-	SetCarry((m_GPR[_inst.RA] == 0) || (Helper_Carry(0-m_GPR[_inst.RA], immediate)));
+	rGPR[_inst.RD] = immediate - (int)rGPR[_inst.RA];
+	SetCarry((rGPR[_inst.RA] == 0) || (Helper_Carry(0 - rGPR[_inst.RA], immediate)));
 }
 
 void Interpreter::twi(UGeckoInstruction _inst)
 {
-	s32 a = m_GPR[_inst.RA];
+	s32 a = rGPR[_inst.RA];
 	s32 b = _inst.SIMM_16;
 	s32 TO = _inst.TO;
 
@@ -165,61 +165,61 @@ void Interpreter::twi(UGeckoInstruction _inst)
 
 void Interpreter::xori(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] ^ _inst.UIMM;
+	rGPR[_inst.RA] = rGPR[_inst.RS] ^ _inst.UIMM;
 }
 
 void Interpreter::xoris(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] ^ (_inst.UIMM << 16);
+	rGPR[_inst.RA] = rGPR[_inst.RS] ^ (_inst.UIMM << 16);
 }
 
 void Interpreter::rlwimix(UGeckoInstruction _inst)
 {
 	u32 mask = Helper_Mask(_inst.MB,_inst.ME);
-	m_GPR[_inst.RA] = (m_GPR[_inst.RA] & ~mask) | (_rotl(m_GPR[_inst.RS],_inst.SH) & mask);
+	rGPR[_inst.RA] = (rGPR[_inst.RA] & ~mask) | (_rotl(rGPR[_inst.RS],_inst.SH) & mask);
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::rlwinmx(UGeckoInstruction _inst)
 {
 	u32 mask = Helper_Mask(_inst.MB,_inst.ME);
-	m_GPR[_inst.RA] = _rotl(m_GPR[_inst.RS],_inst.SH) & mask;
+	rGPR[_inst.RA] = _rotl(rGPR[_inst.RS],_inst.SH) & mask;
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::rlwnmx(UGeckoInstruction _inst)
 {
 	u32 mask = Helper_Mask(_inst.MB,_inst.ME);
-	m_GPR[_inst.RA] = _rotl(m_GPR[_inst.RS], m_GPR[_inst.RB] & 0x1F) & mask;
+	rGPR[_inst.RA] = _rotl(rGPR[_inst.RS], rGPR[_inst.RB] & 0x1F) & mask;
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::andx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] & m_GPR[_inst.RB];
+	rGPR[_inst.RA] = rGPR[_inst.RS] & rGPR[_inst.RB];
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::andcx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] & ~m_GPR[_inst.RB];
+	rGPR[_inst.RA] = rGPR[_inst.RS] & ~rGPR[_inst.RB];
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::cmp(UGeckoInstruction _inst)
 {
-	s32 a = (s32)m_GPR[_inst.RA];
-	s32 b = (s32)m_GPR[_inst.RB];
+	s32 a = (s32)rGPR[_inst.RA];
+	s32 b = (s32)rGPR[_inst.RB];
 	int fTemp = 0x8; // a < b
 
 	// if (a < b) fTemp = 0x8; else
@@ -236,8 +236,8 @@ void Interpreter::cmp(UGeckoInstruction _inst)
 
 void Interpreter::cmpl(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
-	u32 b = m_GPR[_inst.RB];
+	u32 a = rGPR[_inst.RA];
+	u32 b = rGPR[_inst.RB];
 	u32 fTemp = 0x8; // a < b
 
 	// if (a < b)  fTemp = 0x8;else
@@ -254,7 +254,7 @@ void Interpreter::cmpl(UGeckoInstruction _inst)
 
 void Interpreter::cntlzwx(UGeckoInstruction _inst)
 {
-	u32 val = m_GPR[_inst.RS];
+	u32 val = rGPR[_inst.RS];
 	u32 mask = 0x80000000;
 
 	int i = 0;
@@ -264,91 +264,91 @@ void Interpreter::cntlzwx(UGeckoInstruction _inst)
 			break;
 	}
 
-	m_GPR[_inst.RA] = i;
+	rGPR[_inst.RA] = i;
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::eqvx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = ~(m_GPR[_inst.RS] ^ m_GPR[_inst.RB]);
+	rGPR[_inst.RA] = ~(rGPR[_inst.RS] ^ rGPR[_inst.RB]);
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::extsbx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = (u32)(s32)(s8)m_GPR[_inst.RS];
+	rGPR[_inst.RA] = (u32)(s32)(s8)rGPR[_inst.RS];
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::extshx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = (u32)(s32)(s16)m_GPR[_inst.RS];
+	rGPR[_inst.RA] = (u32)(s32)(s16)rGPR[_inst.RS];
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::nandx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = ~(m_GPR[_inst.RS] & m_GPR[_inst.RB]);
+	rGPR[_inst.RA] = ~(rGPR[_inst.RS] & rGPR[_inst.RB]);
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::norx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = ~(m_GPR[_inst.RS] | m_GPR[_inst.RB]);
+	rGPR[_inst.RA] = ~(rGPR[_inst.RS] | rGPR[_inst.RB]);
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::orx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] | m_GPR[_inst.RB];
+	rGPR[_inst.RA] = rGPR[_inst.RS] | rGPR[_inst.RB];
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::orcx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] | (~m_GPR[_inst.RB]);
+	rGPR[_inst.RA] = rGPR[_inst.RS] | (~rGPR[_inst.RB]);
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::slwx(UGeckoInstruction _inst)
 {
-	u32 amount = m_GPR[_inst.RB];
-	m_GPR[_inst.RA] = (amount & 0x20) ? 0 : m_GPR[_inst.RS] << amount;
+	u32 amount = rGPR[_inst.RB];
+	rGPR[_inst.RA] = (amount & 0x20) ? 0 : rGPR[_inst.RS] << amount;
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::srawx(UGeckoInstruction _inst)
 {
-	int rb = m_GPR[_inst.RB];
+	int rb = rGPR[_inst.RB];
 
 	if (rb & 0x20)
 	{
-		if (m_GPR[_inst.RS] & 0x80000000)
+		if (rGPR[_inst.RS] & 0x80000000)
 		{
-			m_GPR[_inst.RA] = 0xFFFFFFFF;
+			rGPR[_inst.RA] = 0xFFFFFFFF;
 			SetCarry(1);
 		}
 		else
 		{
-			m_GPR[_inst.RA] = 0x00000000;
+			rGPR[_inst.RA] = 0x00000000;
 			SetCarry(0);
 		}
 	}
@@ -357,13 +357,13 @@ void Interpreter::srawx(UGeckoInstruction _inst)
 		int amount = rb & 0x1f;
 		if (amount == 0)
 		{
-			m_GPR[_inst.RA] = m_GPR[_inst.RS];
+			rGPR[_inst.RA] = rGPR[_inst.RS];
 			SetCarry(0);
 		}
 		else
 		{
-			s32 rrs = m_GPR[_inst.RS];
-			m_GPR[_inst.RA] = rrs >> amount;
+			s32 rrs = rGPR[_inst.RS];
+			rGPR[_inst.RA] = rrs >> amount;
 
 			if ((rrs < 0) && (rrs << (32 - amount)))
 				SetCarry(1);
@@ -373,7 +373,7 @@ void Interpreter::srawx(UGeckoInstruction _inst)
 	}
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::srawix(UGeckoInstruction _inst)
@@ -382,8 +382,8 @@ void Interpreter::srawix(UGeckoInstruction _inst)
 
 	if (amount != 0)
 	{
-		s32 rrs = m_GPR[_inst.RS];
-		m_GPR[_inst.RA] = rrs >> amount;
+		s32 rrs = rGPR[_inst.RS];
+		rGPR[_inst.RA] = rrs >> amount;
 
 		if ((rrs < 0) && (rrs << (32 - amount)))
 			SetCarry(1);
@@ -393,26 +393,26 @@ void Interpreter::srawix(UGeckoInstruction _inst)
 	else
 	{
 		SetCarry(0);
-		m_GPR[_inst.RA] = m_GPR[_inst.RS];
+		rGPR[_inst.RA] = rGPR[_inst.RS];
 	}
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::srwx(UGeckoInstruction _inst)
 {
-	u32 amount = m_GPR[_inst.RB];
-	m_GPR[_inst.RA] = (amount & 0x20) ? 0 : (m_GPR[_inst.RS] >> (amount & 0x1f));
+	u32 amount = rGPR[_inst.RB];
+	rGPR[_inst.RA] = (amount & 0x20) ? 0 : (rGPR[_inst.RS] >> (amount & 0x1f));
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::tw(UGeckoInstruction _inst)
 {
-	s32 a = m_GPR[_inst.RA];
-	s32 b = m_GPR[_inst.RB];
+	s32 a = rGPR[_inst.RA];
+	s32 b = rGPR[_inst.RB];
 	s32 TO = _inst.TO;
 
 	DEBUG_LOG(POWERPC, "tw rA %0x rB %0x TO %0x", a, b, TO);
@@ -431,84 +431,84 @@ void Interpreter::tw(UGeckoInstruction _inst)
 
 void Interpreter::xorx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RA] = m_GPR[_inst.RS] ^ m_GPR[_inst.RB];
+	rGPR[_inst.RA] = rGPR[_inst.RS] ^ rGPR[_inst.RB];
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RA]);
+		Helper_UpdateCR0(rGPR[_inst.RA]);
 }
 
 void Interpreter::addx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RD] = m_GPR[_inst.RA] + m_GPR[_inst.RB];
+	rGPR[_inst.RD] = rGPR[_inst.RA] + rGPR[_inst.RB];
 
 	if (_inst.OE)
 		PanicAlert("OE: addx");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::addcx(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
-	u32 b = m_GPR[_inst.RB];
-	m_GPR[_inst.RD] = a + b;
+	u32 a = rGPR[_inst.RA];
+	u32 b = rGPR[_inst.RB];
+	rGPR[_inst.RD] = a + b;
 	SetCarry(Helper_Carry(a,b));
 
 	if (_inst.OE)
 		PanicAlert("OE: addcx");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::addex(UGeckoInstruction _inst)
 {
 	int carry = GetCarry();
-	int a = m_GPR[_inst.RA];
-	int b = m_GPR[_inst.RB];
-	m_GPR[_inst.RD] = a + b + carry;
+	int a = rGPR[_inst.RA];
+	int b = rGPR[_inst.RB];
+	rGPR[_inst.RD] = a + b + carry;
 	SetCarry(Helper_Carry(a, b) || (carry != 0 && Helper_Carry(a + b, carry)));
 
 	if (_inst.OE)
 		PanicAlert("OE: addex");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::addmex(UGeckoInstruction _inst)
 {
 	int carry = GetCarry();
-	int a = m_GPR[_inst.RA];
-	m_GPR[_inst.RD] = a + carry - 1;
+	int a = rGPR[_inst.RA];
+	rGPR[_inst.RD] = a + carry - 1;
 	SetCarry(Helper_Carry(a, carry - 1));
 
 	if (_inst.OE)
 		PanicAlert("OE: addmex");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::addzex(UGeckoInstruction _inst)
 {
 	int carry = GetCarry();
-	int a = m_GPR[_inst.RA];
-	m_GPR[_inst.RD] = a + carry;
+	int a = rGPR[_inst.RA];
+	rGPR[_inst.RD] = a + carry;
 	SetCarry(Helper_Carry(a, carry));
 
 	if (_inst.OE)
 		PanicAlert("OE: addzex");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::divwx(UGeckoInstruction _inst)
 {
-	s32 a = m_GPR[_inst.RA];
-	s32 b = m_GPR[_inst.RB];
+	s32 a = rGPR[_inst.RA];
+	s32 b = rGPR[_inst.RB];
 
 	if (b == 0 || ((u32)a == 0x80000000 && b == -1))
 	{
@@ -519,24 +519,24 @@ void Interpreter::divwx(UGeckoInstruction _inst)
 		}
 
 		if (((u32)a & 0x80000000) && b == 0)
-			m_GPR[_inst.RD] = -1;
+			rGPR[_inst.RD] = -1;
 		else
-			m_GPR[_inst.RD] = 0;
+			rGPR[_inst.RD] = 0;
 	}
 	else
 	{
-		m_GPR[_inst.RD] = (u32)(a / b);
+		rGPR[_inst.RD] = (u32)(a / b);
 	}
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 
 void Interpreter::divwux(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
-	u32 b = m_GPR[_inst.RB];
+	u32 a = rGPR[_inst.RA];
+	u32 b = rGPR[_inst.RB];
 
 	if (b == 0)
 	{
@@ -546,133 +546,133 @@ void Interpreter::divwux(UGeckoInstruction _inst)
 			PanicAlert("OE: divwux");
 		}
 
-		m_GPR[_inst.RD] = 0;
+		rGPR[_inst.RD] = 0;
 	}
 	else
 	{
-		m_GPR[_inst.RD] = a / b;
+		rGPR[_inst.RD] = a / b;
 	}
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::mulhwx(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
-	u32 b = m_GPR[_inst.RB];
+	u32 a = rGPR[_inst.RA];
+	u32 b = rGPR[_inst.RB];
 	u32 d = (u32)((u64)(((s64)(s32)a * (s64)(s32)b) ) >> 32);  // This can be done better. Not in plain C/C++ though.
-	m_GPR[_inst.RD] = d;
+	rGPR[_inst.RD] = d;
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::mulhwux(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
-	u32 b = m_GPR[_inst.RB];
+	u32 a = rGPR[_inst.RA];
+	u32 b = rGPR[_inst.RB];
 	u32 d = (u32)(((u64)a * (u64)b) >> 32);
-	m_GPR[_inst.RD] = d;
+	rGPR[_inst.RD] = d;
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::mullwx(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
-	u32 b = m_GPR[_inst.RB];
+	u32 a = rGPR[_inst.RA];
+	u32 b = rGPR[_inst.RB];
 	u32 d = (u32)((s32)a * (s32)b);
-	m_GPR[_inst.RD] = d;
+	rGPR[_inst.RD] = d;
 
 	if (_inst.OE)
 		PanicAlert("OE: mullwx");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::negx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RD] = (~m_GPR[_inst.RA]) + 1;
+	rGPR[_inst.RD] = (~rGPR[_inst.RA]) + 1;
 
-	if (m_GPR[_inst.RD] == 0x80000000)
+	if (rGPR[_inst.RD] == 0x80000000)
 	{
 		if (_inst.OE)
 			PanicAlert("OE: negx");
 	}
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::subfx(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RD] = m_GPR[_inst.RB] - m_GPR[_inst.RA];
+	rGPR[_inst.RD] = rGPR[_inst.RB] - rGPR[_inst.RA];
 
 	if (_inst.OE)
 		PanicAlert("OE: subfx");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::subfcx(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
-	u32 b = m_GPR[_inst.RB];
-	m_GPR[_inst.RD] = b - a;
+	u32 a = rGPR[_inst.RA];
+	u32 b = rGPR[_inst.RB];
+	rGPR[_inst.RD] = b - a;
 	SetCarry(a == 0 || Helper_Carry(b, 0-a));
 
 	if (_inst.OE)
 		PanicAlert("OE: subfcx");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 void Interpreter::subfex(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
-	u32 b = m_GPR[_inst.RB];
+	u32 a = rGPR[_inst.RA];
+	u32 b = rGPR[_inst.RB];
 	int carry = GetCarry();
-	m_GPR[_inst.RD] = (~a) + b + carry;
+	rGPR[_inst.RD] = (~a) + b + carry;
 	SetCarry(Helper_Carry(~a, b) || Helper_Carry((~a) + b, carry));
 
 	if (_inst.OE)
 		PanicAlert("OE: subfex");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 // sub from minus one
 void Interpreter::subfmex(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
+	u32 a = rGPR[_inst.RA];
 	int carry = GetCarry();
-	m_GPR[_inst.RD] = (~a) + carry - 1;
+	rGPR[_inst.RD] = (~a) + carry - 1;
 	SetCarry(Helper_Carry(~a, carry - 1));
 
 	if (_inst.OE)
 		PanicAlert("OE: subfmex");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }
 
 // sub from zero
 void Interpreter::subfzex(UGeckoInstruction _inst)
 {
-	u32 a = m_GPR[_inst.RA];
+	u32 a = rGPR[_inst.RA];
 	int carry = GetCarry();
-	m_GPR[_inst.RD] = (~a) + carry;
+	rGPR[_inst.RD] = (~a) + carry;
 	SetCarry(Helper_Carry(~a, carry));
 
 	if (_inst.OE)
 		PanicAlert("OE: subfzex");
 
 	if (_inst.Rc)
-		Helper_UpdateCR0(m_GPR[_inst.RD]);
+		Helper_UpdateCR0(rGPR[_inst.RD]);
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -16,29 +16,29 @@ u32  Interpreter::g_reserveAddr;
 
 u32 Interpreter::Helper_Get_EA(const UGeckoInstruction _inst)
 {
-	return _inst.RA ? (m_GPR[_inst.RA] + _inst.SIMM_16) : (u32)_inst.SIMM_16;
+	return _inst.RA ? (rGPR[_inst.RA] + _inst.SIMM_16) : (u32)_inst.SIMM_16;
 }
 
 u32 Interpreter::Helper_Get_EA_U(const UGeckoInstruction _inst)
 {
-	return (m_GPR[_inst.RA] + _inst.SIMM_16);
+	return (rGPR[_inst.RA] + _inst.SIMM_16);
 }
 
 u32 Interpreter::Helper_Get_EA_X(const UGeckoInstruction _inst)
 {
-	return _inst.RA ? (m_GPR[_inst.RA] + m_GPR[_inst.RB]) : m_GPR[_inst.RB];
+	return _inst.RA ? (rGPR[_inst.RA] + rGPR[_inst.RB]) : rGPR[_inst.RB];
 }
 
 u32 Interpreter::Helper_Get_EA_UX(const UGeckoInstruction _inst)
 {
-	return (m_GPR[_inst.RA] + m_GPR[_inst.RB]);
+	return (rGPR[_inst.RA] + rGPR[_inst.RB]);
 }
 
 void Interpreter::lbz(UGeckoInstruction _inst)
 {
 	u32 temp = (u32)Memory::Read_U8(Helper_Get_EA(_inst));
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 }
 
 void Interpreter::lbzu(UGeckoInstruction _inst)
@@ -47,8 +47,8 @@ void Interpreter::lbzu(UGeckoInstruction _inst)
 	u32 temp = (u32)Memory::Read_U8(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RD] = temp;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -66,7 +66,7 @@ void Interpreter::lfdu(UGeckoInstruction _inst)
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
 		riPS0(_inst.FD) = temp;
-		m_GPR[_inst.RA]  = uAddress;
+		rGPR[_inst.RA]  = uAddress;
 	}
 }
 
@@ -77,7 +77,7 @@ void Interpreter::lfdux(UGeckoInstruction _inst)
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
 		riPS0(_inst.FD) = temp;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -108,7 +108,7 @@ void Interpreter::lfsu(UGeckoInstruction _inst)
 		u64 value = ConvertToDouble(uTemp);
 		riPS0(_inst.FD) = value;
 		riPS1(_inst.FD) = value;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 
 }
@@ -122,7 +122,7 @@ void Interpreter::lfsux(UGeckoInstruction _inst)
 		u64 value = ConvertToDouble(uTemp);
 		riPS0(_inst.FD) = value;
 		riPS1(_inst.FD) = value;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -142,7 +142,7 @@ void Interpreter::lha(UGeckoInstruction _inst)
 	u32 temp = (u32)(s32)(s16)Memory::Read_U16(Helper_Get_EA(_inst));
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 	}
 }
 
@@ -152,8 +152,8 @@ void Interpreter::lhau(UGeckoInstruction _inst)
 	u32 temp = (u32)(s32)(s16)Memory::Read_U16(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RD] = temp;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -162,7 +162,7 @@ void Interpreter::lhz(UGeckoInstruction _inst)
 	u32 temp = (u32)(u16)Memory::Read_U16(Helper_Get_EA(_inst));
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 	}
 }
 
@@ -172,8 +172,8 @@ void Interpreter::lhzu(UGeckoInstruction _inst)
 	u32 temp = (u32)(u16)Memory::Read_U16(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RD] = temp;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -192,7 +192,7 @@ void Interpreter::lmw(UGeckoInstruction _inst)
 		}
 		else
 		{
-			m_GPR[iReg] = TempReg;
+			rGPR[iReg] = TempReg;
 		}
 	}
 }
@@ -203,7 +203,7 @@ void Interpreter::stmw(UGeckoInstruction _inst)
 	u32 uAddress = Helper_Get_EA(_inst);
 	for (int iReg = _inst.RS; iReg <= 31; iReg++, uAddress+=4)
 	{
-		Memory::Write_U32(m_GPR[iReg], uAddress);
+		Memory::Write_U32(rGPR[iReg], uAddress);
 		if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
 		{
 			PanicAlert("DSI exception in stmw");
@@ -219,7 +219,7 @@ void Interpreter::lwz(UGeckoInstruction _inst)
 	u32 temp = Memory::Read_U32(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 	}
 }
 
@@ -229,23 +229,23 @@ void Interpreter::lwzu(UGeckoInstruction _inst)
 	u32 temp = Memory::Read_U32(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RD] = temp;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
 void Interpreter::stb(UGeckoInstruction _inst)
 {
-	Memory::Write_U8((u8)m_GPR[_inst.RS], Helper_Get_EA(_inst));
+	Memory::Write_U8((u8)rGPR[_inst.RS], Helper_Get_EA(_inst));
 }
 
 void Interpreter::stbu(UGeckoInstruction _inst)
 {
 	u32 uAddress = Helper_Get_EA_U(_inst);
-	Memory::Write_U8((u8)m_GPR[_inst.RS], uAddress);
+	Memory::Write_U8((u8)rGPR[_inst.RS], uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -260,7 +260,7 @@ void Interpreter::stfdu(UGeckoInstruction _inst)
 	Memory::Write_U64(riPS0(_inst.FS), uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -275,37 +275,37 @@ void Interpreter::stfsu(UGeckoInstruction _inst)
 	Memory::Write_U32(ConvertToSingle(riPS0(_inst.FS)), uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
 void Interpreter::sth(UGeckoInstruction _inst)
 {
-	Memory::Write_U16((u16)m_GPR[_inst.RS], Helper_Get_EA(_inst));
+	Memory::Write_U16((u16)rGPR[_inst.RS], Helper_Get_EA(_inst));
 }
 
 void Interpreter::sthu(UGeckoInstruction _inst)
 {
 	u32 uAddress = Helper_Get_EA_U(_inst);
-	Memory::Write_U16((u16)m_GPR[_inst.RS], uAddress);
+	Memory::Write_U16((u16)rGPR[_inst.RS], uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
 void Interpreter::stw(UGeckoInstruction _inst)
 {
-	Memory::Write_U32(m_GPR[_inst.RS], Helper_Get_EA(_inst));
+	Memory::Write_U32(rGPR[_inst.RS], Helper_Get_EA(_inst));
 }
 
 void Interpreter::stwu(UGeckoInstruction _inst)
 {
 	u32 uAddress = Helper_Get_EA_U(_inst);
-	Memory::Write_U32(m_GPR[_inst.RS], uAddress);
+	Memory::Write_U32(rGPR[_inst.RS], uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -390,8 +390,8 @@ void Interpreter::eciwx(UGeckoInstruction _inst)
 	if (_inst.RA == 0)
 		b = 0;
 	else
-		b = m_GPR[_inst.RA];
-	EA = b + m_GPR[_inst.RB];
+		b = rGPR[_inst.RA];
+	EA = b + rGPR[_inst.RB];
 
 	if (!(PowerPC::ppcState.spr[SPR_EAR] & 0x80000000))
 	{
@@ -403,7 +403,7 @@ void Interpreter::eciwx(UGeckoInstruction _inst)
 // 	_assert_msg_(POWERPC,0,"eciwx - fill r%i with word @ %08x from device %02x",
 // 		_inst.RS, EA, PowerPC::ppcState.spr[SPR_EAR] & 0x1f);
 
-	m_GPR[_inst.RS] = Memory::Read_U32(EA);
+	rGPR[_inst.RS] = Memory::Read_U32(EA);
 }
 
 void Interpreter::ecowx(UGeckoInstruction _inst)
@@ -412,8 +412,8 @@ void Interpreter::ecowx(UGeckoInstruction _inst)
 	if (_inst.RA == 0)
 		b = 0;
 	else
-		b = m_GPR[_inst.RA];
-	EA = b + m_GPR[_inst.RB];
+		b = rGPR[_inst.RA];
+	EA = b + rGPR[_inst.RB];
 
 	if (!(PowerPC::ppcState.spr[SPR_EAR] & 0x80000000))
 	{
@@ -423,9 +423,9 @@ void Interpreter::ecowx(UGeckoInstruction _inst)
 		Common::AtomicOr(PowerPC::ppcState.Exceptions, EXCEPTION_ALIGNMENT);
 
 // 	_assert_msg_(POWERPC,0,"ecowx - send stw request (%08x@%08x) to device %02x",
-// 		m_GPR[_inst.RS], EA, PowerPC::ppcState.spr[SPR_EAR] & 0x1f);
+// 		rGPR[_inst.RS], EA, PowerPC::ppcState.spr[SPR_EAR] & 0x1f);
 
-	Memory::Write_U32(m_GPR[_inst.RS], EA);
+	Memory::Write_U32(rGPR[_inst.RS], EA);
 }
 
 void Interpreter::eieio(UGeckoInstruction _inst)
@@ -448,8 +448,8 @@ void Interpreter::lbzux(UGeckoInstruction _inst)
 	u32 temp = (u32)Memory::Read_U8(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RD] = temp;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -458,7 +458,7 @@ void Interpreter::lbzx(UGeckoInstruction _inst)
 	u32 temp = (u32)Memory::Read_U8(Helper_Get_EA_X(_inst));
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 	}
 }
 
@@ -468,8 +468,8 @@ void Interpreter::lhaux(UGeckoInstruction _inst)
 	s32 temp = (s32)(s16)Memory::Read_U16(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RD] = temp;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -478,7 +478,7 @@ void Interpreter::lhax(UGeckoInstruction _inst)
 	s32 temp = (s32)(s16)Memory::Read_U16(Helper_Get_EA_X(_inst));
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 	}
 }
 
@@ -487,7 +487,7 @@ void Interpreter::lhbrx(UGeckoInstruction _inst)
 	u32 temp = (u32)Common::swap16(Memory::Read_U16(Helper_Get_EA_X(_inst)));
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 	}
 }
 
@@ -497,8 +497,8 @@ void Interpreter::lhzux(UGeckoInstruction _inst)
 	u32 temp = (u32)Memory::Read_U16(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RD] = temp;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -507,7 +507,7 @@ void Interpreter::lhzx(UGeckoInstruction _inst)
 	u32 temp = (u32)Memory::Read_U16(Helper_Get_EA_X(_inst));
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 	}
 }
 
@@ -522,7 +522,7 @@ void Interpreter::lswx(UGeckoInstruction _inst)
 
 	if (n > 0)
 	{
-		m_GPR[r] = 0;
+		rGPR[r] = 0;
 		do
 		{
 			u32 TempValue = Memory::Read_U8(EA) << (24 - i);
@@ -532,7 +532,7 @@ void Interpreter::lswx(UGeckoInstruction _inst)
 				NOTICE_LOG(POWERPC, "DSI exception in lswx");
 				return;
 			}
-			m_GPR[r] |= TempValue;
+			rGPR[r] |= TempValue;
 
 			EA++;
 			n--;
@@ -541,7 +541,7 @@ void Interpreter::lswx(UGeckoInstruction _inst)
 			{
 				i = 0;
 				r = (r + 1) & 31;
-				m_GPR[r] = 0;
+				rGPR[r] = 0;
 			}
 		} while (n > 0);
 	}
@@ -552,7 +552,7 @@ void Interpreter::lwbrx(UGeckoInstruction _inst)
 	u32 temp = Common::swap32(Memory::Read_U32(Helper_Get_EA_X(_inst)));
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 	}
 }
 
@@ -562,8 +562,8 @@ void Interpreter::lwzux(UGeckoInstruction _inst)
 	u32 temp = Memory::Read_U32(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RD] = temp;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -573,23 +573,23 @@ void Interpreter::lwzx(UGeckoInstruction _inst)
 	u32 temp = Memory::Read_U32(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 	}
 }
 
 void Interpreter::stbux(UGeckoInstruction _inst)
 {
 	u32 uAddress = Helper_Get_EA_UX(_inst);
-	Memory::Write_U8((u8)m_GPR[_inst.RS], uAddress);
+	Memory::Write_U8((u8)rGPR[_inst.RS], uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
 void Interpreter::stbx(UGeckoInstruction _inst)
 {
-	Memory::Write_U8((u8)m_GPR[_inst.RS], Helper_Get_EA_X(_inst));
+	Memory::Write_U8((u8)rGPR[_inst.RS], Helper_Get_EA_X(_inst));
 }
 
 void Interpreter::stfdux(UGeckoInstruction _inst)
@@ -598,7 +598,7 @@ void Interpreter::stfdux(UGeckoInstruction _inst)
 	Memory::Write_U64(riPS0(_inst.FS), uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -625,7 +625,7 @@ void Interpreter::stfsux(UGeckoInstruction _inst)
 	Memory::Write_U32(ConvertToSingle(riPS0(_inst.FS)), uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
@@ -636,22 +636,22 @@ void Interpreter::stfsx(UGeckoInstruction _inst)
 
 void Interpreter::sthbrx(UGeckoInstruction _inst)
 {
-	Memory::Write_U16(Common::swap16((u16)m_GPR[_inst.RS]), Helper_Get_EA_X(_inst));
+	Memory::Write_U16(Common::swap16((u16)rGPR[_inst.RS]), Helper_Get_EA_X(_inst));
 }
 
 void Interpreter::sthux(UGeckoInstruction _inst)
 {
 	u32 uAddress = Helper_Get_EA_UX(_inst);
-	Memory::Write_U16((u16)m_GPR[_inst.RS], uAddress);
+	Memory::Write_U16((u16)rGPR[_inst.RS], uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
 void Interpreter::sthx(UGeckoInstruction _inst)
 {
-	Memory::Write_U16((u16)m_GPR[_inst.RS], Helper_Get_EA_X(_inst));
+	Memory::Write_U16((u16)rGPR[_inst.RS], Helper_Get_EA_X(_inst));
 }
 
 // __________________________________________________________________________________________________
@@ -663,7 +663,7 @@ void Interpreter::lswi(UGeckoInstruction _inst)
 	if (_inst.RA == 0)
 		EA = 0;
 	else
-		EA = m_GPR[_inst.RA];
+		EA = rGPR[_inst.RA];
 
 	u32 n;
 	if (_inst.NB == 0)
@@ -679,7 +679,7 @@ void Interpreter::lswi(UGeckoInstruction _inst)
 		{
 			r++;
 			r &= 31;
-			m_GPR[r] = 0;
+			rGPR[r] = 0;
 		}
 
 		u32 TempValue = Memory::Read_U8(EA) << (24 - i);
@@ -689,7 +689,7 @@ void Interpreter::lswi(UGeckoInstruction _inst)
 			return;
 		}
 
-		m_GPR[r] |= TempValue;
+		rGPR[r] |= TempValue;
 
 		i += 8;
 		if (i == 32)
@@ -709,7 +709,7 @@ void Interpreter::stswi(UGeckoInstruction _inst)
 	if (_inst.RA == 0)
 		EA = 0;
 	else
-		EA = m_GPR[_inst.RA];
+		EA = rGPR[_inst.RA];
 
 	u32 n;
 	if (_inst.NB == 0)
@@ -726,7 +726,7 @@ void Interpreter::stswi(UGeckoInstruction _inst)
 			r++;
 			r &= 31;
 		}
-		Memory::Write_U8((m_GPR[r] >> (24 - i)) & 0xFF, EA);
+		Memory::Write_U8((rGPR[r] >> (24 - i)) & 0xFF, EA);
 		if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
 		{
 			return;
@@ -750,7 +750,7 @@ void Interpreter::stswx(UGeckoInstruction _inst)
 
 	while (n > 0)
 	{
-		Memory::Write_U8((m_GPR[r] >> (24 - i)) & 0xFF, EA);
+		Memory::Write_U8((rGPR[r] >> (24 - i)) & 0xFF, EA);
 
 		EA++;
 		n--;
@@ -766,7 +766,7 @@ void Interpreter::stswx(UGeckoInstruction _inst)
 void Interpreter::stwbrx(UGeckoInstruction _inst)
 {
 	u32 uAddress = Helper_Get_EA_X(_inst);
-	Memory::Write_U32(Common::swap32(m_GPR[_inst.RS]), uAddress);
+	Memory::Write_U32(Common::swap32(rGPR[_inst.RS]), uAddress);
 }
 
 
@@ -779,7 +779,7 @@ void Interpreter::lwarx(UGeckoInstruction _inst)
 	u32 temp = Memory::Read_U32(uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RD] = temp;
+		rGPR[_inst.RD] = temp;
 		g_bReserve = true;
 		g_reserveAddr = uAddress;
 	}
@@ -795,7 +795,7 @@ void Interpreter::stwcxd(UGeckoInstruction _inst)
 
 		if (uAddress == g_reserveAddr)
 		{
-			Memory::Write_U32(m_GPR[_inst.RS], uAddress);
+			Memory::Write_U32(rGPR[_inst.RS], uAddress);
 			if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 			{
 				g_bReserve = false;
@@ -811,17 +811,17 @@ void Interpreter::stwcxd(UGeckoInstruction _inst)
 void Interpreter::stwux(UGeckoInstruction _inst)
 {
 	u32 uAddress = Helper_Get_EA_UX(_inst);
-	Memory::Write_U32(m_GPR[_inst.RS], uAddress);
+	Memory::Write_U32(rGPR[_inst.RS], uAddress);
 	if (!(PowerPC::ppcState.Exceptions & EXCEPTION_DSI))
 	{
-		m_GPR[_inst.RA] = uAddress;
+		rGPR[_inst.RA] = uAddress;
 	}
 }
 
 void Interpreter::stwx(UGeckoInstruction _inst)
 {
 	u32 uAddress = Helper_Get_EA_X(_inst);
-	Memory::Write_U32(m_GPR[_inst.RS], uAddress);
+	Memory::Write_U32(rGPR[_inst.RS], uAddress);
 }
 
 void Interpreter::sync(UGeckoInstruction _inst)
@@ -840,7 +840,7 @@ void Interpreter::tlbia(UGeckoInstruction _inst)
 void Interpreter::tlbie(UGeckoInstruction _inst)
 {
 	// Invalidate TLB entry
-	u32 _Address = m_GPR[_inst.RB];
+	u32 _Address = rGPR[_inst.RB];
 	Memory::InvalidateTLBEntry(_Address);
 }
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
@@ -139,7 +139,7 @@ void Interpreter::psq_l(UGeckoInstruction _inst)
 	const EQuantizeType ldType = gqr.ld_type;
 	const unsigned int ldScale = gqr.ld_scale;
 	const u32 EA = _inst.RA ?
-		(m_GPR[_inst.RA] + _inst.SIMM_12) : (u32)_inst.SIMM_12;
+		(rGPR[_inst.RA] + _inst.SIMM_12) : (u32)_inst.SIMM_12;
 
 	int c = 4;
 	if (ldType == QUANTIZE_U8  || ldType == QUANTIZE_S8)
@@ -175,7 +175,7 @@ void Interpreter::psq_lu(UGeckoInstruction _inst)
 	const UGQR gqr(rSPR(SPR_GQR0 + _inst.I));
 	const EQuantizeType ldType = gqr.ld_type;
 	const unsigned int ldScale = gqr.ld_scale;
-	const u32 EA = m_GPR[_inst.RA] + _inst.SIMM_12;
+	const u32 EA = rGPR[_inst.RA] + _inst.SIMM_12;
 
 	int c = 4;
 	if (ldType == QUANTIZE_U8 || ldType == QUANTIZE_S8)
@@ -204,7 +204,7 @@ void Interpreter::psq_lu(UGeckoInstruction _inst)
 		rPS0(_inst.RS) = ps0;
 		rPS1(_inst.RS) = 1.0f;
 	}
-	m_GPR[_inst.RA] = EA;
+	rGPR[_inst.RA] = EA;
 }
 
 void Interpreter::psq_st(UGeckoInstruction _inst)
@@ -213,7 +213,7 @@ void Interpreter::psq_st(UGeckoInstruction _inst)
 	const EQuantizeType stType = gqr.st_type;
 	const unsigned int stScale = gqr.st_scale;
 	const u32 EA = _inst.RA ?
-		(m_GPR[_inst.RA] + _inst.SIMM_12) : (u32)_inst.SIMM_12;
+		(rGPR[_inst.RA] + _inst.SIMM_12) : (u32)_inst.SIMM_12;
 
 	int c = 4;
 	if (stType == QUANTIZE_U8 || stType == QUANTIZE_S8)
@@ -237,7 +237,7 @@ void Interpreter::psq_stu(UGeckoInstruction _inst)
 	const UGQR gqr(rSPR(SPR_GQR0 + _inst.I));
 	const EQuantizeType stType = gqr.st_type;
 	const unsigned int stScale = gqr.st_scale;
-	const u32 EA = m_GPR[_inst.RA] + _inst.SIMM_12;
+	const u32 EA = rGPR[_inst.RA] + _inst.SIMM_12;
 
 	int c = 4;
 	if (stType == QUANTIZE_U8 || stType == QUANTIZE_S8)
@@ -258,7 +258,7 @@ void Interpreter::psq_stu(UGeckoInstruction _inst)
 	{
 		return;
 	}
-	m_GPR[_inst.RA] = EA;
+	rGPR[_inst.RA] = EA;
 }
 
 void Interpreter::psq_lx(UGeckoInstruction _inst)
@@ -266,7 +266,7 @@ void Interpreter::psq_lx(UGeckoInstruction _inst)
 	const UGQR gqr(rSPR(SPR_GQR0 + _inst.Ix));
 	const EQuantizeType ldType = gqr.ld_type;
 	const unsigned int ldScale = gqr.ld_scale;
-	const u32 EA = _inst.RA ? (m_GPR[_inst.RA] + m_GPR[_inst.RB]) : m_GPR[_inst.RB];
+	const u32 EA = _inst.RA ? (rGPR[_inst.RA] + rGPR[_inst.RB]) : rGPR[_inst.RB];
 
 	int c = 4;
 	if (ldType == QUANTIZE_U8 || ldType == QUANTIZE_S8)
@@ -307,7 +307,7 @@ void Interpreter::psq_stx(UGeckoInstruction _inst)
 	const UGQR gqr(rSPR(SPR_GQR0 + _inst.Ix));
 	const EQuantizeType stType = gqr.st_type;
 	const unsigned int stScale = gqr.st_scale;
-	const u32 EA = _inst.RA ? (m_GPR[_inst.RA] + m_GPR[_inst.RB]) : m_GPR[_inst.RB];
+	const u32 EA = _inst.RA ? (rGPR[_inst.RA] + rGPR[_inst.RB]) : rGPR[_inst.RB];
 
 	int c = 4;
 	if (stType == QUANTIZE_U8 || stType == QUANTIZE_S8)
@@ -331,7 +331,7 @@ void Interpreter::psq_lux(UGeckoInstruction _inst)
 	const UGQR gqr(rSPR(SPR_GQR0 + _inst.Ix));
 	const EQuantizeType ldType = gqr.ld_type;
 	const unsigned int ldScale = gqr.ld_scale;
-	const u32 EA = m_GPR[_inst.RA] + m_GPR[_inst.RB];
+	const u32 EA = rGPR[_inst.RA] + rGPR[_inst.RB];
 
 	int c = 4;
 	if (ldType == QUANTIZE_U8 || ldType == QUANTIZE_S8)
@@ -360,7 +360,7 @@ void Interpreter::psq_lux(UGeckoInstruction _inst)
 		rPS0(_inst.RS) = ps0;
 		rPS1(_inst.RS) = 1.0f;
 	}
-	m_GPR[_inst.RA] = EA;
+	rGPR[_inst.RA] = EA;
 }
 
 void Interpreter::psq_stux(UGeckoInstruction _inst)
@@ -368,7 +368,7 @@ void Interpreter::psq_stux(UGeckoInstruction _inst)
 	const UGQR gqr(rSPR(SPR_GQR0 + _inst.Ix));
 	const EQuantizeType stType = gqr.st_type;
 	const unsigned int stScale = gqr.st_scale;
-	const u32 EA = m_GPR[_inst.RA] + m_GPR[_inst.RB];
+	const u32 EA = rGPR[_inst.RA] + rGPR[_inst.RB];
 
 	int c = 4;
 	if (stType == QUANTIZE_U8 || stType == QUANTIZE_S8)
@@ -389,6 +389,6 @@ void Interpreter::psq_stux(UGeckoInstruction _inst)
 	{
 		return;
 	}
-	m_GPR[_inst.RA] = EA;
+	rGPR[_inst.RA] = EA;
 
 }  // namespace=======

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -119,7 +119,7 @@ void Interpreter::mcrxr(UGeckoInstruction _inst)
 
 void Interpreter::mfcr(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RD] = GetCR();
+	rGPR[_inst.RD] = GetCR();
 }
 
 void Interpreter::mtcrf(UGeckoInstruction _inst)
@@ -127,7 +127,7 @@ void Interpreter::mtcrf(UGeckoInstruction _inst)
 	u32 crm = _inst.CRM;
 	if (crm == 0xFF)
 	{
-		SetCR(m_GPR[_inst.RS]);
+		SetCR(rGPR[_inst.RS]);
 	}
 	else
 	{
@@ -139,7 +139,7 @@ void Interpreter::mtcrf(UGeckoInstruction _inst)
 				mask |= 0xF << (i*4);
 		}
 
-		SetCR((GetCR() & ~mask) | (m_GPR[_inst.RS] & mask));
+		SetCR((GetCR() & ~mask) | (rGPR[_inst.RS] & mask));
 	}
 }
 
@@ -147,24 +147,24 @@ void Interpreter::mtcrf(UGeckoInstruction _inst)
 void Interpreter::mfmsr(UGeckoInstruction _inst)
 {
 	//Privileged?
-	m_GPR[_inst.RD] = MSR;
+	rGPR[_inst.RD] = MSR;
 }
 
 void Interpreter::mfsr(UGeckoInstruction _inst)
 {
-	m_GPR[_inst.RD] = PowerPC::ppcState.sr[_inst.SR];
+	rGPR[_inst.RD] = PowerPC::ppcState.sr[_inst.SR];
 }
 
 void Interpreter::mfsrin(UGeckoInstruction _inst)
 {
-	int index = (m_GPR[_inst.RB] >> 28) & 0xF;
-	m_GPR[_inst.RD] = PowerPC::ppcState.sr[index];
+	int index = (rGPR[_inst.RB] >> 28) & 0xF;
+	rGPR[_inst.RD] = PowerPC::ppcState.sr[index];
 }
 
 void Interpreter::mtmsr(UGeckoInstruction _inst)
 {
 	// Privileged?
-	MSR = m_GPR[_inst.RS];
+	MSR = rGPR[_inst.RS];
 	PowerPC::CheckExceptions();
 	m_EndBlock = true;
 }
@@ -180,14 +180,14 @@ static void SetSR(int index, u32 value)
 void Interpreter::mtsr(UGeckoInstruction _inst)
 {
 	int index = _inst.SR;
-	u32 value = m_GPR[_inst.RS];
+	u32 value = rGPR[_inst.RS];
 	SetSR(index, value);
 }
 
 void Interpreter::mtsrin(UGeckoInstruction _inst)
 {
-	int index = (m_GPR[_inst.RB] >> 28) & 0xF;
-	u32 value = m_GPR[_inst.RS];
+	int index = (rGPR[_inst.RB] >> 28) & 0xF;
+	u32 value = rGPR[_inst.RS];
 	SetSR(index, value);
 }
 
@@ -239,14 +239,14 @@ void Interpreter::mfspr(UGeckoInstruction _inst)
 		rSPR(iIndex) = GetXER().Hex;
 		break;
 	}
-	m_GPR[_inst.RD] = rSPR(iIndex);
+	rGPR[_inst.RD] = rSPR(iIndex);
 }
 
 void Interpreter::mtspr(UGeckoInstruction _inst)
 {
 	u32 iIndex = (_inst.SPRU << 5) | (_inst.SPRL & 0x1F);
 	u32 oldValue = rSPR(iIndex);
-	rSPR(iIndex) = m_GPR[_inst.RD];
+	rSPR(iIndex) = rGPR[_inst.RD];
 
 	//TODO - check processor privilege level - many of these require privilege
 	//XER LR CTR are the only ones available in user mode, time base can be read too.
@@ -263,12 +263,12 @@ void Interpreter::mtspr(UGeckoInstruction _inst)
 		break;
 
 	case SPR_TL_W:
-		TL = m_GPR[_inst.RD];
+		TL = rGPR[_inst.RD];
 		SystemTimers::TimeBaseSet();
 		break;
 
 	case SPR_TU_W:
-		TU = m_GPR[_inst.RD];
+		TU = rGPR[_inst.RD];
 		SystemTimers::TimeBaseSet();
 		break;
 
@@ -302,7 +302,7 @@ void Interpreter::mtspr(UGeckoInstruction _inst)
 		break;
 
 	case SPR_WPAR:
-		_assert_msg_(POWERPC, m_GPR[_inst.RD] == 0x0C008000, "Gather pipe @ %08x", PC);
+		_assert_msg_(POWERPC, rGPR[_inst.RD] == 0x0C008000, "Gather pipe @ %08x", PC);
 		GPFifo::ResetGatherPipe();
 		break;
 
@@ -341,7 +341,7 @@ void Interpreter::mtspr(UGeckoInstruction _inst)
 		break;
 
 	case SPR_DEC:
-		if (!(oldValue >> 31) && (m_GPR[_inst.RD]>>31))   //top bit from 0 to 1
+		if (!(oldValue >> 31) && (rGPR[_inst.RD]>>31))   //top bit from 0 to 1
 		{
 			PanicAlert("Interesting - Software triggered Decrementer exception");
 			Common::AtomicOr(PowerPC::ppcState.Exceptions, EXCEPTION_DECREMENTER);


### PR DESCRIPTION
We have an equivalent macro centralized in PowerPC.h called rGPR
