### PR TITLE
DSPHLE: Remove individual byteswaps and replace with generic function.

### DIFF
--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -171,7 +171,7 @@ inline void swap<8>(u8* data)
 template <typename T>
 inline T FromBigEndian(T data)
 {
-	//static_assert(std::is_arithmetic<T>::value, "function only makes sense with arithmetic types");
+	static_assert(std::is_arithmetic<T>::value, "function only makes sense with arithmetic types");
 
 	swap<sizeof(data)>(reinterpret_cast<u8*>(&data));
 	return data;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -403,8 +403,7 @@ void AXUCode::ProcessPBList(u32 pb_addr)
 			m_samples_auxB_surround
 		}};
 
-		if (!ReadPB(pb_addr, pb))
-			break;
+		ReadPB(pb_addr, pb);
 
 		u32 updates_addr = HILO_TO_32(pb.updates.data);
 		u16* updates = (u16*)HLEMemory_Get_Pointer(updates_addr);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -78,31 +78,17 @@ union AXBuffers
 };
 
 // Read a PB from MRAM/ARAM
-bool ReadPB(u32 addr, PB_TYPE& pb)
+void ReadPB(u32 addr, PB_TYPE& pb)
 {
 	u16* dst = (u16*)&pb;
-	const u16* src = (const u16*)Memory::GetPointer(addr);
-	if (!src)
-		return false;
-
-	for (u32 i = 0; i < sizeof (pb) / sizeof (u16); ++i)
-		dst[i] = Common::swap16(src[i]);
-
-	return true;
+	Memory::CopyFromEmuSwapped<u16>(dst, addr, sizeof(pb));
 }
 
 // Write a PB back to MRAM/ARAM
-bool WritePB(u32 addr, const PB_TYPE& pb)
+void WritePB(u32 addr, const PB_TYPE& pb)
 {
 	const u16* src = (const u16*)&pb;
-	u16* dst = (u16*)Memory::GetPointer(addr);
-	if (!dst)
-		return false;
-
-	for (u32 i = 0; i < sizeof (pb) / sizeof (u16); ++i)
-		dst[i] = Common::swap16(src[i]);
-
-	return true;
+	Memory::CopyToEmuSwapped<u16>(addr, src, sizeof(pb));
 }
 
 #if 0

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -455,8 +455,7 @@ void AXWiiUCode::ProcessPBList(u32 pb_addr)
 			m_samples_aux3
 		}};
 
-		if (!ReadPB(pb_addr, pb))
-			break;
+		ReadPB(pb_addr, pb);
 
 		u16 num_updates[3];
 		u16 updates[1024];

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -92,4 +92,29 @@ void Write_U64(const u64 var, const u32 address);
 void Write_U32_Swap(const u32 var, const u32 address);
 void Write_U64_Swap(const u64 var, const u32 address);
 
+// Templated functions for byteswapped copies.
+template <typename T>
+void CopyFromEmuSwapped(T* data, u32 address, size_t size)
+{
+	const T* src = reinterpret_cast<T*>(GetPointer(address));
+
+	if(src == nullptr)
+		return;
+
+	for (size_t i = 0; i < size / sizeof(T); i++)
+		data[i] = Common::FromBigEndian(src[i]);
+}
+
+template <typename T>
+void CopyToEmuSwapped(u32 address, const T* data, size_t size)
+{
+	T* dest = reinterpret_cast<T*>(GetPointer(address));
+
+	if (dest == nullptr)
+		return;
+
+	for (size_t i = 0; i < size / sizeof(T); i++)
+		dest[i] = Common::FromBigEndian(data[i]);
+}
+
 }


### PR DESCRIPTION
This removes 7 GetPointers and quite a lot of duplicated code.