### PR TITLE
TexCache: increase TEXTURE_KILL_THRESHOLD

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -21,7 +21,7 @@
 #include "VideoCommon/VideoConfig.h"
 
 static const u64 TEXHASH_INVALID = 0;
-static const int TEXTURE_KILL_THRESHOLD = 10;
+static const int TEXTURE_KILL_THRESHOLD = 60;
 static const int TEXTURE_POOL_KILL_THRESHOLD = 3;
 static const int FRAMECOUNT_INVALID = 0;
 


### PR DESCRIPTION
Xenoblade uses more than 30 textures alternately per frame for eg water effects.
So don't try to drop them as aggressive.