### PR TITLE
D3D: More debug information and break on error

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -264,8 +264,7 @@ HRESULT Create(HWND wnd)
 		UpdateActiveConfig();
 	}
 
-	DXGI_SWAP_CHAIN_DESC swap_chain_desc;
-	memset(&swap_chain_desc, 0, sizeof(swap_chain_desc));
+	DXGI_SWAP_CHAIN_DESC swap_chain_desc = {};
 	swap_chain_desc.BufferCount = 1;
 	swap_chain_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
 	swap_chain_desc.OutputWindow = wnd;
@@ -273,12 +272,10 @@ HRESULT Create(HWND wnd)
 	swap_chain_desc.SampleDesc.Quality = 0;
 	swap_chain_desc.Windowed = !g_Config.bFullscreen;
 
-	DXGI_OUTPUT_DESC out_desc;
-	memset(&out_desc, 0, sizeof(out_desc));
+	DXGI_OUTPUT_DESC out_desc = {};
 	output->GetDesc(&out_desc);
 
-	DXGI_MODE_DESC mode_desc;
-	memset(&mode_desc, 0, sizeof(mode_desc));
+	DXGI_MODE_DESC mode_desc = {};
 	mode_desc.Width = out_desc.DesktopCoordinates.right - out_desc.DesktopCoordinates.left;
 	mode_desc.Height = out_desc.DesktopCoordinates.bottom - out_desc.DesktopCoordinates.top;
 	mode_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -317,8 +314,7 @@ HRESULT Create(HWND wnd)
 					D3D11_MESSAGE_ID_SETPRIVATEDATA_CHANGINGPARAMS
 				};
 
-				D3D11_INFO_QUEUE_FILTER filter;
-				memset(&filter, 0, sizeof(filter));
+				D3D11_INFO_QUEUE_FILTER filter = {};
 				filter.DenyList.NumIDs = sizeof(hide) / sizeof(D3D11_MESSAGE_ID);
 				filter.DenyList.pIDList = hide;
 				infoQueue->AddStorageFilterEntries(&filter);
@@ -402,7 +398,7 @@ void Close()
 #if defined(_DEBUG) || defined(DEBUGFAST)
 	if (debug)
 	{
-		--references; // we didn't release the debug interface yet
+		--references; // the debug interface increases the refcount of the device, subtract that.
 		if (references)
 		{
 			// print out alive objects, but only if we actually have pending references

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -70,8 +70,27 @@ void SetDebugObjectName(T resource, const char* name)
 	static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
 		"resource must be convertible to ID3D11DeviceChild*");
 #if defined(_DEBUG) || defined(DEBUGFAST)
-	resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)strlen(name), name);
+	if (resource)
+		resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)(name ? strlen(name) : 0), name);
 #endif
+}
+
+template <typename T>
+std::string GetDebugObjectName(T resource)
+{
+	static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
+		"resource must be convertible to ID3D11DeviceChild*");
+	std::string name;
+#if defined(_DEBUG) || defined(DEBUGFAST)
+	if (resource)
+	{
+		UINT size = 0;
+		resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, nullptr); //get required size
+		name.resize(size);
+		resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, const_cast<char*>(name.data()));
+	}
+#endif
+	return name;
 }
 
 }  // namespace D3D

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -253,6 +253,11 @@ ID3D11PixelShader* PSTextureEncoder::SetStaticShader(unsigned int dstFormat, PEC
 		HRESULT hr = D3D::device->CreatePixelShader(bytecode->Data(), bytecode->Size(), nullptr, &newShader);
 		CHECK(SUCCEEDED(hr), "create efb encoder pixel shader");
 
+		char debugName[255] = {};
+		sprintf_s(debugName, "efb encoder pixel shader (dst:%d, src:%d, intensity:%d, scale:%d)",
+			dstFormat, srcFormat, isIntensity, scaleByHalf);
+		D3D::SetDebugObjectName(newShader, debugName);
+
 		it = m_staticShaders.insert(std::make_pair(key, newShader)).first;
 		bytecode->Release();
 	}

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
@@ -361,8 +361,8 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 	D3D::context->Unmap(m_outStage, 0);
 
 	// Restore API
-
 	g_renderer->RestoreAPIState();
+	D3D::stateman->Apply(); // force unbind efb texture as shader resource
 	D3D::context->OMSetRenderTargets(1,
 		&FramebufferManager::GetEFBColorTexture()->GetRTV(),
 		FramebufferManager::GetEFBDepthTexture()->GetDSV());


### PR DESCRIPTION
This change only affects the debug build and should give a little more information when debugging the DirectX backend. It also adds a breakpoint when otherwise the graphics driver is likely to crash. The function GetDebugObjectName is added but not used, it's helpful when trying to figure out which objects actually cause a failure.

The commits will be squashed with an appropriate message if you think this is worth adding. It certainly helped me when debugging.