### PR TITLE
Various PAL60 related fixes and improvements.

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -48,7 +48,7 @@ namespace BootManager
 struct ConfigCache
 {
 	bool valid, bCPUThread, bSkipIdle, bSyncGPUOnSkipIdleHack, bFPRF, bAccurateNaNs, bMMU, bDCBZOFF, m_EnableJIT, bDSPThread,
-	     bSyncGPU, bFastDiscSpeed, bDSPHLE, bHLE_BS2, bProgressive;
+	     bSyncGPU, bFastDiscSpeed, bDSPHLE, bHLE_BS2, bProgressive, bPAL60;
 	int iSelectedLanguage;
 	int iCPUCore, Volume;
 	int iWiimoteSource[MAX_BBMOTES];
@@ -121,6 +121,7 @@ bool BootCore(const std::string& _rFilename)
 		config_cache.framelimit = SConfig::GetInstance().m_Framelimit;
 		config_cache.frameSkip = SConfig::GetInstance().m_FrameSkip;
 		config_cache.bProgressive = StartUp.bProgressive;
+		config_cache.bPAL60 = StartUp.bPAL60;
 		config_cache.iSelectedLanguage = StartUp.SelectedLanguage;
 		for (unsigned int i = 0; i < MAX_BBMOTES; ++i)
 		{
@@ -159,6 +160,7 @@ bool BootCore(const std::string& _rFilename)
 		core_section->Get("CPUCore",          &StartUp.iCPUCore, StartUp.iCPUCore);
 		core_section->Get("HLE_BS2",          &StartUp.bHLE_BS2, StartUp.bHLE_BS2);
 		core_section->Get("ProgressiveScan",  &StartUp.bProgressive, StartUp.bProgressive);
+		core_section->Get("PAL60",            &StartUp.bPAL60, StartUp.bPAL60);
 		if (core_section->Get("FrameLimit",   &SConfig::GetInstance().m_Framelimit, SConfig::GetInstance().m_Framelimit))
 			config_cache.bSetFramelimit = true;
 		if (core_section->Get("FrameSkip",    &SConfig::GetInstance().m_FrameSkip))
@@ -256,6 +258,7 @@ bool BootCore(const std::string& _rFilename)
 	}
 
 	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", StartUp.bProgressive);
+	SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", StartUp.bPAL60);
 
 	// Run the game
 	// Init the core
@@ -298,6 +301,8 @@ void Stop()
 		StartUp.bProgressive = config_cache.bProgressive;
 		StartUp.SelectedLanguage = config_cache.iSelectedLanguage;
 		SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", config_cache.bProgressive);
+		StartUp.bPAL60 = config_cache.bPAL60;
+		SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", config_cache.bPAL60);
 
 		// Only change these back if they were actually set by game ini, since they can be changed while a game is running.
 		if (config_cache.bSetFramelimit)

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -196,6 +196,12 @@ bool BootCore(const std::string& _rFilename)
 		// Wii settings
 		if (StartUp.bWii)
 		{
+			// Some NTSC Wii games such as Doc Louis's Punch-Out!! and 1942 (Virtual Console) crash if the PAL60 option is enabled
+			if (StartUp.bNTSC)
+			{
+				StartUp.bPAL60 = false;
+			}
+			
 			// Flush possible changes to SYSCONF to file
 			SConfig::GetInstance().m_SYSCONF->Save();
 

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -229,6 +229,7 @@ bool BootCore(const std::string& _rFilename)
 		StartUp.bSkipIdle = Movie::IsSkipIdle();
 		StartUp.bDSPHLE = Movie::IsDSPHLE();
 		StartUp.bProgressive = Movie::IsProgressive();
+		StartUp.bPAL60 = Movie::IsPAL60();
 		StartUp.bFastDiscSpeed = Movie::IsFastDiscSpeed();
 		StartUp.iCPUCore = Movie::GetCPUMode();
 		StartUp.bSyncGPU = Movie::IsSyncGPU();

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -131,6 +131,7 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
 	display->Set("RenderWindowAutoSize", m_LocalCoreStartupParameter.bRenderWindowAutoSize);
 	display->Set("KeepWindowOnTop", m_LocalCoreStartupParameter.bKeepWindowOnTop);
 	display->Set("ProgressiveScan", m_LocalCoreStartupParameter.bProgressive);
+	display->Set("PAL60", m_LocalCoreStartupParameter.bPAL60);
 	display->Set("DisableScreenSaver", m_LocalCoreStartupParameter.bDisableScreenSaver);
 	display->Set("ForceNTSCJ", m_LocalCoreStartupParameter.bForceNTSCJ);
 }
@@ -373,6 +374,7 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
 	display->Get("RenderWindowAutoSize", &m_LocalCoreStartupParameter.bRenderWindowAutoSize,   false);
 	display->Get("KeepWindowOnTop",      &m_LocalCoreStartupParameter.bKeepWindowOnTop,        false);
 	display->Get("ProgressiveScan",      &m_LocalCoreStartupParameter.bProgressive,            false);
+	display->Get("PAL60",                &m_LocalCoreStartupParameter.bPAL60,                  true);
 	display->Get("DisableScreenSaver",   &m_LocalCoreStartupParameter.bDisableScreenSaver,     true);
 	display->Get("ForceNTSCJ",           &m_LocalCoreStartupParameter.bForceNTSCJ,             false);
 }

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -50,7 +50,8 @@ SCoreStartupParameter::SCoreStartupParameter()
   iRenderWindowWidth(640), iRenderWindowHeight(480),
   bRenderWindowAutoSize(false), bKeepWindowOnTop(false),
   bFullscreen(false), bRenderToMain(false),
-  bProgressive(false), bDisableScreenSaver(false),
+  bProgressive(false), bPAL60(false),
+  bDisableScreenSaver(false),
   iPosX(100), iPosY(100), iWidth(800), iHeight(600),
   bLoopFifoReplay(true)
 {

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -207,7 +207,8 @@ struct SCoreStartupParameter
 	int iRenderWindowWidth, iRenderWindowHeight;
 	bool bRenderWindowAutoSize, bKeepWindowOnTop;
 	bool bFullscreen, bRenderToMain;
-	bool bProgressive, bDisableScreenSaver;
+	bool bProgressive, bPAL60;
+	bool bDisableScreenSaver;
 
 	int iPosX, iPosY, iWidth, iHeight;
 

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -63,7 +63,9 @@ static u64 s_totalLagCount = 0; // just stats
 u64 g_currentInputCount = 0, g_totalInputCount = 0; // just stats
 static u64 s_totalTickCount = 0, s_tickCountAtLastInput = 0; // just stats
 static u64 s_recordingStartTime; // seconds since 1970 that recording started
-static bool s_bSaveConfig = false, s_bSkipIdle = false, s_bDualCore = false, s_bProgressive = false, s_bDSPHLE = false, s_bFastDiscSpeed = false;
+static bool s_bSaveConfig = false, s_bSkipIdle = false, s_bDualCore = false;
+static bool s_bProgressive = false, s_bPAL60 = false;
+static bool s_bDSPHLE = false, s_bFastDiscSpeed = false;
 static bool s_bSyncGPU = false, s_bNetPlay = false;
 static std::string s_videoBackend = "unknown";
 static int s_iCPUCore = 1;
@@ -359,6 +361,11 @@ bool IsDualCore()
 bool IsProgressive()
 {
 	return s_bProgressive;
+}
+
+bool IsPAL60()
+{
+	return s_bPAL60;
 }
 
 bool IsSkipIdle()
@@ -789,6 +796,7 @@ void ReadHeader()
 		s_bSkipIdle = tmpHeader.bSkipIdle;
 		s_bDualCore = tmpHeader.bDualCore;
 		s_bProgressive = tmpHeader.bProgressive;
+		s_bPAL60 = tmpHeader.bPAL60;
 		s_bDSPHLE = tmpHeader.bDSPHLE;
 		s_bFastDiscSpeed = tmpHeader.bFastDiscSpeed;
 		s_iCPUCore = tmpHeader.CPUCore;
@@ -1211,6 +1219,7 @@ void SaveRecording(const std::string& filename)
 	header.bSkipIdle = s_bSkipIdle;
 	header.bDualCore = s_bDualCore;
 	header.bProgressive = s_bProgressive;
+	header.bPAL60 = s_bPAL60;
 	header.bDSPHLE = s_bDSPHLE;
 	header.bFastDiscSpeed = s_bFastDiscSpeed;
 	strncpy((char *)header.videoBackend, s_videoBackend.c_str(),ArraySize(header.videoBackend));
@@ -1290,6 +1299,7 @@ void GetSettings()
 	s_bSkipIdle = SConfig::GetInstance().m_LocalCoreStartupParameter.bSkipIdle;
 	s_bDualCore = SConfig::GetInstance().m_LocalCoreStartupParameter.bCPUThread;
 	s_bProgressive = SConfig::GetInstance().m_LocalCoreStartupParameter.bProgressive;
+	s_bPAL60 = SConfig::GetInstance().m_LocalCoreStartupParameter.bPAL60;
 	s_bDSPHLE = SConfig::GetInstance().m_LocalCoreStartupParameter.bDSPHLE;
 	s_bFastDiscSpeed = SConfig::GetInstance().m_LocalCoreStartupParameter.bFastDiscSpeed;
 	s_videoBackend = g_video_backend->GetName();

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -101,7 +101,8 @@ struct DTMHeader
 	u8   bongos;
 	bool bSyncGPU;
 	bool bNetPlay;
-	u8   reserved[13];      // Padding for any new config options
+	bool bPAL60;
+	u8   reserved[12];      // Padding for any new config options
 	u8   discChange[40];    // Name of iso file to switch to, for two disc games.
 	u8   revision[20];      // Git hash
 	u32  DSPiromHash;
@@ -131,6 +132,7 @@ u64  GetRecordingStartTime();
 bool IsConfigSaved();
 bool IsDualCore();
 bool IsProgressive();
+bool IsPAL60();
 bool IsSkipIdle();
 bool IsDSPHLE();
 bool IsFastDiscSpeed();

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.h
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.h
@@ -22,8 +22,8 @@ private:
 	void LoadGUIValues();
 	void RefreshGUI();
 
+	void OnVideoModeChanged(wxCommandEvent&);
 	void OnScreenSaverCheckBoxChanged(wxCommandEvent&);
-	void OnPAL60CheckBoxChanged(wxCommandEvent&);
 	void OnSDCardCheckBoxChanged(wxCommandEvent&);
 	void OnConnectKeyboardCheckBoxChanged(wxCommandEvent&);
 	void OnSystemLanguageChoiceChanged(wxCommandEvent&);
@@ -31,11 +31,12 @@ private:
 
 	static u8 GetSADRCountryCode(DiscIO::IVolume::ELanguage language);
 
+	wxArrayString m_video_mode_strings;
 	wxArrayString m_system_language_strings;
 	wxArrayString m_aspect_ratio_strings;
 
+	wxRadioBox* m_video_mode_radiobox;
 	wxCheckBox* m_screensaver_checkbox;
-	wxCheckBox* m_pal60_mode_checkbox;
 	wxCheckBox* m_sd_card_checkbox;
 	wxCheckBox* m_connect_keyboard_checkbox;
 	wxChoice* m_system_language_choice;

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -343,6 +343,8 @@ void CISOProperties::CreateGUIControls()
 	FastDiscSpeed = new wxCheckBox(m_GameConfig, ID_DISCSPEED, _("Speed up Disc Transfer Rate"), wxDefaultPosition, wxDefaultSize, GetElementStyle("Core", "FastDiscSpeed"));
 	FastDiscSpeed->SetToolTip(_("Enable fast disc access. This can cause crashes and other problems in some games. (ON = Fast, OFF = Compatible)"));
 	DSPHLE = new wxCheckBox(m_GameConfig, ID_AUDIO_DSP_HLE, _("DSP HLE emulation (fast)"), wxDefaultPosition, wxDefaultSize, GetElementStyle("Core", "DSPHLE"));
+	ProgressiveScan = new wxCheckBox(m_GameConfig, ID_ENABLEPROGRESSIVESCAN, _("Progressive Scan"), wxDefaultPosition, wxDefaultSize, GetElementStyle("Core", "ProgressiveScan"));
+	PAL60 = new wxCheckBox(m_GameConfig, ID_ENABLEPAL60, _("PAL60"), wxDefaultPosition, wxDefaultSize, GetElementStyle("Core", "PAL60"));
 
 	wxBoxSizer* const sGPUDeterminism = new wxBoxSizer(wxHORIZONTAL);
 	wxStaticText* const GPUDeterminismText = new wxStaticText(m_GameConfig, wxID_ANY, _("Deterministic dual core: "));
@@ -398,6 +400,8 @@ void CISOProperties::CreateGUIControls()
 	sbCoreOverrides->Add(SyncGPU, 0, wxLEFT, 5);
 	sbCoreOverrides->Add(FastDiscSpeed, 0, wxLEFT, 5);
 	sbCoreOverrides->Add(DSPHLE, 0, wxLEFT, 5);
+	sbCoreOverrides->Add(ProgressiveScan, 0, wxLEFT, 5);
+	sbCoreOverrides->Add(PAL60, 0, wxLEFT, 5);
 	sbCoreOverrides->Add(sGPUDeterminism, 0, wxEXPAND|wxALL, 5);
 
 	wxStaticBoxSizer * const sbWiiOverrides = new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Wii Console"));
@@ -1028,6 +1032,8 @@ void CISOProperties::LoadGameConfig()
 	SetCheckboxValueFromGameini("Core", "SyncGPU", SyncGPU);
 	SetCheckboxValueFromGameini("Core", "FastDiscSpeed", FastDiscSpeed);
 	SetCheckboxValueFromGameini("Core", "DSPHLE", DSPHLE);
+	SetCheckboxValueFromGameini("Core", "ProgressiveScan", ProgressiveScan);
+	SetCheckboxValueFromGameini("Core", "PAL60", PAL60);
 	SetCheckboxValueFromGameini("Wii", "Widescreen", EnableWideScreen);
 	SetCheckboxValueFromGameini("Video_Stereoscopy", "StereoEFBMonoDepth", MonoDepth);
 
@@ -1122,6 +1128,8 @@ bool CISOProperties::SaveGameConfig()
 	SaveGameIniValueFrom3StateCheckbox("Core", "SyncGPU", SyncGPU);
 	SaveGameIniValueFrom3StateCheckbox("Core", "FastDiscSpeed", FastDiscSpeed);
 	SaveGameIniValueFrom3StateCheckbox("Core", "DSPHLE", DSPHLE);
+	SaveGameIniValueFrom3StateCheckbox("Core", "ProgressiveScan", ProgressiveScan);
+	SaveGameIniValueFrom3StateCheckbox("Core", "PAL60", PAL60);
 	SaveGameIniValueFrom3StateCheckbox("Wii", "Widescreen", EnableWideScreen);
 	SaveGameIniValueFrom3StateCheckbox("Video_Stereoscopy", "StereoEFBMonoDepth", MonoDepth);
 

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -78,6 +78,7 @@ private:
 	// Core
 	wxCheckBox *CPUThread, *SkipIdle, *MMU, *DCBZOFF, *FPRF;
 	wxCheckBox *SyncGPU, *FastDiscSpeed, *DSPHLE;
+	wxCheckBox *ProgressiveScan, *PAL60;
 
 	wxArrayString arrayStringFor_GPUDeterminism;
 	wxChoice* GPUDeterminism;
@@ -144,6 +145,7 @@ private:
 		ID_AUDIO_DSP_HLE,
 		ID_USE_BBOX,
 		ID_ENABLEPROGRESSIVESCAN,
+		ID_ENABLEPAL60,
 		ID_ENABLEWIDESCREEN,
 		ID_EDITCONFIG,
 		ID_SHOWDEFAULTCONFIG,

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -101,7 +101,6 @@ static wxString auto_window_size_desc = wxTRANSLATE("Automatically adjusts the w
 static wxString keep_window_on_top_desc = wxTRANSLATE("Keep the game window on top of all other windows.\n\nIf unsure, leave this unchecked.");
 static wxString hide_mouse_cursor_desc = wxTRANSLATE("Hides the mouse cursor if it's on top of the emulation window.\n\nIf unsure, leave this unchecked.");
 static wxString render_to_main_win_desc = wxTRANSLATE("Enable this if you want to use the main Dolphin window for rendering rather than a separate render window.\n\nIf unsure, leave this unchecked.");
-static wxString prog_scan_desc = wxTRANSLATE("Enables progressive scan if supported by the emulated software.\nMost games don't care about this.\n\nIf unsure, leave this unchecked.");
 static wxString ar_desc = wxTRANSLATE("Select what aspect ratio to use when rendering:\nAuto: Use the native aspect ratio\nForce 16:9: Stretch the picture to an aspect ratio of 16:9.\nForce 4:3: Stretch the picture to an aspect ratio of 4:3.\nStretch to Window: Stretch the picture to the window size.\n\nIf unsure, select Auto.");
 static wxString ws_hack_desc = wxTRANSLATE("Forces the game to output graphics for any aspect ratio.\nUse with \"Aspect Ratio\" set to \"Force 16:9\" to force 4:3-only games to run at 16:9.\nRarely produces good results and often partially breaks graphics and game UIs.\nUnnecessary (and detrimental) if using any AR/Gecko-code widescreen patches.\n\nIf unsure, leave this unchecked.");
 static wxString vsync_desc = wxTRANSLATE("Wait for vertical blanks in order to reduce tearing.\nDecreases performance if emulation speed is below 100%.\n\nIf unsure, leave this unchecked.");
@@ -577,18 +576,6 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	szr_misc->Add(CreateCheckBox(page_advanced, _("Crop"), wxGetTranslation(crop_desc), vconfig.bCrop));
 
-	// Progressive Scan
-	{
-	progressive_scan_checkbox = new wxCheckBox(page_advanced, wxID_ANY, _("Enable Progressive Scan"));
-	RegisterControl(progressive_scan_checkbox, wxGetTranslation(prog_scan_desc));
-	progressive_scan_checkbox->Bind(wxEVT_CHECKBOX, &VideoConfigDiag::Event_ProgressiveScan, this);
-
-	progressive_scan_checkbox->SetValue(SConfig::GetInstance().m_LocalCoreStartupParameter.bProgressive);
-	// A bit strange behavior, but this needs to stay in sync with the main progressive boolean; TODO: Is this still necessary?
-	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", SConfig::GetInstance().m_LocalCoreStartupParameter.bProgressive);
-
-	szr_misc->Add(progressive_scan_checkbox);
-	}
 
 #if defined WIN32
 	// Borderless Fullscreen

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -120,14 +120,6 @@ protected:
 
 	void Event_DisplayResolution(wxCommandEvent &ev);
 
-	void Event_ProgressiveScan(wxCommandEvent &ev)
-	{
-		SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", ev.GetInt());
-		SConfig::GetInstance().m_LocalCoreStartupParameter.bProgressive = ev.IsChecked();
-
-		ev.Skip();
-	}
-
 	void Event_Stc(wxCommandEvent &ev)
 	{
 		int samples[] = { 0, 512, 128 };
@@ -226,7 +218,6 @@ protected:
 			label_display_resolution->Disable();
 #endif
 
-			progressive_scan_checkbox->Disable();
 			render_to_main_checkbox->Disable();
 		}
 		ev.Skip();
@@ -266,8 +257,6 @@ protected:
 	SettingRadioButton* real_xfb;
 
 	SettingCheckBox* cache_hires_textures;
-
-	wxCheckBox* progressive_scan_checkbox;
 
 	wxChoice* choice_ppshader;
 


### PR DESCRIPTION
This is related to https://github.com/dolphin-emu/dolphin/pull/2520.

The main thing this PR does is combine the "Graphics -> Advanced -> Enable Progressive Scan" and "Config -> Wii -> Enable PAL60" options into a single set of radio buttons that more closely resembles the way you'd set video modes on actual console.

There's a ~~few~~ side effect~~s~~ of this:

* The previously selectable combination of "PAL60 off, Progressive on" is no longer possible. Since this combination is not actually selectable on a console, I think this is actually an improvement.
* ~~Since the Progressive Scan option is now in the Wii config tab, it no longer applies to Gamecube games. The only thing the option did for Gamecube games before is set if the emulated Gamecube had a Component Cable connected to it, which would allow games to display the prompt about switching into Progressive Scan if you booted a supported game while holding the B button. This procedure will now just be always available.~~

Additionally, I have added the PAL60 option to the Movie header, as well as allowing it to be overriden by GameINIs. This fixes [issue 7847](https://code.google.com/p/dolphin-emu/issues/detail?id=7847).

Lastly, I have changed the boot procedure to automatically disable PAL60 if an NTSC game boots. This fixes issues such as [7714](https://code.google.com/p/dolphin-emu/issues/detail?id=7714) and [8036](https://code.google.com/p/dolphin-emu/issues/detail?id=8036).