### PR TITLE
Fix CleanRip reading Wii discs

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -39,7 +39,7 @@ void CBoot::Load_FST(bool _bIsWii)
 		return;
 
 	// copy first 20 bytes of disc to start of Mem 1
-	VolumeHandler::ReadToPtr(Memory::GetPointer(0x80000000), 0, 0x20);
+	VolumeHandler::ReadToPtr(Memory::GetPointer(0x80000000), 0, 0x20, false);
 
 	// copy of game id
 	Memory::Write_U32(Memory::Read_U32(0x80000000), 0x80003180);
@@ -48,15 +48,15 @@ void CBoot::Load_FST(bool _bIsWii)
 	if (_bIsWii)
 		shift = 2;
 
-	u32 fstOffset  = VolumeHandler::Read32(0x0424) << shift;
-	u32 fstSize    = VolumeHandler::Read32(0x0428) << shift;
-	u32 maxFstSize = VolumeHandler::Read32(0x042c) << shift;
+	u32 fstOffset  = VolumeHandler::Read32(0x0424, _bIsWii) << shift;
+	u32 fstSize    = VolumeHandler::Read32(0x0428, _bIsWii) << shift;
+	u32 maxFstSize = VolumeHandler::Read32(0x042c, _bIsWii) << shift;
 
 	u32 arenaHigh = ROUND_DOWN(0x817FFFFF - maxFstSize, 0x20);
 	Memory::Write_U32(arenaHigh, 0x00000034);
 
 	// load FST
-	VolumeHandler::ReadToPtr(Memory::GetPointer(arenaHigh), fstOffset, fstSize);
+	VolumeHandler::ReadToPtr(Memory::GetPointer(arenaHigh), fstOffset, fstSize, _bIsWii);
 	Memory::Write_U32(arenaHigh, 0x00000038);
 	Memory::Write_U32(maxFstSize, 0x0000003c);
 }

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -258,7 +258,7 @@ void GenerateDIInterrupt(DIInterruptType _DVDInterrupt);
 
 void WriteImmediate(u32 value, u32 output_address, bool write_to_DIIMMBUF);
 DVDCommandResult ExecuteReadCommand(u64 DVD_offset, u32 output_address,
-	u32 DVD_length, u32 output_length, bool raw = false);
+	u32 DVD_length, u32 output_length, bool decrypt);
 
 u64 SimulateDiscReadTime(u64 offset, u32 length);
 s64 CalculateRawDiscReadTime(u64 offset, s64 length);
@@ -328,7 +328,7 @@ static u32 ProcessDTKSamples(short *tempPCM, u32 num_samples)
 
 		u8 tempADPCM[NGCADPCM::ONE_BLOCK_SIZE];
 		// TODO: What if we can't read from AudioPos?
-		VolumeHandler::ReadToPtr(tempADPCM, AudioPos, sizeof(tempADPCM));
+		VolumeHandler::ReadToPtr(tempADPCM, AudioPos, sizeof(tempADPCM), false);
 		AudioPos += sizeof(tempADPCM);
 		NGCADPCM::DecodeBlock(tempPCM + samples_processed * 2, tempADPCM);
 		samples_processed += NGCADPCM::SAMPLES_PER_BLOCK;
@@ -467,12 +467,9 @@ void SetLidOpen(bool _bOpen)
 	GenerateDIInterrupt(INT_CVRINT);
 }
 
-bool DVDRead(u64 _iDVDOffset, u32 _iRamAddress, u32 _iLength, bool raw)
+bool DVDRead(u64 _iDVDOffset, u32 _iRamAddress, u32 _iLength, bool decrypt)
 {
-	if (raw)
-		return VolumeHandler::RAWReadToPtr(Memory::GetPointer(_iRamAddress), _iDVDOffset, _iLength);
-	else
-		return VolumeHandler::ReadToPtr(Memory::GetPointer(_iRamAddress), _iDVDOffset, _iLength);
+		return VolumeHandler::ReadToPtr(Memory::GetPointer(_iRamAddress), _iDVDOffset, _iLength, decrypt);
 }
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
@@ -615,7 +612,7 @@ void WriteImmediate(u32 value, u32 output_address, bool write_to_DIIMMBUF)
 }
 
 DVDCommandResult ExecuteReadCommand(u64 DVD_offset, u32 output_address,
-                                    u32 DVD_length, u32 output_length, bool raw)
+                                    u32 DVD_length, u32 output_length, bool decrypt)
 {
 	if (DVD_length > output_length)
 	{
@@ -633,7 +630,7 @@ DVDCommandResult ExecuteReadCommand(u64 DVD_offset, u32 output_address,
 		return result;
 	}
 
-	if (!DVDRead(DVD_offset, output_address, DVD_length, raw))
+	if (!DVDRead(DVD_offset, output_address, DVD_length, decrypt))
 		PanicAlertT("Can't read from DVD_Plugin - DVD-Interface: Fatal Error");
 
 	result.interrupt_type = INT_TCINT;
@@ -690,13 +687,13 @@ DVDCommandResult ExecuteCommand(u32 command_0, u32 command_1, u32 command_2,
 	// Only seems to be used from WII_IPC, not through direct access
 	case DVDLowReadDiskID:
 		INFO_LOG(DVDINTERFACE, "DVDLowReadDiskID");
-		result = ExecuteReadCommand(0, output_address, 0x20, output_length, true);
+		result = ExecuteReadCommand(0, output_address, 0x20, output_length, false);
 		break;
 
-	// Only seems to be used from WII_IPC, not through direct access
+	// Only used from WII_IPC. This is the only read command that decrypts data
 	case DVDLowRead:
 		INFO_LOG(DVDINTERFACE, "DVDLowRead: DVDAddr: 0x%09" PRIx64 ", Size: 0x%x", (u64)command_2 << 2, command_1);
-		result = ExecuteReadCommand((u64)command_2 << 2, output_address, command_1, output_length);
+		result = ExecuteReadCommand((u64)command_2 << 2, output_address, command_1, output_length, true);
 		break;
 
 	// Probably only used by Wii
@@ -779,7 +776,7 @@ DVDCommandResult ExecuteCommand(u32 command_0, u32 command_1, u32 command_2,
 			(command_2 > 0x7ed40000 && command_2 < 0x7ed40008) ||
 			(((command_2 + command_1) > 0x7ed40000) && (command_2 + command_1) < 0x7ed40008)))
 		{
-			result = ExecuteReadCommand((u64)command_2 << 2, output_address, command_1, output_length, true);
+			result = ExecuteReadCommand((u64)command_2 << 2, output_address, command_1, output_length, false);
 		}
 		else
 		{
@@ -875,13 +872,13 @@ DVDCommandResult ExecuteCommand(u32 command_0, u32 command_1, u32 command_2,
 					}
 				}
 
-				result = ExecuteReadCommand(iDVDOffset, output_address, command_2, output_length, true);
+				result = ExecuteReadCommand(iDVDOffset, output_address, command_2, output_length, false);
 			}
 			break;
 
 		case 0x40: // Read DiscID
 			INFO_LOG(DVDINTERFACE, "Read DiscID %08x", Memory::Read_U32(output_address));
-			result = ExecuteReadCommand(0, output_address, 0x20, output_length, true);
+			result = ExecuteReadCommand(0, output_address, 0x20, output_length, false);
 			break;
 
 		default:

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -875,13 +875,13 @@ DVDCommandResult ExecuteCommand(u32 command_0, u32 command_1, u32 command_2,
 					}
 				}
 
-				result = ExecuteReadCommand(iDVDOffset, output_address, command_2, output_length);
+				result = ExecuteReadCommand(iDVDOffset, output_address, command_2, output_length, true);
 			}
 			break;
 
 		case 0x40: // Read DiscID
 			INFO_LOG(DVDINTERFACE, "Read DiscID %08x", Memory::Read_U32(output_address));
-			result = ExecuteReadCommand(0, output_address, 0x20, output_length);
+			result = ExecuteReadCommand(0, output_address, 0x20, output_length, true);
 			break;
 
 		default:

--- a/Source/Core/Core/HW/DVDInterface.h
+++ b/Source/Core/Core/HW/DVDInterface.h
@@ -103,7 +103,7 @@ bool IsDiscInside();
 void ChangeDisc(const std::string& fileName);
 
 // DVD Access Functions
-bool DVDRead(u64 _iDVDOffset, u32 _iRamAddress, u32 _iLength, bool raw = false);
+bool DVDRead(u64 _iDVDOffset, u32 _iRamAddress, u32 _iLength, bool decrypt);
 extern bool g_bStream;
 DVDCommandResult ExecuteCommand(u32 command_0, u32 command_1, u32 command_2,
 	u32 output_address, u32 output_length, bool write_to_DIIMMBUF);

--- a/Source/Core/Core/VolumeHandler.cpp
+++ b/Source/Core/Core/VolumeHandler.cpp
@@ -53,29 +53,21 @@ void SetVolumeDirectory(const std::string& _rFullPath, bool _bIsWii, const std::
 	g_pVolume = DiscIO::CreateVolumeFromDirectory(_rFullPath, _bIsWii, _rApploader, _rDOL);
 }
 
-u32 Read32(u64 _Offset)
+u32 Read32(u64 _Offset, bool decrypt)
 {
 	if (g_pVolume != nullptr)
 	{
 		u32 Temp;
-		g_pVolume->Read(_Offset, 4, (u8*)&Temp);
+		g_pVolume->Read(_Offset, 4, (u8*)&Temp, decrypt);
 		return Common::swap32(Temp);
 	}
 	return 0;
 }
 
-bool ReadToPtr(u8* ptr, u64 _dwOffset, u64 _dwLength)
+bool ReadToPtr(u8* ptr, u64 _dwOffset, u64 _dwLength, bool decrypt)
 {
 	if (g_pVolume != nullptr && ptr)
-		return g_pVolume->Read(_dwOffset, _dwLength, ptr);
-
-	return false;
-}
-
-bool RAWReadToPtr(u8* ptr, u64 _dwOffset, u64 _dwLength)
-{
-	if (g_pVolume != nullptr && ptr)
-		return g_pVolume->RAWRead(_dwOffset, _dwLength, ptr);
+		return g_pVolume->Read(_dwOffset, _dwLength, ptr, decrypt);
 
 	return false;
 }

--- a/Source/Core/Core/VolumeHandler.h
+++ b/Source/Core/Core/VolumeHandler.h
@@ -19,9 +19,10 @@ namespace VolumeHandler
 bool SetVolumeName(const std::string& _rFullPath);
 void SetVolumeDirectory(const std::string& _rFullPath, bool _bIsWii, const std::string& _rApploader = "", const std::string& _rDOL = "");
 
-u32 Read32(u64 _Offset);
-bool ReadToPtr(u8* ptr, u64 _dwOffset, u64 _dwLength);
-bool RAWReadToPtr(u8* ptr, u64 _dwOffset, u64 _dwLength);
+// decrypt parameter must be false if not reading a Wii disc
+u32 Read32(u64 _Offset, bool decrypt);
+// decrypt parameter must be false if not reading a Wii disc
+bool ReadToPtr(u8* ptr, u64 _dwOffset, u64 _dwLength, bool decrypt);
 
 bool IsValid();
 bool IsWii();

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -73,10 +73,8 @@ static SPartitionGroup PartitionGroup[4];
 
 void MarkAsUsed(u64 _Offset, u64 _Size);
 void MarkAsUsedE(u64 _PartitionDataOffset, u64 _Offset, u64 _Size);
-void ReadFromDisc(u64 _Offset, u64 _Length, u32& _Buffer);
-void ReadFromDisc(u64 _Offset, u64 _Length, u64& _Buffer);
-void ReadFromVolume(u64 _Offset, u64 _Length, u32& _Buffer);
-void ReadFromVolume(u64 _Offset, u64 _Length, u64& _Buffer);
+void ReadFromVolume(u64 _Offset, u64 _Length, u32& _Buffer, bool _Decrypt);
+void ReadFromVolume(u64 _Offset, u64 _Length, u64& _Buffer, bool _Decrypt);
 bool ParseDisc();
 bool ParsePartitionData(SPartition& _rPartition);
 u32 GetDOLSize(u64 _DOLOffset);
@@ -190,27 +188,15 @@ void MarkAsUsedE(u64 _PartitionDataOffset, u64 _Offset, u64 _Size)
 	MarkAsUsed(Offset, Size);
 }
 
-// Helper functions for RAW reading the BE discs
-void ReadFromDisc(u64 _Offset, u64 _Length, u32& _Buffer)
-{
-	m_Disc->RAWRead(_Offset, _Length, (u8*)&_Buffer);
-	_Buffer = Common::swap32(_Buffer);
-}
-void ReadFromDisc(u64 _Offset, u64 _Length, u64& _Buffer)
-{
-	m_Disc->RAWRead(_Offset, _Length, (u8*)&_Buffer);
-	_Buffer = Common::swap32((u32)_Buffer);
-	_Buffer <<= 2;
-}
 // Helper functions for reading the BE volume
-void ReadFromVolume(u64 _Offset, u64 _Length, u32& _Buffer)
+void ReadFromVolume(u64 _Offset, u64 _Length, u32& _Buffer, bool _Decrypt)
 {
-	m_Disc->Read(_Offset, _Length, (u8*)&_Buffer);
+	m_Disc->Read(_Offset, _Length, (u8*)&_Buffer, _Decrypt);
 	_Buffer = Common::swap32(_Buffer);
 }
-void ReadFromVolume(u64 _Offset, u64 _Length, u64& _Buffer)
+void ReadFromVolume(u64 _Offset, u64 _Length, u64& _Buffer, bool _Decrypt)
 {
-	m_Disc->Read(_Offset, _Length, (u8*)&_Buffer);
+	m_Disc->Read(_Offset, _Length, (u8*)&_Buffer, _Decrypt);
 	_Buffer = Common::swap32((u32)_Buffer);
 	_Buffer <<= 2;
 }
@@ -222,8 +208,8 @@ bool ParseDisc()
 
 	for (int x = 0; x < 4; x++)
 	{
-		ReadFromDisc(0x40000 + (x * 8) + 0, 4, PartitionGroup[x].numPartitions);
-		ReadFromDisc(0x40000 + (x * 8) + 4, 4, PartitionGroup[x].PartitionsOffset);
+		ReadFromVolume(0x40000 + (x * 8) + 0, 4, PartitionGroup[x].numPartitions, false);
+		ReadFromVolume(0x40000 + (x * 8) + 4, 4, PartitionGroup[x].PartitionsOffset, false);
 
 		// Read all partitions
 		for (u32 i = 0; i < PartitionGroup[x].numPartitions; i++)
@@ -233,16 +219,16 @@ bool ParseDisc()
 			Partition.GroupNumber = x;
 			Partition.Number = i;
 
-			ReadFromDisc(PartitionGroup[x].PartitionsOffset + (i * 8) + 0, 4, Partition.Offset);
-			ReadFromDisc(PartitionGroup[x].PartitionsOffset + (i * 8) + 4, 4, Partition.Type);
+			ReadFromVolume(PartitionGroup[x].PartitionsOffset + (i * 8) + 0, 4, Partition.Offset, false);
+			ReadFromVolume(PartitionGroup[x].PartitionsOffset + (i * 8) + 4, 4, Partition.Type, false);
 
-			ReadFromDisc(Partition.Offset + 0x2a4, 4, Partition.Header.TMDSize);
-			ReadFromDisc(Partition.Offset + 0x2a8, 4, Partition.Header.TMDOffset);
-			ReadFromDisc(Partition.Offset + 0x2ac, 4, Partition.Header.CertChainSize);
-			ReadFromDisc(Partition.Offset + 0x2b0, 4, Partition.Header.CertChainOffset);
-			ReadFromDisc(Partition.Offset + 0x2b4, 4, Partition.Header.H3Offset);
-			ReadFromDisc(Partition.Offset + 0x2b8, 4, Partition.Header.DataOffset);
-			ReadFromDisc(Partition.Offset + 0x2bc, 4, Partition.Header.DataSize);
+			ReadFromVolume(Partition.Offset + 0x2a4, 4, Partition.Header.TMDSize, false);
+			ReadFromVolume(Partition.Offset + 0x2a8, 4, Partition.Header.TMDOffset, false);
+			ReadFromVolume(Partition.Offset + 0x2ac, 4, Partition.Header.CertChainSize, false);
+			ReadFromVolume(Partition.Offset + 0x2b0, 4, Partition.Header.CertChainOffset, false);
+			ReadFromVolume(Partition.Offset + 0x2b4, 4, Partition.Header.H3Offset, false);
+			ReadFromVolume(Partition.Offset + 0x2b8, 4, Partition.Header.DataOffset, false);
+			ReadFromVolume(Partition.Offset + 0x2bc, 4, Partition.Header.DataSize, false);
 
 			PartitionGroup[x].PartitionsVec.push_back(Partition);
 		}
@@ -293,8 +279,8 @@ bool ParsePartitionData(SPartition& _rPartition)
 
 		// Mark things as used which are not in the filesystem
 		// Header, Header Information, Apploader
-		ReadFromVolume(0x2440 + 0x14, 4, _rPartition.Header.ApploaderSize);
-		ReadFromVolume(0x2440 + 0x18, 4, _rPartition.Header.ApploaderTrailerSize);
+		ReadFromVolume(0x2440 + 0x14, 4, _rPartition.Header.ApploaderSize, true);
+		ReadFromVolume(0x2440 + 0x18, 4, _rPartition.Header.ApploaderTrailerSize, true);
 		MarkAsUsedE(_rPartition.Offset
 			+ _rPartition.Header.DataOffset
 			, 0
@@ -303,7 +289,7 @@ bool ParsePartitionData(SPartition& _rPartition)
 			+ _rPartition.Header.ApploaderTrailerSize);
 
 		// DOL
-		ReadFromVolume(0x420, 4, _rPartition.Header.DOLOffset);
+		ReadFromVolume(0x420, 4, _rPartition.Header.DOLOffset, true);
 		_rPartition.Header.DOLSize = GetDOLSize(_rPartition.Header.DOLOffset);
 		MarkAsUsedE(_rPartition.Offset
 			+ _rPartition.Header.DataOffset
@@ -311,8 +297,8 @@ bool ParsePartitionData(SPartition& _rPartition)
 			, _rPartition.Header.DOLSize);
 
 		// FST
-		ReadFromVolume(0x424, 4, _rPartition.Header.FSTOffset);
-		ReadFromVolume(0x428, 4, _rPartition.Header.FSTSize);
+		ReadFromVolume(0x424, 4, _rPartition.Header.FSTOffset, true);
+		ReadFromVolume(0x428, 4, _rPartition.Header.FSTSize, true);
 		MarkAsUsedE(_rPartition.Offset
 			+ _rPartition.Header.DataOffset
 			, _rPartition.Header.FSTOffset
@@ -348,8 +334,8 @@ u32 GetDOLSize(u64 _DOLOffset)
 	// Iterate through the 7 code segments
 	for (u8 i = 0; i < 7; i++)
 	{
-		ReadFromVolume(_DOLOffset + 0x00 + i * 4, 4, offset);
-		ReadFromVolume(_DOLOffset + 0x90 + i * 4, 4, size);
+		ReadFromVolume(_DOLOffset + 0x00 + i * 4, 4, offset, true);
+		ReadFromVolume(_DOLOffset + 0x90 + i * 4, 4, size, true);
 		if (offset + size > max)
 			max = offset + size;
 	}
@@ -357,8 +343,8 @@ u32 GetDOLSize(u64 _DOLOffset)
 	// Iterate through the 11 data segments
 	for (u8 i = 0; i < 11; i++)
 	{
-		ReadFromVolume(_DOLOffset + 0x1c + i * 4, 4, offset);
-		ReadFromVolume(_DOLOffset + 0xac + i * 4, 4, size);
+		ReadFromVolume(_DOLOffset + 0x1c + i * 4, 4, offset, true);
+		ReadFromVolume(_DOLOffset + 0xac + i * 4, 4, size, true);
 		if (offset + size > max)
 			max = offset + size;
 	}

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -35,7 +35,7 @@ public:
 private:
 	bool m_Initialized;
 	bool m_Valid;
-	u32 m_OffsetShift; // WII offsets are all shifted
+	bool m_Wii;
 
 	std::vector <SFileInfo> m_FileInfoVector;
 	u32 Read32(u64 _Offset) const;
@@ -44,6 +44,7 @@ private:
 	bool DetectFileSystem();
 	void InitFileSystem();
 	size_t BuildFilenames(const size_t _FirstIndex, const size_t _LastIndex, const std::string& _szDirectory, u64 _NameTableOffset);
+	u32 GetOffsetShift() const;
 };
 
 } // namespace

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -18,8 +18,9 @@ public:
 	IVolume() {}
 	virtual ~IVolume() {}
 
-	virtual bool Read(u64 _Offset, u64 _Length, u8* _pBuffer) const = 0;
-	virtual bool RAWRead(u64 _Offset, u64 _Length, u8* _pBuffer) const = 0;
+	// decrypt parameter must be false if not reading a Wii disc
+	virtual bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const = 0;
+
 	virtual bool GetTitleID(u8*) const { return false; }
 	virtual std::unique_ptr<u8[]> GetTMD(u32 *_sz) const
 	{

--- a/Source/Core/DiscIO/VolumeCreator.cpp
+++ b/Source/Core/DiscIO/VolumeCreator.cpp
@@ -123,7 +123,7 @@ IVolume* CreateVolumeFromDirectory(const std::string& _rDirectory, bool _bIsWii,
 bool IsVolumeWiiDisc(const IVolume *_rVolume)
 {
 	u32 MagicWord = 0;
-	_rVolume->Read(0x18, 4, (u8*)&MagicWord);
+	_rVolume->Read(0x18, 4, (u8*)&MagicWord, false);
 
 	return (Common::swap32(MagicWord) == 0x5D1C9EA3);
 	//GameCube 0xc2339f3d
@@ -132,7 +132,7 @@ bool IsVolumeWiiDisc(const IVolume *_rVolume)
 bool IsVolumeWadFile(const IVolume *_rVolume)
 {
 	u32 MagicWord = 0;
-	_rVolume->Read(0x02, 4, (u8*)&MagicWord);
+	_rVolume->Read(0x02, 4, (u8*)&MagicWord, false);
 
 	return (Common::swap32(MagicWord) == 0x00204973 || Common::swap32(MagicWord) == 0x00206962);
 }

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -15,6 +15,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
+#include "Core/VolumeHandler.h"
 #include "DiscIO/FileBlob.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeDirectory.h"
@@ -63,9 +64,12 @@ bool CVolumeDirectory::IsValidDirectory(const std::string& _rDirectory)
 	return File::IsDirectory(directoryName);
 }
 
-bool CVolumeDirectory::RAWRead( u64 _Offset, u64 _Length, u8* _pBuffer ) const
+bool CVolumeDirectory::RAWRead(u64 _Offset, u64 _Length, u8* _pBuffer) const
 {
-	return false;
+	if (VolumeHandler::IsWii())
+		return false;
+	else
+		return Read(_Offset, _Length, _pBuffer);
 }
 
 bool CVolumeDirectory::Read(u64 _Offset, u64 _Length, u8* _pBuffer) const

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -64,16 +64,23 @@ bool CVolumeDirectory::IsValidDirectory(const std::string& _rDirectory)
 	return File::IsDirectory(directoryName);
 }
 
-bool CVolumeDirectory::RAWRead(u64 _Offset, u64 _Length, u8* _pBuffer) const
+bool CVolumeDirectory::Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const
 {
-	if (VolumeHandler::IsWii())
-		return false;
-	else
-		return Read(_Offset, _Length, _pBuffer);
-}
+	bool wii = VolumeHandler::IsWii();
 
-bool CVolumeDirectory::Read(u64 _Offset, u64 _Length, u8* _pBuffer) const
-{
+	if (!decrypt && (_Offset + _Length >= 0x400) && wii)
+	{
+		// Fully supporting this would require re-encrypting every file that's read.
+		// Only supporting the areas that IOS allows software to read could be more feasible.
+		// Currently, only the header (up to 0x400) is supported, though we're cheating a bit
+		// with it by reading the header inside the current partition instead. Supporting the
+		// header is enough for booting games, but not for running things like the Disc Channel.
+		return false;
+	}
+
+	if (decrypt && !wii)
+		PanicAlertT("Tried to decrypt data from a non-Wii volume");
+
 	// header
 	if (_Offset < DISKHEADERINFO_ADDRESS)
 	{

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -32,8 +32,7 @@ public:
 
 	static bool IsValidDirectory(const std::string& _rDirectory);
 
-	bool Read(u64 _Offset, u64 _Length, u8* _pBuffer) const override;
-	bool RAWRead(u64 _Offset, u64 _Length, u8* _pBuffer) const override;
+	bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const override;
 
 	std::string GetUniqueID() const override;
 	void SetUniqueID(const std::string& _ID);

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -24,19 +24,17 @@ CVolumeGC::~CVolumeGC()
 {
 }
 
-bool CVolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer) const
+bool CVolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const
 {
+	if (decrypt)
+		PanicAlertT("Tried to decrypt data from a non-Wii volume");
+
 	if (m_pReader == nullptr)
 		return false;
 
 	FileMon::FindFilename(_Offset);
 
 	return m_pReader->Read(_Offset, _Length, _pBuffer);
-}
-
-bool CVolumeGC::RAWRead(u64 _Offset, u64 _Length, u8* _pBuffer) const
-{
-	return Read(_Offset, _Length, _pBuffer);
 }
 
 std::string CVolumeGC::GetUniqueID() const

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -23,8 +23,7 @@ class CVolumeGC : public IVolume
 public:
 	CVolumeGC(IBlobReader* _pReader);
 	~CVolumeGC();
-	bool Read(u64 _Offset, u64 _Length, u8* _pBuffer) const override;
-	bool RAWRead(u64 _Offset, u64 _Length, u8* _pBuffer) const override;
+	bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt = false) const override;
 	std::string GetUniqueID() const override;
 	std::string GetRevisionSpecificUniqueID() const override;
 	std::string GetMakerID() const override;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -44,8 +44,11 @@ CVolumeWAD::~CVolumeWAD()
 {
 }
 
-bool CVolumeWAD::Read(u64 _Offset, u64 _Length, u8* _pBuffer) const
+bool CVolumeWAD::Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const
 {
+	if (decrypt)
+		PanicAlertT("Tried to decrypt data from a non-Wii volume");
+
 	if (m_pReader == nullptr)
 		return false;
 

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -25,8 +25,7 @@ class CVolumeWAD : public IVolume
 public:
 	CVolumeWAD(IBlobReader* _pReader);
 	~CVolumeWAD();
-	bool Read(u64 _Offset, u64 _Length, u8* _pBuffer) const override;
-	bool RAWRead(u64 _Offset, u64 _Length, u8* _pBuffer) const override { return false; }
+	bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt = false) const override;
 	bool GetTitleID(u8* _pBuffer) const override;
 	std::string GetUniqueID() const override;
 	std::string GetMakerID() const override;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -24,8 +24,7 @@ class CVolumeWiiCrypted : public IVolume
 public:
 	CVolumeWiiCrypted(IBlobReader* _pReader, u64 _VolumeOffset, const unsigned char* _pVolumeKey);
 	~CVolumeWiiCrypted();
-	bool Read(u64 _Offset, u64 _Length, u8* _pBuffer) const override;
-	bool RAWRead(u64 _Offset, u64 _Length, u8* _pBuffer) const override;
+	bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const override;
 	bool GetTitleID(u8* _pBuffer) const override;
 	virtual std::unique_ptr<u8[]> GetTMD(u32 *_sz) const override;
 	std::string GetUniqueID() const override;


### PR DESCRIPTION
Yep, it actually works now! I've been able to rip a Wii game and get an ISO that's bit-for-bit identical to the original.

Most of the disc code in Dolphin seemed to use Read most of the time, only using RAWRead if Read didn't work, which isn't really correct. Read is the function that decrypts data, while RAWRead performs no encryption at all... but Read was being used for reading GC discs, despite them not having any encryption.

The first commit changes the DI command 0xA8 so that RAWRead is used. Because Read and RAWRead do the same thing for GC discs, there's no change with those. (VolumeDirectory didn't support RAWRead for GC discs before, but I fixed that.) Wii games don't use command 0xA8, so there's no change with them either. Only CleanRip (or theoretically other homebrew) reading Wii discs is affected.

The second commit changes the code to make it clearer whether decryption is being performed or not, so that there's a smaller chance of problems like this happening in the future. I had to update most calls to Read in order to do this, so there might be a risk that something is negatively affected.