### PR TITLE
CFrame: Claim all keyboard events on OS X.

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1068,6 +1068,20 @@ bool TASInputHasFocus()
 	return false;
 }
 
+void CFrame::OnKeyDown(wxKeyEvent& event)
+{
+	// On OS X, we claim all keyboard events while
+	// emulation is running to avoid wxWidgets sounding
+	// the system beep for unhandled key events when
+	// receiving pad/Wiimote keypresses which take an
+	// entirely different path through the HID subsystem.
+#ifndef __APPLE__
+	// On other platforms, we leave the key event alone
+	// so it can be passed on to the windowing system.
+	event.Skip();
+#endif
+}
+
 void CFrame::OnMouse(wxMouseEvent& event)
 {
 	// next handlers are all for FreeLook, so we don't need to check them if disabled

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -320,8 +320,6 @@ private:
 	void OnToggleWindow(wxCommandEvent& event);
 
 	void OnKeyDown(wxKeyEvent& event); // Keyboard
-	void OnKeyUp(wxKeyEvent& event);
-
 	void OnMouse(wxMouseEvent& event); // Mouse
 
 	void OnFocusChange(wxFocusEvent& event);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1046,6 +1046,7 @@ void CFrame::StartGame(const std::string& filename)
 
 		m_RenderParent->SetFocus();
 
+		wxTheApp->Bind(wxEVT_KEY_DOWN,     &CFrame::OnKeyDown,     this);
 		wxTheApp->Bind(wxEVT_RIGHT_DOWN,   &CFrame::OnMouse,       this);
 		wxTheApp->Bind(wxEVT_RIGHT_UP,     &CFrame::OnMouse,       this);
 		wxTheApp->Bind(wxEVT_MIDDLE_DOWN,  &CFrame::OnMouse,       this);


### PR DESCRIPTION
These lines were removed by PR #2518.

Attempt to fix [issue 8765](https://code.google.com/p/dolphin-emu/issues/detail?id=8765).