### PR TITLE
Revert "GeometryShaderGen: Don't use `centroid in` for input variables."

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -94,7 +94,7 @@ static inline void GenerateGeometryShader(T& out, u32 primitive_type, API_TYPE A
 			out.Write("#define InstanceID gl_InvocationID\n");
 
 		out.Write("in VertexData {\n");
-		GenerateVSOutputMembers<T>(out, ApiType);
+		GenerateVSOutputMembers<T>(out, ApiType, g_ActiveConfig.backend_info.bSupportsBindingLayout ? "centroid" : "centroid in");
 		out.Write("} vs[%d];\n", vertex_in);
 
 		out.Write("out VertexData {\n");


### PR DESCRIPTION
This reverts commit 4cbaddb7ad1e84946a6fb1af1d853af15be90615.

Specs say this centroid is allowed, and this commit breaks geometry shader support on all drivers.