### PR TITLE
VertexLoader_Color: Remove some pointer casts

### DIFF
--- a/Source/Core/VideoCommon/VertexLoader_Color.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Color.cpp
@@ -14,15 +14,15 @@
 
 #define AMASK 0xFF000000
 
-__forceinline void _SetCol(VertexLoader* loader, u32 val)
+static void SetCol(VertexLoader* loader, u32 val)
 {
 	DataWrite(val);
 	loader->m_colIndex++;
 }
 
-//color comes in format BARG in 16 bits
-//BARG -> AABBGGRR
-__forceinline void _SetCol4444(VertexLoader* loader, u16 val_)
+// Color comes in format BARG in 16 bits
+// BARG -> AABBGGRR
+static void SetCol4444(VertexLoader* loader, u16 val_)
 {
 	u32 col, val = val_;
 	col  =  val & 0x00F0;        // col  = 000000R0;
@@ -30,24 +30,24 @@ __forceinline void _SetCol4444(VertexLoader* loader, u16 val_)
 	col |= (val & 0xF000) << 8;  // col |= 00B00000;
 	col |= (val & 0x0F00) << 20; // col |= A0000000;
 	col |= col >> 4;             // col  = A0B0G0R0 | 0A0B0G0R;
-	_SetCol(loader, col);
+	SetCol(loader, col);
 }
 
-//color comes in format RGBA
-//RRRRRRGG GGGGBBBB BBAAAAAA
-__forceinline void _SetCol6666(VertexLoader* loader, u32 val)
+// Color comes in format RGBA
+// RRRRRRGG GGGGBBBB BBAAAAAA
+static void SetCol6666(VertexLoader* loader, u32 val)
 {
 	u32 col = (val >> 16) & 0x000000FC;
 	col |=    (val >>  2) & 0x0000FC00;
 	col |=    (val << 12) & 0x00FC0000;
 	col |=    (val << 26) & 0xFC000000;
 	col |=    (col >>  6) & 0x03030303;
-	_SetCol(loader, col);
+	SetCol(loader, col);
 }
 
-//color comes in RGB
-//RRRRRGGG GGGBBBBB
-__forceinline void _SetCol565(VertexLoader* loader, u16 val_)
+// Color comes in RGB
+// RRRRRGGG GGGBBBBB
+static void SetCol565(VertexLoader* loader, u16 val_)
 {
 	u32 col, val = val_;
 	col  = (val >>  8) & 0x0000F8;
@@ -55,52 +55,52 @@ __forceinline void _SetCol565(VertexLoader* loader, u16 val_)
 	col |= (val << 19) & 0xF80000;
 	col |= (col >>  5) & 0x070007;
 	col |= (col >>  6) & 0x000300;
-	_SetCol(loader, col | AMASK);
+	SetCol(loader, col | AMASK);
 }
 
-__forceinline u32 _Read32(const u8 *addr)
+static u32 Read32(const u8* addr)
 {
 	u32 value;
 	std::memcpy(&value, addr, sizeof(u32));
 	return value;
 }
 
-__forceinline u32 _Read24(const u8 *addr)
+static u32 Read24(const u8* addr)
 {
-	return _Read32(addr) | AMASK;
+	return Read32(addr) | AMASK;
 }
 
 void Color_ReadDirect_24b_888(VertexLoader* loader)
 {
-	_SetCol(loader, _Read24(DataGetPosition()));
+	SetCol(loader, Read24(DataGetPosition()));
 	DataSkip(3);
 }
 
 void Color_ReadDirect_32b_888x(VertexLoader* loader)
 {
-	_SetCol(loader, _Read24(DataGetPosition()));
+	SetCol(loader, Read24(DataGetPosition()));
 	DataSkip(4);
 }
 void Color_ReadDirect_16b_565(VertexLoader* loader)
 {
-	_SetCol565(loader, DataReadU16());
+	SetCol565(loader, DataReadU16());
 }
 void Color_ReadDirect_16b_4444(VertexLoader* loader)
 {
 	u16 value;
 	std::memcpy(&value, DataGetPosition(), sizeof(u16));
 
-	_SetCol4444(loader, value);
+	SetCol4444(loader, value);
 	DataSkip(2);
 }
 void Color_ReadDirect_24b_6666(VertexLoader* loader)
 {
-	_SetCol6666(loader, Common::swap32(DataGetPosition() - 1));
+	SetCol6666(loader, Common::swap32(DataGetPosition() - 1));
 	DataSkip(3);
 }
 void Color_ReadDirect_32b_8888(VertexLoader* loader)
 {
-	_SetCol(loader, DataReadU32Unswapped());
+	SetCol(loader, DataReadU32Unswapped());
 }
 
 template <typename I>
@@ -112,7 +112,7 @@ void Color_ReadIndex_16b_565(VertexLoader* loader)
 	u16 value;
 	std::memcpy(&value, address, sizeof(u16));
 
-	_SetCol565(loader, Common::swap16(value));
+	SetCol565(loader, Common::swap16(value));
 }
 
 template <typename I>
@@ -120,7 +120,7 @@ void Color_ReadIndex_24b_888(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
 	const u8 *iAddress = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
-	_SetCol(loader, _Read24(iAddress));
+	SetCol(loader, Read24(iAddress));
 }
 
 template <typename I>
@@ -128,7 +128,7 @@ void Color_ReadIndex_32b_888x(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
 	const u8 *iAddress = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
-	_SetCol(loader, _Read24(iAddress));
+	SetCol(loader, Read24(iAddress));
 }
 
 template <typename I>
@@ -140,7 +140,7 @@ void Color_ReadIndex_16b_4444(VertexLoader* loader)
 	u16 value;
 	std::memcpy(&value, address, sizeof(u16));
 
-	_SetCol4444(loader, value);
+	SetCol4444(loader, value);
 }
 
 template <typename I>
@@ -149,7 +149,7 @@ void Color_ReadIndex_24b_6666(VertexLoader* loader)
 	auto const Index = DataRead<I>();
 	const u8* pData = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]) - 1;
 	u32 val = Common::swap32(pData);
-	_SetCol6666(loader, val);
+	SetCol6666(loader, val);
 }
 
 template <typename I>
@@ -157,7 +157,7 @@ void Color_ReadIndex_32b_8888(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
 	const u8 *iAddress = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
-	_SetCol(loader, _Read32(iAddress));
+	SetCol(loader, Read32(iAddress));
 }
 
 void Color_ReadIndex8_16b_565(VertexLoader* loader) { Color_ReadIndex_16b_565<u8>(loader); }

--- a/Source/Core/VideoCommon/VertexLoader_Color.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Color.cpp
@@ -2,7 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include <cstring>
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 
 #include "VideoCommon/VertexLoader.h"
@@ -57,16 +58,17 @@ __forceinline void _SetCol565(VertexLoader* loader, u16 val_)
 	_SetCol(loader, col | AMASK);
 }
 
-__forceinline u32 _Read24(const u8 *addr)
-{
-	return (*(const u32 *)addr) | AMASK;
-}
-
 __forceinline u32 _Read32(const u8 *addr)
 {
-	return *(const u32 *)addr;
+	u32 value;
+	std::memcpy(&value, addr, sizeof(u32));
+	return value;
 }
 
+__forceinline u32 _Read24(const u8 *addr)
+{
+	return _Read32(addr) | AMASK;
+}
 
 void Color_ReadDirect_24b_888(VertexLoader* loader)
 {
@@ -85,7 +87,10 @@ void Color_ReadDirect_16b_565(VertexLoader* loader)
 }
 void Color_ReadDirect_16b_4444(VertexLoader* loader)
 {
-	_SetCol4444(loader, *(u16*)DataGetPosition());
+	u16 value;
+	std::memcpy(&value, DataGetPosition(), sizeof(u16));
+
+	_SetCol4444(loader, value);
 	DataSkip(2);
 }
 void Color_ReadDirect_24b_6666(VertexLoader* loader)
@@ -102,8 +107,12 @@ template <typename I>
 void Color_ReadIndex_16b_565(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
-	u16 val = Common::swap16(*(const u16 *)(VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex])));
-	_SetCol565(loader, val);
+	const u8* const address = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+
+	u16 value;
+	std::memcpy(&value, address, sizeof(u16));
+
+	_SetCol565(loader, Common::swap16(value));
 }
 
 template <typename I>
@@ -126,8 +135,12 @@ template <typename I>
 void Color_ReadIndex_16b_4444(VertexLoader* loader)
 {
 	auto const Index = DataRead<I>();
-	u16 val = *(const u16 *)(VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]));
-	_SetCol4444(loader, val);
+	const u8* const address = VertexLoaderManager::cached_arraybases[ARRAY_COLOR + loader->m_colIndex] + (Index * g_main_cp_state.array_strides[ARRAY_COLOR + loader->m_colIndex]);
+
+	u16 value;
+	std::memcpy(&value, address, sizeof(u16));
+
+	_SetCol4444(loader, value);
 }
 
 template <typename I>


### PR DESCRIPTION
Also marks translation-unit-only functions as static (this also causes inlining as the compiler now knows there's no external linkage that could occur).