### PR TITLE
Include string.h in Hash.cpp if PCH is disabled

### DIFF
--- a/Source/Core/Common/Hash.cpp
+++ b/Source/Core/Common/Hash.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <cstring>
 #include "Common/CommonFuncs.h"
 #include "Common/CPUDetect.h"
 #include "Common/Hash.h"


### PR DESCRIPTION
Memcpy is needed if compiling without PCH and with -msse4.2 or on ARM64. Therefore this commit includes string.h in those cases. Should fix issue https://bugs.dolphin-emu.org/issues/9008.