### PR TITLE
Jit64: dcbf + dcbi

### DIFF
--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -56,6 +56,8 @@ union UDSPControl
 	UDSPControl(u16 _Hex = 0) : Hex(_Hex) {}
 };
 
+extern UDSPControl g_dspState;
+
 void Init(bool hle);
 void Shutdown();
 
@@ -78,5 +80,6 @@ void UpdateAudioDMA();
 void UpdateDSPSlice(int cycles);
 u64 DMAInProgress();
 void EnableInstantDMA();
+void FlushInstantDMA(u32 address);
 
 }// end of namespace DSP

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -340,18 +340,7 @@ void Interpreter::dcbi(UGeckoInstruction _inst)
 	// The following detects a situation where the game is writing to the dcache at the address being DMA'd. As we do not
 	// have dcache emulation, invalid data is being DMA'd causing audio glitches. The following code detects this and
 	// enables the DMA to complete instantly before the invalid data is written. Resident Evil 2 & 3 trigger this.
-	u64 dma_in_progress = DSP::DMAInProgress();
-	if (dma_in_progress != 0)
-	{
-		u32 start_addr = (dma_in_progress >> 32) & Memory::RAM_MASK;
-		u32 end_addr = (dma_in_progress & Memory::RAM_MASK) & 0xffffffff;
-		u32 invalidated_addr = (address & Memory::RAM_MASK) & ~0x1f;
-
-		if (invalidated_addr >= start_addr && invalidated_addr <= end_addr)
-		{
-			DSP::EnableInstantDMA();
-		}
-	}
+	DSP::FlushInstantDMA(address);
 }
 
 void Interpreter::dcbst(UGeckoInstruction _inst)

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -255,4 +255,6 @@ public:
 
 	void lmw(UGeckoInstruction inst);
 	void stmw(UGeckoInstruction inst);
+
+	void dcbx(UGeckoInstruction inst);
 };

--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -214,11 +214,11 @@ static GekkoOPTemplate table31[] =
 	{824, &Jit64::srawix},                 // srawix
 	{24,  &Jit64::slwx},                   // slwx
 
-	{54,   &Jit64::FallBackToInterpreter}, // dcbst
-	{86,   &Jit64::FallBackToInterpreter}, // dcbf
-	{246,  &Jit64::dcbt },                 // dcbtst
-	{278,  &Jit64::dcbt },                 // dcbt
-	{470,  &Jit64::FallBackToInterpreter}, // dcbi
+	{54,   &Jit64::dcbx},                  // dcbst
+	{86,   &Jit64::dcbx},                  // dcbf
+	{246,  &Jit64::dcbt},                  // dcbtst
+	{278,  &Jit64::dcbt},                  // dcbt
+	{470,  &Jit64::dcbx},                  // dcbi
 	{758,  &Jit64::DoNothing},             // dcba
 	{1014, &Jit64::dcbz},                  // dcbz
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -66,6 +66,7 @@ public:
 		VALID_BLOCK_MASK_SIZE = 0x20000000 / 32,
 		VALID_BLOCK_ALLOC_ELEMENTS = VALID_BLOCK_MASK_SIZE / 32
 	};
+	// Directly accessed by Jit64.
 	std::unique_ptr<u32[]> m_valid_block;
 
 	ValidBlockBitSet()

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -60,6 +60,7 @@ typedef void (*CompiledCode)();
 // implementation of std::bitset is slow.
 class ValidBlockBitSet final
 {
+public:
 	enum
 	{
 		VALID_BLOCK_MASK_SIZE = 0x20000000 / 32,
@@ -67,7 +68,6 @@ class ValidBlockBitSet final
 	};
 	std::unique_ptr<u32[]> m_valid_block;
 
-public:
 	ValidBlockBitSet()
 	{
 		m_valid_block.reset(new u32[VALID_BLOCK_ALLOC_ELEMENTS]);
@@ -157,6 +157,11 @@ public:
 
 	// DOES NOT WORK CORRECTLY WITH INLINING
 	void InvalidateICache(u32 address, const u32 length, bool forced);
+
+	u32* GetBlockBitSet() const
+	{
+		return valid_block.m_valid_block.get();
+	}
 };
 
 // x86 BlockCache


### PR DESCRIPTION
Both dcbx instructions are called quite often and usually NOPs. So inline to first check within the JIT itself to skip over them much faster.