### PR TITLE
SaveState: Fix for race condition in SaveAs(...)

### DIFF
--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -108,6 +108,7 @@
     <ClInclude Include="Network.h" />
     <ClInclude Include="PcapFile.h" />
     <ClInclude Include="Profiler.h" />
+    <ClInclude Include="ScopeGuard.h" />
     <ClInclude Include="SDCardUtil.h" />
     <ClInclude Include="SettingsHandler.h" />
     <ClInclude Include="StringUtil.h" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -53,6 +53,7 @@
     <ClInclude Include="Network.h" />
     <ClInclude Include="PcapFile.h" />
     <ClInclude Include="Profiler.h" />
+    <ClInclude Include="ScopeGuard.h" />
     <ClInclude Include="SDCardUtil.h" />
     <ClInclude Include="SettingsHandler.h" />
     <ClInclude Include="StringUtil.h" />

--- a/Source/Core/Common/ScopeGuard.h
+++ b/Source/Core/Common/ScopeGuard.h
@@ -1,0 +1,50 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+
+namespace Common
+{
+
+class ScopeGuard final
+{
+public:
+	template<class Callable>
+	ScopeGuard(Callable&& finalizer) : m_finalizer(std::forward<Callable>(finalizer)) {}
+
+	ScopeGuard(ScopeGuard&& other) : m_finalizer(std::move(other.m_finalizer))
+	{
+		other.m_finalizer = nullptr;
+	}
+
+	~ScopeGuard()
+	{
+		Exit();
+	}
+
+	void Dismiss()
+	{
+		m_finalizer = nullptr;
+	}
+
+	void Exit()
+	{
+		if (m_finalizer)
+		{
+			m_finalizer(); // must not throw
+			m_finalizer = nullptr;
+		}
+	}
+
+	ScopeGuard(const ScopeGuard&) = delete;
+
+	void operator=(const ScopeGuard&) = delete;
+
+private:
+	std::function<void()> m_finalizer;
+};
+
+}  // Namespace Common


### PR DESCRIPTION
"wait" didn't actually waited for file to flush/close. That sometimes produced savestates with partial data or wrong (zeroed) gameId.

g_compressAndDumpStateSyncEvent.Set() was called before destruction of file object (i.e. before flushing changes and closing file). I've used RAII to correct that.