### PR TITLE
Volume: Use DecodeString more

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -47,7 +47,7 @@ std::string CVolumeGC::GetUniqueID() const
 	if (m_pReader == nullptr)
 		return NO_UID;
 
-	char ID[7];
+	char ID[6];
 
 	if (!Read(0, sizeof(ID), reinterpret_cast<u8*>(ID)))
 	{
@@ -55,9 +55,7 @@ std::string CVolumeGC::GetUniqueID() const
 		return NO_UID;
 	}
 
-	ID[6] = '\0';
-
-	return ID;
+	return DecodeString(ID);
 }
 
 IVolume::ECountry CVolumeGC::GetCountry() const
@@ -76,12 +74,11 @@ std::string CVolumeGC::GetMakerID() const
 	if (m_pReader == nullptr)
 		return std::string();
 
-	char makerID[3];
+	char makerID[2];
 	if (!Read(0x4, 0x2, (u8*)&makerID))
 		return std::string();
-	makerID[2] = '\0';
 
-	return makerID;
+	return DecodeString(makerID);
 }
 
 u16 CVolumeGC::GetRevision() const
@@ -166,10 +163,8 @@ std::string CVolumeGC::GetApploaderDate() const
 	char date[16];
 	if (!Read(0x2440, 0x10, (u8*)&date))
 		return std::string();
-	// Should be 0 already, but just in case
-	date[10] = '\0';
 
-	return date;
+	return DecodeString(date);
 }
 
 u64 CVolumeGC::GetSize() const

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -70,29 +70,25 @@ IVolume::ECountry CVolumeWAD::GetCountry() const
 
 std::string CVolumeWAD::GetUniqueID() const
 {
-	std::string temp = GetMakerID();
-
-	char GameCode[8];
+	char GameCode[6];
 	if (!Read(m_offset + 0x01E0, 4, (u8*)GameCode))
 		return "0";
 
+	std::string temp = GetMakerID();
 	GameCode[4] = temp.at(0);
 	GameCode[5] = temp.at(1);
-	GameCode[6] = 0;
 
-	return GameCode;
+	return DecodeString(GameCode);
 }
 
 std::string CVolumeWAD::GetMakerID() const
 {
-	char temp[3] = {1};
+	char temp[2] = {1};
 	// Some weird channels use 0x0000 in place of the MakerID, so we need a check there
 	if (!Read(0x198 + m_tmd_offset, 2, (u8*)temp) || temp[0] == 0 || temp[1] == 0)
 		return "00";
 
-	temp[2] = 0;
-
-	return temp;
+	return DecodeString(temp);
 }
 
 bool CVolumeWAD::GetTitleID(u8* _pBuffer) const

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -144,14 +144,12 @@ std::string CVolumeWiiCrypted::GetUniqueID() const
 	if (m_pReader == nullptr)
 		return std::string();
 
-	char ID[7];
+	char ID[6];
 
 	if (!Read(0, 6, (u8*)ID, false))
 		return std::string();
 
-	ID[6] = '\0';
-
-	return ID;
+	return DecodeString(ID);
 }
 
 
@@ -171,14 +169,12 @@ std::string CVolumeWiiCrypted::GetMakerID() const
 	if (m_pReader == nullptr)
 		return std::string();
 
-	char makerID[3];
+	char makerID[2];
 
 	if (!Read(0x4, 0x2, (u8*)&makerID, false))
 		return std::string();
 
-	makerID[2] = '\0';
-
-	return makerID;
+	return DecodeString(makerID);
 }
 
 u16 CVolumeWiiCrypted::GetRevision() const
@@ -233,9 +229,7 @@ std::string CVolumeWiiCrypted::GetApploaderDate() const
 	if (!Read(0x2440, 0x10, (u8*)&date, true))
 		return std::string();
 
-	date[10] = '\0';
-
-	return date;
+	return DecodeString(date);
 }
 
 IVolume::EPlatform CVolumeWiiCrypted::GetVolumeType() const


### PR DESCRIPTION
DecodeString handles the case where there is no trailing null byte, so using it lets the code be a bit simpler.