### PR TITLE
Show the cursor in os x fullscreen by default. Fixes issue 8376.

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -960,11 +960,6 @@ void CFrame::ToggleDisplayMode(bool bFullscreen)
 #elif defined(HAVE_XRANDR) && HAVE_XRANDR
 	if (SConfig::GetInstance().m_LocalCoreStartupParameter.strFullscreenResolution != "Auto")
 		m_XRRConfig->ToggleDisplayMode(bFullscreen);
-#elif defined __APPLE__
-	if (bFullscreen)
-		CGDisplayHideCursor(CGMainDisplayID());
-	else
-		CGDisplayShowCursor(CGMainDisplayID());
 #endif
 }
 


### PR DESCRIPTION
Commit c5033e8 started hiding the cursor on os x to fix issue 3956 (cursor does not hide in fullscreen). As the hide cursor checkbox is currently working, this commit removes the code that hides the cursor by default and thus fixes issue 8376. (https://code.google.com/p/dolphin-emu/issues/detail?id=8376)