### PR TITLE
Fixed: Allowed unknown certificates

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -186,6 +186,7 @@ void SConfig::SaveSettings()
 	SaveDSPSettings(ini);
 	SaveInputSettings(ini);
 	SaveFifoPlayerSettings(ini);
+	SaveNetworkSettings(ini);
 
 	ini.Save(File::GetUserPath(F_DOLPHINCONFIG_IDX));
 	m_SYSCONF->Save();
@@ -399,6 +400,13 @@ void SConfig::SaveFifoPlayerSettings(IniFile& ini)
 	fifoplayer->Set("LoopReplay", m_LocalCoreStartupParameter.bLoopFifoReplay);
 }
 
+void SConfig::SaveNetworkSettings(IniFile& ini)
+{
+	IniFile::Section* network = ini.GetOrCreateSection("Network");
+
+	network->Set("SSLVerifyCert", m_SSLVerifyCert);
+}
+
 void SConfig::LoadSettings()
 {
 	INFO_LOG(BOOT, "Loading Settings from %s", File::GetUserPath(F_DOLPHINCONFIG_IDX).c_str());
@@ -415,6 +423,7 @@ void SConfig::LoadSettings()
 	LoadDSPSettings(ini);
 	LoadInputSettings(ini);
 	LoadFifoPlayerSettings(ini);
+	LoadNetworkSettings(ini);
 
 	m_SYSCONF = new SysConf();
 }
@@ -678,4 +687,11 @@ void SConfig::LoadFifoPlayerSettings(IniFile& ini)
 	IniFile::Section* fifoplayer = ini.GetOrCreateSection("FifoPlayer");
 
 	fifoplayer->Get("LoopReplay", &m_LocalCoreStartupParameter.bLoopFifoReplay, true);
+}
+
+void SConfig::LoadNetworkSettings(IniFile& ini)
+{
+	IniFile::Section* network = ini.GetOrCreateSection("Network");
+
+	network->Get("SSLVerifyCert", &m_SSLVerifyCert, false);
 }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -118,6 +118,9 @@ struct SConfig : NonCopyable
 	bool m_GameCubeAdapter;
 	bool m_AdapterRumble;
 
+	// Network settings
+	bool m_SSLVerifyCert;
+
 	SysConf* m_SYSCONF;
 
 	// Save settings
@@ -146,6 +149,7 @@ private:
 	void SaveInputSettings(IniFile& ini);
 	void SaveMovieSettings(IniFile& ini);
 	void SaveFifoPlayerSettings(IniFile& ini);
+	void SaveNetworkSettings(IniFile& ini);
 
 	void LoadGeneralSettings(IniFile& ini);
 	void LoadInterfaceSettings(IniFile& ini);
@@ -157,6 +161,7 @@ private:
 	void LoadInputSettings(IniFile& ini);
 	void LoadMovieSettings(IniFile& ini);
 	void LoadFifoPlayerSettings(IniFile& ini);
+	void LoadNetworkSettings(IniFile& ini);
 
 	static SConfig* m_Instance;
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -6,6 +6,7 @@
 
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h"
 #include "Core/IPC_HLE/WII_Socket.h"
@@ -176,7 +177,10 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
 			ssl_set_session(&ssl->ctx, &ssl->session);
 
 			ssl_set_endpoint(&ssl->ctx, SSL_IS_CLIENT);
-			ssl_set_authmode(&ssl->ctx, SSL_VERIFY_REQUIRED);
+			if (SConfig::GetInstance().m_SSLVerifyCert)
+				ssl_set_authmode(&ssl->ctx, SSL_VERIFY_REQUIRED);
+			else
+				ssl_set_authmode(&ssl->ctx, SSL_VERIFY_NONE);
 			ssl_set_renegotiation(&ssl->ctx, SSL_RENEGOTIATION_ENABLED);
 
 			ssl->hostname = hostname;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -176,7 +176,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
 			ssl_set_session(&ssl->ctx, &ssl->session);
 
 			ssl_set_endpoint(&ssl->ctx, SSL_IS_CLIENT);
-			ssl_set_authmode(&ssl->ctx, SSL_VERIFY_NONE);
+			ssl_set_authmode(&ssl->ctx, SSL_VERIFY_REQUIRED);
 			ssl_set_renegotiation(&ssl->ctx, SSL_RENEGOTIATION_ENABLED);
 
 			ssl->hostname = hostname;


### PR DESCRIPTION
Dolphin allows unknown certificates when the Wii does not because Dolphin doesn't verify it.