### PR TITLE
Asyncevents

### DIFF
--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -95,6 +95,9 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
 			Renderer::Swap(e.swap_event.xfbAddr, e.swap_event.fbWidth, e.swap_event.fbStride, e.swap_event.fbHeight, rc);
 			break;
 
+		case Event::BBOX_READ:
+			*e.bbox.data = g_renderer->BBoxRead(e.bbox.index);
+
 	}
 }
 

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -97,6 +97,11 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
 
 		case Event::BBOX_READ:
 			*e.bbox.data = g_renderer->BBoxRead(e.bbox.index);
+			break;
+
+		case Event::PERF_QUERY:
+			g_perf_query->FlushResults();
+			break;
 
 	}
 }

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -1,0 +1,88 @@
+#include "VideoCommon/AsyncRequests.h"
+#include "VideoCommon/RenderBase.h"
+
+AsyncRequests AsyncRequests::s_singleton;
+
+AsyncRequests::AsyncRequests()
+: m_enable(false)
+{
+}
+
+void AsyncRequests::PullEventsInternal()
+{
+	std::unique_lock<std::mutex> lock(m_mutex);
+	m_empty.store(true);
+
+	while (!m_queue.empty())
+	{
+		const Event& e = m_queue.front();
+
+		lock.unlock();
+		HandleEvent(e);
+		lock.lock();
+
+		m_queue.pop();
+	}
+
+	if (m_wake_me_up_again)
+	{
+		m_wake_me_up_again = false;
+		m_cond.notify_all();
+	}
+}
+
+void AsyncRequests::PushEvent(const AsyncRequests::Event& event, bool blocking)
+{
+	std::unique_lock<std::mutex> lock(m_mutex);
+	m_empty.store(false);
+	m_wake_me_up_again |= blocking;
+
+	if (!m_enable)
+		return;
+
+	m_queue.push(event);
+
+	if (blocking)
+	{
+		m_cond.wait(lock, [this]{return m_queue.empty();});
+	}
+}
+
+void AsyncRequests::SetEnable(bool enable)
+{
+	std::unique_lock<std::mutex> lock(m_mutex);
+	m_enable = enable;
+
+	if (!enable)
+	{
+		// flush the queue on disabling
+		while (!m_queue.empty())
+			m_queue.pop();
+		if (m_wake_me_up_again)
+			m_cond.notify_all();
+	}
+}
+
+void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
+{
+	switch (e.type)
+	{
+		case Event::EFB_POKE_COLOR:
+			g_renderer->AccessEFB(POKE_COLOR, e.efb_poke.x, e.efb_poke.y, e.efb_poke.data);
+			break;
+
+		case Event::EFB_POKE_Z:
+			g_renderer->AccessEFB(POKE_Z, e.efb_poke.x, e.efb_poke.y, e.efb_poke.data);
+			break;
+
+		case Event::EFB_PEEK_COLOR:
+			*e.efb_peek.data = g_renderer->AccessEFB(PEEK_COLOR, e.efb_peek.x, e.efb_peek.y, 0);
+			break;
+
+		case Event::EFB_PEEK_Z:
+			*e.efb_peek.data = g_renderer->AccessEFB(PEEK_Z, e.efb_peek.x, e.efb_peek.y, 0);
+			break;
+
+	}
+}
+

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -24,6 +24,7 @@ public:
 			EFB_PEEK_Z,
 			SWAP_EVENT,
 			BBOX_READ,
+			PERF_QUERY,
 		} type;
 		u64 time;
 
@@ -56,6 +57,10 @@ public:
 				int index;
 				u16* data;
 			} bbox;
+
+			struct
+			{
+			} perf_query;
 		};
 	};
 

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -22,6 +22,7 @@ public:
 			EFB_POKE_Z,
 			EFB_PEEK_COLOR,
 			EFB_PEEK_Z,
+			SWAP_EVENT,
 		} type;
 		u64 time;
 
@@ -40,6 +41,14 @@ public:
 				u16 y;
 				u32* data;
 			} efb_peek;
+
+			struct
+			{
+				u32 xfbAddr;
+				u32 fbWidth;
+				u32 fbStride;
+				u32 fbHeight;
+			} swap_event;
 		};
 	};
 
@@ -52,6 +61,7 @@ public:
 	}
 	void PushEvent(const Event& event, bool blocking = false);
 	void SetEnable(bool enable);
+	void SetPassthrough(bool enable);
 
 	static AsyncRequests* GetInstance() { return &s_singleton; }
 
@@ -68,4 +78,5 @@ private:
 
 	bool m_wake_me_up_again;
 	bool m_enable;
+	bool m_passthrough;
 };

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -23,6 +23,7 @@ public:
 			EFB_PEEK_COLOR,
 			EFB_PEEK_Z,
 			SWAP_EVENT,
+			BBOX_READ,
 		} type;
 		u64 time;
 
@@ -49,6 +50,12 @@ public:
 				u32 fbStride;
 				u32 fbHeight;
 			} swap_event;
+
+			struct
+			{
+				int index;
+				u16* data;
+			} bbox;
 		};
 	};
 

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SRCS	BoundingBox.cpp
+set(SRCS	AsyncRequests.cpp
+			BoundingBox.cpp
 			BPFunctions.cpp
 			BPMemory.cpp
 			BPStructs.cpp

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -284,6 +284,7 @@ void RunGpuLoop()
 	bool yield_cpu = cpu_info.num_cores <= 2;
 
 	AsyncRequests::GetInstance()->SetEnable(true);
+	AsyncRequests::GetInstance()->SetPassthrough(false);
 
 	while (GpuRunningState)
 	{
@@ -383,6 +384,7 @@ void RunGpuLoop()
 	// wake up SyncGPU if we were interrupted
 	s_video_buffer_cond.notify_all();
 	AsyncRequests::GetInstance()->SetEnable(false);
+	AsyncRequests::GetInstance()->SetPassthrough(true);
 }
 
 

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -15,6 +15,7 @@
 #include "Core/NetPlayProto.h"
 #include "Core/HW/Memmap.h"
 
+#include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/DataReader.h"
@@ -282,11 +283,14 @@ void RunGpuLoop()
 	// This allows a system that we are maxing out in dual core mode to do other things
 	bool yield_cpu = cpu_info.num_cores <= 2;
 
+	AsyncRequests::GetInstance()->SetEnable(true);
+
 	while (GpuRunningState)
 	{
 		g_video_backend->PeekMessages();
 
 		VideoFifo_CheckAsyncRequest();
+		AsyncRequests::GetInstance()->PullEvents();
 		if (g_use_deterministic_gpu_thread)
 		{
 			// All the fifo/CP stuff is on the CPU.  We just need to run the opcode decoder.
@@ -349,6 +353,7 @@ void RunGpuLoop()
 				// If we don't, s_swapRequested or s_efbAccessRequested won't be set to false
 				// leading the CPU thread to wait in Video_BeginField or Video_AccessEFB thus slowing things down.
 				VideoFifo_CheckAsyncRequest();
+				AsyncRequests::GetInstance()->PullEvents();
 				CommandProcessor::isPossibleWaitingSetDrawDone = false;
 			}
 
@@ -377,6 +382,7 @@ void RunGpuLoop()
 	}
 	// wake up SyncGPU if we were interrupted
 	s_video_buffer_cond.notify_all();
+	AsyncRequests::GetInstance()->SetEnable(false);
 }
 
 

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -290,7 +290,6 @@ void RunGpuLoop()
 	{
 		g_video_backend->PeekMessages();
 
-		VideoFifo_CheckAsyncRequest();
 		AsyncRequests::GetInstance()->PullEvents();
 		if (g_use_deterministic_gpu_thread)
 		{
@@ -353,7 +352,6 @@ void RunGpuLoop()
 				// This call is pretty important in DualCore mode and must be called in the FIFO Loop.
 				// If we don't, s_swapRequested or s_efbAccessRequested won't be set to false
 				// leading the CPU thread to wait in Video_BeginField or Video_AccessEFB thus slowing things down.
-				VideoFifo_CheckAsyncRequest();
 				AsyncRequests::GetInstance()->PullEvents();
 				CommandProcessor::isPossibleWaitingSetDrawDone = false;
 			}

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -53,7 +53,3 @@ void EmulatorState(bool running);
 bool AtBreakpoint();
 void ResetVideoBuffer();
 void Fifo_SetRendering(bool bEnabled);
-
-
-// Implemented by the Video Backend
-void VideoFifo_CheckAsyncRequest();

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -1,6 +1,7 @@
 #include "Common/Event.h"
 #include "Core/ConfigManager.h"
 
+#include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/BPStructs.h"
 #include "VideoCommon/CommandProcessor.h"
@@ -20,8 +21,6 @@ bool s_BackendInitialized = false;
 
 Common::Flag s_swapRequested;
 static Common::Flag s_FifoShuttingDown;
-static Common::Flag s_efbAccessRequested;
-static Common::Event s_efbAccessReadyEvent;
 
 static Common::Flag s_perfQueryRequested;
 static Common::Event s_perfQueryReadyEvent;
@@ -39,16 +38,6 @@ static volatile struct
 	u32 fbHeight;
 } s_beginFieldArgs;
 
-static struct
-{
-	EFBAccessType type;
-	u32 x;
-	u32 y;
-	u32 Data;
-} s_accessEFBArgs;
-
-static u32 s_AccessEFBResult = 0;
-
 void VideoBackendHardware::EmuStateChange(EMUSTATE_CHANGE newState)
 {
 	EmulatorState((newState == EMUSTATE_CHANGE_PLAY) ? true : false);
@@ -64,7 +53,6 @@ void VideoBackendHardware::Video_ExitLoop()
 {
 	ExitGpuLoop();
 	s_FifoShuttingDown.Set();
-	s_efbAccessReadyEvent.Set();
 	s_perfQueryReadyEvent.Set();
 }
 
@@ -152,44 +140,36 @@ bool VideoBackendHardware::Video_Screenshot(const std::string& filename)
 	return true;
 }
 
-void VideoFifo_CheckEFBAccess()
-{
-	if (s_efbAccessRequested.IsSet())
-	{
-		s_AccessEFBResult = g_renderer->AccessEFB(s_accessEFBArgs.type, s_accessEFBArgs.x, s_accessEFBArgs.y, s_accessEFBArgs.Data);
-		s_efbAccessRequested.Clear();
-		s_efbAccessReadyEvent.Set();
-	}
-}
-
 u32 VideoBackendHardware::Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)
 {
-	if (s_BackendInitialized && g_ActiveConfig.bEFBAccessEnable)
+	if (!g_ActiveConfig.bEFBAccessEnable)
 	{
-		SyncGPU(SYNC_GPU_EFB_POKE);
-
-		s_accessEFBArgs.type = type;
-		s_accessEFBArgs.x = x;
-		s_accessEFBArgs.y = y;
-		s_accessEFBArgs.Data = InputData;
-
-		s_efbAccessRequested.Set();
-
-		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
-		{
-			s_efbAccessReadyEvent.Reset();
-			if (s_FifoShuttingDown.IsSet())
-				return 0;
-			s_efbAccessRequested.Set();
-			s_efbAccessReadyEvent.Wait();
-		}
-		else
-			VideoFifo_CheckEFBAccess();
-
-		return s_AccessEFBResult;
+		return 0;
 	}
 
-	return 0;
+	if (type == POKE_COLOR || type == POKE_Z)
+	{
+		AsyncRequests::Event e;
+		e.type = type == POKE_COLOR ? AsyncRequests::Event::EFB_POKE_COLOR : AsyncRequests::Event::EFB_POKE_Z;
+		e.time = 0;
+		e.efb_poke.data = InputData;
+		e.efb_poke.x = x;
+		e.efb_poke.y = y;
+		AsyncRequests::GetInstance()->PushEvent(e, 0);
+		return 0;
+	}
+	else
+	{
+		AsyncRequests::Event e;
+		u32 result;
+		e.type = type == PEEK_COLOR ? AsyncRequests::Event::EFB_PEEK_COLOR : AsyncRequests::Event::EFB_PEEK_Z;
+		e.time = 0;
+		e.efb_peek.x = x;
+		e.efb_peek.y = y;
+		e.efb_peek.data = &result;
+		AsyncRequests::GetInstance()->PushEvent(e, 1);
+		return result;
+	}
 }
 
 static void VideoFifo_CheckPerfQueryRequest()
@@ -267,12 +247,9 @@ void VideoBackendHardware::InitializeShared()
 	VideoCommon_Init();
 
 	s_swapRequested.Clear();
-	s_efbAccessRequested.Clear();
 	s_perfQueryRequested.Clear();
 	s_FifoShuttingDown.Clear();
 	memset((void*)&s_beginFieldArgs, 0, sizeof(s_beginFieldArgs));
-	memset(&s_accessEFBArgs, 0, sizeof(s_accessEFBArgs));
-	s_AccessEFBResult = 0;
 	m_invalid = false;
 }
 
@@ -292,10 +269,7 @@ void VideoBackendHardware::DoState(PointerWrap& p)
 	p.DoMarker("VideoCommon");
 
 	p.Do(s_swapRequested);
-	p.Do(s_efbAccessRequested);
 	p.Do(s_beginFieldArgs);
-	p.Do(s_accessEFBArgs);
-	p.Do(s_AccessEFBResult);
 	p.DoMarker("VideoBackendHardware");
 
 	// Refresh state.
@@ -335,7 +309,6 @@ void VideoBackendHardware::RunLoop(bool enable)
 void VideoFifo_CheckAsyncRequest()
 {
 	VideoFifo_CheckSwapRequest();
-	VideoFifo_CheckEFBAccess();
 	VideoFifo_CheckPerfQueryRequest();
 	VideoFifo_CheckBBoxRequest();
 }

--- a/Source/Core/VideoCommon/MainBase.h
+++ b/Source/Core/VideoCommon/MainBase.h
@@ -6,5 +6,4 @@
 extern bool s_BackendInitialized;
 extern Common::Flag s_swapRequested;
 
-void VideoFifo_CheckEFBAccess();
 void VideoFifo_CheckSwapRequestAt(u32 xfbAddr, u32 fbWidth, u32 fbHeight);

--- a/Source/Core/VideoCommon/MainBase.h
+++ b/Source/Core/VideoCommon/MainBase.h
@@ -4,6 +4,3 @@
 #include "Common/Flag.h"
 
 extern bool s_BackendInitialized;
-extern Common::Flag s_swapRequested;
-
-void VideoFifo_CheckSwapRequestAt(u32 xfbAddr, u32 fbWidth, u32 fbHeight);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -116,7 +116,6 @@ void Renderer::RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbWidt
 	if (!fbWidth || !fbHeight)
 		return;
 
-	VideoFifo_CheckSwapRequestAt(xfbAddr, fbWidth, fbHeight);
 	XFBWrited = true;
 
 	if (g_ActiveConfig.bUseXFB)
@@ -126,7 +125,6 @@ void Renderer::RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbWidt
 	else
 	{
 		Swap(xfbAddr, fbWidth, fbWidth, fbHeight, sourceRc, Gamma);
-		s_swapRequested.Clear();
 	}
 }
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -116,7 +116,6 @@ void Renderer::RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbWidt
 	if (!fbWidth || !fbHeight)
 		return;
 
-	VideoFifo_CheckEFBAccess();
 	VideoFifo_CheckSwapRequestAt(xfbAddr, fbWidth, fbHeight);
 	XFBWrited = true;
 

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -166,8 +166,6 @@ void VertexManager::Flush()
 	// loading a state will invalidate BP, so check for it
 	g_video_backend->CheckInvalidState();
 
-	VideoFifo_CheckEFBAccess();
-
 #if defined(_DEBUG) || defined(DEBUGFAST)
 	PRIM_LOG("frame%d:\n texgen=%d, numchan=%d, dualtex=%d, ztex=%d, cole=%d, alpe=%d, ze=%d", g_ActiveConfig.iSaveTargetId, xfmem.numTexGen.numTexGens,
 		xfmem.numChan.numColorChans, xfmem.dualTexTrans.enabled, bpmem.ztex2.op,

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -35,6 +35,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
+    <ClCompile Include="AsyncRequests.cpp" />
     <ClCompile Include="AVIDump.cpp" />
     <ClCompile Include="BoundingBox.cpp" />
     <ClCompile Include="BPFunctions.cpp" />
@@ -84,6 +85,7 @@
     <ClCompile Include="XFStructs.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="AsyncRequests.h" />
     <ClInclude Include="AVIDump.h" />
     <ClInclude Include="BoundingBox.h" />
     <ClInclude Include="BPFunctions.h" />

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClCompile Include="TextureDecoder_x64.cpp">
       <Filter>Decoding</Filter>
     </ClCompile>
+    <ClCompile Include="AsyncRequests.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
     <ClCompile Include="BoundingBox.cpp">
       <Filter>Util</Filter>
     </ClCompile>
@@ -289,6 +292,9 @@
     </ClInclude>
     <ClInclude Include="VertexLoaderUtils.h">
       <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="AsyncRequests.h">
+      <Filter>Util</Filter>
     </ClInclude>
     <ClInclude Include="BoundingBox.h">
       <Filter>Util</Filter>


### PR DESCRIPTION
This PR creates a new async event handling framework. It is used to queue swap events, efb access, bbox reads and perf querys reads into a single atomic read on the gpu thread.

There are likely still lots of optimizations remaining, so this PR tries to not be slower and to clean up the code a bit.