### PR TITLE
JIT: catch illegal instruction errors

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -673,6 +673,11 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 			num_inst++;
 			memset(&code[i], 0, sizeof(CodeOp));
 			GekkoOPInfo *opinfo = GetOpInfo(inst);
+			if (!opinfo)
+			{
+				PanicAlert("Invalid PowerPC opcode: %x.", inst.hex);
+				Crash();
+			}
 
 			code[i].opinfo = opinfo;
 			code[i].address = address;


### PR DESCRIPTION
Still crash, but at least give a message informing the world that it happened.