### PR TITLE
x64Emitter: Pass some OpArg parameters by const reference.

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -76,17 +76,17 @@ enum NormalSSEOps
 };
 
 
-void XEmitter::SetCodePtr(u8 *ptr)
+void XEmitter::SetCodePtr(u8* ptr)
 {
 	code = ptr;
 }
 
-const u8 *XEmitter::GetCodePtr() const
+const u8* XEmitter::GetCodePtr() const
 {
 	return code;
 }
 
-u8 *XEmitter::GetWritableCodePtr()
+u8* XEmitter::GetWritableCodePtr()
 {
 	return code;
 }
@@ -97,7 +97,7 @@ void XEmitter::ReserveCodeSpace(int bytes)
 		*code++ = 0xCC;
 }
 
-const u8 *XEmitter::AlignCode4()
+const u8* XEmitter::AlignCode4()
 {
 	int c = int((u64)code & 3);
 	if (c)
@@ -105,7 +105,7 @@ const u8 *XEmitter::AlignCode4()
 	return code;
 }
 
-const u8 *XEmitter::AlignCode16()
+const u8* XEmitter::AlignCode16()
 {
 	int c = int((u64)code & 15);
 	if (c)
@@ -113,7 +113,7 @@ const u8 *XEmitter::AlignCode16()
 	return code;
 }
 
-const u8 *XEmitter::AlignCodePage()
+const u8* XEmitter::AlignCodePage()
 {
 	int c = int((u64)code & 4095);
 	if (c)
@@ -139,7 +139,7 @@ void XEmitter::WriteSIB(int scale, int index, int base)
 	Write8((u8)((scale << 6) | ((index & 7) << 3) | (base & 7)));
 }
 
-void OpArg::WriteREX(XEmitter *emit, int opBits, int bits, int customOp) const
+void OpArg::WriteREX(XEmitter* emit, int opBits, int bits, int customOp) const
 {
 	if (customOp == -1)       customOp = operandReg;
 	u8 op = 0x40;
@@ -189,7 +189,7 @@ void OpArg::WriteVEX(XEmitter* emit, X64Reg regOp1, X64Reg regOp2, int L, int pp
 	}
 }
 
-void OpArg::WriteRest(XEmitter *emit, int extraBytes, X64Reg _operandReg,
+void OpArg::WriteRest(XEmitter* emit, int extraBytes, X64Reg _operandReg,
 	bool warn_64bit_offset) const
 {
 	if (_operandReg == INVALID_REG)
@@ -335,7 +335,7 @@ void XEmitter::Rex(int w, int r, int x, int b)
 		Write8(rx);
 }
 
-void XEmitter::JMP(const u8 *addr, bool force5Bytes)
+void XEmitter::JMP(const u8* addr, bool force5Bytes)
 {
 	u64 fn = (u64)addr;
 	if (!force5Bytes)
@@ -359,7 +359,7 @@ void XEmitter::JMP(const u8 *addr, bool force5Bytes)
 	}
 }
 
-void XEmitter::JMPptr(const OpArg &arg2)
+void XEmitter::JMPptr(const OpArg& arg2)
 {
 	OpArg arg = arg2;
 	if (arg.IsImm()) _assert_msg_(DYNA_REC, 0, "JMPptr - Imm argument");
@@ -386,7 +386,7 @@ void XEmitter::CALLptr(OpArg arg)
 	arg.WriteRest(this);
 }
 
-void XEmitter::CALL(const void *fnptr)
+void XEmitter::CALL(const void* fnptr)
 {
 	u64 distance = u64(fnptr) - (u64(code) + 5);
 	_assert_msg_(DYNA_REC,
@@ -457,7 +457,7 @@ void XEmitter::J_CC(CCFlags conditionCode, const u8* addr)
 	}
 }
 
-void XEmitter::SetJumpTarget(const FixupBranch &branch)
+void XEmitter::SetJumpTarget(const FixupBranch& branch)
 {
 	if (branch.type == 0)
 	{
@@ -628,7 +628,7 @@ void XEmitter::CBW(int bits)
 void XEmitter::PUSH(X64Reg reg) {WriteSimple1Byte(32, 0x50, reg);}
 void XEmitter::POP(X64Reg reg)  {WriteSimple1Byte(32, 0x58, reg);}
 
-void XEmitter::PUSH(int bits, const OpArg &reg)
+void XEmitter::PUSH(int bits, const OpArg& reg)
 {
 	if (reg.IsSimpleReg())
 		PUSH(reg.GetSimpleReg());
@@ -664,7 +664,7 @@ void XEmitter::PUSH(int bits, const OpArg &reg)
 	}
 }
 
-void XEmitter::POP(int /*bits*/, const OpArg &reg)
+void XEmitter::POP(int /*bits*/, const OpArg& reg)
 {
 	if (reg.IsSimpleReg())
 		POP(reg.GetSimpleReg());
@@ -925,7 +925,7 @@ void XEmitter::LEA(int bits, X64Reg dest, OpArg src)
 }
 
 //shift can be either imm8 or cl
-void XEmitter::WriteShift(int bits, OpArg dest, OpArg &shift, int ext)
+void XEmitter::WriteShift(int bits, OpArg dest, OpArg& shift, int ext)
 {
 	CheckFlags();
 	bool writeImm = false;
@@ -975,7 +975,7 @@ void XEmitter::SHR(int bits, OpArg dest, OpArg shift) {WriteShift(bits, dest, sh
 void XEmitter::SAR(int bits, OpArg dest, OpArg shift) {WriteShift(bits, dest, shift, 7);}
 
 // index can be either imm8 or register, don't use memory destination because it's slow
-void XEmitter::WriteBitTest(int bits, OpArg &dest, OpArg &index, int ext)
+void XEmitter::WriteBitTest(int bits, OpArg& dest, OpArg& index, int ext)
 {
 	CheckFlags();
 	if (dest.IsImm())
@@ -1074,7 +1074,7 @@ void XEmitter::SHLD(int bits, OpArg dest, OpArg src, OpArg shift)
 	}
 }
 
-void OpArg::WriteSingleByteOp(XEmitter *emit, u8 op, X64Reg _operandReg, int bits)
+void OpArg::WriteSingleByteOp(XEmitter* emit, u8 op, X64Reg _operandReg, int bits)
 {
 	if (bits == 16)
 		emit->Write8(0x66);
@@ -1086,7 +1086,7 @@ void OpArg::WriteSingleByteOp(XEmitter *emit, u8 op, X64Reg _operandReg, int bit
 }
 
 //operand can either be immediate or register
-void OpArg::WriteNormalOp(XEmitter *emit, bool toRM, NormalOp op, const OpArg &operand, int bits) const
+void OpArg::WriteNormalOp(XEmitter* emit, bool toRM, NormalOp op, const OpArg& operand, int bits) const
 {
 	X64Reg _operandReg;
 	if (IsImm())
@@ -1232,7 +1232,7 @@ void OpArg::WriteNormalOp(XEmitter *emit, bool toRM, NormalOp op, const OpArg &o
 	}
 }
 
-void XEmitter::WriteNormalOp(int bits, NormalOp op, const OpArg &a1, const OpArg &a2)
+void XEmitter::WriteNormalOp(int bits, NormalOp op, const OpArg& a1, const OpArg& a2)
 {
 	if (a1.IsImm())
 	{
@@ -1258,23 +1258,23 @@ void XEmitter::WriteNormalOp(int bits, NormalOp op, const OpArg &a1, const OpArg
 	}
 }
 
-void XEmitter::ADD (int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(bits, nrmADD, a1, a2);}
-void XEmitter::ADC (int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(bits, nrmADC, a1, a2);}
-void XEmitter::SUB (int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(bits, nrmSUB, a1, a2);}
-void XEmitter::SBB (int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(bits, nrmSBB, a1, a2);}
-void XEmitter::AND (int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(bits, nrmAND, a1, a2);}
-void XEmitter::OR  (int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(bits, nrmOR , a1, a2);}
-void XEmitter::XOR (int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(bits, nrmXOR, a1, a2);}
-void XEmitter::MOV (int bits, const OpArg &a1, const OpArg &a2)
+void XEmitter::ADD (int bits, const OpArg& a1, const OpArg& a2) {CheckFlags(); WriteNormalOp(bits, nrmADD, a1, a2);}
+void XEmitter::ADC (int bits, const OpArg& a1, const OpArg& a2) {CheckFlags(); WriteNormalOp(bits, nrmADC, a1, a2);}
+void XEmitter::SUB (int bits, const OpArg& a1, const OpArg& a2) {CheckFlags(); WriteNormalOp(bits, nrmSUB, a1, a2);}
+void XEmitter::SBB (int bits, const OpArg& a1, const OpArg& a2) {CheckFlags(); WriteNormalOp(bits, nrmSBB, a1, a2);}
+void XEmitter::AND (int bits, const OpArg& a1, const OpArg& a2) {CheckFlags(); WriteNormalOp(bits, nrmAND, a1, a2);}
+void XEmitter::OR  (int bits, const OpArg& a1, const OpArg& a2) {CheckFlags(); WriteNormalOp(bits, nrmOR , a1, a2);}
+void XEmitter::XOR (int bits, const OpArg& a1, const OpArg& a2) {CheckFlags(); WriteNormalOp(bits, nrmXOR, a1, a2);}
+void XEmitter::MOV (int bits, const OpArg& a1, const OpArg& a2)
 {
 	if (a1.IsSimpleReg() && a2.IsSimpleReg() && a1.GetSimpleReg() == a2.GetSimpleReg())
 		ERROR_LOG(DYNA_REC, "Redundant MOV @ %p - bug in JIT?", code);
 	WriteNormalOp(bits, nrmMOV, a1, a2);
 }
-void XEmitter::TEST(int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(bits, nrmTEST, a1, a2);}
-void XEmitter::CMP (int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(bits, nrmCMP, a1, a2);}
-void XEmitter::XCHG(int bits, const OpArg &a1, const OpArg &a2) {WriteNormalOp(bits, nrmXCHG, a1, a2);}
-void XEmitter::CMP_or_TEST(int bits, const OpArg &a1, const OpArg &a2)
+void XEmitter::TEST(int bits, const OpArg& a1, const OpArg& a2) {CheckFlags(); WriteNormalOp(bits, nrmTEST, a1, a2);}
+void XEmitter::CMP (int bits, const OpArg& a1, const OpArg& a2) {CheckFlags(); WriteNormalOp(bits, nrmCMP, a1, a2);}
+void XEmitter::XCHG(int bits, const OpArg& a1, const OpArg& a2) {WriteNormalOp(bits, nrmXCHG, a1, a2);}
+void XEmitter::CMP_or_TEST(int bits, const OpArg& a1, const OpArg& a2)
 {
 	CheckFlags();
 	if (a1.IsSimpleReg() && a2.IsImm() && a2.offset == 0) // turn 'CMP reg, 0' into shorter 'TEST reg, reg'
@@ -1460,8 +1460,8 @@ void XEmitter::WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg 
 	WriteBMIOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 
-void XEmitter::MOVD_xmm(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x6E, dest, arg, 0);}
-void XEmitter::MOVD_xmm(const OpArg &arg, X64Reg src) {WriteSSEOp(0x66, 0x7E, src, arg, 0);}
+void XEmitter::MOVD_xmm(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x6E, dest, arg, 0);}
+void XEmitter::MOVD_xmm(const OpArg& arg, X64Reg src) {WriteSSEOp(0x66, 0x7E, src, arg, 0);}
 
 void XEmitter::MOVQ_xmm(X64Reg dest, OpArg arg)
 {
@@ -1658,10 +1658,10 @@ void XEmitter::PACKSSDW(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x6B, dest, ar
 void XEmitter::PACKSSWB(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x63, dest, arg);}
 void XEmitter::PACKUSWB(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x67, dest, arg);}
 
-void XEmitter::PUNPCKLBW(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x60, dest, arg);}
-void XEmitter::PUNPCKLWD(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x61, dest, arg);}
-void XEmitter::PUNPCKLDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x62, dest, arg);}
-void XEmitter::PUNPCKLQDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x6C, dest, arg);}
+void XEmitter::PUNPCKLBW(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x60, dest, arg);}
+void XEmitter::PUNPCKLWD(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x61, dest, arg);}
+void XEmitter::PUNPCKLDQ(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x62, dest, arg);}
+void XEmitter::PUNPCKLQDQ(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x6C, dest, arg);}
 
 void XEmitter::PSRLW(X64Reg reg, int shift)
 {

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -752,12 +752,12 @@ void XEmitter::WriteMulDivType(int bits, OpArg src, int ext)
 	src.WriteRest(this);
 }
 
-void XEmitter::MUL(int bits, OpArg src)  {WriteMulDivType(bits, src, 4);}
-void XEmitter::DIV(int bits, OpArg src)  {WriteMulDivType(bits, src, 6);}
-void XEmitter::IMUL(int bits, OpArg src) {WriteMulDivType(bits, src, 5);}
-void XEmitter::IDIV(int bits, OpArg src) {WriteMulDivType(bits, src, 7);}
-void XEmitter::NEG(int bits, OpArg src)  {WriteMulDivType(bits, src, 3);}
-void XEmitter::NOT(int bits, OpArg src)  {WriteMulDivType(bits, src, 2);}
+void XEmitter::MUL(int bits, const OpArg& src)  {WriteMulDivType(bits, src, 4);}
+void XEmitter::DIV(int bits, const OpArg& src)  {WriteMulDivType(bits, src, 6);}
+void XEmitter::IMUL(int bits, const OpArg& src) {WriteMulDivType(bits, src, 5);}
+void XEmitter::IDIV(int bits, const OpArg& src) {WriteMulDivType(bits, src, 7);}
+void XEmitter::NEG(int bits, const OpArg& src)  {WriteMulDivType(bits, src, 3);}
+void XEmitter::NOT(int bits, const OpArg& src)  {WriteMulDivType(bits, src, 2);}
 
 void XEmitter::WriteBitSearchType(int bits, X64Reg dest, OpArg src, u8 byte2, bool rep)
 {
@@ -774,24 +774,24 @@ void XEmitter::WriteBitSearchType(int bits, X64Reg dest, OpArg src, u8 byte2, bo
 	src.WriteRest(this);
 }
 
-void XEmitter::MOVNTI(int bits, OpArg dest, X64Reg src)
+void XEmitter::MOVNTI(int bits, const OpArg& dest, X64Reg src)
 {
 	if (bits <= 16)
 		_assert_msg_(DYNA_REC, 0, "MOVNTI - bits<=16");
 	WriteBitSearchType(bits, src, dest, 0xC3);
 }
 
-void XEmitter::BSF(int bits, X64Reg dest, OpArg src) {WriteBitSearchType(bits,dest,src,0xBC);} //bottom bit to top bit
-void XEmitter::BSR(int bits, X64Reg dest, OpArg src) {WriteBitSearchType(bits,dest,src,0xBD);} //top bit to bottom bit
+void XEmitter::BSF(int bits, X64Reg dest, const OpArg& src) {WriteBitSearchType(bits,dest,src,0xBC);} // Bottom bit to top bit
+void XEmitter::BSR(int bits, X64Reg dest, const OpArg& src) {WriteBitSearchType(bits,dest,src,0xBD);} // Top bit to bottom bit
 
-void XEmitter::TZCNT(int bits, X64Reg dest, OpArg src)
+void XEmitter::TZCNT(int bits, X64Reg dest, const OpArg& src)
 {
 	CheckFlags();
 	if (!cpu_info.bBMI1)
 		PanicAlert("Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
 	WriteBitSearchType(bits, dest, src, 0xBC, true);
 }
-void XEmitter::LZCNT(int bits, X64Reg dest, OpArg src)
+void XEmitter::LZCNT(int bits, X64Reg dest, const OpArg& src)
 {
 	CheckFlags();
 	if (!cpu_info.bLZCNT)
@@ -866,7 +866,7 @@ void XEmitter::MOVZX(int dbits, int sbits, X64Reg dest, OpArg src)
 	src.WriteRest(this);
 }
 
-void XEmitter::WriteMOVBE(int bits, u8 op, X64Reg reg, OpArg arg)
+void XEmitter::WriteMOVBE(int bits, u8 op, X64Reg reg, const OpArg& arg)
 {
 	_assert_msg_(DYNA_REC, cpu_info.bMOVBE, "Generating MOVBE on a system that does not support it.");
 	if (bits == 8)
@@ -925,7 +925,7 @@ void XEmitter::LEA(int bits, X64Reg dest, OpArg src)
 }
 
 //shift can be either imm8 or cl
-void XEmitter::WriteShift(int bits, OpArg dest, OpArg& shift, int ext)
+void XEmitter::WriteShift(int bits, OpArg dest, const OpArg& shift, int ext)
 {
 	CheckFlags();
 	bool writeImm = false;
@@ -966,16 +966,16 @@ void XEmitter::WriteShift(int bits, OpArg dest, OpArg& shift, int ext)
 
 // large rotates and shift are slower on Intel than AMD
 // Intel likes to rotate by 1, and the op is smaller too
-void XEmitter::ROL(int bits, OpArg dest, OpArg shift) {WriteShift(bits, dest, shift, 0);}
-void XEmitter::ROR(int bits, OpArg dest, OpArg shift) {WriteShift(bits, dest, shift, 1);}
-void XEmitter::RCL(int bits, OpArg dest, OpArg shift) {WriteShift(bits, dest, shift, 2);}
-void XEmitter::RCR(int bits, OpArg dest, OpArg shift) {WriteShift(bits, dest, shift, 3);}
-void XEmitter::SHL(int bits, OpArg dest, OpArg shift) {WriteShift(bits, dest, shift, 4);}
-void XEmitter::SHR(int bits, OpArg dest, OpArg shift) {WriteShift(bits, dest, shift, 5);}
-void XEmitter::SAR(int bits, OpArg dest, OpArg shift) {WriteShift(bits, dest, shift, 7);}
+void XEmitter::ROL(int bits, const OpArg& dest, const OpArg& shift) {WriteShift(bits, dest, shift, 0);}
+void XEmitter::ROR(int bits, const OpArg& dest, const OpArg& shift) {WriteShift(bits, dest, shift, 1);}
+void XEmitter::RCL(int bits, const OpArg& dest, const OpArg& shift) {WriteShift(bits, dest, shift, 2);}
+void XEmitter::RCR(int bits, const OpArg& dest, const OpArg& shift) {WriteShift(bits, dest, shift, 3);}
+void XEmitter::SHL(int bits, const OpArg& dest, const OpArg& shift) {WriteShift(bits, dest, shift, 4);}
+void XEmitter::SHR(int bits, const OpArg& dest, const OpArg& shift) {WriteShift(bits, dest, shift, 5);}
+void XEmitter::SAR(int bits, const OpArg& dest, const OpArg& shift) {WriteShift(bits, dest, shift, 7);}
 
 // index can be either imm8 or register, don't use memory destination because it's slow
-void XEmitter::WriteBitTest(int bits, OpArg& dest, OpArg& index, int ext)
+void XEmitter::WriteBitTest(int bits, const OpArg& dest, const OpArg& index, int ext)
 {
 	CheckFlags();
 	if (dest.IsImm())
@@ -1004,13 +1004,13 @@ void XEmitter::WriteBitTest(int bits, OpArg& dest, OpArg& index, int ext)
 	}
 }
 
-void XEmitter::BT(int bits, OpArg dest, OpArg index)  {WriteBitTest(bits, dest, index, 4);}
-void XEmitter::BTS(int bits, OpArg dest, OpArg index) {WriteBitTest(bits, dest, index, 5);}
-void XEmitter::BTR(int bits, OpArg dest, OpArg index) {WriteBitTest(bits, dest, index, 6);}
-void XEmitter::BTC(int bits, OpArg dest, OpArg index) {WriteBitTest(bits, dest, index, 7);}
+void XEmitter::BT(int bits, const OpArg& dest, const OpArg& index)  {WriteBitTest(bits, dest, index, 4);}
+void XEmitter::BTS(int bits, const OpArg& dest, const OpArg& index) {WriteBitTest(bits, dest, index, 5);}
+void XEmitter::BTR(int bits, const OpArg& dest, const OpArg& index) {WriteBitTest(bits, dest, index, 6);}
+void XEmitter::BTC(int bits, const OpArg& dest, const OpArg& index) {WriteBitTest(bits, dest, index, 7);}
 
 //shift can be either imm8 or cl
-void XEmitter::SHRD(int bits, OpArg dest, OpArg src, OpArg shift)
+void XEmitter::SHRD(int bits, const OpArg& dest, const OpArg& src, const OpArg& shift)
 {
 	CheckFlags();
 	if (dest.IsImm())
@@ -1042,7 +1042,7 @@ void XEmitter::SHRD(int bits, OpArg dest, OpArg src, OpArg shift)
 	}
 }
 
-void XEmitter::SHLD(int bits, OpArg dest, OpArg src, OpArg shift)
+void XEmitter::SHLD(int bits, const OpArg& dest, const OpArg& src, const OpArg& shift)
 {
 	CheckFlags();
 	if (dest.IsImm())
@@ -1287,7 +1287,7 @@ void XEmitter::CMP_or_TEST(int bits, const OpArg& a1, const OpArg& a2)
 	}
 }
 
-void XEmitter::IMUL(int bits, X64Reg regOp, OpArg a1, OpArg a2)
+void XEmitter::IMUL(int bits, X64Reg regOp, const OpArg& a1, const OpArg& a2)
 {
 	CheckFlags();
 	if (bits == 8)
@@ -1340,7 +1340,7 @@ void XEmitter::IMUL(int bits, X64Reg regOp, OpArg a1, OpArg a2)
 	}
 }
 
-void XEmitter::IMUL(int bits, X64Reg regOp, OpArg a)
+void XEmitter::IMUL(int bits, X64Reg regOp, const OpArg& a)
 {
 	CheckFlags();
 	if (bits == 8)
@@ -1400,7 +1400,7 @@ static int GetVEXpp(u8 opPrefix)
 		return 0;
 }
 
-void XEmitter::WriteVEXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int W, int extrabytes)
+void XEmitter::WriteVEXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int W, int extrabytes)
 {
 	int mmmmm = GetVEXmmmmm(op);
 	int pp = GetVEXpp(opPrefix);
@@ -1410,34 +1410,34 @@ void XEmitter::WriteVEXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpA
 	arg.WriteRest(this, extrabytes, regOp1);
 }
 
-void XEmitter::WriteVEXOp4(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, X64Reg regOp3, int W)
+void XEmitter::WriteVEXOp4(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, X64Reg regOp3, int W)
 {
 	WriteVEXOp(opPrefix, op, regOp1, regOp2, arg, W, 1);
 	Write8((u8)regOp3 << 4);
 }
 
-void XEmitter::WriteAVXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int W, int extrabytes)
+void XEmitter::WriteAVXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int W, int extrabytes)
 {
 	if (!cpu_info.bAVX)
 		PanicAlert("Trying to use AVX on a system that doesn't support it. Bad programmer.");
 	WriteVEXOp(opPrefix, op, regOp1, regOp2, arg, W, extrabytes);
 }
 
-void XEmitter::WriteAVXOp4(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, X64Reg regOp3, int W)
+void XEmitter::WriteAVXOp4(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, X64Reg regOp3, int W)
 {
 	if (!cpu_info.bAVX)
 		PanicAlert("Trying to use AVX on a system that doesn't support it. Bad programmer.");
 	WriteVEXOp4(opPrefix, op, regOp1, regOp2, arg, regOp3, W);
 }
 
-void XEmitter::WriteFMA3Op(u8 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int W)
+void XEmitter::WriteFMA3Op(u8 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int W)
 {
 	if (!cpu_info.bFMA)
 		PanicAlert("Trying to use FMA3 on a system that doesn't support it. Computer is v. f'n madd.");
 	WriteVEXOp(0x66, 0x3800 | op, regOp1, regOp2, arg, W);
 }
 
-void XEmitter::WriteBMIOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
+void XEmitter::WriteBMIOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int extrabytes)
 {
 	CheckFlags();
 	if (size != 32 && size != 64)
@@ -1446,14 +1446,14 @@ void XEmitter::WriteBMIOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg r
 	WriteVEXOp(opPrefix, op, regOp1, regOp2, arg, W, extrabytes);
 }
 
-void XEmitter::WriteBMI1Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
+void XEmitter::WriteBMI1Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int extrabytes)
 {
 	if (!cpu_info.bBMI1)
 		PanicAlert("Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
 	WriteBMIOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 
-void XEmitter::WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
+void XEmitter::WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int extrabytes)
 {
 	if (!cpu_info.bBMI2)
 		PanicAlert("Trying to use BMI2 on a system that doesn't support it. Bad programmer.");
@@ -1511,132 +1511,132 @@ void XEmitter::WriteMXCSR(OpArg arg, int ext)
 	arg.WriteRest(this);
 }
 
-void XEmitter::STMXCSR(OpArg memloc) {WriteMXCSR(memloc, 3);}
-void XEmitter::LDMXCSR(OpArg memloc) {WriteMXCSR(memloc, 2);}
+void XEmitter::STMXCSR(const OpArg& memloc) {WriteMXCSR(memloc, 3);}
+void XEmitter::LDMXCSR(const OpArg& memloc) {WriteMXCSR(memloc, 2);}
 
-void XEmitter::MOVNTDQ(OpArg arg, X64Reg regOp) {WriteSSEOp(0x66, sseMOVNTDQ, regOp, arg);}
-void XEmitter::MOVNTPS(OpArg arg, X64Reg regOp) {WriteSSEOp(0x00, sseMOVNTP, regOp, arg);}
-void XEmitter::MOVNTPD(OpArg arg, X64Reg regOp) {WriteSSEOp(0x66, sseMOVNTP, regOp, arg);}
+void XEmitter::MOVNTDQ(const OpArg& arg, X64Reg regOp) {WriteSSEOp(0x66, sseMOVNTDQ, regOp, arg);}
+void XEmitter::MOVNTPS(const OpArg& arg, X64Reg regOp) {WriteSSEOp(0x00, sseMOVNTP, regOp, arg);}
+void XEmitter::MOVNTPD(const OpArg& arg, X64Reg regOp) {WriteSSEOp(0x66, sseMOVNTP, regOp, arg);}
 
-void XEmitter::ADDSS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF3, sseADD, regOp, arg);}
-void XEmitter::ADDSD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF2, sseADD, regOp, arg);}
-void XEmitter::SUBSS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF3, sseSUB, regOp, arg);}
-void XEmitter::SUBSD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF2, sseSUB, regOp, arg);}
-void XEmitter::CMPSS(X64Reg regOp, OpArg arg, u8 compare)   {WriteSSEOp(0xF3, sseCMP, regOp, arg, 1); Write8(compare);}
-void XEmitter::CMPSD(X64Reg regOp, OpArg arg, u8 compare)   {WriteSSEOp(0xF2, sseCMP, regOp, arg, 1); Write8(compare);}
-void XEmitter::MULSS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF3, sseMUL, regOp, arg);}
-void XEmitter::MULSD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF2, sseMUL, regOp, arg);}
-void XEmitter::DIVSS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF3, sseDIV, regOp, arg);}
-void XEmitter::DIVSD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF2, sseDIV, regOp, arg);}
-void XEmitter::MINSS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF3, sseMIN, regOp, arg);}
-void XEmitter::MINSD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF2, sseMIN, regOp, arg);}
-void XEmitter::MAXSS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF3, sseMAX, regOp, arg);}
-void XEmitter::MAXSD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF2, sseMAX, regOp, arg);}
-void XEmitter::SQRTSS(X64Reg regOp, OpArg arg)  {WriteSSEOp(0xF3, sseSQRT, regOp, arg);}
-void XEmitter::SQRTSD(X64Reg regOp, OpArg arg)  {WriteSSEOp(0xF2, sseSQRT, regOp, arg);}
-void XEmitter::RSQRTSS(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF3, sseRSQRT, regOp, arg);}
+void XEmitter::ADDSS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF3, sseADD, regOp, arg);}
+void XEmitter::ADDSD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF2, sseADD, regOp, arg);}
+void XEmitter::SUBSS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF3, sseSUB, regOp, arg);}
+void XEmitter::SUBSD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF2, sseSUB, regOp, arg);}
+void XEmitter::CMPSS(X64Reg regOp, const OpArg& arg, u8 compare) {WriteSSEOp(0xF3, sseCMP, regOp, arg, 1); Write8(compare);}
+void XEmitter::CMPSD(X64Reg regOp, const OpArg& arg, u8 compare) {WriteSSEOp(0xF2, sseCMP, regOp, arg, 1); Write8(compare);}
+void XEmitter::MULSS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF3, sseMUL, regOp, arg);}
+void XEmitter::MULSD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF2, sseMUL, regOp, arg);}
+void XEmitter::DIVSS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF3, sseDIV, regOp, arg);}
+void XEmitter::DIVSD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF2, sseDIV, regOp, arg);}
+void XEmitter::MINSS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF3, sseMIN, regOp, arg);}
+void XEmitter::MINSD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF2, sseMIN, regOp, arg);}
+void XEmitter::MAXSS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF3, sseMAX, regOp, arg);}
+void XEmitter::MAXSD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF2, sseMAX, regOp, arg);}
+void XEmitter::SQRTSS(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0xF3, sseSQRT, regOp, arg);}
+void XEmitter::SQRTSD(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0xF2, sseSQRT, regOp, arg);}
+void XEmitter::RSQRTSS(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF3, sseRSQRT, regOp, arg);}
 
-void XEmitter::ADDPS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x00, sseADD, regOp, arg);}
-void XEmitter::ADDPD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x66, sseADD, regOp, arg);}
-void XEmitter::SUBPS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x00, sseSUB, regOp, arg);}
-void XEmitter::SUBPD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x66, sseSUB, regOp, arg);}
-void XEmitter::CMPPS(X64Reg regOp, OpArg arg, u8 compare)   {WriteSSEOp(0x00, sseCMP, regOp, arg, 1); Write8(compare);}
-void XEmitter::CMPPD(X64Reg regOp, OpArg arg, u8 compare)   {WriteSSEOp(0x66, sseCMP, regOp, arg, 1); Write8(compare);}
-void XEmitter::ANDPS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x00, sseAND, regOp, arg);}
-void XEmitter::ANDPD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x66, sseAND, regOp, arg);}
-void XEmitter::ANDNPS(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x00, sseANDN, regOp, arg);}
-void XEmitter::ANDNPD(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x66, sseANDN, regOp, arg);}
-void XEmitter::ORPS(X64Reg regOp, OpArg arg)    {WriteSSEOp(0x00, sseOR, regOp, arg);}
-void XEmitter::ORPD(X64Reg regOp, OpArg arg)    {WriteSSEOp(0x66, sseOR, regOp, arg);}
-void XEmitter::XORPS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x00, sseXOR, regOp, arg);}
-void XEmitter::XORPD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x66, sseXOR, regOp, arg);}
-void XEmitter::MULPS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x00, sseMUL, regOp, arg);}
-void XEmitter::MULPD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x66, sseMUL, regOp, arg);}
-void XEmitter::DIVPS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x00, sseDIV, regOp, arg);}
-void XEmitter::DIVPD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x66, sseDIV, regOp, arg);}
-void XEmitter::MINPS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x00, sseMIN, regOp, arg);}
-void XEmitter::MINPD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x66, sseMIN, regOp, arg);}
-void XEmitter::MAXPS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x00, sseMAX, regOp, arg);}
-void XEmitter::MAXPD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0x66, sseMAX, regOp, arg);}
-void XEmitter::SQRTPS(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x00, sseSQRT, regOp, arg);}
-void XEmitter::SQRTPD(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x66, sseSQRT, regOp, arg);}
-void XEmitter::RSQRTPS(X64Reg regOp, OpArg arg) {WriteSSEOp(0x00, sseRSQRT, regOp, arg);}
-void XEmitter::SHUFPS(X64Reg regOp, OpArg arg, u8 shuffle) {WriteSSEOp(0x00, sseSHUF, regOp, arg,1); Write8(shuffle);}
-void XEmitter::SHUFPD(X64Reg regOp, OpArg arg, u8 shuffle) {WriteSSEOp(0x66, sseSHUF, regOp, arg,1); Write8(shuffle);}
+void XEmitter::ADDPS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x00, sseADD, regOp, arg);}
+void XEmitter::ADDPD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x66, sseADD, regOp, arg);}
+void XEmitter::SUBPS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x00, sseSUB, regOp, arg);}
+void XEmitter::SUBPD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x66, sseSUB, regOp, arg);}
+void XEmitter::CMPPS(X64Reg regOp, const OpArg& arg, u8 compare) {WriteSSEOp(0x00, sseCMP, regOp, arg, 1); Write8(compare);}
+void XEmitter::CMPPD(X64Reg regOp, const OpArg& arg, u8 compare) {WriteSSEOp(0x66, sseCMP, regOp, arg, 1); Write8(compare);}
+void XEmitter::ANDPS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x00, sseAND, regOp, arg);}
+void XEmitter::ANDPD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x66, sseAND, regOp, arg);}
+void XEmitter::ANDNPS(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x00, sseANDN, regOp, arg);}
+void XEmitter::ANDNPD(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x66, sseANDN, regOp, arg);}
+void XEmitter::ORPS(X64Reg regOp, const OpArg& arg)    {WriteSSEOp(0x00, sseOR, regOp, arg);}
+void XEmitter::ORPD(X64Reg regOp, const OpArg& arg)    {WriteSSEOp(0x66, sseOR, regOp, arg);}
+void XEmitter::XORPS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x00, sseXOR, regOp, arg);}
+void XEmitter::XORPD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x66, sseXOR, regOp, arg);}
+void XEmitter::MULPS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x00, sseMUL, regOp, arg);}
+void XEmitter::MULPD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x66, sseMUL, regOp, arg);}
+void XEmitter::DIVPS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x00, sseDIV, regOp, arg);}
+void XEmitter::DIVPD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x66, sseDIV, regOp, arg);}
+void XEmitter::MINPS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x00, sseMIN, regOp, arg);}
+void XEmitter::MINPD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x66, sseMIN, regOp, arg);}
+void XEmitter::MAXPS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x00, sseMAX, regOp, arg);}
+void XEmitter::MAXPD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x66, sseMAX, regOp, arg);}
+void XEmitter::SQRTPS(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x00, sseSQRT, regOp, arg);}
+void XEmitter::SQRTPD(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x66, sseSQRT, regOp, arg);}
+void XEmitter::RSQRTPS(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0x00, sseRSQRT, regOp, arg);}
+void XEmitter::SHUFPS(X64Reg regOp, const OpArg& arg, u8 shuffle) {WriteSSEOp(0x00, sseSHUF, regOp, arg,1); Write8(shuffle);}
+void XEmitter::SHUFPD(X64Reg regOp, const OpArg& arg, u8 shuffle) {WriteSSEOp(0x66, sseSHUF, regOp, arg,1); Write8(shuffle);}
 
-void XEmitter::COMISS(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x00, sseCOMIS, regOp, arg);} //weird that these should be packed
-void XEmitter::COMISD(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x66, sseCOMIS, regOp, arg);} //ordered
-void XEmitter::UCOMISS(X64Reg regOp, OpArg arg) {WriteSSEOp(0x00, sseUCOMIS, regOp, arg);} //unordered
-void XEmitter::UCOMISD(X64Reg regOp, OpArg arg) {WriteSSEOp(0x66, sseUCOMIS, regOp, arg);}
+void XEmitter::COMISS(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x00, sseCOMIS, regOp, arg);} //weird that these should be packed
+void XEmitter::COMISD(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x66, sseCOMIS, regOp, arg);} //ordered
+void XEmitter::UCOMISS(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0x00, sseUCOMIS, regOp, arg);} //unordered
+void XEmitter::UCOMISD(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0x66, sseUCOMIS, regOp, arg);}
 
-void XEmitter::MOVAPS(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x00, sseMOVAPfromRM, regOp, arg);}
-void XEmitter::MOVAPD(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x66, sseMOVAPfromRM, regOp, arg);}
-void XEmitter::MOVAPS(OpArg arg, X64Reg regOp)  {WriteSSEOp(0x00, sseMOVAPtoRM, regOp, arg);}
-void XEmitter::MOVAPD(OpArg arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVAPtoRM, regOp, arg);}
+void XEmitter::MOVAPS(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x00, sseMOVAPfromRM, regOp, arg);}
+void XEmitter::MOVAPD(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x66, sseMOVAPfromRM, regOp, arg);}
+void XEmitter::MOVAPS(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0x00, sseMOVAPtoRM, regOp, arg);}
+void XEmitter::MOVAPD(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVAPtoRM, regOp, arg);}
 
-void XEmitter::MOVUPS(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x00, sseMOVUPfromRM, regOp, arg);}
-void XEmitter::MOVUPD(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x66, sseMOVUPfromRM, regOp, arg);}
-void XEmitter::MOVUPS(OpArg arg, X64Reg regOp)  {WriteSSEOp(0x00, sseMOVUPtoRM, regOp, arg);}
-void XEmitter::MOVUPD(OpArg arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVUPtoRM, regOp, arg);}
+void XEmitter::MOVUPS(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x00, sseMOVUPfromRM, regOp, arg);}
+void XEmitter::MOVUPD(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x66, sseMOVUPfromRM, regOp, arg);}
+void XEmitter::MOVUPS(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0x00, sseMOVUPtoRM, regOp, arg);}
+void XEmitter::MOVUPD(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVUPtoRM, regOp, arg);}
 
-void XEmitter::MOVDQA(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x66, sseMOVDQfromRM, regOp, arg);}
-void XEmitter::MOVDQA(OpArg arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVDQtoRM, regOp, arg);}
-void XEmitter::MOVDQU(X64Reg regOp, OpArg arg)  {WriteSSEOp(0xF3, sseMOVDQfromRM, regOp, arg);}
-void XEmitter::MOVDQU(OpArg arg, X64Reg regOp)  {WriteSSEOp(0xF3, sseMOVDQtoRM, regOp, arg);}
+void XEmitter::MOVDQA(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x66, sseMOVDQfromRM, regOp, arg);}
+void XEmitter::MOVDQA(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVDQtoRM, regOp, arg);}
+void XEmitter::MOVDQU(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0xF3, sseMOVDQfromRM, regOp, arg);}
+void XEmitter::MOVDQU(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0xF3, sseMOVDQtoRM, regOp, arg);}
 
-void XEmitter::MOVSS(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF3, sseMOVUPfromRM, regOp, arg);}
-void XEmitter::MOVSD(X64Reg regOp, OpArg arg)   {WriteSSEOp(0xF2, sseMOVUPfromRM, regOp, arg);}
-void XEmitter::MOVSS(OpArg arg, X64Reg regOp)   {WriteSSEOp(0xF3, sseMOVUPtoRM, regOp, arg);}
-void XEmitter::MOVSD(OpArg arg, X64Reg regOp)   {WriteSSEOp(0xF2, sseMOVUPtoRM, regOp, arg);}
+void XEmitter::MOVSS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF3, sseMOVUPfromRM, regOp, arg);}
+void XEmitter::MOVSD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF2, sseMOVUPfromRM, regOp, arg);}
+void XEmitter::MOVSS(const OpArg& arg, X64Reg regOp)   {WriteSSEOp(0xF3, sseMOVUPtoRM, regOp, arg);}
+void XEmitter::MOVSD(const OpArg& arg, X64Reg regOp)   {WriteSSEOp(0xF2, sseMOVUPtoRM, regOp, arg);}
 
-void XEmitter::MOVLPS(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x00, sseMOVLPfromRM, regOp, arg);}
-void XEmitter::MOVLPD(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x66, sseMOVLPfromRM, regOp, arg);}
-void XEmitter::MOVLPS(OpArg arg, X64Reg regOp)  {WriteSSEOp(0x00, sseMOVLPtoRM, regOp, arg);}
-void XEmitter::MOVLPD(OpArg arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVLPtoRM, regOp, arg);}
+void XEmitter::MOVLPS(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x00, sseMOVLPfromRM, regOp, arg);}
+void XEmitter::MOVLPD(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x66, sseMOVLPfromRM, regOp, arg);}
+void XEmitter::MOVLPS(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0x00, sseMOVLPtoRM, regOp, arg);}
+void XEmitter::MOVLPD(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVLPtoRM, regOp, arg);}
 
-void XEmitter::MOVHPS(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x00, sseMOVHPfromRM, regOp, arg);}
-void XEmitter::MOVHPD(X64Reg regOp, OpArg arg)  {WriteSSEOp(0x66, sseMOVHPfromRM, regOp, arg);}
-void XEmitter::MOVHPS(OpArg arg, X64Reg regOp)  {WriteSSEOp(0x00, sseMOVHPtoRM, regOp, arg);}
-void XEmitter::MOVHPD(OpArg arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVHPtoRM, regOp, arg);}
+void XEmitter::MOVHPS(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x00, sseMOVHPfromRM, regOp, arg);}
+void XEmitter::MOVHPD(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0x66, sseMOVHPfromRM, regOp, arg);}
+void XEmitter::MOVHPS(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0x00, sseMOVHPtoRM, regOp, arg);}
+void XEmitter::MOVHPD(const OpArg& arg, X64Reg regOp)  {WriteSSEOp(0x66, sseMOVHPtoRM, regOp, arg);}
 
 void XEmitter::MOVHLPS(X64Reg regOp1, X64Reg regOp2) {WriteSSEOp(0x00, sseMOVHLPS, regOp1, R(regOp2));}
 void XEmitter::MOVLHPS(X64Reg regOp1, X64Reg regOp2) {WriteSSEOp(0x00, sseMOVLHPS, regOp1, R(regOp2));}
 
-void XEmitter::CVTPS2PD(X64Reg regOp, OpArg arg) {WriteSSEOp(0x00, 0x5A, regOp, arg);}
-void XEmitter::CVTPD2PS(X64Reg regOp, OpArg arg) {WriteSSEOp(0x66, 0x5A, regOp, arg);}
+void XEmitter::CVTPS2PD(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0x00, 0x5A, regOp, arg);}
+void XEmitter::CVTPD2PS(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0x66, 0x5A, regOp, arg);}
 
-void XEmitter::CVTSD2SS(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF2, 0x5A, regOp, arg);}
-void XEmitter::CVTSS2SD(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF3, 0x5A, regOp, arg);}
-void XEmitter::CVTSD2SI(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF2, 0x2D, regOp, arg);}
-void XEmitter::CVTSS2SI(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF3, 0x2D, regOp, arg);}
-void XEmitter::CVTSI2SD(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF2, 0x2A, regOp, arg);}
-void XEmitter::CVTSI2SS(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF3, 0x2A, regOp, arg);}
+void XEmitter::CVTSD2SS(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF2, 0x5A, regOp, arg);}
+void XEmitter::CVTSS2SD(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF3, 0x5A, regOp, arg);}
+void XEmitter::CVTSD2SI(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF2, 0x2D, regOp, arg);}
+void XEmitter::CVTSS2SI(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF3, 0x2D, regOp, arg);}
+void XEmitter::CVTSI2SD(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF2, 0x2A, regOp, arg);}
+void XEmitter::CVTSI2SS(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF3, 0x2A, regOp, arg);}
 
-void XEmitter::CVTDQ2PD(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF3, 0xE6, regOp, arg);}
-void XEmitter::CVTDQ2PS(X64Reg regOp, OpArg arg) {WriteSSEOp(0x00, 0x5B, regOp, arg);}
-void XEmitter::CVTPD2DQ(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF2, 0xE6, regOp, arg);}
-void XEmitter::CVTPS2DQ(X64Reg regOp, OpArg arg) {WriteSSEOp(0x66, 0x5B, regOp, arg);}
+void XEmitter::CVTDQ2PD(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF3, 0xE6, regOp, arg);}
+void XEmitter::CVTDQ2PS(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0x00, 0x5B, regOp, arg);}
+void XEmitter::CVTPD2DQ(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF2, 0xE6, regOp, arg);}
+void XEmitter::CVTPS2DQ(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0x66, 0x5B, regOp, arg);}
 
-void XEmitter::CVTTSD2SI(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF2, 0x2C, regOp, arg);}
-void XEmitter::CVTTSS2SI(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF3, 0x2C, regOp, arg);}
-void XEmitter::CVTTPS2DQ(X64Reg regOp, OpArg arg) {WriteSSEOp(0xF3, 0x5B, regOp, arg);}
-void XEmitter::CVTTPD2DQ(X64Reg regOp, OpArg arg) {WriteSSEOp(0x66, 0xE6, regOp, arg);}
+void XEmitter::CVTTSD2SI(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF2, 0x2C, regOp, arg);}
+void XEmitter::CVTTSS2SI(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF3, 0x2C, regOp, arg);}
+void XEmitter::CVTTPS2DQ(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF3, 0x5B, regOp, arg);}
+void XEmitter::CVTTPD2DQ(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0x66, 0xE6, regOp, arg);}
 
 void XEmitter::MASKMOVDQU(X64Reg dest, X64Reg src)  {WriteSSEOp(0x66, sseMASKMOVDQU, dest, R(src));}
 
-void XEmitter::MOVMSKPS(X64Reg dest, OpArg arg) {WriteSSEOp(0x00, 0x50, dest, arg);}
-void XEmitter::MOVMSKPD(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x50, dest, arg);}
+void XEmitter::MOVMSKPS(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x00, 0x50, dest, arg);}
+void XEmitter::MOVMSKPD(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x50, dest, arg);}
 
-void XEmitter::LDDQU(X64Reg dest, OpArg arg)    {WriteSSEOp(0xF2, sseLDDQU, dest, arg);} // For integer data only
+void XEmitter::LDDQU(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0xF2, sseLDDQU, dest, arg);} // For integer data only
 
 // THESE TWO ARE UNTESTED.
-void XEmitter::UNPCKLPS(X64Reg dest, OpArg arg) {WriteSSEOp(0x00, 0x14, dest, arg);}
-void XEmitter::UNPCKHPS(X64Reg dest, OpArg arg) {WriteSSEOp(0x00, 0x15, dest, arg);}
+void XEmitter::UNPCKLPS(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x00, 0x14, dest, arg);}
+void XEmitter::UNPCKHPS(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x00, 0x15, dest, arg);}
 
-void XEmitter::UNPCKLPD(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x14, dest, arg);}
-void XEmitter::UNPCKHPD(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x15, dest, arg);}
+void XEmitter::UNPCKLPD(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x14, dest, arg);}
+void XEmitter::UNPCKHPD(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x15, dest, arg);}
 
-void XEmitter::MOVDDUP(X64Reg regOp, OpArg arg)
+void XEmitter::MOVDDUP(X64Reg regOp, const OpArg& arg)
 {
 	if (cpu_info.bSSE3)
 	{
@@ -1654,9 +1654,9 @@ void XEmitter::MOVDDUP(X64Reg regOp, OpArg arg)
 //There are a few more left
 
 // Also some integer instructions are missing
-void XEmitter::PACKSSDW(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x6B, dest, arg);}
-void XEmitter::PACKSSWB(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x63, dest, arg);}
-void XEmitter::PACKUSWB(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x67, dest, arg);}
+void XEmitter::PACKSSDW(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x6B, dest, arg);}
+void XEmitter::PACKSSWB(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x63, dest, arg);}
+void XEmitter::PACKUSWB(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x67, dest, arg);}
 
 void XEmitter::PUNPCKLBW(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x60, dest, arg);}
 void XEmitter::PUNPCKLWD(X64Reg dest, const OpArg& arg) {WriteSSEOp(0x66, 0x61, dest, arg);}
@@ -1681,7 +1681,7 @@ void XEmitter::PSRLQ(X64Reg reg, int shift)
 	Write8(shift);
 }
 
-void XEmitter::PSRLQ(X64Reg reg, OpArg arg)
+void XEmitter::PSRLQ(X64Reg reg, const OpArg& arg)
 {
 	WriteSSEOp(0x66, 0xd3, reg, arg);
 }
@@ -1741,199 +1741,199 @@ void XEmitter::PSRAD(X64Reg reg, int shift)
 	Write8(shift);
 }
 
-void XEmitter::WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes)
+void XEmitter::WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, const OpArg& arg, int extrabytes)
 {
 	if (!cpu_info.bSSSE3)
 		PanicAlert("Trying to use SSSE3 on a system that doesn't support it. Bad programmer.");
 	WriteSSEOp(opPrefix, op, regOp, arg, extrabytes);
 }
 
-void XEmitter::WriteSSE41Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes)
+void XEmitter::WriteSSE41Op(u8 opPrefix, u16 op, X64Reg regOp, const OpArg& arg, int extrabytes)
 {
 	if (!cpu_info.bSSE4_1)
 		PanicAlert("Trying to use SSE4.1 on a system that doesn't support it. Bad programmer.");
 	WriteSSEOp(opPrefix, op, regOp, arg, extrabytes);
 }
 
-void XEmitter::PSHUFB(X64Reg dest, OpArg arg)   {WriteSSSE3Op(0x66, 0x3800, dest, arg);}
-void XEmitter::PTEST(X64Reg dest, OpArg arg)    {WriteSSE41Op(0x66, 0x3817, dest, arg);}
-void XEmitter::PACKUSDW(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x382b, dest, arg);}
+void XEmitter::PSHUFB(X64Reg dest, const OpArg& arg)   {WriteSSSE3Op(0x66, 0x3800, dest, arg);}
+void XEmitter::PTEST(X64Reg dest, const OpArg& arg)    {WriteSSE41Op(0x66, 0x3817, dest, arg);}
+void XEmitter::PACKUSDW(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x382b, dest, arg);}
 
-void XEmitter::PMOVSXBW(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3820, dest, arg);}
-void XEmitter::PMOVSXBD(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3821, dest, arg);}
-void XEmitter::PMOVSXBQ(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3822, dest, arg);}
-void XEmitter::PMOVSXWD(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3823, dest, arg);}
-void XEmitter::PMOVSXWQ(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3824, dest, arg);}
-void XEmitter::PMOVSXDQ(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3825, dest, arg);}
-void XEmitter::PMOVZXBW(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3830, dest, arg);}
-void XEmitter::PMOVZXBD(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3831, dest, arg);}
-void XEmitter::PMOVZXBQ(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3832, dest, arg);}
-void XEmitter::PMOVZXWD(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3833, dest, arg);}
-void XEmitter::PMOVZXWQ(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3834, dest, arg);}
-void XEmitter::PMOVZXDQ(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3835, dest, arg);}
+void XEmitter::PMOVSXBW(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3820, dest, arg);}
+void XEmitter::PMOVSXBD(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3821, dest, arg);}
+void XEmitter::PMOVSXBQ(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3822, dest, arg);}
+void XEmitter::PMOVSXWD(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3823, dest, arg);}
+void XEmitter::PMOVSXWQ(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3824, dest, arg);}
+void XEmitter::PMOVSXDQ(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3825, dest, arg);}
+void XEmitter::PMOVZXBW(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3830, dest, arg);}
+void XEmitter::PMOVZXBD(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3831, dest, arg);}
+void XEmitter::PMOVZXBQ(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3832, dest, arg);}
+void XEmitter::PMOVZXWD(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3833, dest, arg);}
+void XEmitter::PMOVZXWQ(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3834, dest, arg);}
+void XEmitter::PMOVZXDQ(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3835, dest, arg);}
 
-void XEmitter::PBLENDVB(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3810, dest, arg);}
-void XEmitter::BLENDVPS(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3814, dest, arg);}
-void XEmitter::BLENDVPD(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3815, dest, arg);}
-void XEmitter::BLENDPS(X64Reg dest, OpArg arg, u8 blend) {WriteSSE41Op(0x66, 0x3A0C, dest, arg, 1); Write8(blend);}
-void XEmitter::BLENDPD(X64Reg dest, OpArg arg, u8 blend) {WriteSSE41Op(0x66, 0x3A0D, dest, arg, 1); Write8(blend);}
+void XEmitter::PBLENDVB(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3810, dest, arg);}
+void XEmitter::BLENDVPS(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3814, dest, arg);}
+void XEmitter::BLENDVPD(X64Reg dest, const OpArg& arg) {WriteSSE41Op(0x66, 0x3815, dest, arg);}
+void XEmitter::BLENDPS(X64Reg dest, const OpArg& arg, u8 blend) {WriteSSE41Op(0x66, 0x3A0C, dest, arg, 1); Write8(blend);}
+void XEmitter::BLENDPD(X64Reg dest, const OpArg& arg, u8 blend) {WriteSSE41Op(0x66, 0x3A0D, dest, arg, 1); Write8(blend);}
 
-void XEmitter::PAND(X64Reg dest, OpArg arg)     {WriteSSEOp(0x66, 0xDB, dest, arg);}
-void XEmitter::PANDN(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xDF, dest, arg);}
-void XEmitter::PXOR(X64Reg dest, OpArg arg)     {WriteSSEOp(0x66, 0xEF, dest, arg);}
-void XEmitter::POR(X64Reg dest, OpArg arg)      {WriteSSEOp(0x66, 0xEB, dest, arg);}
+void XEmitter::PAND(X64Reg dest, const OpArg& arg)     {WriteSSEOp(0x66, 0xDB, dest, arg);}
+void XEmitter::PANDN(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xDF, dest, arg);}
+void XEmitter::PXOR(X64Reg dest, const OpArg& arg)     {WriteSSEOp(0x66, 0xEF, dest, arg);}
+void XEmitter::POR(X64Reg dest, const OpArg& arg)      {WriteSSEOp(0x66, 0xEB, dest, arg);}
 
-void XEmitter::PADDB(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xFC, dest, arg);}
-void XEmitter::PADDW(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xFD, dest, arg);}
-void XEmitter::PADDD(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xFE, dest, arg);}
-void XEmitter::PADDQ(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xD4, dest, arg);}
+void XEmitter::PADDB(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xFC, dest, arg);}
+void XEmitter::PADDW(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xFD, dest, arg);}
+void XEmitter::PADDD(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xFE, dest, arg);}
+void XEmitter::PADDQ(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xD4, dest, arg);}
 
-void XEmitter::PADDSB(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xEC, dest, arg);}
-void XEmitter::PADDSW(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xED, dest, arg);}
-void XEmitter::PADDUSB(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0xDC, dest, arg);}
-void XEmitter::PADDUSW(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0xDD, dest, arg);}
+void XEmitter::PADDSB(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xEC, dest, arg);}
+void XEmitter::PADDSW(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xED, dest, arg);}
+void XEmitter::PADDUSB(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0xDC, dest, arg);}
+void XEmitter::PADDUSW(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0xDD, dest, arg);}
 
-void XEmitter::PSUBB(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xF8, dest, arg);}
-void XEmitter::PSUBW(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xF9, dest, arg);}
-void XEmitter::PSUBD(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xFA, dest, arg);}
-void XEmitter::PSUBQ(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xFB, dest, arg);}
+void XEmitter::PSUBB(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xF8, dest, arg);}
+void XEmitter::PSUBW(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xF9, dest, arg);}
+void XEmitter::PSUBD(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xFA, dest, arg);}
+void XEmitter::PSUBQ(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xFB, dest, arg);}
 
-void XEmitter::PSUBSB(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xE8, dest, arg);}
-void XEmitter::PSUBSW(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xE9, dest, arg);}
-void XEmitter::PSUBUSB(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0xD8, dest, arg);}
-void XEmitter::PSUBUSW(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0xD9, dest, arg);}
+void XEmitter::PSUBSB(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xE8, dest, arg);}
+void XEmitter::PSUBSW(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xE9, dest, arg);}
+void XEmitter::PSUBUSB(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0xD8, dest, arg);}
+void XEmitter::PSUBUSW(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0xD9, dest, arg);}
 
-void XEmitter::PAVGB(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xE0, dest, arg);}
-void XEmitter::PAVGW(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xE3, dest, arg);}
+void XEmitter::PAVGB(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xE0, dest, arg);}
+void XEmitter::PAVGW(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xE3, dest, arg);}
 
-void XEmitter::PCMPEQB(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x74, dest, arg);}
-void XEmitter::PCMPEQW(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x75, dest, arg);}
-void XEmitter::PCMPEQD(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x76, dest, arg);}
+void XEmitter::PCMPEQB(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0x74, dest, arg);}
+void XEmitter::PCMPEQW(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0x75, dest, arg);}
+void XEmitter::PCMPEQD(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0x76, dest, arg);}
 
-void XEmitter::PCMPGTB(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x64, dest, arg);}
-void XEmitter::PCMPGTW(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x65, dest, arg);}
-void XEmitter::PCMPGTD(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x66, dest, arg);}
+void XEmitter::PCMPGTB(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0x64, dest, arg);}
+void XEmitter::PCMPGTW(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0x65, dest, arg);}
+void XEmitter::PCMPGTD(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0x66, dest, arg);}
 
-void XEmitter::PEXTRW(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSEOp(0x66, 0xC5, dest, arg); Write8(subreg);}
-void XEmitter::PINSRW(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSEOp(0x66, 0xC4, dest, arg); Write8(subreg);}
+void XEmitter::PEXTRW(X64Reg dest, const OpArg& arg, u8 subreg) {WriteSSEOp(0x66, 0xC5, dest, arg); Write8(subreg);}
+void XEmitter::PINSRW(X64Reg dest, const OpArg& arg, u8 subreg) {WriteSSEOp(0x66, 0xC4, dest, arg); Write8(subreg);}
 
-void XEmitter::PMADDWD(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0xF5, dest, arg); }
-void XEmitter::PSADBW(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xF6, dest, arg);}
+void XEmitter::PMADDWD(X64Reg dest, const OpArg& arg)  {WriteSSEOp(0x66, 0xF5, dest, arg); }
+void XEmitter::PSADBW(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xF6, dest, arg);}
 
-void XEmitter::PMAXSW(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xEE, dest, arg); }
-void XEmitter::PMAXUB(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xDE, dest, arg); }
-void XEmitter::PMINSW(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xEA, dest, arg); }
-void XEmitter::PMINUB(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xDA, dest, arg); }
+void XEmitter::PMAXSW(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xEE, dest, arg); }
+void XEmitter::PMAXUB(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xDE, dest, arg); }
+void XEmitter::PMINSW(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xEA, dest, arg); }
+void XEmitter::PMINUB(X64Reg dest, const OpArg& arg)   {WriteSSEOp(0x66, 0xDA, dest, arg); }
 
-void XEmitter::PMOVMSKB(X64Reg dest, OpArg arg)    {WriteSSEOp(0x66, 0xD7, dest, arg); }
-void XEmitter::PSHUFD(X64Reg regOp, OpArg arg, u8 shuffle)    {WriteSSEOp(0x66, 0x70, regOp, arg, 1); Write8(shuffle);}
-void XEmitter::PSHUFLW(X64Reg regOp, OpArg arg, u8 shuffle)   {WriteSSEOp(0xF2, 0x70, regOp, arg, 1); Write8(shuffle);}
-void XEmitter::PSHUFHW(X64Reg regOp, OpArg arg, u8 shuffle)   {WriteSSEOp(0xF3, 0x70, regOp, arg, 1); Write8(shuffle);}
+void XEmitter::PMOVMSKB(X64Reg dest, const OpArg& arg)    {WriteSSEOp(0x66, 0xD7, dest, arg); }
+void XEmitter::PSHUFD(X64Reg regOp, const OpArg& arg, u8 shuffle)    {WriteSSEOp(0x66, 0x70, regOp, arg, 1); Write8(shuffle);}
+void XEmitter::PSHUFLW(X64Reg regOp, const OpArg& arg, u8 shuffle)   {WriteSSEOp(0xF2, 0x70, regOp, arg, 1); Write8(shuffle);}
+void XEmitter::PSHUFHW(X64Reg regOp, const OpArg& arg, u8 shuffle)   {WriteSSEOp(0xF3, 0x70, regOp, arg, 1); Write8(shuffle);}
 
 // VEX
-void XEmitter::VADDSD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0xF2, sseADD, regOp1, regOp2, arg);}
-void XEmitter::VSUBSD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0xF2, sseSUB, regOp1, regOp2, arg);}
-void XEmitter::VMULSD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0xF2, sseMUL, regOp1, regOp2, arg);}
-void XEmitter::VDIVSD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0xF2, sseDIV, regOp1, regOp2, arg);}
-void XEmitter::VADDPD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0x66, sseADD, regOp1, regOp2, arg);}
-void XEmitter::VSUBPD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0x66, sseSUB, regOp1, regOp2, arg);}
-void XEmitter::VMULPD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0x66, sseMUL, regOp1, regOp2, arg);}
-void XEmitter::VDIVPD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0x66, sseDIV, regOp1, regOp2, arg);}
-void XEmitter::VSQRTSD(X64Reg regOp1, X64Reg regOp2, OpArg arg)  {WriteAVXOp(0xF2, sseSQRT, regOp1, regOp2, arg);}
-void XEmitter::VCMPPD(X64Reg regOp1, X64Reg regOp2, OpArg arg, u8 compare)  {WriteAVXOp(0x66, sseCMP, regOp1, regOp2, arg, 0, 1); Write8(compare);}
-void XEmitter::VSHUFPD(X64Reg regOp1, X64Reg regOp2, OpArg arg, u8 shuffle) {WriteAVXOp(0x66, sseSHUF, regOp1, regOp2, arg, 0, 1); Write8(shuffle);}
-void XEmitter::VUNPCKLPD(X64Reg regOp1, X64Reg regOp2, OpArg arg){WriteAVXOp(0x66, 0x14, regOp1, regOp2, arg);}
-void XEmitter::VUNPCKHPD(X64Reg regOp1, X64Reg regOp2, OpArg arg){WriteAVXOp(0x66, 0x15, regOp1, regOp2, arg);}
-void XEmitter::VBLENDVPD(X64Reg regOp1, X64Reg regOp2, OpArg arg, X64Reg regOp3) {WriteAVXOp4(0x66, 0x3A4B, regOp1, regOp2, arg, regOp3);}
+void XEmitter::VADDSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0xF2, sseADD, regOp1, regOp2, arg);}
+void XEmitter::VSUBSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0xF2, sseSUB, regOp1, regOp2, arg);}
+void XEmitter::VMULSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0xF2, sseMUL, regOp1, regOp2, arg);}
+void XEmitter::VDIVSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0xF2, sseDIV, regOp1, regOp2, arg);}
+void XEmitter::VADDPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0x66, sseADD, regOp1, regOp2, arg);}
+void XEmitter::VSUBPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0x66, sseSUB, regOp1, regOp2, arg);}
+void XEmitter::VMULPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0x66, sseMUL, regOp1, regOp2, arg);}
+void XEmitter::VDIVPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0x66, sseDIV, regOp1, regOp2, arg);}
+void XEmitter::VSQRTSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)  {WriteAVXOp(0xF2, sseSQRT, regOp1, regOp2, arg);}
+void XEmitter::VCMPPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg, u8 compare)  {WriteAVXOp(0x66, sseCMP, regOp1, regOp2, arg, 0, 1); Write8(compare);}
+void XEmitter::VSHUFPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg, u8 shuffle) {WriteAVXOp(0x66, sseSHUF, regOp1, regOp2, arg, 0, 1); Write8(shuffle);}
+void XEmitter::VUNPCKLPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg){WriteAVXOp(0x66, 0x14, regOp1, regOp2, arg);}
+void XEmitter::VUNPCKHPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg){WriteAVXOp(0x66, 0x15, regOp1, regOp2, arg);}
+void XEmitter::VBLENDVPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg, X64Reg regOp3) {WriteAVXOp4(0x66, 0x3A4B, regOp1, regOp2, arg, regOp3);}
 
-void XEmitter::VANDPS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0x00, sseAND, regOp1, regOp2, arg);}
-void XEmitter::VANDPD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0x66, sseAND, regOp1, regOp2, arg);}
-void XEmitter::VANDNPS(X64Reg regOp1, X64Reg regOp2, OpArg arg)  {WriteAVXOp(0x00, sseANDN, regOp1, regOp2, arg);}
-void XEmitter::VANDNPD(X64Reg regOp1, X64Reg regOp2, OpArg arg)  {WriteAVXOp(0x66, sseANDN, regOp1, regOp2, arg);}
-void XEmitter::VORPS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteAVXOp(0x00, sseOR, regOp1, regOp2, arg);}
-void XEmitter::VORPD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteAVXOp(0x66, sseOR, regOp1, regOp2, arg);}
-void XEmitter::VXORPS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0x00, sseXOR, regOp1, regOp2, arg);}
-void XEmitter::VXORPD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0x66, sseXOR, regOp1, regOp2, arg);}
+void XEmitter::VANDPS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0x00, sseAND, regOp1, regOp2, arg);}
+void XEmitter::VANDPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0x66, sseAND, regOp1, regOp2, arg);}
+void XEmitter::VANDNPS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)  {WriteAVXOp(0x00, sseANDN, regOp1, regOp2, arg);}
+void XEmitter::VANDNPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)  {WriteAVXOp(0x66, sseANDN, regOp1, regOp2, arg);}
+void XEmitter::VORPS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteAVXOp(0x00, sseOR, regOp1, regOp2, arg);}
+void XEmitter::VORPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteAVXOp(0x66, sseOR, regOp1, regOp2, arg);}
+void XEmitter::VXORPS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0x00, sseXOR, regOp1, regOp2, arg);}
+void XEmitter::VXORPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0x66, sseXOR, regOp1, regOp2, arg);}
 
-void XEmitter::VPAND(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteAVXOp(0x66, 0xDB, regOp1, regOp2, arg);}
-void XEmitter::VPANDN(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteAVXOp(0x66, 0xDF, regOp1, regOp2, arg);}
-void XEmitter::VPOR(X64Reg regOp1, X64Reg regOp2, OpArg arg)     {WriteAVXOp(0x66, 0xEB, regOp1, regOp2, arg);}
-void XEmitter::VPXOR(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteAVXOp(0x66, 0xEF, regOp1, regOp2, arg);}
+void XEmitter::VPAND(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteAVXOp(0x66, 0xDB, regOp1, regOp2, arg);}
+void XEmitter::VPANDN(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteAVXOp(0x66, 0xDF, regOp1, regOp2, arg);}
+void XEmitter::VPOR(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)     {WriteAVXOp(0x66, 0xEB, regOp1, regOp2, arg);}
+void XEmitter::VPXOR(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteAVXOp(0x66, 0xEF, regOp1, regOp2, arg);}
 
-void XEmitter::VFMADD132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0x98, regOp1, regOp2, arg);}
-void XEmitter::VFMADD213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xA8, regOp1, regOp2, arg);}
-void XEmitter::VFMADD231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xB8, regOp1, regOp2, arg);}
-void XEmitter::VFMADD132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0x98, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMADD213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xA8, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMADD231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xB8, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMADD132SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0x99, regOp1, regOp2, arg);}
-void XEmitter::VFMADD213SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xA9, regOp1, regOp2, arg);}
-void XEmitter::VFMADD231SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xB9, regOp1, regOp2, arg);}
-void XEmitter::VFMADD132SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0x99, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMADD213SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xA9, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMADD231SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xB9, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMSUB132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0x9A, regOp1, regOp2, arg);}
-void XEmitter::VFMSUB213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xAA, regOp1, regOp2, arg);}
-void XEmitter::VFMSUB231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xBA, regOp1, regOp2, arg);}
-void XEmitter::VFMSUB132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0x9A, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMSUB213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xAA, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMSUB231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xBA, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMSUB132SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0x9B, regOp1, regOp2, arg);}
-void XEmitter::VFMSUB213SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xAB, regOp1, regOp2, arg);}
-void XEmitter::VFMSUB231SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xBB, regOp1, regOp2, arg);}
-void XEmitter::VFMSUB132SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0x9B, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMSUB213SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xAB, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMSUB231SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)    {WriteFMA3Op(0xBB, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMADD132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0x9C, regOp1, regOp2, arg);}
-void XEmitter::VFNMADD213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xAC, regOp1, regOp2, arg);}
-void XEmitter::VFNMADD231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xBC, regOp1, regOp2, arg);}
-void XEmitter::VFNMADD132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0x9C, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMADD213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xAC, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMADD231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xBC, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMADD132SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0x9D, regOp1, regOp2, arg);}
-void XEmitter::VFNMADD213SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xAD, regOp1, regOp2, arg);}
-void XEmitter::VFNMADD231SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xBD, regOp1, regOp2, arg);}
-void XEmitter::VFNMADD132SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0x9D, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMADD213SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xAD, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMADD231SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xBD, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMSUB132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0x9E, regOp1, regOp2, arg);}
-void XEmitter::VFNMSUB213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xAE, regOp1, regOp2, arg);}
-void XEmitter::VFNMSUB231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xBE, regOp1, regOp2, arg);}
-void XEmitter::VFNMSUB132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0x9E, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMSUB213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xAE, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMSUB231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xBE, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMSUB132SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0x9F, regOp1, regOp2, arg);}
-void XEmitter::VFNMSUB213SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xAF, regOp1, regOp2, arg);}
-void XEmitter::VFNMSUB231SS(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xBF, regOp1, regOp2, arg);}
-void XEmitter::VFNMSUB132SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0x9F, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMSUB213SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xAF, regOp1, regOp2, arg, 1);}
-void XEmitter::VFNMSUB231SD(X64Reg regOp1, X64Reg regOp2, OpArg arg)   {WriteFMA3Op(0xBF, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMADDSUB132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0x96, regOp1, regOp2, arg);}
-void XEmitter::VFMADDSUB213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0xA6, regOp1, regOp2, arg);}
-void XEmitter::VFMADDSUB231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0xB6, regOp1, regOp2, arg);}
-void XEmitter::VFMADDSUB132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0x96, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMADDSUB213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0xA6, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMADDSUB231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0xB6, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMSUBADD132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0x97, regOp1, regOp2, arg);}
-void XEmitter::VFMSUBADD213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0xA7, regOp1, regOp2, arg);}
-void XEmitter::VFMSUBADD231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0xB7, regOp1, regOp2, arg);}
-void XEmitter::VFMSUBADD132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0x97, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMSUBADD213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0xA7, regOp1, regOp2, arg, 1);}
-void XEmitter::VFMSUBADD231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteFMA3Op(0xB7, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMADD132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0x98, regOp1, regOp2, arg);}
+void XEmitter::VFMADD213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xA8, regOp1, regOp2, arg);}
+void XEmitter::VFMADD231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xB8, regOp1, regOp2, arg);}
+void XEmitter::VFMADD132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0x98, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMADD213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xA8, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMADD231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xB8, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMADD132SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0x99, regOp1, regOp2, arg);}
+void XEmitter::VFMADD213SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xA9, regOp1, regOp2, arg);}
+void XEmitter::VFMADD231SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xB9, regOp1, regOp2, arg);}
+void XEmitter::VFMADD132SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0x99, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMADD213SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xA9, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMADD231SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xB9, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMSUB132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0x9A, regOp1, regOp2, arg);}
+void XEmitter::VFMSUB213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xAA, regOp1, regOp2, arg);}
+void XEmitter::VFMSUB231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xBA, regOp1, regOp2, arg);}
+void XEmitter::VFMSUB132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0x9A, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMSUB213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xAA, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMSUB231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xBA, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMSUB132SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0x9B, regOp1, regOp2, arg);}
+void XEmitter::VFMSUB213SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xAB, regOp1, regOp2, arg);}
+void XEmitter::VFMSUB231SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xBB, regOp1, regOp2, arg);}
+void XEmitter::VFMSUB132SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0x9B, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMSUB213SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xAB, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMSUB231SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)    {WriteFMA3Op(0xBB, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMADD132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0x9C, regOp1, regOp2, arg);}
+void XEmitter::VFNMADD213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xAC, regOp1, regOp2, arg);}
+void XEmitter::VFNMADD231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xBC, regOp1, regOp2, arg);}
+void XEmitter::VFNMADD132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0x9C, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMADD213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xAC, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMADD231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xBC, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMADD132SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0x9D, regOp1, regOp2, arg);}
+void XEmitter::VFNMADD213SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xAD, regOp1, regOp2, arg);}
+void XEmitter::VFNMADD231SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xBD, regOp1, regOp2, arg);}
+void XEmitter::VFNMADD132SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0x9D, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMADD213SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xAD, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMADD231SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xBD, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMSUB132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0x9E, regOp1, regOp2, arg);}
+void XEmitter::VFNMSUB213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xAE, regOp1, regOp2, arg);}
+void XEmitter::VFNMSUB231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xBE, regOp1, regOp2, arg);}
+void XEmitter::VFNMSUB132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0x9E, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMSUB213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xAE, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMSUB231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xBE, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMSUB132SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0x9F, regOp1, regOp2, arg);}
+void XEmitter::VFNMSUB213SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xAF, regOp1, regOp2, arg);}
+void XEmitter::VFNMSUB231SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xBF, regOp1, regOp2, arg);}
+void XEmitter::VFNMSUB132SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0x9F, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMSUB213SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xAF, regOp1, regOp2, arg, 1);}
+void XEmitter::VFNMSUB231SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)   {WriteFMA3Op(0xBF, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMADDSUB132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0x96, regOp1, regOp2, arg);}
+void XEmitter::VFMADDSUB213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0xA6, regOp1, regOp2, arg);}
+void XEmitter::VFMADDSUB231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0xB6, regOp1, regOp2, arg);}
+void XEmitter::VFMADDSUB132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0x96, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMADDSUB213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0xA6, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMADDSUB231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0xB6, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMSUBADD132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0x97, regOp1, regOp2, arg);}
+void XEmitter::VFMSUBADD213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0xA7, regOp1, regOp2, arg);}
+void XEmitter::VFMSUBADD231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0xB7, regOp1, regOp2, arg);}
+void XEmitter::VFMSUBADD132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0x97, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMSUBADD213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0xA7, regOp1, regOp2, arg, 1);}
+void XEmitter::VFMSUBADD231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteFMA3Op(0xB7, regOp1, regOp2, arg, 1);}
 
-void XEmitter::SARX(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {WriteBMI2Op(bits, 0xF3, 0x38F7, regOp1, regOp2, arg);}
-void XEmitter::SHLX(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {WriteBMI2Op(bits, 0x66, 0x38F7, regOp1, regOp2, arg);}
-void XEmitter::SHRX(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {WriteBMI2Op(bits, 0xF2, 0x38F7, regOp1, regOp2, arg);}
-void XEmitter::RORX(int bits, X64Reg regOp, OpArg arg, u8 rotate)      {WriteBMI2Op(bits, 0xF2, 0x3AF0, regOp, INVALID_REG, arg, 1); Write8(rotate);}
-void XEmitter::PEXT(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteBMI2Op(bits, 0xF3, 0x38F5, regOp1, regOp2, arg);}
-void XEmitter::PDEP(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteBMI2Op(bits, 0xF2, 0x38F5, regOp1, regOp2, arg);}
-void XEmitter::MULX(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteBMI2Op(bits, 0xF2, 0x38F6, regOp2, regOp1, arg);}
-void XEmitter::BZHI(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {WriteBMI2Op(bits, 0x00, 0x38F5, regOp1, regOp2, arg);}
-void XEmitter::BLSR(int bits, X64Reg regOp, OpArg arg)                 {WriteBMI1Op(bits, 0x00, 0x38F3, (X64Reg)0x1, regOp, arg);}
-void XEmitter::BLSMSK(int bits, X64Reg regOp, OpArg arg)               {WriteBMI1Op(bits, 0x00, 0x38F3, (X64Reg)0x2, regOp, arg);}
-void XEmitter::BLSI(int bits, X64Reg regOp, OpArg arg)                 {WriteBMI1Op(bits, 0x00, 0x38F3, (X64Reg)0x3, regOp, arg);}
-void XEmitter::BEXTR(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2){WriteBMI1Op(bits, 0x00, 0x38F7, regOp1, regOp2, arg);}
-void XEmitter::ANDN(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg) {WriteBMI1Op(bits, 0x00, 0x38F2, regOp1, regOp2, arg);}
+void XEmitter::SARX(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2) {WriteBMI2Op(bits, 0xF3, 0x38F7, regOp1, regOp2, arg);}
+void XEmitter::SHLX(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2) {WriteBMI2Op(bits, 0x66, 0x38F7, regOp1, regOp2, arg);}
+void XEmitter::SHRX(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2) {WriteBMI2Op(bits, 0xF2, 0x38F7, regOp1, regOp2, arg);}
+void XEmitter::RORX(int bits, X64Reg regOp, const OpArg& arg, u8 rotate)      {WriteBMI2Op(bits, 0xF2, 0x3AF0, regOp, INVALID_REG, arg, 1); Write8(rotate);}
+void XEmitter::PEXT(int bits, X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteBMI2Op(bits, 0xF3, 0x38F5, regOp1, regOp2, arg);}
+void XEmitter::PDEP(int bits, X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteBMI2Op(bits, 0xF2, 0x38F5, regOp1, regOp2, arg);}
+void XEmitter::MULX(int bits, X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteBMI2Op(bits, 0xF2, 0x38F6, regOp2, regOp1, arg);}
+void XEmitter::BZHI(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2) {WriteBMI2Op(bits, 0x00, 0x38F5, regOp1, regOp2, arg);}
+void XEmitter::BLSR(int bits, X64Reg regOp, const OpArg& arg)                 {WriteBMI1Op(bits, 0x00, 0x38F3, (X64Reg)0x1, regOp, arg);}
+void XEmitter::BLSMSK(int bits, X64Reg regOp, const OpArg& arg)               {WriteBMI1Op(bits, 0x00, 0x38F3, (X64Reg)0x2, regOp, arg);}
+void XEmitter::BLSI(int bits, X64Reg regOp, const OpArg& arg)                 {WriteBMI1Op(bits, 0x00, 0x38F3, (X64Reg)0x3, regOp, arg);}
+void XEmitter::BEXTR(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2){WriteBMI1Op(bits, 0x00, 0x38F7, regOp1, regOp2, arg);}
+void XEmitter::ANDN(int bits, X64Reg regOp1, X64Reg regOp2, const OpArg& arg) {WriteBMI1Op(bits, 0x00, 0x38F2, regOp1, regOp2, arg);}
 
 // Prefixes
 
@@ -1949,7 +1949,7 @@ void XEmitter::FWAIT()
 }
 
 // TODO: make this more generic
-void XEmitter::WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, OpArg arg)
+void XEmitter::WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, const OpArg& arg)
 {
 	int mf = 0;
 	_assert_msg_(DYNA_REC, !(bits == 80 && op_80b == floatINVALID), "WriteFloatLoadStore: 80 bits not supported for this instruction");
@@ -1967,9 +1967,9 @@ void XEmitter::WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, OpArg a
 	arg.WriteRest(this, 0, (X64Reg) op);
 }
 
-void XEmitter::FLD(int bits, OpArg src) {WriteFloatLoadStore(bits, floatLD, floatLD80, src);}
-void XEmitter::FST(int bits, OpArg dest) {WriteFloatLoadStore(bits, floatST, floatINVALID, dest);}
-void XEmitter::FSTP(int bits, OpArg dest) {WriteFloatLoadStore(bits, floatSTP, floatSTP80, dest);}
+void XEmitter::FLD(int bits, const OpArg& src)   { WriteFloatLoadStore(bits, floatLD, floatLD80, src); }
+void XEmitter::FST(int bits, const OpArg& dest)  { WriteFloatLoadStore(bits, floatST, floatINVALID, dest); }
+void XEmitter::FSTP(int bits, const OpArg& dest) { WriteFloatLoadStore(bits, floatSTP, floatSTP80, dest); }
 void XEmitter::FNSTSW_AX() { Write8(0xDF); Write8(0xE0); }
 
 void XEmitter::RDTSC() { Write8(0x0F); Write8(0x31); }

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -886,7 +886,7 @@ void XEmitter::WriteMOVBE(int bits, u8 op, X64Reg reg, OpArg arg)
 void XEmitter::MOVBE(int bits, X64Reg dest, const OpArg& src) {WriteMOVBE(bits, 0xF0, dest, src);}
 void XEmitter::MOVBE(int bits, const OpArg& dest, X64Reg src) {WriteMOVBE(bits, 0xF1, src, dest);}
 
-void XEmitter::LoadAndSwap(int size, Gen::X64Reg dst, const Gen::OpArg& src)
+void XEmitter::LoadAndSwap(int size, X64Reg dst, const OpArg& src)
 {
 	if (cpu_info.bMOVBE)
 	{
@@ -899,7 +899,7 @@ void XEmitter::LoadAndSwap(int size, Gen::X64Reg dst, const Gen::OpArg& src)
 	}
 }
 
-void XEmitter::SwapAndStore(int size, const Gen::OpArg& dst, Gen::X64Reg src)
+void XEmitter::SwapAndStore(int size, const OpArg& dst, X64Reg src)
 {
 	if (cpu_info.bMOVBE)
 	{

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -145,11 +145,11 @@ struct OpArg
 		return operandReg == b.operandReg && scale == b.scale && offsetOrBaseReg == b.offsetOrBaseReg &&
 		       indexReg == b.indexReg && offset == b.offset;
 	}
-	void WriteREX(XEmitter *emit, int opBits, int bits, int customOp = -1) const;
+	void WriteREX(XEmitter* emit, int opBits, int bits, int customOp = -1) const;
 	void WriteVEX(XEmitter* emit, X64Reg regOp1, X64Reg regOp2, int L, int pp, int mmmmm, int W = 0) const;
-	void WriteRest(XEmitter *emit, int extraBytes=0, X64Reg operandReg=INVALID_REG, bool warn_64bit_offset = true) const;
-	void WriteFloatModRM(XEmitter *emit, FloatOp op);
-	void WriteSingleByteOp(XEmitter *emit, u8 op, X64Reg operandReg, int bits);
+	void WriteRest(XEmitter* emit, int extraBytes=0, X64Reg operandReg=INVALID_REG, bool warn_64bit_offset = true) const;
+	void WriteFloatModRM(XEmitter* emit, FloatOp op);
+	void WriteSingleByteOp(XEmitter* emit, u8 op, X64Reg operandReg, int bits);
 
 	u64 Imm64() const { _dbg_assert_(DYNA_REC, scale == SCALE_IMM64); return (u64)offset; }
 	u32 Imm32() const { _dbg_assert_(DYNA_REC, scale == SCALE_IMM32); return (u32)offset; }
@@ -161,7 +161,7 @@ struct OpArg
 	s16 SImm16() const { _dbg_assert_(DYNA_REC, scale == SCALE_IMM16); return (s16)offset; }
 	s8  SImm8()  const { _dbg_assert_(DYNA_REC, scale == SCALE_IMM8);  return (s8)offset; }
 
-	void WriteNormalOp(XEmitter *emit, bool toRM, NormalOp op, const OpArg &operand, int bits) const;
+	void WriteNormalOp(XEmitter* emit, bool toRM, NormalOp op, const OpArg& operand, int bits) const;
 	bool IsImm() const {return scale == SCALE_IMM8 || scale == SCALE_IMM16 || scale == SCALE_IMM32 || scale == SCALE_IMM64;}
 	bool IsSimpleReg() const {return scale == SCALE_NONE;}
 	bool IsSimpleReg(X64Reg reg) const
@@ -171,7 +171,7 @@ struct OpArg
 		return GetSimpleReg() == reg;
 	}
 
-	bool CanDoOpWith(const OpArg &other) const
+	bool CanDoOpWith(const OpArg& other) const
 	{
 		if (IsSimpleReg()) return true;
 		if (!IsSimpleReg() && !other.IsSimpleReg() && !other.IsImm()) return false;
@@ -214,7 +214,7 @@ private:
 };
 
 template <typename T>
-inline OpArg M(const T *ptr)    {return OpArg((u64)(const void *)ptr, (int)SCALE_RIP);}
+inline OpArg M(const T* ptr)    {return OpArg((u64)(const void*)ptr, (int)SCALE_RIP);}
 inline OpArg R(X64Reg value)    {return OpArg(0, SCALE_NONE, value);}
 inline OpArg MatR(X64Reg value) {return OpArg(0, SCALE_ATREG, value);}
 
@@ -275,7 +275,7 @@ inline u32 PtrOffset(const void* ptr, const void* base)
 
 struct FixupBranch
 {
-	u8 *ptr;
+	u8* ptr;
 	int type; //0 = 8bit 1 = 32bit
 };
 
@@ -297,7 +297,7 @@ class XEmitter
 {
 	friend struct OpArg;  // for Write8 etc
 private:
-	u8 *code;
+	u8* code;
 	bool flags_locked;
 
 	void CheckFlags();
@@ -307,8 +307,8 @@ private:
 	void WriteSimple2Byte(int bits, u8 byte1, u8 byte2, X64Reg reg);
 	void WriteMulDivType(int bits, OpArg src, int ext);
 	void WriteBitSearchType(int bits, X64Reg dest, OpArg src, u8 byte2, bool rep = false);
-	void WriteShift(int bits, OpArg dest, OpArg &shift, int ext);
-	void WriteBitTest(int bits, OpArg &dest, OpArg &index, int ext);
+	void WriteShift(int bits, OpArg dest, OpArg& shift, int ext);
+	void WriteBitTest(int bits, OpArg& dest, OpArg& index, int ext);
 	void WriteMXCSR(OpArg arg, int ext);
 	void WriteSSEOp(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes = 0);
 	void WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes = 0);
@@ -323,7 +323,7 @@ private:
 	void WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes = 0);
 	void WriteMOVBE(int bits, u8 op, X64Reg regOp, OpArg arg);
 	void WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, OpArg arg);
-	void WriteNormalOp(int bits, NormalOp op, const OpArg &a1, const OpArg &a2);
+	void WriteNormalOp(int bits, NormalOp op, const OpArg& a1, const OpArg& a2);
 
 	void ABI_CalculateFrameSize(BitSet32 mask, size_t rsp_alignment, size_t needed_frame_size, size_t* shadowp, size_t* subtractionp, size_t* xmm_offsetp);
 
@@ -335,19 +335,19 @@ protected:
 
 public:
 	XEmitter() { code = nullptr; flags_locked = false; }
-	XEmitter(u8 *code_ptr) { code = code_ptr; flags_locked = false; }
+	XEmitter(u8* code_ptr) { code = code_ptr; flags_locked = false; }
 	virtual ~XEmitter() {}
 
 	void WriteModRM(int mod, int rm, int reg);
 	void WriteSIB(int scale, int index, int base);
 
-	void SetCodePtr(u8 *ptr);
+	void SetCodePtr(u8* ptr);
 	void ReserveCodeSpace(int bytes);
-	const u8 *AlignCode4();
-	const u8 *AlignCode16();
-	const u8 *AlignCodePage();
-	const u8 *GetCodePtr() const;
-	u8 *GetWritableCodePtr();
+	const u8* AlignCode4();
+	const u8* AlignCode16();
+	const u8* AlignCodePage();
+	const u8* GetCodePtr() const;
+	u8* GetWritableCodePtr();
 
 	void LockFlags() { flags_locked = true; }
 	void UnlockFlags() { flags_locked = false; }
@@ -380,8 +380,8 @@ public:
 	// Stack control
 	void PUSH(X64Reg reg);
 	void POP(X64Reg reg);
-	void PUSH(int bits, const OpArg &reg);
-	void POP(int bits, const OpArg &reg);
+	void PUSH(int bits, const OpArg& reg);
+	void POP(int bits, const OpArg& reg);
 	void PUSHF();
 	void POPF();
 
@@ -391,20 +391,20 @@ public:
 	void UD2();
 	FixupBranch J(bool force5bytes = false);
 
-	void JMP(const u8 * addr, bool force5Bytes = false);
-	void JMPptr(const OpArg &arg);
+	void JMP(const u8* addr, bool force5Bytes = false);
+	void JMPptr(const OpArg& arg);
 	void JMPself(); //infinite loop!
 #ifdef CALL
 #undef CALL
 #endif
-	void CALL(const void *fnptr);
+	void CALL(const void* fnptr);
 	void CALLptr(OpArg arg);
 
 	FixupBranch J_CC(CCFlags conditionCode, bool force5bytes = false);
 	//void J_CC(CCFlags conditionCode, JumpTarget target);
 	void J_CC(CCFlags conditionCode, const u8* addr);
 
-	void SetJumpTarget(const FixupBranch &branch);
+	void SetJumpTarget(const FixupBranch& branch);
 
 	void SETcc(CCFlags flag, OpArg dest);
 	// Note: CMOV brings small if any benefit on current CPUs.
@@ -473,24 +473,24 @@ public:
 
 	// Integer arithmetic
 	void NEG (int bits, OpArg src);
-	void ADD (int bits, const OpArg &a1, const OpArg &a2);
-	void ADC (int bits, const OpArg &a1, const OpArg &a2);
-	void SUB (int bits, const OpArg &a1, const OpArg &a2);
-	void SBB (int bits, const OpArg &a1, const OpArg &a2);
-	void AND (int bits, const OpArg &a1, const OpArg &a2);
-	void CMP (int bits, const OpArg &a1, const OpArg &a2);
+	void ADD (int bits, const OpArg& a1, const OpArg& a2);
+	void ADC (int bits, const OpArg& a1, const OpArg& a2);
+	void SUB (int bits, const OpArg& a1, const OpArg& a2);
+	void SBB (int bits, const OpArg& a1, const OpArg& a2);
+	void AND (int bits, const OpArg& a1, const OpArg& a2);
+	void CMP (int bits, const OpArg& a1, const OpArg& a2);
 
 	// Bit operations
 	void NOT (int bits, OpArg src);
-	void OR  (int bits, const OpArg &a1, const OpArg &a2);
-	void XOR (int bits, const OpArg &a1, const OpArg &a2);
-	void MOV (int bits, const OpArg &a1, const OpArg &a2);
-	void TEST(int bits, const OpArg &a1, const OpArg &a2);
+	void OR  (int bits, const OpArg& a1, const OpArg& a2);
+	void XOR (int bits, const OpArg& a1, const OpArg& a2);
+	void MOV (int bits, const OpArg& a1, const OpArg& a2);
+	void TEST(int bits, const OpArg& a1, const OpArg& a2);
 
-	void CMP_or_TEST(int bits, const OpArg &a1, const OpArg &a2);
+	void CMP_or_TEST(int bits, const OpArg& a1, const OpArg& a2);
 
 	// Are these useful at all? Consider removing.
-	void XCHG(int bits, const OpArg &a1, const OpArg &a2);
+	void XCHG(int bits, const OpArg& a1, const OpArg& a2);
 	void XCHG_AHAL();
 
 	// Byte swapping (32 and 64-bit only).
@@ -661,9 +661,9 @@ public:
 	// one is the xmm reg.
 	// ie: "MOVD_xmm(eax, R(xmm1))" generates incorrect code (movd xmm0, rcx)
 	//     use "MOVD_xmm(R(eax), xmm1)" instead.
-	void MOVD_xmm(X64Reg dest, const OpArg &arg);
+	void MOVD_xmm(X64Reg dest, const OpArg& arg);
 	void MOVQ_xmm(X64Reg dest, OpArg arg);
-	void MOVD_xmm(const OpArg &arg, X64Reg src);
+	void MOVD_xmm(const OpArg& arg, X64Reg src);
 	void MOVQ_xmm(OpArg arg, X64Reg src);
 
 	// SSE/SSE2: Generates a mask from the high bits of the components of the packed register in question.
@@ -701,10 +701,10 @@ public:
 	void PACKUSDW(X64Reg dest, OpArg arg);
 	void PACKUSWB(X64Reg dest, OpArg arg);
 
-	void PUNPCKLBW(X64Reg dest, const OpArg &arg);
-	void PUNPCKLWD(X64Reg dest, const OpArg &arg);
-	void PUNPCKLDQ(X64Reg dest, const OpArg &arg);
-	void PUNPCKLQDQ(X64Reg dest, const OpArg &arg);
+	void PUNPCKLBW(X64Reg dest, const OpArg& arg);
+	void PUNPCKLWD(X64Reg dest, const OpArg& arg);
+	void PUNPCKLDQ(X64Reg dest, const OpArg& arg);
+	void PUNPCKLQDQ(X64Reg dest, const OpArg& arg);
 
 	void PTEST(X64Reg dest, OpArg arg);
 	void PAND(X64Reg dest, OpArg arg);
@@ -908,27 +908,27 @@ public:
 	// Utility functions
 	// The difference between this and CALL is that this aligns the stack
 	// where appropriate.
-	void ABI_CallFunction(const void *func);
+	void ABI_CallFunction(const void* func);
 
-	void ABI_CallFunctionC16(const void *func, u16 param1);
-	void ABI_CallFunctionCC16(const void *func, u32 param1, u16 param2);
+	void ABI_CallFunctionC16(const void* func, u16 param1);
+	void ABI_CallFunctionCC16(const void* func, u32 param1, u16 param2);
 
 	// These only support u32 parameters, but that's enough for a lot of uses.
 	// These will destroy the 1 or 2 first "parameter regs".
-	void ABI_CallFunctionC(const void *func, u32 param1);
-	void ABI_CallFunctionCC(const void *func, u32 param1, u32 param2);
-	void ABI_CallFunctionCP(const void *func, u32 param1, void *param2);
-	void ABI_CallFunctionCCC(const void *func, u32 param1, u32 param2, u32 param3);
-	void ABI_CallFunctionCCP(const void *func, u32 param1, u32 param2, void *param3);
-	void ABI_CallFunctionCCCP(const void *func, u32 param1, u32 param2,u32 param3, void *param4);
-	void ABI_CallFunctionPC(const void *func, void *param1, u32 param2);
-	void ABI_CallFunctionPPC(const void *func, void *param1, void *param2, u32 param3);
-	void ABI_CallFunctionAC(int bits, const void *func, const OpArg &arg1, u32 param2);
-	void ABI_CallFunctionA(int bits, const void *func, const OpArg &arg1);
+	void ABI_CallFunctionC(const void* func, u32 param1);
+	void ABI_CallFunctionCC(const void* func, u32 param1, u32 param2);
+	void ABI_CallFunctionCP(const void* func, u32 param1, void* param2);
+	void ABI_CallFunctionCCC(const void* func, u32 param1, u32 param2, u32 param3);
+	void ABI_CallFunctionCCP(const void* func, u32 param1, u32 param2, void* param3);
+	void ABI_CallFunctionCCCP(const void* func, u32 param1, u32 param2,u32 param3, void* param4);
+	void ABI_CallFunctionPC(const void* func, void* param1, u32 param2);
+	void ABI_CallFunctionPPC(const void* func, void* param1, void* param2, u32 param3);
+	void ABI_CallFunctionAC(int bits, const void* func, const OpArg& arg1, u32 param2);
+	void ABI_CallFunctionA(int bits, const void* func, const OpArg& arg1);
 
 	// Pass a register as a parameter.
-	void ABI_CallFunctionR(const void *func, X64Reg reg1);
-	void ABI_CallFunctionRR(const void *func, X64Reg reg1, X64Reg reg2);
+	void ABI_CallFunctionR(const void* func, X64Reg reg1);
+	void ABI_CallFunctionRR(const void* func, X64Reg reg1, X64Reg reg2);
 
 	// Helper method for the above, or can be used separately.
 	void MOVTwo(int bits, Gen::X64Reg dst1, Gen::X64Reg src1, s32 offset, Gen::X64Reg dst2, Gen::X64Reg src2);

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -140,7 +140,7 @@ struct OpArg
 		//if scale == 0 never mind offsetting
 		offset = _offset;
 	}
-	bool operator==(OpArg b)
+	bool operator==(const OpArg& b) const
 	{
 		return operandReg == b.operandReg && scale == b.scale && offsetOrBaseReg == b.offsetOrBaseReg &&
 		       indexReg == b.indexReg && offset == b.offset;
@@ -307,22 +307,22 @@ private:
 	void WriteSimple2Byte(int bits, u8 byte1, u8 byte2, X64Reg reg);
 	void WriteMulDivType(int bits, OpArg src, int ext);
 	void WriteBitSearchType(int bits, X64Reg dest, OpArg src, u8 byte2, bool rep = false);
-	void WriteShift(int bits, OpArg dest, OpArg& shift, int ext);
-	void WriteBitTest(int bits, OpArg& dest, OpArg& index, int ext);
+	void WriteShift(int bits, OpArg dest, const OpArg& shift, int ext);
+	void WriteBitTest(int bits, const OpArg& dest, const OpArg& index, int ext);
 	void WriteMXCSR(OpArg arg, int ext);
 	void WriteSSEOp(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes = 0);
-	void WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes = 0);
-	void WriteSSE41Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes = 0);
-	void WriteVEXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int W = 0, int extrabytes = 0);
-	void WriteVEXOp4(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, X64Reg regOp3, int W = 0);
-	void WriteAVXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int W = 0, int extrabytes = 0);
-	void WriteAVXOp4(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, X64Reg regOp3, int W = 0);
-	void WriteFMA3Op(u8 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int W = 0);
-	void WriteBMIOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes = 0);
-	void WriteBMI1Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes = 0);
-	void WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes = 0);
-	void WriteMOVBE(int bits, u8 op, X64Reg regOp, OpArg arg);
-	void WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, OpArg arg);
+	void WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, const OpArg& arg, int extrabytes = 0);
+	void WriteSSE41Op(u8 opPrefix, u16 op, X64Reg regOp, const OpArg& arg, int extrabytes = 0);
+	void WriteVEXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int W = 0, int extrabytes = 0);
+	void WriteVEXOp4(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, X64Reg regOp3, int W = 0);
+	void WriteAVXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int W = 0, int extrabytes = 0);
+	void WriteAVXOp4(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, X64Reg regOp3, int W = 0);
+	void WriteFMA3Op(u8 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int W = 0);
+	void WriteBMIOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int extrabytes = 0);
+	void WriteBMI1Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int extrabytes = 0);
+	void WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, const OpArg& arg, int extrabytes = 0);
+	void WriteMOVBE(int bits, u8 op, X64Reg regOp, const OpArg& arg);
+	void WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, const OpArg& arg);
 	void WriteNormalOp(int bits, NormalOp op, const OpArg& a1, const OpArg& a2);
 
 	void ABI_CalculateFrameSize(BitSet32 mask, size_t rsp_alignment, size_t needed_frame_size, size_t* shadowp, size_t* subtractionp, size_t* xmm_offsetp);
@@ -416,8 +416,8 @@ public:
 	void SFENCE();
 
 	// Bit scan
-	void BSF(int bits, X64Reg dest, OpArg src); //bottom bit to top bit
-	void BSR(int bits, X64Reg dest, OpArg src); //top bit to bottom bit
+	void BSF(int bits, X64Reg dest, const OpArg& src); // Bottom bit to top bit
+	void BSR(int bits, X64Reg dest, const OpArg& src); // Top bit to bottom bit
 
 	// Cache control
 	enum PrefetchLevel
@@ -428,37 +428,37 @@ public:
 		PF_T2,  //Levels 3+ (aliased to T0 on AMD)
 	};
 	void PREFETCH(PrefetchLevel level, OpArg arg);
-	void MOVNTI(int bits, OpArg dest, X64Reg src);
-	void MOVNTDQ(OpArg arg, X64Reg regOp);
-	void MOVNTPS(OpArg arg, X64Reg regOp);
-	void MOVNTPD(OpArg arg, X64Reg regOp);
+	void MOVNTI(int bits, const OpArg& dest, X64Reg src);
+	void MOVNTDQ(const OpArg& arg, X64Reg regOp);
+	void MOVNTPS(const OpArg& arg, X64Reg regOp);
+	void MOVNTPD(const OpArg& arg, X64Reg regOp);
 
 	// Multiplication / division
-	void MUL(int bits, OpArg src); //UNSIGNED
-	void IMUL(int bits, OpArg src); //SIGNED
-	void IMUL(int bits, X64Reg regOp, OpArg src);
-	void IMUL(int bits, X64Reg regOp, OpArg src, OpArg imm);
-	void DIV(int bits, OpArg src);
-	void IDIV(int bits, OpArg src);
+	void MUL(int bits, const OpArg& src);  // UNSIGNED
+	void IMUL(int bits, const OpArg& src); // SIGNED
+	void IMUL(int bits, X64Reg regOp, const OpArg& src);
+	void IMUL(int bits, X64Reg regOp, const OpArg& src, const OpArg& imm);
+	void DIV(int bits, const OpArg& src);
+	void IDIV(int bits, const OpArg& src);
 
 	// Shift
-	void ROL(int bits, OpArg dest, OpArg shift);
-	void ROR(int bits, OpArg dest, OpArg shift);
-	void RCL(int bits, OpArg dest, OpArg shift);
-	void RCR(int bits, OpArg dest, OpArg shift);
-	void SHL(int bits, OpArg dest, OpArg shift);
-	void SHR(int bits, OpArg dest, OpArg shift);
-	void SAR(int bits, OpArg dest, OpArg shift);
+	void ROL(int bits, const OpArg& dest, const OpArg& shift);
+	void ROR(int bits, const OpArg& dest, const OpArg& shift);
+	void RCL(int bits, const OpArg& dest, const OpArg& shift);
+	void RCR(int bits, const OpArg& dest, const OpArg& shift);
+	void SHL(int bits, const OpArg& dest, const OpArg& shift);
+	void SHR(int bits, const OpArg& dest, const OpArg& shift);
+	void SAR(int bits, const OpArg& dest, const OpArg& shift);
 
 	// Bit Test
-	void BT(int bits, OpArg dest, OpArg index);
-	void BTS(int bits, OpArg dest, OpArg index);
-	void BTR(int bits, OpArg dest, OpArg index);
-	void BTC(int bits, OpArg dest, OpArg index);
+	void BT(int bits, const OpArg& dest, const OpArg& index);
+	void BTS(int bits, const OpArg& dest, const OpArg& index);
+	void BTR(int bits, const OpArg& dest, const OpArg& index);
+	void BTC(int bits, const OpArg& dest, const OpArg& index);
 
 	// Double-Precision Shift
-	void SHRD(int bits, OpArg dest, OpArg src, OpArg shift);
-	void SHLD(int bits, OpArg dest, OpArg src, OpArg shift);
+	void SHRD(int bits, const OpArg& dest, const OpArg& src, const OpArg& shift);
+	void SHLD(int bits, const OpArg& dest, const OpArg& src, const OpArg& shift);
 
 	// Extend EAX into EDX in various ways
 	void CWD(int bits = 16);
@@ -472,7 +472,7 @@ public:
 	void LEA(int bits, X64Reg dest, OpArg src);
 
 	// Integer arithmetic
-	void NEG (int bits, OpArg src);
+	void NEG (int bits, const OpArg& src);
 	void ADD (int bits, const OpArg& a1, const OpArg& a2);
 	void ADC (int bits, const OpArg& a1, const OpArg& a2);
 	void SUB (int bits, const OpArg& a1, const OpArg& a2);
@@ -481,7 +481,7 @@ public:
 	void CMP (int bits, const OpArg& a1, const OpArg& a2);
 
 	// Bit operations
-	void NOT (int bits, OpArg src);
+	void NOT (int bits, const OpArg& src);
 	void OR  (int bits, const OpArg& a1, const OpArg& a2);
 	void XOR (int bits, const OpArg& a1, const OpArg& a2);
 	void MOV (int bits, const OpArg& a1, const OpArg& a2);
@@ -507,13 +507,13 @@ public:
 	void SwapAndStore(int size, const OpArg& dst, X64Reg src);
 
 	// Available only on AMD >= Phenom or Intel >= Haswell
-	void LZCNT(int bits, X64Reg dest, OpArg src);
+	void LZCNT(int bits, X64Reg dest, const OpArg& src);
 	// Note: this one is actually part of BMI1
-	void TZCNT(int bits, X64Reg dest, OpArg src);
+	void TZCNT(int bits, X64Reg dest, const OpArg& src);
 
 	// WARNING - These two take 11-13 cycles and are VectorPath! (AMD64)
-	void STMXCSR(OpArg memloc);
-	void LDMXCSR(OpArg memloc);
+	void STMXCSR(const OpArg& memloc);
+	void LDMXCSR(const OpArg& memloc);
 
 	// Prefixes
 	void LOCK();
@@ -540,118 +540,118 @@ public:
 		x87_FPUBusy = 0x8000,
 	};
 
-	void FLD(int bits, OpArg src);
-	void FST(int bits, OpArg dest);
-	void FSTP(int bits, OpArg dest);
+	void FLD(int bits, const OpArg& src);
+	void FST(int bits, const OpArg& dest);
+	void FSTP(int bits, const OpArg& dest);
 	void FNSTSW_AX();
 	void FWAIT();
 
 	// SSE/SSE2: Floating point arithmetic
-	void ADDSS(X64Reg regOp, OpArg arg);
-	void ADDSD(X64Reg regOp, OpArg arg);
-	void SUBSS(X64Reg regOp, OpArg arg);
-	void SUBSD(X64Reg regOp, OpArg arg);
-	void MULSS(X64Reg regOp, OpArg arg);
-	void MULSD(X64Reg regOp, OpArg arg);
-	void DIVSS(X64Reg regOp, OpArg arg);
-	void DIVSD(X64Reg regOp, OpArg arg);
-	void MINSS(X64Reg regOp, OpArg arg);
-	void MINSD(X64Reg regOp, OpArg arg);
-	void MAXSS(X64Reg regOp, OpArg arg);
-	void MAXSD(X64Reg regOp, OpArg arg);
-	void SQRTSS(X64Reg regOp, OpArg arg);
-	void SQRTSD(X64Reg regOp, OpArg arg);
-	void RSQRTSS(X64Reg regOp, OpArg arg);
+	void ADDSS(X64Reg regOp, const OpArg& arg);
+	void ADDSD(X64Reg regOp, const OpArg& arg);
+	void SUBSS(X64Reg regOp, const OpArg& arg);
+	void SUBSD(X64Reg regOp, const OpArg& arg);
+	void MULSS(X64Reg regOp, const OpArg& arg);
+	void MULSD(X64Reg regOp, const OpArg& arg);
+	void DIVSS(X64Reg regOp, const OpArg& arg);
+	void DIVSD(X64Reg regOp, const OpArg& arg);
+	void MINSS(X64Reg regOp, const OpArg& arg);
+	void MINSD(X64Reg regOp, const OpArg& arg);
+	void MAXSS(X64Reg regOp, const OpArg& arg);
+	void MAXSD(X64Reg regOp, const OpArg& arg);
+	void SQRTSS(X64Reg regOp, const OpArg& arg);
+	void SQRTSD(X64Reg regOp, const OpArg& arg);
+	void RSQRTSS(X64Reg regOp, const OpArg& arg);
 
 	// SSE/SSE2: Floating point bitwise (yes)
-	void CMPSS(X64Reg regOp, OpArg arg, u8 compare);
-	void CMPSD(X64Reg regOp, OpArg arg, u8 compare);
+	void CMPSS(X64Reg regOp, const OpArg& arg, u8 compare);
+	void CMPSD(X64Reg regOp, const OpArg& arg, u8 compare);
 
-	inline void CMPEQSS(X64Reg regOp, OpArg arg) { CMPSS(regOp, arg, CMP_EQ); }
-	inline void CMPLTSS(X64Reg regOp, OpArg arg) { CMPSS(regOp, arg, CMP_LT); }
-	inline void CMPLESS(X64Reg regOp, OpArg arg) { CMPSS(regOp, arg, CMP_LE); }
-	inline void CMPUNORDSS(X64Reg regOp, OpArg arg) { CMPSS(regOp, arg, CMP_UNORD); }
-	inline void CMPNEQSS(X64Reg regOp, OpArg arg) { CMPSS(regOp, arg, CMP_NEQ); }
-	inline void CMPNLTSS(X64Reg regOp, OpArg arg) { CMPSS(regOp, arg, CMP_NLT); }
-	inline void CMPORDSS(X64Reg regOp, OpArg arg) { CMPSS(regOp, arg, CMP_ORD); }
+	inline void CMPEQSS(X64Reg regOp, const OpArg& arg) { CMPSS(regOp, arg, CMP_EQ); }
+	inline void CMPLTSS(X64Reg regOp, const OpArg& arg) { CMPSS(regOp, arg, CMP_LT); }
+	inline void CMPLESS(X64Reg regOp, const OpArg& arg) { CMPSS(regOp, arg, CMP_LE); }
+	inline void CMPUNORDSS(X64Reg regOp, const OpArg& arg) { CMPSS(regOp, arg, CMP_UNORD); }
+	inline void CMPNEQSS(X64Reg regOp, const OpArg& arg) { CMPSS(regOp, arg, CMP_NEQ); }
+	inline void CMPNLTSS(X64Reg regOp, const OpArg& arg) { CMPSS(regOp, arg, CMP_NLT); }
+	inline void CMPORDSS(X64Reg regOp, const OpArg& arg) { CMPSS(regOp, arg, CMP_ORD); }
 
 	// SSE/SSE2: Floating point packed arithmetic (x4 for float, x2 for double)
-	void ADDPS(X64Reg regOp, OpArg arg);
-	void ADDPD(X64Reg regOp, OpArg arg);
-	void SUBPS(X64Reg regOp, OpArg arg);
-	void SUBPD(X64Reg regOp, OpArg arg);
-	void CMPPS(X64Reg regOp, OpArg arg, u8 compare);
-	void CMPPD(X64Reg regOp, OpArg arg, u8 compare);
-	void MULPS(X64Reg regOp, OpArg arg);
-	void MULPD(X64Reg regOp, OpArg arg);
-	void DIVPS(X64Reg regOp, OpArg arg);
-	void DIVPD(X64Reg regOp, OpArg arg);
-	void MINPS(X64Reg regOp, OpArg arg);
-	void MINPD(X64Reg regOp, OpArg arg);
-	void MAXPS(X64Reg regOp, OpArg arg);
-	void MAXPD(X64Reg regOp, OpArg arg);
-	void SQRTPS(X64Reg regOp, OpArg arg);
-	void SQRTPD(X64Reg regOp, OpArg arg);
-	void RSQRTPS(X64Reg regOp, OpArg arg);
+	void ADDPS(X64Reg regOp, const OpArg& arg);
+	void ADDPD(X64Reg regOp, const OpArg& arg);
+	void SUBPS(X64Reg regOp, const OpArg& arg);
+	void SUBPD(X64Reg regOp, const OpArg& arg);
+	void CMPPS(X64Reg regOp, const OpArg& arg, u8 compare);
+	void CMPPD(X64Reg regOp, const OpArg& arg, u8 compare);
+	void MULPS(X64Reg regOp, const OpArg& arg);
+	void MULPD(X64Reg regOp, const OpArg& arg);
+	void DIVPS(X64Reg regOp, const OpArg& arg);
+	void DIVPD(X64Reg regOp, const OpArg& arg);
+	void MINPS(X64Reg regOp, const OpArg& arg);
+	void MINPD(X64Reg regOp, const OpArg& arg);
+	void MAXPS(X64Reg regOp, const OpArg& arg);
+	void MAXPD(X64Reg regOp, const OpArg& arg);
+	void SQRTPS(X64Reg regOp, const OpArg& arg);
+	void SQRTPD(X64Reg regOp, const OpArg& arg);
+	void RSQRTPS(X64Reg regOp, const OpArg& arg);
 
 	// SSE/SSE2: Floating point packed bitwise (x4 for float, x2 for double)
-	void ANDPS(X64Reg regOp, OpArg arg);
-	void ANDPD(X64Reg regOp, OpArg arg);
-	void ANDNPS(X64Reg regOp, OpArg arg);
-	void ANDNPD(X64Reg regOp, OpArg arg);
-	void ORPS(X64Reg regOp, OpArg arg);
-	void ORPD(X64Reg regOp, OpArg arg);
-	void XORPS(X64Reg regOp, OpArg arg);
-	void XORPD(X64Reg regOp, OpArg arg);
+	void ANDPS(X64Reg regOp, const OpArg& arg);
+	void ANDPD(X64Reg regOp, const OpArg& arg);
+	void ANDNPS(X64Reg regOp, const OpArg& arg);
+	void ANDNPD(X64Reg regOp, const OpArg& arg);
+	void ORPS(X64Reg regOp, const OpArg& arg);
+	void ORPD(X64Reg regOp, const OpArg& arg);
+	void XORPS(X64Reg regOp, const OpArg& arg);
+	void XORPD(X64Reg regOp, const OpArg& arg);
 
 	// SSE/SSE2: Shuffle components. These are tricky - see Intel documentation.
-	void SHUFPS(X64Reg regOp, OpArg arg, u8 shuffle);
-	void SHUFPD(X64Reg regOp, OpArg arg, u8 shuffle);
+	void SHUFPS(X64Reg regOp, const OpArg& arg, u8 shuffle);
+	void SHUFPD(X64Reg regOp, const OpArg& arg, u8 shuffle);
 
 	// SSE/SSE2: Useful alternative to shuffle in some cases.
-	void MOVDDUP(X64Reg regOp, OpArg arg);
+	void MOVDDUP(X64Reg regOp, const OpArg& arg);
 
-	void UNPCKLPS(X64Reg dest, OpArg src);
-	void UNPCKHPS(X64Reg dest, OpArg src);
-	void UNPCKLPD(X64Reg dest, OpArg src);
-	void UNPCKHPD(X64Reg dest, OpArg src);
+	void UNPCKLPS(X64Reg dest, const OpArg& src);
+	void UNPCKHPS(X64Reg dest, const OpArg& src);
+	void UNPCKLPD(X64Reg dest, const OpArg& src);
+	void UNPCKHPD(X64Reg dest, const OpArg& src);
 
 	// SSE/SSE2: Compares.
-	void COMISS(X64Reg regOp, OpArg arg);
-	void COMISD(X64Reg regOp, OpArg arg);
-	void UCOMISS(X64Reg regOp, OpArg arg);
-	void UCOMISD(X64Reg regOp, OpArg arg);
+	void COMISS(X64Reg regOp, const OpArg& arg);
+	void COMISD(X64Reg regOp, const OpArg& arg);
+	void UCOMISS(X64Reg regOp, const OpArg& arg);
+	void UCOMISD(X64Reg regOp, const OpArg& arg);
 
 	// SSE/SSE2: Moves. Use the right data type for your data, in most cases.
-	void MOVAPS(X64Reg regOp, OpArg arg);
-	void MOVAPD(X64Reg regOp, OpArg arg);
-	void MOVAPS(OpArg arg, X64Reg regOp);
-	void MOVAPD(OpArg arg, X64Reg regOp);
+	void MOVAPS(X64Reg regOp, const OpArg& arg);
+	void MOVAPD(X64Reg regOp, const OpArg& arg);
+	void MOVAPS(const OpArg& arg, X64Reg regOp);
+	void MOVAPD(const OpArg& arg, X64Reg regOp);
 
-	void MOVUPS(X64Reg regOp, OpArg arg);
-	void MOVUPD(X64Reg regOp, OpArg arg);
-	void MOVUPS(OpArg arg, X64Reg regOp);
-	void MOVUPD(OpArg arg, X64Reg regOp);
+	void MOVUPS(X64Reg regOp, const OpArg& arg);
+	void MOVUPD(X64Reg regOp, const OpArg& arg);
+	void MOVUPS(const OpArg& arg, X64Reg regOp);
+	void MOVUPD(const OpArg& arg, X64Reg regOp);
 
-	void MOVDQA(X64Reg regOp, OpArg arg);
-	void MOVDQA(OpArg arg, X64Reg regOp);
-	void MOVDQU(X64Reg regOp, OpArg arg);
-	void MOVDQU(OpArg arg, X64Reg regOp);
+	void MOVDQA(X64Reg regOp, const OpArg& arg);
+	void MOVDQA(const OpArg& arg, X64Reg regOp);
+	void MOVDQU(X64Reg regOp, const OpArg& arg);
+	void MOVDQU(const OpArg& arg, X64Reg regOp);
 
-	void MOVSS(X64Reg regOp, OpArg arg);
-	void MOVSD(X64Reg regOp, OpArg arg);
-	void MOVSS(OpArg arg, X64Reg regOp);
-	void MOVSD(OpArg arg, X64Reg regOp);
+	void MOVSS(X64Reg regOp, const OpArg& arg);
+	void MOVSD(X64Reg regOp, const OpArg& arg);
+	void MOVSS(const OpArg& arg, X64Reg regOp);
+	void MOVSD(const OpArg& arg, X64Reg regOp);
 
-	void MOVLPS(X64Reg regOp, OpArg arg);
-	void MOVLPD(X64Reg regOp, OpArg arg);
-	void MOVLPS(OpArg arg, X64Reg regOp);
-	void MOVLPD(OpArg arg, X64Reg regOp);
+	void MOVLPS(X64Reg regOp, const OpArg& arg);
+	void MOVLPD(X64Reg regOp, const OpArg& arg);
+	void MOVLPS(const OpArg& arg, X64Reg regOp);
+	void MOVLPD(const OpArg& arg, X64Reg regOp);
 
-	void MOVHPS(X64Reg regOp, OpArg arg);
-	void MOVHPD(X64Reg regOp, OpArg arg);
-	void MOVHPS(OpArg arg, X64Reg regOp);
-	void MOVHPD(OpArg arg, X64Reg regOp);
+	void MOVHPS(X64Reg regOp, const OpArg& arg);
+	void MOVHPD(X64Reg regOp, const OpArg& arg);
+	void MOVHPS(const OpArg& arg, X64Reg regOp);
+	void MOVHPD(const OpArg& arg, X64Reg regOp);
 
 	void MOVHLPS(X64Reg regOp1, X64Reg regOp2);
 	void MOVLHPS(X64Reg regOp1, X64Reg regOp2);
@@ -667,104 +667,104 @@ public:
 	void MOVQ_xmm(OpArg arg, X64Reg src);
 
 	// SSE/SSE2: Generates a mask from the high bits of the components of the packed register in question.
-	void MOVMSKPS(X64Reg dest, OpArg arg);
-	void MOVMSKPD(X64Reg dest, OpArg arg);
+	void MOVMSKPS(X64Reg dest, const OpArg& arg);
+	void MOVMSKPD(X64Reg dest, const OpArg& arg);
 
 	// SSE2: Selective byte store, mask in src register. EDI/RDI specifies store address. This is a weird one.
 	void MASKMOVDQU(X64Reg dest, X64Reg src);
-	void LDDQU(X64Reg dest, OpArg src);
+	void LDDQU(X64Reg dest, const OpArg& src);
 
 	// SSE/SSE2: Data type conversions.
-	void CVTPS2PD(X64Reg dest, OpArg src);
-	void CVTPD2PS(X64Reg dest, OpArg src);
-	void CVTSS2SD(X64Reg dest, OpArg src);
-	void CVTSI2SS(X64Reg dest, OpArg src);
-	void CVTSD2SS(X64Reg dest, OpArg src);
-	void CVTSI2SD(X64Reg dest, OpArg src);
-	void CVTDQ2PD(X64Reg regOp, OpArg arg);
-	void CVTPD2DQ(X64Reg regOp, OpArg arg);
-	void CVTDQ2PS(X64Reg regOp, OpArg arg);
-	void CVTPS2DQ(X64Reg regOp, OpArg arg);
+	void CVTPS2PD(X64Reg dest, const OpArg& src);
+	void CVTPD2PS(X64Reg dest, const OpArg& src);
+	void CVTSS2SD(X64Reg dest, const OpArg& src);
+	void CVTSI2SS(X64Reg dest, const OpArg& src);
+	void CVTSD2SS(X64Reg dest, const OpArg& src);
+	void CVTSI2SD(X64Reg dest, const OpArg& src);
+	void CVTDQ2PD(X64Reg regOp, const OpArg& arg);
+	void CVTPD2DQ(X64Reg regOp, const OpArg& arg);
+	void CVTDQ2PS(X64Reg regOp, const OpArg& arg);
+	void CVTPS2DQ(X64Reg regOp, const OpArg& arg);
 
-	void CVTTPS2DQ(X64Reg regOp, OpArg arg);
-	void CVTTPD2DQ(X64Reg regOp, OpArg arg);
+	void CVTTPS2DQ(X64Reg regOp, const OpArg& arg);
+	void CVTTPD2DQ(X64Reg regOp, const OpArg& arg);
 
 	// Destinations are X64 regs (rax, rbx, ...) for these instructions.
-	void CVTSS2SI(X64Reg xregdest, OpArg src);
-	void CVTSD2SI(X64Reg xregdest, OpArg src);
-	void CVTTSS2SI(X64Reg xregdest, OpArg arg);
-	void CVTTSD2SI(X64Reg xregdest, OpArg arg);
+	void CVTSS2SI(X64Reg xregdest, const OpArg& src);
+	void CVTSD2SI(X64Reg xregdest, const OpArg& src);
+	void CVTTSS2SI(X64Reg xregdest, const OpArg& arg);
+	void CVTTSD2SI(X64Reg xregdest, const OpArg& arg);
 
 	// SSE2: Packed integer instructions
-	void PACKSSDW(X64Reg dest, OpArg arg);
-	void PACKSSWB(X64Reg dest, OpArg arg);
-	void PACKUSDW(X64Reg dest, OpArg arg);
-	void PACKUSWB(X64Reg dest, OpArg arg);
+	void PACKSSDW(X64Reg dest, const OpArg& arg);
+	void PACKSSWB(X64Reg dest, const OpArg& arg);
+	void PACKUSDW(X64Reg dest, const OpArg& arg);
+	void PACKUSWB(X64Reg dest, const OpArg& arg);
 
 	void PUNPCKLBW(X64Reg dest, const OpArg& arg);
 	void PUNPCKLWD(X64Reg dest, const OpArg& arg);
 	void PUNPCKLDQ(X64Reg dest, const OpArg& arg);
 	void PUNPCKLQDQ(X64Reg dest, const OpArg& arg);
 
-	void PTEST(X64Reg dest, OpArg arg);
-	void PAND(X64Reg dest, OpArg arg);
-	void PANDN(X64Reg dest, OpArg arg);
-	void PXOR(X64Reg dest, OpArg arg);
-	void POR(X64Reg dest, OpArg arg);
+	void PTEST(X64Reg dest, const OpArg& arg);
+	void PAND(X64Reg dest, const OpArg& arg);
+	void PANDN(X64Reg dest, const OpArg& arg);
+	void PXOR(X64Reg dest, const OpArg& arg);
+	void POR(X64Reg dest, const OpArg& arg);
 
-	void PADDB(X64Reg dest, OpArg arg);
-	void PADDW(X64Reg dest, OpArg arg);
-	void PADDD(X64Reg dest, OpArg arg);
-	void PADDQ(X64Reg dest, OpArg arg);
+	void PADDB(X64Reg dest, const OpArg& arg);
+	void PADDW(X64Reg dest, const OpArg& arg);
+	void PADDD(X64Reg dest, const OpArg& arg);
+	void PADDQ(X64Reg dest, const OpArg& arg);
 
-	void PADDSB(X64Reg dest, OpArg arg);
-	void PADDSW(X64Reg dest, OpArg arg);
-	void PADDUSB(X64Reg dest, OpArg arg);
-	void PADDUSW(X64Reg dest, OpArg arg);
+	void PADDSB(X64Reg dest, const OpArg& arg);
+	void PADDSW(X64Reg dest, const OpArg& arg);
+	void PADDUSB(X64Reg dest, const OpArg& arg);
+	void PADDUSW(X64Reg dest, const OpArg& arg);
 
-	void PSUBB(X64Reg dest, OpArg arg);
-	void PSUBW(X64Reg dest, OpArg arg);
-	void PSUBD(X64Reg dest, OpArg arg);
-	void PSUBQ(X64Reg dest, OpArg arg);
+	void PSUBB(X64Reg dest, const OpArg& arg);
+	void PSUBW(X64Reg dest, const OpArg& arg);
+	void PSUBD(X64Reg dest, const OpArg& arg);
+	void PSUBQ(X64Reg dest, const OpArg& arg);
 
-	void PSUBSB(X64Reg dest, OpArg arg);
-	void PSUBSW(X64Reg dest, OpArg arg);
-	void PSUBUSB(X64Reg dest, OpArg arg);
-	void PSUBUSW(X64Reg dest, OpArg arg);
+	void PSUBSB(X64Reg dest, const OpArg& arg);
+	void PSUBSW(X64Reg dest, const OpArg& arg);
+	void PSUBUSB(X64Reg dest, const OpArg& arg);
+	void PSUBUSW(X64Reg dest, const OpArg& arg);
 
-	void PAVGB(X64Reg dest, OpArg arg);
-	void PAVGW(X64Reg dest, OpArg arg);
+	void PAVGB(X64Reg dest, const OpArg& arg);
+	void PAVGW(X64Reg dest, const OpArg& arg);
 
-	void PCMPEQB(X64Reg dest, OpArg arg);
-	void PCMPEQW(X64Reg dest, OpArg arg);
-	void PCMPEQD(X64Reg dest, OpArg arg);
+	void PCMPEQB(X64Reg dest, const OpArg& arg);
+	void PCMPEQW(X64Reg dest, const OpArg& arg);
+	void PCMPEQD(X64Reg dest, const OpArg& arg);
 
-	void PCMPGTB(X64Reg dest, OpArg arg);
-	void PCMPGTW(X64Reg dest, OpArg arg);
-	void PCMPGTD(X64Reg dest, OpArg arg);
+	void PCMPGTB(X64Reg dest, const OpArg& arg);
+	void PCMPGTW(X64Reg dest, const OpArg& arg);
+	void PCMPGTD(X64Reg dest, const OpArg& arg);
 
-	void PEXTRW(X64Reg dest, OpArg arg, u8 subreg);
-	void PINSRW(X64Reg dest, OpArg arg, u8 subreg);
+	void PEXTRW(X64Reg dest, const OpArg& arg, u8 subreg);
+	void PINSRW(X64Reg dest, const OpArg& arg, u8 subreg);
 
-	void PMADDWD(X64Reg dest, OpArg arg);
-	void PSADBW(X64Reg dest, OpArg arg);
+	void PMADDWD(X64Reg dest, const OpArg& arg);
+	void PSADBW(X64Reg dest, const OpArg& arg);
 
-	void PMAXSW(X64Reg dest, OpArg arg);
-	void PMAXUB(X64Reg dest, OpArg arg);
-	void PMINSW(X64Reg dest, OpArg arg);
-	void PMINUB(X64Reg dest, OpArg arg);
+	void PMAXSW(X64Reg dest, const OpArg& arg);
+	void PMAXUB(X64Reg dest, const OpArg& arg);
+	void PMINSW(X64Reg dest, const OpArg& arg);
+	void PMINUB(X64Reg dest, const OpArg& arg);
 
-	void PMOVMSKB(X64Reg dest, OpArg arg);
-	void PSHUFD(X64Reg dest, OpArg arg, u8 shuffle);
-	void PSHUFB(X64Reg dest, OpArg arg);
+	void PMOVMSKB(X64Reg dest, const OpArg& arg);
+	void PSHUFD(X64Reg dest, const OpArg& arg, u8 shuffle);
+	void PSHUFB(X64Reg dest, const OpArg& arg);
 
-	void PSHUFLW(X64Reg dest, OpArg arg, u8 shuffle);
-	void PSHUFHW(X64Reg dest, OpArg arg, u8 shuffle);
+	void PSHUFLW(X64Reg dest, const OpArg& arg, u8 shuffle);
+	void PSHUFHW(X64Reg dest, const OpArg& arg, u8 shuffle);
 
 	void PSRLW(X64Reg reg, int shift);
 	void PSRLD(X64Reg reg, int shift);
 	void PSRLQ(X64Reg reg, int shift);
-	void PSRLQ(X64Reg reg, OpArg arg);
+	void PSRLQ(X64Reg reg, const OpArg& arg);
 	void PSRLDQ(X64Reg reg, int shift);
 
 	void PSLLW(X64Reg reg, int shift);
@@ -776,132 +776,132 @@ public:
 	void PSRAD(X64Reg reg, int shift);
 
 	// SSE4: data type conversions
-	void PMOVSXBW(X64Reg dest, OpArg arg);
-	void PMOVSXBD(X64Reg dest, OpArg arg);
-	void PMOVSXBQ(X64Reg dest, OpArg arg);
-	void PMOVSXWD(X64Reg dest, OpArg arg);
-	void PMOVSXWQ(X64Reg dest, OpArg arg);
-	void PMOVSXDQ(X64Reg dest, OpArg arg);
-	void PMOVZXBW(X64Reg dest, OpArg arg);
-	void PMOVZXBD(X64Reg dest, OpArg arg);
-	void PMOVZXBQ(X64Reg dest, OpArg arg);
-	void PMOVZXWD(X64Reg dest, OpArg arg);
-	void PMOVZXWQ(X64Reg dest, OpArg arg);
-	void PMOVZXDQ(X64Reg dest, OpArg arg);
+	void PMOVSXBW(X64Reg dest, const OpArg& arg);
+	void PMOVSXBD(X64Reg dest, const OpArg& arg);
+	void PMOVSXBQ(X64Reg dest, const OpArg& arg);
+	void PMOVSXWD(X64Reg dest, const OpArg& arg);
+	void PMOVSXWQ(X64Reg dest, const OpArg& arg);
+	void PMOVSXDQ(X64Reg dest, const OpArg& arg);
+	void PMOVZXBW(X64Reg dest, const OpArg& arg);
+	void PMOVZXBD(X64Reg dest, const OpArg& arg);
+	void PMOVZXBQ(X64Reg dest, const OpArg& arg);
+	void PMOVZXWD(X64Reg dest, const OpArg& arg);
+	void PMOVZXWQ(X64Reg dest, const OpArg& arg);
+	void PMOVZXDQ(X64Reg dest, const OpArg& arg);
 
 	// SSE4: blend instructions
-	void PBLENDVB(X64Reg dest, OpArg arg);
-	void BLENDVPS(X64Reg dest, OpArg arg);
-	void BLENDVPD(X64Reg dest, OpArg arg);
-	void BLENDPS(X64Reg dest, OpArg arg, u8 blend);
-	void BLENDPD(X64Reg dest, OpArg arg, u8 blend);
+	void PBLENDVB(X64Reg dest, const OpArg& arg);
+	void BLENDVPS(X64Reg dest, const OpArg& arg);
+	void BLENDVPD(X64Reg dest, const OpArg& arg);
+	void BLENDPS(X64Reg dest, const OpArg& arg, u8 blend);
+	void BLENDPD(X64Reg dest, const OpArg& arg, u8 blend);
 
 	// AVX
-	void VADDSD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VSUBSD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VMULSD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VDIVSD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VADDPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VSUBPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VMULPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VDIVPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VSQRTSD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VCMPPD(X64Reg regOp1, X64Reg regOp2, OpArg arg, u8 compare);
-	void VSHUFPD(X64Reg regOp1, X64Reg regOp2, OpArg arg, u8 shuffle);
-	void VUNPCKLPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VUNPCKHPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VBLENDVPD(X64Reg regOp1, X64Reg regOp2, OpArg arg, X64Reg mask);
+	void VADDSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VSUBSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VMULSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VDIVSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VADDPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VSUBPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VMULPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VDIVPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VSQRTSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VCMPPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg, u8 compare);
+	void VSHUFPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg, u8 shuffle);
+	void VUNPCKLPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VUNPCKHPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VBLENDVPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg, X64Reg mask);
 
-	void VANDPS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VANDPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VANDNPS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VANDNPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VORPS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VORPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VXORPS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VXORPD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
+	void VANDPS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VANDPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VANDNPS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VANDNPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VORPS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VORPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VXORPS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VXORPD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
 
-	void VPAND(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VPANDN(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VPOR(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VPXOR(X64Reg regOp1, X64Reg regOp2, OpArg arg);
+	void VPAND(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VPANDN(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VPOR(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VPXOR(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
 
 	// FMA3
-	void VFMADD132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD132SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD213SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD231SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD132SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD213SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADD231SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB132SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB213SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB231SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB132SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB213SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUB231SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD132SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD213SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD231SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD132SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD213SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMADD231SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB132SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB213SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB231SS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB132SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB213SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFNMSUB231SD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADDSUB132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADDSUB213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADDSUB231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADDSUB132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADDSUB213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMADDSUB231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUBADD132PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUBADD213PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUBADD231PS(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUBADD132PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUBADD213PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void VFMSUBADD231PD(X64Reg regOp1, X64Reg regOp2, OpArg arg);
+	void VFMADD132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD132SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD213SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD231SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD132SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD213SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADD231SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB132SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB213SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB231SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB132SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB213SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUB231SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD132SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD213SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD231SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD132SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD213SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMADD231SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB132SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB213SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB231SS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB132SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB213SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFNMSUB231SD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADDSUB132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADDSUB213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADDSUB231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADDSUB132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADDSUB213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMADDSUB231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUBADD132PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUBADD213PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUBADD231PS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUBADD132PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUBADD213PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void VFMSUBADD231PD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
 
 	// VEX GPR instructions
-	void SARX(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
-	void SHLX(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
-	void SHRX(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
-	void RORX(int bits, X64Reg regOp, OpArg arg, u8 rotate);
-	void PEXT(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void PDEP(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void MULX(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);
-	void BZHI(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
-	void BLSR(int bits, X64Reg regOp, OpArg arg);
-	void BLSMSK(int bits, X64Reg regOp, OpArg arg);
-	void BLSI(int bits, X64Reg regOp, OpArg arg);
-	void BEXTR(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
-	void ANDN(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);
+	void SARX(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2);
+	void SHLX(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2);
+	void SHRX(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2);
+	void RORX(int bits, X64Reg regOp, const OpArg& arg, u8 rotate);
+	void PEXT(int bits, X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void PDEP(int bits, X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void MULX(int bits, X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+	void BZHI(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2);
+	void BLSR(int bits, X64Reg regOp, const OpArg& arg);
+	void BLSMSK(int bits, X64Reg regOp, const OpArg& arg);
+	void BLSI(int bits, X64Reg regOp, const OpArg& arg);
+	void BEXTR(int bits, X64Reg regOp1, const OpArg& arg, X64Reg regOp2);
+	void ANDN(int bits, X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
 
 	void RDTSC();
 

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -503,8 +503,8 @@ public:
 	// Available only on Atom or >= Haswell so far. Test with cpu_info.bMOVBE.
 	void MOVBE(int bits, X64Reg dest, const OpArg& src);
 	void MOVBE(int bits, const OpArg& dest, X64Reg src);
-	void LoadAndSwap(int size, Gen::X64Reg dst, const Gen::OpArg& src);
-	void SwapAndStore(int size, const Gen::OpArg& dst, Gen::X64Reg src);
+	void LoadAndSwap(int size, X64Reg dst, const OpArg& src);
+	void SwapAndStore(int size, const OpArg& dst, X64Reg src);
 
 	// Available only on AMD >= Phenom or Intel >= Haswell
 	void LZCNT(int bits, X64Reg dest, OpArg src);
@@ -931,7 +931,7 @@ public:
 	void ABI_CallFunctionRR(const void* func, X64Reg reg1, X64Reg reg2);
 
 	// Helper method for the above, or can be used separately.
-	void MOVTwo(int bits, Gen::X64Reg dst1, Gen::X64Reg src1, s32 offset, Gen::X64Reg dst2, Gen::X64Reg src2);
+	void MOVTwo(int bits, X64Reg dst1, X64Reg src1, s32 offset, X64Reg dst2,X64Reg src2);
 
 	// Saves/restores the registers and adjusts the stack to be aligned as
 	// required by the ABI, where the previous alignment was as specified.

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -140,8 +140,8 @@ public:
 	typedef u32 (*Operation)(u32 a, u32 b);
 	void regimmop(int d, int a, bool binary, u32 value, Operation doop, void (Gen::XEmitter::*op)(int, const Gen::OpArg&, const Gen::OpArg&),
 		          bool Rc = false, bool carry = false);
-	void fp_tri_op(int d, int a, int b, bool reversible, bool single, void (Gen::XEmitter::*avxOp)(Gen::X64Reg, Gen::X64Reg, Gen::OpArg),
-	               void (Gen::XEmitter::*sseOp)(Gen::X64Reg, Gen::OpArg), bool packed = false, bool roundRHS = false);
+	void fp_tri_op(int d, int a, int b, bool reversible, bool single, void (Gen::XEmitter::*avxOp)(Gen::X64Reg, Gen::X64Reg, const Gen::OpArg&),
+	               void (Gen::XEmitter::*sseOp)(Gen::X64Reg, const Gen::OpArg&), bool packed = false, bool roundRHS = false);
 	void FloatCompare(UGeckoInstruction inst, bool upper = false);
 
 	// OPCODES

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -16,8 +16,8 @@ static const u64 GC_ALIGNED16(psAbsMask[2])  = {0x7FFFFFFFFFFFFFFFULL, 0xFFFFFFF
 static const u64 GC_ALIGNED16(psAbsMask2[2]) = {0x7FFFFFFFFFFFFFFFULL, 0x7FFFFFFFFFFFFFFFULL};
 static const double GC_ALIGNED16(half_qnan_and_s32_max[2]) = {0x7FFFFFFF, -0x80000};
 
-void Jit64::fp_tri_op(int d, int a, int b, bool reversible, bool single, void (XEmitter::*avxOp)(X64Reg, X64Reg, OpArg),
-                      void (XEmitter::*sseOp)(X64Reg, OpArg), bool packed, bool roundRHS)
+void Jit64::fp_tri_op(int d, int a, int b, bool reversible, bool single, void (XEmitter::*avxOp)(X64Reg, X64Reg, const OpArg&),
+                      void (XEmitter::*sseOp)(X64Reg, const OpArg&), bool packed, bool roundRHS)
 {
 	fpr.Lock(d, a, b);
 	fpr.BindToRegister(d, d == a || d == b || !single);

--- a/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
@@ -488,7 +488,7 @@ static void regEmitBinInst(RegInfo& RI, InstLoc I,
 	regNormalRegClear(RI, I);
 }
 
-static void fregEmitBinInst(RegInfo& RI, InstLoc I, void (JitIL::*op)(X64Reg, OpArg))
+static void fregEmitBinInst(RegInfo& RI, InstLoc I, void (JitIL::*op)(X64Reg, const OpArg&))
 {
 	X64Reg reg;
 
@@ -640,7 +640,7 @@ static void regEmitMemStore(RegInfo& RI, InstLoc I, unsigned Size)
 		regClearInst(RI, getOp1(I));
 }
 
-static void regEmitShiftInst(RegInfo& RI, InstLoc I, void (JitIL::*op)(int, OpArg, OpArg))
+static void regEmitShiftInst(RegInfo& RI, InstLoc I, void (JitIL::*op)(int, const OpArg&, const OpArg&))
 {
 	X64Reg reg = regBinLHSReg(RI, I);
 

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -156,7 +156,7 @@ private:
 
 	// Generate the proper MOV instruction depending on whether the read should
 	// be sign extended or zero extended.
-	void MoveOpArgToReg(int sbits, Gen::OpArg arg)
+	void MoveOpArgToReg(int sbits, const Gen::OpArg& arg)
 	{
 		if (m_sign_extend)
 			m_code->MOVSX(32, sbits, m_dst_reg, arg);
@@ -233,7 +233,7 @@ void EmuCodeBlock::MMIOLoadToReg(MMIO::Mapping* mmio, Gen::X64Reg reg_value,
 	}
 }
 
-FixupBranch EmuCodeBlock::CheckIfSafeAddress(OpArg reg_value, X64Reg reg_addr, BitSet32 registers_in_use, u32 mem_mask)
+FixupBranch EmuCodeBlock::CheckIfSafeAddress(const OpArg& reg_value, X64Reg reg_addr, BitSet32 registers_in_use, u32 mem_mask)
 {
 	registers_in_use[reg_addr] = true;
 	if (reg_value.IsSimpleReg())
@@ -397,7 +397,7 @@ void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg & opAddress,
 	}
 }
 
-static OpArg SwapImmediate(int accessSize, OpArg reg_value)
+static OpArg SwapImmediate(int accessSize, const OpArg& reg_value)
 {
 	if (accessSize == 32)
 		return Imm32(Common::swap32(reg_value.Imm32()));
@@ -640,7 +640,7 @@ void EmuCodeBlock::WriteToConstRamAddress(int accessSize, OpArg arg, u32 address
 		MOV(accessSize, MRegSum(RMEM, RSCRATCH2), R(reg));
 }
 
-void EmuCodeBlock::ForceSinglePrecision(X64Reg output, OpArg input, bool packed, bool duplicate)
+void EmuCodeBlock::ForceSinglePrecision(X64Reg output, const OpArg& input, bool packed, bool duplicate)
 {
 	// Most games don't need these. Zelda requires it though - some platforms get stuck without them.
 	if (jit->jo.accurateSinglePrecision)
@@ -755,7 +755,7 @@ static const u64 GC_ALIGNED16(psRoundBit[2]) = {0x8000000, 0x8000000};
 // a single precision multiply. To be precise, it drops the low 28 bits of the mantissa,
 // rounding to nearest as it does.
 // It needs a temp, so let the caller pass that in.
-void EmuCodeBlock::Force25BitPrecision(X64Reg output, OpArg input, X64Reg tmp)
+void EmuCodeBlock::Force25BitPrecision(X64Reg output, const OpArg& input, X64Reg tmp)
 {
 	if (jit->jo.accurateSinglePrecision)
 	{

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -668,8 +668,8 @@ void EmuCodeBlock::ForceSinglePrecision(X64Reg output, OpArg input, bool packed,
 }
 
 // Abstract between AVX and SSE: automatically handle 3-operand instructions
-void EmuCodeBlock::avx_op(void (XEmitter::*avxOp)(X64Reg, X64Reg, OpArg), void (XEmitter::*sseOp)(X64Reg, OpArg),
-                          X64Reg regOp, OpArg arg1, OpArg arg2, bool packed, bool reversible)
+void EmuCodeBlock::avx_op(void (XEmitter::*avxOp)(X64Reg, X64Reg, const OpArg&), void (XEmitter::*sseOp)(X64Reg, const OpArg&),
+                          X64Reg regOp, const OpArg& arg1, const OpArg& arg2, bool packed, bool reversible)
 {
 	if (arg1.IsSimpleReg() && regOp == arg1.GetSimpleReg())
 	{
@@ -715,8 +715,8 @@ void EmuCodeBlock::avx_op(void (XEmitter::*avxOp)(X64Reg, X64Reg, OpArg), void (
 }
 
 // Abstract between AVX and SSE: automatically handle 3-operand instructions
-void EmuCodeBlock::avx_op(void (XEmitter::*avxOp)(X64Reg, X64Reg, OpArg, u8), void (XEmitter::*sseOp)(X64Reg, OpArg, u8),
-                          X64Reg regOp, OpArg arg1, OpArg arg2, u8 imm)
+void EmuCodeBlock::avx_op(void (XEmitter::*avxOp)(X64Reg, X64Reg, const OpArg&, u8), void (XEmitter::*sseOp)(X64Reg, const OpArg&, u8),
+                          X64Reg regOp, const OpArg& arg1, const OpArg& arg2, u8 imm)
 {
 	if (arg1.IsSimpleReg() && regOp == arg1.GetSimpleReg())
 	{

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -116,10 +116,10 @@ public:
 	void JitSetCAIf(Gen::CCFlags conditionCode);
 	void JitClearCA();
 
-	void avx_op(void (Gen::XEmitter::*avxOp)(Gen::X64Reg, Gen::X64Reg, Gen::OpArg), void (Gen::XEmitter::*sseOp)(Gen::X64Reg, Gen::OpArg),
-                Gen::X64Reg regOp, Gen::OpArg arg1, Gen::OpArg arg2, bool packed = true, bool reversible = false);
-	void avx_op(void (Gen::XEmitter::*avxOp)(Gen::X64Reg, Gen::X64Reg, Gen::OpArg, u8), void (Gen::XEmitter::*sseOp)(Gen::X64Reg, Gen::OpArg, u8),
-	            Gen::X64Reg regOp, Gen::OpArg arg1, Gen::OpArg arg2, u8 imm);
+	void avx_op(void (Gen::XEmitter::*avxOp)(Gen::X64Reg, Gen::X64Reg, const Gen::OpArg&), void (Gen::XEmitter::*sseOp)(Gen::X64Reg, const Gen::OpArg&),
+	            Gen::X64Reg regOp, const Gen::OpArg& arg1, const Gen::OpArg& arg2, bool packed = true, bool reversible = false);
+	void avx_op(void (Gen::XEmitter::*avxOp)(Gen::X64Reg, Gen::X64Reg, const Gen::OpArg&, u8), void (Gen::XEmitter::*sseOp)(Gen::X64Reg, const Gen::OpArg&, u8),
+	            Gen::X64Reg regOp, const Gen::OpArg& arg1, const Gen::OpArg& arg2, u8 imm);
 
 	void ForceSinglePrecision(Gen::X64Reg output, Gen::OpArg input, bool packed = true, bool duplicate = false);
 	void Force25BitPrecision(Gen::X64Reg output, Gen::OpArg input, Gen::X64Reg tmp);

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -68,7 +68,7 @@ public:
 		SetCodePtr(nearcode);
 	}
 
-	Gen::FixupBranch CheckIfSafeAddress(Gen::OpArg reg_value, Gen::X64Reg reg_addr, BitSet32 registers_in_use, u32 mem_mask);
+	Gen::FixupBranch CheckIfSafeAddress(const Gen::OpArg& reg_value, Gen::X64Reg reg_addr, BitSet32 registers_in_use, u32 mem_mask);
 	void UnsafeLoadRegToReg(Gen::X64Reg reg_addr, Gen::X64Reg reg_value, int accessSize, s32 offset = 0, bool signExtend = false);
 	void UnsafeLoadRegToRegNoSwap(Gen::X64Reg reg_addr, Gen::X64Reg reg_value, int accessSize, s32 offset, bool signExtend = false);
 	// these return the address of the MOV, for backpatching
@@ -121,8 +121,8 @@ public:
 	void avx_op(void (Gen::XEmitter::*avxOp)(Gen::X64Reg, Gen::X64Reg, const Gen::OpArg&, u8), void (Gen::XEmitter::*sseOp)(Gen::X64Reg, const Gen::OpArg&, u8),
 	            Gen::X64Reg regOp, const Gen::OpArg& arg1, const Gen::OpArg& arg2, u8 imm);
 
-	void ForceSinglePrecision(Gen::X64Reg output, Gen::OpArg input, bool packed = true, bool duplicate = false);
-	void Force25BitPrecision(Gen::X64Reg output, Gen::OpArg input, Gen::X64Reg tmp);
+	void ForceSinglePrecision(Gen::X64Reg output, const Gen::OpArg& input, bool packed = true, bool duplicate = false);
+	void Force25BitPrecision(Gen::X64Reg output, const Gen::OpArg& input, Gen::X64Reg tmp);
 
 	// RSCRATCH might get trashed
 	void ConvertSingleToDouble(Gen::X64Reg dst, Gen::X64Reg src, bool src_is_gpr = false);


### PR DESCRIPTION
Considering OpArg is a struct, passing by value isn't necessary in some emitter functions.