### PR TITLE
Reset faked CPU extension support at test end to ensure test isolation.

### DIFF
--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -101,6 +101,11 @@ protected:
 		disasm->set_syntax_intel();
 	}
 
+	void TearDown() override
+	{
+		cpu_info = CPUInfo();
+	}
+
 	void ExpectDisassembly(const std::string& expected)
 	{
 		std::string disasmed;


### PR DESCRIPTION
Intended for revision https://github.com/dolphin-emu/dolphin/commit/cee71afce5bf452a8b201fa4b33f9ab8d9c89b96. Setting all extensions on the cpu_info global may cause other tests to pick up invalid extension support. This can happen with the VertexLoaderTest group.