### PR TITLE
GC Adapter: Do not attempt to claim_interface when libusb_open() fails.

### DIFF
--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -235,6 +235,7 @@ static bool CheckDeviceAccess(libusb_device* device)
 				if (ret == LIBUSB_ERROR_NOT_SUPPORTED)
 					s_libusb_driver_not_supported = true;
 			}
+			return false;
 		}
 		else if ((ret = libusb_kernel_driver_active(s_handle, 0)) == 1)
 		{


### PR DESCRIPTION
Fixes a crash / nullptr dereference when the adapter is plugged in but no drivers are installed for it on Windows.

Fixes [issue 8257](https://code.google.com/p/dolphin-emu/issues/detail?id=8527).

Someone may want to test this for different hardware, OS, and driver configurations.