### PR TITLE
Volume: Use more appropriate types for some returned values

### DIFF
--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -405,7 +405,7 @@ IniFile SCoreStartupParameter::LoadGameIni() const
 	return LoadGameIni(GetUniqueID(), m_revision);
 }
 
-IniFile SCoreStartupParameter::LoadDefaultGameIni(const std::string& id, int revision)
+IniFile SCoreStartupParameter::LoadDefaultGameIni(const std::string& id, u16 revision)
 {
 	IniFile game_ini;
 	for (const std::string& filename : GetGameIniFilenames(id, revision))
@@ -413,7 +413,7 @@ IniFile SCoreStartupParameter::LoadDefaultGameIni(const std::string& id, int rev
 	return game_ini;
 }
 
-IniFile SCoreStartupParameter::LoadLocalGameIni(const std::string& id, int revision)
+IniFile SCoreStartupParameter::LoadLocalGameIni(const std::string& id, u16 revision)
 {
 	IniFile game_ini;
 	for (const std::string& filename : GetGameIniFilenames(id, revision))
@@ -421,7 +421,7 @@ IniFile SCoreStartupParameter::LoadLocalGameIni(const std::string& id, int revis
 	return game_ini;
 }
 
-IniFile SCoreStartupParameter::LoadGameIni(const std::string& id, int revision)
+IniFile SCoreStartupParameter::LoadGameIni(const std::string& id, u16 revision)
 {
 	IniFile game_ini;
 	for (const std::string& filename : GetGameIniFilenames(id, revision))
@@ -432,7 +432,7 @@ IniFile SCoreStartupParameter::LoadGameIni(const std::string& id, int revision)
 }
 
 // Returns all possible filenames in ascending order of priority
-std::vector<std::string> SCoreStartupParameter::GetGameIniFilenames(const std::string& id, int revision)
+std::vector<std::string> SCoreStartupParameter::GetGameIniFilenames(const std::string& id, u16 revision)
 {
 	std::vector<std::string> filenames;
 

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -244,7 +244,7 @@ struct SCoreStartupParameter
 	std::string m_strApploader;
 	std::string m_strUniqueID;
 	std::string m_strName;
-	int m_revision;
+	u16 m_revision;
 
 	std::string m_perfDir;
 
@@ -261,9 +261,9 @@ struct SCoreStartupParameter
 	IniFile LoadLocalGameIni() const;
 	IniFile LoadGameIni() const;
 
-	static IniFile LoadDefaultGameIni(const std::string& id, int revision);
-	static IniFile LoadLocalGameIni(const std::string& id, int revision);
-	static IniFile LoadGameIni(const std::string& id, int revision);
+	static IniFile LoadDefaultGameIni(const std::string& id, u16 revision);
+	static IniFile LoadLocalGameIni(const std::string& id, u16 revision);
+	static IniFile LoadGameIni(const std::string& id, u16 revision);
 
-	static std::vector<std::string> GetGameIniFilenames(const std::string& id, int revision);
+	static std::vector<std::string> GetGameIniFilenames(const std::string& id, u16 revision);
 };

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -75,7 +75,7 @@ public:
 	}
 	virtual std::string GetUniqueID() const = 0;
 	virtual std::string GetMakerID() const = 0;
-	virtual int GetRevision() const = 0;
+	virtual u16 GetRevision() const = 0;
 	virtual std::string GetInternalName() const = 0;
 	virtual std::map<ELanguage, std::string> GetNames() const = 0;
 	virtual std::map<ELanguage, std::string> GetDescriptions() const { return std::map<ELanguage, std::string>(); }
@@ -83,8 +83,9 @@ public:
 	virtual std::vector<u32> GetBanner(int* width, int* height) const;
 	virtual u32 GetFSTSize() const = 0;
 	virtual std::string GetApploaderDate() const = 0;
+	// 0 is the first disc, 1 is the second disc
+	virtual u8 GetDiscNumber() const { return 0; }
 
-	virtual bool IsDiscTwo() const { return false; }
 	virtual bool IsWiiDisc() const { return false; }
 	virtual bool IsWadFile() const { return false; }
 	virtual bool SupportsIntegrityCheck() const { return false; }

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -39,7 +39,7 @@ public:
 
 	std::string GetMakerID() const override;
 
-	int GetRevision() const override { return 0; }
+	u16 GetRevision() const override { return 0; }
 	std::string GetInternalName() const override;
 	std::map<IVolume::ELanguage, std::string> GetNames() const override;
 	void SetName(const std::string&);

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -84,7 +84,7 @@ std::string CVolumeGC::GetMakerID() const
 	return makerID;
 }
 
-int CVolumeGC::GetRevision() const
+u16 CVolumeGC::GetRevision() const
 {
 	if (!m_pReader)
 		return 0;
@@ -265,11 +265,11 @@ u64 CVolumeGC::GetRawSize() const
 		return 0;
 }
 
-bool CVolumeGC::IsDiscTwo() const
+u8 CVolumeGC::GetDiscNumber() const
 {
-	u8 disc_two_check;
-	Read(6, 1, &disc_two_check);
-	return (disc_two_check == 1);
+	u8 disc_number;
+	Read(6, 1, &disc_number);
+	return disc_number;
 }
 
 bool CVolumeGC::LoadBannerFile() const

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -27,7 +27,7 @@ public:
 	bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt = false) const override;
 	std::string GetUniqueID() const override;
 	std::string GetMakerID() const override;
-	int GetRevision() const override;
+	u16 GetRevision() const override;
 	virtual std::string GetInternalName() const override;
 	std::map<ELanguage, std::string> GetNames() const override;
 	std::map<ELanguage, std::string> GetDescriptions() const override;
@@ -35,8 +35,7 @@ public:
 	std::vector<u32> GetBanner(int* width, int* height) const override;
 	u32 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;
-
-	bool IsDiscTwo() const override;
+	u8 GetDiscNumber() const override;
 
 	ECountry GetCountry() const override;
 	u64 GetSize() const override;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -103,7 +103,7 @@ bool CVolumeWAD::GetTitleID(u8* _pBuffer) const
 	return true;
 }
 
-int CVolumeWAD::GetRevision() const
+u16 CVolumeWAD::GetRevision() const
 {
 	u16 revision;
 	if (!m_pReader->Read(m_tmd_offset + 0x1dc, 2, (u8*)&revision))

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -30,7 +30,7 @@ public:
 	bool GetTitleID(u8* _pBuffer) const override;
 	std::string GetUniqueID() const override;
 	std::string GetMakerID() const override;
-	int GetRevision() const override;
+	u16 GetRevision() const override;
 	std::string GetInternalName() const override { return ""; }
 	std::map<IVolume::ELanguage, std::string> GetNames() const override;
 	u32 GetFSTSize() const override { return 0; }

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -181,7 +181,7 @@ std::string CVolumeWiiCrypted::GetMakerID() const
 	return makerID;
 }
 
-int CVolumeWiiCrypted::GetRevision() const
+u16 CVolumeWiiCrypted::GetRevision() const
 {
 	if (!m_pReader)
 		return 0;
@@ -243,13 +243,12 @@ bool CVolumeWiiCrypted::IsWiiDisc() const
 	return true;
 }
 
-bool CVolumeWiiCrypted::IsDiscTwo() const
+u8 CVolumeWiiCrypted::GetDiscNumber() const
 {
-	u8 disc_two_check;
-	m_pReader->Read(6, 1, &disc_two_check);
-	return (disc_two_check == 1);
+	u8 disc_number;
+	m_pReader->Read(6, 1, &disc_number);
+	return disc_number;
 }
-
 
 u64 CVolumeWiiCrypted::GetSize() const
 {

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -30,13 +30,13 @@ public:
 	virtual std::unique_ptr<u8[]> GetTMD(u32 *_sz) const override;
 	std::string GetUniqueID() const override;
 	std::string GetMakerID() const override;
-	int GetRevision() const override;
+	u16 GetRevision() const override;
 	std::string GetInternalName() const override;
 	std::map<IVolume::ELanguage, std::string> GetNames() const override;
 	u32 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;
+	u8 GetDiscNumber() const override;
 
-	bool IsDiscTwo() const override;
 	bool IsWiiDisc() const override;
 	bool SupportsIntegrityCheck() const override { return true; }
 	bool CheckIntegrity() const override;

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -25,7 +25,7 @@
 #include "DolphinQt/Utils/Resources.h"
 #include "DolphinQt/Utils/Utils.h"
 
-static const u32 CACHE_REVISION = 0x007;
+static const u32 CACHE_REVISION = 0x008;
 static const u32 DATASTREAM_REVISION = 15; // Introduced in Qt 5.2
 
 static QMap<DiscIO::IVolume::ELanguage, QString> ConvertLocalizedStrings(std::map<DiscIO::IVolume::ELanguage, std::string> strings)
@@ -100,7 +100,7 @@ GameFile::GameFile(const QString& fileName)
 
 			m_unique_id = QString::fromStdString(volume->GetUniqueID());
 			m_compressed = DiscIO::IsCompressedBlob(fileName.toStdString());
-			m_is_disc_two = volume->IsDiscTwo();
+			m_disc_number = volume->GetDiscNumber();
 			m_revision = volume->GetRevision();
 
 			QFileInfo info(m_file_name);
@@ -180,7 +180,7 @@ bool GameFile::LoadFromCache()
 	       >> m_banner
 	       >> m_compressed
 	       >> m_platform
-	       >> m_is_disc_two
+	       >> m_disc_number
 	       >> m_revision;
 	m_country = (DiscIO::IVolume::ECountry)country;
 	m_names = CastLocalizedStrings<DiscIO::IVolume::ELanguage>(names);
@@ -220,7 +220,7 @@ void GameFile::SaveToCache()
 	       << m_banner
 	       << m_compressed
 	       << m_platform
-	       << m_is_disc_two
+	       << m_disc_number
 	       << m_revision;
 }
 

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -27,7 +27,7 @@ public:
 	QString GetDescription(DiscIO::IVolume::ELanguage language) const;
 	QString GetDescription() const;
 	QString GetCompany() const;
-	int GetRevision() const { return m_revision; }
+	u16 GetRevision() const { return m_revision; }
 	const QString GetUniqueID() const { return m_unique_id; }
 	const QString GetWiiFSPath() const;
 	DiscIO::IVolume::ECountry GetCountry() const { return m_country; }
@@ -37,7 +37,8 @@ public:
 	bool IsCompressed() const { return m_compressed; }
 	u64 GetFileSize() const { return m_file_size; }
 	u64 GetVolumeSize() const { return m_volume_size; }
-	bool IsDiscTwo() const { return m_is_disc_two; }
+	// 0 is the first disc, 1 is the second disc
+	u8 GetDiscNumber() const { return m_disc_number; }
 	const QPixmap GetBitmap() const { return m_banner; }
 
 	enum
@@ -66,12 +67,12 @@ private:
 
 	DiscIO::IVolume::ECountry m_country;
 	int m_platform;
-	int m_revision = 0;
+	u16 m_revision = 0;
 
 	QPixmap m_banner;
 	bool m_valid = false;
 	bool m_compressed = false;
-	bool m_is_disc_two = false;
+	u8 m_disc_number = 0;
 
 	bool LoadFromCache();
 	void SaveToCache();

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -97,8 +97,8 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
 					return t * (iso1->GetUniqueID() > iso2->GetUniqueID() ? 1 : -1);
 				if (iso1->GetRevision() != iso2->GetRevision())
 					return t * (iso1->GetRevision() > iso2->GetRevision() ? 1 : -1);
-				if (iso1->IsDiscTwo() != iso2->IsDiscTwo())
-					return t * (iso1->IsDiscTwo() ? 1 : -1);
+				if (iso1->GetDiscNumber() != iso2->GetDiscNumber())
+					return t * (iso1->GetDiscNumber() > iso2->GetDiscNumber() ? 1 : -1);
 			}
 			return strcasecmp(iso1->GetName(languageOne).c_str(),
 			                  iso2->GetName(languageOther).c_str()) * t;
@@ -415,8 +415,12 @@ void CGameListCtrl::InsertItemInReportView(long _Index)
 	if (gameini.GetIfExists("EmuState", "Title", &title))
 		name = title;
 
-	if (rISOFile.IsDiscTwo() && name.Lower().find("disc 2") == std::string::npos && name.Lower().find("disc2") == std::string::npos)
-		name = wxString::Format(_("%s (Disc 2)"), name.c_str());
+	int disc_number = rISOFile.GetDiscNumber() + 1;
+	if (disc_number > 1 && name.Lower().find(wxString::Format("disc %i", disc_number)) == std::string::npos
+	                    && name.Lower().find(wxString::Format("disc%i", disc_number)) == std::string::npos)
+	{
+		name = wxString::Format(_("%s (Disc %i)"), name.c_str(), disc_number);
+	}
 
 	SetItem(_Index, COLUMN_TITLE, name, -1);
 	SetItem(_Index, COLUMN_MAKER, StrToWxStr(rISOFile.GetCompany()), -1);

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -35,7 +35,7 @@
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/WxUtils.h"
 
-static const u32 CACHE_REVISION = 0x123;
+static const u32 CACHE_REVISION = 0x124;
 
 #define DVD_BANNER_WIDTH 96
 #define DVD_BANNER_HEIGHT 32
@@ -97,7 +97,7 @@ GameListItem::GameListItem(const std::string& _rFileName)
 
 			m_UniqueID = pVolume->GetUniqueID();
 			m_BlobCompressed = DiscIO::IsCompressedBlob(_rFileName);
-			m_IsDiscTwo = pVolume->IsDiscTwo();
+			m_disc_number = pVolume->GetDiscNumber();
 			m_Revision = pVolume->GetRevision();
 
 			std::vector<u32> Buffer = pVolume->GetBanner(&m_ImageWidth, &m_ImageHeight);
@@ -183,7 +183,7 @@ void GameListItem::DoState(PointerWrap &p)
 	p.Do(m_ImageWidth);
 	p.Do(m_ImageHeight);
 	p.Do(m_Platform);
-	p.Do(m_IsDiscTwo);
+	p.Do(m_disc_number);
 	p.Do(m_Revision);
 }
 

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -31,7 +31,7 @@ public:
 	std::string GetDescription() const;
 	std::vector<DiscIO::IVolume::ELanguage> GetLanguages() const;
 	std::string GetCompany() const;
-	int GetRevision() const { return m_Revision; }
+	u16 GetRevision() const { return m_Revision; }
 	const std::string& GetUniqueID() const {return m_UniqueID;}
 	const std::string GetWiiFSPath() const;
 	DiscIO::IVolume::ECountry GetCountry() const {return m_Country;}
@@ -41,7 +41,8 @@ public:
 	bool IsCompressed() const {return m_BlobCompressed;}
 	u64 GetFileSize() const {return m_FileSize;}
 	u64 GetVolumeSize() const {return m_VolumeSize;}
-	bool IsDiscTwo() const {return m_IsDiscTwo;}
+	// 0 is the first disc, 1 is the second disc
+	u8 GetDiscNumber() const {return m_disc_number;}
 #if defined(HAVE_WX) && HAVE_WX
 	const wxBitmap& GetBitmap() const {return m_Bitmap;}
 #endif
@@ -73,7 +74,7 @@ private:
 
 	DiscIO::IVolume::ECountry m_Country;
 	int m_Platform;
-	int m_Revision;
+	u16 m_Revision;
 
 #if defined(HAVE_WX) && HAVE_WX
 	wxBitmap m_Bitmap;
@@ -82,7 +83,7 @@ private:
 	bool m_BlobCompressed;
 	std::vector<u8> m_pImage;
 	int m_ImageWidth, m_ImageHeight;
-	bool m_IsDiscTwo;
+	u8 m_disc_number;
 
 	bool LoadFromCache();
 	void SaveToCache();


### PR DESCRIPTION
Disc number is changed from bool to u8, and revision is changed from int to u16 (WADs can use all 16 bits, but discs can only use 8 bits).