### PR TITLE
Software: Convert most volatile variables to atomics

### DIFF
--- a/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
+++ b/Source/Core/VideoBackends/Software/SWCommandProcessor.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include <atomic>
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
@@ -41,8 +42,8 @@ static u8 commandBuffer[commandBufferSize];
 static u32 readPos;
 static u32 writePos;
 static int et_UpdateInterrupts;
-static volatile bool interruptSet;
-static volatile bool interruptWaiting;
+static std::atomic<bool> interruptSet;
+static std::atomic<bool> interruptWaiting;
 
 static CPReg cpreg; // shared between gfx and emulator thread
 
@@ -92,8 +93,8 @@ void Init()
 	readPos = 0;
 	writePos = 0;
 
-	interruptSet = false;
-	interruptWaiting = false;
+	interruptSet.store(false);
+	interruptWaiting.store(false);
 
 	g_video_buffer_read_ptr = nullptr;
 	g_bSkipCurrentFrame = false;
@@ -195,17 +196,17 @@ void UpdateInterrupts(u64 userdata)
 {
 	if (userdata)
 	{
-		interruptSet = true;
+		interruptSet.store(true);
 		INFO_LOG(COMMANDPROCESSOR,"Interrupt set");
 		ProcessorInterface::SetInterrupt(INT_CAUSE_CP, true);
 	}
 	else
 	{
-		interruptSet = false;
+		interruptSet.store(false);
 		INFO_LOG(COMMANDPROCESSOR,"Interrupt cleared");
 		ProcessorInterface::SetInterrupt(INT_CAUSE_CP, false);
 	}
-	interruptWaiting = false;
+	interruptWaiting.store(false);
 }
 
 void UpdateInterruptsFromVideoBackend(u64 userdata)
@@ -285,12 +286,12 @@ static void SetStatus()
 
 	bool interrupt = bpInt || ovfInt || undfInt;
 
-	if (interrupt != interruptSet && !interruptWaiting)
+	if (interrupt != interruptSet.load() && !interruptWaiting.load())
 	{
 		u64 userdata = interrupt?1:0;
 		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
 		{
-			interruptWaiting = true;
+			interruptWaiting.store(true);
 			SWCommandProcessor::UpdateInterruptsFromVideoBackend(userdata);
 		}
 		else

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -2,9 +2,9 @@
 // Licensed under GPLv2
 // Refer to the license.txt file included.
 
+#include <atomic>
 #include <string>
 
-#include "Common/Atomic.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
@@ -41,7 +41,7 @@
 
 #define VSYNC_ENABLED 0
 
-static volatile u32 s_swapRequested = false;
+static std::atomic<bool> s_swapRequested;
 
 static volatile struct
 {
@@ -53,8 +53,8 @@ static volatile struct
 namespace SW
 {
 
-static volatile bool fifoStateRun = false;
-static volatile bool emuRunningState = false;
+static std::atomic<bool> fifoStateRun;
+static std::atomic<bool> emuRunningState;
 static std::mutex m_csSWVidOccupied;
 
 std::string VideoSoftware::GetName() const
@@ -144,12 +144,12 @@ void VideoSoftware::PauseAndLock(bool doLock, bool unpauseOnUnlock)
 
 void VideoSoftware::RunLoop(bool enable)
 {
-	emuRunningState = enable;
+	emuRunningState.store(enable);
 }
 
 void VideoSoftware::EmuStateChange(EMUSTATE_CHANGE newState)
 {
-	emuRunningState = (newState == EMUSTATE_CHANGE_PLAY) ? true : false;
+	emuRunningState.store(newState == EMUSTATE_CHANGE_PLAY);
 }
 
 void VideoSoftware::Shutdown()
@@ -243,7 +243,7 @@ void VideoSoftware::Video_EndField()
 
 		// If we are in dual core mode, notify the GPU thread about the new color texture.
 		if (SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread)
-			Common::AtomicStoreRelease(s_swapRequested, true);
+			s_swapRequested.store(true);
 		else
 			SWRenderer::Swap(s_beginFieldArgs.fbWidth, s_beginFieldArgs.fbHeight);
 	}
@@ -300,10 +300,10 @@ bool VideoSoftware::Video_Screenshot(const std::string& filename)
 // Run from the graphics thread
 static void VideoFifo_CheckSwapRequest()
 {
-	if (Common::AtomicLoadAcquire(s_swapRequested))
+	if (s_swapRequested.load())
 	{
 		SWRenderer::Swap(s_beginFieldArgs.fbWidth, s_beginFieldArgs.fbHeight);
-		Common::AtomicStoreRelease(s_swapRequested, false);
+		s_swapRequested.store(false);
 	}
 }
 
@@ -313,9 +313,9 @@ static void VideoFifo_CheckSwapRequest()
 void VideoSoftware::Video_EnterLoop()
 {
 	std::lock_guard<std::mutex> lk(m_csSWVidOccupied);
-	fifoStateRun = true;
+	fifoStateRun.store(true);
 
-	while (fifoStateRun)
+	while (fifoStateRun.load())
 	{
 		VideoFifo_CheckSwapRequest();
 		g_video_backend->PeekMessages();
@@ -325,7 +325,7 @@ void VideoSoftware::Video_EnterLoop()
 			Common::YieldCPU();
 		}
 
-		while (!emuRunningState && fifoStateRun)
+		while (!emuRunningState.load() && fifoStateRun.load())
 		{
 			g_video_backend->PeekMessages();
 			VideoFifo_CheckSwapRequest();
@@ -338,7 +338,7 @@ void VideoSoftware::Video_EnterLoop()
 
 void VideoSoftware::Video_ExitLoop()
 {
-	fifoStateRun = false;
+	fifoStateRun.store(false);
 }
 
 // TODO : could use the OSD class in video common, we would need to implement the Renderer class


### PR DESCRIPTION
This gets rid of most usages of volatile within the software backend, except for a struct variable, as I'm not certain what the best approach for this would be.