### PR TITLE
GLInterface: Fix VideoSW on linux + OSX (v2)

### DIFF
--- a/Source/Core/VideoBackends/OGL/GLInterface/AGL.cpp
+++ b/Source/Core/VideoBackends/OGL/GLInterface/AGL.cpp
@@ -15,7 +15,7 @@ void cInterfaceAGL::Swap()
 
 // Create rendering window.
 // Call browser: Core.cpp:EmuThread() > main.cpp:Video_Initialize()
-bool cInterfaceAGL::Create(void *window_handle)
+bool cInterfaceAGL::Create(void *window_handle, bool core)
 {
 	cocoaWin = reinterpret_cast<NSView*>(window_handle);
 	NSSize size = [cocoaWin frame].size;
@@ -33,7 +33,7 @@ bool cInterfaceAGL::Create(void *window_handle)
 	s_backbuffer_width = size.width;
 	s_backbuffer_height = size.height;
 
-	NSOpenGLPixelFormatAttribute attr[] = { NSOpenGLPFADoubleBuffer, NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core, NSOpenGLPFAAccelerated, 0 };
+	NSOpenGLPixelFormatAttribute attr[] = { NSOpenGLPFADoubleBuffer, NSOpenGLPFAOpenGLProfile, core ? NSOpenGLProfileVersion3_2Core : NSOpenGLProfileVersionLegacy, NSOpenGLPFAAccelerated, 0 };
 	NSOpenGLPixelFormat *fmt = [[NSOpenGLPixelFormat alloc]
 		initWithAttributes: attr];
 	if (fmt == nil)

--- a/Source/Core/VideoBackends/OGL/GLInterface/AGL.h
+++ b/Source/Core/VideoBackends/OGL/GLInterface/AGL.h
@@ -17,7 +17,7 @@ private:
 	NSOpenGLContext *cocoaCtx;
 public:
 	void Swap();
-	bool Create(void *window_handle);
+	bool Create(void *window_handle, bool core);
 	bool MakeCurrent();
 	bool ClearCurrent();
 	void Shutdown();

--- a/Source/Core/VideoBackends/OGL/GLInterface/EGL.cpp
+++ b/Source/Core/VideoBackends/OGL/GLInterface/EGL.cpp
@@ -96,7 +96,7 @@ void cInterfaceEGL::DetectMode()
 
 // Create rendering window.
 // Call browser: Core.cpp:EmuThread() > main.cpp:Video_Initialize()
-bool cInterfaceEGL::Create(void *window_handle)
+bool cInterfaceEGL::Create(void *window_handle, bool core)
 {
 	const char *s;
 	EGLint egl_major, egl_minor;

--- a/Source/Core/VideoBackends/OGL/GLInterface/EGL.h
+++ b/Source/Core/VideoBackends/OGL/GLInterface/EGL.h
@@ -26,7 +26,7 @@ public:
 	void Swap();
 	void SetMode(u32 mode) { s_opengl_mode = mode; }
 	void* GetFuncAddress(const std::string& name);
-	bool Create(void *window_handle);
+	bool Create(void *window_handle, bool core);
 	bool MakeCurrent();
 	bool ClearCurrent();
 	void Shutdown();

--- a/Source/Core/VideoBackends/OGL/GLInterface/GLX.cpp
+++ b/Source/Core/VideoBackends/OGL/GLInterface/GLX.cpp
@@ -44,7 +44,7 @@ void cInterfaceGLX::Swap()
 
 // Create rendering window.
 // Call browser: Core.cpp:EmuThread() > main.cpp:Video_Initialize()
-bool cInterfaceGLX::Create(void *window_handle)
+bool cInterfaceGLX::Create(void *window_handle, bool core)
 {
 	dpy = XOpenDisplay(nullptr);
 	int screen = DefaultScreen(dpy);
@@ -107,9 +107,13 @@ bool cInterfaceGLX::Create(void *window_handle)
 		GLX_CONTEXT_FLAGS_ARB,         GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB,
 		None
 	};
-	ctx = glXCreateContextAttribs(dpy, fbconfig, 0, True, context_attribs);
-	XSync(dpy, False);
-	if (!ctx || s_glxError)
+	ctx = nullptr;
+	if (core)
+	{
+		ctx = glXCreateContextAttribs(dpy, fbconfig, 0, True, context_attribs);
+		XSync(dpy, False);
+	}
+	if (core && (!ctx || s_glxError))
 	{
 		int context_attribs_33[] =
 		{

--- a/Source/Core/VideoBackends/OGL/GLInterface/GLX.h
+++ b/Source/Core/VideoBackends/OGL/GLInterface/GLX.h
@@ -23,7 +23,7 @@ public:
 	void SwapInterval(int Interval) override;
 	void Swap() override;
 	void* GetFuncAddress(const std::string& name) override;
-	bool Create(void *window_handle) override;
+	bool Create(void *window_handle, bool core) override;
 	bool MakeCurrent() override;
 	bool ClearCurrent() override;
 	void Shutdown() override;

--- a/Source/Core/VideoBackends/OGL/GLInterface/WGL.cpp
+++ b/Source/Core/VideoBackends/OGL/GLInterface/WGL.cpp
@@ -57,7 +57,7 @@ bool cInterfaceWGL::PeekMessages()
 
 // Create rendering window.
 // Call browser: Core.cpp:EmuThread() > main.cpp:Video_Initialize()
-bool cInterfaceWGL::Create(void *window_handle)
+bool cInterfaceWGL::Create(void *window_handle, bool core)
 {
 	if (window_handle == nullptr)
 		return false;

--- a/Source/Core/VideoBackends/OGL/GLInterface/WGL.h
+++ b/Source/Core/VideoBackends/OGL/GLInterface/WGL.h
@@ -13,7 +13,7 @@ public:
 	void SwapInterval(int Interval);
 	void Swap();
 	void* GetFuncAddress(const std::string& name);
-	bool Create(void *window_handle);
+	bool Create(void *window_handle, bool core);
 	bool MakeCurrent();
 	bool ClearCurrent();
 	void Shutdown();

--- a/Source/Core/VideoBackends/OGL/GLInterfaceBase.h
+++ b/Source/Core/VideoBackends/OGL/GLInterfaceBase.h
@@ -29,7 +29,7 @@ public:
 	virtual void SetMode(u32 mode) { s_opengl_mode = GLInterfaceMode::MODE_OPENGL; }
 	virtual u32 GetMode() { return s_opengl_mode; }
 	virtual void* GetFuncAddress(const std::string& name) { return nullptr; }
-	virtual bool Create(void *window_handle) { return true; }
+	virtual bool Create(void *window_handle, bool core = true) { return true; }
 	virtual bool MakeCurrent() { return true; }
 	virtual bool ClearCurrent() { return true; }
 	virtual void Shutdown() {}

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -78,7 +78,7 @@ bool VideoSoftware::Initialize(void *window_handle)
 
 	InitInterface();
 	GLInterface->SetMode(GLInterfaceMode::MODE_DETECT);
-	if (!GLInterface->Create(window_handle))
+	if (!GLInterface->Create(window_handle, false))
 	{
 		INFO_LOG(VIDEO, "GLInterface::Create failed.");
 		return false;


### PR DESCRIPTION
Our Video Software backend isn't OpenGL Core compatible, so we need a flag to alloc a compatible one.

v2: Fix AGL profile selection.