### PR TITLE
[AArch64] Fix a bug. Improve performance of lfs.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -71,7 +71,6 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode,
 			if (flags & BackPatchInfo::FLAG_SIZE_F32)
 			{
 				m_float_emit.LDR(32, EncodeRegToDouble(RS), X28, addr);
-				m_float_emit.INS(32, RS, 1, RS, 0);
 				m_float_emit.REV32(8, EncodeRegToDouble(RS), EncodeRegToDouble(RS));
 				m_float_emit.FCVTL(64, EncodeRegToDouble(RS), EncodeRegToDouble(RS));
 			}
@@ -188,7 +187,7 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode,
 			{
 				MOVI2R(X30, (u64)&PowerPC::Read_U32);
 				BLR(X30);
-				m_float_emit.DUP(32, RS, X0);
+				m_float_emit.INS(32, RS, 0, X0);
 				m_float_emit.FCVTL(64, RS, RS);
 			}
 			else

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -206,6 +206,9 @@ void JitArm64::lfXX(UGeckoInstruction inst)
 			regs_in_use, fprs_in_use);
 	}
 
+	if (flags & BackPatchInfo::FLAG_SIZE_F32)
+		fpr.DumpDuplicatedLower(inst.FD);
+
 	gpr.Unlock(W0, W30);
 	fpr.Unlock(Q0);
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -281,8 +281,23 @@ ARM64Reg Arm64FPRCache::R(u32 preg, bool only_lower)
 	switch (reg.GetType())
 	{
 	case REG_REG: // already in a reg
-	case REG_LOWER_PAIR:
 		return reg.GetReg();
+	break;
+	case REG_LOWER_PAIR:
+	{
+		if (!only_lower)
+		{
+			// Load the high 64bits from the file and insert them in to the high 64bits of the host register
+			ARM64Reg tmp_reg = GetReg();
+			m_float_emit->LDR(64, INDEX_UNSIGNED, tmp_reg, X29, PPCSTATE_OFF(ps[preg][1]));
+			m_float_emit->INS(64, reg.GetReg(), 1, tmp_reg, 0);
+			UnlockRegister(tmp_reg);
+
+			// Change it over to a full 128bit register
+			reg.LoadToReg(reg.GetReg());
+		}
+		return reg.GetReg();
+	}
 	break;
 	case REG_NOTLOADED: // Register isn't loaded at /all/
 	{
@@ -424,6 +439,18 @@ void Arm64FPRCache::FlushRegister(u32 preg, bool maintain_state)
 			UnlockRegister(host_reg);
 			reg.Flush();
 		}
+	}
+}
+
+void Arm64FPRCache::DumpDuplicatedLower(u32 preg)
+{
+	OpArg& reg = m_guest_registers[preg];
+	if (reg.GetType() == REG_REG ||
+	    reg.GetType() == REG_LOWER_PAIR)
+	{
+		ARM64Reg host_reg = reg.GetReg();
+		m_float_emit->STR(64, INDEX_UNSIGNED, host_reg, X29, PPCSTATE_OFF(ps[preg][1]));
+		reg.LoadLowerReg(host_reg);
 	}
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -269,6 +269,11 @@ public:
 	// Returns if the register is only the lower 64bit register
 	bool IsLower(u32 preg) const { return m_guest_registers[preg].GetType() == REG_LOWER_PAIR; }
 
+	// This flushes the lower 64bit FPR to the higher FPR location
+	// and then sets the guest register type to a lower pair
+	// This is only used with the lfs PowerPC instruction
+	void DumpDuplicatedLower(u32 preg);
+
 	BitSet32 GetCallerSavedUsed() override;
 
 protected:


### PR DESCRIPTION
A bug was introduced in my lower 64bit paired commit that if a register was loaded as a lower pair, and then used in a paired instruction, it wouldn't
ever load the top 64bits of the register.
This also improves performance of lfs. We make the assumption that if an lfs instruction is used then it will be used in non-paired operations.
This assumption generally holds true. So on load I immediately flush the duplicated register to our ppcState and set it as a lower paired type
register.
This has the potential of doing a store+load dance if the register is in a paired operation, but generally doesn't happen.
This removes quite a few INS instructions in the generated code for povray and boosts the performance even higher there.