### PR TITLE
FIFO: allocate slightly more for SIMD vertex loader overreads

### DIFF
--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -94,7 +94,8 @@ void Fifo_PauseAndLock(bool doLock, bool unpauseOnUnlock)
 
 void Fifo_Init()
 {
-	s_video_buffer = (u8*)AllocateMemoryPages(FIFO_SIZE);
+	// Padded so that SIMD overreads in the vertex loader are safe
+	s_video_buffer = (u8*)AllocateMemoryPages(FIFO_SIZE + 4);
 	ResetVideoBuffer();
 	GpuRunningState = false;
 	Common::AtomicStore(CommandProcessor::VITicks, CommandProcessor::m_cpClockOrigin);
@@ -103,7 +104,7 @@ void Fifo_Init()
 void Fifo_Shutdown()
 {
 	if (GpuRunningState) PanicAlert("Fifo shutting down while active");
-	FreeMemoryPages(s_video_buffer, FIFO_SIZE);
+	FreeMemoryPages(s_video_buffer, FIFO_SIZE + 4);
 	s_video_buffer = nullptr;
 	s_video_buffer_write_ptr = nullptr;
 	s_video_buffer_pp_read_ptr = nullptr;


### PR DESCRIPTION
Should fix crashes in rare cases.
