### PR TITLE
Various fixes from the abandoned 5.0 stable

### DIFF
--- a/Data/Sys/GameSettings/GXE.ini
+++ b/Data/Sys/GameSettings/GXE.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -56,7 +56,10 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
 	// Write necessary values
 	// Here we write values to memory that the apploader does not take care of. Game info goes
 	// to 0x80000000 according to YAGCD 4.2.
-	DVDInterface::DVDRead(/*offset*/0x00000000, /*address*/0x00000000, 0x20, false); // write disc info
+
+	// It's possible to boot DOL and ELF files without a disc inserted
+	if (DVDInterface::VolumeIsValid())
+		DVDInterface::DVDRead(/*offset*/0x00000000, /*address*/0x00000000, 0x20, false); // write disc info
 
 	PowerPC::HostWrite_U32(0x0D15EA5E, 0x80000020); // Booted from bootrom. 0xE5207C22 = booted from jtag
 	PowerPC::HostWrite_U32(Memory::REALRAM_SIZE, 0x80000028); // Physical Memory Size (24MB on retail)
@@ -80,6 +83,9 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
 	//PowerPC::HostWrite_U16(0x8200,     0x000030e6); // Console type
 
 	HLE::Patch(0x81300000, "OSReport"); // HLE OSReport for Apploader
+
+	if (!DVDInterface::VolumeIsValid())
+		return false;
 
 	// Load Apploader to Memory - The apploader is hardcoded to begin at 0x2440 on the disc,
 	// but the size can differ between discs. Compare with YAGCD chap 13.

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -95,6 +95,9 @@ bool SetupScrub(const std::string& filename, int block_size)
 	m_BlocksPerCluster = CLUSTER_SIZE / m_BlockSize;
 
 	m_Disc = CreateVolumeFromFilename(filename);
+	if (!m_Disc)
+		return false;
+
 	m_FileSize = m_Disc->GetSize();
 
 	u32 numClusters = (u32)(m_FileSize / CLUSTER_SIZE);


### PR DESCRIPTION
Until recently, we were using both the master and stable branches while working at 5.0. Almost everyone made their PR for master and then got the commits cherry-picked to stable if needed, but I made a few small PRs that were for stable directly. My intent was that they would get brought over to master by the occasional merges of stable to master, removing the need to cherry-pick. That worked for a while, but no more merges were made after the 5.0-rc tag was created, so some of my commits ended up being in the stable branch but not the master branch. Because we are now abandoning the 5.0 stable branch, this PR brings those commits over to master.