### PR TITLE
Add stereoscopic options to RSB.ini

### DIFF
--- a/Data/Sys/GameSettings/RSB.ini
+++ b/Data/Sys/GameSettings/RSB.ini
@@ -16,3 +16,7 @@ EmulationIssues = Classic mode score report needs real xfb. Nes masterpieces and
 
 [ActionReplay]
 # Add action replay cheats here.
+
+[Video_Stereoscopy]
+StereoEFBMonoDepth = False
+StereoConvergenceMinimum = 136


### PR DESCRIPTION
A convergence value of 136 sets player damage meters and overhead tags perfectly in the convergence plane.