### PR TITLE
Accurate loading times for Wii games

### DIFF
--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -770,6 +770,7 @@ DVDCommandResult ExecuteCommand(u32 command_0, u32 command_1, u32 command_2,
 
 		// Less than ~1/155th of a second hangs Oregon Trail at "loading wheel".
 		// More than ~1/140th of a second hangs Resident Evil Archives: Resident Evil Zero.
+		// (Might not be true anymore since the other speeds were completely redone in December 2014)
 		result.ticks_until_completion = SystemTimers::GetTicksPerSecond() / 146;
 		break;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -529,7 +529,7 @@ void ExecuteCommand(u32 _Address)
 	// Ensure replies happen in order
 	const s64 ticks_until_last_reply = last_reply_time - CoreTiming::GetTicks();
 	if (ticks_until_last_reply > 0)
-		result.reply_delay_ticks = ticks_until_last_reply;
+		result.reply_delay_ticks += ticks_until_last_reply;
 	last_reply_time = CoreTiming::GetTicks() + result.reply_delay_ticks;
 
 	if (result.send_reply)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -349,7 +349,7 @@ void DoState(PointerWrap &p)
 
 void ExecuteCommand(u32 _Address)
 {
-	bool CmdSuccess = false;
+	IPCCommandResult result = IPC_NO_REPLY;
 
 	IPCCommandType Command = static_cast<IPCCommandType>(Memory::Read_U32(_Address));
 	volatile s32 DeviceID = Memory::Read_U32(_Address + 8);
@@ -379,7 +379,7 @@ void ExecuteCommand(u32 _Address)
 					{
 						es_inuse[j] = true;
 						g_FdMap[DeviceID] = es_handles[j];
-						CmdSuccess = es_handles[j]->Open(_Address, Mode);
+						result = es_handles[j]->Open(_Address, Mode);
 						Memory::Write_U32(DeviceID, _Address+4);
 						break;
 					}
@@ -388,7 +388,7 @@ void ExecuteCommand(u32 _Address)
 				if (j == ES_MAX_COUNT)
 				{
 					Memory::Write_U32(FS_EESEXHAUSTED, _Address + 4);
-					CmdSuccess = true;
+					result = IPC_DEFAULT_REPLY;
 				}
 			}
 			else if (DeviceName.find("/dev/") == 0)
@@ -397,7 +397,7 @@ void ExecuteCommand(u32 _Address)
 				if (pDevice)
 				{
 					g_FdMap[DeviceID] = pDevice;
-					CmdSuccess = pDevice->Open(_Address, Mode);
+					result = pDevice->Open(_Address, Mode);
 					INFO_LOG(WII_IPC_FILEIO, "IOP: ReOpen (Device=%s, DeviceID=%08x, Mode=%i)",
 						pDevice->GetDeviceName().c_str(), DeviceID, Mode);
 					Memory::Write_U32(DeviceID, _Address+4);
@@ -406,13 +406,13 @@ void ExecuteCommand(u32 _Address)
 				{
 					WARN_LOG(WII_IPC_HLE, "Unimplemented device: %s", DeviceName.c_str());
 					Memory::Write_U32(FS_ENOENT, _Address+4);
-					CmdSuccess = true;
+					result = IPC_DEFAULT_REPLY;
 				}
 			}
 			else
 			{
 				pDevice = CreateFileIO(DeviceID, DeviceName);
-				CmdSuccess = pDevice->Open(_Address, Mode);
+				result = pDevice->Open(_Address, Mode);
 
 				INFO_LOG(WII_IPC_FILEIO, "IOP: Open File (Device=%s, ID=%08x, Mode=%i)",
 						pDevice->GetDeviceName().c_str(), DeviceID, Mode);
@@ -430,7 +430,7 @@ void ExecuteCommand(u32 _Address)
 		else
 		{
 			Memory::Write_U32(FS_EFDEXHAUSTED, _Address + 4);
-			CmdSuccess = true;
+			result = IPC_DEFAULT_REPLY;
 		}
 		break;
 	}
@@ -438,7 +438,7 @@ void ExecuteCommand(u32 _Address)
 	{
 		if (pDevice)
 		{
-			CmdSuccess = pDevice->Close(_Address);
+			result = pDevice->Close(_Address);
 
 			for (u32 j=0; j<ES_MAX_COUNT; j++)
 			{
@@ -460,7 +460,7 @@ void ExecuteCommand(u32 _Address)
 		else
 		{
 			Memory::Write_U32(FS_EINVAL, _Address + 4);
-			CmdSuccess = true;
+			result = IPC_DEFAULT_REPLY;
 		}
 		break;
 	}
@@ -468,12 +468,12 @@ void ExecuteCommand(u32 _Address)
 	{
 		if (pDevice)
 		{
-			CmdSuccess = pDevice->Read(_Address);
+			result = pDevice->Read(_Address);
 		}
 		else
 		{
 			Memory::Write_U32(FS_EINVAL, _Address + 4);
-			CmdSuccess = true;
+			result = IPC_DEFAULT_REPLY;
 		}
 		break;
 	}
@@ -481,12 +481,12 @@ void ExecuteCommand(u32 _Address)
 	{
 		if (pDevice)
 		{
-			CmdSuccess = pDevice->Write(_Address);
+			result = pDevice->Write(_Address);
 		}
 		else
 		{
 			Memory::Write_U32(FS_EINVAL, _Address + 4);
-			CmdSuccess = true;
+			result = IPC_DEFAULT_REPLY;
 		}
 		break;
 	}
@@ -494,12 +494,12 @@ void ExecuteCommand(u32 _Address)
 	{
 		if (pDevice)
 		{
-			CmdSuccess = pDevice->Seek(_Address);
+			result = pDevice->Seek(_Address);
 		}
 		else
 		{
 			Memory::Write_U32(FS_EINVAL, _Address + 4);
-			CmdSuccess = true;
+			result = IPC_DEFAULT_REPLY;
 		}
 		break;
 	}
@@ -507,7 +507,7 @@ void ExecuteCommand(u32 _Address)
 	{
 		if (pDevice)
 		{
-			CmdSuccess = pDevice->IOCtl(_Address);
+			result = pDevice->IOCtl(_Address);
 		}
 		break;
 	}
@@ -515,7 +515,7 @@ void ExecuteCommand(u32 _Address)
 	{
 		if (pDevice)
 		{
-			CmdSuccess = pDevice->IOCtlV(_Address);
+			result = pDevice->IOCtlV(_Address);
 		}
 		break;
 	}
@@ -526,34 +526,20 @@ void ExecuteCommand(u32 _Address)
 	}
 	}
 
+	// Ensure replies happen in order
+	const s64 ticks_until_last_reply = last_reply_time - CoreTiming::GetTicks();
+	if (ticks_until_last_reply > 0)
+		result.reply_delay_ticks = ticks_until_last_reply;
+	last_reply_time = CoreTiming::GetTicks() + result.reply_delay_ticks;
 
-	if (CmdSuccess)
+	if (result.send_reply)
 	{
 		// The original hardware overwrites the command type with the async reply type.
 		Memory::Write_U32(IPC_REP_ASYNC, _Address);
 		// IOS also seems to write back the command that was responded to in the FD field.
 		Memory::Write_U32(Command, _Address + 8);
-
-		// Ensure replies happen in order, fairly ugly
-		// Without this, tons of games fail now that DI commands have different reply delays
-		int reply_delay = pDevice ? pDevice->GetCmdDelay(_Address) : 0;
-		if (!reply_delay)
-		{
-			int delay_us = 250;
-			reply_delay = SystemTimers::GetTicksPerSecond() / 1000000 * delay_us;
-		}
-
-		const s64 ticks_til_last_reply = last_reply_time - CoreTiming::GetTicks();
-
-		if (ticks_til_last_reply > 0)
-		{
-			reply_delay = (int)ticks_til_last_reply;
-		}
-
-		last_reply_time = CoreTiming::GetTicks() + reply_delay;
-
 		// Generate a reply to the IPC command
-		EnqueueReply(_Address, reply_delay);
+		EnqueueReply(_Address, (int)result.reply_delay_ticks);
 	}
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -8,8 +8,16 @@
 
 #include "Common/CommonTypes.h"
 
+#include "Core/HW/SystemTimers.h"
+
 class IWII_IPC_HLE_Device;
 class PointerWrap;
+
+struct IPCCommandResult
+{
+	bool send_reply;
+	u64 reply_delay_ticks;
+};
 
 enum IPCCommandType : u32
 {
@@ -25,6 +33,10 @@ enum IPCCommandType : u32
 	// Reference: http://wiibrew.org/wiki/IOS
 	IPC_REP_ASYNC  = 8
 };
+
+static const u32 IPC_DEFAULT_DELAY = SystemTimers::GetTicksPerSecond() / 4000;	// 250 us
+static const IPCCommandResult IPC_NO_REPLY = { false, 0 };
+static const IPCCommandResult IPC_DEFAULT_REPLY = { true, IPC_DEFAULT_DELAY };
 
 namespace WII_IPC_HLE_Interface
 {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -11,6 +11,7 @@
 #include "Common/StringUtil.h"
 
 #include "Core/HW/Memmap.h"
+#include "Core/IPC_HLE/WII_IPC_HLE.h"
 
 #define FS_SUCCESS      (u32)0      // Success
 #define FS_EACCES       (u32)-1     // Permission denied
@@ -119,39 +120,37 @@ public:
 	const std::string& GetDeviceName() const { return m_Name; }
 	u32 GetDeviceID() const { return m_DeviceID; }
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode)
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode)
 	{
 		(void)_Mode;
 		WARN_LOG(WII_IPC_HLE, "%s does not support Open()", m_Name.c_str());
 		Memory::Write_U32(FS_ENOENT, _CommandAddress + 4);
 		m_Active = true;
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
-	virtual bool Close(u32 _CommandAddress, bool _bForce = false)
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce = false)
 	{
 		WARN_LOG(WII_IPC_HLE, "%s does not support Close()", m_Name.c_str());
 		if (!_bForce)
 			Memory::Write_U32(FS_EINVAL, _CommandAddress + 4);
 		m_Active = false;
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
-#define UNIMPLEMENTED_CMD(cmd) WARN_LOG(WII_IPC_HLE, "%s does not support "#cmd"()", m_Name.c_str()); return true;
-	virtual bool Seek   (u32) { UNIMPLEMENTED_CMD(Seek) }
-	virtual bool Read   (u32) { UNIMPLEMENTED_CMD(Read) }
-	virtual bool Write  (u32) { UNIMPLEMENTED_CMD(Write) }
-	virtual bool IOCtl  (u32) { UNIMPLEMENTED_CMD(IOCtl) }
-	virtual bool IOCtlV (u32) { UNIMPLEMENTED_CMD(IOCtlV) }
+#define UNIMPLEMENTED_CMD(cmd) WARN_LOG(WII_IPC_HLE, "%s does not support "#cmd"()", m_Name.c_str()); return IPC_DEFAULT_REPLY;
+	virtual IPCCommandResult Seek(u32)   { UNIMPLEMENTED_CMD(Seek) }
+	virtual IPCCommandResult Read(u32)   { UNIMPLEMENTED_CMD(Read) }
+	virtual IPCCommandResult Write(u32)  { UNIMPLEMENTED_CMD(Write) }
+	virtual IPCCommandResult IOCtl(u32)  { UNIMPLEMENTED_CMD(IOCtl) }
+	virtual IPCCommandResult IOCtlV(u32) { UNIMPLEMENTED_CMD(IOCtlV) }
 #undef UNIMPLEMENTED_CMD
-
-	virtual int GetCmdDelay(u32) { return 0; }
 
 	virtual u32 Update() { return 0; }
 
 	virtual bool IsHardware() { return m_Hardware; }
 	virtual bool IsOpened() { return m_Active; }
-public:
+
 	std::string m_Name;
 protected:
 
@@ -223,33 +222,33 @@ public:
 	{
 	}
 
-	bool Open(u32 CommandAddress, u32 Mode) override
+	IPCCommandResult Open(u32 CommandAddress, u32 Mode) override
 	{
 		(void)Mode;
 		WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_Name.c_str());
 		Memory::Write_U32(GetDeviceID(), CommandAddress + 4);
 		m_Active = true;
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
-	bool Close(u32 CommandAddress, bool bForce = false) override
+	IPCCommandResult Close(u32 CommandAddress, bool bForce = false) override
 	{
 		WARN_LOG(WII_IPC_HLE, "%s faking Close()", m_Name.c_str());
 		if (!bForce)
 			Memory::Write_U32(FS_SUCCESS, CommandAddress + 4);
 		m_Active = false;
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
-	bool IOCtl(u32 CommandAddress) override
+	IPCCommandResult IOCtl(u32 CommandAddress) override
 	{
 		WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_Name.c_str());
 		Memory::Write_U32(FS_SUCCESS, CommandAddress + 4);
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
-	bool IOCtlV(u32 CommandAddress) override
+	IPCCommandResult IOCtlV(u32 CommandAddress) override
 	{
 		WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_Name.c_str());
 		Memory::Write_U32(FS_SUCCESS, CommandAddress + 4);
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -25,22 +25,22 @@ CWII_IPC_HLE_Device_di::CWII_IPC_HLE_Device_di(u32 _DeviceID, const std::string&
 CWII_IPC_HLE_Device_di::~CWII_IPC_HLE_Device_di()
 {}
 
-bool CWII_IPC_HLE_Device_di::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_di::Open(u32 _CommandAddress, u32 _Mode)
 {
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_di::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_di::Close(u32 _CommandAddress, bool _bForce)
 {
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
 {
 	u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
 	u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
@@ -66,10 +66,10 @@ bool CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
 	                                         BufferOut, BufferOutSize, false);
 	Memory::Write_U32(result.interrupt_type, _CommandAddress + 0x4);
 	// TODO: Don't discard result.ticks_until_completion
-	return true;
+	return { true, GetCmdDelay(_CommandAddress) };
 }
 
-bool CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
 {
 	SIOCtlVBuffer CommandBuffer(_CommandAddress);
 
@@ -111,10 +111,10 @@ bool CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-int CWII_IPC_HLE_Device_di::GetCmdDelay(u32 _CommandAddress)
+u64 CWII_IPC_HLE_Device_di::GetCmdDelay(u32 _CommandAddress)
 {
 	u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
 	u32 Command  = Memory::Read_U32(BufferIn) >> 24;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
@@ -25,8 +25,4 @@ public:
 
 	IPCCommandResult IOCtl(u32 _CommandAddress) override;
 	IPCCommandResult IOCtlV(u32 _CommandAddress) override;
-
-private:
-
-	u64 CWII_IPC_HLE_Device_di::GetCmdDelay(u32 _CommandAddress);
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
@@ -20,11 +20,13 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_di();
 
-	bool Open(u32 _CommandAddress, u32 _Mode) override;
-	bool Close(u32 _CommandAddress, bool _bForce) override;
+	IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
-	bool IOCtl(u32 _CommandAddress) override;
-	bool IOCtlV(u32 _CommandAddress) override;
+	IPCCommandResult IOCtl(u32 _CommandAddress) override;
+	IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
-	int GetCmdDelay(u32) override;
+private:
+
+	u64 CWII_IPC_HLE_Device_di::GetCmdDelay(u32 _CommandAddress);
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -78,7 +78,7 @@ CWII_IPC_HLE_Device_FileIO::~CWII_IPC_HLE_Device_FileIO()
 {
 }
 
-bool CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bForce)
 {
 	INFO_LOG(WII_IPC_FILEIO, "FileIO: Close %s (DeviceID=%08x)", m_Name.c_str(), m_DeviceID);
 	m_Mode = 0;
@@ -87,10 +87,10 @@ bool CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bForce)
 	if (_CommandAddress && !_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_FileIO::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 _CommandAddress, u32 _Mode)
 {
 	m_Mode = _Mode;
 	u32 ReturnValue = 0;
@@ -121,7 +121,7 @@ bool CWII_IPC_HLE_Device_FileIO::Open(u32 _CommandAddress, u32 _Mode)
 	if (_CommandAddress)
 		Memory::Write_U32(ReturnValue, _CommandAddress+4);
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 File::IOFile CWII_IPC_HLE_Device_FileIO::OpenFile()
@@ -147,7 +147,7 @@ File::IOFile CWII_IPC_HLE_Device_FileIO::OpenFile()
 	return File::IOFile(m_filepath, open_mode);
 }
 
-bool CWII_IPC_HLE_Device_FileIO::Seek(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Seek(u32 _CommandAddress)
 {
 	u32 ReturnValue = FS_RESULT_FATAL;
 	const s32 SeekPosition = Memory::Read_U32(_CommandAddress + 0xC);
@@ -208,10 +208,10 @@ bool CWII_IPC_HLE_Device_FileIO::Seek(u32 _CommandAddress)
 	}
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
 
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
 {
 	u32 ReturnValue = FS_EACCESS;
 	const u32 Address = Memory::Read_U32(_CommandAddress + 0xC); // Read to this memory address
@@ -247,10 +247,10 @@ bool CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
 {
 	u32 ReturnValue = FS_EACCESS;
 	const u32 Address = Memory::Read_U32(_CommandAddress + 0xC); // Write data from this memory address
@@ -280,10 +280,10 @@ bool CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
 {
 	INFO_LOG(WII_IPC_FILEIO, "FileIO: IOCtl (Device=%s)", m_Name.c_str());
 #if defined(_DEBUG) || defined(DEBUGFAST)
@@ -323,7 +323,7 @@ bool CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
 
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 void CWII_IPC_HLE_Device_FileIO::DoState(PointerWrap &p)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
@@ -17,12 +17,12 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_FileIO();
 
-	bool Close(u32 _CommandAddress, bool _bForce) override;
-	bool Open(u32 _CommandAddress, u32 _Mode) override;
-	bool Seek(u32 _CommandAddress) override;
-	bool Read(u32 _CommandAddress) override;
-	bool Write(u32 _CommandAddress) override;
-	bool IOCtl(u32 _CommandAddress) override;
+	IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
+	IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	IPCCommandResult Seek(u32 _CommandAddress) override;
+	IPCCommandResult Read(u32 _CommandAddress) override;
+	IPCCommandResult Write(u32 _CommandAddress) override;
+	IPCCommandResult IOCtl(u32 _CommandAddress) override;
 	void DoState(PointerWrap &p) override;
 
 	File::IOFile OpenFile();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -172,7 +172,7 @@ void CWII_IPC_HLE_Device_es::DoState(PointerWrap& p)
 	}
 }
 
-bool CWII_IPC_HLE_Device_es::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_es::Open(u32 _CommandAddress, u32 _Mode)
 {
 	OpenInternal();
 
@@ -180,10 +180,10 @@ bool CWII_IPC_HLE_Device_es::Open(u32 _CommandAddress, u32 _Mode)
 	if (m_Active)
 		INFO_LOG(WII_IPC_ES, "Device was re-opened.");
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce)
 {
 	// Leave deletion of the INANDContentLoader objects to CNANDContentManager, don't do it here!
 	m_NANDContent.clear();
@@ -201,7 +201,7 @@ bool CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce)
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 u32 CWII_IPC_HLE_Device_es::OpenTitleContent(u32 CFD, u64 TitleID, u16 Index)
@@ -244,7 +244,7 @@ u32 CWII_IPC_HLE_Device_es::OpenTitleContent(u32 CFD, u64 TitleID, u16 Index)
 	return CFD;
 }
 
-bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 {
 	SIOCtlVBuffer Buffer(_CommandAddress);
 
@@ -281,7 +281,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETDEVICEID %08X", ec.getNgId());
 			Memory::Write_U32(ec.getNgId(), Buffer.PayloadBuffer[0].m_Address);
 			Memory::Write_U32(0, _CommandAddress + 0x4);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -311,7 +311,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTITLECONTENTSCNT: TitleID: %08x/%08x  content count %i",
 				(u32)(TitleID>>32), (u32)TitleID, rNANDContent.IsValid() ? NumberOfPrivateContent : (u32)rNANDContent.GetContentSize());
 
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -342,7 +342,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 						GetContentSize());
 			}
 
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -360,7 +360,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_OPENTITLECONTENT: TitleID: %08x/%08x  Index %i -> got CFD %x", (u32)(TitleID>>32), (u32)TitleID, Index, CFD);
 
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -374,7 +374,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(CFD, _CommandAddress + 0x4);
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_OPENCONTENT: Index %i -> got CFD %x", Index, CFD);
 
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -391,7 +391,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			if (itr == m_ContentAccessMap.end())
 			{
 				Memory::Write_U32(-1, _CommandAddress + 0x4);
-				return true;
+				return IPC_DEFAULT_REPLY;
 			}
 			SContentAccess& rContent = itr->second;
 
@@ -433,7 +433,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_READCONTENT: CFD %x, Address 0x%x, Size %i -> stream pos %i (Index %i)", CFD, Addr, Size, rContent.m_Position, rContent.m_pContent->m_Index);
 
 			Memory::Write_U32(Size, _CommandAddress + 0x4);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -450,14 +450,14 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			if (itr == m_ContentAccessMap.end())
 			{
 				Memory::Write_U32(-1, _CommandAddress + 0x4);
-				return true;
+				return IPC_DEFAULT_REPLY;
 			}
 
 			delete itr->second.m_pFile;
 			m_ContentAccessMap.erase(itr);
 
 			Memory::Write_U32(0, _CommandAddress + 0x4);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -474,7 +474,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			if (itr == m_ContentAccessMap.end())
 			{
 				Memory::Write_U32(-1, _CommandAddress + 0x4);
-				return true;
+				return IPC_DEFAULT_REPLY;
 			}
 			SContentAccess& rContent = itr->second;
 
@@ -496,7 +496,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_SEEKCONTENT: CFD %x, Address 0x%x, Mode %i -> Pos %i", CFD, Addr, Mode, rContent.m_Position);
 
 			Memory::Write_U32(rContent.m_Position, _CommandAddress + 0x4);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -547,7 +547,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -570,7 +570,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTITLES: Number of titles returned %i", Count);
 			Memory::Write_U32(0, _CommandAddress + 0x4);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -617,7 +617,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			Memory::Write_U32(ViewCount, Buffer.PayloadBuffer[0].m_Address);
 			Memory::Write_U32(retVal, _CommandAddress + 0x4);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -681,7 +681,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETVIEWS for titleID: %08x/%08x (MaxViews = %i)", (u32)(TitleID >> 32), (u32)TitleID, maxViews);
 
 			Memory::Write_U32(retVal, _CommandAddress + 0x4);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -707,7 +707,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTMDVIEWCNT: title: %08x/%08x (view size %i)", (u32)(TitleID >> 32), (u32)TitleID, TMDViewCnt);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -747,7 +747,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTMDVIEWS: title: %08x/%08x (buffer size: %i)", (u32)(TitleID >> 32), (u32)TitleID, MaxCount);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -755,7 +755,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 		Memory::Write_U32(0, Buffer.PayloadBuffer[1].m_Address);
 		Memory::Write_U32(0, _CommandAddress + 0x4);
 		WARN_LOG(WII_IPC_ES, "IOCTL_ES_GETCONSUMPTION:%d", Memory::Read_U32(_CommandAddress+4));
-		return true;
+		return IPC_DEFAULT_REPLY;
 
 	case IOCTL_ES_DELETETICKET:
 		{
@@ -809,7 +809,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETSTOREDTMDSIZE: title: %08x/%08x (view size %i)", (u32)(TitleID >> 32), (u32)TitleID, TMDCnt);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 	case IOCTL_ES_GETSTOREDTMD:
@@ -850,7 +850,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETSTOREDTMD: title: %08x/%08x (buffer size: %i)", (u32)(TitleID >> 32), (u32)TitleID, MaxCount);
-			return true;
+			return IPC_DEFAULT_REPLY;
 		}
 		break;
 
@@ -997,7 +997,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			// Generate a "reply" to the IPC command.  ES_LAUNCH is unique because it
 			// involves restarting IOS; IOS generates two acknowledgements in a row.
 			WII_IPC_HLE_Interface::EnqueueCommandAcknowledgement(_CommandAddress, 0);
-			return false;
+			return IPC_NO_REPLY;
 		}
 		break;
 
@@ -1006,7 +1006,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 		//if the IOS didn't find the Korean keys and 0 if it does. 0 leads to a error 003
 		WARN_LOG(WII_IPC_ES,"IOCTL_ES_CHECKKOREAREGION: Title checked for Korean keys.");
 		Memory::Write_U32(ES_PARAMTER_SIZE_OR_ALIGNMENT , _CommandAddress + 0x4);
-		return true;
+		return IPC_DEFAULT_REPLY;
 
 	case IOCTL_ES_GETDEVICECERT: // (Input: none, Output: 384 bytes)
 		{
@@ -1062,7 +1062,7 @@ bool CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 	// Write return value (0 means OK)
 	Memory::Write_U32(0, _CommandAddress + 0x4);
 
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 const DiscIO::INANDContentLoader& CWII_IPC_HLE_Device_es::AccessContentDevice(u64 _TitleID)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
@@ -24,11 +24,11 @@ public:
 
 	virtual void DoState(PointerWrap& p) override;
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override;
+	virtual IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
-	virtual bool IOCtlV(u32 _CommandAddress) override;
 	static u32 ES_DIVerify(u8 *_pTMD, u32 _sz);
 
 	// This should only be cleared on power reset

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -38,13 +38,11 @@ public:
 
 	virtual void DoState(PointerWrap& p) override;
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override;
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override;
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
-	virtual bool IOCtl(u32 _CommandAddress) override;
-	virtual bool IOCtlV(u32 _CommandAddress) override;
-
-	virtual int GetCmdDelay(u32) override;
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override;
+	virtual IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
 private:
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -109,24 +109,24 @@ CWII_IPC_HLE_Device_hid::~CWII_IPC_HLE_Device_hid()
 		libusb_exit(nullptr);
 }
 
-bool CWII_IPC_HLE_Device_hid::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_hid::Open(u32 _CommandAddress, u32 _Mode)
 {
 	DEBUG_LOG(WII_IPC_HID, "HID::Open");
 	m_Active = true;
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_hid::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_hid::Close(u32 _CommandAddress, bool _bForce)
 {
 	DEBUG_LOG(WII_IPC_HID, "HID::Close");
 	m_Active = false;
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 {
 	u32 Parameter     = Memory::Read_U32(_CommandAddress + 0xC);
 	u32 BufferIn      = Memory::Read_U32(_CommandAddress + 0x10);
@@ -142,7 +142,7 @@ bool CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 		DEBUG_LOG(WII_IPC_HID, "HID::IOCtl(Get Attached) (BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
 			BufferIn, BufferInSize, BufferOut, BufferOutSize);
 		deviceCommandAddress = _CommandAddress;
-		return false;
+		return IPC_NO_REPLY;
 	}
 	case IOCTL_HID_OPEN:
 	{
@@ -205,7 +205,7 @@ bool CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 		//          bmRequestType, bRequest, BufferIn, BufferInSize, BufferOut, BufferOutSize);
 
 		// It's the async way!
-		return false;
+		return IPC_NO_REPLY;
 	}
 	case IOCTL_HID_INTERRUPT_OUT:
 	case IOCTL_HID_INTERRUPT_IN:
@@ -236,7 +236,7 @@ bool CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 		//          Parameter == IOCTL_HID_INTERRUPT_IN ? "In" : "Out", endpoint, length, data, BufferIn, BufferInSize, BufferOut, BufferOutSize);
 
 		// It's the async way!
-		return false;
+		return IPC_NO_REPLY;
 	}
 	case IOCTL_HID_SHUTDOWN:
 	{
@@ -269,7 +269,7 @@ bool CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 4);
 
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 
@@ -299,7 +299,7 @@ bool CWII_IPC_HLE_Device_hid::ClaimDevice(libusb_device_handle * dev)
 	return true;
 }
 
-bool CWII_IPC_HLE_Device_hid::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtlV(u32 _CommandAddress)
 {
 
 	Dolphin_Debugger::PrintCallstack(LogTypes::WII_IPC_HID, LogTypes::LWARNING);
@@ -318,7 +318,7 @@ bool CWII_IPC_HLE_Device_hid::IOCtlV(u32 _CommandAddress)
 	#endif
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -36,11 +36,11 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_hid();
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override;
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override;
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
-	virtual bool IOCtlV(u32 _CommandAddress) override;
-	virtual bool IOCtl(u32 _CommandAddress) override;
+	virtual IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override;
 
 private:
 	enum

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -60,24 +60,24 @@ CWII_IPC_HLE_Device_net_kd_request::~CWII_IPC_HLE_Device_net_kd_request()
 	WiiSockMan::GetInstance().Clean();
 }
 
-bool CWII_IPC_HLE_Device_net_kd_request::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Open(u32 _CommandAddress, u32 _Mode)
 {
 	INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: Open");
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_net_kd_request::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Close(u32 _CommandAddress, bool _bForce)
 {
 	INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: Close");
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 {
 	u32 Parameter     = Memory::Read_U32(_CommandAddress + 0xC);
 	u32 BufferIn      = Memory::Read_U32(_CommandAddress + 0x10);
@@ -205,7 +205,7 @@ bool CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 
@@ -340,24 +340,24 @@ CWII_IPC_HLE_Device_net_ncd_manage::~CWII_IPC_HLE_Device_net_ncd_manage()
 {
 }
 
-bool CWII_IPC_HLE_Device_net_ncd_manage::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Open(u32 _CommandAddress, u32 _Mode)
 {
 	INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: Open");
 	Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_net_ncd_manage::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Close(u32 _CommandAddress, bool _bForce)
 {
 	INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: Close");
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
 {
 	u32 return_value = 0;
 	u32 common_result = 0;
@@ -423,7 +423,7 @@ bool CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
 		Memory::Write_U32(common_result, CommandBuffer.PayloadBuffer.at(common_vector).m_Address + 4);
 	}
 	Memory::Write_U32(return_value, _CommandAddress + 4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 // **********************************************************************************
@@ -437,27 +437,27 @@ CWII_IPC_HLE_Device_net_wd_command::~CWII_IPC_HLE_Device_net_wd_command()
 {
 }
 
-bool CWII_IPC_HLE_Device_net_wd_command::Open(u32 CommandAddress, u32 Mode)
+IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Open(u32 CommandAddress, u32 Mode)
 {
 	INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND: Open");
 	Memory::Write_U32(GetDeviceID(), CommandAddress + 4);
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_net_wd_command::Close(u32 CommandAddress, bool Force)
+IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Close(u32 CommandAddress, bool Force)
 {
 	INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND: Close");
 	if (!Force)
 		Memory::Write_U32(0, CommandAddress + 4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 // This is just for debugging / playing around.
 // There really is no reason to implement wd unless we can bend it such that
 // we can talk to the DS.
-bool CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
 {
 	u32 return_value = 0;
 
@@ -544,7 +544,7 @@ bool CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
 	}
 
 	Memory::Write_U32(return_value, CommandAddress + 4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 // **********************************************************************************
@@ -565,21 +565,21 @@ CWII_IPC_HLE_Device_net_ip_top::~CWII_IPC_HLE_Device_net_ip_top()
 #endif
 }
 
-bool CWII_IPC_HLE_Device_net_ip_top::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Open(u32 _CommandAddress, u32 _Mode)
 {
 	INFO_LOG(WII_IPC_NET, "NET_IP_TOP: Open");
 	Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_net_ip_top::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Close(u32 _CommandAddress, bool _bForce)
 {
 	INFO_LOG(WII_IPC_NET, "NET_IP_TOP: Close");
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 static int inet_pton(const char* src, unsigned char* dst)
@@ -638,7 +638,7 @@ static unsigned int opt_name_mapping[][2] = {
 	{ SO_ERROR, 0x1009 }
 };
 
-bool CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 {
 	u32 Command       = Memory::Read_U32(_CommandAddress + 0x0C);
 	u32 BufferIn      = Memory::Read_U32(_CommandAddress + 0x10);
@@ -697,7 +697,7 @@ bool CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 		u32 fd = Memory::Read_U32(BufferIn);
 		WiiSockMan &sm = WiiSockMan::GetInstance();
 		sm.DoSock(fd, _CommandAddress, (NET_IOCTL)Command);
-		return false;
+		return IPC_NO_REPLY;
 	}
 	/////////////////////////////////////////////////////////////
 	//                  TODO: Tidy all below                   //
@@ -1134,11 +1134,11 @@ bool CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
 
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 
-bool CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
 {
 	SIOCtlVBuffer CommandBuffer(CommandAddress);
 
@@ -1307,7 +1307,7 @@ bool CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
 		u32 fd = Memory::Read_U32(_BufferIn2);
 		WiiSockMan &sm = WiiSockMan::GetInstance();
 		sm.DoSock(fd, CommandAddress, IOCTLV_SO_SENDTO);
-		return false;
+		return IPC_NO_REPLY;
 		break;
 	}
 	case IOCTLV_SO_RECVFROM:
@@ -1315,7 +1315,7 @@ bool CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
 		u32 fd = Memory::Read_U32(_BufferIn);
 		WiiSockMan &sm = WiiSockMan::GetInstance();
 		sm.DoSock(fd, CommandAddress, IOCTLV_SO_RECVFROM);
-		return false;
+		return IPC_NO_REPLY;
 		break;
 	}
 	case IOCTLV_SO_GETADDRINFO:
@@ -1491,7 +1491,7 @@ bool CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, CommandAddress + 4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 u32 CWII_IPC_HLE_Device_net_ip_top::Update()
 {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -391,9 +391,9 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_net_kd_request();
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override;
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override;
-	virtual bool IOCtl(u32 _CommandAddress) override;
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override;
 
 private:
 	enum
@@ -454,22 +454,22 @@ public:
 	virtual ~CWII_IPC_HLE_Device_net_kd_time()
 	{}
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override
 	{
 		INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Open");
 		Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
 	{
 		INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Close");
 		if (!_bForce)
 			Memory::Write_U32(0, _CommandAddress + 4);
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
-	virtual bool IOCtl(u32 _CommandAddress) override
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override
 	{
 		u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
 		u32 BufferIn  = Memory::Read_U32(_CommandAddress + 0x10);
@@ -512,7 +512,7 @@ public:
 		// write return values
 		Memory::Write_U32(common_result, BufferOut);
 		Memory::Write_U32(result, _CommandAddress + 4);
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
 private:
@@ -593,10 +593,10 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_net_ip_top();
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override;
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override;
-	virtual bool IOCtl(u32 _CommandAddress) override;
-	virtual bool IOCtlV(u32 _CommandAddress) override;
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override;
+	virtual IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
 	virtual u32 Update() override;
 
@@ -617,9 +617,9 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_net_ncd_manage();
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override;
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override;
-	virtual bool IOCtlV(u32 _CommandAddress) override;
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
+	virtual IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
 private:
 	enum
@@ -645,9 +645,9 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_net_wd_command();
 
-	virtual bool Open(u32 CommandAddress, u32 Mode) override;
-	virtual bool Close(u32 CommandAddress, bool Force) override;
-	virtual bool IOCtlV(u32 CommandAddress) override;
+	virtual IPCCommandResult Open(u32 CommandAddress, u32 Mode) override;
+	virtual IPCCommandResult Close(u32 CommandAddress, bool Force) override;
+	virtual IPCCommandResult IOCtlV(u32 CommandAddress) override;
 
 private:
 	enum

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -52,24 +52,24 @@ int CWII_IPC_HLE_Device_net_ssl::getSSLFreeID()
 	return 0;
 }
 
-bool CWII_IPC_HLE_Device_net_ssl::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Open(u32 _CommandAddress, u32 _Mode)
 {
 	Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_net_ssl::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Close(u32 _CommandAddress, bool _bForce)
 {
 	if (!_bForce)
 	{
 		Memory::Write_U32(0, _CommandAddress + 4);
 	}
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_net_ssl::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(u32 _CommandAddress)
 {
 	u32 BufferIn      = Memory::Read_U32(_CommandAddress + 0x10);
 	u32 BufferInSize  = Memory::Read_U32(_CommandAddress + 0x14);
@@ -82,10 +82,10 @@ bool CWII_IPC_HLE_Device_net_ssl::IOCtl(u32 _CommandAddress)
 	         GetDeviceName().c_str(), Command,
 	         BufferIn, BufferInSize, BufferOut, BufferOutSize);
 	Memory::Write_U32(0, _CommandAddress + 0x4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
 {
 	SIOCtlVBuffer CommandBuffer(_CommandAddress);
 
@@ -393,7 +393,7 @@ _SSL_NEW_ERROR:
 		{
 			WiiSockMan &sm = WiiSockMan::GetInstance();
 			sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_DOHANDSHAKE);
-			return false;
+			return IPC_NO_REPLY;
 		}
 		else
 		{
@@ -408,7 +408,7 @@ _SSL_NEW_ERROR:
 		{
 			WiiSockMan &sm = WiiSockMan::GetInstance();
 			sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_WRITE);
-			return false;
+			return IPC_NO_REPLY;
 		}
 		else
 		{
@@ -433,7 +433,7 @@ _SSL_NEW_ERROR:
 		{
 			WiiSockMan &sm = WiiSockMan::GetInstance();
 			sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_READ);
-			return false;
+			return IPC_NO_REPLY;
 		}
 		else
 		{
@@ -506,6 +506,6 @@ _SSL_NEW_ERROR:
 	// SSL return codes are written to BufferIn
 	Memory::Write_U32(0, _CommandAddress+4);
 
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
@@ -75,12 +75,12 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_net_ssl();
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override;
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override;
+	virtual IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
-	virtual bool IOCtl(u32 _CommandAddress) override;
-	virtual bool IOCtlV(u32 _CommandAddress) override;
 	int getSSLFreeID();
 
 	static WII_SSL _SSL[NET_SSL_MAXINSTANCES];

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -76,7 +76,7 @@ void CWII_IPC_HLE_Device_sdio_slot0::OpenInternal()
 	}
 }
 
-bool CWII_IPC_HLE_Device_sdio_slot0::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Open(u32 _CommandAddress, u32 _Mode)
 {
 	INFO_LOG(WII_IPC_SD, "Open");
 
@@ -85,10 +85,10 @@ bool CWII_IPC_HLE_Device_sdio_slot0::Open(u32 _CommandAddress, u32 _Mode)
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 0x4);
 	memset(m_Registers, 0, sizeof(m_Registers));
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool _bForce)
 {
 	INFO_LOG(WII_IPC_SD, "Close");
 
@@ -99,11 +99,11 @@ bool CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool _bForce)
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 0x4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 // The front SD slot
-bool CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
 {
 	u32 Cmd = Memory::Read_U32(_CommandAddress + 0xC);
 
@@ -226,7 +226,7 @@ bool CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
 		Memory::Write_U32(0, _CommandAddress + 0x4);
 		// Check if the condition is already true
 		EventNotify();
-		return false;
+		return IPC_NO_REPLY;
 	}
 	else if (ReturnValue == RET_EVENT_UNREGISTER)
 	{
@@ -237,16 +237,16 @@ bool CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
 		m_event.addr = 0;
 		m_event.type = EVENT_NONE;
 		Memory::Write_U32(0, _CommandAddress + 0x4);
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 	else
 	{
 		Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 }
 
-bool CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(u32 _CommandAddress)
 {
 	// PPC sending commands
 
@@ -280,7 +280,7 @@ bool CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(u32 _CommandAddress)
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
 
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 u32 CWII_IPC_HLE_Device_sdio_slot0::ExecuteCommand(u32 _BufferIn, u32 _BufferInSize,

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
@@ -16,10 +16,11 @@ public:
 
 	virtual void DoState(PointerWrap& p) override;
 
-	bool Open(u32 _CommandAddress, u32 _Mode) override;
-	bool Close(u32 _CommandAddress, bool _bForce) override;
-	bool IOCtl(u32 _CommandAddress) override;
-	bool IOCtlV(u32 _CommandAddress) override;
+	IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
+
+	IPCCommandResult IOCtl(u32 _CommandAddress) override;
+	IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
 	static void EnqueueReply(u32 CommandAddress, u32 ReturnValue);
 	void EventNotify();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -36,24 +36,24 @@ public:
 	virtual ~CWII_IPC_HLE_Device_stm_immediate()
 	{}
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override
 	{
 		INFO_LOG(WII_IPC_STM, "STM immediate: Open");
 		Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
 		m_Active = true;
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
 	{
 		INFO_LOG(WII_IPC_STM, "STM immediate: Close");
 		if (!_bForce)
 			Memory::Write_U32(0, _CommandAddress+4);
 		m_Active = false;
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
-	virtual bool IOCtl(u32 _CommandAddress) override
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override
 	{
 		u32 Parameter     = Memory::Read_U32(_CommandAddress + 0x0C);
 		u32 BufferIn      = Memory::Read_U32(_CommandAddress + 0x10);
@@ -107,7 +107,7 @@ public:
 
 		// Write return value to the IPC call
 		Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 };
 
@@ -125,14 +125,14 @@ public:
 	{
 	}
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override
 	{
 		Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
 		m_Active = true;
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
 	{
 		m_EventHookAddress = 0;
 
@@ -140,10 +140,10 @@ public:
 		if (!_bForce)
 			Memory::Write_U32(0, _CommandAddress+4);
 		m_Active = false;
-		return true;
+		return IPC_DEFAULT_REPLY;
 	}
 
-	virtual bool IOCtl(u32 _CommandAddress) override
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override
 	{
 		u32 Parameter     = Memory::Read_U32(_CommandAddress + 0x0C);
 		u32 BufferIn      = Memory::Read_U32(_CommandAddress + 0x10);
@@ -182,7 +182,7 @@ public:
 
 		// Write return value to the IPC call, 0 means success
 		Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-		return false;
+		return IPC_DEFAULT_REPLY;
 	}
 
 	// STATE_TO_SAVE

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -129,7 +129,7 @@ bool CWII_IPC_HLE_Device_usb_oh1_57e_305::RemoteDisconnect(u16 _connectionHandle
 	return SendEventDisconnect(_connectionHandle, 0x13);
 }
 
-bool CWII_IPC_HLE_Device_usb_oh1_57e_305::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::Open(u32 _CommandAddress, u32 _Mode)
 {
 	m_ScanEnable = 0;
 
@@ -141,10 +141,10 @@ bool CWII_IPC_HLE_Device_usb_oh1_57e_305::Open(u32 _CommandAddress, u32 _Mode)
 
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_usb_oh1_57e_305::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::Close(u32 _CommandAddress, bool _bForce)
 {
 	m_ScanEnable = 0;
 
@@ -157,16 +157,16 @@ bool CWII_IPC_HLE_Device_usb_oh1_57e_305::Close(u32 _CommandAddress, bool _bForc
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_usb_oh1_57e_305::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::IOCtl(u32 _CommandAddress)
 {
 	//ERROR_LOG(WII_IPC_WIIMOTE, "Passing ioctl to ioctlv");
 	return IOCtlV(_CommandAddress); // FIXME: Hack
 }
 
-bool CWII_IPC_HLE_Device_usb_oh1_57e_305::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::IOCtlV(u32 _CommandAddress)
 {
 /*
 	Memory::Write_U8(255, 0x80149950);  // BTM LOG  // 3 logs L2Cap  // 4 logs l2_csm$
@@ -304,7 +304,7 @@ bool CWII_IPC_HLE_Device_usb_oh1_57e_305::IOCtlV(u32 _CommandAddress)
 
 	// write return value
 	Memory::Write_U32(0, _CommandAddress + 4);
-	return _SendReply;
+	return { _SendReply, IPC_DEFAULT_DELAY };
 }
 
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
@@ -50,11 +50,11 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_usb_oh1_57e_305();
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override;
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override;
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
-	virtual bool IOCtlV(u32 _CommandAddress) override;
-	virtual bool IOCtl(u32 _CommandAddress) override;
+	virtual IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override;
 
 	virtual u32 Update() override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -20,7 +20,7 @@ CWII_IPC_HLE_Device_usb_kbd::CWII_IPC_HLE_Device_usb_kbd(u32 _DeviceID, const st
 CWII_IPC_HLE_Device_usb_kbd::~CWII_IPC_HLE_Device_usb_kbd()
 {}
 
-bool CWII_IPC_HLE_Device_usb_kbd::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Open(u32 _CommandAddress, u32 _Mode)
 {
 	INFO_LOG(WII_IPC_STM, "CWII_IPC_HLE_Device_usb_kbd: Open");
 	IniFile ini;
@@ -37,10 +37,10 @@ bool CWII_IPC_HLE_Device_usb_kbd::Open(u32 _CommandAddress, u32 _Mode)
 	//m_MessageQueue.push(SMessageData(MSG_KBD_CONNECT, 0, nullptr));
 	Memory::Write_U32(m_DeviceID, _CommandAddress+4);
 	m_Active = true;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _bForce)
 {
 	INFO_LOG(WII_IPC_STM, "CWII_IPC_HLE_Device_usb_kbd: Close");
 	while (!m_MessageQueue.empty())
@@ -48,19 +48,19 @@ bool CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _bForce)
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_usb_kbd::Write(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Write(u32 _CommandAddress)
 {
 	INFO_LOG(WII_IPC_STM, "Ignoring write to CWII_IPC_HLE_Device_usb_kbd");
 #if defined(_DEBUG) || defined(DEBUGFAST)
 	DumpCommands(_CommandAddress, 10, LogTypes::WII_IPC_STM, LogTypes::LDEBUG);
 #endif
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
-bool CWII_IPC_HLE_Device_usb_kbd::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::IOCtl(u32 _CommandAddress)
 {
 	u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
 
@@ -71,7 +71,7 @@ bool CWII_IPC_HLE_Device_usb_kbd::IOCtl(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(0, _CommandAddress + 0x4);
-	return true;
+	return IPC_DEFAULT_REPLY;
 }
 
 bool CWII_IPC_HLE_Device_usb_kbd::IsKeyPressed(int _Key)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
@@ -12,10 +12,10 @@ public:
 	CWII_IPC_HLE_Device_usb_kbd(u32 _DeviceID, const std::string& _rDeviceName);
 	virtual ~CWII_IPC_HLE_Device_usb_kbd();
 
-	virtual bool Open(u32 _CommandAddress, u32 _Mode) override;
-	virtual bool Close(u32 _CommandAddress, bool _bForce) override;
-	virtual bool Write(u32 _CommandAddress) override;
-	virtual bool IOCtl(u32 _CommandAddress) override;
+	virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
+	virtual IPCCommandResult Write(u32 _CommandAddress) override;
+	virtual IPCCommandResult IOCtl(u32 _CommandAddress) override;
 	virtual u32 Update() override;
 
 private:


### PR DESCRIPTION
This is a continuation of [PR 1634](https://github.com/dolphin-emu/dolphin/pull/1617). WII_IPC_HLE_Device_DI now uses all the timing accuracy improvements that DVDInterface has gotten throughout this year. Also, the fast disc speed option now works for Wii games. The second and third commits might cause problems in games that rely on specific IPC timings, so testing is needed.