### PR TITLE
Removed 2.5x IR option in VideoConfigDiag

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -348,17 +348,17 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	// Internal resolution
 	{
 	const wxString efbscale_choices[] = { _("Auto (Window Size)"), _("Auto (Multiple of 640x528)"),
-		_("Native (640x528)"), _("1.5x Native (960x792)"), _("2x Native (1280x1056) for 720p"), _("2.5x Native (1600x1320)"),
+		_("Native (640x528)"), _("1.5x Native (960x792)"), _("2x Native (1280x1056) for 720p"),
 		_("3x Native (1920x1584) for 1080p"), _("4x Native (2560x2112) for 1440p"), _("5x Native (3200x2640)"),
 		_("6x Native (3840x3168) for 4K"), _("7x Native (4480x3696)"), _("8x Native (5120x4224) for 5K"), _("Custom") };
 
 	wxChoice *const choice_efbscale = CreateChoice(page_enh,
-		vconfig.iEFBScale, wxGetTranslation(internal_res_desc), (vconfig.iEFBScale > 11) ?
+		vconfig.iEFBScale, wxGetTranslation(internal_res_desc), (vconfig.iEFBScale > 10) ?
 		ArraySize(efbscale_choices) : ArraySize(efbscale_choices) - 1, efbscale_choices);
 
 
-	if (vconfig.iEFBScale > 11)
-		choice_efbscale->SetSelection(12);
+	if (vconfig.iEFBScale > 10)
+		choice_efbscale->SetSelection(11);
 
 	szr_enh->Add(new wxStaticText(page_enh, wxID_ANY, _("Internal Resolution:")), 1, wxALIGN_CENTER_VERTICAL, 0);
 	szr_enh->Add(choice_efbscale);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -209,13 +209,8 @@ bool Renderer::CalculateTargetSize(unsigned int framebuffer_width, unsigned int 
 			efb_scale_denominatorX = efb_scale_denominatorY = 1;
 			break;
 
-		case SCALE_2_5X:
-			efb_scale_numeratorX = efb_scale_numeratorY = 5;
-			efb_scale_denominatorX = efb_scale_denominatorY = 2;
-			break;
-
 		default:
-			efb_scale_numeratorX = efb_scale_numeratorY = s_last_efb_scale - 3;
+			efb_scale_numeratorX = efb_scale_numeratorY = s_last_efb_scale - 2;
 			efb_scale_denominatorX = efb_scale_denominatorY = 1;
 
 
@@ -346,11 +341,8 @@ void Renderer::DrawDebugText()
 		case SCALE_2X:
 			res_text = "2x";
 			break;
-		case SCALE_2_5X:
-			res_text = "2.5x";
-			break;
 		default:
-			res_text = StringFromFormat("%dx", g_ActiveConfig.iEFBScale - 3);
+			res_text = StringFromFormat("%dx", g_ActiveConfig.iEFBScale - 2);
 			break;
 		}
 		const char* ar_text = "";


### PR DESCRIPTION
So, in reference to https://code.google.com/p/dolphin-emu/issues/detail?id=8747

There is a bit of a debate on keeping half-step IR options in the GUI. MaJoR1 says half step IRs can break games, and AFAIK the only reason we keep those half steps in the GUI is for Intel iGPU users. I'm sure Intel users will fight to the death to keep 1.5x, which is why I didn't remove it, but I feel that 2.5x can be safely removed. AFAIK, Any obscure IR can be set in GameINI so if the user wants to break their games, they still have that.

Thoughts?