### PR TITLE
OpenGL: use ClampUL instead of ClampLL where appropriate.

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -369,7 +369,7 @@ GLuint FramebufferManager::GetEFBColorTexture(const EFBRectangle& sourceRc)
 		// required.
 
 		TargetRectangle targetRc = g_renderer->ConvertEFBRectangle(sourceRc);
-		targetRc.ClampLL(0, 0, m_targetWidth, m_targetHeight);
+		targetRc.ClampUL(0, 0, m_targetWidth, m_targetHeight);
 
 		// Resolve.
 		for (unsigned int i = 0; i < m_EFBLayers; i++)
@@ -401,7 +401,7 @@ GLuint FramebufferManager::GetEFBDepthTexture(const EFBRectangle& sourceRc)
 		// Transfer the EFB to a resolved texture.
 
 		TargetRectangle targetRc = g_renderer->ConvertEFBRectangle(sourceRc);
-		targetRc.ClampLL(0, 0, m_targetWidth, m_targetHeight);
+		targetRc.ClampUL(0, 0, m_targetWidth, m_targetHeight);
 
 		// Resolve.
 		for (unsigned int i = 0; i < m_EFBLayers; i++)


### PR DESCRIPTION
[Issue 8343](http://code.google.com/p/dolphin-emu/issues/detail?id=8343)