### PR TITLE
Remove an assumption in SDL.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -38,21 +38,31 @@ void Init( std::vector<Core::Device*>& devices )
 	// multiple joysticks with the same name shall get unique ids starting at 0
 	std::map<std::string, int> name_counts;
 
-	if (SDL_Init( SDL_INIT_FLAGS ) >= 0)
+#ifdef USE_SDL_HAPTIC
+	if (SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC) >= 0)
 	{
-		// joysticks
-		for (int i = 0; i < SDL_NumJoysticks(); ++i)
+		// Correctly initialized
+	}
+	else
+#endif
+	if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
+	{
+		// Failed to initialize
+		return;
+	}
+
+	// joysticks
+	for (int i = 0; i < SDL_NumJoysticks(); ++i)
+	{
+		SDL_Joystick* dev = SDL_JoystickOpen(i);
+		if (dev)
 		{
-			SDL_Joystick* dev = SDL_JoystickOpen(i);
-			if (dev)
-			{
-				Joystick* js = new Joystick(dev, i, name_counts[GetJoystickName(i)]++);
-				// only add if it has some inputs/outputs
-				if (js->Inputs().size() || js->Outputs().size())
-					devices.push_back( js );
-				else
-					delete js;
-			}
+			Joystick* js = new Joystick(dev, i, name_counts[GetJoystickName(i)]++);
+			// only add if it has some inputs/outputs
+			if (js->Inputs().size() || js->Outputs().size())
+				devices.push_back( js );
+			else
+				delete js;
 		}
 	}
 }

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -17,9 +17,6 @@
 
 #ifdef USE_SDL_HAPTIC
 	#include <SDL_haptic.h>
-	#define SDL_INIT_FLAGS  SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC
-#else
-	#define SDL_INIT_FLAGS  SDL_INIT_JOYSTICK
 #endif
 
 namespace ciface


### PR DESCRIPTION
We can compile with haptic support, and then not initialize due to haptics not being available.
So if we are compiling with haptics, test initializing with haptics and if that fails attempt to initialize without haptics before bailing out.