### PR TITLE
Revert "Join the emu thread in Core::Stop. Get rid of Core::Shutdown which did that before."

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -273,8 +273,6 @@ void Stop()  // - Hammertime!
 
 		g_video_backend->Video_ExitLoop();
 	}
-	if (s_emu_thread.joinable())
-		s_emu_thread.join();
 }
 
 static void DeclareAsCPUThread()
@@ -827,6 +825,18 @@ void UpdateTitle()
 	}
 
 	Host_UpdateTitle(SMessage);
+}
+
+void Shutdown()
+{
+	// During shutdown DXGI expects us to handle some messages on the UI thread.
+	// Therefore we can't immediately block and wait for the emu thread to shut
+	// down, so we join the emu thread as late as possible when the UI has already
+	// shut down.
+	// For more info read "DirectX Graphics Infrastructure (DXGI): Best Practices"
+	// on MSDN.
+	if (s_emu_thread.joinable())
+		s_emu_thread.join();
 }
 
 void SetOnStoppedCallback(StoppedCallbackFunc callback)

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -162,7 +162,7 @@ void DisplayMessage(const std::string& message, int time_in_ms)
 
 bool IsRunning()
 {
-	return (GetState() != CORE_UNINITIALIZED) || s_hardware_initialized;
+	return (GetState() != CORE_UNINITIALIZED || s_hardware_initialized) && !s_is_stopping;
 }
 
 bool IsRunningAndStarted()

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -39,6 +39,7 @@ enum EState
 
 bool Init();
 void Stop();
+void Shutdown();
 
 std::string StopMessage(bool, const std::string&);
 

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -370,6 +370,7 @@ void DolphinApp::OnEndSession(wxCloseEvent& event)
 
 int DolphinApp::OnExit()
 {
+	Core::Shutdown();
 	UICommon::Shutdown();
 
 	delete m_locale;

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -627,6 +627,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Run(JNIEnv *
 			updateMainFrameEvent.Wait();
 	}
 
+	Core::Shutdown();
 	UICommon::Shutdown();
 	ANativeWindow_release(surf);
 

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -358,6 +358,7 @@ int main(int argc, char* argv[])
 	while (PowerPC::GetState() != PowerPC::CPU_POWERDOWN)
 		updateMainFrameEvent.Wait();
 
+	Core::Shutdown();
 	platform->Shutdown();
 	UICommon::Shutdown();
 


### PR DESCRIPTION
This reverts commit ba664b3, fixing [issue 8518](https://code.google.com/p/dolphin-emu/issues/detail?id=8518).

This PR fixes a consistent deadlock on the D3D backend when stopping emulation while using exclusive fullscreen while having the confirm dialog disabled.

I can't reproduce the race condition @comex is referring to and I think a consistent deadlock is more important to fix than a few rare race conditions. The race conditions themselves should be fixed instead of introducing blocking calls to prevent them.

Another possibility to fix this issue if we insist on blocking the UI thread is to wait until we've exited fullscreen before we initiate the shutdown. Or we can have the GPU thread handle render window messaging itself.