### PR TITLE
Wiimotes: Initialize all atomic<bool> globally.

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IONix.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IONix.cpp
@@ -36,8 +36,7 @@ private:
 };
 
 WiimoteScanner::WiimoteScanner()
-	: m_want_wiimotes()
-	, device_id(-1)
+	: device_id(-1)
 	, device_sock(-1)
 {
 	// Get the id of the first Bluetooth device.

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -220,8 +220,6 @@ void RemoveWiimote(BLUETOOTH_DEVICE_INFO_STRUCT&);
 bool ForgetWiimote(BLUETOOTH_DEVICE_INFO_STRUCT&);
 
 WiimoteScanner::WiimoteScanner()
-	: m_run_thread()
-	, m_want_wiimotes()
 {
 	init_lib();
 }

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -71,8 +71,6 @@ private:
 };
 
 WiimoteScanner::WiimoteScanner()
-	: m_run_thread()
-	, m_want_wiimotes()
 {}
 
 WiimoteScanner::~WiimoteScanner()

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -43,7 +43,6 @@ Wiimote::Wiimote()
 	, m_channel(0)
 	, m_last_connect_request_counter(0)
 	, m_rumble_state()
-	, m_need_prepare()
 {}
 
 void Wiimote::Shutdown()

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -99,11 +99,11 @@ private:
 
 	std::thread               m_wiimote_thread;
 	// Whether to keep running the thread.
-	std::atomic<bool>         m_run_thread;
+	std::atomic<bool>         m_run_thread {false};
 	// Whether to call PrepareOnThread.
-	std::atomic<bool>         m_need_prepare;
+	std::atomic<bool>         m_need_prepare {false};
 	// Whether the thread has finished ConnectInternal.
-	std::atomic<bool>         m_thread_ready;
+	std::atomic<bool>         m_thread_ready {false};
 	std::mutex                m_thread_ready_mutex;
 	std::condition_variable   m_thread_ready_cond;
 
@@ -137,9 +137,9 @@ private:
 
 	std::thread m_scan_thread;
 
-	std::atomic<bool> m_run_thread;
-	std::atomic<bool> m_want_wiimotes;
-	std::atomic<bool> m_want_bb;
+	std::atomic<bool> m_run_thread {false};
+	std::atomic<bool> m_want_wiimotes {false};
+	std::atomic<bool> m_want_bb {false};
 
 #if defined(_WIN32)
 	void CheckDeviceType(std::basic_string<TCHAR> &devicepath, bool &real_wiimote, bool &is_bb);


### PR DESCRIPTION
This fixes an issue with broken real wiimotes on linux.