### PR TITLE
Allow several gc adapters to be plugged

### DIFF
--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -143,14 +143,12 @@ void Setup()
 					if (ret == LIBUSB_ERROR_NOT_SUPPORTED)
 						s_libusb_driver_not_supported = true;
 				}
-				Shutdown();
 			}
 			else if ((ret = libusb_kernel_driver_active(s_handle, 0)) == 1)
 			{
 				if ((ret = libusb_detach_kernel_driver(s_handle, 0)) && ret != LIBUSB_ERROR_NOT_SUPPORTED)
 				{
 					ERROR_LOG(SERIALINTERFACE, "libusb_detach_kernel_driver failed with error: %d", ret);
-					Shutdown();
 				}
 				else
 				{
@@ -161,12 +159,10 @@ void Setup()
 			else if ((ret != 0 && ret != LIBUSB_ERROR_NOT_SUPPORTED))
 			{
 				ERROR_LOG(SERIALINTERFACE, "libusb_kernel_driver_active error ret = %d", ret);
-				Shutdown();
 			}
 			else if ((ret = libusb_claim_interface(s_handle, 0)))
 			{
 				ERROR_LOG(SERIALINTERFACE, "libusb_claim_interface failed with error: %d", ret);
-				Shutdown();
 			}
 			else
 			{
@@ -175,6 +171,8 @@ void Setup()
 			}
 		}
 	}
+	if (!s_detected)
+		Shutdown();
 
 	libusb_free_device_list(list, 1);
 }

--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -150,15 +150,12 @@ void Setup()
 				{
 					ERROR_LOG(SERIALINTERFACE, "libusb_detach_kernel_driver failed with error: %d", ret);
 				}
-				else
-				{
-					AddGCAdapter(device);
-					break;
-				}
 			}
-			else if ((ret != 0 && ret != LIBUSB_ERROR_NOT_SUPPORTED))
+			// this split is needed so that we don't avoid claiming the interface when
+			// detaching the kernel driver is successful
+			if (ret != 0)
 			{
-				ERROR_LOG(SERIALINTERFACE, "libusb_kernel_driver_active error ret = %d", ret);
+				continue;
 			}
 			else if ((ret = libusb_claim_interface(s_handle, 0)))
 			{
@@ -224,7 +221,7 @@ void Shutdown()
 
 void Reset()
 {
-	if (!SConfig::GetInstance().m_GameCubeAdapter)
+	if (!s_detected)
 		return;
 
 	if (s_adapter_thread_running.TestAndClear())
@@ -333,7 +330,7 @@ void Output(int chan, u8 rumble_command)
 
 bool IsDetected()
 {
-	return s_handle != nullptr;
+	return s_detected;
 }
 
 bool IsDriverDetected()

--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -235,7 +235,6 @@ void Reset()
 	if (s_handle)
 	{
 		libusb_release_interface(s_handle, 0);
-		libusb_reset_device(s_handle);
 		libusb_close(s_handle);
 		s_handle = nullptr;
 	}

--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -249,9 +249,15 @@ void Input(int chan, GCPadStatus* pad)
 	if (s_handle == nullptr)
 	{
 		if (s_detected)
+		{
 			Init();
+			if (s_handle == nullptr)
+				return;
+		}
 		else
+		{
 			return;
+		}
 	}
 
 	u8 controller_payload_copy[37];

--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -155,6 +155,7 @@ void Setup()
 				else
 				{
 					AddGCAdapter(device);
+					break;
 				}
 			}
 			else if ((ret != 0 && ret != LIBUSB_ERROR_NOT_SUPPORTED))
@@ -170,6 +171,7 @@ void Setup()
 			else
 			{
 				AddGCAdapter(device);
+				break;
 			}
 		}
 	}

--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -104,7 +104,7 @@ void Setup()
 		int dRet = libusb_get_device_descriptor(device, &desc);
 		if (dRet)
 		{
-			// could not aquire the descriptor, no point in trying to use it.
+			// could not acquire the descriptor, no point in trying to use it.
 			ERROR_LOG(SERIALINTERFACE, "libusb_get_device_descriptor failed with error: %d", dRet);
 			continue;
 		}
@@ -153,7 +153,7 @@ void Setup()
 			}
 			// this split is needed so that we don't avoid claiming the interface when
 			// detaching the kernel driver is successful
-			if (ret != 0)
+			if (ret != 0 && ret != LIBUSB_ERROR_NOT_SUPPORTED)
 			{
 				continue;
 			}


### PR DESCRIPTION
Tentative fix for [issue 8286](https://code.google.com/p/dolphin-emu/issues/detail?id=8286), testing needed.

This *should* allow several instances of dolphin to work with one gc adapter each.