### PR TITLE
Fix blob type detection for game right-click menu

### DIFF
--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -20,12 +20,23 @@
 namespace DiscIO
 {
 
+// Increment CACHE_REVISION if the enum below is modified (ISOFile.cpp & GameFile.cpp)
+enum class BlobType
+{
+	PLAIN,
+	DRIVE,
+	DIRECTORY,
+	GCZ,
+	CISO,
+	WBFS
+};
+
 class IBlobReader
 {
 public:
 	virtual ~IBlobReader() {}
 
-	virtual bool IsCompressed() const = 0;
+	virtual BlobType GetBlobType() const = 0;
 	virtual u64 GetRawSize() const = 0;
 	virtual u64 GetDataSize() const = 0;
 	// NOT thread-safe - can't call this from multiple threads.

--- a/Source/Core/DiscIO/CISOBlob.h
+++ b/Source/Core/DiscIO/CISOBlob.h
@@ -36,7 +36,7 @@ class CISOFileReader : public IBlobReader
 public:
 	static CISOFileReader* Create(const std::string& filename);
 
-	bool IsCompressed() const override { return true; }
+	BlobType GetBlobType() const override { return BlobType::CISO; }
 	u64 GetDataSize() const override;
 	u64 GetRawSize() const override;
 	bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;

--- a/Source/Core/DiscIO/CompressedBlob.h
+++ b/Source/Core/DiscIO/CompressedBlob.h
@@ -49,7 +49,7 @@ public:
 	static CompressedBlobReader* Create(const std::string& filename);
 	~CompressedBlobReader();
 	const CompressedBlobHeader &GetHeader() const { return m_header; }
-	bool IsCompressed() const override { return true; }
+	BlobType GetBlobType() const override { return BlobType::GCZ; }
 	u64 GetDataSize() const override { return m_header.data_size; }
 	u64 GetRawSize() const override { return m_file_size; }
 	u64 GetBlockCompressedSize(u64 block_num) const;

--- a/Source/Core/DiscIO/DriveBlob.h
+++ b/Source/Core/DiscIO/DriveBlob.h
@@ -23,7 +23,7 @@ class DriveReader : public SectorReader
 public:
 	static DriveReader* Create(const std::string& drive);
 	~DriveReader();
-	bool IsCompressed() const override { return false; }
+	BlobType GetBlobType() const override { return BlobType::DRIVE; }
 	u64 GetDataSize() const override { return m_size; }
 	u64 GetRawSize() const override { return m_size; }
 

--- a/Source/Core/DiscIO/FileBlob.h
+++ b/Source/Core/DiscIO/FileBlob.h
@@ -19,7 +19,7 @@ class PlainFileReader : public IBlobReader
 public:
 	static PlainFileReader* Create(const std::string& filename);
 
-	bool IsCompressed() const override { return false; }
+	BlobType GetBlobType() const override { return BlobType::PLAIN; }
 	u64 GetDataSize() const override { return m_size; }
 	u64 GetRawSize() const override { return m_size; }
 	bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -12,6 +12,7 @@
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
+#include "DiscIO/Blob.h"
 
 namespace DiscIO
 {
@@ -101,7 +102,7 @@ public:
 	virtual bool ChangePartition(u64 offset) { return false; }
 
 	virtual ECountry GetCountry() const = 0;
-	virtual bool IsCompressed() const = 0;
+	virtual BlobType GetBlobType() const = 0;
 	// Size of virtual disc (not always accurate)
 	virtual u64 GetSize() const = 0;
 	// Size on disc (compressed size)

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -16,6 +16,7 @@
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
 #include "Common/Logging/Log.h"
+#include "DiscIO/Blob.h"
 #include "DiscIO/FileBlob.h"
 #include "DiscIO/FileMonitor.h"
 #include "DiscIO/Volume.h"
@@ -227,9 +228,12 @@ IVolume::EPlatform CVolumeDirectory::GetVolumeType() const
 	return m_is_wii ? WII_DISC : GAMECUBE_DISC;
 }
 
-bool CVolumeDirectory::IsCompressed() const
+BlobType CVolumeDirectory::GetBlobType() const
 {
-	return false;
+	// VolumeDirectory isn't actually a blob, but it sort of acts
+	// like one, so it makes sense that it has its own blob type.
+	// It should be made into a proper blob in the future.
+	return BlobType::DIRECTORY;
 }
 
 u64 CVolumeDirectory::GetSize() const

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 
 namespace File { struct FSTEntry; }
@@ -51,7 +52,7 @@ public:
 
 	ECountry GetCountry() const override;
 
-	bool IsCompressed() const override;
+	BlobType GetBlobType() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
 

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -169,9 +169,9 @@ std::string CVolumeGC::GetApploaderDate() const
 	return DecodeString(date);
 }
 
-bool CVolumeGC::IsCompressed() const
+BlobType CVolumeGC::GetBlobType() const
 {
-	return m_pReader ? m_pReader->IsCompressed() : false;
+	return m_pReader ? m_pReader->GetBlobType() : BlobType::PLAIN;
 }
 
 u64 CVolumeGC::GetSize() const

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -10,14 +10,13 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 
 // --- this volume type is used for GC disc images ---
 
 namespace DiscIO
 {
-
-class IBlobReader;
 
 class CVolumeGC : public IVolume
 {
@@ -39,7 +38,7 @@ public:
 
 	EPlatform GetVolumeType() const override;
 	ECountry GetCountry() const override;
-	bool IsCompressed() const override;
+	BlobType GetBlobType() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
 

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -126,9 +126,9 @@ std::map<IVolume::ELanguage, std::string> CVolumeWAD::GetNames(bool prefer_long)
 	return ReadWiiNames(name_data);
 }
 
-bool CVolumeWAD::IsCompressed() const
+BlobType CVolumeWAD::GetBlobType() const
 {
-	return m_pReader ? m_pReader->IsCompressed() : false;
+	return m_pReader ? m_pReader->GetBlobType() : BlobType::PLAIN;
 }
 
 u64 CVolumeWAD::GetSize() const

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 
 // --- this volume type is used for Wad files ---
@@ -18,8 +19,6 @@
 
 namespace DiscIO
 {
-
-class IBlobReader;
 
 class CVolumeWAD : public IVolume
 {
@@ -39,7 +38,7 @@ public:
 	EPlatform GetVolumeType() const override;
 	ECountry GetCountry() const override;
 
-	bool IsCompressed() const override;
+	BlobType GetBlobType() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
 

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -250,9 +250,9 @@ u8 CVolumeWiiCrypted::GetDiscNumber() const
 	return disc_number;
 }
 
-bool CVolumeWiiCrypted::IsCompressed() const
+BlobType CVolumeWiiCrypted::GetBlobType() const
 {
-	return m_pReader ? m_pReader->IsCompressed() : false;
+	return m_pReader ? m_pReader->GetBlobType() : BlobType::PLAIN;
 }
 
 u64 CVolumeWiiCrypted::GetSize() const

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -11,14 +11,13 @@
 #include <polarssl/aes.h>
 
 #include "Common/CommonTypes.h"
+#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 
 // --- this volume type is used for encrypted Wii images ---
 
 namespace DiscIO
 {
-
-class IBlobReader;
 
 class CVolumeWiiCrypted : public IVolume
 {
@@ -43,7 +42,7 @@ public:
 	bool ChangePartition(u64 offset) override;
 
 	ECountry GetCountry() const override;
-	bool IsCompressed() const override;
+	BlobType GetBlobType() const override;
 	u64 GetSize() const override;
 	u64 GetRawSize() const override;
 

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -19,7 +19,7 @@ class WbfsFileReader : public IBlobReader
 public:
 	static WbfsFileReader* Create(const std::string& filename);
 
-	bool IsCompressed() const override { return true; }
+	BlobType GetBlobType() const override { return BlobType::WBFS; }
 	u64 GetDataSize() const override { return m_size; }
 	u64 GetRawSize() const override { return m_size; }
 	bool Read(u64 offset, u64 nbytes, u8* out_ptr) override;

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -26,7 +26,7 @@
 #include "DolphinQt/GameList/GameFile.h"
 #include "DolphinQt/Utils/Utils.h"
 
-static const u32 CACHE_REVISION = 0x00C; // Last changed in PR 2993
+static const u32 CACHE_REVISION = 0x00D; // Last changed in PR 3097
 static const u32 DATASTREAM_REVISION = 15; // Introduced in Qt 5.2
 
 static QMap<DiscIO::IVolume::ELanguage, QString> ConvertLocalizedStrings(std::map<DiscIO::IVolume::ELanguage, std::string> strings)
@@ -109,11 +109,11 @@ GameFile::GameFile(const QString& fileName)
 			m_company = QString::fromStdString(volume->GetCompany());
 
 			m_country = volume->GetCountry();
+			m_blob_type = volume->GetBlobType();
 			m_file_size = volume->GetRawSize();
 			m_volume_size = volume->GetSize();
 
 			m_unique_id = QString::fromStdString(volume->GetUniqueID());
-			m_compressed = volume->IsCompressed();
 			m_disc_number = volume->GetDiscNumber();
 			m_revision = volume->GetRevision();
 
@@ -181,6 +181,7 @@ bool GameFile::LoadFromCache()
 
 	u32 country;
 	u32 platform;
+	u32 blob_type;
 	QMap<u8, QString> short_names;
 	QMap<u8, QString> long_names;
 	QMap<u8, QString> descriptions;
@@ -189,16 +190,17 @@ bool GameFile::LoadFromCache()
 	       >> descriptions
 	       >> m_company
 	       >> m_unique_id
+	       >> blob_type
 	       >> m_file_size
 	       >> m_volume_size
 	       >> country
 	       >> m_banner
-	       >> m_compressed
 	       >> platform
 	       >> m_disc_number
 	       >> m_revision;
 	m_country = (DiscIO::IVolume::ECountry)country;
 	m_platform = (DiscIO::IVolume::EPlatform)platform;
+	m_blob_type = (DiscIO::BlobType)blob_type;
 	m_short_names = CastLocalizedStrings<DiscIO::IVolume::ELanguage>(short_names);
 	m_long_names = CastLocalizedStrings<DiscIO::IVolume::ELanguage>(long_names);
 	m_descriptions = CastLocalizedStrings<DiscIO::IVolume::ELanguage>(descriptions);
@@ -231,11 +233,11 @@ void GameFile::SaveToCache()
 	       << CastLocalizedStrings<u8>(m_descriptions)
 	       << m_company
 	       << m_unique_id
+	       << (u32)m_blob_type
 	       << m_file_size
 	       << m_volume_size
 	       << (u32)m_country
 	       << m_banner
-	       << m_compressed
 	       << (u32)m_platform
 	       << m_disc_number
 	       << m_revision;

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -10,6 +10,7 @@
 
 #include <string>
 
+#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 
@@ -34,9 +35,14 @@ public:
 	const QString GetWiiFSPath() const;
 	DiscIO::IVolume::ECountry GetCountry() const { return m_country; }
 	DiscIO::IVolume::EPlatform GetPlatform() const { return m_platform; }
+	DiscIO::BlobType GetBlobType() const { m_blob_type; }
 	const QString GetIssues() const { return m_issues; }
 	int GetEmuState() const { return m_emu_state; }
-	bool IsCompressed() const { return m_compressed; }
+	bool IsCompressed() const
+	{
+		return m_blob_type == DiscIO::BlobType::GCZ || m_blob_type == DiscIO::BlobType::CISO ||
+		       m_blob_type == DiscIO::BlobType::WBFS;
+	}
 	u64 GetFileSize() const { return m_file_size; }
 	u64 GetVolumeSize() const { return m_volume_size; }
 	// 0 is the first disc, 1 is the second disc
@@ -68,11 +74,11 @@ private:
 
 	DiscIO::IVolume::ECountry m_country = DiscIO::IVolume::COUNTRY_UNKNOWN;
 	DiscIO::IVolume::EPlatform m_platform;
+	DiscIO::BlobType m_blob_type;
 	u16 m_revision = 0;
 
 	QPixmap m_banner;
 	bool m_valid = false;
-	bool m_compressed = false;
 	u8 m_disc_number = 0;
 
 	bool LoadFromCache();

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -862,10 +862,9 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
 
 			if (platform == DiscIO::IVolume::GAMECUBE_DISC || platform == DiscIO::IVolume::WII_DISC)
 			{
-				if (selected_iso->IsCompressed())
+				if (selected_iso->GetBlobType() == DiscIO::BlobType::GCZ)
 					popupMenu.Append(IDM_COMPRESS_ISO, _("Decompress ISO..."));
-				else if (selected_iso->GetFileName().substr(selected_iso->GetFileName().find_last_of(".")) != ".ciso" &&
-				         selected_iso->GetFileName().substr(selected_iso->GetFileName().find_last_of(".")) != ".wbfs")
+				else if (selected_iso->GetBlobType() == DiscIO::BlobType::PLAIN)
 					popupMenu.Append(IDM_COMPRESS_ISO, _("Compress ISO..."));
 
 				wxMenuItem* changeDiscItem = popupMenu.Append(IDM_LIST_CHANGE_DISC, _("Change &Disc"));
@@ -1152,6 +1151,7 @@ void CGameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED (event))
 	if (!iso)
 		return;
 
+	bool is_compressed = iso->GetBlobType() == DiscIO::BlobType::GCZ;
 	wxString path;
 
 	std::string FileName, FilePath, FileExtension;
@@ -1159,7 +1159,7 @@ void CGameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED (event))
 
 	do
 	{
-		if (iso->IsCompressed())
+		if (is_compressed)
 		{
 			wxString FileType;
 			if (iso->GetPlatform() == DiscIO::IVolume::WII_DISC)
@@ -1200,7 +1200,7 @@ void CGameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED (event))
 
 	{
 	wxProgressDialog dialog(
-		iso->IsCompressed() ? _("Decompressing ISO") : _("Compressing ISO"),
+		is_compressed ? _("Decompressing ISO") : _("Compressing ISO"),
 		_("Working..."),
 		1000,
 		this,
@@ -1211,7 +1211,7 @@ void CGameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED (event))
 		);
 
 
-	if (iso->IsCompressed())
+	if (is_compressed)
 		all_good = DiscIO::DecompressBlobToFile(iso->GetFileName(),
 				WxStrToStr(path), &CompressCB, &dialog);
 	else

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -36,7 +36,7 @@
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/WxUtils.h"
 
-static const u32 CACHE_REVISION = 0x125; // Last changed in PR 2598
+static const u32 CACHE_REVISION = 0x126; // Last changed in PR 3097
 
 #define DVD_BANNER_WIDTH 96
 #define DVD_BANNER_HEIGHT 32
@@ -70,7 +70,6 @@ GameListItem::GameListItem(const std::string& _rFileName, const std::unordered_m
 	, m_Country(DiscIO::IVolume::COUNTRY_UNKNOWN)
 	, m_Revision(0)
 	, m_Valid(false)
-	, m_BlobCompressed(false)
 	, m_ImageWidth(0)
 	, m_ImageHeight(0)
 	, m_disc_number(0)
@@ -107,11 +106,11 @@ GameListItem::GameListItem(const std::string& _rFileName, const std::unordered_m
 			m_company = pVolume->GetCompany();
 
 			m_Country = pVolume->GetCountry();
+			m_blob_type = pVolume->GetBlobType();
 			m_FileSize = pVolume->GetRawSize();
 			m_VolumeSize = pVolume->GetSize();
 
 			m_UniqueID = pVolume->GetUniqueID();
-			m_BlobCompressed = pVolume->IsCompressed();
 			m_disc_number = pVolume->GetDiscNumber();
 			m_Revision = pVolume->GetRevision();
 
@@ -157,6 +156,7 @@ GameListItem::GameListItem(const std::string& _rFileName, const std::unordered_m
 		m_Valid = true;
 		m_FileSize = File::GetSize(_rFileName);
 		m_Platform = DiscIO::IVolume::ELF_DOL;
+		m_blob_type = DiscIO::BlobType::DIRECTORY;
 	}
 
 	std::string path, name;
@@ -209,7 +209,7 @@ void GameListItem::DoState(PointerWrap &p)
 	p.Do(m_FileSize);
 	p.Do(m_VolumeSize);
 	p.Do(m_Country);
-	p.Do(m_BlobCompressed);
+	p.Do(m_blob_type);
 	p.Do(m_pImage);
 	p.Do(m_ImageWidth);
 	p.Do(m_ImageHeight);

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/Common.h"
+#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 
 #if defined(HAVE_WX) && HAVE_WX
@@ -37,9 +38,14 @@ public:
 	const std::string GetWiiFSPath() const;
 	DiscIO::IVolume::ECountry GetCountry() const {return m_Country;}
 	DiscIO::IVolume::EPlatform GetPlatform() const { return m_Platform; }
+	DiscIO::BlobType GetBlobType() const { return m_blob_type; }
 	const std::string& GetIssues() const { return m_issues; }
 	int GetEmuState() const { return m_emu_state; }
-	bool IsCompressed() const {return m_BlobCompressed;}
+	bool IsCompressed() const
+	{
+		return m_blob_type == DiscIO::BlobType::GCZ || m_blob_type == DiscIO::BlobType::CISO ||
+		       m_blob_type == DiscIO::BlobType::WBFS;
+	}
 	u64 GetFileSize() const {return m_FileSize;}
 	u64 GetVolumeSize() const {return m_VolumeSize;}
 	// 0 is the first disc, 1 is the second disc
@@ -68,13 +74,13 @@ private:
 
 	DiscIO::IVolume::ECountry m_Country;
 	DiscIO::IVolume::EPlatform m_Platform;
+	DiscIO::BlobType m_blob_type;
 	u16 m_Revision;
 
 #if defined(HAVE_WX) && HAVE_WX
 	wxBitmap m_Bitmap;
 #endif
 	bool m_Valid;
-	bool m_BlobCompressed;
 	std::vector<u8> m_pImage;
 	int m_ImageWidth, m_ImageHeight;
 	u8 m_disc_number;


### PR DESCRIPTION
I forgot to update it after changing how IsCompressed() works. Also, checking file name extensions is a bad way of checking blob types.