### PR TITLE
DolphinWX: Get rid of unnecessary Destroy calls

### DIFF
--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -947,9 +947,8 @@ void CConfigMain::DisplaySettingsChanged(wxCommandEvent& event)
 #endif
 			}
 
-			InputConfigDialog m_ConfigFrame(this, *hotkey_plugin, _("Dolphin Hotkeys"), 0);
+			InputConfigDialog m_ConfigFrame(this, *hotkey_plugin, _("Dolphin Hotkeys"));
 			m_ConfigFrame.ShowModal();
-			m_ConfigFrame.Destroy();
 
 			// if game isn't running
 			if (!was_init)

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -412,17 +412,14 @@ void ControllerConfigDiag::ConfigEmulatedWiimote(wxCommandEvent& ev)
 		Wiimote::Initialize(reinterpret_cast<void*>(GetHandle()));
 #endif
 	}
+
 	InputConfigDialog m_ConfigFrame(this, *wiimote_plugin, _("Dolphin Emulated Wiimote Configuration"), m_wiimote_index_from_conf_bt_id[ev.GetId()]);
 	m_ConfigFrame.ShowModal();
-	m_ConfigFrame.Destroy();
+
 	if (!was_init) // if game isn't running
 	{
 		Wiimote::Shutdown();
 	}
-
-	//InputConfigDialog* const m_emu_config_diag = new InputConfigDialog(this, *Wiimote::GetConfig(), _trans("Dolphin Emulated Wiimote Configuration"), m_wiimote_index_from_conf_bt_id[ev.GetId()]);
-	//m_emu_config_diag->ShowModal();
-	//m_emu_config_diag->Destroy();
 }
 
 void ControllerConfigDiag::RefreshRealWiimotes(wxCommandEvent&)
@@ -569,13 +566,11 @@ void ControllerConfigDiag::OnGameCubeConfigButton(wxCommandEvent& event)
 	{
 		InputConfigDialog m_ConfigFrame(this, *key_plugin, _("GameCube Controller Configuration"), port_num);
 		m_ConfigFrame.ShowModal();
-		m_ConfigFrame.Destroy();
 	}
 	else
 	{
 		InputConfigDialog m_ConfigFrame(this, *pad_plugin, _("GameCube Controller Configuration"), port_num);
 		m_ConfigFrame.ShowModal();
-		m_ConfigFrame.Destroy();
 	}
 
 	// if game isn't running

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1349,14 +1349,12 @@ void CFrame::OnConfigControllers(wxCommandEvent& WXUNUSED (event))
 {
 	ControllerConfigDiag config_dlg(this);
 	config_dlg.ShowModal();
-	config_dlg.Destroy();
 }
 
 void CFrame::OnConfigMenuCommands(wxCommandEvent& WXUNUSED(event))
 {
-	HotkeyConfigDialog *m_HotkeyDialog = new HotkeyConfigDialog(this);
-	m_HotkeyDialog->ShowModal();
-	m_HotkeyDialog->Destroy();
+	HotkeyConfigDialog m_HotkeyDialog(this);
+	m_HotkeyDialog.ShowModal();
 
 	// Update the GUI in case menu accelerators were changed
 	UpdateGUI();
@@ -1384,9 +1382,8 @@ void CFrame::OnConfigHotkey(wxCommandEvent& WXUNUSED (event))
 #endif
 	}
 
-	InputConfigDialog m_ConfigFrame(this, *hotkey_plugin, _("Dolphin Hotkeys"), 0);
+	InputConfigDialog m_ConfigFrame(this, *hotkey_plugin, _("Dolphin Hotkeys"));
 	m_ConfigFrame.ShowModal();
-	m_ConfigFrame.Destroy();
 
 	// if game isn't running
 	if (!was_init)

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -1079,13 +1079,7 @@ InputConfigDialog::InputConfigDialog(wxWindow* const parent, InputConfig& config
 	Center();
 
 	// live preview update timer
-	m_update_timer = new wxTimer(this);
+	m_update_timer.SetOwner(this);
 	Bind(wxEVT_TIMER, &InputConfigDialog::UpdateBitmaps, this);
-	m_update_timer->Start(PREVIEW_UPDATE_TIME, wxTIMER_CONTINUOUS);
-}
-
-bool InputConfigDialog::Destroy()
-{
-	m_update_timer->Stop();
-	return true;
+	m_update_timer.Start(PREVIEW_UPDATE_TIME, wxTIMER_CONTINUOUS);
 }

--- a/Source/Core/DolphinWX/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/InputConfigDiag.h
@@ -23,6 +23,7 @@
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
 #include <wx/string.h>
+#include <wx/timer.h>
 #include <wx/translation.h>
 
 #include "InputCommon/ControllerEmu.h"
@@ -39,7 +40,6 @@ class wxSlider;
 class wxStaticBitmap;
 class wxStaticText;
 class wxTextCtrl;
-class wxTimer;
 class wxTimerEvent;
 class wxWindow;
 
@@ -224,9 +224,6 @@ class InputConfigDialog : public wxDialog
 {
 public:
 	InputConfigDialog(wxWindow* const parent, InputConfig& config, const wxString& name, const int tab_num = 0);
-	//~InputConfigDialog();
-
-	bool Destroy() override;
 
 	void ClickSave(wxCommandEvent& event);
 
@@ -241,5 +238,5 @@ private:
 	wxNotebook*               m_pad_notebook;
 	std::vector<GamepadPage*> m_padpages;
 	InputConfig&              m_config;
-	wxTimer*                  m_update_timer;
+	wxTimer                   m_update_timer;
 };


### PR DESCRIPTION
Removes the requirement for stack allocated InputConfigDialogs to call Destroy. This shouldn't be necessary for wxDialog derivatives.
This also fixes a leak that would occur every time an InputConfigDialog is opened and closed. wxWindow subclasses (this includes wxDialog) only destroy child windows and sizers (including things in the sizers). So every wxTimer allocation would have resulted in a leak.