### PR TITLE
Implemented ability to block writes to the SD card

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -242,7 +242,7 @@ bool BootCore(const std::string& _rFilename)
 	{
 		StartUp.bCPUThread = g_NetPlaySettings.m_CPUthread;
 		StartUp.bDSPHLE = g_NetPlaySettings.m_DSPHLE;
-		StartUp.bEnableMemcardSaving = g_NetPlaySettings.m_WriteToMemcard;
+		StartUp.bEnableMemcardSdWriting = g_NetPlaySettings.m_WriteToMemcard;
 		StartUp.iCPUCore = g_NetPlaySettings.m_CPUcore;
 		StartUp.SelectedLanguage = g_NetPlaySettings.m_SelectedLanguage;
 		StartUp.bOverrideGCLanguage = g_NetPlaySettings.m_OverrideGCLanguage;

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -39,7 +39,7 @@ SConfig::SConfig()
   bCPUThread(true), bDSPThread(false), bDSPHLE(true),
   bSkipIdle(true), bSyncGPUOnSkipIdleHack(true), bNTSC(false), bForceNTSCJ(false),
   bHLE_BS2(true), bEnableCheats(false),
-  bEnableMemcardSaving(true),
+  bEnableMemcardSdWriting(true),
   bDPL2Decoder(false), iLatency(14),
   bRunCompareServer(false), bRunCompareClient(false),
   bMMU(false), bDCBZOFF(false),
@@ -605,7 +605,7 @@ void SConfig::LoadDefaults()
 	iBBDumpPort = -1;
 	bSyncGPU = false;
 	bFastDiscSpeed = false;
-	bEnableMemcardSaving = true;
+	bEnableMemcardSdWriting = true;
 	SelectedLanguage = 0;
 	bOverrideGCLanguage = false;
 	bWii = false;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -87,7 +87,7 @@ struct SConfig : NonCopyable
 	bool bForceNTSCJ;
 	bool bHLE_BS2;
 	bool bEnableCheats;
-	bool bEnableMemcardSaving;
+	bool bEnableMemcardSdWriting;
 
 	bool bDPL2Decoder;
 	int iLatency;

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -186,7 +186,7 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u
 
 void GCMemcardDirectory::FlushThread()
 {
-	if (!SConfig::GetInstance().bEnableMemcardSaving)
+	if (!SConfig::GetInstance().bEnableMemcardSdWriting)
 	{
 		return;
 	}

--- a/Source/Core/Core/HW/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcardRaw.cpp
@@ -63,7 +63,7 @@ MemoryCard::~MemoryCard()
 
 void MemoryCard::FlushThread()
 {
-	if (!SConfig::GetInstance().bEnableMemcardSaving)
+	if (!SConfig::GetInstance().bEnableMemcardSdWriting)
 	{
 		return;
 	}

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -423,7 +423,7 @@ u32 CWII_IPC_HLE_Device_sdio_slot0::ExecuteCommand(u32 _BufferIn, u32 _BufferInS
 		DEBUG_LOG(WII_IPC_SD, "%sWrite %i Block(s) from 0x%08x bsize %i to offset 0x%08x!",
 			req.isDMA ? "DMA " : "", req.blocks, req.addr, req.bsize, req.arg);
 
-		if (m_Card)
+		if (m_Card && SConfig::GetInstance().bEnableMemcardSdWriting)
 		{
 			u32 size = req.bsize * req.blocks;
 

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -202,7 +202,7 @@ NetPlayDialog::NetPlayDialog(wxWindow* const parent, const CGameListCtrl* const 
 		padbuf_spin->Bind(wxEVT_SPINCTRL, &NetPlayDialog::OnAdjustBuffer, this);
 		bottom_szr->Add(padbuf_spin, 0, wxCENTER);
 
-		m_memcard_write = new wxCheckBox(panel, wxID_ANY, _("Write memcards (GC)"));
+		m_memcard_write = new wxCheckBox(panel, wxID_ANY, _("Write memcards/SD"));
 		bottom_szr->Add(m_memcard_write, 0, wxCENTER);
 	}
 


### PR DESCRIPTION
A couple Project M people in IRC said it would be very beneficial if we had an option to block writes to the SD card as well as memcard for netplay. This is a harmless change and only affects games launched in netplay mode.