### PR TITLE
JIT: fix possible panicalert in loadstore

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -167,7 +167,8 @@ void Jit64::lXXx(UGeckoInstruction inst)
 	{
 		if (inst.OPCD == 31)
 		{
-			gpr.Lock(b);
+			if (!gpr.R(b).IsImm())
+				gpr.BindToRegister(b, true, false);
 			opAddress = gpr.R(b);
 		}
 		else


### PR DESCRIPTION
Didn't bind address register tcorrectly in a very rare case.
