### PR TITLE
Moved projection epsilon back to g_fProjectionMatrix[15]

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -87,7 +87,7 @@ static float PHackValue(std::string sValue)
 
 void UpdateProjectionHack(int iPhackvalue[], std::string sPhackvalue[])
 {
-	float fhackvalue1 = 0, fhackvalue2 = FLT_EPSILON; // hack to fix depth clipping precision issues (such as Sonic Unleashed UI)
+	float fhackvalue1 = 0, fhackvalue2 = 0;
 	float fhacksign1 = 1.0, fhacksign2 = 1.0;
 	const char *sTemp[2];
 
@@ -475,7 +475,7 @@ void VertexShaderManager::SetConstants()
 			g_fProjectionMatrix[13] = 0.0f;
 
 			g_fProjectionMatrix[14] = 0.0f;
-			g_fProjectionMatrix[15] = 1.0f;
+			g_fProjectionMatrix[15] = 1.0f + FLT_EPSILON; // hack to fix depth clipping precision issues (such as Sonic Unleashed UI)
 
 			SETSTAT_FT(stats.g2proj_0, g_fProjectionMatrix[0]);
 			SETSTAT_FT(stats.g2proj_1, g_fProjectionMatrix[1]);


### PR DESCRIPTION
... which essentially scales vertices instead of just biasing. 
Simple bias seems to break quite a lot of games, reported in https://github.com/dolphin-emu/dolphin/pull/1366.
