### PR TITLE
Use WindowFromPoint to track the mouse in DInput

### DIFF
--- a/Source/Core/Core/HotkeyManager.h
+++ b/Source/Core/Core/HotkeyManager.h
@@ -39,4 +39,6 @@ namespace HotkeyManagerEmu
 	bool IsEnabled();
 	void Enable(bool enable_toggle);
 	bool IsPressed(int Id, bool held);
+
+	static bool enabled;
 }

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -1060,9 +1060,6 @@ GamepadPage::GamepadPage(wxWindow* parent, InputConfig& config, const unsigned i
 	mapping->Add(dio, 1, wxEXPAND|wxLEFT|wxTOP|wxBOTTOM, 5);
 	mapping->Add(control_group_sizer, 0, wxLEFT|wxEXPAND, 5);
 
-	wxCommandEvent event;
-	RefreshDevices(event);
-
 	UpdateGUI();
 
 	SetSizerAndFit(mapping); // needed

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -44,7 +44,7 @@ ControllerInterface g_controller_interface;
 void ControllerInterface::Initialize(void* const hwnd)
 {
 	if (m_is_init)
-		DeInit();
+		return;
 
 	m_hwnd = hwnd;
 
@@ -102,11 +102,6 @@ void ControllerInterface::Shutdown()
 		delete d;
 	}
 
-	DeInit();
-}
-
-void ControllerInterface::DeInit()
-{
 	m_devices.clear();
 
 #ifdef CIFACE_USE_XINPUT

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -117,9 +117,6 @@ public:
 	void Initialize(void* const hwnd);
 	void Reinitialize();
 	void Shutdown();
-
-	void DeInit();
-
 	bool IsInit() const { return m_is_init; }
 
 	void UpdateReference(ControlReference* control, const ciface::Core::DeviceQualifier& default_device) const;

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -31,11 +31,11 @@ static const struct
 };
 
 // lil silly
-static HWND hwnd;
+static HWND m_hwnd;
 
 void InitKeyboardMouse(IDirectInput8* const idi8, std::vector<Core::Device*>& devices, HWND _hwnd)
 {
-	hwnd = _hwnd;
+	m_hwnd = _hwnd;
 
 	// mouse and keyboard are a combined device, to allow shift+click and stuff
 	// if that's dumb, I will make a VirtualDevice class that just uses ranges of inputs/outputs from other devices
@@ -124,10 +124,11 @@ void GetMousePos(ControlState* const x, ControlState* const y)
 {
 	POINT point = { 1, 1 };
 	GetCursorPos(&point);
-	// Get the cursor position relative to the upper left corner of the rendering window
+	// Get the cursor position relative to the upper left corner of the current window (separate or render to main)
+	HWND hwnd = WindowFromPoint(point);
 	ScreenToClient(hwnd, &point);
 
-	// Get the size of the rendering window. (In my case Rect.top and Rect.left was zero.)
+	// Get the size of the current window. (In my case Rect.top and Rect.left was zero.)
 	RECT rect;
 	GetClientRect(hwnd, &rect);
 	// Width and height is the size of the rendering window


### PR DESCRIPTION
Trying to update hwnd caused a multitude of issues like a big red "Wrong way go back" sign.  Instead, use WindowFromPoint to track the mouse cursor in DInput.