### PR TITLE
Fix wording of invalid read/write message

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -888,7 +888,7 @@ static void GenerateDSIException(u32 effectiveAddress, bool write)
 	// DSI exceptions are only supported in MMU mode.
 	if (!SConfig::GetInstance().bMMU)
 	{
-		PanicAlert("Invalid %s to 0x%08x, PC = 0x%08x ", write ? "Write to" : "Read from", effectiveAddress, PC);
+		PanicAlert("Invalid %s 0x%08x, PC = 0x%08x ", write ? "write to" : "read from", effectiveAddress, PC);
 		return;
 	}
 


### PR DESCRIPTION
Currently produces messages like "Invalid Read from to 0x..."