### PR TITLE
GCAdapter: Disable the scanning thread when direct connect is disabled

### DIFF
--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -146,6 +146,7 @@ void Init()
 	if (ret)
 	{
 		ERROR_LOG(SERIALINTERFACE, "libusb_init failed with error: %d", ret);
+		s_libusb_driver_not_supported = true;
 		Shutdown();
 	}
 	else

--- a/Source/Core/Core/HW/SI_GCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_GCAdapter.cpp
@@ -151,7 +151,8 @@ void Init()
 	}
 	else
 	{
-		StartScanThread();
+		if (SConfig::GetInstance().m_GameCubeAdapter)
+			StartScanThread();
 	}
 }
 

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -174,6 +174,7 @@ wxStaticBoxSizer* ControllerConfigDiag::CreateGamecubeSizer()
 			m_adapter_status->SetLabelText(_("Driver Not Detected"));
 			gamecube_adapter->Disable();
 			gamecube_adapter->SetValue(false);
+			gamecube_rumble->Disable();
 		}
 	}
 	else

--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -73,6 +73,10 @@ private:
 	void OnGameCubeAdapter(wxCommandEvent& event)
 	{
 		SConfig::GetInstance().m_GameCubeAdapter = event.IsChecked();
+		if (event.IsChecked())
+			SI_GCAdapter::StartScanThread();
+		else
+			SI_GCAdapter::StopScanThread();
 		event.Skip();
 	}
 	void OnAdapterRumble(wxCommandEvent& event)


### PR DESCRIPTION
The goal of this commit is to let people who experience driver issues
with libusb and windows disable the scanning thread (to avoid mouse
issues, keyboard issues, and audio issues).

Also disable the rumble setting when the adapter driver is not detected,
and don’t do anything if libusb can’t init for some reason.