### PR TITLE
VertexLoaderARM64: Disable FORMAT_24B_6666 colors

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -288,7 +288,7 @@ void VertexLoaderARM64::ReadColor(u64 attribute, int format, s32 offset)
 			else if (offset & 3) // Not aligned - unscaled
 				LDUR(scratch2_reg, src_reg, offset);
 			else
-				LDR(INDEX_UNSIGNED, scratch3_reg, src_reg, m_src_ofs);
+				LDR(INDEX_UNSIGNED, scratch3_reg, src_reg, offset);
 
 			REV32(scratch3_reg, scratch3_reg);
 

--- a/Source/Core/VideoCommon/VertexLoaderARM64.h
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.h
@@ -13,7 +13,7 @@ public:
 
 protected:
 	std::string GetName() const override { return "VertexLoaderARM64"; }
-	bool IsInitialized() override { return true; }
+	bool IsInitialized() override { return m_VtxAttr.color[0].Comp != FORMAT_24B_6666 && m_VtxAttr.color[1].Comp != FORMAT_24B_6666 ; }
 	int RunVertices(DataReader src, DataReader dst, int count) override;
 
 private:


### PR DESCRIPTION
This "fixes" lots of strange colors on android. But I'm not able to debug what's wrong here :/