### PR TITLE
Vertex loader: use ABI_CallFunction

### DIFF
--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -410,8 +410,7 @@ void VertexLoader::CompileVertexTranslator()
 void VertexLoader::WriteCall(TPipelineFunction func)
 {
 #ifdef USE_VERTEX_LOADER_JIT
-	MOV(64, R(RAX), Imm64((u64)func));
-	CALLptr(R(RAX));
+	ABI_CallFunction((const void*)func);
 #else
 	m_PipelineStages[m_numPipelineStages++] = func;
 #endif


### PR DESCRIPTION
Should result in faster/shorter code sequences on platforms where generated
code is close enough to the code segment (e.g. Windows).
