### PR TITLE
PerfQueryBase: Move common implementation variables into base class

### DIFF
--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -6,7 +6,6 @@ namespace DX11 {
 
 PerfQuery::PerfQuery()
 	: m_query_read_pos()
-	, m_query_count()
 {
 	for (ActiveQuery& entry : m_query_buffer)
 	{

--- a/Source/Core/VideoBackends/D3D/PerfQuery.h
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.h
@@ -36,10 +36,6 @@ private:
 
 	std::array<ActiveQuery, PERF_QUERY_BUFFER_SIZE> m_query_buffer;
 	int m_query_read_pos;
-
-	// TODO: sloppy
-	volatile int m_query_count;
-	volatile u32 m_results[PQG_NUM_MEMBERS];
 };
 
 } // namespace

--- a/Source/Core/VideoBackends/OGL/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/OGL/PerfQuery.cpp
@@ -22,7 +22,6 @@ PerfQueryBase* GetPerfQuery()
 
 PerfQuery::PerfQuery()
 	: m_query_read_pos()
-	, m_query_count()
 {
 	ResetQuery();
 }

--- a/Source/Core/VideoBackends/OGL/PerfQuery.h
+++ b/Source/Core/VideoBackends/OGL/PerfQuery.h
@@ -37,10 +37,6 @@ protected:
 	std::array<ActiveQuery, PERF_QUERY_BUFFER_SIZE> m_query_buffer;
 	u32 m_query_read_pos;
 
-	// TODO: sloppy
-	volatile u32 m_query_count;
-	volatile u32 m_results[PQG_NUM_MEMBERS];
-
 private:
 	// Implementation
 	std::unique_ptr<PerfQuery> m_query;

--- a/Source/Core/VideoCommon/PerfQueryBase.h
+++ b/Source/Core/VideoCommon/PerfQueryBase.h
@@ -24,7 +24,11 @@ enum PerfQueryGroup
 class PerfQueryBase
 {
 public:
-	PerfQueryBase() {}
+	PerfQueryBase()
+		: m_query_count(0)
+	{
+	}
+
 	virtual ~PerfQueryBase() {}
 
 	// Checks if performance queries are enabled in the gameini configuration.
@@ -50,6 +54,11 @@ public:
 	// True if there are no further pending query results
 	// NOTE: Called from CPU thread
 	virtual bool IsFlushed() const { return true; }
+
+protected:
+	// TODO: sloppy
+	volatile u32 m_query_count;
+	volatile u32 m_results[PQG_NUM_MEMBERS];
 };
 
 extern PerfQueryBase* g_perf_query;


### PR DESCRIPTION
Reduces duplication of code.