### PR TITLE
Fix FreeBSD compilation.

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -35,9 +35,9 @@ namespace AudioCommon
 		std::string backend = SConfig::GetInstance().sBackend;
 		if (backend == BACKEND_OPENAL && OpenALStream::isValid())
 			g_sound_stream = new OpenALStream();
-		else if (backend.c_str() == BACKEND_NULLSOUND && NullSound::isValid())
+		else if (backend.compare(BACKEND_NULLSOUND)==0 && NullSound::isValid())
 			g_sound_stream = new NullSound();
-		else if (backend.c_str() == BACKEND_XAUDIO2)
+		else if (backend.compare(BACKEND_XAUDIO2)==0)
 		{
 			if (XAudio2::isValid())
 				g_sound_stream = new XAudio2();

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -35,9 +35,9 @@ namespace AudioCommon
 		std::string backend = SConfig::GetInstance().sBackend;
 		if (backend == BACKEND_OPENAL && OpenALStream::isValid())
 			g_sound_stream = new OpenALStream();
-		else if (backend.compare(BACKEND_NULLSOUND)==0 && NullSound::isValid())
+		else if (backend==BACKEND_NULLSOUND && NullSound::isValid())
 			g_sound_stream = new NullSound();
-		else if (backend.compare(BACKEND_XAUDIO2)==0)
+		else if (backend==BACKEND_XAUDIO2)
 		{
 			if (XAudio2::isValid())
 				g_sound_stream = new XAudio2();

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -35,9 +35,9 @@ namespace AudioCommon
 		std::string backend = SConfig::GetInstance().sBackend;
 		if (backend == BACKEND_OPENAL && OpenALStream::isValid())
 			g_sound_stream = new OpenALStream();
-		else if (backend == BACKEND_NULLSOUND && NullSound::isValid())
+		else if (backend.c_str() == BACKEND_NULLSOUND && NullSound::isValid())
 			g_sound_stream = new NullSound();
-		else if (backend == BACKEND_XAUDIO2)
+		else if (backend.c_str() == BACKEND_XAUDIO2)
 		{
 			if (XAudio2::isValid())
 				g_sound_stream = new XAudio2();

--- a/Source/Core/Common/Atomic_GCC.h
+++ b/Source/Core/Common/Atomic_GCC.h
@@ -25,7 +25,7 @@
 
 namespace Common
 {
-  
+
 inline void AtomicAdd(volatile u32& target, u32 value)
 {
 	__sync_add_and_fetch(&target, value);

--- a/Source/Core/Common/Atomic_GCC.h
+++ b/Source/Core/Common/Atomic_GCC.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Common/Common.h"
+#include "Common/CommonTypes.h" 
 
 // Atomic operations are performed in a single step by the CPU. It is
 // impossible for other threads to see the operation "half-done."
@@ -24,7 +25,6 @@
 
 namespace Common
 {
-typedef unsigned int u32;
   
 inline void AtomicAdd(volatile u32& target, u32 value)
 {

--- a/Source/Core/Common/Atomic_GCC.h
+++ b/Source/Core/Common/Atomic_GCC.h
@@ -24,7 +24,8 @@
 
 namespace Common
 {
-
+typedef unsigned int u32;
+  
 inline void AtomicAdd(volatile u32& target, u32 value)
 {
 	__sync_add_and_fetch(&target, value);

--- a/Source/Core/Common/CDUtils.cpp
+++ b/Source/Core/Common/CDUtils.cpp
@@ -22,12 +22,12 @@
 #include <IOKit/storage/IOCDMedia.h>
 #include <IOKit/storage/IOMedia.h>
 #include <paths.h>
-#else
+#elif __unix ||__unix__ 
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
-#endif // WIN32
+#endif
 
 #ifdef __linux__
 #include <linux/cdrom.h>
@@ -208,7 +208,7 @@ std::vector<std::string> cdio_get_devices()
 // Returns true if device is a cdrom/dvd drive
 bool cdio_is_cdrom(std::string device)
 {
-#ifndef _WIN32
+#ifdef _WIN32
 	// Resolve symbolic links. This allows symbolic links to valid
 	// drives to be passed from the command line with the -e flag.
 	char resolved_path[MAX_PATH];

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -658,7 +658,7 @@ std::string GetCurrentDir()
 				GetLastErrorMsg().c_str());
 		return nullptr;
 	}
-	std::string strDir = std::string(dir);
+	std::string strDir = dir;
 	free(dir);
 	return strDir;
 }

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -651,15 +651,14 @@ void CopyDir(const std::string &source_path, const std::string &dest_path)
 // Returns the current directory
 std::string GetCurrentDir()
 {
-	char *dir;
-	// Get the current working directory (getcwd uses malloc)
-	if (!(dir = __getcwd(nullptr, 0)))
+	char* dir=(char*) malloc(PATH_MAX*sizeof(char));
+	if (!(getcwd(dir, PATH_MAX)))
 	{
 		ERROR_LOG(COMMON, "GetCurrentDirectory failed: %s",
 				GetLastErrorMsg().c_str());
 		return nullptr;
 	}
-	std::string strDir = dir;
+	std::string strDir = std::string(dir);
 	free(dir);
 	return strDir;
 }
@@ -667,7 +666,7 @@ std::string GetCurrentDir()
 // Sets the current directory to the given directory
 bool SetCurrentDir(const std::string &directory)
 {
-	return __chdir(directory.c_str()) == 0;
+	return chdir(directory.c_str()) == 0;
 }
 
 std::string CreateTempDir()

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -10,6 +10,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/Common.h"
 
 // On disk format:
 //header{

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -8,9 +8,9 @@
 #include <fstream>
 #include <string>
 
+#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
-#include "Common/Common.h"
 
 // On disk format:
 //header{

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -10,6 +10,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Common/Logging/Log.h"
+#include "Common/Common.h"
 
 bool DefaultMsgHandler(const char* caption, const char* text, bool yes_no, int Style);
 static MsgAlertHandler msg_handler = DefaultMsgHandler;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "Common/Common.h"
 #include "Common/IniFile.h"
 #include "Common/NonCopyable.h"
 #include "Common/SysConf.h"
@@ -15,7 +16,7 @@
 #include "DiscIO/Volume.h"
 
 // DSP Backend Types
-#define BACKEND_NULLSOUND   "No audio output"
+#define BACKEND_NULLSOUND   _trans("No audio output")
 #define BACKEND_ALSA        "ALSA"
 #define BACKEND_AOSOUND     "AOSound"
 #define BACKEND_COREAUDIO   "CoreAudio"

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -15,7 +15,7 @@
 #include "DiscIO/Volume.h"
 
 // DSP Backend Types
-#define BACKEND_NULLSOUND   _trans("No audio output")
+#define BACKEND_NULLSOUND   "No audio output"
 #define BACKEND_ALSA        "ALSA"
 #define BACKEND_AOSOUND     "AOSound"
 #define BACKEND_COREAUDIO   "CoreAudio"

--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/CommonTypes.h"
+#include "Common/Common.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/GCKeyboard.h"
 #include "Core/HW/GCKeyboardEmu.h"

--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Common.h"
 #include "Core/HW/GCKeyboardEmu.h"
 #include "InputCommon/KeyboardStatus.h"
 

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/CommonTypes.h"
-
+#include "Common/Common.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/GCPadEmu.h"

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/CommonTypes.h"
 #include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/GCPadEmu.h"

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Common.h"
 #include "Core/Host.h"
 #include "Core/HW/GCPadEmu.h"
 

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cmath>
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Attachment.h"

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Common.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Classic.h"
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Common.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Drums.h"
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Common.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Guitar.h"
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Common.h"
 #include "Common/MathUtil.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Nunchuk.h"

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Common.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Turntable.h"
 

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -7,6 +7,7 @@
 
 #include "Core/ConfigManager.h"
 #include "Core/HotkeyManager.h"
+#include "Common/Common.h"
 
 const std::string hotkey_labels[] =
 {

--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "InputCommon/ControllerEmu.h"
+#include "Common/Common.h"
 
 void ControllerEmu::UpdateReferences(ControllerInterface& devi)
 {

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstring>
 #include <X11/XKBlib.h>
+#include <cstdlib>
 
 #include "InputCommon/ControllerInterface/Xlib/XInput2.h"
 


### PR DESCRIPTION
I am trying to get Dolphin to work on FreeBSD.  I figured a good start was to get it to compile.
FreeBSD does not believe it counts as compilation if you use precompiled headers (I was not sure if they would work anyway).  One comment with compilation is that on FreeBSD, CMake needs the wxWidgets directory set manually.  That is a result of the FreeBSD ports system putting WxWidgets with a different name than on Linux distros.