### PR TITLE
OpenALStream: Fix sample conversion.

### DIFF
--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -295,7 +295,7 @@ void OpenALStream::SoundLoop()
 					// Convert the samples from float to short
 					short stereo[OAL_MAX_SAMPLES * STEREO_CHANNELS * OAL_MAX_BUFFERS];
 					for (u32 i = 0; i < nSamples * STEREO_CHANNELS; ++i)
-						stereo[i] = (short)((float)sampleBuffer[i] * (1 << 16));
+						stereo[i] = (short)((float)sampleBuffer[i] * (1 << 15));
 
 					alBufferData(uiBufferTemp[iBuffersFilled], AL_FORMAT_STEREO16, stereo, nSamples * FRAME_STEREO_SHORT, ulFrequency);
 				}


### PR DESCRIPTION
Looks like it wasn't symmetric anymore.

This line was forgotten in PR #1847.