### PR TITLE
SDL: add more rumble types and fix minor issue

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -130,6 +130,16 @@ Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsi
 		// sine effect
 		if (supported_effects & SDL_HAPTIC_SINE)
 			AddOutput(new SineEffect(m_haptic));
+
+		// leftright effect
+		if (supported_effects & SDL_HAPTIC_LEFTRIGHT)
+		{
+			// some controllers have two rumble motors, SDL allows to control them seperatly through the LeftRight
+			// haptic effect. We should allow the user to use them seperatly, because there is no other use for it
+			// yet and both motors are different, usually a big stronger and slower one and a small weaker and faster one.
+			AddOutput(new LeftRightSmallEffect(m_haptic));
+			AddOutput(new LeftRightLargeEffect(m_haptic));
+		}
 	}
 #endif
 
@@ -187,6 +197,16 @@ std::string Joystick::SineEffect::GetName() const
 	return "Sine";
 }
 
+std::string Joystick::LeftRightSmallEffect::GetName() const
+{
+	return "SmallOnly";
+}
+
+std::string Joystick::LeftRightLargeEffect::GetName() const
+{
+	return "LargeOnly";
+}
+
 void Joystick::ConstantEffect::SetState(ControlState state)
 {
 	if (state)
@@ -233,6 +253,40 @@ void Joystick::SineEffect::SetState(ControlState state)
 	}
 
 	m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
+	Update();
+}
+
+void Joystick::LeftRightLargeEffect::SetState(ControlState state)
+{
+	if (state)
+	{
+		m_effect.type = SDL_HAPTIC_LEFTRIGHT;
+		// 200 seems too weak, somebody with a lot of time could try out other values
+		m_effect.leftright.length = 250;
+	}
+	else
+	{
+		m_effect.type = 0;
+	}
+
+	m_effect.leftright.large_magnitude = (Sint16)(state * 0x7FFF);
+	Update();
+}
+
+void Joystick::LeftRightSmallEffect::SetState(ControlState state)
+{
+	if (state)
+	{
+		m_effect.type = SDL_HAPTIC_LEFTRIGHT;
+		// 200 seems too weak, somebody with a lot of time could try out other values
+		m_effect.leftright.length = 250;
+	}
+	else
+	{
+		m_effect.type = 0;
+	}
+
+	m_effect.leftright.small_magnitude = (Sint16)(state * 0x7FFF);
 	Update();
 }
 #endif

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -126,6 +126,10 @@ Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsi
 		// ramp effect
 		if (supported_effects & SDL_HAPTIC_RAMP)
 			AddOutput(new RampEffect(m_haptic));
+
+		// sine effect
+		if (supported_effects & SDL_HAPTIC_SINE)
+			AddOutput(new SineEffect(m_haptic));
 	}
 #endif
 
@@ -178,6 +182,11 @@ std::string Joystick::RampEffect::GetName() const
 	return "Ramp";
 }
 
+std::string Joystick::SineEffect::GetName() const
+{
+	return "Sine";
+}
+
 void Joystick::ConstantEffect::SetState(ControlState state)
 {
 	if (state)
@@ -207,6 +216,23 @@ void Joystick::RampEffect::SetState(ControlState state)
 	}
 
 	m_effect.ramp.start = (Sint16)(state * 0x7FFF);
+	Update();
+}
+
+void Joystick::SineEffect::SetState(ControlState state)
+{
+	if (state)
+	{
+		m_effect.type = SDL_HAPTIC_SINE;
+		// 200 seems too weak, somebody with a lot of time could try out other values
+		m_effect.periodic.length = 250;
+	}
+	else
+	{
+		m_effect.type = 0;
+	}
+
+	m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
 	Update();
 }
 #endif

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -140,6 +140,10 @@ Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsi
 			AddOutput(new LeftRightSmallEffect(m_haptic));
 			AddOutput(new LeftRightLargeEffect(m_haptic));
 		}
+
+		// triangle effect
+		if (supported_effects & SDL_HAPTIC_TRIANGLE)
+			AddOutput(new TriangleEffect(m_haptic));
 	}
 #endif
 
@@ -205,6 +209,11 @@ std::string Joystick::LeftRightSmallEffect::GetName() const
 std::string Joystick::LeftRightLargeEffect::GetName() const
 {
 	return "LargeOnly";
+}
+
+std::string Joystick::TriangleEffect::GetName() const
+{
+	return "Triangle";
 }
 
 void Joystick::ConstantEffect::SetState(ControlState state)
@@ -287,6 +296,23 @@ void Joystick::LeftRightSmallEffect::SetState(ControlState state)
 	}
 
 	m_effect.leftright.small_magnitude = (Sint16)(state * 0x7FFF);
+	Update();
+}
+
+void Joystick::TriangleEffect::SetState(ControlState state)
+{
+	if (state)
+	{
+		m_effect.type = SDL_HAPTIC_TRIANGLE;
+		// 200 seems too weak, somebody with a lot of time could try out other values
+		m_effect.periodic.length = 250;
+	}
+	else
+	{
+		m_effect.type = 0;
+	}
+
+	m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
 	Update();
 }
 #endif

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -98,6 +98,14 @@ private:
 		std::string GetName() const override;
 		void SetState(ControlState state) override;
 	};
+
+	class SineEffect : public HapticEffect
+	{
+	public:
+		SineEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
+		std::string GetName() const override;
+		void SetState(ControlState state) override;
+	};
 #endif
 
 public:

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -72,7 +72,7 @@ private:
 	class HapticEffect : public Output
 	{
 	public:
-		HapticEffect(SDL_Haptic* haptic) : m_haptic(haptic), m_id(-1) {}
+		HapticEffect(SDL_Haptic* haptic) : m_effect(), m_haptic(haptic), m_id(-1) {}
 		~HapticEffect() { m_effect.type = 0; Update(); }
 
 	protected:

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -122,6 +122,14 @@ private:
 		std::string GetName() const override;
 		void SetState(ControlState state) override;
 	};
+
+	class TriangleEffect : public HapticEffect
+	{
+	public:
+		TriangleEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
+		std::string GetName() const override;
+		void SetState(ControlState state) override;
+	};
 #endif
 
 public:

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -106,6 +106,22 @@ private:
 		std::string GetName() const override;
 		void SetState(ControlState state) override;
 	};
+
+	class LeftRightSmallEffect : public HapticEffect
+	{
+	public:
+		LeftRightSmallEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
+		std::string GetName() const override;
+		void SetState(ControlState state) override;
+	};
+
+	class LeftRightLargeEffect : public HapticEffect
+	{
+	public:
+		LeftRightLargeEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
+		std::string GetName() const override;
+		void SetState(ControlState state) override;
+	};
 #endif
 
 public:


### PR DESCRIPTION
the first commit fixes issues inside the rumble code based on uninitialized fields in the haptic effect struct. Allthough it shouldn't have any effect on the current code it makes it harder to add more complex SDL_Haptic types like all SDL_HapticPeriodic based ones.

The second commit adds three more rumble types: sine, leftright and triangle. They all use default values as far as possible and should be only to get gamepads working which only support these like the xbox360 usb gamepad. The leftright type is splitted into a Small and Large Effect, so that a user can use the rumble motors seperatly.