### PR TITLE
OGL: Don't use texture arrays for MSAA.

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -99,17 +99,17 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
 	}
 	else
 	{
-		m_textureType = GL_TEXTURE_2D_MULTISAMPLE_ARRAY;
+		m_textureType = GL_TEXTURE_2D_MULTISAMPLE;
 		GLenum resolvedType = GL_TEXTURE_2D_ARRAY;
 
 		glBindTexture(m_textureType, m_efbColor);
-		glTexImage3DMultisample(m_textureType, m_msaaSamples, GL_RGBA, m_targetWidth, m_targetHeight, m_EFBLayers, false);
+		glTexImage2DMultisample(m_textureType, m_msaaSamples, GL_RGBA, m_targetWidth, m_targetHeight, false);
 
 		glBindTexture(m_textureType, m_efbDepth);
-		glTexImage3DMultisample(m_textureType, m_msaaSamples, GL_DEPTH_COMPONENT24, m_targetWidth, m_targetHeight, m_EFBLayers, false);
+		glTexImage2DMultisample(m_textureType, m_msaaSamples, GL_DEPTH_COMPONENT24, m_targetWidth, m_targetHeight, false);
 
 		glBindTexture(m_textureType, m_efbColorSwap);
-		glTexImage3DMultisample(m_textureType, m_msaaSamples, GL_RGBA, m_targetWidth, m_targetHeight, m_EFBLayers, false);
+		glTexImage2DMultisample(m_textureType, m_msaaSamples, GL_RGBA, m_targetWidth, m_targetHeight, false);
 		glBindTexture(m_textureType, 0);
 
 		// Although we are able to access the multisampled texture directly, we don't do it everywhere.
@@ -181,9 +181,9 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
 		// This will lead to sample shading, but it's the only way to not loose
 		// the values of each sample.
 		sampler =
-			"SAMPLER_BINDING(9) uniform sampler2DMSArray samp9;\n"
+			"SAMPLER_BINDING(9) uniform sampler2DMS samp9;\n"
 			"vec4 sampleEFB(ivec2 pos) {\n"
-			"	return texelFetch(samp9, ivec3(pos, 0), gl_SampleID);\n"
+			"	return texelFetch(samp9, pos, gl_SampleID);\n"
 			"}\n";
 	}
 	else
@@ -192,11 +192,11 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
 		std::stringstream samples;
 		samples << m_msaaSamples;
 		sampler =
-			"SAMPLER_BINDING(9) uniform sampler2DMSArray samp9;\n"
+			"SAMPLER_BINDING(9) uniform sampler2DMS samp9;\n"
 			"vec4 sampleEFB(ivec2 pos) {\n"
 			"	vec4 color = vec4(0.0, 0.0, 0.0, 0.0);\n"
 			"	for(int i=0; i<" + samples.str() + "; i++)\n"
-			"		color += texelFetch(samp9, ivec3(pos, 0), i);\n"
+			"		color += texelFetch(samp9, pos, i);\n"
 			"	return color / " + samples.str() + ";\n"
 			"}\n";
 	}


### PR DESCRIPTION
We don't support stereoscopy for MSAA anyway.

This is an attempt at fixing [Issue 7895](https://code.google.com/p/dolphin-emu/issues/detail?id=7895).
