### PR TITLE
VolumeWiiCrypted: Replace ChangePartition with a partition parameter

### DIFF
--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -12,6 +12,7 @@
 namespace DiscIO
 {
 class IVolume;
+struct Partition;
 }
 
 struct RegionSetting
@@ -46,7 +47,7 @@ public:
 
 private:
   static bool DVDRead(const DiscIO::IVolume& volume, u64 dvd_offset, u32 output_address, u32 length,
-                      bool decrypt);
+                      const DiscIO::Partition& partition);
   static void RunFunction(u32 address);
 
   static void UpdateDebugger_MapLoaded();

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -19,6 +19,7 @@ namespace DiscIO
 {
 enum class Language;
 enum class Region;
+struct Partition;
 class IVolume;
 }
 namespace IOS
@@ -226,7 +227,7 @@ struct SConfig : NonCopyable
   u64 GetTitleID() const { return m_title_id; }
   u16 GetRevision() const { return m_revision; }
   void ResetRunningGameMetadata();
-  void SetRunningGameMetadata(const DiscIO::IVolume& volume);
+  void SetRunningGameMetadata(const DiscIO::IVolume& volume, const DiscIO::Partition& partition);
   void SetRunningGameMetadata(const IOS::ES::TMDReader& tmd);
 
   void LoadDefaults();

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -218,6 +218,7 @@ static u32 s_pending_samples;
 
 // Disc drive state
 static u32 s_error_code = 0;
+static DiscIO::Partition s_current_partition;
 
 // Disc drive timing
 static u64 s_read_buffer_start_time;
@@ -243,12 +244,14 @@ void UpdateInterrupts();
 void GenerateDIInterrupt(DIInterruptType _DVDInterrupt);
 
 void WriteImmediate(u32 value, u32 output_address, bool reply_to_ios);
-bool ExecuteReadCommand(u64 DVD_offset, u32 output_address, u32 DVD_length, u32 output_length,
-                        bool decrypt, ReplyType reply_type, DIInterruptType* interrupt_type);
+bool ExecuteReadCommand(u64 dvd_offset, u32 output_address, u32 dvd_length, u32 output_length,
+                        const DiscIO::Partition& partition, ReplyType reply_type,
+                        DIInterruptType* interrupt_type);
 
 u64 PackFinishExecutingCommandUserdata(ReplyType reply_type, DIInterruptType interrupt_type);
 
-void ScheduleReads(u64 offset, u32 length, bool decrypt, u32 output_address, ReplyType reply_type);
+void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u32 output_address,
+                   ReplyType reply_type);
 
 void DoState(PointerWrap& p)
 {
@@ -271,6 +274,7 @@ void DoState(PointerWrap& p)
   p.Do(s_pending_samples);
 
   p.Do(s_error_code);
+  p.Do(s_current_partition);
 
   p.Do(s_read_buffer_start_time);
   p.Do(s_read_buffer_end_time);
@@ -309,8 +313,9 @@ static u32 AdvanceDTK(u32 maximum_samples, u32* samples_to_process)
   {
     if (s_audio_position >= s_current_start + s_current_length)
     {
-      DEBUG_LOG(DVDINTERFACE, "AdvanceDTK: NextStart=%08" PRIx64 ", NextLength=%08x, "
-                              "CurrentStart=%08" PRIx64 ", CurrentLength=%08x, AudioPos=%08" PRIx64,
+      DEBUG_LOG(DVDINTERFACE,
+                "AdvanceDTK: NextStart=%08" PRIx64 ", NextLength=%08x, "
+                "CurrentStart=%08" PRIx64 ", CurrentLength=%08x, AudioPos=%08" PRIx64,
                 s_next_start, s_next_length, s_current_start, s_current_length, s_audio_position);
 
       s_audio_position = s_next_start;
@@ -362,7 +367,8 @@ static void DTKStreamingCallback(const std::vector<u8>& audio_data, s64 cycles_l
   ticks_to_dtk -= cycles_late;
   if (read_length > 0)
   {
-    DVDThread::StartRead(read_offset, read_length, false, ReplyType::DTK, ticks_to_dtk);
+    DVDThread::StartRead(read_offset, read_length, DiscIO::PARTITION_NONE, ReplyType::DTK,
+                         ticks_to_dtk);
   }
   else
   {
@@ -432,6 +438,9 @@ void Shutdown()
 
 void SetDisc(std::unique_ptr<DiscIO::IVolume> disc)
 {
+  if (disc)
+    s_current_partition = disc->GetGamePartition();
+
   DVDThread::SetDisc(std::move(disc));
   SetLidOpen();
 }
@@ -496,9 +505,33 @@ void SetLidOpen()
     GenerateDIInterrupt(INT_CVRINT);
 }
 
-bool ChangePartition(u64 offset)
+bool UpdateRunningGameMetadata(u64 title_id)
 {
-  return DVDThread::ChangePartition(offset);
+  if (!DVDThread::HasDisc())
+    return false;
+
+  const DiscIO::Partition& partition = DVDThread::GetDiscType() == DiscIO::Platform::WII_DISC ?
+                                           s_current_partition :
+                                           DiscIO::PARTITION_NONE;
+
+  return DVDThread::UpdateRunningGameMetadata(partition, title_id);
+}
+
+bool UpdateRunningGameMetadata()
+{
+  if (!DVDThread::HasDisc())
+    return false;
+
+  const DiscIO::Partition& partition = DVDThread::GetDiscType() == DiscIO::Platform::WII_DISC ?
+                                           s_current_partition :
+                                           DiscIO::PARTITION_NONE;
+
+  return DVDThread::UpdateRunningGameMetadata(partition);
+}
+
+void ChangePartition(const DiscIO::Partition& partition)
+{
+  s_current_partition = partition;
 }
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
@@ -618,8 +651,9 @@ void WriteImmediate(u32 value, u32 output_address, bool reply_to_ios)
 }
 
 // Iff false is returned, ScheduleEvent must be used to finish executing the command
-bool ExecuteReadCommand(u64 DVD_offset, u32 output_address, u32 DVD_length, u32 output_length,
-                        bool decrypt, ReplyType reply_type, DIInterruptType* interrupt_type)
+bool ExecuteReadCommand(u64 dvd_offset, u32 output_address, u32 dvd_length, u32 output_length,
+                        const DiscIO::Partition& partition, ReplyType reply_type,
+                        DIInterruptType* interrupt_type)
 {
   if (!IsDiscInside())
   {
@@ -634,14 +668,14 @@ bool ExecuteReadCommand(u64 DVD_offset, u32 output_address, u32 DVD_length, u32 
     *interrupt_type = INT_TCINT;
   }
 
-  if (DVD_length > output_length)
+  if (dvd_length > output_length)
   {
     WARN_LOG(DVDINTERFACE, "Detected an attempt to read more data from the DVD "
                            "than what fits inside the out buffer. Clamping.");
-    DVD_length = output_length;
+    dvd_length = output_length;
   }
 
-  ScheduleReads(DVD_offset, DVD_length, decrypt, output_address, reply_type);
+  ScheduleReads(dvd_offset, dvd_length, partition, output_address, reply_type);
   return true;
 }
 
@@ -677,8 +711,9 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
   // Only seems to be used from WII_IPC, not through direct access
   case DVDLowReadDiskID:
     INFO_LOG(DVDINTERFACE, "DVDLowReadDiskID");
-    command_handled_by_thread = ExecuteReadCommand(0, output_address, 0x20, output_length, false,
-                                                   reply_type, &interrupt_type);
+    command_handled_by_thread =
+        ExecuteReadCommand(0, output_address, 0x20, output_length, DiscIO::PARTITION_NONE,
+                           reply_type, &interrupt_type);
     break;
 
   // Only used from WII_IPC. This is the only read command that decrypts data
@@ -686,8 +721,8 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
     INFO_LOG(DVDINTERFACE, "DVDLowRead: DVDAddr: 0x%09" PRIx64 ", Size: 0x%x", (u64)command_2 << 2,
              command_1);
     command_handled_by_thread =
-        ExecuteReadCommand((u64)command_2 << 2, output_address, command_1, output_length, true,
-                           reply_type, &interrupt_type);
+        ExecuteReadCommand((u64)command_2 << 2, output_address, command_1, output_length,
+                           s_current_partition, reply_type, &interrupt_type);
     break;
 
   // Probably only used by Wii
@@ -768,8 +803,8 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
          (((command_2 + command_1) > 0x7ed40000) && (command_2 + command_1) < 0x7ed40008)))
     {
       command_handled_by_thread =
-          ExecuteReadCommand((u64)command_2 << 2, output_address, command_1, output_length, false,
-                             reply_type, &interrupt_type);
+          ExecuteReadCommand((u64)command_2 << 2, output_address, command_1, output_length,
+                             DiscIO::PARTITION_NONE, reply_type, &interrupt_type);
     }
     else
     {
@@ -813,19 +848,22 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
     {
       u64 iDVDOffset = (u64)command_1 << 2;
 
-      INFO_LOG(DVDINTERFACE, "Read: DVDOffset=%08" PRIx64
-                             ", DMABuffer = %08x, SrcLength = %08x, DMALength = %08x",
+      INFO_LOG(DVDINTERFACE,
+               "Read: DVDOffset=%08" PRIx64
+               ", DMABuffer = %08x, SrcLength = %08x, DMALength = %08x",
                iDVDOffset, output_address, command_2, output_length);
 
-      command_handled_by_thread = ExecuteReadCommand(
-          iDVDOffset, output_address, command_2, output_length, false, reply_type, &interrupt_type);
+      command_handled_by_thread =
+          ExecuteReadCommand(iDVDOffset, output_address, command_2, output_length,
+                             DiscIO::PARTITION_NONE, reply_type, &interrupt_type);
     }
     break;
 
     case 0x40:  // Read DiscID
       INFO_LOG(DVDINTERFACE, "Read DiscID %08x", Memory::Read_U32(output_address));
-      command_handled_by_thread = ExecuteReadCommand(0, output_address, 0x20, output_length, false,
-                                                     reply_type, &interrupt_type);
+      command_handled_by_thread =
+          ExecuteReadCommand(0, output_address, 0x20, output_length, DiscIO::PARTITION_NONE,
+                             reply_type, &interrupt_type);
       break;
 
     default:
@@ -934,9 +972,10 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
     switch (command_0 >> 16 & 0xFF)
     {
     case 0x00:  // Returns streaming status
-      INFO_LOG(DVDINTERFACE, "(Audio): Stream Status: Request Audio status "
-                             "AudioPos:%08" PRIx64 "/%08" PRIx64 " "
-                             "CurrentStart:%08" PRIx64 " CurrentLength:%08x",
+      INFO_LOG(DVDINTERFACE,
+               "(Audio): Stream Status: Request Audio status "
+               "AudioPos:%08" PRIx64 "/%08" PRIx64 " "
+               "CurrentStart:%08" PRIx64 " CurrentLength:%08x",
                s_audio_position, s_current_start + s_current_length, s_current_start,
                s_current_length);
       WriteImmediate(s_stream ? 1 : 0, output_address, reply_to_ios);
@@ -1097,7 +1136,8 @@ void FinishExecutingCommand(ReplyType reply_type, DIInterruptType interrupt_type
 
 // Determines from a given read request how much of the request is buffered,
 // and how much is required to be read from disc.
-void ScheduleReads(u64 offset, u32 length, bool decrypt, u32 output_address, ReplyType reply_type)
+void ScheduleReads(u64 offset, u32 length, const DiscIO::Partition& partition, u32 output_address,
+                   ReplyType reply_type)
 {
   // The drive continues to read 1 MiB beyond the last read position when idle.
   // If a future read falls within this window, part of the read may be returned
@@ -1124,9 +1164,7 @@ void ScheduleReads(u64 offset, u32 length, bool decrypt, u32 output_address, Rep
   // The variable dvd_offset tracks the actual offset on the DVD
   // that the disc drive starts reading at, which differs in two ways:
   // It's rounded to a whole ECC block and never uses Wii partition addressing.
-  u64 dvd_offset = offset;
-  if (decrypt)
-    dvd_offset = DVDThread::PartitionOffsetToRawOffset(offset);
+  u64 dvd_offset = DiscIO::CVolumeWiiCrypted::PartitionOffsetToRawOffset(offset, partition);
   dvd_offset = Common::AlignDown(dvd_offset, DVD_ECC_BLOCK_SIZE);
 
   if (SConfig::GetInstance().bFastDiscSpeed)
@@ -1192,8 +1230,9 @@ void ScheduleReads(u64 offset, u32 length, bool decrypt, u32 output_address, Rep
   u32 buffered_blocks = 0;
   u32 unbuffered_blocks = 0;
 
-  const u32 bytes_per_chunk =
-      decrypt ? DiscIO::CVolumeWiiCrypted::BLOCK_DATA_SIZE : DVD_ECC_BLOCK_SIZE;
+  const u32 bytes_per_chunk = partition == DiscIO::PARTITION_NONE ?
+                                  DVD_ECC_BLOCK_SIZE :
+                                  DiscIO::CVolumeWiiCrypted::BLOCK_DATA_SIZE;
 
   while (length > 0)
   {
@@ -1240,7 +1279,7 @@ void ScheduleReads(u64 offset, u32 length, bool decrypt, u32 output_address, Rep
 
     // Schedule this read to complete at the appropriate time
     const ReplyType chunk_reply_type = chunk_length == length ? reply_type : ReplyType::NoReply;
-    DVDThread::StartReadToEmulatedRAM(output_address, offset, chunk_length, decrypt,
+    DVDThread::StartReadToEmulatedRAM(output_address, offset, chunk_length, partition,
                                       chunk_reply_type, ticks_until_completion);
 
     // Advance the read window
@@ -1280,8 +1319,9 @@ void ScheduleReads(u64 offset, u32 length, bool decrypt, u32 output_address, Rep
                              s_read_buffer_end_offset - s_read_buffer_start_offset, wii_disc));
   }
 
-  DEBUG_LOG(DVDINTERFACE, "Schedule reads: ECC blocks unbuffered=%d, buffered=%d, "
-                          "ticks=%" PRId64 ", time=%" PRId64 " us",
+  DEBUG_LOG(DVDINTERFACE,
+            "Schedule reads: ECC blocks unbuffered=%d, buffered=%d, "
+            "ticks=%" PRId64 ", time=%" PRId64 " us",
             unbuffered_blocks, buffered_blocks, ticks_until_completion,
             ticks_until_completion * 1000000 / SystemTimers::GetTicksPerSecond());
 }

--- a/Source/Core/Core/HW/DVD/DVDInterface.h
+++ b/Source/Core/Core/HW/DVD/DVDInterface.h
@@ -13,6 +13,7 @@ class PointerWrap;
 namespace DiscIO
 {
 class IVolume;
+struct Partition;
 }
 namespace MMIO
 {
@@ -113,9 +114,16 @@ bool IsDiscInside();
 void ChangeDiscAsHost(const std::string& new_path);  // Can only be called by the host thread
 void ChangeDiscAsCPU(const std::string& new_path);   // Can only be called by the CPU thread
 
+// If a disc is inserted and its title ID is equal to the title_id argument, returns true and
+// calls SConfig::SetRunningGameMetadata(IVolume&, Partition&). Otherwise, returns false.
+bool UpdateRunningGameMetadata(u64 title_id);
+// If a disc is inserted, returns true and calls
+// SConfig::SetRunningGameMetadata(IVolume&, Partition&). Otherwise, returns false.
+bool UpdateRunningGameMetadata();
+
 // Direct access to DI for IOS HLE (simpler to implement than how real IOS accesses DI,
 // and lets us skip encrypting/decrypting in some cases)
-bool ChangePartition(u64 offset);
+void ChangePartition(const DiscIO::Partition& partition);
 void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_address,
                     u32 output_length, bool reply_to_ios);
 

--- a/Source/Core/Core/HW/DVD/DVDThread.h
+++ b/Source/Core/Core/HW/DVD/DVDThread.h
@@ -10,6 +10,10 @@
 #include "Common/CommonTypes.h"
 
 class PointerWrap;
+namespace DiscIO
+{
+struct Partition;
+}
 namespace DVDInterface
 {
 enum class ReplyType : u32;
@@ -37,20 +41,19 @@ void DoState(PointerWrap& p);
 void SetDisc(std::unique_ptr<DiscIO::IVolume> disc);
 bool HasDisc();
 
-u64 PartitionOffsetToRawOffset(u64 offset);
 DiscIO::Platform GetDiscType();
-IOS::ES::TMDReader GetTMD();
-IOS::ES::TicketReader GetTicket();
-bool ChangePartition(u64 offset);
+IOS::ES::TMDReader GetTMD(const DiscIO::Partition& partition);
+IOS::ES::TicketReader GetTicket(const DiscIO::Partition& partition);
 // If a disc is inserted and its title ID is equal to the title_id argument, returns true and
-// calls SConfig::SetRunningGameMetadata(IVolume&). Otherwise, returns false.
-bool UpdateRunningGameMetadata(u64 title_id);
+// calls SConfig::SetRunningGameMetadata(IVolume&, Partition&). Otherwise, returns false.
+bool UpdateRunningGameMetadata(const DiscIO::Partition& partition, u64 title_id);
 // If a disc is inserted, returns true and calls
-// SConfig::SetRunningGameMetadata(IVolume&). Otherwise, returns false.
-bool UpdateRunningGameMetadata();
+// SConfig::SetRunningGameMetadata(IVolume&, Partition&). Otherwise, returns false.
+bool UpdateRunningGameMetadata(const DiscIO::Partition& partition);
 
-void StartRead(u64 dvd_offset, u32 length, bool decrypt, DVDInterface::ReplyType reply_type,
-               s64 ticks_until_completion);
-void StartReadToEmulatedRAM(u32 output_address, u64 dvd_offset, u32 length, bool decrypt,
-                            DVDInterface::ReplyType reply_type, s64 ticks_until_completion);
+void StartRead(u64 dvd_offset, u32 length, const DiscIO::Partition& partition,
+               DVDInterface::ReplyType reply_type, s64 ticks_until_completion);
+void StartReadToEmulatedRAM(u32 output_address, u64 dvd_offset, u32 length,
+                            const DiscIO::Partition& partition, DVDInterface::ReplyType reply_type,
+                            s64 ticks_until_completion);
 }

--- a/Source/Core/Core/HW/DVD/FileMonitor.h
+++ b/Source/Core/Core/HW/DVD/FileMonitor.h
@@ -4,13 +4,11 @@
 
 #pragma once
 
-#include <memory>
-
 #include "Common/CommonTypes.h"
 
 namespace DiscIO
 {
-class IFileSystem;
+struct Partition;
 class IVolume;
 }
 
@@ -20,5 +18,5 @@ namespace FileMonitor
 // with nullptr, the volume must remain valid until the next SetFileSystem call.
 void SetFileSystem(const DiscIO::IVolume* volume);
 // Logs access to files in the file system set by SetFileSystem
-void Log(u64 offset, bool decrypt);
+void Log(u64 offset, const DiscIO::Partition& partition);
 }

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -19,7 +19,6 @@
 #include "Core/HLE/HLE.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/DVD/DVDInterface.h"
-#include "Core/HW/DVD/DVDThread.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/IOS/ES/Formats.h"
@@ -170,7 +169,7 @@ bool Load()
   Memory::Write_U32(0x00000000, ADDRESS_INIT_SEMAPHORE);
   NOTICE_LOG(IOS, "IPL ready.");
   SConfig::GetInstance().m_BootType = SConfig::BOOT_MIOS;
-  DVDThread::UpdateRunningGameMetadata();
+  DVDInterface::UpdateRunningGameMetadata();
   return true;
 }
 }  // namespace MIOS

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 85;  // Last changed in PR 4241
+static const u32 STATE_VERSION = 86;  // Last changed in PR 2353
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -123,15 +123,15 @@ void DiscScrubber::MarkAsUsedE(u64 partition_data_offset, u64 offset, u64 size)
 }
 
 // Helper functions for reading the BE volume
-bool DiscScrubber::ReadFromVolume(u64 offset, u32& buffer, bool decrypt)
+bool DiscScrubber::ReadFromVolume(u64 offset, u32& buffer, const Partition& partition)
 {
-  return m_disc->ReadSwapped(offset, &buffer, decrypt);
+  return m_disc->ReadSwapped(offset, &buffer, partition);
 }
 
-bool DiscScrubber::ReadFromVolume(u64 offset, u64& buffer, bool decrypt)
+bool DiscScrubber::ReadFromVolume(u64 offset, u64& buffer, const Partition& partition)
 {
   u32 temp_buffer;
-  if (!m_disc->ReadSwapped(offset, &temp_buffer, decrypt))
+  if (!m_disc->ReadSwapped(offset, &temp_buffer, partition))
     return false;
   buffer = static_cast<u64>(temp_buffer) << 2;
   return true;
@@ -142,126 +142,85 @@ bool DiscScrubber::ParseDisc()
   // Mark the header as used - it's mostly 0s anyways
   MarkAsUsed(0, 0x50000);
 
-  for (u32 x = 0; x < 4; x++)
+  for (const DiscIO::Partition& partition : m_disc->GetPartitions())
   {
-    if (!ReadFromVolume(0x40000 + (x * 8) + 0, m_partition_group[x].num_partitions, false) ||
-        !ReadFromVolume(0x40000 + (x * 8) + 4, m_partition_group[x].partitions_offset, false))
+    PartitionHeader header;
+
+    if (!ReadFromVolume(partition.offset + 0x2a4, header.tmd_size, PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + 0x2a8, header.tmd_offset, PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + 0x2ac, header.cert_chain_size, PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + 0x2b0, header.cert_chain_offset, PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + 0x2b4, header.h3_offset, PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + 0x2b8, header.data_offset, PARTITION_NONE) ||
+        !ReadFromVolume(partition.offset + 0x2bc, header.data_size, PARTITION_NONE))
     {
       return false;
     }
 
-    // Read all partitions
-    for (u32 i = 0; i < m_partition_group[x].num_partitions; i++)
-    {
-      Partition partition;
+    MarkAsUsed(partition.offset, 0x2c0);
 
-      partition.group_number = x;
-      partition.number = i;
+    MarkAsUsed(partition.offset + header.tmd_offset, header.tmd_size);
+    MarkAsUsed(partition.offset + header.cert_chain_offset, header.cert_chain_size);
+    MarkAsUsed(partition.offset + header.h3_offset, 0x18000);
+    // This would mark the whole (encrypted) data area
+    // we need to parse FST and other crap to find what's free within it!
+    // MarkAsUsed(partition.offset + header.data_offset, header.data_size);
 
-      if (!ReadFromVolume(m_partition_group[x].partitions_offset + (i * 8) + 0, partition.offset,
-                          false) ||
-          !ReadFromVolume(m_partition_group[x].partitions_offset + (i * 8) + 4, partition.type,
-                          false) ||
-          !ReadFromVolume(partition.offset + 0x2a4, partition.header.tmd_size, false) ||
-          !ReadFromVolume(partition.offset + 0x2a8, partition.header.tmd_offset, false) ||
-          !ReadFromVolume(partition.offset + 0x2ac, partition.header.cert_chain_size, false) ||
-          !ReadFromVolume(partition.offset + 0x2b0, partition.header.cert_chain_offset, false) ||
-          !ReadFromVolume(partition.offset + 0x2b4, partition.header.h3_offset, false) ||
-          !ReadFromVolume(partition.offset + 0x2b8, partition.header.data_offset, false) ||
-          !ReadFromVolume(partition.offset + 0x2bc, partition.header.data_size, false))
-      {
-        return false;
-      }
-
-      m_partition_group[x].partitions.push_back(partition);
-    }
-
-    for (auto& partition : m_partition_group[x].partitions)
-    {
-      const PartitionHeader& header = partition.header;
-
-      MarkAsUsed(partition.offset, 0x2c0);
-
-      MarkAsUsed(partition.offset + header.tmd_offset, header.tmd_size);
-      MarkAsUsed(partition.offset + header.cert_chain_offset, header.cert_chain_size);
-      MarkAsUsed(partition.offset + header.h3_offset, 0x18000);
-      // This would mark the whole (encrypted) data area
-      // we need to parse FST and other crap to find what's free within it!
-      // MarkAsUsed(partition.offset + header.data_offset, header.data_size);
-
-      // Parse Data! This is where the big gain is
-      if (!ParsePartitionData(partition))
-        return false;
-    }
+    // Parse Data! This is where the big gain is
+    if (!ParsePartitionData(partition, &header))
+      return false;
   }
 
   return true;
 }
 
-// Operations dealing with encrypted space are done here - the volume is swapped to allow this
-bool DiscScrubber::ParsePartitionData(Partition& partition)
+// Operations dealing with encrypted space are done here
+bool DiscScrubber::ParsePartitionData(const Partition& partition, PartitionHeader* header)
 {
-  bool parsed_ok = true;
-
-  // Switch out the main volume temporarily
-  std::unique_ptr<IVolume> old_volume;
-  m_disc.swap(old_volume);
-
-  // Ready some stuff
-  m_disc = CreateVolumeFromFilename(m_filename, partition.group_number, partition.number);
-  if (m_disc == nullptr)
+  std::unique_ptr<IFileSystem> filesystem(CreateFileSystem(m_disc.get(), partition));
+  if (!filesystem)
   {
-    ERROR_LOG(DISCIO, "Failed to create volume from file %s", m_filename.c_str());
-    m_disc.swap(old_volume);
+    ERROR_LOG(DISCIO, "Failed to read file system for the partition at 0x%" PRIx64,
+              partition.offset);
     return false;
   }
 
-  std::unique_ptr<IFileSystem> filesystem(CreateFileSystem(m_disc.get()));
-  if (!filesystem)
+  const u64 partition_data_offset = partition.offset + header->data_offset;
+
+  // Mark things as used which are not in the filesystem
+  // Header, Header Information, Apploader
+  if (!ReadFromVolume(0x2440 + 0x14, header->apploader_size, partition) ||
+      !ReadFromVolume(0x2440 + 0x18, header->apploader_size, partition))
   {
-    ERROR_LOG(DISCIO, "Failed to create filesystem for group %u partition %u",
-              partition.group_number, partition.number);
-    parsed_ok = false;
+    return false;
   }
-  else
+  MarkAsUsedE(partition_data_offset, 0,
+              0x2440 + header->apploader_size + header->apploader_trailer_size);
+
+  // DOL
+  header->dol_offset = filesystem->GetBootDOLOffset();
+  header->dol_size = filesystem->GetBootDOLSize(header->dol_offset);
+  if (header->dol_offset == 0 || header->dol_size == 0)
+    return false;
+  MarkAsUsedE(partition_data_offset, header->dol_offset, header->dol_size);
+
+  // FST
+  if (!ReadFromVolume(0x424, header->fst_offset, partition) ||
+      !ReadFromVolume(0x428, header->fst_size, partition))
   {
-    // Mark things as used which are not in the filesystem
-    // Header, Header Information, Apploader
-    parsed_ok = parsed_ok && ReadFromVolume(0x2440 + 0x14, partition.header.apploader_size, true);
-    parsed_ok =
-        parsed_ok && ReadFromVolume(0x2440 + 0x18, partition.header.apploader_trailer_size, true);
-    MarkAsUsedE(partition.offset + partition.header.data_offset, 0,
-                0x2440 + partition.header.apploader_size + partition.header.apploader_trailer_size);
+    return false;
+  }
+  MarkAsUsedE(partition_data_offset, header->fst_offset, header->fst_size);
 
-    // DOL
-    partition.header.dol_offset = filesystem->GetBootDOLOffset();
-    partition.header.dol_size = filesystem->GetBootDOLSize(partition.header.dol_offset);
-    parsed_ok = parsed_ok && partition.header.dol_offset && partition.header.dol_size;
-    MarkAsUsedE(partition.offset + partition.header.data_offset, partition.header.dol_offset,
-                partition.header.dol_size);
-
-    // FST
-    parsed_ok = parsed_ok && ReadFromVolume(0x424, partition.header.fst_offset, true);
-    parsed_ok = parsed_ok && ReadFromVolume(0x428, partition.header.fst_size, true);
-    MarkAsUsedE(partition.offset + partition.header.data_offset, partition.header.fst_offset,
-                partition.header.fst_size);
-
-    // Go through the filesystem and mark entries as used
-    for (const SFileInfo& file : filesystem->GetFileList())
-    {
-      DEBUG_LOG(DISCIO, "%s", file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
-      if ((file.m_NameOffset & 0x1000000) == 0)
-      {
-        MarkAsUsedE(partition.offset + partition.header.data_offset, file.m_Offset,
-                    file.m_FileSize);
-      }
-    }
+  // Go through the filesystem and mark entries as used
+  for (const SFileInfo& file : filesystem->GetFileList())
+  {
+    DEBUG_LOG(DISCIO, "%s", file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
+    if ((file.m_NameOffset & 0x1000000) == 0)
+      MarkAsUsedE(partition_data_offset, file.m_Offset, file.m_FileSize);
   }
 
-  // Swap back
-  m_disc.swap(old_volume);
-
-  return parsed_ok;
+  return true;
 }
 
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/DiscScrubber.h
+++ b/Source/Core/DiscIO/DiscScrubber.h
@@ -26,6 +26,7 @@ class IOFile;
 namespace DiscIO
 {
 class IVolume;
+struct Partition;
 
 class DiscScrubber final
 {
@@ -57,33 +58,15 @@ private:
     u32 apploader_trailer_size;
   };
 
-  struct Partition final
-  {
-    u32 group_number;
-    u32 number;
-    u64 offset;
-    u32 type;
-    PartitionHeader header;
-  };
-
-  struct PartitionGroup final
-  {
-    u32 num_partitions;
-    u64 partitions_offset;
-    std::vector<Partition> partitions;
-  };
-
   void MarkAsUsed(u64 offset, u64 size);
   void MarkAsUsedE(u64 partition_data_offset, u64 offset, u64 size);
-  bool ReadFromVolume(u64 offset, u32& buffer, bool decrypt);
-  bool ReadFromVolume(u64 offset, u64& buffer, bool decrypt);
+  bool ReadFromVolume(u64 offset, u32& buffer, const Partition& partition);
+  bool ReadFromVolume(u64 offset, u64& buffer, const Partition& partition);
   bool ParseDisc();
-  bool ParsePartitionData(Partition& partition);
+  bool ParsePartitionData(const Partition& partition, PartitionHeader* header);
 
   std::string m_filename;
   std::unique_ptr<IVolume> m_disc;
-
-  std::array<PartitionGroup, 4> m_partition_group{};
 
   std::vector<u8> m_free_table;
   u64 m_file_size = 0;

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -20,8 +20,8 @@
 
 namespace DiscIO
 {
-CFileSystemGCWii::CFileSystemGCWii(const IVolume* _rVolume)
-    : IFileSystem(_rVolume), m_Initialized(false), m_Valid(false), m_Wii(false)
+CFileSystemGCWii::CFileSystemGCWii(const IVolume* _rVolume, const Partition& partition)
+    : IFileSystem(_rVolume, partition), m_Initialized(false), m_Valid(false), m_Wii(false)
 {
   m_Valid = DetectFileSystem();
 }
@@ -80,7 +80,7 @@ u64 CFileSystemGCWii::ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 
             read_length, _OffsetInFile, _rFullPath.c_str(), pFileInfo->m_Offset,
             pFileInfo->m_FileSize);
 
-  m_rVolume->Read(pFileInfo->m_Offset + _OffsetInFile, read_length, _pBuffer, m_Wii);
+  m_rVolume->Read(pFileInfo->m_Offset + _OffsetInFile, read_length, _pBuffer, m_partition);
   return read_length;
 }
 
@@ -111,7 +111,7 @@ bool CFileSystemGCWii::ExportFile(const std::string& _rFullPath,
 
     std::vector<u8> buffer(readSize);
 
-    result = m_rVolume->Read(fileOffset, readSize, &buffer[0], m_Wii);
+    result = m_rVolume->Read(fileOffset, readSize, &buffer[0], m_partition);
 
     if (!result)
       break;
@@ -130,14 +130,14 @@ bool CFileSystemGCWii::ExportApploader(const std::string& _rExportFolder) const
   u32 apploader_size;
   u32 trailer_size;
   const u32 header_size = 0x20;
-  if (!m_rVolume->ReadSwapped(0x2440 + 0x14, &apploader_size, m_Wii) ||
-      !m_rVolume->ReadSwapped(0x2440 + 0x18, &trailer_size, m_Wii))
+  if (!m_rVolume->ReadSwapped(0x2440 + 0x14, &apploader_size, m_partition) ||
+      !m_rVolume->ReadSwapped(0x2440 + 0x18, &trailer_size, m_partition))
     return false;
   apploader_size += trailer_size + header_size;
   DEBUG_LOG(DISCIO, "Apploader size -> %x", apploader_size);
 
   std::vector<u8> buffer(apploader_size);
-  if (m_rVolume->Read(0x2440, apploader_size, buffer.data(), m_Wii))
+  if (m_rVolume->Read(0x2440, apploader_size, buffer.data(), m_partition))
   {
     std::string exportName(_rExportFolder + "/apploader.img");
 
@@ -155,7 +155,7 @@ bool CFileSystemGCWii::ExportApploader(const std::string& _rExportFolder) const
 u64 CFileSystemGCWii::GetBootDOLOffset() const
 {
   u32 offset = 0;
-  m_rVolume->ReadSwapped(0x420, &offset, m_Wii);
+  m_rVolume->ReadSwapped(0x420, &offset, m_partition);
   return static_cast<u64>(offset) << GetOffsetShift();
 }
 
@@ -173,8 +173,8 @@ u32 CFileSystemGCWii::GetBootDOLSize(u64 dol_offset) const
   // Iterate through the 7 code segments
   for (u8 i = 0; i < 7; i++)
   {
-    if (!m_rVolume->ReadSwapped(dol_offset + 0x00 + i * 4, &offset, m_Wii) ||
-        !m_rVolume->ReadSwapped(dol_offset + 0x90 + i * 4, &size, m_Wii))
+    if (!m_rVolume->ReadSwapped(dol_offset + 0x00 + i * 4, &offset, m_partition) ||
+        !m_rVolume->ReadSwapped(dol_offset + 0x90 + i * 4, &size, m_partition))
       return 0;
     dol_size = std::max(offset + size, dol_size);
   }
@@ -182,8 +182,8 @@ u32 CFileSystemGCWii::GetBootDOLSize(u64 dol_offset) const
   // Iterate through the 11 data segments
   for (u8 i = 0; i < 11; i++)
   {
-    if (!m_rVolume->ReadSwapped(dol_offset + 0x1c + i * 4, &offset, m_Wii) ||
-        !m_rVolume->ReadSwapped(dol_offset + 0xac + i * 4, &size, m_Wii))
+    if (!m_rVolume->ReadSwapped(dol_offset + 0x1c + i * 4, &offset, m_partition) ||
+        !m_rVolume->ReadSwapped(dol_offset + 0xac + i * 4, &size, m_partition))
       return 0;
     dol_size = std::max(offset + size, dol_size);
   }
@@ -200,7 +200,7 @@ bool CFileSystemGCWii::ExportDOL(const std::string& _rExportFolder) const
     return false;
 
   std::vector<u8> buffer(DolSize);
-  if (m_rVolume->Read(DolOffset, DolSize, &buffer[0], m_Wii))
+  if (m_rVolume->Read(DolOffset, DolSize, &buffer[0], m_partition))
   {
     std::string exportName(_rExportFolder + "/boot.dol");
 
@@ -218,7 +218,7 @@ bool CFileSystemGCWii::ExportDOL(const std::string& _rExportFolder) const
 std::string CFileSystemGCWii::GetStringFromOffset(u64 _Offset) const
 {
   std::string data(255, 0x00);
-  m_rVolume->Read(_Offset, data.size(), (u8*)&data[0], m_Wii);
+  m_rVolume->Read(_Offset, data.size(), (u8*)&data[0], m_partition);
   data.erase(std::find(data.begin(), data.end(), 0x00), data.end());
 
   // TODO: Should we really always use SHIFT-JIS?
@@ -251,12 +251,12 @@ const SFileInfo* CFileSystemGCWii::FindFileInfo(const std::string& _rFullPath)
 bool CFileSystemGCWii::DetectFileSystem()
 {
   u32 magic_bytes;
-  if (m_rVolume->ReadSwapped(0x18, &magic_bytes, false) && magic_bytes == 0x5D1C9EA3)
+  if (m_rVolume->ReadSwapped(0x18, &magic_bytes, m_partition) && magic_bytes == 0x5D1C9EA3)
   {
     m_Wii = true;
     return true;
   }
-  else if (m_rVolume->ReadSwapped(0x1c, &magic_bytes, false) && magic_bytes == 0xC2339F3D)
+  else if (m_rVolume->ReadSwapped(0x1c, &magic_bytes, m_partition) && magic_bytes == 0xC2339F3D)
   {
     m_Wii = false;
     return true;
@@ -272,15 +272,15 @@ void CFileSystemGCWii::InitFileSystem()
 
   // read the whole FST
   u32 fst_offset_unshifted;
-  if (!m_rVolume->ReadSwapped(0x424, &fst_offset_unshifted, m_Wii))
+  if (!m_rVolume->ReadSwapped(0x424, &fst_offset_unshifted, m_partition))
     return;
   u64 FSTOffset = static_cast<u64>(fst_offset_unshifted) << shift;
 
   // read all fileinfos
   u32 name_offset, offset, size;
-  if (!m_rVolume->ReadSwapped(FSTOffset + 0x0, &name_offset, m_Wii) ||
-      !m_rVolume->ReadSwapped(FSTOffset + 0x4, &offset, m_Wii) ||
-      !m_rVolume->ReadSwapped(FSTOffset + 0x8, &size, m_Wii))
+  if (!m_rVolume->ReadSwapped(FSTOffset + 0x0, &name_offset, m_partition) ||
+      !m_rVolume->ReadSwapped(FSTOffset + 0x4, &offset, m_partition) ||
+      !m_rVolume->ReadSwapped(FSTOffset + 0x8, &size, m_partition))
     return;
   SFileInfo root = {name_offset, static_cast<u64>(offset) << shift, size};
 
@@ -308,11 +308,11 @@ void CFileSystemGCWii::InitFileSystem()
   {
     const u64 read_offset = FSTOffset + (i * 0xC);
     name_offset = 0;
-    m_rVolume->ReadSwapped(read_offset + 0x0, &name_offset, m_Wii);
+    m_rVolume->ReadSwapped(read_offset + 0x0, &name_offset, m_partition);
     offset = 0;
-    m_rVolume->ReadSwapped(read_offset + 0x4, &offset, m_Wii);
+    m_rVolume->ReadSwapped(read_offset + 0x4, &offset, m_partition);
     size = 0;
-    m_rVolume->ReadSwapped(read_offset + 0x8, &size, m_Wii);
+    m_rVolume->ReadSwapped(read_offset + 0x8, &size, m_partition);
     m_FileInfoVector.emplace_back(name_offset, static_cast<u64>(offset) << shift, size);
     NameTableOffset += 0xC;
   }

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -37,7 +37,7 @@ public:
 private:
   bool m_Initialized;
   bool m_Valid;
-  bool m_Wii;
+  u32 m_offset_shift;
   std::vector<SFileInfo> m_FileInfoVector;
 
   std::string GetStringFromOffset(u64 _Offset) const;
@@ -46,7 +46,6 @@ private:
   void InitFileSystem();
   size_t BuildFilenames(const size_t _FirstIndex, const size_t _LastIndex,
                         const std::string& _szDirectory, u64 _NameTableOffset);
-  u32 GetOffsetShift() const;
 };
 
 }  // namespace

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -14,11 +14,12 @@
 namespace DiscIO
 {
 class IVolume;
+struct Partition;
 
 class CFileSystemGCWii : public IFileSystem
 {
 public:
-  CFileSystemGCWii(const IVolume* _rVolume);
+  CFileSystemGCWii(const IVolume* _rVolume, const Partition& partition);
   virtual ~CFileSystemGCWii();
 
   bool IsValid() const override { return m_Valid; }

--- a/Source/Core/DiscIO/Filesystem.cpp
+++ b/Source/Core/DiscIO/Filesystem.cpp
@@ -5,10 +5,12 @@
 #include "DiscIO/Filesystem.h"
 #include <memory>
 #include "DiscIO/FileSystemGCWii.h"
+#include "DiscIO/Volume.h"
 
 namespace DiscIO
 {
-IFileSystem::IFileSystem(const IVolume* _rVolume) : m_rVolume(_rVolume)
+IFileSystem::IFileSystem(const IVolume* _rVolume, const Partition& partition)
+    : m_rVolume(_rVolume), m_partition(partition)
 {
 }
 
@@ -16,12 +18,12 @@ IFileSystem::~IFileSystem()
 {
 }
 
-std::unique_ptr<IFileSystem> CreateFileSystem(const IVolume* volume)
+std::unique_ptr<IFileSystem> CreateFileSystem(const IVolume* volume, const Partition& partition)
 {
   if (!volume)
     return nullptr;
 
-  std::unique_ptr<IFileSystem> filesystem = std::make_unique<CFileSystemGCWii>(volume);
+  std::unique_ptr<IFileSystem> filesystem = std::make_unique<CFileSystemGCWii>(volume, partition);
 
   if (!filesystem)
     return nullptr;

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -9,11 +9,10 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "DiscIO/Volume.h"
 
 namespace DiscIO
 {
-class IVolume;
-
 // file info of an FST entry
 struct SFileInfo
 {
@@ -35,7 +34,7 @@ struct SFileInfo
 class IFileSystem
 {
 public:
-  IFileSystem(const IVolume* _rVolume);
+  IFileSystem(const IVolume* _rVolume, const Partition& partition);
 
   virtual ~IFileSystem();
   virtual bool IsValid() const = 0;
@@ -50,10 +49,12 @@ public:
   virtual u64 GetBootDOLOffset() const = 0;
   virtual u32 GetBootDOLSize(u64 dol_offset) const = 0;
 
+  virtual const Partition GetPartition() const { return m_partition; }
 protected:
-  const IVolume* m_rVolume;
+  const IVolume* const m_rVolume;
+  const Partition m_partition;
 };
 
-std::unique_ptr<IFileSystem> CreateFileSystem(const IVolume* volume);
+std::unique_ptr<IFileSystem> CreateFileSystem(const IVolume* volume, const Partition& partition);
 
 }  // namespace

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstring>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -19,49 +20,71 @@ namespace DiscIO
 {
 enum class BlobType;
 
+struct Partition final
+{
+  Partition() : offset(std::numeric_limits<u64>::max()) {}
+  explicit Partition(u64 offset_) : offset(offset_) {}
+  bool operator==(const Partition& other) const { return offset == other.offset; }
+  bool operator!=(const Partition& other) const { return !(*this == other); }
+  bool operator<(const Partition& other) const { return offset < other.offset; }
+  bool operator>(const Partition& other) const { return other < *this; }
+  bool operator<=(const Partition& other) const { return !(*this < other); }
+  bool operator>=(const Partition& other) const { return !(*this > other); }
+  u64 offset;
+};
+
+const Partition PARTITION_NONE(std::numeric_limits<u64>::max() - 1);
+
 class IVolume
 {
 public:
   IVolume() {}
   virtual ~IVolume() {}
-  // decrypt parameter must be false if not reading a Wii disc
-  virtual bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const = 0;
+  virtual bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const = 0;
   template <typename T>
-  bool ReadSwapped(u64 offset, T* buffer, bool decrypt) const
+  bool ReadSwapped(u64 offset, T* buffer, const Partition& partition) const
   {
     T temp;
-    if (!Read(offset, sizeof(T), reinterpret_cast<u8*>(&temp), decrypt))
+    if (!Read(offset, sizeof(T), reinterpret_cast<u8*>(&temp), partition))
       return false;
     *buffer = Common::FromBigEndian(temp);
     return true;
   }
-
-  virtual bool GetTitleID(u64*) const { return false; }
-  virtual IOS::ES::TicketReader GetTicket() const { return {}; }
-  virtual IOS::ES::TMDReader GetTMD() const { return {}; }
-  virtual u64 PartitionOffsetToRawOffset(u64 offset) const { return offset; }
-  virtual std::string GetGameID() const = 0;
-  virtual std::string GetMakerID() const = 0;
-  virtual u16 GetRevision() const = 0;
-  virtual std::string GetInternalName() const = 0;
+  virtual std::vector<Partition> GetPartitions() const { return {{}}; }
+  virtual Partition GetGamePartition() const { return PARTITION_NONE; }
+  bool GetTitleID(u64* buffer) const { return GetTitleID(buffer, GetGamePartition()); }
+  virtual bool GetTitleID(u64* buffer, const Partition& partition) const { return false; }
+  virtual IOS::ES::TicketReader GetTicket(const Partition& partition) const { return {}; }
+  virtual IOS::ES::TMDReader GetTMD(const Partition& partition) const { return {}; }
+  std::string GetGameID() const { return GetGameID(GetGamePartition()); }
+  virtual std::string GetGameID(const Partition& partition) const = 0;
+  std::string GetMakerID() const { return GetMakerID(GetGamePartition()); }
+  virtual std::string GetMakerID(const Partition& partition) const = 0;
+  u16 GetRevision() const { return GetRevision(GetGamePartition()); }
+  virtual u16 GetRevision(const Partition& partition) const = 0;
+  std::string GetInternalName() const { return GetInternalName(GetGamePartition()); }
+  virtual std::string GetInternalName(const Partition& partition) const = 0;
   virtual std::map<Language, std::string> GetShortNames() const { return {{}}; }
   virtual std::map<Language, std::string> GetLongNames() const { return {{}}; }
   virtual std::map<Language, std::string> GetShortMakers() const { return {{}}; }
   virtual std::map<Language, std::string> GetLongMakers() const { return {{}}; }
   virtual std::map<Language, std::string> GetDescriptions() const { return {{}}; }
   virtual std::vector<u32> GetBanner(int* width, int* height) const = 0;
-  virtual u64 GetFSTSize() const = 0;
-  virtual std::string GetApploaderDate() const = 0;
+  u64 GetFSTSize() const { return GetFSTSize(GetGamePartition()); }
+  virtual u64 GetFSTSize(const Partition& partition) const = 0;
+  std::string GetApploaderDate() const { return GetApploaderDate(GetGamePartition()); }
+  virtual std::string GetApploaderDate(const Partition& partition) const = 0;
   // 0 is the first disc, 1 is the second disc
-  virtual u8 GetDiscNumber() const { return 0; }
+  u8 GetDiscNumber() const { return GetDiscNumber(GetGamePartition()); }
+  virtual u8 GetDiscNumber(const Partition& partition) const { return 0; }
   virtual Platform GetVolumeType() const = 0;
   virtual bool SupportsIntegrityCheck() const { return false; }
-  virtual bool CheckIntegrity() const { return false; }
-  virtual bool ChangePartition(u64 offset) { return false; }
+  virtual bool CheckIntegrity(const Partition& partition) const { return false; }
   virtual Region GetRegion() const = 0;
-  virtual Country GetCountry() const = 0;
+  Country GetCountry() const { return GetCountry(GetGamePartition()); }
+  virtual Country GetCountry(const Partition& partition) const = 0;
   virtual BlobType GetBlobType() const = 0;
-  // Size of virtual disc (not always accurate)
+  // Size of virtual disc (may be inaccurate depending on the blob type)
   virtual u64 GetSize() const = 0;
   // Size on disc (compressed size)
   virtual u64 GetRawSize() const = 0;

--- a/Source/Core/DiscIO/VolumeCreator.cpp
+++ b/Source/Core/DiscIO/VolumeCreator.cpp
@@ -9,8 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include <mbedtls/aes.h>
-
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
@@ -33,24 +31,9 @@ enum EDiscType
   DISC_TYPE_WAD
 };
 
-static const unsigned char s_master_key[16] = {0xeb, 0xe4, 0x2a, 0x22, 0x5e, 0x85, 0x93, 0xe4,
-                                               0x48, 0xd9, 0xc5, 0x45, 0x73, 0x81, 0xaa, 0xf7};
-
-static const unsigned char s_master_key_korean[16] = {
-    0x63, 0xb8, 0x2b, 0xb4, 0xf4, 0x61, 0x4e, 0x2e, 0x13, 0xf2, 0xfe, 0xfb, 0xba, 0x4c, 0x9b, 0x7e};
-
-static const unsigned char s_master_key_rvt[16] = {0xa1, 0x60, 0x4a, 0x6a, 0x71, 0x23, 0xb5, 0x29,
-                                                   0xae, 0x8b, 0xec, 0x32, 0xc8, 0x16, 0xfc, 0xaa};
-
-static const char s_issuer_rvt[] = "Root-CA00000002-XS00000006";
-
-static std::unique_ptr<IVolume> CreateVolumeFromCryptedWiiImage(std::unique_ptr<IBlobReader> reader,
-                                                                u32 partition_group,
-                                                                u32 volume_type, u32 volume_number);
 EDiscType GetDiscType(IBlobReader& _rReader);
 
-std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename, u32 partition_group,
-                                                  u32 volume_number)
+std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename)
 {
   std::unique_ptr<IBlobReader> reader(CreateBlobReader(filename));
   if (reader == nullptr)
@@ -66,7 +49,7 @@ std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename, u
     return std::make_unique<CVolumeWAD>(std::move(reader));
 
   case DISC_TYPE_WII_CONTAINER:
-    return CreateVolumeFromCryptedWiiImage(std::move(reader), partition_group, 0, volume_number);
+    return std::make_unique<CVolumeWiiCrypted>(std::move(reader));
 
   case DISC_TYPE_UNK:
     return nullptr;
@@ -81,110 +64,6 @@ std::unique_ptr<IVolume> CreateVolumeFromDirectory(const std::string& directory,
 {
   if (CVolumeDirectory::IsValidDirectory(directory))
     return std::make_unique<CVolumeDirectory>(directory, is_wii, apploader, dol);
-
-  return nullptr;
-}
-
-void VolumeKeyForPartition(IBlobReader& _rReader, u64 offset, u8* VolumeKey)
-{
-  u8 SubKey[16];
-  _rReader.Read(offset + 0x1bf, 16, SubKey);
-
-  u8 IV[16];
-  memset(IV, 0, 16);
-  _rReader.Read(offset + 0x44c, 8, IV);
-
-  mbedtls_aes_context AES_ctx;
-
-  u8 issuer[sizeof(s_issuer_rvt)];
-  _rReader.Read(offset + 0x140, sizeof(issuer), issuer);
-  if (!memcmp(issuer, s_issuer_rvt, sizeof(s_issuer_rvt)))
-  {
-    // RVT issuer. Use the RVT (debug) master key.
-    mbedtls_aes_setkey_dec(&AES_ctx, s_master_key_rvt, 128);
-  }
-  else
-  {
-    // Issue: 6813
-    // Magic value is at partition's offset + 0x1f1 (1byte)
-    // If encrypted with the Korean key, the magic value would be 1
-    // Otherwise it is zero
-    u8 using_korean_key = 0;
-    _rReader.Read(offset + 0x1f1, sizeof(u8), &using_korean_key);
-    u8 region = 0;
-    _rReader.Read(0x3, sizeof(u8), &region);
-
-    mbedtls_aes_setkey_dec(
-        &AES_ctx, (using_korean_key == 1 && region == 'K' ? s_master_key_korean : s_master_key),
-        128);
-  }
-
-  mbedtls_aes_crypt_cbc(&AES_ctx, MBEDTLS_AES_DECRYPT, 16, IV, SubKey, VolumeKey);
-}
-
-static std::unique_ptr<IVolume> CreateVolumeFromCryptedWiiImage(std::unique_ptr<IBlobReader> reader,
-                                                                u32 partition_group,
-                                                                u32 volume_type, u32 volume_number)
-{
-  CBlobBigEndianReader big_endian_reader(*reader);
-
-  u32 num_partitions;
-  if (!big_endian_reader.ReadSwapped(0x40000 + (partition_group * 8), &num_partitions))
-    return nullptr;
-
-  // Check if we're looking for a valid partition
-  if ((int)volume_number != -1 && volume_number > num_partitions)
-    return nullptr;
-
-  u32 partitions_offset_unshifted;
-  if (!big_endian_reader.ReadSwapped(0x40000 + (partition_group * 8) + 4,
-                                     &partitions_offset_unshifted))
-    return nullptr;
-  u64 partitions_offset = (u64)partitions_offset_unshifted << 2;
-
-  struct SPartition
-  {
-    SPartition(u64 offset_, u32 type_) : offset(offset_), type(type_) {}
-    u64 offset;
-    u32 type;
-  };
-
-  struct SPartitionGroup
-  {
-    u32 num_partitions;
-    u64 partitions_offset;
-    std::vector<SPartition> partitions;
-  };
-  SPartitionGroup partition_groups[4];
-
-  // Read all partitions
-  for (SPartitionGroup& group : partition_groups)
-  {
-    for (u32 i = 0; i < num_partitions; i++)
-    {
-      u32 partition_offset, partition_type;
-      if (big_endian_reader.ReadSwapped(partitions_offset + (i * 8) + 0, &partition_offset) &&
-          big_endian_reader.ReadSwapped(partitions_offset + (i * 8) + 4, &partition_type))
-      {
-        group.partitions.emplace_back((u64)partition_offset << 2, partition_type);
-      }
-    }
-  }
-
-  // Return the partition type specified or number
-  // types: 0 = game, 1 = firmware update, 2 = channel installer
-  //  some partitions on SSBB use the ASCII title id of the demo VC game they hold...
-  for (size_t i = 0; i < partition_groups[partition_group].partitions.size(); i++)
-  {
-    const SPartition& partition = partition_groups[partition_group].partitions.at(i);
-
-    if ((partition.type == volume_type && (int)volume_number == -1) || i == volume_number)
-    {
-      u8 volume_key[16];
-      VolumeKeyForPartition(*reader, partition.offset, volume_key);
-      return std::make_unique<CVolumeWiiCrypted>(std::move(reader), partition.offset, volume_key);
-    }
-  }
 
   return nullptr;
 }

--- a/Source/Core/DiscIO/VolumeCreator.h
+++ b/Source/Core/DiscIO/VolumeCreator.h
@@ -7,18 +7,13 @@
 #include <memory>
 #include <string>
 
-#include "Common/CommonTypes.h"
-
 namespace DiscIO
 {
 class IVolume;
-class IBlobReader;
 
-std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename,
-                                                  u32 partition_group = 0, u32 volume_number = -1);
+std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename);
 std::unique_ptr<IVolume> CreateVolumeFromDirectory(const std::string& directory, bool is_wii,
                                                    const std::string& apploader = "",
                                                    const std::string& dol = "");
-void VolumeKeyForPartition(IBlobReader& _rReader, u64 offset, u8* VolumeKey);
 
 }  // namespace

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -39,26 +39,28 @@ public:
 
   static bool IsValidDirectory(const std::string& directory);
 
-  bool Read(u64 offset, u64 length, u8* buffer, bool decrypt) const override;
+  bool Read(u64 offset, u64 length, u8* buffer, const Partition& partition) const override;
+  std::vector<Partition> GetPartitions() const override;
+  Partition GetGamePartition() const override;
 
-  std::string GetGameID() const override;
+  std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
   void SetGameID(const std::string& id);
 
-  std::string GetMakerID() const override;
+  std::string GetMakerID(const Partition& partition = PARTITION_NONE) const override;
 
-  u16 GetRevision() const override { return 0; }
-  std::string GetInternalName() const override;
+  u16 GetRevision(const Partition& partition = PARTITION_NONE) const override { return 0; }
+  std::string GetInternalName(const Partition& partition = PARTITION_NONE) const override;
   std::map<Language, std::string> GetLongNames() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
   void SetName(const std::string&);
 
-  u64 GetFSTSize() const override;
+  u64 GetFSTSize(const Partition& partition = PARTITION_NONE) const override;
 
-  std::string GetApploaderDate() const override;
+  std::string GetApploaderDate(const Partition& partition = PARTITION_NONE) const override;
   Platform GetVolumeType() const override;
 
   Region GetRegion() const override;
-  Country GetCountry() const override;
+  Country GetCountry(const Partition& partition = PARTITION_NONE) const override;
 
   BlobType GetBlobType() const override;
   u64 GetSize() const override;

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -32,21 +32,21 @@ CVolumeGC::~CVolumeGC()
 {
 }
 
-bool CVolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const
+bool CVolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const
 {
-  if (decrypt)
-    PanicAlertT("Tried to decrypt data from a non-Wii volume");
+  if (partition != PARTITION_NONE)
+    return false;
 
   return m_pReader->Read(_Offset, _Length, _pBuffer);
 }
 
-std::string CVolumeGC::GetGameID() const
+std::string CVolumeGC::GetGameID(const Partition& partition) const
 {
   static const std::string NO_UID("NO_UID");
 
   char ID[6];
 
-  if (!Read(0, sizeof(ID), reinterpret_cast<u8*>(ID)))
+  if (!Read(0, sizeof(ID), reinterpret_cast<u8*>(ID), partition))
   {
     PanicAlertT("Failed to read unique ID from disc image");
     return NO_UID;
@@ -58,43 +58,43 @@ std::string CVolumeGC::GetGameID() const
 Region CVolumeGC::GetRegion() const
 {
   u8 country_code;
-  if (!ReadSwapped(3, &country_code, false))
+  if (!ReadSwapped(3, &country_code, PARTITION_NONE))
     return Region::UNKNOWN_REGION;
 
   return RegionSwitchGC(country_code);
 }
 
-Country CVolumeGC::GetCountry() const
+Country CVolumeGC::GetCountry(const Partition& partition) const
 {
   u8 country_code;
-  if (!ReadSwapped(3, &country_code, false))
+  if (!ReadSwapped(3, &country_code, partition))
     return Country::COUNTRY_UNKNOWN;
 
   return CountrySwitch(country_code);
 }
 
-std::string CVolumeGC::GetMakerID() const
+std::string CVolumeGC::GetMakerID(const Partition& partition) const
 {
   char makerID[2];
-  if (!Read(0x4, 0x2, (u8*)&makerID))
+  if (!Read(0x4, 0x2, (u8*)&makerID, partition))
     return std::string();
 
   return DecodeString(makerID);
 }
 
-u16 CVolumeGC::GetRevision() const
+u16 CVolumeGC::GetRevision(const Partition& partition) const
 {
   u8 revision;
-  if (!ReadSwapped(7, &revision, false))
+  if (!ReadSwapped(7, &revision, partition))
     return 0;
 
   return revision;
 }
 
-std::string CVolumeGC::GetInternalName() const
+std::string CVolumeGC::GetInternalName(const Partition& partition) const
 {
   char name[0x60];
-  if (Read(0x20, 0x60, (u8*)name))
+  if (Read(0x20, 0x60, (u8*)name, partition))
     return DecodeString(name);
 
   return "";
@@ -138,19 +138,19 @@ std::vector<u32> CVolumeGC::GetBanner(int* width, int* height) const
   return m_image_buffer;
 }
 
-u64 CVolumeGC::GetFSTSize() const
+u64 CVolumeGC::GetFSTSize(const Partition& partition) const
 {
   u32 size;
-  if (!Read(0x428, 0x4, (u8*)&size))
+  if (!Read(0x428, 0x4, (u8*)&size, partition))
     return 0;
 
   return Common::swap32(size);
 }
 
-std::string CVolumeGC::GetApploaderDate() const
+std::string CVolumeGC::GetApploaderDate(const Partition& partition) const
 {
   char date[16];
-  if (!Read(0x2440, 0x10, (u8*)&date))
+  if (!Read(0x2440, 0x10, (u8*)&date, partition))
     return std::string();
 
   return DecodeString(date);
@@ -171,10 +171,10 @@ u64 CVolumeGC::GetRawSize() const
   return m_pReader->GetRawSize();
 }
 
-u8 CVolumeGC::GetDiscNumber() const
+u8 CVolumeGC::GetDiscNumber(const Partition& partition) const
 {
   u8 disc_number = 0;
-  ReadSwapped(6, &disc_number, false);
+  ReadSwapped(6, &disc_number, partition);
   return disc_number;
 }
 
@@ -192,8 +192,8 @@ void CVolumeGC::LoadBannerFile() const
   m_banner_loaded = true;
 
   GCBanner banner_file;
-  std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this));
-  size_t file_size = (size_t)file_system->GetFileSize("opening.bnr");
+  std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this, PARTITION_NONE));
+  size_t file_size = static_cast<size_t>(file_system->GetFileSize("opening.bnr"));
 
   constexpr int BNR1_MAGIC = 0x31524e42;
   constexpr int BNR2_MAGIC = 0x32524e42;

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -193,8 +193,10 @@ void CVolumeGC::LoadBannerFile() const
 
   GCBanner banner_file;
   std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this, PARTITION_NONE));
-  size_t file_size = static_cast<size_t>(file_system->GetFileSize("opening.bnr"));
+  if (!file_system)
+    return;
 
+  size_t file_size = static_cast<size_t>(file_system->GetFileSize("opening.bnr"));
   constexpr int BNR1_MAGIC = 0x31524e42;
   constexpr int BNR2_MAGIC = 0x32524e42;
   if (file_size != BNR1_SIZE && file_size != BNR2_SIZE)

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -28,24 +28,25 @@ class CVolumeGC : public IVolume
 public:
   CVolumeGC(std::unique_ptr<IBlobReader> reader);
   ~CVolumeGC();
-  bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt = false) const override;
-  std::string GetGameID() const override;
-  std::string GetMakerID() const override;
-  u16 GetRevision() const override;
-  std::string GetInternalName() const override;
+  bool Read(u64 _Offset, u64 _Length, u8* _pBuffer,
+            const Partition& partition = PARTITION_NONE) const override;
+  std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
+  std::string GetMakerID(const Partition& partition = PARTITION_NONE) const override;
+  u16 GetRevision(const Partition& partition = PARTITION_NONE) const override;
+  std::string GetInternalName(const Partition& partition = PARTITION_NONE) const override;
   std::map<Language, std::string> GetShortNames() const override;
   std::map<Language, std::string> GetLongNames() const override;
   std::map<Language, std::string> GetShortMakers() const override;
   std::map<Language, std::string> GetLongMakers() const override;
   std::map<Language, std::string> GetDescriptions() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
-  u64 GetFSTSize() const override;
-  std::string GetApploaderDate() const override;
-  u8 GetDiscNumber() const override;
+  u64 GetFSTSize(const Partition& partition = PARTITION_NONE) const override;
+  std::string GetApploaderDate(const Partition& partition = PARTITION_NONE) const override;
+  u8 GetDiscNumber(const Partition& partition = PARTITION_NONE) const override;
 
   Platform GetVolumeType() const override;
   Region GetRegion() const override;
-  Country GetCountry() const override;
+  Country GetCountry(const Partition& partition = PARTITION_NONE) const override;
   BlobType GetBlobType() const override;
   u64 GetSize() const override;
   u64 GetRawSize() const override;

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -31,20 +31,27 @@ class CVolumeWAD : public IVolume
 public:
   CVolumeWAD(std::unique_ptr<IBlobReader> reader);
   ~CVolumeWAD();
-  bool Read(u64 offset, u64 length, u8* buffer, bool decrypt = false) const override;
-  bool GetTitleID(u64* buffer) const override;
-  IOS::ES::TMDReader GetTMD() const override;
-  std::string GetGameID() const override;
-  std::string GetMakerID() const override;
-  u16 GetRevision() const override;
-  std::string GetInternalName() const override { return ""; }
+  bool Read(u64 offset, u64 length, u8* buffer,
+            const Partition& partition = PARTITION_NONE) const override;
+  bool GetTitleID(u64* buffer, const Partition& partition = PARTITION_NONE) const override;
+  IOS::ES::TMDReader GetTMD(const Partition& partition = PARTITION_NONE) const override;
+  std::string GetGameID(const Partition& partition = PARTITION_NONE) const override;
+  std::string GetMakerID(const Partition& partition = PARTITION_NONE) const override;
+  u16 GetRevision(const Partition& partition = PARTITION_NONE) const override;
+  std::string GetInternalName(const Partition& partition = PARTITION_NONE) const override
+  {
+    return "";
+  }
   std::map<Language, std::string> GetLongNames() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
-  u64 GetFSTSize() const override { return 0; }
-  std::string GetApploaderDate() const override { return ""; }
+  u64 GetFSTSize(const Partition& partition = PARTITION_NONE) const override { return 0; }
+  std::string GetApploaderDate(const Partition& partition = PARTITION_NONE) const override
+  {
+    return "";
+  }
   Platform GetVolumeType() const override;
   Region GetRegion() const override;
-  Country GetCountry() const override;
+  Country GetCountry(const Partition& partition = PARTITION_NONE) const override;
 
   BlobType GetBlobType() const override;
   u64 GetSize() const override;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -4,6 +4,7 @@
 
 #include "DiscIO/VolumeWiiCrypted.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstring>
 #include <map>
@@ -87,14 +88,14 @@ bool CVolumeWiiCrypted::Read(u64 _ReadOffset, u64 _Length, u8* _pBuffer, bool de
     }
 
     // Copy the decrypted data
-    u64 MaxSizeToCopy = BLOCK_DATA_SIZE - data_offset_in_block;
-    u64 CopySize = (_Length > MaxSizeToCopy) ? MaxSizeToCopy : _Length;
-    memcpy(_pBuffer, &m_last_decrypted_block_data[data_offset_in_block], (size_t)CopySize);
+    u64 copy_size = std::min(_Length, BLOCK_DATA_SIZE - data_offset_in_block);
+    memcpy(_pBuffer, &m_last_decrypted_block_data[data_offset_in_block],
+           static_cast<size_t>(copy_size));
 
     // Update offsets
-    _Length -= CopySize;
-    _pBuffer += CopySize;
-    _ReadOffset += CopySize;
+    _Length -= copy_size;
+    _pBuffer += copy_size;
+    _ReadOffset += copy_size;
   }
 
   return true;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -31,41 +31,112 @@ namespace DiscIO
 {
 constexpr u64 PARTITION_DATA_OFFSET = 0x20000;
 
-CVolumeWiiCrypted::CVolumeWiiCrypted(std::unique_ptr<IBlobReader> reader, u64 _VolumeOffset,
-                                     const unsigned char* _pVolumeKey)
-    : m_pReader(std::move(reader)), m_AES_ctx(std::make_unique<mbedtls_aes_context>()),
-      m_VolumeOffset(_VolumeOffset), m_last_decrypted_block(-1)
+CVolumeWiiCrypted::CVolumeWiiCrypted(std::unique_ptr<IBlobReader> reader)
+    : m_pReader(std::move(reader)), m_game_partition(PARTITION_NONE), m_last_decrypted_block(-1)
 {
   _assert_(m_pReader);
 
-  mbedtls_aes_setkey_dec(m_AES_ctx.get(), _pVolumeKey, 128);
-}
+  // Get decryption keys for all partitions
+  CBlobBigEndianReader big_endian_reader(*m_pReader.get());
+  for (u32 partition_group = 0; partition_group < 4; ++partition_group)
+  {
+    u32 number_of_partitions;
+    if (!big_endian_reader.ReadSwapped(0x40000 + (partition_group * 8), &number_of_partitions))
+      continue;
 
-bool CVolumeWiiCrypted::ChangePartition(u64 offset)
-{
-  m_VolumeOffset = offset;
+    u32 read_buffer;
+    if (!big_endian_reader.ReadSwapped(0x40000 + (partition_group * 8) + 4, &read_buffer))
+      continue;
+    const u64 partition_table_offset = (u64)read_buffer << 2;
 
-  u8 volume_key[16];
-  DiscIO::VolumeKeyForPartition(*m_pReader, offset, volume_key);
-  mbedtls_aes_setkey_dec(m_AES_ctx.get(), volume_key, 128);
-  return true;
+    for (u32 i = 0; i < number_of_partitions; i++)
+    {
+      if (!big_endian_reader.ReadSwapped(partition_table_offset + (i * 8), &read_buffer))
+        continue;
+      const u64 partition_offset = (u64)read_buffer << 2;
+
+      if (m_game_partition == PARTITION_NONE)
+      {
+        u32 partition_type;
+        if (!big_endian_reader.ReadSwapped(partition_table_offset + (i * 8) + 4, &partition_type))
+          continue;
+
+        if (partition_type == 0)
+          m_game_partition = Partition(partition_offset);
+      }
+
+      u8 sub_key[16];
+      if (!m_pReader->Read(partition_offset + 0x1bf, 16, sub_key))
+        continue;
+
+      u8 iv[16];
+      memset(iv, 0, 16);
+      if (!m_pReader->Read(partition_offset + 0x44c, 8, iv))
+        continue;
+
+      static const u8 common_key_standard[16] = {0xeb, 0xe4, 0x2a, 0x22, 0x5e, 0x85, 0x93, 0xe4,
+                                                 0x48, 0xd9, 0xc5, 0x45, 0x73, 0x81, 0xaa, 0xf7};
+      static const u8 common_key_korean[16] = {0x63, 0xb8, 0x2b, 0xb4, 0xf4, 0x61, 0x4e, 0x2e,
+                                               0x13, 0xf2, 0xfe, 0xfb, 0xba, 0x4c, 0x9b, 0x7e};
+      static const u8 common_key_rvt[16] = {0xa1, 0x60, 0x4a, 0x6a, 0x71, 0x23, 0xb5, 0x29,
+                                            0xae, 0x8b, 0xec, 0x32, 0xc8, 0x16, 0xfc, 0xaa};
+      static const char issuer_rvt[] = "Root-CA00000002-XS00000006";
+
+      const u8* common_key;
+
+      u8 issuer[sizeof(issuer_rvt)];
+      if (!m_pReader->Read(partition_offset + 0x140, sizeof(issuer), issuer))
+        continue;
+
+      if (!memcmp(issuer, issuer_rvt, sizeof(issuer_rvt)))
+      {
+        // RVT issuer. Use the RVT (debug) master key.
+        common_key = common_key_rvt;
+      }
+      else
+      {
+        u8 key_number = 0;
+        if (!big_endian_reader.ReadSwapped(partition_offset + 0x1f1, &key_number))
+          continue;
+        common_key = (key_number == 1) ? common_key_korean : common_key_standard;
+      }
+
+      mbedtls_aes_context aes_context;
+      mbedtls_aes_setkey_dec(&aes_context, common_key, 128);
+
+      u8 volume_key[16];
+      mbedtls_aes_crypt_cbc(&aes_context, MBEDTLS_AES_DECRYPT, 16, iv, sub_key, volume_key);
+
+      std::unique_ptr<mbedtls_aes_context> partition_AES_context =
+          std::make_unique<mbedtls_aes_context>();
+      mbedtls_aes_setkey_dec(partition_AES_context.get(), volume_key, 128);
+      m_partitions[Partition(partition_offset)] = std::move(partition_AES_context);
+    }
+  }
 }
 
 CVolumeWiiCrypted::~CVolumeWiiCrypted()
 {
 }
 
-bool CVolumeWiiCrypted::Read(u64 _ReadOffset, u64 _Length, u8* _pBuffer, bool decrypt) const
+bool CVolumeWiiCrypted::Read(u64 _ReadOffset, u64 _Length, u8* _pBuffer,
+                             const Partition& partition) const
 {
-  if (!decrypt)
+  if (partition == PARTITION_NONE)
     return m_pReader->Read(_ReadOffset, _Length, _pBuffer);
+
+  // Get the decryption key for the partition
+  auto it = m_partitions.find(partition);
+  if (it == m_partitions.end())
+    return false;
+  mbedtls_aes_context* aes_context = it->second.get();
 
   std::vector<u8> read_buffer(BLOCK_TOTAL_SIZE);
   while (_Length > 0)
   {
     // Calculate offsets
     u64 block_offset_on_disc =
-        _ReadOffset / BLOCK_DATA_SIZE * BLOCK_TOTAL_SIZE + m_VolumeOffset + PARTITION_DATA_OFFSET;
+        partition.offset + PARTITION_DATA_OFFSET + _ReadOffset / BLOCK_DATA_SIZE * BLOCK_TOTAL_SIZE;
     u64 data_offset_in_block = _ReadOffset % BLOCK_DATA_SIZE;
 
     if (m_last_decrypted_block != block_offset_on_disc)
@@ -78,9 +149,8 @@ bool CVolumeWiiCrypted::Read(u64 _ReadOffset, u64 _Length, u8* _pBuffer, bool de
       // 0x3D0 - 0x3DF in read_buffer will be overwritten,
       // but that won't affect anything, because we won't
       // use the content of read_buffer anymore after this
-      mbedtls_aes_crypt_cbc(m_AES_ctx.get(), MBEDTLS_AES_DECRYPT, BLOCK_DATA_SIZE,
-                            &read_buffer[0x3D0], &read_buffer[BLOCK_HEADER_SIZE],
-                            m_last_decrypted_block_data);
+      mbedtls_aes_crypt_cbc(aes_context, MBEDTLS_AES_DECRYPT, BLOCK_DATA_SIZE, &read_buffer[0x3D0],
+                            &read_buffer[BLOCK_HEADER_SIZE], m_last_decrypted_block_data);
       m_last_decrypted_block = block_offset_on_disc;
 
       // The only thing we currently use from the 0x000 - 0x3FF part
@@ -103,26 +173,39 @@ bool CVolumeWiiCrypted::Read(u64 _ReadOffset, u64 _Length, u8* _pBuffer, bool de
   return true;
 }
 
-bool CVolumeWiiCrypted::GetTitleID(u64* buffer) const
+std::vector<Partition> CVolumeWiiCrypted::GetPartitions() const
 {
-  return ReadSwapped(m_VolumeOffset + 0x1DC, buffer, false);
+  std::vector<Partition> partitions;
+  for (const auto& pair : m_partitions)
+    partitions.push_back(pair.first);
+  return partitions;
 }
 
-IOS::ES::TicketReader CVolumeWiiCrypted::GetTicket() const
+Partition CVolumeWiiCrypted::GetGamePartition() const
+{
+  return m_game_partition;
+}
+
+bool CVolumeWiiCrypted::GetTitleID(u64* buffer, const Partition& partition) const
+{
+  return ReadSwapped(partition.offset + 0x1DC, buffer, PARTITION_NONE);
+}
+
+IOS::ES::TicketReader CVolumeWiiCrypted::GetTicket(const Partition& partition) const
 {
   std::vector<u8> buffer(0x2a4);
-  Read(m_VolumeOffset, buffer.size(), buffer.data(), false);
+  Read(partition.offset, buffer.size(), buffer.data(), PARTITION_NONE);
   return IOS::ES::TicketReader{std::move(buffer)};
 }
 
-IOS::ES::TMDReader CVolumeWiiCrypted::GetTMD() const
+IOS::ES::TMDReader CVolumeWiiCrypted::GetTMD(const Partition& partition) const
 {
   u32 tmd_size = 0;
   u32 tmd_address = 0;
 
-  if (!ReadSwapped(m_VolumeOffset + 0x2a4, &tmd_size, false))
+  if (!ReadSwapped(partition.offset + 0x2a4, &tmd_size, PARTITION_NONE))
     return {};
-  if (!ReadSwapped(m_VolumeOffset + 0x2a8, &tmd_address, false))
+  if (!ReadSwapped(partition.offset + 0x2a8, &tmd_address, PARTITION_NONE))
     return {};
   tmd_address <<= 2;
 
@@ -137,23 +220,26 @@ IOS::ES::TMDReader CVolumeWiiCrypted::GetTMD() const
   }
 
   std::vector<u8> buffer(tmd_size);
-  if (!Read(m_VolumeOffset + tmd_address, tmd_size, buffer.data(), false))
+  if (!Read(partition.offset + tmd_address, tmd_size, buffer.data(), PARTITION_NONE))
     return {};
 
   return IOS::ES::TMDReader{std::move(buffer)};
 }
 
-u64 CVolumeWiiCrypted::PartitionOffsetToRawOffset(u64 offset) const
+u64 CVolumeWiiCrypted::PartitionOffsetToRawOffset(u64 offset, const Partition& partition)
 {
-  return m_VolumeOffset + PARTITION_DATA_OFFSET + (offset / BLOCK_DATA_SIZE * BLOCK_TOTAL_SIZE) +
+  if (partition == PARTITION_NONE)
+    return offset;
+
+  return partition.offset + PARTITION_DATA_OFFSET + (offset / BLOCK_DATA_SIZE * BLOCK_TOTAL_SIZE) +
          (offset % BLOCK_DATA_SIZE);
 }
 
-std::string CVolumeWiiCrypted::GetGameID() const
+std::string CVolumeWiiCrypted::GetGameID(const Partition& partition) const
 {
   char ID[6];
 
-  if (!Read(0, 6, (u8*)ID, true))
+  if (!Read(0, 6, (u8*)ID, partition))
     return std::string();
 
   return DecodeString(ID);
@@ -162,16 +248,16 @@ std::string CVolumeWiiCrypted::GetGameID() const
 Region CVolumeWiiCrypted::GetRegion() const
 {
   u32 region_code;
-  if (!ReadSwapped(0x4E000, &region_code, false))
+  if (!ReadSwapped(0x4E000, &region_code, PARTITION_NONE))
     return Region::UNKNOWN_REGION;
 
   return static_cast<Region>(region_code);
 }
 
-Country CVolumeWiiCrypted::GetCountry() const
+Country CVolumeWiiCrypted::GetCountry(const Partition& partition) const
 {
   u8 country_byte;
-  if (!ReadSwapped(3, &country_byte, true))
+  if (!ReadSwapped(3, &country_byte, partition))
     return Country::COUNTRY_UNKNOWN;
 
   const Region region = GetRegion();
@@ -182,29 +268,29 @@ Country CVolumeWiiCrypted::GetCountry() const
   return CountrySwitch(country_byte);
 }
 
-std::string CVolumeWiiCrypted::GetMakerID() const
+std::string CVolumeWiiCrypted::GetMakerID(const Partition& partition) const
 {
   char makerID[2];
 
-  if (!Read(0x4, 0x2, (u8*)&makerID, true))
+  if (!Read(0x4, 0x2, (u8*)&makerID, partition))
     return std::string();
 
   return DecodeString(makerID);
 }
 
-u16 CVolumeWiiCrypted::GetRevision() const
+u16 CVolumeWiiCrypted::GetRevision(const Partition& partition) const
 {
   u8 revision;
-  if (!ReadSwapped(7, &revision, true))
+  if (!ReadSwapped(7, &revision, partition))
     return 0;
 
   return revision;
 }
 
-std::string CVolumeWiiCrypted::GetInternalName() const
+std::string CVolumeWiiCrypted::GetInternalName(const Partition& partition) const
 {
   char name_buffer[0x60];
-  if (Read(0x20, 0x60, (u8*)&name_buffer, true))
+  if (Read(0x20, 0x60, (u8*)&name_buffer, partition))
     return DecodeString(name_buffer);
 
   return "";
@@ -212,7 +298,7 @@ std::string CVolumeWiiCrypted::GetInternalName() const
 
 std::map<Language, std::string> CVolumeWiiCrypted::GetLongNames() const
 {
-  std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this));
+  std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this, GetGamePartition()));
   std::vector<u8> opening_bnr(NAMES_TOTAL_BYTES);
   size_t size = file_system->ReadFile("opening.bnr", opening_bnr.data(), opening_bnr.size(), 0x5C);
   opening_bnr.resize(size);
@@ -225,27 +311,27 @@ std::vector<u32> CVolumeWiiCrypted::GetBanner(int* width, int* height) const
   *height = 0;
 
   u64 title_id;
-  if (!GetTitleID(&title_id))
+  if (!GetTitleID(&title_id, GetGamePartition()))
     return std::vector<u32>();
 
   return GetWiiBanner(width, height, title_id);
 }
 
-u64 CVolumeWiiCrypted::GetFSTSize() const
+u64 CVolumeWiiCrypted::GetFSTSize(const Partition& partition) const
 {
   u32 size;
 
-  if (!Read(0x428, 0x4, (u8*)&size, true))
+  if (!Read(0x428, 0x4, (u8*)&size, partition))
     return 0;
 
   return (u64)Common::swap32(size) << 2;
 }
 
-std::string CVolumeWiiCrypted::GetApploaderDate() const
+std::string CVolumeWiiCrypted::GetApploaderDate(const Partition& partition) const
 {
   char date[16];
 
-  if (!Read(0x2440, 0x10, (u8*)&date, true))
+  if (!Read(0x2440, 0x10, (u8*)&date, partition))
     return std::string();
 
   return DecodeString(date);
@@ -256,10 +342,10 @@ Platform CVolumeWiiCrypted::GetVolumeType() const
   return Platform::WII_DISC;
 }
 
-u8 CVolumeWiiCrypted::GetDiscNumber() const
+u8 CVolumeWiiCrypted::GetDiscNumber(const Partition& partition) const
 {
   u8 disc_number = 0;
-  ReadSwapped(6, &disc_number, true);
+  ReadSwapped(6, &disc_number, partition);
   return disc_number;
 }
 
@@ -278,29 +364,34 @@ u64 CVolumeWiiCrypted::GetRawSize() const
   return m_pReader->GetRawSize();
 }
 
-bool CVolumeWiiCrypted::CheckIntegrity() const
+bool CVolumeWiiCrypted::CheckIntegrity(const Partition& partition) const
 {
+  // Get the decryption key for the partition
+  auto it = m_partitions.find(partition);
+  if (it == m_partitions.end())
+    return false;
+  mbedtls_aes_context* aes_context = it->second.get();
+
   // Get partition data size
   u32 partSizeDiv4;
-  Read(m_VolumeOffset + 0x2BC, 4, (u8*)&partSizeDiv4, false);
+  Read(partition.offset + 0x2BC, 4, (u8*)&partSizeDiv4, PARTITION_NONE);
   u64 partDataSize = (u64)Common::swap32(partSizeDiv4) * 4;
 
   u32 nClusters = (u32)(partDataSize / 0x8000);
   for (u32 clusterID = 0; clusterID < nClusters; ++clusterID)
   {
-    u64 clusterOff = m_VolumeOffset + PARTITION_DATA_OFFSET + (u64)clusterID * 0x8000;
+    u64 clusterOff = partition.offset + PARTITION_DATA_OFFSET + (u64)clusterID * 0x8000;
 
     // Read and decrypt the cluster metadata
     u8 clusterMDCrypted[0x400];
     u8 clusterMD[0x400];
     u8 IV[16] = {0};
-    if (!Read(clusterOff, 0x400, clusterMDCrypted, false))
+    if (!Read(clusterOff, 0x400, clusterMDCrypted, PARTITION_NONE))
     {
       WARN_LOG(DISCIO, "Integrity Check: fail at cluster %d: could not read metadata", clusterID);
       return false;
     }
-    mbedtls_aes_crypt_cbc(m_AES_ctx.get(), MBEDTLS_AES_DECRYPT, 0x400, IV, clusterMDCrypted,
-                          clusterMD);
+    mbedtls_aes_crypt_cbc(aes_context, MBEDTLS_AES_DECRYPT, 0x400, IV, clusterMDCrypted, clusterMD);
 
     // Some clusters have invalid data and metadata because they aren't
     // meant to be read by the game (for example, holes between files). To
@@ -319,7 +410,7 @@ bool CVolumeWiiCrypted::CheckIntegrity() const
       continue;
 
     u8 clusterData[0x7C00];
-    if (!Read((u64)clusterID * 0x7C00, 0x7C00, clusterData, true))
+    if (!Read((u64)clusterID * 0x7C00, 0x7C00, clusterData, partition))
     {
       WARN_LOG(DISCIO, "Integrity Check: fail at cluster %d: could not read data", clusterID);
       return false;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -299,6 +299,9 @@ std::string CVolumeWiiCrypted::GetInternalName(const Partition& partition) const
 std::map<Language, std::string> CVolumeWiiCrypted::GetLongNames() const
 {
   std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this, GetGamePartition()));
+  if (!file_system)
+    return {{}};
+
   std::vector<u8> opening_bnr(NAMES_TOTAL_BYTES);
   size_t size = file_system->ReadFile("opening.bnr", opening_bnr.data(), opening_bnr.size(), 0x5C);
   opening_bnr.resize(size);

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -68,8 +68,8 @@ private:
   u64 m_VolumeOffset;
   u64 m_dataOffset;
 
-  mutable u64 m_LastDecryptedBlockOffset;
-  mutable unsigned char m_LastDecryptedBlock[BLOCK_DATA_SIZE];
+  mutable u64 m_last_decrypted_block;
+  mutable u8 m_last_decrypted_block_data[BLOCK_DATA_SIZE];
 };
 
 }  // namespace

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -28,34 +28,35 @@ enum class Platform;
 class CVolumeWiiCrypted : public IVolume
 {
 public:
-  CVolumeWiiCrypted(std::unique_ptr<IBlobReader> reader, u64 _VolumeOffset,
-                    const unsigned char* _pVolumeKey);
+  CVolumeWiiCrypted(std::unique_ptr<IBlobReader> reader);
   ~CVolumeWiiCrypted();
-  bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const override;
-  bool GetTitleID(u64* buffer) const override;
-  IOS::ES::TicketReader GetTicket() const override;
-  IOS::ES::TMDReader GetTMD() const override;
-  u64 PartitionOffsetToRawOffset(u64 offset) const override;
-  std::string GetGameID() const override;
-  std::string GetMakerID() const override;
-  u16 GetRevision() const override;
-  std::string GetInternalName() const override;
+  bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, const Partition& partition) const override;
+  std::vector<Partition> GetPartitions() const override;
+  Partition GetGamePartition() const override;
+  bool GetTitleID(u64* buffer, const Partition& partition) const override;
+  IOS::ES::TicketReader GetTicket(const Partition& partition) const override;
+  IOS::ES::TMDReader GetTMD(const Partition& partition) const override;
+  std::string GetGameID(const Partition& partition) const override;
+  std::string GetMakerID(const Partition& partition) const override;
+  u16 GetRevision(const Partition& partition) const override;
+  std::string GetInternalName(const Partition& partition) const override;
   std::map<Language, std::string> GetLongNames() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
-  u64 GetFSTSize() const override;
-  std::string GetApploaderDate() const override;
-  u8 GetDiscNumber() const override;
+  u64 GetFSTSize(const Partition& partition) const override;
+  std::string GetApploaderDate(const Partition& partition) const override;
+  u8 GetDiscNumber(const Partition& partition) const override;
 
   Platform GetVolumeType() const override;
   bool SupportsIntegrityCheck() const override { return true; }
-  bool CheckIntegrity() const override;
-  bool ChangePartition(u64 offset) override;
+  bool CheckIntegrity(const Partition& partition) const override;
 
   Region GetRegion() const override;
-  Country GetCountry() const override;
+  Country GetCountry(const Partition& partition) const override;
   BlobType GetBlobType() const override;
   u64 GetSize() const override;
   u64 GetRawSize() const override;
+
+  static u64 PartitionOffsetToRawOffset(u64 offset, const Partition& partition);
 
   static constexpr unsigned int BLOCK_HEADER_SIZE = 0x0400;
   static constexpr unsigned int BLOCK_DATA_SIZE = 0x7C00;
@@ -63,9 +64,8 @@ public:
 
 private:
   std::unique_ptr<IBlobReader> m_pReader;
-  std::unique_ptr<mbedtls_aes_context> m_AES_ctx;
-
-  u64 m_VolumeOffset;
+  std::map<Partition, std::unique_ptr<mbedtls_aes_context>> m_partitions;
+  Partition m_game_partition;
 
   mutable u64 m_last_decrypted_block;
   mutable u8 m_last_decrypted_block_data[BLOCK_DATA_SIZE];

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -66,7 +66,6 @@ private:
   std::unique_ptr<mbedtls_aes_context> m_AES_ctx;
 
   u64 m_VolumeOffset;
-  u64 m_dataOffset;
 
   mutable u64 m_last_decrypted_block;
   mutable u8 m_last_decrypted_block_data[BLOCK_DATA_SIZE];

--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
@@ -33,32 +33,31 @@ namespace
 class WiiPartition final : public wxTreeItemData
 {
 public:
-  WiiPartition(std::unique_ptr<DiscIO::IVolume> volume_,
-               std::unique_ptr<DiscIO::IFileSystem> filesystem_)
-      : volume{std::move(volume_)}, filesystem{std::move(filesystem_)}
+  WiiPartition(std::unique_ptr<DiscIO::IFileSystem> filesystem_)
+      : filesystem{std::move(filesystem_)}
   {
   }
 
-  std::unique_ptr<DiscIO::IVolume> volume;
   std::unique_ptr<DiscIO::IFileSystem> filesystem;
 };
 
 class IntegrityCheckThread final : public wxThread
 {
 public:
-  explicit IntegrityCheckThread(const WiiPartition& partition)
-      : wxThread{wxTHREAD_JOINABLE}, m_partition{partition}
+  explicit IntegrityCheckThread(const DiscIO::IVolume* volume, DiscIO::Partition partition)
+      : wxThread{wxTHREAD_JOINABLE}, m_volume{volume}, m_partition{partition}
   {
     Create();
   }
 
   ExitCode Entry() override
   {
-    return reinterpret_cast<ExitCode>(m_partition.volume->CheckIntegrity());
+    return reinterpret_cast<ExitCode>(m_volume->CheckIntegrity(m_partition));
   }
 
 private:
-  const WiiPartition& m_partition;
+  const DiscIO::IVolume* const m_volume;
+  const DiscIO::Partition m_partition;
 };
 
 enum : int
@@ -156,9 +155,9 @@ WiiPartition* FindWiiPartition(wxTreeCtrl* tree_ctrl, const wxString& label)
 }
 }  // Anonymous namespace
 
-FilesystemPanel::FilesystemPanel(wxWindow* parent, wxWindowID id, const GameListItem& item,
+FilesystemPanel::FilesystemPanel(wxWindow* parent, wxWindowID id,
                                  const std::unique_ptr<DiscIO::IVolume>& opened_iso)
-    : wxPanel{parent, id}, m_game_list_item{item}, m_opened_iso{opened_iso}
+    : wxPanel{parent, id}, m_opened_iso{opened_iso}
 {
   CreateGUI();
   BindEvents();
@@ -217,7 +216,7 @@ void FilesystemPanel::PopulateFileSystemTree()
 
 void FilesystemPanel::PopulateFileSystemTreeGC()
 {
-  m_filesystem = DiscIO::CreateFileSystem(m_opened_iso.get());
+  m_filesystem = DiscIO::CreateFileSystem(m_opened_iso.get(), DiscIO::PARTITION_NONE);
   if (!m_filesystem)
     return;
 
@@ -226,34 +225,23 @@ void FilesystemPanel::PopulateFileSystemTreeGC()
 
 void FilesystemPanel::PopulateFileSystemTreeWii() const
 {
-  u32 partition_count = 0;
-
-  for (u32 group = 0; group < 4; group++)
+  std::vector<DiscIO::Partition> partitions = m_opened_iso->GetPartitions();
+  for (size_t i = 0; i < partitions.size(); ++i)
   {
-    // yes, technically there can be OVER NINE THOUSAND partitions...
-    for (u32 i = 0; i < 0xFFFFFFFF; i++)
+    std::unique_ptr<DiscIO::IFileSystem> file_system(
+        DiscIO::CreateFileSystem(m_opened_iso.get(), partitions[i]));
+    if (file_system)
     {
-      auto volume = DiscIO::CreateVolumeFromFilename(m_game_list_item.GetFileName(), group, i);
-      if (volume == nullptr)
-        break;
+      wxTreeItemId partition_root = m_tree_ctrl->AppendItem(
+          m_tree_ctrl->GetRootItem(), wxString::Format(_("Partition %i"), i), ICON_DISC);
 
-      auto file_system = DiscIO::CreateFileSystem(volume.get());
-      if (file_system != nullptr)
-      {
-        auto* const partition = new WiiPartition(std::move(volume), std::move(file_system));
+      WiiPartition* const partition = new WiiPartition(std::move(file_system));
 
-        const wxTreeItemId partition_root = m_tree_ctrl->AppendItem(
-            m_tree_ctrl->GetRootItem(), wxString::Format(_("Partition %u"), partition_count),
-            ICON_DISC);
+      m_tree_ctrl->SetItemData(partition_root, partition);
+      CreateDirectoryTree(m_tree_ctrl, partition_root, partition->filesystem->GetFileList());
 
-        m_tree_ctrl->SetItemData(partition_root, partition);
-        CreateDirectoryTree(m_tree_ctrl, partition_root, partition->filesystem->GetFileList());
-
-        if (partition_count == 1)
-          m_tree_ctrl->Expand(partition_root);
-
-        partition_count++;
-      }
+      if (i == 1)
+        m_tree_ctrl->Expand(partition_root);
     }
   }
 }
@@ -382,8 +370,9 @@ void FilesystemPanel::OnCheckPartitionIntegrity(wxCommandEvent& WXUNUSED(event))
                           wxPD_APP_MODAL | wxPD_ELAPSED_TIME | wxPD_SMOOTH);
 
   const auto selection = m_tree_ctrl->GetSelection();
-
-  IntegrityCheckThread thread(*static_cast<WiiPartition*>(m_tree_ctrl->GetItemData(selection)));
+  WiiPartition* partition =
+      static_cast<WiiPartition*>(m_tree_ctrl->GetItemData(m_tree_ctrl->GetSelection()));
+  IntegrityCheckThread thread(m_opened_iso.get(), partition->filesystem->GetPartition());
   thread.Run();
 
   while (thread.IsAlive())

--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.h
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.h
@@ -21,7 +21,7 @@ class IVolume;
 class FilesystemPanel final : public wxPanel
 {
 public:
-  explicit FilesystemPanel(wxWindow* parent, wxWindowID id, const GameListItem& item,
+  explicit FilesystemPanel(wxWindow* parent, wxWindowID id,
                            const std::unique_ptr<DiscIO::IVolume>& opened_iso);
   ~FilesystemPanel();
 
@@ -69,7 +69,6 @@ private:
 
   wxTreeCtrl* m_tree_ctrl;
 
-  const GameListItem& m_game_list_item;
   const std::unique_ptr<DiscIO::IVolume>& m_opened_iso;
 
   std::unique_ptr<DiscIO::IFileSystem> m_filesystem;

--- a/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
@@ -433,9 +433,8 @@ void CISOProperties::CreateGUIControls()
 
   if (m_open_iso->GetVolumeType() != DiscIO::Platform::WII_WAD)
   {
-    m_Notebook->AddPage(
-        new FilesystemPanel(m_Notebook, ID_FILESYSTEM, OpenGameListItem, m_open_iso),
-        _("Filesystem"));
+    m_Notebook->AddPage(new FilesystemPanel(m_Notebook, ID_FILESYSTEM, m_open_iso),
+                        _("Filesystem"));
   }
 
   wxStdDialogButtonSizer* sButtons = CreateStdDialogButtonSizer(wxOK | wxNO_DEFAULT);

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
@@ -182,7 +182,7 @@ void InfoPanel::LoadISODetails()
   m_fst->SetValue(StrToWxStr(std::to_string(m_opened_iso->GetFSTSize())));
   if (m_ios_version)
   {
-    const IOS::ES::TMDReader tmd = m_opened_iso->GetTMD();
+    const IOS::ES::TMDReader tmd = m_opened_iso->GetTMD(m_opened_iso->GetGamePartition());
     if (tmd.IsValid())
       m_ios_version->SetValue(StringFromFormat("IOS%u", static_cast<u32>(tmd.GetIOSId())));
   }
@@ -223,7 +223,7 @@ wxStaticBoxSizer* InfoPanel::CreateISODetailsSizer()
       {_("Apploader Date:"), m_date},
       {_("FST Size:"), m_fst},
   }};
-  if (m_opened_iso->GetTMD().IsValid())
+  if (m_opened_iso->GetTMD(m_opened_iso->GetGamePartition()).IsValid())
     controls.emplace_back(_("IOS Version:"), m_ios_version);
 
   const int space_10 = FromDIP(10);


### PR DESCRIPTION
By removing mutable state in VolumeWiiCrypted, this change makes partition-related code simpler. It also gets rid of other ugly things, like ISOProperties's "over 9000" loop that creates a list of partitions by trying possible combinations, and DiscScrubber's volume swapping that recreates the entire volume when it needs to change partition.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/2353)

<!-- Reviewable:end -->
