### PR TITLE
Don't force EFB Copies to Texture Only off for Metroid Prime

### DIFF
--- a/Data/Sys/GameSettings/GM8.ini
+++ b/Data/Sys/GameSettings/GM8.ini
@@ -21,4 +21,3 @@ EmulationIssues =
 SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
-EFBToTextureEnable = False


### PR DESCRIPTION
Made unnecessary by PRs #2059 and #2960. MP2 and MP3 still need it.