### PR TITLE
WiimoteReal: Fix crash when switching a real Wiimote to a different slot or type during emulation.

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -485,9 +485,12 @@ void WiimoteScanner::ThreadFunc()
 
 bool Wiimote::Connect()
 {
-	m_thread_ready.store(false);
-	StartThread();
-	WaitReady();
+	if (!m_run_thread.load())
+	{
+		m_thread_ready.store(false);
+		StartThread();
+		WaitReady();
+	}
 	return IsConnected();
 }
 


### PR DESCRIPTION
This fixes [issue 7642](https://code.google.com/p/dolphin-emu/issues/detail?id=7642), or at least the problem named in its title. The description is actually complaining about something entirely different.

What happens is that, when the type of a Wiimote or amounts of Wiimotes changes in the config, the emulator attempts to re-assign any existing actual Wiimote connections to other internal slots, so it doesn't have to disconnect everything just to reconnect them again. (see https://github.com/dolphin-emu/dolphin/commit/a6461ca186c67592c1bd6bb4f6cd175c03ddcde3)

So like, example, if we have selected two Wiimotes as Real in the config and only one actual Wiimote is connected to the emulator, that Wiimote acts as Wiimote 1 in games, while nothing is connected for Wiimote 2. If you now switch the config of Wiimote 1 to Emulated, it doesn't just disconnect Wiimote 1 and make you reconnect it as Wiimote 2, it tries to automatically find a new empty slot for it, and since Wiimote 2 is empty it automatically re-assigns it there.

Which is a nice idea and all, but unfortunately it runs into situations where it tries to `Connect()` a Wiimote that is already connected, which then crashes the program by assigning a new `std::thread` to an already running one. I haven't actually checked when or how this broke, so that might be interesting to find out.

This PR simply makes sure that a Wiimote that is trying to be `Connect()`ed isn't already running a thread. If it is, the thread is just left alone. This works fine and allows the behavior described above for regular Real Wiimotes and switching from Hybrid to Real Wiimotes, but oddly enough breaks when switching to a Hybrid Wiimote while a game is running -- not in a crash though, the emulated software simply doesn't get any inputs from an actual Wiimote in that situation. I've debugged this for a bit and found that it's somehow related to `m_channel` getting set to 0 after a Wiimote is switched to Hybrid, though I haven't found the actual cause. I believe it is unrelated to this crash and fix though, since it also happens if you start with a Emulated Wiimote and switch that to Hybrid mid-game. It should be investigated further.