### PR TITLE
D3D: Fix Dolphin immediately exiting exclusive fullscreen.

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1398,8 +1398,7 @@ void CFrame::DoFullscreen(bool enable_fullscreen)
 		m_RenderFrame->Raise();
 	}
 
-	g_Config.bFullscreen = (!g_Config.ExclusiveFullscreenEnabled() ||
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain) ? false : enable_fullscreen;
+	g_Config.bFullscreen = enable_fullscreen;
 }
 
 const CGameListCtrl *CFrame::GetGameListCtrl() const

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -211,6 +211,11 @@ bool CRenderFrame::ShowFullScreen(bool show, long style)
 	{
 		// OpenGL requires the pop-up style to activate exclusive mode.
 		SetWindowStyle((GetWindowStyle() & ~wxDEFAULT_FRAME_STYLE) | wxPOPUP_WINDOW);
+
+		// Some backends don't support exclusive fullscreen, so we
+		// can't tell exactly when exclusive mode is activated.
+		if (!g_Config.backend_info.bSupportsExclusiveFullscreen)
+			OSD::AddMessage("Enabled exclusive fullscreen.");
 	}
 #endif
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1319,13 +1319,11 @@ void CFrame::OnMouse(wxMouseEvent& event)
 
 void CFrame::DoFullscreen(bool enable_fullscreen)
 {
-	if (g_Config.ExclusiveFullscreenEnabled() &&
-		!SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain &&
-		Core::GetState() == Core::CORE_PAUSE)
+	if (g_Config.bExclusiveMode && Core::GetState() == Core::CORE_PAUSE)
 	{
 		// A responsive renderer is required for exclusive fullscreen, but the
 		// renderer can only respond in the running state. Therefore we ignore
-		// fullscreen switches if we support exclusive fullscreen, but the
+		// fullscreen switches if we are in exclusive fullscreen, but the
 		// renderer is not running.
 		// TODO: Allow the renderer to switch fullscreen modes while paused.
 		return;
@@ -1346,11 +1344,10 @@ void CFrame::DoFullscreen(bool enable_fullscreen)
 	{
 		m_RenderFrame->ShowFullScreen(true, wxFULLSCREEN_ALL);
 	}
-	else if (!g_Config.ExclusiveFullscreenEnabled() ||
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain)
+	else if (!g_Config.bExclusiveMode)
 	{
 		// Exiting exclusive fullscreen should be done from a Renderer callback.
-		// Therefore we don't exit fullscreen from here if we support exclusive mode.
+		// Therefore we don't exit fullscreen from here if we are in exclusive mode.
 		m_RenderFrame->ShowFullScreen(false, wxFULLSCREEN_ALL);
 	}
 #endif

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -891,20 +891,10 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 			// we can apply exclusive mode.
 			fullscreen_changed = Host_RendererHasFocus();
 		}
-		else if (!fullscreen)
+		else if (!fullscreen && exclusive_mode)
 		{
-			if (exclusive_mode)
-			{
-				// Exclusive fullscreen is disabled, but we're still in exclusive mode.
-				fullscreen_changed = true;
-			}
-			else if (!g_ActiveConfig.bBorderlessFullscreen && Host_RendererIsFullscreen())
-			{
-				// Exclusive fullscreen is disabled and we are no longer in exclusive
-				// mode. Thus we can now safely notify the UI to exit fullscreen. But
-				// we should only do so if borderless fullscreen mode is disabled.
-				Host_RequestFullscreen(false);
-			}
+			// Exclusive fullscreen is disabled, but we're still in exclusive mode.
+			fullscreen_changed = true;
 		}
 	}
 
@@ -924,7 +914,13 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 		{
 			// Apply fullscreen state
 			if (fullscreen_changed)
+			{
 				D3D::SetFullscreenState(fullscreen);
+
+				// If exclusive fullscreen is disabled we can safely notify the UI to exit fullscreen.
+				if (!fullscreen)
+					Host_RequestFullscreen(false);
+			}
 
 			// TODO: Aren't we still holding a reference to the back buffer right now?
 			D3D::Reset();

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -43,6 +43,7 @@ namespace DX11
 static u32 s_last_multisample_mode = 0;
 static bool s_last_stereo_mode = false;
 static bool s_last_xfb_mode = false;
+static bool s_last_fullscreen = false;
 
 static Television s_television;
 
@@ -230,6 +231,7 @@ Renderer::Renderer(void *&window_handle)
 	s_last_efb_scale = g_ActiveConfig.iEFBScale;
 	s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
 	s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
+	s_last_fullscreen = g_ActiveConfig.bFullscreen;
 	CalculateTargetSize(s_backbuffer_width, s_backbuffer_height);
 
 	SetupDeviceObjects();
@@ -885,6 +887,11 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 	{
 		if (fullscreen && !exclusive_mode)
 		{
+			if (s_last_fullscreen)
+				OSD::AddMessage("Lost exclusive fullscreen.");
+
+			s_last_fullscreen = false;
+
 			// Exclusive fullscreen is enabled in the configuration, but we're
 			// not in exclusive mode. Either exclusive fullscreen was turned on
 			// or the render frame lost focus. When the render frame is in focus
@@ -915,6 +922,11 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 			// Apply fullscreen state
 			if (fullscreen_changed)
 			{
+				s_last_fullscreen = fullscreen;
+
+				if (fullscreen)
+					OSD::AddMessage("Entered exclusive fullscreen.");
+
 				D3D::SetFullscreenState(fullscreen);
 
 				// If fullscreen is disabled we can safely notify the UI to exit fullscreen.

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -43,7 +43,6 @@ namespace DX11
 static u32 s_last_multisample_mode = 0;
 static bool s_last_stereo_mode = false;
 static bool s_last_xfb_mode = false;
-static bool s_last_fullscreen = false;
 
 static Television s_television;
 
@@ -231,7 +230,6 @@ Renderer::Renderer(void *&window_handle)
 	s_last_efb_scale = g_ActiveConfig.iEFBScale;
 	s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
 	s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
-	s_last_fullscreen = g_ActiveConfig.bFullscreen;
 	CalculateTargetSize(s_backbuffer_width, s_backbuffer_height);
 
 	SetupDeviceObjects();
@@ -887,16 +885,16 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 	{
 		if (fullscreen && !exclusive_mode)
 		{
-			if (s_last_fullscreen)
+			if (g_Config.bExclusiveMode)
 				OSD::AddMessage("Lost exclusive fullscreen.");
-
-			s_last_fullscreen = false;
 
 			// Exclusive fullscreen is enabled in the configuration, but we're
 			// not in exclusive mode. Either exclusive fullscreen was turned on
 			// or the render frame lost focus. When the render frame is in focus
 			// we can apply exclusive mode.
 			fullscreen_changed = Host_RendererHasFocus();
+
+			g_Config.bExclusiveMode = false;
 		}
 		else if (!fullscreen && exclusive_mode)
 		{
@@ -922,7 +920,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 			// Apply fullscreen state
 			if (fullscreen_changed)
 			{
-				s_last_fullscreen = fullscreen;
+				g_Config.bExclusiveMode = fullscreen;
 
 				if (fullscreen)
 					OSD::AddMessage("Entered exclusive fullscreen.");

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -862,7 +862,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 	SetWindowSize(fbStride, fbHeight);
 
 	const bool windowResized = CheckForResize();
-	const bool fullscreen = g_ActiveConfig.bFullscreen &&
+	const bool fullscreen = g_ActiveConfig.bFullscreen && !g_ActiveConfig.bBorderlessFullscreen &&
 		!SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderToMain;
 
 	bool xfbchanged = s_last_xfb_mode != g_ActiveConfig.bUseRealXFB;
@@ -917,8 +917,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 			{
 				D3D::SetFullscreenState(fullscreen);
 
-				// If exclusive fullscreen is disabled we can safely notify the UI to exit fullscreen.
-				if (!fullscreen)
+				// If fullscreen is disabled we can safely notify the UI to exit fullscreen.
+				if (!g_ActiveConfig.bFullscreen)
 					Host_RequestFullscreen(false);
 			}
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -28,7 +28,10 @@ void UpdateActiveConfig()
 VideoConfig::VideoConfig()
 {
 	bRunning = false;
+
+	// Exclusive fullscreen flags
 	bFullscreen = false;
+	bExclusiveMode = false;
 
 	// Needed for the first frame, I think
 	fAspectRatioHackW = 1;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -67,6 +67,7 @@ struct VideoConfig final
 	// General
 	bool bVSync;
 	bool bFullscreen;
+	bool bExclusiveMode;
 	bool bRunning;
 	bool bWidescreenHack;
 	int iAspectRatio;


### PR DESCRIPTION
This PR fixes an issue reported on the forums.

I also added an OSD message to make it clear to the user when exactly exclusive mode is enabled.