### PR TITLE
Mark which Wii root to use in the NAND path code.

### DIFF
--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -54,34 +54,40 @@ void ShutdownWiiRoot()
 	}
 }
 
-std::string GetTicketFileName(u64 _titleID)
+static std::string RootUserPath(FromWhichRoot from)
+{
+	int idx = from == FROM_CONFIGURED_ROOT ? D_WIIROOT_IDX : D_SESSION_WIIROOT_IDX;
+	return File::GetUserPath(idx);
+}
+
+std::string GetTicketFileName(u64 _titleID, FromWhichRoot from)
 {
 	return StringFromFormat("%s/ticket/%08x/%08x.tik",
-			File::GetUserPath(D_SESSION_WIIROOT_IDX).c_str(),
+			RootUserPath(from).c_str(),
 			(u32)(_titleID >> 32), (u32)_titleID);
 }
 
-std::string GetTitleDataPath(u64 _titleID)
+std::string GetTitleDataPath(u64 _titleID, FromWhichRoot from)
 {
 	return StringFromFormat("%s/title/%08x/%08x/data/",
-			File::GetUserPath(D_SESSION_WIIROOT_IDX).c_str(),
+			RootUserPath(from).c_str(),
 			(u32)(_titleID >> 32), (u32)_titleID);
 }
 
-std::string GetTMDFileName(u64 _titleID)
+std::string GetTMDFileName(u64 _titleID, FromWhichRoot from)
 {
-	return GetTitleContentPath(_titleID) + "title.tmd";
+	return GetTitleContentPath(_titleID, from) + "title.tmd";
 }
-std::string GetTitleContentPath(u64 _titleID)
+std::string GetTitleContentPath(u64 _titleID, FromWhichRoot from)
 {
 	return StringFromFormat("%s/title/%08x/%08x/content/",
-			File::GetUserPath(D_SESSION_WIIROOT_IDX).c_str(),
+			RootUserPath(from).c_str(),
 			(u32)(_titleID >> 32), (u32)_titleID);
 }
 
-bool CheckTitleTMD(u64 _titleID)
+bool CheckTitleTMD(u64 _titleID, FromWhichRoot from)
 {
-	const std::string TitlePath = GetTMDFileName(_titleID);
+	const std::string TitlePath = GetTMDFileName(_titleID, from);
 	if (File::Exists(TitlePath))
 	{
 		File::IOFile pTMDFile(TitlePath, "rb");
@@ -94,9 +100,9 @@ bool CheckTitleTMD(u64 _titleID)
 	return false;
 }
 
-bool CheckTitleTIK(u64 _titleID)
+bool CheckTitleTIK(u64 _titleID, FromWhichRoot from)
 {
-	const std::string ticketFileName = Common::GetTicketFileName(_titleID);
+	const std::string ticketFileName = Common::GetTicketFileName(_titleID, from);
 	if (File::Exists(ticketFileName))
 	{
 		File::IOFile pTIKFile(ticketFileName, "rb");

--- a/Source/Core/Common/NandPaths.h
+++ b/Source/Core/Common/NandPaths.h
@@ -21,11 +21,17 @@ namespace Common
 	void InitializeWiiRoot(bool use_temporary);
 	void ShutdownWiiRoot();
 
-	std::string GetTicketFileName(u64 _titleID);
-	std::string GetTMDFileName(u64 _titleID);
-	std::string GetTitleDataPath(u64 _titleID);
-	std::string GetTitleContentPath(u64 _titleID);
-	bool CheckTitleTMD(u64 _titleID);
-	bool CheckTitleTIK(u64 _titleID);
+	enum FromWhichRoot
+	{
+		FROM_CONFIGURED_ROOT, // not related to currently running game - use D_WIIROOT_IDX
+		FROM_SESSION_ROOT, // request from currently running game - use D_SESSION_WIIROOT_IDX
+	};
+
+	std::string GetTicketFileName(u64 _titleID, FromWhichRoot from);
+	std::string GetTMDFileName(u64 _titleID, FromWhichRoot from);
+	std::string GetTitleDataPath(u64 _titleID, FromWhichRoot from);
+	std::string GetTitleContentPath(u64 _titleID, FromWhichRoot from);
+	bool CheckTitleTMD(u64 _titleID, FromWhichRoot from);
+	bool CheckTitleTIK(u64 _titleID, FromWhichRoot from);
 	void ReadReplacements(replace_v& replacements);
 }

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -79,7 +79,7 @@ bool CBoot::FindMapFile(std::string* existing_map_file,
 	{
 	case SConfig::BOOT_WII_NAND:
 	{
-		const DiscIO::INANDContentLoader& Loader =
+		const DiscIO::CNANDContentLoader& Loader =
 				DiscIO::CNANDContentManager::Access().GetNANDLoader(_StartupPara.m_strFilename);
 		if (Loader.IsValid())
 		{

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -187,7 +187,7 @@ bool CBoot::SetupWiiMemory(DiscIO::IVolume::ECountry country)
 
 	SettingsHandler gen;
 	std::string serno;
-	std::string settings_Filename(Common::GetTitleDataPath(TITLEID_SYSMENU) + WII_SETTING);
+	std::string settings_Filename(Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) + WII_SETTING);
 	if (File::Exists(settings_Filename))
 	{
 		File::IOFile settingsFileHandle(settings_Filename, "rb");

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -50,7 +50,7 @@ struct StateFlags
 
 bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
 {
-	std::string state_filename(Common::GetTitleDataPath(TITLEID_SYSMENU) + WII_STATE);
+	std::string state_filename(Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) + WII_STATE);
 
 	if (File::Exists(state_filename))
 	{
@@ -76,13 +76,13 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
 		state_file.WriteBytes(&state, sizeof(StateFlags));
 	}
 
-	const DiscIO::INANDContentLoader& ContentLoader = DiscIO::CNANDContentManager::Access().GetNANDLoader(_pFilename);
+	const DiscIO::CNANDContentLoader& ContentLoader = DiscIO::CNANDContentManager::Access().GetNANDLoader(_pFilename);
 	if (!ContentLoader.IsValid())
 		return false;
 
 	u64 titleID = ContentLoader.GetTitleID();
 	// create data directory
-	File::CreateFullPath(Common::GetTitleDataPath(titleID));
+	File::CreateFullPath(Common::GetTitleDataPath(titleID, Common::FROM_SESSION_ROOT));
 
 	if (titleID == TITLEID_SYSMENU)
 		HLE_IPC_CreateVirtualFATFilesystem();

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -750,7 +750,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
 			else if (DiscIO::CNANDContentManager::Access().GetNANDLoader(m_strFilename).IsValid())
 			{
 				std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(m_strFilename));
-				const DiscIO::INANDContentLoader& ContentLoader = DiscIO::CNANDContentManager::Access().GetNANDLoader(m_strFilename);
+				const DiscIO::CNANDContentLoader& ContentLoader = DiscIO::CNANDContentManager::Access().GetNANDLoader(m_strFilename);
 
 				if (ContentLoader.GetContentByIndex(ContentLoader.GetBootIndex()) == nullptr)
 				{

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -144,7 +144,7 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 	u32 CurrentGameId = 0;
 	if (strUniqueID == TITLEID_SYSMENU_STRING)
 	{
-		const DiscIO::INANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, false);
+		const DiscIO::CNANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT);
 		if (SysMenu_Loader.IsValid())
 		{
 			country_code = DiscIO::CountrySwitch(SysMenu_Loader.GetCountryChar());

--- a/Source/Core/Core/HW/WiiSaveCrypted.cpp
+++ b/Source/Core/Core/HW/WiiSaveCrypted.cpp
@@ -566,7 +566,8 @@ bool CWiiSaveCrypted::getPaths(bool for_export)
 {
 	if (m_title_id)
 	{
-		m_wii_title_path = Common::GetTitleDataPath(m_title_id);
+		// CONFIGURED because this whole class is only used from the GUI, not directly by games.
+		m_wii_title_path = Common::GetTitleDataPath(m_title_id, Common::FROM_CONFIGURED_ROOT);
 	}
 
 	if (for_export)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -39,7 +39,7 @@ std::string HLE_IPC_BuildFilename(std::string path_wii)
 void HLE_IPC_CreateVirtualFATFilesystem()
 {
 	const int cdbSize = 0x01400000;
-	const std::string cdbPath = Common::GetTitleDataPath(TITLEID_SYSMENU) + "cdb.vff";
+	const std::string cdbPath = Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) + "cdb.vff";
 	if ((int)File::GetSize(cdbPath) < cdbSize)
 	{
 		// cdb.vff is a virtual Fat filesystem created on first launch of sysmenu

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -186,7 +186,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Open(u32 _CommandAddress, u32 _Mode)
 
 IPCCommandResult CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce)
 {
-	// Leave deletion of the INANDContentLoader objects to CNANDContentManager, don't do it here!
+	// Leave deletion of the CNANDContentLoader objects to CNANDContentManager, don't do it here!
 	m_NANDContent.clear();
 	for (auto& pair : m_ContentAccessMap)
 	{
@@ -207,7 +207,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce
 
 u32 CWII_IPC_HLE_Device_es::OpenTitleContent(u32 CFD, u64 TitleID, u16 Index)
 {
-	const DiscIO::INANDContentLoader& Loader = AccessContentDevice(TitleID);
+	const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
 
 	if (!Loader.IsValid())
 	{
@@ -293,7 +293,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			u64 TitleID = Memory::Read_U64(Buffer.InBuffer[0].m_Address);
 
-			const DiscIO::INANDContentLoader& rNANDContent = AccessContentDevice(TitleID);
+			const DiscIO::CNANDContentLoader& rNANDContent = AccessContentDevice(TitleID);
 			u16 NumberOfPrivateContent = 0;
 			if (rNANDContent.IsValid()) // Not sure if dolphin will ever fail this check
 			{
@@ -323,7 +323,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			u64 TitleID = Memory::Read_U64(Buffer.InBuffer[0].m_Address);
 
-			const DiscIO::INANDContentLoader& rNANDCOntent = AccessContentDevice(TitleID);
+			const DiscIO::CNANDContentLoader& rNANDCOntent = AccessContentDevice(TitleID);
 			if (rNANDCOntent.IsValid()) // Not sure if dolphin will ever fail this check
 			{
 				for (u16 i = 0; i < rNANDCOntent.GetNumEntries(); i++)
@@ -584,18 +584,18 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			u64 TitleID = Memory::Read_U64(Buffer.InBuffer[0].m_Address);
 
 			u32 retVal = 0;
-			const DiscIO::INANDContentLoader& Loader = AccessContentDevice(TitleID);
-			u32 ViewCount = Loader.GetTIKSize() / DiscIO::INANDContentLoader::TICKET_SIZE;
+			const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
+			u32 ViewCount = Loader.GetTIKSize() / DiscIO::CNANDContentLoader::TICKET_SIZE;
 
 			if (!ViewCount)
 			{
-				std::string TicketFilename = Common::GetTicketFileName(TitleID);
+				std::string TicketFilename = Common::GetTicketFileName(TitleID, Common::FROM_SESSION_ROOT);
 				if (File::Exists(TicketFilename))
 				{
 					u32 FileSize = (u32)File::GetSize(TicketFilename);
-					_dbg_assert_msg_(WII_IPC_ES, (FileSize % DiscIO::INANDContentLoader::TICKET_SIZE) == 0, "IOCTL_ES_GETVIEWCNT ticket file size seems to be wrong");
+					_dbg_assert_msg_(WII_IPC_ES, (FileSize % DiscIO::CNANDContentLoader::TICKET_SIZE) == 0, "IOCTL_ES_GETVIEWCNT ticket file size seems to be wrong");
 
-					ViewCount = FileSize / DiscIO::INANDContentLoader::TICKET_SIZE;
+					ViewCount = FileSize / DiscIO::CNANDContentLoader::TICKET_SIZE;
 					_dbg_assert_msg_(WII_IPC_ES, (ViewCount>0) && (ViewCount<=4), "IOCTL_ES_GETVIEWCNT ticket count seems to be wrong");
 				}
 				else if (TitleID >> 32 == 0x00000001)
@@ -631,29 +631,29 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			u32 maxViews = Memory::Read_U32(Buffer.InBuffer[1].m_Address);
 			u32 retVal = 0;
 
-			const DiscIO::INANDContentLoader& Loader = AccessContentDevice(TitleID);
+			const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
 
 			const u8 *Ticket = Loader.GetTIK();
 			if (Ticket)
 			{
-				u32 viewCnt = Loader.GetTIKSize() / DiscIO::INANDContentLoader::TICKET_SIZE;
+				u32 viewCnt = Loader.GetTIKSize() / DiscIO::CNANDContentLoader::TICKET_SIZE;
 				for (unsigned int View = 0; View != maxViews && View < viewCnt; ++View)
 				{
 					Memory::Write_U32(View, Buffer.PayloadBuffer[0].m_Address + View * 0xD8);
 					Memory::CopyToEmu(Buffer.PayloadBuffer[0].m_Address + 4 + View * 0xD8,
-						Ticket + 0x1D0 + (View * DiscIO::INANDContentLoader::TICKET_SIZE), 212);
+						Ticket + 0x1D0 + (View * DiscIO::CNANDContentLoader::TICKET_SIZE), 212);
 				}
 			}
 			else
 			{
-				std::string TicketFilename = Common::GetTicketFileName(TitleID);
+				std::string TicketFilename = Common::GetTicketFileName(TitleID, Common::FROM_SESSION_ROOT);
 				if (File::Exists(TicketFilename))
 				{
 					File::IOFile pFile(TicketFilename, "rb");
 					if (pFile)
 					{
-						u8 FileTicket[DiscIO::INANDContentLoader::TICKET_SIZE];
-						for (unsigned int View = 0; View != maxViews && pFile.ReadBytes(FileTicket, DiscIO::INANDContentLoader::TICKET_SIZE); ++View)
+						u8 FileTicket[DiscIO::CNANDContentLoader::TICKET_SIZE];
+						for (unsigned int View = 0; View != maxViews && pFile.ReadBytes(FileTicket, DiscIO::CNANDContentLoader::TICKET_SIZE); ++View)
 						{
 							Memory::Write_U32(View, Buffer.PayloadBuffer[0].m_Address + View * 0xD8);
 							Memory::CopyToEmu(Buffer.PayloadBuffer[0].m_Address + 4 + View * 0xD8, FileTicket+0x1D0, 212);
@@ -693,12 +693,12 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			u64 TitleID = Memory::Read_U64(Buffer.InBuffer[0].m_Address);
 
-			const DiscIO::INANDContentLoader& Loader = AccessContentDevice(TitleID);
+			const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
 
 			u32 TMDViewCnt = 0;
 			if (Loader.IsValid())
 			{
-				TMDViewCnt += DiscIO::INANDContentLoader::TMD_VIEW_SIZE;
+				TMDViewCnt += DiscIO::CNANDContentLoader::TMD_VIEW_SIZE;
 				TMDViewCnt += 2; // title version
 				TMDViewCnt += 2; // num entries
 				TMDViewCnt += (u32)Loader.GetContentSize() * (4+2+2+8); // content id, index, type, size
@@ -720,7 +720,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			u64 TitleID = Memory::Read_U64(Buffer.InBuffer[0].m_Address);
 			u32 MaxCount = Memory::Read_U32(Buffer.InBuffer[1].m_Address);
 
-			const DiscIO::INANDContentLoader& Loader = AccessContentDevice(TitleID);
+			const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTMDVIEWCNT: title: %08x/%08x   buffer size: %i", (u32)(TitleID >> 32), (u32)TitleID, MaxCount);
 
@@ -728,8 +728,8 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			{
 				u32 Address = Buffer.PayloadBuffer[0].m_Address;
 
-				Memory::CopyToEmu(Address, Loader.GetTMDView(), DiscIO::INANDContentLoader::TMD_VIEW_SIZE);
-				Address += DiscIO::INANDContentLoader::TMD_VIEW_SIZE;
+				Memory::CopyToEmu(Address, Loader.GetTMDView(), DiscIO::CNANDContentLoader::TMD_VIEW_SIZE);
+				Address += DiscIO::CNANDContentLoader::TMD_VIEW_SIZE;
 
 				Memory::Write_U16(Loader.GetTitleVersion(), Address); Address += 2;
 				Memory::Write_U16(Loader.GetNumEntries(), Address); Address += 2;
@@ -762,7 +762,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 		{
 			u64 TitleID = Memory::Read_U64(Buffer.InBuffer[0].m_Address);
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_DELETETICKET: title: %08x/%08x", (u32)(TitleID >> 32), (u32)TitleID);
-			if (File::Delete(Common::GetTicketFileName(TitleID)))
+			if (File::Delete(Common::GetTicketFileName(TitleID, Common::FROM_SESSION_ROOT)))
 			{
 				Memory::Write_U32(0, _CommandAddress + 0x4);
 			}
@@ -777,7 +777,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 		{
 			u64 TitleID = Memory::Read_U64(Buffer.InBuffer[0].m_Address);
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_DELETETITLECONTENT: title: %08x/%08x", (u32)(TitleID >> 32), (u32)TitleID);
-			if (DiscIO::CNANDContentManager::Access().RemoveTitle(TitleID))
+			if (DiscIO::CNANDContentManager::Access().RemoveTitle(TitleID, Common::FROM_SESSION_ROOT))
 			{
 				Memory::Write_U32(0, _CommandAddress + 0x4);
 			}
@@ -795,14 +795,14 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			// _dbg_assert_msg_(WII_IPC_ES, Buffer.NumberPayloadBuffer == 1, "IOCTL_ES_ES_GETSTOREDTMDSIZE no out buffer");
 
 			u64 TitleID = Memory::Read_U64(Buffer.InBuffer[0].m_Address);
-			const DiscIO::INANDContentLoader& Loader = AccessContentDevice(TitleID);
+			const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
 
 			_dbg_assert_(WII_IPC_ES, Loader.IsValid());
 			u32 TMDCnt = 0;
 			if (Loader.IsValid())
 			{
-				TMDCnt += DiscIO::INANDContentLoader::TMD_HEADER_SIZE;
-				TMDCnt += (u32)Loader.GetContentSize() * DiscIO::INANDContentLoader::CONTENT_HEADER_SIZE;
+				TMDCnt += DiscIO::CNANDContentLoader::TMD_HEADER_SIZE;
+				TMDCnt += (u32)Loader.GetContentSize() * DiscIO::CNANDContentLoader::CONTENT_HEADER_SIZE;
 			}
 			if (Buffer.NumberPayloadBuffer)
 				Memory::Write_U32(TMDCnt, Buffer.PayloadBuffer[0].m_Address);
@@ -827,7 +827,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 				// TODO: actually use this param in when writing to the outbuffer :/
 				MaxCount = Memory::Read_U32(Buffer.InBuffer[1].m_Address);
 			}
-			const DiscIO::INANDContentLoader& Loader = AccessContentDevice(TitleID);
+			const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
 
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETSTOREDTMD: title: %08x/%08x   buffer size: %i", (u32)(TitleID >> 32), (u32)TitleID, MaxCount);
@@ -836,14 +836,14 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			{
 				u32 Address = Buffer.PayloadBuffer[0].m_Address;
 
-				Memory::CopyToEmu(Address, Loader.GetTMDHeader(), DiscIO::INANDContentLoader::TMD_HEADER_SIZE);
-				Address += DiscIO::INANDContentLoader::TMD_HEADER_SIZE;
+				Memory::CopyToEmu(Address, Loader.GetTMDHeader(), DiscIO::CNANDContentLoader::TMD_HEADER_SIZE);
+				Address += DiscIO::CNANDContentLoader::TMD_HEADER_SIZE;
 
 				const std::vector<DiscIO::SNANDContent>& rContent = Loader.GetContent();
 				for (size_t i=0; i<Loader.GetContentSize(); i++)
 				{
-					Memory::CopyToEmu(Address, rContent[i].m_Header, DiscIO::INANDContentLoader::CONTENT_HEADER_SIZE);
-					Address += DiscIO::INANDContentLoader::CONTENT_HEADER_SIZE;
+					Memory::CopyToEmu(Address, rContent[i].m_Header, DiscIO::CNANDContentLoader::CONTENT_HEADER_SIZE);
+					Address += DiscIO::CNANDContentLoader::CONTENT_HEADER_SIZE;
 				}
 
 				_dbg_assert_(WII_IPC_ES, (Address-Buffer.PayloadBuffer[0].m_Address) == Buffer.PayloadBuffer[0].m_Size);
@@ -908,14 +908,14 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			std::string tContentFile;
 			if ((u32)(TitleID>>32) != 0x00000001 || TitleID == TITLEID_SYSMENU)
 			{
-				const DiscIO::INANDContentLoader& ContentLoader = AccessContentDevice(TitleID);
+				const DiscIO::CNANDContentLoader& ContentLoader = AccessContentDevice(TitleID);
 				if (ContentLoader.IsValid())
 				{
 					u32 bootInd = ContentLoader.GetBootIndex();
 					const DiscIO::SNANDContent* pContent = ContentLoader.GetContentByIndex(bootInd);
 					if (pContent)
 					{
-						tContentFile = Common::GetTitleContentPath(TitleID);
+						tContentFile = Common::GetTitleContentPath(TitleID, Common::FROM_SESSION_ROOT);
 						std::unique_ptr<CDolLoader> pDolLoader;
 						if (pContent->m_pData)
 						{
@@ -1076,7 +1076,8 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 	return IPC_DEFAULT_REPLY;
 }
 
-const DiscIO::INANDContentLoader& CWII_IPC_HLE_Device_es::AccessContentDevice(u64 _TitleID)
+// TODO: This cache is redundant with the one in CNANDContentManager.h
+const DiscIO::CNANDContentLoader& CWII_IPC_HLE_Device_es::AccessContentDevice(u64 _TitleID)
 {
 	if (m_pContentLoader->IsValid() && m_pContentLoader->GetTitleID() == _TitleID)
 		return *m_pContentLoader;
@@ -1085,7 +1086,7 @@ const DiscIO::INANDContentLoader& CWII_IPC_HLE_Device_es::AccessContentDevice(u6
 	if (itr != m_NANDContent.end())
 		return *itr->second;
 
-	m_NANDContent[_TitleID] = &DiscIO::CNANDContentManager::Access().GetNANDLoader(_TitleID);
+	m_NANDContent[_TitleID] = &DiscIO::CNANDContentManager::Access().GetNANDLoader(_TitleID, Common::FROM_SESSION_ROOT);
 
 	_dbg_assert_msg_(WII_IPC_ES, ((u32)(_TitleID >> 32) == 0x00010000) || m_NANDContent[_TitleID]->IsValid(), "NandContent not valid for TitleID %08x/%08x", (u32)(_TitleID >> 32), (u32)_TitleID);
 	return *m_NANDContent[_TitleID];
@@ -1109,13 +1110,13 @@ u32 CWII_IPC_HLE_Device_es::ES_DIVerify(u8* _pTMD, u32 _sz)
 	{
 		return -1;
 	}
-	std::string tmdPath  = Common::GetTMDFileName(tmdTitleID);
+	std::string tmdPath  = Common::GetTMDFileName(tmdTitleID, Common::FROM_SESSION_ROOT);
 
 	File::CreateFullPath(tmdPath);
-	File::CreateFullPath(Common::GetTitleDataPath(tmdTitleID));
+	File::CreateFullPath(Common::GetTitleDataPath(tmdTitleID, Common::FROM_SESSION_ROOT));
 
 	Movie::g_titleID = tmdTitleID;
-	std::string savePath = Common::GetTitleDataPath(tmdTitleID);
+	std::string savePath = Common::GetTitleDataPath(tmdTitleID, Common::FROM_SESSION_ROOT);
 	if (Movie::IsRecordingInput())
 	{
 		// TODO: Check for the actual save data
@@ -1166,5 +1167,6 @@ u32 CWII_IPC_HLE_Device_es::ES_DIVerify(u8* _pTMD, u32 _sz)
 			ERROR_LOG(WII_IPC_ES, "DIVerify failed to write disc TMD to NAND.");
 	}
 	DiscIO::cUIDsys::AccessInstance().AddTitle(tmdTitleID);
+	DiscIO::CNANDContentManager::Access().ClearCache();
 	return 0;
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
@@ -14,7 +14,7 @@
 class PointerWrap;
 namespace DiscIO
 {
-	class INANDContentLoader;
+	class CNANDContentLoader;
 	struct SNANDContent;
 }
 
@@ -133,10 +133,10 @@ private:
 	typedef std::map<u32, SContentAccess> CContentAccessMap;
 	CContentAccessMap m_ContentAccessMap;
 
-	typedef std::map<u64, const DiscIO::INANDContentLoader*> CTitleToContentMap;
+	typedef std::map<u64, const DiscIO::CNANDContentLoader*> CTitleToContentMap;
 	CTitleToContentMap m_NANDContent;
 
-	const DiscIO::INANDContentLoader* m_pContentLoader;
+	const DiscIO::CNANDContentLoader* m_pContentLoader;
 
 	std::vector<u64> m_TitleIDs;
 	u64 m_TitleID;
@@ -146,7 +146,7 @@ private:
 
 	u64 GetCurrentTitleID() const;
 
-	const DiscIO::INANDContentLoader& AccessContentDevice(u64 _TitleID);
+	const DiscIO::CNANDContentLoader& AccessContentDevice(u64 _TitleID);
 	u32 OpenTitleContent(u32 CFD, u64 TitleID, u16 Index);
 
 	bool IsValid(u64 _TitleID) const;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -134,7 +134,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 		INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_GENERATED_USER_ID");
 		if (config.CreationStage() == nwc24_config_t::NWC24_IDCS_INITIAL)
 		{
-			std::string settings_Filename(Common::GetTitleDataPath(TITLEID_SYSMENU) + WII_SETTING);
+			std::string settings_Filename(Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) + WII_SETTING);
 			SettingsHandler gen;
 			std::string area, model;
 			bool _GotSettings = false;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -490,7 +490,7 @@ bool BeginRecordingInput(int controllers)
 		// TODO: find a way to GetTitleDataPath() from Movie::Init()
 		if (SConfig::GetInstance().bWii)
 		{
-			if (File::Exists(Common::GetTitleDataPath(g_titleID) + "banner.bin"))
+			if (File::Exists(Common::GetTitleDataPath(g_titleID, Common::FROM_SESSION_ROOT) + "banner.bin"))
 				Movie::g_bClearSave = false;
 			else
 				Movie::g_bClearSave = true;

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -182,6 +182,7 @@ void PathConfigPane::OnNANDRootChanged(wxCommandEvent& event)
 	m_nand_root_dirpicker->SetPath(StrToWxStr(nand_path));
 
 	SConfig::GetInstance().m_SYSCONF->UpdateLocation();
+	DiscIO::CNANDContentManager::Access().ClearCache();
 
 	main_frame->UpdateWiiMenuChoice();
 }

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1454,7 +1454,7 @@ void CFrame::OnShowCheatsWindow(wxCommandEvent& WXUNUSED (event))
 
 void CFrame::OnLoadWiiMenu(wxCommandEvent& WXUNUSED(event))
 {
-	BootGame(Common::GetTitleContentPath(TITLEID_SYSMENU));
+	BootGame(Common::GetTitleContentPath(TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT));
 }
 
 void CFrame::OnInstallWAD(wxCommandEvent& event)
@@ -1510,7 +1510,7 @@ void CFrame::UpdateWiiMenuChoice(wxMenuItem *WiiMenuItem)
 		WiiMenuItem = GetMenuBar()->FindItem(IDM_LOAD_WII_MENU);
 	}
 
-	const DiscIO::INANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, true);
+	const DiscIO::CNANDContentLoader & SysMenu_Loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT);
 	if (SysMenu_Loader.IsValid())
 	{
 		int sysmenuVersion = SysMenu_Loader.GetTitleVersion();
@@ -1741,7 +1741,7 @@ void CFrame::UpdateGUI()
 	GetMenuBar()->FindItem(IDM_SAVE_STATE)->Enable(Initialized);
 	// Misc
 	GetMenuBar()->FindItem(IDM_CHANGE_DISC)->Enable(Initialized);
-	if (DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU).IsValid())
+	if (DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT).IsValid())
 		GetMenuBar()->FindItem(IDM_LOAD_WII_MENU)->Enable(!Initialized);
 
 	// Tools


### PR DESCRIPTION
It's used by both the GUI to do things like install WADs and check up on
the system menu, in which case the global root should be used, and by
/dev/es, in which case the local one should.  The latter isn't
*terribly* useful today, since no contents will ever be installed in
temporary roots (although it's still relevant for data directories), but
converting the whole thing makes sense because then it will Just Work
once the entire NAND is synced.

Because it would have been a bit of work to split it up (but I can if
desired), this commit also contains some basic cleanup of
NANDContentLoader:

(1) The useless interface class INANDContentLoader is removed and the
    methods are changed to just return CNANDContentLoader (the only
    implementation);
(2) CNANDContentManager is changed to use unique_ptr and cleaned up a
    bit.