### PR TITLE
Config Hotfix: Prevent per-game settings (ie. GameINI) being stored to the global user configuration.

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -7,6 +7,7 @@
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/HW/SI.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "DiscIO/NANDContentLoader.h"
@@ -39,6 +40,13 @@ SConfig::~SConfig()
 
 void SConfig::SaveSettings()
 {
+	// TODO: The is a hotfix to prevent writing of temporary per-game settings
+	// (GameINI, Movie, Netplay, ...) to the global Dolphin configuration file.
+	// The Config logic should be rewritten instead so that per-game settings
+	// aren't stored in the same configuration as the actual user settings.
+	if (Core::IsRunning())
+		return;
+
 	NOTICE_LOG(BOOT, "Saving settings to %s", File::GetUserPath(F_DOLPHINCONFIG_IDX).c_str());
 	IniFile ini;
 	ini.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX)); // load first to not kill unknown stuff

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -239,6 +239,13 @@ void VideoConfig::VerifyValidity()
 
 void VideoConfig::Save(const std::string& ini_file)
 {
+	// TODO: The is a hotfix to prevent writing of temporary per-game settings
+	// (GameINI, Movie, Netplay, ...) to the global Dolphin configuration file.
+	// The Config logic should be rewritten instead so that per-game settings
+	// aren't stored in the same configuration as the actual user settings.
+	if (Core::IsRunning())
+		return;
+
 	IniFile iniFile;
 	iniFile.Load(ini_file);
 


### PR DESCRIPTION
This addresses [issue 8734](https://code.google.com/p/dolphin-emu/issues/detail?id=8734), please read that for more detailed information.

This is a hotfix and should be properly fixed by a rewrite of how the current configuration is stored in memory at some point.

As a side-effect, this change means that changing a setting while a game is running will not immediately persist it to the global user configuration, however it will eventually write it once Dolphin closes, which means that settings changed while a game is running can be undone if the game crashes later. I think this is less of a problem than GameINI settings being written to the user configuration, though.

Do note that while this will prevent further improper setting writes, it will not fix oddities (ie, SyncGPU being globally on) that already exist in ini files.