### PR TITLE
Arm(64)Emitter: Make some variables static

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -71,7 +71,7 @@ void ARM64XEmitter::FlushIcacheSection(u8* start, u8* end)
 
 
 // Exception generation
-const u32 ExcEnc[][3] = {
+static const u32 ExcEnc[][3] = {
 	{0, 0, 1}, // SVC
 	{0, 0, 2}, // HVC
 	{0, 0, 3}, // SMC
@@ -83,13 +83,13 @@ const u32 ExcEnc[][3] = {
 };
 
 // Arithmetic generation
-const u32 ArithEnc[] = {
+static const u32 ArithEnc[] = {
 	0x058, // ADD
 	0x258, // SUB
 };
 
 // Conditional Select
-const u32 CondSelectEnc[][2] = {
+static const u32 CondSelectEnc[][2] = {
 	{0, 0}, // CSEL
 	{0, 1}, // CSINC
 	{1, 0}, // CSINV
@@ -97,7 +97,7 @@ const u32 CondSelectEnc[][2] = {
 };
 
 // Data-Processing (1 source)
-const u32 Data1SrcEnc[][2] = {
+static const u32 Data1SrcEnc[][2] = {
 	{0, 0}, // RBIT
 	{0, 1}, // REV16
 	{0, 2}, // REV32
@@ -107,7 +107,7 @@ const u32 Data1SrcEnc[][2] = {
 };
 
 // Data-Processing (2 source)
-const u32 Data2SrcEnc[] = {
+static const u32 Data2SrcEnc[] = {
 	0x02, // UDIV
 	0x03, // SDIV
 	0x08, // LSLV
@@ -125,7 +125,7 @@ const u32 Data2SrcEnc[] = {
 };
 
 // Data-Processing (3 source)
-const u32 Data3SrcEnc[][2] = {
+static const u32 Data3SrcEnc[][2] = {
 	{0, 0}, // MADD
 	{0, 1}, // MSUB
 	{1, 0}, // SMADDL (64Bit Only)
@@ -137,7 +137,7 @@ const u32 Data3SrcEnc[][2] = {
 };
 
 // Logical (shifted register)
-const u32 LogicalEnc[][2] = {
+static const u32 LogicalEnc[][2] = {
 	{0, 0}, // AND
 	{0, 1}, // BIC
 	{1, 0}, // OOR
@@ -149,7 +149,7 @@ const u32 LogicalEnc[][2] = {
 };
 
 // Load/Store Exclusive
-u32 LoadStoreExcEnc[][5] = {
+static u32 LoadStoreExcEnc[][5] = {
 	{0, 0, 0, 0, 0}, // STXRB
 	{0, 0, 0, 0, 1}, // STLXRB
 	{0, 0, 1, 0, 0}, // LDXRB

--- a/Source/Core/Common/ArmEmitter.cpp
+++ b/Source/Core/Common/ArmEmitter.cpp
@@ -543,43 +543,45 @@ void ARMXEmitter::WriteShiftedDataOp(u32 op, bool SetFlags, ARMReg dest, ARMReg 
 
 // IMM, REG, IMMSREG, RSR
 // -1 for invalid if the instruction doesn't support that
-const s32 InstOps[][4] = {{16, 0, 0, 0}, // AND(s)
-                          {17, 1, 1, 1}, // EOR(s)
-                          {18, 2, 2, 2}, // SUB(s)
-                          {19, 3, 3, 3}, // RSB(s)
-                          {20, 4, 4, 4}, // ADD(s)
-                          {21, 5, 5, 5}, // ADC(s)
-                          {22, 6, 6, 6}, // SBC(s)
-                          {23, 7, 7, 7}, // RSC(s)
-                          {24, 8, 8, 8}, // TST
-                          {25, 9, 9, 9}, // TEQ
-                          {26, 10, 10, 10}, // CMP
-                          {27, 11, 11, 11}, // CMN
-                          {28, 12, 12, 12}, // ORR(s)
-                          {29, 13, 13, 13}, // MOV(s)
-                          {30, 14, 14, 14}, // BIC(s)
-                          {31, 15, 15, 15}, // MVN(s)
-                          {24, -1, -1, -1}, // MOVW
-                          {26, -1, -1, -1}, // MOVT
-                         };
+static const s32 InstOps[][4] = {
+	{16, 0, 0, 0}, // AND(s)
+	{17, 1, 1, 1}, // EOR(s)
+	{18, 2, 2, 2}, // SUB(s)
+	{19, 3, 3, 3}, // RSB(s)
+	{20, 4, 4, 4}, // ADD(s)
+	{21, 5, 5, 5}, // ADC(s)
+	{22, 6, 6, 6}, // SBC(s)
+	{23, 7, 7, 7}, // RSC(s)
+	{24, 8, 8, 8}, // TST
+	{25, 9, 9, 9}, // TEQ
+	{26, 10, 10, 10}, // CMP
+	{27, 11, 11, 11}, // CMN
+	{28, 12, 12, 12}, // ORR(s)
+	{29, 13, 13, 13}, // MOV(s)
+	{30, 14, 14, 14}, // BIC(s)
+	{31, 15, 15, 15}, // MVN(s)
+	{24, -1, -1, -1}, // MOVW
+	{26, -1, -1, -1}, // MOVT
+};
 
-const char *InstNames[] = {"AND",
-                           "EOR",
-                           "SUB",
-                           "RSB",
-                           "ADD",
-                           "ADC",
-                           "SBC",
-                           "RSC",
-                           "TST",
-                           "TEQ",
-                           "CMP",
-                           "CMN",
-                           "ORR",
-                           "MOV",
-                           "BIC",
-                           "MVN"
-                          };
+static const char* InstNames[] = {
+	"AND",
+	"EOR",
+	"SUB",
+	"RSB",
+	"ADD",
+	"ADC",
+	"SBC",
+	"RSC",
+	"TST",
+	"TEQ",
+	"CMP",
+	"CMN",
+	"ORR",
+	"MOV",
+	"BIC",
+	"MVN"
+};
 
 void ARMXEmitter::AND (ARMReg Rd, ARMReg Rn, Operand2 Rm) { WriteInstruction(0, Rd, Rn, Rm); }
 void ARMXEmitter::ANDS(ARMReg Rd, ARMReg Rn, Operand2 Rm) { WriteInstruction(0, Rd, Rn, Rm, true); }
@@ -774,7 +776,7 @@ void ARMXEmitter::SVC(Operand2 op)
 
 // IMM, REG, IMMSREG, RSR
 // -1 for invalid if the instruction doesn't support that
-const s32 LoadStoreOps[][4] = {
+static const s32 LoadStoreOps[][4] = {
 	{0x40, 0x60, 0x60, -1}, // STR
 	{0x41, 0x61, 0x61, -1}, // LDR
 	{0x44, 0x64, 0x64, -1}, // STRB
@@ -785,7 +787,7 @@ const s32 LoadStoreOps[][4] = {
 	{ 0x5,  0x1,  -1, -1}, // LDRSB
 	{ 0x5,  0x1,  -1, -1}, // LDRSH
 };
-const char *LoadStoreNames[] = {
+static const char* LoadStoreNames[] = {
 	"STR",
 	"LDR",
 	"STRB",


### PR DESCRIPTION
Not used outside of their respective translation units.
