### PR TITLE
Fix invalid pointer errors in Burnout 2.

### DIFF
--- a/Source/Core/VideoBackends/Software/CPMemLoader.cpp
+++ b/Source/Core/VideoBackends/Software/CPMemLoader.cpp
@@ -48,7 +48,6 @@ void SWLoadCPReg(u32 sub_cmd, u32 value)
 	// Pointers to vertex arrays in GC RAM
 	case 0xA0:
 		g_main_cp_state.array_bases[sub_cmd & 0xF] = value;
-		cached_arraybases[sub_cmd & 0xF] = Memory::GetPointer(value);
 		break;
 
 	case 0xB0:

--- a/Source/Core/VideoBackends/Software/CPMemLoader.cpp
+++ b/Source/Core/VideoBackends/Software/CPMemLoader.cpp
@@ -23,11 +23,13 @@ void SWLoadCPReg(u32 sub_cmd, u32 value)
 	case 0x50:
 		g_main_cp_state.vtx_desc.Hex &= ~0x1FFFF;  // keep the Upper bits
 		g_main_cp_state.vtx_desc.Hex |= value;
+		g_main_cp_state.bases_dirty = true;
 		break;
 
 	case 0x60:
 		g_main_cp_state.vtx_desc.Hex &= 0x1FFFF;  // keep the lower 17Bits
 		g_main_cp_state.vtx_desc.Hex |= (u64)value << 17;
+		g_main_cp_state.bases_dirty = true;
 		break;
 
 	case 0x70:
@@ -48,6 +50,7 @@ void SWLoadCPReg(u32 sub_cmd, u32 value)
 	// Pointers to vertex arrays in GC RAM
 	case 0xA0:
 		g_main_cp_state.array_bases[sub_cmd & 0xF] = value;
+		g_main_cp_state.bases_dirty = true;
 		break;
 
 	case 0xB0:

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -16,7 +16,9 @@
 #include "VideoBackends/Software/XFMemLoader.h"
 
 #include "VideoCommon/VertexLoaderBase.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderUtils.h"
+
 
 SWVertexLoader::SWVertexLoader() :
 	m_VertexSize(0)
@@ -175,6 +177,8 @@ void SWVertexLoader::LoadVertex()
 
 	// reserve memory for the destination of the vertex loader
 	m_LoadedVertices.resize(vdec.stride + 4);
+
+	VertexLoaderManager::UpdateVertexArrayPointers();
 
 	// convert the vertex from the gc format to the videocommon (hardware optimized) format
 	u8* old = g_video_buffer_read_ptr;

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -7,8 +7,6 @@
 #include "VideoCommon/CPMemory.h"
 
 // CP state
-u8 *cached_arraybases[16];
-
 CPState g_main_cp_state;
 CPState g_preprocess_cp_state;
 

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -22,7 +22,10 @@ void DoCPState(PointerWrap& p)
 	p.DoArray(g_main_cp_state.vtx_attr, 8);
 	p.DoMarker("CP Memory");
 	if (p.mode == PointerWrap::MODE_READ)
+	{
 		CopyPreprocessCPStateFromMain();
+		g_main_cp_state.bases_dirty = true;
+	}
 }
 
 void CopyPreprocessCPStateFromMain()

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -88,6 +88,12 @@ union TVtxDesc
 	{
 		u32 Hex0, Hex1;
 	};
+
+	// Easily index into the Position..Tex7Coord fields.
+	u32 GetVertexArrayStatus(int idx)
+	{
+		return (Hex >> (9 + idx * 2)) & 0x3;
+	}
 };
 
 union UVAT_group0
@@ -239,6 +245,7 @@ class VertexLoaderBase;
 // STATE_TO_SAVE
 struct CPState final
 {
+	// Only 12 of these arrays are used.
 	u32 array_bases[16];
 	u32 array_strides[16];
 	TMatrixIndexA matrix_index_a;

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -255,6 +255,7 @@ struct CPState final
 
 	// Attributes that actually belong to VertexLoaderManager:
 	BitSet32 attr_dirty;
+	bool bases_dirty;
 	VertexLoaderBase* vertex_loaders[8];
 };
 

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -245,7 +245,6 @@ class VertexLoaderBase;
 // STATE_TO_SAVE
 struct CPState final
 {
-	// Only 12 of these arrays are used.
 	u32 array_bases[16];
 	u32 array_strides[16];
 	TMatrixIndexA matrix_index_a;
@@ -268,7 +267,6 @@ extern void CopyPreprocessCPStateFromMain();
 extern CPState g_main_cp_state;
 extern CPState g_preprocess_cp_state;
 
-extern u8 *cached_arraybases[16];
 
 // Might move this into its own file later.
 void LoadCPReg(u32 SubCmd, u32 Value, bool is_preprocess = false);

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -212,7 +212,6 @@ void VideoBackendHardware::DoState(PointerWrap& p)
 	if (p.GetMode() == PointerWrap::MODE_READ)
 	{
 		m_invalid = true;
-		RecomputeCachedArraybases();
 
 		// Clear all caches that touch RAM
 		// (? these don't appear to touch any emulation state that gets saved. moved to on load only.)

--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "VideoCommon/VertexLoaderARM64.h"
+#include "VideoCommon/VertexLoaderManager.h"
 
 using namespace Arm64Gen;
 
@@ -331,7 +332,7 @@ void VertexLoaderARM64::GenerateVertexLoader()
 	MOV(saved_count, count_reg);
 
 	MOVI2R(stride_reg, (u64)&g_main_cp_state.array_strides);
-	MOVI2R(arraybase_reg, (u64)&cached_arraybases);
+	MOVI2R(arraybase_reg, (u64)&VertexLoaderManager::cached_arraybases);
 	MOVI2R(scale_reg, (u64)&scale_factors);
 
 	const u8* loop_start = GetCodePtr();

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -26,4 +26,4 @@ namespace VertexLoaderManager
 	NativeVertexFormat* GetCurrentVertexFormat();
 }
 
-void RecomputeCachedArraybases();
+void ComputeCachedArrayBases();

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -24,6 +24,9 @@ namespace VertexLoaderManager
 	void AppendListToString(std::string *dest);
 
 	NativeVertexFormat* GetCurrentVertexFormat();
+
+	// Resolved pointers to array bases. Used by vertex loaders.
+	extern u8 *cached_arraybases[12];
+	void UpdateVertexArrayPointers();
 }
 
-void ComputeCachedArrayBases();

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -7,6 +7,7 @@
 #include "Common/Intrinsics.h"
 #include "Common/JitRegister.h"
 #include "Common/x64ABI.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderX64.h"
 
 using namespace Gen;
@@ -58,7 +59,7 @@ OpArg VertexLoaderX64::GetVertexAddr(int array, u64 attribute)
 		}
 		// TODO: Move cached_arraybases into CPState and use MDisp() relative to a constant register loaded with &g_main_cp_state.
 		IMUL(32, scratch1, M(&g_main_cp_state.array_strides[array]));
-		MOV(64, R(scratch2), M(&cached_arraybases[array]));
+		MOV(64, R(scratch2), M(&VertexLoaderManager::cached_arraybases[array]));
 		return MRegSum(scratch1, scratch2);
 	}
 	else

--- a/Source/Core/VideoCommon/VertexLoader_Color.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Color.cpp
@@ -6,6 +6,7 @@
 
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoader_Color.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoCommon.h"
 
@@ -100,7 +101,7 @@ template <typename I>
 void Color_ReadIndex_16b_565(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
-	u16 val = Common::swap16(*(const u16 *)(cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex])));
+	u16 val = Common::swap16(*(const u16 *)(VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex])));
 	_SetCol565(loader, val);
 }
 
@@ -108,7 +109,7 @@ template <typename I>
 void Color_ReadIndex_24b_888(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
-	const u8 *iAddress = cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+	const u8 *iAddress = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
 	_SetCol(loader, _Read24(iAddress));
 }
 
@@ -116,7 +117,7 @@ template <typename I>
 void Color_ReadIndex_32b_888x(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
-	const u8 *iAddress = cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+	const u8 *iAddress = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
 	_SetCol(loader, _Read24(iAddress));
 }
 
@@ -124,7 +125,7 @@ template <typename I>
 void Color_ReadIndex_16b_4444(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
-	u16 val = *(const u16 *)(cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]));
+	u16 val = *(const u16 *)(VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]));
 	_SetCol4444(loader, val);
 }
 
@@ -132,7 +133,7 @@ template <typename I>
 void Color_ReadIndex_24b_6666(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
-	const u8* pData = cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]) - 1;
+	const u8* pData = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]) - 1;
 	u32 val = Common::swap32(pData);
 	_SetCol6666(loader, val);
 }
@@ -141,7 +142,7 @@ template <typename I>
 void Color_ReadIndex_32b_8888(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
-	const u8 *iAddress = cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+	const u8 *iAddress = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
 	_SetCol(loader, _Read32(iAddress));
 }
 

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -8,6 +8,7 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoader_Normal.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoCommon.h"
 
@@ -71,7 +72,7 @@ __forceinline void Normal_Index_Offset()
 	static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
 
 	auto const index = DataRead<I>();
-	auto const data = reinterpret_cast<const T*>(cached_arraybases[ARRAY_NORMAL]
+	auto const data = reinterpret_cast<const T*>(VertexLoaderManager::cached_arraybases[ARRAY_NORMAL]
 	                + (index * g_main_cp_state.array_strides[ARRAY_NORMAL]) + sizeof(T) * 3 * Offset);
 	ReadIndirect<T, N * 3>(data);
 }

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -7,6 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoader_Position.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoCommon.h"
 
@@ -46,7 +47,7 @@ void LOADERDECL Pos_ReadIndex(VertexLoader* loader)
 
 	auto const index = DataRead<I>();
 	loader->m_vertexSkip = index == std::numeric_limits<I>::max();
-	auto const data = reinterpret_cast<const T*>(cached_arraybases[ARRAY_POSITION] + (index * g_main_cp_state.array_strides[ARRAY_POSITION]));
+	auto const data = reinterpret_cast<const T*>(VertexLoaderManager::cached_arraybases[ARRAY_POSITION] + (index * g_main_cp_state.array_strides[ARRAY_POSITION]));
 	auto const scale = loader->m_posScale;
 	DataReader dst(g_vertex_manager_write_ptr, nullptr);
 

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -7,6 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoader_TextCoord.h"
+#include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoCommon.h"
 
@@ -67,7 +68,7 @@ void LOADERDECL TexCoord_ReadIndex(VertexLoader* loader)
 	static_assert(std::is_unsigned<I>::value, "Only unsigned I is sane!");
 
 	auto const index = DataRead<I>();
-	auto const data = reinterpret_cast<const T*>(cached_arraybases[ARRAY_TEXCOORD0 + loader->m_tcIndex]
+	auto const data = reinterpret_cast<const T*>(VertexLoaderManager::cached_arraybases[ARRAY_TEXCOORD0 + loader->m_tcIndex]
 	                + (index * g_main_cp_state.array_strides[ARRAY_TEXCOORD0 + loader->m_tcIndex]));
 	auto const scale = loader->m_tcScale[loader->m_tcIndex];
 	DataReader dst(g_vertex_manager_write_ptr, nullptr);

--- a/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
+++ b/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
@@ -16,6 +16,7 @@
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/VertexLoaderBase.h"
+#include "VideoCommon/VertexLoaderManager.h"
 
 TEST(VertexLoaderUID, UniqueEnough)
 {
@@ -151,7 +152,7 @@ TEST_P(VertexLoaderParamTest, PositionAll)
 				Input<u8>(i);
 			else
 				Input<u16>(i);
-		cached_arraybases[ARRAY_POSITION] = m_src.GetPointer();
+		VertexLoaderManager::cached_arraybases[ARRAY_POSITION] = m_src.GetPointer();
 		g_main_cp_state.array_strides[ARRAY_POSITION] = elements * elem_size;
 	}
 	CreateAndCheckSizes(input_size, elements * sizeof(float));
@@ -192,7 +193,7 @@ TEST_F(VertexLoaderTest, PositionIndex16FloatXY)
 	m_vtx_attr.g0.PosFormat = FORMAT_FLOAT;
 	CreateAndCheckSizes(sizeof(u16), 2 * sizeof(float));
 	Input<u16>(1); Input<u16>(0);
-	cached_arraybases[ARRAY_POSITION] = m_src.GetPointer();
+	VertexLoaderManager::cached_arraybases[ARRAY_POSITION] = m_src.GetPointer();
 	g_main_cp_state.array_strides[ARRAY_POSITION] = sizeof(float); // ;)
 	Input(1.f); Input(2.f); Input(3.f);
 	RunVertices(2);
@@ -297,9 +298,9 @@ TEST_F(VertexLoaderTest, LargeFloatVertexSpeed)
 
 	CreateAndCheckSizes(33, 156);
 
-	for (int i = 0; i < 16; i++)
+	for (int i = 0; i < 12; i++)
 	{
-		cached_arraybases[i] = m_src.GetPointer();
+		VertexLoaderManager::cached_arraybases[i] = m_src.GetPointer();
 		g_main_cp_state.array_strides[i] = 129;
 	}
 


### PR DESCRIPTION
Yet another story of games loading weird shit into registers.

For some reason, Burnout 2 would (in rare situations) load invalid addresses into cp_state.array_bases. What would the real hardware do in this situation? Who knows, Burnout 2 doesn't actually enable the vertex array with the invalid address so nothing kinky happens.

But dolphin tries to optimise things and starts using the address as soon as it is loaded into memory. This causes GetPointer (which is now much more vocal) to throw an error.

The Fix:  We don't call GetPointer until we are sure the vertex array has been enabled.