### PR TITLE
NetPlay: Disable some UI elements when a game is running

### DIFF
--- a/Source/Core/DolphinWX/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetWindow.cpp
@@ -546,9 +546,9 @@ NetPlayDiag::NetPlayDiag(wxWindow* const parent, const CGameListCtrl* const game
 		player_szr->Add(m_kick_btn, 0, wxEXPAND | wxTOP, 5);
 		m_kick_btn->Disable();
 
-		wxButton* const player_config_btn = new wxButton(panel, wxID_ANY, _("Configure Pads"));
-		player_config_btn->Bind(wxEVT_BUTTON, &NetPlayDiag::OnConfigPads, this);
-		player_szr->Add(player_config_btn, 0, wxEXPAND | wxTOP, 5);
+		m_player_config_btn = new wxButton(panel, wxID_ANY, _("Configure Pads"));
+		m_player_config_btn->Bind(wxEVT_BUTTON, &NetPlayDiag::OnConfigPads, this);
+		player_szr->Add(m_player_config_btn, 0, wxEXPAND | wxTOP, 5);
 	}
 
 	wxBoxSizer* const mid_szr = new wxBoxSizer(wxHORIZONTAL);
@@ -691,8 +691,14 @@ void NetPlayDiag::OnMsgStartGame()
 {
 	wxThreadEvent evt(wxEVT_THREAD, NP_GUI_EVT_START_GAME);
 	GetEventHandler()->AddPendingEvent(evt);
-	if (m_start_btn)
+	if (m_is_hosting)
+	{
 		m_start_btn->Disable();
+		m_memcard_write->Disable();
+		m_game_btn->Disable();
+		m_player_config_btn->Disable();
+	}
+
 	m_record_chkbox->Disable();
 }
 
@@ -700,8 +706,13 @@ void NetPlayDiag::OnMsgStopGame()
 {
 	wxThreadEvent evt(wxEVT_THREAD, NP_GUI_EVT_STOP_GAME);
 	GetEventHandler()->AddPendingEvent(evt);
-	if (m_start_btn)
+	if (m_is_hosting)
+	{
 		m_start_btn->Enable();
+		m_memcard_write->Enable();
+		m_game_btn->Enable();
+		m_player_config_btn->Enable();
+	}
 	m_record_chkbox->Enable();
 }
 

--- a/Source/Core/DolphinWX/NetWindow.h
+++ b/Source/Core/DolphinWX/NetWindow.h
@@ -114,6 +114,7 @@ private:
 	wxCheckBox*   m_record_chkbox;
 
 	std::string   m_selected_game;
+	wxButton*     m_player_config_btn;
 	wxButton*     m_game_btn;
 	wxButton*     m_start_btn;
 	wxButton*     m_kick_btn;


### PR DESCRIPTION
Changing stuff while a game is running on netplay (like changing the game, configuring gamepads) makes dolphin crash. Some options also aren't meant to be dynamically changed (write memcards, changing the game…).

This change disables the wx elements on the host when a game starts, and re-enables them when the game stops.