### PR TITLE
CoreTiming: Add assert to ScheduleEvent_Immediate

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -236,6 +236,7 @@ void ScheduleEvent_Threadsafe(int cyclesIntoFuture, int event_type, u64 userdata
 // Executes an event immediately, then returns.
 void ScheduleEvent_Immediate(int event_type, u64 userdata)
 {
+	_assert_msg_(POWERPC, Core::IsCPUThread(), "ScheduleEvent_Immediate from wrong thread");
 	event_types[event_type].callback(userdata, 0);
 }
 


### PR DESCRIPTION
My PR that added ScheduleEvent_Immediate and magumagu's PR that added the CoreTiming asserts were made around the same time, so this function never got an assert.