### PR TITLE
Fixed error with hidden wii settings file

### DIFF
--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -152,7 +152,7 @@ bool WriteStringToFile(const std::string& str, const std::string& filename);
 bool ReadFileToString(const std::string& filename, std::string& str);
 
 // simple wrapper for cstdlib file functions to
-// hopefully will make error checking easier
+// hopefully make error checking easier
 // and make forgetting an fclose() harder
 class IOFile : public NonCopyable
 {

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -258,12 +258,14 @@ bool CBoot::BootUp()
 		// HLE BS2 or not
 		if (_StartupPara.bHLE_BS2)
 		{
-			EmulatedBS2(_StartupPara.bWii);
+			if (!EmulatedBS2(_StartupPara.bWii))
+				return false;
 		}
 		else if (!Load_BS2(_StartupPara.m_strBootROM))
 		{
 			// If we can't load the bootrom file we HLE it instead
-			EmulatedBS2(_StartupPara.bWii);
+			if (!EmulatedBS2(_StartupPara.bWii))
+				return false;
 		}
 		else
 		{

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -194,6 +194,7 @@ bool CBoot::SetupWiiMemory(IVolume::ECountry country)
 			serno = gen.GetValue("SERNO");
 			gen.Reset();
 		}
+		settingsFileHandle.Close();
 		File::Delete(settings_Filename);
 	}
 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -466,7 +466,13 @@ void EmuThread()
 	// Load GCM/DOL/ELF whatever ... we boot with the interpreter core
 	PowerPC::SetMode(PowerPC::MODE_INTERPRETER);
 
-	CBoot::BootUp();
+	if (!CBoot::BootUp())
+	{
+		HW::Shutdown();
+		g_video_backend->Shutdown();
+		Host_Message(WM_USER_STOP);
+		return;
+	}
 
 	// Thread is no longer acting as CPU Thread
 	UndeclareAsCPUThread();


### PR DESCRIPTION
This fixes a bug that occurred (on Windows) when the `\Dolphin Emulator\Wii\title\xxx\xxx\data\setting.txt` file was hidden.

But I don’t think I correctly uninitialized everything correctly in Core.cpp, so Dolphin locks up when the file still can’t be accessed.
