### PR TITLE
Debugger: Update the registers/watches before refreshing grids.

### DIFF
--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -262,8 +262,8 @@ CRegisterView::CRegisterView(wxWindow *parent, wxWindowID id)
 
 void CRegisterView::Update()
 {
-	ForceRefresh();
 	m_register_table->UpdateCachedRegs();
+	ForceRefresh();
 }
 
 void CRegisterView::OnMouseDownR(wxGridEvent& event)

--- a/Source/Core/DolphinWX/Debugger/WatchView.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchView.cpp
@@ -230,8 +230,8 @@ void CWatchView::Update()
 {
 	if (PowerPC::GetState() != PowerPC::CPU_POWERDOWN)
 	{
-		ForceRefresh();
 		m_watch_table->UpdateWatch();
+		ForceRefresh();
 	}
 }
 


### PR DESCRIPTION
Values now update more correctly.