### PR TITLE
Android TV: Replace toolbar on EmulationActivity with a full-screen menu

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -13,6 +13,9 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.view.animation.AccelerateInterpolator;
+import android.view.animation.DecelerateInterpolator;
+import android.view.animation.Interpolator;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -40,6 +43,9 @@ public final class EmulationActivity extends AppCompatActivity
 
 	// So that MainActivity knows which view to invalidate before the return animation.
 	private int mPosition;
+
+	private static Interpolator sDecelerator = new DecelerateInterpolator();
+	private static Interpolator sAccelerator = new AccelerateInterpolator();
 
 	/**
 	 * Handlers are a way to pass a message to an Activity telling it to do something
@@ -241,44 +247,40 @@ public final class EmulationActivity extends AppCompatActivity
 	{
 		if (mMenuVisible)
 		{
+			mMenuVisible = false;
+
 			mMenuLayout.animate()
 					.withLayer()
 					.setDuration(200)
+					.setInterpolator(sAccelerator)
 					.alpha(0.0f)
-					.scaleX(1.1f)
-					.scaleY(1.1f)
+					.translationX(-400.0f)
 					.withEndAction(new Runnable()
 					{
 						@Override
 						public void run()
 						{
-							mMenuLayout.setVisibility(View.GONE);
-							mMenuVisible = false;
+							if (mMenuVisible)
+							{
+								mMenuLayout.setVisibility(View.GONE);
+							}
 						}
 					});
 		}
 		else
 		{
+			mMenuVisible = true;
 			mMenuLayout.setVisibility(View.VISIBLE);
 
-			mMenuLayout.setScaleX(1.1f);
-			mMenuLayout.setScaleY(1.1f);
+//			mMenuLayout.setTranslationX(-400.0f);
 			mMenuLayout.setAlpha(0.0f);
 
 			mMenuLayout.animate()
 					.withLayer()
 					.setDuration(300)
+					.setInterpolator(sDecelerator)
 					.alpha(1.0f)
-					.scaleX(1.0f)
-					.scaleY(1.0f)
-					.withEndAction(new Runnable()
-					{
-						@Override
-						public void run()
-						{
-							mMenuVisible = true;
-						}
-					});
+					.translationX(0.0f);
 		}
 	}
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -28,6 +28,7 @@ import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.fragments.EmulationFragment;
 import org.dolphinemu.dolphinemu.fragments.LoadStateFragment;
+import org.dolphinemu.dolphinemu.fragments.MenuFragment;
 import org.dolphinemu.dolphinemu.fragments.SaveStateFragment;
 
 import java.util.List;
@@ -40,7 +41,7 @@ public final class EmulationActivity extends AppCompatActivity
 	private FrameLayout mFrameEmulation;
 	private LinearLayout mMenuLayout;
 
-	private String mMenuFragmentTag;
+	private String mSubmenuFragmentTag;
 
 	// So that MainActivity knows which view to invalidate before the return animation.
 	private int mPosition;
@@ -67,6 +68,7 @@ public final class EmulationActivity extends AppCompatActivity
 	};
 	private String mScreenPath;
 	private FrameLayout mFrameContent;
+	private String mSelectedTitle;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
@@ -129,7 +131,7 @@ public final class EmulationActivity extends AppCompatActivity
 
 		Intent gameToEmulate = getIntent();
 		String path = gameToEmulate.getStringExtra("SelectedGame");
-		String title = gameToEmulate.getStringExtra("SelectedTitle");
+		mSelectedTitle = gameToEmulate.getStringExtra("SelectedTitle");
 		mScreenPath = gameToEmulate.getStringExtra("ScreenPath");
 		mPosition = gameToEmulate.getIntExtra("GridPosition", -1);
 
@@ -175,8 +177,6 @@ public final class EmulationActivity extends AppCompatActivity
 					}
 				});
 
-		setTitle(title);
-
 		// Instantiate an EmulationFragment.
 		EmulationFragment emulationFragment = EmulationFragment.newInstance(path);
 
@@ -184,6 +184,21 @@ public final class EmulationActivity extends AppCompatActivity
 		getFragmentManager().beginTransaction()
 				.add(R.id.frame_emulation_fragment, emulationFragment, EmulationFragment.FRAGMENT_TAG)
 				.commit();
+
+		if (mDeviceHasTouchScreen)
+		{
+			setTitle(mSelectedTitle);
+		}
+		else
+		{
+			MenuFragment menuFragment = (MenuFragment) getFragmentManager()
+					.findFragmentById(R.id.fragment_menu);
+
+			if (menuFragment != null)
+			{
+				menuFragment.setTitleText(mSelectedTitle);
+			}
+		}
 	}
 
 	@Override
@@ -240,7 +255,7 @@ public final class EmulationActivity extends AppCompatActivity
 	{
 		if (!mDeviceHasTouchScreen)
 		{
-			if (mMenuFragmentTag != null)
+			if (mSubmenuFragmentTag != null)
 			{
 				removeMenu();
 			}
@@ -579,12 +594,12 @@ public final class EmulationActivity extends AppCompatActivity
 		{
 			case SaveStateFragment.FRAGMENT_ID:
 				fragment = SaveStateFragment.newInstance();
-				mMenuFragmentTag = SaveStateFragment.FRAGMENT_TAG;
+				mSubmenuFragmentTag = SaveStateFragment.FRAGMENT_TAG;
 				break;
 
 			case LoadStateFragment.FRAGMENT_ID:
 				fragment = LoadStateFragment.newInstance();
-				mMenuFragmentTag = LoadStateFragment.FRAGMENT_TAG;
+				mSubmenuFragmentTag = LoadStateFragment.FRAGMENT_TAG;
 				break;
 
 			default:
@@ -593,15 +608,15 @@ public final class EmulationActivity extends AppCompatActivity
 
 		getFragmentManager().beginTransaction()
 				.setCustomAnimations(R.animator.menu_slide_in, R.animator.menu_slide_out)
-				.replace(R.id.frame_submenu, fragment, mMenuFragmentTag)
+				.replace(R.id.frame_submenu, fragment, mSubmenuFragmentTag)
 				.commit();
 	}
 
 	private void removeMenu()
 	{
-		if (mMenuFragmentTag != null)
+		if (mSubmenuFragmentTag != null)
 		{
-			final Fragment fragment = getFragmentManager().findFragmentByTag(mMenuFragmentTag);
+			final Fragment fragment = getFragmentManager().findFragmentByTag(mSubmenuFragmentTag);
 
 			if (fragment != null)
 			{
@@ -632,11 +647,16 @@ public final class EmulationActivity extends AppCompatActivity
 				Log.e("DolphinEmu", "[EmulationActivity] Fragment not found, can't remove.");
 			}
 
-			mMenuFragmentTag = null;
+			mSubmenuFragmentTag = null;
 		}
 		else
 		{
 			Log.e("DolphinEmu", "[EmulationActivity] Fragment Tag empty.");
 		}
+	}
+
+	public String getSelectedTitle()
+	{
+		return mSelectedTitle;
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -81,9 +81,12 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 		mSurfaceView.getHolder().addCallback(this);
 
 		// If the input overlay was previously disabled, then don't show it.
-		if (!mPreferences.getBoolean("showInputOverlay", true))
+		if (mInputOverlay != null)
 		{
-			mInputOverlay.setVisibility(View.GONE);
+			if (!mPreferences.getBoolean("showInputOverlay", true))
+			{
+				mInputOverlay.setVisibility(View.GONE);
+			}
 		}
 
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/LoadStateFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/LoadStateFragment.java
@@ -1,0 +1,55 @@
+package org.dolphinemu.dolphinemu.fragments;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.GridLayout;
+
+import org.dolphinemu.dolphinemu.BuildConfig;
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.activities.EmulationActivity;
+
+public final class LoadStateFragment extends Fragment implements View.OnClickListener
+{
+	public static final String FRAGMENT_TAG = BuildConfig.APPLICATION_ID + ".load_state";
+	public static final int FRAGMENT_ID = R.layout.fragment_state_load;
+
+	public static LoadStateFragment newInstance()
+	{
+		LoadStateFragment fragment = new LoadStateFragment();
+
+		// TODO Add any appropriate arguments to this fragment.
+
+		return fragment;
+	}
+
+	@Nullable
+	@Override
+	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+	{
+		View rootView = inflater.inflate(FRAGMENT_ID, container, false);
+
+		GridLayout grid = (GridLayout) rootView.findViewById(R.id.grid_state_slots);
+		for (int childIndex = 0; childIndex < grid.getChildCount(); childIndex++)
+		{
+			Button button = (Button) grid.getChildAt(childIndex);
+
+			button.setOnClickListener(this);
+		}
+
+		// So that item clicked to start this Fragment is no longer the focused item.
+		grid.requestFocus();
+
+		return rootView;
+	}
+
+	@Override
+	public void onClick(View button)
+	{
+		((EmulationActivity) getActivity()).onMenuItemClicked(button.getId());
+	}
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import org.dolphinemu.dolphinemu.BuildConfig;
 import org.dolphinemu.dolphinemu.R;
@@ -17,19 +18,23 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
 {
 	public static final String FRAGMENT_TAG = BuildConfig.APPLICATION_ID + ".ingame_menu";
 	public static final int FRAGMENT_ID = R.layout.fragment_ingame_menu;
+	private TextView mTitleText;
 
 	@Nullable
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 	{
-		LinearLayout rootView = (LinearLayout) inflater.inflate(FRAGMENT_ID, container, false);
+		View rootView = inflater.inflate(FRAGMENT_ID, container, false);
 
-		for (int childIndex = 0; childIndex < rootView.getChildCount(); childIndex++)
+		LinearLayout options = (LinearLayout) rootView.findViewById(R.id.layout_options);
+		for (int childIndex = 0; childIndex < options.getChildCount(); childIndex++)
 		{
-			Button button = (Button) rootView.getChildAt(childIndex);
+			Button button = (Button) options.getChildAt(childIndex);
 
 			button.setOnClickListener(this);
 		}
+
+		mTitleText = (TextView) rootView.findViewById(R.id.text_game_title);
 
 		return rootView;
 	}
@@ -38,5 +43,10 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
 	public void onClick(View button)
 	{
 		((EmulationActivity) getActivity()).onMenuItemClicked(button.getId());
+	}
+
+	public void setTitleText(String title)
+	{
+		mTitleText.setText(title);
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -9,16 +9,20 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
 
+import org.dolphinemu.dolphinemu.BuildConfig;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 
 public final class MenuFragment extends Fragment implements View.OnClickListener
 {
+	public static final String FRAGMENT_TAG = BuildConfig.APPLICATION_ID + ".ingame_menu";
+	public static final int FRAGMENT_ID = R.layout.fragment_ingame_menu;
+
 	@Nullable
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 	{
-		LinearLayout rootView = (LinearLayout) inflater.inflate(R.layout.fragment_ingame_menu, container, false);
+		LinearLayout rootView = (LinearLayout) inflater.inflate(FRAGMENT_ID, container, false);
 
 		for (int childIndex = 0; childIndex < rootView.getChildCount(); childIndex++)
 		{

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -1,0 +1,38 @@
+package org.dolphinemu.dolphinemu.fragments;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.LinearLayout;
+
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.activities.EmulationActivity;
+
+public final class MenuFragment extends Fragment implements View.OnClickListener
+{
+	@Nullable
+	@Override
+	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+	{
+		LinearLayout rootView = (LinearLayout) inflater.inflate(R.layout.fragment_ingame_menu, container, false);
+
+		for (int childIndex = 0; childIndex < rootView.getChildCount(); childIndex++)
+		{
+			Button button = (Button) rootView.getChildAt(childIndex);
+
+			button.setOnClickListener(this);
+		}
+
+		return rootView;
+	}
+
+	@Override
+	public void onClick(View button)
+	{
+		((EmulationActivity) getActivity()).onMenuItemClicked(button.getId());
+	}
+}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/SaveStateFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/SaveStateFragment.java
@@ -1,0 +1,55 @@
+package org.dolphinemu.dolphinemu.fragments;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.GridLayout;
+
+import org.dolphinemu.dolphinemu.BuildConfig;
+import org.dolphinemu.dolphinemu.R;
+import org.dolphinemu.dolphinemu.activities.EmulationActivity;
+
+public final class SaveStateFragment extends Fragment implements View.OnClickListener
+{
+	public static final String FRAGMENT_TAG = BuildConfig.APPLICATION_ID + ".save_state";
+	public static final int FRAGMENT_ID = R.layout.fragment_state_save;
+
+	public static SaveStateFragment newInstance()
+	{
+		SaveStateFragment fragment = new SaveStateFragment();
+
+		// TODO Add any appropriate arguments to this fragment.
+
+		return fragment;
+	}
+
+	@Nullable
+	@Override
+	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+	{
+		View rootView = inflater.inflate(FRAGMENT_ID, container, false);
+
+		GridLayout grid = (GridLayout) rootView.findViewById(R.id.grid_state_slots);
+		for (int childIndex = 0; childIndex < grid.getChildCount(); childIndex++)
+		{
+			Button button = (Button) grid.getChildAt(childIndex);
+
+			button.setOnClickListener(this);
+		}
+
+		// So that item clicked to start this Fragment is no longer the focused item.
+		grid.requestFocus();
+
+		return rootView;
+	}
+
+	@Override
+	public void onClick(View button)
+	{
+		((EmulationActivity) getActivity()).onMenuItemClicked(button.getId());
+	}
+}

--- a/Source/Android/app/src/main/res/animator/menu_slide_in.xml
+++ b/Source/Android/app/src/main/res/animator/menu_slide_in.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <objectAnimator
+        android:propertyName="translationX"
+        android:valueType="floatType"
+        android:valueFrom="1280"
+        android:valueTo="0"
+        android:interpolator="@android:interpolator/decelerate_quad"
+        android:duration="300"/>
+    <objectAnimator
+        android:propertyName="alpha"
+        android:valueType="floatType"
+        android:valueFrom="0"
+        android:valueTo="1"
+        android:interpolator="@android:interpolator/accelerate_quad"
+        android:duration="300"/>
+</set>

--- a/Source/Android/app/src/main/res/animator/menu_slide_out.xml
+++ b/Source/Android/app/src/main/res/animator/menu_slide_out.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- This animation is used ONLY when a submenu is replaced. -->
+    <objectAnimator xmlns:android="http://schemas.android.com/apk/res/android"
+                    android:propertyName="translationX"
+                    android:valueType="floatType"
+                    android:valueFrom="0"
+                    android:valueTo="1280"
+                    android:interpolator="@android:interpolator/decelerate_quad"
+                    android:duration="300"/>
+    <objectAnimator xmlns:android="http://schemas.android.com/apk/res/android"
+                    android:propertyName="alpha"
+                    android:valueType="floatType"
+                    android:valueFrom="1"
+                    android:valueTo="0"
+                    android:interpolator="@android:interpolator/decelerate_quad"
+                    android:duration="300"/>
+</set>

--- a/Source/Android/app/src/main/res/layout-television/activity_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-television/activity_emulation.xml
@@ -1,0 +1,45 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:id="@+id/frame_content">
+
+    <FrameLayout
+        android:id="@+id/frame_emulation_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="invisible"/>
+
+    <LinearLayout
+        android:id="@+id/layout_ingame_menu"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#af000000"
+        android:orientation="horizontal"
+        android:visibility="gone"
+        tools:visibility="visible"
+        android:baselineAligned="false">
+
+        <fragment
+            android:id="@+id/fragment_menu"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:name="org.dolphinemu.dolphinemu.fragments.MenuFragment"
+            tools:layout="@layout/fragment_ingame_menu"/>
+
+        <FrameLayout
+            android:id="@+id/frame_submenu"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"/>
+
+    </LinearLayout>
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/image_screenshot"
+        android:transitionName="image_game_screenshot"/>
+
+</FrameLayout>

--- a/Source/Android/app/src/main/res/layout-television/activity_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-television/activity_emulation.xml
@@ -10,6 +10,12 @@
         android:layout_height="match_parent"
         android:visibility="invisible"/>
 
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/image_screenshot"
+        android:transitionName="image_game_screenshot"/>
+
     <LinearLayout
         android:id="@+id/layout_ingame_menu"
         android:layout_width="match_parent"
@@ -35,11 +41,5 @@
             android:layout_weight="2"/>
 
     </LinearLayout>
-
-    <ImageView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:id="@+id/image_screenshot"
-        android:transitionName="image_game_screenshot"/>
 
 </FrameLayout>

--- a/Source/Android/app/src/main/res/layout-television/activity_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-television/activity_emulation.xml
@@ -20,7 +20,6 @@
         android:id="@+id/layout_ingame_menu"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#af000000"
         android:orientation="horizontal"
         android:visibility="gone"
         tools:visibility="visible"
@@ -38,7 +37,7 @@
             android:id="@+id/frame_submenu"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="2"/>
+            android:layout_weight="3"/>
 
     </LinearLayout>
 

--- a/Source/Android/app/src/main/res/layout-television/fragment_emulation.xml
+++ b/Source/Android/app/src/main/res/layout-television/fragment_emulation.xml
@@ -1,0 +1,14 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             tools:context="org.dolphinemu.dolphinemu.fragments.EmulationFragment">
+
+    <!-- This is what everything is rendered to during emulation -->
+    <SurfaceView
+        android:id="@+id/surface_emulation"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:focusable="false"
+        android:focusableInTouchMode="false"/>
+</FrameLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:padding="32dp">
+
+    <Button
+        android:id="@+id/menu_take_screenshot"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/overlay_screenshot"
+        android:layout_margin="8dp"
+        style="@style/InGameMenuOption"/>
+
+    <Button
+        android:id="@+id/menu_quicksave"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/emulation_quicksave"
+        android:layout_margin="8dp"
+        style="@style/InGameMenuOption"/>
+
+    <Button
+        android:id="@+id/menu_quickload"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/emulation_quickload"
+        android:layout_margin="8dp"
+        style="@style/InGameMenuOption"/>
+
+    <Button
+        android:id="@+id/menu_emulation_save_root"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/overlay_savestate"
+        android:layout_margin="8dp"
+        style="@style/InGameMenuOption"/>
+
+    <Button
+        android:id="@+id/menu_emulation_load_root"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/overlay_loadstate"
+        android:layout_margin="8dp"
+        style="@style/InGameMenuOption"/>
+
+    <Button
+        android:id="@+id/menu_ingame_settings"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/settings"
+        android:layout_margin="8dp"
+        style="@style/InGameMenuOption"/>
+
+    <Button
+        android:id="@+id/menu_exit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/overlay_exit_emulation"
+        android:layout_margin="8dp"
+        style="@style/InGameMenuOption"/>
+
+</LinearLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -1,46 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:background="@color/dolphin_blue_dark"
-              android:paddingTop="32dp"
-              android:paddingBottom="32dp"
+              tools:layout_width="250dp"
     >
 
-    <Button
-        android:id="@+id/menu_take_screenshot"
-        android:text="@string/overlay_screenshot"
-        style="@style/InGameMenuOption"/>
+    <TextView
+        android:id="@+id/text_game_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="The Legend of Zelda: The Wind Waker"
+        android:textColor="@android:color/white"
+        android:textSize="20sp"
+        android:layout_margin="32dp"/>
 
-    <Button
-        android:id="@+id/menu_quicksave"
-        android:text="@string/emulation_quicksave"
-        style="@style/InGameMenuOption"/>
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        >
 
-    <Button
-        android:id="@+id/menu_quickload"
-        android:text="@string/emulation_quickload"
-        style="@style/InGameMenuOption"/>
+        <LinearLayout
+            android:id="@+id/layout_options"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-    <Button
-        android:id="@+id/menu_emulation_save_root"
-        android:text="@string/overlay_savestate"
-        style="@style/InGameMenuOption"/>
+            <Button
+                android:id="@+id/menu_take_screenshot"
+                android:text="@string/overlay_screenshot"
+                style="@style/InGameMenuOption"/>
 
-    <Button
-        android:id="@+id/menu_emulation_load_root"
-        android:text="@string/overlay_loadstate"
-        style="@style/InGameMenuOption"/>
+            <Button
+                android:id="@+id/menu_quicksave"
+                android:text="@string/emulation_quicksave"
+                style="@style/InGameMenuOption"/>
 
-    <Button
-        android:id="@+id/menu_ingame_settings"
-        android:text="@string/settings"
-        style="@style/InGameMenuOption"/>
+            <Button
+                android:id="@+id/menu_quickload"
+                android:text="@string/emulation_quickload"
+                style="@style/InGameMenuOption"/>
 
-    <Button
-        android:id="@+id/menu_exit"
-        android:text="@string/overlay_exit_emulation"
-        style="@style/InGameMenuOption"/>
+            <Button
+                android:id="@+id/menu_emulation_save_root"
+                android:text="@string/overlay_savestate"
+                style="@style/InGameMenuOption"/>
 
+            <Button
+                android:id="@+id/menu_emulation_load_root"
+                android:text="@string/overlay_loadstate"
+                style="@style/InGameMenuOption"/>
+
+            <Button
+                android:id="@+id/menu_ingame_settings"
+                android:text="@string/settings"
+                style="@style/InGameMenuOption"/>
+
+            <Button
+                android:id="@+id/menu_exit"
+                android:text="@string/overlay_exit_emulation"
+                style="@style/InGameMenuOption"/>
+
+        </LinearLayout>
+    </ScrollView>
 </LinearLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -3,62 +3,44 @@
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
-              android:padding="32dp">
+              android:background="@color/dolphin_blue_dark"
+              android:paddingTop="32dp"
+              android:paddingBottom="32dp"
+    >
 
     <Button
         android:id="@+id/menu_take_screenshot"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:text="@string/overlay_screenshot"
-        android:layout_margin="8dp"
         style="@style/InGameMenuOption"/>
 
     <Button
         android:id="@+id/menu_quicksave"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:text="@string/emulation_quicksave"
-        android:layout_margin="8dp"
         style="@style/InGameMenuOption"/>
 
     <Button
         android:id="@+id/menu_quickload"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:text="@string/emulation_quickload"
-        android:layout_margin="8dp"
         style="@style/InGameMenuOption"/>
 
     <Button
         android:id="@+id/menu_emulation_save_root"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:text="@string/overlay_savestate"
-        android:layout_margin="8dp"
         style="@style/InGameMenuOption"/>
 
     <Button
         android:id="@+id/menu_emulation_load_root"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:text="@string/overlay_loadstate"
-        android:layout_margin="8dp"
         style="@style/InGameMenuOption"/>
 
     <Button
         android:id="@+id/menu_ingame_settings"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:text="@string/settings"
-        android:layout_margin="8dp"
         style="@style/InGameMenuOption"/>
 
     <Button
         android:id="@+id/menu_exit"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:text="@string/overlay_exit_emulation"
-        android:layout_margin="8dp"
         style="@style/InGameMenuOption"/>
 
 </LinearLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_state_load.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_state_load.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             android:background="#af000000"
+             android:orientation="vertical"
+    >
+
+    <GridLayout
+        android:id="@+id/grid_state_slots"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:columnCount="3"
+        android:rowCount="2"
+        android:layout_gravity="center">
+
+        <Button
+            android:id="@+id/menu_emulation_load_1"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot1"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_load_2"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot2"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_load_3"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot3"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_load_4"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot4"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_load_5"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot5"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_load_6"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot6"
+            style="@style/InGameMenuOption"
+            />
+    </GridLayout>
+</FrameLayout>

--- a/Source/Android/app/src/main/res/layout/fragment_state_save.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_state_save.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             android:background="#af000000"
+             android:orientation="vertical"
+    >
+
+    <GridLayout
+        android:id="@+id/grid_state_slots"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:columnCount="3"
+        android:rowCount="2"
+        android:layout_gravity="center">
+
+        <Button
+            android:id="@+id/menu_emulation_save_1"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot1"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_save_2"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot2"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_save_3"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot3"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_save_4"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot4"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_save_5"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot5"
+            style="@style/InGameMenuOption"
+            />
+
+        <Button
+            android:id="@+id/menu_emulation_save_6"
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:text="@string/overlay_slot6"
+            style="@style/InGameMenuOption"
+            />
+    </GridLayout>
+</FrameLayout>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="overlay_slot3">Slot 3</string>
     <string name="overlay_slot4">Slot 4</string>
     <string name="overlay_slot5">Slot 5</string>
+    <string name="overlay_slot6">Slot 6</string>
 
     <!-- Input Config Fragment -->
     <string name="input_settings">Input</string>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -127,11 +127,16 @@
     </style>
 
     <style name="InGameMenuOption" parent="Widget.AppCompat.Button.Borderless">
-        <item name="android:textSize">24dp</item>
+        <item name="android:textSize">20sp</item>
         <item name="android:fontFamily">sans-serif-condensed</item>
         <item name="android:textColor">@android:color/white</item>
         <item name="android:textAllCaps">false</item>
-        <item name="android:gravity">left</item>
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">48dp</item>
+        <item name="android:gravity">center_vertical|left</item>
+        <item name="android:paddingLeft">32dp</item>
+        <item name="android:paddingRight">32dp</item>
+        <item name="android:layout_margin">0dp</item>
     </style>
 
 </resources>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -127,7 +127,7 @@
     </style>
 
     <style name="InGameMenuOption" parent="Widget.AppCompat.Button.Borderless">
-        <item name="android:textSize">20sp</item>
+        <item name="android:textSize">16sp</item>
         <item name="android:fontFamily">sans-serif-condensed</item>
         <item name="android:textColor">@android:color/white</item>
         <item name="android:textAllCaps">false</item>

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -95,9 +95,43 @@
         <item name="colorAccent">@color/dolphin_accent_wiiware</item>
     </style>
 
+    <style name="DolphinEmulationTvBase" parent="Theme.AppCompat.NoActionBar">
+        <item name="colorPrimary">@color/dolphin_blue</item>
+        <item name="colorPrimaryDark">@color/dolphin_blue_dark</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+
+        <item name="android:windowBackground">@android:color/black</item>
+
+        <!--enable window content transitions-->
+        <item name="android:windowContentTransitions">true</item>
+        <item name="android:windowAllowEnterTransitionOverlap">true</item>
+        <item name="android:windowAllowReturnTransitionOverlap">true</item>
+    </style>
+
+    <!-- Inherit from the Base Dolphin Emulation Theme-->
+    <style name="DolphinEmulationTvWii" parent="DolphinEmulationTvBase">
+        <item name="colorAccent">@color/dolphin_accent_wii</item>
+    </style>
+
+    <style name="DolphinEmulationTvGamecube" parent="DolphinEmulationTvBase">
+        <item name="colorAccent">@color/dolphin_accent_gamecube</item>
+    </style>
+
+    <style name="DolphinEmulationTvWiiware" parent="DolphinEmulationTvBase">
+        <item name="colorAccent">@color/dolphin_accent_wiiware</item>
+    </style>
+
     <!-- Hax to make Tablayout render icons -->
     <style name="MyCustomTextAppearance" parent="TextAppearance.Design.Tab">
         <item name="textAllCaps">false</item>
+    </style>
+
+    <style name="InGameMenuOption" parent="Widget.AppCompat.Button.Borderless">
+        <item name="android:textSize">24dp</item>
+        <item name="android:fontFamily">sans-serif-condensed</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:gravity">left</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Android TV devices do not have a touch-screen, and so there were issues with navigating the ingame options with the controller.

It's also tough to read small text, and icons are no better. This PR adds a transparent full-screen overlay menu, while emulation continues in the background. (The settings, savestate, and loadstate options are no-ops for now, but everything else works including quicksave/load.) This menu will also be expandable to allow runtime modifications of certain settings (internal resolution, for example.)

It should be functional, but there are still visual artifacts here and there. I'm working on resolving those, as well as making the existing no-ops not no-ops anymore. However, I think there may be value in merging this asap, as it resolves a major pain point for folks trying to develop for the X1.