### PR TITLE
DolphinWX: Kill off trivial event tables

### DIFF
--- a/Source/Core/DolphinWX/ARCodeAddEdit.cpp
+++ b/Source/Core/DolphinWX/ARCodeAddEdit.cpp
@@ -29,15 +29,12 @@
 #include "DolphinWX/ISOProperties.h"
 #include "DolphinWX/WxUtils.h"
 
-BEGIN_EVENT_TABLE(CARCodeAddEdit, wxDialog)
-	EVT_BUTTON(wxID_OK, CARCodeAddEdit::SaveCheatData)
-	EVT_SPIN(ID_ENTRY_SELECT, CARCodeAddEdit::ChangeEntry)
-END_EVENT_TABLE()
-
 CARCodeAddEdit::CARCodeAddEdit(int _selection, wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& position, const wxSize& size, long style)
 	: wxDialog(parent, id, title, position, size, style)
 	, selection(_selection)
 {
+	Bind(wxEVT_BUTTON, &CARCodeAddEdit::SaveCheatData, this);
+
 	ActionReplay::ARCode tempEntries;
 	wxString currentName = _("Insert name here..");
 
@@ -55,13 +52,16 @@ CARCodeAddEdit::CARCodeAddEdit(int _selection, wxWindow* parent, wxWindowID id, 
 	wxStaticBoxSizer* sbEntry = new wxStaticBoxSizer(wxVERTICAL, this, _("Cheat Code"));
 	wxGridBagSizer* sgEntry = new wxGridBagSizer(0, 0);
 
-	wxStaticText* EditCheatNameText = new wxStaticText(this, ID_EDITCHEAT_NAME_TEXT, _("Name:"));
-	EditCheatName = new wxTextCtrl(this, ID_EDITCHEAT_NAME, wxEmptyString);
+	wxStaticText* EditCheatNameText = new wxStaticText(this, wxID_ANY, _("Name:"));
+	EditCheatName = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
 	EditCheatName->SetValue(currentName);
-	EntrySelection = new wxSpinButton(this, ID_ENTRY_SELECT);
+
+	EntrySelection = new wxSpinButton(this);
 	EntrySelection->SetRange(1, ((int)arCodes.size()) > 0 ? (int)arCodes.size() : 1);
 	EntrySelection->SetValue((int)(arCodes.size() - selection));
-	EditCheatCode = new wxTextCtrl(this, ID_EDITCHEAT_CODE, wxEmptyString, wxDefaultPosition, wxSize(300, 100), wxTE_MULTILINE);
+	EntrySelection->Bind(wxEVT_SPIN, &CARCodeAddEdit::ChangeEntry, this);
+
+	EditCheatCode = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(300, 100), wxTE_MULTILINE);
 	UpdateTextCtrl(tempEntries);
 
 	sgEntry->Add(EditCheatNameText, wxGBPosition(0, 0), wxGBSpan(1, 1), wxALIGN_CENTER|wxALL, 5);

--- a/Source/Core/DolphinWX/ARCodeAddEdit.h
+++ b/Source/Core/DolphinWX/ARCodeAddEdit.h
@@ -20,33 +20,22 @@ namespace ActionReplay { struct ARCode; }
 
 class CARCodeAddEdit : public wxDialog
 {
-	public:
-		CARCodeAddEdit(int _selection, wxWindow* parent,
-			wxWindowID id = 1,
-			const wxString& title = _("Edit ActionReplay Code"),
-			const wxPoint& pos = wxDefaultPosition,
-			const wxSize& size = wxDefaultSize,
-			long style = wxDEFAULT_DIALOG_STYLE);
+public:
+	CARCodeAddEdit(int _selection, wxWindow* parent,
+		wxWindowID id = 1,
+		const wxString& title = _("Edit ActionReplay Code"),
+		const wxPoint& pos = wxDefaultPosition,
+		const wxSize& size = wxDefaultSize,
+		long style = wxDEFAULT_DIALOG_STYLE);
 
-	private:
-		DECLARE_EVENT_TABLE();
+private:
+	wxTextCtrl* EditCheatName;
+	wxSpinButton* EntrySelection;
+	wxTextCtrl* EditCheatCode;
 
-		wxTextCtrl *EditCheatName;
-		wxSpinButton *EntrySelection;
-		wxTextCtrl *EditCheatCode;
+	void SaveCheatData(wxCommandEvent& event);
+	void ChangeEntry(wxSpinEvent& event);
+	void UpdateTextCtrl(ActionReplay::ARCode arCode);
 
-		enum
-		{
-			ID_EDITCHEAT_NAME_TEXT = 4550,
-			ID_EDITCHEAT_NAME,
-			ID_ENTRY_SELECT,
-			ID_EDITCHEAT_CODE
-		};
-
-		void SaveCheatData(wxCommandEvent& event);
-		void ChangeEntry(wxSpinEvent& event);
-		void UpdateTextCtrl(ActionReplay::ARCode arCode);
-
-		int selection;
-
+	int selection;
 };

--- a/Source/Core/DolphinWX/Debugger/DebuggerPanel.cpp
+++ b/Source/Core/DolphinWX/Debugger/DebuggerPanel.cpp
@@ -28,20 +28,6 @@
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/TextureCacheBase.h"
 
-BEGIN_EVENT_TABLE(GFXDebuggerPanel, wxPanel)
-	EVT_CLOSE(GFXDebuggerPanel::OnClose)
-	EVT_BUTTON(ID_PAUSE,GFXDebuggerPanel::OnPauseButton)
-	EVT_BUTTON(ID_PAUSE_AT_NEXT,GFXDebuggerPanel::OnPauseAtNextButton)
-	EVT_BUTTON(ID_PAUSE_AT_NEXT_FRAME,GFXDebuggerPanel::OnPauseAtNextFrameButton)
-	EVT_BUTTON(ID_CONT,GFXDebuggerPanel::OnContButton)
-	EVT_BUTTON(ID_DUMP,GFXDebuggerPanel::OnDumpButton)
-	EVT_BUTTON(ID_UPDATE_SCREEN,GFXDebuggerPanel::OnUpdateScreenButton)
-	EVT_BUTTON(ID_CLEAR_SCREEN,GFXDebuggerPanel::OnClearScreenButton)
-	EVT_BUTTON(ID_CLEAR_TEXTURE_CACHE,GFXDebuggerPanel::OnClearTextureCacheButton)
-	EVT_BUTTON(ID_CLEAR_VERTEX_SHADER_CACHE,GFXDebuggerPanel::OnClearVertexShaderCacheButton)
-	EVT_BUTTON(ID_CLEAR_PIXEL_SHADER_CACHE,GFXDebuggerPanel::OnClearPixelShaderCacheButton)
-END_EVENT_TABLE()
-
 GFXDebuggerPanel::GFXDebuggerPanel(wxWindow *parent, wxWindowID id, const wxPoint &position,
 									const wxSize& size, long style, const wxString &title)
 	: wxPanel(parent, id, position, size, style, title)
@@ -49,6 +35,8 @@ GFXDebuggerPanel::GFXDebuggerPanel(wxWindow *parent, wxWindowID id, const wxPoin
 	g_pdebugger = this;
 
 	CreateGUIControls();
+
+	Bind(wxEVT_CLOSE_WINDOW, &GFXDebuggerPanel::OnClose, this);
 
 	LoadSettings();
 }
@@ -148,28 +136,46 @@ void GFXDebuggerPanel::CreateGUIControls()
 	// Basic settings
 	CenterOnParent();
 
-	m_pButtonPause = new wxButton(this, ID_PAUSE, _("Pause"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Pause"));
-	m_pButtonPauseAtNext = new wxButton(this, ID_PAUSE_AT_NEXT, _("Pause After"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Pause At Next"));
-	m_pButtonPauseAtNextFrame = new wxButton(this, ID_PAUSE_AT_NEXT_FRAME, _("Go to Next Frame"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Next Frame"));
-	m_pButtonCont = new wxButton(this, ID_CONT, _("Continue"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Continue"));
+	m_pButtonPause = new wxButton(this, wxID_ANY, _("Pause"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Pause"));
+	m_pButtonPause->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnPauseButton, this);
 
-	m_pCount = new wxTextCtrl(this, ID_COUNT, "1", wxDefaultPosition, wxSize(50,25), wxTE_RIGHT, wxDefaultValidator, _("Count"));
+	m_pButtonPauseAtNext = new wxButton(this, wxID_ANY, _("Pause After"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Pause At Next"));
+	m_pButtonPauseAtNext->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnPauseAtNextButton, this);
 
-	m_pPauseAtList = new wxChoice(this, ID_PAUSE_AT_LIST, wxDefaultPosition, wxSize(100,25), 0, nullptr,0,wxDefaultValidator, _("PauseAtList"));
+	m_pButtonPauseAtNextFrame = new wxButton(this, wxID_ANY, _("Go to Next Frame"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Next Frame"));
+	m_pButtonPauseAtNextFrame->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnPauseAtNextFrameButton, this);
+
+	m_pButtonCont = new wxButton(this, wxID_ANY, _("Continue"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Continue"));
+	m_pButtonCont->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnContButton, this);
+
+	m_pCount = new wxTextCtrl(this, wxID_ANY, "1", wxDefaultPosition, wxSize(50,25), wxTE_RIGHT, wxDefaultValidator, _("Count"));
+
+	m_pPauseAtList = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxSize(100,25), 0, nullptr,0,wxDefaultValidator, _("PauseAtList"));
 	for (int i=0; i<numPauseEventMap; i++)
 	{
 		m_pPauseAtList->Append(pauseEventMap[i].ListStr);
 	}
 	m_pPauseAtList->SetSelection(0);
 
-	m_pButtonDump = new wxButton(this, ID_DUMP, _("Dump"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Dump"));
-	m_pButtonUpdateScreen = new wxButton(this, ID_UPDATE_SCREEN, _("Update Screen"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Update Screen"));
-	m_pButtonClearScreen = new wxButton(this, ID_CLEAR_SCREEN, _("Clear Screen"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Clear Screen"));
-	m_pButtonClearTextureCache = new wxButton(this, ID_CLEAR_TEXTURE_CACHE, _("Clear Textures"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Clear Textures"));
-	m_pButtonClearVertexShaderCache = new wxButton(this, ID_CLEAR_VERTEX_SHADER_CACHE, _("Clear V Shaders"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Clear V Shaders"));
-	m_pButtonClearPixelShaderCache = new wxButton(this, ID_CLEAR_PIXEL_SHADER_CACHE, _("Clear P Shaders"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Clear P Shaders"));
+	m_pButtonDump = new wxButton(this, wxID_ANY, _("Dump"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Dump"));
+	m_pButtonDump->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnDumpButton, this);
 
-	m_pDumpList = new wxChoice(this, ID_DUMP_LIST, wxDefaultPosition, wxSize(120,25), 0, nullptr, 0 ,wxDefaultValidator, _("DumpList"));
+	m_pButtonUpdateScreen = new wxButton(this, wxID_ANY, _("Update Screen"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Update Screen"));
+	m_pButtonUpdateScreen->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnUpdateScreenButton, this);
+
+	m_pButtonClearScreen = new wxButton(this, wxID_ANY, _("Clear Screen"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Clear Screen"));
+	m_pButtonClearScreen->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnClearScreenButton, this);
+
+	m_pButtonClearTextureCache = new wxButton(this, wxID_ANY, _("Clear Textures"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Clear Textures"));
+	m_pButtonClearTextureCache->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnClearTextureCacheButton, this);
+
+	m_pButtonClearVertexShaderCache = new wxButton(this, wxID_ANY, _("Clear V Shaders"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Clear V Shaders"));
+	m_pButtonClearVertexShaderCache->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnClearVertexShaderCacheButton, this);
+
+	m_pButtonClearPixelShaderCache = new wxButton(this, wxID_ANY, _("Clear P Shaders"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _("Clear P Shaders"));
+	m_pButtonClearPixelShaderCache->Bind(wxEVT_BUTTON, &GFXDebuggerPanel::OnClearPixelShaderCacheButton, this);
+
+	m_pDumpList = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxSize(120,25), 0, nullptr, 0 ,wxDefaultValidator, _("DumpList"));
 	m_pDumpList->Insert(_("Pixel Shader"),0);
 	m_pDumpList->Append(_("Vertex Shader"));
 	m_pDumpList->Append(_("Pixel Shader Constants"));

--- a/Source/Core/DolphinWX/Debugger/DebuggerPanel.h
+++ b/Source/Core/DolphinWX/Debugger/DebuggerPanel.h
@@ -22,7 +22,7 @@ class wxWindow;
 class GFXDebuggerPanel : public wxPanel, public GFXDebuggerBase
 {
 public:
-	GFXDebuggerPanel(wxWindow *parent,
+	GFXDebuggerPanel(wxWindow* parent,
 		wxWindowID id = wxID_ANY,
 		const wxPoint& pos = wxDefaultPosition,
 		const wxSize& size = wxDefaultSize,
@@ -46,8 +46,6 @@ public:
 	void OnContinue() override;
 
 private:
-	DECLARE_EVENT_TABLE();
-
 	wxPanel*    m_MainPanel;
 
 	wxButton*   m_pButtonPause;
@@ -63,26 +61,6 @@ private:
 	wxButton*   m_pButtonClearVertexShaderCache;
 	wxButton*   m_pButtonClearPixelShaderCache;
 	wxTextCtrl* m_pCount;
-
-
-	// TODO: Prefix with GFX_
-	enum
-	{
-		ID_MAINPANEL = 3900,
-		ID_CONT,
-		ID_PAUSE,
-		ID_PAUSE_AT_NEXT,
-		ID_PAUSE_AT_NEXT_FRAME,
-		ID_PAUSE_AT_LIST,
-		ID_DUMP,
-		ID_DUMP_LIST,
-		ID_UPDATE_SCREEN,
-		ID_CLEAR_SCREEN,
-		ID_CLEAR_TEXTURE_CACHE,
-		ID_CLEAR_VERTEX_SHADER_CACHE,
-		ID_CLEAR_PIXEL_SHADER_CACHE,
-		ID_COUNT
-	};
 
 	void OnClose(wxCloseEvent& event);
 	void CreateGUIControls();

--- a/Source/Core/DolphinWX/FifoPlayerDlg.cpp
+++ b/Source/Core/DolphinWX/FifoPlayerDlg.cpp
@@ -65,25 +65,6 @@ FifoPlayerDlg::FifoPlayerDlg(wxWindow * const parent) :
 
 FifoPlayerDlg::~FifoPlayerDlg()
 {
-	Unbind(RECORDING_FINISHED_EVENT, &FifoPlayerDlg::OnRecordingFinished, this);
-	Unbind(FRAME_WRITTEN_EVENT, &FifoPlayerDlg::OnFrameWritten, this);
-
-	// Disconnect Events
-	Unbind(wxEVT_PAINT, &FifoPlayerDlg::OnPaint, this);
-	m_FrameFromCtrl->Unbind(wxEVT_SPINCTRL, &FifoPlayerDlg::OnFrameFrom, this);
-	m_FrameToCtrl->Unbind(wxEVT_SPINCTRL, &FifoPlayerDlg::OnFrameTo, this);
-	m_ObjectFromCtrl->Unbind(wxEVT_SPINCTRL, &FifoPlayerDlg::OnObjectFrom, this);
-	m_ObjectToCtrl->Unbind(wxEVT_SPINCTRL, &FifoPlayerDlg::OnObjectTo, this);
-	m_EarlyMemoryUpdates->Unbind(wxEVT_CHECKBOX, &FifoPlayerDlg::OnCheckEarlyMemoryUpdates, this);
-	m_RecordStop->Unbind(wxEVT_BUTTON, &FifoPlayerDlg::OnRecordStop, this);
-	m_Save->Unbind(wxEVT_BUTTON, &FifoPlayerDlg::OnSaveFile, this);
-	m_FramesToRecordCtrl->Unbind(wxEVT_SPINCTRL, &FifoPlayerDlg::OnNumFramesToRecord, this);
-	m_Close->Unbind(wxEVT_BUTTON, &FifoPlayerDlg::OnCloseClick, this);
-
-	m_framesList->Unbind(wxEVT_LISTBOX, &FifoPlayerDlg::OnFrameListSelectionChanged, this);
-	m_objectsList->Unbind(wxEVT_LISTBOX, &FifoPlayerDlg::OnObjectListSelectionChanged, this);
-	m_objectCmdList->Unbind(wxEVT_LISTBOX, &FifoPlayerDlg::OnObjectCmdListSelectionChanged, this);
-
 	FifoPlayer::GetInstance().SetFrameWrittenCallback(nullptr);
 
 	sMutex.lock();

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -319,7 +319,6 @@ EVT_ACTIVATE(CFrame::OnActive)
 EVT_CLOSE(CFrame::OnClose)
 EVT_SIZE(CFrame::OnResize)
 EVT_MOVE(CFrame::OnMove)
-EVT_LIST_ITEM_ACTIVATED(LIST_CTRL, CFrame::OnGameListCtrl_ItemActivated)
 EVT_HOST_COMMAND(wxID_ANY, CFrame::OnHostMessage)
 
 EVT_AUI_PANE_CLOSE(CFrame::OnPaneClose)
@@ -393,9 +392,10 @@ CFrame::CFrame(wxFrame* parent,
 	// This panel is the parent for rendering and it holds the gamelistctrl
 	m_Panel = new wxPanel(this, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
 
-	m_GameListCtrl = new CGameListCtrl(m_Panel, LIST_CTRL,
-			wxDefaultPosition, wxDefaultSize,
-			wxLC_REPORT | wxSUNKEN_BORDER | wxLC_ALIGN_LEFT);
+	m_GameListCtrl = new CGameListCtrl(m_Panel, wxID_ANY,
+	        wxDefaultPosition, wxDefaultSize,
+	        wxLC_REPORT | wxSUNKEN_BORDER | wxLC_ALIGN_LEFT);
+	m_GameListCtrl->Bind(wxEVT_LIST_ITEM_ACTIVATED, &CFrame::OnGameListCtrl_ItemActivated, this);
 
 	wxBoxSizer *sizerPanel = new wxBoxSizer(wxHORIZONTAL);
 	sizerPanel->Add(m_GameListCtrl, 1, wxEXPAND | wxALL);

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -184,35 +184,29 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
 	return 0;
 }
 
-BEGIN_EVENT_TABLE(wxEmuStateTip, wxTipWindow)
-	EVT_KEY_DOWN(wxEmuStateTip::OnKeyDown)
-END_EVENT_TABLE()
-
-BEGIN_EVENT_TABLE(CGameListCtrl, wxListCtrl)
-	EVT_SIZE(CGameListCtrl::OnSize)
-	EVT_RIGHT_DOWN(CGameListCtrl::OnRightClick)
-	EVT_LEFT_DOWN(CGameListCtrl::OnLeftClick)
-	EVT_LIST_KEY_DOWN(LIST_CTRL, CGameListCtrl::OnKeyPress)
-	EVT_MOTION(CGameListCtrl::OnMouseMotion)
-	EVT_LIST_COL_BEGIN_DRAG(LIST_CTRL, CGameListCtrl::OnColBeginDrag)
-	EVT_LIST_COL_CLICK(LIST_CTRL, CGameListCtrl::OnColumnClick)
-	EVT_MENU(IDM_PROPERTIES, CGameListCtrl::OnProperties)
-	EVT_MENU(IDM_GAMEWIKI, CGameListCtrl::OnWiki)
-	EVT_MENU(IDM_OPENCONTAININGFOLDER, CGameListCtrl::OnOpenContainingFolder)
-	EVT_MENU(IDM_OPENSAVEFOLDER, CGameListCtrl::OnOpenSaveFolder)
-	EVT_MENU(IDM_EXPORTSAVE, CGameListCtrl::OnExportSave)
-	EVT_MENU(IDM_SETDEFAULTISO, CGameListCtrl::OnSetDefaultISO)
-	EVT_MENU(IDM_COMPRESSISO, CGameListCtrl::OnCompressISO)
-	EVT_MENU(IDM_MULTICOMPRESSISO, CGameListCtrl::OnMultiCompressISO)
-	EVT_MENU(IDM_MULTIDECOMPRESSISO, CGameListCtrl::OnMultiDecompressISO)
-	EVT_MENU(IDM_DELETEISO, CGameListCtrl::OnDeleteISO)
-	EVT_MENU(IDM_LIST_CHANGEDISC, CGameListCtrl::OnChangeDisc)
-END_EVENT_TABLE()
-
 CGameListCtrl::CGameListCtrl(wxWindow* parent, const wxWindowID id, const
 		wxPoint& pos, const wxSize& size, long style)
 	: wxListCtrl(parent, id, pos, size, style), toolTip(nullptr)
 {
+	Bind(wxEVT_SIZE, &CGameListCtrl::OnSize, this);
+	Bind(wxEVT_RIGHT_DOWN, &CGameListCtrl::OnRightClick, this);
+	Bind(wxEVT_LEFT_DOWN, &CGameListCtrl::OnLeftClick, this);
+	Bind(wxEVT_MOTION, &CGameListCtrl::OnMouseMotion, this);
+	Bind(wxEVT_LIST_KEY_DOWN, &CGameListCtrl::OnKeyPress, this);
+	Bind(wxEVT_LIST_COL_BEGIN_DRAG, &CGameListCtrl::OnColBeginDrag, this);
+	Bind(wxEVT_LIST_COL_CLICK, &CGameListCtrl::OnColumnClick, this);
+
+	Bind(wxEVT_MENU, &CGameListCtrl::OnProperties, this, IDM_PROPERTIES);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnWiki, this, IDM_GAMEWIKI);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnOpenContainingFolder, this, IDM_OPENCONTAININGFOLDER);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnOpenSaveFolder, this, IDM_OPENSAVEFOLDER);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnExportSave, this, IDM_EXPORTSAVE);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnSetDefaultISO, this, IDM_SETDEFAULTISO);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnCompressISO, this, IDM_COMPRESSISO);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnMultiCompressISO, this, IDM_MULTICOMPRESSISO);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnMultiDecompressISO, this, IDM_MULTIDECOMPRESSISO);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnDeleteISO, this, IDM_DELETEISO);
+	Bind(wxEVT_MENU, &CGameListCtrl::OnChangeDisc, this, IDM_LIST_CHANGEDISC);
 }
 
 CGameListCtrl::~CGameListCtrl()

--- a/Source/Core/DolphinWX/GameListCtrl.h
+++ b/Source/Core/DolphinWX/GameListCtrl.h
@@ -24,11 +24,13 @@ class wxEmuStateTip : public wxTipWindow
 {
 public:
 	wxEmuStateTip(wxWindow* parent, const wxString& text, wxEmuStateTip** windowPtr)
-		: wxTipWindow(parent, text, 70, (wxTipWindow**)windowPtr) {}
+	    : wxTipWindow(parent, text, 70, (wxTipWindow**)windowPtr)
+	{
+		Bind(wxEVT_KEY_DOWN, &wxEmuStateTip::OnKeyDown, this);
+	}
+
 	// wxTipWindow doesn't correctly handle KeyEvents and crashes... we must overload that.
 	void OnKeyDown(wxKeyEvent& event) { event.StopPropagation(); Close(); }
-private:
-	DECLARE_EVENT_TABLE()
 };
 
 class CGameListCtrl : public wxListCtrl
@@ -82,8 +84,6 @@ private:
 	void InsertItemInReportView(long _Index);
 	void SetBackgroundColor();
 	void ScanForISOs();
-
-	DECLARE_EVENT_TABLE()
 
 	// events
 	void OnLeftClick(wxMouseEvent& event);

--- a/Source/Core/DolphinWX/Globals.h
+++ b/Source/Core/DolphinWX/Globals.h
@@ -281,7 +281,6 @@ enum
 	IDM_MPANEL, ID_STATUSBAR,
 
 	ID_TOOLBAR = 500,
-	LIST_CTRL = 1000
 };
 
 // custom message macro

--- a/Source/Core/DolphinWX/HotkeyDlg.cpp
+++ b/Source/Core/DolphinWX/HotkeyDlg.cpp
@@ -27,17 +27,15 @@
 #include "DolphinWX/HotkeyDlg.h"
 #include "DolphinWX/WXInputBase.h"
 
-BEGIN_EVENT_TABLE(HotkeyConfigDialog,wxDialog)
-	EVT_COMMAND_RANGE(0, NUM_HOTKEYS - 1, wxEVT_BUTTON, HotkeyConfigDialog::OnButtonClick)
-	EVT_TIMER(wxID_ANY, HotkeyConfigDialog::OnButtonTimer)
-END_EVENT_TABLE()
-
 HotkeyConfigDialog::HotkeyConfigDialog(wxWindow *parent, wxWindowID id, const wxString &title,
 		const wxPoint &position, const wxSize& size, long style)
 : wxDialog(parent, id, title, position, size, style)
 , m_ButtonMappingTimer(this)
 {
 	CreateHotkeyGUIControls();
+
+	Bind(wxEVT_BUTTON, &HotkeyConfigDialog::OnButtonClick, this, 0, NUM_HOTKEYS - 1);
+	Bind(wxEVT_TIMER, &HotkeyConfigDialog::OnButtonTimer, this);
 
 	g_Pressed = 0;
 	g_Modkey = 0;

--- a/Source/Core/DolphinWX/HotkeyDlg.h
+++ b/Source/Core/DolphinWX/HotkeyDlg.h
@@ -26,35 +26,33 @@ class wxWindow;
 
 class HotkeyConfigDialog : public wxDialog
 {
-	public:
-		HotkeyConfigDialog(wxWindow *parent,
-				wxWindowID id = 1,
-				const wxString &title = _("Hotkey Configuration"),
-				const wxPoint& pos = wxDefaultPosition,
-				const wxSize& size = wxDefaultSize,
-				long style = wxDEFAULT_DIALOG_STYLE);
-		virtual ~HotkeyConfigDialog();
+public:
+	HotkeyConfigDialog(wxWindow* parent,
+			wxWindowID id = 1,
+			const wxString &title = _("Hotkey Configuration"),
+			const wxPoint& pos = wxDefaultPosition,
+			const wxSize& size = wxDefaultSize,
+			long style = wxDEFAULT_DIALOG_STYLE);
+	virtual ~HotkeyConfigDialog();
 
-	private:
-		DECLARE_EVENT_TABLE();
+private:
+	wxString OldLabel;
 
-		wxString OldLabel;
+	wxButton* ClickedButton;
+	wxButton* m_Button_Hotkeys[NUM_HOTKEYS];
 
-		wxButton *ClickedButton;
-		wxButton *m_Button_Hotkeys[NUM_HOTKEYS];
+	wxTimer m_ButtonMappingTimer;
 
-		wxTimer m_ButtonMappingTimer;
+	void OnButtonTimer(wxTimerEvent& WXUNUSED(event)) { DoGetButtons(GetButtonWaitingID); }
+	void OnButtonClick(wxCommandEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
+	void SaveButtonMapping(int Id, int Key, int Modkey);
+	void CreateHotkeyGUIControls();
 
-		void OnButtonTimer(wxTimerEvent& WXUNUSED(event)) { DoGetButtons(GetButtonWaitingID); }
-		void OnButtonClick(wxCommandEvent& event);
-		void OnKeyDown(wxKeyEvent& event);
-		void SaveButtonMapping(int Id, int Key, int Modkey);
-		void CreateHotkeyGUIControls();
+	void SetButtonText(int id, const wxString &keystr, const wxString &modkeystr = wxString());
 
-		void SetButtonText(int id, const wxString &keystr, const wxString &modkeystr = wxString());
+	void DoGetButtons(int id);
+	void EndGetButtons();
 
-		void DoGetButtons(int id);
-		void EndGetButtons();
-
-		int GetButtonWaitingID, GetButtonWaitingTimer, g_Pressed, g_Modkey;
+	int GetButtonWaitingID, GetButtonWaitingTimer, g_Pressed, g_Modkey;
 };

--- a/Source/Core/DolphinWX/LogWindow.cpp
+++ b/Source/Core/DolphinWX/LogWindow.cpp
@@ -41,14 +41,6 @@
 // Milliseconds between msgQueue flushes to wxTextCtrl
 #define UPDATETIME 200
 
-BEGIN_EVENT_TABLE(CLogWindow, wxPanel)
-	EVT_CLOSE(CLogWindow::OnClose)
-	EVT_BUTTON(IDM_CLEARLOG, CLogWindow::OnClear)
-	EVT_CHOICE(IDM_FONT, CLogWindow::OnFontChange)
-	EVT_CHECKBOX(IDM_WRAPLINE, CLogWindow::OnWrapLineCheck)
-	EVT_TIMER(IDTM_UPDATELOG, CLogWindow::OnLogTimer)
-END_EVENT_TABLE()
-
 CLogWindow::CLogWindow(CFrame *parent, wxWindowID id, const wxPoint& pos,
 		const wxSize& size, long style, const wxString& name)
 	: wxPanel(parent, id, pos, size, style, name)
@@ -56,11 +48,13 @@ CLogWindow::CLogWindow(CFrame *parent, wxWindowID id, const wxPoint& pos,
 	, Parent(parent), m_ignoreLogTimer(false), m_LogAccess(true)
 	, m_Log(nullptr), m_cmdline(nullptr), m_FontChoice(nullptr)
 {
+	Bind(wxEVT_CLOSE_WINDOW, &CLogWindow::OnClose, this);
 	m_LogManager = LogManager::GetInstance();
 
 	CreateGUIControls();
 
-	m_LogTimer = new wxTimer(this, IDTM_UPDATELOG);
+	m_LogTimer = new wxTimer(this);
+	m_LogTimer->Bind(wxEVT_TIMER, &CLogWindow::OnLogTimer, this);
 	m_LogTimer->Start(UPDATETIME);
 }
 
@@ -124,7 +118,8 @@ void CLogWindow::CreateGUIControls()
 	}
 
 	// Font
-	m_FontChoice = new wxChoice(this, IDM_FONT);
+	m_FontChoice = new wxChoice(this, wxID_ANY);
+	m_FontChoice->Bind(wxEVT_CHOICE, &CLogWindow::OnFontChange, this);
 	m_FontChoice->Append(_("Default font"));
 	m_FontChoice->Append(_("Monospaced font"));
 	m_FontChoice->Append(_("Selected font"));
@@ -142,27 +137,32 @@ void CLogWindow::CreateGUIControls()
 	// Word wrap
 	bool wrap_lines;
 	options->Get("WrapLines", &wrap_lines, false);
-	m_WrapLine = new wxCheckBox(this, IDM_WRAPLINE, _("Word Wrap"));
+	m_WrapLine = new wxCheckBox(this, wxID_ANY, _("Word Wrap"));
+	m_WrapLine->Bind(wxEVT_CHECKBOX, &CLogWindow::OnWrapLineCheck, this);
 	m_WrapLine->SetValue(wrap_lines);
 
 	// Log viewer
-	m_Log = CreateTextCtrl(this, IDM_LOG, wxTE_RICH | wxTE_MULTILINE | wxTE_READONLY |
+	m_Log = CreateTextCtrl(this, wxID_ANY, wxTE_RICH | wxTE_MULTILINE | wxTE_READONLY |
 			(wrap_lines ? wxTE_WORDWRAP : wxTE_DONTWRAP));
 
 	// submit row
-	m_cmdline = new wxTextCtrl(this, IDM_SUBMITCMD, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+	m_cmdline = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
 			wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
 
+	// Clear log button
+	m_clear_log_btn = new wxButton(this, wxID_ANY, _("Clear"), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+	m_clear_log_btn->Bind(wxEVT_BUTTON, &CLogWindow::OnClear, this);
+
 	// Sizers
-	wxBoxSizer *sTop = new wxBoxSizer(wxHORIZONTAL);
-	sTop->Add(new wxButton(this, IDM_CLEARLOG, _("Clear"), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT));
+	wxBoxSizer* sTop = new wxBoxSizer(wxHORIZONTAL);
+	sTop->Add(m_clear_log_btn);
 	sTop->Add(m_FontChoice, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 3);
 	sTop->Add(m_WrapLine, 0, wxALIGN_CENTER_VERTICAL);
 
 	sBottom = new wxBoxSizer(wxVERTICAL);
 	PopulateBottom();
 
-	wxBoxSizer *sMain = new wxBoxSizer(wxVERTICAL);
+	wxBoxSizer* sMain = new wxBoxSizer(wxVERTICAL);
 	sMain->Add(sTop, 0, wxEXPAND);
 	sMain->Add(sBottom, 1, wxEXPAND);
 	SetSizer(sMain);
@@ -273,9 +273,9 @@ void CLogWindow::OnWrapLineCheck(wxCommandEvent& event)
 	Text = m_Log->GetValue();
 	m_Log->Destroy();
 	if (event.IsChecked())
-		m_Log = CreateTextCtrl(this, IDM_LOG, wxTE_RICH | wxTE_MULTILINE | wxTE_READONLY | wxTE_WORDWRAP);
+		m_Log = CreateTextCtrl(this, wxID_ANY, wxTE_RICH | wxTE_MULTILINE | wxTE_READONLY | wxTE_WORDWRAP);
 	else
-		m_Log = CreateTextCtrl(this, IDM_LOG, wxTE_RICH | wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
+		m_Log = CreateTextCtrl(this, wxID_ANY, wxTE_RICH | wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
 	m_Log->SetDefaultStyle(wxTextAttr(*wxWHITE));
 	m_Log->AppendText(Text);
 	PopulateBottom();

--- a/Source/Core/DolphinWX/LogWindow.h
+++ b/Source/Core/DolphinWX/LogWindow.h
@@ -28,22 +28,11 @@ class wxTextCtrl;
 class wxTimer;
 class wxTimerEvent;
 
-enum
-{
-	IDM_LOG,
-	IDM_CLEARLOG,
-	IDM_TOGGLEALL,
-	IDM_WRAPLINE,
-	IDTM_UPDATELOG,
-	IDM_FONT,
-	IDM_SUBMITCMD
-};
-
 // Uses multiple inheritance - only sane because LogListener is a pure virtual interface.
 class CLogWindow : public wxPanel, LogListener
 {
 public:
-	CLogWindow(CFrame *parent,
+	CLogWindow(CFrame* parent,
 		wxWindowID id = wxID_ANY,
 		const wxPoint& pos = wxDefaultPosition,
 		const wxSize& size = wxDefaultSize,
@@ -58,26 +47,26 @@ public:
 	int x, y, winpos;
 
 private:
-	CFrame *Parent;
+	CFrame* Parent;
 	wxFont DefaultFont, MonoSpaceFont;
 	std::vector<wxFont> LogFont;
-	wxTimer *m_LogTimer;
+	wxTimer* m_LogTimer;
 	bool m_ignoreLogTimer;
-	LogManager *m_LogManager;
+	LogManager* m_LogManager;
 	std::queue<std::pair<u8, wxString> > msgQueue;
 	bool m_writeFile, m_writeWindow, m_writeDebugger, m_LogAccess;
 
 	// Controls
-	wxBoxSizer *sBottom;
-	wxTextCtrl *m_Log, *m_cmdline;
-	wxChoice *m_FontChoice;
-	wxCheckBox *m_WrapLine;
+	wxBoxSizer* sBottom;
+	wxTextCtrl* m_Log;
+	wxTextCtrl* m_cmdline;
+	wxChoice* m_FontChoice;
+	wxCheckBox* m_WrapLine;
+	wxButton* m_clear_log_btn;
 
 	std::mutex m_LogSection;
 
-	DECLARE_EVENT_TABLE()
-
-	wxTextCtrl * CreateTextCtrl(wxPanel* parent, wxWindowID id, long Style);
+	wxTextCtrl* CreateTextCtrl(wxPanel* parent, wxWindowID id, long Style);
 	void CreateGUIControls();
 	void PopulateBottom();
 	void UnPopulateBottom();

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -89,12 +89,6 @@ class wxFrame;
 
 IMPLEMENT_APP(DolphinApp)
 
-BEGIN_EVENT_TABLE(DolphinApp, wxApp)
-	EVT_TIMER(wxID_ANY, DolphinApp::AfterInit)
-	EVT_QUERY_END_SESSION(DolphinApp::OnEndSession)
-	EVT_END_SESSION(DolphinApp::OnEndSession)
-END_EVENT_TABLE()
-
 bool wxMsgAlert(const char*, const char*, bool, int);
 std::string wxStringTranslator(const char *);
 
@@ -138,6 +132,9 @@ bool DolphinApp::Initialize(int& c, wxChar **v)
 
 bool DolphinApp::OnInit()
 {
+	Bind(wxEVT_QUERY_END_SESSION, &DolphinApp::OnEndSession, this);
+	Bind(wxEVT_END_SESSION, &DolphinApp::OnEndSession, this);
+
 	InitLanguageSupport();
 
 	// Declarations and definitions
@@ -309,18 +306,14 @@ bool DolphinApp::OnInit()
 		y = wxDefaultCoord;
 #endif
 
-	main_frame = new CFrame((wxFrame*)nullptr, wxID_ANY,
+	main_frame = new CFrame(nullptr, wxID_ANY,
 				StrToWxStr(scm_rev_str),
 				wxPoint(x, y), wxSize(w, h),
 				UseDebugger, BatchMode, UseLogger);
 	SetTopWindow(main_frame);
 	main_frame->SetMinSize(wxSize(400, 300));
 
-	// Postpone final actions until event handler is running.
-	// Updating the game list makes use of wxProgressDialog which may
-	// only be run after OnInit() when the event handler is running.
-	m_afterinit = new wxTimer(this, wxID_ANY);
-	m_afterinit->Start(1, wxTIMER_ONE_SHOT);
+	AfterInit();
 
 	return true;
 }
@@ -329,16 +322,11 @@ void DolphinApp::MacOpenFile(const wxString &fileName)
 {
 	FileToLoad = fileName;
 	LoadFile = true;
-
-	if (m_afterinit == nullptr)
-		main_frame->BootGame(WxStrToStr(FileToLoad));
+	main_frame->BootGame(WxStrToStr(FileToLoad));
 }
 
-void DolphinApp::AfterInit(wxTimerEvent& WXUNUSED(event))
+void DolphinApp::AfterInit()
 {
-	delete m_afterinit;
-	m_afterinit = nullptr;
-
 	if (!BatchMode)
 		main_frame->UpdateGameList();
 
@@ -352,7 +340,7 @@ void DolphinApp::AfterInit(wxTimerEvent& WXUNUSED(event))
 			}
 			else
 			{
-				main_frame->BootGame(std::string(""));
+				main_frame->BootGame("");
 			}
 		}
 	}

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -12,8 +12,6 @@
 
 class CFrame;
 class wxLocale;
-class wxTimer;
-class wxTimerEvent;
 
 extern CFrame* main_frame;
 
@@ -31,9 +29,6 @@ private:
 	void InitLanguageSupport();
 	void MacOpenFile(const wxString &fileName);
 
-	DECLARE_EVENT_TABLE()
-
-	wxTimer *m_afterinit;
 	bool BatchMode;
 	bool LoadFile;
 	bool playMovie;
@@ -41,7 +36,7 @@ private:
 	wxString movieFile;
 	wxLocale *m_locale;
 
-	void AfterInit(wxTimerEvent& WXUNUSED(event));
+	void AfterInit();
 	void OnEndSession(wxCloseEvent& event);
 };
 

--- a/Source/Core/DolphinWX/PatchAddEdit.cpp
+++ b/Source/Core/DolphinWX/PatchAddEdit.cpp
@@ -28,18 +28,13 @@
 #include "DolphinWX/PatchAddEdit.h"
 #include "DolphinWX/WxUtils.h"
 
-BEGIN_EVENT_TABLE(CPatchAddEdit, wxDialog)
-	EVT_BUTTON(wxID_OK, CPatchAddEdit::SavePatchData)
-	EVT_BUTTON(ID_ENTRY_ADD, CPatchAddEdit::AddRemoveEntry)
-	EVT_BUTTON(ID_ENTRY_REMOVE, CPatchAddEdit::AddRemoveEntry)
-	EVT_SPIN(ID_ENTRY_SELECT, CPatchAddEdit::ChangeEntry)
-END_EVENT_TABLE()
-
 CPatchAddEdit::CPatchAddEdit(int _selection, wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& position, const wxSize& size, long style)
 	: wxDialog(parent, id, title, position, size, style)
 {
 	selection = _selection;
 	CreateGUIControls(selection);
+
+	Bind(wxEVT_BUTTON, &CPatchAddEdit::SavePatchData, this, wxID_OK);
 }
 
 CPatchAddEdit::~CPatchAddEdit()
@@ -64,25 +59,35 @@ void CPatchAddEdit::CreateGUIControls(int _selection)
 	itCurEntry = tempEntries.begin();
 
 	wxBoxSizer* sEditPatch = new wxBoxSizer(wxVERTICAL);
-	wxStaticText* EditPatchNameText = new wxStaticText(this, ID_EDITPATCH_NAME_TEXT, _("Name:"));
-	EditPatchName = new wxTextCtrl(this, ID_EDITPATCH_NAME);
+
+	wxStaticText* EditPatchNameText = new wxStaticText(this, wxID_ANY, _("Name:"));
+	EditPatchName = new wxTextCtrl(this, wxID_ANY);
 	EditPatchName->SetValue(currentName);
-	wxStaticText* EditPatchOffsetText = new wxStaticText(this, ID_EDITPATCH_OFFSET_TEXT, _("Offset:"));
-	EditPatchOffset = new wxTextCtrl(this, ID_EDITPATCH_OFFSET);
+
+	wxStaticText* EditPatchOffsetText = new wxStaticText(this, wxID_ANY, _("Offset:"));
+	EditPatchOffset = new wxTextCtrl(this, wxID_ANY);
 	EditPatchOffset->SetValue(wxString::Format("%08X", tempEntries.at(0).address));
-	EntrySelection = new wxSpinButton(this, ID_ENTRY_SELECT);
+
+	EntrySelection = new wxSpinButton(this);
+	EntrySelection->Bind(wxEVT_SPIN, &CPatchAddEdit::ChangeEntry, this);
 	EntrySelection->SetRange(0, (int)tempEntries.size()-1);
 	EntrySelection->SetValue((int)tempEntries.size()-1);
+
 	wxArrayString wxArrayStringFor_EditPatchType;
 	for (int i = 0; i < 3; ++i)
 		wxArrayStringFor_EditPatchType.Add(StrToWxStr(PatchEngine::PatchTypeStrings[i]));
-	EditPatchType = new wxRadioBox(this, ID_EDITPATCH_TYPE, _("Type"), wxDefaultPosition, wxDefaultSize, wxArrayStringFor_EditPatchType, 3, wxRA_SPECIFY_COLS);
+	EditPatchType = new wxRadioBox(this, wxID_ANY, _("Type"), wxDefaultPosition, wxDefaultSize, wxArrayStringFor_EditPatchType, 3, wxRA_SPECIFY_COLS);
 	EditPatchType->SetSelection((int)tempEntries.at(0).type);
-	wxStaticText* EditPatchValueText = new wxStaticText(this, ID_EDITPATCH_VALUE_TEXT, _("Value:"));
-	EditPatchValue = new wxTextCtrl(this, ID_EDITPATCH_VALUE);
+
+	wxStaticText* EditPatchValueText = new wxStaticText(this, wxID_ANY, _("Value:"));
+	EditPatchValue = new wxTextCtrl(this, wxID_ANY);
 	EditPatchValue->SetValue(wxString::Format("%0*X", PatchEngine::GetPatchTypeCharLength(tempEntries.at(0).type), tempEntries.at(0).value));
-	wxButton *EntryAdd = new wxButton(this, ID_ENTRY_ADD, _("Add"));
-	EntryRemove = new wxButton(this, ID_ENTRY_REMOVE, _("Remove"));
+
+	EntryAdd = new wxButton(this, wxID_ANY, _("Add"));
+	EntryAdd->Bind(wxEVT_BUTTON, &CPatchAddEdit::AddEntry, this);
+
+	EntryRemove = new wxButton(this, wxID_ANY, _("Remove"));
+	EntryRemove->Bind(wxEVT_BUTTON, &CPatchAddEdit::RemoveEntry, this);
 	if ((int)tempEntries.size() <= 1)
 		EntryRemove->Disable();
 
@@ -92,6 +97,7 @@ void CPatchAddEdit::CreateGUIControls(int _selection)
 	sEditPatch->Add(sEditPatchName, 0, wxEXPAND);
 	sbEntry = new wxStaticBoxSizer(wxVERTICAL, this, wxString::Format(_("Entry 1/%d"), (int)tempEntries.size()));
 	currentItem = 1;
+
 	wxGridBagSizer* sgEntry = new wxGridBagSizer(0, 0);
 	sgEntry->Add(EditPatchType, wxGBPosition(0, 0), wxGBSpan(1, 2), wxEXPAND|wxALL, 5);
 	sgEntry->Add(EditPatchOffsetText, wxGBPosition(1, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL|wxALL, 5);
@@ -100,6 +106,7 @@ void CPatchAddEdit::CreateGUIControls(int _selection)
 	sgEntry->Add(EditPatchValue, wxGBPosition(2, 1), wxGBSpan(1, 1), wxEXPAND|wxALL, 5);
 	sgEntry->Add(EntrySelection, wxGBPosition(0, 2), wxGBSpan(3, 1), wxEXPAND|wxALL, 5);
 	sgEntry->AddGrowableCol(1);
+
 	wxBoxSizer* sEntryAddRemove = new wxBoxSizer(wxHORIZONTAL);
 	sEntryAddRemove->Add(EntryAdd, 0, wxALL, 5);
 	sEntryAddRemove->Add(EntryRemove, 0, wxALL, 5);
@@ -146,51 +153,44 @@ void CPatchAddEdit::SavePatchData(wxCommandEvent& event)
 	event.Skip();
 }
 
-void CPatchAddEdit::AddRemoveEntry(wxCommandEvent& event)
+void CPatchAddEdit::AddEntry(wxCommandEvent& event)
 {
-	switch (event.GetId())
+	if (!UpdateTempEntryData(itCurEntry))
+		return;
+
+	PatchEngine::PatchEntry peEmptyEntry(PatchEngine::PATCH_8BIT, 0x00000000, 0x00000000);
+	++itCurEntry;
+	currentItem++;
+	itCurEntry = tempEntries.insert(itCurEntry, peEmptyEntry);
+
+	EntrySelection->SetRange(EntrySelection->GetMin(), EntrySelection->GetMax() + 1);
+	UpdateEntryCtrls(*itCurEntry);
+
+	EntryRemove->Enable();
+	EntrySelection->Enable();
+}
+
+void CPatchAddEdit::RemoveEntry(wxCommandEvent& event)
+{
+	itCurEntry = tempEntries.erase(itCurEntry);
+
+	if (itCurEntry != tempEntries.begin())
 	{
-	case ID_ENTRY_ADD:
-		{
-			if (!UpdateTempEntryData(itCurEntry))
-				break;
+		--itCurEntry;
+		currentItem--;
+	}
+	else
+	{
+		EntrySelection->SetValue(EntrySelection->GetValue() - 1);
+	}
 
-			PatchEngine::PatchEntry peEmptyEntry(PatchEngine::PATCH_8BIT, 0x00000000, 0x00000000);
-			++itCurEntry;
-			currentItem++;
-			itCurEntry = tempEntries.insert(itCurEntry, peEmptyEntry);
+	EntrySelection->SetRange(EntrySelection->GetMin(), EntrySelection->GetMax() - 1);
+	UpdateEntryCtrls(*itCurEntry);
 
-			EntrySelection->SetRange(EntrySelection->GetMin(), EntrySelection->GetMax() + 1);
-			UpdateEntryCtrls(*itCurEntry);
-
-			EntryRemove->Enable();
-			EntrySelection->Enable();
-		}
-		break;
-	case ID_ENTRY_REMOVE:
-		{
-			itCurEntry = tempEntries.erase(itCurEntry);
-
-			if (itCurEntry != tempEntries.begin())
-			{
-				--itCurEntry;
-				currentItem--;
-			}
-			else
-			{
-				EntrySelection->SetValue(EntrySelection->GetValue() - 1);
-			}
-
-			EntrySelection->SetRange(EntrySelection->GetMin(), EntrySelection->GetMax() - 1);
-			UpdateEntryCtrls(*itCurEntry);
-
-			if ((int)tempEntries.size() <= 1)
-			{
-				EntryRemove->Disable();
-				EntrySelection->Disable();
-			}
-		}
-		break;
+	if ((int)tempEntries.size() <= 1)
+	{
+		EntryRemove->Disable();
+		EntrySelection->Disable();
 	}
 }
 

--- a/Source/Core/DolphinWX/PatchAddEdit.h
+++ b/Source/Core/DolphinWX/PatchAddEdit.h
@@ -24,49 +24,34 @@ class wxWindow;
 
 class CPatchAddEdit : public wxDialog
 {
-	public:
-		CPatchAddEdit(int _selection, wxWindow* parent,
-			wxWindowID id = 1,
-			const wxString& title = _("Edit Patch"),
-			const wxPoint& pos = wxDefaultPosition,
-			const wxSize& size = wxDefaultSize,
-			long style = wxDEFAULT_DIALOG_STYLE);
-		virtual ~CPatchAddEdit();
+public:
+	CPatchAddEdit(int _selection, wxWindow* parent,
+		wxWindowID id = 1,
+		const wxString& title = _("Edit Patch"),
+		const wxPoint& pos = wxDefaultPosition,
+		const wxSize& size = wxDefaultSize,
+		long style = wxDEFAULT_DIALOG_STYLE);
+	virtual ~CPatchAddEdit();
 
-	private:
-		DECLARE_EVENT_TABLE();
+private:
+	wxTextCtrl* EditPatchName;
+	wxTextCtrl* EditPatchOffset;
+	wxRadioBox* EditPatchType;
+	wxTextCtrl* EditPatchValue;
+	wxSpinButton* EntrySelection;
+	wxButton* EntryAdd;
+	wxButton* EntryRemove;
+	wxStaticBoxSizer* sbEntry;
 
-		wxTextCtrl *EditPatchName;
-		wxTextCtrl *EditPatchOffset;
-		wxRadioBox *EditPatchType;
-		wxTextCtrl *EditPatchValue;
-		wxSpinButton *EntrySelection;
-		wxButton *EntryRemove;
-		wxStaticBoxSizer* sbEntry;
+	void CreateGUIControls(int selection);
+	void ChangeEntry(wxSpinEvent& event);
+	void SavePatchData(wxCommandEvent& event);
+	void AddEntry(wxCommandEvent& event);
+	void RemoveEntry(wxCommandEvent& event);
+	void UpdateEntryCtrls(PatchEngine::PatchEntry pE);
+	bool UpdateTempEntryData(std::vector<PatchEngine::PatchEntry>::iterator iterEntry);
 
-		enum
-		{
-			ID_EDITPATCH_NAME_TEXT = 4500,
-			ID_EDITPATCH_NAME,
-			ID_EDITPATCH_OFFSET_TEXT,
-			ID_EDITPATCH_OFFSET,
-			ID_ENTRY_SELECT,
-			ID_EDITPATCH_TYPE,
-			ID_EDITPATCH_VALUE_TEXT,
-			ID_EDITPATCH_VALUE,
-			ID_ENTRY_ADD,
-			ID_ENTRY_REMOVE
-		};
-
-		void CreateGUIControls(int selection);
-		void ChangeEntry(wxSpinEvent& event);
-		void SavePatchData(wxCommandEvent& event);
-		void AddRemoveEntry(wxCommandEvent& event);
-		void UpdateEntryCtrls(PatchEngine::PatchEntry pE);
-		bool UpdateTempEntryData(std::vector<PatchEngine::PatchEntry>::iterator iterEntry);
-
-		int selection, currentItem;
-		std::vector<PatchEngine::PatchEntry> tempEntries;
-		std::vector<PatchEngine::PatchEntry>::iterator itCurEntry;
-
+	int selection, currentItem;
+	std::vector<PatchEngine::PatchEntry> tempEntries;
+	std::vector<PatchEngine::PatchEntry>::iterator itCurEntry;
 };


### PR DESCRIPTION
Also fixes some of the wonky stuff in Main where we would fire an event to do post-init stuff which isn't necessary anymore.

The other tables are left because to remove those, I will need to move code around, so that will be separated out into another PR that will detail changes in functionality.
