### PR TITLE
Fix some false positive ScheduleEvent alerts

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -362,6 +362,7 @@ static void FifoPlayerThread()
 	}
 
 	s_is_started = true;
+	DeclareAsCPUThread();
 
 	// Enter CPU run loop. When we leave it - we are done.
 	if (FifoPlayer::GetInstance().Open(_CoreParameter.m_strFilename))
@@ -370,6 +371,7 @@ static void FifoPlayerThread()
 		FifoPlayer::GetInstance().Close();
 	}
 
+	UndeclareAsCPUThread();
 	s_is_started = false;
 
 	if (!_CoreParameter.bCPUThread)

--- a/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
@@ -403,7 +403,7 @@ void CEXIETHERNET::SendComplete()
 		mBbaMem[BBA_IR] |= INT_T;
 
 		exi_status.interrupt |= exi_status.TRANSFER;
-		ExpansionInterface::ScheduleUpdateInterrupts_Threadsafe(0);
+		ExpansionInterface::ScheduleUpdateInterrupts(0);
 	}
 
 	mBbaMem[BBA_LTPS] = 0;


### PR DESCRIPTION
Someone please test this, I'm too tired. ;(

- CEXIETHERNET::SendComplete is always called from the main thread, so
  drop the _Threadsafe.

- Mark the FIFO player thread as the "CPU thread" so it can call
  ScheduleEvent without complaints.  I haven't actually tested this,
  since I don't know how to use the FIFO player; it might break
  something.