### PR TITLE
[GLES] Support texture_buffer for palette texture conversion.

### DIFF
--- a/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
@@ -1293,19 +1293,26 @@ const GLFunc gl_function_array[] =
 	// EXT_copy_image
 	GLFUNC_SUFFIX(glCopyImageSubData, EXT, "GL_EXT_copy_image !GL_OES_copy_image !VERSION_GLES_3_2"),
 
+	// EXT_texture_buffer
+	GLFUNC_SUFFIX(glTexBuffer, OES, "GL_OES_texture_buffer !VERSION_GLES_3_2"),
+
+	// EXT_texture_buffer
+	GLFUNC_SUFFIX(glTexBuffer, EXT, "GL_EXT_texture_buffer !GL_OES_texture_buffer !VERSION_GLES_3_2"),
+
 	// GLES 3.2
-	GLFUNC_REQUIRES(glMinSampleShading,     "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glDebugMessageCallback, "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glDebugMessageControl,  "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glDebugMessageInsert,   "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glGetDebugMessageLog,   "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glGetObjectLabel,       "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glGetObjectPtrLabel,    "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glObjectLabel,          "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glObjectPtrLabel,       "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glPopDebugGroup,        "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glPushDebugGroup,       "VERSION_GLES_3_2"),
-	GLFUNC_REQUIRES(glCopyImageSubData,     "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glMinSampleShading,        "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glDebugMessageCallback,    "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glDebugMessageControl,     "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glDebugMessageInsert,      "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glGetDebugMessageLog,      "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glGetObjectLabel,          "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glGetObjectPtrLabel,       "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glObjectLabel,             "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glObjectPtrLabel,          "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glPopDebugGroup,           "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glPushDebugGroup,          "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glCopyImageSubData,        "VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glTexBuffer,               "VERSION_GLES_3_2"),
 
 	// gl_1_1
 	// OpenGL 1.1 is at the end due to a bug in Android's EGL stack.

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -524,11 +524,26 @@ void ProgramShaderCache::CreateHeader()
 	GLSL_VERSION v = g_ogl_config.eSupportedGLSLVersion;
 	bool is_glsles = v >= GLSLES_300;
 	std::string SupportedESPointSize;
+	std::string SupportedESTextureBuffer;
 	switch (g_ogl_config.SupportedESPointSize)
 	{
 	case 1: SupportedESPointSize = "#extension GL_OES_geometry_point_size : enable"; break;
 	case 2: SupportedESPointSize = "#extension GL_EXT_geometry_point_size : enable"; break;
 	default: SupportedESPointSize = ""; break;
+	}
+
+	switch (g_ogl_config.SupportedESTextureBuffer)
+	{
+	case ES_TEXBUF_TYPE::TEXBUF_EXT:
+		SupportedESTextureBuffer = "#extension GL_EXT_texture_buffer : enable";
+	break;
+	case ES_TEXBUF_TYPE::TEXBUF_OES:
+		SupportedESTextureBuffer = "#extension GL_OES_texture_buffer : enable";
+	break;
+	case ES_TEXBUF_TYPE::TEXBUF_CORE:
+	case ES_TEXBUF_TYPE::TEXBUF_NONE:
+		SupportedESTextureBuffer = "";
+	break;
 	}
 
 	snprintf(s_glsl_header, sizeof(s_glsl_header),
@@ -544,8 +559,10 @@ void ProgramShaderCache::CreateHeader()
 		"%s\n" // Geometry point size
 		"%s\n" // AEP
 		"%s\n" // texture buffer
+		"%s\n" // ES texture buffer
 
 		// Precision defines for GLSL ES
+		"%s\n"
 		"%s\n"
 		"%s\n"
 		"%s\n"
@@ -581,10 +598,12 @@ void ProgramShaderCache::CreateHeader()
 		, SupportedESPointSize.c_str()
 		, g_ogl_config.bSupportsAEP ? "#extension GL_ANDROID_extension_pack_es31a : enable" : ""
 		, v<GLSL_140 && g_ActiveConfig.backend_info.bSupportsPaletteConversion ? "#extension GL_ARB_texture_buffer_object : enable" : ""
+		, SupportedESTextureBuffer.c_str()
 
 		, is_glsles ? "precision highp float;" : ""
 		, is_glsles ? "precision highp int;" : ""
 		, is_glsles ? "precision highp sampler2DArray;" : ""
+		, (is_glsles && g_ActiveConfig.backend_info.bSupportsPaletteConversion) ? "precision highp usamplerBuffer;" : ""
 
 		, DriverDetails::HasBug(DriverDetails::BUG_BROKENTEXTURESIZE) ? "#define textureSize(x, y) ivec2(1, 1)" : ""
 		, DriverDetails::HasBug(DriverDetails::BUG_BROKENCENTROID) ? "#define centroid" : ""

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -467,7 +467,9 @@ Renderer::Renderer()
 	g_Config.backend_info.bSupportsBBox = GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
 	g_Config.backend_info.bSupportsGSInstancing = GLExtensions::Supports("GL_ARB_gpu_shader5");
 	g_Config.backend_info.bSupportsGeometryShaders = GLExtensions::Version() >= 320;
-	g_Config.backend_info.bSupportsPaletteConversion = GLExtensions::Supports("GL_ARB_texture_buffer_object");
+	g_Config.backend_info.bSupportsPaletteConversion = GLExtensions::Supports("GL_ARB_texture_buffer_object") ||
+	                                                   GLExtensions::Supports("GL_OES_texture_buffer") ||
+	                                                   GLExtensions::Supports("GL_EXT_texture_buffer");
 	g_Config.backend_info.bSupportsClipControl = GLExtensions::Supports("GL_ARB_clip_control");
 	g_ogl_config.bSupportsCopySubImage = (GLExtensions::Supports("GL_ARB_copy_image") ||
 	                                      GLExtensions::Supports("GL_NV_copy_image") ||
@@ -497,6 +499,9 @@ Renderer::Renderer()
 	if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGLES3)
 	{
 		g_ogl_config.SupportedESPointSize = GLExtensions::Supports("GL_OES_geometry_point_size") ? 1 : GLExtensions::Supports("GL_EXT_geometry_point_size") ? 2 : 0;
+		g_ogl_config.SupportedESTextureBuffer = GLExtensions::Supports("VERSION_GLES_3_2") ? ES_TEXBUF_TYPE::TEXBUF_CORE :
+		                                        GLExtensions::Supports("GL_OES_texture_buffer") ? ES_TEXBUF_TYPE::TEXBUF_OES :
+		                                        GLExtensions::Supports("GL_EXT_texture_buffer") ? ES_TEXBUF_TYPE::TEXBUF_EXT : ES_TEXBUF_TYPE::TEXBUF_NONE;
 
 		if (strstr(g_ogl_config.glsl_version, "3.0") || DriverDetails::HasBug(DriverDetails::BUG_BROKENGLES31))
 		{
@@ -512,7 +517,6 @@ Renderer::Renderer()
 			g_Config.backend_info.bSupportsEarlyZ = true;
 			g_Config.backend_info.bSupportsGeometryShaders = g_ogl_config.bSupportsAEP;
 			g_Config.backend_info.bSupportsGSInstancing = g_Config.backend_info.bSupportsGeometryShaders && g_ogl_config.SupportedESPointSize > 0;
-			//g_Config.backend_info.bSupportsPaletteConversion = GLExtensions::Supports("GL_EXT_texture_buffer");
 		}
 		else
 		{
@@ -522,6 +526,7 @@ Renderer::Renderer()
 			g_Config.backend_info.bSupportsEarlyZ = true;
 			g_Config.backend_info.bSupportsGeometryShaders = true;
 			g_Config.backend_info.bSupportsGSInstancing = g_ogl_config.SupportedESPointSize > 0;
+			g_Config.backend_info.bSupportsPaletteConversion = true;
 			g_ogl_config.bSupportsCopySubImage = true;
 			g_ogl_config.bSupportsGLBaseVertex = true;
 			g_ogl_config.bSupportSampleShading = true;

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -21,6 +21,13 @@ enum GLSL_VERSION
 	GLSLES_310, // GLES 3.1
 	GLSLES_320, // GLES 3.2
 };
+enum class ES_TEXBUF_TYPE
+{
+	TEXBUF_NONE,
+	TEXBUF_CORE,
+	TEXBUF_OES,
+	TEXBUF_EXT
+};
 
 // ogl-only config, so not in VideoConfig.h
 struct VideoConfig
@@ -39,6 +46,7 @@ struct VideoConfig
 	bool bSupportsDebug;
 	bool bSupportsCopySubImage;
 	u8   SupportedESPointSize;
+	ES_TEXBUF_TYPE SupportedESTextureBuffer;
 
 	const char* gl_vendor;
 	const char* gl_renderer;


### PR DESCRIPTION
OpenGL ES 3.2 adds this feature to core
It was available to GLES 3.1 as GL_{EXT, OES}_texture_buffer as well.
For the non-Nvidia vendors that implemented this is:
      - Qualcomm's Adreno 4xx
      - IMGTec's PowerVR Rogue