### PR TITLE
Android TV: Have panic alerts show a blocking dialog, with an option to abort emulation

### DIFF
--- a/Source/Android/app/src/arm_64/res/values/strings.xml
+++ b/Source/Android/app/src/arm_64/res/values/strings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- Title of the app -->
-    <string name="title_new_ui">Dolphin ARM64</string>
-</resources>

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -8,7 +8,6 @@ package org.dolphinemu.dolphinemu;
 
 import android.util.Log;
 import android.view.Surface;
-import android.widget.Toast;
 
 import org.dolphinemu.dolphinemu.activities.EmulationActivity;
 
@@ -351,16 +350,6 @@ public final class NativeLibrary
 	public static native void WriteProfileResults();
 
 	/**
-	 * @return If we have an alert
-	 */
-	public static native boolean HasAlertMsg();
-
-	/**
-	 * @return The alert string
-	 */
-	public static native String GetAlertMsg();
-
-	/**
 	 * Clears event in the JNI so we can continue onward
 	 */
 	public static native void ClearAlertMsg();
@@ -397,7 +386,7 @@ public final class NativeLibrary
 			@Override
 			public void run()
 			{
-				Toast.makeText(mEmulationActivity, "Panic Alert: " + alert, Toast.LENGTH_LONG).show();
+				mEmulationActivity.showPanicDialog(alert);
 			}
 		});
 	}

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -674,7 +674,7 @@ public final class EmulationActivity extends AppCompatActivity
 					@Override
 					public void onClick(DialogInterface dialog, int which)
 					{
-						NativeLibrary.UnPauseEmulation();
+						NativeLibrary.ClearAlertMsg();
 					}
 				})
 				.setNegativeButton(R.string.dialog_panic_neg, new DialogInterface.OnClickListener()
@@ -682,8 +682,7 @@ public final class EmulationActivity extends AppCompatActivity
 					@Override
 					public void onClick(DialogInterface dialog, int which)
 					{
-						// TODO If this Unpause isn't here, for some reason, the emulator stops responding.
-						NativeLibrary.UnPauseEmulation();
+						NativeLibrary.ClearAlertMsg();
 
 						EmulationFragment fragment = (EmulationFragment) getFragmentManager()
 								.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -1,5 +1,7 @@
 package org.dolphinemu.dolphinemu.activities;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.app.Fragment;
 import android.content.Intent;
 import android.os.Bundle;
@@ -658,5 +660,38 @@ public final class EmulationActivity extends AppCompatActivity
 	public String getSelectedTitle()
 	{
 		return mSelectedTitle;
+	}
+
+	public void showPanicDialog(String message)
+	{
+		AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+		builder.setTitle(R.string.dialog_panic_title)
+				.setMessage(message + "\n\n" +
+						getString(R.string.dialog_panic_instructions))
+				.setPositiveButton(R.string.dialog_panic_pos, new DialogInterface.OnClickListener()
+				{
+					@Override
+					public void onClick(DialogInterface dialog, int which)
+					{
+						NativeLibrary.UnPauseEmulation();
+					}
+				})
+				.setNegativeButton(R.string.dialog_panic_neg, new DialogInterface.OnClickListener()
+				{
+					@Override
+					public void onClick(DialogInterface dialog, int which)
+					{
+						// TODO If this Unpause isn't here, for some reason, the emulator stops responding.
+						NativeLibrary.UnPauseEmulation();
+
+						EmulationFragment fragment = (EmulationFragment) getFragmentManager()
+								.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
+						fragment.notifyEmulationStopped();
+
+						NativeLibrary.StopEmulation();
+					}
+				})
+				.show();
 	}
 }

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -352,4 +352,9 @@
 
     <!-- Package Names-->
     <string name="application_id">org.dolphinemu.dolphinemu</string>
+
+    <string name="dialog_panic_title">Panic Alert</string>
+    <string name="dialog_panic_instructions">Emulation will probably fail, but you can try to continue regardless.</string>
+    <string name="dialog_panic_pos">Continue</string>
+    <string name="dialog_panic_neg">Quit</string>
 </resources>

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -124,6 +124,9 @@ static bool MsgAlert(const char* caption, const char* text, bool yes_no, int /*S
 	// Execute the Java method.
 	env->CallStaticVoidMethod(g_jni_class, g_jni_method_alert, env->NewStringUTF(text));
 
+	// Block until the alert is acknowledged.
+	PowerPC::Pause();
+
 	// Must be called before the current thread exits; might as well do it here.
 	g_java_vm->DetachCurrentThread();
 


### PR DESCRIPTION
Pretty self explanatory, but I was unable to get the "quit" option to work without first resuming emulation, which is obviously wrong. I'm still investigating whether or not I've made a mistake on the Android side, but if someone could take a look at the native implementation and see if i've made an obvious mistake, I'd appreciate it.