### PR TITLE
Fix Wiimote speaker divisor for format 0x00

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -97,7 +97,10 @@ void Wiimote::SpeakerData(wm_speaker_data* sd)
 
 		// Following details from http://wiibrew.org/wiki/Wiimote#Speaker
 		sample_rate_dividend = 6000000;
-		volume_divisor = 0x40;
+
+		// 0 - 127
+		// TODO: does it go beyond 127 for format == 0x40?
+		volume_divisor = 0x7F;
 	}
 	else
 	{


### PR DESCRIPTION
Playing with the wiimote volume in the Wii menu in-game, I found that the range for m_reg_speaker.volume is 0 -127, not 0 - 64, for 4-bit ADPCM.
