### PR TITLE
Add COUNTRY_GERMANY to load german disks without warning

### DIFF
--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -108,9 +108,39 @@ void SCoreStartupParameter::LoadDefaults()
 	m_strUniqueID = "00000000";
 }
 
+static const char* GetRegionOfCountry(DiscIO::IVolume::ECountry country)
+{
+	switch (country)
+	{
+	case DiscIO::IVolume::COUNTRY_USA:
+		return USA_DIR;
+
+	case DiscIO::IVolume::COUNTRY_TAIWAN:
+	case DiscIO::IVolume::COUNTRY_KOREA:
+		// TODO: Should these have their own Region Dir?
+	case DiscIO::IVolume::COUNTRY_JAPAN:
+		return JAP_DIR;
+
+	case DiscIO::IVolume::COUNTRY_AUSTRALIA:
+	case DiscIO::IVolume::COUNTRY_EUROPE:
+	case DiscIO::IVolume::COUNTRY_FRANCE:
+	case DiscIO::IVolume::COUNTRY_GERMANY:
+	case DiscIO::IVolume::COUNTRY_INTERNATIONAL:
+	case DiscIO::IVolume::COUNTRY_ITALY:
+	case DiscIO::IVolume::COUNTRY_NETHERLANDS:
+	case DiscIO::IVolume::COUNTRY_RUSSIA:
+	case DiscIO::IVolume::COUNTRY_SPAIN:
+		return EUR_DIR;
+
+	case DiscIO::IVolume::COUNTRY_UNKNOWN:
+	default:
+		return nullptr;
+	}
+}
+
 bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 {
-	std::string Region(EUR_DIR);
+	std::string set_region_dir(EUR_DIR);
 
 	switch (_BootBS2)
 	{
@@ -154,52 +184,23 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 
 				// Check if we have a Wii disc
 				bWii = pVolume.get()->IsWiiDisc();
-				switch (pVolume->GetCountry())
+
+				const char* retrieved_region_dir = GetRegionOfCountry(pVolume->GetCountry());
+				if (!retrieved_region_dir)
 				{
-				case DiscIO::IVolume::COUNTRY_USA:
-					bNTSC = true;
-					Region = USA_DIR;
-					break;
-
-				case DiscIO::IVolume::COUNTRY_TAIWAN:
-				case DiscIO::IVolume::COUNTRY_KOREA:
-					// TODO: Should these have their own Region Dir?
-				case DiscIO::IVolume::COUNTRY_JAPAN:
-					bNTSC = true;
-					Region = JAP_DIR;
-					break;
-
-				case DiscIO::IVolume::COUNTRY_AUSTRALIA:
-				case DiscIO::IVolume::COUNTRY_EUROPE:
-				case DiscIO::IVolume::COUNTRY_FRANCE:
-				case DiscIO::IVolume::COUNTRY_INTERNATIONAL:
-				case DiscIO::IVolume::COUNTRY_ITALY:
-				case DiscIO::IVolume::COUNTRY_NETHERLANDS:
-				case DiscIO::IVolume::COUNTRY_RUSSIA:
-				case DiscIO::IVolume::COUNTRY_SPAIN:
-					bNTSC = false;
-					Region = EUR_DIR;
-					break;
-
-				case DiscIO::IVolume::COUNTRY_UNKNOWN:
-				default:
-					if (PanicYesNoT("Your GCM/ISO file seems to be invalid (invalid country)."
-								   "\nContinue with PAL region?"))
-					{
-						bNTSC = false;
-						Region = EUR_DIR;
-						break;
-					}
-					else
-					{
+					if (!PanicYesNoT("Your GCM/ISO file seems to be invalid (invalid country)."
+						"\nContinue with PAL region?"))
 						return false;
-					}
+					retrieved_region_dir = EUR_DIR;
 				}
+
+				set_region_dir = retrieved_region_dir;
+				bNTSC = set_region_dir == USA_DIR || set_region_dir == JAP_DIR;
 			}
 			else if (!strcasecmp(Extension.c_str(), ".elf"))
 			{
 				bWii = CBoot::IsElfWii(m_strFilename);
-				Region = USA_DIR;
+				set_region_dir = USA_DIR;
 				m_BootType = BOOT_ELF;
 				bNTSC = true;
 			}
@@ -207,14 +208,14 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 			{
 				CDolLoader dolfile(m_strFilename);
 				bWii = dolfile.IsWii();
-				Region = USA_DIR;
+				set_region_dir = USA_DIR;
 				m_BootType = BOOT_DOL;
 				bNTSC = true;
 			}
 			else if (!strcasecmp(Extension.c_str(), ".dff"))
 			{
 				bWii = true;
-				Region = USA_DIR;
+				set_region_dir = USA_DIR;
 				bNTSC = true;
 				m_BootType = BOOT_DFF;
 
@@ -239,37 +240,9 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 					return false; //do not boot
 				}
 
-				switch (ContentLoader.GetCountry())
-				{
-				case DiscIO::IVolume::COUNTRY_USA:
-					bNTSC = true;
-					Region = USA_DIR;
-					break;
-
-				case DiscIO::IVolume::COUNTRY_TAIWAN:
-				case DiscIO::IVolume::COUNTRY_KOREA:
-					// TODO: Should these have their own Region Dir?
-				case DiscIO::IVolume::COUNTRY_JAPAN:
-					bNTSC = true;
-					Region = JAP_DIR;
-					break;
-
-				case DiscIO::IVolume::COUNTRY_AUSTRALIA:
-				case DiscIO::IVolume::COUNTRY_EUROPE:
-				case DiscIO::IVolume::COUNTRY_FRANCE:
-				case DiscIO::IVolume::COUNTRY_INTERNATIONAL:
-				case DiscIO::IVolume::COUNTRY_ITALY:
-				case DiscIO::IVolume::COUNTRY_RUSSIA:
-					bNTSC = false;
-					Region = EUR_DIR;
-					break;
-
-				case DiscIO::IVolume::COUNTRY_UNKNOWN:
-				default:
-					bNTSC = false;
-					Region = EUR_DIR;
-						break;
-				}
+				const char* retrieved_region_dir = GetRegionOfCountry(ContentLoader.GetCountry());
+				set_region_dir = retrieved_region_dir ? retrieved_region_dir : EUR_DIR;
+				bNTSC = set_region_dir == USA_DIR || set_region_dir == JAP_DIR;
 
 				bWii = true;
 				m_BootType = BOOT_WII_NAND;
@@ -309,35 +282,35 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 		break;
 
 	case BOOT_BS2_USA:
-		Region = USA_DIR;
+		set_region_dir = USA_DIR;
 		m_strFilename.clear();
 		bNTSC = true;
 		break;
 
 	case BOOT_BS2_JAP:
-		Region = JAP_DIR;
+		set_region_dir = JAP_DIR;
 		m_strFilename.clear();
 		bNTSC = true;
 		break;
 
 	case BOOT_BS2_EUR:
-		Region = EUR_DIR;
+		set_region_dir = EUR_DIR;
 		m_strFilename.clear();
 		bNTSC = false;
 		break;
 	}
 
 	// Setup paths
-	CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardA, Region, true);
-	CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardB, Region, false);
+	CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardA, set_region_dir, true);
+	CheckMemcardPath(SConfig::GetInstance().m_strMemoryCardB, set_region_dir, false);
 	m_strSRAM = File::GetUserPath(F_GCSRAM_IDX);
 	if (!bWii)
 	{
 		if (!bHLE_BS2)
 		{
-			m_strBootROM = File::GetUserPath(D_GCUSER_IDX) + DIR_SEP + Region + DIR_SEP GC_IPL;
+			m_strBootROM = File::GetUserPath(D_GCUSER_IDX) + DIR_SEP + set_region_dir + DIR_SEP GC_IPL;
 			if (!File::Exists(m_strBootROM))
-				m_strBootROM = File::GetSysDirectory() + GC_SYS_DIR + DIR_SEP + Region + DIR_SEP GC_IPL;
+				m_strBootROM = File::GetSysDirectory() + GC_SYS_DIR + DIR_SEP + set_region_dir + DIR_SEP GC_IPL;
 
 			if (!File::Exists(m_strBootROM))
 			{

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -261,7 +261,7 @@ struct SCoreStartupParameter
 	void LoadDefaults();
 	bool AutoSetup(EBootBS2 _BootBS2);
 	const std::string &GetUniqueID() const { return m_strUniqueID; }
-	void CheckMemcardPath(std::string& memcardPath, std::string Region, bool isSlotA);
+	void CheckMemcardPath(std::string& memcardPath, std::string gameRegion, bool isSlotA);
 	IniFile LoadDefaultGameIni() const;
 	IniFile LoadLocalGameIni() const;
 	IniFile LoadGameIni() const;


### PR DESCRIPTION
When booting german disks, you currently receive the warning "Your GCM/ISO file seems to be invalid (invalid country)." This commit fixes this behaviour, and refactors the code to remove the duplicate switch statement.