### PR TITLE
VideoCommon{Backends}: Remove unnecessary wxWidgets references.

### DIFF
--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -15,11 +15,15 @@ if(WIN32)
 				ControllerInterface/XInput/XInput.cpp
 				ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	FIND_LIBRARY(COREFOUNDATION_LIBRARY CoreFoundation)
+	FIND_LIBRARY(CARBON_LIBRARY Carbon)
+	FIND_LIBRARY(COCOA_LIBRARY Cocoa)
 	set(SRCS	${SRCS}
 				ControllerInterface/OSX/OSX.mm
 				ControllerInterface/OSX/OSXKeyboard.mm
 				ControllerInterface/OSX/OSXJoystick.mm
 				ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp)
+	set(LIBS ${LIBS} ${COREFOUNDATION_LIBRARY} ${CARBON_LIBRARY} ${COCOA_LIBRARY})
 elseif(X11_FOUND)
 	set(SRCS	${SRCS}
 				ControllerInterface/Xlib/Xlib.cpp)

--- a/Source/Core/VideoBackends/OGL/CMakeLists.txt
+++ b/Source/Core/VideoBackends/OGL/CMakeLists.txt
@@ -24,10 +24,6 @@ if(USE_EGL)
 		EGL)
 endif()
 
-if(wxWidgets_FOUND)
-	set(LIBS	${LIBS} ${wxWidgets_LIBRARIES})
-endif(wxWidgets_FOUND)
-
 if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR
 	${CMAKE_SYSTEM_NAME} MATCHES "NetBSD")
 	set(LIBS	${LIBS} usbhid)

--- a/Source/Core/VideoBackends/OGL/OGL.vcxproj
+++ b/Source/Core/VideoBackends/OGL/OGL.vcxproj
@@ -98,9 +98,6 @@
     <Text Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(ExternalsDir)wxWidgets3\build\msw\wx_base.vcxproj">
-      <Project>{1c8436c9-dbaf-42be-83bc-cf3ec9175abe}</Project>
-    </ProjectReference>
     <ProjectReference Include="$(ExternalsDir)zlib\zlib.vcxproj">
       <Project>{ff213b23-2c26-4214-9f88-85271e557e87}</Project>
     </ProjectReference>

--- a/Source/Core/VideoBackends/Software/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Software/CMakeLists.txt
@@ -21,10 +21,9 @@ set(SRCS BPMemLoader.cpp
 	   SWVideoConfig.cpp
 	   XFMemLoader.cpp)
 
-set(LIBS	videocommon
-			SOIL
-			common
-			${X11_LIBRARIES}
-			${wxWidgets_LIBRARIES})
+set(LIBS videocommon
+         SOIL
+         common
+         ${X11_LIBRARIES})
 
 add_dolphin_library(videosoftware "${SRCS}" "${LIBS}")

--- a/Source/Core/VideoBackends/Software/Software.vcxproj
+++ b/Source/Core/VideoBackends/Software/Software.vcxproj
@@ -88,9 +88,6 @@
     <Text Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(ExternalsDir)wxWidgets3\build\msw\wx_base.vcxproj">
-      <Project>{1c8436c9-dbaf-42be-83bc-cf3ec9175abe}</Project>
-    </ProjectReference>
     <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
       <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
     </ProjectReference>

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -50,10 +50,6 @@ if(NOT ${CL} STREQUAL CL-NOTFOUND)
 	list(APPEND LIBS ${CL})
 endif()
 
-if(wxWidgets_FOUND AND WIN32)
-	set(SRCS ${SRCS} EmuWindow.cpp)
-endif()
-
 if(LIBAV_FOUND OR WIN32)
 	set(SRCS ${SRCS} AVIDump.cpp)
 endif()


### PR DESCRIPTION
Also EmuWindow doesn't even exist anymore.

Turns out InputCommon actually relied on wx linking in the correct OSX libraries, so it removes even more coupling in that regard.

Now building VideoCommon and the Software and OGL backends isn't blocked by the compilation of wx (at least on OSX. *nix just ignores building the static version if wx is already installed on the system).
