### PR TITLE
Filesystem redesign and performance improvements

### DIFF
--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -88,28 +88,27 @@ void Log(u64 offset, const DiscIO::Partition& partition)
   if (!s_filesystem)
     return;
 
-  const std::string filename = s_filesystem->GetFileName(offset);
+  const std::string path = s_filesystem->GetPath(offset);
 
   // Do nothing if no file was found at that offset
-  if (filename.empty())
+  if (path.empty())
     return;
 
   // Do nothing if we found the same file again
-  if (s_previous_file == filename)
+  if (s_previous_file == path)
     return;
 
-  const u64 size = s_filesystem->GetFileSize(filename);
+  const u64 size = s_filesystem->GetFileSize(path);
   const std::string size_string = ThousandSeparate(size / 1000, 7);
 
-  const std::string log_string =
-      StringFromFormat("%s kB %s", size_string.c_str(), filename.c_str());
-  if (IsSoundFile(filename))
+  const std::string log_string = StringFromFormat("%s kB %s", size_string.c_str(), path.c_str());
+  if (IsSoundFile(path))
     INFO_LOG(FILEMON, "%s", log_string.c_str());
   else
     WARN_LOG(FILEMON, "%s", log_string.c_str());
 
   // Update the last accessed file
-  s_previous_file = filename;
+  s_previous_file = path;
 }
 
 }  // namespace FileMonitor

--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -88,13 +88,13 @@ void Log(u64 offset, const DiscIO::Partition& partition)
   if (!s_filesystem)
     return;
 
-  const DiscIO::FileInfo* file_info = s_filesystem->FindFileInfo(offset);
+  const std::unique_ptr<DiscIO::FileInfo> file_info = s_filesystem->FindFileInfo(offset);
 
   // Do nothing if no file was found at that offset
   if (!file_info)
     return;
 
-  const std::string path = s_filesystem->GetPath(file_info->GetOffset());
+  const std::string path = file_info->GetPath();
 
   // Do nothing if we found the same file again
   if (s_previous_file == path)

--- a/Source/Core/Core/HW/DVD/FileMonitor.cpp
+++ b/Source/Core/Core/HW/DVD/FileMonitor.cpp
@@ -88,18 +88,19 @@ void Log(u64 offset, const DiscIO::Partition& partition)
   if (!s_filesystem)
     return;
 
-  const std::string path = s_filesystem->GetPath(offset);
+  const DiscIO::FileInfo* file_info = s_filesystem->FindFileInfo(offset);
 
   // Do nothing if no file was found at that offset
-  if (path.empty())
+  if (!file_info)
     return;
+
+  const std::string path = s_filesystem->GetPath(file_info->GetOffset());
 
   // Do nothing if we found the same file again
   if (s_previous_file == path)
     return;
 
-  const u64 size = s_filesystem->GetFileSize(path);
-  const std::string size_string = ThousandSeparate(size / 1000, 7);
+  const std::string size_string = ThousandSeparate(file_info->GetSize() / 1000, 7);
 
   const std::string log_string = StringFromFormat("%s kB %s", size_string.c_str(), path.c_str());
   if (IsSoundFile(path))

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -221,9 +221,12 @@ bool DiscScrubber::ParsePartitionData(const Partition& partition, PartitionHeade
   MarkAsUsedE(partition_data_offset, header->fst_offset, header->fst_size);
 
   // Go through the filesystem and mark entries as used
-  for (const FileInfoGCWii& file : filesystem->GetFileList())
+  auto& file_list = filesystem->GetFileList();
+  for (size_t i = 0; i < file_list.size(); ++i)
   {
-    DEBUG_LOG(DISCIO, "%s", file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
+    const std::string path = filesystem->GetPathFromFSTOffset(i);
+    DEBUG_LOG(DISCIO, "%s", path.empty() ? "/" : path.c_str());
+    auto& file = file_list[i];
     if (!file.IsDirectory())
       MarkAsUsedE(partition_data_offset, file.GetOffset(), file.GetSize());
   }

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -222,7 +222,7 @@ bool DiscScrubber::ParsePartitionData(const Partition& partition, PartitionHeade
   for (const FileInfo& file : filesystem->GetFileList())
   {
     DEBUG_LOG(DISCIO, "%s", file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
-    if ((file.m_NameOffset & 0x1000000) == 0)
+    if (!file.IsDirectory())
       MarkAsUsedE(partition_data_offset, file.m_Offset, file.m_FileSize);
   }
 

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -16,6 +16,8 @@
 #include "Common/Logging/Log.h"
 #include "DiscIO/DiscScrubber.h"
 #include "DiscIO/Filesystem.h"
+// TODO: eww
+#include "DiscIO/FileSystemGCWii.h"
 #include "DiscIO/Volume.h"
 
 namespace DiscIO
@@ -219,11 +221,11 @@ bool DiscScrubber::ParsePartitionData(const Partition& partition, PartitionHeade
   MarkAsUsedE(partition_data_offset, header->fst_offset, header->fst_size);
 
   // Go through the filesystem and mark entries as used
-  for (const FileInfo& file : filesystem->GetFileList())
+  for (const FileInfoGCWii& file : filesystem->GetFileList())
   {
     DEBUG_LOG(DISCIO, "%s", file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
     if (!file.IsDirectory())
-      MarkAsUsedE(partition_data_offset, file.m_Offset, file.m_FileSize);
+      MarkAsUsedE(partition_data_offset, file.GetOffset(), file.GetSize());
   }
 
   return true;

--- a/Source/Core/DiscIO/DiscScrubber.h
+++ b/Source/Core/DiscIO/DiscScrubber.h
@@ -25,6 +25,7 @@ class IOFile;
 
 namespace DiscIO
 {
+class FileInfo;
 class Volume;
 struct Partition;
 
@@ -64,6 +65,7 @@ private:
   bool ReadFromVolume(u64 offset, u64& buffer, const Partition& partition);
   bool ParseDisc();
   bool ParsePartitionData(const Partition& partition, PartitionHeader* header);
+  void ParseFileSystemData(u64 partition_data_offset, const FileInfo& directory);
 
   std::string m_filename;
   std::unique_ptr<Volume> m_disc;

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -42,12 +42,34 @@ FileSystemGCWii::~FileSystemGCWii()
   m_FileInfoVector.clear();
 }
 
+const std::vector<FileInfoGCWii>& FileSystemGCWii::GetFileList()
+{
+  if (!m_Initialized)
+    InitFileSystem();
+
+  return m_FileInfoVector;
+}
+
+const FileInfo* FileSystemGCWii::FindFileInfo(const std::string& _rFullPath)
+{
+  if (!m_Initialized)
+    InitFileSystem();
+
+  for (size_t i = 0; i < m_FileInfoVector.size(); ++i)
+  {
+    if (!strcasecmp(GetPathFromFSTOffset(i).c_str(), _rFullPath.c_str()))
+      return &m_FileInfoVector[i];
+  }
+
+  return nullptr;
+}
+
 u64 FileSystemGCWii::GetFileSize(const std::string& _rFullPath)
 {
   if (!m_Initialized)
     InitFileSystem();
 
-  const FileInfoGCWii* pFileInfo = FindFileInfo(_rFullPath);
+  const FileInfo* pFileInfo = FindFileInfo(_rFullPath);
 
   if (pFileInfo != nullptr && !pFileInfo->IsDirectory())
     return pFileInfo->GetSize();
@@ -119,7 +141,7 @@ u64 FileSystemGCWii::ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _
   if (!m_Initialized)
     InitFileSystem();
 
-  const FileInfoGCWii* pFileInfo = FindFileInfo(_rFullPath);
+  const FileInfo* pFileInfo = FindFileInfo(_rFullPath);
   if (pFileInfo == nullptr)
     return 0;
 
@@ -142,7 +164,7 @@ bool FileSystemGCWii::ExportFile(const std::string& _rFullPath, const std::strin
   if (!m_Initialized)
     InitFileSystem();
 
-  const FileInfoGCWii* pFileInfo = FindFileInfo(_rFullPath);
+  const FileInfo* pFileInfo = FindFileInfo(_rFullPath);
 
   if (!pFileInfo)
     return false;
@@ -274,28 +296,6 @@ std::string FileSystemGCWii::GetStringFromOffset(u64 _Offset) const
   // TODO: Should we really always use SHIFT-JIS?
   // It makes some filenames in Pikmin (NTSC-U) sane, but is it correct?
   return SHIFTJISToUTF8(data);
-}
-
-const std::vector<FileInfoGCWii>& FileSystemGCWii::GetFileList()
-{
-  if (!m_Initialized)
-    InitFileSystem();
-
-  return m_FileInfoVector;
-}
-
-const FileInfoGCWii* FileSystemGCWii::FindFileInfo(const std::string& _rFullPath)
-{
-  if (!m_Initialized)
-    InitFileSystem();
-
-  for (size_t i = 0; i < m_FileInfoVector.size(); ++i)
-  {
-    if (!strcasecmp(GetPathFromFSTOffset(i).c_str(), _rFullPath.c_str()))
-      return &m_FileInfoVector[i];
-  }
-
-  return nullptr;
 }
 
 bool FileSystemGCWii::DetectFileSystem()

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -22,8 +22,8 @@
 
 namespace DiscIO
 {
-FileInfoGCWii::FileInfoGCWii(u64 name_offset, u64 offset, u64 file_size)
-    : m_NameOffset(name_offset), m_Offset(offset), m_FileSize(file_size)
+FileInfoGCWii::FileInfoGCWii(u64 name_offset, u64 offset, u64 file_size, std::string name)
+    : m_NameOffset(name_offset), m_Offset(offset), m_FileSize(file_size), m_Name(name)
 {
 }
 
@@ -55,21 +55,62 @@ u64 FileSystemGCWii::GetFileSize(const std::string& _rFullPath)
   return 0;
 }
 
-std::string FileSystemGCWii::GetFileName(u64 _Address)
+std::string FileSystemGCWii::GetPath(u64 _Address)
 {
   if (!m_Initialized)
     InitFileSystem();
 
-  for (auto& fileInfo : m_FileInfoVector)
+  for (size_t i = 0; i < m_FileInfoVector.size(); ++i)
   {
-    if ((fileInfo.GetOffset() <= _Address) &&
-        ((fileInfo.GetOffset() + fileInfo.GetSize()) > _Address))
+    const FileInfoGCWii& file_info = m_FileInfoVector[i];
+    if ((file_info.GetOffset() <= _Address) &&
+        ((file_info.GetOffset() + file_info.GetSize()) > _Address))
     {
-      return fileInfo.m_FullPath;
+      return GetPathFromFSTOffset(i);
     }
   }
 
   return "";
+}
+
+std::string FileSystemGCWii::GetPathFromFSTOffset(size_t file_info_offset)
+{
+  if (!m_Initialized)
+    InitFileSystem();
+
+  // Root entry doesn't have a name
+  if (file_info_offset == 0)
+    return "";
+
+  const FileInfoGCWii& file_info = m_FileInfoVector[file_info_offset];
+  if (file_info.IsDirectory())
+  {
+    // The offset of the parent directory is stored in the current directory.
+
+    if (file_info.GetOffset() >= file_info_offset)
+    {
+      // The offset of the parent directory is supposed to be smaller than
+      // the current offset. If an FST is malformed and breaks that rule,
+      // there's a risk that parent directory pointers form a loop.
+      // To avoid stack overflows, this method returns.
+      ERROR_LOG(DISCIO, "Invalid parent offset in file system");
+      return "";
+    }
+    return GetPathFromFSTOffset(file_info.GetOffset()) + file_info.GetName() + "/";
+  }
+  else
+  {
+    // The parent directory can be found by searching backwards
+    // for a directory that contains this file.
+
+    size_t parent_offset = file_info_offset - 1;
+    while (!(m_FileInfoVector[parent_offset].IsDirectory() &&
+             m_FileInfoVector[parent_offset].GetSize() > file_info_offset))
+    {
+      parent_offset--;
+    }
+    return GetPathFromFSTOffset(parent_offset) + file_info.GetName();
+  }
 }
 
 u64 FileSystemGCWii::ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
@@ -248,10 +289,10 @@ const FileInfoGCWii* FileSystemGCWii::FindFileInfo(const std::string& _rFullPath
   if (!m_Initialized)
     InitFileSystem();
 
-  for (auto& fileInfo : m_FileInfoVector)
+  for (size_t i = 0; i < m_FileInfoVector.size(); ++i)
   {
-    if (!strcasecmp(fileInfo.m_FullPath.c_str(), _rFullPath.c_str()))
-      return &fileInfo;
+    if (!strcasecmp(GetPathFromFSTOffset(i).c_str(), _rFullPath.c_str()))
+      return &m_FileInfoVector[i];
   }
 
   return nullptr;
@@ -290,7 +331,7 @@ void FileSystemGCWii::InitFileSystem()
   if (!root_name_offset || !root_offset || !root_size)
     return;
   FileInfoGCWii root(*root_name_offset, static_cast<u64>(*root_offset) << m_offset_shift,
-                     *root_size);
+                     *root_size, "");
 
   if (!root.IsDirectory())
     return;
@@ -309,53 +350,20 @@ void FileSystemGCWii::InitFileSystem()
 
   if (m_FileInfoVector.size())
     PanicAlert("Wtf?");
-  u64 NameTableOffset = FSTOffset;
+  u64 NameTableOffset = FSTOffset + (root.GetSize() * 0xC);
 
   m_FileInfoVector.reserve((size_t)root.GetSize());
   for (u32 i = 0; i < root.GetSize(); i++)
   {
     const u64 read_offset = FSTOffset + (i * 0xC);
-    const std::optional<u32> name_offset = m_rVolume->ReadSwapped<u32>(read_offset, m_partition);
-    const std::optional<u32> offset = m_rVolume->ReadSwapped<u32>(read_offset + 0x4, m_partition);
-    const std::optional<u32> size = m_rVolume->ReadSwapped<u32>(read_offset + 0x8, m_partition);
-    m_FileInfoVector.emplace_back(name_offset.value_or(0),
-                                  static_cast<u64>(offset.value_or(0)) << m_offset_shift,
-                                  size.value_or(0));
-    NameTableOffset += 0xC;
+    const u32 name_offset = m_rVolume->ReadSwapped<u32>(read_offset, m_partition).value_or(0);
+    const u32 offset = m_rVolume->ReadSwapped<u32>(read_offset + 0x4, m_partition).value_or(0);
+    const u32 size = m_rVolume->ReadSwapped<u32>(read_offset + 0x8, m_partition).value_or(0);
+    const std::string name = GetStringFromOffset(NameTableOffset + (name_offset & 0xFFFFFF));
+    m_FileInfoVector.emplace_back(
+        name_offset, static_cast<u64>(offset) << (m_offset_shift * !(name_offset & 0xFF000000)),
+        size, name);
   }
-
-  BuildFilenames(1, m_FileInfoVector.size(), "", NameTableOffset);
-}
-
-size_t FileSystemGCWii::BuildFilenames(const size_t _FirstIndex, const size_t _LastIndex,
-                                       const std::string& _szDirectory, u64 _NameTableOffset)
-{
-  size_t CurrentIndex = _FirstIndex;
-
-  while (CurrentIndex < _LastIndex)
-  {
-    FileInfoGCWii& rFileInfo = m_FileInfoVector[CurrentIndex];
-    u64 const uOffset = _NameTableOffset + (rFileInfo.m_NameOffset & 0xFFFFFF);
-    std::string const offset_str{GetStringFromOffset(uOffset)};
-    bool const is_dir = rFileInfo.IsDirectory();
-    rFileInfo.m_FullPath.reserve(_szDirectory.size() + offset_str.size());
-
-    rFileInfo.m_FullPath.append(_szDirectory.data(), _szDirectory.size())
-        .append(offset_str.data(), offset_str.size())
-        .append("/", size_t(is_dir));
-
-    if (!is_dir)
-    {
-      ++CurrentIndex;
-      continue;
-    }
-
-    // check next index
-    CurrentIndex = BuildFilenames(CurrentIndex + 1, (size_t)rFileInfo.GetSize(),
-                                  rFileInfo.m_FullPath, _NameTableOffset);
-  }
-
-  return CurrentIndex;
 }
 
 }  // namespace

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -45,9 +45,7 @@ FileInfoGCWii::FileInfoGCWii(const FileInfoGCWii& file_info, u32 index)
 {
 }
 
-FileInfoGCWii::~FileInfoGCWii()
-{
-}
+FileInfoGCWii::~FileInfoGCWii() = default;
 
 uintptr_t FileInfoGCWii::GetAddress() const
 {
@@ -252,9 +250,7 @@ FileSystemGCWii::FileSystemGCWii(const Volume* volume, const Partition& partitio
   m_valid = m_root.IsValid(fst_size, m_root);
 }
 
-FileSystemGCWii::~FileSystemGCWii()
-{
-}
+FileSystemGCWii::~FileSystemGCWii() = default;
 
 const FileInfo& FileSystemGCWii::GetRoot() const
 {

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -64,17 +64,10 @@ FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partit
 {
   // Check if this is a GameCube or Wii disc
   if (m_rVolume->ReadSwapped<u32>(0x18, m_partition) == u32(0x5D1C9EA3))
-  {
     m_offset_shift = 2;  // Wii file system
-    m_Valid = true;
-  }
   else if (m_rVolume->ReadSwapped<u32>(0x1c, m_partition) == u32(0xC2339F3D))
-  {
     m_offset_shift = 0;  // GameCube file system
-    m_Valid = true;
-  }
-
-  if (!m_Valid)
+  else
     return;
 
   const std::optional<u32> fst_offset_unshifted = m_rVolume->ReadSwapped<u32>(0x424, m_partition);
@@ -112,6 +105,9 @@ FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partit
     return;
   for (u32 i = 0; i < number_of_file_infos; i++)
     m_FileInfoVector.emplace_back(m_offset_shift, fst_start + (i * 0xC), name_table_start);
+
+  // If we haven't returned yet, everything succeeded
+  m_Valid = true;
 }
 
 FileSystemGCWii::~FileSystemGCWii()

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -88,18 +88,7 @@ u32 FileInfoGCWii::Get(EntryProperty entry_property) const
 
 u32 FileInfoGCWii::GetSize() const
 {
-  u32 result = Get(EntryProperty::FILE_SIZE);
-
-  if (IsDirectory() && result <= m_index)
-  {
-    // For directories, GetSize is supposed to return the index of the next entry.
-    // If a file system is malformed and instead has an index that isn't after this one,
-    // we act as if the directory is empty to avoid strange behavior.
-    ERROR_LOG(DISCIO, "Invalid folder end in file system");
-    return m_index + 1;
-  }
-
-  return result;
+  return Get(EntryProperty::FILE_SIZE);
 }
 
 u64 FileInfoGCWii::GetOffset() const
@@ -114,16 +103,20 @@ bool FileInfoGCWii::IsDirectory() const
 
 u32 FileInfoGCWii::GetTotalChildren() const
 {
-  return GetSize() - (m_index + 1);
+  return Get(EntryProperty::FILE_SIZE) - (m_index + 1);
+}
+
+u64 FileInfoGCWii::GetNameOffset() const
+{
+  return static_cast<u64>(FST_ENTRY_SIZE) * m_total_file_infos +
+         (Get(EntryProperty::NAME_OFFSET) & 0xFFFFFF);
 }
 
 std::string FileInfoGCWii::GetName() const
 {
   // TODO: Should we really always use SHIFT-JIS?
   // Some names in Pikmin (NTSC-U) don't make sense without it, but is it correct?
-  u32 name_offset = Get(EntryProperty::NAME_OFFSET) & 0xFFFFFF;
-  const u8* name = m_fst + FST_ENTRY_SIZE * m_total_file_infos + name_offset;
-  return SHIFTJISToUTF8(reinterpret_cast<const char*>(name));
+  return SHIFTJISToUTF8(reinterpret_cast<const char*>(m_fst + GetNameOffset()));
 }
 
 std::string FileInfoGCWii::GetPath() const
@@ -135,35 +128,61 @@ std::string FileInfoGCWii::GetPath() const
   if (IsDirectory())
   {
     u32 parent_directory_index = Get(EntryProperty::FILE_OFFSET);
-    if (parent_directory_index >= m_index)
-    {
-      // The index of the parent directory is supposed to be smaller than
-      // the current index. If an FST is malformed and breaks that rule,
-      // there's a risk that parent directory pointers form a loop.
-      // To avoid stack overflows, this method returns.
-      ERROR_LOG(DISCIO, "Invalid parent offset in file system");
-      return "";
-    }
     return FileInfoGCWii(*this, parent_directory_index).GetPath() + GetName() + "/";
   }
   else
   {
     // The parent directory can be found by searching backwards
-    // for a directory that contains this file.
-
+    // for a directory that contains this file. The search cannot fail,
+    // because the root directory at index 0 contains all files.
     FileInfoGCWii potential_parent(*this, m_index - 1);
-    while (!(potential_parent.IsDirectory() && potential_parent.GetSize() > m_index))
+    while (!(potential_parent.IsDirectory() &&
+             potential_parent.Get(EntryProperty::FILE_SIZE) > m_index))
     {
-      if (potential_parent.m_index == 0)
-      {
-        // This can happen if an FST has a root with a size that's too small
-        ERROR_LOG(DISCIO, "The parent of %s couldn't be found", GetName().c_str());
-        return "";
-      }
       potential_parent = FileInfoGCWii(*this, potential_parent.m_index - 1);
     }
     return potential_parent.GetPath() + GetName();
   }
+}
+
+bool FileInfoGCWii::IsValid(u64 fst_size, const FileInfoGCWii& parent_directory) const
+{
+  if (GetNameOffset() >= fst_size)
+  {
+    ERROR_LOG(DISCIO, "Impossibly large name offset in file system");
+    return false;
+  }
+
+  if (IsDirectory())
+  {
+    if (Get(EntryProperty::FILE_OFFSET) != parent_directory.m_index)
+    {
+      ERROR_LOG(DISCIO, "Incorrect parent offset in file system");
+      return false;
+    }
+
+    u32 size = Get(EntryProperty::FILE_SIZE);
+
+    if (size <= m_index)
+    {
+      ERROR_LOG(DISCIO, "Impossibly small directory size in file system");
+      return false;
+    }
+
+    if (size > parent_directory.Get(EntryProperty::FILE_SIZE))
+    {
+      ERROR_LOG(DISCIO, "Impossibly large directory size in file system");
+      return false;
+    }
+
+    for (const FileInfo& child : *this)
+    {
+      if (!static_cast<const FileInfoGCWii&>(child).IsValid(fst_size, *this))
+        return false;
+    }
+  }
+
+  return true;
 }
 
 FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partition)
@@ -217,8 +236,20 @@ FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partit
     return;
   }
 
-  // If we haven't returned yet, everything succeeded
-  m_Valid = true;
+  if (FST_ENTRY_SIZE * m_root.GetSize() > fst_size)
+  {
+    ERROR_LOG(DISCIO, "File system has too many entries for its size");
+    return;
+  }
+
+  // If the FST's final byte isn't 0, CFileInfoGCWii::GetName() can read past the end
+  if (m_file_system_table[fst_size - 1] != 0)
+  {
+    ERROR_LOG(DISCIO, "File system does not end with a null byte");
+    return;
+  }
+
+  m_Valid = m_root.IsValid(fst_size, m_root);
 }
 
 FileSystemGCWii::~FileSystemGCWii()

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -50,31 +50,35 @@ const std::vector<FileInfoGCWii>& FileSystemGCWii::GetFileList()
   return m_FileInfoVector;
 }
 
-const FileInfo* FileSystemGCWii::FindFileInfo(const std::string& _rFullPath)
+const FileInfo* FileSystemGCWii::FindFileInfo(const std::string& path)
 {
   if (!m_Initialized)
     InitFileSystem();
 
   for (size_t i = 0; i < m_FileInfoVector.size(); ++i)
   {
-    if (!strcasecmp(GetPathFromFSTOffset(i).c_str(), _rFullPath.c_str()))
+    if (!strcasecmp(GetPathFromFSTOffset(i).c_str(), path.c_str()))
       return &m_FileInfoVector[i];
   }
 
   return nullptr;
 }
 
-u64 FileSystemGCWii::GetFileSize(const std::string& _rFullPath)
+const FileInfo* FileSystemGCWii::FindFileInfo(u64 disc_offset)
 {
   if (!m_Initialized)
     InitFileSystem();
 
-  const FileInfo* pFileInfo = FindFileInfo(_rFullPath);
+  for (auto& file_info : m_FileInfoVector)
+  {
+    if ((file_info.GetOffset() <= disc_offset) &&
+        ((file_info.GetOffset() + file_info.GetSize()) > disc_offset))
+    {
+      return &file_info;
+    }
+  }
 
-  if (pFileInfo != nullptr && !pFileInfo->IsDirectory())
-    return pFileInfo->GetSize();
-
-  return 0;
+  return nullptr;
 }
 
 std::string FileSystemGCWii::GetPath(u64 _Address)
@@ -135,42 +139,39 @@ std::string FileSystemGCWii::GetPathFromFSTOffset(size_t file_info_offset)
   }
 }
 
-u64 FileSystemGCWii::ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
+u64 FileSystemGCWii::ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
                               u64 _OffsetInFile)
 {
   if (!m_Initialized)
     InitFileSystem();
 
-  const FileInfo* pFileInfo = FindFileInfo(_rFullPath);
-  if (pFileInfo == nullptr)
+  if (!file_info || file_info->IsDirectory())
     return 0;
 
-  if (_OffsetInFile >= pFileInfo->GetSize())
+  if (_OffsetInFile >= file_info->GetSize())
     return 0;
 
-  u64 read_length = std::min(_MaxBufferSize, pFileInfo->GetSize() - _OffsetInFile);
+  u64 read_length = std::min(_MaxBufferSize, file_info->GetSize() - _OffsetInFile);
 
   DEBUG_LOG(DISCIO, "Reading %" PRIx64 " bytes at %" PRIx64 " from file %s. Offset: %" PRIx64
                     " Size: %" PRIx64,
-            read_length, _OffsetInFile, _rFullPath.c_str(), pFileInfo->GetOffset(),
-            pFileInfo->GetSize());
+            read_length, _OffsetInFile, GetPath(file_info->GetOffset()).c_str(),
+            file_info->GetOffset(), file_info->GetSize());
 
-  m_rVolume->Read(pFileInfo->GetOffset() + _OffsetInFile, read_length, _pBuffer, m_partition);
+  m_rVolume->Read(file_info->GetOffset() + _OffsetInFile, read_length, _pBuffer, m_partition);
   return read_length;
 }
 
-bool FileSystemGCWii::ExportFile(const std::string& _rFullPath, const std::string& _rExportFilename)
+bool FileSystemGCWii::ExportFile(const FileInfo* file_info, const std::string& _rExportFilename)
 {
   if (!m_Initialized)
     InitFileSystem();
 
-  const FileInfo* pFileInfo = FindFileInfo(_rFullPath);
-
-  if (!pFileInfo)
+  if (!file_info || file_info->IsDirectory())
     return false;
 
-  u64 remainingSize = pFileInfo->GetSize();
-  u64 fileOffset = pFileInfo->GetOffset();
+  u64 remainingSize = file_info->GetSize();
+  u64 fileOffset = file_info->GetOffset();
 
   File::IOFile f(_rExportFilename, "wb");
   if (!f)

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -22,8 +22,17 @@
 
 namespace DiscIO
 {
+FileInfoGCWii::FileInfoGCWii(u64 name_offset, u64 offset, u64 file_size)
+    : m_NameOffset(name_offset), m_Offset(offset), m_FileSize(file_size)
+{
+}
+
+FileInfoGCWii::~FileInfoGCWii()
+{
+}
+
 FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partition)
-    : FileSystem(_rVolume, partition), m_Initialized(false), m_Valid(false), m_offset_shift(0)
+  : FileSystem(_rVolume, partition), m_Initialized(false), m_Valid(false), m_offset_shift(0)
 {
   m_Valid = DetectFileSystem();
 }
@@ -38,10 +47,10 @@ u64 FileSystemGCWii::GetFileSize(const std::string& _rFullPath)
   if (!m_Initialized)
     InitFileSystem();
 
-  const FileInfo* pFileInfo = FindFileInfo(_rFullPath);
+  const FileInfoGCWii* pFileInfo = FindFileInfo(_rFullPath);
 
   if (pFileInfo != nullptr && !pFileInfo->IsDirectory())
-    return pFileInfo->m_FileSize;
+    return pFileInfo->GetSize();
 
   return 0;
 }
@@ -53,7 +62,8 @@ std::string FileSystemGCWii::GetFileName(u64 _Address)
 
   for (auto& fileInfo : m_FileInfoVector)
   {
-    if ((fileInfo.m_Offset <= _Address) && ((fileInfo.m_Offset + fileInfo.m_FileSize) > _Address))
+    if ((fileInfo.GetOffset() <= _Address) &&
+        ((fileInfo.GetOffset() + fileInfo.GetSize()) > _Address))
     {
       return fileInfo.m_FullPath;
     }
@@ -68,21 +78,21 @@ u64 FileSystemGCWii::ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _
   if (!m_Initialized)
     InitFileSystem();
 
-  const FileInfo* pFileInfo = FindFileInfo(_rFullPath);
+  const FileInfoGCWii* pFileInfo = FindFileInfo(_rFullPath);
   if (pFileInfo == nullptr)
     return 0;
 
-  if (_OffsetInFile >= pFileInfo->m_FileSize)
+  if (_OffsetInFile >= pFileInfo->GetSize())
     return 0;
 
-  u64 read_length = std::min(_MaxBufferSize, pFileInfo->m_FileSize - _OffsetInFile);
+  u64 read_length = std::min(_MaxBufferSize, pFileInfo->GetSize() - _OffsetInFile);
 
   DEBUG_LOG(DISCIO, "Reading %" PRIx64 " bytes at %" PRIx64 " from file %s. Offset: %" PRIx64
                     " Size: %" PRIx64,
-            read_length, _OffsetInFile, _rFullPath.c_str(), pFileInfo->m_Offset,
-            pFileInfo->m_FileSize);
+            read_length, _OffsetInFile, _rFullPath.c_str(), pFileInfo->GetOffset(),
+            pFileInfo->GetSize());
 
-  m_rVolume->Read(pFileInfo->m_Offset + _OffsetInFile, read_length, _pBuffer, m_partition);
+  m_rVolume->Read(pFileInfo->GetOffset() + _OffsetInFile, read_length, _pBuffer, m_partition);
   return read_length;
 }
 
@@ -91,13 +101,13 @@ bool FileSystemGCWii::ExportFile(const std::string& _rFullPath, const std::strin
   if (!m_Initialized)
     InitFileSystem();
 
-  const FileInfo* pFileInfo = FindFileInfo(_rFullPath);
+  const FileInfoGCWii* pFileInfo = FindFileInfo(_rFullPath);
 
   if (!pFileInfo)
     return false;
 
-  u64 remainingSize = pFileInfo->m_FileSize;
-  u64 fileOffset = pFileInfo->m_Offset;
+  u64 remainingSize = pFileInfo->GetSize();
+  u64 fileOffset = pFileInfo->GetOffset();
 
   File::IOFile f(_rExportFilename, "wb");
   if (!f)
@@ -225,7 +235,7 @@ std::string FileSystemGCWii::GetStringFromOffset(u64 _Offset) const
   return SHIFTJISToUTF8(data);
 }
 
-const std::vector<FileInfo>& FileSystemGCWii::GetFileList()
+const std::vector<FileInfoGCWii>& FileSystemGCWii::GetFileList()
 {
   if (!m_Initialized)
     InitFileSystem();
@@ -233,7 +243,7 @@ const std::vector<FileInfo>& FileSystemGCWii::GetFileList()
   return m_FileInfoVector;
 }
 
-const FileInfo* FileSystemGCWii::FindFileInfo(const std::string& _rFullPath)
+const FileInfoGCWii* FileSystemGCWii::FindFileInfo(const std::string& _rFullPath)
 {
   if (!m_Initialized)
     InitFileSystem();
@@ -279,7 +289,8 @@ void FileSystemGCWii::InitFileSystem()
   const std::optional<u32> root_size = m_rVolume->ReadSwapped<u32>(FSTOffset + 0x8, m_partition);
   if (!root_name_offset || !root_offset || !root_size)
     return;
-  FileInfo root = {*root_name_offset, static_cast<u64>(*root_offset) << m_offset_shift, *root_size};
+  FileInfoGCWii root(*root_name_offset, static_cast<u64>(*root_offset) << m_offset_shift,
+                     *root_size);
 
   if (!root.IsDirectory())
     return;
@@ -287,7 +298,7 @@ void FileSystemGCWii::InitFileSystem()
   // 12 bytes (the size of a file entry) times 10 * 1024 * 1024 is 120 MiB,
   // more than total RAM in a Wii. No file system should use anywhere near that much.
   static const u32 ARBITRARY_FILE_SYSTEM_SIZE_LIMIT = 10 * 1024 * 1024;
-  if (root.m_FileSize > ARBITRARY_FILE_SYSTEM_SIZE_LIMIT)
+  if (root.GetSize() > ARBITRARY_FILE_SYSTEM_SIZE_LIMIT)
   {
     // Without this check, Dolphin can crash by trying to allocate too much
     // memory when loading the file systems of certain malformed disc images.
@@ -300,8 +311,8 @@ void FileSystemGCWii::InitFileSystem()
     PanicAlert("Wtf?");
   u64 NameTableOffset = FSTOffset;
 
-  m_FileInfoVector.reserve((size_t)root.m_FileSize);
-  for (u32 i = 0; i < root.m_FileSize; i++)
+  m_FileInfoVector.reserve((size_t)root.GetSize());
+  for (u32 i = 0; i < root.GetSize(); i++)
   {
     const u64 read_offset = FSTOffset + (i * 0xC);
     const std::optional<u32> name_offset = m_rVolume->ReadSwapped<u32>(read_offset, m_partition);
@@ -323,7 +334,7 @@ size_t FileSystemGCWii::BuildFilenames(const size_t _FirstIndex, const size_t _L
 
   while (CurrentIndex < _LastIndex)
   {
-    FileInfo& rFileInfo = m_FileInfoVector[CurrentIndex];
+    FileInfoGCWii& rFileInfo = m_FileInfoVector[CurrentIndex];
     u64 const uOffset = _NameTableOffset + (rFileInfo.m_NameOffset & 0xFFFFFF);
     std::string const offset_str{GetStringFromOffset(uOffset)};
     bool const is_dir = rFileInfo.IsDirectory();
@@ -340,7 +351,7 @@ size_t FileSystemGCWii::BuildFilenames(const size_t _FirstIndex, const size_t _L
     }
 
     // check next index
-    CurrentIndex = BuildFilenames(CurrentIndex + 1, (size_t)rFileInfo.m_FileSize,
+    CurrentIndex = BuildFilenames(CurrentIndex + 1, (size_t)rFileInfo.GetSize(),
                                   rFileInfo.m_FullPath, _NameTableOffset);
   }
 

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -6,6 +6,7 @@
 #include <cinttypes>
 #include <cstddef>
 #include <cstring>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -24,13 +25,58 @@ namespace DiscIO
 {
 constexpr u32 FST_ENTRY_SIZE = 4 * 3;  // An FST entry consists of three 32-bit integers
 
+// Set everything manually.
 FileInfoGCWii::FileInfoGCWii(const u8* fst, u8 offset_shift, u32 index, u32 total_file_infos)
     : m_fst(fst), m_offset_shift(offset_shift), m_index(index), m_total_file_infos(total_file_infos)
 {
 }
 
+// For the root object only.
+// m_fst and m_index must be correctly set before GetSize() is called!
+FileInfoGCWii::FileInfoGCWii(const u8* fst, u8 offset_shift)
+    : m_fst(fst), m_offset_shift(offset_shift), m_index(0), m_total_file_infos(GetSize())
+{
+}
+
+// Copy data that is common to the whole file system.
+FileInfoGCWii::FileInfoGCWii(const FileInfoGCWii& file_info, u32 index)
+    : FileInfoGCWii(file_info.m_fst, file_info.m_offset_shift, index, file_info.m_total_file_infos)
+{
+}
+
 FileInfoGCWii::~FileInfoGCWii()
 {
+}
+
+uintptr_t FileInfoGCWii::GetAddress() const
+{
+  return reinterpret_cast<uintptr_t>(m_fst + FST_ENTRY_SIZE * m_index);
+}
+
+u32 FileInfoGCWii::GetNextIndex() const
+{
+  return IsDirectory() ? GetSize() : m_index + 1;
+}
+
+FileInfo& FileInfoGCWii::operator++()
+{
+  m_index = GetNextIndex();
+  return *this;
+}
+
+std::unique_ptr<FileInfo> FileInfoGCWii::clone() const
+{
+  return std::make_unique<FileInfoGCWii>(*this);
+}
+
+FileInfo::const_iterator FileInfoGCWii::begin() const
+{
+  return const_iterator(std::make_unique<FileInfoGCWii>(*this, m_index + 1));
+}
+
+FileInfo::const_iterator FileInfoGCWii::end() const
+{
+  return const_iterator(std::make_unique<FileInfoGCWii>(*this, GetNextIndex()));
 }
 
 u32 FileInfoGCWii::Get(EntryProperty entry_property) const
@@ -41,17 +87,33 @@ u32 FileInfoGCWii::Get(EntryProperty entry_property) const
 
 u32 FileInfoGCWii::GetSize() const
 {
-  return Get(EntryProperty::FILE_SIZE);
+  u32 result = Get(EntryProperty::FILE_SIZE);
+
+  if (IsDirectory() && result <= m_index)
+  {
+    // For directories, GetSize is supposed to return the index of the next entry.
+    // If a file system is malformed and instead has an index that isn't after this one,
+    // we act as if the directory is empty to avoid strange behavior.
+    ERROR_LOG(DISCIO, "Invalid folder end in file system");
+    return m_index + 1;
+  }
+
+  return result;
 }
 
 u64 FileInfoGCWii::GetOffset() const
 {
-  return static_cast<u64>(Get(EntryProperty::FILE_OFFSET)) << (IsDirectory() ? 0 : m_offset_shift);
+  return static_cast<u64>(Get(EntryProperty::FILE_OFFSET)) << m_offset_shift;
 }
 
 bool FileInfoGCWii::IsDirectory() const
 {
   return (Get(EntryProperty::NAME_OFFSET) & 0xFF000000) != 0;
+}
+
+u32 FileInfoGCWii::GetTotalChildren() const
+{
+  return GetSize() - (m_index + 1);
 }
 
 std::string FileInfoGCWii::GetName() const
@@ -63,8 +125,48 @@ std::string FileInfoGCWii::GetName() const
   return SHIFTJISToUTF8(reinterpret_cast<const char*>(name));
 }
 
+std::string FileInfoGCWii::GetPath() const
+{
+  // The root entry doesn't have a name
+  if (m_index == 0)
+    return "";
+
+  if (IsDirectory())
+  {
+    u32 parent_directory_index = Get(EntryProperty::FILE_OFFSET);
+    if (parent_directory_index >= m_index)
+    {
+      // The index of the parent directory is supposed to be smaller than
+      // the current index. If an FST is malformed and breaks that rule,
+      // there's a risk that parent directory pointers form a loop.
+      // To avoid stack overflows, this method returns.
+      ERROR_LOG(DISCIO, "Invalid parent offset in file system");
+      return "";
+    }
+    return FileInfoGCWii(*this, parent_directory_index).GetPath() + GetName() + "/";
+  }
+  else
+  {
+    // The parent directory can be found by searching backwards
+    // for a directory that contains this file.
+
+    FileInfoGCWii potential_parent(*this, m_index - 1);
+    while (!(potential_parent.IsDirectory() && potential_parent.GetSize() > m_index))
+    {
+      if (potential_parent.m_index == 0)
+      {
+        // This can happen if an FST has a root with a size that's too small
+        ERROR_LOG(DISCIO, "The parent of %s couldn't be found", GetName().c_str());
+        return "";
+      }
+      potential_parent = FileInfoGCWii(*this, potential_parent.m_index - 1);
+    }
+    return potential_parent.GetPath() + GetName();
+  }
+}
+
 FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partition)
-    : FileSystem(_rVolume, partition), m_Valid(false), m_offset_shift(0)
+    : FileSystem(_rVolume, partition), m_Valid(false), m_offset_shift(0), m_root(nullptr, 0, 0, 0)
 {
   // Check if this is a GameCube or Wii disc
   if (m_rVolume->ReadSwapped<u32>(0x18, m_partition) == u32(0x5D1C9EA3))
@@ -81,7 +183,10 @@ FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partit
   const u64 fst_offset = static_cast<u64>(*fst_offset_unshifted) << m_offset_shift;
   const u64 fst_size = static_cast<u64>(*fst_size_unshifted) << m_offset_shift;
   if (fst_size < FST_ENTRY_SIZE)
+  {
+    ERROR_LOG(DISCIO, "File system is too small");
     return;
+  }
 
   // 128 MiB is more than the total amount of RAM in a Wii.
   // No file system should use anywhere near that much.
@@ -98,17 +203,18 @@ FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partit
   // Read the whole FST
   m_file_system_table.resize(fst_size);
   if (!m_rVolume->Read(fst_offset, fst_size, m_file_system_table.data(), m_partition))
+  {
+    ERROR_LOG(DISCIO, "Couldn't read file system table");
     return;
+  }
 
-  // Create all file info objects
-  u32 number_of_file_infos = Common::swap32(*((u32*)m_file_system_table.data() + 2));
-  const u8* fst_start = m_file_system_table.data();
-  const u8* name_table_start = fst_start + (FST_ENTRY_SIZE * number_of_file_infos);
-  const u8* name_table_end = fst_start + fst_size;
-  if (name_table_end < name_table_start)
+  // Create the root object
+  m_root = FileInfoGCWii(m_file_system_table.data(), m_offset_shift);
+  if (!m_root.IsDirectory())
+  {
+    ERROR_LOG(DISCIO, "File system root is not a directory");
     return;
-  for (u32 i = 0; i < number_of_file_infos; i++)
-    m_FileInfoVector.emplace_back(fst_start, m_offset_shift, i, number_of_file_infos);
+  }
 
   // If we haven't returned yet, everything succeeded
   m_Valid = true;
@@ -116,33 +222,32 @@ FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partit
 
 FileSystemGCWii::~FileSystemGCWii()
 {
-  m_FileInfoVector.clear();
 }
 
-const std::vector<FileInfoGCWii>& FileSystemGCWii::GetFileList() const
+const FileInfo& FileSystemGCWii::GetRoot() const
 {
-  return m_FileInfoVector;
+  return m_root;
 }
 
-const FileInfo* FileSystemGCWii::FindFileInfo(const std::string& path) const
+std::unique_ptr<FileInfo> FileSystemGCWii::FindFileInfo(const std::string& path) const
 {
-  if (m_FileInfoVector.empty())
+  if (!IsValid())
     return nullptr;
 
-  return FindFileInfo(path, 0);
+  return FindFileInfo(path, m_root);
 }
 
-const FileInfo* FileSystemGCWii::FindFileInfo(const std::string& path,
-                                              size_t search_start_offset) const
+std::unique_ptr<FileInfo> FileSystemGCWii::FindFileInfo(const std::string& path,
+                                                        const FileInfo& file_info) const
 {
   // Given a path like "directory1/directory2/fileA.bin", this function will
   // find directory1 and then call itself to search for "directory2/fileA.bin".
 
   if (path.empty() || path == "/")
-    return &m_FileInfoVector[search_start_offset];
+    return file_info.clone();
 
   // It's only possible to search in directories. Searching in a file is an error
-  if (!m_FileInfoVector[search_start_offset].IsDirectory())
+  if (!file_info.IsDirectory())
     return nullptr;
 
   size_t first_dir_separator = path.find('/');
@@ -150,113 +255,50 @@ const FileInfo* FileSystemGCWii::FindFileInfo(const std::string& path,
   const std::string rest_of_path =
       (first_dir_separator != std::string::npos) ? path.substr(first_dir_separator + 1) : "";
 
-  size_t search_end_offset = m_FileInfoVector[search_start_offset].GetSize();
-  search_start_offset++;
-  while (search_start_offset < search_end_offset)
+  for (const FileInfo& child : file_info)
   {
-    const FileInfoGCWii& file_info = m_FileInfoVector[search_start_offset];
-
-    if (file_info.GetName() == searching_for)
+    if (child.GetName() == searching_for)
     {
       // A match is found. The rest of the path is passed on to finish the search.
-      const FileInfo* result = FindFileInfo(rest_of_path, search_start_offset);
+      std::unique_ptr<FileInfo> result = FindFileInfo(rest_of_path, child);
 
       // If the search wasn't successful, the loop continues, just in case there's a second
       // file info that matches searching_for (which probably won't happen in practice)
       if (result)
         return result;
     }
-
-    if (file_info.IsDirectory())
-    {
-      // Skip a directory and everything that it contains
-
-      if (file_info.GetSize() <= search_start_offset)
-      {
-        // The next offset (obtained by GetSize) is supposed to be larger than
-        // the current offset. If an FST is malformed and breaks that rule,
-        // there's a risk that next offset pointers form a loop.
-        // To avoid infinite loops, this method returns.
-        ERROR_LOG(DISCIO, "Invalid next offset in file system");
-        return nullptr;
-      }
-
-      search_start_offset = file_info.GetSize();
-    }
-    else
-    {
-      // Skip a single file
-      search_start_offset++;
-    }
   }
 
   return nullptr;
 }
 
-const FileInfo* FileSystemGCWii::FindFileInfo(u64 disc_offset) const
+std::unique_ptr<FileInfo> FileSystemGCWii::FindFileInfo(u64 disc_offset) const
 {
-  for (auto& file_info : m_FileInfoVector)
+  if (!IsValid())
+    return nullptr;
+
+  return FindFileInfo(disc_offset, m_root);
+}
+
+std::unique_ptr<FileInfo> FileSystemGCWii::FindFileInfo(u64 disc_offset,
+                                                        const FileInfo& file_info) const
+{
+  for (const FileInfo& child : file_info)
   {
-    if ((file_info.GetOffset() <= disc_offset) &&
-        ((file_info.GetOffset() + file_info.GetSize()) > disc_offset))
+    if (child.IsDirectory())
     {
-      return &file_info;
+      std::unique_ptr<FileInfo> result = FindFileInfo(disc_offset, child);
+      if (result)
+        return result;
+    }
+    else if ((file_info.GetOffset() <= disc_offset) &&
+             ((file_info.GetOffset() + file_info.GetSize()) > disc_offset))
+    {
+      return file_info.clone();
     }
   }
 
   return nullptr;
-}
-
-std::string FileSystemGCWii::GetPath(u64 _Address) const
-{
-  for (size_t i = 0; i < m_FileInfoVector.size(); ++i)
-  {
-    const FileInfoGCWii& file_info = m_FileInfoVector[i];
-    if ((file_info.GetOffset() <= _Address) &&
-        ((file_info.GetOffset() + file_info.GetSize()) > _Address))
-    {
-      return GetPathFromFSTOffset(i);
-    }
-  }
-
-  return "";
-}
-
-std::string FileSystemGCWii::GetPathFromFSTOffset(size_t file_info_offset) const
-{
-  // Root entry doesn't have a name
-  if (file_info_offset == 0)
-    return "";
-
-  const FileInfoGCWii& file_info = m_FileInfoVector[file_info_offset];
-  if (file_info.IsDirectory())
-  {
-    // The offset of the parent directory is stored in the current directory.
-
-    if (file_info.GetOffset() >= file_info_offset)
-    {
-      // The offset of the parent directory is supposed to be smaller than
-      // the current offset. If an FST is malformed and breaks that rule,
-      // there's a risk that parent directory pointers form a loop.
-      // To avoid stack overflows, this method returns.
-      ERROR_LOG(DISCIO, "Invalid parent offset in file system");
-      return "";
-    }
-    return GetPathFromFSTOffset(file_info.GetOffset()) + file_info.GetName() + "/";
-  }
-  else
-  {
-    // The parent directory can be found by searching backwards
-    // for a directory that contains this file.
-
-    size_t parent_offset = file_info_offset - 1;
-    while (!(m_FileInfoVector[parent_offset].IsDirectory() &&
-             m_FileInfoVector[parent_offset].GetSize() > file_info_offset))
-    {
-      parent_offset--;
-    }
-    return GetPathFromFSTOffset(parent_offset) + file_info.GetName();
-  }
 }
 
 u64 FileSystemGCWii::ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
@@ -272,8 +314,8 @@ u64 FileSystemGCWii::ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxB
 
   DEBUG_LOG(DISCIO, "Reading %" PRIx64 " bytes at %" PRIx64 " from file %s. Offset: %" PRIx64
                     " Size: %" PRIx32,
-            read_length, _OffsetInFile, GetPath(file_info->GetOffset()).c_str(),
-            file_info->GetOffset(), file_info->GetSize());
+            read_length, _OffsetInFile, file_info->GetPath().c_str(), file_info->GetOffset(),
+            file_info->GetSize());
 
   m_rVolume->Read(file_info->GetOffset() + _OffsetInFile, read_length, _pBuffer, m_partition);
   return read_length;

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -22,8 +22,10 @@
 
 namespace DiscIO
 {
-FileInfoGCWii::FileInfoGCWii(u8 offset_shift, const u8* fst_entry, const u8* name_table_start)
-    : m_offset_shift(offset_shift), m_fst_entry(fst_entry), m_name_table_start(name_table_start)
+constexpr u32 FST_ENTRY_SIZE = 4 * 3;  // An FST entry consists of three 32-bit integers
+
+FileInfoGCWii::FileInfoGCWii(const u8* fst, u8 offset_shift, u32 index, u32 total_file_infos)
+    : m_fst(fst), m_offset_shift(offset_shift), m_index(index), m_total_file_infos(total_file_infos)
 {
 }
 
@@ -33,7 +35,8 @@ FileInfoGCWii::~FileInfoGCWii()
 
 u32 FileInfoGCWii::Get(EntryProperty entry_property) const
 {
-  return Common::swap32(m_fst_entry + sizeof(u32) * static_cast<int>(entry_property));
+  return Common::swap32(m_fst + FST_ENTRY_SIZE * m_index +
+                        sizeof(u32) * static_cast<int>(entry_property));
 }
 
 u32 FileInfoGCWii::GetSize() const
@@ -55,7 +58,8 @@ std::string FileInfoGCWii::GetName() const
 {
   // TODO: Should we really always use SHIFT-JIS?
   // Some names in Pikmin (NTSC-U) don't make sense without it, but is it correct?
-  const u8* name = m_name_table_start + (Get(EntryProperty::NAME_OFFSET) & 0xFFFFFF);
+  u32 name_offset = Get(EntryProperty::NAME_OFFSET) & 0xFFFFFF;
+  const u8* name = m_fst + FST_ENTRY_SIZE * m_total_file_infos + name_offset;
   return SHIFTJISToUTF8(reinterpret_cast<const char*>(name));
 }
 
@@ -76,7 +80,7 @@ FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partit
     return;
   const u64 fst_offset = static_cast<u64>(*fst_offset_unshifted) << m_offset_shift;
   const u64 fst_size = static_cast<u64>(*fst_size_unshifted) << m_offset_shift;
-  if (fst_size < 0xC)
+  if (fst_size < FST_ENTRY_SIZE)
     return;
 
   // 128 MiB is more than the total amount of RAM in a Wii.
@@ -99,12 +103,12 @@ FileSystemGCWii::FileSystemGCWii(const Volume* _rVolume, const Partition& partit
   // Create all file info objects
   u32 number_of_file_infos = Common::swap32(*((u32*)m_file_system_table.data() + 2));
   const u8* fst_start = m_file_system_table.data();
-  const u8* name_table_start = fst_start + (number_of_file_infos * 0xC);
+  const u8* name_table_start = fst_start + (FST_ENTRY_SIZE * number_of_file_infos);
   const u8* name_table_end = fst_start + fst_size;
   if (name_table_end < name_table_start)
     return;
   for (u32 i = 0; i < number_of_file_infos; i++)
-    m_FileInfoVector.emplace_back(m_offset_shift, fst_start + (i * 0xC), name_table_start);
+    m_FileInfoVector.emplace_back(fst_start, m_offset_shift, i, number_of_file_infos);
 
   // If we haven't returned yet, everything succeeded
   m_Valid = true;

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -51,29 +51,26 @@ public:
   FileSystemGCWii(const Volume* _rVolume, const Partition& partition);
   ~FileSystemGCWii() override;
   bool IsValid() const override { return m_Valid; }
-  const std::vector<FileInfoGCWii>& GetFileList() override;
-  const FileInfo* FindFileInfo(const std::string& path) override;
-  const FileInfo* FindFileInfo(u64 disc_offset) override;
-  std::string GetPath(u64 _Address) override;
-  std::string GetPathFromFSTOffset(size_t file_info_offset) override;
+  const std::vector<FileInfoGCWii>& GetFileList() const override;
+  const FileInfo* FindFileInfo(const std::string& path) const override;
+  const FileInfo* FindFileInfo(u64 disc_offset) const override;
+  std::string GetPath(u64 _Address) const override;
+  std::string GetPathFromFSTOffset(size_t file_info_offset) const override;
   u64 ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
-               u64 _OffsetInFile) override;
-  bool ExportFile(const FileInfo* file_info, const std::string& _rExportFilename) override;
+               u64 _OffsetInFile) const override;
+  bool ExportFile(const FileInfo* file_info, const std::string& _rExportFilename) const override;
   bool ExportApploader(const std::string& _rExportFolder) const override;
   bool ExportDOL(const std::string& _rExportFolder) const override;
   std::optional<u64> GetBootDOLOffset() const override;
   std::optional<u32> GetBootDOLSize(u64 dol_offset) const override;
 
 private:
-  bool m_Initialized;
   bool m_Valid;
   u32 m_offset_shift;
   std::vector<FileInfoGCWii> m_FileInfoVector;
   std::vector<u8> m_file_system_table;
 
   const FileInfo* FindFileInfo(const std::string& path, size_t search_start_offset) const;
-  bool DetectFileSystem();
-  void InitFileSystem();
 };
 
 }  // namespace

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -21,7 +21,7 @@ class FileInfoGCWii : public FileInfo
 {
 public:
   // Does not take ownership of pointers
-  FileInfoGCWii(u8 offset_shift, const u8* fst_entry, const u8* name_table_start);
+  FileInfoGCWii(const u8* fst, u8 offset_shift, u32 index, u32 total_file_infos);
 
   ~FileInfoGCWii() override;
 
@@ -40,9 +40,10 @@ private:
 
   u32 Get(EntryProperty entry_property) const;
 
+  const u8* const m_fst;
   const u8 m_offset_shift;
-  const u8* const m_fst_entry;
-  const u8* const m_name_table_start;
+  const u32 m_index;
+  const u32 m_total_file_infos;
 };
 
 class FileSystemGCWii : public FileSystem

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -44,12 +44,12 @@ public:
   bool IsValid() const override { return m_Valid; }
   const std::vector<FileInfoGCWii>& GetFileList() override;
   const FileInfo* FindFileInfo(const std::string& path) override;
-  u64 GetFileSize(const std::string& _rFullPath) override;
+  const FileInfo* FindFileInfo(u64 disc_offset) override;
   std::string GetPath(u64 _Address) override;
   std::string GetPathFromFSTOffset(size_t file_info_offset) override;
-  u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
+  u64 ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
                u64 _OffsetInFile) override;
-  bool ExportFile(const std::string& _rFullPath, const std::string& _rExportFilename) override;
+  bool ExportFile(const FileInfo* file_info, const std::string& _rExportFilename) override;
   bool ExportApploader(const std::string& _rExportFolder) const override;
   bool ExportDOL(const std::string& _rExportFolder) const override;
   std::optional<u64> GetBootDOLOffset() const override;

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -85,24 +85,24 @@ private:
 class FileSystemGCWii : public FileSystem
 {
 public:
-  FileSystemGCWii(const Volume* _rVolume, const Partition& partition);
+  FileSystemGCWii(const Volume* volume, const Partition& partition);
   ~FileSystemGCWii() override;
 
-  bool IsValid() const override { return m_Valid; }
+  bool IsValid() const override { return m_valid; }
   const FileInfo& GetRoot() const override;
   std::unique_ptr<FileInfo> FindFileInfo(const std::string& path) const override;
   std::unique_ptr<FileInfo> FindFileInfo(u64 disc_offset) const override;
 
-  u64 ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
-               u64 _OffsetInFile) const override;
-  bool ExportFile(const FileInfo* file_info, const std::string& _rExportFilename) const override;
-  bool ExportApploader(const std::string& _rExportFolder) const override;
-  bool ExportDOL(const std::string& _rExportFolder) const override;
+  u64 ReadFile(const FileInfo* file_info, u8* buffer, u64 max_buffer_size,
+               u64 offset_in_file) const override;
+  bool ExportFile(const FileInfo* file_info, const std::string& export_filename) const override;
+  bool ExportApploader(const std::string& export_folder) const override;
+  bool ExportDOL(const std::string& export_folder) const override;
   std::optional<u64> GetBootDOLOffset() const override;
   std::optional<u32> GetBootDOLSize(u64 dol_offset) const override;
 
 private:
-  bool m_Valid;
+  bool m_valid;
   u32 m_offset_shift;
   std::vector<u8> m_file_system_table;
   FileInfoGCWii m_root;

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -46,6 +46,8 @@ public:
   std::string GetName() const override;
   std::string GetPath() const override;
 
+  bool IsValid(u64 fst_size, const FileInfoGCWii& parent_directory) const;
+
 protected:
   uintptr_t GetAddress() const override;
   FileInfo& operator++() override;
@@ -71,6 +73,8 @@ private:
   // Returns one of the three properties of this FST entry.
   // Read the comments in EntryProperty for details.
   u32 Get(EntryProperty entry_property) const;
+  // Returns the name offset, excluding the directory identification byte
+  u64 GetNameOffset() const;
 
   const u8* m_fst;
   u8 m_offset_shift;

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -101,9 +102,10 @@ private:
   u32 m_offset_shift;
   std::vector<u8> m_file_system_table;
   FileInfoGCWii m_root;
+  // Maps the end offset of files to FST indexes
+  mutable std::map<u64, u32> m_offset_file_info_cache;
 
   std::unique_ptr<FileInfo> FindFileInfo(const std::string& path, const FileInfo& file_info) const;
-  std::unique_ptr<FileInfo> FindFileInfo(u64 disc_offset, const FileInfo& file_info) const;
 };
 
 }  // namespace

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -17,15 +17,32 @@ namespace DiscIO
 class Volume;
 struct Partition;
 
+class FileInfoGCWii : public FileInfo
+{
+public:
+  FileInfoGCWii(u64 name_offset, u64 offset, u64 file_size);
+  ~FileInfoGCWii() override;
+
+  u64 GetOffset() const override { return m_Offset; }
+  u64 GetSize() const override { return m_FileSize; }
+  bool IsDirectory() const override { return (m_NameOffset & 0xFF000000) != 0; }
+  // TODO: These shouldn't be public
+  std::string m_FullPath;
+  const u64 m_NameOffset = 0u;
+
+private:
+  const u64 m_Offset = 0u;
+  const u64 m_FileSize = 0u;
+};
+
 class FileSystemGCWii : public FileSystem
 {
 public:
   FileSystemGCWii(const Volume* _rVolume, const Partition& partition);
-  virtual ~FileSystemGCWii();
-
+  ~FileSystemGCWii() override;
   bool IsValid() const override { return m_Valid; }
   u64 GetFileSize(const std::string& _rFullPath) override;
-  const std::vector<FileInfo>& GetFileList() override;
+  const std::vector<FileInfoGCWii>& GetFileList() override;
   std::string GetFileName(u64 _Address) override;
   u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
                u64 _OffsetInFile) override;
@@ -39,10 +56,10 @@ private:
   bool m_Initialized;
   bool m_Valid;
   u32 m_offset_shift;
-  std::vector<FileInfo> m_FileInfoVector;
+  std::vector<FileInfoGCWii> m_FileInfoVector;
 
   std::string GetStringFromOffset(u64 _Offset) const;
-  const FileInfo* FindFileInfo(const std::string& _rFullPath);
+  const FileInfoGCWii* FindFileInfo(const std::string& _rFullPath);
   bool DetectFileSystem();
   void InitFileSystem();
   size_t BuildFilenames(const size_t _FirstIndex, const size_t _LastIndex,

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -20,30 +21,60 @@ struct Partition;
 class FileInfoGCWii : public FileInfo
 {
 public:
-  // Does not take ownership of pointers
+  // None of the constructors take ownership of FST pointers
+
+  // Set everything manually
   FileInfoGCWii(const u8* fst, u8 offset_shift, u32 index, u32 total_file_infos);
+  // For the root object only
+  FileInfoGCWii(const u8* fst, u8 offset_shift);
+  // Copy another object
+  FileInfoGCWii(const FileInfoGCWii& file_info) = default;
+  // Copy data that is common to the whole file system
+  FileInfoGCWii(const FileInfoGCWii& file_info, u32 index);
 
   ~FileInfoGCWii() override;
+
+  std::unique_ptr<FileInfo> clone() const override;
+  const_iterator begin() const override;
+  const_iterator end() const override;
 
   u64 GetOffset() const override;
   u32 GetSize() const override;
   bool IsDirectory() const override;
+  u32 GetTotalChildren() const override;
   std::string GetName() const override;
+  std::string GetPath() const override;
+
+protected:
+  uintptr_t GetAddress() const override;
+  FileInfo& operator++() override;
 
 private:
   enum class EntryProperty
   {
+    // NAME_OFFSET's lower 3 bytes are the name's offset within the name table.
+    // NAME_OFFSET's upper 1 byte is 1 for directories and 0 for files.
     NAME_OFFSET = 0,
+    // For files, FILE_OFFSET is the file offset in the partition,
+    // and for directories, it's the FST index of the parent directory.
+    // The root directory has its parent directory index set to 0.
     FILE_OFFSET = 1,
+    // For files, FILE_SIZE is the file size, and for directories,
+    // it's the FST index of the next entry that isn't in the directory.
     FILE_SIZE = 2
   };
 
+  // For files, returns the index of the next item. For directories,
+  // returns the index of the next item that isn't inside it.
+  u32 GetNextIndex() const;
+  // Returns one of the three properties of this FST entry.
+  // Read the comments in EntryProperty for details.
   u32 Get(EntryProperty entry_property) const;
 
-  const u8* const m_fst;
-  const u8 m_offset_shift;
-  const u32 m_index;
-  const u32 m_total_file_infos;
+  const u8* m_fst;
+  u8 m_offset_shift;
+  u32 m_index;
+  u32 m_total_file_infos;
 };
 
 class FileSystemGCWii : public FileSystem
@@ -51,12 +82,12 @@ class FileSystemGCWii : public FileSystem
 public:
   FileSystemGCWii(const Volume* _rVolume, const Partition& partition);
   ~FileSystemGCWii() override;
+
   bool IsValid() const override { return m_Valid; }
-  const std::vector<FileInfoGCWii>& GetFileList() const override;
-  const FileInfo* FindFileInfo(const std::string& path) const override;
-  const FileInfo* FindFileInfo(u64 disc_offset) const override;
-  std::string GetPath(u64 _Address) const override;
-  std::string GetPathFromFSTOffset(size_t file_info_offset) const override;
+  const FileInfo& GetRoot() const override;
+  std::unique_ptr<FileInfo> FindFileInfo(const std::string& path) const override;
+  std::unique_ptr<FileInfo> FindFileInfo(u64 disc_offset) const override;
+
   u64 ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
                u64 _OffsetInFile) const override;
   bool ExportFile(const FileInfo* file_info, const std::string& _rExportFilename) const override;
@@ -68,10 +99,11 @@ public:
 private:
   bool m_Valid;
   u32 m_offset_shift;
-  std::vector<FileInfoGCWii> m_FileInfoVector;
   std::vector<u8> m_file_system_table;
+  FileInfoGCWii m_root;
 
-  const FileInfo* FindFileInfo(const std::string& path, size_t search_start_offset) const;
+  std::unique_ptr<FileInfo> FindFileInfo(const std::string& path, const FileInfo& file_info) const;
+  std::unique_ptr<FileInfo> FindFileInfo(u64 disc_offset, const FileInfo& file_info) const;
 };
 
 }  // namespace

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -20,14 +20,15 @@ struct Partition;
 class FileInfoGCWii : public FileInfo
 {
 public:
-  FileInfoGCWii(u64 name_offset, u64 offset, u64 file_size);
+  FileInfoGCWii(u64 name_offset, u64 offset, u64 file_size, std::string name);
   ~FileInfoGCWii() override;
 
   u64 GetOffset() const override { return m_Offset; }
   u64 GetSize() const override { return m_FileSize; }
   bool IsDirectory() const override { return (m_NameOffset & 0xFF000000) != 0; }
+  const std::string& GetName() const override { return m_Name; }
   // TODO: These shouldn't be public
-  std::string m_FullPath;
+  std::string m_Name;
   const u64 m_NameOffset = 0u;
 
 private:
@@ -43,7 +44,8 @@ public:
   bool IsValid() const override { return m_Valid; }
   u64 GetFileSize(const std::string& _rFullPath) override;
   const std::vector<FileInfoGCWii>& GetFileList() override;
-  std::string GetFileName(u64 _Address) override;
+  std::string GetPath(u64 _Address) override;
+  std::string GetPathFromFSTOffset(size_t file_info_offset) override;
   u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
                u64 _OffsetInFile) override;
   bool ExportFile(const std::string& _rFullPath, const std::string& _rExportFilename) override;
@@ -62,8 +64,6 @@ private:
   const FileInfoGCWii* FindFileInfo(const std::string& _rFullPath);
   bool DetectFileSystem();
   void InitFileSystem();
-  size_t BuildFilenames(const size_t _FirstIndex, const size_t _LastIndex,
-                        const std::string& _szDirectory, u64 _NameTableOffset);
 };
 
 }  // namespace

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -42,8 +42,9 @@ public:
   FileSystemGCWii(const Volume* _rVolume, const Partition& partition);
   ~FileSystemGCWii() override;
   bool IsValid() const override { return m_Valid; }
-  u64 GetFileSize(const std::string& _rFullPath) override;
   const std::vector<FileInfoGCWii>& GetFileList() override;
+  const FileInfo* FindFileInfo(const std::string& path) override;
+  u64 GetFileSize(const std::string& _rFullPath) override;
   std::string GetPath(u64 _Address) override;
   std::string GetPathFromFSTOffset(size_t file_info_offset) override;
   u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
@@ -61,7 +62,6 @@ private:
   std::vector<FileInfoGCWii> m_FileInfoVector;
 
   std::string GetStringFromOffset(u64 _Offset) const;
-  const FileInfoGCWii* FindFileInfo(const std::string& _rFullPath);
   bool DetectFileSystem();
   void InitFileSystem();
 };

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -61,6 +61,7 @@ private:
   u32 m_offset_shift;
   std::vector<FileInfoGCWii> m_FileInfoVector;
 
+  const FileInfo* FindFileInfo(const std::string& path, size_t search_start_offset) const;
   std::string GetStringFromOffset(u64 _Offset) const;
   bool DetectFileSystem();
   void InitFileSystem();

--- a/Source/Core/DiscIO/Filesystem.cpp
+++ b/Source/Core/DiscIO/Filesystem.cpp
@@ -9,6 +9,10 @@
 
 namespace DiscIO
 {
+FileInfo::~FileInfo()
+{
+}
+
 FileSystem::FileSystem(const Volume* _rVolume, const Partition& partition)
     : m_rVolume(_rVolume), m_partition(partition)
 {

--- a/Source/Core/DiscIO/Filesystem.cpp
+++ b/Source/Core/DiscIO/Filesystem.cpp
@@ -9,18 +9,14 @@
 
 namespace DiscIO
 {
-FileInfo::~FileInfo()
-{
-}
+FileInfo::~FileInfo() = default;
 
 FileSystem::FileSystem(const Volume* volume, const Partition& partition)
     : m_volume(volume), m_partition(partition)
 {
 }
 
-FileSystem::~FileSystem()
-{
-}
+FileSystem::~FileSystem() = default;
 
 std::unique_ptr<FileSystem> CreateFileSystem(const Volume* volume, const Partition& partition)
 {

--- a/Source/Core/DiscIO/Filesystem.cpp
+++ b/Source/Core/DiscIO/Filesystem.cpp
@@ -13,8 +13,8 @@ FileInfo::~FileInfo()
 {
 }
 
-FileSystem::FileSystem(const Volume* _rVolume, const Partition& partition)
-    : m_rVolume(_rVolume), m_partition(partition)
+FileSystem::FileSystem(const Volume* volume, const Partition& partition)
+    : m_volume(volume), m_partition(partition)
 {
 }
 

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -14,22 +14,20 @@
 
 namespace DiscIO
 {
+// TODO: eww
+class FileInfoGCWii;
+
 // file info of an FST entry
-struct FileInfo
+class FileInfo
 {
-  u64 m_NameOffset = 0u;
-  u64 m_Offset = 0u;
-  u64 m_FileSize = 0u;
-  std::string m_FullPath;
+public:
+  virtual ~FileInfo();
 
-  bool IsDirectory() const { return (m_NameOffset & 0xFF000000) != 0; }
-  FileInfo(u64 name_offset, u64 offset, u64 filesize)
-      : m_NameOffset(name_offset), m_Offset(offset), m_FileSize(filesize)
-  {
-  }
-
-  FileInfo(FileInfo const&) = default;
-  FileInfo() = default;
+  // Not guaranteed to return a meaningful value for directories
+  virtual u64 GetOffset() const = 0;
+  // Not guaranteed to return a meaningful value for directories
+  virtual u64 GetSize() const = 0;
+  virtual bool IsDirectory() const = 0;
 };
 
 class FileSystem
@@ -39,7 +37,8 @@ public:
 
   virtual ~FileSystem();
   virtual bool IsValid() const = 0;
-  virtual const std::vector<FileInfo>& GetFileList() = 0;
+  // TODO: Should only return FileInfo, not FileInfoGCWii
+  virtual const std::vector<FileInfoGCWii>& GetFileList() = 0;
   virtual u64 GetFileSize(const std::string& _rFullPath) = 0;
   virtual u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
                        u64 _OffsetInFile = 0) = 0;

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <string>
@@ -14,42 +15,116 @@
 
 namespace DiscIO
 {
-// TODO: eww
-class FileInfoGCWii;
-
 // file info of an FST entry
 class FileInfo
 {
+  friend class const_iterator;
+
 public:
+  class const_iterator final
+  {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = const FileInfo;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    const_iterator() : m_file_info(nullptr) {}
+    const_iterator(std::unique_ptr<FileInfo> file_info) : m_file_info(std::move(file_info)) {}
+    const_iterator(const const_iterator& it) : m_file_info(it.m_file_info->clone()) {}
+    const_iterator(const_iterator&& it) : m_file_info(std::move(it.m_file_info)) {}
+    ~const_iterator() {}
+    const_iterator& operator=(const const_iterator& it)
+    {
+      m_file_info = it.m_file_info ? it.m_file_info->clone() : nullptr;
+      return *this;
+    }
+    const_iterator& operator=(const_iterator&& it)
+    {
+      m_file_info = std::move(it.m_file_info);
+      return *this;
+    }
+    const_iterator& operator++()
+    {
+      ++*m_file_info;
+      return *this;
+    }
+    const_iterator operator++(int)
+    {
+      const_iterator old = *this;
+      ++*m_file_info;
+      return old;
+    }
+    bool operator==(const const_iterator& it) const
+    {
+      return m_file_info ? (it.m_file_info && *m_file_info == *it.m_file_info) : (!it.m_file_info);
+    }
+    bool operator!=(const const_iterator& it) const { return !operator==(it); }
+    // Incrementing or destroying an iterator will invalidate its returned references and
+    // pointers, but will not invalidate copies of the iterator or file info object.
+    const FileInfo& operator*() const { return *m_file_info.get(); }
+    const FileInfo* operator->() const { return m_file_info.get(); }
+  private:
+    std::unique_ptr<FileInfo> m_file_info;
+  };
+
   virtual ~FileInfo();
 
-  // Not guaranteed to return a meaningful value for directories
+  bool operator==(const FileInfo& other) const { return GetAddress() == other.GetAddress(); }
+  bool operator!=(const FileInfo& other) const { return !operator==(other); }
+  virtual std::unique_ptr<FileInfo> clone() const = 0;
+  virtual const_iterator cbegin() const { return begin(); }
+  virtual const_iterator cend() const { return end(); }
+  virtual const_iterator begin() const = 0;
+  virtual const_iterator end() const = 0;
+
+  // The offset of a file on the disc (inside the partition, if there is one).
+  // Not guaranteed to return a meaningful value for directories.
   virtual u64 GetOffset() const = 0;
-  // Not guaranteed to return a meaningful value for directories
+  // The size of a file.
+  // Not guaranteed to return a meaningful value for directories.
   virtual u32 GetSize() const = 0;
   virtual bool IsDirectory() const = 0;
+  // The number of files and directories in a directory, including those in subdirectories.
+  // Not guaranteed to return a meaningful value for files.
+  virtual u32 GetTotalChildren() const = 0;
   virtual std::string GetName() const = 0;
+  // GetPath will find the parents of the current object and call GetName on them,
+  // so it's slower than other functions. If you're traversing through folders
+  // to get a file and its path, building the path while traversing is faster.
+  virtual std::string GetPath() const = 0;
+
+protected:
+  // Only used for comparisons with other file info objects
+  virtual uintptr_t GetAddress() const = 0;
+
+  // Called by iterators
+  virtual FileInfo& operator++() = 0;
 };
 
 class FileSystem
 {
 public:
   FileSystem(const Volume* _rVolume, const Partition& partition);
-
   virtual ~FileSystem();
+
+  // If IsValid is false, GetRoot must not be called. CreateFileSystem
+  // takes care of this automatically, so other code is recommended to use it.
   virtual bool IsValid() const = 0;
-  // TODO: Should only return FileInfo, not FileInfoGCWii
-  virtual const std::vector<FileInfoGCWii>& GetFileList() const = 0;
-  virtual const FileInfo* FindFileInfo(const std::string& path) const = 0;
-  virtual const FileInfo* FindFileInfo(u64 disc_offset) const = 0;
+  // The object returned by GetRoot and all objects created from it
+  // are only valid for as long as the file system object is valid.
+  virtual const FileInfo& GetRoot() const = 0;
+  // Returns nullptr if not found
+  virtual std::unique_ptr<FileInfo> FindFileInfo(const std::string& path) const = 0;
+  // Returns nullptr if not found
+  virtual std::unique_ptr<FileInfo> FindFileInfo(u64 disc_offset) const = 0;
+
   virtual u64 ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
                        u64 _OffsetInFile = 0) const = 0;
-  virtual bool ExportFile(const FileInfo* file_info,
-                          const std::string& _rExportFilename) const = 0;
+  virtual bool ExportFile(const FileInfo* file_info, const std::string& _rExportFilename) const = 0;
   virtual bool ExportApploader(const std::string& _rExportFolder) const = 0;
   virtual bool ExportDOL(const std::string& _rExportFolder) const = 0;
-  virtual std::string GetPath(u64 _Address) const = 0;
-  virtual std::string GetPathFromFSTOffset(size_t file_info_offset) const = 0;
   virtual std::optional<u64> GetBootDOLOffset() const = 0;
   virtual std::optional<u32> GetBootDOLSize(u64 dol_offset) const = 0;
 
@@ -59,6 +134,7 @@ protected:
   const Partition m_partition;
 };
 
+// Returns nullptr if a valid file system could not be created
 std::unique_ptr<FileSystem> CreateFileSystem(const Volume* volume, const Partition& partition);
 
 }  // namespace

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -106,7 +106,7 @@ protected:
 class FileSystem
 {
 public:
-  FileSystem(const Volume* _rVolume, const Partition& partition);
+  FileSystem(const Volume* volume, const Partition& partition);
   virtual ~FileSystem();
 
   // If IsValid is false, GetRoot must not be called. CreateFileSystem
@@ -120,17 +120,17 @@ public:
   // Returns nullptr if not found
   virtual std::unique_ptr<FileInfo> FindFileInfo(u64 disc_offset) const = 0;
 
-  virtual u64 ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
-                       u64 _OffsetInFile = 0) const = 0;
-  virtual bool ExportFile(const FileInfo* file_info, const std::string& _rExportFilename) const = 0;
-  virtual bool ExportApploader(const std::string& _rExportFolder) const = 0;
-  virtual bool ExportDOL(const std::string& _rExportFolder) const = 0;
+  virtual u64 ReadFile(const FileInfo* file_info, u8* buffer, u64 max_buffer_size,
+                       u64 offset_in_file = 0) const = 0;
+  virtual bool ExportFile(const FileInfo* file_info, const std::string& export_filename) const = 0;
+  virtual bool ExportApploader(const std::string& export_folder) const = 0;
+  virtual bool ExportDOL(const std::string& export_folder) const = 0;
   virtual std::optional<u64> GetBootDOLOffset() const = 0;
   virtual std::optional<u32> GetBootDOLSize(u64 dol_offset) const = 0;
 
   virtual const Partition GetPartition() const { return m_partition; }
 protected:
-  const Volume* const m_rVolume;
+  const Volume* const m_volume;
   const Partition m_partition;
 };
 

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -41,6 +41,7 @@ public:
   // TODO: Should only return FileInfo, not FileInfoGCWii
   virtual const std::vector<FileInfoGCWii>& GetFileList() = 0;
   virtual u64 GetFileSize(const std::string& _rFullPath) = 0;
+  virtual const FileInfo* FindFileInfo(const std::string& path) = 0;
   virtual u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
                        u64 _OffsetInFile = 0) = 0;
   virtual bool ExportFile(const std::string& _rFullPath, const std::string& _rExportFilename) = 0;

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -34,7 +34,7 @@ public:
     const_iterator(std::unique_ptr<FileInfo> file_info) : m_file_info(std::move(file_info)) {}
     const_iterator(const const_iterator& it) : m_file_info(it.m_file_info->clone()) {}
     const_iterator(const_iterator&& it) : m_file_info(std::move(it.m_file_info)) {}
-    ~const_iterator() {}
+    ~const_iterator() = default;
     const_iterator& operator=(const const_iterator& it)
     {
       m_file_info = it.m_file_info ? it.m_file_info->clone() : nullptr;

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -26,9 +26,9 @@ public:
   // Not guaranteed to return a meaningful value for directories
   virtual u64 GetOffset() const = 0;
   // Not guaranteed to return a meaningful value for directories
-  virtual u64 GetSize() const = 0;
+  virtual u32 GetSize() const = 0;
   virtual bool IsDirectory() const = 0;
-  virtual const std::string& GetName() const = 0;
+  virtual std::string GetName() const = 0;
 };
 
 class FileSystem

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -40,11 +40,11 @@ public:
   virtual bool IsValid() const = 0;
   // TODO: Should only return FileInfo, not FileInfoGCWii
   virtual const std::vector<FileInfoGCWii>& GetFileList() = 0;
-  virtual u64 GetFileSize(const std::string& _rFullPath) = 0;
   virtual const FileInfo* FindFileInfo(const std::string& path) = 0;
-  virtual u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
+  virtual const FileInfo* FindFileInfo(u64 disc_offset) = 0;
+  virtual u64 ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
                        u64 _OffsetInFile = 0) = 0;
-  virtual bool ExportFile(const std::string& _rFullPath, const std::string& _rExportFilename) = 0;
+  virtual bool ExportFile(const FileInfo* file_info, const std::string& _rExportFilename) = 0;
   virtual bool ExportApploader(const std::string& _rExportFolder) const = 0;
   virtual bool ExportDOL(const std::string& _rExportFolder) const = 0;
   virtual std::string GetPath(u64 _Address) = 0;

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -28,6 +28,7 @@ public:
   // Not guaranteed to return a meaningful value for directories
   virtual u64 GetSize() const = 0;
   virtual bool IsDirectory() const = 0;
+  virtual const std::string& GetName() const = 0;
 };
 
 class FileSystem
@@ -45,7 +46,8 @@ public:
   virtual bool ExportFile(const std::string& _rFullPath, const std::string& _rExportFilename) = 0;
   virtual bool ExportApploader(const std::string& _rExportFolder) const = 0;
   virtual bool ExportDOL(const std::string& _rExportFolder) const = 0;
-  virtual std::string GetFileName(u64 _Address) = 0;
+  virtual std::string GetPath(u64 _Address) = 0;
+  virtual std::string GetPathFromFSTOffset(size_t file_info_offset) = 0;
   virtual std::optional<u64> GetBootDOLOffset() const = 0;
   virtual std::optional<u32> GetBootDOLSize(u64 dol_offset) const = 0;
 

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -39,16 +39,17 @@ public:
   virtual ~FileSystem();
   virtual bool IsValid() const = 0;
   // TODO: Should only return FileInfo, not FileInfoGCWii
-  virtual const std::vector<FileInfoGCWii>& GetFileList() = 0;
-  virtual const FileInfo* FindFileInfo(const std::string& path) = 0;
-  virtual const FileInfo* FindFileInfo(u64 disc_offset) = 0;
+  virtual const std::vector<FileInfoGCWii>& GetFileList() const = 0;
+  virtual const FileInfo* FindFileInfo(const std::string& path) const = 0;
+  virtual const FileInfo* FindFileInfo(u64 disc_offset) const = 0;
   virtual u64 ReadFile(const FileInfo* file_info, u8* _pBuffer, u64 _MaxBufferSize,
-                       u64 _OffsetInFile = 0) = 0;
-  virtual bool ExportFile(const FileInfo* file_info, const std::string& _rExportFilename) = 0;
+                       u64 _OffsetInFile = 0) const = 0;
+  virtual bool ExportFile(const FileInfo* file_info,
+                          const std::string& _rExportFilename) const = 0;
   virtual bool ExportApploader(const std::string& _rExportFolder) const = 0;
   virtual bool ExportDOL(const std::string& _rExportFolder) const = 0;
-  virtual std::string GetPath(u64 _Address) = 0;
-  virtual std::string GetPathFromFSTOffset(size_t file_info_offset) = 0;
+  virtual std::string GetPath(u64 _Address) const = 0;
+  virtual std::string GetPathFromFSTOffset(size_t file_info_offset) const = 0;
   virtual std::optional<u64> GetBootDOLOffset() const = 0;
   virtual std::optional<u32> GetBootDOLSize(u64 dol_offset) const = 0;
 

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -177,7 +177,7 @@ void VolumeGC::LoadBannerFile() const
   if (!file_system)
     return;
 
-  const FileInfo* file_info = file_system->FindFileInfo("opening.bnr");
+  std::unique_ptr<FileInfo> file_info = file_system->FindFileInfo("opening.bnr");
   if (!file_info)
     return;
 
@@ -190,7 +190,8 @@ void VolumeGC::LoadBannerFile() const
     return;
   }
 
-  if (file_size != file_system->ReadFile(file_info, reinterpret_cast<u8*>(&banner_file), file_size))
+  if (file_size !=
+      file_system->ReadFile(file_info.get(), reinterpret_cast<u8*>(&banner_file), file_size))
   {
     WARN_LOG(DISCIO, "Could not read opening.bnr.");
     return;

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -177,7 +177,11 @@ void VolumeGC::LoadBannerFile() const
   if (!file_system)
     return;
 
-  size_t file_size = static_cast<size_t>(file_system->GetFileSize("opening.bnr"));
+  const FileInfo* file_info = file_system->FindFileInfo("opening.bnr");
+  if (!file_info)
+    return;
+
+  size_t file_size = static_cast<size_t>(file_info->GetSize());
   constexpr int BNR1_MAGIC = 0x31524e42;
   constexpr int BNR2_MAGIC = 0x32524e42;
   if (file_size != BNR1_SIZE && file_size != BNR2_SIZE)
@@ -186,7 +190,11 @@ void VolumeGC::LoadBannerFile() const
     return;
   }
 
-  file_system->ReadFile("opening.bnr", reinterpret_cast<u8*>(&banner_file), file_size);
+  if (file_size != file_system->ReadFile(file_info, reinterpret_cast<u8*>(&banner_file), file_size))
+  {
+    WARN_LOG(DISCIO, "Could not read opening.bnr.");
+    return;
+  }
 
   bool is_bnr1;
   if (banner_file.id == BNR1_MAGIC && file_size == BNR1_SIZE)

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -274,9 +274,9 @@ std::map<Language, std::string> VolumeWii::GetLongNames() const
     return {};
 
   std::vector<u8> opening_bnr(NAMES_TOTAL_BYTES);
-  const FileInfo* file_info = file_system->FindFileInfo("opening.bnr");
-  size_t size = file_system->ReadFile(file_info, opening_bnr.data(), opening_bnr.size(), 0x5C);
-  opening_bnr.resize(size);
+  std::unique_ptr<FileInfo> file_info = file_system->FindFileInfo("opening.bnr");
+  opening_bnr.resize(
+      file_system->ReadFile(file_info.get(), opening_bnr.data(), opening_bnr.size(), 0x5C));
   return ReadWiiNames(opening_bnr);
 }
 

--- a/Source/Core/DiscIO/VolumeWii.cpp
+++ b/Source/Core/DiscIO/VolumeWii.cpp
@@ -274,7 +274,8 @@ std::map<Language, std::string> VolumeWii::GetLongNames() const
     return {};
 
   std::vector<u8> opening_bnr(NAMES_TOTAL_BYTES);
-  size_t size = file_system->ReadFile("opening.bnr", opening_bnr.data(), opening_bnr.size(), 0x5C);
+  const FileInfo* file_info = file_system->FindFileInfo("opening.bnr");
+  size_t size = file_system->ReadFile(file_info, opening_bnr.data(), opening_bnr.size(), 0x5C);
   opening_bnr.resize(size);
   return ReadWiiNames(opening_bnr);
 }

--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
@@ -5,6 +5,8 @@
 #include "DolphinWX/ISOProperties/FilesystemPanel.h"
 
 #include <array>
+#include <functional>
+#include <memory>
 #include <vector>
 
 #include <wx/bitmap.h>
@@ -23,8 +25,6 @@
 #include "Common/Logging/Log.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/Filesystem.h"
-// TODO: eww
-#include "DiscIO/FileSystemGCWii.h"
 #include "DiscIO/Volume.h"
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/WxUtils.h"
@@ -85,41 +85,22 @@ wxImageList* LoadIconBitmaps(const wxWindow* context)
   return icon_list;
 }
 
-size_t CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
-                           const std::vector<DiscIO::FileInfoGCWii>& file_infos,
-                           const size_t first_index, const size_t last_index)
+void CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
+                         const DiscIO::FileInfo& directory)
 {
-  size_t current_index = first_index;
-
-  while (current_index < last_index)
+  for (const DiscIO::FileInfo& file_info : directory)
   {
-    const DiscIO::FileInfoGCWii& file_info = file_infos[current_index];
-
-    // check next index
+    const wxString name = StrToWxStr(file_info.GetName());
     if (file_info.IsDirectory())
     {
-      const wxTreeItemId item =
-          tree_ctrl->AppendItem(parent, StrToWxStr(file_info.GetName()), ICON_FOLDER);
-      current_index = CreateDirectoryTree(tree_ctrl, item, file_infos, current_index + 1,
-                                          static_cast<size_t>(file_info.GetSize()));
+      wxTreeItemId item = tree_ctrl->AppendItem(parent, name, ICON_FOLDER);
+      CreateDirectoryTree(tree_ctrl, item, file_info);
     }
     else
     {
-      tree_ctrl->AppendItem(parent, StrToWxStr(file_info.GetName()), ICON_FILE);
-      current_index++;
+      tree_ctrl->AppendItem(parent, name, ICON_FILE);
     }
   }
-
-  return current_index;
-}
-
-size_t CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
-                           const std::vector<DiscIO::FileInfoGCWii>& file_infos)
-{
-  if (file_infos.empty())
-    return 0;
-
-  return CreateDirectoryTree(tree_ctrl, parent, file_infos, 1, file_infos.at(0).GetSize());
 }
 
 WiiPartition* FindWiiPartition(wxTreeCtrl* tree_ctrl, const wxString& label)
@@ -201,7 +182,7 @@ bool FilesystemPanel::PopulateFileSystemTree()
         WiiPartition* const partition = new WiiPartition(std::move(file_system));
 
         m_tree_ctrl->SetItemData(partition_root, partition);
-        CreateDirectoryTree(m_tree_ctrl, partition_root, partition->filesystem->GetFileList());
+        CreateDirectoryTree(m_tree_ctrl, partition_root, partition->filesystem->GetRoot());
 
         if (partitions[i] == m_opened_iso->GetGamePartition())
           m_tree_ctrl->Expand(partition_root);
@@ -214,7 +195,7 @@ bool FilesystemPanel::PopulateFileSystemTree()
     if (!m_filesystem)
       return false;
 
-    CreateDirectoryTree(m_tree_ctrl, m_tree_ctrl->GetRootItem(), m_filesystem->GetFileList());
+    CreateDirectoryTree(m_tree_ctrl, m_tree_ctrl->GetRootItem(), m_filesystem->GetRoot());
   }
 
   return true;
@@ -382,13 +363,13 @@ void FilesystemPanel::ExtractAllFiles(const wxString& output_folder)
     while (item.IsOk())
     {
       const auto* const partition = static_cast<WiiPartition*>(m_tree_ctrl->GetItemData(item));
-      ExtractDirectories("", WxStrToStr(output_folder), partition->filesystem.get());
+      ExtractDirectories("", WxStrToStr(output_folder), *partition->filesystem);
       item = m_tree_ctrl->GetNextChild(root, cookie);
     }
   }
   else
   {
-    ExtractDirectories("", WxStrToStr(output_folder), m_filesystem.get());
+    ExtractDirectories("", WxStrToStr(output_folder), *m_filesystem);
   }
 }
 
@@ -406,12 +387,12 @@ void FilesystemPanel::ExtractSingleFile(const wxString& output_file_path) const
     selection_file_path.erase(0, slash_index + 1);
 
     partition->filesystem->ExportFile(
-        partition->filesystem->FindFileInfo(WxStrToStr(selection_file_path)),
+        partition->filesystem->FindFileInfo(WxStrToStr(selection_file_path)).get(),
         WxStrToStr(output_file_path));
   }
   else
   {
-    m_filesystem->ExportFile(m_filesystem->FindFileInfo(WxStrToStr(selection_file_path)),
+    m_filesystem->ExportFile(m_filesystem->FindFileInfo(WxStrToStr(selection_file_path)).get(),
                              WxStrToStr(output_file_path));
   }
 }
@@ -430,102 +411,71 @@ void FilesystemPanel::ExtractSingleDirectory(const wxString& output_folder)
     directory_path.erase(0, slash_index + 1);
 
     ExtractDirectories(WxStrToStr(directory_path), WxStrToStr(output_folder),
-                       partition->filesystem.get());
+                       *partition->filesystem);
   }
   else
   {
-    ExtractDirectories(WxStrToStr(directory_path), WxStrToStr(output_folder), m_filesystem.get());
+    ExtractDirectories(WxStrToStr(directory_path), WxStrToStr(output_folder), *m_filesystem);
+  }
+}
+
+void ExtractDir(const std::string& full_path, const std::string& output_folder,
+                const DiscIO::FileSystem& file_system, const DiscIO::FileInfo& directory,
+                const std::function<bool(const std::string& path)>& update_progress)
+{
+  for (const DiscIO::FileInfo& file_info : directory)
+  {
+    const std::string path = full_path + file_info.GetName() + (file_info.IsDirectory() ? "/" : "");
+    const std::string output_path = output_folder + DIR_SEP_CHR + path;
+
+    if (update_progress(path))
+      return;
+
+    DEBUG_LOG(DISCIO, "%s", output_path.c_str());
+
+    if (file_info.IsDirectory())
+    {
+      File::CreateFullPath(output_path);
+      ExtractDir(path, output_folder, file_system, file_info, update_progress);
+    }
+    else
+    {
+      if (File::Exists(output_path))
+        NOTICE_LOG(DISCIO, "%s already exists", output_path.c_str());
+      else if (!file_system.ExportFile(&file_info, output_path))
+        ERROR_LOG(DISCIO, "Could not export %s", output_path.c_str());
+    }
   }
 }
 
 void FilesystemPanel::ExtractDirectories(const std::string& full_path,
                                          const std::string& output_folder,
-                                         DiscIO::FileSystem* filesystem)
+                                         const DiscIO::FileSystem& filesystem)
 {
-  const std::vector<DiscIO::FileInfoGCWii>& fst = filesystem->GetFileList();
-
-  u32 index = 0;
-  u32 size = 0;
-
-  // Extract all
-  if (full_path.empty())
+  if (full_path.empty())  // Root
   {
-    size = static_cast<u32>(fst.size());
-
-    filesystem->ExportApploader(output_folder);
-    filesystem->ExportDOL(output_folder);
-  }
-  else
-  {
-    // Look for the dir we are going to extract
-    // TODO: Make this more efficient
-    for (index = 0; index < fst.size(); ++index)
-    {
-      if (filesystem->GetPathFromFSTOffset(index) == full_path)
-      {
-        INFO_LOG(DISCIO, "Found the directory at %u", index);
-        size = static_cast<u32>(fst[index].GetSize());
-        break;
-      }
-    }
-
-    INFO_LOG(DISCIO, "Directory found from %u to %u\nextracting to: %s", index, size,
-             output_folder.c_str());
+    filesystem.ExportApploader(output_folder);
+    filesystem.ExportDOL(output_folder);
   }
 
-  const auto dialog_title = (index != 0) ? _("Extracting Directory") : _("Extracting All Files");
-  wxProgressDialog dialog(dialog_title, _("Extracting..."), static_cast<int>(size - 1), this,
+  std::unique_ptr<DiscIO::FileInfo> file_info = filesystem.FindFileInfo(full_path);
+  u32 size = file_info->GetTotalChildren();
+  u32 progress = 0;
+
+  wxString dialog_title = full_path.empty() ? _("Extracting All Files") : _("Extracting Directory");
+  wxProgressDialog dialog(dialog_title, _("Extracting..."), size, this,
                           wxPD_APP_MODAL | wxPD_AUTO_HIDE | wxPD_CAN_ABORT | wxPD_ELAPSED_TIME |
                               wxPD_ESTIMATED_TIME | wxPD_REMAINING_TIME | wxPD_SMOOTH);
 
-  // Extraction
-  for (u32 i = index; i < size; i++)
-  {
-    const std::string path = filesystem->GetPathFromFSTOffset(i);
+  File::CreateFullPath(output_folder + "/" + full_path);
+  ExtractDir(full_path, output_folder, filesystem, *file_info, [&](const std::string& path) {
     dialog.SetTitle(wxString::Format(
-        "%s : %u%%", dialog_title.c_str(),
-        static_cast<u32>((static_cast<float>(i - index) / static_cast<float>(size - index)) *
-                         100)));
-
-    dialog.Update(i, wxString::Format(_("Extracting %s"), StrToWxStr(path)));
-
-    if (dialog.WasCancelled())
-      break;
-
-    if (fst[i].IsDirectory())
-    {
-      const std::string export_name =
-          StringFromFormat("%s/%s/", output_folder.c_str(), path.c_str());
-      INFO_LOG(DISCIO, "%s", export_name.c_str());
-
-      if (!File::Exists(export_name) && !File::CreateFullPath(export_name))
-      {
-        ERROR_LOG(DISCIO, "Could not create the path %s", export_name.c_str());
-      }
-      else
-      {
-        if (!File::IsDirectory(export_name))
-          ERROR_LOG(DISCIO, "%s already exists and is not a directory", export_name.c_str());
-
-        ERROR_LOG(DISCIO, "Folder %s already exists", export_name.c_str());
-      }
-    }
-    else
-    {
-      const std::string export_name =
-          StringFromFormat("%s/%s", output_folder.c_str(), path.c_str());
-      INFO_LOG(DISCIO, "%s", export_name.c_str());
-
-      if (!File::Exists(export_name) && !filesystem->ExportFile(&fst[index], export_name))
-      {
-        ERROR_LOG(DISCIO, "Could not export %s", export_name.c_str());
-      }
-      else
-      {
-        ERROR_LOG(DISCIO, "%s already exists", export_name.c_str());
-      }
-    }
-  }
+        "%s : %d%%", dialog_title.c_str(),
+        static_cast<u32>((static_cast<float>(progress) / static_cast<float>(size)) * 100)));
+    dialog.Update(progress, wxString::Format(_("Extracting %s"), StrToWxStr(path)));
+    ++progress;
+    return dialog.WasCancelled();
+  });
 }
 
 wxString FilesystemPanel::BuildFilePathFromSelection() const

--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
@@ -405,12 +405,14 @@ void FilesystemPanel::ExtractSingleFile(const wxString& output_file_path) const
     // Remove "Partition x/"
     selection_file_path.erase(0, slash_index + 1);
 
-    partition->filesystem->ExportFile(WxStrToStr(selection_file_path),
-                                      WxStrToStr(output_file_path));
+    partition->filesystem->ExportFile(
+        partition->filesystem->FindFileInfo(WxStrToStr(selection_file_path)),
+        WxStrToStr(output_file_path));
   }
   else
   {
-    m_filesystem->ExportFile(WxStrToStr(selection_file_path), WxStrToStr(output_file_path));
+    m_filesystem->ExportFile(m_filesystem->FindFileInfo(WxStrToStr(selection_file_path)),
+                             WxStrToStr(output_file_path));
   }
 }
 
@@ -456,6 +458,7 @@ void FilesystemPanel::ExtractDirectories(const std::string& full_path,
   else
   {
     // Look for the dir we are going to extract
+    // TODO: Make this more efficient
     for (index = 0; index < fst.size(); ++index)
     {
       if (filesystem->GetPathFromFSTOffset(index) == full_path)
@@ -513,7 +516,7 @@ void FilesystemPanel::ExtractDirectories(const std::string& full_path,
           StringFromFormat("%s/%s", output_folder.c_str(), path.c_str());
       INFO_LOG(DISCIO, "%s", export_name.c_str());
 
-      if (!File::Exists(export_name) && !filesystem->ExportFile(path, export_name))
+      if (!File::Exists(export_name) && !filesystem->ExportFile(&fst[index], export_name))
       {
         ERROR_LOG(DISCIO, "Could not export %s", export_name.c_str());
       }

--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.cpp
@@ -23,6 +23,8 @@
 #include "Common/Logging/Log.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/Filesystem.h"
+// TODO: eww
+#include "DiscIO/FileSystemGCWii.h"
 #include "DiscIO/Volume.h"
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/WxUtils.h"
@@ -84,14 +86,14 @@ wxImageList* LoadIconBitmaps(const wxWindow* context)
 }
 
 size_t CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
-                           const std::vector<DiscIO::FileInfo>& file_infos,
+                           const std::vector<DiscIO::FileInfoGCWii>& file_infos,
                            const size_t first_index, const size_t last_index)
 {
   size_t current_index = first_index;
 
   while (current_index < last_index)
   {
-    const DiscIO::FileInfo& file_info = file_infos[current_index];
+    const DiscIO::FileInfoGCWii& file_info = file_infos[current_index];
     std::string file_path = file_info.m_FullPath;
 
     // Trim the trailing '/' if it exists.
@@ -113,7 +115,7 @@ size_t CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
     {
       const wxTreeItemId item = tree_ctrl->AppendItem(parent, StrToWxStr(file_path), ICON_FOLDER);
       current_index = CreateDirectoryTree(tree_ctrl, item, file_infos, current_index + 1,
-                                          static_cast<size_t>(file_info.m_FileSize));
+                                          static_cast<size_t>(file_info.GetSize()));
     }
     else
     {
@@ -126,12 +128,12 @@ size_t CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
 }
 
 size_t CreateDirectoryTree(wxTreeCtrl* tree_ctrl, wxTreeItemId parent,
-                           const std::vector<DiscIO::FileInfo>& file_infos)
+                           const std::vector<DiscIO::FileInfoGCWii>& file_infos)
 {
   if (file_infos.empty())
     return 0;
 
-  return CreateDirectoryTree(tree_ctrl, parent, file_infos, 1, file_infos.at(0).m_FileSize);
+  return CreateDirectoryTree(tree_ctrl, parent, file_infos, 1, file_infos.at(0).GetSize());
 }
 
 WiiPartition* FindWiiPartition(wxTreeCtrl* tree_ctrl, const wxString& label)
@@ -452,7 +454,7 @@ void FilesystemPanel::ExtractDirectories(const std::string& full_path,
                                          const std::string& output_folder,
                                          DiscIO::FileSystem* filesystem)
 {
-  const std::vector<DiscIO::FileInfo>& fst = filesystem->GetFileList();
+  const std::vector<DiscIO::FileInfoGCWii>& fst = filesystem->GetFileList();
 
   u32 index = 0;
   u32 size = 0;
@@ -473,7 +475,7 @@ void FilesystemPanel::ExtractDirectories(const std::string& full_path,
       if (fst[index].m_FullPath == full_path)
       {
         INFO_LOG(DISCIO, "Found the directory at %u", index);
-        size = static_cast<u32>(fst[index].m_FileSize);
+        size = static_cast<u32>(fst[index].GetSize());
         break;
       }
     }

--- a/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.h
+++ b/Source/Core/DolphinWX/ISOProperties/FilesystemPanel.h
@@ -51,7 +51,7 @@ private:
   void ExtractSingleFile(const wxString& output_file_path) const;
   void ExtractSingleDirectory(const wxString& output_folder);
   void ExtractDirectories(const std::string& full_path, const std::string& output_folder,
-                          DiscIO::FileSystem* filesystem);
+                          const DiscIO::FileSystem& filesystem);
 
   wxString BuildFilePathFromSelection() const;
   wxString BuildDirectoryPathFromSelection() const;

--- a/Source/Core/DolphinWX/ISOProperties/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties/ISOProperties.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <set>
 #include <string>


### PR DESCRIPTION
Scanning the game list without a cache can take a while when there are many games. As evidenced by games with large file systems taking significantly longer than others, a big part of this time is spent dealing with file systems. To improve the speed of scanning the game list, I made this PR. Initializing a file system now only involves three tiny disc reads and one big disc read to a `vector<u8>`, as opposed to the old code which made lots of tiny reads (many of them even going backwards!) and then constructed a bunch of objects from the values it obtained. I have also implemented better search algorithms for the two variants of `FindFileInfo`. With these changes, building the game list cache now takes about the same time for each game – the only real speed limit that's left is the limitations of the hard drive. ~~I had hoped that these changes also would make opening the game properties fast, but it can still take a second or so with large file systems because of the time it takes for the GUI to create all the tree items.~~ (EDIT: After updating to VS2015, this seems to be reasonably fast even in master.)

Another goal with this PR was to avoid implementation details of file systems being exposed to code that uses them. In the past, getting all file infos in a directory involved looping through the file system's vector of file infos and knowing that getting the size of a directory in a GC/Wii disc file system happens to produce the index of the first file info that comes after the directory. This is now taken care of inside the file system code, and code that uses file systems simply needs to use a range-based for loop on a directory to get its children. This should make it easier to both write new code that interacts with file systems and to implement new types of file systems that can be used in the same way as GC/Wii disc file systems. However, working with iterators and unique_ptrs and whatnot is still a bit new to me, so please comment if any parts of the design are bad.

While working on the changes needed for these two goals, I also tried to do as much error checking as possible. Invalid file systems should never make Dolphin crash or hang, because this code gets run when Dolphin boots. ~~The only remaining issue that I know of is that Dolphin can run out of memory if a file system is too large, which is handled by PR #2610.~~ (EDIT: That fix has been merged.)

Now, the question is... @JMC47, how much faster can your game list be scanned with this PR?

EDIT: This description was originally written when using VS2013. Now that Dolphin uses VS2015, the speed of scanning the game list and opening game properties windows has been significantly improved in master, at least with local drives. That means that the speed difference between master and this PR isn't as large as on VS2013, but it still does improve the speed, especially in situations like FileMonitor being called frequently. I'm not sure what the situation is like on other compilers/platforms.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/2820)

<!-- Reviewable:end -->
