### PR TITLE
DolphinWX: Eliminate some memory leaks

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -364,26 +364,26 @@ void CCodeView::OnMouseUpR(wxMouseEvent& event)
 {
 	bool isSymbol = m_symbol_db->GetSymbolFromAddr(m_selection) != nullptr;
 	// popup menu
-	wxMenu* menu = new wxMenu;
+	wxMenu menu;
 	//menu->Append(IDM_GOTOINMEMVIEW, "&Goto in mem view");
-	menu->Append(IDM_FOLLOWBRANCH, _("&Follow branch"))->Enable(AddrToBranch(m_selection) ? true : false);
-	menu->AppendSeparator();
+	menu.Append(IDM_FOLLOWBRANCH, _("&Follow branch"))->Enable(AddrToBranch(m_selection) ? true : false);
+	menu.AppendSeparator();
 #if wxUSE_CLIPBOARD
-	menu->Append(IDM_COPYADDRESS, _("Copy &address"));
-	menu->Append(IDM_COPYFUNCTION, _("Copy &function"))->Enable(isSymbol);
-	menu->Append(IDM_COPYCODE, _("Copy &code line"));
-	menu->Append(IDM_COPYHEX, _("Copy &hex"));
-	menu->AppendSeparator();
+	menu.Append(IDM_COPYADDRESS, _("Copy &address"));
+	menu.Append(IDM_COPYFUNCTION, _("Copy &function"))->Enable(isSymbol);
+	menu.Append(IDM_COPYCODE, _("Copy &code line"));
+	menu.Append(IDM_COPYHEX, _("Copy &hex"));
+	menu.AppendSeparator();
 #endif
-	menu->Append(IDM_RENAMESYMBOL, _("Rename &symbol"))->Enable(isSymbol);
-	menu->AppendSeparator();
-	menu->Append(IDM_RUNTOHERE, _("&Run To Here"))->Enable(Core::IsRunning());
-	menu->Append(IDM_ADDFUNCTION, _("&Add function"))->Enable(Core::IsRunning());
-	menu->Append(IDM_JITRESULTS, _("PPC vs X86"))->Enable(Core::IsRunning());
-	menu->Append(IDM_INSERTBLR, _("Insert &blr"))->Enable(Core::IsRunning());
-	menu->Append(IDM_INSERTNOP, _("Insert &nop"))->Enable(Core::IsRunning());
-	menu->Append(IDM_PATCHALERT, _("Patch alert"))->Enable(Core::IsRunning());
-	PopupMenu(menu);
+	menu.Append(IDM_RENAMESYMBOL, _("Rename &symbol"))->Enable(isSymbol);
+	menu.AppendSeparator();
+	menu.Append(IDM_RUNTOHERE, _("&Run To Here"))->Enable(Core::IsRunning());
+	menu.Append(IDM_ADDFUNCTION, _("&Add function"))->Enable(Core::IsRunning());
+	menu.Append(IDM_JITRESULTS, _("PPC vs X86"))->Enable(Core::IsRunning());
+	menu.Append(IDM_INSERTBLR, _("Insert &blr"))->Enable(Core::IsRunning());
+	menu.Append(IDM_INSERTNOP, _("Insert &nop"))->Enable(Core::IsRunning());
+	menu.Append(IDM_PATCHALERT, _("Patch alert"))->Enable(Core::IsRunning());
+	PopupMenu(&menu);
 	event.Skip();
 }
 

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -221,22 +221,22 @@ void CMemoryView::OnPopupMenu(wxCommandEvent& event)
 void CMemoryView::OnMouseDownR(wxMouseEvent& event)
 {
 	// popup menu
-	wxMenu* menu = new wxMenu;
+	wxMenu menu;
 	//menu.Append(IDM_GOTOINMEMVIEW, _("&Goto in mem view"));
 #if wxUSE_CLIPBOARD
-	menu->Append(IDM_COPYADDRESS, _("Copy &address"));
-	menu->Append(IDM_COPYHEX, _("Copy &hex"));
+	menu.Append(IDM_COPYADDRESS, _("Copy &address"));
+	menu.Append(IDM_COPYHEX, _("Copy &hex"));
 #endif
-	menu->Append(IDM_WATCHADDRESS, _("Add to &watch"));
-	menu->Append(IDM_TOGGLEMEMORY, _("Toggle &memory"));
+	menu.Append(IDM_WATCHADDRESS, _("Add to &watch"));
+	menu.Append(IDM_TOGGLEMEMORY, _("Toggle &memory"));
 
-	wxMenu* viewAsSubMenu = new wxMenu;
-	viewAsSubMenu->Append(IDM_VIEWASFP, _("FP value"));
-	viewAsSubMenu->Append(IDM_VIEWASASCII, "ASCII");
-	viewAsSubMenu->Append(IDM_VIEWASHEX, _("Hex"));
-	menu->AppendSubMenu(viewAsSubMenu, _("View As:"));
+	wxMenu viewAsSubMenu;
+	viewAsSubMenu.Append(IDM_VIEWASFP, _("FP value"));
+	viewAsSubMenu.Append(IDM_VIEWASASCII, "ASCII");
+	viewAsSubMenu.Append(IDM_VIEWASHEX, _("Hex"));
+	menu.AppendSubMenu(&viewAsSubMenu, _("View As:"));
 
-	PopupMenu(menu);
+	PopupMenu(&menu);
 }
 
 void CMemoryView::OnPaint(wxPaintEvent& event)

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -274,10 +274,10 @@ void CRegisterView::OnMouseDownR(wxGridEvent& event)
 	wxString strNewVal = GetValueByRowCol(row, col);
 	TryParse("0x" + WxStrToStr(strNewVal), &m_selectedAddress);
 
-	wxMenu* menu = new wxMenu;
-	menu->Append(IDM_WATCHADDRESS, _("Add to &watch"));
-	menu->Append(IDM_VIEWMEMORY, _("View &memory"));
-	PopupMenu(menu);
+	wxMenu menu;
+	menu.Append(IDM_WATCHADDRESS, _("Add to &watch"));
+	menu.Append(IDM_VIEWMEMORY, _("View &memory"));
+	PopupMenu(&menu);
 }
 
 void CRegisterView::OnPopupMenu(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Debugger/WatchView.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchView.cpp
@@ -247,18 +247,18 @@ void CWatchView::OnMouseDownR(wxGridEvent& event)
 		TryParse("0x" + WxStrToStr(strNewVal), &m_selectedAddress);
 	}
 
-	wxMenu* menu = new wxMenu;
+	wxMenu menu;
 	if (row != 0 && row != (int)(PowerPC::watches.GetWatches().size() + 1))
-		menu->Append(IDM_DELETEWATCH, _("&Delete watch"));
+		menu.Append(IDM_DELETEWATCH, _("&Delete watch"));
 
 	if (row != 0 && row != (int)(PowerPC::watches.GetWatches().size() + 1) && (col == 1 || col == 2))
 	{
 #ifdef ENABLE_MEM_CHECK
-		menu->Append(IDM_ADDMEMCHECK, _("Add memory &breakpoint"));
+		menu.Append(IDM_ADDMEMCHECK, _("Add memory &breakpoint"));
 #endif
-		menu->Append(IDM_VIEWMEMORY, _("View &memory"));
+		menu.Append(IDM_VIEWMEMORY, _("View &memory"));
 	}
-	PopupMenu(menu);
+	PopupMenu(&menu);
 }
 
 void CWatchView::OnPopupMenu(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/FrameAui.cpp
+++ b/Source/Core/DolphinWX/FrameAui.cpp
@@ -333,21 +333,21 @@ void CFrame::OnTab(wxAuiNotebookEvent& event)
 	if (!g_pCodeWindow) return;
 
 	// Create the popup menu
-	wxMenu* MenuPopup = new wxMenu;
+	wxMenu MenuPopup;
 
-	wxMenuItem* Item =  new wxMenuItem(MenuPopup, wxID_ANY, _("Select floating windows"));
-	MenuPopup->Append(Item);
+	wxMenuItem* Item =  new wxMenuItem(&MenuPopup, wxID_ANY, _("Select floating windows"));
+	MenuPopup.Append(Item);
 	Item->Enable(false);
-	MenuPopup->Append(new wxMenuItem(MenuPopup));
+	MenuPopup.Append(new wxMenuItem(&MenuPopup));
 
 	for (int i = IDM_LOGWINDOW; i <= IDM_CODEWINDOW; i++)
 	{
 		wxWindow *Win = FindWindowById(i);
 		if (Win && Win->IsEnabled())
 		{
-			Item = new wxMenuItem(MenuPopup, i + IDM_FLOAT_LOGWINDOW - IDM_LOGWINDOW,
+			Item = new wxMenuItem(&MenuPopup, i + IDM_FLOAT_LOGWINDOW - IDM_LOGWINDOW,
 					Win->GetName(), "", wxITEM_CHECK);
-			MenuPopup->Append(Item);
+			MenuPopup.Append(Item);
 			Item->Check(!!FindWindowById(i + IDM_LOGWINDOW_PARENT - IDM_LOGWINDOW));
 		}
 	}
@@ -357,7 +357,7 @@ void CFrame::OnTab(wxAuiNotebookEvent& event)
 	Pt = ScreenToClient(Pt);
 
 	// Show
-	PopupMenu(MenuPopup, Pt);
+	PopupMenu(&MenuPopup, Pt);
 }
 
 void CFrame::OnAllowNotebookDnD(wxAuiNotebookEvent& event)

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -903,57 +903,57 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
 		const GameListItem *selected_iso = GetSelectedISO();
 		if (selected_iso)
 		{
-			wxMenu* popupMenu = new wxMenu;
-			popupMenu->Append(IDM_PROPERTIES, _("&Properties"));
-			popupMenu->Append(IDM_GAMEWIKI, _("&Wiki"));
-			popupMenu->AppendSeparator();
+			wxMenu popupMenu;
+			popupMenu.Append(IDM_PROPERTIES, _("&Properties"));
+			popupMenu.Append(IDM_GAMEWIKI, _("&Wiki"));
+			popupMenu.AppendSeparator();
 
 			if (selected_iso->GetPlatform() != GameListItem::GAMECUBE_DISC)
 			{
-				popupMenu->Append(IDM_OPENSAVEFOLDER, _("Open Wii &save folder"));
-				popupMenu->Append(IDM_EXPORTSAVE, _("Export Wii save (Experimental)"));
+				popupMenu.Append(IDM_OPENSAVEFOLDER, _("Open Wii &save folder"));
+				popupMenu.Append(IDM_EXPORTSAVE, _("Export Wii save (Experimental)"));
 			}
-			popupMenu->Append(IDM_OPENCONTAININGFOLDER, _("Open &containing folder"));
-			popupMenu->AppendCheckItem(IDM_SETDEFAULTISO, _("Set as &default ISO"));
+			popupMenu.Append(IDM_OPENCONTAININGFOLDER, _("Open &containing folder"));
+			popupMenu.AppendCheckItem(IDM_SETDEFAULTISO, _("Set as &default ISO"));
 
 			// First we have to decide a starting value when we append it
 			if (selected_iso->GetFileName() == SConfig::GetInstance().
 				m_LocalCoreStartupParameter.m_strDefaultISO)
-				popupMenu->FindItem(IDM_SETDEFAULTISO)->Check();
+				popupMenu.FindItem(IDM_SETDEFAULTISO)->Check();
 
-			popupMenu->AppendSeparator();
-			popupMenu->Append(IDM_DELETEISO, _("&Delete ISO..."));
+			popupMenu.AppendSeparator();
+			popupMenu.Append(IDM_DELETEISO, _("&Delete ISO..."));
 
 			if (selected_iso->GetPlatform() != GameListItem::WII_WAD)
 			{
 				if (selected_iso->IsCompressed())
-					popupMenu->Append(IDM_COMPRESSISO, _("Decompress ISO..."));
+					popupMenu.Append(IDM_COMPRESSISO, _("Decompress ISO..."));
 				else if (selected_iso->GetFileName().substr(selected_iso->GetFileName().find_last_of(".")) != ".ciso" &&
 				         selected_iso->GetFileName().substr(selected_iso->GetFileName().find_last_of(".")) != ".wbfs")
-					popupMenu->Append(IDM_COMPRESSISO, _("Compress ISO..."));
+					popupMenu.Append(IDM_COMPRESSISO, _("Compress ISO..."));
 			}
 			else
 			{
-				popupMenu->Append(IDM_LIST_INSTALLWAD, _("Install to Wii Menu"));
+				popupMenu.Append(IDM_LIST_INSTALLWAD, _("Install to Wii Menu"));
 			}
 			if (selected_iso->GetPlatform() == GameListItem::GAMECUBE_DISC ||
 				selected_iso->GetPlatform() == GameListItem::WII_DISC)
 			{
-				wxMenuItem* changeDiscItem = popupMenu->Append(IDM_LIST_CHANGEDISC, _("Change &Disc"));
+				wxMenuItem* changeDiscItem = popupMenu.Append(IDM_LIST_CHANGEDISC, _("Change &Disc"));
 				changeDiscItem->Enable(Core::IsRunning());
 			}
 
-			PopupMenu(popupMenu);
+			PopupMenu(&popupMenu);
 		}
 	}
 	else if (GetSelectedItemCount() > 1)
 	{
-		wxMenu* popupMenu = new wxMenu;
-		popupMenu->Append(IDM_DELETEISO, _("&Delete selected ISOs..."));
-		popupMenu->AppendSeparator();
-		popupMenu->Append(IDM_MULTICOMPRESSISO, _("Compress selected ISOs..."));
-		popupMenu->Append(IDM_MULTIDECOMPRESSISO, _("Decompress selected ISOs..."));
-		PopupMenu(popupMenu);
+		wxMenu popupMenu;
+		popupMenu.Append(IDM_DELETEISO, _("&Delete selected ISOs..."));
+		popupMenu.AppendSeparator();
+		popupMenu.Append(IDM_MULTICOMPRESSISO, _("Compress selected ISOs..."));
+		popupMenu.Append(IDM_MULTIDECOMPRESSISO, _("Decompress selected ISOs..."));
+		PopupMenu(&popupMenu);
 	}
 }
 

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -645,9 +645,9 @@ void CISOProperties::OnCloseClick(wxCommandEvent& WXUNUSED (event))
 
 void CISOProperties::RightClickOnBanner(wxMouseEvent& event)
 {
-	wxMenu* popupMenu = new wxMenu;
-	popupMenu->Append(IDM_BNRSAVEAS, _("Save as..."));
-	PopupMenu(popupMenu);
+	wxMenu popupMenu;
+	popupMenu.Append(IDM_BNRSAVEAS, _("Save as..."));
+	PopupMenu(&popupMenu);
 
 	event.Skip();
 }
@@ -668,41 +668,41 @@ void CISOProperties::OnRightClickOnTree(wxTreeEvent& event)
 {
 	m_Treectrl->SelectItem(event.GetItem());
 
-	wxMenu* popupMenu = new wxMenu;
+	wxMenu popupMenu;
 
 	if (m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 0 &&
 	    m_Treectrl->GetFirstVisibleItem() != m_Treectrl->GetSelection())
 	{
-		popupMenu->Append(IDM_EXTRACTDIR, _("Extract Partition..."));
+		popupMenu.Append(IDM_EXTRACTDIR, _("Extract Partition..."));
 	}
 	else if (m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 1)
 	{
-		popupMenu->Append(IDM_EXTRACTDIR, _("Extract Directory..."));
+		popupMenu.Append(IDM_EXTRACTDIR, _("Extract Directory..."));
 	}
 	else if (m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 2)
 	{
-		popupMenu->Append(IDM_EXTRACTFILE, _("Extract File..."));
+		popupMenu.Append(IDM_EXTRACTFILE, _("Extract File..."));
 	}
 
-	popupMenu->Append(IDM_EXTRACTALL, _("Extract All Files..."));
+	popupMenu.Append(IDM_EXTRACTALL, _("Extract All Files..."));
 
 	if (!DiscIO::IsVolumeWiiDisc(OpenISO) ||
 		(m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 0 &&
 		m_Treectrl->GetFirstVisibleItem() != m_Treectrl->GetSelection()))
 	{
-		popupMenu->AppendSeparator();
-		popupMenu->Append(IDM_EXTRACTAPPLOADER, _("Extract Apploader..."));
-		popupMenu->Append(IDM_EXTRACTDOL, _("Extract DOL..."));
+		popupMenu.AppendSeparator();
+		popupMenu.Append(IDM_EXTRACTAPPLOADER, _("Extract Apploader..."));
+		popupMenu.Append(IDM_EXTRACTDOL, _("Extract DOL..."));
 	}
 
 	if (m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 0 &&
 		m_Treectrl->GetFirstVisibleItem() != m_Treectrl->GetSelection())
 	{
-		popupMenu->AppendSeparator();
-		popupMenu->Append(IDM_CHECKINTEGRITY, _("Check Partition Integrity"));
+		popupMenu.AppendSeparator();
+		popupMenu.Append(IDM_CHECKINTEGRITY, _("Check Partition Integrity"));
 	}
 
-	PopupMenu(popupMenu);
+	PopupMenu(&popupMenu);
 
 	event.Skip();
 }

--- a/Source/Core/DolphinWX/MemcardManager.cpp
+++ b/Source/Core/DolphinWX/MemcardManager.cpp
@@ -807,7 +807,7 @@ void CMemcardManager::CMemcardListCtrl::OnRightClick(wxMouseEvent& event)
 
 	int flags;
 	long item = HitTest(event.GetPosition(), flags);
-	wxMenu* popupMenu = new wxMenu;
+	wxMenu popupMenu;
 
 	if (item != wxNOT_FOUND)
 	{
@@ -818,41 +818,41 @@ void CMemcardManager::CMemcardListCtrl::OnRightClick(wxMouseEvent& event)
 		SetItemState(item, wxLIST_STATE_FOCUSED, wxLIST_STATE_FOCUSED);
 
 		int slot = GetId() - ID_MEMCARDLIST_A;
-		popupMenu->Append(ID_COPYFROM_A + slot, wxString::Format(_("Copy to Memcard %c"), 'B' - slot));
-		popupMenu->Append(ID_DELETE_A + slot, _("Delete Save"));
-		popupMenu->Append(ID_SAVEIMPORT_A + slot, _("Import Save"));
-		popupMenu->Append(ID_SAVEEXPORT_A + slot, _("Export Save"));
-		popupMenu->Append(ID_EXPORTALL_A + slot, _("Export all saves"));
+		popupMenu.Append(ID_COPYFROM_A + slot, wxString::Format(_("Copy to Memcard %c"), 'B' - slot));
+		popupMenu.Append(ID_DELETE_A + slot, _("Delete Save"));
+		popupMenu.Append(ID_SAVEIMPORT_A + slot, _("Import Save"));
+		popupMenu.Append(ID_SAVEEXPORT_A + slot, _("Export Save"));
+		popupMenu.Append(ID_EXPORTALL_A + slot, _("Export all saves"));
 
-		popupMenu->FindItem(ID_COPYFROM_A + slot)->Enable(__mcmSettings.twoCardsLoaded);
+		popupMenu.FindItem(ID_COPYFROM_A + slot)->Enable(__mcmSettings.twoCardsLoaded);
 
-		popupMenu->AppendSeparator();
+		popupMenu.AppendSeparator();
 
-		popupMenu->Append(ID_FIXCHECKSUM_A + slot, _("Fix Checksums"));
-		popupMenu->Append(ID_PREVPAGE_A + slot, _("Previous Page"));
-		popupMenu->Append(ID_NEXTPAGE_A + slot, _("Next Page"));
-		popupMenu->Append(ID_MEMCARDPATH_A + slot, wxString::Format(_("Set as default Memcard %c"), 'A' + slot));
-		popupMenu->AppendCheckItem(ID_USEPAGES, _("Enable pages"));
+		popupMenu.Append(ID_FIXCHECKSUM_A + slot, _("Fix Checksums"));
+		popupMenu.Append(ID_PREVPAGE_A + slot, _("Previous Page"));
+		popupMenu.Append(ID_NEXTPAGE_A + slot, _("Next Page"));
+		popupMenu.Append(ID_MEMCARDPATH_A + slot, wxString::Format(_("Set as default Memcard %c"), 'A' + slot));
+		popupMenu.AppendCheckItem(ID_USEPAGES, _("Enable pages"));
 
-		popupMenu->FindItem(ID_PREVPAGE_A + slot)->Enable(prevPage && __mcmSettings.usePages);
-		popupMenu->FindItem(ID_NEXTPAGE_A + slot)->Enable(nextPage && __mcmSettings.usePages);
-		popupMenu->FindItem(ID_USEPAGES)->Check(__mcmSettings.usePages);
+		popupMenu.FindItem(ID_PREVPAGE_A + slot)->Enable(prevPage && __mcmSettings.usePages);
+		popupMenu.FindItem(ID_NEXTPAGE_A + slot)->Enable(nextPage && __mcmSettings.usePages);
+		popupMenu.FindItem(ID_USEPAGES)->Check(__mcmSettings.usePages);
 
-		popupMenu->AppendSeparator();
+		popupMenu.AppendSeparator();
 
 		// popupMenu->AppendCheckItem(COLUMN_BANNER, _("Show save banner"));
-		popupMenu->AppendCheckItem(COLUMN_TITLE, _("Show save title"));
-		popupMenu->AppendCheckItem(COLUMN_COMMENT, _("Show save comment"));
-		popupMenu->AppendCheckItem(COLUMN_ICON, _("Show save icon"));
-		popupMenu->AppendCheckItem(COLUMN_BLOCKS, _("Show save blocks"));
-		popupMenu->AppendCheckItem(COLUMN_FIRSTBLOCK, _("Show first block"));
+		popupMenu.AppendCheckItem(COLUMN_TITLE, _("Show save title"));
+		popupMenu.AppendCheckItem(COLUMN_COMMENT, _("Show save comment"));
+		popupMenu.AppendCheckItem(COLUMN_ICON, _("Show save icon"));
+		popupMenu.AppendCheckItem(COLUMN_BLOCKS, _("Show save blocks"));
+		popupMenu.AppendCheckItem(COLUMN_FIRSTBLOCK, _("Show first block"));
 
 		// for (int i = COLUMN_BANNER; i <= COLUMN_FIRSTBLOCK; i++)
 		for (int i = COLUMN_TITLE; i <= COLUMN_FIRSTBLOCK; i++)
 		{
-			popupMenu->FindItem(i)->Check(__mcmSettings.column[i]);
+			popupMenu.FindItem(i)->Check(__mcmSettings.column[i]);
 		}
 	}
-	PopupMenu(popupMenu);
+	PopupMenu(&popupMenu);
 }
 


### PR DESCRIPTION
Since the menus aren't actually assigned a parent, they would not be freed by wx. Plus, these should have initially been constructed on the stack in the first place.

Technically any time someone right-clicked the game list they would be leaking memory.
