### PR TITLE
Linux: Install a udev rule for the GC Adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -856,6 +856,10 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pixmaps)
 	install(FILES Installer/dolphin-emu.desktop
 		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+	# Install udev rule
+	install(FILES Installer/51-gcadapter.rules
+		DESTINATION /lib/udev/rules.d
+		OPTIONAL)
 endif()
 
 # packaging information

--- a/Installer/51-gcadapter.rules
+++ b/Installer/51-gcadapter.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", MODE="0666"


### PR DESCRIPTION
This will mess up installs to a prefix not run as root. However, bare `make install`s already needed root to write to `/usr`, so this will... probably be fine.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/2510)
<!-- Reviewable:end -->
