### PR TITLE
Fix build error with -Werror=format-security

### DIFF
--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -313,7 +313,7 @@ bool ParsePartitionData(SPartition& _rPartition)
 		// Go through the filesystem and mark entries as used
 		for (SFileInfo file : filesystem->GetFileList())
 		{
-			DEBUG_LOG(DISCIO, file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
+			DEBUG_LOG(DISCIO, "%s", file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
 			// Just 1byte for directory? - it will end up reserving a cluster this way
 			if (file.m_NameOffset & 0x1000000)
 				MarkAsUsedE(_rPartition.Offset + _rPartition.Header.DataOffset, file.m_Offset, 1);


### PR DESCRIPTION
This is #2608 already applied in master.

The patch fixes this build error in stable, when building with `-Werror=format-security` which is enabled by default in package builds in many Linux distributions:

```
[ 16%] Building CXX object Source/Core/DiscIO/CMakeFiles/discio.dir/DiscScrubber.cpp.o
In file included from /home/james/deb-pkg/dolphin-emu/dolphin/Source/Core/Common/Common.h:152:0,
                 from /home/james/deb-pkg/dolphin-emu/dolphin/build/Source/CMakeFiles/pch.dir/pch.h:78,
                 from <command-line>:0:
/home/james/deb-pkg/dolphin-emu/dolphin/Source/Core/DiscIO/DiscScrubber.cpp: In function ‘bool DiscIO::DiscScrubber::ParsePartitionData(DiscIO::DiscScrubber::SPartition&)’:
/home/james/deb-pkg/dolphin-emu/dolphin/Source/Core/Common/Logging/Log.h:96:51: error: format not a string literal and no format arguments [-Werror=format-security]
   GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__); \
                                                   ^
/home/james/deb-pkg/dolphin-emu/dolphin/Source/Core/Common/Logging/Log.h:104:31: note: in expansion of macro ‘GENERIC_LOG’
 #define DEBUG_LOG(t,...) do { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__) } while (0)
                               ^
/home/james/deb-pkg/dolphin-emu/dolphin/Source/Core/DiscIO/DiscScrubber.cpp:316:4: note: in expansion of macro ‘DEBUG_LOG’
    DEBUG_LOG(DISCIO, file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
    ^
cc1plus: some warnings being treated as errors

```