### PR TITLE
Jit64: duplicate fres result into ps1

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -650,10 +650,10 @@ void Jit64::fresx(UGeckoInstruction inst)
 
 	gpr.FlushLockX(RSCRATCH_EXTRA);
 	fpr.Lock(b, d);
-	fpr.BindToRegister(d);
 	MOVAPD(XMM0, fpr.R(b));
+	fpr.BindToRegister(d, false);
 	CALL(asm_routines.fres);
-	MOVSD(fpr.R(d), XMM0);
+	MOVDDUP(fpr.RX(d), R(XMM0));
 	SetFPRFIfNeeded(fpr.RX(d));
 	fpr.UnlockAll();
 	gpr.UnlockAllX();


### PR DESCRIPTION
We don't emulate `HID2[PSE] = 0` so the result should always be duplicated.