### PR TITLE
WbfsBlob: Don't enter an infinite loop when reading beyond end of disc

### DIFF
--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -115,8 +115,10 @@ bool WbfsFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 {
 	while (nbytes)
 	{
-		u64 read_size = 0;
+		u64 read_size;
 		File::IOFile& data_file = SeekToCluster(offset, &read_size);
+		if (read_size == 0)
+			return false;
 		read_size = (read_size > nbytes) ? nbytes : read_size;
 
 		if (!data_file.ReadBytes(out_ptr, read_size))
@@ -160,6 +162,8 @@ File::IOFile& WbfsFileReader::SeekToCluster(u64 offset, u64* available)
 	}
 
 	PanicAlert("Read beyond end of disc");
+	if (available)
+		*available = 0;
 	m_files[0]->file.Seek(0, SEEK_SET);
 	return m_files[0]->file;
 }


### PR DESCRIPTION
`read_size` remained 0 when the "Read beyond end of disc" error occurs, which made the while (nbytes) loop never end. As a fix, `SeekToCluster` now explicitly sets available to 0 when the error occurs, and `Read` checks for it.