### PR TITLE
Get rid of Memory::RAM_SIZE and Memory::RAM_MASK.

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -273,10 +273,12 @@ void FifoPlayer::WriteMemory(const MemoryUpdate& memUpdate)
 {
 	u8 *mem = nullptr;
 
-	if (memUpdate.address & 0x10000000)
-		mem = &Memory::m_pEXRAM[memUpdate.address & Memory::EXRAM_MASK];
+	if ((memUpdate.address & 0x10000000) != 0 && (memUpdate.address & 0x0FFFFFFF) < Memory::EXRAM_SIZE)
+		mem = &Memory::m_pEXRAM[memUpdate.address & 0x0FFFFFFF];
+	else if ((memUpdate.address & 0x10000000) == 0 && (memUpdate.address & 0x0FFFFFFF) < Memory::REALRAM_SIZE)
+		mem = &Memory::m_pRAM[memUpdate.address & 0x0FFFFFFF];
 	else
-		mem = &Memory::m_pRAM[memUpdate.address & Memory::RAM_MASK];
+		return;
 
 	memcpy(mem, memUpdate.data, memUpdate.size);
 }

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -23,7 +23,7 @@ FifoRecorder::FifoRecorder() :
 	m_SkipNextData(true),
 	m_SkipFutureData(true),
 	m_FrameEnded(false),
-	m_Ram(Memory::RAM_SIZE),
+	m_Ram(Memory::REALRAM_SIZE),
 	m_ExRam(Memory::EXRAM_SIZE)
 {
 }
@@ -105,15 +105,19 @@ void FifoRecorder::WriteMemory(u32 address, u32 size, MemoryUpdate::Type type)
 {
 	u8 *curData;
 	u8 *newData;
-	if (address & 0x10000000)
+	if ((address & 0x10000000) != 0 && (address & 0x0FFFFFFF) < Memory::EXRAM_SIZE)
 	{
-		curData = &m_ExRam[address & Memory::EXRAM_MASK];
-		newData = &Memory::m_pEXRAM[address & Memory::EXRAM_MASK];
+		curData = &m_ExRam[address & 0x0FFFFFFF];
+		newData = &Memory::m_pEXRAM[address & 0x0FFFFFFF];
+	}
+	else if ((address & 0x10000000) == 0 && (address & 0x0FFFFFFF) < Memory::REALRAM_SIZE)
+	{
+		curData = &m_Ram[address & 0x0FFFFFFF];
+		newData = &Memory::m_pRAM[address & 0x0FFFFFFF];
 	}
 	else
 	{
-		curData = &m_Ram[address & Memory::RAM_MASK];
-		newData = &Memory::m_pRAM[address & Memory::RAM_MASK];
+		return;
 	}
 
 	if (memcmp(curData, newData, size) != 0)

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -645,18 +645,11 @@ static void Do_ARAM_DMA()
 	}
 }
 
-// (shuffle2) I still don't believe that this hack is actually needed... :(
-// Maybe the Wii Sports ucode is processed incorrectly?
-// (LM) It just means that DSP reads via '0xffdd' on Wii can end up in EXRAM or main RAM
 u8 ReadARAM(u32 _iAddress)
 {
-	//NOTICE_LOG(DSPINTERFACE, "ReadARAM 0x%08x", _iAddress);
 	if (g_ARAM.wii_mode)
 	{
-		if (_iAddress & 0x10000000)
-			return g_ARAM.ptr[_iAddress & g_ARAM.mask];
-		else
-			return Memory::Read_U8(_iAddress & Memory::RAM_MASK);
+		return Memory::Read_U8(_iAddress);
 	}
 	else
 	{

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
@@ -19,42 +19,52 @@ class CMailHandler;
 
 inline bool ExramRead(u32 address)
 {
-	if (address & 0x10000000)
-		return true;
-	else
-		return false;
+	return (address & 0x10000000) && (address & 0x0FFFFFFF) < Memory::EXRAM_SIZE;
+}
+
+inline bool RamRead(u32 address)
+{
+	return (address & 0x1FFFFFFF) < Memory::REALRAM_SIZE;
 }
 
 inline u8 HLEMemory_Read_U8(u32 address)
 {
 	if (ExramRead(address))
-		return Memory::m_pEXRAM[address & Memory::EXRAM_MASK];
-	else
-		return Memory::m_pRAM[address & Memory::RAM_MASK];
+		return Memory::m_pEXRAM[address & 0x0FFFFFFF];
+	if (RamRead(address))
+		return Memory::m_pRAM[address & 0x0FFFFFFF];
+	_assert_msg_(DSPHLE, 0, "Unexpected address in DSP 0x%08x", address);
+	return 0;
 }
 
 inline u16 HLEMemory_Read_U16(u32 address)
 {
 	if (ExramRead(address))
-		return Common::swap16(*(u16*)&Memory::m_pEXRAM[address & Memory::EXRAM_MASK]);
-	else
-		return Common::swap16(*(u16*)&Memory::m_pRAM[address & Memory::RAM_MASK]);
+		return Common::swap16(*(u16*)&Memory::m_pEXRAM[address & 0x0FFFFFFF]);
+	if (RamRead(address))
+		return Common::swap16(*(u16*)&Memory::m_pRAM[address & 0x0FFFFFFF]);
+	_assert_msg_(DSPHLE, 0, "Unexpected address in DSP 0x%08x", address);
+	return 0;
 }
 
 inline u32 HLEMemory_Read_U32(u32 address)
 {
 	if (ExramRead(address))
-		return Common::swap32(*(u32*)&Memory::m_pEXRAM[address & Memory::EXRAM_MASK]);
-	else
-		return Common::swap32(*(u32*)&Memory::m_pRAM[address & Memory::RAM_MASK]);
+		return Common::swap32(*(u32*)&Memory::m_pEXRAM[address & 0x0FFFFFFF]);
+	if (RamRead(address))
+		return Common::swap32(*(u32*)&Memory::m_pRAM[address & 0x0FFFFFFF]);
+	_assert_msg_(DSPHLE, 0, "Unexpected address in DSP 0x%08x", address);
+	return 0;
 }
 
 inline void* HLEMemory_Get_Pointer(u32 address)
 {
 	if (ExramRead(address))
-		return &Memory::m_pEXRAM[address & Memory::EXRAM_MASK];
-	else
-		return &Memory::m_pRAM[address & Memory::RAM_MASK];
+		return &Memory::m_pEXRAM[address & 0x0FFFFFFF];
+	if (RamRead(address))
+		return &Memory::m_pRAM[address & 0x0FFFFFFF];
+	_assert_msg_(DSPHLE, 0, "Unexpected address in DSP 0x%08x", address);
+	return 0;
 }
 
 class UCodeInterface

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ZeldaVoice.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ZeldaVoice.cpp
@@ -461,7 +461,7 @@ void Decoder21_ReadAudio(ZeldaVoicePB &PB, int size, s16* _Buffer)
 	// ACC0 is the address
 	// ACC1 is the read size
 
-	const u16* src = (u16*) Memory::GetPointer(ACC0 & Memory::RAM_MASK);
+	const u16* src = (u16*) Memory::GetPointer(ACC0);
 
 	for (u32 i = 0; i < (ACC1 >> 16); i++)
 	{

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -148,10 +148,10 @@ bool IsInitialized()
 // Dolphin doesn't emulate the difference between cached and uncached access.
 static MemoryView views[] =
 {
-	{&m_pRAM,      0x00000000, RAM_SIZE,      0},
-	{nullptr,      0x200000000, RAM_SIZE,     MV_MIRROR_PREVIOUS},
-	{nullptr,      0x280000000, RAM_SIZE,     MV_MIRROR_PREVIOUS},
-	{nullptr,      0x2C0000000, RAM_SIZE,     MV_MIRROR_PREVIOUS},
+	{&m_pRAM,      0x00000000, REALRAM_SIZE,      0},
+	{nullptr,      0x200000000, REALRAM_SIZE,     MV_MIRROR_PREVIOUS},
+	{nullptr,      0x280000000, REALRAM_SIZE,     MV_MIRROR_PREVIOUS},
+	{nullptr,      0x2C0000000, REALRAM_SIZE,     MV_MIRROR_PREVIOUS},
 	{&m_pL1Cache,  0x2E0000000, L1_CACHE_SIZE, 0},
 	{&m_pFakeVMEM, 0x27E000000, FAKEVMEM_SIZE, MV_FAKE_VMEM},
 	{&m_pEXRAM,    0x10000000, EXRAM_SIZE,    MV_WII_ONLY},
@@ -192,7 +192,7 @@ void Init()
 void DoState(PointerWrap &p)
 {
 	bool wii = SConfig::GetInstance().m_LocalCoreStartupParameter.bWii;
-	p.DoArray(m_pRAM, RAM_SIZE);
+	p.DoArray(m_pRAM, REALRAM_SIZE);
 	p.DoArray(m_pL1Cache, L1_CACHE_SIZE);
 	p.DoMarker("Memory RAM");
 	if (bFakeVMEM)
@@ -220,7 +220,7 @@ void Shutdown()
 void Clear()
 {
 	if (m_pRAM)
-		memset(m_pRAM, 0, RAM_SIZE);
+		memset(m_pRAM, 0, REALRAM_SIZE);
 	if (m_pL1Cache)
 		memset(m_pL1Cache, 0, L1_CACHE_SIZE);
 	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii && m_pEXRAM)

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -39,13 +39,7 @@ extern bool bFakeVMEM;
 
 enum
 {
-	// RAM_SIZE is the amount allocated by the emulator, whereas REALRAM_SIZE is
-	// what will be reported in lowmem, and thus used by emulated software.
-	// Note: Writing to lowmem is done by IPL. If using retail IPL, it will
-	// always be set to 24MB.
 	REALRAM_SIZE  = 0x01800000,
-	RAM_SIZE      = ROUND_UP_POW2(REALRAM_SIZE),
-	RAM_MASK      = RAM_SIZE - 1,
 	FAKEVMEM_SIZE = 0x02000000,
 	FAKEVMEM_MASK = FAKEVMEM_SIZE - 1,
 	L1_CACHE_SIZE = 0x00040000,

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -343,9 +343,10 @@ void Interpreter::dcbi(UGeckoInstruction _inst)
 	u64 dma_in_progress = DSP::DMAInProgress();
 	if (dma_in_progress != 0)
 	{
-		u32 start_addr = (dma_in_progress >> 32) & Memory::RAM_MASK;
-		u32 end_addr = (dma_in_progress & Memory::RAM_MASK) & 0xffffffff;
-		u32 invalidated_addr = (address & Memory::RAM_MASK) & ~0x1f;
+		u32 start_addr = (u32)(dma_in_progress >> 32);
+		u32 end_addr = (u32)(dma_in_progress);
+		// TODO: perform real address translation on address.
+		u32 invalidated_addr = (address & 0x1FFFFFFF) & ~0x1f;
 
 		if (invalidated_addr >= start_addr && invalidated_addr <= end_addr)
 		{

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -343,9 +343,9 @@ void Jit64::dcbz(UGeckoInstruction inst)
 
 	SwitchToNearCode();
 	// Mask out the address so we don't write to MEM1 out of bounds
-	// FIXME: Work out why the AGP disc writes out of bounds
+	// TODO: Implement correct behavior for dcbz to direct store segment.
 	if (!SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
-		AND(32, R(RSCRATCH), Imm32(Memory::RAM_MASK));
+		AND(32, R(RSCRATCH), Imm32(0x01FFFFFF));
 	PXOR(XMM0, R(XMM0));
 	MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 0), XMM0);
 	MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 16), XMM0);

--- a/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
@@ -138,14 +138,14 @@ void CheatSearchTab::StartNewSearch(wxCommandEvent& WXUNUSED (event))
 
 	// Set up the search results efficiently to prevent automatic re-allocations.
 	m_search_results.clear();
-	m_search_results.reserve(Memory::RAM_SIZE / m_search_type_size);
+	m_search_results.reserve(Memory::REALRAM_SIZE / m_search_type_size);
 
 	// Enable the "Next Scan" button.
 	m_btn_next_scan->Enable();
 
 	CheatSearchResult r;
 	// can I assume cheatable values will be aligned like this?
-	for (u32 addr = 0; addr != Memory::RAM_SIZE; addr += m_search_type_size)
+	for (u32 addr = 0; addr != Memory::REALRAM_SIZE; addr += m_search_type_size)
 	{
 		r.address = addr;
 		memcpy(&r.old_value, memptr + addr, m_search_type_size);


### PR DESCRIPTION
There's no good reason to round the size of the emulated RAM up to a power of two.