### PR TITLE
Eliminate some spammy log messages in MMU mode

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -237,16 +237,10 @@ void Memset(const u32 _Address, const u8 _iValue, const u32 _iLength)
 
 void ClearCacheLine(const u32 _Address)
 {
-	u8* ptr = GetPointer(_Address);
-	if (ptr != nullptr)
-	{
-		memset(ptr, 0, 32);
-	}
-	else
-	{
-		for (u32 i = 0; i < 32; i += 8)
-			Write_U64(0, _Address + i);
-	}
+	// FIXME: does this do the right thing if dcbz is run on hardware memory, e.g.
+	// the FIFO? Do games even do that? Probably not, but we should try to be correct...
+	for (u32 i = 0; i < 32; i += 8)
+		Write_U64(0, _Address + i);
 }
 
 void DMA_LCToMemory(const u32 _MemAddr, const u32 _CacheAddr, const u32 _iNumBlocks)

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -646,7 +646,8 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 		return address;
 	}
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bMMU && (address & JIT_ICACHE_VMEM_BIT))
+	bool virtualAddr = SConfig::GetInstance().m_LocalCoreStartupParameter.bMMU && (address & JIT_ICACHE_VMEM_BIT);
+	if (virtualAddr)
 	{
 		if (!Memory::TranslateAddress(address, Memory::FLAG_NO_EXCEPTION))
 		{
@@ -789,7 +790,9 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 		else
 		{
 			// ISI exception or other critical memory exception occured (game over)
-			ERROR_LOG(DYNA_REC, "Instruction hex was 0!");
+			// We can continue on in MMU mode though, so don't spam this error in that case.
+			if (!virtualAddr)
+				ERROR_LOG(DYNA_REC, "Instruction hex was 0!");
 			break;
 		}
 	}


### PR DESCRIPTION
dcbz: just don't use GetPointer, that can't be right anyways
ppcanalyst: don't print "instruction hex 0" messages in MMU mode, where ISIs
are expected.
