### PR TITLE
Core: Explicitly declare enum values in switch statements

### DIFF
--- a/Source/Core/Common/Logging/ConsoleListener.cpp
+++ b/Source/Core/Common/Logging/ConsoleListener.cpp
@@ -303,7 +303,8 @@ void ConsoleListener::Log(LogTypes::LOG_LEVELS Level, const char *Text)
 		case LogTypes::LOG_LEVELS::LWARNING: // light yellow
 			strcpy(ColorAttr, "\033[93m");
 			break;
-		default:
+		case LogTypes::LOG_LEVELS::LDEBUG:
+		case LogTypes::LOG_LEVELS::LINFO:
 			break;
 		}
 	}

--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -136,11 +136,10 @@ bool SysConf::LoadFromFileInternal(FILE *fh)
 			curEntry.dataLength = 4;
 			break;
 
-		default:
+		case Type_Unknown:
 			PanicAlertT("Unknown entry type %i in SYSCONF (%s@%x)!",
 				curEntry.type, curEntry.name, curEntry.offset);
 			return false;
-			break;
 		}
 		// Fill in the actual data
 		if (curEntry.dataLength)
@@ -178,9 +177,11 @@ static unsigned int create_item(SSysConfEntry &item, SysconfType type, const std
 		case Type_Long:
 			// size of description + name length + data length
 			return 1 + item.nameLength + item.dataLength;
-		default:
+		case Type_Unknown:
 			return 0;
 	}
+
+	return 0;
 }
 
 void SysConf::GenerateSysConf()
@@ -347,7 +348,11 @@ void SysConf::GenerateSysConf()
 				g.WriteBytes(&null_byte, 1);
 				break;
 
-			default:
+			case Type_Bool:
+			case Type_Byte:
+			case Type_Long:
+			case Type_Short:
+			case Type_Unknown:
 				g.WriteBytes(items[i].data, items[i].dataLength);
 				break;
 		}

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -102,7 +102,9 @@ bool CBoot::FindMapFile(std::string* existing_map_file,
 				name_begin_index, _StartupPara.m_strFilename.size() - 4 - name_begin_index);
 		break;
 
-	default:
+	case SCoreStartupParameter::BOOT_BS2:
+	case SCoreStartupParameter::BOOT_DFF:
+	case SCoreStartupParameter::BOOT_ISO:
 		title_id_str = _StartupPara.GetUniqueID();
 		break;
 	}
@@ -391,12 +393,6 @@ bool CBoot::BootUp()
 	case SCoreStartupParameter::BOOT_DFF:
 		// do nothing
 		break;
-
-	default:
-	{
-		PanicAlertT("Tried to load an unknown file type.");
-		return false;
-	}
 	}
 
 	// HLE jump to loader (homebrew).  Disabled when Gecko is active as it interferes with the code handler

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -520,7 +520,8 @@ void SetState(EState _State)
 		CCPU::EnableStepping(false);
 		Wiimote::Resume();
 		break;
-	default:
+	case CORE_STOPPING:
+	case CORE_UNINITIALIZED:
 		PanicAlertT("Invalid state");
 		break;
 	}

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -172,6 +172,7 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 				case DiscIO::IVolume::COUNTRY_AUSTRALIA:
 				case DiscIO::IVolume::COUNTRY_EUROPE:
 				case DiscIO::IVolume::COUNTRY_FRANCE:
+				case DiscIO::IVolume::COUNTRY_GERMANY:
 				case DiscIO::IVolume::COUNTRY_INTERNATIONAL:
 				case DiscIO::IVolume::COUNTRY_ITALY:
 				case DiscIO::IVolume::COUNTRY_NETHERLANDS:
@@ -182,7 +183,7 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 					break;
 
 				case DiscIO::IVolume::COUNTRY_UNKNOWN:
-				default:
+				case DiscIO::IVolume::NUMBER_OF_COUNTRIES: // Should never happen.
 					if (PanicYesNoT("Your GCM/ISO file seems to be invalid (invalid country)."
 								   "\nContinue with PAL region?"))
 					{
@@ -257,15 +258,18 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 				case DiscIO::IVolume::COUNTRY_AUSTRALIA:
 				case DiscIO::IVolume::COUNTRY_EUROPE:
 				case DiscIO::IVolume::COUNTRY_FRANCE:
+				case DiscIO::IVolume::COUNTRY_GERMANY:
 				case DiscIO::IVolume::COUNTRY_INTERNATIONAL:
 				case DiscIO::IVolume::COUNTRY_ITALY:
+				case DiscIO::IVolume::COUNTRY_NETHERLANDS:
 				case DiscIO::IVolume::COUNTRY_RUSSIA:
+				case DiscIO::IVolume::COUNTRY_SPAIN:
 					bNTSC = false;
 					Region = EUR_DIR;
 					break;
 
 				case DiscIO::IVolume::COUNTRY_UNKNOWN:
-				default:
+				case DiscIO::IVolume::NUMBER_OF_COUNTRIES: // Should never happen.
 					bNTSC = false;
 					Region = EUR_DIR;
 						break;

--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -160,6 +160,7 @@ void gdsp_ifx_write(u32 addr, u32 val)
 			{
 				INFO_LOG(DSPLLE,"Gain Written: 0x%04x", val);
 			}
+			// Fallthrough
 		case DSP_DSPA:
 		case DSP_DSMAH:
 		case DSP_DSMAL:

--- a/Source/Core/Core/DSP/Jit/DSPJitUtil.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitUtil.cpp
@@ -204,7 +204,6 @@ void DSPEmitter::dsp_op_read_reg_dont_saturate(int reg, Gen::X64Reg host_dreg, D
 			MOVZX(64, 16, host_dreg, R(host_dreg));
 			break;
 		case NONE:
-		default:
 			break;
 		}
 		return;
@@ -232,7 +231,6 @@ void DSPEmitter::dsp_op_read_reg(int reg, Gen::X64Reg host_dreg, DSPJitSignExten
 			MOVZX(64, 16, host_dreg, R(host_dreg));
 			break;
 		case NONE:
-		default:
 			break;
 		}
 		return;

--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -37,6 +37,7 @@ void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<Ge
 				// enabled or disabled code
 			case '+' :
 				ss.seekg(1);
+			// Fallthrough
 			case '$' :
 				if (gcode.name.size())
 					gcodes.push_back(gcode);

--- a/Source/Core/Core/HW/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI_Device.cpp
@@ -136,7 +136,6 @@ IEXIDevice* EXIDevice_Create(TEXIDevices device_type, const int channel_num)
 		break;
 
 	case EXIDEVICE_NONE:
-	default:
 		result = new IEXIDevice();
 		break;
 	}

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -158,14 +158,33 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 	std::string strDirectoryName = File::GetUserPath(D_GCUSER_IDX);
 	switch (CountryCode)
 	{
+	case DiscIO::IVolume::COUNTRY_KOREA:
+	case DiscIO::IVolume::COUNTRY_TAIWAN:
 	case DiscIO::IVolume::COUNTRY_JAPAN:
 		ascii = false;
+		CountryCode = DiscIO::IVolume::COUNTRY_JAPAN;
 		strDirectoryName += JAP_DIR DIR_SEP;
 		break;
+
 	case DiscIO::IVolume::COUNTRY_USA:
 		strDirectoryName += USA_DIR DIR_SEP;
 		break;
+
+	case DiscIO::IVolume::COUNTRY_AUSTRALIA:
+	case DiscIO::IVolume::COUNTRY_EUROPE:
+	case DiscIO::IVolume::COUNTRY_FRANCE:
+	case DiscIO::IVolume::COUNTRY_GERMANY:
+	case DiscIO::IVolume::COUNTRY_INTERNATIONAL:
+	case DiscIO::IVolume::COUNTRY_ITALY:
+	case DiscIO::IVolume::COUNTRY_NETHERLANDS:
+	case DiscIO::IVolume::COUNTRY_RUSSIA:
+	case DiscIO::IVolume::COUNTRY_SPAIN:
+		CountryCode = DiscIO::IVolume::COUNTRY_EUROPE;
+		strDirectoryName += EUR_DIR DIR_SEP;
+		break;
+
 	case DiscIO::IVolume::COUNTRY_UNKNOWN:
+	case DiscIO::IVolume::NUMBER_OF_COUNTRIES: // Should never happen.
 	{
 		// The current game's region is not passed down to the EXI device level.
 		// Usually, we can retrieve the region from SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueId.
@@ -175,9 +194,9 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 		// Earlier in the boot process the region is added to the memory card name (This is done by the function checkMemcardPath)
 		// For now take advantage of this.
 		// Future options:
-		// 			Set memory card directory path in the checkMemcardPath function.
-		// 	or		Add region to SConfig::GetInstance().m_LocalCoreStartupParameter.
-		// 	or		Pass region down to the EXI device creation.
+		//          Set memory card directory path in the checkMemcardPath function.
+		//  or      Add region to SConfig::GetInstance().m_LocalCoreStartupParameter.
+		//  or      Pass region down to the EXI device creation.
 
 		std::string memcardFilename = (card_index == 0) ? SConfig::GetInstance().m_strMemoryCardA : SConfig::GetInstance().m_strMemoryCardB;
 		std::string region = memcardFilename.substr(memcardFilename.size() - 7, 3);
@@ -186,18 +205,20 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 			CountryCode = DiscIO::IVolume::COUNTRY_JAPAN;
 			ascii = false;
 			strDirectoryName += JAP_DIR DIR_SEP;
-			break;
 		}
 		else if (region == USA_DIR)
 		{
 			CountryCode = DiscIO::IVolume::COUNTRY_USA;
 			strDirectoryName += USA_DIR DIR_SEP;
-			break;
 		}
+		else
+		{
+			CountryCode = DiscIO::IVolume::COUNTRY_EUROPE;
+			strDirectoryName += EUR_DIR DIR_SEP;
+		}
+
+		break;
 	}
-	default:
-		CountryCode = DiscIO::IVolume::COUNTRY_EUROPE;
-		strDirectoryName += EUR_DIR DIR_SEP;
 	}
 	strDirectoryName += StringFromFormat("Card %c", 'A' + card_index);
 

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -278,6 +278,7 @@ u8* GetPointer(const u32 address)
 		case 0xcc:
 		case 0xcd:
 			_dbg_assert_msg_(MEMMAP, 0, "GetPointer from IO Bridge doesnt work");
+			break;
 		case 0xc8:
 			// EFB. We don't want to return a pointer here since we have no memory mapped for it.
 			break;
@@ -286,6 +287,7 @@ u8* GetPointer(const u32 address)
 			if ((address & 0xfffffff) < REALRAM_SIZE)
 				return m_pRAM + (address & RAM_MASK);
 		}
+		break;
 
 	case 0x1:
 	case 0x9:
@@ -295,8 +297,7 @@ u8* GetPointer(const u32 address)
 			if ((address & 0xfffffff) < EXRAM_SIZE)
 				return m_pEXRAM + (address & EXRAM_MASK);
 		}
-		else
-			break;
+		break;
 
 	case 0xe:
 		if (address < (0xE0000000 + L1_CACHE_SIZE))

--- a/Source/Core/Core/HW/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI_Device.cpp
@@ -66,35 +66,33 @@ ISIDevice* SIDevice_Create(const SIDevices device, const int port_number)
 	{
 	case SIDEVICE_GC_CONTROLLER:
 		return new CSIDevice_GCController(device, port_number);
-		break;
 
 	case SIDEVICE_DANCEMAT:
 		return new CSIDevice_DanceMat(device, port_number);
-		break;
 
 	case SIDEVICE_GC_STEERING:
 		return new CSIDevice_GCSteeringWheel(device, port_number);
-		break;
 
 	case SIDEVICE_GC_TARUKONGA:
 		return new CSIDevice_TaruKonga(device, port_number);
-		break;
 
 	case SIDEVICE_GC_GBA:
 		return new CSIDevice_GBA(device, port_number);
-		break;
 
 	case SIDEVICE_GC_KEYBOARD:
 		return new CSIDevice_Keyboard(device, port_number);
-		break;
 
 	case SIDEVICE_AM_BASEBOARD:
 		return new CSIDevice_AMBaseboard(device, port_number);
-		break;
 
 	case SIDEVICE_NONE:
-	default:
+	case SIDEVICE_N64_CONTROLLER:
+	case SIDEVICE_N64_KEYBOARD:
+	case SIDEVICE_N64_MIC:
+	case SIDEVICE_N64_MOUSE:
 		return new CSIDevice_Null(device, port_number);
-		break;
 	}
+
+	// Should never be hit.
+	return new CSIDevice_Null(device, port_number);
 }

--- a/Source/Core/Core/HW/SI_DeviceAMBaseboard.cpp
+++ b/Source/Core/Core/HW/SI_DeviceAMBaseboard.cpp
@@ -425,14 +425,6 @@ int CSIDevice_AMBaseboard::RunBuffer(u8* _pBuffer, int _iLength)
 				iPosition = _iLength;
 				break;
 			}
-			// DEFAULT
-		default:
-			{
-				ERROR_LOG(SERIALINTERFACE, "Unknown SI command     (0x%x)", command);
-				PanicAlert("SI: Unknown command");
-				iPosition = _iLength;
-			}
-			break;
 		}
 	}
 

--- a/Source/Core/Core/HW/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCController.cpp
@@ -106,14 +106,6 @@ int CSIDevice_GCController::RunBuffer(u8* _pBuffer, int _iLength)
 			}
 		}
 		break;
-
-	// DEFAULT
-	default:
-		{
-			ERROR_LOG(SERIALINTERFACE, "Unknown SI command     (0x%x)", command);
-			PanicAlert("SI: Unknown command (0x%x)", command);
-		}
-		break;
 	}
 
 	return _iLength;

--- a/Source/Core/Core/HW/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCSteeringWheel.cpp
@@ -25,12 +25,9 @@ int CSIDevice_GCSteeringWheel::RunBuffer(u8* _pBuffer, int _iLength)
 		*(u32*)&_pBuffer[0] = SI_GC_STEERING;
 		break;
 
-	// DEFAULT
-	default:
-	{
+	case CMD_ORIGIN:
+	case CMD_RECALIBRATE:
 		return CSIDevice_GCController::RunBuffer(_pBuffer, _iLength);
-	}
-	break;
 	}
 
 	return _iLength;

--- a/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
@@ -38,12 +38,6 @@ int CSIDevice_Keyboard::RunBuffer(u8* _pBuffer, int _iLength)
 			}
 		}
 		break;
-
-	default:
-		{
-			ERROR_LOG(SERIALINTERFACE, "Unknown SI command     (0x%x)", command);
-		}
-		break;
 	}
 
 	return _iLength;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -519,11 +519,8 @@ void ExecuteCommand(u32 _Address)
 		}
 		break;
 	}
-	default:
-	{
-		_dbg_assert_msg_(WII_IPC_HLE, 0, "Unknown IPC Command %i (0x%08x)", Command, _Address);
+	case IPC_REP_ASYNC:
 		break;
-	}
 	}
 
 	// Ensure replies happen in order

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -326,12 +326,13 @@ void NetPlayClient::ThreadFunc()
 			sf::Packet rpac;
 			switch (m_socket.receive(rpac))
 			{
-			case sf::Socket::Done :
+			case sf::Socket::Done:
 				OnData(rpac);
 				break;
 
-			//case sf::Socket::Disconnected :
-			default :
+			case sf::Socket::Disconnected:
+			case sf::Socket::Error:
+			case sf::Socket::NotReady:
 				m_is_running = false;
 				NetPlay_Disable();
 				m_dialog->AppendChat("< LOST CONNECTION TO SERVER >");

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -106,8 +106,10 @@ void NetPlayServer::ThreadFunc()
 						if (0 == OnData(rpac, client))
 							break;
 
-					//case sf::Socket::Disconnected :
-					default :
+					// Fallthrough
+					case sf::Socket::Disconnected:
+					case sf::Socket::Error:
+					case sf::Socket::NotReady:
 						{
 						std::lock_guard<std::recursive_mutex> lkg(m_crit.game);
 						OnDisconnect(client);

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -196,9 +196,6 @@ static void ApplyPatches(const std::vector<Patch> &patches)
 				case PATCH_32BIT:
 					Memory::Write_U32(value, addr);
 					break;
-				default:
-					//unknown patchtype
-					break;
 				}
 			}
 		}

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStorePaired.cpp
@@ -88,10 +88,6 @@ void Interpreter::Helper_Quantize(const u32 _Addr, const double _fValue, const E
 			Memory::Write_U16((u16)(s16)fResult, _Addr);
 		}
 		break;
-
-	default:
-		_dbg_assert_msg_(POWERPC, 0, "PS dequantize - unknown type to read");
-		break;
 	}
 }
 
@@ -123,11 +119,6 @@ float Interpreter::Helper_Dequantize(const u32 _Addr, const EQuantizeType _quant
 		// used for THP player
 	case QUANTIZE_S16:
 		fResult = static_cast<float>((s16)Memory::Read_U16(_Addr)) * m_dequantizeTable[_uScale];
-		break;
-
-	default:
-		_dbg_assert_msg_(POWERPC, 0, "PS dequantize - unknown type to read");
-		fResult = 0;
 		break;
 	}
 	return fResult;

--- a/Source/Core/DiscIO/BannerLoaderGC.cpp
+++ b/Source/Core/DiscIO/BannerLoaderGC.cpp
@@ -82,7 +82,7 @@ std::vector<std::string> CBannerLoaderGC::GetNames()
 		name_count = 6;
 		break;
 
-	default:
+	case CBannerLoaderGC::BANNER_UNKNOWN:
 		break;
 	}
 
@@ -146,7 +146,7 @@ std::vector<std::string> CBannerLoaderGC::GetDescriptions()
 		desc_count = 6;
 		break;
 
-	default:
+	case CBannerLoaderGC::BANNER_UNKNOWN:
 		break;
 	}
 

--- a/Source/Core/DiscIO/VolumeCreator.cpp
+++ b/Source/Core/DiscIO/VolumeCreator.cpp
@@ -100,7 +100,6 @@ IVolume* CreateVolumeFromFilename(const std::string& _rFilename, u32 _PartitionG
 		}
 
 		case DISC_TYPE_UNK:
-		default:
 			std::string Filename, ext;
 			SplitPath(_rFilename, nullptr, &Filename, &ext);
 			Filename += ext;

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -219,8 +219,6 @@ Joystick::Hat::Hat(IOHIDElementRef element, IOHIDDeviceRef device, direction dir
 	case left:
 		m_name = "Left";
 		break;
-	default:
-		m_name = "unk";
 	}
 }
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -56,10 +56,10 @@ static std::string GetGLSLVersionString()
 			return "#version 140";
 		case GLSL_150:
 			return "#version 150";
-		default:
-			// Shouldn't ever hit this
-			return "#version ERROR";
 	}
+
+	// Should never be reached.
+	return "#version ERROR";
 }
 
 void SHADER::SetProgramVariables()

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -337,7 +337,12 @@ static void InitDriverInfo()
 		}
 		break;
 		// We don't care about these
-		default:
+		case DriverDetails::VENDOR_ALL:
+		case DriverDetails::VENDOR_ATI:
+		case DriverDetails::VENDOR_IMGTEC:
+		case DriverDetails::VENDOR_TEGRA:
+		case DriverDetails::VENDOR_UNKNOWN:
+		case DriverDetails::VENDOR_VIVANTE:
 		break;
 	}
 	DriverDetails::Init(vendor, driver, version, family);
@@ -1147,9 +1152,6 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 
 		break;
 	}
-
-	default:
-		break;
 	}
 
 	return 0;

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -54,8 +54,14 @@ namespace EfbInterface
 				*dst = val;
 			}
 			break;
-		default:
+
+		case PEControl::INVALID_FMT:
+		case PEControl::U8:
+		case PEControl::V8:
+		case PEControl::Y8:
+		case PEControl::YUV420:
 			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			break;
 		}
 	}
 
@@ -94,8 +100,14 @@ namespace EfbInterface
 				*dst = val;
 			}
 			break;
-		default:
+
+		case PEControl::INVALID_FMT:
+		case PEControl::U8:
+		case PEControl::V8:
+		case PEControl::Y8:
+		case PEControl::YUV420:
 			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			break;
 		}
 	}
 
@@ -135,8 +147,14 @@ namespace EfbInterface
 				*dst = val;
 			}
 			break;
-		default:
+
+		case PEControl::INVALID_FMT:
+		case PEControl::U8:
+		case PEControl::V8:
+		case PEControl::Y8:
+		case PEControl::YUV420:
 			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			break;
 		}
 	}
 
@@ -171,8 +189,14 @@ namespace EfbInterface
 				*dst = val;
 			}
 			break;
-		default:
+
+		case PEControl::INVALID_FMT:
+		case PEControl::U8:
+		case PEControl::V8:
+		case PEControl::Y8:
+		case PEControl::YUV420:
 			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			break;
 		}
 	}
 
@@ -199,8 +223,14 @@ namespace EfbInterface
 				*dst = val;
 			}
 			break;
-		default:
+
+		case PEControl::INVALID_FMT:
+		case PEControl::U8:
+		case PEControl::V8:
+		case PEControl::Y8:
+		case PEControl::YUV420:
 			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			break;
 		}
 	}
 
@@ -223,8 +253,14 @@ namespace EfbInterface
 				depth = (*(u32*)&efb[offset]) & 0x00ffffff;
 			}
 			break;
-		default:
+
+		case PEControl::INVALID_FMT:
+		case PEControl::U8:
+		case PEControl::V8:
+		case PEControl::Y8:
+		case PEControl::YUV420:
 			ERROR_LOG(VIDEO, "Unsupported pixel format: %i", static_cast<int>(bpmem.zcontrol.pixel_format));
+			break;
 		}
 
 		return depth;
@@ -613,9 +649,6 @@ namespace EfbInterface
 		case ZMode::ALWAYS:
 			pass = true;
 			break;
-		default:
-			pass = false;
-			ERROR_LOG(VIDEO, "Bad Z compare mode %i", (int)bpmem.zmode.func);
 		}
 
 		if (pass && bpmem.zmode.updateenable)

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -347,8 +347,10 @@ static bool AlphaCompare(int alpha, int ref, AlphaTest::CompareMode comp)
 	case AlphaTest::GREATER: return alpha > ref;
 	case AlphaTest::EQUAL:   return alpha == ref;
 	case AlphaTest::NEQUAL:  return alpha != ref;
-	default: return true;
 	}
+
+	// Never reached.
+	return true;
 }
 
 static bool TevAlphaTest(int alpha)
@@ -358,12 +360,14 @@ static bool TevAlphaTest(int alpha)
 
 	switch (bpmem.alpha_test.logic)
 	{
-	case 0: return comp0 && comp1;   // and
-	case 1: return comp0 || comp1;   // or
-	case 2: return comp0 ^ comp1;    // xor
-	case 3: return !(comp0 ^ comp1); // xnor
-	default: return true;
+	case AlphaTest::AND:  return comp0 && comp1;
+	case AlphaTest::OR:   return comp0 || comp1;
+	case AlphaTest::XOR:  return comp0 ^ comp1;
+	case AlphaTest::XNOR: return !(comp0 ^ comp1);
 	}
+
+	// Never reached.
+	return true;
 }
 
 static inline s32 WrapIndirectCoord(s32 coord, int wrapMode)

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -201,7 +201,11 @@ void OnPixelFormatChange()
 				convtype = 5;
 			break;
 
-		default:
+		case PEControl::INVALID_FMT:
+		case PEControl::U8:
+		case PEControl::V8:
+		case PEControl::Y8:
+		case PEControl::YUV420:
 			break;
 	}
 

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -959,9 +959,6 @@ union AlphaTest
 			if ((comp0 == ALWAYS && comp1 == ALWAYS) || (comp0 == NEVER && comp1 == NEVER))
 				return PASS;
 			break;
-
-		default:
-			return UNDETERMINED;
 		}
 		return UNDETERMINED;
 	}

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -89,7 +89,12 @@ namespace DriverDetails
 				case VENDOR_VIVANTE:
 					m_driver = DRIVER_VIVANTE;
 					break;
-				default:
+
+				case VENDOR_ALL:
+				case VENDOR_ARM:
+				case VENDOR_MESA:
+				case VENDOR_QUALCOMM:
+				case VENDOR_UNKNOWN:
 					break;
 			}
 

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -273,9 +273,10 @@ static inline u32 DecodePixel_Paletted(u16 pixel, TlutFormat tlutfmt)
 		return DecodePixel_RGB565(Common::swap16(pixel));
 	case GX_TL_RGB5A3:
 		return DecodePixel_RGB5A3(Common::swap16(pixel));
-	default:
-		return 0;
 	}
+
+	// Never reached.
+	return 0;
 }
 
 struct DXTBlock


### PR DESCRIPTION
Gets rid of a swath of warnings when compiling with -Weverything.