### PR TITLE
Made the CPU thread wait for the GPU thread to swap

### DIFF
--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -125,6 +125,12 @@ void VideoBackendHardware::Video_EndField()
 	if (s_BackendInitialized)
 	{
 		SyncGPU(SYNC_GPU_SWAP);
+
+		// Wait until the GPU thread has swapped. Prevents FIFO overflows.
+		while (g_ActiveConfig.bUseXFB && SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread && s_swapRequested.IsSet())
+		{
+			Common::YieldCPU();
+		}
 		s_swapRequested.Set();
 	}
 }


### PR DESCRIPTION
Made the CPU thread wait for the GPU thread to swap, when XFB is enabled. May fix some of the "FIFO is overflowed by GatherPipe ! CPU thread is too fast!" errors.