### PR TITLE
OGL: Allow inverted depth ranges.

### DIFF
--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -83,7 +83,7 @@ void InitBackendInfo()
 	g_Config.backend_info.bSupports3DVision = true;
 	g_Config.backend_info.bSupportsPostProcessing = false;
 	g_Config.backend_info.bSupportsPaletteConversion = true;
-	g_Config.backend_info.bSupportsClipControl = false;
+	g_Config.backend_info.bSupportsClipControl = true;
 
 	IDXGIFactory* factory;
 	IDXGIAdapter* ad;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1197,7 +1197,7 @@ void Renderer::SetViewport()
 	float Y = EFBToScaledYf((float)EFB_HEIGHT - xfmem.viewport.yOrig + xfmem.viewport.ht + (float)scissorYOff);
 	float Width = EFBToScaledXf(2.0f * xfmem.viewport.wd);
 	float Height = EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-	float GLNear = MathUtil::Clamp<float>(xfmem.viewport.farZ - MathUtil::Clamp<float>(xfmem.viewport.zRange, 0.0f, 16777215.0f), 0.0f, 16777215.0f) / 16777216.0f;
+	float GLNear = MathUtil::Clamp<float>(xfmem.viewport.farZ - MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777215.0f, 16777215.0f), 0.0f, 16777215.0f) / 16777216.0f;
 	float GLFar = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
 	if (Width < 0)
 	{

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -383,10 +383,6 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 	{
 		out.Write("o.pos.z = -o.pos.z;\n");
 	}
-	else if (api_type == API_D3D)
-	{
-		out.Write("o.pos.z = -o.pos.z;\n");
-	}
 	else // OGL
 	{
 		// this results in a scale from -1..0 to -1..1 after perspective


### PR DESCRIPTION
Seems like there are some games out there which use an inverted depth range. We can easily support this in OGL, however D3D is much more difficult due to viewport restrictions not allowing an inverted depth range.

Workarounds could be used for D3D, but I don't want to merge workarounds so close to the stable.