### PR TITLE
Jit64: Use variadic templates for RegCache locking

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -48,41 +48,6 @@ void RegCache::Start()
 	//But only preload IF written OR reads >= 3
 }
 
-// these are powerpc reg indices
-void RegCache::Lock(int p1, int p2, int p3, int p4)
-{
-	regs[p1].locked = true;
-
-	if (p2 != 0xFF)
-		regs[p2].locked = true;
-
-	if (p3 != 0xFF)
-		regs[p3].locked = true;
-
-	if (p4 != 0xFF)
-		regs[p4].locked = true;
-}
-
-// these are x64 reg indices
-void RegCache::LockX(int x1, int x2, int x3, int x4)
-{
-	if (xregs[x1].locked)
-	{
-		PanicAlert("RegCache: x %i already locked!", x1);
-	}
-
-	xregs[x1].locked = true;
-
-	if (x2 != 0xFF)
-		xregs[x2].locked = true;
-
-	if (x3 != 0xFF)
-		xregs[x3].locked = true;
-
-	if (x4 != 0xFF)
-		xregs[x4].locked = true;
-}
-
 void RegCache::UnlockAll()
 {
 	for (auto& reg : regs)

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -109,8 +109,35 @@ public:
 	virtual Gen::OpArg GetDefaultLocation(size_t reg) const = 0;
 
 	// Register locking.
-	void Lock(int p1, int p2=0xff, int p3=0xff, int p4=0xff);
-	void LockX(int x1, int x2=0xff, int x3=0xff, int x4=0xff);
+
+	// these are powerpc reg indices
+	template<typename T>
+	void Lock(T p)
+	{
+		regs[p].locked = true;
+	}
+	template<typename T, typename... Args>
+	void Lock(T first, Args... args)
+	{
+		Lock(first);
+		Lock(args...);
+	}
+
+	// these are x64 reg indices
+	template<typename T>
+	void LockX(T x)
+	{
+		if (xregs[x].locked)
+			PanicAlert("RegCache: x %i already locked!", x);
+		xregs[x].locked = true;
+	}
+	template<typename T, typename... Args>
+	void LockX(T first, Args... args)
+	{
+		LockX(first);
+		LockX(args...);
+	}
+
 	void UnlockAll();
 	void UnlockAllX();
 


### PR DESCRIPTION
Found this low-hanging fruit while reading through the code. Trims off a few branches in unimportant places; shouldn't make much of a difference otherwise.