### PR TITLE
Quick fix for an invalid iterator

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -933,16 +933,16 @@ TextureCache::TCacheEntryBase* TextureCache::AllocateTexture(const TCacheEntryCo
 		INCSTAT(stats.numTexturesCreated);
 	}
 
-	entry->textures_by_hash_iter = textures_by_address.end();
+	entry->textures_by_hash_iter = textures_by_hash.end();
 	return entry;
 }
 
 TextureCache::TexCache::iterator TextureCache::RemoveTextureFromCache(TexCache::iterator iter)
 {
-	if (iter->second->textures_by_hash_iter != textures_by_address.end())
+	if (iter->second->textures_by_hash_iter != textures_by_hash.end())
 	{
 		textures_by_hash.erase(iter->second->textures_by_hash_iter);
-		iter->second->textures_by_hash_iter = textures_by_address.end();
+		iter->second->textures_by_hash_iter = textures_by_hash.end();
 	}
 
 	FreeTexture(iter->second);


### PR DESCRIPTION
textures_by_hash_iter was pointing to elements of textures_by_hash, but pointing to textures_by_address.end() instead of textures_by_hash.end() when it's not pointing to an element.