### PR TITLE
Fix reading Wii FST size (for real this time)

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -89,7 +89,7 @@ public:
 	virtual std::map<ELanguage, std::string> GetDescriptions() const { return std::map<ELanguage, std::string>(); }
 	virtual std::string GetCompany() const { return std::string(); }
 	virtual std::vector<u32> GetBanner(int* width, int* height) const;
-	virtual u32 GetFSTSize() const = 0;
+	virtual u64 GetFSTSize() const = 0;
 	virtual std::string GetApploaderDate() const = 0;
 	// 0 is the first disc, 1 is the second disc
 	virtual u8 GetDiscNumber() const { return 0; }

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -210,7 +210,7 @@ void CVolumeDirectory::SetName(const std::string& name)
 	m_diskHeader[length + 0x20] = 0;
 }
 
-u32 CVolumeDirectory::GetFSTSize() const
+u64 CVolumeDirectory::GetFSTSize() const
 {
 	return 0;
 }

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -44,7 +44,7 @@ public:
 	std::map<IVolume::ELanguage, std::string> GetNames(bool prefer_long) const override;
 	void SetName(const std::string&);
 
-	u32 GetFSTSize() const override;
+	u64 GetFSTSize() const override;
 
 	std::string GetApploaderDate() const override;
 	EPlatform GetVolumeType() const override;

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -143,7 +143,7 @@ std::vector<u32> CVolumeGC::GetBanner(int* width, int* height) const
 	return image_buffer;
 }
 
-u32 CVolumeGC::GetFSTSize() const
+u64 CVolumeGC::GetFSTSize() const
 {
 	if (m_pReader == nullptr)
 		return 0;

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -33,7 +33,7 @@ public:
 	std::map<ELanguage, std::string> GetDescriptions() const override;
 	std::string GetCompany() const override;
 	std::vector<u32> GetBanner(int* width, int* height) const override;
-	u32 GetFSTSize() const override;
+	u64 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;
 	u8 GetDiscNumber() const override;
 

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -33,7 +33,7 @@ public:
 	u16 GetRevision() const override;
 	std::string GetInternalName() const override { return ""; }
 	std::map<IVolume::ELanguage, std::string> GetNames(bool prefer_long) const override;
-	u32 GetFSTSize() const override { return 0; }
+	u64 GetFSTSize() const override { return 0; }
 	std::string GetApploaderDate() const override { return ""; }
 
 	EPlatform GetVolumeType() const override;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -206,7 +206,7 @@ std::map<IVolume::ELanguage, std::string> CVolumeWiiCrypted::GetNames(bool prefe
 	return ReadWiiNames(opening_bnr);
 }
 
-u32 CVolumeWiiCrypted::GetFSTSize() const
+u64 CVolumeWiiCrypted::GetFSTSize() const
 {
 	if (m_pReader == nullptr)
 		return 0;
@@ -216,7 +216,7 @@ u32 CVolumeWiiCrypted::GetFSTSize() const
 	if (!Read(0x428, 0x4, (u8*)&size, true))
 		return 0;
 
-	return Common::swap32(size);
+	return (u64)Common::swap32(size) << 2;
 }
 
 std::string CVolumeWiiCrypted::GetApploaderDate() const

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -33,7 +33,7 @@ public:
 	u16 GetRevision() const override;
 	std::string GetInternalName() const override;
 	std::map<IVolume::ELanguage, std::string> GetNames(bool prefer_long) const override;
-	u32 GetFSTSize() const override;
+	u64 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;
 	u8 GetDiscNumber() const override;
 

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -183,9 +183,9 @@ CISOProperties::CISOProperties(const std::string& fileName, wxWindow* parent, wx
 
 	wxString temp = "0x" + StrToWxStr(OpenISO->GetMakerID());
 	m_MakerID->SetValue(temp);
-	m_Revision->SetValue(wxString::Format("%u", OpenISO->GetRevision()));
+	m_Revision->SetValue(StrToWxStr(std::to_string(OpenISO->GetRevision())));
 	m_Date->SetValue(StrToWxStr(OpenISO->GetApploaderDate()));
-	m_FST->SetValue(wxString::Format("%u", OpenISO->GetFSTSize()));
+	m_FST->SetValue(StrToWxStr(std::to_string(OpenISO->GetFSTSize())));
 
 	// Here we set all the info to be shown + we set the window title
 	bool wii = OpenISO->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;


### PR DESCRIPTION
04fcb72 fixed an issue with reading the Wii FST size, but I found a second issue when working on PR #2820 - the size must be shifted left by 2. DiscScrubber and Boot already do this correctly using separate code.

Do we want this fix in stable? It's not something that most users will care about, but it's a very easy and safe fix. The only thing GetFSTSize() is used for is the FST size field in the game properties window.