### PR TITLE
Reinstate format string.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Externals/Qt"]
 	path = Externals/Qt
-	url = https://github.com/dolphin-emu/ext-win-qt.git
+	url = ../ext-win-qt.git
 	branch = master

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -304,7 +304,7 @@ bool ParsePartitionData(SPartition& _rPartition)
 		// Go through the filesystem and mark entries as used
 		for (SFileInfo file : filesystem->GetFileList())
 		{
-			DEBUG_LOG(DISCIO, file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
+			DEBUG_LOG(DISCIO, "%s", file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
 			// Just 1byte for directory? - it will end up reserving a cluster this way
 			if (file.m_NameOffset & 0x1000000)
 				MarkAsUsedE(_rPartition.Offset + _rPartition.Header.DataOffset, file.m_Offset, 1);


### PR DESCRIPTION
Avoid the consequences in the unlikely event the path includes a % and debug logging is enabled.