### PR TITLE
Make EXI use CoreTiming events like everything else instead of having its own special check.

### DIFF
--- a/Source/Core/Core/HW/EXI.h
+++ b/Source/Core/Core/HW/EXI.h
@@ -27,10 +27,10 @@ void PauseAndLock(bool doLock, bool unpauseOnUnlock);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
-void UpdateInterruptsCallback(u64 userdata, int cyclesLate);
 void UpdateInterrupts();
+void ScheduleUpdateInterrupts_Threadsafe(int cycles_late);
+void ScheduleUpdateInterrupts(int cycles_late);
 
-void ChangeDeviceCallback(u64 userdata, int cyclesLate);
 void ChangeDevice(const u8 channel, const TEXIDevices device_type, const u8 device_num);
 
 CEXIChannel* GetChannel(u32 index);

--- a/Source/Core/Core/HW/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI_Channel.cpp
@@ -35,8 +35,6 @@ CEXIChannel::CEXIChannel(u32 ChannelId) :
 
 	for (auto& device : m_pDevices)
 		device.reset(EXIDevice_Create(EXIDEVICE_NONE, m_ChannelId));
-
-	updateInterrupts = CoreTiming::RegisterEvent("EXIInterrupt", UpdateInterrupts);
 }
 
 CEXIChannel::~CEXIChannel()
@@ -93,7 +91,7 @@ void CEXIChannel::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 			if (pDevice != nullptr)
 				pDevice->SetCS(m_Status.CHIP_SELECT);
 
-			CoreTiming::ScheduleEvent_Threadsafe_Immediate(updateInterrupts, 0);
+			ExpansionInterface::UpdateInterrupts();
 		})
 	);
 
@@ -156,7 +154,7 @@ void CEXIChannel::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 void CEXIChannel::SendTransferComplete()
 {
 	m_Status.TCINT = 1;
-	CoreTiming::ScheduleEvent_Threadsafe_Immediate(updateInterrupts, 0);
+	ExpansionInterface::UpdateInterrupts();
 }
 
 void CEXIChannel::RemoveDevices()
@@ -185,14 +183,9 @@ void CEXIChannel::AddDevice(IEXIDevice* pDevice, const int device_num, bool noti
 		if (m_ChannelId != 2)
 		{
 			m_Status.EXTINT = 1;
-			CoreTiming::ScheduleEvent_Threadsafe_Immediate(updateInterrupts, 0);
+			ExpansionInterface::UpdateInterrupts();
 		}
 	}
-}
-
-void CEXIChannel::UpdateInterrupts(u64 userdata, int cyclesLate)
-{
-	ExpansionInterface::UpdateInterrupts();
 }
 
 bool CEXIChannel::IsCausingInterrupt()

--- a/Source/Core/Core/HW/EXI_Channel.h
+++ b/Source/Core/Core/HW/EXI_Channel.h
@@ -83,10 +83,6 @@ private:
 	// Since channels operate a bit differently from each other
 	u32 m_ChannelId;
 
-	int updateInterrupts;
-
-	static void UpdateInterrupts(u64 userdata, int cyclesLate);
-
 public:
 	// get device
 	IEXIDevice* GetDevice(const u8 _CHIP_SELECT);

--- a/Source/Core/Core/HW/EXI_DeviceAMBaseboard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAMBaseboard.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/Core.h"
 
+#include "Core/HW/EXI.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceAMBaseboard.h"
 
@@ -87,6 +88,7 @@ void CEXIAMBaseboard::TransferByte(u8& _byte)
 				m_have_irq = true;
 			else if (m_command[0] == 0x82)
 				m_have_irq = false;
+			ExpansionInterface::UpdateInterrupts();
 		}
 		else if (m_position > 4)
 		{

--- a/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
@@ -4,6 +4,7 @@
 
 #include "Common/Network.h"
 #include "Core/ConfigManager.h"
+#include "Core/HW/EXI.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceEthernet.h"
 #include "Core/HW/Memmap.h"
@@ -123,6 +124,7 @@ void CEXIETHERNET::ImmWrite(u32 data,  u32 size)
 			exi_status.interrupt_mask = data;
 			break;
 		}
+		ExpansionInterface::UpdateInterrupts();
 	}
 	else
 	{
@@ -401,6 +403,7 @@ void CEXIETHERNET::SendComplete()
 		mBbaMem[BBA_IR] |= INT_T;
 
 		exi_status.interrupt |= exi_status.TRANSFER;
+		ExpansionInterface::ScheduleUpdateInterrupts_Threadsafe(0);
 	}
 
 	mBbaMem[BBA_LTPS] = 0;
@@ -571,6 +574,7 @@ bool CEXIETHERNET::RecvHandlePacket()
 		mBbaMem[BBA_IR] |= INT_R;
 
 		exi_status.interrupt |= exi_status.TRANSFER;
+		ExpansionInterface::ScheduleUpdateInterrupts_Threadsafe(0);
 	}
 	else
 	{

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -263,6 +263,7 @@ void CEXIMemoryCard::CmdDone()
 	status &= ~MC_STATUS_BUSY;
 
 	m_bInterruptSet = 1;
+	ExpansionInterface::UpdateInterrupts();
 }
 
 void CEXIMemoryCard::TransferComplete()

--- a/Source/Core/Core/HW/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMic.cpp
@@ -7,6 +7,7 @@
 #if HAVE_PORTAUDIO
 
 #include "Core/CoreTiming.h"
+#include "Core/HW/EXI.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceMic.h"
 #include "Core/HW/GCPad.h"
@@ -176,8 +177,9 @@ void CEXIMic::SetCS(int cs)
 
 void CEXIMic::UpdateNextInterruptTicks()
 {
-	next_int_ticks = CoreTiming::GetTicks() +
-		(SystemTimers::GetTicksPerSecond() / sample_rate) * buff_size_samples;
+	int diff = (SystemTimers::GetTicksPerSecond() / sample_rate) * buff_size_samples;
+	next_int_ticks = CoreTiming::GetTicks() + diff;
+	ExpansionInterface::ScheduleUpdateInterrupts(diff);
 }
 
 bool CEXIMic::IsInterruptSet()

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -303,10 +303,6 @@ void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst)
 
 void CheckExceptions()
 {
-	// Make sure we are checking against the latest EXI status. This is required
-	// for devices which interrupt frequently, such as the gc mic
-	ExpansionInterface::UpdateInterrupts();
-
 	// Read volatile data once
 	u32 exceptions = ppcState.Exceptions;
 


### PR DESCRIPTION
Microphone is probably wrong/mistimed because it doesn't take into
account cycles late, but that's not a new issue here.

I'm too tired to test any device other than memory card.

This is hopefully a slight performance win.

I still have no idea what the root cause of the sound issue is.  It doesn't really make sense that calling UpdateInterrupts would 'batch' anything, as the original PR submitter suggested, if the same number of calls are being made, and there are no off-thread shenanigans with memory cards.  In fact, in lieu of such shenanigans, it's hard to imagine why a computer's CPU speed would affect _anything_, and of course sound playback has no direct relationship to EXI.  Perhaps... more calls to UpdateInterrupts in inner loops => slower computation => GPU thread finishes too early?  Might be worth testing in deterministic or single-core mode.  Anyway, if that's the issue, this should at least hide the symptom, as UpdateInterrupts is only called when necessary.
