### PR TITLE
Changed GC adapter "Direct Connect" to false by default

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -522,7 +522,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("FrameSkip",                 &m_FrameSkip,                                   0);
 	core->Get("GFXBackend",                &m_strVideoBackend, "");
 	core->Get("GPUDeterminismMode",        &m_strGPUDeterminismMode, "auto");
-	core->Get("GameCubeAdapter",           &m_GameCubeAdapter,                             true);
+	core->Get("GameCubeAdapter",           &m_GameCubeAdapter,                             false);
 	core->Get("AdapterRumble",             &m_AdapterRumble,                               true);
 	core->Get("PerfMapDir",                &m_perfDir, "");
 }


### PR DESCRIPTION
So according to @MaJoRoesch and @JMC47, users have been running into lots of issues with the direct connect feature of the GC adapter support screwing things up for people who don't even use an adapter. This is caused by libusb conflicting with other drivers and causing Weird Stuff to happen, such as keyboards to stop functioning. Wiimote continuous scanning is also off by default for similar reasons. With this change we should see fewer users having problems with this.

Paging @mathieui to review this as well.

@MaJoRoesch wants this merged into stable