### PR TITLE
Android: Allow compilation using Android NDK r10e.

### DIFF
--- a/Source/Android/android.toolchain.cmake
+++ b/Source/Android/android.toolchain.cmake
@@ -29,7 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # ------------------------------------------------------------------------------
-#  Android CMake toolchain file, for use with the Android NDK r5-r10d
+#  Android CMake toolchain file, for use with the Android NDK r5-r10e
 #  Requires cmake 2.6.3 or newer (2.8.9 or newer is recommended).
 #  See home page: https://github.com/taka-no-me/android-cmake
 #
@@ -216,7 +216,7 @@ set( CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "" )
 set( CMAKE_SKIP_RPATH TRUE CACHE BOOL "If set, runtime paths are not added when using shared libraries." )
 
 # NDK search paths
-set( ANDROID_SUPPORTED_NDK_VERSIONS ${ANDROID_EXTRA_NDK_VERSIONS} -r10d -r10c -r10b -r10 -r9d -r9c -r9b -r9 -r8e -r8d -r8c -r8b -r8 -r7c -r7b -r7 -r6b -r6 -r5c -r5b -r5 "" )
+set( ANDROID_SUPPORTED_NDK_VERSIONS ${ANDROID_EXTRA_NDK_VERSIONS} -r10e -r10d -r10c -r10b -r10 -r9d -r9c -r9b -r9 -r8e -r8d -r8c -r8b -r8 -r7c -r7b -r7 -r6b -r6 -r5c -r5b -r5 "" )
 if( NOT DEFINED ANDROID_NDK_SEARCH_PATHS )
  if( CMAKE_HOST_WIN32 )
   file( TO_CMAKE_PATH "$ENV{PROGRAMFILES}" ANDROID_NDK_SEARCH_PATHS )

--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -171,7 +171,7 @@ String getNdkPath() {
         def stdout = new ByteArrayOutputStream()
 
         exec {
-            // ndk-build.cmd is a file unique to the root directory of android-ndk-r10d.
+            // ndk-build.cmd is a file unique to the root directory of android-ndk-r10e.
             commandLine 'locate', 'ndk-build.cmd'
             standardOutput = stdout
         }


### PR DESCRIPTION
Allows, but does not mandate or set it up for you.

The gradle script will likely continue to point to the old one until you delete it and run `sudo updatedb`. If you're not using that functionality, you won't be affected.