### PR TITLE
Base.props: Remove DXSDK_DIR from the include path.

### DIFF
--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -23,6 +23,7 @@
     <IntDir>$(BuildRootDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(IntDir)bin\</OutDir>
     <TargetName Condition="'$(ConfigurationType)'=='Application'">$(ProjectName)$(TargetSuffix)</TargetName>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <!--ClCompile Base-->


### PR DESCRIPTION
By overriding the include directories we can ensure we only use the Windows SDK.

This commit makes [this line](https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/AudioCommon/XAudio2Stream.cpp#L10) redundant, but I left it in just to be sure.