### PR TITLE
[Android] Remove posix_memalign workaround.

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -115,12 +115,8 @@ void* AllocateAlignedMemory(size_t size,size_t alignment)
 	void* ptr =  _aligned_malloc(size,alignment);
 #else
 	void* ptr = nullptr;
-#ifdef ANDROID
-	ptr = memalign(alignment, size);
-#else
 	if (posix_memalign(&ptr, alignment, size) != 0)
 		ERROR_LOG(MEMMAP, "Failed to allocate aligned memory");
-#endif
 #endif
 
 	// printf("Mapped memory at %p (size %ld)\n", ptr,


### PR DESCRIPTION
Google fixed the issue of posix_memalign not being available. It now works fine in r10d of the NDK.