### PR TITLE
Translations fix for Linux & Mac OS X

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -332,8 +332,13 @@ void DolphinApp::InitLanguageSupport()
 	{
 		m_locale = new wxLocale(language);
 
+        // Specify where dolphins *.gmo files are located on each operating system
 #ifdef _WIN32
-		m_locale->AddCatalogLookupPathPrefix(StrToWxStr(File::GetExeDirectory() + DIR_SEP "Languages"));
+        m_locale->AddCatalogLookupPathPrefix(StrToWxStr(File::GetExeDirectory() + DIR_SEP "Languages"));
+#elif defined(__LINUX__)
+		m_locale->AddCatalogLookupPathPrefix(StrToWxStr(DATA_DIR "../locale"));
+#elif defined(__APPLE__)
+		m_locale->AddCatalogLookupPathPrefix(StrToWxStr(GetBundleDirectory() + "Contents/Resources"));
 #endif
 
 		m_locale->AddCatalog("dolphin-emu");

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -338,7 +338,7 @@ void DolphinApp::InitLanguageSupport()
 #elif defined(__LINUX__)
 		m_locale->AddCatalogLookupPathPrefix(StrToWxStr(DATA_DIR "../locale"));
 #elif defined(__APPLE__)
-		m_locale->AddCatalogLookupPathPrefix(StrToWxStr(GetBundleDirectory() + "Contents/Resources"));
+		m_locale->AddCatalogLookupPathPrefix(StrToWxStr(File::GetBundleDirectory() + "Contents/Resources"));
 #endif
 
 		m_locale->AddCatalog("dolphin-emu");

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -332,9 +332,9 @@ void DolphinApp::InitLanguageSupport()
 	{
 		m_locale = new wxLocale(language);
 
-        // Specify where dolphins *.gmo files are located on each operating system
+		// Specify where dolphins *.gmo files are located on each operating system
 #ifdef _WIN32
-        m_locale->AddCatalogLookupPathPrefix(StrToWxStr(File::GetExeDirectory() + DIR_SEP "Languages"));
+		m_locale->AddCatalogLookupPathPrefix(StrToWxStr(File::GetExeDirectory() + DIR_SEP "Languages"));
 #elif defined(__LINUX__)
 		m_locale->AddCatalogLookupPathPrefix(StrToWxStr(DATA_DIR "../locale"));
 #elif defined(__APPLE__)


### PR DESCRIPTION
Partially fixes this [issue](https://code.google.com/p/dolphin-emu/issues/detail?id=8649), as Mac OS X is likely still broken.
The translations require *.gmo files, the locations of these were previously specified for windows only.
# Linux
*    Located .gmo files
*    Specified their location to wx
*    Working on my computer

# Mac OSX
*    Unable to locate .gmo files (I checked in the dolphin-master-4.0-6820.dmg)
*    I don't have access to Mac OSX so cant test anything
*    Specified a location they should be [according to this](https://wiki.wxwidgets.org/Internationalization)