### PR TITLE
Volume: Return volume type as an enum

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -239,7 +239,7 @@ bool CBoot::BootUp()
 
 		const DiscIO::IVolume& pVolume = DVDInterface::GetVolume();
 
-		if (pVolume.IsWiiDisc() != _StartupPara.bWii)
+		if ((pVolume.GetVolumeType() == DiscIO::IVolume::WII_DISC) != _StartupPara.bWii)
 		{
 			PanicAlertT("Warning - starting ISO in wrong console mode!");
 		}
@@ -255,7 +255,7 @@ bool CBoot::BootUp()
 			WII_IPC_HLE_Interface::ES_DIVerify(tmd_buf.get(), tmd_size);
 		}
 
-		_StartupPara.bWii = pVolume.IsWiiDisc();
+		_StartupPara.bWii = pVolume.GetVolumeType() == DiscIO::IVolume::WII_DISC;
 
 		// HLE BS2 or not
 		if (_StartupPara.bHLE_BS2)
@@ -314,7 +314,8 @@ bool CBoot::BootUp()
 		{
 			BS2Success = EmulatedBS2(dolWii);
 		}
-		else if ((!DVDInterface::VolumeIsValid() || !DVDInterface::GetVolume().IsWiiDisc()) && !_StartupPara.m_strDefaultISO.empty())
+		else if ((!DVDInterface::VolumeIsValid() || DVDInterface::GetVolume().GetVolumeType() != DiscIO::IVolume::WII_DISC) &&
+		         !_StartupPara.m_strDefaultISO.empty())
 		{
 			DVDInterface::SetVolumeName(_StartupPara.m_strDefaultISO);
 			BS2Success = EmulatedBS2(dolWii);

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -321,7 +321,7 @@ bool CBoot::EmulatedBS2_Wii()
 
 	// Execute the apploader
 	bool apploaderRan = false;
-	if (DVDInterface::VolumeIsValid() && DVDInterface::GetVolume().IsWiiDisc())
+	if (DVDInterface::VolumeIsValid() && DVDInterface::GetVolume().GetVolumeType() == DiscIO::IVolume::WII_DISC)
 	{
 		// This is some kind of consistency check that is compared to the 0x00
 		// values as the game boots. This location keep the 4 byte ID for as long

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -184,7 +184,7 @@ bool SCoreStartupParameter::AutoSetup(EBootBS2 _BootBS2)
 				m_revision = pVolume->GetRevision();
 
 				// Check if we have a Wii disc
-				bWii = pVolume.get()->IsWiiDisc();
+				bWii = pVolume.get()->GetVolumeType() == DiscIO::IVolume::WII_DISC;
 
 				const char* retrieved_region_dir = GetRegionOfCountry(pVolume->GetCountry());
 				if (!retrieved_region_dir)

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -1434,7 +1434,7 @@ s64 CalculateRawDiscReadTime(u64 offset, s64 length)
 	// Note that the speed at a track (in bytes per second) is the same as
 	// the radius of that track because of the length unit used.
 	double speed;
-	if (s_inserted_volume->IsWiiDisc())
+	if (s_inserted_volume->GetVolumeType() == DiscIO::IVolume::WII_DISC)
 	{
 		speed = std::sqrt(((average_offset - WII_DISC_LOCATION_1_OFFSET) /
 			WII_BYTES_PER_AREA_UNIT + WII_DISC_AREA_UP_TO_LOCATION_1) / PI);

--- a/Source/Core/DiscIO/FileMonitor.cpp
+++ b/Source/Core/DiscIO/FileMonitor.cpp
@@ -76,7 +76,7 @@ void ReadFileSystem(const std::string& filename)
 	if (!OpenISO)
 		return;
 
-	if (!OpenISO->IsWadFile())
+	if (OpenISO->GetVolumeType() != DiscIO::IVolume::WII_WAD)
 	{
 		pFileSystem = DiscIO::CreateFileSystem(OpenISO);
 

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -19,6 +19,14 @@ class IVolume
 {
 public:
 	// Increment CACHE_REVISION if the enums below are modified (ISOFile.cpp & GameFile.cpp)
+	enum EPlatform
+	{
+		GAMECUBE_DISC = 0,
+		WII_DISC,
+		WII_WAD,
+		NUMBER_OF_PLATFORMS
+	};
+
 	enum ECountry
 	{
 		COUNTRY_EUROPE = 0,
@@ -86,8 +94,7 @@ public:
 	// 0 is the first disc, 1 is the second disc
 	virtual u8 GetDiscNumber() const { return 0; }
 
-	virtual bool IsWiiDisc() const { return false; }
-	virtual bool IsWadFile() const { return false; }
+	virtual EPlatform GetVolumeType() const = 0;
 	virtual bool SupportsIntegrityCheck() const { return false; }
 	virtual bool CheckIntegrity() const { return false; }
 	virtual bool ChangePartition(u64 offset) { return false; }

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -220,9 +220,9 @@ std::string CVolumeDirectory::GetApploaderDate() const
 	return "VOID";
 }
 
-bool CVolumeDirectory::IsWiiDisc() const
+IVolume::EPlatform CVolumeDirectory::GetVolumeType() const
 {
-	return m_is_wii;
+	return m_is_wii ? WII_DISC : GAMECUBE_DISC;
 }
 
 u64 CVolumeDirectory::GetSize() const

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -47,7 +47,7 @@ public:
 	u32 GetFSTSize() const override;
 
 	std::string GetApploaderDate() const override;
-	bool IsWiiDisc() const override;
+	EPlatform GetVolumeType() const override;
 
 	ECountry GetCountry() const override;
 

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -272,6 +272,11 @@ u8 CVolumeGC::GetDiscNumber() const
 	return disc_number;
 }
 
+IVolume::EPlatform CVolumeGC::GetVolumeType() const
+{
+	return GAMECUBE_DISC;
+}
+
 bool CVolumeGC::LoadBannerFile() const
 {
 	// The methods GetNames, GetDescriptions, GetCompany and GetBanner

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -37,6 +37,7 @@ public:
 	std::string GetApploaderDate() const override;
 	u8 GetDiscNumber() const override;
 
+	EPlatform GetVolumeType() const override;
 	ECountry GetCountry() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -112,9 +112,9 @@ u16 CVolumeWAD::GetRevision() const
 	return Common::swap16(revision);
 }
 
-bool CVolumeWAD::IsWadFile() const
+IVolume::EPlatform CVolumeWAD::GetVolumeType() const
 {
-	return true;
+	return WII_WAD;
 }
 
 std::map<IVolume::ELanguage, std::string> CVolumeWAD::GetNames() const

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -36,7 +36,7 @@ public:
 	u32 GetFSTSize() const override { return 0; }
 	std::string GetApploaderDate() const override { return ""; }
 
-	bool IsWadFile() const override;
+	EPlatform GetVolumeType() const override;
 
 	ECountry GetCountry() const override;
 	u64 GetSize() const override;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -238,9 +238,9 @@ std::string CVolumeWiiCrypted::GetApploaderDate() const
 	return date;
 }
 
-bool CVolumeWiiCrypted::IsWiiDisc() const
+IVolume::EPlatform CVolumeWiiCrypted::GetVolumeType() const
 {
-	return true;
+	return WII_DISC;
 }
 
 u8 CVolumeWiiCrypted::GetDiscNumber() const

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -37,7 +37,7 @@ public:
 	std::string GetApploaderDate() const override;
 	u8 GetDiscNumber() const override;
 
-	bool IsWiiDisc() const override;
+	EPlatform GetVolumeType() const override;
 	bool SupportsIntegrityCheck() const override { return true; }
 	bool CheckIntegrity() const override;
 	bool ChangePartition(u64 offset) override;

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -31,7 +31,7 @@ public:
 	const QString GetUniqueID() const { return m_unique_id; }
 	const QString GetWiiFSPath() const;
 	DiscIO::IVolume::ECountry GetCountry() const { return m_country; }
-	int GetPlatform() const { return m_platform; }
+	DiscIO::IVolume::EPlatform GetPlatform() const { return m_platform; }
 	const QString GetIssues() const { return m_issues; }
 	int GetEmuState() const { return m_emu_state; }
 	bool IsCompressed() const { return m_compressed; }
@@ -40,14 +40,6 @@ public:
 	// 0 is the first disc, 1 is the second disc
 	u8 GetDiscNumber() const { return m_disc_number; }
 	const QPixmap GetBitmap() const { return m_banner; }
-
-	enum
-	{
-		GAMECUBE_DISC = 0,
-		WII_DISC,
-		WII_WAD,
-		NUMBER_OF_PLATFORMS
-	};
 
 private:
 	QString m_file_name;
@@ -66,7 +58,7 @@ private:
 	quint64 m_volume_size = 0;
 
 	DiscIO::IVolume::ECountry m_country;
-	int m_platform;
+	DiscIO::IVolume::EPlatform m_platform;
 	u16 m_revision = 0;
 
 	QPixmap m_banner;

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -85,8 +85,8 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
 		sortData = -sortData;
 	}
 
-	DiscIO::IVolume::ELanguage languageOne = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(iso1->GetPlatform() != GameListItem::GAMECUBE_DISC);
-	DiscIO::IVolume::ELanguage languageOther = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(iso2->GetPlatform() != GameListItem::GAMECUBE_DISC);
+	DiscIO::IVolume::ELanguage languageOne = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(iso1->GetPlatform() != DiscIO::IVolume::GAMECUBE_DISC);
+	DiscIO::IVolume::ELanguage languageOther = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(iso2->GetPlatform() != DiscIO::IVolume::GAMECUBE_DISC);
 
 	switch (sortData)
 	{
@@ -519,11 +519,11 @@ void CGameListCtrl::ScanForISOs()
 
 				switch(iso_file->GetPlatform())
 				{
-					case GameListItem::WII_DISC:
+					case DiscIO::IVolume::WII_DISC:
 						if (!SConfig::GetInstance().m_ListWii)
 							list = false;
 						break;
-					case GameListItem::WII_WAD:
+					case DiscIO::IVolume::WII_WAD:
 						if (!SConfig::GetInstance().m_ListWad)
 							list = false;
 						break;
@@ -842,7 +842,7 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
 			popupMenu.Append(IDM_GAME_WIKI, _("&Wiki"));
 			popupMenu.AppendSeparator();
 
-			if (selected_iso->GetPlatform() != GameListItem::GAMECUBE_DISC)
+			if (selected_iso->GetPlatform() != DiscIO::IVolume::GAMECUBE_DISC)
 			{
 				popupMenu.Append(IDM_OPEN_SAVE_FOLDER, _("Open Wii &save folder"));
 				popupMenu.Append(IDM_EXPORT_SAVE, _("Export Wii save (Experimental)"));
@@ -858,7 +858,7 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
 			popupMenu.AppendSeparator();
 			popupMenu.Append(IDM_DELETE_ISO, _("&Delete ISO..."));
 
-			if (selected_iso->GetPlatform() != GameListItem::WII_WAD)
+			if (selected_iso->GetPlatform() != DiscIO::IVolume::WII_WAD)
 			{
 				if (selected_iso->IsCompressed())
 					popupMenu.Append(IDM_COMPRESS_ISO, _("Decompress ISO..."));
@@ -870,8 +870,8 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
 			{
 				popupMenu.Append(IDM_LIST_INSTALL_WAD, _("Install to Wii Menu"));
 			}
-			if (selected_iso->GetPlatform() == GameListItem::GAMECUBE_DISC ||
-				selected_iso->GetPlatform() == GameListItem::WII_DISC)
+			if (selected_iso->GetPlatform() == DiscIO::IVolume::GAMECUBE_DISC ||
+				selected_iso->GetPlatform() == DiscIO::IVolume::WII_DISC)
 			{
 				wxMenuItem* changeDiscItem = popupMenu.Append(IDM_LIST_CHANGE_DISC, _("Change &Disc"));
 				changeDiscItem->Enable(Core::IsRunning());
@@ -1079,7 +1079,7 @@ void CGameListCtrl::CompressSelection(bool _compress)
 		for (u32 i = 0; i < m_numberItem; i++)
 		{
 			const GameListItem* iso = GetSelectedISO();
-			if (iso->GetPlatform() == GameListItem::WII_WAD || iso->GetFileName().rfind(".wbfs") != std::string::npos)
+			if (iso->GetPlatform() == DiscIO::IVolume::WII_WAD || iso->GetFileName().rfind(".wbfs") != std::string::npos)
 				continue;
 
 			if (!iso->IsCompressed() && _compress)
@@ -1104,7 +1104,7 @@ void CGameListCtrl::CompressSelection(bool _compress)
 
 				all_good &= DiscIO::CompressFileToBlob(iso->GetFileName(),
 						OutputFileName,
-						(iso->GetPlatform() == GameListItem::WII_DISC) ? 1 : 0,
+						(iso->GetPlatform() == DiscIO::IVolume::WII_DISC) ? 1 : 0,
 						16384, &MultiCompressCB, &progressDialog);
 			}
 			else if (iso->IsCompressed() && !_compress)
@@ -1112,7 +1112,7 @@ void CGameListCtrl::CompressSelection(bool _compress)
 				std::string FileName, FileExt;
 				SplitPath(iso->GetFileName(), nullptr, &FileName, &FileExt);
 				m_currentFilename = FileName;
-				if (iso->GetPlatform() == GameListItem::WII_DISC)
+				if (iso->GetPlatform() == DiscIO::IVolume::WII_DISC)
 					FileName.append(".iso");
 				else
 					FileName.append(".gcm");
@@ -1165,7 +1165,7 @@ void CGameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED (event))
 		if (iso->IsCompressed())
 		{
 			wxString FileType;
-			if (iso->GetPlatform() == GameListItem::WII_DISC)
+			if (iso->GetPlatform() == DiscIO::IVolume::WII_DISC)
 				FileType = _("All Wii ISO files (iso)") + "|*.iso";
 			else
 				FileType = _("All GameCube GCM files (gcm)") + "|*.gcm";
@@ -1220,7 +1220,7 @@ void CGameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED (event))
 	else
 		all_good = DiscIO::CompressFileToBlob(iso->GetFileName(),
 				WxStrToStr(path),
-				(iso->GetPlatform() == GameListItem::WII_DISC) ? 1 : 0,
+				(iso->GetPlatform() == DiscIO::IVolume::WII_DISC) ? 1 : 0,
 				16384, &CompressCB, &dialog);
 	}
 

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -82,10 +82,7 @@ GameListItem::GameListItem(const std::string& _rFileName)
 
 		if (pVolume != nullptr)
 		{
-			if (!pVolume->IsWadFile())
-				m_Platform = pVolume->IsWiiDisc() ? WII_DISC : GAMECUBE_DISC;
-			else
-				m_Platform = WII_WAD;
+			m_Platform = pVolume->GetVolumeType();
 
 			m_names = pVolume->GetNames();
 			m_descriptions = pVolume->GetDescriptions();
@@ -217,7 +214,8 @@ std::string GameListItem::GetDescription(DiscIO::IVolume::ELanguage language) co
 
 std::string GameListItem::GetDescription() const
 {
-	return GetDescription(SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(m_Platform != GAMECUBE_DISC));
+	bool wii = m_Platform != DiscIO::IVolume::GAMECUBE_DISC;
+	return GetDescription(SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(wii));
 }
 
 std::string GameListItem::GetName(DiscIO::IVolume::ELanguage language) const
@@ -227,7 +225,8 @@ std::string GameListItem::GetName(DiscIO::IVolume::ELanguage language) const
 
 std::string GameListItem::GetName() const
 {
-	std::string name = GetName(SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(m_Platform != GAMECUBE_DISC));
+	bool wii = m_Platform != DiscIO::IVolume::GAMECUBE_DISC;
+	std::string name = GetName(SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(wii));
 	if (name.empty())
 	{
 		// No usable name, return filename (better than nothing)
@@ -252,7 +251,7 @@ const std::string GameListItem::GetWiiFSPath() const
 	if (iso == nullptr)
 		return ret;
 
-	if (iso->IsWiiDisc() || iso->IsWadFile())
+	if (iso->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC)
 	{
 		u64 title = 0;
 

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -35,7 +35,7 @@ public:
 	const std::string& GetUniqueID() const {return m_UniqueID;}
 	const std::string GetWiiFSPath() const;
 	DiscIO::IVolume::ECountry GetCountry() const {return m_Country;}
-	int GetPlatform() const {return m_Platform;}
+	DiscIO::IVolume::EPlatform GetPlatform() const { return m_Platform; }
 	const std::string& GetIssues() const { return m_issues; }
 	int GetEmuState() const { return m_emu_state; }
 	bool IsCompressed() const {return m_BlobCompressed;}
@@ -48,14 +48,6 @@ public:
 #endif
 
 	void DoState(PointerWrap &p);
-
-	enum
-	{
-		GAMECUBE_DISC = 0,
-		WII_DISC,
-		WII_WAD,
-		NUMBER_OF_PLATFORMS
-	};
 
 private:
 	std::string m_FileName;
@@ -73,7 +65,7 @@ private:
 	u64 m_VolumeSize;
 
 	DiscIO::IVolume::ECountry m_Country;
-	int m_Platform;
+	DiscIO::IVolume::EPlatform m_Platform;
 	u16 m_Revision;
 
 #if defined(HAVE_WX) && HAVE_WX

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -189,16 +189,17 @@ CISOProperties::CISOProperties(const std::string fileName, wxWindow* parent, wxW
 	m_FST->SetValue(wxString::Format("%u", OpenISO->GetFSTSize()));
 
 	// Here we set all the info to be shown + we set the window title
-	ChangeBannerDetails(SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(OpenISO->IsWadFile() || OpenISO->IsWiiDisc()));
+	bool wii = OpenISO->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;
+	ChangeBannerDetails(SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(wii));
 
 	m_Banner->SetBitmap(OpenGameListItem->GetBitmap());
 	m_Banner->Bind(wxEVT_RIGHT_DOWN, &CISOProperties::RightClickOnBanner, this);
 
 	// Filesystem browser/dumper
 	// TODO : Should we add a way to browse the wad file ?
-	if (!OpenISO->IsWadFile())
+	if (OpenISO->GetVolumeType() != DiscIO::IVolume::WII_WAD)
 	{
-		if (OpenISO->IsWiiDisc())
+		if (OpenISO->GetVolumeType() == DiscIO::IVolume::WII_DISC)
 		{
 			int partition_count = 0;
 			for (int group = 0; group < 4; group++)
@@ -239,7 +240,7 @@ CISOProperties::CISOProperties(const std::string fileName, wxWindow* parent, wxW
 
 CISOProperties::~CISOProperties()
 {
-	if (!OpenISO->IsWiiDisc() && !OpenISO->IsWadFile() && pFileSystem)
+	if (OpenISO->GetVolumeType() == DiscIO::IVolume::GAMECUBE_DISC && pFileSystem)
 		delete pFileSystem;
 	delete OpenGameListItem;
 	delete OpenISO;
@@ -400,7 +401,7 @@ void CISOProperties::CreateGUIControls()
 	sbCoreOverrides->Add(sGPUDeterminism, 0, wxEXPAND|wxALL, 5);
 
 	wxStaticBoxSizer * const sbWiiOverrides = new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Wii Console"));
-	if (!OpenISO->IsWiiDisc() && !OpenISO->IsWadFile())
+	if (OpenISO->GetVolumeType() == DiscIO::IVolume::GAMECUBE_DISC)
 	{
 		sbWiiOverrides->ShowItems(false);
 		EnableWideScreen->Hide();
@@ -488,7 +489,8 @@ void CISOProperties::CreateGUIControls()
 
 	wxStaticText* const m_LangText = new wxStaticText(m_Information, wxID_ANY, _("Show Language:"));
 
-	DiscIO::IVolume::ELanguage preferred_language = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(OpenISO->IsWadFile() || OpenISO->IsWiiDisc());
+	bool wii = OpenISO->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;
+	DiscIO::IVolume::ELanguage preferred_language = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(wii);
 
 	std::vector<DiscIO::IVolume::ELanguage> languages = OpenGameListItem->GetLanguages();
 	int preferred_language_index = 0;
@@ -598,7 +600,7 @@ void CISOProperties::CreateGUIControls()
 	sInfoPage->Add(sbBannerDetails, 0, wxEXPAND|wxALL, 5);
 	m_Information->SetSizer(sInfoPage);
 
-	if (!OpenISO->IsWadFile())
+	if (OpenISO->GetVolumeType() != DiscIO::IVolume::WII_WAD)
 	{
 		wxPanel* const m_Filesystem = new wxPanel(m_Notebook, ID_FILESYSTEM);
 		m_Notebook->AddPage(m_Filesystem, _("Filesystem"));
@@ -705,7 +707,7 @@ void CISOProperties::OnRightClickOnTree(wxTreeEvent& event)
 
 	popupMenu.Append(IDM_EXTRACTALL, _("Extract All Files..."));
 
-	if (!OpenISO->IsWiiDisc() ||
+	if (OpenISO->GetVolumeType() != DiscIO::IVolume::WII_DISC ||
 		(m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 0 &&
 		m_Treectrl->GetFirstVisibleItem() != m_Treectrl->GetSelection()))
 	{
@@ -748,7 +750,7 @@ void CISOProperties::OnExtractFile(wxCommandEvent& WXUNUSED (event))
 		m_Treectrl->SelectItem(m_Treectrl->GetItemParent(m_Treectrl->GetSelection()));
 	}
 
-	if (OpenISO->IsWiiDisc())
+	if (OpenISO->GetVolumeType() == DiscIO::IVolume::WII_DISC)
 	{
 		const wxTreeItemId tree_selection = m_Treectrl->GetSelection();
 		WiiPartition* partition = reinterpret_cast<WiiPartition*>(m_Treectrl->GetItemData(tree_selection));
@@ -764,7 +766,7 @@ void CISOProperties::OnExtractFile(wxCommandEvent& WXUNUSED (event))
 
 void CISOProperties::ExportDir(const std::string& _rFullPath, const std::string& _rExportFolder, const WiiPartition* partition)
 {
-	DiscIO::IFileSystem* const fs = OpenISO->IsWiiDisc() ? partition->FileSystem : pFileSystem;
+	DiscIO::IFileSystem* const fs = OpenISO->GetVolumeType() == DiscIO::IVolume::WII_DISC ? partition->FileSystem : pFileSystem;
 
 	const std::vector<DiscIO::SFileInfo>& fst = fs->GetFileList();
 
@@ -778,7 +780,7 @@ void CISOProperties::ExportDir(const std::string& _rFullPath, const std::string&
 		size = (u32)fst.size();
 
 		fs->ExportApploader(_rExportFolder);
-		if (!OpenISO->IsWiiDisc())
+		if (OpenISO->GetVolumeType() != DiscIO::IVolume::WII_DISC)
 			fs->ExportDOL(_rExportFolder);
 	}
 	else
@@ -863,7 +865,7 @@ void CISOProperties::OnExtractDir(wxCommandEvent& event)
 
 	if (event.GetId() == IDM_EXTRACTALL)
 	{
-		if (OpenISO->IsWiiDisc())
+		if (OpenISO->GetVolumeType() == DiscIO::IVolume::WII_DISC)
 		{
 			wxTreeItemIdValue cookie;
 			wxTreeItemId root = m_Treectrl->GetRootItem();
@@ -892,7 +894,7 @@ void CISOProperties::OnExtractDir(wxCommandEvent& event)
 
 	Directory += DIR_SEP_CHR;
 
-	if (OpenISO->IsWiiDisc())
+	if (OpenISO->GetVolumeType() == DiscIO::IVolume::WII_DISC)
 	{
 		const wxTreeItemId tree_selection = m_Treectrl->GetSelection();
 		WiiPartition* partition = reinterpret_cast<WiiPartition*>(m_Treectrl->GetItemData(tree_selection));
@@ -914,7 +916,7 @@ void CISOProperties::OnExtractDataFromHeader(wxCommandEvent& event)
 	if (Path.empty())
 		return;
 
-	if (OpenISO->IsWiiDisc())
+	if (OpenISO->GetVolumeType() == DiscIO::IVolume::WII_DISC)
 	{
 		WiiPartition* partition = reinterpret_cast<WiiPartition*>(m_Treectrl->GetItemData(m_Treectrl->GetSelection()));
 		FS = partition->FileSystem;
@@ -960,7 +962,7 @@ void CISOProperties::CheckPartitionIntegrity(wxCommandEvent& event)
 {
 	// Normally we can't enter this function if we aren't analyzing a Wii disc
 	// anyway, but let's still check to be sure.
-	if (!OpenISO->IsWiiDisc())
+	if (OpenISO->GetVolumeType() != DiscIO::IVolume::WII_DISC)
 		return;
 
 	wxProgressDialog dialog(_("Checking integrity..."), _("Working..."), 1000, this,

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -182,25 +182,17 @@ static int GetPlatform(std::string filename)
 
 	if (pVolume != nullptr)
 	{
-		bool is_wii_disc = pVolume->IsWiiDisc();
-		bool is_wii_wad = pVolume->IsWadFile();
-
-		if (is_wii_disc)
+		switch (pVolume->GetVolumeType())
 		{
-			__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a Wii disc.");
-
-			// See Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/Game.java
-			return 1;
-		}
-		else if (is_wii_wad)
-		{
-			__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a Wii WAD.");
-			return 2;
-		}
-		else
-		{
-			__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a Gamecube disc.");
-			return 0;
+			case DiscIO::IVolume::GAMECUBE_DISC:
+				__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a GameCube disc.");
+				return 0;
+			case DiscIO::IVolume::WII_DISC:
+				__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a Wii disc.");
+				return 1;
+			case DiscIO::IVolume::WII_WAD:
+				__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a Wii WAD.");
+				return 2;
 		}
 	}
 
@@ -216,13 +208,9 @@ static std::string GetTitle(std::string filename)
 	if (pVolume != nullptr) {
 		std::map <DiscIO::IVolume::ELanguage, std::string> titles = pVolume->GetNames();
 
-
-		/*bool is_wii_title = IsWiiTitle(filename);
-
-		DiscIO::IVolume::ELanguage language = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(
-				is_wii_title);
-
-
+		/*
+		bool is_wii_title = pVolume->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;
+		DiscIO::IVolume::ELanguage language = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(is_wii_title);
 
 		auto it = titles.find(language);
 		if (it != end)
@@ -262,10 +250,8 @@ static std::string GetDescription(std::string filename)
 		std::map <DiscIO::IVolume::ELanguage, std::string> descriptions = pVolume->GetDescriptions();
 
 		/*
-		bool is_wii_title = IsWiiTitle(filename);
-
-		DiscIO::IVolume::ELanguage language = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(
-				is_wii_title);
+		bool is_wii_title = pVolume->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;
+		DiscIO::IVolume::ELanguage language = SConfig::GetInstance().m_LocalCoreStartupParameter.GetCurrentLanguage(is_wii_title);
 
 		auto it = descriptions.find(language);
 		if (it != end)


### PR DESCRIPTION
ISOFile and GameFile were using IsWiiDisc() and IsWadFile() to set an enum value. The volume might as well return an enum directly.

I increased the Qt CACHE_REVISION because m_platform now is saved as u32 instead of int, but increasing the wx CACHE_REVISION is not necessary.