### PR TITLE
ISOProperties: Fixed editor launch for configs (on Windows).

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -1199,6 +1199,10 @@ void CISOProperties::LaunchExternalEditor(const std::string& filename, bool wait
 		}
 	}
 
+#ifdef _WIN32
+	wxString OpenCommand = StrToWxStr("cmd /c \"" + filename + "\"");
+	wxExecute(OpenCommand, wxEXEC_HIDE_CONSOLE);
+#else
 	wxString OpenCommand = filetype->GetOpenCommand(StrToWxStr(filename));
 	if (OpenCommand.IsEmpty())
 	{
@@ -1221,6 +1225,7 @@ void CISOProperties::LaunchExternalEditor(const std::string& filename, bool wait
 
 	if (wait_until_closed)
 		bRefreshList = true; // Just in case
+#endif
 #endif
 }
 


### PR DESCRIPTION
Old method was not able to find and launch associated editor.
Changed it to simple "cmd /c file_name".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3077)
<!-- Reviewable:end -->
