### PR TITLE
VolumeGC: Get rid of banner pointer casts

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -119,11 +119,10 @@ std::string CVolumeGC::GetCompany() const
 	if (!LoadBannerFile())
 		return "";
 
-	auto const pBanner = (GCBanner*)m_banner_file.data();
-	std::string company = DecodeString(pBanner->comment[0].longMaker);
+	std::string company = DecodeString(m_banner_file.comment[0].longMaker);
 
 	if (company.empty())
-		company = DecodeString(pBanner->comment[0].shortMaker);
+		company = DecodeString(m_banner_file.comment[0].shortMaker);
 
 	return company;
 }
@@ -138,8 +137,7 @@ std::vector<u32> CVolumeGC::GetBanner(int* width, int* height) const
 	}
 
 	std::vector<u32> image_buffer(GC_BANNER_WIDTH * GC_BANNER_HEIGHT);
-	auto const pBanner = (GCBanner*)m_banner_file.data();
-	ColorUtil::decode5A3image(image_buffer.data(), pBanner->image, GC_BANNER_WIDTH, GC_BANNER_HEIGHT);
+	ColorUtil::decode5A3image(image_buffer.data(), m_banner_file.image, GC_BANNER_WIDTH, GC_BANNER_HEIGHT);
 	*width = GC_BANNER_WIDTH;
 	*height = GC_BANNER_HEIGHT;
 	return image_buffer;
@@ -220,22 +218,20 @@ bool CVolumeGC::LoadBannerFile() const
 	size_t file_size = (size_t)file_system->GetFileSize("opening.bnr");
 	if (file_size == BNR1_SIZE || file_size == BNR2_SIZE)
 	{
-		m_banner_file.resize(file_size);
-		file_system->ReadFile("opening.bnr", m_banner_file.data(), m_banner_file.size());
+		file_system->ReadFile("opening.bnr", reinterpret_cast<u8*>(&m_banner_file), file_size);
 
-		u32 bannerSignature = *(u32*)m_banner_file.data();
-		if (file_size == BNR1_SIZE && bannerSignature == 0x31524e42)        // "BNR1"
+		if (file_size == BNR1_SIZE && m_banner_file.id == 0x31524e42)      // "BNR1"
 		{
 			m_banner_file_type = BANNER_BNR1;
 		}
-		else if (file_size == BNR2_SIZE && bannerSignature == 0x32524e42)   // "BNR2"
+		else if (file_size == BNR2_SIZE && m_banner_file.id == 0x32524e42) // "BNR2"
 		{
 			m_banner_file_type = BANNER_BNR2;
 		}
 		else
 		{
 			m_banner_file_type = BANNER_INVALID;
-			WARN_LOG(DISCIO, "Invalid opening.bnr. Type: %0x Size: %0zx", bannerSignature, file_size);
+			WARN_LOG(DISCIO, "Invalid opening.bnr. Type: %0x Size: %0zx", m_banner_file.id, file_size);
 		}
 	}
 	else
@@ -276,11 +272,9 @@ std::map<IVolume::ELanguage, std::string> CVolumeGC::ReadMultiLanguageStrings(bo
 		break;
 	}
 
-	auto const banner = reinterpret_cast<const GCBanner*>(m_banner_file.data());
-
 	for (u32 i = 0; i < number_of_languages; ++i)
 	{
-		GCBannerComment comment = banner->comment[i];
+		const GCBannerComment& comment = m_banner_file.comment[i];
 		std::string string;
 
 		if (description)

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -80,7 +80,7 @@ private:
 	};
 
 	mutable BannerFileType m_banner_file_type = BANNER_NOT_LOADED;
-	mutable std::vector<u8> m_banner_file;
+	mutable GCBanner m_banner_file;
 
 	std::unique_ptr<IBlobReader> m_pReader;
 };


### PR DESCRIPTION
Prefer reading the data into the reified struct instead.

If it's preferable to move the struct onto the heap, that can be done too.