### PR TITLE
DolphinQt: Use short GC game titles in grid view

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -85,7 +85,7 @@ public:
 	virtual std::string GetMakerID() const = 0;
 	virtual u16 GetRevision() const = 0;
 	virtual std::string GetInternalName() const = 0;
-	virtual std::map<ELanguage, std::string> GetNames() const = 0;
+	virtual std::map<ELanguage, std::string> GetNames(bool prefer_long) const = 0;
 	virtual std::map<ELanguage, std::string> GetDescriptions() const { return std::map<ELanguage, std::string>(); }
 	virtual std::string GetCompany() const { return std::string(); }
 	virtual std::vector<u32> GetBanner(int* width, int* height) const;

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -191,7 +191,7 @@ std::string CVolumeDirectory::GetInternalName() const
 		return "";
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeDirectory::GetNames() const
+std::map<IVolume::ELanguage, std::string> CVolumeDirectory::GetNames(bool prefer_long) const
 {
 	std::map<IVolume::ELanguage, std::string> names;
 	std::string name = GetInternalName();

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -41,7 +41,7 @@ public:
 
 	u16 GetRevision() const override { return 0; }
 	std::string GetInternalName() const override;
-	std::map<IVolume::ELanguage, std::string> GetNames() const override;
+	std::map<IVolume::ELanguage, std::string> GetNames(bool prefer_long) const override;
 	void SetName(const std::string&);
 
 	u32 GetFSTSize() const override;

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -29,7 +29,7 @@ public:
 	std::string GetMakerID() const override;
 	u16 GetRevision() const override;
 	virtual std::string GetInternalName() const override;
-	std::map<ELanguage, std::string> GetNames() const override;
+	std::map<ELanguage, std::string> GetNames(bool prefer_long) const override;
 	std::map<ELanguage, std::string> GetDescriptions() const override;
 	std::string GetCompany() const override;
 	std::vector<u32> GetBanner(int* width, int* height) const override;
@@ -44,6 +44,7 @@ public:
 
 private:
 	bool LoadBannerFile() const;
+	std::map<ELanguage, std::string> ReadMultiLanguageStrings(bool description, bool prefer_long = true) const;
 
 	static const int GC_BANNER_WIDTH = 96;
 	static const int GC_BANNER_HEIGHT = 32;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -117,7 +117,7 @@ IVolume::EPlatform CVolumeWAD::GetVolumeType() const
 	return WII_WAD;
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeWAD::GetNames() const
+std::map<IVolume::ELanguage, std::string> CVolumeWAD::GetNames(bool prefer_long) const
 {
 	std::vector<u8> name_data(NAMES_TOTAL_BYTES);
 	if (!Read(m_opening_bnr_offset + 0x9C, NAMES_TOTAL_BYTES, name_data.data()))

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -32,7 +32,7 @@ public:
 	std::string GetMakerID() const override;
 	u16 GetRevision() const override;
 	std::string GetInternalName() const override { return ""; }
-	std::map<IVolume::ELanguage, std::string> GetNames() const override;
+	std::map<IVolume::ELanguage, std::string> GetNames(bool prefer_long) const override;
 	u32 GetFSTSize() const override { return 0; }
 	std::string GetApploaderDate() const override { return ""; }
 

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -202,7 +202,7 @@ std::string CVolumeWiiCrypted::GetInternalName() const
 	return "";
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeWiiCrypted::GetNames() const
+std::map<IVolume::ELanguage, std::string> CVolumeWiiCrypted::GetNames(bool prefer_long) const
 {
 	std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this));
 	std::vector<u8> opening_bnr(NAMES_TOTAL_BYTES);

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -32,7 +32,7 @@ public:
 	std::string GetMakerID() const override;
 	u16 GetRevision() const override;
 	std::string GetInternalName() const override;
-	std::map<IVolume::ELanguage, std::string> GetNames() const override;
+	std::map<IVolume::ELanguage, std::string> GetNames(bool prefer_long) const override;
 	u32 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;
 	u8 GetDiscNumber() const override;

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -87,7 +87,7 @@ GameFile::GameFile(const QString& fileName)
 		{
 			m_platform = volume->GetVolumeType();
 
-			m_names = ConvertLocalizedStrings(volume->GetNames());
+			m_names = ConvertLocalizedStrings(volume->GetNames(true));
 			m_descriptions = ConvertLocalizedStrings(volume->GetDescriptions());
 			m_company = QString::fromStdString(volume->GetCompany());
 

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -22,8 +22,8 @@ public:
 	bool IsValid() const { return m_valid; }
 	QString GetFileName() { return m_file_name; }
 	QString GetFolderName() { return m_folder_name; }
-	QString GetName(DiscIO::IVolume::ELanguage language) const;
-	QString GetName() const;
+	QString GetName(bool prefer_long, DiscIO::IVolume::ELanguage language) const;
+	QString GetName(bool prefer_long) const;
 	QString GetDescription(DiscIO::IVolume::ELanguage language) const;
 	QString GetDescription() const;
 	QString GetCompany() const;
@@ -45,7 +45,8 @@ private:
 	QString m_file_name;
 	QString m_folder_name;
 
-	QMap<DiscIO::IVolume::ELanguage, QString> m_names;
+	QMap<DiscIO::IVolume::ELanguage, QString> m_short_names;
+	QMap<DiscIO::IVolume::ELanguage, QString> m_long_names;
 	QMap<DiscIO::IVolume::ELanguage, QString> m_descriptions;
 	QString m_company;
 

--- a/Source/Core/DolphinQt/GameList/GameGrid.cpp
+++ b/Source/Core/DolphinQt/GameList/GameGrid.cpp
@@ -76,7 +76,7 @@ void DGameGrid::AddGame(GameFile* gameItem)
 	QListWidgetItem* i = new QListWidgetItem;
 	i->setIcon(QIcon(gameItem->GetBitmap()
 		.scaled(GRID_BANNER_WIDTH, GRID_BANNER_HEIGHT, Qt::KeepAspectRatio, Qt::SmoothTransformation)));
-	i->setText(gameItem->GetName());
+	i->setText(gameItem->GetName(false));
 	if (gameItem->IsCompressed())
 		i->setTextColor(QColor("#00F"));
 

--- a/Source/Core/DolphinQt/GameList/GameTree.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTree.cpp
@@ -110,7 +110,7 @@ void DGameTree::AddGame(GameFile* item)
 	QTreeWidgetItem* i = new QTreeWidgetItem;
 	i->setIcon(COL_TYPE, QIcon(Resources::GetPlatformPixmap(item->GetPlatform())));
 	i->setIcon(COL_BANNER, QIcon(item->GetBitmap()));
-	i->setText(COL_TITLE, item->GetName());
+	i->setText(COL_TITLE, item->GetName(true));
 	i->setText(COL_DESCRIPTION, item->GetDescription());
 	i->setIcon(COL_REGION, QIcon(Resources::GetRegionPixmap(item->GetCountry())));
 	i->setText(COL_SIZE, NiceSizeFormat(item->GetFileSize()));

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -84,7 +84,7 @@ GameListItem::GameListItem(const std::string& _rFileName)
 		{
 			m_Platform = pVolume->GetVolumeType();
 
-			m_names = pVolume->GetNames();
+			m_names = pVolume->GetNames(true);
 			m_descriptions = pVolume->GetDescriptions();
 			m_company = pVolume->GetCompany();
 

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -222,7 +222,7 @@ static std::string GetTitle(std::string filename)
 	std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(filename));
 
 	if (pVolume != nullptr) {
-		std::map <DiscIO::IVolume::ELanguage, std::string> titles = pVolume->GetNames();
+		std::map <DiscIO::IVolume::ELanguage, std::string> titles = pVolume->GetNames(true);
 
 		/*
 		bool is_wii_title = pVolume->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;


### PR DESCRIPTION
GC games have both a long name and a short name in opening.bnr. Until now, Dolphin has only used the long one. This PR lets callers of `IVolume::GetNames()` choose which one they want using a bool parameter. This is used in DolphinQt to display short names in the grid view because they fit well in the available space unlike some long titles. It probably has no use in the wx GUI, but I think it can be appropriate to use in the new Android GUI in the future.