### PR TITLE
Gameini database update.

### DIFF
--- a/Data/Sys/GameSettings/DLS.ini
+++ b/Data/Sys/GameSettings/DLS.ini
@@ -1,7 +1,7 @@
 # DLSE64, DLSP64 - Star Wars: Rogue Squadron III: Rebel Strike: Limited Edition Bonus Disc (Demo)
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Values set here will override the main dolphin settings.
 MMU = 1
 
 [EmuState]
@@ -23,7 +23,6 @@ EmulationIssues =
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False
-SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/DLS.ini
+++ b/Data/Sys/GameSettings/DLS.ini
@@ -1,7 +1,7 @@
 # DLSE64, DLSP64 - Star Wars: Rogue Squadron III: Rebel Strike: Limited Edition Bonus Disc (Demo)
 
 [Core]
-# Values set here will override the main dolphin settings.
+# Values set here will override the main Dolphin settings.
 MMU = 1
 
 [EmuState]

--- a/Data/Sys/GameSettings/G5T.ini
+++ b/Data/Sys/GameSettings/G5T.ini
@@ -1,7 +1,7 @@
 # G5TE69, G5TP69 - Tiger Woods PGA TOUR 2005
 
 [Core]
-# Values set here will override the main dolphin settings.
+# Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/G5T.ini
+++ b/Data/Sys/GameSettings/G5T.ini
@@ -1,7 +1,7 @@
 # G5TE69, G5TP69 - Tiger Woods PGA TOUR 2005
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Values set here will override the main dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
@@ -24,9 +24,6 @@ PH_SZFar = 0
 PH_ExtraParam = 0
 PH_ZNear =
 PH_ZFar =
-
-[Video_Hacks]
-EFBToTextureEnable = False
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/G6W.ini
+++ b/Data/Sys/GameSettings/G6W.ini
@@ -1,7 +1,7 @@
 # G6WE69, G6WP69 - Tiger Woods PGA TOUR 06
 
 [Core]
-# Values set here will override the main dolphin settings.
+# Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/G6W.ini
+++ b/Data/Sys/GameSettings/G6W.ini
@@ -1,7 +1,7 @@
 # G6WE69, G6WP69 - Tiger Woods PGA TOUR 06
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Values set here will override the main dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
@@ -25,5 +25,5 @@ PH_ExtraParam = 0
 PH_ZNear =
 PH_ZFar =
 
-[Video_Hacks]
-EFBToTextureEnable = False
+[Video_Settings]
+SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/GAC.ini
+++ b/Data/Sys/GameSettings/GAC.ini
@@ -2,10 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+DSPHLE = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
+EmulationIssues = Slow audio with HLE.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,3 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
+[DSP]
+EnableJIT = True

--- a/Data/Sys/GameSettings/GFF.ini
+++ b/Data/Sys/GameSettings/GFF.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs real xfb for videos to show up (r7422)
+EmulationIssues = Needs real xfb for videos to show up.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GGR.ini
+++ b/Data/Sys/GameSettings/GGR.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-EmulationIssues = Needs Real Xfb to show videos. Graphic glitches (r6945)
+EmulationIssues = Needs Real Xfb to show videos. Graphic glitches.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GJN.ini
+++ b/Data/Sys/GameSettings/GJN.ini
@@ -1,7 +1,7 @@
 # GJNE78 - Jimmy Neutron Boy Genius
 
 [Core]
-# Values set here will override the main dolphin settings.
+# Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/GJN.ini
+++ b/Data/Sys/GameSettings/GJN.ini
@@ -1,12 +1,12 @@
 # GJNE78 - Jimmy Neutron Boy Genius
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Values set here will override the main dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Black screen
-EmulationStateId = 3
+EmulationIssues = Needs real xfb for the videos to display.
+EmulationStateId = 4
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -17,3 +17,6 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+UseXFB = True
+UseRealXFB = True

--- a/Data/Sys/GameSettings/GK7.ini
+++ b/Data/Sys/GameSettings/GK7.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Tested with (r6801)
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GMH.ini
+++ b/Data/Sys/GameSettings/GMH.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs real Xfb for videos to show up (r6945)
+EmulationIssues = Needs real Xfb for videos to show up.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GMI.ini
+++ b/Data/Sys/GameSettings/GMI.ini
@@ -1,7 +1,7 @@
 # GMIE70, GMIP70 - Mission: Impossible Operation Surma
 
 [Core]
-# Values set here will override the main dolphin settings.
+# Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/GMI.ini
+++ b/Data/Sys/GameSettings/GMI.ini
@@ -1,12 +1,12 @@
 # GMIE70, GMIP70 - Mission: Impossible Operation Surma
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Values set here will override the main dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationStateId = 3
-EmulationIssues = Needs Efb to Ram for Sonic Imager (gadgets).
+EmulationStateId = 4
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -28,7 +28,4 @@ PH_ZFar =
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False
-
-[Video_Hacks]
-EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/GP2.ini
+++ b/Data/Sys/GameSettings/GP2.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs Real xfb for the videos to show up(r6651)
+EmulationIssues = Needs real xfb for the videos to show up.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GP8.ini
+++ b/Data/Sys/GameSettings/GP8.ini
@@ -2,11 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+DSPHLE = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues =
+EmulationIssues = Slow audio with HLE.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -25,3 +26,5 @@ PH_ExtraParam = 0
 PH_ZNear =
 PH_ZFar =
 
+[DSP]
+EnableJIT = True

--- a/Data/Sys/GameSettings/GPT.ini
+++ b/Data/Sys/GameSettings/GPT.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs Real Xfb for videos to show up(r6898)
+EmulationIssues = Needs Real Xfb for videos to show up.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GRK.ini
+++ b/Data/Sys/GameSettings/GRK.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Use Directx11 plugin (r6651)
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -27,7 +27,6 @@ PH_ZFar =
 
 [Video_Settings]
 UseXFB = True
-
 UseRealXFB = False
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GSA.ini
+++ b/Data/Sys/GameSettings/GSA.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Use dx11 plugin(r6477)
+EmulationIssues =
 EmulationStateId = 4
 
 [OnLoad]

--- a/Data/Sys/GameSettings/GT6.ini
+++ b/Data/Sys/GameSettings/GT6.ini
@@ -1,7 +1,7 @@
 # GT6E70 - Terminator 3: The Redemption
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Values set here will override the main dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
@@ -30,6 +30,5 @@ UseXFB = True
 UseRealXFB = False
 
 [Video_Hacks]
-EFBToTextureEnable = False
 EFBAccessEnable = False
 

--- a/Data/Sys/GameSettings/GT6.ini
+++ b/Data/Sys/GameSettings/GT6.ini
@@ -1,7 +1,7 @@
 # GT6E70 - Terminator 3: The Redemption
 
 [Core]
-# Values set here will override the main dolphin settings.
+# Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/GT6E70.ini
+++ b/Data/Sys/GameSettings/GT6E70.ini
@@ -1,7 +1,7 @@
 # GT6E70 - Terminator 3: The Redemption
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Values set here will override the main dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
@@ -62,6 +62,5 @@ UseXFB = True
 UseRealXFB = False
 
 [Video_Hacks]
-EFBToTextureEnable = False
 EFBAccessEnable = False
 

--- a/Data/Sys/GameSettings/GT6E70.ini
+++ b/Data/Sys/GameSettings/GT6E70.ini
@@ -1,7 +1,7 @@
 # GT6E70 - Terminator 3: The Redemption
 
 [Core]
-# Values set here will override the main dolphin settings.
+# Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/JAC.ini
+++ b/Data/Sys/GameSettings/JAC.ini
@@ -1,8 +1,7 @@
 # JACE01, JACP01 - F-Zero
 
 [Core]
-# Values set here will override the main Dolphin settings.
-FPRF = True
+# Values set here will override the main dolphin settings.
 ProgressiveScan = True
 
 [EmuState]

--- a/Data/Sys/GameSettings/JAC.ini
+++ b/Data/Sys/GameSettings/JAC.ini
@@ -1,7 +1,7 @@
 # JACE01, JACP01 - F-Zero
 
 [Core]
-# Values set here will override the main dolphin settings.
+# Values set here will override the main Dolphin settings.
 ProgressiveScan = True
 
 [EmuState]

--- a/Data/Sys/GameSettings/R5W.ini
+++ b/Data/Sys/GameSettings/R5W.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Flashlight glitches (r6521)
+EmulationIssues = Flashlight glitches.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/R96.ini
+++ b/Data/Sys/GameSettings/R96.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 5
-EmulationIssues = Disable PAL60 (EuRGB60) mode in general settings-> wii tab for the game to run (r7446)
+EmulationIssues = Disable PAL60 (EuRGB60) mode in general settings-> wii tab for the game to run.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RPB.ini
+++ b/Data/Sys/GameSettings/RPB.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs texture cache set to "Safe"(r6906).
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RQR.ini
+++ b/Data/Sys/GameSettings/RQR.ini
@@ -7,7 +7,7 @@ CPUThread = 0
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs single core to run properly(r7436).
+EmulationIssues = Needs single core to run properly.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RT4.ini
+++ b/Data/Sys/GameSettings/RT4.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Needs emulating format changes (r6871)
+EmulationIssues = 
 EmulationStateId = 4
 
 [OnLoad]

--- a/Data/Sys/GameSettings/RWS.ini
+++ b/Data/Sys/GameSettings/RWS.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs emulating format changes (r6871)
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/S2W.ini
+++ b/Data/Sys/GameSettings/S2W.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Use direct 3d 11 for less glitches(r7436)
+EmulationIssues = Use direct3d 11 for less glitches.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/S2W.ini
+++ b/Data/Sys/GameSettings/S2W.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Use direct3d 11 for less glitches.
+EmulationIssues = Use direct3d for less glitches.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/S75.ini
+++ b/Data/Sys/GameSettings/S75.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Skip any errors at startup and use integral efb scale (r6682)
+EmulationIssues = Skip any errors at startup and use integral efb scale.
 EmulationStateId = 4
 
 [OnLoad]

--- a/Data/Sys/GameSettings/STK.ini
+++ b/Data/Sys/GameSettings/STK.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Disable GC controllers if you want to use wiimote(r6590)
+EmulationIssues = Disable GC controllers if you want to use a wiimote instead.
 EmulationStateId = 5
 
 [OnLoad]

--- a/Data/Sys/GameSettings/SXC.ini
+++ b/Data/Sys/GameSettings/SXC.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-EmulationIssues = Create a quitar profile and use that for controls instead of wiimote controls(r6575)
+EmulationIssues = Create a quitar profile and use that instead of wiimote controls.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/SXC.ini
+++ b/Data/Sys/GameSettings/SXC.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-EmulationIssues = Create a quitar profile and use that instead of wiimote controls.
+EmulationIssues = Create a guitar profile and use that instead of wiimote controls.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/SZA.ini
+++ b/Data/Sys/GameSettings/SZA.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Config and use the quitar and drums, wiimote asks for a microphone otherwise.
+EmulationIssues = Create a guitar profile and use that instead of wiimote controls.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/SZA.ini
+++ b/Data/Sys/GameSettings/SZA.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Config and use the quitar and drums, wiimote asks for a microphone otherwise.(r6575)
+EmulationIssues = Config and use the quitar and drums, wiimote asks for a microphone otherwise.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/UGP.ini
+++ b/Data/Sys/GameSettings/UGP.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 2
-EmulationIssues = No GameBoy Player Device (r7574)
+EmulationIssues = No GameBoy Player Device.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/WSL.ini
+++ b/Data/Sys/GameSettings/WSL.ini
@@ -1,7 +1,7 @@
 # WSLEE6 - The Magic Obelisk
 
 [Core]
-# Values set here will override the main dolphin settings.
+# Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/WSL.ini
+++ b/Data/Sys/GameSettings/WSL.ini
@@ -1,11 +1,11 @@
 # WSLEE6 - The Magic Obelisk
 
 [Core]
-# Values set here will override the main Dolphin settings.
+# Values set here will override the main dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Needs efb to ram otherwise character is invisible in the light.
+EmulationIssues = Needs efb to ram otherwise character is invincible in the light.
 EmulationStateId = 4
 
 [OnLoad]


### PR DESCRIPTION
Removes STC from Star Wars: Rogue Squadron III: Rebel Strike: Limited
Edition Bonus Disc (Demo). Removes efb to ram setting from Tiger Woods
PGA TOUR 2005, Tiger Woods PGA TOUR 06, Mission: Impossible Operation
Surma and Terminator 3: The Redemption since it is no longer needed.
Sets Army Men Air Combat and Pac-Man World 3 to LLE audio due to audio
issues with HLE (slow audio). Corrects some mistakes in F zero (virtual
console) and The Magic Obelisk ini files. Finally it removes comments
that are simply stating the obvious and references to revs that games
were tested with.