### PR TITLE
ChunkFile: Provide additional helpers for C-style arrays

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -174,6 +174,12 @@ public:
 		DoVoid(x, count * sizeof(T));
 	}
 
+	template <typename T, std::size_t N>
+	void DoArray(T (&arr)[N])
+	{
+		DoArray(arr, static_cast<u32>(N));
+	}
+
 	void Do(Common::Flag& flag)
 	{
 		bool s = flag.IsSet();

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -293,7 +293,7 @@ void DoState(PointerWrap &p)
 {
 	p.DoPOD(m_DISR);
 	p.DoPOD(m_DICVR);
-	p.DoArray(m_DICMDBUF, 3);
+	p.DoArray(m_DICMDBUF);
 	p.Do(m_DIMAR);
 	p.Do(m_DILENGTH);
 	p.Do(m_DICR);

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -84,8 +84,8 @@ void DoState(PointerWrap &p)
 	p.Do(m_XFBInfoBottom);
 	p.Do(m_3DFBInfoTop);
 	p.Do(m_3DFBInfoBottom);
-	p.DoArray(m_InterruptRegister, 4);
-	p.DoArray(m_LatchRegister, 2);
+	p.DoArray(m_InterruptRegister);
+	p.DoArray(m_LatchRegister);
 	p.Do(m_PictureConfiguration);
 	p.DoPOD(m_HorizontalScaling);
 	p.Do(m_FilterCoefTables);

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -591,7 +591,7 @@ void Wiimote::DoState(PointerWrap& p)
 	p.Do(m_status);
 	p.Do(m_adpcm_state);
 	p.Do(m_ext_key);
-	p.DoArray(m_eeprom, sizeof(m_eeprom));
+	p.DoArray(m_eeprom);
 	p.Do(m_reg_motion_plus);
 	p.Do(m_reg_ir);
 	p.Do(m_reg_ext);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -517,7 +517,7 @@ void CWII_IPC_HLE_Device_fs::DoState(PointerWrap& p)
 				u32 count = size;
 				while (count > 65536)
 				{
-					p.DoArray(&buf[0], 65536);
+					p.DoArray(buf);
 					handle.WriteArray(&buf[0], 65536);
 					count -= 65536;
 				}
@@ -561,7 +561,7 @@ void CWII_IPC_HLE_Device_fs::DoState(PointerWrap& p)
 				while (count > 65536)
 				{
 					handle.ReadArray(&buf[0], 65536);
-					p.DoArray(&buf[0], 65536);
+					p.DoArray(buf);
 					count -= 65536;
 				}
 				handle.ReadArray(&buf[0], count);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -131,7 +131,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305::DoState(PointerWrap &p)
 	p.DoPOD(m_HCIEndpoint);
 	p.DoPOD(m_ACLEndpoint);
 	p.Do(m_last_ticks);
-	p.DoArray(m_PacketCount,MAX_BBMOTES);
+	p.DoArray(m_PacketCount);
 	p.Do(m_ScanEnable);
 	p.Do(m_EventQueue);
 	m_acl_pool.DoState(p);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -66,7 +66,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 47; // Last changed in PR 3045
+static const u32 STATE_VERSION = 48; // Last changed in PR 3108
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -58,7 +58,7 @@ namespace Clipper
 
 	void DoState(PointerWrap &p)
 	{
-		p.DoArray(m_ViewOffset,2);
+		p.DoArray(m_ViewOffset);
 		for (auto& ClippedVertice : ClippedVertices)
 			ClippedVertice.DoState(p);
 	}

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -33,7 +33,7 @@ namespace EfbInterface
 
 	void DoState(PointerWrap &p)
 	{
-		p.DoArray(efb, EFB_WIDTH*EFB_HEIGHT*6);
+		p.DoArray(efb);
 	}
 
 	static void SetPixelAlphaOnly(u32 offset, u8 a)

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -818,7 +818,6 @@ void Tev::DoState(PointerWrap &p)
 	p.DoArray(TexColor);
 	p.DoArray(RasColor);
 	p.DoArray(StageKonst);
-	p.DoArray(Zero16);
 
 	p.DoArray(FixedConstants);
 	p.Do(AlphaBump);

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -812,28 +812,28 @@ void Tev::SetRegColor(int reg, int comp, bool konst, s16 color)
 
 void Tev::DoState(PointerWrap &p)
 {
-	p.DoArray(Reg, sizeof(Reg));
+	p.DoArray(Reg);
 
-	p.DoArray(KonstantColors, sizeof(KonstantColors));
-	p.DoArray(TexColor,4);
-	p.DoArray(RasColor,4);
-	p.DoArray(StageKonst,4);
-	p.DoArray(Zero16,4);
+	p.DoArray(KonstantColors);
+	p.DoArray(TexColor);
+	p.DoArray(RasColor);
+	p.DoArray(StageKonst);
+	p.DoArray(Zero16);
 
-	p.DoArray(FixedConstants,9);
+	p.DoArray(FixedConstants);
 	p.Do(AlphaBump);
-	p.DoArray(IndirectTex, sizeof(IndirectTex));
+	p.DoArray(IndirectTex);
 	p.Do(TexCoord);
 
-	p.DoArray(m_BiasLUT,4);
-	p.DoArray(m_ScaleLShiftLUT,4);
-	p.DoArray(m_ScaleRShiftLUT,4);
+	p.DoArray(m_BiasLUT);
+	p.DoArray(m_ScaleLShiftLUT);
+	p.DoArray(m_ScaleRShiftLUT);
 
-	p.DoArray(Position,3);
-	p.DoArray(Color, sizeof(Color));
-	p.DoArray(Uv, 8);
-	p.DoArray(IndirectLod,4);
-	p.DoArray(IndirectLinear,4);
-	p.DoArray(TextureLod,16);
-	p.DoArray(TextureLinear,16);
+	p.DoArray(Position);
+	p.DoArray(Color);
+	p.DoArray(Uv);
+	p.DoArray(IndirectLod);
+	p.DoArray(IndirectLinear);
+	p.DoArray(TextureLod);
+	p.DoArray(TextureLinear);
 }

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -14,12 +14,12 @@ void DoCPState(PointerWrap& p)
 {
 	// We don't save g_preprocess_cp_state separately because the GPU should be
 	// synced around state save/load.
-	p.DoArray(g_main_cp_state.array_bases, 16);
-	p.DoArray(g_main_cp_state.array_strides, 16);
+	p.DoArray(g_main_cp_state.array_bases);
+	p.DoArray(g_main_cp_state.array_strides);
 	p.Do(g_main_cp_state.matrix_index_a);
 	p.Do(g_main_cp_state.matrix_index_b);
 	p.Do(g_main_cp_state.vtx_desc.Hex);
-	p.DoArray(g_main_cp_state.vtx_attr, 8);
+	p.DoArray(g_main_cp_state.vtx_attr);
 	p.DoMarker("CP Memory");
 	if (p.mode == PointerWrap::MODE_READ)
 	{

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -31,7 +31,7 @@ static void DoState(PointerWrap &p)
 	p.DoMarker("XF Memory");
 
 	// Texture decoder
-	p.DoArray(texMem, TMEM_SIZE);
+	p.DoArray(texMem);
 	p.DoMarker("texMem");
 
 	// FIFO


### PR DESCRIPTION
Gets rid of magic numbers in cases where the array size is known at compile time. This is also useful for future additions, as it gets rid of the need to care about the correct size being provided.