### PR TITLE
Common: Alter semantics of the NonCopyable mixin

### DIFF
--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -60,12 +60,12 @@ extern const char *netplay_dolphin_ver;
 class NonCopyable
 {
 protected:
-	NonCopyable() {}
-	NonCopyable(const NonCopyable&&) {}
-	void operator=(const NonCopyable&&) {}
+	constexpr NonCopyable() = default;
+	~NonCopyable() = default;
+
 private:
-	NonCopyable(NonCopyable&);
-	NonCopyable& operator=(NonCopyable& other);
+	NonCopyable(NonCopyable&) = delete;
+	NonCopyable& operator=(NonCopyable&) = delete;
 };
 
 #if defined _WIN32


### PR DESCRIPTION
Uses delete to make the unimplemented functions detectable at compile time and not link time if they are used.

The move constructor and assignment operator are removed as moves are not copies, but transfers of ownership, which isn't suited for this class.