### PR TITLE
Add stereoscopic options to tested gameini files

### DIFF
--- a/Data/Sys/GameSettings/RSB.ini
+++ b/Data/Sys/GameSettings/RSB.ini
@@ -18,5 +18,4 @@ EmulationIssues = Classic mode score report needs real xfb. Nes masterpieces and
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoEFBMonoDepth = False
 StereoConvergenceMinimum = 136

--- a/Data/Sys/GameSettings/RSB.ini
+++ b/Data/Sys/GameSettings/RSB.ini
@@ -16,3 +16,7 @@ EmulationIssues = Classic mode score report needs real xfb. Nes masterpieces and
 
 [ActionReplay]
 # Add action replay cheats here.
+
+[Video_Stereoscopy]
+StereoEFBMonoDepth = False
+StereoConvergenceMinimum = 136

--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -20,3 +20,6 @@ EmulationIssues = Sound crackling can be fixed by lle audio.
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+[Video_Stereoscopy]
+StereoEFBMonoDepth = False
+StereoConvergenceMinimum = 26

--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -21,5 +21,4 @@ EmulationIssues = Sound crackling can be fixed by lle audio.
 SafeTextureCacheColorSamples = 512
 
 [Video_Stereoscopy]
-StereoEFBMonoDepth = False
 StereoConvergenceMinimum = 26


### PR DESCRIPTION
Stereoscopy values have been tested and a convergence value of 26 is ideal for placing the characters on the convergence plane. No perceived issues with disabling monoscopic shadows. 
![sf8e01-4](https://cloud.githubusercontent.com/assets/13172667/9299294/6fe2bbd4-4488-11e5-9235-24c2d4b791fa.png)
