### PR TITLE
Fix bug where Gecko codes would be "enabled by default"

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -262,11 +262,12 @@ bool IniFile::GetKeys(const std::string& sectionName, std::vector<std::string>* 
 // Return a list of all lines in a section
 bool IniFile::GetLines(const std::string& sectionName, std::vector<std::string>* lines, const bool remove_comments) const
 {
+	lines->clear();
+
 	const Section* section = GetSection(sectionName);
 	if (!section)
 		return false;
 
-	lines->clear();
 	for (std::string line : section->lines)
 	{
 		line = StripSpaces(line);


### PR DESCRIPTION
Actually caused by IniFiles::GetLines leaving the output vector in its
old state if the section wasn't found, and Gecko::LoadCodes not checking
the return value.  Fix by moving lines->clear() up.