### PR TITLE
zfreeze

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -64,7 +64,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 38;
+static const u32 STATE_VERSION = 39;
 
 enum
 {

--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -59,7 +59,7 @@ DXGI_FORMAT VarToD3D(VarType t, int size, bool integer)
 
 void D3DVertexFormat::Initialize(const PortableVertexDeclaration &_vtx_decl)
 {
-	vertex_stride = _vtx_decl.stride;
+	vtx_decl = _vtx_decl;
 	memset(m_elems, 0, sizeof(m_elems));
 	const AttributeFormat* format = &_vtx_decl.position;
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -33,6 +33,7 @@
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PixelEngine.h"
+#include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
@@ -231,6 +232,7 @@ Renderer::Renderer(void *&window_handle)
 	s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
 	s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
 	CalculateTargetSize(s_backbuffer_width, s_backbuffer_height);
+	PixelShaderManager::SetEfbScaleChanged();
 
 	SetupDeviceObjects();
 
@@ -945,6 +947,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 		s_last_efb_scale = g_ActiveConfig.iEFBScale;
 		s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
 		CalculateTargetSize(s_backbuffer_width, s_backbuffer_height);
+
+		PixelShaderManager::SetEfbScaleChanged();
 
 		D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
 

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -181,12 +181,10 @@ void VertexManager::vFlush(bool useDstAlpha)
 
 	PrepareDrawBuffers(stride);
 
-	if (!bpmem.genMode.zfreeze && IndexGenerator::GetIndexLen() >= 3)
-	{
+	if (!bpmem.genMode.zfreeze)
 		CalculateZSlope(stride);
-	}
 
-	// if cull mode is CULL_ALL, ignore triangles and quads
+	// If cull mode is CULL_ALL, do not render these triangles
 	if (bpmem.genMode.cullmode == GenMode::CULL_ALL && current_primitive_type == PRIMITIVE_TRIANGLES)
 		return;
 
@@ -202,6 +200,9 @@ void VertexManager::ResetBuffer(u32 stride)
 {
 	s_pCurBufferPointer = s_pBaseBufferPointer;
 	IndexGenerator::Start(GetIndexBuffer());
+
+	if (bpmem.genMode.zfreeze)
+		PixelShaderManager::SetZSlope(ZSlope.dfdx, ZSlope.dfdy, ZSlope.f0);
 }
 
 }  // namespace

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -186,6 +186,10 @@ void VertexManager::vFlush(bool useDstAlpha)
 		CalculateZSlope(stride);
 	}
 
+	// if cull mode is CULL_ALL, ignore triangles and quads
+	if (bpmem.genMode.cullmode == GenMode::CULL_ALL && current_primitive_type == PRIMITIVE_TRIANGLES)
+		return;
+
 	VertexLoaderManager::GetCurrentVertexFormat()->SetupVertexPointers();
 	g_renderer->ApplyState(useDstAlpha);
 

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -181,13 +181,6 @@ void VertexManager::vFlush(bool useDstAlpha)
 
 	PrepareDrawBuffers(stride);
 
-	if (!bpmem.genMode.zfreeze)
-		CalculateZSlope(stride);
-
-	// If cull mode is CULL_ALL, do not render these triangles
-	if (bpmem.genMode.cullmode == GenMode::CULL_ALL && current_primitive_type == PRIMITIVE_TRIANGLES)
-		return;
-
 	VertexLoaderManager::GetCurrentVertexFormat()->SetupVertexPointers();
 	g_renderer->ApplyState(useDstAlpha);
 
@@ -200,9 +193,6 @@ void VertexManager::ResetBuffer(u32 stride)
 {
 	s_pCurBufferPointer = s_pBaseBufferPointer;
 	IndexGenerator::Start(GetIndexBuffer());
-
-	if (bpmem.genMode.zfreeze)
-		PixelShaderManager::SetZSlope(ZSlope.dfdx, ZSlope.dfdy, ZSlope.f0);
 }
 
 }  // namespace

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -178,49 +178,12 @@ void VertexManager::vFlush(bool useDstAlpha)
 	}
 
 	u32 stride = VertexLoaderManager::GetCurrentVertexFormat()->GetVertexStride();
-	u32 indices = IndexGenerator::GetIndexLen();
 
 	PrepareDrawBuffers(stride);
 
-	if (!bpmem.genMode.zfreeze && indices >= 3)
+	if (!bpmem.genMode.zfreeze && IndexGenerator::GetIndexLen() >= 3)
 	{
-		float vtx[9];
-		float out[12];
-
-		// Lookup vertices of the last rendered triangle and software-transform them
-		// This allows us to determine the depth slope, which will be used if zfreeze
-		// is enabled in the following flush.
-		for (unsigned int i = 0; i < 3; ++i)
-		{
-			const int base_index = GetIndexBuffer()[indices - 3 + i];
-			u8* vtx_ptr = &((u8*)GetVertexBuffer())[base_index * stride];
-			vtx[0 + i * 3] = ((float*)vtx_ptr)[0];
-			vtx[1 + i * 3] = ((float*)vtx_ptr)[1];
-			vtx[2 + i * 3] = ((float*)vtx_ptr)[2];
-
-			VertexShaderManager::TransformToClipSpace(&vtx[i * 3], &out[i * 4]);
-
-			// viewport offset ignored because we only look at coordinate differences.
-			out[0 + i * 4] = out[0 + i * 4] / out[3 + i * 4] * xfmem.viewport.wd;
-			out[1 + i * 4] = out[1 + i * 4] / out[3 + i * 4] * xfmem.viewport.ht;
-			out[2 + i * 4] = out[2 + i * 4] / out[3 + i * 4] * xfmem.viewport.zRange + xfmem.viewport.farZ;
-		}
-		float dx31 = out[8] - out[0];
-		float dx12 = out[0] - out[4];
-		float dy12 = out[1] - out[5];
-		float dy31 = out[9] - out[1];
-
-		float DF31 = out[10] - out[2];
-		float DF21 = out[6] - out[2];
-		float a = DF31 * -dy12 - DF21 * dy31;
-		float b = dx31 * DF21 + dx12 * DF31;
-		float c = -dx12 * dy31 - dx31 * -dy12;
-
-		float slope_dfdx = -a / c;
-		float slope_dfdy = -b / c;
-		float slope_f0 = out[2];
-
-		PixelShaderManager::SetZSlopeChanged(slope_dfdx, slope_dfdy, slope_f0);
+		CalculateZSlope(stride);
 	}
 
 	VertexLoaderManager::GetCurrentVertexFormat()->SetupVertexPointers();

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -22,6 +22,7 @@ public:
 protected:
 	virtual void ResetBuffer(u32 stride) override;
 	u16* GetIndexBuffer() { return &LocalIBuffer[0]; }
+	u8* GetVertexBuffer() { return &LocalVBuffer[0]; }
 
 private:
 

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -22,7 +22,6 @@ public:
 protected:
 	virtual void ResetBuffer(u32 stride) override;
 	u16* GetIndexBuffer() { return &LocalIBuffer[0]; }
-	u8* GetVertexBuffer() { return &LocalVBuffer[0]; }
 
 private:
 

--- a/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
@@ -58,7 +58,7 @@ static void SetPointer(u32 attrib, u32 stride, const AttributeFormat &format)
 void GLVertexFormat::Initialize(const PortableVertexDeclaration &_vtx_decl)
 {
 	this->vtx_decl = _vtx_decl;
-	vertex_stride = vtx_decl.stride;
+	u32 vertex_stride = _vtx_decl.stride;
 
 	// We will not allow vertex components causing uneven strides.
 	if (vertex_stride & 3)

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -43,6 +43,7 @@
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PixelEngine.h"
+#include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderGen.h"
@@ -617,6 +618,8 @@ Renderer::Renderer()
 
 	s_last_efb_scale = g_ActiveConfig.iEFBScale;
 	CalculateTargetSize(s_backbuffer_width, s_backbuffer_height);
+
+	PixelShaderManager::SetEfbScaleChanged();
 
 	// Because of the fixed framebuffer size we need to disable the resolution
 	// options while running
@@ -1681,6 +1684,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 			delete g_framebuffer_manager;
 			g_framebuffer_manager = new FramebufferManager(s_target_width, s_target_height,
 				s_MSAASamples);
+
+			PixelShaderManager::SetEfbScaleChanged();
 		}
 	}
 

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -42,6 +42,13 @@ static size_t s_index_offset;
 
 VertexManager::VertexManager()
 {
+	LocalVBuffer.resize(MAXVBUFFERSIZE);
+
+	s_pCurBufferPointer = s_pBaseBufferPointer = &LocalVBuffer[0];
+	s_pEndBufferPointer = s_pBaseBufferPointer + LocalVBuffer.size();
+
+	LocalIBuffer.resize(MAXIBUFFERSIZE);
+
 	CreateDeviceObjects();
 }
 
@@ -131,6 +138,7 @@ void VertexManager::vFlush(bool useDstAlpha)
 {
 	GLVertexFormat *nativeVertexFmt = (GLVertexFormat*)VertexLoaderManager::GetCurrentVertexFormat();
 	u32 stride  = nativeVertexFmt->GetVertexStride();
+	u32 indices = IndexGenerator::GetIndexLen();
 
 	if (m_last_vao != nativeVertexFmt->VAO)
 	{
@@ -139,6 +147,47 @@ void VertexManager::vFlush(bool useDstAlpha)
 	}
 
 	PrepareDrawBuffers(stride);
+
+	if (!bpmem.genMode.zfreeze && indices >= 3)
+	{
+		float vtx[9];
+		float out[12];
+
+		// Lookup vertices of the last rendered triangle and software-transform them
+		// This allows us to determine the depth slope, which will be used if zfreeze
+		// is enabled in the following flush.
+		for (unsigned int i = 0; i < 3; ++i)
+		{
+			const int base_index = GetIndexBuffer()[indices - 3 + i];
+			u8* vtx_ptr = &((u8*)GetVertexBuffer())[base_index * stride];
+			vtx[0 + i * 3] = ((float*)vtx_ptr)[0];
+			vtx[1 + i * 3] = ((float*)vtx_ptr)[1];
+			vtx[2 + i * 3] = ((float*)vtx_ptr)[2];
+
+			VertexShaderManager::TransformToClipSpace(&vtx[i * 3], &out[i * 4]);
+
+			// viewport offset ignored because we only look at coordinate differences.
+			out[0 + i * 4] = out[0 + i * 4] / out[3 + i * 4] * xfmem.viewport.wd;
+			out[1 + i * 4] = out[1 + i * 4] / out[3 + i * 4] * xfmem.viewport.ht;
+			out[2 + i * 4] = out[2 + i * 4] / out[3 + i * 4] * xfmem.viewport.zRange + xfmem.viewport.farZ;
+		}
+		float dx31 = out[8] - out[0];
+		float dx12 = out[0] - out[4];
+		float dy12 = out[1] - out[5];
+		float dy31 = out[9] - out[1];
+
+		float DF31 = out[10] - out[2];
+		float DF21 = out[6] - out[2];
+		float a = DF31 * -dy12 - DF21 * dy31;
+		float b = dx31 * DF21 + dx12 * DF31;
+		float c = -dx12 * dy31 - dx31 * -dy12;
+
+		float slope_dfdx = -a / c;
+		float slope_dfdy = -b / c;
+		float slope_f0 = out[2];
+
+		PixelShaderManager::SetZSlopeChanged(slope_dfdx, slope_dfdy, slope_f0);
+	}
 
 	// Makes sure we can actually do Dual source blending
 	bool dualSourcePossible = g_ActiveConfig.backend_info.bSupportsDualSourceBlend;

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -145,6 +145,10 @@ void VertexManager::vFlush(bool useDstAlpha)
 		CalculateZSlope(stride);
 	}
 
+	// if cull mode is CULL_ALL, ignore triangles and quads
+	if (bpmem.genMode.cullmode == GenMode::CULL_ALL && current_primitive_type == PRIMITIVE_TRIANGLES)
+		return;
+
 	// Makes sure we can actually do Dual source blending
 	bool dualSourcePossible = g_ActiveConfig.backend_info.bSupportsDualSourceBlend;
 

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -42,13 +42,6 @@ static size_t s_index_offset;
 
 VertexManager::VertexManager()
 {
-	LocalVBuffer.resize(MAXVBUFFERSIZE);
-
-	s_pCurBufferPointer = s_pBaseBufferPointer = &LocalVBuffer[0];
-	s_pEndBufferPointer = s_pBaseBufferPointer + LocalVBuffer.size();
-
-	LocalIBuffer.resize(MAXIBUFFERSIZE);
-
 	CreateDeviceObjects();
 }
 
@@ -138,7 +131,6 @@ void VertexManager::vFlush(bool useDstAlpha)
 {
 	GLVertexFormat *nativeVertexFmt = (GLVertexFormat*)VertexLoaderManager::GetCurrentVertexFormat();
 	u32 stride  = nativeVertexFmt->GetVertexStride();
-	u32 indices = IndexGenerator::GetIndexLen();
 
 	if (m_last_vao != nativeVertexFmt->VAO)
 	{
@@ -148,45 +140,9 @@ void VertexManager::vFlush(bool useDstAlpha)
 
 	PrepareDrawBuffers(stride);
 
-	if (!bpmem.genMode.zfreeze && indices >= 3)
+	if (!bpmem.genMode.zfreeze && IndexGenerator::GetIndexLen() >= 3)
 	{
-		float vtx[9];
-		float out[12];
-
-		// Lookup vertices of the last rendered triangle and software-transform them
-		// This allows us to determine the depth slope, which will be used if zfreeze
-		// is enabled in the following flush.
-		for (unsigned int i = 0; i < 3; ++i)
-		{
-			const int base_index = GetIndexBuffer()[indices - 3 + i];
-			u8* vtx_ptr = &((u8*)GetVertexBuffer())[base_index * stride];
-			vtx[0 + i * 3] = ((float*)vtx_ptr)[0];
-			vtx[1 + i * 3] = ((float*)vtx_ptr)[1];
-			vtx[2 + i * 3] = ((float*)vtx_ptr)[2];
-
-			VertexShaderManager::TransformToClipSpace(&vtx[i * 3], &out[i * 4]);
-
-			// viewport offset ignored because we only look at coordinate differences.
-			out[0 + i * 4] = out[0 + i * 4] / out[3 + i * 4] * xfmem.viewport.wd;
-			out[1 + i * 4] = out[1 + i * 4] / out[3 + i * 4] * xfmem.viewport.ht;
-			out[2 + i * 4] = out[2 + i * 4] / out[3 + i * 4] * xfmem.viewport.zRange + xfmem.viewport.farZ;
-		}
-		float dx31 = out[8] - out[0];
-		float dx12 = out[0] - out[4];
-		float dy12 = out[1] - out[5];
-		float dy31 = out[9] - out[1];
-
-		float DF31 = out[10] - out[2];
-		float DF21 = out[6] - out[2];
-		float a = DF31 * -dy12 - DF21 * dy31;
-		float b = dx31 * DF21 + dx12 * DF31;
-		float c = -dx12 * dy31 - dx31 * -dy12;
-
-		float slope_dfdx = -a / c;
-		float slope_dfdy = -b / c;
-		float slope_f0 = out[2];
-
-		PixelShaderManager::SetZSlopeChanged(slope_dfdx, slope_dfdy, slope_f0);
+		CalculateZSlope(stride);
 	}
 
 	// Makes sure we can actually do Dual source blending

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -89,9 +89,6 @@ void VertexManager::ResetBuffer(u32 stride)
 	buffer = s_indexBuffer->Map(MAXIBUFFERSIZE * sizeof(u16));
 	IndexGenerator::Start((u16*)buffer.first);
 	s_index_offset = buffer.second;
-
-	if (bpmem.genMode.zfreeze)
-		PixelShaderManager::SetZSlope(ZSlope.dfdx, ZSlope.dfdy, ZSlope.f0);
 }
 
 void VertexManager::Draw(u32 stride)
@@ -142,13 +139,6 @@ void VertexManager::vFlush(bool useDstAlpha)
 	}
 
 	PrepareDrawBuffers(stride);
-
-	if (!bpmem.genMode.zfreeze)
-		CalculateZSlope(stride);
-
-	// If cull mode is CULL_ALL, do not render these triangles
-	if (bpmem.genMode.cullmode == GenMode::CULL_ALL && current_primitive_type == PRIMITIVE_TRIANGLES)
-		return;
 
 	// Makes sure we can actually do Dual source blending
 	bool dualSourcePossible = g_ActiveConfig.backend_info.bSupportsDualSourceBlend;

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -89,6 +89,9 @@ void VertexManager::ResetBuffer(u32 stride)
 	buffer = s_indexBuffer->Map(MAXIBUFFERSIZE * sizeof(u16));
 	IndexGenerator::Start((u16*)buffer.first);
 	s_index_offset = buffer.second;
+
+	if (bpmem.genMode.zfreeze)
+		PixelShaderManager::SetZSlope(ZSlope.dfdx, ZSlope.dfdy, ZSlope.f0);
 }
 
 void VertexManager::Draw(u32 stride)
@@ -140,12 +143,10 @@ void VertexManager::vFlush(bool useDstAlpha)
 
 	PrepareDrawBuffers(stride);
 
-	if (!bpmem.genMode.zfreeze && IndexGenerator::GetIndexLen() >= 3)
-	{
+	if (!bpmem.genMode.zfreeze)
 		CalculateZSlope(stride);
-	}
 
-	// if cull mode is CULL_ALL, ignore triangles and quads
+	// If cull mode is CULL_ALL, do not render these triangles
 	if (bpmem.genMode.cullmode == GenMode::CULL_ALL && current_primitive_type == PRIMITIVE_TRIANGLES)
 		return;
 

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -42,15 +42,11 @@ public:
 	GLuint m_last_vao;
 protected:
 	virtual void ResetBuffer(u32 stride) override;
-	u16* GetIndexBuffer() { return &LocalIBuffer[0]; }
-	u8* GetVertexBuffer() { return &LocalVBuffer[0]; }
+
 private:
 	void Draw(u32 stride);
 	void vFlush(bool useDstAlpha) override;
 	void PrepareDrawBuffers(u32 stride);
-
-	std::vector<u8> LocalVBuffer;
-	std::vector<u16> LocalIBuffer;
 };
 
 }

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -42,10 +42,15 @@ public:
 	GLuint m_last_vao;
 protected:
 	virtual void ResetBuffer(u32 stride) override;
+	u16* GetIndexBuffer() { return &LocalIBuffer[0]; }
+	u8* GetVertexBuffer() { return &LocalVBuffer[0]; }
 private:
 	void Draw(u32 stride);
 	void vFlush(bool useDstAlpha) override;
 	void PrepareDrawBuffers(u32 stride);
+
+	std::vector<u8> LocalVBuffer;
+	std::vector<u16> LocalIBuffer;
 };
 
 }

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -13,8 +13,6 @@ namespace OGL
 {
 	class GLVertexFormat : public NativeVertexFormat
 	{
-		PortableVertexDeclaration vtx_decl;
-
 	public:
 		GLVertexFormat();
 		~GLVertexFormat();

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -45,6 +45,10 @@ private:
 	void Draw(u32 stride);
 	void vFlush(bool useDstAlpha) override;
 	void PrepareDrawBuffers(u32 stride);
+
+	// Alternative buffers in CPU memory for primatives we are going to discard.
+	std::vector<u8> CpuVBuffer;
+	std::vector<u16> CpuIBuffer;
 };
 
 }

--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -23,6 +23,7 @@ struct PixelShaderConstants
 	int4 fogcolor;
 	int4 fogi;
 	float4 fogf[2];
+	float4 zslope;
 };
 
 struct VertexShaderConstants

--- a/Source/Core/VideoCommon/ConstantManager.h
+++ b/Source/Core/VideoCommon/ConstantManager.h
@@ -24,6 +24,7 @@ struct PixelShaderConstants
 	int4 fogi;
 	float4 fogf[2];
 	float4 zslope;
+	float4 efbscale;
 };
 
 struct VertexShaderConstants

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -26,7 +26,11 @@ void GeometryShaderManager::Init()
 {
 	memset(&constants, 0, sizeof(constants));
 
-	Dirty();
+	// Init any intial constants which aren't zero when bpmem is zero.
+	SetViewportChanged();
+	SetProjectionChanged();
+
+	dirty = true;
 }
 
 void GeometryShaderManager::Shutdown()
@@ -35,12 +39,9 @@ void GeometryShaderManager::Shutdown()
 
 void GeometryShaderManager::Dirty()
 {
-	SetViewportChanged();
-	SetProjectionChanged();
-	SetLinePtWidthChanged();
-
-	for (int i = 0; i < 8; i++)
-		SetTexCoordChanged(i);
+	// This function is called after a savestate is loaded.
+	// Any constants that can changed based on settings should be re-calculated
+	s_projection_changed = true;
 
 	dirty = true;
 }
@@ -110,9 +111,14 @@ void GeometryShaderManager::SetTexCoordChanged(u8 texmapid)
 
 void GeometryShaderManager::DoState(PointerWrap &p)
 {
+	p.Do(s_projection_changed);
+	p.Do(s_viewport_changed);
+
+	p.Do(constants);
+
 	if (p.GetMode() == PointerWrap::MODE_READ)
 	{
-		// Reload current state from global GPU state
+		// Fixup the current state from global GPU state
 		// NOTE: This requires that all GPU memory has been loaded already.
 		Dirty();
 	}

--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -109,7 +109,8 @@ public:
 	virtual void Initialize(const PortableVertexDeclaration &vtx_decl) = 0;
 	virtual void SetupVertexPointers() = 0;
 
-	u32 GetVertexStride() const { return vertex_stride; }
+	u32 GetVertexStride() const { return vtx_decl.stride; }
+	PortableVertexDeclaration GetVertexDeclaration() const { return vtx_decl; }
 
 	// TODO: move this under private:
 	u32 m_components;  // VB_HAS_X. Bitmask telling what vertex components are present.
@@ -118,5 +119,5 @@ protected:
 	// Let subclasses construct.
 	NativeVertexFormat() {}
 
-	u32 vertex_stride;
+	PortableVertexDeclaration vtx_decl;
 };

--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -110,7 +110,7 @@ public:
 	virtual void SetupVertexPointers() = 0;
 
 	u32 GetVertexStride() const { return vtx_decl.stride; }
-	PortableVertexDeclaration GetVertexDeclaration() const { return vtx_decl; }
+	const PortableVertexDeclaration& GetVertexDeclaration() const { return vtx_decl; }
 
 	// TODO: move this under private:
 	u32 m_components;  // VB_HAS_X. Bitmask telling what vertex components are present.

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -271,7 +271,11 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	GenerateVSOutputMembers<T>(out, ApiType);
 	out.Write("};\n");
 
-	const bool forced_early_z = g_ActiveConfig.backend_info.bSupportsEarlyZ && bpmem.UseEarlyDepthTest() && (g_ActiveConfig.bFastDepthCalc || bpmem.alpha_test.TestResult() == AlphaTest::UNDETERMINED);
+	const bool forced_early_z = g_ActiveConfig.backend_info.bSupportsEarlyZ && bpmem.UseEarlyDepthTest()
+								&& (g_ActiveConfig.bFastDepthCalc || bpmem.alpha_test.TestResult() == AlphaTest::UNDETERMINED)
+								// We can't allow early_ztest for zfreeze because a reference poly is used
+								// to control the depth and we need a depth test after the alpha test.
+								&& !bpmem.genMode.zfreeze;
 	const bool per_pixel_depth = (bpmem.ztex2.op != ZTEXTURE_DISABLE && bpmem.UseLateDepthTest()) || (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !forced_early_z) || bpmem.genMode.zfreeze;
 
 	if (forced_early_z)
@@ -365,7 +369,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 		out.Write("void main(\n");
 		out.Write("  out float4 ocol0 : SV_Target0,%s%s\n  in float4 rawpos : SV_Position,\n",
 			dstAlphaMode == DSTALPHA_DUAL_SOURCE_BLEND ? "\n  out float4 ocol1 : SV_Target1," : "",
-			per_pixel_depth ? "\n  out float depth : SV_Depth," : "");
+			(per_pixel_depth && bpmem.zmode.testenable) ? "\n  out float depth : SV_Depth," : "");
 
 		out.Write("  in centroid float4 colors_0 : COLOR0,\n");
 		out.Write("  in centroid float4 colors_1 : COLOR1\n");
@@ -1023,7 +1027,11 @@ static inline void WriteAlphaTest(T& out, pixel_shader_uid_data* uid_data, API_T
 	// Tests seem to have proven that writing depth even when the alpha test fails is more
 	// important that a reliable alpha test, so we just force the alpha test to always succeed.
 	// At least this seems to be less buggy.
-	uid_data->alpha_test_use_zcomploc_hack = bpmem.UseEarlyDepthTest() && bpmem.zmode.updateenable && !g_ActiveConfig.backend_info.bSupportsEarlyZ;
+	uid_data->alpha_test_use_zcomploc_hack = bpmem.UseEarlyDepthTest()
+											 && bpmem.zmode.updateenable
+											 && !g_ActiveConfig.backend_info.bSupportsEarlyZ
+											 && !bpmem.genMode.zfreeze; // Might not be neccessary
+
 	if (!uid_data->alpha_test_use_zcomploc_hack)
 	{
 		out.Write("\t\tdiscard;\n");
@@ -1114,10 +1122,10 @@ static inline void WritePerPixelDepth(T& out, pixel_shader_uid_data* uid_data, A
 		out.Write("\tfloat2 screenpos = rawpos.xy * " I_EFBSCALE".xy;\n");
 
 		// Opengl has reversed vertical screenspace coordiantes
-		if(ApiType == API_OPENGL)
+		if (ApiType == API_OPENGL)
 			out.Write("\tscreenpos.y = %i - screenpos.y - 1;\n", EFB_HEIGHT);
 
-		out.Write("\tdepth = float(" I_ZSLOPE".z + " I_ZSLOPE".x * screenpos.x + " I_ZSLOPE".y * screenpos.y) / float(0xffffff);\n");
+		out.Write("\tdepth = float(" I_ZSLOPE".z + " I_ZSLOPE".x * screenpos.x + " I_ZSLOPE".y * screenpos.y) / float(0xFFFFFF);\n");
 	}
 	else
 	{

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -228,6 +228,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 		"\tint4 " I_FOGCOLOR";\n"
 		"\tint4 " I_FOGI";\n"
 		"\tfloat4 " I_FOGF"[2];\n"
+		"\tfloat4 " I_ZSLOPE";\n"
 		"};\n");
 
 	if (g_ActiveConfig.bEnablePixelLighting)
@@ -269,7 +270,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	out.Write("};\n");
 
 	const bool forced_early_z = g_ActiveConfig.backend_info.bSupportsEarlyZ && bpmem.UseEarlyDepthTest() && (g_ActiveConfig.bFastDepthCalc || bpmem.alpha_test.TestResult() == AlphaTest::UNDETERMINED);
-	const bool per_pixel_depth = (bpmem.ztex2.op != ZTEXTURE_DISABLE && bpmem.UseLateDepthTest()) || (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !forced_early_z);
+	const bool per_pixel_depth = (bpmem.ztex2.op != ZTEXTURE_DISABLE && bpmem.UseLateDepthTest()) || (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !forced_early_z) || bpmem.genMode.zfreeze;
 
 	if (forced_early_z)
 	{
@@ -538,10 +539,20 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	uid_data->fast_depth_calc = g_ActiveConfig.bFastDepthCalc;
 	uid_data->early_ztest = bpmem.UseEarlyDepthTest();
 	uid_data->fog_fsel = bpmem.fog.c_proj_fsel.fsel;
+	uid_data->zfreeze = bpmem.genMode.zfreeze;
 
 	// Note: z-textures are not written to depth buffer if early depth test is used
 	if (per_pixel_depth && bpmem.UseEarlyDepthTest())
-		out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+	{
+		if (bpmem.genMode.zfreeze)
+		{
+			out.Write("\tdepth = " I_ZSLOPE".z + " I_ZSLOPE".x * (clipPos.x / clipPos.w) + " I_ZSLOPE".y * (clipPos.y / clipPos.w);\n");
+		}
+		else
+		{
+			out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+		}
+	}
 
 	// Note: depth texture output is only written to depth buffer if late depth test is used
 	// theoretical final depth value is used for fog calculation, though, so we have to emulate ztextures anyway
@@ -555,7 +566,16 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	}
 
 	if (per_pixel_depth && bpmem.UseLateDepthTest())
-		out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+	{
+		if (bpmem.genMode.zfreeze)
+		{
+			out.Write("\tdepth = " I_ZSLOPE".z + " I_ZSLOPE".x * (clipPos.x / clipPos.w) + " I_ZSLOPE".y * (clipPos.y / clipPos.w);\n");
+		}
+		else
+		{
+			out.Write("\tdepth = float(zCoord) / float(0xFFFFFF);\n");
+		}
+	}
 
 	if (dstAlphaMode == DSTALPHA_ALPHA_PASS)
 	{

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -546,7 +546,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	{
 		if (bpmem.genMode.zfreeze)
 		{
-			out.Write("\tdepth = " I_ZSLOPE".z + " I_ZSLOPE".x * (clipPos.x / clipPos.w) + " I_ZSLOPE".y * (clipPos.y / clipPos.w);\n");
+			out.Write("\tdepth = float(" I_ZSLOPE".z + " I_ZSLOPE".x * rawpos.x + " I_ZSLOPE".y * rawpos.y) / float(0xffffff);\n");
 		}
 		else
 		{
@@ -569,7 +569,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	{
 		if (bpmem.genMode.zfreeze)
 		{
-			out.Write("\tdepth = " I_ZSLOPE".z + " I_ZSLOPE".x * (clipPos.x / clipPos.w) + " I_ZSLOPE".y * (clipPos.y / clipPos.w);\n");
+			out.Write("\tdepth = float(" I_ZSLOPE".z + " I_ZSLOPE".x * rawpos.x + " I_ZSLOPE".y * rawpos.y) / float(0xffffff);\n");
 		}
 		else
 		{

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -64,7 +64,10 @@ struct pixel_shader_uid_data
 	u32 forced_early_z : 1;
 	u32 early_ztest : 1;
 	u32 bounding_box : 1;
+
+	// TODO: 31 bits of padding is a waste. Can we free up some bits elseware?
 	u32 zfreeze : 1;
+	u32 pad : 31;
 
 	u32 texMtxInfo_n_projection : 8; // 8x1 bit
 	u32 tevindref_bi0 : 3;

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -20,8 +20,8 @@
 #define C_INDTEXMTX     (C_INDTEXSCALE + 2) //21
 #define C_FOGCOLOR      (C_INDTEXMTX + 6)   //27
 #define C_FOGI          (C_FOGCOLOR + 1)    //28
-#define C_FOGF          (C_FOGI + 1)        //29
-#define C_ZSLOPE        (C_FOGF + 1)        //30
+#define C_FOGF          (C_FOGI + 2)        //29
+#define C_ZSLOPE        (C_FOGF + 1)        //31
 
 #define C_PENVCONST_END (C_ZSLOPE + 2)
 

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -20,8 +20,8 @@
 #define C_INDTEXMTX     (C_INDTEXSCALE + 2) //21
 #define C_FOGCOLOR      (C_INDTEXMTX + 6)   //27
 #define C_FOGI          (C_FOGCOLOR + 1)    //28
-#define C_FOGF          (C_FOGI + 2)        //29
-#define C_ZSLOPE        (C_FOGF + 1)        //31
+#define C_FOGF          (C_FOGI + 1)        //29
+#define C_ZSLOPE        (C_FOGF + 2)        //31
 #define C_EFBSCALE      (C_ZSLOPE + 1)      //32
 
 #define C_PENVCONST_END (C_EFBSCALE + 1)

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -21,8 +21,9 @@
 #define C_FOGCOLOR      (C_INDTEXMTX + 6)   //27
 #define C_FOGI          (C_FOGCOLOR + 1)    //28
 #define C_FOGF          (C_FOGI + 1)        //29
+#define C_ZSLOPE        (C_FOGF + 1)        //30
 
-#define C_PENVCONST_END (C_FOGF + 2)
+#define C_PENVCONST_END (C_ZSLOPE + 2)
 
 // Different ways to achieve rendering with destination alpha
 enum DSTALPHA_MODE
@@ -62,6 +63,7 @@ struct pixel_shader_uid_data
 	u32 forced_early_z : 1;
 	u32 early_ztest : 1;
 	u32 bounding_box : 1;
+	u32 zfreeze : 1;
 
 	u32 texMtxInfo_n_projection : 8; // 8x1 bit
 	u32 tevindref_bi0 : 3;

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -22,8 +22,9 @@
 #define C_FOGI          (C_FOGCOLOR + 1)    //28
 #define C_FOGF          (C_FOGI + 2)        //29
 #define C_ZSLOPE        (C_FOGF + 1)        //31
+#define C_EFBSCALE      (C_ZSLOPE + 1)      //32
 
-#define C_PENVCONST_END (C_ZSLOPE + 2)
+#define C_PENVCONST_END (C_EFBSCALE + 1)
 
 // Different ways to achieve rendering with destination alpha
 enum DSTALPHA_MODE

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -14,10 +14,6 @@
 
 bool PixelShaderManager::s_bFogRangeAdjustChanged;
 bool PixelShaderManager::s_bViewPortChanged;
-bool PixelShaderManager::s_bEFBScaleChanged;
-
-std::array<int4,4> PixelShaderManager::s_tev_color;
-std::array<int4,4> PixelShaderManager::s_tev_konst_color;
 
 PixelShaderConstants PixelShaderManager::constants;
 bool PixelShaderManager::dirty;
@@ -25,34 +21,12 @@ bool PixelShaderManager::dirty;
 void PixelShaderManager::Init()
 {
 	memset(&constants, 0, sizeof(constants));
-	memset(s_tev_color.data(), 0, sizeof(s_tev_color));
-	memset(s_tev_konst_color.data(), 0, sizeof(s_tev_konst_color));
 
-	Dirty();
-}
-
-void PixelShaderManager::Dirty()
-{
+	// Init any intial constants which aren't zero when bpmem is zero.
 	s_bFogRangeAdjustChanged = true;
-	s_bViewPortChanged = true;
+	s_bViewPortChanged = false;
 
-	for (unsigned index = 0; index < s_tev_color.size(); ++index)
-	{
-		for (int comp = 0; comp < 4; ++comp)
-		{
-			SetTevColor(index, comp, s_tev_color[index][comp]);
-			SetTevKonstColor(index, comp, s_tev_konst_color[index][comp]);
-		}
-	}
-
-	SetAlpha();
-	SetDestAlpha();
-	SetZTextureBias();
-	SetViewportChanged();
 	SetEfbScaleChanged();
-	SetZSlope(0, 0, (float)0xFFFFFF);
-	SetIndTexScaleChanged(false);
-	SetIndTexScaleChanged(true);
 	SetIndMatrixChanged(0);
 	SetIndMatrixChanged(1);
 	SetIndMatrixChanged(2);
@@ -65,8 +39,20 @@ void PixelShaderManager::Dirty()
 	SetTexCoordChanged(5);
 	SetTexCoordChanged(6);
 	SetTexCoordChanged(7);
-	SetFogColorChanged();
+
+	dirty = true;
+}
+
+void PixelShaderManager::Dirty()
+{
+	// This function is called after a savestate is loaded.
+	// Any constants that can changed based on settings should be re-calculated
+	s_bFogRangeAdjustChanged = true;
+
+	SetEfbScaleChanged();
 	SetFogParamChanged();
+
+	dirty = true;
 }
 
 void PixelShaderManager::Shutdown()
@@ -115,20 +101,12 @@ void PixelShaderManager::SetConstants()
 		dirty = true;
 		s_bViewPortChanged = false;
 	}
-
-	if (s_bEFBScaleChanged)
-	{
-		constants.efbscale[0] = 1.0f / float(Renderer::EFBToScaledXf(1));
-		constants.efbscale[1] = 1.0f / float(Renderer::EFBToScaledYf(1));
-		dirty = true;
-		s_bEFBScaleChanged = false;
-	}
 }
 
 void PixelShaderManager::SetTevColor(int index, int component, s32 value)
 {
 	auto& c = constants.colors[index];
-	c[component] = s_tev_color[index][component] = value;
+	c[component] = value;
 	dirty = true;
 
 	PRIM_LOG("tev color%d: %d %d %d %d\n", index, c[0], c[1], c[2], c[3]);
@@ -137,7 +115,7 @@ void PixelShaderManager::SetTevColor(int index, int component, s32 value)
 void PixelShaderManager::SetTevKonstColor(int index, int component, s32 value)
 {
 	auto& c = constants.kcolors[index];
-	c[component] = s_tev_konst_color[index][component] = value;
+	c[component] = value;
 	dirty = true;
 
 	PRIM_LOG("tev konst color%d: %d %d %d %d\n", index, c[0], c[1], c[2], c[3]);
@@ -181,8 +159,9 @@ void PixelShaderManager::SetViewportChanged()
 
 void PixelShaderManager::SetEfbScaleChanged()
 {
-	s_bEFBScaleChanged = true;
-	s_bViewPortChanged = true;
+	constants.efbscale[0] = 1.0f / float(Renderer::EFBToScaledXf(1));
+	constants.efbscale[1] = 1.0f / float(Renderer::EFBToScaledYf(1));
+	dirty = true;
 }
 
 void PixelShaderManager::SetZSlope(float dfdx, float dfdy, float f0)
@@ -190,7 +169,6 @@ void PixelShaderManager::SetZSlope(float dfdx, float dfdy, float f0)
 	constants.zslope[0] = dfdx;
 	constants.zslope[1] = dfdy;
 	constants.zslope[2] = f0;
-	constants.zslope[3] = 0;
 	dirty = true;
 }
 
@@ -304,12 +282,14 @@ void PixelShaderManager::SetFogRangeAdjustChanged()
 
 void PixelShaderManager::DoState(PointerWrap &p)
 {
-	p.DoArray(s_tev_color);
-	p.DoArray(s_tev_konst_color);
+	p.Do(s_bFogRangeAdjustChanged);
+	p.Do(s_bViewPortChanged);
+
+	p.Do(constants);
 
 	if (p.GetMode() == PointerWrap::MODE_READ)
 	{
-		// Reload current state from global GPU state
+		// Fixup the current state from global GPU state
 		// NOTE: This requires that all GPU memory has been loaded already.
 		Dirty();
 	}

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -50,7 +50,7 @@ void PixelShaderManager::Dirty()
 	SetZTextureBias();
 	SetViewportChanged();
 	SetEfbScaleChanged();
-	SetZSlope(0, 0, 1);
+	SetZSlope(0, 0, (float)0xFFFFFF);
 	SetIndTexScaleChanged(false);
 	SetIndTexScaleChanged(true);
 	SetIndMatrixChanged(0);
@@ -116,7 +116,8 @@ void PixelShaderManager::SetConstants()
 		s_bViewPortChanged = false;
 	}
 
-	if (s_bEFBScaleChanged) {
+	if (s_bEFBScaleChanged)
+	{
 		constants.efbscale[0] = 1.0f / float(Renderer::EFBToScaledXf(1));
 		constants.efbscale[1] = 1.0f / float(Renderer::EFBToScaledYf(1));
 		dirty = true;

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -14,8 +14,6 @@
 
 bool PixelShaderManager::s_bFogRangeAdjustChanged;
 bool PixelShaderManager::s_bViewPortChanged;
-bool PixelShaderManager::s_bZSlopeChanged;
-static float zslope[3];
 
 std::array<int4,4> PixelShaderManager::s_tev_color;
 std::array<int4,4> PixelShaderManager::s_tev_konst_color;
@@ -50,7 +48,7 @@ void PixelShaderManager::Dirty()
 	SetDestAlpha();
 	SetZTextureBias();
 	SetViewportChanged();
-	SetZSlopeChanged(0, 0, 1);
+	SetZSlope(0, 0, 1);
 	SetIndTexScaleChanged(false);
 	SetIndTexScaleChanged(true);
 	SetIndMatrixChanged(0);
@@ -115,17 +113,6 @@ void PixelShaderManager::SetConstants()
 		dirty = true;
 		s_bViewPortChanged = false;
 	}
-
-	if (s_bZSlopeChanged)
-	{
-		constants.zslope[0] = zslope[0];
-		constants.zslope[1] = zslope[1];
-		constants.zslope[2] = zslope[2];
-		constants.zslope[3] = 0;
-
-		dirty = true;
-		s_bZSlopeChanged = false;
-	}
 }
 
 void PixelShaderManager::SetTevColor(int index, int component, s32 value)
@@ -182,12 +169,13 @@ void PixelShaderManager::SetViewportChanged()
 	s_bFogRangeAdjustChanged = true; // TODO: Shouldn't be necessary with an accurate fog range adjust implementation
 }
 
-void PixelShaderManager::SetZSlopeChanged(float dfdx, float dfdy, float f0)
+void PixelShaderManager::SetZSlope(float dfdx, float dfdy, float f0)
 {
-	zslope[0] = dfdx;
-	zslope[1] = dfdy;
-	zslope[2] = f0;
-	s_bZSlopeChanged = true;
+	constants.zslope[0] = dfdx;
+	constants.zslope[1] = dfdy;
+	constants.zslope[2] = f0;
+	constants.zslope[3] = 0;
+	dirty = true;
 }
 
 void PixelShaderManager::SetIndTexScaleChanged(bool high)

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -14,6 +14,8 @@
 
 bool PixelShaderManager::s_bFogRangeAdjustChanged;
 bool PixelShaderManager::s_bViewPortChanged;
+bool PixelShaderManager::s_bZSlopeChanged;
+static float zslope[3];
 
 std::array<int4,4> PixelShaderManager::s_tev_color;
 std::array<int4,4> PixelShaderManager::s_tev_konst_color;
@@ -48,6 +50,7 @@ void PixelShaderManager::Dirty()
 	SetDestAlpha();
 	SetZTextureBias();
 	SetViewportChanged();
+	SetZSlopeChanged(0, 0, 1);
 	SetIndTexScaleChanged(false);
 	SetIndTexScaleChanged(true);
 	SetIndMatrixChanged(0);
@@ -112,6 +115,17 @@ void PixelShaderManager::SetConstants()
 		dirty = true;
 		s_bViewPortChanged = false;
 	}
+
+	if (s_bZSlopeChanged)
+	{
+		constants.zslope[0] = zslope[0];
+		constants.zslope[1] = zslope[1];
+		constants.zslope[2] = zslope[2];
+		constants.zslope[3] = 0;
+
+		dirty = true;
+		s_bZSlopeChanged = false;
+	}
 }
 
 void PixelShaderManager::SetTevColor(int index, int component, s32 value)
@@ -166,6 +180,14 @@ void PixelShaderManager::SetViewportChanged()
 {
 	s_bViewPortChanged = true;
 	s_bFogRangeAdjustChanged = true; // TODO: Shouldn't be necessary with an accurate fog range adjust implementation
+}
+
+void PixelShaderManager::SetZSlopeChanged(float dfdx, float dfdy, float f0)
+{
+	zslope[0] = dfdx;
+	zslope[1] = dfdy;
+	zslope[2] = f0;
+	s_bZSlopeChanged = true;
 }
 
 void PixelShaderManager::SetIndTexScaleChanged(bool high)

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -14,6 +14,7 @@
 
 bool PixelShaderManager::s_bFogRangeAdjustChanged;
 bool PixelShaderManager::s_bViewPortChanged;
+bool PixelShaderManager::s_bEFBScaleChanged;
 
 std::array<int4,4> PixelShaderManager::s_tev_color;
 std::array<int4,4> PixelShaderManager::s_tev_konst_color;
@@ -48,6 +49,7 @@ void PixelShaderManager::Dirty()
 	SetDestAlpha();
 	SetZTextureBias();
 	SetViewportChanged();
+	SetEfbScaleChanged();
 	SetZSlope(0, 0, 1);
 	SetIndTexScaleChanged(false);
 	SetIndTexScaleChanged(true);
@@ -113,6 +115,13 @@ void PixelShaderManager::SetConstants()
 		dirty = true;
 		s_bViewPortChanged = false;
 	}
+
+	if (s_bEFBScaleChanged) {
+		constants.efbscale[0] = 1.0f / float(Renderer::EFBToScaledXf(1));
+		constants.efbscale[1] = 1.0f / float(Renderer::EFBToScaledYf(1));
+		dirty = true;
+		s_bEFBScaleChanged = false;
+	}
 }
 
 void PixelShaderManager::SetTevColor(int index, int component, s32 value)
@@ -167,6 +176,12 @@ void PixelShaderManager::SetViewportChanged()
 {
 	s_bViewPortChanged = true;
 	s_bFogRangeAdjustChanged = true; // TODO: Shouldn't be necessary with an accurate fog range adjust implementation
+}
+
+void PixelShaderManager::SetEfbScaleChanged()
+{
+	s_bEFBScaleChanged = true;
+	s_bViewPortChanged = true;
 }
 
 void PixelShaderManager::SetZSlope(float dfdx, float dfdy, float f0)

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -36,7 +36,7 @@ public:
 	static void SetTexDims(int texmapid, u32 width, u32 height, u32 wraps, u32 wrapt);
 	static void SetZTextureBias();
 	static void SetViewportChanged();
-	static void SetZSlopeChanged(float dfdx, float dfdy, float f0);
+	static void SetZSlope(float dfdx, float dfdy, float f0);
 	static void SetIndMatrixChanged(int matrixidx);
 	static void SetTevKSelChanged(int id);
 	static void SetZTextureTypeChanged();
@@ -51,7 +51,6 @@ public:
 
 	static bool s_bFogRangeAdjustChanged;
 	static bool s_bViewPortChanged;
-	static bool s_bZSlopeChanged;
 
 	// These colors aren't available from global BP state,
 	// hence we keep a copy of them around.

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -36,6 +36,7 @@ public:
 	static void SetTexDims(int texmapid, u32 width, u32 height, u32 wraps, u32 wrapt);
 	static void SetZTextureBias();
 	static void SetViewportChanged();
+	static void SetZSlopeChanged(float dfdx, float dfdy, float f0);
 	static void SetIndMatrixChanged(int matrixidx);
 	static void SetTevKSelChanged(int id);
 	static void SetZTextureTypeChanged();
@@ -50,6 +51,7 @@ public:
 
 	static bool s_bFogRangeAdjustChanged;
 	static bool s_bViewPortChanged;
+	static bool s_bZSlopeChanged;
 
 	// These colors aren't available from global BP state,
 	// hence we keep a copy of them around.

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -52,10 +52,4 @@ public:
 
 	static bool s_bFogRangeAdjustChanged;
 	static bool s_bViewPortChanged;
-	static bool s_bEFBScaleChanged;
-
-	// These colors aren't available from global BP state,
-	// hence we keep a copy of them around.
-	static std::array<int4,4> s_tev_color;
-	static std::array<int4,4> s_tev_konst_color;
 };

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -36,6 +36,7 @@ public:
 	static void SetTexDims(int texmapid, u32 width, u32 height, u32 wraps, u32 wrapt);
 	static void SetZTextureBias();
 	static void SetViewportChanged();
+	static void SetEfbScaleChanged();
 	static void SetZSlope(float dfdx, float dfdy, float f0);
 	static void SetIndMatrixChanged(int matrixidx);
 	static void SetTevKSelChanged(int id);
@@ -51,6 +52,7 @@ public:
 
 	static bool s_bFogRangeAdjustChanged;
 	static bool s_bViewPortChanged;
+	static bool s_bEFBScaleChanged;
 
 	// These colors aren't available from global BP state,
 	// hence we keep a copy of them around.

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -292,6 +292,7 @@ static inline void AssignVSOutputMembers(T& object, const char* a, const char* b
 #define I_FOGI          "cfogi"
 #define I_FOGF          "cfogf"
 #define I_ZSLOPE        "czslope"
+#define I_EFBSCALE      "cefbscale"
 
 #define I_POSNORMALMATRIX       "cpnmtx"
 #define I_PROJECTION            "cproj"

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -291,6 +291,7 @@ static inline void AssignVSOutputMembers(T& object, const char* a, const char* b
 #define I_FOGCOLOR      "cfogcolor"
 #define I_FOGI          "cfogi"
 #define I_FOGF          "cfogf"
+#define I_ZSLOPE        "czslope"
 
 #define I_POSNORMALMATRIX       "cpnmtx"
 #define I_PROJECTION            "cproj"

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -157,8 +157,12 @@ int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bo
 		VertexManager::Flush();
 	s_current_vtx_fmt = loader->m_native_vertex_format;
 
+	// if cull mode is CULL_ALL, tell VertexManager to skip triangles and quads.
+	// They still need to go through vertex loading, because we need to calculate a zfreeze refrence slope.
+	bool cullall = (bpmem.genMode.cullmode == GenMode::CULL_ALL && primitive < 5);
+
 	DataReader dst = VertexManager::PrepareForAdditionalData(primitive, count,
-			loader->m_native_vtx_decl.stride);
+			loader->m_native_vtx_decl.stride, cullall);
 
 	count = loader->RunVertices(primitive, count, src, dst);
 

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -149,11 +149,8 @@ int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bo
 	if ((int)src.size() < size)
 		return -1;
 
-	if (skip_drawing || (bpmem.genMode.cullmode == GenMode::CULL_ALL && primitive < 5))
-	{
-		// if cull mode is CULL_ALL, ignore triangles and quads
+	if (skip_drawing)
 		return size;
-	}
 
 	// If the native vertex format changed, force a flush.
 	if (loader->m_native_vertex_format != s_current_vtx_fmt)

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -259,11 +259,12 @@ void VertexManager::CalculateZSlope(u32 stride)
 
 		VertexShaderManager::TransformToClipSpace(&vtx[i * 3], &out[i * 4]);
 
-		// viewport offset ignored because we only look at coordinate differences.
-		out[0 + i * 4] = out[0 + i * 4] / out[3 + i * 4] * xfmem.viewport.wd;
-		out[1 + i * 4] = out[1 + i * 4] / out[3 + i * 4] * xfmem.viewport.ht;
+		// Transform to Screenspace
+		out[0 + i * 4] = out[0 + i * 4] / out[3 + i * 4] * xfmem.viewport.wd + (xfmem.viewport.xOrig - 342);
+		out[1 + i * 4] = out[1 + i * 4] / out[3 + i * 4] * xfmem.viewport.ht + (xfmem.viewport.yOrig - 342);
 		out[2 + i * 4] = out[2 + i * 4] / out[3 + i * 4] * xfmem.viewport.zRange + xfmem.viewport.farZ;
 	}
+
 	float dx31 = out[8] - out[0];
 	float dx12 = out[0] - out[4];
 	float dy12 = out[1] - out[5];
@@ -277,7 +278,7 @@ void VertexManager::CalculateZSlope(u32 stride)
 
 	float slope_dfdx = -a / c;
 	float slope_dfdy = -b / c;
-	float slope_f0 = out[2];
+	float slope_f0 = out[2] - (out[0] * slope_dfdx + out[1] * slope_dfdy);
 
 	PixelShaderManager::SetZSlope(slope_dfdx, slope_dfdy, slope_f0);
 }

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -264,11 +264,11 @@ void VertexManager::CalculateZSlope(u32 stride)
 		VertexShaderManager::TransformToClipSpace(&vtx[i * 3], &out[i * 4]);
 
 		// Transform to Screenspace
-		float w = out[3 + i * 4];
+		float inv_w = 1.0f / out[3 + i * 4];
 
-		out[0 + i * 4] = out[0 + i * 4] / w * xfmem.viewport.wd + viewOffset[0];
-		out[1 + i * 4] = out[1 + i * 4] / w * xfmem.viewport.ht + viewOffset[1];
-		out[2 + i * 4] = out[2 + i * 4] / w * xfmem.viewport.zRange + xfmem.viewport.farZ;
+		out[0 + i * 4] = out[0 + i * 4] * inv_w * xfmem.viewport.wd + viewOffset[0];
+		out[1 + i * 4] = out[1 + i * 4] * inv_w * xfmem.viewport.ht + viewOffset[1];
+		out[2 + i * 4] = out[2 + i * 4] * inv_w * xfmem.viewport.zRange + xfmem.viewport.farZ;
 	}
 
 	float dx31 = out[8] - out[0];

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -241,3 +241,43 @@ void VertexManager::DoState(PointerWrap& p)
 {
 	g_vertex_manager->vDoState(p);
 }
+
+void VertexManager::CalculateZSlope(u32 stride)
+{
+	float vtx[9];
+	float out[12];
+
+	// Lookup vertices of the last rendered triangle and software-transform them
+	// This allows us to determine the depth slope, which will be used if zfreeze
+	// is enabled in the following flush.
+	for (unsigned int i = 0; i < 3; ++i)
+	{
+		u8* vtx_ptr = s_pCurBufferPointer - stride * (3 - i);
+		vtx[0 + i * 3] = ((float*)vtx_ptr)[0];
+		vtx[1 + i * 3] = ((float*)vtx_ptr)[1];
+		vtx[2 + i * 3] = ((float*)vtx_ptr)[2];
+
+		VertexShaderManager::TransformToClipSpace(&vtx[i * 3], &out[i * 4]);
+
+		// viewport offset ignored because we only look at coordinate differences.
+		out[0 + i * 4] = out[0 + i * 4] / out[3 + i * 4] * xfmem.viewport.wd;
+		out[1 + i * 4] = out[1 + i * 4] / out[3 + i * 4] * xfmem.viewport.ht;
+		out[2 + i * 4] = out[2 + i * 4] / out[3 + i * 4] * xfmem.viewport.zRange + xfmem.viewport.farZ;
+	}
+	float dx31 = out[8] - out[0];
+	float dx12 = out[0] - out[4];
+	float dy12 = out[1] - out[5];
+	float dy31 = out[9] - out[1];
+
+	float DF31 = out[10] - out[2];
+	float DF21 = out[6] - out[2];
+	float a = DF31 * -dy12 - DF21 * dy31;
+	float b = dx31 * DF21 + dx12 * DF31;
+	float c = -dx12 * dy31 - dx31 * -dy12;
+
+	float slope_dfdx = -a / c;
+	float slope_dfdy = -b / c;
+	float slope_f0 = out[2];
+
+	PixelShaderManager::SetZSlope(slope_dfdx, slope_dfdy, slope_f0);
+}

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -241,6 +241,7 @@ void VertexManager::Flush()
 
 void VertexManager::DoState(PointerWrap& p)
 {
+	p.Do(ZSlope);
 	g_vertex_manager->vDoState(p);
 }
 

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -250,7 +250,7 @@ void VertexManager::CalculateZSlope(u32 stride)
 	float vtx[9];
 	float out[12];
 	float viewOffset[2] = { xfmem.viewport.xOrig - bpmem.scissorOffset.x * 2,
-						    xfmem.viewport.yOrig - bpmem.scissorOffset.y * 2};
+	                        xfmem.viewport.yOrig - bpmem.scissorOffset.y * 2};
 
 	// Lookup vertices of the last rendered triangle and software-transform them
 	// This allows us to determine the depth slope, which will be used if zfreeze

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -4,6 +4,7 @@
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "VideoCommon/DataReader.h"
+#include "VideoCommon/NativeVertexFormat.h"
 
 class NativeVertexFormat;
 class PointerWrap;
@@ -19,6 +20,7 @@ struct Slope
 	float dfdx;
 	float dfdy;
 	float f0;
+	bool dirty;
 };
 
 class VertexManager
@@ -63,7 +65,7 @@ protected:
 	static u32 GetRemainingIndices(int primitive);
 
 	static Slope ZSlope;
-	static void CalculateZSlope(u32 stride);
+	static void CalculateZSlope(NativeVertexFormat *format);
 
 private:
 	static bool IsFlushed;

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -41,6 +41,8 @@ public:
 
 	static void DoState(PointerWrap& p);
 
+	static void CalculateZSlope(u32 stride);
+
 protected:
 	virtual void vDoState(PointerWrap& p) {  }
 

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -14,6 +14,13 @@ enum PrimitiveType {
 	PRIMITIVE_TRIANGLES,
 };
 
+struct Slope
+{
+	float dfdx;
+	float dfdy;
+	float f0;
+};
+
 class VertexManager
 {
 private:
@@ -41,8 +48,6 @@ public:
 
 	static void DoState(PointerWrap& p);
 
-	static void CalculateZSlope(u32 stride);
-
 protected:
 	virtual void vDoState(PointerWrap& p) {  }
 
@@ -56,6 +61,9 @@ protected:
 
 	static u32 GetRemainingSize();
 	static u32 GetRemainingIndices(int primitive);
+
+	static Slope ZSlope;
+	static void CalculateZSlope(u32 stride);
 
 private:
 	static bool IsFlushed;

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -41,7 +41,7 @@ public:
 	// needs to be virtual for DX11's dtor
 	virtual ~VertexManager();
 
-	static DataReader PrepareForAdditionalData(int primitive, u32 count, u32 stride);
+	static DataReader PrepareForAdditionalData(int primitive, u32 count, u32 stride, bool cullall);
 	static void FlushData(u32 count, u32 stride);
 
 	static void Flush();
@@ -66,6 +66,8 @@ protected:
 
 	static Slope ZSlope;
 	static void CalculateZSlope(NativeVertexFormat *format);
+
+	static bool CullAll;
 
 private:
 	static bool IsFlushed;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -690,6 +690,24 @@ void VertexShaderManager::ResetView()
 	bProjectionChanged = true;
 }
 
+void VertexShaderManager::TransformToClipSpace(const float* data, float *out)
+{
+	const float *world_matrix = (const float *)xfmem.posMatrices + g_main_cp_state.matrix_index_a.PosNormalMtxIdx * 4;
+	const float *proj_matrix = &g_fProjectionMatrix[0];
+
+	float t[3];
+	t[0] = data[0] * world_matrix[0] + data[1] * world_matrix[1] + data[2] * world_matrix[2] + world_matrix[3];
+	t[1] = data[0] * world_matrix[4] + data[1] * world_matrix[5] + data[2] * world_matrix[6] + world_matrix[7];
+	t[2] = data[0] * world_matrix[8] + data[1] * world_matrix[9] + data[2] * world_matrix[10] + world_matrix[11];
+
+	// TODO: this requires g_fProjectionMatrix to be up to date, which is not really a good design decision.
+
+	out[0] = t[0] * proj_matrix[0] + t[1] * proj_matrix[1] + t[2] * proj_matrix[2] + proj_matrix[3];
+	out[1] = t[0] * proj_matrix[4] + t[1] * proj_matrix[5] + t[2] * proj_matrix[6] + proj_matrix[7];
+	out[2] = t[0] * proj_matrix[8] + t[1] * proj_matrix[9] + t[2] * proj_matrix[10] + proj_matrix[11];
+	out[3] = t[0] * proj_matrix[12] + t[1] * proj_matrix[13] + t[2] * proj_matrix[14] + proj_matrix[15];
+}
+
 void VertexShaderManager::DoState(PointerWrap &p)
 {
 	p.Do(g_fProjectionMatrix);

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -690,10 +690,12 @@ void VertexShaderManager::ResetView()
 	bProjectionChanged = true;
 }
 
-void VertexShaderManager::TransformToClipSpace(const float* data, float *out)
+void VertexShaderManager::TransformToClipSpace(const float* data, float *out, u32 MtxIdx)
 {
-	// Can we use constants.posnormalmatrix here instead?
-	const float *world_matrix = (const float *)xfmem.posMatrices + g_main_cp_state.matrix_index_a.PosNormalMtxIdx * 4;
+	const float *world_matrix = (const float *)xfmem.posMatrices + (MtxIdx & 0x3f) * 4;
+	// We use the projection matrix calculated by vertexShaderManager, because it
+	// includes any free look transformations.
+	// Make sure VertexManager::SetConstants() has been called first.
 	const float *proj_matrix = &g_fProjectionMatrix[0];
 
 	float t[3];

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -692,6 +692,7 @@ void VertexShaderManager::ResetView()
 
 void VertexShaderManager::TransformToClipSpace(const float* data, float *out)
 {
+	// Can we use constants.posnormalmatrix here instead?
 	const float *world_matrix = (const float *)xfmem.posMatrices + g_main_cp_state.matrix_index_a.PosNormalMtxIdx * 4;
 	const float *proj_matrix = &g_fProjectionMatrix[0];
 
@@ -699,8 +700,6 @@ void VertexShaderManager::TransformToClipSpace(const float* data, float *out)
 	t[0] = data[0] * world_matrix[0] + data[1] * world_matrix[1] + data[2] * world_matrix[2] + world_matrix[3];
 	t[1] = data[0] * world_matrix[4] + data[1] * world_matrix[5] + data[2] * world_matrix[6] + world_matrix[7];
 	t[2] = data[0] * world_matrix[8] + data[1] * world_matrix[9] + data[2] * world_matrix[10] + world_matrix[11];
-
-	// TODO: this requires g_fProjectionMatrix to be up to date, which is not really a good design decision.
 
 	out[0] = t[0] * proj_matrix[0] + t[1] * proj_matrix[1] + t[2] * proj_matrix[2] + proj_matrix[3];
 	out[1] = t[0] * proj_matrix[4] + t[1] * proj_matrix[5] + t[2] * proj_matrix[6] + proj_matrix[7];

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -34,6 +34,12 @@ public:
 	static void RotateView(float x, float y);
 	static void ResetView();
 
+	// data: 3 floats representing the X, Y and Z vertex model coordinates
+	// out: 4 floats which will be initialized with the corresponding clip space coordinates
+	// NOTE: g_fProjectionMatrix must be up to date when this is called
+	//		(i.e. VertexShaderManager::SetConstants needs to be called before using this!)
+	static void TransformToClipSpace(const float* data, float *out);
+
 	static VertexShaderConstants constants;
 	static bool dirty;
 };

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -34,11 +34,11 @@ public:
 	static void RotateView(float x, float y);
 	static void ResetView();
 
-	// data: 3 floats representing the X, Y and Z vertex model coordinates
+	// data: 3 floats representing the X, Y and Z vertex model coordinates and the posmatrix index.
 	// out: 4 floats which will be initialized with the corresponding clip space coordinates
 	// NOTE: g_fProjectionMatrix must be up to date when this is called
 	//		(i.e. VertexShaderManager::SetConstants needs to be called before using this!)
-	static void TransformToClipSpace(const float* data, float *out);
+	static void TransformToClipSpace(const float* data, float *out, u32 mtxIdx);
 
 	static VertexShaderConstants constants;
 	static bool dirty;


### PR DESCRIPTION
This has been a long journey but zfreeze is finished.
This PR contains code from neobrain, NanoByte011 and phire.

Changes since #1767 
 * Don't cull CULLALL primitives so early because they are often used as reference planes.
 * Convert CalculateZSlope to screenspace coordinates.
 * Convert Pixelshader to screenspace coordinates (instead of worldspace  xy coordinates, which is totally wrong)
 * Divide depth by 2^24 instead of clamping to 0.0-1.0 as was done before.
 * Adjust from DirectX/OpenGL screenspace coordinates to gamecube screenspace coordinates, by compensating for EFB scale. (and flipping the vertical axis in the case of OpenGL) Zfreeze now works in most games.
 * Make sure early depth isn't forced on when zfreeze is enabled, fixing fast depth and gimmick courts in Mario Power Tennis **(NanoByte)**
 * Improved shader constant uniform buffer savestate code.
 * Move Common code into VideoCommon
 * OpenGL: don't send CULLALL vertexes to GPU Memory.

## Known Issues:
 - [x] The Delfino Plaza court in Mario Power Tennis has zfighting issues. These may be unfixable.
 - [ ] It should still be possible to generate test cases with visible reference triangles which aren't rendered correctly with this approach. Fortunately, all known retail games use invisible reference planes.

## Todo:
 - [x] Don't update the constants uniform buffer before every drawcall.
 - [x] Cleanup CULLALL mode code path.
 - [x] Make sure this isn't broken on anyone's video card.
 - [x] Savestate Issues
 - [x] Handle per-vertex matrix indexes for the reference plane, or leave a comment justifying that we don't need to.