### PR TITLE
Display Savestate information in Overlay and Menu.

### DIFF
--- a/Source/Core/Common/Timer.cpp
+++ b/Source/Core/Common/Timer.cpp
@@ -225,7 +225,6 @@ std::string Timer::GetTimeFormatted()
 }
 
 // Returns a timestamp with decimals for precise time comparisons
-// ----------------
 double Timer::GetDoubleTime()
 {
 #ifdef _WIN32
@@ -245,7 +244,7 @@ double Timer::GetDoubleTime()
 	// sure that we are detecting actual actions, perhaps 60 seconds is
 	// enough really, but I leave a year of seconds anyway, in case the
 	// user's clock is incorrect or something like that.
-	TmpSeconds = TmpSeconds - (38 * 365 * 24 * 60 * 60);
+	TmpSeconds = TmpSeconds - DOUBLE_TIME_OFFSET;
 
 	// Make a smaller integer that fits in the double
 	u32 Seconds = (u32)TmpSeconds;
@@ -259,6 +258,18 @@ double Timer::GetDoubleTime()
 	double TmpTime = Seconds + ms;
 
 	return TmpTime;
+}
+
+// Formats a timestamp from GetDoubleTime() into a date and time string
+std::string Timer::GetDateTimeFormatted(double time)
+{
+	// revert adjustments from GetDoubleTime() to get a normal Unix timestamp again
+	time_t seconds = (time_t)time + DOUBLE_TIME_OFFSET;
+	tm* localTime = localtime(&seconds);
+
+	char tmp[32] = {};
+	strftime(tmp, sizeof(tmp), "%x %X", localTime);
+	return tmp;
 }
 
 } // Namespace Common

--- a/Source/Core/Common/Timer.h
+++ b/Source/Core/Common/Timer.h
@@ -26,14 +26,21 @@ public:
 	static void RestoreResolution();
 	static u64 GetTimeSinceJan1970();
 	static u64 GetLocalTimeSinceJan1970();
+	// Returns a timestamp with decimals for precise time comparisons
 	static double GetDoubleTime();
 
 	static std::string GetTimeFormatted();
+	// Formats a timestamp from GetDoubleTime() into a date and time string
+	static std::string GetDateTimeFormatted(double time);
 	std::string GetTimeElapsedFormatted() const;
 	u64 GetTimeElapsed();
 
 	static u32 GetTimeMs();
 	static u64 GetTimeUs();
+
+	// Arbitrarily chosen value (38 years) that is subtracted in GetDoubleTime()
+	// to increase sub-second precision of the resulting double timestamp
+	static const int DOUBLE_TIME_OFFSET = (38 * 365 * 24 * 60 * 60);
 
 private:
 	u64 m_LastTime;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -435,6 +435,19 @@ bool ReadHeader(const std::string& filename, StateHeader& header)
 	return true;
 }
 
+std::string GetInfoStringOfSlot(int slot)
+{
+	std::string filename = MakeStateFilename(slot);
+	if (!File::Exists(filename))
+		return "Empty";
+
+	State::StateHeader header;
+	if (!ReadHeader(filename, header))
+		return "Unknown";
+
+	return Common::Timer::GetDateTimeFormatted(header.time);
+}
+
 static void LoadFileStateData(const std::string& filename, std::vector<u8>& ret_data)
 {
 	Flush();

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -17,6 +17,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
+#include "Core/Host.h"
 #include "Core/Movie.h"
 #include "Core/State.h"
 #include "Core/HW/CPU.h"
@@ -373,6 +374,7 @@ static void CompressAndDumpState(CompressAndDumpState_args save_args)
 	}
 
 	Core::DisplayMessage(StringFromFormat("Saved State to %s", filename.c_str()), 2000);
+	Host_UpdateMainFrame();
 }
 
 void SaveAs(const std::string& filename, bool wait)

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -119,7 +119,8 @@ void EnableCompression(bool compression)
 	g_use_compression = compression;
 }
 
-static std::string DoState(PointerWrap& p)
+// Returns true if state version matches current Dolphin state version, false otherwise.
+static bool DoStateVersion(PointerWrap& p, std::string* version_created_by)
 {
 	u32 version = STATE_VERSION;
 	{
@@ -129,15 +130,15 @@ static std::string DoState(PointerWrap& p)
 		version = cookie - COOKIE_BASE;
 	}
 
-	std::string version_created_by = scm_rev_str;
+	*version_created_by = scm_rev_str;
 	if (version > 42)
-		p.Do(version_created_by);
+		p.Do(*version_created_by);
 	else
-		version_created_by.clear();
+		version_created_by->clear();
 
 	if (version != STATE_VERSION)
 	{
-		if (version_created_by.empty() && s_old_versions.count(version))
+		if (version_created_by->empty() && s_old_versions.count(version))
 		{
 			// The savestate is from an old version that doesn't
 			// save the Dolphin version number to savestates, but
@@ -148,17 +149,27 @@ static std::string DoState(PointerWrap& p)
 			std::string oldest_version = version_range.first;
 			std::string newest_version = version_range.second;
 
-			version_created_by = "Dolphin " + oldest_version + " - " + newest_version;
+			*version_created_by = "Dolphin " + oldest_version + " - " + newest_version;
 		}
 
+		return false;
+	}
+
+	p.DoMarker("Version");
+	return true;
+}
+
+static std::string DoState(PointerWrap& p)
+{
+	std::string version_created_by;
+	if (!DoStateVersion(p, &version_created_by))
+	{
 		// because the version doesn't match, fail.
 		// this will trigger an OSD message like "Can't load state from other revisions"
 		// we could use the version numbers to maintain some level of backward compatibility, but currently don't.
 		p.SetMode(PointerWrap::MODE_MEASURE);
 		return version_created_by;
 	}
-
-	p.DoMarker("Version");
 
 	// Begin with video backend, so that it gets a chance to clear its caches and writeback modified things to RAM
 	g_video_backend->DoState(p);

--- a/Source/Core/Core/State.h
+++ b/Source/Core/Core/State.h
@@ -33,6 +33,10 @@ void EnableCompression(bool compression);
 
 bool ReadHeader(const std::string& filename, StateHeader& header);
 
+// Returns a string containing information of the savestate in the given slot
+// which can be presented to the user for identification purposes
+std::string GetInfoStringOfSlot(int slot);
+
 // These don't happen instantly - they get scheduled as events.
 // ...But only if we're not in the main CPU thread.
 //    If we're in the main CPU thread then they run immediately instead

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1680,7 +1680,7 @@ void CFrame::OnFrameSkip(wxCommandEvent& event)
 void CFrame::OnSelectSlot(wxCommandEvent& event)
 {
 	g_saveSlot = event.GetId() - IDM_SELECT_SLOT_1 + 1;
-	Core::DisplayMessage(StringFromFormat("Selected slot %d", g_saveSlot), 1000);
+	Core::DisplayMessage(StringFromFormat("Selected slot %d - %s", g_saveSlot, State::GetInfoStringOfSlot(g_saveSlot).c_str()), 2500);
 }
 
 void CFrame::OnLoadCurrentSlot(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -462,8 +462,8 @@ wxString CFrame::GetMenuLabel(int Id)
 		case HK_LOAD_STATE_SLOT_8:
 		case HK_LOAD_STATE_SLOT_9:
 		case HK_LOAD_STATE_SLOT_10:
-			Label = wxString::Format(_("Slot %i"),
-					Id - HK_LOAD_STATE_SLOT_1 + 1);
+			Label = wxString::Format(_("Slot %i - %s"),
+			        Id - HK_LOAD_STATE_SLOT_1 + 1, State::GetInfoStringOfSlot(Id - HK_LOAD_STATE_SLOT_1 + 1).c_str());
 			break;
 
 		case HK_SAVE_STATE_SLOT_1:
@@ -476,8 +476,8 @@ wxString CFrame::GetMenuLabel(int Id)
 		case HK_SAVE_STATE_SLOT_8:
 		case HK_SAVE_STATE_SLOT_9:
 		case HK_SAVE_STATE_SLOT_10:
-			Label = wxString::Format(_("Slot %i"),
-					Id - HK_SAVE_STATE_SLOT_1 + 1);
+			Label = wxString::Format(_("Slot %i - %s"),
+			        Id - HK_SAVE_STATE_SLOT_1 + 1, State::GetInfoStringOfSlot(Id - HK_SAVE_STATE_SLOT_1 + 1).c_str());
 			break;
 		case HK_SAVE_STATE_FILE:
 			Label = _("Save State...");
@@ -522,7 +522,8 @@ wxString CFrame::GetMenuLabel(int Id)
 		case HK_SELECT_STATE_SLOT_8:
 		case HK_SELECT_STATE_SLOT_9:
 		case HK_SELECT_STATE_SLOT_10:
-			Label = wxString::Format(_("Select Slot %i"), Id - HK_SELECT_STATE_SLOT_1 + 1);
+			Label = wxString::Format(_("Select Slot %i - %s"),
+			        Id - HK_SELECT_STATE_SLOT_1 + 1, State::GetInfoStringOfSlot(Id - HK_SELECT_STATE_SLOT_1 + 1).c_str());
 			break;
 
 


### PR DESCRIPTION
Implements [issue 8234](https://code.google.com/p/dolphin-emu/issues/detail?id=8234).

This shows information about savestate slots so you know if a slot is used or not, and when the savestate was made, without having to actually select and load the state.

This shows up in the Overlay when selecting a slot next to the previously existing "Selected slot %i" message:

[![Overlay Filled Slot](http://i.imgur.com/cZPRdqX.png)](http://i.imgur.com/cZPRdqX.png)
[![Overlay Empty Slot](http://i.imgur.com/x0CWaT4.png)](http://i.imgur.com/x0CWaT4.png)

And also next to each Load State and Save State option in the menu:

[![Save Menu](http://i.imgur.com/TbZ5dJH.png)](http://i.imgur.com/TbZ5dJH.png)
[![Load Menu](http://i.imgur.com/dElIbXn.png)](http://i.imgur.com/dElIbXn.png)