### PR TITLE
DolphinWX: Make some UI functions/members private

### DIFF
--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -20,12 +20,14 @@ class ControllerConfigDiag : public wxDialog
 public:
 	ControllerConfigDiag(wxWindow* const parent);
 
+private:
 	void RefreshRealWiimotes(wxCommandEvent& event);
+
+	void ConfigEmulatedWiimote(wxCommandEvent& event);
 
 	void SelectSource(wxCommandEvent& event);
 	void RevertSource();
 
-	void ConfigEmulatedWiimote(wxCommandEvent& event);
 	void Save(wxCommandEvent& event);
 
 	void OnSensorBarPos(wxCommandEvent& event)
@@ -33,39 +35,44 @@ public:
 		SConfig::GetInstance().m_SYSCONF->SetData("BT.BAR", event.GetInt());
 		event.Skip();
 	}
+
 	void OnSensorBarSensitivity(wxCommandEvent& event)
 	{
 		SConfig::GetInstance().m_SYSCONF->SetData("BT.SENS", event.GetInt());
 		event.Skip();
 	}
+
 	void OnSpeakerVolume(wxCommandEvent& event)
 	{
 		SConfig::GetInstance().m_SYSCONF->SetData("BT.SPKV", event.GetInt());
 		event.Skip();
 	}
+
 	void OnMotor(wxCommandEvent& event)
 	{
 		SConfig::GetInstance().m_SYSCONF->SetData("BT.MOT", event.GetInt());
 		event.Skip();
 	}
+
 	void OnContinuousScanning(wxCommandEvent& event)
 	{
 		SConfig::GetInstance().m_WiimoteContinuousScanning = event.IsChecked();
 		WiimoteReal::Initialize();
 		event.Skip();
 	}
+
 	void OnEnableSpeaker(wxCommandEvent& event)
 	{
 		SConfig::GetInstance().m_WiimoteEnableSpeaker = event.IsChecked();
 		event.Skip();
 	}
+
 	void OnGameCubeAdapter(wxCommandEvent& event)
 	{
 		SConfig::GetInstance().m_GameCubeAdapter = event.IsChecked();
 		event.Skip();
 	}
 
-private:
 	wxStaticBoxSizer* CreateGamecubeSizer();
 	wxStaticBoxSizer* CreateWiimoteConfigSizer();
 	wxStaticBoxSizer* CreateBalanceBoardSizer();

--- a/Source/Core/DolphinWX/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Debugger/CodeView.h
@@ -30,19 +30,10 @@ class CCodeView : public wxControl
 public:
 	CCodeView(DebugInterface* debuginterface, SymbolDB *symbol_db,
 			wxWindow* parent, wxWindowID Id = wxID_ANY);
-	void OnPaint(wxPaintEvent& event);
-	void OnErase(wxEraseEvent& event);
-	void OnScrollWheel(wxMouseEvent& event);
-	void OnMouseDown(wxMouseEvent& event);
-	void OnMouseMove(wxMouseEvent& event);
-	void OnMouseUpL(wxMouseEvent& event);
-	void OnMouseUpR(wxMouseEvent& event);
-	void OnPopupMenu(wxCommandEvent& event);
-	void InsertBlrNop(int);
 
 	void ToggleBreakpoint(u32 address);
 
-	u32 GetSelection()
+	u32 GetSelection() const
 	{
 		return m_selection;
 	}
@@ -60,6 +51,16 @@ public:
 	}
 
 private:
+	void OnPaint(wxPaintEvent& event);
+	void OnErase(wxEraseEvent& event);
+	void OnScrollWheel(wxMouseEvent& event);
+	void OnMouseDown(wxMouseEvent& event);
+	void OnMouseMove(wxMouseEvent& event);
+	void OnMouseUpL(wxMouseEvent& event);
+	void OnMouseUpR(wxMouseEvent& event);
+	void OnPopupMenu(wxCommandEvent& event);
+	void InsertBlrNop(int);
+
 	void RaiseEvent();
 	int YToAddress(int y);
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -75,10 +75,6 @@ public:
 	void UpdateManager();
 
 	// Menu bar
-	// -------------------
-	void OnCPUMode(wxCommandEvent& event); // CPU Mode menu
-	void OnJITOff(wxCommandEvent& event);
-
 	void ToggleCodeWindow(bool bShow);
 	void ToggleRegisterWindow(bool bShow);
 	void ToggleWatchWindow(bool bShow);
@@ -87,14 +83,6 @@ public:
 	void ToggleJitWindow(bool bShow);
 	void ToggleSoundWindow(bool bShow);
 	void ToggleVideoWindow(bool bShow);
-
-	void OnChangeFont(wxCommandEvent& event);
-
-	void OnCodeStep(wxCommandEvent& event);
-	void OnAddrBoxChange(wxCommandEvent& event);
-	void OnSymbolsMenu(wxCommandEvent& event);
-	void OnJitMenu(wxCommandEvent& event);
-	void OnProfilerMenu(wxCommandEvent& event);
 
 	// Sub dialogs
 	CRegisterWindow* m_RegisterWindow;
@@ -111,6 +99,16 @@ public:
 	int iNbAffiliation[IDM_CODE_WINDOW - IDM_LOG_WINDOW + 1];
 
 private:
+	void OnCPUMode(wxCommandEvent& event);
+
+	void OnChangeFont(wxCommandEvent& event);
+
+	void OnCodeStep(wxCommandEvent& event);
+	void OnAddrBoxChange(wxCommandEvent& event);
+	void OnSymbolsMenu(wxCommandEvent& event);
+	void OnJitMenu(wxCommandEvent& event);
+	void OnProfilerMenu(wxCommandEvent& event);
+
 	void OnSymbolListChange(wxCommandEvent& event);
 	void OnSymbolListContextMenu(wxContextMenuEvent& event);
 	void OnCallstackListChange(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Debugger/MemoryView.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.h
@@ -16,16 +16,9 @@ class CMemoryView : public wxControl
 {
 public:
 	CMemoryView(DebugInterface* debuginterface, wxWindow* parent);
-	void OnPaint(wxPaintEvent& event);
-	void OnMouseDownL(wxMouseEvent& event);
-	void OnMouseMove(wxMouseEvent& event);
-	void OnMouseUpL(wxMouseEvent& event);
-	void OnMouseDownR(wxMouseEvent& event);
-	void OnScrollWheel(wxMouseEvent& event);
-	void OnPopupMenu(wxCommandEvent& event);
 
-	u32 GetSelection() { return selection ; }
-	int GetMemoryType() { return memory; }
+	u32 GetSelection() const { return selection ; }
+	int GetMemoryType() const { return memory; }
 
 	void Center(u32 addr)
 	{
@@ -36,6 +29,14 @@ public:
 	int curAddress; // Will be accessed by parent
 
 private:
+	void OnPaint(wxPaintEvent& event);
+	void OnMouseDownL(wxMouseEvent& event);
+	void OnMouseMove(wxMouseEvent& event);
+	void OnMouseUpL(wxMouseEvent& event);
+	void OnMouseDownR(wxMouseEvent& event);
+	void OnScrollWheel(wxMouseEvent& event);
+	void OnPopupMenu(wxCommandEvent& event);
+
 	int YToAddress(int y);
 	void OnResize(wxSizeEvent& event);
 

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.h
@@ -32,12 +32,6 @@ public:
 	              long style = wxTAB_TRAVERSAL | wxBORDER_NONE,
 	              const wxString& name = _("Memory"));
 
-	wxCheckBox* chk8;
-	wxCheckBox* chk16;
-	wxCheckBox* chk32;
-	wxButton*   btnSearch;
-	wxCheckBox* chkAscii;
-	wxCheckBox* chkHex;
 	void Save(IniFile& _IniFile) const;
 	void Load(IniFile& _IniFile);
 
@@ -48,13 +42,6 @@ public:
 
 private:
 	DECLARE_EVENT_TABLE()
-
-	CMemoryView* memview;
-	wxListBox* symbols;
-
-	wxButton* buttonGo;
-	wxTextCtrl* addrbox;
-	wxTextCtrl* valbox;
 
 	void U8(wxCommandEvent& event);
 	void U16(wxCommandEvent& event);
@@ -71,4 +58,18 @@ private:
 	void OnDumpMemory(wxCommandEvent& event);
 	void OnDumpMem2(wxCommandEvent& event);
 	void OnDumpFakeVMEM(wxCommandEvent& event);
+
+	wxCheckBox* chk8;
+	wxCheckBox* chk16;
+	wxCheckBox* chk32;
+	wxButton*   btnSearch;
+	wxCheckBox* chkAscii;
+	wxCheckBox* chkHex;
+
+	CMemoryView* memview;
+	wxListBox* symbols;
+
+	wxButton* buttonGo;
+	wxTextCtrl* addrbox;
+	wxTextCtrl* valbox;
 };

--- a/Source/Core/DolphinWX/Debugger/RegisterView.h
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.h
@@ -71,10 +71,11 @@ class CRegisterView : public wxGrid
 public:
 	CRegisterView(wxWindow* parent, wxWindowID id = wxID_ANY);
 	void Update() override;
+
+private:
 	void OnMouseDownR(wxGridEvent& event);
 	void OnPopupMenu(wxCommandEvent& event);
 
-private:
 	u32 m_selectedAddress = 0;
 
 	// Owned by wx. Deleted implicitly upon destruction.

--- a/Source/Core/DolphinWX/Debugger/WatchView.h
+++ b/Source/Core/DolphinWX/Debugger/WatchView.h
@@ -46,10 +46,11 @@ class CWatchView : public wxGrid
 public:
 	CWatchView(wxWindow* parent, wxWindowID id = wxID_ANY);
 	void Update() override;
+
+private:
 	void OnMouseDownR(wxGridEvent& event);
 	void OnPopupMenu(wxCommandEvent& event);
 
-private:
 	u32 m_selectedAddress = 0;
 	u32 m_selectedRow = 0;
 	CWatchTable* m_watch_table;

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -216,6 +216,11 @@ void InputConfigDialog::ClickSave(wxCommandEvent& event)
 	event.Skip();
 }
 
+int ControlDialog::GetRangeSliderValue() const
+{
+	return range_slider->GetValue();
+}
+
 void ControlDialog::UpdateListContents()
 {
 	control_lbox->Clear();
@@ -467,7 +472,7 @@ void GamepadPage::AdjustSettingUI(wxCommandEvent& event)
 
 void GamepadPage::AdjustControlOption(wxCommandEvent&)
 {
-	m_control_dialog->control_reference->range = (ControlState)(m_control_dialog->range_slider->GetValue()) / SLIDER_TICK_COUNT;
+	m_control_dialog->control_reference->range = (ControlState)(m_control_dialog->GetRangeSliderValue()) / SLIDER_TICK_COUNT;
 }
 
 void GamepadPage::ConfigControl(wxEvent& event)

--- a/Source/Core/DolphinWX/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/InputConfigDiag.h
@@ -98,35 +98,37 @@ class ControlDialog : public wxDialog
 public:
 	ControlDialog(GamepadPage* const parent, InputConfig& config, ControllerInterface::ControlReference* const ref);
 
+	bool Validate() override;
+
+	int GetRangeSliderValue() const;
+
+	ControllerInterface::ControlReference* const control_reference;
+	InputConfig& m_config;
+
+private:
 	wxStaticBoxSizer* CreateControlChooser(GamepadPage* const parent);
-
-	virtual bool Validate() override;
-
-	void DetectControl(wxCommandEvent& event);
-	void ClearControl(wxCommandEvent& event);
-	void SetDevice(wxCommandEvent& event);
 
 	void UpdateGUI();
 	void UpdateListContents();
 	void SelectControl(const std::string& name);
 
+	void DetectControl(wxCommandEvent& event);
+	void ClearControl(wxCommandEvent& event);
+	void SetDevice(wxCommandEvent& event);
+
 	void SetSelectedControl(wxCommandEvent& event);
 	void AppendControl(wxCommandEvent& event);
 
-	ControllerInterface::ControlReference* const control_reference;
-	InputConfig& m_config;
-	wxComboBox*  device_cbox;
+	bool GetExpressionForSelectedControl(wxString &expr);
 
-	wxTextCtrl* textctrl;
-	wxListBox*  control_lbox;
-	wxSlider*   range_slider;
-
-private:
 	GamepadPage* const m_parent;
+	wxComboBox*        device_cbox;
+	wxTextCtrl*        textctrl;
+	wxListBox*         control_lbox;
+	wxSlider*          range_slider;
 	wxStaticText*      m_bound_label;
 	wxStaticText*      m_error_label;
-	ciface::Core::DeviceQualifier    m_devq;
-	bool GetExpressionForSelectedControl(wxString &expr);
+	ciface::Core::DeviceQualifier m_devq;
 };
 
 class ExtensionButton : public wxButton


### PR DESCRIPTION
Quite a bit of behavior in the UI controls are localized and not used outside of the implementing class (and some things shouldn't be exposed, either).

Most of this is wx event handling functions that shouldn't be accessible to other classes.