### PR TITLE
Debugger: Fix memory leaks related to grid tables

### DIFF
--- a/Source/Core/DolphinWX/Debugger/DSPRegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/DSPRegisterView.cpp
@@ -70,7 +70,6 @@ wxGridCellAttr *CDSPRegTable::GetAttr(int row, int col, wxGridCellAttr::wxAttrKi
 	if (col == 1)
 		attr->SetTextColour(m_CachedRegHasChanged[row] ? *wxRED : *wxBLACK);
 
-	attr->IncRef();
 	return attr;
 }
 

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -241,7 +241,6 @@ wxGridCellAttr *CRegTable::GetAttr(int row, int col, wxGridCellAttr::wxAttrKind)
 	}
 
 	attr->SetTextColour(red ? *wxRED : *wxBLACK);
-	attr->IncRef();
 	return attr;
 }
 

--- a/Source/Core/DolphinWX/Debugger/WatchView.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchView.cpp
@@ -208,7 +208,7 @@ wxGridCellAttr* CWatchTable::GetAttr(int row, int col, wxGridCellAttr::wxAttrKin
 			attr->SetBackgroundColour(*wxLIGHT_GREY);
 		}
 	}
-	attr->IncRef();
+
 	return attr;
 }
 


### PR DESCRIPTION
Incrementing the reference count here isn't necessary, as they construct with a count of 1. Incrementing again results in the attributes not being freed.