### PR TITLE
Common: CallLambdaTrampoline can return a value

### DIFF
--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -711,10 +711,9 @@ public:
 	// (this method might be a thunk in the case of multi-inheritance) so we
 	// have to go through a trampoline function.
 	template <typename T, typename... Args>
-	static void CallLambdaTrampoline(const std::function<T(Args...)>* f,
-	                                 Args... args)
+	static T CallLambdaTrampoline(const std::function<T(Args...)>* f, Args... args)
 	{
-		(*f)(args...);
+		return (*f)(args...);
 	}
 
 	// This function expects you to have set up the state.

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -971,10 +971,9 @@ public:
 	// (this method might be a thunk in the case of multi-inheritance) so we
 	// have to go through a trampoline function.
 	template <typename T, typename... Args>
-	static void CallLambdaTrampoline(const std::function<T(Args...)>* f,
-	                                 Args... args)
+	static T CallLambdaTrampoline(const std::function<T(Args...)>* f, Args... args)
 	{
-		(*f)(args...);
+		return (*f)(args...);
 	}
 
 	template <typename T, typename... Args>


### PR DESCRIPTION
As it is currently written, CallLambdaTrampoline does not return a value. However, some of the functions that are being wrapped may return a value that the JIT is expected to understand. A compiler ***cough cough clang*** may opt to alter `%rax` after the wrapped lambda returns, e.g. popping a previous value, which can clobber the return value. If we actually have a return value, then the compiler must not clobber it.