### PR TITLE
TextureDecoder_Common: Add missing algorithm include

### DIFF
--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cmath>
 
 #include "Common/Common.h"


### PR DESCRIPTION
It was being indirectly included, causing VS to syntactically mark std::min/max usages as being undefined (however it still compiled fine, of course)