### PR TITLE
GameINI: fix Need for Speed: Hot Pursuit 2

### DIFF
--- a/Data/Sys/GameSettings/GH2.ini
+++ b/Data/Sys/GameSettings/GH2.ini
@@ -2,11 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+SyncOnSkipIdle = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationStateId = 3
-EmulationIssues = The game is slow.
+EmulationStateId = 4
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
It's super slow with `SyncOnSkipIdle = True`.