### PR TITLE
Respect the stride for efb copies when hashing them

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -114,6 +114,8 @@ public:
 		u32 CacheLinesPerRow() const;
 
 		void Zero(u8* ptr);
+
+		u64 CalculateHash() const;
 	};
 
 	virtual ~TextureCache(); // needs virtual for DX11 dtor


### PR DESCRIPTION
Before there was memory hashed that does not belong to the efb copy.

One problem with this right now is that the hash will be the same if the "blocks" of the efb copy are the same, but the order is different.