### PR TITLE
Audio: Fix subwoofer output in software 5.1 decoding

### DIFF
--- a/Source/Core/AudioCommon/DPL2Decoder.cpp
+++ b/Source/Core/AudioCommon/DPL2Decoder.cpp
@@ -361,7 +361,7 @@ void DPL2Decode(float *samples, int numsamples, float *out)
 		out[cur + 0] = lf[k];
 		out[cur + 1] = rf[k];
 		out[cur + 2] = cf[k];
-		LFE_buf[lfe_pos] = (lf[k] + rf[k] + 2.0 * cf[k] + lr[k] + rr[k]) / 2.0;
+		LFE_buf[lfe_pos] = (lf[k] + rf[k] + 2.0f * cf[k] + lr[k] + rr[k]) / 2.0f;
 		out[cur + 3] = FIRFilter(LFE_buf, lfe_pos, len125, len125, filter_coefs_lfe);
 		lfe_pos++;
 		if (lfe_pos == len125)

--- a/Source/Core/AudioCommon/DPL2Decoder.cpp
+++ b/Source/Core/AudioCommon/DPL2Decoder.cpp
@@ -361,7 +361,7 @@ void DPL2Decode(float *samples, int numsamples, float *out)
 		out[cur + 0] = lf[k];
 		out[cur + 1] = rf[k];
 		out[cur + 2] = cf[k];
-		LFE_buf[lfe_pos] = (out[cur + 0] + out[cur + 1]) / 2;
+		LFE_buf[lfe_pos] = (lf[k] + rf[k] + 2.0 * cf[k] + lr[k] + rr[k]) / 2.0;
 		out[cur + 3] = FIRFilter(LFE_buf, lfe_pos, len125, len125, filter_coefs_lfe);
 		lfe_pos++;
 		if (lfe_pos == len125)

--- a/Source/Core/AudioCommon/DPL2Decoder.cpp
+++ b/Source/Core/AudioCommon/DPL2Decoder.cpp
@@ -361,7 +361,7 @@ void DPL2Decode(float *samples, int numsamples, float *out)
 		out[cur + 0] = lf[k];
 		out[cur + 1] = rf[k];
 		out[cur + 2] = cf[k];
-		LFE_buf[lfe_pos] = (out[0] + out[1]) / 2;
+		LFE_buf[lfe_pos] = (out[cur + 0] + out[cur + 1]) / 2;
 		out[cur + 3] = FIRFilter(LFE_buf, lfe_pos, len125, len125, filter_coefs_lfe);
 		lfe_pos++;
 		if (lfe_pos == len125)


### PR DESCRIPTION
The FIR filter was only using the first sample of each input packet.
Tested with Eternal Darkness and the new Pulse 5.1 backend (though OpenAL will also see the same benefits) - much improved LFE.