### PR TITLE
DolphinWX: Remove unnecessary control IDs

### DIFF
--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
@@ -89,7 +89,7 @@ DSPDebuggerLLE::DSPDebuggerLLE(wxWindow* parent, wxWindowID id)
 	mem_panel->SetSizer(mem_sizer);
 	m_MainNotebook->AddPage(mem_panel, _("Memory"));
 
-	m_Regs = new DSPRegisterView(this, ID_DSP_REGS);
+	m_Regs = new DSPRegisterView(this);
 
 	// add the panes to the manager
 	m_mgr.AddPane(m_Toolbar, wxAuiPaneInfo().

--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.h
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.h
@@ -36,7 +36,6 @@ private:
 		ID_RUNTOOL,
 		ID_STEPTOOL,
 		ID_SHOWPCTOOL,
-		ID_DSP_REGS
 	};
 
 	DSPDebugInterface debug_interface;

--- a/Source/Core/DolphinWX/Debugger/DSPRegisterView.h
+++ b/Source/Core/DolphinWX/Debugger/DSPRegisterView.h
@@ -42,6 +42,6 @@ public:
 class DSPRegisterView : public wxGrid
 {
 public:
-	DSPRegisterView(wxWindow* parent, wxWindowID id);
+	DSPRegisterView(wxWindow* parent, wxWindowID id = wxID_ANY);
 	void Update() override;
 };

--- a/Source/Core/DolphinWX/Debugger/RegisterView.h
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.h
@@ -69,7 +69,7 @@ private:
 class CRegisterView : public wxGrid
 {
 public:
-	CRegisterView(wxWindow* parent, wxWindowID id);
+	CRegisterView(wxWindow* parent, wxWindowID id = wxID_ANY);
 	void Update() override;
 	void OnMouseDownR(wxGridEvent& event);
 	void OnPopupMenu(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Debugger/RegisterWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterWindow.cpp
@@ -27,7 +27,7 @@ CRegisterWindow::CRegisterWindow(wxWindow* parent, wxWindowID id,
 void CRegisterWindow::CreateGUIControls()
 {
 	wxBoxSizer *sGrid = new wxBoxSizer(wxVERTICAL);
-	m_GPRGridView = new CRegisterView(this, ID_GPR);
+	m_GPRGridView = new CRegisterView(this);
 	sGrid->Add(m_GPRGridView, 1, wxGROW);
 	SetSizer(sGrid);
 

--- a/Source/Core/DolphinWX/Debugger/RegisterWindow.h
+++ b/Source/Core/DolphinWX/Debugger/RegisterWindow.h
@@ -28,11 +28,6 @@ public:
 	void NotifyUpdate();
 
 private:
-	enum
-	{
-		ID_GPR = 1002
-	};
-
 	CRegisterView* m_GPRGridView;
 	void CreateGUIControls();
 };

--- a/Source/Core/DolphinWX/Debugger/WatchView.h
+++ b/Source/Core/DolphinWX/Debugger/WatchView.h
@@ -44,7 +44,7 @@ private:
 class CWatchView : public wxGrid
 {
 public:
-	CWatchView(wxWindow* parent, wxWindowID id);
+	CWatchView(wxWindow* parent, wxWindowID id = wxID_ANY);
 	void Update() override;
 	void OnMouseDownR(wxGridEvent& event);
 	void OnPopupMenu(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Debugger/WatchWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchWindow.cpp
@@ -71,7 +71,7 @@ CWatchWindow::CWatchWindow(wxWindow* parent, wxWindowID id,
 	m_mgr.SetFlags(wxAUI_MGR_DEFAULT | wxAUI_MGR_LIVE_RESIZE);
 
 	wxBoxSizer *sGrid = new wxBoxSizer(wxVERTICAL);
-	m_GPRGridView = new CWatchView(this, ID_GPR);
+	m_GPRGridView = new CWatchView(this);
 	sGrid->Add(m_GPRGridView, 1, wxGROW);
 	SetSizer(sGrid);
 

--- a/Source/Core/DolphinWX/Debugger/WatchWindow.h
+++ b/Source/Core/DolphinWX/Debugger/WatchWindow.h
@@ -36,11 +36,6 @@ public:
 private:
 	wxAuiManager m_mgr;
 
-	enum
-	{
-		ID_GPR = 1002
-	};
-
 	CWatchView* m_GPRGridView;
 	void CreateGUIControls();
 };


### PR DESCRIPTION
These don't need to be specifically identified, since no events are directly sent to them. Technically the regular register grid and watch grid would clash if events were sent with the ID of ID_GPR, because it wasn't changed for the watch grid when it was implemented.