### PR TITLE
Revert "VideoCommon: Clamp integer conversions."

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -146,7 +146,7 @@ const char depth_matrix_program[] = {
 	" in float4 pos : SV_Position,\n"
 	" in float3 uv0 : TEXCOORD0){\n"
 	"	float4 texcol = Tex0.Sample(samp0,uv0);\n"
-	"	int depth = clamp(int((1.0 - texcol.x) * 16777216.0), 0, 0xFFFFFF);\n"
+	"	int depth = int((1.0 - texcol.x) * 16777216.0);\n"
 
 	// Convert to Z24 format
 	"	int4 workspace;\n"
@@ -180,7 +180,7 @@ const char depth_matrix_program_msaa[] = {
 	"	for(int i = 0; i < SAMPLES; ++i)\n"
 	"		texcol += Tex0.Load(int3(uv0.x*(width), uv0.y*(height), uv0.z), i);\n"
 	"	texcol /= SAMPLES;\n"
-	"	int depth = clamp(int((1.0 - texcol.x) * 16777216.0), 0, 0xFFFFFF);\n"
+	"	int depth = int((1.0 - texcol.x) * 16777216.0);\n"
 
 	// Convert to Z24 format
 	"	int4 workspace;\n"

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -362,7 +362,7 @@ void TextureCache::CompileShaders()
 		"\n"
 		"void main(){\n"
 		"	vec4 texcol = texture(samp9, vec3(f_uv0.xy, %s));\n"
-		"	int depth = clamp(int(texcol.x * 16777216.0), 0, 0xFFFFFF);\n"
+		"	int depth = int(floor(texcol.x * 16777216.0));\n"
 
 		// Convert to Z24 format
 		"	ivec4 workspace;\n"

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -362,7 +362,7 @@ void TextureCache::CompileShaders()
 		"\n"
 		"void main(){\n"
 		"	vec4 texcol = texture(samp9, vec3(f_uv0.xy, %s));\n"
-		"	int depth = int(floor(texcol.x * 16777216.0));\n"
+		"	int depth = int(texcol.x * 16777216.0);\n"
 
 		// Convert to Z24 format
 		"	ivec4 workspace;\n"

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -492,7 +492,7 @@ static void WriteZ16Encoder(char*& p,API_TYPE ApiType)
 	WriteSampleColor(p, "r", "depth", 0, ApiType);
 	if (ApiType == API_D3D) WRITE(p, "depth = 1.0f - depth;\n");
 
-	WRITE(p, "  depth = clamp(depth * 16777216.0, 0.0, float(0xFFFFFF));\n");
+	WRITE(p, "  depth *= 16777216.0;\n");
 	WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
 	WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
 	WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
@@ -503,7 +503,7 @@ static void WriteZ16Encoder(char*& p,API_TYPE ApiType)
 	WriteSampleColor(p, "r", "depth", 1, ApiType);
 	if (ApiType == API_D3D) WRITE(p, "depth = 1.0f - depth;\n");
 
-	WRITE(p, "  depth = clamp(depth * 16777216.0, 0.0, float(0xFFFFFF));\n");
+	WRITE(p, "  depth *= 16777216.0;\n");
 	WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
 	WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
 	WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
@@ -526,7 +526,7 @@ static void WriteZ16LEncoder(char*& p,API_TYPE ApiType)
 	WriteSampleColor(p, "r", "depth", 0, ApiType);
 	if (ApiType == API_D3D) WRITE(p, "depth = 1.0f - depth;\n");
 
-	WRITE(p, "  depth = clamp(depth * 16777216.0, 0.0, float(0xFFFFFF));\n");
+	WRITE(p, "  depth *= 16777216.0;\n");
 	WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
 	WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
 	WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
@@ -539,7 +539,7 @@ static void WriteZ16LEncoder(char*& p,API_TYPE ApiType)
 	WriteSampleColor(p, "r", "depth", 1, ApiType);
 	if (ApiType == API_D3D) WRITE(p, "depth = 1.0f - depth;\n");
 
-	WRITE(p, "  depth = clamp(depth * 16777216.0, 0.0, float(0xFFFFFF));\n");
+	WRITE(p, "  depth *= 16777216.0;\n");
 	WRITE(p, "  expanded.r = floor(depth / (256.0 * 256.0));\n");
 	WRITE(p, "  depth -= expanded.r * 256.0 * 256.0;\n");
 	WRITE(p, "  expanded.g = floor(depth / 256.0);\n");
@@ -568,7 +568,7 @@ static void WriteZ24Encoder(char*& p, API_TYPE ApiType)
 
 	for (int i = 0; i < 2; i++)
 	{
-		WRITE(p, "  depth%i = clamp(depth%i * 16777216.0, 0.0, float(0xFFFFFF));\n", i, i);
+		WRITE(p, "  depth%i *= 16777216.0;\n", i);
 
 		WRITE(p, "  expanded%i.r = floor(depth%i / (256.0 * 256.0));\n", i, i);
 		WRITE(p, "  depth%i -= expanded%i.r * 256.0 * 256.0;\n", i, i);


### PR DESCRIPTION
This reverts commit 0f2c72f0f844c219e168faa7de8dd515f8723fdc.

Attempts to fix various depth copy issues, including [issue 8833](https://code.google.com/p/dolphin-emu/issues/detail?id=8833). Some games use the full depth range of 2^24, so we shouldn't clamp those values anymore or we should only clamp them to 2^24.