### PR TITLE
Display a message on screen when the emulated software disconnects a Wiimote.

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -1308,6 +1308,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305::CommandDisconnect(u8* _Input)
 	DEBUG_LOG(WII_IPC_WIIMOTE, "  Reason: 0x%02x", pDiscon->reason);
 
 	Host_SetWiiMoteConnectionState(0);
+	DisplayDisconnectMessage((pDiscon->con_handle & 0xFF) + 1, pDiscon->reason);
 
 	SendEventCommandStatus(HCI_CMD_DISCONNECT);
 	SendEventDisconnect(pDiscon->con_handle, pDiscon->reason);
@@ -1875,6 +1876,13 @@ CWII_IPC_HLE_WiiMote* CWII_IPC_HLE_Device_usb_oh1_57e_305::AccessWiiMote(u16 _Co
 	ERROR_LOG(WII_IPC_WIIMOTE, "Can't find Wiimote by connection handle %02x", _ConnectionHandle);
 	PanicAlertT("Can't find Wiimote by connection handle %02x", _ConnectionHandle);
 	return nullptr;
+}
+
+void CWII_IPC_HLE_Device_usb_oh1_57e_305::DisplayDisconnectMessage(const int wiimoteNumber, const int reason)
+{
+	// TODO: If someone wants to be fancy we could also figure out what the values for pDiscon->reason mean
+	// and display things like "Wiimote %i disconnected due to inactivity!" etc.
+	Core::DisplayMessage(StringFromFormat(_trans("Wiimote %i disconnected by emulated software"), wiimoteNumber), 3000);
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305::LOG_LinkKey(const u8* _pLinkKey)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
@@ -267,6 +267,8 @@ private:
 	void CommandVendorSpecific_FC4C(u8* _Input, u32 _Size);
 	void CommandVendorSpecific_FC4F(u8* _Input, u32 _Size);
 
+	static void DisplayDisconnectMessage(const int wiimoteNumber, const int reason);
+
 	// Debugging
 	void LOG_LinkKey(const u8* _pLinkKey);
 


### PR DESCRIPTION
At the moment, Wiimotes getting disconnected by the game for whatever reason (5 minutes inactivity, game intentionally doesn't support more than X players, etc.) can be quite confusing to the user, since it happens near-silently. (The status bar in the main Dolphin GUI window changes to "Not connected" but who ever looks at that?) With #2724, the inactivity issue is probably no longer a problem, but the game intentionally disconnecting a 2nd/3rd/4th Wiimote may become even more confusing if you can keep reconnecting a Wiimote without ever getting a message about it getting disconnected.

This displays a "Wiimote %i disconnected by emulated software!" OSD message when the Wii disconnects a Wiimote to prevent such confusion.

If we want to be fancy we could also try figuring out what the values for `pDiscon->reason` mean to display more descriptive messages.