### PR TITLE
DolphinQt: GameList!

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -323,6 +323,8 @@ private:
 	}
 };
 
+// NOTE: this class is only used in DolphinWX/ISOFile.cpp for caching loaded
+// ISO data. It will be removed when DolphinWX is, so please don't use it.
 class CChunkFileReader
 {
 public:

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -12,6 +12,10 @@ set(SRCS
 	MainWindow.cpp
 	MainWindow.h
 	SystemInfo.cpp
+	GameList/GameFile.cpp
+	GameList/GameGrid.cpp
+	GameList/GameTracker.cpp
+	GameList/GameTree.cpp
 	Utils/Resources.cpp
 	Utils/Utils.cpp
 	VideoInterface/RenderWidget.cpp
@@ -21,6 +25,8 @@ set(UIS
 	AboutDialog.ui
 	MainWindow.ui
 	SystemInfo.ui
+	GameList/GameGrid.ui
+	GameList/GameTree.ui
 	)
 
 set(LIBS core uicommon)

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -49,7 +49,7 @@
       <AdditionalDependencies>iphlpapi.lib;winmm.lib;setupapi.lib;vfw32.lib;opengl32.lib;glu32.lib;rpcrt4.lib;comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)\VideoInterface;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\VideoInterface;$(ProjectDir)\GameList;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <!--QRC and UI files are handled automatically-->
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <QtUi Include="*.ui" />
+    <QtUi Include="GameList\*.ui" />
   </ItemGroup>
   <!--MOC files need to be listed. Perhaps scan for Q_OBJECT in the future? (like automoc)-->
   <!--NOTE: When adding moc'd files, you must list the outputs in the following ItemGroup!-->
@@ -66,6 +67,10 @@
     <QtMoc Include="MainWindow.h" />
     <QtMoc Include="SystemInfo.h" />
     <QtMoc Include="VideoInterface\RenderWidget.h" />
+    <QtMoc Include="GameList\GameFile.h" />
+    <QtMoc Include="GameList\GameGrid.h" />
+    <QtMoc Include="GameList\GameTracker.h" />
+    <QtMoc Include="GameList\GameTree.h" />
   </ItemGroup>
   <!--TODO figure out how to get QtMoc to add outputs to ClCompile's inputs...-->
   <ItemGroup>
@@ -73,6 +78,13 @@
     <ClCompile Include="$(QtMocOutPrefix)MainWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)SystemInfo.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)RenderWidget.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)GameGrid.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)GameTracker.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)GameTree.cpp" />
+    <ClCompile Include="GameList\GameFile.cpp" />
+    <ClCompile Include="GameList\GameGrid.cpp" />
+    <ClCompile Include="GameList\GameTracker.cpp" />
+    <ClCompile Include="GameList\GameTree.cpp" />
     <ClCompile Include="SystemInfo.cpp" />
     <ClCompile Include="Utils\Resources.cpp" />
     <ClCompile Include="Utils\Utils.cpp" />
@@ -155,6 +167,10 @@
     <AllInputFiles Include="@(DataDirFiles);@(ExternalDlls);@(BinaryFiles)" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="GameList\GameFile.h" />
+    <ClInclude Include="GameList\GameGrid.h" />
+    <ClInclude Include="GameList\GameTracker.h" />
+    <ClInclude Include="GameList\GameTree.h" />
     <ClInclude Include="Utils\Resources.h" />
     <ClInclude Include="Utils\Utils.h" />
     <ClInclude Include="VideoInterface\RenderWidget.h" />

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj.filters
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj.filters
@@ -27,6 +27,27 @@
     <ClCompile Include="$(QtMocOutPrefix)SystemInfo.cpp">
       <Filter>Generated Files</Filter>
     </ClCompile>
+    <ClCompile Include="GameList\GameFile.cpp">
+      <Filter>GameList</Filter>
+    </ClCompile>
+    <ClCompile Include="GameList\GameGrid.cpp">
+      <Filter>GameList</Filter>
+    </ClCompile>
+    <ClCompile Include="GameList\GameTracker.cpp">
+      <Filter>GameList</Filter>
+    </ClCompile>
+    <ClCompile Include="GameList\GameTree.cpp">
+      <Filter>GameList</Filter>
+    </ClCompile>
+    <ClCompile Include="$(QtMocOutPrefix)GameGrid.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(QtMocOutPrefix)GameTracker.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(QtMocOutPrefix)GameTree.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="AboutDialog.h" />
@@ -36,6 +57,9 @@
   </ItemGroup>
   <ItemGroup>
     <QtUi Include="*.ui" />
+    <QtUi Include="GameList\*.ui">
+      <Filter>GameList</Filter>
+    </QtUi>
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />
@@ -50,6 +74,9 @@
     <Filter Include="Generated Files">
       <UniqueIdentifier>{c18a1fb3-64ff-4249-b808-d73a56ea3a2d}</UniqueIdentifier>
     </Filter>
+    <Filter Include="GameList">
+      <UniqueIdentifier>{be9925db-448c-46d8-a5a3-fb957490d3ef}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Utils\Resources.h">
@@ -60,6 +87,18 @@
     </ClInclude>
     <ClInclude Include="VideoInterface\RenderWidget.h">
       <Filter>VideoInterface</Filter>
+    </ClInclude>
+    <ClInclude Include="GameList\GameFile.h">
+      <Filter>GameList</Filter>
+    </ClInclude>
+    <ClInclude Include="GameList\GameGrid.h">
+      <Filter>GameList</Filter>
+    </ClInclude>
+    <ClInclude Include="GameList\GameTracker.h">
+      <Filter>GameList</Filter>
+    </ClInclude>
+    <ClInclude Include="GameList\GameTree.h">
+      <Filter>GameList</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj.user
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj.user
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!--For some stupid reason this has to be in the .user file...-->

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -1,0 +1,329 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include <QDataStream>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+
+#include "Common/Common.h"
+#include "Common/CommonPaths.h"
+#include "Common/FileUtil.h"
+#include "Common/Hash.h"
+#include "Common/IniFile.h"
+#include "Common/StringUtil.h"
+
+#include "Core/ConfigManager.h"
+
+#include "DiscIO/BannerLoader.h"
+#include "DiscIO/CompressedBlob.h"
+#include "DiscIO/Filesystem.h"
+
+#include "DolphinQt/GameList/GameFile.h"
+#include "DolphinQt/Utils/Resources.h"
+#include "DolphinQt/Utils/Utils.h"
+
+static const u32 CACHE_REVISION = 0x003;
+static const u32 DATASTREAM_REVISION = 15; // Introduced in Qt 5.2
+
+static QStringList VectorToStringList(std::vector<std::string> vec, bool trim = false)
+{
+	QStringList result;
+	if (trim)
+	{
+		for (const std::string& member : vec)
+			result.append(QString::fromStdString(member).trimmed());
+	}
+	else
+	{
+		for (const std::string& member : vec)
+			result.append(QString::fromStdString(member));
+	}
+	return result;
+}
+
+GameFile::GameFile(const QString& fileName)
+    : m_file_name(fileName)
+{
+	bool hasBanner = false;
+
+	if (LoadFromCache())
+	{
+		m_valid = true;
+		hasBanner = true;
+	}
+	else
+	{
+		DiscIO::IVolume* volume = DiscIO::CreateVolumeFromFilename(fileName.toStdString());
+
+		if (volume != nullptr)
+		{
+			if (!DiscIO::IsVolumeWadFile(volume))
+				m_platform = DiscIO::IsVolumeWiiDisc(volume) ? WII_DISC : GAMECUBE_DISC;
+			else
+				m_platform = WII_WAD;
+
+			m_volume_names = VectorToStringList(volume->GetNames());
+
+			m_country  = volume->GetCountry();
+			m_file_size = volume->GetRawSize();
+			m_volume_size = volume->GetSize();
+
+			m_unique_id = QString::fromStdString(volume->GetUniqueID());
+			m_compressed = DiscIO::IsCompressedBlob(fileName.toStdString());
+			m_is_disc_two = volume->IsDiscTwo();
+			m_revision = volume->GetRevision();
+
+			QFileInfo info(m_file_name);
+			m_folder_name = info.absoluteDir().dirName();
+
+			// check if we can get some info from the banner file too
+			DiscIO::IFileSystem* fileSystem = DiscIO::CreateFileSystem(volume);
+
+			if (fileSystem != nullptr || m_platform == WII_WAD)
+			{
+				std::unique_ptr<DiscIO::IBannerLoader> bannerLoader(DiscIO::CreateBannerLoader(*fileSystem, volume));
+
+				if (bannerLoader != nullptr)
+				{
+					if (bannerLoader->IsValid())
+					{
+						if (m_platform != WII_WAD)
+							m_names = VectorToStringList(bannerLoader->GetNames());
+						m_company = QString::fromStdString(bannerLoader->GetCompany());
+						m_descriptions = VectorToStringList(bannerLoader->GetDescriptions(), true);
+
+						int width, height;
+						std::vector<u32> buffer = bannerLoader->GetBanner(&width, &height);
+						QImage banner(width, height, QImage::Format_RGB888);
+						for (int i = 0; i < width * height; i++)
+						{
+							int x = i % width, y = i / width;
+							banner.setPixel(x, y, qRgb((buffer[i] & 0xFF0000) >> 16,
+						                    (buffer[i] & 0x00FF00) >>  8,
+						                    (buffer[i] & 0x0000FF) >>  0));
+						}
+
+						if (!banner.isNull())
+						{
+							hasBanner = true;
+							m_banner = QPixmap::fromImage(banner);
+						}
+					}
+				}
+				delete fileSystem;
+			}
+			delete volume;
+
+			m_valid = true;
+			if (hasBanner)
+				SaveToCache();
+		}
+	}
+
+	if (m_valid)
+	{
+		IniFile ini;
+		ini.Load(File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + m_unique_id.toStdString() + ".ini");
+		ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_unique_id.toStdString() + ".ini", true);
+
+		std::string issues_temp;
+		ini.GetIfExists("EmuState", "EmulationStateId", &m_emu_state);
+		ini.GetIfExists("EmuState", "EmulationIssues", &issues_temp);
+		m_issues = QString::fromStdString(issues_temp);
+	}
+
+	if (!hasBanner)
+		m_banner = Resources::GetPixmap(Resources::BANNER_MISSING);
+}
+
+bool GameFile::LoadFromCache()
+{
+	QString filename = CreateCacheFilename();
+	if (filename.isEmpty())
+		return false;
+
+	QFile file(filename);
+	if (!file.exists())
+		return false;
+	if (!file.open(QFile::ReadOnly))
+		return false;
+
+	// If you modify the code below, you MUST bump the CACHE_REVISION!
+	QDataStream stream(&file);
+	stream.setVersion(DATASTREAM_REVISION);
+
+	u32 cache_rev;
+	stream >> cache_rev;
+	if (cache_rev != CACHE_REVISION)
+		return false;
+
+	int country;
+	stream >> m_folder_name
+	       >> m_volume_names
+	       >> m_company
+	       >> m_descriptions
+	       >> m_unique_id
+	       >> m_file_size
+	       >> m_volume_size
+	       >> country
+	       >> m_banner
+	       >> m_compressed
+	       >> m_platform
+	       >> m_is_disc_two
+	       >> m_revision;
+	m_country = (DiscIO::IVolume::ECountry)country;
+	file.close();
+	return true;
+}
+
+void GameFile::SaveToCache()
+{
+	if (!File::IsDirectory(File::GetUserPath(D_CACHE_IDX)))
+		File::CreateDir(File::GetUserPath(D_CACHE_IDX));
+
+	QString filename = CreateCacheFilename();
+	if (filename.isEmpty())
+		return;
+	if (QFile::exists(filename))
+		QFile::remove(filename);
+
+	QFile file(filename);
+	if (!file.open(QFile::WriteOnly))
+		return;
+
+	// If you modify the code below, you MUST bump the CACHE_REVISION!
+	QDataStream stream(&file);
+	stream.setVersion(DATASTREAM_REVISION);
+	stream << CACHE_REVISION;
+
+	stream << m_folder_name
+	       << m_volume_names
+	       << m_company
+	       << m_descriptions
+	       << m_unique_id
+	       << m_file_size
+	       << m_volume_size
+	       << (int)m_country
+	       << m_banner
+	       << m_compressed
+	       << m_platform
+	       << m_is_disc_two
+	       << m_revision;
+}
+
+QString GameFile::CreateCacheFilename()
+{
+	std::string filename, pathname, extension;
+	SplitPath(m_file_name.toStdString(), &pathname, &filename, &extension);
+
+	if (filename.empty())
+		return SL(""); // must be a disc drive
+
+	// Filename.extension_HashOfFolderPath_Size.cache
+	// Append hash to prevent ISO name-clashing in different folders.
+	filename.append(StringFromFormat("%s_%x_%lx.qcache",
+		extension.c_str(), HashFletcher((const u8*)pathname.c_str(), pathname.size()),
+		File::GetSize(m_file_name.toStdString())));
+
+	QString fullname = QString::fromStdString(File::GetUserPath(D_CACHE_IDX));
+	fullname += QString::fromStdString(filename);
+	return fullname;
+}
+
+QString GameFile::GetCompany() const
+{
+	if (m_company.isEmpty())
+		return QObject::tr("N/A");
+	else
+		return m_company;
+}
+
+// For all of the following functions that accept an "index" parameter,
+// (-1 = Japanese, 0 = English, etc)?
+
+QString GameFile::GetDescription(int index) const
+{
+	if (index < m_descriptions.size())
+		return m_descriptions[index];
+
+	if (!m_descriptions.empty())
+		return m_descriptions[0];
+
+	return SL("");
+}
+
+QString GameFile::GetVolumeName(int index) const
+{
+	if (index < m_volume_names.size() && !m_volume_names[index].isEmpty())
+		return m_volume_names[index];
+
+	if (!m_volume_names.isEmpty())
+		return m_volume_names[0];
+
+	return SL("");
+}
+
+QString GameFile::GetBannerName(int index) const
+{
+	if (index < m_names.size() && !m_names[index].isEmpty())
+		return m_names[index];
+
+	if (!m_names.isEmpty())
+		return m_names[0];
+
+	return SL("");
+}
+
+QString GameFile::GetName(int index) const
+{
+	// Prefer name from banner, fallback to name from volume, fallback to filename
+	QString name = GetBannerName(index);
+
+	if (name.isEmpty())
+		name = GetVolumeName(index);
+
+	if (name.isEmpty())
+	{
+		// No usable name, return filename (better than nothing)
+		std::string nametemp;
+		SplitPath(m_file_name.toStdString(), nullptr, &nametemp, nullptr);
+		name = QString::fromStdString(nametemp);
+	}
+
+	return name;
+}
+
+const QString GameFile::GetWiiFSPath() const
+{
+	DiscIO::IVolume* volume = DiscIO::CreateVolumeFromFilename(m_file_name.toStdString());
+	QString ret;
+
+	if (volume == nullptr)
+		return ret;
+
+	if (DiscIO::IsVolumeWiiDisc(volume) || DiscIO::IsVolumeWadFile(volume))
+	{
+		std::string path;
+		u64 title;
+
+		volume->GetTitleID((u8*)&title);
+		title = Common::swap64(title);
+
+		path = StringFromFormat("%stitle/%08x/%08x/data/", File::GetUserPath(D_WIIUSER_IDX).c_str(), (u32)(title >> 32), (u32)title);
+
+		if (!File::Exists(path))
+			File::CreateFullPath(path);
+
+		if (path[0] == '.')
+			ret = QDir::currentPath() + QString::fromStdString(path).mid((int)strlen(ROOT_DIR));
+		else
+			ret = QString::fromStdString(path);
+	}
+	delete volume;
+
+	return ret;
+}

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -1,0 +1,83 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QPixmap>
+#include <QString>
+#include <QStringList>
+
+#include <string>
+
+#include "DiscIO/Volume.h"
+#include "DiscIO/VolumeCreator.h"
+
+class GameFile final
+{
+public:
+	GameFile(const QString& fileName);
+	GameFile(const std::string& fileName) : GameFile(QString::fromStdString(fileName)) {}
+
+	bool IsValid() const { return m_valid; }
+	QString GetFileName() { return m_file_name; }
+	QString GetFolderName() { return m_folder_name; }
+	QString GetBannerName(int index) const;
+	QString GetVolumeName(int index) const;
+	QString GetName(int index) const;
+	QString GetCompany() const;
+	QString GetDescription(int index = 0) const;
+	int GetRevision() const { return m_revision; }
+	const QString GetUniqueID() const { return m_unique_id; }
+	const QString GetWiiFSPath() const;
+	DiscIO::IVolume::ECountry GetCountry() const { return m_country; }
+	int GetPlatform() const { return m_platform; }
+	const QString GetIssues() const { return m_issues; }
+	int GetEmuState() const { return m_emu_state; }
+	bool IsCompressed() const { return m_compressed; }
+	u64 GetFileSize() const { return m_file_size; }
+	u64 GetVolumeSize() const { return m_volume_size; }
+	bool IsDiscTwo() const { return m_is_disc_two; }
+	const QPixmap GetBitmap() const { return m_banner; }
+
+	enum
+	{
+		GAMECUBE_DISC = 0,
+		WII_DISC,
+		WII_WAD,
+		NUMBER_OF_PLATFORMS
+	};
+
+private:
+	QString m_file_name;
+	QString m_folder_name;
+
+	// TODO: eliminate this and overwrite with names from banner when available?
+	QStringList m_volume_names;
+
+	QString m_company;
+	QStringList m_names;
+	QStringList m_descriptions;
+
+	QString m_unique_id;
+
+	QString m_issues;
+	int m_emu_state = 0;
+
+	quint64 m_file_size = 0;
+	quint64 m_volume_size = 0;
+
+	DiscIO::IVolume::ECountry m_country;
+	int m_platform;
+	int m_revision = 0;
+
+	QPixmap m_banner;
+	bool m_valid = false;
+	bool m_compressed = false;
+	bool m_is_disc_two = false;
+
+	bool LoadFromCache();
+	void SaveToCache();
+
+	QString CreateCacheFilename();
+};

--- a/Source/Core/DolphinQt/GameList/GameGrid.cpp
+++ b/Source/Core/DolphinQt/GameList/GameGrid.cpp
@@ -1,0 +1,95 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#include "ui_GameGrid.h"
+
+#include "Common/StdMakeUnique.h"
+
+#include "DolphinQt/GameList/GameGrid.h"
+
+// Game banner image size
+static const u32 GRID_BANNER_WIDTH = 144;
+static const u32 GRID_BANNER_HEIGHT = 48;
+
+static const u32 ICON_BANNER_WIDTH = 64;
+static const u32 ICON_BANNER_HEIGHT = 64;
+
+DGameGrid::DGameGrid(QWidget* parent_widget) :
+	QListWidget(parent_widget)
+{
+	m_ui = std::make_unique<Ui::DGameGrid>();
+	m_ui->setupUi(this);
+	SetViewStyle(STYLE_GRID);
+
+	connect(this, SIGNAL(itemActivated(QListWidgetItem*)), this, SIGNAL(StartGame()));
+}
+
+DGameGrid::~DGameGrid()
+{
+	for (QListWidgetItem* i : m_items.keys())
+		delete i;
+}
+
+GameFile* DGameGrid::SelectedGame()
+{
+	if (!selectedItems().empty())
+		return m_items.value(selectedItems().at(0));
+	else
+		return nullptr;
+}
+
+void DGameGrid::SelectGame(GameFile* game)
+{
+	if (game == nullptr)
+		return;
+	if (!selectedItems().empty())
+		selectedItems().at(0)->setSelected(false);
+	m_items.key(game)->setSelected(true);
+}
+
+void DGameGrid::SetViewStyle(GameListStyle newStyle)
+{
+	if (newStyle == STYLE_GRID)
+	{
+		m_current_style = STYLE_GRID;
+		setIconSize(QSize(GRID_BANNER_WIDTH, GRID_BANNER_HEIGHT));
+		setViewMode(QListView::IconMode);
+	}
+	else
+	{
+		m_current_style = STYLE_ICON;
+		setIconSize(QSize(ICON_BANNER_WIDTH, ICON_BANNER_HEIGHT));
+		setViewMode(QListView::ListMode);
+	}
+
+	// QListView resets this when you change the view mode, so let's set it again
+	setDragEnabled(false);
+}
+
+void DGameGrid::AddGame(GameFile* item)
+{
+	if (m_items.values().contains(item))
+		return;
+	m_items.values().append(item);
+
+	QListWidgetItem* i = new QListWidgetItem;
+	i->setIcon(QIcon(item->GetBitmap()
+		.scaled(GRID_BANNER_WIDTH, GRID_BANNER_HEIGHT, Qt::KeepAspectRatio, Qt::SmoothTransformation)));
+	i->setText(item->GetName(0));
+	if (item->IsCompressed())
+		i->setTextColor(QColor("#00F"));
+
+	addItem(i);
+	m_items.insert(i, item);
+}
+
+void DGameGrid::RemoveGame(GameFile* item)
+{
+	if (!m_items.values().contains(item))
+		return;
+
+	QListWidgetItem* i = m_items.key(item);
+	m_items.remove(i);
+	delete i;
+}

--- a/Source/Core/DolphinQt/GameList/GameGrid.h
+++ b/Source/Core/DolphinQt/GameList/GameGrid.h
@@ -1,0 +1,44 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include <QListWidget>
+
+#include "DolphinQt/GameList/GameTracker.h"
+
+// Predefinitions
+namespace Ui
+{
+class DGameGrid;
+}
+
+class DGameGrid : public QListWidget, public AbstractGameList
+{
+	Q_OBJECT
+
+public:
+	explicit DGameGrid(QWidget* parent_widget = nullptr);
+	~DGameGrid();
+
+	// AbstractGameList stuff
+	virtual GameFile* SelectedGame();
+	virtual void SelectGame(GameFile* game);
+
+	virtual void SetViewStyle(GameListStyle newStyle);
+
+	virtual void AddGame(GameFile* item);
+	virtual void RemoveGame(GameFile* item);
+
+signals:
+	void StartGame();
+
+private:
+	std::unique_ptr<Ui::DGameGrid> m_ui;
+
+	QMap<QListWidgetItem*, GameFile*> m_items;
+	GameListStyle m_current_style;
+};

--- a/Source/Core/DolphinQt/GameList/GameGrid.ui
+++ b/Source/Core/DolphinQt/GameList/GameGrid.ui
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DGameGrid</class>
+ <widget class="QListWidget" name="DGameGrid">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>256</width>
+    <height>192</height>
+   </rect>
+  </property>
+  <property name="isWrapping" stdset="0">
+   <bool>true</bool>
+  </property>
+  <property name="resizeMode">
+   <enum>QListView::Adjust</enum>
+  </property>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -1,0 +1,252 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#include "Common/CDUtils.h"
+#include "Common/FileSearch.h"
+#include "Core/ConfigManager.h"
+
+#include "DolphinQt/GameList/GameGrid.h"
+#include "DolphinQt/GameList/GameTracker.h"
+#include "DolphinQt/GameList/GameTree.h"
+
+void AbstractGameList::AddGames(QList<GameFile*> items)
+{
+	for (GameFile* o : items)
+		AddGame(o);
+}
+void AbstractGameList::RemoveGames(QList<GameFile*> items)
+{
+	for (GameFile* o : items)
+		RemoveGame(o);
+}
+
+
+DGameTracker::DGameTracker(QWidget* parent_widget)
+	: QStackedWidget(parent_widget),
+	  m_watcher(this)
+{
+	connect(&m_watcher, SIGNAL(directoryChanged(QString)), this, SLOT(ScanForGames()));
+
+	m_tree_widget = new DGameTree(this);
+	addWidget(m_tree_widget);
+	connect(m_tree_widget, SIGNAL(StartGame()), this, SIGNAL(StartGame()));
+
+	m_grid_widget = new DGameGrid(this);
+	addWidget(m_grid_widget);
+	connect(m_grid_widget, SIGNAL(StartGame()), this, SIGNAL(StartGame()));
+
+	SetViewStyle(STYLE_LIST);
+}
+
+DGameTracker::~DGameTracker()
+{
+	for (GameFile* file : m_games.values())
+		delete file;
+}
+
+void DGameTracker::SetViewStyle(GameListStyle newStyle)
+{
+	if (newStyle == m_current_style)
+		return;
+	m_current_style = newStyle;
+
+	if (newStyle == STYLE_LIST || newStyle == STYLE_TREE)
+	{
+		m_tree_widget->SelectGame(SelectedGame());
+		setCurrentWidget(m_tree_widget);
+		m_tree_widget->SetViewStyle(newStyle);
+	}
+	else
+	{
+		m_grid_widget->SelectGame(SelectedGame());
+		setCurrentWidget(m_grid_widget);
+		m_grid_widget->SetViewStyle(newStyle);
+	}
+}
+
+GameFile* DGameTracker::SelectedGame()
+{
+	if (currentWidget() == m_grid_widget)
+		return m_grid_widget->SelectedGame();
+	else
+		return m_tree_widget->SelectedGame();
+}
+
+void DGameTracker::ScanForGames()
+{
+	setDisabled(true);
+
+	CFileSearch::XStringVector dirs(SConfig::GetInstance().m_ISOFolder);
+
+	if (SConfig::GetInstance().m_RecursiveISOFolder)
+	{
+		for (u32 i = 0; i < dirs.size(); i++)
+		{
+			File::FSTEntry FST_Temp;
+			File::ScanDirectoryTree(dirs[i], FST_Temp);
+			for (auto& entry : FST_Temp.children)
+			{
+				if (entry.isDirectory)
+				{
+					bool duplicate = false;
+					for (auto& dir : dirs)
+					{
+						if (dir == entry.physicalName)
+						{
+							duplicate = true;
+							break;
+						}
+					}
+					if (!duplicate)
+						dirs.push_back(entry.physicalName);
+				}
+			}
+		}
+	}
+
+	for (std::string& dir : dirs)
+		m_watcher.addPath(QString::fromStdString(dir));
+
+	CFileSearch::XStringVector exts;
+	if (SConfig::GetInstance().m_ListGC)
+	{
+		exts.push_back("*.gcm");
+		exts.push_back("*.gcz");
+	}
+	if (SConfig::GetInstance().m_ListWii || SConfig::GetInstance().m_ListGC)
+	{
+		exts.push_back("*.iso");
+		exts.push_back("*.ciso");
+		exts.push_back("*.wbfs");
+	}
+	if (SConfig::GetInstance().m_ListWad)
+		exts.push_back("*.wad");
+
+	CFileSearch FileSearch(exts, dirs);
+	const CFileSearch::XStringVector& rFilenames = FileSearch.GetFileNames();
+	QList<GameFile*> newItems;
+	QStringList allItems;
+
+	if (!rFilenames.empty())
+	{
+		for (u32 i = 0; i < rFilenames.size(); i++)
+		{
+			std::string FileName;
+			SplitPath(rFilenames[i], nullptr, &FileName, nullptr);
+			QString NameAndPath = QString::fromStdString(rFilenames[i]);
+			allItems.append(NameAndPath);
+
+			if (m_games.keys().contains(NameAndPath))
+				continue;
+
+			GameFile* obj = new GameFile(rFilenames[i]);
+			if (obj->IsValid())
+			{
+				bool list = true;
+
+				switch(obj->GetCountry())
+				{
+					case DiscIO::IVolume::COUNTRY_AUSTRALIA:
+						if (!SConfig::GetInstance().m_ListAustralia)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_GERMANY:
+						if (!SConfig::GetInstance().m_ListGermany)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_RUSSIA:
+						if (!SConfig::GetInstance().m_ListRussia)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_UNKNOWN:
+						if (!SConfig::GetInstance().m_ListUnknown)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_TAIWAN:
+						if (!SConfig::GetInstance().m_ListTaiwan)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_KOREA:
+						if (!SConfig::GetInstance().m_ListKorea)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_JAPAN:
+						if (!SConfig::GetInstance().m_ListJap)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_USA:
+						if (!SConfig::GetInstance().m_ListUsa)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_FRANCE:
+						if (!SConfig::GetInstance().m_ListFrance)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_ITALY:
+						if (!SConfig::GetInstance().m_ListItaly)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_SPAIN:
+						if (!SConfig::GetInstance().m_ListSpain)
+							list = false;
+						break;
+					case DiscIO::IVolume::COUNTRY_NETHERLANDS:
+						if (!SConfig::GetInstance().m_ListNetherlands)
+							list = false;
+						break;
+					default:
+						if (!SConfig::GetInstance().m_ListPal)
+							list = false;
+						break;
+				}
+
+				if (list)
+					newItems.append(obj);
+			}
+		}
+	}
+
+	// Process all the new GameFiles
+	for (GameFile* o : newItems)
+		m_games.insert(o->GetFileName(), o);
+
+	// Check for games that were removed
+	QList<GameFile*> removedGames;
+	for (QString& path : m_games.keys())
+	{
+		if (!allItems.contains(path))
+		{
+			removedGames.append(m_games.value(path));
+			m_games.remove(path);
+		}
+	}
+
+	m_tree_widget->AddGames(newItems);
+	m_grid_widget->AddGames(newItems);
+
+	m_tree_widget->RemoveGames(removedGames);
+	m_grid_widget->RemoveGames(removedGames);
+
+	for (GameFile* file : removedGames)
+		delete file;
+
+	setDisabled(false);
+}
+
+void DGameTracker::SelectLastBootedGame()
+{
+	if (!SConfig::GetInstance().m_LastFilename.empty() && File::Exists(SConfig::GetInstance().m_LastFilename))
+	{
+		QString lastfilename = QString::fromStdString(SConfig::GetInstance().m_LastFilename);
+		for (GameFile* game : m_games.values())
+		{
+			if (game->GetFileName() == lastfilename)
+			{
+				m_tree_widget->SelectGame(game);
+				break;
+			}
+
+		}
+	}
+}

--- a/Source/Core/DolphinQt/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt/GameList/GameTracker.h
@@ -1,0 +1,68 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QFileSystemWatcher>
+#include <QList>
+#include <QMap>
+#include <QStackedWidget>
+
+#include "DolphinQt/GameList/GameFile.h"
+
+// Predefinitions
+class DGameGrid;
+class DGameTree;
+
+enum GameListStyle
+{
+	STYLE_LIST,
+	STYLE_TREE,
+	STYLE_GRID,
+	STYLE_ICON
+};
+
+class AbstractGameList
+{
+public:
+	virtual GameFile* SelectedGame() = 0;
+	virtual void SelectGame(GameFile* game) = 0;
+
+	virtual void SetViewStyle(GameListStyle newStyle) = 0;
+
+	virtual void AddGame(GameFile* item) = 0;
+	void AddGames(QList<GameFile*> items);
+
+	virtual void RemoveGame(GameFile* item) = 0;
+	void RemoveGames(QList<GameFile*> items);
+};
+
+class DGameTracker : public QStackedWidget
+{
+	Q_OBJECT
+
+public:
+	DGameTracker(QWidget* parent_widget = nullptr);
+	~DGameTracker();
+
+	GameListStyle ViewStyle() const { return m_current_style; }
+	void SetViewStyle(GameListStyle newStyle);
+
+	GameFile* SelectedGame();
+	void SelectLastBootedGame();
+
+signals:
+	void StartGame();
+
+public slots:
+	void ScanForGames();
+
+private:
+	QMap<QString, GameFile*> m_games;
+	QFileSystemWatcher m_watcher;
+
+	GameListStyle m_current_style;
+	DGameGrid* m_grid_widget = nullptr;
+	DGameTree* m_tree_widget = nullptr;
+};

--- a/Source/Core/DolphinQt/GameList/GameTree.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTree.cpp
@@ -1,0 +1,167 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#include "ui_GameTree.h"
+
+#include "Common/StdMakeUnique.h"
+
+#include "DolphinQt/GameList/GameTree.h"
+
+#include "DolphinQt/Utils/Resources.h"
+#include "DolphinQt/Utils/Utils.h"
+
+// Game banner image size
+static const u32 BANNER_WIDTH = 96;
+static const u32 BANNER_HEIGHT = 32;
+
+DGameTree::DGameTree(QWidget* parent_widget) :
+	QTreeWidget(parent_widget)
+{
+	m_ui = std::make_unique<Ui::DGameTree>();
+	m_ui->setupUi(this);
+
+	SetViewStyle(STYLE_TREE);
+	setIconSize(QSize(BANNER_WIDTH, BANNER_HEIGHT));
+	sortByColumn(COL_TITLE);
+
+	connect(this, SIGNAL(itemActivated(QTreeWidgetItem*, int)), this, SLOT(ItemActivated(QTreeWidgetItem*)));
+}
+
+DGameTree::~DGameTree()
+{
+	int count = topLevelItemCount();
+	for (int a = 0; a < count; a++)
+		takeTopLevelItem(0);
+
+	for (QTreeWidgetItem* i : m_path_nodes.values())
+	{
+		count = i->childCount();
+		for (int a = 0; a < count; a++)
+			i->takeChild(0);
+	}
+
+	for (QTreeWidgetItem* i : m_path_nodes.values())
+		delete i;
+	for (QTreeWidgetItem* i : m_items.keys())
+		delete i;
+}
+
+void DGameTree::ResizeAllCols()
+{
+	for (int i = 0; i < columnCount(); i++)
+		resizeColumnToContents(i);
+}
+
+void DGameTree::ItemActivated(QTreeWidgetItem* item)
+{
+	if (!m_path_nodes.values().contains(item))
+		emit StartGame();
+}
+
+GameFile* DGameTree::SelectedGame()
+{
+	if (!selectedItems().empty())
+		return m_items.value(selectedItems().at(0));
+	else
+		return nullptr;
+}
+
+void DGameTree::SelectGame(GameFile* game)
+{
+	if (game == nullptr)
+		return;
+	if (!selectedItems().empty())
+		selectedItems().at(0)->setSelected(false);
+	m_items.key(game)->setSelected(true);
+}
+
+void DGameTree::SetViewStyle(GameListStyle newStyle)
+{
+	if (newStyle == STYLE_LIST)
+	{
+		m_current_style = STYLE_LIST;
+		setIndentation(0);
+		RebuildTree();
+	}
+	else
+	{
+		m_current_style = STYLE_TREE;
+		setIndentation(20);
+		RebuildTree();
+	}
+}
+
+void DGameTree::AddGame(GameFile* item)
+{
+	if (m_items.values().contains(item))
+		return;
+
+	QString folder = item->GetFolderName();
+	if (!m_path_nodes.contains(folder))
+	{
+		QTreeWidgetItem* i = new QTreeWidgetItem;
+		i->setText(0, folder);
+		m_path_nodes.insert(folder, i);
+		if (m_current_style == STYLE_TREE)
+			addTopLevelItem(i);
+	}
+
+	QTreeWidgetItem* i = new QTreeWidgetItem;
+	i->setIcon(COL_TYPE, QIcon(Resources::GetPlatformPixmap(item->GetPlatform())));
+	i->setIcon(COL_BANNER, QIcon(item->GetBitmap()));
+	i->setText(COL_TITLE, item->GetName(0));
+	i->setText(COL_DESCRIPTION, item->GetDescription());
+	i->setIcon(COL_REGION, QIcon(Resources::GetRegionPixmap(item->GetCountry())));
+	i->setText(COL_SIZE, NiceSizeFormat(item->GetFileSize()));
+	if (item->IsCompressed())
+	{
+		for (int col = 0; col < columnCount(); col++)
+			i->setTextColor(col, QColor("#00F"));
+	}
+	m_items.insert(i, item);
+
+	RebuildTree(); // TODO: only call this once per group of items added
+}
+
+void DGameTree::RemoveGame(GameFile* item)
+{
+	if (!m_items.values().contains(item))
+		return;
+	QTreeWidgetItem* i = m_items.key(item);
+	m_items.remove(i);
+	delete i;
+}
+
+void DGameTree::RebuildTree()
+{
+	GameFile* currentGame = SelectedGame();
+
+	int count = topLevelItemCount();
+	for (int a = 0; a < count; a++)
+		takeTopLevelItem(0);
+
+	for (QTreeWidgetItem* i : m_path_nodes.values())
+	{
+		count = i->childCount();
+		for (int a = 0; a < count; a++)
+			i->takeChild(0);
+	}
+
+	if (m_current_style == STYLE_TREE)
+	{
+		for (QTreeWidgetItem* i : m_path_nodes.values())
+			addTopLevelItem(i);
+		for (QTreeWidgetItem* i : m_items.keys())
+			m_path_nodes.value(m_items.value(i)->GetFolderName())->addChild(i);
+	}
+	else
+	{
+		for (QTreeWidgetItem* i : m_items.keys())
+			addTopLevelItem(i);
+	}
+
+	expandAll();
+	ResizeAllCols();
+	SelectGame(currentGame);
+}

--- a/Source/Core/DolphinQt/GameList/GameTree.h
+++ b/Source/Core/DolphinQt/GameList/GameTree.h
@@ -1,0 +1,62 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include <QTreeWidget>
+
+#include "DolphinQt/GameList/GameTracker.h"
+
+// Predefinitions
+namespace Ui
+{
+class DGameTree;
+}
+
+class DGameTree : public QTreeWidget, public AbstractGameList
+{
+	Q_OBJECT
+
+public:
+	explicit DGameTree(QWidget* parent_widget = nullptr);
+	~DGameTree();
+
+	// AbstractGameList stuff
+	virtual GameFile* SelectedGame();
+	virtual void SelectGame(GameFile* game);
+
+	virtual void SetViewStyle(GameListStyle newStyle);
+
+	virtual void AddGame(GameFile* item);
+	virtual void RemoveGame(GameFile* item);
+
+signals:
+	void StartGame();
+
+private slots:
+	void ItemActivated(QTreeWidgetItem* item);
+
+private:
+	enum Columns
+	{
+		COL_TYPE = 0,
+		COL_BANNER = 1,
+		COL_TITLE = 2,
+		COL_DESCRIPTION = 3,
+		COL_REGION = 4,
+		COL_SIZE = 5,
+		COL_STATE = 6
+	};
+
+	std::unique_ptr<Ui::DGameTree> m_ui;
+	GameListStyle m_current_style;
+
+	QMap<QTreeWidgetItem*, GameFile*> m_items;
+	QMap<QString, QTreeWidgetItem*> m_path_nodes;
+
+	void RebuildTree();
+	void ResizeAllCols();
+};

--- a/Source/Core/DolphinQt/GameList/GameTree.ui
+++ b/Source/Core/DolphinQt/GameList/GameTree.ui
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DGameTree</class>
+ <widget class="QTreeWidget" name="DGameTree">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>396</width>
+    <height>296</height>
+   </rect>
+  </property>
+  <property name="sortingEnabled">
+   <bool>true</bool>
+  </property>
+  <column>
+   <property name="text">
+    <string>Type</string>
+   </property>
+  </column>
+  <column>
+   <property name="text">
+    <string>Banner</string>
+   </property>
+  </column>
+  <column>
+   <property name="text">
+    <string>Title</string>
+   </property>
+  </column>
+  <column>
+   <property name="text">
+    <string>Description</string>
+   </property>
+  </column>
+  <column>
+   <property name="text">
+    <string>Region</string>
+   </property>
+  </column>
+  <column>
+   <property name="text">
+    <string>Size</string>
+   </property>
+  </column>
+  <column>
+   <property name="text">
+    <string>State</string>
+   </property>
+  </column>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -9,6 +9,7 @@
 
 #include "Core/Core.h"
 
+#include "DolphinQt/GameList/GameTracker.h"
 #include "DolphinQt/VideoInterface/RenderWidget.h"
 
 // Predefinitions
@@ -42,6 +43,9 @@ private slots:
 	void OnPlay();
 	void OnStop();
 
+	// View menu
+	void OnGameListStyleChanged();
+
 	// Help menu
 	void OnOpenWebsite();
 	void OnOpenDocs();
@@ -54,13 +58,14 @@ private slots:
 
 private:
 	std::unique_ptr<Ui::DMainWindow> m_ui;
+	DGameTracker* m_game_tracker;
 
 	// Emulation
 	QString RequestBootFilename();
 	QString ShowFileDialog();
 	void DoStartPause();
 
-	std::unique_ptr<DRenderWidget> m_render_widget;
+	std::unique_ptr<DRenderWidget> m_render_widget; // TODO: just create this once and reuse it
 	bool m_isStopping = false;
 };
 

--- a/Source/Core/DolphinQt/MainWindow.ui
+++ b/Source/Core/DolphinQt/MainWindow.ui
@@ -60,6 +60,16 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
+    <widget class="QMenu" name="mnuGameListStyle">
+     <property name="title">
+      <string>Gamelist view style</string>
+     </property>
+     <addaction name="actionListView"/>
+     <addaction name="actionTreeView"/>
+     <addaction name="actionGridView"/>
+     <addaction name="actionIconView"/>
+    </widget>
+    <addaction name="mnuGameListStyle"/>
    </widget>
    <widget class="QMenu" name="mnuHelp">
     <property name="title">
@@ -79,11 +89,11 @@
     </property>
    </widget>
    <addaction name="mnuFile"/>
+   <addaction name="mnuView"/>
    <addaction name="mnuEmulation"/>
    <addaction name="mnuMovie"/>
    <addaction name="mnuOptions"/>
    <addaction name="mnuTools"/>
-   <addaction name="mnuView"/>
    <addaction name="mnuHelp"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
@@ -155,6 +165,38 @@
    </property>
    <property name="menuRole">
     <enum>QAction::AboutQtRole</enum>
+   </property>
+  </action>
+  <action name="actionListView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>List view</string>
+   </property>
+  </action>
+  <action name="actionTreeView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Tree view</string>
+   </property>
+  </action>
+  <action name="actionGridView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Grid view</string>
+   </property>
+  </action>
+  <action name="actionIconView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Icon view</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This is in a very rudimentary state. There are lots of style violations so don't bother commenting on those, I know I have to fix them. TODO:
- [x] Wholesale renaming of all the things that currently are named badly
- [x] GameFile should cache FolderName (used in GameTree)
- [x] GameTracker should watch folders (using `QFileSystemWatcher`)
- [x] Highlight compressed ISOs like they are in DolphinWX
- [x] Actually delete the `Q...ListItem`s and `GameFile`s when we're done with them
- [x] Add more stuff I'm forgetting to this TODO list

No flags are currently visible because that needs #1333 to be merged, so CC @Stevoisiak for that. Also CC @lioncash and @comex for comments on what else needs to be done (read the above first plz :wink:)
And here's the obligatory screenshot:
![dolphinqt-gamelist](https://cloud.githubusercontent.com/assets/2175324/5057891/5b030dfe-6ca7-11e4-8ae4-ae9aead7fdf6.png)
