### PR TITLE
DolphinWX: Fix build if libusb is disabled

### DIFF
--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -73,10 +73,12 @@ private:
 	void OnGameCubeAdapter(wxCommandEvent& event)
 	{
 		SConfig::GetInstance().m_GameCubeAdapter = event.IsChecked();
+#ifdef __LIBUSB__
 		if (event.IsChecked())
 			SI_GCAdapter::StartScanThread();
 		else
 			SI_GCAdapter::StopScanThread();
+#endif
 		event.Skip();
 	}
 	void OnAdapterRumble(wxCommandEvent& event)


### PR DESCRIPTION
Fixes fallout from #2744 where there would be undefined symbols in the non-libusb build, due to SI_GCAdapter.cpp only being built when libusb is found.