### PR TITLE
VideoCommon: xfb height calculation adjusted

### DIFF
--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -241,7 +241,7 @@ static void BPWritten(const BPCmd& bp)
 				else
 					yScale = (float)bpmem.dispcopyyscale / 256.0f;
 
-				float num_xfb_lines = ((bpmem.copyTexSrcWH.y + 1.0f) * yScale);
+				float num_xfb_lines = 1.0f + bpmem.copyTexSrcWH.y  * yScale;
 
 				u32 height = static_cast<u32>(num_xfb_lines);
 				if (height > MAX_XFB_HEIGHT)


### PR DESCRIPTION
Baten Kaitos allocates its XFBs from a tagged heap
structure. With the old calculation, too many lines
were being written so the tag of the allocation
after the XFB was being corrupted. Fixes crash
mentioned in this comment:
https://code.google.com/p/dolphin-emu/issues/detail?id=7734#c6