### PR TITLE
Remove the "nativeLibsToJar" gradle task.

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -4,18 +4,6 @@ android {
     compileSdkVersion 21
 	buildToolsVersion "20.0.0"
 
-    task nativeLibsToJar(type: Zip, description: 'create a jar archive of the native libs') {
-        destinationDir file("$buildDir/native-libs")
-        baseName 'native-libs'
-        extension 'jar'
-        from fileTree(dir: 'libs', include: '**/*.so')
-        into 'lib/'
-    }
-
-    tasks.withType(JavaCompile) {
-        compileTask -> compileTask.dependsOn(nativeLibsToJar)
-    }
-
     lintOptions {
         // This is important as it will run lint but not abort on error
         // Lint has some overly obnoxious "errors" that should really be warnings
@@ -29,7 +17,6 @@ android {
         versionCode 13
         versionName "0.13"
     }
-
 
     signingConfigs {
         release {
@@ -59,8 +46,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-	compile fileTree(dir: "$buildDir/native-libs", include: 'native-libs.jar')
 
 	compile 'com.android.support:support-v4:22.0.0'
 	compile 'com.android.support:support-v13:22.0.0'

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -117,13 +117,13 @@ if(ANDROID)
 	"-Wl,--no-whole-archive"
 	)
 	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
-		COMMAND mkdir ARGS -p ${CMAKE_SOURCE_DIR}/Source/Android/app/libs/${ANDROID_NDK_ABI_NAME}
+		COMMAND mkdir ARGS -p ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/jniLibs/${ANDROID_NDK_ABI_NAME}
 	)
 	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
 		COMMAND mkdir ARGS -p ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/
 	)
 	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
-		COMMAND cp ARGS ${LIBRARY_OUTPUT_PATH_ROOT}/libs/${ANDROID_NDK_ABI_NAME}/lib${DOLPHIN_EXE}.so ${CMAKE_SOURCE_DIR}/Source/Android/app/libs/${ANDROID_NDK_ABI_NAME}/
+		COMMAND cp ARGS ${LIBRARY_OUTPUT_PATH_ROOT}/libs/${ANDROID_NDK_ABI_NAME}/lib${DOLPHIN_EXE}.so ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/jniLibs/${ANDROID_NDK_ABI_NAME}/
 	)
 	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
 		COMMAND cp ARGS ${CMAKE_SOURCE_DIR}/Data/Sys/GC/* ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/


### PR DESCRIPTION
It's not necessary; Gradle will include any *.so files you place in the  `jniLibs` folder for a given build configuration. (i.e. main vs. debug, though we don't differentiate right now.)

However, this means that the native libraries must actually be placed there, so this PR modifies CMakeLists.txt to ensure that successful builds target that folder.