### PR TITLE
Debugger: Use wxSearchCtrls instead of wxTextCtrl for address searching.

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -10,6 +10,7 @@
 #include <wx/listbox.h>
 #include <wx/menu.h>
 #include <wx/panel.h>
+#include <wx/srchctrl.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 #include <wx/textdlg.h>
@@ -83,12 +84,11 @@ CCodeWindow::CCodeWindow(const SConfig& _LocalCoreStartupParameter, CFrame *pare
 
 	m_aui_toolbar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxAUI_TB_HORIZONTAL | wxAUI_TB_PLAIN_BACKGROUND);
 
-	wxTextCtrl* const address_textctrl = new wxTextCtrl(m_aui_toolbar, IDM_ADDRBOX);
-	address_textctrl->Bind(wxEVT_TEXT, &CCodeWindow::OnAddrBoxChange, this);
+	wxSearchCtrl* const address_searchctrl = new wxSearchCtrl(m_aui_toolbar, IDM_ADDRBOX);
+	address_searchctrl->Bind(wxEVT_TEXT, &CCodeWindow::OnAddrBoxChange, this);
+	address_searchctrl->SetDescriptiveText(_("Search Address"));
 
-	m_aui_toolbar->AddControl(new wxStaticText(m_aui_toolbar, wxID_ANY, _("Address Search:")));
-	m_aui_toolbar->AddSpacer(5);
-	m_aui_toolbar->AddControl(address_textctrl);
+	m_aui_toolbar->AddControl(address_searchctrl);
 	m_aui_toolbar->Realize();
 
 	m_aui_manager.SetManagedWindow(this);
@@ -225,7 +225,7 @@ void CCodeWindow::OnCodeViewChange(wxCommandEvent &event)
 
 void CCodeWindow::OnAddrBoxChange(wxCommandEvent& event)
 {
-	wxTextCtrl* pAddrCtrl = (wxTextCtrl*)m_aui_toolbar->FindControl(IDM_ADDRBOX);
+	wxSearchCtrl* pAddrCtrl = (wxSearchCtrl*)m_aui_toolbar->FindControl(IDM_ADDRBOX);
 
 	// Trim leading and trailing whitespace.
 	wxString txt = pAddrCtrl->GetValue().Trim().Trim(false);

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -240,7 +240,7 @@ void CCodeWindow::OnAddrBoxChange(wxCommandEvent& event)
 
 	if (success)
 		pAddrCtrl->SetBackgroundColour(wxNullColour);
-	else
+	else if (!txt.empty())
 		pAddrCtrl->SetBackgroundColour(*wxRED);
 
 	pAddrCtrl->Refresh();

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -67,9 +67,6 @@ CMemoryWindow::CMemoryWindow(wxWindow* parent, wxWindowID id,
 		const wxPoint& pos, const wxSize& size, long style, const wxString& name)
 	: wxPanel(parent, id, pos, size, style, name)
 {
-	wxBoxSizer* sizerBig   = new wxBoxSizer(wxHORIZONTAL);
-	wxBoxSizer* sizerRight = new wxBoxSizer(wxVERTICAL);
-
 	DebugInterface* di = &PowerPC::debug_interface;
 
 	memview = new CMemoryView(di, this);
@@ -81,37 +78,43 @@ CMemoryWindow::CMemoryWindow(wxWindow* parent, wxWindowID id,
 	valbox = new wxTextCtrl(this, IDM_VALBOX, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
 	valbox->Bind(wxEVT_TEXT_ENTER, &CMemoryWindow::SetMemoryValueFromValBox, this);
 
-	sizerBig->Add(memview, 20, wxEXPAND);
-	sizerBig->Add(sizerRight, 0, wxEXPAND | wxALL, 3);
-	sizerRight->Add(addrbox);
-	sizerRight->Add(valbox);
-	sizerRight->Add(new wxButton(this, IDM_SETVALBUTTON, _("Set Value")));
+	wxGridSizer* const search_sizer = new wxGridSizer(1);
+	search_sizer->Add(addrbox);
+	search_sizer->Add(valbox, 0, wxEXPAND);
+	search_sizer->Add(new wxButton(this, IDM_SETVALBUTTON, _("Set Value")));
 
-	sizerRight->AddSpacer(5);
-	sizerRight->Add(new wxButton(this, IDM_DUMP_MEMORY, _("Dump MRAM")));
-	sizerRight->Add(new wxButton(this, IDM_DUMP_MEM2, _("Dump EXRAM")));
-
+	wxGridSizer* const dump_sizer = new wxGridSizer(1);
+	dump_sizer->Add(new wxButton(this, IDM_DUMP_MEMORY, _("Dump MRAM")), 0, wxEXPAND);
+	dump_sizer->Add(new wxButton(this, IDM_DUMP_MEM2, _("Dump EXRAM")), 0, wxEXPAND);
 	if (!SConfig::GetInstance().bMMU)
-		sizerRight->Add(new wxButton(this, IDM_DUMP_FAKEVMEM, _("Dump FakeVMEM")));
+		dump_sizer->Add(new wxButton(this, IDM_DUMP_FAKEVMEM, _("Dump FakeVMEM")), 0, wxEXPAND);
 
-	wxStaticBoxSizer* sizerSearchType = new wxStaticBoxSizer(wxVERTICAL, this, _("Search"));
-
+	wxStaticBoxSizer* const sizerSearchType = new wxStaticBoxSizer(wxVERTICAL, this, _("Search"));
 	sizerSearchType->Add(btnSearch = new wxButton(this, IDM_SEARCH, _("Search")));
 	sizerSearchType->Add(chkAscii = new wxCheckBox(this, IDM_ASCII, "Ascii "));
 	sizerSearchType->Add(chkHex = new wxCheckBox(this, IDM_HEX, _("Hex")));
-	sizerRight->Add(sizerSearchType);
-	wxStaticBoxSizer* sizerDataTypes = new wxStaticBoxSizer(wxVERTICAL, this, _("Data Type"));
 
+	wxStaticBoxSizer* const sizerDataTypes = new wxStaticBoxSizer(wxVERTICAL, this, _("Data Type"));
 	sizerDataTypes->SetMinSize(74, 40);
 	sizerDataTypes->Add(chk8 = new wxCheckBox(this, IDM_U8, "U8"));
 	sizerDataTypes->Add(chk16 = new wxCheckBox(this, IDM_U16, "U16"));
 	sizerDataTypes->Add(chk32 = new wxCheckBox(this, IDM_U32, "U32"));
+
+	wxBoxSizer* const sizerRight = new wxBoxSizer(wxVERTICAL);
+	sizerRight->Add(search_sizer);
+	sizerRight->AddSpacer(5);
+	sizerRight->Add(dump_sizer);
+	sizerRight->Add(sizerSearchType);
 	sizerRight->Add(sizerDataTypes);
+
+	wxBoxSizer* const sizerBig = new wxBoxSizer(wxHORIZONTAL);
+	sizerBig->Add(memview, 20, wxEXPAND);
+	sizerBig->Add(sizerRight, 0, wxEXPAND | wxALL, 3);
+
 	SetSizer(sizerBig);
 	chkHex->SetValue(1); //Set defaults
 	chk8->SetValue(1);
 
-	//sizerLeft->Fit(this);
 	sizerRight->Fit(this);
 	sizerBig->Fit(this);
 }

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -13,6 +13,7 @@
 #include <wx/msgdlg.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>
+#include <wx/srchctrl.h>
 #include <wx/textctrl.h>
 
 #include "Common/CommonTypes.h"
@@ -48,8 +49,6 @@ enum
 };
 
 BEGIN_EVENT_TABLE(CMemoryWindow, wxPanel)
-	EVT_TEXT(IDM_MEM_ADDRBOX,       CMemoryWindow::OnAddrBoxChange)
-	EVT_TEXT_ENTER(IDM_VALBOX,      CMemoryWindow::SetMemoryValueFromValBox)
 	EVT_LISTBOX(IDM_SYMBOLLIST,     CMemoryWindow::OnSymbolListChange)
 	EVT_HOST_COMMAND(wxID_ANY,      CMemoryWindow::OnHostMessage)
 	EVT_BUTTON(IDM_SETVALBUTTON,    CMemoryWindow::SetMemoryValue)
@@ -70,21 +69,22 @@ CMemoryWindow::CMemoryWindow(wxWindow* parent, wxWindowID id,
 {
 	wxBoxSizer* sizerBig   = new wxBoxSizer(wxHORIZONTAL);
 	wxBoxSizer* sizerRight = new wxBoxSizer(wxVERTICAL);
-	// Didn't see anything useful in the left part
-	//wxBoxSizer* sizerLeft  = new wxBoxSizer(wxVERTICAL);
 
 	DebugInterface* di = &PowerPC::debug_interface;
 
-	//symbols = new wxListBox(this, IDM_SYMBOLLIST, wxDefaultPosition,
-	//      wxSize(20, 100), 0, nullptr, wxLB_SORT);
-	//sizerLeft->Add(symbols, 1, wxEXPAND);
 	memview = new CMemoryView(di, this);
 
-	//sizerBig->Add(sizerLeft, 1, wxEXPAND);
+	addrbox = new wxSearchCtrl(this, IDM_MEM_ADDRBOX);
+	addrbox->Bind(wxEVT_TEXT, &CMemoryWindow::OnAddrBoxChange, this);
+	addrbox->SetDescriptiveText(_("Search Address"));
+
+	valbox = new wxTextCtrl(this, IDM_VALBOX, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+	valbox->Bind(wxEVT_TEXT_ENTER, &CMemoryWindow::SetMemoryValueFromValBox, this);
+
 	sizerBig->Add(memview, 20, wxEXPAND);
 	sizerBig->Add(sizerRight, 0, wxEXPAND | wxALL, 3);
-	sizerRight->Add(addrbox = new wxTextCtrl(this, IDM_MEM_ADDRBOX, ""));
-	sizerRight->Add(valbox = new wxTextCtrl(this, IDM_VALBOX, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER));
+	sizerRight->Add(addrbox);
+	sizerRight->Add(valbox);
 	sizerRight->Add(new wxButton(this, IDM_SETVALBUTTON, _("Set Value")));
 
 	sizerRight->AddSpacer(5);

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.h
@@ -12,6 +12,7 @@ class IniFile;
 class wxButton;
 class wxCheckBox;
 class wxListBox;
+class wxSearchCtrl;
 class wxTextCtrl;
 
 class CMemoryWindow : public wxPanel
@@ -60,6 +61,6 @@ private:
 	CMemoryView* memview;
 	wxListBox* symbols;
 
-	wxTextCtrl* addrbox;
+	wxSearchCtrl* addrbox;
 	wxTextCtrl* valbox;
 };


### PR DESCRIPTION
Essentially the same thing, however wxSearchCtrls allow for transparent description text that fades away once the user inputs something (and comes back if the field is cleared).

e.g. ![](http://docs.wxwidgets.org/trunk/appear-searchctrl-msw.png)