### PR TITLE
Fix D3D regression from PR1948.

### DIFF
--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -153,6 +153,10 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 	else
 		D3D::SetPointCopySampler();
 
+	// Make sure we don't draw with the texture set as both a source and target.
+	// (This can happen because we don't unbind textures when we free them.)
+	D3D::stateman->UnsetTexture(texture->GetSRV());
+
 	D3D::context->OMSetRenderTargets(1, &texture->GetRTV(), nullptr);
 
 	// Create texture copy


### PR DESCRIPTION
Make sure we don't have a texture bound as both an ShaderResourceView and
a RenderTargetView; this causes rendering glitches.

This isn't really the right place to do this... but I'm not sure
how the code should be structured.