### PR TITLE
Android: Run AssetCopyService only once.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/GameGridActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/GameGridActivity.java
@@ -5,8 +5,10 @@ import android.app.LoaderManager;
 import android.content.CursorLoader;
 import android.content.Intent;
 import android.content.Loader;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -79,9 +81,16 @@ public final class GameGridActivity extends Activity implements LoaderManager.Lo
 		// Stuff in this block only happens when this activity is newly created (i.e. not a rotation)
 		if (savedInstanceState == null)
 		{
-			// Copy assets into appropriate locations.
-			Intent copyAssets = new Intent(this, AssetCopyService.class);
-			startService(copyAssets);
+			SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+			boolean assetsCopied = preferences.getBoolean("assetsCopied", false);
+
+			// Only perform these extensive copy operations once.
+			if (!assetsCopied)
+			{
+				// Copy assets into appropriate locations.
+				Intent copyAssets = new Intent(this, AssetCopyService.class);
+				startService(copyAssets);
+			}
 		}
 	}
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/AssetCopyService.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/services/AssetCopyService.java
@@ -8,6 +8,8 @@ package org.dolphinemu.dolphinemu.services;
 
 import android.app.IntentService;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.dolphinemu.dolphinemu.NativeLibrary;
@@ -63,6 +65,13 @@ public final class AssetCopyService extends IntentService
 		// Load the configuration keys set in the Dolphin ini and gfx ini files
 		// into the application's shared preferences.
 		UserPreferences.LoadIniToPrefs(this);
+
+		// Record the fact that we've done this before, so we don't do it on every launch.
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+		SharedPreferences.Editor editor = preferences.edit();
+
+		editor.putBoolean("assetsCopied", true);
+		editor.commit();
 	}
 
 	private void copyAsset(String asset, String output)


### PR DESCRIPTION
The AssetCopyService is really expensive so we should only ever do it once. Ideally I'd like to have a screen show up on the first run of the application to on-board the user and do one-time stuff like this, but for now this should be good enough.

This should also fix the user's preferences being gobbled every time they reload the app.