### PR TITLE
JIT: discard values that will not be used again (Don't merge, please review)

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
@@ -181,7 +181,7 @@ static GekkoOPTemplate table31[] =
 	{954, Interpreter::extsbx,      {"extsbx", OPTYPE_INTEGER, FL_OUT_A | FL_IN_S | FL_RC_BIT, 1, 0, 0, 0}},
 	{536, Interpreter::srwx,        {"srwx",   OPTYPE_INTEGER, FL_OUT_A | FL_IN_SB | FL_RC_BIT, 1, 0, 0, 0}},
 	{792, Interpreter::srawx,       {"srawx",  OPTYPE_INTEGER, FL_OUT_A | FL_IN_SB | FL_SET_CA | FL_RC_BIT, 1, 0, 0, 0}},
-	{824, Interpreter::srawix,      {"srawix", OPTYPE_INTEGER, FL_OUT_A | FL_IN_SB | FL_SET_CA | FL_RC_BIT, 1, 0, 0, 0}},
+	{824, Interpreter::srawix,      {"srawix", OPTYPE_INTEGER, FL_OUT_A | FL_IN_S | FL_SET_CA | FL_RC_BIT, 1, 0, 0, 0}},
 	{24,  Interpreter::slwx,        {"slwx",   OPTYPE_INTEGER, FL_OUT_A | FL_IN_SB | FL_RC_BIT, 1, 0, 0, 0}},
 
 	{54,   Interpreter::dcbst,      {"dcbst",  OPTYPE_DCACHE, 0, 5, 0, 0, 0}},

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -490,6 +490,47 @@ void Jit64::Trace()
 		PC, SRR0, SRR1, PowerPC::ppcState.fpscr, PowerPC::ppcState.msr, PowerPC::ppcState.spr[8], regs.c_str(), fregs.c_str());
 }
 
+void Jit64::DoForwardBranches(u32 address)
+{
+	auto src = branch_targets.equal_range(address);
+	auto begin = src.first;
+	auto end = src.second;
+	if (begin == end)
+		return;
+	// First, do everything that needs to go in the main path
+	for (auto it = begin; it != end; ++it)
+	{
+		gpr.PrepareRegCache(it->second.gpr);
+		fpr.PrepareRegCache(it->second.fpr);
+	}
+	std::vector<FixupBranch> jumpsToMainCode;
+	jumpsToMainCode.push_back(J(true));
+	for (auto it = begin; it != end;)
+	{
+		BranchTarget branchData = it->second;
+		if (!(branchData.sourceOp->inst.BO & BO_DONT_DECREMENT_FLAG))
+			SetJumpTarget(branchData.sourceBranchCtr);
+		if (!(branchData.sourceOp->inst.BO & BO_DONT_CHECK_CONDITION))
+			SetJumpTarget(branchData.sourceBranchCond);
+		if (branchData.sourceOp->inst.LK)
+			MOV(32, PPCSTATE_LR, Imm32(branchData.sourceOp->address + 4)); // LR = PC + 4;
+		// revert the downcount amount difference
+		ADD(32, PPCSTATE(downcount), Imm32(js.downcountAmount - branchData.downcountAmount));
+		// we have to assume the worst
+		js.fifoBytesThisBlock = std::max(branchData.fifoBytesThisBlock, js.fifoBytesThisBlock);
+		if (!branchData.firstFPInstructionFound)
+			js.firstFPInstructionFound = false;
+		branchData.gpr.ConvertRegCache(gpr);
+		branchData.fpr.ConvertRegCache(fpr);
+		++it;
+		if (it != end)
+			jumpsToMainCode.push_back(J(true));
+	}
+	for (FixupBranch jump : jumpsToMainCode)
+		SetJumpTarget(jump);
+	branch_targets.erase(begin, end);
+}
+
 void Jit64::Jit(u32 em_address)
 {
 	if (GetSpaceLeft() < 0x10000 ||
@@ -522,6 +563,7 @@ void Jit64::Jit(u32 em_address)
 				analyzer.ClearOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
 				analyzer.ClearOption(PPCAnalyst::PPCAnalyzer::OPTION_BRANCH_MERGE);
 				analyzer.ClearOption(PPCAnalyst::PPCAnalyzer::OPTION_CARRY_MERGE);
+				analyzer.ClearOption(PPCAnalyst::PPCAnalyzer::OPTION_FORWARD_JUMP);
 			}
 			Trace();
 		}
@@ -556,6 +598,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	jit->js.numFloatingPointInst = 0;
 
 	PPCAnalyst::CodeOp *ops = code_buf->codebuffer;
+	js.blockEnd = nextPC;
 
 	const u8 *start = AlignCode4(); // TODO: Test if this or AlignCode16 make a difference from GetCodePtr
 	b->checkedEntry = start;
@@ -605,6 +648,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 	js.skipnext = false;
 	js.carryFlagSet = false;
 	js.carryFlagInverted = false;
+	branch_targets.clear();
 	// Translate instructions
 	for (u32 i = 0; i < code_block.m_num_instructions; i++)
 	{
@@ -613,7 +657,6 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 		js.instructionNumber = i;
 		js.instructionsLeft = (code_block.m_num_instructions - 1) - i;
 		const GekkoOPInfo *opinfo = ops[i].opinfo;
-		js.downcountAmount += opinfo->numCycles;
 		js.fastmemLoadStore = NULL;
 		js.fixupExceptionHandler = false;
 		js.revertGprLoad = -1;
@@ -643,6 +686,12 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBloc
 			js.next_op = &ops[i + 1];
 			js.next_inst_bp = SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableDebugging && breakpoints.IsAddressBreakPoint(ops[i + 1].address);
 		}
+
+		if (analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_FORWARD_JUMP))
+			DoForwardBranches(js.compilerPC);
+
+		// We have to do this after DoForwardBranches, so the correct cycle count delta gets used.
+		js.downcountAmount += opinfo->numCycles;
 
 		if (jo.optimizeGatherPipe && js.fifoBytesThisBlock >= 32)
 		{
@@ -890,4 +939,5 @@ void Jit64::EnableOptimization()
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_BRANCH_MERGE);
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CARRY_MERGE);
+	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_FORWARD_JUMP);
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -51,7 +51,6 @@ private:
 		Gen::FixupBranch sourceBranchCtr;
 		int downcountAmount;
 		int fifoBytesThisBlock;
-		bool firstFPInstructionFound;
 		GPRRegCache gpr;
 		FPURegCache fpr;
 		PPCAnalyst::CodeOp* sourceOp;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -45,6 +45,19 @@ private:
 	GPRRegCache gpr;
 	FPURegCache fpr;
 
+	struct BranchTarget
+	{
+		Gen::FixupBranch sourceBranchCond;
+		Gen::FixupBranch sourceBranchCtr;
+		int downcountAmount;
+		int fifoBytesThisBlock;
+		bool firstFPInstructionFound;
+		GPRRegCache gpr;
+		FPURegCache fpr;
+		PPCAnalyst::CodeOp* sourceOp;
+	};
+	std::unordered_multimap<u32, BranchTarget> branch_targets;
+
 	// The default code buffer. We keep it around to not have to alloc/dealloc a
 	// large chunk of memory for each recompiled block.
 	PPCAnalyst::CodeBuffer code_buffer;
@@ -67,6 +80,8 @@ public:
 	void Shutdown() override;
 
 	bool HandleFault(uintptr_t access_address, SContext* ctx) override;
+
+	void DoForwardBranches(u32 address);
 
 	// Jit!
 
@@ -115,6 +130,7 @@ public:
 	void GenerateConstantOverflow(bool overflow);
 	void GenerateConstantOverflow(s64 val);
 	void GenerateOverflow();
+	bool MergeAllowedNextInstruction();
 	void FinalizeCarryOverflow(bool oe, bool inv = false);
 	void FinalizeCarry(Gen::CCFlags cond);
 	void FinalizeCarry(bool ca);

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -440,3 +440,92 @@ int RegCache::NumFreeRegisters()
 			count++;
 	return count;
 }
+
+// Step 1 for forward branches: modify the main path register cache to match.
+// We have to do this in two cases that can't be covered by modifying the branch-path
+// register cache.
+// If they disagree on immediates, we must flush the immediates.
+// If the main path has a register that's not dirty, but the branch path's is dirty, we have
+// to explicitly mark the main path's as dirty.
+void GPRRegCache::PrepareRegCache(GPRRegCache other)
+{
+	for (int i = 0; i < 32; i++)
+	{
+		if (R(i).IsImm() && (!other.R(i).IsImm() || other.R(i).offset != R(i).offset))
+			KillImmediate(i, true, false);
+		if (R(i).IsSimpleReg() && other.R(i).IsSimpleReg() && RX(i) == other.RX(i) && other.xregs[RX(i)].dirty)
+			xregs[RX(i)].dirty = true;
+	}
+}
+
+void FPURegCache::PrepareRegCache(FPURegCache other)
+{
+	for (int i = 0; i < 32; i++)
+	{
+		if (R(i).IsSimpleReg() && other.R(i).IsSimpleReg() && RX(i) == other.RX(i) && other.xregs[RX(i)].dirty)
+			xregs[RX(i)].dirty = true;
+	}
+}
+
+void GPRRegCache::ConvertRegCache(GPRRegCache target)
+{
+	for (int i = 0; i < 32; i++)
+	{
+		OpArg src = R(i);
+		OpArg dst = target.R(i);
+		if (dst.IsImm())
+		{
+			if (!src.IsImm() || src.offset != dst.offset)
+			{
+				PanicAlert("Cannot convert register cache!");
+				return;
+			}
+			// Immediates are the same, nothing to do
+		}
+		else if (dst.IsSimpleReg())
+		{
+			if (src.IsSimpleReg() && src.GetSimpleReg() == dst.GetSimpleReg())
+			{
+				// Nothing to do
+			}
+			else
+			{
+				FlushR(dst.GetSimpleReg());
+				emit->MOV(32, dst, src);
+				// we don't actually have to update the reg cache state, because this reg
+				// cache is going to be discarded after we're done.
+			}
+		}
+		else
+		{
+			// Target is in the cache, just store.
+			StoreFromRegister(i);
+		}
+	}
+}
+
+void FPURegCache::ConvertRegCache(FPURegCache target)
+{
+	for (int i = 0; i < 32; i++)
+	{
+		OpArg src = R(i);
+		OpArg dst = target.R(i);
+		if (dst.IsSimpleReg())
+		{
+			if (src.IsSimpleReg() && src.GetSimpleReg() == dst.GetSimpleReg())
+			{
+				// Nothing to do
+			}
+			else
+			{
+				FlushR(dst.GetSimpleReg());
+				emit->MOVAPD(dst.GetSimpleReg(), src);
+			}
+		}
+		else
+		{
+			// Target is in the cache, just store.
+			StoreFromRegister(i);
+		}
+	}
+}

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -253,7 +253,6 @@ void RegCache::DiscardRegContentsIfCached(size_t preg)
 	}
 }
 
-
 void GPRRegCache::SetImmediate32(size_t preg, u32 immValue)
 {
 	DiscardRegContentsIfCached(preg);

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -139,6 +139,8 @@ public:
 	void SetImmediate32(size_t preg, u32 immValue);
 	BitSet32 GetRegUtilization() override;
 	BitSet32 CountRegsIn(size_t preg, u32 lookahead) override;
+	void ConvertRegCache(GPRRegCache target);
+	void PrepareRegCache(GPRRegCache other);
 };
 
 
@@ -151,4 +153,6 @@ public:
 	Gen::OpArg GetDefaultLocation(size_t reg) const override;
 	BitSet32 GetRegUtilization() override;
 	BitSet32 CountRegsIn(size_t preg, u32 lookahead) override;
+	void ConvertRegCache(FPURegCache target);
+	void PrepareRegCache(FPURegCache other);
 };

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -131,7 +131,7 @@ void Jit64::bcx(UGeckoInstruction inst)
 
 	if (jumpInBlock)
 	{
-		BranchTarget branchData = { pConditionBranch, pCTRBranch, js.downcountAmount, js.fifoBytesThisBlock, js.firstFPInstructionFound, gpr, fpr, js.op };
+		BranchTarget branchData = { pConditionBranch, pCTRBranch, js.downcountAmount, js.fifoBytesThisBlock, gpr, fpr, js.op };
 		branch_targets.insert(std::make_pair(destination, branchData));
 	}
 	else

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include <initializer_list>
 #include "Common/CommonTypes.h"
 
 #include "Core/PowerPC/Jit64/Jit.h"
@@ -103,44 +104,52 @@ void Jit64::bcx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITBranchOff);
 
-	// USES_CR
-
-	FixupBranch pCTRDontBranch;
-	if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
-	{
-		SUB(32, PPCSTATE_CTR, Imm8(1));
-		if (inst.BO & BO_BRANCH_IF_CTR_0)
-			pCTRDontBranch = J_CC(CC_NZ, true);
-		else
-			pCTRDontBranch = J_CC(CC_Z, true);
-	}
-
-	FixupBranch pConditionDontBranch;
-	if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)  // Test a CR bit
-	{
-		pConditionDontBranch = JumpIfCRFieldBit(inst.BI >> 2, 3 - (inst.BI & 3),
-		                                        !(inst.BO_2 & BO_BRANCH_IF_TRUE));
-	}
-
-	if (inst.LK)
-		MOV(32, PPCSTATE_LR, Imm32(js.compilerPC + 4));
-
 	u32 destination;
 	if (inst.AA)
 		destination = SignExt16(inst.BD << 2);
 	else
 		destination = js.compilerPC + SignExt16(inst.BD << 2);
 
-	gpr.Flush(FLUSH_MAINTAIN_STATE);
-	fpr.Flush(FLUSH_MAINTAIN_STATE);
-	WriteExit(destination, inst.LK, js.compilerPC + 4);
+	bool cc = analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+	bool forwardJumps = analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_FORWARD_JUMP);
+	bool jumpInBlock = cc && forwardJumps && destination > js.compilerPC && destination < js.blockEnd;
 
-	if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)
-		SetJumpTarget( pConditionDontBranch );
-	if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)
-		SetJumpTarget( pCTRDontBranch );
+	FixupBranch pCTRBranch = { NULL, 0 }; // shut up uninitialized warnings
+	if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
+	{
+		bool dir = jumpInBlock ^ !!(inst.BO & BO_BRANCH_IF_CTR_0);
+		SUB(32, PPCSTATE_CTR, Imm8(1));
+		pCTRBranch = J_CC(dir ? CC_NZ : CC_Z, true);
+	}
 
-	if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
+	FixupBranch pConditionBranch = { NULL, 0 };
+	if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)  // Test a CR bit
+	{
+		bool dir = jumpInBlock ^ !(inst.BO_2 & BO_BRANCH_IF_TRUE);
+		pConditionBranch = JumpIfCRFieldBit(inst.BI >> 2, 3 - (inst.BI & 3), dir);
+	}
+
+	if (jumpInBlock)
+	{
+		BranchTarget branchData = { pConditionBranch, pCTRBranch, js.downcountAmount, js.fifoBytesThisBlock, js.firstFPInstructionFound, gpr, fpr, js.op };
+		branch_targets.insert(std::make_pair(destination, branchData));
+	}
+	else
+	{
+		if (inst.LK)
+			MOV(32, PPCSTATE_LR, Imm32(js.compilerPC + 4));
+
+		gpr.Flush(FLUSH_MAINTAIN_STATE);
+		fpr.Flush(FLUSH_MAINTAIN_STATE);
+		WriteExit(destination, inst.LK, js.compilerPC + 4);
+
+		if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)
+			SetJumpTarget(pConditionBranch);
+		if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)
+			SetJumpTarget(pCTRBranch);
+	}
+
+	if (!cc)
 	{
 		gpr.Flush();
 		fpr.Flush();

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -347,7 +347,7 @@ void Jit64::FloatCompare(UGeckoInstruction inst, bool upper)
 
 	// Merge neighboring fcmp and cror (the primary use of cror).
 	UGeckoInstruction next = js.next_inst;
-	if (next.OPCD == 19 && next.SUBOP10 == 449 && (next.CRBA >> 2) == crf && (next.CRBB >> 2) == crf && (next.CRBD >> 2) == crf)
+	if (MergeAllowedNextInstruction() && next.OPCD == 19 && next.SUBOP10 == 449 && (next.CRBA >> 2) == crf && (next.CRBB >> 2) == crf && (next.CRBD >> 2) == crf)
 	{
 		js.skipnext = true;
 		js.downcountAmount++;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -419,7 +419,7 @@ void Jit64::DoMergedBranchCondition()
 
 	if (jumpInBlock)
 	{
-		BranchTarget branchData = { pBranch, pBranch, js.downcountAmount, js.fifoBytesThisBlock, js.firstFPInstructionFound, gpr, fpr, js.next_op };
+		BranchTarget branchData = { pBranch, pBranch, js.downcountAmount, js.fifoBytesThisBlock, gpr, fpr, js.next_op };
 		branch_targets.insert(std::make_pair(destination, branchData));
 	}
 	else
@@ -476,7 +476,7 @@ void Jit64::DoMergedBranchImmediate(s64 val)
 		if (jumpInBlock)
 		{
 			FixupBranch pBranch = J(true);
-			BranchTarget branchData = { pBranch, pBranch, js.downcountAmount, js.fifoBytesThisBlock, js.firstFPInstructionFound, gpr, fpr, js.next_op };
+			BranchTarget branchData = { pBranch, pBranch, js.downcountAmount, js.fifoBytesThisBlock, gpr, fpr, js.next_op };
 			branch_targets.insert(std::make_pair(destination, branchData));
 		}
 		// IMPORTANT: we can't actually leave the block in this case!! A forward branch is still waiting around for

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -50,14 +50,19 @@ void Jit64::GenerateOverflow()
 	SetJumpTarget(exit);
 }
 
+bool Jit64::MergeAllowedNextInstruction()
+{
+	// Be careful: a breakpoint kills flags in between instructions
+	return PowerPC::GetState() != PowerPC::CPU_STEPPING && !js.isLastInstruction && !js.next_inst_bp && !js.next_op->isBranchTarget;
+}
+
 void Jit64::FinalizeCarry(CCFlags cond)
 {
 	js.carryFlagSet = false;
 	js.carryFlagInverted = false;
 	if (js.op->wantsCA)
 	{
-		// Be careful: a breakpoint kills flags in between instructions
-		if (!js.isLastInstruction && js.next_op->wantsCAInFlags && !js.next_inst_bp)
+		if (MergeAllowedNextInstruction() && js.next_op->wantsCAInFlags)
 		{
 			if (cond == CC_C || cond == CC_NC)
 			{
@@ -86,7 +91,7 @@ void Jit64::FinalizeCarry(bool ca)
 	js.carryFlagInverted = false;
 	if (js.op->wantsCA)
 	{
-		if (!js.isLastInstruction && js.next_op->wantsCAInFlags && !js.next_inst_bp)
+		if (MergeAllowedNextInstruction() && js.next_op->wantsCAInFlags)
 		{
 			if (ca)
 				STC();
@@ -331,6 +336,9 @@ bool Jit64::CheckMergedBranch(int crf)
 	if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_BRANCH_MERGE))
 		return false;
 
+	if (!MergeAllowedNextInstruction())
+		return false;
+
 	const UGeckoInstruction& next = js.next_inst;
 	return (((next.OPCD == 16 /* bcx */) ||
 	        ((next.OPCD == 19) && (next.SUBOP10 == 528) /* bcctrx */) ||
@@ -383,28 +391,48 @@ void Jit64::DoMergedBranchCondition()
 	js.downcountAmount++;
 	js.skipnext = true;
 	int test_bit = 8 >> (js.next_inst.BI & 3);
-	bool condition = !!(js.next_inst.BO & BO_BRANCH_IF_TRUE);
+	bool cc = analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+	bool forwardJumps = analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_FORWARD_JUMP);
+	bool jumpInBlock = false;
+	u32 destination;
+	if (js.next_inst.OPCD == 16 && cc && forwardJumps && !(test_bit & 1))
+	{
+		if (js.next_inst.AA)
+			destination = SignExt16(js.next_inst.BD << 2);
+		else
+			destination = js.next_compilerPC + SignExt16(js.next_inst.BD << 2);
+		jumpInBlock = destination > js.next_compilerPC && destination < js.blockEnd;
+	}
+	bool condition = !!(js.next_inst.BO & BO_BRANCH_IF_TRUE) ^ jumpInBlock;
 
 	gpr.UnlockAll();
 	gpr.UnlockAllX();
-	FixupBranch pDontBranch;
+	FixupBranch pBranch;
 	if (test_bit & 8)
-		pDontBranch = J_CC(condition ? CC_GE : CC_L, true);  // Test < 0, so jump over if >= 0.
+		pBranch = J_CC(condition ? CC_GE : CC_L, true);  // Test < 0, so jump over if >= 0.
 	else if (test_bit & 4)
-		pDontBranch = J_CC(condition ? CC_LE : CC_G, true);  // Test > 0, so jump over if <= 0.
+		pBranch = J_CC(condition ? CC_LE : CC_G, true);  // Test > 0, so jump over if <= 0.
 	else if (test_bit & 2)
-		pDontBranch = J_CC(condition ? CC_NE : CC_E, true);  // Test = 0, so jump over if != 0.
+		pBranch = J_CC(condition ? CC_NE : CC_E, true);  // Test = 0, so jump over if != 0.
 	else  // SO bit, do not branch (we don't emulate SO for cmp).
-		pDontBranch = J(true);
+		pBranch = J(true);
 
-	gpr.Flush(FLUSH_MAINTAIN_STATE);
-	fpr.Flush(FLUSH_MAINTAIN_STATE);
+	if (jumpInBlock)
+	{
+		BranchTarget branchData = { pBranch, pBranch, js.downcountAmount, js.fifoBytesThisBlock, js.firstFPInstructionFound, gpr, fpr, js.next_op };
+		branch_targets.insert(std::make_pair(destination, branchData));
+	}
+	else
+	{
+		gpr.Flush(FLUSH_MAINTAIN_STATE);
+		fpr.Flush(FLUSH_MAINTAIN_STATE);
 
-	DoMergedBranch();
+		DoMergedBranch();
 
-	SetJumpTarget(pDontBranch);
+		SetJumpTarget(pBranch);
+	}
 
-	if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
+	if (!cc)
 	{
 		gpr.Flush();
 		fpr.Flush();
@@ -417,6 +445,18 @@ void Jit64::DoMergedBranchImmediate(s64 val)
 	js.downcountAmount++;
 	js.skipnext = true;
 	int test_bit = 8 >> (js.next_inst.BI & 3);
+	bool cc = analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+	bool forwardJumps = analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_FORWARD_JUMP);
+	bool jumpInBlock = false;
+	u32 destination;
+	if (js.next_inst.OPCD == 16 && cc && forwardJumps)
+	{
+		if (js.next_inst.AA)
+			destination = SignExt16(js.next_inst.BD << 2);
+		else
+			destination = js.next_compilerPC + SignExt16(js.next_inst.BD << 2);
+		jumpInBlock = destination > js.next_compilerPC && destination < js.blockEnd;
+	}
 	bool condition = !!(js.next_inst.BO & BO_BRANCH_IF_TRUE);
 
 	gpr.UnlockAll();
@@ -433,9 +473,27 @@ void Jit64::DoMergedBranchImmediate(s64 val)
 
 	if (branch)
 	{
-		gpr.Flush();
-		fpr.Flush();
-		DoMergedBranch();
+		if (jumpInBlock)
+		{
+			FixupBranch pBranch = J(true);
+			BranchTarget branchData = { pBranch, pBranch, js.downcountAmount, js.fifoBytesThisBlock, js.firstFPInstructionFound, gpr, fpr, js.next_op };
+			branch_targets.insert(std::make_pair(destination, branchData));
+		}
+		// IMPORTANT: we can't actually leave the block in this case!! A forward branch is still waiting around for
+		// its entry point. This -really- should be better optimized, but I don't think immediate branches are common
+		// anyways. Should we keep this feature around at all, given the possible complexity of interactions?
+		else if (!branch_targets.empty())
+		{
+			gpr.Flush(FLUSH_MAINTAIN_STATE);
+			fpr.Flush(FLUSH_MAINTAIN_STATE);
+			DoMergedBranch();
+		}
+		else
+		{
+			gpr.Flush();
+			fpr.Flush();
+			DoMergedBranch();
+		}
 	}
 	else if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
 	{

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -95,15 +95,12 @@ void Jit64::lXXx(UGeckoInstruction inst)
 	}
 
 	// PowerPC has no 8-bit sign extended load, but x86 does, so merge extsb with the load if we find it.
-	if (accessSize == 8 && js.next_inst.OPCD == 31 && js.next_inst.SUBOP10 == 954 &&
+	if (MergeAllowedNextInstruction() && accessSize == 8 && js.next_inst.OPCD == 31 && js.next_inst.SUBOP10 == 954 &&
 	    js.next_inst.RS == inst.RD && js.next_inst.RA == inst.RD && !js.next_inst.Rc)
 	{
-		if (PowerPC::GetState() != PowerPC::CPU_STEPPING)
-		{
-			js.downcountAmount++;
-			js.skipnext = true;
-			signExtend = true;
-		}
+		js.downcountAmount++;
+		js.skipnext = true;
+		signExtend = true;
 	}
 
 	// TODO(ector): Make it dynamically enable/disable idle skipping where appropriate

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -380,8 +380,6 @@ void Jit64::mtmsr(UGeckoInstruction inst)
 	SetJumpTarget(eeDisabled);
 
 	WriteExit(js.compilerPC + 4);
-
-	js.firstFPInstructionFound = false;
 }
 
 void Jit64::mfmsr(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -85,7 +85,6 @@ protected:
 		int revertGprLoad;
 		int revertFprLoad;
 
-		bool firstFPInstructionFound;
 		bool isLastInstruction;
 		bool memcheck;
 		bool skipnext;

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -67,6 +67,7 @@ protected:
 		u32 compilerPC;
 		u32 next_compilerPC;
 		u32 blockStart;
+		u32 blockEnd;
 		UGeckoInstruction next_inst;  // for easy peephole opt.
 		int instructionNumber;
 		int instructionsLeft;

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <queue>
 #include <string>
+#include <unordered_set>
 
 #include "Common/StringUtil.h"
 
@@ -219,6 +220,10 @@ static bool CanSwapAdjacentOps(const CodeOp &a, const CodeOp &b)
 	const GekkoOPInfo *b_info = b.opinfo;
 	int a_flags = a_info->flags;
 	int b_flags = b_info->flags;
+
+	// can't reorder around branch targets, for now
+	if (a.isBranchTarget || b.isBranchTarget)
+		return false;
 	if (b_flags & (FL_SET_CRx | FL_ENDBLOCK | FL_TIMER | FL_EVIL | FL_SET_OE))
 		return false;
 	if ((b_flags & (FL_RC_BIT | FL_RC_BIT_F)) && (b.inst.Rc))
@@ -664,6 +669,8 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 	u32 numFollows = 0;
 	u32 num_inst = 0;
 
+	std::unordered_set<u32> branchTargets;
+
 	for (u32 i = 0; i < blockSize; ++i)
 	{
 		UGeckoInstruction inst = JitInterface::ReadOpcodeJIT(address);
@@ -694,6 +701,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 			code[i].branchTo = -1;
 			code[i].branchToIndex = -1;
 			code[i].skip = false;
+			code[i].isBranchTarget = HasOption(OPTION_FORWARD_JUMP) && branchTargets.count(address);
 			block->m_stats->numCycles += opinfo->numCycles;
 
 			SetInstructionStats(block, &code[i], opinfo, i);
@@ -757,6 +765,15 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 				{
 					// bcx with conditional branch
 					conditional_continue = true;
+					if (HasOption(OPTION_FORWARD_JUMP))
+					{
+						if (inst.AA)
+							destination = SignExt16(inst.BD << 2);
+						else
+							destination = address + SignExt16(inst.BD << 2);
+						if (destination > address)
+							branchTargets.insert(destination);
+					}
 				}
 				else if (inst.OPCD == 19 && inst.SUBOP10 == 16 &&
 				        ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0 || (inst.BO & BO_DONT_CHECK_CONDITION) == 0))
@@ -824,6 +841,7 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 
 	// Scan for flag dependencies; assume the next block (or any branch that can leave the block)
 	// wants flags, to be safe.
+	// TODO: optimize for forward jumps, instead of assuming all jumps are block exits.
 	bool wantsCR0 = true, wantsCR1 = true, wantsFPRF = true, wantsCA = true;
 	BitSet32 fprInUse, gprInUse, gprInReg, fprInXmm;
 	for (int i = block->m_num_instructions - 1; i >= 0; i--)
@@ -867,6 +885,10 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 	BitSet32 fprIsSingle, fprIsDuplicated, fprIsStoreSafe;
 	for (u32 i = 0; i < block->m_num_instructions; i++)
 	{
+		// TODO: actually follow forward branches and calculate the real values instead
+		// of just giving up and assuming the worst.
+		if (code[i].isBranchTarget)
+			fprIsSingle = fprIsDuplicated = fprIsStoreSafe = BitSet32(0);
 		code[i].fprIsSingle = fprIsSingle;
 		code[i].fprIsDuplicated = fprIsDuplicated;
 		code[i].fprIsStoreSafe = fprIsStoreSafe;

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -23,40 +23,83 @@ namespace PPCAnalyst
 struct CodeOp //16B
 {
 	UGeckoInstruction inst;
-	GekkoOPInfo * opinfo;
+	GekkoOPInfo* opinfo;
 	u32 address;
-	u32 branchTo; //if 0, not a branch
-	int branchToIndex; //index of target block
+
+	// -----------------------------
+	// Properties of the instruction
+	// -----------------------------
+
+	// Which registers are possible inputs/outputs. If an output register might not be modified
+	// (e.g. in the case of a load that can exception) or is partially modified, it's listed in
+	// the inputs, too.
 	BitSet32 regsOut;
 	BitSet32 regsIn;
 	BitSet32 fregsIn;
-	s8 fregOut;
-	bool isBranchTarget;
-	bool wantsCR0;
-	bool wantsCR1;
-	bool wantsFPRF;
-	bool wantsCA;
-	bool wantsCAInFlags;
+	BitSet32 fregsOut;
+
+	// Whether the instruction writes to certain flags.
 	bool outputCR0;
 	bool outputCR1;
 	bool outputFPRF;
 	bool outputCA;
+
+	// -----------------------------
+	// Results of block analysis
+	// -----------------------------
+
+	// Whether this instruction needs to maintain particular flags: false if the flag will be
+	// clobbered before being used or block exit.
+	bool wantsFPRF; // floating point result flags
+	bool wantsCA;   // carry flag
+	// This instruction wants the carry flag in the host carry flag to use it as input, e.g. for
+	// instructions such as addex.
+	// TODO: add a similar "keep the carry flag in the host carry flag" feature for ARM? This is currently
+	// only used for x86.
+	bool wantsCAInFlags;
+	// Whether this instruction is the first FPU instruction in the block (for FP exception bailouts).
+	// This includes the case where a forward branch skipped a previous first FPU instruction.
+	bool firstFPUInst;
+	// Whether this instruction can end a block, either by branch or possible exception path.
 	bool canEndBlock;
-	bool skip;  // followed BL-s for example
-	// which registers are still needed after this instruction in this block
+	// Whether this instruction is the target of a forward branch from within the block.
+	bool isBranchTarget;
+	// Whether this instruction should be skipped (not currently used).
+	bool skip;
+
+	// Which registers are still used after this instruction in this block.
+	// If a register isn't used again we store it in order to reclaim the host register it was stored in.
 	BitSet32 fprInUse;
 	BitSet32 gprInUse;
-	// just because a register is in use doesn't mean we actually need or want it in an x86 register.
+
+	// Which registers have values that we can't discard after this instruction, i.e. won't be clobbered
+	// before being used.
+	// We use these to discard values that will be clobbered before a block exit point. This is an "unsafe"
+	// optimization: a mistake here will result in incorrect code.
+	BitSet32 gprNeeded;
+	BitSet32 fprNeeded;
+
+	// Which registers we would prefer to be loaded into host registers if possible.
+	// We use these to choose whether or not to load values into host registers: if we have the option
+	// of using a memory operand now, but the value will be used after this instruction, try to put it
+	// in a register.
+	// Just because a register is in use doesn't mean we actually need or want it in a host register;
+	// hence these aren't identical to gprInUse/fprInUse.
+	// For example, we do double stores from GPRs, so we don't want to load a PowerPC floating point register
+	// into an XMM only to move it again to a GPR afterwards. If we change how double stores work, the way
+	// these are decided upon should be changed too.
+	// TODO: optimization heuristics for ARM, too!
 	BitSet32 gprInReg;
-	// we do double stores from GPRs, so we don't want to load a PowerPC floating point register into
-	// an XMM only to move it again to a GPR afterwards.
-	BitSet32 fprInXmm;
-	// whether an fpr is known to be an actual single-precision value at this point in the block.
+	BitSet32 fprInReg;
+
+	// Knowledge we have about the values in registers (based on where they came from) that allow us to
+	// perform further optimizations.
+	// Whether an fpr is known to be an actual single-precision value at this point in the block.
 	BitSet32 fprIsSingle;
-	// whether an fpr is known to have identical top and bottom halves (e.g. due to a single instruction)
+	// Whether an fpr is known to have identical top and bottom halves (e.g. due to a single instruction)
 	BitSet32 fprIsDuplicated;
-	// whether an fpr is the output of a single-precision arithmetic instruction, i.e. whether we can safely
-	// skip PPC_FP.
+	// Whether an fpr is the output of a single-precision arithmetic instruction, i.e. whether we can safely
+	// skip denormal/sNaN handling in single-precision stores.
 	BitSet32 fprIsStoreSafe;
 };
 

--- a/Source/Core/Core/PowerPC/PPCAnalyst.h
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.h
@@ -198,7 +198,6 @@ public:
 		// Similar to complex blocks.
 		// Instead of jumping backwards, this jumps forwards within the block.
 		// Requires JIT support to work.
-		// XXX: NOT COMPLETE
 		OPTION_FORWARD_JUMP = (1 << 3),
 
 		// Reorder compare/Rc instructions next to their associated branches and


### PR DESCRIPTION
This dramatically reduces register pressure in long blocks, cutting instruction
count by 5% or more in some.

This is an "unsafe" optimization: an error in the optimizer could result in
incorrect code (e.g. necessary values thrown out), not merely suboptimal code
(as in the case of the other register-usage optimizations in PPCAnalyst).

Fix an interpreter_tables mistake in the definition of srawix: srawix does not
use RB as an input. Having interpreter_tables be precisely correct is doubly
important now, given that this optimization relies on its correctness.

Also clean up and comment more of PPCAnalyst and make it more consistent.
Make sure it accounts for every possible block exit point, even exception ones,
so that the optimization is correct in all cases.

**This is a moderately dangerous optimization, so it probably needs a decent amount of testing to make sure nothing explodes.** I was also thinking there might be some way to enforce the constraints of this optimization inside the register cache (e.g. by marking a physical register as valid, but discarded, then erroring if it gets bound and loaded) to make sure problems don't occur, but there are some subtleties: for example, falling back to interpreter flushes the register cache but does not require all the values in the register cache to be correct, just the ones the interpreter uses.