### PR TITLE
Jit64: fix pre-SSE4.1 fallback of ps_sum1 with AccurateNaNs=True

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -135,7 +135,8 @@ public:
 	Gen::FixupBranch JumpIfCRFieldBit(int field, int bit, bool jump_if_set = true);
 	void SetFPRFIfNeeded(Gen::X64Reg xmm);
 
-	void HandleNaNs(UGeckoInstruction inst, Gen::X64Reg xmm_out, Gen::X64Reg xmm_in);
+	void HandleNaNs(UGeckoInstruction inst, Gen::X64Reg xmm_out, Gen::X64Reg xmm_in,
+	                Gen::X64Reg clobber = Gen::XMM0);
 
 	void MultiplyImmediate(u32 imm, int a, int d, bool overflow);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -68,7 +68,7 @@ void Jit64::ps_sum(UGeckoInstruction inst)
 	default:
 		PanicAlert("ps_sum WTF!!!");
 	}
-	HandleNaNs(inst, fpr.RX(d), tmp);
+	HandleNaNs(inst, fpr.RX(d), tmp, tmp == XMM1 ? XMM0 : XMM1);
 	ForceSinglePrecision(fpr.RX(d), fpr.R(d));
 	SetFPRFIfNeeded(fpr.RX(d));
 	fpr.UnlockAll();


### PR DESCRIPTION
The problem is that ps_sum1 outputs into XMM0 if SSE4.1 is not available, but `HandleNaNs()` uses XMM0 for other things. It didn't trigger the `_assert_(xmm != XMM0)` because `_assert_()` is currently equivalent to `_dbg_assert_()`. ¯\\\_(ツ)\_/¯

~~Kept the two commits separate to make it easier to review and to let @Armada651 decide what to pull into the stable branch.~~

Fixes [issue 8712](http://dolp.in/i8712).