### PR TITLE
Fix more game list name encoding errors caused by 4.0-6419 (d7900b4)

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -403,7 +403,7 @@ void CGameListCtrl::InsertItemInReportView(long _Index)
 
 			if (line.substr(0,rISOFile.GetUniqueID().size()) == rISOFile.GetUniqueID())
 			{
-				name = line.substr(rISOFile.GetUniqueID().size() + 3);
+				name = StrToWxStr(line.substr(rISOFile.GetUniqueID().size() + 3));
 				break;
 			}
 		}
@@ -413,7 +413,7 @@ void CGameListCtrl::InsertItemInReportView(long _Index)
 	std::string title;
 	IniFile gameini = SCoreStartupParameter::LoadGameIni(rISOFile.GetUniqueID(), rISOFile.GetRevision());
 	if (gameini.GetIfExists("EmuState", "Title", &title))
-		name = title;
+		name = StrToWxStr(title);
 
 	int disc_number = rISOFile.GetDiscNumber() + 1;
 	if (disc_number > 1 && name.Lower().find(wxString::Format("disc %i", disc_number)) == std::string::npos


### PR DESCRIPTION
4.0-6442 (a26cf63) didn't fix names read from INIs or titles.txt.