### PR TITLE
AR: Fix Memory Copy Without Pointer Support

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -598,7 +598,7 @@ static bool ZeroCode_MemoryCopy(const u32 val_last, const ARAddr& addr, const u3
 			for (int i=0; i < num_bytes; ++i)
 			{
 				Memory::Write_U8(Memory::Read_U8(addr_src + i), addr_dest + i);
-				LogInfo("Wrote %08x to address %08x", Memory::Read_U8(addr_src + i), addr_dest + i);
+				LogInfo("Wrote %08x to address %08x", Memory::ReadUnchecked_U8(addr_src + i), addr_dest + i);
 			}
 			LogInfo("--------");
 			return true;


### PR DESCRIPTION
Fix a bug when using AR codes with "Memory Copy Without Pointer Support"
code type which would write more data than it should.
