### PR TITLE
Remove DiscScrubber::GetDOLSize in favor of IFileSystem::GetBootDOLSize

### DIFF
--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -78,7 +78,6 @@ void ReadFromVolume(u64 _Offset, u64 _Length, u32& _Buffer, bool _Decrypt);
 void ReadFromVolume(u64 _Offset, u64 _Length, u64& _Buffer, bool _Decrypt);
 bool ParseDisc();
 bool ParsePartitionData(SPartition& _rPartition);
-u32 GetDOLSize(u64 _DOLOffset);
 
 
 bool SetupScrub(const std::string& filename, int block_size)
@@ -294,7 +293,7 @@ bool ParsePartitionData(SPartition& _rPartition)
 
 		// DOL
 		ReadFromVolume(0x420, 4, _rPartition.Header.DOLOffset, true);
-		_rPartition.Header.DOLSize = GetDOLSize(_rPartition.Header.DOLOffset);
+		_rPartition.Header.DOLSize = filesystem->GetBootDOLSize(_rPartition.Header.DOLOffset);
 		MarkAsUsedE(_rPartition.Offset
 			+ _rPartition.Header.DataOffset
 			, _rPartition.Header.DOLOffset
@@ -325,31 +324,6 @@ bool ParsePartitionData(SPartition& _rPartition)
 	m_Disc = OldVolume;
 
 	return ParsedOK;
-}
-
-u32 GetDOLSize(u64 _DOLOffset)
-{
-	u32 offset = 0, size = 0, max = 0;
-
-	// Iterate through the 7 code segments
-	for (u8 i = 0; i < 7; i++)
-	{
-		ReadFromVolume(_DOLOffset + 0x00 + i * 4, 4, offset, true);
-		ReadFromVolume(_DOLOffset + 0x90 + i * 4, 4, size, true);
-		if (offset + size > max)
-			max = offset + size;
-	}
-
-	// Iterate through the 11 data segments
-	for (u8 i = 0; i < 11; i++)
-	{
-		ReadFromVolume(_DOLOffset + 0x1c + i * 4, 4, offset, true);
-		ReadFromVolume(_DOLOffset + 0xac + i * 4, 4, size, true);
-		if (offset + size > max)
-			max = offset + size;
-	}
-
-	return max;
 }
 
 } // namespace DiscScrubber

--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -150,27 +150,32 @@ bool CFileSystemGCWii::ExportApploader(const std::string& _rExportFolder) const
 
 u32 CFileSystemGCWii::GetBootDOLSize() const
 {
-	u32 DolOffset = m_rVolume->Read32(0x420, m_Wii) << GetOffsetShift();
-	u32 DolSize = 0, offset = 0, size = 0;
+	return GetBootDOLSize((u64)m_rVolume->Read32(0x420, m_Wii) << GetOffsetShift());
+}
+
+u32 CFileSystemGCWii::GetBootDOLSize(u64 dol_offset) const
+{
+	u32 dol_size = 0;
+	u32 offset = 0;
+	u32 size = 0;
 
 	// Iterate through the 7 code segments
 	for (u8 i = 0; i < 7; i++)
 	{
-		offset = m_rVolume->Read32(DolOffset + 0x00 + i * 4, m_Wii);
-		size   = m_rVolume->Read32(DolOffset + 0x90 + i * 4, m_Wii);
-		if (offset + size > DolSize)
-			DolSize = offset + size;
+		offset   = m_rVolume->Read32(dol_offset + 0x00 + i * 4, m_Wii);
+		size     = m_rVolume->Read32(dol_offset + 0x90 + i * 4, m_Wii);
+		dol_size = std::max(offset + size, dol_size);
 	}
 
 	// Iterate through the 11 data segments
 	for (u8 i = 0; i < 11; i++)
 	{
-		offset = m_rVolume->Read32(DolOffset + 0x1c + i * 4, m_Wii);
-		size   = m_rVolume->Read32(DolOffset + 0xac + i * 4, m_Wii);
-		if (offset + size > DolSize)
-			DolSize = offset + size;
+		offset   = m_rVolume->Read32(dol_offset + 0x1c + i * 4, m_Wii);
+		size     = m_rVolume->Read32(dol_offset + 0xac + i * 4, m_Wii);
+		dol_size = std::max(offset + size, dol_size);
 	}
-	return DolSize;
+
+	return dol_size;
 }
 
 bool CFileSystemGCWii::GetBootDOL(u8* &buffer, u32 DolSize) const

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -32,6 +32,7 @@ public:
 	bool ExportDOL(const std::string& _rExportFolder) const override;
 	bool GetBootDOL(u8* &buffer, u32 DolSize) const override;
 	u32 GetBootDOLSize() const override;
+	u32 GetBootDOLSize(u64 dol_offset) const override;
 
 private:
 	bool m_Initialized;

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -52,6 +52,7 @@ public:
 	virtual const std::string GetFileName(u64 _Address) = 0;
 	virtual bool GetBootDOL(u8* &buffer, u32 DolSize) const = 0;
 	virtual u32 GetBootDOLSize() const = 0;
+	virtual u32 GetBootDOLSize(u64 dol_offset) const = 0;
 
 	virtual const IVolume *GetVolume() const { return m_rVolume; }
 protected:


### PR DESCRIPTION
IFileSystem::GetBootDOLSize acts the same. The only difference is that it reads the DOL offset on its own, but this change makes that optional.