### PR TITLE
IsTriviallyCopyable macro under GCC 5

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -29,10 +29,8 @@
 #include "Common/Flag.h"
 
 // ewww
-#if _LIBCPP_VERSION
+#if _LIBCPP_VERSION || __GNUC__
 #define IsTriviallyCopyable(T) std::is_trivially_copyable<typename std::remove_volatile<T>::type>::value
-#elif __GNUC__
-#define IsTriviallyCopyable(T) std::has_trivial_copy_constructor<T>::value
 #elif _MSC_VER >= 1800
 // work around bug
 #define IsTriviallyCopyable(T) (std::is_trivially_copyable<T>::value || std::is_pod<T>::value)


### PR DESCRIPTION
Since GCC 5, std::is_trivially_copyable should be used instead of std::has_trivial_copy_constructor.
Source: https://gcc.gnu.org/gcc-5/changes.html