### PR TITLE
WiimoteEmu: Add back the calibrated accel data to the EEPROM

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -32,13 +32,14 @@ auto const PI = TAU / 2.0;
 namespace WiimoteEmu
 {
 
-/* An example of a factory default first bytes of the Eeprom memory. There are differences between
-   different Wiimotes, my Wiimote had different neutral values for the accelerometer. */
 static const u8 eeprom_data_0[] = {
 	// IR, maybe more
 	// assuming last 2 bytes are checksum
 	0xA1, 0xAA, 0x8B, 0x99, 0xAE, 0x9E, 0x78, 0x30, 0xA7, /*0x74, 0xD3,*/ 0x00, 0x00, // messing up the checksum on purpose
 	0xA1, 0xAA, 0x8B, 0x99, 0xAE, 0x9E, 0x78, 0x30, 0xA7, /*0x74, 0xD3,*/ 0x00, 0x00,
+	// Accelerometer
+	ACCEL_ZERO_G, ACCEL_ZERO_G, ACCEL_ZERO_G, 0, ACCEL_ONE_G, ACCEL_ONE_G, ACCEL_ONE_G, 0, 0, 0,
+	ACCEL_ZERO_G, ACCEL_ZERO_G, ACCEL_ZERO_G, 0, ACCEL_ONE_G, ACCEL_ONE_G, ACCEL_ONE_G, 0, 0, 0,
 };
 
 static const u8 motion_plus_id[] = { 0x00, 0x00, 0xA6, 0x20, 0x00, 0x05 };

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -85,6 +85,13 @@ inline double trim(double a)
 	return a;
 }
 
+enum
+{
+	ACCEL_ZERO_G = 0x80,
+	ACCEL_ONE_G = 0x9A,
+	ACCEL_RANGE = (ACCEL_ONE_G - ACCEL_ZERO_G),
+};
+
 class Wiimote : public ControllerEmu
 {
 friend class WiimoteReal::Wiimote;
@@ -104,13 +111,6 @@ public:
 		BUTTON_A     = 0x0800,
 		BUTTON_MINUS = 0x1000,
 		BUTTON_HOME  = 0x8000,
-	};
-
-	enum
-	{
-		ACCEL_ZERO_G = 0x80,
-		ACCEL_ONE_G = 0x9A,
-		ACCEL_RANGE = (ACCEL_ONE_G - ACCEL_ZERO_G),
 	};
 
 	Wiimote(const unsigned int index);


### PR DESCRIPTION
It seems that games actually read this to determine how to act, which
isn't particularly strange. I was imagining it was more for the
Wiimote's internal normalization, but I was wrong.