### PR TITLE
Fix typo in usage of IsOptimizableMMIOAccess.

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -312,7 +312,7 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg & opAddress,
 		if (accessSize != 64 && mmioAddress)
 		{
 			MMIOLoadToReg(Memory::mmio_mapping, reg_value, registersInUse,
-				            address, accessSize, signExtend);
+			              mmioAddress, accessSize, signExtend);
 			return;
 		}
 


### PR DESCRIPTION
Fixes [issue 8326](https://code.google.com/p/dolphin-emu/issues/detail?id=8326).