### PR TITLE
Android: Have non-games use their filename as a Game ID.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameDatabase.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/GameDatabase.java
@@ -188,12 +188,20 @@ public final class GameDatabase extends SQLiteOpenHelper
 									name = filePath.substring(filePath.lastIndexOf("/") + 1);
 								}
 
+								String gameId = NativeLibrary.GetGameId(filePath);
+
+								// If the game's ID field is empty, use the filename without extension.
+								if (gameId.isEmpty())
+								{
+									gameId = filePath.substring(filePath.lastIndexOf("/") + 1, filePath.lastIndexOf("."));
+								}
+
 								ContentValues game = Game.asContentValues(NativeLibrary.GetPlatform(filePath),
 										name,
 										NativeLibrary.GetDescription(filePath).replace("\n", " "),
 										NativeLibrary.GetCountry(filePath),
 										filePath,
-										NativeLibrary.GetGameId(filePath),
+										gameId,
 										NativeLibrary.GetCompany(filePath));
 
 								// Try to update an existing game first.


### PR DESCRIPTION
This allows multiple non-games (Fifo logs, for example) to show up in the library grid.