### PR TITLE
SDL: handle SDL_QUIT event

### DIFF
--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -136,6 +136,7 @@ enum HOST_COMM
 	WM_USER_STOP = 10,
 	WM_USER_CREATE,
 	WM_USER_SETCURSOR,
+	WM_USER_QUIT,
 };
 
 // Used for notification on emulation state

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -778,6 +778,10 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
 	case IDM_STOPPED:
 		OnStopped();
 		break;
+
+	case WM_USER_QUIT:
+		Close(true);
+		break;
 	}
 }
 

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -49,7 +49,7 @@ void Host_RefreshDSPDebuggerWindow() {}
 static Common::Event updateMainFrameEvent;
 void Host_Message(int Id)
 {
-	if (Id == WM_USER_STOP)
+	if (Id == WM_USER_STOP || Id == WM_USER_QUIT)
 		running = false;
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -134,6 +134,11 @@ void ControllerInterface::Shutdown()
 //
 void ControllerInterface::UpdateInput()
 {
+#ifdef CIFACE_USE_SDL
+	// SDL currently also handles SIGINT and SIGTERM,
+	// so make sure to update it even if there is no SDL device.
+	ciface::SDL::UpdateInput();
+#endif
 	for (ciface::Core::Device* d : m_devices)
 		d->UpdateInput();
 }

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include "Common/StringUtil.h"
+#include "Core/Host.h"
 #include "InputCommon/ControllerInterface/SDL/SDL.h"
 
 #ifdef _WIN32
@@ -65,6 +66,19 @@ void Init( std::vector<Core::Device*>& devices )
 				delete js;
 		}
 	}
+}
+
+void UpdateInput()
+{
+	// Using SDL_INIT_JOYSTICK implies SDL_INIT_EVENT which installs a signal handler for SIGINT and SIGTERM.
+	// In the future, we will be able to prevent this from happening:
+	//     SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
+	// but this was added after SDL 2.0.3 and is scheduled to be included in 2.0.4.
+	// Until then, handle SDL_QUIT events here and tell Dolphin to exit.
+	if (SDL_QuitRequested())
+		Host_Message(WM_USER_QUIT);
+
+	SDL_JoystickUpdate();
 }
 
 Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsigned int index)
@@ -282,12 +296,6 @@ void Joystick::LeftRightEffect::SetSDLHapticEffect(ControlState state)
 	m_effect.leftright.small_magnitude = (Uint16)(state * 0xFFFF);
 }
 #endif
-
-void Joystick::UpdateInput()
-{
-	// each joystick is doin this, o well
-	SDL_JoystickUpdate();
-}
 
 std::string Joystick::GetName() const
 {

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -25,6 +25,7 @@ namespace SDL
 {
 
 void Init( std::vector<Core::Device*>& devices );
+void UpdateInput();
 
 class Joystick : public Core::Device
 {
@@ -130,8 +131,6 @@ private:
 #endif
 
 public:
-	void UpdateInput() override;
-
 	Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsigned int index);
 	~Joystick();
 


### PR DESCRIPTION
Using SDL_INIT_JOYSTICK implies SDL_INIT_EVENTS which installs a signal handler for SIGINT and SIGTERM. There will be a way to prevent this in 2.0.4 but for now we'll need to handle SDL_QUIT.

Tested and working. Fixes [issue 8630](http://dolp.in/i8630).