### PR TITLE
Interpreter: Fix bug with icache emulation.

### DIFF
--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -71,8 +71,6 @@ namespace PowerPC
 	{
 		memset(data, 0, sizeof(data));
 		memset(tags, 0, sizeof(tags));
-		memset(way_from_valid, 0, sizeof(way_from_valid));
-		memset(way_from_plru, 0, sizeof(way_from_plru));
 
 		Reset();
 	}


### PR DESCRIPTION
The constructor sets up way_from_valid and way_from_plur as fast lookup tables for implementing the PLRU algorithm. Then the Init function memsets them to zero, meaning the instruction cache will now always choose the first way in each set.

This degrades the cache from 128 sets, 8 way to 128 sets, 1 way.

Not only does fixing this bug increase accuracy, but it increases performance too, giving a 1% speedup to interpreter.