### PR TITLE
Core: Convert some volatile bools to atomics

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceGecko.cpp
@@ -14,7 +14,7 @@
 u16                       GeckoSockServer::server_port;
 int                       GeckoSockServer::client_count;
 std::thread               GeckoSockServer::connectionThread;
-volatile bool             GeckoSockServer::server_running;
+std::atomic<bool>         GeckoSockServer::server_running;
 std::mutex                GeckoSockServer::connection_lock;
 std::queue<std::unique_ptr<sf::TcpSocket>> GeckoSockServer::waiting_socks;
 
@@ -31,13 +31,13 @@ GeckoSockServer::~GeckoSockServer()
 	{
 		--client_count;
 
-		client_running = false;
+		client_running.store(false);
 		clientThread.join();
 	}
 
 	if (client_count <= 0)
 	{
-		server_running = false;
+		server_running.store(false);
 		connectionThread.join();
 	}
 }
@@ -48,14 +48,14 @@ void GeckoSockServer::GeckoConnectionWaiter()
 
 	sf::TcpListener server;
 	server_port = 0xd6ec; // "dolphin gecko"
-	for (int bind_tries = 0; bind_tries <= 10 && !server_running; bind_tries++)
+	for (int bind_tries = 0; bind_tries <= 10 && !server_running.load(); bind_tries++)
 	{
-		server_running = server.listen(server_port) == sf::Socket::Done;
-		if (!server_running)
+		server_running.store(server.listen(server_port) == sf::Socket::Done);
+		if (!server_running.load())
 			server_port++;
 	}
 
-	if (!server_running)
+	if (!server_running.load())
 		return;
 
 	Core::DisplayMessage(
@@ -65,7 +65,7 @@ void GeckoSockServer::GeckoConnectionWaiter()
 	server.setBlocking(false);
 
 	auto new_client = std::make_unique<sf::TcpSocket>();
-	while (server_running)
+	while (server_running.load())
 	{
 		if (server.accept(*new_client) == sf::Socket::Done)
 		{
@@ -89,7 +89,7 @@ bool GeckoSockServer::GetAvailableSock()
 		client = std::move(waiting_socks.front());
 		if (clientThread.joinable())
 		{
-			client_running = false;
+			client_running.store(false);
 			clientThread.join();
 
 			recv_fifo = std::deque<u8>();
@@ -106,13 +106,13 @@ bool GeckoSockServer::GetAvailableSock()
 
 void GeckoSockServer::ClientThread()
 {
-	client_running = true;
+	client_running.store(true);
 
 	Common::SetCurrentThreadName("Gecko Client");
 
 	client->setBlocking(false);
 
-	while (client_running)
+	while (client_running.load())
 	{
 		bool did_nothing = true;
 
@@ -124,7 +124,7 @@ void GeckoSockServer::ClientThread()
 		std::size_t got = 0;
 
 		if (client->receive(&data[0], ArraySize(data), got) == sf::Socket::Disconnected)
-			client_running = false;
+			client_running.store(false);
 
 		if (got != 0)
 		{
@@ -141,7 +141,7 @@ void GeckoSockServer::ClientThread()
 			send_fifo.clear();
 
 			if (client->send(&packet[0], packet.size()) == sf::Socket::Disconnected)
-				client_running = false;
+				client_running.store(false);
 		}
 		} // unlock transfer
 

--- a/Source/Core/Core/HW/EXI_DeviceGecko.h
+++ b/Source/Core/Core/HW/EXI_DeviceGecko.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <deque>
 #include <memory>
 #include <mutex>
@@ -31,14 +32,14 @@ public:
 	std::deque<u8> recv_fifo;
 
 private:
-	static int    client_count;
-	volatile bool client_running;
+	static int        client_count;
+	std::atomic<bool> client_running;
 
 	// Only ever one server thread
 	static void GeckoConnectionWaiter();
 
 	static u16                       server_port;
-	static volatile bool             server_running;
+	static std::atomic<bool>         server_running;
 	static std::thread               connectionThread;
 	static std::mutex                connection_lock;
 	static std::queue<std::unique_ptr<sf::TcpSocket>> waiting_socks;

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <string>
@@ -96,11 +97,11 @@ private:
 
 	std::thread               m_wiimote_thread;
 	// Whether to keep running the thread.
-	volatile bool             m_run_thread;
+	std::atomic<bool>         m_run_thread;
 	// Whether to call PrepareOnThread.
-	volatile bool             m_need_prepare;
+	std::atomic<bool>         m_need_prepare;
 	// Whether the thread has finished ConnectInternal.
-	volatile bool             m_thread_ready;
+	std::atomic<bool>         m_thread_ready;
 	std::mutex                m_thread_ready_mutex;
 	std::condition_variable   m_thread_ready_cond;
 
@@ -134,9 +135,9 @@ private:
 
 	std::thread m_scan_thread;
 
-	volatile bool m_run_thread;
-	volatile bool m_want_wiimotes;
-	volatile bool m_want_bb;
+	std::atomic<bool> m_run_thread;
+	std::atomic<bool> m_want_wiimotes;
+	std::atomic<bool> m_want_bb;
 
 #if defined(_WIN32)
 	void CheckDeviceType(std::basic_string<TCHAR> &devicepath, bool &real_wiimote, bool &is_bb);

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <map>
 #include <mutex>
 #include <queue>
@@ -108,9 +109,9 @@ protected:
 	ENetPeer*    m_server;
 	std::thread  m_thread;
 
-	std::string   m_selected_game;
-	volatile bool m_is_running;
-	volatile bool m_do_loop;
+	std::string       m_selected_game;
+	std::atomic<bool> m_is_running;
+	std::atomic<bool> m_do_loop;
 
 	unsigned int  m_target_buffer_size;
 


### PR DESCRIPTION
Converts over bools that are typically used as loop checks (e.g. marked volatile simply to avoid being optimized away) into atomics.