### PR TITLE
CommandProcessor: Remove unused extern

### DIFF
--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -11,8 +11,6 @@
 class PointerWrap;
 namespace MMIO { class Mapping; }
 
-extern bool MT;
-
 namespace CommandProcessor
 {
 


### PR DESCRIPTION
There's no variable defined that represents said extern.