### PR TITLE
VideoCommon: Make GPU syncing hack optional

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -314,6 +314,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("CPUThread", m_LocalCoreStartupParameter.bCPUThread);
 	core->Set("DSPHLE", m_LocalCoreStartupParameter.bDSPHLE);
 	core->Set("SkipIdle", m_LocalCoreStartupParameter.bSkipIdle);
+	core->Set("SyncOnSkipIdle", m_LocalCoreStartupParameter.bSyncGPUOnSkipIdleHack);
 	core->Set("DefaultISO", m_LocalCoreStartupParameter.m_strDefaultISO);
 	core->Set("DVDRoot", m_LocalCoreStartupParameter.m_strDVDRoot);
 	core->Set("Apploader", m_LocalCoreStartupParameter.m_strApploader);
@@ -540,6 +541,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("DSPHLE",            &m_LocalCoreStartupParameter.bDSPHLE,       true);
 	core->Get("CPUThread",         &m_LocalCoreStartupParameter.bCPUThread,    true);
 	core->Get("SkipIdle",          &m_LocalCoreStartupParameter.bSkipIdle,     true);
+	core->Get("SyncOnSkipIdle",    &m_LocalCoreStartupParameter.bSyncGPUOnSkipIdleHack, true);
 	core->Get("DefaultISO",        &m_LocalCoreStartupParameter.m_strDefaultISO);
 	core->Get("DVDRoot",           &m_LocalCoreStartupParameter.m_strDVDRoot);
 	core->Get("Apploader",         &m_LocalCoreStartupParameter.m_strApploader);

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -34,7 +34,7 @@ SCoreStartupParameter::SCoreStartupParameter()
   bJITILTimeProfiling(false), bJITILOutputIR(false),
   bFPRF(false),
   bCPUThread(true), bDSPThread(false), bDSPHLE(true),
-  bSkipIdle(true), bNTSC(false), bForceNTSCJ(false),
+  bSkipIdle(true), bSyncGPUOnSkipIdleHack(true), bNTSC(false), bForceNTSCJ(false),
   bHLE_BS2(true), bEnableCheats(false),
   bMergeBlocks(false), bEnableMemcardSaving(true),
   bDPL2Decoder(false), iLatency(14),
@@ -69,6 +69,7 @@ void SCoreStartupParameter::LoadDefaults()
 	iCPUCore = CORE_JIT64;
 	bCPUThread = false;
 	bSkipIdle = false;
+	bSyncGPUOnSkipIdleHack = true;
 	bRunCompareServer = false;
 	bDSPHLE = true;
 	bFastmem = true;

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -163,6 +163,7 @@ struct SCoreStartupParameter
 	bool bDSPThread;
 	bool bDSPHLE;
 	bool bSkipIdle;
+	bool bSyncGPUOnSkipIdleHack;
 	bool bNTSC;
 	bool bForceNTSCJ;
 	bool bHLE_BS2;

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -11,6 +11,7 @@
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
 
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -443,13 +444,16 @@ void Idle()
 {
 	//DEBUG_LOG(POWERPC, "Idle");
 
-	//When the FIFO is processing data we must not advance because in this way
-	//the VI will be desynchronized. So, We are waiting until the FIFO finish and
-	//while we process only the events required by the FIFO.
-	while (g_video_backend->Video_IsPossibleWaitingSetDrawDone())
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bSyncGPUOnSkipIdleHack)
 	{
-		ProcessFifoWaitEvents();
-		Common::YieldCPU();
+		//When the FIFO is processing data we must not advance because in this way
+		//the VI will be desynchronized. So, We are waiting until the FIFO finish and
+		//while we process only the events required by the FIFO.
+		while (g_video_backend->Video_IsPossibleWaitingSetDrawDone())
+		{
+			ProcessFifoWaitEvents();
+			Common::YieldCPU();
+		}
 	}
 
 	idledCycles += PowerPC::ppcState.downcount;


### PR DESCRIPTION
This hack is there for quite a long time, and lots of games crashes if it's disabled.
But it's still a hack, so it shouldn't be enabled hard coded. This commit create a new
ini option for this hack which is enabled by default.
Maybe some games does still run very fine without this hack.
