### PR TITLE
GameIni: Remove default Projection Hack

### DIFF
--- a/Data/Sys/GameSettings/010.ini
+++ b/Data/Sys/GameSettings/010.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/D43.ini
+++ b/Data/Sys/GameSettings/D43.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/D85.ini
+++ b/Data/Sys/GameSettings/D85.ini
@@ -17,7 +17,4 @@ EmulationIssues = Videos run at low FPS
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]

--- a/Data/Sys/GameSettings/DD2.ini
+++ b/Data/Sys/GameSettings/DD2.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/FA6.ini
+++ b/Data/Sys/GameSettings/FA6.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FA7.ini
+++ b/Data/Sys/GameSettings/FA7.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FA8.ini
+++ b/Data/Sys/GameSettings/FA8.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FA9.ini
+++ b/Data/Sys/GameSettings/FA9.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAA.ini
+++ b/Data/Sys/GameSettings/FAA.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAB.ini
+++ b/Data/Sys/GameSettings/FAB.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAG.ini
+++ b/Data/Sys/GameSettings/FAG.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAH.ini
+++ b/Data/Sys/GameSettings/FAH.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAK.ini
+++ b/Data/Sys/GameSettings/FAK.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAL.ini
+++ b/Data/Sys/GameSettings/FAL.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAN.ini
+++ b/Data/Sys/GameSettings/FAN.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAO.ini
+++ b/Data/Sys/GameSettings/FAO.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAP.ini
+++ b/Data/Sys/GameSettings/FAP.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAQ.ini
+++ b/Data/Sys/GameSettings/FAQ.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAS.ini
+++ b/Data/Sys/GameSettings/FAS.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAT.ini
+++ b/Data/Sys/GameSettings/FAT.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAV.ini
+++ b/Data/Sys/GameSettings/FAV.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAW.ini
+++ b/Data/Sys/GameSettings/FAW.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FAX.ini
+++ b/Data/Sys/GameSettings/FAX.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FB4.ini
+++ b/Data/Sys/GameSettings/FB4.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FB5.ini
+++ b/Data/Sys/GameSettings/FB5.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBB.ini
+++ b/Data/Sys/GameSettings/FBB.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBC.ini
+++ b/Data/Sys/GameSettings/FBC.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBD.ini
+++ b/Data/Sys/GameSettings/FBD.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBE.ini
+++ b/Data/Sys/GameSettings/FBE.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBH.ini
+++ b/Data/Sys/GameSettings/FBH.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBI.ini
+++ b/Data/Sys/GameSettings/FBI.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBJ.ini
+++ b/Data/Sys/GameSettings/FBJ.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBL.ini
+++ b/Data/Sys/GameSettings/FBL.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBN.ini
+++ b/Data/Sys/GameSettings/FBN.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBR.ini
+++ b/Data/Sys/GameSettings/FBR.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBS.ini
+++ b/Data/Sys/GameSettings/FBS.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBU.ini
+++ b/Data/Sys/GameSettings/FBU.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBY.ini
+++ b/Data/Sys/GameSettings/FBY.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = 2

--- a/Data/Sys/GameSettings/FBZ.ini
+++ b/Data/Sys/GameSettings/FBZ.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FC3.ini
+++ b/Data/Sys/GameSettings/FC3.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FC6.ini
+++ b/Data/Sys/GameSettings/FC6.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FC7.ini
+++ b/Data/Sys/GameSettings/FC7.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FC8.ini
+++ b/Data/Sys/GameSettings/FC8.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCA.ini
+++ b/Data/Sys/GameSettings/FCA.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCP.ini
+++ b/Data/Sys/GameSettings/FCP.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCQ.ini
+++ b/Data/Sys/GameSettings/FCQ.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCR.ini
+++ b/Data/Sys/GameSettings/FCR.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCS.ini
+++ b/Data/Sys/GameSettings/FCS.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCT.ini
+++ b/Data/Sys/GameSettings/FCT.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCU.ini
+++ b/Data/Sys/GameSettings/FCU.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCV.ini
+++ b/Data/Sys/GameSettings/FCV.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCW.ini
+++ b/Data/Sys/GameSettings/FCW.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCY.ini
+++ b/Data/Sys/GameSettings/FCY.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FCZ.ini
+++ b/Data/Sys/GameSettings/FCZ.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FD2.ini
+++ b/Data/Sys/GameSettings/FD2.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FD6.ini
+++ b/Data/Sys/GameSettings/FD6.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FD7.ini
+++ b/Data/Sys/GameSettings/FD7.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDA.ini
+++ b/Data/Sys/GameSettings/FDA.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDF.ini
+++ b/Data/Sys/GameSettings/FDF.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDG.ini
+++ b/Data/Sys/GameSettings/FDG.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDL.ini
+++ b/Data/Sys/GameSettings/FDL.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDN.ini
+++ b/Data/Sys/GameSettings/FDN.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDO.ini
+++ b/Data/Sys/GameSettings/FDO.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDP.ini
+++ b/Data/Sys/GameSettings/FDP.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDQ.ini
+++ b/Data/Sys/GameSettings/FDQ.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDT.ini
+++ b/Data/Sys/GameSettings/FDT.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDU.ini
+++ b/Data/Sys/GameSettings/FDU.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FDV.ini
+++ b/Data/Sys/GameSettings/FDV.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FEC.ini
+++ b/Data/Sys/GameSettings/FEC.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FED.ini
+++ b/Data/Sys/GameSettings/FED.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FEI.ini
+++ b/Data/Sys/GameSettings/FEI.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FEM.ini
+++ b/Data/Sys/GameSettings/FEM.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FEN.ini
+++ b/Data/Sys/GameSettings/FEN.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FEQ.ini
+++ b/Data/Sys/GameSettings/FEQ.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 4096
 EFBScale = 2

--- a/Data/Sys/GameSettings/FER.ini
+++ b/Data/Sys/GameSettings/FER.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FES.ini
+++ b/Data/Sys/GameSettings/FES.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FEU.ini
+++ b/Data/Sys/GameSettings/FEU.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FFA.ini
+++ b/Data/Sys/GameSettings/FFA.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FFD.ini
+++ b/Data/Sys/GameSettings/FFD.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FFE.ini
+++ b/Data/Sys/GameSettings/FFE.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FFL.ini
+++ b/Data/Sys/GameSettings/FFL.ini
@@ -17,9 +17,6 @@ EmulationIssues = Texture filtering will cause glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FFM.ini
+++ b/Data/Sys/GameSettings/FFM.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FFN.ini
+++ b/Data/Sys/GameSettings/FFN.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/FFQ.ini
+++ b/Data/Sys/GameSettings/FFQ.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/G2B.ini
+++ b/Data/Sys/GameSettings/G2B.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/G2M.ini
+++ b/Data/Sys/GameSettings/G2M.ini
@@ -17,14 +17,6 @@ EmulationIssues = EFB to RAM is needed for the scanner/visors to work properly.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/G2O.ini
+++ b/Data/Sys/GameSettings/G2O.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/G2T.ini
+++ b/Data/Sys/GameSettings/G2T.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/G2V.ini
+++ b/Data/Sys/GameSettings/G2V.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs xfb real for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/G2X.ini
+++ b/Data/Sys/GameSettings/G2X.ini
@@ -17,14 +17,6 @@ EmulationIssues = Everything playable with minor glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/G3A.ini
+++ b/Data/Sys/GameSettings/G3A.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/G3B.ini
+++ b/Data/Sys/GameSettings/G3B.ini
@@ -17,13 +17,5 @@ EmulationIssues = Needs EFB to Ram for transition scenes.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/G3E.ini
+++ b/Data/Sys/GameSettings/G3E.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/G3L.ini
+++ b/Data/Sys/GameSettings/G3L.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/G3Q.ini
+++ b/Data/Sys/GameSettings/G3Q.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/G3R.ini
+++ b/Data/Sys/GameSettings/G3R.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/G3S.ini
+++ b/Data/Sys/GameSettings/G3S.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/G3X.ini
+++ b/Data/Sys/GameSettings/G3X.ini
@@ -18,14 +18,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/G4A.ini
+++ b/Data/Sys/GameSettings/G4A.ini
@@ -20,13 +20,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/G4B.ini
+++ b/Data/Sys/GameSettings/G4B.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/G4F.ini
+++ b/Data/Sys/GameSettings/G4F.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/G4M.ini
+++ b/Data/Sys/GameSettings/G4M.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/G4Q.ini
+++ b/Data/Sys/GameSettings/G4Q.ini
@@ -17,5 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0

--- a/Data/Sys/GameSettings/G4S.ini
+++ b/Data/Sys/GameSettings/G4S.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/G4Z.ini
+++ b/Data/Sys/GameSettings/G4Z.ini
@@ -9,11 +9,4 @@ EmulationIssues =
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Gecko]

--- a/Data/Sys/GameSettings/G5D.ini
+++ b/Data/Sys/GameSettings/G5D.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/G5N.ini
+++ b/Data/Sys/GameSettings/G5N.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/G5S.ini
+++ b/Data/Sys/GameSettings/G5S.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs efb to Ram for proper lighting.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/G5T.ini
+++ b/Data/Sys/GameSettings/G5T.ini
@@ -17,13 +17,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/G6N.ini
+++ b/Data/Sys/GameSettings/G6N.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/G6T.ini
+++ b/Data/Sys/GameSettings/G6T.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/G6W.ini
+++ b/Data/Sys/GameSettings/G6W.ini
@@ -17,13 +17,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/G8F.ini
+++ b/Data/Sys/GameSettings/G8F.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/G9S.ini
+++ b/Data/Sys/GameSettings/G9S.ini
@@ -17,14 +17,6 @@ EmulationIssues = Use directx11 backend with efb scale set at 1x to deal with bl
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2

--- a/Data/Sys/GameSettings/G9T.ini
+++ b/Data/Sys/GameSettings/G9T.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/GAF.ini
+++ b/Data/Sys/GameSettings/GAF.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GAH.ini
+++ b/Data/Sys/GameSettings/GAH.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GAL.ini
+++ b/Data/Sys/GameSettings/GAL.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/GALP01.ini
+++ b/Data/Sys/GameSettings/GALP01.ini
@@ -351,13 +351,5 @@ EC210032 C0010034
 EC210024 39C00000
 281E0000 00000000
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1

--- a/Data/Sys/GameSettings/GAR.ini
+++ b/Data/Sys/GameSettings/GAR.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GAU.ini
+++ b/Data/Sys/GameSettings/GAU.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GAV.ini
+++ b/Data/Sys/GameSettings/GAV.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GAX.ini
+++ b/Data/Sys/GameSettings/GAX.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GAZ.ini
+++ b/Data/Sys/GameSettings/GAZ.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GB4.ini
+++ b/Data/Sys/GameSettings/GB4.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GBG.ini
+++ b/Data/Sys/GameSettings/GBG.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GBH.ini
+++ b/Data/Sys/GameSettings/GBH.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GBI.ini
+++ b/Data/Sys/GameSettings/GBI.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/GBL.ini
+++ b/Data/Sys/GameSettings/GBL.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GBM.ini
+++ b/Data/Sys/GameSettings/GBM.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GBO.ini
+++ b/Data/Sys/GameSettings/GBO.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GBS.ini
+++ b/Data/Sys/GameSettings/GBS.ini
@@ -18,14 +18,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 FastDepthCalc = False
 

--- a/Data/Sys/GameSettings/GBV.ini
+++ b/Data/Sys/GameSettings/GBV.ini
@@ -18,14 +18,6 @@ EmulationIssues = Needs Real xfb for videos to display. Slow audio with HLE.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GBW.ini
+++ b/Data/Sys/GameSettings/GBW.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GBZ.ini
+++ b/Data/Sys/GameSettings/GBZ.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GC3.ini
+++ b/Data/Sys/GameSettings/GC3.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GC6.ini
+++ b/Data/Sys/GameSettings/GC6.ini
@@ -17,14 +17,6 @@ EmulationIssues = If EFB scale is not integral, serious texture glitches occur.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/GCC.ini
+++ b/Data/Sys/GameSettings/GCC.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GCE.ini
+++ b/Data/Sys/GameSettings/GCE.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = Needs real xfb for the videos to display.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GCI.ini
+++ b/Data/Sys/GameSettings/GCI.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Gecko]
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/GCJ.ini
+++ b/Data/Sys/GameSettings/GCJ.ini
@@ -5,11 +5,3 @@ EmulationStateId = 3
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-

--- a/Data/Sys/GameSettings/GCN.ini
+++ b/Data/Sys/GameSettings/GCN.ini
@@ -16,14 +16,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GCP.ini
+++ b/Data/Sys/GameSettings/GCP.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to appear.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GCV.ini
+++ b/Data/Sys/GameSettings/GCV.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GCZ.ini
+++ b/Data/Sys/GameSettings/GCZ.ini
@@ -17,14 +17,6 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GDG.ini
+++ b/Data/Sys/GameSettings/GDG.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GDJ.ini
+++ b/Data/Sys/GameSettings/GDJ.ini
@@ -17,6 +17,3 @@ EmulationIssues = Screen Blinking unless you enable use real efb
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GDS.ini
+++ b/Data/Sys/GameSettings/GDS.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GE3.ini
+++ b/Data/Sys/GameSettings/GE3.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/GE4.ini
+++ b/Data/Sys/GameSettings/GE4.ini
@@ -18,5 +18,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-
-

--- a/Data/Sys/GameSettings/GEA.ini
+++ b/Data/Sys/GameSettings/GEA.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GED.ini
+++ b/Data/Sys/GameSettings/GED.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GEN.ini
+++ b/Data/Sys/GameSettings/GEN.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GEO.ini
+++ b/Data/Sys/GameSettings/GEO.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GEY.ini
+++ b/Data/Sys/GameSettings/GEY.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GEZ.ini
+++ b/Data/Sys/GameSettings/GEZ.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GF4.ini
+++ b/Data/Sys/GameSettings/GF4.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GF5.ini
+++ b/Data/Sys/GameSettings/GF5.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GF6.ini
+++ b/Data/Sys/GameSettings/GF6.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GF7.ini
+++ b/Data/Sys/GameSettings/GF7.ini
@@ -18,14 +18,6 @@ EmulationIssues = EFB must be an integer (integral, 1x, 2x, 3x).
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/GF8.ini
+++ b/Data/Sys/GameSettings/GF8.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GFA.ini
+++ b/Data/Sys/GameSettings/GFA.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GFD.ini
+++ b/Data/Sys/GameSettings/GFD.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GFF.ini
+++ b/Data/Sys/GameSettings/GFF.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GFH.ini
+++ b/Data/Sys/GameSettings/GFH.ini
@@ -18,6 +18,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GFT.ini
+++ b/Data/Sys/GameSettings/GFT.ini
@@ -17,5 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0

--- a/Data/Sys/GameSettings/GFY.ini
+++ b/Data/Sys/GameSettings/GFY.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GFZ.ini
+++ b/Data/Sys/GameSettings/GFZ.ini
@@ -19,11 +19,3 @@ EmulationIssues = Needs Synchronize GPU thread for stability.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-

--- a/Data/Sys/GameSettings/GFZJ8P.ini
+++ b/Data/Sys/GameSettings/GFZJ8P.ini
@@ -19,11 +19,3 @@ EmulationIssues = Crashes on startup (Triforce game)
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-

--- a/Data/Sys/GameSettings/GG5.ini
+++ b/Data/Sys/GameSettings/GG5.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GGCOSD.ini
+++ b/Data/Sys/GameSettings/GGCOSD.ini
@@ -18,6 +18,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GGE.ini
+++ b/Data/Sys/GameSettings/GGE.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GGN.ini
+++ b/Data/Sys/GameSettings/GGN.ini
@@ -17,9 +17,6 @@ EmulationIssues = Needs real xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GGR.ini
+++ b/Data/Sys/GameSettings/GGR.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb to show videos. Graphic glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GGS.ini
+++ b/Data/Sys/GameSettings/GGS.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GGV.ini
+++ b/Data/Sys/GameSettings/GGV.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = Needs real xfb for the videos to display.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Gecko]
 [Video_Settings]
 UseXFB = True

--- a/Data/Sys/GameSettings/GGY.ini
+++ b/Data/Sys/GameSettings/GGY.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real XFB for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GGZ.ini
+++ b/Data/Sys/GameSettings/GGZ.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/GH2.ini
+++ b/Data/Sys/GameSettings/GH2.ini
@@ -17,14 +17,6 @@ EmulationIssues = The game is slow.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GH4.ini
+++ b/Data/Sys/GameSettings/GH4.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GH5.ini
+++ b/Data/Sys/GameSettings/GH5.ini
@@ -9,10 +9,3 @@ EmulationIssues =
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 

--- a/Data/Sys/GameSettings/GH7.ini
+++ b/Data/Sys/GameSettings/GH7.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GHB.ini
+++ b/Data/Sys/GameSettings/GHB.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GHC.ini
+++ b/Data/Sys/GameSettings/GHC.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GHL.ini
+++ b/Data/Sys/GameSettings/GHL.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GHM.ini
+++ b/Data/Sys/GameSettings/GHM.ini
@@ -17,11 +17,3 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GHQ.ini
+++ b/Data/Sys/GameSettings/GHQ.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GHS.ini
+++ b/Data/Sys/GameSettings/GHS.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb for videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GHY.ini
+++ b/Data/Sys/GameSettings/GHY.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GIL.ini
+++ b/Data/Sys/GameSettings/GIL.ini
@@ -18,14 +18,6 @@ EmulationIssues = Slow audio with HLE.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GIQ.ini
+++ b/Data/Sys/GameSettings/GIQ.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GIS.ini
+++ b/Data/Sys/GameSettings/GIS.ini
@@ -18,6 +18,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GIT.ini
+++ b/Data/Sys/GameSettings/GIT.ini
@@ -17,11 +17,3 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GJB.ini
+++ b/Data/Sys/GameSettings/GJB.ini
@@ -17,14 +17,6 @@ EmulationIssues = Videos need Real XFB to show up. Graphic glitches / unstable d
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 UseXFB = True

--- a/Data/Sys/GameSettings/GJU.ini
+++ b/Data/Sys/GameSettings/GJU.ini
@@ -17,6 +17,3 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GJW.ini
+++ b/Data/Sys/GameSettings/GJW.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GJX.ini
+++ b/Data/Sys/GameSettings/GJX.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GJZ.ini
+++ b/Data/Sys/GameSettings/GJZ.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GK2.ini
+++ b/Data/Sys/GameSettings/GK2.ini
@@ -11,13 +11,5 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GK4.ini
+++ b/Data/Sys/GameSettings/GK4.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GK5.ini
+++ b/Data/Sys/GameSettings/GK5.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GK7.ini
+++ b/Data/Sys/GameSettings/GK7.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBAccessEnable = True
 

--- a/Data/Sys/GameSettings/GK9.ini
+++ b/Data/Sys/GameSettings/GK9.ini
@@ -17,11 +17,3 @@ EmulationIssues = Needs Microphone set in a gamecube pad slot to play this game.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GKB.ini
+++ b/Data/Sys/GameSettings/GKB.ini
@@ -18,14 +18,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBAccessEnable = False
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GKL.ini
+++ b/Data/Sys/GameSettings/GKL.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GKM.ini
+++ b/Data/Sys/GameSettings/GKM.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GKO.ini
+++ b/Data/Sys/GameSettings/GKO.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GKQ.ini
+++ b/Data/Sys/GameSettings/GKQ.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GKU.ini
+++ b/Data/Sys/GameSettings/GKU.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GKY.ini
+++ b/Data/Sys/GameSettings/GKY.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 

--- a/Data/Sys/GameSettings/GL8.ini
+++ b/Data/Sys/GameSettings/GL8.ini
@@ -17,11 +17,3 @@ EmulationIssues = Sound little crappy
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GLC.ini
+++ b/Data/Sys/GameSettings/GLC.ini
@@ -19,14 +19,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 DstAlphaPass = True

--- a/Data/Sys/GameSettings/GLM.ini
+++ b/Data/Sys/GameSettings/GLM.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Stereoscopy]
 StereoEFBMonoDepth = True

--- a/Data/Sys/GameSettings/GLN.ini
+++ b/Data/Sys/GameSettings/GLN.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GLS.ini
+++ b/Data/Sys/GameSettings/GLS.ini
@@ -18,14 +18,6 @@ EmulationIssues = Needs Real Xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GLW.ini
+++ b/Data/Sys/GameSettings/GLW.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GLY.ini
+++ b/Data/Sys/GameSettings/GLY.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GM2.ini
+++ b/Data/Sys/GameSettings/GM2.ini
@@ -18,13 +18,5 @@ EmulationIssues = Shadows need fast depth enabled.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 FastDepthCalc = True

--- a/Data/Sys/GameSettings/GM4.ini
+++ b/Data/Sys/GameSettings/GM4.ini
@@ -17,10 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =

--- a/Data/Sys/GameSettings/GM5.ini
+++ b/Data/Sys/GameSettings/GM5.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GM6.ini
+++ b/Data/Sys/GameSettings/GM6.ini
@@ -17,13 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/GM8.ini
+++ b/Data/Sys/GameSettings/GM8.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GMB.ini
+++ b/Data/Sys/GameSettings/GMB.ini
@@ -18,6 +18,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GMH.ini
+++ b/Data/Sys/GameSettings/GMH.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real Xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GMI.ini
+++ b/Data/Sys/GameSettings/GMI.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GMN.ini
+++ b/Data/Sys/GameSettings/GMN.ini
@@ -18,14 +18,6 @@ EmulationIssues = Videos require real XFB, slow audio with HLE.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GMP.ini
+++ b/Data/Sys/GameSettings/GMP.ini
@@ -17,5 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0

--- a/Data/Sys/GameSettings/GMX.ini
+++ b/Data/Sys/GameSettings/GMX.ini
@@ -17,9 +17,6 @@ EmulationIssues = Needs real xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/GN4.ini
+++ b/Data/Sys/GameSettings/GN4.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for the videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GN5.ini
+++ b/Data/Sys/GameSettings/GN5.ini
@@ -17,10 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =

--- a/Data/Sys/GameSettings/GN6.ini
+++ b/Data/Sys/GameSettings/GN6.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GN8.ini
+++ b/Data/Sys/GameSettings/GN8.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GNH.ini
+++ b/Data/Sys/GameSettings/GNH.ini
@@ -18,8 +18,5 @@ EmulationIssues = Slow audio with HLE.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [DSP]
 EnableJIT = True

--- a/Data/Sys/GameSettings/GNI.ini
+++ b/Data/Sys/GameSettings/GNI.ini
@@ -5,11 +5,4 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Gecko]

--- a/Data/Sys/GameSettings/GNJ.ini
+++ b/Data/Sys/GameSettings/GNJ.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GNL.ini
+++ b/Data/Sys/GameSettings/GNL.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GNM.ini
+++ b/Data/Sys/GameSettings/GNM.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/GNN.ini
+++ b/Data/Sys/GameSettings/GNN.ini
@@ -17,9 +17,6 @@ EmulationIssues = Needs real xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 UseXFB = True

--- a/Data/Sys/GameSettings/GNU.ini
+++ b/Data/Sys/GameSettings/GNU.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GNW.ini
+++ b/Data/Sys/GameSettings/GNW.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GOA.ini
+++ b/Data/Sys/GameSettings/GOA.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GOO.ini
+++ b/Data/Sys/GameSettings/GOO.ini
@@ -17,6 +17,3 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GOS.ini
+++ b/Data/Sys/GameSettings/GOS.ini
@@ -18,11 +18,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GOW.ini
+++ b/Data/Sys/GameSettings/GOW.ini
@@ -18,11 +18,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GOY.ini
+++ b/Data/Sys/GameSettings/GOY.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GP2.ini
+++ b/Data/Sys/GameSettings/GP2.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for the videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GP5.ini
+++ b/Data/Sys/GameSettings/GP5.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/GP6.ini
+++ b/Data/Sys/GameSettings/GP6.ini
@@ -17,14 +17,6 @@ EmulationIssues = Mini games tour bus needs emulate format changes to preview th
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 

--- a/Data/Sys/GameSettings/GP7.ini
+++ b/Data/Sys/GameSettings/GP7.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/GP8.ini
+++ b/Data/Sys/GameSettings/GP8.ini
@@ -18,13 +18,5 @@ EmulationIssues = Slow audio with HLE.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [DSP]
 EnableJIT = True

--- a/Data/Sys/GameSettings/GPA.ini
+++ b/Data/Sys/GameSettings/GPA.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Efb to Ram for painting.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/GPH.ini
+++ b/Data/Sys/GameSettings/GPH.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GPI.ini
+++ b/Data/Sys/GameSettings/GPI.ini
@@ -17,5 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0

--- a/Data/Sys/GameSettings/GPK.ini
+++ b/Data/Sys/GameSettings/GPK.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb for videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GPO.ini
+++ b/Data/Sys/GameSettings/GPO.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GPS.ini
+++ b/Data/Sys/GameSettings/GPS.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb for the videos to display. D3D11 has issues.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GPT.ini
+++ b/Data/Sys/GameSettings/GPT.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GPV.ini
+++ b/Data/Sys/GameSettings/GPV.ini
@@ -17,10 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =

--- a/Data/Sys/GameSettings/GPZ.ini
+++ b/Data/Sys/GameSettings/GPZ.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GQC.ini
+++ b/Data/Sys/GameSettings/GQC.ini
@@ -10,10 +10,3 @@ EmulationStateId = 4
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 

--- a/Data/Sys/GameSettings/GQQ.ini
+++ b/Data/Sys/GameSettings/GQQ.ini
@@ -5,11 +5,4 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Gecko]

--- a/Data/Sys/GameSettings/GQS.ini
+++ b/Data/Sys/GameSettings/GQS.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 0.5
-PH_ZFar = 1
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GQT.ini
+++ b/Data/Sys/GameSettings/GQT.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GQW.ini
+++ b/Data/Sys/GameSettings/GQW.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GR8.ini
+++ b/Data/Sys/GameSettings/GR8.ini
@@ -9,10 +9,3 @@ EmulationIssues =
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 

--- a/Data/Sys/GameSettings/GRB.ini
+++ b/Data/Sys/GameSettings/GRB.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GRE.ini
+++ b/Data/Sys/GameSettings/GRE.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GRH.ini
+++ b/Data/Sys/GameSettings/GRH.ini
@@ -16,14 +16,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GRJ.ini
+++ b/Data/Sys/GameSettings/GRJ.ini
@@ -17,8 +17,5 @@ EmulationIssues = Efb to Ram is needed for video cutscenes.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GRK.ini
+++ b/Data/Sys/GameSettings/GRK.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GRQ.ini
+++ b/Data/Sys/GameSettings/GRQ.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real XFB for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GRS.ini
+++ b/Data/Sys/GameSettings/GRS.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GRU.ini
+++ b/Data/Sys/GameSettings/GRU.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GRY.ini
+++ b/Data/Sys/GameSettings/GRY.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb for videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GS2.ini
+++ b/Data/Sys/GameSettings/GS2.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GSA.ini
+++ b/Data/Sys/GameSettings/GSA.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GSO.ini
+++ b/Data/Sys/GameSettings/GSO.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GSQ.ini
+++ b/Data/Sys/GameSettings/GSQ.ini
@@ -5,13 +5,6 @@ EmulationStateId = 3
 EmulationIssues = Needs real xfb for the videos to display.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Gecko]
 [Video_Settings]
 UseXFB = True

--- a/Data/Sys/GameSettings/GSS.ini
+++ b/Data/Sys/GameSettings/GSS.ini
@@ -17,14 +17,6 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GSZ.ini
+++ b/Data/Sys/GameSettings/GSZ.ini
@@ -18,13 +18,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 BBoxEnable = True

--- a/Data/Sys/GameSettings/GT6.ini
+++ b/Data/Sys/GameSettings/GT6.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/GT7.ini
+++ b/Data/Sys/GameSettings/GT7.ini
@@ -17,14 +17,6 @@ EmulationIssues = Videos need real XFB to show up and loading screens show garba
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GTF.ini
+++ b/Data/Sys/GameSettings/GTF.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GTK.ini
+++ b/Data/Sys/GameSettings/GTK.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GTL.ini
+++ b/Data/Sys/GameSettings/GTL.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-

--- a/Data/Sys/GameSettings/GTO.ini
+++ b/Data/Sys/GameSettings/GTO.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 0.5
-PH_ZFar = 1
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GTR.ini
+++ b/Data/Sys/GameSettings/GTR.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = Needs real xfb for the videos to display.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GTS.ini
+++ b/Data/Sys/GameSettings/GTS.ini
@@ -17,11 +17,3 @@ EmulationIssues = Can Crash on some systems (unknown)
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GTW.ini
+++ b/Data/Sys/GameSettings/GTW.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GTY.ini
+++ b/Data/Sys/GameSettings/GTY.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GTZ.ini
+++ b/Data/Sys/GameSettings/GTZ.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real Xfb for videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GUB.ini
+++ b/Data/Sys/GameSettings/GUB.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GUM.ini
+++ b/Data/Sys/GameSettings/GUM.ini
@@ -18,11 +18,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GUN.ini
+++ b/Data/Sys/GameSettings/GUN.ini
@@ -17,8 +17,5 @@ EmulationIssues = Needs safe texture cache for videos.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/GUP.ini
+++ b/Data/Sys/GameSettings/GUP.ini
@@ -17,8 +17,5 @@ EmulationIssues = 2P mode is playable only with EFB to RAM.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GUT.ini
+++ b/Data/Sys/GameSettings/GUT.ini
@@ -18,14 +18,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GUZ.ini
+++ b/Data/Sys/GameSettings/GUZ.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real XFB for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseRealXFB = True
 UseXFB = True

--- a/Data/Sys/GameSettings/GV4.ini
+++ b/Data/Sys/GameSettings/GV4.ini
@@ -17,11 +17,3 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GVC.ini
+++ b/Data/Sys/GameSettings/GVC.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GVJ.ini
+++ b/Data/Sys/GameSettings/GVJ.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GVK.ini
+++ b/Data/Sys/GameSettings/GVK.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GVO.ini
+++ b/Data/Sys/GameSettings/GVO.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GW2.ini
+++ b/Data/Sys/GameSettings/GW2.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Efb to Ram for created fighters.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/GW7.ini
+++ b/Data/Sys/GameSettings/GW7.ini
@@ -17,9 +17,6 @@ EmulationIssues = Needs real xfb for the video cutscenes to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GW8.ini
+++ b/Data/Sys/GameSettings/GW8.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GWA.ini
+++ b/Data/Sys/GameSettings/GWA.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GWB.ini
+++ b/Data/Sys/GameSettings/GWB.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GWJ.ini
+++ b/Data/Sys/GameSettings/GWJ.ini
@@ -16,10 +16,3 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 

--- a/Data/Sys/GameSettings/GWO.ini
+++ b/Data/Sys/GameSettings/GWO.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = 1
 

--- a/Data/Sys/GameSettings/GWP.ini
+++ b/Data/Sys/GameSettings/GWP.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Efb to Ram for created fighters.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/GWQ.ini
+++ b/Data/Sys/GameSettings/GWQ.ini
@@ -17,6 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GWR.ini
+++ b/Data/Sys/GameSettings/GWR.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GWRE01.ini
+++ b/Data/Sys/GameSettings/GWRE01.ini
@@ -29,11 +29,3 @@ $Stunt mode: Freeze timer at 65"00
 $Have 99 Points (1P Mode)
 00632B43 00000063
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GWV.ini
+++ b/Data/Sys/GameSettings/GWV.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GWW.ini
+++ b/Data/Sys/GameSettings/GWW.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GX2.ini
+++ b/Data/Sys/GameSettings/GX2.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GX3.ini
+++ b/Data/Sys/GameSettings/GX3.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for the videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GXB.ini
+++ b/Data/Sys/GameSettings/GXB.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBAccessEnable = False
 

--- a/Data/Sys/GameSettings/GXC.ini
+++ b/Data/Sys/GameSettings/GXC.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GXF.ini
+++ b/Data/Sys/GameSettings/GXF.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GXG.ini
+++ b/Data/Sys/GameSettings/GXG.ini
@@ -9,12 +9,5 @@ EmulationIssues =
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/GXL.ini
+++ b/Data/Sys/GameSettings/GXL.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GXM.ini
+++ b/Data/Sys/GameSettings/GXM.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GXN.ini
+++ b/Data/Sys/GameSettings/GXN.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GXO.ini
+++ b/Data/Sys/GameSettings/GXO.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GXS.ini
+++ b/Data/Sys/GameSettings/GXS.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/GXX.ini
+++ b/Data/Sys/GameSettings/GXX.ini
@@ -17,14 +17,6 @@ EmulationIssues = HLE music fades in and out. If EFB scale is not integral, 1x, 
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/GYF.ini
+++ b/Data/Sys/GameSettings/GYF.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GYK.ini
+++ b/Data/Sys/GameSettings/GYK.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/GYW.ini
+++ b/Data/Sys/GameSettings/GYW.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/GZ2.ini
+++ b/Data/Sys/GameSettings/GZ2.ini
@@ -17,10 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =

--- a/Data/Sys/GameSettings/GZD.ini
+++ b/Data/Sys/GameSettings/GZD.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Gecko]
 [Video_Hacks]
 EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/GZE.ini
+++ b/Data/Sys/GameSettings/GZE.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/GZL.ini
+++ b/Data/Sys/GameSettings/GZL.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBAccessEnable = True
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/GZP.ini
+++ b/Data/Sys/GameSettings/GZP.ini
@@ -18,14 +18,6 @@ EmulationIssues = Needs real xfb for the videos to display. Slow audio with HLE.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/GZW.ini
+++ b/Data/Sys/GameSettings/GZW.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 EFBScale = -1

--- a/Data/Sys/GameSettings/HAA.ini
+++ b/Data/Sys/GameSettings/HAA.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/HAC.ini
+++ b/Data/Sys/GameSettings/HAC.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/HAD.ini
+++ b/Data/Sys/GameSettings/HAD.ini
@@ -17,7 +17,4 @@ EmulationIssues = If using a hard drive, low FPS on first run while save data is
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]

--- a/Data/Sys/GameSettings/HAW.ini
+++ b/Data/Sys/GameSettings/HAW.ini
@@ -17,6 +17,3 @@ EmulationIssues = Uses WiiConnect24
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/HAX.ini
+++ b/Data/Sys/GameSettings/HAX.ini
@@ -17,6 +17,3 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/HAY.ini
+++ b/Data/Sys/GameSettings/HAY.ini
@@ -17,7 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-Hack = 0
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/JA4.ini
+++ b/Data/Sys/GameSettings/JA4.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JA6.ini
+++ b/Data/Sys/GameSettings/JA6.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JA7.ini
+++ b/Data/Sys/GameSettings/JA7.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/JA8.ini
+++ b/Data/Sys/GameSettings/JA8.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAA.ini
+++ b/Data/Sys/GameSettings/JAA.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAC.ini
+++ b/Data/Sys/GameSettings/JAC.ini
@@ -18,9 +18,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/JAD.ini
+++ b/Data/Sys/GameSettings/JAD.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAE.ini
+++ b/Data/Sys/GameSettings/JAE.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/JAF.ini
+++ b/Data/Sys/GameSettings/JAF.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAH.ini
+++ b/Data/Sys/GameSettings/JAH.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAI.ini
+++ b/Data/Sys/GameSettings/JAI.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAJ.ini
+++ b/Data/Sys/GameSettings/JAJ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAL.ini
+++ b/Data/Sys/GameSettings/JAL.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/JAM.ini
+++ b/Data/Sys/GameSettings/JAM.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAV.ini
+++ b/Data/Sys/GameSettings/JAV.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAW.ini
+++ b/Data/Sys/GameSettings/JAW.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JAZ.ini
+++ b/Data/Sys/GameSettings/JAZ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JB3.ini
+++ b/Data/Sys/GameSettings/JB3.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JBA.ini
+++ b/Data/Sys/GameSettings/JBA.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/JBB.ini
+++ b/Data/Sys/GameSettings/JBB.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JBC.ini
+++ b/Data/Sys/GameSettings/JBC.ini
@@ -11,14 +11,6 @@ EmulationIssues = Needs progressive scan for proper speed.
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/JBD.ini
+++ b/Data/Sys/GameSettings/JBD.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JBI.ini
+++ b/Data/Sys/GameSettings/JBI.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JBK.ini
+++ b/Data/Sys/GameSettings/JBK.ini
@@ -11,14 +11,6 @@ EmulationIssues = Needs progressive scan for proper speed.
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/JBL.ini
+++ b/Data/Sys/GameSettings/JBL.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JBP.ini
+++ b/Data/Sys/GameSettings/JBP.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JBQ.ini
+++ b/Data/Sys/GameSettings/JBQ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/JBR.ini
+++ b/Data/Sys/GameSettings/JBR.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JBS.ini
+++ b/Data/Sys/GameSettings/JBS.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/JBT.ini
+++ b/Data/Sys/GameSettings/JBT.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JBU.ini
+++ b/Data/Sys/GameSettings/JBU.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/JBW.ini
+++ b/Data/Sys/GameSettings/JBW.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JBY.ini
+++ b/Data/Sys/GameSettings/JBY.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JC4.ini
+++ b/Data/Sys/GameSettings/JC4.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JC7.ini
+++ b/Data/Sys/GameSettings/JC7.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JC8.ini
+++ b/Data/Sys/GameSettings/JC8.ini
@@ -11,14 +11,6 @@ EmulationIssues = Needs progressive scan for proper speed.
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/JCA.ini
+++ b/Data/Sys/GameSettings/JCA.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JCB.ini
+++ b/Data/Sys/GameSettings/JCB.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JCC.ini
+++ b/Data/Sys/GameSettings/JCC.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JCD.ini
+++ b/Data/Sys/GameSettings/JCD.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/JCJ.ini
+++ b/Data/Sys/GameSettings/JCJ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JCK.ini
+++ b/Data/Sys/GameSettings/JCK.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JCL.ini
+++ b/Data/Sys/GameSettings/JCL.ini
@@ -11,14 +11,6 @@ EmulationIssues = Needs progressive scan for proper speed.
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/JCN.ini
+++ b/Data/Sys/GameSettings/JCN.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JCT.ini
+++ b/Data/Sys/GameSettings/JCT.ini
@@ -11,14 +11,6 @@ EmulationIssues = Needs progressive scan for proper speed.
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/JCV.ini
+++ b/Data/Sys/GameSettings/JCV.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JCW.ini
+++ b/Data/Sys/GameSettings/JCW.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JCX.ini
+++ b/Data/Sys/GameSettings/JCX.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/JCY.ini
+++ b/Data/Sys/GameSettings/JCY.ini
@@ -11,14 +11,6 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/JCZ.ini
+++ b/Data/Sys/GameSettings/JCZ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDA.ini
+++ b/Data/Sys/GameSettings/JDA.ini
@@ -11,14 +11,6 @@ EmulationIssues = Needs progressive scan for proper speed.
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/JDC.ini
+++ b/Data/Sys/GameSettings/JDC.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDD.ini
+++ b/Data/Sys/GameSettings/JDD.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDE.ini
+++ b/Data/Sys/GameSettings/JDE.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDI.ini
+++ b/Data/Sys/GameSettings/JDI.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDJ.ini
+++ b/Data/Sys/GameSettings/JDJ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDL.ini
+++ b/Data/Sys/GameSettings/JDL.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDN.ini
+++ b/Data/Sys/GameSettings/JDN.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDV.ini
+++ b/Data/Sys/GameSettings/JDV.ini
@@ -11,14 +11,6 @@ EmulationIssues = Needs progressive scan for proper speed.
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/JDW.ini
+++ b/Data/Sys/GameSettings/JDW.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDX.ini
+++ b/Data/Sys/GameSettings/JDX.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JDZ.ini
+++ b/Data/Sys/GameSettings/JDZ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JEB.ini
+++ b/Data/Sys/GameSettings/JEB.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/JEC.ini
+++ b/Data/Sys/GameSettings/JEC.ini
@@ -11,14 +11,6 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/JEH.ini
+++ b/Data/Sys/GameSettings/JEH.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/LAB.ini
+++ b/Data/Sys/GameSettings/LAB.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/LAC.ini
+++ b/Data/Sys/GameSettings/LAC.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/LAD.ini
+++ b/Data/Sys/GameSettings/LAD.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/LAE.ini
+++ b/Data/Sys/GameSettings/LAE.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/LAF.ini
+++ b/Data/Sys/GameSettings/LAF.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/LAG.ini
+++ b/Data/Sys/GameSettings/LAG.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/LAI.ini
+++ b/Data/Sys/GameSettings/LAI.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/LAJ.ini
+++ b/Data/Sys/GameSettings/LAJ.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/LAK.ini
+++ b/Data/Sys/GameSettings/LAK.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/LAL.ini
+++ b/Data/Sys/GameSettings/LAL.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/LAM.ini
+++ b/Data/Sys/GameSettings/LAM.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/LAN.ini
+++ b/Data/Sys/GameSettings/LAN.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/LAO.ini
+++ b/Data/Sys/GameSettings/LAO.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/LAP.ini
+++ b/Data/Sys/GameSettings/LAP.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/LAQ.ini
+++ b/Data/Sys/GameSettings/LAQ.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/MA3.ini
+++ b/Data/Sys/GameSettings/MA3.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MA6.ini
+++ b/Data/Sys/GameSettings/MA6.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MA7.ini
+++ b/Data/Sys/GameSettings/MA7.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MA8.ini
+++ b/Data/Sys/GameSettings/MA8.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAA.ini
+++ b/Data/Sys/GameSettings/MAA.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAB.ini
+++ b/Data/Sys/GameSettings/MAB.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAC.ini
+++ b/Data/Sys/GameSettings/MAC.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAD.ini
+++ b/Data/Sys/GameSettings/MAD.ini
@@ -17,8 +17,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAE.ini
+++ b/Data/Sys/GameSettings/MAE.ini
@@ -17,8 +17,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAF.ini
+++ b/Data/Sys/GameSettings/MAF.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAG.ini
+++ b/Data/Sys/GameSettings/MAG.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAH.ini
+++ b/Data/Sys/GameSettings/MAH.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAI.ini
+++ b/Data/Sys/GameSettings/MAI.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAJ.ini
+++ b/Data/Sys/GameSettings/MAJ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAL.ini
+++ b/Data/Sys/GameSettings/MAL.ini
@@ -17,8 +17,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAM.ini
+++ b/Data/Sys/GameSettings/MAM.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAN.ini
+++ b/Data/Sys/GameSettings/MAN.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAO.ini
+++ b/Data/Sys/GameSettings/MAO.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAP.ini
+++ b/Data/Sys/GameSettings/MAP.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAQ.ini
+++ b/Data/Sys/GameSettings/MAQ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAR.ini
+++ b/Data/Sys/GameSettings/MAR.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAS.ini
+++ b/Data/Sys/GameSettings/MAS.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAT.ini
+++ b/Data/Sys/GameSettings/MAT.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAV.ini
+++ b/Data/Sys/GameSettings/MAV.ini
@@ -17,8 +17,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAW.ini
+++ b/Data/Sys/GameSettings/MAW.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAX.ini
+++ b/Data/Sys/GameSettings/MAX.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAY.ini
+++ b/Data/Sys/GameSettings/MAY.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MAZ.ini
+++ b/Data/Sys/GameSettings/MAZ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MB6.ini
+++ b/Data/Sys/GameSettings/MB6.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MB7.ini
+++ b/Data/Sys/GameSettings/MB7.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MB8.ini
+++ b/Data/Sys/GameSettings/MB8.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBB.ini
+++ b/Data/Sys/GameSettings/MBB.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBC.ini
+++ b/Data/Sys/GameSettings/MBC.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBD.ini
+++ b/Data/Sys/GameSettings/MBD.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBE.ini
+++ b/Data/Sys/GameSettings/MBE.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBF.ini
+++ b/Data/Sys/GameSettings/MBF.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBG.ini
+++ b/Data/Sys/GameSettings/MBG.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBI.ini
+++ b/Data/Sys/GameSettings/MBI.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBJ.ini
+++ b/Data/Sys/GameSettings/MBJ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBK.ini
+++ b/Data/Sys/GameSettings/MBK.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBL.ini
+++ b/Data/Sys/GameSettings/MBL.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBM.ini
+++ b/Data/Sys/GameSettings/MBM.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBO.ini
+++ b/Data/Sys/GameSettings/MBO.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBP.ini
+++ b/Data/Sys/GameSettings/MBP.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBQ.ini
+++ b/Data/Sys/GameSettings/MBQ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBR.ini
+++ b/Data/Sys/GameSettings/MBR.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBT.ini
+++ b/Data/Sys/GameSettings/MBT.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBU.ini
+++ b/Data/Sys/GameSettings/MBU.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBW.ini
+++ b/Data/Sys/GameSettings/MBW.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBX.ini
+++ b/Data/Sys/GameSettings/MBX.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBY.ini
+++ b/Data/Sys/GameSettings/MBY.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MBZ.ini
+++ b/Data/Sys/GameSettings/MBZ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCA.ini
+++ b/Data/Sys/GameSettings/MCA.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCB.ini
+++ b/Data/Sys/GameSettings/MCB.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCC.ini
+++ b/Data/Sys/GameSettings/MCC.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCD.ini
+++ b/Data/Sys/GameSettings/MCD.ini
@@ -17,10 +17,6 @@ EmulationStateId = 2
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-# Add memory patches to be applied every frame here.
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/MCE.ini
+++ b/Data/Sys/GameSettings/MCE.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCG.ini
+++ b/Data/Sys/GameSettings/MCG.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCH.ini
+++ b/Data/Sys/GameSettings/MCH.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCJ.ini
+++ b/Data/Sys/GameSettings/MCJ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCK.ini
+++ b/Data/Sys/GameSettings/MCK.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCL.ini
+++ b/Data/Sys/GameSettings/MCL.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCP.ini
+++ b/Data/Sys/GameSettings/MCP.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCQ.ini
+++ b/Data/Sys/GameSettings/MCQ.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/MCR.ini
+++ b/Data/Sys/GameSettings/MCR.ini
@@ -18,8 +18,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/NAB.ini
+++ b/Data/Sys/GameSettings/NAB.ini
@@ -9,13 +9,5 @@ EmulationStateId = 4
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-Hack = -1
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/NAC.ini
+++ b/Data/Sys/GameSettings/NAC.ini
@@ -17,6 +17,3 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/NAE.ini
+++ b/Data/Sys/GameSettings/NAE.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 FastDepthCalc = True
 

--- a/Data/Sys/GameSettings/NAF.ini
+++ b/Data/Sys/GameSettings/NAF.ini
@@ -17,8 +17,5 @@ EmulationIssues = Needs EFB to Ram to fix a bar of stretched pixels at the botto
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/NAH.ini
+++ b/Data/Sys/GameSettings/NAH.ini
@@ -10,8 +10,5 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/PC6.ini
+++ b/Data/Sys/GameSettings/PC6.ini
@@ -17,11 +17,3 @@ EmulationIssues = Menu works but videos do not play, and GCN/GBA emulation is to
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/PM4.ini
+++ b/Data/Sys/GameSettings/PM4.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/R22.ini
+++ b/Data/Sys/GameSettings/R22.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real wiimote and motion plus.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/R2G.ini
+++ b/Data/Sys/GameSettings/R2G.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/R2U.ini
+++ b/Data/Sys/GameSettings/R2U.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/R3B.ini
+++ b/Data/Sys/GameSettings/R3B.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/R3D.ini
+++ b/Data/Sys/GameSettings/R3D.ini
@@ -17,14 +17,6 @@ EmulationIssues = Automatic framelimit is problematic.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/R3M.ini
+++ b/Data/Sys/GameSettings/R3M.ini
@@ -17,14 +17,6 @@ EmulationIssues = Disable PAL60 (EuRGB60) to avoid a black bar appearing.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/R3N.ini
+++ b/Data/Sys/GameSettings/R3N.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/R3O.ini
+++ b/Data/Sys/GameSettings/R3O.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 1
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/R3R.ini
+++ b/Data/Sys/GameSettings/R3R.ini
@@ -9,12 +9,5 @@ EmulationIssues = Use direct 3d 11 for less graphic glitches.
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/R46.ini
+++ b/Data/Sys/GameSettings/R46.ini
@@ -17,6 +17,3 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/R49.ini
+++ b/Data/Sys/GameSettings/R49.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/R4E.ini
+++ b/Data/Sys/GameSettings/R4E.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/R4Q.ini
+++ b/Data/Sys/GameSettings/R4Q.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/R4R.ini
+++ b/Data/Sys/GameSettings/R4R.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/R4Z.ini
+++ b/Data/Sys/GameSettings/R4Z.ini
@@ -18,14 +18,6 @@ EmulationIssues = Anti-aliasing causes control issues with the piano mini-game.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBAccessEnable = True
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/R5D.ini
+++ b/Data/Sys/GameSettings/R5D.ini
@@ -17,3 +17,4 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
+

--- a/Data/Sys/GameSettings/R5I.ini
+++ b/Data/Sys/GameSettings/R5I.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/R5V.ini
+++ b/Data/Sys/GameSettings/R5V.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/R5W.ini
+++ b/Data/Sys/GameSettings/R5W.ini
@@ -17,14 +17,6 @@ EmulationIssues = Flashlight glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/R64.ini
+++ b/Data/Sys/GameSettings/R64.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 

--- a/Data/Sys/GameSettings/R6B.ini
+++ b/Data/Sys/GameSettings/R6B.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Enhancements]
 ForceFiltering = False
 

--- a/Data/Sys/GameSettings/R6T.ini
+++ b/Data/Sys/GameSettings/R6T.ini
@@ -17,8 +17,5 @@ EmulationIssues = Ending credits and images need normal safe texture cache setti
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/R6Y.ini
+++ b/Data/Sys/GameSettings/R6Y.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/R7E.ini
+++ b/Data/Sys/GameSettings/R7E.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/R7F.ini
+++ b/Data/Sys/GameSettings/R7F.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/R7G.ini
+++ b/Data/Sys/GameSettings/R7G.ini
@@ -18,14 +18,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/R7P.ini
+++ b/Data/Sys/GameSettings/R7P.ini
@@ -17,8 +17,5 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/R7X.ini
+++ b/Data/Sys/GameSettings/R7X.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/R84.ini
+++ b/Data/Sys/GameSettings/R84.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/R8A.ini
+++ b/Data/Sys/GameSettings/R8A.ini
@@ -17,14 +17,6 @@ EmulationIssues = NPCs sporadically disappear. Needs Efb to Ram for photos.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/R8D.ini
+++ b/Data/Sys/GameSettings/R8D.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/R8J.ini
+++ b/Data/Sys/GameSettings/R8J.ini
@@ -17,3 +17,4 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
+

--- a/Data/Sys/GameSettings/R8L.ini
+++ b/Data/Sys/GameSettings/R8L.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real XFB in order to be playable.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/R8P.ini
+++ b/Data/Sys/GameSettings/R8P.ini
@@ -17,9 +17,6 @@ EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/R8X.ini
+++ b/Data/Sys/GameSettings/R8X.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/R96.ini
+++ b/Data/Sys/GameSettings/R96.ini
@@ -17,11 +17,3 @@ EmulationIssues = Disable PAL60 (EuRGB60) mode in general settings-> wii tab for
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/R9I.ini
+++ b/Data/Sys/GameSettings/R9I.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RBB.ini
+++ b/Data/Sys/GameSettings/RBB.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RBI.ini
+++ b/Data/Sys/GameSettings/RBI.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/RBM.ini
+++ b/Data/Sys/GameSettings/RBM.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RBR.ini
+++ b/Data/Sys/GameSettings/RBR.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RBU.ini
+++ b/Data/Sys/GameSettings/RBU.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RCJ.ini
+++ b/Data/Sys/GameSettings/RCJ.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Enhancements]
 ForceFiltering = False
 

--- a/Data/Sys/GameSettings/RCL.ini
+++ b/Data/Sys/GameSettings/RCL.ini
@@ -17,9 +17,6 @@ EmulationIssues = Needs real xfb for the video cutscenes to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/RD2.ini
+++ b/Data/Sys/GameSettings/RD2.ini
@@ -17,11 +17,3 @@ EmulationIssues = Needs real wiimote and motion plus.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RDB.ini
+++ b/Data/Sys/GameSettings/RDB.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RDI.ini
+++ b/Data/Sys/GameSettings/RDI.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RDQ.ini
+++ b/Data/Sys/GameSettings/RDQ.ini
@@ -17,10 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =

--- a/Data/Sys/GameSettings/RDS.ini
+++ b/Data/Sys/GameSettings/RDS.ini
@@ -17,9 +17,6 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RDZ.ini
+++ b/Data/Sys/GameSettings/RDZ.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/RE4.ini
+++ b/Data/Sys/GameSettings/RE4.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/RED.ini
+++ b/Data/Sys/GameSettings/RED.ini
@@ -17,11 +17,3 @@ EmulationIssues = Nunchuk doesn't work (both real and emulated).
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/REN.ini
+++ b/Data/Sys/GameSettings/REN.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-

--- a/Data/Sys/GameSettings/RF7.ini
+++ b/Data/Sys/GameSettings/RF7.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RFB.ini
+++ b/Data/Sys/GameSettings/RFB.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs efb to ram for photos to be developed.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/RFC.ini
+++ b/Data/Sys/GameSettings/RFC.ini
@@ -17,9 +17,6 @@ EmulationIssues = Turn off "use panic handlers". Water glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RFE.ini
+++ b/Data/Sys/GameSettings/RFE.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RFF.ini
+++ b/Data/Sys/GameSettings/RFF.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs integral scaling for the black lines to disappear.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/RFS.ini
+++ b/Data/Sys/GameSettings/RFS.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RGH.ini
+++ b/Data/Sys/GameSettings/RGH.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RGL.ini
+++ b/Data/Sys/GameSettings/RGL.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RGQ.ini
+++ b/Data/Sys/GameSettings/RGQ.ini
@@ -17,9 +17,6 @@ EmulationStateId = 0
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Enhancements]
 ForceFiltering = False
 

--- a/Data/Sys/GameSettings/RGV.ini
+++ b/Data/Sys/GameSettings/RGV.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RH8.ini
+++ b/Data/Sys/GameSettings/RH8.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real Xfb for the videos to display.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/RHA.ini
+++ b/Data/Sys/GameSettings/RHA.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/RHD.ini
+++ b/Data/Sys/GameSettings/RHD.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RHM.ini
+++ b/Data/Sys/GameSettings/RHM.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/RHO.ini
+++ b/Data/Sys/GameSettings/RHO.ini
@@ -9,12 +9,5 @@ EmulationIssues =
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Hacks]
 EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/RHT.ini
+++ b/Data/Sys/GameSettings/RHT.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RIJ.ini
+++ b/Data/Sys/GameSettings/RIJ.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RIP.ini
+++ b/Data/Sys/GameSettings/RIP.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RIU.ini
+++ b/Data/Sys/GameSettings/RIU.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RIV.ini
+++ b/Data/Sys/GameSettings/RIV.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RK2.ini
+++ b/Data/Sys/GameSettings/RK2.ini
@@ -17,9 +17,6 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RK5.ini
+++ b/Data/Sys/GameSettings/RK5.ini
@@ -17,11 +17,3 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RKD.ini
+++ b/Data/Sys/GameSettings/RKD.ini
@@ -17,9 +17,6 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RLB.ini
+++ b/Data/Sys/GameSettings/RLB.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RLG.ini
+++ b/Data/Sys/GameSettings/RLG.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RLJ.ini
+++ b/Data/Sys/GameSettings/RLJ.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RM3.ini
+++ b/Data/Sys/GameSettings/RM3.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RM6.ini
+++ b/Data/Sys/GameSettings/RM6.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RM8.ini
+++ b/Data/Sys/GameSettings/RM8.ini
@@ -9,13 +9,6 @@ EmulationIssues =
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Enhancements]
 ForceFiltering = False
 [Video_Hacks]

--- a/Data/Sys/GameSettings/RMC.ini
+++ b/Data/Sys/GameSettings/RMC.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 

--- a/Data/Sys/GameSettings/RMG.ini
+++ b/Data/Sys/GameSettings/RMG.ini
@@ -17,13 +17,5 @@ EmulationIssues = Needs Efb Access from CPU.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBAccessEnable = True

--- a/Data/Sys/GameSettings/RMH.ini
+++ b/Data/Sys/GameSettings/RMH.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RMK.ini
+++ b/Data/Sys/GameSettings/RMK.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/RML.ini
+++ b/Data/Sys/GameSettings/RML.ini
@@ -18,13 +18,5 @@ EmulationIssues = Dual core causes random texture corruption.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/RNE.ini
+++ b/Data/Sys/GameSettings/RNE.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RNO.ini
+++ b/Data/Sys/GameSettings/RNO.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RO3.ini
+++ b/Data/Sys/GameSettings/RO3.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RO9.ini
+++ b/Data/Sys/GameSettings/RO9.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/ROA.ini
+++ b/Data/Sys/GameSettings/ROA.ini
@@ -17,14 +17,6 @@ EmulationIssues = Accessing the map will crash the game (see issue 3953).
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/ROD.ini
+++ b/Data/Sys/GameSettings/ROD.ini
@@ -17,13 +17,5 @@ EmulationIssues = This game doesn't support widescreen
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/ROL.ini
+++ b/Data/Sys/GameSettings/ROL.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RON.ini
+++ b/Data/Sys/GameSettings/RON.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 

--- a/Data/Sys/GameSettings/ROU.ini
+++ b/Data/Sys/GameSettings/ROU.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/ROW.ini
+++ b/Data/Sys/GameSettings/ROW.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RPB.ini
+++ b/Data/Sys/GameSettings/RPB.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/RPO.ini
+++ b/Data/Sys/GameSettings/RPO.ini
@@ -17,14 +17,6 @@ EmulationIssues = Jerky videos need safe cache.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/RQ6.ini
+++ b/Data/Sys/GameSettings/RQ6.ini
@@ -17,14 +17,6 @@ EmulationIssues = Use direct 3d 11 for less glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Enhancements]
 MaxAnisotropy = 0
 

--- a/Data/Sys/GameSettings/RQL.ini
+++ b/Data/Sys/GameSettings/RQL.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RQO.ini
+++ b/Data/Sys/GameSettings/RQO.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RQR.ini
+++ b/Data/Sys/GameSettings/RQR.ini
@@ -18,11 +18,3 @@ EmulationIssues = Needs single core to run properly.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RRB.ini
+++ b/Data/Sys/GameSettings/RRB.ini
@@ -18,11 +18,3 @@ EmulationIssues = Needs Synchronise GPU thread for stability. Use direct3d11 for
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RRK.ini
+++ b/Data/Sys/GameSettings/RRK.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RRY.ini
+++ b/Data/Sys/GameSettings/RRY.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RRZ.ini
+++ b/Data/Sys/GameSettings/RRZ.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RS5.ini
+++ b/Data/Sys/GameSettings/RS5.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 

--- a/Data/Sys/GameSettings/RS8.ini
+++ b/Data/Sys/GameSettings/RS8.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RSF.ini
+++ b/Data/Sys/GameSettings/RSF.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/RSI.ini
+++ b/Data/Sys/GameSettings/RSI.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/RSL.ini
+++ b/Data/Sys/GameSettings/RSL.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RSP.ini
+++ b/Data/Sys/GameSettings/RSP.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RSV.ini
+++ b/Data/Sys/GameSettings/RSV.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RSW.ini
+++ b/Data/Sys/GameSettings/RSW.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RSX.ini
+++ b/Data/Sys/GameSettings/RSX.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Wii nand dump (reconnect wiimote if necessary). EFB cpu 
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RT3.ini
+++ b/Data/Sys/GameSettings/RT3.ini
@@ -5,13 +5,6 @@ EmulationStateId = 3
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RT4.ini
+++ b/Data/Sys/GameSettings/RT4.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 

--- a/Data/Sys/GameSettings/RTM.ini
+++ b/Data/Sys/GameSettings/RTM.ini
@@ -17,14 +17,6 @@ EmulationIssues = Fog emulation creates problems with the game (see issue 4922).
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 DisableFog = True
 

--- a/Data/Sys/GameSettings/RTN.ini
+++ b/Data/Sys/GameSettings/RTN.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RTZ.ini
+++ b/Data/Sys/GameSettings/RTZ.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RUU.ini
+++ b/Data/Sys/GameSettings/RUU.ini
@@ -9,12 +9,5 @@ EmulationIssues =
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/RUY.ini
+++ b/Data/Sys/GameSettings/RUY.ini
@@ -17,11 +17,3 @@ EmulationIssues = Small graphical glitch with light saber (light stays at the sa
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RVK.ini
+++ b/Data/Sys/GameSettings/RVK.ini
@@ -17,6 +17,3 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RVU.ini
+++ b/Data/Sys/GameSettings/RVU.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RW9.ini
+++ b/Data/Sys/GameSettings/RW9.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RWL.ini
+++ b/Data/Sys/GameSettings/RWL.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/RWR.ini
+++ b/Data/Sys/GameSettings/RWR.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/RWS.ini
+++ b/Data/Sys/GameSettings/RWS.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 

--- a/Data/Sys/GameSettings/RWU.ini
+++ b/Data/Sys/GameSettings/RWU.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RX3.ini
+++ b/Data/Sys/GameSettings/RX3.ini
@@ -17,9 +17,6 @@ EmulationIssues = Tested with (r6521)
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RXX.ini
+++ b/Data/Sys/GameSettings/RXX.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RYX.ini
+++ b/Data/Sys/GameSettings/RYX.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RZD.ini
+++ b/Data/Sys/GameSettings/RZD.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBAccessEnable = True

--- a/Data/Sys/GameSettings/RZJ.ini
+++ b/Data/Sys/GameSettings/RZJ.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/RZO.ini
+++ b/Data/Sys/GameSettings/RZO.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/RZP.ini
+++ b/Data/Sys/GameSettings/RZP.ini
@@ -16,7 +16,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/RZT.ini
+++ b/Data/Sys/GameSettings/RZT.ini
@@ -9,12 +9,5 @@ EmulationIssues = Needs real wiimote and motion plus.
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Hacks]
 EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/RZZ.ini
+++ b/Data/Sys/GameSettings/RZZ.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/S2E.ini
+++ b/Data/Sys/GameSettings/S2E.ini
@@ -17,14 +17,6 @@ EmulationIssues = USB Microphone not emulated
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/S2L.ini
+++ b/Data/Sys/GameSettings/S2L.ini
@@ -17,13 +17,5 @@ EmulationIssues = Needs EFB to Ram to display photographs.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/S2W.ini
+++ b/Data/Sys/GameSettings/S2W.ini
@@ -17,14 +17,6 @@ EmulationIssues = Use direct3d for less glitches.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/S3B.ini
+++ b/Data/Sys/GameSettings/S3B.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/S59.ini
+++ b/Data/Sys/GameSettings/S59.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 FastDepthCalc = False

--- a/Data/Sys/GameSettings/S72.ini
+++ b/Data/Sys/GameSettings/S72.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/S75.ini
+++ b/Data/Sys/GameSettings/S75.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/SAK.ini
+++ b/Data/Sys/GameSettings/SAK.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/SB3.ini
+++ b/Data/Sys/GameSettings/SB3.ini
@@ -17,14 +17,6 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/SB4.ini
+++ b/Data/Sys/GameSettings/SB4.ini
@@ -17,13 +17,5 @@ EmulationIssues = Needs Efb Access from CPU.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBAccessEnable = True

--- a/Data/Sys/GameSettings/SBD.ini
+++ b/Data/Sys/GameSettings/SBD.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SBL.ini
+++ b/Data/Sys/GameSettings/SBL.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/SC2.ini
+++ b/Data/Sys/GameSettings/SC2.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/SC4.ini
+++ b/Data/Sys/GameSettings/SC4.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/SC7.ini
+++ b/Data/Sys/GameSettings/SC7.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar =
-
 [Video_Enhancements]
 MaxAnisotropy = 0

--- a/Data/Sys/GameSettings/SC8.ini
+++ b/Data/Sys/GameSettings/SC8.ini
@@ -17,11 +17,3 @@ EmulationIssues = Needs real wiimote and motion plus.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/SCA.ini
+++ b/Data/Sys/GameSettings/SCA.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SCY.ini
+++ b/Data/Sys/GameSettings/SCY.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/SD2.ini
+++ b/Data/Sys/GameSettings/SD2.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/SD2J01.ini
+++ b/Data/Sys/GameSettings/SD2J01.ini
@@ -20,14 +20,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/SDB.ini
+++ b/Data/Sys/GameSettings/SDB.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/SDF.ini
+++ b/Data/Sys/GameSettings/SDF.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/SDM.ini
+++ b/Data/Sys/GameSettings/SDM.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/SDN.ini
+++ b/Data/Sys/GameSettings/SDN.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/SDW.ini
+++ b/Data/Sys/GameSettings/SDW.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/SE2.ini
+++ b/Data/Sys/GameSettings/SE2.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SE3.ini
+++ b/Data/Sys/GameSettings/SE3.ini
@@ -17,13 +17,5 @@ EmulationIssues = Freezes at boot, refer issue 6701
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/SEA.ini
+++ b/Data/Sys/GameSettings/SEA.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SEM.ini
+++ b/Data/Sys/GameSettings/SEM.ini
@@ -17,14 +17,6 @@ EmulationIssues = Enable progressive scan if the game has boot issues.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SER.ini
+++ b/Data/Sys/GameSettings/SER.ini
@@ -17,14 +17,6 @@ EmulationIssues = Enable progressive scan if the game has boot issues.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -17,14 +17,6 @@ EmulationIssues = Sound crackling can be fixed by lle audio.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SFI.ini
+++ b/Data/Sys/GameSettings/SFI.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs real xfb for videos to show up.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 UseXFB = True

--- a/Data/Sys/GameSettings/SG8.ini
+++ b/Data/Sys/GameSettings/SG8.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/SGA.ini
+++ b/Data/Sys/GameSettings/SGA.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/SH6.ini
+++ b/Data/Sys/GameSettings/SH6.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/SHL.ini
+++ b/Data/Sys/GameSettings/SHL.ini
@@ -17,14 +17,6 @@ EmulationIssues = Flashlight glitches (r6521)
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SJB.ini
+++ b/Data/Sys/GameSettings/SJB.ini
@@ -17,14 +17,6 @@ EmulationIssues = Disable the gamecube controller or the wiimote to not have con
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/SJD.ini
+++ b/Data/Sys/GameSettings/SJD.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/SJDJ01.ini
+++ b/Data/Sys/GameSettings/SJDJ01.ini
@@ -20,14 +20,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/SJE.ini
+++ b/Data/Sys/GameSettings/SJE.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/SJO.ini
+++ b/Data/Sys/GameSettings/SJO.ini
@@ -17,13 +17,5 @@ EmulationIssues = Freezes at boot, refer issue 6701
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/SJX.ini
+++ b/Data/Sys/GameSettings/SJX.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/SK3.ini
+++ b/Data/Sys/GameSettings/SK3.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SKJ.ini
+++ b/Data/Sys/GameSettings/SKJ.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/SKV.ini
+++ b/Data/Sys/GameSettings/SKV.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/SL2.ini
+++ b/Data/Sys/GameSettings/SL2.ini
@@ -14,14 +14,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Gecko]
 
 [Video_Hacks]

--- a/Data/Sys/GameSettings/SLS.ini
+++ b/Data/Sys/GameSettings/SLS.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/SLW.ini
+++ b/Data/Sys/GameSettings/SLW.ini
@@ -17,14 +17,6 @@ EmulationIssues = Needs Real Xfb for the pointer to appear.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/SMF.ini
+++ b/Data/Sys/GameSettings/SMF.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 UseXFB = True

--- a/Data/Sys/GameSettings/SMN.ini
+++ b/Data/Sys/GameSettings/SMN.ini
@@ -17,14 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SMO.ini
+++ b/Data/Sys/GameSettings/SMO.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/SN4.ini
+++ b/Data/Sys/GameSettings/SN4.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/SNC.ini
+++ b/Data/Sys/GameSettings/SNC.ini
@@ -17,14 +17,6 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 EFBScale = -1
 

--- a/Data/Sys/GameSettings/SND.ini
+++ b/Data/Sys/GameSettings/SND.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SNJ.ini
+++ b/Data/Sys/GameSettings/SNJ.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SO3.ini
+++ b/Data/Sys/GameSettings/SO3.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/SOJ.ini
+++ b/Data/Sys/GameSettings/SOJ.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-

--- a/Data/Sys/GameSettings/SOU.ini
+++ b/Data/Sys/GameSettings/SOU.ini
@@ -15,14 +15,6 @@ EmulationIssues = Needs real wiimote and motion plus. Time stone transition need
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Hacks]
 EFBAccessEnable = True
 EFBEmulateFormatChanges = True

--- a/Data/Sys/GameSettings/SPT.ini
+++ b/Data/Sys/GameSettings/SPT.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SPV.ini
+++ b/Data/Sys/GameSettings/SPV.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SQM.ini
+++ b/Data/Sys/GameSettings/SQM.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/SR5.ini
+++ b/Data/Sys/GameSettings/SR5.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/SRQ.ini
+++ b/Data/Sys/GameSettings/SRQ.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/SS3.ini
+++ b/Data/Sys/GameSettings/SS3.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/SSQ.ini
+++ b/Data/Sys/GameSettings/SSQ.ini
@@ -17,14 +17,6 @@ EmulationIssues = Flinger Painting minigame needs EFB to RAM to function properl
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/SSR.ini
+++ b/Data/Sys/GameSettings/SSR.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/SSZ.ini
+++ b/Data/Sys/GameSettings/SSZ.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/STE.ini
+++ b/Data/Sys/GameSettings/STE.ini
@@ -17,11 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/STH.ini
+++ b/Data/Sys/GameSettings/STH.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 

--- a/Data/Sys/GameSettings/STK.ini
+++ b/Data/Sys/GameSettings/STK.ini
@@ -17,6 +17,3 @@ EmulationStateId = 5
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/SU7.ini
+++ b/Data/Sys/GameSettings/SU7.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/SUK.ini
+++ b/Data/Sys/GameSettings/SUK.ini
@@ -17,14 +17,6 @@ EmulationIssues = Some minigames need XFB to work.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/SVB.ini
+++ b/Data/Sys/GameSettings/SVB.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/SVM.ini
+++ b/Data/Sys/GameSettings/SVM.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/SVV.ini
+++ b/Data/Sys/GameSettings/SVV.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/SVX.ini
+++ b/Data/Sys/GameSettings/SVX.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/SX3.ini
+++ b/Data/Sys/GameSettings/SX3.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 

--- a/Data/Sys/GameSettings/SX4.ini
+++ b/Data/Sys/GameSettings/SX4.ini
@@ -17,12 +17,4 @@ EmulationIssues = The game randomly freezes.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Hacks]

--- a/Data/Sys/GameSettings/SXB.ini
+++ b/Data/Sys/GameSettings/SXB.ini
@@ -17,6 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/SXC.ini
+++ b/Data/Sys/GameSettings/SXC.ini
@@ -17,9 +17,6 @@ EmulationIssues = Create a guitar profile and use that instead of wiimote contro
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/SXD.ini
+++ b/Data/Sys/GameSettings/SXD.ini
@@ -17,11 +17,3 @@ EmulationIssues = Plays awfully if emu doesn't run at 100%
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/SZA.ini
+++ b/Data/Sys/GameSettings/SZA.ini
@@ -17,6 +17,3 @@ EmulationIssues = Create a guitar profile and use that instead of wiimote contro
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/SZB.ini
+++ b/Data/Sys/GameSettings/SZB.ini
@@ -17,14 +17,6 @@ EmulationIssues = If emu is running less than 100% it's EXTREMELY hard to hit no
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Enhancements]
 ForceFiltering = False
 

--- a/Data/Sys/GameSettings/UGP.ini
+++ b/Data/Sys/GameSettings/UGP.ini
@@ -17,11 +17,3 @@ EmulationIssues = No GameBoy Player Device.
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/W2G.ini
+++ b/Data/Sys/GameSettings/W2G.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 [Video_Settings]

--- a/Data/Sys/GameSettings/W2M.ini
+++ b/Data/Sys/GameSettings/W2M.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/W3G.ini
+++ b/Data/Sys/GameSettings/W3G.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 [Video_Settings]

--- a/Data/Sys/GameSettings/WAL.ini
+++ b/Data/Sys/GameSettings/WAL.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WAY.ini
+++ b/Data/Sys/GameSettings/WAY.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WB2.ini
+++ b/Data/Sys/GameSettings/WB2.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WB3.ini
+++ b/Data/Sys/GameSettings/WB3.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WB4.ini
+++ b/Data/Sys/GameSettings/WB4.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Gecko]
 [Video_Hacks]
 EFBAccessEnable = True

--- a/Data/Sys/GameSettings/WB6.ini
+++ b/Data/Sys/GameSettings/WB6.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WBL.ini
+++ b/Data/Sys/GameSettings/WBL.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WBM.ini
+++ b/Data/Sys/GameSettings/WBM.ini
@@ -17,10 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =

--- a/Data/Sys/GameSettings/WBQ.ini
+++ b/Data/Sys/GameSettings/WBQ.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WBX.ini
+++ b/Data/Sys/GameSettings/WBX.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WBY.ini
+++ b/Data/Sys/GameSettings/WBY.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WBZ.ini
+++ b/Data/Sys/GameSettings/WBZ.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WC6.ini
+++ b/Data/Sys/GameSettings/WC6.ini
@@ -15,14 +15,6 @@ EmulationIssues = Disable PAL60 (EuRGB60) mode
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WCH.ini
+++ b/Data/Sys/GameSettings/WCH.ini
@@ -10,14 +10,6 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/WCV.ini
+++ b/Data/Sys/GameSettings/WCV.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WDM.ini
+++ b/Data/Sys/GameSettings/WDM.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WER.ini
+++ b/Data/Sys/GameSettings/WER.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WF4.ini
+++ b/Data/Sys/GameSettings/WF4.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 

--- a/Data/Sys/GameSettings/WFL.ini
+++ b/Data/Sys/GameSettings/WFL.ini
@@ -10,13 +10,5 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/WFU.ini
+++ b/Data/Sys/GameSettings/WFU.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WGD.ini
+++ b/Data/Sys/GameSettings/WGD.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WGO.ini
+++ b/Data/Sys/GameSettings/WGO.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WGS.ini
+++ b/Data/Sys/GameSettings/WGS.ini
@@ -9,13 +9,6 @@ EmulationIssues =
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 [Video_Settings]

--- a/Data/Sys/GameSettings/WGY.ini
+++ b/Data/Sys/GameSettings/WGY.ini
@@ -17,7 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-Hack = -1
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WHF.ini
+++ b/Data/Sys/GameSettings/WHF.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WHP.ini
+++ b/Data/Sys/GameSettings/WHP.ini
@@ -17,9 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WHU.ini
+++ b/Data/Sys/GameSettings/WHU.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WHW.ini
+++ b/Data/Sys/GameSettings/WHW.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 [Video_Hacks]

--- a/Data/Sys/GameSettings/WIC.ini
+++ b/Data/Sys/GameSettings/WIC.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WID.ini
+++ b/Data/Sys/GameSettings/WID.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WIL.ini
+++ b/Data/Sys/GameSettings/WIL.ini
@@ -17,11 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-

--- a/Data/Sys/GameSettings/WIY.ini
+++ b/Data/Sys/GameSettings/WIY.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WJE.ini
+++ b/Data/Sys/GameSettings/WJE.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WKD.ini
+++ b/Data/Sys/GameSettings/WKD.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WKT.ini
+++ b/Data/Sys/GameSettings/WKT.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WLE.ini
+++ b/Data/Sys/GameSettings/WLE.ini
@@ -10,14 +10,6 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WLN.ini
+++ b/Data/Sys/GameSettings/WLN.ini
@@ -10,14 +10,6 @@ EmulationIssues =
 
 [ActionReplay]
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WLO.ini
+++ b/Data/Sys/GameSettings/WLO.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/WLW.ini
+++ b/Data/Sys/GameSettings/WLW.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WM8.ini
+++ b/Data/Sys/GameSettings/WM8.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WMB.ini
+++ b/Data/Sys/GameSettings/WMB.ini
@@ -17,14 +17,6 @@ EmulationIssues = Use OpenGL and Real XFB
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True

--- a/Data/Sys/GameSettings/WMM.ini
+++ b/Data/Sys/GameSettings/WMM.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WOT.ini
+++ b/Data/Sys/GameSettings/WOT.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WOY.ini
+++ b/Data/Sys/GameSettings/WOY.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Gecko]
 [Video_Settings]
 UseXFB = True

--- a/Data/Sys/GameSettings/WPC.ini
+++ b/Data/Sys/GameSettings/WPC.ini
@@ -9,10 +9,3 @@ EmulationIssues = Disable PAL60 (EuRGB60) mode
 # Add memory patches to be loaded once on boot here.
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 

--- a/Data/Sys/GameSettings/WPJ.ini
+++ b/Data/Sys/GameSettings/WPJ.ini
@@ -5,12 +5,5 @@ EmulationStateId = 5
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/WPP.ini
+++ b/Data/Sys/GameSettings/WPP.ini
@@ -17,6 +17,3 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WPU.ini
+++ b/Data/Sys/GameSettings/WPU.ini
@@ -5,13 +5,6 @@ EmulationStateId = 4
 EmulationIssues = 
 [OnFrame]
 [ActionReplay]
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WR9.ini
+++ b/Data/Sys/GameSettings/WR9.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WRG.ini
+++ b/Data/Sys/GameSettings/WRG.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WRI.ini
+++ b/Data/Sys/GameSettings/WRI.ini
@@ -17,8 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Hacks]
 EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/WRX.ini
+++ b/Data/Sys/GameSettings/WRX.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear =
-PH_ZFar =
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WSN.ini
+++ b/Data/Sys/GameSettings/WSN.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WTE.ini
+++ b/Data/Sys/GameSettings/WTE.ini
@@ -17,14 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WTK.ini
+++ b/Data/Sys/GameSettings/WTK.ini
@@ -17,13 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 512

--- a/Data/Sys/GameSettings/WTR.ini
+++ b/Data/Sys/GameSettings/WTR.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WTT.ini
+++ b/Data/Sys/GameSettings/WTT.ini
@@ -17,6 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WTX.ini
+++ b/Data/Sys/GameSettings/WTX.ini
@@ -17,7 +17,3 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-Hack = -1
-ProjectionHack = 0
-

--- a/Data/Sys/GameSettings/WXB.ini
+++ b/Data/Sys/GameSettings/WXB.ini
@@ -16,13 +16,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-PH_SZNear = 0
-PH_SZFar = 0
-PH_ExtraParam = 0
-PH_ZNear = 
-PH_ZFar = 
-
 [Video_Settings]
 SafeTextureCacheColorSamples = 0

--- a/Data/Sys/GameSettings/WYM.ini
+++ b/Data/Sys/GameSettings/WYM.ini
@@ -17,9 +17,6 @@ EmulationIssues = Crashes after warning screen
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-
 [Video_Settings]
 UseXFB = True
 UseRealXFB = False

--- a/Data/Sys/GameSettings/WZI.ini
+++ b/Data/Sys/GameSettings/WZI.ini
@@ -18,6 +18,3 @@ EmulationIssues = Requires data cache emulation
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video]
-ProjectionHack = 0
-

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -103,6 +103,10 @@ void VideoConfig::Load(const std::string& ini_file)
 	hacks->Get("EFBScaledCopy", &bCopyEFBScaled, true);
 	hacks->Get("EFBEmulateFormatChanges", &bEFBEmulateFormatChanges, false);
 
+	// hacks which are disabled by default
+	iPhackvalue[0] = 0;
+	bPerfQueriesEnable = false;
+
 	// Load common settings
 	iniFile.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
 	IniFile::Section* interface = iniFile.GetOrCreateSection("Interface");


### PR DESCRIPTION
Now we disable the projection hack on startup, so we don't need to disabled them in almost all game inis.