### PR TITLE
Fix Intellisense error spam on Visual Studio.

### DIFF
--- a/Source/Core/Common/BitField.h
+++ b/Source/Core/Common/BitField.h
@@ -115,10 +115,14 @@ template<std::size_t position, std::size_t bits, typename T>
 struct BitField
 {
 private:
+#ifndef _WIN32
 	// This constructor might be considered ambiguous:
 	// Would it initialize the storage or just the bitfield?
 	// Hence, delete it. Use the assignment operator to set bitfield values!
+	// MSVC 2013 Intellisense complains that this declaration isn't allowed
+	// in a union member, so disable it on Windows.
 	BitField(T val) = delete;
+#endif
 
 public:
 	// Force default constructor to be created

--- a/Source/PCH/pch.h
+++ b/Source/PCH/pch.h
@@ -67,19 +67,6 @@
 #error Please update your build environment to VS2013 with Update 3 or later!
 #endif
 
-// This numeral indicates the "minimum system required" to run the resulting
-// program. Dolphin targets Vista+, so it should be 0x0600. However in practice,
-// _WIN32_WINNT just removes up-level API declarations from headers. This is a
-// problem for XAudio2 and XInput, where Dolphin expects to compile against the
-// Win8+ versions of their headers. So while we really need Vista+ level of
-// support, we declare Win8+ here globally. If this becomes a problem, the
-// higher declaration can be contained to just the XAudio2/XInput related code.
-#define _WIN32_WINNT 0x0602
-
-// Exclude rarely-used stuff from Windows headers
-#define WIN32_LEAN_AND_MEAN
-// Don't include Windows min/max definitions. They would conflict with the STL.
-#define NOMINMAX
 #include <Windows.h>
 
 #endif

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -53,6 +53,20 @@
       <PreprocessorDefinitions>PSAPI_VERSION=1;_M_X86=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>SFML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">_ARCH_64=1;_M_X86_64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+      Make sure we include a clean version of windows.h.
+      -->
+      <PreprocessorDefinitions Condition="'$(ProjectName)'!='portaudio' And '$(ProjectName)'!='wxWidgets'">WIN32_LEAN_AND_MEAN;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!--
+      This numeral indicates the "minimum system required" to run the resulting
+      program. Dolphin targets Vista+, so it should be 0x0600. However in practice,
+      _WIN32_WINNT just removes up-level API declarations from headers. This is a
+      problem for XAudio2 and XInput, where Dolphin expects to compile against the
+      Win8+ versions of their headers. So while we really need Vista+ level of
+      support, we declare Win8+ here globally. If this becomes a problem, the
+      higher declaration can be contained to just the XAudio2/XInput related code.
+      -->
+      <PreprocessorDefinitions>_WIN32_WINNT=0x0602;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <IntrinsicFunctions>true</IntrinsicFunctions>


### PR DESCRIPTION
Intellisense doesn't like defines in PCH files, and it doesn't like the deleted
constructor for BitField.  (I think it's being overly strict about the
"must have no non-default constructors" rule for classes in unions.)