### PR TITLE
[AArch64] Implement slwx in the recompiler.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -97,6 +97,7 @@ public:
 	void addzex(UGeckoInstruction inst);
 	void subfx(UGeckoInstruction inst);
 	void addcx(UGeckoInstruction inst);
+	void slwx(UGeckoInstruction inst);
 
 	// System Registers
 	void mtmsr(UGeckoInstruction inst);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -218,7 +218,7 @@ static GekkoOPTemplate table31[] =
 	{536, &JitArm64::FallBackToInterpreter},    // srwx
 	{792, &JitArm64::FallBackToInterpreter},    // srawx
 	{824, &JitArm64::srawix},                   // srawix
-	{24,  &JitArm64::FallBackToInterpreter},    // slwx
+	{24,  &JitArm64::slwx},                     // slwx
 
 	{54,   &JitArm64::FallBackToInterpreter},   // dcbst
 	{86,   &JitArm64::FallBackToInterpreter},   // dcbf


### PR DESCRIPTION
I streamed this implementation earlier today to get people to have a feel for implementing instructions in the AArch64 recompiler.
This one was a fairly simple one to implement.