### PR TITLE
GUI: Re-enable the Tools -> Load Wii System Menu option on emulator start.

### DIFF
--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -72,10 +72,10 @@ std::string GetTMDFileName(u64 _titleID)
 {
 	return GetTitleContentPath(_titleID) + "title.tmd";
 }
-std::string GetTitleContentPath(u64 _titleID)
+std::string GetTitleContentPath(u64 _titleID, int wiiRootIndex)
 {
 	return StringFromFormat("%s/title/%08x/%08x/content/",
-			File::GetUserPath(D_SESSION_WIIROOT_IDX).c_str(),
+			File::GetUserPath(wiiRootIndex).c_str(),
 			(u32)(_titleID >> 32), (u32)_titleID);
 }
 

--- a/Source/Core/Common/NandPaths.h
+++ b/Source/Core/Common/NandPaths.h
@@ -24,7 +24,7 @@ namespace Common
 	std::string GetTicketFileName(u64 _titleID);
 	std::string GetTMDFileName(u64 _titleID);
 	std::string GetTitleDataPath(u64 _titleID);
-	std::string GetTitleContentPath(u64 _titleID);
+	std::string GetTitleContentPath(u64 _titleID, int wiiRootIndex = D_SESSION_WIIROOT_IDX);
 	bool CheckTitleTMD(u64 _titleID);
 	bool CheckTitleTIK(u64 _titleID);
 	void ReadReplacements(replace_v& replacements);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1455,7 +1455,7 @@ void CFrame::OnShowCheatsWindow(wxCommandEvent& WXUNUSED (event))
 
 void CFrame::OnLoadWiiMenu(wxCommandEvent& WXUNUSED(event))
 {
-	BootGame(Common::GetTitleContentPath(TITLEID_SYSMENU));
+	BootGame(Common::GetTitleContentPath(TITLEID_SYSMENU, D_WIIROOT_IDX));
 }
 
 void CFrame::OnInstallWAD(wxCommandEvent& event)
@@ -1511,12 +1511,13 @@ void CFrame::UpdateWiiMenuChoice(wxMenuItem *WiiMenuItem)
 		WiiMenuItem = GetMenuBar()->FindItem(IDM_LOAD_WII_MENU);
 	}
 
-	const DiscIO::INANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, true);
+	std::string path = Common::GetTitleContentPath(TITLEID_SYSMENU, D_WIIROOT_IDX);
+	const DiscIO::INANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(path, true);
 	if (SysMenu_Loader.IsValid())
 	{
 		int sysmenuVersion = SysMenu_Loader.GetTitleVersion();
 		char sysmenuRegion = SysMenu_Loader.GetCountryChar();
-		WiiMenuItem->Enable();
+		WiiMenuItem->Enable(!Core::IsRunning());
 		WiiMenuItem->SetItemLabel(wxString::Format(_("Load Wii System Menu %d%c"), sysmenuVersion, sysmenuRegion));
 	}
 	else
@@ -1742,8 +1743,7 @@ void CFrame::UpdateGUI()
 	GetMenuBar()->FindItem(IDM_SAVE_STATE)->Enable(Initialized);
 	// Misc
 	GetMenuBar()->FindItem(IDM_CHANGE_DISC)->Enable(Initialized);
-	if (DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU).IsValid())
-		GetMenuBar()->FindItem(IDM_LOAD_WII_MENU)->Enable(!Initialized);
+	UpdateWiiMenuChoice();
 
 	// Tools
 	GetMenuBar()->FindItem(IDM_CHEATS)->Enable(SConfig::GetInstance().m_LocalCoreStartupParameter.bEnableCheats);


### PR DESCRIPTION
This re-enables the Tools -> Load Wii System Menu option on emulator start, which I believe was broken when D_SESSION_WIIROOT_IDX was introduced in dc91e8b60793276e83cc3c141dcdc551aa36d8ed. Since that commit, the option was greyed-out when first starting the emulator and was only enabled when a Wii game booted. (UpdateWiiMenuChoice() in FrameTools.cpp uses the regular GetNANDLoader() function, which always uses the session WiiRoot, which was only initialized on game boot.)

I assume it's fine to just initialize it immediately? It'll be re-set in InitializeWiiRoot() anyway.