### PR TITLE
GekkoDisassembler: Fix disassembly of mtfsf's FM field.

### DIFF
--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -2204,7 +2204,7 @@ u32* GekkoDisassembler::DoDisassembly(bool big_endian)
 				if ((in & 0x02010000) == 0)
 				{
 					m_opcode = StringFromFormat("mtfsf%s", rcsel[in & 1]);
-					m_operands = StringFromFormat("0x%x,%u", (unsigned int)(in >> 17) & 0x01fe, (int)PPCGETB(in));
+					m_operands = StringFromFormat("0x%x,%u", (unsigned int)(in >> 17) & 0x01fe, (unsigned int)PPCGETB(in));
 				}
 				else
 				{

--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -2204,7 +2204,7 @@ u32* GekkoDisassembler::DoDisassembly(bool big_endian)
 				if ((in & 0x02010000) == 0)
 				{
 					m_opcode = StringFromFormat("mtfsf%s", rcsel[in & 1]);
-					m_operands = StringFromFormat("0x%x,%u", (unsigned int)(in & 0x01fe) >> 17, (int)PPCGETB(in));
+					m_operands = StringFromFormat("0x%x,%u", (unsigned int)(in >> 17) & 0x01fe, (int)PPCGETB(in));
 				}
 				else
 				{


### PR DESCRIPTION
Bitwise AND should be after the shift. Tested with a hombrew app that explicitly uses mtfsf.

Example with "mtfsf 0xE0, 5"

Prior to this change:
![](http://i.imgur.com/QgzTLaX.png)

After this change:
![](http://i.imgur.com/JN1jl3s.png)