### PR TITLE
DVDInterface: Translate and align offsets for timing purposes

### DIFF
--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -30,6 +30,7 @@
 
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
+#include "DiscIO/VolumeWiiCrypted.h"
 
 static const double PI = 3.14159265358979323846264338328;
 
@@ -40,7 +41,7 @@ static const u32 BUFFER_TRANSFER_RATE = 1024 * 1024 * 16;
 // Disc access time measured in milliseconds
 static const u32 DISC_ACCESS_TIME_MS = 50;
 
-// The size of a Wii disc layer in bytes (is this correct?)
+// The size of the first Wii disc layer in bytes
 static const u64 WII_DISC_LAYER_SIZE = 4699979776;
 
 // By knowing the disc read speed at two locations defined here,
@@ -240,6 +241,7 @@ static bool s_stop_at_track_end = false;
 static int s_finish_executing_command = 0;
 static int s_dtk = 0;
 
+static u64 s_last_decrypted_block;
 static u64 s_last_read_offset;
 static u64 s_last_read_time;
 
@@ -263,7 +265,8 @@ bool ExecuteReadCommand(u64 DVD_offset, u32 output_address, u32 DVD_length, u32 
                         bool decrypt, bool reply_to_ios, DIInterruptType* interrupt_type,
                         u64* ticks_until_completion);
 
-u64 SimulateDiscReadTime(u64 offset, u32 length);
+u64 SimulateDiscReadTimeWii(u64 offset, u32 length, bool decrypt);
+u64 SimulateDiscReadTime(u64 offset, u64 length);
 s64 CalculateRawDiscReadTime(u64 offset, s64 length);
 
 void DoState(PointerWrap& p)
@@ -288,6 +291,7 @@ void DoState(PointerWrap& p)
   p.Do(s_current_start);
   p.Do(s_current_length);
 
+  p.Do(s_last_decrypted_block);
   p.Do(s_last_read_offset);
   p.Do(s_last_read_time);
 
@@ -388,6 +392,7 @@ void Init()
   s_stream = false;
   s_stop_at_track_end = false;
 
+  s_last_decrypted_block = 0;
   s_last_read_offset = 0;
   s_last_read_time = 0;
 
@@ -655,7 +660,7 @@ bool ExecuteReadCommand(u64 DVD_offset, u32 output_address, u32 DVD_length, u32 
     *ticks_until_completion =
         output_length * (SystemTimers::GetTicksPerSecond() / BUFFER_TRANSFER_RATE);
   else
-    *ticks_until_completion = SimulateDiscReadTime(DVD_offset, DVD_length);
+    *ticks_until_completion = SimulateDiscReadTimeWii(DVD_offset, DVD_length, decrypt);
 
   DVDThread::StartRead(DVD_offset, output_address, DVD_length, decrypt, reply_to_ios,
                        (int)*ticks_until_completion);
@@ -1291,11 +1296,55 @@ void FinishExecutingCommand(bool reply_to_ios, DIInterruptType interrupt_type)
   }
 }
 
+// This function calls SimulateDiscReadTime and also performs
+// some extra handling when decrypting Wii partition data.
+u64 SimulateDiscReadTimeWii(u64 offset, u32 length, bool decrypt)
+{
+  u64 end_offset = offset + length;
+
+  // When decrypting, we need to translate Wii partition offsets to DVD offsets.
+  // We also need to align offsets to the Wii partition block size, 32 KiB.
+  if (decrypt)
+  {
+    static const u64 WII_BLOCK_SIZE = DiscIO::CVolumeWiiCrypted::s_block_total_size;
+    offset = ROUND_DOWN(s_inserted_volume->OffsetToRawOffset(offset), WII_BLOCK_SIZE);
+
+    if (length == 0)
+    {
+      end_offset = offset;
+    }
+    else
+    {
+      end_offset = ROUND_UP(s_inserted_volume->OffsetToRawOffset(end_offset), WII_BLOCK_SIZE);
+
+      // This simulates IOS having a 32 KiB buffer where it keeps
+      // the last decrypted block, avoiding to re-decrypt it.
+      // This behavior is an unconfirmed guess.
+      if (s_last_decrypted_block == offset)
+        offset += WII_BLOCK_SIZE;
+
+      s_last_decrypted_block = end_offset - WII_BLOCK_SIZE;
+    }
+  }
+
+  return SimulateDiscReadTime(offset, end_offset - offset);
+}
+
 // Simulates the timing aspects of reading data from a disc.
 // Returns the amount of ticks needed to finish executing the command,
 // and sets some state that is used the next time this function runs.
-u64 SimulateDiscReadTime(u64 offset, u32 length)
+u64 SimulateDiscReadTime(u64 offset, u64 length)
 {
+  // Data from a DVD can only be used once an entire ECC block has been read,
+  // so we align the offsets to the size of an ECC block, 32 KiB. This is the
+  // same size as for a Wii partition block, most likely not by coincidence.
+  static const u64 ECC_BLOCK_SIZE = 32768;
+  u64 end_offset = offset + length;
+  u64 buffer_start_for_next_read = ROUND_DOWN(end_offset, ECC_BLOCK_SIZE);
+  offset = ROUND_DOWN(offset, ECC_BLOCK_SIZE);
+  end_offset = (length == 0) ? offset : ROUND_UP(end_offset, ECC_BLOCK_SIZE);
+  u64 aligned_length = end_offset - offset;
+
   // The drive buffers 1 MiB (?) of data after every read request;
   // if a read request is covered by this buffer (or if it's
   // faster to wait for the data to be buffered), the drive
@@ -1323,14 +1372,14 @@ u64 SimulateDiscReadTime(u64 offset, u32 length)
   u64 ticks_until_completion;
 
   // Number of ticks it takes to seek and read directly from the disk.
-  u64 disk_read_duration = CalculateRawDiscReadTime(offset, length) +
+  u64 disk_read_duration = CalculateRawDiscReadTime(offset, aligned_length) +
                            SystemTimers::GetTicksPerSecond() / 1000 * DISC_ACCESS_TIME_MS;
 
   // Assume unbuffered read if the read we are performing asks for data >
   // 1MB past the end of the last read *or* asks for data before the last
   // read. It assumes the buffer is only used when reading small amounts
   // forward.
-  if (offset + length > s_last_read_offset + 1024 * 1024 || offset < s_last_read_offset)
+  if (end_offset > s_last_read_offset + 1024 * 1024 || offset < s_last_read_offset)
   {
     // No buffer; just use the simple seek time + read time.
     DEBUG_LOG(DVDINTERFACE, "Seeking %" PRId64 " bytes", s64(offset) - s64(s_last_read_offset));
@@ -1340,13 +1389,13 @@ u64 SimulateDiscReadTime(u64 offset, u32 length)
   else
   {
     // Possibly buffered; use the buffer if it saves time.
-    // It's not proven that the buffer actually behaves like this, but
-    // it appears to be a decent approximation.
+    // It's not proven that the buffer actually behaves like this,
+    // but it appears to be a decent approximation.
 
     // Time at which the buffer will contain the data we need.
     u64 buffer_fill_time =
         s_last_read_time +
-        CalculateRawDiscReadTime(s_last_read_offset, offset + length - s_last_read_offset);
+        CalculateRawDiscReadTime(s_last_read_offset, end_offset - s_last_read_offset);
     // Number of ticks it takes to transfer the data from the buffer to memory.
     u64 buffer_read_duration = length * (SystemTimers::GetTicksPerSecond() / BUFFER_TRANSFER_RATE);
 
@@ -1371,7 +1420,7 @@ u64 SimulateDiscReadTime(u64 offset, u32 length)
     }
   }
 
-  s_last_read_offset = ROUND_DOWN(offset + length - 2048, 2048);
+  s_last_read_offset = buffer_start_for_next_read;
 
   return ticks_until_completion;
 }
@@ -1386,10 +1435,15 @@ s64 CalculateRawDiscReadTime(u64 offset, s64 length)
   // but since reads only span a small part of the disc, it's insignificant.
   u64 average_offset = offset + (length / 2);
 
-  // Here, addresses on the second layer of Wii discs are replaced with equivalent
-  // addresses on the first layer so that the speed calculation works correctly.
-  // This is wrong for reads spanning two layers, but those should be rare.
+  // Offsets on layers beyond layer 1 are replaced with equivalent offsets
+  // on layer 1 so that the speed calculation will work correctly.
+  // Layer 2 starts where layer 1 ends and goes backwards.
+  // This code also supports layers beyond layer 2,
+  // but discs with that many layers don't exist in reality.
+  bool layer_goes_backwards = (average_offset / WII_DISC_LAYER_SIZE) % 2 == 1;
   average_offset %= WII_DISC_LAYER_SIZE;
+  if (layer_goes_backwards)
+    average_offset = WII_DISC_LAYER_SIZE - average_offset;
 
   // The area on the disc between position 1 and the arbitrary position X is:
   // LOCATION_X_SPEED * LOCATION_X_SPEED * pi - AREA_UP_TO_LOCATION_1

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -70,7 +70,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 54;  // Last changed in PR 3782
+static const u32 STATE_VERSION = 55;  // Last changed in PR 1900
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -81,6 +81,7 @@ public:
 
   virtual bool GetTitleID(u64*) const { return false; }
   virtual std::vector<u8> GetTMD() const { return {}; }
+  virtual u64 OffsetToRawOffset(u64 offset) const { return offset; }
   virtual std::string GetUniqueID() const = 0;
   virtual std::string GetMakerID() const = 0;
   virtual u16 GetRevision() const = 0;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -139,6 +139,12 @@ std::vector<u8> CVolumeWiiCrypted::GetTMD() const
   return buffer;
 }
 
+u64 CVolumeWiiCrypted::OffsetToRawOffset(u64 offset) const
+{
+  return m_VolumeOffset + m_dataOffset + (offset / s_block_data_size * s_block_total_size) +
+         (offset % s_block_data_size);
+}
+
 std::string CVolumeWiiCrypted::GetUniqueID() const
 {
   if (m_pReader == nullptr)

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -27,6 +27,7 @@ public:
   bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const override;
   bool GetTitleID(u64* buffer) const override;
   std::vector<u8> GetTMD() const override;
+  u64 OffsetToRawOffset(u64 offset) const override;
   std::string GetUniqueID() const override;
   std::string GetMakerID() const override;
   u16 GetRevision() const override;
@@ -47,11 +48,11 @@ public:
   u64 GetSize() const override;
   u64 GetRawSize() const override;
 
-private:
   static const unsigned int s_block_header_size = 0x0400;
   static const unsigned int s_block_data_size = 0x7C00;
   static const unsigned int s_block_total_size = s_block_header_size + s_block_data_size;
 
+private:
   std::unique_ptr<IBlobReader> m_pReader;
   std::unique_ptr<mbedtls_aes_context> m_AES_ctx;
 


### PR DESCRIPTION
This is a fairly large timing change for decrypted reads and a smaller timing change for non-decrypted reads.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/1900)

<!-- Reviewable:end -->
