### PR TITLE
JitWindow: Use TitleCase for the JIT block viewer tab

### DIFF
--- a/Source/Core/DolphinWX/Debugger/JitWindow.h
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.h
@@ -35,7 +35,7 @@ public:
 		const wxPoint& pos = wxDefaultPosition,
 		const wxSize& size = wxDefaultSize,
 		long style = wxTAB_TRAVERSAL | wxBORDER_NONE,
-		const wxString& name = _("JIT block viewer"));
+		const wxString& name = _("JIT Block Viewer"));
 
 	void ViewAddr(u32 em_address);
 	void Update() override;


### PR DESCRIPTION
Makes the title consistent with all other debugger tabs.