### PR TITLE
Ignore all writes to BBA_TXFIFOCNT

### DIFF
--- a/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
@@ -304,21 +304,25 @@ bool CEXIETHERNET::RecvStart()
 	DWORD res = ReadFile(mHAdapter, mRecvBuffer, BBA_RECV_SIZE,
 		(LPDWORD)&mRecvBufferLength, &mReadOverlapped);
 
-	DWORD err = GetLastError();
-	if (!res && err != ERROR_IO_PENDING)
-	{
-		// error occurred
-		ERROR_LOG(SP1, "Failed to recieve packet with error 0x%X", err);
-		return false;
-	}
-
 	if (res)
 	{
 		// Since the read is synchronous here, complete immediately
 		RecvHandlePacket();
+		return true;
+	}
+	else
+	{
+		DWORD err = GetLastError();
+		if (err == ERROR_IO_PENDING)
+		{
+			return true;
+		}
+
+		// Unexpected error
+		ERROR_LOG(SP1, "Failed to recieve packet with error 0x%X", err);
+		return false;
 	}
 
-	return true;
 }
 
 void CEXIETHERNET::RecvStop()

--- a/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
@@ -304,15 +304,17 @@ bool CEXIETHERNET::RecvStart()
 	DWORD res = ReadFile(mHAdapter, mRecvBuffer, BBA_RECV_SIZE,
 		(LPDWORD)&mRecvBufferLength, &mReadOverlapped);
 
-	if (!res && (GetLastError() != ERROR_IO_PENDING))
+	DWORD err = GetLastError();
+	if (!res && err != ERROR_IO_PENDING)
 	{
 		// error occurred
+		ERROR_LOG(SP1, "Failed to recieve packet with error 0x%X", err);
 		return false;
 	}
 
 	if (res)
 	{
-		// Completed immediately
+		// Synce the read is syncronouse here, complete immediately
 		RecvHandlePacket();
 	}
 
@@ -326,6 +328,9 @@ void CEXIETHERNET::RecvStop()
 
 	UnregisterWaitEx(mHReadWait, INVALID_HANDLE_VALUE);
 
-	CloseHandle(mHRecvEvent);
-	mHRecvEvent = INVALID_HANDLE_VALUE;
+	if (mHRecvEvent != INVALID_HANDLE_VALUE)
+	{
+		CloseHandle(mHRecvEvent);
+		mHRecvEvent = INVALID_HANDLE_VALUE;
+	}
 }

--- a/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
@@ -248,7 +248,7 @@ bool CEXIETHERNET::SendFrame(u8 *frame, u32 size)
 	OVERLAPPED overlap;
 	ZeroMemory(&overlap, sizeof(overlap));
 
-	//WriteFile will always return false because the TAP handle is async
+	// WriteFile will always return false because the TAP handle is async
 	WriteFile(mHAdapter, frame, size, NULL, &overlap);
 
 	DWORD res = GetLastError();
@@ -314,7 +314,7 @@ bool CEXIETHERNET::RecvStart()
 
 	if (res)
 	{
-		// Synce the read is syncronouse here, complete immediately
+		// Since the read is synchronous here, complete immediately
 		RecvHandlePacket();
 	}
 

--- a/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
@@ -358,6 +358,12 @@ void CEXIETHERNET::MXCommandHandler(u32 data, u32 size)
 		data &= (data & 0xff) ^ 0xff;
 		goto write_to_register;
 
+	case BBA_TXFIFOCNT:
+	case BBA_TXFIFOCNT+1:
+		// Ignore all writes to BBA_TXFIFOCNT
+		transfer.address += size;
+		return;
+
 write_to_register:
 	default:
 		for (int i = size - 1; i >= 0; i--)


### PR DESCRIPTION
Actuall hardware has no visible effects when writing to BBA_TXFIFOCNT
Writing to BBA_TXFIFOCNT on Dolphin however breaks sending messages.
Double Dash and Kirby neither even write to BBA_TXFIFOCNT when sending messages, so this fix will only show its effects on homebrew.