### PR TITLE
Fix a warning

### DIFF
--- a/Source/Core/Core/HotkeyManager.h
+++ b/Source/Core/Core/HotkeyManager.h
@@ -39,6 +39,4 @@ namespace HotkeyManagerEmu
 	bool IsEnabled();
 	void Enable(bool enable_toggle);
 	bool IsPressed(int Id, bool held);
-
-	static bool enabled;
 }


### PR DESCRIPTION
HotkeyManagerEmu.enabled is unused, it has been replaced by HotkeyManagerEmu.s_enabled.