### PR TITLE
WiiConfigPane: Handle switch cases explicitly

### DIFF
--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -164,8 +164,10 @@ u8 WiiConfigPane::GetSADRCountryCode(DiscIO::IVolume::ELanguage language)
 		return 157; // China
 	case DiscIO::IVolume::LANGUAGE_KOREAN:
 		return 136; // Korea
-	default:
-		PanicAlert("Invalid language");
-		return 1;
+	case DiscIO::IVolume::LANGUAGE_UNKNOWN:
+		break;
 	}
+
+	PanicAlert("Invalid language. Defaulting to Japanese.");
+	return 1;
 }


### PR DESCRIPTION
Gets rid of a warning on higher warning levels (switching on an enum type should handle cases explicitly)