### PR TITLE
VertexLoaderX64: fix 2GB warnings

### DIFF
--- a/Source/Core/Common/CodeBlock.h
+++ b/Source/Core/Common/CodeBlock.h
@@ -38,10 +38,10 @@ public:
 	virtual ~CodeBlock() { if (region) FreeCodeSpace(); }
 
 	// Call this before you generate any code.
-	void AllocCodeSpace(int size)
+	void AllocCodeSpace(int size, bool need_low = true)
 	{
 		region_size = size;
-		region = (u8*)AllocateExecutableMemory(region_size);
+		region = (u8*)AllocateExecutableMemory(region_size, need_low);
 		T::SetCodePtr(region);
 	}
 

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -38,7 +38,7 @@ VertexLoaderX64::VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att) :
 	if (!IsInitialized())
 		return;
 
-	AllocCodeSpace(4096);
+	AllocCodeSpace(4096, false);
 	ClearCodeSpace();
 	GenerateVertexLoader();
 	WriteProtect();


### PR DESCRIPTION
Unlike the CPU JIT, the vertex loader JIT already emits position-independent code, so all we need to do is disable the warning.