### PR TITLE
JitArm64: branching fallbacks

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -621,6 +621,7 @@ void SConfig::LoadDefaults()
 	bJITIntegerOff = false;
 	bJITPairedOff = false;
 	bJITSystemRegistersOff = false;
+	bJITBranchOff = false;
 
 	m_strName = "NONE";
 	m_strUniqueID = "00000000";

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -114,7 +114,6 @@ public:
 	void mtspr(UGeckoInstruction inst);
 
 	// LoadStore
-	void icbi(UGeckoInstruction inst);
 	void lXX(UGeckoInstruction inst);
 	void stX(UGeckoInstruction inst);
 	void lmw(UGeckoInstruction inst);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -179,39 +179,34 @@ void JitArm64::bcctrx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITBranchOff);
 
+	// Rare condition seen in (just some versions of?) Nintendo's NES Emulator
+	// BO_2 == 001zy -> b if false
+	// BO_2 == 011zy -> b if true
+	FALLBACK_IF(!(inst.BO_2 & BO_DONT_CHECK_CONDITION));
+
 	// bcctrx doesn't decrement and/or test CTR
 	_assert_msg_(DYNA_REC, inst.BO_2 & BO_DONT_DECREMENT_FLAG, "bcctrx with decrement and test CTR option is invalid!");
 
-	if (inst.BO_2 & BO_DONT_CHECK_CONDITION)
+	// BO_2 == 1z1zz -> b always
+
+	//NPC = CTR & 0xfffffffc;
+	gpr.Flush(FlushMode::FLUSH_ALL);
+	fpr.Flush(FlushMode::FLUSH_ALL);
+
+	if (inst.LK_3)
 	{
-		// BO_2 == 1z1zz -> b always
-
-		//NPC = CTR & 0xfffffffc;
-		gpr.Flush(FlushMode::FLUSH_ALL);
-		fpr.Flush(FlushMode::FLUSH_ALL);
-
-		if (inst.LK_3)
-		{
-			ARM64Reg WB = gpr.GetReg();
-			u32 Jumpto = js.compilerPC + 4;
-			MOVI2R(WB, Jumpto);
-			STR(INDEX_UNSIGNED, WB, X29, PPCSTATE_OFF(spr[SPR_LR]));
-			gpr.Unlock(WB);
-		}
-
-		ARM64Reg WA = gpr.GetReg();
-
-		LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_CTR]));
-		AND(WA, WA, 30, 29); // Wipe the bottom 2 bits.
-		WriteExitDestInR(WA);
+		ARM64Reg WB = gpr.GetReg();
+		u32 Jumpto = js.compilerPC + 4;
+		MOVI2R(WB, Jumpto);
+		STR(INDEX_UNSIGNED, WB, X29, PPCSTATE_OFF(spr[SPR_LR]));
+		gpr.Unlock(WB);
 	}
-	else
-	{
-		// Rare condition seen in (just some versions of?) Nintendo's NES Emulator
-		// BO_2 == 001zy -> b if false
-		// BO_2 == 011zy -> b if true
-		_assert_msg_(DYNA_REC, false, "Haven't implemented rare form of bcctrx yet");
-	}
+
+	ARM64Reg WA = gpr.GetReg();
+
+	LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_CTR]));
+	AND(WA, WA, 30, 29); // Wipe the bottom 2 bits.
+	WriteExitDestInR(WA);
 }
 
 void JitArm64::bclrx(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -18,6 +18,7 @@ using namespace Arm64Gen;
 void JitArm64::sc(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
+	JITDISABLE(bJITBranchOff);
 
 	gpr.Flush(FlushMode::FLUSH_ALL);
 	fpr.Flush(FlushMode::FLUSH_ALL);
@@ -38,6 +39,7 @@ void JitArm64::sc(UGeckoInstruction inst)
 void JitArm64::rfi(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
+	JITDISABLE(bJITBranchOff);
 
 	gpr.Flush(FlushMode::FLUSH_ALL);
 	fpr.Flush(FlushMode::FLUSH_ALL);
@@ -78,6 +80,7 @@ void JitArm64::rfi(UGeckoInstruction inst)
 void JitArm64::bx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
+	JITDISABLE(bJITBranchOff);
 
 	gpr.Flush(FlushMode::FLUSH_ALL);
 	fpr.Flush(FlushMode::FLUSH_ALL);
@@ -115,6 +118,7 @@ void JitArm64::bx(UGeckoInstruction inst)
 void JitArm64::bcx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
+	JITDISABLE(bJITBranchOff);
 
 	ARM64Reg WA = gpr.GetReg();
 	FixupBranch pCTRDontBranch;
@@ -173,6 +177,7 @@ void JitArm64::bcx(UGeckoInstruction inst)
 void JitArm64::bcctrx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
+	JITDISABLE(bJITBranchOff);
 
 	// bcctrx doesn't decrement and/or test CTR
 	_assert_msg_(DYNA_REC, inst.BO_2 & BO_DONT_DECREMENT_FLAG, "bcctrx with decrement and test CTR option is invalid!");
@@ -212,6 +217,7 @@ void JitArm64::bcctrx(UGeckoInstruction inst)
 void JitArm64::bclrx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
+	JITDISABLE(bJITBranchOff);
 
 	ARM64Reg WA = gpr.GetReg();
 	FixupBranch pCTRDontBranch;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -18,15 +18,6 @@
 
 using namespace Arm64Gen;
 
-void JitArm64::icbi(UGeckoInstruction inst)
-{
-	gpr.Flush(FlushMode::FLUSH_ALL);
-	fpr.Flush(FlushMode::FLUSH_ALL);
-
-	FallBackToInterpreter(inst);
-	WriteExit(js.compilerPC + 4);
-}
-
 void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 offset, bool update)
 {
 	// We want to make sure to not get LR as a temp register

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -48,8 +48,7 @@ FixupBranch JitArm64::JumpIfCRFieldBit(int field, int bit, bool jump_if_set)
 void JitArm64::mtmsr(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
-	// Don't interpret this, if we do we get thrown out
-	//JITDISABLE(bJITSystemRegistersOff)
+	JITDISABLE(bJITSystemRegistersOff);
 
 	gpr.BindToRegister(inst.RS, true);
 	STR(INDEX_UNSIGNED, gpr.R(inst.RS), X29, PPCSTATE_OFF(msr));
@@ -143,6 +142,7 @@ void JitArm64::mtsrin(UGeckoInstruction inst)
 void JitArm64::twx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
+	JITDISABLE(bJITSystemRegistersOff);
 
 	s32 a = inst.RA;
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -302,7 +302,7 @@ static GekkoOPTemplate table31[] =
 
 	{4,   &JitArm64::twx},                      // tw
 	{598, &JitArm64::DoNothing},                // sync
-	{982, &JitArm64::icbi},                     // icbi
+	{982, &JitArm64::FallBackToInterpreter},    // icbi
 
 	// Unused instructions on GC
 	{310, &JitArm64::FallBackToInterpreter},    // eciwx


### PR DESCRIPTION
This PR extends the FallbackToInterpreter function to also support branching instructions.