### PR TITLE
Interpreter: fix architecture-dependent rounding order in non-IEEE mode

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FPUtils.h
@@ -55,6 +55,13 @@ inline void UpdateFPSCR()
 
 inline double ForceSingle(double _x)
 {
+	if (FPSCR.NI && std::abs(_x) < std::numeric_limits<float>::min())
+	{
+		// PPC first flushes then rounds, x86 does it the other way around,
+		// so do it by hand.
+		return copysign(0, _x);
+	}
+
 	// convert to float...
 	float x = (float) _x;
 	if (!cpu_info.bFlushToZero && FPSCR.NI)


### PR DESCRIPTION
PPC and x86 behave differently in non-IEEE mode (NI=1/FTZ):

For single-precision floating point operations with denormal inputs (and frsp with a denormal output), PPC first flushes the input to zero, then applies the current rounding mode while x86 does it the other way around. At least this would explain what happens.

Ignoring the sign bit, the only range in which this affects the output is `[0x380ffffff0000000, 0x380fffffffffffff]` in round-to-nearest/zero and `[0x380fffffe0000001, 0x380fffffffffffff]` in round-to-+/-infinity. On PPC, a number in this range results in `0` while on x86 it results in `0x3810000000000000`. An example of this bug can be seen when running the [frsp hwtest](https://github.com/dolphin-emu/hwtests/blob/master/cputest/frsp.cpp).

All credit goes to @FioraAeterna for finding the cause of this bug.

This PR fixes both the extended frsp hwtest as well as a simple fadds test I haven't pushed yet.

TODO:
- Find out if this madness is actually true or just a hallucination caused by sleep deprivation.
- Investigate what ARM does.
- Fix the JITs.