### PR TITLE
Implemented missing pixel data reinterpretation shaders in D3D backend

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.h
@@ -31,8 +31,12 @@ public:
 	static ID3D11PixelShader* GetDepthMatrixProgram(bool multisampled);
 	static ID3D11PixelShader* GetClearProgram();
 	static ID3D11PixelShader* GetAnaglyphProgram();
-	static ID3D11PixelShader* ReinterpRGBA6ToRGB8(bool multisampled);
 	static ID3D11PixelShader* ReinterpRGB8ToRGBA6(bool multisampled);
+	static ID3D11PixelShader* ReinterpRGB8ToRGB565(bool multisampled);
+	static ID3D11PixelShader* ReinterpRGBA6ToRGB8(bool multisampled);
+	static ID3D11PixelShader* ReinterpRGBA6ToRGB565(bool multisampled);
+	static ID3D11PixelShader* ReinterpRGB565ToRGB8(bool multisampled);
+	static ID3D11PixelShader* ReinterpRGB565ToRGBA6(bool multisampled);
 
 	static void InvalidateMSAAShaders();
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -560,7 +560,7 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
 	D3D11_RECT source = CD3D11_RECT(0, 0, g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight());
 
 	ID3D11PixelShader* pixel_shader;
-	switch (convtype) 
+	switch (convtype)
 	{
 		case 0:
 			pixel_shader = PixelShaderCache::ReinterpRGB8ToRGBA6(true);

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -560,12 +560,29 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
 	D3D11_RECT source = CD3D11_RECT(0, 0, g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight());
 
 	ID3D11PixelShader* pixel_shader;
-	if (convtype == 0) pixel_shader = PixelShaderCache::ReinterpRGB8ToRGBA6(true);
-	else if (convtype == 2) pixel_shader = PixelShaderCache::ReinterpRGBA6ToRGB8(true);
-	else
+	switch (convtype) 
 	{
-		ERROR_LOG(VIDEO, "Trying to reinterpret pixel data with unsupported conversion type %d", convtype);
-		return;
+		case 0:
+			pixel_shader = PixelShaderCache::ReinterpRGB8ToRGBA6(true);
+			break;
+		case 1:
+			pixel_shader = PixelShaderCache::ReinterpRGB8ToRGB565(true);
+			break;
+		case 2:
+			pixel_shader = PixelShaderCache::ReinterpRGBA6ToRGB8(true);
+			break;
+		case 3:
+			pixel_shader = PixelShaderCache::ReinterpRGBA6ToRGB565(true);
+			break;
+		case 4:
+			pixel_shader = PixelShaderCache::ReinterpRGB565ToRGB8(true);
+			break;
+		case 5:
+			pixel_shader = PixelShaderCache::ReinterpRGB565ToRGBA6(true);
+			break;
+		default:
+			ERROR_LOG(VIDEO, "Trying to reinterpret pixel data with unsupported conversion type %d", convtype);
+			return;
 	}
 
 	// convert data and set the target texture as our new EFB


### PR DESCRIPTION
I used the 2 shaders that were already implemented as a basis for the additional 4. This is for D3D only, since I wanted someone to look at this PR first before porting it to OGL.

RS2 is known to complain a about 1, 4, and 5 missing during the dance. However, as far as I can tell it only acts on the black "sky" pixels. I was unable to test anything past that as I couldn't get the debug build to give me more than 1fps.