### PR TITLE
Qt: Disable Display Sleep when game is running (Windows)

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -138,9 +138,25 @@ void DMainWindow::StartGame(const QString filename)
 	}
 	else
 	{
-		// TODO: Disable screensaver!
+		DisableScreensaver();
 		emit CoreStateChanged(Core::CORE_RUN);
 	}
+}
+
+void DMainWindow::DisableScreensaver()
+{
+#ifdef Q_OS_WIN
+	// Prevents Windows from sleeping or turning off the display
+	SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED);
+#endif
+}
+
+void DMainWindow::EnableScreensaver()
+{
+#ifdef Q_OS_WIN
+	// Allows Windows to sleep and turn off the display
+	SetThreadExecutionState(ES_CONTINUOUS);
+#endif
 }
 
 QString DMainWindow::RequestBootFilename()
@@ -263,8 +279,7 @@ bool DMainWindow::Stop()
 	// TODO: Show the author/description dialog here
 
 	BootManager::Stop();
-
-	// TODO: Allow screensaver again
+	EnableScreensaver();
 	// TODO: Restore original window title
 
 	// TODO:

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -68,6 +68,9 @@ private:
 	std::unique_ptr<Ui::DMainWindow> m_ui;
 	DGameTracker* m_game_tracker;
 
+	// Misc.
+	void DisableScreensaver();
+	void EnableScreensaver();
 	// Emulation
 	QString RequestBootFilename();
 	QString ShowFileDialog();


### PR DESCRIPTION
This PR lays the groundwork for Power Management on Game start and end, as well as disables monitor sleeping on Windows. This is only while a game is running, and is re-enabled after it has finished.