### PR TITLE
Config tabs

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -29,14 +29,15 @@ void AdvancedConfigPane::InitializeGUI()
 	m_clock_override_slider->Bind(wxEVT_SLIDER, &AdvancedConfigPane::OnClockOverrideSliderChanged, this);
 
 	wxStaticText* const clock_override_description = new wxStaticText(this, wxID_ANY,
-	  _("Higher values can make variable-framerate games\n"
-	    "run at a higher framerate, at the expense of CPU.\n"
-	    "Lower values can make variable-framerate games\n"
+	  _("Higher values can make variable-framerate games "
+	    "run at a higher framerate, at the expense of CPU. "
+	    "Lower values can make variable-framerate games "
 	    "run at a lower framerate, saving CPU.\n\n"
-	    "WARNING: Changing this from the default (100%)\n"
-	    "can and will break games and cause glitches.\n"
-	    "Do so at your own risk. Please do not report\n"
-	    "bugs that occur with a non-default clock.\n"));
+	    "WARNING: Changing this from the default (100%) "
+	    "can and will break games and cause glitches. "
+	    "Do so at your own risk. Please do not report "
+	    "bugs that occur with a non-default clock. "));
+	clock_override_description->Wrap(400);
 
 	wxBoxSizer* const clock_override_checkbox_sizer = new wxBoxSizer(wxHORIZONTAL);
 	clock_override_checkbox_sizer->Add(m_clock_override_checkbox);

--- a/Source/Core/DolphinWX/Config/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/Config/ConfigMain.cpp
@@ -81,6 +81,8 @@ void CConfigMain::CreateGUIControls()
 	main_sizer->Add(Notebook, 1, wxEXPAND | wxALL, 5);
 	main_sizer->Add(CreateButtonSizer(wxOK), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
+	main_sizer->SetMinSize(400, 0);
+
 	SetSizerAndFit(main_sizer);
 	Center();
 	SetFocus();


### PR DESCRIPTION
Pursuant to [issue 8431](https://code.google.com/p/dolphin-emu/issues/detail?id=8431), this PR increases the minimum width of the config window main_sizer from 0 to 400 pixels. It also uses wxStaticText::Wrap to wrap the text in the Advanced tab to better fit the slightly wider size.

![Window](https://i.imgur.com/393wejK.png) ![Advanced tab](https://i.imgur.com/l6klCd2.png)

The ideal option would have been to alter CConfigMain::Notebook to size based on the width of its tabs rather than the contents of each page, but I have scoured the documentation and Stack Overflow high and low and found no way to accomplish this without hacking WxWidgets.

Another potential option is to set the Notebook style to wxNB_LEFT. I like the way this looks but it's not consistent with the rest of the UI. This isn't part of the PR, just another option to consider.
![Left-aligned tabs](https://i.imgur.com/1jpS55O.png)