### PR TITLE
VertexLoaderX64: pre-allocate code space

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -27,9 +27,9 @@ u8* ARM64XEmitter::GetWritableCodePtr()
 	return m_code;
 }
 
-void ARM64XEmitter::ReserveCodeSpace(u32 bytes)
+void ARM64XEmitter::ReserveCodeSpace(size_t bytes)
 {
-	for (u32 i = 0; i < bytes/4; i++)
+	for (size_t i = 0; i < bytes/4; i++)
 		BRK(0);
 }
 

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -362,7 +362,7 @@ public:
 	}
 
 	void SetCodePtr(u8* ptr);
-	void ReserveCodeSpace(u32 bytes);
+	void ReserveCodeSpace(size_t bytes);
 	const u8* AlignCode16();
 	const u8* AlignCodePage();
 	const u8* GetCodePtr() const;

--- a/Source/Core/Common/ArmEmitter.cpp
+++ b/Source/Core/Common/ArmEmitter.cpp
@@ -319,9 +319,9 @@ u8 *ARMXEmitter::GetWritableCodePtr()
 	return code;
 }
 
-void ARMXEmitter::ReserveCodeSpace(u32 bytes)
+void ARMXEmitter::ReserveCodeSpace(size_t bytes)
 {
-	for (u32 i = 0; i < bytes/4; i++)
+	for (size_t i = 0; i < bytes/4; i++)
 		Write32(0xE1200070); //bkpt 0
 }
 

--- a/Source/Core/Common/ArmEmitter.h
+++ b/Source/Core/Common/ArmEmitter.h
@@ -360,7 +360,7 @@ public:
 	virtual ~ARMXEmitter() {}
 
 	void SetCodePtr(u8 *ptr);
-	void ReserveCodeSpace(u32 bytes);
+	void ReserveCodeSpace(size_t bytes);
 	const u8 *AlignCode16();
 	const u8 *AlignCodePage();
 	const u8 *GetCodePtr() const;

--- a/Source/Core/Common/CodeBlock.h
+++ b/Source/Core/Common/CodeBlock.h
@@ -28,7 +28,7 @@ public:
 	virtual ~CodeBlock() { if (region) FreeCodeSpace(); }
 
 	// Call this before you generate any code.
-	void AllocCodeSpace(int size)
+	void AllocCodeSpace(size_t size)
 	{
 		region_size = size;
 		region = (u8*)AllocateExecutableMemory(region_size);

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -91,10 +91,10 @@ u8 *XEmitter::GetWritableCodePtr()
 	return code;
 }
 
-void XEmitter::ReserveCodeSpace(int bytes)
+void XEmitter::ReserveCodeSpace(size_t bytes)
 {
-	for (int i = 0; i < bytes; i++)
-		*code++ = 0xCC;
+	for (size_t i = 0; i < bytes; i++)
+		INT3();
 }
 
 const u8 *XEmitter::AlignCode4()

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -320,7 +320,7 @@ public:
 	void WriteSIB(int scale, int index, int base);
 
 	void SetCodePtr(u8 *ptr);
-	void ReserveCodeSpace(int bytes);
+	void ReserveCodeSpace(size_t bytes);
 	const u8 *AlignCode4();
 	const u8 *AlignCode16();
 	const u8 *AlignCodePage();

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -190,6 +190,13 @@ private:
 	std::vector<u8> buffer_a, buffer_b;
 };
 
+void VertexLoaderBase::Initialize()
+{
+#ifdef _M_X86_64
+	VertexLoaderX64::Initialize();
+#endif
+}
+
 VertexLoaderBase* VertexLoaderBase::CreateVertexLoader(const TVtxDesc& vtx_desc, const VAT& vtx_attr)
 {
 	VertexLoaderBase* loader;

--- a/Source/Core/VideoCommon/VertexLoaderBase.h
+++ b/Source/Core/VideoCommon/VertexLoaderBase.h
@@ -71,6 +71,7 @@ template <> struct hash<VertexLoaderUID>
 class VertexLoaderBase
 {
 public:
+	static void Initialize();
 	static VertexLoaderBase* CreateVertexLoader(const TVtxDesc &vtx_desc, const VAT &vtx_attr);
 	virtual ~VertexLoaderBase() {}
 

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -44,6 +44,7 @@ void Init()
 		map_entry = nullptr;
 	RecomputeCachedArraybases();
 	SETSTAT(stats.numVertexLoaders, 0);
+	VertexLoaderBase::Initialize();
 }
 
 void Shutdown()

--- a/Source/Core/VideoCommon/VertexLoaderX64.h
+++ b/Source/Core/VideoCommon/VertexLoaderX64.h
@@ -1,9 +1,10 @@
 #include "Common/x64Emitter.h"
 #include "VideoCommon/VertexLoaderBase.h"
 
-class VertexLoaderX64 : public VertexLoaderBase, public Gen::X64CodeBlock
+class VertexLoaderX64 : public VertexLoaderBase, public Gen::XEmitter
 {
 public:
+	static void Initialize();
 	VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att);
 
 protected:
@@ -12,11 +13,13 @@ protected:
 	int RunVertices(DataReader src, DataReader dst, int count, int primitive) override;
 
 private:
-	u32 m_src_ofs = 0;
-	u32 m_dst_ofs = 0;
-	Gen::FixupBranch m_skip_vertex;
 	Gen::OpArg GetVertexAddr(int array, u64 attribute);
 	int ReadVertex(Gen::OpArg data, u64 attribute, int format, int count_in, int count_out, bool dequantize, u8 scaling_exponent, AttributeFormat* native_format);
 	void ReadColor(Gen::OpArg data, u64 attribute, int format);
 	void GenerateVertexLoader();
+
+	const u8* region = nullptr;
+	u32 m_src_ofs = 0;
+	u32 m_dst_ofs = 0;
+	Gen::FixupBranch m_skip_vertex;
 };

--- a/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
+++ b/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
@@ -38,6 +38,7 @@ protected:
 
 	void SetUp() override
 	{
+		VertexLoaderBase::Initialize();
 		memset(&input_memory[0], 0, sizeof(input_memory));
 		memset(&output_memory[0], 0, sizeof(input_memory));
 


### PR DESCRIPTION
Should partially fix [issue 8180](https://code.google.com/p/dolphin-emu/issues/detail?id=8180).

This is just to show what I had in mind. The code should be moved elsewhere before merging.

~~TODO: ARM.~~