### PR TITLE
Common: Remove locale based functions from CommonFuncs.

### DIFF
--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -15,7 +15,6 @@
 #include <libkern/OSByteOrder.h>
 #endif
 
-#include <clocale>
 #include <cstddef>
 #include <type_traits>
 #include "Common/CommonTypes.h"
@@ -108,45 +107,6 @@ inline u64 _rotr64(u64 x, unsigned int shift)
 	#define unlink _unlink
 	#define snprintf _snprintf
 	#define vscprintf _vscprintf
-
-// Locale Cross-Compatibility
-	#define locale_t _locale_t
-	#define freelocale _free_locale
-	#define newlocale(mask, locale, base) _create_locale(mask, locale)
-
-	#define LC_GLOBAL_LOCALE    ((locale_t)-1)
-	#define LC_ALL_MASK         LC_ALL
-	#define LC_COLLATE_MASK     LC_COLLATE
-	#define LC_CTYPE_MASK       LC_CTYPE
-	#define LC_MONETARY_MASK    LC_MONETARY
-	#define LC_NUMERIC_MASK     LC_NUMERIC
-	#define LC_TIME_MASK        LC_TIME
-
-	inline locale_t uselocale(locale_t new_locale)
-	{
-		// Retrieve the current per thread locale setting
-		bool bIsPerThread = (_configthreadlocale(0) == _ENABLE_PER_THREAD_LOCALE);
-
-		// Retrieve the current thread-specific locale
-		locale_t old_locale = bIsPerThread ? _get_current_locale() : LC_GLOBAL_LOCALE;
-
-		if (new_locale == LC_GLOBAL_LOCALE)
-		{
-			// Restore the global locale
-			_configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
-		}
-		else if (new_locale != nullptr)
-		{
-			// Configure the thread to set the locale only for this thread
-			_configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
-
-			// Set all locale categories
-			for (int i = LC_MIN; i <= LC_MAX; i++)
-				setlocale(i, new_locale->locinfo->lc_category[i].locale);
-		}
-
-		return old_locale;
-	}
 
 // 64 bit offsets for windows
 	#define fseeko _fseeki64

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -72,7 +72,7 @@ bool CharArrayFromFormatV(char* out, int outsize, const char* format, va_list ar
 	// will be present in the middle of a multibyte sequence.
 	//
 	// This is why we lookup an ANSI (cp1252) locale here and use _vsnprintf_l.
-	static locale_t c_locale = nullptr;
+	static _locale_t c_locale = nullptr;
 	if (!c_locale)
 		c_locale = _create_locale(LC_ALL, ".1252");
 	writtenCount = _vsnprintf_l(out, outsize, format, c_locale, args);

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -3,10 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
-#include <locale.h>
-#ifdef __APPLE__
-	#include <xlocale.h>
-#endif
 
 #include "VideoCommon/GeometryShaderGen.h"
 #include "VideoCommon/LightingShaderGen.h"
@@ -26,15 +22,6 @@ static inline void GenerateGeometryShader(T& out, u32 components, API_TYPE ApiTy
 
 	out.SetBuffer(text);
 	const bool is_writing_shadercode = (out.GetBuffer() != nullptr);
-#ifndef ANDROID
-	locale_t locale;
-	locale_t old_locale;
-	if (is_writing_shadercode)
-	{
-		locale = newlocale(LC_NUMERIC_MASK, "C", nullptr); // New locale for compilation
-		old_locale = uselocale(locale); // Apply the locale for this thread
-	}
-#endif
 
 	if (is_writing_shadercode)
 		text[sizeof(text) - 1] = 0x7C;  // canary
@@ -115,11 +102,6 @@ static inline void GenerateGeometryShader(T& out, u32 components, API_TYPE ApiTy
 	{
 		if (text[sizeof(text) - 1] != 0x7C)
 			PanicAlert("GeometryShader generator - buffer too small, canary has been eaten!");
-
-#ifndef ANDROID
-		uselocale(old_locale); // restore locale
-		freelocale(locale);
-#endif
 	}
 }
 

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -5,10 +5,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstdio>
-#include <locale.h>
-#ifdef __APPLE__
-	#include <xlocale.h>
-#endif
 
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/BPMemory.h"
@@ -160,15 +156,6 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 
 	out.SetBuffer(text);
 	const bool is_writing_shadercode = (out.GetBuffer() != nullptr);
-#ifndef ANDROID
-	locale_t locale;
-	locale_t old_locale;
-	if (is_writing_shadercode)
-	{
-		locale = newlocale(LC_NUMERIC_MASK, "C", nullptr); // New locale for compilation
-		old_locale = uselocale(locale); // Apply the locale for this thread
-	}
-#endif
 
 	if (is_writing_shadercode)
 		text[sizeof(text) - 1] = 0x7C;  // canary
@@ -596,11 +583,6 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	{
 		if (text[sizeof(text) - 1] != 0x7C)
 			PanicAlert("PixelShader generator - buffer too small, canary has been eaten!");
-
-#ifndef ANDROID
-		uselocale(old_locale); // restore locale
-		freelocale(locale);
-#endif
 	}
 }
 

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -4,10 +4,6 @@
 
 #include <cmath>
 #include <cstdio>
-#include <locale.h>
-#ifdef __APPLE__
-	#include <xlocale.h>
-#endif
 
 #include "Common/MathUtil.h"
 #include "VideoCommon/BPMemory.h"
@@ -579,10 +575,6 @@ static void WriteZ24Encoder(char*& p, API_TYPE ApiType)
 
 const char *GenerateEncodingShader(u32 format,API_TYPE ApiType)
 {
-#ifndef ANDROID
-	locale_t locale = newlocale(LC_NUMERIC_MASK, "C", nullptr); // New locale for compilation
-	locale_t old_locale = uselocale(locale); // Apply the locale for this thread
-#endif
 	text[sizeof(text) - 1] = 0x7C;  // canary
 
 	char *p = text;
@@ -666,10 +658,6 @@ const char *GenerateEncodingShader(u32 format,API_TYPE ApiType)
 	if (text[sizeof(text) - 1] != 0x7C)
 		PanicAlert("TextureConversionShader generator - buffer too small, canary has been eaten!");
 
-#ifndef ANDROID
-	uselocale(old_locale); // restore locale
-	freelocale(locale);
-#endif
 	return text;
 }
 

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -3,10 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
-#include <locale.h>
-#ifdef __APPLE__
-	#include <xlocale.h>
-#endif
 
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/CPMemory.h"
@@ -66,15 +62,6 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 
 	out.SetBuffer(text);
 	const bool is_writing_shadercode = (out.GetBuffer() != nullptr);
-#ifndef ANDROID
-	locale_t locale;
-	locale_t old_locale;
-	if (is_writing_shadercode)
-	{
-		locale = newlocale(LC_NUMERIC_MASK, "C", nullptr); // New locale for compilation
-		old_locale = uselocale(locale); // Apply the locale for this thread
-	}
-#endif
 
 	if (is_writing_shadercode)
 		text[sizeof(text) - 1] = 0x7C;  // canary
@@ -465,11 +452,6 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 	{
 		if (text[sizeof(text) - 1] != 0x7C)
 			PanicAlert("VertexShader generator - buffer too small, canary has been eaten!");
-
-#ifndef ANDROID
-		uselocale(old_locale); // restore locale
-		freelocale(locale);
-#endif
 	}
 }
 


### PR DESCRIPTION
Since %f isn't used anymore in the shader generators, these can go.
