### PR TITLE
Netplay: Sync GameCube SRAM.

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -35,6 +35,7 @@
 #include "Core/NetPlayProto.h"
 #include "Core/HW/EXI.h"
 #include "Core/HW/SI.h"
+#include "Core/HW/Sram.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
@@ -246,6 +247,8 @@ bool BootCore(const std::string& _rFilename)
 		StartUp.bDSPHLE = g_NetPlaySettings.m_DSPHLE;
 		StartUp.bEnableMemcardSaving = g_NetPlaySettings.m_WriteToMemcard;
 		StartUp.iCPUCore = g_NetPlaySettings.m_CPUcore;
+		StartUp.SelectedLanguage = g_NetPlaySettings.m_SelectedLanguage;
+		StartUp.bOverrideGCLanguage = g_NetPlaySettings.m_OverrideGCLanguage;
 		SConfig::GetInstance().m_DSPEnableJIT = g_NetPlaySettings.m_DSPEnableJIT;
 		SConfig::GetInstance().m_OCEnable = g_NetPlaySettings.m_OCEnable;
 		SConfig::GetInstance().m_OCFactor = g_NetPlaySettings.m_OCFactor;
@@ -253,6 +256,10 @@ bool BootCore(const std::string& _rFilename)
 		SConfig::GetInstance().m_EXIDevice[1] = g_NetPlaySettings.m_EXIDevice[1];
 		config_cache.bSetEXIDevice[0] = true;
 		config_cache.bSetEXIDevice[1] = true;
+	}
+	else
+	{
+		g_SRAM_netplay_initialized = false;
 	}
 
 	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", StartUp.bProgressive);

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -186,12 +186,6 @@ bool BootCore(const std::string& _rFilename)
 			}
 		}
 
-		// Some NTSC GameCube games such as Baten Kaitos react strangely to language settings that would be invalid on an NTSC system
-		if (!StartUp.bOverrideGCLanguage && StartUp.bNTSC)
-		{
-			StartUp.SelectedLanguage = 0;
-		}
-
 		// Wii settings
 		if (StartUp.bWii)
 		{
@@ -260,6 +254,13 @@ bool BootCore(const std::string& _rFilename)
 	else
 	{
 		g_SRAM_netplay_initialized = false;
+	}
+
+	// Apply overrides
+	// Some NTSC GameCube games such as Baten Kaitos react strangely to language settings that would be invalid on an NTSC system
+	if (!StartUp.bOverrideGCLanguage && StartUp.bNTSC)
+	{
+		StartUp.SelectedLanguage = 0;
 	}
 
 	SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", StartUp.bProgressive);

--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -16,6 +16,7 @@
 #include "Core/PowerPC/PowerPC.h"
 
 SRAM g_SRAM;
+bool g_SRAM_netplay_initialized = false;
 
 namespace ExpansionInterface
 {
@@ -30,7 +31,11 @@ static void UpdateInterruptsCallback(u64 userdata, int cycles_late);
 
 void Init()
 {
-	InitSRAM();
+	if (!g_SRAM_netplay_initialized)
+	{
+		InitSRAM();
+	}
+
 	for (u32 i = 0; i < MAX_EXI_CHANNELS; i++)
 		g_Channels[i] = new CEXIChannel(i);
 

--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -128,8 +128,15 @@ CEXIIPL::~CEXIIPL()
 	m_pIPL = nullptr;
 
 	// SRAM
-	File::IOFile file(SConfig::GetInstance().m_strSRAM, "wb");
-	file.WriteArray(&g_SRAM, 1);
+	if (!g_SRAM_netplay_initialized)
+	{
+		File::IOFile file(SConfig::GetInstance().m_strSRAM, "wb");
+		file.WriteArray(&g_SRAM, 1);
+	}
+	else
+	{
+		g_SRAM_netplay_initialized = false;
+	}
 }
 void CEXIIPL::DoState(PointerWrap &p)
 {

--- a/Source/Core/Core/HW/Sram.h
+++ b/Source/Core/Core/HW/Sram.h
@@ -84,3 +84,4 @@ void FixSRAMChecksums();
 
 extern SRAM sram_dump;
 extern SRAM g_SRAM;
+extern bool g_SRAM_netplay_initialized;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -12,6 +12,8 @@ struct NetSettings
 {
 	bool m_CPUthread;
 	int m_CPUcore;
+	int m_SelectedLanguage;
+	bool m_OverrideGCLanguage;
 	bool m_DSPHLE;
 	bool m_DSPEnableJIT;
 	bool m_WriteToMemcard;
@@ -29,7 +31,7 @@ struct Rpt : public std::vector<u8>
 
 typedef std::vector<u8> NetWiimote;
 
-#define NETPLAY_VERSION  "Dolphin NetPlay 2015-03-10"
+#define NETPLAY_VERSION  "Dolphin NetPlay 2015-06-14"
 
 extern u64 g_netplay_initial_gctime;
 
@@ -62,6 +64,8 @@ enum
 	NP_MSG_PING = 0xE0,
 	NP_MSG_PONG = 0xE1,
 	NP_MSG_PLAYER_PING_DATA = 0xE2,
+
+	NP_MSG_SYNC_GC_SRAM = 0xF0,
 };
 
 typedef u8  MessageId;

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -252,6 +252,8 @@ void NetPlayDialog::GetNetSettings(NetSettings &settings)
 	SConfig &instance = SConfig::GetInstance();
 	settings.m_CPUthread = instance.bCPUThread;
 	settings.m_CPUcore = instance.iCPUCore;
+	settings.m_SelectedLanguage = instance.SelectedLanguage;
+	settings.m_OverrideGCLanguage = instance.bOverrideGCLanguage;
 	settings.m_DSPHLE = instance.bDSPHLE;
 	settings.m_DSPEnableJIT = instance.m_DSPEnableJIT;
 	settings.m_WriteToMemcard = m_memcard_write->GetValue();


### PR DESCRIPTION
Sync the GameCube SRAM and related settings of all Netplay Clients to that of the Netplay Host.

I'm not entirely sure about the `g_SRAM_netplay_initialized` boolean but I can't really think of a better way to make sure the host SRAM doesn't get written to HDD on the client's side -- `NetPlay::IsNetPlayRunning()` can be no longer true when the `CEXIIPL::~CEXIIPL()` destructor runs depending on how Netplay terminated. Suggestions welcome.

Fixes [issue 8660](https://code.google.com/p/dolphin-emu/issues/detail?id=8660).