### PR TITLE
Android: Show transition animations on game start / end.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -277,7 +277,7 @@ public final class NativeLibrary
 	public static void endEmulationActivity()
 	{
 		Log.v("DolphinEmu", "Ending EmulationActivity.");
-		mEmulationActivity.finish();
+		mEmulationActivity.exitWithAnimation();
 	}
 
 	public static void setEmulationActivity(EmulationActivity emulationActivity)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -12,6 +12,10 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+
+import com.squareup.picasso.Picasso;
 
 import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
@@ -22,6 +26,8 @@ import java.util.List;
 public final class EmulationActivity extends AppCompatActivity
 {
 	private View mDecorView;
+	private ImageView mImageView;
+	private FrameLayout mFrameLayout;
 
 	private boolean mDeviceHasTouchScreen;
 	private boolean mSystemUiVisible;
@@ -79,9 +85,33 @@ public final class EmulationActivity extends AppCompatActivity
 
 		setContentView(R.layout.activity_emulation);
 
+		mImageView = (ImageView) findViewById(R.id.image_screenshot);
+		mFrameLayout = (FrameLayout) findViewById(R.id.frame_content);
+
 		Intent gameToEmulate = getIntent();
 		String path = gameToEmulate.getStringExtra("SelectedGame");
 		String title = gameToEmulate.getStringExtra("SelectedTitle");
+		String screenPath = gameToEmulate.getStringExtra("ScreenPath");
+
+		Picasso.with(this)
+				.load(screenPath)
+				.fit()
+				.noFade()
+				.into(mImageView);
+
+		mImageView.animate()
+				.setStartDelay(2000)
+				.setDuration(500)
+				.alpha(0.0f)
+				.withEndAction(new Runnable()
+				{
+					@Override
+					public void run()
+					{
+						mImageView.setVisibility(View.GONE);
+						mFrameLayout.setVisibility(View.VISIBLE);
+					}
+				});
 
 		setTitle(title);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/MainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/MainActivity.java
@@ -36,6 +36,7 @@ import org.dolphinemu.dolphinemu.services.AssetCopyService;
 public final class MainActivity extends AppCompatActivity implements LoaderManager.LoaderCallbacks<Cursor>
 {
 	private static final int REQUEST_ADD_DIRECTORY = 1;
+	public static final int REQUEST_EMULATE_GAME = 2;
 
 	/**
 	 * It is important to keep track of loader ID separately from platform ID (see Game.java)
@@ -115,15 +116,29 @@ public final class MainActivity extends AppCompatActivity implements LoaderManag
 	@Override
 	protected void onActivityResult(int requestCode, int resultCode, Intent result)
 	{
-		// If the user picked a file, as opposed to just backing out.
-		if (resultCode == RESULT_OK)
+		switch (requestCode)
 		{
-			// Sanity check to make sure the Activity that just returned was the AddDirectoryActivity;
-			// other activities might use this callback in the future (don't forget to change Javadoc!)
-			if (requestCode == REQUEST_ADD_DIRECTORY)
-			{
-				refreshFragment();
-			}
+			case REQUEST_ADD_DIRECTORY:
+				// If the user picked a file, as opposed to just backing out.
+				if (resultCode == RESULT_OK)
+				{
+					// Sanity check to make sure the Activity that just returned was the AddDirectoryActivity;
+					// other activities might use this callback in the future (don't forget to change Javadoc!)
+					if (requestCode == REQUEST_ADD_DIRECTORY)
+					{
+						refreshFragment();
+					}
+				}
+				break;
+
+			case REQUEST_EMULATE_GAME:
+				// Invalidate Picasso image so that the new screenshot is animated in.
+				PlatformGamesFragment fragment = getPlatformFragment(mViewPager.getCurrentItem());
+
+				if (fragment != null)
+				{
+					fragment.refreshScreenshotAtPosition(resultCode);
+				}
 		}
 	}
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -5,6 +5,7 @@ import android.app.ActivityOptions;
 import android.content.Intent;
 import android.database.Cursor;
 import android.database.DataSetObserver;
+import android.graphics.Bitmap;
 import android.graphics.Rect;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -16,6 +17,7 @@ import com.squareup.picasso.Picasso;
 
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
+import org.dolphinemu.dolphinemu.activities.MainActivity;
 import org.dolphinemu.dolphinemu.dialogs.GameDetailsDialog;
 import org.dolphinemu.dolphinemu.model.GameDatabase;
 import org.dolphinemu.dolphinemu.viewholders.GameViewHolder;
@@ -81,14 +83,15 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 			if (mCursor.moveToPosition(position))
 			{
 				String screenPath = mCursor.getString(GameDatabase.GAME_COLUMN_SCREENSHOT_PATH);
-				Picasso.with(holder.imageScreenshot.getContext())
-						.invalidate(screenPath);
 
 				// Fill in the view contents.
 				Picasso.with(holder.imageScreenshot.getContext())
 						.load(screenPath)
 						.fit()
 						.centerCrop()
+						.noFade()
+						.noPlaceholder()
+						.config(Bitmap.Config.RGB_565)
 						.error(R.drawable.no_banner)
 						.into(holder.imageScreenshot);
 
@@ -113,8 +116,6 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 		{
 			Log.e("DolphinEmu", "Can't bind view; dataset is not valid.");
 		}
-
-
 	}
 
 	/**
@@ -222,13 +223,16 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 		intent.putExtra("SelectedGame", holder.path);
 		intent.putExtra("SelectedTitle", holder.title);
 		intent.putExtra("ScreenPath", holder.screenshotPath);
+		intent.putExtra("GridPosition", holder.getAdapterPosition());
 
 		ActivityOptions options = ActivityOptions.makeSceneTransitionAnimation(
 				(Activity) view.getContext(),
 				holder.imageScreenshot,
 				"image_game_screenshot");
 
-		view.getContext().startActivity(intent, options.toBundle());
+		((Activity) view.getContext()).startActivityForResult(intent,
+				MainActivity.REQUEST_EMULATE_GAME,
+				options.toBundle());
 	}
 
 	/**

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -1,6 +1,7 @@
 package org.dolphinemu.dolphinemu.adapters;
 
 import android.app.Activity;
+import android.app.ActivityOptions;
 import android.content.Intent;
 import android.database.Cursor;
 import android.database.DataSetObserver;
@@ -222,7 +223,12 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 		intent.putExtra("SelectedTitle", holder.title);
 		intent.putExtra("ScreenPath", holder.screenshotPath);
 
-		view.getContext().startActivity(intent);
+		ActivityOptions options = ActivityOptions.makeSceneTransitionAnimation(
+				(Activity) view.getContext(),
+				holder.imageScreenshot,
+				"image_game_screenshot");
+
+		view.getContext().startActivity(intent, options.toBundle());
 	}
 
 	/**

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameAdapter.java
@@ -220,6 +220,7 @@ public final class GameAdapter extends RecyclerView.Adapter<GameViewHolder> impl
 
 		intent.putExtra("SelectedGame", holder.path);
 		intent.putExtra("SelectedTitle", holder.title);
+		intent.putExtra("ScreenPath", holder.screenshotPath);
 
 		view.getContext().startActivity(intent);
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/PlatformGamesFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/PlatformGamesFragment.java
@@ -1,12 +1,12 @@
 package org.dolphinemu.dolphinemu.fragments;
 
-import android.app.Activity;
 import android.app.Fragment;
 import android.app.LoaderManager;
 import android.content.Loader;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -57,6 +57,15 @@ public class PlatformGamesFragment extends Fragment
 		RecyclerView.LayoutManager layoutManager = new GridLayoutManager(getActivity(),
 				getResources().getInteger(R.integer.game_grid_columns));
 		recyclerView.setLayoutManager(layoutManager);
+		recyclerView.setItemAnimator(new DefaultItemAnimator()
+		{
+			@Override
+			public boolean animateChange(RecyclerView.ViewHolder oldHolder, RecyclerView.ViewHolder newHolder, int fromX, int fromY, int toX, int toY)
+			{
+				dispatchChangeFinished(newHolder, false);
+				return true;
+			}
+		});
 
 		recyclerView.addItemDecoration(new GameAdapter.SpacesItemDecoration(8));
 
@@ -70,10 +79,9 @@ public class PlatformGamesFragment extends Fragment
 		return rootView;
 	}
 
-	@Override
-	public void onAttach(Activity activity)
+	public void refreshScreenshotAtPosition(int position)
 	{
-		super.onAttach(activity);
+		mAdapter.notifyItemChanged(position);
 	}
 
 	public void refresh()

--- a/Source/Android/app/src/main/res/layout/activity_emulation.xml
+++ b/Source/Android/app/src/main/res/layout/activity_emulation.xml
@@ -1,5 +1,16 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
-             android:id="@+id/frame_content">
+    >
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/image_screenshot"/>
+
+    <FrameLayout
+        android:id="@+id/frame_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"/>
 </FrameLayout>

--- a/Source/Android/app/src/main/res/layout/activity_emulation.xml
+++ b/Source/Android/app/src/main/res/layout/activity_emulation.xml
@@ -1,10 +1,11 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
+             android:id="@+id/frame_content"
     >
 
     <FrameLayout
-        android:id="@+id/frame_content"
+        android:id="@+id/frame_emulation_fragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="invisible"/>

--- a/Source/Android/app/src/main/res/layout/activity_emulation.xml
+++ b/Source/Android/app/src/main/res/layout/activity_emulation.xml
@@ -3,14 +3,16 @@
              android:layout_height="match_parent"
     >
 
-    <ImageView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:id="@+id/image_screenshot"/>
-
     <FrameLayout
         android:id="@+id/frame_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone"/>
+        android:visibility="invisible"/>
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/image_screenshot"
+        android:transitionName="image_game_screenshot"/>
+
 </FrameLayout>

--- a/Source/Android/app/src/main/res/layout/card_game.xml
+++ b/Source/Android/app/src/main/res/layout/card_game.xml
@@ -20,7 +20,7 @@
             android:id="@+id/image_game_screen"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:transitionName="image_game_screen"
+            android:transitionName="image_game_screenshot"
             android:layout_weight="1"
             tools:src="@drawable/placeholder_screenshot"
             tools:scaleType="centerCrop"/>

--- a/Source/Android/app/src/main/res/transition/change_image_transform.xml
+++ b/Source/Android/app/src/main/res/transition/change_image_transform.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<transitionSet>
+    <changeImageTransform/>
+</transitionSet>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -8,17 +8,10 @@
         <!--   darker variant for the status bar and contextual app bars -->
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
 
-        <!--enable window content transitions
-       <item name="android:windowContentTransitions">true</item>
-
-       &lt;!&ndash; specify enter and exit transitions &ndash;&gt;
-       <item name="android:windowEnterTransition">@android:transition/fade</item>
-       <item name="android:windowExitTransition">@android:transition/fade</item>
-
-       &lt;!&ndash; specify shared element transitions &ndash;&gt;
-       <item name="android:windowSharedElementEnterTransition">@transition/change_image_transform</item>
-       <item name="android:windowSharedElementExitTransition">@transition/change_image_transform</item>
--->
+        <!--enable window content transitions-->
+        <item name="android:windowContentTransitions">true</item>
+        <item name="android:windowAllowEnterTransitionOverlap">true</item>
+        <item name="android:windowAllowReturnTransitionOverlap">true</item>
     </style>
 
     <!-- Same as above, but use default action bar, and mandate margins. -->
@@ -74,23 +67,17 @@
         <item name="colorAccent">@color/dolphin_accent_wiiware</item>
     </style>
 
-    <style name="DolphinEmulationBase" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="DolphinEmulationBase" parent="Theme.AppCompat">
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="android:windowTranslucentNavigation">true</item>
 
-        <!-- enable window content transitions -->
+        <item name="android:windowBackground">@android:color/black</item>
+
+        <!--enable window content transitions-->
         <item name="android:windowContentTransitions">true</item>
-
-        <!-- specify enter and exit transitions -->
-        <item name="android:windowEnterTransition">@android:transition/explode</item>
-        <item name="android:windowExitTransition">@android:transition/explode</item>
-
-        <!-- specify shared element transitions -->
-        <item name="android:windowSharedElementEnterTransition">@transition/change_image_transform
-        </item>
-        <item name="android:windowSharedElementExitTransition">@transition/change_image_transform
-        </item>
+        <item name="android:windowAllowEnterTransitionOverlap">true</item>
+        <item name="android:windowAllowReturnTransitionOverlap">true</item>
     </style>
 
     <!-- Inherit from the Base Dolphin Emulation Theme-->

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -7,6 +7,18 @@
         <item name="colorPrimary">@color/dolphin_blue</item>
         <!--   darker variant for the status bar and contextual app bars -->
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
+
+        <!--enable window content transitions
+       <item name="android:windowContentTransitions">true</item>
+
+       &lt;!&ndash; specify enter and exit transitions &ndash;&gt;
+       <item name="android:windowEnterTransition">@android:transition/fade</item>
+       <item name="android:windowExitTransition">@android:transition/fade</item>
+
+       &lt;!&ndash; specify shared element transitions &ndash;&gt;
+       <item name="android:windowSharedElementEnterTransition">@transition/change_image_transform</item>
+       <item name="android:windowSharedElementExitTransition">@transition/change_image_transform</item>
+-->
     </style>
 
     <!-- Same as above, but use default action bar, and mandate margins. -->
@@ -66,6 +78,19 @@
         <item name="colorPrimary">@color/dolphin_blue</item>
         <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
         <item name="android:windowTranslucentNavigation">true</item>
+
+        <!-- enable window content transitions -->
+        <item name="android:windowContentTransitions">true</item>
+
+        <!-- specify enter and exit transitions -->
+        <item name="android:windowEnterTransition">@android:transition/explode</item>
+        <item name="android:windowExitTransition">@android:transition/explode</item>
+
+        <!-- specify shared element transitions -->
+        <item name="android:windowSharedElementEnterTransition">@transition/change_image_transform
+        </item>
+        <item name="android:windowSharedElementExitTransition">@transition/change_image_transform
+        </item>
     </style>
 
     <!-- Inherit from the Base Dolphin Emulation Theme-->
@@ -80,7 +105,6 @@
     <style name="DolphinEmulationWiiware" parent="DolphinEmulationBase">
         <item name="colorAccent">@color/dolphin_accent_wiiware</item>
     </style>
-
 
     <!-- Hax to make Tablayout render icons -->
     <style name="MyCustomTextAppearance" parent="TextAppearance.Design.Tab">


### PR DESCRIPTION
This gives the user something to look at while their game is being loaded, and doesn't affect load-times in any tangible way.

The transition back to the grid is slowed down a little bit (the attached video exacerbates this because duh, writing a video to disk while writing a screenshot) and is also a little bit glitchy. I'm working on fixing that, but it will require deeper changes (probably a non-Picasso image library.)

I think it looks pretty cool already, but it'll look even cooler once the save/load flow is in.

I'll upload some gfycats of what it looks like when those are done processing.