### PR TITLE
[AArch64] Optimize FPR pushing and popping.

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -2877,6 +2877,19 @@ void ARM64FloatEmitter::FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 
 void ARM64FloatEmitter::ABI_PushRegisters(BitSet32 registers)
 {
 	bool bundled_loadstore = false;
+	int num_regs = registers.Count();
+
+	if (num_regs == 2)
+	{
+		int i = 0;
+		ARM64Reg regs[2];
+		for (auto it : registers)
+			regs[i++] = (ARM64Reg)(Q0 + it);
+
+		STP(128, INDEX_PRE, regs[0], regs[1], SP, -32);
+		return;
+	}
+
 	for (int i = 0; i < 32; ++i)
 	{
 		if (!registers[i])
@@ -2898,7 +2911,6 @@ void ARM64FloatEmitter::ABI_PushRegisters(BitSet32 registers)
 	}
 	else
 	{
-		int num_regs = registers.Count();
 		// Violating the AAPCS64 never felt so right.
 		m_emit->SUB(SP, SP, num_regs * 16);
 		for (int i = 0; i < 32; ++i)
@@ -2925,6 +2937,19 @@ void ARM64FloatEmitter::ABI_PushRegisters(BitSet32 registers)
 void ARM64FloatEmitter::ABI_PopRegisters(BitSet32 registers)
 {
 	bool bundled_loadstore = false;
+	int num_regs = registers.Count();
+
+	if (num_regs == 2)
+	{
+		int i = 0;
+		ARM64Reg regs[2];
+		for (auto it : registers)
+			regs[i++] = (ARM64Reg)(Q0 + it);
+
+		LDP(128, INDEX_POST, regs[0], regs[1], SP, 32);
+		return;
+	}
+
 	for (int i = 0; i < 32; ++i)
 	{
 		if (!registers[i])

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -755,8 +755,8 @@ public:
 	void FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index);
 
 	// ABI related
-	void ABI_PushRegisters(BitSet32 registers);
-	void ABI_PopRegisters(BitSet32 registers);
+	void ABI_PushRegisters(BitSet32 registers, ARM64Reg tmp = INVALID_REG);
+	void ABI_PopRegisters(BitSet32 registers, ARM64Reg tmp = INVALID_REG);
 
 private:
 	ARM64XEmitter* m_emit;

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -658,7 +658,9 @@ public:
 
 	// Loadstore multiple structure
 	void LD1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn);
+	void LD1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm = SP);
 	void ST1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn);
+	void ST1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm = SP);
 
 	// Scalar - 1 Source
 	void FABS(ARM64Reg Rd, ARM64Reg Rn);
@@ -748,7 +750,7 @@ public:
 
 	// ABI related
 	void ABI_PushRegisters(BitSet32 registers);
-	void ABI_PopRegisters(BitSet32 registers, BitSet32 ignore_mask = BitSet32(0));
+	void ABI_PopRegisters(BitSet32 registers);
 
 private:
 	ARM64XEmitter* m_emit;
@@ -770,6 +772,7 @@ private:
 	void EmitScalarImm(bool M, bool S, u32 type, u32 imm5, ARM64Reg Rd, u32 imm);
 	void EmitShiftImm(bool U, u32 immh, u32 immb, u32 opcode, ARM64Reg Rd, ARM64Reg Rn);
 	void EmitLoadStoreMultipleStructure(u32 size, bool L, u32 opcode, ARM64Reg Rt, ARM64Reg Rn);
+	void EmitLoadStoreMultipleStructurePost(u32 size, bool L, u32 opcode, ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm);
 	void EmitScalar1Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd, ARM64Reg Rn);
 	void EmitVectorxElement(bool U, u32 size, bool L, u32 opcode, bool H, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void EmitLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm);

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -109,6 +109,8 @@ enum IndexType
 	INDEX_UNSIGNED,
 	INDEX_POST,
 	INDEX_PRE,
+	// Only for VFP loadstore paired
+	INDEX_SIGNED,
 };
 
 enum ShiftAmount
@@ -662,6 +664,10 @@ public:
 	void ST1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn);
 	void ST1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm = SP);
 
+	// Loadstore paired
+	void LDP(u8 size, IndexType type, ARM64Reg Rt, ARM64Reg Rt2, ARM64Reg Rn, s32 imm);
+	void STP(u8 size, IndexType type, ARM64Reg Rt, ARM64Reg Rt2, ARM64Reg Rn, s32 imm);
+
 	// Scalar - 1 Source
 	void FABS(ARM64Reg Rd, ARM64Reg Rn);
 	void FNEG(ARM64Reg Rd, ARM64Reg Rn);
@@ -776,6 +782,7 @@ private:
 	void EmitScalar1Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd, ARM64Reg Rn);
 	void EmitVectorxElement(bool U, u32 size, bool L, u32 opcode, bool H, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void EmitLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm);
+	void EncodeLoadStorePair(u32 size, bool load, IndexType type, ARM64Reg Rt, ARM64Reg Rt2, ARM64Reg Rn, s32 imm);
 };
 
 class ARM64CodeBlock : public CodeBlock<ARM64XEmitter>

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -167,12 +167,12 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
 		// Has a chance of being backpatched which will destroy our state
 		// push and pop everything in this instance
 		ABI_PushRegisters(regs_in_use);
-		m_float_emit.ABI_PushRegisters(fprs_in_use);
+		m_float_emit.ABI_PushRegisters(fprs_in_use, X30);
 		EmitBackpatchRoutine(this, flags,
 			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
 			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
 			dest_reg, XA);
-		m_float_emit.ABI_PopRegisters(fprs_in_use);
+		m_float_emit.ABI_PopRegisters(fprs_in_use, X30);
 		ABI_PopRegisters(regs_in_use);
 	}
 
@@ -318,12 +318,12 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
 		// Has a chance of being backpatched which will destroy our state
 		// push and pop everything in this instance
 		ABI_PushRegisters(regs_in_use);
-		m_float_emit.ABI_PushRegisters(fprs_in_use);
+		m_float_emit.ABI_PushRegisters(fprs_in_use, X30);
 		EmitBackpatchRoutine(this, flags,
 			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
 			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
 			RS, XA);
-		m_float_emit.ABI_PopRegisters(fprs_in_use);
+		m_float_emit.ABI_PopRegisters(fprs_in_use, X30);
 		ABI_PopRegisters(regs_in_use);
 	}
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -190,12 +190,12 @@ void JitArm64::lfXX(UGeckoInstruction inst)
 		// Has a chance of being backpatched which will destroy our state
 		// push and pop everything in this instance
 		ABI_PushRegisters(regs_in_use);
-		m_float_emit.ABI_PushRegisters(fprs_in_use);
+		m_float_emit.ABI_PushRegisters(fprs_in_use, X30);
 		EmitBackpatchRoutine(this, flags,
 			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
 			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
 			VD, XA);
-		m_float_emit.ABI_PopRegisters(fprs_in_use);
+		m_float_emit.ABI_PopRegisters(fprs_in_use, X30);
 		ABI_PopRegisters(regs_in_use);
 	}
 
@@ -406,9 +406,9 @@ void JitArm64::stfXX(UGeckoInstruction inst)
 		else
 		{
 			ABI_PushRegisters(regs_in_use);
-			m_float_emit.ABI_PushRegisters(fprs_in_use);
+			m_float_emit.ABI_PushRegisters(fprs_in_use, X30);
 			EmitBackpatchRoutine(this, flags, false, false, V0, XA);
-			m_float_emit.ABI_PopRegisters(fprs_in_use);
+			m_float_emit.ABI_PopRegisters(fprs_in_use, X30);
 			ABI_PopRegisters(regs_in_use);
 		}
 	}
@@ -417,12 +417,12 @@ void JitArm64::stfXX(UGeckoInstruction inst)
 		// Has a chance of being backpatched which will destroy our state
 		// push and pop everything in this instance
 		ABI_PushRegisters(regs_in_use);
-		m_float_emit.ABI_PushRegisters(fprs_in_use);
+		m_float_emit.ABI_PushRegisters(fprs_in_use, X30);
 		EmitBackpatchRoutine(this, flags,
 			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
 			SConfig::GetInstance().m_LocalCoreStartupParameter.bFastmem,
 			V0, XA);
-		m_float_emit.ABI_PopRegisters(fprs_in_use);
+		m_float_emit.ABI_PopRegisters(fprs_in_use, X30);
 		ABI_PopRegisters(regs_in_use);
 	}
 	gpr.Unlock(W0, W1, W30);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -279,12 +279,12 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 		SetJumpTarget(argh);
 
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.UMOV(64, X0, Q0, 0);
 		ORR(X0, SP, X0, ArithOption(X0, ST_ROR, 32));
 		MOVI2R(X30, (u64)PowerPC::Write_U64);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}
@@ -310,12 +310,12 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 
 		SetJumpTarget(argh);
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.UMOV(16, W0, Q0, 0);
 		REV16(W0, W0);
 		MOVI2R(X30, (u64)PowerPC::Write_U16);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}
@@ -341,12 +341,12 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 
 		SetJumpTarget(argh);
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.UMOV(16, W0, Q0, 0);
 		REV16(W0, W0);
 		MOVI2R(X30, (u64)PowerPC::Write_U16);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}
@@ -372,12 +372,12 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 
 		SetJumpTarget(argh);
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.REV32(8, D0, D0);
 		float_emit.UMOV(32, W0, Q0, 0);
 		MOVI2R(X30, (u64)PowerPC::Write_U32);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}
@@ -402,12 +402,12 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 
 		SetJumpTarget(argh);
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.REV32(8, D0, D0);
 		float_emit.UMOV(32, W0, Q0, 0);
 		MOVI2R(X30, (u64)PowerPC::Write_U32);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}
@@ -428,11 +428,11 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 		SetJumpTarget(argh);
 
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.UMOV(32, W0, Q0, 0);
 		MOVI2R(X30, (u64)&PowerPC::Write_U32);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}
@@ -457,11 +457,11 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 
 		SetJumpTarget(argh);
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.UMOV(32, W0, Q0, 0);
 		MOVI2R(X30, (u64)&PowerPC::Write_U8);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}
@@ -486,11 +486,11 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 
 		SetJumpTarget(argh);
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.SMOV(32, W0, Q0, 0);
 		MOVI2R(X30, (u64)&PowerPC::Write_U8);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}
@@ -515,11 +515,11 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 
 		SetJumpTarget(argh);
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.UMOV(32, W0, Q0, 0);
 		MOVI2R(X30, (u64)&PowerPC::Write_U16);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}
@@ -544,11 +544,11 @@ void JitArm64AsmRoutineManager::GenerateCommon()
 
 		SetJumpTarget(argh);
 		ABI_PushRegisters(gprs);
-		float_emit.ABI_PushRegisters(fprs);
+		float_emit.ABI_PushRegisters(fprs, X3);
 		float_emit.SMOV(32, W0, Q0, 0);
 		MOVI2R(X30, (u64)&PowerPC::Write_U16);
 		BLR(X30);
-		float_emit.ABI_PopRegisters(fprs);
+		float_emit.ABI_PopRegisters(fprs, X3);
 		ABI_PopRegisters(gprs);
 		RET(X30);
 	}

--- a/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit_Util.cpp
@@ -79,11 +79,11 @@ private:
 		ARM64FloatEmitter float_emit(m_emit);
 
 		m_emit->ABI_PushRegisters(m_gprs_in_use);
-		float_emit.ABI_PushRegisters(m_fprs_in_use);
+		float_emit.ABI_PushRegisters(m_fprs_in_use, X1);
 			m_emit->MOVI2R(W1, m_address);
 			m_emit->MOV(W2, m_src_reg);
 			m_emit->BLR(m_emit->ABI_SetupLambda(lambda));
-		float_emit.ABI_PopRegisters(m_fprs_in_use);
+		float_emit.ABI_PopRegisters(m_fprs_in_use, X1);
 		m_emit->ABI_PopRegisters(m_gprs_in_use);
 	}
 
@@ -179,10 +179,10 @@ private:
 		ARM64FloatEmitter float_emit(m_emit);
 
 		m_emit->ABI_PushRegisters(m_gprs_in_use);
-		float_emit.ABI_PushRegisters(m_fprs_in_use);
+		float_emit.ABI_PushRegisters(m_fprs_in_use, X1);
 			m_emit->MOVI2R(W1, m_address);
 			m_emit->BLR(m_emit->ABI_SetupLambda(lambda));
-		float_emit.ABI_PopRegisters(m_fprs_in_use);
+		float_emit.ABI_PopRegisters(m_fprs_in_use, X1);
 		m_emit->ABI_PopRegisters(m_gprs_in_use);
 
 		if (m_sign_extend)


### PR DESCRIPTION
Previously on FPR pushing and popping we would do a single STR/LDR per quad FPR we wanted to push/pop.
In most of our cases when we are pushing and popping VFP registers they will be consecutive registers that will save more efficiently using the NEON
loadstores that can do up to four quad registers.
So this can potentially cutting instructions down to ~1/4th the amount of instructions if the registers are all consecutive.

On the Cortex-A57 this is basically just an icache improvement, but on the Nvidia Denver this may be optimized to be more efficient. Either way it's a
win.