### PR TITLE
Improved OGL and D3D's AA options in UI

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -245,6 +245,8 @@ protected:
 	void Evt_LeaveControl(wxMouseEvent& ev);
 	void CreateDescriptionArea(wxPanel* const page, wxBoxSizer* const sizer);
 	void PopulatePostProcessingShaders();
+	void OnSSAAClick(wxCommandEvent& event);
+	void RefreshAAList();
 
 	wxChoice* choice_backend;
 	wxChoice* choice_adapter;

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -178,13 +178,13 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter)
 		{
 			UINT quality_levels = 0;
 			_device->CheckMultisampleQualityLevels(DXGI_FORMAT_R8G8B8A8_UNORM, samples, &quality_levels);
+
+			DXGI_SAMPLE_DESC desc;
+			desc.Count = samples;
+			desc.Quality = 0;
+
 			if (quality_levels > 0)
-			{
-				DXGI_SAMPLE_DESC desc;
-				desc.Count = samples;
-				for (desc.Quality = 0; desc.Quality < quality_levels; ++desc.Quality)
-					_aa_modes.push_back(desc);
-			}
+				_aa_modes.push_back(desc);
 		}
 		_context->Release();
 		_device->Release();

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -106,16 +106,10 @@ void InitBackendInfo()
 		{
 			std::string samples;
 			std::vector<DXGI_SAMPLE_DESC> modes = DX11::D3D::EnumAAModes(ad);
+			// First iteration will be 1. This equals no AA.
 			for (unsigned int i = 0; i < modes.size(); ++i)
 			{
-				if (i == 0)
-					samples = _trans("None");
-				else if (modes[i].Quality)
-					samples = StringFromFormat(_trans("%d samples (quality level %d)"), modes[i].Count, modes[i].Quality);
-				else
-					samples = StringFromFormat(_trans("%d samples"), modes[i].Count);
-
-				g_Config.backend_info.AAModes.push_back(samples);
+				g_Config.backend_info.AAModes.push_back(modes[i].Count);
 			}
 
 			bool shader_model_5_supported = (DX11::D3D::GetFeatureLevel(ad) >= D3D_FEATURE_LEVEL_11_0);

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -121,9 +121,9 @@ static void InitBackendInfo()
 
 	g_Config.backend_info.Adapters.clear();
 
-	// aamodes
-	const char* caamodes[] = {_trans("None"), "2x MSAA", "4x MSAA", "8x MSAA"};
-	g_Config.backend_info.AAModes.assign(caamodes, caamodes + sizeof(caamodes)/sizeof(*caamodes));
+	// aamodes - 1 is to stay consistent with D3D (means no AA)
+	const int aamodes[] = { 1, 2, 4, 8 };
+	g_Config.backend_info.AAModes.assign(aamodes, aamodes + sizeof(aamodes)/sizeof(*aamodes));
 
 	// pp shaders
 	g_Config.backend_info.PPShaders = GetShaders("");

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -144,7 +144,7 @@ struct VideoConfig final
 		API_TYPE APIType;
 
 		std::vector<std::string> Adapters; // for D3D
-		std::vector<std::string> AAModes;
+		std::vector<int> AAModes;
 		std::vector<std::string> PPShaders; // post-processing shaders
 		std::vector<std::string> AnaglyphShaders; // anaglyph shaders
 


### PR DESCRIPTION
This has gone through a significant rewrite since the initial PR. I've modified D3D to not return quality levels. 99% of the time this is just confusing to the user. Nobody needs 30 AA options that are minuscule improvements on the last. Second, I modified the UI to normalize what OGL and D3D display for AA options. I like this implementation because it will scale to more MSAA/SSAA levels if they are added. Third, I gave the SSAA checkbox a proper description. It used to be copy pasted from the MSAA dropdown. "If unsure, select none"? lol. Fourth, both backends now display what AA type is being applied. It was bad UX previously to show MSAA options if the user had SSAA checked. It implied to some that MSAA + ??x SSAA was being applied, which isn't true. Now it shows "SSAA" if it is enabled.

I plan on removing the SSAA checkbox later. I need this merged first so I know what I'm working with to do that though, as this changes some relevant stuff in the backend, and if I fail to properly remove the checkbox, at the very least this is a big UI improvement.

Screenshots for the Dial-up Woman.

![On](http://i.imgur.com/Qy6mXO6.png)
![Off](http://i.imgur.com/yv8b43u.png)
![desc](http://i.imgur.com/rzjDe7D.png)
