### PR TITLE
Fixed: NULL remoteHost in IOCTL_SO_INETATON

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -921,16 +921,22 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 		std::string hostname = Memory::GetString(BufferIn);
 		struct hostent* remoteHost = gethostbyname(hostname.c_str());
 
-		if (remoteHost != nullptr && remoteHost->h_addr_list != nullptr)
+		if (remoteHost == nullptr || remoteHost->h_addr_list == nullptr || remoteHost->h_addr_list[0] == nullptr)
+		{
+			INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = -1 "
+				"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: None",
+				hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize);
+			ReturnValue = 0;
+		}
+		else
+		{
 			Memory::Write_U32(Common::swap32(*(u32*)remoteHost->h_addr_list[0]), BufferOut);
-
-		INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = %d "
-			"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: %08X",
-			(remoteHost == nullptr || remoteHost->h_addr_list == nullptr || remoteHost->h_addr_list[0] == nullptr) ? -1 : 0,
-			hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize,
-			(remoteHost == nullptr || remoteHost->h_addr_list == nullptr) ? -1 : Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
-
-		ReturnValue = (remoteHost == nullptr || remoteHost->h_addr_list == nullptr || remoteHost->h_addr_list[0] == nullptr) ? 0 : 1;
+			INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = 0 "
+				"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: %08X",
+				hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize,
+				Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
+			ReturnValue = 1;
+		}
 		break;
 	}
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -921,16 +921,16 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 		std::string hostname = Memory::GetString(BufferIn);
 		struct hostent* remoteHost = gethostbyname(hostname.c_str());
 
-		if (remoteHost != nullptr)
+		if (remoteHost != nullptr && remoteHost->h_addr_list != nullptr)
 			Memory::Write_U32(Common::swap32(*(u32*)remoteHost->h_addr_list[0]), BufferOut);
 
 		INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = %d "
 			"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: %08X",
-			(remoteHost == nullptr || remoteHost->h_addr_list[0] == nullptr) ? -1 : 0,
+			(remoteHost == nullptr || remoteHost->h_addr_list == nullptr || remoteHost->h_addr_list[0] == nullptr) ? -1 : 0,
 			hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize,
-			remoteHost == nullptr ? -1 : Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
+			(remoteHost == nullptr || remoteHost->h_addr_list == nullptr) ? -1 : Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
 
-		ReturnValue = (remoteHost == nullptr || remoteHost->h_addr_list[0] == nullptr) ? 0 : 1;
+		ReturnValue = (remoteHost == nullptr || remoteHost->h_addr_list == nullptr || remoteHost->h_addr_list[0] == nullptr) ? 0 : 1;
 		break;
 	}
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -921,21 +921,16 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 		std::string hostname = Memory::GetString(BufferIn);
 		struct hostent* remoteHost = gethostbyname(hostname.c_str());
 
-		if (remoteHost == nullptr)
-		{
-			INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = %d "
-				"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: NULL", -1,
-				hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize);
-			ReturnValue = 0;
-		}
-		else
-		{
+		if (remoteHost != nullptr)
 			Memory::Write_U32(Common::swap32(*(u32*)remoteHost->h_addr_list[0]), BufferOut);
-			INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = %d "
-				"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: %08X", remoteHost->h_addr_list[0] == nullptr ? -1 : 0,
-				hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize, Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
-			ReturnValue = remoteHost->h_addr_list[0] == nullptr ? 0 : 1;
-		}
+
+		INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = %d "
+			"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: %08X",
+			(remoteHost == nullptr || remoteHost->h_addr_list[0] == nullptr) ? -1 : 0,
+			hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize,
+			remoteHost == nullptr ? -1 : Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
+
+		ReturnValue = (remoteHost == nullptr || remoteHost->h_addr_list[0] == nullptr) ? 0 : 1;
 		break;
 	}
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -921,11 +921,21 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 		std::string hostname = Memory::GetString(BufferIn);
 		struct hostent* remoteHost = gethostbyname(hostname.c_str());
 
-		Memory::Write_U32(Common::swap32(*(u32*)remoteHost->h_addr_list[0]), BufferOut);
-		INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = %d "
-			"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: %08X",remoteHost->h_addr_list[0] == nullptr ? -1 : 0,
-			hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize, Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
-		ReturnValue = remoteHost->h_addr_list[0] == nullptr ? 0 : 1;
+		if (remoteHost == nullptr)
+		{
+			INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = %d "
+				"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: NULL", -1,
+				hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize);
+			ReturnValue = 0;
+		}
+		else
+		{
+			Memory::Write_U32(Common::swap32(*(u32*)remoteHost->h_addr_list[0]), BufferOut);
+			INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = %d "
+				"%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: %08X", remoteHost->h_addr_list[0] == nullptr ? -1 : 0,
+				hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize, Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
+			ReturnValue = remoteHost->h_addr_list[0] == nullptr ? 0 : 1;
+		}
 		break;
 	}
 


### PR DESCRIPTION
Fix a crash when a domain name doesn't exist. (Ex: Monster Hunter Tri)