### PR TITLE
JIT: free up a register by eliminating RCODE_POINTERS

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -267,9 +267,9 @@ const int* GPRRegCache::GetAllocationOrder(size_t& count)
 	{
 		// R12, when used as base register, for example in a LEA, can generate bad code! Need to look into this.
 #ifdef _WIN32
-		RSI, RDI, R13, R14, R8, R9, R10, R11, R12, RCX
+		RSI, RDI, R13, R14, R15, R8, R9, R10, R11, R12, RCX
 #else
-		R12, R13, R14, RSI, RDI, R8, R9, R10, R11, RCX
+		R12, R13, R14, R15, RSI, RDI, R8, R9, R10, R11, RCX
 #endif
 	};
 	count = sizeof(allocationOrder) / sizeof(const int);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -39,8 +39,6 @@
 #define RSCRATCH_EXTRA RCX
 // RMEM points to the start of emulated memory.
 #define RMEM RBX
-// RCODE_POINTERS does what it says.
-#define RCODE_POINTERS R15
 // RPPCSTATE points to ppcState + 0x80.  It's offset because we want to be able
 // to address as much as possible in a one-byte offset form.
 #define RPPCSTATE RBP


### PR DESCRIPTION
Why not.
