### PR TITLE
PixelShaderGen: Fix uninitialized variables.

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -390,6 +390,11 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	          "\tint2 wrappedcoord=int2(0,0), tempcoord=int2(0,0);\n"
 	          "\tint4 tevin_a=int4(0,0,0,0),tevin_b=int4(0,0,0,0),tevin_c=int4(0,0,0,0),tevin_d=int4(0,0,0,0);\n\n"); // tev combiner inputs
 
+	// On GLSL, input variables must not be assigned to.
+	// This is why we declare these variables locally instead.
+	out.Write("\tfloat4 col0 = colors_0;\n");
+	out.Write("\tfloat4 col1 = colors_1;\n");
+
 	if (g_ActiveConfig.bEnablePixelLighting)
 	{
 		out.Write("\tfloat3 _norm0 = normalize(Normal.xyz);\n\n");
@@ -399,10 +404,6 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 				"\tfloat3 ldir, h;\n"
 				"\tfloat dist, dist2, attn;\n");
 
-		// On GLSL, input variables must not be assigned to.
-		// This is why we declare these variables locally instead.
-		out.Write("\tfloat4 col0, col1;\n");
-
 		// TODO: Our current constant usage code isn't able to handle more than one buffer.
 		//       So we can't mark the VS constant as used here. But keep them here as reference.
 		//out.SetConstantsUsed(C_PLIGHT_COLORS, C_PLIGHT_COLORS+7); // TODO: Can be optimized further
@@ -410,11 +411,6 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 		//out.SetConstantsUsed(C_PMATERIALS, C_PMATERIALS+3);
 		uid_data->components = components;
 		GenerateLightingShader<T>(out, uid_data->lighting, components, "colors_", "col");
-	}
-	else
-	{
-		out.Write("\tfloat4 col0 = colors_0;\n");
-		out.Write("\tfloat4 col1 = colors_1;\n");
 	}
 
 	// HACK to handle cases where the tex gen is not enabled


### PR DESCRIPTION
Without this change per-pixel-lighting is broken.