### PR TITLE
JitWindow: Add missing virtual destructor to HostDisassembler

### DIFF
--- a/Source/Core/DolphinWX/Debugger/JitWindow.h
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.h
@@ -29,6 +29,7 @@ public:
 class HostDisassembler
 {
 public:
+	virtual ~HostDisassembler() {}
 	std::string DisassembleBlock(u32* address, u32* host_instructions_count, u32* code_size);
 
 private:


### PR DESCRIPTION
HostDisassemblerLLVM has a destructor, but the class uses a pointer to the base class.