### PR TITLE
VideoBackends: Implement depth copy shaders with integer math.

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -146,28 +146,21 @@ const char depth_matrix_program[] = {
 	" in float4 pos : SV_Position,\n"
 	" in float3 uv0 : TEXCOORD0){\n"
 	"	float4 texcol = Tex0.Sample(samp0,uv0);\n"
+	"	int depth = int(round(texcol.x * float(0xFFFFFF)));\n"
 
-	// 255.99998474121 = 16777215/16777216*256
-	"	float workspace = texcol.x * 255.99998474121;\n"
+	// Convert to Z24 format
+	"	int4 workspace;\n"
+	"	workspace.r = (depth >> 16) & 255;\n"
+	"	workspace.g = (depth >> 8) & 255;\n"
+	"	workspace.b = depth & 255;\n"
 
-	"	texcol.x = floor(workspace);\n"         // x component
+	// Convert to Z4 format
+	"	workspace.a = (depth >> 16) & 0xF0;\n"
 
-	"	workspace = workspace - texcol.x;\n"    // subtract x component out
-	"	workspace = workspace * 256.0;\n"       // shift left 8 bits
-	"	texcol.y = floor(workspace);\n"         // y component
+	// Normalize components to [0.0..1.0]
+	"	texcol = float4(workspace) / 255.0;\n"
 
-	"	workspace = workspace - texcol.y;\n"    // subtract y component out
-	"	workspace = workspace * 256.0;\n"       // shift left 8 bits
-	"	texcol.z = floor(workspace);\n"         // z component
-
-	"	texcol.w = texcol.x;\n"                 // duplicate x into w
-
-	"	texcol = texcol / 255.0;\n"             // normalize components to [0.0..1.0]
-
-	"	texcol.w = texcol.w * 15.0;\n"
-	"	texcol.w = floor(texcol.w);\n"
-	"	texcol.w = texcol.w / 15.0;\n"          // w component
-
+	// Apply color matrix
 	"	ocol0 = float4(dot(texcol,cColMatrix[0]),dot(texcol,cColMatrix[1]),dot(texcol,cColMatrix[2]),dot(texcol,cColMatrix[3])) + cColMatrix[4];\n"
 	"}\n"
 };
@@ -188,27 +181,22 @@ const char depth_matrix_program_msaa[] = {
 	"		texcol += Tex0.Load(int3(uv0.x*(width), uv0.y*(height), uv0.z), i);\n"
 	"	texcol /= SAMPLES;\n"
 
-	// 255.99998474121 = 16777215/16777216*256
-	"	float workspace = texcol.x * 255.99998474121;\n"
+	"	float4 texcol = Tex0.Sample(samp0,uv0);\n"
+	"	int depth = int(round(texcol.x * float(0xFFFFFF)));\n"
 
-	"	texcol.x = floor(workspace);\n"         // x component
+	// Convert to Z24 format
+	"	int4 workspace;\n"
+	"	workspace.r = (depth >> 16) & 255;\n"
+	"	workspace.g = (depth >> 8) & 255;\n"
+	"	workspace.b = depth & 255;\n"
 
-	"	workspace = workspace - texcol.x;\n"    // subtract x component out
-	"	workspace = workspace * 256.0;\n"       // shift left 8 bits
-	"	texcol.y = floor(workspace);\n"         // y component
+	// Convert to Z4 format
+	"	workspace.a = (depth >> 16) & 0xF0;\n"
 
-	"	workspace = workspace - texcol.y;\n"    // subtract y component out
-	"	workspace = workspace * 256.0;\n"       // shift left 8 bits
-	"	texcol.z = floor(workspace);\n"         // z component
+	// Normalize components to [0.0..1.0]
+	"	texcol = float4(workspace) / 255.0;\n"
 
-	"	texcol.w = texcol.x;\n"                 // duplicate x into w
-
-	"	texcol = texcol / 255.0;\n"             // normalize components to [0.0..1.0]
-
-	"	texcol.w = texcol.w * 15.0;\n"
-	"	texcol.w = floor(texcol.w);\n"
-	"	texcol.w = texcol.w / 15.0;\n"          // w component
-
+	// Apply color matrix
 	"	ocol0 = float4(dot(texcol,cColMatrix[0]),dot(texcol,cColMatrix[1]),dot(texcol,cColMatrix[2]),dot(texcol,cColMatrix[3])) + cColMatrix[4];\n"
 	"}\n"
 };

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -294,27 +294,19 @@ void TextureCache::CompileShaders()
 		"\n"
 		"void main(){\n"
 		"	vec4 texcol = texture(samp9, vec3(f_uv0.xy, %s));\n"
+		"	int depth = int(round(texcol.x * float(0xFFFFFF)));\n"
 
-		// 255.99998474121 = 16777215/16777216*256
-		"	float workspace = texcol.x * 255.99998474121;\n"
+		// Convert to Z24 format
+		"	ivec4 workspace;\n"
+		"	workspace.r = (depth >> 16) & 255;\n"
+		"	workspace.g = (depth >> 8) & 255;\n"
+		"	workspace.b = depth & 255;\n"
 
-		"	texcol.x = floor(workspace);\n"         // x component
+		// Convert to Z4 format
+		"	workspace.a = (depth >> 16) & 0xF0;\n"
 
-		"	workspace = workspace - texcol.x;\n"    // subtract x component out
-		"	workspace = workspace * 256.0;\n"       // shift left 8 bits
-		"	texcol.y = floor(workspace);\n"         // y component
-
-		"	workspace = workspace - texcol.y;\n"    // subtract y component out
-		"	workspace = workspace * 256.0;\n"       // shift left 8 bits
-		"	texcol.z = floor(workspace);\n"         // z component
-
-		"	texcol.w = texcol.x;\n"                 // duplicate x into w
-
-		"	texcol = texcol / 255.0;\n"             // normalize components to [0.0..1.0]
-
-		"	texcol.w = texcol.w * 15.0;\n"
-		"	texcol.w = floor(texcol.w);\n"
-		"	texcol.w = texcol.w / 15.0;\n"          // w component
+		// Normalize components to [0.0..1.0]
+		"	texcol = vec4(workspace) / 255.0;\n"
 
 		"	ocol0 = texcol * mat4(colmat[0], colmat[1], colmat[2], colmat[3]) + colmat[4];\n"
 		"}\n";


### PR DESCRIPTION
Because why use floating-point hacks when you can just use integers? No accuracy tests done yet though.