### PR TITLE
D3D: allow selecting adapters with no outputs.

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -243,11 +243,16 @@ HRESULT Create(HWND wnd)
 	if (FAILED(hr))
 	{
 		// try using the first one
-		hr = adapter->EnumOutputs(0, &output);
-		if (FAILED(hr)) MessageBox(wnd, _T("Failed to enumerate outputs!\n")
-		                                _T("This usually happens when you've set your video adapter to the Nvidia GPU in an Optimus-equipped system.\n")
-		                                _T("Set Dolphin to use the high-performance graphics in Nvidia's drivers instead and leave Dolphin's video adapter set to the Intel GPU."),
-		                                _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
+		IDXGIAdapter* firstadapter;
+		hr = factory->EnumAdapters(0, &firstadapter);
+		if (!FAILED(hr))
+			hr = firstadapter->EnumOutputs(0, &output);
+		if (FAILED(hr)) MessageBox(wnd,
+			_T("Failed to enumerate outputs!\n")
+			_T("This usually happens when you've set your video adapter to the Nvidia GPU in an Optimus-equipped system.\n")
+			_T("Set Dolphin to use the high-performance graphics in Nvidia's drivers instead and leave Dolphin's video adapter set to the Intel GPU."),
+			_T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
+		SAFE_RELEASE(firstadapter);
 	}
 
 	// get supported AA modes


### PR DESCRIPTION
The result might be a little iffy in complicated situations (e.g. you have three graphics cards and monitors hooked up to two of them), but we really need better UI for such cases anyway.

This change has two benefits:

1. On Windows 8 it provides an easy way to switch to WARP rendering (labeled "Microsoft Basic Render Driver").
2. It should allow quickly switching between integrated and discrete graphics for Optimus configurations (untested).