### PR TITLE
VideoCommon: Allow more Ram for HiresTexture if system memory is over 4GB

### DIFF
--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -140,7 +140,10 @@ void HiresTexture::Prefetch()
 	Common::SetCurrentThreadName("Prefetcher");
 
 	size_t size_sum = 0;
-	size_t max_mem = MemPhysical() / 2;
+	size_t sys_mem = MemPhysical();
+	size_t recommended_min_mem = 2 * size_t(1024 * 1024 * 1024);
+	// keep 2GB memory for system stability if system RAM is 4GB+ - use half of memory in other cases
+	size_t max_mem = (sys_mem / 2 < recommended_min_mem) ? (sys_mem / 2) : (sys_mem - recommended_min_mem);
 	u32 starttime = Common::Timer::GetTimeMs();
 	for (const auto& entry : s_textureMap)
 	{


### PR DESCRIPTION
Inspired by Jhonn on dolphin forum I created one improvement. IMO 2GB memory is enough to make sure that system will be stable. 
This change will allow to have 6GB texture memory for users with 8GB RAM (previous 4GB).