### PR TITLE
Android: Scale number of columns in game grid according to screen width.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/GameGridActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/GameGridActivity.java
@@ -54,7 +54,8 @@ public final class GameGridActivity extends Activity
 		//mRecyclerView.setHasFixedSize(true);
 
 		// Specifying the LayoutManager determines how the RecyclerView arranges views.
-		RecyclerView.LayoutManager layoutManager = new GridLayoutManager(this, 4);
+		RecyclerView.LayoutManager layoutManager = new GridLayoutManager(this,
+				getResources().getInteger(R.integer.game_grid_columns));
 		recyclerView.setLayoutManager(layoutManager);
 
 		recyclerView.addItemDecoration(new GameAdapter.SpacesItemDecoration(8));

--- a/Source/Android/app/src/main/res/values-w1000dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w1000dp/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="game_grid_columns">4</integer>
+</resources>

--- a/Source/Android/app/src/main/res/values-w500dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w500dp/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="game_grid_columns">2</integer>
+</resources>

--- a/Source/Android/app/src/main/res/values-w750dp/integers.xml
+++ b/Source/Android/app/src/main/res/values-w750dp/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="game_grid_columns">3</integer>
+</resources>

--- a/Source/Android/app/src/main/res/values/integers.xml
+++ b/Source/Android/app/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="game_grid_columns">1</integer>
+</resources>


### PR DESCRIPTION
Rather than hard-coding to 4 columns, this defines the number of columns to show in a resource file. At runtime, Android picks the most appropriate resource file satisfying the id `R.integer.game_grid_columns`.

I've included four: a default, one which is used for screens at least 500dp in width (the folder `values-w500dp`), and again at 750dp and 1000dp.

So now you can look at the new UI on your phone and it won't look silly.