### PR TITLE
Interpreter: Use std::isnan instead of IsNAN

### DIFF
--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -56,19 +56,6 @@ union IntFloat {
 	explicit IntFloat(float _f) : f(_f) {}
 };
 
-inline bool IsINF(double d)
-{
-	IntDouble x(d);
-	return (x.i & ~DOUBLE_SIGN) == DOUBLE_EXP;
-}
-
-inline bool IsNAN(double d)
-{
-	IntDouble x(d);
-	return ((x.i & DOUBLE_EXP) == DOUBLE_EXP) &&
-	       ((x.i & DOUBLE_FRAC) != DOUBLE_ZERO);
-}
-
 inline bool IsQNAN(double d)
 {
 	IntDouble x(d);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -22,7 +22,7 @@ void Interpreter::Helper_FloatCompareOrdered(UGeckoInstruction _inst, double fa,
 {
 	int compareResult;
 
-	if (IsNAN(fa) || IsNAN(fb))
+	if (std::isnan(fa) || std::isnan(fb))
 	{
 		FPSCR.FX = 1;
 		compareResult = FPCC::FU;
@@ -62,7 +62,7 @@ void Interpreter::Helper_FloatCompareUnordered(UGeckoInstruction _inst, double f
 {
 	int compareResult;
 
-	if (IsNAN(fa) || IsNAN(fb))
+	if (std::isnan(fa) || std::isnan(fb))
 	{
 		compareResult = FPCC::FU;
 

--- a/Source/UnitTests/Common/MathUtilTest.cpp
+++ b/Source/UnitTests/Common/MathUtilTest.cpp
@@ -20,18 +20,6 @@ TEST(MathUtil, Clamp)
 	EXPECT_EQ(0.0, MathUtil::Clamp(-1.0, 0.0, 2.0));
 }
 
-TEST(MathUtil, IsINF)
-{
-	EXPECT_TRUE(MathUtil::IsINF(+std::numeric_limits<double>::infinity()));
-	EXPECT_TRUE(MathUtil::IsINF(-std::numeric_limits<double>::infinity()));
-}
-
-TEST(MathUtil, IsNAN)
-{
-	EXPECT_TRUE(MathUtil::IsNAN(std::numeric_limits<double>::quiet_NaN()));
-	EXPECT_TRUE(MathUtil::IsNAN(std::numeric_limits<double>::signaling_NaN()));
-}
-
 TEST(MathUtil, IsQNAN)
 {
 	EXPECT_TRUE(MathUtil::IsQNAN(std::numeric_limits<double>::quiet_NaN()));


### PR DESCRIPTION
Same thing, however we don't need to provide the boilerplate anymore.