### PR TITLE
VI: derive field timing from VI registers

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -15,6 +15,7 @@
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
+#include "Core/HW/VideoInterface.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "VideoCommon/BPMemory.h"
 
@@ -169,7 +170,7 @@ FifoPlayer::FifoPlayer() :
 void FifoPlayer::WriteFrame(const FifoFrameInfo &frame, const AnalyzedFrameInfo &info)
 {
 	// Core timing information
-	m_CyclesPerFrame = SystemTimers::GetTicksPerSecond() / 60;
+	m_CyclesPerFrame = SystemTimers::GetTicksPerSecond() / VideoInterface::TargetRefreshRate;
 	m_ElapsedCycles = 0;
 	m_FrameFifoSize = frame.fifoDataSize;
 

--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -581,11 +581,11 @@ int GetTicksToNextSIPoll()
 		return SystemTimers::GetTicksPerSecond() / VideoInterface::TargetRefreshRate / 2;
 
 	if (!g_Poll.Y && g_Poll.X)
-		return VideoInterface::GetTicksPerLine() * g_Poll.X;
+		return 2 * VideoInterface::GetTicksPerHalfLine() * g_Poll.X;
 	else if (!g_Poll.Y)
 		return SystemTimers::GetTicksPerSecond() / 60;
 
-	return std::min(VideoInterface::GetTicksPerFrame() / g_Poll.Y, VideoInterface::GetTicksPerLine() * g_Poll.X);
+	return std::min(VideoInterface::GetTicksPerField() / g_Poll.Y, 2 * VideoInterface::GetTicksPerHalfLine() * g_Poll.X);
 }
 
 } // end of namespace SerialInterface

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -126,7 +126,7 @@ static void IPC_HLE_UpdateCallback(u64 userdata, int cyclesLate)
 static void VICallback(u64 userdata, int cyclesLate)
 {
 	VideoInterface::Update();
-	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerLine() - cyclesLate, et_VI);
+	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerHalfLine() - cyclesLate, et_VI);
 }
 
 static void SICallback(u64 userdata, int cyclesLate)
@@ -185,7 +185,7 @@ static void PatchEngineCallback(u64 userdata, int cyclesLate)
 {
 	// Patch mem and run the Action Replay
 	PatchEngine::ApplyFramePatches();
-	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerFrame() - cyclesLate, et_PatchEngine);
+	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerField() - cyclesLate, et_PatchEngine);
 }
 
 static void ThrottleCallback(u64 last_time, int cyclesLate)
@@ -259,16 +259,16 @@ void Init()
 	et_PatchEngine = CoreTiming::RegisterEvent("PatchEngine", PatchEngineCallback);
 	et_Throttle = CoreTiming::RegisterEvent("Throttle", ThrottleCallback);
 
-	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerLine(), et_VI);
+	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerHalfLine(), et_VI);
 	CoreTiming::ScheduleEvent(0, et_DSP);
-	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerFrame(), et_SI);
+	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerField(), et_SI);
 	CoreTiming::ScheduleEvent(AUDIO_DMA_PERIOD, et_AudioDMA);
 	CoreTiming::ScheduleEvent(0, et_Throttle, Common::Timer::GetTimeMs());
 	if (SConfig::GetInstance().bCPUThread && SConfig::GetInstance().bSyncGPU)
 		CoreTiming::ScheduleEvent(0, et_CP);
 	s_last_sync_gpu_tick = CoreTiming::GetTicks();
 
-	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerFrame(), et_PatchEngine);
+	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerField(), et_PatchEngine);
 
 	if (SConfig::GetInstance().bWii)
 		CoreTiming::ScheduleEvent(IPC_HLE_PERIOD, et_IPC_HLE);

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -18,6 +18,7 @@
 #include "Core/PowerPC/PowerPC.h"
 
 #include "VideoCommon/VideoBackendBase.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace VideoInterface
 {
@@ -520,7 +521,7 @@ void UpdateParameters()
 	s_even_field_last_hl = s_odd_field_first_hl - 1;
 	s_odd_field_last_hl = s_odd_field_first_hl + GetHalfLinesPerOddField() - 1;
 
-	TargetRefreshRate = 2 * SystemTimers::GetTicksPerSecond() / (GetTicksPerEvenField() + GetTicksPerOddField());
+	TargetRefreshRate = lround(2.0 * SystemTimers::GetTicksPerSecond() / (GetTicksPerEvenField() + GetTicksPerOddField()));
 }
 
 u32 GetTicksPerHalfLine()
@@ -564,13 +565,21 @@ static void BeginField(FieldType field)
 
 	u32 xfbAddr;
 
-	if (field == FieldType::FIELD_EVEN)
-	{
-		xfbAddr = GetXFBAddressTop();
+	if (g_ActiveConfig.bForceProgressive && (multiplier == 2)) {
+		if (m_VBlankTimingOdd.PRB < m_VBlankTimingEven.PRB)
+			xfbAddr = GetXFBAddressTop();
+		else
+			xfbAddr = GetXFBAddressBottom();
 	}
-	else
-	{
-		xfbAddr = GetXFBAddressBottom();
+	else {
+		if (field == FieldType::FIELD_EVEN)
+		{
+			xfbAddr = GetXFBAddressTop();
+		}
+		else
+		{
+			xfbAddr = GetXFBAddressBottom();
+		}
 	}
 
 	static const char* const fieldTypeNames[] = { "Odd", "Even" };

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -11,27 +11,6 @@ namespace MMIO { class Mapping; }
 
 namespace VideoInterface
 {
-// NTSC is 60 FPS, right?
-// Wrong, it's about 59.94 FPS. The NTSC engineers had to slightly lower
-// the field rate from 60 FPS when they added color to the standard.
-// This was done to prevent analog interference between the video and
-// audio signals. PAL has no similar reduction; it is exactly 50 FPS.
-//#define NTSC_FIELD_RATE  (60.0f / 1.001f)
-#define NTSC_FIELD_RATE    60
-#define NTSC_LINE_COUNT    525
-// These line numbers indicate the beginning of the "active video" in a frame.
-// An NTSC frame has the lower field first followed by the upper field.
-// TODO: Is this true for PAL-M? Is this true for PAL60?
-#define NTSC_LOWER_BEGIN    21
-#define NTSC_UPPER_BEGIN    283
-
-//#define PAL_FIELD_RATE      50.0f
-#define PAL_FIELD_RATE      50
-#define PAL_LINE_COUNT      625
-// These line numbers indicate the beginning of the "active video" in a frame.
-// A PAL frame has the upper field first followed by the lower field.
-#define PAL_UPPER_BEGIN     23
-#define PAL_LOWER_BEGIN     336
 
 // VI Internal Hardware Addresses
 enum
@@ -351,8 +330,8 @@ union UVIHorizontalStepping
 	// Change values pertaining to video mode
 	void UpdateParameters();
 
-	unsigned int GetTicksPerLine();
-	unsigned int GetTicksPerFrame();
+	u32 GetTicksPerHalfLine();
+	u32 GetTicksPerField();
 
 	//For VI Scaling and Aspect Ratio Correction
 	float GetAspectRatio(bool);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -66,7 +66,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 45; // Last changed in PR 2846
+static const u32 STATE_VERSION = 46; // Last changed in PR 2686
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -15,9 +15,8 @@ namespace MMIO { class Mapping; }
 
 enum FieldType
 {
-	FIELD_PROGRESSIVE = 0,
-	FIELD_UPPER,
-	FIELD_LOWER
+	FIELD_ODD = 0,
+	FIELD_EVEN = 1,
 };
 
 enum EFBAccessType

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -99,6 +99,7 @@ void VideoConfig::Load(const std::string& ini_file)
 	IniFile::Section* hacks = iniFile.GetOrCreateSection("Hacks");
 	hacks->Get("EFBAccessEnable", &bEFBAccessEnable, true);
 	hacks->Get("BBoxEnable", &bBBoxEnable, false);
+	hacks->Get("ForceProgressive", &bForceProgressive, true);
 	hacks->Get("EFBToTextureEnable", &bSkipEFBCopyToRam, true);
 	hacks->Get("EFBScaledCopy", &bCopyEFBScaled, true);
 	hacks->Get("EFBEmulateFormatChanges", &bEFBEmulateFormatChanges, false);
@@ -204,6 +205,7 @@ void VideoConfig::GameIniLoad()
 
 	CHECK_SETTING("Video_Hacks", "EFBAccessEnable", bEFBAccessEnable);
 	CHECK_SETTING("Video_Hacks", "BBoxEnable", bBBoxEnable);
+	CHECK_SETTING("Video_Hacks", "ForceProgressive", bForceProgressive);
 	CHECK_SETTING("Video_Hacks", "EFBToTextureEnable", bSkipEFBCopyToRam);
 	CHECK_SETTING("Video_Hacks", "EFBScaledCopy", bCopyEFBScaled);
 	CHECK_SETTING("Video_Hacks", "EFBEmulateFormatChanges", bEFBEmulateFormatChanges);
@@ -293,6 +295,7 @@ void VideoConfig::Save(const std::string& ini_file)
 	IniFile::Section* hacks = iniFile.GetOrCreateSection("Hacks");
 	hacks->Set("EFBAccessEnable", bEFBAccessEnable);
 	hacks->Set("BBoxEnable", bBBoxEnable);
+	hacks->Set("ForceProgressive", bForceProgressive);
 	hacks->Set("EFBToTextureEnable", bSkipEFBCopyToRam);
 	hacks->Set("EFBScaledCopy", bCopyEFBScaled);
 	hacks->Set("EFBEmulateFormatChanges", bEFBEmulateFormatChanges);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -112,6 +112,7 @@ struct VideoConfig final
 	bool bEFBAccessEnable;
 	bool bPerfQueriesEnable;
 	bool bBBoxEnable;
+	bool bForceProgressive;
 
 	bool bEFBEmulateFormatChanges;
 	bool bSkipEFBCopyToRam;


### PR DESCRIPTION
Rather than hard coding field timing for PAL/NTSC/Progressive this should derive it from the values set in the VI registers.

This PR also adds an option to enable/disable the forcing of interlaced to progressive fields. The option is not exposed via the UI. It defaults to ON and when on forces interlaced video modes to emit full progressive fields. This restores the old force-progressive hack but makes it optional via INI edit.

PR created to trigger builds for testing.

Some problems:
- [x] ~~% in title bar seems to be slightly off.~~
- [x] ~~Interlaced signal gives the one-line-jitter problem (again)~~
- [x] ~~save state version has been bumped, might need to be updated later on~~