### PR TITLE
Fix issue with Wind Waker not displaying boot display options.

### DIFF
--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -86,7 +86,7 @@ void Init()
 	m_FlipperRev = 0x246500B1; // revision C
 	m_Unknown = 0;
 
-	m_ResetCode = 0x80000000; // Cold reset
+	m_ResetCode = 0; // Cold reset
 	m_InterruptCause = INT_CAUSE_RST_BUTTON | INT_CAUSE_VI;
 
 	toggleResetButton = CoreTiming::RegisterEvent("ToggleResetButton", ToggleResetButtonCallback);


### PR DESCRIPTION
From what I've been told this removes remnants of the old ES_LAUNCH hack. The reset code needs to be 0 or 1 on boot for Wind Waker to display the options -- both the NTSC version asking for Progressive Scan and the PAL version asking for PAL60.

Some testing may be required on if this breaks other games. Also it might be interesting to know what exactly should be in m_InterruptCause on boot, too.

Fixes [issue 8593](https://code.google.com/p/dolphin-emu/issues/detail?id=8593).