### PR TITLE
VideoBackends: Clamp depth to uint24 range.

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -523,8 +523,8 @@ void Renderer::SetViewport()
 	Ht = (Y + Ht <= GetTargetHeight()) ? Ht : (GetTargetHeight() - Y);
 
 	D3D11_VIEWPORT vp = CD3D11_VIEWPORT(X, Y, Wd, Ht,
-		std::max(0.0f, std::min(1.0f, (xfmem.viewport.farZ - xfmem.viewport.zRange) / 16777216.0f)),
-		std::max(0.0f, std::min(1.0f, xfmem.viewport.farZ / 16777216.0f)));
+		MathUtil::Clamp<float>(xfmem.viewport.farZ - xfmem.viewport.zRange, 0.0f, 16777215.0f) / 16777216.0f,
+		MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f);
 	D3D::context->RSSetViewports(1, &vp);
 }
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1217,8 +1217,8 @@ void Renderer::SetViewport()
 	float Y = EFBToScaledYf((float)EFB_HEIGHT - xfmem.viewport.yOrig + xfmem.viewport.ht + (float)scissorYOff);
 	float Width = EFBToScaledXf(2.0f * xfmem.viewport.wd);
 	float Height = EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-	float GLNear = (xfmem.viewport.farZ - xfmem.viewport.zRange) / 16777216.0f;
-	float GLFar = xfmem.viewport.farZ / 16777216.0f;
+	float GLNear = MathUtil::Clamp<float>(xfmem.viewport.farZ - xfmem.viewport.zRange, 0.0f, 16777215.0f) / 16777216.0f;
+	float GLFar = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
 	if (Width < 0)
 	{
 		X += Width;

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -127,9 +127,7 @@ inline void Draw(s32 x, s32 y, s32 xi, s32 yi)
 	float dx = vertexOffsetX + (float)(x - vertex0X);
 	float dy = vertexOffsetY + (float)(y - vertex0Y);
 
-	s32 z = (s32)ZSlope.GetValue(dx, dy);
-	if (z < 0 || z > 0x00ffffff)
-		return;
+	s32 z = (s32)MathUtil::Clamp<float>(ZSlope.GetValue(dx, dy), 0.0f, 16777215.0f);
 
 	if (!BoundingBox::active && bpmem.UseEarlyDepthTest() && g_SWVideoConfig.bZComploc)
 	{

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -96,8 +96,8 @@ void PixelShaderManager::SetConstants()
 
 	if (s_bViewPortChanged)
 	{
-		constants.zbias[1][0] = static_cast<u32>(xfmem.viewport.farZ);
-		constants.zbias[1][1] = static_cast<u32>(xfmem.viewport.zRange);
+		constants.zbias[1][0] = MathUtil::Clamp<u32>((u32)xfmem.viewport.farZ, 0, 0xFFFFFF);
+		constants.zbias[1][1] = MathUtil::Clamp<u32>((u32)xfmem.viewport.zRange, 0, 0xFFFFFF);
 		dirty = true;
 		s_bViewPortChanged = false;
 	}


### PR DESCRIPTION
This clamp is necessary because the depth range can cause pixels to fall outside of the integer range.

This fixes [Issue 8556](https://code.google.com/p/dolphin-emu/issues/detail?id=8556) and [Issue 8565](https://code.google.com/p/dolphin-emu/issues/detail?id=8565).

Thanks to Parax0 for finding the underlying cause.