### PR TITLE
InputConfigFragment: Use a StringBuilder for string concatenation

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/InputConfigFragment.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/settings/input/InputConfigFragment.java
@@ -91,12 +91,12 @@ public final class InputConfigFragment extends PreferenceFragment
 		else
 		{
 			List<InputDevice.MotionRange> motions = input.getMotionRanges();
-			String fakeid = "";
+			StringBuilder fakeid = new StringBuilder();
 
 			for (InputDevice.MotionRange range : motions)
-				fakeid += range.getAxis();
+				fakeid.append(range.getAxis());
 
-			return fakeid;
+			return fakeid.toString();
 		}
 	}
 }


### PR DESCRIPTION
This is the recommended way to join strings, since it doesn't destroy and recreate the string repeatedly.
