### PR TITLE
Remove segfault from DX11 backend.

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -152,9 +152,10 @@ void PSTextureEncoder::Encode(u8* dst, const TextureCache::TCacheEntryBase *text
 		CHECK(SUCCEEDED(hr), "map staging buffer (0x%x)", hr);
 
 		u8* src = (u8*)map.pData;
+		u32 readStride = std::min(texture_entry->CacheLinesPerRow() * 32, map.RowPitch);
 		for (unsigned int y = 0; y < texture_entry->NumBlocksY(); ++y)
 		{
-			memcpy(dst, src, texture_entry->CacheLinesPerRow() * 32);
+			memcpy(dst, src, readStride);
 			dst += texture_entry->memory_stride;
 			src += map.RowPitch;
 		}


### PR DESCRIPTION
Instead of blindly using the expected width, clamp it to the stride of the buffer which dx11 returns. This prevents use from reading invalid memory at the end of textures.

This doesn't solve the base issue of what to do when a game tries to copy from outside the efb. On real hardware it returns random noise (biased to all ones), but at least it shouldn't crash.