### PR TITLE
JIT: Fix redundant MOVs in x86 trampolines

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/TrampolineCache.cpp
@@ -86,7 +86,8 @@ const u8* TrampolineCache::GenerateReadTrampoline(const InstructionInfo &info, B
 		break;
 	}
 
-	MOV(dataRegSize, R(dataReg), R(ABI_RETURN));
+	if (dataReg != ABI_RETURN)
+		MOV(dataRegSize, R(dataReg), R(ABI_RETURN));
 
 	ABI_PopRegistersAndAdjustStack(registersInUse, 8);
 	RET();


### PR DESCRIPTION
Fixes spammy log messages about redundant MOVs.
