### PR TITLE
VideoCommon: Don't specify the redundant in/out qualifier if GL_ARB_shading_language_420pack is supported.

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -88,11 +88,11 @@ static inline void GenerateGeometryShader(T& out, u32 primitive_type, API_TYPE A
 			out.Write("#define InstanceID gl_InvocationID\n");
 
 		out.Write("in VertexData {\n");
-		out.Write("\tcentroid in VS_OUTPUT o;\n");
+		out.Write("\tcentroid %s VS_OUTPUT o;\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? "" : "in");
 		out.Write("} vs[%d];\n", vertex_in);
 
 		out.Write("out VertexData {\n");
-		out.Write("\tcentroid out VS_OUTPUT o;\n");
+		out.Write("\tcentroid %s VS_OUTPUT o;\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? "" : "out");
 
 		if (g_ActiveConfig.iStereoMode > 0)
 			out.Write("\tflat int layer;\n");

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -320,7 +320,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 		if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
 		{
 			out.Write("in VertexData {\n");
-			out.Write("\tcentroid in VS_OUTPUT o;\n");
+			out.Write("\tcentroid %s VS_OUTPUT o;\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? "" : "in");
 
 			if (g_ActiveConfig.iStereoMode > 0)
 				out.Write("\tflat int layer;\n");

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -75,8 +75,8 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 		if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
 		{
 			out.Write("out VertexData {\n"
-			          "\tcentroid out VS_OUTPUT o;\n"
-			          "};\n");
+			          "\tcentroid %s VS_OUTPUT o;\n"
+					  "};\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? "" : "out");
 		}
 		else
 		{


### PR DESCRIPTION
Some driver developers interpreted "can" as "must" in the OpenGL specs. (I'm looking at you AMD)

>  they _can_ be separated from the in/out​ storage qualifier.
