### PR TITLE
Fix subdialogs of the ISO props dialog... sort of

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -687,6 +687,7 @@ void CISOProperties::OnBannerImageSave(wxCommandEvent& WXUNUSED (event))
 	{
 		m_Banner->GetBitmap().ConvertToImage().SaveFile(dialog.GetPath());
 	}
+	Raise();
 }
 
 void CISOProperties::OnRightClickOnTree(wxTreeEvent& event)
@@ -1382,12 +1383,15 @@ void CISOProperties::PatchButtonClicked(wxCommandEvent& event)
 		{
 		CPatchAddEdit dlg(selection, &onFrame, this);
 		dlg.ShowModal();
+		Raise();
 		}
 		break;
 	case ID_ADDPATCH:
 		{
 		CPatchAddEdit dlg(-1, &onFrame, this, 1, _("Add Patch"));
-		if (dlg.ShowModal() == wxID_OK)
+		int res = dlg.ShowModal();
+		Raise();
+		if (res == wxID_OK)
 		{
 			Patches->Append(StrToWxStr(onFrame.back().name));
 			Patches->Check((unsigned int)(onFrame.size() - 1), onFrame.back().active);
@@ -1462,12 +1466,15 @@ void CISOProperties::ActionReplayButtonClicked(wxCommandEvent& event)
 		{
 		CARCodeAddEdit dlg(selection, &arCodes, this);
 		dlg.ShowModal();
+		Raise();
 		}
 		break;
 	case ID_ADDCHEAT:
 		{
 			CARCodeAddEdit dlg(-1, &arCodes, this, 1, _("Add ActionReplay Code"));
-			if (dlg.ShowModal() == wxID_OK)
+			int res = dlg.ShowModal();
+			Raise();
+			if (res == wxID_OK)
 			{
 				Cheats->Append(StrToWxStr(arCodes.back().name));
 				Cheats->Check((unsigned int)(arCodes.size() - 1), arCodes.back().active);


### PR DESCRIPTION
On OS X, if you close a subdialog of the ISO Properties dialog, such as
the one to add a new AR code, the main Dolphin window would magically
get raised above ISO Properties.  This is confusing, to say the least;
when I encountered this the other day, I thought the dialog was actually
getting closed.

I *think* the diagnosis looks like this:
Cocoa expects NSPanel (not to be confused with wxPanel) to be for things
like find dialogs, font dialogs with the little title bars, sheets, etc.
See:
https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/WinPanel/Concepts/ChangingMainKeyWindow.html
Therefore, NSPanels return NO for canBecomeMainWindow, which is
documented; and when [NSWindow orderOut:] is called to hide a window,
Cocoa seems to want to make the window it focuses in its place a main
window, which, as far as I can tell, is not.  So if the next highest
window is a panel, it gets skipped over.  (I tested this by overriding
wxNSPanel's canBecomeMainWindow to return YES, in which case the right
window gets focused, but this isn't a correct fix.)

The ISO Properties dialog does have grounds to be a dialog/panel - the
close button, whose positioning is provided by the wxDialog class.  This
is arguably simply a roundabout discovery that our UI sucks for an OS X
app and that to be consistent with other nonmodal preferences dialogs,
it shouldn't have such a button on OS X (though ESC to close is still
kosher).  However, I'm not willing to make that change right now, so...

Hack around the problem by calling Raise (on this) after each call to
ShowModal in CISOProperties.  The resulting behavior is slightly
glitchy, and I'd like to revisit it, but for now it fixes the issue.