### PR TITLE
WiimoteReal: improve Linux Bluetooth connectivity.

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IONix.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IONix.cpp
@@ -166,7 +166,7 @@ WiimoteLinux::~WiimoteLinux()
 // Connect to a wiimote with a known address.
 bool WiimoteLinux::ConnectInternal()
 {
-	sockaddr_l2 addr;
+	sockaddr_l2 addr = {};
 	addr.l2_family = AF_BLUETOOTH;
 	addr.l2_bdaddr = m_bdaddr;
 	addr.l2_cid = 0;
@@ -176,7 +176,7 @@ bool WiimoteLinux::ConnectInternal()
 	if ((m_cmd_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP)) == -1 ||
 	                  connect(m_cmd_sock, (sockaddr*)&addr, sizeof(addr)) < 0)
 	{
-		DEBUG_LOG(WIIMOTE, "Unable to open output socket to wiimote.");
+		DEBUG_LOG(WIIMOTE, "Unable to open output socket to wiimote: %s", strerror(errno));
 		close(m_cmd_sock);
 		m_cmd_sock = -1;
 		return false;
@@ -187,7 +187,7 @@ bool WiimoteLinux::ConnectInternal()
 	if ((m_int_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP)) == -1 ||
 	                  connect(m_int_sock, (sockaddr*)&addr, sizeof(addr)) < 0)
 	{
-		DEBUG_LOG(WIIMOTE, "Unable to open input socket from wiimote.");
+		DEBUG_LOG(WIIMOTE, "Unable to open input socket from wiimote: %s", strerror(errno));
 		close(m_int_sock);
 		close(m_cmd_sock);
 		m_int_sock = m_cmd_sock = -1;

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -530,6 +530,13 @@ void Wiimote::ThreadFunc()
 
 	bool ok = ConnectInternal();
 
+	if (!ok)
+	{
+		// try again, it might take a moment to settle
+		Common::SleepCurrentThread(100);
+		ok = ConnectInternal();
+	}
+
 	SetReady();
 
 	if (!ok)


### PR DESCRIPTION
An uninitialized struct member was making most connect calls fail
with "Invalid argument". The connection would occasionally succeed if the
unitialized memory happened to have a zero byte in the appropriate location.

Also, retry a failed connection after a short delay -- hardware sometimes
needs some time to settle, or other Bluetooth programs are attempting to query
the device as well (e.g. blueman-manager).