### PR TITLE
[AArch64] Optimize lmw.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -206,6 +206,8 @@ void Arm64GPRCache::BindToRegister(u32 preg, bool do_load)
 {
 	OpArg& reg = m_guest_registers[preg];
 
+	reg.ResetLastUsed();
+
 	reg.SetDirty(true);
 	if (reg.GetType() == REG_NOTLOADED)
 	{
@@ -331,6 +333,9 @@ void Arm64FPRCache::BindToRegister(u32 preg, bool do_load, bool only_lower)
 	OpArg& reg = m_guest_registers[preg];
 
 	bool was_dirty = reg.IsDirty();
+
+	reg.ResetLastUsed();
+
 	reg.SetDirty(true);
 	switch (reg.GetType())
 	{


### PR DESCRIPTION
This instruction is fairly heavily used by Ikaruga to load a bunch of registers from the stack.
In particular at the start of the second stage is a block that takes up ~20% CPU time that includes a usage of lmw to load half of the guest
registers.

Basic thing optimized here is changing from a single 32bit LDR to potentially a single 128bit LDR.
a single 32bit LDR is fairly slow, so we can optimize a few ways.
If we have four or more registers to load, do a 64bit LDP in to two host registers, byteswap, and then move the high 32bits of the host registers in
to the correct mapped guest register locations.
If we have two registers to load then do a 32bit LDP which will load two guest registers in a single instruction.
and then if we have only one register left to load, load it as before.

This saves quite a bit of cycles since the Cortex-A57 and A72's LDR instruction takes a few cycles.

Each 32bit LDR takes 4 cycles latency, plus 1 cycle for post-index(which typically happens in parallel.
Both the 32bit and 64bit LDP take the same amount of latency.

So we are improving latencies and reducing code bloat here.