### PR TITLE
Support OpenGL ES 3.2.

### DIFF
--- a/Source/Core/VideoBackends/OGL/GLExtensions/ARB_sample_shading.h
+++ b/Source/Core/VideoBackends/OGL/GLExtensions/ARB_sample_shading.h
@@ -4,5 +4,5 @@
 
 #include "VideoBackends/OGL/GLExtensions/gl_common.h"
 
-extern PFNGLMINSAMPLESHADINGARBPROC glMinSampleShadingARB;
+extern PFNGLMINSAMPLESHADINGARBPROC glMinSampleShading;
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -50,6 +50,8 @@ static std::string GetGLSLVersionString()
 			return "#version 300 es";
 		case GLSLES_310:
 			return "#version 310 es";
+		case GLSLES_320:
+			return "#version 320 es";
 		case GLSL_130:
 			return "#version 130";
 		case GLSL_140:
@@ -521,6 +523,13 @@ void ProgramShaderCache::CreateHeader()
 {
 	GLSL_VERSION v = g_ogl_config.eSupportedGLSLVersion;
 	bool is_glsles = v >= GLSLES_300;
+	std::string SupportedESPointSize;
+	switch (g_ogl_config.SupportedESPointSize)
+	{
+	case 1: SupportedESPointSize = "#extension GL_OES_geometry_point_size : enable"; break;
+	case 2: SupportedESPointSize = "#extension GL_EXT_geometry_point_size : enable"; break;
+	default: SupportedESPointSize = ""; break;
+	}
 
 	snprintf(s_glsl_header, sizeof(s_glsl_header),
 		"%s\n"
@@ -532,6 +541,7 @@ void ProgramShaderCache::CreateHeader()
 		"%s\n" // Sampler binding
 		"%s\n" // storage buffer
 		"%s\n" // shader5
+		"%s\n" // Geometry point size
 		"%s\n" // AEP
 		"%s\n" // texture buffer
 
@@ -567,7 +577,8 @@ void ProgramShaderCache::CreateHeader()
 		, (g_ogl_config.bSupportSampleShading) ? "#extension GL_ARB_sample_shading : enable" : ""
 		, g_ActiveConfig.backend_info.bSupportsBindingLayout ? "#define SAMPLER_BINDING(x) layout(binding = x)" : "#define SAMPLER_BINDING(x)"
 		, g_ActiveConfig.backend_info.bSupportsBBox ? "#extension GL_ARB_shader_storage_buffer_object : enable" : ""
-		, g_ActiveConfig.backend_info.bSupportsGSInstancing ? "#extension GL_ARB_gpu_shader5 : enable" : ""
+		, !is_glsles && g_ActiveConfig.backend_info.bSupportsGSInstancing ? "#extension GL_ARB_gpu_shader5 : enable" : ""
+		, SupportedESPointSize.c_str()
 		, g_ogl_config.bSupportsAEP ? "#extension GL_ANDROID_extension_pack_es31a : enable" : ""
 		, v<GLSL_140 && g_ActiveConfig.backend_info.bSupportsPaletteConversion ? "#extension GL_ARB_texture_buffer_object : enable" : ""
 

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -19,6 +19,7 @@ enum GLSL_VERSION
 	GLSL_150,  // and above
 	GLSLES_300,  // GLES 3.0
 	GLSLES_310, // GLES 3.1
+	GLSLES_320, // GLES 3.2
 };
 
 // ogl-only config, so not in VideoConfig.h
@@ -37,6 +38,7 @@ struct VideoConfig
 	bool bSupportsAEP;
 	bool bSupportsDebug;
 	bool bSupportsCopySubImage;
+	u8   SupportedESPointSize;
 
 	const char* gl_vendor;
 	const char* gl_renderer;


### PR DESCRIPTION
OpenGL ES 3.2 adds a few things we care about supporting in core. In particular:
- GL_{ARB,EXT,OES}_draw_elements_base_vertex
- KHR_Debug
- Sample Shading
- GL_{ARB,EXT,OES,NV}_copy_image
- Geometry shaders
- Geometry shader instancing (If they support GL_{EXT,OES}_geometry_point_size)

Nvidia was the first to release an OpenGL ES 3.2 driver which I uesd to test this on.
This also enables GS Instancing on GLES 3.1 hardware if it supports all of the required extensions.