### PR TITLE
[WIP] MemoryUtil: fix a couple of mmap fails

### DIFF
--- a/Source/Core/Common/MemoryUtil.h
+++ b/Source/Core/Common/MemoryUtil.h
@@ -17,6 +17,7 @@ void WriteProtectMemory(void* ptr, size_t size, bool executable = false);
 void UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute = false);
 std::string MemUsage();
 size_t MemPhysical();
+void CheckRIPRelative(const void* addr, size_t size);
 
 void GuardMemoryMake(void* ptr, size_t size);
 void GuardMemoryUnmake(void* ptr, size_t size);

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -11,6 +11,7 @@
 #include "Common/Common.h"
 #include "Common/FileUtil.h"
 #include "Common/Intrinsics.h"
+#include "Common/MemoryUtil.h"
 #include "Common/StdMakeUnique.h"
 #include "Common/StringUtil.h"
 #include "Core/PatchEngine.h"
@@ -251,6 +252,7 @@ void JitIL::Init()
 
 	trampolines.Init(jo.memcheck ? TRAMPOLINE_CODE_SIZE_MMU : TRAMPOLINE_CODE_SIZE);
 	AllocCodeSpace(CODE_SIZE, PPCSTATE_BASE);
+	CheckRIPRelative(region, CODE_SIZE);
 	blocks.Init();
 	asm_routines.Init(nullptr);
 

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -8,6 +8,7 @@
 
 #include "Common/BitSet.h"
 #include "Common/CPUDetect.h"
+#include "Common/MemoryUtil.h"
 #include "Common/x64Emitter.h"
 #include "Core/PowerPC/PowerPC.h"
 
@@ -31,7 +32,7 @@ private:
 	bool m_enabled = false;
 public:
 	bool Enabled() { return m_enabled; }
-	void Init(int size) { AllocCodeSpace(size, PPCSTATE_BASE); m_enabled = true; }
+	void Init(int size) { AllocCodeSpace(size, PPCSTATE_BASE); CheckRIPRelative(region, size); m_enabled = true; }
 	void Shutdown() { FreeCodeSpace(); m_enabled = false; }
 };
 

--- a/Source/Core/Core/PowerPC/JitCommon/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/TrampolineCache.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/JitRegister.h"
+#include "Common/MemoryUtil.h"
 #include "Common/StringUtil.h"
 #include "Common/x64ABI.h"
 #include "Core/HW/Memmap.h"
@@ -23,6 +24,7 @@ using namespace Gen;
 void TrampolineCache::Init(int size)
 {
 	AllocCodeSpace(size, PPCSTATE_BASE);
+	CheckRIPRelative(region, size);
 }
 
 void TrampolineCache::ClearCodeSpace()

--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -97,6 +97,7 @@ protected:
 		emitter.reset(new X64CodeBlock());
 		emitter->AllocCodeSpace(4096, PPCSTATE_BASE);
 		code_buffer = emitter->GetWritableCodePtr();
+		CheckRIPRelative(code_buffer, 4096);
 
 		disasm.reset(new disassembler);
 		disasm->set_syntax_intel();


### PR DESCRIPTION
- Page-align the mmap hint because Valgrind requires it.
- Fix a macro typo.
- Cast size to signed to correct the upper bounds check.
- Explain how to run Dolphin in GDB.