### PR TITLE
Avoid deadlock when adding Wiimotes

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -150,9 +150,9 @@ bool CCPU::PauseAndLock(bool doLock, bool unpauseOnUnlock)
 	if (doLock)
 	{
 		// we can't use EnableStepping, that would causes deadlocks with both audio and video
-		PowerPC::Pause();
 		if (!Core::IsCPUThread())
 			m_csCpuOccupied.lock();
+		PowerPC::Pause();
 	}
 	else
 	{


### PR DESCRIPTION
When I try to automatically scan for Wiimotes with git master, the first remote is added fine, but there's a deadlock when I try to add the second one.  I tracked it down to a deadlock the when running m_csCpuOccupied.lock() the second time.  Running pause after we've acquired the lock seems to fix the problem.

Signed-off-by: Jonathan Dieter <jdieter@lesbg.com>