### PR TITLE
[WIP] JIT leaf functions inlining

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter.cpp
@@ -180,7 +180,7 @@ void CachedInterpreter::Jit(u32 address)
 	b->codeSize = (u32)(GetCodePtr() - b->checkedEntry);
 	b->originalSize = code_block.m_num_instructions;
 
-	FinalizeBlock(block_num, jo.enableBlocklink, b->checkedEntry);
+	FinalizeBlock(block_num, code_block.m_inlined_addrs, jo.enableBlocklink, b->checkedEntry);
 }
 
 void CachedInterpreter::ClearCache()

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -528,6 +528,7 @@ void Jit64::Jit(u32 em_address)
 				// Do not link this block to other blocks While single stepping
 				jo.enableBlocklink = false;
 				analyzer.ClearOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+				analyzer.ClearOption(PPCAnalyst::PPCAnalyzer::OPTION_LEAF_INLINE);
 				analyzer.ClearOption(PPCAnalyst::PPCAnalyzer::OPTION_BRANCH_MERGE);
 				analyzer.ClearOption(PPCAnalyst::PPCAnalyzer::OPTION_CROR_MERGE);
 				analyzer.ClearOption(PPCAnalyst::PPCAnalyzer::OPTION_CARRY_MERGE);
@@ -906,6 +907,7 @@ void Jit64::EnableBlockLink()
 void Jit64::EnableOptimization()
 {
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_LEAF_INLINE);
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_BRANCH_MERGE);
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CROR_MERGE);
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CARRY_MERGE);

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -553,7 +553,7 @@ void Jit64::Jit(u32 em_address)
 
 	int block_num = blocks.AllocateBlock(em_address);
 	JitBlock *b = blocks.GetBlock(block_num);
-	blocks.FinalizeBlock(block_num, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
+	blocks.FinalizeBlock(block_num, code_block.m_inlined_addrs, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
 }
 
 const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlock *b, u32 nextPC)

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -499,7 +499,7 @@ void JitIL::Jit(u32 em_address)
 
 	int block_num = blocks.AllocateBlock(em_address);
 	JitBlock *b = blocks.GetBlock(block_num);
-	blocks.FinalizeBlock(block_num, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
+	blocks.FinalizeBlock(block_num, code_block.m_inlined_addrs, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
 }
 
 const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlock *b, u32 nextPC)

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -331,7 +331,7 @@ void JitArm64::Jit(u32)
 	int block_num = blocks.AllocateBlock(PowerPC::ppcState.pc);
 	JitBlock *b = blocks.GetBlock(block_num);
 	const u8* BlockPtr = DoJit(PowerPC::ppcState.pc, &code_buffer, b);
-	blocks.FinalizeBlock(block_num, jo.enableBlocklink, BlockPtr);
+	blocks.FinalizeBlock(block_num, code_block.m_inlined_addrs, jo.enableBlocklink, BlockPtr);
 }
 
 const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlock *b)

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -119,6 +119,7 @@ public:
 	JitState js;
 
 	virtual JitBaseBlockCache *GetBlockCache() = 0;
+	PPCAnalyst::PPCAnalyzer *GetPPCAnalyzer() { return &analyzer; }
 
 	virtual void Jit(u32 em_address) = 0;
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -117,7 +117,7 @@ using namespace Gen;
 		return num_blocks - 1;
 	}
 
-	void JitBaseBlockCache::FinalizeBlock(int block_num, bool block_link, const u8 *code_ptr)
+	void JitBaseBlockCache::FinalizeBlock(int block_num, const std::array<u32, 8>& inlined_addrs, bool block_link, const u8 *code_ptr)
 	{
 		blockCodePointers[block_num] = code_ptr;
 		JitBlock &b = blocks[block_num];
@@ -129,8 +129,12 @@ using namespace Gen;
 
 		for (u32 block = pAddr / 32; block <= (pAddr + (b.originalSize - 1) * 4) / 32; ++block)
 			valid_block.Set(block);
+		for (u32 inlined_addr : inlined_addrs)
+			valid_block.Set((inlined_addr & 0x1FFFFFFF) / 32);
 
 		block_map[std::make_pair(pAddr + 4 * b.originalSize - 1, pAddr)] = block_num;
+		for (u32 inlined_addr : inlined_addrs)
+			reverse_inlining_map.insert(std::make_pair(inlined_addr & ~32, block_num));
 
 		if (block_link)
 		{
@@ -303,6 +307,21 @@ using namespace Gen;
 			if (it1 != it2)
 			{
 				block_map.erase(it1, it2);
+			}
+
+			// Remove blocks referencing the invalidated code through inlined
+			// calls.
+			auto it3 = reverse_inlining_map.lower_bound(pAddr), it4 = it3;
+			while (it4 != reverse_inlining_map.end() && it4->first < pAddr + length)
+			{
+				JitBlock &b = blocks[it4->second];
+				*GetICachePtr(b.originalAddress) = JIT_ICACHE_INVALID_WORD;
+				DestroyBlock(it4->second, false);
+				++it4;
+			}
+			if (it3 != it4)
+			{
+				reverse_inlining_map.erase(it3, it4);
 			}
 
 			// If the code was actually modified, we need to clear the relevant entries from the

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -107,6 +107,7 @@ class JitBaseBlockCache
 	std::array<JitBlock, MAX_NUM_BLOCKS> blocks;
 	int num_blocks;
 	std::multimap<u32, int> links_to;
+	std::multimap<u32, int> reverse_inlining_map;
 	std::map<std::pair<u32, u32>, u32> block_map; // (end_addr, start_addr) -> number
 	ValidBlockBitSet valid_block;
 
@@ -134,7 +135,8 @@ public:
 	}
 
 	int AllocateBlock(u32 em_address);
-	void FinalizeBlock(int block_num, bool block_link, const u8 *code_ptr);
+	void FinalizeBlock(int block_num, const std::array<u32, 8>& inlined_addrs,
+	                   bool block_link, const u8 *code_ptr);
 
 	void Clear();
 	void Init();
@@ -156,7 +158,6 @@ public:
 
 	CompiledCode GetCompiledCodeFromBlock(int block_num);
 
-	// DOES NOT WORK CORRECTLY WITH INLINING
 	void InvalidateICache(u32 address, const u32 length, bool forced);
 
 	u32* GetBlockBitSet() const

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -41,7 +41,10 @@ namespace JitInterface
 	void DoState(PointerWrap &p)
 	{
 		if (jit && p.GetMode() == PointerWrap::MODE_READ)
+		{
+			jit->GetPPCAnalyzer()->ClearCache();
 			jit->GetBlockCache()->Clear();
+		}
 	}
 	CPUCoreBase *InitJitCore(int core)
 	{
@@ -231,13 +234,19 @@ namespace JitInterface
 		// the JIT'ed code.
 		// TODO: There's probably a better way to handle this situation.
 		if (jit)
+		{
+			jit->GetPPCAnalyzer()->ClearCache();
 			jit->GetBlockCache()->Clear();
+		}
 	}
 
 	void InvalidateICache(u32 address, u32 size, bool forced)
 	{
 		if (jit)
+		{
+			jit->GetPPCAnalyzer()->InvalidateCache(address, size);
 			jit->GetBlockCache()->InvalidateICache(address, size, forced);
+		}
 	}
 
 	void CompileExceptionCheck(ExceptionType type)

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -623,123 +623,86 @@ void PPCAnalyzer::SetInstructionStats(CodeBlock *block, CodeOp *code, GekkoOPInf
 	}
 }
 
-u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 blockSize)
+u32 PPCAnalyzer::CollectInstructions(u32 address, CodeOp* code,
+                                     u32 max_block_size, bool inlining)
 {
-	// Clear block stats
-	memset(block->m_stats, 0, sizeof(BlockStats));
-
-	// Clear register stats
-	block->m_gpa->any = true;
-	block->m_fpa->any = false;
-
-	block->m_gpa->Clear();
-	block->m_fpa->Clear();
-
-	// Set the blocks start address
-	block->m_address = address;
-
-	// Reset our block state
-	block->m_broken = false;
-	block->m_memory_exception = false;
-	block->m_num_instructions = 0;
-	block->m_gqr_used = BitSet8(0);
-
-	CodeOp *code = buffer->codebuffer;
-
-	bool found_exit = false;
-	u32 return_address = 0;
-	u32 numFollows = 0;
-	u32 num_inst = 0;
+	u32 start_address = address;
+	u32 num_instrs = 0;
 	bool prev_inst_from_bat = true;
+	bool clean_inlining_exit = false;
 
-	for (u32 i = 0; i < blockSize; ++i)
+	while (num_instrs < max_block_size)
 	{
 		auto result = PowerPC::TryReadInstruction(address);
 		if (!result.valid)
-		{
-			if (i == 0)
-				block->m_memory_exception = true;
 			break;
-		}
 		UGeckoInstruction inst = result.hex;
 
 		// Slight hack: the JIT block cache currently assumes all blocks end at the same place,
 		// but broken blocks due to page faults break this assumption. Avoid this by just ending
 		// all virtual memory instruction blocks at page boundaries.
 		// FIXME: improve the JIT block cache so we don't need to do this.
-		if ((!result.from_bat || !prev_inst_from_bat) && i > 0 && (address & 0xfff) == 0)
-		{
+		if ((!result.from_bat || !prev_inst_from_bat) && address != start_address && (address & 0xfff) == 0)
 			break;
-		}
 		prev_inst_from_bat = result.from_bat;
 
-		num_inst++;
-		memset(&code[i], 0, sizeof(CodeOp));
+		CodeOp* this_code = code++;
+		memset(this_code, 0, sizeof(CodeOp));
 		GekkoOPInfo *opinfo = GetOpInfo(inst);
 
-		code[i].opinfo = opinfo;
-		code[i].address = address;
-		code[i].inst = inst;
-		code[i].branchTo = -1;
-		code[i].branchToIndex = -1;
-		code[i].skip = false;
-		block->m_stats->numCycles += opinfo->numCycles;
+		this_code->opinfo = opinfo;
+		this_code->address = address;
+		this_code->inst = inst;
+		this_code->branchTo = -1;
+		this_code->branchToIndex = -1;
+		this_code->skip = false;
 
-		SetInstructionStats(block, &code[i], opinfo, i);
+		// Blacklist inlining this block if it contains "dangerous" instructions.
+		// In particular, modifying LR is a no-no.
+		bool blr = (inst.hex == 0x4e800020);
+		if (inlining)
+		{
+			if (!blr && (opinfo->type == OPTYPE_SPR ||
+			             opinfo->type == OPTYPE_BRANCH ||
+			             opinfo->type == OPTYPE_SYSTEM))
+				break;
+		}
 
-		bool follow = false;
-		u32 destination = 0;
+		num_instrs++;
 
+		if (inlining && blr)
+		{
+			// Cleanly break the block -- we reached the inlined leaf function end.
+			this_code->isInlinedBLR = true;
+			clean_inlining_exit = true;
+			break;
+		}
+
+		bool try_inlining = false;
+		u32 branch_destination = 0;
 		bool conditional_continue = false;
 
-		// Do we inline leaf functions?
-		if (HasOption(OPTION_LEAF_INLINE))
+		// Do we inline leaf functions? Also refuse inlining several level deeps
+		// (for now -- it should be relatively easy to support, but it's not clear
+		// if that would ever be useful).
+		if (HasOption(OPTION_LEAF_INLINE) && !inlining)
 		{
-			if (inst.OPCD == 18 && blockSize > 1)
+			if (inst.OPCD == 18 && inst.LK && max_block_size > 1)
 			{
 				//Is bx - should we inline? yes!
 				if (inst.AA)
-					destination = SignExt26(inst.LI << 2);
+					branch_destination = SignExt26(inst.LI << 2);
 				else
-					destination = address + SignExt26(inst.LI << 2);
-				if (destination != block->m_address)
-					follow = true;
-			}
-			else if (inst.OPCD == 19 && inst.SUBOP10 == 16 &&
-				(inst.BO & (1 << 4)) && (inst.BO & (1 << 2)) &&
-				return_address != 0)
-			{
-				// bclrx with unconditional branch = return
-				follow = true;
-				destination = return_address;
-				return_address = 0;
-
-				if (inst.LK)
-					return_address = address + 4;
-			}
-			else if (inst.OPCD == 31 && inst.SUBOP10 == 467)
-			{
-				// mtspr
-				const u32 index = (inst.SPRU << 5) | (inst.SPRL & 0x1F);
-				if (index == SPR_LR)
-				{
-					// We give up to follow the return address
-					// because we have to check the register usage.
-					return_address = 0;
-				}
+					branch_destination = address + SignExt26(inst.LI << 2);
+				if (branch_destination != start_address)
+					try_inlining = true;
 			}
 
-			// TODO: Find the optimal value for FUNCTION_FOLLOWING_THRESHOLD.
-			//       If it is small, the performance will be down.
-			//       If it is big, the size of generated code will be big and
-			//       cache clearning will happen many times.
-			// TODO: Investivate the reason why
-			//       "0" is fastest in some games, MP2 for example.
-			if (numFollows > FUNCTION_FOLLOWING_THRESHOLD)
-				follow = false;
+			if (try_inlining && m_not_inlinable.find(branch_destination) != m_not_inlinable.end())
+				try_inlining = false;
 		}
 
-		if (HasOption(OPTION_CONDITIONAL_CONTINUE))
+		if (HasOption(OPTION_CONDITIONAL_CONTINUE) && !inlining)
 		{
 			if (inst.OPCD == 16 &&
 				((inst.BO & BO_DONT_DECREMENT_FLAG) == 0 || (inst.BO & BO_DONT_CHECK_CONDITION) == 0))
@@ -768,42 +731,95 @@ u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 
 			}
 		}
 
-		if (!follow)
+		bool inlined = false;
+		if (try_inlining)
 		{
-			address += 4;
+			u32 inlined_instrs = CollectInstructions(branch_destination, code,
+			                                         max_block_size - num_instrs, true);
+			if (inlined_instrs)
+			{
+				inlined = true;
+				code += inlined_instrs;
+				num_instrs += inlined_instrs;
+			}
+			else
+			{
+				m_not_inlinable.insert(branch_destination);
+			}
+		}
+
+		address += 4;
+		if (!inlined)
+		{
 			if (!conditional_continue && opinfo->flags & FL_ENDBLOCK) //right now we stop early
 			{
-				found_exit = true;
+				this_code->isExit = true;
 				break;
 			}
 		}
-		// XXX: We don't support inlining yet.
-#if 0
-		else
-		{
-			numFollows++;
-			// We don't "code[i].skip = true" here
-			// because bx may store a certain value to the link register.
-			// Instead, we skip a part of bx in Jit**::bx().
-			address = destination;
-			merged_addresses[size_of_merged_addresses++] = address;
-		}
-#endif
 	}
 
-	block->m_num_instructions = num_inst;
 
+	// If inlining, don't emit partial blocks. Only accept things that end
+	// cleanly.
+	if (inlining && !clean_inlining_exit)
+		return 0;
+
+	return num_instrs;
+}
+
+u32 PPCAnalyzer::Analyze(u32 address, CodeBlock *block, CodeBuffer *buffer, u32 blockSize)
+{
+	// Clear block stats
+	memset(block->m_stats, 0, sizeof(BlockStats));
+
+	// Clear register stats
+	block->m_gpa->any = true;
+	block->m_fpa->any = false;
+
+	block->m_gpa->Clear();
+	block->m_fpa->Clear();
+
+	// Set the blocks start address
+	block->m_address = address;
+
+	// Reset our block state
+	block->m_broken = false;
+	block->m_memory_exception = false;
+	block->m_num_instructions = 0;
+	block->m_gqr_used = BitSet8(0);
+
+	// Pass 1: collect instructions and potentially inline.
+	CodeOp *code = buffer->codebuffer;
+	block->m_num_instructions = CollectInstructions(
+			address, code, blockSize, false /* inlining */);
+	if (!block->m_num_instructions && blockSize)
+		block->m_memory_exception = true;
+
+	// Pass 2: compute number of cycles and other block stats.
+	//
+	// Note: in theory, this pass could be folded into pass 1. However, the
+	// recursive nature of pass 1 (to handle inlining) makes it harder to do so.
+	for (u32 i = 0; i < block->m_num_instructions; ++i)
+	{
+		block->m_stats->numCycles += code[i].opinfo->numCycles;
+		SetInstructionStats(block, &code[i], code[i].opinfo, i);
+	}
+
+	// Pass 3: reorder instructions.
 	if (block->m_num_instructions > 1)
 		ReorderInstructions(block->m_num_instructions, code);
 
-	if ((!found_exit && num_inst > 0) || blockSize == 1)
+	bool found_exit = code[block->m_num_instructions - 1].isExit;
+	if ((!found_exit && block->m_num_instructions > 0) || blockSize == 1)
 	{
 		// We couldn't find an exit
 		block->m_broken = true;
 	}
 
-	// Scan for flag dependencies; assume the next block (or any branch that can leave the block)
-	// wants flags, to be safe.
+	// Pass 4: scan for instruction dependencies (e.g. flags). Assume the next
+	// block (or any branch that can leave the block) wants these dependencies
+	// computed, to be safe.
 	bool wantsCR0 = true, wantsCR1 = true, wantsFPRF = true, wantsCA = true;
 	BitSet32 fprInUse, gprInUse, gprInReg, fprInXmm;
 	for (int i = block->m_num_instructions - 1; i >= 0; i--)

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -93,7 +93,7 @@ CCodeWindow::CCodeWindow(const SConfig& _LocalCoreStartupParameter, CFrame *pare
 
 	m_aui_manager.SetManagedWindow(this);
 	m_aui_manager.SetFlags(wxAUI_MGR_DEFAULT | wxAUI_MGR_LIVE_RESIZE);
-	m_aui_manager.AddPane(m_aui_toolbar, wxAuiPaneInfo().ToolbarPane().Top().Floatable(false));
+	m_aui_manager.AddPane(m_aui_toolbar, wxAuiPaneInfo().ToolbarPane().Top().Floatable(false).MinSize(-1, 50));
 	m_aui_manager.AddPane(callstack, wxAuiPaneInfo().MinSize(150, 100).Left().CloseButton(false).Floatable(false).Caption(_("Callstack")));
 	m_aui_manager.AddPane(symbols, wxAuiPaneInfo().MinSize(150, 100).Left().CloseButton(false).Floatable(false).Caption(_("Symbols")));
 	m_aui_manager.AddPane(calls, wxAuiPaneInfo().MinSize(150, 100).Left().CloseButton(false).Floatable(false).Caption(_("Function calls")));

--- a/Source/Core/DolphinWX/Debugger/JitWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.cpp
@@ -86,6 +86,10 @@ void CJitWindow::Compare(u32 em_address)
 	PPCAnalyst::CodeBlock code_block;
 	PPCAnalyst::PPCAnalyzer analyzer;
 	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_LEAF_INLINE);
+	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_BRANCH_MERGE);
+	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CROR_MERGE);
+	analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CARRY_MERGE);
 
 	code_block.m_stats = &st;
 	code_block.m_gpa = &gpa;


### PR DESCRIPTION
VERY WIP, don't even bother reviewing. I can't get buildbot-try to work, I'm just using that PR for automagic builds.

But the tl;dr is this inlines leaf functions, avoiding back-and-forth dispatcher jumps in many situations. It will also be potentially very useful in the future for automated idle skipping detection.

This is missing the harder part of the problem though: how to implement invalidation of inlined blocks. But hey, it's a start. So because of this, don't expect this change to work in many games. It works in TWW, barely.