### PR TITLE
Add missing INI file for SMB: The Lost Levels

### DIFF
--- a/Data/Sys/GameSettings/FB2.ini
+++ b/Data/Sys/GameSettings/FB2.ini
@@ -1,0 +1,29 @@
+# FB2E01, FB2P01 - Super Mario Bros. The Lost Levels
+
+[Core]
+# Values set here will override the main Dolphin settings.
+
+[EmuState]
+# The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
+EmulationIssues = Texture filtering will cause glitches.
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+
+[Video_Settings]
+SafeTextureCacheColorSamples = 0
+EFBScale = 2
+
+[Video_Hacks]
+EFBToTextureEnable = False
+
+[Video_Enhancements]
+MaxAnisotropy = 0
+ForceFiltering = False


### PR DESCRIPTION
Lost Levels NES VC game was missing an INI file and prevented it from
displaying anything but a black screen. This seems to get the graphics
working.

Played though 1-2 without issue.