### PR TITLE
Boot: Automatically temporarily set GameCube language to 0 when booting NTSC games.

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -186,7 +186,7 @@ bool BootCore(const std::string& _rFilename)
 		}
 
 		// Some NTSC GameCube games such as Baten Kaitos react strangely to language settings that would be invalid on an NTSC system
-		if (StartUp.bNTSC)
+		if (!StartUp.bOverrideGCLanguage && StartUp.bNTSC)
 		{
 			StartUp.SelectedLanguage = 0;
 		}

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -49,6 +49,7 @@ struct ConfigCache
 {
 	bool valid, bCPUThread, bSkipIdle, bSyncGPUOnSkipIdleHack, bFPRF, bAccurateNaNs, bMMU, bDCBZOFF, m_EnableJIT, bDSPThread,
 	     bSyncGPU, bFastDiscSpeed, bDSPHLE, bHLE_BS2, bProgressive;
+	int iSelectedLanguage;
 	int iCPUCore, Volume;
 	int iWiimoteSource[MAX_BBMOTES];
 	SIDevices Pads[MAX_SI_CHANNELS];
@@ -120,6 +121,7 @@ bool BootCore(const std::string& _rFilename)
 		config_cache.framelimit = SConfig::GetInstance().m_Framelimit;
 		config_cache.frameSkip = SConfig::GetInstance().m_FrameSkip;
 		config_cache.bProgressive = StartUp.bProgressive;
+		config_cache.iSelectedLanguage = StartUp.SelectedLanguage;
 		for (unsigned int i = 0; i < MAX_BBMOTES; ++i)
 		{
 			config_cache.iWiimoteSource[i] = g_wiimote_sources[i];
@@ -181,6 +183,12 @@ bool BootCore(const std::string& _rFilename)
 				SConfig::GetInstance().m_SIDevice[i] = (SIDevices) source;
 				config_cache.bSetPads[i] = true;
 			}
+		}
+
+		// Some NTSC GameCube games such as Baten Kaitos react strangely to language settings that would be invalid on an NTSC system
+		if (StartUp.bNTSC)
+		{
+			StartUp.SelectedLanguage = 0;
 		}
 
 		// Wii settings
@@ -288,6 +296,7 @@ void Stop()
 		SConfig::GetInstance().sBackend = config_cache.sBackend;
 		SConfig::GetInstance().m_DSPEnableJIT = config_cache.m_EnableJIT;
 		StartUp.bProgressive = config_cache.bProgressive;
+		StartUp.SelectedLanguage = config_cache.iSelectedLanguage;
 		SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", config_cache.bProgressive);
 
 		// Only change these back if they were actually set by game ini, since they can be changed while a game is running.

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -191,6 +191,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("Apploader", m_LocalCoreStartupParameter.m_strApploader);
 	core->Set("EnableCheats", m_LocalCoreStartupParameter.bEnableCheats);
 	core->Set("SelectedLanguage", m_LocalCoreStartupParameter.SelectedLanguage);
+	core->Set("OverrideGCLang", m_LocalCoreStartupParameter.bOverrideGCLanguage);
 	core->Set("DPL2Decoder", m_LocalCoreStartupParameter.bDPL2Decoder);
 	core->Set("Latency", m_LocalCoreStartupParameter.iLatency);
 	core->Set("MemcardAPath", m_strMemoryCardA);
@@ -437,6 +438,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("Apploader",         &m_LocalCoreStartupParameter.m_strApploader);
 	core->Get("EnableCheats",      &m_LocalCoreStartupParameter.bEnableCheats, false);
 	core->Get("SelectedLanguage",  &m_LocalCoreStartupParameter.SelectedLanguage, 0);
+	core->Get("OverrideGCLang",    &m_LocalCoreStartupParameter.bOverrideGCLanguage, false);
 	core->Get("DPL2Decoder",       &m_LocalCoreStartupParameter.bDPL2Decoder, false);
 	core->Get("Latency",           &m_LocalCoreStartupParameter.iLatency, 2);
 	core->Get("MemcardAPath",      &m_strMemoryCardA);

--- a/Source/Core/Core/CoreParameter.cpp
+++ b/Source/Core/Core/CoreParameter.cpp
@@ -43,7 +43,7 @@ SCoreStartupParameter::SCoreStartupParameter()
   bMMU(false), bDCBZOFF(false),
   iBBDumpPort(0),
   bFastDiscSpeed(false), bSyncGPU(false),
-  SelectedLanguage(0), bWii(false),
+  SelectedLanguage(0), bOverrideGCLanguage(false), bWii(false),
   bConfirmStop(false), bHideCursor(false),
   bAutoHideCursor(false), bUsePanicHandlers(true), bOnScreenDisplayMessages(true),
   iRenderWindowXPos(-1), iRenderWindowYPos(-1),
@@ -86,6 +86,7 @@ void SCoreStartupParameter::LoadDefaults()
 	bFastDiscSpeed = false;
 	bEnableMemcardSaving = true;
 	SelectedLanguage = 0;
+	bOverrideGCLanguage = false;
 	bWii = false;
 	bDPL2Decoder = false;
 	iLatency = 14;

--- a/Source/Core/Core/CoreParameter.h
+++ b/Source/Core/Core/CoreParameter.h
@@ -193,6 +193,7 @@ struct SCoreStartupParameter
 	float fSyncGpuOverclock;
 
 	int SelectedLanguage;
+	bool bOverrideGCLanguage;
 
 	bool bWii;
 

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -55,6 +55,10 @@ void GameCubeConfigPane::InitializeGUI()
 	m_system_lang_choice->SetToolTip(_("Sets the GameCube system language."));
 	m_system_lang_choice->Bind(wxEVT_CHOICE, &GameCubeConfigPane::OnSystemLanguageChange, this);
 
+	m_override_lang_checkbox = new wxCheckBox(this, wxID_ANY, _("Override Language on NTSC Games"));
+	m_override_lang_checkbox->SetToolTip(_("Lets the system language be set to values that games were not designed for. This can allow the use of extra translations for a few games, but can also lead to text display issues."));
+	m_override_lang_checkbox->Bind(wxEVT_CHECKBOX, &GameCubeConfigPane::OnOverrideLanguageCheckBoxChanged, this);
+
 	m_skip_bios_checkbox = new wxCheckBox(this, wxID_ANY, _("Skip BIOS"));
 	m_skip_bios_checkbox->Bind(wxEVT_CHECKBOX, &GameCubeConfigPane::OnSkipBiosCheckBoxChanged, this);
 
@@ -96,6 +100,7 @@ void GameCubeConfigPane::InitializeGUI()
 	sGamecubeIPLSettings->Add(new wxStaticText(this, wxID_ANY, _("System Language:")),
 		wxGBPosition(1, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 	sGamecubeIPLSettings->Add(m_system_lang_choice, wxGBPosition(1, 1), wxDefaultSpan, wxLEFT | wxRIGHT | wxBOTTOM, 5);
+	sGamecubeIPLSettings->Add(m_override_lang_checkbox, wxGBPosition(2, 0), wxGBSpan(1, 2), wxALL, 5);
 
 	wxStaticBoxSizer* const sbGamecubeIPLSettings = new wxStaticBoxSizer(wxVERTICAL, this, _("IPL Settings"));
 	sbGamecubeIPLSettings->Add(sGamecubeIPLSettings);
@@ -128,6 +133,7 @@ void GameCubeConfigPane::LoadGUIValues()
 
 	m_system_lang_choice->SetSelection(startup_params.SelectedLanguage);
 	m_skip_bios_checkbox->SetValue(startup_params.bHLE_BS2);
+	m_override_lang_checkbox->SetValue(startup_params.bOverrideGCLanguage);
 
 	wxArrayString slot_devices;
 	slot_devices.Add(_(DEV_NONE_STR));
@@ -199,6 +205,7 @@ void GameCubeConfigPane::RefreshGUI()
 	if (Core::IsRunning())
 	{
 		m_system_lang_choice->Disable();
+		m_override_lang_checkbox->Disable();
 		m_skip_bios_checkbox->Disable();
 	}
 }
@@ -206,6 +213,13 @@ void GameCubeConfigPane::RefreshGUI()
 void GameCubeConfigPane::OnSystemLanguageChange(wxCommandEvent& event)
 {
 	SConfig::GetInstance().m_LocalCoreStartupParameter.SelectedLanguage = m_system_lang_choice->GetSelection();
+
+	AddPendingEvent(wxCommandEvent(wxDOLPHIN_CFG_REFRESH_LIST));
+}
+
+void GameCubeConfigPane::OnOverrideLanguageCheckBoxChanged(wxCommandEvent& event)
+{
+	SConfig::GetInstance().m_LocalCoreStartupParameter.bOverrideGCLanguage = m_override_lang_checkbox->IsChecked();
 
 	AddPendingEvent(wxCommandEvent(wxDOLPHIN_CFG_REFRESH_LIST));
 }

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -23,6 +23,7 @@ private:
 	void RefreshGUI();
 
 	void OnSystemLanguageChange(wxCommandEvent&);
+	void OnOverrideLanguageCheckBoxChanged(wxCommandEvent&);
 	void OnSkipBiosCheckBoxChanged(wxCommandEvent&);
 	void OnSlotAChanged(wxCommandEvent&);
 	void OnSlotBChanged(wxCommandEvent&);
@@ -36,6 +37,7 @@ private:
 	wxArrayString m_ipl_language_strings;
 
 	wxChoice* m_system_lang_choice;
+	wxCheckBox* m_override_lang_checkbox;
 	wxCheckBox* m_skip_bios_checkbox;
 	wxChoice* m_exi_devices[3];
 	wxButton* m_memcard_path[2];


### PR DESCRIPTION
NTSC GameCubes have no Language setting, so the language byte in SRAM is always 0. Some NTSC games (such as Baten Kaitos) do react oddly and display unfinished translations and debug/placeholder text when the byte is set to a nonzero value that corresponds to a non-English language on a PAL GameCube.

There are also some games (such as Metroid Prime 2) that actually have near-finished translations of European languages on the disc and work fine, so it might be useful to have an "override" option somewhere.

Fixes [issue 7731](https://code.google.com/p/dolphin-emu/issues/detail?id=7731).