### PR TITLE
Fix line ending bug for downloaded gecko codes

### DIFF
--- a/Source/Core/DolphinWX/Cheats/GeckoCodeDiag.cpp
+++ b/Source/Core/DolphinWX/Cheats/GeckoCodeDiag.cpp
@@ -192,8 +192,10 @@ void CodeConfigPanel::DownloadCodes(wxCommandEvent&)
 
 		while ((std::getline(ss, line).good()))
 		{
-			// empty line
-			if (0 == line.size() || line == "\r" || line == "\n") // \r\n checks might not be needed
+			// Remove \r at the end of the line for files using windows line endings, std::getline only removes \n
+			line = StripSpaces(line);
+
+			if (line.empty())
 			{
 				// add the code
 				if (gcode.codes.size())


### PR DESCRIPTION
Gecko codes .txt files that contain windows style line endings result in mixed line endings for the generated .ini file(\r\r\n) when using Windows. This PR removes some single \r at the end of lines. The generated file uses the line ending style from the running OS, so in case of Windows, it's generating files with \r\n line endings.

Tested on Windows, some confirmation that this generates proper unix line endings on linux would be nice. Test example was Wii Sports Resort PAL.