### PR TITLE
There... Are... Eight... Texgens!

### DIFF
--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -571,7 +571,8 @@ union GenMode
 		CULL_ALL = 3, // cull all primitives
 	};
 
-	BitField< 0,4,u32> numtexgens;
+	BitField< 0,3,u32> numtexgens;
+	// 1 bit unused?
 	BitField< 4,3,u32> numcolchans;
 	// 1 bit unused?
 	BitField< 8,1,u32> flat_shading; // unconfirmed

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -16,7 +16,7 @@ struct geometry_shader_uid_data
 	bool IsPassthrough() const { return primitive_type == PRIMITIVE_TRIANGLES && !stereo && !wireframe; }
 
 	u32 stereo : 1;
-	u32 numTexGens : 4;
+	u32 numTexGens : 3;
 	u32 pixel_lighting : 1;
 	u32 primitive_type : 2;
 	u32 wireframe : 1;

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -31,7 +31,7 @@ struct pixel_shader_uid_data
 	u32 nIndirectStagesUsed : 4;
 	u32 stereo : 1;
 
-	u32 genMode_numtexgens : 4;
+	u32 genMode_numtexgens : 3;
 	u32 genMode_numtevstages : 4;
 	u32 genMode_numindstages : 3;
 	u32 alpha_test_comp0 : 3;
@@ -47,12 +47,13 @@ struct pixel_shader_uid_data
 	u32 forced_early_z : 1;
 	u32 early_ztest : 1;
 	u32 bounding_box : 1;
+	u32 pad : 1;
 
 	// TODO: 29 bits of padding is a waste. Can we free up some bits elseware?
 	u32 zfreeze : 1;
 	u32 msaa : 1;
 	u32 ssaa : 1;
-	u32 pad : 29;
+	u32 pad2 : 29;
 
 	u32 texMtxInfo_n_projection : 8; // 8x1 bit
 	u32 tevindref_bi0 : 3;

--- a/Source/Core/VideoCommon/VertexShaderGen.h
+++ b/Source/Core/VideoCommon/VertexShaderGen.h
@@ -33,11 +33,11 @@ struct vertex_shader_uid_data
 	u32 NumValues() const { return sizeof(vertex_shader_uid_data); }
 
 	u32 components           : 23;
-	u32 numTexGens           : 4;
+	u32 numTexGens           : 3;
 	u32 numColorChans        : 2;
 	u32 dualTexTrans_enabled : 1;
 	u32 pixel_lighting       : 1;
-	u32 pad                  : 1;
+	u32 pad                  : 2;
 
 	u32 texMtxInfo_n_projection : 16; // Stored separately to guarantee that the texMtxInfo struct is 8 bits wide
 	struct {

--- a/Source/Core/VideoCommon/XFMemory.h
+++ b/Source/Core/VideoCommon/XFMemory.h
@@ -210,7 +210,7 @@ union NumTexGen
 {
 	struct
 	{
-		u32 numTexGens : 4;
+		u32 numTexGens : 3;
 	};
 	u32 hex;
 };

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -131,7 +131,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
 			break;
 
 		case XFMEM_SETNUMTEXGENS: // GXSetNumTexGens
-			if (xfmem.numTexGen.numTexGens != (newValue & 15))
+			if (xfmem.numTexGen.numTexGens != (newValue & 7))
 				VertexManager::Flush();
 			break;
 


### PR DESCRIPTION
Not sixteen.

I suspect at one point the design had 16 texgens and 4 color channels, but they were removed, leaving gaps in the encoding.