### PR TITLE
DSPSpy: Fix build failures

### DIFF
--- a/Source/DSPSpy/Makefile
+++ b/Source/DSPSpy/Makefile
@@ -33,7 +33,7 @@ INCLUDES	:=	include ../Core/Common .
 #---------------------------------------------------------------------------------
 
 CFLAGS	= -save-temps -O2 -Wall --no-strict-aliasing $(MACHDEP) $(INCLUDE)
-CXXFLAGS	=	$(CFLAGS)
+CXXFLAGS	=	-std=c++0x $(CFLAGS)
 
 LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map
 

--- a/Source/DSPSpy/dsp_interface.h
+++ b/Source/DSPSpy/dsp_interface.h
@@ -32,5 +32,3 @@ public:
 	// the implementation does nothing but calling the virtual methods above.
 	void SendTask(void *addr, u16 iram_addr, u16 len, u16 start);
 };
-
-#endif  // _DSP_INTERFACE_H


### PR DESCRIPTION
Remove dangling #endif include guard left by d2038049f5
```
main_spy.cpp
In file included from dolphin/Source/DSPSpy/./main_spy.cpp:47:0:
dolphin/Source/DSPSpy/./dsp_interface.h:36:2: error: #endif without #if
 #endif  // _DSP_INTERFACE_H
  ^
```

Enable C++0x support for nullptr introduced by d802d39281
-std=c++0x was used instead of -std=c++11 to support older versions of DevkitPPC (r23-26) that use GCC 4.6.x
```
main_spy.cpp
dolphin/Source/DSPSpy/./main_spy.cpp:54:1: warning: identifier 'nullptr' is a keyword in C++11 [-Wc++0x-compat]
 static void *xfb = nullptr;
 ^
dolphin/Source/DSPSpy/./main_spy.cpp:54:20: error: 'nullptr' was not declared in this scope
 static void *xfb = nullptr;
                    ^
dolphin/Source/DSPSpy/./main_spy.cpp: In function 'void InitGeneral()':
dolphin/Source/DSPSpy/./main_spy.cpp:529:33: error: 'nullptr' was not declared in this scope
  rmode = VIDEO_GetPreferredMode(nullptr);
                                 ^
```

Tested and built using DevkitPPC r27