### PR TITLE
JIT: clear FIFO write addresses when block cache is cleared

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -81,7 +81,7 @@ using namespace Gen;
 		else
 			Core::DisplayMessage("Clearing code cache.", 3000);
 #endif
-
+		jit->js.fifoWriteAddresses.clear();
 		for (int i = 0; i < num_blocks; i++)
 		{
 			DestroyBlock(i, false);


### PR DESCRIPTION
Fixes a spurious FIFO write check which caused a flags locking assert in
Splinter Cell: Double Agent.
