### PR TITLE
Gameini updates.

### DIFF
--- a/Data/Sys/GameSettings/G2M.ini
+++ b/Data/Sys/GameSettings/G2M.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+SyncGPU = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/G2X.ini
+++ b/Data/Sys/GameSettings/G2X.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Everything playable with minor glitches.
+EmulationIssues = 
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -18,7 +18,4 @@ EmulationIssues = Everything playable with minor glitches.
 # Add action replay cheats here.
 
 [Video_Settings]
-SafeTextureCacheColorSamples = 512
-
-[Video_Hacks]
-
+SafeTextureCacheColorSamples = 4096

--- a/Data/Sys/GameSettings/GEA.ini
+++ b/Data/Sys/GameSettings/GEA.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+SyncGPU = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/GFZ.ini
+++ b/Data/Sys/GameSettings/GFZ.ini
@@ -4,6 +4,7 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 FPRF = True
+SyncGPU = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/GXX.ini
+++ b/Data/Sys/GameSettings/GXX.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+SyncGPU = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
@@ -19,6 +20,4 @@ EmulationIssues = HLE music fades in and out. If EFB scale is not integral, 1x, 
 
 [Video_Settings]
 EFBScale = -1
-
 SafeTextureCacheColorSamples = 0
-

--- a/Data/Sys/GameSettings/RSN.ini
+++ b/Data/Sys/GameSettings/RSN.ini
@@ -2,11 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+SyncGPU = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 3
-EmulationIssues = Unstable with graphical glitches.
+EmulationIssues = Has graphical glitches.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/SMN.ini
+++ b/Data/Sys/GameSettings/SMN.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Enable EFB to RAM for the coins to spin (it will cause a big slowdown).
+EmulationIssues = Efb to texture needs scaled efb copies to be disabled for the coins to spin.
 EmulationStateId = 4
 
 [OnLoad]
@@ -21,4 +21,4 @@ EmulationStateId = 4
 SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
-
+EFBScaledCopy = False

--- a/Data/Sys/GameSettings/SMN.ini
+++ b/Data/Sys/GameSettings/SMN.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Efb to texture needs scaled efb copies to be disabled for the coins to spin.
+EmulationIssues = If "Store EFB Copies to Texture Only" is enabled, "Scaled EFB Copy" needs to be disabled for the coins to spin.
 EmulationStateId = 4
 
 [OnLoad]


### PR DESCRIPTION
Fixes issues 8713 and 8674. Also disables scaled efb copies by default
for New Super Mario Bros to take advantage of the recent efb to texture
spinning coin fix.