### PR TITLE
Fix clang on x86_64.

### DIFF
--- a/Source/Core/Common/Hash.cpp
+++ b/Source/Core/Common/Hash.cpp
@@ -10,7 +10,7 @@
 #include <nmmintrin.h>
 #endif
 
-static u64 (*ptrHashFunction)(const u8 *src, int len, u32 samples) = &GetMurmurHash3;
+static u64 (*ptrHashFunction)(const u8 *src, u32 len, u32 samples) = &GetMurmurHash3;
 
 // uint32_t
 // WARNING - may read one more byte!
@@ -151,7 +151,7 @@ inline u64 fmix64(u64 k)
 	return k;
 }
 
-u64 GetMurmurHash3(const u8 *src, int len, u32 samples)
+u64 GetMurmurHash3(const u8 *src, u32 len, u32 samples)
 {
 	const u8 * data = (const u8*)src;
 	const int nblocks = len / 16;
@@ -227,7 +227,7 @@ u64 GetMurmurHash3(const u8 *src, int len, u32 samples)
 
 
 // CRC32 hash using the SSE4.2 instruction
-u64 GetCRC32(const u8 *src, int len, u32 samples)
+u64 GetCRC32(const u8 *src, u32 len, u32 samples)
 {
 #if _M_SSE >= 0x402
 	u64 h[4] = { len, 0, 0, 0 };
@@ -269,7 +269,7 @@ u64 GetCRC32(const u8 *src, int len, u32 samples)
  * changed, make sure this one is still used when the legacy parameter is
  * true.
  */
-u64 GetHashHiresTexture(const u8 *src, int len, u32 samples)
+u64 GetHashHiresTexture(const u8 *src, u32 len, u32 samples)
 {
 	const u64 m = 0xc6a4a7935bd1e995;
 	u64 h = len * m;
@@ -313,7 +313,7 @@ u64 GetHashHiresTexture(const u8 *src, int len, u32 samples)
 }
 #else
 // CRC32 hash using the SSE4.2 instruction
-u64 GetCRC32(const u8 *src, int len, u32 samples)
+u64 GetCRC32(const u8 *src, u32 len, u32 samples)
 {
 #if _M_SSE >= 0x402
 	u32 h = len;
@@ -386,7 +386,7 @@ inline void bmix32(u32 & h1, u32 & h2, u32 & k1, u32 & k2, u32 & c1, u32 & c2)
 
 //----------
 
-u64 GetMurmurHash3(const u8* src, int len, u32 samples)
+u64 GetMurmurHash3(const u8* src, u32 len, u32 samples)
 {
 	const u8 * data = (const u8*)src;
 	u32 out[2];
@@ -460,7 +460,7 @@ u64 GetMurmurHash3(const u8* src, int len, u32 samples)
  * 64-bit version. Until someone can make a new version of the 32-bit one that
  * makes identical hashes, this is just a c/p of the 64-bit one.
  */
-u64 GetHashHiresTexture(const u8 *src, int len, u32 samples)
+u64 GetHashHiresTexture(const u8 *src, u32 len, u32 samples)
 {
 	const u64 m = 0xc6a4a7935bd1e995ULL;
 	u64 h = len * m;
@@ -504,7 +504,7 @@ u64 GetHashHiresTexture(const u8 *src, int len, u32 samples)
 }
 #endif
 
-u64 GetHash64(const u8 *src, int len, u32 samples)
+u64 GetHash64(const u8 *src, u32 len, u32 samples)
 {
 	return ptrHashFunction(src, len, samples);
 }

--- a/Source/Core/Common/Hash.h
+++ b/Source/Core/Common/Hash.h
@@ -12,8 +12,8 @@ u32 HashFletcher(const u8* data_u8, size_t length);  // FAST. Length & 1 == 0.
 u32 HashAdler32(const u8* data, size_t len);         // Fairly accurate, slightly slower
 u32 HashFNV(const u8* ptr, int length);              // Another fast and decent hash
 u32 HashEctor(const u8* ptr, int length);            // JUNK. DO NOT USE FOR NEW THINGS
-u64 GetCRC32(const u8 *src, int len, u32 samples);   // SSE4.2 version of CRC32
-u64 GetHashHiresTexture(const u8 *src, int len, u32 samples = 0);
-u64 GetMurmurHash3(const u8 *src, int len, u32 samples);
-u64 GetHash64(const u8 *src, int len, u32 samples);
+u64 GetCRC32(const u8 *src, u32 len, u32 samples);   // SSE4.2 version of CRC32
+u64 GetHashHiresTexture(const u8 *src, u32 len, u32 samples = 0);
+u64 GetMurmurHash3(const u8 *src, u32 len, u32 samples);
+u64 GetHash64(const u8 *src, u32 len, u32 samples);
 void SetHash64Function();


### PR DESCRIPTION
If we are compiling in the CRC32 hash, clang has an issue with casting a s32 to a u64.
Change our lens argument to a unsigned integer to fix the issue.