### PR TITLE
GCAdapter: Don't destroy the libusb context before freeing the device list.

### DIFF
--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -168,10 +168,11 @@ void Setup()
 			}
 		}
 	}
-	if (!s_detected)
-		Shutdown();
 
 	libusb_free_device_list(list, 1);
+
+	if (!s_detected)
+		Shutdown();
 }
 
 


### PR DESCRIPTION
Destroying the libusb context before freeing the device list may lead to heap corruption and other sadness.