### PR TITLE
[RFC] mark incorrect usages of volatile, which conflict with ChunkFile usage.

### DIFF
--- a/Source/Core/Common/CommonTypes.h
+++ b/Source/Core/Common/CommonTypes.h
@@ -11,6 +11,8 @@
 
 #include <cstdint>
 
+#define VOLATILE_BUG volatile
+
 #ifdef _WIN32
 
 #include <tchar.h>

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include "Common/CommonTypes.h"
 
 #include "Core/DSP/DSPBreakpoints.h"
 #include "Core/DSP/DSPCaptureLogger.h"
@@ -223,7 +224,7 @@ struct SDSP
 
 	u8 reg_stack_ptr[4];
 	u8 exceptions;   // pending exceptions
-	volatile bool external_interrupt_waiting;
+	VOLATILE_BUG bool external_interrupt_waiting;
 	bool reset_dspjit_codespace;
 
 	// DSP hardware stacks. They're mapped to a bunch of registers, such that writes

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -25,7 +25,7 @@ bool s_BackendInitialized = false;
 
 static Common::Flag s_FifoShuttingDown;
 
-static volatile struct
+static VOLATILE_BUG struct
 {
 	u32 xfbAddr;
 	u32 fbWidth;

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -31,34 +31,34 @@ enum EFBAccessType
 struct SCPFifoStruct
 {
 	// fifo registers
-	volatile u32 CPBase;
-	volatile u32 CPEnd;
+	VOLATILE_BUG u32 CPBase;
+	VOLATILE_BUG u32 CPEnd;
 	u32 CPHiWatermark;
 	u32 CPLoWatermark;
-	volatile u32 CPReadWriteDistance;
-	volatile u32 CPWritePointer;
-	volatile u32 CPReadPointer;
-	volatile u32 CPBreakpoint;
-	volatile u32 SafeCPReadPointer;
+	VOLATILE_BUG u32 CPReadWriteDistance;
+	VOLATILE_BUG u32 CPWritePointer;
+	VOLATILE_BUG u32 CPReadPointer;
+	VOLATILE_BUG u32 CPBreakpoint;
+	VOLATILE_BUG u32 SafeCPReadPointer;
 	// Super Monkey Ball Adventure require this.
 	// Because the read&check-PEToken-loop stays in its JITed block I suppose.
 	// So no possiblity to ack the Token irq by the scheduler until some sort of PPC watchdog do its mess.
-	volatile u16 PEToken;
+	VOLATILE_BUG u16 PEToken;
 
-	volatile u32 bFF_GPLinkEnable;
-	volatile u32 bFF_GPReadEnable;
-	volatile u32 bFF_BPEnable;
-	volatile u32 bFF_BPInt;
-	volatile u32 bFF_Breakpoint;
+	VOLATILE_BUG u32 bFF_GPLinkEnable;
+	VOLATILE_BUG u32 bFF_GPReadEnable;
+	VOLATILE_BUG u32 bFF_BPEnable;
+	VOLATILE_BUG u32 bFF_BPInt;
+	VOLATILE_BUG u32 bFF_Breakpoint;
 
-	volatile u32 bFF_LoWatermarkInt;
-	volatile u32 bFF_HiWatermarkInt;
+	VOLATILE_BUG u32 bFF_LoWatermarkInt;
+	VOLATILE_BUG u32 bFF_HiWatermarkInt;
 
-	volatile u32 bFF_LoWatermark;
-	volatile u32 bFF_HiWatermark;
+	VOLATILE_BUG u32 bFF_LoWatermark;
+	VOLATILE_BUG u32 bFF_HiWatermark;
 
 	// for GP watchdog hack
-	volatile u32 isGpuReadingData;
+	VOLATILE_BUG u32 isGpuReadingData;
 };
 
 class VideoBackend


### PR DESCRIPTION
(other incorrect usages of volatile probably exist elsewhere in dolphin...)  
When porting to vs2015 ctp6, I noticed that VS now adheres to The Standard's definition of `std::is_trivially_copyable` (cv-qualified == not trivially copyable).  
This means our code passing structs containing volatiles to ChunkFile for state saves triggers our `static_assert`s. GCC will soon adopt this behavior as well: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63959  
This PR is only intended to be a place to discuss what needs to be done, but it could be committed if someone finds it useful.  
I don't see any negative side effects when removing volatile from `SCPFifoStruct`. However the rest (or some subset, I haven't tested much) seem to actually need to be replaced with some sync/atomic primitives.  
There are two things to decide:
- [ ] what parts actually need special treatment for threading reasons
- [ ]  how to serialize these types into ChunkFile