### PR TITLE
Add Forced Fullscreen or Windowed mode option in gameini

### DIFF
--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -112,6 +112,7 @@ public:
 	bool RendererHasFocus();
 	bool UIHasFocus();
 	bool RendererIsFullscreen();
+	void DoAutoFullscreen(const std::string& filename);
 	void DoFullscreen(bool bF);
 	void ToggleDisplayMode (bool bFullscreen);
 	void UpdateWiiMenuChoice(wxMenuItem *WiiMenuItem=nullptr);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -364,8 +364,6 @@ wxMenuBar* CFrame::CreateMenu()
 	columnsMenu->AppendCheckItem(IDM_SHOW_STATE, _("State"));
 	columnsMenu->Check(IDM_SHOW_STATE, SConfig::GetInstance().m_showStateColumn);
 
-
-
 	menubar->Append(viewMenu, _("&View"));
 
 	if (g_pCodeWindow)
@@ -1027,7 +1025,6 @@ void CFrame::StartGame(const std::string& filename)
 	// Determine if Dolphin needs to force fullscreen. 
 	// This needs to be done before BootManager does, as it can't fullscreen the window.
 	DoAutoFullscreen(filename);
-	
 	if (!BootManager::BootCore(filename))
 	{
 		DoFullscreen(false);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1025,8 +1025,45 @@ void CFrame::StartGame(const std::string& filename)
 
 	wxBeginBusyCursor();
 
-	DoFullscreen(SConfig::GetInstance().bFullscreen);
+	// Determine if Dolphin needs to force fullscreen. 
+	// This needs to be done before BootManager does, as it can't fullscreen the window.
+	bool force_fullscreen = false;
+	bool force_windowed = false;
+	SConfig& MiniStartUp = SConfig::GetInstance();
+	MiniStartUp.m_BootType = SConfig::BOOT_ISO;
+	MiniStartUp.m_strFilename = filename;
+	SConfig::GetInstance().m_LastFilename = filename;
+	SConfig::GetInstance().SaveSettings();
+	// This is saved separately from everything because it can be changed in SConfig::AutoSetup()
+	bool cache_bHLE_BS2 = MiniStartUp.bHLE_BS2;
+	if (MiniStartUp.AutoSetup(SConfig::BOOT_DEFAULT))
+	{
+		if (MiniStartUp.GetUniqueID().size() == 6)
+		{
+			IniFile game_ini = MiniStartUp.GetInstance().LoadGameIni();
+			IniFile::Section* display_section = game_ini.GetOrCreateSection("Display");
+			display_section->Get("ForceFullscreen", &force_fullscreen, false);
+			display_section->Get("ForceWindowed", &force_windowed, false);
+		}
+		MiniStartUp.bHLE_BS2 = cache_bHLE_BS2;
+	}
 
+	if (force_fullscreen || force_windowed)
+	{
+		if (force_fullscreen)
+		{
+			DoFullscreen(true);
+		}
+		if (force_windowed)
+		{
+			DoFullscreen(false);
+		}
+	}
+	else
+	{
+		DoFullscreen(SConfig::GetInstance().bFullscreen);
+	}
+	
 	if (!BootManager::BootCore(filename))
 	{
 		DoFullscreen(false);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1027,42 +1027,8 @@ void CFrame::StartGame(const std::string& filename)
 
 	// Determine if Dolphin needs to force fullscreen. 
 	// This needs to be done before BootManager does, as it can't fullscreen the window.
-	bool force_fullscreen = false;
-	bool force_windowed = false;
-	SConfig& MiniStartUp = SConfig::GetInstance();
-	MiniStartUp.m_BootType = SConfig::BOOT_ISO;
-	MiniStartUp.m_strFilename = filename;
-	SConfig::GetInstance().m_LastFilename = filename;
-	SConfig::GetInstance().SaveSettings();
-	// This is saved separately from everything because it can be changed in SConfig::AutoSetup()
-	bool cache_bHLE_BS2 = MiniStartUp.bHLE_BS2;
-	if (MiniStartUp.AutoSetup(SConfig::BOOT_DEFAULT))
-	{
-		if (MiniStartUp.GetUniqueID().size() == 6)
-		{
-			IniFile game_ini = MiniStartUp.GetInstance().LoadGameIni();
-			IniFile::Section* display_section = game_ini.GetOrCreateSection("Display");
-			display_section->Get("ForceFullscreen", &force_fullscreen, false);
-			display_section->Get("ForceWindowed", &force_windowed, false);
-		}
-		MiniStartUp.bHLE_BS2 = cache_bHLE_BS2;
-	}
-
-	if (force_fullscreen || force_windowed)
-	{
-		if (force_fullscreen)
-		{
-			DoFullscreen(true);
-		}
-		if (force_windowed)
-		{
-			DoFullscreen(false);
-		}
-	}
-	else
-	{
-		DoFullscreen(SConfig::GetInstance().bFullscreen);
-	}
+	
+	DoAutoFullscreen(filename);
 	
 	if (!BootManager::BootCore(filename))
 	{
@@ -1096,6 +1062,45 @@ void CFrame::StartGame(const std::string& filename)
 	}
 
 	wxEndBusyCursor();
+}
+// Automatically decides whether Dolphin should fullscreen or not
+void CFrame::DoAutoFullscreen(const std::string& filename) {
+	bool force_fullscreen = false;
+	bool force_windowed = false;
+	SConfig& mini_startup = SConfig::GetInstance();
+	mini_startup.m_BootType = SConfig::BOOT_ISO;
+	mini_startup.m_strFilename = filename;
+	SConfig::GetInstance().m_LastFilename = filename;
+	SConfig::GetInstance().SaveSettings();
+	// This is saved separately from everything because it can be changed in SConfig::AutoSetup()
+	bool cache_bHLE_BS2 = mini_startup.bHLE_BS2;
+	if (mini_startup.AutoSetup(SConfig::BOOT_DEFAULT))
+	{
+		if (mini_startup.GetUniqueID().size() == 6)
+		{
+			IniFile game_ini = mini_startup.GetInstance().LoadGameIni();
+			IniFile::Section* display_section = game_ini.GetOrCreateSection("Display");
+			display_section->Get("ForceFullscreen", &force_fullscreen, false);
+			display_section->Get("ForceWindowed", &force_windowed, false);
+		}
+		mini_startup.bHLE_BS2 = cache_bHLE_BS2;
+	}
+
+	if (force_fullscreen || force_windowed)
+	{
+		if (force_fullscreen)
+		{
+			DoFullscreen(true);
+		}
+		if (force_windowed)
+		{
+			DoFullscreen(false);
+		}
+	}
+	else
+	{
+		DoFullscreen(SConfig::GetInstance().bFullscreen);
+	}
 }
 
 void CFrame::OnBootDrive(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1024,10 +1024,8 @@ void CFrame::StartGame(const std::string& filename)
 #endif
 
 	wxBeginBusyCursor();
-
 	// Determine if Dolphin needs to force fullscreen. 
 	// This needs to be done before BootManager does, as it can't fullscreen the window.
-	
 	DoAutoFullscreen(filename);
 	
 	if (!BootManager::BootCore(filename))

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -1046,16 +1046,18 @@ void CISOProperties::LoadGameConfig()
 
 	wxCheckBoxState FullscreenState = wxCHK_UNDETERMINED;
 	bool bTemp;
-	if (GameIniLocal.GetOrCreateSection("Display")->Get("ForceFullscreen", &bTemp)) {
-		if (bTemp == true)
+	if (GameIniLocal.GetOrCreateSection("Display")->Get("ForceFullscreen", &bTemp)) 
+	{
+		if (bTemp)
 		{
-			FullscreenState = (wxCheckBoxState)true;
+			FullscreenState = wxCHK_CHECKED;
 		}
 	}
-	if (GameIniLocal.GetOrCreateSection("Display")->Get("ForceWindowed", &bTemp)) {
-		if (bTemp == true)
+	if (GameIniLocal.GetOrCreateSection("Display")->Get("ForceWindowed", &bTemp)) 
+	{
+		if (bTemp)
 		{
-			FullscreenState = (wxCheckBoxState)false;
+			FullscreenState = wxCHK_UNCHECKED;
 		}
 	}
 	ForceFullscreen->Set3StateValue(FullscreenState);

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -1045,15 +1045,16 @@ void CISOProperties::LoadGameConfig()
 	SetCheckboxValueFromGameini("Video_Stereoscopy", "StereoEFBMonoDepth", MonoDepth);
 
 	wxCheckBoxState FullscreenState = wxCHK_UNDETERMINED;
+	IniFile::Section* display_section = GameIniLocal.GetOrCreateSection("Display");
 	bool bTemp;
-	if (GameIniLocal.GetOrCreateSection("Display")->Get("ForceFullscreen", &bTemp)) 
+	if (display_section->Get("ForceFullscreen", &bTemp))
 	{
 		if (bTemp)
 		{
 			FullscreenState = wxCHK_CHECKED;
 		}
 	}
-	if (GameIniLocal.GetOrCreateSection("Display")->Get("ForceWindowed", &bTemp)) 
+	if (display_section->Get("ForceWindowed", &bTemp))
 	{
 		if (bTemp)
 		{

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -362,6 +362,9 @@ void CISOProperties::CreateGUIControls()
 	// Wii Console
 	EnableWideScreen = new wxCheckBox(m_GameConfig, ID_ENABLEWIDESCREEN, _("Enable WideScreen"), wxDefaultPosition, wxDefaultSize, GetElementStyle("Wii", "Widescreen"));
 
+	// Display
+	ForceFullscreen = new wxCheckBox(m_GameConfig, ID_ENABLEWIDESCREEN, _("Force Fullscreen"), wxDefaultPosition, wxDefaultSize, GetElementStyle("Display", "ForceFullscreen"));
+	
 	// Stereoscopy
 	wxBoxSizer* const sDepthPercentage = new wxBoxSizer(wxHORIZONTAL);
 	wxStaticText* const DepthPercentageText = new wxStaticText(m_GameConfig, wxID_ANY, _("Depth Percentage: "));
@@ -405,6 +408,10 @@ void CISOProperties::CreateGUIControls()
 	sbCoreOverrides->Add(DSPHLE, 0, wxLEFT, 5);
 	sbCoreOverrides->Add(sGPUDeterminism, 0, wxEXPAND|wxALL, 5);
 
+	wxStaticBoxSizer* const sbDisplayOverrides =
+		new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Display"));
+	sbDisplayOverrides->Add(ForceFullscreen, 0, wxLEFT, 5);
+
 	wxStaticBoxSizer * const sbWiiOverrides = new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Wii Console"));
 	if (OpenISO->GetVolumeType() == DiscIO::IVolume::GAMECUBE_DISC)
 	{
@@ -422,6 +429,7 @@ void CISOProperties::CreateGUIControls()
 	wxStaticBoxSizer * const sbGameConfig = new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Game-Specific Settings"));
 	sbGameConfig->Add(OverrideText, 0, wxEXPAND|wxALL, 5);
 	sbGameConfig->Add(sbCoreOverrides, 0, wxEXPAND);
+	sbGameConfig->Add(sbDisplayOverrides, 0, wxEXPAND);
 	sbGameConfig->Add(sbWiiOverrides, 0, wxEXPAND);
 	sbGameConfig->Add(sbStereoOverrides, 0, wxEXPAND);
 	sConfigPage->Add(sbGameConfig, 0, wxEXPAND|wxALL, 5);
@@ -1036,6 +1044,22 @@ void CISOProperties::LoadGameConfig()
 	SetCheckboxValueFromGameini("Wii", "Widescreen", EnableWideScreen);
 	SetCheckboxValueFromGameini("Video_Stereoscopy", "StereoEFBMonoDepth", MonoDepth);
 
+	wxCheckBoxState FullscreenState = wxCHK_UNDETERMINED;
+	bool bTemp;
+	if (GameIniLocal.GetOrCreateSection("Display")->Get("ForceFullscreen", &bTemp)) {
+		if (bTemp == true)
+		{
+			FullscreenState = (wxCheckBoxState)true;
+		}
+	}
+	if (GameIniLocal.GetOrCreateSection("Display")->Get("ForceWindowed", &bTemp)) {
+		if (bTemp == true)
+		{
+			FullscreenState = (wxCheckBoxState)false;
+		}
+	}
+	ForceFullscreen->Set3StateValue(FullscreenState);
+
 	IniFile::Section* default_video = GameIniDefault.GetOrCreateSection("Video");
 
 	int iTemp;
@@ -1129,6 +1153,22 @@ bool CISOProperties::SaveGameConfig()
 	SaveGameIniValueFrom3StateCheckbox("Core", "DSPHLE", DSPHLE);
 	SaveGameIniValueFrom3StateCheckbox("Wii", "Widescreen", EnableWideScreen);
 	SaveGameIniValueFrom3StateCheckbox("Video_Stereoscopy", "StereoEFBMonoDepth", MonoDepth);
+
+	if (ForceFullscreen->Get3StateValue() == wxCHK_UNDETERMINED)
+	{
+		GameIniLocal.DeleteKey("Display", "ForceFullscreen");
+		GameIniLocal.DeleteKey("Display", "ForceWindowed");
+	}
+	else if (ForceFullscreen->Get3StateValue() == wxCHK_CHECKED)
+	{
+		GameIniLocal.GetOrCreateSection("Display")->Set("ForceFullscreen", true);
+		GameIniLocal.DeleteKey("Display", "ForceWindowed");
+	}
+	else if (ForceFullscreen->Get3StateValue() == wxCHK_UNCHECKED)
+	{
+		GameIniLocal.GetOrCreateSection("Display")->Set("ForceWindowed", true);
+		GameIniLocal.DeleteKey("Display", "ForceFullscreen");
+	}
 
 	#define SAVE_IF_NOT_DEFAULT(section, key, val, def) do { \
 		if (GameIniDefault.Exists((section), (key))) { \

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -88,6 +88,10 @@ private:
 
 	wxArrayString arrayStringFor_GPUDeterminism;
 	wxChoice* GPUDeterminism;
+
+	// Wii
+	wxCheckBox* ForceFullscreen;
+
 	// Wii
 	wxCheckBox* EnableWideScreen;
 


### PR DESCRIPTION
This PR adds two options to the game ini that allow Dolphin to go into fullscreen or windowed mode per game. By default, Dolphin follows the global setting, but if either option exists, it will fullscreen or window itself.

The earlier commit adds the ini functionality, while the later one adds this functionality to the GUI, under ISO Properties. This is in a new section titled "Display", under core, and before Wii settings.

This is only for the WX version of Dolphin, I believe.

This is also my first pull request, and first contribution to Dolphin c:
