### PR TITLE
DolphinWX: Ensure TASInputDlg only gets modified on the main thread

### DIFF
--- a/Source/Core/DolphinWX/TASInputDlg.h
+++ b/Source/Core/DolphinWX/TASInputDlg.h
@@ -89,6 +89,8 @@ class TASInputDlg : public wxDialog
 		};
 
 		wxBoxSizer* CreateCCLayout();
+		void FinishLayout();
+		void GetValuesCallback(wxCommandEvent& event);
 		void SetStickValue(bool* ActivatedByKeyboard, int* AmountPressed, wxTextCtrl* Textbox, int CurrentValue, int center = 128);
 		void SetButtonValue(Button* button, bool CurrentState);
 		void SetSliderValue(Control* control, int CurrentValue);


### PR DESCRIPTION
The TASInputDlg class had tons of threading problems due to updates being called on the CPU thread. This patch forwards these updates to the main thread if they come in on the wrong thread, so it should finally flatten out all threading issues with the class. It also reverts the bandaids applied in 3639755120815bdae5a343df0638920570cb1750 and 704f787c5a4fa90e50928174b4fe71eedfc93383, since they are no longer necessary.