### PR TITLE
Android: Use a PagerTabStrip instead of the ActionBar.

### DIFF
--- a/Source/Android/res/layout/viewpager.xml
+++ b/Source/Android/res/layout/viewpager.xml
@@ -1,5 +1,15 @@
-<android.support.v4.view.ViewPager 
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.view.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/pager"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <android.support.v4.view.PagerTabStrip
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:paddingBottom="10dp"
+        android:paddingTop="10dp" />
+
+</android.support.v4.view.ViewPager>
+

--- a/Source/Android/src/org/dolphinemu/dolphinemu/about/AboutActivity.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/about/AboutActivity.java
@@ -9,13 +9,9 @@ package org.dolphinemu.dolphinemu.about;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.utils.EGLHelper;
 
-import android.app.ActionBar;
-import android.app.ActionBar.Tab;
-import android.app.ActionBar.TabListener;
 import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.os.Bundle;
 import android.support.v13.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
@@ -25,9 +21,8 @@ import android.support.v4.view.ViewPager;
  * Activity for the about menu, which displays info
  * related to the CPU and GPU. Along with misc other info.
  */
-public final class AboutActivity extends Activity implements TabListener
+public final class AboutActivity extends Activity
 {
-	private ViewPager viewPager;
 	private final EGLHelper eglHelper = new EGLHelper(EGLHelper.EGL_OPENGL_ES2_BIT);
 
 	@Override
@@ -37,32 +32,10 @@ public final class AboutActivity extends Activity implements TabListener
 
 		// Set the view pager
 		setContentView(R.layout.viewpager);
-		viewPager = (ViewPager) findViewById(R.id.pager);
 
-		// Initialize the ViewPager adapter.
-		final ViewPagerAdapter adapter = new ViewPagerAdapter(getFragmentManager());
-		viewPager.setAdapter(adapter);
-
-		// Set up the ActionBar
-		final ActionBar actionBar = getActionBar();
-		actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
-		actionBar.addTab(actionBar.newTab().setText(R.string.general).setTabListener(this));
-		actionBar.addTab(actionBar.newTab().setText(R.string.cpu).setTabListener(this));
-		actionBar.addTab(actionBar.newTab().setText(R.string.gles_two).setTabListener(this));
-		if (eglHelper.supportsGLES3())
-			actionBar.addTab(actionBar.newTab().setText(R.string.gles_three).setTabListener(this));
-		if (eglHelper.supportsOpenGL())
-			actionBar.addTab(actionBar.newTab().setText(R.string.desktop_gl).setTabListener(this));
-
-		// Set the page change listener
-		viewPager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener()
-		{
-			@Override
-			public void onPageSelected(int position)
-			{
-				actionBar.setSelectedNavigationItem(position);
-			}
-		});
+		// Initialize the viewpager.
+		final ViewPager viewPager = (ViewPager) findViewById(R.id.pager);
+		viewPager.setAdapter(new ViewPagerAdapter(getFragmentManager()));
 	}
 
 	@Override
@@ -73,31 +46,20 @@ public final class AboutActivity extends Activity implements TabListener
 		eglHelper.closeHelper();
 	}
 
-	@Override
-	public void onTabSelected(Tab tab, FragmentTransaction ft)
-	{
-		// When the given tab is selected, switch to the corresponding page in the ViewPager.
-		viewPager.setCurrentItem(tab.getPosition());
-	}
-
-	@Override
-	public void onTabReselected(Tab tab, FragmentTransaction ft)
-	{
-		// Do nothing.
-	}
-
-	@Override
-	public void onTabUnselected(Tab tab, FragmentTransaction ft)
-	{
-		// Do nothing.
-	}
-
 	/**
 	 * {@link FragmentPagerAdapter} subclass responsible for handling
 	 * the individual {@link Fragment}s within the {@link ViewPager}.
 	 */
 	private final class ViewPagerAdapter extends FragmentPagerAdapter
 	{
+		private final String[] pageTitles = {
+			getString(R.string.general),
+			getString(R.string.cpu),
+			getString(R.string.gles_two),
+			getString(R.string.gles_three),
+			getString(R.string.desktop_gl),
+		};
+
 		public ViewPagerAdapter(FragmentManager fm)
 		{
 			super(fm);
@@ -154,26 +116,7 @@ public final class AboutActivity extends Activity implements TabListener
 		@Override
 		public CharSequence getPageTitle(int position)
 		{
-			switch (position)
-			{
-				case 0:
-					return getString(R.string.general);
-
-				case 1:
-					return getString(R.string.cpu);
-
-				case 2:
-					return getString(R.string.gles_two);
-
-				case 3:
-					return getString(R.string.gles_three);
-				
-				case 4:
-					return getString(R.string.desktop_gl);
-
-				default: // Should never happen
-					return null;
-			}
+			return pageTitles[position];
 		}
 	}
 }

--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/PrefsActivity.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/PrefsActivity.java
@@ -11,12 +11,9 @@ import org.dolphinemu.dolphinemu.settings.cpu.CPUSettingsFragment;
 import org.dolphinemu.dolphinemu.settings.input.InputConfigFragment;
 import org.dolphinemu.dolphinemu.settings.video.VideoSettingsFragment;
 
-import android.app.ActionBar;
-import android.app.ActionBar.Tab;
 import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.os.Bundle;
@@ -28,66 +25,23 @@ import android.support.v4.view.ViewPager;
  * Main activity that manages all of the preference fragments used to display
  * the settings to the user.
  */
-public final class PrefsActivity extends Activity implements ActionBar.TabListener, OnSharedPreferenceChangeListener
+public final class PrefsActivity extends Activity implements OnSharedPreferenceChangeListener
 {
-	/**
-	 * The {@link ViewPager} that will host the section contents.
-	 */
-	private ViewPager mViewPager;
-
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
 		super.onCreate(savedInstanceState);
-
-		// Set the ViewPager.
 		setContentView(R.layout.viewpager);
-		mViewPager = (ViewPager) findViewById(R.id.pager);
 
 		// Set the ViewPager adapter.
-		final ViewPagerAdapter mSectionsPagerAdapter = new ViewPagerAdapter(getFragmentManager());
-		mViewPager.setAdapter(mSectionsPagerAdapter);
+		final ViewPager viewPager = (ViewPager) findViewById(R.id.pager);
+		viewPager.setAdapter(new ViewPagerAdapter(getFragmentManager()));
 
 		// Register the preference change listener.
 		final SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(this);
 		sPrefs.registerOnSharedPreferenceChangeListener(this);
-
-		// Set up the action bar.
-		final ActionBar actionBar = getActionBar();
-		actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
-		actionBar.addTab(actionBar.newTab().setText(R.string.cpu_settings).setTabListener(this));
-		actionBar.addTab(actionBar.newTab().setText(R.string.input_settings).setTabListener(this));
-		actionBar.addTab(actionBar.newTab().setText(R.string.video_settings).setTabListener(this));
-
-		// When swiping between different sections, select the corresponding
-		// tab. We can also use ActionBar.Tab#select() to do this if we have
-		// a reference to the Tab.
-		mViewPager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener()
-		{
-			@Override
-			public void onPageSelected(int position)
-			{
-				actionBar.setSelectedNavigationItem(position);
-			}
-		} );
 	}
 
-	public void onTabSelected(Tab tab, FragmentTransaction ft)
-	{
-		// When the given tab is selected, switch to the corresponding page in the ViewPager.
-		mViewPager.setCurrentItem(tab.getPosition());
-	}
-
-	public void onTabReselected(Tab tab, FragmentTransaction ft)
-	{
-		// Do nothing.
-	}
-
-	public void onTabUnselected(Tab tab, FragmentTransaction ft)
-	{
-		// Do nothing.
-	}
-	
 	@Override
 	public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key)
 	{
@@ -101,6 +55,12 @@ public final class PrefsActivity extends Activity implements ActionBar.TabListen
 	 */
 	private final class ViewPagerAdapter extends FragmentPagerAdapter
 	{
+		private final String[] pageTitles = {
+			getString(R.string.cpu_settings),
+			getString(R.string.input_settings),
+			getString(R.string.video_settings)
+		};
+
 		public ViewPagerAdapter(FragmentManager fm)
 		{
 			super(fm);
@@ -135,20 +95,7 @@ public final class PrefsActivity extends Activity implements ActionBar.TabListen
 		@Override
 		public CharSequence getPageTitle(int position)
 		{
-			switch(position)
-			{
-				case 0:
-					return getString(R.string.cpu_settings);
-
-				case 1:
-					return getString(R.string.input_settings);
-
-				case 2:
-					return getString(R.string.video_settings);
-
-				default: // Should never happen.
-					return null;
-			}
+			return pageTitles[position];
 		}
 	}
 }


### PR DESCRIPTION
The ActionBar method of doing the tabular layout is deprecated on Android 5.0.
This method alleviates those deprecations while providing the same functionality.
