### PR TITLE
Add support of more JIT-compiled code for profiling

### DIFF
--- a/Source/Core/Common/JitRegister.cpp
+++ b/Source/Core/Common/JitRegister.cpp
@@ -72,18 +72,17 @@ void Shutdown()
 }
 
 void Register(const void* base_address, u32 code_size,
-	const char* name, u32 original_address)
+	const char* format, ...)
 {
 #if !(defined USE_OPROFILE && USE_OPROFILE) && !defined(USE_VTUNE)
 	if (!s_perf_map_file.IsOpen())
 		return;
 #endif
 
-	std::string symbol_name;
-	if (original_address)
-		symbol_name = StringFromFormat("%s_%x", name, original_address);
-	else
-		symbol_name = name;
+	va_list args;
+	va_start(args, format);
+	std::string symbol_name = StringFromFormatV(format, args);
+	va_end(args);
 
 #if defined USE_OPROFILE && USE_OPROFILE
 	op_write_native_code(s_agent, symbol_name.data(), (u64)base_address,

--- a/Source/Core/Common/JitRegister.cpp
+++ b/Source/Core/Common/JitRegister.cpp
@@ -71,18 +71,15 @@ void Shutdown()
 		s_perf_map_file.Close();
 }
 
-void Register(const void* base_address, u32 code_size,
-	const char* format, ...)
+void RegisterV(const void* base_address, u32 code_size,
+	const char* format, va_list args)
 {
 #if !(defined USE_OPROFILE && USE_OPROFILE) && !defined(USE_VTUNE)
 	if (!s_perf_map_file.IsOpen())
 		return;
 #endif
 
-	va_list args;
-	va_start(args, format);
 	std::string symbol_name = StringFromFormatV(format, args);
-	va_end(args);
 
 #if defined USE_OPROFILE && USE_OPROFILE
 	op_write_native_code(s_agent, symbol_name.data(), (u64)base_address,

--- a/Source/Core/Common/JitRegister.h
+++ b/Source/Core/Common/JitRegister.h
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #pragma once
+#include <stdarg.h>
 #include "Common/CommonTypes.h"
 
 namespace JitRegister
@@ -10,7 +11,26 @@ namespace JitRegister
 
 void Init();
 void Shutdown();
-void Register(const void* base_address, u32 code_size,
-	const char* format, ...);
+void RegisterV(const void* base_address, u32 code_size,
+	const char* format, va_list args);
+
+inline void Register(const void* base_address, u32 code_size,
+	const char* format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	RegisterV(base_address, code_size, format, args);
+	va_end(args);
+}
+
+inline void Register(const void* start, const void* end,
+	const char* format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	u32 code_size = (u32) ((const char*) end - (const char*) start);
+	RegisterV(start, code_size, format, args);
+	va_end(args);
+}
 
 }

--- a/Source/Core/Common/JitRegister.h
+++ b/Source/Core/Common/JitRegister.h
@@ -11,6 +11,6 @@ namespace JitRegister
 void Init();
 void Shutdown();
 void Register(const void* base_address, u32 code_size,
-	const char* name, u32 original_address=0);
+	const char* format, ...);
 
 }

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -95,28 +95,30 @@ bool CharArrayFromFormatV(char* out, int outsize, const char* format, va_list ar
 std::string StringFromFormat(const char* format, ...)
 {
 	va_list args;
+	va_start(args, format);
+	std::string res = StringFromFormatV(format, args);
+	va_end(args);
+	return std::move(res);
+}
+
+std::string StringFromFormatV(const char* format, va_list args)
+{
 	char *buf = nullptr;
 #ifdef _WIN32
-	int required = 0;
-
-	va_start(args, format);
-	required = _vscprintf(format, args);
+	int required = _vscprintf(format, args);
 	buf = new char[required + 1];
 	CharArrayFromFormatV(buf, required + 1, format, args);
-	va_end(args);
 
 	std::string temp = buf;
 	delete[] buf;
 #else
-	va_start(args, format);
 	if (vasprintf(&buf, format, args) < 0)
 		ERROR_LOG(COMMON, "Unable to allocate memory for string");
-	va_end(args);
 
 	std::string temp = buf;
 	free(buf);
 #endif
-	return temp;
+	return std::move(temp);
 }
 
 // For Debugging. Read out an u8 array.

--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -13,6 +13,8 @@
 
 #include "Common/Common.h"
 
+std::string StringFromFormatV(const char* format, va_list args);
+
 std::string StringFromFormat(const char* format, ...)
 #if !defined _WIN32
 // On compilers that support function attributes, this gives StringFromFormat

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/JitRegister.h"
 #include "Common/MemoryUtil.h"
 
 #include "Core/PowerPC/Jit64/Jit.h"
@@ -199,6 +200,8 @@ void Jit64AsmRoutineManager::Generate()
 	}
 	ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8, 16);
 	RET();
+
+	JitRegister::Register(enterCode, GetCodePtr(), "JIT_Loop");
 
 	GenerateCommon();
 }

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -144,7 +144,7 @@ using namespace Gen;
 		}
 
 		JitRegister::Register(blockCodePointers[block_num], b.codeSize,
-			"JIT_PPC", b.originalAddress);
+			"JIT_PPC_%08x", b.originalAddress);
 	}
 
 	const u8 **JitBaseBlockCache::GetCodePointers()

--- a/Source/Core/Core/PowerPC/JitCommon/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/TrampolineCache.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "Common/JitRegister.h"
 #include "Common/StringUtil.h"
 #include "Common/x64ABI.h"
 #include "Core/HW/Memmap.h"
@@ -95,6 +96,8 @@ const u8* TrampolineCache::GenerateReadTrampoline(const InstructionInfo &info, B
 		MOVZX(dataRegSize, info.operandSize * 8, dataReg, R(ABI_RETURN));
 
 	JMP(returnPtr, true);
+
+	JitRegister::Register(trampoline, GetCodePtr(), "JIT_ReadTrampoline");
 	return trampoline;
 }
 
@@ -172,5 +175,6 @@ const u8* TrampolineCache::GenerateWriteTrampoline(const InstructionInfo &info, 
 	}
 	JMP(returnPtr, true);
 
+	JitRegister::Register(trampoline, GetCodePtr(), "JIT_WriteTrampoline_%x", pc);
 	return trampoline;
 }

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -33,7 +33,7 @@ VertexLoaderX64::VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att): 
 
 	std::string name;
 	AppendToString(&name);
-	JitRegister::Register(region, (u32)(GetCodePtr() - region), name.c_str());
+	JitRegister::Register(region, GetCodePtr(), name.c_str());
 }
 
 OpArg VertexLoaderX64::GetVertexAddr(int array, u64 attribute)


### PR DESCRIPTION

Extends [PR-1432](https://github.com/dolphin-emu/dolphin/pull/1432) in order to support [more JIT-compiled code](https://github.com/dolphin-emu/dolphin/pull/1432#issuecomment-68222071):

  * VertexLoader;
  * shared/common JIT-compiled code (`JitAsmCommon`);
  * far code;
  * dispatch loop (?) (`JitAsm`).

I don't really known what some of the JIT-compiled functions do, so the names might need to be adjusted.

For the fare code case, the code in semantically part of the basic block, so we generate a symbol name in the format `"JIT_PPC_${basicBlockAddress}/${typeOfFarCode}%${farCodeAddress}"`. This means that:

  * most profilig solutions will not be able to account them with their basic block as they will not recognize that `"JIT_PPC_${basicBlockAddress}/${typeOfFarCode}%${farCodeAddress}"` is  a part of `"JIT_PPC_${basicBlockAddress}"`;

  * we can teach FlameGraph/`stackcollapse`-based solutions to recognize this with `sed 's/%/;/m'`.

Note: the current version of `stackcollapse-perf.pl` does a `s/;/:/` in order to handle Java symbols such as `Lorg/mozilla/javascript/ContextFactory;.call(Lorg/mozilla/javascript/ContextAction;)Ljava/lang/Object;` so we can't use `"JIT_PPC_${basicBlockAddress}/${typeOfFarCode};${farCodeAddress}"` without disabling the java handling code. This is why I'm using `%`.
