### PR TITLE
Don't Use PAL60 on NTSC

### DIFF
--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -28,8 +28,14 @@
 
 namespace HW
 {
+	bool PAL60;
+
 	void Init()
 	{
+		bool NTSC = SConfig::GetInstance().m_LocalCoreStartupParameter.bNTSC;
+		bool PAL60 = WiiPAL60;
+		WiiPAL60->SetValue(!!SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.E60") && !NTSC); // Don't use PAL60 on NTSC games
+
 		CoreTiming::Init();
 		SystemTimers::PreInit();
 
@@ -65,6 +71,8 @@ namespace HW
 		Memory::Shutdown();
 		SerialInterface::Shutdown();
 		AudioInterface::Shutdown();
+
+		WiiPAL60->SetValue(PAL60)); // Set WiiPAL60 back to what it was before
 
 		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
 		{


### PR DESCRIPTION
PAL60 should only be enabled if it's a PAL game because some NTSC games (e.g. Doc Louis's Punch-Out!!) have leftover code from the PAL version that looks at the PAL60 setting, and if it's enabled it attempts to load the NTSC game in PAL60 mode. This causes the game to hang on a black screen because NTSC games cannot display in PAL mode. This doesn't affect actual console because there is no PAL60 setting on an NTSC console.

This needs testing to see if it fixes these issues:
[Issue 7714](https://code.google.com/p/dolphin-emu/issues/detail?id=7714)
[Issue 7862](https://code.google.com/p/dolphin-emu/issues/detail?id=7862)
[Issue 8036](https://code.google.com/p/dolphin-emu/issues/detail?id=8036)

@Stevoisiak You should be able to remove your sentence saying PAL60 may not work for all games in PR #1808.

@Linktothepast You should be able to remove the notes in INI files about NTSC games not working with PAL60.