### PR TITLE
Netplay: Sync Video Mode settings. (Progressive Scan and PAL60)

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -246,6 +246,8 @@ bool BootCore(const std::string& _rFilename)
 		StartUp.iCPUCore = g_NetPlaySettings.m_CPUcore;
 		StartUp.SelectedLanguage = g_NetPlaySettings.m_SelectedLanguage;
 		StartUp.bOverrideGCLanguage = g_NetPlaySettings.m_OverrideGCLanguage;
+		StartUp.bProgressive = g_NetPlaySettings.m_ProgressiveScan;
+		StartUp.bPAL60 = g_NetPlaySettings.m_PAL60;
 		SConfig::GetInstance().m_DSPEnableJIT = g_NetPlaySettings.m_DSPEnableJIT;
 		SConfig::GetInstance().m_OCEnable = g_NetPlaySettings.m_OCEnable;
 		SConfig::GetInstance().m_OCFactor = g_NetPlaySettings.m_OCFactor;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -381,6 +381,8 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
 			packet >> g_NetPlaySettings.m_CPUcore;
 			packet >> g_NetPlaySettings.m_SelectedLanguage;
 			packet >> g_NetPlaySettings.m_OverrideGCLanguage;
+			packet >> g_NetPlaySettings.m_ProgressiveScan;
+			packet >> g_NetPlaySettings.m_PAL60;
 			packet >> g_NetPlaySettings.m_DSPEnableJIT;
 			packet >> g_NetPlaySettings.m_DSPHLE;
 			packet >> g_NetPlaySettings.m_WriteToMemcard;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -14,6 +14,8 @@ struct NetSettings
 	int m_CPUcore;
 	int m_SelectedLanguage;
 	bool m_OverrideGCLanguage;
+	bool m_ProgressiveScan;
+	bool m_PAL60;
 	bool m_DSPHLE;
 	bool m_DSPEnableJIT;
 	bool m_WriteToMemcard;
@@ -31,7 +33,7 @@ struct Rpt : public std::vector<u8>
 
 typedef std::vector<u8> NetWiimote;
 
-#define NETPLAY_VERSION  "Dolphin NetPlay 2015-06-14"
+#define NETPLAY_VERSION  "Dolphin NetPlay 2015-06-24"
 
 extern u64 g_netplay_initial_gctime;
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -717,6 +717,8 @@ bool NetPlayServer::StartGame()
 	*spac << m_settings.m_CPUcore;
 	*spac << m_settings.m_SelectedLanguage;
 	*spac << m_settings.m_OverrideGCLanguage;
+	*spac << m_settings.m_ProgressiveScan;
+	*spac << m_settings.m_PAL60;
 	*spac << m_settings.m_DSPEnableJIT;
 	*spac << m_settings.m_DSPHLE;
 	*spac << m_settings.m_WriteToMemcard;

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -254,6 +254,8 @@ void NetPlayDialog::GetNetSettings(NetSettings &settings)
 	settings.m_CPUcore = instance.iCPUCore;
 	settings.m_SelectedLanguage = instance.SelectedLanguage;
 	settings.m_OverrideGCLanguage = instance.bOverrideGCLanguage;
+	settings.m_ProgressiveScan = instance.bProgressive;
+	settings.m_PAL60 = instance.bPAL60;
 	settings.m_DSPHLE = instance.bDSPHLE;
 	settings.m_DSPEnableJIT = instance.m_DSPEnableJIT;
 	settings.m_WriteToMemcard = m_memcard_write->GetValue();


### PR DESCRIPTION
They must match so that Wii games don't desync, especially PAL games.

Fixes [issue 8661](https://code.google.com/p/dolphin-emu/issues/detail?id=8661).