### PR TITLE
Android: Have build.gradle figure out what ABI and Toolchain to use.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,19 +60,14 @@ Android Studio will do this for you if you create `Source/Android/build.properti
 following inside:
 
 ```
-toolchain=<toolchain>
-abi=<abi>
 makeArgs=<make-args>
 ```
 
-Replace `<make-args>` with any arguments you want to pass to `make`, and the rest depending on which
-platform the Android device you are targeting uses:
-
-|Platform                 | `<abi>`     | `<toolchain>`             |
-|-------------------------|-------------|---------------------------|
-|ARM 32-bit (most devices)| armeabi-v7a | arm-linux-androideabi-4.9 |
-|ARM 64-bit (i.e. Nexus 9)| arm64-v8a   | aarch64-linux-android-4.9 |
-|Intel 64-bit             | x86_64      | x86_64-4.9                |
+Replace `<make-args>` with any arguments you want to pass to `make`, and then execute the
+`assembleDebug` or `installDebug` task corresponding to the hardware platform you are targeting.
+For example, to deploy to a Nexus 9, which runs the AArch64 architecture, execute `installArm_64Debug`.
+A list of available tasks can be found in Android Studio in the Gradle tray, located at the top-right
+corner of the IDE by default.
 
 The native libraries will be compiled, and copied into `./Source/Android/app/libs`. Android Studio
 and Gradle will include any libraries in that folder into the APK at build time.

--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "20.0.0"
+    buildToolsVersion "22.0.1"
 
     lintOptions {
         // This is important as it will run lint but not abort on error

--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -69,13 +69,12 @@ android {
             }
         }
 
-        // TODO Uncomment this when we successfully build for x86_64.
-        /*x86_64 {
+        x86_64 {
             flavorDimension "abi"
             ndk {
                 abiFilter "x86_64"
             }
-        }*/
+        }
     }
 }
 
@@ -103,8 +102,10 @@ task setupCMake(type: Exec) {
         def buildProperties = new Properties()
         buildProperties.load(new FileInputStream(propsFile))
 
-        mkdir('build/' + buildProperties.abi)
-        workingDir 'build/' + buildProperties.abi
+        String abi = getAbi()
+
+        mkdir('build/' + abi)
+        workingDir 'build/' + abi
 
         executable 'cmake'
 
@@ -114,8 +115,8 @@ task setupCMake(type: Exec) {
                 "../../../../..",
                 "-DGIT_EXECUTABLE=" + getGitPath(),
                 "-DANDROID_NDK=" + getNdkPath(),
-                "-DANDROID_TOOLCHAIN_NAME=" + buildProperties.toolchain,
-                "-DANDROID_ABI=" + buildProperties.abi
+                "-DANDROID_TOOLCHAIN_NAME=" + getToolchainName(),
+                "-DANDROID_ABI=" + abi
     } else {
         executable 'echo'
         args 'No build.properties found; skipping CMake.'
@@ -132,7 +133,9 @@ task compileNative(type: Exec, dependsOn: 'setupCMake') {
         def buildProperties = new Properties()
         buildProperties.load(new FileInputStream(propsFile))
 
-        workingDir 'build/' + buildProperties.abi
+        String abi = getAbi()
+
+        workingDir 'build/' + abi
 
         executable 'make'
 
@@ -183,4 +186,46 @@ String getNdkPath() {
         project.logger.error("Gradle error: Couldn't find NDK.")
         return null;
     }
+}
+
+String getAbi() {
+    String taskName = getGradle().startParameter.taskNames[0]
+    String abi;
+
+    if (taskName == null) {
+        return ""
+    }
+
+    project.logger.quiet("Gradle: Build = " + taskName)
+
+    if (taskName.contains("Arm_64")) {
+        abi = "arm64-v8a"
+    } else if (taskName.contains("Arm")) {
+        abi = "armeabi-v7a"
+    } else if (taskName.contains("X86_64")) {
+        abi = "x86_64"
+    }
+
+    project.logger.quiet("Gradle: ABI name: " + abi)
+    return abi;
+}
+
+String getToolchainName() {
+    String taskName = getGradle().startParameter.taskNames[0]
+    String toolchain;
+
+    if (taskName == null) {
+        return ""
+    }
+
+    if (taskName.contains("Arm_64")) {
+        toolchain = "aarch64-linux-android-4.9"
+    } else if (taskName.contains("Arm")) {
+        toolchain = "arm-linux-androideabi-4.9"
+    } else if (taskName.contains("X86_64")) {
+        toolchain = "x86_64-4.9"
+    }
+
+    project.logger.quiet("Gradle: ABI name: " + toolchain)
+    return toolchain;
 }


### PR DESCRIPTION
Gradle is now smart enough to allow you to bulid native code for multiple architectures, without editing files in between. (It is still required to have a `build.properties` file in order to trigger this functionality, but there's no longer any reason this is the case; a better implementation is coming soon.)

A list of Gradle tasks can be found in the Gradle tray at the top right of Android Studio. In the below screenshot, double-clicking the highlighted item starts a build targeting AArch64:

![gradle-tray](https://cloud.githubusercontent.com/assets/1912034/7779906/ec4909b0-00a6-11e5-8b62-a1afb338656f.png)

Once a task has been executed once, it'll show up in a dropdown menu in the Toolbar. The most recently used task can be executed by clicking the green triangle next to the list:

![shortcuts](https://cloud.githubusercontent.com/assets/1912034/7779919/1a494be0-00a7-11e5-9a97-68a9107a63f6.png)

The goal here is to lower the barrier to contributing to the Android project to as close to 0 as possible. This gets us almost there, I think.