### PR TITLE
Disable FakeVMem in Wii mode.

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -38,16 +38,8 @@
 
 namespace Memory
 {
-
-// =================================
-// LOCAL SETTINGS
-// ----------------
-
-// Enable the Translation Lookaside Buffer functions.
+// (See comment below describing memory map.)
 bool bFakeVMEM = false;
-static bool bMMU = false;
-// ==============
-
 
 // =================================
 // Init() declarations
@@ -106,10 +98,10 @@ bool IsInitialized()
 // Dolphin allocates memory to represent four regions:
 // - 32MB RAM (actually 24MB on hardware), available on Gamecube and Wii
 // - 64MB "EXRAM", RAM only available on Wii
-// - 32MB FakeVMem, allocated when MMU support is turned off. This is used
-//   to approximate the behavior of a common library which pages memory to
-//   and from the DSP's dedicated RAM, which isn't directly addressable on
-//   GameCube.
+// - 32MB FakeVMem, allocated in GameCube mode when MMU support is turned off.
+//   This is used to approximate the behavior of a common library which pages
+//   memory to and from the DSP's dedicated RAM. The DSP's RAM (ARAM) isn't
+//   directly addressable on GameCube.
 // - 256KB Locked L1, to represent cache lines allocated out of the L1 data
 //   cache in Locked L1 mode.  Dolphin does not emulate this hardware feature
 //   accurately; it just pretends there is extra memory at 0xE0000000.
@@ -176,11 +168,12 @@ static const int num_views = sizeof(views) / sizeof(MemoryView);
 void Init()
 {
 	bool wii = SConfig::GetInstance().m_LocalCoreStartupParameter.bWii;
-	bMMU = SConfig::GetInstance().m_LocalCoreStartupParameter.bMMU;
+	bool bMMU = SConfig::GetInstance().m_LocalCoreStartupParameter.bMMU;
 #ifndef _ARCH_32
-	// The fake VMEM hack's address space is above the memory space that we allocate on 32bit targets
-	// Disable it entirely on 32bit targets.
-	bFakeVMEM = !bMMU;
+	// If MMU is turned off in GameCube mode, turn on fake VMEM hack.
+	// The fake VMEM hack's address space is above the memory space that we
+	// allocate on 32bit targets, so disable it there.
+	bFakeVMEM = !wii && !bMMU;
 #endif
 
 	u32 flags = 0;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -64,7 +64,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 41;
+static const u32 STATE_VERSION = 42; // Last changed in PR2193
 
 enum
 {


### PR DESCRIPTION
I'm assuming nobody thought of this when FakeVMem was turned on by
default; FakeVMem doesn't make any sense in Wii mode.