### PR TITLE
Alternate zfreeze solution

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -1040,6 +1040,12 @@ void Renderer::SetGenerationMode()
 void Renderer::SetDepthMode()
 {
 	gx_state.zmode = bpmem.zmode;
+	if (bpmem.genMode.zfreeze)
+	{
+		gx_state.zmode.testenable = true;
+		gx_state.zmode.updateenable = false;
+		gx_state.zmode.func = ZMode::LEQUAL;
+	}	
 }
 
 void Renderer::SetLogicOpMode()

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1799,6 +1799,13 @@ void Renderer::SetDepthMode()
 		glDisable(GL_DEPTH_TEST);
 		glDepthMask(GL_FALSE);
 	}
+
+	if (bpmem.genMode.zfreeze)
+	{
+		glEnable(GL_DEPTH_TEST);
+		glDepthMask(GL_FALSE);
+		glDepthFunc(GL_LEQUAL);
+	}
 }
 
 void Renderer::SetLogicOpMode()

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -267,7 +267,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	GenerateVSOutputStruct<T>(out, ApiType);
 
 	const bool forced_early_z = g_ActiveConfig.backend_info.bSupportsEarlyZ && bpmem.UseEarlyDepthTest() && (g_ActiveConfig.bFastDepthCalc || bpmem.alpha_test.TestResult() == AlphaTest::UNDETERMINED);
-	const bool per_pixel_depth = (bpmem.ztex2.op != ZTEXTURE_DISABLE && bpmem.UseLateDepthTest()) || (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !forced_early_z);
+	const bool per_pixel_depth = (bpmem.ztex2.op != ZTEXTURE_DISABLE && bpmem.UseLateDepthTest()) || (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !forced_early_z) || bpmem.genMode.zfreeze;
 
 	if (forced_early_z)
 	{
@@ -541,10 +541,20 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	uid_data->fast_depth_calc = g_ActiveConfig.bFastDepthCalc;
 	uid_data->early_ztest = bpmem.UseEarlyDepthTest();
 	uid_data->fog_fsel = bpmem.fog.c_proj_fsel.fsel;
+	uid_data->zfreeze = bpmem.genMode.zfreeze;
 
 	// Note: z-textures are not written to depth buffer if early depth test is used
 	if (per_pixel_depth && bpmem.UseEarlyDepthTest())
-		out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+	{
+		if (bpmem.genMode.zfreeze)
+		{
+			out.Write("\tdepth = 1.0;\n");
+		}
+		else
+		{
+			out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+		}
+	}
 
 	// Note: depth texture output is only written to depth buffer if late depth test is used
 	// theoretical final depth value is used for fog calculation, though, so we have to emulate ztextures anyway
@@ -558,7 +568,16 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	}
 
 	if (per_pixel_depth && bpmem.UseLateDepthTest())
-		out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+	{
+		if (bpmem.genMode.zfreeze)
+		{
+			out.Write("\tdepth = 1.0;\n");
+		}
+		else
+		{
+			out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+		}
+	}
 
 	if (dstAlphaMode == DSTALPHA_ALPHA_PASS)
 	{

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -62,6 +62,7 @@ struct pixel_shader_uid_data
 	u32 forced_early_z : 1;
 	u32 early_ztest : 1;
 	u32 bounding_box : 1;
+	u32 zfreeze : 1;
 
 	u32 texMtxInfo_n_projection : 8; // 8x1 bit
 	u32 tevindref_bi0 : 3;


### PR DESCRIPTION
Provides skybox depth fix for RS games and eliminates shadow z-fighting.
Mario Tennis gimmick courses are still an issue, but I think can be
fixed if we can adjust z-depth bias.  Changes to PixelShaderGen, so
clear ShaderCache to test please!  Was only able to test RS games, Mario
Tennis and Mario Strikers.

Additional work/testing to determine better state setting logic in
Render.cpp