### PR TITLE
[AArch64] Fix a load of games.

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1754,7 +1754,8 @@ void ARM64FloatEmitter::EmitConversion(bool sf, bool S, u32 type, u32 rmode, u32
 
 void ARM64FloatEmitter::EmitCompare(bool M, bool S, u32 op, u32 opcode2, ARM64Reg Rn, ARM64Reg Rm)
 {
-	bool is_double = !IsSingle(Rn);
+	_assert_msg_(DYNA_REC, IsQuad(Rn), "%s doesn't support vector!", __FUNCTION__);
+	bool is_double = IsDouble(Rn);
 
 	Rn = DecodeReg(Rn);
 	Rm = DecodeReg(Rm);
@@ -1765,7 +1766,8 @@ void ARM64FloatEmitter::EmitCompare(bool M, bool S, u32 op, u32 opcode2, ARM64Re
 
 void ARM64FloatEmitter::EmitCondSelect(bool M, bool S, CCFlags cond, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
-	bool is_double = !IsSingle(Rd);
+	_assert_msg_(DYNA_REC, IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
+	bool is_double = IsDouble(Rd);
 
 	Rd = DecodeReg(Rd);
 	Rn = DecodeReg(Rn);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -22,7 +22,6 @@ void JitArm64::fabsx(UGeckoInstruction inst)
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
 
-	fpr.BindToRegister(inst.FD, inst.FD == inst.FB);
 	ARM64Reg VB = fpr.R(inst.FB);
 	ARM64Reg VD = fpr.R(inst.FD);
 	ARM64Reg V0 = fpr.GetReg();
@@ -54,7 +53,6 @@ void JitArm64::faddx(UGeckoInstruction inst)
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
 
-	fpr.BindToRegister(inst.FD, inst.FD == inst.FA || inst.FD == inst.FB);
 	ARM64Reg VA = fpr.R(inst.FA);
 	ARM64Reg VB = fpr.R(inst.FB);
 	ARM64Reg VD = fpr.R(inst.FD);
@@ -94,7 +92,6 @@ void JitArm64::fmaddx(UGeckoInstruction inst)
 	FALLBACK_IF(inst.Rc);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
-	fpr.BindToRegister(d, d == a || d == b || d == c);
 
 	ARM64Reg VA = fpr.R(a);
 	ARM64Reg VB = fpr.R(b);
@@ -114,7 +111,6 @@ void JitArm64::fmrx(UGeckoInstruction inst)
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
 
-	fpr.BindToRegister(inst.FD, inst.FD == inst.FB);
 	ARM64Reg VB = fpr.R(inst.FB);
 	ARM64Reg VD = fpr.R(inst.FD);
 
@@ -149,7 +145,6 @@ void JitArm64::fmsubx(UGeckoInstruction inst)
 	FALLBACK_IF(inst.Rc);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
-	fpr.BindToRegister(d, d == a || d == b || d == c);
 
 	ARM64Reg VA = fpr.R(a);
 	ARM64Reg VB = fpr.R(b);
@@ -184,7 +179,6 @@ void JitArm64::fmulx(UGeckoInstruction inst)
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
 
-	fpr.BindToRegister(inst.FD, inst.FD == inst.FA || inst.FD == inst.FC);
 	ARM64Reg VA = fpr.R(inst.FA);
 	ARM64Reg VC = fpr.R(inst.FC);
 	ARM64Reg VD = fpr.R(inst.FD);
@@ -202,7 +196,6 @@ void JitArm64::fnabsx(UGeckoInstruction inst)
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
 
-	fpr.BindToRegister(inst.FD, inst.FD == inst.FB);
 	ARM64Reg VB = fpr.R(inst.FB);
 	ARM64Reg VD = fpr.R(inst.FD);
 	ARM64Reg V0 = fpr.GetReg();
@@ -220,7 +213,6 @@ void JitArm64::fnegx(UGeckoInstruction inst)
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
 
-	fpr.BindToRegister(inst.FD, inst.FD == inst.FB);
 	ARM64Reg VB = fpr.R(inst.FB);
 	ARM64Reg VD = fpr.R(inst.FD);
 	ARM64Reg V0 = fpr.GetReg();
@@ -260,7 +252,6 @@ void JitArm64::fnmaddx(UGeckoInstruction inst)
 	FALLBACK_IF(inst.Rc);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
-	fpr.BindToRegister(d, d == a || d == b || d == c);
 
 	ARM64Reg VA = fpr.R(a);
 	ARM64Reg VB = fpr.R(b);
@@ -304,7 +295,6 @@ void JitArm64::fnmsubx(UGeckoInstruction inst)
 	FALLBACK_IF(inst.Rc);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
-	fpr.BindToRegister(d, d == a || d == b || d == c);
 
 	ARM64Reg VA = fpr.R(a);
 	ARM64Reg VB = fpr.R(b);
@@ -324,16 +314,12 @@ void JitArm64::fselx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
-	fpr.BindToRegister(inst.FD,
-			inst.FD == inst.FA ||
-			inst.FD == inst.FB ||
-			inst.FD == inst.FC);
 
 	ARM64Reg V0 = fpr.GetReg();
 	ARM64Reg VD = fpr.R(inst.FD);
 	ARM64Reg VA = fpr.R(inst.FA);
 	ARM64Reg VB = fpr.R(inst.FB);
-	ARM64Reg VC = gpr.R(inst.FC);
+	ARM64Reg VC = fpr.R(inst.FC);
 
 	m_float_emit.FCMPE(VA);
 	m_float_emit.FCSEL(V0, VC, VB, CC_GE);
@@ -363,7 +349,6 @@ void JitArm64::fsubx(UGeckoInstruction inst)
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
 
-	fpr.BindToRegister(inst.FD, inst.FD == inst.FA || inst.FD == inst.FB);
 	ARM64Reg VA = fpr.R(inst.FA);
 	ARM64Reg VB = fpr.R(inst.FB);
 	ARM64Reg VD = fpr.R(inst.FD);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -321,8 +321,8 @@ void JitArm64::fselx(UGeckoInstruction inst)
 	ARM64Reg VB = fpr.R(inst.FB);
 	ARM64Reg VC = fpr.R(inst.FC);
 
-	m_float_emit.FCMPE(VA);
-	m_float_emit.FCSEL(V0, VC, VB, CC_GE);
+	m_float_emit.FCMPE(EncodeRegToDouble(VA));
+	m_float_emit.FCSEL(EncodeRegToDouble(V0), EncodeRegToDouble(VC), EncodeRegToDouble(VB), CC_GE);
 	m_float_emit.INS(64, VD, 0, V0, 0);
 
 	fpr.Unlock(V0);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -702,7 +702,7 @@ void JitArm64::addcx(UGeckoInstruction inst)
 	if (gpr.IsImm(a) && gpr.IsImm(b))
 	{
 		u32 i = gpr.GetImm(a), j = gpr.GetImm(b);
-		gpr.SetImmediate(d, i * j);
+		gpr.SetImmediate(d, i + j);
 
 		bool has_carry = Interpreter::Helper_Carry(i, j);
 		ComputeCarry(has_carry);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -377,13 +377,18 @@ void JitArm64::cmp(UGeckoInstruction inst)
 	}
 
 	ARM64Reg WA = gpr.GetReg();
+	ARM64Reg WB = gpr.GetReg();
+	ARM64Reg XA = EncodeRegTo64(WA);
+	ARM64Reg XB = EncodeRegTo64(WB);
 	ARM64Reg RA = gpr.R(a);
 	ARM64Reg RB = gpr.R(b);
+	SXTW(XA, RA);
+	SXTW(XB, RB);
 
-	SUB(WA, RA, RB);
-	ComputeRC(WA, crf);
+	SUB(XA, XA, XB);
+	STR(INDEX_UNSIGNED, XA, X29, PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
 
-	gpr.Unlock(WA);
+	gpr.Unlock(WA, WB);
 }
 
 void JitArm64::cmpl(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -659,11 +659,13 @@ void JitArm64::addzex(UGeckoInstruction inst)
 	gpr.BindToRegister(d, d == a);
 	ARM64Reg WA = gpr.GetReg();
 	LDRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
-	CMP(WA, 1);
-	CSINC(gpr.R(d), gpr.R(a), gpr.R(a), CC_NEQ);
+	CMP(WA, 0);
+	CSINC(gpr.R(d), gpr.R(a), gpr.R(a), CC_EQ);
 	CMP(gpr.R(d), 0);
 	gpr.Unlock(WA);
 	ComputeCarry();
+	if (inst.Rc)
+		ComputeRC(gpr.R(d), 0);
 }
 
 void JitArm64::subfx(UGeckoInstruction inst)


### PR DESCRIPTION
This fixes a bunch of games.
cmp - Fixes invisible text in Alien Hominid
        - Fixes a error message in MK Wii
        - Fixes black stuff on characters in SA:DX
fselx - Fixes Ikaruga black screen issue
addcx - Fixes Muramasa hang on intro
           - Fixes Pokemon XD hang on intro
addzex - Fixes an issue in all gamecube games thinking the memory card is corrupt.
Floating point destination - Fixes an issue in Pokemon Channel where the game would receive zero input.