### PR TITLE
DriverDetails: Disable GL_ARB_copy_image on mesa.

### DIFF
--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -84,7 +84,6 @@ void InitBackendInfo()
 	g_Config.backend_info.bSupportsPostProcessing = false;
 	g_Config.backend_info.bSupportsPaletteConversion = true;
 	g_Config.backend_info.bSupportsClipControl = true;
-	g_Config.backend_info.bSupportsCopySubImage = true;
 
 	IDXGIFactory* factory;
 	IDXGIAdapter* ad;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -303,7 +303,7 @@ static void InitDriverInfo()
 			int major = 0;
 			int minor = 0;
 			int release = 0;
-			sscanf(g_ogl_config.gl_version, "%*s Mesa %d.%d.%d", &major, &minor, &release);
+			sscanf(g_ogl_config.gl_version, "%*s (Core Profile) Mesa %d.%d.%d", &major, &minor, &release);
 			version = 100*major + 10*minor + release;
 		}
 		break;
@@ -469,10 +469,11 @@ Renderer::Renderer()
 	g_Config.backend_info.bSupportsGeometryShaders = GLExtensions::Version() >= 320;
 	g_Config.backend_info.bSupportsPaletteConversion = GLExtensions::Supports("GL_ARB_texture_buffer_object");
 	g_Config.backend_info.bSupportsClipControl = GLExtensions::Supports("GL_ARB_clip_control");
-	g_ogl_config.bSupportsCopySubImage = GLExtensions::Supports("GL_ARB_copy_image") ||
-	                                     GLExtensions::Supports("GL_NV_copy_image") ||
-	                                     GLExtensions::Supports("GL_EXT_copy_image") ||
-	                                     GLExtensions::Supports("GL_OES_copy_image");
+	g_ogl_config.bSupportsCopySubImage = (GLExtensions::Supports("GL_ARB_copy_image") ||
+	                                      GLExtensions::Supports("GL_NV_copy_image") ||
+	                                      GLExtensions::Supports("GL_EXT_copy_image") ||
+	                                      GLExtensions::Supports("GL_OES_copy_image")) &&
+	                                      !DriverDetails::HasBug(DriverDetails::BUG_BROKENCOPYIMAGE);
 
 	// Desktop OpenGL supports the binding layout if it supports 420pack
 	// OpenGL ES 3.1 supports it implicitly without an extension

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -469,10 +469,10 @@ Renderer::Renderer()
 	g_Config.backend_info.bSupportsGeometryShaders = GLExtensions::Version() >= 320;
 	g_Config.backend_info.bSupportsPaletteConversion = GLExtensions::Supports("GL_ARB_texture_buffer_object");
 	g_Config.backend_info.bSupportsClipControl = GLExtensions::Supports("GL_ARB_clip_control");
-	g_Config.backend_info.bSupportsCopySubImage = GLExtensions::Supports("GL_ARB_copy_image") ||
-	                                              GLExtensions::Supports("GL_NV_copy_image") ||
-	                                              GLExtensions::Supports("GL_EXT_copy_image") ||
-	                                              GLExtensions::Supports("GL_OES_copy_image");
+	g_ogl_config.bSupportsCopySubImage = GLExtensions::Supports("GL_ARB_copy_image") ||
+	                                     GLExtensions::Supports("GL_NV_copy_image") ||
+	                                     GLExtensions::Supports("GL_EXT_copy_image") ||
+	                                     GLExtensions::Supports("GL_OES_copy_image");
 
 	// Desktop OpenGL supports the binding layout if it supports 420pack
 	// OpenGL ES 3.1 supports it implicitly without an extension
@@ -603,7 +603,7 @@ Renderer::Renderer()
 			g_ogl_config.bSupportSampleShading ? "" : "SSAA ",
 			g_ActiveConfig.backend_info.bSupportsGSInstancing ? "" : "GSInstancing ",
 			g_ActiveConfig.backend_info.bSupportsClipControl ? "" : "ClipControl ",
-			g_ActiveConfig.backend_info.bSupportsCopySubImage ? "" : "CopyImageSubData "
+			g_ogl_config.bSupportsCopySubImage ? "" : "CopyImageSubData "
 			);
 
 	s_last_multisample_mode = g_ActiveConfig.iMultisampleMode;

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -36,6 +36,7 @@ struct VideoConfig
 	bool bSupportViewportFloat;
 	bool bSupportsAEP;
 	bool bSupportsDebug;
+	bool bSupportsCopySubImage;
 
 	const char* gl_vendor;
 	const char* gl_renderer;

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -147,7 +147,7 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 	TCacheEntry* srcentry = (TCacheEntry*)source;
 	if (srcrect.GetWidth() == dstrect.GetWidth()
 		&& srcrect.GetHeight() == dstrect.GetHeight()
-		&& g_ActiveConfig.backend_info.bSupportsCopySubImage)
+		&& g_ogl_config.bSupportsCopySubImage)
 	{
 		glCopyImageSubData(
 			srcentry->texture,
@@ -167,9 +167,11 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 			1);
 		return;
 	}
-	else if (!config.rendertarget)
+	else if (!framebuffer)
 	{
-		return;
+		glGenFramebuffers(1, &framebuffer);
+		FramebufferManager::SetFramebuffer(framebuffer);
+		FramebufferManager::FramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_ARRAY, texture, 0);
 	}
 	g_renderer->ResetAPIState();
 	FramebufferManager::SetFramebuffer(framebuffer);

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -57,6 +57,7 @@ namespace DriverDetails
 		{OS_ALL,    VENDOR_MESA,     DRIVER_NOUVEAU,      -1, BUG_BROKENUBO,           900,  916, true},
 		{OS_ALL,    VENDOR_MESA,     DRIVER_R600,         -1, BUG_BROKENUBO,           900,  913, true},
 		{OS_ALL,    VENDOR_MESA,     DRIVER_I965,         -1, BUG_BROKENUBO,           900,  920, true},
+		{OS_ALL,    VENDOR_MESA,     DRIVER_ALL,          -1, BUG_BROKENCOPYIMAGE,     -1.0, 1064.0, true},
 		{OS_LINUX,  VENDOR_ATI,      DRIVER_ATI,          -1, BUG_BROKENPINNEDMEMORY,  -1.0, -1.0, true},
 		{OS_LINUX,  VENDOR_NVIDIA,   DRIVER_NVIDIA,       -1, BUG_BROKENBUFFERSTORAGE, -1.0, 33138.0, true},
 		{OS_OSX,    VENDOR_INTEL,    DRIVER_INTEL,      3000, BUG_PRIMITIVERESTART,    -1.0, -1.0, true},

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -234,6 +234,12 @@ namespace DriverDetails
 		//		ab.z <<= cd.z;
 		//		ab.w <<= cd.w;
 		BUG_BROKENIVECSHIFTS,
+
+		// Bug: glCopyImageSubData doesn't work on i965
+		// Started Version: -1
+		// Ended Version: 10.6.4
+		// Mesa meta misses to disable the scissor test.
+		BUG_BROKENCOPYIMAGE,
 	};
 
 	// Initializes our internal vendor, device family, and driver version

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -160,7 +160,6 @@ struct VideoConfig final
 		bool bSupportsPostProcessing;
 		bool bSupportsPaletteConversion;
 		bool bSupportsClipControl; // Needed by VertexShaderGen, so must stay in VideoCommon
-		bool bSupportsCopySubImage; // Needed for partial texture updates
 	} backend_info;
 
 	// Utility


### PR DESCRIPTION
Bughotfix: http://hastebin.com/vubivonike.md

The first patch is a bit maintaining, it's a workaround to just create a new framebuffer if the OGL extension isn't available.