### PR TITLE
WIP: faster paired loadstore

### DIFF
--- a/Source/Core/Common/x64ABI.cpp
+++ b/Source/Core/Common/x64ABI.cpp
@@ -222,3 +222,30 @@ void XEmitter::ABI_CallFunctionA(int bits, const void *func, const Gen::OpArg &a
 	ABI_CallFunction(func);
 }
 
+void XEmitter::MOVImm64(Gen::OpArg dst, u64 src, Gen::X64Reg tmp)
+{
+	if (dst.IsSimpleReg())
+	{
+		if (src > std::numeric_limits<u32>::max())
+			MOV(64, dst, Imm64(src));
+		else
+			MOV(32, dst, Imm32((u32)src));
+	}
+	else
+	{
+		if (src > std::numeric_limits<u32>::max())
+		{
+			MOV(64, R(tmp), Imm64(src));
+			MOV(64, dst, R(tmp));
+		}
+		else if (src > std::numeric_limits<s32>::max())
+		{
+			MOV(32, R(tmp), Imm32((u32)src));
+			MOV(64, dst, R(tmp));
+		}
+		else
+		{
+			MOV(64, dst, Imm32((u32)src));
+		}
+	}
+}

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -113,6 +113,14 @@ const u8 *XEmitter::AlignCode16()
 	return code;
 }
 
+const u8 *XEmitter::AlignCode64()
+{
+	int c = int((u64)code & 63);
+	if (c)
+		ReserveCodeSpace(64-c);
+	return code;
+}
+
 const u8 *XEmitter::AlignCodePage()
 {
 	int c = int((u64)code & 4095);

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -322,6 +322,7 @@ public:
 	void ReserveCodeSpace(int bytes);
 	const u8 *AlignCode4();
 	const u8 *AlignCode16();
+	const u8 *AlignCode64();
 	const u8 *AlignCodePage();
 	const u8 *GetCodePtr() const;
 	u8 *GetWritableCodePtr();
@@ -889,6 +890,9 @@ public:
 
 	// Helper method for the above, or can be used separately.
 	void MOVTwo(int bits, Gen::X64Reg dst1, Gen::X64Reg src1, Gen::X64Reg dst2, Gen::X64Reg src2);
+
+	// Helper to efficiently move a possibly-64-bit value to a destination register or memory location
+	void MOVImm64(Gen::OpArg dst, u64 src, Gen::X64Reg tmp = Gen::INVALID_REG);
 
 	// Saves/restores the registers and adjusts the stack to be aligned as
 	// required by the ABI, where the previous alignment was as specified.

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
@@ -10,8 +10,10 @@
 #include "Common/FPURoundMode.h"
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/SystemTimers.h"
+#include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/Interpreter/Interpreter_FPUtils.h"
+#include "Core/PowerPC/JitCommon/JitAsmCommon.h"
 
 /*
 
@@ -315,6 +317,7 @@ void Interpreter::mtspr(UGeckoInstruction _inst)
 	case SPR_GQR0 + 5:
 	case SPR_GQR0 + 6:
 	case SPR_GQR0 + 7:
+		JitInterface::SetGQR(iIndex - SPR_GQR0, rSPR(iIndex));
 		break;
 
 	case SPR_DMAL:

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -81,6 +81,8 @@ public:
 
 	void ClearCache() override;
 
+	void SetGQR(int index, u32 gqr) override;
+
 	const u8 *GetDispatcher()
 	{
 		return asm_routines.dispatcher;

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -229,7 +229,7 @@ void Jit64AsmRoutineManager::GenerateCommon()
 
 	GenQuantizedLoads();
 	GenQuantizedStores();
-	GenQuantizedSingleStores();
+	ReserveQuantizeTableSpace();
 
 	//CMPSD(R(XMM0), M(&zero),
 	// TODO

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.h
@@ -34,7 +34,7 @@ public:
 		m_stack_top = stack_top;
 		AllocCodeSpace(8192);
 		Generate();
-		WriteProtect();
+		//WriteProtect();
 	}
 
 	void Shutdown()

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -273,6 +273,11 @@ void JitIL::ClearCache()
 	ClearCodeSpace();
 }
 
+void JitIL::SetGQR(int index, u32 gqr)
+{
+	// TODO: use this instead of the existing paired load/store code
+}
+
 void JitIL::Shutdown()
 {
 	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bJITILTimeProfiling)

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
@@ -61,6 +61,7 @@ public:
 	JitBlockCache *GetBlockCache() override { return &blocks; }
 
 	void ClearCache() override;
+	void SetGQR(int index, u32 gqr) override;
 	const u8 *GetDispatcher()
 	{
 		return asm_routines.dispatcher;  // asm_routines.dispatcher

--- a/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
@@ -47,6 +47,11 @@ void JitArm::ClearCache()
 	blocks.Clear();
 }
 
+void JitArm::SetGQR(int index, u32 gqr)
+{
+	// TODO: use this instead of the existing paired load/store code
+}
+
 void JitArm::Shutdown()
 {
 	FreeCodeSpace();

--- a/Source/Core/Core/PowerPC/JitArm32/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.h
@@ -94,6 +94,8 @@ public:
 
 	void ClearCache();
 
+	void SetGQR(int index, u32 gqr);
+
 	const u8 *GetDispatcher()
 	{
 		return asm_routines.dispatcher;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -35,6 +35,11 @@ void JitArm64::ClearCache()
 	blocks.Clear();
 }
 
+void JitArm64::SetGQR(int index, u32 gqr)
+{
+	// TODO: use this instead of the existing paired load/store code
+}
+
 void JitArm64::Shutdown()
 {
 	FreeCodeSpace();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -39,6 +39,8 @@ public:
 
 	void ClearCache();
 
+	void SetGQR(int index, u32 gqr);
+
 	CommonAsmRoutinesBase *GetAsmRoutines()
 	{
 		return &asm_routines;

--- a/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitAsmCommon.h
@@ -35,16 +35,14 @@ public:
 
 	// In: array index: GQR to use.
 	// In: ECX: Address to write to.
-	// In: XMM0: Bottom two 32-bit slots hold the pair of floats to be written.
+	// In: XMM0: Bottom two 32-bit slots hold the float(s) to be written.
 	// Out: Nothing.
 	// Trashes: all three RSCRATCH
 	const u8 **pairedStoreQuantized;
 
-	// In: array index: GQR to use.
-	// In: ECX: Address to write to.
-	// In: XMM0: Bottom 32-bit slot holds the float to be written.
-	const u8 **singleStoreQuantized;
-
+	// Current function pointers: get updated as GQRs are modified
+	const u8 **pairedLoadQuantizeFunc;
+	const u8 **pairedStoreQuantizeFunc;
 };
 
 class CommonAsmRoutines : public CommonAsmRoutinesBase, public EmuCodeBlock
@@ -52,7 +50,7 @@ class CommonAsmRoutines : public CommonAsmRoutinesBase, public EmuCodeBlock
 protected:
 	void GenQuantizedLoads();
 	void GenQuantizedStores();
-	void GenQuantizedSingleStores();
+	void ReserveQuantizeTableSpace();
 
 public:
 	void GenFifoWrite(int size);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -111,6 +111,8 @@ public:
 	virtual const CommonAsmRoutinesBase *GetAsmRoutines() = 0;
 
 	virtual bool HandleFault(uintptr_t access_address, SContext* ctx) = 0;
+
+	virtual void SetGQR(int index, u32 gqr) = 0;
 };
 
 class Jitx86Base : public JitBase, public EmuCodeBlock

--- a/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/JitILBase_LoadStorePaired.cpp
@@ -22,7 +22,7 @@ void JitILBase::psq_st(UGeckoInstruction inst)
 
 	val = ibuild.EmitLoadFReg(inst.RS);
 	val = ibuild.EmitCompactMRegToPacked(val);
-	ibuild.EmitStorePaired(val, addr, inst.I);
+	ibuild.EmitStorePaired(val, addr, inst.I | (inst.W << 3));
 }
 
 void JitILBase::psq_l(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -44,7 +44,11 @@ namespace JitInterface
 	void DoState(PointerWrap &p)
 	{
 		if (jit && p.GetMode() == PointerWrap::MODE_READ)
+		{
 			jit->GetBlockCache()->Clear();
+			for (int i = 0; i < 8; i++)
+				jit->SetGQR(i, GQR(i));
+		}
 	}
 	CPUCoreBase *InitJitCore(int core)
 	{
@@ -199,6 +203,11 @@ namespace JitInterface
 		// TODO: There's probably a better way to handle this situation.
 		if (jit)
 			jit->GetBlockCache()->Clear();
+	}
+	void SetGQR(int index, u32 gqr)
+	{
+		if (jit)
+			jit->SetGQR(index, gqr);
 	}
 
 	void InvalidateICache(u32 address, u32 size, bool forced)

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -36,6 +36,9 @@ namespace JitInterface
 
 	void ClearSafe();
 
+	// Set up any internal data necessary upon a graphics quantization register change
+	void SetGQR(int index, u32 gqr);
+
 	// If "forced" is true, a recompile is being requested on code that hasn't been modified.
 	void InvalidateICache(u32 address, u32 size, bool forced);
 

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -96,6 +96,12 @@ struct GC_ALIGNED64(PowerPCState)
 	std::tuple<> above_fits_in_first_0x100;
 #endif
 
+	// The quantization factors from the 8 GQR registers, kept updated.
+	// The function pointers associated with these are kept in JitAsmCommon, since
+	// they're host pointers and don't belong in PPCState.
+	// [0] = store, [1] = load
+	u8 gqrquant[8][2];
+
 	// The paired singles are strange : PS0 is stored in the full 64 bits of each FPR
 	// but ps calculations are only done in 32-bit precision, and PS1 is only 32 bits.
 	// Since we want to use SIMD, SSE2 is the only viable alternative - 2x double.
@@ -185,6 +191,7 @@ void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst);
 #define SPRG2  PowerPC::ppcState.spr[SPR_SPRG2]
 #define SPRG3  PowerPC::ppcState.spr[SPR_SPRG3]
 #define GQR(x) PowerPC::ppcState.spr[SPR_GQR0+x]
+#define GQRQuant(x,i) PowerPC::ppcState.gqrquant[x][i]
 #define TL     PowerPC::ppcState.spr[SPR_TL]
 #define TU     PowerPC::ppcState.spr[SPR_TU]
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -64,7 +64,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 37;
+static const u32 STATE_VERSION = 38;
 
 enum
 {

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -25,6 +25,7 @@ public:
 	void Init() override {}
 	void Shutdown() override {}
 	void ClearCache() override {}
+	void SetGQR(int index, u32 gqr) override {}
 	void Run() override {}
 	void SingleStep() override {}
 	const char *GetName() override { return nullptr; }


### PR DESCRIPTION
~3 fewer instructions per operation (2 generated by JIT, 1 in jitasmcommon).
Not implemented yet in JITIL (still takes the old path).
Currently disables write protection on JitAsmCommon, because I'm not sure what
to do there.

The basic idea: make a function pointer table that's updated each time the
GQRs are, letting us simplify the process of calling the correct paired
(de)quantization function.
