### PR TITLE
Fixes GLExtensions for GL 2.1 or GLES 2 devices.

### DIFF
--- a/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
@@ -1892,17 +1892,20 @@ namespace GLExtensions
 		// Grab a few functions for initial checking
 		// We need them to grab the extension list
 		// Also to check if there is an error grabbing the version
-		// If it fails then the user's drivers don't support GL 3.0
 		if (GetFuncAddress ("glGetIntegerv", (void**)&glGetIntegerv) == nullptr)
 			return false;
 		if (GetFuncAddress("glGetString", (void**)&glGetString) == nullptr)
-			return false;
-		if (GetFuncAddress("glGetStringi", (void**)&glGetStringi) == nullptr)
 			return false;
 		if (GetFuncAddress("glGetError", (void**)&glGetError) == nullptr)
 			return false;
 
 		InitVersion();
+
+		// We need to use glGetStringi to get the extension list
+		// if we are using GLES3 or a GL version greater than 2.1
+		if (_GLVersion > 210 && GetFuncAddress("glGetStringi", (void**)&glGetStringi) == nullptr)
+			return false;
+
 		InitExtensionList();
 
 		return InitFunctionPointers();


### PR DESCRIPTION
This wasn't too much of a concern since we normally don't care about this feature set, but it is nice when testing on new devices and they don't
support the higher feature sets but want to run under software renderer.

The Mesa softpipe and PowerVR 5xx drivers don't support higher GL versions, but they shouldn't exit out just because they couldn't get a GL3 function
pointer that isn't even going to be used at that point.
