### PR TITLE
InputCommon/Core: Get rid of some virtual destructor warnings

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -128,6 +128,10 @@ public:
 	{
 	}
 
+	virtual ~JitBaseBlockCache()
+	{
+	}
+
 	int AllocateBlock(u32 em_address);
 	void FinalizeBlock(int block_num, bool block_link, const u8 *code_ptr);
 

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -85,7 +85,6 @@ public:
 		class Setting
 		{
 		public:
-
 			Setting(const std::string& _name, const ControlState def_value
 				, const unsigned int _low = 0, const unsigned int _high = 100)
 				: name(_name)
@@ -95,6 +94,10 @@ public:
 				, high(_high)
 				, is_virtual(false)
 				, is_iterate(false) {}
+
+			virtual ~Setting()
+			{
+			}
 
 			const std::string   name;
 			ControlState        value;


### PR DESCRIPTION
These classes have virtual methods, but no virtual destructor, which causes warnings on some compilers.