### PR TITLE
FreeBSD Compilation fix

### DIFF
--- a/Source/Core/Common/GL/GLInterface/EGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGL.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <array>
+#include <cstdlib>
+
 #include "Common/GL/GLInterface/EGL.h"
 #include "Common/Logging/Log.h"
 

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cmath>
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <X11/XKBlib.h>
 


### PR DESCRIPTION
Once again trying to make Dolphin work on FreeBSD.  This is allows the program to compile assuming you manually set wxWidgets file names because the FreeBSD ports system gives it a different name.