### PR TITLE
DSPInterpreter: Remove an unused typedef

### DIFF
--- a/Source/Core/Core/DSP/DSPInterpreter.h
+++ b/Source/Core/Core/DSP/DSPInterpreter.h
@@ -25,9 +25,6 @@ int RunCyclesDebug(int cycles);
 void WriteCR(u16 val);
 u16  ReadCR();
 
-
-typedef void (*DSPInterpreterFunc)(const UDSPInstruction opc);
-
 // All the opcode functions.
 void call(const UDSPInstruction opc);
 void callr(const UDSPInstruction opc);


### PR DESCRIPTION
DSPTables already has an equivalent of this, which it uses.