### PR TITLE
GameCube SRAM: Recalculate checksums after setting language.

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -116,6 +116,7 @@ CEXIIPL::CEXIIPL() :
 
 	// We Overwrite language selection here since it's possible on the GC to change the language as you please
 	g_SRAM.lang = SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage;
+	FixSRAMChecksums();
 
 	WriteProtectMemory(m_pIPL, ROM_SIZE);
 	m_uAddress = 0;

--- a/Source/Core/Core/HW/Sram.cpp
+++ b/Source/Core/Core/HW/Sram.cpp
@@ -89,3 +89,16 @@ void SetCardFlashID(u8* buffer, u8 card_index)
 	g_SRAM.flashID_chksum[card_index] = csum^0xFF;
 }
 
+void FixSRAMChecksums()
+{
+	u16 checksum = 0;
+	u16 checksum_inv = 0;
+	for (int i = 0x0C; i < 0x14; i += 2)
+	{
+		int value = (g_SRAM.p_SRAM[i] << 8) + g_SRAM.p_SRAM[i+1];
+		checksum += value;
+		checksum_inv += value ^ 0xFFFF;
+	}
+	g_SRAM.checksum = Common::swap16(checksum);
+	g_SRAM.checksum_inv = Common::swap16(checksum_inv);
+}

--- a/Source/Core/Core/HW/Sram.h
+++ b/Source/Core/Core/HW/Sram.h
@@ -66,6 +66,7 @@ union SRAM
 #pragma pack(pop)
 void InitSRAM();
 void SetCardFlashID(u8* buffer, u8 card_index);
+void FixSRAMChecksums();
 
 extern SRAM sram_dump;
 extern SRAM g_SRAM;

--- a/Source/Core/Core/HW/Sram.h
+++ b/Source/Core/Core/HW/Sram.h
@@ -38,6 +38,20 @@ distribution.
 #include "Common/CommonTypes.h"
 
 #pragma pack(push,1)
+union SRAMFlags
+{
+	u8 Hex;
+	struct
+	{
+		u8             : 2;
+		u8 sound       : 1; // Audio settings; 0 = Mono, 1 = Stereo
+		u8 initialized : 1; // if 0, displays prompt to set language on boot and asks user to set options and time/date
+		u8             : 2;
+		u8 boot_menu   : 1; // if 1, skips logo animation and boots into the system menu regardless of if there is a disc inserted
+		u8 progressive : 1; // if 1, automatically displays Progressive Scan prompt in games that support it
+	};
+};
+
 union SRAM
 {
 	u8 p_SRAM[64];
@@ -51,7 +65,7 @@ union SRAM
 		s8 display_offsetH;     // Pixel offset for the VI
 		u8 ntd;                 // Unknown attribute
 		u8 lang;                // Language of system
-		u8 flags;               // Device and operations flag
+		SRAMFlags flags;        // Device and operations flag
 
 		                        // Stored configuration value from the extended SRAM area
 		u8 flash_id[2][12];     // flash_id[2][12] 96bit memorycard unlock flash ID


### PR DESCRIPTION
Fixes a small bug that you can trigger by doing the following in order:
* Uncheck "Skip BIOS" in Config -> GameCube.
* Boot any GameCube game, then close it.
* Change the system language in Config -> GameCube.
* Boot any GameCube game again.

The IPL will now display this message:
[![Checksum error](http://i.imgur.com/tBq3gHkm.jpg)](http://i.imgur.com/tBq3gHk.jpg)

This is caused by the SRAM failing the checksum check after the Language byte has been force-modified via the Dolphin setting. This PR recalculates this checksum after the language has been set, so that the error won't happen.

I've also added a structure that identifies some of the SRAM flags at 0x13.