### PR TITLE
Support Conservative Depth as a fallback for Early Z (Mesa support for ZCompLoc)

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -554,6 +554,22 @@ void ProgramShaderCache::CreateHeader()
 	break;
 	}
 
+	const char* earlyz_string = "";
+	if (!is_glsles && g_ActiveConfig.backend_info.bSupportsEarlyZ)
+	{
+		if (g_ogl_config.bSupportsEarlyFragmentTests)
+		{
+			earlyz_string = "#extension GL_ARB_shader_image_load_store : enable\n"
+			                "#define FORCE_EARLY_Z layout(early_fragment_tests) in\n";
+		}
+		else if(g_ogl_config.bSupportsConservativeDepth)
+		{
+			// See PixelShaderGen for details about this fallback.
+			earlyz_string = "#extension GL_ARB_conservative_depth : enable\n"
+			                "#define FORCE_EARLY_Z layout(depth_unchanged) out float gl_FragDepth\n";
+		}
+	}
+
 	snprintf(s_glsl_header, sizeof(s_glsl_header),
 		"%s\n"
 		"%s\n" // ubo
@@ -594,7 +610,7 @@ void ProgramShaderCache::CreateHeader()
 
 		, GetGLSLVersionString().c_str()
 		, v < GLSL_140 ? "#extension GL_ARB_uniform_buffer_object : enable" : ""
-		, !is_glsles && g_ActiveConfig.backend_info.bSupportsEarlyZ ? "#extension GL_ARB_shader_image_load_store : enable" : ""
+		, earlyz_string
 		, (g_ActiveConfig.backend_info.bSupportsBindingLayout && v < GLSLES_310) ? "#extension GL_ARB_shading_language_420pack : enable" : ""
 		, (g_ogl_config.bSupportsMSAA && v < GLSL_150) ? "#extension GL_ARB_texture_multisample : enable" : ""
 		, g_ActiveConfig.backend_info.bSupportsBindingLayout ? "#define SAMPLER_BINDING(x) layout(binding = x)" : "#define SAMPLER_BINDING(x)"

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -50,6 +50,8 @@ struct VideoConfig
 	ES_TEXBUF_TYPE SupportedESTextureBuffer;
 	bool bSupports2DTextureStorage;
 	bool bSupports3DTextureStorage;
+	bool bSupportsEarlyFragmentTests;
+	bool bSupportsConservativeDepth;
 
 	const char* gl_vendor;
 	const char* gl_renderer;


### PR DESCRIPTION
Allows Mesa based drivers to support ZCompLoc.

Though i965 already supports ARB_Image_Load_Store