### PR TITLE
Qt: Check if game filename is null before loading it.

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -160,7 +160,9 @@ void DMainWindow::DoStartPause()
 
 void DMainWindow::OnOpen()
 {
-	StartGame(ShowFileDialog());
+	QString filename = ShowFileDialog();
+	if (!filename.isNull())
+		StartGame(filename);
 }
 
 void DMainWindow::OnPlay()


### PR DESCRIPTION
This is so that the error message box does not
appear if the user simply cancels loading a game.