### PR TITLE
JitArm64: Add lwz, lwzu, lwzx, and lwzux

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -68,6 +68,12 @@ public:
 
 	// Force break
 	void Break(UGeckoInstruction inst);
+	
+	// Load
+	void lwz(UGeckoInstruction inst);
+	void lwzu(UGeckoInstruction inst);
+	void lwzx(UGeckoInstruction inst);
+	void lwzux(UGeckoInstruction inst);
 
 	// Branch
 	void sc(UGeckoInstruction inst);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -20,3 +20,47 @@ void JitArm64::icbi(UGeckoInstruction inst)
 	FallBackToInterpreter(inst);
 	WriteExit(js.compilerPC + 4);
 }
+
+void JitArm64::lwz(UGeckoInstruction inst)
+{
+	Gen::OpArg opAddress;
+	u32 tmp;
+	if(!inst.RA) tmp = (u32)inst.SIMM_16;
+	else tmp = gpr.R(inst.RA).offset + inst.SIMM_16;
+	
+	opAddress = Imm32(tmp);
+	
+	SafeLoadToReg(gpr.RX(inst.RD), opAddress, 32, 0, CallerSavedRegistersInUse(), false);
+}
+
+void JitArm64::lwzu(UGeckoInstruction inst)
+{
+	Gen::OpArg opAddress;
+	u32 tmp = gpr.R(inst.RA).offset + inst.SIMM_16;
+	opaddress = Imm32(tmp);
+	
+	SafeLoadToReg(gpr.RX(inst.RD), opAddress, 32, 0, CallerSavedRegistersInUse(), false);
+	gpr.SetImmediate(inst.RA, tmp);
+}
+
+void JitArm64::lwzx(UGeckoInstruction inst)
+{
+	Gen::OpArg opAddress;
+	u32 tmp;
+	if(!inst.RA) tmp = gpr.R(inst.RB).offset;
+	else tmp = gpr.R(inst.RA).offset + gpr.R(inst.RB).offset;
+	
+	opAddress = Imm32(tmp);
+	
+	SafeLoadToReg(gpr.RX(inst.RD), opAddress, 32, 0, CallerSavedRegistersInUse(), false);
+}
+
+void JitArm64::lwzux(UGeckoInstruction inst)
+{
+	Gen::OpArg opAddress;
+	u32 tmp = gpr.R(inst.RA).offset + gpr.R(inst.RB).offset;
+	opaddress = Imm32(tmp);
+	
+	SafeLoadToReg(gpr.RX(inst.RD), opAddress, 32, 0, CallerSavedRegistersInUse(), false);
+	gpr.SetImmediate(inst.RA, tmp);
+}

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -65,8 +65,8 @@ static GekkoOPTemplate primarytable[] =
 	{28, &JitArm64::arith_imm},                 //"andi_rc",  OPTYPE_INTEGER, FL_OUT_A | FL_IN_S | FL_SET_CR0}},
 	{29, &JitArm64::arith_imm},                 //"andis_rc", OPTYPE_INTEGER, FL_OUT_A | FL_IN_S | FL_SET_CR0}},
 
-	{32, &JitArm64::FallBackToInterpreter},     //"lwz",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A}},
-	{33, &JitArm64::FallBackToInterpreter},     //"lwzu", OPTYPE_LOAD, FL_OUT_D | FL_OUT_A | FL_IN_A}},
+	{32, &JitArm64::lwz},     //"lwz",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A}},
+	{33, &JitArm64::lwzu},     //"lwzu", OPTYPE_LOAD, FL_OUT_D | FL_OUT_A | FL_IN_A}},
 	{34, &JitArm64::FallBackToInterpreter},     //"lbz",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A}},
 	{35, &JitArm64::FallBackToInterpreter},     //"lbzu", OPTYPE_LOAD, FL_OUT_D | FL_OUT_A | FL_IN_A}},
 	{40, &JitArm64::FallBackToInterpreter},     //"lhz",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A}},
@@ -208,8 +208,8 @@ static GekkoOPTemplate table31[] =
 	{1014, &JitArm64::FallBackToInterpreter},   //"dcbz",   OPTYPE_DCACHE, 0, 4}},
 
 	//load word
-	{23,  &JitArm64::FallBackToInterpreter},    //"lwzx",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A0 | FL_IN_B}},
-	{55,  &JitArm64::FallBackToInterpreter},    //"lwzux", OPTYPE_LOAD, FL_OUT_D | FL_OUT_A | FL_IN_A | FL_IN_B}},
+	{23,  &JitArm64::lwzx},    //"lwzx",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A0 | FL_IN_B}},
+	{55,  &JitArm64::lwzux},    //"lwzux", OPTYPE_LOAD, FL_OUT_D | FL_OUT_A | FL_IN_A | FL_IN_B}},
 
 	//load halfword
 	{279, &JitArm64::FallBackToInterpreter},    //"lhzx",  OPTYPE_LOAD, FL_OUT_D | FL_IN_A0 | FL_IN_B}},


### PR DESCRIPTION
Wow, I was really surprised to see that no load or store instructions
were implemented in JitArm64. They should work now, but I have nothing
to test on.
