### PR TITLE
Add a button in the controller config dialog to refresh the usb gc adapter status

### DIFF
--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -164,8 +164,12 @@ void Init()
 						ERROR_LOG(SERIALINTERFACE, "libusb_detach_kernel_driver failed with error: %d", ret);
 						Shutdown();
 					}
+					else
+					{
+						goto continue_setup;
+					}
 				}
-				else if (ret != 0 && ret != LIBUSB_ERROR_NOT_SUPPORTED)
+				else if ((ret != 0 && ret != LIBUSB_ERROR_NOT_SUPPORTED))
 				{
 					ERROR_LOG(SERIALINTERFACE, "libusb_kernel_driver_active error ret = %d", ret);
 					Shutdown();
@@ -177,6 +181,7 @@ void Init()
 				}
 				else
 				{
+continue_setup:
 					libusb_config_descriptor *config = nullptr;
 					libusb_get_config_descriptor(device, 0, &config);
 					for (u8 ic = 0; ic < config->bNumInterfaces; ic++)

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -185,10 +185,12 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateGamecubeSizer()
 	{
 		m_gamecube_adapter->SetValue(SConfig::GetInstance().m_GameCubeAdapter);
 		m_gamecube_adapter_thread->SetValue(SConfig::GetInstance().m_GameCubeAdapterThread);
+		// Disable the adapter options when emulation is running
 		if (Core::GetState() != Core::CORE_UNINITIALIZED)
 		{
 			m_gamecube_adapter->Disable();
 			m_gamecube_adapter_thread->Disable();
+			m_gamecube_adapter_scan->Disable();
 		}
 	}
 #endif

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -177,7 +177,6 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateGamecubeSizer()
 			m_gamecube_adapter->SetLabelText(_("Adapter Not Detected"));
 		}
 		m_gamecube_adapter->SetValue(false);
-		m_gamecube_adapter->SetValue(false);
 		m_gamecube_adapter->Disable();
 		m_gamecube_adapter_thread->SetValue(false);
 		m_gamecube_adapter_thread->Disable();
@@ -186,7 +185,6 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateGamecubeSizer()
 	{
 		m_gamecube_adapter->SetValue(SConfig::GetInstance().m_GameCubeAdapter);
 		m_gamecube_adapter_thread->SetValue(SConfig::GetInstance().m_GameCubeAdapterThread);
-		m_gamecube_adapter_scan->Disable();
 		if (Core::GetState() != Core::CORE_UNINITIALIZED)
 		{
 			m_gamecube_adapter->Disable();

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -149,14 +149,18 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateGamecubeSizer()
 	wxStaticBoxSizer* const gamecube_adapter_group = new wxStaticBoxSizer(wxHORIZONTAL, this, _("GameCube Adapter"));
 	wxBoxSizer* const gamecube_adapter_sizer = new wxBoxSizer(wxHORIZONTAL);
 
-	wxCheckBox* const gamecube_adapter = new wxCheckBox(this, wxID_ANY, _("Direct Connect"));
-	gamecube_adapter->Bind(wxEVT_CHECKBOX, &ControllerConfigDiag::OnGameCubeAdapter, this);
+	m_gamecube_adapter = new wxCheckBox(this, wxID_ANY, _("Direct Connect"));
+	m_gamecube_adapter->Bind(wxEVT_CHECKBOX, &ControllerConfigDiag::OnGameCubeAdapter, this);
 
-	wxCheckBox* const gamecube_adapter_thread = new wxCheckBox(this, wxID_ANY, _("Use Thread"));
-	gamecube_adapter_thread->Bind(wxEVT_CHECKBOX, &ControllerConfigDiag::OnGameCubeAdapterThread, this);
+	m_gamecube_adapter_thread = new wxCheckBox(this, wxID_ANY, _("Use Thread"));
+	m_gamecube_adapter_thread->Bind(wxEVT_CHECKBOX, &ControllerConfigDiag::OnGameCubeAdapterThread, this);
 
-	gamecube_adapter_sizer->Add(gamecube_adapter, 0, wxEXPAND);
-	gamecube_adapter_sizer->Add(gamecube_adapter_thread, 0, wxEXPAND);
+	m_gamecube_adapter_scan = new wxButton(this, wxID_ANY, _("Find adapter"));
+	m_gamecube_adapter_scan->Bind(wxEVT_BUTTON, &ControllerConfigDiag::OnGameCubeAdapterScan, this);
+
+	gamecube_adapter_sizer->Add(m_gamecube_adapter, 0, wxEXPAND);
+	gamecube_adapter_sizer->Add(m_gamecube_adapter_thread, 0, wxEXPAND);
+	gamecube_adapter_sizer->Add(m_gamecube_adapter_scan, 0, wxEXPAND);
 	gamecube_adapter_group->Add(gamecube_adapter_sizer, 0, wxEXPAND);
 	gamecube_static_sizer->Add(gamecube_adapter_group, 0, wxEXPAND);
 
@@ -164,22 +168,29 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateGamecubeSizer()
 	if (!SI_GCAdapter::IsDetected())
 	{
 		if (!SI_GCAdapter::IsDriverDetected())
-			gamecube_adapter->SetLabelText(_("Driver Not Detected"));
+		{
+			m_gamecube_adapter->SetLabelText(_("Driver Not Detected"));
+			m_gamecube_adapter_scan->Disable();
+		}
 		else
-			gamecube_adapter->SetLabelText(_("Adapter Not Detected"));
-		gamecube_adapter->SetValue(false);
-		gamecube_adapter->Disable();
-		gamecube_adapter_thread->SetValue(false);
-		gamecube_adapter_thread->Disable();
+		{
+			m_gamecube_adapter->SetLabelText(_("Adapter Not Detected"));
+		}
+		m_gamecube_adapter->SetValue(false);
+		m_gamecube_adapter->SetValue(false);
+		m_gamecube_adapter->Disable();
+		m_gamecube_adapter_thread->SetValue(false);
+		m_gamecube_adapter_thread->Disable();
 	}
 	else
 	{
-		gamecube_adapter->SetValue(SConfig::GetInstance().m_GameCubeAdapter);
-		gamecube_adapter_thread->SetValue(SConfig::GetInstance().m_GameCubeAdapterThread);
+		m_gamecube_adapter->SetValue(SConfig::GetInstance().m_GameCubeAdapter);
+		m_gamecube_adapter_thread->SetValue(SConfig::GetInstance().m_GameCubeAdapterThread);
+		m_gamecube_adapter_scan->Disable();
 		if (Core::GetState() != Core::CORE_UNINITIALIZED)
 		{
-			gamecube_adapter->Disable();
-			gamecube_adapter_thread->Disable();
+			m_gamecube_adapter->Disable();
+			m_gamecube_adapter_thread->Disable();
 		}
 	}
 #endif

--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -2,11 +2,11 @@
 
 #include <array>
 #include <map>
+#include <wx/button.h>
+#include <wx/checkbox.h>
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/windowid.h>
-#include <wx/checkbox.h>
-#include <wx/button.h>
 
 #include "Common/SysConf.h"
 #include "Core/ConfigManager.h"
@@ -74,26 +74,29 @@ public:
 	}
 	void OnGameCubeAdapterScan(wxCommandEvent& event)
 	{
+		bool gcadapter_config = SConfig::GetInstance().m_GameCubeAdapter;
+		// required for SI_GCAdapter::Shutdown() to proceed
 		SConfig::GetInstance().m_GameCubeAdapter = true;
-		SConfig::GetInstance().m_GameCubeAdapterThread = true;
 		SI_GCAdapter::Shutdown();
 		SI_GCAdapter::Init();
 		if (SI_GCAdapter::IsDetected())
 		{
+			m_gamecube_adapter->SetLabelText(_("Direct Connect"));
 			m_gamecube_adapter->Enable();
-			m_gamecube_adapter->SetValue(true);
 			m_gamecube_adapter_thread->Enable();
-			m_gamecube_adapter_thread->SetValue(true);
+
+			m_gamecube_adapter->SetValue(gcadapter_config);
+			m_gamecube_adapter_thread->SetValue(SConfig::GetInstance().m_GameCubeAdapterThread);
 		}
 		else
 		{
+			m_gamecube_adapter->SetLabelText(_("Adapter Not Detected"));
 			m_gamecube_adapter->Disable();
 			m_gamecube_adapter->SetValue(false);
 			m_gamecube_adapter_thread->Disable();
 			m_gamecube_adapter_thread->SetValue(false);
-			SConfig::GetInstance().m_GameCubeAdapter = false;
-			SConfig::GetInstance().m_GameCubeAdapterThread = false;
 		}
+		SConfig::GetInstance().m_GameCubeAdapter = gcadapter_config;
 		event.Skip();
 	}
 

--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -5,10 +5,13 @@
 #include <wx/dialog.h>
 #include <wx/event.h>
 #include <wx/windowid.h>
+#include <wx/checkbox.h>
+#include <wx/button.h>
 
 #include "Common/SysConf.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/Wiimote.h"
+#include "Core/HW/SI_GCAdapter.h"
 
 class InputConfig;
 class wxButton;
@@ -69,6 +72,26 @@ public:
 		SConfig::GetInstance().m_GameCubeAdapterThread = event.IsChecked();
 		event.Skip();
 	}
+	void OnGameCubeAdapterScan(wxCommandEvent& event)
+	{
+		SConfig::GetInstance().m_GameCubeAdapter = true;
+		SConfig::GetInstance().m_GameCubeAdapterThread = true;
+		SI_GCAdapter::Init();
+		if (SI_GCAdapter::IsDetected())
+		{
+			m_gamecube_adapter->Enable();
+			m_gamecube_adapter->SetValue(true);
+			m_gamecube_adapter_thread->Enable();
+			m_gamecube_adapter_thread->SetValue(true);
+			m_gamecube_adapter_scan->Disable();
+		}
+		else
+		{
+			SConfig::GetInstance().m_GameCubeAdapter = false;
+			SConfig::GetInstance().m_GameCubeAdapterThread = false;
+		}
+		event.Skip();
+	}
 
 private:
 	wxStaticBoxSizer* CreateGamecubeSizer();
@@ -91,4 +114,8 @@ private:
 	wxButton* wiimote_configure_bt[MAX_WIIMOTES];
 	wxButton* gamecube_configure_bt[4];
 	std::map<wxWindowID, unsigned int> m_wiimote_index_from_conf_bt_id;
+
+	wxCheckBox* m_gamecube_adapter;
+	wxCheckBox* m_gamecube_adapter_thread;
+	wxButton* m_gamecube_adapter_scan;
 };

--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -76,6 +76,7 @@ public:
 	{
 		SConfig::GetInstance().m_GameCubeAdapter = true;
 		SConfig::GetInstance().m_GameCubeAdapterThread = true;
+		SI_GCAdapter::Shutdown();
 		SI_GCAdapter::Init();
 		if (SI_GCAdapter::IsDetected())
 		{
@@ -83,10 +84,13 @@ public:
 			m_gamecube_adapter->SetValue(true);
 			m_gamecube_adapter_thread->Enable();
 			m_gamecube_adapter_thread->SetValue(true);
-			m_gamecube_adapter_scan->Disable();
 		}
 		else
 		{
+			m_gamecube_adapter->Disable();
+			m_gamecube_adapter->SetValue(false);
+			m_gamecube_adapter_thread->Disable();
+			m_gamecube_adapter_thread->SetValue(false);
 			SConfig::GetInstance().m_GameCubeAdapter = false;
 			SConfig::GetInstance().m_GameCubeAdapterThread = false;
 		}


### PR DESCRIPTION
This is useful when:
- The adapter was not plugged in when dolphin started
- The adapter gets unplugged (or unplugged and then re-plugged) while dolphin is running

Initially that also permitted to re-scan for the adapter when dolphin was terminated abruptly (like a segfault) and was unable to get a hold of the device quickly after startup, but this branch also fixes that.