### PR TITLE
Common: Get rid of a few pointer casts

### DIFF
--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -170,14 +170,15 @@ private:
 	struct Header
 	{
 		Header()
-			: id(*(u32*)"DCAC")
-			, key_t_size(sizeof(K))
+			: key_t_size(sizeof(K))
 			, value_t_size(sizeof(V))
 		{
-			memcpy(ver, scm_rev_git_str, 40);
+			// Null-terminator is intentionally not copied.
+			std::memcpy(&id, "DCAC", sizeof(u32));
+			std::memcpy(ver, scm_rev_git_str, 40);
 		}
 
-		const u32 id;
+		u32 id;
 		const u16 key_t_size, value_t_size;
 		char ver[40];
 

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -82,9 +82,9 @@ void CPUInfo::Detect()
 	// Detect CPU's CPUID capabilities, and grab CPU string
 	__cpuid(cpu_id, 0x00000000);
 	u32 max_std_fn = cpu_id[0];  // EAX
-	*((int *)brand_string) = cpu_id[1];
-	*((int *)(brand_string + 4)) = cpu_id[3];
-	*((int *)(brand_string + 8)) = cpu_id[2];
+	std::memcpy(&brand_string[0], &cpu_id[1], sizeof(int));
+	std::memcpy(&brand_string[4], &cpu_id[3], sizeof(int));
+	std::memcpy(&brand_string[8], &cpu_id[2], sizeof(int));
 	__cpuid(cpu_id, 0x80000000);
 	u32 max_ex_fn = cpu_id[0];
 	if (!strcmp(brand_string, "GenuineIntel"))


### PR DESCRIPTION
ubsan doesn't fire in our code during initialization of a clean GUI build of Dolphin with this, which is also nice (unfortunately we still get runtime notifications about wx, but we can't do anything about that, aside from submitting patches to wx).

It might be more beneficial/less icky to consider altering LinearDiskCache to store the ID string as a char array directly instead of a u32, however I've kept it like this to preserve functionality (if it's fine to change it to a char[5], I can amend this PR, or do a followup.)