### PR TITLE
Fix for alignment of zero-length files within directory based virtual disk

### DIFF
--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -459,7 +459,7 @@ void CVolumeDirectory::WriteEntry(const File::FSTEntry& entry, u32& fstOffset, u
 		m_virtualDisk.insert(make_pair(dataOffset, entry.physicalName));
 
 		// 4 byte aligned
-		dataOffset = ROUND_UP(dataOffset + entry.size, 0x8000ull);
+		dataOffset = ROUND_UP(dataOffset + std::max<u64>(entry.size, 1ull), 0x8000ull);
 	}
 }
 


### PR DESCRIPTION
When a game is executed from a directory on disk, any zero-length files will not cause an alignment shift for the file that follows it causing them to overlap in the virtual file table.
