### PR TITLE
Disable an IsCPUThread() assert in Release builds.

### DIFF
--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -191,7 +191,7 @@ static const char *Debug_GetInterruptName(u32 _causemask)
 
 void SetInterrupt(u32 _causemask, bool _bSet)
 {
-	_assert_msg_(POWERPC, Core::IsCPUThread(), "SetInterrupt from wrong thread");
+	_dbg_assert_msg_(POWERPC, Core::IsCPUThread(), "SetInterrupt from wrong thread");
 
 	if (_bSet && !(m_InterruptCause & _causemask))
 	{


### PR DESCRIPTION
IsCPUThread is extremely slow at the moment, and this code runs
frequently.