### PR TITLE
Partially revert "General: Toss out PRI macro usage"

### DIFF
--- a/Source/Core/Common/JitRegister.cpp
+++ b/Source/Core/Common/JitRegister.cpp
@@ -96,7 +96,7 @@ void RegisterV(const void* base_address, u32 code_size,
 	if (s_perf_map_file.IsOpen())
 	{
 		std::string entry = StringFromFormat(
-			"%llx %x %s\n",
+			"%" PRIx64 " %x %s\n",
 			(u64)base_address, code_size, symbol_name.data());
 		s_perf_map_file.WriteBytes(entry.data(), entry.size());
 	}

--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -64,9 +64,6 @@ void* AllocateExecutableMemory(size_t size, bool low)
 		, -1, 0);
 #endif /* defined(_WIN32) */
 
-	// printf("Mapped executable memory at %p (size %ld)\n", ptr,
-	//	(unsigned long)size);
-
 #ifdef _WIN32
 	if (ptr == nullptr)
 	{
@@ -84,7 +81,6 @@ void* AllocateExecutableMemory(size_t size, bool low)
 		{
 			map_hint += size;
 			map_hint = (char*)round_page(map_hint); /* round up to the next page */
-			// printf("Next map will (hopefully) be at %p\n", map_hint);
 		}
 	}
 #endif
@@ -124,9 +120,6 @@ void* AllocateAlignedMemory(size_t size, size_t alignment)
 	if (posix_memalign(&ptr, alignment, size) != 0)
 		ERROR_LOG(MEMMAP, "Failed to allocate aligned memory");
 #endif
-
-	// printf("Mapped memory at %p (size %ld)\n", ptr,
-	//	(unsigned long)size);
 
 	if (ptr == nullptr)
 		PanicAlert("Failed to allocate aligned memory");

--- a/Source/Core/Common/SDCardUtil.cpp
+++ b/Source/Core/Common/SDCardUtil.cpp
@@ -203,7 +203,7 @@ bool SDCardCreate(u64 disk_size /*in MB*/, const std::string& filename)
 
 	if (disk_size < 0x800000 || disk_size > 0x800000000ULL)
 	{
-		ERROR_LOG(COMMON, "Trying to create SD Card image of size %lluMB is out of range (8MB-32GB)", disk_size/(1024*1024));
+		ERROR_LOG(COMMON, "Trying to create SD Card image of size %" PRIu64 "MB is out of range (8MB-32GB)", disk_size/(1024*1024));
 		return false;
 	}
 

--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -20,8 +20,7 @@ void SymbolDB::List()
 		          func.second.size, func.second.hash,
 		          func.second.numCalls);
 	}
-	INFO_LOG(OSHLE, "%lu functions known in this program above.",
-	         (unsigned long)functions.size());
+	INFO_LOG(OSHLE, "%zu functions known in this program above.", functions.size());
 }
 
 void SymbolDB::Clear(const char *prefix)

--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -53,7 +53,7 @@ bool SysConf::LoadFromFile(const std::string& filename)
 	u64 size = File::GetSize(filename);
 	if (size != SYSCONF_SIZE)
 	{
-		if (AskYesNoT("Your SYSCONF file is the wrong size.\nIt should be 0x%04x (but is 0x%04llx)\nDo you want to generate a new one?",
+		if (AskYesNoT("Your SYSCONF file is the wrong size.\nIt should be 0x%04x (but is 0x%04" PRIx64 ")\nDo you want to generate a new one?",
 					SYSCONF_SIZE, size))
 		{
 			GenerateSysConf();

--- a/Source/Core/Common/Timer.cpp
+++ b/Source/Core/Common/Timer.cpp
@@ -147,7 +147,7 @@ std::string Timer::GetTimeElapsedFormatted() const
 	// Hours
 	u32 Hours = Minutes / 60;
 
-	std::string TmpStr = StringFromFormat("%02i:%02i:%02i:%03llu",
+	std::string TmpStr = StringFromFormat("%02i:%02i:%02i:%03" PRIu64,
 		Hours, Minutes % 60, Seconds % 60, Milliseconds % 1000);
 	return TmpStr;
 }

--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -236,7 +236,7 @@ void OpArg::WriteRest(XEmitter* emit, int extraBytes, X64Reg _operandReg,
 		             (distance < 0x80000000LL &&
 		              distance >=  -0x80000000LL) ||
 		             !warn_64bit_offset,
-		             "WriteRest: op out of range (0x%llx uses 0x%llx)",
+		             "WriteRest: op out of range (0x%" PRIx64 " uses 0x%" PRIx64 ")",
 		             ripAddr, offset);
 		s32 offs = (s32)distance;
 		emit->Write32((u32)offs);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -790,7 +790,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
 
 				// Use the TitleIDhex for name and/or unique ID if launching from nand folder
 				// or if it is not ascii characters (specifically sysmenu could potentially apply to other things)
-				std::string titleidstr = StringFromFormat("%016llx", ContentLoader.GetTitleID());
+				std::string titleidstr = StringFromFormat("%016" PRIx64, ContentLoader.GetTitleID());
 
 				if (m_strName.empty())
 				{

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -421,7 +421,7 @@ void LogPendingEvents()
 	Event *ptr = first;
 	while (ptr)
 	{
-		INFO_LOG(POWERPC, "PENDING: Now: %lld Pending: %lld Type: %d", globalTimer, ptr->time, ptr->type);
+		INFO_LOG(POWERPC, "PENDING: Now: %" PRId64 " Pending: %" PRId64 " Type: %d", globalTimer, ptr->time, ptr->type);
 		ptr = ptr->next;
 	}
 }
@@ -456,7 +456,7 @@ std::string GetScheduledEventsSummary()
 
 		const std::string& name = event_types[ptr->type].name;
 
-		text += StringFromFormat("%s : %lld %016llx\n", name.c_str(), ptr->time, ptr->userdata);
+		text += StringFromFormat("%s : %" PRIi64 " %016" PRIx64 "\n", name.c_str(), ptr->time, ptr->userdata);
 		ptr = ptr->next;
 	}
 	return text;

--- a/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.cpp
@@ -40,12 +40,12 @@ void ProfilerDump(u64 count)
 	File::IOFile pFile("DSP_Prof.txt", "wt");
 	if (pFile)
 	{
-		fprintf(pFile.GetHandle(), "Number of DSP steps: %llu\n\n", count);
+		fprintf(pFile.GetHandle(), "Number of DSP steps: %" PRIu64 "\n\n", count);
 		for (int i=0; i<PROFILE_MAP_SIZE;i++)
 		{
 			if (g_profileMap[i] > 0)
 			{
-				fprintf(pFile.GetHandle(), "0x%04X: %llu\n", i, g_profileMap[i]);
+				fprintf(pFile.GetHandle(), "0x%04X: %" PRIu64 "\n", i, g_profileMap[i]);
 			}
 		}
 	}

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -779,7 +779,7 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 
 	// Only used from WII_IPC. This is the only read command that decrypts data
 	case DVDLowRead:
-		INFO_LOG(DVDINTERFACE, "DVDLowRead: DVDAddr: 0x%09llx, Size: 0x%x", (u64)command_2 << 2, command_1);
+		INFO_LOG(DVDINTERFACE, "DVDLowRead: DVDAddr: 0x%09" PRIx64 ", Size: 0x%x", (u64)command_2 << 2, command_1);
 		read_command = ExecuteReadCommand((u64)command_2 << 2, output_address, command_1, output_length,
 		                                  true, &interrupt_type, &ticks_until_completion);
 		break;
@@ -846,7 +846,7 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 
 	// Probably only used by Wii
 	case DVDLowUnencryptedRead:
-		INFO_LOG(DVDINTERFACE, "DVDLowUnencryptedRead: DVDAddr: 0x%09llx, Size: 0x%x", (u64)command_2 << 2, command_1);
+		INFO_LOG(DVDINTERFACE, "DVDLowUnencryptedRead: DVDAddr: 0x%09" PRIx64 ", Size: 0x%x", (u64)command_2 << 2, command_1);
 
 		// We must make sure it is in a valid area! (#001 check)
 		// Are these checks correct? They seem to mix 32-bit offsets and 8-bit lengths
@@ -865,7 +865,7 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 		}
 		else
 		{
-			WARN_LOG(DVDINTERFACE, "DVDLowUnencryptedRead: trying to read out of bounds @ %09llx", (u64)command_2 << 2);
+			WARN_LOG(DVDINTERFACE, "DVDLowUnencryptedRead: trying to read out of bounds @ %09" PRIx64, (u64)command_2 << 2);
 			g_ErrorCode = ERROR_READY | ERROR_BLOCK_OOB;
 			// Should cause software to call DVDLowRequestError
 			interrupt_type = INT_BRKINT;
@@ -904,7 +904,7 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 			{
 				u64 iDVDOffset = (u64)command_1 << 2;
 
-				INFO_LOG(DVDINTERFACE, "Read: DVDOffset=%08llx, DMABuffer = %08x, SrcLength = %08x, DMALength = %08x",
+				INFO_LOG(DVDINTERFACE, "Read: DVDOffset=%08" PRIx64 ", DMABuffer = %08x, SrcLength = %08x, DMALength = %08x",
 					        iDVDOffset, output_address, command_2, output_length);
 
 				if (GCAM)
@@ -941,7 +941,7 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 								Memory::Write_U32(0x00000000, output_address + i);
 							break;
 						default:
-							ERROR_LOG(DVDINTERFACE, "GC-AM: UNKNOWN MEDIA BOARD LOCATION %llx", iDVDOffset);
+							ERROR_LOG(DVDINTERFACE, "GC-AM: UNKNOWN MEDIA BOARD LOCATION %" PRIx64, iDVDOffset);
 							break;
 						}
 						break;
@@ -1002,7 +1002,7 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 
 				while (len >= 4)
 				{
-					ERROR_LOG(DVDINTERFACE, "GC-AM Media Board WRITE (0xAA): %08llx: %08x", iDVDOffset, Memory::Read_U32(addr));
+					ERROR_LOG(DVDINTERFACE, "GC-AM Media Board WRITE (0xAA): %08" PRIx64 ": %08x", iDVDOffset, Memory::Read_U32(addr));
 					addr += 4;
 					len -= 4;
 					iDVDOffset += 4;
@@ -1014,7 +1014,7 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 				Memory::CopyFromEmu(media_buffer + offset, addr, len);
 				while (len >= 4)
 				{
-					ERROR_LOG(DVDINTERFACE, "GC-AM Media Board WRITE (0xAA): %08llx: %08x", iDVDOffset, Memory::Read_U32(addr));
+					ERROR_LOG(DVDINTERFACE, "GC-AM Media Board WRITE (0xAA): %08" PRIx64 ": %08x", iDVDOffset, Memory::Read_U32(addr));
 					addr += 4;
 					len -= 4;
 					iDVDOffset += 4;
@@ -1028,7 +1028,7 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 		if (!GCAM)
 		{
 			// Currently unimplemented
-			INFO_LOG(DVDINTERFACE, "Seek: offset=%09llx (ignoring)", (u64)command_1 << 2);
+			INFO_LOG(DVDINTERFACE, "Seek: offset=%09" PRIx64 " (ignoring)", (u64)command_1 << 2);
 		}
 		else
 		{
@@ -1190,7 +1190,7 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
 				}
 			}
 
-			INFO_LOG(DVDINTERFACE, "(Audio) Stream cmd: %08x offset: %08llx length: %08x",
+			INFO_LOG(DVDINTERFACE, "(Audio) Stream cmd: %08x offset: %08" PRIx64 " length: %08x",
 			         command_0, (u64)command_1 << 2, command_2);
 		}
 		break;
@@ -1357,7 +1357,7 @@ u64 SimulateDiscReadTime(u64 offset, u32 length)
 	if (offset + length - g_last_read_offset > 1024 * 1024)
 	{
 		// No buffer; just use the simple seek time + read time.
-		DEBUG_LOG(DVDINTERFACE, "Seeking %lld bytes",
+		DEBUG_LOG(DVDINTERFACE, "Seeking %" PRId64 " bytes",
 		          s64(g_last_read_offset) - s64(offset));
 		ticks_until_completion = disk_read_duration;
 		g_last_read_time = current_time + ticks_until_completion;
@@ -1378,20 +1378,20 @@ u64 SimulateDiscReadTime(u64 offset, u32 length)
 
 		if (current_time > buffer_fill_time)
 		{
-			DEBUG_LOG(DVDINTERFACE, "Fast buffer read at %llx", offset);
+			DEBUG_LOG(DVDINTERFACE, "Fast buffer read at %" PRIx64, offset);
 			ticks_until_completion = buffer_read_duration;
 			g_last_read_time = buffer_fill_time;
 		}
 		else if (current_time + disk_read_duration > buffer_fill_time)
 		{
-			DEBUG_LOG(DVDINTERFACE, "Slow buffer read at %llx", offset);
+			DEBUG_LOG(DVDINTERFACE, "Slow buffer read at %" PRIx64, offset);
 			ticks_until_completion = std::max(buffer_fill_time - current_time,
 			                                  buffer_read_duration);
 			g_last_read_time = buffer_fill_time;
 		}
 		else
 		{
-			DEBUG_LOG(DVDINTERFACE, "Short seek %lld bytes",
+			DEBUG_LOG(DVDINTERFACE, "Short seek %" PRId64 " bytes",
 			          s64(g_last_read_offset) - s64(offset));
 			ticks_until_completion = disk_read_duration;
 			g_last_read_time = current_time + ticks_until_completion;

--- a/Source/Core/Core/HW/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard.cpp
@@ -181,7 +181,7 @@ GCMemcard::GCMemcard(const std::string &filename, bool forceCreation, bool ascii
 		}
 		else
 		{
-			PanicAlertT("Failed to read block %u of the save data\nMemcard may be truncated\nFile position: 0x%llx", i, mcdFile.Tell());
+			PanicAlertT("Failed to read block %u of the save data\nMemcard may be truncated\nFile position: 0x%" PRIx64, i, mcdFile.Tell());
 			m_valid = false;
 			break;
 		}

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -85,7 +85,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::IVolume::EC
 		u64 file_size = gcifile.GetSize();
 		if (file_size != size + DENTRY_SIZE)
 		{
-			PanicAlertT("%s\nwas not loaded because it is an invalid GCI.\n File size (0x%llx"
+			PanicAlertT("%s\nwas not loaded because it is an invalid GCI.\n File size (0x%" PRIx64
 						") does not match the size recorded in the header (0x%x)",
 						gci.m_filename.c_str(), file_size, size + DENTRY_SIZE);
 			return NO_INDEX;

--- a/Source/Core/Core/HW/WiiSaveCrypted.cpp
+++ b/Source/Core/Core/HW/WiiSaveCrypted.cpp
@@ -88,7 +88,7 @@ void CWiiSaveCrypted::ExportAllSaves()
 			}
 		}
 	}
-	SuccessAlertT("Found %u save files", (unsigned int)titles.size());
+	SuccessAlertT("Found %zu save files", titles.size());
 	u32 success = 0;
 	for (const u64& title : titles)
 	{
@@ -176,7 +176,7 @@ void CWiiSaveCrypted::ReadHDR()
 	md5((u8*)&m_header, HEADER_SZ, md5_calc);
 	if (memcmp(md5_file, md5_calc, 0x10))
 	{
-		ERROR_LOG(CONSOLE, "MD5 mismatch\n %016llx%016llx != %016llx%016llx",
+		ERROR_LOG(CONSOLE, "MD5 mismatch\n %016" PRIx64 "%016" PRIx64 " != %016" PRIx64 "%016" PRIx64,
 			Common::swap64(md5_file),Common::swap64(md5_file + 8), Common::swap64(md5_calc),
 			Common::swap64(md5_calc + 8));
 		m_valid= false;
@@ -276,7 +276,7 @@ void CWiiSaveCrypted::ReadBKHDR()
 	}
 	if (m_title_id != Common::swap64(m_bk_hdr.SaveGameTitle))
 	{
-		WARN_LOG(CONSOLE, "Encrypted title (%llx) does not match unencrypted title (%llx)",
+		WARN_LOG(CONSOLE, "Encrypted title (%" PRIx64 ") does not match unencrypted title (%" PRIx64 ")",
 			m_title_id, Common::swap64(m_bk_hdr.SaveGameTitle));
 	}
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -162,7 +162,7 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
 			u64 const partition_offset = ((u64)Memory::Read_U32(CommandBuffer.InBuffer[0].m_Address + 4) << 2);
 			DVDInterface::ChangePartition(partition_offset);
 
-			INFO_LOG(WII_IPC_DVD, "DVDLowOpenPartition: partition_offset 0x%016llx", partition_offset);
+			INFO_LOG(WII_IPC_DVD, "DVDLowOpenPartition: partition_offset 0x%016" PRIx64, partition_offset);
 
 			// Read TMD to the buffer
 			u32 tmd_size;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -211,7 +211,7 @@ u32 CWII_IPC_HLE_Device_es::OpenTitleContent(u32 CFD, u64 TitleID, u16 Index)
 
 	if (!Loader.IsValid())
 	{
-		WARN_LOG(WII_IPC_ES, "ES: loader not valid for %llx", TitleID);
+		WARN_LOG(WII_IPC_ES, "ES: loader not valid for %" PRIx64, TitleID);
 		return 0xffffffff;
 	}
 
@@ -336,9 +336,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			else
 			{
 				Memory::Write_U32((u32)rNANDCOntent.GetContentSize(), _CommandAddress + 0x4);
-				INFO_LOG(WII_IPC_ES,
-					"IOCTL_ES_GETTITLECONTENTS: "
-					"Unable to open content %zu",
+				INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTITLECONTENTS: Unable to open content %zu",
 					rNANDCOntent.GetContentSize());
 			}
 
@@ -952,7 +950,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			if (!bSuccess)
 			{
 				PanicAlertT("IOCTL_ES_LAUNCH: Game tried to reload a title that is not available in your NAND dump\n"
-					"TitleID %016llx.\n Dolphin will likely hang now.", TitleID);
+					"TitleID %016" PRIx64".\n Dolphin will likely hang now.", TitleID);
 			}
 			else
 			{
@@ -993,7 +991,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			//TODO: provide correct return code when bSuccess= false
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
-			ERROR_LOG(WII_IPC_ES, "IOCTL_ES_LAUNCH %016llx %08x %016llx %08x %016llx %04x", TitleID,view,ticketid,devicetype,titleid,access);
+			ERROR_LOG(WII_IPC_ES, "IOCTL_ES_LAUNCH %016" PRIx64 " %08x %016" PRIx64 " %08x %016" PRIx64 " %04x", TitleID,view,ticketid,devicetype,titleid,access);
 			//                     IOCTL_ES_LAUNCH 0001000248414341 00000001 0001c0fef3df2cfa 00000000 0001000248414341 ffff
 
 			// This is necessary because Reset(true) above deleted this object.  Ew.

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -401,8 +401,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305::AddEventToQueue(const SQueuedEvent& _e
 		}
 		else // push new one, pop oldest
 		{
-			DEBUG_LOG(WII_IPC_WIIMOTE, "HCI endpoint not "
-				"currently valid, queueing (%zu)...",
+			DEBUG_LOG(WII_IPC_WIIMOTE, "HCI endpoint not currently valid, queueing (%zu)...",
 				m_EventQueue.size());
 			m_EventQueue.push_back(_event);
 			const SQueuedEvent& event = m_EventQueue.front();

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -62,7 +62,7 @@ static void Trace(UGeckoInstruction& instCode)
 	std::string fregs = "";
 	for (int i = 0; i < 32; i++)
 	{
-		fregs += StringFromFormat("f%02d: %08llx %08llx ", i, PowerPC::ppcState.ps[i][0], PowerPC::ppcState.ps[i][1]);
+		fregs += StringFromFormat("f%02d: %08" PRIx64 " %08" PRIx64 " ", i, PowerPC::ppcState.ps[i][0], PowerPC::ppcState.ps[i][1]);
 	}
 
 	std::string ppc_inst = GekkoDisassembler::Disassemble(instCode.hex, PC);

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -103,7 +103,7 @@ public:
 		if (IsBound(preg))
 			return regs[preg].location.GetSimpleReg();
 
-		PanicAlert("Unbounded register - %zu", preg);
+		PanicAlert("Unbound register - %zu", preg);
 		return Gen::INVALID_REG;
 	}
 	virtual Gen::OpArg GetDefaultLocation(size_t reg) const = 0;

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -216,14 +216,14 @@ namespace JitILProfiler
 			std::string filename = StringFromFormat("JitIL_profiling_%d.csv", (int)time(nullptr));
 			File::IOFile file(filename, "w");
 			setvbuf(file.GetHandle(), nullptr, _IOFBF, 1024 * 1024);
-			fprintf(file.GetHandle(), "code hash, total elapsed, number of calls, elapsed per call\n");
+			fprintf(file.GetHandle(), "code hash,total elapsed,number of calls,elapsed per call\n");
 			for (auto& block : blocks)
 			{
 				const u64 codeHash = block.codeHash;
 				const u64 totalElapsed = block.totalElapsed;
 				const u64 numberOfCalls = block.numberOfCalls;
 				const double elapsedPerCall = totalElapsed / (double)numberOfCalls;
-				fprintf(file.GetHandle(), "%016llx, %lld, %lld, %f\n", codeHash, totalElapsed, numberOfCalls, elapsedPerCall);
+				fprintf(file.GetHandle(), "%016" PRIx64 ",%" PRId64 ",%" PRId64 ",%f\n", codeHash, totalElapsed, numberOfCalls, elapsedPerCall);
 			}
 		}
 	};

--- a/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBackpatch.cpp
@@ -19,7 +19,7 @@ static void BackPatchError(const std::string &text, u8 *codePtr, u32 emAddress)
 	disasm.disasm64(0, code_addr, codePtr, disbuf);
 	PanicAlert("%s\n\n"
 		"Error encountered accessing emulated address %08x.\n"
-		"Culprit instruction: \n%s\nat %#llx",
+		"Culprit instruction: \n%s\nat %#" PRIx64,
 		text.c_str(), emAddress, disbuf, code_addr);
 	return;
 }

--- a/Source/Core/Core/PowerPC/JitILCommon/IR.cpp
+++ b/Source/Core/Core/PowerPC/JitILCommon/IR.cpp
@@ -1513,7 +1513,7 @@ void IRBuilder::WriteToFile(u64 codeHash)
 	}
 
 	FILE* const file = writer->file.GetHandle();
-	fprintf(file, "\ncode hash:%016llx\n", codeHash);
+	fprintf(file, "\ncode hash:%016" PRIx64 "\n", codeHash);
 
 	const InstLoc lastCurReadPtr = curReadPtr;
 	StartForwardPass();

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -124,7 +124,7 @@ namespace JitInterface
 			std::string name = g_symbolDB.GetDescription(stat.addr);
 			double percent = 100.0 * (double)stat.cost / (double)prof_stats.cost_sum;
 			double timePercent = 100.0 * (double)stat.tick_counter / (double)prof_stats.timecost_sum;
-			fprintf(f.GetHandle(), "%08x\t%s\t%llu\t%llu\t%llu\t%.2f\t%.2f\t%.2f\t%i\n",
+			fprintf(f.GetHandle(), "%08x\t%s\t%" PRIu64 "\t%" PRIu64 "\t%" PRIu64 "\t%.2f\t%.2f\t%.2f\t%i\n",
 					stat.addr, name.c_str(), stat.run_count, stat.cost,
 					stat.tick_counter, percent, timePercent,
 					(double)stat.tick_counter*1000.0/(double)prof_stats.countsPerSec, stat.block_size);

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -161,7 +161,7 @@ void PrintInstructionRunCounts()
 		if (inst.second == 0)
 			break;
 
-		DEBUG_LOG(POWERPC, "%s : %llu", inst.first, inst.second);
+		DEBUG_LOG(POWERPC, "%s : %" PRIu64, inst.first, inst.second);
 	}
 }
 
@@ -175,7 +175,7 @@ void LogCompiledInstructions()
 		GekkoOPInfo *pInst = m_allInstructions[i];
 		if (pInst->compileCount > 0)
 		{
-			fprintf(f.GetHandle(), "%s\t%i\t%lld\t%08x\n", pInst->opname,
+			fprintf(f.GetHandle(), "%s\t%i\t%" PRId64 "\t%08x\n", pInst->opname,
 				pInst->compileCount, pInst->runCount, pInst->lastUse);
 		}
 	}
@@ -186,7 +186,7 @@ void LogCompiledInstructions()
 		GekkoOPInfo *pInst = m_allInstructions[i];
 		if (pInst->compileCount == 0)
 		{
-			fprintf(f.GetHandle(), "%s\t%i\t%lld\n", pInst->opname,
+			fprintf(f.GetHandle(), "%s\t%i\t%" PRId64 "\n", pInst->opname,
 				pInst->compileCount, pInst->runCount);
 		}
 	}

--- a/Source/Core/Core/ec_wii.cpp
+++ b/Source/Core/Core/ec_wii.cpp
@@ -133,7 +133,7 @@ EcWii::EcWii()
 			}
 			else
 			{
-				ERROR_LOG(WII_IPC_ES, "Failed to read keys.bin, check it is the correct size of %08X bytes.", (unsigned int) sizeof(BootMiiKeysBin));
+				ERROR_LOG(WII_IPC_ES, "Failed to read keys.bin, check it is the correct size of %08zX bytes.", sizeof(BootMiiKeysBin));
 			}
 		}
 		else

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -108,7 +108,7 @@ void CompressedBlobReader::GetBlock(u64 block_num, u8 *out_ptr)
 	u32 block_hash = HashAdler32(source, comp_block_size);
 	if (block_hash != m_hashes[block_num])
 		PanicAlertT("The disc image \"%s\" is corrupt.\n"
-		            "Hash of block %llu is %08x instead of %08x.",
+		            "Hash of block %" PRIu64 " is %08x instead of %08x.",
 		            m_file_name.c_str(),
 		            block_num, block_hash, m_hashes[block_num]);
 
@@ -135,7 +135,7 @@ void CompressedBlobReader::GetBlock(u64 block_num, u8 *out_ptr)
 		{
 			// this seem to fire wrongly from time to time
 			// to be sure, don't use compressed isos :P
-			PanicAlert("Failure reading block %llu - out of data and not at end.", block_num);
+			PanicAlert("Failure reading block %" PRIu64 " - out of data and not at end.", block_num);
 		}
 		inflateEnd(&z);
 		if (uncomp_size != m_header.block_size)

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -130,14 +130,14 @@ size_t GetNextBlock(File::IOFile& in, u8* buffer)
 	size_t ReadBytes = 0;
 	if (m_isScrubbing && m_FreeTable[i])
 	{
-		DEBUG_LOG(DISCIO, "Freeing 0x%016llx", CurrentOffset);
+		DEBUG_LOG(DISCIO, "Freeing 0x%016" PRIx64, CurrentOffset);
 		std::fill(buffer, buffer + m_BlockSize, 0xFF);
 		in.Seek(m_BlockSize, SEEK_CUR);
 		ReadBytes = m_BlockSize;
 	}
 	else
 	{
-		DEBUG_LOG(DISCIO, "Used    0x%016llx", CurrentOffset);
+		DEBUG_LOG(DISCIO, "Used    0x%016" PRIx64, CurrentOffset);
 		in.ReadArray(buffer, m_BlockSize, &ReadBytes);
 	}
 
@@ -161,7 +161,7 @@ void MarkAsUsed(u64 _Offset, u64 _Size)
 	u64 CurrentOffset = _Offset;
 	u64 EndOffset = CurrentOffset + _Size;
 
-	DEBUG_LOG(DISCIO, "Marking 0x%016llx - 0x%016llx as used", _Offset, EndOffset);
+	DEBUG_LOG(DISCIO, "Marking 0x%016" PRIx64 " - 0x%016" PRIx64 " as used", _Offset, EndOffset);
 
 	while ((CurrentOffset < EndOffset) && (CurrentOffset < m_FileSize))
 	{

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -77,7 +77,7 @@ u64 CFileSystemGCWii::ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 
 
 	u64 read_length = std::min(_MaxBufferSize, pFileInfo->m_FileSize - _OffsetInFile);
 
-	DEBUG_LOG(DISCIO, "Reading %llx bytes at %llx from file %s. Offset: %llx Size: %llx",
+	DEBUG_LOG(DISCIO, "Reading %" PRIx64 " bytes at %" PRIx64 " from file %s. Offset: %" PRIx64 " Size: %" PRIx64,
 	          read_length, _OffsetInFile, _rFullPath.c_str(), pFileInfo->m_Offset, pFileInfo->m_FileSize);
 
 	m_rVolume->Read(pFileInfo->m_Offset + _OffsetInFile, read_length, _pBuffer, m_Wii);

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -229,13 +229,13 @@ bool CVolumeGC::LoadBannerFile() const
 		else
 		{
 			m_banner_file_type = BANNER_INVALID;
-			WARN_LOG(DISCIO, "Invalid opening.bnr. Type: %0x Size: %0lx", bannerSignature, (unsigned long)file_size);
+			WARN_LOG(DISCIO, "Invalid opening.bnr. Type: %0x Size: %0zx", bannerSignature, file_size);
 		}
 	}
 	else
 	{
 		m_banner_file_type = BANNER_INVALID;
-		WARN_LOG(DISCIO, "Invalid opening.bnr. Size: %0lx", (unsigned long)file_size);
+		WARN_LOG(DISCIO, "Invalid opening.bnr. Size: %0zx", file_size);
 	}
 
 	return m_banner_file_type != BANNER_INVALID;

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
@@ -212,7 +212,7 @@ void wxCheatsWindow::OnEvent_CheatsList_ItemSelected(wxCommandEvent& WXUNUSED(ev
 			ARCode code = GetARCode(i);
 			m_label_code_name->SetLabel(_("Name: ") + StrToWxStr(code.name));
 
-			std::string numcodes = StringFromFormat("Number of Codes: %lu", (unsigned long)code.ops.size());
+			std::string numcodes = StringFromFormat("Number of Codes: %zu", code.ops.size());
 			m_label_num_codes->SetLabel(StrToWxStr(numcodes));
 			m_listbox_codes_list->Clear();
 

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -206,7 +206,7 @@ std::string GameListItem::CreateCacheFilename()
 
 	// Filename.extension_HashOfFolderPath_Size.cache
 	// Append hash to prevent ISO name-clashing in different folders.
-	Filename.append(StringFromFormat("%s_%x_%llx.cache",
+	Filename.append(StringFromFormat("%s_%x_%" PRIx64 ".cache",
 		extension.c_str(), HashFletcher((const u8 *)LegalPathname.c_str(), LegalPathname.size()),
 		File::GetSize(m_FileName)));
 

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -112,7 +112,7 @@ CISOProperties::CISOProperties(const std::string& fileName, wxWindow* parent, wx
 		u8 game_id_bytes[8];
 		if (OpenISO->GetTitleID(game_id_bytes))
 		{
-			game_id = StringFromFormat("%016llx", Common::swap64(game_id_bytes));
+			game_id = StringFromFormat("%016" PRIx64, Common::swap64(game_id_bytes));
 		}
 	}
 

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -217,7 +217,7 @@ static void ReadDataFromFifo(u32 readPtr)
 		size_t existing_len = s_video_buffer_write_ptr - s_video_buffer_read_ptr;
 		if (len > (size_t)(FIFO_SIZE - existing_len))
 		{
-			PanicAlert("FIFO out of bounds (existing %lu + new %lu > %lu)", (unsigned long) existing_len, (unsigned long) len, (unsigned long) FIFO_SIZE);
+			PanicAlert("FIFO out of bounds (existing %zu + new %zu > %lu)", existing_len, len, (unsigned long) FIFO_SIZE);
 			return;
 		}
 		memmove(s_video_buffer, s_video_buffer_read_ptr, existing_len);
@@ -254,7 +254,7 @@ static void ReadDataFromFifoOnCPU(u32 readPtr)
 		size_t existing_len = write_ptr - s_video_buffer_pp_read_ptr;
 		if (len > (size_t)(FIFO_SIZE - existing_len))
 		{
-			PanicAlert("FIFO out of bounds (existing %lu + new %lu > %lu)", (unsigned long) existing_len, (unsigned long) len, (unsigned long) FIFO_SIZE);
+			PanicAlert("FIFO out of bounds (existing %zu + new %zu > %lu)", existing_len, len, (unsigned long) FIFO_SIZE);
 			return;
 		}
 	}

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -259,8 +259,8 @@ std::string HiresTexture::GenBaseName(const u8* texture, size_t texture_size, co
 		u64 tex_hash = XXH64(texture, texture_size, 0);
 		u64 tlut_hash = tlut_size ? XXH64(tlut, tlut_size, 0) : 0;
 
-		std::string basename = s_format_prefix + StringFromFormat("%dx%d%s_%016llx", width, height, has_mipmaps ? "_m" : "", tex_hash);
-		std::string tlutname = tlut_size ? StringFromFormat("_%016llx", tlut_hash) : "";
+		std::string basename = s_format_prefix + StringFromFormat("%dx%d%s_%016" PRIx64, width, height, has_mipmaps ? "_m" : "", tex_hash);
+		std::string tlutname = tlut_size ? StringFromFormat("_%016" PRIx64, tlut_hash) : "";
 		std::string formatname = StringFromFormat("_%d", format);
 		std::string fullname = basename + tlutname + formatname;
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -312,7 +312,7 @@ void Renderer::DrawDebugText()
 
 	if (SConfig::GetInstance().m_ShowLag)
 	{
-		final_cyan += StringFromFormat("Lag: %llu\n", Movie::g_currentLagCount);
+		final_cyan += StringFromFormat("Lag: %" PRIu64 "\n", Movie::g_currentLagCount);
 		final_yellow += "\n";
 	}
 

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -173,7 +173,7 @@ public:
 
 		if (memcmp(buffer_a.data(), buffer_b.data(), std::min(count_a, count_b) * m_native_vtx_decl.stride))
 			ERROR_LOG(VIDEO, "The two vertex loaders have loaded different data "
-			                 "(guru meditation 0x%016llx, 0x%08x, 0x%08x, 0x%08x).",
+			                 "(guru meditation 0x%016" PRIx64 ", 0x%08x, 0x%08x, 0x%08x).",
 			                 m_VtxDesc.Hex, m_vat.g0.Hex, m_vat.g1.Hex, m_vat.g2.Hex);
 
 		memcpy(dst.GetPointer(), buffer_a.data(), count_a * m_native_vtx_decl.stride);


### PR DESCRIPTION
Reverts dolphin-emu/dolphin#2961 because Linux and Windows can never just use the same formatting specifiers.