### PR TITLE
JIT: fix handling of PC in dispatcher/block cache.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -339,29 +339,12 @@ void Jit64::JustWriteExit(u32 destination, bool bl, u32 after)
 	linkData.exitAddress = destination;
 	linkData.linkStatus = false;
 
-	// Link opportunity!
-	int block;
-	if (jo.enableBlocklink && (block = blocks.GetBlockNumberFromStartAddress(destination)) >= 0)
-	{
-		// It exists! Joy of joy!
-		JitBlock* jb = blocks.GetBlock(block);
-		const u8* addr = jb->checkedEntry;
-		linkData.exitPtrs = GetWritableCodePtr();
-		if (bl)
-			CALL(addr);
-		else
-			JMP(addr, true);
-		linkData.linkStatus = true;
-	}
+	MOV(32, PPCSTATE(pc), Imm32(destination));
+	linkData.exitPtrs = GetWritableCodePtr();
+	if (bl)
+		CALL(asm_routines.dispatcher);
 	else
-	{
-		MOV(32, PPCSTATE(pc), Imm32(destination));
-		linkData.exitPtrs = GetWritableCodePtr();
-		if (bl)
-			CALL(asm_routines.dispatcher);
-		else
-			JMP(asm_routines.dispatcher, true);
-	}
+		JMP(asm_routines.dispatcher, true);
 
 	b->linkData.push_back(linkData);
 

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -17,6 +17,11 @@ static void* s_saved_rsp;
 // dynarec buffer
 // At this offset - 4, there is an int specifying the block number.
 
+static void DispatchSlow()
+{
+	jit->GetBlockCache()->MoveBlockIntoFastCache(PC);
+}
+
 void Jit64AsmRoutineManager::Generate()
 {
 	enterCode = AlignCode16();
@@ -95,28 +100,10 @@ void Jit64AsmRoutineManager::Generate()
 			MOV(64, R(RMEM), Imm64((u64)Memory::logical_base));
 			SetJumpTarget(membaseend);
 
+			// Translate PC.
 			MOV(32, R(RSCRATCH), PPCSTATE(pc));
-
-			// TODO: We need to handle code which executes the same PC with
-			// different values of MSR.IR. It probably makes sense to handle
-			// MSR.DR here too, to allow IsOptimizableRAMAddress-based
-			// optimizations safe, because IR and DR are usually set/cleared together.
-			// TODO: Branching based on the 20 most significant bits of instruction
-			// addresses without translating them is wrong.
 			u64 icache = (u64)jit->GetBlockCache()->iCache.data();
-			u64 icacheVmem = (u64)jit->GetBlockCache()->iCacheVMEM.data();
-			u64 icacheEx = (u64)jit->GetBlockCache()->iCacheEx.data();
-			u32 mask = 0;
-			FixupBranch no_mem;
-			FixupBranch exit_mem;
-			FixupBranch exit_vmem;
-			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
-				mask = JIT_ICACHE_EXRAM_BIT;
-			mask |= JIT_ICACHE_VMEM_BIT;
-			TEST(32, R(RSCRATCH), Imm32(mask));
-			no_mem = J_CC(CC_NZ);
-			AND(32, R(RSCRATCH), Imm32(JIT_ICACHE_MASK));
-
+			AND(32, R(RSCRATCH), Imm32(JitBaseBlockCache::iCache_Mask << 2));
 			if (icache <= INT_MAX)
 			{
 				MOV(32, R(RSCRATCH), MDisp(RSCRATCH, (s32)icache));
@@ -124,66 +111,33 @@ void Jit64AsmRoutineManager::Generate()
 			else
 			{
 				MOV(64, R(RSCRATCH2), Imm64(icache));
-				MOV(32, R(RSCRATCH), MComplex(RSCRATCH2, RSCRATCH, SCALE_1, 0));
+				MOV(32, R(RSCRATCH), MRegSum(RSCRATCH2, RSCRATCH));
 			}
 
-			exit_mem = J();
-			SetJumpTarget(no_mem);
-			TEST(32, R(RSCRATCH), Imm32(JIT_ICACHE_VMEM_BIT));
-			FixupBranch no_vmem = J_CC(CC_Z);
-			AND(32, R(RSCRATCH), Imm32(JIT_ICACHE_MASK));
-			if (icacheVmem <= INT_MAX)
+			u64 blocks = (u64)jit->GetBlockCache()->GetBlocks();
+			IMUL(32, RSCRATCH, R(RSCRATCH), Imm32(sizeof(JitBlock)));
+			if (blocks <= INT_MAX)
 			{
-				MOV(32, R(RSCRATCH), MDisp(RSCRATCH, (s32)icacheVmem));
+				ADD(32, R(RSCRATCH), Imm32((s32)blocks));
 			}
 			else
 			{
-				MOV(64, R(RSCRATCH2), Imm64(icacheVmem));
-				MOV(32, R(RSCRATCH), MComplex(RSCRATCH2, RSCRATCH, SCALE_1, 0));
+				MOV(64, R(RSCRATCH2), Imm64(blocks));
+				ADD(32, R(RSCRATCH), R(RSCRATCH2));
 			}
-
-			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii) exit_vmem = J();
-			SetJumpTarget(no_vmem);
-			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
-			{
-				TEST(32, R(RSCRATCH), Imm32(JIT_ICACHE_EXRAM_BIT));
-				FixupBranch no_exram = J_CC(CC_Z);
-				AND(32, R(RSCRATCH), Imm32(JIT_ICACHEEX_MASK));
-
-				if (icacheEx <= INT_MAX)
-				{
-					MOV(32, R(RSCRATCH), MDisp(RSCRATCH, (s32)icacheEx));
-				}
-				else
-				{
-					MOV(64, R(RSCRATCH2), Imm64(icacheEx));
-					MOV(32, R(RSCRATCH), MComplex(RSCRATCH2, RSCRATCH, SCALE_1, 0));
-				}
-
-				SetJumpTarget(no_exram);
-			}
-			SetJumpTarget(exit_mem);
-			if (SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
-				SetJumpTarget(exit_vmem);
-
-			TEST(32, R(RSCRATCH), R(RSCRATCH));
-			FixupBranch notfound = J_CC(CC_L);
-			//grab from list and jump to it
-			u64 codePointers = (u64)jit->GetBlockCache()->GetCodePointers();
-			if (codePointers <= INT_MAX)
-			{
-				JMPptr(MScaled(RSCRATCH, 8, (s32)codePointers));
-			}
-			else
-			{
-				MOV(64, R(RSCRATCH2), Imm64(codePointers));
-				JMPptr(MComplex(RSCRATCH2, RSCRATCH, 8, 0));
-			}
+			MOV(32, R(RSCRATCH2), PPCSTATE(msr));
+			AND(32, R(RSCRATCH2), Imm32(0x30));
+			SHL(64, R(RSCRATCH2), Imm8(32));
+			MOV(32, R(RSCRATCH_EXTRA), PPCSTATE(pc));
+			OR(64, R(RSCRATCH2), R(RSCRATCH_EXTRA));
+			CMP(64, R(RSCRATCH2), MDisp(RSCRATCH, (s32)offsetof(JitBlock, effectiveAddress)));
+			FixupBranch notfound = J_CC(CC_NE);
+			JMPptr(MDisp(RSCRATCH, (s32)offsetof(JitBlock, normalEntry)));
 			SetJumpTarget(notfound);
 
-			//Ok, no block, let's jit
+			// Slow path.
 			ABI_PushRegistersAndAdjustStack({}, 0);
-			ABI_CallFunctionA(32, (void *)&Jit, PPCSTATE(pc));
+			ABI_CallFunction((void*)DispatchSlow);
 			ABI_PopRegistersAndAdjustStack({}, 0);
 
 			// Jit might have cleared the code cache

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -375,19 +375,9 @@ void JitIL::WriteExit(u32 destination)
 	linkData.exitPtrs = GetWritableCodePtr();
 	linkData.linkStatus = false;
 
-	// Link opportunity!
-	int block;
-	if (jo.enableBlocklink && (block = blocks.GetBlockNumberFromStartAddress(destination)) >= 0)
-	{
-		// It exists! Joy of joy!
-		JMP(blocks.GetBlock(block)->checkedEntry, true);
-		linkData.linkStatus = true;
-	}
-	else
-	{
-		MOV(32, PPCSTATE(pc), Imm32(destination));
-		JMP(asm_routines.dispatcher, true);
-	}
+	MOV(32, PPCSTATE(pc), Imm32(destination));
+	JMP(asm_routines.dispatcher, true);
+
 	b->linkData.push_back(linkData);
 }
 

--- a/Source/Core/Core/PowerPC/JitArm32/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/JitAsm.cpp
@@ -97,7 +97,7 @@ void JitArmAsmRoutineManager::Generate()
 
 			FixupBranch no_block = B_CC(CC_NEQ);
 				// Success, it is our Jitblock.
-				MOVI2R(R14, (u32)jit->GetBlockCache()->GetCodePointers());
+				MOVI2R(R14, (u32)jit->GetBlockCache()->GetBlocks());
 				// LDR R14 right here to get CodePointers()[0] pointer.
 				LSL(R12, R12, 2); // Multiply by four because address locations are u32 in size
 				LDR(R14, R14, R12); // Load the block address in to R14

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -49,7 +49,7 @@ void JitArm64AsmRoutineManager::Generate()
 
 		FixupBranch JitBlock = TBNZ(W27, 7); // Test the 7th bit
 			// Success, it is our Jitblock.
-			MOVI2R(X30, (u64)jit->GetBlockCache()->GetCodePointers());
+			MOVI2R(X30, (u64)jit->GetBlockCache()->GetBlocks());
 			UBFM(X27, X27, 61, 60); // Same as X27 << 3
 			LDR(X30, X30, X27); // Load the block address in to R14
 			BR(X30);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -30,26 +30,15 @@ using namespace Gen;
 
 	void JitBaseBlockCache::Init()
 	{
-		if (m_initialized)
-		{
-			PanicAlert("JitBaseBlockCache::Init() - iCache is already initialized");
-			return;
-		}
-
 		JitRegister::Init();
 
-		iCache.fill(JIT_ICACHE_INVALID_BYTE);
-		iCacheEx.fill(JIT_ICACHE_INVALID_BYTE);
-		iCacheVMEM.fill(JIT_ICACHE_INVALID_BYTE);
+		iCache.fill(0);
 		Clear();
-
-		m_initialized = true;
 	}
 
 	void JitBaseBlockCache::Shutdown()
 	{
 		num_blocks = 0;
-		m_initialized = false;
 
 		JitRegister::Shutdown();
 	}
@@ -76,7 +65,8 @@ using namespace Gen;
 		valid_block.ClearAll();
 
 		num_blocks = 0;
-		blockCodePointers.fill(nullptr);
+		blocks[0].msrBits = 0xFFFFFFFF;
+		blocks[0].invalid = true;
 	}
 
 	void JitBaseBlockCache::Reset()
@@ -111,7 +101,9 @@ using namespace Gen;
 	{
 		JitBlock &b = blocks[num_blocks];
 		b.invalid = false;
-		b.originalAddress = em_address;
+		b.effectiveAddress = em_address;
+		b.physicalAddress = PowerPC::JitCache_TranslateAddress(em_address).address;
+		b.msrBits = MSR & 0x30;
 		b.linkData.clear();
 		num_blocks++; //commit the current block
 		return num_blocks - 1;
@@ -119,13 +111,21 @@ using namespace Gen;
 
 	void JitBaseBlockCache::FinalizeBlock(int block_num, bool block_link, const u8 *code_ptr)
 	{
-		blockCodePointers[block_num] = code_ptr;
 		JitBlock &b = blocks[block_num];
-		u32* icp = GetICachePtr(b.originalAddress);
-		*icp = block_num;
+		if (start_block_map.count(b.physicalAddress))
+		{
+			// We already have a block at this address; invalidate the old block.
+			// This should be very rare.
+			WARN_LOG(DYNA_REC, "Invalidating compiled block at same address %08x", b.physicalAddress);
+			int old_block_num = start_block_map[b.physicalAddress];
+			JitBlock &old_b = blocks[old_block_num];
+			block_map.erase(std::make_pair(old_b.physicalAddress + 4 * old_b.originalSize - 1, old_b.physicalAddress));
+			DestroyBlock(old_block_num, true);
+		}
+		start_block_map[b.physicalAddress] = block_num;
+		iCache[(b.effectiveAddress >> 2) & iCache_Mask] = block_num;
 
-		// Convert the logical address to a physical address for the block map
-		u32 pAddr = b.originalAddress & 0x1FFFFFFF;
+		u32 pAddr = b.physicalAddress;
 
 		for (u32 block = pAddr / 32; block <= (pAddr + (b.originalSize - 1) * 4) / 32; ++block)
 			valid_block.Set(block);
@@ -143,43 +143,41 @@ using namespace Gen;
 			LinkBlockExits(block_num);
 		}
 
-		JitRegister::Register(blockCodePointers[block_num], b.codeSize,
-			"JIT_PPC_%08x", b.originalAddress);
-	}
-
-	const u8 **JitBaseBlockCache::GetCodePointers()
-	{
-		return blockCodePointers.data();
-	}
-
-	u32* JitBaseBlockCache::GetICachePtr(u32 addr)
-	{
-		if (addr & JIT_ICACHE_VMEM_BIT)
-			return (u32*)(&jit->GetBlockCache()->iCacheVMEM[addr & JIT_ICACHE_MASK]);
-		else if (addr & JIT_ICACHE_EXRAM_BIT)
-			return (u32*)(&jit->GetBlockCache()->iCacheEx[addr & JIT_ICACHEEX_MASK]);
-		else
-			return (u32*)(&jit->GetBlockCache()->iCache[addr & JIT_ICACHE_MASK]);
+		JitRegister::Register(b.normalEntry, b.codeSize,
+			"JIT_PPC_%08x", b.physicalAddress);
 	}
 
 	int JitBaseBlockCache::GetBlockNumberFromStartAddress(u32 addr)
 	{
-		u32 inst = *GetICachePtr(addr);
-		if (inst & 0xfc000000) // definitely not a JIT block
-			return -1;
+		u32 translated_addr = addr;
+		if (UReg_MSR(MSR).IR)
+		{
+			auto translated = PowerPC::JitCache_TranslateAddress(addr);
+			if (!translated.valid)
+			{
+				return -1;
+			}
+			translated_addr = translated.address;
+		}
 
-		if ((int)inst >= num_blocks)
+		auto map_result = start_block_map.find(translated_addr);
+		if (map_result == start_block_map.end())
 			return -1;
-
-		if (blocks[inst].originalAddress != addr)
+		int block_num = map_result->second;
+		if (blocks[block_num].invalid)
 			return -1;
-
-		return inst;
+		if (blocks[block_num].effectiveAddress != addr)
+			return -1;
+		return block_num;
 	}
 
-	CompiledCode JitBaseBlockCache::GetCompiledCodeFromBlock(int block_num)
+	void JitBaseBlockCache::MoveBlockIntoFastCache(u32 addr)
 	{
-		return (CompiledCode)blockCodePointers[block_num];
+		int block_num = GetBlockNumberFromStartAddress(addr);
+		if (block_num < 0 || blocks[block_num].msrBits != (MSR & 0x30))
+			Jit(addr);
+		else
+			iCache[(addr >> 2) & iCache_Mask] = block_num;
 	}
 
 	//Block linker
@@ -201,7 +199,7 @@ using namespace Gen;
 			if (!e.linkStatus)
 			{
 				int destinationBlock = GetBlockNumberFromStartAddress(e.exitAddress);
-				if (destinationBlock != -1)
+				if (destinationBlock != -1 && blocks[destinationBlock].msrBits == b.msrBits)
 				{
 					WriteLinkBlock(e.exitPtrs, blocks[destinationBlock].checkedEntry);
 					e.linkStatus = true;
@@ -214,16 +212,10 @@ using namespace Gen;
 	{
 		LinkBlockExits(i);
 		JitBlock &b = blocks[i];
-		// equal_range(b) returns pair<iterator,iterator> representing the range
-		// of element with key b
-		auto ppp = links_to.equal_range(b.originalAddress);
-
-		if (ppp.first == ppp.second)
-			return;
+		auto ppp = links_to.equal_range(b.effectiveAddress);
 
 		for (auto iter = ppp.first; iter != ppp.second; ++iter)
 		{
-			// PanicAlert("Linking block %i to block %i", iter->second, i);
 			LinkBlockExits(iter->second);
 		}
 	}
@@ -231,21 +223,18 @@ using namespace Gen;
 	void JitBaseBlockCache::UnlinkBlock(int i)
 	{
 		JitBlock &b = blocks[i];
-		auto ppp = links_to.equal_range(b.originalAddress);
-
-		if (ppp.first == ppp.second)
-			return;
+		auto ppp = links_to.equal_range(b.effectiveAddress);
 
 		for (auto iter = ppp.first; iter != ppp.second; ++iter)
 		{
 			JitBlock &sourceBlock = blocks[iter->second];
 			for (auto& e : sourceBlock.linkData)
 			{
-				if (e.exitAddress == b.originalAddress)
+				if (e.exitAddress == b.effectiveAddress)
 					e.linkStatus = false;
 			}
 		}
-		links_to.erase(b.originalAddress);
+		links_to.erase(b.effectiveAddress);
 	}
 
 	void JitBaseBlockCache::DestroyBlock(int block_num, bool invalidate)
@@ -263,20 +252,23 @@ using namespace Gen;
 			return;
 		}
 		b.invalid = true;
-		*GetICachePtr(b.originalAddress) = JIT_ICACHE_INVALID_WORD;
+		start_block_map.erase(b.physicalAddress);
+		iCache[(b.effectiveAddress >> 2) & iCache_Mask] = 0;
 
 		UnlinkBlock(block_num);
 
 		// Send anyone who tries to run this block back to the dispatcher.
 		// Not entirely ideal, but .. pretty good.
 		// Spurious entrances from previously linked blocks can only come through checkedEntry
-		WriteDestroyBlock(b.checkedEntry, b.originalAddress);
+		WriteDestroyBlock(b.checkedEntry, b.effectiveAddress);
 	}
 
 	void JitBaseBlockCache::InvalidateICache(u32 address, const u32 length, bool forced)
 	{
-		// Convert the logical address to a physical address for the block map
-		u32 pAddr = address & 0x1FFFFFFF;
+		auto translated = PowerPC::JitCache_TranslateAddress(address);
+		if (!translated.valid)
+			return;
+		u32 pAddr = translated.address;
 
 		// Optimize the common case of length == 32 which is used by Interpreter::dcb*
 		bool destroy_block = true;
@@ -295,8 +287,6 @@ using namespace Gen;
 			std::map<std::pair<u32,u32>, u32>::iterator it1 = block_map.lower_bound(std::make_pair(pAddr, 0)), it2 = it1;
 			while (it2 != block_map.end() && it2->first.second < pAddr + length)
 			{
-				JitBlock &b = blocks[it2->second];
-				*GetICachePtr(b.originalAddress) = JIT_ICACHE_INVALID_WORD;
 				DestroyBlock(it2->second, true);
 				++it2;
 			}

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -97,7 +97,6 @@ class JitBaseBlockCache
 	std::map<u32, u32> start_block_map; // start_addr -> number
 	ValidBlockBitSet valid_block;
 
-	bool RangeIntersect(int s1, int e1, int s2, int e2) const;
 	void LinkBlockExits(int i);
 	void LinkBlock(int i);
 	void UnlinkBlock(int i);
@@ -107,6 +106,7 @@ class JitBaseBlockCache
 	// Virtual for overloaded
 	virtual void WriteLinkBlock(u8* location, const u8* address) = 0;
 	virtual void WriteDestroyBlock(const u8* location, u32 address) = 0;
+	virtual void WriteUndestroyBlock(const u8* location, u32 address) = 0;
 
 public:
 	JitBaseBlockCache() : num_blocks(0)
@@ -136,8 +136,8 @@ public:
 
 	void MoveBlockIntoFastCache(u32 em_address);
 
-	// DOES NOT WORK CORRECTLY WITH INLINING
 	void InvalidateICache(u32 address, const u32 length, bool forced);
+	void EvictTLBEntry(u32 address);
 };
 
 // x86 BlockCache
@@ -146,4 +146,5 @@ class JitBlockCache : public JitBaseBlockCache
 private:
 	void WriteLinkBlock(u8* location, const u8* address) override;
 	void WriteDestroyBlock(const u8* location, u32 address) override;
+	void WriteUndestroyBlock(const u8* location, u32 address) override;
 };

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -152,13 +152,13 @@ namespace JitInterface
 			const JitBlock *block = jit->GetBlockCache()->GetBlock(stat.blockNum);
 			if (block)
 			{
-				std::string name = g_symbolDB.GetDescription(block->originalAddress);
+				std::string name = g_symbolDB.GetDescription(block->effectiveAddress);
 				double percent = 100.0 * (double)stat.cost / (double)cost_sum;
 				double timePercent = 100.0 * (double)block->ticCounter / (double)timecost_sum;
 				fprintf(f.GetHandle(), "%08x\t%s\t%" PRIu64 "\t%" PRIu64 "\t%.2f\t%.2f\t%.2f\t%i\n",
-						block->originalAddress, name.c_str(), stat.cost,
-						block->ticCounter, percent, timePercent,
-						(double)block->ticCounter*1000.0/(double)countsPerSec, block->codeSize);
+				    block->effectiveAddress, name.c_str(), stat.cost,
+				    block->ticCounter, percent, timePercent,
+				    (double)block->ticCounter*1000.0/(double)countsPerSec, block->codeSize);
 			}
 		}
 	}

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -188,6 +188,12 @@ namespace JitInterface
 			jit->GetBlockCache()->InvalidateICache(address, size, forced);
 	}
 
+	void EvictTLBEntry(u32 address)
+	{
+		if (jit)
+			jit->GetBlockCache()->EvictTLBEntry(address);
+	}
+
 	void CompileExceptionCheck(ExceptionType type)
 	{
 		if (!jit)

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -37,6 +37,8 @@ namespace JitInterface
 	// If "forced" is true, a recompile is being requested on code that hasn't been modified.
 	void InvalidateICache(u32 address, u32 size, bool forced);
 
+	void EvictTLBEntry(u32 address);
+
 	void CompileExceptionCheck(ExceptionType type);
 
 	void Shutdown();

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -272,6 +272,13 @@ bool IsOptimizableRAMAddress(const u32 address);
 u32 IsOptimizableMMIOAccess(u32 address, u32 accessSize);
 bool IsOptimizableGatherPipeWrite(u32 address);
 
+struct TranslateResult
+{
+	bool valid;
+	bool from_bat;
+	u32 address;
+};
+TranslateResult JitCache_TranslateAddress(u32 address);
 }  // namespace
 
 enum CRBits

--- a/Source/Core/DolphinWX/Debugger/JitWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.cpp
@@ -159,8 +159,8 @@ std::string HostDisassembler::DisassembleBlock(u32* address, u32* host_instructi
 		if (block_num >= 0)
 		{
 			JitBlock* block = jit->GetBlockCache()->GetBlock(block_num);
-			if (!(block->originalAddress <= *address &&
-			    block->originalSize + block->originalAddress >= *address))
+			if (!(block->effectiveAddress <= *address &&
+				block->originalSize + block->effectiveAddress >= *address))
 				block_num = -1;
 		}
 
@@ -175,10 +175,10 @@ std::string HostDisassembler::DisassembleBlock(u32* address, u32* host_instructi
 
 	JitBlock* block = jit->GetBlockCache()->GetBlock(block_num);
 
-	const u8* code = (const u8*)jit->GetBlockCache()->GetCompiledCodeFromBlock(block_num);
+	const u8* code = block->normalEntry;
 
 	*code_size = block->codeSize;
-	*address = block->originalAddress;
+	*address = block->effectiveAddress;
 	return DisassembleHostBlock(code, block->codeSize, host_instructions_count);
 }
 


### PR DESCRIPTION
Specifically, don't make any assumptions about what effective addresses
are used for code, and correctly handle changes to MSR.DR/MSR.IR.

(Split off from dynamic-bat.)

I've only done very basic testing so far, and no performance testing.  ARM needs some additional changes to support this.  Stills need some sort of handling for tlbie.