### PR TITLE
Video: Distinguish between interlace and non-interlace X11 XRANDR modes

### DIFF
--- a/Source/Core/DolphinWX/X11Utils.cpp
+++ b/Source/Core/DolphinWX/X11Utils.cpp
@@ -144,7 +144,6 @@ void XRRConfiguration::Update()
 	{
 		sscanf(SConfig::GetInstance().m_LocalCoreStartupParameter.strFullscreenResolution.c_str(),
 				"%m[^:]: %ux%u%c", &output_name, &fullWidth, &fullHeight, &auxFlag);
-		ERROR_LOG(AUDIO, "auxflag = %c", auxFlag);
 	}
 	bool want_interlaced = ('i' == auxFlag);
 

--- a/Source/Core/DolphinWX/X11Utils.cpp
+++ b/Source/Core/DolphinWX/X11Utils.cpp
@@ -173,11 +173,6 @@ void XRRConfiguration::Update()
 						{
 							if (output_info->modes[j] == screenResources->modes[k].id)
 							{
-								std::string modename(screenResources->modes[k].name, screenResources->modes[k].nameLength);
-								ERROR_LOG(AUDIO, "%dx%d: %d %08x / %s", screenResources->modes[k].width,
-										screenResources->modes[k].height,
-										screenResources->modes[k].dotClock,
-										screenResources->modes[k].modeFlags, modename.c_str());
 								if (fullWidth == screenResources->modes[k].width &&
 										fullHeight == screenResources->modes[k].height &&
 										want_interlaced == !!(screenResources->modes[k].modeFlags & RR_Interlace))


### PR DESCRIPTION
The XRANDR code was treating available interlace and progressive modes of the same resolutions as equivalent.  As it happens, a monitor (like mine!) might support (say) both 1080i and 1080p, but 1080i was always chosen because it was the first found.  This change makes the UI and the mode code distinguish between interlaced and progressive modes.