### PR TITLE
Ignore the emulated wiimotes speaker data if the sample rate is set at 0hz

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -107,14 +107,13 @@ void Wiimote::SpeakerData(wm_speaker_data* sd)
 
 	// Speaker Pan
 	unsigned int vol = (unsigned int)(m_options->settings[4]->GetValue() * 100);
-	float amp = 10.0f; // Boost the speaker volume relative to the rest of the game audio
 
 	if (m_reg_speaker.sample_rate)
 	{
-		unsigned int sample_rate = sample_rate_dividend / Common::swap16(m_reg_speaker.sample_rate);
+		unsigned int sample_rate = sample_rate_dividend / m_reg_speaker.sample_rate;
 		float speaker_volume_ratio = (float)m_reg_speaker.volume / volume_divisor;
-		unsigned int left_volume = (unsigned int)((128 + vol) * speaker_volume_ratio * amp);
-		unsigned int right_volume = (unsigned int)((128 - vol) * speaker_volume_ratio * amp);
+		unsigned int left_volume = (unsigned int)((128 + vol) * speaker_volume_ratio);
+		unsigned int right_volume = (unsigned int)((128 - vol) * speaker_volume_ratio);
 
 		if (left_volume > 255)
 			left_volume = 255;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -24,10 +24,9 @@ namespace WiimoteReal
 {
 class Wiimote;
 }
-
 namespace WiimoteEmu
 {
-
+#pragma pack(push,1)
 struct ReportFeatures
 {
 	u8 core, accel, ir, ext, size;
@@ -197,7 +196,6 @@ private:
 	wiimote_key m_ext_key;
 
 	u8 m_eeprom[WIIMOTE_EEPROM_SIZE];
-
 	struct MotionPlusReg
 	{
 		u8 unknown[0xF0];
@@ -233,6 +231,7 @@ private:
 		u8  play;
 		u8  unk_9;
 	} m_reg_speaker;
+#pragma pack(pop)
 };
 
 void Spy(Wiimote* wm_, const void* data_, size_t size_);


### PR DESCRIPTION
Fixes issue 7806.
