### PR TITLE
Match Wii Video Mode settings to console.

### DIFF
--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -5,6 +5,7 @@
 #include <wx/checkbox.h>
 #include <wx/choice.h>
 #include <wx/gbsizer.h>
+#include <wx/radiobox.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
@@ -38,34 +39,39 @@ void WiiConfigPane::InitializeGUI()
   m_system_language_strings.Add(_("Traditional Chinese"));
   m_system_language_strings.Add(_("Korean"));
 
+  m_refresh_rate_strings.Add(_("50 Hz"));
+  m_refresh_rate_strings.Add(_("60 Hz"));
+
   m_screensaver_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Screen Saver"));
-  m_pal60_mode_checkbox = new wxCheckBox(this, wxID_ANY, _("Use PAL60 Mode (EuRGB60)"));
   m_aspect_ratio_choice =
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_aspect_ratio_strings);
   m_system_language_choice =
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_system_language_strings);
   m_sd_card_checkbox = new wxCheckBox(this, wxID_ANY, _("Insert SD Card"));
   m_connect_keyboard_checkbox = new wxCheckBox(this, wxID_ANY, _("Connect USB Keyboard"));
+  m_refresh_rate_radiobox =
+      new wxRadioBox(this, wxID_ANY, _("Refresh Rate (PAL)"), wxDefaultPosition, wxDefaultSize,
+                     m_refresh_rate_strings, 0, wxRA_SPECIFY_COLS);
 
   m_screensaver_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnScreenSaverCheckBoxChanged, this);
-  m_pal60_mode_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnPAL60CheckBoxChanged, this);
   m_aspect_ratio_choice->Bind(wxEVT_CHOICE, &WiiConfigPane::OnAspectRatioChoiceChanged, this);
   m_system_language_choice->Bind(wxEVT_CHOICE, &WiiConfigPane::OnSystemLanguageChoiceChanged, this);
   m_sd_card_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnSDCardCheckBoxChanged, this);
   m_connect_keyboard_checkbox->Bind(wxEVT_CHECKBOX,
                                     &WiiConfigPane::OnConnectKeyboardCheckBoxChanged, this);
+  m_refresh_rate_radiobox->Bind(wxEVT_RADIOBOX, &WiiConfigPane::OnRefreshRateRadioBoxChanged, this);
 
   m_screensaver_checkbox->SetToolTip(_("Dims the screen after five minutes of inactivity."));
-  m_pal60_mode_checkbox->SetToolTip(_("Sets the Wii display mode to 60Hz (480i) instead of 50Hz "
-                                      "(576i) for PAL games.\nMay not work for all games."));
   m_system_language_choice->SetToolTip(_("Sets the Wii system language."));
   m_sd_card_checkbox->SetToolTip(_("Saved to /Wii/sd.raw (default size is 128mb)"));
   m_connect_keyboard_checkbox->SetToolTip(_("May cause slow down in Wii Menu and some games."));
+  m_refresh_rate_radiobox->SetToolTip(_("Sets the video refresh rate for PAL games and homebrew. "
+                                        "Some games may only support one or the other."));
 
   wxGridBagSizer* const misc_settings_grid_sizer = new wxGridBagSizer();
-  misc_settings_grid_sizer->Add(m_screensaver_checkbox, wxGBPosition(0, 0), wxGBSpan(1, 2), wxALL,
+  misc_settings_grid_sizer->Add(m_refresh_rate_radiobox, wxGBPosition(0, 0), wxGBSpan(1, 2), wxALL,
                                 5);
-  misc_settings_grid_sizer->Add(m_pal60_mode_checkbox, wxGBPosition(1, 0), wxGBSpan(1, 2), wxALL,
+  misc_settings_grid_sizer->Add(m_screensaver_checkbox, wxGBPosition(1, 0), wxGBSpan(1, 2), wxALL,
                                 5);
   misc_settings_grid_sizer->Add(new wxStaticText(this, wxID_ANY, _("Aspect Ratio:")),
                                 wxGBPosition(2, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxALL,
@@ -96,12 +102,16 @@ void WiiConfigPane::InitializeGUI()
 void WiiConfigPane::LoadGUIValues()
 {
   m_screensaver_checkbox->SetValue(!!SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.SSV"));
-  m_pal60_mode_checkbox->SetValue(SConfig::GetInstance().bPAL60);
   m_aspect_ratio_choice->SetSelection(SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.AR"));
   m_system_language_choice->SetSelection(SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG"));
 
   m_sd_card_checkbox->SetValue(SConfig::GetInstance().m_WiiSDCard);
   m_connect_keyboard_checkbox->SetValue(SConfig::GetInstance().m_WiiKeyboard);
+
+  if (SConfig::GetInstance().bPAL60)
+    m_refresh_rate_radiobox->SetSelection(1);
+  else
+    m_refresh_rate_radiobox->SetSelection(0);
 }
 
 void WiiConfigPane::RefreshGUI()
@@ -109,21 +119,15 @@ void WiiConfigPane::RefreshGUI()
   if (Core::IsRunning())
   {
     m_screensaver_checkbox->Disable();
-    m_pal60_mode_checkbox->Disable();
     m_aspect_ratio_choice->Disable();
     m_system_language_choice->Disable();
+    m_refresh_rate_radiobox->Disable();
   }
 }
 
 void WiiConfigPane::OnScreenSaverCheckBoxChanged(wxCommandEvent& event)
 {
   SConfig::GetInstance().m_SYSCONF->SetData("IPL.SSV", m_screensaver_checkbox->IsChecked());
-}
-
-void WiiConfigPane::OnPAL60CheckBoxChanged(wxCommandEvent& event)
-{
-  SConfig::GetInstance().bPAL60 = m_pal60_mode_checkbox->IsChecked();
-  SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", m_pal60_mode_checkbox->IsChecked());
 }
 
 void WiiConfigPane::OnSDCardCheckBoxChanged(wxCommandEvent& event)
@@ -151,6 +155,13 @@ void WiiConfigPane::OnSystemLanguageChoiceChanged(wxCommandEvent& event)
 void WiiConfigPane::OnAspectRatioChoiceChanged(wxCommandEvent& event)
 {
   SConfig::GetInstance().m_SYSCONF->SetData("IPL.AR", m_aspect_ratio_choice->GetSelection());
+}
+
+void WiiConfigPane::OnRefreshRateRadioBoxChanged(wxCommandEvent& event)
+{
+  const bool bPAL60 = m_refresh_rate_radiobox->GetSelection() != 0;
+  SConfig::GetInstance().bPAL60 = bPAL60;
+  SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", bPAL60);
 }
 
 // Change from IPL.LNG value to IPL.SADR country code.

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.h
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.h
@@ -15,6 +15,7 @@ enum class Language;
 
 class wxCheckBox;
 class wxChoice;
+class wxRadioBox;
 
 class WiiConfigPane final : public wxPanel
 {
@@ -27,21 +28,22 @@ private:
   void RefreshGUI();
 
   void OnScreenSaverCheckBoxChanged(wxCommandEvent&);
-  void OnPAL60CheckBoxChanged(wxCommandEvent&);
   void OnSDCardCheckBoxChanged(wxCommandEvent&);
   void OnConnectKeyboardCheckBoxChanged(wxCommandEvent&);
   void OnSystemLanguageChoiceChanged(wxCommandEvent&);
   void OnAspectRatioChoiceChanged(wxCommandEvent&);
+  void OnRefreshRateRadioBoxChanged(wxCommandEvent&);
 
   static u8 GetSADRCountryCode(DiscIO::Language language);
 
+  wxArrayString m_refresh_rate_strings;
   wxArrayString m_system_language_strings;
   wxArrayString m_aspect_ratio_strings;
 
   wxCheckBox* m_screensaver_checkbox;
-  wxCheckBox* m_pal60_mode_checkbox;
   wxCheckBox* m_sd_card_checkbox;
   wxCheckBox* m_connect_keyboard_checkbox;
   wxChoice* m_system_language_choice;
   wxChoice* m_aspect_ratio_choice;
+  wxRadioBox* m_refresh_rate_radiobox;
 };


### PR DESCRIPTION
~~This is the GUI changes from #2532, which changes the Wii video mode selection to be more like on console. http://i.imgur.com/0y3DLI1m.png http://i.imgur.com/wB9znLe.png The labeling is slightly different because "EDTV/HDTV" would make little sense in Dolphin.~~

Changed after some feedback to the more user-friendly:

e: All this has now is the GUI change from PAL60 checkbox to 50Hz/60Hz radio buttons.

[![Wii 50Hz/60Hz](http://i.imgur.com/qtPdpYa.png)](http://i.imgur.com/qtPdpYa.png)

~~Since the bProgressive flag also applied to GameCube before, this also includes a separate option for Component Cable emulation rather than having it combined with the Progressive/480p option. If 480p is selected as the Wii video mode but Component Cable is disabled, it will be automatically temporarily enabled while running Wii games. (e: Last part no longer necessary since it's not combined anymore.)~~

Please review and discuss.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/2618)

<!-- Reviewable:end -->
