### PR TITLE
Wiimote: Extend emulated Wiimote reconnect-on-button-press to attachments.

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
@@ -50,3 +50,15 @@ void ControllerEmu::Extension::GetState(u8* const data)
 {
 	((WiimoteEmu::Attachment*)attachments[active_extension].get())->GetState(data);
 }
+
+bool ControllerEmu::Extension::IsButtonPressed() const
+{
+	// Extension == 0 means no Extension, > 0 means one is connected
+	// Since we want to use this to know if disconnected Wiimotes want to be connected, and disconnected
+	// Wiimotes (can? always?) have their active_extension set to -1, we also have to check the switch_extension
+	if (active_extension > 0)
+		return ((WiimoteEmu::Attachment*)attachments[active_extension].get())->IsButtonPressed();
+	if (switch_extension > 0)
+		return ((WiimoteEmu::Attachment*)attachments[switch_extension].get())->IsButtonPressed();
+	return false;
+}

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.h
@@ -17,6 +17,7 @@ public:
 	Attachment(const char* const _name, WiimoteEmu::ExtensionReg& _reg);
 
 	virtual void GetState(u8* const data) {}
+	virtual bool IsButtonPressed() const { return false; }
 	void Reset();
 	std::string GetName() const override;
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -135,5 +135,14 @@ void Classic::GetState(u8* const data)
 	ccdata->bt.hex ^= 0xFFFF;
 }
 
+bool Classic::IsButtonPressed() const
+{
+	u16 buttons = 0;
+	ControlState trigs[2] = { 0, 0 };
+	m_buttons->GetState(&buttons, classic_button_bitmasks);
+	m_dpad->GetState(&buttons, classic_dpad_bitmasks);
+	m_triggers->GetState(&buttons, classic_trigger_bitmasks, trigs);
+	return buttons != 0;
+}
 
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.h
@@ -16,6 +16,7 @@ class Classic : public Attachment
 public:
 	Classic(WiimoteEmu::ExtensionReg& _reg);
 	void GetState(u8* const data) override;
+	bool IsButtonPressed() const override;
 
 	enum
 	{

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -81,4 +81,12 @@ void Drums::GetState(u8* const data)
 	ddata->bt ^= 0xFFFF;
 }
 
+bool Drums::IsButtonPressed() const
+{
+	u16 buttons = 0;
+	m_buttons->GetState(&buttons, drum_button_bitmasks);
+	m_pads->GetState(&buttons, drum_pad_bitmasks);
+	return buttons != 0;
+}
+
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.h
@@ -16,6 +16,7 @@ class Drums : public Attachment
 public:
 	Drums(WiimoteEmu::ExtensionReg& _reg);
 	void GetState(u8* const data) override;
+	bool IsButtonPressed() const override;
 
 	enum
 	{

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -100,4 +100,13 @@ void Guitar::GetState(u8* const data)
 	gdata->bt ^= 0xFFFF;
 }
 
+bool Guitar::IsButtonPressed() const
+{
+	u16 buttons = 0;
+	m_buttons->GetState(&buttons, guitar_button_bitmasks);
+	m_frets->GetState(&buttons, guitar_fret_bitmasks);
+	m_strum->GetState(&buttons, guitar_strum_bitmasks);
+	return buttons != 0;
+}
+
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.h
@@ -16,6 +16,7 @@ class Guitar : public Attachment
 public:
 	Guitar(WiimoteEmu::ExtensionReg& _reg);
 	void GetState(u8* const data) override;
+	bool IsButtonPressed() const override;
 
 	enum
 	{

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -106,6 +106,13 @@ void Nunchuk::GetState(u8* const data)
 	ncdata->bt.acc_z_lsb = accel_z & 0x3;
 }
 
+bool Nunchuk::IsButtonPressed() const
+{
+	u8 buttons = 0;
+	m_buttons->GetState(&buttons, nunchuk_button_bitmasks);
+	return buttons != 0;
+}
+
 void Nunchuk::LoadDefaults(const ControllerInterface& ciface)
 {
 	// ugly macroooo

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.h
@@ -17,6 +17,7 @@ public:
 	Nunchuk(WiimoteEmu::ExtensionReg& _reg);
 
 	void GetState(u8* const data) override;
+	bool IsButtonPressed() const override;
 
 	enum
 	{

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -127,5 +127,11 @@ void Turntable::GetState(u8* const data)
 		);
 }
 
+bool Turntable::IsButtonPressed() const
+{
+	u16 buttons = 0;
+	m_buttons->GetState(&buttons, turntable_button_bitmasks);
+	return buttons != 0;
+}
 
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.h
@@ -16,6 +16,7 @@ class Turntable : public Attachment
 public:
 	Turntable(WiimoteEmu::ExtensionReg& _reg);
 	void GetState(u8* const data) override;
+	bool IsButtonPressed() const override;
 
 	enum
 	{

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -881,7 +881,7 @@ void Wiimote::ConnectOnInput()
 	m_buttons->GetState(&buttons, button_bitmasks);
 	m_dpad->GetState(&buttons, dpad_bitmasks);
 
-	if (buttons != 0)
+	if (buttons != 0 || m_extension->IsButtonPressed())
 	{
 		Host_ConnectWiimote(m_index, true);
 		// arbitrary value so it doesn't try to send multiple requests before Dolphin can react

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -424,6 +424,7 @@ public:
 		~Extension() {}
 
 		void GetState(u8* const data);
+		bool IsButtonPressed() const;
 
 		std::vector<std::unique_ptr<ControllerEmu>> attachments;
 


### PR DESCRIPTION
This extends the functionality of #2724 to work with emulated Wiimote attachments/extensions. See the linked PR for more information.