### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,9 +11,9 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 ## System Requirements
 ### Desktop
 * OS
-    * Microsoft Windows (Vista or higher).
+    * Windows (7 SP1 or higher).
     * Linux.
-    * Apple Mac OS X (10.9 or higher).
+    * OS X (10.9 Mavericks or higher).
     * Unix-like systems other than Linux might work but are not officially supported.
 * Processor
     * A CPU with SSE2 support.


### PR DESCRIPTION
Updated required OS information.

As stated in the latest progress report (https://dolphin-emu.org/blog/2015/10/01/dolphin-progress-report-september-2015/) Vista support has been dropped and now at least 7 SP1 is required for Windows. I also decided to clean up this section a bit while I was editing and removed company names from the OS list as they were largely pointless, renamed Mac OS X to just OS X as Apple dropped "Mac" from the name quite a while ago, and lastly added the OS X version name (Mavericks) in addition to the version number to make it more clear for users who don't memorize version numbers.