### PR TITLE
JIT: fix fcmp+cror merging bug

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -285,6 +285,7 @@ void Jit64::FloatCompare(UGeckoInstruction inst, bool upper)
 		js.skipnext = true;
 		js.downcountAmount++;
 		int dst = 3 - (next.CRBD & 3);
+		output[3 - (next.CRBD & 3)] &= ~(1 << dst);
 		output[3 - (next.CRBA & 3)] |= 1 << dst;
 		output[3 - (next.CRBB & 3)] |= 1 << dst;
 	}


### PR DESCRIPTION
Destination CR bit needs to be cleared if it's not one of the sources.
