### PR TITLE
Intrinsics: drop custom _mm_shuffle_epi8()

### DIFF
--- a/Source/Core/Common/Intrinsics.h
+++ b/Source/Core/Common/Intrinsics.h
@@ -12,26 +12,6 @@
 #include <x86intrin.h>
 #endif
 
-#ifndef __GNUC_PREREQ
-#define __GNUC_PREREQ(maj, min) 0
-#endif
-
-#if defined __GNUC__ && !__GNUC_PREREQ(4, 9) && !defined __SSSE3__
-// GCC <= 4.8 only enables intrinsics based on the command-line.
-// GCC >= 4.9 always declares all intrinsics.
-// We only want to require SSE2 and thus compile with -msse2,
-// so define the one post-SSE2 intrinsic that we dispatch at runtime.
-static __inline __m128i __attribute__((__gnu_inline__, __always_inline__, __artificial__))
-_mm_shuffle_epi8(__m128i a, __m128i mask)
-{
-	__m128i result;
-	__asm__("pshufb %1, %0"
-		: "=x" (result)
-		: "xm" (mask), "0" (a));
-	return result;
-}
-#endif
-
 #if defined _M_GENERIC
 #  define _M_SSE 0
 #elif _MSC_VER || __INTEL_COMPILER


### PR DESCRIPTION
We never actually use it because it's only defined (correctly so) when `__SSSE3__` is not defined. When that's the case, `_M_SSE` also doesn't indicate SSSE3 support so it's never actually used. All the `_M_SSE >= 0x301` checks cannot be replaced by `_M_X86` because that breaks GCC 4.9+ which always provides the intrinsic itself but then requires `-mssse3` per function/translation unit to actually use them. The only alternative would be to only include SSE2 headers and define SSSE3 intrinsics ourselves without builtins (otherwise we'd define it twice in GCC 4.9+) which would require to include headers manually in files where we use SSE4 which is ugly and aaaaargh...
Don't even get me started on Clang. (MSVC always supplies all intrinsics so it's not affected.)

At this point, I'd say we either sit this out until nobody cares about pre-SSSE3 CPUs anymore or somebody steps up and finishes the work started in #241 (moving post-SSE2 functions into separate files because that's the only thing that works on all compilers/architectures).