### PR TITLE
SDL Input: Support more types of force feedback for controllers through SDL

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -18,6 +18,14 @@ namespace ciface
 namespace SDL
 {
 
+namespace
+{
+// 10ms = 100Hz which homebrew docs very roughly imply is within WiiMote normal
+// range, used for periodic haptic effects though often ignored by devices
+const u16 RUMBLE_PERIOD = 10;
+const u16 RUMBLE_LENGTH_MAX = 500; // ms: enough to span multiple frames at low FPS, but still finite
+}
+
 static std::string GetJoystickName(int index)
 {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -223,25 +231,25 @@ void Joystick::HapticEffect::SetState(ControlState state)
 void Joystick::ConstantEffect::SetSDLHapticEffect(ControlState state)
 {
 	m_effect.type = SDL_HAPTIC_CONSTANT;
-	m_effect.constant.length = SDL_HAPTIC_INFINITY;
+	m_effect.constant.length = RUMBLE_LENGTH_MAX;
 	m_effect.constant.level = (Sint16)(state * 0x7FFF);
 }
 
 void Joystick::RampEffect::SetSDLHapticEffect(ControlState state)
 {
 	m_effect.type = SDL_HAPTIC_RAMP;
-	m_effect.ramp.length = SDL_HAPTIC_INFINITY;
+	m_effect.ramp.length = RUMBLE_LENGTH_MAX;
 	m_effect.ramp.start = (Sint16)(state * 0x7FFF);
 }
 
 void Joystick::SineEffect::SetSDLHapticEffect(ControlState state)
 {
 	m_effect.type = SDL_HAPTIC_SINE;
-	m_effect.periodic.period = 1000;
+	m_effect.periodic.period = RUMBLE_PERIOD;
 	m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
 	m_effect.periodic.offset = 0;
 	m_effect.periodic.phase = 18000;
-	m_effect.periodic.length = SDL_HAPTIC_INFINITY;
+	m_effect.periodic.length = RUMBLE_LENGTH_MAX;
 	m_effect.periodic.delay = 0;
 	m_effect.periodic.attack_length = 0;
 }
@@ -249,11 +257,11 @@ void Joystick::SineEffect::SetSDLHapticEffect(ControlState state)
 void Joystick::TriangleEffect::SetSDLHapticEffect(ControlState state)
 {
 	m_effect.type = SDL_HAPTIC_TRIANGLE;
-	m_effect.periodic.period = 1000;
+	m_effect.periodic.period = RUMBLE_PERIOD;
 	m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
 	m_effect.periodic.offset = 0;
 	m_effect.periodic.phase = 18000;
-	m_effect.periodic.length = SDL_HAPTIC_INFINITY;
+	m_effect.periodic.length = RUMBLE_LENGTH_MAX;
 	m_effect.periodic.delay = 0;
 	m_effect.periodic.attack_length = 0;
 }
@@ -261,7 +269,7 @@ void Joystick::TriangleEffect::SetSDLHapticEffect(ControlState state)
 void Joystick::LeftRightEffect::SetSDLHapticEffect(ControlState state)
 {
 	m_effect.type = SDL_HAPTIC_LEFTRIGHT;
-	m_effect.leftright.length = SDL_HAPTIC_INFINITY;
+	m_effect.leftright.length = RUMBLE_LENGTH_MAX;
 	// max ranges tuned to 'feel' similar in magnitude to triangle/sine on xbox360 controller
 	m_effect.leftright.large_magnitude = (Uint16)(state * 0x4000);
 	m_effect.leftright.small_magnitude = (Uint16)(state * 0xFFFF);

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -205,9 +205,14 @@ std::string Joystick::LeftRightEffect::GetName() const
 	return "LeftRight";
 }
 
-void Joystick::ConstantEffect::SetState(ControlState state)
+void Joystick::HapticEffect::SetState(ControlState state)
 {
 	memset(&m_effect, 0, sizeof(m_effect));
+	_SetState(state);
+}
+
+void Joystick::ConstantEffect::_SetState(ControlState state)
+{
 	if (state)
 	{
 		m_effect.type = SDL_HAPTIC_CONSTANT;
@@ -222,9 +227,8 @@ void Joystick::ConstantEffect::SetState(ControlState state)
 	Update();
 }
 
-void Joystick::RampEffect::SetState(ControlState state)
+void Joystick::RampEffect::_SetState(ControlState state)
 {
-	memset(&m_effect, 0, sizeof(m_effect));
 	if (state)
 	{
 		m_effect.type = SDL_HAPTIC_RAMP;
@@ -239,9 +243,8 @@ void Joystick::RampEffect::SetState(ControlState state)
 	Update();
 }
 
-void Joystick::SineEffect::SetState(ControlState state)
+void Joystick::SineEffect::_SetState(ControlState state)
 {
-	memset(&m_effect, 0, sizeof(m_effect));
 	if (state)
 	{
 		m_effect.type = SDL_HAPTIC_SINE;
@@ -261,9 +264,8 @@ void Joystick::SineEffect::SetState(ControlState state)
 	Update();
 }
 
-void Joystick::TriangleEffect::SetState(ControlState state)
+void Joystick::TriangleEffect::_SetState(ControlState state)
 {
-	memset(&m_effect, 0, sizeof(m_effect));
 	if (state)
 	{
 		m_effect.type = SDL_HAPTIC_TRIANGLE;
@@ -283,9 +285,8 @@ void Joystick::TriangleEffect::SetState(ControlState state)
 	Update();
 }
 
-void Joystick::LeftRightEffect::SetState(ControlState state)
+void Joystick::LeftRightEffect::_SetState(ControlState state)
 {
-	memset(&m_effect, 0, sizeof(m_effect));
 	if (state)
 	{
 		m_effect.type = SDL_HAPTIC_LEFTRIGHT;

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -208,90 +208,63 @@ std::string Joystick::LeftRightEffect::GetName() const
 void Joystick::HapticEffect::SetState(ControlState state)
 {
 	memset(&m_effect, 0, sizeof(m_effect));
-	SetSDLHapticEffect(state);
+	if (state)
+	{
+		SetSDLHapticEffect(state);
+	}
+	else
+	{
+		// this module uses type==0 to indicate 'off'
+		m_effect.type = 0;
+	}
 	Update();
 }
 
 void Joystick::ConstantEffect::SetSDLHapticEffect(ControlState state)
 {
-	if (state)
-	{
-		m_effect.type = SDL_HAPTIC_CONSTANT;
-		m_effect.constant.length = SDL_HAPTIC_INFINITY;
-		m_effect.constant.level = (Sint16)(state * 0x7FFF);
-	}
-	else
-	{
-		m_effect.type = 0;
-	}
+	m_effect.type = SDL_HAPTIC_CONSTANT;
+	m_effect.constant.length = SDL_HAPTIC_INFINITY;
+	m_effect.constant.level = (Sint16)(state * 0x7FFF);
 }
 
 void Joystick::RampEffect::SetSDLHapticEffect(ControlState state)
 {
-	if (state)
-	{
-		m_effect.type = SDL_HAPTIC_RAMP;
-		m_effect.ramp.length = SDL_HAPTIC_INFINITY;
-		m_effect.ramp.start = (Sint16)(state * 0x7FFF);
-	}
-	else
-	{
-		m_effect.type = 0;
-	}
+	m_effect.type = SDL_HAPTIC_RAMP;
+	m_effect.ramp.length = SDL_HAPTIC_INFINITY;
+	m_effect.ramp.start = (Sint16)(state * 0x7FFF);
 }
 
 void Joystick::SineEffect::SetSDLHapticEffect(ControlState state)
 {
-	if (state)
-	{
-		m_effect.type = SDL_HAPTIC_SINE;
-		m_effect.periodic.period = 1000;
-		m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
-		m_effect.periodic.offset = 0;
-		m_effect.periodic.phase = 18000;
-		m_effect.periodic.length = SDL_HAPTIC_INFINITY;
-		m_effect.periodic.delay = 0;
-		m_effect.periodic.attack_length = 0;
-	}
-	else
-	{
-		m_effect.type = 0;
-	}
+	m_effect.type = SDL_HAPTIC_SINE;
+	m_effect.periodic.period = 1000;
+	m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
+	m_effect.periodic.offset = 0;
+	m_effect.periodic.phase = 18000;
+	m_effect.periodic.length = SDL_HAPTIC_INFINITY;
+	m_effect.periodic.delay = 0;
+	m_effect.periodic.attack_length = 0;
 }
 
 void Joystick::TriangleEffect::SetSDLHapticEffect(ControlState state)
 {
-	if (state)
-	{
-		m_effect.type = SDL_HAPTIC_TRIANGLE;
-		m_effect.periodic.period = 1000;
-		m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
-		m_effect.periodic.offset = 0;
-		m_effect.periodic.phase = 18000;
-		m_effect.periodic.length = SDL_HAPTIC_INFINITY;
-		m_effect.periodic.delay = 0;
-		m_effect.periodic.attack_length = 0;
-	}
-	else
-	{
-		m_effect.type = 0;
-	}
+	m_effect.type = SDL_HAPTIC_TRIANGLE;
+	m_effect.periodic.period = 1000;
+	m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
+	m_effect.periodic.offset = 0;
+	m_effect.periodic.phase = 18000;
+	m_effect.periodic.length = SDL_HAPTIC_INFINITY;
+	m_effect.periodic.delay = 0;
+	m_effect.periodic.attack_length = 0;
 }
 
 void Joystick::LeftRightEffect::SetSDLHapticEffect(ControlState state)
 {
-	if (state)
-	{
-		m_effect.type = SDL_HAPTIC_LEFTRIGHT;
-		m_effect.leftright.length = SDL_HAPTIC_INFINITY;
-		// max ranges tuned to 'feel' similar in magnitude to triangle/sine on xbox360 controller
-		m_effect.leftright.large_magnitude = (Uint16)(state * 0x4000);
-		m_effect.leftright.small_magnitude = (Uint16)(state * 0xFFFF);
-	}
-	else
-	{
-		m_effect.type = 0;
-	}
+	m_effect.type = SDL_HAPTIC_LEFTRIGHT;
+	m_effect.leftright.length = SDL_HAPTIC_INFINITY;
+	// max ranges tuned to 'feel' similar in magnitude to triangle/sine on xbox360 controller
+	m_effect.leftright.large_magnitude = (Uint16)(state * 0x4000);
+	m_effect.leftright.small_magnitude = (Uint16)(state * 0xFFFF);
 }
 #endif
 

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -126,6 +126,18 @@ Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsi
 		// ramp effect
 		if (supported_effects & SDL_HAPTIC_RAMP)
 			AddOutput(new RampEffect(m_haptic));
+
+		// sine effect
+		if (supported_effects & SDL_HAPTIC_SINE)
+			AddOutput(new SineEffect(m_haptic));
+
+		// triangle effect
+		if (supported_effects & SDL_HAPTIC_TRIANGLE)
+			AddOutput(new TriangleEffect(m_haptic));
+
+		// left-right effect
+		if (supported_effects & SDL_HAPTIC_LEFTRIGHT)
+			AddOutput(new LeftRightEffect(m_haptic));
 	}
 #endif
 
@@ -178,8 +190,24 @@ std::string Joystick::RampEffect::GetName() const
 	return "Ramp";
 }
 
+std::string Joystick::SineEffect::GetName() const
+{
+	return "Sine";
+}
+
+std::string Joystick::TriangleEffect::GetName() const
+{
+	return "Triangle";
+}
+
+std::string Joystick::LeftRightEffect::GetName() const
+{
+	return "LeftRight";
+}
+
 void Joystick::ConstantEffect::SetState(ControlState state)
 {
+	memset(&m_effect, 0, sizeof(m_effect));
 	if (state)
 	{
 		m_effect.type = SDL_HAPTIC_CONSTANT;
@@ -196,6 +224,7 @@ void Joystick::ConstantEffect::SetState(ControlState state)
 
 void Joystick::RampEffect::SetState(ControlState state)
 {
+	memset(&m_effect, 0, sizeof(m_effect));
 	if (state)
 	{
 		m_effect.type = SDL_HAPTIC_RAMP;
@@ -207,6 +236,69 @@ void Joystick::RampEffect::SetState(ControlState state)
 	}
 
 	m_effect.ramp.start = (Sint16)(state * 0x7FFF);
+	Update();
+}
+
+void Joystick::SineEffect::SetState(ControlState state)
+{
+	memset(&m_effect, 0, sizeof(m_effect));
+	if (state)
+	{
+		m_effect.type = SDL_HAPTIC_SINE;
+		m_effect.periodic.period = 1000;
+		m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
+		m_effect.periodic.offset = 0;
+		m_effect.periodic.phase = 18000;
+		m_effect.periodic.length = SDL_HAPTIC_INFINITY;
+		m_effect.periodic.delay = 0;
+		m_effect.periodic.attack_length = 0;
+	}
+	else
+	{
+		m_effect.type = 0;
+	}
+
+	Update();
+}
+
+void Joystick::TriangleEffect::SetState(ControlState state)
+{
+	memset(&m_effect, 0, sizeof(m_effect));
+	if (state)
+	{
+		m_effect.type = SDL_HAPTIC_TRIANGLE;
+		m_effect.periodic.period = 1000;
+		m_effect.periodic.magnitude = (Sint16)(state * 0x7FFF);
+		m_effect.periodic.offset = 0;
+		m_effect.periodic.phase = 18000;
+		m_effect.periodic.length = SDL_HAPTIC_INFINITY;
+		m_effect.periodic.delay = 0;
+		m_effect.periodic.attack_length = 0;
+	}
+	else
+	{
+		m_effect.type = 0;
+	}
+
+	Update();
+}
+
+void Joystick::LeftRightEffect::SetState(ControlState state)
+{
+	memset(&m_effect, 0, sizeof(m_effect));
+	if (state)
+	{
+		m_effect.type = SDL_HAPTIC_LEFTRIGHT;
+		m_effect.leftright.length = SDL_HAPTIC_INFINITY;
+		// max ranges tuned to 'feel' similar in magnitude to triangle/sine on xbox360 controller
+		m_effect.leftright.large_magnitude = (Uint16)(state * 0x4000);
+		m_effect.leftright.small_magnitude = (Uint16)(state * 0xFFFF);
+	}
+	else
+	{
+		m_effect.type = 0;
+	}
+
 	Update();
 }
 #endif

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -18,13 +18,10 @@ namespace ciface
 namespace SDL
 {
 
-namespace
-{
 // 10ms = 100Hz which homebrew docs very roughly imply is within WiiMote normal
 // range, used for periodic haptic effects though often ignored by devices
-const u16 RUMBLE_PERIOD = 10;
-const u16 RUMBLE_LENGTH_MAX = 500; // ms: enough to span multiple frames at low FPS, but still finite
-}
+static const u16 RUMBLE_PERIOD = 10;
+static const u16 RUMBLE_LENGTH_MAX = 500; // ms: enough to span multiple frames at low FPS, but still finite
 
 static std::string GetJoystickName(int index)
 {

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -208,42 +208,39 @@ std::string Joystick::LeftRightEffect::GetName() const
 void Joystick::HapticEffect::SetState(ControlState state)
 {
 	memset(&m_effect, 0, sizeof(m_effect));
-	_SetState(state);
+	SetSDLHapticEffect(state);
+	Update();
 }
 
-void Joystick::ConstantEffect::_SetState(ControlState state)
+void Joystick::ConstantEffect::SetSDLHapticEffect(ControlState state)
 {
 	if (state)
 	{
 		m_effect.type = SDL_HAPTIC_CONSTANT;
 		m_effect.constant.length = SDL_HAPTIC_INFINITY;
+		m_effect.constant.level = (Sint16)(state * 0x7FFF);
 	}
 	else
 	{
 		m_effect.type = 0;
 	}
-
-	m_effect.constant.level = (Sint16)(state * 0x7FFF);
-	Update();
 }
 
-void Joystick::RampEffect::_SetState(ControlState state)
+void Joystick::RampEffect::SetSDLHapticEffect(ControlState state)
 {
 	if (state)
 	{
 		m_effect.type = SDL_HAPTIC_RAMP;
 		m_effect.ramp.length = SDL_HAPTIC_INFINITY;
+		m_effect.ramp.start = (Sint16)(state * 0x7FFF);
 	}
 	else
 	{
 		m_effect.type = 0;
 	}
-
-	m_effect.ramp.start = (Sint16)(state * 0x7FFF);
-	Update();
 }
 
-void Joystick::SineEffect::_SetState(ControlState state)
+void Joystick::SineEffect::SetSDLHapticEffect(ControlState state)
 {
 	if (state)
 	{
@@ -260,11 +257,9 @@ void Joystick::SineEffect::_SetState(ControlState state)
 	{
 		m_effect.type = 0;
 	}
-
-	Update();
 }
 
-void Joystick::TriangleEffect::_SetState(ControlState state)
+void Joystick::TriangleEffect::SetSDLHapticEffect(ControlState state)
 {
 	if (state)
 	{
@@ -281,11 +276,9 @@ void Joystick::TriangleEffect::_SetState(ControlState state)
 	{
 		m_effect.type = 0;
 	}
-
-	Update();
 }
 
-void Joystick::LeftRightEffect::_SetState(ControlState state)
+void Joystick::LeftRightEffect::SetSDLHapticEffect(ControlState state)
 {
 	if (state)
 	{
@@ -299,8 +292,6 @@ void Joystick::LeftRightEffect::_SetState(ControlState state)
 	{
 		m_effect.type = 0;
 	}
-
-	Update();
 }
 #endif
 

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -77,7 +77,7 @@ private:
 
 	protected:
 		void Update();
-		virtual void _SetState(ControlState state) = 0;
+		virtual void SetSDLHapticEffect(ControlState state) = 0;
 
 		SDL_HapticEffect m_effect;
 		SDL_Haptic* m_haptic;
@@ -91,7 +91,8 @@ private:
 	public:
 		ConstantEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void _SetState(ControlState state) override;
+	private:
+		void SetSDLHapticEffect(ControlState state) override;
 	};
 
 	class RampEffect : public HapticEffect
@@ -99,7 +100,8 @@ private:
 	public:
 		RampEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void _SetState(ControlState state) override;
+	private:
+		void SetSDLHapticEffect(ControlState state) override;
 	};
 
 	class SineEffect : public HapticEffect
@@ -107,7 +109,8 @@ private:
 	public:
 		SineEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void _SetState(ControlState state) override;
+	private:
+		void SetSDLHapticEffect(ControlState state) override;
 	};
 
 	class TriangleEffect : public HapticEffect
@@ -115,7 +118,8 @@ private:
 	public:
 		TriangleEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void _SetState(ControlState state) override;
+	private:
+		void SetSDLHapticEffect(ControlState state) override;
 	};
 
 	class LeftRightEffect : public HapticEffect
@@ -123,7 +127,8 @@ private:
 	public:
 		LeftRightEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void _SetState(ControlState state) override;
+	private:
+		void SetSDLHapticEffect(ControlState state) override;
 	};
 #endif
 

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -98,6 +98,30 @@ private:
 		std::string GetName() const override;
 		void SetState(ControlState state) override;
 	};
+
+	class SineEffect : public HapticEffect
+	{
+	public:
+		SineEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
+		std::string GetName() const override;
+		void SetState(ControlState state) override;
+	};
+
+	class TriangleEffect : public HapticEffect
+	{
+	public:
+		TriangleEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
+		std::string GetName() const override;
+		void SetState(ControlState state) override;
+	};
+
+	class LeftRightEffect : public HapticEffect
+	{
+	public:
+		LeftRightEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
+		std::string GetName() const override;
+		void SetState(ControlState state) override;
+	};
 #endif
 
 public:

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -77,10 +77,13 @@ private:
 
 	protected:
 		void Update();
+		virtual void _SetState(ControlState state) = 0;
 
 		SDL_HapticEffect m_effect;
 		SDL_Haptic* m_haptic;
 		int m_id;
+	private:
+		virtual void SetState(ControlState state) override final;
 	};
 
 	class ConstantEffect : public HapticEffect
@@ -88,7 +91,7 @@ private:
 	public:
 		ConstantEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void SetState(ControlState state) override;
+		void _SetState(ControlState state) override;
 	};
 
 	class RampEffect : public HapticEffect
@@ -96,7 +99,7 @@ private:
 	public:
 		RampEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void SetState(ControlState state) override;
+		void _SetState(ControlState state) override;
 	};
 
 	class SineEffect : public HapticEffect
@@ -104,7 +107,7 @@ private:
 	public:
 		SineEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void SetState(ControlState state) override;
+		void _SetState(ControlState state) override;
 	};
 
 	class TriangleEffect : public HapticEffect
@@ -112,7 +115,7 @@ private:
 	public:
 		TriangleEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void SetState(ControlState state) override;
+		void _SetState(ControlState state) override;
 	};
 
 	class LeftRightEffect : public HapticEffect
@@ -120,7 +123,7 @@ private:
 	public:
 		LeftRightEffect(SDL_Haptic* haptic) : HapticEffect(haptic) {}
 		std::string GetName() const override;
-		void SetState(ControlState state) override;
+		void _SetState(ControlState state) override;
 	};
 #endif
 


### PR DESCRIPTION
Three new haptic modes tested with XBox 360 controller under Linux where no force-feedback was previously available in Dolphin.