### PR TITLE
Disable thread safety assertions added in PR1987.

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -224,7 +224,8 @@ u64 GetIdleTicks()
 // schedule things to be executed on the main thread.
 void ScheduleEvent_Threadsafe(int cyclesIntoFuture, int event_type, u64 userdata)
 {
-	_assert_msg_(POWERPC, !Core::IsCPUThread(), "ScheduleEvent_Threadsafe from wrong thread");
+	// TODO: Fix UI thread safety problems, and enable this assertion
+	// _assert_msg_(POWERPC, !Core::IsCPUThread(), "ScheduleEvent_Threadsafe from wrong thread");
 	std::lock_guard<std::mutex> lk(tsWriteLock);
 	Event ne;
 	ne.time = globalTimer + cyclesIntoFuture;
@@ -280,7 +281,8 @@ static void AddEventToQueue(Event* ne)
 // than Advance
 void ScheduleEvent(int cyclesIntoFuture, int event_type, u64 userdata)
 {
-	_assert_msg_(POWERPC, Core::IsCPUThread(), "ScheduleEvent from wrong thread");
+	// TODO: Fix UI thread safety problems, and enable this assertion
+	//_assert_msg_(POWERPC, Core::IsCPUThread(), "ScheduleEvent from wrong thread");
 	Event *ne = GetNewEvent();
 	ne->userdata = userdata;
 	ne->type = event_type;


### PR DESCRIPTION
We do a whole bunch of non-threadsafe stuff, especially in the UI, and I'm
probably not going to get around to implementing a threadsafe framework
for interaction between the UI and the CPU thread anytime soon.  See issue
8220.