### PR TITLE
VertexLoaderUtils: Get rid of pointer casts

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderUtils.h
+++ b/Source/Core/VideoCommon/VertexLoaderUtils.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstring>
 #include "Common/Common.h"
 #include "VideoCommon/VertexManagerBase.h"
 
@@ -24,10 +25,11 @@ __forceinline void DataSkip()
 }
 
 template <typename T>
-__forceinline T DataPeek(int _uOffset, u8** bufp = &g_video_buffer_read_ptr)
+__forceinline T DataPeek(int _uOffset, u8* bufp = g_video_buffer_read_ptr)
 {
-	auto const result = Common::FromBigEndian(*reinterpret_cast<T*>(*bufp + _uOffset));
-	return result;
+	T result;
+	std::memcpy(&result, &bufp[_uOffset], sizeof(T));
+	return Common::FromBigEndian(result);
 }
 
 // TODO: kill these
@@ -49,7 +51,7 @@ __forceinline u32 DataPeek32(int _uOffset)
 template <typename T>
 __forceinline T DataRead(u8** bufp = &g_video_buffer_read_ptr)
 {
-	auto const result = DataPeek<T>(0, bufp);
+	auto const result = DataPeek<T>(0, *bufp);
 	*bufp += sizeof(T);
 	return result;
 }
@@ -77,9 +79,10 @@ __forceinline u32 DataReadU32()
 
 __forceinline u32 DataReadU32Unswapped()
 {
-	u32 tmp = *(u32*)g_video_buffer_read_ptr;
-	g_video_buffer_read_ptr += 4;
-	return tmp;
+	u32 result;
+	std::memcpy(&result, g_video_buffer_read_ptr, sizeof(u32));
+	g_video_buffer_read_ptr += sizeof(u32);
+	return result;
 }
 
 __forceinline u8* DataGetPosition()
@@ -90,6 +93,6 @@ __forceinline u8* DataGetPosition()
 template <typename T>
 __forceinline void DataWrite(T data)
 {
-	*(T*)g_vertex_manager_write_ptr = data;
+	std::memcpy(g_vertex_manager_write_ptr, &data, sizeof(T));
 	g_vertex_manager_write_ptr += sizeof(T);
 }


### PR DESCRIPTION
Eliminates most ubsan asserts that stem from VideoCommon when running starfield.