### PR TITLE
VideoCommon: Add includes for generic build

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -6,7 +6,9 @@
 #include <vector>
 
 #include "Common/Common.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
+#include "Common/Logging/Log.h"
 
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoaderBase.h"


### PR DESCRIPTION
On x86_64 and arm64 builds Common/MsgHandler.h and Common/Logging/Log.h are
indirectly included through the corresponding VertexLoaders, Emitters
and lastly Assert.h. Because the generic build does not build a vertex
loader JIT it does not include those and fails at compile time.
Thanks to HdkR and mibofra!