### PR TITLE
Fix register usage detection in PPCAnalyst.

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
@@ -66,8 +66,8 @@ static GekkoOPTemplate primarytable[] =
 	{38, Interpreter::stb,          {"stb",  OPTYPE_STORE, FL_IN_A | FL_IN_S | FL_LOADSTORE, 1, 0, 0, 0}},
 	{39, Interpreter::stbu,         {"stbu", OPTYPE_STORE, FL_OUT_A | FL_IN_A | FL_IN_S | FL_LOADSTORE, 1, 0, 0, 0}},
 
-	{46, Interpreter::lmw,          {"lmw",   OPTYPE_SYSTEM, FL_EVIL | FL_LOADSTORE, 11, 0, 0, 0}},
-	{47, Interpreter::stmw,         {"stmw",  OPTYPE_SYSTEM, FL_EVIL | FL_LOADSTORE, 11, 0, 0, 0}},
+	{46, Interpreter::lmw,          {"lmw",   OPTYPE_SYSTEM, FL_EVIL | FL_IN_A0 | FL_LOADSTORE, 11, 0, 0, 0}},
+	{47, Interpreter::stmw,         {"stmw",  OPTYPE_SYSTEM, FL_EVIL | FL_IN_A0 | FL_LOADSTORE, 11, 0, 0, 0}},
 
 	{48, Interpreter::lfs,          {"lfs",  OPTYPE_LOADFP, FL_OUT_FLOAT_D | FL_IN_A | FL_USE_FPU | FL_LOADSTORE, 1, 0, 0, 0}},
 	{49, Interpreter::lfsu,         {"lfsu", OPTYPE_LOADFP, FL_OUT_FLOAT_D | FL_OUT_A | FL_IN_A | FL_USE_FPU | FL_LOADSTORE, 1, 0, 0, 0}},
@@ -190,7 +190,7 @@ static GekkoOPTemplate table31[] =
 	{278,  Interpreter::dcbt,       {"dcbt",   OPTYPE_DCACHE, 0, 2, 0, 0, 0}},
 	{470,  Interpreter::dcbi,       {"dcbi",   OPTYPE_DCACHE, 0, 5, 0, 0, 0}},
 	{758,  Interpreter::dcba,       {"dcba",   OPTYPE_DCACHE, 0, 5, 0, 0, 0}},
-	{1014, Interpreter::dcbz,       {"dcbz",   OPTYPE_DCACHE, FL_LOADSTORE, 5, 0, 0, 0}},
+	{1014, Interpreter::dcbz,       {"dcbz",   OPTYPE_DCACHE, FL_IN_A0B | FL_LOADSTORE, 5, 0, 0, 0}},
 
 	//load word
 	{23,  Interpreter::lwzx,        {"lwzx",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A0B | FL_LOADSTORE, 1, 0, 0, 0}},

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -560,6 +560,22 @@ void PPCAnalyzer::SetInstructionStats(CodeBlock *block, CodeOp *code, GekkoOPInf
 		code->regsIn[code->inst.RS] = true;
 		block->m_gpa->SetInputRegister(code->inst.RS, index);
 	}
+	if (code->inst.OPCD == 46) // lmw
+	{
+		for (int iReg = code->inst.RD; iReg < 32; ++iReg)
+		{
+			code->regsOut[iReg] = true;
+			block->m_gpa->SetOutputRegister(iReg, index);
+		}
+	}
+	else if (code->inst.OPCD == 47) //stmw
+	{
+		for (int iReg = code->inst.RS; iReg < 32; ++iReg)
+		{
+			code->regsIn[iReg] = true;
+			block->m_gpa->SetInputRegister(iReg, index);
+		}
+	}
 
 	code->fregOut = -1;
 	if (opinfo->flags & FL_OUT_FLOAT_D)


### PR DESCRIPTION
lmw/stmw weren't properly setting input and output registers since they use multiple registers.
dcbz was just missing a flag in the instruction tables.
