### PR TITLE
GeometryShaderGen: Add an option to render thin lines as line primitives.

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -150,6 +150,7 @@ static wxString stereo_3d_desc = wxTRANSLATE("Selects the stereoscopic 3D mode. 
 static wxString stereo_depth_desc = wxTRANSLATE("Controls the separation distance between the virtual cameras.\nA higher value creates a stronger feeling of depth while a lower value is more comfortable.");
 static wxString stereo_convergence_desc = wxTRANSLATE("Controls the distance of the convergence plane. This is the distance at which virtual objects will appear to be in front of the screen.\nA higher value creates stronger out-of-screen effects while a lower value is more comfortable.");
 static wxString stereo_swap_desc = wxTRANSLATE("Swaps the left and right eye. Mostly useful if you want to view side-by-side cross-eyed.\n\nIf unsure, leave this unchecked.");
+static wxString thin_lines_desc = wxTRANSLATE("Renders thin lines at the minimum width.\nCauses graphical inaccuracies in some games, but can give a speed boost when many lines are on the screen.\n\nIf unsure, leave this unchecked.");
 
 #if !defined(__APPLE__)
 // Search for available resolutions - TODO: Move to Common?
@@ -525,6 +526,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	wxGridSizer* const szr_other = new wxGridSizer(2, 5, 5);
 	szr_other->Add(CreateCheckBox(page_hacks, _("Disable Destination Alpha"), wxGetTranslation(disable_dstalpha_desc), vconfig.bDstAlphaPass));
 	szr_other->Add(CreateCheckBox(page_hacks, _("Fast Depth Calculation"), wxGetTranslation(fast_depth_calc_desc), vconfig.bFastDepthCalc));
+	szr_other->Add(CreateCheckBox(page_hacks, _("Minimum Width Thin Lines"), wxGetTranslation(thin_lines_desc), vconfig.bThinLines));
 
 	wxStaticBoxSizer* const group_other = new wxStaticBoxSizer(wxVERTICAL, page_hacks, _("Other"));
 	group_other->Add(szr_other, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -133,6 +133,11 @@ static inline void GenerateGeometryShader(T& out, u32 primitive_type, API_TYPE A
 
 	if (primitive_type == PRIMITIVE_LINES)
 	{
+		if (g_ActiveConfig.bThinLines)
+			uid_data->wide_lines = bpmem.lineptwidth.linesize > 12;
+		else
+			uid_data->wide_lines = true;
+
 		if (ApiType == API_OPENGL)
 		{
 			out.Write("\tVS_OUTPUT start, end;\n");
@@ -165,6 +170,11 @@ static inline void GenerateGeometryShader(T& out, u32 primitive_type, API_TYPE A
 	}
 	else if (primitive_type == PRIMITIVE_POINTS)
 	{
+		if (g_ActiveConfig.bThinLines)
+			uid_data->wide_points = bpmem.lineptwidth.pointsize > 12;
+		else
+			uid_data->wide_points = true;
+
 		if (ApiType == API_OPENGL)
 		{
 			out.Write("\tVS_OUTPUT center;\n");
@@ -178,6 +188,11 @@ static inline void GenerateGeometryShader(T& out, u32 primitive_type, API_TYPE A
 		// Offset from center to upper right vertex
 		// Lerp PointSize/2 from [0,0..VpWidth,VpHeight] to [-1,1..1,-1]
 		out.Write("\tfloat2 offset = float2(" I_LINEPTPARAMS".w / " I_LINEPTPARAMS".x, -" I_LINEPTPARAMS".w / " I_LINEPTPARAMS".y) * center.pos.w;\n");
+	}
+	else
+	{
+		uid_data->wide_lines = false;
+		uid_data->wide_points = false;
 	}
 
 	if (g_ActiveConfig.iStereoMode > 0)

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -13,13 +13,15 @@
 struct geometry_shader_uid_data
 {
 	u32 NumValues() const { return sizeof(geometry_shader_uid_data); }
-	bool IsPassthrough() const { return primitive_type == PRIMITIVE_TRIANGLES && !stereo && !wireframe; }
+	bool IsPassthrough() const { return !stereo && !wireframe && !wide_lines && !wide_points; }
 
 	u32 stereo : 1;
 	u32 numTexGens : 4;
 	u32 pixel_lighting : 1;
 	u32 primitive_type : 2;
 	u32 wireframe : 1;
+	u32 wide_lines : 1;
+	u32 wide_points : 1;
 };
 
 #pragma pack()

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -85,6 +85,7 @@ void VideoConfig::Load(const std::string& ini_file)
 	settings->Get("DisableFog", &bDisableFog, 0);
 	settings->Get("EnableShaderDebugging", &bEnableShaderDebugging, false);
 	settings->Get("BorderlessFullscreen", &bBorderlessFullscreen, false);
+	settings->Get("ThinLines", &bThinLines, false);
 
 	IniFile::Section* enhancements = iniFile.GetOrCreateSection("Enhancements");
 	enhancements->Get("ForceFiltering", &bForceFiltering, 0);
@@ -153,6 +154,7 @@ void VideoConfig::GameIniLoad()
 	CHECK_SETTING("Video_Settings", "EnablePixelLighting", bEnablePixelLighting);
 	CHECK_SETTING("Video_Settings", "FastDepthCalc", bFastDepthCalc);
 	CHECK_SETTING("Video_Settings", "MSAA", iMultisampleMode);
+	CHECK_SETTING("Video_Settings", "ThinLines", bThinLines);
 	int tmp = -9000;
 	CHECK_SETTING("Video_Settings", "EFBScale", tmp); // integral
 	if (tmp != -9000)
@@ -271,6 +273,7 @@ void VideoConfig::Save(const std::string& ini_file)
 	settings->Set("DisableFog", bDisableFog);
 	settings->Set("EnableShaderDebugging", bEnableShaderDebugging);
 	settings->Set("BorderlessFullscreen", bBorderlessFullscreen);
+	settings->Set("ThinLines", bThinLines);
 
 	IniFile::Section* enhancements = iniFile.GetOrCreateSection("Enhancements");
 	enhancements->Set("ForceFiltering", bForceFiltering);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -124,6 +124,7 @@ struct VideoConfig final
 	bool bFastDepthCalc;
 	int iLog; // CONF_ bits
 	int iSaveTargetId; // TODO: Should be dropped
+	bool bThinLines;
 
 	// Stereoscopy
 	bool bStereoEFBMonoDepth;


### PR DESCRIPTION
This is a speed-hack option that introduces graphical inaccuracies if enabled.

Here are two screenshots for comparison:

Speed-hack on: https://www.dropbox.com/s/dtt0lou77fcnzna/00000000-2.png?dl=0
Speed-hack off: https://www.dropbox.com/s/yp2whv5o1d87ao0/00000000-3.png?dl=0

~~I've also enabled this speed-hack by default for lines that have a width of <=1px in the hopes that it will not affect the FIFO-CI output. It likely will, in which case I'll test ==1px and see if we can get away with that.~~ Couldn't get away with any of that, lines now render as normal when the speed-hack is disabled.

I'm still attempting other solutions for this problem without the need for a speed hack, do _not_ merge this PR.