### PR TITLE
Throttler + Mixer: Configureable variance

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -47,9 +47,12 @@ unsigned int CMixer::MixerFifo::Mix(short* samples, unsigned int numSamples, boo
 	u32 indexR = m_indexR.load();
 	u32 indexW = m_indexW.load();
 
+	int low_waterwark = m_input_sample_rate * SConfig::GetInstance().iTimingVariance / 1000;
+	low_waterwark = std::min(low_waterwark, MAX_SAMPLES / 2);
+
 	float numLeft = (float)(((indexW - indexR) & INDEX_MASK) / 2);
 	m_numLeftI = (numLeft + m_numLeftI*(CONTROL_AVG-1)) / CONTROL_AVG;
-	float offset = (m_numLeftI - LOW_WATERMARK) * CONTROL_FACTOR;
+	float offset = (m_numLeftI - low_waterwark) * CONTROL_FACTOR;
 	if (offset > MAX_FREQ_SHIFT) offset = MAX_FREQ_SHIFT;
 	if (offset < -MAX_FREQ_SHIFT) offset = -MAX_FREQ_SHIFT;
 

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -11,10 +11,9 @@
 #include "AudioCommon/WaveFile.h"
 
 // 16 bit Stereo
-#define MAX_SAMPLES     (1024 * 2) // 64ms
+#define MAX_SAMPLES     (1024 * 4) // 128 ms
 #define INDEX_MASK      (MAX_SAMPLES * 2 - 1)
 
-#define LOW_WATERMARK   1280 // 40 ms
 #define MAX_FREQ_SHIFT  200  // per 32000 Hz
 #define CONTROL_FACTOR  0.2f // in freq_shift per fifo size offset
 #define CONTROL_AVG     32

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -35,7 +35,7 @@ SConfig::SConfig()
   bJITPairedOff(false), bJITSystemRegistersOff(false),
   bJITBranchOff(false),
   bJITILTimeProfiling(false), bJITILOutputIR(false),
-  bFPRF(false), bAccurateNaNs(false),
+  bFPRF(false), bAccurateNaNs(false), iTimingVariance(40),
   bCPUThread(true), bDSPThread(false), bDSPHLE(true),
   bSkipIdle(true), bSyncGPUOnSkipIdleHack(true), bNTSC(false), bForceNTSCJ(false),
   bHLE_BS2(true), bEnableCheats(false),
@@ -221,6 +221,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	IniFile::Section* core = ini.GetOrCreateSection("Core");
 
 	core->Set("HLE_BS2", bHLE_BS2);
+	core->Set("TimingVariance", iTimingVariance);
 	core->Set("CPUCore", iCPUCore);
 	core->Set("Fastmem", bFastmem);
 	core->Set("CPUThread", bCPUThread);
@@ -479,6 +480,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 #endif
 	core->Get("Fastmem",           &bFastmem,      true);
 	core->Get("DSPHLE",            &bDSPHLE,       true);
+	core->Get("TimingVariance",    &iTimingVariance, 40);
 	core->Get("CPUThread",         &bCPUThread,    true);
 	core->Get("SkipIdle",          &bSkipIdle,     true);
 	core->Get("SyncOnSkipIdle",    &bSyncGPUOnSkipIdleHack, true);
@@ -592,6 +594,7 @@ void SConfig::LoadDefaults()
 	#endif
 
 	iCPUCore = PowerPC::CORE_JIT64;
+	iTimingVariance = 40;
 	bCPUThread = false;
 	bSkipIdle = false;
 	bSyncGPUOnSkipIdleHack = true;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -79,6 +79,7 @@ struct SConfig : NonCopyable
 	bool bFPRF;
 	bool bAccurateNaNs;
 
+	int iTimingVariance; // in milli secounds
 	bool bCPUThread;
 	bool bDSPThread;
 	bool bDSPHLE;

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -197,12 +197,12 @@ static void ThrottleCallback(u64 last_time, int cyclesLate)
 	const SConfig& config = SConfig::GetInstance();
 	bool frame_limiter = config.m_Framelimit && !Core::GetIsFramelimiterTempDisabled();
 	u32 next_event = GetTicksPerSecond()/1000;
-	if (SConfig::GetInstance().m_Framelimit > 1)
+	if (config.m_Framelimit > 1)
 	{
-		next_event = next_event * (SConfig::GetInstance().m_Framelimit - 1) * 5 / VideoInterface::TargetRefreshRate;
+		next_event = next_event * (config.m_Framelimit - 1) * 5 / VideoInterface::TargetRefreshRate;
 	}
 
-	const int max_fallback = 40; // 40 ms for one frame on 25 fps games
+	const int max_fallback = config.iTimingVariance;
 	if (frame_limiter && abs(diff) > max_fallback)
 	{
 		DEBUG_LOG(COMMON, "system too %s, %d ms skipped", diff<0 ? "slow" : "fast", abs(diff) - max_fallback);


### PR DESCRIPTION
The default is the old hardcoded value of 40ms which is ideal for 25fps games.

Higher values may "fix" stutters, lower ones slows down much more because of small stutters.

Audio latency and framelimiter variance are coupled for slowdown detection. Our framelimiter tries to catch up small slowdowns. If the slowdown is bigger than this configured variance, it gives up and tries to start from skretch. But so, we might get this variance on emulation speed which must be buffered by the audio mixer. So this ensure to not underrun our mixer if we're within the allowed timing variance of the framelimiter.

In the end, it's a slider for performance vs latency.