### PR TITLE
Allow NetPlay's Initial GCTime to be set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ Source/Core/Common/scmrev.h
 *.vcxproj.user
 *.obj
 *.tlog
+ninjabuild/
+
 # Ignore build info file created by QtCreator
 CMakeLists.txt.user
 # Ignore files created by posix people

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -182,6 +182,7 @@ void SConfig::SaveSettings()
 	SaveDSPSettings(ini);
 	SaveInputSettings(ini);
 	SaveFifoPlayerSettings(ini);
+	SaveNetPlaySettings(ini);
 
 	ini.Save(File::GetUserPath(F_DOLPHINCONFIG_IDX));
 	m_SYSCONF->Save();
@@ -385,7 +386,12 @@ void SConfig::SaveFifoPlayerSettings(IniFile& ini)
 
 	fifoplayer->Set("LoopReplay", m_LocalCoreStartupParameter.bLoopFifoReplay);
 }
-
+void SConfig::SaveNetPlaySettings(IniFile& ini)
+{
+	IniFile::Section* netplay = ini.GetOrCreateSection("NetPlay");
+	
+	netplay->Set("InitialGCTime", m_NetPlayInitialGCTime);
+}
 void SConfig::LoadSettings()
 {
 	INFO_LOG(BOOT, "Loading Settings from %s", File::GetUserPath(F_DOLPHINCONFIG_IDX).c_str());
@@ -402,6 +408,7 @@ void SConfig::LoadSettings()
 	LoadDSPSettings(ini);
 	LoadInputSettings(ini);
 	LoadFifoPlayerSettings(ini);
+	LoadNetPlaySettings(ini);
 
 	m_SYSCONF = new SysConf();
 }
@@ -632,4 +639,9 @@ void SConfig::LoadFifoPlayerSettings(IniFile& ini)
 	IniFile::Section* fifoplayer = ini.GetOrCreateSection("FifoPlayer");
 
 	fifoplayer->Get("LoopReplay", &m_LocalCoreStartupParameter.bLoopFifoReplay, true);
+}
+void SConfig::LoadNetPlaySettings(IniFile &ini)
+{
+	IniFile::Section* netplay = ini.GetOrCreateSection("NetPlay");
+	netplay->Get("InitialGCTime", &m_NetPlayInitialGCTime, 1272737767);
 }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -110,6 +110,9 @@ struct SConfig : NonCopyable
 	bool m_BackgroundInput;
 	bool m_GameCubeAdapter;
 	bool m_GameCubeAdapterThread;
+	
+	// Netplay Settings
+	int m_NetPlayInitialGCTime;
 
 	SysConf* m_SYSCONF;
 
@@ -139,6 +142,8 @@ private:
 	void SaveInputSettings(IniFile& ini);
 	void SaveMovieSettings(IniFile& ini);
 	void SaveFifoPlayerSettings(IniFile& ini);
+	void SaveNetPlaySettings(IniFile& ini);
+
 
 	void LoadGeneralSettings(IniFile& ini);
 	void LoadInterfaceSettings(IniFile& ini);
@@ -150,6 +155,7 @@ private:
 	void LoadInputSettings(IniFile& ini);
 	void LoadMovieSettings(IniFile& ini);
 	void LoadFifoPlayerSettings(IniFile& ini);
+	void LoadNetPlaySettings(IniFile& ini);
 
 	static SConfig* m_Instance;
 };

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -454,7 +454,7 @@ bool BeginRecordingInput(int controllers)
 	if (NetPlay::IsNetPlayRunning())
 	{
 		s_bNetPlay = true;
-		s_recordingStartTime = NETPLAY_INITIAL_GCTIME;
+		s_recordingStartTime = g_NetplayInitialGCTime;
 	}
 	else
 	{

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -27,7 +27,10 @@ NetPlayClient::~NetPlayClient()
 	// not perfect
 	if (m_is_running)
 		StopGame();
-
+	
+	// incase it was changed by the server
+	g_NetplayInitialGCTime = SConfig::GetInstance().m_NetPlayInitialGCTime;
+	
 	if (is_connected)
 	{
 		m_do_loop = false;
@@ -218,13 +221,21 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
 		}
 		break;
 
-
 	case NP_MSG_PAD_BUFFER :
 		{
 			u32 size = 0;
 			packet >> size;
 
 			m_target_buffer_size = size;
+		}
+		break;
+			
+	case NP_MSG_INITIAL_GCTIME :
+		{
+			int gctime = 0;
+			packet >> gctime;
+			
+			g_NetplayInitialGCTime = gctime;
 		}
 		break;
 
@@ -842,7 +853,7 @@ u32 CEXIIPL::NetPlay_GetGCTime()
 	std::lock_guard<std::mutex> lk(crit_netplay_client);
 
 	if (netplay_client)
-		return NETPLAY_INITIAL_GCTIME; // watev
+		return g_NetplayInitialGCTime; // watev
 	else
 		return 0;
 }

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -30,7 +30,7 @@ typedef std::vector<u8> NetWiimote;
 
 #define NETPLAY_VERSION  "Dolphin NetPlay 2014-01-08"
 
-const int NETPLAY_INITIAL_GCTIME = 1272737767;
+extern int g_NetplayInitialGCTime = 1272737767;
 
 
 // messages
@@ -40,6 +40,8 @@ enum
 	NP_MSG_PLAYER_LEAVE     = 0x11,
 
 	NP_MSG_CHAT_MESSAGE     = 0x30,
+	
+	NP_MSG_INITIAL_GCTIME   = 0x40,
 
 	NP_MSG_PAD_DATA         = 0x60,
 	NP_MSG_PAD_MAPPING      = 0x61,

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/StdMakeUnique.h"
 #include "Common/StringUtil.h"
+#include "Core/ConfigManager.h"
 #include "Core/NetPlayServer.h"
 #include "InputCommon/GCPadStatus.h"
 
@@ -40,6 +41,7 @@ NetPlayServer::NetPlayServer(const u16 port) : is_connected(false), m_is_running
 		m_thread = std::thread(&NetPlayServer::ThreadFunc, this);
 		m_target_buffer_size = 5;
 	}
+	g_NetplayInitialGCTime = SConfig::GetInstance().m_NetPlayInitialGCTime;
 }
 
 // called from ---NETPLAY--- thread
@@ -203,6 +205,11 @@ unsigned int NetPlayServer::OnConnect(std::unique_ptr<sf::TcpSocket>& socket)
 	spac.clear();
 	spac << (MessageId)NP_MSG_PAD_BUFFER;
 	spac << (u32)m_target_buffer_size;
+	player.socket->send(spac);
+		
+	spac.clear();
+	spac << (MessageId)NP_MSG_INITIAL_GCTIME;
+	spac << g_NetplayInitialGCTime;
 	player.socket->send(spac);
 
 	// sync values with new client


### PR DESCRIPTION
Fixed [Issue #8030](https://code.google.com/p/dolphin-emu/issues/detail?id=8030)

So, these changes allows people to set the initial GCTime for NetPlay, which is the time netplay sets for everyone to keep them sync'd.  How it works, is that the server will load the time from the ini, and then send to the clients when they connect. 

I have not added this to the GUI in any way, as I do not know if it should be in the GUI.  I feel it might just confuse people.