### PR TITLE
[WIP] Add option for forcing square pixels.

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -18,6 +18,7 @@
 #include "Core/PowerPC/PowerPC.h"
 
 #include "VideoCommon/VideoBackendBase.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace VideoInterface
 {
@@ -473,7 +474,7 @@ float GetAspectRatio(bool wide)
 			pixelAR = 648.0f / 710.85f;
 		}
 	}
-	if (width == 0 || height == 0)
+	if (width == 0 || height == 0 || g_ActiveConfig.bSquarePixels)
 	{
 		if (wide)
 		{

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -137,6 +137,7 @@ static wxString use_ffv1_desc = wxTRANSLATE("Encode frame dumps using the FFV1 c
 #endif
 static wxString free_look_desc = wxTRANSLATE("This feature allows you to change the game's camera.\nMove the mouse while holding the right mouse button to pan and while holding the middle button to move.\nHold SHIFT and press one of the WASD keys to move the camera by a certain step distance (SHIFT+2 to move faster and SHIFT+1 to move slower). Press SHIFT+R to reset the camera and SHIFT+F to reset the speed.\n\nIf unsure, leave this unchecked.");
 static wxString crop_desc = wxTRANSLATE("Crop the picture from its native aspect ratio to 4:3 or 16:9.\n\nIf unsure, leave this unchecked.");
+static wxString square_pixels_desc = wxTRANSLATE("Force Dolphin to output square pixels instead of the correct PAL or NTSC aspect ratios.\n\n If unsure, leave this unchecked.");
 static wxString ppshader_desc = wxTRANSLATE("Apply a post-processing effect after finishing a frame.\n\nIf unsure, select (off).");
 static wxString cache_efb_copies_desc = wxTRANSLATE("Slightly speeds up EFB to RAM copies by sacrificing emulation accuracy.\nIf you're experiencing any issues, try raising texture cache accuracy or disable this option.\n\nIf unsure, leave this unchecked.");
 static wxString stereo_3d_desc = wxTRANSLATE("Selects the stereoscopic 3D mode. Stereoscopy allows you to get a better feeling of depth if you have the necessary hardware.\nSide-by-Side and Top-and-Bottom are used by most 3D TVs.\nAnaglyph is used for Red-Cyan colored glasses.\nHeavily decreases emulation speed and sometimes causes issues.\n\nIf unsure, select Off.");
@@ -588,6 +589,8 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	szr_misc->Add(progressive_scan_checkbox);
 	}
+
+	szr_misc->Add(CreateCheckBox(page_advanced, _("Force square pixels"), wxGetTranslation(square_pixels_desc), vconfig.bSquarePixels));
 
 #if defined WIN32
 	// Borderless Fullscreen

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -70,6 +70,7 @@ struct VideoConfig final
 	bool bWidescreenHack;
 	int iAspectRatio;
 	bool bCrop;   // Aspect ratio controls.
+	bool bSquarePixels;
 	bool bUseXFB;
 	bool bUseRealXFB;
 


### PR DESCRIPTION
This option is only for people who think circles in poorly programmed games should be emulated as circles in dolphin. They don't appear as circles on the real hardware. 

If you are here because you want to get rid of the tiny black bars that dolphin now has around  the picture on your 16:9 monitor, you are in the wrong place. While this option might fix that for some games, it won't for others.

Instead you want to check the "crop" option in the advanced graphics settings. Crop has been improved and now crops the image to either 16:9 or 4:3. A few pixels will be chopped off, but those pixels would have been hidden in the overscan area of your TV.

This option will never be enabled by default, as that will cause many other games (that put an effort to use the correct aspect ratio) to render incorrectly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/2791)

<!-- Reviewable:end -->
