### PR TITLE
Android: Allow building of native code inside Android Studio / Gradle

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,18 +56,22 @@ Gradle task `assembleDebug` to build, or `installDebug` to install the UI onto a
 
 In order to launch the app, you must build and include the native Dolphin libraries into the UI project.
 Building native code requires the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html).
+Android Studio will do this for you if you create `Source/Android/build.properties`, and place the
+following inside:
 
-### Build Steps:
-1. `mkdir Build-Android-<abi>`
-2. `cd Build-Android-<abi>`
-3. `cmake -DANDROID=True -DANDROID_NDK=<ndk-path> -DANDROID_NATIVE_API_LEVEL=android-18 -DANDROID_TOOLCHAIN_NAME=<toolchain> -DANDROID_ABI=<abi> -DCMAKE_TOOLCHAIN_FILE=../Source/Android/android.toolchain.cmake -DGIT_EXECUTABLE=<git-path> ..`
-4. `make`
+```
+gitPath=<git-path>
+ndkPath=<ndk-path>
+toolchain=<toolchain>
+abi=<abi>
+makeArgs=<make-args>
+```
 
-Replace `<git-path>` with the absolute path to your machine's Git executable, <ndk-path> with the absolute
-path to where you installed your NDK, and the rest depending on which platform the Android device you are
-targeting uses:
+Replace `<git-path>` with the absolute path to your machine's Git executable, `<ndk-path>` with the absolute
+path to where you installed your NDK, `<make-args>` with any arguments you want to pass to `make`, and the 
+rest depending on which platform the Android device you are targeting uses:
 
-|Platform                 | abi         | toolchain                 |
+|Platform                 | `<abi>`     | `<toolchain>`             |
 |-------------------------|-------------|---------------------------|
 |ARM 32-bit (most devices)| armeabi-v7a | arm-linux-androideabi-4.9 |
 |ARM 64-bit (i.e. Nexus 9)| arm64-v8a   | aarch64-linux-android-4.9 |

--- a/Readme.md
+++ b/Readme.md
@@ -55,21 +55,18 @@ the Android UI. Import the Gradle project located in `./Source/Android`, and the
 Gradle task `assembleDebug` to build, or `installDebug` to install the UI onto a connected device.
 
 In order to launch the app, you must build and include the native Dolphin libraries into the UI project.
-Building native code requires the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html).
+(Building native code requires the [Android NDK](https://developer.android.com/tools/sdk/ndk/index.html).)
 Android Studio will do this for you if you create `Source/Android/build.properties`, and place the
 following inside:
 
 ```
-gitPath=<git-path>
-ndkPath=<ndk-path>
 toolchain=<toolchain>
 abi=<abi>
 makeArgs=<make-args>
 ```
 
-Replace `<git-path>` with the absolute path to your machine's Git executable, `<ndk-path>` with the absolute
-path to where you installed your NDK, `<make-args>` with any arguments you want to pass to `make`, and the 
-rest depending on which platform the Android device you are targeting uses:
+Replace `<make-args>` with any arguments you want to pass to `make`, and the rest depending on which
+platform the Android device you are targeting uses:
 
 |Platform                 | `<abi>`     | `<toolchain>`             |
 |-------------------------|-------------|---------------------------|

--- a/Source/Android/.gitignore
+++ b/Source/Android/.gitignore
@@ -40,3 +40,4 @@ gradle/
 build/
 *.so
 *.iml
+build.properties

--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -41,6 +41,10 @@ android {
             applicationIdSuffix ".debug"
             versionNameSuffix '-debug'
             jniDebuggable true
+
+            tasks.withType(JavaCompile) {
+                compileTask -> compileTask.dependsOn(compileNative)
+            }
         }
     }
 }
@@ -57,4 +61,54 @@ dependencies {
 
     // For loading huge screenshots from the disk.
     compile 'com.squareup.picasso:picasso:2.5.2'
+}
+
+task setupCMake(type: Exec) {
+    // Check if a build properties file exists.
+    def propsFile = rootProject.file("build.properties")
+
+    // If it does, call CMake.
+    if (propsFile.canRead()) {
+        // Read the properties file's contents.
+        def buildProperties = new Properties()
+        buildProperties.load(new FileInputStream(propsFile))
+
+        mkdir('build/' + buildProperties.abi)
+        workingDir 'build/' + buildProperties.abi
+
+        executable 'cmake'
+
+        args "-DANDROID=true",
+                "-DANDROID_NATIVE_API_LEVEL=android-18",
+                "-DCMAKE_TOOLCHAIN_FILE=../../../android.toolchain.cmake",
+                "../../../../..",
+                "-DGIT_EXECUTABLE=" + buildProperties.gitPath,
+                "-DANDROID_NDK=" + buildProperties.ndkPath,
+                "-DANDROID_TOOLCHAIN_NAME=" + buildProperties.toolchain,
+                "-DANDROID_ABI=" + buildProperties.abi
+    } else {
+        executable 'echo'
+        args 'No build.properties found; skipping CMake.'
+    }
+}
+
+task compileNative(type: Exec, dependsOn: 'setupCMake') {
+    // Check if a build properties file exists.
+    def propsFile = rootProject.file("build.properties")
+
+    // If it does, call make.
+    if (propsFile.canRead()) {
+        // Read the properties file's contents.
+        def buildProperties = new Properties()
+        buildProperties.load(new FileInputStream(propsFile))
+
+        workingDir 'build/' + buildProperties.abi
+
+        executable 'make'
+
+        args buildProperties.makeArgs
+    } else {
+        executable 'echo'
+        args 'No build.properties found; skipping native build.'
+    }
 }

--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -82,8 +82,8 @@ task setupCMake(type: Exec) {
                 "-DANDROID_NATIVE_API_LEVEL=android-18",
                 "-DCMAKE_TOOLCHAIN_FILE=../../../android.toolchain.cmake",
                 "../../../../..",
-                "-DGIT_EXECUTABLE=" + buildProperties.gitPath,
-                "-DANDROID_NDK=" + buildProperties.ndkPath,
+                "-DGIT_EXECUTABLE=" + getGitPath(),
+                "-DANDROID_NDK=" + getNdkPath(),
                 "-DANDROID_TOOLCHAIN_NAME=" + buildProperties.toolchain,
                 "-DANDROID_ABI=" + buildProperties.abi
     } else {
@@ -110,5 +110,47 @@ task compileNative(type: Exec, dependsOn: 'setupCMake') {
     } else {
         executable 'echo'
         args 'No build.properties found; skipping native build.'
+    }
+}
+
+String getGitPath() {
+    try {
+        def stdout = new ByteArrayOutputStream()
+
+        exec {
+            commandLine 'which', 'git'
+            standardOutput = stdout
+        }
+
+        def gitPath = stdout.toString().trim()
+        project.logger.quiet("Gradle: Found git executuable:" + gitPath)
+
+        return gitPath
+    } catch (ignored) {
+        // Shouldn't happen. How did the user get this file without git?
+        project.logger.error("Gradle error: Couldn't find git executable.")
+        return null;
+    }
+}
+
+String getNdkPath() {
+    try {
+        def stdout = new ByteArrayOutputStream()
+
+        exec {
+            // ndk-build.cmd is a file unique to the root directory of android-ndk-r10d.
+            commandLine 'locate', 'ndk-build.cmd'
+            standardOutput = stdout
+        }
+
+        def ndkCmdPath = stdout.toString()
+        def ndkPath = ndkCmdPath.substring(0, ndkCmdPath.lastIndexOf('/'))
+
+        project.logger.quiet("Gradle: Found Android NDK:" + ndkPath)
+
+        return ndkPath
+    } catch (ignored) {
+        project.logger.error("Gradle error: Couldn't find NDK.")
+        return null;
     }
 }


### PR DESCRIPTION
Instead of running some script in a terminal, waiting 2-3 minutes, then telling Android Studio to compile the java portion, now Gradle knows how to kick off CMake. So you just click one button in Android Studio (or a single Gradle command) and it's good to go.

Currently, this depends on the developer placing some parameters into a file, but they had to do that anyway to make a build script. Unfortunately, as it is you'll have to change those parameters if you decide you want to build for a different ABI; once #2409 is merged, the ABI-specifc entries in that file won't be necessary anymore, as I can make Gradle aware of those properties through other methods.