### PR TITLE
[netplay] Fix a crash

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -192,6 +192,8 @@ void NetPlayServer::ThreadFunc()
 			case ENET_EVENT_TYPE_DISCONNECT:
 			{
 				std::lock_guard<std::recursive_mutex> lkg(m_crit.game);
+				if  (!netEvent.peer->data)
+					break;
 				auto it = m_players.find(*(PlayerId *)netEvent.peer->data);
 				if (it != m_players.end())
 				{
@@ -232,6 +234,18 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
 	} while (epack == nullptr);
 	rpac.append(epack->data, epack->dataLength);
 
+	// give new client first available id
+	PlayerId pid = 1;
+	for (auto i = m_players.begin(); i != m_players.end(); ++i)
+	{
+		if (i->second.pid == pid)
+		{
+			pid++;
+			i = m_players.begin();
+		}
+	}
+	socket->data = new PlayerId(pid);
+
 	std::string npver;
 	rpac >> npver;
 	// Dolphin netplay version
@@ -250,25 +264,12 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
 	m_update_pings = true;
 
 	Client player;
+	player.pid = pid;
 	player.socket = socket;
 	rpac >> player.revision;
 	rpac >> player.name;
 
 	enet_packet_destroy(epack);
-
-	// give new client first available id
-	PlayerId pid = 1;
-	for (auto i = m_players.begin(); i != m_players.end(); ++i)
-	{
-		if (i->second.pid == pid)
-		{
-			pid++;
-			i = m_players.begin();
-		}
-	}
-	player.pid = pid;
-	socket->data = new PlayerId(pid);
-
 	// try to automatically assign new user a pad
 	for (PadMapping& mapping : m_pad_map)
 	{


### PR DESCRIPTION
If OnConnect returns an error, it means that memory hasn’t been allocated yet, making the free useless. I haven’t checked if enet zeroes the data before, but if not, that could be the source of https://code.google.com/p/dolphin-emu/issues/detail?id=8656