### PR TITLE
Fix Wii configuration path being incorrect.

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -822,6 +822,9 @@ const std::string& GetUserPath(unsigned int dir_index)
 // Rebuilds internal directory structure to compensate for the new directory
 void SetUserPath(unsigned int dir_index, const std::string& path)
 {
+	if (path.empty())
+		return;
+
 	s_user_paths[dir_index] = path;
 	RebuildUserDirectories(dir_index);
 }


### PR DESCRIPTION
On loading the NANDRoot from the config, if it isn't set it will still attempt to be set.
So on the invalid empty path, just don't set it.