### PR TITLE
Memmap: Remove pointer casts

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -8,6 +8,8 @@
 // However, if a JITed instruction (for example lwz) wants to access a bad memory area that call
 // may be redirected here (for example to Read_U32()).
 
+#include <cstring>
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/MemArena.h"
@@ -341,27 +343,30 @@ void Write_U8(u8 value, u32 address)
 
 void Write_U16(u16 value, u32 address)
 {
-	*(u16*)GetPointer(address) = Common::swap16(value);
+	u16 swapped_value = Common::swap16(value);
+	std::memcpy(GetPointer(address), &swapped_value, sizeof(u16));
 }
 
 void Write_U32(u32 value, u32 address)
 {
-	*(u32*)GetPointer(address) = Common::swap32(value);
+	u32 swapped_value = Common::swap32(value);
+	std::memcpy(GetPointer(address), &swapped_value, sizeof(u32));
 }
 
 void Write_U64(u64 value, u32 address)
 {
-	*(u64*)GetPointer(address) = Common::swap64(value);
+	u64 swapped_value = Common::swap64(value);
+	std::memcpy(GetPointer(address), &swapped_value, sizeof(u64));
 }
 
 void Write_U32_Swap(u32 value, u32 address)
 {
-	*(u32*)GetPointer(address) = value;
+	std::memcpy(GetPointer(address), &value, sizeof(u32));
 }
 
 void Write_U64_Swap(u64 value, u32 address)
 {
-	*(u64*)GetPointer(address) = value;
+	std::memcpy(GetPointer(address), &value, sizeof(u64));
 }
 
 }  // namespace


### PR DESCRIPTION
Gets rid of ugly casts, and also silences some ubsan asserts