### PR TITLE
Don't display the branch name in the titlebar for the stable branch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,6 @@ if (APPLE)
 	endif()
 endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/CMakeTests)
-set(DOLPHIN_IS_STABLE FALSE)
 # Libraries to link
 set(LIBS)
 
@@ -126,7 +125,7 @@ endif()
 # version number
 set(DOLPHIN_VERSION_MAJOR "4")
 set(DOLPHIN_VERSION_MINOR "0")
-if(DOLPHIN_IS_STABLE)
+if(DOLPHIN_WC_BRANCH STREQUAL "stable")
 	set(DOLPHIN_VERSION_PATCH "0")
 else()
 	set(DOLPHIN_VERSION_PATCH ${DOLPHIN_WC_REVISION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,17 +817,17 @@ endif()
 ########################################
 # Pre-build events: Define configuration variables and write SCM info header
 #
-if(DOLPHIN_WC_BRANCH STREQUAL "master")
-	set(DOLPHIN_WC_IS_MASTER "1")
+if(DOLPHIN_WC_BRANCH STREQUAL "master" OR DOLPHIN_WC_BRANCH STREQUAL "stable")
+	set(DOLPHIN_WC_IS_STABLE "1")
 else()
-	set(DOLPHIN_WC_IS_MASTER "0")
+	set(DOLPHIN_WC_IS_STABLE "0")
 endif()
 
 file(WRITE ${PROJECT_BINARY_DIR}/Source/Core/Common/scmrev.h
 	"#define SCM_REV_STR \"" ${DOLPHIN_WC_REVISION} "\"\n"
 	"#define SCM_DESC_STR \"" ${DOLPHIN_WC_DESCRIBE} "\"\n"
 	"#define SCM_BRANCH_STR \"" ${DOLPHIN_WC_BRANCH} "\"\n"
-	"#define SCM_IS_MASTER " ${DOLPHIN_WC_IS_MASTER} "\n"
+	"#define SCM_IS_MASTER " ${DOLPHIN_WC_IS_STABLE} "\n"
 	)
 include_directories("${PROJECT_BINARY_DIR}/Source/Core/Common")
 

--- a/Source/Core/Common/make_scmrev.h.js
+++ b/Source/Core/Common/make_scmrev.h.js
@@ -65,7 +65,7 @@ var gitexe = GetGitExe();
 var revision	= GetFirstStdOutLine(gitexe + cmd_revision);
 var describe	= GetFirstStdOutLine(gitexe + cmd_describe);
 var branch		= GetFirstStdOutLine(gitexe + cmd_branch);
-var isMaster	= +("master" == branch);
+var isStable	= +("master" == branch || "stable" == branch);
 
 // remove hash (and trailing "-0" if needed) from description
 describe = describe.replace(/(-0)?-[^-]+(-dirty)?$/, '$2');
@@ -74,7 +74,7 @@ var out_contents =
 	"#define SCM_REV_STR \"" + revision + "\"\n" +
 	"#define SCM_DESC_STR \"" + describe + "\"\n" +
 	"#define SCM_BRANCH_STR \"" + branch + "\"\n" +
-	"#define SCM_IS_MASTER " + isMaster + "\n";
+	"#define SCM_IS_MASTER " + isStable + "\n";
 
 // check if file needs updating
 if (out_contents == GetFileContents(outfile))


### PR DESCRIPTION
These commits were cherry-pick from the 4.0-hotfixes branch, they weren't merged into master yet.