### PR TITLE
Synchronize DVDInterface::ChangeDisc with the CPU thread properly

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -276,7 +276,7 @@ void Stop()  // - Hammertime!
 	}
 }
 
-static void DeclareAsCPUThread()
+void DeclareAsCPUThread()
 {
 #ifdef ThreadLocalStorage
 	tls_is_cpu_thread = true;
@@ -288,7 +288,7 @@ static void DeclareAsCPUThread()
 #endif
 }
 
-static void UndeclareAsCPUThread()
+void UndeclareAsCPUThread()
 {
 #ifdef ThreadLocalStorage
 	tls_is_cpu_thread = false;
@@ -715,6 +715,7 @@ bool PauseAndLock(bool doLock, bool unpauseOnUnlock)
 
 	// video has to come after CPU, because CPU thread can wait for video thread (s_efbAccessRequested).
 	g_video_backend->PauseAndLock(doLock, unpauseOnUnlock);
+
 	return wasUnpaused;
 }
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -41,6 +41,9 @@ bool Init();
 void Stop();
 void Shutdown();
 
+void DeclareAsCPUThread();
+void UndeclareAsCPUThread();
+
 std::string StopMessage(bool, const std::string&);
 
 bool IsRunning();


### PR DESCRIPTION
This is an updated version of PR #2535. Fixes a 5.0 blocker: https://bugs.dolphin-emu.org/issues/8568