### PR TITLE
Core: Don't display on-screen messages via DisplayMessage until emulation has begun

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -140,6 +140,9 @@ std::string StopMessage(bool bMainThread, std::string Message)
 
 void DisplayMessage(const std::string& message, int time_in_ms)
 {
+	if (!IsRunning())
+		return;
+
 	// Actually displaying non-ASCII could cause things to go pear-shaped
 	for (const char& c : message)
 	{


### PR DESCRIPTION
This is called by some UI code to display when some settings are changed. However, it's possible to change some settings (e.g. save state slots) when emulation is not currently running. Doing so then would cause the emulator to crash.