### PR TITLE
DiscIO: Add a missing header to Volume.h

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 
 namespace DiscIO


### PR DESCRIPTION
The previous volume refactor didn't include the header where all of the swap functions are.