### PR TITLE
Fix 4.0-5689 regression (AR codes, patches)

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -934,9 +934,9 @@ bool RunCode(const ARCode &arcode)
 	return true;
 }
 
-std::vector<ARCode> GetARCodes()
+std::vector<ARCode>* GetARCodes()
 {
-	return arCodes;
+	return &arCodes;
 }
 
 } // namespace ActionReplay

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -36,5 +36,5 @@ void UpdateActiveList();
 void EnableSelfLogging(bool enable);
 const std::vector<std::string> &GetSelfLog();
 bool IsSelfLogging();
-std::vector<ARCode> GetARCodes();
+std::vector<ARCode>* GetARCodes();
 }  // namespace

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Core/PatchEngine.h"
 
 class IniFile;
 

--- a/Source/Core/DolphinWX/ARCodeAddEdit.cpp
+++ b/Source/Core/DolphinWX/ARCodeAddEdit.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
 #include <string>
@@ -28,7 +29,7 @@
 #include "DolphinWX/ARCodeAddEdit.h"
 #include "DolphinWX/WxUtils.h"
 
-CARCodeAddEdit::CARCodeAddEdit(int _selection, const std::vector<ActionReplay::ARCode>& _arCodes, wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& position, const wxSize& size, long style)
+CARCodeAddEdit::CARCodeAddEdit(int _selection, std::vector<ActionReplay::ARCode>* _arCodes, wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& position, const wxSize& size, long style)
 	: wxDialog(parent, id, title, position, size, style)
 	, arCodes(_arCodes)
 	, selection(_selection)
@@ -36,7 +37,7 @@ CARCodeAddEdit::CARCodeAddEdit(int _selection, const std::vector<ActionReplay::A
 	Bind(wxEVT_BUTTON, &CARCodeAddEdit::SaveCheatData, this, wxID_OK);
 
 	ActionReplay::ARCode tempEntries;
-	wxString currentName = _("Insert name here..");
+	wxString currentName = _("Insert name here...");
 
 	if (selection == wxNOT_FOUND)
 	{
@@ -44,8 +45,8 @@ CARCodeAddEdit::CARCodeAddEdit(int _selection, const std::vector<ActionReplay::A
 	}
 	else
 	{
-		currentName = StrToWxStr(arCodes.at(selection).name);
-		tempEntries = arCodes.at(selection);
+		currentName = StrToWxStr(arCodes->at(selection).name);
+		tempEntries = arCodes->at(selection);
 	}
 
 	wxBoxSizer* sEditCheat = new wxBoxSizer(wxVERTICAL);
@@ -57,8 +58,8 @@ CARCodeAddEdit::CARCodeAddEdit(int _selection, const std::vector<ActionReplay::A
 	EditCheatName->SetValue(currentName);
 
 	EntrySelection = new wxSpinButton(this);
-	EntrySelection->SetRange(1, ((int)arCodes.size()) > 0 ? (int)arCodes.size() : 1);
-	EntrySelection->SetValue((int)(arCodes.size() - selection));
+	EntrySelection->SetRange(1, std::max((int)arCodes->size(), 1));
+	EntrySelection->SetValue((int)(arCodes->size() - selection));
 	EntrySelection->Bind(wxEVT_SPIN, &CARCodeAddEdit::ChangeEntry, this);
 
 	EditCheatCode = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(300, 100), wxTE_MULTILINE);
@@ -81,7 +82,7 @@ CARCodeAddEdit::CARCodeAddEdit(int _selection, const std::vector<ActionReplay::A
 
 void CARCodeAddEdit::ChangeEntry(wxSpinEvent& event)
 {
-	ActionReplay::ARCode currentCode = arCodes.at((int)arCodes.size() - event.GetPosition());
+	ActionReplay::ARCode currentCode = arCodes->at((int)arCodes->size() - event.GetPosition());
 	EditCheatName->SetValue(StrToWxStr(currentCode.name));
 	UpdateTextCtrl(currentCode);
 }
@@ -161,13 +162,13 @@ void CARCodeAddEdit::SaveCheatData(wxCommandEvent& WXUNUSED(event))
 		newCheat.ops = decryptedLines;
 		newCheat.active = true;
 
-		arCodes.push_back(newCheat);
+		arCodes->push_back(newCheat);
 	}
 	else
 	{
 		// Update the currently-selected AR cheat code.
-		arCodes.at(selection).name = WxStrToStr(EditCheatName->GetValue());
-		arCodes.at(selection).ops = decryptedLines;
+		arCodes->at(selection).name = WxStrToStr(EditCheatName->GetValue());
+		arCodes->at(selection).ops = decryptedLines;
 	}
 
 	AcceptAndClose();

--- a/Source/Core/DolphinWX/ARCodeAddEdit.h
+++ b/Source/Core/DolphinWX/ARCodeAddEdit.h
@@ -21,7 +21,7 @@ namespace ActionReplay { struct ARCode; }
 class CARCodeAddEdit : public wxDialog
 {
 public:
-	CARCodeAddEdit(int _selection, const std::vector<ActionReplay::ARCode>& _arCodes,
+	CARCodeAddEdit(int _selection, std::vector<ActionReplay::ARCode>* _arCodes,
 		wxWindow* parent,
 		wxWindowID id = wxID_ANY,
 		const wxString& title = _("Edit ActionReplay Code"),
@@ -34,7 +34,7 @@ private:
 	wxSpinButton* EntrySelection;
 	wxTextCtrl* EditCheatCode;
 
-	std::vector<ActionReplay::ARCode> arCodes;
+	std::vector<ActionReplay::ARCode>* arCodes;
 
 	void SaveCheatData(wxCommandEvent& event);
 	void ChangeEntry(wxSpinEvent& event);

--- a/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
+++ b/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
@@ -20,7 +20,7 @@
 // Fired when an ActionReplay code is created.
 wxDEFINE_EVENT(UPDATE_CHEAT_LIST_EVENT, wxCommandEvent);
 
-CreateCodeDialog::CreateCodeDialog(wxWindow* const parent, const u32 address, const std::vector<ActionReplay::ARCode>& _arCodes)
+CreateCodeDialog::CreateCodeDialog(wxWindow* const parent, const u32 address, std::vector<ActionReplay::ARCode>* _arCodes)
 	: wxDialog(parent, wxID_ANY, _("Create AR Code"))
 	, m_code_address(address)
 	, arCodes(_arCodes)
@@ -92,7 +92,7 @@ void CreateCodeDialog::PressOK(wxCommandEvent& ev)
 	{
 	CISOProperties isoprops(SConfig::GetInstance().m_LastFilename, this);
 	// add the code to the isoproperties arcode list
-	arCodes.push_back(new_cheat);
+	arCodes->push_back(new_cheat);
 	// save the gameini
 	isoprops.SaveGameConfig();
 	isoprops.ActionReplayList_Load(); // loads the new arcodes

--- a/Source/Core/DolphinWX/Cheats/CreateCodeDialog.h
+++ b/Source/Core/DolphinWX/Cheats/CreateCodeDialog.h
@@ -19,11 +19,11 @@ wxDECLARE_EVENT(UPDATE_CHEAT_LIST_EVENT, wxCommandEvent);
 class CreateCodeDialog final : public wxDialog
 {
 public:
-	CreateCodeDialog(wxWindow* const parent, const u32 address, const std::vector<ActionReplay::ARCode>& _arCodes);
+	CreateCodeDialog(wxWindow* const parent, const u32 address, std::vector<ActionReplay::ARCode>* _arCodes);
 
 private:
 	const u32 m_code_address;
-	std::vector<ActionReplay::ARCode> arCodes;
+	std::vector<ActionReplay::ARCode>* arCodes;
 
 	wxTextCtrl* m_textctrl_name;
 	wxTextCtrl* m_textctrl_code;

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -1388,13 +1388,13 @@ void CISOProperties::PatchButtonClicked(wxCommandEvent& event)
 	{
 	case ID_EDITPATCH:
 		{
-		CPatchAddEdit dlg(selection, onFrame, this);
+		CPatchAddEdit dlg(selection, &onFrame, this);
 		dlg.ShowModal();
 		}
 		break;
 	case ID_ADDPATCH:
 		{
-		CPatchAddEdit dlg(-1, onFrame, this, 1, _("Add Patch"));
+		CPatchAddEdit dlg(-1, &onFrame, this, 1, _("Add Patch"));
 		if (dlg.ShowModal() == wxID_OK)
 		{
 			Patches->Append(StrToWxStr(onFrame.back().name));
@@ -1468,13 +1468,13 @@ void CISOProperties::ActionReplayButtonClicked(wxCommandEvent& event)
 	{
 	case ID_EDITCHEAT:
 		{
-		CARCodeAddEdit dlg(selection, arCodes, this);
+		CARCodeAddEdit dlg(selection, &arCodes, this);
 		dlg.ShowModal();
 		}
 		break;
 	case ID_ADDCHEAT:
 		{
-			CARCodeAddEdit dlg(-1, arCodes, this, 1, _("Add ActionReplay Code"));
+			CARCodeAddEdit dlg(-1, &arCodes, this, 1, _("Add ActionReplay Code"));
 			if (dlg.ShowModal() == wxID_OK)
 			{
 				Cheats->Append(StrToWxStr(arCodes.back().name));

--- a/Source/Core/DolphinWX/PatchAddEdit.cpp
+++ b/Source/Core/DolphinWX/PatchAddEdit.cpp
@@ -28,12 +28,12 @@
 #include "DolphinWX/PatchAddEdit.h"
 #include "DolphinWX/WxUtils.h"
 
-CPatchAddEdit::CPatchAddEdit(int _selection, const std::vector<PatchEngine::Patch>& _onFrame, wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& position, const wxSize& size, long style)
+CPatchAddEdit::CPatchAddEdit(int _selection, std::vector<PatchEngine::Patch>* _onFrame, wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& position, const wxSize& size, long style)
 	: wxDialog(parent, id, title, position, size, style)
+	, onFrame(_onFrame)
+	, selection(_selection)
 {
-	selection = _selection;
 	CreateGUIControls(selection);
-	onFrame = _onFrame;
 
 	Bind(wxEVT_BUTTON, &CPatchAddEdit::SavePatchData, this, wxID_OK);
 }
@@ -53,8 +53,8 @@ void CPatchAddEdit::CreateGUIControls(int _selection)
 	}
 	else
 	{
-		currentName = StrToWxStr(onFrame.at(_selection).name);
-		tempEntries = onFrame.at(_selection).entries;
+		currentName = StrToWxStr(onFrame->at(_selection).name);
+		tempEntries = onFrame->at(_selection).entries;
 	}
 
 	itCurEntry = tempEntries.begin();
@@ -142,12 +142,12 @@ void CPatchAddEdit::SavePatchData(wxCommandEvent& event)
 		newPatch.entries = tempEntries;
 		newPatch.active = true;
 
-		onFrame.push_back(newPatch);
+		onFrame->push_back(newPatch);
 	}
 	else
 	{
-		onFrame.at(selection).name = WxStrToStr(EditPatchName->GetValue());
-		onFrame.at(selection).entries = tempEntries;
+		onFrame->at(selection).name = WxStrToStr(EditPatchName->GetValue());
+		onFrame->at(selection).entries = tempEntries;
 	}
 
 	AcceptAndClose();

--- a/Source/Core/DolphinWX/PatchAddEdit.h
+++ b/Source/Core/DolphinWX/PatchAddEdit.h
@@ -25,7 +25,7 @@ class wxWindow;
 class CPatchAddEdit : public wxDialog
 {
 public:
-	CPatchAddEdit(int _selection, const std::vector<PatchEngine::Patch>& _onFrame,
+	CPatchAddEdit(int _selection, std::vector<PatchEngine::Patch>* _onFrame,
 		wxWindow* parent,
 		wxWindowID id = wxID_ANY,
 		const wxString& title = _("Edit Patch"),
@@ -43,7 +43,7 @@ private:
 	wxButton* EntryAdd;
 	wxButton* EntryRemove;
 	wxStaticBoxSizer* sbEntry;
-	std::vector<PatchEngine::Patch> onFrame;
+	std::vector<PatchEngine::Patch>* onFrame;
 
 	void CreateGUIControls(int selection);
 	void ChangeEntry(wxSpinEvent& event);


### PR DESCRIPTION
CreateCodeTab, ARCodeAddEdit and PatchAddEdit need to be able to modify arCodes/onFrame. I'm not familiar with this code, so this definitely needs reviewing.