### PR TITLE
[RFC] Super experimental LLVM tiered recompiler.

### DIFF
--- a/CMakeTests/FindLLVM.cmake
+++ b/CMakeTests/FindLLVM.cmake
@@ -17,6 +17,7 @@ foreach(LLVM_CONFIG_NAME ${LLVM_CONFIG_EXECUTABLES})
 			execute_process(COMMAND ${LLVM_CONFIG_EXE} --ldflags OUTPUT_VARIABLE LLVM_LDFLAGS
 				OUTPUT_STRIP_TRAILING_WHITESPACE )
 			set(LLVM_LIBRARIES "${LLVM_LDFLAGS} -lLLVM-${LLVM_PACKAGE_VERSION}")
+			add_definitions(-fno-rtti)
 			break()
 		endif()
 	endif()

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -168,6 +168,7 @@ set(SRCS	ActionReplay.cpp
 			PowerPC/Interpreter/Interpreter_Paired.cpp
 			PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
 			PowerPC/Interpreter/Interpreter_Tables.cpp
+			PowerPC/TieredRecompiler.cpp
 			PowerPC/JitCommon/JitAsmCommon.cpp
 			PowerPC/JitCommon/JitBase.cpp
 			PowerPC/JitCommon/JitCache.cpp
@@ -221,6 +222,24 @@ elseif(_M_ARM_64)
 	         PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
 	         PowerPC/JitArm64/Jit_Util.cpp
 	         PowerPC/JitArm64/JitArm64_Tables.cpp)
+endif()
+
+if(HAS_LLVM)
+	set(SRCS ${SRCS}
+	         PowerPC/JitLLVM/Jit.cpp
+	         PowerPC/JitLLVM/JitBinding.cpp
+	         PowerPC/JitLLVM/JitFunction.cpp
+	         PowerPC/JitLLVM/JitHelpers.cpp
+	         PowerPC/JitLLVM/JitModule.cpp
+	         PowerPC/JitLLVM/JitLLVM_Branch.cpp
+	         PowerPC/JitLLVM/JitLLVM_FloatingPoint.cpp
+	         PowerPC/JitLLVM/JitLLVM_Integer.cpp
+	         PowerPC/JitLLVM/JitLLVM_LoadStore.cpp
+	         PowerPC/JitLLVM/JitLLVM_LoadStoreFloating.cpp
+	         PowerPC/JitLLVM/JitLLVM_LoadStorePaired.cpp
+	         PowerPC/JitLLVM/JitLLVM_Paired.cpp
+	         PowerPC/JitLLVM/JitLLVM_SystemRegisters.cpp
+	         PowerPC/JitLLVM/JitLLVM_Tables.cpp)
 endif()
 
 set(LIBS

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -252,6 +252,7 @@
     <ClCompile Include="PowerPC\PPCTables.cpp" />
     <ClCompile Include="PowerPC\Profiler.cpp" />
     <ClCompile Include="PowerPC\SignatureDB.cpp" />
+    <ClCompile Include="PowerPC\TieredRecompiler.cpp" />
     <ClCompile Include="State.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -435,6 +436,7 @@
     <ClInclude Include="PowerPC\PPCTables.h" />
     <ClInclude Include="PowerPC\Profiler.h" />
     <ClInclude Include="PowerPC\SignatureDB.h" />
+    <ClInclude Include="PowerPC\TieredRecompiler.h" />
     <ClInclude Include="State.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -636,6 +636,9 @@
     <ClCompile Include="PowerPC\SignatureDB.cpp">
       <Filter>PowerPC</Filter>
     </ClCompile>
+    <ClCompile Include="PowerPC\TieredRecompiler.cpp">
+      <Filter>PowerPC</Filter>
+    </ClCompile>
     <ClCompile Include="PowerPC\JitCommon\Jit_Util.cpp">
       <Filter>PowerPC\JitCommon</Filter>
     </ClCompile>
@@ -1202,6 +1205,9 @@
       <Filter>PowerPC</Filter>
     </ClInclude>
     <ClInclude Include="PowerPC\SignatureDB.h">
+      <Filter>PowerPC</Filter>
+    </ClInclude>
+    <ClInclude Include="PowerPC\TieredRecompiler.h">
       <Filter>PowerPC</Filter>
     </ClInclude>
     <ClInclude Include="PowerPC\JitCommon\Jit_Util.h">

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -19,6 +19,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/Profiler.h"
+#include "Core/PowerPC/TieredRecompiler.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 
 #if _M_X86
@@ -75,6 +76,7 @@ namespace JitInterface
 		}
 		jit = static_cast<JitBase*>(ptr);
 		jit->Init();
+		TieredRecompiler::Init();
 		return ptr;
 	}
 	void InitTables(int core)
@@ -282,5 +284,14 @@ namespace JitInterface
 			delete jit;
 			jit = nullptr;
 		}
+		TieredRecompiler::Shutdown();
+	}
+
+	const void* GetDispatcher()
+	{
+		if (jit)
+			return (const void*)jit->GetAsmRoutines()->dispatcher;
+
+		return nullptr;
 	}
 }

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -43,6 +43,10 @@ namespace JitInterface
 	void CompileExceptionCheck(ExceptionType type);
 
 	void Shutdown();
+
+	// This is used with the tiered recompiler
+	// We need to know the JIT's dispatcher location to jump to it
+	const void* GetDispatcher();
 }
 extern bool bMMU;
 

--- a/Source/Core/Core/PowerPC/JitLLVM/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/Jit.cpp
@@ -1,0 +1,295 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <sstream>
+
+#include <llvm/InitializePasses.h>
+#include <llvm/LinkAllPasses.h>
+#include <llvm/PassRegistry.h>
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+#include <llvm/ExecutionEngine/GenericValue.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/IRPrintingPasses.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Support/TargetSelect.h>
+#include <llvm/Transforms/Scalar.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
+
+#include "Common/GekkoDisassembler.h"
+
+#include "Core/PowerPC/CPUCoreBase.h"
+#include "Core/PowerPC/PPCAnalyst.h"
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+#include "Core/PowerPC/JitLLVM/JitFunction.h"
+#include "Core/PowerPC/JitLLVM/JitHelpers.h"
+#include "Core/PowerPC/JitLLVM/JitLLVM_Tables.h"
+
+using namespace llvm;
+
+void JitLLVM::Init()
+{
+	JitLLVMTables::InitTables();
+
+	m_debug_enabled = false;
+
+	code_block.m_stats = &js.st;
+	code_block.m_gpa = &js.gpa;
+	code_block.m_fpa = &js.fpa;
+
+	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+
+	InitializeNativeTarget();
+	InitializeNativeTargetAsmPrinter();
+	LLVMContext& con = getGlobalContext();
+
+	m_named_binder = new LLVMNamedBinding();
+	m_mem_manager = new LLVMMemoryManager(m_named_binder);
+	m_main_mod = new Module("Dolphin LLVM JIT Recompiler", con);
+
+	m_engine = EngineBuilder(std::unique_ptr<Module>(m_main_mod))
+		.setEngineKind(EngineKind::JIT)
+		.setMCJITMemoryManager(std::unique_ptr<RTDyldMemoryManager>(m_mem_manager))
+		.create();
+}
+
+void JitLLVM::Shutdown()
+{
+	// The ExecutionEngine takes ownership of nearly everything
+	// Delete the engine, delete the world.
+	delete m_engine;
+	delete m_named_binder;
+}
+
+void JitLLVM::DoDownCount()
+{
+	LLVMFunction* func = GetCurrentFunc();
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* downcount = func->LoadDownCount();
+	Value* res = builder->CreateSub(downcount, builder->getInt32(js.downcountAmount));
+	func->StoreDownCount(res);
+}
+
+void JitLLVM::WriteExceptionExit(Value* val)
+{
+	LLVMFunction* func = GetCurrentFunc();
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	DoDownCount();
+
+	func->StorePC(val);
+	func->StoreNPC(val);
+
+	Function* check_exceptions_func = m_cur_binder->GetBinding((void*)&PowerPC::CheckExceptions);
+	builder->CreateCall(check_exceptions_func);
+
+	func->StorePC(func->LoadNPC());
+
+	Function* dispatcher_func = m_cur_binder->GetBinding(m_cur_binder->GetBinding("Dispatcher"));
+	builder->CreateCall(dispatcher_func);
+	builder->CreateRetVoid();
+}
+
+void JitLLVM::WriteExit(u32 destination)
+{
+	LLVMFunction* func = GetCurrentFunc();
+
+	IRBuilder<>* builder = GetCurrentFunc()->GetBuilder();
+
+	DoDownCount();
+
+	func->StorePC(builder->getInt32(destination));
+
+	Function* dispatcher_func = m_cur_binder->GetBinding(m_cur_binder->GetBinding("Dispatcher"));
+	builder->CreateCall(dispatcher_func);
+	builder->CreateRetVoid();
+}
+
+void JitLLVM::WriteExitInValue(Value* destination)
+{
+	LLVMFunction* func = GetCurrentFunc();
+
+	IRBuilder<>* builder = GetCurrentFunc()->GetBuilder();
+
+	DoDownCount();
+
+	func->StorePC(destination);
+
+	Function* dispatcher_func = m_cur_binder->GetBinding(m_cur_binder->GetBinding("Dispatcher"));
+	builder->CreateCall(dispatcher_func);
+	builder->CreateRetVoid();
+}
+
+void JitLLVM::FallBackToInterpreter(LLVMFunction* func, UGeckoInstruction inst)
+{
+	Interpreter::_interpreterInstruction instr = GetInterpreterOp(inst);
+
+	LLVMContext& con = getGlobalContext();
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Function* bound_func = m_cur_binder->GetBinding((void*)instr);
+
+	if (!bound_func)
+	{
+		// Haven't ever bound this interpreter function
+		// Generate it and then bind it
+		GekkoOPInfo* opcodeInfo = GetOpInfo(inst);
+
+		FunctionType* type = GenerateFunctionType(
+			Type::getVoidTy(con),
+			Type::getInt32Ty(con));
+
+		bound_func = Function::Create(type, Function::ExternalLinkage, opcodeInfo->opname, m_cur_mod->GetModule());
+		m_cur_binder->Bind(bound_func, (void*)instr);
+	}
+
+	builder->CreateCall(bound_func, builder->getInt32(inst.hex));
+}
+
+void JitLLVM::Break(LLVMFunction* func, UGeckoInstruction inst)
+{
+	// XXX: Actually break!
+}
+
+void JitLLVM::DoNothing(LLVMFunction* func, UGeckoInstruction inst)
+{
+}
+
+void JitLLVM::Jit(u32 em_address)
+{
+	if (em_address == 0)
+	{
+		Core::SetState(Core::CORE_PAUSE);
+		WARN_LOG(DYNA_REC, "ERROR: Compiling at 0. LR=%08x CTR=%08x", LR, CTR);
+	}
+
+	js.isLastInstruction = false;
+	js.firstFPInstructionFound = false;
+	js.blockStart = em_address;
+	js.fifoBytesThisBlock = 0;
+	js.downcountAmount = 0;
+	js.skipInstructions = 0;
+
+	int blockSize = code_buffer.GetSize();
+
+	if (SConfig::GetInstance().bEnableDebugging)
+	{
+		// Comment out the following to disable breakpoints (speed-up)
+		blockSize = 1;
+	}
+
+	u32 nextPC = em_address;
+	// Analyze the block, collect all instructions it is made of (including inlining,
+	// if that is enabled), reorder instructions for optimal performance, and join joinable instructions.
+	nextPC = analyzer.Analyze(em_address, &code_block, &code_buffer, blockSize);
+
+	legacy::PassManager PM;
+	PassManagerBuilder Builder;
+	Builder.OptLevel = 2;
+	Builder.populateModulePassManager(PM);
+	PM.add(createSLPVectorizerPass());
+	raw_ostream& out = outs();
+
+	if (m_debug_enabled)
+		PM.add(createPrintModulePass(out));
+
+	LLVMModule* mod = new LLVMModule(m_engine, em_address);
+	m_mods[em_address] = mod;
+
+	m_cur_mod = mod;
+	m_cur_func = mod->GetFunction();
+	m_cur_binder = mod->GetBinding();
+	m_mem_manager->SetNamedBinder(mod->GetNamedBinding());
+
+	// Build our GEP references first
+	m_cur_func->BuildGEPs();
+
+	PPCAnalyst::CodeOp *ops = code_buffer.codebuffer;
+
+	if (m_debug_enabled)
+	{
+		for (u32 i = 0; i < code_block.m_num_instructions; i++)
+		{
+			std::ostringstream ppc_disasm;
+			const PPCAnalyst::CodeOp &op = ops[i];
+			std::string opcode = GekkoDisassembler::Disassemble(op.inst.hex, op.address);
+			ppc_disasm << std::setfill('0') << std::setw(8) << std::hex << op.address;
+			ppc_disasm << " " << opcode << std::endl;
+			printf("%s", ppc_disasm.str().c_str());
+		}
+	}
+
+	IRBuilder<>* builder = m_cur_func->GetBuilder();
+
+	for (u32 i = 0; i < code_block.m_num_instructions; i++)
+	{
+		js.compilerPC = ops[i].address;
+		js.op = &ops[i];
+		js.instructionNumber = i;
+		const GekkoOPInfo *opinfo = ops[i].opinfo;
+		js.downcountAmount += opinfo->numCycles;
+
+		if (i == (code_block.m_num_instructions - 1))
+		{
+			// WARNING - cmp->branch merging will screw this up.
+			js.isLastInstruction = true;
+		}
+
+		if (!ops[i].skip)
+		{
+			if ((opinfo->flags & FL_USE_FPU) && !js.firstFPInstructionFound)
+			{
+				BasicBlock* disabled_block = m_cur_func->CreateBlock("fp_disabled");
+				BasicBlock* enabled_block = m_cur_func->CreateBlock("fp_enabled");
+
+				Value* msr = m_cur_func->LoadMSR();
+				Value* fp_enabled = builder->CreateAnd(msr, builder->getInt32(1 << 13));
+				fp_enabled = builder->CreateICmpNE(fp_enabled, builder->getInt32(0));
+
+				builder->CreateCondBr(fp_enabled, enabled_block, disabled_block);
+
+				builder->SetInsertPoint(disabled_block);
+					Value* exceptions = m_cur_func->LoadExceptions();
+					exceptions = builder->CreateOr(exceptions, builder->getInt32(EXCEPTION_FPU_UNAVAILABLE));
+					m_cur_func->StoreExceptions(exceptions);
+					WriteExceptionExit(builder->getInt32(js.compilerPC));
+
+				builder->SetInsertPoint(enabled_block);
+					// Continue on with our life
+
+				js.firstFPInstructionFound = true;
+			}
+
+			JitLLVMTables::CompileInstruction(this, m_cur_func, ops[i]);
+		}
+
+		i += js.skipInstructions;
+		js.skipInstructions = 0;
+	}
+
+	if (code_block.m_broken)
+		WriteExit(nextPC);
+
+	verifyModule(*m_cur_mod->GetModule(), &out);
+	PM.run(*m_cur_mod->GetModule());
+
+	m_engine->addModule(std::unique_ptr<Module>(mod->GetModule()));
+	m_engine->finalizeObject();
+
+	//std::string loc = StringFromFormat("ppc%08x", em_address);
+	//void* normal_entry_ptr = (void*)m_engine->getFunctionAddress(loc.c_str());
+	// XXX: Enable when we actually start giving blocks to swap in
+	//b->normalEntry = normal_entry_ptr;
+	// XXX: Enable once we enable block linking
+	//b->checkedEntry = start;
+}
+

--- a/Source/Core/Core/PowerPC/JitLLVM/Jit.h
+++ b/Source/Core/Core/PowerPC/JitLLVM/Jit.h
@@ -102,16 +102,16 @@ public:
 
 	void Run() override {};
 
-	const char *GetName() override { return "LLVMJIT"; }
+	const char* GetName() override { return "LLVMJIT"; }
 
 	// XXX: Tie our LLVM memory manager and block cache together?
-	JitBaseBlockCache *GetBlockCache() override { return nullptr; }
+	JitBaseBlockCache* GetBlockCache() override { return nullptr; }
 
 	void Jit(u32 em_address) override;
 
 	// We don't generate our own ASM routines
 	// We ride on the ASM routines that the tier 1 recompiler uses
-	const CommonAsmRoutinesBase *GetAsmRoutines() override { return nullptr; }
+	const CommonAsmRoutinesBase* GetAsmRoutines() override { return nullptr; }
 
 	// We don't actually handle faults...yet
 	bool HandleFault(uintptr_t access_address, SContext* ctx) override { return false; }

--- a/Source/Core/Core/PowerPC/JitLLVM/Jit.h
+++ b/Source/Core/Core/PowerPC/JitLLVM/Jit.h
@@ -1,0 +1,303 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include <llvm/ExecutionEngine/ExecutionEngine.h>
+#include <llvm/ExecutionEngine/GenericValue.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include "Core/PowerPC/JitCommon/JitBase.h"
+#include "Core/PowerPC/JitLLVM/JitBinding.h"
+#include "Core/PowerPC/JitLLVM/JitFunction.h"
+#include "Core/PowerPC/JitLLVM/JitModule.h"
+
+class LLVMNamedBinding;
+class LLVMBinding;
+class LLVMFunction;
+class LLVMMemoryManager;
+class LLVMModule;
+
+#define LLVM_FALLBACK_IF(cond) do { if (cond) { FallBackToInterpreter(func, inst); return; } } while (0)
+
+#define LLVM_JITDISABLE(setting) LLVM_FALLBACK_IF(SConfig::GetInstance().bJITOff || \
+                                        SConfig::GetInstance().setting)
+
+class JitLLVM : public JitBase
+{
+private:
+	std::unordered_map<u32, LLVMModule*> m_mods;
+	llvm::Module* m_main_mod;
+	llvm::ExecutionEngine* m_engine;
+	LLVMMemoryManager* m_mem_manager;
+	LLVMNamedBinding* m_named_binder;
+
+	// Debug helper
+	bool m_debug_enabled;
+
+	// Currently emitting things
+	LLVMModule* m_cur_mod;
+	LLVMFunction* m_cur_func;
+	LLVMBinding* m_cur_binder;
+
+	LLVMFunction* GetCurrentFunc() { return m_cur_func; }
+
+	PPCAnalyst::CodeBuffer code_buffer;
+
+	llvm::Value* JumpIfCRFieldBit(LLVMFunction* func, int field, int bit, bool jump_if_set);
+	void reg_imm(LLVMFunction* func, u32 d, u32 a, bool binary, u32 value, llvm::Instruction::BinaryOps opc, bool Rc = false);
+
+	// Helpers
+	llvm::Value* ForceSingle(LLVMFunction* func, llvm::Value* val);
+	// Returns an ICmpGT value
+	llvm::Value* HasCarry(LLVMFunction* func, llvm::Value* a, llvm::Value* b);
+	void ComputeRC(LLVMFunction* func, llvm::Value* val, int crf, bool needs_sext = true);
+	llvm::Value* GetCRBit(LLVMFunction* func, int field, int bit, bool negate);
+	void SetCRBit(LLVMFunction* func, int field, int bit);
+	void SetCRBit(LLVMFunction* func, int field, int bit, llvm::Value* val);
+	void ClearCRBit(LLVMFunction* func, int field, int bit);
+
+	// LoadStore Helpers
+	llvm::Value* GetEA(LLVMFunction* func, UGeckoInstruction inst);
+	llvm::Value* GetEAU(LLVMFunction* func, UGeckoInstruction inst);
+	llvm::Value* GetEAX(LLVMFunction* func, UGeckoInstruction inst);
+	llvm::Value* GetEAUX(LLVMFunction* func, UGeckoInstruction inst);
+	llvm::Value* CreateReadU64(LLVMFunction* func, llvm::Value* address);
+	llvm::Value* CreateReadU32(LLVMFunction* func, llvm::Value* address);
+	llvm::Value* CreateReadU16(LLVMFunction* func, llvm::Value* address, bool needs_sext);
+	llvm::Value* CreateReadU8(LLVMFunction* func, llvm::Value* address, bool needs_sext);
+	llvm::Value* CreateWriteU64(LLVMFunction* func, llvm::Value* val, llvm::Value* address);
+	llvm::Value* CreateWriteU32(LLVMFunction* func, llvm::Value* val, llvm::Value* address);
+	llvm::Value* CreateWriteU16(LLVMFunction* func, llvm::Value* val, llvm::Value* address);
+	llvm::Value* CreateWriteU8(LLVMFunction* func, llvm::Value* val, llvm::Value* address);
+
+	// Paired Loadstore helpers
+	llvm::Value* Paired_GetEA(LLVMFunction* func, UGeckoInstruction inst);
+	llvm::Value* Paired_GetEAU(LLVMFunction* func, UGeckoInstruction inst);
+	llvm::Value* Paired_GetEAX(LLVMFunction* func, UGeckoInstruction inst);
+	llvm::Value* Paired_GetEAUX(LLVMFunction* func, UGeckoInstruction inst);
+	llvm::Value* CreatePairedLoad(LLVMFunction* func, llvm::Value* paired, llvm::Value* type, llvm::Value* scale, llvm::Value* address);
+	llvm::Value* Paired_GetLoadType(LLVMFunction* func, llvm::Value* gqr);
+	llvm::Value* Paired_GetLoadScale(LLVMFunction* func, llvm::Value* gqr);
+
+public:
+	JitLLVM() : code_buffer(32000) {}
+
+	void Init() override;
+	void Shutdown() override;
+
+	// Can't actually clear the cache yet
+	void ClearCache() override {}
+	void SingleStep() override {}
+
+	void Run() override {};
+
+	const char *GetName() override { return "LLVMJIT"; }
+
+	// XXX: Tie our LLVM memory manager and block cache together?
+	JitBaseBlockCache *GetBlockCache() override { return nullptr; }
+
+	void Jit(u32 em_address) override;
+
+	// We don't generate our own ASM routines
+	// We ride on the ASM routines that the tier 1 recompiler uses
+	const CommonAsmRoutinesBase *GetAsmRoutines() override { return nullptr; }
+
+	// We don't actually handle faults...yet
+	bool HandleFault(uintptr_t access_address, SContext* ctx) override { return false; }
+
+	void DoDownCount();
+	void WriteExit(u32 destination);
+	void WriteExitInValue(llvm::Value* destination);
+	void WriteExceptionExit(llvm::Value* val);
+
+	// Opcode
+	void FallBackToInterpreter(LLVMFunction* func, UGeckoInstruction inst);
+	void DoNothing(LLVMFunction* func, UGeckoInstruction inst);
+
+	void DynaRunTable4 (LLVMFunction* func, UGeckoInstruction inst);
+	void DynaRunTable19(LLVMFunction* func, UGeckoInstruction inst);
+	void DynaRunTable31(LLVMFunction* func, UGeckoInstruction inst);
+	void DynaRunTable59(LLVMFunction* func, UGeckoInstruction inst);
+	void DynaRunTable63(LLVMFunction* func, UGeckoInstruction inst);
+
+	// Force break
+	void Break(LLVMFunction* func, UGeckoInstruction inst);
+
+	// Branches
+	void bx(LLVMFunction* func, UGeckoInstruction inst);
+	void bcx(LLVMFunction* func, UGeckoInstruction inst);
+	void bcctrx(LLVMFunction* func, UGeckoInstruction inst);
+	void bclrx(LLVMFunction* func, UGeckoInstruction inst);
+	void sc(LLVMFunction* func, UGeckoInstruction inst);
+	void rfi(LLVMFunction* func, UGeckoInstruction inst);
+	void mtmsr(LLVMFunction* func, UGeckoInstruction inst);
+	void icbi(LLVMFunction* func, UGeckoInstruction inst);
+
+	// Integer
+	void arith_imm(LLVMFunction* func, UGeckoInstruction inst);
+	void rlwXX(LLVMFunction* func, UGeckoInstruction inst);
+	void rlwinmx(LLVMFunction* func, UGeckoInstruction inst);
+	void rlwnmx(LLVMFunction* func, UGeckoInstruction inst);
+	void mulli(LLVMFunction* func, UGeckoInstruction inst);
+	void mullwx(LLVMFunction* func, UGeckoInstruction inst);
+	void mulhwx(LLVMFunction* func, UGeckoInstruction inst);
+	void mulhwux(LLVMFunction* func, UGeckoInstruction inst);
+	void negx(LLVMFunction* func, UGeckoInstruction inst);
+	void subfx(LLVMFunction* func, UGeckoInstruction inst);
+	void xorx(LLVMFunction* func, UGeckoInstruction inst);
+	void orx(LLVMFunction* func, UGeckoInstruction inst);
+	void orcx(LLVMFunction* func, UGeckoInstruction inst);
+	void norx(LLVMFunction* func, UGeckoInstruction inst);
+	void nandx(LLVMFunction* func, UGeckoInstruction inst);
+	void eqvx(LLVMFunction* func, UGeckoInstruction inst);
+	void andx(LLVMFunction* func, UGeckoInstruction inst);
+	void andcx(LLVMFunction* func, UGeckoInstruction inst);
+	void slwx(LLVMFunction* func, UGeckoInstruction inst);
+	void srwx(LLVMFunction* func, UGeckoInstruction inst);
+	void addx(LLVMFunction* func, UGeckoInstruction inst);
+	void cmp(LLVMFunction* func, UGeckoInstruction inst);
+	void cmpi(LLVMFunction* func, UGeckoInstruction inst);
+	void cmpl(LLVMFunction* func, UGeckoInstruction inst);
+	void cmpli(LLVMFunction* func, UGeckoInstruction inst);
+	void extsXx(LLVMFunction* func, UGeckoInstruction inst);
+	void cntlzwx(LLVMFunction* func, UGeckoInstruction inst);
+	void addic(LLVMFunction* func, UGeckoInstruction inst);
+	void addic_rc(LLVMFunction* func, UGeckoInstruction inst);
+	void addcx(LLVMFunction* func, UGeckoInstruction inst);
+	void addex(LLVMFunction* func, UGeckoInstruction inst);
+	void addmex(LLVMFunction* func, UGeckoInstruction inst);
+	void addzex(LLVMFunction* func, UGeckoInstruction inst);
+	void subfcx(LLVMFunction* func, UGeckoInstruction inst);
+	void subfex(LLVMFunction* func, UGeckoInstruction inst);
+	void subfmex(LLVMFunction* func, UGeckoInstruction inst);
+	void subfzex(LLVMFunction* func, UGeckoInstruction inst);
+	void subfic(LLVMFunction* func, UGeckoInstruction inst);
+
+	// System Registers
+	void mtspr(LLVMFunction* func, UGeckoInstruction inst);
+	void mftb(LLVMFunction* func, UGeckoInstruction inst);
+	void mfspr(LLVMFunction* func, UGeckoInstruction inst);
+	void mfmsr(LLVMFunction* func, UGeckoInstruction inst);
+	void mcrf(LLVMFunction* func, UGeckoInstruction inst);
+	void crXX(LLVMFunction* func, UGeckoInstruction inst);
+	void mfsr(LLVMFunction* func, UGeckoInstruction inst);
+	void mfsrin(LLVMFunction* func, UGeckoInstruction inst);
+	void mtsr(LLVMFunction* func, UGeckoInstruction inst);
+	void mtsrin(LLVMFunction* func, UGeckoInstruction inst);
+
+	// Floating Point
+	void fabsx(LLVMFunction* func, UGeckoInstruction inst);
+	void faddsx(LLVMFunction* func, UGeckoInstruction inst);
+	void faddx(LLVMFunction* func, UGeckoInstruction inst);
+	void fmaddsx(LLVMFunction* func, UGeckoInstruction inst);
+	void fmaddx(LLVMFunction* func, UGeckoInstruction inst);
+	void fmrx(LLVMFunction* func, UGeckoInstruction inst);
+	void fmsubsx(LLVMFunction* func, UGeckoInstruction inst);
+	void fmsubx(LLVMFunction* func, UGeckoInstruction inst);
+	void fmulsx(LLVMFunction* func, UGeckoInstruction inst);
+	void fmulx(LLVMFunction* func, UGeckoInstruction inst);
+	void fnabsx(LLVMFunction* func, UGeckoInstruction inst);
+	void fnegx(LLVMFunction* func, UGeckoInstruction inst);
+	void fnmaddsx(LLVMFunction* func, UGeckoInstruction inst);
+	void fnmaddx(LLVMFunction* func, UGeckoInstruction inst);
+	void fnmsubsx(LLVMFunction* func, UGeckoInstruction inst);
+	void fnmsubx(LLVMFunction* func, UGeckoInstruction inst);
+	void fselx(LLVMFunction* func, UGeckoInstruction inst);
+	void fsubsx(LLVMFunction* func, UGeckoInstruction inst);
+	void fsubx(LLVMFunction* func, UGeckoInstruction inst);
+
+	// Paired
+	void ps_abs(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_add(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_sub(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_div(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_madd(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_madds0(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_madds1(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_merge00(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_merge01(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_merge10(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_merge11(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_mr(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_mul(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_muls0(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_muls1(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_msub(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_nabs(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_neg(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_nmadd(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_nmsub(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_sum0(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_sum1(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_res(LLVMFunction* func, UGeckoInstruction inst);
+	void ps_sel(LLVMFunction* func, UGeckoInstruction inst);
+
+	// LoadStore
+	void lwz(LLVMFunction* func, UGeckoInstruction inst);
+	void lwzu(LLVMFunction* func, UGeckoInstruction inst);
+	void lhz(LLVMFunction* func, UGeckoInstruction inst);
+	void lhzu(LLVMFunction* func, UGeckoInstruction inst);
+	void lbz(LLVMFunction* func, UGeckoInstruction inst);
+	void lbzu(LLVMFunction* func, UGeckoInstruction inst);
+	void lha(LLVMFunction* func, UGeckoInstruction inst);
+	void lhau(LLVMFunction* func, UGeckoInstruction inst);
+	void stw(LLVMFunction* func, UGeckoInstruction inst);
+	void stwu(LLVMFunction* func, UGeckoInstruction inst);
+	void sth(LLVMFunction* func, UGeckoInstruction inst);
+	void sthu(LLVMFunction* func, UGeckoInstruction inst);
+	void stb(LLVMFunction* func, UGeckoInstruction inst);
+	void stbu(LLVMFunction* func, UGeckoInstruction inst);
+	void lmw(LLVMFunction* func, UGeckoInstruction inst);
+	void stmw(LLVMFunction* func, UGeckoInstruction inst);
+	void lwzx(LLVMFunction* func, UGeckoInstruction inst);
+	void lwzux(LLVMFunction* func, UGeckoInstruction inst);
+	void lhzx(LLVMFunction* func, UGeckoInstruction inst);
+	void lhzux(LLVMFunction* func, UGeckoInstruction inst);
+	void lhax(LLVMFunction* func, UGeckoInstruction inst);
+	void lhaux(LLVMFunction* func, UGeckoInstruction inst);
+	void lbzx(LLVMFunction* func, UGeckoInstruction inst);
+	void lbzux(LLVMFunction* func, UGeckoInstruction inst);
+	void lwbrx(LLVMFunction* func, UGeckoInstruction inst);
+	void lhbrx(LLVMFunction* func, UGeckoInstruction inst);
+	void stwx(LLVMFunction* func, UGeckoInstruction inst);
+	void stwux(LLVMFunction* func, UGeckoInstruction inst);
+	void sthx(LLVMFunction* func, UGeckoInstruction inst);
+	void sthux(LLVMFunction* func, UGeckoInstruction inst);
+	void stbx(LLVMFunction* func, UGeckoInstruction inst);
+	void stbux(LLVMFunction* func, UGeckoInstruction inst);
+	void stwbrx(LLVMFunction* func, UGeckoInstruction inst);
+	void sthbrx(LLVMFunction* func, UGeckoInstruction inst);
+	void stfiwx(LLVMFunction* func, UGeckoInstruction inst);
+
+	// LoadStore Floating
+	void lfs(LLVMFunction* func, UGeckoInstruction inst);
+	void lfsu(LLVMFunction* func, UGeckoInstruction inst);
+	void lfd(LLVMFunction* func, UGeckoInstruction inst);
+	void lfdu(LLVMFunction* func, UGeckoInstruction inst);
+	void stfs(LLVMFunction* func, UGeckoInstruction inst);
+	void stfsu(LLVMFunction* func, UGeckoInstruction inst);
+	void stfd(LLVMFunction* func, UGeckoInstruction inst);
+	void stfdu(LLVMFunction* func, UGeckoInstruction inst);
+	void lfsx(LLVMFunction* func, UGeckoInstruction inst);
+	void lfsux(LLVMFunction* func, UGeckoInstruction inst);
+	void lfdx(LLVMFunction* func, UGeckoInstruction inst);
+	void lfdux(LLVMFunction* func, UGeckoInstruction inst);
+	void stfsx(LLVMFunction* func, UGeckoInstruction inst);
+	void stfsux(LLVMFunction* func, UGeckoInstruction inst);
+	void stfdx(LLVMFunction* func, UGeckoInstruction inst);
+	void stfdux(LLVMFunction* func, UGeckoInstruction inst);
+
+	// LoadStore Paired
+	void psq_lXX(LLVMFunction* func, UGeckoInstruction inst);
+};

--- a/Source/Core/Core/PowerPC/JitLLVM/JitBinding.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitBinding.cpp
@@ -1,0 +1,77 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Common/MemoryUtil.h"
+#include "Core/PowerPC/JitLLVM/JitBinding.h"
+
+using namespace llvm;
+
+void* LLVMNamedBinding::GetBinding(const std::string& name)
+{
+	auto binding = m_named_map.find(name);
+	if (binding == m_named_map.end())
+		return nullptr;
+	return binding->second;
+}
+
+void LLVMNamedBinding::Bind(const std::string& Name, void* address)
+{
+	m_named_map[Name] = address;
+}
+
+Function* LLVMBinding::GetBinding(void* address)
+{
+	auto binding = m_map.find(address);
+	if (binding == m_map.end())
+		return nullptr;
+	return binding->second;
+}
+
+void LLVMBinding::Bind(llvm::Function* stub, void* address)
+{
+	if (!m_engine->getPointerToGlobalIfAvailable(stub))
+		m_engine->addGlobalMapping(stub, address);
+
+	m_map[address] = stub;
+	m_named_binding->Bind(stub->getName(), address);
+}
+
+// Memory Management
+LLVMMemoryManager::~LLVMMemoryManager()
+{
+	for (auto& it : m_code_sections)
+		FreeMemoryPages(it.second.first, it.second.second);
+
+	for (auto& it : m_data_sections)
+		free(it.second);
+
+	m_code_sections.clear();
+	m_data_sections.clear();
+}
+
+uint8_t *LLVMMemoryManager::allocateCodeSection(
+	uintptr_t Size, unsigned Alignment, unsigned SectionID,
+	StringRef SectionName)
+{
+	// XXX: Respect alignment
+	uint8_t* section = (uint8_t*)AllocateExecutableMemory(Size);
+	m_code_sections[SectionID] = std::make_pair(section, Size);
+	return section;
+}
+
+uint8_t *LLVMMemoryManager::allocateDataSection(
+	uintptr_t Size, unsigned Alignment, unsigned SectionID,
+	StringRef SectionName, bool IsReadOnly)
+{
+	// XXX: Respect alignment
+	uint8_t* section = (uint8_t*)malloc(Size);
+	m_data_sections[SectionID] = section;
+	return section;
+}
+
+bool LLVMMemoryManager::finalizeMemory(std::string *ErrMsg)
+{
+	return true;
+}
+

--- a/Source/Core/Core/PowerPC/JitLLVM/JitBinding.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitBinding.cpp
@@ -44,33 +44,33 @@ LLVMMemoryManager::~LLVMMemoryManager()
 		FreeMemoryPages(it.second.first, it.second.second);
 
 	for (auto& it : m_data_sections)
-		free(it.second);
+		delete[] it.second;
 
 	m_code_sections.clear();
 	m_data_sections.clear();
 }
 
-uint8_t *LLVMMemoryManager::allocateCodeSection(
+u8* LLVMMemoryManager::allocateCodeSection(
 	uintptr_t Size, unsigned Alignment, unsigned SectionID,
 	StringRef SectionName)
 {
 	// XXX: Respect alignment
-	uint8_t* section = (uint8_t*)AllocateExecutableMemory(Size);
+	u8* section = (u8*)AllocateExecutableMemory(Size);
 	m_code_sections[SectionID] = std::make_pair(section, Size);
 	return section;
 }
 
-uint8_t *LLVMMemoryManager::allocateDataSection(
+u8* LLVMMemoryManager::allocateDataSection(
 	uintptr_t Size, unsigned Alignment, unsigned SectionID,
 	StringRef SectionName, bool IsReadOnly)
 {
 	// XXX: Respect alignment
-	uint8_t* section = (uint8_t*)malloc(Size);
+	u8* section = new u8(Size);
 	m_data_sections[SectionID] = section;
 	return section;
 }
 
-bool LLVMMemoryManager::finalizeMemory(std::string *ErrMsg)
+bool LLVMMemoryManager::finalizeMemory(std::string* ErrMsg)
 {
 	return true;
 }

--- a/Source/Core/Core/PowerPC/JitLLVM/JitBinding.h
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitBinding.h
@@ -49,8 +49,8 @@ class LLVMMemoryManager : public llvm::RTDyldMemoryManager
 private:
 	LLVMNamedBinding* m_binder;
 
-	std::unordered_map<unsigned, std::pair<uint8_t*, uint64_t>> m_code_sections;
-	std::unordered_map<unsigned, uint8_t*> m_data_sections;
+	std::unordered_map<unsigned, std::pair<u8*, u64>> m_code_sections;
+	std::unordered_map<unsigned, u8*> m_data_sections;
 
 public:
 	LLVMMemoryManager(LLVMNamedBinding* binder)
@@ -65,11 +65,11 @@ public:
 
 	/// This method returns the address of the specified function or variable.
 	/// It is used to resolve symbols during module linking.
-	uint64_t getSymbolAddress(const std::string &Name) override
+	u64 getSymbolAddress(const std::string &Name) override
 	{
 		void* our_bind = m_binder->GetBinding(Name);
 		if (our_bind)
-			return (uint64_t)our_bind;
+			return (u64)our_bind;
 		else
 			return llvm::RTDyldMemoryManager::getSymbolAddressInProcess(Name);
 	}
@@ -78,14 +78,14 @@ public:
 	/// executable code. The SectionID is a unique identifier assigned by the JIT
 	/// engine, and optionally recorded by the memory manager to access a loaded
 	/// section.
-	uint8_t *allocateCodeSection(
+	u8* allocateCodeSection(
 		uintptr_t Size, unsigned Alignment, unsigned SectionID,
 		llvm::StringRef SectionName) override;
 
 	/// Allocate a memory block of (at least) the given size suitable for data.
 	/// The SectionID is a unique identifier assigned by the JIT engine, and
 	/// optionally recorded by the memory manager to access a loaded section.
-	uint8_t *allocateDataSection(
+	u8* allocateDataSection(
 		uintptr_t Size, unsigned Alignment, unsigned SectionID,
 		llvm::StringRef SectionName, bool IsReadOnly) override;
 
@@ -99,5 +99,5 @@ public:
 	/// operations needed to reliably use the memory are also performed.
 	///
 	/// Returns true if an error occurred, false otherwise.
-	bool finalizeMemory(std::string *ErrMsg = nullptr) override;
+	bool finalizeMemory(std::string* ErrMsg = nullptr) override;
 };

--- a/Source/Core/Core/PowerPC/JitLLVM/JitBinding.h
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitBinding.h
@@ -1,0 +1,103 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+class LLVMNamedBinding
+{
+private:
+	std::unordered_map<std::string, void*> m_named_map;
+
+public:
+	void* GetBinding(const std::string& name);
+	void Bind(const std::string& Name, void* address);
+};
+
+class LLVMBinding
+{
+private:
+	llvm::ExecutionEngine* m_engine;
+	llvm::Module* m_mod;
+	LLVMNamedBinding* m_named_binding;
+
+	std::unordered_map<void*, llvm::Function*> m_map;
+
+public:
+	LLVMBinding(llvm::ExecutionEngine* engine, llvm::Module* mod, LLVMNamedBinding* named_binder)
+		: m_engine(engine), m_mod(mod), m_named_binding(named_binder)
+	{}
+
+	llvm::Function* GetBinding(void* address);
+	void Bind(llvm::Function* stub, void* address);
+
+	// Named bindings
+	void* GetBinding(const std::string& name) { return m_named_binding->GetBinding(name); }
+	void Bind(const std::string& Name, void* address);
+};
+
+// This is a super annoying class that needs to be implemented to get custom symbol resolving
+class LLVMMemoryManager : public llvm::RTDyldMemoryManager
+{
+private:
+	LLVMNamedBinding* m_binder;
+
+	std::unordered_map<unsigned, std::pair<uint8_t*, uint64_t>> m_code_sections;
+	std::unordered_map<unsigned, uint8_t*> m_data_sections;
+
+public:
+	LLVMMemoryManager(LLVMNamedBinding* binder)
+		: m_binder(binder)
+	{}
+	~LLVMMemoryManager();
+
+	void SetNamedBinder(LLVMNamedBinding* binder)
+	{
+		m_binder = binder;
+	}
+
+	/// This method returns the address of the specified function or variable.
+	/// It is used to resolve symbols during module linking.
+	uint64_t getSymbolAddress(const std::string &Name) override
+	{
+		void* our_bind = m_binder->GetBinding(Name);
+		if (our_bind)
+			return (uint64_t)our_bind;
+		else
+			return llvm::RTDyldMemoryManager::getSymbolAddressInProcess(Name);
+	}
+
+	/// Allocate a memory block of (at least) the given size suitable for
+	/// executable code. The SectionID is a unique identifier assigned by the JIT
+	/// engine, and optionally recorded by the memory manager to access a loaded
+	/// section.
+	uint8_t *allocateCodeSection(
+		uintptr_t Size, unsigned Alignment, unsigned SectionID,
+		llvm::StringRef SectionName) override;
+
+	/// Allocate a memory block of (at least) the given size suitable for data.
+	/// The SectionID is a unique identifier assigned by the JIT engine, and
+	/// optionally recorded by the memory manager to access a loaded section.
+	uint8_t *allocateDataSection(
+		uintptr_t Size, unsigned Alignment, unsigned SectionID,
+		llvm::StringRef SectionName, bool IsReadOnly) override;
+
+
+	/// This method is called when object loading is complete and section page
+	/// permissions can be applied.  It is up to the memory manager implementation
+	/// to decide whether or not to act on this method.  The memory manager will
+	/// typically allocate all sections as read-write and then apply specific
+	/// permissions when this method is called.  Code sections cannot be executed
+	/// until this function has been called.  In addition, any cache coherency
+	/// operations needed to reliably use the memory are also performed.
+	///
+	/// Returns true if an error occurred, false otherwise.
+	bool finalizeMemory(std::string *ErrMsg = nullptr) override;
+};

--- a/Source/Core/Core/PowerPC/JitLLVM/JitFunction.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitFunction.cpp
@@ -1,0 +1,485 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/PowerPC/JitLLVM/JitFunction.h"
+
+using namespace llvm;
+
+LLVMFunction::LLVMFunction(Module* mod, u32 address, FunctionType* type)
+	: m_builder(mod->getContext())
+{
+	m_mod = mod;
+	m_address = address;
+
+	//
+	memset(&m_ptrs, 0, sizeof(m_ptrs));
+
+	std::string func_name = StringFromFormat("ppc%08x", address);
+
+	LLVMContext& con = getGlobalContext();
+
+	// Generate the function
+	m_func = Function::Create(
+		type,
+		Function::ExternalLinkage,
+		func_name,
+		m_mod);
+	m_func->setCallingConv(CallingConv::C);
+
+	BasicBlock* block = BasicBlock::Create(con, "entry", m_func);
+	m_builder.SetInsertPoint(block);
+}
+
+LLVMFunction::LLVMFunction(Module* mod, const std::string& name, FunctionType* type)
+	: m_builder(mod->getContext())
+{
+	m_mod = mod;
+
+	//
+	memset(&m_ptrs, 0, sizeof(m_ptrs));
+
+	LLVMContext& con = getGlobalContext();
+
+	// Generate the function
+	m_func = Function::Create(
+		type,
+		Function::ExternalLinkage,
+		name,
+		m_mod);
+	m_func->setCallingConv(CallingConv::C);
+
+	BasicBlock* block = BasicBlock::Create(con, "entry", m_func);
+	m_builder.SetInsertPoint(block);
+}
+
+void LLVMFunction::BuildGEPs()
+{
+	// Build our GEPs
+	GetPPCState();
+	GetPCGEP();
+	GetNPCGEP();
+	for (int i = 0; i < 8; ++i)
+		GetCRGEP(i);
+	GetMSRGEP();
+	GetEXCGEP();
+	GetCTRGEP();
+	GetLRGEP();
+}
+
+LoadInst* LLVMFunction::GetPPCState()
+{
+	if (!m_ptrs.m_ppcstate)
+	{
+		GlobalVariable* ppcStatePtr_global = m_mod->getNamedGlobal("ppcState_ptr");
+		m_ptrs.m_ppcstate = m_builder.CreateLoad(ppcStatePtr_global, m_builder.getInt32(0), "ppcState");
+	}
+
+	return m_ptrs.m_ppcstate;
+}
+
+Value* LLVMFunction::GetPCGEP()
+{
+	if (!m_ptrs.m_PCGEP)
+	{
+		Value* ppcState = GetPPCState();
+
+		const std::vector<Value*> pc_loc =
+		{
+			m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+			m_builder.getInt32(INDEX_PC), // 1th index in to index in structs(PC)
+		};
+
+		m_ptrs.m_PCGEP = m_builder.CreateGEP(ppcState, pc_loc, "PC");
+	}
+
+	return m_ptrs.m_PCGEP;
+}
+
+Value* LLVMFunction::GetNPCGEP()
+{
+	if (!m_ptrs.m_NPCGEP)
+	{
+		Value* ppcState = GetPPCState();
+
+		const std::vector<Value*> ctr_loc =
+		{
+			m_builder.getInt32(0), // 0th index in to the PowerNPCState "array"
+			m_builder.getInt32(INDEX_NPC), // 1th index in to index in structs(NPC)
+		};
+
+		m_ptrs.m_NPCGEP = m_builder.CreateGEP(ppcState, ctr_loc, "NPC");
+	}
+
+	return m_ptrs.m_NPCGEP;
+}
+
+Value* LLVMFunction::GetCTRGEP()
+{
+	if (!m_ptrs.m_CTRGEP)
+	{
+		Value* ppcState = GetPPCState();
+
+		const std::vector<Value*> ctr_loc =
+		{
+			m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+			m_builder.getInt32(INDEX_SPR), // 1th index in to index in structs(PC)
+			m_builder.getInt32(SPR_CTR),
+		};
+
+		m_ptrs.m_CTRGEP = m_builder.CreateGEP(ppcState, ctr_loc, "CTR");
+	}
+
+	return m_ptrs.m_CTRGEP;
+}
+
+Value* LLVMFunction::GetMSRGEP()
+{
+	if (!m_ptrs.m_MSRGEP)
+	{
+		Value* ppcState = GetPPCState();
+
+		const std::vector<Value*> ctr_loc =
+		{
+			m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+			m_builder.getInt32(INDEX_MSR), // 1th index in to index in structs(PC)
+		};
+
+		m_ptrs.m_MSRGEP = m_builder.CreateGEP(ppcState, ctr_loc, "MSR");
+	}
+
+	return m_ptrs.m_MSRGEP;
+}
+
+Value* LLVMFunction::GetEXCGEP()
+{
+	if (!m_ptrs.m_EXCGEP)
+	{
+		Value* ppcState = GetPPCState();
+
+		const std::vector<Value*> exc_loc =
+		{
+			m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+			m_builder.getInt32(INDEX_EXCEPTIONS),
+		};
+
+		m_ptrs.m_EXCGEP = m_builder.CreateGEP(ppcState, exc_loc, "Exceptions");
+	}
+
+	return m_ptrs.m_EXCGEP;
+}
+
+Value* LLVMFunction::GetCRGEP(int field)
+{
+	if (!m_ptrs.m_CRGEP[field])
+	{
+		Value* ppcState = GetPPCState();
+
+		const std::vector<Value*> cr_loc =
+		{
+			m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+			m_builder.getInt32(INDEX_CR), // 1th index in to index in structs(PC)
+			m_builder.getInt32(field),
+		};
+
+		m_ptrs.m_CRGEP[field] = m_builder.CreateGEP(ppcState, cr_loc, StringFromFormat("CR%d", field));
+	}
+
+	return m_ptrs.m_CRGEP[field];
+}
+
+Value* LLVMFunction::GetLRGEP()
+{
+	if (!m_ptrs.m_LRGEP)
+	{
+		Value* ppcState = GetPPCState();
+
+		const std::vector<Value*> lr_loc =
+		{
+			m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+			m_builder.getInt32(INDEX_SPR), // 1th index in to index in structs(PC)
+			m_builder.getInt32(SPR_LR),
+		};
+
+		m_ptrs.m_LRGEP = m_builder.CreateGEP(ppcState, lr_loc, "LR");
+	}
+
+	return m_ptrs.m_LRGEP;
+}
+
+LoadInst* LLVMFunction::LoadPC()
+{
+	return m_builder.CreateLoad(GetPCGEP());
+}
+
+LoadInst* LLVMFunction::LoadNPC()
+{
+	return m_builder.CreateLoad(GetNPCGEP());
+}
+
+LoadInst* LLVMFunction::LoadCTR()
+{
+	return m_builder.CreateLoad(GetCTRGEP());
+}
+
+LoadInst* LLVMFunction::LoadMSR()
+{
+	return m_builder.CreateLoad(GetMSRGEP());
+}
+
+LoadInst* LLVMFunction::LoadExceptions()
+{
+	return m_builder.CreateLoad(GetEXCGEP());
+}
+
+LoadInst* LLVMFunction::LoadCR(int field)
+{
+	return m_builder.CreateLoad(GetCRGEP(field));
+}
+
+LoadInst* LLVMFunction::LoadLR()
+{
+	return m_builder.CreateLoad(GetLRGEP());
+}
+
+LoadInst* LLVMFunction::LoadSPR(int spr)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> spr_loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_SPR), // 0th index in to index in structs(SPRs)
+		m_builder.getInt32(spr),
+	};
+
+	Value* spr_val = m_builder.CreateGEP(ppcState, spr_loc);
+	return m_builder.CreateLoad(spr_val, StringFromFormat("SPR_%d", spr));
+}
+
+Value* LLVMFunction::LoadCarry()
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_XER_CA),
+	};
+
+	Value* val = m_builder.CreateGEP(ppcState, loc);
+	Value* carry = m_builder.CreateLoad(val, "Carry");
+	return m_builder.CreateTrunc(carry, m_builder.getInt1Ty());
+}
+
+LoadInst* LLVMFunction::LoadSR(Value* sr)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_SR),
+		sr
+	};
+
+	Value* sr_val = m_builder.CreateGEP(ppcState, loc);
+	return m_builder.CreateLoad(sr_val);
+}
+
+LoadInst* LLVMFunction::LoadGQR(int gqr)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> spr_loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_SPR), // 0th index in to index in structs(SPRs)
+		m_builder.getInt32(SPR_GQR0 + gqr),
+	};
+
+	Value* spr_val = m_builder.CreateGEP(ppcState, spr_loc);
+	return m_builder.CreateLoad(spr_val, StringFromFormat("GQR_%d", gqr));
+}
+
+LoadInst* LLVMFunction::LoadDownCount()
+{
+	Value* ppcState = GetPPCState();
+
+	std::vector<Value*> downcount_loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_DOWNCOUNT), // 7th index in to index in structs(downcount)
+	};
+
+	Value* downcount = m_builder.CreateGEP(ppcState, downcount_loc, "Downcount");
+	return m_builder.CreateLoad(downcount);
+}
+
+void LLVMFunction::StorePC(Value* val)
+{
+	m_builder.CreateStore(val, GetPCGEP());
+}
+
+void LLVMFunction::StoreNPC(Value* val)
+{
+	m_builder.CreateStore(val, GetNPCGEP());
+}
+
+void LLVMFunction::StoreCTR(Value* val)
+{
+	m_builder.CreateStore(val, GetCTRGEP());
+}
+
+void LLVMFunction::StoreMSR(Value* val)
+{
+	m_builder.CreateStore(val, GetMSRGEP());
+}
+
+void LLVMFunction::StoreExceptions(Value* val)
+{
+	m_builder.CreateStore(val, GetEXCGEP());
+}
+
+void LLVMFunction::StoreCR(Value* val, int field)
+{
+	m_builder.CreateStore(val, GetCRGEP(field));
+}
+
+void LLVMFunction::StoreLR(Value* val)
+{
+	m_builder.CreateStore(val, GetLRGEP());
+}
+
+LoadInst* LLVMFunction::LoadGPR(int reg)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> gpr_loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_GPR), // 0th index in to index in structs(GPRS)
+		m_builder.getInt32(reg),
+	};
+
+	Value* gpr = m_builder.CreateGEP(ppcState, gpr_loc);
+	return m_builder.CreateLoad(gpr, StringFromFormat("GPR_%d", reg));
+}
+
+LoadInst* LLVMFunction::LoadFPR(int reg, bool ps1)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> fpr_loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_PS),
+		m_builder.getInt32(reg),
+		m_builder.getInt32(ps1),
+	};
+
+	Value* fpr = m_builder.CreateGEP(ppcState, fpr_loc);
+	return m_builder.CreateLoad(fpr, StringFromFormat("FPR_%d_%d", reg, ps1));
+}
+
+void LLVMFunction::StoreSPR(Value* val, int spr)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> spr_loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_SPR), // 0th index in to index in structs(SPRs)
+		m_builder.getInt32(spr),
+	};
+
+	Value* spr_gep = m_builder.CreateGEP(ppcState, spr_loc);
+	m_builder.CreateStore(val, spr_gep);
+}
+
+void LLVMFunction::StoreCarry(Value* val)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_XER_CA),
+	};
+
+	Value* gep = m_builder.CreateGEP(ppcState, loc);
+	Value* res = m_builder.CreateZExt(val, m_builder.getInt8Ty());
+	m_builder.CreateStore(res, gep);
+}
+
+void LLVMFunction::StoreSR(Value* val, Value* sr)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_SR),
+		sr,
+	};
+
+	Value* sr_val = m_builder.CreateGEP(ppcState, loc);
+	m_builder.CreateStore(val, sr_val);
+}
+
+void LLVMFunction::StoreDownCount(Value* val)
+{
+	Value* ppcState = GetPPCState();
+
+	std::vector<Value*> downcount_loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_DOWNCOUNT), // 7th index in to index in structs(downcount)
+	};
+
+	Value* downcount = m_builder.CreateGEP(ppcState, downcount_loc, "Downcount");
+	m_builder.CreateStore(val, downcount);
+}
+
+void LLVMFunction::StoreGPR(Value* val, int reg)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> gpr_loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_GPR), // 0th index in to index in structs(GPRS)
+		m_builder.getInt32(reg),
+	};
+
+	Value* gpr = m_builder.CreateGEP(ppcState, gpr_loc);
+	m_builder.CreateStore(val, gpr);
+}
+
+void LLVMFunction::StoreFPR(Value* val, int reg, bool ps1)
+{
+	Value* ppcState = GetPPCState();
+
+	const std::vector<Value*> fpr_loc =
+	{
+		m_builder.getInt32(0), // 0th index in to the PowerPCState "array"
+		m_builder.getInt32(INDEX_PS),
+		m_builder.getInt32(reg),
+		m_builder.getInt32(ps1),
+	};
+
+	Value* fpr = m_builder.CreateGEP(ppcState, fpr_loc);
+	val = m_builder.CreateFPExt(val, m_builder.getDoubleTy());
+	m_builder.CreateStore(val, fpr);
+}
+
+BasicBlock* LLVMFunction::CreateBlock(const std::string& name)
+{
+	return BasicBlock::Create(m_mod->getContext(), name, m_func, nullptr);
+}
+
+void LLVMFunction::AddBlock(BasicBlock* block)
+{
+	m_func->getBasicBlockList().push_back(block);
+}
+

--- a/Source/Core/Core/PowerPC/JitLLVM/JitFunction.h
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitFunction.h
@@ -1,0 +1,98 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+enum
+{
+	INDEX_GPR,
+	INDEX_PC,
+	INDEX_NPC,
+	INDEX_CR,
+	INDEX_MSR,
+	INDEX_FPSCR,
+	INDEX_EXCEPTIONS,
+	INDEX_DOWNCOUNT,
+	INDEX_XER_CA,
+	INDEX_XER_SO_OV,
+	INDEX_XER_STRCTL,
+	INDEX_PS,
+	INDEX_SR,
+	INDEX_SPR,
+};
+
+
+class LLVMFunction
+{
+private:
+	llvm::Module* m_mod;
+	llvm::Function* m_func;
+	llvm::IRBuilder<> m_builder;
+	u32 m_address;
+
+	// Helper values
+	struct
+	{
+		llvm::LoadInst* m_ppcstate;
+		llvm::Value* m_PCGEP;
+		llvm::Value* m_NPCGEP;
+		llvm::Value* m_CRGEP[8];
+		llvm::Value* m_MSRGEP;
+		llvm::Value* m_EXCGEP;
+		llvm::Value* m_CTRGEP;
+		llvm::Value* m_LRGEP;
+	} m_ptrs;
+
+	llvm::Value* GetPCGEP();
+	llvm::Value* GetNPCGEP();
+	llvm::Value* GetCRGEP(int field);
+	llvm::Value* GetMSRGEP();
+	llvm::Value* GetEXCGEP();
+	llvm::Value* GetCTRGEP();
+	llvm::Value* GetLRGEP();
+
+public:
+
+	LLVMFunction(llvm::Module* mod, u32 address, llvm::FunctionType* type);
+	LLVMFunction(llvm::Module* mod, const std::string& name, llvm::FunctionType* type);
+
+	llvm::Function* GetFunction() { return m_func; }
+	llvm::IRBuilder<>* GetBuilder() { return &m_builder; }
+
+	void BuildGEPs();
+
+	// Helpers
+	llvm::LoadInst* GetPPCState();
+	llvm::LoadInst* LoadPC();
+	llvm::LoadInst* LoadNPC();
+	llvm::LoadInst* LoadCTR();
+	llvm::LoadInst* LoadMSR();
+	llvm::LoadInst* LoadExceptions();
+	llvm::LoadInst* LoadCR(int field);
+	llvm::LoadInst* LoadLR();
+	llvm::LoadInst* LoadSPR(int spr);
+	llvm::Value*    LoadCarry();
+	llvm::LoadInst* LoadSR(llvm::Value* sr);
+	llvm::LoadInst* LoadGQR(int gqr);
+	llvm::LoadInst* LoadDownCount();
+	void StorePC(llvm::Value* val);
+	void StoreNPC(llvm::Value* val);
+	void StoreCTR(llvm::Value* val);
+	void StoreCR(llvm::Value* val, int field);
+	void StoreLR(llvm::Value* val);
+	void StoreMSR(llvm::Value* val);
+	void StoreExceptions(llvm::Value* val);
+	void StoreSPR(llvm::Value* val, int spr);
+	void StoreCarry(llvm::Value* val);
+	void StoreSR(llvm::Value* val, llvm::Value* sr);
+	void StoreDownCount(llvm::Value* val);
+	llvm::LoadInst* LoadGPR(int reg);
+	void StoreGPR(llvm::Value* val, int reg);
+	llvm::LoadInst* LoadFPR(int reg, bool ps1);
+	void StoreFPR(llvm::Value* val, int reg, bool ps1);
+
+	llvm::BasicBlock* CreateBlock(const std::string& name);
+	void AddBlock(llvm::BasicBlock* block);
+};

--- a/Source/Core/Core/PowerPC/JitLLVM/JitHelpers.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitHelpers.cpp
@@ -1,0 +1,9 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/PowerPC/JitLLVM/JitHelpers.h"
+
+using namespace llvm;
+
+

--- a/Source/Core/Core/PowerPC/JitLLVM/JitHelpers.h
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitHelpers.h
@@ -1,0 +1,15 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+template<typename... Args>
+llvm::FunctionType* GenerateFunctionType(llvm::Type* ret_type, Args... args)
+{
+	std::vector<llvm::Type*> types = {args...};
+	return llvm::FunctionType::get(ret_type, types, false);
+}
+

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Branch.cpp
@@ -100,7 +100,9 @@ void JitLLVM::bcx(LLVMFunction* func, UGeckoInstruction inst)
 		builder->CreateCondBr(ctr_cmp, do_branch, cr_branch);
 	}
 	else
+	{
 		builder->CreateBr(cr_branch);
+	}
 
 	builder->SetInsertPoint(cr_branch);
 	if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)  // Test a CR bit
@@ -110,7 +112,9 @@ void JitLLVM::bcx(LLVMFunction* func, UGeckoInstruction inst)
 		builder->CreateCondBr(cr_cmp, do_branch, no_branch);
 	}
 	else
+	{
 		builder->CreateBr(do_branch);
+	}
 
 	builder->SetInsertPoint(do_branch);
 	{
@@ -200,7 +204,9 @@ void JitLLVM::bclrx(LLVMFunction* func, UGeckoInstruction inst)
 		builder->CreateCondBr(ctr_cmp, do_branch, cr_branch);
 	}
 	else
+	{
 		builder->CreateBr(cr_branch);
+	}
 
 	builder->SetInsertPoint(cr_branch);
 	if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)  // Test a CR bit
@@ -210,7 +216,9 @@ void JitLLVM::bclrx(LLVMFunction* func, UGeckoInstruction inst)
 		builder->CreateCondBr(cr_cmp, do_branch, no_branch);
 	}
 	else
+	{
 		builder->CreateBr(do_branch);
+	}
 
 	builder->SetInsertPoint(do_branch);
 	{

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Branch.cpp
@@ -1,0 +1,288 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+using namespace llvm;
+
+void JitLLVM::bx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 destination;
+	if (inst.AA)
+		destination = SignExt26(inst.LI << 2);
+	else
+		destination = js.compilerPC + SignExt26(inst.LI << 2);
+
+	if (inst.LK)
+	{
+		Value* new_lr = builder->getInt32(js.compilerPC + 4);
+		func->StoreLR(new_lr);
+	}
+
+	if (destination == js.compilerPC)
+		js.downcountAmount += 8;
+
+	WriteExit(destination);
+}
+
+Value* JitLLVM::JumpIfCRFieldBit(LLVMFunction* func, int field, int bit, bool jump_if_set)
+{
+	LLVMContext& con = getGlobalContext();
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* cr_cmp, *tmp_val;
+	Value* zero = builder->getInt64(0);
+	LoadInst* cr_val = func->LoadCR(field);
+	switch (bit)
+	{
+	case CR_SO_BIT:  // check bit 61 set
+		tmp_val = builder->CreateAnd(cr_val, builder->getInt64(1ULL << 61));
+		if (jump_if_set)
+			cr_cmp = builder->CreateICmpNE(tmp_val, zero);
+		else
+			cr_cmp = builder->CreateICmpEQ(tmp_val, zero);
+	break;
+	case CR_EQ_BIT:  // check bits 31-0 == 0
+		tmp_val = builder->CreateAnd(cr_val, builder->getInt64(0xFFFFFFFF));
+		if (jump_if_set)
+			cr_cmp = builder->CreateICmpEQ(tmp_val, zero);
+		else
+			cr_cmp = builder->CreateICmpNE(tmp_val, zero);
+	break;
+	case CR_GT_BIT:  // check val > 0
+		if (jump_if_set)
+			cr_cmp = builder->CreateICmpSGT(cr_val, zero);
+		else
+			cr_cmp = builder->CreateICmpSLE(cr_val, zero);
+	break;
+	case CR_LT_BIT:  // check bit 62 set
+		tmp_val = builder->CreateAnd(cr_val, builder->getInt64(1ULL << 62));
+		if (jump_if_set)
+			cr_cmp = builder->CreateICmpNE(tmp_val, zero);
+		else
+			cr_cmp = builder->CreateICmpEQ(tmp_val, zero);
+	break;
+	default:
+		_assert_msg_(DYNA_REC, false, "Invalid CR bit");
+		cr_cmp = UndefValue::get(Type::getInt64Ty(con));
+	}
+
+	return cr_cmp;
+}
+
+void JitLLVM::bcx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	BasicBlock* do_branch = func->CreateBlock("bcx_do_branch");
+	BasicBlock* no_branch = js.isLastInstruction ? nullptr : func->CreateBlock("bcx_no_branch");
+	BasicBlock* cr_branch = func->CreateBlock("bcx_cr_test");
+
+	if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
+	{
+		LoadInst* ctr = func->LoadCTR();
+		Value* new_ctr = builder->CreateSub(ctr, builder->getInt32(1));
+		func->StoreCTR(new_ctr);
+
+		Value* ctr_cmp;
+		if (inst.BO & BO_BRANCH_IF_CTR_0)
+			ctr_cmp = builder->CreateICmpNE(new_ctr, builder->getInt32(0));
+		else
+			ctr_cmp = builder->CreateICmpEQ(new_ctr, builder->getInt32(0));
+
+		builder->CreateCondBr(ctr_cmp, do_branch, cr_branch);
+	}
+	else
+		builder->CreateBr(cr_branch);
+
+	builder->SetInsertPoint(cr_branch);
+	if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)  // Test a CR bit
+	{
+		Value* cr_cmp = JumpIfCRFieldBit(func, inst.BI >> 2, 3 - (inst.BI & 3),
+		                                 !(inst.BO_2 & BO_BRANCH_IF_TRUE));
+		builder->CreateCondBr(cr_cmp, do_branch, no_branch);
+	}
+	else
+		builder->CreateBr(do_branch);
+
+	builder->SetInsertPoint(do_branch);
+	{
+		if (inst.LK)
+		{
+			Value* new_lr = builder->getInt32(js.compilerPC + 4);
+			func->StoreLR(new_lr);
+		}
+
+		u32 destination;
+		if (inst.AA)
+			destination = SignExt16(inst.BD << 2);
+		else
+			destination = js.compilerPC + SignExt16(inst.BD << 2);
+
+		WriteExit(destination);
+	}
+
+	builder->SetInsertPoint(no_branch);
+
+	if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
+		WriteExit(js.compilerPC + 4);
+}
+
+void JitLLVM::bcctrx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	// bcctrx doesn't decrement and/or test CTR
+	_dbg_assert_msg_(POWERPC, inst.BO_2 & BO_DONT_DECREMENT_FLAG, "bcctrx with decrement and test CTR option is invalid!");
+	if (inst.BO_2 & BO_DONT_CHECK_CONDITION)
+	{
+		Value* ctr = func->LoadSPR(SPR_CTR);
+		if (inst.LK_3)
+			func->StoreLR(builder->getInt32(js.compilerPC + 4));
+		ctr = builder->CreateAnd(ctr, builder->getInt32(~3));
+		WriteExitInValue(ctr);
+	}
+	else
+	{
+		BasicBlock* do_branch = func->CreateBlock("bcctrx_do_branch");
+		BasicBlock* no_branch = js.isLastInstruction ? nullptr : func->CreateBlock("bcctrx_no_branch");
+
+		Value* cr_cmp = JumpIfCRFieldBit(func, inst.BI >> 2, 3 - (inst.BI & 3),
+		                                 !(inst.BO_2 & BO_BRANCH_IF_TRUE));
+		builder->CreateCondBr(cr_cmp, do_branch, no_branch);
+
+		builder->SetInsertPoint(do_branch);
+		{
+			Value* ctr = func->LoadSPR(SPR_CTR);
+			if (inst.LK_3)
+				func->StoreLR(builder->getInt32(js.compilerPC + 4));
+			ctr = builder->CreateAnd(ctr, builder->getInt32(~3));
+			WriteExitInValue(ctr);
+		}
+
+		builder->SetInsertPoint(no_branch);
+
+		if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
+			WriteExit(js.compilerPC + 4);
+	}
+}
+void JitLLVM::bclrx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	BasicBlock* do_branch = func->CreateBlock("bclrx_do_branch");
+	BasicBlock* no_branch = js.isLastInstruction ? nullptr : func->CreateBlock("bclrx_no_branch");
+	BasicBlock* cr_branch = func->CreateBlock("bclrx_cr_test");
+
+	if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
+	{
+		LoadInst* ctr = func->LoadCTR();
+		Value* new_ctr = builder->CreateSub(ctr, builder->getInt32(1));
+		func->StoreCTR(new_ctr);
+
+		Value* ctr_cmp;
+		if (inst.BO & BO_BRANCH_IF_CTR_0)
+			ctr_cmp = builder->CreateICmpNE(new_ctr, builder->getInt32(0));
+		else
+			ctr_cmp = builder->CreateICmpEQ(new_ctr, builder->getInt32(0));
+
+		builder->CreateCondBr(ctr_cmp, do_branch, cr_branch);
+	}
+	else
+		builder->CreateBr(cr_branch);
+
+	builder->SetInsertPoint(cr_branch);
+	if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)  // Test a CR bit
+	{
+		Value* cr_cmp = JumpIfCRFieldBit(func, inst.BI >> 2, 3 - (inst.BI & 3),
+		                                 !(inst.BO_2 & BO_BRANCH_IF_TRUE));
+		builder->CreateCondBr(cr_cmp, do_branch, no_branch);
+	}
+	else
+		builder->CreateBr(do_branch);
+
+	builder->SetInsertPoint(do_branch);
+	{
+		if (inst.LK)
+		{
+			Value* new_lr = builder->getInt32(js.compilerPC + 4);
+			func->StoreLR(new_lr);
+		}
+
+		Value* destination = func->LoadLR();
+		destination = builder->CreateAnd(destination, builder->getInt32(~3));
+		WriteExitInValue(destination);
+	}
+
+	builder->SetInsertPoint(no_branch);
+
+	if (!analyzer.HasOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE))
+		WriteExit(js.compilerPC + 4);
+}
+
+void JitLLVM::sc(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+
+	IRBuilder<>* builder = func->GetBuilder();
+	Value* Exceptions = func->LoadExceptions();
+	Exceptions = builder->CreateOr(Exceptions, builder->getInt32(EXCEPTION_SYSCALL));
+	func->StoreExceptions(Exceptions);
+
+	WriteExceptionExit(builder->getInt32(js.compilerPC + 4));
+}
+
+void JitLLVM::rfi(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	// See Interpreter rfi for details
+	Value* mask = builder->getInt32(0x87C0FFFF);
+	Value* neg_mask = builder->getInt32(~0x87C0FFFF);
+	Value* clearMSR13 = builder->getInt32(0xFFFBFFFF); // Mask used to clear the bit MSR[13]
+	// MSR = ((MSR & ~mask) | (SRR1 & mask)) & clearMSR13;
+
+	Value* msr = func->LoadMSR();
+
+	msr = builder->CreateAnd(msr, neg_mask);
+
+	Value* srr1 = func->LoadSPR(SPR_SRR1);
+
+	srr1 = builder->CreateAnd(srr1, mask);
+
+	msr = builder->CreateOr(msr, srr1);
+	msr = builder->CreateAnd(msr, clearMSR13);
+
+	func->StoreMSR(msr);
+
+	Value* srr0 = func->LoadSPR(SPR_SRR0);
+	WriteExceptionExit(srr0);
+}
+
+void JitLLVM::mtmsr(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+
+	Value* reg_rs = func->LoadGPR(inst.RS);
+	func->StoreMSR(reg_rs);
+	WriteExit(js.compilerPC + 4);
+}
+
+void JitLLVM::icbi(LLVMFunction* func, UGeckoInstruction inst)
+{
+	FallBackToInterpreter(func, inst);
+	WriteExit(js.compilerPC + 4);
+}

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_FloatingPoint.cpp
@@ -1,0 +1,390 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <llvm/IR/Intrinsics.h>
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+using namespace llvm;
+
+Value* JitLLVM::ForceSingle(LLVMFunction* func, Value* val)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	return builder->CreateFPTrunc(val, builder->getFloatTy());
+}
+
+void JitLLVM::fabsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 b = inst.FB, d = inst.FD;
+
+	Value* reg_fb = func->LoadFPR(b, false);
+
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getDoubleTy());
+
+	std::vector<Value *> args;
+	args.push_back(reg_fb);
+
+	Function *fabs_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::fabs, arg_type);
+	Value* res = builder->CreateCall(fabs_fun, args);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::faddsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+
+	Value* res = builder->CreateFAdd(reg_fa, reg_fb);
+	res = ForceSingle(func, res);
+
+	func->StoreFPR(res, d, false);
+	func->StoreFPR(res, d, true);
+}
+
+void JitLLVM::faddx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+
+	Value* res = builder->CreateFAdd(reg_fa, reg_fb);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::fmaddsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* mul_res = builder->CreateFMul(reg_fa, reg_fc);
+
+	Value* res = builder->CreateFAdd(mul_res, reg_fb);
+	res = ForceSingle(func, res);
+
+	func->StoreFPR(res, d, false);
+	func->StoreFPR(res, d, true);
+}
+
+void JitLLVM::fmaddx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* mul_res = builder->CreateFMul(reg_fa, reg_fc);
+
+	Value* res = builder->CreateFAdd(mul_res, reg_fb);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::fmrx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+
+	u32 b = inst.FB, d = inst.FD;
+
+	func->StoreFPR(func->LoadFPR(b, false), d, false);
+}
+
+void JitLLVM::fmsubsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* mul_res = builder->CreateFMul(reg_fa, reg_fc);
+
+	Value* res = builder->CreateFSub(mul_res, reg_fb);
+	res = ForceSingle(func, res);
+
+	func->StoreFPR(res, d, false);
+	func->StoreFPR(res, d, true);
+}
+
+void JitLLVM::fmsubx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* mul_res = builder->CreateFMul(reg_fa, reg_fc);
+
+	Value* res = builder->CreateFSub(mul_res, reg_fb);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::fmulsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* res = builder->CreateFMul(reg_fa, reg_fc);
+	res = ForceSingle(func, res);
+
+	func->StoreFPR(res, d, false);
+	func->StoreFPR(res, d, true);
+}
+
+void JitLLVM::fmulx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* res = builder->CreateFMul(reg_fa, reg_fc);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::fnabsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 b = inst.FB, d = inst.FD;
+
+	Value* reg_fb = func->LoadFPR(b, false);
+
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getDoubleTy());
+
+	std::vector<Value *> args;
+	args.push_back(reg_fb);
+
+	Function *fabs_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::fabs, arg_type);
+	Value* res = builder->CreateCall(fabs_fun, args);
+	res = builder->CreateFNeg(res);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::fnegx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 b = inst.FB, d = inst.FD;
+
+	Value* reg_fb = func->LoadFPR(b, false);
+
+	Value* res = builder->CreateFNeg(reg_fb);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::fnmaddsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* mul_res = builder->CreateFMul(reg_fa, reg_fc);
+
+	Value* res = builder->CreateFAdd(mul_res, reg_fb);
+	res = builder->CreateFNeg(reg_fb);
+	res = ForceSingle(func, res);
+
+	func->StoreFPR(res, d, false);
+	func->StoreFPR(res, d, true);
+}
+
+void JitLLVM::fnmaddx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* mul_res = builder->CreateFMul(reg_fa, reg_fc);
+
+	Value* res = builder->CreateFAdd(mul_res, reg_fb);
+	res = builder->CreateFNeg(reg_fb);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::fnmsubsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* mul_res = builder->CreateFMul(reg_fa, reg_fc);
+
+	Value* res = builder->CreateFSub(mul_res, reg_fb);
+	res = builder->CreateFNeg(reg_fb);
+	res = ForceSingle(func, res);
+
+	func->StoreFPR(res, d, false);
+	func->StoreFPR(res, d, true);
+}
+
+void JitLLVM::fnmsubx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* mul_res = builder->CreateFMul(reg_fa, reg_fc);
+
+	Value* res = builder->CreateFSub(mul_res, reg_fb);
+	res = builder->CreateFNeg(reg_fb);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::fsubsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+
+	Value* res = builder->CreateFSub(reg_fa, reg_fb);
+	res = ForceSingle(func, res);
+
+	func->StoreFPR(res, d, false);
+	func->StoreFPR(res, d, true);
+}
+
+void JitLLVM::fsubx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+
+	Value* res = builder->CreateFSub(reg_fa, reg_fb);
+
+	func->StoreFPR(res, d, false);
+}
+
+void JitLLVM::fselx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* zero = builder->CreateUIToFP(builder->getInt32(0), builder->getDoubleTy());
+
+	Value* reg_fa = func->LoadFPR(a, false);
+	Value* reg_fb = func->LoadFPR(b, false);
+	Value* reg_fc = func->LoadFPR(c, false);
+
+	Value* cmp_res = builder->CreateFCmpUGE(reg_fa, zero);
+	Value* res = builder->CreateSelect(cmp_res, reg_fc, reg_fb);
+
+	func->StoreFPR(res, d, false);
+}

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Integer.cpp
@@ -1,0 +1,864 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <llvm/IR/Intrinsics.h>
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+using namespace llvm;
+
+void JitLLVM::ComputeRC(LLVMFunction* func, Value* val, int crf, bool needs_sext)
+{
+	LLVMContext& con = getGlobalContext();
+	IRBuilder<>* builder = func->GetBuilder();
+	Type* llvm_i64 = Type::getInt64Ty(con);
+
+	if (needs_sext)
+	{
+		Value* res = builder->CreateSExtOrTrunc(val, llvm_i64);
+		func->StoreCR(res, crf);
+	}
+	else
+	{
+		Value* res = builder->CreateZExtOrTrunc(val, llvm_i64);
+		func->StoreCR(res, crf);
+	}
+}
+
+Value* JitLLVM::HasCarry(LLVMFunction* func, Value* a, Value* b)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	b = builder->CreateNot(b);
+	return builder->CreateICmpUGT(a, b);
+}
+
+void JitLLVM::reg_imm(LLVMFunction* func, u32 d, u32 a, bool binary, u32 value, Instruction::BinaryOps opc, bool Rc)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	if (a || binary)
+	{
+		Value* reg_ra = func->LoadGPR(a);
+		Value* res = builder->CreateBinOp(opc, reg_ra, builder->getInt32(value));
+		func->StoreGPR(res, d);
+
+		if (Rc)
+			ComputeRC(func, res, 0);
+	}
+	else if (opc == Instruction::BinaryOps::Add)
+	{
+		// a == 0, implies zero register
+		Value* res = builder->getInt32(value);
+		func->StoreGPR(res, d);
+		if (Rc)
+			ComputeRC(func, res, 0);
+	}
+	else
+	{
+		_assert_msg_(DYNA_REC, false, "Hit impossible condition in reg_imm!");
+	}
+}
+
+void JitLLVM::arith_imm(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	u32 d = inst.RD, a = inst.RA, s = inst.RS;
+
+	switch (inst.OPCD)
+	{
+	case 14: // addi
+		reg_imm(func, d, a, false, (u32)(s32)inst.SIMM_16, Instruction::BinaryOps::Add);
+	break;
+	case 15: // addis
+		reg_imm(func, d, a, false, (u32)inst.SIMM_16 << 16, Instruction::BinaryOps::Add);
+	break;
+	case 24: // ori
+		if (a == 0 && s == 0 && inst.UIMM == 0 && !inst.Rc)  //check for nop
+		{
+			// NOP
+			return;
+		}
+		reg_imm(func, a, s, true, inst.UIMM,       Instruction::BinaryOps::Or);
+	break;
+	case 25: // oris
+		reg_imm(func, a, s, true, inst.UIMM << 16, Instruction::BinaryOps::Or);
+	break;
+	case 28: // andi
+		reg_imm(func, a, s, true, inst.UIMM,       Instruction::BinaryOps::And, true);
+	break;
+	case 29: // andis
+		reg_imm(func, a, s, true, inst.UIMM << 16, Instruction::BinaryOps::And, true);
+	break;
+	case 26: // xori
+		reg_imm(func, a, s, true, inst.UIMM,       Instruction::BinaryOps::Xor);
+	break;
+	case 27: // xoris
+		reg_imm(func, a, s, true, inst.UIMM << 16, Instruction::BinaryOps::Xor);
+	break;
+	}
+}
+
+void JitLLVM::rlwXX(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.RA, s = inst.RS;
+	u32 mask_val = Helper_Mask(inst.MB, inst.ME);
+	Value* lsl_amount, *lsr_amount;
+	Value* mask, *neg_mask;
+	Value* res;
+
+	Value* reg_rs = func->LoadGPR(s);
+
+	if (inst.OPCD == 23) // rlwnmx
+	{
+		Value* reg_rb = func->LoadGPR(inst.RB);
+		lsl_amount = builder->CreateAnd(reg_rb, builder->getInt32(0x1F));
+		lsr_amount = builder->CreateSub(builder->getInt32(32), lsl_amount);
+	}
+	else
+	{
+		lsl_amount = builder->getInt32(inst.SH);
+		lsr_amount = builder->getInt32((32 - inst.SH) & 0x1F);
+	}
+
+	mask = builder->getInt32(mask_val);
+	neg_mask = builder->getInt32(~mask_val);
+
+	Value* lsl_res = builder->CreateShl(reg_rs, lsl_amount);
+	Value* lsr_res = builder->CreateLShr(reg_rs, lsr_amount);
+	Value* rotl_res = builder->CreateOr(lsl_res, lsr_res);
+
+	if (inst.OPCD == 20) // rlwimix
+	{
+		Value* reg_ra = func->LoadGPR(a);
+		Value* masked_ra = builder->CreateAnd(reg_ra, neg_mask);
+		Value* masked_rs = builder->CreateAnd(rotl_res, mask);
+		res = builder->CreateOr(masked_ra, masked_rs);
+	}
+	else // rlwinmx/rlwnmx
+	{
+		res = builder->CreateAnd(rotl_res, mask);
+	}
+
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::mulli(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* rhs_val = builder->getInt32(inst.SIMM_16);
+	Value* res = builder->CreateMul(reg_ra, rhs_val);
+	func->StoreGPR(res, d);
+}
+
+void JitLLVM::mullwx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	LLVM_FALLBACK_IF(inst.OE);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* res = builder->CreateMul(reg_ra, reg_rb);
+	func->StoreGPR(res, d);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::mulhwx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	LLVMContext& con = getGlobalContext();
+	IRBuilder<>* builder = func->GetBuilder();
+	Type* llvm_i32 = Type::getInt32Ty(con);
+	Type* llvm_i64 = Type::getInt64Ty(con);
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* ra64 = builder->CreateSExtOrTrunc(reg_ra, llvm_i64);
+	Value* rb64 = builder->CreateSExtOrTrunc(reg_rb, llvm_i64);
+	Value* res64 = builder->CreateMul(ra64, rb64);
+	Value* res = builder->CreateLShr(res64, builder->getInt64(32));
+	res = builder->CreateZExtOrTrunc(res, llvm_i32);
+
+	func->StoreGPR(res, d);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::mulhwux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	LLVMContext& con = getGlobalContext();
+	IRBuilder<>* builder = func->GetBuilder();
+	Type* llvm_i32 = Type::getInt32Ty(con);
+	Type* llvm_i64 = Type::getInt64Ty(con);
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* ra64 = builder->CreateZExtOrTrunc(reg_ra, llvm_i64);
+	Value* rb64 = builder->CreateZExtOrTrunc(reg_rb, llvm_i64);
+	Value* res64 = builder->CreateMul(ra64, rb64);
+	Value* res = builder->CreateLShr(res64, builder->getInt64(32));
+	res = builder->CreateZExtOrTrunc(res, llvm_i32);
+	func->StoreGPR(res, d);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::negx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, d = inst.RD;
+	Value* reg_ra = func->LoadGPR(a);
+	Value* res = builder->CreateNeg(reg_ra);
+	func->StoreGPR(res, d);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::subfx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* res = builder->CreateSub(reg_rb, reg_ra);
+	func->StoreGPR(res, d);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::xorx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* res = builder->CreateXor(reg_rs, reg_rb);
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::orx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* res = builder->CreateOr(reg_rs, reg_rb);
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::orcx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* res = builder->CreateOr(reg_rs, builder->CreateNot(reg_rb));
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::norx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* res = builder->CreateOr(reg_rs, reg_rb);
+	res = builder->CreateNot(res);
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::nandx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* res = builder->CreateAnd(reg_rs, reg_rb);
+	res = builder->CreateNot(res);
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::eqvx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* res = builder->CreateXor(reg_rs, reg_rb);
+	res = builder->CreateNot(res);
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::andx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* res = builder->CreateAnd(reg_rs, reg_rb);
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::andcx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* res = builder->CreateAnd(reg_rs, builder->CreateNot(reg_rb));
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::slwx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* cmp_res = builder->CreateICmpEQ(reg_rb, builder->getInt32(0x20));
+	Value* shift_amount = builder->CreateAnd(reg_rb, builder->getInt32(0x1F));
+	Value* shifted_res = builder->CreateShl(reg_rs, shift_amount);
+	Value* res = builder->CreateSelect(cmp_res, builder->getInt32(0), shifted_res);
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::srwx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+	Value* cmp_res = builder->CreateICmpEQ(reg_rb, builder->getInt32(0x20));
+	Value* shift_amount = builder->CreateAnd(reg_rb, builder->getInt32(0x1F));
+	Value* shifted_res = builder->CreateLShr(reg_rs, shift_amount);
+	Value* res = builder->CreateSelect(cmp_res, builder->getInt32(0), shifted_res);
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::addx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* res = builder->CreateAdd(reg_rb, reg_ra);
+	func->StoreGPR(res, d);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::cmp(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int crf = inst.CRFD;
+	int a = inst.RA, b = inst.RB;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* res = builder->CreateSub(reg_ra, reg_rb);
+
+	ComputeRC(func, res, crf);
+
+}
+
+void JitLLVM::cmpi(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int crf = inst.CRFD;
+	int a = inst.RA;
+
+	Value* imm_val = builder->getInt32(inst.UIMM);
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* res = builder->CreateSub(reg_ra, imm_val);
+
+	ComputeRC(func, res, crf, false);
+}
+
+void JitLLVM::cmpl(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	LLVMContext& con = getGlobalContext();
+	IRBuilder<>* builder = func->GetBuilder();
+	Type* llvm_i64 = Type::getInt64Ty(con);
+
+	int crf = inst.CRFD;
+	int a = inst.RA, b = inst.RB;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_xa = builder->CreateZExtOrTrunc(reg_ra, llvm_i64);
+	Value* reg_xb = builder->CreateZExtOrTrunc(reg_rb, llvm_i64);
+	Value* res = builder->CreateSub(reg_xa, reg_xb);
+
+	ComputeRC(func, res, crf, false);
+}
+
+void JitLLVM::cmpli(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	LLVMContext& con = getGlobalContext();
+	IRBuilder<>* builder = func->GetBuilder();
+	Type* llvm_i64 = Type::getInt64Ty(con);
+
+	int crf = inst.CRFD;
+	int a = inst.RA;
+
+	Value* imm_val = builder->getInt64(inst.UIMM);
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_xa = builder->CreateZExtOrTrunc(reg_ra, llvm_i64);
+	Value* res = builder->CreateSub(reg_xa, imm_val);
+
+	ComputeRC(func, res, crf, false);
+}
+
+void JitLLVM::extsXx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, s = inst.RS;
+	int size = inst.SUBOP10 == 922 ? 16 : 8;
+
+	Value* reg_rs = func->LoadGPR(s);
+	Value* trunc_reg = builder->CreateTrunc(reg_rs, builder->getIntNTy(size));
+	Value* res = builder->CreateSExt(trunc_reg, builder->getInt32Ty());
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::cntlzwx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, s = inst.RS;
+
+	Value* reg_rs = func->LoadGPR(s);
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getInt32Ty());
+
+	std::vector<Value *> args;
+	args.push_back(reg_rs);
+	args.push_back(builder->getInt1(false));
+
+	Function *ctlz_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::ctlz, arg_type);
+	Value* res = builder->CreateCall(ctlz_fun, args);
+	func->StoreGPR(res, a);
+
+	if (inst.Rc)
+		ComputeRC(func, res, 0);
+}
+
+void JitLLVM::addic(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* imm = builder->getInt32((u32)(s32)inst.SIMM_16);
+
+	Value* res = builder->CreateAdd(reg_ra, imm);
+	func->StoreGPR(res, d);
+
+	Value* has_carry = HasCarry(func, reg_ra, imm);
+	func->StoreCarry(has_carry);
+}
+
+void JitLLVM::addic_rc(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+
+	addic(func, inst);
+	ComputeRC(func, func->LoadGPR(inst.RD), 0);
+}
+
+void JitLLVM::addcx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+
+	Value* res = builder->CreateAdd(reg_ra, reg_rb);
+	func->StoreGPR(res, d);
+
+	Value* has_carry = HasCarry(func, reg_ra, reg_rb);
+	func->StoreCarry(has_carry);
+
+	if (inst.OE)
+		PanicAlert("OE: addcx");
+
+	if (inst.Rc)
+		ComputeRC(func, func->LoadGPR(d), 0);
+}
+
+void JitLLVM::addex(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* old_carry = func->LoadCarry();
+	Value* old_carry_value = builder->CreateZExt(old_carry, builder->getInt32Ty());
+
+	Value* res = builder->CreateAdd(reg_ra, reg_rb);
+	res = builder->CreateAdd(res, old_carry_value);
+	func->StoreGPR(res, d);
+
+	// SetCarry(Helper_Carry(a, b) || (carry != 0 && Helper_Carry(a + b, carry)));
+	Value* has_carry0 = HasCarry(func, reg_ra, reg_rb);
+	Value* has_carry1 = HasCarry(func, res, old_carry_value);
+	Value* carry_res = builder->CreateOr(has_carry0, has_carry1);
+
+	func->StoreCarry(carry_res);
+
+	if (inst.OE)
+		PanicAlert("OE: addex");
+
+	if (inst.Rc)
+		ComputeRC(func, func->LoadGPR(d), 0);
+}
+
+void JitLLVM::addmex(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* old_carry = func->LoadCarry();
+	Value* old_carry_value = builder->CreateZExt(old_carry, builder->getInt32Ty());
+
+	Value* res = builder->CreateAdd(reg_ra, reg_rb);
+	res = builder->CreateSub(res, old_carry_value);
+	func->StoreGPR(res, d);
+
+	// SetCarry(Helper_Carry(a, carry - 1));
+	func->StoreCarry(HasCarry(func, reg_ra, builder->CreateSub(old_carry_value, builder->getInt32(1))));
+
+	if (inst.OE)
+		PanicAlert("OE: addex");
+
+	if (inst.Rc)
+		ComputeRC(func, func->LoadGPR(d), 0);
+}
+
+void JitLLVM::addzex(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* old_carry = func->LoadCarry();
+	Value* old_carry_value = builder->CreateZExt(old_carry, builder->getInt32Ty());
+
+	Value* res = builder->CreateAdd(reg_ra, old_carry_value);
+	func->StoreGPR(res, d);
+
+	// SetCarry(Helper_Carry(a, carry));
+	func->StoreCarry(HasCarry(func, reg_ra, old_carry_value));
+
+	if (inst.OE)
+		PanicAlert("OE: addex");
+
+	if (inst.Rc)
+		ComputeRC(func, func->LoadGPR(d), 0);
+}
+
+void JitLLVM::subfcx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+
+	Value* res = builder->CreateSub(reg_rb, reg_ra);
+	func->StoreGPR(res, d);
+
+	// SetCarry(a == 0 || Helper_Carry(b, 0-a));
+	Value* has_carry0 = builder->CreateICmpEQ(reg_ra, builder->getInt32(0));
+	Value* has_carry1 = HasCarry(func, reg_rb, builder->CreateNeg(reg_ra));
+	Value* carry_res = builder->CreateOr(has_carry0, has_carry1);
+
+	func->StoreCarry(carry_res);
+
+	if (inst.OE)
+		PanicAlert("OE: addex");
+
+	if (inst.Rc)
+		ComputeRC(func, func->LoadGPR(d), 0);
+}
+
+void JitLLVM::subfex(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* reg_rb = func->LoadGPR(b);
+	Value* old_carry = func->LoadCarry();
+	Value* old_carry_value = builder->CreateZExt(old_carry, builder->getInt32Ty());
+
+	Value* not_ra = builder->CreateNot(reg_ra);
+
+	Value* res = builder->CreateAdd(not_ra, reg_rb);
+	res = builder->CreateAdd(res, old_carry_value);
+	func->StoreGPR(res, d);
+
+	// SetCarry(Helper_Carry(~a, b) || Helper_Carry((~a) + b, carry));
+	Value* has_carry0 = HasCarry(func, not_ra, reg_rb);
+	Value* has_carry1 = HasCarry(func, builder->CreateAdd(not_ra, reg_rb), old_carry_value);
+	Value* carry_res = builder->CreateOr(has_carry0, has_carry1);
+
+	func->StoreCarry(carry_res);
+
+	if (inst.OE)
+		PanicAlert("OE: addex");
+
+	if (inst.Rc)
+		ComputeRC(func, func->LoadGPR(d), 0);
+}
+
+void JitLLVM::subfmex(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* old_carry = func->LoadCarry();
+	Value* old_carry_value = builder->CreateZExt(old_carry, builder->getInt32Ty());
+
+	Value* not_ra = builder->CreateNot(reg_ra);
+
+	Value* res = builder->CreateAdd(not_ra, old_carry_value);
+	res = builder->CreateSub(res, builder->getInt32(1));
+	func->StoreGPR(res, d);
+
+	// SetCarry(Helper_Carry(~a, carry - 1));
+	Value* has_carry = HasCarry(func, not_ra, builder->CreateSub(old_carry_value, builder->getInt32(1)));
+	func->StoreCarry(has_carry);
+
+	if (inst.OE)
+		PanicAlert("OE: addex");
+
+	if (inst.Rc)
+		ComputeRC(func, func->LoadGPR(d), 0);
+}
+
+void JitLLVM::subfzex(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* old_carry = func->LoadCarry();
+	Value* old_carry_value = builder->CreateZExt(old_carry, builder->getInt32Ty());
+
+	Value* not_ra = builder->CreateNot(reg_ra);
+
+	Value* res = builder->CreateAdd(not_ra, old_carry_value);
+	func->StoreGPR(res, d);
+
+	// SetCarry(Helper_Carry(~a, carry));
+	Value* has_carry = HasCarry(func, not_ra, old_carry_value);
+	func->StoreCarry(has_carry);
+
+	if (inst.OE)
+		PanicAlert("OE: addex");
+
+	if (inst.Rc)
+		ComputeRC(func, func->LoadGPR(d), 0);
+}
+
+void JitLLVM::subfic(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITIntegerOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, d = inst.RD;
+
+	Value* reg_ra = func->LoadGPR(a);
+	Value* imm = builder->getInt32((u32)(s32)inst.SIMM_16);
+
+	Value* res = builder->CreateAdd(imm, reg_ra);
+	func->StoreGPR(res, d);
+
+	// SetCarry((rGPR[_inst.RA] == 0) || (Helper_Carry(0 - rGPR[_inst.RA], immediate)));
+	reg_ra = func->LoadGPR(a); // May have changed from the previous store
+	Value* has_carry0 = builder->CreateICmpEQ(reg_ra, builder->getInt32(0));
+	Value* has_carry1 = HasCarry(func, builder->CreateNeg(reg_ra), imm);
+	Value* carry_res = builder->CreateOr(has_carry0, has_carry1);
+
+	func->StoreCarry(carry_res);
+}

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Integer.cpp
@@ -420,7 +420,8 @@ void JitLLVM::slwx(LLVMFunction* func, UGeckoInstruction inst)
 	int a = inst.RA, b = inst.RB, s = inst.RS;
 	Value* reg_rb = func->LoadGPR(b);
 	Value* reg_rs = func->LoadGPR(s);
-	Value* cmp_res = builder->CreateICmpEQ(reg_rb, builder->getInt32(0x20));
+	Value* bit = builder->CreateAnd(reg_rb, builder->getInt32(0x20));
+	Value* cmp_res = builder->CreateICmpEQ(bit, builder->getInt32(0x20));
 	Value* shift_amount = builder->CreateAnd(reg_rb, builder->getInt32(0x1F));
 	Value* shifted_res = builder->CreateShl(reg_rs, shift_amount);
 	Value* res = builder->CreateSelect(cmp_res, builder->getInt32(0), shifted_res);
@@ -440,7 +441,8 @@ void JitLLVM::srwx(LLVMFunction* func, UGeckoInstruction inst)
 	int a = inst.RA, b = inst.RB, s = inst.RS;
 	Value* reg_rb = func->LoadGPR(b);
 	Value* reg_rs = func->LoadGPR(s);
-	Value* cmp_res = builder->CreateICmpEQ(reg_rb, builder->getInt32(0x20));
+	Value* bit = builder->CreateAnd(reg_rb, builder->getInt32(0x20));
+	Value* cmp_res = builder->CreateICmpEQ(bit, builder->getInt32(0x20));
 	Value* shift_amount = builder->CreateAnd(reg_rb, builder->getInt32(0x1F));
 	Value* shifted_res = builder->CreateLShr(reg_rs, shift_amount);
 	Value* res = builder->CreateSelect(cmp_res, builder->getInt32(0), shifted_res);

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_LoadStore.cpp
@@ -1,0 +1,493 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <llvm/IR/Intrinsics.h>
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+using namespace llvm;
+
+Value* JitLLVM::GetEA(LLVMFunction* func, UGeckoInstruction inst)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA;
+	if (a)
+		return builder->CreateAdd(func->LoadGPR(a), builder->getInt32((s32)inst.SIMM_16));
+
+	return builder->getInt32((s32)inst.SIMM_16);
+}
+
+Value* JitLLVM::GetEAU(LLVMFunction* func, UGeckoInstruction inst)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	return builder->CreateAdd(func->LoadGPR(inst.RA), builder->getInt32((s32)inst.SIMM_16));
+}
+
+Value* JitLLVM::GetEAX(LLVMFunction* func, UGeckoInstruction inst)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB;
+	if (a)
+		return builder->CreateAdd(func->LoadGPR(a), func->LoadGPR(b));
+
+	return func->LoadGPR(b);
+}
+
+Value* JitLLVM::GetEAUX(LLVMFunction* func, UGeckoInstruction inst)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	return builder->CreateAdd(func->LoadGPR(inst.RA), func->LoadGPR(inst.RB));
+}
+
+Value* JitLLVM::CreateReadU64(LLVMFunction* func, Value* address)
+{
+	return m_cur_mod->CreateReadU64(func, address);
+}
+
+Value* JitLLVM::CreateReadU32(LLVMFunction* func, Value* address)
+{
+	return m_cur_mod->CreateReadU32(func, address);
+}
+
+Value* JitLLVM::CreateReadU16(LLVMFunction* func, Value* address, bool needs_sext)
+{
+	return m_cur_mod->CreateReadU16(func, address, needs_sext);
+}
+
+Value* JitLLVM::CreateReadU8(LLVMFunction* func, Value* address, bool needs_sext)
+{
+	return m_cur_mod->CreateReadU8(func, address, needs_sext);
+}
+
+Value* JitLLVM::CreateWriteU64(LLVMFunction* func, Value* val, Value* address)
+{
+	return m_cur_mod->CreateWriteU64(func, val, address);
+}
+
+Value* JitLLVM::CreateWriteU32(LLVMFunction* func, Value* val, Value* address)
+{
+	return m_cur_mod->CreateWriteU32(func, val, address);
+}
+
+Value* JitLLVM::CreateWriteU16(LLVMFunction* func, Value* val, Value* address)
+{
+	return m_cur_mod->CreateWriteU16(func, val, address);
+}
+
+Value* JitLLVM::CreateWriteU8(LLVMFunction* func, Value* val, Value* address)
+{
+	return m_cur_mod->CreateWriteU8(func, val, address);
+}
+
+void JitLLVM::lwz(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEA(func, inst);
+	Value* res = CreateReadU32(func, address);
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::lwzu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAU(func, inst);
+	Value* res = CreateReadU32(func, address);
+	func->StoreGPR(res, inst.RD);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lbz(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEA(func, inst);
+	Value* res = CreateReadU8(func, address, false);
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::lbzu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAU(func, inst);
+	Value* res = CreateReadU8(func, address, false);
+	func->StoreGPR(res, inst.RD);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lhz(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEA(func, inst);
+	Value* res = CreateReadU16(func, address, false);
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::lhzu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAU(func, inst);
+	Value* res = CreateReadU16(func, address, false);
+	func->StoreGPR(res, inst.RD);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lha(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEA(func, inst);
+	Value* res = CreateReadU16(func, address, true);
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::lhau(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAU(func, inst);
+	Value* res = CreateReadU16(func, address, true);
+	func->StoreGPR(res, inst.RD);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::stw(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEA(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU32(func, val, address);
+}
+
+void JitLLVM::stwu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAU(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU32(func, val, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::sth(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEA(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU16(func, val, address);
+}
+
+void JitLLVM::sthu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAU(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU16(func, val, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::stb(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEA(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU8(func, val, address);
+}
+
+void JitLLVM::stbu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAU(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU8(func, val, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lmw(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEA(func, inst);
+	for (int iReg = inst.RD; iReg <= 31; iReg++)
+	{
+		Value* res = CreateReadU32(func, address);
+		func->StoreGPR(res, iReg);
+		address = builder->CreateAdd(address, builder->getInt32(4));
+	}
+}
+
+void JitLLVM::stmw(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEA(func, inst);
+	for (int iReg = inst.RD; iReg <= 31; iReg++)
+	{
+		Value* res = func->LoadGPR(iReg);
+		CreateWriteU32(func, res, address);
+		address = builder->CreateAdd(address, builder->getInt32(4));
+	}
+}
+
+void JitLLVM::lwzx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAX(func, inst);
+	Value* res = CreateReadU32(func, address);
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::lwzux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAUX(func, inst);
+	Value* res = CreateReadU32(func, address);
+	func->StoreGPR(res, inst.RD);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lhzx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAX(func, inst);
+	Value* res = CreateReadU16(func, address, false);
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::lhzux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAUX(func, inst);
+	Value* res = CreateReadU16(func, address, false);
+	func->StoreGPR(res, inst.RD);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lhax(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAX(func, inst);
+	Value* res = CreateReadU16(func, address, true);
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::lhaux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAUX(func, inst);
+	Value* res = CreateReadU16(func, address, true);
+	func->StoreGPR(res, inst.RD);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lbzx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAX(func, inst);
+	Value* res = CreateReadU8(func, address, false);
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::lbzux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAUX(func, inst);
+	Value* res = CreateReadU8(func, address, false);
+	func->StoreGPR(res, inst.RD);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lwbrx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* res = CreateReadU32(func, address);
+
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getInt32Ty());
+
+	std::vector<Value *> args;
+	args.push_back(res);
+
+	Function* bswap_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::bswap, arg_type);
+	res = builder->CreateCall(bswap_fun, args);
+
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::lhbrx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* res = CreateReadU16(func, address, false);
+	res = builder->CreateTrunc(res, builder->getInt16Ty());
+
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getInt16Ty());
+
+	std::vector<Value *> args;
+	args.push_back(res);
+
+	Function* bswap_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::bswap, arg_type);
+	res = builder->CreateCall(bswap_fun, args);
+	res = builder->CreateZExt(res, builder->getInt32Ty());
+
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::stwx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAX(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU32(func, val, address);
+}
+
+void JitLLVM::stwux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAUX(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU32(func, val, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::sthx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAX(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU16(func, val, address);
+}
+
+void JitLLVM::sthux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAUX(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU16(func, val, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::stbx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAX(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU8(func, val, address);
+}
+
+void JitLLVM::stbux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	Value* address = GetEAUX(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	CreateWriteU8(func, val, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::stwbrx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getInt32Ty());
+
+	std::vector<Value *> args;
+	args.push_back(val);
+
+	Function* bswap_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::bswap, arg_type);
+	val = builder->CreateCall(bswap_fun, args);
+
+	CreateWriteU32(func, val, address);
+}
+
+void JitLLVM::sthbrx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* val = func->LoadGPR(inst.RS);
+	val = builder->CreateTrunc(val, builder->getInt16Ty());
+
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getInt16Ty());
+
+	std::vector<Value *> args;
+	args.push_back(val);
+
+	Function* bswap_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::bswap, arg_type);
+	val = builder->CreateCall(bswap_fun, args);
+
+	CreateWriteU16(func, val, address);
+}

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_LoadStoreFloating.cpp
@@ -1,0 +1,232 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+using namespace llvm;
+
+void JitLLVM::lfs(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEA(func, inst);
+	Value* res = CreateReadU32(func, address);
+	res = builder->CreateBitCast(res, builder->getFloatTy());
+	res = builder->CreateFPExt(res, builder->getDoubleTy());
+	func->StoreFPR(res, inst.FD, false);
+	func->StoreFPR(res, inst.FD, true);
+}
+
+void JitLLVM::lfsu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAU(func, inst);
+	Value* res = CreateReadU32(func, address);
+	res = builder->CreateBitCast(res, builder->getFloatTy());
+	res = builder->CreateFPExt(res, builder->getDoubleTy());
+	func->StoreFPR(res, inst.FD, false);
+	func->StoreFPR(res, inst.FD, true);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lfd(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEA(func, inst);
+	Value* res = CreateReadU64(func, address);
+	res = builder->CreateBitCast(res, builder->getDoubleTy());
+	func->StoreFPR(res, inst.FD, false);
+}
+
+void JitLLVM::lfdu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAU(func, inst);
+	Value* res = CreateReadU64(func, address);
+	res = builder->CreateBitCast(res, builder->getDoubleTy());
+	func->StoreFPR(res, inst.FD, false);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::stfs(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEA(func, inst);
+	Value* res = func->LoadFPR(inst.FS, false);
+	res = ForceSingle(func, res);
+	res = builder->CreateBitCast(res, builder->getInt32Ty());
+	CreateWriteU32(func, res, address);
+}
+
+void JitLLVM::stfsu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAU(func, inst);
+	Value* res = func->LoadFPR(inst.FS, false);
+	res = ForceSingle(func, res);
+	res = builder->CreateBitCast(res, builder->getInt32Ty());
+	CreateWriteU32(func, res, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::stfd(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEA(func, inst);
+	Value* res = func->LoadFPR(inst.FS, false);
+	res = builder->CreateBitCast(res, builder->getInt64Ty());
+	CreateWriteU64(func, res, address);
+}
+
+void JitLLVM::stfdu(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEA(func, inst);
+	Value* res = func->LoadFPR(inst.FS, false);
+	res = builder->CreateBitCast(res, builder->getInt64Ty());
+	CreateWriteU64(func, res, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lfsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* res = CreateReadU32(func, address);
+	res = builder->CreateBitCast(res, builder->getFloatTy());
+	res = builder->CreateFPExt(res, builder->getDoubleTy());
+	func->StoreFPR(res, inst.FD, false);
+	func->StoreFPR(res, inst.FD, true);
+}
+
+void JitLLVM::lfsux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAUX(func, inst);
+	Value* res = CreateReadU32(func, address);
+	res = builder->CreateBitCast(res, builder->getFloatTy());
+	res = builder->CreateFPExt(res, builder->getDoubleTy());
+	func->StoreFPR(res, inst.FD, false);
+	func->StoreFPR(res, inst.FD, true);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::lfdx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* res = CreateReadU64(func, address);
+	res = builder->CreateBitCast(res, builder->getDoubleTy());
+	func->StoreFPR(res, inst.FD, false);
+}
+
+void JitLLVM::lfdux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAUX(func, inst);
+	Value* res = CreateReadU64(func, address);
+	res = builder->CreateBitCast(res, builder->getDoubleTy());
+	func->StoreFPR(res, inst.FD, false);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::stfsx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* res = func->LoadFPR(inst.FS, false);
+	res = ForceSingle(func, res);
+	res = builder->CreateBitCast(res, builder->getInt32Ty());
+	CreateWriteU32(func, res, address);
+}
+
+void JitLLVM::stfsux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAUX(func, inst);
+	Value* res = func->LoadFPR(inst.FS, false);
+	res = ForceSingle(func, res);
+	res = builder->CreateBitCast(res, builder->getInt32Ty());
+	CreateWriteU32(func, res, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::stfdx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* res = func->LoadFPR(inst.FS, false);
+	res = builder->CreateBitCast(res, builder->getInt64Ty());
+	CreateWriteU64(func, res, address);
+}
+
+void JitLLVM::stfdux(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* res = func->LoadFPR(inst.FS, false);
+	res = builder->CreateBitCast(res, builder->getInt64Ty());
+	CreateWriteU64(func, res, address);
+	func->StoreGPR(address, inst.RA);
+}
+
+void JitLLVM::stfiwx(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address = GetEAX(func, inst);
+	Value* res = func->LoadFPR(inst.FS, false);
+	res = builder->CreateBitCast(res, builder->getInt64Ty());
+	res = builder->CreateTrunc(res, builder->getInt32Ty());
+	CreateWriteU32(func, res, address);
+}

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_LoadStorePaired.cpp
@@ -1,0 +1,105 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+using namespace llvm;
+
+Value* JitLLVM::Paired_GetEA(LLVMFunction* func, UGeckoInstruction inst)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA;
+	if (a)
+		return builder->CreateAdd(func->LoadGPR(a), builder->getInt32((s32)inst.SIMM_12));
+
+	return builder->getInt32((s32)inst.SIMM_12);
+}
+
+Value* JitLLVM::Paired_GetEAU(LLVMFunction* func, UGeckoInstruction inst)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	return builder->CreateAdd(func->LoadGPR(inst.RA), builder->getInt32((s32)inst.SIMM_12));
+}
+
+Value* JitLLVM::Paired_GetEAX(LLVMFunction* func, UGeckoInstruction inst)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB;
+	if (a)
+		return builder->CreateAdd(func->LoadGPR(a), func->LoadGPR(b));
+
+	return func->LoadGPR(b);
+}
+
+Value* JitLLVM::Paired_GetEAUX(LLVMFunction* func, UGeckoInstruction inst)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int a = inst.RA, b = inst.RB;
+	return builder->CreateAdd(func->LoadGPR(a), func->LoadGPR(b));
+}
+
+Value* JitLLVM::CreatePairedLoad(LLVMFunction* func, Value* paired, Value* type, Value* scale, Value* address)
+{
+	return m_cur_mod->CreatePairedLoad(func, paired, type, scale, address);
+}
+
+Value* JitLLVM::Paired_GetLoadType(LLVMFunction* func, Value* gqr)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Value* res = builder->CreateLShr(gqr, builder->getInt32(16));
+	res = builder->CreateAnd(res, builder->getInt32(7));
+	return builder->CreateTrunc(res, builder->getInt8Ty());
+}
+
+Value* JitLLVM::Paired_GetLoadScale(LLVMFunction* func, Value* gqr)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Value* res = builder->CreateLShr(gqr, builder->getInt32(24));
+	res = builder->CreateAnd(res, builder->getInt32(0x3F));
+	return builder->CreateTrunc(res, builder->getInt8Ty());
+}
+
+void JitLLVM::psq_lXX(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITLoadStoreOff);
+
+	s32 offset = inst.SIMM_12;
+	bool indexed = inst.OPCD == 4;
+	bool update = (inst.OPCD == 57 && offset) || (inst.OPCD == 4 && !!(inst.SUBOP6 & 32));
+
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* address;
+
+	Value* gqr = func->LoadGQR(inst.I);
+	Value* paired = builder->getInt8(inst.W ? 0 : 1);
+	Value* type = Paired_GetLoadType(func, gqr);
+	Value* scale = Paired_GetLoadScale(func, gqr);
+
+	if (indexed)
+		if (update)
+			address = Paired_GetEAUX(func, inst);
+		else
+			address = Paired_GetEAX(func, inst);
+	else
+		if (update)
+			address = Paired_GetEAU(func, inst);
+		else
+			address = Paired_GetEA(func, inst);
+
+	Value* res = CreatePairedLoad(func, paired, type, scale, address);
+	Value* PS0 = builder->CreateExtractElement(res, builder->getInt32(0));
+	Value* PS1 = builder->CreateExtractElement(res, builder->getInt32(1));
+
+	func->StoreFPR(PS0, inst.RD, false);
+	func->StoreFPR(PS1, inst.RD, true);
+
+	if (update)
+		func->StoreGPR(address, inst.RA);
+}
+

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_LoadStorePaired.cpp
@@ -82,15 +82,19 @@ void JitLLVM::psq_lXX(LLVMFunction* func, UGeckoInstruction inst)
 	Value* scale = Paired_GetLoadScale(func, gqr);
 
 	if (indexed)
+	{
 		if (update)
 			address = Paired_GetEAUX(func, inst);
 		else
 			address = Paired_GetEAX(func, inst);
+	}
 	else
+	{
 		if (update)
 			address = Paired_GetEAU(func, inst);
 		else
 			address = Paired_GetEA(func, inst);
+	}
 
 	Value* res = CreatePairedLoad(func, paired, type, scale, address);
 	Value* PS0 = builder->CreateExtractElement(res, builder->getInt32(0));

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Paired.cpp
@@ -1,0 +1,612 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <llvm/IR/Intrinsics.h>
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+using namespace llvm;
+
+void JitLLVM::ps_abs(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 b = inst.FB, d = inst.FD;
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getDoubleTy());
+
+	std::vector<Value *> args;
+	args.push_back(reg_fb0);
+
+	Function *fabs_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::fabs, arg_type);
+	Value* res0 = builder->CreateCall(fabs_fun, args);
+
+	args[0] = reg_fb1;
+	Value* res1 = builder->CreateCall(fabs_fun, args);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_add(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* res0 = builder->CreateFAdd(reg_fa0, reg_fb0);
+	Value* res1 = builder->CreateFAdd(reg_fa1, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_sub(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* res0 = builder->CreateFSub(reg_fa0, reg_fb0);
+	Value* res1 = builder->CreateFSub(reg_fa1, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_div(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* res0 = builder->CreateFDiv(reg_fa0, reg_fb0);
+	Value* res1 = builder->CreateFDiv(reg_fa1, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_madd(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* reg_fc0 = func->LoadFPR(c, false);
+	Value* reg_fc1 = func->LoadFPR(c, true);
+
+	Value* mul_res0 = builder->CreateFMul(reg_fa0, reg_fc0);
+	Value* mul_res1 = builder->CreateFMul(reg_fa1, reg_fc1);
+
+	Value* res0 = builder->CreateFAdd(mul_res0, reg_fb0);
+	Value* res1 = builder->CreateFAdd(mul_res1, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_madds0(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* reg_fc0 = func->LoadFPR(c, false);
+
+	Value* mul_res0 = builder->CreateFMul(reg_fa0, reg_fc0);
+	Value* mul_res1 = builder->CreateFMul(reg_fa1, reg_fc0);
+
+	Value* res0 = builder->CreateFAdd(mul_res0, reg_fb0);
+	Value* res1 = builder->CreateFAdd(mul_res1, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_madds1(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* reg_fc1 = func->LoadFPR(c, true);
+
+	Value* mul_res0 = builder->CreateFMul(reg_fa0, reg_fc1);
+	Value* mul_res1 = builder->CreateFMul(reg_fa1, reg_fc1);
+
+	Value* res0 = builder->CreateFAdd(mul_res0, reg_fb0);
+	Value* res1 = builder->CreateFAdd(mul_res1, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_merge00(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+
+	func->StoreFPR(reg_fa0, d, false);
+	func->StoreFPR(reg_fb0, d, true);
+}
+
+void JitLLVM::ps_merge01(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	func->StoreFPR(reg_fa0, d, false);
+	func->StoreFPR(reg_fb1, d, true);
+}
+
+void JitLLVM::ps_merge10(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+
+	func->StoreFPR(reg_fa1, d, false);
+	func->StoreFPR(reg_fb0, d, true);
+}
+
+void JitLLVM::ps_merge11(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+
+	u32 a = inst.FA, b = inst.FB, d = inst.FD;
+
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	func->StoreFPR(reg_fa1, d, false);
+	func->StoreFPR(reg_fb1, d, true);
+}
+
+void JitLLVM::ps_mr(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+
+	u32 b = inst.FB, d = inst.FD;
+
+	if (b == d)
+		return;
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	func->StoreFPR(reg_fb0, d, false);
+	func->StoreFPR(reg_fb1, d, true);
+}
+
+void JitLLVM::ps_mul(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fc0 = func->LoadFPR(c, false);
+	Value* reg_fc1 = func->LoadFPR(c, true);
+
+	Value* res0 = builder->CreateFMul(reg_fa0, reg_fc0);
+	Value* res1 = builder->CreateFMul(reg_fa1, reg_fc1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_muls0(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fc0 = func->LoadFPR(c, false);
+
+	Value* res0 = builder->CreateFMul(reg_fa0, reg_fc0);
+	Value* res1 = builder->CreateFMul(reg_fa1, reg_fc0);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_muls1(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fc1 = func->LoadFPR(c, true);
+
+	Value* res0 = builder->CreateFMul(reg_fa0, reg_fc1);
+	Value* res1 = builder->CreateFMul(reg_fa1, reg_fc1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_msub(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* reg_fc0 = func->LoadFPR(c, false);
+	Value* reg_fc1 = func->LoadFPR(c, true);
+
+	Value* mul_res0 = builder->CreateFMul(reg_fa0, reg_fc0);
+	Value* mul_res1 = builder->CreateFMul(reg_fa1, reg_fc1);
+
+	Value* res0 = builder->CreateFSub(mul_res0, reg_fb0);
+	Value* res1 = builder->CreateFSub(mul_res1, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_nabs(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 b = inst.FB, d = inst.FD;
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getDoubleTy());
+
+	std::vector<Value *> args;
+	args.push_back(reg_fb0);
+
+	Function *fabs_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::fabs, arg_type);
+	Value* res0 = builder->CreateCall(fabs_fun, args);
+	res0 = builder->CreateFNeg(res0);
+
+	args[0] = reg_fb1;
+	Value* res1 = builder->CreateCall(fabs_fun, args);
+	res1 = builder->CreateFNeg(res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_neg(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 b = inst.FB, d = inst.FD;
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* res0 = builder->CreateFNeg(reg_fb0);
+	Value* res1 = builder->CreateFNeg(reg_fb1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_nmadd(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* reg_fc0 = func->LoadFPR(c, false);
+	Value* reg_fc1 = func->LoadFPR(c, true);
+
+	Value* mul_res0 = builder->CreateFMul(reg_fa0, reg_fc0);
+	Value* mul_res1 = builder->CreateFMul(reg_fa1, reg_fc1);
+
+	Value* res0 = builder->CreateFAdd(mul_res0, reg_fb0);
+	Value* res1 = builder->CreateFAdd(mul_res1, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	res0 = builder->CreateFNeg(res0);
+	res1 = builder->CreateFNeg(res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_nmsub(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* reg_fc0 = func->LoadFPR(c, false);
+	Value* reg_fc1 = func->LoadFPR(c, true);
+
+	Value* mul_res0 = builder->CreateFMul(reg_fa0, reg_fc0);
+	Value* mul_res1 = builder->CreateFMul(reg_fa1, reg_fc1);
+
+	Value* res0 = builder->CreateFSub(mul_res0, reg_fb0);
+	Value* res1 = builder->CreateFSub(mul_res1, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	res1 = ForceSingle(func, res1);
+
+	res0 = builder->CreateFNeg(res0);
+	res1 = builder->CreateFNeg(res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_sum0(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* reg_fc1 = func->LoadFPR(c, true);
+
+	Value* res0 = builder->CreateFAdd(reg_fa0, reg_fb1);
+
+	res0 = ForceSingle(func, res0);
+	Value* res1 = ForceSingle(func, reg_fc1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_sum1(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* reg_fc0 = func->LoadFPR(c, false);
+
+	Value* res0 = ForceSingle(func, reg_fc0);
+
+	Value* res1 = builder->CreateFAdd(reg_fa0, reg_fb1);
+
+	res1 = ForceSingle(func, res1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_res(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 b = inst.FB, d = inst.FD;
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	std::vector<Type *> arg_type;
+	arg_type.push_back(builder->getDoubleTy());
+
+	std::vector<Value *> args;
+	args.push_back(reg_fb0);
+
+	Function *fabs_fun = Intrinsic::getDeclaration(m_cur_mod->GetModule(), Intrinsic::sqrt, arg_type);
+	Value* res0 = builder->CreateCall(fabs_fun, args);
+
+	args[0] = reg_fb1;
+	Value* res1 = builder->CreateCall(fabs_fun, args);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}
+
+void JitLLVM::ps_sel(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITFloatingPointOff);
+	LLVM_FALLBACK_IF(inst.Rc);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
+
+	Constant* zero = ConstantFP::get(builder->getDoubleTy(), 0.0);
+
+	Value* reg_fa0 = func->LoadFPR(a, false);
+	Value* reg_fa1 = func->LoadFPR(a, true);
+
+	Value* reg_fb0 = func->LoadFPR(b, false);
+	Value* reg_fb1 = func->LoadFPR(b, true);
+
+	Value* reg_fc0 = func->LoadFPR(c, false);
+	Value* reg_fc1 = func->LoadFPR(c, true);
+
+	Value* cmp_res0 = builder->CreateFCmpUGE(reg_fa0, zero);
+	Value* res0 = builder->CreateSelect(cmp_res0, reg_fc0, reg_fb0);
+
+	Value* cmp_res1 = builder->CreateFCmpUGE(reg_fa1, zero);
+	Value* res1 = builder->CreateSelect(cmp_res1, reg_fc1, reg_fb1);
+
+	func->StoreFPR(res0, d, false);
+	func->StoreFPR(res1, d, true);
+}

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_SystemRegisters.cpp
@@ -1,0 +1,364 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+using namespace llvm;
+
+Value* JitLLVM::GetCRBit(LLVMFunction* func, int field, int bit, bool negate)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* cr = func->LoadCR(field);
+	Value* res;
+	Value* tmp;
+	switch (bit)
+	{
+	case CR_SO_BIT:  // check bit 61 set
+		tmp = builder->CreateAnd(cr, builder->getInt64(1ULL << 61));
+		if (negate)
+			res = builder->CreateICmpEQ(tmp, builder->getInt64(0));
+		else
+			res = builder->CreateICmpNE(tmp, builder->getInt64(0));
+		break;
+
+	case CR_EQ_BIT:  // check bits 31-0 == 0
+		tmp = builder->CreateAnd(cr, builder->getInt64((1ULL << 31) - 1));
+		if (negate)
+			res = builder->CreateICmpNE(tmp, builder->getInt64(0));
+		else
+			res = builder->CreateICmpEQ(tmp, builder->getInt64(0));
+		break;
+
+	case CR_GT_BIT:  // check val > 0
+		if (negate)
+			res = builder->CreateICmpSLE(cr, builder->getInt64(0));
+		else
+			res = builder->CreateICmpSGT(cr, builder->getInt64(0));
+		break;
+
+	case CR_LT_BIT:  // check bit 62 set
+		tmp = builder->CreateAnd(cr, builder->getInt64(1ULL << 62));
+		if (negate)
+			res = builder->CreateICmpEQ(tmp, builder->getInt64(0));
+		else
+			res = builder->CreateICmpNE(tmp, builder->getInt64(0));
+		break;
+
+	default:
+		_assert_msg_(DYNA_REC, false, "Invalid CR bit");
+		res = UndefValue::get(builder->getInt64Ty());
+	}
+
+	return res;
+}
+
+void JitLLVM::SetCRBit(LLVMFunction* func, int field, int bit, Value* val)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* cr = func->LoadCR(field);
+	Value* res;
+	Value* tmp;
+	switch (bit)
+	{
+	case CR_SO_BIT:
+		res = builder->CreateAnd(cr, builder->getInt64(~(1ULL << 61)));
+		tmp = builder->CreateOr(cr, builder->getInt64(1ULL << 61));
+		res = builder->CreateSelect(val, tmp, res);
+		break;
+
+	case CR_EQ_BIT:
+		res = builder->CreateLShr(cr, builder->getInt64(32));
+		res = builder->CreateShl(res, builder->getInt64(32));
+
+		tmp = builder->CreateOr(res, builder->getInt64(1));
+		res = builder->CreateSelect(val, tmp, res);
+		break;
+
+	case CR_GT_BIT:
+		res = builder->CreateAnd(cr, builder->getInt64(~(1ULL << 63)));
+		tmp = builder->CreateOr(cr, builder->getInt64(1ULL << 63));
+		res = builder->CreateSelect(val, tmp, res);
+		break;
+
+	case CR_LT_BIT:
+		res = builder->CreateAnd(cr, builder->getInt64(~(1ULL << 62)));
+		tmp = builder->CreateOr(cr, builder->getInt64(1ULL << 62));
+		res = builder->CreateSelect(val, tmp, res);
+		break;
+	default:
+		_assert_msg_(DYNA_REC, false, "Invalid CR bit");
+		res = UndefValue::get(builder->getInt64Ty());
+	}
+	func->StoreCR(res, field);
+}
+
+void JitLLVM::SetCRBit(LLVMFunction* func, int field, int bit)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* cr = func->LoadCR(field);
+	Value* res;
+	switch (bit)
+	{
+	case CR_SO_BIT:
+		res = builder->CreateOr(cr, builder->getInt64(1ULL << 61));
+		break;
+
+	case CR_EQ_BIT:
+		res = builder->CreateLShr(cr, builder->getInt64(32));
+		res = builder->CreateShl(res, builder->getInt64(32));
+		break;
+
+	case CR_GT_BIT:
+		res = builder->CreateAnd(cr, builder->getInt64(~(1ULL << 63)));
+		break;
+
+	case CR_LT_BIT:
+		res = builder->CreateOr(cr, builder->getInt64(1ULL << 62));
+		break;
+	default:
+		_assert_msg_(DYNA_REC, false, "Invalid CR bit");
+		res = UndefValue::get(builder->getInt64Ty());
+	}
+	func->StoreCR(res, field);
+}
+
+void JitLLVM::ClearCRBit(LLVMFunction* func, int field, int bit)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* cr = func->LoadCR(field);
+	Value* res;
+	switch (bit)
+	{
+	case CR_SO_BIT:
+		res = builder->CreateAnd(cr, builder->getInt64(~(1ULL << 61)));
+		break;
+
+	case CR_EQ_BIT:
+		res = builder->CreateOr(cr, builder->getInt64(1));
+		break;
+
+	case CR_GT_BIT:
+		res = builder->CreateOr(cr, builder->getInt64(1ULL << 63));
+		break;
+
+	case CR_LT_BIT:
+		res = builder->CreateAnd(cr, builder->getInt64(~(1ULL << 62)));
+		break;
+	default:
+		_assert_msg_(DYNA_REC, false, "Invalid CR bit");
+		res = UndefValue::get(builder->getInt64Ty());
+	}
+	func->StoreCR(res, field);
+	// We don't need to set bit 32; the cases where that's needed only come up when setting bits, not clearing.
+}
+
+void JitLLVM::mfspr(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+
+	u32 iIndex = (inst.SPRU << 5) | (inst.SPRL & 0x1F);
+
+	switch (iIndex)
+	{
+	case SPR_XER:
+		// XXX
+	case SPR_WPAR:
+	case SPR_DEC:
+		LLVM_FALLBACK_IF(true);
+	case SPR_TL:
+	case SPR_TU:
+		// XXX:
+	default:
+		Value* spr_val = func->LoadSPR(iIndex * 4);
+		func->StoreGPR(spr_val, inst.RD);
+		break;
+	}
+}
+
+void JitLLVM::mftb(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+	mfspr(func, inst);
+}
+
+void JitLLVM::mtspr(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+
+	u32 iIndex = (inst.SPRU << 5) | (inst.SPRL & 0x1F);
+
+	switch (iIndex)
+	{
+	case SPR_DMAU:
+
+	case SPR_SPRG0:
+	case SPR_SPRG1:
+	case SPR_SPRG2:
+	case SPR_SPRG3:
+
+	case SPR_SRR0:
+	case SPR_SRR1:
+		// These are safe to do the easy way, see the bottom of this function.
+	break;
+
+	case SPR_LR:
+	case SPR_CTR:
+	case SPR_GQR0:
+	case SPR_GQR0 + 1:
+	case SPR_GQR0 + 2:
+	case SPR_GQR0 + 3:
+	case SPR_GQR0 + 4:
+	case SPR_GQR0 + 5:
+	case SPR_GQR0 + 6:
+	case SPR_GQR0 + 7:
+		// These are safe to do the easy way, see the bottom of this function.
+	break;
+	case SPR_XER:
+		// XXX:
+	default:
+		LLVM_FALLBACK_IF(true);
+	}
+
+	Value* reg_rd = func->LoadGPR(inst.RD);
+	func->StoreSPR(reg_rd, iIndex * 4);
+}
+
+void JitLLVM::mfmsr(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+
+	func->StoreGPR(func->LoadMSR(), inst.RD);
+}
+
+void JitLLVM::mcrf(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+
+	func->StoreCR(func->LoadCR(inst.CRFS), inst.CRFD);
+}
+
+void JitLLVM::crXX(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	_dbg_assert_msg_(DYNA_REC, inst.OPCD == 19, "Invalid crXXX");
+
+	// Special case: crclr
+	if (inst.CRBA == inst.CRBB && inst.CRBA == inst.CRBD && inst.SUBOP10 == 193)
+	{
+		ClearCRBit(func, inst.CRBD >> 2, 3 - (inst.CRBD & 3));
+		return;
+	}
+
+	// Special case: crset
+	if (inst.CRBA == inst.CRBB && inst.CRBA == inst.CRBD && inst.SUBOP10 == 289)
+	{
+		SetCRBit(func, inst.CRBD >> 2, 3 - (inst.CRBD & 3));
+		return;
+	}
+
+	// creqv or crnand or crnor
+	bool negateA = inst.SUBOP10 == 289 || inst.SUBOP10 == 225 || inst.SUBOP10 == 33;
+	// crandc or crorc or crnand or crnor
+	bool negateB = inst.SUBOP10 == 129 || inst.SUBOP10 == 417 || inst.SUBOP10 == 225 || inst.SUBOP10 == 33;
+
+	Value* cr_a = GetCRBit(func, inst.CRBA >> 2, 3 - (inst.CRBA & 3), negateA);
+	Value* cr_b = GetCRBit(func, inst.CRBB >> 2, 3 - (inst.CRBB & 3), negateB);
+	Value* cr_res;
+
+	// Compute combined bit
+	switch (inst.SUBOP10)
+	{
+	case 33:  // crnor: ~(A || B) == (~A && ~B)
+	case 129: // crandc: A && ~B
+	case 257: // crand:  A && B
+		cr_res = builder->CreateAnd(cr_a, cr_b);
+		break;
+
+	case 193: // crxor: A ^ B
+	case 289: // creqv: ~(A ^ B) = ~A ^ B
+		cr_res = builder->CreateXor(cr_a, cr_b);
+		break;
+
+	case 225: // crnand: ~(A && B) == (~A || ~B)
+	case 417: // crorc: A || ~B
+	case 449: // cror:  A || B
+		cr_res = builder->CreateOr(cr_a, cr_b);
+		break;
+	default:
+		cr_res = UndefValue::get(builder->getInt1Ty());
+		break;
+	}
+
+	// Store result bit in CRBD
+	SetCRBit(func, inst.CRBD >> 2, 3 - (inst.CRBD & 3), cr_res);
+}
+
+void JitLLVM::mfsr(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* res = func->LoadSR(builder->getInt32(inst.SR));
+	res = builder->CreateZExt(res, builder->getInt32Ty());
+
+	func->StoreGPR(res, inst.RD);
+}
+
+void JitLLVM::mfsrin(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int b = inst.RB, d = inst.RD;
+	Value* reg_rb = func->LoadGPR(b);
+	reg_rb = builder->CreateLShr(reg_rb, builder->getInt32(28));
+	reg_rb = builder->CreateAnd(reg_rb, builder->getInt32(0xF));
+	Value* res = func->LoadSR(reg_rb);
+	res = builder->CreateZExt(res, builder->getInt32Ty());
+
+	func->StoreGPR(res, d);
+}
+
+void JitLLVM::mtsr(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	Value* reg_rs = func->LoadGPR(inst.RS);
+	reg_rs = builder->CreateTrunc(reg_rs, builder->getInt8Ty());
+
+	func->StoreSR(reg_rs, builder->getInt32(inst.SR));
+}
+
+void JitLLVM::mtsrin(LLVMFunction* func, UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	LLVM_JITDISABLE(bJITSystemRegistersOff);
+	IRBuilder<>* builder = func->GetBuilder();
+
+	int b = inst.RB, s = inst.RS;
+	Value* reg_rb = func->LoadGPR(b);
+	Value* reg_rs = func->LoadGPR(s);
+
+	reg_rs = builder->CreateTrunc(reg_rs, builder->getInt8Ty());
+
+	reg_rb = builder->CreateLShr(reg_rb, builder->getInt32(28));
+	reg_rb = builder->CreateAnd(reg_rb, builder->getInt32(0xF));
+	func->StoreSR(reg_rs, reg_rb);
+}

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Tables.cpp
@@ -1,0 +1,473 @@
+// Copyright 2009 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+#include "Core/PowerPC/JitLLVM/JitLLVM_Tables.h"
+
+// Should be moved in to the Jit class
+typedef void (JitLLVM::*_Instruction) (LLVMFunction* func, UGeckoInstruction instCode);
+
+static _Instruction dynaOpTable[64];
+static _Instruction dynaOpTable4[1024];
+static _Instruction dynaOpTable19[1024];
+static _Instruction dynaOpTable31[1024];
+static _Instruction dynaOpTable59[32];
+static _Instruction dynaOpTable63[1024];
+void JitLLVM::DynaRunTable4 (LLVMFunction* func, UGeckoInstruction _inst) {(this->*dynaOpTable4 [_inst.SUBOP10])(func, _inst);}
+void JitLLVM::DynaRunTable19(LLVMFunction* func, UGeckoInstruction _inst) {(this->*dynaOpTable19[_inst.SUBOP10])(func, _inst);}
+void JitLLVM::DynaRunTable31(LLVMFunction* func, UGeckoInstruction _inst) {(this->*dynaOpTable31[_inst.SUBOP10])(func, _inst);}
+void JitLLVM::DynaRunTable59(LLVMFunction* func, UGeckoInstruction _inst) {(this->*dynaOpTable59[_inst.SUBOP5 ])(func, _inst);}
+void JitLLVM::DynaRunTable63(LLVMFunction* func, UGeckoInstruction _inst) {(this->*dynaOpTable63[_inst.SUBOP10])(func, _inst);}
+
+struct GekkoOPTemplate
+{
+	int opcode;
+	_Instruction Inst;
+};
+static GekkoOPTemplate primarytable[] =
+{
+	{4,  &JitLLVM::DynaRunTable4},         // RunTable4
+	{19, &JitLLVM::DynaRunTable19},        // RunTable19
+	{31, &JitLLVM::DynaRunTable31},        // RunTable31
+	{59, &JitLLVM::DynaRunTable59},        // RunTable59
+	{63, &JitLLVM::DynaRunTable63},        // RunTable63
+
+	{16, &JitLLVM::bcx},                   // bcx
+	{18, &JitLLVM::bx},                    // bx
+
+	{3,  &JitLLVM::FallBackToInterpreter}, // twi
+	{17, &JitLLVM::sc},                    // sc
+
+	{7,  &JitLLVM::mulli},                 // mulli
+	{8,  &JitLLVM::subfic},                // subfic
+	{10, &JitLLVM::cmpli},                 // cmpli
+	{11, &JitLLVM::cmpi},                  // cmpi
+	{12, &JitLLVM::addic},                 // addic
+	{13, &JitLLVM::addic_rc},              // addic_rc
+	{14, &JitLLVM::arith_imm},             // addi
+	{15, &JitLLVM::arith_imm},             // addis
+
+	{20, &JitLLVM::rlwXX},                 // rlwimix
+	{21, &JitLLVM::rlwXX},                 // rlwinmx
+	{23, &JitLLVM::rlwXX},                 // rlwnmx
+
+	{24, &JitLLVM::arith_imm},             // ori
+	{25, &JitLLVM::arith_imm},             // oris
+	{26, &JitLLVM::arith_imm},             // xori
+	{27, &JitLLVM::arith_imm},             // xoris
+	{28, &JitLLVM::arith_imm},             // andi_rc
+	{29, &JitLLVM::arith_imm},             // andis_rc
+
+	{32, &JitLLVM::lwz},                   // lwz
+	{33, &JitLLVM::lwzu},                  // lwzu
+	{34, &JitLLVM::lbz},                   // lbz
+	{35, &JitLLVM::lbzu},                  // lbzu
+	{40, &JitLLVM::lhz},                   // lhz
+	{41, &JitLLVM::lhzu},                  // lhzu
+	{42, &JitLLVM::lha},                   // lha
+	{43, &JitLLVM::lhau},                  // lhau
+
+	{44, &JitLLVM::sth},                   // sth
+	{45, &JitLLVM::sthu},                  // sthu
+	{36, &JitLLVM::stw},                   // stw
+	{37, &JitLLVM::stwu},                  // stwu
+	{38, &JitLLVM::stb},                   // stb
+	{39, &JitLLVM::stbu},                  // stbu
+
+	{46, &JitLLVM::lmw},                   // lmw
+	{47, &JitLLVM::stmw},                  // stmw
+
+	{48, &JitLLVM::lfs},                   // lfs
+	{49, &JitLLVM::lfsu},                  // lfsu
+	{50, &JitLLVM::lfd},                   // lfd
+	{51, &JitLLVM::lfdu},                  // lfdu
+
+	{52, &JitLLVM::stfs},                  // stfs
+	{53, &JitLLVM::stfsu},                 // stfsu
+	{54, &JitLLVM::stfd},                  // stfd
+	{55, &JitLLVM::stfdu},                 // stfdu
+
+	{56, &JitLLVM::psq_lXX},               // psq_l
+	{57, &JitLLVM::psq_lXX},               // psq_lu
+	{60, &JitLLVM::FallBackToInterpreter}, // psq_st
+	{61, &JitLLVM::FallBackToInterpreter}, // psq_stu
+
+	//missing: 0, 1, 2, 5, 6, 9, 22, 30, 62, 58
+};
+
+static GekkoOPTemplate table4[] =
+{     //SUBOP10
+	{0,    &JitLLVM::FallBackToInterpreter},   // ps_cmpu0
+	{32,   &JitLLVM::FallBackToInterpreter},   // ps_cmpo0
+	{40,   &JitLLVM::ps_neg},                  // ps_neg
+	{136,  &JitLLVM::ps_nabs},                 // ps_nabs
+	{264,  &JitLLVM::ps_abs},                  // ps_abs
+	{64,   &JitLLVM::FallBackToInterpreter},   // ps_cmpu1
+	{72,   &JitLLVM::ps_mr},                   // ps_mr
+	{96,   &JitLLVM::FallBackToInterpreter},   // ps_cmpo1
+	{528,  &JitLLVM::ps_merge00},              // ps_merge00
+	{560,  &JitLLVM::ps_merge01},              // ps_merge01
+	{592,  &JitLLVM::ps_merge10},              // ps_merge10
+	{624,  &JitLLVM::ps_merge11},              // ps_merge11
+	{1014, &JitLLVM::FallBackToInterpreter},   // dcbz_l
+};
+
+static GekkoOPTemplate table4_2[] =
+{
+	{10, &JitLLVM::ps_sum0},                   // ps_sum0
+	{11, &JitLLVM::ps_sum1},                   // ps_sum1
+	{12, &JitLLVM::ps_muls0},                  // ps_muls0
+	{13, &JitLLVM::ps_muls1},                  // ps_muls1
+	{14, &JitLLVM::ps_madds0},                 // ps_madds0
+	{15, &JitLLVM::ps_madds1},                 // ps_madds1
+	{18, &JitLLVM::ps_div},                    // ps_div
+	{20, &JitLLVM::ps_sub},                    // ps_sub
+	{21, &JitLLVM::ps_add},                    // ps_add
+	{23, &JitLLVM::ps_sel},                    // ps_sel
+	{24, &JitLLVM::ps_res},                    // ps_res
+	{25, &JitLLVM::ps_mul},                    // ps_mul
+	{26, &JitLLVM::FallBackToInterpreter},     // ps_rsqrte
+	{28, &JitLLVM::ps_msub},                   // ps_msub
+	{29, &JitLLVM::ps_madd},                   // ps_madd
+	{30, &JitLLVM::ps_nmsub},                  // ps_nmsub
+	{31, &JitLLVM::ps_nmadd},                  // ps_nmadd
+};
+
+
+static GekkoOPTemplate table4_3[] =
+{
+	{6,  &JitLLVM::psq_lXX},                   // psq_lx
+	{7,  &JitLLVM::FallBackToInterpreter},     // psq_stx
+	{38, &JitLLVM::psq_lXX},                   // psq_lux
+	{39, &JitLLVM::FallBackToInterpreter},     // psq_stux
+};
+
+static GekkoOPTemplate table19[] =
+{
+	{528, &JitLLVM::bcctrx},                   // bcctrx
+	{16,  &JitLLVM::bclrx},                    // bclrx
+	{257, &JitLLVM::crXX},                     // crand
+	{129, &JitLLVM::crXX},                     // crandc
+	{289, &JitLLVM::crXX},                     // creqv
+	{225, &JitLLVM::crXX},                     // crnand
+	{33,  &JitLLVM::crXX},                     // crnor
+	{449, &JitLLVM::crXX},                     // cror
+	{417, &JitLLVM::crXX},                     // crorc
+	{193, &JitLLVM::crXX},                     // crxor
+
+	{150, &JitLLVM::FallBackToInterpreter},    // isync
+	{0,   &JitLLVM::FallBackToInterpreter},    // mcrf
+
+	{50,  &JitLLVM::rfi},                      // rfi
+	{18,  &JitLLVM::Break},                    // rfid
+};
+
+
+static GekkoOPTemplate table31[] =
+{
+	{266,  &JitLLVM::addx},                    // addx
+	{778,  &JitLLVM::addx},                    // addox
+	{10,   &JitLLVM::addcx},                   // addcx
+	{522,  &JitLLVM::addcx},                   // addcox
+	{138,  &JitLLVM::addex},                   // addex
+	{650,  &JitLLVM::addex},                   // addeox
+	{234,  &JitLLVM::addmex},                  // addmex
+	{746,  &JitLLVM::addmex},                  // addmeox
+	{202,  &JitLLVM::addzex},                  // addzex
+	{714,  &JitLLVM::addzex},                  // addzeox
+	{491,  &JitLLVM::FallBackToInterpreter},   // divwx
+	{1003, &JitLLVM::FallBackToInterpreter},   // divwox
+	{459,  &JitLLVM::FallBackToInterpreter},   // divwux
+	{971,  &JitLLVM::FallBackToInterpreter},   // divwuox
+	{75,   &JitLLVM::mulhwx},                  // mulhwx
+	{11,   &JitLLVM::mulhwux},                 // mulhwux
+	{235,  &JitLLVM::mullwx},                  // mullwx
+	{747,  &JitLLVM::mullwx},                  // mullwox
+	{104,  &JitLLVM::negx},                    // negx
+	{616,  &JitLLVM::negx},                    // negox
+	{40,   &JitLLVM::subfx},                   // subfx
+	{552,  &JitLLVM::subfx},                   // subfox
+	{8,    &JitLLVM::subfcx},                  // subfcx
+	{520,  &JitLLVM::subfcx},                  // subfcox
+	{136,  &JitLLVM::subfex},                  // subfex
+	{648,  &JitLLVM::subfex},                  // subfeox
+	{232,  &JitLLVM::subfmex},                 // subfmex
+	{744,  &JitLLVM::subfmex},                 // subfmeox
+	{200,  &JitLLVM::subfzex},                 // subfzex
+	{712,  &JitLLVM::subfzex},                 // subfzeox
+
+	{28,  &JitLLVM::andx},                     // andx
+	{60,  &JitLLVM::andcx},                    // andcx
+	{444, &JitLLVM::orx},                      // orx
+	{124, &JitLLVM::norx},                     // norx
+	{316, &JitLLVM::xorx},                     // xorx
+	{412, &JitLLVM::orcx},                     // orcx
+	{476, &JitLLVM::nandx},                    // nandx
+	{284, &JitLLVM::eqvx},                     // eqvx
+	{0,   &JitLLVM::cmp},                      // cmp
+	{32,  &JitLLVM::cmpl},                     // cmpl
+	{26,  &JitLLVM::cntlzwx},                  // cntlzwx
+	{922, &JitLLVM::extsXx},                   // extshx
+	{954, &JitLLVM::extsXx},                   // extsbx
+	{536, &JitLLVM::srwx},                     // srwx
+	{792, &JitLLVM::FallBackToInterpreter},    // srawx
+	{824, &JitLLVM::FallBackToInterpreter},    // srawix
+	{24,  &JitLLVM::slwx},                     // slwx
+
+	{54,   &JitLLVM::FallBackToInterpreter},   // dcbst
+	{86,   &JitLLVM::FallBackToInterpreter},   // dcbf
+	{246,  &JitLLVM::DoNothing},               // dcbtst
+	{278,  &JitLLVM::DoNothing},               // dcbt
+	{470,  &JitLLVM::FallBackToInterpreter},   // dcbi
+	{758,  &JitLLVM::DoNothing},               // dcba
+	{1014, &JitLLVM::FallBackToInterpreter},   // dcbz
+
+	//load word
+	{23,  &JitLLVM::lwzx},                     // lwzx
+	{55,  &JitLLVM::lwzux},                    // lwzux
+
+	//load halfword
+	{279, &JitLLVM::lhzx},                     // lhzx
+	{311, &JitLLVM::lhzux},                    // lhzux
+
+	//load halfword signextend
+	{343, &JitLLVM::lhax},                     // lhax
+	{375, &JitLLVM::lhaux},                    // lhaux
+
+	//load byte
+	{87,  &JitLLVM::lbzx},                     // lbzx
+	{119, &JitLLVM::lbzux},                    // lbzux
+
+	//load byte reverse
+	{534, &JitLLVM::lwbrx},                    // lwbrx
+	{790, &JitLLVM::lhbrx},                    // lhbrx
+
+	// Conditional load/store (Wii SMP)
+	{150, &JitLLVM::FallBackToInterpreter},    // stwcxd
+	{20,  &JitLLVM::FallBackToInterpreter},    // lwarx
+
+	//load string (interpret these)
+	{533, &JitLLVM::FallBackToInterpreter},    // lswx
+	{597, &JitLLVM::FallBackToInterpreter},    // lswi
+
+	//store word
+	{151, &JitLLVM::stwx},                     // stwx
+	{183, &JitLLVM::stwux},                    // stwux
+
+	//store halfword
+	{407, &JitLLVM::sthx},                     // sthx
+	{439, &JitLLVM::sthux},                    // sthux
+
+	//store byte
+	{215, &JitLLVM::stbx},                     // stbx
+	{247, &JitLLVM::stbux},                    // stbux
+
+	//store bytereverse
+	{662, &JitLLVM::stwbrx},                   // stwbrx
+	{918, &JitLLVM::sthbrx},                   // sthbrx
+
+	{661, &JitLLVM::FallBackToInterpreter},    // stswx
+	{725, &JitLLVM::FallBackToInterpreter},    // stswi
+
+	// fp load/store
+	{535, &JitLLVM::lfsx},                     // lfsx
+	{567, &JitLLVM::lfsux},                    // lfsux
+	{599, &JitLLVM::lfdx},                     // lfdx
+	{631, &JitLLVM::lfdux},                    // lfdux
+
+	{663, &JitLLVM::stfsx},                    // stfsx
+	{695, &JitLLVM::stfsux},                   // stfsux
+	{727, &JitLLVM::stfdx},                    // stfdx
+	{759, &JitLLVM::stfdux},                   // stfdux
+	{983, &JitLLVM::stfiwx},                   // stfiwx
+
+	{19,  &JitLLVM::FallBackToInterpreter},    // mfcr
+	{83,  &JitLLVM::mfmsr},                    // mfmsr
+	{144, &JitLLVM::FallBackToInterpreter},    // mtcrf
+	{146, &JitLLVM::mtmsr},                    // mtmsr
+	{210, &JitLLVM::mtsr},                     // mtsr
+	{242, &JitLLVM::mtsrin},                   // mtsrin
+	{339, &JitLLVM::mfspr},                    // mfspr
+	{467, &JitLLVM::mtspr},                    // mtspr
+	{371, &JitLLVM::FallBackToInterpreter},    // mftb
+	{512, &JitLLVM::FallBackToInterpreter},    // mcrxr
+	{595, &JitLLVM::mfsr},                     // mfsr
+	{659, &JitLLVM::mfsrin},                   // mfsrin
+
+	{4,   &JitLLVM::FallBackToInterpreter},    // tw
+	{598, &JitLLVM::DoNothing},                // sync
+	{982, &JitLLVM::icbi},                     // icbi
+
+	// Unused instructions on GC
+	{310, &JitLLVM::FallBackToInterpreter},    // eciwx
+	{438, &JitLLVM::FallBackToInterpreter},    // ecowx
+	{854, &JitLLVM::DoNothing},                // eieio
+	{306, &JitLLVM::FallBackToInterpreter},    // tlbie
+	{370, &JitLLVM::FallBackToInterpreter},    // tlbia
+	{566, &JitLLVM::DoNothing},                // tlbsync
+};
+
+static GekkoOPTemplate table59[] =
+{
+	{18, &JitLLVM::FallBackToInterpreter},     // fdivsx
+	{20, &JitLLVM::fsubsx},                    // fsubsx
+	{21, &JitLLVM::faddsx},                    // faddsx
+//  {22, &JitLLVM::FallBackToInterpreter},       // fsqrtsx
+	{24, &JitLLVM::FallBackToInterpreter},     // fresx
+	{25, &JitLLVM::fmulsx},                    // fmulsx
+	{28, &JitLLVM::fmsubsx},                   // fmsubsx
+	{29, &JitLLVM::fmaddsx},                   // fmaddsx
+	{30, &JitLLVM::fnmsubsx},                  // fnmsubsx
+	{31, &JitLLVM::fnmaddsx},                  // fnmaddsx
+};
+
+static GekkoOPTemplate table63[] =
+{
+	{264, &JitLLVM::fabsx},                    // fabsx
+	{32,  &JitLLVM::FallBackToInterpreter},    // fcmpo
+	{0,   &JitLLVM::FallBackToInterpreter},    // fcmpu
+	{14,  &JitLLVM::FallBackToInterpreter},    // fctiwx
+	{15,  &JitLLVM::FallBackToInterpreter},    // fctiwzx
+	{72,  &JitLLVM::fmrx},                     // fmrx
+	{136, &JitLLVM::fnabsx},                   // fnabsx
+	{40,  &JitLLVM::fnegx},                    // fnegx
+	{12,  &JitLLVM::FallBackToInterpreter},    // frspx
+
+	{64,  &JitLLVM::FallBackToInterpreter},    // mcrfs
+	{583, &JitLLVM::FallBackToInterpreter},    // mffsx
+	{70,  &JitLLVM::FallBackToInterpreter},    // mtfsb0x
+	{38,  &JitLLVM::FallBackToInterpreter},    // mtfsb1x
+	{134, &JitLLVM::FallBackToInterpreter},    // mtfsfix
+	{711, &JitLLVM::FallBackToInterpreter},    // mtfsfx
+};
+
+static GekkoOPTemplate table63_2[] =
+{
+	{18, &JitLLVM::FallBackToInterpreter},     // fdivx
+	{20, &JitLLVM::fsubx},                     // fsubx
+	{21, &JitLLVM::faddx},                     // faddx
+	{22, &JitLLVM::FallBackToInterpreter},     // fsqrtx
+	{23, &JitLLVM::fselx},                     // fselx
+	{25, &JitLLVM::fmulx},                     // fmulx
+	{26, &JitLLVM::FallBackToInterpreter},     // frsqrtex
+	{28, &JitLLVM::fmsubx},                    // fmsubx
+	{29, &JitLLVM::fmaddx},                    // fmaddx
+	{30, &JitLLVM::fnmsubx},                   // fnmsubx
+	{31, &JitLLVM::fnmaddx},                   // fnmaddx
+};
+namespace JitLLVMTables
+{
+
+void CompileInstruction(JitLLVM* _jit, LLVMFunction* func, PPCAnalyst::CodeOp & op)
+{
+	(_jit->*dynaOpTable[op.inst.OPCD])(func, op.inst);
+	GekkoOPInfo *info = op.opinfo;
+	if (info)
+	{
+#ifdef OPLOG
+		if (!strcmp(info->opname, OP_TO_LOG)) // "mcrfs"
+		{
+			rsplocations.push_back(jit.js.compilerPC);
+		}
+#endif
+		info->compileCount++;
+		info->lastUse = jit->js.compilerPC;
+	}
+}
+
+void InitTables()
+{
+	// once initialized, tables are read-only
+	static bool initialized = false;
+	if (initialized)
+		return;
+
+	//clear
+	for (auto& tpl : dynaOpTable)
+	{
+		tpl = &JitLLVM::FallBackToInterpreter;
+	}
+
+	for (auto& tpl : dynaOpTable59)
+	{
+		tpl = &JitLLVM::FallBackToInterpreter;
+	}
+
+	for (int i = 0; i < 1024; i++)
+	{
+		dynaOpTable4 [i] = &JitLLVM::FallBackToInterpreter;
+		dynaOpTable19[i] = &JitLLVM::FallBackToInterpreter;
+		dynaOpTable31[i] = &JitLLVM::FallBackToInterpreter;
+		dynaOpTable63[i] = &JitLLVM::FallBackToInterpreter;
+	}
+
+	for (auto& tpl : primarytable)
+	{
+		dynaOpTable[tpl.opcode] = tpl.Inst;
+	}
+
+	for (int i = 0; i < 32; i++)
+	{
+		int fill = i << 5;
+		for (auto& tpl : table4_2)
+		{
+			int op = fill+tpl.opcode;
+			dynaOpTable4[op] = tpl.Inst;
+		}
+	}
+
+	for (int i = 0; i < 16; i++)
+	{
+		int fill = i << 6;
+		for (auto& tpl : table4_3)
+		{
+			int op = fill+tpl.opcode;
+			dynaOpTable4[op] = tpl.Inst;
+		}
+	}
+
+	for (auto& tpl : table4)
+	{
+		int op = tpl.opcode;
+		dynaOpTable4[op] = tpl.Inst;
+	}
+
+	for (auto& tpl : table31)
+	{
+		int op = tpl.opcode;
+		dynaOpTable31[op] = tpl.Inst;
+	}
+
+	for (auto& tpl : table19)
+	{
+		int op = tpl.opcode;
+		dynaOpTable19[op] = tpl.Inst;
+	}
+
+	for (auto& tpl : table59)
+	{
+		int op = tpl.opcode;
+		dynaOpTable59[op] = tpl.Inst;
+	}
+
+	for (auto& tpl : table63)
+	{
+		int op = tpl.opcode;
+		dynaOpTable63[op] = tpl.Inst;
+	}
+
+	for (int i = 0; i < 32; i++)
+	{
+		int fill = i << 5;
+		for (auto& tpl : table63_2)
+		{
+			int op = fill + tpl.opcode;
+			dynaOpTable63[op] = tpl.Inst;
+		}
+	}
+
+	initialized = true;
+}
+
+}  // namespace

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Tables.cpp
@@ -359,7 +359,7 @@ static GekkoOPTemplate table63_2[] =
 namespace JitLLVMTables
 {
 
-void CompileInstruction(JitLLVM* _jit, LLVMFunction* func, PPCAnalyst::CodeOp & op)
+void CompileInstruction(JitLLVM* _jit, LLVMFunction* func, PPCAnalyst::CodeOp& op)
 {
 	(_jit->*dynaOpTable[op.inst.OPCD])(func, op.inst);
 	GekkoOPInfo *info = op.opinfo;

--- a/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Tables.h
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitLLVM_Tables.h
@@ -1,0 +1,15 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Core/PowerPC/Gekko.h"
+#include "Core/PowerPC/PPCTables.h"
+#include "Core/PowerPC/JitLLVM/Jit.h"
+
+namespace JitLLVMTables
+{
+	void CompileInstruction(JitLLVM* _jit, LLVMFunction* func, PPCAnalyst::CodeOp & op);
+	void InitTables();
+}

--- a/Source/Core/Core/PowerPC/JitLLVM/JitModule.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitModule.cpp
@@ -1,0 +1,497 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/PowerPC/JitInterface.h"
+#include "Core/PowerPC/JitLLVM/JitHelpers.h"
+#include "Core/PowerPC/JitLLVM/JitModule.h"
+
+using namespace llvm;
+
+static Type* GeneratePPCState()
+{
+	LLVMContext& con = getGlobalContext();
+
+	// Basic types to make our life easier
+	Type* llvm_i8 = Type::getInt8Ty(con);
+	Type* llvm_i16 = Type::getInt16Ty(con);
+	Type* llvm_i32 = Type::getInt32Ty(con);
+	Type* llvm_i64 = Type::getInt64Ty(con);
+	Type* llvm_f64 = Type::getDoubleTy(con);
+
+	// This needs to match the ppcState in PowerPC.h otherwise we will be in trouble
+	// XXX: This isn't a fully complete representation of the ppcState structure
+	// Especially on x86_64 where the paired registers are required to be aligned to a boundary
+	std::vector<Type*> struct_values =
+	{
+		ArrayType::get(llvm_i32, 32),           // GPRs
+		llvm_i32,                               // PC
+		llvm_i32,                               // NPC
+		ArrayType::get(llvm_i64, 8),            // cr_val
+		llvm_i32,                               // MSR
+		llvm_i32,                               // fpscr
+		llvm_i32,                               // Exceptions
+		llvm_i32,                               // Downcount
+		llvm_i8,                                // xer_ca
+		llvm_i8,                                // xer_so_ov
+		llvm_i16,                               // xer_stringctrl
+		ArrayType::get(
+			ArrayType::get(llvm_f64, 32), 2), // PS
+		ArrayType::get(llvm_i32, 16),           // SR
+		ArrayType::get(llvm_i32, 1024),         // SPRs
+	};
+
+	return StructType::create(struct_values, "PowerPCState", false);
+}
+
+LLVMModule::LLVMModule(ExecutionEngine* engine, u32 address)
+	: m_engine(engine), m_address(address)
+{
+	LLVMContext& con = getGlobalContext();
+
+	m_mod = new Module(StringFromFormat("ppc%08x", m_address), con);
+
+	m_named_binder = new LLVMNamedBinding();
+	m_binder = new LLVMBinding(m_engine, m_mod, m_named_binder);
+
+	GenerateGlobalVariables();
+	BindGlobalFunctions();
+
+	FunctionType* main_type = GenerateFunctionType(Type::getVoidTy(con));
+	m_func = new LLVMFunction(m_mod, m_address, main_type);
+
+	GeneratePairedLoadFunction();
+}
+
+void LLVMModule::GenerateGlobalVariables()
+{
+	LLVMContext& con = getGlobalContext();
+
+	std::vector<Constant*> dequantize_values;
+	std::vector<Constant*> quantize_values;
+
+	for (u32 i = 0; i < 32; ++i)
+		dequantize_values.push_back(ConstantFP::get(Type::getFloatTy(con), 1.0 / (1ULL << i)));
+	for (u32 i = 32; i > 0; --i)
+		dequantize_values.push_back(ConstantFP::get(Type::getFloatTy(con), 1ULL << i));
+
+	for (u32 i = 0; i < 32; ++i)
+		quantize_values.push_back(ConstantFP::get(Type::getFloatTy(con), 1ULL << i));
+	for (u32 i = 32; i > 0; --i)
+		quantize_values.push_back(ConstantFP::get(Type::getFloatTy(con), 1.0 / (1ULL << i)));
+
+	Constant* dequantize_constant = ConstantArray::get(ArrayType::get(Type::getFloatTy(con), 64), dequantize_values);
+	Constant* quantize_constant = ConstantArray::get(ArrayType::get(Type::getFloatTy(con), 64), quantize_values);
+
+	m_mod->getOrInsertGlobal("dequantize_table", ArrayType::get(Type::getFloatTy(con), 64));
+	GlobalVariable* dequantize_global = m_mod->getNamedGlobal("dequantize_table");
+	dequantize_global->setInitializer(dequantize_constant);
+
+	m_mod->getOrInsertGlobal("quantize_table", ArrayType::get(Type::getFloatTy(con), 64));
+	GlobalVariable* quantize_global = m_mod->getNamedGlobal("quantize_table");
+	quantize_global->setInitializer(quantize_constant);
+
+	/* Types */
+	static Type* ppcStateType = GeneratePPCState();
+	Type* ppcStatePtr = ppcStateType->getPointerTo();
+
+	/* Constants */
+	Constant* const_ppcstate_val = ConstantInt::getIntegerValue(ppcStatePtr, APInt(64, (uint64_t)&PowerPC::ppcState));
+	m_mod->getOrInsertGlobal("ppcState_ptr", ppcStatePtr);
+	GlobalVariable* ppcStatePtr_global = m_mod->getNamedGlobal("ppcState_ptr");
+	ppcStatePtr_global->setInitializer(const_ppcstate_val);
+}
+
+void LLVMModule::BindGlobalFunctions()
+{
+	LLVMContext& con = getGlobalContext();
+
+	Function* dispatcher_func;
+	FunctionType* void_type = GenerateFunctionType(Type::getVoidTy(con));
+
+	dispatcher_func = Function::Create(void_type, Function::ExternalLinkage, "Dispatcher", m_mod);
+	dispatcher_func->setCallingConv(CallingConv::C);
+	dispatcher_func->setDoesNotReturn();
+	m_binder->Bind(dispatcher_func, (void*)JitInterface::GetDispatcher());
+
+	// PowerPC::CheckExceptions
+	{
+		FunctionType* type = GenerateFunctionType(
+			Type::getVoidTy(con));
+
+		Function* bound_func = Function::Create(type, Function::ExternalLinkage, "PowerPC::CheckExceptions", m_mod);
+		bound_func->setCallingConv(CallingConv::C);
+		m_binder->Bind(bound_func, (void*)&PowerPC::CheckExceptions);
+	}
+
+	// Generate our loadstore calling functions
+	// Read_U64
+	{
+		FunctionType* type = GenerateFunctionType(
+			Type::getInt64Ty(con),
+			Type::getInt32Ty(con));
+
+		Function* bound_func = Function::Create(type, Function::ExternalLinkage, "PowerPC::Read_U64", m_mod);
+		bound_func->setCallingConv(CallingConv::C);
+		m_binder->Bind(bound_func, (void*)PowerPC::Read_U64);
+	}
+	// Read_U32
+	{
+		FunctionType* type = GenerateFunctionType(
+			Type::getInt32Ty(con),
+			Type::getInt32Ty(con));
+
+		Function* bound_func = Function::Create(type, Function::ExternalLinkage, "PowerPC::Read_U32", m_mod);
+		bound_func->setCallingConv(CallingConv::C);
+		m_binder->Bind(bound_func, (void*)PowerPC::Read_U32);
+	}
+	// Read_U16
+	{
+		FunctionType* type = GenerateFunctionType(
+			Type::getInt16Ty(con),
+			Type::getInt32Ty(con));
+
+		Function* bound_func = Function::Create(type, Function::ExternalLinkage, "PowerPC::Read_U16", m_mod);
+		bound_func->setCallingConv(CallingConv::C);
+		m_binder->Bind(bound_func, (void*)PowerPC::Read_U16);
+	}
+	// Read_U8
+	{
+		FunctionType* type = GenerateFunctionType(
+			Type::getInt8Ty(con),
+			Type::getInt32Ty(con));
+
+		Function* bound_func = Function::Create(type, Function::ExternalLinkage, "PowerPC::Read_U8", m_mod);
+		bound_func->setCallingConv(CallingConv::C);
+		m_binder->Bind(bound_func, (void*)PowerPC::Read_U8);
+	}
+	// Write_U64
+	{
+		FunctionType* type = GenerateFunctionType(
+			Type::getVoidTy(con),
+			Type::getInt64Ty(con),
+			Type::getInt32Ty(con));
+
+		Function* bound_func = Function::Create(type, Function::ExternalLinkage, "PowerPC::Write_U64", m_mod);
+		bound_func->setCallingConv(CallingConv::C);
+		m_binder->Bind(bound_func, (void*)PowerPC::Write_U64);
+	}
+	// Write_U32
+	{
+		FunctionType* type = GenerateFunctionType(
+			Type::getVoidTy(con),
+			Type::getInt32Ty(con),
+			Type::getInt32Ty(con));
+
+		Function* bound_func = Function::Create(type, Function::ExternalLinkage, "PowerPC::Write_U32", m_mod);
+		bound_func->setCallingConv(CallingConv::C);
+		m_binder->Bind(bound_func, (void*)PowerPC::Write_U32);
+	}
+	// Write_U16
+	{
+		FunctionType* type = GenerateFunctionType(
+			Type::getVoidTy(con),
+			Type::getInt16Ty(con),
+			Type::getInt32Ty(con));
+
+		Function* bound_func = Function::Create(type, Function::ExternalLinkage, "PowerPC::Write_U16", m_mod);
+		bound_func->setCallingConv(CallingConv::C);
+		m_binder->Bind(bound_func, (void*)PowerPC::Write_U16);
+	}
+	// Write_U8
+	{
+		FunctionType* type = GenerateFunctionType(
+			Type::getVoidTy(con),
+			Type::getInt8Ty(con),
+			Type::getInt32Ty(con));
+
+		Function* bound_func = Function::Create(type, Function::ExternalLinkage, "PowerPC::Write_U8", m_mod);
+		bound_func->setCallingConv(CallingConv::C);
+		m_binder->Bind(bound_func, (void*)PowerPC::Write_U8);
+	}
+}
+
+void LLVMModule::GeneratePairedLoadFunction()
+{
+	LLVMContext& con = getGlobalContext();
+
+	VectorType* ret_type = VectorType::get(Type::getFloatTy(con), 2);
+
+	FunctionType* main_type = GenerateFunctionType(
+		ret_type, // returns <2 x float>
+		Type::getInt8Ty(con), // bool paired
+		Type::getInt8Ty(con), // u3 type
+		Type::getInt8Ty(con), // u6 scale
+		Type::getInt32Ty(con)); // u32 address
+	m_paired_load = new LLVMFunction(m_mod, "Helper_PairedLoad", main_type);
+
+	BasicBlock* ending_block = m_paired_load->CreateBlock("EndBlock");
+
+	// QUANTIZE_FLOAT
+	BasicBlock* float_case      = m_paired_load->CreateBlock("Float_Single");
+	BasicBlock* float_pair_case = m_paired_load->CreateBlock("Float_Paired");
+
+	// QUANTIZE_U8
+	BasicBlock* u8_case      = m_paired_load->CreateBlock("U8_Single");
+	BasicBlock* u8_pair_case = m_paired_load->CreateBlock("U8_Paired");
+
+	// QUANTIZE_U16
+	BasicBlock* u16_case      = m_paired_load->CreateBlock("U16_Single");
+	BasicBlock* u16_pair_case = m_paired_load->CreateBlock("U16_Paired");
+
+	// QUANTIZE_S8
+	BasicBlock* s8_case      = m_paired_load->CreateBlock("S8_Single");
+	BasicBlock* s8_pair_case = m_paired_load->CreateBlock("S8_Paired");
+
+	// QUANTIZE_S16
+	BasicBlock* s16_case      = m_paired_load->CreateBlock("S16_Single");
+	BasicBlock* s16_pair_case = m_paired_load->CreateBlock("S16_Paired");
+
+	std::vector<Argument*> args;
+	for (Argument& arg : m_paired_load->GetFunction()->args())
+		args.push_back(&arg);
+
+	IRBuilder<>* builder = m_paired_load->GetBuilder();
+
+	std::vector<Constant*> default_ret_values;
+		default_ret_values.push_back(ConstantFP::get(Type::getFloatTy(con), 1.0f));
+		default_ret_values.push_back(ConstantFP::get(Type::getFloatTy(con), 1.0f));
+
+	Value* ret_values = ConstantVector::get(default_ret_values);
+
+	std::vector<Constant*> invalid_values;
+		invalid_values.push_back(ConstantFP::get(Type::getFloatTy(con), 0.0f));
+		invalid_values.push_back(ConstantFP::get(Type::getFloatTy(con), 0.0f));
+
+	Value* invalid_ret_values = ConstantVector::get(invalid_values);
+
+	BasicBlock* start_block = &m_paired_load->GetFunction()->front();
+	SwitchInst* switch_statement = builder->CreateSwitch(args[1], ending_block, 5);
+
+	switch_statement->addCase(builder->getInt8(QUANTIZE_FLOAT), float_case);
+	switch_statement->addCase(builder->getInt8(QUANTIZE_U8),    u8_case);
+	switch_statement->addCase(builder->getInt8(QUANTIZE_U16),   u16_case);
+	switch_statement->addCase(builder->getInt8(QUANTIZE_S8),    s8_case);
+	switch_statement->addCase(builder->getInt8(QUANTIZE_S16),   s16_case);
+
+	std::array<std::pair<Value*, Value*>, 5> phi_values;
+
+	builder->SetInsertPoint(float_case);
+	{
+		Value* res0 = CreateReadU32(m_paired_load, args[3]);
+		res0 = builder->CreateBitCast(res0, builder->getFloatTy());
+		Value* final_res = builder->CreateInsertElement(ret_values, res0, builder->getInt32(0), "float_res");
+		Value* cmp_val = builder->CreateICmpEQ(args[0], builder->getInt8(1));
+		builder->CreateCondBr(cmp_val, float_pair_case, ending_block);
+
+		builder->SetInsertPoint(float_pair_case);
+			Value* res1 = CreateReadU32(m_paired_load, builder->CreateAdd(args[3], builder->getInt32(4)));
+			res1 = builder->CreateBitCast(res1, builder->getFloatTy());
+			Value* final_paired_res = builder->CreateInsertElement(final_res, res1, builder->getInt32(1));
+			builder->CreateBr(ending_block);
+		phi_values[0] = std::make_pair(final_res, final_paired_res);
+	}
+
+	builder->SetInsertPoint(u8_case);
+	{
+		Value* dequantize_value = LoadDequantizeValue(m_paired_load, args[2]);
+		Value* res0 = CreateReadU8(m_paired_load, args[3], false);
+		res0 = builder->CreateUIToFP(res0, builder->getFloatTy());
+		res0 = builder->CreateFMul(res0, dequantize_value);
+		Value* final_res = builder->CreateInsertElement(ret_values, res0, builder->getInt32(0), "u8_res");
+		Value* cmp_val = builder->CreateICmpEQ(args[0], builder->getInt8(1));
+		builder->CreateCondBr(cmp_val, u8_pair_case, ending_block);
+
+		builder->SetInsertPoint(u8_pair_case);
+			Value* res1 = CreateReadU8(m_paired_load, builder->CreateAdd(args[3], builder->getInt32(1)), false);
+			res1 = builder->CreateUIToFP(res1, builder->getFloatTy());
+			res1 = builder->CreateFMul(res1, dequantize_value);
+			Value* final_paired_res = builder->CreateInsertElement(final_res, res1, builder->getInt32(1));
+			builder->CreateBr(ending_block);
+		phi_values[1] = std::make_pair(final_res, final_paired_res);
+	}
+
+	builder->SetInsertPoint(u16_case);
+	{
+		Value* dequantize_value = LoadDequantizeValue(m_paired_load, args[2]);
+		Value* res0 = CreateReadU16(m_paired_load, args[3], false);
+		res0 = builder->CreateUIToFP(res0, builder->getFloatTy());
+		res0 = builder->CreateFMul(res0, dequantize_value);
+		Value* final_res = builder->CreateInsertElement(ret_values, res0, builder->getInt32(0), "u16_res");
+		Value* cmp_val = builder->CreateICmpEQ(args[0], builder->getInt8(1));
+		builder->CreateCondBr(cmp_val, u16_pair_case, ending_block);
+
+		builder->SetInsertPoint(u16_pair_case);
+			Value* res1 = CreateReadU16(m_paired_load, builder->CreateAdd(args[3], builder->getInt32(2)), false);
+			res1 = builder->CreateUIToFP(res1, builder->getFloatTy());
+			res1 = builder->CreateFMul(res1, dequantize_value);
+			Value* final_paired_res = builder->CreateInsertElement(final_res, res1, builder->getInt32(1));
+			builder->CreateBr(ending_block);
+		phi_values[2] = std::make_pair(final_res, final_paired_res);
+	}
+
+	builder->SetInsertPoint(s8_case);
+	{
+		Value* dequantize_value = LoadDequantizeValue(m_paired_load, args[2]);
+		Value* res0 = CreateReadU8(m_paired_load, args[3], true);
+		res0 = builder->CreateUIToFP(res0, builder->getFloatTy());
+		res0 = builder->CreateFMul(res0, dequantize_value);
+		Value* final_res = builder->CreateInsertElement(ret_values, res0, builder->getInt32(0), "s8_res");
+		Value* cmp_val = builder->CreateICmpEQ(args[0], builder->getInt8(1));
+		builder->CreateCondBr(cmp_val, s8_pair_case, ending_block);
+
+		builder->SetInsertPoint(s8_pair_case);
+			Value* res1 = CreateReadU8(m_paired_load, builder->CreateAdd(args[3], builder->getInt32(1)), true);
+			res1 = builder->CreateSIToFP(res1, builder->getFloatTy());
+			res1 = builder->CreateFMul(res1, dequantize_value);
+			Value* final_paired_res = builder->CreateInsertElement(final_res, res1, builder->getInt32(1));
+			builder->CreateBr(ending_block);
+		phi_values[3] = std::make_pair(final_res, final_paired_res);
+	}
+
+	builder->SetInsertPoint(s16_case);
+	{
+		Value* dequantize_value = LoadDequantizeValue(m_paired_load, args[2]);
+		Value* res0 = CreateReadU16(m_paired_load, args[3], true);
+		res0 = builder->CreateUIToFP(res0, builder->getFloatTy());
+		res0 = builder->CreateFMul(res0, dequantize_value);
+		Value* final_res = builder->CreateInsertElement(ret_values, res0, builder->getInt32(0), "s16_res");
+		Value* cmp_val = builder->CreateICmpEQ(args[0], builder->getInt8(1));
+		builder->CreateCondBr(cmp_val, s16_pair_case, ending_block);
+
+		builder->SetInsertPoint(s16_pair_case);
+			Value* res1 = CreateReadU16(m_paired_load, builder->CreateAdd(args[3], builder->getInt32(2)), true);
+			res1 = builder->CreateSIToFP(res1, builder->getFloatTy());
+			res1 = builder->CreateFMul(res1, dequantize_value);
+			Value* final_paired_res = builder->CreateInsertElement(final_res, res1, builder->getInt32(1));
+			builder->CreateBr(ending_block);
+		phi_values[4] = std::make_pair(final_res, final_paired_res);
+	}
+
+	builder->SetInsertPoint(ending_block);
+
+	PHINode* final_phi = builder->CreatePHI(ret_type, 11);
+	final_phi->addIncoming(phi_values[0].first, float_case);
+	final_phi->addIncoming(phi_values[1].first, u8_case);
+	final_phi->addIncoming(phi_values[2].first, u16_case);
+	final_phi->addIncoming(phi_values[3].first, s8_case);
+	final_phi->addIncoming(phi_values[4].first, s16_case);
+	final_phi->addIncoming(phi_values[0].second, float_pair_case);
+	final_phi->addIncoming(phi_values[1].second, u8_pair_case);
+	final_phi->addIncoming(phi_values[2].second, u16_pair_case);
+	final_phi->addIncoming(phi_values[3].second, s8_pair_case);
+	final_phi->addIncoming(phi_values[4].second, s16_pair_case);
+	final_phi->addIncoming(invalid_ret_values, start_block);
+	builder->CreateRet(final_phi);
+}
+
+Value* LLVMModule::CreateReadU64(LLVMFunction* func, Value* address)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Function* bound_func = m_binder->GetBinding((void*)PowerPC::Read_U64);
+
+	return builder->CreateCall(bound_func, address);
+}
+
+Value* LLVMModule::CreateReadU32(LLVMFunction* func, Value* address)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Function* bound_func = m_binder->GetBinding((void*)PowerPC::Read_U32);
+
+	return builder->CreateCall(bound_func, address);
+}
+
+Value* LLVMModule::CreateReadU16(LLVMFunction* func, Value* address, bool needs_sext)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Function* bound_func = m_binder->GetBinding((void*)PowerPC::Read_U16);
+
+	Value* res = builder->CreateCall(bound_func, address);
+
+	if (needs_sext)
+		return builder->CreateSExt(res, builder->getInt32Ty());
+	else
+		return builder->CreateZExt(res, builder->getInt32Ty());
+}
+
+Value* LLVMModule::CreateReadU8(LLVMFunction* func, Value* address, bool needs_sext)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Function* bound_func = m_binder->GetBinding((void*)PowerPC::Read_U8);
+
+	Value* res = builder->CreateCall(bound_func, address);
+
+	if (needs_sext)
+		return builder->CreateSExt(res, builder->getInt32Ty());
+	else
+		return builder->CreateZExt(res, builder->getInt32Ty());
+}
+
+Value* LLVMModule::CreateWriteU64(LLVMFunction* func, Value* val, Value* address)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Function* bound_func = m_binder->GetBinding((void*)PowerPC::Write_U64);
+
+	std::vector<Value*> args = {val, address};
+
+	return builder->CreateCall(bound_func, args);
+}
+
+Value* LLVMModule::CreateWriteU32(LLVMFunction* func, Value* val, Value* address)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Function* bound_func = m_binder->GetBinding((void*)PowerPC::Write_U32);
+
+	std::vector<Value*> args = {val, address};
+
+	return builder->CreateCall(bound_func, args);
+}
+
+Value* LLVMModule::CreateWriteU16(LLVMFunction* func, Value* val, Value* address)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Function* bound_func = m_binder->GetBinding((void*)PowerPC::Write_U16);
+
+	val = builder->CreateTrunc(val, builder->getInt16Ty());
+
+	std::vector<Value*> args = {val, address};
+
+	return builder->CreateCall(bound_func, args);
+}
+
+Value* LLVMModule::CreateWriteU8(LLVMFunction* func, Value* val, Value* address)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+	Function* bound_func = m_binder->GetBinding((void*)PowerPC::Write_U8);
+
+	val = builder->CreateTrunc(val, builder->getInt8Ty());
+
+	std::vector<Value*> args = {val, address};
+
+	return builder->CreateCall(bound_func, args);
+}
+
+Value* LLVMModule::LoadDequantizeValue(LLVMFunction* func, Value* scale)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	GlobalVariable* dequantize_global = m_mod->getNamedGlobal("dequantize_table");
+	const std::vector<Value*> loc =
+	{
+		builder->getInt32(0),
+		scale,
+	};
+
+	Value* scale_val = builder->CreateGEP(dequantize_global, loc);
+	return builder->CreateLoad(scale_val, "Dequantize_Scale");
+}
+
+Value* LLVMModule::CreatePairedLoad(LLVMFunction* func, Value* paired, Value* type, Value* scale, Value* address)
+{
+	IRBuilder<>* builder = func->GetBuilder();
+
+	std::vector<Value*> args = {paired, type, scale, address};
+
+	return builder->CreateCall(m_paired_load->GetFunction(), args);
+}
+

--- a/Source/Core/Core/PowerPC/JitLLVM/JitModule.cpp
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitModule.cpp
@@ -106,10 +106,9 @@ void LLVMModule::BindGlobalFunctions()
 {
 	LLVMContext& con = getGlobalContext();
 
-	Function* dispatcher_func;
 	FunctionType* void_type = GenerateFunctionType(Type::getVoidTy(con));
 
-	dispatcher_func = Function::Create(void_type, Function::ExternalLinkage, "Dispatcher", m_mod);
+	Function* dispatcher_func = Function::Create(void_type, Function::ExternalLinkage, "Dispatcher", m_mod);
 	dispatcher_func->setCallingConv(CallingConv::C);
 	dispatcher_func->setDoesNotReturn();
 	m_binder->Bind(dispatcher_func, (void*)JitInterface::GetDispatcher());

--- a/Source/Core/Core/PowerPC/JitLLVM/JitModule.h
+++ b/Source/Core/Core/PowerPC/JitLLVM/JitModule.h
@@ -1,0 +1,57 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Core/PowerPC/JitLLVM/Jit.h"
+#include "Core/PowerPC/JitLLVM/JitBinding.h"
+#include "Core/PowerPC/JitLLVM/JitFunction.h"
+
+class LLVMNamedBinding;
+class LLVMBinding;
+class LLVMFunction;
+
+class LLVMModule
+{
+private:
+	llvm::Module* m_mod;
+	llvm::ExecutionEngine* m_engine;
+	u32 m_address;
+
+	LLVMFunction* m_func;
+
+	// Helpers
+	LLVMFunction* m_paired_load;
+
+	LLVMNamedBinding* m_named_binder;
+	LLVMBinding* m_binder;
+
+	void GenerateGlobalVariables();
+	void BindGlobalFunctions();
+
+	void GeneratePairedLoadFunction();
+
+	llvm::Value* LoadDequantizeValue(LLVMFunction* func, llvm::Value* scale);
+
+public:
+	LLVMModule(llvm::ExecutionEngine* engine, u32 address);
+	llvm::Module* GetModule() { return m_mod; }
+	LLVMFunction* GetFunction() { return m_func; }
+	LLVMBinding* GetBinding() { return m_binder; }
+	LLVMNamedBinding* GetNamedBinding() { return m_named_binder; }
+
+	// Helpers
+	llvm::Value* CreateReadU64(LLVMFunction* func, llvm::Value* address);
+	llvm::Value* CreateReadU32(LLVMFunction* func, llvm::Value* address);
+	llvm::Value* CreateReadU16(LLVMFunction* func, llvm::Value* address, bool needs_sext);
+	llvm::Value* CreateReadU8(LLVMFunction* func, llvm::Value* address, bool needs_sext);
+	llvm::Value* CreateWriteU64(LLVMFunction* func, llvm::Value* val, llvm::Value* address);
+	llvm::Value* CreateWriteU32(LLVMFunction* func, llvm::Value* val, llvm::Value* address);
+	llvm::Value* CreateWriteU16(LLVMFunction* func, llvm::Value* val, llvm::Value* address);
+	llvm::Value* CreateWriteU8(LLVMFunction* func, llvm::Value* val, llvm::Value* address);
+
+	// Returns a <2 x float> with the values of the registers that go in to PS{0,1}
+	llvm::Value* CreatePairedLoad(LLVMFunction* func, llvm::Value* paired, llvm::Value* type, llvm::Value* scale, llvm::Value* address);
+
+};

--- a/Source/Core/Core/PowerPC/TieredRecompiler.cpp
+++ b/Source/Core/Core/PowerPC/TieredRecompiler.cpp
@@ -61,7 +61,7 @@ namespace TieredRecompiler
 		m_rec_thread.join();
 		m_work_queue.Clear();
 #if HAS_LLVM
-		delete m_llvm_jit.release();
+		m_llvm_jit.reset();
 #endif
 	}
 

--- a/Source/Core/Core/PowerPC/TieredRecompiler.cpp
+++ b/Source/Core/Core/PowerPC/TieredRecompiler.cpp
@@ -1,0 +1,75 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "Common/Event.h"
+#include "Common/FifoQueue.h"
+#include "Common/Thread.h"
+
+#include "Core/PowerPC/TieredRecompiler.h"
+#if HAS_LLVM
+#include "Core/PowerPC/JitLLVM/Jit.h"
+#endif
+
+namespace TieredRecompiler
+{
+	bool m_running = false;
+	std::thread m_rec_thread;
+	Common::Event m_has_work;
+	Common::FifoQueue<u32, true> m_work_queue;
+#if HAS_LLVM
+	std::unique_ptr<JitLLVM> m_llvm_jit;
+#endif
+
+	static void RecompilerThread()
+	{
+		Common::SetCurrentThreadName("Tiered Recompiler");
+		m_running = true;
+
+		while (m_running)
+		{
+			if (!m_work_queue.Size())
+				m_has_work.Wait();
+
+			u32 work_address = 0;
+			if (m_work_queue.Pop(work_address))
+			{
+				// Looks like we have a bit of work
+#if HAS_LLVM
+				m_llvm_jit->Jit(work_address);
+#endif
+			}
+		}
+	}
+
+	bool Init()
+	{
+#if HAS_LLVM
+		m_llvm_jit.reset(new JitLLVM());
+		m_llvm_jit->Init();
+		m_rec_thread = std::thread(RecompilerThread);
+#endif
+		return true;
+	}
+
+	void Shutdown()
+	{
+		m_running = false;
+		m_has_work.Set(); // Give the event in the thread a kick
+		m_rec_thread.join();
+		m_work_queue.Clear();
+#if HAS_LLVM
+		delete m_llvm_jit.release();
+#endif
+	}
+
+	void AddWorkToQueue(u32 em_address)
+	{
+#if HAS_LLVM
+		m_work_queue.Push(em_address);
+		m_has_work.Set();
+#endif
+	}
+}

--- a/Source/Core/Core/PowerPC/TieredRecompiler.h
+++ b/Source/Core/Core/PowerPC/TieredRecompiler.h
@@ -1,0 +1,11 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+namespace TieredRecompiler
+{
+	bool Init();
+	void Shutdown();
+	// If we want to queue up work to the tiered recompiler, we do it here
+	void AddWorkToQueue(u32 em_address);
+}


### PR DESCRIPTION
Thsi is a /super/ experimental tiered LLVM recompiler for Dolphin.
The idea behind this is that we will be able to identify hot blocks that are running and pass it off to the LLVM tier two recompiler that is compiling on a different thread.
There is still a /lot/ of work that still needs to go in to this, and it may not even pay off in the end, LLVM may produce more terrible code for us(and currently does) than what our regular recompilers produce.

Things to take note with the state of this recompiler
- It's not actually hooked up (won't compile blocks without modifying the source)
- Even if a block is compiled, it won't drop itself in as a replacement to the ones from the tier one recompilers
- No Fastmem (Super bad loadstores)
- Only 161(68.8%) instructions implemented
- No block linking
- Zero optimizations done to it
- Only tested on x86_64, AArch64 threw asserts about 32bit relative offsets being too large (bigger than 32bits)

Things that also still need to be done
- More instructions
- On fly block replacement
- Heuristics to get the tier one recompiler to compile new blocks
- Vectorize paired instructions properly
- Tons more

So super experimental LLVM recompiler for use only by devs currently