### PR TITLE
Tools: buildbot try with binary diffs

### DIFF
--- a/Tools/buildbot-try.sh
+++ b/Tools/buildbot-try.sh
@@ -35,4 +35,4 @@ echo "Change author: $author"
 echo "Short rev: $shortrev"
 echo "Base rev: $baserev"
 
-git diff -r $baserev | buildbot try --properties=branchname=$branchname,author=$author,shortrev=$shortrev --diff=- -p1 --baserev $baserev $*
+git diff --binary -r $baserev | buildbot try --properties=branchname=$branchname,author=$author,shortrev=$shortrev --diff=- -p1 --baserev $baserev $*


### PR DESCRIPTION
Currently, buildbot-trying a patch that modifies binary files always fails to apply ("error: cannot apply binary patch to 'foo' without full index line").
