### PR TITLE
[ARMv7] Extend the life of the JIT Recompiler.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm32/Jit.cpp
@@ -40,6 +40,13 @@ void JitArm::Init()
 	code_block.m_fpa = &js.fpa;
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
 	InitBackpatch();
+
+	// Disable all loadstores
+	// Ever since the MMU has been optimized for x86, loadstores on ARMv7 have been knackered
+	// XXX: Investigate exactly why these are broken
+	SConfig::GetInstance().m_LocalCoreStartupParameter.bJITLoadStoreOff = true;
+	SConfig::GetInstance().m_LocalCoreStartupParameter.bJITLoadStoreFloatingOff = true;
+	SConfig::GetInstance().m_LocalCoreStartupParameter.bJITLoadStorePairedOff= true;
 }
 
 void JitArm::ClearCache()


### PR DESCRIPTION
Until loadstores are fully investigated, let's artificially extend the life of it by disabling all of them.
These instructions break in a very terrible way and eventually all loadstores end up attempting to access memory region (u32)-1.
Disable until someone has enough time to investigate further.