### PR TITLE
D3DState: Always update the m_pending members in the setters.

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -198,6 +198,7 @@ public:
 	void SetPixelShaderDynamic(ID3D11PixelShader* shader, ID3D11ClassInstance * const * classInstances, u32 classInstancesCount)
 	{
 		D3D::context->PSSetShader(shader, classInstances, classInstancesCount);
+		m_current.pixelShader = shader;
 		m_pending.pixelShader = shader;
 	}
 


### PR DESCRIPTION
Fixes unintentional behaviour when a setter is called twice before the state is applied, see https://github.com/dolphin-emu/dolphin/pull/1503#discussion_r21789224.
