### PR TITLE
Revert "VideoBackends: Use the new divisor when clearing the depth buffer."

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -549,7 +549,7 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaE
 
 	// Color is passed in bgra mode so we need to convert it to rgba
 	u32 rgbaColor = (color & 0xFF00FF00) | ((color >> 16) & 0xFF) | ((color << 16) & 0xFF0000);
-	D3D::drawClearQuad(rgbaColor, (z & 0xFFFFFF) / 16777216.0f);
+	D3D::drawClearQuad(rgbaColor, (z & 0xFFFFFF) / float(0xFFFFFF));
 
 	D3D::stateman->PopDepthState();
 	D3D::stateman->PopBlendState();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1131,7 +1131,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		ResetAPIState();
 
 		glDepthMask(GL_TRUE);
-		glClearDepthf(float(poke_data & 0xFFFFFF) / 16777216.0f);
+		glClearDepthf(float(poke_data & 0xFFFFFF) / float(0xFFFFFF));
 
 		glEnable(GL_SCISSOR_TEST);
 		glScissor(targetPixelRc.left, targetPixelRc.bottom, targetPixelRc.GetWidth(), targetPixelRc.GetHeight());
@@ -1265,7 +1265,7 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaE
 	// depth
 	glDepthMask(zEnable ? GL_TRUE : GL_FALSE);
 
-	glClearDepthf(float(z & 0xFFFFFF) / 16777216.0f);
+	glClearDepthf(float(z & 0xFFFFFF) / float(0xFFFFFF));
 
 	// Update rect for clearing the picture
 	glEnable(GL_SCISSOR_TEST);


### PR DESCRIPTION
It looks like some games don't expect the clear operation to leave anything in the depth buffer that could cause z clipping.

This commit uses the old multiplier which will allow most games to reach the max depth value, but that is clearly a hack. I will amend this PR with a proper fix later, note that the software renderer suffers from the same problem and should also be fixed.

This PR is for testing purposes right now, do _not_ merge.