### PR TITLE
VertexLoader: fix position offset bug

### DIFF
--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -145,7 +145,6 @@ void VertexLoader::CompileVertexTranslator()
 		m_VertexSize += 1;
 	}
 
-
 	if (m_VtxDesc.Tex0MatIdx) {m_VertexSize += 1; components |= VB_HAS_TEXMTXIDX0; WriteCall(TexMtx_ReadDirect_UByte); }
 	if (m_VtxDesc.Tex1MatIdx) {m_VertexSize += 1; components |= VB_HAS_TEXMTXIDX1; WriteCall(TexMtx_ReadDirect_UByte); }
 	if (m_VtxDesc.Tex2MatIdx) {m_VertexSize += 1; components |= VB_HAS_TEXMTXIDX2; WriteCall(TexMtx_ReadDirect_UByte); }
@@ -159,12 +158,12 @@ void VertexLoader::CompileVertexTranslator()
 	WriteCall(VertexLoader_Position::GetFunction(m_VtxDesc.Position, m_VtxAttr.PosFormat, m_VtxAttr.PosElements));
 
 	m_VertexSize += VertexLoader_Position::GetSize(m_VtxDesc.Position, m_VtxAttr.PosFormat, m_VtxAttr.PosElements);
-	nat_offset += 12;
 	m_native_vtx_decl.position.components = 3;
 	m_native_vtx_decl.position.enable = true;
-	m_native_vtx_decl.position.offset = 0;
+	m_native_vtx_decl.position.offset = nat_offset;
 	m_native_vtx_decl.position.type = VAR_FLOAT;
 	m_native_vtx_decl.position.integer = false;
+	nat_offset += 12;
 
 	// Normals
 	if (m_VtxDesc.Normal != NOT_PRESENT)

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -12,52 +12,6 @@
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoCommon.h"
 
-// Thoughts on the implementation of a vertex loader compiler.
-// g_vertex_manager_write_ptr should definitely be in a register.
-// Could load the position scale factor in XMM7, for example.
-
-// The pointer inside DataReadU8 in another.
-// Let's check out Pos_ReadDirect_UByte(). For Byte, replace MOVZX with MOVSX.
-
-/*
-MOVZX(32, R(EAX), MOffset(ESI, 0));
-MOVZX(32, R(EBX), MOffset(ESI, 1));
-MOVZX(32, R(ECX), MOffset(ESI, 2));
-MOVD(XMM0, R(EAX));
-MOVD(XMM1, R(EBX));
-MOVD(XMM2, R(ECX));
-CVTDQ2PS(XMM0, XMM0);
-CVTDQ2PS(XMM1, XMM1);
-CVTDQ2PS(XMM2, XMM2);
-MULSS(XMM0, XMM7);
-MULSS(XMM1, XMM7);
-MULSS(XMM2, XMM7);
-MOVSS(MOffset(EDI, 0), XMM0);
-MOVSS(MOffset(EDI, 4), XMM1);
-MOVSS(MOffset(EDI, 8), XMM2);
-
-Alternatively, lookup table:
-MOVZX(32, R(EAX), MOffset(ESI, 0));
-MOVZX(32, R(EBX), MOffset(ESI, 1));
-MOVZX(32, R(ECX), MOffset(ESI, 2));
-MOV(32, R(EAX), MComplex(LUTREG, EAX, 4));
-MOV(32, R(EBX), MComplex(LUTREG, EBX, 4));
-MOV(32, R(ECX), MComplex(LUTREG, ECX, 4));
-MOV(MOffset(EDI, 0), XMM0);
-MOV(MOffset(EDI, 4), XMM1);
-MOV(MOffset(EDI, 8), XMM2);
-
-SSE4:
-PINSRB(XMM0, MOffset(ESI, 0), 0);
-PINSRB(XMM0, MOffset(ESI, 1), 4);
-PINSRB(XMM0, MOffset(ESI, 2), 8);
-CVTDQ2PS(XMM0, XMM0);
-<two unpacks here to sign extend>
-MULPS(XMM0, XMM7);
-MOVUPS(MOffset(EDI, 0), XMM0);
-
-									 */
-
 template <typename T>
 float PosScale(T val, float scale)
 {


### PR DESCRIPTION
The position offset was hardcoded to oksopoff which caused it to break when I moved the position matrix index to the front.