### PR TITLE
Android TV: Show the in-game menu when back button is pushed.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -25,6 +25,9 @@ public final class EmulationActivity extends Activity
 {
 	private View mDecorView;
 
+	private boolean mDeviceHasTouchScreen;
+	private boolean mSystemUiVisible;
+
 	/**
 	 * Handlers are a way to pass a message to an Activity telling it to do something
 	 * on the UI thread. This Handler responds to any message, even blank ones, by
@@ -44,6 +47,8 @@ public final class EmulationActivity extends Activity
 	{
 		super.onCreate(savedInstanceState);
 
+		mDeviceHasTouchScreen = getPackageManager().hasSystemFeature("android.hardware.touchscreen");
+
 		// Get a handle to the Window containing the UI.
 		mDecorView = getWindow().getDecorView();
 
@@ -59,9 +64,9 @@ public final class EmulationActivity extends Activity
 					@Override
 					public void onSystemUiVisibilityChange(int flags)
 					{
-						boolean visible = (flags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
+						mSystemUiVisible = (flags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
 
-						if (visible)
+						if (mSystemUiVisible)
 						{
 							getActionBar().show();
 							hideSystemUiAfterDelay();
@@ -114,6 +119,20 @@ public final class EmulationActivity extends Activity
 			// If the window loses focus (i.e. a dialog box, or a popup menu is on screen
 			// stop hiding the UI.
 			mSystemUiHider.removeMessages(0);
+		}
+	}
+
+	@Override
+	public void onBackPressed()
+	{
+		if (!mDeviceHasTouchScreen && !mSystemUiVisible)
+		{
+			showSystemUI();
+		}
+		else
+		{
+			// Let the system handle it; i.e. quit the activity TODO or show "are you sure?" dialog.
+			super.onBackPressed();
 		}
 	}
 
@@ -275,6 +294,8 @@ public final class EmulationActivity extends Activity
 
 	private void hideSystemUI()
 	{
+		mSystemUiVisible = false;
+
 		mDecorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
 				View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
 				View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
@@ -285,8 +306,12 @@ public final class EmulationActivity extends Activity
 
 	private void showSystemUI()
 	{
+		mSystemUiVisible = true;
+
 		mDecorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
 				View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
 				View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+
+		hideSystemUiAfterDelay();
 	}
 }


### PR DESCRIPTION
On touch-screen capable devices, the in-game menu can be shown with a swipe from top or bottom of the screen.

On TV devices, there's no touch screen. So use the back button to show it. You still can't control it with the gamepad; a bluetooth or USB mouse can be used to click the buttons.

Android TV apps really need a bespoke UI to function properly, and that is currently how I plan to solve this better in the future.