### PR TITLE
Mixer: Devirtualize the logging functions.

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -203,6 +203,64 @@ void CMixer::SetWiimoteSpeakerVolume(unsigned int lvolume, unsigned int rvolume)
 	m_wiimote_speaker_mixer.SetVolume(lvolume, rvolume);
 }
 
+void CMixer::StartLogDTKAudio(const std::string& filename)
+{
+	if (!m_log_dtk_audio)
+	{
+		m_log_dtk_audio = true;
+		g_wave_writer_dtk.Start(filename, 48000);
+		g_wave_writer_dtk.SetSkipSilence(false);
+		NOTICE_LOG(DSPHLE, "Starting DTK Audio logging");
+	}
+	else
+	{
+		WARN_LOG(DSPHLE, "DTK Audio logging has already been started");
+	}
+}
+
+void CMixer::StopLogDTKAudio()
+{
+	if (m_log_dtk_audio)
+	{
+		m_log_dtk_audio = false;
+		g_wave_writer_dtk.Stop();
+		NOTICE_LOG(DSPHLE, "Stopping DTK Audio logging");
+	}
+	else
+	{
+		WARN_LOG(DSPHLE, "DTK Audio logging has already been stopped");
+	}
+}
+
+void CMixer::StartLogDSPAudio(const std::string& filename)
+{
+	if (!m_log_dsp_audio)
+	{
+		m_log_dsp_audio = true;
+		g_wave_writer_dsp.Start(filename, 32000);
+		g_wave_writer_dsp.SetSkipSilence(false);
+		NOTICE_LOG(DSPHLE, "Starting DSP Audio logging");
+	}
+	else
+	{
+		WARN_LOG(DSPHLE, "DSP Audio logging has already been started");
+	}
+}
+
+void CMixer::StopLogDSPAudio()
+{
+	if (m_log_dsp_audio)
+	{
+		m_log_dsp_audio = false;
+		g_wave_writer_dsp.Stop();
+		NOTICE_LOG(DSPHLE, "Stopping DSP Audio logging");
+	}
+	else
+	{
+		WARN_LOG(DSPHLE, "DSP Audio logging has already been stopped");
+	}
+}
+
 void CMixer::MixerFifo::SetInputSampleRate(unsigned int rate)
 {
 	m_input_sample_rate = rate;

--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -155,14 +155,14 @@ void CMixer::PushSamples(const short *samples, unsigned int num_samples)
 {
 	m_dma_mixer.PushSamples(samples, num_samples);
 	if (m_log_dsp_audio)
-		g_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples);
+		m_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples);
 }
 
 void CMixer::PushStreamingSamples(const short *samples, unsigned int num_samples)
 {
 	m_streaming_mixer.PushSamples(samples, num_samples);
 	if (m_log_dtk_audio)
-		g_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples);
+		m_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples);
 }
 
 void CMixer::PushWiimoteSpeakerSamples(const short *samples, unsigned int num_samples, unsigned int sample_rate)
@@ -208,8 +208,8 @@ void CMixer::StartLogDTKAudio(const std::string& filename)
 	if (!m_log_dtk_audio)
 	{
 		m_log_dtk_audio = true;
-		g_wave_writer_dtk.Start(filename, 48000);
-		g_wave_writer_dtk.SetSkipSilence(false);
+		m_wave_writer_dtk.Start(filename, 48000);
+		m_wave_writer_dtk.SetSkipSilence(false);
 		NOTICE_LOG(DSPHLE, "Starting DTK Audio logging");
 	}
 	else
@@ -223,7 +223,7 @@ void CMixer::StopLogDTKAudio()
 	if (m_log_dtk_audio)
 	{
 		m_log_dtk_audio = false;
-		g_wave_writer_dtk.Stop();
+		m_wave_writer_dtk.Stop();
 		NOTICE_LOG(DSPHLE, "Stopping DTK Audio logging");
 	}
 	else
@@ -237,8 +237,8 @@ void CMixer::StartLogDSPAudio(const std::string& filename)
 	if (!m_log_dsp_audio)
 	{
 		m_log_dsp_audio = true;
-		g_wave_writer_dsp.Start(filename, 32000);
-		g_wave_writer_dsp.SetSkipSilence(false);
+		m_wave_writer_dsp.Start(filename, 32000);
+		m_wave_writer_dsp.SetSkipSilence(false);
 		NOTICE_LOG(DSPHLE, "Starting DSP Audio logging");
 	}
 	else
@@ -252,7 +252,7 @@ void CMixer::StopLogDSPAudio()
 	if (m_log_dsp_audio)
 	{
 		m_log_dsp_audio = false;
-		g_wave_writer_dsp.Stop();
+		m_wave_writer_dsp.Stop();
 		NOTICE_LOG(DSPHLE, "Stopping DSP Audio logging");
 	}
 	else

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -50,63 +50,11 @@ public:
 	void SetStreamingVolume(unsigned int lvolume, unsigned int rvolume);
 	void SetWiimoteSpeakerVolume(unsigned int lvolume, unsigned int rvolume);
 
-	virtual void StartLogDTKAudio(const std::string& filename)
-	{
-		if (!m_log_dtk_audio)
-		{
-			m_log_dtk_audio = true;
-			g_wave_writer_dtk.Start(filename, 48000);
-			g_wave_writer_dtk.SetSkipSilence(false);
-			NOTICE_LOG(DSPHLE, "Starting DTK Audio logging");
-		}
-		else
-		{
-			WARN_LOG(DSPHLE, "DTK Audio logging has already been started");
-		}
-	}
+	void StartLogDTKAudio(const std::string& filename);
+	void StopLogDTKAudio();
 
-	virtual void StopLogDTKAudio()
-	{
-		if (m_log_dtk_audio)
-		{
-			m_log_dtk_audio = false;
-			g_wave_writer_dtk.Stop();
-			NOTICE_LOG(DSPHLE, "Stopping DTK Audio logging");
-		}
-		else
-		{
-			WARN_LOG(DSPHLE, "DTK Audio logging has already been stopped");
-		}
-	}
-
-	virtual void StartLogDSPAudio(const std::string& filename)
-	{
-		if (!m_log_dsp_audio)
-		{
-			m_log_dsp_audio = true;
-			g_wave_writer_dsp.Start(filename, 32000);
-			g_wave_writer_dsp.SetSkipSilence(false);
-			NOTICE_LOG(DSPHLE, "Starting DSP Audio logging");
-		}
-		else
-		{
-			WARN_LOG(DSPHLE, "DSP Audio logging has already been started");
-		}
-	}
-
-	virtual void StopLogDSPAudio()
-	{
-		if (m_log_dsp_audio)
-		{
-			m_log_dsp_audio = false;
-			g_wave_writer_dsp.Stop();
-			NOTICE_LOG(DSPHLE, "Stopping DSP Audio logging");
-		}
-		else
-		{
-			WARN_LOG(DSPHLE, "DSP Audio logging has already been stopped");
-		}
-	}
+	void StartLogDSPAudio(const std::string& filename);
+	void StopLogDSPAudio();
 
 	float GetCurrentSpeed() const { return m_speed.load(); }
 	void UpdateSpeed(float val) { m_speed.store(val); }

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -95,8 +95,8 @@ protected:
 	MixerFifo m_wiimote_speaker_mixer;
 	unsigned int m_sampleRate;
 
-	WaveFileWriter g_wave_writer_dtk;
-	WaveFileWriter g_wave_writer_dsp;
+	WaveFileWriter m_wave_writer_dtk;
+	WaveFileWriter m_wave_writer_dsp;
 
 	bool m_log_dtk_audio;
 	bool m_log_dsp_audio;


### PR DESCRIPTION
This isn't necessary, since the logging functionality is already implemented fully in the base Mixer class.