### PR TITLE
VertexShaderManager: Turn the epsilon hack back on for 3D Vision.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -458,8 +458,7 @@ void VertexShaderManager::SetConstants()
 			g_fProjectionMatrix[14] = 0.0f;
 
 			// Hack to fix depth clipping precision issues (such as Sonic Unleashed UI)
-			// Turn it off for Nvidia 3D Vision, because it can't handle such a projection matrix
-			g_fProjectionMatrix[15] = (g_ActiveConfig.iStereoMode == STEREO_3DVISION) ? 1.0f : 1.0f + FLT_EPSILON;
+			g_fProjectionMatrix[15] = 1.0f + FLT_EPSILON;
 
 			SETSTAT_FT(stats.g2proj_0, g_fProjectionMatrix[0]);
 			SETSTAT_FT(stats.g2proj_1, g_fProjectionMatrix[1]);


### PR DESCRIPTION
The bug is fixed in version 347.52 of the drivers.