### PR TITLE
Use CRC32 for IPL checks and update hashes

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -3,10 +3,11 @@
 // Refer to the license.txt file included.
 
 
+#include <zlib.h>
+
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
-#include "Common/Hash.h"
 #include "Common/MathUtil.h"
 #include "Common/StringUtil.h"
 
@@ -151,30 +152,37 @@ bool CBoot::LoadMapFromFilename()
 // It does not initialize the hardware or anything else like BS1 does.
 bool CBoot::Load_BS2(const std::string& _rBootROMFilename)
 {
-	const u32 USA = 0x1FCE3FD6;
-	const u32 USA_v1_1 = 0x4D5935D1;
-	const u32 JAP = 0x87424396;
-	const u32 PAL = 0xA0EA7341;
-	//const u32 PanasonicQJ = 0xAEA8265C;
-	//const u32 PanasonicQU = 0x94015753;
+	// CRC32
+	const u32 USA_v1_0 = 0x6D740AE7; // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385344#pid385344
+	const u32 USA_v1_1 = 0xD5E6FEEA; // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385334#pid385334
+	const u32 USA_v1_2 = 0x86573808; // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385399#pid385399
+	const u32 JAP_v1_0 = 0x6DAC1F2A; // Redump
+	const u32 JAP_v1_1 = 0xD235E3F9; // https://bugs.dolphin-emu.org/issues/8936
+	const u32 PAL_v1_0 = 0x4F319F43; // Redump
+	const u32 PAL_v1_2 = 0xAD1B7F16; // Redump
 
 	// Load the whole ROM dump
 	std::string data;
 	if (!File::ReadFileToString(_rBootROMFilename, data))
 		return false;
 
-	u32 ipl_hash = HashAdler32((const u8*)data.data(), data.size());
+	// Use zlibs crc32 implementation to compute the hash
+	u32 ipl_hash = crc32(0L, Z_NULL, 0);
+	ipl_hash = crc32(ipl_hash, (const Bytef*)data.data(), (u32)data.size());
 	std::string ipl_region;
 	switch (ipl_hash)
 	{
-	case USA:
+	case USA_v1_0:
 	case USA_v1_1:
+	case USA_v1_2:
 		ipl_region = USA_DIR;
 		break;
-	case JAP:
+	case JAP_v1_0:
+	case JAP_v1_1:
 		ipl_region = JAP_DIR;
 		break;
-	case PAL:
+	case PAL_v1_0:
+	case PAL_v1_2:
 		ipl_region = EUR_DIR;
 		break;
 	default:


### PR DESCRIPTION
This changes the hashing algorithm from Adler32 to CRC32 for it
is more widely used and therefore makes it easier to verify hashes.
For example the Redump database does provide CRC32 hashes, while it
doesn't have Adler32 ones.
Additionally adds new hashes from the bugtracker and the forums and
removes unknown ones.
Should fix issues https://bugs.dolphin-emu.org/issues/7035 and https://bugs.dolphin-emu.org/issues/8936.