### PR TITLE
General: Direct initialize some unions

### DIFF
--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -75,8 +75,9 @@ enum
 // AI Control Register
 union AICR
 {
-	AICR() { hex = 0;}
-	AICR(u32 _hex) { hex = _hex;}
+	constexpr AICR() = default;
+	constexpr AICR(u32 hex_) : hex(hex_) {}
+
 	struct
 	{
 		u32 PSTAT    : 1;  // sample counter/playback enable
@@ -89,20 +90,21 @@ union AICR
 		u32 AIDFR    : 1;  // AID Frequency (0=48khz 1=32khz)
 		u32          :25;
 	};
-	u32 hex;
+	u32 hex = 0;
 };
 
 // AI Volume Register
 union AIVR
 {
-	AIVR() { hex = 0;}
+	constexpr AIVR() = default;
+
 	struct
 	{
 		u32 left  : 8;
 		u32 right : 8;
 		u32       :16;
 	};
-	u32 hex;
+	u32 hex = 0;
 };
 
 // STATE_TO_SAVE

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -82,15 +82,15 @@ union UARAMCount
 // Blocks are 32 bytes.
 union UAudioDMAControl
 {
-	u16 Hex;
+	u16 Hex = 0;
 	struct
 	{
 		u16 NumBlocks  : 15;
 		u16 Enable     : 1;
 	};
 
-	UAudioDMAControl(u16 _Hex = 0) : Hex(_Hex)
-	{}
+	constexpr UAudioDMAControl() = default;
+	constexpr UAudioDMAControl(u16 hex) : Hex(hex) {}
 };
 
 // AudioDMA

--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -31,7 +31,7 @@ enum
 #define DSP_CONTROL_MASK 0x0C07
 union UDSPControl
 {
-	u16 Hex;
+	u16 Hex = 0;
 	struct
 	{
 		// DSP Control
@@ -53,7 +53,9 @@ union UDSPControl
 		u16 DSPInit : 1; // DSPInit() writes to this flag
 		u16 pad : 4;
 	};
-	UDSPControl(u16 _Hex = 0) : Hex(_Hex) {}
+
+	constexpr UDSPControl() = default;
+	constexpr UDSPControl(u16 hex) : Hex(hex) {}
 };
 
 extern UDSPControl g_dspState;

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -106,7 +106,7 @@ enum
 // DI Status Register
 union UDISR
 {
-	u32 Hex;
+	u32 Hex = 0;
 	struct
 	{
 		u32 BREAK      :  1; // Stop the Device + Interrupt
@@ -118,14 +118,15 @@ union UDISR
 		u32 BRKINT     :  1; // w 1: clear brkint
 		u32            : 25;
 	};
-	UDISR() {Hex = 0;}
-	UDISR(u32 _hex) {Hex = _hex;}
+
+	constexpr UDISR() = default;
+	constexpr UDISR(u32 hex) : Hex(hex) {}
 };
 
 // DI Cover Register
 union UDICVR
 {
-	u32 Hex;
+	u32 Hex = 0;
 	struct
 	{
 		u32 CVR        :  1; // 0: Cover closed  1: Cover open
@@ -133,8 +134,9 @@ union UDICVR
 		u32 CVRINT     :  1; // r 1: Interrupt requested w 1: Interrupt clear
 		u32            : 29;
 	};
-	UDICVR() {Hex = 0;}
-	UDICVR(u32 _hex) {Hex = _hex;}
+
+	constexpr UDICVR() = default;
+	constexpr UDICVR(u32 hex) : Hex(hex) {}
 };
 
 union UDICMDBUF
@@ -209,14 +211,15 @@ union UDIIMMBUF
 // DI Config Register
 union UDICFG
 {
-	u32 Hex;
+	u32 Hex = 0;
 	struct
 	{
 		u32 CONFIG : 8;
 		u32        : 24;
 	};
-	UDICFG() {Hex = 0;}
-	UDICFG(u32 _hex) {Hex = _hex;}
+
+	constexpr UDICFG() = default;
+	constexpr UDICFG(u32 hex) : Hex(hex) {}
 };
 
 struct DVDReadCommand

--- a/Source/Core/Core/HW/EXI_Channel.h
+++ b/Source/Core/Core/HW/EXI_Channel.h
@@ -28,7 +28,7 @@ private:
 	// EXI Status Register - "Channel Parameter Register"
 	union UEXI_STATUS
 	{
-		u32 Hex;
+		u32 Hex = 0;
 		// DO NOT obey the warning and give this struct a name. Things will fail.
 		struct
 		{
@@ -48,8 +48,9 @@ private:
 			        u32 ROMDIS  : 1; // ROM Disable
 			u32                 :18;
 		};
-		UEXI_STATUS() { Hex = 0; }
-		UEXI_STATUS(u32 _hex) { Hex = _hex; }
+
+		constexpr UEXI_STATUS() = default;
+		constexpr UEXI_STATUS(u32 hex) : Hex(hex) {}
 	};
 
 	// EXI Control Register

--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -130,7 +130,7 @@ union USIPoll
 // SI Communication Control Status Register
 union USIComCSR
 {
-	u32 Hex;
+	u32 Hex = 0;
 	struct
 	{
 		u32 TSTART     : 1; // write: start transfer  read: transfer status
@@ -150,14 +150,15 @@ union USIComCSR
 		u32 TCINTMSK   : 1; // Transfer Complete Interrupt Mask
 		u32 TCINT      : 1; // Transfer Complete Interrupt
 	};
-	USIComCSR() {Hex = 0;}
-	USIComCSR(u32 _hex) {Hex = _hex;}
+
+	constexpr USIComCSR() = default;
+	constexpr USIComCSR(u32 hex) : Hex(hex) {}
 };
 
 // SI Status Register
 union USIStatusReg
 {
-	u32 Hex;
+	u32 Hex = 0;
 	struct
 	{
 		u32 UNRUN3  : 1; // (RWC) write 1: bit cleared  read 1: main proc underrun error
@@ -190,8 +191,9 @@ union USIStatusReg
 		u32         : 1;
 		u32 WR      : 1; // (RW) write 1 start copy, read 0 copy done
 	};
-	USIStatusReg() {Hex = 0;}
-	USIStatusReg(u32 _hex) {Hex = _hex;}
+
+	constexpr USIStatusReg() = default;
+	constexpr USIStatusReg(u32 hex) : Hex(hex) {}
 };
 
 // SI EXI Clock Count

--- a/Source/Core/Core/HW/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI_DeviceGCController.h
@@ -43,7 +43,7 @@ protected:
 
 	union UCommand
 	{
-		u32 Hex;
+		u32 Hex = 0;
 		struct
 		{
 			u32 Parameter1 : 8;
@@ -51,8 +51,9 @@ protected:
 			u32 Command    : 8;
 			u32            : 8;
 		};
-		UCommand()            {Hex = 0;}
-		UCommand(u32 _iValue) {Hex = _iValue;}
+
+		constexpr UCommand() = default;
+		constexpr UCommand(u32 hex) : Hex(hex) {}
 	};
 
 	enum EButtonCombo

--- a/Source/Core/Core/HW/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.h
@@ -29,7 +29,7 @@ protected:
 
 	union UCommand
 	{
-		u32 Hex;
+		u32 Hex = 0;
 		struct
 		{
 			u32 Parameter1 : 8;
@@ -37,8 +37,9 @@ protected:
 			u32 Command    : 8;
 			u32            : 8;
 		};
-		UCommand()            {Hex = 0;}
-		UCommand(u32 _iValue) {Hex = _iValue;}
+
+		constexpr UCommand() = default;
+		constexpr UCommand(u32 hex) : Hex(hex) {}
 	};
 
 	// PADAnalogMode

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -79,20 +79,21 @@ enum
 
 union UVIVerticalTimingRegister
 {
-	u16 Hex;
+	u16 Hex = 0;
 	struct
 	{
 		u16 EQU : 4; // Equalization pulse in half lines
 		u16 ACV : 10; // Active video in lines per field (seems always zero)
 		u16     : 2;
 	};
-	UVIVerticalTimingRegister(u16 _hex) { Hex = _hex;}
-	UVIVerticalTimingRegister() { Hex = 0;}
+
+	constexpr UVIVerticalTimingRegister() = default;
+	constexpr UVIVerticalTimingRegister(u16 hex) : Hex(hex) {}
 };
 
 union UVIDisplayControlRegister
 {
-	u16 Hex;
+	u16 Hex = 0;
 	struct
 	{
 		u16 ENB : 1; // Enables video timing generation and data request
@@ -104,8 +105,9 @@ union UVIDisplayControlRegister
 		u16 FMT : 2; // 0: NTSC, 1: PAL, 2: MPAL, 3: Debug
 		u16     : 6;
 	};
-	UVIDisplayControlRegister(u16 _hex) { Hex = _hex;}
-	UVIDisplayControlRegister() { Hex = 0;}
+
+	constexpr UVIDisplayControlRegister() = default;
+	constexpr UVIDisplayControlRegister(u16 hex) : Hex(hex) {}
 };
 
 union UVIHorizontalTiming0
@@ -223,7 +225,7 @@ union PictureConfigurationRegister
 
 union UVIHorizontalScaling
 {
-	u16 Hex;
+	u16 Hex = 0;
 	struct
 	{
 		u16 STP   : 9; // Horizontal stepping size (U1.8 Scaler Value) (0x160 Works for 320)
@@ -231,8 +233,9 @@ union UVIHorizontalScaling
 		u16 HS_EN : 1; // Enable Horizontal Scaling
 		u16       : 3;
 	};
-	UVIHorizontalScaling(u16 _hex) { Hex = _hex;}
-	UVIHorizontalScaling() { Hex = 0;}
+
+	constexpr UVIHorizontalScaling() = default;
+	constexpr UVIHorizontalScaling(u16 hex) : Hex(hex) {}
 };
 
 // Used for tables 0-2

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -15,10 +15,10 @@
 
 union UGeckoInstruction
 {
-	u32 hex;
+	u32 hex = 0;
 
-	UGeckoInstruction(u32 _hex) : hex(_hex) {}
-	UGeckoInstruction() : hex(0) {}
+	constexpr UGeckoInstruction() = default;
+	constexpr UGeckoInstruction(u32 hex_) : hex(hex_) {}
 
 	struct
 	{
@@ -322,10 +322,10 @@ union UGQR
 	BitField<16, 3, EQuantizeType> ld_type;
 	BitField<24, 6, u32> ld_scale;
 
-	u32 Hex;
+	u32 Hex = 0;
 
-	UGQR(u32 _hex) { Hex = _hex; }
-	UGQR()         { Hex = 0;  }
+	constexpr UGQR() = default;
+	constexpr UGQR(u32 hex) : Hex(hex) {}
 };
 
 // FPU Register
@@ -357,10 +357,10 @@ union UReg_XER
 		u32 OV         : 1;
 		u32 SO         : 1;
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_XER(u32 _hex) { Hex = _hex; }
-	UReg_XER()         { Hex = 0; }
+	constexpr UReg_XER() = default;
+	constexpr UReg_XER(u32 hex) : Hex(hex) {}
 };
 
 // Machine State Register
@@ -389,10 +389,10 @@ union UReg_MSR
 		u32 POW     : 1;
 		u32 res     : 13;
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_MSR(u32 _hex) { Hex = _hex; }
-	UReg_MSR()         { Hex = 0; }
+	constexpr UReg_MSR() = default;
+	constexpr UReg_MSR(u32 hex) : Hex(hex) {}
 };
 
 #define FPRF_SHIFT 12
@@ -486,10 +486,10 @@ union UReg_FPSCR
 		// Exception summary (sticky)
 		u32 FX      : 1;
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_FPSCR(u32 _hex) { Hex = _hex; }
-	UReg_FPSCR()         { Hex = 0;}
+	constexpr UReg_FPSCR() = default;
+	constexpr UReg_FPSCR(u32 hex) : Hex(hex) {}
 };
 
 // Hardware Implementation-Dependent Register 0
@@ -551,10 +551,10 @@ union UReg_HID2
 		u32 WPE     : 1;
 		u32 LSQE    : 1;
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_HID2(u32 _hex) { Hex = _hex; }
-	UReg_HID2()         { Hex = 0; }
+	constexpr UReg_HID2() = default;
+	constexpr UReg_HID2(u32 hex) : Hex(hex) {}
 };
 
 // Hardware Implementation-Dependent Register 4
@@ -574,10 +574,10 @@ union UReg_HID4
 		u32 L2FM  : 2;
 		u32       : 1;
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_HID4(u32 _hex) { Hex = _hex; }
-	UReg_HID4()         { Hex = 0; }
+	constexpr UReg_HID4() = default;
+	constexpr UReg_HID4(u32 hex) : Hex(hex) {}
 };
 
 // SPR1 - Page Table format
@@ -637,10 +637,10 @@ union UReg_WPAR
 		u32         : 4;
 		u32 GB_ADDR : 27;
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_WPAR(u32 _hex) { Hex = _hex; }
-	UReg_WPAR()         { Hex = 0; }
+	constexpr UReg_WPAR() = default;
+	constexpr UReg_WPAR(u32 hex) : Hex(hex) {}
 };
 
 // Direct Memory Access Upper register
@@ -651,10 +651,10 @@ union UReg_DMAU
 		u32 DMA_LEN_U : 5;
 		u32 MEM_ADDR  : 27;
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_DMAU(u32 _hex) { Hex = _hex; }
-	UReg_DMAU()         { Hex = 0; }
+	constexpr UReg_DMAU() = default;
+	constexpr UReg_DMAU(u32 hex) : Hex(hex) {}
 };
 
 // Direct Memory Access Lower (DMAL) register
@@ -668,10 +668,10 @@ union UReg_DMAL
 		u32 DMA_LD    : 1;
 		u32 LC_ADDR   : 27;
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_DMAL(u32 _hex) { Hex = _hex; }
-	UReg_DMAL()         { Hex = 0; }
+	constexpr UReg_DMAL() = default;
+	constexpr UReg_DMAL(u32 hex) : Hex(hex) {}
 };
 
 union UReg_BAT_Up
@@ -684,10 +684,10 @@ union UReg_BAT_Up
 		u32      : 4;
 		u32 BEPI : 15;
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_BAT_Up(u32 _hex) { Hex = _hex; }
-	UReg_BAT_Up()         { Hex = 0; }
+	constexpr UReg_BAT_Up() = default;
+	constexpr UReg_BAT_Up(u32 hex) : Hex(hex) {}
 };
 
 union UReg_BAT_Lo
@@ -700,10 +700,10 @@ union UReg_BAT_Lo
 		u32      : 10;
 		u32 BRPN : 15; // Physical Block Number
 	};
-	u32 Hex;
+	u32 Hex = 0;
 
-	UReg_BAT_Lo(u32 _hex) { Hex = _hex; }
-	UReg_BAT_Lo()         { Hex = 0; }
+	constexpr UReg_BAT_Lo() = default;
+	constexpr UReg_BAT_Lo(u32 hex) : Hex(hex) {}
 };
 
 union UReg_PTE

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -81,9 +81,10 @@ union UCPStatusReg
 		u16 Breakpoint           : 1;
 		u16                      : 11;
 	};
-	u16 Hex;
-	UCPStatusReg() {Hex = 0; }
-	UCPStatusReg(u16 _hex) {Hex = _hex; }
+	u16 Hex = 0;
+
+	constexpr UCPStatusReg() = default;
+	constexpr UCPStatusReg(u16 hex) : Hex(hex) {}
 };
 
 // Fifo Control Register
@@ -99,9 +100,10 @@ union UCPCtrlReg
 		u16 BPInt                  : 1;
 		u16                        : 10;
 	};
-	u16 Hex;
-	UCPCtrlReg() {Hex = 0; }
-	UCPCtrlReg(u16 _hex) {Hex = _hex; }
+	u16 Hex = 0;
+
+	constexpr UCPCtrlReg() = default;
+	constexpr UCPCtrlReg(u16 hex) : Hex(hex) {}
 };
 
 // Fifo Clear Register
@@ -114,9 +116,10 @@ union UCPClearReg
 		u16 ClearMetrices      : 1;
 		u16                    : 13;
 	};
-	u16 Hex;
-	UCPClearReg() {Hex = 0; }
-	UCPClearReg(u16 _hex) {Hex = _hex; }
+	u16 Hex = 0;
+
+	constexpr UCPClearReg() = default;
+	constexpr UCPClearReg(u16 hex) : Hex(hex) {}
 };
 
 // Init

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -87,9 +87,10 @@ union UPECtrlReg
 		u16 PEFinish       : 1; // write only
 		u16                : 12;
 	};
-	u16 Hex;
-	UPECtrlReg() {Hex = 0; }
-	UPECtrlReg(u16 _hex) {Hex = _hex; }
+	u16 Hex = 0;
+
+	constexpr UPECtrlReg() = default;
+	constexpr UPECtrlReg(u16 hex) : Hex(hex) {}
 };
 
 // STATE_TO_SAVE


### PR DESCRIPTION
Standard allows for brace-or-equal initializers on one member of a union.