### PR TITLE
PPCAnalyst: Don't swap instruction which might cause interrupts.

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -250,6 +250,10 @@ static bool CanSwapAdjacentOps(const CodeOp &a, const CodeOp &b)
 	if (b_info->type != OPTYPE_INTEGER)
 		return false;
 
+	// And it's possible a might raise an interrupt too (fcmpo/fcmpu)
+	if (a_info->type != OPTYPE_INTEGER)
+		return false;
+
 	// Check that we have no register collisions.
 	// That is, check that none of b's outputs matches any of a's inputs,
 	// and that none of a's outputs matches any of b's inputs.


### PR DESCRIPTION
fcmpo and fcmpu can be matched by the REORDER_CMP pass, as they set CR0 and they can cause interrupts if the fpu is disabled.
So we add an extra check to make sure op a is an integer op too.

This fixes a very intermittent crash in Sonic Unleashed that took @JMC47 two solid days to track down. It probably also fixes various other intermittent crashes in other games. 