### PR TITLE
Remove useless volatile from ProcessorInterface.

### DIFF
--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdio>
 
-#include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 
@@ -37,8 +36,8 @@ enum
 
 
 // STATE_TO_SAVE
-volatile u32 m_InterruptCause;
-volatile u32 m_InterruptMask;
+u32 m_InterruptCause;
+u32 m_InterruptMask;
 // addresses for CPU fifo accesses
 u32 Fifo_CPUBase;
 u32 Fifo_CPUEnd;
@@ -98,7 +97,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 	mmio->Register(base | PI_INTERRUPT_CAUSE,
 		MMIO::DirectRead<u32>(&m_InterruptCause),
 		MMIO::ComplexWrite<u32>([](u32, u32 val) {
-			Common::AtomicAnd(m_InterruptCause, ~val);
+			m_InterruptCause &= ~val;
 			UpdateException();
 		})
 	);
@@ -204,20 +203,17 @@ void SetInterrupt(u32 _causemask, bool _bSet)
 	}
 
 	if (_bSet)
-		Common::AtomicOr(m_InterruptCause, _causemask);
+		m_InterruptCause |= _causemask;
 	else
-		Common::AtomicAnd(m_InterruptCause, ~_causemask);// is there any reason to have this possibility?
-										// F|RES: i think the hw devices reset the interrupt in the PI to 0
-										// if the interrupt cause is eliminated. that isnt done by software (afaik)
+		m_InterruptCause &= ~_causemask;// is there any reason to have this possibility?
+		                                // F|RES: i think the hw devices reset the interrupt in the PI to 0
+		                                // if the interrupt cause is eliminated. that isnt done by software (afaik)
 	UpdateException();
 }
 
 static void SetResetButton(bool _bSet)
 {
-	if (_bSet)
-		Common::AtomicAnd(m_InterruptCause, ~INT_CAUSE_RST_BUTTON);
-	else
-		Common::AtomicOr(m_InterruptCause, INT_CAUSE_RST_BUTTON);
+	SetInterrupt(INT_CAUSE_RST_BUTTON, !_bSet);
 }
 
 void ToggleResetButtonCallback(u64 userdata, int cyclesLate)

--- a/Source/Core/Core/HW/ProcessorInterface.h
+++ b/Source/Core/Core/HW/ProcessorInterface.h
@@ -35,8 +35,8 @@ enum InterruptCause
 };
 
 
-extern volatile u32 m_InterruptCause;
-extern volatile u32 m_InterruptMask;
+extern u32 m_InterruptCause;
+extern u32 m_InterruptMask;
 extern u32 Fifo_CPUBase;
 extern u32 Fifo_CPUEnd;
 extern u32 Fifo_CPUWritePointer;


### PR DESCRIPTION
These values are only accessed/used from the CPU thread.