### PR TITLE
Support partial texture updates via efb copies

### DIFF
--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -77,6 +77,13 @@ bool TextureCache::TCacheEntry::Save(const std::string& filename, unsigned int l
 	return saved_png;
 }
 
+void TextureCache::TCacheEntry::DoPartialTextureUpdate(TCacheEntryBase* entry_, u32 x, u32 y)
+{
+	TCacheEntry* entry = (TCacheEntry*)entry_;
+
+	D3D::context->CopySubresourceRegion(texture->GetTex(), 0, x , y , 0, entry->texture->GetTex(), 0, NULL);
+}
+
 void TextureCache::TCacheEntry::Load(unsigned int width, unsigned int height,
 	unsigned int expanded_width, unsigned int level)
 {

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -26,6 +26,8 @@ private:
 		TCacheEntry(const TCacheEntryConfig& config, D3DTexture2D *_tex) : TCacheEntryBase(config), texture(_tex) {}
 		~TCacheEntry();
 
+		void DoPartialTextureUpdate(TCacheEntryBase* entry, u32 x, u32 y) override;
+
 		void Load(unsigned int width, unsigned int height,
 			unsigned int expanded_width, unsigned int levels) override;
 

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -84,6 +84,7 @@ void InitBackendInfo()
 	g_Config.backend_info.bSupportsPostProcessing = false;
 	g_Config.backend_info.bSupportsPaletteConversion = true;
 	g_Config.backend_info.bSupportsClipControl = false;
+	g_Config.backend_info.bSupportsCopySubImage = true;
 
 	IDXGIFactory* factory;
 	IDXGIAdapter* ad;

--- a/Source/Core/VideoBackends/OGL/GLExtensions/ARB_copy_image.h
+++ b/Source/Core/VideoBackends/OGL/GLExtensions/ARB_copy_image.h
@@ -1,0 +1,10 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoBackends/OGL/GLExtensions/gl_common.h"
+
+typedef void (GLAPIENTRY * PFNGLCOPYIMAGESUBDATAPROC) (GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth);
+
+extern PFNGLCOPYIMAGESUBDATAPROC glCopyImageSubData;
+

--- a/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
@@ -788,6 +788,9 @@ PFNGLGETOCCLUSIONQUERYUIVNVPROC glGetOcclusionQueryuivNV;
 // ARB_clip_control
 PFNGLCLIPCONTROLPROC glClipControl;
 
+// ARB_copy_image
+PFNGLCOPYIMAGESUBDATAPROC glCopyImageSubData;
+
 // Creates a GLFunc object that requires a feature
 #define GLFUNC_REQUIRES(x, y) { (void**)&x, #x, y }
 // Creates a GLFunc object with a different function suffix
@@ -1277,6 +1280,18 @@ const GLFunc gl_function_array[] =
 
 	// ARB_clip_control
 	GLFUNC_REQUIRES(glClipControl, "GL_ARB_clip_control"),
+
+	// ARB_copy_image
+	GLFUNC_REQUIRES(glCopyImageSubData, "GL_ARB_copy_image"),
+
+	// NV_copy_image
+	GLFUNC_SUFFIX(glCopyImageSubData, NV, "GL_NV_copy_image !GL_ARB_copy_image"),
+
+	// OES_copy_image
+	GLFUNC_SUFFIX(glCopyImageSubData, OES, "GL_OES_copy_image"),
+
+	// EXT_copy_image
+	GLFUNC_SUFFIX(glCopyImageSubData, EXT, "GL_EXT_copy_image !GL_OES_copy_image"),
 
 	// gl_1_1
 	// OpenGL 1.1 is at the end due to a bug in Android's EGL stack.

--- a/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.h
+++ b/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.h
@@ -9,6 +9,7 @@
 #include "VideoBackends/OGL/GLExtensions/ARB_blend_func_extended.h"
 #include "VideoBackends/OGL/GLExtensions/ARB_buffer_storage.h"
 #include "VideoBackends/OGL/GLExtensions/ARB_clip_control.h"
+#include "VideoBackends/OGL/GLExtensions/ARB_copy_image.h"
 #include "VideoBackends/OGL/GLExtensions/ARB_debug_output.h"
 #include "VideoBackends/OGL/GLExtensions/ARB_draw_elements_base_vertex.h"
 #include "VideoBackends/OGL/GLExtensions/ARB_ES2_compatibility.h"

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -469,6 +469,10 @@ Renderer::Renderer()
 	g_Config.backend_info.bSupportsGeometryShaders = GLExtensions::Version() >= 320;
 	g_Config.backend_info.bSupportsPaletteConversion = GLExtensions::Supports("GL_ARB_texture_buffer_object");
 	g_Config.backend_info.bSupportsClipControl = GLExtensions::Supports("GL_ARB_clip_control");
+	g_Config.backend_info.bSupportsCopySubImage = GLExtensions::Supports("GL_ARB_copy_image") ||
+	                                              GLExtensions::Supports("GL_NV_copy_image") ||
+	                                              GLExtensions::Supports("GL_EXT_copy_image") ||
+	                                              GLExtensions::Supports("GL_OES_copy_image");
 
 	// Desktop OpenGL supports the binding layout if it supports 420pack
 	// OpenGL ES 3.1 supports it implicitly without an extension
@@ -598,7 +602,8 @@ Renderer::Renderer()
 			g_ogl_config.bSupportsMSAA ? "" : "MSAA ",
 			g_ogl_config.bSupportSampleShading ? "" : "SSAA ",
 			g_ActiveConfig.backend_info.bSupportsGSInstancing ? "" : "GSInstancing ",
-			g_ActiveConfig.backend_info.bSupportsClipControl ? "" : "ClipControl "
+			g_ActiveConfig.backend_info.bSupportsClipControl ? "" : "ClipControl ",
+			g_ActiveConfig.backend_info.bSupportsCopySubImage ? "" : "CopyImageSubData "
 			);
 
 	s_last_multisample_mode = g_ActiveConfig.iMultisampleMode;

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -137,6 +137,14 @@ TextureCache::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntryConf
 	return entry;
 }
 
+void TextureCache::TCacheEntry::DoPartialTextureUpdate(TCacheEntryBase* entry_, u32 x, u32 y)
+{
+
+	TCacheEntry* entry = (TCacheEntry*)entry_;
+
+	glCopyImageSubData(entry->texture, GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, texture, GL_TEXTURE_2D_ARRAY, 0, x, y, 0, entry->native_width, entry->native_height, 1);
+}
+
 void TextureCache::TCacheEntry::Load(unsigned int width, unsigned int height,
 	unsigned int expanded_width, unsigned int level)
 {

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -33,6 +33,8 @@ private:
 		TCacheEntry(const TCacheEntryConfig& config);
 		~TCacheEntry();
 
+		void DoPartialTextureUpdate(TCacheEntryBase* entry, u32 x, u32 y) override;
+
 		void Load(unsigned int width, unsigned int height,
 			unsigned int expanded_width, unsigned int level) override;
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -53,6 +53,7 @@ public:
 		u32 format;
 		bool is_efb_copy;
 		bool is_custom_tex;
+		u32 copyMipMapStrideChannels;
 
 		unsigned int native_width, native_height; // Texture dimensions from the GameCube's point of view
 		unsigned int native_levels;
@@ -88,6 +89,8 @@ public:
 		virtual void Bind(unsigned int stage) = 0;
 		virtual bool Save(const std::string& filename, unsigned int level) = 0;
 
+		virtual void DoPartialTextureUpdate(TCacheEntryBase* entry, u32 x, u32 y) = 0;
+
 		virtual void Load(unsigned int width, unsigned int height,
 			unsigned int expanded_width, unsigned int level) = 0;
 		virtual void FromRenderTarget(u32 dstAddr, unsigned int dstFormat,
@@ -96,6 +99,8 @@ public:
 			const float *colmat) = 0;
 
 		bool OverlapsMemoryRange(u32 range_address, u32 range_size) const;
+
+		void DoPartialTextureUpdates();
 
 		bool IsEfbCopy() const { return is_efb_copy; }
 	};

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -160,6 +160,7 @@ struct VideoConfig final
 		bool bSupportsPostProcessing;
 		bool bSupportsPaletteConversion;
 		bool bSupportsClipControl; // Needed by VertexShaderGen, so must stay in VideoCommon
+		bool bSupportsCopySubImage; // Needed for partial texture updates
 	} backend_info;
 
 	// Utility


### PR DESCRIPTION
New Super Mario Bros uses a 1024x1024 texture for most objects in the levels. This texture is generated from data in memory, but some parts of it are generated via efb copies. On efb to texure only, the data from the efb copies is not written to memory. This results in those parts being either static or missing in Dolphin's representation of the texture. Examples for this are the spinning coins, the blue coins and the question mark block animation.

This pr copies the graphics from these efb copies into the graphics of of the big texture, at the right position. After this, the data in memory is still wrong, but the textures on the GPU are correct. Since this is only a display issue, that's fine.

Note: Apparently the efb copies happen 1st, and then the big texture is loaded, which is why the updates are applied on load, and not on the efb copy.

The limitations of this pr are(not going to be fixed in this pr):
- The big texture is not upscaled, so the partial texture updates are disabled, if the IR is not 1 and scaled efb copies is enabled. Otherwise there would be big graphical issues.
- The updates are disabled for efb to ram. 1. Without upscaling it would identical to how it looks now and 2. this would require a change or the removal of MakeRangeDynamic, among other things.
- Paletted textures are excluded, because support for those would require more work, like converting the efb copies before using them for the updates. This needs an example where this would be useful.
- Efb copies are excluded. Would this even make sense somehow?

About 90% of the OpenGL part was written by HdkR, thanks a lot.