### PR TITLE
FileSearch: Don't use RegExes, just do string comparisons.

### DIFF
--- a/Source/Core/Common/FileSearch.h
+++ b/Source/Core/Common/FileSearch.h
@@ -7,5 +7,5 @@
 #include <string>
 #include <vector>
 
-std::vector<std::string> DoFileSearch(const std::vector<std::string>& globs, const std::vector<std::string>& directories, bool recursive = false);
+std::vector<std::string> DoFileSearch(const std::vector<std::string>& exts, const std::vector<std::string>& directories, bool recursive = false);
 std::vector<std::string> FindSubdirectories(const std::vector<std::string>& directories, bool recursive);

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -153,7 +153,7 @@ GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u
 		hdrfile.ReadBytes(&m_hdr, BLOCK_SIZE);
 	}
 
-	std::vector<std::string> rFilenames = DoFileSearch({"*.gci"}, {m_SaveDirectory});
+	std::vector<std::string> rFilenames = DoFileSearch({".gci"}, {m_SaveDirectory});
 
 	if (rFilenames.size() > 112)
 	{

--- a/Source/Core/DolphinQt/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt/GameList/GameTracker.cpp
@@ -91,21 +91,21 @@ void DGameTracker::ScanForGames()
 	std::vector<std::string> exts;
 	if (SConfig::GetInstance().m_ListGC)
 	{
-		exts.push_back("*.gcm");
-		exts.push_back("*.gcz");
+		exts.push_back(".gcm");
+		exts.push_back(".gcz");
 	}
 	if (SConfig::GetInstance().m_ListWii || SConfig::GetInstance().m_ListGC)
 	{
-		exts.push_back("*.iso");
-		exts.push_back("*.ciso");
-		exts.push_back("*.wbfs");
+		exts.push_back(".iso");
+		exts.push_back(".ciso");
+		exts.push_back(".wbfs");
 	}
 	if (SConfig::GetInstance().m_ListWad)
-		exts.push_back("*.wad");
+		exts.push_back(".wad");
 	if (SConfig::GetInstance().m_ListElfDol)
 	{
-		exts.push_back("*.dol");
-		exts.push_back("*.elf");
+		exts.push_back(".dol");
+		exts.push_back(".elf");
 	}
 
 	auto rFilenames = DoFileSearch(exts, SConfig::GetInstance().m_ISOFolder, SConfig::GetInstance().m_RecursiveISOFolder);

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
@@ -162,7 +162,7 @@ void InterfaceConfigPane::LoadGUIValues()
 
 void InterfaceConfigPane::LoadThemes()
 {
-	auto sv = DoFileSearch({"*"}, {
+	auto sv = DoFileSearch({""}, {
 		File::GetUserPath(D_THEMES_IDX),
 		File::GetSysDirectory() + THEMES_DIR
 	}, /*recursive*/ false);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1956,7 +1956,7 @@ void CFrame::GameListChanged(wxCommandEvent& event)
 		SConfig::GetInstance().m_ListDrives = event.IsChecked();
 		break;
 	case IDM_PURGE_CACHE:
-		std::vector<std::string> rFilenames = DoFileSearch({"*.cache"}, {File::GetUserPath(D_CACHE_IDX)});
+		std::vector<std::string> rFilenames = DoFileSearch({".cache"}, {File::GetUserPath(D_CACHE_IDX)});
 
 		for (const std::string& rFilename : rFilenames)
 		{

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -465,20 +465,20 @@ void CGameListCtrl::ScanForISOs()
 	std::vector<std::string> Extensions;
 
 	if (SConfig::GetInstance().m_ListGC)
-		Extensions.push_back("*.gcm");
+		Extensions.push_back(".gcm");
 	if (SConfig::GetInstance().m_ListWii || SConfig::GetInstance().m_ListGC)
 	{
-		Extensions.push_back("*.iso");
-		Extensions.push_back("*.ciso");
-		Extensions.push_back("*.gcz");
-		Extensions.push_back("*.wbfs");
+		Extensions.push_back(".iso");
+		Extensions.push_back(".ciso");
+		Extensions.push_back(".gcz");
+		Extensions.push_back(".wbfs");
 	}
 	if (SConfig::GetInstance().m_ListWad)
-		Extensions.push_back("*.wad");
+		Extensions.push_back(".wad");
 	if (SConfig::GetInstance().m_ListElfDol)
 	{
-		Extensions.push_back("*.dol");
-		Extensions.push_back("*.elf");
+		Extensions.push_back(".dol");
+		Extensions.push_back(".elf");
 	}
 
 	auto rFilenames = DoFileSearch(Extensions, SConfig::GetInstance().m_ISOFolder, SConfig::GetInstance().m_RecursiveISOFolder);

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -172,7 +172,7 @@ void InputConfigDialog::UpdateProfileComboBox()
 	pname += PROFILES_PATH;
 	pname += m_config.profile_name;
 
-	std::vector<std::string> sv = DoFileSearch({"*.ini"}, {pname});
+	std::vector<std::string> sv = DoFileSearch({".ini"}, {pname});
 
 	wxArrayString strs;
 	for (const std::string& filename : sv)

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -38,7 +38,6 @@ Make AA apply instantly during gameplay if possible
 
 #include <algorithm>
 #include <cstdarg>
-#include <regex>
 
 #include "Common/Atomic.h"
 #include "Common/CommonPaths.h"
@@ -105,7 +104,11 @@ static std::vector<std::string> GetShaders(const std::string &sub_dir = "")
 	});
 	std::vector<std::string> result;
 	for (std::string path : paths)
-		result.push_back(std::regex_replace(path, std::regex("^.*/(.*)\\.glsl$"), "$1"));
+	{
+		std::string name;
+		SplitPath(path, nullptr, &name, nullptr);
+		result.push_back(name);
+	}
 	return result;
 }
 

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -99,7 +99,7 @@ std::string VideoBackend::GetDisplayName() const
 
 static std::vector<std::string> GetShaders(const std::string &sub_dir = "")
 {
-	std::vector<std::string> paths = DoFileSearch({"*.glsl"}, {
+	std::vector<std::string> paths = DoFileSearch({".glsl"}, {
 		File::GetUserPath(D_SHADERS_IDX) + sub_dir,
 		File::GetSysDirectory() + SHADERS_DIR DIR_SEP + sub_dir
 	});

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -84,11 +84,11 @@ void HiresTexture::Update()
 	std::string szDir = StringFromFormat("%s%s", File::GetUserPath(D_HIRESTEXTURES_IDX).c_str(), gameCode.c_str());
 
 	std::vector<std::string> Extensions {
-		"*.png",
-		"*.bmp",
-		"*.tga",
-		"*.dds",
-		"*.jpg" // Why not? Could be useful for large photo-like textures
+		".png",
+		".bmp",
+		".tga",
+		".dds",
+		".jpg" // Why not? Could be useful for large photo-like textures
 	};
 
 	auto rFilenames = DoFileSearch(Extensions, {szDir}, /*recursive*/ true);


### PR DESCRIPTION
Nothing used the RegEx feature of FileSearch, and GCC < 4.9 doesn't support C++11 RegEx properly, so get rid of it.

CC @comex as he wrote the feature & @lioncash for code review