### PR TITLE
Fix a buffer underrun in CalculateZSlope.

### DIFF
--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -287,6 +287,10 @@ void VertexManager::CalculateZSlope(NativeVertexFormat* format)
 	size_t posOff = vert_decl.position.offset;
 	size_t mtxOff = vert_decl.posmtx.offset;
 
+	// Make sure the buffer contains at lest 3 vertices.
+	if ((s_pCurBufferPointer - s_pBaseBufferPointer) < (vert_decl.stride * 3))
+		return;
+
 	// Lookup vertices of the last rendered triangle and software-transform them
 	// This allows us to determine the depth slope, which will be used if z--freeze
 	// is enabled in the following flush.


### PR DESCRIPTION
if the vertex buffer contained less than 3 vertices, (say trying to render a single line, or one/two points) then this could underrun and potentially cause a segfault.