### PR TITLE
JitInterface: fix disassembly entry point

### DIFF
--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -202,8 +202,7 @@ namespace JitInterface
 
 		JitBlock* block = jit->GetBlockCache()->GetBlock(block_num);
 
-		*code = (const u8*)jit->GetBlockCache()->GetCompiledCodeFromBlock(block_num);
-
+		*code = block->checkedEntry;
 		*code_size = block->codeSize;
 		*address = block->originalAddress;
 		return 0;


### PR DESCRIPTION
This adds the [downcount check code](https://github.com/dolphin-emu/dolphin/blob/f800a5b93fd60696f86ebb338c6599ec4b6402cb/Source/Core/Core/PowerPC/Jit64/Jit.cpp#L572) to the disassembly text and removes the bogus instructions at the end.