### PR TITLE
Rasterizer: Use multiplication instead of shifts in DrawTriangleFrontFace

### DIFF
--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -360,13 +360,13 @@ void DrawTriangleFrontFace(OutputVertexData *v0, OutputVertexData *v1, OutputVer
 	const s32 DY31 = Y3 - Y1;
 
 	// Fixed-pos32 deltas
-	const s32 FDX12 = DX12 << 4;
-	const s32 FDX23 = DX23 << 4;
-	const s32 FDX31 = DX31 << 4;
+	const s32 FDX12 = DX12 * 16;
+	const s32 FDX23 = DX23 * 16;
+	const s32 FDX31 = DX31 * 16;
 
-	const s32 FDY12 = DY12 << 4;
-	const s32 FDY23 = DY23 << 4;
-	const s32 FDY31 = DY31 << 4;
+	const s32 FDY12 = DY12 * 16;
+	const s32 FDY23 = DY23 * 16;
+	const s32 FDY31 = DY31 * 16;
 
 	// Bounding rectangle
 	s32 minx = (std::min(std::min(X1, X2), X3) + 0xF) >> 4;


### PR DESCRIPTION
The left-hand-side is negative at some point; the left shifting of which is considered undefined by the standard (despite usually getting intended results on 2s complement machines).