### PR TITLE
Get rid of some casts used with logging for size_t

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -788,7 +788,7 @@ bool RunCode(const ARCode &arcode)
 	current_code = &arcode;
 
 	LogInfo("Code Name: %s", arcode.name.c_str());
-	LogInfo("Number of codes: %i", arcode.ops.size());
+	LogInfo("Number of codes: %zu", arcode.ops.size());
 
 	for (const AREntry& entry : arcode.ops)
 	{

--- a/Source/Core/Core/DSP/DSPCodeUtil.cpp
+++ b/Source/Core/Core/DSP/DSPCodeUtil.cpp
@@ -58,7 +58,7 @@ bool Disassemble(const std::vector<u16> &code, bool line_numbers, std::string &t
 bool Compare(const std::vector<u16> &code1, const std::vector<u16> &code2)
 {
 	if (code1.size() != code2.size())
-		printf("Size difference! 1=%i 2=%i\n", (int)code1.size(), (int)code2.size());
+		printf("Size difference! 1=%zu 2=%zu\n", code1.size(), code2.size());
 	u32 count_equal = 0;
 	const int min_size = std::min<int>((int)code1.size(), (int)code2.size());
 

--- a/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
@@ -348,7 +348,7 @@ void DSPJitRegCache::FlushRegs()
 
 		_assert_msg_(DSPLLE,
 		             !regs[i].loc.IsSimpleReg(),
-		             "register %u is still a simple reg", static_cast<u32>(i));
+		             "register %zu is still a simple reg", i);
 	}
 
 	_assert_msg_(DSPLLE,
@@ -434,7 +434,7 @@ void DSPJitRegCache::SaveRegs()
 
 		_assert_msg_(DSPLLE,
 		             !regs[i].loc.IsSimpleReg(),
-		             "register %u is still a simple reg", static_cast<u32>(i));
+		             "register %zu is still a simple reg", i);
 	}
 
 	emitter.MOV(64, R(RBP), M(&ebp_store));
@@ -453,7 +453,7 @@ void DSPJitRegCache::PushRegs()
 
 		_assert_msg_(DSPLLE,
 		             !regs[i].loc.IsSimpleReg(),
-		             "register %u is still a simple reg", static_cast<u32>(i));
+		             "register %zu is still a simple reg", i);
 	}
 
 	int push_count = 0;
@@ -481,7 +481,7 @@ void DSPJitRegCache::PushRegs()
 		_assert_msg_(DSPLLE,
 		             xregs[i].guest_reg == DSP_REG_NONE ||
 		             xregs[i].guest_reg == DSP_REG_STATIC,
-		             "register %u is still used", static_cast<u32>(i));
+		             "register %zu is still used", i);
 	}
 
 	emitter.MOV(64, R(RBP), M(&ebp_store));
@@ -542,11 +542,11 @@ X64Reg DSPJitRegCache::MakeABICallSafe(X64Reg reg)
 void DSPJitRegCache::MovToHostReg(size_t reg, X64Reg host_reg, bool load)
 {
 	_assert_msg_(DSPLLE, reg < regs.size(),
-	             "bad register name %u", static_cast<u32>(reg));
+	             "bad register name %zu", reg);
 	_assert_msg_(DSPLLE, regs[reg].parentReg == DSP_REG_NONE,
-	             "register %u is proxy for %d", static_cast<u32>(reg), regs[reg].parentReg);
+	             "register %zu is proxy for %d", reg, regs[reg].parentReg);
 	_assert_msg_(DSPLLE, !regs[reg].used,
-	             "moving to host reg in use guest reg %u", static_cast<u32>(reg));
+	             "moving to host reg in use guest reg %zu", reg);
 	X64Reg old_reg = regs[reg].loc.GetSimpleReg();
 	if (old_reg == host_reg)
 	{
@@ -588,11 +588,11 @@ void DSPJitRegCache::MovToHostReg(size_t reg, X64Reg host_reg, bool load)
 void DSPJitRegCache::MovToHostReg(size_t reg, bool load)
 {
 	_assert_msg_(DSPLLE, reg < regs.size(),
-	             "bad register name %u", static_cast<u32>(reg));
+	             "bad register name %zu", reg);
 	_assert_msg_(DSPLLE, regs[reg].parentReg == DSP_REG_NONE,
-	             "register %u is proxy for %d", static_cast<u32>(reg), regs[reg].parentReg);
+	             "register %zu is proxy for %d", reg, regs[reg].parentReg);
 	_assert_msg_(DSPLLE, !regs[reg].used,
-	             "moving to host reg in use guest reg %u", static_cast<u32>(reg));
+	             "moving to host reg in use guest reg %zu", reg);
 
 	if (regs[reg].loc.IsSimpleReg())
 	{
@@ -620,13 +620,13 @@ void DSPJitRegCache::MovToHostReg(size_t reg, bool load)
 void DSPJitRegCache::RotateHostReg(size_t reg, int shift, bool emit)
 {
 	_assert_msg_(DSPLLE, reg < regs.size(),
-	             "bad register name %u", static_cast<u32>(reg));
+	             "bad register name %zu", reg);
 	_assert_msg_(DSPLLE, regs[reg].parentReg == DSP_REG_NONE,
-	             "register %u is proxy for %d", static_cast<u32>(reg), regs[reg].parentReg);
+	             "register %zu is proxy for %d", reg, regs[reg].parentReg);
 	_assert_msg_(DSPLLE, regs[reg].loc.IsSimpleReg(),
-	             "register %u is not a simple reg", static_cast<u32>(reg));
+	             "register %zu is not a simple reg", reg);
 	_assert_msg_(DSPLLE, !regs[reg].used,
-	             "rotating in use guest reg %u", static_cast<u32>(reg));
+	             "rotating in use guest reg %zu", reg);
 
 	if (shift > regs[reg].shift && emit)
 	{
@@ -664,11 +664,11 @@ void DSPJitRegCache::RotateHostReg(size_t reg, int shift, bool emit)
 void DSPJitRegCache::MovToMemory(size_t reg)
 {
 	_assert_msg_(DSPLLE, reg < regs.size(),
-		     "bad register name %u", static_cast<u32>(reg));
+		     "bad register name %zu", reg);
 	_assert_msg_(DSPLLE, regs[reg].parentReg == DSP_REG_NONE,
-		     "register %u is proxy for %d", static_cast<u32>(reg), regs[reg].parentReg);
+		     "register %zu is proxy for %d", reg, regs[reg].parentReg);
 	_assert_msg_(DSPLLE, !regs[reg].used,
-		     "moving to memory in use guest reg %u", static_cast<u32>(reg));
+		     "moving to memory in use guest reg %zu", reg);
 
 	if (regs[reg].used)
 	{

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -125,8 +125,8 @@ static bool LoadDSPRom(u16* rom, const std::string& filename, u32 size_in_bytes)
 
 	if (bytes.size() != size_in_bytes)
 	{
-		ERROR_LOG(DSPLLE, "%s has a wrong size (%u, expected %u)",
-		          filename.c_str(), (u32)bytes.size(), size_in_bytes);
+		ERROR_LOG(DSPLLE, "%s has a wrong size (%zu, expected %u)",
+		          filename.c_str(), bytes.size(), size_in_bytes);
 		return false;
 	}
 

--- a/Source/Core/Core/HW/MMIO.cpp
+++ b/Source/Core/Core/HW/MMIO.cpp
@@ -195,8 +195,8 @@ template <typename T>
 ReadHandlingMethod<T>* InvalidRead()
 {
 	return ComplexRead<T>([](u32 addr) {
-		ERROR_LOG(MEMMAP, "Trying to read%d from an invalid MMIO (addr=%08x)",
-			8 * (int)(sizeof (T)), addr);
+		ERROR_LOG(MEMMAP, "Trying to read %zu bytes from an invalid MMIO (addr=%08x)",
+			8 * sizeof(T), addr);
 		return -1;
 	});
 }
@@ -204,8 +204,8 @@ template <typename T>
 WriteHandlingMethod<T>* InvalidWrite()
 {
 	return ComplexWrite<T>([](u32 addr, T val) {
-		ERROR_LOG(MEMMAP, "Trying to write%d to an invalid MMIO (addr=%08x, val=%08x)",
-			8 * (int)(sizeof (T)), addr, (u32)val);
+		ERROR_LOG(MEMMAP, "Trying to write %zu bytes to an invalid MMIO (addr=%08x, val=%08x)",
+			8 * sizeof(T), addr, (u32)val);
 	});
 }
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -481,7 +481,7 @@ static void LoadFileStateData(const std::string& filename, std::vector<u8>& ret_
 
 		if (!f.ReadBytes(&buffer[0], size))
 		{
-			PanicAlert("wtf? reading bytes: %i", (int)size);
+			PanicAlert("wtf? reading bytes: %zu", size);
 			return;
 		}
 	}


### PR DESCRIPTION
Replaces them with the now-valid %z specifiers