### PR TITLE
Fix Homebrew region inconsistency exposed by #2596.

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -166,21 +166,24 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
 bool CBoot::SetupWiiMemory(DiscIO::IVolume::ECountry country)
 {
 	static const CountrySetting SETTING_EUROPE = {"EUR", "PAL",  "EU", "LE"};
+	static const CountrySetting SETTING_USA    = {"USA", "NTSC", "US", "LU"};
+	static const CountrySetting SETTING_JAPAN  = {"JPN", "NTSC", "JP", "LJ"};
+	static const CountrySetting SETTING_KOREA  = {"KOR", "NTSC", "KR", "LKH"};
 	static const std::map<DiscIO::IVolume::ECountry, const CountrySetting> country_settings = {
 		{DiscIO::IVolume::COUNTRY_EUROPE, SETTING_EUROPE},
-		{DiscIO::IVolume::COUNTRY_USA,    {"USA", "NTSC", "US", "LU"}},
-		{DiscIO::IVolume::COUNTRY_JAPAN,  {"JPN", "NTSC", "JP", "LJ"}},
-		{DiscIO::IVolume::COUNTRY_KOREA,  {"KOR", "NTSC", "KR", "LKH"}},
+		{DiscIO::IVolume::COUNTRY_USA,    SETTING_USA},
+		{DiscIO::IVolume::COUNTRY_JAPAN,  SETTING_JAPAN},
+		{DiscIO::IVolume::COUNTRY_KOREA,  SETTING_KOREA},
 		//TODO: Determine if Taiwan have their own specific settings.
 		//      Also determine if there are other specific settings
 		//      for other countries.
-		{DiscIO::IVolume::COUNTRY_TAIWAN, {"JPN", "NTSC", "JP", "LJ"}}
+		{DiscIO::IVolume::COUNTRY_TAIWAN, SETTING_JAPAN}
 	};
 	auto entryPos = country_settings.find(country);
 	const CountrySetting& country_setting =
 		(entryPos != country_settings.end()) ?
 		  entryPos->second :
-		  SETTING_EUROPE; //Default to EUROPE
+		  (SConfig::GetInstance().bNTSC ? SETTING_USA : SETTING_EUROPE); // default to USA or EUR depending on game's video mode
 
 	SettingsHandler gen;
 	std::string serno;

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -717,17 +717,21 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
 			else if (!strcasecmp(Extension.c_str(), ".elf"))
 			{
 				bWii = CBoot::IsElfWii(m_strFilename);
-				set_region_dir = USA_DIR;
+				// TODO: Right now GC homebrew boots in NTSC and Wii homebrew in PAL.
+				// This is intentional so that Wii homebrew can boot in both 50Hz and 60Hz, without forcing all GC homebrew to 50Hz.
+				// In the future, it probably makes sense to add a Region setting for homebrew somewhere in the emulator config.
+				bNTSC = bWii ? false : true;
+				set_region_dir = bNTSC ? USA_DIR : EUR_DIR;
 				m_BootType = BOOT_ELF;
-				bNTSC = true;
 			}
 			else if (!strcasecmp(Extension.c_str(), ".dol"))
 			{
 				CDolLoader dolfile(m_strFilename);
 				bWii = dolfile.IsWii();
-				set_region_dir = USA_DIR;
+				// TODO: See the ELF code above.
+				bNTSC = bWii ? false : true;
+				set_region_dir = bNTSC ? USA_DIR : EUR_DIR;
 				m_BootType = BOOT_DOL;
-				bNTSC = true;
 			}
 			else if (!strcasecmp(Extension.c_str(), ".dff"))
 			{


### PR DESCRIPTION
Prior to #2596, Wii Homebrew would boot in either 50Hz or 60Hz depending on if the PAL60 option was ticked in Config -> Wii. This made some amount of sense if you weren't familiar with the internal boot logic, so no one noticed why or how that actually worked.

#2596 changed it so that NTSC games would always turn off the PAL60 setting because some NTSC games would read that setting and crash because they were never tested in that environment. This exposed an odd behavior: Wii Homebrew now always boots in 50Hz! How and why does that happen?

To find the answer to that, we have to look into the source code for libogc, which almost all homebrew uses, to figure out how they choose which video mode to use. The sample code suggests to select an appropriate video mode by calling `VIDEO_GetPreferredMode()`, which is defined in `video.c`. The relevant part is this:

	u32 tvmode = CONF_GetVideo();
	if (CONF_GetProgressiveScan() > 0 && VIDEO_HaveComponentCable()) {
		switch (tvmode) {
			case CONF_VIDEO_NTSC:
				rmode = &TVNtsc480Prog;
				break;
			case CONF_VIDEO_PAL:
				if (CONF_GetEuRGB60() > 0)
					rmode = &TVEurgb60Hz480Prog;
				else rmode = &TVPal576ProgScale;
				break;
			case CONF_VIDEO_MPAL:
				rmode = &TVMpal480Prog;
				break;
			default:
				rmode = &TVNtsc480Prog;
		}
	} else {
		switch (tvmode) {
			case CONF_VIDEO_NTSC:
				rmode = &TVNtsc480IntDf;
				break;
			case CONF_VIDEO_PAL:
				if (CONF_GetEuRGB60() > 0)
					rmode = &TVEurgb60Hz480IntDf;
				else rmode = &TVPal576IntDfScale;
				break;
			case CONF_VIDEO_MPAL:
				rmode = &TVMpal480IntDf;
				break;
			default:
				rmode = &TVNtsc480IntDf;
		}
	}

Most of this is pretty clear, but what exactly does `CONF_GetVideo()` (in `conf.c`) do? Let's see...

	s32 CONF_GetVideo(void)
	{
		int res;
		char buf[5];

		res = __CONF_GetTxt("VIDEO", buf, 5);
		if(res < 0) return res;
		if(!strcmp(buf, "NTSC")) return CONF_VIDEO_NTSC;
		if(!strcmp(buf, "PAL")) return CONF_VIDEO_PAL;
		if(!strcmp(buf, "MPAL")) return CONF_VIDEO_MPAL;
		return CONF_EBADVALUE;
	}

Aha! `__CONF_GetTxt()` reads from the Wii's `setting.txt` file, so `CONF_GetVideo()` uses the VIDEO string from that to figure out the console region. From here we can work backwards to understand what this code does in Dolphin.

The `setting.txt` is generated in  [CBoot::SetupWiiMemory](https://github.com/AdmiralCurtiss/dolphin/blob/c375111076235313669e71953c877c9512cebd16/Source/Core/Core/Boot/Boot_BS2Emu.cpp#L166). Specifically, we decide which region to generate for with these lines:

	auto entryPos = country_settings.find(country);
	const CountrySetting& country_setting =
	        (entryPos != country_settings.end()) ?
	          entryPos->second :
	          SETTING_EUROPE; //Default to EUROPE

Homebrew doesn't have a game ID to read a country from, so it will always be `COUNTRY_UNKNOWN`, which in turn sets `SETTING_EUROPE`. In other words, homebrew always boots in a European console environment.

Well, that explains why the PAL60 setting affects the refresh rate of homebrew (compare with the `VIDEO_GetPreferredMode()` code), but it doesn't explain why that stopped working in #2596. So let's dig further.

[SConfig::AutoSetup](https://github.com/AdmiralCurtiss/dolphin/blob/92447fb052f5e4a0bc31f6a1268b439f5baf06a3/Source/Core/Core/ConfigManager.cpp#L658) runs before `CBoot::SetupWiiMemory` and sets up some boot parameters. For homebrew specifically, it sets:

	set_region_dir = USA_DIR;
	m_BootType = BOOT_ELF;
	bNTSC = true;

Now hold on, we just established that homebrew runs in a European environment! This is inconsistent! But it explains what happens and why #2596 broke it:

`SConfig::AutoSetup` sets NTSC-U parameters, which in turn causes [BootManager::BootCore()](https://github.com/AdmiralCurtiss/dolphin/blob/2e5e724f9401cb3dea28981a93b7467854f98dbb/Source/Core/Core/BootManager.cpp#L261) to turn off the PAL60 setting for compatibility reasons. Meanwhile, `CBoot::SetupWiiMemory` generates a European `setting.txt`. Then, in libogc, `VIDEO_GetPreferredMode()` sees the European `setting.txt` and the turned off PAL60 flag and selects a 50Hz video mode from that information.

This PR changes this so that a turned off PAL60 setting will boot Wii homebrew in a PAL/Europe environment at 50Hz, and a turned on PAL60 setting will boot Wii homebrew in a PAL/Europe environment at 60Hz. GameCube homebrew always boots in NTSC at 60Hz. This corresponds to how homebrew booted before #2596 and removes the odd regional inconsistency.

In the future we should maybe provide options to boot homebrew in any environment, and I've set it up so you'd only have to change the bNTSC flag appropriately in `SConfig::AutoSetup()` for the rest to set properly, but this is probably good enough for most use cases for now.