### PR TITLE
Pause the emulator based on mouse focus

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -242,6 +242,7 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
 	interface->Set("ShowLogConfigWindow", m_InterfaceLogConfigWindow);
 	interface->Set("ExtendedFPSInfo", m_InterfaceExtendedFPSInfo);
 	interface->Set("ThemeName40", m_LocalCoreStartupParameter.theme_name);
+	interface->Set("PauseOnFocusLost", m_PauseOnFocusLost);
 }
 
 void SConfig::SaveHotkeySettings(IniFile& ini)
@@ -464,6 +465,7 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
 	interface->Get("ShowLogConfigWindow",     &m_InterfaceLogConfigWindow,                    false);
 	interface->Get("ExtendedFPSInfo",         &m_InterfaceExtendedFPSInfo,                    false);
 	interface->Get("ThemeName40",             &m_LocalCoreStartupParameter.theme_name,        "Clean");
+	interface->Get("PauseOnFocusLost",        &m_PauseOnFocusLost,                            false);
 }
 
 void SConfig::LoadHotkeySettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -103,6 +103,8 @@ struct SConfig : NonCopyable
 	bool m_DumpFramesSilent;
 	bool m_ShowInputDisplay;
 
+	bool m_PauseOnFocusLost;
+
 	// DSP settings
 	bool m_DSPEnableJIT;
 	bool m_DSPCaptureLog;

--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -154,6 +154,7 @@ EVT_SLIDER(ID_VOLUME, CConfigMain::AudioSettingsChanged)
 EVT_CHECKBOX(ID_INTERFACE_CONFIRMSTOP, CConfigMain::DisplaySettingsChanged)
 EVT_CHECKBOX(ID_INTERFACE_USEPANICHANDLERS, CConfigMain::DisplaySettingsChanged)
 EVT_CHECKBOX(ID_INTERFACE_ONSCREENDISPLAYMESSAGES, CConfigMain::DisplaySettingsChanged)
+EVT_CHECKBOX(ID_INTERFACE_PAUSEONFOCUSLOST, CConfigMain::DisplaySettingsChanged)
 EVT_CHOICE(ID_INTERFACE_LANG, CConfigMain::DisplaySettingsChanged)
 EVT_BUTTON(ID_HOTKEY_CONFIG, CConfigMain::DisplaySettingsChanged)
 
@@ -354,6 +355,7 @@ void CConfigMain::InitializeGUIValues()
 	ConfirmStop->SetValue(startup_params.bConfirmStop);
 	UsePanicHandlers->SetValue(startup_params.bUsePanicHandlers);
 	OnScreenDisplayMessages->SetValue(startup_params.bOnScreenDisplayMessages);
+	PauseOnFocusLost->SetValue(SConfig::GetInstance().m_PauseOnFocusLost);
 	// need redesign
 	for (unsigned int i = 0; i < sizeof(langIds) / sizeof(wxLanguage); i++)
 	{
@@ -486,6 +488,7 @@ void CConfigMain::InitializeGUITooltips()
 	ConfirmStop->SetToolTip(_("Show a confirmation box before stopping a game."));
 	UsePanicHandlers->SetToolTip(_("Show a message box when a potentially serious error has occurred.\nDisabling this may avoid annoying and non-fatal messages, but it may result in major crashes having no explanation at all."));
 	OnScreenDisplayMessages->SetToolTip(_("Display messages over the emulation screen area.\nThese messages include memory card writes, video backend and CPU information, and JIT cache clearing."));
+	PauseOnFocusLost->SetToolTip(_("Pauses the emulator when focus is taken away from the emulation screen."));
 
 	InterfaceLang->SetToolTip(_("Change the language of the user interface.\nRequires restart."));
 
@@ -577,6 +580,7 @@ void CConfigMain::CreateGUIControls()
 	ConfirmStop = new wxCheckBox(DisplayPage, ID_INTERFACE_CONFIRMSTOP, _("Confirm on Stop"));
 	UsePanicHandlers = new wxCheckBox(DisplayPage, ID_INTERFACE_USEPANICHANDLERS, _("Use Panic Handlers"));
 	OnScreenDisplayMessages = new wxCheckBox(DisplayPage, ID_INTERFACE_ONSCREENDISPLAYMESSAGES, _("On-Screen Display Messages"));
+	PauseOnFocusLost = new wxCheckBox(DisplayPage, ID_INTERFACE_PAUSEONFOCUSLOST, _("Pause on Focus Lost"));
 
 	wxBoxSizer* sInterface = new wxBoxSizer(wxHORIZONTAL);
 	sInterface->Add(TEXT_BOX(DisplayPage, _("Language:")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
@@ -623,6 +627,7 @@ void CConfigMain::CreateGUIControls()
 	sbInterface->Add(ConfirmStop, 0, wxALL, 5);
 	sbInterface->Add(UsePanicHandlers, 0, wxALL, 5);
 	sbInterface->Add(OnScreenDisplayMessages, 0, wxALL, 5);
+	sbInterface->Add(PauseOnFocusLost, 0, wxALL, 5);
 	sbInterface->Add(scInterface, 0, wxEXPAND | wxALL, 5);
 	sbInterface->Add(sInterface, 0, wxEXPAND | wxALL, 5);
 	sDisplayPage = new wxBoxSizer(wxVERTICAL);
@@ -937,6 +942,9 @@ void CConfigMain::DisplaySettingsChanged(wxCommandEvent& event)
 	case ID_INTERFACE_ONSCREENDISPLAYMESSAGES:
 		SConfig::GetInstance().m_LocalCoreStartupParameter.bOnScreenDisplayMessages = OnScreenDisplayMessages->IsChecked();
 		SetEnableAlert(OnScreenDisplayMessages->IsChecked());
+		break;
+	case ID_INTERFACE_PAUSEONFOCUSLOST:
+		SConfig::GetInstance().m_PauseOnFocusLost = PauseOnFocusLost->IsChecked();
 		break;
 	case ID_INTERFACE_LANG:
 		if (SConfig::GetInstance().m_InterfaceLanguage != langIds[InterfaceLang->GetSelection()])

--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -488,7 +488,7 @@ void CConfigMain::InitializeGUITooltips()
 	ConfirmStop->SetToolTip(_("Show a confirmation box before stopping a game."));
 	UsePanicHandlers->SetToolTip(_("Show a message box when a potentially serious error has occurred.\nDisabling this may avoid annoying and non-fatal messages, but it may result in major crashes having no explanation at all."));
 	OnScreenDisplayMessages->SetToolTip(_("Display messages over the emulation screen area.\nThese messages include memory card writes, video backend and CPU information, and JIT cache clearing."));
-	PauseOnFocusLost->SetToolTip(_("Pauses the emulator when focus is taken away from the emulation screen."));
+	PauseOnFocusLost->SetToolTip(_("Pauses the emulator when focus is taken away from the emulation window."));
 
 	InterfaceLang->SetToolTip(_("Change the language of the user interface.\nRequires restart."));
 

--- a/Source/Core/DolphinWX/ConfigMain.h
+++ b/Source/Core/DolphinWX/ConfigMain.h
@@ -99,6 +99,7 @@ private:
 		ID_INTERFACE_CONFIRMSTOP,
 		ID_INTERFACE_USEPANICHANDLERS,
 		ID_INTERFACE_ONSCREENDISPLAYMESSAGES,
+		ID_INTERFACE_PAUSEONFOCUSLOST,
 		ID_INTERFACE_LANG,
 		ID_HOTKEY_CONFIG,
 
@@ -170,6 +171,7 @@ private:
 	wxCheckBox* ConfirmStop;
 	wxCheckBox* UsePanicHandlers;
 	wxCheckBox* OnScreenDisplayMessages;
+	wxCheckBox* PauseOnFocusLost;
 	wxChoice* InterfaceLang;
 	wxButton* HotkeyConfig;
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1121,6 +1121,33 @@ void CFrame::OnKeyUp(wxKeyEvent& event)
 
 void CFrame::OnMouse(wxMouseEvent& event)
 {
+	if (SConfig::GetInstance().m_PauseOnFocusLost && 
+			event.GetEventObject() == (wxObject*)m_RenderParent)
+	{
+		if (event.Leaving())
+		{
+			if (Core::GetState() == Core::CORE_RUN)
+			{
+				Core::SetState(Core::CORE_PAUSE);
+				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+					m_RenderParent->SetCursor(wxNullCursor);
+				Core::UpdateTitle();
+			}
+			UpdateGUI();
+		}
+		else if (event.Entering())
+		{
+			if (Core::GetState() == Core::CORE_PAUSE)
+			{
+				Core::SetState(Core::CORE_RUN);
+				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+					m_RenderParent->SetCursor(wxCURSOR_BLANK);
+			}
+			UpdateGUI();
+		}
+	}
+
+
 	// next handlers are all for FreeLook, so we don't need to check them if disabled
 	if (!g_Config.bFreeLook)
 	{

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1188,8 +1188,6 @@ void CFrame::OnFocusChange(wxFocusEvent& event)
 				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
 					m_RenderParent->SetCursor(wxCURSOR_BLANK);
 			}
-			UpdateGUI();
-
 		}
 		else
 		{
@@ -1200,8 +1198,8 @@ void CFrame::OnFocusChange(wxFocusEvent& event)
 					m_RenderParent->SetCursor(wxNullCursor);
 				Core::UpdateTitle();
 			}
-			UpdateGUI();
 		}
+		UpdateGUI();
 	}
 }
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1121,33 +1121,6 @@ void CFrame::OnKeyUp(wxKeyEvent& event)
 
 void CFrame::OnMouse(wxMouseEvent& event)
 {
-	if (SConfig::GetInstance().m_PauseOnFocusLost && 
-			event.GetEventObject() == (wxObject*)m_RenderParent)
-	{
-		if (event.Leaving())
-		{
-			if (Core::GetState() == Core::CORE_RUN)
-			{
-				Core::SetState(Core::CORE_PAUSE);
-				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
-					m_RenderParent->SetCursor(wxNullCursor);
-				Core::UpdateTitle();
-			}
-			UpdateGUI();
-		}
-		else if (event.Entering())
-		{
-			if (Core::GetState() == Core::CORE_PAUSE)
-			{
-				Core::SetState(Core::CORE_RUN);
-				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
-					m_RenderParent->SetCursor(wxCURSOR_BLANK);
-			}
-			UpdateGUI();
-		}
-	}
-
-
 	// next handlers are all for FreeLook, so we don't need to check them if disabled
 	if (!g_Config.bFreeLook)
 	{
@@ -1201,6 +1174,35 @@ void CFrame::OnMouse(wxMouseEvent& event)
 	}
 
 	event.Skip();
+}
+
+void CFrame::OnFocusChange(wxFocusEvent& event)
+{
+	if (SConfig::GetInstance().m_PauseOnFocusLost)
+	{
+		if (RendererHasFocus())
+		{
+			if (Core::GetState() == Core::CORE_PAUSE)
+			{
+				Core::SetState(Core::CORE_RUN);
+				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+					m_RenderParent->SetCursor(wxCURSOR_BLANK);
+			}
+			UpdateGUI();
+
+		}
+		else
+		{
+			if (Core::GetState() == Core::CORE_RUN)
+			{
+				Core::SetState(Core::CORE_PAUSE);
+				if (SConfig::GetInstance().m_LocalCoreStartupParameter.bHideCursor)
+					m_RenderParent->SetCursor(wxNullCursor);
+				Core::UpdateTitle();
+			}
+			UpdateGUI();
+		}
+	}
 }
 
 void CFrame::DoFullscreen(bool enable_fullscreen)

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -334,6 +334,8 @@ private:
 
 	void OnMouse(wxMouseEvent& event); // Mouse
 
+	void OnFocusChange(wxFocusEvent& event);
+
 	void OnHostMessage(wxCommandEvent& event);
 
 	void OnMemcard(wxCommandEvent& event); // Misc

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1073,13 +1073,15 @@ void CFrame::StartGame(const std::string& filename)
 
 		m_RenderParent->SetFocus();
 
-		wxTheApp->Bind(wxEVT_KEY_DOWN,    &CFrame::OnKeyDown, this);
-		wxTheApp->Bind(wxEVT_KEY_UP,      &CFrame::OnKeyUp,   this);
-		wxTheApp->Bind(wxEVT_RIGHT_DOWN,  &CFrame::OnMouse,   this);
-		wxTheApp->Bind(wxEVT_RIGHT_UP,    &CFrame::OnMouse,   this);
-		wxTheApp->Bind(wxEVT_MIDDLE_DOWN, &CFrame::OnMouse,   this);
-		wxTheApp->Bind(wxEVT_MIDDLE_UP,   &CFrame::OnMouse,   this);
-		wxTheApp->Bind(wxEVT_MOTION,      &CFrame::OnMouse,   this);
+		wxTheApp->Bind(wxEVT_KEY_DOWN,     &CFrame::OnKeyDown, this);
+		wxTheApp->Bind(wxEVT_KEY_UP,       &CFrame::OnKeyUp,   this);
+		wxTheApp->Bind(wxEVT_RIGHT_DOWN,   &CFrame::OnMouse,   this);
+		wxTheApp->Bind(wxEVT_RIGHT_UP,     &CFrame::OnMouse,   this);
+		wxTheApp->Bind(wxEVT_MIDDLE_DOWN,  &CFrame::OnMouse,   this);
+		wxTheApp->Bind(wxEVT_MIDDLE_UP,    &CFrame::OnMouse,   this);
+		wxTheApp->Bind(wxEVT_MOTION,       &CFrame::OnMouse,   this);
+		wxTheApp->Bind(wxEVT_ENTER_WINDOW, &CFrame::OnMouse,  this);
+		wxTheApp->Bind(wxEVT_LEAVE_WINDOW, &CFrame::OnMouse,  this);
 		m_RenderParent->Bind(wxEVT_SIZE, &CFrame::OnRenderParentResize, this);
 	}
 

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1073,15 +1073,15 @@ void CFrame::StartGame(const std::string& filename)
 
 		m_RenderParent->SetFocus();
 
-		wxTheApp->Bind(wxEVT_KEY_DOWN,     &CFrame::OnKeyDown, this);
-		wxTheApp->Bind(wxEVT_KEY_UP,       &CFrame::OnKeyUp,   this);
-		wxTheApp->Bind(wxEVT_RIGHT_DOWN,   &CFrame::OnMouse,   this);
-		wxTheApp->Bind(wxEVT_RIGHT_UP,     &CFrame::OnMouse,   this);
-		wxTheApp->Bind(wxEVT_MIDDLE_DOWN,  &CFrame::OnMouse,   this);
-		wxTheApp->Bind(wxEVT_MIDDLE_UP,    &CFrame::OnMouse,   this);
-		wxTheApp->Bind(wxEVT_MOTION,       &CFrame::OnMouse,   this);
-		wxTheApp->Bind(wxEVT_ENTER_WINDOW, &CFrame::OnMouse,  this);
-		wxTheApp->Bind(wxEVT_LEAVE_WINDOW, &CFrame::OnMouse,  this);
+		wxTheApp->Bind(wxEVT_KEY_DOWN,     &CFrame::OnKeyDown,     this);
+		wxTheApp->Bind(wxEVT_KEY_UP,       &CFrame::OnKeyUp,       this);
+		wxTheApp->Bind(wxEVT_RIGHT_DOWN,   &CFrame::OnMouse,       this);
+		wxTheApp->Bind(wxEVT_RIGHT_UP,     &CFrame::OnMouse,       this);
+		wxTheApp->Bind(wxEVT_MIDDLE_DOWN,  &CFrame::OnMouse,       this);
+		wxTheApp->Bind(wxEVT_MIDDLE_UP,    &CFrame::OnMouse,       this);
+		wxTheApp->Bind(wxEVT_MOTION,       &CFrame::OnMouse,       this);
+		wxTheApp->Bind(wxEVT_SET_FOCUS,    &CFrame::OnFocusChange, this);
+		wxTheApp->Bind(wxEVT_KILL_FOCUS,   &CFrame::OnFocusChange, this);
 		m_RenderParent->Bind(wxEVT_SIZE, &CFrame::OnRenderParentResize, this);
 	}
 


### PR DESCRIPTION
This was requested in issue #8232. Adds the option to pause the emulator when the mouse leaves the render window's focus. Defaults to false.