### PR TITLE
Fix game list name encoding error caused by 4.0-6419 (d7900b4)

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -387,7 +387,7 @@ void CGameListCtrl::InsertItemInReportView(long _Index)
 	// Set the game's banner in the second column
 	SetItemColumnImage(_Index, COLUMN_BANNER, ImageIndex);
 
-	wxString name = rISOFile.GetName();
+	wxString name = StrToWxStr(rISOFile.GetName());
 
 	std::ifstream titlestxt;
 	OpenFStream(titlestxt, File::GetUserPath(D_LOAD_IDX) + "titles.txt", std::ios::in);


### PR DESCRIPTION
The UTF-8 std::strings were being interpreted as the default encoding.