### PR TITLE
GeneralConfig: Option to autoload most recent savestate at game launch.

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -37,7 +37,7 @@ SConfig::SConfig()
   bJITILTimeProfiling(false), bJITILOutputIR(false),
   bFPRF(false), bAccurateNaNs(false),
   bCPUThread(true), bDSPThread(false), bDSPHLE(true),
-  bSkipIdle(true), bSyncGPUOnSkipIdleHack(true), bNTSC(false), bForceNTSCJ(false),
+  bSkipIdle(true), bSyncGPUOnSkipIdleHack(true), bNTSC(false), bForceNTSCJ(false), bAutoLoadSavestate(false),
   bHLE_BS2(true), bEnableCheats(false),
   bEnableMemcardSdWriting(true),
   bDPL2Decoder(false), iLatency(14),
@@ -177,6 +177,7 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
 	display->Set("PAL60", bPAL60);
 	display->Set("DisableScreenSaver", bDisableScreenSaver);
 	display->Set("ForceNTSCJ", bForceNTSCJ);
+	display->Set("AutoLoadSavestate", bAutoLoadSavestate);
 }
 
 void SConfig::SaveGameListSettings(IniFile& ini)
@@ -423,6 +424,7 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
 	display->Get("PAL60",                &bPAL60,                  true);
 	display->Get("DisableScreenSaver",   &bDisableScreenSaver,     true);
 	display->Get("ForceNTSCJ",           &bForceNTSCJ,             false);
+	display->Get("AutoLoadSavestate",    &bAutoLoadSavestate,      false);
 }
 
 void SConfig::LoadGameListSettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -85,6 +85,7 @@ struct SConfig : NonCopyable
 	bool bSyncGPUOnSkipIdleHack;
 	bool bNTSC;
 	bool bForceNTSCJ;
+	bool bAutoLoadSavestate;
 	bool bHLE_BS2;
 	bool bEnableCheats;
 	bool bEnableMemcardSdWriting;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -634,13 +634,15 @@ void Verify(int slot)
 	VerifyAt(MakeStateFilename(slot));
 }
 
-void LoadLastSaved(int i)
+void LoadLastSaved(int i, bool silent)
 {
 	std::map<double, int> savedStates = GetSavedStates();
 
 	if (i > (int)savedStates.size())
-		Core::DisplayMessage("State doesn't exist", 2000);
-	else
+	{
+		if (!silent)
+			Core::DisplayMessage("State doesn't exist", 2000);
+	} else
 	{
 		std::map<double, int>::iterator it = savedStates.begin();
 		std::advance(it, i-1);

--- a/Source/Core/Core/State.h
+++ b/Source/Core/Core/State.h
@@ -50,7 +50,7 @@ void SaveToBuffer(std::vector<u8>& buffer);
 void LoadFromBuffer(std::vector<u8>& buffer);
 void VerifyBuffer(std::vector<u8>& buffer);
 
-void LoadLastSaved(int i = 1);
+void LoadLastSaved(int i = 1, bool silent = true);
 void SaveFirstSaved();
 void UndoSaveState();
 void UndoLoadState();

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -51,6 +51,7 @@ void GeneralConfigPane::InitializeGUI()
 	m_idle_skip_checkbox   = new wxCheckBox(this, wxID_ANY, _("Enable Idle Skipping (speedup)"));
 	m_cheats_checkbox      = new wxCheckBox(this, wxID_ANY, _("Enable Cheats"));
 	m_force_ntscj_checkbox = new wxCheckBox(this, wxID_ANY, _("Force Console as NTSC-J"));
+	m_auto_load_checkbox   = new wxCheckBox(this, wxID_ANY, _("Autoload latest savestate"));
 	m_frame_limit_choice   = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_frame_limit_array_string);
 	m_cpu_engine_radiobox  = new wxRadioBox(this, wxID_ANY, _("CPU Emulator Engine"), wxDefaultPosition, wxDefaultSize, m_cpu_engine_array_string, 0, wxRA_SPECIFY_ROWS);
 
@@ -58,12 +59,14 @@ void GeneralConfigPane::InitializeGUI()
 	m_idle_skip_checkbox->SetToolTip(_("Attempt to detect and skip wait-loops.\nIf unsure, leave this checked."));
 	m_cheats_checkbox->SetToolTip(_("Enables the use of Action Replay and Gecko cheats."));
 	m_force_ntscj_checkbox->SetToolTip(_("Forces NTSC-J mode for using the Japanese ROM font.\nIf left unchecked, Dolphin defaults to NTSC-U and automatically enables this setting when playing Japanese games."));
+	m_auto_load_checkbox->SetToolTip(_("Automatically loads most recent savestate at game launch."));
 	m_frame_limit_choice->SetToolTip(_("Limits the game speed to the specified number of frames per second (full speed is 60 for NTSC and 50 for PAL)."));
 
 	m_dual_core_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnDualCoreCheckBoxChanged, this);
 	m_idle_skip_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnIdleSkipCheckBoxChanged, this);
 	m_cheats_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnCheatCheckBoxChanged, this);
 	m_force_ntscj_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnForceNTSCJCheckBoxChanged, this);
+	m_auto_load_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnAutoLoadCheckBoxChanged, this);
 	m_frame_limit_choice->Bind(wxEVT_CHOICE, &GeneralConfigPane::OnFrameLimitChoiceChanged, this);
 	m_cpu_engine_radiobox->Bind(wxEVT_RADIOBOX, &GeneralConfigPane::OnCPUEngineRadioBoxChanged, this);
 
@@ -76,6 +79,7 @@ void GeneralConfigPane::InitializeGUI()
 	basic_settings_sizer->Add(m_idle_skip_checkbox, 0, wxALL, 5);
 	basic_settings_sizer->Add(m_cheats_checkbox, 0, wxALL, 5);
 	basic_settings_sizer->Add(frame_limit_sizer);
+	basic_settings_sizer->Add(m_auto_load_checkbox, 0, wxALL, 5);
 
 	wxStaticBoxSizer* const advanced_settings_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Advanced Settings"));
 	advanced_settings_sizer->Add(m_cpu_engine_radiobox, 0, wxALL, 5);
@@ -96,6 +100,7 @@ void GeneralConfigPane::LoadGUIValues()
 	m_idle_skip_checkbox->SetValue(startup_params.bSkipIdle);
 	m_cheats_checkbox->SetValue(startup_params.bEnableCheats);
 	m_force_ntscj_checkbox->SetValue(startup_params.bForceNTSCJ);
+	m_auto_load_checkbox->SetValue(startup_params.bAutoLoadSavestate);
 	m_frame_limit_choice->SetSelection(SConfig::GetInstance().m_Framelimit);
 
 	for (size_t i = 0; i < cpu_cores.size(); ++i)
@@ -138,6 +143,11 @@ void GeneralConfigPane::OnCheatCheckBoxChanged(wxCommandEvent& event)
 void GeneralConfigPane::OnForceNTSCJCheckBoxChanged(wxCommandEvent& event)
 {
 	SConfig::GetInstance().bForceNTSCJ = m_force_ntscj_checkbox->IsChecked();
+}
+
+void GeneralConfigPane::OnAutoLoadCheckBoxChanged(wxCommandEvent& event)
+{
+	SConfig::GetInstance().bAutoLoadSavestate = m_auto_load_checkbox->IsChecked();
 }
 
 void GeneralConfigPane::OnFrameLimitChoiceChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.h
@@ -32,6 +32,7 @@ private:
 	void OnIdleSkipCheckBoxChanged(wxCommandEvent&);
 	void OnCheatCheckBoxChanged(wxCommandEvent&);
 	void OnForceNTSCJCheckBoxChanged(wxCommandEvent&);
+	void OnAutoLoadCheckBoxChanged(wxCommandEvent&);
 	void OnFrameLimitChoiceChanged(wxCommandEvent&);
 	void OnCPUEngineRadioBoxChanged(wxCommandEvent&);
 
@@ -42,6 +43,7 @@ private:
 	wxCheckBox* m_idle_skip_checkbox;
 	wxCheckBox* m_cheats_checkbox;
 	wxCheckBox* m_force_ntscj_checkbox;
+	wxCheckBox* m_auto_load_checkbox;
 
 	wxChoice* m_frame_limit_choice;
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1283,6 +1283,7 @@ void CFrame::PollHotkeys(wxTimerEvent& event)
 
 void CFrame::ParseHotkeys()
 {
+	static bool onceOnLaunch = true;
 	for (int i = 0; i < NUM_HOTKEYS; i++)
 	{
 		switch  (i)
@@ -1324,7 +1325,15 @@ void CFrame::ParseHotkeys()
 
 	if (!Core::IsRunningAndStarted())
 	{
+		onceOnLaunch = true;
 		return;
+	}
+
+	if (onceOnLaunch)
+	{
+		onceOnLaunch = false;
+		if (SConfig::GetInstance().bAutoLoadSavestate)
+			State::LoadLastSaved();
 	}
 
 	// Toggle fullscreen


### PR DESCRIPTION
This allows you to continue to play from the last savestate you've made. You don't need to remember into which slot you've saved last, you don't need to wait for some strange heavy iso-disc access to complete before you can play the game (hi, Xenoblade). The game just continues from the last save.

Added a new option into dolphin.ini and a checkbox to Config->General.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3087)

<!-- Reviewable:end -->
