### PR TITLE
Change "Installation' headers to say 'Building' in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
     * A reasonably modern graphics card (Direct3D 10.0 / OpenGL 3.0).
     * A graphics card that supports Direct3D 11 / OpenGL 4.4 is recommended.
 
-## Installation on Windows
+## Building for Windows
 Use the solution file `Source/dolphin-emu.sln` to build Dolphin on Windows.
 Visual Studio 2013 is a hard requirement since previous versions don't support
 many C++ features that we use. Other compilers might be able to build Dolphin
@@ -33,7 +33,7 @@ Nullsoft Scriptable Install System (NSIS) to be installed. Creating an
 installer is not necessary to run Dolphin since the Build directory contains
 a working Dolphin distribution.
 
-## Installation on Linux and OS X
+## Building for Linux and OS X
 Dolphin requires [CMake](http://www.cmake.org/) for systems other than Windows. Many libraries are
 bundled with Dolphin and used if they're not installed on your system. CMake
 will inform you if a bundled library is used or if you need to install any
@@ -49,7 +49,7 @@ On OS X, an application bundle will be created in `./Binaries`.
 
 On Linux, it's strongly recommended to perform a global installation via `sudo make install`.
 
-## Installation on Android
+## Building for Android
 
 These instructions assume familiarity with Android development. If you do not have an
 Android dev environment set up, see [AndroidSetup.md](AndroidSetup.md).


### PR DESCRIPTION
The instructions under those headers are about 90% for building the application, and the rest about installation; this language should more accurately indicate that.