### PR TITLE
Remove AtBreakpoint() from ReadIdle - Fixes Rogue Squadron 2 without breaking Gladius

### DIFF
--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -494,7 +494,7 @@ void SetCpStatusRegister()
 {
 	// Here always there is one fifo attached to the GPU
 	m_CPStatusReg.Breakpoint = fifo.bFF_Breakpoint;
-	m_CPStatusReg.ReadIdle = !fifo.CPReadWriteDistance ||  AtBreakpoint() || (fifo.CPReadPointer == fifo.CPWritePointer);
+	m_CPStatusReg.ReadIdle = !fifo.CPReadWriteDistance || (fifo.CPReadPointer == fifo.CPWritePointer);
 	m_CPStatusReg.CommandIdle = !fifo.CPReadWriteDistance || AtBreakpoint() || !fifo.bFF_GPReadEnable;
 	m_CPStatusReg.UnderflowLoWatermark = fifo.bFF_LoWatermark;
 	m_CPStatusReg.OverflowHiWatermark = fifo.bFF_HiWatermark;


### PR DESCRIPTION
All the credit in the world goes to skidau for pointing out the area that caused the issue and also [Unknown], whom held my hand as we added logs throughout CommandProcessor.cpp and Fifo.cpp.  Without those logs, I wouldn't have found this change.  

Basically, what's been going on is that under CommandIdle (The line directly below the one I edited,) there was a fix Rogue Squadron 2 (makes Pausing/Targeting Computer/Regular Disc Speeds work) by removing AtBreakpoint() from that line.  This unfortunately would break Gladius.  When I got annoyed about this bug again while testing the zfreeze branch, I decided to beg in the IRC for help debugging this while I randomly plugged away.  [Unknown] showed up and gave me some logging lines which revealed something that didn't seem right to me.  

If we removed AtBreakpoint() in line 498 of CommandProcessor.cpp we were essentially making ReadIdle set to on.  This broke Gladius, but Fixed RS2.  By removing it from ReadIdle instead of CommandIdle, both games work without breaking the other (and I tested other Fifo sensitive games I tested, like Battalion Wars 2.)  

Considering this Pull Request touches the Fifo, I know it needs a lot of testing.  There's a chance it fixes other bugs or causes other bugs.