### PR TITLE
Wiimote: simplify DoState() parameters

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -70,7 +70,6 @@ public:
 
 	void SetMode(Mode mode_) { mode = mode_; }
 	Mode GetMode() const { return mode; }
-	u8** GetPPtr() { return ptr; }
 
 	template <typename K, class V>
 	void Do(std::map<K, V>& x)

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -153,11 +153,10 @@ unsigned int GetAttached()
 // input/output: ptr: [Description Needed]
 // input: mode        [Description needed]
 //
-void DoState(u8 **ptr, PointerWrap::Mode mode)
+void DoState(PointerWrap& p)
 {
 	// TODO:
 
-	PointerWrap p(ptr, mode);
 	for (unsigned int i=0; i<MAX_BBMOTES; ++i)
 		((WiimoteEmu::Wiimote*)s_config.controllers[i])->DoState(p);
 }

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -42,7 +42,7 @@ void Resume();
 void Pause();
 
 unsigned int GetAttached();
-void DoState(u8 **ptr, PointerWrap::Mode mode);
+void DoState(PointerWrap& p);
 void EmuStateChange(EMUSTATE_CHANGE newState);
 InputConfig* GetConfig();
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -164,7 +164,7 @@ static std::string DoState(PointerWrap& p)
 	p.DoMarker("video_backend");
 
 	if (SConfig::GetInstance().bWii)
-		Wiimote::DoState(p.GetPPtr(), p.GetMode());
+		Wiimote::DoState(p);
 	p.DoMarker("Wiimote");
 
 	PowerPC::DoState(p);


### PR DESCRIPTION
No idea why we were creating a new PointerWrap object here.