### PR TITLE
Display all compressed formats in blue in GUI

### DIFF
--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -129,7 +129,7 @@ IBlobReader* CreateBlobReader(const std::string& filename)
 	if (IsWbfsBlob(filename))
 		return WbfsFileReader::Create(filename);
 
-	if (IsCompressedBlob(filename))
+	if (IsGCZBlob(filename))
 		return CompressedBlobReader::Create(filename);
 
 	if (IsCISOBlob(filename))

--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -25,7 +25,8 @@ class IBlobReader
 public:
 	virtual ~IBlobReader() {}
 
-	virtual u64 GetRawSize() const  = 0;
+	virtual bool IsCompressed() const = 0;
+	virtual u64 GetRawSize() const = 0;
 	virtual u64 GetDataSize() const = 0;
 	// NOT thread-safe - can't call this from multiple threads.
 	virtual bool Read(u64 offset, u64 size, u8* out_ptr) = 0;

--- a/Source/Core/DiscIO/CISOBlob.h
+++ b/Source/Core/DiscIO/CISOBlob.h
@@ -36,6 +36,7 @@ class CISOFileReader : public IBlobReader
 public:
 	static CISOFileReader* Create(const std::string& filename);
 
+	bool IsCompressed() const override { return true; }
 	u64 GetDataSize() const override;
 	u64 GetRawSize() const override;
 	bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -55,7 +55,7 @@ CompressedBlobReader::CompressedBlobReader(const std::string& filename) : m_file
 
 CompressedBlobReader* CompressedBlobReader::Create(const std::string& filename)
 {
-	if (IsCompressedBlob(filename))
+	if (IsGCZBlob(filename))
 		return new CompressedBlobReader(filename);
 	else
 		return nullptr;
@@ -148,7 +148,7 @@ bool CompressFileToBlob(const std::string& infile, const std::string& outfile, u
 {
 	bool scrubbing = false;
 
-	if (IsCompressedBlob(infile))
+	if (IsGCZBlob(infile))
 	{
 		PanicAlertT("\"%s\" is already compressed! Cannot compress it further.", infile.c_str());
 		return false;
@@ -330,7 +330,7 @@ bool CompressFileToBlob(const std::string& infile, const std::string& outfile, u
 
 bool DecompressBlobToFile(const std::string& infile, const std::string& outfile, CompressCB callback, void* arg)
 {
-	if (!IsCompressedBlob(infile))
+	if (!IsGCZBlob(infile))
 	{
 		PanicAlertT("File not compressed");
 		return false;
@@ -400,7 +400,7 @@ bool DecompressBlobToFile(const std::string& infile, const std::string& outfile,
 	return true;
 }
 
-bool IsCompressedBlob(const std::string& filename)
+bool IsGCZBlob(const std::string& filename)
 {
 	File::IOFile f(filename, "rb");
 

--- a/Source/Core/DiscIO/CompressedBlob.h
+++ b/Source/Core/DiscIO/CompressedBlob.h
@@ -49,6 +49,7 @@ public:
 	static CompressedBlobReader* Create(const std::string& filename);
 	~CompressedBlobReader();
 	const CompressedBlobHeader &GetHeader() const { return m_header; }
+	bool IsCompressed() const override { return true; }
 	u64 GetDataSize() const override { return m_header.data_size; }
 	u64 GetRawSize() const override { return m_file_size; }
 	u64 GetBlockCompressedSize(u64 block_num) const;

--- a/Source/Core/DiscIO/CompressedBlob.h
+++ b/Source/Core/DiscIO/CompressedBlob.h
@@ -23,11 +23,11 @@
 namespace DiscIO
 {
 
-bool IsCompressedBlob(const std::string& filename);
+bool IsGCZBlob(const std::string& filename);
 
 const u32 kBlobCookie = 0xB10BC001;
 
-// A blob file structure:
+// GCZ file structure:
 // BlobHeader
 // u64 offsetsToBlocks[n], top bit specifies whether the block is compressed, or not.
 // compressed data

--- a/Source/Core/DiscIO/DriveBlob.h
+++ b/Source/Core/DiscIO/DriveBlob.h
@@ -23,6 +23,7 @@ class DriveReader : public SectorReader
 public:
 	static DriveReader* Create(const std::string& drive);
 	~DriveReader();
+	bool IsCompressed() const override { return false; }
 	u64 GetDataSize() const override { return m_size; }
 	u64 GetRawSize() const override { return m_size; }
 

--- a/Source/Core/DiscIO/FileBlob.h
+++ b/Source/Core/DiscIO/FileBlob.h
@@ -19,6 +19,7 @@ class PlainFileReader : public IBlobReader
 public:
 	static PlainFileReader* Create(const std::string& filename);
 
+	bool IsCompressed() const override { return false; }
 	u64 GetDataSize() const override { return m_size; }
 	u64 GetRawSize() const override { return m_size; }
 	bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -101,8 +101,9 @@ public:
 	virtual bool ChangePartition(u64 offset) { return false; }
 
 	virtual ECountry GetCountry() const = 0;
+	virtual bool IsCompressed() const = 0;
+	// Size of virtual disc (not always accurate)
 	virtual u64 GetSize() const = 0;
-
 	// Size on disc (compressed size)
 	virtual u64 GetRawSize() const = 0;
 

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -225,6 +225,11 @@ IVolume::EPlatform CVolumeDirectory::GetVolumeType() const
 	return m_is_wii ? WII_DISC : GAMECUBE_DISC;
 }
 
+bool CVolumeDirectory::IsCompressed() const
+{
+	return false;
+}
+
 u64 CVolumeDirectory::GetSize() const
 {
 	return 0;

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -51,6 +51,7 @@ public:
 
 	ECountry GetCountry() const override;
 
+	bool IsCompressed() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
 

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -168,6 +168,11 @@ std::string CVolumeGC::GetApploaderDate() const
 	return DecodeString(date);
 }
 
+bool CVolumeGC::IsCompressed() const
+{
+	return m_pReader ? m_pReader->IsCompressed() : false;
+}
+
 u64 CVolumeGC::GetSize() const
 {
 	if (m_pReader)

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -39,6 +39,7 @@ public:
 
 	EPlatform GetVolumeType() const override;
 	ECountry GetCountry() const override;
+	bool IsCompressed() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
 

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -124,6 +124,11 @@ std::map<IVolume::ELanguage, std::string> CVolumeWAD::GetNames(bool prefer_long)
 	return ReadWiiNames(name_data);
 }
 
+bool CVolumeWAD::IsCompressed() const
+{
+	return m_pReader ? m_pReader->IsCompressed() : false;
+}
+
 u64 CVolumeWAD::GetSize() const
 {
 	if (m_pReader)

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -37,8 +37,9 @@ public:
 	std::string GetApploaderDate() const override { return ""; }
 
 	EPlatform GetVolumeType() const override;
-
 	ECountry GetCountry() const override;
+
+	bool IsCompressed() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
 

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -250,6 +250,11 @@ u8 CVolumeWiiCrypted::GetDiscNumber() const
 	return disc_number;
 }
 
+bool CVolumeWiiCrypted::IsCompressed() const
+{
+	return m_pReader ? m_pReader->IsCompressed() : false;
+}
+
 u64 CVolumeWiiCrypted::GetSize() const
 {
 	if (m_pReader)

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -43,6 +43,7 @@ public:
 	bool ChangePartition(u64 offset) override;
 
 	ECountry GetCountry() const override;
+	bool IsCompressed() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
 

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -19,6 +19,7 @@ class WbfsFileReader : public IBlobReader
 public:
 	static WbfsFileReader* Create(const std::string& filename);
 
+	bool IsCompressed() const override { return true; }
 	u64 GetDataSize() const override { return m_size; }
 	u64 GetRawSize() const override { return m_size; }
 	bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -113,7 +113,7 @@ GameFile::GameFile(const QString& fileName)
 			m_volume_size = volume->GetSize();
 
 			m_unique_id = QString::fromStdString(volume->GetUniqueID());
-			m_compressed = DiscIO::IsCompressedBlob(fileName.toStdString());
+			m_compressed = DiscIO::IsGCZBlob(fileName.toStdString());
 			m_disc_number = volume->GetDiscNumber();
 			m_revision = volume->GetRevision();
 

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -113,7 +113,7 @@ GameFile::GameFile(const QString& fileName)
 			m_volume_size = volume->GetSize();
 
 			m_unique_id = QString::fromStdString(volume->GetUniqueID());
-			m_compressed = DiscIO::IsGCZBlob(fileName.toStdString());
+			m_compressed = volume->IsCompressed();
 			m_disc_number = volume->GetDiscNumber();
 			m_revision = volume->GetRevision();
 

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -111,7 +111,7 @@ GameListItem::GameListItem(const std::string& _rFileName, const std::unordered_m
 			m_VolumeSize = pVolume->GetSize();
 
 			m_UniqueID = pVolume->GetUniqueID();
-			m_BlobCompressed = DiscIO::IsGCZBlob(_rFileName);
+			m_BlobCompressed = pVolume->IsCompressed();
 			m_disc_number = pVolume->GetDiscNumber();
 			m_Revision = pVolume->GetRevision();
 

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -111,7 +111,7 @@ GameListItem::GameListItem(const std::string& _rFileName, const std::unordered_m
 			m_VolumeSize = pVolume->GetSize();
 
 			m_UniqueID = pVolume->GetUniqueID();
-			m_BlobCompressed = DiscIO::IsCompressedBlob(_rFileName);
+			m_BlobCompressed = DiscIO::IsGCZBlob(_rFileName);
 			m_disc_number = pVolume->GetDiscNumber();
 			m_Revision = pVolume->GetRevision();
 


### PR DESCRIPTION
Only GCZ files used to be displayed as compressed in the GUI despite CISO and WBFS files also being compressed.