### PR TITLE
Volume: Rename GetName to GetInternalName

### DIFF
--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -176,7 +176,7 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 								m_strFilename.c_str());
 					return false;
 				}
-				m_strName = pVolume->GetName();
+				m_strName = pVolume->GetInternalName();
 				m_strUniqueID = pVolume->GetUniqueID();
 				m_revision = pVolume->GetRevision();
 
@@ -247,7 +247,7 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 
 				if (pVolume)
 				{
-					m_strName = pVolume->GetName();
+					m_strName = pVolume->GetInternalName();
 					m_strUniqueID = pVolume->GetUniqueID();
 				}
 				else

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -76,7 +76,7 @@ public:
 	virtual std::string GetUniqueID() const = 0;
 	virtual std::string GetMakerID() const = 0;
 	virtual int GetRevision() const = 0;
-	virtual std::string GetName() const = 0;
+	virtual std::string GetInternalName() const = 0;
 	virtual std::map<ELanguage, std::string> GetNames() const = 0;
 	virtual std::map<ELanguage, std::string> GetDescriptions() const { return std::map<ELanguage, std::string>(); }
 	virtual std::string GetCompany() const { return std::string(); }

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -182,7 +182,7 @@ std::string CVolumeDirectory::GetMakerID() const
 	return "VOID";
 }
 
-std::string CVolumeDirectory::GetName() const
+std::string CVolumeDirectory::GetInternalName() const
 {
 	char name[0x60];
 	if (Read(0x20, 0x60, (u8*)name, false))
@@ -194,7 +194,7 @@ std::string CVolumeDirectory::GetName() const
 std::map<IVolume::ELanguage, std::string> CVolumeDirectory::GetNames() const
 {
 	std::map<IVolume::ELanguage, std::string> names;
-	std::string name = GetName();
+	std::string name = GetInternalName();
 	if (!name.empty())
 		names[IVolume::ELanguage::LANGUAGE_UNKNOWN] = name;
 	return names;

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -40,7 +40,7 @@ public:
 	std::string GetMakerID() const override;
 
 	int GetRevision() const override { return 0; }
-	std::string GetName() const override;
+	std::string GetInternalName() const override;
 	std::map<IVolume::ELanguage, std::string> GetNames() const override;
 	void SetName(const std::string&);
 

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -96,7 +96,7 @@ int CVolumeGC::GetRevision() const
 	return revision;
 }
 
-std::string CVolumeGC::GetName() const
+std::string CVolumeGC::GetInternalName() const
 {
 	char name[0x60];
 	if (m_pReader != nullptr && Read(0x20, 0x60, (u8*)name))

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -28,7 +28,7 @@ public:
 	std::string GetUniqueID() const override;
 	std::string GetMakerID() const override;
 	int GetRevision() const override;
-	virtual std::string GetName() const override;
+	virtual std::string GetInternalName() const override;
 	std::map<ELanguage, std::string> GetNames() const override;
 	std::map<ELanguage, std::string> GetDescriptions() const override;
 	std::string GetCompany() const override;

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -31,7 +31,7 @@ public:
 	std::string GetUniqueID() const override;
 	std::string GetMakerID() const override;
 	int GetRevision() const override;
-	std::string GetName() const override { return ""; }
+	std::string GetInternalName() const override { return ""; }
 	std::map<IVolume::ELanguage, std::string> GetNames() const override;
 	u32 GetFSTSize() const override { return 0; }
 	std::string GetApploaderDate() const override { return ""; }

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -193,7 +193,7 @@ int CVolumeWiiCrypted::GetRevision() const
 	return revision;
 }
 
-std::string CVolumeWiiCrypted::GetName() const
+std::string CVolumeWiiCrypted::GetInternalName() const
 {
 	char name_buffer[0x60];
 	if (m_pReader != nullptr && Read(0x20, 0x60, (u8*)&name_buffer, false))

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -31,7 +31,7 @@ public:
 	std::string GetUniqueID() const override;
 	std::string GetMakerID() const override;
 	int GetRevision() const override;
-	std::string GetName() const override;
+	std::string GetInternalName() const override;
 	std::map<IVolume::ELanguage, std::string> GetNames() const override;
 	u32 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -133,7 +133,7 @@ CISOProperties::CISOProperties(const std::string fileName, wxWindow* parent, wxW
 
 	// Disk header and apploader
 
-	m_Name->SetValue(StrToWxStr(OpenISO->GetName()));
+	m_InternalName->SetValue(StrToWxStr(OpenISO->GetInternalName()));
 	m_GameID->SetValue(StrToWxStr(OpenISO->GetUniqueID()));
 	switch (OpenISO->GetCountry())
 	{
@@ -474,8 +474,8 @@ void CISOProperties::CreateGUIControls()
 	m_CheatPage->SetSizer(sCheatPage);
 
 
-	wxStaticText* const m_NameText = new wxStaticText(m_Information, wxID_ANY, _("Name:"));
-	m_Name = new wxTextCtrl(m_Information, ID_NAME, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	wxStaticText* const m_InternalNameText = new wxStaticText(m_Information, wxID_ANY, _("Internal Name:"));
+	m_InternalName = new wxTextCtrl(m_Information, ID_NAME, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 	wxStaticText* const m_GameIDText = new wxStaticText(m_Information, wxID_ANY, _("Game ID:"));
 	m_GameID = new wxTextCtrl(m_Information, ID_GAMEID, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 	wxStaticText* const m_CountryText = new wxStaticText(m_Information, wxID_ANY, _("Country:"));
@@ -546,19 +546,19 @@ void CISOProperties::CreateGUIControls()
 	if (arrayStringFor_Lang.size() <= 1)
 		m_Lang->Disable();
 
-	wxStaticText* const m_ShortText = new wxStaticText(m_Information, wxID_ANY, _("Short Name:"));
-	m_ShortName = new wxTextCtrl(m_Information, ID_SHORTNAME, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	wxStaticText* const m_NameText = new wxStaticText(m_Information, wxID_ANY, _("Name:"));
+	m_Name = new wxTextCtrl(m_Information, ID_SHORTNAME, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 	wxStaticText* const m_MakerText = new wxStaticText(m_Information, wxID_ANY, _("Maker:"));
 	m_Maker = new wxTextCtrl(m_Information, ID_MAKER, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
-	wxStaticText* const m_CommentText = new wxStaticText(m_Information, wxID_ANY, _("Comment:"));
+	wxStaticText* const m_CommentText = new wxStaticText(m_Information, wxID_ANY, _("Description:"));
 	m_Comment = new wxTextCtrl(m_Information, ID_COMMENT, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY);
 	wxStaticText* const m_BannerText = new wxStaticText(m_Information, wxID_ANY, _("Banner:"));
 	m_Banner = new wxStaticBitmap(m_Information, ID_BANNER, wxNullBitmap, wxDefaultPosition, wxSize(96, 32));
 
 	// ISO Details
 	wxGridBagSizer* const sISODetails = new wxGridBagSizer(0, 0);
-	sISODetails->Add(m_NameText, wxGBPosition(0, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL|wxALL, 5);
-	sISODetails->Add(m_Name, wxGBPosition(0, 1), wxGBSpan(1, 2), wxEXPAND|wxALL, 5);
+	sISODetails->Add(m_InternalNameText, wxGBPosition(0, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL|wxALL, 5);
+	sISODetails->Add(m_InternalName, wxGBPosition(0, 1), wxGBSpan(1, 2), wxEXPAND|wxALL, 5);
 	sISODetails->Add(m_GameIDText, wxGBPosition(1, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL|wxALL, 5);
 	sISODetails->Add(m_GameID, wxGBPosition(1, 1), wxGBSpan(1, 2), wxEXPAND|wxALL, 5);
 	sISODetails->Add(m_CountryText, wxGBPosition(2, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL|wxALL, 5);
@@ -586,8 +586,8 @@ void CISOProperties::CreateGUIControls()
 	wxGridBagSizer* const sBannerDetails = new wxGridBagSizer(0, 0);
 	sBannerDetails->Add(m_LangText, wxGBPosition(0, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL|wxALL, 5);
 	sBannerDetails->Add(m_Lang, wxGBPosition(0, 1), wxGBSpan(1, 1), wxEXPAND|wxALL, 5);
-	sBannerDetails->Add(m_ShortText, wxGBPosition(1, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL|wxALL, 5);
-	sBannerDetails->Add(m_ShortName, wxGBPosition(1, 1), wxGBSpan(1, 1), wxEXPAND|wxALL, 5);
+	sBannerDetails->Add(m_NameText, wxGBPosition(1, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL|wxALL, 5);
+	sBannerDetails->Add(m_Name, wxGBPosition(1, 1), wxGBSpan(1, 1), wxEXPAND|wxALL, 5);
 	sBannerDetails->Add(m_MakerText, wxGBPosition(2, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL|wxALL, 5);
 	sBannerDetails->Add(m_Maker, wxGBPosition(2, 1), wxGBSpan(1, 1), wxEXPAND|wxALL, 5);
 	sBannerDetails->Add(m_CommentText, wxGBPosition(3, 0), wxGBSpan(1, 1), wxALL, 5);
@@ -1488,12 +1488,12 @@ void CISOProperties::OnChangeBannerLang(wxCommandEvent& event)
 
 void CISOProperties::ChangeBannerDetails(DiscIO::IVolume::ELanguage language)
 {
-	wxString const shortName = StrToWxStr(OpenGameListItem->GetName(language));
+	wxString const name = StrToWxStr(OpenGameListItem->GetName(language));
 	wxString const comment = StrToWxStr(OpenGameListItem->GetDescription(language));
 	wxString const maker = StrToWxStr(OpenGameListItem->GetCompany());
 
 	// Updates the information shown in the window
-	m_ShortName->SetValue(shortName);
+	m_Name->SetValue(name);
 	m_Comment->SetValue(comment);
 	m_Maker->SetValue(maker);//dev too
 
@@ -1501,5 +1501,5 @@ void CISOProperties::ChangeBannerDetails(DiscIO::IVolume::ELanguage language)
 	SplitPath(OpenGameListItem->GetFileName(), nullptr, &filename, &extension);
 	// Also sets the window's title
 	SetTitle(StrToWxStr(StringFromFormat("%s%s: %s - ", filename.c_str(),
-		extension.c_str(), OpenGameListItem->GetUniqueID().c_str())) + shortName);
+		extension.c_str(), OpenGameListItem->GetUniqueID().c_str())) + name);
 }

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -102,7 +102,7 @@ private:
 	wxButton* EditCheat;
 	wxButton* RemoveCheat;
 
-	wxTextCtrl* m_Name;
+	wxTextCtrl* m_InternalName;
 	wxTextCtrl* m_GameID;
 	wxTextCtrl* m_Country;
 	wxTextCtrl* m_MakerID;
@@ -113,7 +113,7 @@ private:
 	wxButton*   m_MD5SumCompute;
 	wxArrayString arrayStringFor_Lang;
 	wxChoice*   m_Lang;
-	wxTextCtrl* m_ShortName;
+	wxTextCtrl* m_Name;
 	wxTextCtrl* m_Maker;
 	wxTextCtrl* m_Comment;
 	wxStaticBitmap* m_Banner;


### PR DESCRIPTION
This is intended to better separate it from GetNames and to clarify that this name originally wasn't meant to be shown to users. The ISOProperties GUI is also updated, mainly because labeling the long banner name "short name" was confusing.