### PR TITLE
DiscIO: Clear error status when reading file

### DIFF
--- a/Source/Core/DiscIO/CISOBlob.cpp
+++ b/Source/Core/DiscIO/CISOBlob.cpp
@@ -66,7 +66,10 @@ bool CISOFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 			u64 const file_off = CISO_HEADER_SIZE + m_ciso_map[block] * (u64)m_block_size + data_offset;
 
 			if (!(m_file.Seek(file_off, SEEK_SET) && m_file.ReadArray(out_ptr, bytes_to_read)))
+			{
+				m_file.Clear();
 				return false;
+			}
 		}
 		else
 		{

--- a/Source/Core/DiscIO/FileBlob.cpp
+++ b/Source/Core/DiscIO/FileBlob.cpp
@@ -25,8 +25,15 @@ PlainFileReader* PlainFileReader::Create(const std::string& filename)
 
 bool PlainFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 {
-	m_file.Seek(offset, SEEK_SET);
-	return m_file.ReadBytes(out_ptr, nbytes);
+	if (m_file.Seek(offset, SEEK_SET) && m_file.ReadBytes(out_ptr, nbytes))
+	{
+		return true;
+	}
+	else
+	{
+		m_file.Clear();
+		return false;
+	}
 }
 
 }  // namespace

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -130,7 +130,11 @@ bool WbfsFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 		File::IOFile& data_file = SeekToCluster(offset, &read_size);
 		read_size = (read_size > nbytes) ? nbytes : read_size;
 
-		data_file.ReadBytes(out_ptr, read_size);
+		if (!data_file.ReadBytes(out_ptr, read_size))
+		{
+			data_file.Clear();
+			return false;
+		}
 
 		out_ptr += read_size;
 		nbytes -= read_size;


### PR DESCRIPTION
If the error status isn't cleared, getting an error on one read results in getting errors on every read after that, regardless of whether they succeed. This wasn't a problem before 4.0-4585 ([PR 1682](https://github.com/dolphin-emu/dolphin/pull/1682)), because VolumeHandler discarded all errors back then. See [issue 7930](https://code.google.com/p/dolphin-emu/issues/detail?id=7930) for details.
