### PR TITLE
Moved DEBUG_SSL features in INI options

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -95,6 +95,7 @@ void SConfig::SaveSettings()
 	SaveDSPSettings(ini);
 	SaveInputSettings(ini);
 	SaveFifoPlayerSettings(ini);
+	SaveNetworkSettings(ini);
 
 	ini.Save(File::GetUserPath(F_DOLPHINCONFIG_IDX));
 	m_SYSCONF->Save();
@@ -302,6 +303,14 @@ void SConfig::SaveFifoPlayerSettings(IniFile& ini)
 	fifoplayer->Set("LoopReplay", bLoopFifoReplay);
 }
 
+void SConfig::SaveNetworkSettings(IniFile& ini)
+{
+	IniFile::Section* network = ini.GetOrCreateSection("Network");
+
+	network->Set("SSLDumpRead", m_SSLDumpRead);
+	network->Set("SSLDumpWrite", m_SSLDumpWrite);
+}
+
 void SConfig::LoadSettings()
 {
 	INFO_LOG(BOOT, "Loading Settings from %s", File::GetUserPath(F_DOLPHINCONFIG_IDX).c_str());
@@ -317,6 +326,7 @@ void SConfig::LoadSettings()
 	LoadDSPSettings(ini);
 	LoadInputSettings(ini);
 	LoadFifoPlayerSettings(ini);
+	LoadNetworkSettings(ini);
 
 	m_SYSCONF = new SysConf();
 }
@@ -963,4 +973,12 @@ std::vector<std::string> SConfig::GetGameIniFilenames(const std::string& id, u16
 	filenames.push_back(id + StringFromFormat("r%d", revision) + ".ini");
 
 	return filenames;
+}
+
+void SConfig::LoadNetworkSettings(IniFile& ini)
+{
+	IniFile::Section* network = ini.GetOrCreateSection("Network");
+
+	network->Get("SSLDumpRead", &m_SSLDumpRead, false);
+	network->Get("SSLDumpWrite", &m_SSLDumpWrite, false);
 }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -263,6 +263,10 @@ struct SConfig : NonCopyable
 	bool m_GameCubeAdapter;
 	bool m_AdapterRumble;
 
+	// Network settings
+	bool m_SSLDumpRead;
+	bool m_SSLDumpWrite;
+
 	SysConf* m_SYSCONF;
 
 	// Save settings
@@ -290,6 +294,7 @@ private:
 	void SaveInputSettings(IniFile& ini);
 	void SaveMovieSettings(IniFile& ini);
 	void SaveFifoPlayerSettings(IniFile& ini);
+	void SaveNetworkSettings(IniFile& ini);
 
 	void LoadGeneralSettings(IniFile& ini);
 	void LoadInterfaceSettings(IniFile& ini);
@@ -300,6 +305,7 @@ private:
 	void LoadInputSettings(IniFile& ini);
 	void LoadMovieSettings(IniFile& ini);
 	void LoadFifoPlayerSettings(IniFile& ini);
+	void LoadNetworkSettings(IniFile& ini);
 
 	static SConfig* m_Instance;
 };

--- a/Source/Core/Core/IPC_HLE/WII_Socket.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 
 #include "Common/FileUtil.h"
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
@@ -342,9 +343,9 @@ void WiiSocket::Update(bool read, bool write, bool except)
 					{
 						int ret = ssl_write(&CWII_IPC_HLE_Device_net_ssl::_SSL[sslID].ctx, Memory::GetPointer(BufferOut2), BufferOutSize2);
 
-#ifdef DEBUG_SSL
-						File::IOFile("ssl_write.bin", "ab").WriteBytes(Memory::GetPointer(BufferOut2), BufferOutSize2);
-#endif
+						if (SConfig::GetInstance().m_SSLDumpWrite && ret > 0)
+							File::IOFile("ssl_write.bin", "ab").WriteBytes(Memory::GetPointer(BufferOut2), ret);
+
 						if (ret >= 0)
 						{
 							// Return bytes written or SSL_ERR_ZERO if none
@@ -374,12 +375,10 @@ void WiiSocket::Update(bool read, bool write, bool except)
 					case IOCTLV_NET_SSL_READ:
 					{
 						int ret = ssl_read(&CWII_IPC_HLE_Device_net_ssl::_SSL[sslID].ctx, Memory::GetPointer(BufferIn2), BufferInSize2);
-#ifdef DEBUG_SSL
-						if (ret > 0)
-						{
+
+						if (SConfig::GetInstance().m_SSLDumpRead && ret > 0)
 							File::IOFile("ssl_read.bin", "ab").WriteBytes(Memory::GetPointer(BufferIn2), ret);
-						}
-#endif
+
 						if (ret >= 0)
 						{
 							// Return bytes read or SSL_ERR_ZERO if none


### PR DESCRIPTION
Moved DEBUG_SSL features in INI options. This way, no need to recompile the emulator to use them.