### PR TITLE
Prevent nullptr dereference on a crash with no JIT present

### DIFF
--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -203,6 +203,12 @@ namespace JitInterface
 
 	bool HandleFault(uintptr_t access_address, SContext* ctx)
 	{
+		// Prevent nullptr dereference on a crash with no JIT present
+		if (!jit)
+		{
+			return false;
+		}
+
 		return jit->HandleFault(access_address, ctx);
 	}
 


### PR DESCRIPTION
If Dolphin crashes while no JIT is present (e.g. no game running), JitInterface::HandleFault will try to dereference `jit`, which is `NULL`. This will again cause a crash, sending Dolphin into an infinite exception recursion which will eventually overflow the stack and (for me) cause a crash inside USP10.dll. This PR changes this to return `false`, so the exception handler will return `EXCEPTION_CONTINUE_SEARCH`.

This might be shortened to `return jit && ...`, though I don't know which one should be preferred.