### PR TITLE
[AArch64] Optimize lfd instructions if possible.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -71,11 +71,18 @@ void JitArm64::lfXX(UGeckoInstruction inst)
 	u32 imm_addr = 0;
 	bool is_immediate = false;
 
-	// 64 bit loads only load PSR0
-	fpr.BindToRegister(inst.FD, flags & BackPatchInfo::FLAG_SIZE_F64, flags & BackPatchInfo::FLAG_SIZE_F64);
+	bool only_lower = !!(flags & BackPatchInfo::FLAG_SIZE_F64);
 
-	ARM64Reg VD = fpr.R(inst.FD, flags & BackPatchInfo::FLAG_SIZE_F64);
+	fpr.BindToRegister(inst.FD, false, only_lower);
+
+	ARM64Reg VD = fpr.R(inst.FD, only_lower);
 	ARM64Reg addr_reg = W0;
+
+	if (!fpr.IsLower(inst.FD))
+		only_lower = false;
+
+	if (only_lower)
+		flags |= BackPatchInfo::FLAG_ONLY_LOWER;
 
 	gpr.Lock(W0, W30);
 	fpr.Lock(Q0);

--- a/Source/Core/Core/PowerPC/JitArmCommon/BackPatch.h
+++ b/Source/Core/Core/PowerPC/JitArmCommon/BackPatch.h
@@ -18,6 +18,7 @@ struct BackPatchInfo
 		FLAG_SIZE_F64 = (1 << 6),
 		FLAG_REVERSE  = (1 << 7),
 		FLAG_EXTEND   = (1 << 8),
+		FLAG_ONLY_LOWER = (1 << 9),
 	};
 
 	static u32 GetFlagSize(u32 flags)


### PR DESCRIPTION
If we are going to be using lfd, then chances are it is going to be used in double heavy areas of code.
If we only need to load the lower register, then we should also not worry about having to insert in to the low 64bits of the guest register.
So add a new flag to the backpatching to handle lfd to directly to the destination register.
This gives ~3% performance improvement to Povray.