### PR TITLE
NoGUI: Don’t segfault when the DISPLAY environment variable isn’t set

### DIFF
--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -118,6 +118,11 @@ class PlatformX11 : public Platform
 	{
 		XInitThreads();
 		dpy = XOpenDisplay(nullptr);
+		if (!dpy)
+		{
+			PanicAlert("No X11 display found");
+			exit(1);
+		}
 
 		win = XCreateSimpleWindow(dpy, DefaultRootWindow(dpy),
 					  SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowXPos,


### PR DESCRIPTION
An error message is better than a segfault.