### PR TITLE
[ARMv7] Minor integer fastmem optimization.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm32/JitArm_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitArm_LoadStore.cpp
@@ -352,7 +352,7 @@ void JitArm::SafeLoadToReg(ARMReg dest, s32 addr, s32 offsetReg, int accessSize,
 
 	EmitBackpatchRoutine(this, flags,
 			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
-			!(is_immediate && Memory::IsRAMAddress(imm_addr)), dest);
+			true, dest);
 
 	if (update)
 		MOV(gpr.R(addr), rA);


### PR DESCRIPTION
This is a one instruction optimization for integer loadstores.
Makes sure to enable nop padding in some cases where a fault can still happen and cause us to overwrite other instructions that aren't meant to be.
