### PR TITLE
EFB2RAM Speedhack

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -500,7 +500,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	SettingCheckBox* efbcopy_disable = CreateCheckBox(page_hacks, _("Disable"), wxGetTranslation(efb_copy_desc), vconfig.bEFBCopyEnable, true);
 	efbcopy_texture = CreateRadioButton(page_hacks, _("Texture"), wxGetTranslation(efb_copy_texture_desc), vconfig.bCopyEFBToTexture, false, wxRB_GROUP);
 	efbcopy_ram = CreateRadioButton(page_hacks, _("RAM"), wxGetTranslation(efb_copy_ram_desc), vconfig.bCopyEFBToTexture, true);
-	cache_efb_copies = CreateCheckBox(page_hacks, _("Enable Cache"), wxGetTranslation(cache_efb_copies_desc), vconfig.bEFBCopyCacheEnable);
+	cache_efb_copies = CreateCheckBox(page_hacks, _("Speedhack"), wxGetTranslation(cache_efb_copies_desc), vconfig.bEFBCopyCacheEnable);
 
 	group_efbcopy->Add(efbcopy_disable, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
 	group_efbcopy->AddStretchSpacer(1);

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -176,7 +176,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 		D3D::stateman->SetTextureByMask(textureSlotMask, texture->GetSRV());
 	}
 
-	if (!g_ActiveConfig.bCopyEFBToTexture)
+	if (!g_ActiveConfig.bCopyEFBToTexture && (!g_ActiveConfig.bEFBCopyCacheEnable || do_efb2ram))
 	{
 		u8* dst = Memory::GetPointer(dstAddr);
 		size_t encoded_size = g_encoder->Encode(dst, dstFormat, srcFormat, srcRect, isIntensity, scaleByHalf);
@@ -185,11 +185,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 
 		size_in_bytes = (u32)encoded_size;
 
-		// Mark texture entries in destination address range dynamic unless caching is enabled and the texture entry is up to date
-		if (!g_ActiveConfig.bEFBCopyCacheEnable)
-			TextureCache::MakeRangeDynamic(addr, (u32)encoded_size);
-		else if (!TextureCache::Find(addr, hash))
-			TextureCache::MakeRangeDynamic(addr, (u32)encoded_size);
+		TextureCache::MakeRangeDynamic(addr, (u32)encoded_size);
 
 		this->hash = hash;
 	}

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -204,7 +204,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 	}
 
-	if (false == g_ActiveConfig.bCopyEFBToTexture)
+	if (false == g_ActiveConfig.bCopyEFBToTexture && (!g_ActiveConfig.bEFBCopyCacheEnable || do_efb2ram))
 	{
 		int encoded_size = TextureConverter::EncodeToRamFromTexture(
 			addr,
@@ -220,11 +220,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 
 		size_in_bytes = (u32)encoded_size;
 
-		// Mark texture entries in destination address range dynamic unless caching is enabled and the texture entry is up to date
-		if (!g_ActiveConfig.bEFBCopyCacheEnable)
-			TextureCache::MakeRangeDynamic(addr,encoded_size);
-		else if (!TextureCache::Find(addr, new_hash))
-			TextureCache::MakeRangeDynamic(addr,encoded_size);
+		TextureCache::MakeRangeDynamic(addr,encoded_size);
 
 		hash = new_hash;
 	}

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -69,6 +69,8 @@ public:
 		// used to delete textures which haven't been used for TEXTURE_KILL_THRESHOLD frames
 		int frameCount;
 
+		// used for the efb2ram speedhack
+		bool do_efb2ram;
 
 		void SetGeneralParameters(u32 _addr, u32 _size, u32 _format)
 		{


### PR DESCRIPTION
Please do not review coding style issues yet! Also, the efb2ram cache option is used for now, if this PR has an actual change to be merged, it will be changed. This PR is supposed to be merged after PR https://github.com/dolphin-emu/dolphin/pull/1948.

This hack tries to make efb2ram faster, by skipping the efb to ram copy under the following conditions:
- The texture was loaded at least once
- The texture is not one of the paletted textures that are efb copies

Obviously this won't work on games that read or change the efb data after it was copied to RAM. But some games require efb2ram right now, without doing this.

This hack is mostly intended to be used for those paletted textures that are efb copies, but it does work on some others as well. Examples for this are the spinning coins in New Super Mario Bros and the garbage on screen that happens in RS2 after loading a profile.

TODO:
- Check if the other uses of efb2ram in RS2 work with this. This is at least some effect on torpedoes and some heat effect.
- Test if New Super Mario Bros really works fine with this