### PR TITLE
Windows AVIDump: support "silent" frame dumping

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -362,6 +362,7 @@ void SConfig::SaveMovieSettings(IniFile& ini)
 	movie->Set("PauseMovie", m_PauseMovie);
 	movie->Set("Author", m_strMovieAuthor);
 	movie->Set("DumpFrames", m_DumpFrames);
+	movie->Set("DumpFramesSilent", m_DumpFramesSilent);
 	movie->Set("ShowInputDisplay", m_ShowInputDisplay);
 }
 
@@ -603,6 +604,7 @@ void SConfig::LoadMovieSettings(IniFile& ini)
 	movie->Get("PauseMovie", &m_PauseMovie, false);
 	movie->Get("Author", &m_strMovieAuthor, "");
 	movie->Get("DumpFrames", &m_DumpFrames, false);
+	movie->Get("DumpFramesSilent", &m_DumpFramesSilent, false);
 	movie->Get("ShowInputDisplay", &m_ShowInputDisplay, false);
 }
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -100,6 +100,7 @@ struct SConfig : NonCopyable
 	std::string m_strMovieAuthor;
 	unsigned int m_FrameSkip;
 	bool m_DumpFrames;
+	bool m_DumpFramesSilent;
 	bool m_ShowInputDisplay;
 
 	// DSP settings

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -88,8 +88,11 @@ bool AVIDump::CreateFile()
 	// Ask to delete file
 	if (File::Exists(movie_file_name))
 	{
-		if (AskYesNoT("Delete the existing file '%s'?", movie_file_name.c_str()))
+		if (SConfig::GetInstance().m_DumpFramesSilent ||
+		    AskYesNoT("Delete the existing file '%s'?", movie_file_name.c_str()))
+		{
 			File::Delete(movie_file_name);
+		}
 	}
 
 	AVIFileInit();
@@ -291,7 +294,16 @@ bool AVIDump::SetCompressionOptions()
 	memset(&s_options, 0, sizeof(s_options));
 	s_array_options[0] = &s_options;
 
-	return (AVISaveOptions(s_emu_wnd, 0, 1, &s_stream, s_array_options) != 0);
+	if (SConfig::GetInstance().m_DumpFramesSilent)
+	{
+		s_options.fccType = streamtypeVIDEO;
+		s_options.fccHandler = mmioFOURCC('D', 'I', 'B', ' ');  // Uncompressed
+		return true;
+	}
+	else
+	{
+		return (AVISaveOptions(s_emu_wnd, 0, 1, &s_stream, s_array_options) != 0);
+	}
 }
 
 bool AVIDump::SetVideoFormat()


### PR DESCRIPTION
When enabled, the silent option will avoid popping up dialog boxes for
overwrite confirmation or codec selection. The codec selection defaults to
uncompressed RGB.

This is required for FifoCI on Windows which needs to drive Dolphin from the
command line exclusively.