### PR TITLE
fixed disabling auto reporting for emulated wiimotes not working properly

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -754,7 +754,7 @@ void Wiimote::Update()
 	Movie::CheckWiimoteStatus(m_index, data, rptf, m_extension->active_extension, m_ext_key);
 
 	// don't send a data report if auto reporting is off
-	if (false == m_reporting_auto && data[2] >= WM_REPORT_CORE)
+	if (false == m_reporting_auto && data[1] >= WM_REPORT_CORE)
 		return;
 
 	// send data report


### PR DESCRIPTION
I noticed that the offset here is wrong. data[2] contains some button data, data[1] contains the type of data transmotted (reports starting at WM_REPORT_CORE = 0x30). Therefore if you set m_reporting_auto to false, it only actually disable auto reporting whilst some obscure button press states.