### PR TITLE
[AArch64] Fix bugs in floating point loadstores.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -260,11 +260,7 @@ void JitArm64::stfXX(UGeckoInstruction inst)
 	bool is_immediate = false;
 
 	ARM64Reg V0 = fpr.R(inst.FS);
-	ARM64Reg addr_reg;
-	if (flags & BackPatchInfo::FLAG_SIZE_F64)
-		addr_reg = W0;
-	else
-		addr_reg = W1;
+	ARM64Reg addr_reg = W1;
 
 	gpr.Lock(W0, W1, W30);
 	fpr.Lock(Q0);


### PR DESCRIPTION
The Backpatching routines didn't correctly understand where to find the real VFP register from, so in most cases it was using D0.
Fixes bugs in the slowmem loadstore routines as well.