### PR TITLE
JitInterface: Fix null checking in GetProfileResults

### DIFF
--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -133,14 +133,14 @@ namespace JitInterface
 
 	void GetProfileResults(ProfileStats* prof_stats)
 	{
+		// Can't really do this with no jit core available
+		if (!jit)
+			return;
+
 		prof_stats->cost_sum = 0;
 		prof_stats->timecost_sum = 0;
 		prof_stats->block_stats.clear();
 		prof_stats->block_stats.reserve(jit->GetBlockCache()->GetNumBlocks());
-
-		// Can't really do this with no jit core available
-		if (!jit)
-			return;
 
 		Core::EState old_state = Core::GetState();
 		if (old_state == Core::CORE_RUN)


### PR DESCRIPTION
Technically a null pointer dereference can occur here otherwise