### PR TITLE
MemoryUtil: add comment for Valgrind

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -69,7 +69,7 @@ void* AllocateExecutableMemory(size_t size, bool low)
 	{
 		ptr = nullptr;
 #endif
-		PanicAlert("Failed to allocate executable memory");
+		PanicAlert("Failed to allocate executable memory. If you are running Dolphin in Valgrind, try '#undef MAP_32BIT'.");
 	}
 #if !defined(_WIN32) && defined(_M_X86_64) && !defined(MAP_32BIT)
 	else

--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -21,6 +21,10 @@
 #include <sys/mman.h>
 #endif
 
+// Valgrind doesn't support MAP_32BIT.
+// Uncomment the following line to be able to run Dolphin in Valgrind.
+//#undef MAP_32BIT
+
 #if !defined(_WIN32) && defined(_M_X86_64) && !defined(MAP_32BIT)
 #include <unistd.h>
 #define PAGE_MASK     (getpagesize() - 1)


### PR DESCRIPTION
Valgrind doesn't support the `mmap()` flag `MAP_32BIT` (see [this bug](https://bugs.kde.org/show_bug.cgi?id=324181#c1)).

Alternatives that I decided not to use:
- Adding a simple CMake option would force a full recompile for something that is only used for debugging.
- Including valgrind.h if available and using the `RUNNING_ON_VALGRIND` macro to decide at runtime could cause heisenbugs.