### PR TITLE
DVDInterface: Read disc after delay, not before

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -232,8 +232,14 @@ void ScheduleEvent_Threadsafe(int cyclesIntoFuture, int event_type, u64 userdata
 	tsQueue.Push(ne);
 }
 
+// Executes an event immediately, then returns.
+void ScheduleEvent_Immediate(int event_type, u64 userdata)
+{
+	event_types[event_type].callback(userdata, 0);
+}
+
 // Same as ScheduleEvent_Threadsafe(0, ...) EXCEPT if we are already on the CPU thread
-// in which case the event will get handled immediately, before returning.
+// in which case this is the same as ScheduleEvent_Immediate.
 void ScheduleEvent_Threadsafe_Immediate(int event_type, u64 userdata)
 {
 	if (Core::IsCPUThread())

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -43,11 +43,11 @@ void DoState(PointerWrap &p);
 int RegisterEvent(const std::string& name, TimedCallback callback);
 void UnregisterAllEvents();
 
-// userdata MAY NOT CONTAIN POINTERS. userdata might get written and reloaded from disk,
-// when we implement state saves.
-void ScheduleEvent(int cyclesIntoFuture, int event_type, u64 userdata=0);
-void ScheduleEvent_Threadsafe(int cyclesIntoFuture, int event_type, u64 userdata=0);
-void ScheduleEvent_Threadsafe_Immediate(int event_type, u64 userdata=0);
+// userdata MAY NOT CONTAIN POINTERS. userdata might get written and reloaded from savestates.
+void ScheduleEvent(int cyclesIntoFuture, int event_type, u64 userdata = 0);
+void ScheduleEvent_Immediate(int event_type, u64 userdata = 0);
+void ScheduleEvent_Threadsafe(int cyclesIntoFuture, int event_type, u64 userdata = 0);
+void ScheduleEvent_Threadsafe_Immediate(int event_type, u64 userdata = 0);
 
 // We only permit one event of each type in the queue at a time.
 void RemoveEvent(int event_type);

--- a/Source/Core/Core/HW/DVDInterface.h
+++ b/Source/Core/Core/HW/DVDInterface.h
@@ -105,7 +105,7 @@ void ChangeDisc(const std::string& fileName);
 // DVD Access Functions
 bool DVDRead(u64 _iDVDOffset, u32 _iRamAddress, u32 _iLength, bool decrypt);
 extern bool g_bStream;
-DVDCommandResult ExecuteCommand(u32 command_0, u32 command_1, u32 command_2,
-	u32 output_address, u32 output_length, bool write_to_DIIMMBUF);
+void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_address, u32 output_length,
+                    bool write_to_DIIMMBUF, int callback_event_type);
 
 } // end of namespace DVDInterface

--- a/Source/Core/Core/HW/DVDInterface.h
+++ b/Source/Core/Core/HW/DVDInterface.h
@@ -85,12 +85,6 @@ enum DIInterruptType
 	INT_CVRINT = 3,
 };
 
-struct DVDCommandResult
-{
-	DIInterruptType interrupt_type;
-	u64 ticks_until_completion;
-};
-
 void Init();
 void Shutdown();
 void DoState(PointerWrap &p);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -85,7 +85,7 @@ static u64 last_reply_time;
 
 static const u64 ENQUEUE_REQUEST_FLAG = 0x100000000ULL;
 static const u64 ENQUEUE_ACKNOWLEDGEMENT_FLAG = 0x200000000ULL;
-static void EnqueueEventCallback(u64 userdata, int)
+static void EnqueueEvent(u64 userdata, int cycles_late = 0)
 {
 	if (userdata & ENQUEUE_ACKNOWLEDGEMENT_FLAG)
 	{
@@ -144,7 +144,7 @@ void Init()
 	g_DeviceMap[i] = new CWII_IPC_HLE_Device_stub(i, "/dev/usb/oh1"); i++;
 	g_DeviceMap[i] = new IWII_IPC_HLE_Device(i, "_Unimplemented_Device_"); i++;
 
-	event_enqueue = CoreTiming::RegisterEvent("IPCEvent", EnqueueEventCallback);
+	event_enqueue = CoreTiming::RegisterEvent("IPCEvent", EnqueueEvent);
 }
 
 void Reset(bool _bHard)
@@ -561,6 +561,11 @@ void EnqueueReply(u32 address, int cycles_in_future)
 void EnqueueReply_Threadsafe(u32 address, int cycles_in_future)
 {
 	CoreTiming::ScheduleEvent_Threadsafe(cycles_in_future, event_enqueue, address);
+}
+
+void EnqueueReply_Immediate(u32 address)
+{
+	EnqueueEvent(address);
 }
 
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -80,6 +80,7 @@ void ExecuteCommand(u32 _Address);
 void EnqueueRequest(u32 address);
 void EnqueueReply(u32 address, int cycles_in_future = 0);
 void EnqueueReply_Threadsafe(u32 address, int cycles_in_future = 0);
+void EnqueueReply_Immediate(u32 address);
 void EnqueueCommandAcknowledgement(u32 _Address, int cycles_in_future = 0);
 
 } // end of namespace WII_IPC_HLE_Interface

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -67,9 +67,6 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
 	                                         BufferOut, BufferOutSize, false);
 	Memory::Write_U32(result.interrupt_type, _CommandAddress + 0x4);
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bFastDiscSpeed)
-		result.ticks_until_completion = 0;	// An optional hack to speed up loading times
-
 	return { true, result.ticks_until_completion };
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -9,6 +9,7 @@
 #include "Common/Logging/LogManager.h"
 
 #include "Core/ConfigManager.h"
+#include "Core/CoreTiming.h"
 #include "Core/VolumeHandler.h"
 #include "Core/HW/DVDInterface.h"
 #include "Core/HW/Memmap.h"
@@ -17,14 +18,38 @@
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_DI.h"
 
-using namespace DVDInterface;
+static CWII_IPC_HLE_Device_di* g_di_pointer;
+static int ioctl_callback;
 
-CWII_IPC_HLE_Device_di::CWII_IPC_HLE_Device_di(u32 _DeviceID, const std::string& _rDeviceName )
+static void IOCtlCallback(u64 userdata, int cycles_late)
+{
+	if (g_di_pointer != nullptr)
+		g_di_pointer->FinishIOCtl((DVDInterface::DIInterruptType)userdata);
+
+	// If g_di_pointer == nullptr, IOS was probably shut down,
+	// so the command shouldn't be completed
+}
+
+CWII_IPC_HLE_Device_di::CWII_IPC_HLE_Device_di(u32 _DeviceID, const std::string& _rDeviceName)
 	: IWII_IPC_HLE_Device(_DeviceID, _rDeviceName)
-{}
+{
+	if (g_di_pointer == nullptr)
+		ERROR_LOG(WII_IPC_DVD, "Trying to run two DI devices at once. IOCtl may not behave as expected.");
+
+	g_di_pointer = this;
+	ioctl_callback = CoreTiming::RegisterEvent("IOCtlCallbackDI", IOCtlCallback);
+}
 
 CWII_IPC_HLE_Device_di::~CWII_IPC_HLE_Device_di()
-{}
+{
+	g_di_pointer = nullptr;
+}
+
+void CWII_IPC_HLE_Device_di::DoState(PointerWrap& p)
+{
+	DoStateShared(p);
+	p.Do(m_commands_to_execute);
+}
 
 IPCCommandResult CWII_IPC_HLE_Device_di::Open(u32 _CommandAddress, u32 _Mode)
 {
@@ -43,10 +68,29 @@ IPCCommandResult CWII_IPC_HLE_Device_di::Close(u32 _CommandAddress, bool _bForce
 
 IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
 {
-	u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-	u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-	u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-	u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
+	// DI IOCtls are handled in a special way by Dolphin
+	// compared to other WII_IPC_HLE functions.
+	// This is a wrapper around DVDInterface's ExecuteCommand,
+	// which will execute commands more or less asynchronously.
+	// Only one command can be executed at a time, so commands
+	// are queued until DVDInterface is ready to handle them.
+
+	bool ready_to_execute = m_commands_to_execute.empty();
+	m_commands_to_execute.push_back(_CommandAddress);
+	if (ready_to_execute)
+		StartIOCtl(_CommandAddress);
+
+	// DVDInterface handles the timing, and we handle the reply,
+	// so WII_IPC_HLE shouldn't do any of that.
+	return IPC_NO_REPLY;
+}
+
+void CWII_IPC_HLE_Device_di::StartIOCtl(u32 command_address)
+{
+	u32 BufferIn = Memory::Read_U32(command_address + 0x10);
+	u32 BufferInSize = Memory::Read_U32(command_address + 0x14);
+	u32 BufferOut = Memory::Read_U32(command_address + 0x18);
+	u32 BufferOutSize = Memory::Read_U32(command_address + 0x1C);
 
 	u32 command_0 = Memory::Read_U32(BufferIn);
 	u32 command_1 = Memory::Read_U32(BufferIn + 4);
@@ -63,11 +107,38 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
 		Memory::Memset(BufferOut, 0, BufferOutSize);
 	}
 
-	DVDCommandResult result = ExecuteCommand(command_0, command_1, command_2,
-	                                         BufferOut, BufferOutSize, false);
-	Memory::Write_U32(result.interrupt_type, _CommandAddress + 0x4);
+	// DVDInterface's ExecuteCommand handles most of the work.
+	// The IOCtl callback is used to generate a reply afterwards.
+	DVDInterface::ExecuteCommand(command_0, command_1, command_2, BufferOut, BufferOutSize,
+	                             false, ioctl_callback);
+}
 
-	return { true, result.ticks_until_completion };
+void CWII_IPC_HLE_Device_di::FinishIOCtl(DVDInterface::DIInterruptType interrupt_type)
+{
+	if (m_commands_to_execute.empty())
+	{
+		PanicAlertT("WII_IPC_HLE_Device_DI tried to reply to non-existing command");
+		return;
+	}
+
+	// This command has been executed, so it's removed from the queue
+	u32 command_address = m_commands_to_execute.front();
+	m_commands_to_execute.pop_front();
+
+	// The DI interrupt type is used as a return value
+	Memory::Write_U32(interrupt_type, command_address + 4);
+
+	// The original hardware overwrites the command type with the async reply type.
+	Memory::Write_U32(IPC_REP_ASYNC, command_address);
+	// IOS also seems to write back the command that was responded to in the FD field.
+	Memory::Write_U32(Memory::Read_U32(command_address), command_address + 8);
+	// Generate a reply to the IPC command
+	WII_IPC_HLE_Interface::EnqueueReply_Immediate(command_address);
+
+	// DVDInterface is now ready to execute another command,
+	// so we start executing a command from the queue if there is one
+	if (!m_commands_to_execute.empty())
+		StartIOCtl(m_commands_to_execute.front());
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
@@ -85,7 +156,7 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
 	u32 ReturnValue = 0;
 	switch (CommandBuffer.Parameter)
 	{
-	case DVDLowOpenPartition:
+	case DVDInterface::DVDLowOpenPartition:
 		{
 			_dbg_assert_msg_(WII_IPC_DVD, CommandBuffer.InBuffer[1].m_Address == 0, "DVDLowOpenPartition with ticket");
 			_dbg_assert_msg_(WII_IPC_DVD, CommandBuffer.InBuffer[2].m_Address == 0, "DVDLowOpenPartition with cert chain");

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
@@ -4,13 +4,9 @@
 
 #pragma once
 
+#include <deque>
+#include "Core/HW/DVDInterface.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
-
-namespace DiscIO
-{
-	class IVolume;
-	class IFileSystem;
-}
 
 class CWII_IPC_HLE_Device_di : public IWII_IPC_HLE_Device
 {
@@ -20,9 +16,18 @@ public:
 
 	virtual ~CWII_IPC_HLE_Device_di();
 
+	void DoState(PointerWrap& p) override;
+
 	IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
 	IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
 	IPCCommandResult IOCtl(u32 _CommandAddress) override;
 	IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+
+	void FinishIOCtl(DVDInterface::DIInterruptType interrupt_type);
+private:
+
+	void StartIOCtl(u32 command_address);
+
+	std::deque<u32> m_commands_to_execute;
 };

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -64,7 +64,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 39;
+static const u32 STATE_VERSION = 40;
 
 enum
 {


### PR DESCRIPTION
DVDInterface behavior before 4.0-4222:
* Receive and parse command
* Wait for a while to simulate loading times
* Read data from disc image and copy to emulator memory
* Reply to command

DVDInterface behavior starting with 4.0-4222:
* Receive and parse command
* Read data from disc image and copy to emulator memory
* Wait for a while to simulate loading times
* Reply to command

The former is obviously more accurate, because a real console isn't able to copy all the data to RAM before it has finished reading it from the disc. I changed it in order to not make the code unnecessarily complicated when adding a few things... and games shouldn't be reading the memory that is being copied to, right? Unfortunately, Resident Evil 3 does exactly that, and plays incorrect audio starting with 4.0-2222: https://code.google.com/p/dolphin-emu/issues/detail?id=8026

The main obstacle to reverting the order things happen in is that WII_IPC_HLE only can schedule a "reply to command" event, not arbitrary things like "read disc data and reply to command" that we would need. Because of this, WII_IPC_HLE_Device_DI::IOCtl now returns false and lets DVDInterface::ExecuteCommand schedule an event instead. A second obstacle is that the scheduled event needs to know what data to read. Since DVDInterface now supports WII_IPC_HLE_Device_DI, we can't just read the hardware registers like before 4.0-4222. We can't use pointers in the event userdata either, because it would break savestates. The solution I used is a deque, where a function looks up commands based on an ID that is passed as userdata.

Most of this solution is actually based on my plans for making a separate thread for disc IO. That has additional reasons for not letting WII_IPC_HLE schedule reads, mainly that it would be nice to be able to finish reads right after the disc IO thread finishes reading from the disc image, but I think this solution is OK for the current requirements too. The good thing is that most of the code in this PR can be used without any change when/if a disc IO thread is made, instead of having to write something similar again.

Because this touches WII_IPC_HLE timing, chances are that it will break stuff.