### PR TITLE
GeometryShaderManager: Set viewport in SetConstants().

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -20,6 +20,7 @@ GeometryShaderConstants GeometryShaderManager::constants;
 bool GeometryShaderManager::dirty;
 
 static bool s_projection_changed;
+static bool s_viewport_changed;
 
 void GeometryShaderManager::Init()
 {
@@ -64,13 +65,21 @@ void GeometryShaderManager::SetConstants()
 
 		dirty = true;
 	}
+
+	if (s_viewport_changed)
+	{
+		s_viewport_changed = false;
+
+		constants.lineptparams[0] = 2.0f * xfmem.viewport.wd;
+		constants.lineptparams[1] = -2.0f * xfmem.viewport.ht;
+
+		dirty = true;
+	}
 }
 
 void GeometryShaderManager::SetViewportChanged()
 {
-	constants.lineptparams[0] = 2.0f * xfmem.viewport.wd;
-	constants.lineptparams[1] = -2.0f * xfmem.viewport.ht;
-	dirty = true;
+	s_viewport_changed = true;
 }
 
 void GeometryShaderManager::SetProjectionChanged()


### PR DESCRIPTION
Setting it in the callback is too early.

Fixes [issue 8005](https://code.google.com/p/dolphin-emu/issues/detail?id=8005).
