### PR TITLE
Increase AsmCommon code space to fix crashes on Linux systems.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.h
@@ -32,7 +32,9 @@ public:
 	void Init(u8* stack_top)
 	{
 		m_stack_top = stack_top;
-		AllocCodeSpace(8192);
+		// NOTE: When making large additions to the AsmCommon code, you might
+		// want to ensure this number is big enough.
+		AllocCodeSpace(16384);
 		Generate();
 		WriteProtect();
 	}


### PR DESCRIPTION
Revision b058bbd was causing the AsmCommon routines to overrun the code
buffer allocated for it. According to Fiora, it happens only on Linux
because of the fact that Linux has more caller-save registers than other
platforms.