### PR TITLE
JIT: fix profiler call

### DIFF
--- a/Source/Core/Core/PowerPC/Profiler.h
+++ b/Source/Core/Core/PowerPC/Profiler.h
@@ -16,7 +16,7 @@
 
 #define PROFILER_QUERY_PERFORMANCE_COUNTER(pt) \
 	MOV(64, R(ABI_PARAM1), Imm64((u64) pt)); \
-	CALL((const void*) QueryPerformanceCounter)
+	ABI_CallFunction((const void*) QueryPerformanceCounter)
 
 // block->ticCounter += block->ticStop - block->ticStart
 #define PROFILER_UPDATE_TIME(block) \


### PR DESCRIPTION
Sometimes this seems to require a 64-bit offset, so use CallFunction instead
