### PR TITLE
AudioCommon: Construct the mixer inside the SoundStream base class.

### DIFF
--- a/Source/Core/AudioCommon/AOSoundStream.cpp
+++ b/Source/Core/AudioCommon/AOSoundStream.cpp
@@ -77,8 +77,4 @@ void AOSound::Stop()
 	}
 }
 
-AOSound::~AOSound()
-{
-}
-
 #endif

--- a/Source/Core/AudioCommon/AOSoundStream.h
+++ b/Source/Core/AudioCommon/AOSoundStream.h
@@ -33,10 +33,6 @@ class AOSound final : public SoundStream
 	short realtimeBuffer[1024 * 1024];
 
 public:
-	AOSound(CMixer *mixer) : SoundStream(mixer) {}
-
-	virtual ~AOSound();
-
 	virtual bool Start() override;
 
 	virtual void SoundLoop() override;
@@ -49,9 +45,5 @@ public:
 	}
 
 	virtual void Update() override;
-
-#else
-public:
-	AOSound(CMixer *mixer) : SoundStream(mixer) {}
 #endif
 };

--- a/Source/Core/AudioCommon/AlsaSoundStream.cpp
+++ b/Source/Core/AudioCommon/AlsaSoundStream.cpp
@@ -10,9 +10,8 @@
 #define BUFFER_SIZE_MAX 8192
 #define BUFFER_SIZE_BYTES (BUFFER_SIZE_MAX*2*2)
 
-AlsaSound::AlsaSound(CMixer *mixer)
-	: SoundStream(mixer)
-	, m_thread_status(ALSAThreadStatus::STOPPED)
+AlsaSound::AlsaSound()
+	: m_thread_status(ALSAThreadStatus::STOPPED)
 	, handle(nullptr)
 	, frames_to_deliver(FRAME_COUNT_MIN)
 {

--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -18,7 +18,7 @@ class AlsaSound final : public SoundStream
 {
 #if defined(HAVE_ALSA) && HAVE_ALSA
 public:
-	AlsaSound(CMixer *mixer);
+	AlsaSound();
 	virtual ~AlsaSound();
 
 	virtual bool Start() override;
@@ -49,8 +49,5 @@ private:
 
 	snd_pcm_t *handle;
 	int frames_to_deliver;
-#else
-public:
-	AlsaSound(CMixer *mixer) : SoundStream(mixer) {}
 #endif
 };

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -32,38 +32,34 @@ namespace AudioCommon
 
 	SoundStream* InitSoundStream()
 	{
-		CMixer *mixer = new CMixer(48000);
-
-		// TODO: possible memleak with mixer
-
 		std::string backend = SConfig::GetInstance().sBackend;
-		if (backend == BACKEND_OPENAL           && OpenALStream::isValid())
-			g_sound_stream = new OpenALStream(mixer);
-		else if (backend == BACKEND_NULLSOUND   && NullSound::isValid())
-			g_sound_stream = new NullSound(mixer);
+		if (backend == BACKEND_OPENAL && OpenALStream::isValid())
+			g_sound_stream = new OpenALStream();
+		else if (backend == BACKEND_NULLSOUND && NullSound::isValid())
+			g_sound_stream = new NullSound();
 		else if (backend == BACKEND_XAUDIO2)
 		{
 			if (XAudio2::isValid())
-				g_sound_stream = new XAudio2(mixer);
+				g_sound_stream = new XAudio2();
 			else if (XAudio2_7::isValid())
-				g_sound_stream = new XAudio2_7(mixer);
+				g_sound_stream = new XAudio2_7();
 		}
-		else if (backend == BACKEND_AOSOUND     && AOSound::isValid())
-			g_sound_stream = new AOSound(mixer);
-		else if (backend == BACKEND_ALSA        && AlsaSound::isValid())
-			g_sound_stream = new AlsaSound(mixer);
-		else if (backend == BACKEND_COREAUDIO   && CoreAudioSound::isValid())
-			g_sound_stream = new CoreAudioSound(mixer);
-		else if (backend == BACKEND_PULSEAUDIO  && PulseAudio::isValid())
-			g_sound_stream = new PulseAudio(mixer);
+		else if (backend == BACKEND_AOSOUND && AOSound::isValid())
+			g_sound_stream = new AOSound();
+		else if (backend == BACKEND_ALSA && AlsaSound::isValid())
+			g_sound_stream = new AlsaSound();
+		else if (backend == BACKEND_COREAUDIO && CoreAudioSound::isValid())
+			g_sound_stream = new CoreAudioSound();
+		else if (backend == BACKEND_PULSEAUDIO && PulseAudio::isValid())
+			g_sound_stream = new PulseAudio();
 		else if (backend == BACKEND_OPENSLES && OpenSLESStream::isValid())
-			g_sound_stream = new OpenSLESStream(mixer);
+			g_sound_stream = new OpenSLESStream();
 
 		if (!g_sound_stream && NullSound::isValid())
 		{
 			WARN_LOG(DSPHLE, "Could not initialize backend %s, using %s instead.",
 				backend.c_str(), BACKEND_NULLSOUND);
-			g_sound_stream = new NullSound(mixer);
+			g_sound_stream = new NullSound();
 		}
 
 		if (g_sound_stream)

--- a/Source/Core/AudioCommon/CoreAudioSoundStream.cpp
+++ b/Source/Core/AudioCommon/CoreAudioSoundStream.cpp
@@ -19,14 +19,6 @@ OSStatus CoreAudioSound::callback(void *inRefCon,
 	return noErr;
 }
 
-CoreAudioSound::CoreAudioSound(CMixer *mixer) : SoundStream(mixer)
-{
-}
-
-CoreAudioSound::~CoreAudioSound()
-{
-}
-
 bool CoreAudioSound::Start()
 {
 	OSStatus err;

--- a/Source/Core/AudioCommon/CoreAudioSoundStream.h
+++ b/Source/Core/AudioCommon/CoreAudioSoundStream.h
@@ -14,9 +14,6 @@ class CoreAudioSound final : public SoundStream
 {
 #ifdef __APPLE__
 public:
-	CoreAudioSound(CMixer *mixer);
-	virtual ~CoreAudioSound();
-
 	virtual bool Start();
 	virtual void SetVolume(int volume);
 	virtual void SoundLoop();
@@ -38,8 +35,5 @@ private:
 		const AudioTimeStamp *inTimeStamp,
 		UInt32 inBusNumber, UInt32 inNumberFrames,
 		AudioBufferList *ioData);
-#else
-public:
-	CoreAudioSound(CMixer *mixer) : SoundStream(mixer) {}
 #endif
 };

--- a/Source/Core/AudioCommon/NullSoundStream.h
+++ b/Source/Core/AudioCommon/NullSoundStream.h
@@ -15,12 +15,6 @@ class NullSound final : public SoundStream
 	short realtimeBuffer[BUF_SIZE / sizeof(short)];
 
 public:
-	NullSound(CMixer *mixer)
-		: SoundStream(mixer)
-	{}
-
-	virtual ~NullSound() {}
-
 	virtual bool Start() override;
 	virtual void SoundLoop() override;
 	virtual void SetVolume(int volume) override;

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -56,12 +56,9 @@ class OpenALStream final : public SoundStream
 {
 #if defined HAVE_OPENAL && HAVE_OPENAL
 public:
-	OpenALStream(CMixer *mixer)
-		: SoundStream(mixer)
-		, uiSource(0)
-	{}
-
-	virtual ~OpenALStream() {}
+	OpenALStream() : uiSource(0)
+	{
+	}
 
 	virtual bool Start() override;
 	virtual void SoundLoop() override;
@@ -84,10 +81,5 @@ private:
 	ALfloat fVolume;
 
 	u8 numBuffers;
-#else
-public:
-	OpenALStream(CMixer *mixer)
-		: SoundStream(mixer)
-	{}
 #endif // HAVE_OPENAL
 };

--- a/Source/Core/AudioCommon/OpenSLESStream.cpp
+++ b/Source/Core/AudioCommon/OpenSLESStream.cpp
@@ -102,7 +102,7 @@ bool OpenSLESStream::Start()
 
 	// Render and enqueue a first buffer.
 	curBuffer ^= 1;
-	g_mixer = m_mixer;
+	g_mixer = m_mixer.get();
 
 	result = (*bqPlayerBufferQueue)->Enqueue(bqPlayerBufferQueue, buffer[0], sizeof(buffer[0]));
 	if (SL_RESULT_SUCCESS != result)

--- a/Source/Core/AudioCommon/OpenSLESStream.h
+++ b/Source/Core/AudioCommon/OpenSLESStream.h
@@ -13,15 +13,6 @@ class OpenSLESStream final : public SoundStream
 {
 #ifdef ANDROID
 public:
-	OpenSLESStream(CMixer *mixer)
-		: SoundStream(mixer)
-	{
-	}
-
-	virtual ~OpenSLESStream()
-	{
-	}
-
 	virtual bool Start();
 	virtual void Stop();
 	static bool isValid() { return true; }
@@ -29,11 +20,5 @@ public:
 private:
 	std::thread thread;
 	Common::Event soundSyncEvent;
-#else
-public:
-	OpenSLESStream(CMixer *mixer)
-		: SoundStream(mixer)
-	{
-	}
 #endif // HAVE_OPENSL
 };

--- a/Source/Core/AudioCommon/PulseAudioStream.cpp
+++ b/Source/Core/AudioCommon/PulseAudioStream.cpp
@@ -13,9 +13,8 @@ namespace
 const size_t BUFFER_SAMPLES = 512; // ~10 ms - needs to be at least 240 for surround
 }
 
-PulseAudio::PulseAudio(CMixer *mixer)
-	: SoundStream(mixer)
-	, m_thread()
+PulseAudio::PulseAudio()
+	: m_thread()
 	, m_run_thread()
 {
 }

--- a/Source/Core/AudioCommon/PulseAudioStream.h
+++ b/Source/Core/AudioCommon/PulseAudioStream.h
@@ -18,7 +18,7 @@ class PulseAudio final : public SoundStream
 {
 #if defined(HAVE_PULSEAUDIO) && HAVE_PULSEAUDIO
 public:
-	PulseAudio(CMixer *mixer);
+	PulseAudio();
 
 	virtual bool Start() override;
 	virtual void Stop() override;
@@ -56,8 +56,5 @@ private:
 	pa_context *m_pa_ctx;
 	pa_stream *m_pa_s;
 	pa_buffer_attr m_pa_ba;
-#else
-public:
-	PulseAudio(CMixer *mixer) : SoundStream(mixer) {}
 #endif
 };

--- a/Source/Core/AudioCommon/SoundStream.h
+++ b/Source/Core/AudioCommon/SoundStream.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "AudioCommon/Mixer.h"
 #include "AudioCommon/WaveFile.h"
 #include "Common/CommonTypes.h"
@@ -11,17 +13,17 @@
 class SoundStream
 {
 protected:
-	CMixer* m_mixer;
+	std::unique_ptr<CMixer> m_mixer;
 	bool m_logAudio;
 	WaveFileWriter g_wave_writer;
 	bool m_muted;
 
 public:
-	SoundStream(CMixer* mixer) : m_mixer(mixer), m_logAudio(false), m_muted(false) {}
-	virtual ~SoundStream() { delete m_mixer; }
+	SoundStream() : m_mixer(new CMixer(48000)), m_logAudio(false), m_muted(false) {}
+	virtual ~SoundStream() { }
 
 	static  bool isValid() { return false; }
-	virtual CMixer* GetMixer() const { return m_mixer; }
+	virtual CMixer* GetMixer() const { return m_mixer.get(); }
 	virtual bool Start() { return false; }
 	virtual void SetVolume(int) {}
 	virtual void SoundLoop() {}

--- a/Source/Core/AudioCommon/SoundStream.h
+++ b/Source/Core/AudioCommon/SoundStream.h
@@ -23,7 +23,7 @@ public:
 	virtual ~SoundStream() { }
 
 	static  bool isValid() { return false; }
-	virtual CMixer* GetMixer() const { return m_mixer.get(); }
+	CMixer* GetMixer() const { return m_mixer.get(); }
 	virtual bool Start() { return false; }
 	virtual void SetVolume(int) {}
 	virtual void SoundLoop() {}

--- a/Source/Core/AudioCommon/XAudio2Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2Stream.cpp
@@ -155,9 +155,8 @@ bool XAudio2::InitLibrary()
 	return true;
 }
 
-XAudio2::XAudio2(CMixer *mixer)
-	: SoundStream(mixer)
-	, m_mastering_voice(nullptr)
+XAudio2::XAudio2()
+	: m_mastering_voice(nullptr)
 	, m_volume(1.0f)
 	, m_cleanup_com(SUCCEEDED(CoInitializeEx(nullptr, COINIT_MULTITHREADED)))
 {
@@ -197,7 +196,7 @@ bool XAudio2::Start()
 	m_mastering_voice->SetVolume(m_volume);
 
 	m_voice_context = std::unique_ptr<StreamingVoiceContext>
-		(new StreamingVoiceContext(m_xaudio2.get(), m_mixer, m_sound_sync_event));
+		(new StreamingVoiceContext(m_xaudio2.get(), m_mixer.get(), m_sound_sync_event));
 
 	return true;
 }

--- a/Source/Core/AudioCommon/XAudio2Stream.h
+++ b/Source/Core/AudioCommon/XAudio2Stream.h
@@ -51,7 +51,7 @@ private:
 	static bool InitLibrary();
 
 public:
-	XAudio2(CMixer *mixer);
+	XAudio2();
 	virtual ~XAudio2();
 
 	virtual bool Start();
@@ -62,13 +62,5 @@ public:
 	virtual void SetVolume(int volume);
 
 	static bool isValid() { return InitLibrary(); }
-
-#else
-
-public:
-	XAudio2(CMixer *mixer)
-		: SoundStream(mixer)
-	{}
-
 #endif
 };

--- a/Source/Core/AudioCommon/XAudio2_7Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2_7Stream.cpp
@@ -143,9 +143,8 @@ bool XAudio2_7::InitLibrary()
 	return m_xaudio2_dll != nullptr;
 }
 
-XAudio2_7::XAudio2_7(CMixer *mixer)
-	: SoundStream(mixer)
-	, m_mastering_voice(nullptr)
+XAudio2_7::XAudio2_7()
+	: m_mastering_voice(nullptr)
 	, m_volume(1.0f)
 	, m_cleanup_com(SUCCEEDED(CoInitializeEx(nullptr, COINIT_MULTITHREADED)))
 {
@@ -185,7 +184,7 @@ bool XAudio2_7::Start()
 	m_mastering_voice->SetVolume(m_volume);
 
 	m_voice_context = std::unique_ptr<StreamingVoiceContext2_7>
-		(new StreamingVoiceContext2_7(m_xaudio2.get(), m_mixer, m_sound_sync_event));
+		(new StreamingVoiceContext2_7(m_xaudio2.get(), m_mixer.get(), m_sound_sync_event));
 
 	return true;
 }

--- a/Source/Core/AudioCommon/XAudio2_7Stream.h
+++ b/Source/Core/AudioCommon/XAudio2_7Stream.h
@@ -58,7 +58,7 @@ private:
 	static bool InitLibrary();
 
 public:
-	XAudio2_7(CMixer *mixer);
+	XAudio2_7();
 	virtual ~XAudio2_7();
 
 	virtual bool Start();
@@ -69,13 +69,5 @@ public:
 	virtual void SetVolume(int volume);
 
 	static bool isValid() { return InitLibrary(); }
-
-#else
-
-public:
-	XAudio2_7(CMixer *mixer)
-		: SoundStream(mixer)
-	{}
-
 #endif
 };


### PR DESCRIPTION
Rather than pass it in as a parameter, it's now just constructed in the base class constructor since all audio streams utilize an instantiation of it.