### PR TITLE
TextureCache: Efb Copy Separation

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -32,8 +32,8 @@ public:
 	void Init();
 	void Shutdown();
 	void Encode(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-	              PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
-	              bool isIntensity, bool scaleByHalf);
+	            PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+	            bool isIntensity, bool scaleByHalf);
 
 private:
 	bool m_ready;

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -31,9 +31,9 @@ public:
 
 	void Init();
 	void Shutdown();
-	void Encode(u8* dst, const TextureCacheBase::TCacheEntryBase* texture_entry,
-	            PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
-	            bool isIntensity, bool scaleByHalf);
+	void Encode(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+	              PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+	              bool isIntensity, bool scaleByHalf);
 
 private:
 	bool m_ready;

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -236,11 +236,13 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, unsigned int dstFormat
 	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
 
 	g_renderer->RestoreAPIState();
+}
 
-	if (g_ActiveConfig.bSkipEFBCopyToRam)
-		this->Zero(dst);
-	else
-		g_encoder->Encode(dst, format, native_width, BytesPerRow(), NumBlocksY(), memory_stride, srcFormat, srcRect, isIntensity, scaleByHalf);
+void TextureCache::CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+	PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+	bool isIntensity, bool scaleByHalf)
+{
+	g_encoder->Encode(dst, format, native_width, bytes_per_row, num_blocks_y, memory_stride, srcFormat, srcRect, isIntensity, scaleByHalf);
 }
 
 const char palette_shader[] =

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -184,10 +184,8 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 	}
 }
 
-void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, unsigned int dstFormat, u32 dstStride,
-	PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
-	bool isIntensity, bool scaleByHalf, unsigned int cbufid,
-	const float *colmat)
+void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+	bool scaleByHalf, unsigned int cbufid, const float *colmat)
 {
 	g_renderer->ResetAPIState();
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -240,7 +240,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, unsigned int dstFormat
 	if (g_ActiveConfig.bSkipEFBCopyToRam)
 		this->Zero(dst);
 	else
-		g_encoder->Encode(dst, this, srcFormat, srcRect, isIntensity, scaleByHalf);
+		g_encoder->Encode(dst, format, native_width, BytesPerRow(), NumBlocksY(), memory_stride, srcFormat, srcRect, isIntensity, scaleByHalf);
 }
 
 const char palette_shader[] =

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -49,6 +49,10 @@ private:
 
 	void ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* unconverted, void* palette, TlutFormat format) override;
 
+	void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+		PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+		bool isIntensity, bool scaleByHalf) override;
+
 	void CompileShaders() override { }
 	void DeleteShaders() override { }
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -34,10 +34,8 @@ private:
 		void Load(unsigned int width, unsigned int height,
 			unsigned int expanded_width, unsigned int levels) override;
 
-		void FromRenderTarget(u8* dst, unsigned int dstFormat, u32 dstStride,
-			PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
-			bool isIntensity, bool scaleByHalf, unsigned int cbufid,
-			const float *colmat) override;
+		void FromRenderTarget(u8* dst, PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+			bool scaleByHalf, unsigned int cbufid, const float *colmat) override;
 
 		void Bind(unsigned int stage) override;
 		bool Save(const std::string& filename, unsigned int level) override;

--- a/Source/Core/VideoBackends/D3D/TextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/TextureEncoder.h
@@ -26,7 +26,7 @@ public:
 	virtual void Init() = 0;
 	virtual void Shutdown() = 0;
 	// Returns size in bytes of encoded block of memory
-	virtual void Encode(u8* dst, const TextureCacheBase::TCacheEntryBase* texture_entry,
+	virtual void Encode(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
 		PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
 		bool isIntensity, bool scaleByHalf) = 0;
 

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -266,25 +266,23 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dstPointer, unsigned int ds
 
 	FramebufferManager::SetFramebuffer(0);
 	g_renderer->RestoreAPIState();
+}
 
-	if (g_ActiveConfig.bSkipEFBCopyToRam)
-	{
-		this->Zero(dstPointer);
-	}
-	else
-	{
-		TextureConverter::EncodeToRamFromTexture(
-			dstPointer,
-			format,
-			native_width,
-			BytesPerRow(),
-			NumBlocksY(),
-			memory_stride,
-			srcFormat,
-			isIntensity,
-			scaleByHalf,
-			srcRect);
-	}
+void TextureCache::CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+		PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+		bool isIntensity, bool scaleByHalf)
+{
+	TextureConverter::EncodeToRamFromTexture(
+		dst,
+		format,
+		native_width,
+		bytes_per_row,
+		num_blocks_y,
+		memory_stride,
+		srcFormat,
+		isIntensity,
+		scaleByHalf,
+		srcRect);
 }
 
 TextureCache::TextureCache()

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -272,7 +272,11 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dstPointer, unsigned int ds
 	{
 		TextureConverter::EncodeToRamFromTexture(
 			dstPointer,
-			this,
+			format,
+			native_width,
+			BytesPerRow(),
+			NumBlocksY(),
+			memory_stride,
 			read_texture,
 			srcFormat == PEControl::Z24,
 			isIntensity,

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -215,10 +215,8 @@ void TextureCache::TCacheEntry::Load(unsigned int width, unsigned int height,
 	TextureCache::SetStage();
 }
 
-void TextureCache::TCacheEntry::FromRenderTarget(u8* dstPointer, unsigned int dstFormat, u32 dstStride,
-	PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
-	bool isIntensity, bool scaleByHalf, unsigned int cbufid,
-	const float *colmat)
+void TextureCache::TCacheEntry::FromRenderTarget(u8* dstPointer, PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+	bool scaleByHalf, unsigned int cbufid, const float *colmat)
 {
 	g_renderer->ResetAPIState(); // reset any game specific settings
 

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -264,6 +264,9 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dstPointer, unsigned int ds
 
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
+	FramebufferManager::SetFramebuffer(0);
+	g_renderer->RestoreAPIState();
+
 	if (g_ActiveConfig.bSkipEFBCopyToRam)
 	{
 		this->Zero(dstPointer);
@@ -277,16 +280,11 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dstPointer, unsigned int ds
 			BytesPerRow(),
 			NumBlocksY(),
 			memory_stride,
-			read_texture,
-			srcFormat == PEControl::Z24,
+			srcFormat,
 			isIntensity,
 			scaleByHalf,
 			srcRect);
 	}
-
-	FramebufferManager::SetFramebuffer(0);
-
-	g_renderer->RestoreAPIState();
 }
 
 TextureCache::TextureCache()

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -42,10 +42,8 @@ private:
 		void Load(unsigned int width, unsigned int height,
 			unsigned int expanded_width, unsigned int level) override;
 
-		void FromRenderTarget(u8 *dst, unsigned int dstFormat, u32 dstStride,
-			PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
-			bool isIntensity, bool scaleByHalf, unsigned int cbufid,
-			const float *colmat) override;
+		void FromRenderTarget(u8 *dst, PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+			bool scaleByHalf, unsigned int cbufid, const float *colmat) override;
 
 		void Bind(unsigned int stage) override;
 		bool Save(const std::string& filename, unsigned int level) override;

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -56,6 +56,10 @@ private:
 	TCacheEntryBase* CreateTexture(const TCacheEntryConfig& config) override;
 	void ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* unconverted, void* palette, TlutFormat format) override;
 
+	void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+		PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+		bool isIntensity, bool scaleByHalf) override;
+
 	void CompileShaders() override;
 	void DeleteShaders() override;
 };

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -270,17 +270,26 @@ static void EncodeToRamUsingShader(GLuint srcTexture,
 }
 
 void EncodeToRamFromTexture(u8 *dest_ptr, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-                            GLuint source_texture, bool bFromZBuffer, bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source)
+                            PEControl::PixelFormat srcFormat, bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source)
 {
+	g_renderer->ResetAPIState();
+
 	SHADER& texconv_shader = GetOrCreateEncodingShader(format);
 
 	texconv_shader.Bind();
 	glUniform4i(s_encodingUniforms[format],
 		source.left, source.top, native_width, bScaleByHalf ? 2 : 1);
 
-	EncodeToRamUsingShader(source_texture,
+	const GLuint read_texture = (srcFormat == PEControl::Z24) ?
+		FramebufferManager::ResolveAndGetDepthTarget(source) :
+		FramebufferManager::ResolveAndGetRenderTarget(source);
+
+	EncodeToRamUsingShader(read_texture,
 		dest_ptr, bytes_per_row, num_blocks_y,
-		memory_stride, bScaleByHalf > 0 && !bFromZBuffer);
+		memory_stride, bScaleByHalf > 0 && srcFormat != PEControl::Z24);
+
+	FramebufferManager::SetFramebuffer(0);
+	g_renderer->RestoreAPIState();
 }
 
 void EncodeToRamYUYV(GLuint srcTexture, const TargetRectangle& sourceRc, u8* destAddr, u32 dstWidth, u32 dstStride, u32 dstHeight)

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -269,7 +269,7 @@ static void EncodeToRamUsingShader(GLuint srcTexture,
 	}
 }
 
-void EncodeToRamFromTexture(u8 *dest_ptr, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+void EncodeToRamFromTexture(u8* dest_ptr, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
                             PEControl::PixelFormat srcFormat, bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source)
 {
 	g_renderer->ResetAPIState();

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -269,18 +269,18 @@ static void EncodeToRamUsingShader(GLuint srcTexture,
 	}
 }
 
-void EncodeToRamFromTexture(u8 *dest_ptr, const TextureCache::TCacheEntryBase *texture_entry,
+void EncodeToRamFromTexture(u8 *dest_ptr, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
                             GLuint source_texture, bool bFromZBuffer, bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source)
 {
-	SHADER& texconv_shader = GetOrCreateEncodingShader(texture_entry->format);
+	SHADER& texconv_shader = GetOrCreateEncodingShader(format);
 
 	texconv_shader.Bind();
-	glUniform4i(s_encodingUniforms[texture_entry->format],
-		source.left, source.top, texture_entry->native_width, bScaleByHalf ? 2 : 1);
+	glUniform4i(s_encodingUniforms[format],
+		source.left, source.top, native_width, bScaleByHalf ? 2 : 1);
 
 	EncodeToRamUsingShader(source_texture,
-		dest_ptr, texture_entry->BytesPerRow(), texture_entry->NumBlocksY(),
-		texture_entry->memory_stride, bScaleByHalf > 0 && !bFromZBuffer);
+		dest_ptr, bytes_per_row, num_blocks_y,
+		memory_stride, bScaleByHalf > 0 && !bFromZBuffer);
 }
 
 void EncodeToRamYUYV(GLuint srcTexture, const TargetRectangle& sourceRc, u8* destAddr, u32 dstWidth, u32 dstStride, u32 dstHeight)

--- a/Source/Core/VideoBackends/OGL/TextureConverter.h
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.h
@@ -26,7 +26,7 @@ void EncodeToRamYUYV(GLuint srcTexture, const TargetRectangle& sourceRc,
 void DecodeToTexture(u32 xfbAddr, int srcWidth, int srcHeight, GLuint destTexture);
 
 // returns size of the encoded data (in bytes)
-void EncodeToRamFromTexture(u8* dest_ptr, const TextureCacheBase::TCacheEntryBase* texture_entry,
+void EncodeToRamFromTexture(u8 *dest_ptr, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
 	GLuint source_texture, bool bFromZBuffer, bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source);
 
 }

--- a/Source/Core/VideoBackends/OGL/TextureConverter.h
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.h
@@ -26,7 +26,7 @@ void EncodeToRamYUYV(GLuint srcTexture, const TargetRectangle& sourceRc,
 void DecodeToTexture(u32 xfbAddr, int srcWidth, int srcHeight, GLuint destTexture);
 
 // returns size of the encoded data (in bytes)
-void EncodeToRamFromTexture(u8 *dest_ptr, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+void EncodeToRamFromTexture(u8* dest_ptr, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
 	PEControl::PixelFormat srcFormat, bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source);
 
 }

--- a/Source/Core/VideoBackends/OGL/TextureConverter.h
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.h
@@ -27,7 +27,7 @@ void DecodeToTexture(u32 xfbAddr, int srcWidth, int srcHeight, GLuint destTextur
 
 // returns size of the encoded data (in bytes)
 void EncodeToRamFromTexture(u8 *dest_ptr, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-	GLuint source_texture, bool bFromZBuffer, bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source);
+	PEControl::PixelFormat srcFormat, bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source);
 
 }
 

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1050,6 +1050,25 @@ void TextureCacheBase::CopyRenderTargetToTexture(u32 dstAddr, unsigned int dstFo
 
 	entry->FromRenderTarget(dst, dstFormat, dstStride, srcFormat, srcRect, isIntensity, scaleByHalf, cbufid, colmat);
 
+	if (g_ActiveConfig.bSkipEFBCopyToRam)
+	{
+		entry->Zero(dst);
+	}
+	else
+	{
+		g_texture_cache->CopyEFB(
+			dst,
+			entry->format,
+			entry->native_width,
+			entry->BytesPerRow(),
+			entry->NumBlocksY(),
+			entry->memory_stride,
+			srcFormat,
+			srcRect,
+			isIntensity,
+			scaleByHalf);
+	}
+
 	u64 hash = entry->CalculateHash();
 	entry->SetHashes(hash, hash);
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -130,6 +130,10 @@ public:
 
 	virtual TCacheEntryBase* CreateTexture(const TCacheEntryConfig& config) = 0;
 
+	virtual void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+		PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+		bool isIntensity, bool scaleByHalf) = 0;
+
 	virtual void CompileShaders() = 0; // currently only implemented by OGL
 	virtual void DeleteShaders() = 0; // currently only implemented by OGL
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -101,10 +101,8 @@ public:
 
 		virtual void Load(unsigned int width, unsigned int height,
 			unsigned int expanded_width, unsigned int level) = 0;
-		virtual void FromRenderTarget(u8* dst, unsigned int dstFormat, u32 dstStride,
-			PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
-			bool isIntensity, bool scaleByHalf, unsigned int cbufid,
-			const float *colmat) = 0;
+		virtual void FromRenderTarget(u8* dst, PEControl::PixelFormat srcFormat, const EFBRectangle& srcRect,
+			bool scaleByHalf, unsigned int cbufid, const float *colmat) = 0;
 
 		bool OverlapsMemoryRange(u32 range_address, u32 range_size) const;
 
@@ -112,8 +110,6 @@ public:
 
 		u32 NumBlocksY() const;
 		u32 BytesPerRow() const;
-
-		void Zero(u8* ptr);
 
 		u64 CalculateHash() const;
 	};


### PR DESCRIPTION
This PR tries to seperate EFB 2 RAM and EFB 2 TEX code as much as possible. I'd like to play a bit with only one of those enabled, maybe we'll see some efb2ram issues only, or we can create better hyristics when to do efb2ram.