### PR TITLE
IniFile: Fix floating point number locale issues.

### DIFF
--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -47,12 +47,12 @@ public:
 
 		void Set(const std::string& key, float newValue)
 		{
-			Set(key, StringFromFormat("%f", newValue));
+			Set(key, StringFromFormat("%#.9g", newValue));
 		}
 
 		void Set(const std::string& key, double newValue)
 		{
-			Set(key, StringFromFormat("%f", newValue));
+			Set(key, StringFromFormat("%#.17g", newValue));
 		}
 
 		void Set(const std::string& key, int newValue)

--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -80,10 +80,10 @@ bool CharArrayFromFormatV(char* out, int outsize, const char* format, va_list ar
 	// multibyte handling is required as we can simply assume that no '%' char
 	// will be present in the middle of a multibyte sequence.
 	//
-	// This is why we lookup an ANSI (cp1252) locale here and use _vsnprintf_l.
+	// This is why we look up the default C locale here and use _vsnprintf_l.
 	static _locale_t c_locale = nullptr;
 	if (!c_locale)
-		c_locale = _create_locale(LC_ALL, ".1252");
+		c_locale = _create_locale(LC_ALL, "C");
 	writtenCount = _vsnprintf_l(out, outsize, format, c_locale, args);
 #else
 	#if !defined(ANDROID)


### PR DESCRIPTION
Trying to fix [issue 8095](https://code.google.com/p/dolphin-emu/issues/detail?id=8095). This prints a `.` for me on Windows with a German/Austria locale when it was printing a `,` before but I don't know if it works for all locales and OSes. Submitting this as a PR so I can easily hand out a test build on the issue tracker.