### PR TITLE
Added identifier for country code 'B'

### DIFF
--- a/Source/Core/DiscIO/VolumeCommon.cpp
+++ b/Source/Core/DiscIO/VolumeCommon.cpp
@@ -52,6 +52,7 @@ IVolume::ECountry CountrySwitch(u8 CountryCode)
 		case 'E':
 		case 'N': // Japanese import to USA and other NTSC regions
 		case 'Z': // Prince Of Persia - The Forgotten Sands (WII)
+		case 'B': // Ufouria: The Saga (Virtual Console)
 			return IVolume::COUNTRY_USA;
 
 		case 'J':

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -37,7 +37,7 @@
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/WxUtils.h"
 
-static const u32 CACHE_REVISION = 0x117;
+static const u32 CACHE_REVISION = 0x118;
 
 #define DVD_BANNER_WIDTH 96
 #define DVD_BANNER_HEIGHT 32


### PR DESCRIPTION
Only used by the American version of Ufouria: The Saga
