### PR TITLE
VideoConfig: Don't disable stereoscopy if Real XFB is enabled but not in use.

### DIFF
--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -225,7 +225,7 @@ void VideoConfig::VerifyValidity()
 			iStereoMode = 0;
 		}
 
-		if (bUseRealXFB)
+		if (bUseXFB && bUseRealXFB)
 		{
 			OSD::AddMessage("Stereoscopic 3D isn't supported with Real XFB, turning off stereoscopy.", 10000);
 			iStereoMode = 0;


### PR DESCRIPTION
Small mistake on my part when verifying the validity of the settings.
