### PR TITLE
Android: Prevent MainActivity toolbar from rendering behind status bar.

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -76,13 +76,13 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v13:22.2.0'
-    compile 'com.android.support:cardview-v7:22.2.0'
-    compile 'com.android.support:recyclerview-v7:22.2.0'
-    compile 'com.android.support:design:22.2.0'
+    compile 'com.android.support:support-v13:22.2.1'
+    compile 'com.android.support:cardview-v7:22.2.1'
+    compile 'com.android.support:recyclerview-v7:22.2.1'
+    compile 'com.android.support:design:22.2.1'
 
     // Android TV UI libraries.
-    compile 'com.android.support:leanback-v17:22.2.0'
+    compile 'com.android.support:leanback-v17:22.2.1'
 
     // For showing the banner as a circle a-la Material Design Guidelines
     compile 'de.hdodenhof:circleimageview:1.2.2'

--- a/Source/Android/app/src/main/res/layout/activity_main.xml
+++ b/Source/Android/app/src/main/res/layout/activity_main.xml
@@ -3,8 +3,7 @@
                                                  xmlns:app="http://schemas.android.com/apk/res-auto"
                                                  android:id="@+id/coordinator_main"
                                                  android:layout_width="match_parent"
-                                                 android:layout_height="match_parent"
-                                                 android:fitsSystemWindows="true">
+                                                 android:layout_height="match_parent">
 
     <android.support.design.widget.AppBarLayout
         android:id="@+id/appbar"


### PR DESCRIPTION
Should fix an issue present on some phones, but will require updates to Buildbot in order to build successfully.