### PR TITLE
HotkeyManager: Activate hotkey when key is pressed.

### DIFF
--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -159,16 +159,14 @@ bool IsPressed(int Id, bool held)
 	unsigned int setKey = Id % 32;
 	if (s_hotkey.button[set] & (1 << setKey))
 	{
+		bool pressed = !!(s_hotkeyDown[set] & (1 << setKey));
 		s_hotkeyDown[set] |= (1 << setKey);
-		if (held)
+		if (!pressed || held)
 			return true;
 	}
 	else
 	{
-		bool pressed = !!(s_hotkeyDown[set] & (1 << setKey));
 		s_hotkeyDown[set] &= ~(1 << setKey);
-		if (pressed)
-			return true;
 	}
 
 	return false;


### PR DESCRIPTION
As opposed to activating the hotkey when it is released.

Fixes [issue 8745](https://code.google.com/p/dolphin-emu/issues/detail?id=8745).