### PR TITLE
Fix netplay threading issues

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SRCS BreakPoints.cpp
          CDUtils.cpp
          ColorUtil.cpp
+         ENetUtil.cpp
          FileSearch.cpp
          FileUtil.cpp
          GekkoDisassembler.cpp

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -51,6 +51,7 @@
     <ClInclude Include="CommonTypes.h" />
     <ClInclude Include="CPUDetect.h" />
     <ClInclude Include="DebugInterface.h" />
+    <ClInclude Include="ENetUtil.h" />
     <ClInclude Include="Event.h" />
     <ClInclude Include="FifoQueue.h" />
     <ClInclude Include="FileSearch.h" />
@@ -94,6 +95,7 @@
     <ClCompile Include="BreakPoints.cpp" />
     <ClCompile Include="CDUtils.cpp" />
     <ClCompile Include="ColorUtil.cpp" />
+    <ClCompile Include="ENetUtil.cpp" />
     <ClCompile Include="FileSearch.cpp" />
     <ClCompile Include="FileUtil.cpp" />
     <ClCompile Include="GekkoDisassembler.cpp" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -25,6 +25,7 @@
     <ClInclude Include="CommonTypes.h" />
     <ClInclude Include="CPUDetect.h" />
     <ClInclude Include="DebugInterface.h" />
+    <ClInclude Include="ENetUtil.h" />
     <ClInclude Include="FifoQueue.h" />
     <ClInclude Include="FileSearch.h" />
     <ClInclude Include="FileUtil.h" />
@@ -78,6 +79,7 @@
     <ClCompile Include="BreakPoints.cpp" />
     <ClCompile Include="CDUtils.cpp" />
     <ClCompile Include="ColorUtil.cpp" />
+    <ClCompile Include="ENetUtil.cpp" />
     <ClCompile Include="FileSearch.cpp" />
     <ClCompile Include="FileUtil.cpp" />
     <ClCompile Include="Hash.cpp" />

--- a/Source/Core/Common/ENetUtil.cpp
+++ b/Source/Core/Common/ENetUtil.cpp
@@ -1,0 +1,28 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+
+#include "ENetUtil.h"
+
+namespace ENetUtil
+{
+
+void WakeupThread(ENetHost* host)
+{
+	// Send ourselves a spurious message.  This is hackier than it should be.
+	// comex reported this as https://github.com/lsalzman/enet/issues/23, so
+	// hopefully there will be a better way to do it in the future.
+	ENetAddress address;
+	if (host->address.port != 0)
+		address.port = host->address.port;
+	else
+		enet_socket_get_address(host->socket, &address);
+	address.host = 0x0100007f; // localhost
+	u8 byte = 0;
+	ENetBuffer buf;
+	buf.data = &byte;
+	buf.dataLength = 1;
+	enet_socket_send(host->socket, &address, &buf, 1);
+}
+
+}

--- a/Source/Core/Common/ENetUtil.cpp
+++ b/Source/Core/Common/ENetUtil.cpp
@@ -25,4 +25,16 @@ void WakeupThread(ENetHost* host)
 	enet_socket_send(host->socket, &address, &buf, 1);
 }
 
+int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event)
+{
+	// wakeup packet received
+	if (host->receivedDataLength == 1 && host->receivedData[0] == 0)
+	{
+		event->type = (ENetEventType) 42;
+		return 1;
+	}
+	return 0;
+}
+
+
 }

--- a/Source/Core/Common/ENetUtil.h
+++ b/Source/Core/Common/ENetUtil.h
@@ -1,0 +1,15 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2
+// Refer to the license.txt file included.
+//
+#pragma once
+
+#include <enet/enet.h>
+#include "Common.h"
+
+namespace ENetUtil
+{
+
+void WakeupThread(ENetHost* host);
+
+}

--- a/Source/Core/Common/ENetUtil.h
+++ b/Source/Core/Common/ENetUtil.h
@@ -11,5 +11,6 @@ namespace ENetUtil
 {
 
 void WakeupThread(ENetHost* host);
+int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event);
 
 }

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -301,7 +301,8 @@ void TraversalClient::Reset()
 int ENET_CALLBACK TraversalClient::InterceptCallback(ENetHost* host, ENetEvent* event)
 {
 	auto traversalClient = g_TraversalClient.get();
-	if (traversalClient->TestPacket(host->receivedData, host->receivedDataLength, &host->receivedAddress))
+	if (traversalClient->TestPacket(host->receivedData, host->receivedDataLength, &host->receivedAddress)
+			|| (host->receivedDataLength == 1 && host->receivedData[0] == 0))
 	{
 		event->type = (ENetEventType)42;
 		return 1;

--- a/Source/Core/Common/TraversalClient.cpp
+++ b/Source/Core/Common/TraversalClient.cpp
@@ -7,9 +7,10 @@ static void GetRandomishBytes(u8* buf, size_t size)
 {
 	// We don't need high quality random numbers (which might not be available),
 	// just non-repeating numbers!
-	srand(enet_time_get());
+	static std::mt19937 prng(enet_time_get());
+	static std::uniform_int_distribution<unsigned int> u8_distribution(0, 255);
 	for (size_t i = 0; i < size; i++)
-		buf[i] = rand() & 0xff;
+		buf[i] = u8_distribution(prng);
 }
 
 TraversalClient::TraversalClient(ENetHost* netHost, const std::string& server, const u16 port)

--- a/Source/Core/Common/TraversalClient.h
+++ b/Source/Core/Common/TraversalClient.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <random>
 #include <enet/enet.h>
 #include "Common/Common.h"
 #include "Common/Thread.h"

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -485,25 +485,7 @@ void NetPlayClient::RunOnThread(std::function<void()> func)
 		std::lock_guard<std::recursive_mutex> lkq(m_crit.run_queue_write);
 		m_run_queue.Push(func);
 	}
-	WakeupThread(m_client);
-}
-
-void NetPlayClient::WakeupThread(ENetHost* host)
-{
-	// Send ourselves a spurious message.  This is hackier than it should be.
-	// comex reported this as https://github.com/lsalzman/enet/issues/23, so
-	// hopefully there will be a better way to do it in the future.
-	ENetAddress address;
-	if (host->address.port != 0)
-		address.port = host->address.port;
-	else
-		enet_socket_get_address(host->socket, &address);
-	address.host = 0x0100007f; // localhost
-	u8 byte = 0;
-	ENetBuffer buf;
-	buf.data = &byte;
-	buf.dataLength = 1;
-	enet_socket_send(host->socket, &address, &buf, 1);
+	ENetUtil::WakeupThread(m_client);
 }
 
 // called from ---NETPLAY--- thread

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -103,7 +103,10 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
 		if (net > 0 && netEvent.type == ENET_EVENT_TYPE_CONNECT)
 		{
 			if (Connect())
+			{
+				m_client->intercept = ENetUtil::InterceptCallback;
 				m_thread = std::thread(&NetPlayClient::ThreadFunc, this);
+			}
 		}
 		else
 		{
@@ -497,7 +500,7 @@ void NetPlayClient::ThreadFunc()
 		int net;
 		if (m_traversal_client)
 			m_traversal_client->HandleResends();
-		net = enet_host_service(m_client, &netEvent, 4);
+		net = enet_host_service(m_client, &netEvent, 250);
 		while (!m_async_queue.Empty())
 		{
 			Send(*(m_async_queue.Front().get()));

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -47,6 +47,8 @@ class NetPlayClient : public TraversalClientClient
 {
 public:
 	void ThreadFunc();
+	void RunOnThread(std::function<void()> func);
+	void WakeupThread(ENetHost* host);
 
 	NetPlayClient(const std::string& address, const u16 port, NetPlayUI* dialog, const std::string& name, bool traversal, std::string centralServer, u16 centralPort);
 	~NetPlayClient();
@@ -92,8 +94,11 @@ protected:
 	{
 		std::recursive_mutex game;
 		// lock order
-		std::recursive_mutex players, send;
+		std::recursive_mutex players;
+		std::recursive_mutex run_queue_write;
 	} m_crit;
+
+	Common::FifoQueue<std::function<void()>, false> m_run_queue;
 
 	Common::FifoQueue<GCPadStatus> m_pad_buffer[4];
 	Common::FifoQueue<NetWiimote>  m_wiimote_buffer[4];

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -48,7 +48,7 @@ class NetPlayClient : public TraversalClientClient
 {
 public:
 	void ThreadFunc();
-	void RunOnThread(std::function<void()> func);
+	void SendAsync(sf::Packet* packet);
 
 	NetPlayClient(const std::string& address, const u16 port, NetPlayUI* dialog, const std::string& name, bool traversal, std::string centralServer, u16 centralPort);
 	~NetPlayClient();
@@ -95,10 +95,10 @@ protected:
 		std::recursive_mutex game;
 		// lock order
 		std::recursive_mutex players;
-		std::recursive_mutex run_queue_write;
+		std::recursive_mutex async_queue_write;
 	} m_crit;
 
-	Common::FifoQueue<std::function<void()>, false> m_run_queue;
+	Common::FifoQueue<std::unique_ptr<sf::Packet>, false> m_async_queue;
 
 	Common::FifoQueue<GCPadStatus> m_pad_buffer[4];
 	Common::FifoQueue<NetWiimote>  m_wiimote_buffer[4];

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <SFML/Network/Packet.hpp>
 #include "Common/CommonTypes.h"
+#include "Common/ENetUtil.h"
 #include "Common/FifoQueue.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"
@@ -48,7 +49,6 @@ class NetPlayClient : public TraversalClientClient
 public:
 	void ThreadFunc();
 	void RunOnThread(std::function<void()> func);
-	void WakeupThread(ENetHost* host);
 
 	NetPlayClient(const std::string& address, const u16 port, NetPlayUI* dialog, const std::string& name, bool traversal, std::string centralServer, u16 centralPort);
 	~NetPlayClient();

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -91,6 +91,8 @@ NetPlayServer::NetPlayServer(const u16 port, bool traversal, std::string central
 		serverAddr.host = ENET_HOST_ANY;
 		serverAddr.port = port;
 		m_server = enet_host_create(&serverAddr, 10, 3, 0, 0);
+		if (m_server != nullptr)
+			m_server->intercept = ENetUtil::InterceptCallback;
 	}
 	if (m_server != nullptr)
 	{

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -454,25 +454,7 @@ void NetPlayServer::RunOnThread(std::function<void()> func)
 		std::lock_guard<std::recursive_mutex> lkq(m_crit.run_queue_write);
 		m_run_queue.Push(func);
 	}
-	WakeupThread(m_server);
-}
-
-void NetPlayServer::WakeupThread(ENetHost* host)
-{
-	// Send ourselves a spurious message.  This is hackier than it should be.
-	// comex reported this as https://github.com/lsalzman/enet/issues/23, so
-	// hopefully there will be a better way to do it in the future.
-	ENetAddress address;
-	if (host->address.port != 0)
-		address.port = host->address.port;
-	else
-		enet_socket_get_address(host->socket, &address);
-	address.host = 0x0100007f; // localhost
-	u8 byte = 0;
-	ENetBuffer buf;
-	buf.data = &byte;
-	buf.dataLength = 1;
-	enet_socket_send(host->socket, &address, &buf, 1);
+	ENetUtil::WakeupThread(m_server);
 }
 
 // called from ---NETPLAY--- thread

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <unordered_set>
 #include <SFML/Network/Packet.hpp>
+#include "Common/ENetUtil.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"
 #include "Common/TraversalClient.h"
@@ -21,7 +22,6 @@ class NetPlayServer : public TraversalClientClient
 public:
 	void ThreadFunc();
 	void RunOnThread(std::function<void()> func);
-	void WakeupThread(ENetHost* host);
 
 	NetPlayServer(const u16 port, bool traversal, std::string centralServer, u16 centralPort);
 	~NetPlayServer();

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -20,6 +20,8 @@ class NetPlayServer : public TraversalClientClient
 {
 public:
 	void ThreadFunc();
+	void RunOnThread(std::function<void()> func);
+	void WakeupThread(ENetHost* host);
 
 	NetPlayServer(const u16 port, bool traversal, std::string centralServer, u16 centralPort);
 	~NetPlayServer();
@@ -101,11 +103,13 @@ private:
 	{
 		std::recursive_mutex game;
 		// lock order
-		std::recursive_mutex players, send;
+		std::recursive_mutex players;
+		std::recursive_mutex run_queue_write;
 	} m_crit;
 
 	std::string m_selected_game;
 	std::thread m_thread;
+	Common::FifoQueue<std::function<void()>, false> m_run_queue;
 
 	ENetHost*        m_server;
 	TraversalClient* m_traversal_client;

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -21,7 +21,7 @@ class NetPlayServer : public TraversalClientClient
 {
 public:
 	void ThreadFunc();
-	void RunOnThread(std::function<void()> func);
+	void SendAsyncToClients(sf::Packet* packet);
 
 	NetPlayServer(const u16 port, bool traversal, std::string centralServer, u16 centralPort);
 	~NetPlayServer();
@@ -104,12 +104,12 @@ private:
 		std::recursive_mutex game;
 		// lock order
 		std::recursive_mutex players;
-		std::recursive_mutex run_queue_write;
+		std::recursive_mutex async_queue_write;
 	} m_crit;
 
 	std::string m_selected_game;
 	std::thread m_thread;
-	Common::FifoQueue<std::function<void()>, false> m_run_queue;
+	Common::FifoQueue<std::unique_ptr<sf::Packet>, false> m_async_queue;
 
 	ENetHost*        m_server;
 	TraversalClient* m_traversal_client;

--- a/Source/Core/DolphinWX/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetWindow.cpp
@@ -360,10 +360,10 @@ void NetPlaySetupDiag::OnHost(wxCommandEvent&)
 	unsigned long centralPort = 0;
 	m_traversal_port->GetValue().ToULong(&centralPort);
 	netplay_server = new NetPlayServer(u16(port), trav, WxStrToStr(m_traversal_server->GetValue()), u16(centralPort));
-	netplay_server->ChangeGame(game);
-	netplay_server->AdjustPadBufferSize(INITIAL_PAD_BUFFER_SIZE);
 	if (netplay_server->is_connected)
 	{
+		netplay_server->ChangeGame(game);
+		netplay_server->AdjustPadBufferSize(INITIAL_PAD_BUFFER_SIZE);
 #ifdef USE_UPNP
 		if (m_upnp_chk->GetValue())
 			netplay_server->TryPortmapping(port);


### PR DESCRIPTION
Fixes [issue 8311](https://code.google.com/p/dolphin-emu/issues/detail?id=8311) (which is responsible for a massive drop in performance in netplay since “expected behavior” is essentially a race condition which may or may not happen depending of what your OS decideds) by backporting more of comex's dc-netplay stuff to remove the send lock and run all network-related events in the network event loop.

- [x] backport the hack to wake up enet_host_service from another thread and run callbacks after that
- [x] remove locking around it
- [x] don't mess with lambdas & RunOnThread, use a SendAsync method or something, which will queue a pointer to a sf::Packet instead (an trigger a send)
- [x] check the usefulness of all locks
- [x] make sure traversal still works (at least, not more broken than master)
- [x] make sure upnp still works too

JMC indicated that this brought performance back to normal when testing. As master isn't usable on linux (possibly OSX too), I wasn't able to infer normal behavior. AFAIK, this shouldn't affect traversal or upnp, as the traversal or upnp code takes effect **before** the networking thread is even started.