### PR TITLE
Use unique_ptr for some IVolume instances

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -210,7 +210,7 @@ bool CBoot::BootUp()
 	// GCM and Wii
 	case SCoreStartupParameter::BOOT_ISO:
 	{
-		DiscIO::IVolume* pVolume = DiscIO::CreateVolumeFromFilename(_StartupPara.m_strFilename);
+		std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(_StartupPara.m_strFilename));
 		if (pVolume == nullptr)
 			break;
 
@@ -267,13 +267,11 @@ bool CBoot::BootUp()
 			}
 		}
 
-		/* Try to load the symbol map if there is one, and then scan it for
-			and eventually replace code */
+		// Try to load the symbol map if there is one, and then scan it for
+		// and eventually replace code
 		if (LoadMapFromFilename())
 			HLE::PatchFunctions();
 
-		// We don't need the volume any more
-		delete pVolume;
 		break;
 	}
 

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -120,7 +120,7 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
 	Memory::Write_U32(Memory::Read_U32(0x00003140), 0x00003188);
 
 	// Load patches and run startup patches
-	const DiscIO::IVolume* pVolume = DiscIO::CreateVolumeFromFilename(_pFilename);
+	const std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(_pFilename));
 	if (pVolume != nullptr)
 		PatchEngine::LoadPatches();
 

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -299,7 +299,7 @@ QString GameFile::GetName(int index) const
 
 const QString GameFile::GetWiiFSPath() const
 {
-	DiscIO::IVolume* volume = DiscIO::CreateVolumeFromFilename(m_file_name.toStdString());
+	std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(m_file_name.toStdString()));
 	QString ret;
 
 	if (volume == nullptr)
@@ -323,7 +323,6 @@ const QString GameFile::GetWiiFSPath() const
 		else
 			ret = QString::fromStdString(path);
 	}
-	delete volume;
 
 	return ret;
 }


### PR DESCRIPTION
Also fixes a leak that would occur any time a WAD was launched.