### PR TITLE
Android: Build separate APKs for each native platform.

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -29,6 +29,7 @@ android {
         }
     }
 
+    // Define build types, which are orthogonal to product flavors.
     buildTypes {
         // Signed by release key, allowing for upload to Play Store.
         release {
@@ -42,6 +43,35 @@ android {
             versionNameSuffix '-debug'
             jniDebuggable true
         }
+    }
+
+    // Define product flavors, which can be split into categories. Common examples
+    // of product flavors are paid vs. free, ARM vs. x86, etc.
+    productFlavors {
+        arm {
+            // This flavor is mutually exclusive against any flavor in the same dimension.
+            flavorDimension "abi"
+
+            // When building this flavor, only include native libs from the specified folder.
+            ndk {
+                abiFilter "armeabi-v7a"
+            }
+        }
+
+        arm_64 {
+            flavorDimension "abi"
+            ndk {
+                abiFilter "arm64-v8a"
+            }
+        }
+
+        // TODO Uncomment this when we successfully build for x86_64.
+        /*x86_64 {
+            flavorDimension "abi"
+            ndk {
+                abiFilter "x86_64"
+            }
+        }*/
     }
 }
 

--- a/Source/Android/app/src/arm/res/values/strings.xml
+++ b/Source/Android/app/src/arm/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Title of the app -->
+    <string name="title_new_ui">Dolphin ARM32</string>
+</resources>

--- a/Source/Android/app/src/arm_64/res/values/strings.xml
+++ b/Source/Android/app/src/arm_64/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Title of the app -->
+    <string name="title_new_ui">Dolphin ARM64</string>
+</resources>

--- a/Source/Android/app/src/main/AndroidManifest.xml
+++ b/Source/Android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
 
         <activity
             android:name=".activities.GameGridActivity"
-            android:label="Dolphin New UI"
+            android:label="@string/title_new_ui"
             android:theme="@style/DolphinGamecube">
 
             <!-- This intentfilter marks this Activity as the one that gets launched from Home screen. -->

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -220,6 +220,8 @@
     <string name="disabled">Disabled</string>
     <string name="other">Other</string>
 
+    <!-- New UI Strings -->
+    <string name="title_new_ui">Dolphin New UI</string>
 
     <string name="add_directory_title">Add Folder to Library</string>
     <string name="add_directory_up_one_level">Up one level</string>

--- a/Source/Android/app/src/x86_64/res/values/strings.xml
+++ b/Source/Android/app/src/x86_64/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Title of the app -->
+    <string name="title_new_ui">Dolphin ARM32</string>
+</resources>


### PR DESCRIPTION
Currently, we build one APK and stuff as many native `libmain.so` files as we have into it. As we start to support more platforms, this will cause the APK to grow quite large.

This PR instructs Gradle that it should instead create ABI-specific APK's, each with only the appropriate native library included. If one wants to build a 32-bit ARM release build, the Gradle task `assembleArmRelease` will do it; for a 64-bit x86 debug build, use `assemblex86_64Debug`. The tasks used by the CI server, `assembleDebug` and `assembleRelease`, will build all possible permutations.

This PR will necessitate changes at the CI server.

When we deploy to the Google Play Store (a task which should be handled by the CI server), we provide all APKs created from a given build. The Play Store provides the user the appropriate APK silently. Users would only need to worry about installing the correct APK if they are pulling builds straight from the CI server.

The practical upshot of this is that it allows us to get away from using deprecated methods (see `CPUSettingsFragment.java`) to determine what ABI we are running. Non-deprecated methods exist for doing this, but really we should be letting the Play Store figure it out for us - that way, we can make assumptions about what ABI is running based on what files have been included by Gradle. As proof of concept, see the included modification to the title string of the New UI activity, which shows which ABI you are running.