### PR TITLE
VideoCommon: Drop "Disable destAlpha" hack

### DIFF
--- a/Data/Sys/GameSettings/GLC.ini
+++ b/Data/Sys/GameSettings/GLC.ini
@@ -21,7 +21,6 @@ EmulationStateId = 4
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-DstAlphaPass = True
 
 [Video_Hacks]
 EFBToTextureEnable = True

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/UserPreferences.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/UserPreferences.java
@@ -110,7 +110,6 @@ public final class UserPreferences
 			editor.putString("externalFrameBuffer", "Real");
 		}
 
-		editor.putBoolean("disableDestinationAlpha", getConfig("gfx_opengl.ini", "Settings", "DstAlphaPass", "False").equals("True"));
 		editor.putBoolean("fastDepthCalculation",    getConfig("gfx_opengl.ini", "Settings", "FastDepthCalc", "True").equals("True"));
 		editor.putString("aspectRatio", getConfig("gfx_opengl.ini", "Settings", "AspectRatio", "0"));
 
@@ -165,9 +164,6 @@ public final class UserPreferences
 
 		// External frame buffer emulation. Falls back to disabled upon error.
 		String externalFrameBuffer = prefs.getString("externalFrameBuffer", "Disabled");
-
-		// Whether or not to disable destination alpha.
-		boolean disableDstAlphaPass = prefs.getBoolean("disableDestinationAlpha", false);
 
 		// Whether or not to use fast depth calculation.
 		boolean useFastDepthCalc = prefs.getBoolean("fastDepthCalculation", true);
@@ -275,7 +271,6 @@ public final class UserPreferences
 			NativeLibrary.SetConfig("gfx_opengl.ini", "Settings", "UseRealXFB", "True");
 		}
 
-		NativeLibrary.SetConfig("gfx_opengl.ini", "Settings", "DstAlphaPass", disableDstAlphaPass ? "True" : "False");
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Settings", "FastDepthCalc", useFastDepthCalc ? "True" : "False");
 
 		//-- Enhancement Settings --//

--- a/Source/Android/app/src/main/res/xml/preferences.xml
+++ b/Source/Android/app/src/main/res/xml/preferences.xml
@@ -1031,12 +1031,6 @@
             <PreferenceCategory android:title="@string/other">
 
                 <CheckBoxPreference
-                    android:defaultValue="false"
-                    android:key="disableDestinationAlpha"
-                    android:summary="@string/disable_destination_alpha_descrip"
-                    android:title="@string/disable_destination_alpha"/>
-
-                <CheckBoxPreference
                     android:defaultValue="true"
                     android:key="fastDepthCalculation"
                     android:summary="@string/fast_depth_calculation_descrip"

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -119,7 +119,6 @@ static wxString skip_efb_copy_to_ram_desc = wxTRANSLATE("Stores EFB Copies exclu
 static wxString stc_desc = wxTRANSLATE("The \"Safe\" setting eliminates the likelihood of the GPU missing texture updates from RAM.\nLower accuracies cause in-game text to appear garbled in certain games.\n\nIf unsure, use the rightmost value.");
 static wxString wireframe_desc = wxTRANSLATE("Render the scene as a wireframe.\n\nIf unsure, leave this unchecked.");
 static wxString disable_fog_desc = wxTRANSLATE("Makes distant objects more visible by removing fog, thus increasing the overall detail.\nDisabling fog will break some games which rely on proper fog emulation.\n\nIf unsure, leave this unchecked.");
-static wxString disable_dstalpha_desc = wxTRANSLATE("Disables emulation of a hardware feature called destination alpha, which is used in many games for various graphical effects.\nThis has no performance impact on D3D and desktop OpenGL, but on OpenGL ES this is rendered in two passes, which has a minor but noticeable performance impact.\n\nIf unsure, leave this unchecked.");
 static wxString show_fps_desc = wxTRANSLATE("Show the number of frames rendered per second as a measure of emulation speed.\n\nIf unsure, leave this unchecked.");
 static wxString log_render_time_to_file_desc = wxTRANSLATE("Log the render time of every frame to User/Logs/render_time.txt. Use this feature when you want to measure the performance of Dolphin.\n\nIf unsure, leave this unchecked.");
 static wxString show_stats_desc = wxTRANSLATE("Show various rendering statistics.\n\nIf unsure, leave this unchecked.");
@@ -520,7 +519,6 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	// - other hacks
 	{
 	wxGridSizer* const szr_other = new wxGridSizer(2, 5, 5);
-	szr_other->Add(CreateCheckBox(page_hacks, _("Disable Destination Alpha"), wxGetTranslation(disable_dstalpha_desc), vconfig.bDstAlphaPass));
 	szr_other->Add(CreateCheckBox(page_hacks, _("Fast Depth Calculation"), wxGetTranslation(fast_depth_calc_desc), vconfig.bFastDepthCalc));
 	szr_other->Add(CreateCheckBox(page_hacks, _("Disable Bounding Box"), wxGetTranslation(disable_bbox_desc), vconfig.bBBoxEnable, true));
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1322,7 +1322,7 @@ void Renderer::SetBlendMode(bool forceUpdate)
 	// Example: D3DBLEND_DESTALPHA needs to be D3DBLEND_ONE since the result without an alpha channel is assumed to always be 1.
 	bool target_has_alpha = bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24;
 
-	bool useDstAlpha = !g_ActiveConfig.bDstAlphaPass && bpmem.dstalpha.enable && bpmem.blendmode.alphaupdate && target_has_alpha;
+	bool useDstAlpha = bpmem.dstalpha.enable && bpmem.blendmode.alphaupdate && target_has_alpha;
 	bool useDualSource = useDstAlpha && g_ActiveConfig.backend_info.bSupportsDualSourceBlend;
 
 	const GLenum glSrcFactors[8] =

--- a/Source/Core/VideoCommon/Debugger.cpp
+++ b/Source/Core/VideoCommon/Debugger.cpp
@@ -82,7 +82,7 @@ void GFXDebuggerBase::DumpPixelShader(const std::string& path)
 	const std::string filename = StringFromFormat("%sdump_ps.txt", path.c_str());
 
 	std::string output;
-	bool useDstAlpha = !g_ActiveConfig.bDstAlphaPass && bpmem.dstalpha.enable && bpmem.blendmode.alphaupdate && bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24;
+	bool useDstAlpha = bpmem.dstalpha.enable && bpmem.blendmode.alphaupdate && bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24;
 	if (!useDstAlpha)
 	{
 		output = "Destination alpha disabled:\n";

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -250,8 +250,7 @@ void VertexManager::Flush()
 		GeometryShaderManager::SetConstants();
 		PixelShaderManager::SetConstants();
 
-		bool useDstAlpha = !g_ActiveConfig.bDstAlphaPass &&
-						   bpmem.dstalpha.enable &&
+		bool useDstAlpha = bpmem.dstalpha.enable &&
 						   bpmem.blendmode.alphaupdate &&
 						   bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24;
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -80,7 +80,6 @@ void VideoConfig::Load(const std::string& ini_file)
 	settings->Get("MSAA", &iMultisampleMode, 0);
 	settings->Get("SSAA", &bSSAA, false);
 	settings->Get("EFBScale", &iEFBScale, (int)SCALE_1X); // native
-	settings->Get("DstAlphaPass", &bDstAlphaPass, false);
 	settings->Get("TexFmtOverlayEnable", &bTexFmtOverlayEnable, 0);
 	settings->Get("TexFmtOverlayCenter", &bTexFmtOverlayCenter, 0);
 	settings->Get("WireFrame", &bWireFrame, 0);
@@ -191,7 +190,6 @@ void VideoConfig::GameIniLoad()
 		}
 	}
 
-	CHECK_SETTING("Video_Settings", "DstAlphaPass", bDstAlphaPass);
 	CHECK_SETTING("Video_Settings", "DisableFog", bDisableFog);
 
 	CHECK_SETTING("Video_Enhancements", "ForceFiltering", bForceFiltering);
@@ -282,7 +280,6 @@ void VideoConfig::Save(const std::string& ini_file)
 	settings->Set("TexFmtOverlayEnable", bTexFmtOverlayEnable);
 	settings->Set("TexFmtOverlayCenter", bTexFmtOverlayCenter);
 	settings->Set("Wireframe", bWireFrame);
-	settings->Set("DstAlphaPass", bDstAlphaPass);
 	settings->Set("DisableFog", bDisableFog);
 	settings->Set("EnableShaderDebugging", bEnableShaderDebugging);
 	settings->Set("BorderlessFullscreen", bBorderlessFullscreen);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -96,7 +96,6 @@ struct VideoConfig final
 
 	// Render
 	bool bWireFrame;
-	bool bDstAlphaPass;
 	bool bDisableFog;
 
 	// Utility


### PR DESCRIPTION
This option has no use any more, neither performance nor driver workaround.