### PR TITLE
More miscellaneous Qt fixes

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -116,9 +116,15 @@ void DMainWindow::StartGame(const QString filename)
 		m_ui->centralWidget->addWidget(m_render_widget.get());
 		m_ui->centralWidget->setCurrentWidget(m_render_widget.get());
 
-		// TODO: When rendering to main, this won't resize the parent window...
-		m_render_widget->resize(SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowWidth,
-			SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowHeight);
+		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bRenderWindowAutoSize)
+		{
+			// Resize main window to fit render
+			m_render_widget->setMinimumSize(SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowWidth,
+				SConfig::GetInstance().m_LocalCoreStartupParameter.iRenderWindowHeight);
+			qApp->processEvents(); // Force a redraw so the window has time to resize
+			m_render_widget->setMinimumSize(0, 0); // Allow the widget to scale down
+		}
+		m_render_widget->adjustSize();
 	}
 
 	if (!BootManager::BootCore(filename.toStdString()))

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -78,6 +78,7 @@ DMainWindow::DMainWindow(QWidget* parent_widget)
 	connect(m_ui->actionGitHub, SIGNAL(triggered()), this, SLOT(OnOpenGitHub()));
 	connect(m_ui->actionSystemInfo, SIGNAL(triggered()), this, SLOT(OnOpenSystemInfo()));
 	connect(m_ui->actionAbout, SIGNAL(triggered()), this, SLOT(OnOpenAbout()));
+	connect(m_ui->actionAboutQt, SIGNAL(triggered()), this, SLOT(OnOpenAboutQt()));
 
 	// Update GUI items
 	emit CoreStateChanged(Core::CORE_UNINITIALIZED);
@@ -361,4 +362,9 @@ void DMainWindow::OnOpenAbout()
 {
 	DAboutDialog* dlg = new DAboutDialog(this);
 	dlg->open();
+}
+
+void DMainWindow::OnOpenAboutQt()
+{
+	QApplication::aboutQt();
 }

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -92,6 +92,11 @@ DMainWindow::~DMainWindow()
 {
 }
 
+void DMainWindow::closeEvent(QCloseEvent* ce)
+{
+	Stop();
+}
+
 // Emulation
 
 void DMainWindow::StartGame(const QString filename)

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -63,6 +63,7 @@ private slots:
 	void UpdateIcons();
 
 private:
+	void closeEvent(QCloseEvent* ce);
 	std::unique_ptr<Ui::DMainWindow> m_ui;
 	DGameTracker* m_game_tracker;
 

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -58,6 +58,7 @@ private slots:
 	void OnOpenGitHub();
 	void OnOpenSystemInfo();
 	void OnOpenAbout();
+	void OnOpenAboutQt();
 
 	// Misc.
 	void UpdateIcons();

--- a/Source/Core/DolphinQt/MainWindow.ui
+++ b/Source/Core/DolphinQt/MainWindow.ui
@@ -32,7 +32,7 @@
      <x>0</x>
      <y>0</y>
      <width>990</width>
-     <height>24</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="mnuFile">
@@ -218,17 +218,23 @@
   </action>
   <action name="actionPlay_mnu">
    <property name="text">
-    <string>Play</string>
+    <string>&amp;Play</string>
+   </property>
+   <property name="shortcut">
+    <string>F10</string>
    </property>
   </action>
   <action name="actionStop_mnu">
    <property name="text">
-    <string>Stop</string>
+    <string>&amp;Stop</string>
+   </property>
+   <property name="shortcut">
+    <string>Esc</string>
    </property>
   </action>
   <action name="actionReset">
    <property name="text">
-    <string>Reset</string>
+    <string>&amp;Reset</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
All the other stuff I have deserves its own PR, so this is probably the last 'misc fixes' PR for a while.

This PR contains the following:

* Fix a crash that would occur if a user Alt+F4'd with a game running
* Size the window up to fit the game if it's smaller than the IR (the user can still scale the window up or down once the game launches if they so choose)
* Fix the About Qt menu item not actually doing anything
* Bring in keyboard shortcuts from the wx UI.

What I'm working on next in rough order:

* Save states
* Movies
* Config window
* TAS (might need some help with this as I'm not too familiar with what a good TAS setup looks like)