### PR TITLE
Use emplace() instead of insert() where applicable for maps.

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -53,5 +53,5 @@ Symbol* SymbolDB::GetSymbolFromName(const std::string& name)
 
 void SymbolDB::AddCompleteSymbol(const Symbol &symbol)
 {
-	functions.insert(std::pair<u32, Symbol>(symbol.address, symbol));
+	functions.emplace(symbol.address, symbol);
 }

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -333,7 +333,7 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
 	// add client to the player list
 	{
 		std::lock_guard<std::recursive_mutex> lkp(m_crit.players);
-		m_players.insert(std::pair<PlayerId, Client>(*(PlayerId *)player.socket->data, player));
+		m_players.emplace(*(PlayerId *)player.socket->data, player);
 		UpdatePadMapping(); // sync pad mappings with everyone
 		UpdateWiimoteMapping();
 	}

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -136,7 +136,7 @@ using namespace Gen;
 		{
 			for (const auto& e : b.linkData)
 			{
-				links_to.insert(std::pair<u32, int>(e.exitAddress, block_num));
+				links_to.emplace(e.exitAddress, block_num);
 			}
 
 			LinkBlock(block_num);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -257,9 +257,12 @@ static std::map<double, int> GetSavedStates()
 			if (ReadHeader(filename, header))
 			{
 				double d = Common::Timer::GetDoubleTime() - header.time;
+
 				// increase time until unique value is obtained
-				while (m.find(d) != m.end()) d += .001;
-				m.insert(std::pair<double,int>(d, i));
+				while (m.find(d) != m.end())
+					d += .001;
+
+				m.emplace(d, i);
 			}
 		}
 	}

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -467,7 +467,7 @@ void CVolumeDirectory::WriteEntry(const File::FSTEntry& entry, u32& fstOffset, u
 
 		// write entry to virtual disk
 		_dbg_assert_(DVDINTERFACE, m_virtualDisk.find(dataOffset) == m_virtualDisk.end());
-		m_virtualDisk.insert(make_pair(dataOffset, entry.physicalName));
+		m_virtualDisk.emplace(dataOffset, entry.physicalName);
 
 		// 4 byte aligned
 		dataOffset = ROUND_UP(dataOffset + entry.size, 0x8000ull);

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -87,13 +87,13 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateGamecubeSizer()
 
 		// Create an ID for the config button.
 		const wxWindowID button_id = wxWindow::NewControlId();
-		m_gc_port_config_ids.insert(std::make_pair(button_id, i));
+		m_gc_port_config_ids.emplace(button_id, i);
 		gamecube_configure_bt[i] = new wxButton(this, button_id, _("Configure"), wxDefaultPosition, wxSize(100, 25));
 		gamecube_configure_bt[i]->Bind(wxEVT_BUTTON, &ControllerConfigDiag::OnGameCubeConfigButton, this);
 
 		// Create a control ID for the choice boxes on the fly.
 		const wxWindowID choice_id = wxWindow::NewControlId();
-		m_gc_port_choice_ids.insert(std::make_pair(choice_id, i));
+		m_gc_port_choice_ids.emplace(choice_id, i);
 
 		// Only add AM-Baseboard to the first pad.
 		if (i == 0)
@@ -223,10 +223,10 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateWiimoteConfigSizer()
 		// reserve four ids, so that we can calculate the index from the ids later on
 		// Stupid wx 2.8 doesn't support reserving sequential IDs, so we need to do that more complicated..
 		int source_ctrl_id =  wxWindow::NewControlId();
-		m_wiimote_index_from_ctrl_id.insert(std::pair<wxWindowID, unsigned int>(source_ctrl_id, i));
+		m_wiimote_index_from_ctrl_id.emplace(source_ctrl_id, i);
 
 		int config_bt_id = wxWindow::NewControlId();
-		m_wiimote_index_from_conf_bt_id.insert(std::pair<wxWindowID, unsigned int>(config_bt_id, i));
+		m_wiimote_index_from_conf_bt_id.emplace(config_bt_id, i);
 
 		wiimote_label[i] = new wxStaticText(this, wxID_ANY, wiimote_str);
 		wiimote_source_ch[i] = new wxChoice(this, source_ctrl_id, wxDefaultPosition, wxDefaultSize, src_choices.size(), src_choices.data());
@@ -284,7 +284,7 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateBalanceBoardSizer()
 	wxFlexGridSizer* const bb_sizer = new wxFlexGridSizer(1, 5, 5);
 	int source_ctrl_id =  wxWindow::NewControlId();
 
-	m_wiimote_index_from_ctrl_id.insert(std::pair<wxWindowID, unsigned int>(source_ctrl_id, WIIMOTE_BALANCE_BOARD));
+	m_wiimote_index_from_ctrl_id.emplace(source_ctrl_id, WIIMOTE_BALANCE_BOARD);
 
 	static const std::array<wxString, 2> src_choices = {{
 		_("None"), _("Real Balance Board")

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -655,7 +655,7 @@ SettingRadioButton* VideoConfigDiag::CreateRadioButton(wxWindow* parent, const w
 /* Use this to register descriptions for controls which have NOT been created using the Create* functions from above */
 wxControl* VideoConfigDiag::RegisterControl(wxControl* const control, const wxString& description)
 {
-	ctrl_descs.insert(std::pair<wxWindow*, wxString>(control, description));
+	ctrl_descs.emplace(control, description);
 	control->Bind(wxEVT_ENTER_WINDOW, &VideoConfigDiag::Evt_EnterControl, this);
 	control->Bind(wxEVT_LEAVE_WINDOW, &VideoConfigDiag::Evt_LeaveControl, this);
 	return control;
@@ -710,7 +710,7 @@ void VideoConfigDiag::CreateDescriptionArea(wxPanel* const page, wxBoxSizer* con
 	desc_sizer->Add(desc_text, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
 	// Store description text object for later lookup
-	desc_texts.insert(std::pair<wxWindow*, wxStaticText*>(page, desc_text));
+	desc_texts.emplace(page, desc_text);
 }
 
 void VideoConfigDiag::PopulatePostProcessingShaders()

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -315,9 +315,11 @@ ID3D11SamplerState* StateCache::Get(SamplerState state)
 	ID3D11SamplerState* res = nullptr;
 
 	HRESULT hr = D3D::device->CreateSamplerState(&sampdc, &res);
-	if (FAILED(hr)) PanicAlert("Fail %s %d\n", __FILE__, __LINE__);
+	if (FAILED(hr))
+		PanicAlert("Fail %s %d\n", __FILE__, __LINE__);
+
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)res, "sampler state used to emulate the GX pipeline");
-	m_sampler.insert(std::make_pair(state.packed, res));
+	m_sampler.emplace(state.packed, res);
 
 	return res;
 }
@@ -394,9 +396,11 @@ ID3D11BlendState* StateCache::Get(BlendState state)
 	ID3D11BlendState* res = nullptr;
 
 	HRESULT hr = D3D::device->CreateBlendState(&blenddc, &res);
-	if (FAILED(hr)) PanicAlert("Failed to create blend state at %s %d\n", __FILE__, __LINE__);
+	if (FAILED(hr))
+		PanicAlert("Failed to create blend state at %s %d\n", __FILE__, __LINE__);
+
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)res, "blend state used to emulate the GX pipeline");
-	m_blend.insert(std::make_pair(state.packed, res));
+	m_blend.emplace(state.packed, res);
 
 	return res;
 }
@@ -415,9 +419,11 @@ ID3D11RasterizerState* StateCache::Get(RasterizerState state)
 	ID3D11RasterizerState* res = nullptr;
 
 	HRESULT hr = D3D::device->CreateRasterizerState(&rastdc, &res);
-	if (FAILED(hr)) PanicAlert("Failed to create rasterizer state at %s %d\n", __FILE__, __LINE__);
+	if (FAILED(hr))
+		PanicAlert("Failed to create rasterizer state at %s %d\n", __FILE__, __LINE__);
+
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)res, "rasterizer state used to emulate the GX pipeline");
-	m_raster.insert(std::make_pair(state.packed, res));
+	m_raster.emplace(state.packed, res);
 
 	return res;
 }
@@ -466,10 +472,12 @@ ID3D11DepthStencilState* StateCache::Get(ZMode state)
 	ID3D11DepthStencilState* res = nullptr;
 
 	HRESULT hr = D3D::device->CreateDepthStencilState(&depthdc, &res);
-	if (SUCCEEDED(hr)) D3D::SetDebugObjectName((ID3D11DeviceChild*)res, "depth-stencil state used to emulate the GX pipeline");
-	else PanicAlert("Failed to create depth state at %s %d\n", __FILE__, __LINE__);
+	if (SUCCEEDED(hr))
+		D3D::SetDebugObjectName((ID3D11DeviceChild*)res, "depth-stencil state used to emulate the GX pipeline");
+	else
+		PanicAlert("Failed to create depth state at %s %d\n", __FILE__, __LINE__);
 
-	m_depth.insert(std::make_pair(state.hex, res));
+	m_depth.emplace(state.hex, res);
 
 	return res;
 }

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -258,7 +258,7 @@ ID3D11PixelShader* PSTextureEncoder::SetStaticShader(unsigned int dstFormat, PEC
 			dstFormat, srcFormat, isIntensity, scaleByHalf);
 		D3D::SetDebugObjectName(newShader, debugName);
 
-		it = m_staticShaders.insert(std::make_pair(key, newShader)).first;
+		it = m_staticShaders.emplace(key, newShader).first;
 		bytecode->Release();
 	}
 

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -105,7 +105,7 @@ namespace DriverDetails
 			    ( bug.m_versionstart <= m_version || bug.m_versionstart == -1 ) &&
 			    ( bug.m_versionend > m_version || bug.m_versionend == -1 )
 			)
-				m_bugs.insert(std::make_pair(bug.m_bug, bug));
+				m_bugs.emplace(bug.m_bug, bug);
 		}
 	}
 

--- a/Source/Core/VideoCommon/OnScreenDisplay.cpp
+++ b/Source/Core/VideoCommon/OnScreenDisplay.cpp
@@ -71,7 +71,7 @@ void ClearMessages()
 // On-Screen Display Callbacks
 void AddCallback(CallbackType type, Callback cb)
 {
-	s_callbacks.insert(std::pair<CallbackType, Callback>(type, cb));
+	s_callbacks.emplace(type, cb);
 }
 
 void DoCallbacks(CallbackType type)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -474,7 +474,7 @@ TextureCache::TCacheEntryBase* TextureCache::Load(const u32 stage)
 		decoded_entry->is_efb_copy = false;
 
 		g_texture_cache->ConvertTexture(decoded_entry, entry, &texMem[tlutaddr], (TlutFormat)tlutfmt);
-		textures_by_address.insert(TexCache::value_type((u64)address, decoded_entry));
+		textures_by_address.emplace((u64)address, decoded_entry);
 		return ReturnEntry(stage, decoded_entry);
 	}
 
@@ -560,11 +560,11 @@ TextureCache::TCacheEntryBase* TextureCache::Load(const u32 stage)
 	TCacheEntryBase* entry = AllocateTexture(config);
 	GFX_DEBUGGER_PAUSE_AT(NEXT_NEW_TEXTURE, true);
 
-	textures_by_address.insert(TexCache::value_type((u64)address, entry));
+	textures_by_address.emplace((u64)address, entry);
 	if (g_ActiveConfig.iSafeTextureCache_ColorSamples == 0 ||
 		std::max(texture_size, palette_size) <= (u32)g_ActiveConfig.iSafeTextureCache_ColorSamples * 8)
 	{
-		entry->textures_by_hash_iter = textures_by_hash.insert(TexCache::value_type(full_hash, entry));
+		entry->textures_by_hash_iter = textures_by_hash.emplace(full_hash, entry);
 	}
 
 	entry->SetGeneralParameters(address, texture_size, full_format);
@@ -963,7 +963,7 @@ void TextureCache::CopyRenderTargetToTexture(u32 dstAddr, unsigned int dstFormat
 			count++), 0);
 	}
 
-	textures_by_address.insert(TexCache::value_type((u64)dstAddr, entry));
+	textures_by_address.emplace((u64)dstAddr, entry);
 }
 
 TextureCache::TCacheEntryBase* TextureCache::AllocateTexture(const TCacheEntryConfig& config)
@@ -996,7 +996,7 @@ TextureCache::TexCache::iterator TextureCache::FreeTexture(TexCache::iterator it
 	}
 
 	entry->frameCount = FRAMECOUNT_INVALID;
-	texture_pool.insert(TexPool::value_type(entry->config, entry));
+	texture_pool.emplace(entry->config, entry);
 
 	return textures_by_address.erase(iter);
 }


### PR DESCRIPTION
Since the *nix buildbots use GCC 4.9 (which implements emplace for maps), we can use it instead of inserts for direct object storing.