### PR TITLE
evdev: Delete rumble effects on the correct file descriptor.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -216,6 +216,12 @@ void evdevDevice::ForceFeedback::SetState(ControlState state)
 	// libevdev doesn't have nice helpers for forcefeedback
 	// we will use the file descriptors directly.
 
+	if (m_id != -1)  // delete the previous effect (which also stops it)
+	{
+		ioctl(m_fd, EVIOCRMFF, m_id);
+		m_id = -1;
+	}
+
 	if (state > 0) // Upload and start an effect.
 	{
 		ff_effect effect;
@@ -260,9 +266,14 @@ void evdevDevice::ForceFeedback::SetState(ControlState state)
 
 		write(m_fd, (const void*) &play, sizeof(play));
 	}
-	else if (m_id != -1)  // delete the effect (which also stops it)
+}
+
+evdevDevice::ForceFeedback::~ForceFeedback()
+{
+	// delete the uploaded effect, so we don't leak it.
+	if (m_id != -1)
 	{
-		ioctl(m_id, EVIOCRMFF, m_id);
+		ioctl(m_fd, EVIOCRMFF, m_id);
 	}
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
@@ -52,6 +52,7 @@ private:
 	public:
 		std::string GetName() const override;
 		ForceFeedback(u16 type, libevdev* dev) : m_type(type), m_dev(dev), m_id(-1) { m_fd = libevdev_get_fd(dev); }
+		~ForceFeedback();
 		void SetState(ControlState state) override;
 	private:
 		const u16 m_type;


### PR DESCRIPTION
Was using m_id insted of m_fd.
Also re-arrange the code so rumble effects always get deleted instead of just on stop commands.

This fixes a bug where rumble stops working after 16 effects are played.