### PR TITLE
JIT: simplify ISI handling.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -71,7 +71,7 @@ public:
 	// Jit!
 
 	void Jit(u32 em_address) override;
-	const u8* DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buffer, JitBlock *b);
+	const u8* DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buffer, JitBlock *b, u32 nextPC);
 
 	BitSet32 CallerSavedRegistersInUse();
 

--- a/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
@@ -791,7 +791,6 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 		case ShortIdleLoop:
 		case FPExceptionCheck:
 		case DSIExceptionCheck:
-		case ISIException:
 		case ExtExceptionCheck:
 		case BreakPointCheck:
 		case Int3:
@@ -2240,20 +2239,6 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 			Jit->MOV(32, PPCSTATE(pc), Imm32(InstLoc));
 			Jit->WriteExceptionExit();
 			Jit->SetJumpTarget(noMemException);
-			break;
-		}
-		case ISIException:
-		{
-			unsigned InstLoc = ibuild->GetImmValue(getOp1(I));
-
-			// Address of instruction could not be translated
-			Jit->MOV(32, PPCSTATE(npc), Imm32(InstLoc));
-			Jit->OR(32, PPCSTATE(Exceptions), Imm32(EXCEPTION_ISI));
-
-			// Remove the invalid instruction from the icache, forcing a recompile
-			Jit->MOV(64, R(RSCRATCH), ImmPtr(jit->GetBlockCache()->GetICachePtr(InstLoc)));
-			Jit->MOV(32, MatR(RSCRATCH), Imm32(JIT_ICACHE_INVALID_WORD));
-			Jit->WriteExceptionExit();
 			break;
 		}
 		case ExtExceptionCheck:

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
@@ -54,7 +54,7 @@ public:
 	// Jit!
 
 	void Jit(u32 em_address) override;
-	const u8* DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buffer, JitBlock *b);
+	const u8* DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buffer, JitBlock *b, u32 nextPC);
 
 	void Trace();
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -110,7 +110,6 @@ using namespace Gen;
 	{
 		JitBlock &b = blocks[num_blocks];
 		b.invalid = false;
-		b.memoryException = false;
 		b.originalAddress = em_address;
 		b.linkData.clear();
 		num_blocks++; //commit the current block
@@ -132,11 +131,7 @@ using namespace Gen;
 
 		block_map[std::make_pair(pAddr + 4 * b.originalSize - 1, pAddr)] = block_num;
 
-		// Blocks where a memory exception (ISI) occurred in the instruction fetch have to
-		// execute the ISI handler as the next instruction. These blocks cannot be
-		// linked to other blocks.  The block will be recompiled after the ISI is handled
-		// and so we do not link other blocks to it either.
-		if (block_link && !b.memoryException)
+		if (block_link)
 		{
 			for (const auto& e : b.linkData)
 			{

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -42,7 +42,6 @@ struct JitBlock
 	int runCount;  // for profiling.
 
 	bool invalid;
-	bool memoryException;
 
 	struct LinkData
 	{
@@ -121,6 +120,9 @@ class JitBaseBlockCache
 	void LinkBlock(int i);
 	void UnlinkBlock(int i);
 
+	u32* GetICachePtr(u32 addr);
+	void DestroyBlock(int block_num, bool invalidate);
+
 	// Virtual for overloaded
 	virtual void WriteLinkBlock(u8* location, const u8* address) = 0;
 	virtual void WriteDestroyBlock(const u8* location, u32 address) = 0;
@@ -148,17 +150,13 @@ public:
 	std::array<u8, JIT_ICACHEEX_SIZE> iCacheEx;
 	std::array<u8, JIT_ICACHE_SIZE>   iCacheVMEM;
 
-	u32* GetICachePtr(u32 addr);
-
 	// Fast way to get a block. Only works on the first ppc instruction of a block.
 	int GetBlockNumberFromStartAddress(u32 em_address);
 
-	u32 GetOriginalFirstOp(int block_num);
 	CompiledCode GetCompiledCodeFromBlock(int block_num);
 
 	// DOES NOT WORK CORRECTLY WITH INLINING
 	void InvalidateICache(u32 address, const u32 length, bool forced);
-	void DestroyBlock(int block_num, bool invalidate);
 };
 
 // x86 BlockCache

--- a/Source/Core/Core/PowerPC/JitILCommon/IR.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/IR.cpp
@@ -1476,7 +1476,7 @@ static const std::string opcodeNames[] = {
 	"FResult_End", "StorePaired", "StoreSingle", "StoreDouble", "StoreFReg",
 	"FDCmpCR", "CInt16", "CInt32", "SystemCall", "RFIExit",
 	"InterpreterBranch", "IdleBranch", "ShortIdleLoop",
-	"FPExceptionCheckStart", "FPExceptionCheckEnd", "ISIException", "ExtExceptionCheck",
+	"FPExceptionCheckStart", "FPExceptionCheckEnd", "ExtExceptionCheck",
 	"Tramp", "BlockStart", "BlockEnd", "Int3",
 };
 static const unsigned alwaysUsedList[] = {
@@ -1485,7 +1485,7 @@ static const unsigned alwaysUsedList[] = {
 	Store16, Store32, StoreSingle, StoreDouble, StorePaired, StoreFReg, FDCmpCR,
 	BlockStart, BlockEnd, IdleBranch, BranchCond, BranchUncond, ShortIdleLoop,
 	SystemCall, InterpreterBranch, RFIExit, FPExceptionCheck,
-	DSIExceptionCheck, ISIException, ExtExceptionCheck, BreakPointCheck,
+	DSIExceptionCheck, ExtExceptionCheck, BreakPointCheck,
 	Int3, Tramp, Nop
 };
 static const unsigned extra8RegList[] = {

--- a/Source/Core/Core/PowerPC/JitILCommon/IR.h
+++ b/Source/Core/Core/PowerPC/JitILCommon/IR.h
@@ -166,7 +166,7 @@ enum Opcode
 	// used for exception checking, at least until someone
 	// has a better idea of integrating it
 	FPExceptionCheck, DSIExceptionCheck,
-	ISIException, ExtExceptionCheck, BreakPointCheck,
+	ExtExceptionCheck, BreakPointCheck,
 	// "Opcode" representing a register too far away to
 	// reference directly; this is a size optimization
 	Tramp,
@@ -549,11 +549,6 @@ public:
 	InstLoc EmitDSIExceptionCheck(InstLoc pc)
 	{
 		return EmitUOp(DSIExceptionCheck, pc);
-	}
-
-	InstLoc EmitISIException(InstLoc dest)
-	{
-		return EmitUOp(ISIException, dest);
 	}
 
 	InstLoc EmitExtExceptionCheck(InstLoc pc)


### PR DESCRIPTION
When we try to JIT from a block which doesn't exist, don't JIT any code; just update the PPC state to indicate an ISI.  This is a little simpler, and avoids abusing the JIT block cache.

Still needs to be tested.