### PR TITLE
Add size to CPU clock override slider

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -22,7 +22,7 @@ AdvancedConfigPane::AdvancedConfigPane(wxWindow* parent, wxWindowID id)
 void AdvancedConfigPane::InitializeGUI()
 {
 	m_clock_override_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable CPU Clock Override"));
-	m_clock_override_slider = new wxSlider(this, wxID_ANY, 100, 0, 150);
+	m_clock_override_slider = new wxSlider(this, wxID_ANY, 100, 0, 150, wxDefaultPosition, wxSize(200,-1));
 	m_clock_override_text = new wxStaticText(this, wxID_ANY, "");
 
 	m_clock_override_checkbox->Bind(wxEVT_CHECKBOX, &AdvancedConfigPane::OnClockOverrideCheckBoxChanged, this);


### PR DESCRIPTION
Fixes slider having 0 width on wxGTK
[Relevant issue](https://code.google.com/p/dolphin-emu/issues/detail?id=8215)
Possibly a bug in wxWidgets?

Without fix:
![Before](https://i.imgur.com/QvrgGkh.png)

With fix:
![After](https://i.imgur.com/1rRCw5Y.png)