### PR TITLE
[Android] Stop eating button events we don't handle.

### DIFF
--- a/Source/Android/src/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -69,8 +69,10 @@ public final class NativeLibrary
 	 * @param Device The input descriptor of the gamepad.
 	 * @param Button Key code identifying which button was pressed.
 	 * @param Action Mask identifying which action is happing (button pressed down, or button released).
+	 *
+	 * @return If we handled the button press.
 	 */
-	public static native void onGamePadEvent(String Device, int Button, int Action);
+	public static native boolean onGamePadEvent(String Device, int Button, int Action);
 
 	/**
 	 * Handles gamepad movement events.

--- a/Source/Android/src/org/dolphinemu/dolphinemu/emulation/EmulationActivity.java
+++ b/Source/Android/src/org/dolphinemu/dolphinemu/emulation/EmulationActivity.java
@@ -285,8 +285,8 @@ public final class EmulationActivity extends Activity
 					return false;
 			}
 			InputDevice input = event.getDevice();
-			NativeLibrary.onGamePadEvent(InputConfigFragment.getInputDesc(input), event.getKeyCode(), action);
-			return true;
+			boolean handled = NativeLibrary.onGamePadEvent(InputConfigFragment.getInputDesc(input), event.getKeyCode(), action);
+			return handled;
 		}
 		return false;
 	}

--- a/Source/Core/DolphinWX/Android/ButtonManager.cpp
+++ b/Source/Core/DolphinWX/Android/ButtonManager.cpp
@@ -156,16 +156,14 @@ namespace ButtonManager
 		}
 		return value;
 	}
-	void GamepadEvent(std::string dev, int button, int action)
+	bool GamepadEvent(std::string dev, int button, int action)
 	{
 		auto it = m_controllers.find(dev);
 		if (it != m_controllers.end())
-		{
-			it->second->PressEvent(button, action);
-			return;
-		}
+			return it->second->PressEvent(button, action);
+
 		m_controllers[dev] = new InputDevice(dev);
-		m_controllers[dev]->PressEvent(button, action);
+		return m_controllers[dev]->PressEvent(button, action);
 	}
 	void GamepadAxisEvent(std::string dev, int axis, float value)
 	{
@@ -186,8 +184,9 @@ namespace ButtonManager
 	}
 
 	// InputDevice
-	void InputDevice::PressEvent(int button, int action)
+	bool InputDevice::PressEvent(int button, int action)
 	{
+		bool handled = false;
 		for (const auto& binding : _inputbinds)
 		{
 			if (binding.second->_bind == button)
@@ -196,8 +195,10 @@ namespace ButtonManager
 					_buttons[binding.second->_buttontype] = action == BUTTON_PRESSED ? true : false;
 				else
 					_axises[binding.second->_buttontype] = action == BUTTON_PRESSED ? 1.0f : 0.0f;
+				handled = true;
 			}
 		}
+		return handled;
 	}
 	void InputDevice::AxisEvent(int axis, float value)
 	{

--- a/Source/Core/DolphinWX/Android/ButtonManager.h
+++ b/Source/Core/DolphinWX/Android/ButtonManager.h
@@ -99,7 +99,7 @@ namespace ButtonManager
 			_inputbinds.clear();
 		}
 		void AddBind(sBind* bind) { _inputbinds[std::make_pair(bind->_padID, bind->_buttontype)] = bind; }
-		void PressEvent(int button, int action);
+		bool PressEvent(int button, int action);
 		void AxisEvent(int axis, float value);
 		bool ButtonValue(int padID, ButtonType button);
 		float AxisValue(int padID, ButtonType axis);
@@ -108,7 +108,7 @@ namespace ButtonManager
 	void Init();
 	bool GetButtonPressed(int padID, ButtonType button);
 	float GetAxisValue(int padID, ButtonType axis);
-	void GamepadEvent(std::string dev, int button, int action);
+	bool GamepadEvent(std::string dev, int button, int action);
 	void GamepadAxisEvent(std::string dev, int axis, float value);
 	void Shutdown();
 }

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -217,7 +217,7 @@ extern "C"
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_UnPauseEmulation(JNIEnv *env, jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_PauseEmulation(JNIEnv *env, jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulation(JNIEnv *env, jobject obj);
-JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadEvent(JNIEnv *env, jobject obj, jstring jDevice, jint Button, jint Action);
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadEvent(JNIEnv *env, jobject obj, jstring jDevice, jint Button, jint Action);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadMoveEvent(JNIEnv *env, jobject obj, jstring jDevice, jint Axis, jfloat Value);
 JNIEXPORT jintArray JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetBanner(JNIEnv *env, jobject obj, jstring jFile);
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetTitle(JNIEnv *env, jobject obj, jstring jFile);
@@ -247,9 +247,9 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulatio
 	Core::Stop();
 	updateMainFrameEvent.Set(); // Kick the waiting event
 }
-JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadEvent(JNIEnv *env, jobject obj, jstring jDevice, jint Button, jint Action)
+JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadEvent(JNIEnv *env, jobject obj, jstring jDevice, jint Button, jint Action)
 {
-	ButtonManager::GamepadEvent(GetJString(env, jDevice), Button, Action);
+	return ButtonManager::GamepadEvent(GetJString(env, jDevice), Button, Action);
 }
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadMoveEvent(JNIEnv *env, jobject obj, jstring jDevice, jint Axis, jfloat Value)
 {


### PR DESCRIPTION
We were eating /all/ button events except the back button. This would cause issues where Android wouldn't receive button press events for things like
volume rockers. So you couldn't change the audio ingame, even if that button isn't bound to an input.

Now we return to Android if we've handled that button press, so it works fine.