### PR TITLE
BitField: Enable ifdef'd out code for Windows

### DIFF
--- a/Source/Core/Common/BitField.h
+++ b/Source/Core/Common/BitField.h
@@ -115,35 +115,25 @@ template<std::size_t position, std::size_t bits, typename T>
 struct BitField
 {
 private:
-#ifndef _WIN32
 	// This constructor might be considered ambiguous:
 	// Would it initialize the storage or just the bitfield?
 	// Hence, delete it. Use the assignment operator to set bitfield values!
-	// MSVC 2013 Intellisense complains that this declaration isn't allowed
-	// in a union member, so disable it on Windows.
 	BitField(T val) = delete;
-#endif
 
 public:
 	// Force default constructor to be created
 	// so that we can use this within unions
 	BitField() = default;
 
-#ifndef _WIN32
 	// We explicitly delete the copy assignment operator here, because the
 	// default copy assignment would copy the full storage value, rather than
 	// just the bits relevant to this particular bit field.
 	// Ideally, we would just implement the copy assignment to copy only the
 	// relevant bits, but this requires compiler support for unrestricted
 	// unions.
-	// MSVC 2013 has no support for this, hence we disable this code on
-	// Windows (so that the default copy assignment operator will be used).
-	// For any C++11 conformant compiler we delete the operator to make sure
-	// we never use this inappropriate operator to begin with.
 	// TODO: Implement this operator properly once all target compilers
 	// support unrestricted unions.
 	BitField& operator=(const BitField&) = delete;
-#endif
 
 	__forceinline BitField& operator=(T val)
 	{

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -1077,7 +1077,7 @@ void Renderer::SetGenerationMode()
 
 void Renderer::SetDepthMode()
 {
-	gx_state.zmode = bpmem.zmode;
+	gx_state.zmode.hex = bpmem.zmode.hex;
 }
 
 void Renderer::SetLogicOpMode()


### PR DESCRIPTION
These ifdefs can be removed since MSVC now supports these.