### PR TITLE
Replace DISC_TYPE_WII with DISC_TYPE_WII_CONTAINER

### DIFF
--- a/Source/Core/DiscIO/VolumeCreator.cpp
+++ b/Source/Core/DiscIO/VolumeCreator.cpp
@@ -26,7 +26,6 @@ namespace DiscIO
 enum EDiscType
 {
 	DISC_TYPE_UNK,
-	DISC_TYPE_WII,
 	DISC_TYPE_WII_CONTAINER,
 	DISC_TYPE_GC,
 	DISC_TYPE_WAD
@@ -80,7 +79,6 @@ IVolume* CreateVolumeFromFilename(const std::string& _rFilename, u32 _PartitionG
 
 	switch (GetDiscType(*pReader))
 	{
-		case DISC_TYPE_WII:
 		case DISC_TYPE_GC:
 			return new CVolumeGC(pReader);
 
@@ -217,8 +215,6 @@ EDiscType GetDiscType(IBlobReader& _rReader)
 	u32 GCMagic = Reader.Read32(0x1C);
 
 	// check for Wii
-	if (WiiMagic == 0x5D1C9EA3 && WiiContainerMagic != 0)
-		return DISC_TYPE_WII;
 	if (WiiMagic == 0x5D1C9EA3 && WiiContainerMagic == 0)
 		return DISC_TYPE_WII_CONTAINER;
 

--- a/Source/Core/DiscIO/VolumeCreator.cpp
+++ b/Source/Core/DiscIO/VolumeCreator.cpp
@@ -26,7 +26,7 @@ namespace DiscIO
 enum EDiscType
 {
 	DISC_TYPE_UNK,
-	DISC_TYPE_WII_CONTAINER,
+	DISC_TYPE_WII,
 	DISC_TYPE_GC,
 	DISC_TYPE_WAD
 };
@@ -85,7 +85,7 @@ IVolume* CreateVolumeFromFilename(const std::string& _rFilename, u32 _PartitionG
 		case DISC_TYPE_WAD:
 			return new CVolumeWAD(pReader);
 
-		case DISC_TYPE_WII_CONTAINER:
+		case DISC_TYPE_WII:
 		{
 			IVolume* pVolume = CreateVolumeFromCryptedWiiImage(*pReader, _PartitionGroup, 0, _VolumeNum);
 
@@ -209,14 +209,13 @@ static IVolume* CreateVolumeFromCryptedWiiImage(IBlobReader& _rReader, u32 _Part
 EDiscType GetDiscType(IBlobReader& _rReader)
 {
 	CBlobBigEndianReader Reader(_rReader);
-	u32 WiiMagic = Reader.Read32(0x18);
-	u32 WiiContainerMagic = Reader.Read32(0x60);
+	u32 WiiMagic = Reader.Read32(0x18); // Disc layout magic (Wii)
 	u32 WADMagic = Reader.Read32(0x02);
-	u32 GCMagic = Reader.Read32(0x1C);
+	u32 GCMagic = Reader.Read32(0x1C); // Disc layout magic (GC)
 
 	// check for Wii
-	if (WiiMagic == 0x5D1C9EA3 && WiiContainerMagic == 0)
-		return DISC_TYPE_WII_CONTAINER;
+	if (WiiMagic == 0x5D1C9EA3)
+		return DISC_TYPE_WII;
 
 	// check for WAD
 	// 0x206962 for boot2 wads
@@ -229,7 +228,6 @@ EDiscType GetDiscType(IBlobReader& _rReader)
 
 	WARN_LOG(DISCIO, "No known magic words found");
 	WARN_LOG(DISCIO, "Wii  offset: 0x18 value: 0x%08x", WiiMagic);
-	WARN_LOG(DISCIO, "WiiC offset: 0x60 value: 0x%08x", WiiContainerMagic);
 	WARN_LOG(DISCIO, "WAD  offset: 0x02 value: 0x%08x", WADMagic);
 	WARN_LOG(DISCIO, "GC   offset: 0x1C value: 0x%08x", GCMagic);
 


### PR DESCRIPTION
As best as I can tell, this code goes completely unused, as all of my Wii games come up as "DISC_TYPE_WII_CONTAINER".

If anyone knows what these variables are used for, please let me know. I'm trying to figure out what the purpose of this code is.

Git blame said this section was authored by Soren Jorvang on Jun 1, 2010.

Edit: It seems that Wii Container Magic is the debugger hook. So DISC_TYPE_WII is only used if the debugger hook is not equal to 0. http://hitmen.c02.at/files/yagcd/yagcd/chap4.html#sec4.2.1.3