### PR TITLE
VideoSW: Wipe alpha on bypass EFB

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -575,7 +575,7 @@ namespace EfbInterface
 			for (u16 x = left; x < right; x++)
 			{
 				GetColor(x, y, colorPtr);
-				texturePtr[textureAddress++] = Common::swap32(color);
+				texturePtr[textureAddress++] = Common::swap32(color | 0xFF);
 			}
 		}
 	}


### PR DESCRIPTION
Alpha must not be displayed.