### PR TITLE
Reorder MainNoGUI shutdown

### DIFF
--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -367,8 +367,8 @@ int main(int argc, char* argv[])
 	while (PowerPC::GetState() != PowerPC::CPU_POWERDOWN)
 		updateMainFrameEvent.Wait();
 
-	platform->Shutdown();
 	Core::Shutdown();
+	platform->Shutdown();
 	UICommon::Shutdown();
 
 	delete platform;


### PR DESCRIPTION
Before this change I always got this when closing dolphin-emu-nogui:

```
X Error of failed request:  BadWindow (invalid Window parameter)
  Major opcode of failed request:  10 (X_UnmapWindow)
  Resource id in failed request:  0x3400003
  Serial number of failed request:  215
  Current serial number in output stream:  219
terminate called without an active exception
Aborted
```
