### PR TITLE
Interpreter: Uncomment code related to cmp and cmpl

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Integer.cpp
@@ -220,16 +220,17 @@ void Interpreter::cmp(UGeckoInstruction _inst)
 {
 	s32 a = (s32)rGPR[_inst.RA];
 	s32 b = (s32)rGPR[_inst.RB];
-	int fTemp = 0x8; // a < b
+	int fTemp;
 
-	// if (a < b) fTemp = 0x8; else
-	if (a > b)
+	if (a < b)
+		fTemp = 0x8;
+	else if (a > b)
 		fTemp = 0x4;
-	else if (a == b)
+	else // Equals
 		fTemp = 0x2;
 
 	if (GetXER_SO())
-		PanicAlert("cmp getting overflow flag"); // fTemp |= 0x1
+		fTemp |= 0x1;
 
 	SetCRField(_inst.CRFD, fTemp);
 }
@@ -238,16 +239,17 @@ void Interpreter::cmpl(UGeckoInstruction _inst)
 {
 	u32 a = rGPR[_inst.RA];
 	u32 b = rGPR[_inst.RB];
-	u32 fTemp = 0x8; // a < b
+	u32 fTemp;
 
-	// if (a < b)  fTemp = 0x8;else
-	if (a > b)
+	if (a < b)
+		fTemp = 0x8;
+	else if (a > b)
 		fTemp = 0x4;
-	else if (a == b)
+	else // Equals
 		fTemp = 0x2;
 
 	if (GetXER_SO())
-		PanicAlert("cmpl getting overflow flag"); // fTemp |= 0x1;
+		fTemp |= 0x1;
 
 	SetCRField(_inst.CRFD, fTemp);
 }


### PR DESCRIPTION
This is actually correct. Also cmpli has this uncommented as well.