### PR TITLE
Fix emulated Wii Remote battery level being low when not configured

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -302,7 +302,7 @@ Wiimote::Wiimote( const unsigned int index )
 	m_options->settings.emplace_back(new ControlGroup::Setting(_trans("Upright Wiimote"), false));
 	m_options->settings.emplace_back(new ControlGroup::IterateUI(_trans("Iterative Input")));
 	m_options->settings.emplace_back(new ControlGroup::Setting(_trans("Speaker Pan"), 0, -127, 127));
-	m_options->settings.emplace_back(new ControlGroup::Setting(_trans("Battery"), 95, 0, 255));
+	m_options->settings.emplace_back(new ControlGroup::Setting(_trans("Battery"), 95.0 / 100, 0, 255));
 
 	// TODO: This value should probably be re-read if SYSCONF gets changed
 	m_sensor_bar_on_top = SConfig::GetInstance().m_SYSCONF->GetData<u8>("BT.BAR") != 0;


### PR DESCRIPTION
All the multiplying and dividing by 100 in controller configs is messy... An attempted solution to the problem was to not multiply default_value by 100 in ControllerEmu::ControlGroup::LoadConfig, but that broke other things instead, so I went with this.