### PR TITLE
VertexShaderGen: Remove assert

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -207,7 +207,8 @@ static inline void GenerateVertexShader(T& out, u32 components, API_TYPE api_typ
 		case XF_SRCNORMAL_INROW:
 			if (components & VB_HAS_NRM0)
 			{
-				_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
+				// The following assert was triggered in Project M 3.6, with Jigglypuff's Fairy Wing outfit
+				//_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
 				out.Write("coord = float4(rawnorm0.xyz, 1.0);\n");
 			}
 			break;


### PR DESCRIPTION
This state can be configured on hardware, but we have no clue about the behavior.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3207)
<!-- Reviewable:end -->
