### PR TITLE
Fix WAD crash caused by VolumeHandler removal

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -242,7 +242,10 @@ bool CBoot::SetupWiiMemory(IVolume::ECountry country)
 	0x80000060  Copyright code
 	*/
 
-	DVDInterface::DVDRead(0x00000000, 0x00000000, 0x20, false);        // Game Code
+	// When booting a WAD or the system menu, there will probably not be a disc inserted
+	if (DVDInterface::VolumeIsValid())
+		DVDInterface::DVDRead(0x00000000, 0x00000000, 0x20, false); // Game Code
+
 	Memory::Write_U32(0x0D15EA5E, 0x00000020);                  // Another magic word
 	Memory::Write_U32(0x00000001, 0x00000024);                  // Unknown
 	Memory::Write_U32(Memory::REALRAM_SIZE, 0x00000028);        // MEM1 size 24MB


### PR DESCRIPTION
Boot_BS2Emu was trying to read from the inserted disc even when nothing was inserted, and this happened to not crash (but not work either) before VolumeHandler was removed. This commit adds a check that restores the old behavior, so there is no longer a crash, but the game ID still doesn't get set for WADs. I don't know if/how it should be set, so this felt like the safest option.