### PR TITLE
Partially fix WWE12 titantron videos.

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -192,6 +192,12 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 	          "int3 iround(float3 x) { return int3(round(x)); }\n"
 	          "int4 iround(float4 x) { return int4(round(x)); }\n\n");
 
+	out.Write("int  itrunc(float  x) { return int (trunc(x)); }\n"
+	          "int2 itrunc(float2 x) { return int2(trunc(x)); }\n"
+	          "int3 itrunc(float3 x) { return int3(trunc(x)); }\n"
+	          "int4 itrunc(float4 x) { return int4(trunc(x)); }\n\n");
+
+
 	if (ApiType == API_OPENGL)
 	{
 		// Declare samplers
@@ -430,7 +436,7 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 		out.SetConstantsUsed(C_TEXDIMS, C_TEXDIMS+numTexgen-1);
 		for (unsigned int i = 0; i < numTexgen; ++i)
 		{
-			out.Write("\tint2 fixpoint_uv%d = iround(", i);
+			out.Write("\tint2 fixpoint_uv%d = itrunc(", i);
 			// optional perspective divides
 			uid_data->texMtxInfo_n_projection |= xfmem.texMtxInfo[i].projection << i;
 			if (xfmem.texMtxInfo[i].projection == XF_TEXPROJ_STQ)


### PR DESCRIPTION
The obvious question here is, why does it matter if we round or truncate?
The key is that GC/Wii does fixed-point interpolation, where PC GPUs do
floating-point interpolation. Discarding fractional bits makes the conversion
from floating-point to fixed point give more consistent results.

I'm not confident this is really the right fix, or that my explanation is
completely correct; ideally, we don't want to depend on floating-point
interpolation at all.