### PR TITLE
OpenAL 32-bit fixed point support

### DIFF
--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -38,18 +38,35 @@
 #undef BOOL
 #endif
 
-// 16 bit Stereo
 #define SFX_MAX_SOURCE 1
 #define OAL_MAX_BUFFERS 32
 #define OAL_MAX_SAMPLES 256
 #define STEREO_CHANNELS 2
 #define SURROUND_CHANNELS 6  // number of channels in surround mode
 #define SIZE_SHORT 2
+#define SIZE_INT32 4
 #define SIZE_FLOAT 4  // size of a float in bytes
 #define FRAME_STEREO_SHORT STEREO_CHANNELS* SIZE_SHORT
 #define FRAME_STEREO_FLOAT STEREO_CHANNELS* SIZE_FLOAT
+#define FRAME_STEREO_INT32 STEREO_CHANNELS* SIZE_INT32
 #define FRAME_SURROUND_FLOAT SURROUND_CHANNELS* SIZE_FLOAT
 #define FRAME_SURROUND_SHORT SURROUND_CHANNELS* SIZE_SHORT
+#define FRAME_SURROUND_INT32 SURROUND_CHANNELS* SIZE_INT32
+#endif
+
+#if defined(__APPLE__)
+// OS X does not have the alext AL_FORMAT_STEREO_FLOAT32, AL_FORMAT_STEREO32,
+// AL_FORMAT_51CHN32 and AL_FORMAT_51CHN16 yet.
+#define AL_FORMAT_STEREO_FLOAT32 0
+#define AL_FORMAT_STEREO32 0
+#define AL_FORMAT_51CHN32 0
+#define AL_FORMAT_51CHN16 0
+#elif defined(_WIN32)
+// Only X-Fi on Windows supports the alext AL_FORMAT_STEREO32 alext for now,
+// but it is not documented or in "OpenAL/include/al.h".
+#define AL_FORMAT_STEREO32 0x1203
+#else
+#define AL_FORMAT_STEREO32 0
 #endif
 
 class OpenALStream final : public SoundStream


### PR DESCRIPTION
I believe that clamping to (-1 ; 1) is the best solution, and this new method works correctly, even though it is possible to hear the hard-clipping it is better than distortion. When the DPL2 decoder is reworked the clamping will probably be unnecessary, but until then it is needed.

Original PR message follows:

The X-Fi DSP supports only 32-bit and 16-bit fixed point buffers. This commit adds support to 32-bit fixed point buffers on stereo and on surround and allows a X-Fi to output surround sound with no artifacts or noise. I also changed how floating point support is detected.
There is a problem, though. The Dolby Decoder gives some samples outside the usual [ -1 ; 1 ] range, and just clamping them to 1 or -1 gives undesirable sound artifacts as the samples are usually at [ -2,5 ; 2,5 ]. As there is enough dynamic range on 32-bit fixed point, I am clamping it to [ -4 ; 4 ]. The best solution is to fix the DPL2 decoder somehow, but I am still trying to understand how it works.
FFDShow always clamps to one, but I did not verify if its DPL2 decoder gives samples outside [ -1; 1 ].

Tested on OpenAL Soft, X-Fi and Generic Software (wrap_oal). Everything seems to be working, but someone needs to test it on Linux and on Mac.

EDIT:
I am not clamping on [ -4; 4 ] anymore as this is clearly wrong, but this causes some artifacts. I need to fix the DPL2 decoder somehow.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3080)

<!-- Reviewable:end -->
