### PR TITLE
DSP HLE: Remove timing informations from ucodes

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -75,10 +75,8 @@ void DSPHLE::DSP_Update(int cycles)
 u32 DSPHLE::DSP_UpdateRate()
 {
 	// AX HLE uses 3ms (Wii) or 5ms (GC) timing period
-	if (m_pUCode != nullptr)
-		return (SystemTimers::GetTicksPerSecond() / 1000) * m_pUCode->GetUpdateMs();
-	else
-		return SystemTimers::GetTicksPerSecond() / 1000;
+	// But to be sure, just update the HLE every ms.
+	return SystemTimers::GetTicksPerSecond() / 1000;
 }
 
 void DSPHLE::SendMailToDSP(u32 _uMail)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -14,7 +14,6 @@
 
 AXUCode::AXUCode(DSPHLE* dsphle, u32 crc)
 	: UCodeInterface(dsphle, crc)
-	, m_work_available(false)
 	, m_cmdlist_size(0)
 {
 	WARN_LOG(DSPHLE, "Instantiating AXUCode: crc=%08x", crc);
@@ -609,7 +608,9 @@ void AXUCode::HandleMail(u32 mail)
 	if (next_is_cmdlist)
 	{
 		CopyCmdList(mail, cmdlist_size);
-		m_work_available = true;
+		HandleCommandList();
+		m_cmdlist_size = 0;
+		SignalWorkEnd();
 	}
 	else if (m_upload_setup_in_progress)
 	{
@@ -668,12 +669,6 @@ void AXUCode::Update()
 	{
 		m_mail_handler.PushMail(DSP_RESUME);
 		DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
-	}
-	else if (m_work_available)
-	{
-		HandleCommandList();
-		m_cmdlist_size = 0;
-		SignalWorkEnd();
 	}
 }
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -672,11 +672,6 @@ void AXUCode::Update()
 	}
 }
 
-u32 AXUCode::GetUpdateMs()
-{
-	return 5;
-}
-
 void AXUCode::DoAXState(PointerWrap& p)
 {
 	p.Do(m_cmdlist);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -58,7 +58,6 @@ public:
 	void HandleMail(u32 mail) override;
 	void Update() override;
 	void DoState(PointerWrap& p) override;
-	u32 GetUpdateMs() override;
 
 protected:
 	enum MailType

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -84,9 +84,6 @@ protected:
 	int m_samples_auxB_right[32 * 5];
 	int m_samples_auxB_surround[32 * 5];
 
-	// This flag is set if there is anything to process.
-	bool m_work_available;
-
 	u16 m_cmdlist[512];
 	u32 m_cmdlist_size;
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -660,11 +660,6 @@ void AXWiiUCode::OutputWMSamples(u32* addresses)
 	}
 }
 
-u32 AXWiiUCode::GetUpdateMs()
-{
-	return 3;
-}
-
 void AXWiiUCode::DoState(PointerWrap &p)
 {
 	DoStateShared(p);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
@@ -11,7 +11,6 @@ class AXWiiUCode : public AXUCode
 public:
 	AXWiiUCode(DSPHLE *dsphle, u32 crc);
 	virtual ~AXWiiUCode();
-	u32 GetUpdateMs() override;
 
 	void DoState(PointerWrap &p) override;
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -32,11 +32,6 @@ void CARDUCode::Update()
 	}
 }
 
-u32 CARDUCode::GetUpdateMs()
-{
-	return SConfig::GetInstance().bWii ? 3 : 5;
-}
-
 void CARDUCode::HandleMail(u32 mail)
 {
 	if (mail == 0xFF000000) // unlock card

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
@@ -11,7 +11,6 @@ class CARDUCode : public UCodeInterface
 public:
 	CARDUCode(DSPHLE *dsphle, u32 crc);
 	virtual ~CARDUCode();
-	u32 GetUpdateMs() override;
 
 	void HandleMail(u32 mail) override;
 	void Update() override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -102,11 +102,6 @@ void GBAUCode::Update()
 	}
 }
 
-u32 GBAUCode::GetUpdateMs()
-{
-	return SConfig::GetInstance().bWii ? 3 : 5;
-}
-
 void GBAUCode::HandleMail(u32 mail)
 {
 	static bool nextmail_is_mramaddr = false;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
@@ -15,7 +15,6 @@ struct GBAUCode : public UCodeInterface
 {
 	GBAUCode(DSPHLE *dsphle, u32 crc);
 	virtual ~GBAUCode();
-	u32 GetUpdateMs() override;
 
 	void HandleMail(u32 mail) override;
 	void Update() override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
@@ -25,11 +25,6 @@ void INITUCode::Update()
 {
 }
 
-u32 INITUCode::GetUpdateMs()
-{
-	return SConfig::GetInstance().bWii ? 3 : 5;
-}
-
 void INITUCode::HandleMail(u32 mail)
 {
 }

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
@@ -11,7 +11,6 @@ class INITUCode : public UCodeInterface
 public:
 	INITUCode(DSPHLE *dsphle, u32 crc);
 	virtual ~INITUCode();
-	u32 GetUpdateMs() override;
 
 	void HandleMail(u32 mail) override;
 	void Update() override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -116,11 +116,6 @@ void ROMUCode::BootUCode()
 	m_dsphle->SetUCode(ector_crc);
 }
 
-u32 ROMUCode::GetUpdateMs()
-{
-	return SConfig::GetInstance().bWii ? 3 : 5;
-}
-
 void ROMUCode::DoState(PointerWrap &p)
 {
 	p.Do(m_current_ucode);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
@@ -11,7 +11,6 @@ class ROMUCode : public UCodeInterface
 public:
 	ROMUCode(DSPHLE* dsphle, u32 crc);
 	virtual ~ROMUCode();
-	u32 GetUpdateMs() override;
 
 	void HandleMail(u32 mail) override;
 	void Update() override;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
@@ -77,7 +77,6 @@ public:
 
 	virtual void HandleMail(u32 mail) = 0;
 	virtual void Update() = 0;
-	virtual u32 GetUpdateMs() = 0;
 
 	virtual void DoState(PointerWrap &p)
 	{

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -134,11 +134,6 @@ void ZeldaUCode::Update()
 	}
 }
 
-u32 ZeldaUCode::GetUpdateMs()
-{
-	return SConfig::GetInstance().bWii ? 3 : 5;
-}
-
 void ZeldaUCode::DoState(PointerWrap &p)
 {
 	p.Do(m_flags);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -189,7 +189,6 @@ class ZeldaUCode : public UCodeInterface
 public:
 	ZeldaUCode(DSPHLE *dsphle, u32 crc);
 	virtual ~ZeldaUCode();
-	u32 GetUpdateMs() override;
 
 	void HandleMail(u32 mail) override;
 	void Update() override;


### PR DESCRIPTION
On HLE, we don't emulate the timings on HLE, so there is also no need
to setup periods callbacks.

This fixes AX HLE when used for 48 kHz audio.