### PR TITLE
GeometryShaderManager: Set stereo parameters in a SetConstants() call.

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderManager.h
+++ b/Source/Core/VideoCommon/GeometryShaderManager.h
@@ -18,6 +18,7 @@ public:
 	static void Shutdown();
 	static void DoState(PointerWrap &p);
 
+	static void SetConstants();
 	static void SetViewportChanged();
 	static void SetProjectionChanged();
 	static void SetLinePtWidthChanged();

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -223,6 +223,7 @@ void VertexManager::Flush()
 
 	// set global constants
 	VertexShaderManager::SetConstants();
+	GeometryShaderManager::SetConstants();
 	PixelShaderManager::SetConstants();
 
 	bool useDstAlpha = !g_ActiveConfig.bDstAlphaPass &&


### PR DESCRIPTION
Doing it in SetProjectionChanged() is too early because the projection type is not set yet.
