### PR TITLE
Gameini updates.

### DIFF
--- a/Data/Sys/GameSettings/G8W.ini
+++ b/Data/Sys/GameSettings/G8W.ini
@@ -2,12 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = False
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Idle skipping slows down the game.
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,9 +19,4 @@ EmulationIssues = Idle skipping slows down the game.
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
+

--- a/Data/Sys/GameSettings/G8W.ini
+++ b/Data/Sys/GameSettings/G8W.ini
@@ -18,5 +18,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-

--- a/Data/Sys/GameSettings/G9R.ini
+++ b/Data/Sys/GameSettings/G9R.ini
@@ -2,11 +2,11 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = 0
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Idle skipping can cause speed issues.
+EmulationIssues = 
 EmulationStateId = 4
 
 [OnLoad]

--- a/Data/Sys/GameSettings/GDE.ini
+++ b/Data/Sys/GameSettings/GDE.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = 0
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
@@ -19,12 +18,6 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/GDE.ini
+++ b/Data/Sys/GameSettings/GDE.ini
@@ -17,8 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GE4.ini
+++ b/Data/Sys/GameSettings/GE4.ini
@@ -2,12 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = 0
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-EmulationIssues = Idleskipping causes speed issues(menus,etc.)
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,10 +19,5 @@ EmulationIssues = Idleskipping causes speed issues(menus,etc.)
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
+
 

--- a/Data/Sys/GameSettings/GHK.ini
+++ b/Data/Sys/GameSettings/GHK.ini
@@ -16,6 +16,4 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-
 [Gecko]

--- a/Data/Sys/GameSettings/GHK.ini
+++ b/Data/Sys/GameSettings/GHK.ini
@@ -1,20 +1,21 @@
 # GHKD7D, GHKE7D, GHKF7D, GHKP7D, GHKS7D - The Hulk
+
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = 0
+SyncOnSkipIdle = False
+
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
 EmulationIssues = 
+
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
+
 [OnFrame]
+
 [ActionReplay]
+
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
+
 [Gecko]

--- a/Data/Sys/GameSettings/GVL.ini
+++ b/Data/Sys/GameSettings/GVL.ini
@@ -18,6 +18,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-
-

--- a/Data/Sys/GameSettings/GVL.ini
+++ b/Data/Sys/GameSettings/GVL.ini
@@ -2,12 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = 0
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-EmulationIssues = Idleskipping if enabled will cause speed issues.
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,10 +19,5 @@ EmulationIssues = Idleskipping if enabled will cause speed issues.
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
+
 

--- a/Data/Sys/GameSettings/NAK.ini
+++ b/Data/Sys/GameSettings/NAK.ini
@@ -1,12 +1,12 @@
-# NAKE01, NAKP01 - Pokémon Snap
+# NAKE01, NAKP01 - Pokemon Snap
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationStateId = 3
-EmulationIssues = Game can't recognize taken pictures. Progressing is impossible
+EmulationStateId = 4
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,5 +16,6 @@ EmulationIssues = Game can't recognize taken pictures. Progressing is impossible
 
 [ActionReplay]
 # Add action replay cheats here.
+
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/R5D.ini
+++ b/Data/Sys/GameSettings/R5D.ini
@@ -17,8 +17,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video]
-
-[Video_Hacks]
-

--- a/Data/Sys/GameSettings/R5D.ini
+++ b/Data/Sys/GameSettings/R5D.ini
@@ -2,12 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = 0
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Idle skipping causes speed issues.
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,12 +19,6 @@ EmulationIssues = Idle skipping causes speed issues.
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
 
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/R8J.ini
+++ b/Data/Sys/GameSettings/R8J.ini
@@ -2,12 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = False
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-EmulationIssues = Idle skipping slows down the game
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,12 +19,6 @@ EmulationIssues = Idle skipping slows down the game
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
 
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/R8J.ini
+++ b/Data/Sys/GameSettings/R8J.ini
@@ -17,8 +17,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video]
-
-[Video_Hacks]
-

--- a/Data/Sys/GameSettings/RB7.ini
+++ b/Data/Sys/GameSettings/RB7.ini
@@ -1,13 +1,13 @@
-# GE4E7D - 4x4 Evolution 2
+# RB7E54, RB7P54 - Bully: Scholarship Edition
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncOnSkipIdle = False
+FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationStateId = 3
-EmulationIssues = 
+EmulationIssues =
+EmulationStateId = 4
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -17,6 +17,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-
-

--- a/Data/Sys/GameSettings/RBH.ini
+++ b/Data/Sys/GameSettings/RBH.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues =
+EmulationIssues = Needs efb from cpu access for proper lighting.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -18,15 +18,9 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
-
+EFBAccessEnable = True

--- a/Data/Sys/GameSettings/RBH.ini
+++ b/Data/Sys/GameSettings/RBH.ini
@@ -17,8 +17,6 @@ EmulationIssues = Needs efb from cpu access for proper lighting.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RBW.ini
+++ b/Data/Sys/GameSettings/RBW.ini
@@ -17,7 +17,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video]
-
-

--- a/Data/Sys/GameSettings/RBW.ini
+++ b/Data/Sys/GameSettings/RBW.ini
@@ -2,12 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = False
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Idle skipping slows down the game.
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,10 +19,5 @@ EmulationIssues = Idle skipping slows down the game.
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
+
 

--- a/Data/Sys/GameSettings/RPJ.ini
+++ b/Data/Sys/GameSettings/RPJ.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
@@ -17,16 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-

--- a/Data/Sys/GameSettings/SIL.ini
+++ b/Data/Sys/GameSettings/SIL.ini
@@ -18,8 +18,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SIL.ini
+++ b/Data/Sys/GameSettings/SIL.ini
@@ -2,12 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = 0
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Idleskipping causes speed issues(menus,etc.)
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,12 +19,6 @@ EmulationIssues = Idleskipping causes speed issues(menus,etc.)
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/SX8.ini
+++ b/Data/Sys/GameSettings/SX8.ini
@@ -2,12 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SkipIdle = 0
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Idle skipping causes drop in performance.
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,12 +19,6 @@ EmulationIssues = Idle skipping causes drop in performance.
 # Add action replay cheats here.
 
 [Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SX8.ini
+++ b/Data/Sys/GameSettings/SX8.ini
@@ -18,8 +18,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 


### PR DESCRIPTION
Fixes issue 8637 by replacing SkipIdle=0 with SyncOnSkipIdle = False.
Updates gameinis for Resident Evil Archives: Resident Evil Zero, Pokemon
Snap and fixes a mistake in Baldur's Gate: Dark Alliance.