### PR TITLE
Revert "Defer processing of expansion interface interrupts (fixes audio ...

### DIFF
--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -20,7 +20,6 @@ namespace ExpansionInterface
 {
 
 static int changeDevice;
-static int updateInterrupts;
 
 static CEXIChannel *g_Channels[MAX_EXI_CHANNELS];
 void Init()
@@ -44,7 +43,6 @@ void Init()
 	g_Channels[2]->AddDevice(EXIDEVICE_AD16,                            0);
 
 	changeDevice = CoreTiming::RegisterEvent("ChangeEXIDevice", ChangeDeviceCallback);
-	updateInterrupts = CoreTiming::RegisterEvent("EXIUpdateInterrupts", UpdateInterruptsCallback);
 }
 
 void Shutdown()
@@ -116,11 +114,6 @@ IEXIDevice* FindDevice(TEXIDevices device_type, int customIndex)
 }
 
 void UpdateInterrupts()
-{
-	CoreTiming::ScheduleEvent_Threadsafe(0, updateInterrupts, 0);
-}
-
-void UpdateInterruptsCallback(u64 userdata, int cyclesLate)
 {
 	// Interrupts are mapped a bit strangely:
 	// Channel 0 Device 0 generates interrupt on channel 0

--- a/Source/Core/Core/HW/EXI.h
+++ b/Source/Core/Core/HW/EXI.h
@@ -27,7 +27,6 @@ void PauseAndLock(bool doLock, bool unpauseOnUnlock);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
-void UpdateInterruptsCallback(u64 userdata, int cyclesLate);
 void UpdateInterrupts();
 
 void ChangeDeviceCallback(u64 userdata, int cyclesLate);


### PR DESCRIPTION
Reverts dolphin-emu/dolphin#1417

I already explained in the PR that this was not a threading issue, so the threadsafe thing is useless overhead.  It should not have been merged.  Furthermore, using any kind of event inside UpdateInterrupts is rather redundant when one of the two callers (IIRC) already uses one.  I suggest not making a change like this, but rather figuring out what the actual problem is and fixing it rather than blindly putting it off until "later".
