### PR TITLE
JIT: fix possible block map crash with ISI blocks

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -143,11 +143,12 @@ using namespace Gen;
 
 		// Convert the logical address to a physical address for the block map
 		u32 pAddr = b.originalAddress & 0x1FFFFFFF;
+		u32 pAddrEnd = pAddr + (b.originalSize ? b.originalSize - 1 : 0) * 4;
 
-		for (u32 block = pAddr / 32; block <= (pAddr + (b.originalSize - 1) * 4) / 32; ++block)
+		for (u32 block = pAddr / 32; block <= pAddrEnd / 32; ++block)
 			valid_block.Set(block);
 
-		block_map[std::make_pair(pAddr + 4 * b.originalSize - 1, pAddr)] = block_num;
+		block_map[std::make_pair(pAddrEnd, pAddr)] = block_num;
 
 		// Blocks where a memory exception (ISI) occurred in the instruction fetch have to
 		// execute the ISI handler as the next instruction. These blocks cannot be


### PR DESCRIPTION
If a block ISIs at the start (zero instructions) the logic here can fail and
cause a crash.