### PR TITLE
Android: Save screenshot at end of an emulation session.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -274,6 +274,12 @@ public final class NativeLibrary
 		});
 	}
 
+	public static void endEmulationActivity()
+	{
+		Log.v("DolphinEmu", "Ending EmulationActivity.");
+		mEmulationActivity.finish();
+	}
+
 	public static void setEmulationActivity(EmulationActivity emulationActivity)
 	{
 		Log.v("DolphinEmu", "Registering EmulationActivity.");

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -150,7 +150,11 @@ public final class EmulationActivity extends AppCompatActivity
 		else
 		{
 			// Let the system handle it; i.e. quit the activity TODO or show "are you sure?" dialog.
-			super.onBackPressed();
+			EmulationFragment fragment = (EmulationFragment) getFragmentManager()
+					.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
+			fragment.notifyEmulationStopped();
+
+			NativeLibrary.StopEmulation();
 		}
 	}
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/MainActivity.java
@@ -128,13 +128,6 @@ public final class MainActivity extends AppCompatActivity implements LoaderManag
 	}
 
 	@Override
-	protected void onResume()
-	{
-		super.onResume();
-		mAdapter.notifyDataSetChanged();
-	}
-
-	@Override
 	public boolean onCreateOptionsMenu(Menu menu)
 	{
 		MenuInflater inflater = getMenuInflater();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/MainActivity.java
@@ -128,6 +128,13 @@ public final class MainActivity extends AppCompatActivity implements LoaderManag
 	}
 
 	@Override
+	protected void onResume()
+	{
+		super.onResume();
+		mAdapter.notifyDataSetChanged();
+	}
+
+	@Override
 	public boolean onCreateOptionsMenu(Menu menu)
 	{
 		MenuInflater inflater = getMenuInflater();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -79,9 +79,13 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 		{
 			if (mCursor.moveToPosition(position))
 			{
+				String screenPath = mCursor.getString(GameDatabase.GAME_COLUMN_SCREENSHOT_PATH);
+				Picasso.with(holder.imageScreenshot.getContext())
+						.invalidate(screenPath);
+
 				// Fill in the view contents.
 				Picasso.with(holder.imageScreenshot.getContext())
-						.load(mCursor.getString(GameDatabase.GAME_COLUMN_SCREENSHOT_PATH))
+						.load(screenPath)
 						.fit()
 						.centerCrop()
 						.error(R.drawable.no_banner)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -119,7 +119,7 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 	public void onDestroyView()
 	{
 		super.onDestroyView();
-		if (getActivity().isFinishing())
+		if (getActivity().isFinishing() && mEmulationStarted)
 		{
 			NativeLibrary.StopEmulation();
 		}
@@ -192,6 +192,16 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 		Log.d("DolphinEmu", "Pausing emulation.");
 
 		NativeLibrary.PauseEmulation();
+		mEmulationRunning = false;
+	}
+
+	/**
+	 * Called by containing activity to tell the Fragment emulation is already stopping,
+	 * so it doesn't try to stop emulation on its way to the garbage collector.
+	 */
+	public void notifyEmulationStopped()
+	{
+		mEmulationStarted = false;
 		mEmulationRunning = false;
 	}
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/Game.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/Game.java
@@ -113,21 +113,7 @@ public final class Game
 	{
 		ContentValues values = new ContentValues();
 
-		// TODO Come up with a way of finding the most recent screenshot that doesn't involve counting files
-		String screenshotFolderPath = PATH_SCREENSHOT_FOLDER + gameId + "/";
-
-		// Count how many screenshots are available, so we can use the most recent one.
-		File screenshotFolder = new File(screenshotFolderPath.substring(screenshotFolderPath.indexOf('s') - 1));
-		int screenCount = 0;
-
-		if (screenshotFolder.isDirectory())
-		{
-			screenCount = screenshotFolder.list().length;
-		}
-
-		String screenPath = screenshotFolderPath
-				+ gameId + "-"
-				+ screenCount + ".png";
+		String screenPath = PATH_SCREENSHOT_FOLDER + gameId + "/thumb.png";
 
 		values.put(GameDatabase.KEY_GAME_PLATFORM, platform);
 		values.put(GameDatabase.KEY_GAME_TITLE, title);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -636,7 +636,7 @@ EState GetState()
 	return CORE_UNINITIALIZED;
 }
 
-static std::string GenerateScreenshotName()
+static std::string GenerateScreenshotFolderPath()
 {
 	const std::string& gameId = SConfig::GetInstance().GetUniqueID();
 	std::string path = File::GetUserPath(D_SCREENSHOTS_IDX) + gameId + DIR_SEP_CHR;
@@ -647,8 +647,15 @@ static std::string GenerateScreenshotName()
 		path = File::GetUserPath(D_SCREENSHOTS_IDX);
 	}
 
+	return path;
+}
+
+static std::string GenerateScreenshotName()
+{
+	std::string path = GenerateScreenshotFolderPath();
+
 	//append gameId, path only contains the folder here.
-	path += gameId;
+	path += SConfig::GetInstance().GetUniqueID();
 
 	std::string name;
 	for (int i = 1; File::Exists(name = StringFromFormat("%s-%d.png", path.c_str(), i)); ++i)
@@ -671,15 +678,13 @@ void SaveScreenShot()
 		SetState(CORE_RUN);
 }
 
-void SaveScreenShot(std::string name)
+void SaveScreenShot(const std::string name)
 {
 	const bool bPaused = (GetState() == CORE_PAUSE);
 
 	SetState(CORE_PAUSE);
 
-	const std::string& gameId = SConfig::GetInstance().GetUniqueID();
-
-	std::string filePath = File::GetUserPath(D_SCREENSHOTS_IDX) + gameId + DIR_SEP_CHR + name + ".png";
+	std::string filePath = GenerateScreenshotFolderPath() + name + ".png";
 
 	g_video_backend->Video_Screenshot(filePath);
 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -671,6 +671,22 @@ void SaveScreenShot()
 		SetState(CORE_RUN);
 }
 
+void SaveScreenShot(std::string name)
+{
+	const bool bPaused = (GetState() == CORE_PAUSE);
+
+	SetState(CORE_PAUSE);
+
+	const std::string& gameId = SConfig::GetInstance().GetUniqueID();
+    std::string path = File::GetUserPath(D_SCREENSHOTS_IDX) + gameId + DIR_SEP_CHR;
+
+	name = StringFromFormat("%s%s.png", path.c_str(), name.c_str());
+	g_video_backend->Video_Screenshot(name);
+
+	if (!bPaused)
+	 	SetState(CORE_RUN);
+}
+
 void RequestRefreshInfo()
 {
 	s_request_refresh_info = true;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -678,10 +678,10 @@ void SaveScreenShot(std::string name)
 	SetState(CORE_PAUSE);
 
 	const std::string& gameId = SConfig::GetInstance().GetUniqueID();
-    std::string path = File::GetUserPath(D_SCREENSHOTS_IDX) + gameId + DIR_SEP_CHR;
 
-	name = StringFromFormat("%s%s.png", path.c_str(), name.c_str());
-	g_video_backend->Video_Screenshot(name);
+	std::string filePath = File::GetUserPath(D_SCREENSHOTS_IDX) + gameId + DIR_SEP_CHR + name + ".png";
+
+	g_video_backend->Video_Screenshot(filePath);
 
 	if (!bPaused)
 	 	SetState(CORE_RUN);

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -52,6 +52,7 @@ void SetState(EState _State);
 EState GetState();
 
 void SaveScreenShot();
+void SaveScreenShot(std::string name);
 
 void Callback_WiimoteInterruptChannel(int _number, u16 _channelID, const void* _pData, u32 _Size);
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1510,6 +1510,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 		// Reset settings
 		s_sScreenshotName.clear();
 		s_bScreenshot = false;
+		s_screenshotCompleted.Set();
 	}
 
 	// Frame dumps are handled a little differently in Windows

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "Common/Atomic.h"
+#include "Common/Event.h"
 #include "Common/Profiler.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
@@ -52,6 +53,8 @@ Renderer *g_renderer = nullptr;
 
 std::mutex Renderer::s_criticalScreenshot;
 std::string Renderer::s_sScreenshotName;
+
+Common::Event Renderer::s_screenshotCompleted;
 
 volatile bool Renderer::s_bScreenshot;
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <string>
 
+#include "Common/Event.h"
 #include "Common/MathUtil.h"
 #include "Common/Thread.h"
 #include "VideoCommon/BPMemory.h"
@@ -132,6 +133,8 @@ public:
 	PostProcessingShaderImplementation* GetPostProcessor() { return m_post_processor; }
 	// Max height/width
 	virtual int GetMaxTextureSize() = 0;
+
+	static Common::Event s_screenshotCompleted;
 
 protected:
 


### PR DESCRIPTION
This one is more complex than it might sound. Just telling Dolphin to take a screenshot as things are tearing down doesn't work; so now when the user asks the emulator to end the EmulationActivity, it sends a message to native-land telling it to take the screenshot and then block until the screenshot function reports completion. Native-land then tells Java to actually quit the Activity.

I also added a method that allows for namiing the target screenshot file. Right now the end-of-game screenshot is called "thumb.png" so that I can get rid of the logic that tried to figure out which screenshot was newest to show in the grid screen. Unfortunately, sometimes you have to quit the app altogether to get the grid to show the new screenshot. I'm working on fixing this, so this should get a WIP label for now.

However, this is a lot of C++ code for me, so I'd appreciate any feedback on that aspect.