### PR TITLE
VertexShaderManager: Turn off the epsilon hack for Nvidia 3D Vision.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -456,7 +456,10 @@ void VertexShaderManager::SetConstants()
 			g_fProjectionMatrix[13] = 0.0f;
 
 			g_fProjectionMatrix[14] = 0.0f;
-			g_fProjectionMatrix[15] = 1.0f + FLT_EPSILON; // hack to fix depth clipping precision issues (such as Sonic Unleashed UI)
+
+			// Hack to fix depth clipping precision issues (such as Sonic Unleashed UI)
+			// Turn it off for Nvidia 3D Vision, because it can't handle such a projection matrix
+			g_fProjectionMatrix[15] = (g_ActiveConfig.iStereoMode == STEREO_3DVISION) ? 1.0f : 1.0f + FLT_EPSILON;
 
 			SETSTAT_FT(stats.g2proj_0, g_fProjectionMatrix[0]);
 			SETSTAT_FT(stats.g2proj_1, g_fProjectionMatrix[1]);


### PR DESCRIPTION
Nvidia's 3D Vision driver freaks out so badly over seeing such a projection matrix, it won't even try to display our native 3D anymore.
