### PR TITLE
Fix issues with the GC adapter handling code

### DIFF
--- a/Source/Core/Core/HW/SI_GCAdapter.h
+++ b/Source/Core/Core/HW/SI_GCAdapter.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+struct libusb_device;
+
 #include "Common/Thread.h"
 #include "Core/HW/SI.h"
 #include "InputCommon/GCPadStatus.h"
@@ -12,7 +14,10 @@ namespace SI_GCAdapter
 {
 
 void Init();
+void Reset();
+void Setup();
 void Shutdown();
+void AddGCAdapter(libusb_device* device);
 void Input(int chan, GCPadStatus* pad);
 void Output(int chan, u8 rumble_command);
 bool IsDetected();


### PR DESCRIPTION
I split this from PR #1968 because it will be useful in any case, regardless which solution is adopted for refreshing the adapter status, or when it is adopted.

- successfully detaching the kernel driver from the interface should make the setup continue, not abort
- refactor the code a bit to avoid setting up and exiting libusb every time dolphin needs to detect gc adapters

for "adapter-thread"-less code:
- remove libusb_handle_events() because the API says it shouln't be used, and its 60 seconds timeout causes issues (e.g. closing dolphin takes 60 seconds if the option is on). Instead, use libusb_handle_events_timeout_completed() with a 1 second timeout.
- cancel any pending usb transfers before freeing them and closing the device (generates libusb errors and potential crashes)