### PR TITLE
Remove an old comment about stfiwx.

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -607,9 +607,6 @@ void Interpreter::stfdx(UGeckoInstruction _inst)
 	Memory::Write_U64(riPS0(_inst.FS), Helper_Get_EA_X(_inst));
 }
 
-// __________________________________________________________________________________________________
-// stfiwx
-// TODO - examine what this really does
 // Stores Floating points into Integers indeXed
 void Interpreter::stfiwx(UGeckoInstruction _inst)
 {


### PR DESCRIPTION
This instruction does exactly what it is supposed to. No need for this comment.