### PR TITLE
PPCTables: Remove an unnecessary forward declaration

### DIFF
--- a/Source/Core/Core/PowerPC/PPCTables.h
+++ b/Source/Core/Core/PowerPC/PPCTables.h
@@ -105,8 +105,6 @@ extern int m_numInstructions;
 GekkoOPInfo *GetOpInfo(UGeckoInstruction _inst);
 Interpreter::_interpreterInstruction GetInterpreterOp(UGeckoInstruction _inst);
 
-class cJit64;
-
 namespace PPCTables
 {
 


### PR DESCRIPTION
This class name isn't used anymore.