### PR TITLE
StringUtils: use C locale instead of .1252

### DIFF
--- a/Source/Core/Common/StringUtil.h
+++ b/Source/Core/Common/StringUtil.h
@@ -65,7 +65,7 @@ static bool TryParse(const std::string &str, N *const output)
 {
 	std::istringstream iss(str);
 	// is this right? not doing this breaks reading floats on locales that use different decimal separators
-	iss.imbue(std::locale(".1252"));
+	iss.imbue(std::locale("C"));
 
 	N tmp = 0;
 	if (iss >> tmp)


### PR DESCRIPTION
Fixes regression on Linux.