### PR TITLE
Basic volume code cleanup

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -307,10 +307,10 @@ bool CBoot::EmulatedBS2_Wii()
 	INFO_LOG(BOOT, "Faking Wii BS2...");
 
 	// setup Wii memory
-	DiscIO::IVolume::ECountry CountryCode = DiscIO::IVolume::COUNTRY_UNKNOWN;
+	DiscIO::IVolume::ECountry country_code = DiscIO::IVolume::COUNTRY_UNKNOWN;
 	if (VolumeHandler::IsValid())
-		CountryCode = VolumeHandler::GetVolume()->GetCountry();
-	if (SetupWiiMemory(CountryCode) == false)
+		country_code = VolumeHandler::GetVolume()->GetCountry();
+	if (SetupWiiMemory(country_code) == false)
 		return false;
 
 	// This is some kind of consistency check that is compared to the 0x00

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -136,7 +136,7 @@ CEXIMemoryCard::CEXIMemoryCard(const int index, bool gciFolder)
 
 void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 {
-	DiscIO::IVolume::ECountry CountryCode = DiscIO::IVolume::COUNTRY_UNKNOWN;
+	DiscIO::IVolume::ECountry country_code = DiscIO::IVolume::COUNTRY_UNKNOWN;
 	auto strUniqueID = SConfig::GetInstance().m_LocalCoreStartupParameter.m_strUniqueID;
 
 	u32 CurrentGameId = 0;
@@ -145,17 +145,17 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 		const DiscIO::INANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, false);
 		if (SysMenu_Loader.IsValid())
 		{
-			CountryCode = DiscIO::CountrySwitch(SysMenu_Loader.GetCountryChar());
+			country_code = DiscIO::CountrySwitch(SysMenu_Loader.GetCountryChar());
 		}
 	}
 	else if (strUniqueID.length() >= 4)
 	{
-		CountryCode = DiscIO::CountrySwitch(strUniqueID.at(3));
+		country_code = DiscIO::CountrySwitch(strUniqueID.at(3));
 		CurrentGameId = BE32((u8*)strUniqueID.c_str());
 	}
 	bool ascii = true;
 	std::string strDirectoryName = File::GetUserPath(D_GCUSER_IDX);
-	switch (CountryCode)
+	switch (country_code)
 	{
 	case DiscIO::IVolume::COUNTRY_JAPAN:
 		ascii = false;
@@ -182,20 +182,20 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 		std::string region = memcardFilename.substr(memcardFilename.size() - 7, 3);
 		if (region == JAP_DIR)
 		{
-			CountryCode = DiscIO::IVolume::COUNTRY_JAPAN;
+			country_code = DiscIO::IVolume::COUNTRY_JAPAN;
 			ascii = false;
 			strDirectoryName += JAP_DIR DIR_SEP;
 			break;
 		}
 		else if (region == USA_DIR)
 		{
-			CountryCode = DiscIO::IVolume::COUNTRY_USA;
+			country_code = DiscIO::IVolume::COUNTRY_USA;
 			strDirectoryName += USA_DIR DIR_SEP;
 			break;
 		}
 	}
 	default:
-		CountryCode = DiscIO::IVolume::COUNTRY_EUROPE;
+		country_code = DiscIO::IVolume::COUNTRY_EUROPE;
 		strDirectoryName += EUR_DIR DIR_SEP;
 	}
 	strDirectoryName += StringFromFormat("Card %c", 'A' + card_index);
@@ -222,7 +222,7 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 	}
 
 	memorycard = std::make_unique<GCMemcardDirectory>(strDirectoryName + DIR_SEP, card_index, sizeMb, ascii,
-													  CountryCode, CurrentGameId);
+													  country_code, CurrentGameId);
 }
 
 void CEXIMemoryCard::SetupRawMemcard(u16 sizeMb)

--- a/Source/Core/DiscIO/CISOBlob.cpp
+++ b/Source/Core/DiscIO/CISOBlob.cpp
@@ -77,8 +77,8 @@ bool CISOFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 		}
 
 		out_ptr += bytes_to_read;
-		offset += bytes_to_read;
-		nbytes -= bytes_to_read;
+		offset  += bytes_to_read;
+		nbytes  -= bytes_to_read;
 	}
 
 	return true;

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -240,14 +240,14 @@ bool CNANDContentLoader::Initialize(const std::string& _rName)
 	m_Content.resize(m_numEntries);
 
 
-	for (u32 i=0; i<m_numEntries; i++)
+	for (u32 i=0; i < m_numEntries; i++)
 	{
 		SNANDContent& rContent = m_Content[i];
 
 		rContent.m_ContentID = Common::swap32(pTMD + 0x01e4 + 0x24*i);
 		rContent.m_Index = Common::swap16(pTMD + 0x01e8 + 0x24*i);
 		rContent.m_Type = Common::swap16(pTMD + 0x01ea + 0x24*i);
-		rContent.m_Size= (u32)Common::swap64(pTMD + 0x01ec + 0x24*i);
+		rContent.m_Size = (u32)Common::swap64(pTMD + 0x01ec + 0x24*i);
 		memcpy(rContent.m_SHA1Hash, pTMD + 0x01f4 + 0x24*i, 20);
 		memcpy(rContent.m_Header, pTMD + 0x01e4 + 0x24*i, 36);
 
@@ -271,7 +271,7 @@ bool CNANDContentLoader::Initialize(const std::string& _rName)
 		else
 			rContent.m_Filename = StringFromFormat("%s/%08x.app", m_Path.c_str(), rContent.m_ContentID);
 
-		// Be graceful about incorrect tmds.
+		// Be graceful about incorrect TMDs.
 		if (File::Exists(rContent.m_Filename))
 			rContent.m_Size = (u32) File::GetSize(rContent.m_Filename);
 	}
@@ -355,7 +355,7 @@ void CNANDContentLoader::RemoveTitle() const
 	INFO_LOG(DISCIO, "RemoveTitle %08x/%08x", (u32)(m_TitleID >> 32), (u32)m_TitleID);
 	if (IsValid())
 	{
-		// remove tmd?
+		// remove TMD?
 		for (u32 i = 0; i < m_numEntries; i++)
 		{
 			if (!(m_Content[i].m_Type & 0x8000)) // skip shared apps
@@ -455,7 +455,7 @@ u64 CNANDContentManager::Install_WiiWAD(std::string &fileName)
 
 	u64 TitleID = ContentLoader.GetTitleID();
 
-	//copy WAD's tmd header and contents to content directory
+	//copy WAD's TMD header and contents to content directory
 
 	std::string ContentPath(Common::GetTitleContentPath(TitleID));
 	std::string TMDFileName(Common::GetTMDFileName(TitleID));

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -35,12 +35,12 @@ public:
 	virtual std::vector<std::string> GetNames() const = 0;
 	virtual u32 GetFSTSize() const = 0;
 	virtual std::string GetApploaderDate() const = 0;
+
 	virtual bool IsDiscTwo() const { return false; }
 	virtual bool IsWiiDisc() const { return false; }
 	virtual bool IsWadFile() const { return false; }
 	virtual bool SupportsIntegrityCheck() const { return false; }
 	virtual bool CheckIntegrity() const { return false; }
-
 	virtual bool ChangePartition(u64 offset) { return false; }
 
 	// Increment CACHE_REVISION if the code below is modified (ISOFile.cpp & GameFile.cpp)

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -71,7 +71,7 @@ public:
 };
 
 // Generic Switch function for all volumes
-IVolume::ECountry CountrySwitch(u8 CountryCode);
+IVolume::ECountry CountrySwitch(u8 country_code);
 u8 GetSysMenuRegion(u16 _TitleVersion);
 
 } // namespace

--- a/Source/Core/DiscIO/VolumeCommon.cpp
+++ b/Source/Core/DiscIO/VolumeCommon.cpp
@@ -12,9 +12,9 @@
 // Increment CACHE_REVISION if the code below is modified (ISOFile.cpp & GameFile.cpp)
 namespace DiscIO
 {
-IVolume::ECountry CountrySwitch(u8 CountryCode)
+IVolume::ECountry CountrySwitch(u8 country_code)
 {
-	switch (CountryCode)
+	switch (country_code)
 	{
 		// Region free - Uses European flag as placeholder
 		case 'A':
@@ -68,8 +68,8 @@ IVolume::ECountry CountrySwitch(u8 CountryCode)
 			return IVolume::COUNTRY_TAIWAN;
 
 		default:
-			if (CountryCode > 'A') // Silently ignore IOS wads
-				WARN_LOG(DISCIO, "Unknown Country Code! %c", CountryCode);
+			if (country_code > 'A') // Silently ignore IOS wads
+				WARN_LOG(DISCIO, "Unknown Country Code! %c", country_code);
 			return IVolume::COUNTRY_UNKNOWN;
 	}
 }

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -174,9 +174,9 @@ void CVolumeDirectory::SetUniqueID(const std::string& id)
 
 IVolume::ECountry CVolumeDirectory::GetCountry() const
 {
-	u8 CountryCode = m_diskHeader[3];
+	u8 country_code = m_diskHeader[3];
 
-	return CountrySwitch(CountryCode);
+	return CountrySwitch(country_code);
 }
 
 std::string CVolumeDirectory::GetMakerID() const

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -140,9 +140,9 @@ bool CVolumeDirectory::Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt
 			if (!reader->Read(fileOffset, fileBytes, _pBuffer))
 				return false;
 
-			_Length -= fileBytes;
+			_Length  -= fileBytes;
 			_pBuffer += fileBytes;
-			_Offset += fileBytes;
+			_Offset  += fileBytes;
 		}
 
 		++fileIter;

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -108,7 +108,7 @@ private:
 		u32 debug_flag;
 		u32 track_location;
 		u32 track_size;
-		u32 countrycode;
+		u32 country_code;
 		u32 unknown;
 		u32 unknown2;
 
@@ -121,7 +121,7 @@ private:
 			debug_flag = 0;
 			track_location = 0;
 			track_size = 0;
-			countrycode = 0;
+			country_code = 0;
 			unknown = 0;
 			unknown2 = 0;
 		}

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -61,10 +61,10 @@ IVolume::ECountry CVolumeGC::GetCountry() const
 	if (!m_pReader)
 		return COUNTRY_UNKNOWN;
 
-	u8 CountryCode;
-	m_pReader->Read(3, 1, &CountryCode);
+	u8 country_code;
+	m_pReader->Read(3, 1, &country_code);
 
-	return CountrySwitch(CountryCode);
+	return CountrySwitch(country_code);
 }
 
 std::string CVolumeGC::GetMakerID() const

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -149,9 +149,9 @@ u64 CVolumeGC::GetRawSize() const
 
 bool CVolumeGC::IsDiscTwo() const
 {
-	bool discTwo = false;
-	Read(6,1, (u8*) &discTwo);
-	return discTwo;
+	u8 disc_two_check;
+	Read(6, 1, &disc_two_check);
+	return (disc_two_check == 1);
 }
 
 CVolumeGC::StringDecoder CVolumeGC::GetStringDecoder(ECountry country)

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -30,10 +30,12 @@ public:
 	std::vector<std::string> GetNames() const override;
 	u32 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;
+
+	bool IsDiscTwo() const override;
+
 	ECountry GetCountry() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
-	bool IsDiscTwo() const override;
 
 	typedef std::string(*StringDecoder)(const std::string&);
 

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -54,17 +54,17 @@ IVolume::ECountry CVolumeWAD::GetCountry() const
 		return COUNTRY_UNKNOWN;
 
 	// read the last digit of the titleID in the ticket
-	u8 CountryCode;
-	Read(m_tmd_offset + 0x0193, 1, &CountryCode);
+	u8 country_code;
+	Read(m_tmd_offset + 0x0193, 1, &country_code);
 
-	if (CountryCode == 2) // SYSMENU
+	if (country_code == 2) // SYSMENU
 	{
 		u16 titlever = 0;
 		Read(m_tmd_offset + 0x01dc, 2, (u8*)&titlever);
-		CountryCode = GetSysMenuRegion(Common::swap16(titlever));
+		country_code = GetSysMenuRegion(Common::swap16(titlever));
 	}
 
-	return CountrySwitch(CountryCode);
+	return CountrySwitch(country_code);
 }
 
 std::string CVolumeWAD::GetUniqueID() const

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -19,8 +19,8 @@
 namespace DiscIO
 {
 CVolumeWAD::CVolumeWAD(IBlobReader* _pReader)
-	: m_pReader(_pReader), m_opening_bnr_offset(0), m_hdr_size(0)
-	, m_cert_size(0), m_tick_size(0), m_tmd_size(0), m_data_size(0)
+	: m_pReader(_pReader), m_offset(0), m_tmd_offset(0), m_opening_bnr_offset(0),
+	m_hdr_size(0), m_cert_size(0), m_tick_size(0), m_tmd_size(0), m_data_size(0)
 {
 	Read(0x00, 4, (u8*)&m_hdr_size);
 	Read(0x08, 4, (u8*)&m_cert_size);
@@ -28,14 +28,16 @@ CVolumeWAD::CVolumeWAD(IBlobReader* _pReader)
 	Read(0x14, 4, (u8*)&m_tmd_size);
 	Read(0x18, 4, (u8*)&m_data_size);
 
-	u32 TmdOffset = ALIGN_40(m_hdr_size) + ALIGN_40(m_cert_size) + ALIGN_40(m_tick_size);
-	m_opening_bnr_offset = TmdOffset + ALIGN_40(m_tmd_size) + ALIGN_40(m_data_size);
+	m_offset = ALIGN_40(m_hdr_size) + ALIGN_40(m_cert_size);
+	m_tmd_offset = ALIGN_40(m_hdr_size) + ALIGN_40(m_cert_size) + ALIGN_40(m_tick_size);
+	m_opening_bnr_offset = m_tmd_offset + ALIGN_40(m_tmd_size) + ALIGN_40(m_data_size);
+
 	// read the last digit of the titleID in the ticket
-	Read(TmdOffset + 0x0193, 1, &m_Country);
+	Read(m_tmd_offset + 0x0193, 1, &m_Country);
 	if (m_Country == 2) // SYSMENU
 	{
 		u16 titlever = 0;
-		Read(TmdOffset + 0x01dc, 2, (u8*)&titlever);
+		Read(m_tmd_offset + 0x01dc, 2, (u8*)&titlever);
 		m_Country = GetSysMenuRegion(Common::swap16(titlever));
 	}
 }
@@ -66,10 +68,9 @@ IVolume::ECountry CVolumeWAD::GetCountry() const
 std::string CVolumeWAD::GetUniqueID() const
 {
 	std::string temp = GetMakerID();
-	u32 Offset = ALIGN_40(m_hdr_size) + ALIGN_40(m_cert_size);
 
 	char GameCode[8];
-	if (!Read(Offset + 0x01E0, 4, (u8*)GameCode))
+	if (!Read(m_offset + 0x01E0, 4, (u8*)GameCode))
 		return "0";
 
 	GameCode[4] = temp.at(0);
@@ -81,11 +82,9 @@ std::string CVolumeWAD::GetUniqueID() const
 
 std::string CVolumeWAD::GetMakerID() const
 {
-	u32 Offset = ALIGN_40(m_hdr_size) + ALIGN_40(m_cert_size) + ALIGN_40(m_tick_size);
-
 	char temp[3] = {1};
 	// Some weird channels use 0x0000 in place of the MakerID, so we need a check there
-	if (!Read(0x198 + Offset, 2, (u8*)temp) || temp[0] == 0 || temp[1] == 0)
+	if (!Read(0x198 + m_tmd_offset, 2, (u8*)temp) || temp[0] == 0 || temp[1] == 0)
 		return "00";
 
 	temp[2] = 0;
@@ -95,9 +94,7 @@ std::string CVolumeWAD::GetMakerID() const
 
 bool CVolumeWAD::GetTitleID(u8* _pBuffer) const
 {
-	u32 Offset = ALIGN_40(m_hdr_size) + ALIGN_40(m_cert_size);
-
-	if (!Read(Offset + 0x01DC, 8, _pBuffer))
+	if (!Read(m_offset + 0x01DC, 8, _pBuffer))
 		return false;
 
 	return true;
@@ -105,10 +102,8 @@ bool CVolumeWAD::GetTitleID(u8* _pBuffer) const
 
 int CVolumeWAD::GetRevision() const
 {
-	u32 TmdOffset = ALIGN_40(m_hdr_size) + ALIGN_40(m_cert_size) + ALIGN_40(m_tick_size);
-
 	u16 revision;
-	if (!m_pReader->Read(TmdOffset + 0x1dc, 2, (u8*)&revision))
+	if (!m_pReader->Read(m_tmd_offset + 0x1dc, 2, (u8*)&revision))
 		return 0;
 
 	return Common::swap16(revision);

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -60,9 +60,9 @@ IVolume::ECountry CVolumeWAD::GetCountry() const
 
 	if (country_code == 2) // SYSMENU
 	{
-		u16 titlever = 0;
-		Read(m_tmd_offset + 0x01dc, 2, (u8*)&titlever);
-		country_code = GetSysMenuRegion(Common::swap16(titlever));
+		u16 title_version = 0;
+		Read(m_tmd_offset + 0x01dc, 2, (u8*)&title_version);
+		country_code = GetSysMenuRegion(Common::swap16(title_version));
 	}
 
 	return CountrySwitch(country_code);

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -22,6 +22,7 @@ CVolumeWAD::CVolumeWAD(IBlobReader* _pReader)
 	: m_pReader(_pReader), m_offset(0), m_tmd_offset(0), m_opening_bnr_offset(0),
 	m_hdr_size(0), m_cert_size(0), m_tick_size(0), m_tmd_size(0), m_data_size(0)
 {
+	// Source: http://wiibrew.org/wiki/WAD_files
 	Read(0x00, 4, (u8*)&m_hdr_size);
 	Read(0x08, 4, (u8*)&m_cert_size);
 	Read(0x10, 4, (u8*)&m_tick_size);

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -31,15 +31,6 @@ CVolumeWAD::CVolumeWAD(IBlobReader* _pReader)
 	m_offset = ALIGN_40(m_hdr_size) + ALIGN_40(m_cert_size);
 	m_tmd_offset = ALIGN_40(m_hdr_size) + ALIGN_40(m_cert_size) + ALIGN_40(m_tick_size);
 	m_opening_bnr_offset = m_tmd_offset + ALIGN_40(m_tmd_size) + ALIGN_40(m_data_size);
-
-	// read the last digit of the titleID in the ticket
-	Read(m_tmd_offset + 0x0193, 1, &m_Country);
-	if (m_Country == 2) // SYSMENU
-	{
-		u16 titlever = 0;
-		Read(m_tmd_offset + 0x01dc, 2, (u8*)&titlever);
-		m_Country = GetSysMenuRegion(Common::swap16(titlever));
-	}
 }
 
 CVolumeWAD::~CVolumeWAD()
@@ -62,7 +53,18 @@ IVolume::ECountry CVolumeWAD::GetCountry() const
 	if (!m_pReader)
 		return COUNTRY_UNKNOWN;
 
-	return CountrySwitch(m_Country);
+	// read the last digit of the titleID in the ticket
+	u8 CountryCode;
+	Read(m_tmd_offset + 0x0193, 1, &CountryCode);
+
+	if (CountryCode == 2) // SYSMENU
+	{
+		u16 titlever = 0;
+		Read(m_tmd_offset + 0x01dc, 2, (u8*)&titlever);
+		CountryCode = GetSysMenuRegion(Common::swap16(titlever));
+	}
+
+	return CountrySwitch(CountryCode);
 }
 
 std::string CVolumeWAD::GetUniqueID() const

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -48,7 +48,6 @@ private:
 	u32 m_tick_size;
 	u32 m_tmd_size;
 	u32 m_data_size;
-	u8 m_Country;
 };
 
 } // namespace

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -40,6 +40,8 @@ public:
 
 private:
 	std::unique_ptr<IBlobReader> m_pReader;
+	u32 m_offset;
+	u32 m_tmd_offset;
 	u32 m_opening_bnr_offset;
 	u32 m_hdr_size;
 	u32 m_cert_size;

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -29,14 +29,16 @@ public:
 	bool GetTitleID(u8* _pBuffer) const override;
 	std::string GetUniqueID() const override;
 	std::string GetMakerID() const override;
+	int GetRevision() const override;
 	std::vector<std::string> GetNames() const override;
 	u32 GetFSTSize() const override               { return 0; }
 	std::string GetApploaderDate() const override { return "0"; }
+
 	bool IsWadFile() const override;
+
 	ECountry GetCountry() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
-	int GetRevision() const override;
 
 private:
 	std::unique_ptr<IBlobReader> m_pReader;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -158,10 +158,10 @@ IVolume::ECountry CVolumeWiiCrypted::GetCountry() const
 	if (!m_pReader)
 		return COUNTRY_UNKNOWN;
 
-	u8 CountryCode;
-	m_pReader->Read(3, 1, &CountryCode);
+	u8 country_code;
+	m_pReader->Read(3, 1, &country_code);
 
-	return CountrySwitch(CountryCode);
+	return CountrySwitch(country_code);
 }
 
 std::string CVolumeWiiCrypted::GetMakerID() const

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -237,6 +237,14 @@ bool CVolumeWiiCrypted::IsWiiDisc() const
 	return true;
 }
 
+bool CVolumeWiiCrypted::IsDiscTwo() const
+{
+	bool discTwo = false;
+	m_pReader->Read(6, 1, (u8*)&discTwo);
+	return discTwo;
+}
+
+
 u64 CVolumeWiiCrypted::GetSize() const
 {
 	if (m_pReader)

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -239,9 +239,9 @@ bool CVolumeWiiCrypted::IsWiiDisc() const
 
 bool CVolumeWiiCrypted::IsDiscTwo() const
 {
-	bool discTwo = false;
-	m_pReader->Read(6, 1, (u8*)&discTwo);
-	return discTwo;
+	u8 disc_two_check;
+	m_pReader->Read(6, 1, &disc_two_check);
+	return (disc_two_check == 1);
 }
 
 

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -95,7 +95,7 @@ bool CVolumeWiiCrypted::Read(u64 _ReadOffset, u64 _Length, u8* _pBuffer, bool de
 		memcpy(_pBuffer, &m_LastDecryptedBlock[Offset], (size_t)CopySize);
 
 		// Update offsets
-		_Length -= CopySize;
+		_Length     -= CopySize;
 		_pBuffer    += CopySize;
 		_ReadOffset += CopySize;
 	}

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -29,19 +29,21 @@ public:
 	virtual std::unique_ptr<u8[]> GetTMD(u32 *_sz) const override;
 	std::string GetUniqueID() const override;
 	std::string GetMakerID() const override;
+	int GetRevision() const override;
 	std::vector<std::string> GetNames() const override;
 	u32 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;
+
 	bool IsWiiDisc() const override;
+	bool SupportsIntegrityCheck() const override { return true; }
+	bool CheckIntegrity() const override;
+	bool ChangePartition(u64 offset) override;
+
 	ECountry GetCountry() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
-	int GetRevision() const override;
 
-	bool SupportsIntegrityCheck() const override { return true; }
-	bool CheckIntegrity() const override;
 
-	bool ChangePartition(u64 offset) override;
 
 private:
 	static const unsigned int s_block_header_size = 0x0400;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -34,6 +34,7 @@ public:
 	u32 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;
 
+	bool IsDiscTwo() const override;
 	bool IsWiiDisc() const override;
 	bool SupportsIntegrityCheck() const override { return true; }
 	bool CheckIntegrity() const override;

--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -1333,37 +1333,37 @@ void CConfigMain::OnConfig(wxCommandEvent&)
 inline u8 CConfigMain::GetSADRCountryCode(int language)
 {
 	//http://wiibrew.org/wiki/Country_Codes
-	u8 countrycode = language;
-	switch (countrycode)
+	u8 country_code = language;
+	switch (country_code)
 	{
 	case 0: //Japanese
-		countrycode = 1; //Japan
+		country_code = 1; //Japan
 		break;
 	case 1: //English
-		countrycode = 49; //USA
+		country_code = 49; //USA
 		break;
 	case 2: //German
-		countrycode = 78; //Germany
+		country_code = 78; //Germany
 		break;
 	case 3: //French
-		countrycode = 77; //France
+		country_code = 77; //France
 		break;
 	case 4: //Spanish
-		countrycode = 105; //Spain
+		country_code = 105; //Spain
 		break;
 	case 5: //Italian
-		countrycode = 83; //Italy
+		country_code = 83; //Italy
 		break;
 	case 6: //Dutch
-		countrycode = 94; //Netherlands
+		country_code = 94; //Netherlands
 		break;
 	case 7: //Simplified Chinese
 	case 8: //Traditional Chinese
-		countrycode = 157; //China
+		country_code = 157; //China
 		break;
 	case 9: //Korean
-		countrycode = 136; //Korea
+		country_code = 136; //Korea
 		break;
 	}
-	return countrycode;
+	return country_code;
 }


### PR DESCRIPTION
I noticed that our game volume code was a bit messy, with a great deal of redundancy and duplicate code. This PR will restructure the code, while still keeping it functionally the same.

Edit: Having a bit of scope-creep on this PR, encompassing more than just the DiscIO code. I think this should be merged as is, with the rest of my work coming in a separate PR.