### PR TITLE
Disable bad optimization in Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,11 @@ if(NOT MSVC)
 	check_and_add_flag(MISSING_VARIABLE_DECLARATIONS -Wmissing-variable-declarations)
 endif(NOT MSVC)
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+	# The JIT breaks horrendously if clang inlines functions, which it does at -O3
+	add_definitions(-fno-inline-functions)
+endif()
+
 # gcc uses some optimizations which might break stuff without this flag
 add_definitions(-fno-strict-aliasing -fno-exceptions)
 


### PR DESCRIPTION
Inlining functions breaks the JIT when compiled with clang -O3. By disabling inlining functions specifically in the clang build, the JIT functions normally again.