### PR TITLE
CFrame: Ignore "Pause on Focus Lost" when not started.

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1141,7 +1141,7 @@ void CFrame::OnMouse(wxMouseEvent& event)
 
 void CFrame::OnFocusChange(wxFocusEvent& event)
 {
-	if (SConfig::GetInstance().m_PauseOnFocusLost)
+	if (SConfig::GetInstance().m_PauseOnFocusLost && Core::IsRunningAndStarted())
 	{
 		if (RendererHasFocus())
 		{


### PR DESCRIPTION
Fixes [issue 8739](https://code.google.com/p/dolphin-emu/issues/detail?id=8739).