### PR TITLE
Jit64: some byte-swapping changes

### DIFF
--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -480,8 +480,8 @@ public:
 	// Available only on Atom or >= Haswell so far. Test with cpu_info.bMOVBE.
 	void MOVBE(int bits, X64Reg dest, const OpArg& src);
 	void MOVBE(int bits, const OpArg& dest, X64Reg src);
-	void LoadAndSwap(int size, X64Reg dst, const OpArg& src);
-	void SwapAndStore(int size, const OpArg& dst, X64Reg src);
+	void LoadAndSwap(int size, X64Reg dst, const OpArg& src, bool sign_extend = false);
+	u8* SwapAndStore(int size, const OpArg& dst, X64Reg src);
 
 	// Available only on AMD >= Phenom or Intel >= Haswell
 	void LZCNT(int bits, X64Reg dest, const OpArg& src);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
@@ -86,33 +86,35 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
 
 	// Compute the start and length of the memory operation, including
 	// any byteswapping.
-	int totalSize;
+	int totalSize = info.instructionSize;
 	u8 *start = codePtr;
 	if (!info.isMemoryWrite)
 	{
-		int bswapNopCount;
-		if (info.byteSwap || info.operandSize == 1)
-			bswapNopCount = 0;
-		// Check the following BSWAP for REX byte
-		else if ((codePtr[info.instructionSize] & 0xF0) == 0x40)
-			bswapNopCount = 3;
-		else
-			bswapNopCount = 2;
-
-		totalSize = info.instructionSize + bswapNopCount;
-		if (info.operandSize == 2 && !info.byteSwap)
+		// MOVBE and single bytes don't need to be swapped.
+		if (!info.byteSwap && info.operandSize > 1)
 		{
+			// REX
 			if ((codePtr[totalSize] & 0xF0) == 0x40)
+				totalSize++;
+
+			// BSWAP
+			if (codePtr[totalSize] == 0x0F && (codePtr[totalSize + 1] & 0xF8) == 0xC8)
+				totalSize += 2;
+
+			if (info.operandSize == 2)
 			{
-				++totalSize;
+				// operand size override
+				if (codePtr[totalSize] == 0x66)
+					totalSize++;
+				// REX
+				if ((codePtr[totalSize] & 0xF0) == 0x40)
+					totalSize++;
+				// SAR/ROL
+				_assert_(codePtr[totalSize] == 0xC1 && (codePtr[totalSize + 2] == 0x10 ||
+				                                        codePtr[totalSize + 2] == 0x08));
+				info.signExtend = (codePtr[totalSize + 1] & 0x10) != 0;
+				totalSize += 3;
 			}
-			if (codePtr[totalSize] != 0xc1 || codePtr[totalSize + 2] != 0x10)
-			{
-				PanicAlert("BackPatch: didn't find expected shift %p", codePtr);
-				return false;
-			}
-			info.signExtend = (codePtr[totalSize + 1] & 0x10) != 0;
-			totalSize += 3;
 		}
 	}
 	else
@@ -120,7 +122,6 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
 		if (info.byteSwap || info.hasImmediate)
 		{
 			// The instruction is a MOVBE but it failed so the value is still in little-endian byte order.
-			totalSize = info.instructionSize;
 		}
 		else
 		{
@@ -146,7 +147,7 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
 				break;
 			}
 			start = codePtr - bswapSize;
-			totalSize = info.instructionSize + bswapSize;
+			totalSize += bswapSize;
 		}
 	}
 

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -53,21 +53,12 @@ OpArg VertexLoaderX64::GetVertexAddr(int array, u64 attribute)
 	OpArg data = MDisp(src_reg, m_src_ofs);
 	if (attribute & MASK_INDEXED)
 	{
-		if (attribute == INDEX8)
-		{
-			MOVZX(64, 8, scratch1, data);
-			m_src_ofs += 1;
-		}
-		else
-		{
-			MOV(16, R(scratch1), data);
-			m_src_ofs += 2;
-			BSWAP(16, scratch1);
-			MOVZX(64, 16, scratch1, R(scratch1));
-		}
+		int bits = attribute == INDEX8 ? 8 : 16;
+		LoadAndSwap(bits, scratch1, data);
+		m_src_ofs += bits / 8;
 		if (array == ARRAY_POSITION)
 		{
-			CMP(attribute == INDEX8 ? 8 : 16, R(scratch1), Imm8(-1));
+			CMP(bits, R(scratch1), Imm8(-1));
 			m_skip_vertex = J_CC(CC_E, true);
 		}
 		IMUL(32, scratch1, MPIC(&g_main_cp_state.array_strides[array]));


### PR DESCRIPTION
Adds support for MOVBE in loads.

Byte-reversed (little endian) loads still swap twice...