### PR TITLE
EXI_DeviceIPL: Get rid of a pointer cast

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.h
@@ -64,6 +64,8 @@ private:
 	std::string m_buffer;
 	bool m_FontsLoaded;
 
+	void UpdateRTC();
+
 	void TransferByte(u8& _uByte) override;
 	bool IsWriteCommand() const { return !!(m_uAddress & (1 << 31)); }
 	u32 CommandRegion() const { return (m_uAddress & ~(1 << 31)) >> 8; }


### PR DESCRIPTION
Also moves the RTC updating code to its own function.