### PR TITLE
[WIP] Synchronize DVDInterface::ChangeDisc with the CPU thread properly.

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -274,7 +274,7 @@ void Stop()  // - Hammertime!
 		s_emu_thread.join();
 }
 
-static void DeclareAsCPUThread()
+void DeclareAsCPUThread()
 {
 #ifdef ThreadLocalStorage
 	tls_is_cpu_thread = true;
@@ -286,7 +286,7 @@ static void DeclareAsCPUThread()
 #endif
 }
 
-static void UndeclareAsCPUThread()
+void UndeclareAsCPUThread()
 {
 #ifdef ThreadLocalStorage
 	tls_is_cpu_thread = false;
@@ -694,6 +694,7 @@ bool PauseAndLock(bool doLock, bool unpauseOnUnlock)
 
 	// video has to come after CPU, because CPU thread can wait for video thread (s_efbAccessRequested).
 	g_video_backend->PauseAndLock(doLock, unpauseOnUnlock);
+
 	return wasUnpaused;
 }
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -40,6 +40,9 @@ enum EState
 bool Init();
 void Stop();
 
+void DeclareAsCPUThread();
+void UndeclareAsCPUThread();
+
 std::string StopMessage(bool, const std::string&);
 
 bool IsRunning();

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -225,7 +225,6 @@ u64 GetIdleTicks()
 // schedule things to be executed on the main thread.
 void ScheduleEvent_Threadsafe(int cyclesIntoFuture, int event_type, u64 userdata)
 {
-	_assert_msg_(POWERPC, !Core::IsCPUThread(), "ScheduleEvent_Threadsafe from wrong thread");
 	if (Core::g_want_determinism)
 	{
 		ERROR_LOG(POWERPC, "Someone scheduled an off-thread \"%s\" event while netplay or movie play/record "

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -13,6 +13,7 @@
 #include "Common/CommonTypes.h"
 
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/Movie.h"
 #include "Core/HW/AudioInterface.h"
@@ -521,10 +522,11 @@ void InsertDiscCallback(u64 userdata, int cyclesLate)
 
 void ChangeDisc(const std::string& newFileName)
 {
+	bool not_cpu = !Core::IsCPUThread();
+	bool was_unpaused = not_cpu ? Core::PauseAndLock(true) : false;
 	std::string* _FileName = new std::string(newFileName);
-	CoreTiming::ScheduleEvent_Threadsafe(0, ejectDisc);
-	CoreTiming::ScheduleEvent_Threadsafe(500000000, insertDisc, (u64)_FileName);
-	// TODO: We shouldn't be modifying movie state from the GUI thread.
+	CoreTiming::ScheduleEvent(0, ejectDisc);
+	CoreTiming::ScheduleEvent(500000000, insertDisc, (u64)_FileName);
 	if (Movie::IsRecordingInput())
 	{
 		Movie::g_bDiscChange = true;
@@ -537,6 +539,8 @@ void ChangeDisc(const std::string& newFileName)
 		}
 		Movie::g_discChange = fileName.substr(sizeofpath);
 	}
+	if (not_cpu)
+		Core::PauseAndLock(false, was_unpaused);
 }
 
 void SetLidOpen(bool _bOpen)


### PR DESCRIPTION
This addresses a bit of thread unsafety mentioned in a comment, and
fixes a 'ScheduleEvent_Threadsafe from main thread' message.

To make this work nicely, make PauseAndLock call DeclareAsCPUThread -
i.e. while you have the CPU thread locked, you can consider yourself the
CPU thread.