### PR TITLE
CommonFuncs: Remove define for snprintf

### DIFF
--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -77,7 +77,6 @@ inline u64 _rotr64(u64 x, unsigned int shift)
 	#define strcasecmp _stricmp
 	#define strncasecmp _strnicmp
 	#define unlink _unlink
-	#define snprintf _snprintf
 	#define vscprintf _vscprintf
 
 // 64 bit offsets for Windows


### PR DESCRIPTION
VS 2015 implements snprintf with the correct C99 name, so this isn't necessary anymore.