### PR TITLE
For idle loops, perform an exception check before CoreTiming::Advance.

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -479,8 +479,6 @@ void Idle()
 
 	idledCycles += DowncountToCycles(PowerPC::ppcState.downcount);
 	PowerPC::ppcState.downcount = 0;
-
-	Advance();
 }
 
 std::string GetScheduledEventsSummary()

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -134,7 +134,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
 		BitSet32 registersInUse = CallerSavedRegistersInUse();
 		ABI_PushRegistersAndAdjustStack(registersInUse, 0);
 
-		ABI_CallFunctionC((void *)&PowerPC::OnIdle, PowerPC::ppcState.gpr[a] + (s32)(s16)inst.SIMM_16);
+		ABI_CallFunction((void *)&PowerPC::OnIdle);
 
 		ABI_PopRegistersAndAdjustStack(registersInUse, 0);
 

--- a/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
@@ -2088,7 +2088,7 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 			FixupBranch noidle = Jit->J_CC(CC_NZ);
 
 			RI.Jit->Cleanup(); // is it needed?
-			Jit->ABI_CallFunction((void *)&PowerPC::OnIdleIL);
+			Jit->ABI_CallFunction((void *)&PowerPC::OnIdle);
 
 			Jit->MOV(32, PPCSTATE(pc), Imm32(ibuild->GetImmValue( getOp2(I) )));
 			Jit->WriteExceptionExit();

--- a/Source/Core/Core/PowerPC/JitArm32/JitArm_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitArm_LoadStore.cpp
@@ -464,7 +464,6 @@ void JitArm::lXX(UGeckoInstruction inst)
 		rA = gpr.GetReg();
 
 		MOVI2R(rA, (u32)&PowerPC::OnIdle);
-		MOVI2R(R0, PowerPC::ppcState.gpr[a] + (s32)(s16)inst.SIMM_16);
 		BL(rA);
 
 		gpr.Unlock(rA);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -344,7 +344,6 @@ void JitArm64::lXX(UGeckoInstruction inst)
 		ARM64Reg XA = EncodeRegTo64(WA);
 
 		MOVI2R(XA, (u64)&PowerPC::OnIdle);
-		MOVI2R(W0, PowerPC::ppcState.gpr[a] + (s32)(s16)inst.SIMM_16);
 		BLR(XA);
 
 		gpr.Unlock(WA);

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -510,15 +510,7 @@ void CheckBreakPoints()
 	}
 }
 
-void OnIdle(u32 _uThreadAddr)
-{
-	u32 nextThread = Memory::Read_U32(_uThreadAddr);
-	//do idle skipping
-	if (nextThread == 0)
-		CoreTiming::Idle();
-}
-
-void OnIdleIL()
+void OnIdle()
 {
 	CoreTiming::Idle();
 }

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -153,8 +153,7 @@ volatile CPUState *GetStatePtr();  // this oddity is here instead of an extern d
 u32 CompactCR();
 void ExpandCR(u32 cr);
 
-void OnIdle(u32 _uThreadAddr);
-void OnIdleIL();
+void OnIdle();
 
 void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst);
 


### PR DESCRIPTION
This is more consistent with the way Dolphin behaves with idle skipping off.