### PR TITLE
Fix performance regression in Sonic the Fighters, introduced by PR#2001

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -22,7 +22,7 @@
 #include "VideoCommon/VideoConfig.h"
 
 static const u64 TEXHASH_INVALID = 0;
-static const int TEXTURE_KILL_THRESHOLD = 60;
+static const int TEXTURE_KILL_THRESHOLD = 64; // Sonic the Fighters (inside Sonic Gems Collection) loops a 64 frames animation
 static const int TEXTURE_POOL_KILL_THRESHOLD = 3;
 static const int FRAMECOUNT_INVALID = 0;
 
@@ -496,8 +496,12 @@ TextureCache::TCacheEntryBase* TextureCache::Load(const u32 stage)
 			}
 		}
 
-		// Find the entry which hasn't been used for the longest time
-		if (entry->frameCount != FRAMECOUNT_INVALID && entry->frameCount < temp_frameCount)
+		// Find the texture which hasn't been used for the longest time. Count paletted
+		// textures as the same texture here, when the texture itself is the same. This
+		// improves the performance a lot in some games that use paletted textures.
+		// Example: Sonic the Fighters (inside Sonic Gems Collection)
+		if (entry->frameCount != FRAMECOUNT_INVALID && entry->frameCount < temp_frameCount &&
+			!(isPaletteTexture && entry->base_hash == base_hash))
 		{
 			temp_frameCount = entry->frameCount;
 			oldest_entry = iter;


### PR DESCRIPTION
Rewritten version of: https://github.com/dolphin-emu/dolphin/pull/2612

Sonic the Fighters (part of the Sonic Gems Collection) uses a lot of paletted textures, which are not cached properly since merging PR #2001. This PR readds caching for paletted textures, as long as only the palette changes.

This also increases TEXTURE_KILL_THRESHOLD to 64, because the game uses some 64 long animation and loops it. If TEXTURE_KILL_THRESHOLD is less than 64, there's a new texture uploaded every frame. On the original arcade machine, which runs at 64 Hz/fps, this animation is 1 second long, so the increased threshold might relate to the timer.

This might also restore the performance on some Metroid Prime titles in menus with a lot of text.

One alternative to increasing the threshold might be to set all those textures with the same base hash to just used. But then every palette would keep its own texture in the cache, as long as the same base texture is in use. Since this could become a large number, i prefer this implementation with the kill threshold.

The best way to handle this would to be to upload the palette to the GPU and let it decode it on-the-fly, and have only one entry per "base texture". (suggested by degasus)