### PR TITLE
Fix clamping for rectangles.

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -156,20 +156,20 @@ struct Rectangle
 	// this Clamp.
 	void ClampLL(T x1, T y1, T x2, T y2)
 	{
-		if (left < x1) left = x1;
-		if (right > x2) right = x2;
-		if (top > y1) top = y1;
-		if (bottom < y2) bottom = y2;
+		Clamp(&left, x1, x2);
+		Clamp(&right, x1, x2);
+		Clamp(&top, y2, y1);
+		Clamp(&bottom, y2, y1);
 	}
 
 	// If the rectangle is in a coordinate system with an upper-left origin,
 	// use this Clamp.
 	void ClampUL(T x1, T y1, T x2, T y2)
 	{
-		if (left < x1) left = x1;
-		if (right > x2) right = x2;
-		if (top < y1) top = y1;
-		if (bottom > y2) bottom = y2;
+		Clamp(&left, x1, x2);
+		Clamp(&right, x1, x2);
+		Clamp(&top, y1, y2);
+		Clamp(&bottom, y1, y2);
 	}
 };
 


### PR DESCRIPTION
Clamping a rectangle correctly requires fully clamping all four
coordinates in the general case.

This should fix issue 6923, sort of; at least, it fixes the part where a
rectangle ends up with a nonsensical height after being clamped.