### PR TITLE
DolphinWX: Fix sorting games by custom titles

### DIFF
--- a/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
+++ b/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
@@ -87,7 +87,7 @@ void CreateCodeDialog::PressOK(wxCommandEvent& ev)
 
 	// pretty hacky - add the code to the gameini
 	{
-	CISOProperties isoprops(SConfig::GetInstance().m_LastFilename, this);
+	CISOProperties isoprops(GameListItem(SConfig::GetInstance().m_LastFilename, std::unordered_map<std::string, std::string>()), this);
 	// add the code to the isoproperties arcode list
 	arCodes->push_back(new_cheat);
 	// save the gameini

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -83,13 +83,10 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
 		sortData = -sortData;
 	}
 
-	DiscIO::IVolume::ELanguage languageOne = SConfig::GetInstance().GetCurrentLanguage(iso1->GetPlatform() != DiscIO::IVolume::GAMECUBE_DISC);
-	DiscIO::IVolume::ELanguage languageOther = SConfig::GetInstance().GetCurrentLanguage(iso2->GetPlatform() != DiscIO::IVolume::GAMECUBE_DISC);
-
 	switch (sortData)
 	{
 		case CGameListCtrl::COLUMN_TITLE:
-			if (!strcasecmp(iso1->GetName(languageOne).c_str(), iso2->GetName(languageOther).c_str()))
+			if (!strcasecmp(iso1->GetName().c_str(), iso2->GetName().c_str()))
 			{
 				if (iso1->GetUniqueID() != iso2->GetUniqueID())
 					return t * (iso1->GetUniqueID() > iso2->GetUniqueID() ? 1 : -1);
@@ -98,8 +95,7 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
 				if (iso1->GetDiscNumber() != iso2->GetDiscNumber())
 					return t * (iso1->GetDiscNumber() > iso2->GetDiscNumber() ? 1 : -1);
 			}
-			return strcasecmp(iso1->GetName(languageOne).c_str(),
-			                  iso2->GetName(languageOther).c_str()) * t;
+			return strcasecmp(iso1->GetName().c_str(), iso2->GetName().c_str()) * t;
 		case CGameListCtrl::COLUMN_MAKER:
 			return strcasecmp(iso1->GetCompany().c_str(), iso2->GetCompany().c_str()) * t;
 		case CGameListCtrl::COLUMN_ID:
@@ -387,46 +383,6 @@ void CGameListCtrl::InsertItemInReportView(long _Index)
 	SetItemColumnImage(_Index, COLUMN_BANNER, ImageIndex);
 
 	wxString name = StrToWxStr(rISOFile.GetName());
-
-	// Attempt to load game titles from titles.txt
-	// http://www.gametdb.com/Wii/Downloads
-	std::ifstream titlestxt;
-	OpenFStream(titlestxt, File::GetUserPath(D_LOAD_IDX) + "titles.txt", std::ios::in);
-
-	if (!titlestxt.is_open())
-	{
-		OpenFStream(titlestxt, File::GetUserPath(D_LOAD_IDX) + "wiitdb.txt", std::ios::in);
-	}
-
-	if (titlestxt.is_open() && rISOFile.GetUniqueID().size() > 3)
-	{
-		while (!titlestxt.eof())
-		{
-			std::string line;
-
-			if (!std::getline(titlestxt, line) && titlestxt.eof())
-				break;
-
-			const size_t equals_index = line.find('=');
-			std::string game_id = rISOFile.GetUniqueID();
-
-			// Ignore publisher ID for WAD files
-			if (rISOFile.GetPlatform() == DiscIO::IVolume::WII_WAD)
-				game_id.erase(game_id.size() - 2);
-
-			if (line.substr(0, equals_index - 1) == game_id)
-			{
-				name = StrToWxStr(StripSpaces(line.substr(equals_index + 1)));
-				break;
-			}
-		}
-		titlestxt.close();
-	}
-
-	std::string title;
-	IniFile gameini = SConfig::LoadGameIni(rISOFile.GetUniqueID(), rISOFile.GetRevision());
-	if (gameini.GetIfExists("EmuState", "Title", &title))
-		name = StrToWxStr(title);
 
 	int disc_number = rISOFile.GetDiscNumber() + 1;
 	if (disc_number > 1 && name.Lower().find(wxString::Format("disc %i", disc_number)) == std::string::npos

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -78,6 +78,9 @@ private:
 	int m_ImageWidth, m_ImageHeight;
 	u8 m_disc_number;
 
+	std::string m_custom_name;
+	bool m_has_custom_name;
+
 	bool LoadFromCache();
 	void SaveToCache();
 

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -17,10 +18,10 @@
 #endif
 
 class PointerWrap;
-class GameListItem : NonCopyable
+class GameListItem
 {
 public:
-	GameListItem(const std::string& _rFileName);
+	GameListItem(const std::string& _rFileName, const std::unordered_map<std::string, std::string>& custom_titles);
 	~GameListItem();
 
 	bool IsValid() const {return m_Valid;}

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -19,6 +19,7 @@
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 #include "DolphinWX/ARCodeAddEdit.h"
+#include "DolphinWX/ISOFile.h"
 #include "DolphinWX/PatchAddEdit.h"
 
 class GameListItem;
@@ -58,7 +59,7 @@ struct PHackData
 class CISOProperties : public wxDialog
 {
 public:
-	CISOProperties(const std::string& fileName,
+	CISOProperties(const GameListItem& game_list_item,
 			wxWindow* parent,
 			wxWindowID id = wxID_ANY,
 			const wxString& title = _("Properties"),
@@ -215,7 +216,7 @@ private:
 	void SetRefresh(wxCommandEvent& event);
 	void OnChangeBannerLang(wxCommandEvent& event);
 
-	GameListItem* OpenGameListItem;
+	const GameListItem OpenGameListItem;
 
 	typedef std::vector<const DiscIO::SFileInfo*>::iterator fileIter;
 


### PR DESCRIPTION
Games are now sorted by the name they're displayed as, not their original name. As a little efficiency bonus, the first commit halves the number of times that game INIs are opened, and the second commit reduces the number of times that titles.txt is opened to one per gamelist scan.

Fixes https://bugs.dolphin-emu.org/issues/7921