### PR TITLE
GameCube Config: Store paths relatively when selected file is within Dolphin's directory. (Windows)

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -731,8 +731,12 @@ std::string& GetExeDirectory()
 	if (DolphinPath.empty())
 	{
 		TCHAR Dolphin_exe_Path[2048];
+		TCHAR Dolphin_exe_Clean_Path[MAX_PATH];
 		GetModuleFileName(nullptr, Dolphin_exe_Path, 2048);
-		DolphinPath = TStrToUTF8(Dolphin_exe_Path);
+		if (_tfullpath(Dolphin_exe_Clean_Path, Dolphin_exe_Path, MAX_PATH) != nullptr)
+			DolphinPath = TStrToUTF8(Dolphin_exe_Clean_Path);
+		else
+			DolphinPath = TStrToUTF8(Dolphin_exe_Path);
 		DolphinPath = DolphinPath.substr(0, DolphinPath.find_last_of('\\'));
 	}
 	return DolphinPath;

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -332,20 +332,24 @@ void GameCubeConfigPane::ChooseSlotPath(bool is_slot_a, TEXIDevices device_type)
 				}
 			}
 		}
+
+		wxFileName newFilename(filename);
+		newFilename.MakeAbsolute();
+		filename = newFilename.GetFullPath();
+
 #ifdef _WIN32
 		// If the Memory Card file is within the Exe dir, we can assume that the user wants it to be stored relative
 		// to the executable, so it stays set correctly when the probably portable Exe dir is moved.
+		// TODO: Replace this with a cleaner, non-wx solution once std::filesystem is standard
 		std::string exeDir = File::GetExeDirectory() + '\\';
-		if (!strncmp(exeDir.c_str(), filename.c_str(), exeDir.size()))
+		if (wxString(filename).Lower().StartsWith(wxString(exeDir).Lower()))
 			filename.erase(0, exeDir.size());
 
 		std::replace(filename.begin(), filename.end(), '\\', '/');
 #endif
 
 		// also check that the path isn't used for the other memcard...
-		wxFileName newFilename(filename);
 		wxFileName otherFilename(is_slot_a ? pathB : pathA);
-		newFilename.MakeAbsolute();
 		otherFilename.MakeAbsolute();
 		if (newFilename.GetFullPath().compare(otherFilename.GetFullPath()) != 0)
 		{


### PR DESCRIPTION
This is for portable installations that have the User dir in the same directory as Dolphin. Currently, if you pick a Memory Card file in that setup, then move the Dolphin dir somewhere else, Dolphin will no longer find the Memory Card file and force you to re-select it. There seems to have been some code that handled such cases already, but it relied on `GetExeDirectory()` returning a path that ends in a directory separator, which is not (or no longer?) the case. It also probably wouldn't have worked anyway as it incremented the returned character by one before comparing it to a directory separator -- I assume the `+ 1` was meant to go inside of the `at()` call?

Anyway, this fixes that without affecting regular installs that have their User dir in My Documents or whatever.

I've also fixed a small issue where `GetExeDirectory()` would return non-normalized paths, mainly because the way Visual Studio launches executables results in a path that includes `dolphin\Source\..\Binary` being returned by `GetModuleFileName()`, which then interfered with the detection of the "is this file in Dolphin's dir?" part of the memory card path set function.

Fixes [issue 8137](https://code.google.com/p/dolphin-emu/issues/detail?id=8137) for Windows only. I don't know how the User dir and portable install situation looks on other OSes.