### PR TITLE
D3D: Implement Z pokes.

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -442,7 +442,7 @@ struct
 
 struct
 {
-	float x1, y1, x2, y2;
+	float x1, y1, x2, y2, z;
 	u32 col;
 } draw_quad_data;
 
@@ -572,19 +572,19 @@ void drawShadedTexQuad(ID3D11ShaderResourceView* texture,
 
 // Fills a certain area of the current render target with the specified color
 // destination coordinates normalized to (-1;1)
-void drawColorQuad(u32 Color, float x1, float y1, float x2, float y2)
+void drawColorQuad(u32 Color, float z, float x1, float y1, float x2, float y2)
 {
 	ColVertex coords[4] = {
-		{ x1, y2, 0.f, Color },
-		{ x2, y2, 0.f, Color },
-		{ x1, y1, 0.f, Color },
-		{ x2, y1, 0.f, Color },
+		{ x1, y1, z, Color },
+		{ x2, y1, z, Color },
+		{ x1, y2, z, Color },
+		{ x2, y2, z, Color },
 	};
 
 	if (cq_observer ||
 	    draw_quad_data.x1 != x1 || draw_quad_data.y1 != y1 ||
 	    draw_quad_data.x2 != x2 || draw_quad_data.y2 != y2 ||
-	    draw_quad_data.col != Color)
+	    draw_quad_data.col != Color || draw_quad_data.z != z)
 	{
 		cq_offset = util_vbuf->AppendData(coords, sizeof(coords), sizeof(ColVertex));
 		cq_observer = false;
@@ -594,10 +594,11 @@ void drawColorQuad(u32 Color, float x1, float y1, float x2, float y2)
 		draw_quad_data.x2 = x2;
 		draw_quad_data.y2 = y2;
 		draw_quad_data.col = Color;
+		draw_quad_data.z = z;
 	}
 
 	stateman->SetVertexShader(VertexShaderCache::GetClearVertexShader());
-	stateman->SetGeometryShader(g_ActiveConfig.iStereoMode > 0 ? GeometryShaderCache::GetClearGeometryShader() : nullptr);
+	stateman->SetGeometryShader(GeometryShaderCache::GetClearGeometryShader());
 	stateman->SetPixelShader(PixelShaderCache::GetClearProgram());
 	stateman->SetInputLayout(VertexShaderCache::GetClearInputLayout());
 

--- a/Source/Core/VideoBackends/D3D/D3DUtil.h
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.h
@@ -66,7 +66,7 @@ namespace D3D
 						float Gamma = 1.0f,
 						u32 slice = 0);
 	void drawClearQuad(u32 Color, float z);
-	void drawColorQuad(u32 Color, float x1, float y1, float x2, float y2);
+	void drawColorQuad(u32 Color, float z, float x1, float y1, float x2, float y2);
 }
 
 }

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -472,6 +472,9 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		// TODO: The first five PE registers may change behavior of EFB pokes, this isn't implemented, yet.
 		ResetAPIState();
 
+		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
+		D3D::context->RSSetViewports(1, &vp);
+
 		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), nullptr);
 		D3D::drawColorQuad(rgbaColor, (float)RectToLock.left   * 2.f / (float)Renderer::GetTargetWidth()  - 1.f,
 		                            - (float)RectToLock.top    * 2.f / (float)Renderer::GetTargetHeight() + 1.f,

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -351,15 +351,6 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 	D3D11_MAPPED_SUBRESOURCE map;
 	ID3D11Texture2D* read_tex;
 
-	if (type == POKE_Z)
-	{
-		static bool alert_only_once = true;
-		if (!alert_only_once) return 0;
-		PanicAlert("EFB: Poke Z not implemented (tried to poke z value %#x at (%d,%d))", poke_data, x, y);
-		alert_only_once = false;
-		return 0;
-	}
-
 	// Convert EFB dimensions to the ones of our render target
 	EFBRectangle efbPixelRc;
 	efbPixelRc.left = x;
@@ -465,7 +456,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		else if (alpha_read_mode.ReadMode == 1) return (ret | 0xFF000000); // GX_READ_FF
 		else /*if(alpha_read_mode.ReadMode == 0)*/ return (ret & 0x00FFFFFF); // GX_READ_00
 	}
-	else //if(type == POKE_COLOR)
+	else if (type == POKE_COLOR)
 	{
 		u32 rgbaColor = (poke_data & 0xFF00FF00) | ((poke_data >> 16) & 0xFF) | ((poke_data << 16) & 0xFF0000);
 
@@ -476,14 +467,42 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		D3D::context->RSSetViewports(1, &vp);
 
 		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), nullptr);
-		D3D::drawColorQuad(rgbaColor, (float)RectToLock.left   * 2.f / (float)Renderer::GetTargetWidth()  - 1.f,
-		                            - (float)RectToLock.top    * 2.f / (float)Renderer::GetTargetHeight() + 1.f,
-		                              (float)RectToLock.right  * 2.f / (float)Renderer::GetTargetWidth()  - 1.f,
-		                            - (float)RectToLock.bottom * 2.f / (float)Renderer::GetTargetHeight() + 1.f);
+		D3D::drawColorQuad(rgbaColor, 0.f,
+		                  (float)RectToLock.left   * 2.f / GetTargetWidth()  - 1.f,
+		                - (float)RectToLock.top    * 2.f / GetTargetHeight() + 1.f,
+		                  (float)RectToLock.right  * 2.f / GetTargetWidth()  - 1.f,
+		                - (float)RectToLock.bottom * 2.f / GetTargetHeight() + 1.f);
 
 		RestoreAPIState();
-		return 0;
 	}
+	else // if (type == POKE_Z)
+	{
+		// TODO: The first five PE registers may change behavior of EFB pokes, this isn't implemented, yet.
+		ResetAPIState();
+
+		D3D::stateman->PushBlendState(clearblendstates[3]);
+		D3D::stateman->PushDepthState(cleardepthstates[1]);
+
+		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight(),
+			1.0f - MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f,
+			1.0f - MathUtil::Clamp<float>((xfmem.viewport.farZ - MathUtil::Clamp<float>(xfmem.viewport.zRange, 0.0f, 16777215.0f)), 0.0f, 16777215.0f) / 16777216.0f);
+		D3D::context->RSSetViewports(1, &vp);
+
+		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
+			FramebufferManager::GetEFBDepthTexture()->GetDSV());
+		D3D::drawColorQuad(0, 1.0f - float(poke_data & 0xFFFFFF) / 16777216.0f,
+		                  (float)RectToLock.left   * 2.f / GetTargetWidth()  - 1.f,
+		                - (float)RectToLock.top    * 2.f / GetTargetHeight() + 1.f,
+		                  (float)RectToLock.right  * 2.f / GetTargetWidth()  - 1.f,
+		                - (float)RectToLock.bottom * 2.f / GetTargetHeight() + 1.f);
+
+		D3D::stateman->PopDepthState();
+		D3D::stateman->PopBlendState();
+
+		RestoreAPIState();
+	}
+
+	return 0;
 }
 
 


### PR DESCRIPTION
This also fixes an offset issue with color pokes.

This is just a quick implementation of Z pokes. It should still be expanded to support the EFB poke method used in the OGL backend.