### PR TITLE
MSVS2015: Workaround for warning generated by MS header (shlobj.h).

### DIFF
--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -3,7 +3,10 @@
 // Refer to the license.txt file included.
 
 #ifdef _WIN32
+//http://connect.microsoft.com/VisualStudio/feedbackdetail/view/956372/shlobj-h-invalid-typedef-c4091-warning
+#pragma warning(disable : 4091)
 #include <shlobj.h>    // for SHGetFolderPath
+#pragma warning(default : 4091)
 #endif
 
 #include "Common/CommonPaths.h"


### PR DESCRIPTION
There are versions of shlobj.h (distributed by MS) that generate a warning.
So I was forced to disable that warning for that header file to be able to build Dolphin.
The problem is known to MS: http://connect.microsoft.com/VisualStudio/feedbackdetail/view/956372/shlobj-h-invalid-typedef-c4091-warning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3086)
<!-- Reviewable:end -->
