### PR TITLE
AVIDump: fix -Wsign-compare warning

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -480,12 +480,12 @@ void AVIDump::AddFrame(const u8* data, int width, int height)
 	while (!error && got_packet)
 	{
 		// Write the compressed frame in the media file.
-		if (static_cast<u64>(pkt.pts) != AV_NOPTS_VALUE)
+		if (pkt.pts != (s64)AV_NOPTS_VALUE)
 		{
 			pkt.pts = av_rescale_q(pkt.pts,
 			                       s_stream->codec->time_base, s_stream->time_base);
 		}
-		if (static_cast<u64>(pkt.dts) != AV_NOPTS_VALUE)
+		if (pkt.dts != (s64)AV_NOPTS_VALUE)
 		{
 			pkt.dts = av_rescale_q(pkt.dts,
 			                       s_stream->codec->time_base, s_stream->time_base);


### PR DESCRIPTION
Cast the other side of the comparison to avoid a warning with newer ffmpeg/libav versions (https://github.com/FFmpeg/FFmpeg/commit/cb3591e69738c808d26ba15eb02414fedfcd91cc).