### PR TITLE
Remove odd way of getting ID in ISOProperties

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -106,16 +106,7 @@ CISOProperties::CISOProperties(const GameListItem& game_list_item, wxWindow* par
 	// Load ISO data
 	OpenISO = DiscIO::CreateVolumeFromFilename(OpenGameListItem.GetFileName());
 
-	// Is it really necessary to use GetTitleID if GetUniqueID fails?
 	game_id = OpenISO->GetUniqueID();
-	if (game_id.empty())
-	{
-		u8 game_id_bytes[8];
-		if (OpenISO->GetTitleID(game_id_bytes))
-		{
-			game_id = StringFromFormat("%016" PRIx64, Common::swap64(game_id_bytes));
-		}
-	}
 
 	// Load game INIs
 	GameIniFileLocal = File::GetUserPath(D_GAMESETTINGS_IDX) + game_id + ".ini";


### PR DESCRIPTION
Other code (like GameListItem) simply calls GetUniqueID, and I've never seen that lead to any problems.