### PR TITLE
WiimoteReal: Add IOHIDDevice support for OS X

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteRealBase.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteRealBase.h
@@ -16,6 +16,7 @@
 	// end hack
 	#import <IOBluetooth/IOBluetooth.h>
 	#include <IOKit/pwr_mgt/IOPMLib.h>
+	#include <IOKit/hid/IOHIDManager.h>
 #elif defined(__linux__) && HAVE_BLUEZ
 	#include <bluetooth/bluetooth.h>
 #endif


### PR DESCRIPTION
It's a little flaky at the moment, but this adds support for IOHIDDevices as opposed to just IOBluetoothDevices, enabling devices like the DolphinBar to work on OS X.