### PR TITLE
Implement ClearCurrent on the EGL GLInterface

### DIFF
--- a/Source/Core/VideoBackends/OGL/GLInterface/EGL.cpp
+++ b/Source/Core/VideoBackends/OGL/GLInterface/EGL.cpp
@@ -201,6 +201,12 @@ bool cInterfaceEGL::MakeCurrent()
 {
 	return eglMakeCurrent(egl_dpy, egl_surf, egl_surf, egl_ctx);
 }
+
+bool cInterfaceEGL::ClearCurrent()
+{
+	return eglMakeCurrent(egl_dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+}
+
 // Close backend
 void cInterfaceEGL::Shutdown()
 {

--- a/Source/Core/VideoBackends/OGL/GLInterface/EGL.h
+++ b/Source/Core/VideoBackends/OGL/GLInterface/EGL.h
@@ -28,5 +28,6 @@ public:
 	void* GetFuncAddress(const std::string& name);
 	bool Create(void *window_handle);
 	bool MakeCurrent();
+	bool ClearCurrent();
 	void Shutdown();
 };


### PR DESCRIPTION
This fixes an error on GLInterface shutdown when using EGL.