### PR TITLE
JitIL: Fix a bug in floatpoint load/store instructions.

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
@@ -1563,7 +1563,6 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 			RI.Jit->SafeLoadToReg(RSCRATCH2, info.first, 32, info.second, regsInUse(RI), false);
 			Jit->MOVD_xmm(reg, R(RSCRATCH2));
 			RI.fregs[reg] = I;
-			regNormalRegClear(RI, I);
 			break;
 		}
 		case LoadDouble:
@@ -1577,7 +1576,6 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 			RI.Jit->SafeLoadToReg(RSCRATCH2, info.first, 64, info.second, regsInUse(RI), false);
 			Jit->MOVQ_xmm(reg, R(RSCRATCH2));
 			RI.fregs[reg] = I;
-			regNormalRegClear(RI, I);
 			break;
 		}
 		case LoadPaired:
@@ -1624,8 +1622,6 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 
 			if (RI.IInfo[I - RI.FirstI] & 4)
 				fregClearInst(RI, getOp1(I));
-			if (RI.IInfo[I - RI.FirstI] & 8)
-				regClearInst(RI, getOp2(I));
 			break;
 		}
 		case StoreDouble:
@@ -1646,8 +1642,6 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 
 			if (RI.IInfo[I - RI.FirstI] & 4)
 				fregClearInst(RI, getOp1(I));
-			if (RI.IInfo[I - RI.FirstI] & 8)
-				regClearInst(RI, getOp2(I));
 			break;
 		}
 		case StorePaired:

--- a/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
@@ -43,8 +43,19 @@ struct RegInfo
 	JitIL *Jit;
 	IRBuilder* Build;
 	InstLoc FirstI;
+
+	// IInfo contains (per instruction)
+	// Bits 0-1: Saturating count of number of instructions referencing this instruction.
+	// Bits 2-3: single bit per operand marking if this is the last instruction to reference that operand's result.
+	//           Used to decide if we should free any registers associated with the operands after this instruction
+	//           and if we can clobber the operands registers.
+	//           Warning, Memory instruction use these bits slightly differently.
+	// Bits 15-31: Spill location
 	std::vector<unsigned> IInfo;
+
+	// The last instruction which uses the result of this instruction. Used by the register allocator.
 	std::vector<InstLoc> lastUsed;
+
 	InstLoc regs[MAX_NUMBER_OF_REGS];
 	InstLoc fregs[MAX_NUMBER_OF_REGS];
 	unsigned numSpills;
@@ -412,6 +423,8 @@ static X64Reg regBinLHSReg(RegInfo& RI, InstLoc I)
 	return reg;
 }
 
+// Clear any registers which end their lifetime at I
+// Don't use this for special instructions like memory load/stores
 static void regNormalRegClear(RegInfo& RI, InstLoc I)
 {
 	if (RI.IInfo[I - RI.FirstI] & 4)
@@ -420,6 +433,7 @@ static void regNormalRegClear(RegInfo& RI, InstLoc I)
 		regClearInst(RI, getOp2(I));
 }
 
+// Clear any floating point registers which end their lifetime at I
 static void fregNormalRegClear(RegInfo& RI, InstLoc I)
 {
 	if (RI.IInfo[I - RI.FirstI] & 4)


### PR DESCRIPTION
The regBuildMemAddress function already clears the address register.

Not only is clearing it again pointless, regBuildMemAddress uses the bits in IInfo slightly differently and the second clear can clear the wrong register, causing bugs if something else actually needs to use those registers.

Fixes [issue 8437](https://code.google.com/p/dolphin-emu/issues/detail?id=8437) and #2166 