### PR TITLE
PixelEngine: Replace volatile usages with atomics

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -66,7 +66,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 43;	// Last changed in PR 2232
+static const u32 STATE_VERSION = 44; // Last changed in PR 2464
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -5,6 +5,7 @@
 
 // http://www.nvidia.com/object/General_FAQ.html#t6 !!!!!
 
+#include <atomic>
 
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
@@ -99,14 +100,11 @@ static UPEAlphaReadReg     m_AlphaRead;
 static UPECtrlReg          m_Control;
 //static u16                 m_Token; // token value most recently encountered
 
-static volatile u32 g_bSignalTokenInterrupt;
-static volatile u32 g_bSignalFinishInterrupt;
+static std::atomic<u32> s_signal_token_interrupt;
+static std::atomic<u32> s_signal_finish_interrupt;
 
 static int et_SetTokenOnMainThread;
 static int et_SetFinishOnMainThread;
-
-static volatile u32 interruptSetToken = 0;
-static volatile u32 interruptSetFinish = 0;
 
 enum
 {
@@ -123,10 +121,8 @@ void DoState(PointerWrap &p)
 	p.Do(m_AlphaRead);
 	p.DoPOD(m_Control);
 
-	p.Do(g_bSignalTokenInterrupt);
-	p.Do(g_bSignalFinishInterrupt);
-	p.Do(interruptSetToken);
-	p.Do(interruptSetFinish);
+	p.Do(s_signal_token_interrupt);
+	p.Do(s_signal_finish_interrupt);
 }
 
 void UpdateInterrupts();
@@ -144,10 +140,8 @@ void Init()
 	m_AlphaModeConf.Hex = 0;
 	m_AlphaRead.Hex = 0;
 
-	g_bSignalTokenInterrupt = 0;
-	g_bSignalFinishInterrupt = 0;
-	interruptSetToken = 0;
-	interruptSetFinish = 0;
+	s_signal_token_interrupt.store(0);
+	s_signal_finish_interrupt.store(0);
 
 	et_SetTokenOnMainThread = CoreTiming::RegisterEvent("SetToken", SetToken_OnMainThread);
 	et_SetFinishOnMainThread = CoreTiming::RegisterEvent("SetFinish", SetFinish_OnMainThread);
@@ -209,8 +203,11 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 		MMIO::ComplexWrite<u16>([](u32, u16 val) {
 			UPECtrlReg tmpCtrl(val);
 
-			if (tmpCtrl.PEToken)  g_bSignalTokenInterrupt = 0;
-			if (tmpCtrl.PEFinish) g_bSignalFinishInterrupt = 0;
+			if (tmpCtrl.PEToken)
+				s_signal_token_interrupt.store(0);
+
+			if (tmpCtrl.PEFinish)
+				s_signal_finish_interrupt.store(0);
 
 			m_Control.PETokenEnable  = tmpCtrl.PETokenEnable;
 			m_Control.PEFinishEnable = tmpCtrl.PEFinishEnable;
@@ -244,22 +241,20 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 void UpdateInterrupts()
 {
 	// check if there is a token-interrupt
-	UpdateTokenInterrupt((g_bSignalTokenInterrupt & m_Control.PETokenEnable));
+	UpdateTokenInterrupt((s_signal_token_interrupt.load() & m_Control.PETokenEnable) != 0);
 
 	// check if there is a finish-interrupt
-	UpdateFinishInterrupt((g_bSignalFinishInterrupt & m_Control.PEFinishEnable));
+	UpdateFinishInterrupt((s_signal_finish_interrupt.load() & m_Control.PEFinishEnable) != 0);
 }
 
 void UpdateTokenInterrupt(bool active)
 {
 	ProcessorInterface::SetInterrupt(INT_CAUSE_PE_TOKEN, active);
-	Common::AtomicStore(interruptSetToken, active ? 1 : 0);
 }
 
 void UpdateFinishInterrupt(bool active)
 {
 	ProcessorInterface::SetInterrupt(INT_CAUSE_PE_FINISH, active);
-	Common::AtomicStore(interruptSetFinish, active ? 1 : 0);
 }
 
 // TODO(mb2): Refactor SetTokenINT_OnMainThread(u64 userdata, int cyclesLate).
@@ -276,7 +271,7 @@ void SetToken_OnMainThread(u64 userdata, int cyclesLate)
 	INFO_LOG(PIXELENGINE, "VIDEO Backend raises INT_CAUSE_PE_TOKEN (btw, token: %04x)", CommandProcessor::fifo.PEToken);
 	if (userdata >> 16)
 	{
-		Common::AtomicStore(*(volatile u32*)&g_bSignalTokenInterrupt, 1);
+		s_signal_token_interrupt.store(1);
 		UpdateInterrupts();
 	}
 	CommandProcessor::interruptTokenWaiting = false;
@@ -284,7 +279,7 @@ void SetToken_OnMainThread(u64 userdata, int cyclesLate)
 
 void SetFinish_OnMainThread(u64 userdata, int cyclesLate)
 {
-	Common::AtomicStore(*(volatile u32*)&g_bSignalFinishInterrupt, 1);
+	s_signal_finish_interrupt.store(1);
 	UpdateInterrupts();
 	CommandProcessor::interruptFinishWaiting = false;
 }
@@ -295,7 +290,7 @@ void SetToken(const u16 _token, const int _bSetTokenAcknowledge)
 {
 	if (_bSetTokenAcknowledge) // set token INT
 	{
-		Common::AtomicStore(*(volatile u32*)&g_bSignalTokenInterrupt, 1);
+		s_signal_token_interrupt.store(1);
 	}
 
 	CommandProcessor::interruptTokenWaiting = true;


### PR DESCRIPTION
Also removes two unused volatile variables.