### PR TITLE
State: Increase savestate version

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -66,7 +66,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 46; // Last changed in PR 2686
+static const u32 STATE_VERSION = 47; // Last changed in PR 3045
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This should have been done when GC_ALIGN macros were replaced.