### PR TITLE
Actually compile SSSE3 intrinsics on GCC and Clang

### DIFF
--- a/Source/Core/Common/Intrinsics.h
+++ b/Source/Core/Common/Intrinsics.h
@@ -16,7 +16,7 @@
 #define __GNUC_PREREQ(maj, min) 0
 #endif
 
-#if defined __GNUC__ && !__GNUC_PREREQ(4, 9) && !defined __SSSE3__
+#if defined __GNUC__ && !defined __clang__ && !__GNUC_PREREQ(4, 9) && !defined __SSSE3__
 // GCC <= 4.8 only enables intrinsics based on the command-line.
 // GCC >= 4.9 always declares all intrinsics.
 // We only want to require SSE2 and thus compile with -msse2,

--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -266,7 +266,7 @@ static const u8* gdsp_idma_out(u16 dsp_addr, u32 addr, u32 size)
 	return nullptr;
 }
 
-#if _M_SSE >= 0x301
+#if _M_X86
 static const __m128i s_mask = _mm_set_epi32(0x0E0F0C0DL, 0x0A0B0809L, 0x06070405L, 0x02030001L);
 #endif
 
@@ -275,7 +275,7 @@ static const u8* gdsp_ddma_in(u16 dsp_addr, u32 addr, u32 size)
 {
 	u8* dst = ((u8*)g_dsp.dram);
 
-#if _M_SSE >= 0x301
+#if _M_X86
 	if (cpu_info.bSSSE3 && !(size % 16))
 	{
 		for (u32 i = 0; i < size; i += 16)
@@ -300,7 +300,7 @@ static const u8* gdsp_ddma_out(u16 dsp_addr, u32 addr, u32 size)
 {
 	const u8* src = ((const u8*)g_dsp.dram);
 
-#if _M_SSE >= 0x301
+#if _M_X86
 	if (cpu_info.bSSSE3 && !(size % 16))
 	{
 		for (u32 i = 0; i < size; i += 16)

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -265,7 +265,7 @@ void _TexDecoder_DecodeImpl(u32 * dst, const u8 * src, int width, int height, in
 		{
 			const __m128i kMask_x0f = _mm_set1_epi32(0x0f0f0f0fL);
 			const __m128i kMask_xf0 = _mm_set1_epi32(0xf0f0f0f0L);
-#if _M_SSE >= 0x301
+#if _M_X86
 			// xsacha optimized with SSSE3 intrinsics
 			// Produces a ~40% speed improvement over SSE2 implementation
 			if (cpu_info.bSSSE3)
@@ -375,7 +375,7 @@ void _TexDecoder_DecodeImpl(u32 * dst, const u8 * src, int width, int height, in
 		break;
 	case GX_TF_I8:  // speed critical
 		{
-#if _M_SSE >= 0x301
+#if _M_X86
 			// xsacha optimized with SSSE3 intrinsics
 			// Produces a ~10% speed improvement over SSE2 implementation
 			if (cpu_info.bSSSE3)
@@ -522,7 +522,7 @@ void _TexDecoder_DecodeImpl(u32 * dst, const u8 * src, int width, int height, in
 		break;
 	case GX_TF_IA8:
 		{
-#if _M_SSE >= 0x301
+#if _M_X86
 			// xsacha optimized with SSSE3 intrinsics.
 			// Produces an ~50% speed improvement over SSE2 implementation.
 			if (cpu_info.bSSSE3)
@@ -696,7 +696,7 @@ void _TexDecoder_DecodeImpl(u32 * dst, const u8 * src, int width, int height, in
 			// for the RGB555 case when (s[x] & 0x8000) is true for all pixels.
 			const __m128i aVxff00   = _mm_set1_epi32(0xFF000000L);
 
-#if _M_SSE >= 0x301
+#if _M_X86
 			// xsacha optimized with SSSE3 intrinsics (2 in 4 cases)
 			// Produces a ~10% speed improvement over SSE2 implementation
 			if (cpu_info.bSSSE3)
@@ -901,7 +901,7 @@ void _TexDecoder_DecodeImpl(u32 * dst, const u8 * src, int width, int height, in
 		break;
 	case GX_TF_RGBA8:  // speed critical
 		{
-#if _M_SSE >= 0x301
+#if _M_X86
 			// xsacha optimized with SSSE3 instrinsics
 			// Produces a ~30% speed improvement over SSE2 implementation
 			if (cpu_info.bSSSE3)


### PR DESCRIPTION
Should give a little speedup on non-Windows platforms.