### PR TITLE
Remove the one commit (as far as I can tell) by soreau that added nontrivial material still in the tree

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -126,21 +126,6 @@ Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsi
 		// ramp effect
 		if (supported_effects & SDL_HAPTIC_RAMP)
 			AddOutput(new RampEffect(m_haptic));
-
-		// sine effect
-		if (supported_effects & SDL_HAPTIC_SINE)
-			AddOutput(new SineEffect(m_haptic));
-
-#ifdef SDL_HAPTIC_SQUARE
-		// square effect
-		if (supported_effects & SDL_HAPTIC_SQUARE)
-			AddOutput(new SquareEffect(m_haptic));
-
-#endif // defined(SDL_HAPTIC_SQUARE)
-
-		// triangle effect
-		if (supported_effects & SDL_HAPTIC_TRIANGLE)
-			AddOutput(new TriangleEffect(m_haptic));
 	}
 #endif
 
@@ -193,23 +178,6 @@ std::string Joystick::RampEffect::GetName() const
 	return "Ramp";
 }
 
-std::string Joystick::SineEffect::GetName() const
-{
-	return "Sine";
-}
-
-#ifdef SDL_HAPTIC_SQUARE
-std::string Joystick::SquareEffect::GetName() const
-{
-	return "Square";
-}
-#endif // defined(SDL_HAPTIC_SQUARE)
-
-std::string Joystick::TriangleEffect::GetName() const
-{
-	return "Triangle";
-}
-
 void Joystick::ConstantEffect::SetState(ControlState state)
 {
 	if (state)
@@ -239,65 +207,6 @@ void Joystick::RampEffect::SetState(ControlState state)
 	}
 
 	m_effect.ramp.start = (Sint16)(state * 0x7FFF);
-	Update();
-}
-
-void Joystick::SineEffect::SetState(ControlState state)
-{
-	if (state)
-	{
-		m_effect.type = SDL_HAPTIC_SINE;
-		m_effect.periodic.length = 250;
-	}
-	else
-	{
-		m_effect.type = 0;
-	}
-
-	m_effect.periodic.period = 5;
-	m_effect.periodic.magnitude = (Sint16)(state * 0x5000);
-	m_effect.periodic.attack_length = 0;
-	m_effect.periodic.fade_length = 500;
-	Update();
-}
-
-#ifdef SDL_HAPTIC_SQUARE
-void Joystick::SquareEffect::SetState(ControlState state)
-{
-	if (state)
-	{
-		m_effect.type = SDL_HAPTIC_SQUARE;
-		m_effect.periodic.length = 250;
-	}
-	else
-	{
-		m_effect.type = 0;
-	}
-
-	m_effect.periodic.period = 5;
-	m_effect.periodic.magnitude = state * 0x5000;
-	m_effect.periodic.attack_length = 0;
-	m_effect.periodic.fade_length = 100;
-	Update();
-}
-#endif // defined(SDL_HAPTIC_SQUARE)
-
-void Joystick::TriangleEffect::SetState(ControlState state)
-{
-	if (state)
-	{
-		m_effect.type = SDL_HAPTIC_TRIANGLE;
-		m_effect.periodic.length = 250;
-	}
-	else
-	{
-		m_effect.type = 0;
-	}
-
-	m_effect.periodic.period = 5;
-	m_effect.periodic.magnitude = (Sint16)(state * 0x5000);
-	m_effect.periodic.attack_length = 0;
-	m_effect.periodic.fade_length = 100;
 	Update();
 }
 #endif

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -98,32 +98,6 @@ private:
 		std::string GetName() const override;
 		void SetState(ControlState state) override;
 	};
-
-	class SineEffect : public HapticEffect
-	{
-	public:
-		SineEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
-		std::string GetName() const override;
-		void SetState(ControlState state) override;
-	};
-
-#ifdef SDL_HAPTIC_SQUARE
-	class SquareEffect : public HapticEffect
-	{
-	public:
-		SquareEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
-		std::string GetName() const;
-		void SetState(ControlState state);
-	};
-#endif // defined(SDL_HAPTIC_SQUARE)
-
-	class TriangleEffect : public HapticEffect
-	{
-	public:
-		TriangleEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
-		std::string GetName() const override;
-		void SetState(ControlState state) override;
-	};
 #endif
 
 public:


### PR DESCRIPTION
```
commit 202054708b1f221c720736ddee06741d66403ce3
Author: Scott Moreau <oreaus@gmail.com>
Date:   Thu Jan 23 19:41:07 2014 -0700

    EGL: Fix android build broken by last commit

commit d4ff195cadd3e7510eca7226bf43591d7f558671
Author: Scott Moreau <oreaus@gmail.com>
Date:   Thu Jan 23 19:20:22 2014 -0700

    EGL: Properly set parent window.

    In X with EGL and WX frontend enabled, running the emulator created
    two windows. This was because the parent window was set incorrectly.

commit 2c8340e1dc3b05d7f314c363ebc9278f40eb5350
Author: Scott Moreau <oreaus@gmail.com>
Date:   Mon Jan 20 00:46:21 2014 -0700

    Move GLInterface.h into GLInterface directory

commit 4b3c338930464c2d3d33d1e6fbd5397ef3067a2e
Author: Scott Moreau <oreaus@gmail.com>
Date:   Sun Jan 19 19:06:55 2014 -0700

    Merge Platform.h into GLInterface.h

commit 84aa98a5a4587629d6fa2bc9b3b07a5432c2e131
Author: Scott Moreau <oreaus@gmail.com>
Date:   Sun Jan 19 09:11:07 2014 -0700

    wayland: Add bits required to run as a wayland client.

--> all above commits involve code that was later rewritten or removed; no action taken

commit 1ffb9ce47eb2f84dc5feda027aa09991778ff283
Author: Scott Moreau <oreaus@gmail.com>
Date:   Sun Sep 2 16:53:15 2012 -0600

    Fix broken build when using SDL from Externals.

    The problem here was the logic that detects SDL in the main CMakeLists.txt
    is not the same as it is in DolphinWX/CmakeLists.txt to set libraries. When
    using SDL from Externals it failed at link time because -lSDL was never set.
    This fixes the problem by using the same condition logic to set the libs
    as used when detecting SDL in the first place.

--> pretty trivial, but was already rewritten anyway

commit 6773261a85d87bd7337689af55dd25c6963c7261
Author: Scott Moreau <oreaus@gmail.com>
Date:   Tue Aug 28 03:35:31 2012 -0600

    Use correct linker flags for SDL.

--> trivial makefile change which is the only correct way to do it; no action taken

commit 0e1348c839cd55a2321dda3a47f13dd5ee7075ef
Author: Scott Moreau <oreaus@gmail.com>
Date:   Sat Jul 14 16:58:31 2012 -0600

    Re-add hack to use SDL/SDL.h ifndef _WIN32.

    The correct convention is to use #include SDL.h in all cases but we have to
    do this so Externals/SDL builds, which isn't in the best shape.

--> no longer present

commit d34418100be19fdbdf112febde3303edd48c9247
Author: Scott Moreau <oreaus@gmail.com>
Date:   Wed Jul 11 14:48:15 2012 -0600

    Add periodic effects for haptic devices.

    This adds support for drivers supporting sine, square and triangle
    periodic haptic effects. This allows rumble to work on devices/drivers
    supporting these effects, such as an xbox controller using the xpad
    driver under Linux.

--> code removed; if you feel like fixing the xpad driver on Linux, don't read the commit...

commit 80c15f21b4556394330918d32e30b6c1bbbce42e
Author: Scott Moreau <oreaus@gmail.com>
Date:   Thu Jul 12 16:38:29 2012 -0600

    Add SDL2 support to build system.

    Dolphin code already builds against SDL2 but the build system never
    checks for SDL2, which is the what latest SDL is called now. SDL2
    replaces SDL 1.3. This allows Dolphin to be build against SDL2, which
    activates certain new features such as the haptic interface.

--> trivial except for FindSDL2.cmake, which was not written by soreau
```
