### PR TITLE
Don't busy wait in the audio thread (ALSA)

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.cpp
+++ b/Source/Core/AudioCommon/AlsaSoundStream.cpp
@@ -26,6 +26,12 @@ AlsaSound::~AlsaSound()
 bool AlsaSound::Start()
 {
 	m_thread_status.store(ALSAThreadStatus::RUNNING);
+	if (!AlsaInit())
+	{
+		m_thread_status.store(ALSAThreadStatus::STOPPED);
+		return false;
+	}
+
 	thread = std::thread(&AlsaSound::SoundLoop, this);
 	return true;
 }
@@ -44,10 +50,6 @@ void AlsaSound::Update()
 // Called on audio thread.
 void AlsaSound::SoundLoop()
 {
-	if (!AlsaInit()) {
-		m_thread_status.store(ALSAThreadStatus::STOPPED);
-		return;
-	}
 	Common::SetCurrentThreadName("Audio thread - alsa");
 	while (m_thread_status.load() == ALSAThreadStatus::RUNNING)
 	{

--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 
 #if defined(HAVE_ALSA) && HAVE_ALSA
@@ -25,6 +27,7 @@ public:
 	void SoundLoop() override;
 	void Stop() override;
 	void Update() override;
+	void Clear(bool) override;
 
 	static bool isValid()
 	{
@@ -45,6 +48,8 @@ private:
 	u8 *mix_buffer;
 	std::thread thread;
 	std::atomic<ALSAThreadStatus> m_thread_status;
+	std::condition_variable cv;
+	std::mutex cv_m;
 
 	snd_pcm_t *handle;
 	int frames_to_deliver;


### PR DESCRIPTION
When the emulation is paused and the ALSA backend is used, make the audio
thread wait on a condition variable instead of busy-waiting. This commit
fixes bug #7729