### PR TITLE
PixelShaderManager: Remove unnecessary casts.

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -159,8 +159,8 @@ void PixelShaderManager::SetViewportChanged()
 
 void PixelShaderManager::SetEfbScaleChanged()
 {
-	constants.efbscale[0] = 1.0f / float(Renderer::EFBToScaledXf(1));
-	constants.efbscale[1] = 1.0f / float(Renderer::EFBToScaledYf(1));
+	constants.efbscale[0] = 1.0f / Renderer::EFBToScaledXf(1);
+	constants.efbscale[1] = 1.0f / Renderer::EFBToScaledYf(1);
 	dirty = true;
 }
 


### PR DESCRIPTION
EFBToScaledXf and EFBScaledYf return a float, so the cast isn't needed here.