### PR TITLE
Revert "Merge pull request #2943 from booto/vi-enb"

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -110,7 +110,7 @@ void Preset(bool _bNTSC)
 	m_VerticalTimingRegister.EQU = 6;
 	m_VerticalTimingRegister.ACV = 0;
 
-	m_DisplayControlRegister.ENB = 0;
+	m_DisplayControlRegister.ENB = 1;
 	m_DisplayControlRegister.FMT = _bNTSC ? 0 : 1;
 
 	m_HTiming0.HLW = 429;
@@ -605,9 +605,6 @@ static void EndField()
 // Run when: When a frame is scanned (progressive/interlace)
 void Update()
 {
-	if (!m_DisplayControlRegister.ENB)
-		return;
-
 	if (s_half_line_count == s_even_field_first_hl)
 	{
 		BeginField(FIELD_EVEN);


### PR DESCRIPTION
This reverts commit 8dd80b8e970c9da306892862bb09329d231aacc4, reversing
changes made to c5979b47be1cf508f3624e5d939462b706a06cda.

Having ENB disabled causes VIInit to go craze and reset to NTSC (regardless of region), which then causes the legit VIConfigure to PAL to fail.