### PR TITLE
Main: Explicitly use the HTTPS site URL.

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -286,11 +286,11 @@ bool DolphinApp::OnInit()
 		File::Delete("www.dolphin-emulator.com.txt");
 		wxMessageDialog dlg(nullptr, _(
 		    "This version of Dolphin was downloaded from a website stealing money from developers of the emulator. Please "
-		    "download Dolphin from the official website instead: http://dolphin-emu.org/"),
+		    "download Dolphin from the official website instead: https://dolphin-emu.org/"),
 		    _("Unofficial version detected"), wxOK | wxICON_WARNING);
 		dlg.ShowModal();
 
-		wxLaunchDefaultBrowser("http://dolphin-emu.org/?ref=badver");
+		wxLaunchDefaultBrowser("https://dolphin-emu.org/?ref=badver");
 
 		exit(0);
 	}


### PR DESCRIPTION
Shouldn't matter since we redirect through it, but may as well switch it over.
