### PR TITLE
Rewrites ARMv7 fastmem entirely.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
@@ -40,6 +40,7 @@ void JitArm::Init()
 	code_block.m_gpa = &js.gpa;
 	code_block.m_fpa = &js.fpa;
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+	InitBackpatch();
 }
 
 void JitArm::ClearCache()

--- a/Source/Core/Core/PowerPC/JitArm32/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.h
@@ -48,6 +48,26 @@ private:
 	ArmFPRCache fpr;
 
 	PPCAnalyst::CodeBuffer code_buffer;
+	struct BackPatchInfo
+	{
+		enum
+		{
+			FLAG_STORE    = (1 << 0),
+			FLAG_LOAD     = (1 << 1),
+			FLAG_SIZE_8   = (1 << 2),
+			FLAG_SIZE_16  = (1 << 3),
+			FLAG_SIZE_32  = (1 << 4),
+			FLAG_SIZE_F32 = (1 << 5),
+			FLAG_SIZE_F64 = (1 << 6),
+			FLAG_REVERSE  = (1 << 7),
+		};
+
+		u32 m_fastmem_size;
+		u32 m_fastmem_trouble_inst_offset;
+		u32 m_slowmem_size;
+	};
+	// The key is the flags
+	std::map<u32, BackPatchInfo> m_backpatch_info;
 
 	void DoDownCount();
 
@@ -57,10 +77,18 @@ private:
 
 	ArmGen::FixupBranch JumpIfCRFieldBit(int field, int bit, bool jump_if_set);
 
-	bool BackPatch(SContext* ctx);
-
 	void BeginTimeProfile(JitBlock* b);
 	void EndTimeProfile(JitBlock* b);
+
+	bool BackPatch(SContext* ctx);
+	bool DisasmLoadStore(const u8* ptr, u32* flags, ArmGen::ARMReg* rD, ArmGen::ARMReg* V1);
+	// Initializes the information that backpatching needs
+	// This is required so we know the backpatch routine sizes and trouble offsets
+	void InitBackpatch();
+
+	// Returns the trouble instruction offset
+	// Zero if it isn't a fastmem routine
+	u32 EmitBackpatchRoutine(ARMXEmitter* emit, u32 flags, bool fastmem, bool do_padding, ArmGen::ARMReg RS, ArmGen::ARMReg V1 = ArmGen::ARMReg::INVALID_REG);
 
 public:
 	JitArm() : code_buffer(32000) {}
@@ -118,13 +146,8 @@ public:
 	void GetCarryAndClear(ArmGen::ARMReg reg);
 	void FinalizeCarry(ArmGen::ARMReg reg);
 
-	// TODO: This shouldn't be here
-	void UnsafeStoreFromReg(ArmGen::ARMReg dest, ArmGen::ARMReg value, int accessSize, s32 offset);
-	void SafeStoreFromReg(bool fastmem, s32 dest, u32 value, s32 offsetReg, int accessSize, s32 offset);
-
-	void UnsafeLoadToReg(ArmGen::ARMReg dest, ArmGen::ARMReg addr, int accessSize, s32 offsetReg, s32 offset);
-	void SafeLoadToReg(bool fastmem, u32 dest, s32 addr, s32 offsetReg, int accessSize, s32 offset, bool signExtend, bool reverse);
-
+	void SafeStoreFromReg(s32 dest, u32 value, s32 offsetReg, int accessSize, s32 offset);
+	void SafeLoadToReg(ArmGen::ARMReg dest, s32 addr, s32 offsetReg, int accessSize, s32 offset, bool signExtend, bool reverse, bool update);
 
 	// OPCODES
 	void unknown_instruction(UGeckoInstruction _inst);

--- a/Source/Core/Core/PowerPC/JitArm32/JitArm_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitArm_LoadStore.cpp
@@ -18,114 +18,149 @@
 
 using namespace ArmGen;
 
-void JitArm::UnsafeStoreFromReg(ARMReg dest, ARMReg value, int accessSize, s32 offset)
+void JitArm::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, int accessSize, s32 offset)
 {
-	// All this gets replaced on backpatch
-	Operand2 mask(2, 1); // ~(Memory::MEMVIEW32_MASK)
-	BIC(dest, dest, mask); // 1
-	MOVI2R(R14, (u32)Memory::base, false); // 2-3
-	ADD(dest, dest, R14); // 4
-	switch (accessSize)
-	{
-		case 32:
-			REV(value, value); // 5
-		break;
-		case 16:
-			REV16(value, value);
-		break;
-		case 8:
-			NOP(1);
-		break;
-	}
-	switch (accessSize)
-	{
-		case 32:
-			STR(value, dest); // 6
-		break;
-		case 16:
-			STRH(value, dest);
-		break;
-		case 8:
-			STRB(value, dest);
-		break;
-	}
-	NOP(1); // 7
-}
+	// We want to make sure to not get LR as a temp register
+	ARMReg rA = R12;
 
-void JitArm::SafeStoreFromReg(bool fastmem, s32 dest, u32 value, s32 regOffset, int accessSize, s32 offset)
-{
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem && fastmem)
-	{
-		ARMReg RA;
-		ARMReg RB;
-		ARMReg RS = gpr.R(value);
+	u32 imm_addr = 0;
+	bool is_immediate = false;
 
-		if (dest != -1)
-			RA = gpr.R(dest);
-
-		if (regOffset != -1)
-		{
-			RB = gpr.R(regOffset);
-			MOV(R10, RB);
-			NOP(1);
-		}
-		else
-		{
-			MOVI2R(R10, (u32)offset, false);
-		}
-
-		if (dest != -1)
-			ADD(R10, R10, RA);
-		else
-			NOP(1);
-
-		MOV(R12, RS);
-		UnsafeStoreFromReg(R10, R12, accessSize, 0);
-		return;
-	}
-	ARMReg rA = gpr.GetReg();
-	ARMReg rB = gpr.GetReg();
-	ARMReg rC = gpr.GetReg();
-	ARMReg RA = INVALID_REG;
-	ARMReg RB = INVALID_REG;
-	if (dest != -1)
-		RA = gpr.R(dest);
-	if (regOffset != -1)
-		RB = gpr.R(regOffset);
-	ARMReg RS = gpr.R(value);
-	switch (accessSize)
-	{
-		case 32:
-			MOVI2R(rA, (u32)&Memory::Write_U32);
-		break;
-		case 16:
-			MOVI2R(rA, (u32)&Memory::Write_U16);
-		break;
-		case 8:
-			MOVI2R(rA, (u32)&Memory::Write_U8);
-		break;
-	}
-	MOV(rB, RS);
 	if (regOffset == -1)
 	{
-		MOVI2R(rC, offset);
 		if (dest != -1)
-			ADD(rC, rC, RA);
+		{
+			if (gpr.IsImm(dest))
+			{
+				is_immediate = true;
+				imm_addr = gpr.GetImm(dest) + offset;
+			}
+			else
+			{
+				Operand2 off;
+				if (TryMakeOperand2(offset, off))
+				{
+					ADD(rA, gpr.R(dest), off);
+				}
+				else
+				{
+					MOVI2R(rA, offset);
+					ADD(rA, rA, gpr.R(dest));
+				}
+			}
+		}
+		else
+		{
+			is_immediate = true;
+			imm_addr = offset;
+		}
 	}
 	else
 	{
 		if (dest != -1)
-			ADD(rC, RA, RB);
+		{
+			if (gpr.IsImm(dest) && gpr.IsImm(regOffset))
+			{
+				is_immediate = true;
+				imm_addr = gpr.GetImm(dest) + gpr.GetImm(regOffset);
+			}
+			else if (gpr.IsImm(dest) && !gpr.IsImm(regOffset))
+			{
+				Operand2 off;
+				if (TryMakeOperand2(gpr.GetImm(dest), off))
+				{
+					ADD(rA, gpr.R(regOffset), off);
+				}
+				else
+				{
+					MOVI2R(rA, gpr.GetImm(dest));
+					ADD(rA, rA, gpr.R(regOffset));
+				}
+			}
+			else if (!gpr.IsImm(dest) && gpr.IsImm(regOffset))
+			{
+				Operand2 off;
+				if (TryMakeOperand2(gpr.GetImm(regOffset), off))
+				{
+					ADD(rA, gpr.R(dest), off);
+				}
+				else
+				{
+					MOVI2R(rA, gpr.GetImm(regOffset));
+					ADD(rA, rA, gpr.R(dest));
+				}
+			}
+			else
+			{
+				ADD(rA, gpr.R(dest), gpr.R(regOffset));
+			}
+		}
 		else
-			MOV(rC, RB);
+		{
+			if (gpr.IsImm(regOffset))
+			{
+				is_immediate = true;
+				imm_addr = gpr.GetImm(regOffset);
+			}
+			else
+			{
+				MOV(rA, gpr.R(regOffset));
+			}
+		}
+	}
+	ARMReg RS = gpr.R(value);
+
+	u32 flags = BackPatchInfo::FLAG_STORE;
+	if (accessSize == 32)
+		flags |= BackPatchInfo::FLAG_SIZE_32;
+	else if (accessSize == 16)
+		flags |= BackPatchInfo::FLAG_SIZE_16;
+	else
+		flags |= BackPatchInfo::FLAG_SIZE_8;
+
+	if (is_immediate)
+	{
+		if ((imm_addr & 0xFFFFF000) == 0xCC008000 && jit->jo.optimizeGatherPipe)
+		{
+			MOVI2R(R14, (u32)&GPFifo::m_gatherPipeCount);
+			MOVI2R(R10, (u32)GPFifo::m_gatherPipe);
+			LDR(R11, R14);
+			if (accessSize == 32)
+			{
+				REV(RS, RS);
+				STR(RS, R10, R11);
+				REV(RS, RS);
+			}
+			else if (accessSize == 16)
+			{
+				REV16(RS, RS);
+				STRH(RS, R10, R11);
+				REV16(RS, RS);
+			}
+			else
+			{
+				STRB(RS, R10, R11);
+			}
+			ADD(R11, R11, accessSize >> 3);
+			STR(R11, R14);
+			jit->js.fifoBytesThisBlock += accessSize >> 3;
+		}
+		else if (Memory::IsRAMAddress(imm_addr))
+		{
+			MOVI2R(rA, imm_addr);
+			EmitBackpatchRoutine(this, flags, SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem, false, RS);
+		}
+		else
+		{
+			MOVI2R(rA, imm_addr);
+			EmitBackpatchRoutine(this, flags, false, false, RS);
+		}
+	}
+	else
+	{
+		EmitBackpatchRoutine(this, flags, SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem, true, RS);
 	}
 
-	PUSH(4, R0, R1, R2, R3);
-	MOV(R0, rB);
-	MOV(R1, rC);
-	BL(rA);
-	POP(4, R0, R1, R2, R3);
-	gpr.Unlock(rA, rB, rC);
 }
 
 void JitArm::stX(UGeckoInstruction inst)
@@ -138,7 +173,6 @@ void JitArm::stX(UGeckoInstruction inst)
 	u32 accessSize = 0;
 	s32 regOffset = -1;
 	bool update = false;
-	bool fastmem = false;
 	switch (inst.OPCD)
 	{
 		case 45: // sthu
@@ -152,7 +186,6 @@ void JitArm::stX(UGeckoInstruction inst)
 				case 183: // stwux
 					update = true;
 				case 151: // stwx
-					fastmem = true;
 					accessSize = 32;
 					regOffset = b;
 				break;
@@ -173,7 +206,6 @@ void JitArm::stX(UGeckoInstruction inst)
 		case 37: // stwu
 			update = true;
 		case 36: // stw
-			fastmem = true;
 			accessSize = 32;
 		break;
 		case 39: // stbu
@@ -182,7 +214,9 @@ void JitArm::stX(UGeckoInstruction inst)
 			accessSize = 8;
 		break;
 	}
-	SafeStoreFromReg(fastmem, update ? a : (a ? a : -1), s, regOffset, accessSize, offset);
+
+	SafeStoreFromReg(update ? a : (a ? a : -1), s, regOffset, accessSize, offset);
+
 	if (update)
 	{
 		ARMReg rA = gpr.GetReg();
@@ -193,143 +227,135 @@ void JitArm::stX(UGeckoInstruction inst)
 		// Check for DSI exception prior to writing back address
 		LDR(rA, R9, PPCSTATE_OFF(Exceptions));
 		TST(rA, EXCEPTION_DSI);
-		FixupBranch DoNotWrite = B_CC(CC_NEQ);
-		if (a)
+		SetCC(CC_EQ);
+		if (regOffset == -1)
 		{
-			if (regOffset == -1)
-			{
-				MOVI2R(rA, offset);
-				ADD(RA, RA, rA);
-			}
-			else
-			{
-				ADD(RA, RA, RB);
-			}
+			MOVI2R(rA, offset);
+			ADD(RA, RA, rA);
 		}
 		else
 		{
-			if (regOffset == -1)
-				MOVI2R(RA, (u32)offset);
-			else
-				MOV(RA, RB);
+			ADD(RA, RA, RB);
 		}
-		SetJumpTarget(DoNotWrite);
+		SetCC();
 		gpr.Unlock(rA);
 	}
 }
 
-void JitArm::UnsafeLoadToReg(ARMReg dest, ARMReg addr, int accessSize, s32 offsetReg, s32 offset)
+void JitArm::SafeLoadToReg(ARMReg dest, s32 addr, s32 offsetReg, int accessSize, s32 offset, bool signExtend, bool reverse, bool update)
 {
-	ARMReg rA = gpr.GetReg();
+	// We want to make sure to not get LR as a temp register
+	ARMReg rA = R12;
+
+	u32 imm_addr = 0;
+	bool is_immediate = false;
+
 	if (offsetReg == -1)
 	{
-		MOVI2R(rA, offset, false); // -3
-		ADD(addr, addr, rA); // - 1
-	}
-	else
-	{
-		NOP(2); // -3, -2
-		// offsetReg is preloaded here
-		ADD(addr, addr, gpr.R(offsetReg)); // -1
-	}
-
-	// All this gets replaced on backpatch
-	Operand2 mask(2, 1); // ~(Memory::MEMVIEW32_MASK)
-	BIC(addr, addr, mask); // 1
-	MOVI2R(rA, (u32)Memory::base, false); // 2-3
-	ADD(addr, addr, rA); // 4
-	switch (accessSize)
-	{
-		case 32:
-			LDR(dest, addr); // 5
-		break;
-		case 16:
-			LDRH(dest, addr);
-		break;
-		case 8:
-			LDRB(dest, addr);
-		break;
-	}
-	switch (accessSize)
-	{
-		case 32:
-			REV(dest, dest); // 6
-		break;
-		case 16:
-			REV16(dest, dest);
-		break;
-		case 8:
-			NOP(1);
-		break;
-
-	}
-	NOP(2); // 7-8
-	gpr.Unlock(rA);
-}
-
-void JitArm::SafeLoadToReg(bool fastmem, u32 dest, s32 addr, s32 offsetReg, int accessSize, s32 offset, bool signExtend, bool reverse)
-{
-	ARMReg RD = gpr.R(dest);
-
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem && fastmem)
-	{
-		// Preload for fastmem
-		if (offsetReg != -1)
-			gpr.R(offsetReg);
-
 		if (addr != -1)
-			MOV(R10, gpr.R(addr));
+		{
+			if (gpr.IsImm(addr))
+			{
+				is_immediate = true;
+				imm_addr = gpr.GetImm(addr) + offset;
+			}
+			else
+			{
+				Operand2 off;
+				if (TryMakeOperand2(offset, off))
+				{
+					ADD(rA, gpr.R(addr), off);
+				}
+				else
+				{
+					MOVI2R(rA, offset);
+					ADD(rA, rA, gpr.R(addr));
+				}
+			}
+		}
 		else
-			MOV(R10, 0);
-
-		UnsafeLoadToReg(RD, R10, accessSize, offsetReg, offset);
-		return;
-	}
-	ARMReg rA = gpr.GetReg();
-	ARMReg rB = gpr.GetReg();
-
-	if (offsetReg == -1)
-	{
-		MOVI2R(rA, offset);
-		if (addr != -1)
-			ADD(rA, rA, gpr.R(addr));
+		{
+			is_immediate = true;
+			imm_addr = offset;
+		}
 	}
 	else
 	{
 		if (addr != -1)
-			ADD(rA, gpr.R(addr), gpr.R(offsetReg));
+		{
+			if (gpr.IsImm(addr) && gpr.IsImm(offsetReg))
+			{
+				is_immediate = true;
+				imm_addr = gpr.GetImm(addr) + gpr.GetImm(offsetReg);
+			}
+			else if (gpr.IsImm(addr) && !gpr.IsImm(offsetReg))
+			{
+				Operand2 off;
+				if (TryMakeOperand2(gpr.GetImm(addr), off))
+				{
+					ADD(rA, gpr.R(offsetReg), off);
+				}
+				else
+				{
+					MOVI2R(rA, gpr.GetImm(addr));
+					ADD(rA, rA, gpr.R(offsetReg));
+				}
+			}
+			else if (!gpr.IsImm(addr) && gpr.IsImm(offsetReg))
+			{
+				Operand2 off;
+				if (TryMakeOperand2(gpr.GetImm(offsetReg), off))
+				{
+					ADD(rA, gpr.R(addr), off);
+				}
+				else
+				{
+					MOVI2R(rA, gpr.GetImm(offsetReg));
+					ADD(rA, rA, gpr.R(addr));
+				}
+			}
+			else
+			{
+				ADD(rA, gpr.R(addr), gpr.R(offsetReg));
+			}
+		}
 		else
-			MOV(rA, gpr.R(offsetReg));
+		{
+			if (gpr.IsImm(offsetReg))
+			{
+				is_immediate = true;
+				imm_addr = gpr.GetImm(offsetReg);
+			}
+			else
+			{
+				MOV(rA, gpr.R(offsetReg));
+			}
+		}
 	}
 
-	switch (accessSize)
-	{
-		case 8:
-			MOVI2R(rB, (u32)&Memory::Read_U8);
-		break;
-		case 16:
-			MOVI2R(rB, (u32)&Memory::Read_U16);
-		break;
-		case 32:
-			MOVI2R(rB, (u32)&Memory::Read_U32);
-		break;
-	}
-	PUSH(4, R0, R1, R2, R3);
-	MOV(R0, rA);
-	BL(rB);
-	MOV(rA, R0);
-	POP(4, R0, R1, R2, R3);
-	MOV(RD, rA);
-	if (signExtend) // Only on 16 loads
-		SXTH(RD, RD);
+	if (is_immediate)
+		MOVI2R(rA, imm_addr);
+
+	u32 flags = BackPatchInfo::FLAG_LOAD;
+	if (accessSize == 32)
+		flags |= BackPatchInfo::FLAG_SIZE_32;
+	else if (accessSize == 16)
+		flags |= BackPatchInfo::FLAG_SIZE_16;
+	else
+		flags |= BackPatchInfo::FLAG_SIZE_8;
+
 	if (reverse)
-	{
-		if (accessSize == 32)
-			REV(RD, RD);
-		else if (accessSize == 16)
-			REV16(RD, RD);
-	}
-	gpr.Unlock(rA, rB);
+		flags |= BackPatchInfo::FLAG_REVERSE;
+
+	EmitBackpatchRoutine(this, flags,
+			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
+			!(is_immediate && Memory::IsRAMAddress(imm_addr)), dest);
+
+	if (signExtend) // Only on 16 loads
+		SXTH(dest, dest);
+
+	if (update)
+		MOV(gpr.R(addr), rA);
 }
 
 void JitArm::lXX(UGeckoInstruction inst)
@@ -344,7 +370,6 @@ void JitArm::lXX(UGeckoInstruction inst)
 	bool update = false;
 	bool signExtend = false;
 	bool reverse = false;
-	bool fastmem = false;
 
 	switch (inst.OPCD)
 	{
@@ -354,21 +379,18 @@ void JitArm::lXX(UGeckoInstruction inst)
 				case 55: // lwzux
 					update = true;
 				case 23: // lwzx
-					fastmem = true;
 					accessSize = 32;
 					offsetReg = b;
 				break;
 				case 119: //lbzux
 					update = true;
 				case 87: // lbzx
-					fastmem = true;
 					accessSize = 8;
 					offsetReg = b;
 				break;
 				case 311: // lhzux
 					update = true;
 				case 279: // lhzx
-					fastmem = true;
 					accessSize = 16;
 					offsetReg = b;
 				break;
@@ -392,19 +414,16 @@ void JitArm::lXX(UGeckoInstruction inst)
 		case 33: // lwzu
 			update = true;
 		case 32: // lwz
-			fastmem = true;
 			accessSize = 32;
 		break;
 		case 35: // lbzu
 			update = true;
 		case 34: // lbz
-			fastmem = true;
 			accessSize = 8;
 		break;
 		case 41: // lhzu
 			update = true;
 		case 40: // lhz
-			fastmem = true;
 			accessSize = 16;
 		break;
 		case 43: // lhau
@@ -417,27 +436,13 @@ void JitArm::lXX(UGeckoInstruction inst)
 
 	// Check for exception before loading
 	ARMReg rA = gpr.GetReg(false);
+	ARMReg RD = gpr.R(d);
 
 	LDR(rA, R9, PPCSTATE_OFF(Exceptions));
 	TST(rA, EXCEPTION_DSI);
 	FixupBranch DoNotLoad = B_CC(CC_NEQ);
 
-	SafeLoadToReg(fastmem, d, update ? a : (a ? a : -1), offsetReg, accessSize, offset, signExtend, reverse);
-
-	if (update)
-	{
-		ARMReg RA = gpr.R(a);
-		if (offsetReg == -1)
-		{
-			rA = gpr.GetReg(false);
-			MOVI2R(rA, offset);
-			ADD(RA, RA, rA);
-		}
-		else
-		{
-			ADD(RA, RA, gpr.R(offsetReg));
-		}
-	}
+	SafeLoadToReg(RD, update ? a : (a ? a : -1), offsetReg, accessSize, offset, signExtend, reverse, update);
 
 	SetJumpTarget(DoNotLoad);
 
@@ -449,8 +454,6 @@ void JitArm::lXX(UGeckoInstruction inst)
 	    (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii && Memory::ReadUnchecked_U32(js.compilerPC + 4) == 0x2C000000)) &&
 	    Memory::ReadUnchecked_U32(js.compilerPC + 8) == 0x4182fff8)
 	{
-		ARMReg RD = gpr.R(d);
-
 		// if it's still 0, we can wait until the next event
 		TST(RD, RD);
 		FixupBranch noIdle = B_CC(CC_NEQ);


### PR DESCRIPTION
This is a fairly lengthy change that can't be separated out to multiple commits well due to the nature of fastmem being a bit of an intertangled mess.
This makes my life easier for maintaining fastmem on ARMv7 because I now don't have to do any terrible instruction counting and NOP padding. Really
makes my brain stop hurting when working with it.

This enables fastmem for a whole bunch of new instructions, which basically means that all instructions now have fastmem working for them. This also
rewrites the floating point loadstores again because the last implementation was pretty crap when it comes to performance, even if they were the
cleanest implementation from my point of view.

This initially started with me rewriting the fastmem routines to work just like the previous/current implementation of floating loadstores. That was
when I noticed that the performance tanked and decided to rewrite all of it.

This also happens to implement gatherpipe optimizations alongside constant address optimization.

Overall this comment brings a fairly large speedboost when using fastmem.
