### PR TITLE
Jit: Remove unnecessary namespace prefixes

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -128,7 +128,7 @@ void Jit64::FinalizeCarryOverflow(bool oe, bool inv)
 // to be recalculated and haven't been clobbered. Keep in mind not all instructions set
 // sufficient flags -- for example, the flags from SHL/SHR are *not* sufficient for LT/GT
 // branches, only EQ.
-void Jit64::ComputeRC(const Gen::OpArg & arg, bool needs_test, bool needs_sext)
+void Jit64::ComputeRC(const OpArg& arg, bool needs_test, bool needs_sext)
 {
 	_assert_msg_(DYNA_REC, arg.IsSimpleReg() || arg.IsImm(), "Invalid ComputeRC operand");
 	if (arg.IsImm())
@@ -215,7 +215,7 @@ static u32 Xor(u32 a, u32 b)
 	return a ^ b;
 }
 
-void Jit64::regimmop(int d, int a, bool binary, u32 value, Operation doop, void (XEmitter::*op)(int, const Gen::OpArg&, const Gen::OpArg&), bool Rc, bool carry)
+void Jit64::regimmop(int d, int a, bool binary, u32 value, Operation doop, void (XEmitter::*op)(int, const OpArg&, const OpArg&), bool Rc, bool carry)
 {
 	bool needs_test = false;
 	gpr.Lock(d, a);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -162,7 +162,7 @@ void Jit64::lXXx(UGeckoInstruction inst)
 	s32 loadOffset = 0;
 
 	// Prepare address operand
-	Gen::OpArg opAddress;
+	OpArg opAddress;
 	if (!update && !a)
 	{
 		if (inst.OPCD == 31)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -11,7 +11,7 @@
 
 using namespace Gen;
 
-void Jit64::GetCRFieldBit(int field, int bit, Gen::X64Reg out, bool negate)
+void Jit64::GetCRFieldBit(int field, int bit, X64Reg out, bool negate)
 {
 	switch (bit)
 	{
@@ -40,7 +40,7 @@ void Jit64::GetCRFieldBit(int field, int bit, Gen::X64Reg out, bool negate)
 	}
 }
 
-void Jit64::SetCRFieldBit(int field, int bit, Gen::X64Reg in)
+void Jit64::SetCRFieldBit(int field, int bit, X64Reg in)
 {
 	MOV(64, R(RSCRATCH2), PPCSTATE(cr_val[field]));
 	MOVZX(32, 8, in, R(in));

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -375,7 +375,7 @@ void JitIL::WriteExit(u32 destination)
 	b->linkData.push_back(linkData);
 }
 
-void JitIL::WriteExitDestInOpArg(const Gen::OpArg& arg)
+void JitIL::WriteExitDestInOpArg(const OpArg& arg)
 {
 	MOV(32, PPCSTATE(pc), arg);
 	Cleanup();
@@ -387,7 +387,7 @@ void JitIL::WriteExitDestInOpArg(const Gen::OpArg& arg)
 	JMP(asm_routines.dispatcher, true);
 }
 
-void JitIL::WriteRfiExitDestInOpArg(const Gen::OpArg& arg)
+void JitIL::WriteRfiExitDestInOpArg(const OpArg& arg)
 {
 	MOV(32, PPCSTATE(pc), arg);
 	MOV(32, PPCSTATE(npc), arg);


### PR DESCRIPTION
Implementation files have a `using namespace Gen;` statement in them, so the prefix isn't necessary.