### PR TITLE
[AArch64] Implement block profiling.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -200,6 +200,10 @@ private:
 
 	void DoDownCount();
 
+	// Profiling
+	void BeginTimeProfile(JitBlock* b);
+	void EndTimeProfile(JitBlock* b);
+
 	// Exits
 	void WriteExit(u32 destination);
 	void WriteExceptionExit(Arm64Gen::ARM64Reg dest);


### PR DESCRIPTION
This is time based block profiling unlike the ARMv7 core.
I would like to add cycle counter based block profiling like the ARMv7 core, but it first requires writing a kernel module to enable the counters to userland applications