### PR TITLE
JIT: fix Force25BitPrecision with accurate single precision mode off

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -799,6 +799,10 @@ void EmuCodeBlock::Force25BitPrecision(X64Reg output, OpArg input, X64Reg tmp)
 			PADDQ(output, R(tmp));
 		}
 	}
+	else if (!input.IsSimpleReg() || input.GetSimpleReg() != output)
+	{
+		MOVAPD(output, input);
+	}
 }
 
 static u32 GC_ALIGNED16(temp32);


### PR DESCRIPTION
Doesn't affect anything now, but it's more correct (and should make setting
AccurateSinglePrecision to false work properly now).
