### PR TITLE
Add missing ifdefs around GCAdapter code in Controller config

### DIFF
--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -200,12 +200,14 @@ void ControllerConfigDiag::ScheduleAdapterUpdate()
 
 void ControllerConfigDiag::UpdateAdapter(wxCommandEvent& ev)
 {
+#if defined(__LIBUSB__) || defined (_WIN32)
 	bool unpause = Core::PauseAndLock(true);
 	if (SI_GCAdapter::IsDetected())
 		m_adapter_status->SetLabelText(_("Adapter Detected"));
 	else
 		m_adapter_status->SetLabelText(_("Adapter Not Detected"));
 	Core::PauseAndLock(false, unpause);
+#endif
 }
 
 wxStaticBoxSizer* ControllerConfigDiag::CreateWiimoteConfigSizer()
@@ -568,5 +570,7 @@ void ControllerConfigDiag::OnGameCubeConfigButton(wxCommandEvent& event)
 
 ControllerConfigDiag::~ControllerConfigDiag()
 {
+#if defined(__LIBUSB__) || defined (_WIN32)
 	SI_GCAdapter::SetAdapterCallback(nullptr);
+#endif
 }


### PR DESCRIPTION
Otherwise the build will fail when libusb cannot be found (e.g. https://launchpadlibrarian.net/205340499/buildlog_ubuntu-trusty-amd64.dolphin-emu-master_4.0%2Bgit%2Br22~8~ubuntu14.04.1_BUILDING.txt.gz)