### PR TITLE
Block gpu thread

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -480,11 +480,8 @@ void Idle()
 		//When the FIFO is processing data we must not advance because in this way
 		//the VI will be desynchronized. So, We are waiting until the FIFO finish and
 		//while we process only the events required by the FIFO.
-		while (g_video_backend->Video_IsPossibleWaitingSetDrawDone())
-		{
-			ProcessFifoWaitEvents();
-			Common::YieldCPU();
-		}
+		ProcessFifoWaitEvents();
+		g_video_backend->Video_Sync();
 	}
 
 	idledCycles += DowncountToCycles(PowerPC::ppcState.downcount);

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -199,6 +199,9 @@ static void PatchEngineCallback(u64 userdata, int cyclesLate)
 
 static void ThrottleCallback(u64 last_time, int cyclesLate)
 {
+	// Allow the GPU thread to sleep. Setting this flag here limits the wakeups to 1 kHz.
+	CommandProcessor::s_gpuMaySleep.Set();
+
 	u32 time = Common::Timer::GetTimeMs();
 
 	int diff = (u32)last_time - time;

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -360,11 +360,6 @@ void VideoSoftware::Video_GatherPipeBursted()
 	SWCommandProcessor::GatherPipeBursted();
 }
 
-bool VideoSoftware::Video_IsPossibleWaitingSetDrawDone()
-{
-	return false;
-}
-
 void VideoSoftware::RegisterCPMMIO(MMIO::Mapping* mmio, u32 base)
 {
 	SWCommandProcessor::RegisterMMIO(mmio, base);

--- a/Source/Core/VideoBackends/Software/VideoBackend.h
+++ b/Source/Core/VideoBackends/Software/VideoBackend.h
@@ -45,7 +45,7 @@ class VideoSoftware : public VideoBackend
 	void Video_SetRendering(bool bEnabled) override;
 
 	void Video_GatherPipeBursted() override;
-	bool Video_IsPossibleWaitingSetDrawDone() override;
+	void Video_Sync() override {}
 
 	void RegisterCPMMIO(MMIO::Mapping* mmio, u32 base) override;
 

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -1,4 +1,5 @@
 #include "VideoCommon/AsyncRequests.h"
+#include "VideoCommon/Fifo.h"
 #include "VideoCommon/RenderBase.h"
 
 AsyncRequests AsyncRequests::s_singleton;
@@ -49,6 +50,7 @@ void AsyncRequests::PushEvent(const AsyncRequests::Event& event, bool blocking)
 
 	m_queue.push(event);
 
+	RunGpu();
 	if (blocking)
 	{
 		m_cond.wait(lock, [this]{return m_queue.empty();});

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -322,10 +322,7 @@ void GatherPipeBursted()
 				ProcessFifoAllDistance();
 			}
 		}
-		else
-		{
-			RunGpu();
-		}
+		RunGpu();
 		return;
 	}
 
@@ -375,6 +372,7 @@ void UpdateInterrupts(u64 userdata)
 	}
 	CoreTiming::ForceExceptionCheck(0);
 	interruptWaiting = false;
+	RunGpu();
 }
 
 void UpdateInterruptsFromVideoBackend(u64 userdata)
@@ -551,5 +549,7 @@ void Update()
 
 	if (fifo.isGpuReadingData)
 		Common::AtomicAdd(VITicks, SystemTimers::GetTicksPerSecond() / 10000);
+
+	RunGpu();
 }
 } // end of namespace CommandProcessor

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -45,6 +45,8 @@ volatile bool interruptWaiting= false;
 volatile bool interruptTokenWaiting = false;
 volatile bool interruptFinishWaiting = false;
 
+Common::Flag s_gpuMaySleep;
+
 volatile u32 VITicks = CommandProcessor::m_cpClockOrigin;
 
 static bool IsOnThread()

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "Common/Flag.h"
 #include "VideoCommon/VideoBackendBase.h"
 
 class PointerWrap;
@@ -21,6 +22,7 @@ extern volatile bool interruptSet;
 extern volatile bool interruptWaiting;
 extern volatile bool interruptTokenWaiting;
 extern volatile bool interruptFinishWaiting;
+extern Common::Flag s_gpuMaySleep;
 
 // internal hardware addresses
 enum

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -17,7 +17,6 @@ namespace CommandProcessor
 
 extern SCPFifoStruct fifo; //This one is shared between gfx thread and emulator thread.
 
-extern volatile bool isPossibleWaitingSetDrawDone; //This one is used for sync gfx thread and emulator thread.
 extern volatile bool interruptSet;
 extern volatile bool interruptWaiting;
 extern volatile bool interruptTokenWaiting;
@@ -145,7 +144,6 @@ void UpdateInterruptsFromVideoBackend(u64 userdata);
 void SetCpClearRegister();
 void SetCpControlRegister();
 void SetCpStatusRegister();
-void ProcessFifoAllDistance();
 void ProcessFifoEvents();
 
 void Update();

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -369,9 +369,13 @@ void RunGpuLoop()
 		{
 			if (s_gpu_is_running.IsSet())
 			{
-				// reset the atomic flag. But as the CPU thread might have pushed some new data, we have to rerun the GPU loop
-				s_gpu_is_pending.Set();
-				s_gpu_is_running.Clear();
+				if (CommandProcessor::s_gpuMaySleep.IsSet())
+				{
+					// Reset the atomic flag. But as the CPU thread might have pushed some new data, we have to rerun the GPU loop
+					s_gpu_is_pending.Set();
+					s_gpu_is_running.Clear();
+					CommandProcessor::s_gpuMaySleep.Clear();
+				}
 			}
 			else
 			{
@@ -403,6 +407,7 @@ void FlushGpu()
 
 	while (s_gpu_is_running.IsSet() || s_gpu_is_pending.IsSet())
 	{
+		CommandProcessor::s_gpuMaySleep.Set();
 		s_gpu_done_event.Wait();
 	}
 }

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -41,6 +41,7 @@ void SyncGPU(SyncGPUReason reason, bool may_move_read_ptr = true);
 void PushFifoAuxBuffer(void* ptr, size_t size);
 void* PopFifoAuxBuffer(size_t size);
 
+void FlushGpu();
 void RunGpu();
 void RunGpuLoop();
 void ExitGpuLoop();

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -233,9 +233,9 @@ void VideoBackendHardware::Video_GatherPipeBursted()
 	CommandProcessor::GatherPipeBursted();
 }
 
-bool VideoBackendHardware::Video_IsPossibleWaitingSetDrawDone()
+void VideoBackendHardware::Video_Sync()
 {
-	return CommandProcessor::isPossibleWaitingSetDrawDone;
+	FlushGpu();
 }
 
 void VideoBackendHardware::RegisterCPMMIO(MMIO::Mapping* mmio, u32 base)

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -287,7 +287,6 @@ void SetFinish_OnMainThread(u64 userdata, int cyclesLate)
 	Common::AtomicStore(*(volatile u32*)&g_bSignalFinishInterrupt, 1);
 	UpdateInterrupts();
 	CommandProcessor::interruptFinishWaiting = false;
-	CommandProcessor::isPossibleWaitingSetDrawDone = false;
 }
 
 // SetToken

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -99,7 +99,7 @@ public:
 
 	virtual void Video_GatherPipeBursted() = 0;
 
-	virtual bool Video_IsPossibleWaitingSetDrawDone() = 0;
+	virtual void Video_Sync() = 0;
 
 	// Registers MMIO handlers for the CommandProcessor registers.
 	virtual void RegisterCPMMIO(MMIO::Mapping* mmio, u32 base) = 0;
@@ -148,7 +148,7 @@ class VideoBackendHardware : public VideoBackend
 
 	void Video_GatherPipeBursted() override;
 
-	bool Video_IsPossibleWaitingSetDrawDone() override;
+	void Video_Sync() override;
 
 	void RegisterCPMMIO(MMIO::Mapping* mmio, u32 base) override;
 


### PR DESCRIPTION
This PR tries to use Common::Event for CPU <-> GPU synchronization. It tries to get the same speed without using busy loops all over the code. So it should run much faster on thermal bottlenecked devices and maybe dual core CPUs.