### PR TITLE
DSPDebugWindow: Fix issue where the DSPLLE window would hang Dolphin on OSX

### DIFF
--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
@@ -171,7 +171,6 @@ void DSPDebuggerLLE::Update()
 	UpdateDisAsmListView();
 	UpdateRegisterFlags();
 	UpdateState();
-	m_mgr.Update();
 #if defined __WXGTK__
 	if (!wxIsMainThread())
 		wxMutexGuiLeave();


### PR DESCRIPTION
This isn't necessary either, because none of the functions before it modify the actual enclosing panes' location or other traits which would make it necessary. Even if they did modify it, the update should be called immediately after those changes.