### PR TITLE
VideoCommon: Custom texture handling

### DIFF
--- a/Source/Core/Common/Hash.cpp
+++ b/Source/Core/Common/Hash.cpp
@@ -510,19 +510,15 @@ u64 GetHash64(const u8 *src, int len, u32 samples)
 }
 
 // sets the hash function used for the texture cache
-void SetHash64Function(bool useHiresTextures)
+void SetHash64Function()
 {
-	if (useHiresTextures)
-	{
-		ptrHashFunction = &GetHashHiresTexture;
-	}
 #if _M_SSE >= 0x402
-	else if (cpu_info.bSSE4_2 && !useHiresTextures) // sse crc32 version
+	if (cpu_info.bSSE4_2) // sse crc32 version
 	{
 		ptrHashFunction = &GetCRC32;
 	}
-#endif
 	else
+#endif
 	{
 		ptrHashFunction = &GetMurmurHash3;
 	}

--- a/Source/Core/Common/Hash.h
+++ b/Source/Core/Common/Hash.h
@@ -16,4 +16,4 @@ u64 GetCRC32(const u8 *src, int len, u32 samples);   // SSE4.2 version of CRC32
 u64 GetHashHiresTexture(const u8 *src, int len, u32 samples);
 u64 GetMurmurHash3(const u8 *src, int len, u32 samples);
 u64 GetHash64(const u8 *src, int len, u32 samples);
-void SetHash64Function(bool useHiresTextures);
+void SetHash64Function();

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -13,14 +13,14 @@
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
+#include "Core/ConfigManager.h"
+
 #include "VideoCommon/HiresTextures.h"
+#include "VideoCommon/VideoConfig.h"
 
-namespace HiresTextures
-{
+std::unordered_map<std::string, std::string> HiresTexture::textureMap;
 
-static std::map<std::string, std::string> textureMap;
-
-void Init(const std::string& gameCode)
+void HiresTexture::Init(const std::string& gameCode)
 {
 	textureMap.clear();
 
@@ -80,85 +80,87 @@ void Init(const std::string& gameCode)
 	}
 }
 
-bool HiresTexExists(const std::string& filename)
+HiresTexture* HiresTexture::Search(const u8* texture, size_t texture_size, const u8* tlut, size_t tlut_size, u32 width, u32 height, int format)
 {
-	return textureMap.find(filename) != textureMap.end();
-}
-
-PC_TexFormat GetHiresTex(const std::string& filename, unsigned int* pWidth, unsigned int* pHeight, unsigned int* required_size, int texformat, unsigned int data_size, u8* data)
-{
-	if (textureMap.find(filename) == textureMap.end())
-		return PC_TEX_FMT_NONE;
-
-	int width;
-	int height;
-	int channels;
-
-	File::IOFile file;
-	file.Open(textureMap[filename], "rb");
-	std::vector<u8> buffer(file.GetSize());
-	file.ReadBytes(buffer.data(), file.GetSize());
-
-	u8* temp = SOIL_load_image_from_memory(buffer.data(), (int)buffer.size(), &width, &height, &channels, SOIL_LOAD_RGBA);
-
-	if (temp == nullptr)
+	u64 tex_hash = GetHashHiresTexture(texture, (int)texture_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
+	u64 tlut_hash = 0;
+	u64 hash = tex_hash;
+	if (tlut_size)
 	{
-		ERROR_LOG(VIDEO, "Custom texture %s failed to load", textureMap[filename].c_str());
-		return PC_TEX_FMT_NONE;
+		tlut_hash = GetHashHiresTexture(tlut, (int)tlut_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
+		hash ^= tlut_hash;
 	}
 
-	*pWidth = width;
-	*pHeight = height;
-
-	//int offset = 0;
-	PC_TexFormat returnTex = PC_TEX_FMT_NONE;
-
-	// TODO(neobrain): This function currently has no way to enforce RGBA32
-	// output, which however is required on some configurations to function
-	// properly. As a lazy workaround, we hence disable the optimized code
-	// path for now.
-#if 0
-	switch (texformat)
+	HiresTexture* ret = nullptr;
+	std::string base_filename = StringFromFormat("%s_%08x_%i", SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str(), (u32)hash, format);
+	for (int level = 0;; level++)
 	{
-	case GX_TF_I4:
-	case GX_TF_I8:
-	case GX_TF_IA4:
-	case GX_TF_IA8:
-		*required_size = width * height * 8;
-		if (data_size < *required_size)
-			goto cleanup;
-
-		for (int i = 0; i < width * height * 4; i += 4)
+		std::string filename = base_filename;
+		if (level)
 		{
-			// Rather than use a luminosity function, just use the most intense color for luminance
-			// TODO(neobrain): Isn't this kind of.. stupid?
-			data[offset++] = *std::max_element(temp+i, temp+i+3);
-			data[offset++] = temp[i+3];
+			filename += StringFromFormat("_mip%u", level);
 		}
-		returnTex = PC_TEX_FMT_IA8;
-		break;
-	default:
-		*required_size = width * height * 4;
-		if (data_size < *required_size)
-			goto cleanup;
 
-		memcpy(data, temp, width * height * 4);
-		returnTex = PC_TEX_FMT_RGBA32;
-		break;
+		if (textureMap.find(filename) != textureMap.end())
+		{
+			Level l;
+
+			File::IOFile file;
+			file.Open(textureMap[filename], "rb");
+			std::vector<u8> buffer(file.GetSize());
+			file.ReadBytes(buffer.data(), file.GetSize());
+
+			int channels;
+			l.data = SOIL_load_image_from_memory(buffer.data(), (int)buffer.size(), (int*)&l.width, (int*)&l.height, &channels, SOIL_LOAD_RGBA);
+			l.data_size = (size_t)l.width * l.height * 4;
+
+			if (l.data == nullptr)
+			{
+				ERROR_LOG(VIDEO, "Custom texture %s failed to load", filename.c_str());
+				break;
+			}
+
+			if (!level)
+			{
+				if (l.width * height != l.height * width)
+					ERROR_LOG(VIDEO, "Invalid custom texture size %dx%d for texture %s. The aspect differs from the native size %dx%d.",
+					          l.width, l.height, filename.c_str(), width, height);
+				if (l.width % width || l.height % height)
+					WARN_LOG(VIDEO, "Invalid custom texture size %dx%d for texture %s. Please use an integer upscaling factor based on the native size %dx%d.",
+					         l.width, l.height, filename.c_str(), width, height);
+				width = l.width;
+				height = l.height;
+			}
+			else if (width != l.width || height != l.height)
+			{
+				ERROR_LOG(VIDEO, "Invalid custom texture size %dx%d for texture %s. This mipmap layer _must_ be %dx%d.",
+				          l.width, l.height, filename.c_str(), width, height);
+				SOIL_free_image_data(l.data);
+				break;
+			}
+
+			// calculate the size of the next mipmap
+			width >>= 1;
+			height >>= 1;
+
+			if (!ret)
+				ret = new HiresTexture();
+			ret->m_levels.push_back(l);
+		}
+		else
+		{
+			break;
+		}
 	}
-#else
-	*required_size = width * height * 4;
-	if (data_size < *required_size)
-		goto cleanup;
 
-	memcpy(data, temp, width * height * 4);
-	returnTex = PC_TEX_FMT_RGBA32;
-#endif
-
-	INFO_LOG(VIDEO, "Loading custom texture from %s", textureMap[filename].c_str());
-cleanup:
-	SOIL_free_image_data(temp);
-	return returnTex;
+	return ret;
 }
 
+HiresTexture::~HiresTexture()
+{
+	for (auto& l : m_levels)
+	{
+		SOIL_free_image_data(l.data);
+	}
 }
+

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -80,7 +80,7 @@ void HiresTexture::Init(const std::string& gameCode)
 	}
 }
 
-HiresTexture* HiresTexture::Search(const u8* texture, size_t texture_size, const u8* tlut, size_t tlut_size, u32 width, u32 height, int format)
+std::string HiresTexture::GenBaseName(const u8* texture, size_t texture_size, const u8* tlut, size_t tlut_size, u32 width, u32 height, int format)
 {
 	u64 tex_hash = GetHashHiresTexture(texture, (int)texture_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
 	u64 tlut_hash = 0;
@@ -90,9 +90,14 @@ HiresTexture* HiresTexture::Search(const u8* texture, size_t texture_size, const
 		tlut_hash = GetHashHiresTexture(tlut, (int)tlut_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
 		hash ^= tlut_hash;
 	}
+	return StringFromFormat("%s_%08x_%i", SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str(), (u32)hash, (u16)format);
+}
+
+HiresTexture* HiresTexture::Search(const u8* texture, size_t texture_size, const u8* tlut, size_t tlut_size, u32 width, u32 height, int format)
+{
+	std::string base_filename = GenBaseName(texture, texture_size, tlut, tlut_size, width, height, format);
 
 	HiresTexture* ret = nullptr;
-	std::string base_filename = StringFromFormat("%s_%08x_%i", SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID.c_str(), (u32)hash, format);
 	for (int level = 0;; level++)
 	{
 		std::string filename = base_filename;

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -21,6 +21,13 @@ public:
 		int format
 	);
 
+	static std::string GenBaseName(
+		const u8* texture, size_t texture_size,
+		const u8* tlut, size_t tlut_size,
+		u32 width, u32 height,
+		int format
+	);
+
 	~HiresTexture();
 
 	struct Level

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -4,15 +4,36 @@
 
 #pragma once
 
-#include <map>
 #include <string>
+#include <unordered_map>
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoCommon.h"
 
-namespace HiresTextures
+class HiresTexture
 {
-void Init(const std::string& gameCode);
-bool HiresTexExists(const std::string& filename);
-PC_TexFormat GetHiresTex(const std::string& fileName, unsigned int* pWidth, unsigned int* pHeight, unsigned int* required_size, int texformat, unsigned int data_size, u8* data);
+public:
+	static void Init(const std::string& gameCode);
 
-}
+	static HiresTexture* Search(
+		const u8* texture, size_t texture_size,
+		const u8* tlut, size_t tlut_size,
+		u32 width, u32 height,
+		int format
+	);
+
+	~HiresTexture();
+
+	struct Level
+	{
+		u8* data;
+		size_t data_size;
+		u32 width, height;
+	};
+	std::vector<Level> m_levels;
+
+	static std::unordered_map<std::string, std::string> textureMap;
+
+private:
+	HiresTexture() {}
+
+};

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -62,7 +62,7 @@ TextureCache::TextureCache()
 	if (g_ActiveConfig.bHiresTextures && !g_ActiveConfig.bDumpTextures)
 		HiresTexture::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID);
 
-	SetHash64Function(g_ActiveConfig.bHiresTextures || g_ActiveConfig.bDumpTextures);
+	SetHash64Function();
 
 	invalidate_texture_cache_requested = false;
 }
@@ -110,7 +110,6 @@ void TextureCache::OnConfigChanged(VideoConfig& config)
 			if (g_ActiveConfig.bHiresTextures)
 				HiresTexture::Init(SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID);
 
-			SetHash64Function(g_ActiveConfig.bHiresTextures || g_ActiveConfig.bDumpTextures);
 			TexDecoder_SetTexFmtOverlayOptions(g_ActiveConfig.bTexFmtOverlayEnable, g_ActiveConfig.bTexFmtOverlayCenter);
 
 			invalidate_texture_cache_requested = false;

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -120,7 +120,7 @@ protected:
 	static size_t temp_size;
 
 private:
-	static void DumpTexture(TCacheEntryBase* entry, unsigned int level);
+	static void DumpTexture(TCacheEntryBase* entry, std::string basename, unsigned int level);
 	static void CheckTempSize(size_t required_size);
 
 	static TCacheEntryBase* AllocateRenderTarget(unsigned int width, unsigned int height);

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -116,13 +116,12 @@ public:
 protected:
 	TextureCache();
 
-	static  GC_ALIGNED16(u8 *temp);
-	static unsigned int temp_size;
+	static GC_ALIGNED16(u8 *temp);
+	static size_t temp_size;
 
 private:
-	static bool CheckForCustomTextureLODs(u64 tex_hash, int texformat, unsigned int levels);
-	static PC_TexFormat LoadCustomTexture(u64 tex_hash, int texformat, unsigned int level, unsigned int* width, unsigned int* height);
 	static void DumpTexture(TCacheEntryBase* entry, unsigned int level);
+	static void CheckTempSize(size_t required_size);
 
 	static TCacheEntryBase* AllocateRenderTarget(unsigned int width, unsigned int height);
 	static void FreeRenderTarget(TCacheEntryBase* entry);


### PR DESCRIPTION
This won't change the custom texture format neither any compatibility. It's just a cleanup to let us change this more easily.
This also seperates the texcache hash from the custom texture hash. Now both can be calculated independet. Through we do hash twice on texcache miss and enabled custom textures.