### PR TITLE
Main: Remove unnecessary shellapi.h include

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -60,7 +60,6 @@
 #endif
 
 #ifdef _WIN32
-#include <shellapi.h>
 
 #ifndef SM_XVIRTUALSCREEN
 #define SM_XVIRTUALSCREEN 76


### PR DESCRIPTION
The include was introduced by bcf1f54c and made unnecessary by 611f3494.