### PR TITLE
[AArch64] Don't disable tw{i,}

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -143,7 +143,6 @@ void JitArm64::mtsrin(UGeckoInstruction inst)
 void JitArm64::twx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	JITDISABLE(bJITIntegerOff);
 
 	s32 a = inst.RA;
 


### PR DESCRIPTION
It's an endblock instruction, it shouldn't be disabled via the JITDISABLE macro.