### PR TITLE
Enable block-linking with MMU

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -814,6 +814,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 
 	if (code_block.m_memory_exception)
 	{
+		b->memoryException = true;
 		// Address of instruction could not be translated
 		MOV(32, PPCSTATE(npc), Imm32(js.compilerPC));
 
@@ -859,12 +860,8 @@ BitSet32 Jit64::CallerSavedRegistersInUse()
 void Jit64::EnableBlockLink()
 {
 	jo.enableBlocklink = true;
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITNoBlockLinking ||
-	    SConfig::GetInstance().m_LocalCoreStartupParameter.bMMU)
-	{
-		// TODO: support block linking with MMU
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITNoBlockLinking)
 		jo.enableBlocklink = false;
-	}
 }
 
 void Jit64::EnableOptimization()

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -683,6 +683,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 
 	if (code_block.m_memory_exception)
 	{
+		b->memoryException = true;
 		ibuild.EmitISIException(ibuild.EmitIntConst(em_address));
 	}
 
@@ -707,10 +708,6 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 void JitIL::EnableBlockLink()
 {
 	jo.enableBlocklink = true;
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITNoBlockLinking ||
-	    SConfig::GetInstance().m_LocalCoreStartupParameter.bMMU)
-	{
-		// TODO: support block linking with MMU
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITNoBlockLinking)
 		jo.enableBlocklink = false;
-	}
 }

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -127,6 +127,7 @@ using namespace Gen;
 	{
 		JitBlock &b = blocks[num_blocks];
 		b.invalid = false;
+		b.memoryException = false;
 		b.originalAddress = em_address;
 		b.linkData.clear();
 		num_blocks++; //commit the current block
@@ -147,7 +148,12 @@ using namespace Gen;
 			valid_block.Set(block);
 
 		block_map[std::make_pair(pAddr + 4 * b.originalSize - 1, pAddr)] = block_num;
-		if (block_link)
+
+		// Blocks where a memory exception (ISI) occurred in the instruction fetch have to
+		// execute the ISI handler as the next instruction. These blocks cannot be
+		// linked to other blocks.  The block will be recompiled after the ISI is handled
+		// and so we do not link other blocks to it either.
+		if (block_link && !b.memoryException)
 		{
 			for (const auto& e : b.linkData)
 			{

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -42,6 +42,7 @@ struct JitBlock
 	int runCount;  // for profiling.
 
 	bool invalid;
+	bool memoryException;
 
 	struct LinkData
 	{


### PR DESCRIPTION
Enable block-linking with MMU. Blocks that cause an ISI exception are not linked.
