### PR TITLE
Android: Allow usage of Cached Interpreter core.

### DIFF
--- a/Source/Android/app/src/arm_64/res/values/arrays.xml
+++ b/Source/Android/app/src/arm_64/res/values/arrays.xml
@@ -6,10 +6,12 @@
     <!-- New UI CPU Core selection - ARM64 -->
     <string-array name="string_emu_cores" translatable="false">
         <item>@string/interpreter</item>
+        <item>@string/cached_interpreter</item>
         <item>@string/jit_arm64_recompiler</item>
     </string-array>
     <string-array name="int_emu_cores" translatable="false">
         <item>0</item>
+        <item>5</item>
         <item>4</item>
     </string-array>
 

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -46,9 +46,11 @@
     <!-- New UI CPU Core selection - Default -->
     <string-array name="string_emu_cores" translatable="false">
         <item>@string/interpreter</item>
+        <item>@string/cached_interpreter</item>
     </string-array>
     <string-array name="int_emu_cores" translatable="false">
         <item>0</item>
+        <item>5</item>
     </string-array>
     
     <!-- Video Backend Selection - Supports OpenGL ES 3 -->

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
 
     <!-- CPU Preference Fragment -->
     <string name="interpreter">Interpreter</string>
+    <string name="cached_interpreter">Cached Interpreter</string>
     <string name="jit64_recompiler">JIT64 Recompiler</string>
     <string name="jitil_recompiler">JITIL Recompiler</string>
     <string name="jit_arm_recompiler">JIT ARM Recompiler</string>


### PR DESCRIPTION
Roughly 10fps in Twilight Princess intro, versus 3fps in the standard interpreter, so I'm pretty sure this actually works.