### PR TITLE
[AArch64] Flush registers from register cache if they won't be used again.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -271,6 +271,10 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 
 			JitArm64Tables::CompileInstruction(ops[i]);
 
+			// If we have a register that will never be used again, flush it.
+			for (int j : ~ops[i].gprInUse)
+				gpr.StoreRegister(j);
+
 			if (js.memcheck && (opinfo->flags & FL_LOADSTORE))
 			{
 				// Don't do this yet


### PR DESCRIPTION
This requires PR #1705 and #1723 prior to merging.
