### PR TITLE
Added missing Mega Man 5 INI file

### DIFF
--- a/Data/Sys/GameSettings/FFY.ini
+++ b/Data/Sys/GameSettings/FFY.ini
@@ -1,0 +1,29 @@
+# FFYE01, FFYJ01, FFYP01 - Mega Man 5
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[EmuState]
+# The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationIssues = Texture filtering will cause glitches.
+EmulationStateId = 4
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+EFBScale = 2
+
+[Video_Hacks]
+EFBToTextureEnable = False
+
+[Video_Enhancements]
+MaxAnisotropy = 0
+ForceFiltering = False


### PR DESCRIPTION
While going through and testing various NES VC games, I noticed Mega Man
5 was just displaying a black screen but the sound and button inputs
were working as expected. Turns out, there is no INI file for that game
id. Copying and renaming Mega Man 4's INI file appears to be enough to
get the game going.