### PR TITLE
Remove unneeded spaces from code.

### DIFF
--- a/Source/Core/AudioCommon/DPL2Decoder.cpp
+++ b/Source/Core/AudioCommon/DPL2Decoder.cpp
@@ -51,7 +51,7 @@ static _ftype_t DotProduct(int count,const T *buf,const _ftype_t *coefficients)
 	}
 
 	while (count--)
-		sum0+= *buf++ * *coefficients++;
+		sum0+=*buf++**coefficients++;
 
 	return sum0+sum1+sum2+sum3;
 }


### PR DESCRIPTION
As they aren't required by the C++11 standard.

Line now matches the style of the rest of the function.