### PR TITLE
Call SetUserDirectory before InitLanguageSupport

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -135,8 +135,6 @@ bool DolphinApp::OnInit()
 	Bind(wxEVT_QUERY_END_SESSION, &DolphinApp::OnEndSession, this);
 	Bind(wxEVT_END_SESSION, &DolphinApp::OnEndSession, this);
 
-	InitLanguageSupport();
-
 	// Declarations and definitions
 	bool UseDebugger = false;
 	bool UseLogger = false;
@@ -246,6 +244,7 @@ bool DolphinApp::OnInit()
 
 	UICommon::SetUserDirectory(userPath.ToStdString());
 	UICommon::CreateDirectories();
+	InitLanguageSupport();	// The language setting is loaded from the user directory
 	UICommon::Init();
 
 	if (selectPerfDir)


### PR DESCRIPTION
Fixes a regression from 4.0-5692 where only the system language was used.