### PR TITLE
Jit64: Faster linking of continuous blocks

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -324,9 +324,20 @@ using namespace Gen;
 	{
 		XEmitter emit(location);
 		if (*location == 0xE8)
+		{
 			emit.CALL(address);
+		}
 		else
-			emit.JMP(address, true);
+		{
+			// If we're going to link with the next block, there is no need
+			// to emit JMP. So just NOP out the gap to the next block.
+			// Support up to 3 additional bytes because of alignment.
+			s64 offset = address - emit.GetCodePtr();
+			if (offset > 0 && offset <= 5 + 3)
+				emit.NOP(offset);
+			else
+				emit.JMP(address, true);
+		}
 	}
 
 	void JitBlockCache::WriteDestroyBlock(const u8* location, u32 address)


### PR DESCRIPTION
We compile the blocks as they are executed, so it's common
to link them continuously. We end with calling JMP after every
block, but often just with a distance of 0.
So just emitting NOPs instead also "calls" the next block, but
easier for the CPU.