### PR TITLE
DolphinWX: decompress discs to calculate MD5 hash

### DIFF
--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -77,23 +77,19 @@ bool SectorReader::Read(u64 offset, u64 size, u8* out_ptr)
 			continue;
 		}
 
+		const u8* data = GetBlockData(block);
+		if (!data)
+			return false;
+
 		u32 toCopy = m_blocksize - positionInBlock;
 		if (toCopy >= remain)
 		{
-			const u8* data = GetBlockData(block);
-			if (!data)
-				return false;
-
 			// Yay, we are done!
 			memcpy(out_ptr, data + positionInBlock, (size_t)remain);
 			return true;
 		}
 		else
 		{
-			const u8* data = GetBlockData(block);
-			if (!data)
-				return false;
-
 			memcpy(out_ptr, data + positionInBlock, toCopy);
 			out_ptr += toCopy;
 			remain -= toCopy;

--- a/Source/Core/DiscIO/CISOBlob.cpp
+++ b/Source/Core/DiscIO/CISOBlob.cpp
@@ -44,7 +44,7 @@ CISOFileReader* CISOFileReader::Create(const std::string& filename)
 
 u64 CISOFileReader::GetDataSize() const
 {
-	return GetRawSize();
+	return CISO_MAP_SIZE * m_block_size;
 }
 
 u64 CISOFileReader::GetRawSize() const

--- a/Source/Core/DiscIO/CISOBlob.h
+++ b/Source/Core/DiscIO/CISOBlob.h
@@ -37,7 +37,11 @@ public:
 	static CISOFileReader* Create(const std::string& filename);
 
 	BlobType GetBlobType() const override { return BlobType::CISO; }
+
+	// The CISO format does not save the original file size.
+	// This function returns an upper bound.
 	u64 GetDataSize() const override;
+
 	u64 GetRawSize() const override;
 	bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;
 

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -39,6 +39,8 @@ WbfsFileReader::WbfsFileReader(const std::string& filename)
 	m_wlba_table = new u16[m_blocks_per_disc];
 	m_files[0]->file.Seek(m_hd_sector_size + WII_DISC_HEADER_SIZE /*+ i * m_disc_info_size*/, SEEK_SET);
 	m_files[0]->file.ReadBytes(m_wlba_table, m_blocks_per_disc * sizeof(u16));
+	for (size_t i = 0; i < m_blocks_per_disc; i++)
+		m_wlba_table[i] = Common::swap16(m_wlba_table[i]);
 }
 
 WbfsFileReader::~WbfsFileReader()
@@ -143,7 +145,7 @@ File::IOFile& WbfsFileReader::SeekToCluster(u64 offset, u64* available)
 	u64 base_cluster = (offset >> m_wbfs_sector_shift);
 	if (base_cluster < m_blocks_per_disc)
 	{
-		u64 cluster_address = m_wbfs_sector_size * Common::swap16(m_wlba_table[base_cluster]);
+		u64 cluster_address = m_wbfs_sector_size * m_wlba_table[base_cluster];
 		u64 cluster_offset = offset & (m_wbfs_sector_size - 1);
 		u64 final_address = cluster_address + cluster_offset;
 

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -51,6 +51,11 @@ WbfsFileReader::~WbfsFileReader()
 	delete[] m_wlba_table;
 }
 
+u64 WbfsFileReader::GetDataSize() const
+{
+	return WII_SECTOR_COUNT * WII_SECTOR_SIZE;
+}
+
 bool WbfsFileReader::OpenFiles(const std::string& filename)
 {
 	m_total_files = 0;

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -102,7 +102,7 @@ bool WbfsFileReader::ReadHeader()
 		return false;
 
 	m_blocks_per_disc = (WII_SECTOR_COUNT * WII_SECTOR_SIZE) / m_wbfs_sector_size;
-	m_disc_info_size = align(WII_DISC_HEADER_SIZE + m_blocks_per_disc * 2, m_hd_sector_size);
+	m_disc_info_size = align(WII_DISC_HEADER_SIZE + m_blocks_per_disc * sizeof(u16), m_hd_sector_size);
 
 	// Read disc table
 	m_files[0]->file.Seek(2, SEEK_CUR);
@@ -122,7 +122,7 @@ bool WbfsFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)
 		File::IOFile& data_file = SeekToCluster(offset, &read_size);
 		if (read_size == 0)
 			return false;
-		read_size = (read_size > nbytes) ? nbytes : read_size;
+		read_size = std::min(read_size, nbytes);
 
 		if (!data_file.ReadBytes(out_ptr, read_size))
 		{

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -99,7 +99,7 @@ bool WbfsFileReader::ReadHeader()
 	if (m_wbfs_sector_size < WII_SECTOR_SIZE)
 		return false;
 
-	m_blocks_per_disc = (WII_SECTOR_COUNT * WII_SECTOR_SIZE) / m_wbfs_sector_size;
+	m_blocks_per_disc = (WII_SECTOR_COUNT * WII_SECTOR_SIZE + m_wbfs_sector_size - 1) / m_wbfs_sector_size;
 	m_disc_info_size = align(WII_DISC_HEADER_SIZE + m_blocks_per_disc * sizeof(u16), m_hd_sector_size);
 
 	return m_header.disc_table[0] != 0;

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -20,7 +20,12 @@ public:
 	static WbfsFileReader* Create(const std::string& filename);
 
 	BlobType GetBlobType() const override { return BlobType::WBFS; }
-	u64 GetDataSize() const override { return m_size; }
+
+	// The WBFS format does not save the original file size.
+	// This function returns a constant upper bound
+	// (the size of a double-layer Wii disc).
+	u64 GetDataSize() const override;
+
 	u64 GetRawSize() const override { return m_size; }
 	bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;
 

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -48,15 +48,21 @@ private:
 	u64 m_size;
 
 	u64 m_hd_sector_size;
-	u8 m_hd_sector_shift;
-	u32 m_hd_sector_count;
-
 	u64 m_wbfs_sector_size;
-	u8 m_wbfs_sector_shift;
 	u64 m_wbfs_sector_count;
 	u64 m_disc_info_size;
 
-	u8 m_disc_table[500];
+#pragma pack(1)
+	struct WbfsHeader
+	{
+		char magic[4];
+		u32 hd_sector_count;
+		u8 hd_sector_shift;
+		u8 wbfs_sector_shift;
+		u8 padding[2];
+		u8 disc_table[500];
+	} m_header;
+#pragma pack()
 
 	u16* m_wlba_table;
 	u64 m_blocks_per_disc;


### PR DESCRIPTION
The main use case of calculating the MD5 hash is to compare it to known-good values.