### PR TITLE
Common: Fix IsTriviallyCopyable macro for GCC 5

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -29,7 +29,7 @@
 #include "Common/Flag.h"
 
 // ewww
-#if _LIBCPP_VERSION
+#if _LIBCPP_VERSION || __GNUC__ >= 5
 #define IsTriviallyCopyable(T) std::is_trivially_copyable<typename std::remove_volatile<T>::type>::value
 #elif __GNUC__
 #define IsTriviallyCopyable(T) std::has_trivial_copy_constructor<T>::value


### PR DESCRIPTION
Based on @quarthex patch in PR #2440