### PR TITLE
Disables assert messages that seem to be invalid.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -241,7 +241,8 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 		switch (texinfo.sourcerow)
 		{
 		case XF_SRCGEOM_INROW:
-			_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
+			// The following assert was triggered in Super Smash Bros. Project M 3.6.
+			//_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
 			out.Write("coord = rawpos;\n"); // pos.w is 1
 			break;
 		case XF_SRCNORMAL_INROW:
@@ -291,7 +292,8 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 				}
 				else
 				{
-					_assert_(0); // should have normals
+					// The following assert was triggered in House of the Dead Overkill and Star Wars Rogue Squadron 2
+					//_assert_(0); // should have normals
 					uid_data->texMtxInfo[i].embosssourceshift = xfmem.texMtxInfo[i].embosssourceshift;
 					out.Write("o.tex%d.xyz = o.tex%d.xyz;\n", i, texinfo.embosssourceshift);
 				}


### PR DESCRIPTION
Since no one else wants to do it, I went through the games I had and disabled the offending assert messages that are popping up.  @degasus said at least one of them were a valid state for things to be in, so I figured the other ones probably were as well.  I did not remove the Panic Alerts, and added a comment to each one so future developers looking into things could find a title that creates a situation where it would have been hit.