### PR TITLE
AlsaSound: fix buffer type, clean up macros

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -21,7 +21,6 @@ class AlsaSound final : public SoundStream
 #if defined(HAVE_ALSA) && HAVE_ALSA
 public:
 	AlsaSound();
-	virtual ~AlsaSound();
 
 	bool Start() override;
 	void SoundLoop() override;
@@ -35,6 +34,15 @@ public:
 	}
 
 private:
+	// maximum number of frames the buffer can hold
+	static constexpr size_t BUFFER_SIZE_MAX = 8192;
+
+	// minimum number of frames to deliver in one transfer
+	static constexpr u32 FRAME_COUNT_MIN = 256;
+
+	// number of channels per frame
+	static constexpr u32 CHANNEL_COUNT = 2;
+
 	enum class ALSAThreadStatus
 	{
 		RUNNING,
@@ -45,7 +53,7 @@ private:
 	bool AlsaInit();
 	void AlsaShutdown();
 
-	u8 *mix_buffer;
+	s16 mix_buffer[BUFFER_SIZE_MAX * CHANNEL_COUNT];
 	std::thread thread;
 	std::atomic<ALSAThreadStatus> m_thread_status;
 	std::condition_variable cv;


### PR DESCRIPTION
* Change the fundamental type of the `mix_buffer` to `s16`, eliminating a `reinterpret_cast`
* Move macro'd immediates into private `static constexpr` values
* Remove the dynamic allocation of the `mix_buffer` array
* Fix up typo'd (?) error logs