### PR TITLE
Fix uninitialized GPU determinism mode for NAND titles or whatever.

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -184,7 +184,6 @@ bool BootCore(const std::string& _rFilename)
 		dsp_section->Get("Backend",           &SConfig::GetInstance().sBackend, SConfig::GetInstance().sBackend);
 		VideoBackend::ActivateBackend(StartUp.m_strVideoBackend);
 		core_section->Get("GPUDeterminismMode", &StartUp.m_strGPUDeterminismMode, StartUp.m_strGPUDeterminismMode);
-		StartUp.m_GPUDeterminismMode = ParseGPUDeterminismMode(StartUp.m_strGPUDeterminismMode);
 
 		for (unsigned int i = 0; i < MAX_SI_CHANNELS; ++i)
 		{
@@ -223,6 +222,8 @@ bool BootCore(const std::string& _rFilename)
 			}
 		}
 	}
+
+	StartUp.m_GPUDeterminismMode = ParseGPUDeterminismMode(StartUp.m_strGPUDeterminismMode);
 
 	// Movie settings
 	if (Movie::IsPlayingInput() && Movie::IsConfigSaved())


### PR DESCRIPTION
m_strGPUDeterminismMode can be set by either the global or game
settings.  Either way, it's then supposed to be parsed into an enum,
m_GPUDeterminismMode.  However, the code to do this was placed right
after checking for game settings, which doesn't happen at all if there
isn't a valid title ID.  Move it outside the if block.

Thanks to flacs for forwarding a valgrind report, which I think is caused by this.
