### PR TITLE
Make Speed Up Disc Transfer Rate not instant

### DIFF
--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -669,7 +669,7 @@ DVDReadCommand ExecuteReadCommand(u64 DVD_offset, u32 output_address, u32 DVD_le
 	}
 
 	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bFastDiscSpeed)
-		*ticks_until_completion = 0;	// An optional hack to speed up loading times
+		*ticks_until_completion = output_length * BUFFER_TRANSFER_RATE;	// An optional hack to speed up loading times
 	else
 		*ticks_until_completion = SimulateDiscReadTime(DVD_offset, DVD_length);
 


### PR DESCRIPTION
The instant speed broke some games. SUDTR will now emulate the transfer from the disc drive buffer to the main memory, but not the speed of the disc drive itself.