### PR TITLE
Specified the type of AA in OGL AA settings

### DIFF
--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -121,7 +121,7 @@ static void InitBackendInfo()
 	g_Config.backend_info.Adapters.clear();
 
 	// aamodes
-	const char* caamodes[] = {_trans("None"), "2x", "4x", "8x", "4x SSAA"};
+	const char* caamodes[] = {_trans("None"), "2x MSAA", "4x MSAA", "8x MSAA", "4x SSAA"};
 	g_Config.backend_info.AAModes.assign(caamodes, caamodes + sizeof(caamodes)/sizeof(*caamodes));
 
 	// pp shaders


### PR DESCRIPTION
One little UI quirk that mislead me on what Dolphin actually does is the anti-aliasing setting. In OGL it only says "2x, 4x, 8x" and "4x SSAA". To me that's pretty weird and doesn't tell me what the others are. Considering there's a zillion different forms of AA, I think that it would be better to be verbose with what those other settings are. IMO this is a pretty safe change. It takes up no additional UI space. Doesn't even stretch the drop down box.


However, I'm slightly concerned why the AA UI labels were in OGL's video backend and not the videoconfigdialog.cpp file. So I did extensive testing with ZTP in the titlescreen and frame advancing between AA settings to make sure I didn't break anything and AA modes still worked as designed. If others could test this as well that would be very nice. Thanks.

![image](http://i.imgur.com/JbG4g0U.jpg)