### PR TITLE
Core: Remove some header inclusions in header files

### DIFF
--- a/Source/Core/Common/ENetUtil.h
+++ b/Source/Core/Common/ENetUtil.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <enet/enet.h>
-#include "Common.h"
 
 namespace ENetUtil
 {

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 #include "Common/Logging/LogManager.h"
 

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
-#include "Common/IniFile.h"
+#include <string>
+#include <vector>
+#include "Common/CommonTypes.h"
+
+class IniFile;
 
 namespace ActionReplay
 {

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -12,6 +12,7 @@
 
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/CoreParameter.h"
 #include "Core/Host.h"
 #include "Core/PatchEngine.h"
 #include "Core/Boot/Boot.h"

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -7,10 +7,7 @@
 #include <cstdlib>
 #include <string>
 
-#include "Core/CoreParameter.h"
-
 #include "DiscIO/Volume.h"
-using DiscIO::IVolume;
 
 struct CountrySetting
 {
@@ -58,5 +55,5 @@ private:
 	static bool Load_BS2(const std::string& _rBootROMFilename);
 	static void Load_FST(bool _bIsWii);
 
-	static bool SetupWiiMemory(IVolume::ECountry country);
+	static bool SetupWiiMemory(DiscIO::IVolume::ECountry country);
 };

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -163,18 +163,18 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
 	return true;
 }
 
-bool CBoot::SetupWiiMemory(IVolume::ECountry country)
+bool CBoot::SetupWiiMemory(DiscIO::IVolume::ECountry country)
 {
 	static const CountrySetting SETTING_EUROPE = {"EUR", "PAL",  "EU", "LE"};
-	static const std::map<IVolume::ECountry, const CountrySetting> country_settings = {
-		{IVolume::COUNTRY_EUROPE, SETTING_EUROPE},
-		{IVolume::COUNTRY_USA,    {"USA", "NTSC", "US", "LU"}},
-		{IVolume::COUNTRY_JAPAN,  {"JPN", "NTSC", "JP", "LJ"}},
-		{IVolume::COUNTRY_KOREA,  {"KOR", "NTSC", "KR", "LKH"}},
+	static const std::map<DiscIO::IVolume::ECountry, const CountrySetting> country_settings = {
+		{DiscIO::IVolume::COUNTRY_EUROPE, SETTING_EUROPE},
+		{DiscIO::IVolume::COUNTRY_USA,    {"USA", "NTSC", "US", "LU"}},
+		{DiscIO::IVolume::COUNTRY_JAPAN,  {"JPN", "NTSC", "JP", "LJ"}},
+		{DiscIO::IVolume::COUNTRY_KOREA,  {"KOR", "NTSC", "KR", "LKH"}},
 		//TODO: Determine if Taiwan have their own specific settings.
 		//      Also determine if there are other specific settings
 		//      for other countries.
-		{IVolume::COUNTRY_TAIWAN, {"JPN", "NTSC", "JP", "LJ"}}
+		{DiscIO::IVolume::COUNTRY_TAIWAN, {"JPN", "NTSC", "JP", "LJ"}}
 	};
 	auto entryPos = country_settings.find(country);
 	const CountrySetting& country_setting =

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "Common/SysConf.h"
-#include "Core/Boot/Boot.h"
+#include "Core/CoreParameter.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/SI_Device.h"
 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -23,6 +23,7 @@
 
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/CoreParameter.h"
 #include "Core/CoreTiming.h"
 #include "Core/DSPEmulator.h"
 #include "Core/Host.h"
@@ -33,7 +34,6 @@
 #include "Core/State.h"
 #include "Core/Boot/Boot.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
-
 #include "Core/HW/AudioInterface.h"
 #include "Core/HW/CPU.h"
 #include "Core/HW/DSP.h"
@@ -48,6 +48,7 @@
 #include "Core/HW/VideoInterface.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
+#include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
 #include "Core/IPC_HLE/WII_Socket.h"
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -57,7 +58,7 @@
 #endif
 
 #include "DiscIO/FileMonitor.h"
-
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoBackendBase.h"
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Core/CoreParameter.h"
 
 // TODO: ugly, remove
 extern bool g_aspect_wide;

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -373,17 +373,17 @@ void SCoreStartupParameter::CheckMemcardPath(std::string& memcardPath, std::stri
 	}
 }
 
-IVolume::ELanguage SCoreStartupParameter::GetCurrentLanguage(bool wii) const
+DiscIO::IVolume::ELanguage SCoreStartupParameter::GetCurrentLanguage(bool wii) const
 {
-	IVolume::ELanguage language;
+	DiscIO::IVolume::ELanguage language;
 	if (wii)
-		language = (IVolume::ELanguage)SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG");
+		language = (DiscIO::IVolume::ELanguage)SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG");
 	else
-		language = (IVolume::ELanguage)(SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage + 1);
+		language = (DiscIO::IVolume::ELanguage)(SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage + 1);
 
 	// Get rid of invalid values (probably doesn't matter, but might as well do it)
-	if (language > IVolume::ELanguage::LANGUAGE_UNKNOWN || language < 0)
-		language = IVolume::ELanguage::LANGUAGE_UNKNOWN;
+	if (language > DiscIO::IVolume::ELanguage::LANGUAGE_UNKNOWN || language < 0)
+		language = DiscIO::IVolume::ELanguage::LANGUAGE_UNKNOWN;
 	return language;
 }
 

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <array>
-#include "Core/DSP/DSPInterpreter.h"
+#include "Common/CommonTypes.h"
 
 // Basic code analysis.
 namespace DSPAnalyzer

--- a/Source/Core/Core/DSP/DSPBreakpoints.h
+++ b/Source/Core/Core/DSP/DSPBreakpoints.h
@@ -4,7 +4,8 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include <cstring>
+#include "Common/CommonTypes.h"
 
 // super fast breakpoints for a limited range.
 // To be used interchangeably with the BreakPoints class.

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -34,6 +34,7 @@
 #include "Core/DSP/DSPEmitter.h"
 #include "Core/DSP/DSPHost.h"
 #include "Core/DSP/DSPHWInterface.h"
+#include "Core/DSP/DSPInterpreter.h"
 #include "Core/DSP/DSPIntUtil.h"
 
 SDSP g_dsp;

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -29,8 +29,6 @@
 #include <memory>
 #include <string>
 
-#include "Common/Thread.h"
-
 #include "Core/DSP/DSPBreakpoints.h"
 #include "Core/DSP/DSPCaptureLogger.h"
 #include "Core/DSP/DSPEmitter.h"

--- a/Source/Core/Core/DSP/DSPIntArithmetic.cpp
+++ b/Source/Core/Core/DSP/DSPIntArithmetic.cpp
@@ -7,6 +7,8 @@
 #include "Core/DSP/DSPIntCCUtil.h"
 #include "Core/DSP/DSPInterpreter.h"
 #include "Core/DSP/DSPIntUtil.h"
+#include "Core/DSP/DSPMemoryMap.h"
+#include "Core/DSP/DSPTables.h"
 
 // Arithmetic and accumulator control.
 

--- a/Source/Core/Core/DSP/DSPIntExtOps.h
+++ b/Source/Core/Core/DSP/DSPIntExtOps.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "Core/DSP/DSPTables.h"
+#include "Core/DSP/DSPCommon.h"
 
 // Extended opcode support.
 // Many opcode have the lower 0xFF (some only 0x7f) free - there, an opcode extension

--- a/Source/Core/Core/DSP/DSPIntMisc.cpp
+++ b/Source/Core/Core/DSP/DSPIntMisc.cpp
@@ -6,8 +6,9 @@
 
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPInterpreter.h"
-
 #include "Core/DSP/DSPIntUtil.h"
+#include "Core/DSP/DSPMemoryMap.h"
+#include "Core/DSP/DSPTables.h"
 
 namespace DSPInterpreter {
 

--- a/Source/Core/Core/DSP/DSPIntMultiplier.cpp
+++ b/Source/Core/Core/DSP/DSPIntMultiplier.cpp
@@ -10,6 +10,7 @@
 #include "Core/DSP/DSPIntCCUtil.h"
 #include "Core/DSP/DSPInterpreter.h"
 #include "Core/DSP/DSPIntUtil.h"
+#include "Core/DSP/DSPTables.h"
 
 namespace DSPInterpreter {
 

--- a/Source/Core/Core/DSP/DSPIntUtil.h
+++ b/Source/Core/Core/DSP/DSPIntUtil.h
@@ -28,8 +28,6 @@
 #include "Common/CommonTypes.h"
 
 #include "Core/DSP/DSPCore.h"
-#include "Core/DSP/DSPInterpreter.h"
-#include "Core/DSP/DSPMemoryMap.h"
 #include "Core/DSP/DSPStacks.h"
 
 

--- a/Source/Core/Core/DSP/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/DSPInterpreter.cpp
@@ -26,7 +26,9 @@
 #include "Core/DSP/DSPAnalyzer.h"
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPHWInterface.h"
+#include "Core/DSP/DSPInterpreter.h"
 #include "Core/DSP/DSPIntUtil.h"
+#include "Core/DSP/DSPMemoryMap.h"
 #include "Core/DSP/DSPTables.h"
 
 namespace DSPInterpreter {

--- a/Source/Core/Core/DSP/DSPInterpreter.h
+++ b/Source/Core/Core/DSP/DSPInterpreter.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Core/DSP/DSPTables.h"
+#include "Core/DSP/DSPCommon.h"
 
 #define DSP_REG_MASK    0x1f
 

--- a/Source/Core/Core/DSP/DSPMemoryMap.h
+++ b/Source/Core/Core/DSP/DSPMemoryMap.h
@@ -28,7 +28,7 @@
 #include "Common/CommonTypes.h"
 
 #include "Core/DSP/DSPCore.h"
-#include "Core/DSP/DSPInterpreter.h"
+#include "Core/DSP/DSPTables.h"
 
 u16  dsp_imem_read(u16 addr);
 void dsp_dmem_write(u16 addr, u16 val);

--- a/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
@@ -8,6 +8,7 @@
 #include "Core/DSP/DSPEmitter.h"
 #include "Core/DSP/DSPIntCCUtil.h"
 #include "Core/DSP/DSPIntUtil.h"
+#include "Core/DSP/DSPMemoryMap.h"
 
 using namespace Gen;
 

--- a/Source/Core/Core/DSP/Jit/DSPJitLoadStore.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitLoadStore.cpp
@@ -6,7 +6,9 @@
 
 #include "Core/DSP/DSPEmitter.h"
 #include "Core/DSP/DSPIntCCUtil.h"
+#include "Core/DSP/DSPInterpreter.h"
 #include "Core/DSP/DSPIntUtil.h"
+#include "Core/DSP/DSPMemoryMap.h"
 
 using namespace Gen;
 

--- a/Source/Core/Core/DSP/Jit/DSPJitMisc.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitMisc.cpp
@@ -3,7 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "Core/DSP/DSPEmitter.h"
+#include "Core/DSP/DSPInterpreter.h"
 #include "Core/DSP/DSPIntUtil.h"
+#include "Core/DSP/DSPMemoryMap.h"
 
 using namespace Gen;
 

--- a/Source/Core/Core/DSPEmulator.h
+++ b/Source/Core/Core/DSPEmulator.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Common/ChunkFile.h"
+class PointerWrap;
 
 class DSPEmulator
 {

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "Common/CommonPaths.h"
+#include "Common/FileUtil.h"
 #include "Common/Thread.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <map>
 #include <string>
 #include <vector>
 

--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 
 #include "Common/CommonTypes.h"
 

--- a/Source/Core/Core/HLE/HLE_OS.h
+++ b/Source/Core/Core/HLE/HLE_OS.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "Common/CommonTypes.h"
-
 namespace HLE_OS
 {
 	void HLE_GeneralDebugPrint();

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -8,6 +8,7 @@
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/MailHandler.h"
 
+class PointerWrap;
 class UCodeInterface;
 
 class DSPHLE : public DSPEmulator {

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -12,6 +12,7 @@
 #include "Common/CPUDetect.h"
 #include "Common/Event.h"
 #include "Common/IniFile.h"
+#include "Common/Thread.h"
 #include "Common/Logging/LogManager.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.h
@@ -5,11 +5,13 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
+#include <thread>
 
-#include "Common/Thread.h"
-
+#include "Common/Flag.h"
 #include "Core/DSPEmulator.h"
-#include "Core/HW/DSPLLE/DSPLLEGlobals.h"
+
+class PointerWrap;
 
 class DSPLLE : public DSPEmulator
 {

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -9,6 +9,7 @@
 
 #include "AudioCommon/AudioCommon.h"
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/HW/DVDInterface.h
+++ b/Source/Core/Core/HW/DVDInterface.h
@@ -7,9 +7,9 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
-#include "DiscIO/Volume.h"
 
 class PointerWrap;
+namespace DiscIO { class IVolume; }
 namespace MMIO { class Mapping; }
 
 namespace DVDInterface
@@ -79,7 +79,7 @@ enum DICommand
 	DVDLowAudioBufferConfig = 0xe4
 };
 
-enum DIInterruptType
+enum DIInterruptType : int
 {
 	INT_DEINT = 0,
 	INT_TCINT = 1,

--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -9,6 +9,7 @@
 #include "Core/CoreTiming.h"
 #include "Core/Movie.h"
 #include "Core/HW/EXI.h"
+#include "Core/HW/EXI_Channel.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/Sram.h"

--- a/Source/Core/Core/HW/EXI.h
+++ b/Source/Core/Core/HW/EXI.h
@@ -5,11 +5,11 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
-#include "Common/Thread.h"
 
-#include "Core/HW/EXI_Channel.h"
-
+class CEXIChannel;
+class IEXIDevice;
 class PointerWrap;
+enum TEXIDevices : int;
 namespace MMIO { class Mapping; }
 
 enum

--- a/Source/Core/Core/HW/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI_Channel.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/Movie.h"

--- a/Source/Core/Core/HW/EXI_Channel.h
+++ b/Source/Core/Core/HW/EXI_Channel.h
@@ -5,10 +5,11 @@
 #pragma once
 
 #include <memory>
-
 #include "Common/CommonTypes.h"
-#include "Core/HW/EXI_Device.h"
 
+class IEXIDevice;
+class PointerWrap;
+enum TEXIDevices : int;
 namespace MMIO { class Mapping; }
 
 class CEXIChannel

--- a/Source/Core/Core/HW/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI_Device.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-
+#include "Common/ChunkFile.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/EXI_Device.h"
@@ -15,7 +15,6 @@
 #include "Core/HW/EXI_DeviceMemoryCard.h"
 #include "Core/HW/EXI_DeviceMic.h"
 #include "Core/HW/Memmap.h"
-
 
 // --- interface IEXIDevice ---
 void IEXIDevice::ImmWrite(u32 _uData, u32 _uSize)

--- a/Source/Core/Core/HW/EXI_Device.h
+++ b/Source/Core/Core/HW/EXI_Device.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 
-enum TEXIDevices
+class PointerWrap;
+
+enum TEXIDevices : int
 {
 	EXIDEVICE_DUMMY,
 	EXIDEVICE_MEMORYCARD,

--- a/Source/Core/Core/HW/EXI_DeviceAD16.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAD16.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Core/Core.h"
-
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceAD16.h"
 

--- a/Source/Core/Core/HW/EXI_DeviceAD16.h
+++ b/Source/Core/Core/HW/EXI_DeviceAD16.h
@@ -6,6 +6,8 @@
 
 #include "Core/HW/EXI_Device.h"
 
+class PointerWrap;
+
 class CEXIAD16 : public IEXIDevice
 {
 public:

--- a/Source/Core/Core/HW/EXI_DeviceAGP.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAGP.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Common/FileUtil.h"
 #include "Common/MemoryUtil.h"
 #include "Common/StdMakeUnique.h"

--- a/Source/Core/Core/HW/EXI_DeviceAGP.h
+++ b/Source/Core/Core/HW/EXI_DeviceAGP.h
@@ -6,8 +6,12 @@
 
 #include <deque>
 #include <queue>
+#include <string>
+#include <vector>
 
 #include "Core/HW/EXI_Device.h"
+
+class PointerWrap;
 
 class CEXIAgp
 	: public IEXIDevice

--- a/Source/Core/Core/HW/EXI_DeviceAMBaseboard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAMBaseboard.cpp
@@ -2,8 +2,9 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
+#include "Common/Logging/Log.h"
 #include "Core/Core.h"
-
 #include "Core/HW/EXI.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceAMBaseboard.h"

--- a/Source/Core/Core/HW/EXI_DeviceAMBaseboard.h
+++ b/Source/Core/Core/HW/EXI_DeviceAMBaseboard.h
@@ -6,6 +6,8 @@
 
 #include "Core/HW/EXI_Device.h"
 
+class PointerWrap;
+
 class CEXIAMBaseboard : public IEXIDevice
 {
 public:

--- a/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Common/Network.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/EXI.h"

--- a/Source/Core/Core/HW/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.h
@@ -11,6 +11,8 @@
 #include "Common/Thread.h"
 #include "Core/HW/EXI_Device.h"
 
+class PointerWrap;
+
 // Network Control Register A
 enum NCRA
 {

--- a/Source/Core/Core/HW/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceGecko.cpp
@@ -2,7 +2,11 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
+#include "Common/CommonFuncs.h"
 #include "Common/StdMakeUnique.h"
+#include "Common/StringUtil.h"
+#include "Common/Thread.h"
 #include "Core/Core.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceGecko.h"

--- a/Source/Core/Core/HW/EXI_DeviceGecko.h
+++ b/Source/Core/Core/HW/EXI_DeviceGecko.h
@@ -5,12 +5,13 @@
 #pragma once
 
 #include <deque>
+#include <memory>
+#include <mutex>
 #include <queue>
-
+#include <thread>
 #include <SFML/Network.hpp>
 
-#include "Common/Thread.h"
-
+#include "Common/CommonTypes.h"
 #include "Core/HW/EXI_Device.h"
 
 class GeckoSockServer

--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
@@ -14,6 +15,7 @@
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
 #include "Core/HW/EXI_DeviceIPL.h"
+#include "Core/HW/Sram.h"
 #include "Core/HW/SystemTimers.h"
 
 // We should provide an option to choose from the above, or figure out the checksum (the algo in yagcd seems wrong)

--- a/Source/Core/Core/HW/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.h
@@ -7,7 +7,8 @@
 #include <string>
 
 #include "Core/HW/EXI_Device.h"
-#include "Core/HW/Sram.h"
+
+class PointerWrap;
 
 class CEXIIPL : public IEXIDevice
 {

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -2,9 +2,11 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
+#include "Common/StdMakeUnique.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
@@ -3,10 +3,15 @@
 // Refer to the license.txt file included.
 
 #pragma once
-#include "Common/StdMakeUnique.h"
+
+#include <functional>
+#include <memory>
+
 #include "Core/HW/EXI_Device.h"
 
 class MemoryCardBase;
+class PointerWrap;
+
 class CEXIMemoryCard : public IEXIDevice
 {
 public:

--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include "Common/CommonTypes.h"
-
 #include "Core/ConfigManager.h"
 #include "Core/HW/GCKeyboard.h"
 #include "Core/HW/GCKeyboardEmu.h"

--- a/Source/Core/Core/HW/GCKeyboard.h
+++ b/Source/Core/Core/HW/GCKeyboard.h
@@ -2,11 +2,12 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/CommonTypes.h"
-#include "InputCommon/InputConfig.h"
-#include "InputCommon/KeyboardStatus.h"
-
 #pragma once
+
+#include "Common/CommonTypes.h"
+
+class InputConfig;
+struct KeyboardStatus;
 
 namespace Keyboard
 {

--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Core/Host.h"
 #include "Core/HW/GCKeyboardEmu.h"
+#include "InputCommon/KeyboardStatus.h"
 
 static const u16 keys0_bitmasks[] =
 {

--- a/Source/Core/Core/HW/GCKeyboardEmu.h
+++ b/Source/Core/Core/HW/GCKeyboardEmu.h
@@ -7,7 +7,8 @@
 #include <string>
 
 #include "InputCommon/ControllerEmu.h"
-#include "InputCommon/KeyboardStatus.h"
+
+struct KeyboardStatus;
 
 class GCKeyboard : public ControllerEmu
 {

--- a/Source/Core/Core/HW/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Common/ColorUtil.h"
+#include "Common/FileUtil.h"
 #include "Core/HW/GCMemcard.h"
 
 static void ByteSwap(u8 *valueA, u8 *valueB)

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -2,8 +2,10 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 #include <cinttypes>
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileSearch.h"
+#include "Common/FileUtil.h"
 #include "Common/StdMakeUnique.h"
 #include "Common/Thread.h"
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/HW/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcardDirectory.h
@@ -4,6 +4,13 @@
 
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
 #include "Common/Event.h"
 #include "Core/HW/GCMemcard.h"
 #include "DiscIO/Volume.h"

--- a/Source/Core/Core/HW/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcardRaw.cpp
@@ -4,7 +4,9 @@
 
 #include <chrono>
 #include "Common/ChunkFile.h"
+#include "Common/FileUtil.h"
 #include "Common/StdMakeUnique.h"
+#include "Common/Thread.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/GCMemcard.h"

--- a/Source/Core/Core/HW/GCMemcardRaw.h
+++ b/Source/Core/Core/HW/GCMemcardRaw.h
@@ -5,9 +5,11 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
 #include "Common/Event.h"
 #include "Common/Flag.h"
-#include "Common/Thread.h"
 #include "Core/HW/GCMemcard.h"
 
 class PointerWrap;

--- a/Source/Core/Core/HW/GCPad.h
+++ b/Source/Core/Core/HW/GCPad.h
@@ -2,11 +2,13 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include "Common/CommonTypes.h"
-#include "InputCommon/GCPadStatus.h"
-#include "InputCommon/InputConfig.h"
-
 #pragma once
+
+#include "Common/CommonTypes.h"
+#include "InputCommon/ControllerInterface/Device.h"
+
+class InputConfig;
+struct GCPadStatus;
 
 namespace Pad
 {

--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 
 #include "Core/HW/GPFifo.h"

--- a/Source/Core/Core/HW/GPFifo.h
+++ b/Source/Core/Core/HW/GPFifo.h
@@ -4,7 +4,8 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
+
 class PointerWrap;
 
 namespace GPFifo

--- a/Source/Core/Core/HW/MMIO.h
+++ b/Source/Core/Core/HW/MMIO.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <type_traits>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/MMIOHandlers.h"
 

--- a/Source/Core/Core/HW/MMIOHandlers.h
+++ b/Source/Core/Core/HW/MMIOHandlers.h
@@ -7,7 +7,7 @@
 #include <functional>
 #include <memory>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 
 // All the templated and very repetitive MMIO-related code is isolated in this
 // file for easier reading. It mostly contains code related to handling methods

--- a/Source/Core/Core/HW/SI.h
+++ b/Source/Core/Core/HW/SI.h
@@ -5,10 +5,10 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
-#include "Core/HW/SI_Device.h"
 
 class PointerWrap;
 class ISIDevice;
+enum SIDevices : int;
 namespace MMIO { class Mapping; }
 
 // SI number of channels

--- a/Source/Core/Core/HW/SI_Device.h
+++ b/Source/Core/Core/HW/SI_Device.h
@@ -38,7 +38,7 @@ enum TSIDevices
 };
 
 // For configuration use, since some devices can have the same SI Device ID
-enum SIDevices
+enum SIDevices : int
 {
 	SIDEVICE_NONE,
 	SIDEVICE_N64_MIC,

--- a/Source/Core/Core/HW/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI_DeviceDanceMat.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/HW/SI_DeviceDanceMat.h"
+#include "InputCommon/GCPadStatus.h"
 
 CSIDevice_DanceMat::CSIDevice_DanceMat(SIDevices device, int _iDeviceNumber)
 	: CSIDevice_GCController(device, _iDeviceNumber) {}

--- a/Source/Core/Core/HW/SI_DeviceDanceMat.h
+++ b/Source/Core/Core/HW/SI_DeviceDanceMat.h
@@ -6,6 +6,8 @@
 
 #include "Core/HW/SI_DeviceGCController.h"
 
+struct GCPadStatus;
+
 class CSIDevice_DanceMat : public CSIDevice_GCController
 {
 public:

--- a/Source/Core/Core/HW/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCController.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/Movie.h"
@@ -16,6 +17,7 @@
 #include "Core/HW/SI_GCAdapter.h"
 #endif
 #include "Core/HW/SystemTimers.h"
+#include "InputCommon/GCPadStatus.h"
 
 // --- standard GameCube controller ---
 CSIDevice_GCController::CSIDevice_GCController(SIDevices device, int _iDeviceNumber)

--- a/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
@@ -2,8 +2,10 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Core/HW/GCKeyboard.h"
 #include "Core/HW/SI_DeviceKeyboard.h"
+#include "InputCommon/KeyboardStatus.h"
 
 // --- GameCube keyboard ---
 CSIDevice_Keyboard::CSIDevice_Keyboard(SIDevices device, int _iDeviceNumber)

--- a/Source/Core/Core/HW/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.h
@@ -4,7 +4,10 @@
 
 #pragma once
 
-#include "InputCommon/KeyboardStatus.h"
+#include "Core/HW/SI_Device.h"
+
+class PointerWrap;
+struct KeyboardStatus;
 
 class CSIDevice_Keyboard : public ISIDevice
 {

--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -4,11 +4,15 @@
 
 #include <libusb.h>
 
+#include "Common/Flag.h"
+#include "Common/Thread.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
+#include "Core/HW/SI.h"
 #include "Core/HW/SI_GCAdapter.h"
 #include "Core/HW/SystemTimers.h"
+#include "InputCommon/GCPadStatus.h"
 
 namespace SI_GCAdapter
 {

--- a/Source/Core/Core/HW/SI_GCAdapter.h
+++ b/Source/Core/Core/HW/SI_GCAdapter.h
@@ -6,9 +6,7 @@
 
 #include <functional>
 
-#include "Common/Thread.h"
-#include "Core/HW/SI.h"
-#include "InputCommon/GCPadStatus.h"
+struct GCPadStatus;
 
 namespace SI_GCAdapter
 {

--- a/Source/Core/Core/HW/Sram.cpp
+++ b/Source/Core/Core/HW/Sram.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/Sram.h"
 

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -5,7 +5,8 @@
 #pragma once
 
 #include "Common/ChunkFile.h"
-#include "InputCommon/InputConfig.h"
+
+class InputConfig;
 
 enum
 {

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/CommonTypes.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Attachment.h"
 
 namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.h
@@ -4,11 +4,12 @@
 
 #pragma once
 
-#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "InputCommon/ControllerEmu.h"
 
 namespace WiimoteEmu
 {
+
+struct ExtensionReg;
 
 class Attachment : public ControllerEmu
 {

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Classic.h"
 
 namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.h
@@ -9,6 +9,8 @@
 namespace WiimoteEmu
 {
 
+struct ExtensionReg;
+
 class Classic : public Attachment
 {
 public:

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Drums.h"
 
 namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.h
@@ -9,6 +9,8 @@
 namespace WiimoteEmu
 {
 
+struct ExtensionReg;
+
 class Drums : public Attachment
 {
 public:

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Guitar.h"
 
 namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.h
@@ -9,6 +9,8 @@
 namespace WiimoteEmu
 {
 
+struct ExtensionReg;
+
 class Guitar : public Attachment
 {
 public:

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Nunchuk.h"
 
 namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.h
@@ -9,6 +9,8 @@
 namespace WiimoteEmu
 {
 
+struct ExtensionReg;
+
 class Nunchuk : public Attachment
 {
 public:

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Turntable.h"
 
 namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.h
@@ -9,6 +9,8 @@
 namespace WiimoteEmu
 {
 
+struct ExtensionReg;
+
 class Turntable : public Attachment
 {
 public:

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -4,14 +4,13 @@
 
 #include <cmath>
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Timer.h"
-
 #include "Core/ConfigManager.h"
 #include "Core/Host.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayClient.h"
-
 #include "Core/HW/WiimoteEmu/MatrixMath.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/WiimoteHid.h"

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <queue>
+#include <string>
 #include <vector>
 
-#include "Common/ChunkFile.h"
 #include "Core/Core.h"
 #include "Core/HW/WiimoteEmu/Encryption.h"
 #include "Core/HW/WiimoteEmu/WiimoteHid.h"
@@ -19,6 +19,8 @@
 #define WIIMOTE_REG_SPEAKER_SIZE  10
 #define WIIMOTE_REG_EXT_SIZE      0x100
 #define WIIMOTE_REG_IR_SIZE       0x34
+
+class PointerWrap;
 
 namespace WiimoteReal
 {

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -6,11 +6,12 @@
 #include <cstdlib>
 #include <queue>
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
+#include "Common/Thread.h"
 #include "Common/Timer.h"
-
 #include "Core/ConfigManager.h"
 #include "Core/Host.h"
 #include "Core/HW/WiimoteEmu/WiimoteHid.h"

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -4,18 +4,19 @@
 
 #pragma once
 
+#include <mutex>
+#include <string>
+#include <thread>
 #include <vector>
 
-#include "Common/ChunkFile.h"
 #include "Common/FifoQueue.h"
-#include "Common/Thread.h"
 #include "Common/Timer.h"
-
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteReal/WiimoteRealBase.h"
-
 #include "InputCommon/InputConfig.h"
+
+class PointerWrap;
 
 typedef std::vector<u8> Report;
 

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -2,8 +2,10 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include <string>
+#include <vector>
+
 #include "Core/ConfigManager.h"
-#include "Core/CoreParameter.h"
 #include "Core/HotkeyManager.h"
 
 const std::string hotkey_labels[] =

--- a/Source/Core/Core/HotkeyManager.h
+++ b/Source/Core/Core/HotkeyManager.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Core/CoreParameter.h"
+#include <string>
 #include "InputCommon/InputConfig.h"
 
 struct HotkeyStatus

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -6,10 +6,10 @@
 
 #include <queue>
 #include <string>
+#include <vector>
 
 #include "Common/ChunkFile.h"
 #include "Common/StringUtil.h"
-
 #include "Core/HW/Memmap.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -5,15 +5,14 @@
 #include <cinttypes>
 #include <memory>
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/LogManager.h"
-
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/DVDInterface.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
-
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_DI.h"
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
@@ -5,8 +5,10 @@
 #pragma once
 
 #include <deque>
-#include "Core/HW/DVDInterface.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
+
+class PointerWrap;
+namespace DVDInterface { enum DIInterruptType : int; }
 
 class CWII_IPC_HLE_Device_di : public IWII_IPC_HLE_Device
 {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
@@ -4,8 +4,11 @@
 
 #pragma once
 
-#include "Common/FileUtil.h"
+#include <string>
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
+
+class PointerWrap;
+namespace File { class IOFile; }
 
 std::string HLE_IPC_BuildFilename(std::string _pFilename);
 void HLE_IPC_CreateVirtualFATFilesystem();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -36,15 +36,14 @@
 // need to include this before polarssl/aes.h,
 // otherwise we may not get __STDC_FORMAT_MACROS
 #include <cinttypes>
-
 #include <polarssl/aes.h>
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
 #include "Common/StdMakeUnique.h"
 #include "Common/StringUtil.h"
-
 #include "Core/ConfigManager.h"
 #include "Core/ec_wii.h"
 #include "Core/Movie.h"
@@ -52,7 +51,9 @@
 #include "Core/HW/DVDInterface.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_es.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
+#include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "DiscIO/NANDContentLoader.h"
 
 #ifdef _WIN32
 #include <Windows.h>

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
@@ -6,9 +6,17 @@
 
 #include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
-#include "DiscIO/NANDContentLoader.h"
+
+class PointerWrap;
+namespace DiscIO
+{
+	class INANDContentLoader;
+	struct SNANDContent;
+}
 
 class CWII_IPC_HLE_Device_es : public IWII_IPC_HLE_Device
 {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -6,6 +6,8 @@
 
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
+class PointerWrap;
+
 struct NANDStat
 {
 	u32 BlockSize;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -2,9 +2,10 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
-#include <errno.h>
+#include <cerrno>
 #include <libusb.h>
 
+#include "Common/Thread.h"
 #include "Core/Core.h"
 #include "Core/Debugger/Debugger_SymbolMap.h"
 #include "Core/HW/WII_IPC.h"

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -5,8 +5,10 @@
 #pragma once
 
 #include <list>
+#include <map>
+#include <mutex>
+#include <thread>
 
-#include "Common/Thread.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <string>
 #include <polarssl/ctr_drbg.h>
 #include <polarssl/entropy.h>
 #include <polarssl/net.h>

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -2,7 +2,9 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/SDCardUtil.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
@@ -6,7 +6,11 @@
 
 #pragma once
 
+#include <string>
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
+
+class PointerWrap;
+namespace File { class IOFile; }
 
 class CWII_IPC_HLE_Device_sdio_slot0 : public IWII_IPC_HLE_Device
 {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <string>
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
 enum

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -13,7 +13,7 @@
 #include "Core/HW/Wiimote.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
-
+#include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
 
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305::EnqueueReply(u32 CommandAddress)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <deque>
 #include <queue>
 #include <vector>
 
@@ -12,7 +13,8 @@
 #include "Core/IPC_HLE/hci.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
-#include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
+
+class CWII_IPC_HLE_WiiMote;
 
 struct SQueuedEvent
 {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <queue>
+#include <string>
+
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
 class CWII_IPC_HLE_Device_usb_kbd : public IWII_IPC_HLE_Device

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_WiiMote.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_WiiMote.h
@@ -7,7 +7,8 @@
 #include <map>
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Core/IPC_HLE/hci.h"
 
 class CWII_IPC_HLE_Device_usb_oh1_57e_305;

--- a/Source/Core/Core/IPC_HLE/WII_Socket.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 
+#include "Common/FileUtil.h"
 #include "Core/Core.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"

--- a/Source/Core/Core/IPC_HLE/WII_Socket.h
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.h
@@ -47,7 +47,6 @@ typedef struct pollfd pollfd_t;
 #include <string>
 #include <unordered_map>
 
-#include "Common/FileUtil.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_net.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h"

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -29,6 +29,7 @@
 #include "Core/HW/WiimoteEmu/Attachment/Classic.h"
 #include "Core/HW/WiimoteEmu/Attachment/Nunchuk.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
+#include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "InputCommon/GCPadStatus.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include "Common/ENetUtil.h"
+#include "Common/Timer.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/Movie.h"

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -9,10 +9,8 @@
 #include <sstream>
 #include <SFML/Network/Packet.hpp>
 #include "Common/CommonTypes.h"
-#include "Common/ENetUtil.h"
 #include "Common/FifoQueue.h"
 #include "Common/Thread.h"
-#include "Common/Timer.h"
 #include "Common/TraversalClient.h"
 #include "Core/NetPlayProto.h"
 #include "InputCommon/GCPadStatus.h"

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -4,9 +4,8 @@
 
 #pragma once
 
+#include <vector>
 #include "Common/CommonTypes.h"
-#include "Common/CommonTypes.h"
-
 #include "Core/HW/EXI_Device.h"
 
 struct NetSettings

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include "Common/ENetUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StdMakeUnique.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <unordered_set>
 #include <SFML/Network/Packet.hpp>
-#include "Common/ENetUtil.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"
 #include "Common/TraversalClient.h"

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "Common/Common.h"
+#include "Common/FileUtil.h"
 #include "Common/Intrinsics.h"
 #include "Common/StdMakeUnique.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/Core/PowerPC/JitILCommon/IR.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/IR.cpp
@@ -126,6 +126,7 @@ TODO (in no particular order):
 #include <set>
 #include <string>
 
+#include "Common/FileUtil.h"
 #include "Common/StdMakeUnique.h"
 #include "Common/StringUtil.h"
 #include "Core/Core.h"

--- a/Source/Core/Core/ec_wii.h
+++ b/Source/Core/Core/ec_wii.h
@@ -24,7 +24,8 @@
 
 #pragma once
 
-#include "Common/Common.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 
 void get_ng_cert(u8* ng_cert_out, u32 NG_id, u32 NG_key_id, const u8* NG_priv, const u8* NG_sig);
 void get_ap_sig_and_cert(u8 *sig_out, u8 *ap_cert_out, u64 title_id, u8 *data, u32 data_size, const u8 *NG_priv, u32 NG_id);

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -28,9 +28,9 @@
 static const u32 CACHE_REVISION = 0x007;
 static const u32 DATASTREAM_REVISION = 15; // Introduced in Qt 5.2
 
-static QMap<IVolume::ELanguage, QString> ConvertLocalizedStrings(std::map<IVolume::ELanguage, std::string> strings)
+static QMap<DiscIO::IVolume::ELanguage, QString> ConvertLocalizedStrings(std::map<DiscIO::IVolume::ELanguage, std::string> strings)
 {
-	QMap<IVolume::ELanguage, QString> result;
+	QMap<DiscIO::IVolume::ELanguage, QString> result;
 
 	for (auto entry : strings)
 		result.insert(entry.first, QString::fromStdString(entry.second).trimmed());
@@ -50,16 +50,16 @@ static QMap<to, QString> CastLocalizedStrings(QMap<from, QString> strings)
 	return result;
 }
 
-static QString GetLanguageString(IVolume::ELanguage language, QMap<IVolume::ELanguage, QString> strings)
+static QString GetLanguageString(DiscIO::IVolume::ELanguage language, QMap<DiscIO::IVolume::ELanguage, QString> strings)
 {
 	if (strings.contains(language))
 		return strings.value(language);
 
 	// English tends to be a good fallback when the requested language isn't available
-	if (language != IVolume::ELanguage::LANGUAGE_ENGLISH)
+	if (language != DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH)
 	{
-		if (strings.contains(IVolume::ELanguage::LANGUAGE_ENGLISH))
-			return strings.value(IVolume::ELanguage::LANGUAGE_ENGLISH);
+		if (strings.contains(DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH))
+			return strings.value(DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH);
 	}
 
 	// If English isn't available either, just pick something
@@ -180,8 +180,8 @@ bool GameFile::LoadFromCache()
 	       >> m_is_disc_two
 	       >> m_revision;
 	m_country = (DiscIO::IVolume::ECountry)country;
-	m_names = CastLocalizedStrings<IVolume::ELanguage>(names);
-	m_descriptions = CastLocalizedStrings<IVolume::ELanguage>(descriptions);
+	m_names = CastLocalizedStrings<DiscIO::IVolume::ELanguage>(names);
+	m_descriptions = CastLocalizedStrings<DiscIO::IVolume::ELanguage>(descriptions);
 	file.close();
 	return true;
 }
@@ -245,7 +245,7 @@ QString GameFile::GetCompany() const
 	return m_company;
 }
 
-QString GameFile::GetDescription(IVolume::ELanguage language) const
+QString GameFile::GetDescription(DiscIO::IVolume::ELanguage language) const
 {
 	return GetLanguageString(language, m_descriptions);
 }
@@ -255,7 +255,7 @@ QString GameFile::GetDescription() const
 	return GetDescription(SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(m_platform != GAMECUBE_DISC));
 }
 
-QString GameFile::GetName(IVolume::ELanguage language) const
+QString GameFile::GetName(DiscIO::IVolume::ELanguage language) const
 {
 	return GetLanguageString(language, m_names);
 }

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -4,6 +4,7 @@
 
 #include "Common/CDUtils.h"
 #include "Common/FileSearch.h"
+#include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
 
 #include "DolphinQt/GameList/GameGrid.h"

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
@@ -22,6 +22,7 @@
 #include <wx/textctrl.h>
 
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
 #include "Core/ActionReplay.h"

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -13,6 +13,7 @@
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
+#include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "DiscIO/NANDContentLoader.h"

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -126,7 +126,7 @@ void WiiConfigPane::OnConnectKeyboardCheckBoxChanged(wxCommandEvent& event)
 
 void WiiConfigPane::OnSystemLanguageChoiceChanged(wxCommandEvent& event)
 {
-	IVolume::ELanguage wii_system_lang = (IVolume::ELanguage)m_system_language_choice->GetSelection();
+	DiscIO::IVolume::ELanguage wii_system_lang = (DiscIO::IVolume::ELanguage)m_system_language_choice->GetSelection();
 	SConfig::GetInstance().m_SYSCONF->SetData("IPL.LNG", wii_system_lang);
 	u8 country_code = GetSADRCountryCode(wii_system_lang);
 
@@ -141,28 +141,28 @@ void WiiConfigPane::OnAspectRatioChoiceChanged(wxCommandEvent& event)
 
 // Change from IPL.LNG value to IPL.SADR country code.
 // http://wiibrew.org/wiki/Country_Codes
-u8 WiiConfigPane::GetSADRCountryCode(IVolume::ELanguage language)
+u8 WiiConfigPane::GetSADRCountryCode(DiscIO::IVolume::ELanguage language)
 {
 	switch (language)
 	{
-	case IVolume::LANGUAGE_JAPANESE:
+	case DiscIO::IVolume::LANGUAGE_JAPANESE:
 		return 1;   // Japan
-	case IVolume::LANGUAGE_ENGLISH:
+	case DiscIO::IVolume::LANGUAGE_ENGLISH:
 		return 49;  // USA
-	case IVolume::LANGUAGE_GERMAN:
+	case DiscIO::IVolume::LANGUAGE_GERMAN:
 		return 78;  // Germany
-	case IVolume::LANGUAGE_FRENCH:
+	case DiscIO::IVolume::LANGUAGE_FRENCH:
 		return 77;  // France
-	case IVolume::LANGUAGE_SPANISH:
+	case DiscIO::IVolume::LANGUAGE_SPANISH:
 		return 105; // Spain
-	case IVolume::LANGUAGE_ITALIAN:
+	case DiscIO::IVolume::LANGUAGE_ITALIAN:
 		return 83;  // Italy
-	case IVolume::LANGUAGE_DUTCH:
+	case DiscIO::IVolume::LANGUAGE_DUTCH:
 		return 94;  // Netherlands
-	case IVolume::LANGUAGE_SIMPLIFIED_CHINESE:
-	case IVolume::LANGUAGE_TRADITIONAL_CHINESE:
+	case DiscIO::IVolume::LANGUAGE_SIMPLIFIED_CHINESE:
+	case DiscIO::IVolume::LANGUAGE_TRADITIONAL_CHINESE:
 		return 157; // China
-	case IVolume::LANGUAGE_KOREAN:
+	case DiscIO::IVolume::LANGUAGE_KOREAN:
 		return 136; // Korea
 	}
 

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.h
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.h
@@ -29,7 +29,7 @@ private:
 	void OnSystemLanguageChoiceChanged(wxCommandEvent&);
 	void OnAspectRatioChoiceChanged(wxCommandEvent&);
 
-	static u8 GetSADRCountryCode(IVolume::ELanguage language);
+	static u8 GetSADRCountryCode(DiscIO::IVolume::ELanguage language);
 
 	wxArrayString m_system_language_strings;
 	wxArrayString m_aspect_ratio_strings;

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -85,8 +85,8 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
 		sortData = -sortData;
 	}
 
-	IVolume::ELanguage languageOne = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(iso1->GetPlatform() != GameListItem::GAMECUBE_DISC);
-	IVolume::ELanguage languageOther = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(iso2->GetPlatform() != GameListItem::GAMECUBE_DISC);
+	DiscIO::IVolume::ELanguage languageOne = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(iso1->GetPlatform() != GameListItem::GAMECUBE_DISC);
+	DiscIO::IVolume::ELanguage languageOther = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(iso2->GetPlatform() != GameListItem::GAMECUBE_DISC);
 
 	switch (sortData)
 	{

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -40,7 +40,7 @@ static const u32 CACHE_REVISION = 0x123;
 #define DVD_BANNER_WIDTH 96
 #define DVD_BANNER_HEIGHT 32
 
-static std::string GetLanguageString(IVolume::ELanguage language, std::map<IVolume::ELanguage, std::string> strings)
+static std::string GetLanguageString(DiscIO::IVolume::ELanguage language, std::map<DiscIO::IVolume::ELanguage, std::string> strings)
 {
 	auto end = strings.end();
 	auto it = strings.find(language);
@@ -48,9 +48,9 @@ static std::string GetLanguageString(IVolume::ELanguage language, std::map<IVolu
 		return it->second;
 
 	// English tends to be a good fallback when the requested language isn't available
-	if (language != IVolume::ELanguage::LANGUAGE_ENGLISH)
+	if (language != DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH)
 	{
-		it = strings.find(IVolume::ELanguage::LANGUAGE_ENGLISH);
+		it = strings.find(DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH);
 		if (it != end)
 			return it->second;
 	}
@@ -207,7 +207,7 @@ std::string GameListItem::GetCompany() const
 	return m_company;
 }
 
-std::string GameListItem::GetDescription(IVolume::ELanguage language) const
+std::string GameListItem::GetDescription(DiscIO::IVolume::ELanguage language) const
 {
 	return GetLanguageString(language, m_descriptions);
 }
@@ -217,7 +217,7 @@ std::string GameListItem::GetDescription() const
 	return GetDescription(SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(m_Platform != GAMECUBE_DISC));
 }
 
-std::string GameListItem::GetName(IVolume::ELanguage language) const
+std::string GameListItem::GetName(DiscIO::IVolume::ELanguage language) const
 {
 	return GetLanguageString(language, m_names);
 }
@@ -233,10 +233,10 @@ std::string GameListItem::GetName() const
 	return name;
 }
 
-std::vector<IVolume::ELanguage> GameListItem::GetLanguages() const
+std::vector<DiscIO::IVolume::ELanguage> GameListItem::GetLanguages() const
 {
-	std::vector<IVolume::ELanguage> languages;
-	for (std::pair<IVolume::ELanguage, std::string> name : m_names)
+	std::vector<DiscIO::IVolume::ELanguage> languages;
+	for (std::pair<DiscIO::IVolume::ELanguage, std::string> name : m_names)
 		languages.push_back(name.first);
 	return languages;
 }

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -25,11 +25,11 @@ public:
 
 	bool IsValid() const {return m_Valid;}
 	const std::string& GetFileName() const {return m_FileName;}
-	std::string GetName(IVolume::ELanguage language) const;
+	std::string GetName(DiscIO::IVolume::ELanguage language) const;
 	std::string GetName() const;
-	std::string GetDescription(IVolume::ELanguage language) const;
+	std::string GetDescription(DiscIO::IVolume::ELanguage language) const;
 	std::string GetDescription() const;
-	std::vector<IVolume::ELanguage> GetLanguages() const;
+	std::vector<DiscIO::IVolume::ELanguage> GetLanguages() const;
 	std::string GetCompany() const;
 	int GetRevision() const { return m_Revision; }
 	const std::string& GetUniqueID() const {return m_UniqueID;}
@@ -59,8 +59,8 @@ public:
 private:
 	std::string m_FileName;
 
-	std::map<IVolume::ELanguage, std::string> m_names;
-	std::map<IVolume::ELanguage, std::string> m_descriptions;
+	std::map<DiscIO::IVolume::ELanguage, std::string> m_names;
+	std::map<DiscIO::IVolume::ELanguage, std::string> m_descriptions;
 	std::string m_company;
 
 	std::string m_UniqueID;

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -494,9 +494,9 @@ void CISOProperties::CreateGUIControls()
 
 	wxStaticText* const m_LangText = new wxStaticText(m_Information, wxID_ANY, _("Show Language:"));
 
-	IVolume::ELanguage preferred_language = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(OpenISO->IsWadFile() || OpenISO->IsWiiDisc());
+	DiscIO::IVolume::ELanguage preferred_language = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(OpenISO->IsWadFile() || OpenISO->IsWiiDisc());
 
-	std::vector<IVolume::ELanguage> languages = OpenGameListItem->GetLanguages();
+	std::vector<DiscIO::IVolume::ELanguage> languages = OpenGameListItem->GetLanguages();
 	int preferred_language_index = 0;
 	for (size_t i = 0; i < languages.size(); ++i)
 	{
@@ -505,37 +505,37 @@ void CISOProperties::CreateGUIControls()
 
 		switch (languages[i])
 		{
-		case IVolume::LANGUAGE_JAPANESE:
+		case DiscIO::IVolume::LANGUAGE_JAPANESE:
 			arrayStringFor_Lang.Add(_("Japanese"));
 			break;
-		case IVolume::LANGUAGE_ENGLISH:
+		case DiscIO::IVolume::LANGUAGE_ENGLISH:
 			arrayStringFor_Lang.Add(_("English"));
 			break;
-		case IVolume::LANGUAGE_GERMAN:
+		case DiscIO::IVolume::LANGUAGE_GERMAN:
 			arrayStringFor_Lang.Add(_("German"));
 			break;
-		case IVolume::LANGUAGE_FRENCH:
+		case DiscIO::IVolume::LANGUAGE_FRENCH:
 			arrayStringFor_Lang.Add(_("French"));
 			break;
-		case IVolume::LANGUAGE_SPANISH:
+		case DiscIO::IVolume::LANGUAGE_SPANISH:
 			arrayStringFor_Lang.Add(_("Spanish"));
 			break;
-		case IVolume::LANGUAGE_ITALIAN:
+		case DiscIO::IVolume::LANGUAGE_ITALIAN:
 			arrayStringFor_Lang.Add(_("Italian"));
 			break;
-		case IVolume::LANGUAGE_DUTCH:
+		case DiscIO::IVolume::LANGUAGE_DUTCH:
 			arrayStringFor_Lang.Add(_("Dutch"));
 			break;
-		case IVolume::LANGUAGE_SIMPLIFIED_CHINESE:
+		case DiscIO::IVolume::LANGUAGE_SIMPLIFIED_CHINESE:
 			arrayStringFor_Lang.Add(_("Simplified Chinese"));
 			break;
-		case IVolume::LANGUAGE_TRADITIONAL_CHINESE:
+		case DiscIO::IVolume::LANGUAGE_TRADITIONAL_CHINESE:
 			arrayStringFor_Lang.Add(_("Traditional Chinese"));
 			break;
-		case IVolume::LANGUAGE_KOREAN:
+		case DiscIO::IVolume::LANGUAGE_KOREAN:
 			arrayStringFor_Lang.Add(_("Korean"));
 			break;
-		case IVolume::LANGUAGE_UNKNOWN:
+		case DiscIO::IVolume::LANGUAGE_UNKNOWN:
 		default:
 			arrayStringFor_Lang.Add(_("Unknown"));
 			break;
@@ -1486,7 +1486,7 @@ void CISOProperties::OnChangeBannerLang(wxCommandEvent& event)
 	ChangeBannerDetails(OpenGameListItem->GetLanguages()[event.GetSelection()]);
 }
 
-void CISOProperties::ChangeBannerDetails(IVolume::ELanguage language)
+void CISOProperties::ChangeBannerDetails(DiscIO::IVolume::ELanguage language)
 {
 	wxString const shortName = StrToWxStr(OpenGameListItem->GetName(language));
 	wxString const comment = StrToWxStr(OpenGameListItem->GetDescription(language));

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -235,7 +235,7 @@ private:
 	void PatchList_Load();
 	void PatchList_Save();
 	void ActionReplayList_Save();
-	void ChangeBannerDetails(IVolume::ELanguage language);
+	void ChangeBannerDetails(DiscIO::IVolume::ELanguage language);
 
 	long GetElementStyle(const char* section, const char* key);
 	void SetCheckboxValueFromGameini(const char* section, const char* key, wxCheckBox* checkbox);

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -202,8 +202,8 @@ static std::string GetTitle(std::string filename)
 		auto end = titles.end();
 
 		// English tends to be a good fallback when the requested language isn't available
-		//if (language != IVolume::ELanguage::LANGUAGE_ENGLISH) {
-			auto it = titles.find(IVolume::ELanguage::LANGUAGE_ENGLISH);
+		//if (language != DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH) {
+			auto it = titles.find(DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH);
 			if (it != end)
 				return it->second;
 		//}
@@ -245,8 +245,8 @@ static std::string GetDescription(std::string filename)
 		auto end = descriptions.end();
 
 		// English tends to be a good fallback when the requested language isn't available
-		//if (language != IVolume::ELanguage::LANGUAGE_ENGLISH) {
-			auto it = descriptions.find(IVolume::ELanguage::LANGUAGE_ENGLISH);
+		//if (language != DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH) {
+			auto it = descriptions.find(DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH);
 			if (it != end)
 				return it->second;
 		//}

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -69,7 +69,7 @@ static wxString FailureReasonStringForHostLabel(int reason)
 static std::string BuildGameName(const GameListItem& game)
 {
 	// Lang needs to be consistent
-	IVolume::ELanguage const lang = IVolume::LANGUAGE_ENGLISH;
+	DiscIO::IVolume::ELanguage const lang = DiscIO::IVolume::LANGUAGE_ENGLISH;
 
 	std::string name(game.GetName(lang));
 


### PR DESCRIPTION
Replaces them with forward declarations of used types, or removes them entirely if they aren't used at all. This also gets rid of quite a bit of indirect inclusion with regards to core header files.