### PR TITLE
TextureCache: load all mipmap levels from custom textures

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -1154,7 +1154,7 @@ void Renderer::SetDitherMode()
 	// TODO: Set dither mode to bpmem.blendmode.dither
 }
 
-void Renderer::SetSamplerState(int stage, int texindex)
+void Renderer::SetSamplerState(int stage, int texindex, bool custom_tex)
 {
 	const FourTexUnits &tex = bpmem.tex[texindex];
 	const TexMode0 &tm0 = tex.texMode0[stage];
@@ -1179,6 +1179,12 @@ void Renderer::SetSamplerState(int stage, int texindex)
 	gx_state.sampler[stage].max_lod = (u32)tm1.max_lod;
 	gx_state.sampler[stage].min_lod = (u32)tm1.min_lod;
 	gx_state.sampler[stage].lod_bias = (s32)tm0.lod_bias;
+
+	// custom textures may have higher resolution, so disable the max_lod
+	if (custom_tex)
+	{
+		gx_state.sampler[stage].max_lod = 255;
+	}
 }
 
 void Renderer::SetInterlacingMode()

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -19,7 +19,7 @@ public:
 	void SetDepthMode() override;
 	void SetLogicOpMode() override;
 	void SetDitherMode() override;
-	void SetSamplerState(int stage,int texindex) override;
+	void SetSamplerState(int stage, int texindex, bool custom_tex) override;
 	void SetInterlacingMode() override;
 	void SetViewport() override;
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1868,13 +1868,13 @@ void Renderer::SetDitherMode()
 		glDisable(GL_DITHER);
 }
 
-void Renderer::SetSamplerState(int stage, int texindex)
+void Renderer::SetSamplerState(int stage, int texindex, bool custom_tex)
 {
 	auto const& tex = bpmem.tex[texindex];
 	auto const& tm0 = tex.texMode0[stage];
 	auto const& tm1 = tex.texMode1[stage];
 
-	g_sampler_cache->SetSamplerState((texindex * 4) + stage, tm0, tm1);
+	g_sampler_cache->SetSamplerState((texindex * 4) + stage, tm0, tm1, custom_tex);
 }
 
 void Renderer::SetInterlacingMode()

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -58,7 +58,7 @@ public:
 	void SetDepthMode() override;
 	void SetLogicOpMode() override;
 	void SetDitherMode() override;
-	void SetSamplerState(int stage,int texindex) override;
+	void SetSamplerState(int stage, int texindex, bool custom_tex) override;
 	void SetInterlacingMode() override;
 	void SetViewport() override;
 

--- a/Source/Core/VideoBackends/OGL/SamplerCache.cpp
+++ b/Source/Core/VideoBackends/OGL/SamplerCache.cpp
@@ -20,7 +20,7 @@ SamplerCache::~SamplerCache()
 	Clear();
 }
 
-void SamplerCache::SetSamplerState(int stage, const TexMode0& tm0, const TexMode1& tm1)
+void SamplerCache::SetSamplerState(int stage, const TexMode0& tm0, const TexMode1& tm1, bool custom_tex)
 {
 	// TODO: can this go somewhere else?
 	if (m_last_max_anisotropy != g_ActiveConfig.iMaxAnisotropy)
@@ -36,6 +36,12 @@ void SamplerCache::SetSamplerState(int stage, const TexMode0& tm0, const TexMode
 	{
 		params.tm0.min_filter |= 0x4;
 		params.tm0.mag_filter |= 0x1;
+	}
+
+	// custom textures may have higher resolution, so disable the max_lod
+	if (custom_tex)
+	{
+		params.tm1.max_lod = 255;
 	}
 
 	// TODO: Should keep a circular buffer for each stage of recently used samplers.

--- a/Source/Core/VideoBackends/OGL/SamplerCache.h
+++ b/Source/Core/VideoBackends/OGL/SamplerCache.h
@@ -14,7 +14,7 @@ public:
 	SamplerCache();
 	~SamplerCache();
 
-	void SetSamplerState(int stage, const TexMode0& tm0, const TexMode1& tm1);
+	void SetSamplerState(int stage, const TexMode0& tm0, const TexMode1& tm1, bool custom_tex);
 	void Clear();
 
 private:

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -134,7 +134,7 @@ void PixelShaderManager::SetDestAlpha()
 	dirty = true;
 }
 
-void PixelShaderManager::SetTexDims(int texmapid, u32 width, u32 height, u32 wraps, u32 wrapt)
+void PixelShaderManager::SetTexDims(int texmapid, u32 width, u32 height)
 {
 	// TODO: move this check out to callee. There we could just call this function on texture changes
 	// or better, use textureSize() in glsl

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -33,7 +33,7 @@ public:
 	static void SetTevKonstColor(int index, int component, s32 value);
 	static void SetAlpha();
 	static void SetDestAlpha();
-	static void SetTexDims(int texmapid, u32 width, u32 height, u32 wraps, u32 wrapt);
+	static void SetTexDims(int texmapid, u32 width, u32 height);
 	static void SetZTextureBias();
 	static void SetViewportChanged();
 	static void SetEfbScaleChanged();

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -57,7 +57,7 @@ public:
 	virtual void SetDepthMode() = 0;
 	virtual void SetLogicOpMode() = 0;
 	virtual void SetDitherMode() = 0;
-	virtual void SetSamplerState(int stage,int texindex) = 0;
+	virtual void SetSamplerState(int stage, int texindex, bool custom_tex) = 0;
 	virtual void SetInterlacingMode() = 0;
 	virtual void SetViewport() = 0;
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -52,6 +52,7 @@ public:
 		u64 hash;
 		u32 format;
 		bool is_efb_copy;
+		bool is_custom_tex;
 
 		unsigned int native_width, native_height; // Texture dimensions from the GameCube's point of view
 		unsigned int native_levels;

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -210,13 +210,12 @@ void VertexManager::Flush()
 		TextureCache::UnbindTextures();
 		for (unsigned int i : usedtextures)
 		{
-			g_renderer->SetSamplerState(i & 3, i >> 2);
 			const TextureCache::TCacheEntryBase* tentry = TextureCache::Load(i);
 
 			if (tentry)
 			{
-				// 0s are probably for no manual wrapping needed.
-				PixelShaderManager::SetTexDims(i, tentry->native_width, tentry->native_height, 0, 0);
+				g_renderer->SetSamplerState(i & 3, i >> 2, tentry->is_custom_tex);
+				PixelShaderManager::SetTexDims(i, tentry->native_width, tentry->native_height);
 			}
 			else
 			{


### PR DESCRIPTION
This drops the "feature" to load level 0 from the custom texture
and all other levels from the native one if the size matches.
But in my opinion, when a custom texture only provide one level,
no more should be used at all.