### PR TITLE
DVDInterface: Initialize variables

### DIFF
--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -346,8 +346,13 @@ void Init()
 	CurrentStart = 0;
 	CurrentLength = 0;
 
+	g_ErrorCode = 0;
+	g_bDiscInside = false;
 	g_bStream = false;
 	g_bStopAtTrackEnd = false;
+
+	g_last_read_offset = 0;
+	g_last_read_time = 0;
 
 	ejectDisc = CoreTiming::RegisterEvent("EjectDisc", EjectDiscCallback);
 	insertDisc = CoreTiming::RegisterEvent("InsertDisc", InsertDiscCallback);


### PR DESCRIPTION
If the g_last_read variables are not reset at the beginning of emulation sessions, values from a previous session can be used. That behavior has the possibility to be non-deterministic in certain rare cases. This change makes Init() reset those two variables, along with two other variables that seem to have the same problem.
