### PR TITLE
Fix reading Wii FST size

### DIFF
--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -214,7 +214,7 @@ u32 CVolumeWiiCrypted::GetFSTSize() const
 	if (!Read(0x428, 0x4, (u8*)&size, true))
 		return 0;
 
-	return size;
+	return Common::swap32(size);
 }
 
 std::string CVolumeWiiCrypted::GetApploaderDate() const


### PR DESCRIPTION
Apparently this has been wrong all along since it was introduced in 2008 without anyone noticing.