### PR TITLE
Stable device identifier for evdev

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -15,8 +15,28 @@ namespace ciface
 namespace evdev
 {
 
+static std::string GetName(const std::string& devnode)
+{
+	int fd = open(devnode.c_str(), O_RDWR|O_NONBLOCK);
+	libevdev* dev = nullptr;
+	int ret = libevdev_new_from_fd(fd, &dev);
+	if (ret != 0)
+	{
+		close(fd);
+		return std::string();
+	}
+	std::string res = libevdev_get_name(dev);
+	libevdev_free(dev);
+	close(fd);
+	return std::move(res);
+}
+
 void Init(std::vector<Core::Device*> &controllerDevices)
 {
+	// this is used to number the joysticks
+	// multiple joysticks with the same name shall get unique ids starting at 0
+	std::map<std::string, int> name_counts;
+
 	int num_controllers = 0;
 
 	// We use Udev to find any devices. In the future this will allow for hotplugging.
@@ -46,7 +66,8 @@ void Init(std::vector<Core::Device*> &controllerDevices)
 		{
 			// Unfortunately udev gives us no way to filter out the non event device interfaces.
 			// So we open it and see if it works with evdev ioctls or not.
-			evdevDevice* input = new evdevDevice(devnode, num_controllers);
+			std::string name = GetName(devnode);
+			evdevDevice* input = new evdevDevice(devnode, name_counts[name]++);
 
 			if (input->IsInteresting())
 			{


### PR DESCRIPTION
This should fix [evdev controller unique identifier changes on reboot](https://code.google.com/p/dolphin-emu/issues/detail?id=8781).