### PR TITLE
Set Speed Up Disc Transfer rate in the Sonic Riders INI

### DIFF
--- a/Data/Sys/GameSettings/GXE.ini
+++ b/Data/Sys/GameSettings/GXE.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.


### PR DESCRIPTION
091db36 added a new delay for disc commands in an attempt to fix issues. It fixed Sonic Riders crashing after the third level... or so we thought. 091db36 also happened changed the order disc reads happen in so that the data is copied to memory before the emulated delay is finished. This was inaccurate and caused an audio problem in Resident Evil 3, leading to the old order being restored in 8cc6e5c. Now that the order is correct, Sonic Riders is broken again, despite 091db36's delay still existing. We're more or less back to square one - nobody knows what's broken, and nobody knows how to fix it. This commit restores SUDTR to Sonic Rider's game INI so that it'll work out of the box in 5.0 just like in 4.0.

https://code.google.com/p/dolphin-emu/issues/detail?id=7257
https://code.google.com/p/dolphin-emu/issues/detail?id=8725