### PR TITLE
ISOProperties: Don't block when opening default INI in text editor

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -195,7 +195,7 @@ private:
 		IDM_BNRSAVEAS
 	};
 
-	void LaunchExternalEditor(const std::string& filename);
+	void LaunchExternalEditor(const std::string& filename, bool wait_until_closed);
 
 	void CreateGUIControls(bool);
 	void OnClose(wxCloseEvent& event);


### PR DESCRIPTION
The purpose of blocking is to reload user INIs after they have been edited. However, ISOProperties never reloads default INIs, because they aren't meant to be edited. Blocking on default INIs is thus useless, and it's rather annoying for games that have two default INIs, because it makes it impossible to see both at once.