### PR TITLE
JitArm64: fix addzex

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -678,17 +678,12 @@ void JitArm64::addzex(UGeckoInstruction inst)
 	JITDISABLE(bJITIntegerOff);
 	FALLBACK_IF(inst.OE);
 
-	// breaks Kirby
-	FALLBACK_IF(1);
-
 	int a = inst.RA, d = inst.RD;
 
 	gpr.BindToRegister(d, d == a);
 	ARM64Reg WA = gpr.GetReg();
 	LDRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
-	CMP(WA, 0);
-	CSINC(gpr.R(d), gpr.R(a), gpr.R(a), CC_EQ);
-	CMP(gpr.R(d), 0);
+	ADDS(gpr.R(d), gpr.R(a), WA);
 	gpr.Unlock(WA);
 	ComputeCarry();
 	if (inst.Rc)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -680,11 +680,21 @@ void JitArm64::addzex(UGeckoInstruction inst)
 
 	int a = inst.RA, d = inst.RD;
 
-	gpr.BindToRegister(d, d == a);
-	ARM64Reg WA = gpr.GetReg();
-	LDRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
-	ADDS(gpr.R(d), gpr.R(a), WA);
-	gpr.Unlock(WA);
+	if (d == a)
+	{
+		gpr.BindToRegister(d, true);
+		ARM64Reg WA = gpr.GetReg();
+		LDRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
+		ADDS(gpr.R(d), gpr.R(a), WA);
+		gpr.Unlock(WA);
+	}
+	else
+	{
+		gpr.BindToRegister(d, false);
+		LDRB(INDEX_UNSIGNED, gpr.R(d), X29, PPCSTATE_OFF(xer_ca));
+		ADDS(gpr.R(d), gpr.R(a), gpr.R(d));
+	}
+
 	ComputeCarry();
 	if (inst.Rc)
 		ComputeRC(gpr.R(d), 0);


### PR DESCRIPTION
CMP doesn't update the carry flag, so we have to use an addition.