### PR TITLE
Skipped the calibration of the GC controller if it has already been calibrated.

### DIFF
--- a/Source/Core/Core/HW/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCController.cpp
@@ -78,7 +78,8 @@ int CSIDevice_GCController::RunBuffer(u8* _pBuffer, int _iLength)
 		{
 			INFO_LOG(SERIALINTERFACE, "PAD - Get Origin");
 
-			Calibrate();
+			if (!m_Calibrated)
+				Calibrate();
 
 			u8* pCalibration = reinterpret_cast<u8*>(&m_Origin);
 			for (int i = 0; i < (int)sizeof(SOrigin); i++)


### PR DESCRIPTION
Possible fix for PSO and other games where the GC pad would go out of control half way into the game