### PR TITLE
D3D: Fixed D3D validation error during EFB to texture copy

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -215,6 +215,17 @@ u32 StateManager::UnsetTexture(ID3D11ShaderResourceView* srv)
 	return mask;
 }
 
+void StateManager::SetTextureByMask(u32 textureSlotMask, ID3D11ShaderResourceView* srv)
+{
+	while (textureSlotMask)
+	{
+		unsigned long index;
+		_BitScanForward(&index, textureSlotMask);
+		SetTexture(index, srv);
+		textureSlotMask &= ~(1 << index);
+	}
+}
+
 }  // namespace D3D
 
 ID3D11SamplerState* StateCache::Get(SamplerState state)

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -235,7 +235,8 @@ public:
 	}
 
 	// removes currently set texture from all slots, returns mask of previously bound slots
-	u32 StateManager::UnsetTexture(ID3D11ShaderResourceView* srv);
+	u32 UnsetTexture(ID3D11ShaderResourceView* srv);
+	void SetTextureByMask(u32 textureSlotMask, ID3D11ShaderResourceView* srv);
 
 	// call this immediately before any drawing operation or to explicitly apply pending resource state changes
 	void Apply();

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -174,13 +174,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 		g_renderer->RestoreAPIState();
 
 		// Restore old texture in all previously used slots, if any
-		while (textureSlotMask)
-		{
-			unsigned long index;
-			_BitScanForward(&index, textureSlotMask);
-			D3D::stateman->SetTexture(index, texture->GetSRV());
-			textureSlotMask &= ~(1 << index);
-		}
+		D3D::stateman->SetTextureByMask(textureSlotMask, texture->GetSRV());
 	}
 
 	if (!g_ActiveConfig.bCopyEFBToTexture)


### PR DESCRIPTION
Texture was being bound as a render target while still being set as a shader resource.
D3D automatically unbinds the SRV in this case and generates a validation error.
The fix is to manually unbind SRV, render into it and then re-bind to old slots.

This was responsible for https://code.google.com/p/dolphin-emu/issues/detail?id=7929 and quite likely https://forums.dolphin-emu.org/Thread-4-0-4583-d3d-regression?pid=348967
