### PR TITLE
x64Emitter: Remove pointer casts from Write{8,16,32,64} functions

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cinttypes>
+#include <cstring>
 
 #include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
@@ -89,6 +90,29 @@ const u8* XEmitter::GetCodePtr() const
 u8* XEmitter::GetWritableCodePtr()
 {
 	return code;
+}
+
+void XEmitter::Write8(u8 value)
+{
+	*code++ = value;
+}
+
+void XEmitter::Write16(u16 value)
+{
+	std::memcpy(code, &value, sizeof(u16));
+	code += sizeof(u16);
+}
+
+void XEmitter::Write32(u32 value)
+{
+	std::memcpy(code, &value, sizeof(u32));
+	code += sizeof(u32);
+}
+
+void XEmitter::Write64(u64 value)
+{
+	std::memcpy(code, &value, sizeof(u64));
+	code += sizeof(u64);
 }
 
 void XEmitter::ReserveCodeSpace(int bytes)

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -309,10 +309,10 @@ private:
 	void ABI_CalculateFrameSize(BitSet32 mask, size_t rsp_alignment, size_t needed_frame_size, size_t* shadowp, size_t* subtractionp, size_t* xmm_offsetp);
 
 protected:
-	inline void Write8(u8 value)   {*code++ = value;}
-	inline void Write16(u16 value) {*(u16*)code = (value); code += 2;}
-	inline void Write32(u32 value) {*(u32*)code = (value); code += 4;}
-	inline void Write64(u64 value) {*(u64*)code = (value); code += 8;}
+	void Write8(u8 value);
+	void Write16(u16 value);
+	void Write32(u32 value);
+	void Write64(u64 value);
 
 public:
 	XEmitter() { code = nullptr; flags_locked = false; }


### PR DESCRIPTION
This also silences quite a few ubsan asserts from firing when the emitter is being used.