### PR TITLE
Exclusive fullscreen OSD notification consistency

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -207,7 +207,7 @@ bool CRenderFrame::ShowFullScreen(bool show, long style)
 		// Some backends don't support exclusive fullscreen, so we
 		// can't tell exactly when exclusive mode is activated.
 		if (!g_Config.backend_info.bSupportsExclusiveFullscreen)
-			OSD::AddMessage("Enabled exclusive fullscreen.");
+			OSD::AddMessage("Entered exclusive fullscreen.");
 	}
 #endif
 


### PR DESCRIPTION
OpenGL exclusive fullscreen OSD notification is made consistent with the one used for [D3D](https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/VideoBackends/D3D/Render.cpp#L951).