### PR TITLE
DolphinWX: Add missing breaks to a switch in RegisterView

### DIFF
--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -69,54 +69,48 @@ static wxString GetValueByRowCol(int row, int col)
 		case 5:
 		{
 			if (row < 4)
-			{
 				return wxString::Format("DBAT%01d", row);
-			}
+
 			if (row < 8)
-			{
 				return wxString::Format("IBAT%01d", row - 4);
-			}
+
 			if (row < 12)
-			{
 				return wxString::Format("DBAT%01d", row - 4);
-			}
+
 			if (row < 16)
-			{
 				return wxString::Format("IBAT%01d", row - 8);
-			}
+
+			break;
 		}
 		case 6:
 		{
 			if (row < 4)
-			{
 				return wxString::Format("%016llx", (u64)PowerPC::ppcState.spr[SPR_DBAT0U + row * 2] << 32 | PowerPC::ppcState.spr[SPR_DBAT0L + row * 2]);
-			}
+
 			if (row < 8)
-			{
 				return wxString::Format("%016llx", (u64)PowerPC::ppcState.spr[SPR_IBAT0U + (row - 4) * 2] << 32 | PowerPC::ppcState.spr[SPR_IBAT0L + (row - 4) * 2]);
-			}
+
 			if (row < 12)
-			{
 				return wxString::Format("%016llx", (u64)PowerPC::ppcState.spr[SPR_DBAT4U + (row - 12) * 2] << 32 | PowerPC::ppcState.spr[SPR_DBAT4L + (row - 12) * 2]);
-			}
+
 			if (row < 16)
-			{
 				return wxString::Format("%016llx", (u64)PowerPC::ppcState.spr[SPR_IBAT4U + (row - 16) * 2] << 32 | PowerPC::ppcState.spr[SPR_IBAT4L + (row - 16) * 2]);
-			}
+
+			break;
 		}
 		case 7:
 		{
 			if (row < 16)
-			{
 				return wxString::Format("SR%02d", row);
-			}
+
+			break;
 		}
 		case 8:
 		{
 			if (row < 16)
-			{
 				return wxString::Format("%08x", PowerPC::ppcState.sr[row]);
-			}
+
+			break;
 		}
 		default: return wxEmptyString;
 		}


### PR DESCRIPTION
Technically the fallthrough would never happen, as the row numbers correspond to the grid view (which will always be zero or greater). However, it gets rid of compiler warnings on higher warning levels.