### PR TITLE
DolphinQt: remove non-render-to-main and add fullscreen.

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -33,6 +33,10 @@ public:
 signals:
 	void CoreStateChanged(Core::EState state);
 
+public slots:
+	// Main toolbar (also used by DRenderWidget)
+	bool OnStop();
+
 private slots:
 	// Emulation
 	void StartGame(const QString filename);
@@ -41,7 +45,6 @@ private slots:
 	// Main toolbar
 	void OnOpen();
 	void OnPlay();
-	void OnStop();
 
 	// View menu
 	void OnGameListStyleChanged();

--- a/Source/Core/DolphinQt/VideoInterface/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/VideoInterface/RenderWidget.cpp
@@ -2,8 +2,10 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include <QCloseEvent>
 #include <QMessageBox>
 
+#include "DolphinQt/MainWindow.h"
 #include "DolphinQt/VideoInterface/RenderWidget.h"
 
 DRenderWidget::DRenderWidget(QWidget* parent_widget)
@@ -16,9 +18,10 @@ DRenderWidget::DRenderWidget(QWidget* parent_widget)
 
 void DRenderWidget::closeEvent(QCloseEvent* e)
 {
-	// TODO: update render window positions in config
-
-	// TODO: Do this differently...
-	emit Closed();
+	if (!g_main_window->OnStop())
+	{
+		e->ignore();
+		return;
+	}
 	QWidget::closeEvent(e);
 }


### PR DESCRIPTION
Not sure what needs to be done here for exclusive fullscreen; on X11/Wayland I already have `BypassWindowManager` enabled which should provide some performance improvement.

There's also a new crash-on-exit but I think that's unrelated to this change (it looks like something is killing timers from another thread). I'll have to poke around and see what that is.