### PR TITLE
zfreeze: cache vertex positions

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -1823,6 +1823,7 @@ void XEmitter::PCMPGTD(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0x66, d
 
 void XEmitter::PEXTRW(X64Reg dest, const OpArg& arg, u8 subreg) {WriteSSEOp(0x66, 0xC5, dest, arg); Write8(subreg);}
 void XEmitter::PINSRW(X64Reg dest, const OpArg& arg, u8 subreg) {WriteSSEOp(0x66, 0xC4, dest, arg); Write8(subreg);}
+void XEmitter::PINSRD(X64Reg dest, const OpArg& arg, u8 subreg) {WriteSSE41Op(0x66, 0x3A22, dest, arg); Write8(subreg);}
 
 void XEmitter::PMADDWD(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0xF5, dest, arg); }
 void XEmitter::PSADBW(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xF6, dest, arg);}

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -711,6 +711,7 @@ public:
 
 	void PEXTRW(X64Reg dest, const OpArg& arg, u8 subreg);
 	void PINSRW(X64Reg dest, const OpArg& arg, u8 subreg);
+	void PINSRD(X64Reg dest, const OpArg& arg, u8 subreg);
 
 	void PMADDWD(X64Reg dest, const OpArg& arg);
 	void PSADBW(X64Reg dest, const OpArg& arg);

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -14,6 +14,7 @@
 #include "VideoCommon/VertexLoader_Normal.h"
 #include "VideoCommon/VertexLoader_Position.h"
 #include "VideoCommon/VertexLoader_TextCoord.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -24,6 +25,8 @@ u8* g_vertex_manager_write_ptr;
 static void LOADERDECL PosMtx_ReadDirect_UByte(VertexLoader* loader)
 {
 	u32 posmtx = DataReadU8() & 0x3f;
+	if (loader->m_counter < 3)
+		VertexLoaderManager::position_matrix_index[loader->m_counter] = posmtx;
 	DataWrite<u32>(posmtx);
 	PRIM_LOG("posmtx: %d, ", posmtx);
 }
@@ -316,7 +319,7 @@ int VertexLoader::RunVertices(DataReader src, DataReader dst, int count)
 	m_numLoadedVertices += count;
 	m_skippedVertices = 0;
 
-	for (int s = 0; s < count; s++)
+	for (m_counter = count - 1; m_counter >= 0; m_counter--)
 	{
 		m_tcIndex = 0;
 		m_colIndex = 0;

--- a/Source/Core/VideoCommon/VertexLoader.h
+++ b/Source/Core/VideoCommon/VertexLoader.h
@@ -49,6 +49,7 @@ public:
 	int m_texmtxread;
 	bool m_vertexSkip;
 	int m_skippedVertices;
+	int m_counter;
 
 private:
 	// Pipeline.

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -26,6 +26,9 @@
 namespace VertexLoaderManager
 {
 
+float position_cache[3][4];
+u32 position_matrix_index[3];
+
 typedef std::unordered_map<PortableVertexDeclaration, std::unique_ptr<NativeVertexFormat>> NativeVertexFormatMap;
 static NativeVertexFormatMap s_native_vertex_map;
 static NativeVertexFormat* s_current_vtx_fmt;

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -28,5 +28,10 @@ namespace VertexLoaderManager
 	// Resolved pointers to array bases. Used by vertex loaders.
 	extern u8 *cached_arraybases[12];
 	void UpdateVertexArrayPointers();
+
+	// Position cache for zfreeze (3 vertices, 4 floats each to allow SIMD overwrite).
+	// These arrays are in reverse order.
+	extern float position_cache[3][4];
+	extern u32 position_matrix_index[3];
 }
 

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -23,6 +23,11 @@ static const X64Reg base_reg = RBX;
 
 static const u8* memory_base_ptr = (u8*)&g_main_cp_state.array_strides;
 
+static OpArg MPIC(const void* ptr, X64Reg scale_reg, int scale = SCALE_1)
+{
+	return MComplex(base_reg, scale_reg, scale, (s32)((u8*)ptr - memory_base_ptr));
+}
+
 static OpArg MPIC(const void* ptr)
 {
 	return MDisp(base_reg, (s32)((u8*)ptr - memory_base_ptr));
@@ -193,6 +198,31 @@ int VertexLoaderX64::ReadVertex(OpArg data, u64 attribute, int format, int count
 				MOV(32, dest, R(scratch3));
 				data.AddMemOffset(sizeof(float));
 				dest.AddMemOffset(sizeof(float));
+
+				// zfreeze
+				if (native_format == &m_native_vtx_decl.position)
+				{
+					if (cpu_info.bSSE4_1)
+					{
+						PINSRD(coords, R(scratch3), i);
+					}
+					else
+					{
+						PINSRW(coords, R(scratch3), 2 * i + 0);
+						SHR(32, R(scratch3), Imm8(16));
+						PINSRW(coords, R(scratch3), 2 * i + 1);
+					}
+				}
+			}
+
+			// zfreeze
+			if (native_format == &m_native_vtx_decl.position)
+			{
+				CMP(32, R(count_reg), Imm8(3));
+				FixupBranch dont_store = J_CC(CC_A);
+				LEA(32, scratch3, MScaled(count_reg, SCALE_4, -4));
+				MOVUPS(MPIC(VertexLoaderManager::position_cache, scratch3, SCALE_4), coords);
+				SetJumpTarget(dont_store);
 			}
 			return load_bytes;
 		}
@@ -211,6 +241,16 @@ int VertexLoaderX64::ReadVertex(OpArg data, u64 attribute, int format, int count
 	case 1: MOVSS(dest, coords); break;
 	case 2: MOVLPS(dest, coords); break;
 	case 3: MOVUPS(dest, coords); break;
+	}
+
+	// zfreeze
+	if (native_format == &m_native_vtx_decl.position)
+	{
+		CMP(32, R(count_reg), Imm8(3));
+		FixupBranch dont_store = J_CC(CC_A);
+		LEA(32, scratch3, MScaled(count_reg, SCALE_4, -4));
+		MOVUPS(MPIC(VertexLoaderManager::position_cache, scratch3, SCALE_4), coords);
+		SetJumpTarget(dont_store);
 	}
 
 	return load_bytes;
@@ -388,6 +428,13 @@ void VertexLoaderX64::GenerateVertexLoader()
 		MOVZX(32, 8, scratch1, MDisp(src_reg, m_src_ofs));
 		AND(32, R(scratch1), Imm8(0x3F));
 		MOV(32, MDisp(dst_reg, m_dst_ofs), R(scratch1));
+
+		// zfreeze
+		CMP(32, R(count_reg), Imm8(3));
+		FixupBranch dont_store = J_CC(CC_A);
+		MOV(32, MPIC(VertexLoaderManager::position_matrix_index - 1, count_reg, SCALE_4), R(scratch1));
+		SetJumpTarget(dont_store);
+
 		m_native_components |= VB_HAS_POSMTXIDX;
 		m_native_vtx_decl.posmtx.components = 4;
 		m_native_vtx_decl.posmtx.enable = true;

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -32,7 +32,12 @@ void LOADERDECL Pos_ReadDirect(VertexLoader* loader)
 	DataReader src(g_video_buffer_read_ptr, nullptr);
 
 	for (int i = 0; i < N; ++i)
-		dst.Write(PosScale(src.Read<T>(), scale));
+	{
+		float value = PosScale(src.Read<T>(), scale);
+		if (loader->m_counter < 3)
+			VertexLoaderManager::position_cache[loader->m_counter][i] = value;
+		dst.Write(value);
+	}
 
 	g_vertex_manager_write_ptr = dst.GetPointer();
 	g_video_buffer_read_ptr = src.GetPointer();
@@ -52,7 +57,12 @@ void LOADERDECL Pos_ReadIndex(VertexLoader* loader)
 	DataReader dst(g_vertex_manager_write_ptr, nullptr);
 
 	for (int i = 0; i < N; ++i)
-		dst.Write(PosScale(Common::FromBigEndian(data[i]), scale));
+	{
+		float value = PosScale(Common::FromBigEndian(data[i]), scale);
+		if (loader->m_counter < 3)
+			VertexLoaderManager::position_cache[loader->m_counter][i] = value;
+		dst.Write(value);
+	}
 
 	g_vertex_manager_write_ptr = dst.GetPointer();
 	LOG_VTX();


### PR DESCRIPTION
This avoids reading from write-combined memory. Might give a small speedup in some games.

Suggested by @degasus.

TODO:
- [x] fix bug: https://dl.dropboxusercontent.com/u/484730/Itdoenstwork.jpg
- [x] do this in a way that isn't super ugly
- [x] AArch64 vertex loader JIT
- [x] software vertex loader
- [x] adapt indexed memory operands if #2358 is merged before this