### PR TITLE
DolphinWX: Relocate the address search into the code window

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -15,6 +15,7 @@
 #include <wx/menu.h>
 #include <wx/menuitem.h>
 #include <wx/panel.h>
+#include <wx/stattext.h>
 #include <wx/string.h>
 #include <wx/textctrl.h>
 #include <wx/textdlg.h>
@@ -90,8 +91,19 @@ CCodeWindow::CCodeWindow(const SCoreStartupParameter& _LocalCoreStartupParameter
 	callers = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_SORT);
 	callers->Bind(wxEVT_LISTBOX, &CCodeWindow::OnCallersListChange, this);
 
+	m_aui_toolbar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxAUI_TB_HORIZONTAL | wxAUI_TB_PLAIN_BACKGROUND);
+
+	wxTextCtrl* const address_textctrl = new wxTextCtrl(m_aui_toolbar, IDM_ADDRBOX);
+	address_textctrl->Bind(wxEVT_TEXT, &CCodeWindow::OnAddrBoxChange, this);
+
+	m_aui_toolbar->AddControl(new wxStaticText(m_aui_toolbar, wxID_ANY, _("Address Search:")));
+	m_aui_toolbar->AddSpacer(5);
+	m_aui_toolbar->AddControl(address_textctrl);
+	m_aui_toolbar->Realize();
+
 	m_aui_manager.SetManagedWindow(this);
 	m_aui_manager.SetFlags(wxAUI_MGR_DEFAULT | wxAUI_MGR_LIVE_RESIZE);
+	m_aui_manager.AddPane(m_aui_toolbar, wxAuiPaneInfo().ToolbarPane().Top().Floatable(false));
 	m_aui_manager.AddPane(callstack, wxAuiPaneInfo().MinSize(150, 100).Left().CloseButton(false).Floatable(false).Caption(_("Callstack")));
 	m_aui_manager.AddPane(symbols, wxAuiPaneInfo().MinSize(150, 100).Left().CloseButton(false).Floatable(false).Caption(_("Symbols")));
 	m_aui_manager.AddPane(calls, wxAuiPaneInfo().MinSize(150, 100).Left().CloseButton(false).Floatable(false).Caption(_("Function calls")));
@@ -108,7 +120,6 @@ CCodeWindow::CCodeWindow(const SCoreStartupParameter& _LocalCoreStartupParameter
 
 	// Toolbar
 	Bind(wxEVT_MENU, &CCodeWindow::OnCodeStep, this, IDM_STEP, IDM_GOTOPC);
-	Bind(wxEVT_TEXT, &CCodeWindow::OnAddrBoxChange, this, IDM_ADDRBOX);
 
 	// Other
 	Bind(wxEVT_HOST_COMMAND, &CCodeWindow::OnHostMessage, this);
@@ -224,10 +235,7 @@ void CCodeWindow::OnCodeViewChange(wxCommandEvent &event)
 
 void CCodeWindow::OnAddrBoxChange(wxCommandEvent& event)
 {
-	if (!GetToolBar())
-		return;
-
-	wxTextCtrl* pAddrCtrl = (wxTextCtrl*)GetToolBar()->FindControl(IDM_ADDRBOX);
+	wxTextCtrl* pAddrCtrl = (wxTextCtrl*)m_aui_toolbar->FindControl(IDM_ADDRBOX);
 
 	// Trim leading and trailing whitespace.
 	wxString txt = pAddrCtrl->GetValue().Trim().Trim(false);
@@ -676,8 +684,6 @@ void CCodeWindow::PopulateToolbar(wxToolBar* toolBar)
 	toolBar->AddSeparator();
 	WxUtils::AddToolbarButton(toolBar, IDM_GOTOPC,   _("Show PC"),   m_Bitmaps[Toolbar_GotoPC],   _("Go to the current instruction"));
 	WxUtils::AddToolbarButton(toolBar, IDM_SETPC,    _("Set PC"),    m_Bitmaps[Toolbar_SetPC],    _("Set the current instruction"));
-	toolBar->AddSeparator();
-	toolBar->AddControl(new wxTextCtrl(toolBar, IDM_ADDRBOX, ""));
 }
 
 // Update GUI

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -29,10 +29,11 @@ class DSPDebuggerLLE;
 class GFXDebuggerPanel;
 struct SCoreStartupParameter;
 
-class wxToolBar;
+class wxAuiToolBar;
 class wxListBox;
 class wxMenu;
 class wxMenuBar;
+class wxToolBar;
 
 class CCodeWindow : public wxPanel
 {
@@ -136,5 +137,6 @@ private:
 	wxListBox* calls;
 	Common::Event sync_event;
 
-	wxAuiManager m_aui_manager;
+	wxAuiManager  m_aui_manager;
+	wxAuiToolBar* m_aui_toolbar;
 };


### PR DESCRIPTION
It's only function is in this window. Leaving it on the main application toolbar not only looks gross, but subverts what a user might think it applies to. The search capabilities of this will also be expanded in a (soonish) future PR as well.

![](http://i.imgur.com/yHqdiEo.png)