### PR TITLE
Make efb2tex behave much more like efb2ram.

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -19,6 +19,8 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "VideoCommon/BPMemory.h"
 
+bool IsPlayingBackFifologWithBrokenEFBCopies = false;
+
 FifoPlayer::~FifoPlayer()
 {
 	delete m_File;
@@ -61,6 +63,9 @@ bool FifoPlayer::Play()
 	if (m_File->GetFrameCount() == 0)
 		return false;
 
+	// Currently these is no such thing as a Fifolog without broken EFB copies.
+	IsPlayingBackFifologWithBrokenEFBCopies = true;
+
 	m_CurrentFrame = m_FrameRangeStart;
 
 	LoadMemory();
@@ -99,6 +104,8 @@ bool FifoPlayer::Play()
 			}
 		}
 	}
+
+	IsPlayingBackFifologWithBrokenEFBCopies = false;
 
 	return true;
 }

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -13,6 +13,33 @@ class FifoDataFile;
 struct MemoryUpdate;
 struct AnalyzedFrameInfo;
 
+// Story time:
+// When FifoRecorder was created, efb copies weren't really used or they used efb2tex which ignored
+// the underlying memory, so FifoRecorder didn't do anything special about the memory backing efb
+// copies. This means the memory underlying efb copies go treated like regular textures and was
+// baked into the fifo log. If you recorded with efb2ram on, the result of efb2ram would be baked
+// into the fifo. If you recorded with efb2tex or efb off, random data would be included in the fifo
+// log.
+// Later the behaviour of efb2tex was changed to zero the underlying memory and check the hash of that.
+// But this broke a whole lot of fifologs due to the following sequence of events:
+//    1. fifoplayer would trigger the efb copy
+//    2. Texture cache would zero the memory backing the texture and hash it.
+//    3. Time passes.
+//    4. fifoplayer would encounter the drawcall using the efb copy
+//    5. fifoplayer would overwrite the memory backing the efb copy back to it's state when recording.
+//    6. Texture cache would hash the memory and see that the hash no-longer matches
+//    7. Texture cache would load whatever data was now in memory as a texture either a baked in
+//       efb2ram copy from recording time or just random data.
+//    8. The output of fifoplayer would be wrong.
+
+// To keep compatibility with old fifologs, we have this flag which signals texture cache to not bother
+// hashing the memory and just assume the hash matched.
+// At a later point proper efb copy support should be added to fiforecorder and this flag will change
+// based on the version of the .dff file, but until then it will always be true when a fifolog is playing.
+
+// Shitty global to fix a shitty problem
+extern bool IsPlayingBackFifologWithBrokenEFBCopies;
+
 class FifoPlayer
 {
 public:

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -237,10 +237,10 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, unsigned int dstFormat
 
 	g_renderer->RestoreAPIState();
 
-	if (!g_ActiveConfig.bSkipEFBCopyToRam)
-	{
+	if (g_ActiveConfig.bSkipEFBCopyToRam)
+		this->Zero(dst);
+	else
 		g_encoder->Encode(dst, this, srcFormat, srcRect, isIntensity, scaleByHalf);
-	}
 }
 
 const char palette_shader[] =

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -262,7 +262,11 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dstPointer, unsigned int ds
 
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-	if (!g_ActiveConfig.bSkipEFBCopyToRam)
+	if (g_ActiveConfig.bSkipEFBCopyToRam)
+	{
+		this->Zero(dstPointer);
+	}
+	else
 	{
 		TextureConverter::EncodeToRamFromTexture(
 			dstPointer,

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -10,6 +10,7 @@
 #include "Common/StringUtil.h"
 
 #include "Core/ConfigManager.h"
+#include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/HW/Memmap.h"
 
 #include "VideoCommon/Debugger.h"
@@ -441,7 +442,8 @@ TextureCache::TCacheEntryBase* TextureCache::Load(const u32 stage)
 		{
 			// EFB copies have slightly different rules as EFB copy formats have different
 			// meanings from texture formats.
-			if (tex_hash == entry->hash && (!isPaletteTexture || g_Config.backend_info.bSupportsPaletteConversion))
+			if ((tex_hash == entry->hash && (!isPaletteTexture || g_Config.backend_info.bSupportsPaletteConversion)) ||
+				IsPlayingBackFifologWithBrokenEFBCopies)
 			{
 				// TODO: We should check format/width/height/levels for EFB copies. Checking
 				// format is complicated because EFB copy formats don't exactly match

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1014,7 +1014,10 @@ void TextureCache::CopyRenderTargetToTexture(u32 dstAddr, unsigned int dstFormat
 
 	entry->hash = GetHash64(dst, (int)entry->size_in_bytes, g_ActiveConfig.iSafeTextureCache_ColorSamples);
 
-	// Invalidate all textures that overlap the range of our texture
+	// Invalidate all textures that overlap the range of our efb copy.
+	// Unless our efb copy has a weird stride, then we want avoid invalidating textures which
+	// we might be able to do a partial texture update on.
+	if (entry->memory_stride == entry->CacheLinesPerRow() * 32)
 	{
 		TexCache::iterator iter = textures_by_address.begin();
 		while (iter != textures_by_address.end())

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -111,7 +111,7 @@ public:
 		u32 NumBlocksY() const;
 		u32 CacheLinesPerRow() const;
 
-		void Memset(u8* ptr, u32 tag);
+		void Zero(u8* ptr);
 	};
 
 	virtual ~TextureCache(); // needs virtual for DX11 dtor


### PR DESCRIPTION
The efb2tex code path is now almost identical to the efb2ram code path.
The main difference is efb2tex writes zeros to ram while efb2ram writes actual texture data to ram.

efb2tex now hashes the (zeroed) ram supporting it and invalidates itself if something overwrites it, fixing issues where an efb2tex texture could permanently replace a normal texture that was later loaded into the same address as that efb2tex texture. 

Also, efb2tex now invalidates any textures that overlap with the copy, especially other efb2tex copies, preventing efb2tex memory leaks in certain games.