### PR TITLE
DolphinQt: Support ELF and DOL files in the game list

### DIFF
--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -73,7 +73,8 @@ GameFile::GameFile(const QString& fileName)
     : m_file_name(fileName)
 {
 	QFileInfo info(m_file_name);
-	m_folder_name = info.absoluteDir().dirName();
+	QDir directory = info.absoluteDir();
+	m_folder_name = directory.dirName();
 
 	if (LoadFromCache())
 	{
@@ -140,6 +141,16 @@ GameFile::GameFile(const QString& fileName)
 		m_file_size = info.size();
 		m_platform = DiscIO::IVolume::ELF_DOL;
 	}
+
+	// PNG files can optionally be used as banners. Typical for DOLs and ELFs, but also works with
+	// volumes. icon.png is the file name used by Homebrew Channel. The ability to use a PNG file
+	// with the same name as the main file is provided as an alternative for those who want to have
+	// multiple files in one folder instead of having a Homebrew Channel-style folder structure.
+	QImage banner(directory.filePath(info.baseName() + SL(".png")));
+	if (banner.isNull())
+		banner.load(directory.filePath(SL("icon.png")));
+	if (!banner.isNull())
+		m_banner = QPixmap::fromImage(banner);
 }
 
 bool GameFile::LoadFromCache()
@@ -259,6 +270,7 @@ QString GameFile::CreateCacheFilename() const
 	return fullname;
 }
 
+// Outputs to m_banner
 void GameFile::ReadBanner(const DiscIO::IVolume& volume)
 {
 	int width, height;

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -66,7 +66,7 @@ private:
 	quint64 m_file_size = 0;
 	quint64 m_volume_size = 0;
 
-	DiscIO::IVolume::ECountry m_country;
+	DiscIO::IVolume::ECountry m_country = DiscIO::IVolume::COUNTRY_UNKNOWN;
 	DiscIO::IVolume::EPlatform m_platform;
 	u16 m_revision = 0;
 
@@ -78,7 +78,8 @@ private:
 	bool LoadFromCache();
 	void SaveToCache();
 
-	QString CreateCacheFilename();
+	bool IsElfOrDol() const;
+	QString CreateCacheFilename() const;
 
 	void ReadBanner(const DiscIO::IVolume& volume);
 };

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -83,4 +83,7 @@ private:
 
 	// Outputs to m_banner
 	void ReadBanner(const DiscIO::IVolume& volume);
+	// Outputs to m_short_names, m_long_names, m_descriptions, m_company.
+	// Returns whether a file was found, not whether it contained useful data.
+	bool ReadXML(const QString& file_path);
 };

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -81,5 +81,6 @@ private:
 	bool IsElfOrDol() const;
 	QString CreateCacheFilename() const;
 
+	// Outputs to m_banner
 	void ReadBanner(const DiscIO::IVolume& volume);
 };

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -102,6 +102,11 @@ void DGameTracker::ScanForGames()
 	}
 	if (SConfig::GetInstance().m_ListWad)
 		exts.push_back("*.wad");
+	if (SConfig::GetInstance().m_ListElfDol)
+	{
+		exts.push_back("*.dol");
+		exts.push_back("*.elf");
+	}
 
 	auto rFilenames = DoFileSearch(exts, SConfig::GetInstance().m_ISOFolder, SConfig::GetInstance().m_RecursiveISOFolder);
 	QList<GameFile*> newItems;

--- a/Source/Core/DolphinQt/Utils/Resources.cpp
+++ b/Source/Core/DolphinQt/Utils/Resources.cpp
@@ -40,7 +40,7 @@ void Resources::Init()
 	m_regions[DiscIO::IVolume::COUNTRY_WORLD].load(GIFN("Flag_Europe")); // Uses European flag as a placeholder
 	m_regions[DiscIO::IVolume::COUNTRY_UNKNOWN].load(GIFN("Flag_Unknown"));
 
-	m_platforms.resize(3);
+	m_platforms.resize(4);
 	m_platforms[0].load(GIFN("Platform_Gamecube"));
 	m_platforms[1].load(GIFN("Platform_Wii"));
 	m_platforms[2].load(GIFN("Platform_Wad"));
@@ -78,6 +78,8 @@ void Resources::UpdatePixmaps()
 	// TODO: toolbar[MEMCARD];
 	// TODO: toolbar[HOTKEYS];
 	m_pixmaps[BANNER_MISSING].load(GIFN("nobanner"));
+	// TODO: Make this consistent with the other files
+	m_platforms[3].load(GIFN("fileplatform"));
 }
 
 QString Resources::GetImageFilename(QString name, QString dir)


### PR DESCRIPTION
Like in wx, except also with the things that I didn't know how to do in wx: XML metadata and non-terrible scaling!

![](https://cloud.githubusercontent.com/assets/6716818/9706557/60a74d36-54e8-11e5-86fc-5b028985db2a.png)

As you can see in the screenshot, HBC banners are a bit more narrow than standard banners. Also, you might be wondering about the three entries I have that lack metadata. The Helium Boy XML file fails to be parsed because it incorrectly claims to use XML version 0.9. The other two entries are ones that I simply don't have any PNG or XML files for.