### PR TITLE
Fix an oversight in GLExtensions

### DIFF
--- a/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
@@ -1984,7 +1984,7 @@ namespace GLExtensions
 		while (buffer >> tmp)
 		{
 			if (tmp[0] == '!')
-				result &= !m_extension_list[tmp.erase(0)];
+				result &= !m_extension_list[tmp.erase(0, 1)];
 			else
 				result &= m_extension_list[tmp];
 		}


### PR DESCRIPTION
I only wanted to erase the first character in the string, not the entire thing.
Fixes Qualcomm and PowerVR devices crashing out immediately.