### PR TITLE
DolphinWX: Remove the dolphin-emulator.com check.

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -96,7 +96,7 @@ bool DolphinApp::Initialize(int& c, wxChar **v)
 
 bool DolphinApp::OnInit()
 {
-	if (!wxApp::OnInit() || DolphinEmulatorDotComTextFileExists())
+	if (!wxApp::OnInit())
 		return false;
 
 	Bind(wxEVT_QUERY_END_SESSION, &DolphinApp::OnEndSession, this);
@@ -256,23 +256,6 @@ void DolphinApp::MacOpenFile(const wxString& fileName)
 	main_frame->BootGame(WxStrToStr(m_file_to_load));
 }
 #endif
-
-bool DolphinApp::DolphinEmulatorDotComTextFileExists()
-{
-	if (!File::Exists("www.dolphin-emulator.com.txt"))
-		return false;
-
-	File::Delete("www.dolphin-emulator.com.txt");
-	wxMessageDialog dlg(nullptr, _(
-	    "This version of Dolphin was downloaded from a website stealing money from developers of the emulator. Please "
-	    "download Dolphin from the official website instead: https://dolphin-emu.org/"),
-	    _("Unofficial version detected"), wxOK | wxICON_WARNING);
-	dlg.ShowModal();
-
-	wxLaunchDefaultBrowser("https://dolphin-emu.org/?ref=badver");
-
-	return true;
-}
 
 void DolphinApp::AfterInit()
 {

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -33,7 +33,6 @@ private:
 	void OnEndSession(wxCloseEvent& event);
 	void InitLanguageSupport();
 	void AfterInit();
-	static bool DolphinEmulatorDotComTextFileExists();
 
 	bool m_batch_mode = false;
 	bool m_confirm_stop = false;


### PR DESCRIPTION
Surprisingly we still got 3 /?ref=badver today on dolphin-emu.org. In any case, it's not really needed for newer builds.