### PR TITLE
Search the texture cache for small textures by address and hash

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -60,6 +60,8 @@ public:
 		// used to delete textures which haven't been used for TEXTURE_KILL_THRESHOLD frames
 		int frameCount;
 
+		// Keep an iterator to the entry in textures_by_hash, so it does not need to be searched when removing the cache entry
+		std::multimap<u64, TCacheEntryBase*>::iterator textures_by_hash_iter;
 
 		void SetGeneralParameters(u32 _addr, u32 _size, u32 _format)
 		{
@@ -131,18 +133,20 @@ protected:
 	static size_t temp_size;
 
 private:
+	typedef std::multimap<u64, TCacheEntryBase*> TexCache;
+	typedef std::unordered_multimap<TCacheEntryConfig, TCacheEntryBase*, TCacheEntryConfig::Hasher> TexPool;
+
 	static void DumpTexture(TCacheEntryBase* entry, std::string basename, unsigned int level);
 	static void CheckTempSize(size_t required_size);
 
 	static TCacheEntryBase* AllocateTexture(const TCacheEntryConfig& config);
+	static TexCache::iterator RemoveTextureFromCache(TexCache::iterator t_iter);
 	static void FreeTexture(TCacheEntryBase* entry);
 
 	static TCacheEntryBase* ReturnEntry(unsigned int stage, TCacheEntryBase* entry);
 
-	typedef std::multimap<u32, TCacheEntryBase*> TexCache;
-	typedef std::unordered_multimap<TCacheEntryConfig, TCacheEntryBase*, TCacheEntryConfig::Hasher> TexPool;
-
-	static TexCache textures;
+	static TexCache textures_by_address;
+	static TexCache textures_by_hash;
 	static TexPool texture_pool;
 	static TCacheEntryBase* bound_textures[8];
 


### PR DESCRIPTION
This fixes issue 6563:
https://code.google.com/p/dolphin-emu/issues/detail?id=6563

This PR adds a 2nd map to texture cache, which uses the hash as key. Cache entries from this new map are used only if the address matches or if the texture was fully hashed. This restriction avoids false positive cache hits. This results in a possible situation where safe texture cache accuracy could be faster than the fast one.

Small textures means up to 1KB for fast texture cache accuracy, 4KB for medium, and all textures for safe accuracy.

Since this adds a small overhead to all texture cache handling, some regression testing would be nice. Games, which use a lot of textures the same time, should be affected the most.