### PR TITLE
WiimoteEmu: Change define into a variable and move it to where it's used.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -422,11 +422,13 @@ void Wiimote::GetAccelData(u8* const data, const ReportFeatures& rptf)
 	core.acc_y_lsb = (y >> 1) & 0x1;
 	core.acc_z_lsb = (z >> 1) & 0x1;
 }
-#define kCutoffFreq 5.0
-inline void LowPassFilter(double & var, double newval, double period)
+
+inline void LowPassFilter(double& var, double newval, double period)
 {
-	double RC=1.0/kCutoffFreq;
-	double alpha=period/(period+RC);
+	static const double CUTOFF_FREQUENCY = 5.0;
+
+	double RC = 1.0 / CUTOFF_FREQUENCY;
+	double alpha = period / (period + RC);
 	var = newval * alpha + var * (1.0 - alpha);
 }
 


### PR DESCRIPTION
Sorta weird it wasn't just declared inside the function in the first place, but oh well.