### PR TITLE
Minor DSP JIT optimizations

### DIFF
--- a/Source/Core/Core/DSP/DSPEmitter.h
+++ b/Source/Core/Core/DSP/DSPEmitter.h
@@ -41,8 +41,7 @@ public:
 
 	// CC Util
 	void Update_SR_Register64(Gen::X64Reg val = Gen::EAX);
-	void Update_SR_Register64_Carry(Gen::X64Reg val, Gen::X64Reg carry_ovfl);
-	void Update_SR_Register64_Carry2(Gen::X64Reg val, Gen::X64Reg carry_ovfl);
+	void Update_SR_Register64_Carry(Gen::X64Reg val, Gen::X64Reg carry_ovfl, bool carry_eq = false);
 	void Update_SR_Register16(Gen::X64Reg val = Gen::EAX);
 	void Update_SR_Register16_OverS32(Gen::X64Reg val = Gen::EAX);
 

--- a/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
@@ -179,7 +179,7 @@ void DSPEmitter::cmp(const UDSPInstruction opc)
 		SUB(64, R(RAX), R(RDX));
 //		Update_SR_Register64(res, isCarry2(acc0, res), isOverflow(acc0, -acc1, res)); // CF -> influence on ABS/0xa100
 		NEG(64, R(RDX));
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 		gpr.putXReg(tmp1);
 	}
 }
@@ -210,7 +210,7 @@ void DSPEmitter::cmpar(const UDSPInstruction opc)
 		SUB(64, R(RAX), R(RDX));
 //		Update_SR_Register64(res, isCarry2(sr, res), isOverflow(sr, -rr, res));
 		NEG(64, R(RDX));
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 		gpr.putXReg(tmp1);
 	}
 }
@@ -239,7 +239,7 @@ void DSPEmitter::cmpi(const UDSPInstruction opc)
 		SUB(64, R(RAX), R(RDX));
 //		Update_SR_Register64(res, isCarry2(val, res), isOverflow(val, -imm, res));
 		NEG(64, R(RDX));
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 		gpr.putXReg(tmp1);
 	}
 }
@@ -268,7 +268,7 @@ void DSPEmitter::cmpis(const UDSPInstruction opc)
 		SUB(64, R(RAX), R(RDX));
 //		Update_SR_Register64(res, isCarry2(acc, res), isOverflow(acc, -val, res));
 		NEG(64, R(RDX));
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 		gpr.putXReg(tmp1);
 	}
 }
@@ -862,7 +862,7 @@ void DSPEmitter::subr(const UDSPInstruction opc)
 		NEG(64, R(RDX));
 		MOV(64, R(RCX), R(RAX));
 		set_long_acc(dreg, RCX);
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 	}
 	else
 	{
@@ -898,7 +898,7 @@ void DSPEmitter::subax(const UDSPInstruction opc)
 		NEG(64, R(RDX));
 		MOV(64, R(RCX), R(RAX));
 		set_long_acc(dreg, RCX);
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 	}
 	else
 	{
@@ -932,7 +932,7 @@ void DSPEmitter::sub(const UDSPInstruction opc)
 		NEG(64, R(RDX));
 		MOV(64, R(RCX), R(RAX));
 		set_long_acc(dreg, RCX);
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 	}
 	else
 	{
@@ -966,7 +966,7 @@ void DSPEmitter::subp(const UDSPInstruction opc)
 		NEG(64, R(RDX));
 		MOV(64, R(RCX), R(RAX));
 		set_long_acc(dreg, RCX);
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 	}
 	else
 	{
@@ -999,7 +999,7 @@ void DSPEmitter::decm(const UDSPInstruction opc)
 		MOV(64, R(RDX), Imm64(-subtract));
 		MOV(64, R(RCX), R(RAX));
 		set_long_acc(dreg, RCX);
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 	}
 	else
 	{
@@ -1031,7 +1031,7 @@ void DSPEmitter::dec(const UDSPInstruction opc)
 		MOV(64, R(RDX), Imm64(-1));
 		MOV(64, R(RCX), R(RAX));
 		set_long_acc(dreg, RCX);
-		Update_SR_Register64_Carry2(EAX, tmp1);
+		Update_SR_Register64_Carry(EAX, tmp1, true);
 	}
 	else
 	{

--- a/Source/Core/Core/DSP/Jit/DSPJitCCUtil.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitCCUtil.cpp
@@ -107,7 +107,6 @@ void DSPEmitter::Update_SR_Register64_Carry(X64Reg val, X64Reg carry_ovfl, bool 
 }
 
 // In: RAX: s64 _Value
-// Clobbers RDX
 void DSPEmitter::Update_SR_Register16(X64Reg val)
 {
 	OpArg sr_reg;
@@ -144,7 +143,7 @@ void DSPEmitter::Update_SR_Register16(X64Reg val)
 }
 
 // In: RAX: s64 _Value
-// Clobbers RDX
+// Clobbers RCX
 void DSPEmitter::Update_SR_Register16_OverS32(Gen::X64Reg val)
 {
 	OpArg sr_reg;

--- a/Source/Core/Core/DSP/Jit/DSPJitCCUtil.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitCCUtil.cpp
@@ -17,14 +17,14 @@ void DSPEmitter::Update_SR_Register(Gen::X64Reg val)
 	gpr.getReg(DSP_REG_SR,sr_reg);
 	//	// 0x04
 	//	if (_Value == 0) g_dsp.r[DSP_REG_SR] |= SR_ARITH_ZERO;
-	CMP(64, R(val), Imm8(0));
+	TEST(64, R(val), R(val));
 	FixupBranch notZero = J_CC(CC_NZ);
-	OR(16, sr_reg, Imm16(SR_ARITH_ZERO));
+	OR(16, sr_reg, Imm16(SR_ARITH_ZERO | SR_TOP2BITS));
+	FixupBranch end = J();
 	SetJumpTarget(notZero);
 
 	//	// 0x08
 	//	if (_Value < 0) g_dsp.r[DSP_REG_SR] |= SR_SIGN;
-	CMP(64, R(val), Imm8(0));
 	FixupBranch greaterThanEqual = J_CC(CC_GE);
 	OR(16, sr_reg, Imm16(SR_SIGN));
 	SetJumpTarget(greaterThanEqual);
@@ -39,15 +39,16 @@ void DSPEmitter::Update_SR_Register(Gen::X64Reg val)
 
 	//	// 0x20 - Checks if top bits of m are equal
 	//	if (((_Value & 0xc0000000) == 0) || ((_Value & 0xc0000000) == 0xc0000000))
-	AND(32, R(val), Imm32(0xc0000000));
-	CMP(32, R(val), Imm32(0));
-	FixupBranch zeroC = J_CC(CC_E);
-	CMP(32, R(val), Imm32(0xc0000000));
+	MOV(32, R(RDX), Imm32(0xc0000000));
+	AND(32, R(val), R(RDX));
+	FixupBranch zeroC = J_CC(CC_Z);
+	CMP(32, R(val), R(RDX));
 	FixupBranch cC = J_CC(CC_NE);
 	SetJumpTarget(zeroC);
 	//		g_dsp.r[DSP_REG_SR] |= SR_TOP2BITS;
 	OR(16, sr_reg, Imm16(SR_TOP2BITS));
 	SetJumpTarget(cC);
+	SetJumpTarget(end);
 	gpr.putReg(DSP_REG_SR);
 }
 
@@ -88,8 +89,7 @@ void DSPEmitter::Update_SR_Register64_Carry(X64Reg val, X64Reg carry_ovfl)
 	// Overflow = ((acc ^ res) & (ax ^ res)) < 0
 	XOR(64, R(carry_ovfl), R(val));
 	XOR(64, R(RDX), R(val));
-	AND(64, R(carry_ovfl), R(RDX));
-	CMP(64, R(carry_ovfl), Imm8(0));
+	TEST(64, R(carry_ovfl), R(RDX));
 	FixupBranch noOverflow = J_CC(CC_GE);
 	OR(16, sr_reg, Imm16(SR_OVERFLOW | SR_OVERFLOW_STICKY));
 	SetJumpTarget(noOverflow);
@@ -123,8 +123,7 @@ void DSPEmitter::Update_SR_Register64_Carry2(X64Reg val, X64Reg carry_ovfl)
 	// Overflow = ((acc ^ res) & (ax ^ res)) < 0
 	XOR(64, R(carry_ovfl), R(val));
 	XOR(64, R(RDX), R(val));
-	AND(64, R(carry_ovfl), R(RDX));
-	CMP(64, R(carry_ovfl), Imm8(0));
+	TEST(64, R(carry_ovfl), R(RDX));
 	FixupBranch noOverflow = J_CC(CC_GE);
 	OR(16, sr_reg, Imm16(SR_OVERFLOW | SR_OVERFLOW_STICKY));
 	SetJumpTarget(noOverflow);
@@ -143,33 +142,30 @@ void DSPEmitter::Update_SR_Register16(X64Reg val)
 
 	//	// 0x04
 	//	if (_Value == 0) g_dsp.r[DSP_REG_SR] |= SR_ARITH_ZERO;
-	CMP(64, R(val), Imm8(0));
+	TEST(64, R(val), R(val));
 	FixupBranch notZero = J_CC(CC_NZ);
-	OR(16, sr_reg, Imm16(SR_ARITH_ZERO));
+	OR(16, sr_reg, Imm16(SR_ARITH_ZERO | SR_TOP2BITS));
+	FixupBranch end = J();
 	SetJumpTarget(notZero);
 
 	//	// 0x08
 	//	if (_Value < 0) g_dsp.r[DSP_REG_SR] |= SR_SIGN;
-	CMP(64, R(val), Imm8(0));
 	FixupBranch greaterThanEqual = J_CC(CC_GE);
 	OR(16, sr_reg, Imm16(SR_SIGN));
 	SetJumpTarget(greaterThanEqual);
 
 	//	// 0x20 - Checks if top bits of m are equal
 	//	if ((((u16)_Value >> 14) == 0) || (((u16)_Value >> 14) == 3))
-	//AND(32, R(val), Imm32(0xc0000000));
 	SHR(16, R(val), Imm8(14));
-	CMP(16, R(val), Imm16(0));
-	FixupBranch nZero = J_CC(CC_NE);
-	OR(16, sr_reg, Imm16(SR_TOP2BITS));
-	FixupBranch cC = J();
-	SetJumpTarget(nZero);
+	TEST(16, R(val), R(val));
+	FixupBranch isZero = J_CC(CC_Z);
 	CMP(16, R(val), Imm16(3));
 	FixupBranch notThree = J_CC(CC_NE);
+	SetJumpTarget(isZero);
 	//		g_dsp.r[DSP_REG_SR] |= SR_TOP2BITS;
 	OR(16, sr_reg, Imm16(SR_TOP2BITS));
 	SetJumpTarget(notThree);
-	SetJumpTarget(cC);
+	SetJumpTarget(end);
 	gpr.putReg(DSP_REG_SR);
 }
 


### PR DESCRIPTION
Noticed some minor improvements could be made in this area. Probably won't make a measurable difference. Notable changes include:

* Merge two ORs and early exit when _Value == 0
* Remove some extraneous instructions (don't recalculate flags, AND already modifies flags, ...)
* Prefer TEST over CMP for comparison to zero