### PR TITLE
AudioCommon: Add override specifiers to SoundStream subclasses.

### DIFF
--- a/Source/Core/AudioCommon/AOSoundStream.h
+++ b/Source/Core/AudioCommon/AOSoundStream.h
@@ -33,17 +33,15 @@ class AOSound final : public SoundStream
 	short realtimeBuffer[1024 * 1024];
 
 public:
-	virtual bool Start() override;
-
-	virtual void SoundLoop() override;
-
-	virtual void Stop() override;
+	bool Start() override;
+	void SoundLoop() override;
+	void Stop() override;
+	void Update() override;
 
 	static bool isValid()
 	{
 		return true;
 	}
 
-	virtual void Update() override;
 #endif
 };

--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -21,16 +21,15 @@ public:
 	AlsaSound();
 	virtual ~AlsaSound();
 
-	virtual bool Start() override;
-	virtual void SoundLoop() override;
-	virtual void Stop() override;
+	bool Start() override;
+	void SoundLoop() override;
+	void Stop() override;
+	void Update() override;
 
 	static bool isValid()
 	{
 		return true;
 	}
-
-	virtual void Update() override;
 
 private:
 	enum class ALSAThreadStatus

--- a/Source/Core/AudioCommon/CoreAudioSoundStream.h
+++ b/Source/Core/AudioCommon/CoreAudioSoundStream.h
@@ -14,17 +14,16 @@ class CoreAudioSound final : public SoundStream
 {
 #ifdef __APPLE__
 public:
-	virtual bool Start();
-	virtual void SetVolume(int volume);
-	virtual void SoundLoop();
-	virtual void Stop();
+	bool Start() override;
+	void SetVolume(int volume) override;
+	void SoundLoop() override;
+	void Stop() override;
+	void Update() override;
 
 	static bool isValid()
 	{
 		return true;
 	}
-
-	virtual void Update();
 
 private:
 	AudioUnit audioUnit;

--- a/Source/Core/AudioCommon/NullSoundStream.h
+++ b/Source/Core/AudioCommon/NullSoundStream.h
@@ -15,11 +15,12 @@ class NullSound final : public SoundStream
 	short realtimeBuffer[BUF_SIZE / sizeof(short)];
 
 public:
-	virtual bool Start() override;
-	virtual void SoundLoop() override;
-	virtual void SetVolume(int volume) override;
-	virtual void Stop() override;
-	virtual void Clear(bool mute) override;
+	bool Start() override;
+	void SoundLoop() override;
+	void SetVolume(int volume) override;
+	void Stop() override;
+	void Clear(bool mute) override;
+	void Update() override;
+
 	static bool isValid() { return true; }
-	virtual void Update() override;
 };

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -60,13 +60,14 @@ public:
 	{
 	}
 
-	virtual bool Start() override;
-	virtual void SoundLoop() override;
-	virtual void SetVolume(int volume) override;
-	virtual void Stop() override;
-	virtual void Clear(bool mute) override;
+	bool Start() override;
+	void SoundLoop() override;
+	void SetVolume(int volume) override;
+	void Stop() override;
+	void Clear(bool mute) override;
+	void Update() override;
+
 	static bool isValid() { return true; }
-	virtual void Update() override;
 
 private:
 	std::thread thread;

--- a/Source/Core/AudioCommon/OpenSLESStream.h
+++ b/Source/Core/AudioCommon/OpenSLESStream.h
@@ -13,8 +13,8 @@ class OpenSLESStream final : public SoundStream
 {
 #ifdef ANDROID
 public:
-	virtual bool Start();
-	virtual void Stop();
+	bool Start() override;
+	void Stop() override;
 	static bool isValid() { return true; }
 
 private:

--- a/Source/Core/AudioCommon/PulseAudioStream.h
+++ b/Source/Core/AudioCommon/PulseAudioStream.h
@@ -20,12 +20,11 @@ class PulseAudio final : public SoundStream
 public:
 	PulseAudio();
 
-	virtual bool Start() override;
-	virtual void Stop() override;
+	bool Start() override;
+	void Stop() override;
+	void Update() override;
 
 	static bool isValid() { return true; }
-
-	virtual void Update() override;
 
 	void StateCallback(pa_context *c);
 	void WriteCallback(pa_stream *s, size_t length);

--- a/Source/Core/AudioCommon/SoundStream.h
+++ b/Source/Core/AudioCommon/SoundStream.h
@@ -32,7 +32,7 @@ public:
 	virtual void Clear(bool mute) { m_muted = mute; }
 	bool IsMuted() const { return m_muted; }
 
-	virtual void StartLogAudio(const std::string& filename)
+	void StartLogAudio(const std::string& filename)
 	{
 		if (!m_logAudio)
 		{
@@ -47,7 +47,7 @@ public:
 		}
 	}
 
-	virtual void StopLogAudio()
+	void StopLogAudio()
 	{
 		if (m_logAudio)
 		{

--- a/Source/Core/AudioCommon/XAudio2Stream.h
+++ b/Source/Core/AudioCommon/XAudio2Stream.h
@@ -54,12 +54,12 @@ public:
 	XAudio2();
 	virtual ~XAudio2();
 
-	virtual bool Start();
-	virtual void Stop();
+	bool Start() override;
+	void Stop() override;
 
-	virtual void Update();
-	virtual void Clear(bool mute);
-	virtual void SetVolume(int volume);
+	void Update() override;
+	void Clear(bool mute) override;
+	void SetVolume(int volume) override;
 
 	static bool isValid() { return InitLibrary(); }
 #endif

--- a/Source/Core/AudioCommon/XAudio2_7Stream.h
+++ b/Source/Core/AudioCommon/XAudio2_7Stream.h
@@ -61,12 +61,12 @@ public:
 	XAudio2_7();
 	virtual ~XAudio2_7();
 
-	virtual bool Start();
-	virtual void Stop();
+	bool Start() override;
+	void Stop() override;
 
-	virtual void Update();
-	virtual void Clear(bool mute);
-	virtual void SetVolume(int volume);
+	void Update() override;
+	void Clear(bool mute) override;
+	void SetVolume(int volume) override;
 
 	static bool isValid() { return InitLibrary(); }
 #endif


### PR DESCRIPTION
Also removes the virtual keyword where appropriate since it's unnecessary with override.