### PR TITLE
Use correct GetTicksPerSecond() value in IPC delays

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -57,10 +57,6 @@ They will also generate a true or false return for UpdateInterrupts() in WII_IPC
 
 #include "Core/PowerPC/PowerPC.h"
 
-const u32 IPC_DEFAULT_DELAY = SystemTimers::GetTicksPerSecond() / 4000;	// 250 us
-const IPCCommandResult IPC_NO_REPLY = { false, 0 };
-const IPCCommandResult IPC_DEFAULT_REPLY = { true, IPC_DEFAULT_DELAY };
-
 namespace WII_IPC_HLE_Interface
 {
 
@@ -353,7 +349,7 @@ void DoState(PointerWrap &p)
 
 void ExecuteCommand(u32 _Address)
 {
-	IPCCommandResult result = IPC_NO_REPLY;
+	IPCCommandResult result = IWII_IPC_HLE_Device::GetNoReply();
 
 	IPCCommandType Command = static_cast<IPCCommandType>(Memory::Read_U32(_Address));
 	s32 DeviceID = Memory::Read_U32(_Address + 8);
@@ -392,7 +388,7 @@ void ExecuteCommand(u32 _Address)
 				if (j == ES_MAX_COUNT)
 				{
 					Memory::Write_U32(FS_EESEXHAUSTED, _Address + 4);
-					result = IPC_DEFAULT_REPLY;
+					result = IWII_IPC_HLE_Device::GetDefaultReply();
 				}
 			}
 			else if (DeviceName.find("/dev/") == 0)
@@ -410,7 +406,7 @@ void ExecuteCommand(u32 _Address)
 				{
 					WARN_LOG(WII_IPC_HLE, "Unimplemented device: %s", DeviceName.c_str());
 					Memory::Write_U32(FS_ENOENT, _Address+4);
-					result = IPC_DEFAULT_REPLY;
+					result = IWII_IPC_HLE_Device::GetDefaultReply();
 				}
 			}
 			else
@@ -429,7 +425,7 @@ void ExecuteCommand(u32 _Address)
 		else
 		{
 			Memory::Write_U32(FS_EFDEXHAUSTED, _Address + 4);
-			result = IPC_DEFAULT_REPLY;
+			result = IWII_IPC_HLE_Device::GetDefaultReply();
 		}
 		break;
 	}
@@ -452,7 +448,7 @@ void ExecuteCommand(u32 _Address)
 		else
 		{
 			Memory::Write_U32(FS_EINVAL, _Address + 4);
-			result = IPC_DEFAULT_REPLY;
+			result = IWII_IPC_HLE_Device::GetDefaultReply();
 		}
 		break;
 	}
@@ -465,7 +461,7 @@ void ExecuteCommand(u32 _Address)
 		else
 		{
 			Memory::Write_U32(FS_EINVAL, _Address + 4);
-			result = IPC_DEFAULT_REPLY;
+			result = IWII_IPC_HLE_Device::GetDefaultReply();
 		}
 		break;
 	}
@@ -478,7 +474,7 @@ void ExecuteCommand(u32 _Address)
 		else
 		{
 			Memory::Write_U32(FS_EINVAL, _Address + 4);
-			result = IPC_DEFAULT_REPLY;
+			result = IWII_IPC_HLE_Device::GetDefaultReply();
 		}
 		break;
 	}
@@ -491,7 +487,7 @@ void ExecuteCommand(u32 _Address)
 		else
 		{
 			Memory::Write_U32(FS_EINVAL, _Address + 4);
-			result = IPC_DEFAULT_REPLY;
+			result = IWII_IPC_HLE_Device::GetDefaultReply();
 		}
 		break;
 	}

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -35,10 +35,6 @@ enum IPCCommandType : u32
 	IPC_REP_ASYNC  = 8
 };
 
-extern const u32 IPC_DEFAULT_DELAY;
-extern const IPCCommandResult IPC_NO_REPLY;
-extern const IPCCommandResult IPC_DEFAULT_REPLY;
-
 namespace WII_IPC_HLE_Interface
 {
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -126,7 +126,7 @@ public:
 		WARN_LOG(WII_IPC_HLE, "%s does not support Open()", m_Name.c_str());
 		Memory::Write_U32(FS_ENOENT, _CommandAddress + 4);
 		m_Active = true;
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce = false)
@@ -135,10 +135,10 @@ public:
 		if (!_bForce)
 			Memory::Write_U32(FS_EINVAL, _CommandAddress + 4);
 		m_Active = false;
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
-#define UNIMPLEMENTED_CMD(cmd) WARN_LOG(WII_IPC_HLE, "%s does not support "#cmd"()", m_Name.c_str()); return IPC_DEFAULT_REPLY;
+#define UNIMPLEMENTED_CMD(cmd) WARN_LOG(WII_IPC_HLE, "%s does not support "#cmd"()", m_Name.c_str()); return GetDefaultReply();
 	virtual IPCCommandResult Seek(u32)   { UNIMPLEMENTED_CMD(Seek) }
 	virtual IPCCommandResult Read(u32)   { UNIMPLEMENTED_CMD(Read) }
 	virtual IPCCommandResult Write(u32)  { UNIMPLEMENTED_CMD(Write) }
@@ -150,6 +150,11 @@ public:
 
 	virtual bool IsHardware() { return m_Hardware; }
 	virtual bool IsOpened() { return m_Active; }
+
+	// Returns an IPCCommandResult for a reply that takes 250 us (arbitrarily chosen value)
+	static IPCCommandResult GetDefaultReply() { return { true, SystemTimers::GetTicksPerSecond() / 4000 }; }
+	// Returns an IPCCommandResult with no reply. Useful for async commands that will generate a reply later
+	static IPCCommandResult GetNoReply() { return { false, 0 }; }
 
 	std::string m_Name;
 protected:
@@ -228,7 +233,7 @@ public:
 		WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_Name.c_str());
 		Memory::Write_U32(GetDeviceID(), CommandAddress + 4);
 		m_Active = true;
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 	IPCCommandResult Close(u32 CommandAddress, bool bForce = false) override
 	{
@@ -236,19 +241,19 @@ public:
 		if (!bForce)
 			Memory::Write_U32(FS_SUCCESS, CommandAddress + 4);
 		m_Active = false;
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	IPCCommandResult IOCtl(u32 CommandAddress) override
 	{
 		WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_Name.c_str());
 		Memory::Write_U32(FS_SUCCESS, CommandAddress + 4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 	IPCCommandResult IOCtlV(u32 CommandAddress) override
 	{
 		WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_Name.c_str());
 		Memory::Write_U32(FS_SUCCESS, CommandAddress + 4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -53,7 +53,7 @@ IPCCommandResult CWII_IPC_HLE_Device_di::Open(u32 _CommandAddress, u32 _Mode)
 {
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_di::Close(u32 _CommandAddress, bool _bForce)
@@ -61,7 +61,7 @@ IPCCommandResult CWII_IPC_HLE_Device_di::Close(u32 _CommandAddress, bool _bForce
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
@@ -78,9 +78,9 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
 	if (ready_to_execute)
 		StartIOCtl(_CommandAddress);
 
-	// DVDInterface handles the timing, and we handle the reply,
-	// so WII_IPC_HLE shouldn't do any of that.
-	return IPC_NO_REPLY;
+	// DVDInterface handles the timing and we handle the reply,
+	// so WII_IPC_HLE shouldn't handle anything.
+	return GetNoReply();
 }
 
 void CWII_IPC_HLE_Device_di::StartIOCtl(u32 command_address)
@@ -181,5 +181,5 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -96,7 +96,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bF
 	if (_CommandAddress && !_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 _CommandAddress, u32 _Mode)
@@ -131,7 +131,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 _CommandAddress, u32 _Mode
 	if (_CommandAddress)
 		Memory::Write_U32(ReturnValue, _CommandAddress+4);
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 // This isn't theadsafe, but it's only called from the CPU thread.
@@ -238,7 +238,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Seek(u32 _CommandAddress)
 	}
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
 
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
@@ -277,7 +277,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
@@ -310,7 +310,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
@@ -353,7 +353,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
 
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 void CWII_IPC_HLE_Device_FileIO::DoState(PointerWrap &p)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -181,7 +181,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Open(u32 _CommandAddress, u32 _Mode)
 	if (m_Active)
 		INFO_LOG(WII_IPC_ES, "Device was re-opened.");
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce)
@@ -202,7 +202,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 u32 CWII_IPC_HLE_Device_es::OpenTitleContent(u32 CFD, u64 TitleID, u16 Index)
@@ -282,7 +282,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETDEVICEID %08X", ec.getNgId());
 			Memory::Write_U32(ec.getNgId(), Buffer.PayloadBuffer[0].m_Address);
 			Memory::Write_U32(0, _CommandAddress + 0x4);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -312,7 +312,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTITLECONTENTSCNT: TitleID: %08x/%08x  content count %i",
 				(u32)(TitleID>>32), (u32)TitleID, rNANDContent.IsValid() ? NumberOfPrivateContent : (u32)rNANDContent.GetContentSize());
 
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -340,7 +340,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 					rNANDCOntent.GetContentSize());
 			}
 
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -358,7 +358,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_OPENTITLECONTENT: TitleID: %08x/%08x  Index %i -> got CFD %x", (u32)(TitleID>>32), (u32)TitleID, Index, CFD);
 
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -372,7 +372,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(CFD, _CommandAddress + 0x4);
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_OPENCONTENT: Index %i -> got CFD %x", Index, CFD);
 
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -389,7 +389,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			if (itr == m_ContentAccessMap.end())
 			{
 				Memory::Write_U32(-1, _CommandAddress + 0x4);
-				return IPC_DEFAULT_REPLY;
+				return GetDefaultReply();
 			}
 			SContentAccess& rContent = itr->second;
 
@@ -431,7 +431,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_READCONTENT: CFD %x, Address 0x%x, Size %i -> stream pos %i (Index %i)", CFD, Addr, Size, rContent.m_Position, rContent.m_pContent->m_Index);
 
 			Memory::Write_U32(Size, _CommandAddress + 0x4);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -448,14 +448,14 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			if (itr == m_ContentAccessMap.end())
 			{
 				Memory::Write_U32(-1, _CommandAddress + 0x4);
-				return IPC_DEFAULT_REPLY;
+				return GetDefaultReply();
 			}
 
 			delete itr->second.m_pFile;
 			m_ContentAccessMap.erase(itr);
 
 			Memory::Write_U32(0, _CommandAddress + 0x4);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -472,7 +472,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			if (itr == m_ContentAccessMap.end())
 			{
 				Memory::Write_U32(-1, _CommandAddress + 0x4);
-				return IPC_DEFAULT_REPLY;
+				return GetDefaultReply();
 			}
 			SContentAccess& rContent = itr->second;
 
@@ -494,7 +494,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_SEEKCONTENT: CFD %x, Address 0x%x, Mode %i -> Pos %i", CFD, Addr, Mode, rContent.m_Position);
 
 			Memory::Write_U32(rContent.m_Position, _CommandAddress + 0x4);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -544,7 +544,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -567,7 +567,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTITLES: Number of titles returned %i", Count);
 			Memory::Write_U32(0, _CommandAddress + 0x4);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -614,7 +614,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
 			Memory::Write_U32(ViewCount, Buffer.PayloadBuffer[0].m_Address);
 			Memory::Write_U32(retVal, _CommandAddress + 0x4);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -678,7 +678,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETVIEWS for titleID: %08x/%08x (MaxViews = %i)", (u32)(TitleID >> 32), (u32)TitleID, maxViews);
 
 			Memory::Write_U32(retVal, _CommandAddress + 0x4);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -704,7 +704,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTMDVIEWCNT: title: %08x/%08x (view size %i)", (u32)(TitleID >> 32), (u32)TitleID, TMDViewCnt);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -744,7 +744,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETTMDVIEWS: title: %08x/%08x (buffer size: %i)", (u32)(TitleID >> 32), (u32)TitleID, MaxCount);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -752,7 +752,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 		Memory::Write_U32(0, Buffer.PayloadBuffer[1].m_Address);
 		Memory::Write_U32(0, _CommandAddress + 0x4);
 		WARN_LOG(WII_IPC_ES, "IOCTL_ES_GETCONSUMPTION:%d", Memory::Read_U32(_CommandAddress+4));
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 
 	case IOCTL_ES_DELETETICKET:
 		{
@@ -806,7 +806,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETSTOREDTMDSIZE: title: %08x/%08x (view size %i)", (u32)(TitleID >> 32), (u32)TitleID, TMDCnt);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 	case IOCTL_ES_GETSTOREDTMD:
@@ -847,7 +847,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			Memory::Write_U32(0, _CommandAddress + 0x4);
 
 			INFO_LOG(WII_IPC_ES, "IOCTL_ES_GETSTOREDTMD: title: %08x/%08x (buffer size: %i)", (u32)(TitleID >> 32), (u32)TitleID, MaxCount);
-			return IPC_DEFAULT_REPLY;
+			return GetDefaultReply();
 		}
 		break;
 
@@ -1004,7 +1004,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 			// Generate a "reply" to the IPC command.  ES_LAUNCH is unique because it
 			// involves restarting IOS; IOS generates two acknowledgements in a row.
 			WII_IPC_HLE_Interface::EnqueueCommandAcknowledgement(_CommandAddress, 0);
-			return IPC_NO_REPLY;
+			return GetNoReply();
 		}
 		break;
 
@@ -1013,7 +1013,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 		//if the IOS didn't find the Korean keys and 0 if it does. 0 leads to a error 003
 		WARN_LOG(WII_IPC_ES,"IOCTL_ES_CHECKKOREAREGION: Title checked for Korean keys.");
 		Memory::Write_U32(ES_PARAMTER_SIZE_OR_ALIGNMENT , _CommandAddress + 0x4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 
 	case IOCTL_ES_GETDEVICECERT: // (Input: none, Output: 384 bytes)
 		{
@@ -1069,7 +1069,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 	// Write return value (0 means OK)
 	Memory::Write_U32(0, _CommandAddress + 0x4);
 
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 const DiscIO::INANDContentLoader& CWII_IPC_HLE_Device_es::AccessContentDevice(u64 _TitleID)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -17,10 +17,6 @@
 
 static Common::replace_v replacements;
 
-// ~1/1000th of a second is too short and causes hangs in Wii Party
-// Play it safe at 1/500th
-static const IPCCommandResult IPC_FS_REPLY = { true, SystemTimers::GetTicksPerSecond() / 500 };
-
 CWII_IPC_HLE_Device_fs::CWII_IPC_HLE_Device_fs(u32 _DeviceID, const std::string& _rDeviceName)
 	: IWII_IPC_HLE_Device(_DeviceID, _rDeviceName)
 {
@@ -41,7 +37,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::Open(u32 _CommandAddress, u32 _Mode)
 
 	Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
 	m_Active = true;
-	return IPC_FS_REPLY;
+	return GetFSReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_fs::Close(u32 _CommandAddress, bool _bForce)
@@ -50,7 +46,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::Close(u32 _CommandAddress, bool _bForce
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return IPC_FS_REPLY;
+	return GetFSReply();
 }
 
 // Get total filesize of contents of a directory (recursive)
@@ -217,7 +213,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
 
 	Memory::Write_U32(ReturnValue, _CommandAddress+4);
 
-	return IPC_FS_REPLY;
+	return GetFSReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtl(u32 _CommandAddress)
@@ -238,7 +234,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtl(u32 _CommandAddress)
 	u32 ReturnValue = ExecuteCommand(Parameter, BufferIn, BufferInSize, BufferOut, BufferOutSize);
 	Memory::Write_U32(ReturnValue, _CommandAddress + 4);
 
-	return IPC_FS_REPLY;
+	return GetFSReply();
 }
 
 s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _BufferInSize, u32 _BufferOut, u32 _BufferOutSize)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -62,5 +62,9 @@ private:
 		IOCTL_SHUTDOWN    = 0x0D
 	};
 
+	// ~1/1000th of a second is too short and causes hangs in Wii Party
+	// Play it safe at 1/500th
+	IPCCommandResult GetFSReply() const { return { true, SystemTimers::GetTicksPerSecond() / 500 }; }
+
 	s32 ExecuteCommand(u32 Parameter, u32 _BufferIn, u32 _BufferInSize, u32 _BufferOut, u32 _BufferOutSize);
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -115,7 +115,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::Open(u32 _CommandAddress, u32 _Mode)
 	DEBUG_LOG(WII_IPC_HID, "HID::Open");
 	m_Active = true;
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_hid::Close(u32 _CommandAddress, bool _bForce)
@@ -124,7 +124,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::Close(u32 _CommandAddress, bool _bForc
 	m_Active = false;
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
@@ -132,7 +132,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 	if (Core::g_want_determinism)
 	{
 		Memory::Write_U32(-1, _CommandAddress + 0x4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	u32 Parameter     = Memory::Read_U32(_CommandAddress + 0xC);
@@ -149,7 +149,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 		DEBUG_LOG(WII_IPC_HID, "HID::IOCtl(Get Attached) (BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
 			BufferIn, BufferInSize, BufferOut, BufferOutSize);
 		deviceCommandAddress = _CommandAddress;
-		return IPC_NO_REPLY;
+		return GetNoReply();
 	}
 	case IOCTL_HID_OPEN:
 	{
@@ -212,7 +212,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 		//          bmRequestType, bRequest, BufferIn, BufferInSize, BufferOut, BufferOutSize);
 
 		// It's the async way!
-		return IPC_NO_REPLY;
+		return GetNoReply();
 	}
 	case IOCTL_HID_INTERRUPT_OUT:
 	case IOCTL_HID_INTERRUPT_IN:
@@ -243,7 +243,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 		//          Parameter == IOCTL_HID_INTERRUPT_IN ? "In" : "Out", endpoint, length, data, BufferIn, BufferInSize, BufferOut, BufferOutSize);
 
 		// It's the async way!
-		return IPC_NO_REPLY;
+		return GetNoReply();
 	}
 	case IOCTL_HID_SHUTDOWN:
 	{
@@ -276,7 +276,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 4);
 
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 
@@ -325,7 +325,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtlV(u32 _CommandAddress)
 	#endif
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -66,7 +66,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Open(u32 _CommandAddress, u
 	INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: Open");
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Close(u32 _CommandAddress, bool _bForce)
@@ -75,7 +75,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Close(u32 _CommandAddress, 
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
@@ -205,7 +205,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 
@@ -349,7 +349,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Open(u32 _CommandAddress, u
 	INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: Open");
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Close(u32 _CommandAddress, bool _bForce)
@@ -358,7 +358,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Close(u32 _CommandAddress, 
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
@@ -427,7 +427,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
 		Memory::Write_U32(common_result, CommandBuffer.PayloadBuffer.at(common_vector).m_Address + 4);
 	}
 	Memory::Write_U32(return_value, _CommandAddress + 4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 // **********************************************************************************
@@ -446,7 +446,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Open(u32 CommandAddress, u3
 	INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND: Open");
 	Memory::Write_U32(GetDeviceID(), CommandAddress + 4);
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Close(u32 CommandAddress, bool Force)
@@ -455,7 +455,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Close(u32 CommandAddress, b
 	if (!Force)
 		Memory::Write_U32(0, CommandAddress + 4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 // This is just for debugging / playing around.
@@ -548,7 +548,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
 	}
 
 	Memory::Write_U32(return_value, CommandAddress + 4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 // **********************************************************************************
@@ -574,7 +574,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Open(u32 _CommandAddress, u32 _
 	INFO_LOG(WII_IPC_NET, "NET_IP_TOP: Open");
 	Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Close(u32 _CommandAddress, bool _bForce)
@@ -583,7 +583,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Close(u32 _CommandAddress, bool
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 static int inet_pton(const char* src, unsigned char* dst)
@@ -647,7 +647,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 	if (Core::g_want_determinism)
 	{
 		Memory::Write_U32(-1, _CommandAddress + 4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 
@@ -708,7 +708,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 		u32 fd = Memory::Read_U32(BufferIn);
 		WiiSockMan &sm = WiiSockMan::GetInstance();
 		sm.DoSock(fd, _CommandAddress, (NET_IOCTL)Command);
-		return IPC_NO_REPLY;
+		return GetNoReply();
 	}
 	/////////////////////////////////////////////////////////////
 	//                  TODO: Tidy all below                   //
@@ -1171,7 +1171,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
 
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 
@@ -1347,7 +1347,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
 		u32 fd = Memory::Read_U32(_BufferIn2);
 		WiiSockMan &sm = WiiSockMan::GetInstance();
 		sm.DoSock(fd, CommandAddress, IOCTLV_SO_SENDTO);
-		return IPC_NO_REPLY;
+		return GetNoReply();
 		break;
 	}
 	case IOCTLV_SO_RECVFROM:
@@ -1355,7 +1355,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
 		u32 fd = Memory::Read_U32(_BufferIn);
 		WiiSockMan &sm = WiiSockMan::GetInstance();
 		sm.DoSock(fd, CommandAddress, IOCTLV_SO_RECVFROM);
-		return IPC_NO_REPLY;
+		return GetNoReply();
 		break;
 	}
 	case IOCTLV_SO_GETADDRINFO:
@@ -1532,8 +1532,9 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
 	}
 
 	Memory::Write_U32(ReturnValue, CommandAddress + 4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
+
 u32 CWII_IPC_HLE_Device_net_ip_top::Update()
 {
 	WiiSockMan::GetInstance().Update();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -461,7 +461,7 @@ public:
 	{
 		INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Open");
 		Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
@@ -469,7 +469,7 @@ public:
 		INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Close");
 		if (!_bForce)
 			Memory::Write_U32(0, _CommandAddress + 4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	IPCCommandResult IOCtl(u32 _CommandAddress) override
@@ -515,7 +515,7 @@ public:
 		// write return values
 		Memory::Write_U32(common_result, BufferOut);
 		Memory::Write_U32(result, _CommandAddress + 4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 private:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -58,7 +58,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Open(u32 _CommandAddress, u32 _Mod
 {
 	Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Close(u32 _CommandAddress, bool _bForce)
@@ -68,7 +68,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Close(u32 _CommandAddress, bool _b
 		Memory::Write_U32(0, _CommandAddress + 4);
 	}
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(u32 _CommandAddress)
@@ -84,7 +84,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(u32 _CommandAddress)
 	         GetDeviceName().c_str(), Command,
 	         BufferIn, BufferInSize, BufferOut, BufferOutSize);
 	Memory::Write_U32(0, _CommandAddress + 0x4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
@@ -134,7 +134,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
 	if (Core::g_want_determinism)
 	{
 		Memory::Write_U32(-1, _CommandAddress + 0x4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	switch (CommandBuffer.Parameter)
@@ -402,7 +402,7 @@ _SSL_NEW_ERROR:
 		{
 			WiiSockMan &sm = WiiSockMan::GetInstance();
 			sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_DOHANDSHAKE);
-			return IPC_NO_REPLY;
+			return GetNoReply();
 		}
 		else
 		{
@@ -417,7 +417,7 @@ _SSL_NEW_ERROR:
 		{
 			WiiSockMan &sm = WiiSockMan::GetInstance();
 			sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_WRITE);
-			return IPC_NO_REPLY;
+			return GetNoReply();
 		}
 		else
 		{
@@ -442,7 +442,7 @@ _SSL_NEW_ERROR:
 		{
 			WiiSockMan &sm = WiiSockMan::GetInstance();
 			sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_READ);
-			return IPC_NO_REPLY;
+			return GetNoReply();
 		}
 		else
 		{
@@ -515,6 +515,6 @@ _SSL_NEW_ERROR:
 	// SSL return codes are written to BufferIn
 	Memory::Write_U32(0, _CommandAddress+4);
 
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -87,7 +87,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Open(u32 _CommandAddress, u32 _
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 0x4);
 	memset(m_Registers, 0, sizeof(m_Registers));
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool _bForce)
@@ -101,7 +101,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 0x4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 // The front SD slot
@@ -228,7 +228,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
 		Memory::Write_U32(0, _CommandAddress + 0x4);
 		// Check if the condition is already true
 		EventNotify();
-		return IPC_NO_REPLY;
+		return GetNoReply();
 	}
 	else if (ReturnValue == RET_EVENT_UNREGISTER)
 	{
@@ -239,12 +239,12 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
 		m_event.addr = 0;
 		m_event.type = EVENT_NONE;
 		Memory::Write_U32(0, _CommandAddress + 0x4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 	else
 	{
 		Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 }
 
@@ -282,7 +282,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(u32 _CommandAddress)
 
 	Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
 
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 u32 CWII_IPC_HLE_Device_sdio_slot0::ExecuteCommand(u32 _BufferIn, u32 _BufferInSize,

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -42,7 +42,7 @@ public:
 		INFO_LOG(WII_IPC_STM, "STM immediate: Open");
 		Memory::Write_U32(GetDeviceID(), _CommandAddress+4);
 		m_Active = true;
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
@@ -51,7 +51,7 @@ public:
 		if (!_bForce)
 			Memory::Write_U32(0, _CommandAddress+4);
 		m_Active = false;
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	IPCCommandResult IOCtl(u32 _CommandAddress) override
@@ -108,7 +108,7 @@ public:
 
 		// Write return value to the IPC call
 		Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 };
 
@@ -130,7 +130,7 @@ public:
 	{
 		Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
 		m_Active = true;
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
@@ -141,7 +141,7 @@ public:
 		if (!_bForce)
 			Memory::Write_U32(0, _CommandAddress+4);
 		m_Active = false;
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	IPCCommandResult IOCtl(u32 _CommandAddress) override
@@ -183,7 +183,7 @@ public:
 
 		// Write return value to the IPC call, 0 means success
 		Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-		return IPC_DEFAULT_REPLY;
+		return GetDefaultReply();
 	}
 
 	// STATE_TO_SAVE

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -157,7 +157,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::Open(u32 _CommandAddress, 
 
 	Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::Close(u32 _CommandAddress, bool _bForce)
@@ -173,7 +173,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::Close(u32 _CommandAddress,
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::IOCtl(u32 _CommandAddress)
@@ -320,7 +320,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::IOCtlV(u32 _CommandAddress
 
 	// write return value
 	Memory::Write_U32(0, _CommandAddress + 4);
-	return { _SendReply, IPC_DEFAULT_DELAY };
+	return _SendReply ? GetDefaultReply() : GetNoReply();
 }
 
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -39,7 +39,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Open(u32 _CommandAddress, u32 _Mod
 	//m_MessageQueue.push(SMessageData(MSG_KBD_CONNECT, 0, nullptr));
 	Memory::Write_U32(m_DeviceID, _CommandAddress+4);
 	m_Active = true;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _bForce)
@@ -50,7 +50,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _b
 	if (!_bForce)
 		Memory::Write_U32(0, _CommandAddress + 4);
 	m_Active = false;
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Write(u32 _CommandAddress)
@@ -59,7 +59,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Write(u32 _CommandAddress)
 #if defined(_DEBUG) || defined(DEBUGFAST)
 	DumpCommands(_CommandAddress, 10, LogTypes::WII_IPC_STM, LogTypes::LDEBUG);
 #endif
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::IOCtl(u32 _CommandAddress)
@@ -73,7 +73,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::IOCtl(u32 _CommandAddress)
 	}
 
 	Memory::Write_U32(0, _CommandAddress + 0x4);
-	return IPC_DEFAULT_REPLY;
+	return GetDefaultReply();
 }
 
 bool CWII_IPC_HLE_Device_usb_kbd::IsKeyPressed(int _Key)


### PR DESCRIPTION
The constant IPC_DEFAULT_DELAY used a value from GetTicksPerSecond(), which in turn uses a value from CPU_CORE_CLOCK... but CPU_CORE_CLOCK isn't actually a constant! It's first initialized to 486 MHz and then changed to 729 MHz in SystemTimers::PreInit if emulating a Wii. This means that the IPC delays always used 486 MHz and thus were wrong. To fix this, the IPC reply constants are changed to functions.