### PR TITLE
DolphinWX: Improve HBC banner scaling

### DIFF
--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -279,10 +279,7 @@ bool GameListItem::ReadPNGBanner(const std::string& path)
 wxBitmap GameListItem::ScaleBanner(wxImage* image)
 {
 	double scale = wxTheApp->GetTopWindow()->GetContentScaleFactor();
-	// Note: This uses nearest neighbor, which subjectively looks a lot
-	// better for GC banners than smooth scaling.
-	// TODO: Make scaling less bad for Homebrew Channel banners.
-	image->Rescale(DVD_BANNER_WIDTH * scale, DVD_BANNER_HEIGHT * scale);
+	image->Rescale(DVD_BANNER_WIDTH * scale, DVD_BANNER_HEIGHT * scale, wxIMAGE_QUALITY_HIGH);
 #ifdef __APPLE__
 	return wxBitmap(*image, -1, scale);
 #else

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -278,10 +278,14 @@ bool GameListItem::ReadPNGBanner(const std::string& path)
 
 wxBitmap GameListItem::ScaleBanner(wxImage* image)
 {
-	double scale = wxTheApp->GetTopWindow()->GetContentScaleFactor();
-	image->Rescale(DVD_BANNER_WIDTH * scale, DVD_BANNER_HEIGHT * scale, wxIMAGE_QUALITY_HIGH);
+	const double gui_scale = wxTheApp->GetTopWindow()->GetContentScaleFactor();
+	const double target_width = DVD_BANNER_WIDTH * gui_scale;
+	const double target_height = DVD_BANNER_HEIGHT * gui_scale;
+	const double banner_scale = std::min(target_width / image->GetWidth(), target_height / image->GetHeight());
+	image->Rescale(image->GetWidth() * banner_scale, image->GetHeight() * banner_scale, wxIMAGE_QUALITY_HIGH);
+	image->Resize(wxSize(target_width, target_height), wxPoint(), 0xFF, 0xFF, 0xFF);
 #ifdef __APPLE__
-	return wxBitmap(*image, -1, scale);
+	return wxBitmap(*image, -1, gui_scale);
 #else
 	return wxBitmap(*image, -1);
 #endif


### PR DESCRIPTION
Aspect ratios are now correct, and the scaling algorithm is better. The scaling still looks worse than in DolphinQt, but I don't know why. Maybe the quality of `wxIMAGE_QUALITY_HIGH` isn't especially high after all?

Needs testing with GC games when rendering at a 2x scale. I would also appreciate someone testing whether the white dots bug is fixed: https://bugs.dolphin-emu.org/issues/8899

The screenshot below can be compared to the ones in PRs #2958 (DolphinWX) and #2993 (DolphinQt).

![](https://cloud.githubusercontent.com/assets/6716818/10204380/a8ac355c-67bb-11e5-8d4a-eb01d6e5196d.png)