### PR TITLE
Moved the EXI::UpdateInterrupts call so that it is after the MSR.EE check

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -303,10 +303,6 @@ void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst)
 
 void CheckExceptions()
 {
-	// Make sure we are checking against the latest EXI status. This is required
-	// for devices which interrupt frequently, such as the gc mic
-	ExpansionInterface::UpdateInterrupts();
-
 	// Read volatile data once
 	u32 exceptions = ppcState.Exceptions;
 
@@ -405,6 +401,10 @@ void CheckExceptions()
 	// EXTERNAL INTERRUPT
 	else if (MSR & 0x0008000)  // Handling is delayed until MSR.EE=1.
 	{
+		// Make sure we are checking against the latest EXI status. This is required
+		// for devices which interrupt frequently, such as the gc mic
+		ExpansionInterface::UpdateInterrupts();
+
 		if (exceptions & EXCEPTION_EXTERNAL_INT)
 		{
 			// Pokemon gets this "too early", it hasn't a handler yet


### PR DESCRIPTION
Moved the EXI::UpdateInterrupts call so that it is after the MSR.EE check.  Fixes the slow speed in DKCR.
