### PR TITLE
[Android] Fix NEON detection with AArch64

### DIFF
--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -255,7 +255,7 @@ JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetVersio
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SupportsNEON(JNIEnv *env, jobject obj)
 {
-	return cpu_info.bNEON;
+	return cpu_info.bNEON || cpu_info.bASIMD;
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SaveScreenShot(JNIEnv *env, jobject obj)


### PR DESCRIPTION
On AArch64 asimd is the new name for NEON.
This fixes a message on application start in Android about the device not supporting NEON.
If it's AArch64 then it supports NEON!
