### PR TITLE
Android: Fix a bug making Input Overlay config screen only work in debug builds.

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -11,6 +11,7 @@ android {
     }
 
     defaultConfig {
+        // TODO If this is ever modified, change application_id in strings.xml
         applicationId "org.dolphinemu.dolphinemu"
         minSdkVersion 21
         targetSdkVersion 21
@@ -43,6 +44,7 @@ android {
         // Signed by debug key disallowing distribution on Play Store.
         // Attaches 'debug' suffix to version and package name, allowing installation alongside the release build.
         debug {
+            // TODO If this is ever modified, change application_id in debug/strings.xml
             applicationIdSuffix ".debug"
             versionNameSuffix '-debug'
             jniDebuggable true

--- a/Source/Android/app/src/debug/res/values/strings.xml
+++ b/Source/Android/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="application_id">org.dolphinemu.dolphinemu.debug</string>
+</resources>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -240,4 +240,7 @@
     <string name="emulation_title">Emulation Activity</string>
 
     <string name="emulation_toggle_input">Toggle Input Overlay</string>
+
+    <!-- Package Names-->
+    <string name="application_id">org.dolphinemu.dolphinemu</string>
 </resources>

--- a/Source/Android/app/src/main/res/xml/preferences.xml
+++ b/Source/Android/app/src/main/res/xml/preferences.xml
@@ -43,7 +43,7 @@
 
                 <intent
                     android:targetClass="org.dolphinemu.dolphinemu.activities.OverlayConfigActivity"
-                    android:targetPackage="org.dolphinemu.dolphinemu.debug"/>
+                    android:targetPackage="@string/application_id"/>
 
             </Preference>
 


### PR DESCRIPTION
This bug has been around a long time, only it used to make that screen only work in Release builds, so it went unnoticed.

Now it should work regardless of build type.