### PR TITLE
GCMemcard: Clean up memcard logging messages.

### DIFF
--- a/Source/Core/Core/HW/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard.cpp
@@ -30,7 +30,7 @@ GCMemcard::GCMemcard(const std::string &filename, bool forceCreation, bool ascii
 		{
 			if (!AskYesNoT("\"%s\" does not exist.\n Create a new 16MB Memcard?", filename.c_str()))
 				return;
-			ascii = AskYesNoT("Format as ascii (NTSC\\PAL)?\nChoose no for sjis (NTSC-J)");
+			ascii = AskYesNoT("Format as ASCII (NTSC\\PAL)?\nChoose no for Shift JIS (NTSC-J)");
 		}
 		Format(ascii);
 		return;
@@ -42,18 +42,18 @@ GCMemcard::GCMemcard(const std::string &filename, bool forceCreation, bool ascii
 		SplitPath(filename, nullptr, nullptr, &fileType);
 		if (strcasecmp(fileType.c_str(), ".raw") && strcasecmp(fileType.c_str(), ".gcp"))
 		{
-			PanicAlertT("File has the extension \"%s\"\nvalid extensions are (.raw/.gcp)", fileType.c_str());
+			PanicAlertT("File has the extension \"%s\".\nValid extensions are (.raw/.gcp)", fileType.c_str());
 			return;
 		}
 		auto size = mcdFile.GetSize();
 		if (size < MC_FST_BLOCKS*BLOCK_SIZE)
 		{
-			PanicAlertT("%s failed to load as a memorycard \nfile is not large enough to be a valid memory card file (0x%x bytes)", filename.c_str(), (unsigned) size);
+			PanicAlertT("%s failed to load as a memory card.\nFile is not large enough to be a valid memory card file (0x%x bytes)", filename.c_str(), (unsigned) size);
 			return;
 		}
 		if (size % BLOCK_SIZE)
 		{
-			PanicAlertT("%s failed to load as a memorycard \n Card file size is invalid (0x%x bytes)", filename.c_str(), (unsigned) size);
+			PanicAlertT("%s failed to load as a memory card.\nCard file size is invalid (0x%x bytes)", filename.c_str(), (unsigned) size);
 				return;
 		}
 
@@ -68,7 +68,7 @@ GCMemcard::GCMemcard(const std::string &filename, bool forceCreation, bool ascii
 			case MemCard2043Mb:
 				break;
 			default:
-				PanicAlertT("%s failed to load as a memorycard \n Card size is invalid (0x%x bytes)", filename.c_str(), (unsigned) size);
+				PanicAlertT("%s failed to load as a memory card.\nCard size is invalid (0x%x bytes)", filename.c_str(), (unsigned) size);
 				return;
 		}
 	}
@@ -82,7 +82,7 @@ GCMemcard::GCMemcard(const std::string &filename, bool forceCreation, bool ascii
 	}
 	if (m_sizeMb != BE16(hdr.SizeMb))
 	{
-		PanicAlertT("Memorycard filesize does not match the header size");
+		PanicAlertT("Memory card file size does not match the header size");
 		return;
 	}
 
@@ -125,7 +125,7 @@ GCMemcard::GCMemcard(const std::string &filename, bool forceCreation, bool ascii
 		if (csums & 0x4)
 		{
 			// backup is also wrong!
-			PanicAlertT("Directory checksum failed\n and Directory backup checksum failed");
+			PanicAlertT("Directory checksum and directory backup checksum failed");
 			return;
 		}
 		else
@@ -181,7 +181,7 @@ GCMemcard::GCMemcard(const std::string &filename, bool forceCreation, bool ascii
 		}
 		else
 		{
-			PanicAlertT("Failed to read block %d of the save data\nMemcard may be truncated\nFilePosition:%" PRIx64, i, mcdFile.Tell());
+			PanicAlertT("Failed to read block %u of the save data\nMemcard may be truncated\nFile position: 0x%" PRIx64, i, mcdFile.Tell());
 			m_valid = false;
 			break;
 		}

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -74,7 +74,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::IVolume::EC
 		// in reality, there are not likely any valid gci files > 251 blocks
 		if (numBlocks > 2043)
 		{
-			PanicAlertT("%s\nwas not loaded because it is an invalid gci.\n Number of blocks claimed to be %d",
+			PanicAlertT("%s\nwas not loaded because it is an invalid GCI.\n Number of blocks claimed to be %u",
 						gci.m_filename.c_str(), numBlocks);
 			return NO_INDEX;
 		}
@@ -83,8 +83,8 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::IVolume::EC
 		u64 file_size = gcifile.GetSize();
 		if (file_size != size + DENTRY_SIZE)
 		{
-			PanicAlertT("%s\nwas not loaded because it is an invalid gci.\n File size (%" PRIx64
-						") does not match the size recorded in the header (%d)",
+			PanicAlertT("%s\nwas not loaded because it is an invalid GCI.\n File size (0x%" PRIx64
+						") does not match the size recorded in the header (0x%x)",
 						gci.m_filename.c_str(), file_size, size + DENTRY_SIZE);
 			return NO_INDEX;
 		}
@@ -104,7 +104,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::IVolume::EC
 			if (totalBlocks > freeBlocks * 10)
 			{
 
-				PanicAlertT("%s\nwas not loaded because there is less than 10%% free space on the memorycard\n"\
+				PanicAlertT("%s\nwas not loaded because there is less than 10%% free blocks available on the memory card\n"\
 					"Total Blocks: %d; Free Blocks: %d",
 					gci.m_filename.c_str(), totalBlocks, freeBlocks);
 				return NO_INDEX;
@@ -113,7 +113,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::IVolume::EC
 		u16 first_block = m_bat1.AssignBlocksContiguous(numBlocks);
 		if (first_block == 0xFFFF)
 		{
-			PanicAlertT("%s\nwas not loaded because there are not enough free blocks on virtual memorycard",
+			PanicAlertT("%s\nwas not loaded because there are not enough free blocks on the virtual memory card",
 						fileName.c_str());
 			return NO_INDEX;
 		}
@@ -155,9 +155,8 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u
 
 	if (rFilenames.size() > 112)
 	{
-		Core::DisplayMessage(
-		StringFromFormat("WARNING: There are more than 112 save files on this memorycards"\
-		"\n Only loading the first 112 in the folder, unless the gameid is the current games id"),
+		Core::DisplayMessage("Warning: There are more than 112 save files on this memory card.\n"
+		" Only loading the first 112 in the folder, unless the game ID is the same as the current game's ID",
 		4000);
 	}
 
@@ -165,7 +164,7 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u
 	{
 		if (m_saves.size() == DIRLEN)
 		{
-			PanicAlertT("There are too many gci files in the folder\n%s\nOnly the first 127 will be available",
+			PanicAlertT("There are too many GCI files in the folder\n%s.\nOnly the first 127 will be available",
 				m_SaveDirectory.c_str());
 			break;
 		}
@@ -194,7 +193,7 @@ void GCMemcardDirectory::FlushThread()
 
 
 	Common::SetCurrentThreadName(
-		StringFromFormat("Memcard%x-Flush", card_index).c_str());
+		StringFromFormat("Memcard %d flushing thread", card_index).c_str());
 
 	while (true)
 	{
@@ -291,7 +290,7 @@ s32 GCMemcardDirectory::Write(u32 destaddress, s32 length, u8 *srcaddress)
 {
 	std::unique_lock<std::mutex> l(m_write_mutex);
 	if (length != 0x80)
-		INFO_LOG(EXPANSIONINTERFACE, "WRITING TO %x, len %x", destaddress, length);
+		INFO_LOG(EXPANSIONINTERFACE, "Writing to 0x%x. Length: 0x%x", destaddress, length);
 	s32 block = destaddress / BLOCK_SIZE;
 	u32 offset = destaddress % BLOCK_SIZE;
 	s32 extra = 0; // used for write calls that are across multiple blocks
@@ -338,7 +337,7 @@ s32 GCMemcardDirectory::Write(u32 destaddress, s32 length, u8 *srcaddress)
 			m_LastBlock = SaveAreaRW(block, true);
 			if (m_LastBlock == -1)
 			{
-				PanicAlertT("Report: GCIFolder Writing to unallocated block %x", block);
+				PanicAlertT("Report: GCIFolder Writing to unallocated block 0x%x", block);
 				exit(0);
 			}
 		}
@@ -363,7 +362,7 @@ void GCMemcardDirectory::ClearBlock(u32 address)
 	}
 
 	u32 block = address / BLOCK_SIZE;
-	INFO_LOG(EXPANSIONINTERFACE, "clearing block %d", block);
+	INFO_LOG(EXPANSIONINTERFACE, "Clearing block %u", block);
 	switch (block)
 	{
 	case 0:
@@ -407,7 +406,7 @@ inline void GCMemcardDirectory::SyncSaves()
 	{
 		if (BE32(current->Dir[i].Gamecode) != 0xFFFFFFFF)
 		{
-			INFO_LOG(EXPANSIONINTERFACE, "Syncing Save %x", *(u32 *)&(current->Dir[i].Gamecode));
+			INFO_LOG(EXPANSIONINTERFACE, "Syncing save 0x%x", *(u32 *)&(current->Dir[i].Gamecode));
 			bool added = false;
 			while (i >= m_saves.size())
 			{
@@ -427,13 +426,13 @@ inline void GCMemcardDirectory::SyncSaves()
 				if ((gamecode != 0xFFFFFFFF)
 					&& (gamecode != newGameCode))
 				{
-					PanicAlertT("Game overwrote with another games save, data corruption ahead %x, %x ",
+					PanicAlertT("Game overwrote with another games save. Data corruption ahead 0x%x, 0x%x",
 						BE32(m_saves[i].m_gci_header.Gamecode), BE32(current->Dir[i].Gamecode));
 				}
 				memcpy((u8 *)&(m_saves[i].m_gci_header), (u8 *)&(current->Dir[i]), DENTRY_SIZE);
 				if (old_start != new_start)
 				{
-					INFO_LOG(EXPANSIONINTERFACE, "Save moved from %x to %x", old_start, new_start);
+					INFO_LOG(EXPANSIONINTERFACE, "Save moved from 0x%x to 0x%x", old_start, new_start);
 					m_saves[i].m_used_blocks.clear();
 					m_saves[i].m_save_data.clear();
 				}
@@ -445,7 +444,7 @@ inline void GCMemcardDirectory::SyncSaves()
 		}
 		else if ((i < m_saves.size()) && (*(u32 *)&(m_saves[i].m_gci_header) != 0xFFFFFFFF))
 		{
-			INFO_LOG(EXPANSIONINTERFACE, "Clearing and/or Deleting Save %x", BE32(m_saves[i].m_gci_header.Gamecode));
+			INFO_LOG(EXPANSIONINTERFACE, "Clearing and/or deleting save 0x%x", BE32(m_saves[i].m_gci_header.Gamecode));
 			*(u32 *)&(m_saves[i].m_gci_header.Gamecode) = 0xFFFFFFFF;
 			m_saves[i].m_save_data.clear();
 			m_saves[i].m_used_blocks.clear();
@@ -527,7 +526,7 @@ bool GCMemcardDirectory::SetUsedBlocks(int saveIndex)
 		block = currentBat->GetNextBlock(block);
 		if (block == 0)
 		{
-			PanicAlertT("BAT Incorrect, Dolphin will now exit");
+			PanicAlertT("BAT incorrect. Dolphin will now exit");
 			exit(0);
 		}
 	}
@@ -536,7 +535,8 @@ bool GCMemcardDirectory::SetUsedBlocks(int saveIndex)
 	u16 blocksFromBat = (u16)m_saves[saveIndex].m_used_blocks.size();
 	if (blocksFromBat != num_blocks)
 	{
-		PanicAlertT("Warning BAT number of blocks %d does not match file header loaded %d", blocksFromBat, num_blocks);
+		PanicAlertT("Warning: Number of blocks indicated by the BAT (%u) does not match that of the loaded file header (%u)",
+			blocksFromBat, num_blocks);
 		return false;
 	}
 
@@ -567,7 +567,7 @@ void GCMemcardDirectory::FlushToFile()
 						defaultSaveName.insert(defaultSaveName.end() - 4, '0');
 					}
 					if (File::Exists(defaultSaveName))
-						PanicAlertT("Failed to find new filename\n %s\n will be overwritten", defaultSaveName.c_str());
+						PanicAlertT("Failed to find new filename.\n%s\n will be overwritten", defaultSaveName.c_str());
 					m_saves[i].m_filename = defaultSaveName;
 				}
 				File::IOFile GCI(m_saves[i].m_filename, "wb");
@@ -660,7 +660,7 @@ bool GCIFile::LoadSaveBlocks()
 		m_save_data.resize(num_blocks);
 		if (!savefile.ReadBytes(m_save_data.data(), num_blocks * BLOCK_SIZE))
 		{
-			PanicAlertT("Failed to read data from gci file %s", m_filename.c_str());
+			PanicAlertT("Failed to read data from GCI file %s", m_filename.c_str());
 			m_save_data.clear();
 			return false;
 		}

--- a/Source/Core/Core/HW/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcardRaw.cpp
@@ -42,7 +42,7 @@ MemoryCard::MemoryCard(const std::string& filename, int _card_index, u16 sizeMb)
 		GCMemcard::Format(&m_memcard_data[0], m_filename.find(".JAP.raw") != std::string::npos, sizeMb);
 		memset(&m_memcard_data[MC_HDR_SIZE], 0xFF, memory_card_size - MC_HDR_SIZE);
 
-		INFO_LOG(EXPANSIONINTERFACE, "No memory card found - a new one was created.");
+		INFO_LOG(EXPANSIONINTERFACE, "No memory card found. A new one was created instead.");
 	}
 
 	// Class members (including inherited ones) have now been initialized, so
@@ -69,7 +69,7 @@ void MemoryCard::FlushThread()
 	}
 
 	Common::SetCurrentThreadName(
-		StringFromFormat("Memcard%x-Flush", card_index).c_str());
+		StringFromFormat("Memcard %d flushing thread", card_index).c_str());
 
 	const auto flush_interval = std::chrono::seconds(15);
 
@@ -146,7 +146,7 @@ s32 MemoryCard::Read(u32 srcaddress, s32 length, u8 *destaddress)
 {
 	if (!IsAddressInBounds(srcaddress))
 	{
-		PanicAlertT("MemoryCard: Read called with invalid source address, %x",
+		PanicAlertT("MemoryCard: Read called with invalid source address (0x%x)",
 					srcaddress);
 		return -1;
 	}
@@ -159,7 +159,7 @@ s32 MemoryCard::Write(u32 destaddress, s32 length, u8 *srcaddress)
 {
 	if (!IsAddressInBounds(destaddress))
 	{
-		PanicAlertT("MemoryCard: Write called with invalid destination address, %x",
+		PanicAlertT("MemoryCard: Write called with invalid destination address (0x%x)",
 					destaddress);
 		return -1;
 	}
@@ -176,7 +176,7 @@ void MemoryCard::ClearBlock(u32 address)
 {
 	if (address & (BLOCK_SIZE - 1) || !IsAddressInBounds(address))
 	{
-		PanicAlertT("MemoryCard: ClearBlock called on invalid address %x",
+		PanicAlertT("MemoryCard: ClearBlock called on invalid address (0x%x)",
 			address);
 		return;
 	}


### PR DESCRIPTION
Also corrects some format specifiers which should silence some warnings on higher warning levels (particularly on clang)