### PR TITLE
Remove runtime OS X version check.

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -240,18 +240,6 @@ bool DolphinApp::OnInit()
 	wxHandleFatalExceptions(true);
 #endif
 
-#ifdef __APPLE__
-	if (floor(NSAppKitVersionNumber) < NSAppKitVersionNumber10_9)
-	{
-		PanicAlertT("Hi,\n\nDolphin requires Mac OS X 10.9 or greater.\n"
-				"Unfortunately you're running an old version of OS X.\n"
-				"The last Dolphin version to support OS X 10.6 is Dolphin 3.5\n"
-				"Please upgrade to 10.9 or greater to use the newest Dolphin version.\n\n"
-				"Sayonara!\n");
-		return false;
-	}
-#endif
-
 	UICommon::CreateDirectories();
 	UICommon::Init();
 


### PR DESCRIPTION
My recent update to that check broke compilation on 10.9:
https://code.google.com/p/dolphin-emu/issues/detail?id=7900

However, on further review, the check isn't actually necessary.  If the
OS X version is older than LSMinimumSystemVersion in Info.plist, the
system will generally refuse to run the binary in the first place.  You
can try to launch it via a terminal, but at that point it's the user's
problem if it crashes.
