### PR TITLE
Fixes disassembly of paired store instructions.

### DIFF
--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -994,7 +994,7 @@ void GekkoDisassembler::ps(u32 inst)
 
 	case 7:
 		m_opcode = inst & 0x40 ? "psq_stux" : "psq_stx";
-		m_operands = StringFromFormat("(r%u + r%u), p%u, %d, qr%d", RA, RB, FS, WX, IX);
+		m_operands = StringFromFormat("p%u, r%u, r%u, %d, qr%d", RA, RB, FS, RA, RB, WX, IX);
 		return;
 
 	case 18:
@@ -1167,12 +1167,12 @@ void GekkoDisassembler::ps_mem(u32 inst)
 
 	case 60:
 		m_opcode = "psq_st";
-		m_operands = StringFromFormat("%i(r%u), p%u, %d, qr%d", SEX12(inst & 0xFFF), RA, RS, W, I);
+		m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
 		break;
 
 	case 61:
 		m_opcode = "psq_stu";
-		m_operands = StringFromFormat("%i(r%u), p%u, %d, qr%d", SEX12(inst & 0xFFF), RA, RS, W, I);
+		m_operands = StringFromFormat("p%u, %i(r%u), %d, qr%d", RS, SEX12(inst & 0xFFF), RA, W, I);
 		break;
 	}
 }


### PR DESCRIPTION
Someone thought it would be a good idea to have the location as the first argument on the instruction.
Changed it to how it is supposed to be disassembled.