### PR TITLE
WiiWad: Use correct form of delete for arrays

### DIFF
--- a/Source/Core/DiscIO/WiiWad.cpp
+++ b/Source/Core/DiscIO/WiiWad.cpp
@@ -49,11 +49,11 @@ WiiWAD::~WiiWAD()
 {
 	if (m_Valid)
 	{
-		delete m_pCertificateChain;
-		delete m_pTicket;
-		delete m_pTMD;
-		delete m_pDataApp;
-		delete m_pFooter;
+		delete[] m_pCertificateChain;
+		delete[] m_pTicket;
+		delete[] m_pTMD;
+		delete[] m_pDataApp;
+		delete[] m_pFooter;
 	}
 }
 


### PR DESCRIPTION
CreateWADEntry returns an array allocated with new, so `delete[]` should be used instead of `delete`