### PR TITLE
DolphinWX: Get rid of wxGrid-based casts in the debugger.

### DIFF
--- a/Source/Core/DolphinWX/Debugger/DSPRegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/DSPRegisterView.cpp
@@ -77,7 +77,9 @@ wxGridCellAttr *CDSPRegTable::GetAttr(int row, int col, wxGridCellAttr::wxAttrKi
 DSPRegisterView::DSPRegisterView(wxWindow *parent, wxWindowID id)
 	: wxGrid(parent, id, wxDefaultPosition, wxSize(130, 120))
 {
-	SetTable(new CDSPRegTable(), true);
+	m_register_table = new CDSPRegTable();
+
+	SetTable(m_register_table, true);
 	SetRowLabelSize(0);
 	SetColLabelSize(0);
 	DisableDragRowSize();
@@ -87,6 +89,6 @@ DSPRegisterView::DSPRegisterView(wxWindow *parent, wxWindowID id)
 
 void DSPRegisterView::Update()
 {
-	((CDSPRegTable *)GetTable())->UpdateCachedRegs();
+	m_register_table->UpdateCachedRegs();
 	ForceRefresh();
 }

--- a/Source/Core/DolphinWX/Debugger/DSPRegisterView.h
+++ b/Source/Core/DolphinWX/Debugger/DSPRegisterView.h
@@ -44,4 +44,8 @@ class DSPRegisterView : public wxGrid
 public:
 	DSPRegisterView(wxWindow* parent, wxWindowID id = wxID_ANY);
 	void Update() override;
+
+private:
+	// Owned by wx. Deleted implicitly upon destruction.
+	CDSPRegTable* m_register_table;
 };

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -248,7 +248,9 @@ wxGridCellAttr *CRegTable::GetAttr(int row, int col, wxGridCellAttr::wxAttrKind)
 CRegisterView::CRegisterView(wxWindow *parent, wxWindowID id)
 	: wxGrid(parent, id)
 {
-	SetTable(new CRegTable(), true);
+	m_register_table = new CRegTable();
+
+	SetTable(m_register_table, true);
 	SetRowLabelSize(0);
 	SetColLabelSize(0);
 	DisableDragRowSize();
@@ -262,7 +264,7 @@ CRegisterView::CRegisterView(wxWindow *parent, wxWindowID id)
 void CRegisterView::Update()
 {
 	ForceRefresh();
-	((CRegTable *)GetTable())->UpdateCachedRegs();
+	m_register_table->UpdateCachedRegs();
 }
 
 void CRegisterView::OnMouseDownR(wxGridEvent& event)

--- a/Source/Core/DolphinWX/Debugger/RegisterView.h
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.h
@@ -76,4 +76,7 @@ public:
 
 private:
 	u32 m_selectedAddress = 0;
+
+	// Owned by wx. Deleted implicitly upon destruction.
+	CRegTable* m_register_table;
 };

--- a/Source/Core/DolphinWX/Debugger/WatchView.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchView.cpp
@@ -215,7 +215,9 @@ wxGridCellAttr* CWatchTable::GetAttr(int row, int col, wxGridCellAttr::wxAttrKin
 CWatchView::CWatchView(wxWindow* parent, wxWindowID id)
 	: wxGrid(parent, id)
 {
-	SetTable(new CWatchTable(), false);
+	m_watch_table = new CWatchTable();
+
+	SetTable(m_watch_table, true);
 	SetRowLabelSize(0);
 	SetColLabelSize(0);
 	DisableDragRowSize();
@@ -229,7 +231,7 @@ void CWatchView::Update()
 	if (PowerPC::GetState() != PowerPC::CPU_POWERDOWN)
 	{
 		ForceRefresh();
-		((CWatchTable *)GetTable())->UpdateWatch();
+		m_watch_table->UpdateWatch();
 	}
 }
 

--- a/Source/Core/DolphinWX/Debugger/WatchView.h
+++ b/Source/Core/DolphinWX/Debugger/WatchView.h
@@ -52,4 +52,5 @@ public:
 private:
 	u32 m_selectedAddress = 0;
 	u32 m_selectedRow = 0;
+	CWatchTable* m_watch_table;
 };

--- a/Source/Core/DolphinWX/Debugger/WatchWindow.h
+++ b/Source/Core/DolphinWX/Debugger/WatchWindow.h
@@ -34,8 +34,10 @@ public:
 	void LoadAll();
 
 private:
+	void CreateGUIControls();
+
 	wxAuiManager m_mgr;
 
+	// Owned by wx. Deleted implicitly upon destruction.
 	CWatchView* m_GPRGridView;
-	void CreateGUIControls();
 };


### PR DESCRIPTION
This technically also fixes a memory leak in WatchView.cpp, because the table setting was done such that the grid wouldn't take ownership of the table, which means said table wouldn't be deleted in the grid's destructor.