### PR TITLE
Fix performance regression in Sonic the Fighters, introduced by PR#2001

### DIFF
--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -244,7 +244,8 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 
 		TextureCache::MakeRangeDynamic(dstAddr, (u32)encoded_size);
 
-		this->hash = GetHash64(dst, (int)encoded_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
+		u64 const new_hash = GetHash64(dst, (u32)encoded_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
+		SetHashes(new_hash, new_hash);
 	}
 }
 

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -275,13 +275,13 @@ void TextureCache::TCacheEntry::FromRenderTarget(u32 dstAddr, unsigned int dstFo
 			copyMipMapStrideChannels * 32);
 
 		u8* dst = Memory::GetPointer(dstAddr);
-		u64 const new_hash = GetHash64(dst,encoded_size,g_ActiveConfig.iSafeTextureCache_ColorSamples);
+		u64 const new_hash = GetHash64(dst, encoded_size, g_ActiveConfig.iSafeTextureCache_ColorSamples);
 
 		size_in_bytes = (u32)encoded_size;
 
 		TextureCache::MakeRangeDynamic(dstAddr, encoded_size);
 
-		hash = new_hash;
+		SetHashes(new_hash, new_hash);
 	}
 
 	FramebufferManager::SetFramebuffer(0);

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -50,6 +50,7 @@ public:
 		u32 addr;
 		u32 size_in_bytes;
 		u64 hash;
+		u64 base_hash;
 		u32 format;
 		bool is_efb_copy;
 		bool is_custom_tex;
@@ -78,9 +79,10 @@ public:
 			native_levels = _native_levels;
 		}
 
-		void SetHashes(u64 _hash)
+		void SetHashes(u64 _hash, u64 _base_hash)
 		{
 			hash = _hash;
+			base_hash = _base_hash;
 		}
 
 		TCacheEntryBase(const TCacheEntryConfig& c) : config(c) {}


### PR DESCRIPTION
Ready for review and merging.

Sonic the Fighters (part of the Sonic Gems Collection) uses a lot of paletted textures, which are not cached properly since merging PR https://github.com/dolphin-emu/dolphin/pull/2001. This PR readds caching for paletted textures, as long as only the palette changes.

The TEXTURE_KILL_THRESHOLD change is needed to undo a large part of the performance regression. The game uses some 64 long animation and loops it. If TEXTURE_KILL_THRESHOLD is less than 64, there's a new texture uploaded every frame. On the original arcade machine, this animation is 1 second long, so the animation might be the timer.