### PR TITLE
CheatSearchTab: Show floating point value equivalent

### DIFF
--- a/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <array>
+#include <cstring>
 #include <wx/button.h>
 #include <wx/choice.h>
 #include <wx/listctrl.h>
@@ -294,6 +295,16 @@ void CheatSearchTab::UpdateCheatSearchResultsList()
 
 			buf.Printf("0x%08X", display_value);
 			m_lview_search_results->SetItem(index, 1, buf);
+
+			float display_value_float = 0.0f;
+			std::memcpy(&display_value_float, &display_value, sizeof(u32));
+			buf.Printf("%e", display_value_float);
+			m_lview_search_results->SetItem(index, 2, buf);
+
+			double display_value_double = 0.0;
+			std::memcpy(&display_value_double, &display_value, sizeof(u32));
+			buf.Printf("%e", display_value_double);
+			m_lview_search_results->SetItem(index, 3, buf);
 		}
 
 		m_lview_search_results->Thaw();
@@ -320,4 +331,6 @@ void CheatSearchTab::ResetListViewColumns()
 {
 	m_lview_search_results->AppendColumn(_("Address"));
 	m_lview_search_results->AppendColumn(_("Value"));
+	m_lview_search_results->AppendColumn(_("Value (float)"));
+	m_lview_search_results->AppendColumn(_("Value (double)"));
 }

--- a/Source/Core/DolphinWX/Cheats/CheatSearchTab.h
+++ b/Source/Core/DolphinWX/Cheats/CheatSearchTab.h
@@ -10,7 +10,7 @@
 class wxButton;
 class wxChoice;
 class wxFocusEvent;
-class wxListBox;
+class wxListView;
 class wxRadioBox;
 class wxRadioButton;
 class wxStaticText;
@@ -31,11 +31,18 @@ private:
 		u32 old_value;
 	};
 
+	void UpdateCheatSearchResultsList();
+	void ResetListViewColumns();
+	void StartNewSearch(wxCommandEvent& event);
+	void FilterCheatSearchResults(wxCommandEvent& event);
+	void CreateARCode(wxCommandEvent&);
+	void ApplyFocus(wxFocusEvent&);
+
 	std::vector<CheatSearchResult> m_search_results;
 	unsigned int m_search_type_size;
 
 	wxChoice* m_search_type;
-	wxListBox* m_lbox_search_results;
+	wxListView* m_lview_search_results;
 	wxStaticText* m_label_results_count;
 	wxTextCtrl* m_textctrl_value_x;
 
@@ -49,10 +56,4 @@ private:
 		wxRadioButton* rad_oldvalue;
 		wxRadioButton* rad_uservalue;
 	} m_value_x_radiobtn;
-
-	void UpdateCheatSearchResultsList();
-	void StartNewSearch(wxCommandEvent& event);
-	void FilterCheatSearchResults(wxCommandEvent& event);
-	void CreateARCode(wxCommandEvent&);
-	void ApplyFocus(wxFocusEvent&);
 };


### PR DESCRIPTION
Shows the floating-point equivalent of the hex value displayed during searches in a new column.

Solves issue [8842](https://code.google.com/p/dolphin-emu/issues/detail?id=8842)