### PR TITLE
PixelShaderGen: Use arrays of texture samplers.

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -88,11 +88,14 @@ void SHADER::SetProgramVariables()
 		if (GSBlock_id != -1)
 			glUniformBlockBinding(glprogid, GSBlock_id, 3);
 
-		// Bind Texture Sampler
+		// Bind Texture Samplers
 		for (int a = 0; a <= 9; ++a)
 		{
-			char name[8];
-			snprintf(name, 8, "samp%d", a);
+			char name[10];
+			if (a < 8)
+				snprintf(name, 8, "samp[%d]", a);
+			else
+				snprintf(name, 8, "samp%d", a);
 
 			// Still need to get sampler locations since we aren't binding them statically in the shaders
 			int loc = glGetUniformLocation(glprogid, name);

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -217,19 +217,14 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 
 	if (ApiType == API_OPENGL)
 	{
-		// Declare samplers
-		for (int i = 0; i < 8; ++i)
-			out.Write("SAMPLER_BINDING(%d) uniform sampler2DArray samp%d;\n", i, i);
+		out.Write("SAMPLER_BINDING(0) uniform sampler2DArray samp[8];\n");
 	}
 	else // D3D
 	{
 		// Declare samplers
-		for (int i = 0; i < 8; ++i)
-			out.Write("sampler samp%d : register(s%d);\n", i, i);
-
+		out.Write("SamplerState samp[8] : register(s0);\n");
 		out.Write("\n");
-		for (int i = 0; i < 8; ++i)
-			out.Write("Texture2DArray Tex%d : register(t%d);\n", i, i);
+		out.Write("Texture2DArray Tex[8] : register(t0);\n");
 	}
 	out.Write("\n");
 
@@ -1000,9 +995,9 @@ static inline void SampleTexture(T& out, const char *texcoords, const char *texs
 	out.SetConstantsUsed(C_TEXDIMS+texmap,C_TEXDIMS+texmap);
 
 	if (ApiType == API_D3D)
-		out.Write("iround(255.0 * Tex%d.Sample(samp%d, float3(%s.xy * " I_TEXDIMS"[%d].xy, %s))).%s;\n", texmap, texmap, texcoords, texmap, g_ActiveConfig.iStereoMode > 0 ? "layer" : "0.0", texswap);
+		out.Write("iround(255.0 * Tex[%d].Sample(samp[%d], float3(%s.xy * " I_TEXDIMS"[%d].xy, %s))).%s;\n", texmap, texmap, texcoords, texmap, g_ActiveConfig.iStereoMode > 0 ? "layer" : "0.0", texswap);
 	else
-		out.Write("iround(255.0 * texture(samp%d, float3(%s.xy * " I_TEXDIMS"[%d].xy, %s))).%s;\n", texmap, texcoords, texmap, g_ActiveConfig.iStereoMode > 0 ? "layer" : "0.0", texswap);
+		out.Write("iround(255.0 * texture(samp[%d], float3(%s.xy * " I_TEXDIMS"[%d].xy, %s))).%s;\n", texmap, texcoords, texmap, g_ActiveConfig.iStereoMode > 0 ? "layer" : "0.0", texswap);
 }
 
 static const char *tevAlphaFuncsTable[] =


### PR DESCRIPTION
Mostly this just makes the generated shaders look a bit cleaner, but I need to select samplers dynamically for #3163 

I've pulled this out for individual review and fifoci runs.

Also, I'm not 100% sure all versions of GLSL support compile time constant indexed arrays of samplers.