### PR TITLE
Block WX input when detecting controls

### DIFF
--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -492,6 +492,7 @@ void ControlDialog::DetectControl(wxCommandEvent& event)
 	ciface::Core::Device* const dev = g_controller_interface.FindDevice(m_devq);
 	if (dev)
 	{
+		m_event_filter.BlockEvents(true);
 		btn->SetLabel(_("[ waiting ]"));
 
 		// This makes the "waiting" text work on Linux. true (only if needed) prevents crash on Windows
@@ -504,6 +505,10 @@ void ControlDialog::DetectControl(wxCommandEvent& event)
 			SelectControl(ctrl->GetName());
 
 		btn->SetLabel(lbl);
+
+		// This lets the input events be sent to the filter and discarded before unblocking
+		wxTheApp->Yield(true);
+		m_event_filter.BlockEvents(false);
 	}
 }
 
@@ -531,6 +536,7 @@ bool GamepadPage::DetectButton(ControlButton* button)
 	ciface::Core::Device* const dev = g_controller_interface.FindDevice(controller->default_device);
 	if (dev)
 	{
+		m_event_filter.BlockEvents(true);
 		button->SetLabel(_("[ waiting ]"));
 
 		// This makes the "waiting" text work on Linux. true (only if needed) prevents crash on Windows
@@ -548,6 +554,10 @@ bool GamepadPage::DetectButton(ControlButton* button)
 			g_controller_interface.UpdateReference(button->control_reference, controller->default_device);
 			success = true;
 		}
+
+		// This lets the input events be sent to the filter and discarded before unblocking
+		wxTheApp->Yield(true);
+		m_event_filter.BlockEvents(false);
 	}
 
 	UpdateGUI();
@@ -1071,4 +1081,15 @@ InputConfigDialog::InputConfigDialog(wxWindow* const parent, InputConfig& config
 	m_update_timer.SetOwner(this);
 	Bind(wxEVT_TIMER, &InputConfigDialog::UpdateBitmaps, this);
 	m_update_timer.Start(PREVIEW_UPDATE_TIME, wxTIMER_CONTINUOUS);
+}
+
+int InputEventFilter::FilterEvent(wxEvent& event)
+{
+	if (m_block && ShouldCatchEventType(event.GetEventType()))
+	{
+		event.StopPropagation();
+		return Event_Processed;
+	}
+
+	return Event_Skip;
 }

--- a/Source/Core/DolphinWX/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/InputConfigDiag.h
@@ -17,6 +17,7 @@
 #include <vector>
 #include <wx/button.h>
 #include <wx/dialog.h>
+#include <wx/eventfilter.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
@@ -83,6 +84,36 @@ public:
 	ControllerEmu::ControlGroup::Setting* const setting;
 };
 
+class InputEventFilter : public wxEventFilter
+{
+public:
+	InputEventFilter()
+	{
+		wxEvtHandler::AddFilter(this);
+	}
+
+	~InputEventFilter()
+	{
+		wxEvtHandler::RemoveFilter(this);
+	}
+
+	int FilterEvent(wxEvent& event) override;
+
+	void BlockEvents(bool block) { m_block = block; }
+
+private:
+	static bool ShouldCatchEventType(wxEventType type)
+	{
+		return type == wxEVT_KEY_DOWN || type == wxEVT_KEY_UP ||
+			type == wxEVT_CHAR || type == wxEVT_CHAR_HOOK ||
+			type == wxEVT_LEFT_DOWN || type == wxEVT_LEFT_UP ||
+			type == wxEVT_MIDDLE_DOWN || type == wxEVT_MIDDLE_UP ||
+			type == wxEVT_RIGHT_DOWN || type == wxEVT_RIGHT_UP;
+	}
+
+	bool m_block = false;
+};
+
 class GamepadPage;
 
 class ControlDialog : public wxDialog
@@ -120,6 +151,7 @@ private:
 	wxSlider*          range_slider;
 	wxStaticText*      m_bound_label;
 	wxStaticText*      m_error_label;
+	InputEventFilter   m_event_filter;
 	ciface::Core::DeviceQualifier m_devq;
 };
 
@@ -209,7 +241,9 @@ private:
 
 	ControlDialog*           m_control_dialog;
 	InputConfigDialog* const m_config_dialog;
-	InputConfig& m_config;
+	InputConfig&             m_config;
+	InputEventFilter         m_event_filter;
+
 	bool DetectButton(ControlButton* button);
 	bool m_iterate = false;
 };


### PR DESCRIPTION
This, to some extent, prevents operating the WX GUI when detecting controls, so binding Escape doesn't close the window, Space doesn't press the current button again, etc.