### PR TITLE
Cache games without banners

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -22,7 +22,6 @@
 #include "DiscIO/Filesystem.h"
 
 #include "DolphinQt/GameList/GameFile.h"
-#include "DolphinQt/Utils/Resources.h"
 #include "DolphinQt/Utils/Utils.h"
 
 static const u32 CACHE_REVISION = 0x00A;
@@ -72,12 +71,9 @@ static QString GetLanguageString(DiscIO::IVolume::ELanguage language, QMap<DiscI
 GameFile::GameFile(const QString& fileName)
     : m_file_name(fileName)
 {
-	bool hasBanner = false;
-
 	if (LoadFromCache())
 	{
 		m_valid = true;
-		hasBanner = true;
 	}
 	else
 	{
@@ -115,15 +111,13 @@ GameFile::GameFile(const QString& fileName)
 						        (buffer[i] & 0x0000FF) >>  0));
 			}
 
+			m_valid = true;
+
 			if (!banner.isNull())
 			{
-				hasBanner = true;
 				m_banner = QPixmap::fromImage(banner);
-			}
-
-			m_valid = true;
-			if (hasBanner)
 				SaveToCache();
+			}
 		}
 	}
 
@@ -138,9 +132,6 @@ GameFile::GameFile(const QString& fileName)
 		ini.GetIfExists("EmuState", "EmulationIssues", &issues_temp);
 		m_issues = QString::fromStdString(issues_temp);
 	}
-
-	if (!hasBanner)
-		m_banner = Resources::GetPixmap(Resources::BANNER_MISSING);
 }
 
 bool GameFile::LoadFromCache()

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -13,6 +13,8 @@
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 
+#include "DolphinQt/Utils/Resources.h"
+
 class GameFile final
 {
 public:
@@ -39,7 +41,13 @@ public:
 	u64 GetVolumeSize() const { return m_volume_size; }
 	// 0 is the first disc, 1 is the second disc
 	u8 GetDiscNumber() const { return m_disc_number; }
-	const QPixmap GetBitmap() const { return m_banner; }
+	const QPixmap GetBitmap() const
+	{
+		if (m_banner.isNull())
+			return Resources::GetPixmap(Resources::BANNER_MISSING);
+
+		return m_banner;
+	}
 
 private:
 	QString m_file_name;

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -79,4 +79,6 @@ private:
 	void SaveToCache();
 
 	QString CreateCacheFilename();
+
+	void ReadBanner(const DiscIO::IVolume& volume);
 };

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -81,4 +81,6 @@ private:
 	void SaveToCache();
 
 	std::string CreateCacheFilename();
+
+	void ReadBanner(const DiscIO::IVolume& volume);
 };


### PR DESCRIPTION
Games without banners were not cached before, because a banner could become available at any time, making the cache outdated without it becoming invalidated. Instead of not caching anything, this change makes Dolphin check for a banner every time a cache that lacks a banner is read. This is faster than reading all metadata, because reading a Wii banner only reads from the game's save file, not the volume and its filesystem.

The cache revision is incremented, because otherwise banners will be missing if a cache without a banner is created in the new version and the user switches to an old version and creates a savefile.

~~This change should also be applied to DolphinQt. Is anyone up for doing it? (cc @waddlesplash)~~