### PR TITLE
PixelShaderCache: Fix MSAA depth copy shader.

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -180,8 +180,6 @@ const char depth_matrix_program_msaa[] = {
 	"	for(int i = 0; i < SAMPLES; ++i)\n"
 	"		texcol += Tex0.Load(int3(uv0.x*(width), uv0.y*(height), uv0.z), i);\n"
 	"	texcol /= SAMPLES;\n"
-
-	"	float4 texcol = Tex0.Sample(samp0,uv0);\n"
 	"	int depth = int(round(texcol.x * float(0xFFFFFF)));\n"
 
 	// Convert to Z24 format


### PR DESCRIPTION
Simple copy+paste error, copied one line too many from the non-msaa shader.