### PR TITLE
DolphinWX: fix searching the game list in GTK

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -771,11 +771,7 @@ void CGameListCtrl::OnKeyPress(wxListEvent& event)
 
 		wxString text = bleh.GetText();
 
-#ifdef __WXGTK__
-		if (text.MakeLower()[0] == event.GetKeyCode())
-#else
 		if (text.MakeUpper()[0] == event.GetKeyCode())
-#endif
 		{
 			if (lastKey == event.GetKeyCode() && Loop < sLoop)
 			{


### PR DESCRIPTION
(Maybe wxGTK behavior changed?)

Fixes [issue 8100](https://code.google.com/p/dolphin-emu/issues/detail?id=8100).