### PR TITLE
Fix -Wswitch warning

### DIFF
--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -164,8 +164,8 @@ u8 WiiConfigPane::GetSADRCountryCode(DiscIO::IVolume::ELanguage language)
 		return 157; // China
 	case DiscIO::IVolume::LANGUAGE_KOREAN:
 		return 136; // Korea
+	default:
+		PanicAlert("Invalid language");
+		return 1;
 	}
-
-	PanicAlert("Invalid language");
-	return 1;
 }


### PR DESCRIPTION
Fixes `enumeration value ‘LANGUAGE_UNKNOWN’ not handled in switch`