### PR TITLE
DolphinWX: Clean up some wxTimer code

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -508,15 +508,13 @@ CFrame::CFrame(wxFrame* parent,
 	// check if game is running
 	m_bHotkeysInit = InitControllers();
 
-	m_poll_hotkey_timer = new wxTimer(this);
+	m_poll_hotkey_timer.SetOwner(this);
 	Bind(wxEVT_TIMER, &CFrame::PollHotkeys, this);
-	m_poll_hotkey_timer->Start(1000 / 60, wxTIMER_CONTINUOUS);
+	m_poll_hotkey_timer.Start(1000 / 60, wxTIMER_CONTINUOUS);
 }
 // Destructor
 CFrame::~CFrame()
 {
-	m_poll_hotkey_timer->Stop();
-
 	if (m_bHotkeysInit)
 	{
 		Wiimote::Shutdown();

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -18,6 +18,7 @@
 #include <wx/mstream.h>
 #include <wx/panel.h>
 #include <wx/string.h>
+#include <wx/timer.h>
 #include <wx/toplevel.h>
 #include <wx/windowid.h>
 
@@ -47,8 +48,6 @@ class wxAuiNotebook;
 class wxAuiNotebookEvent;
 class wxListEvent;
 class wxMenuItem;
-class wxTimer;
-class wxTimerEvent;
 class wxWindow;
 
 class CRenderFrame : public wxFrame
@@ -198,7 +197,7 @@ private:
 		EToolbar_Max
 	};
 
-	wxTimer* m_poll_hotkey_timer;
+	wxTimer m_poll_hotkey_timer;
 
 	wxBitmap m_Bitmaps[EToolbar_Max];
 	wxBitmap m_BitmapsMenu[EToolbar_Max];

--- a/Source/Core/DolphinWX/LogWindow.h
+++ b/Source/Core/DolphinWX/LogWindow.h
@@ -14,6 +14,7 @@
 #include <wx/gdicmn.h>
 #include <wx/panel.h>
 #include <wx/string.h>
+#include <wx/timer.h>
 #include <wx/translation.h>
 #include <wx/windowid.h>
 
@@ -25,8 +26,6 @@ class wxBoxSizer;
 class wxCheckBox;
 class wxChoice;
 class wxTextCtrl;
-class wxTimer;
-class wxTimerEvent;
 
 // Uses multiple inheritance - only sane because LogListener is a pure virtual interface.
 class CLogWindow : public wxPanel, LogListener
@@ -50,8 +49,7 @@ private:
 	CFrame* Parent;
 	wxFont DefaultFont, MonoSpaceFont;
 	std::vector<wxFont> LogFont;
-	wxTimer* m_LogTimer;
-	bool m_ignoreLogTimer;
+	wxTimer m_LogTimer;
 	LogManager* m_LogManager;
 	std::queue<std::pair<u8, wxString> > msgQueue;
 	bool m_writeFile, m_writeWindow, m_writeDebugger, m_LogAccess;


### PR DESCRIPTION
Technically fixes a memory leak (which wouldn't matter because the timer is only created once and destroyed on shutdown).

Also starting and stopping the timer does not cause leaks.