### PR TITLE
VideoCommon: reduce level of debug output

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -252,7 +252,7 @@ static void BPWritten(const BPCmd& bp)
 				}
 
 				u32 stride = bpmem.copyMipMapStrideChannels << 5;
-				WARN_LOG(VIDEO, "RenderToXFB: destAddr: %08x | srcRect {%d %d %d %d} | fbWidth: %u | fbStride: %u | fbHeight: %u",
+				DEBUG_LOG(VIDEO, "RenderToXFB: destAddr: %08x | srcRect {%d %d %d %d} | fbWidth: %u | fbStride: %u | fbHeight: %u",
 					destAddr, srcRect.left, srcRect.top, srcRect.right, srcRect.bottom, bpmem.copyTexSrcWH.x + 1, stride, height);
 				Renderer::RenderToXFB(destAddr, srcRect, stride, height, s_gammaLUT[PE_copy.gamma]);
 			}


### PR DESCRIPTION
Accidentally left in a debugging statement at WARN level rather than reducing to DEBUG