### PR TITLE
Limit Wiimote battery usage for Dolphin-lite users.

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -354,6 +354,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("GFXBackend", m_LocalCoreStartupParameter.m_strVideoBackend);
 	core->Set("GPUDeterminismMode", m_LocalCoreStartupParameter.m_strGPUDeterminismMode);
 	core->Set("GameCubeAdapter", m_GameCubeAdapter);
+	core->Set("DolphinPro", m_DolphinPro);
 }
 
 void SConfig::SaveMovieSettings(IniFile& ini)
@@ -621,6 +622,11 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("GFXBackend",                &m_LocalCoreStartupParameter.m_strVideoBackend, "");
 	core->Get("GPUDeterminismMode",        &m_LocalCoreStartupParameter.m_strGPUDeterminismMode, "auto");
 	core->Get("GameCubeAdapter",           &m_GameCubeAdapter,                             true);
+#ifdef DOLPHINPRO
+	m_DolphinPro = true;
+#else
+	core->Get("DolphinPro",                &m_DolphinPro,                                  false);
+#endif
 }
 
 void SConfig::LoadMovieSettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -119,6 +119,8 @@ struct SConfig : NonCopyable
 
 	SysConf* m_SYSCONF;
 
+	bool m_DolphinPro;
+
 	// Save settings
 	void SaveSettings();
 

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -25,6 +25,8 @@ InputConfig* GetConfig()
 
 void Shutdown()
 {
+	s_config.SaveConfig();
+
 	for (const ControllerEmu* i : s_config.controllers)
 	{
 		delete i;

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -946,7 +946,14 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 					setting->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
 					options.push_back(setting);
 					wxBoxSizer* const szr = new wxBoxSizer(wxHORIZONTAL);
-					szr->Add(new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name))), 0, wxCENTER | wxRIGHT, 3);
+					wxStaticText* nameBox = new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name)));
+					if (groupSetting->name == "Battery" && !SConfig::GetInstance().m_DolphinPro)
+					{
+						setting->wxcontrol->Disable();
+						nameBox->SetToolTip(wxGetTranslation("Upgrade to Dolphin Pro™ to recharge batteries."));
+					}
+
+					szr->Add(nameBox, 0, wxCENTER | wxRIGHT, 3);
 					szr->Add(setting->wxcontrol, 0, wxRIGHT, 3);
 					Add(szr, 0, wxALL | wxCENTER, 3);
 				}

--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -219,7 +219,6 @@ ControllerEmu::Cursor::Cursor(const std::string& _name)
 	settings.emplace_back(new Setting(_trans("Center"), 0.5));
 	settings.emplace_back(new Setting(_trans("Width"), 0.5));
 	settings.emplace_back(new Setting(_trans("Height"), 0.5));
-
 }
 
 void ControllerEmu::LoadDefaults(const ControllerInterface &ciface)


### PR DESCRIPTION
Wiimote batteries drain over time. The user must upgrade to Dolphin Pro for $19.95 to recharge them.