### PR TITLE
DolphinWX: Specify wxID_ANY where -1 is used in controls

### DIFF
--- a/Source/Core/DolphinWX/ARCodeAddEdit.h
+++ b/Source/Core/DolphinWX/ARCodeAddEdit.h
@@ -22,7 +22,7 @@ class CARCodeAddEdit : public wxDialog
 {
 public:
 	CARCodeAddEdit(int _selection, wxWindow* parent,
-		wxWindowID id = 1,
+		wxWindowID id = wxID_ANY,
 		const wxString& title = _("Edit ActionReplay Code"),
 		const wxPoint& pos = wxDefaultPosition,
 		const wxSize& size = wxDefaultSize,

--- a/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
@@ -30,14 +30,14 @@ namespace
 }
 
 CheatSearchTab::CheatSearchTab(wxWindow* const parent)
-	: wxPanel(parent, -1)
+	: wxPanel(parent)
 {
 	// first scan button
-	m_btn_init_scan = new wxButton(this, -1, _("New Scan"));
+	m_btn_init_scan = new wxButton(this, wxID_ANY, _("New Scan"));
 	m_btn_init_scan->Bind(wxEVT_BUTTON, &CheatSearchTab::StartNewSearch, this);
 
 	// next scan button
-	m_btn_next_scan = new wxButton(this, -1, _("Next Scan"));
+	m_btn_next_scan = new wxButton(this, wxID_ANY, _("Next Scan"));
 	m_btn_next_scan->Bind(wxEVT_BUTTON, &CheatSearchTab::FilterCheatSearchResults, this);
 	m_btn_next_scan->Disable();
 
@@ -46,16 +46,16 @@ CheatSearchTab::CheatSearchTab(wxWindow* const parent)
 	m_data_sizes = new wxRadioBox(this, wxID_ANY, _("Data Size"), wxDefaultPosition, wxDefaultSize, static_cast<int>(data_size_names.size()), data_size_names.data());
 
 	// Listbox for search results (shown in monospace font).
-	m_lbox_search_results = new wxListBox(this, -1);
+	m_lbox_search_results = new wxListBox(this, wxID_ANY);
 	wxFont list_font = m_lbox_search_results->GetFont();
 	list_font.SetFamily(wxFONTFAMILY_TELETYPE);
 	m_lbox_search_results->SetFont(list_font);
 
 	// Result count
-	m_label_results_count = new wxStaticText(this, -1, _("Count:"));
+	m_label_results_count = new wxStaticText(this, wxID_ANY, _("Count:"));
 
 	// create AR code button
-	wxButton* const button_cheat_search_copy_address = new wxButton(this, -1, _("Create AR Code"));
+	wxButton* const button_cheat_search_copy_address = new wxButton(this, wxID_ANY, _("Create AR Code"));
 	button_cheat_search_copy_address->Bind(wxEVT_BUTTON, &CheatSearchTab::CreateARCode, this);
 
 	// results groupbox
@@ -65,12 +65,12 @@ CheatSearchTab::CheatSearchTab(wxWindow* const parent)
 	sizer_cheat_search_results->Add(button_cheat_search_copy_address, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
 
 	// Search value radio buttons
-	m_value_x_radiobtn.rad_oldvalue = new wxRadioButton(this, -1, _("Previous Value"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
-	m_value_x_radiobtn.rad_uservalue = new wxRadioButton(this, -1, "");
+	m_value_x_radiobtn.rad_oldvalue = new wxRadioButton(this, wxID_ANY, _("Previous Value"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+	m_value_x_radiobtn.rad_uservalue = new wxRadioButton(this, wxID_ANY, "");
 	m_value_x_radiobtn.rad_oldvalue->SetValue(true);
 
 	// search value textbox
-	m_textctrl_value_x = new wxTextCtrl(this, -1, "0x0", wxDefaultPosition, wxSize(96,-1));
+	m_textctrl_value_x = new wxTextCtrl(this, wxID_ANY, "0x0", wxDefaultPosition, wxSize(96, -1));
 	m_textctrl_value_x->Bind(wxEVT_SET_FOCUS, &CheatSearchTab::ApplyFocus, this);
 
 	wxBoxSizer* const sizer_cheat_filter_text = new wxBoxSizer(wxHORIZONTAL);
@@ -93,7 +93,7 @@ CheatSearchTab::CheatSearchTab(wxWindow* const parent)
 		//_("Between"),
 	};
 
-	m_search_type = new wxChoice(this, -1, wxDefaultPosition, wxDefaultSize, sizeof(searches)/sizeof(*searches), searches);
+	m_search_type = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, sizeof(searches) / sizeof(*searches), searches);
 	m_search_type->Select(0);
 
 	wxStaticBoxSizer* const sizer_cheat_search_filter = new wxStaticBoxSizer(wxVERTICAL, this, _("Search Filter"));

--- a/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
+++ b/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
@@ -21,20 +21,20 @@
 wxDEFINE_EVENT(UPDATE_CHEAT_LIST_EVENT, wxCommandEvent);
 
 CreateCodeDialog::CreateCodeDialog(wxWindow* const parent, const u32 address)
-	: wxDialog(parent, -1, _("Create AR Code"))
+	: wxDialog(parent, wxID_ANY, _("Create AR Code"))
 	, m_code_address(address)
 {
-	wxStaticText* const label_name = new wxStaticText(this, -1, _("Name: "));
-	m_textctrl_name = new wxTextCtrl(this, -1, wxEmptyString, wxDefaultPosition, wxSize(256,-1));
+	wxStaticText* const label_name = new wxStaticText(this, wxID_ANY, _("Name: "));
+	m_textctrl_name = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(256, -1));
 
-	wxStaticText* const label_code = new wxStaticText(this, -1, _("Code: "));
-	m_textctrl_code = new wxTextCtrl(this, -1, wxString::Format("0x%08x", address));
+	wxStaticText* const label_code = new wxStaticText(this, wxID_ANY, _("Code: "));
+	m_textctrl_code = new wxTextCtrl(this, wxID_ANY, wxString::Format("0x%08x", address));
 	m_textctrl_code->Disable();
 
-	wxStaticText* const label_value = new wxStaticText(this, -1, _("Value: "));
-	m_textctrl_value = new wxTextCtrl(this, -1, "0");
+	wxStaticText* const label_value = new wxStaticText(this, wxID_ANY, _("Value: "));
+	m_textctrl_value = new wxTextCtrl(this, wxID_ANY, "0");
 
-	m_checkbox_use_hex = new wxCheckBox(this, -1, _("Use Hex"));
+	m_checkbox_use_hex = new wxCheckBox(this, wxID_ANY, _("Use Hex"));
 	m_checkbox_use_hex->SetValue(true);
 
 	wxBoxSizer* const sizer_value_label = new wxBoxSizer(wxHORIZONTAL);

--- a/Source/Core/DolphinWX/Cheats/GeckoCodeDiag.cpp
+++ b/Source/Core/DolphinWX/Cheats/GeckoCodeDiag.cpp
@@ -38,17 +38,17 @@ static const wxString wxstr_name(wxTRANSLATE("Name: ")),
 	wxstr_creator(wxTRANSLATE("Creator: "));
 
 CodeConfigPanel::CodeConfigPanel(wxWindow* const parent)
-	: wxPanel(parent, -1)
+	: wxPanel(parent)
 {
-	m_listbox_gcodes = new wxCheckListBox(this, -1);
+	m_listbox_gcodes = new wxCheckListBox(this, wxID_ANY);
 	m_listbox_gcodes->Bind(wxEVT_LISTBOX, &CodeConfigPanel::UpdateInfoBox, this);
 	m_listbox_gcodes->Bind(wxEVT_CHECKLISTBOX, &CodeConfigPanel::ToggleCode, this);
 
-	m_infobox.label_name = new wxStaticText(this, -1, wxGetTranslation(wxstr_name));
-	m_infobox.label_creator = new wxStaticText(this, -1, wxGetTranslation(wxstr_creator));
-	m_infobox.label_notes = new wxStaticText(this, -1, wxGetTranslation(wxstr_notes));
-	m_infobox.textctrl_notes = new wxTextCtrl(this, -1, wxEmptyString, wxDefaultPosition, wxSize(64, -1), wxTE_MULTILINE | wxTE_READONLY);
-	m_infobox.listbox_codes = new wxListBox(this, -1, wxDefaultPosition, wxSize(-1, 64));
+	m_infobox.label_name = new wxStaticText(this, wxID_ANY, wxGetTranslation(wxstr_name));
+	m_infobox.label_creator = new wxStaticText(this, wxID_ANY, wxGetTranslation(wxstr_creator));
+	m_infobox.label_notes = new wxStaticText(this, wxID_ANY, wxGetTranslation(wxstr_notes));
+	m_infobox.textctrl_notes = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(64, -1), wxTE_MULTILINE | wxTE_READONLY);
+	m_infobox.listbox_codes = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxSize(-1, 64));
 
 	// TODO: buttons to add/edit codes
 
@@ -62,7 +62,7 @@ CodeConfigPanel::CodeConfigPanel(wxWindow* const parent)
 
 	// button sizer
 	wxBoxSizer* const sizer_buttons = new wxBoxSizer(wxHORIZONTAL);
-	btn_download = new wxButton(this, -1, _("Download Codes (WiiRD Database)"), wxDefaultPosition, wxSize(128, -1));
+	btn_download = new wxButton(this, wxID_ANY, _("Download Codes (WiiRD Database)"), wxDefaultPosition, wxSize(128, -1));
 	btn_download->Enable(false);
 	btn_download->Bind(wxEVT_BUTTON, &CodeConfigPanel::DownloadCodes, this);
 	sizer_buttons->AddStretchSpacer(1);

--- a/Source/Core/DolphinWX/ConfigMain.h
+++ b/Source/Core/DolphinWX/ConfigMain.h
@@ -45,7 +45,7 @@ class CConfigMain : public wxDialog
 public:
 
 	CConfigMain(wxWindow* parent,
-		wxWindowID id = 1,
+		wxWindowID id = wxID_ANY,
 		const wxString& title = _("Dolphin Configuration"),
 		const wxPoint& pos = wxDefaultPosition,
 		const wxSize& size = wxDefaultSize,

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -47,7 +47,7 @@ const std::array<wxString, 7> ControllerConfigDiag::m_gc_pad_type_strs = {{
 }};
 
 ControllerConfigDiag::ControllerConfigDiag(wxWindow* const parent)
-	: wxDialog(parent, -1, _("Dolphin Controller Configuration"))
+	: wxDialog(parent, wxID_ANY, _("Dolphin Controller Configuration"))
 {
 	wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -239,15 +239,15 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateBalanceBoardSizer()
 wxStaticBoxSizer* ControllerConfigDiag::CreateRealWiimoteSizer()
 {
 	// "Real wiimotes" controls
-	wxButton* const refresh_btn = new wxButton(this, -1, _("Refresh"));
+	wxButton* const refresh_btn = new wxButton(this, wxID_ANY, _("Refresh"));
 	refresh_btn->Bind(wxEVT_BUTTON, &ControllerConfigDiag::RefreshRealWiimotes, this);
 
 	wxStaticBoxSizer* const real_wiimotes_group = new wxStaticBoxSizer(wxVERTICAL, this, _("Real Wiimotes"));
 	wxBoxSizer* const real_wiimotes_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 	if (!WiimoteReal::g_wiimote_scanner.IsReady())
-		real_wiimotes_group->Add(new wxStaticText(this, -1, _("A supported bluetooth device could not be found.\n"
-		                                                      "You must manually connect your wiimotes.")), 0, wxALIGN_CENTER | wxALL, 5);
+		real_wiimotes_group->Add(new wxStaticText(this, wxID_ANY, _("A supported bluetooth device could not be found.\n"
+		                                                            "You must manually connect your wiimotes.")), 0, wxALIGN_CENTER | wxALL, 5);
 
 	wxCheckBox* const continuous_scanning = new wxCheckBox(this, wxID_ANY, _("Continuous Scanning"));
 	continuous_scanning->Bind(wxEVT_CHECKBOX, &ControllerConfigDiag::OnContinuousScanning, this);

--- a/Source/Core/DolphinWX/HotkeyDlg.cpp
+++ b/Source/Core/DolphinWX/HotkeyDlg.cpp
@@ -306,7 +306,7 @@ void HotkeyConfigDialog::CreateHotkeyGUIControls()
 
 	for (int j = 0; j < 2; j++)
 	{
-		wxPanel *Page = new wxPanel(Notebook, wxID_ANY);
+		wxPanel *Page = new wxPanel(Notebook);
 		Notebook->AddPage(Page, pageNames[j]);
 
 		wxGridBagSizer *sHotkeys = new wxGridBagSizer();

--- a/Source/Core/DolphinWX/HotkeyDlg.h
+++ b/Source/Core/DolphinWX/HotkeyDlg.h
@@ -28,7 +28,7 @@ class HotkeyConfigDialog : public wxDialog
 {
 public:
 	HotkeyConfigDialog(wxWindow* parent,
-			wxWindowID id = 1,
+			wxWindowID id = wxID_ANY,
 			const wxString &title = _("Hotkey Configuration"),
 			const wxPoint& pos = wxDefaultPosition,
 			const wxSize& size = wxDefaultSize,

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -49,7 +49,7 @@ class CISOProperties : public wxDialog
 public:
 	CISOProperties(const std::string fileName,
 			wxWindow* parent,
-			wxWindowID id = 1,
+			wxWindowID id = wxID_ANY,
 			const wxString& title = _("Properties"),
 			const wxPoint& pos = wxDefaultPosition,
 			const wxSize& size = wxDefaultSize,

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -62,7 +62,7 @@ void GamepadPage::ConfigExtension(wxCommandEvent& event)
 	// show config diag, if "none" isn't selected
 	if (ex->switch_extension)
 	{
-		wxDialog dlg(this, -1,
+		wxDialog dlg(this, wxID_ANY,
 			wxGetTranslation(StrToWxStr(ex->attachments[ex->switch_extension]->GetName())));
 
 		wxBoxSizer* const main_szr = new wxBoxSizer(wxVERTICAL);
@@ -82,7 +82,7 @@ void GamepadPage::ConfigExtension(wxCommandEvent& event)
 }
 
 PadSettingExtension::PadSettingExtension(wxWindow* const parent, ControllerEmu::Extension* const ext)
-	: PadSetting(new wxChoice(parent, -1))
+	: PadSetting(new wxChoice(parent, wxID_ANY))
 	, extension(ext)
 {
 	for (auto& attachment : extension->attachments)
@@ -104,7 +104,7 @@ void PadSettingExtension::UpdateValue()
 }
 
 PadSettingCheckBox::PadSettingCheckBox(wxWindow* const parent, ControllerEmu::ControlGroup::Setting* const _setting)
-	: PadSetting(new wxCheckBox(parent, -1, wxGetTranslation(StrToWxStr(_setting->name))))
+	: PadSetting(new wxCheckBox(parent, wxID_ANY, wxGetTranslation(StrToWxStr(_setting->name))))
 	, setting(_setting)
 {
 	UpdateGUI();
@@ -132,7 +132,7 @@ void PadSettingSpin::UpdateValue()
 }
 
 ControlDialog::ControlDialog(GamepadPage* const parent, InputConfig& config, ControllerInterface::ControlReference* const ref)
-	: wxDialog(parent, -1, _("Configure Control"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+	: wxDialog(parent, wxID_ANY, _("Configure Control"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 	, control_reference(ref)
 	, m_config(config)
 	, m_parent(parent)
@@ -140,8 +140,8 @@ ControlDialog::ControlDialog(GamepadPage* const parent, InputConfig& config, Con
 	m_devq = m_parent->controller->default_device;
 
 	// GetStrings() sounds slow :/
-	//device_cbox = new wxComboBox(this, -1, StrToWxStr(ref->device_qualifier.ToString()), wxDefaultPosition, wxSize(256,-1), parent->device_cbox->GetStrings(), wxTE_PROCESS_ENTER);
-	device_cbox = new wxComboBox(this, -1, StrToWxStr(m_devq.ToString()), wxDefaultPosition, wxSize(256,-1), parent->device_cbox->GetStrings(), wxTE_PROCESS_ENTER);
+	//device_cbox = new wxComboBox(this, wxID_ANY, StrToWxStr(ref->device_qualifier.ToString()), wxDefaultPosition, wxSize(256,-1), parent->device_cbox->GetStrings(), wxTE_PROCESS_ENTER);
+	device_cbox = new wxComboBox(this, wxID_ANY, StrToWxStr(m_devq.ToString()), wxDefaultPosition, wxSize(256, -1), parent->device_cbox->GetStrings(), wxTE_PROCESS_ENTER);
 
 	device_cbox->Bind(wxEVT_COMBOBOX, &ControlDialog::SetDevice, this);
 	device_cbox->Bind(wxEVT_TEXT_ENTER, &ControlDialog::SetDevice, this);
@@ -162,7 +162,7 @@ ControlDialog::ControlDialog(GamepadPage* const parent, InputConfig& config, Con
 }
 
 ControlButton::ControlButton(wxWindow* const parent, ControllerInterface::ControlReference* const _ref, const unsigned int width, const std::string& label)
-: wxButton(parent, -1, "", wxDefaultPosition, wxSize(width,20))
+: wxButton(parent, wxID_ANY, "", wxDefaultPosition, wxSize(width,20))
 , control_reference(_ref)
 {
 	if (label.empty())
@@ -576,22 +576,22 @@ wxStaticBoxSizer* ControlDialog::CreateControlChooser(GamepadPage* const parent)
 {
 	wxStaticBoxSizer* const main_szr = new wxStaticBoxSizer(wxVERTICAL, this, control_reference->is_input ? _("Input") : _("Output"));
 
-	textctrl = new wxTextCtrl(this, -1, wxEmptyString, wxDefaultPosition, wxSize(-1, 48), wxTE_MULTILINE | wxTE_RICH2);
+	textctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(-1, 48), wxTE_MULTILINE | wxTE_RICH2);
 	wxFont font = textctrl->GetFont();
 	font.SetFamily(wxFONTFAMILY_MODERN);
 	textctrl->SetFont(font);
 
-	wxButton* const detect_button = new wxButton(this, -1, control_reference->is_input ? _("Detect") : _("Test"));
+	wxButton* const detect_button = new wxButton(this, wxID_ANY, control_reference->is_input ? _("Detect") : _("Test"));
 
-	wxButton* const clear_button = new  wxButton(this, -1, _("Clear"));
+	wxButton* const clear_button = new  wxButton(this, wxID_ANY, _("Clear"));
 
-	wxButton* const select_button = new wxButton(this, -1, _("Select"));
+	wxButton* const select_button = new wxButton(this, wxID_ANY, _("Select"));
 	select_button->Bind(wxEVT_BUTTON, &ControlDialog::SetSelectedControl, this);
 
-	wxButton* const or_button = new  wxButton(this, -1, _("| OR"));
+	wxButton* const or_button = new  wxButton(this, wxID_ANY, _("| OR"));
 	or_button->Bind(wxEVT_BUTTON, &ControlDialog::AppendControl, this);
 
-	control_lbox = new wxListBox(this, -1, wxDefaultPosition, wxSize(-1, 64));
+	control_lbox = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxSize(-1, 64));
 
 	wxBoxSizer* const button_sizer = new wxBoxSizer(wxVERTICAL);
 	button_sizer->Add(detect_button, 1, 0, 5);
@@ -601,9 +601,9 @@ wxStaticBoxSizer* ControlDialog::CreateControlChooser(GamepadPage* const parent)
 	if (control_reference->is_input)
 	{
 		// TODO: check if && is good on other OS
-		wxButton* const and_button = new  wxButton(this, -1, _("&& AND"));
-		wxButton* const not_button = new  wxButton(this, -1, _("! NOT"));
-		wxButton* const add_button = new  wxButton(this, -1, _("+ ADD"));
+		wxButton* const and_button = new  wxButton(this, wxID_ANY, _("&& AND"));
+		wxButton* const not_button = new  wxButton(this, wxID_ANY, _("! NOT"));
+		wxButton* const add_button = new  wxButton(this, wxID_ANY, _("+ ADD"));
 
 		and_button->Bind(wxEVT_BUTTON, &ControlDialog::AppendControl, this);
 		not_button->Bind(wxEVT_BUTTON, &ControlDialog::AppendControl, this);
@@ -614,7 +614,7 @@ wxStaticBoxSizer* ControlDialog::CreateControlChooser(GamepadPage* const parent)
 		button_sizer->Add(add_button, 1, 0, 5);
 	}
 
-	range_slider = new wxSlider(this, -1, SLIDER_TICK_COUNT, -SLIDER_TICK_COUNT * 5, SLIDER_TICK_COUNT * 5, wxDefaultPosition, wxDefaultSize, wxSL_TOP | wxSL_LABELS /*| wxSL_AUTOTICKS*/);
+	range_slider = new wxSlider(this, wxID_ANY, SLIDER_TICK_COUNT, -SLIDER_TICK_COUNT * 5, SLIDER_TICK_COUNT * 5, wxDefaultPosition, wxDefaultSize, wxSL_TOP | wxSL_LABELS /*| wxSL_AUTOTICKS*/);
 
 	range_slider->SetValue((int)(control_reference->range * SLIDER_TICK_COUNT));
 
@@ -622,10 +622,10 @@ wxStaticBoxSizer* ControlDialog::CreateControlChooser(GamepadPage* const parent)
 	clear_button->Bind(wxEVT_BUTTON, &ControlDialog::ClearControl, this);
 
 	range_slider->Bind(wxEVT_SCROLL_CHANGED, &GamepadPage::AdjustControlOption, parent);
-	wxStaticText* const range_label = new wxStaticText(this, -1, _("Range"));
+	wxStaticText* const range_label = new wxStaticText(this, wxID_ANY, _("Range"));
 
-	m_bound_label = new wxStaticText(this, -1, "");
-	m_error_label = new wxStaticText(this, -1, "");
+	m_bound_label = new wxStaticText(this, wxID_ANY, "");
+	m_error_label = new wxStaticText(this, wxID_ANY, "");
 
 	wxBoxSizer* const range_sizer = new wxBoxSizer(wxHORIZONTAL);
 	range_sizer->Add(range_label, 0, wxCENTER|wxLEFT, 5);
@@ -769,7 +769,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 	wxFont m_SmallFont(7, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
 	for (auto& control : group->controls)
 	{
-		wxStaticText* const label = new wxStaticText(parent, -1, wxGetTranslation(StrToWxStr(control->name)));
+		wxStaticText* const label = new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(control->name)));
 
 		ControlButton* const control_button = new ControlButton(parent, control->control_ref.get(), 80);
 		control_button->SetFont(m_SmallFont);
@@ -815,7 +815,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 			wxBitmap bitmap(64, 64);
 			dc.SelectObject(bitmap);
 			dc.Clear();
-			static_bitmap = new wxStaticBitmap(parent, -1, bitmap, wxDefaultPosition, wxDefaultSize, wxBITMAP_TYPE_BMP);
+			static_bitmap = new wxStaticBitmap(parent, wxID_ANY, bitmap, wxDefaultPosition, wxDefaultSize, wxBITMAP_TYPE_BMP);
 
 			wxBoxSizer* const szr = new wxBoxSizer(wxVERTICAL);
 			for (auto& groupSetting : group->settings)
@@ -823,7 +823,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 				PadSettingSpin* setting = new PadSettingSpin(parent, groupSetting.get());
 				setting->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
 				options.push_back(setting);
-				szr->Add(new wxStaticText(parent, -1, wxGetTranslation(StrToWxStr(groupSetting->name))));
+				szr->Add(new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name))));
 				szr->Add(setting->wxcontrol, 0, wxLEFT, 0);
 			}
 
@@ -839,7 +839,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 			wxBitmap bitmap(int(12*group->controls.size()+1), 12);
 			dc.SelectObject(bitmap);
 			dc.Clear();
-			static_bitmap = new wxStaticBitmap(parent, -1, bitmap, wxDefaultPosition, wxDefaultSize, wxBITMAP_TYPE_BMP);
+			static_bitmap = new wxStaticBitmap(parent, wxID_ANY, bitmap, wxDefaultPosition, wxDefaultSize, wxBITMAP_TYPE_BMP);
 
 			PadSettingSpin* const threshold_cbox = new PadSettingSpin(parent, group->settings[0].get());
 			threshold_cbox->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
@@ -849,7 +849,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 			options.push_back(threshold_cbox);
 
 			wxBoxSizer* const szr = new wxBoxSizer(wxHORIZONTAL);
-			szr->Add(new wxStaticText(parent, -1, wxGetTranslation(StrToWxStr(group->settings[0]->name))),
+			szr->Add(new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(group->settings[0]->name))),
 					0, wxCENTER|wxRIGHT, 3);
 			szr->Add(threshold_cbox->wxcontrol, 0, wxRIGHT, 3);
 
@@ -873,7 +873,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 			wxBitmap bitmap(width, height+1);
 			dc.SelectObject(bitmap);
 			dc.Clear();
-			static_bitmap = new wxStaticBitmap(parent, -1, bitmap, wxDefaultPosition, wxDefaultSize, wxBITMAP_TYPE_BMP);
+			static_bitmap = new wxStaticBitmap(parent, wxID_ANY, bitmap, wxDefaultPosition, wxDefaultSize, wxBITMAP_TYPE_BMP);
 
 			for (auto& groupSetting : group->settings)
 			{
@@ -881,7 +881,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 				setting->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
 				options.push_back(setting);
 				wxBoxSizer* const szr = new wxBoxSizer(wxHORIZONTAL);
-				szr->Add(new wxStaticText(parent, -1, wxGetTranslation(StrToWxStr(groupSetting->name))), 0, wxCENTER|wxRIGHT, 3);
+				szr->Add(new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name))), 0, wxCENTER | wxRIGHT, 3);
 				szr->Add(setting->wxcontrol, 0, wxRIGHT, 3);
 				Add(szr, 0, wxALL|wxCENTER, 3);
 			}
@@ -929,7 +929,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 					setting->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
 					options.push_back(setting);
 					wxBoxSizer* const szr = new wxBoxSizer(wxHORIZONTAL);
-					szr->Add(new wxStaticText(parent, -1, wxGetTranslation(StrToWxStr(groupSetting->name))), 0, wxCENTER | wxRIGHT, 3);
+					szr->Add(new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name))), 0, wxCENTER | wxRIGHT, 3);
 					szr->Add(setting->wxcontrol, 0, wxRIGHT, 3);
 					Add(szr, 0, wxALL | wxCENTER, 3);
 				}
@@ -996,10 +996,10 @@ GamepadPage::GamepadPage(wxWindow* parent, InputConfig& config, const unsigned i
 
 	wxStaticBoxSizer* const device_sbox = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Device"));
 
-	device_cbox = new wxComboBox(this, -1, "", wxDefaultPosition, wxSize(64,-1));
+	device_cbox = new wxComboBox(this, wxID_ANY, "", wxDefaultPosition, wxSize(64, -1));
 	device_cbox->ToggleWindowStyle(wxTE_PROCESS_ENTER);
 
-	wxButton* refresh_button = new wxButton(this, -1, _("Refresh"), wxDefaultPosition, wxSize(60,-1));
+	wxButton* refresh_button = new wxButton(this, wxID_ANY, _("Refresh"), wxDefaultPosition, wxSize(60, -1));
 
 	device_cbox->Bind(wxEVT_COMBOBOX, &GamepadPage::SetDevice, this);
 	device_cbox->Bind(wxEVT_TEXT_ENTER, &GamepadPage::SetDevice, this);
@@ -1008,8 +1008,8 @@ GamepadPage::GamepadPage(wxWindow* parent, InputConfig& config, const unsigned i
 	device_sbox->Add(device_cbox, 1, wxLEFT|wxRIGHT, 3);
 	device_sbox->Add(refresh_button, 0, wxRIGHT|wxBOTTOM, 3);
 
-	wxButton* const default_button = new wxButton(this, -1, _("Default"), wxDefaultPosition, wxSize(48,-1));
-	wxButton* const clearall_button = new wxButton(this, -1, _("Clear"), wxDefaultPosition, wxSize(58,-1));
+	wxButton* const default_button = new wxButton(this, wxID_ANY, _("Default"), wxDefaultPosition, wxSize(48, -1));
+	wxButton* const clearall_button = new wxButton(this, wxID_ANY, _("Clear"), wxDefaultPosition, wxSize(58, -1));
 
 	wxStaticBoxSizer* const clear_sbox = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Reset"));
 	clear_sbox->Add(default_button, 1, wxLEFT, 3);
@@ -1018,11 +1018,11 @@ GamepadPage::GamepadPage(wxWindow* parent, InputConfig& config, const unsigned i
 	clearall_button->Bind(wxEVT_BUTTON, &GamepadPage::ClearAll, this);
 	default_button->Bind(wxEVT_BUTTON, &GamepadPage::LoadDefaults, this);
 
-	profile_cbox = new wxComboBox(this, -1, "", wxDefaultPosition, wxSize(64,-1));
+	profile_cbox = new wxComboBox(this, wxID_ANY, "", wxDefaultPosition, wxSize(64, -1));
 
-	wxButton* const pload_btn = new wxButton(this, -1, _("Load"), wxDefaultPosition, wxSize(48,-1));
-	wxButton* const psave_btn = new wxButton(this, -1, _("Save"), wxDefaultPosition, wxSize(48,-1));
-	wxButton* const pdelete_btn = new wxButton(this, -1, _("Delete"), wxDefaultPosition, wxSize(60,-1));
+	wxButton* const pload_btn = new wxButton(this, wxID_ANY, _("Load"), wxDefaultPosition, wxSize(48, -1));
+	wxButton* const psave_btn = new wxButton(this, wxID_ANY, _("Save"), wxDefaultPosition, wxSize(48, -1));
+	wxButton* const pdelete_btn = new wxButton(this, wxID_ANY, _("Delete"), wxDefaultPosition, wxSize(60, -1));
 
 	pload_btn->Bind(wxEVT_BUTTON, &GamepadPage::LoadProfile, this);
 	psave_btn->Bind(wxEVT_BUTTON, &GamepadPage::SaveProfile, this);
@@ -1054,7 +1054,7 @@ InputConfigDialog::InputConfigDialog(wxWindow* const parent, InputConfig& config
 	: wxDialog(parent, wxID_ANY, name, wxPoint(128,-1))
 	, m_config(config)
 {
-	m_pad_notebook = new wxNotebook(this, -1, wxDefaultPosition, wxDefaultSize, wxNB_DEFAULT);
+	m_pad_notebook = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_DEFAULT);
 	for (unsigned int i = 0; i < std::min(config.controllers.size(), (size_t)MAX_WIIMOTES); ++i)
 	{
 		GamepadPage* gp = new GamepadPage(m_pad_notebook, m_config, i, this);
@@ -1077,7 +1077,7 @@ InputConfigDialog::InputConfigDialog(wxWindow* const parent, InputConfig& config
 	Center();
 
 	// live preview update timer
-	m_update_timer = new wxTimer(this, -1);
+	m_update_timer = new wxTimer(this);
 	Bind(wxEVT_TIMER, &InputConfigDialog::UpdateBitmaps, this);
 	m_update_timer->Start(PREVIEW_UPDATE_TIME, wxTIMER_CONTINUOUS);
 }

--- a/Source/Core/DolphinWX/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/InputConfigDiag.h
@@ -71,7 +71,7 @@ class PadSettingSpin : public PadSetting
 {
 public:
 	PadSettingSpin(wxWindow* const parent, ControllerEmu::ControlGroup::Setting* const _setting)
-		: PadSetting(new wxSpinCtrl(parent, -1, wxEmptyString, wxDefaultPosition,
+		: PadSetting(new wxSpinCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition,
 					    wxSize(54, -1), 0, _setting->low, _setting->high, (int)(_setting->value * 100)))
 		, setting(_setting) {}
 
@@ -133,7 +133,7 @@ class ExtensionButton : public wxButton
 {
 public:
 	ExtensionButton(wxWindow* const parent, ControllerEmu::Extension* const ext)
-		: wxButton(parent, -1, _("Configure"), wxDefaultPosition)
+		: wxButton(parent, wxID_ANY, _("Configure"), wxDefaultPosition)
 		, extension(ext) {}
 
 	ControllerEmu::Extension* const extension;

--- a/Source/Core/DolphinWX/PatchAddEdit.h
+++ b/Source/Core/DolphinWX/PatchAddEdit.h
@@ -26,7 +26,7 @@ class CPatchAddEdit : public wxDialog
 {
 public:
 	CPatchAddEdit(int _selection, wxWindow* parent,
-		wxWindowID id = 1,
+		wxWindowID id = wxID_ANY,
 		const wxString& title = _("Edit Patch"),
 		const wxPoint& pos = wxDefaultPosition,
 		const wxSize& size = wxDefaultSize,

--- a/Source/Core/DolphinWX/PostProcessingConfigDiag.cpp
+++ b/Source/Core/DolphinWX/PostProcessingConfigDiag.cpp
@@ -20,7 +20,7 @@
 #include "VideoCommon/RenderBase.h"
 
 PostProcessingConfigDiag::PostProcessingConfigDiag(wxWindow* parent, const std::string& shader)
-	: wxDialog(parent, -1,
+	: wxDialog(parent, wxID_ANY,
 		wxString::Format(_("Post Processing Shader Configuration"))),
 	  m_shader(shader)
 {
@@ -73,8 +73,8 @@ PostProcessingConfigDiag::PostProcessingConfigDiag(wxWindow* parent, const std::
 	}
 
 	// Generate our UI
-	wxNotebook* const notebook = new wxNotebook(this, -1);
-	wxPanel* const page_general = new wxPanel(notebook, -1);
+	wxNotebook* const notebook = new wxNotebook(this, wxID_ANY);
+	wxPanel* const page_general = new wxPanel(notebook);
 	wxFlexGridSizer* const szr_general = new wxFlexGridSizer(2, 5, 5);
 
 	// Now let's actually populate our window with our information
@@ -84,7 +84,7 @@ PostProcessingConfigDiag::PostProcessingConfigDiag(wxWindow* parent, const std::
 		if (it->HasChildren())
 		{
 			// Options with children get their own tab
-			wxPanel* const page_option = new wxPanel(notebook, -1);
+			wxPanel* const page_option = new wxPanel(notebook);
 			wxFlexGridSizer* const szr_option = new wxFlexGridSizer(2, 10, 5);
 			it->GenerateUI(this, page_option, szr_option);
 

--- a/Source/Core/DolphinWX/SoftwareVideoConfigDialog.cpp
+++ b/Source/Core/DolphinWX/SoftwareVideoConfigDialog.cpp
@@ -22,7 +22,7 @@
 
 template <typename T>
 IntegerSetting<T>::IntegerSetting(wxWindow* parent, const wxString& label, T& setting, int minVal, int maxVal, long style) :
-	wxSpinCtrl(parent, -1, label, wxDefaultPosition, wxDefaultSize, style),
+	wxSpinCtrl(parent, wxID_ANY, label, wxDefaultPosition, wxDefaultSize, style),
 	m_setting(setting)
 {
 	SetRange(minVal, maxVal);
@@ -32,18 +32,18 @@ IntegerSetting<T>::IntegerSetting(wxWindow* parent, const wxString& label, T& se
 
 
 SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std::string& title, const std::string& _ininame) :
-	wxDialog(parent, -1,
+	wxDialog(parent, wxID_ANY,
 	wxString(wxString::Format(_("Dolphin %s Graphics Configuration"), title))),
 	vconfig(g_SWVideoConfig),
 	ininame(_ininame)
 {
 	vconfig.Load((File::GetUserPath(D_CONFIG_IDX) + ininame + ".ini").c_str());
 
-	wxNotebook* const notebook = new wxNotebook(this, -1);
+	wxNotebook* const notebook = new wxNotebook(this, wxID_ANY);
 
 	// -- GENERAL --
 	{
-	wxPanel* const page_general= new wxPanel(notebook, -1);
+	wxPanel* const page_general= new wxPanel(notebook);
 	notebook->AddPage(page_general, _("General"));
 	wxBoxSizer* const szr_general = new wxBoxSizer(wxVERTICAL);
 

--- a/Source/Core/DolphinWX/TASInputDlg.h
+++ b/Source/Core/DolphinWX/TASInputDlg.h
@@ -29,7 +29,7 @@ class TASInputDlg : public wxDialog
 {
 	public:
 		TASInputDlg(wxWindow* parent,
-		            wxWindowID id = 1,
+		            wxWindowID id = wxID_ANY,
 		            const wxString& title = _("TAS Input"),
 		            const wxPoint& pos = wxDefaultPosition,
 		            const wxSize& size = wxDefaultSize,

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -50,7 +50,7 @@ template class BoolSetting<wxRadioButton>;
 
 template <>
 SettingCheckBox::BoolSetting(wxWindow* parent, const wxString& label, const wxString& tooltip, bool &setting, bool reverse, long style)
-	: wxCheckBox(parent, -1, label, wxDefaultPosition, wxDefaultSize, style)
+	: wxCheckBox(parent, wxID_ANY, label, wxDefaultPosition, wxDefaultSize, style)
 	, m_setting(setting)
 	, m_reverse(reverse)
 {
@@ -61,7 +61,7 @@ SettingCheckBox::BoolSetting(wxWindow* parent, const wxString& label, const wxSt
 
 template <>
 SettingRadioButton::BoolSetting(wxWindow* parent, const wxString& label, const wxString& tooltip, bool &setting, bool reverse, long style)
-	: wxRadioButton(parent, -1, label, wxDefaultPosition, wxDefaultSize, style)
+	: wxRadioButton(parent, wxID_ANY, label, wxDefaultPosition, wxDefaultSize, style)
 	, m_setting(setting)
 	, m_reverse(reverse)
 {
@@ -71,7 +71,7 @@ SettingRadioButton::BoolSetting(wxWindow* parent, const wxString& label, const w
 }
 
 SettingChoice::SettingChoice(wxWindow* parent, int &setting, const wxString& tooltip, int num, const wxString choices[], long style)
-	: wxChoice(parent, -1, wxDefaultPosition, wxDefaultSize, num, choices)
+	: wxChoice(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, num, choices)
 	, m_setting(setting)
 {
 	SetToolTip(tooltip);
@@ -219,7 +219,7 @@ static wxArrayString GetListOfResolutions()
 #endif
 
 VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, const std::string& _ininame)
-	: wxDialog(parent, -1,
+	: wxDialog(parent, wxID_ANY,
 		wxString::Format(_("Dolphin %s Graphics Configuration"), wxGetTranslation(StrToWxStr(title))))
 	, vconfig(g_Config)
 	, ininame(_ininame)
@@ -228,11 +228,11 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	Bind(wxEVT_UPDATE_UI, &VideoConfigDiag::OnUpdateUI, this);
 
-	wxNotebook* const notebook = new wxNotebook(this, -1);
+	wxNotebook* const notebook = new wxNotebook(this, wxID_ANY);
 
 	// -- GENERAL --
 	{
-	wxPanel* const page_general = new wxPanel(notebook, -1);
+	wxPanel* const page_general = new wxPanel(notebook);
 	notebook->AddPage(page_general, _("General"));
 	wxBoxSizer* const szr_general = new wxBoxSizer(wxVERTICAL);
 
@@ -303,7 +303,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	{
 	const wxString ar_choices[] = { _("Auto"), _("Force 16:9"), _("Force 4:3"), _("Stretch to Window") };
 
-	szr_display->Add(new wxStaticText(page_general, -1, _("Aspect Ratio:")), 1, wxALIGN_CENTER_VERTICAL, 0);
+	szr_display->Add(new wxStaticText(page_general, wxID_ANY, _("Aspect Ratio:")), 1, wxALIGN_CENTER_VERTICAL, 0);
 	wxChoice* const choice_aspect = CreateChoice(page_general, vconfig.iAspectRatio, wxGetTranslation(ar_desc),
 														sizeof(ar_choices)/sizeof(*ar_choices), ar_choices);
 	szr_display->Add(choice_aspect, 1, 0, 0);
@@ -349,7 +349,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	// -- ENHANCEMENTS --
 	{
-	wxPanel* const page_enh = new wxPanel(notebook, -1);
+	wxPanel* const page_enh = new wxPanel(notebook);
 	notebook->AddPage(page_enh, _("Enhancements"));
 	wxBoxSizer* const szr_enh_main = new wxBoxSizer(wxVERTICAL);
 
@@ -376,7 +376,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	// AA
 	{
-	text_aamode = new wxStaticText(page_enh, -1, _("Anti-Aliasing:"));
+	text_aamode = new wxStaticText(page_enh, wxID_ANY, _("Anti-Aliasing:"));
 	choice_aamode = CreateChoice(page_enh, vconfig.iMultisampleMode, wxGetTranslation(aa_desc));
 
 	for (const std::string& mode : vconfig.backend_info.AAModes)
@@ -392,7 +392,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	// AF
 	{
 	const wxString af_choices[] = {"1x", "2x", "4x", "8x", "16x"};
-	szr_enh->Add(new wxStaticText(page_enh, -1, _("Anisotropic Filtering:")), 1, wxALIGN_CENTER_VERTICAL, 0);
+	szr_enh->Add(new wxStaticText(page_enh, wxID_ANY, _("Anisotropic Filtering:")), 1, wxALIGN_CENTER_VERTICAL, 0);
 	szr_enh->Add(CreateChoice(page_enh, vconfig.iMaxAnisotropy, wxGetTranslation(af_desc), 5, af_choices));
 	}
 
@@ -400,7 +400,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	if (vconfig.backend_info.PPShaders.size())
 	{
 		wxFlexGridSizer* const szr_pp = new wxFlexGridSizer(3, 5, 5);
-		choice_ppshader = new wxChoice(page_enh, -1);
+		choice_ppshader = new wxChoice(page_enh, wxID_ANY);
 		RegisterControl(choice_ppshader, wxGetTranslation(ppshader_desc));
 		choice_ppshader->AppendString(_("(off)"));
 
@@ -424,7 +424,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 		choice_ppshader->Bind(wxEVT_CHOICE, &VideoConfigDiag::Event_PPShader, this);
 		button_config_pp->Bind(wxEVT_BUTTON, &VideoConfigDiag::Event_ConfigurePPShader, this);
 
-		szr_enh->Add(new wxStaticText(page_enh, -1, _("Post-Processing Effect:")), 1, wxALIGN_CENTER_VERTICAL, 0);
+		szr_enh->Add(new wxStaticText(page_enh, wxID_ANY, _("Post-Processing Effect:")), 1, wxALIGN_CENTER_VERTICAL, 0);
 		szr_pp->Add(choice_ppshader);
 		szr_pp->Add(button_config_pp);
 		szr_enh->Add(szr_pp);
@@ -454,7 +454,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 		wxFlexGridSizer* const szr_stereo = new wxFlexGridSizer(2, 5, 5);
 
 		const wxString stereo_choices[] = { "Off", "Side-by-Side", "Top-and-Bottom", "Anaglyph" };
-		szr_stereo->Add(new wxStaticText(page_enh, -1, _("Stereoscopic 3D Mode:")), 1, wxALIGN_CENTER_VERTICAL, 0);
+		szr_stereo->Add(new wxStaticText(page_enh, wxID_ANY, _("Stereoscopic 3D Mode:")), 1, wxALIGN_CENTER_VERTICAL, 0);
 		szr_stereo->Add(CreateChoice(page_enh, vconfig.iStereoMode, wxGetTranslation(stereo_3d_desc), 4, stereo_choices));
 
 		wxSlider* const sep_slider = new wxSlider(page_enh, wxID_ANY, vconfig.iStereoSeparation, 0, 100, wxDefaultPosition, wxDefaultSize);
@@ -486,7 +486,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	// -- SPEED HACKS --
 	{
-	wxPanel* const page_hacks = new wxPanel(notebook, -1);
+	wxPanel* const page_hacks = new wxPanel(notebook);
 	notebook->AddPage(page_hacks, _("Hacks"));
 	wxBoxSizer* const szr_hacks = new wxBoxSizer(wxVERTICAL);
 
@@ -567,7 +567,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	// -- ADVANCED --
 	{
-	wxPanel* const page_advanced = new wxPanel(notebook, -1);
+	wxPanel* const page_advanced = new wxPanel(notebook);
 	notebook->AddPage(page_advanced, _("Advanced"));
 	wxBoxSizer* const szr_advanced = new wxBoxSizer(wxVERTICAL);
 


### PR DESCRIPTION
Both are synonyms for one another, but wxID_ANY is more descriptive. Some cases where 1 was used were also changed over (form instantiations) because these aren't needed, and were just cargo-culted around during the UI's history, it seems.
