### PR TITLE
Remove GetPointers in VideoSoftware.

### DIFF
--- a/Source/Core/VideoBackends/Software/BPMemLoader.cpp
+++ b/Source/Core/VideoBackends/Software/BPMemLoader.cpp
@@ -91,19 +91,14 @@ void SWBPWritten(int address, int newvalue)
 		{
 			u32 tlutTMemAddr = (newvalue & 0x3FF) << 9;
 			u32 tlutXferCount = (newvalue & 0x1FFC00) >> 5;
+			u32 addr = bpmem.tmem_config.tlut_src << 5;
 
-			u8 *ptr = nullptr;
+			// The GameCube ignores the upper bits of this address. Some games (WW, MKDD) set them.
+			if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
+				addr = addr & 0x01FFFFFF;
 
-			// TODO - figure out a cleaner way.
-			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
-				ptr = Memory::GetPointer(bpmem.tmem_config.tlut_src << 5);
-			else
-				ptr = Memory::GetPointer((bpmem.tmem_config.tlut_src & 0xFFFFF) << 5);
+			Memory::CopyFromEmu(texMem + tlutTMemAddr, addr, tlutXferCount);
 
-			if (ptr)
-				memcpy(texMem + tlutTMemAddr, ptr, tlutXferCount);
-			else
-				PanicAlert("Invalid palette pointer %08x %08x %08x", bpmem.tmem_config.tlut_src, bpmem.tmem_config.tlut_src << 5, (bpmem.tmem_config.tlut_src & 0xFFFFF)<< 5);
 			break;
 		}
 
@@ -114,7 +109,7 @@ void SWBPWritten(int address, int newvalue)
 			// NOTE: libogc's implementation of GX_PreloadEntireTexture seems flawed, so it's not necessarily a good reference for RE'ing this feature.
 
 			BPS_TmemConfig& tmem_cfg = bpmem.tmem_config;
-			u8* src_ptr = Memory::GetPointer(tmem_cfg.preload_addr << 5); // TODO: Should we add mask here on GC?
+			u32 src_addr = tmem_cfg.preload_addr << 5; // TODO: Should we add mask here on GC?
 			u32 size = tmem_cfg.preload_tile_info.count * TMEM_LINE_SIZE;
 			u32 tmem_addr_even = tmem_cfg.preload_tmem_even * TMEM_LINE_SIZE;
 
@@ -123,10 +118,12 @@ void SWBPWritten(int address, int newvalue)
 				if (tmem_addr_even + size > TMEM_SIZE)
 					size = TMEM_SIZE - tmem_addr_even;
 
-				memcpy(texMem + tmem_addr_even, src_ptr, size);
+				Memory::CopyFromEmu(texMem + tmem_addr_even, src_addr, size);
 			}
 			else // RGBA8 tiles (and CI14, but that might just be stupid libogc!)
 			{
+				u8* src_ptr = Memory::GetPointer(src_addr);
+
 				// AR and GB tiles are stored in separate TMEM banks => can't use a single memcpy for everything
 				u32 tmem_addr_odd = tmem_cfg.preload_tmem_odd * TMEM_LINE_SIZE;
 


### PR DESCRIPTION
This same code was previously fixed in VideoCommon, just updating this to match.

We are down to 121 GetPointers.
