### PR TITLE
DolphinWX/Common: Change some find_first_of usages to find

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -104,7 +104,7 @@ bool IniFile::Section::Get(const std::string& key, std::vector<std::string>* out
 	while (subStart != std::string::npos)
 	{
 		// Find next ,
-		size_t subEnd = temp.find_first_of(",", subStart);
+		size_t subEnd = temp.find(',', subStart);
 		if (subStart != subEnd)
 			// take from first char until next ,
 			out->push_back(StripSpaces(temp.substr(subStart, subEnd - subStart)));

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -92,7 +92,7 @@ void LoadPatchSection(const std::string& section, std::vector<Patch>& patches, I
 			}
 			else
 			{
-				std::string::size_type loc = line.find_first_of('=', 0);
+				std::string::size_type loc = line.find('=');
 
 				if (loc != std::string::npos)
 				{

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -767,8 +767,10 @@ void CISOProperties::OnExtractFile(wxCommandEvent& WXUNUSED (event))
 
 	if (OpenISO->IsWiiDisc())
 	{
-		int partitionNum = wxAtoi(File.Mid(File.find_first_of("/") - 1, 1));
-		File.erase(0, File.find_first_of("/") + 1); // Remove "Partition x/"
+		size_t slash_index = File.find('/');
+		int partitionNum = wxAtoi(File.Mid(slash_index - 1, 1));
+
+		File.erase(0, slash_index + 1); // Remove "Partition x/"
 		WiiDisc.at(partitionNum).FileSystem->ExportFile(WxStrToStr(File), WxStrToStr(Path));
 	}
 	else
@@ -900,8 +902,10 @@ void CISOProperties::OnExtractDir(wxCommandEvent& event)
 
 	if (OpenISO->IsWiiDisc())
 	{
-		int partitionNum = wxAtoi(Directory.Mid(Directory.find_first_of("/") - 1, 1));
-		Directory.erase(0, Directory.find_first_of("/") + 1); // Remove "Partition x/"
+		size_t slash_index = Directory.find('/');
+		int partitionNum = wxAtoi(Directory.Mid(slash_index - 1, 1));
+
+		Directory.erase(0, slash_index + 1); // Remove "Partition x/"
 		ExportDir(WxStrToStr(Directory), WxStrToStr(Path), partitionNum);
 	}
 	else


### PR DESCRIPTION
It's unnecessary to use `find_first_of` when all you're searching for is a single character.