### PR TITLE
Try to detect when discs need to be changed

### DIFF
--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -22,6 +22,8 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/PowerPC/PowerPC.h"
 
+#include "VideoCommon/OnScreenDisplay.h"
+
 static const double PI = 3.14159265358979323846264338328;
 
 // Rate the drive can transfer data to main memory, given the data
@@ -1189,6 +1191,8 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 	case DVDLowStopMotor:
 		INFO_LOG(DVDINTERFACE, "DVDLowStopMotor %s %s",
 		         command_1 ? "eject" : "", command_2 ? "kill!" : "");
+
+		OSD::AddMessage("The disc is ready to be changed. You can use the Change Disc option in the game list.", 5000);
 
 		if (command_1 && !command_2)
 			EjectDiscCallback(0, 0);


### PR DESCRIPTION
It would be nice if Dolphin automatically could detect and insert the second disc of 2-disc games when needed, like GC USB loaders for the Wii do. This PR tries to implement the first part, detecting when the disc should be changed, as preparation for possibly doing the latter in the future. It isn't all that useful on its own, but I guess it could be nice for users to see an OSD message about how discs can be changed in Dolphin, as the game's instructions only are relevant for a real GameCube. I didn't include a full instruction ("go to the game list, right-click on the disc of the current game that is not currently inserted, press Change Disc...") because I felt that it would be too long for an OSD message.

Details: https://code.google.com/p/dolphin-emu/issues/detail?id=8374