### PR TITLE
Android: Display Panic Alerts on-screen as a Toast message.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -8,6 +8,9 @@ package org.dolphinemu.dolphinemu;
 
 import android.util.Log;
 import android.view.Surface;
+import android.widget.Toast;
+
+import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 
 /**
  * Class which contains methods that interact
@@ -15,6 +18,8 @@ import android.view.Surface;
  */
 public final class NativeLibrary
 {
+	private static EmulationActivity mEmulationActivity;
+
 	/**
 	 * Button type for use in onTouchEvent
 	 */
@@ -235,6 +240,13 @@ public final class NativeLibrary
 	/** Native EGL functions not exposed by Java bindings **/
 	public static native void eglBindAPI(int api);
 
+	/**
+	 * The methods C++ uses to find references to Java classes and methods
+	 * are really expensive. Rather than calling them every time we want to
+	 * run them, do it once when we load the native library.
+	 */
+	private static native void CacheClassesAndMethods();
+
 	static
 	{
 		try
@@ -245,5 +257,26 @@ public final class NativeLibrary
 		{
 			Log.e("NativeLibrary", ex.toString());
 		}
+
+		CacheClassesAndMethods();
+	}
+
+	public static void displayAlertMsg(final String alert)
+	{
+		Log.e("DolphinEmu", "Alert: " + alert);
+		mEmulationActivity.runOnUiThread(new Runnable()
+		{
+			@Override
+			public void run()
+			{
+				Toast.makeText(mEmulationActivity, "Panic Alert: " + alert, Toast.LENGTH_LONG).show();
+			}
+		});
+	}
+
+	public static void setEmulationActivity(EmulationActivity emulationActivity)
+	{
+		Log.v("DolphinEmu", "Registering EmulationActivity.");
+		mEmulationActivity = emulationActivity;
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.util.Log;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -89,6 +90,23 @@ public final class EmulationActivity extends Activity
 		getFragmentManager().beginTransaction()
 				.add(R.id.frame_content, emulationFragment, EmulationFragment.FRAGMENT_TAG)
 				.commit();
+	}
+
+	@Override
+	protected void onStart()
+	{
+		super.onStart();
+		Log.d("DolphinEmu", "EmulationActivity starting.");
+		NativeLibrary.setEmulationActivity(this);
+	}
+
+	@Override
+	protected void onStop()
+	{
+		super.onStop();
+		Log.d("DolphinEmu", "EmulationActivity stopping.");
+
+		NativeLibrary.setEmulationActivity(null);
 	}
 
 	@Override

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -41,11 +41,6 @@ JavaVM* g_java_vm;
 jclass g_jni_class;
 jmethodID g_jni_method_alert;
 
-// PanicAlert
-static bool g_alert_available = false;
-static std::string g_alert_message = "";
-static Common::Event g_alert_event;
-
 #define DOLPHIN_TAG "DolphinEmuNative"
 
 /*
@@ -125,11 +120,6 @@ static bool MsgAlert(const char* caption, const char* text, bool yes_no, int /*S
 	// Must be called before the current thread exits; might as well do it here.
 	g_java_vm->DetachCurrentThread();
 
-	g_alert_message = std::string(text);
-	g_alert_available = true;
-	// XXX: Uncomment next line when the Android UI actually handles messages
-	// g_alert_event.Wait()
-	g_alert_available = false;
 	return false;
 }
 
@@ -389,13 +379,9 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetUserDirec
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDirectory(JNIEnv *env, jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetProfiling(JNIEnv *env, jobject obj, jboolean enable);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_WriteProfileResults(JNIEnv *env, jobject obj);
+JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_CacheClassesAndMethods(JNIEnv *env, jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Run(JNIEnv *env, jobject obj, jobject _surf);
 
-// Msg
-JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_HasAlertMsg(JNIEnv *env, jobject obj);
-JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetAlertMsg(JNIEnv *env, jobject obj);
-JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ClearAlertMsg(JNIEnv *env, jobject obj);
-JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_CacheClassesAndMethods(JNIEnv *env, jobject obj);
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_UnPauseEmulation(JNIEnv *env, jobject obj)
 {
@@ -589,21 +575,6 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_WriteProfile
 	std::string filename = File::GetUserPath(D_DUMP_IDX) + "Debug/profiler.txt";
 	File::CreateFullPath(filename);
 	JitInterface::WriteProfileResults(filename);
-}
-
-JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_HasAlertMsg(JNIEnv *env, jobject obj)
-{
-	return g_alert_available;
-}
-
-JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetAlertMsg(JNIEnv *env, jobject obj)
-{
-	return env->NewStringUTF(g_alert_message.c_str());
-}
-
-JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ClearAlertMsg(JNIEnv *env, jobject obj)
-{
-	g_alert_event.Set(); // Kick the alert
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_CacheClassesAndMethods(JNIEnv *env, jobject obj)


### PR DESCRIPTION
This should provide crucial information as to why devices aren't working. More importantly however, it proves out a method for calling Java methods from native code, which will probably happen more frequently from now on, so I appreciate guidance on how to make the C++ side of this PR less horrific.