### PR TITLE
Hotkeys fixes

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -138,10 +138,10 @@ void GCPad::LoadDefaults(const ControllerInterface& ciface)
 	set_control(m_buttons, 3, "S"); // Y
 	set_control(m_buttons, 4, "D"); // Z
 #ifdef _WIN32
-	set_control(m_buttons, 5, "RETURN"); // Start
+	set_control(m_buttons, 5, "!LMENU & RETURN"); // Start
 #else
 	// OS X/Linux
-	set_control(m_buttons, 5, "Return"); // Start
+	set_control(m_buttons, 5, "!`Alt_L` & Return"); // Start
 #endif
 
 	// stick modifiers to 50 %

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -895,9 +895,9 @@ void Wiimote::LoadDefaults(const ControllerInterface& ciface)
 	set_control(m_buttons, 5, "E"); // +
 
 #ifdef _WIN32
-	set_control(m_buttons, 6, "RETURN"); // Home
+	set_control(m_buttons, 6, "!LMENU & RETURN"); // Home
 #else
-	set_control(m_buttons, 6, "Return"); // Home
+	set_control(m_buttons, 6, "!`Alt_L` & Return"); // Home
 #endif
 
 	// Shake

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -10,9 +10,9 @@
 
 const std::string hotkey_labels[] =
 {
-	(""), // Open
-	(""), // Change Disc
-	(""), // Refresh List
+	_trans("Open"),
+	_trans("Change Disc"),
+	_trans("Refresh List"),
 
 	_trans("Toggle Pause"),
 	_trans("Stop"),
@@ -26,7 +26,7 @@ const std::string hotkey_labels[] =
 
 	_trans("Toggle Fullscreen"),
 	_trans("Take Screenshot"),
-	(""), // Exit
+	_trans("Exit"),
 
 	_trans("Connect Wiimote 1"),
 	_trans("Connect Wiimote 2"),

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -932,9 +932,6 @@ void CFrame::OnGameListCtrlItemActivated(wxListEvent& WXUNUSED(event))
 
 static bool IsHotkey(wxKeyEvent &event, int id, bool held = false)
 {
-	if (Core::GetState() == Core::CORE_UNINITIALIZED)
-		return false;
-
 	// Input event hotkey
 	if (event.GetKeyCode() == WXK_NONE)
 	{
@@ -1085,7 +1082,14 @@ void CFrame::OnKeyDown(wxKeyEvent& event)
 	if (Core::GetState() != Core::CORE_UNINITIALIZED &&
 	    (RendererHasFocus() || TASInputHasFocus()))
 	{
-		ParseHotkeys(event);
+		if (IsHotkey(event, HK_TOGGLE_THROTTLE))
+		{
+			Core::SetIsFramelimiterTempDisabled(true);
+		}
+		else
+		{
+			ParseHotkeys(event);
+		}
 	}
 	else
 	{
@@ -1297,216 +1301,207 @@ void CFrame::PollHotkeys(wxTimerEvent& event)
 	{
 		HotkeyManagerEmu::GetStatus();
 		wxKeyEvent keyevent = 0;
-
-		if (IsHotkey(keyevent, HK_TOGGLE_THROTTLE))
-		{
-			Core::SetIsFramelimiterTempDisabled(false);
-		}
-		else
-		{
-			ParseHotkeys(keyevent);
-		}
+		ParseHotkeys(keyevent);
 	}
 }
 
 void CFrame::ParseHotkeys(wxKeyEvent &event)
 {
+	if (Core::GetState() == Core::CORE_UNINITIALIZED)
+	{
+		event.Skip();
+		return;
+	}
+
 	int WiimoteId = -1;
 	// Toggle fullscreen
 	if (IsHotkey(event, HK_FULLSCREEN))
 		DoFullscreen(!RendererIsFullscreen());
-	// Send Debugger keys to CodeWindow
-	else if (g_pCodeWindow && (event.GetKeyCode() >= WXK_F9 && event.GetKeyCode() <= WXK_F11))
-		event.Skip();
 	// Pause and Unpause
-	else if (IsHotkey(event, HK_PLAY_PAUSE))
+	if (IsHotkey(event, HK_PLAY_PAUSE))
 		DoPause();
 	// Stop
-	else if (IsHotkey(event, HK_STOP))
+	if (IsHotkey(event, HK_STOP))
 		DoStop();
 	// Screenshot hotkey
-	else if (IsHotkey(event, HK_SCREENSHOT))
+	if (IsHotkey(event, HK_SCREENSHOT))
 		Core::SaveScreenShot();
-	else if (IsHotkey(event, HK_EXIT))
+	if (IsHotkey(event, HK_EXIT))
 		wxPostEvent(this, wxCommandEvent(wxID_EXIT));
-	else if (IsHotkey(event, HK_VOLUME_DOWN))
+	if (IsHotkey(event, HK_VOLUME_DOWN))
 		AudioCommon::DecreaseVolume(3);
-	else if (IsHotkey(event, HK_VOLUME_UP))
+	if (IsHotkey(event, HK_VOLUME_UP))
 		AudioCommon::IncreaseVolume(3);
-	else if (IsHotkey(event, HK_VOLUME_TOGGLE_MUTE))
+	if (IsHotkey(event, HK_VOLUME_TOGGLE_MUTE))
 		AudioCommon::ToggleMuteVolume();
 	// Wiimote connect and disconnect hotkeys
-	else if (IsHotkey(event, HK_WIIMOTE1_CONNECT))
+	if (IsHotkey(event, HK_WIIMOTE1_CONNECT))
 		WiimoteId = 0;
-	else if (IsHotkey(event, HK_WIIMOTE2_CONNECT))
+	if (IsHotkey(event, HK_WIIMOTE2_CONNECT))
 		WiimoteId = 1;
-	else if (IsHotkey(event, HK_WIIMOTE3_CONNECT))
+	if (IsHotkey(event, HK_WIIMOTE3_CONNECT))
 		WiimoteId = 2;
-	else if (IsHotkey(event, HK_WIIMOTE4_CONNECT))
+	if (IsHotkey(event, HK_WIIMOTE4_CONNECT))
 		WiimoteId = 3;
-	else if (IsHotkey(event, HK_BALANCEBOARD_CONNECT))
+	if (IsHotkey(event, HK_BALANCEBOARD_CONNECT))
 		WiimoteId = 4;
-	else if (IsHotkey(event, HK_TOGGLE_IR))
+	if (IsHotkey(event, HK_TOGGLE_IR))
 	{
 		OSDChoice = 1;
 		// Toggle native resolution
 		if (++g_Config.iEFBScale > SCALE_4X)
 			g_Config.iEFBScale = SCALE_AUTO;
 	}
-	else if (IsHotkey(event, HK_INCREASE_IR))
+	if (IsHotkey(event, HK_INCREASE_IR))
 	{
 		OSDChoice = 1;
-		if (++g_Config.iEFBScale > SCALE_4X)
-			g_Config.iEFBScale = SCALE_4X;
+		++g_Config.iEFBScale;
 	}
-	else if (IsHotkey(event, HK_DECREASE_IR))
+	if (IsHotkey(event, HK_DECREASE_IR))
 	{
 		OSDChoice = 1;
 		if (--g_Config.iEFBScale < SCALE_1X)
 			g_Config.iEFBScale = SCALE_1X;
 	}
-	else if (IsHotkey(event, HK_TOGGLE_AR))
+	if (IsHotkey(event, HK_TOGGLE_AR))
 	{
 		OSDChoice = 2;
 		// Toggle aspect ratio
 		g_Config.iAspectRatio = (g_Config.iAspectRatio + 1) & 3;
 	}
-	else if (IsHotkey(event, HK_TOGGLE_EFBCOPIES))
+	if (IsHotkey(event, HK_TOGGLE_EFBCOPIES))
 	{
 		OSDChoice = 3;
 		// Toggle EFB copies between EFB2RAM and EFB2Texture
 		g_Config.bSkipEFBCopyToRam = !g_Config.bSkipEFBCopyToRam;
 	}
-	else if (IsHotkey(event, HK_TOGGLE_FOG))
+	if (IsHotkey(event, HK_TOGGLE_FOG))
 	{
 		OSDChoice = 4;
 		g_Config.bDisableFog = !g_Config.bDisableFog;
+	}
+	if (IsHotkey(event, HK_TOGGLE_THROTTLE, false))
+	{
+		Core::SetIsFramelimiterTempDisabled(false);
 	}
 	else if (IsHotkey(event, HK_TOGGLE_THROTTLE, true))
 	{
 		Core::SetIsFramelimiterTempDisabled(true);
 	}
-	else if (IsHotkey(event, HK_DECREASE_FRAME_LIMIT))
+	if (IsHotkey(event, HK_DECREASE_FRAME_LIMIT))
 	{
 		if (--SConfig::GetInstance().m_Framelimit > 0x19)
 			SConfig::GetInstance().m_Framelimit = 0x19;
 	}
-	else if (IsHotkey(event, HK_INCREASE_FRAME_LIMIT))
+	if (IsHotkey(event, HK_INCREASE_FRAME_LIMIT))
 	{
 		if (++SConfig::GetInstance().m_Framelimit > 0x19)
 			SConfig::GetInstance().m_Framelimit = 0;
 	}
-	else if (IsHotkey(event, HK_SAVE_STATE_SLOT_SELECTED))
+	if (IsHotkey(event, HK_SAVE_STATE_SLOT_SELECTED))
 	{
 		State::Save(g_saveSlot);
 	}
-	else if (IsHotkey(event, HK_LOAD_STATE_SLOT_SELECTED))
+	if (IsHotkey(event, HK_LOAD_STATE_SLOT_SELECTED))
 	{
 		State::Load(g_saveSlot);
 	}
-	else if (IsHotkey(event, HK_DECREASE_DEPTH, true))
+	if (IsHotkey(event, HK_DECREASE_DEPTH, true))
 	{
 		if (--g_Config.iStereoDepth < 0)
 			g_Config.iStereoDepth = 0;
 	}
-	else if (IsHotkey(event, HK_INCREASE_DEPTH, true))
+	if (IsHotkey(event, HK_INCREASE_DEPTH, true))
 	{
 		if (++g_Config.iStereoDepth > 100)
 			g_Config.iStereoDepth = 100;
 	}
-	else if (IsHotkey(event, HK_DECREASE_CONVERGENCE, true))
+	if (IsHotkey(event, HK_DECREASE_CONVERGENCE, true))
 	{
 		g_Config.iStereoConvergence -= 5;
 		if (g_Config.iStereoConvergence < 0)
 			g_Config.iStereoConvergence = 0;
 	}
-	else if (IsHotkey(event, HK_INCREASE_CONVERGENCE, true))
+	if (IsHotkey(event, HK_INCREASE_CONVERGENCE, true))
 	{
 		g_Config.iStereoConvergence += 5;
 		if (g_Config.iStereoConvergence > 500)
 			g_Config.iStereoConvergence = 500;
 	}
 
-	else
+	for (int i = HK_SELECT_STATE_SLOT_1; i < HK_SELECT_STATE_SLOT_10; ++i)
 	{
-		for (int i = HK_SELECT_STATE_SLOT_1; i < HK_SELECT_STATE_SLOT_10; ++i)
+		if (IsHotkey(event, i))
 		{
-			if (IsHotkey(event, i))
-			{
-				wxCommandEvent slot_event;
-				slot_event.SetId(i + IDM_SELECT_SLOT_1 - HK_SELECT_STATE_SLOT_1);
-				CFrame::OnSelectSlot(slot_event);
-			}
+			wxCommandEvent slot_event;
+			slot_event.SetId(i + IDM_SELECT_SLOT_1 - HK_SELECT_STATE_SLOT_1);
+			CFrame::OnSelectSlot(slot_event);
 		}
-
-		unsigned int i = NUM_HOTKEYS;
-		for (i = 0; i < NUM_HOTKEYS; i++)
-		{
-			bool held = false;
-			if (i == HK_FRAME_ADVANCE)
-				held = true;
-
-			if (IsHotkey(event, i, held))
-			{
-				int cmd = GetCmdForHotkey(i);
-				if (cmd >= 0)
-				{
-					wxCommandEvent evt(wxEVT_MENU, cmd);
-					wxMenuItem* item = GetMenuBar()->FindItem(cmd);
-					if (item && item->IsCheckable())
-					{
-						item->wxMenuItemBase::Toggle();
-						evt.SetInt(item->IsChecked());
-					}
-					GetEventHandler()->AddPendingEvent(evt);
-					break;
-				}
-			}
-		}
-		// On OS X, we claim all keyboard events while
-		// emulation is running to avoid wxWidgets sounding
-		// the system beep for unhandled key events when
-		// receiving pad/Wiimote keypresses which take an
-		// entirely different path through the HID subsystem.
-#ifndef __APPLE__
-		// On other platforms, we leave the key event alone
-		// so it can be passed on to the windowing system.
-		if (i == NUM_HOTKEYS)
-			event.Skip();
-#endif
 	}
+
+	unsigned int i = NUM_HOTKEYS;
+	for (i = 0; i < NUM_HOTKEYS; i++)
+	{
+		bool held = false;
+		if (i == HK_FRAME_ADVANCE)
+			held = true;
+
+		if (IsHotkey(event, i, held))
+		{
+			int cmd = GetCmdForHotkey(i);
+			if (cmd >= 0)
+			{
+				wxCommandEvent evt(wxEVT_MENU, cmd);
+				wxMenuItem* item = GetMenuBar()->FindItem(cmd);
+				if (item && item->IsCheckable())
+				{
+					item->wxMenuItemBase::Toggle();
+					evt.SetInt(item->IsChecked());
+				}
+				GetEventHandler()->AddPendingEvent(evt);
+				break;
+			}
+		}
+	}
+	// On OS X, we claim all keyboard events while
+	// emulation is running to avoid wxWidgets sounding
+	// the system beep for unhandled key events when
+	// receiving pad/Wiimote keypresses which take an
+	// entirely different path through the HID subsystem.
+#ifndef __APPLE__
+	// On other platforms, we leave the key event alone
+	// so it can be passed on to the windowing system.
+	if (i == NUM_HOTKEYS)
+		event.Skip();
+#endif
 
 	// Actually perform the Wiimote connection or disconnection
-	if (Core::GetState() != Core::CORE_UNINITIALIZED)
+	if (WiimoteId >= 0 && SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
 	{
-		if (WiimoteId >= 0 && SConfig::GetInstance().m_LocalCoreStartupParameter.bWii)
-		{
-			wxCommandEvent evt;
-			evt.SetId(IDM_CONNECT_WIIMOTE1 + WiimoteId);
-			OnConnectWiimote(evt);
-		}
-
-		static float debugSpeed = 1.0f;
-
-		if (IsHotkey(event, HK_FREELOOK_DECREASE_SPEED, true))
-			debugSpeed /= 1.1f;
-		else if (IsHotkey(event, HK_FREELOOK_INCREASE_SPEED, true))
-			debugSpeed *= 1.1f;
-		else if (IsHotkey(event, HK_FREELOOK_RESET_SPEED, true))
-			debugSpeed = 1.0f;
-		else if (IsHotkey(event, HK_FREELOOK_UP, true))
-			VertexShaderManager::TranslateView(0.0f, 0.0f, -debugSpeed);
-		else if (IsHotkey(event, HK_FREELOOK_DOWN, true))
-			VertexShaderManager::TranslateView(0.0f, 0.0f, debugSpeed);
-		else if (IsHotkey(event, HK_FREELOOK_LEFT, true))
-			VertexShaderManager::TranslateView(debugSpeed, 0.0f);
-		else if (IsHotkey(event, HK_FREELOOK_RIGHT, true))
-			VertexShaderManager::TranslateView(-debugSpeed, 0.0f);
-		else if (IsHotkey(event, HK_FREELOOK_ZOOM_IN, true))
-			VertexShaderManager::TranslateView(0.0f, debugSpeed);
-		else if (IsHotkey(event, HK_FREELOOK_ZOOM_OUT, true))
-			VertexShaderManager::TranslateView(0.0f, -debugSpeed);
-		else if (IsHotkey(event, HK_FREELOOK_RESET, true))
-			VertexShaderManager::ResetView();
+		wxCommandEvent evt;
+		evt.SetId(IDM_CONNECT_WIIMOTE1 + WiimoteId);
+		OnConnectWiimote(evt);
 	}
+
+	static float debugSpeed = 1.0f;
+	if (IsHotkey(event, HK_FREELOOK_DECREASE_SPEED, true))
+		debugSpeed /= 1.1f;
+	if (IsHotkey(event, HK_FREELOOK_INCREASE_SPEED, true))
+		debugSpeed *= 1.1f;
+	if (IsHotkey(event, HK_FREELOOK_RESET_SPEED, true))
+		debugSpeed = 1.0f;
+	if (IsHotkey(event, HK_FREELOOK_UP, true))
+		VertexShaderManager::TranslateView(0.0f, 0.0f, -debugSpeed);
+	if (IsHotkey(event, HK_FREELOOK_DOWN, true))
+		VertexShaderManager::TranslateView(0.0f, 0.0f, debugSpeed);
+	if (IsHotkey(event, HK_FREELOOK_LEFT, true))
+		VertexShaderManager::TranslateView(debugSpeed, 0.0f);
+	if (IsHotkey(event, HK_FREELOOK_RIGHT, true))
+		VertexShaderManager::TranslateView(-debugSpeed, 0.0f);
+	if (IsHotkey(event, HK_FREELOOK_ZOOM_IN, true))
+		VertexShaderManager::TranslateView(0.0f, debugSpeed);
+	if (IsHotkey(event, HK_FREELOOK_ZOOM_OUT, true))
+		VertexShaderManager::TranslateView(0.0f, -debugSpeed);
+	if (IsHotkey(event, HK_FREELOOK_RESET, true))
+		VertexShaderManager::ResetView();
 }


### PR DESCRIPTION
This PR shall fix some issues with the current hotkey implementation:
- We now can parse more than one hotkey at the same time, eg pressing F1 while TAB is pressed.
- Add the missed hotkeys (Open, Change Disc, Refresh List, Exit) and make them working.
- Change the default key of wiimote home or gcpad start to "!ALT & ENTER" to not pressing home while toggling fullscreen.
