### PR TITLE
Fix extracting Wii disc partitions numbered 10 or higher

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -115,39 +115,6 @@ CISOProperties::CISOProperties(const std::string fileName, wxWindow* parent, wxW
 	// Load ISO data
 	OpenISO = DiscIO::CreateVolumeFromFilename(fileName);
 	bool IsWad = OpenISO->IsWadFile();
-	if (OpenISO->IsWiiDisc())
-	{
-		for (int group = 0; group < 4; group++)
-		{
-			for (u32 i = 0; i < 0xFFFFFFFF; i++) // yes, technically there can be OVER NINE THOUSAND partitions...
-			{
-				WiiPartition temp;
-				if ((temp.Partition = DiscIO::CreateVolumeFromFilename(fileName, group, i)) != nullptr)
-				{
-					if ((temp.FileSystem = DiscIO::CreateFileSystem(temp.Partition)) != nullptr)
-					{
-						temp.FileSystem->GetFileList(temp.Files);
-						WiiDisc.push_back(temp);
-					}
-				}
-				else
-				{
-					break;
-				}
-			}
-		}
-	}
-	else
-	{
-		// TODO : Should we add a way to browse the wad file ?
-		if (!IsWad)
-		{
-			GCFiles.clear();
-			pFileSystem = DiscIO::CreateFileSystem(OpenISO);
-			if (pFileSystem)
-				pFileSystem->GetFileList(GCFiles);
-		}
-	}
 
 	// TODO: Is it really necessary to use GetTitleID in case GetUniqueID fails?
 	game_id = OpenISO->GetUniqueID();
@@ -274,19 +241,41 @@ CISOProperties::CISOProperties(const std::string fileName, wxWindow* parent, wxW
 	{
 		if (OpenISO->IsWiiDisc())
 		{
-			for (u32 i = 0; i < WiiDisc.size(); i++)
+			int partition_count = 0;
+			for (int group = 0; group < 4; group++)
 			{
-				WiiPartition partition = WiiDisc.at(i);
-				wxTreeItemId PartitionRoot =
-					m_Treectrl->AppendItem(RootId, wxString::Format(_("Partition %i"), i), 0, 0);
-				CreateDirectoryTree(PartitionRoot, partition.Files, 1, partition.Files.at(0)->m_FileSize);
-				if (i == 1)
-					m_Treectrl->Expand(PartitionRoot);
+				for (u32 i = 0; i < 0xFFFFFFFF; i++) // yes, technically there can be OVER NINE THOUSAND partitions...
+				{
+					WiiPartition partition;
+					if ((partition.Partition = DiscIO::CreateVolumeFromFilename(fileName, group, i)) != nullptr)
+					{
+						if ((partition.FileSystem = DiscIO::CreateFileSystem(partition.Partition)) != nullptr)
+						{
+							partition.FileSystem->GetFileList(partition.Files);
+							wxTreeItemId PartitionRoot =
+								m_Treectrl->AppendItem(RootId, wxString::Format(_("Partition %i"), partition_count), 0, 0);
+							m_Treectrl->SetItemData(PartitionRoot, new WiiPartition(partition));
+							CreateDirectoryTree(PartitionRoot, partition.Files, 1, partition.Files.at(0)->m_FileSize);
+							if (partition_count == 1)
+								m_Treectrl->Expand(PartitionRoot);
+							partition_count++;
+						}
+					}
+					else
+					{
+						break;
+					}
+				}
 			}
 		}
-		else if (!GCFiles.empty())
+		else
 		{
-			CreateDirectoryTree(RootId, GCFiles, 1, GCFiles.at(0)->m_FileSize);
+			GCFiles.clear();
+			pFileSystem = DiscIO::CreateFileSystem(OpenISO);
+			if (pFileSystem)
+				pFileSystem->GetFileList(GCFiles);
+			if (!GCFiles.empty())
+				CreateDirectoryTree(RootId, GCFiles, 1, GCFiles.at(0)->m_FileSize);
 		}
 
 		m_Treectrl->Expand(RootId);
@@ -297,8 +286,7 @@ CISOProperties::~CISOProperties()
 {
 	if (!OpenISO->IsWiiDisc() && !OpenISO->IsWadFile() && pFileSystem)
 		delete pFileSystem;
-	// two vector's items are no longer valid after deleting filesystem
-	WiiDisc.clear();
+	// vector's items are no longer valid after deleting filesystem
 	GCFiles.clear();
 	delete OpenGameListItem;
 	delete OpenISO;
@@ -767,11 +755,8 @@ void CISOProperties::OnExtractFile(wxCommandEvent& WXUNUSED (event))
 
 	if (OpenISO->IsWiiDisc())
 	{
-		size_t slash_index = File.find('/');
-		int partitionNum = wxAtoi(File.Mid(slash_index - 1, 1));
-
-		File.erase(0, slash_index + 1); // Remove "Partition x/"
-		WiiDisc.at(partitionNum).FileSystem->ExportFile(WxStrToStr(File), WxStrToStr(Path));
+		WiiPartition* partition = reinterpret_cast<WiiPartition*>(m_Treectrl->GetItemData(m_Treectrl->GetSelection()));
+		partition->FileSystem->ExportFile(WxStrToStr(File), WxStrToStr(Path));
 	}
 	else
 	{
@@ -779,9 +764,9 @@ void CISOProperties::OnExtractFile(wxCommandEvent& WXUNUSED (event))
 	}
 }
 
-void CISOProperties::ExportDir(const std::string& _rFullPath, const std::string& _rExportFolder, const int partitionNum)
+void CISOProperties::ExportDir(const std::string& _rFullPath, const std::string& _rExportFolder, const WiiPartition* partition)
 {
-	DiscIO::IFileSystem* const fs = OpenISO->IsWiiDisc() ? WiiDisc[partitionNum].FileSystem : pFileSystem;
+	DiscIO::IFileSystem* const fs = OpenISO->IsWiiDisc() ? partition->FileSystem : pFileSystem;
 
 	std::vector<const DiscIO::SFileInfo*> fst;
 	fs->GetFileList(fst);
@@ -882,10 +867,20 @@ void CISOProperties::OnExtractDir(wxCommandEvent& event)
 	if (event.GetId() == IDM_EXTRACTALL)
 	{
 		if (OpenISO->IsWiiDisc())
-			for (u32 i = 0; i < WiiDisc.size(); i++)
-				ExportDir("", WxStrToStr(Path), i);
+		{
+			wxTreeItemIdValue cookie;
+			wxTreeItemId root = m_Treectrl->GetRootItem();
+			wxTreeItemId item = m_Treectrl->GetFirstChild(root, cookie);
+			while (item.IsOk())
+			{
+				ExportDir("", WxStrToStr(Path), reinterpret_cast<WiiPartition*>(m_Treectrl->GetItemData(item)));
+				item = m_Treectrl->GetNextChild(root, cookie);
+			}
+		}
 		else
+		{
 			ExportDir("", WxStrToStr(Path));
+		}
 
 		return;
 	}
@@ -902,11 +897,9 @@ void CISOProperties::OnExtractDir(wxCommandEvent& event)
 
 	if (OpenISO->IsWiiDisc())
 	{
-		size_t slash_index = Directory.find('/');
-		int partitionNum = wxAtoi(Directory.Mid(slash_index - 1, 1));
-
-		Directory.erase(0, slash_index + 1); // Remove "Partition x/"
-		ExportDir(WxStrToStr(Directory), WxStrToStr(Path), partitionNum);
+		WiiPartition* partition = reinterpret_cast<WiiPartition*>(m_Treectrl->GetItemData(m_Treectrl->GetSelection()));
+		Directory.erase(0, m_Treectrl->GetItemText(m_Treectrl->GetSelection()).length() + 1); // Remove "Partition x/"
+		ExportDir(WxStrToStr(Directory), WxStrToStr(Path), partition);
 	}
 	else
 	{
@@ -924,19 +917,8 @@ void CISOProperties::OnExtractDataFromHeader(wxCommandEvent& event)
 
 	if (OpenISO->IsWiiDisc())
 	{
-		wxString Directory = m_Treectrl->GetItemText(m_Treectrl->GetSelection());
-		unsigned int partitionNum = wxAtoi(Directory.Mid(Directory.find_first_of("0123456789"), 2));
-
-		if (WiiDisc.size() > partitionNum)
-		{
-			// Get the filesystem of the LAST partition
-			FS = WiiDisc.at(partitionNum).FileSystem;
-		}
-		else
-		{
-			WxUtils::ShowErrorDialog(wxString::Format(_("Partition doesn't exist: %d"), partitionNum));
-			return;
-		}
+		WiiPartition* partition = reinterpret_cast<WiiPartition*>(m_Treectrl->GetItemData(m_Treectrl->GetSelection()));
+		FS = partition->FileSystem;
 	}
 	else
 	{
@@ -982,19 +964,12 @@ void CISOProperties::CheckPartitionIntegrity(wxCommandEvent& event)
 	if (!OpenISO->IsWiiDisc())
 		return;
 
-	wxString PartitionName = m_Treectrl->GetItemText(m_Treectrl->GetSelection());
-	if (!PartitionName)
-		return;
-
-	// Get the partition number from the item text ("Partition N")
-	int PartitionNum = wxAtoi(PartitionName.Mid(PartitionName.find_first_of("0123456789"), 1));
-	const WiiPartition& Partition = WiiDisc[PartitionNum];
-
 	wxProgressDialog dialog(_("Checking integrity..."), _("Working..."), 1000, this,
 		wxPD_APP_MODAL | wxPD_ELAPSED_TIME | wxPD_SMOOTH
 	);
 
-	IntegrityCheckThread thread(Partition);
+	WiiPartition* partition = reinterpret_cast<WiiPartition*>(m_Treectrl->GetItemData(m_Treectrl->GetSelection()));
+	IntegrityCheckThread thread(*partition);
 	thread.Run();
 
 	while (thread.IsAlive())
@@ -1008,9 +983,9 @@ void CISOProperties::CheckPartitionIntegrity(wxCommandEvent& event)
 	if (!thread.Wait())
 	{
 		wxMessageBox(
-			wxString::Format(_("Integrity check for partition %d failed. "
-							   "Your dump is most likely corrupted or has been "
-							   "patched incorrectly."), PartitionNum),
+			wxString::Format(_("Integrity check for %s failed. The disc image is most "
+			                   "likely corrupted or has been patched incorrectly."),
+			                 m_Treectrl->GetItemText(m_Treectrl->GetSelection())),
 			_("Integrity Check Error"), wxOK | wxICON_ERROR, this
 		);
 	}

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -40,8 +40,9 @@ class wxWindow;
 namespace DiscIO { struct SFileInfo; }
 namespace Gecko { class CodeConfigPanel; }
 
-struct WiiPartition
+class WiiPartition final : public wxTreeItemData
 {
+public:
 	DiscIO::IVolume *Partition;
 	DiscIO::IFileSystem *FileSystem;
 	std::vector<const DiscIO::SFileInfo *> Files;
@@ -74,8 +75,6 @@ public:
 
 private:
 	DECLARE_EVENT_TABLE();
-
-	std::vector<WiiPartition> WiiDisc;
 
 	DiscIO::IVolume *OpenISO;
 	DiscIO::IFileSystem *pFileSystem;
@@ -227,7 +226,7 @@ private:
 			const size_t _FirstIndex,
 			const size_t _LastIndex);
 	void ExportDir(const std::string& _rFullPath, const std::string& _rExportFilename,
-			const int partitionNum = 0);
+			const WiiPartition* partition = nullptr);
 
 	IniFile GameIniDefault;
 	IniFile GameIniLocal;


### PR DESCRIPTION
Instead of trying to get the partition number from the (localized!) item name, the partitions are now stored as item data. Fixes https://code.google.com/p/dolphin-emu/issues/detail?id=8460