### PR TITLE
Don't construct NANDContentLoader classes before Main.cpp runs

### DIFF
--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -25,9 +25,6 @@
 
 namespace DiscIO
 {
-CSharedContent CSharedContent::m_Instance;
-cUIDsys cUIDsys::m_Instance;
-
 
 CSharedContent::CSharedContent()
 {
@@ -304,9 +301,6 @@ DiscIO::IVolume::ECountry CNANDContentLoader::GetCountry() const
 
 	return CountrySwitch(m_Country);
 }
-
-
-CNANDContentManager CNANDContentManager::m_Instance;
 
 
 CNANDContentManager::~CNANDContentManager()

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -64,11 +64,11 @@ public:
 };
 
 
-// we open the NAND Content files to often... lets cache them
+// we open the NAND Content files too often... let's cache them
 class CNANDContentManager
 {
 public:
-	static CNANDContentManager& Access() { return m_Instance; }
+	static CNANDContentManager& Access() { static CNANDContentManager instance; return instance; }
 	u64 Install_WiiWAD(std::string &fileName);
 
 	const INANDContentLoader& GetNANDLoader(const std::string& _rName, bool forceReload = false);
@@ -79,7 +79,8 @@ private:
 	CNANDContentManager() {}
 	~CNANDContentManager();
 
-	static CNANDContentManager m_Instance;
+	CNANDContentManager(CNANDContentManager const&) = delete;
+	void operator=(CNANDContentManager const&) = delete;
 
 	typedef std::map<std::string, INANDContentLoader*> CNANDContentMap;
 	CNANDContentMap m_Map;
@@ -88,7 +89,7 @@ private:
 class CSharedContent
 {
 public:
-	static CSharedContent& AccessInstance() { return m_Instance; }
+	static CSharedContent& AccessInstance() { static CSharedContent instance; return instance; }
 
 	std::string GetFilenameFromSHA1(const u8* _pHash);
 	std::string AddSharedContent(const u8* _pHash);
@@ -97,6 +98,9 @@ public:
 private:
 	CSharedContent();
 	virtual ~CSharedContent();
+
+	CSharedContent(CSharedContent const&) = delete;
+	void operator=(CSharedContent const&) = delete;
 
 #pragma pack(push,1)
 	struct SElement
@@ -109,13 +113,12 @@ private:
 	u32 m_lastID;
 	std::string m_contentMap;
 	std::vector<SElement> m_Elements;
-	static CSharedContent m_Instance;
 };
 
 class cUIDsys
 {
 public:
-	static cUIDsys& AccessInstance() { return m_Instance; }
+	static cUIDsys& AccessInstance() { static cUIDsys instance; return instance; }
 
 	u32 GetUIDFromTitle(u64 _Title);
 	void AddTitle(u64 _Title);
@@ -125,6 +128,9 @@ public:
 private:
 	cUIDsys();
 	virtual ~cUIDsys();
+
+	cUIDsys(cUIDsys const&) = delete;
+	void operator=(cUIDsys const&) = delete;
 
 #pragma pack(push,1)
 	struct SElement
@@ -137,7 +143,6 @@ private:
 	u32 m_lastUID;
 	std::string m_uidSys;
 	std::vector<SElement> m_Elements;
-	static cUIDsys m_Instance;
 };
 
 }


### PR DESCRIPTION
The cUIDsys constructor writes to &lt;Wii user path&gt;/sys/uid.sys. This must not be done before Main.cpp sets the correct user paths.