### PR TITLE
Include unistd.h in memtools.cpp to fix nopch

### DIFF
--- a/Source/Core/Core/MemTools.cpp
+++ b/Source/Core/Core/MemTools.cpp
@@ -21,6 +21,9 @@
 #ifdef __FreeBSD__
 #include <signal.h>
 #endif
+#ifndef _WIN32
+#include <unistd.h> // Needed for _POSIX_VERSION
+#endif
 
 namespace EMM
 {


### PR DESCRIPTION
On non-windows builds without PCH _POSIX_VERSION was not defined and therefore the code fell back to generic which led to runtime crashes and the pagefault test failing. This commit adds the include of unistd.h to fix that issue. Thanks to HdkR!