### PR TITLE
Frame: Fix a crash-on-exit on Mac OS X.

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -577,7 +577,8 @@ void CFrame::OnClose(wxCloseEvent& event)
 	else
 	{
 		// Close the log window now so that its settings are saved
-		m_LogWindow->Close();
+		if (m_LogWindow)
+			m_LogWindow->Close();
 		m_LogWindow = nullptr;
 	}
 


### PR DESCRIPTION
A null pointer exception is triggered when Dolphin is quit from the dock.
