### PR TITLE
Revert "Dolphin Pro" April Fools joke that never should've been merged

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -354,7 +354,6 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("GFXBackend", m_LocalCoreStartupParameter.m_strVideoBackend);
 	core->Set("GPUDeterminismMode", m_LocalCoreStartupParameter.m_strGPUDeterminismMode);
 	core->Set("GameCubeAdapter", m_GameCubeAdapter);
-	core->Set("DolphinPro", m_DolphinPro);
 }
 
 void SConfig::SaveMovieSettings(IniFile& ini)
@@ -622,11 +621,6 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("GFXBackend",                &m_LocalCoreStartupParameter.m_strVideoBackend, "");
 	core->Get("GPUDeterminismMode",        &m_LocalCoreStartupParameter.m_strGPUDeterminismMode, "auto");
 	core->Get("GameCubeAdapter",           &m_GameCubeAdapter,                             true);
-#ifdef DOLPHINPRO
-	m_DolphinPro = true;
-#else
-	core->Get("DolphinPro",                &m_DolphinPro,                                  false);
-#endif
 }
 
 void SConfig::LoadMovieSettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -119,8 +119,6 @@ struct SConfig : NonCopyable
 
 	SysConf* m_SYSCONF;
 
-	bool m_DolphinPro;
-
 	// Save settings
 	void SaveSettings();
 

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -25,8 +25,6 @@ InputConfig* GetConfig()
 
 void Shutdown()
 {
-	s_config.SaveConfig();
-
 	for (const ControllerEmu* i : s_config.controllers)
 	{
 		delete i;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -21,8 +21,6 @@
 #include "Core/HW/WiimoteEmu/Attachment/Nunchuk.h"
 #include "Core/HW/WiimoteEmu/Attachment/Turntable.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
-#include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
-#include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
 
 namespace
 {
@@ -304,7 +302,6 @@ Wiimote::Wiimote( const unsigned int index )
 	m_options->settings.emplace_back(new ControlGroup::Setting(_trans("Upright Wiimote"), false));
 	m_options->settings.emplace_back(new ControlGroup::IterateUI(_trans("Iterative Input")));
 	m_options->settings.emplace_back(new ControlGroup::Setting(_trans("Speaker Pan"), 0, -127, 127));
-	m_options->settings.emplace_back(new ControlGroup::Setting(_trans("Battery"), 95, 0, 255));
 
 	// TODO: This value should probably be re-read if SYSCONF gets changed
 	m_sensor_bar_on_top = SConfig::GetInstance().m_SYSCONF->GetData<u8>("BT.BAR") != 0;
@@ -638,23 +635,6 @@ void Wiimote::Update()
 	// returns true if a report was sent
 	if (Step())
 		return;
-
-	m_status.battery = (u8)(m_options->settings[5]->GetValue() * 100);
-	if (!m_status.battery)
-	{
-		GetUsbPointer()->AccessWiiMote(m_index | 0x100)->Activate(false);
-		return;
-	}
-
-	static u32 batteryCounter = 0;
-	// drop battery by 1 every 144000 times input is polled. At 200 hz polling, this is once per 12 mins. Gives 19 hours
-	// of battery life from the default of 95, or 51 hours at the max of 255.
-	if (++batteryCounter > 144000)
-	{
-		m_status.battery--;
-		m_options->settings[5]->SetValue(((ControlState)m_status.battery) / 100);
-		batteryCounter = 0;
-	}
 
 	u8 data[MAX_PAYLOAD];
 	memset(data, 0, sizeof(data));

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -946,14 +946,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 					setting->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
 					options.push_back(setting);
 					wxBoxSizer* const szr = new wxBoxSizer(wxHORIZONTAL);
-					wxStaticText* nameBox = new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name)));
-					if (groupSetting->name == "Battery" && !SConfig::GetInstance().m_DolphinPro)
-					{
-						setting->wxcontrol->Disable();
-						nameBox->SetToolTip(wxGetTranslation("Upgrade to Dolphin Pro to recharge batteries."));
-					}
-
-					szr->Add(nameBox, 0, wxCENTER | wxRIGHT, 3);
+					szr->Add(new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name))), 0, wxCENTER | wxRIGHT, 3);
 					szr->Add(setting->wxcontrol, 0, wxRIGHT, 3);
 					Add(szr, 0, wxALL | wxCENTER, 3);
 				}

--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -219,6 +219,7 @@ ControllerEmu::Cursor::Cursor(const std::string& _name)
 	settings.emplace_back(new Setting(_trans("Center"), 0.5));
 	settings.emplace_back(new Setting(_trans("Width"), 0.5));
 	settings.emplace_back(new Setting(_trans("Height"), 0.5));
+
 }
 
 void ControllerEmu::LoadDefaults(const ControllerInterface &ciface)


### PR DESCRIPTION
People are going to download Dolphin today, and then they're going to be stuck with this crap for maybe months, because not everyone updates all the time. Dolphin won't tell you to update to resolve the issue, it'll demand that the user needs to _pay_. It will be hard for users to know that this is an April Fools joke. It might not be triggered until weeks later, depending on how much they use Dolphin.