### PR TITLE
DSP: Inline DSPControl into DSPState

### DIFF
--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -79,16 +79,6 @@ union UARAMCount
 	};
 };
 
-// DSPState
-struct DSPState
-{
-	UDSPControl DSPControl;
-	DSPState()
-	{
-		DSPControl.Hex = 0;
-	}
-};
-
 // Blocks are 32 bytes.
 union UAudioDMAControl
 {
@@ -155,7 +145,7 @@ struct ARAMInfo
 
 // STATE_TO_SAVE
 static ARAMInfo g_ARAM;
-static DSPState g_dspState;
+static UDSPControl g_dspState;
 static AudioDMA g_audioDMA;
 static ARAM_DMA g_arDMA;
 static u32 last_mmaddr;
@@ -215,7 +205,7 @@ static int et_CompleteARAM;
 
 static void CompleteARAM(u64 userdata, int cyclesLate)
 {
-	g_dspState.DSPControl.DMAState = 0;
+	g_dspState.DMAState = 0;
 	GenerateDSPInterrupt(INT_ARAM);
 }
 
@@ -255,8 +245,8 @@ void Init(bool hle)
 	memset(&g_audioDMA, 0, sizeof(g_audioDMA));
 	memset(&g_arDMA, 0, sizeof(g_arDMA));
 
-	g_dspState.DSPControl.Hex = 0;
-	g_dspState.DSPControl.DSPHalt = 1;
+	g_dspState.Hex = 0;
+	g_dspState.DSPHalt = 1;
 
 	g_ARAM_Info.Hex = 0;
 	g_AR_MODE = 1; // ARAM Controller has init'd
@@ -356,7 +346,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 
 	mmio->Register(base | DSP_CONTROL,
 		MMIO::ComplexRead<u16>([](u32) {
-			return (g_dspState.DSPControl.Hex & ~DSP_CONTROL_MASK) |
+			return (g_dspState.Hex & ~DSP_CONTROL_MASK) |
 			       (dsp_emulator->DSP_ReadControlRegister() & DSP_CONTROL_MASK);
 		}),
 		MMIO::ComplexWrite<u16>([](u32, u16 val) {
@@ -373,27 +363,27 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 			}
 
 			// Update DSP related flags
-			g_dspState.DSPControl.DSPReset     = tmpControl.DSPReset;
-			g_dspState.DSPControl.DSPAssertInt = tmpControl.DSPAssertInt;
-			g_dspState.DSPControl.DSPHalt      = tmpControl.DSPHalt;
-			g_dspState.DSPControl.DSPInit      = tmpControl.DSPInit;
+			g_dspState.DSPReset     = tmpControl.DSPReset;
+			g_dspState.DSPAssertInt = tmpControl.DSPAssertInt;
+			g_dspState.DSPHalt      = tmpControl.DSPHalt;
+			g_dspState.DSPInit      = tmpControl.DSPInit;
 
 			// Interrupt (mask)
-			g_dspState.DSPControl.AID_mask  = tmpControl.AID_mask;
-			g_dspState.DSPControl.ARAM_mask = tmpControl.ARAM_mask;
-			g_dspState.DSPControl.DSP_mask  = tmpControl.DSP_mask;
+			g_dspState.AID_mask  = tmpControl.AID_mask;
+			g_dspState.ARAM_mask = tmpControl.ARAM_mask;
+			g_dspState.DSP_mask  = tmpControl.DSP_mask;
 
 			// Interrupt
-			if (tmpControl.AID)  g_dspState.DSPControl.AID  = 0;
-			if (tmpControl.ARAM) g_dspState.DSPControl.ARAM = 0;
-			if (tmpControl.DSP)  g_dspState.DSPControl.DSP  = 0;
+			if (tmpControl.AID)  g_dspState.AID  = 0;
+			if (tmpControl.ARAM) g_dspState.ARAM = 0;
+			if (tmpControl.DSP)  g_dspState.DSP  = 0;
 
 			// unknown
-			g_dspState.DSPControl.DSPInitCode = tmpControl.DSPInitCode;
-			g_dspState.DSPControl.pad  = tmpControl.pad;
-			if (g_dspState.DSPControl.pad != 0)
+			g_dspState.DSPInitCode = tmpControl.DSPInitCode;
+			g_dspState.pad  = tmpControl.pad;
+			if (g_dspState.pad != 0)
 			{
-				PanicAlert("DSPInterface (w) g_dspState.DSPControl (CC00500A) gets a value with junk in the padding %08x", val);
+				PanicAlert("DSPInterface (w) g_dspState (CC00500A) gets a value with junk in the padding %08x", val);
 			}
 
 			UpdateInterrupts();
@@ -459,7 +449,7 @@ static void UpdateInterrupts()
 	// to the left of it. By doing:
 	// (DSP_CONTROL>>1) & DSP_CONTROL & MASK_OF_ALL_INTERRUPT_BITS
 	// We can check if any of the interrupts are enabled and active, all at once.
-	bool ints_set = (((g_dspState.DSPControl.Hex >> 1) & g_dspState.DSPControl.Hex & (INT_DSP | INT_ARAM | INT_AID)) != 0);
+	bool ints_set = (((g_dspState.Hex >> 1) & g_dspState.Hex & (INT_DSP | INT_ARAM | INT_AID)) != 0);
 
 	ProcessorInterface::SetInterrupt(ProcessorInterface::INT_CAUSE_DSP, ints_set);
 }
@@ -469,7 +459,7 @@ static void GenerateDSPInterrupt(u64 DSPIntType, int cyclesLate)
 	// The INT_* enumeration members have values that reflect their bit positions in
 	// DSP_CONTROL - we mask by (INT_DSP | INT_ARAM | INT_AID) just to ensure people
 	// don't call this with bogus values.
-	g_dspState.DSPControl.Hex |= (DSPIntType & (INT_DSP | INT_ARAM | INT_AID));
+	g_dspState.Hex |= (DSPIntType & (INT_DSP | INT_ARAM | INT_AID));
 
 	UpdateInterrupts();
 }
@@ -536,7 +526,7 @@ void UpdateAudioDMA()
 
 static void Do_ARAM_DMA()
 {
-	g_dspState.DSPControl.DMAState = 1;
+	g_dspState.DMAState = 1;
 
 	// ARAM DMA transfer rate has been measured on real hw
 	int ticksToTransfer = (g_arDMA.Cnt.count / 32) * 246;
@@ -678,7 +668,7 @@ u8 *GetARAMPtr()
 
 u64 DMAInProgress()
 {
-	if (g_dspState.DSPControl.DMAState == 1)
+	if (g_dspState.DMAState == 1)
 	{
 		return ((u64)last_mmaddr << 32 | (last_mmaddr + last_aram_dma_count));
 	}


### PR DESCRIPTION
This was a struct with exactly one element, and
an overloaded constructor which matches the construtor
of this element. So there is no need for this stacked
structur.