### PR TITLE
NetPlay: Don’t wait forever in the traversal client

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -137,6 +137,9 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
 		OnTraversalStateChanged();
 		m_connecting = true;
 
+		Common::Timer connect_timer;
+		connect_timer.Start();
+
 		while (m_connecting)
 		{
 			ENetEvent netEvent;
@@ -160,6 +163,8 @@ NetPlayClient::NetPlayClient(const std::string& address, const u16 port, NetPlay
 					break;
 				}
 			}
+			if (connect_timer.GetTimeElapsed() > 5000)
+				break;
 		}
 		PanicAlertT("Failed To Connect!");
 	}


### PR DESCRIPTION
With some specific, STUN-hostile routers, the netplay client can get
stuck forever while trying to connect to the stun server. This adds a
5 seconds (much more than should be necessary if it works) timer until
a failure is registered and the attempt stops.