### PR TITLE
VolumeWiiCrypted: Decryption optimization

### DIFF
--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -33,7 +33,7 @@ CVolumeWiiCrypted::CVolumeWiiCrypted(IBlobReader* _pReader, u64 _VolumeOffset,
 	m_LastDecryptedBlockOffset(-1)
 {
 	aes_setkey_dec(m_AES_ctx.get(), _pVolumeKey, 128);
-	m_pBuffer = new u8[0x8000];
+	m_pBuffer = new u8[s_block_total_size];
 }
 
 bool CVolumeWiiCrypted::ChangePartition(u64 offset)
@@ -66,20 +66,21 @@ bool CVolumeWiiCrypted::Read(u64 _ReadOffset, u64 _Length, u8* _pBuffer, bool de
 	while (_Length > 0)
 	{
 		// Calculate block offset
-		u64 Block  = _ReadOffset / 0x7C00;
-		u64 Offset = _ReadOffset % 0x7C00;
+		u64 Block  = _ReadOffset / s_block_data_size;
+		u64 Offset = _ReadOffset % s_block_data_size;
 
 		if (m_LastDecryptedBlockOffset != Block)
 		{
 			// Read the current block
-			if (!m_pReader->Read(m_VolumeOffset + m_dataOffset + Block * 0x8000, 0x8000, m_pBuffer))
+			if (!m_pReader->Read(m_VolumeOffset + m_dataOffset + Block * s_block_total_size, s_block_total_size, m_pBuffer))
 				return false;
 
 			// Decrypt the block's data.
 			// 0x3D0 - 0x3DF in m_pBuffer will be overwritten,
 			// but that won't affect anything, because we won't
 			// use the content of m_pBuffer anymore after this
-			aes_crypt_cbc(m_AES_ctx.get(), AES_DECRYPT, 0x7C00, m_pBuffer + 0x3D0, m_pBuffer + 0x400, m_LastDecryptedBlock);
+			aes_crypt_cbc(m_AES_ctx.get(), AES_DECRYPT, s_block_data_size, m_pBuffer + 0x3D0,
+			              m_pBuffer + s_block_header_size, m_LastDecryptedBlock);
 			m_LastDecryptedBlockOffset = Block;
 
 			// The only thing we currently use from the 0x000 - 0x3FF part
@@ -89,7 +90,7 @@ bool CVolumeWiiCrypted::Read(u64 _ReadOffset, u64 _Length, u8* _pBuffer, bool de
 		}
 
 		// Copy the decrypted data
-		u64 MaxSizeToCopy = 0x7C00 - Offset;
+		u64 MaxSizeToCopy = s_block_data_size - Offset;
 		u64 CopySize = (_Length > MaxSizeToCopy) ? MaxSizeToCopy : _Length;
 		memcpy(_pBuffer, &m_LastDecryptedBlock[Offset], (size_t)CopySize);
 

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -53,7 +53,7 @@ private:
 	u64 m_dataOffset;
 
 	mutable u64 m_LastDecryptedBlockOffset;
-	mutable unsigned char m_LastDecryptedBlock[0x8000];
+	mutable unsigned char m_LastDecryptedBlock[0x7C00];
 };
 
 } // namespace

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -44,6 +44,10 @@ public:
 	bool ChangePartition(u64 offset) override;
 
 private:
+	static const unsigned int s_block_header_size = 0x0400;
+	static const unsigned int s_block_data_size   = 0x7C00;
+	static const unsigned int s_block_total_size  = s_block_header_size + s_block_data_size;
+
 	std::unique_ptr<IBlobReader> m_pReader;
 	std::unique_ptr<aes_context> m_AES_ctx;
 
@@ -53,7 +57,7 @@ private:
 	u64 m_dataOffset;
 
 	mutable u64 m_LastDecryptedBlockOffset;
-	mutable unsigned char m_LastDecryptedBlock[0x7C00];
+	mutable unsigned char m_LastDecryptedBlock[s_block_data_size];
 };
 
 } // namespace


### PR DESCRIPTION
The block doesn't have to be read if it already is in m_pBuffer.

@tueidj: This should fix the problem you pointed out.