### PR TITLE
VideoBackends: set GLInterface to zero after deleting it

### DIFF
--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -226,6 +226,7 @@ void VideoBackend::Shutdown()
 
 	GLInterface->Shutdown();
 	delete GLInterface;
+	GLInterface = nullptr;
 }
 
 void VideoBackend::Video_Cleanup()

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -164,6 +164,7 @@ void VideoSoftware::Shutdown()
 
 	GLInterface->Shutdown();
 	delete GLInterface;
+	GLInterface = nullptr;
 }
 
 void VideoSoftware::Video_Cleanup()


### PR DESCRIPTION
This fixes a crash on opening the gfx settings after closing a game.