### PR TITLE
Support EXT_blend_func_extended in GLES.

### DIFF
--- a/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/VideoBackends/OGL/GLExtensions/GLExtensions.cpp
@@ -1299,6 +1299,10 @@ const GLFunc gl_function_array[] =
 	// EXT_texture_buffer
 	GLFUNC_SUFFIX(glTexBuffer, EXT, "GL_EXT_texture_buffer !GL_OES_texture_buffer !VERSION_GLES_3_2"),
 
+	// EXT_blend_func_extended
+	GLFUNC_SUFFIX(glBindFragDataLocationIndexed, EXT, "GL_EXT_blend_func_extended"),
+	GLFUNC_SUFFIX(glGetFragDataIndex, EXT,            "GL_EXT_blend_func_extended"),
+
 	// GLES 3.2
 	GLFUNC_REQUIRES(glMinSampleShading,        "VERSION_GLES_3_2"),
 	GLFUNC_REQUIRES(glDebugMessageCallback,    "VERSION_GLES_3_2"),

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -560,6 +560,7 @@ void ProgramShaderCache::CreateHeader()
 		"%s\n" // AEP
 		"%s\n" // texture buffer
 		"%s\n" // ES texture buffer
+		"%s\n" // ES dual source blend
 
 		// Precision defines for GLSL ES
 		"%s\n"
@@ -599,6 +600,7 @@ void ProgramShaderCache::CreateHeader()
 		, g_ogl_config.bSupportsAEP ? "#extension GL_ANDROID_extension_pack_es31a : enable" : ""
 		, v<GLSL_140 && g_ActiveConfig.backend_info.bSupportsPaletteConversion ? "#extension GL_ARB_texture_buffer_object : enable" : ""
 		, SupportedESTextureBuffer.c_str()
+		, is_glsles && g_ActiveConfig.backend_info.bSupportsDualSourceBlend ? "#extension GL_EXT_blend_func_extended : enable" : ""
 
 		, is_glsles ? "precision highp float;" : ""
 		, is_glsles ? "precision highp int;" : ""

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -460,7 +460,8 @@ Renderer::Renderer()
 		glClearDepthf = ClearDepthf;
 	}
 
-	g_Config.backend_info.bSupportsDualSourceBlend = GLExtensions::Supports("GL_ARB_blend_func_extended");
+	g_Config.backend_info.bSupportsDualSourceBlend = GLExtensions::Supports("GL_ARB_blend_func_extended") ||
+	                                                 GLExtensions::Supports("GL_EXT_blend_func_extended");
 	g_Config.backend_info.bSupportsPrimitiveRestart = !DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVERESTART) &&
 				((GLExtensions::Version() >= 310) || GLExtensions::Supports("GL_NV_primitive_restart"));
 	g_Config.backend_info.bSupportsEarlyZ = GLExtensions::Supports("GL_ARB_shader_image_load_store");


### PR DESCRIPTION
This lets us get dual source blending on GLES targets.