### PR TITLE
Dolphin[Qt|WX]: Miscellaneous cleanup.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ option(ENCODE_FRAMEDUMPS "Encode framedumps in AVI format" ON)
 option(FASTLOG "Enable all logs" OFF)
 option(OPROFILING "Enable profiling" OFF)
 option(GDBSTUB "Enable gdb stub for remote debugging." OFF)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	option(SKIP_POSTPROCESS_BUNDLE "Skip postprocessing bundle for redistributability" OFF)
+endif()
 ########################################
 # Optional Targets
 # TODO: Add DSPSpy

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -33,12 +33,25 @@ DMainWindow::DMainWindow(QWidget* parent_widget)
 #endif
 
 	Resources::Init();
-
 	UpdateIcons();
 	setWindowIcon(Resources::GetIcon(Resources::DOLPHIN_LOGO));
 
+	// Connect all the signals/slots
 	connect(this, SIGNAL(CoreStateChanged(Core::EState)), this, SLOT(OnCoreStateChanged(Core::EState)));
-	emit CoreStateChanged(Core::CORE_UNINITIALIZED); // update GUI items
+
+	connect(m_ui->actionOpen, SIGNAL(triggered()), this, SLOT(OnOpen()));
+
+	connect(m_ui->actionPlay, SIGNAL(triggered()), this, SLOT(OnPlay()));
+	connect(m_ui->actionStop, SIGNAL(triggered()), this, SLOT(OnStop()));
+
+	connect(m_ui->actionWebsite, SIGNAL(triggered()), this, SLOT(OnOpenWebsite()));
+	connect(m_ui->actionOnlineDocs, SIGNAL(triggered()), this, SLOT(OnOpenDocs()));
+	connect(m_ui->actionGitHub, SIGNAL(triggered()), this, SLOT(OnOpenGitHub()));
+	connect(m_ui->actionSystemInfo, SIGNAL(triggered()), this, SLOT(OnOpenSystemInfo()));
+	connect(m_ui->actionAbout, SIGNAL(triggered()), this, SLOT(OnOpenAbout()));
+
+	// Update GUI items
+	emit CoreStateChanged(Core::CORE_UNINITIALIZED);
 }
 
 DMainWindow::~DMainWindow()
@@ -121,12 +134,12 @@ void DMainWindow::DoStartPause()
 		m_render_widget->setCursor(Qt::BlankCursor);
 }
 
-void DMainWindow::on_actOpen_triggered()
+void DMainWindow::OnOpen()
 {
 	StartGame(ShowFileDialog());
 }
 
-void DMainWindow::on_actPlay_triggered()
+void DMainWindow::OnPlay()
 {
 	if (Core::GetState() != Core::CORE_UNINITIALIZED)
 	{
@@ -141,7 +154,7 @@ void DMainWindow::on_actPlay_triggered()
 	}
 }
 
-void DMainWindow::on_actStop_triggered()
+void DMainWindow::OnStop()
 {
 	if (Core::GetState() != Core::CORE_UNINITIALIZED && !m_isStopping)
 	{
@@ -192,20 +205,20 @@ void DMainWindow::OnCoreStateChanged(Core::EState state)
 	bool is_paused = (state == Core::CORE_PAUSE);
 
 	// Update the toolbar
-	m_ui->actPlay->setEnabled(is_not_initialized || is_running || is_paused);
+	m_ui->actionPlay->setEnabled(is_not_initialized || is_running || is_paused);
 	if (is_running)
 	{
-		m_ui->actPlay->setIcon(Resources::GetIcon(Resources::TOOLBAR_PAUSE));
-		m_ui->actPlay->setText(tr("Pause"));
+		m_ui->actionPlay->setIcon(Resources::GetIcon(Resources::TOOLBAR_PAUSE));
+		m_ui->actionPlay->setText(tr("Pause"));
 	}
 	else if (is_paused || is_not_initialized)
 	{
-		m_ui->actPlay->setIcon(Resources::GetIcon(Resources::TOOLBAR_PLAY));
-		m_ui->actPlay->setText(tr("Play"));
+		m_ui->actionPlay->setIcon(Resources::GetIcon(Resources::TOOLBAR_PLAY));
+		m_ui->actionPlay->setText(tr("Play"));
 	}
 
-	m_ui->actStop->setEnabled(!is_not_initialized);
-	m_ui->actOpen->setEnabled(is_not_initialized);
+	m_ui->actionStop->setEnabled(!is_not_initialized);
+	m_ui->actionOpen->setEnabled(is_not_initialized);
 }
 
 // DRenderWidget
@@ -239,33 +252,33 @@ bool DMainWindow::RenderWidgetHasFocus()
 // "Resources". Call this function after changing the icon theme.
 void DMainWindow::UpdateIcons()
 {
-	m_ui->actOpen->setIcon(Resources::GetIcon(Resources::TOOLBAR_OPEN));
-	m_ui->actStop->setIcon(Resources::GetIcon(Resources::TOOLBAR_STOP));
+	// Play/Pause is handled in OnCoreStateChanged().
+	m_ui->actionStop->setIcon(Resources::GetIcon(Resources::TOOLBAR_STOP));
 }
 
 // Help menu
-void DMainWindow::on_actWebsite_triggered()
+void DMainWindow::OnOpenWebsite()
 {
     QDesktopServices::openUrl(QUrl(SL("https://dolphin-emu.org/")));
 }
 
-void DMainWindow::on_actOnlineDocs_triggered()
+void DMainWindow::OnOpenDocs()
 {
 	QDesktopServices::openUrl(QUrl(SL("https://dolphin-emu.org/docs/guides/")));
 }
 
-void DMainWindow::on_actGitHub_triggered()
+void DMainWindow::OnOpenGitHub()
 {
 	QDesktopServices::openUrl(QUrl(SL("https://github.com/dolphin-emu/dolphin/")));
 }
 
-void DMainWindow::on_actSystemInfo_triggered()
+void DMainWindow::OnOpenSystemInfo()
 {
 	DSystemInfo* dlg = new DSystemInfo(this);
 	dlg->open();
 }
 
-void DMainWindow::on_actAbout_triggered()
+void DMainWindow::OnOpenAbout()
 {
 	DAboutDialog* dlg = new DAboutDialog(this);
 	dlg->open();

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -39,16 +39,16 @@ private slots:
 	void OnCoreStateChanged(Core::EState state);
 
 	// Main toolbar
-	void on_actOpen_triggered();
-	void on_actPlay_triggered();
-	void on_actStop_triggered();
+	void OnOpen();
+	void OnPlay();
+	void OnStop();
 
 	// Help menu
-	void on_actWebsite_triggered();
-	void on_actOnlineDocs_triggered();
-	void on_actGitHub_triggered();
-	void on_actSystemInfo_triggered();
-	void on_actAbout_triggered();
+	void OnOpenWebsite();
+	void OnOpenDocs();
+	void OnOpenGitHub();
+	void OnOpenSystemInfo();
+	void OnOpenAbout();
 
 	// Misc.
 	void UpdateIcons();

--- a/Source/Core/DolphinQt/MainWindow.ui
+++ b/Source/Core/DolphinQt/MainWindow.ui
@@ -39,7 +39,7 @@
     <property name="title">
      <string>Fi&amp;le</string>
     </property>
-    <addaction name="actOpen"/>
+    <addaction name="actionOpen"/>
    </widget>
    <widget class="QMenu" name="mnuEmulation">
     <property name="title">
@@ -65,12 +65,13 @@
     <property name="title">
      <string>Help</string>
     </property>
-    <addaction name="actWebsite"/>
-    <addaction name="actOnlineDocs"/>
-    <addaction name="actGitHub"/>
+    <addaction name="actionWebsite"/>
+    <addaction name="actionOnlineDocs"/>
+    <addaction name="actionGitHub"/>
     <addaction name="separator"/>
-    <addaction name="actSystemInfo"/>
-    <addaction name="actAbout"/>
+    <addaction name="actionSystemInfo"/>
+    <addaction name="actionAbout"/>
+    <addaction name="actionAboutQt"/>
    </widget>
    <widget class="QMenu" name="mnuMovie">
     <property name="title">
@@ -96,34 +97,35 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="actOpen"/>
-   <addaction name="separator"/>
-   <addaction name="actPlay"/>
-   <addaction name="actStop"/>
+   <addaction name="actionPlay"/>
+   <addaction name="actionStop"/>
   </widget>
-  <action name="actWebsite">
+  <action name="actionWebsite">
    <property name="text">
     <string>&amp;Website</string>
    </property>
   </action>
-  <action name="actOnlineDocs">
+  <action name="actionOnlineDocs">
    <property name="text">
     <string>&amp;Online Documentation</string>
    </property>
   </action>
-  <action name="actGitHub">
+  <action name="actionGitHub">
    <property name="text">
     <string>&amp;Dolphin at GitHub</string>
    </property>
   </action>
-  <action name="actAbout">
+  <action name="actionAbout">
    <property name="text">
     <string>&amp;About</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::AboutRole</enum>
+   </property>
   </action>
-  <action name="actOpen">
+  <action name="actionOpen">
    <property name="text">
-    <string>&amp;Open</string>
+    <string>&amp;Open...</string>
    </property>
    <property name="toolTip">
     <string>Open file...</string>
@@ -132,19 +134,27 @@
     <string>Ctrl+O</string>
    </property>
   </action>
-  <action name="actSystemInfo">
+  <action name="actionSystemInfo">
    <property name="text">
     <string>&amp;System Information</string>
    </property>
   </action>
-  <action name="actPlay">
+  <action name="actionPlay">
    <property name="text">
     <string>Play</string>
    </property>
   </action>
-  <action name="actStop">
+  <action name="actionStop">
    <property name="text">
     <string>Stop</string>
+   </property>
+  </action>
+  <action name="actionAboutQt">
+   <property name="text">
+    <string>About Qt</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::AboutQtRole</enum>
    </property>
   </action>
  </widget>

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	option(SKIP_POSTPROCESS_BUNDLE "Skip postprocessing bundle for redistributability" OFF)
-endif()
-
 set(LIBS	core
 			uicommon
 			${LZO}


### PR DESCRIPTION
DolphinQt:
- Make the connect() calls explicit, not automatic
- Follow better naming convention for the QActions
- Remove the Open action from the toolbar.

Dolphin[Qt|WX]:
- Move the "Skip Bundle" option to the root CMakeLists so that both DolphinQt and DolphinWX can use it.
