### PR TITLE
[AArch64] Minor bugfix and optimization.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -162,9 +162,9 @@ u32 JitArm64::EmitBackpatchRoutine(ARM64XEmitter* emit, u32 flags, bool fastmem,
 			trouble_offset = (emit->GetCodePtr() - code_base) / 4;
 			if (flags & BackPatchInfo::FLAG_SIZE_F32)
 			{
-				float_emit.LD1R(32, RS, addr);
-				float_emit.REV64(8, RS, RS);
-				float_emit.FCVTL(64, RS, RS);
+				float_emit.LD1R(32, EncodeRegToDouble(RS), addr);
+				float_emit.REV32(8, EncodeRegToDouble(RS), EncodeRegToDouble(RS));
+				float_emit.FCVTL(64, EncodeRegToDouble(RS), EncodeRegToDouble(RS));
 			}
 			else
 			{

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -21,7 +21,6 @@ void JitArm64::psq_l(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITLoadStorePairedOff);
 	FALLBACK_IF(jo.memcheck || !jo.fastmem);
-	FALLBACK_IF(true);
 
 	// X30 is LR
 	// X0 contains the scale


### PR DESCRIPTION
Fixes a bug in lfs where I was doing a rev64.16b when I needed to do a rev32.8b.
Change a ld1r.4s to a ld1r.2s.
Fix an issue where a fcvtl2 needed to be a fcvtl.
Re-enabled psq_l, issue with flickering can't be reproduced anymore, so whatever.