### PR TITLE
Remove an old outdated comment that makes no sense.

### DIFF
--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -98,7 +98,7 @@ void SCoreStartupParameter::LoadDefaults()
 	bJITOff = false; // debugger only settings
 	bJITLoadStoreOff = false;
 	bJITLoadStoreFloatingOff = false;
-	bJITLoadStorePairedOff = false; // XXX not 64-bit clean
+	bJITLoadStorePairedOff = false;
 	bJITFloatingPointOff = false;
 	bJITIntegerOff = false;
 	bJITPairedOff = false;


### PR DESCRIPTION
This comment was left over from a long time ago. It is no longer true.