### PR TITLE
DolphinWX: Don't use IsElfOrDol outside of ISOFile

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -875,16 +875,13 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
 				else if (selected_iso->GetFileName().substr(selected_iso->GetFileName().find_last_of(".")) != ".ciso" &&
 				         selected_iso->GetFileName().substr(selected_iso->GetFileName().find_last_of(".")) != ".wbfs")
 					popupMenu.Append(IDM_COMPRESS_ISO, _("Compress ISO..."));
-			}
-			if (platform == DiscIO::IVolume::WII_WAD)
-			{
-				popupMenu.Append(IDM_LIST_INSTALL_WAD, _("Install to Wii Menu"));
-			}
-			if (platform == DiscIO::IVolume::GAMECUBE_DISC || platform == DiscIO::IVolume::WII_DISC)
-			{
+
 				wxMenuItem* changeDiscItem = popupMenu.Append(IDM_LIST_CHANGE_DISC, _("Change &Disc"));
 				changeDiscItem->Enable(Core::IsRunning());
 			}
+
+			if (platform == DiscIO::IVolume::WII_WAD)
+				popupMenu.Append(IDM_LIST_INSTALL_WAD, _("Install to Wii Menu"));
 
 			PopupMenu(&popupMenu);
 		}

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -843,31 +843,32 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
 		if (selected_iso)
 		{
 			wxMenu popupMenu;
+			DiscIO::IVolume::EPlatform platform = selected_iso->GetPlatform();
 
-			if (!selected_iso->IsElfOrDol())
+			if (platform != DiscIO::IVolume::ELF_DOL)
 			{
 				popupMenu.Append(IDM_PROPERTIES, _("&Properties"));
 				popupMenu.Append(IDM_GAME_WIKI, _("&Wiki"));
 				popupMenu.AppendSeparator();
 			}
-			if (selected_iso->GetPlatform() != DiscIO::IVolume::GAMECUBE_DISC && !selected_iso->IsElfOrDol())
+			if (platform == DiscIO::IVolume::WII_DISC || platform == DiscIO::IVolume::WII_WAD)
 			{
 				popupMenu.Append(IDM_OPEN_SAVE_FOLDER, _("Open Wii &save folder"));
 				popupMenu.Append(IDM_EXPORT_SAVE, _("Export Wii save (Experimental)"));
 			}
 			popupMenu.Append(IDM_OPEN_CONTAINING_FOLDER, _("Open &containing folder"));
 
-			if (!selected_iso->IsElfOrDol())
+			if (platform != DiscIO::IVolume::ELF_DOL)
 				popupMenu.AppendCheckItem(IDM_SET_DEFAULT_ISO, _("Set as &default ISO"));
 
 			// First we have to decide a starting value when we append it
-			if (selected_iso->GetFileName() == SConfig::GetInstance().m_strDefaultISO)
+			if (platform == SConfig::GetInstance().m_strDefaultISO)
 				popupMenu.FindItem(IDM_SET_DEFAULT_ISO)->Check();
 
 			popupMenu.AppendSeparator();
 			popupMenu.Append(IDM_DELETE_ISO, _("&Delete File..."));
 
-			if (selected_iso->GetPlatform() != DiscIO::IVolume::WII_WAD && !selected_iso->IsElfOrDol())
+			if (platform == DiscIO::IVolume::GAMECUBE_DISC || platform == DiscIO::IVolume::WII_DISC)
 			{
 				if (selected_iso->IsCompressed())
 					popupMenu.Append(IDM_COMPRESS_ISO, _("Decompress ISO..."));
@@ -875,12 +876,11 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
 				         selected_iso->GetFileName().substr(selected_iso->GetFileName().find_last_of(".")) != ".wbfs")
 					popupMenu.Append(IDM_COMPRESS_ISO, _("Compress ISO..."));
 			}
-			else if (!selected_iso->IsElfOrDol())
+			if (platform == DiscIO::IVolume::WII_WAD)
 			{
 				popupMenu.Append(IDM_LIST_INSTALL_WAD, _("Install to Wii Menu"));
 			}
-			if (selected_iso->GetPlatform() == DiscIO::IVolume::GAMECUBE_DISC ||
-				selected_iso->GetPlatform() == DiscIO::IVolume::WII_DISC)
+			if (platform == DiscIO::IVolume::GAMECUBE_DISC || platform == DiscIO::IVolume::WII_DISC)
 			{
 				wxMenuItem* changeDiscItem = popupMenu.Append(IDM_LIST_CHANGE_DISC, _("Change &Disc"));
 				changeDiscItem->Enable(Core::IsRunning());

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
@@ -193,7 +194,22 @@ void GameListItem::DoState(PointerWrap &p)
 	p.Do(m_Revision);
 }
 
-std::string GameListItem::CreateCacheFilename()
+bool GameListItem::IsElfOrDol() const
+{
+	const std::string name = GetName();
+	const size_t pos = name.rfind('.');
+
+	if (pos != std::string::npos)
+	{
+		std::string ext = name.substr(pos);
+		std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+
+		return ext == ".elf" || ext == ".dol";
+	}
+	return false;
+}
+
+std::string GameListItem::CreateCacheFilename() const
 {
 	std::string Filename, LegalPathname, extension;
 	SplitPath(m_FileName, &LegalPathname, &Filename, &extension);
@@ -293,20 +309,4 @@ const std::string GameListItem::GetWiiFSPath() const
 	delete iso;
 
 	return ret;
-}
-
-bool GameListItem::IsElfOrDol() const
-{
-	const std::string name = GetName();
-	const size_t pos = name.rfind('.');
-
-	if (pos != std::string::npos)
-	{
-		std::string ext = name.substr(pos);
-		std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-
-		return ext == ".elf" ||
-		       ext == ".dol";
-	}
-	return false;
 }

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -43,7 +43,6 @@ public:
 	u64 GetVolumeSize() const {return m_VolumeSize;}
 	// 0 is the first disc, 1 is the second disc
 	u8 GetDiscNumber() const { return m_disc_number; }
-	bool IsElfOrDol() const;
 
 #if defined(HAVE_WX) && HAVE_WX
 	const wxBitmap& GetBitmap() const {return m_Bitmap;}
@@ -82,7 +81,8 @@ private:
 	bool LoadFromCache();
 	void SaveToCache();
 
-	std::string CreateCacheFilename();
+	bool IsElfOrDol() const;
+	std::string CreateCacheFilename() const;
 
 	void ReadBanner(const DiscIO::IVolume& volume);
 };


### PR DESCRIPTION
It's redundant because GetPlatform can do the same thing.