### PR TITLE
Reverts #2362 while still fixing deadlock when adding multiple Wiimotes

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -150,9 +150,9 @@ bool CCPU::PauseAndLock(bool doLock, bool unpauseOnUnlock)
 	if (doLock)
 	{
 		// we can't use EnableStepping, that would causes deadlocks with both audio and video
+		PowerPC::Pause();
 		if (!Core::IsCPUThread())
 			m_csCpuOccupied.lock();
-		PowerPC::Pause();
 	}
 	else
 	{


### PR DESCRIPTION
My [original fix](https://github.com/dolphin-emu/dolphin/pull/2362) for issue [8514](https://code.google.com/p/dolphin-emu/issues/detail?id=8514) was wrong and caused worse deadlocks in some situations (see #2371 and issue [8542](https://code.google.com/p/dolphin-emu/issues/detail?id=8542)).

This reverts #2362 and (I think) fixes the deadlock properly as per [this comment](https://github.com/dolphin-emu/dolphin/pull/2371#issuecomment-99567567).