### PR TITLE
Fix a crash with fastmem disabled.

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -337,7 +337,8 @@ static void CpuThread()
 	if (!_CoreParameter.bCPUThread)
 		g_video_backend->Video_Cleanup();
 
-	EMM::UninstallExceptionHandler();
+	if (_CoreParameter.bFastmem)
+		EMM::UninstallExceptionHandler();
 
 	return;
 }


### PR DESCRIPTION
When the core is busy shutting down only uninstall the exception handler if fastmem is actually enabled.
We only install when fastmem is enabled, so only uninstall when it is as well.

Fixes a crash I was getting on ARMv7.