### PR TITLE
DolphinWX: Fix memory leaks relating to the TAS dialog

### DIFF
--- a/Source/Core/DolphinWX/TASInputDlg.cpp
+++ b/Source/Core/DolphinWX/TASInputDlg.cpp
@@ -37,7 +37,6 @@ TASInputDlg::TASInputDlg(wxWindow* parent, wxWindowID id, const wxString& title,
                          const wxPoint& position, const wxSize& size, long style)
 : wxDialog(parent, id, title, position, size, style)
 {
-	CreateBaseLayout();
 }
 
 void TASInputDlg::CreateBaseLayout()
@@ -63,6 +62,7 @@ void TASInputDlg::CreateBaseLayout()
 	m_dpad_down = CreateButton("Down");
 	m_dpad_left = CreateButton("Left");
 
+	m_buttons_dpad = new wxGridSizer(3);
 	m_buttons_dpad->AddSpacer(20);
 	m_buttons_dpad->Add(m_dpad_up.checkbox);
 	m_buttons_dpad->AddSpacer(20);
@@ -92,6 +92,8 @@ void TASInputDlg::CreateWiiLayout(int num)
 {
 	if (m_has_layout)
 		return;
+
+	CreateBaseLayout();
 
 	m_buttons[6] = &m_one;
 	m_buttons[7] = &m_two;
@@ -195,6 +197,8 @@ void TASInputDlg::CreateGCLayout()
 {
 	if (m_has_layout)
 		return;
+
+	CreateBaseLayout();
 
 	m_buttons[6] = &m_x;
 	m_buttons[7] = &m_y;

--- a/Source/Core/DolphinWX/TASInputDlg.h
+++ b/Source/Core/DolphinWX/TASInputDlg.h
@@ -121,5 +121,5 @@ class TASInputDlg : public wxDialog
 
 		bool m_has_layout = false;
 
-		wxGridSizer* const m_buttons_dpad = new wxGridSizer(3);
+		wxGridSizer* m_buttons_dpad;
 };


### PR DESCRIPTION
Initially, the dialogs construct in the background when Dolphin initializes. However, it waits until the user actually makes the dialogs visible to decide on whether to create the Wii or GC control layouts.

Therefore, the call to CreateBaseLayout() essentially creates a sizer that isn't actually attached to a main sizer that is set as the sizer for the dialog to use. So upon destruction, these controls would never actually be destroyed if the user didn't open and then close the TAS dialogs. Gets rid of around 129 memory leaks.