### PR TITLE
OGL: Implement a line-width fallback when geometry shaders are unsupported.

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -1249,6 +1249,11 @@ void Renderer::SetDitherMode()
 	// TODO: Set dither mode to bpmem.blendmode.dither
 }
 
+void Renderer::SetLineWidth()
+{
+	// Handled by the geometry shader
+}
+
 void Renderer::SetSamplerState(int stage, int texindex)
 {
 	const FourTexUnits &tex = bpmem.tex[texindex];

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -19,6 +19,7 @@ public:
 	void SetDepthMode() override;
 	void SetLogicOpMode() override;
 	void SetDitherMode() override;
+	void SetLineWidth() override;
 	void SetSamplerState(int stage,int texindex) override;
 	void SetInterlacingMode() override;
 	void SetViewport() override;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -872,6 +872,12 @@ void Renderer::DrawDebugInfo()
 		GLsizei count = static_cast<GLsizei>(stats.efb_regions.size() * 2*6);
 		glDrawArrays(GL_LINES, 0, count);
 
+		// Restore Line Size
+		if (!g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+			SetLineWidth();
+		else
+			glLineWidth(1.0f);
+
 		// Clear stored regions
 		stats.efb_regions.clear();
 	}
@@ -1884,6 +1890,20 @@ void Renderer::SetDitherMode()
 		glEnable(GL_DITHER);
 	else
 		glDisable(GL_DITHER);
+}
+
+void Renderer::SetLineWidth()
+{
+	if (!g_ActiveConfig.backend_info.bSupportsGeometryShaders)
+	{
+		float fratio = xfmem.viewport.wd != 0 ?
+				((float)Renderer::GetTargetWidth() / EFB_WIDTH) : 1.0f;
+		if (bpmem.lineptwidth.linesize > 0)
+			// scale by ratio of widths
+			glLineWidth((float)bpmem.lineptwidth.linesize * fratio / 6.0f);
+		if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGL && bpmem.lineptwidth.pointsize > 0)
+			glPointSize((float)bpmem.lineptwidth.pointsize * fratio / 6.0f);
+	}
 }
 
 void Renderer::SetSamplerState(int stage, int texindex)

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -57,6 +57,7 @@ public:
 	void SetDepthMode() override;
 	void SetLogicOpMode() override;
 	void SetDitherMode() override;
+	void SetLineWidth() override;
 	void SetSamplerState(int stage,int texindex) override;
 	void SetInterlacingMode() override;
 	void SetViewport() override;

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -62,6 +62,11 @@ void SetScissor()
 	g_renderer->SetScissorRect(rc);
 }
 
+void SetLineWidth()
+{
+	g_renderer->SetLineWidth();
+}
+
 void SetDepthMode()
 {
 	g_renderer->SetDepthMode();

--- a/Source/Core/VideoCommon/BPFunctions.h
+++ b/Source/Core/VideoCommon/BPFunctions.h
@@ -18,6 +18,7 @@ namespace BPFunctions
 void FlushPipeline();
 void SetGenerationMode();
 void SetScissor();
+void SetLineWidth();
 void SetDepthMode();
 void SetBlendMode();
 void SetDitherMode();

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -129,6 +129,7 @@ static void BPWritten(const BPCmd& bp)
 		GeometryShaderManager::SetViewportChanged();
 		return;
 	case BPMEM_LINEPTWIDTH: // Line Width
+		SetLineWidth();
 		GeometryShaderManager::SetLinePtWidthChanged();
 		return;
 	case BPMEM_ZMODE: // Depth Control

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -55,6 +55,7 @@ public:
 	virtual void SetScissorRect(const EFBRectangle& rc) = 0;
 	virtual void SetGenerationMode() = 0;
 	virtual void SetDepthMode() = 0;
+	virtual void SetLineWidth() = 0;
 	virtual void SetLogicOpMode() = 0;
 	virtual void SetDitherMode() = 0;
 	virtual void SetSamplerState(int stage,int texindex) = 0;


### PR DESCRIPTION
Don't call it a fallback, it's been here for years.
