### PR TITLE
DolphinQt: Install binary for systems not matching APPLE

### DIFF
--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -83,4 +83,6 @@ if(APPLE)
 			DEPENDS ${BUNDLE_PATH}/Contents/Resources/Sys
 			)
 	endif()
+else()
+	install(TARGETS ${DOLPHINQT_BINARY} RUNTIME DESTINATION ${bindir})
 endif()


### PR DESCRIPTION
The CMakelists of DolphinQt only handles installation of the binary on systems matching APPLE. This leads to the binary not getting copied to the bindir on any other system and therefore not getting installed. This should fix the issue.