### PR TITLE
Common: Remove TLS usage in GetLastErrorMsg

### DIFF
--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -16,6 +16,7 @@
 #endif
 
 #include <cstddef>
+#include <string>
 #include <type_traits>
 #include "Common/CommonTypes.h"
 
@@ -115,7 +116,7 @@ extern "C"
 // Call directly after the command or use the error num.
 // This function might change the error code.
 // Defined in Misc.cpp.
-const char* GetLastErrorMsg();
+std::string GetLastErrorMsg();
 
 namespace Common
 {

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -97,7 +97,7 @@ bool IsDirectory(const std::string &filename)
 	if (result < 0)
 	{
 		WARN_LOG(COMMON, "IsDirectory: stat failed on %s: %s",
-				 filename.c_str(), GetLastErrorMsg());
+				 filename.c_str(), GetLastErrorMsg().c_str());
 		return false;
 	}
 
@@ -129,14 +129,14 @@ bool Delete(const std::string &filename)
 	if (!DeleteFile(UTF8ToTStr(filename).c_str()))
 	{
 		WARN_LOG(COMMON, "Delete: DeleteFile failed on %s: %s",
-				 filename.c_str(), GetLastErrorMsg());
+				 filename.c_str(), GetLastErrorMsg().c_str());
 		return false;
 	}
 #else
 	if (unlink(filename.c_str()) == -1)
 	{
 		WARN_LOG(COMMON, "Delete: unlink failed on %s: %s",
-				 filename.c_str(), GetLastErrorMsg());
+				 filename.c_str(), GetLastErrorMsg().c_str());
 		return false;
 	}
 #endif
@@ -234,7 +234,7 @@ bool DeleteDir(const std::string &filename)
 	if (rmdir(filename.c_str()) == 0)
 		return true;
 #endif
-	ERROR_LOG(COMMON, "DeleteDir: %s: %s", filename.c_str(), GetLastErrorMsg());
+	ERROR_LOG(COMMON, "DeleteDir: %s: %s", filename.c_str(), GetLastErrorMsg().c_str());
 
 	return false;
 }
@@ -262,7 +262,7 @@ bool Rename(const std::string &srcFilename, const std::string &destFilename)
 		return true;
 #endif
 	ERROR_LOG(COMMON, "Rename: failed %s --> %s: %s",
-			  srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg());
+			  srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 	return false;
 }
 
@@ -311,7 +311,7 @@ bool Copy(const std::string &srcFilename, const std::string &destFilename)
 		return true;
 
 	ERROR_LOG(COMMON, "Copy: failed %s --> %s: %s",
-			srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg());
+			srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 	return false;
 #else
 
@@ -326,7 +326,7 @@ bool Copy(const std::string &srcFilename, const std::string &destFilename)
 	if (!input.is_open())
 	{
 		ERROR_LOG(COMMON, "Copy: input failed %s --> %s: %s",
-				srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg());
+				srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 		return false;
 	}
 
@@ -336,7 +336,7 @@ bool Copy(const std::string &srcFilename, const std::string &destFilename)
 	if (!output.IsOpen())
 	{
 		ERROR_LOG(COMMON, "Copy: output failed %s --> %s: %s",
-				srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg());
+				srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 		return false;
 	}
 
@@ -349,7 +349,7 @@ bool Copy(const std::string &srcFilename, const std::string &destFilename)
 		{
 			ERROR_LOG(COMMON,
 					"Copy: failed reading from source, %s --> %s: %s",
-					srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg());
+					srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 			return false;
 		}
 
@@ -358,7 +358,7 @@ bool Copy(const std::string &srcFilename, const std::string &destFilename)
 		{
 			ERROR_LOG(COMMON,
 					"Copy: failed writing to output, %s --> %s: %s",
-					srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg());
+					srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 			return false;
 		}
 	}
@@ -395,7 +395,7 @@ u64 GetSize(const std::string &filename)
 	}
 
 	ERROR_LOG(COMMON, "GetSize: Stat failed %s: %s",
-			filename.c_str(), GetLastErrorMsg());
+			filename.c_str(), GetLastErrorMsg().c_str());
 	return 0;
 }
 
@@ -406,7 +406,7 @@ u64 GetSize(const int fd)
 	if (fstat64(fd, &buf) != 0)
 	{
 		ERROR_LOG(COMMON, "GetSize: stat failed %i: %s",
-			fd, GetLastErrorMsg());
+			fd, GetLastErrorMsg().c_str());
 		return 0;
 	}
 	return buf.st_size;
@@ -420,7 +420,7 @@ u64 GetSize(FILE *f)
 	if (fseeko(f, 0, SEEK_END) != 0)
 	{
 		ERROR_LOG(COMMON, "GetSize: seek failed %p: %s",
-			  f, GetLastErrorMsg());
+			  f, GetLastErrorMsg().c_str());
 		return 0;
 	}
 
@@ -428,7 +428,7 @@ u64 GetSize(FILE *f)
 	if ((size != pos) && (fseeko(f, pos, SEEK_SET) != 0))
 	{
 		ERROR_LOG(COMMON, "GetSize: seek failed %p: %s",
-			  f, GetLastErrorMsg());
+			  f, GetLastErrorMsg().c_str());
 		return 0;
 	}
 
@@ -443,7 +443,7 @@ bool CreateEmptyFile(const std::string &filename)
 	if (!File::IOFile(filename, "wb"))
 	{
 		ERROR_LOG(COMMON, "CreateEmptyFile: failed %s: %s",
-				  filename.c_str(), GetLastErrorMsg());
+				  filename.c_str(), GetLastErrorMsg().c_str());
 		return false;
 	}
 
@@ -656,7 +656,7 @@ std::string GetCurrentDir()
 	if (!(dir = __getcwd(nullptr, 0)))
 	{
 		ERROR_LOG(COMMON, "GetCurrentDirectory failed: %s",
-				GetLastErrorMsg());
+				GetLastErrorMsg().c_str());
 		return nullptr;
 	}
 	std::string strDir = dir;

--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -145,7 +145,7 @@ void FreeMemoryPages(void* ptr, size_t size)
 #endif
 
 		if (error_occurred)
-			PanicAlert("FreeMemoryPages failed!\n%s", GetLastErrorMsg());
+			PanicAlert("FreeMemoryPages failed!\n%s", GetLastErrorMsg().c_str());
 	}
 }
 
@@ -177,7 +177,7 @@ void ReadProtectMemory(void* ptr, size_t size)
 #endif
 
 	if (error_occurred)
-		PanicAlert("ReadProtectMemory failed!\n%s", GetLastErrorMsg());
+		PanicAlert("ReadProtectMemory failed!\n%s", GetLastErrorMsg().c_str());
 }
 
 void WriteProtectMemory(void* ptr, size_t size, bool allowExecute)
@@ -196,7 +196,7 @@ void WriteProtectMemory(void* ptr, size_t size, bool allowExecute)
 #endif
 
 	if (error_occurred)
-		PanicAlert("WriteProtectMemory failed!\n%s", GetLastErrorMsg());
+		PanicAlert("WriteProtectMemory failed!\n%s", GetLastErrorMsg().c_str());
 }
 
 void UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute)
@@ -215,7 +215,7 @@ void UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute)
 #endif
 
 	if (error_occurred)
-		PanicAlert("UnWriteProtectMemory failed!\n%s", GetLastErrorMsg());
+		PanicAlert("UnWriteProtectMemory failed!\n%s", GetLastErrorMsg().c_str());
 }
 
 std::string MemUsage()

--- a/Source/Core/Common/Misc.cpp
+++ b/Source/Core/Common/Misc.cpp
@@ -8,31 +8,23 @@
 
 #include "Common/CommonFuncs.h"
 
-// Neither Android nor OS X support TLS
-#if  defined(__APPLE__) || (ANDROID && __clang__)
-#define __thread
-#endif
-
 // Generic function to get last error message.
 // Call directly after the command or use the error num.
 // This function might change the error code.
-const char* GetLastErrorMsg()
+std::string GetLastErrorMsg()
 {
-	static const size_t buff_size = 255;
+	const size_t buff_size = 256;
+	char err_str[buff_size];
 
 #ifdef _WIN32
-	static __declspec(thread) char err_str[buff_size] = {};
-
 	FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, GetLastError(),
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
 		err_str, buff_size, nullptr);
 #else
-	static __thread char err_str[buff_size] = {};
-
 	// Thread safe (XSI-compliant)
 	if (strerror_r(errno, err_str, buff_size))
-		return nullptr;
+		return "";
 #endif
 
-	return err_str;
+	return std::string(err_str);
 }

--- a/Source/Core/Common/SDCardUtil.cpp
+++ b/Source/Core/Common/SDCardUtil.cpp
@@ -276,6 +276,6 @@ bool SDCardCreate(u64 disk_size /*in MB*/, const std::string& filename)
 FailWrite:
 	ERROR_LOG(COMMON, "Could not write to '%s', aborting...\n", filename.c_str());
 	if (unlink(filename.c_str()) < 0)
-		ERROR_LOG(COMMON, "unlink(%s) failed\n%s", filename.c_str(), GetLastErrorMsg());
+		ERROR_LOG(COMMON, "unlink(%s) failed\n%s", filename.c_str(), GetLastErrorMsg().c_str());
 	return false;
 }


### PR DESCRIPTION
Just return std::string as this code isn't performance critical.