### PR TITLE
OGL: Avoid interface blocks on Intel drivers

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -211,7 +211,8 @@ SHADER* ProgramShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode, u32 components
 	ShaderCode gcode;
 	GenerateVertexShaderCode(vcode, components, API_OPENGL);
 	GeneratePixelShaderCode(pcode, dstAlphaMode, API_OPENGL, components);
-	if (g_ActiveConfig.backend_info.bSupportsGeometryShaders && !uid.guid.GetUidData()->IsPassthrough())
+	if (g_ActiveConfig.backend_info.bSupportsGeometryShaders && (!uid.guid.GetUidData()->IsPassthrough() ||
+			DriverDetails::HasBug(DriverDetails::BUG_INTELBROKENINTERFACEBLOCKS)))
 		GenerateGeometryShaderCode(gcode, primitive_type, API_OPENGL);
 
 	if (g_ActiveConfig.bEnableShaderDebugging)

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -465,8 +465,7 @@ Renderer::Renderer()
 	g_Config.backend_info.bSupportsEarlyZ = GLExtensions::Supports("GL_ARB_shader_image_load_store");
 	g_Config.backend_info.bSupportsBBox = GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
 	g_Config.backend_info.bSupportsGSInstancing = GLExtensions::Supports("GL_ARB_gpu_shader5");
-	g_Config.backend_info.bSupportsGeometryShaders = (GLExtensions::Version() >= 320) &&
-			!DriverDetails::HasBug(DriverDetails::BUG_INTELBROKENINTERFACEBLOCKS);
+	g_Config.backend_info.bSupportsGeometryShaders = (GLExtensions::Version() >= 320);
 
 	// Desktop OpenGL supports the binding layout if it supports 420pack
 	// OpenGL ES 3.1 supports it implicitly without an extension

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -319,13 +319,23 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 		uid_data->stereo = g_ActiveConfig.iStereoMode > 0;
 		if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
 		{
-			out.Write("in VertexData {\n");
-			out.Write("\tcentroid %s VS_OUTPUT o;\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? "" : "in");
+			if (DriverDetails::HasBug(DriverDetails::BUG_INTELBROKENINTERFACEBLOCKS))
+			{
+				out.Write("centroid in VS_OUTPUT ps;\n");
 
-			if (g_ActiveConfig.iStereoMode > 0)
-				out.Write("\tflat int layer;\n");
+				if (g_ActiveConfig.iStereoMode > 0)
+					out.Write("flat in int layer;\n");
+			}
+			else
+			{
+				out.Write("in VertexData {\n");
+				out.Write("\tcentroid %s VS_OUTPUT o;\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? "" : "in");
 
-			out.Write("};\n");
+				if (g_ActiveConfig.iStereoMode > 0)
+					out.Write("\tflat int layer;\n");
+
+				out.Write("};\n");
+			}
 		}
 		else
 		{
@@ -348,6 +358,9 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 
 		if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
 		{
+			if (DriverDetails::HasBug(DriverDetails::BUG_INTELBROKENINTERFACEBLOCKS))
+				out.Write("\tVS_OUTPUT o = ps;\n");
+
 			// compute window position if needed because binding semantic WPOS is not widely supported
 			// Let's set up attributes
 			for (unsigned int i = 0; i < numTexgen; ++i)

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -74,9 +74,16 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 
 		if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
 		{
-			out.Write("out VertexData {\n"
-			          "\tcentroid %s VS_OUTPUT o;\n"
-					  "};\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? "" : "out");
+			if (DriverDetails::HasBug(DriverDetails::BUG_INTELBROKENINTERFACEBLOCKS))
+			{
+				out.Write("centroid out VS_OUTPUT o;\n");
+			}
+			else
+			{
+				out.Write("out VertexData {\n"
+						  "\tcentroid %s VS_OUTPUT o;\n"
+						  "};\n", g_ActiveConfig.backend_info.bSupportsBindingLayout ? "" : "out");
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Interface blocks are required to make the geometry shader stage optional. If we always force the geometry shader to be present then we can do without them.
