### PR TITLE
ALSA: Don't block on Clear() call.

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -46,6 +46,7 @@ private:
 	enum class ALSAThreadStatus
 	{
 		RUNNING,
+		PAUSED,
 		STOPPING,
 		STOPPED,
 	};


### PR DESCRIPTION
snd_pcm_writei() is meant to block block until all samples are written,
but apparently in some situations it can block for much longer, perhaps
even a infinite time, in the case of virtual machine FifoCI runs in.

Because it grabed a mutex before blocking, it could also block the
Clear() call for an infinite length of time, blocking dolphin's emu
thread.

snd_pcm_writei() also takes 10-15 seconds if you run dolphin under GDB
and can randomly take 5 or so seconds during normal usage.

By moving all the pause code to the ALSA thread, Clear() no-longer
blocks and everyone keeps their sanity.