### PR TITLE
Saved the selected controller profile into the game ini.

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -325,6 +325,8 @@ bool IniFile::Load(const std::string& filename, bool keep_current_data)
 	if (in.fail())
 		return false;
 
+	m_filename = filename;
+
 	Section* current_section = nullptr;
 	bool first_line = true;
 	while (!in.eof())
@@ -380,9 +382,24 @@ bool IniFile::Load(const std::string& filename, bool keep_current_data)
 					     (line[0] == '$' ||
 					      line[0] == '+' ||
 					      line[0] == '*')))
-						current_section->lines.push_back(line);
+					{
+						if (line[0] == '#')
+						{
+							// Prevent dupe comments from default ini
+							if (current_section->lines.empty() || current_section->lines.back() != line)
+							{
+								current_section->lines.push_back(line);
+							}
+						}
+						else
+						{
+							current_section->lines.push_back(line);
+						}
+					}
 					else
+					{
 						current_section->Set(key, value);
+					}
 				}
 			}
 		}
@@ -390,6 +407,14 @@ bool IniFile::Load(const std::string& filename, bool keep_current_data)
 
 	in.close();
 	return true;
+}
+
+bool IniFile::Save()
+{
+	if (m_filename.length() > 0)
+		return Save(m_filename);
+	else
+		return false;
 }
 
 bool IniFile::Save(const std::string& filename)

--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -107,6 +107,7 @@ public:
 	bool Load(const std::string& filename, bool keep_current_data = false);
 
 	bool Save(const std::string& filename);
+	bool Save();
 
 	// Returns true if key exists in section
 	bool Exists(const std::string& sectionName, const std::string& key) const;
@@ -135,6 +136,8 @@ public:
 	// It's used outside of IniFile, which is why it is exposed publicly
 	// In particular it is used in PostProcessing for its configuration
 	static void ParseLine(const std::string& line, std::string* keyOut, std::string* valueOut);
+
+	std::string m_filename;
 
 private:
 	std::list<Section> sections;

--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -38,12 +38,12 @@ void Initialize(void* const hwnd)
 	g_controller_interface.Initialize(hwnd);
 
 	// Load the saved controller config
-	s_config.LoadConfig(true);
+	s_config.LoadConfig(INPUT_TYPE_KEYBOARD);
 }
 
 void LoadConfig()
 {
-	s_config.LoadConfig(true);
+	s_config.LoadConfig(INPUT_TYPE_KEYBOARD);
 }
 
 void GetStatus(u8 port, KeyboardStatus* keyboard_status)

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -39,12 +39,12 @@ void Initialize(void* const hwnd)
 	g_controller_interface.Initialize(hwnd);
 
 	// Load the saved controller config
-	s_config.LoadConfig(true);
+	s_config.LoadConfig(INPUT_TYPE_PAD);
 }
 
 void LoadConfig()
 {
-	s_config.LoadConfig(true);
+	s_config.LoadConfig(INPUT_TYPE_PAD);
 }
 
 

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -42,7 +42,7 @@ void Initialize(void* const hwnd, bool wait)
 
 	g_controller_interface.Initialize(hwnd);
 
-	s_config.LoadConfig(false);
+	s_config.LoadConfig(INPUT_TYPE_WIIMOTE);
 
 	WiimoteReal::Initialize(wait);
 
@@ -53,7 +53,7 @@ void Initialize(void* const hwnd, bool wait)
 
 void LoadConfig()
 {
-	s_config.LoadConfig(false);
+	s_config.LoadConfig(INPUT_TYPE_WIIMOTE);
 }
 
 

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -194,7 +194,7 @@ void Initialize(void* const hwnd)
 	g_controller_interface.Initialize(hwnd);
 
 	// load the saved controller config
-	s_config.LoadConfig(true);
+	s_config.LoadConfig(INPUT_TYPE_HOTKEY);
 
 	for (u32& key : s_hotkeyDown)
 		key = 0;
@@ -204,7 +204,7 @@ void Initialize(void* const hwnd)
 
 void LoadConfig()
 {
-	s_config.LoadConfig(true);
+	s_config.LoadConfig(INPUT_TYPE_HOTKEY);
 }
 
 void Shutdown()

--- a/Source/Core/DolphinWX/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/InputConfigDiag.h
@@ -145,14 +145,14 @@ private:
 	bool GetExpressionForSelectedControl(wxString &expr);
 
 	GamepadPage* const m_parent;
-	wxComboBox*        device_cbox;
-	wxTextCtrl*        textctrl;
-	wxListBox*         control_lbox;
-	wxSlider*          range_slider;
+	wxComboBox*  device_cbox;
+	wxTextCtrl* textctrl;
+	wxListBox*  control_lbox;
+	wxSlider*   range_slider;
 	wxStaticText*      m_bound_label;
 	wxStaticText*      m_error_label;
 	InputEventFilter   m_event_filter;
-	ciface::Core::DeviceQualifier m_devq;
+	ciface::Core::DeviceQualifier    m_devq;
 };
 
 class ExtensionButton : public wxButton
@@ -208,7 +208,10 @@ public:
 
 	void LoadProfile(wxCommandEvent& event);
 	void SaveProfile(wxCommandEvent& event);
+	void SetProfile(wxCommandEvent& event);
 	void DeleteProfile(wxCommandEvent& event);
+
+	void SaveProfileToGameIni();
 
 	void ConfigControl(wxEvent& event);
 	void ClearControl(wxEvent& event);
@@ -226,9 +229,12 @@ public:
 	void AdjustSettingUI(wxCommandEvent& event);
 
 	void GetProfilePath(std::string& path);
+	void GetProfilePath(wxString name, std::string& path);
 
 	wxComboBox* profile_cbox;
 	wxComboBox* device_cbox;
+
+	wxButton* set_btn;
 
 	std::vector<ControlGroupBox*> control_groups;
 	std::vector<ControlButton*>   control_buttons;
@@ -241,9 +247,10 @@ private:
 
 	ControlDialog*           m_control_dialog;
 	InputConfigDialog* const m_config_dialog;
-	InputConfig&             m_config;
+	InputConfig& m_config;
 	InputEventFilter         m_event_filter;
 
+	int m_pad_num;
 	bool DetectButton(ControlButton* button);
 	bool m_iterate = false;
 };

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -12,26 +12,53 @@
 #include "InputCommon/InputConfig.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
-bool InputConfig::LoadConfig(bool isGC)
+bool InputConfig::LoadConfig(int control_type)
+{
+	profile_type = control_type;
+	return LoadConfig();
+}
+
+bool InputConfig::LoadConfig()
 {
 	IniFile inifile;
 	bool useProfile[MAX_BBMOTES] = {false, false, false, false, false};
 	std::string num[MAX_BBMOTES] = {"1", "2", "3", "4", "BB"};
-	std::string profile[MAX_BBMOTES];
 	std::string path;
 
 	if (SConfig::GetInstance().GetUniqueID() != "00000000")
 	{
-		std::string type;
-		if (isGC)
+		switch (profile_type)
+		{
+		case INPUT_TYPE_PAD:
 		{
 			type = "Pad";
 			path = "Profiles/GCPad/";
+			break;
 		}
-		else
+		case INPUT_TYPE_WIIMOTE:
 		{
 			type = "Wiimote";
 			path = "Profiles/Wiimote/";
+			break;
+		}
+		case INPUT_TYPE_KEYBOARD:
+		{
+			type = "Key";
+			path = "Profiles/GCKey/";
+			break;
+		}
+		case INPUT_TYPE_HOTKEY:
+		{
+			type = "Hotkey";
+			path = "Profiles/Hotkeys/";
+			break;
+		}
+		default:
+		{
+			type = "Pad";
+			path = "Profiles/GCPad/";
+			break;
+		}
 		}
 
 		IniFile game_ini = SConfig::GetInstance().LoadGameIni();
@@ -46,11 +73,6 @@ bool InputConfig::LoadConfig(bool isGC)
 					if (File::Exists(File::GetUserPath(D_CONFIG_IDX) + path + profile[i] + ".ini"))
 					{
 						useProfile[i] = true;
-					}
-					else
-					{
-						// TODO: PanicAlert shouldn't be used for this.
-						PanicAlertT("Selected controller profile does not exist");
 					}
 				}
 			}

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -11,6 +11,14 @@
 
 class ControllerEmu;
 
+enum
+{
+	INPUT_TYPE_PAD,
+	INPUT_TYPE_WIIMOTE,
+	INPUT_TYPE_KEYBOARD,
+	INPUT_TYPE_HOTKEY
+};
+
 class InputConfig
 {
 public:
@@ -19,7 +27,8 @@ public:
 	{
 	}
 
-	bool LoadConfig(bool isGC);
+	bool LoadConfig(int control_type);
+	bool LoadConfig();
 	void SaveConfig();
 
 	template <typename T, typename... Args>
@@ -35,9 +44,14 @@ public:
 	std::string GetGUIName() const { return m_gui_name; }
 	std::string GetProfileName() const { return m_profile_name; }
 
+	std::string profile[5];
+	std::string type;
+
 private:
 	std::vector<std::unique_ptr<ControllerEmu>> m_controllers;
 	const std::string m_ini_name;
 	const std::string m_gui_name;
 	const std::string m_profile_name;
+
+	int profile_type;
 };


### PR DESCRIPTION
A controller profile can be linked to a game by pressing the Set button while the game is running.  This allows Dolphin to remember games which have controller profiles like "Nunchuck required" or "Horizontal Wiimote" and automatically load those profiles without the user needing to switch between them after the game has started. To clear the selected profile, the user can clear the profile combo-box and press the Set button.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/2236)

<!-- Reviewable:end -->
