### PR TITLE
PAL60 improvements: Allow setting in GameINI, disable for NTSC games, store in Movie files.

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -226,8 +226,7 @@ bool CBoot::BootUp()
 	g_symbolDB.Clear();
 
 	// PAL Wii uses NTSC framerate and linecount in 60Hz modes
-	const bool bPAL60 = _StartupPara.bWii && SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.E60");
-	VideoInterface::Preset(_StartupPara.bNTSC || bPAL60);
+	VideoInterface::Preset(_StartupPara.bNTSC || (_StartupPara.bWii && _StartupPara.bPAL60));
 
 	switch (_StartupPara.m_BootType)
 	{

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -257,6 +257,12 @@ bool BootCore(const std::string& _rFilename)
 		config_cache.bSetEXIDevice[1] = true;
 	}
 
+	// Some NTSC Wii games such as Doc Louis's Punch-Out!! and 1942 (Virtual Console) crash if the PAL60 option is enabled
+	if (StartUp.bWii && StartUp.bNTSC)
+	{
+		StartUp.bPAL60 = false;
+	}
+
 	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", StartUp.bProgressive);
 	SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", StartUp.bPAL60);
 

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -229,6 +229,7 @@ bool BootCore(const std::string& _rFilename)
 		StartUp.bSkipIdle = Movie::IsSkipIdle();
 		StartUp.bDSPHLE = Movie::IsDSPHLE();
 		StartUp.bProgressive = Movie::IsProgressive();
+		StartUp.bPAL60 = Movie::IsPAL60();
 		StartUp.bFastDiscSpeed = Movie::IsFastDiscSpeed();
 		StartUp.iCPUCore = Movie::GetCPUMode();
 		StartUp.bSyncGPU = Movie::IsSyncGPU();

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -160,6 +160,7 @@ bool BootCore(const std::string& _rFilename)
 		core_section->Get("CPUCore",          &StartUp.iCPUCore, StartUp.iCPUCore);
 		core_section->Get("HLE_BS2",          &StartUp.bHLE_BS2, StartUp.bHLE_BS2);
 		core_section->Get("ProgressiveScan",  &StartUp.bProgressive, StartUp.bProgressive);
+		core_section->Get("PAL60",            &StartUp.bPAL60, StartUp.bPAL60);
 		if (core_section->Get("FrameLimit",   &SConfig::GetInstance().m_Framelimit, SConfig::GetInstance().m_Framelimit))
 			config_cache.bSetFramelimit = true;
 		if (core_section->Get("FrameSkip",    &SConfig::GetInstance().m_FrameSkip))

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -48,7 +48,7 @@ namespace BootManager
 struct ConfigCache
 {
 	bool valid, bCPUThread, bSkipIdle, bSyncGPUOnSkipIdleHack, bFPRF, bAccurateNaNs, bMMU, bDCBZOFF, m_EnableJIT, bDSPThread,
-	     bSyncGPU, bFastDiscSpeed, bDSPHLE, bHLE_BS2, bProgressive;
+	     bSyncGPU, bFastDiscSpeed, bDSPHLE, bHLE_BS2, bProgressive, bPAL60;
 	int iSelectedLanguage;
 	int iCPUCore, Volume;
 	int iWiimoteSource[MAX_BBMOTES];
@@ -121,6 +121,7 @@ bool BootCore(const std::string& _rFilename)
 		config_cache.framelimit = SConfig::GetInstance().m_Framelimit;
 		config_cache.frameSkip = SConfig::GetInstance().m_FrameSkip;
 		config_cache.bProgressive = StartUp.bProgressive;
+		config_cache.bPAL60 = StartUp.bPAL60;
 		config_cache.iSelectedLanguage = StartUp.SelectedLanguage;
 		for (unsigned int i = 0; i < MAX_BBMOTES; ++i)
 		{
@@ -256,6 +257,7 @@ bool BootCore(const std::string& _rFilename)
 	}
 
 	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", StartUp.bProgressive);
+	SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", StartUp.bPAL60);
 
 	// Run the game
 	// Init the core
@@ -298,6 +300,8 @@ void Stop()
 		StartUp.bProgressive = config_cache.bProgressive;
 		StartUp.SelectedLanguage = config_cache.iSelectedLanguage;
 		SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", config_cache.bProgressive);
+		StartUp.bPAL60 = config_cache.bPAL60;
+		SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", config_cache.bPAL60);
 
 		// Only change these back if they were actually set by game ini, since they can be changed while a game is running.
 		if (config_cache.bSetFramelimit)

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -52,7 +52,8 @@ SConfig::SConfig()
   iRenderWindowWidth(640), iRenderWindowHeight(480),
   bRenderWindowAutoSize(false), bKeepWindowOnTop(false),
   bFullscreen(false), bRenderToMain(false),
-  bProgressive(false), bDisableScreenSaver(false),
+  bProgressive(false), bPAL60(false),
+  bDisableScreenSaver(false),
   iPosX(100), iPosY(100), iWidth(800), iHeight(600),
   bLoopFifoReplay(true)
 {
@@ -173,6 +174,7 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
 	display->Set("RenderWindowAutoSize", bRenderWindowAutoSize);
 	display->Set("KeepWindowOnTop", bKeepWindowOnTop);
 	display->Set("ProgressiveScan", bProgressive);
+	display->Set("PAL60", bPAL60);
 	display->Set("DisableScreenSaver", bDisableScreenSaver);
 	display->Set("ForceNTSCJ", bForceNTSCJ);
 }
@@ -415,6 +417,7 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
 	display->Get("RenderWindowAutoSize", &bRenderWindowAutoSize,   false);
 	display->Get("KeepWindowOnTop",      &bKeepWindowOnTop,        false);
 	display->Get("ProgressiveScan",      &bProgressive,            false);
+	display->Get("PAL60",                &bPAL60,                  true);
 	display->Get("DisableScreenSaver",   &bDisableScreenSaver,     true);
 	display->Get("ForceNTSCJ",           &bForceNTSCJ,             false);
 }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -120,7 +120,8 @@ struct SConfig : NonCopyable
 	int iRenderWindowWidth, iRenderWindowHeight;
 	bool bRenderWindowAutoSize, bKeepWindowOnTop;
 	bool bFullscreen, bRenderToMain;
-	bool bProgressive, bDisableScreenSaver;
+	bool bProgressive, bPAL60;
+	bool bDisableScreenSaver;
 
 	int iPosX, iPosY, iWidth, iHeight;
 

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -63,7 +63,9 @@ static u64 s_totalLagCount = 0; // just stats
 u64 g_currentInputCount = 0, g_totalInputCount = 0; // just stats
 static u64 s_totalTickCount = 0, s_tickCountAtLastInput = 0; // just stats
 static u64 s_recordingStartTime; // seconds since 1970 that recording started
-static bool s_bSaveConfig = false, s_bSkipIdle = false, s_bDualCore = false, s_bProgressive = false, s_bDSPHLE = false, s_bFastDiscSpeed = false;
+static bool s_bSaveConfig = false, s_bSkipIdle = false, s_bDualCore = false;
+static bool s_bProgressive = false, s_bPAL60 = false;
+static bool s_bDSPHLE = false, s_bFastDiscSpeed = false;
 static bool s_bSyncGPU = false, s_bNetPlay = false;
 static std::string s_videoBackend = "unknown";
 static int s_iCPUCore = 1;
@@ -359,6 +361,11 @@ bool IsDualCore()
 bool IsProgressive()
 {
 	return s_bProgressive;
+}
+
+bool IsPAL60()
+{
+	return s_bPAL60;
 }
 
 bool IsSkipIdle()
@@ -789,6 +796,7 @@ void ReadHeader()
 		s_bSkipIdle = tmpHeader.bSkipIdle;
 		s_bDualCore = tmpHeader.bDualCore;
 		s_bProgressive = tmpHeader.bProgressive;
+		s_bPAL60 = tmpHeader.bPAL60;
 		s_bDSPHLE = tmpHeader.bDSPHLE;
 		s_bFastDiscSpeed = tmpHeader.bFastDiscSpeed;
 		s_iCPUCore = tmpHeader.CPUCore;
@@ -1211,6 +1219,7 @@ void SaveRecording(const std::string& filename)
 	header.bSkipIdle = s_bSkipIdle;
 	header.bDualCore = s_bDualCore;
 	header.bProgressive = s_bProgressive;
+	header.bPAL60 = s_bPAL60;
 	header.bDSPHLE = s_bDSPHLE;
 	header.bFastDiscSpeed = s_bFastDiscSpeed;
 	strncpy((char *)header.videoBackend, s_videoBackend.c_str(),ArraySize(header.videoBackend));
@@ -1290,6 +1299,7 @@ void GetSettings()
 	s_bSkipIdle = SConfig::GetInstance().bSkipIdle;
 	s_bDualCore = SConfig::GetInstance().bCPUThread;
 	s_bProgressive = SConfig::GetInstance().bProgressive;
+	s_bPAL60 = SConfig::GetInstance().bPAL60;
 	s_bDSPHLE = SConfig::GetInstance().bDSPHLE;
 	s_bFastDiscSpeed = SConfig::GetInstance().bFastDiscSpeed;
 	s_videoBackend = g_video_backend->GetName();

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -101,7 +101,8 @@ struct DTMHeader
 	u8   bongos;
 	bool bSyncGPU;
 	bool bNetPlay;
-	u8   reserved[13];      // Padding for any new config options
+	bool bPAL60;
+	u8   reserved[12];      // Padding for any new config options
 	u8   discChange[40];    // Name of iso file to switch to, for two disc games.
 	u8   revision[20];      // Git hash
 	u32  DSPiromHash;
@@ -131,6 +132,7 @@ u64  GetRecordingStartTime();
 bool IsConfigSaved();
 bool IsDualCore();
 bool IsProgressive();
+bool IsPAL60();
 bool IsSkipIdle();
 bool IsDSPHLE();
 bool IsFastDiscSpeed();

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -84,7 +84,7 @@ void WiiConfigPane::InitializeGUI()
 void WiiConfigPane::LoadGUIValues()
 {
 	m_screensaver_checkbox->SetValue(!!SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.SSV"));
-	m_pal60_mode_checkbox->SetValue(!!SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.E60"));
+	m_pal60_mode_checkbox->SetValue(SConfig::GetInstance().bPAL60);
 	m_aspect_ratio_choice->SetSelection(SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.AR"));
 	m_system_language_choice->SetSelection(SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG"));
 
@@ -110,6 +110,7 @@ void WiiConfigPane::OnScreenSaverCheckBoxChanged(wxCommandEvent& event)
 
 void WiiConfigPane::OnPAL60CheckBoxChanged(wxCommandEvent& event)
 {
+	SConfig::GetInstance().bPAL60 = m_pal60_mode_checkbox->IsChecked();
 	SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", m_pal60_mode_checkbox->IsChecked());
 }
 


### PR DESCRIPTION
This is the PAL60-related improvements of #2532 without the GUI changes, which I hope makes it easier to test and merge.

Fixes issues [7847](https://code.google.com/p/dolphin-emu/issues/detail?id=7847), [7714](https://code.google.com/p/dolphin-emu/issues/detail?id=7714), and [8036](https://code.google.com/p/dolphin-emu/issues/detail?id=8036). Also adds the PAL60 option to the Movie file header.