### PR TITLE
VertexLoaderX64: require hardware bounding box

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderARM64.h
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.h
@@ -5,6 +5,7 @@
 #pragma once
 #include "Common/Arm64Emitter.h"
 #include "VideoCommon/VertexLoaderBase.h"
+#include "VideoCommon/VideoConfig.h"
 
 class VertexLoaderARM64 : public VertexLoaderBase, public Arm64Gen::ARM64CodeBlock
 {
@@ -13,7 +14,7 @@ public:
 
 protected:
 	std::string GetName() const override { return "VertexLoaderARM64"; }
-	bool IsInitialized() override { return true; }
+	bool IsInitialized() override { return g_ActiveConfig.backend_info.bSupportsBBox; }
 	int RunVertices(DataReader src, DataReader dst, int count, int primitive) override;
 
 private:

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -3,6 +3,7 @@
 #include "Common/JitRegister.h"
 #include "Common/x64ABI.h"
 #include "VideoCommon/VertexLoaderX64.h"
+#include "VideoCommon/VideoConfig.h"
 
 using namespace Gen;
 
@@ -449,7 +450,7 @@ void VertexLoaderX64::GenerateVertexLoader()
 bool VertexLoaderX64::IsInitialized()
 {
 	// Uses PSHUFB.
-	return cpu_info.bSSSE3;
+	return cpu_info.bSSSE3 && g_ActiveConfig.backend_info.bSupportsBBox;
 }
 
 int VertexLoaderX64::RunVertices(DataReader src, DataReader dst, int count, int primitive)

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -177,12 +177,18 @@ void VertexLoader_Normal::Init()
 unsigned int VertexLoader_Normal::GetSize(u64 _type,
 	unsigned int _format, unsigned int _elements, unsigned int _index3)
 {
+	// FIXME: This is only a workaround for the FIFA Street fifo log.
+	_format = std::min(_format, 4u);
+
 	return m_Table[_type][_index3][_elements][_format].gc_size;
 }
 
 TPipelineFunction VertexLoader_Normal::GetFunction(u64 _type,
 	unsigned int _format, unsigned int _elements, unsigned int _index3)
 {
+	// FIXME: This is only a workaround for the FIFA Street fifo log.
+	_format = std::min(_format, 4u);
+
 	TPipelineFunction pFunc = m_Table[_type][_index3][_elements][_format].function;
 	return pFunc;
 }


### PR DESCRIPTION
On graphics cards that don't support GL_ARB_shader_storage_buffer_object, this has the unfortunate side effect that it disables the vertex loader JIT for games that run fine without bounding box. Any ideas?

Fixes [issue 8270](https://code.google.com/p/dolphin-emu/issues/detail?id=8270).