### PR TITLE
UICommon: Respect XDG Base Directory Specification on POSIX systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,6 @@ else()
 	set(datadir ${CMAKE_INSTALL_PREFIX}/share/dolphin-emu CACHE PATH "datadir")
 	add_definitions(-DDATA_DIR="${datadir}/")
 endif()
-set(userdir ".dolphin-emu" CACHE STRING "User directory")
-add_definitions(-DUSER_DIR="${userdir}")
 
 # Set where the binary files will be built.  The program will not execute from
 # here.  You must run "make install" to install these to the proper location

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -54,7 +54,7 @@
 #define GAMESETTINGS_DIR    "GameSettings"
 #define MAPS_DIR            "Maps"
 #define CACHE_DIR           "Cache"
-#define SHADERCACHE_DIR     "ShaderCache"
+#define SHADERCACHE_DIR     "Shaders"
 #define STATESAVES_DIR      "StateSaves"
 #define SCREENSHOTS_DIR     "ScreenShots"
 #define LOAD_DIR            "Load"
@@ -72,6 +72,9 @@
 #define THEMES_DIR          "Themes"
 #define ANAGLYPH_DIR        "Anaglyph"
 #define PIPES_DIR           "Pipes"
+
+// This one is only used to remove it if it was present
+#define SHADERCACHE_LEGACY_DIR "ShaderCache"
 
 // Filenames
 // Files in the directory returned by GetUserPath(D_CONFIG_IDX)

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -24,11 +24,7 @@
 	#define DOLPHIN_DATA_DIR "/sdcard/dolphin-emu"
 #else
 	#define USERDATA_DIR "user"
-	#ifdef USER_DIR
-		#define DOLPHIN_DATA_DIR USER_DIR
-	#else
-		#define DOLPHIN_DATA_DIR ".dolphin"
-	#endif
+	#define DOLPHIN_DATA_DIR "dolphin-emu"
 #endif
 
 // Shared data dirs (Sys and shared User for Linux)

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -776,7 +776,7 @@ static void RebuildUserDirectories(unsigned int dir_index)
 		s_user_paths[D_GAMESETTINGS_IDX]   = s_user_paths[D_USER_IDX] + GAMESETTINGS_DIR DIR_SEP;
 		s_user_paths[D_MAPS_IDX]           = s_user_paths[D_USER_IDX] + MAPS_DIR DIR_SEP;
 		s_user_paths[D_CACHE_IDX]          = s_user_paths[D_USER_IDX] + CACHE_DIR DIR_SEP;
-		s_user_paths[D_SHADERCACHE_IDX]    = s_user_paths[D_USER_IDX] + SHADERCACHE_DIR DIR_SEP;
+		s_user_paths[D_SHADERCACHE_IDX]    = s_user_paths[D_CACHE_IDX] + SHADERCACHE_DIR DIR_SEP;
 		s_user_paths[D_SHADERS_IDX]        = s_user_paths[D_USER_IDX] + SHADERS_DIR DIR_SEP;
 		s_user_paths[D_STATESAVES_IDX]     = s_user_paths[D_USER_IDX] + STATESAVES_DIR DIR_SEP;
 		s_user_paths[D_SCREENSHOTS_IDX]    = s_user_paths[D_USER_IDX] + SCREENSHOTS_DIR DIR_SEP;
@@ -799,12 +799,20 @@ static void RebuildUserDirectories(unsigned int dir_index)
 		s_user_paths[F_ARAMDUMP_IDX]       = s_user_paths[D_DUMP_IDX] + ARAM_DUMP;
 		s_user_paths[F_FAKEVMEMDUMP_IDX]   = s_user_paths[D_DUMP_IDX] + FAKEVMEM_DUMP;
 		s_user_paths[F_GCSRAM_IDX]         = s_user_paths[D_GCUSER_IDX] + GC_SRAM;
+
+		// The shader cache has moved to the cache directory, so remove the old one.
+		// TODO: remove that someday.
+		File::DeleteDirRecursively(s_user_paths[D_USER_IDX] + SHADERCACHE_LEGACY_DIR DIR_SEP);
 		break;
 
 	case D_CONFIG_IDX:
 		s_user_paths[F_DOLPHINCONFIG_IDX]  = s_user_paths[D_CONFIG_IDX] + DOLPHIN_CONFIG;
 		s_user_paths[F_DEBUGGERCONFIG_IDX] = s_user_paths[D_CONFIG_IDX] + DEBUGGER_CONFIG;
 		s_user_paths[F_LOGGERCONFIG_IDX]   = s_user_paths[D_CONFIG_IDX] + LOGGER_CONFIG;
+		break;
+
+	case D_CACHE_IDX:
+		s_user_paths[D_SHADERCACHE_IDX]    = s_user_paths[D_CACHE_IDX] + SHADERCACHE_DIR DIR_SEP;
 		break;
 
 	case D_GCUSER_IDX:

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -137,11 +137,50 @@ void SetUserDirectory(const std::string& custom_path)
 		user_path += DIR_SEP;
 #else
 	if (File::Exists(ROOT_DIR DIR_SEP USERDATA_DIR))
+	{
 		user_path = ROOT_DIR DIR_SEP USERDATA_DIR DIR_SEP;
+	}
 	else
-		user_path = std::string(getenv("HOME") ?
-			getenv("HOME") : getenv("PWD") ?
-			getenv("PWD") : "") + DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
+	{
+		const char* home = getenv("HOME");
+		if (!home)
+			home = getenv("PWD");
+		if (!home)
+			home = "";
+		std::string home_path = std::string(home) + DIR_SEP;
+
+#if defined(__APPLE__) || defined(ANDROID)
+		user_path = home_path + DOLPHIN_DATA_DIR DIR_SEP;
+#else
+		// We are on a non-Apple and non-Android POSIX system, let's respect XDG basedir.
+		// The only case we don't is when there is an existing ~/.dolphin-emu directory.
+		// See http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
+		user_path = home_path + "." DOLPHIN_DATA_DIR DIR_SEP;
+		if (!File::Exists(user_path))
+		{
+			const char* data_home = getenv("XDG_DATA_HOME");
+			std::string data_path = std::string(data_home && data_home[0] == '/' ?
+				data_home :
+				(home_path + ".local" DIR_SEP "share")) + DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
+
+			const char* config_home = getenv("XDG_CONFIG_HOME");
+			std::string config_path = std::string(config_home && config_home[0] == '/' ?
+				config_home :
+				(home_path + ".config")) + DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
+
+			const char* cache_home = getenv("XDG_CACHE_HOME");
+			std::string cache_path = std::string(cache_home && cache_home[0] == '/' ?
+				cache_home :
+				(home_path + ".cache")) + DIR_SEP DOLPHIN_DATA_DIR DIR_SEP;
+
+			File::SetUserPath(D_USER_IDX, data_path);
+			File::SetUserPath(D_CONFIG_IDX, config_path);
+			File::SetUserPath(D_CACHE_IDX, cache_path);
+			return;
+		}
+#endif
+	}
 #endif
 	File::SetUserPath(D_USER_IDX, user_path);
 }


### PR DESCRIPTION
I haven’t tested on anything but Linux, so I’d like to get some testing at least on OSX and Android, to make sure I didn’t mess anything.

Also I’m not sure what to do wrt migration, I’d be for letting the user do it by themselves, but perhaps a warning that they have an old $HOME/.dolphin-emu directory would be better.