### PR TITLE
Limit size of loaded file systems

### DIFF
--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -270,6 +270,18 @@ void CFileSystemGCWii::InitFileSystem()
 	if (!Root.IsDirectory())
 		return;
 
+	// 12 bytes (the size of a file entry) times 10 * 1024 * 1024 is 120 MiB,
+	// more than total RAM in a Wii. No file system should use anywhere near that much.
+	static const u32 ARBITRARY_FILE_SYSTEM_SIZE_LIMIT = 10 * 1024 * 1024;
+	if (Root.m_FileSize > ARBITRARY_FILE_SYSTEM_SIZE_LIMIT)
+	{
+		// Without this check, Dolphin can crash by trying to allocate too much
+		// memory when loading the file systems of certain malformed disc images.
+
+		ERROR_LOG(DISCIO, "File system is abnormally large! Aborting loading");
+		return;
+	}
+
 	if (m_FileInfoVector.size())
 		PanicAlert("Wtf?");
 	u64 NameTableOffset = FSTOffset;


### PR DESCRIPTION
If a disc image is corrupt in a specific way, Dolphin will try to allocate a lot of memory, making it crash. (https://github.com/dolphin-emu/dolphin/commit/2d5d5fa83e9ccb32252756fc0390740c952121b1#commitcomment-11147057)

To avoid that, this change adds an artificial limit for the size of file systems that Dolphin will try to load.