### PR TITLE
[WIP] Fix efb2tex for Sonic Riders: Zero Gravity

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -457,6 +457,10 @@ TextureCache::TCacheEntryBase* TextureCache::Load(const u32 stage)
 		if (entry->IsEfbCopy())
 		{
 			u64 efb_hash = base_hash;
+			u32 texture_stride = (expandedWidth / bsw) * 32;
+
+			if (texformat == 6)
+				texture_stride = texture_stride * 2;
 
 			// Normally the above hash is fine, but some games (like Sonic Riders: Zero Gravity) do an efb copy which is
 			// smaller than the texture it ultimatlly tries to use (640x480 copy into a 1024x512 texture in this case)
@@ -466,7 +470,8 @@ TextureCache::TCacheEntryBase* TextureCache::Load(const u32 stage)
 
 			// EFB copies have slightly different rules as EFB copy formats have different
 			// meanings from texture formats.
-			if ((efb_hash == entry->hash && (!isPaletteTexture || g_Config.backend_info.bSupportsPaletteConversion)) ||
+			if ((efb_hash == entry->hash && texture_stride == entry->memory_stride &&
+				(!isPaletteTexture || g_Config.backend_info.bSupportsPaletteConversion)) ||
 				IsPlayingBackFifologWithBrokenEFBCopies)
 			{
 				// TODO: We should check format/width/height/levels for EFB copies. Checking

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -456,9 +456,17 @@ TextureCache::TCacheEntryBase* TextureCache::Load(const u32 stage)
 		TCacheEntryBase* entry = iter->second;
 		if (entry->IsEfbCopy())
 		{
+			u64 efb_hash = base_hash;
+
+			// Normally the above hash is fine, but some games (like Sonic Riders: Zero Gravity) do an efb copy which is
+			// smaller than the texture it ultimatlly tries to use (640x480 copy into a 1024x512 texture in this case)
+			// We need to make sure we hash the same number of bytes that we did during the efb copy.
+			if (texture_size != entry->size_in_bytes)
+				efb_hash = GetHash64(src_data, entry->size_in_bytes, g_ActiveConfig.iSafeTextureCache_ColorSamples);
+
 			// EFB copies have slightly different rules as EFB copy formats have different
 			// meanings from texture formats.
-			if ((base_hash == entry->hash && (!isPaletteTexture || g_Config.backend_info.bSupportsPaletteConversion)) ||
+			if ((efb_hash == entry->hash && (!isPaletteTexture || g_Config.backend_info.bSupportsPaletteConversion)) ||
 				IsPlayingBackFifologWithBrokenEFBCopies)
 			{
 				// TODO: We should check format/width/height/levels for EFB copies. Checking
@@ -1120,7 +1128,7 @@ void TextureCache::TCacheEntryBase::SetEfbCopy(u32 stride)
 	is_efb_copy = true;
 	memory_stride = stride;
 
-	_assert_msg_(VIDEO, memory_stride >= CacheLinesPerRow(), "Memory stride is too small");
+	_assert_msg_(VIDEO, memory_stride >= CacheLinesPerRow() * 32, "Memory stride is too small.");
 
 	size_in_bytes = memory_stride * NumBlocksY();
 }


### PR DESCRIPTION
Was broken by #2960. Compared to the original code, this probably improves efb2ram quality at higher IRs.

The game was padding the size of the efb2ram copy from 640x480 to 1024x512 (power of 2), It didn't actually use the rest of the texture, just leaving it a solid pink color, so our current method of "just give it the efb copy anyway no matter what dimensions, as long as the starting address and hash match" works just fine. 

But our efb copy code hashes a 1024x480 texture, while the texture loading code hashes a 1024x512 texture, so they get different results.

The new texture loading code checks the size of the efb copy hash and re-does it's hash to match,