### PR TITLE
Fix a typo in the Android cmake toolchain script.

### DIFF
--- a/Source/Android/android.toolchain.cmake
+++ b/Source/Android/android.toolchain.cmake
@@ -1487,7 +1487,7 @@ endif()
 # setup output directories
 set( CMAKE_INSTALL_PREFIX "${ANDROID_TOOLCHAIN_ROOT}/user" CACHE STRING "path for installing" )
 
-if( DEFINED LIBRARY_OUTPUT_PATH_ROOT
+if( NOT DEFINED LIBRARY_OUTPUT_PATH_ROOT
       OR EXISTS "${CMAKE_SOURCE_DIR}/AndroidManifest.xml"
       OR (EXISTS "${CMAKE_SOURCE_DIR}/../AndroidManifest.xml" AND EXISTS "${CMAKE_SOURCE_DIR}/../jni/") )
   set( LIBRARY_OUTPUT_PATH_ROOT ${CMAKE_SOURCE_DIR} CACHE PATH "Root for binaries output, set this to change where Android libs are installed to" )


### PR DESCRIPTION
This was a fairly recent update that went unnoticed because it uses a cached variable.
When I previously updated Android cmake I didn't noticed this.
Basically the issue was that Android cmake was no longer setting ${LIBRARY_OUTPUT_PATH_ROOT}
and instead only setting it to ${CMAKE_SOURCE_DIR} if it was passed a variable.

Same PR is open on the android cmake repo here https://github.com/taka-no-me/android-cmake/pull/37