### PR TITLE
Readme Fixes and Improvements

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,9 @@
-# Dolphin - A GameCube / Triforce / Wii Emulator
+# Dolphin - A GameCube / Wii / Triforce Emulator
 
 [Homepage](https://dolphin-emu.org/) | [Project Site](https://github.com/dolphin-emu/dolphin) | [Forums](https://forums.dolphin-emu.org/) | [Wiki](https://wiki.dolphin-emu.org/) | [Issue Tracker](https://code.google.com/p/dolphin-emu/issues/list) | [Coding Style](https://github.com/dolphin-emu/dolphin/blob/master/Contributing.md) | [Transifex Page](https://www.transifex.com/projects/p/dolphin-emu/)
 
-Dolphin is an emulator for running GameCube, Triforce and Wii games on
-Windows/Linux/OS X systems and recent Android devices. It's licensed under
+Dolphin is an emulator for running GameCube, Wii, and Triforce games on
+Windows, Linux, OS X, and recent Android devices. It's licensed under
 the terms of the GNU General Public License, version 2 (GPLv2).
 
 Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
@@ -11,7 +11,8 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 ## System Requirements
 * OS
     * Microsoft Windows (Vista or higher).
-    * Linux or Apple Mac OS X (10.9 or higher).
+    * Linux.
+    * Apple Mac OS X (10.9 or higher).
     * Unix-like systems other than Linux might work but are not officially supported.
 * Processor
     * A CPU with SSE2 support.
@@ -32,13 +33,13 @@ Nullsoft Scriptable Install System (NSIS) to be installed. Creating an
 installer is not necessary to run Dolphin since the Build directory contains
 a working Dolphin distribution.
 
-## Installation on Linux/OS X
+## Installation on Linux and OS X
 Dolphin requires [CMake](http://www.cmake.org/) for systems other than Windows. Many libraries are
 bundled with Dolphin and used if they're not installed on your system. CMake
 will inform you if a bundled library is used or if you need to install any
 missing packages yourself.
 
-### Build steps:
+### Build Steps:
 1. `mkdir Build`
 2. `cd Build`
 3. `cmake ..`
@@ -60,7 +61,7 @@ OS X users can simply delete Dolphin.app to uninstall it.
 Additionally, you'll want to remove the global user directory (see below to
 see where it's stored) if you don't plan to reinstall Dolphin.
 
-## Command line usage
+## Command Line Usage
 `Usage: Dolphin [-h] [-d] [-l] [-e <str>] [-b] [-V <str>] [-A <str>]`  
 
 * -h, --help Show this help message  
@@ -76,9 +77,9 @@ LLE (Low Level Emulation). HLE is fast but often less accurate while LLE is
 slow but close to perfect. Note that LLE has two submodes (Interpreter and
 Recompiler), which cannot be selected from the command line.
 
-Available video backends are "D3D" (only available on Windows Vista or higher),
+Available video backends are "D3D" (only available on Windows) and
 "OGL". There's also "Software Renderer", which uses the CPU for rendering and
-is intended for debugging purposes, only.
+is intended for debugging purposes only.
 
 ## Sys Files
 * `totaldb.dsy`: Database of symbols (for devs only)
@@ -93,7 +94,7 @@ some games implement copy protection by checksumming the dumps. You will need
 to dump the DSP files from a console and replace the default dumps if you want
 to fix those issues.
 
-## Folder structure
+## Folder Structure
 These folders are installed read-only and should not be changed:
 
 * `GameSettings`: per-game default settings database
@@ -104,7 +105,7 @@ These folders are installed read-only and should not be changed:
 * `Resources`: icons that are theme-agnostic
 * `Wii`: default Wii NAND contents
 
-## User folder structure
+## User Folder Structure
 A number of user writeable directories are created for caching purposes or for
 allowing the user to edit their contents. On OS X and Linux these folders are
 stored in `~/Library/Application Support/Dolphin/` and `~/.dolphin-emu`
@@ -136,7 +137,7 @@ List of user folders:
 * `StateSaves`: save states
 * `Wii`: Wii NAND contents
 
-## Custom textures
+## Custom Textures
 Custom textures have to be placed in the user directory under
 `Load/Textures/[GameID]/`. You can find the Game ID by right-clicking a game
 in the ISO list and selecting "ISO Properties".


### PR DESCRIPTION
Identical to PR #1655, but with the commits squashed into one.

These are mostly some edits to clean up inconsistencies in the Readme.

Rationale for the edits:

Switched places of Wii and Triforce in lists. Triforce emulation is pretty obviously not treated with the same importance as GameCube and Wii emulation is and so I feel it makes sense to have it listed last rather than second.

Made the spacing between slashes consistent. In some locations slashes had spaces and in others they didn't. I chose to add spaces throughout as it makes it a bit easier to read.

Gave Linux and OS X separate lines in the system requirements. If Windows gets its own line it makes sense for Linux and OS X to also have their own lines. This also clears up a potential ambiguity in what 10.9 is referring to.

Unified title capitalization. Some titles used capitals for the whole title and others only used capitals for the first word. I decided to capitalize all the titles.

Removed Vista or higher as higher as a requirement for using D3D. As Vista or higher is already a requirement for running Dolphin on Windows this is completely redundant. Also cleaned up a bit of a typo here.