### PR TITLE
DolphinWX: Remove unnecessary wxBeginBusyCursor and wxEndBusyCursor calls

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1211,7 +1211,6 @@ void CFrame::DoStop()
 			Movie::EndPlayInput(false);
 		NetPlay::StopGame();
 
-		wxBeginBusyCursor();
 		BootManager::Stop();
 		UpdateGUI();
 	}
@@ -1219,8 +1218,6 @@ void CFrame::DoStop()
 
 void CFrame::OnStopped()
 {
-	wxEndBusyCursor();
-
 	m_confirmStop = false;
 
 #if defined(HAVE_X11) && HAVE_X11


### PR DESCRIPTION
The UI greys all buttons when shutting down, so it's sufficient as a visual cue