### PR TITLE
Include publisher codes in region-free INIs

### DIFF
--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -420,9 +420,12 @@ IniFile SCoreStartupParameter::LoadGameIni(const std::string& id, int revision)
 void SCoreStartupParameter::LoadGameIni(IniFile* game_ini, const std::string& path,
                                         const std::string& id, int revision)
 {
-	// INIs that match all regions
+	// INIs that match all regions (Without publisher codes)
 	if (id.size() >= 4)
 		game_ini->Load(path + id.substr(0, 3) + ".ini", true);
+
+	// INIs that match all regions (With publisher codes)
+	game_ini->Load(path + id.substr(0, 3) + "-" + id.substr(4) + ".ini", true);
 
 	// Regular INIs
 	game_ini->Load(path + id + ".ini", true);

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -425,7 +425,8 @@ void SCoreStartupParameter::LoadGameIni(IniFile* game_ini, const std::string& pa
 		game_ini->Load(path + id.substr(0, 3) + ".ini", true);
 
 	// INIs that match all regions (With publisher codes)
-	game_ini->Load(path + id.substr(0, 3) + "-" + id.substr(4) + ".ini", true);
+	if (id.size() >= 5)
+		game_ini->Load(path + id.substr(0, 3) + "-" + id.substr(4) + ".ini", true);
 
 	// Regular INIs
 	game_ini->Load(path + id + ".ini", true);


### PR DESCRIPTION
Recently, #2018 was merged, introducing region free INI game settings files. For example, the ini file for Super Smash Brothers Brawl would be `RSB.ini`, instead of `RSBE01.ini`, `RSBK01.ini`, `RSBP01.ini`, and `RSBJ01.ini`.

While I love the idea of region free INI files, I don't like the idea of only using the first 3 digits of a 6 digit Game ID, disregarding publisher codes entirely. Instead, I would prefer if we only used a wild character for the region code. So instead of using `RSB.ini`, we would use `RSB-01.ini` There are a few reasons why I prefer 

* Under the 3 digit system, mods such as Project M would display the same emulation rating/issues from the base game, which may lead users into thinking we have reviewed whether these games run properly without any issues
* Showing the publisher code makes it simpler to identify which game an ini file refers to from the filename
* It's more consistent with how Dolphin displays GameIDs to the user

This PR would allow us to use a wild character for the game's region, while still including the game's publisher ID. 