### PR TITLE
OGL: Fix a memory leak that would occur every time a game is launched

### DIFF
--- a/Source/Core/VideoBackends/OGL/GLInterfaceBase.h
+++ b/Source/Core/VideoBackends/OGL/GLInterfaceBase.h
@@ -24,6 +24,7 @@ protected:
 
 	u32 s_opengl_mode;
 public:
+	virtual ~cInterfaceBase() {}
 	virtual void Swap() {}
 	virtual void SetMode(u32 mode) { s_opengl_mode = GLInterfaceMode::MODE_OPENGL; }
 	virtual u32 GetMode() { return s_opengl_mode; }

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -225,6 +225,7 @@ void VideoBackend::Shutdown()
 	OSD::DoCallbacks(OSD::OSD_SHUTDOWN);
 
 	GLInterface->Shutdown();
+	delete GLInterface;
 }
 
 void VideoBackend::Video_Cleanup()

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -163,6 +163,7 @@ void VideoSoftware::Shutdown()
 	OSD::DoCallbacks(OSD::OSD_SHUTDOWN);
 
 	GLInterface->Shutdown();
+	delete GLInterface;
 }
 
 void VideoSoftware::Video_Cleanup()


### PR DESCRIPTION
The GL interface would always be re-initialized, but the previous instance would never be deleted.