### PR TITLE
OGL: fix buffer destruction

### DIFF
--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -63,9 +63,6 @@ void VertexManager::CreateDeviceObjects()
 
 void VertexManager::DestroyDeviceObjects()
 {
-	glBindBuffer(GL_ARRAY_BUFFER, 0 );
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0 );
-
 	delete s_vertexBuffer;
 	delete s_indexBuffer;
 }


### PR DESCRIPTION
This buffer will be unbound in the StreamBuffer class itself, so no need to unbind them before.
