### PR TITLE
MemoryView: Fix a dealloc of a stack reference

### DIFF
--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -230,11 +230,11 @@ void CMemoryView::OnMouseDownR(wxMouseEvent& event)
 	menu.Append(IDM_WATCHADDRESS, _("Add to &watch"));
 	menu.Append(IDM_TOGGLEMEMORY, _("Toggle &memory"));
 
-	wxMenu viewAsSubMenu;
-	viewAsSubMenu.Append(IDM_VIEWASFP, _("FP value"));
-	viewAsSubMenu.Append(IDM_VIEWASASCII, "ASCII");
-	viewAsSubMenu.Append(IDM_VIEWASHEX, _("Hex"));
-	menu.AppendSubMenu(&viewAsSubMenu, _("View As:"));
+	wxMenu* viewAsSubMenu = new wxMenu;
+	viewAsSubMenu->Append(IDM_VIEWASFP, _("FP value"));
+	viewAsSubMenu->Append(IDM_VIEWASASCII, "ASCII");
+	viewAsSubMenu->Append(IDM_VIEWASHEX, _("Hex"));
+	menu.AppendSubMenu(viewAsSubMenu, _("View As:"));
 
 	PopupMenu(&menu);
 }


### PR DESCRIPTION
stack allocation only works with the root menu. Any other children must be heap allocated.

These however, will be freed by wxWidgets.
