### PR TITLE
DolphinWX: Eliminate most usages of event tables in the debugger

### DIFF
--- a/Source/Core/DolphinWX/Debugger/BreakpointDlg.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointDlg.cpp
@@ -21,14 +21,12 @@
 #include "DolphinWX/Debugger/BreakpointDlg.h"
 #include "DolphinWX/Debugger/BreakpointWindow.h"
 
-BEGIN_EVENT_TABLE(BreakPointDlg, wxDialog)
-	EVT_BUTTON(wxID_OK, BreakPointDlg::OnOK)
-END_EVENT_TABLE()
-
 BreakPointDlg::BreakPointDlg(CBreakPointWindow *_Parent)
 	: wxDialog(_Parent, wxID_ANY, _("Add Breakpoint"))
 	, Parent(_Parent)
 {
+	Bind(wxEVT_BUTTON, &BreakPointDlg::OnOK, this, wxID_OK);
+
 	m_pEditAddress = new wxTextCtrl(this, wxID_ANY, "80000000");
 
 	wxBoxSizer *sMainSizer = new wxBoxSizer(wxVERTICAL);

--- a/Source/Core/DolphinWX/Debugger/BreakpointDlg.h
+++ b/Source/Core/DolphinWX/Debugger/BreakpointDlg.h
@@ -20,6 +20,4 @@ private:
 	wxTextCtrl *m_pEditAddress;
 
 	void OnOK(wxCommandEvent& event);
-
-	DECLARE_EVENT_TABLE();
 };

--- a/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
@@ -96,21 +96,19 @@ private:
 	wxBitmap m_Bitmaps[Num_Bitmaps];
 };
 
-BEGIN_EVENT_TABLE(CBreakPointWindow, wxPanel)
-	EVT_CLOSE(CBreakPointWindow::OnClose)
-	EVT_LIST_ITEM_SELECTED(wxID_ANY, CBreakPointWindow::OnSelectBP)
-END_EVENT_TABLE()
-
 CBreakPointWindow::CBreakPointWindow(CCodeWindow* _pCodeWindow, wxWindow* parent,
 	    wxWindowID id, const wxString& title, const wxPoint& position,
 	    const wxSize& size, long style)
 	: wxPanel(parent, id, position, size, style, title)
 	, m_pCodeWindow(_pCodeWindow)
 {
+	Bind(wxEVT_CLOSE_WINDOW, &CBreakPointWindow::OnClose, this);
+
 	m_mgr.SetManagedWindow(this);
 	m_mgr.SetFlags(wxAUI_MGR_DEFAULT | wxAUI_MGR_LIVE_RESIZE);
 
 	m_BreakPointListView = new CBreakPointView(this, wxID_ANY);
+	m_BreakPointListView->Bind(wxEVT_LIST_ITEM_SELECTED, &CBreakPointWindow::OnSelectBP, this);
 
 	m_mgr.AddPane(new CBreakPointBar(this, wxID_ANY), wxAuiPaneInfo().ToolbarPane().Top().
 	              LeftDockable(true).RightDockable(true).BottomDockable(false).Floatable(false));

--- a/Source/Core/DolphinWX/Debugger/BreakpointWindow.h
+++ b/Source/Core/DolphinWX/Debugger/BreakpointWindow.h
@@ -43,8 +43,6 @@ public:
 	void LoadAll();
 
 private:
-	DECLARE_EVENT_TABLE();
-
 	wxAuiManager m_mgr;
 	CBreakPointView* m_BreakPointListView;
 	CCodeWindow* m_pCodeWindow;

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -58,19 +58,6 @@ enum
 	IDM_ADDFUNCTION,
 };
 
-BEGIN_EVENT_TABLE(CCodeView, wxControl)
-	EVT_ERASE_BACKGROUND(CCodeView::OnErase)
-	EVT_PAINT(CCodeView::OnPaint)
-	EVT_MOUSEWHEEL(CCodeView::OnScrollWheel)
-	EVT_LEFT_DOWN(CCodeView::OnMouseDown)
-	EVT_LEFT_UP(CCodeView::OnMouseUpL)
-	EVT_MOTION(CCodeView::OnMouseMove)
-	EVT_RIGHT_DOWN(CCodeView::OnMouseDown)
-	EVT_RIGHT_UP(CCodeView::OnMouseUpR)
-	EVT_MENU(-1, CCodeView::OnPopupMenu)
-	EVT_SIZE(CCodeView::OnResize)
-END_EVENT_TABLE()
-
 CCodeView::CCodeView(DebugInterface* debuginterface, SymbolDB *symboldb,
 		wxWindow* parent, wxWindowID Id)
 	: wxControl(parent, Id),
@@ -86,6 +73,16 @@ CCodeView::CCodeView(DebugInterface* debuginterface, SymbolDB *symboldb,
 	  m_lx(-1),
 	  m_ly(-1)
 {
+	Bind(wxEVT_ERASE_BACKGROUND, &CCodeView::OnErase, this);
+	Bind(wxEVT_PAINT, &CCodeView::OnPaint, this);
+	Bind(wxEVT_MOUSEWHEEL, &CCodeView::OnScrollWheel, this);
+	Bind(wxEVT_LEFT_DOWN, &CCodeView::OnMouseDown, this);
+	Bind(wxEVT_LEFT_UP, &CCodeView::OnMouseUpL, this);
+	Bind(wxEVT_MOTION, &CCodeView::OnMouseMove, this);
+	Bind(wxEVT_RIGHT_DOWN, &CCodeView::OnMouseDown, this);
+	Bind(wxEVT_RIGHT_UP, &CCodeView::OnMouseUpR, this);
+	Bind(wxEVT_MENU, &CCodeView::OnPopupMenu, this);
+	Bind(wxEVT_SIZE, &CCodeView::OnResize, this);
 }
 
 int CCodeView::YToAddress(int y)

--- a/Source/Core/DolphinWX/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Debugger/CodeView.h
@@ -95,6 +95,4 @@ private:
 	bool m_selecting;
 
 	int m_lx, m_ly;
-
-	DECLARE_EVENT_TABLE()
 };

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -108,16 +108,6 @@ public:
 	int iNbAffiliation[IDM_CODEWINDOW - IDM_LOGWINDOW + 1];
 
 private:
-	enum
-	{
-		// Debugger GUI Objects
-		ID_CODEVIEW,
-		ID_CALLSTACKLIST,
-		ID_CALLERSLIST,
-		ID_CALLSLIST,
-		ID_SYMBOLLIST
-	};
-
 	void OnSymbolListChange(wxCommandEvent& event);
 	void OnSymbolListContextMenu(wxContextMenuEvent& event);
 	void OnCallstackListChange(wxCommandEvent& event);
@@ -143,6 +133,4 @@ private:
 	wxListBox* callers;
 	wxListBox* calls;
 	Common::Event sync_event;
-
-	DECLARE_EVENT_TABLE()
 };

--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.h
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.h
@@ -30,16 +30,12 @@ public:
 	void Update() override;
 
 private:
-	DECLARE_EVENT_TABLE();
-
 	enum
 	{
 		ID_TOOLBAR = 1000,
 		ID_RUNTOOL,
 		ID_STEPTOOL,
 		ID_SHOWPCTOOL,
-		ID_ADDRBOX,
-		ID_SYMBOLLIST,
 		ID_DSP_REGS
 	};
 
@@ -59,6 +55,7 @@ private:
 	CMemoryView* m_MemView;
 	DSPRegisterView* m_Regs;
 	wxListBox* m_SymbolList;
+	wxTextCtrl* m_addr_txtctrl;
 	wxAuiNotebook* m_MainNotebook;
 
 	void OnClose(wxCloseEvent& event);

--- a/Source/Core/DolphinWX/Debugger/JitWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.cpp
@@ -170,43 +170,24 @@ std::string HostDisassemblerX86::DisassembleHostBlock(const u8* code_start, cons
 	return x86_disasm.str();
 }
 
-enum
-{
-	IDM_REFRESH_LIST = 23350,
-	IDM_PPC_BOX,
-	IDM_X86_BOX,
-	IDM_NEXT,
-	IDM_PREV,
-	IDM_BLOCKLIST,
-};
-
-BEGIN_EVENT_TABLE(CJitWindow, wxPanel)
-	//EVT_TEXT(IDM_ADDRBOX, CJitWindow::OnAddrBoxChange)
-	//EVT_LISTBOX(IDM_SYMBOLLIST, CJitWindow::OnSymbolListChange)
-	//EVT_HOST_COMMAND(wxID_ANY, CJitWindow::OnHostMessage)
-	EVT_BUTTON(IDM_REFRESH_LIST, CJitWindow::OnRefresh)
-END_EVENT_TABLE()
-
 CJitWindow::CJitWindow(wxWindow* parent, wxWindowID id, const wxPoint& pos,
 		const wxSize& size, long style, const wxString& name)
 : wxPanel(parent, id, pos, size, style, name)
 {
 	wxBoxSizer* sizerBig   = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* sizerSplit = new wxBoxSizer(wxHORIZONTAL);
-	sizerSplit->Add(ppc_box = new wxTextCtrl(this, IDM_PPC_BOX, "(ppc)",
+	sizerSplit->Add(ppc_box = new wxTextCtrl(this, wxID_ANY, "(ppc)",
 				wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE), 1, wxEXPAND);
-	sizerSplit->Add(x86_box = new wxTextCtrl(this, IDM_X86_BOX, "(x86)",
+	sizerSplit->Add(x86_box = new wxTextCtrl(this, wxID_ANY, "(x86)",
 				wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE), 1, wxEXPAND);
-	sizerBig->Add(block_list = new JitBlockList(this, IDM_BLOCKLIST,
+	sizerBig->Add(block_list = new JitBlockList(this, wxID_ANY,
 				wxDefaultPosition, wxSize(100, 140),
 				wxLC_REPORT | wxSUNKEN_BORDER | wxLC_ALIGN_LEFT | wxLC_SINGLE_SEL | wxLC_SORT_ASCENDING),
 				0, wxEXPAND);
 	sizerBig->Add(sizerSplit, 2, wxEXPAND);
-	// sizerBig->Add(memview, 5, wxEXPAND);
-	// sizerBig->Add(sizerRight, 0, wxEXPAND | wxALL, 3);
-	sizerBig->Add(button_refresh = new wxButton(this, IDM_REFRESH_LIST, _("&Refresh")));
-	// sizerRight->Add(addrbox = new wxTextCtrl(this, IDM_ADDRBOX, ""));
-	// sizerRight->Add(new wxButton(this, IDM_SETPC, _("S&et PC")));
+
+	sizerBig->Add(button_refresh = new wxButton(this, wxID_ANY, _("&Refresh")));
+	button_refresh->Bind(wxEVT_BUTTON, &CJitWindow::OnRefresh, this);
 
 	SetSizer(sizerBig);
 

--- a/Source/Core/DolphinWX/Debugger/JitWindow.h
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.h
@@ -77,8 +77,6 @@ private:
 	wxTextCtrl* x86_box;
 	wxListBox* top_instructions;
 
-	DECLARE_EVENT_TABLE()
-
 	void OnSymbolListChange(wxCommandEvent& event);
 	void OnCallstackListChange(wxCommandEvent& event);
 	void OnAddrBoxChange(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.cpp
@@ -25,14 +25,12 @@
 
 #define TEXT_BOX(text) new wxStaticText(this, wxID_ANY, _(text))
 
-BEGIN_EVENT_TABLE(MemoryCheckDlg, wxDialog)
-	EVT_BUTTON(wxID_OK, MemoryCheckDlg::OnOK)
-END_EVENT_TABLE()
-
 MemoryCheckDlg::MemoryCheckDlg(CBreakPointWindow *parent)
 	: wxDialog(parent, wxID_ANY, _("Memory Check"))
 	, m_parent(parent)
 {
+	Bind(wxEVT_BUTTON, &MemoryCheckDlg::OnOK, this);
+
 	m_pEditStartAddress = new wxTextCtrl(this, wxID_ANY, "");
 	m_pEditEndAddress = new wxTextCtrl(this, wxID_ANY, "");
 	m_pWriteFlag = new wxCheckBox(this, wxID_ANY, _("Write"));

--- a/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.h
@@ -26,6 +26,4 @@ private:
 	wxTextCtrl* m_pEditStartAddress;
 
 	void OnOK(wxCommandEvent& event);
-
-	DECLARE_EVENT_TABLE();
 };

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -48,17 +48,6 @@ enum
 	IDM_VIEWASHEX,
 };
 
-BEGIN_EVENT_TABLE(CMemoryView, wxControl)
-	EVT_PAINT(CMemoryView::OnPaint)
-	EVT_LEFT_DOWN(CMemoryView::OnMouseDownL)
-	EVT_LEFT_UP(CMemoryView::OnMouseUpL)
-	EVT_MOTION(CMemoryView::OnMouseMove)
-	EVT_RIGHT_DOWN(CMemoryView::OnMouseDownR)
-	EVT_MOUSEWHEEL(CMemoryView::OnScrollWheel)
-	EVT_MENU(-1, CMemoryView::OnPopupMenu)
-	EVT_SIZE(CMemoryView::OnResize)
-END_EVENT_TABLE()
-
 CMemoryView::CMemoryView(DebugInterface* debuginterface, wxWindow* parent)
 	: wxControl(parent, wxID_ANY)
 	, curAddress(debuginterface->GetPC())
@@ -71,6 +60,14 @@ CMemoryView::CMemoryView(DebugInterface* debuginterface, wxWindow* parent)
 	, memory(0)
 	, viewAsType(VIEWAS_FP)
 {
+	Bind(wxEVT_PAINT, &CMemoryView::OnPaint, this);
+	Bind(wxEVT_LEFT_DOWN, &CMemoryView::OnMouseDownL, this);
+	Bind(wxEVT_LEFT_UP, &CMemoryView::OnMouseUpL, this);
+	Bind(wxEVT_MOTION, &CMemoryView::OnMouseMove, this);
+	Bind(wxEVT_RIGHT_DOWN, &CMemoryView::OnMouseDownR, this);
+	Bind(wxEVT_MOUSEWHEEL, &CMemoryView::OnScrollWheel, this);
+	Bind(wxEVT_MENU, &CMemoryView::OnPopupMenu, this);
+	Bind(wxEVT_SIZE, &CMemoryView::OnResize, this);
 }
 
 int CMemoryView::YToAddress(int y)

--- a/Source/Core/DolphinWX/Debugger/MemoryView.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.h
@@ -58,6 +58,4 @@ private:
 	};
 
 	EViewAsType viewAsType;
-
-	DECLARE_EVENT_TABLE()
 };

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -255,6 +255,9 @@ CRegisterView::CRegisterView(wxWindow *parent, wxWindowID id)
 	SetColLabelSize(0);
 	DisableDragRowSize();
 
+	Bind(wxEVT_GRID_CELL_RIGHT_CLICK, &CRegisterView::OnMouseDownR, this);
+	Bind(wxEVT_MENU, &CRegisterView::OnPopupMenu, this);
+
 	AutoSizeColumns();
 }
 

--- a/Source/Core/DolphinWX/Debugger/RegisterWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterWindow.cpp
@@ -15,14 +15,6 @@
 #include "DolphinWX/Debugger/RegisterView.h"
 #include "DolphinWX/Debugger/RegisterWindow.h"
 
-class wxWindow;
-
-BEGIN_EVENT_TABLE(CRegisterWindow, wxPanel)
-EVT_GRID_CELL_RIGHT_CLICK(CRegisterView::OnMouseDownR)
-EVT_MENU(-1, CRegisterView::OnPopupMenu)
-END_EVENT_TABLE()
-
-
 CRegisterWindow::CRegisterWindow(wxWindow* parent, wxWindowID id,
 		const wxPoint& position, const wxSize& size,
 		long style, const wxString& name)

--- a/Source/Core/DolphinWX/Debugger/RegisterWindow.h
+++ b/Source/Core/DolphinWX/Debugger/RegisterWindow.h
@@ -15,8 +15,7 @@
 class CRegisterView;
 class wxWindow;
 
-class CRegisterWindow
-	: public wxPanel
+class CRegisterWindow : public wxPanel
 {
 public:
 	CRegisterWindow(wxWindow* parent,
@@ -28,10 +27,7 @@ public:
 
 	void NotifyUpdate();
 
-
 private:
-	DECLARE_EVENT_TABLE();
-
 	enum
 	{
 		ID_GPR = 1002

--- a/Source/Core/DolphinWX/Debugger/WatchView.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchView.cpp
@@ -221,6 +221,9 @@ CWatchView::CWatchView(wxWindow* parent, wxWindowID id)
 	SetRowLabelSize(0);
 	SetColLabelSize(0);
 	DisableDragRowSize();
+
+	Bind(wxEVT_GRID_CELL_RIGHT_CLICK, &CWatchView::OnMouseDownR, this);
+	Bind(wxEVT_MENU, &CWatchView::OnPopupMenu, this);
 }
 
 void CWatchView::Update()

--- a/Source/Core/DolphinWX/Debugger/WatchWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchWindow.cpp
@@ -26,13 +26,6 @@ extern "C" {
 #include "DolphinWX/resources/toolbar_debugger_delete.c"
 }
 
-class wxWindow;
-
-BEGIN_EVENT_TABLE(CWatchWindow, wxPanel)
-EVT_GRID_CELL_RIGHT_CLICK(CWatchView::OnMouseDownR)
-EVT_MENU(-1, CWatchView::OnPopupMenu)
-END_EVENT_TABLE()
-
 class CWatchToolbar : public wxAuiToolBar
 {
 public:

--- a/Source/Core/DolphinWX/Debugger/WatchWindow.h
+++ b/Source/Core/DolphinWX/Debugger/WatchWindow.h
@@ -16,8 +16,7 @@
 class CWatchView;
 class wxWindow;
 
-class CWatchWindow
-	: public wxPanel
+class CWatchWindow : public wxPanel
 {
 public:
 	CWatchWindow(wxWindow* parent,
@@ -35,8 +34,6 @@ public:
 	void LoadAll();
 
 private:
-	DECLARE_EVENT_TABLE();
-
 	wxAuiManager m_mgr;
 
 	enum

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -229,7 +229,7 @@ bool CRenderFrame::ShowFullScreen(bool show, long style)
 // Notice that wxID_HELP will be processed for the 'About' menu and the toolbar
 // help button.
 
-const wxEventType wxEVT_HOST_COMMAND = wxNewEventType();
+wxDEFINE_EVENT(wxEVT_HOST_COMMAND, wxCommandEvent);
 
 BEGIN_EVENT_TABLE(CFrame, CRenderFrame)
 

--- a/Source/Core/DolphinWX/Globals.h
+++ b/Source/Core/DolphinWX/Globals.h
@@ -292,4 +292,4 @@ enum
 			(wxObject*) nullptr \
 			),
 
-extern const wxEventType wxEVT_HOST_COMMAND;
+wxDECLARE_EVENT(wxEVT_HOST_COMMAND, wxCommandEvent);


### PR DESCRIPTION
Moves things over to Bind.
