### PR TITLE
Fix some issues with the ARM32 JIT with fastmem disabled

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
@@ -485,6 +485,10 @@ const u8* JitArm::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlo
 				}
 				JitArmTables::CompileInstruction(ops[i]);
 
+				// FPR cache causes issues without fastmem
+				if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem)
+					fpr.Flush();
+
 				// If we have a register that will never be used again, flush it.
 				for (int j : ~ops[i].gprInUse)
 					gpr.StoreFromRegister(j);


### PR DESCRIPTION
This partially fixes issue 8016. There are still a lot of problems, but the remaining ones aren't related to #1542. My current suspect is #1579, but I haven't been able to look into it too much yet. This at least allows Mario Sunshine to get past the title screen and partially fixes Wind Waker's camera, among other things.