### PR TITLE
Move worldpos into it's own varying.

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -219,7 +219,6 @@ static inline void GenerateGeometryShader(T& out, u32 primitive_type, API_TYPE A
 		// the depth value. This results in objects at a distance smaller than the convergence
 		// distance to seemingly appear in front of the screen.
 		// This formula is based on page 13 of the "Nvidia 3D Vision Automatic, Best Practices Guide"
-		out.Write("\tf.clipPos.x += " I_STEREOPARAMS"[eye] * (f.clipPos.w - " I_STEREOPARAMS"[2]);\n");
 		out.Write("\tf.pos.x += " I_STEREOPARAMS"[eye] * (f.pos.w - " I_STEREOPARAMS"[2]);\n");
 	}
 

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -342,7 +342,8 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 			out.Write("centroid in float4 clipPos;\n");
 			if (g_ActiveConfig.bEnablePixelLighting)
 			{
-				out.Write("centroid in float4 Normal;\n");
+				out.Write("centroid in float3 Normal;\n");
+				out.Write("centroid in float3 WorldPos;\n");
 			}
 		}
 
@@ -371,7 +372,10 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 			out.Write(",\n  in centroid float3 uv%d : TEXCOORD%d", i, i);
 		out.Write(",\n  in centroid float4 clipPos : TEXCOORD%d", numTexgen);
 		if (g_ActiveConfig.bEnablePixelLighting)
-			out.Write(",\n  in centroid float4 Normal : TEXCOORD%d", numTexgen + 1);
+		{
+			out.Write(",\n  in centroid float3 Normal : TEXCOORD%d", numTexgen + 1);
+			out.Write(",\n  in centroid float3 WorldPos : TEXCOORD%d", numTexgen + 2);
+		}
 		uid_data->stereo = g_ActiveConfig.iStereoMode > 0;
 		if (g_ActiveConfig.iStereoMode > 0)
 			out.Write(",\n  in uint layer : SV_RenderTargetArrayIndex\n");
@@ -389,7 +393,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	if (g_ActiveConfig.bEnablePixelLighting)
 	{
 		out.Write("\tfloat3 _norm0 = normalize(Normal.xyz);\n\n");
-		out.Write("\tfloat3 pos = float3(clipPos.x,clipPos.y,Normal.w);\n");
+		out.Write("\tfloat3 pos = WorldPos;\n");
 
 		out.Write("\tint4 lacc;\n"
 				"\tfloat3 ldir, h;\n"

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -255,7 +255,10 @@ static inline void GenerateVSOutputMembers(T& object, API_TYPE api_type, const c
 	DefineOutputMember(object, api_type, qualifier, "float4", "clipPos", -1, "TEXCOORD", xfmem.numTexGen.numTexGens);
 
 	if (g_ActiveConfig.bEnablePixelLighting)
-		DefineOutputMember(object, api_type, qualifier, "float4", "Normal", -1, "TEXCOORD", xfmem.numTexGen.numTexGens + 1);
+	{
+		DefineOutputMember(object, api_type, qualifier, "float3", "Normal", -1, "TEXCOORD", xfmem.numTexGen.numTexGens + 1);
+		DefineOutputMember(object, api_type, qualifier, "float3", "WorldPos", -1, "TEXCOORD", xfmem.numTexGen.numTexGens + 2);
+	}
 }
 
 template<class T>
@@ -271,7 +274,10 @@ static inline void AssignVSOutputMembers(T& object, const char* a, const char* b
 	object.Write("\t%s.clipPos = %s.clipPos;\n", a, b);
 
 	if (g_ActiveConfig.bEnablePixelLighting)
+	{
 		object.Write("\t%s.Normal = %s.Normal;\n", a, b);
+		object.Write("\t%s.WorldPos = %s.WorldPos;\n", a, b);
+	}
 }
 
 // Constant variable names

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -92,7 +92,10 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 			}
 			out.Write("centroid out float4 clipPos;\n");
 			if (g_ActiveConfig.bEnablePixelLighting)
-				out.Write("centroid out float4 Normal;\n");
+			{
+				out.Write("centroid out float3 Normal;\n");
+				out.Write("centroid out float3 WorldPos;\n");
+			}
 			out.Write("centroid out float4 colors_0;\n");
 			out.Write("centroid out float4 colors_1;\n");
 		}
@@ -337,11 +340,12 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 	}
 
 	// clipPos/w needs to be done in pixel shader, not here
-	out.Write("o.clipPos = float4(pos.x,pos.y,o.pos.z,o.pos.w);\n");
+	out.Write("o.clipPos = o.pos;\n");
 
 	if (g_ActiveConfig.bEnablePixelLighting)
 	{
-		out.Write("o.Normal = float4(_norm0.x,_norm0.y,_norm0.z,pos.z);\n");
+		out.Write("o.Normal = _norm0;\n");
+		out.Write("o.WorldPos = pos.xyz;\n");
 
 		if (components & VB_HAS_COL0)
 			out.Write("o.colors_0 = color0;\n");
@@ -395,7 +399,10 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 				out.Write("uv%d.xyz = o.tex%d;\n", i, i);
 			out.Write("clipPos = o.clipPos;\n");
 			if (g_ActiveConfig.bEnablePixelLighting)
+			{
 				out.Write("Normal = o.Normal;\n");
+				out.Write("WorldPos = o.WorldPos;\n");
+			}
 			out.Write("colors_0 = o.colors_0;\n");
 			out.Write("colors_1 = o.colors_1;\n");
 		}


### PR DESCRIPTION
Previously it was packed into spare slots in clippos.xy and normal.w, but it's ugly and more importantly it's causing bugs.

This was discovered during the debugging of a zfreeze branch, which expected clippos.xy to be xy position coordinates in clipspace (as the name suggested).

Turns out the stereoscopy shader had also run into this trap, modifying clippos.x (introducing errors with per-pixel lighting).

This commit has been moved outside of the zfreeze PR for fast merging.