### PR TITLE
Remove Android <ucontext.h> hack.

### DIFF
--- a/Source/Core/Core/MachineContext.h
+++ b/Source/Core/Core/MachineContext.h
@@ -88,20 +88,7 @@
 #elif defined(__linux__)
 	#include <signal.h>
 
-	#ifdef ANDROID
-		#include <asm/sigcontext.h>
-		typedef struct sigcontext mcontext_t;
-		typedef struct ucontext
-		{
-			uint32_t uc_flags;
-			struct ucontext* uc_link;
-			stack_t uc_stack;
-			mcontext_t uc_mcontext;
-			// ...
-		} ucontext_t;
-	#else
-		#include <ucontext.h>
-	#endif
+	#include <ucontext.h>
 	typedef mcontext_t SContext;
 
 	#if _M_X86_64


### PR DESCRIPTION
There was a longstanding hack that defined ucontext_t manually to work
around the lack of this header on the Android NDK.  However, it looks
like newer NDK versions now have it like good little POSIX boys, and my
recent header reshuffle broke the build on those versions, presumably
because the real and fake definitions of ucontext_t end up included in
the same file where they weren't under the old organization.

Rather than try to revert the conflict, this commit just removes the
hack.  The buildbot's NDK will need to be upgraded.
