### PR TITLE
Fifo: Rewrite SyncGPU

### DIFF
--- a/Source/Core/Common/BlockingLoop.h
+++ b/Source/Core/Common/BlockingLoop.h
@@ -54,7 +54,7 @@ public:
 	void Wait()
 	{
 		// already done
-		if (m_stopped.IsSet() || m_running_state.load() <= STATE_DONE)
+		if (IsDone())
 			return;
 
 		// notifying this event will only wake up one thread, so use a mutex here to
@@ -63,7 +63,7 @@ public:
 		std::lock_guard<std::mutex> lk(m_wait_lock);
 
 		// Wait for the worker thread to finish.
-		while (!m_stopped.IsSet() && m_running_state.load() > STATE_DONE)
+		while (!IsDone())
 		{
 			m_done_event.Wait();
 		}
@@ -181,6 +181,11 @@ public:
 	bool IsRunning() const
 	{
 		return !m_stopped.IsSet() && !m_shutdown.IsSet();
+	}
+
+	bool IsDone() const
+	{
+		return m_stopped.IsSet() || m_running_state.load() <= STATE_DONE;
 	}
 
 	// This function should be triggered regularly over time so

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -182,6 +182,10 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("DSPHLE", m_LocalCoreStartupParameter.bDSPHLE);
 	core->Set("SkipIdle", m_LocalCoreStartupParameter.bSkipIdle);
 	core->Set("SyncOnSkipIdle", m_LocalCoreStartupParameter.bSyncGPUOnSkipIdleHack);
+	core->Set("SyncGPU", m_LocalCoreStartupParameter.bSyncGPU);
+	core->Set("SyncGpuMaxDistance", m_LocalCoreStartupParameter.iSyncGpuMaxDistance);
+	core->Set("SyncGpuMinDistance", m_LocalCoreStartupParameter.iSyncGpuMinDistance);
+	core->Set("SyncGpuOverclock", m_LocalCoreStartupParameter.fSyncGpuOverclock);
 	core->Set("DefaultISO", m_LocalCoreStartupParameter.m_strDefaultISO);
 	core->Set("DVDRoot", m_LocalCoreStartupParameter.m_strDVDRoot);
 	core->Set("Apploader", m_LocalCoreStartupParameter.m_strApploader);
@@ -458,6 +462,9 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("MMU",                       &m_LocalCoreStartupParameter.bMMU,              false);
 	core->Get("BBDumpPort",                &m_LocalCoreStartupParameter.iBBDumpPort,       -1);
 	core->Get("SyncGPU",                   &m_LocalCoreStartupParameter.bSyncGPU,          false);
+	core->Get("SyncGpuMaxDistance",        &m_LocalCoreStartupParameter.iSyncGpuMaxDistance,  200000);
+	core->Get("SyncGpuMinDistance",        &m_LocalCoreStartupParameter.iSyncGpuMinDistance, -200000);
+	core->Get("SyncGpuOverclock",          &m_LocalCoreStartupParameter.fSyncGpuOverclock, 1.0);
 	core->Get("FastDiscSpeed",             &m_LocalCoreStartupParameter.bFastDiscSpeed,    false);
 	core->Get("DCBZ",                      &m_LocalCoreStartupParameter.bDCBZOFF,          false);
 	core->Get("FrameLimit",                &m_Framelimit,                                  1); // auto frame limit by default

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -184,8 +184,12 @@ struct SCoreStartupParameter
 	bool bMMU;
 	bool bDCBZOFF;
 	int iBBDumpPort;
-	bool bSyncGPU;
 	bool bFastDiscSpeed;
+
+	bool bSyncGPU;
+	int iSyncGpuMaxDistance;
+	int iSyncGpuMinDistance;
+	float fSyncGpuOverclock;
 
 	int SelectedLanguage;
 

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -482,13 +482,13 @@ void Idle()
 {
 	//DEBUG_LOG(POWERPC, "Idle");
 
-	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bSyncGPUOnSkipIdleHack && !SConfig::GetInstance().m_LocalCoreStartupParameter.bSyncGPU)
+	if (SConfig::GetInstance().m_LocalCoreStartupParameter.bSyncGPUOnSkipIdleHack)
 	{
 		//When the FIFO is processing data we must not advance because in this way
 		//the VI will be desynchronized. So, We are waiting until the FIFO finish and
 		//while we process only the events required by the FIFO.
 		ProcessFifoWaitEvents();
-		g_video_backend->Video_Sync();
+		g_video_backend->Video_Sync(0);
 	}
 
 	idledCycles += DowncountToCycles(PowerPC::ppcState.downcount);

--- a/Source/Core/VideoBackends/Software/VideoBackend.h
+++ b/Source/Core/VideoBackends/Software/VideoBackend.h
@@ -49,7 +49,7 @@ class VideoSoftware : public VideoBackend
 	void Video_SetRendering(bool bEnabled) override;
 
 	void Video_GatherPipeBursted() override;
-	void Video_Sync() override {}
+	int Video_Sync(int ticks) override { return 0; }
 
 	void RegisterCPMMIO(MMIO::Mapping* mmio, u32 base) override;
 

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -16,7 +16,6 @@
 #include "Core/HW/Memmap.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
-#include "Core/HW/SystemTimers.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/PixelEngine.h"
@@ -46,8 +45,6 @@ static std::atomic<bool> s_interrupt_set;
 static std::atomic<bool> s_interrupt_waiting;
 static std::atomic<bool> s_interrupt_token_waiting;
 static std::atomic<bool> s_interrupt_finish_waiting;
-
-static std::atomic<u32> s_vi_ticks(CommandProcessor::m_cpClockOrigin);
 
 static bool IsOnThread()
 {
@@ -544,32 +541,6 @@ void SetCpControlRegister()
 // We don't emulate proper GP timing anyway at the moment, so it would just slow down emulation.
 void SetCpClearRegister()
 {
-}
-
-void Update()
-{
-	while (s_vi_ticks.load() > m_cpClockOrigin && fifo.isGpuReadingData && IsOnThread())
-		Common::YieldCPU();
-
-	if (fifo.isGpuReadingData)
-		s_vi_ticks.fetch_add(SystemTimers::GetTicksPerSecond() / 10000);
-
-	RunGpu();
-}
-
-u32 GetVITicks()
-{
-	return s_vi_ticks.load();
-}
-
-void SetVITicks(u32 ticks)
-{
-	s_vi_ticks.store(ticks);
-}
-
-void DecrementVITicks(u32 ticks)
-{
-	s_vi_ticks.fetch_sub(ticks);
 }
 
 } // end of namespace CommandProcessor

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -121,9 +121,6 @@ union UCPClearReg
 	UCPClearReg(u16 _hex) {Hex = _hex; }
 };
 
-// Can be any number, low enough to not be below the number of clocks executed by the GPU per CP_PERIOD
-const static u32 m_cpClockOrigin = 200000;
-
 // Init
 void Init();
 void Shutdown();
@@ -145,11 +142,5 @@ void SetCpClearRegister();
 void SetCpControlRegister();
 void SetCpStatusRegister();
 void ProcessFifoEvents();
-
-void Update();
-
-u32 GetVITicks();
-void SetVITicks(u32 ticks);
-void DecrementVITicks(u32 ticks);
 
 } // namespace CommandProcessor

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -50,3 +50,4 @@ void EmulatorState(bool running);
 bool AtBreakpoint();
 void ResetVideoBuffer();
 void Fifo_SetRendering(bool bEnabled);
+int Fifo_Update(int ticks);

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -245,9 +245,9 @@ void VideoBackendHardware::Video_GatherPipeBursted()
 	CommandProcessor::GatherPipeBursted();
 }
 
-void VideoBackendHardware::Video_Sync()
+int VideoBackendHardware::Video_Sync(int ticks)
 {
-	FlushGpu();
+	return Fifo_Update(ticks);
 }
 
 void VideoBackendHardware::RegisterCPMMIO(MMIO::Mapping* mmio, u32 base)

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -56,9 +56,6 @@ struct SCPFifoStruct
 
 	volatile u32 bFF_LoWatermark;
 	volatile u32 bFF_HiWatermark;
-
-	// for GP watchdog hack
-	volatile u32 isGpuReadingData;
 };
 
 class VideoBackend
@@ -99,7 +96,7 @@ public:
 
 	virtual void Video_GatherPipeBursted() = 0;
 
-	virtual void Video_Sync() = 0;
+	virtual int Video_Sync(int ticks) = 0;
 
 	// Registers MMIO handlers for the CommandProcessor registers.
 	virtual void RegisterCPMMIO(MMIO::Mapping* mmio, u32 base) = 0;
@@ -148,7 +145,7 @@ class VideoBackendHardware : public VideoBackend
 
 	void Video_GatherPipeBursted() override;
 
-	void Video_Sync() override;
+	int Video_Sync(int ticks) override;
 
 	void RegisterCPMMIO(MMIO::Mapping* mmio, u32 base) override;
 


### PR DESCRIPTION
The new implementation has two options:
SyncGpuMaxDistance
SyncGpuMinDistance

The MaxDistance controlls how many CPU cycles the CPU is allowed to be in front
of the GPU. Too low values will slow down extremly, too high values are as
unsynchronized and half of the games will crash.
The -MinDistance (negative) set how many cycles the GPU is allowed to be in
front of the CPU. As we are used to emulate an infinitiv fast GPU, this may be
set to any high (negative) number.