### PR TITLE
Properly set default video mode for PAL Wii games.

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -226,7 +226,11 @@ bool CBoot::BootUp()
 	NOTICE_LOG(BOOT, "Booting %s", _StartupPara.m_strFilename.c_str());
 
 	g_symbolDB.Clear();
-	VideoInterface::Preset(_StartupPara.bNTSC);
+
+	// PAL Wii uses NTSC framerate and linecount in 60Hz modes
+	const bool bPAL60 = _StartupPara.bWii && SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.E60");
+	VideoInterface::Preset(_StartupPara.bNTSC || bPAL60);
+
 	switch (_StartupPara.m_BootType)
 	{
 	// GCM and Wii


### PR DESCRIPTION
To explain this I'm going to have to talk a bit about a PAL Wii's video modes, so bear with me.

A PAL Wii can be set to three possible video modes: 50Hz (576i), 60Hz (480i), and EDTV/HDTV (480p) (which is still 60Hz, just progressive instead of interlaced). These can be found in Wii Settings -> Screen -> TV Type.

[![PAL Wii TV Types](http://i.imgur.com/0y3DLI1m.png)](http://i.imgur.com/0y3DLI1.png)

On console, PAL Wii games properly respect these settings when they can. Here's a few examples.

| PAL Wii TV Mode         | 576i   | 480i   | 480p   | Comment
|-------------------------|--------|--------|--------|-------------------------------------
| Mario Party 8           | 576i50 | 576i50 | 576i50 | Don't support 60Hz at all and will switch to 576i50 no matter what your Wii's settings are.
| Kororinpa               | 576i50 | 480i60 | 480i60 | Supports 60Hz just fine, but doesn't run in Progressive.
| Xenoblade Chronicles    | 576i50 | 480i60 | 480p60 | Runs fine in all modes.
| Boom Street             | 576i50 | 480i60 | 480p60 | Booting in 576i displays a message that it cannot run in 50Hz and that you should change to 480i/p in the Wii Settings
| The Last Story          | 576i50 | 480i60 | 480p60 | Same as above.
| Super Smash Bros. Brawl | 576i50 | 480i60 | 480p60 | Booting in 576i without a save file displays a message that the game runs better in 60Hz and that you should, if possible, change to 480i/p.

[![The Last Story 50Hz](http://i.imgur.com/UESSJrBm.png)](http://i.imgur.com/UESSJrB.png) [![Smash Bros Brawl 50Hz](http://i.imgur.com/0FMYuo8m.png)](http://i.imgur.com/0FMYuo8.png)


On Dolphin these results don't look as clean, and are in fact rather inconsistent.

| Dolphin 4.0-6554        | PAL60 off, Progressive off | PAL60 on, Progressive off | PAL60 on, Progressive on |
|-------------------------|----------------------------|---------------------------|--------------------------|
| Mario Party 8           | 576/50                     | 576/50                    | 576/50                   |
| Kororinpa               | 576/50                     | 576/50                    | 480/60                   |
| Xenoblade Chronicles    | 576/50                     | 576/50                    | 576/50                   |
| Boom Street             | 576/50                     | 576/50                    | 480/60                   |
| The Last Story          | 576/50                     | 480/60                    | 480/60                   |
| Super Smash Bros. Brawl | 576/50                     | 576/50                    | 576/50                   |

(Since as far as I can tell it doesn't really matter in Dolphin if a game runs interlaced or progressive, I have omitted this information from the above table.)

So why doesn't Dolphin match what the actual console does? To explain that, let's look at what settings the video modes actually correspond to: The IPL.E60 and IPL.PGS settings in the Wii's SYSCONF file.

576i -> IPL.E60 = 0, IPL.PGS = 0
480i -> IPL.E60 = 1, IPL.PGS = 0
480p -> IPL.E60 = 1, IPL.PGS = 1

The combination IPL.E60 = 0, IPL.PGS = 1 is invalid and cannot be set on a PAL Wii.

In Dolphin, these two options, despite being very closely related, are in completely different configuration windows. IPL.E60 can be toggled with Config -> Wii -> Use PAL60 Mode (EuRGB60), while IPL.PGS is toggled in Graphics -> Advanced -> Enable Progressive Scan. (It might be good to move one of them next to the other, but that's not the point here.)

The way Dolphin handles these settings is to just correctly set them in the SYSCONF and expect games to properly handle them themselves, while always defaulting to 50Hz when booting a PAL game. Unfortunately, this doesn't work out in all cases. Some games expect the System Menu to set the correct video mode for them before the game boots, while others are a bit more proactive and set themselves correctly in some or all cases. By loading the System Menu first and booting a game through that, all games behave the same they would on console when it comes to video mode.

(Do note that all of this is accurate for Wii games only. PAL Gamecube games will always boot in 50Hz mode and then, if supported, may ask the user if they want to switch to 60Hz. Some require the user to hold B during game boot for the option to appear.)


This PR changes the initial Wii game boot settings to match what the System Menu would set, so that games run in the video mode they are expected to run in.

Fixes [issue 6991](https://code.google.com/p/dolphin-emu/issues/detail?id=6991), [this forum thread](https://forums.dolphin-emu.org/Thread-still-no-60-hz-in-pal-games), and [this forum thread](https://forums.dolphin-emu.org/Thread-ssbb-pal-frame-rate-oddity). Also properly fixes [issue 2251](https://code.google.com/p/dolphin-emu/issues/detail?id=2251), [issue 3066](https://code.google.com/p/dolphin-emu/issues/detail?id=3066), and [issue 5089](https://code.google.com/p/dolphin-emu/issues/detail?id=5089).