### PR TITLE
Fix VTune static library dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,8 +348,10 @@ if(VTUNE)
 	endif()
 	add_definitions(-DUSE_VTUNE)
 	include_directories("${VTUNE_DIR}/include")
-	list(APPEND LIBS "${VTUNE_DIR}/lib64/libjitprofiling.a")
-	list(APPEND LIBS "${VTUNE_DIR}/lib64/libittnotify.a")
+	set(VTUNE_LIBRARIES
+		"${VTUNE_DIR}/lib64/libjitprofiling.a"
+		"${VTUNE_DIR}/lib64/libittnotify.a"
+	)
 endif(VTUNE)
 
 if(ANDROID)

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -60,7 +60,7 @@ if(WIN32)
     set(SRCS ${SRCS} ExtendedTrace.cpp)
 endif(WIN32)
 
-set(LIBS "${CMAKE_THREAD_LIBS_INIT}")
+set(LIBS "${CMAKE_THREAD_LIBS_INIT}" ${VTUNE_LIBRARIES})
 if(NOT APPLE AND NOT ANDROID)
 	set(LIBS ${LIBS} rt)
 endif()


### PR DESCRIPTION
Since libcommon.a is also the last library to be linked, this has the totally hacky but useful side-effect that it doesn't require people to modify CMake files for temporarily adding VTune code to other Dolphin libraries.