### PR TITLE
x64FPURoundMode: Make a look-up table static

### DIFF
--- a/Source/Core/Common/x64FPURoundMode.cpp
+++ b/Source/Core/Common/x64FPURoundMode.cpp
@@ -18,7 +18,7 @@ namespace FPURoundMode
 	void SetRoundMode(int mode)
 	{
 		// Convert PowerPC to native rounding mode.
-		const int rounding_mode_lut[] = {
+		static const int rounding_mode_lut[] = {
 			FE_TONEAREST,
 			FE_TOWARDZERO,
 			FE_UPWARD,


### PR DESCRIPTION
Since it's only a look-up table, this doesn't need to be recreated every time the function is called.