### PR TITLE
OGL: reimplement SSAA based on ARB_gpu_shader5

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -559,6 +559,7 @@ void ProgramShaderCache::CreateHeader()
 		"%s\n" // Sampler binding
 		"%s\n" // storage buffer
 		"%s\n" // shader5
+		"%s\n" // SSAA
 		"%s\n" // Geometry point size
 		"%s\n" // AEP
 		"%s\n" // texture buffer
@@ -595,6 +596,7 @@ void ProgramShaderCache::CreateHeader()
 		, g_ActiveConfig.backend_info.bSupportsBindingLayout ? "#define SAMPLER_BINDING(x) layout(binding = x)" : "#define SAMPLER_BINDING(x)"
 		, g_ActiveConfig.backend_info.bSupportsBBox ? "#extension GL_ARB_shader_storage_buffer_object : enable" : ""
 		, v < GLSL_400 && g_ActiveConfig.backend_info.bSupportsGSInstancing ? "#extension GL_ARB_gpu_shader5 : enable" : ""
+		, v < GLSL_400 && g_ActiveConfig.backend_info.bSupportsSSAA ? "#extension GL_ARB_sample_shading : enable" : ""
 		, SupportedESPointSize.c_str()
 		, g_ogl_config.bSupportsAEP ? "#extension GL_ANDROID_extension_pack_es31a : enable" : ""
 		, v < GLSL_140 && g_ActiveConfig.backend_info.bSupportsPaletteConversion ? "#extension GL_ARB_texture_buffer_object : enable" : ""

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -437,6 +437,7 @@ Renderer::Renderer()
 	g_Config.backend_info.bSupportsEarlyZ = GLExtensions::Supports("GL_ARB_shader_image_load_store");
 	g_Config.backend_info.bSupportsBBox = GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
 	g_Config.backend_info.bSupportsGSInstancing = GLExtensions::Supports("GL_ARB_gpu_shader5");
+	g_Config.backend_info.bSupportsSSAA = GLExtensions::Supports("GL_ARB_gpu_shader5") && GLExtensions::Supports("GL_ARB_sample_shading");
 	g_Config.backend_info.bSupportsGeometryShaders = GLExtensions::Version() >= 320;
 	g_Config.backend_info.bSupportsPaletteConversion = GLExtensions::Supports("GL_ARB_texture_buffer_object") ||
 	                                                   GLExtensions::Supports("GL_OES_texture_buffer") ||
@@ -532,28 +533,25 @@ Renderer::Renderer()
 			g_ogl_config.eSupportedGLSLVersion = GLSL_130;
 			g_Config.backend_info.bSupportsEarlyZ = false; // layout keyword is only supported on glsl150+
 			g_Config.backend_info.bSupportsGeometryShaders = false; // geometry shaders are only supported on glsl150+
-			g_Config.backend_info.bSupportsSSAA = false; // sample shading is only supported on glsl400+
 		}
 		else if (strstr(g_ogl_config.glsl_version, "1.40"))
 		{
 			g_ogl_config.eSupportedGLSLVersion = GLSL_140;
 			g_Config.backend_info.bSupportsEarlyZ = false; // layout keyword is only supported on glsl150+
 			g_Config.backend_info.bSupportsGeometryShaders = false; // geometry shaders are only supported on glsl150+
-			g_Config.backend_info.bSupportsSSAA = false; // sample shading is only supported on glsl400+
 		}
 		else if (strstr(g_ogl_config.glsl_version, "1.50"))
 		{
 			g_ogl_config.eSupportedGLSLVersion = GLSL_150;
-			g_Config.backend_info.bSupportsSSAA = false; // sample shading is only supported on glsl400+
 		}
 		else if (strstr(g_ogl_config.glsl_version, "3.30"))
 		{
 			g_ogl_config.eSupportedGLSLVersion = GLSL_330;
-			g_Config.backend_info.bSupportsSSAA = false; // sample shading is only supported on glsl400+
 		}
 		else
 		{
 			g_ogl_config.eSupportedGLSLVersion = GLSL_400;
+			g_Config.backend_info.bSupportsSSAA = true;
 		}
 
 		// Desktop OpenGL can't have the Android Extension Pack


### PR DESCRIPTION
So i965 shall support it again. GLSL 4.00 is a by far bigger requirement than ARB_gpu_shader5