### PR TITLE
Make OC slider match enabled state on window load

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -63,8 +63,10 @@ void AdvancedConfigPane::InitializeGUI()
 void AdvancedConfigPane::LoadGUIValues()
 {
 	int ocFactor = (int)(std::log2f(SConfig::GetInstance().m_OCFactor) * 25.f + 100.f + 0.5f);
-	m_clock_override_checkbox->SetValue(SConfig::GetInstance().m_OCEnable);
+	bool oc_enabled = SConfig::GetInstance().m_OCEnable;
+	m_clock_override_checkbox->SetValue(oc_enabled);
 	m_clock_override_slider ->SetValue(ocFactor);
+	m_clock_override_slider->Enable(oc_enabled);
 	UpdateCPUClock();
 }
 


### PR DESCRIPTION
Currently the overclock slider can be slid even when the checkbox is disabled. The config window does not set the state of the slider on load, only when the associated checkbox's change event is triggered.

This PR alters AdvancedConfigPane::LoadGUIValues() to fetch the m_OCEnable value on window load and apply it appropriately.