### PR TITLE
[Android] Raise requirements to Android 4.3 and OpenGL ES 3.0

### DIFF
--- a/Source/Android/AndroidManifest.xml
+++ b/Source/Android/AndroidManifest.xml
@@ -6,10 +6,10 @@
     android:installLocation="auto">
 
     <uses-sdk
-        android:minSdkVersion="17"
+        android:minSdkVersion="18"
         android:targetSdkVersion="21" />
 
-    <uses-feature android:glEsVersion="0x00020000" />
+    <uses-feature android:glEsVersion="0x00030000" />
 
     <uses-feature android:name="android.hardware.screen.landscape" />
 


### PR DESCRIPTION
We need to stop pretending that we "support" GLES 2.0 devices.
We are a high performance application that requires GLES 3.0, which was officially supported in Android 4.3.
The few Android phones that released with Android 4.2 and supported OpenGL ES 3.0 have already been updated to a later Android version.
