### PR TITLE
[Android] Workaround Mali driver issue on the Samsung Galaxy S6.

### DIFF
--- a/Source/Core/VideoBackends/OGL/GLInterface/EGL.cpp
+++ b/Source/Core/VideoBackends/OGL/GLInterface/EGL.cpp
@@ -4,6 +4,7 @@
 
 #include "VideoBackends/OGL/GLInterfaceBase.h"
 #include "VideoBackends/OGL/GLInterface/EGL.h"
+#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/RenderBase.h"
 
 // Show the current FPS
@@ -13,7 +14,8 @@ void cInterfaceEGL::Swap()
 }
 void cInterfaceEGL::SwapInterval(int Interval)
 {
-	eglSwapInterval(egl_dpy, Interval);
+	if (!DriverDetails::HasBug(DriverDetails::BUG_BROKENVSYNC))
+		eglSwapInterval(egl_dpy, Interval);
 }
 
 void* cInterfaceEGL::GetFuncAddress(const std::string& name)

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -54,6 +54,7 @@ namespace DriverDetails
 		{OS_ALL,    VENDOR_QUALCOMM, DRIVER_QUALCOMM,     -1, BUG_BROKENIVECSHIFTS,    -1.0, 46.0, true},
 		{OS_ALL,    VENDOR_QUALCOMM, DRIVER_QUALCOMM,     -1, BUG_BROKENGLES31,        -1.0, -1.0, true},
 		{OS_ALL,    VENDOR_ARM,      DRIVER_ARM,          -1, BUG_BROKENBUFFERSTREAM,  -1.0, -1.0, true},
+		{OS_ALL,    VENDOR_ARM,      DRIVER_ARM,          -1, BUG_BROKENVSYNC,         -1.0, -1.0, true},
 		{OS_ALL,    VENDOR_IMGTEC,   DRIVER_IMGTEC,       -1, BUG_BROKENBUFFERSTREAM,  -1.0, -1.0, true},
 		{OS_ALL,    VENDOR_MESA,     DRIVER_NOUVEAU,      -1, BUG_BROKENUBO,           900,  916, true},
 		{OS_ALL,    VENDOR_MESA,     DRIVER_R600,         -1, BUG_BROKENUBO,           900,  913, true},

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -248,6 +248,17 @@ namespace DriverDetails
 		// This isn't fully researched, but at the very least Qualcomm doesn't implement Geometry shader features fully.
 		// Until each bug is fully investigated, just disable GLES 3.1 entirely on these devices.
 		BUG_BROKENGLES31,
+
+		// Bug: ARM Mali managed to break disabling vsync
+		// Affected Devices: Mali
+		// Started Version: r5p0-rev2
+		// Ended Version: -1
+		// If we disable vsync with eglSwapInterval(dpy, 0) then the screen will stop showing new updates after a handful of swaps.
+		// This was noticed on a Samsung Galaxy S6 with its Android 5.1.1 update.
+		// The default Android 5.0 image didn't encounter this issue.
+		// We can't actually detect what the driver version is on Android, so until the driver version lands that displays the version in
+		// the GL_VERSION string, we will have to force vsync to be enabled at all times.
+		BUG_BROKENVSYNC,
 	};
 
 	// Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
Samsung updated the video drivers on the SGS6 which introduced a bug when disabling vsync.
Both the driver versions are r5p0, but the md5sums of the blob differ.
To work around the issue, make sure to never disable vsync by calling eglSwapInterval.

We can't actually determine the driver version on Android yet.
So until the driver version lands that displays the driver version string in the GL_VERSION string
we will need to keep this workaround enabled at all times, which is a bit annoying.

Current mali drivers return the video driver version in one of the EGL strings you can query.
The issue with that is that Android eats all of those strings, so we can't query it.