### PR TITLE
Interpreter: Idle skipping support

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -137,7 +137,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
 		BitSet32 registersInUse = CallerSavedRegistersInUse();
 		ABI_PushRegistersAndAdjustStack(registersInUse, 0);
 
-		ABI_CallFunction((void *)&PowerPC::OnIdle);
+		ABI_CallFunction((void *)&CoreTiming::Idle);
 
 		ABI_PopRegistersAndAdjustStack(registersInUse, 0);
 

--- a/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/IR_X86.cpp
@@ -2111,7 +2111,7 @@ static void DoWriteCode(IRBuilder* ibuild, JitIL* Jit, u32 exitAddress)
 			FixupBranch noidle = Jit->J_CC(CC_NZ);
 
 			RI.Jit->Cleanup(); // is it needed?
-			Jit->ABI_CallFunction((void *)&PowerPC::OnIdle);
+			Jit->ABI_CallFunction((void *)&CoreTiming::Idle);
 
 			Jit->MOV(32, PPCSTATE(pc), Imm32(ibuild->GetImmValue( getOp2(I) )));
 			Jit->WriteExceptionExit();

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -426,7 +426,7 @@ void JitArm64::lXX(UGeckoInstruction inst)
 		ARM64Reg WA = gpr.GetReg();
 		ARM64Reg XA = EncodeRegTo64(WA);
 
-		MOVI2R(XA, (u64)&PowerPC::OnIdle);
+		MOVI2R(XA, (u64)&CoreTiming::Idle);
 		BLR(XA);
 
 		gpr.Unlock(WA);

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -529,11 +529,6 @@ void CheckBreakPoints()
 	}
 }
 
-void OnIdle()
-{
-	CoreTiming::Idle();
-}
-
 }  // namespace
 
 

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -163,8 +163,6 @@ volatile CPUState *GetStatePtr();  // this oddity is here instead of an extern d
 u32 CompactCR();
 void ExpandCR(u32 cr);
 
-void OnIdle();
-
 void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst);
 
 // Easy register access macros.


### PR DESCRIPTION
Stupid formulation, but the same as used for Jit64.
But moved into the bcx instruction instead of lwz. Seems more natural to me.