### PR TITLE
Change Wording in Help Menu

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.ui
+++ b/Source/Core/DolphinQt/MainWindow.ui
@@ -122,7 +122,7 @@
   </action>
   <action name="actionGitHub">
    <property name="text">
-    <string>&amp;Dolphin at GitHub</string>
+    <string>&amp;GitHub Repository</string>
    </property>
   </action>
   <action name="actionAbout">

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -387,9 +387,9 @@ wxMenuBar* CFrame::CreateMenu()
 	wxMenu* helpMenu = new wxMenu;
 	// Re-enable when there's something useful to display */
 	// helpMenu->Append(wxID_HELP, _("&Help"));
-	helpMenu->Append(IDM_HELP_WEBSITE, _("Dolphin &Website"));
+	helpMenu->Append(IDM_HELP_WEBSITE, _("&Website"));
 	helpMenu->Append(IDM_HELP_ONLINE_DOCS, _("Online &Documentation"));
-	helpMenu->Append(IDM_HELP_GITHUB, _("Dolphin at &GitHub"));
+	helpMenu->Append(IDM_HELP_GITHUB, _("&GitHub Repository"));
 	helpMenu->AppendSeparator();
 	helpMenu->Append(wxID_ABOUT, _("&About..."));
 	menubar->Append(helpMenu, _("&Help"));


### PR DESCRIPTION
"Dolphin at GitHub" doesn't make much sense IMO. We could also make it say "Source Code" or "Dolphin on GitHub".

I also changed "Dolphin Website" to make it consistent with the Qt version.