### PR TITLE
Android TV: Make file selector screen usable with d-pads

### DIFF
--- a/Source/Android/app/src/main/res/layout/list_item_file.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_file.xml
@@ -4,6 +4,8 @@
               android:layout_width="match_parent"
               android:layout_height="56dp"
               android:background="?android:attr/selectableItemBackground"
+              android:focusable="true"
+              android:clickable="true"
               android:orientation="horizontal">
 
     <ImageView


### PR DESCRIPTION
Pretty self-explanatory. Hard to use the app on android TV if you can't add games to the library.