### PR TITLE
AudioCommon: Remove lock on Pause state

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -121,25 +121,6 @@ namespace AudioCommon
 		return backends;
 	}
 
-	void PauseAndLock(bool doLock, bool unpauseOnUnlock)
-	{
-		if (g_sound_stream)
-		{
-			// audio typically doesn't maintain its own "paused" state
-			// (that's already handled by the CPU and whatever else being paused)
-			// so it should be good enough to only lock/unlock here.
-			CMixer* pMixer = g_sound_stream->GetMixer();
-			if (pMixer)
-			{
-				std::mutex& csMixing = pMixer->MixerCritical();
-				if (doLock)
-					csMixing.lock();
-				else
-					csMixing.unlock();
-			}
-		}
-	}
-
 	void UpdateSoundStream()
 	{
 		if (g_sound_stream)

--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -17,7 +17,6 @@ namespace AudioCommon
 	SoundStream* InitSoundStream();
 	void ShutdownSoundStream();
 	std::vector<std::string> GetSoundBackends();
-	void PauseAndLock(bool doLock, bool unpauseOnUnlock = true);
 	void UpdateSoundStream();
 	void ClearAudioBuffer(bool mute);
 	void SendAIBuffer(short* samples, unsigned int num_samples);

--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -108,8 +108,6 @@ unsigned int CMixer::Mix(short* samples, unsigned int num_samples, bool consider
 	if (!samples)
 		return 0;
 
-	std::lock_guard<std::mutex> lk(m_csMixing);
-
 	memset(samples, 0, num_samples * 2 * sizeof(short));
 
 	if (PowerPC::GetState() != PowerPC::CPU_RUNNING)

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -108,8 +108,6 @@ public:
 		}
 	}
 
-	std::mutex& MixerCritical() { return m_csMixing; }
-
 	float GetCurrentSpeed() const { return m_speed.load(); }
 	void UpdateSpeed(float val) { m_speed.store(val); }
 
@@ -154,8 +152,6 @@ protected:
 
 	bool m_log_dtk_audio;
 	bool m_log_dsp_audio;
-
-	std::mutex m_csMixing;
 
 	std::atomic<float> m_speed; // Current rate of the emulation (1.0 = 100% speed)
 };

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -690,7 +690,6 @@ bool PauseAndLock(bool doLock, bool unpauseOnUnlock)
 	ExpansionInterface::PauseAndLock(doLock, unpauseOnUnlock);
 
 	// audio has to come after CPU, because CPU thread can wait for audio thread (m_throttle).
-	AudioCommon::PauseAndLock(doLock, unpauseOnUnlock);
 	DSP::GetDSPEmulator()->PauseAndLock(doLock, unpauseOnUnlock);
 
 	// video has to come after CPU, because CPU thread can wait for video thread (s_efbAccessRequested).


### PR DESCRIPTION
We had to lock audiocommon with the old asynchron HLE audio emulation,
now our Mixer is just a plain FIFO which may underrun.
Of course, this will stutter, but underruning the audio backend is likely worse.