### PR TITLE
WiimoteReal: use inheritance instead of #ifdef

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IODummy.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IODummy.cpp
@@ -9,9 +9,7 @@ namespace WiimoteReal
 {
 
 WiimoteScanner::WiimoteScanner()
-{
-	return;
-}
+{}
 
 WiimoteScanner::~WiimoteScanner()
 {}
@@ -29,44 +27,5 @@ bool WiimoteScanner::IsReady() const
 {
 	return false;
 }
-
-void Wiimote::InitInternal()
-{}
-
-void Wiimote::TeardownInternal()
-{}
-
-bool Wiimote::ConnectInternal()
-{
-	return 0;
-}
-
-void Wiimote::DisconnectInternal()
-{
-	return;
-}
-
-bool Wiimote::IsConnected() const
-{
-	return false;
-}
-
-void Wiimote::IOWakeup()
-{}
-
-int Wiimote::IORead(u8* buf)
-{
-	return 0;
-}
-
-int Wiimote::IOWrite(const u8* buf, size_t len)
-{
-	return 0;
-}
-
-void Wiimote::EnablePowerAssertionInternal()
-{}
-void Wiimote::DisablePowerAssertionInternal()
-{}
 
 };

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -42,17 +42,13 @@ Wiimote::Wiimote()
 	, m_channel(0)
 	, m_rumble_state()
 	, m_need_prepare()
-{
-	InitInternal();
-}
+{}
 
-Wiimote::~Wiimote()
+void Wiimote::Shutdown()
 {
-	DisablePowerAssertionInternal();
 	StopThread();
 	ClearReadQueue();
 	m_write_reports.Clear();
-	TeardownInternal();
 }
 
 // to be called from CPU thread
@@ -62,12 +58,9 @@ void Wiimote::WriteReport(Report rpt)
 	{
 		bool const new_rumble_state = (rpt[2] & 0x1) != 0;
 
+		// If this is a rumble report and the rumble state didn't change, ignore.
 		if (WM_RUMBLE == rpt[1] && new_rumble_state == m_rumble_state)
-		{
-			// If this is a rumble report and the rumble state didn't change, ignore
-			//ERROR_LOG(WIIMOTE, "Ignoring rumble report.");
 			return;
-		}
 
 		m_rumble_state = new_rumble_state;
 	}
@@ -508,8 +501,6 @@ void Wiimote::StopThread()
 	IOWakeup();
 	if (m_wiimote_thread.joinable())
 		m_wiimote_thread.join();
-#if defined(__APPLE__)
-#endif
 }
 
 void Wiimote::SetReady()

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -26,8 +26,9 @@ class Wiimote : NonCopyable
 {
 friend class WiimoteEmu::Wiimote;
 public:
-	Wiimote();
-	~Wiimote();
+	virtual ~Wiimote() {}
+	// This needs to be called in derived destructors!
+	void Shutdown();
 
 	void ControlChannel(const u16 channel, const void* const data, const u32 size);
 	void InterruptChannel(const u16 channel, const void* const data, const u32 size);
@@ -47,22 +48,19 @@ public:
 	void EmuResume();
 	void EmuPause();
 
-	void EnablePowerAssertionInternal();
-	void DisablePowerAssertionInternal();
+	virtual void EnablePowerAssertionInternal() {}
+	virtual void DisablePowerAssertionInternal() {}
 
 	// connecting and disconnecting from physical devices
 	// (using address inserted by FindWiimotes)
 	// these are called from the wiimote's thread.
-	bool ConnectInternal();
-	void DisconnectInternal();
-
-	void InitInternal();
-	void TeardownInternal();
+	virtual bool ConnectInternal() = 0;
+	virtual void DisconnectInternal() = 0;
 
 	bool Connect();
 
 	// TODO: change to something like IsRelevant
-	bool IsConnected() const;
+	virtual bool IsConnected() const = 0;
 
 	void Prepare(int index);
 	bool PrepareOnThread();
@@ -75,30 +73,8 @@ public:
 
 	int m_index;
 
-#if defined(__APPLE__)
-	IOBluetoothDevice *m_btd;
-	IOBluetoothL2CAPChannel *m_ichan;
-	IOBluetoothL2CAPChannel *m_cchan;
-	unsigned char* m_input;
-	int m_inputlen;
-	bool m_connected;
-	CFRunLoopRef m_wiimote_thread_run_loop;
-	IOPMAssertionID m_pm_assertion;
-#elif defined(__linux__) && HAVE_BLUEZ
-	bdaddr_t m_bdaddr;                    // Bluetooth address
-	int m_cmd_sock;                       // Command socket
-	int m_int_sock;                       // Interrupt socket
-	int m_wakeup_pipe_w, m_wakeup_pipe_r;
-
-#elif defined(_WIN32)
-	std::basic_string<TCHAR> m_devicepath; // Unique wiimote reference
-	//ULONGLONG btaddr;                  // Bluetooth address
-	HANDLE m_dev_handle;                   // HID handle
-	OVERLAPPED m_hid_overlap_read, m_hid_overlap_write; // Overlap handle
-	enum win_bt_stack_t m_stack;           // Type of bluetooth stack to use
-#endif
-
 protected:
+	Wiimote();
 	Report m_last_input_report;
 	u16 m_channel;
 
@@ -106,9 +82,9 @@ private:
 	void ClearReadQueue();
 	void WriteReport(Report rpt);
 
-	int IORead(u8* buf);
-	int IOWrite(u8 const* buf, size_t len);
-	void IOWakeup();
+	virtual int IORead(u8* buf) = 0;
+	virtual int IOWrite(u8 const* buf, size_t len) = 0;
+	virtual void IOWakeup() = 0;
 
 	void ThreadFunc();
 	void SetReady();


### PR DESCRIPTION
The OS X implementation doesn't compile yet. Could someone familiar with Objective C please help me find a good way to solve this, @comex maybe? My primitive solution would be making the class variables public and casting the objects from the `g_wiimotes` list to `WiimoteDarwin` but I'm sure this can be done more elegantly.
