### PR TITLE
VI: Respect DisplayControlRegister ENB bit

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -110,7 +110,7 @@ void Preset(bool _bNTSC)
 	m_VerticalTimingRegister.EQU = 6;
 	m_VerticalTimingRegister.ACV = 0;
 
-	m_DisplayControlRegister.ENB = 1;
+	m_DisplayControlRegister.ENB = 0;
 	m_DisplayControlRegister.FMT = _bNTSC ? 0 : 1;
 
 	m_HTiming0.HLW = 429;
@@ -605,6 +605,9 @@ static void EndField()
 // Run when: When a frame is scanned (progressive/interlace)
 void Update()
 {
+	if (!m_DisplayControlRegister.ENB)
+		return;
+
 	if (s_half_line_count == s_even_field_first_hl)
 	{
 		BeginField(FIELD_EVEN);


### PR DESCRIPTION
When ENB is set to 0 (default), VI should not
generate clocks, and so shouldn't generate
output.