### PR TITLE
Android TV: Use accent color to highlight games on selection screen.

### DIFF
--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -12,6 +12,8 @@
         <item name="android:windowContentTransitions">true</item>
         <item name="android:windowAllowEnterTransitionOverlap">true</item>
         <item name="android:windowAllowReturnTransitionOverlap">true</item>
+
+        <item name="android:colorControlHighlight">?attr/colorAccent</item>
     </style>
 
     <!-- Same as above, but use default action bar, and mandate margins. -->


### PR DESCRIPTION
Per request. Kind of a thoughtless hack because this screen won't be around on Android TV much longer.