### PR TITLE
CMake: Fix FindMiniupnpc for ubuntu 14.04

### DIFF
--- a/CMakeTests/FindMiniupnpc.cmake
+++ b/CMakeTests/FindMiniupnpc.cmake
@@ -6,7 +6,9 @@ find_library(MINIUPNPC_LIBRARY miniupnpc)
 
 if(MINIUPNPC_INCLUDE_DIR)
 	file(STRINGS "${MINIUPNPC_INCLUDE_DIR}/miniupnpc.h" MINIUPNPC_API_VERSION_STR REGEX "^#define[\t ]+MINIUPNPC_API_VERSION[\t ]+[0-9]+")
-	string(REGEX REPLACE "^#define[\t ]+MINIUPNPC_API_VERSION[\t ]+([0-9]+)" "\\1" MINIUPNPC_API_VERSION ${MINIUPNPC_API_VERSION_STR})
+	if(MINIUPNPC_API_VERSION_STR)
+		string(REGEX REPLACE "^#define[\t ]+MINIUPNPC_API_VERSION[\t ]+([0-9]+)" "\\1" MINIUPNPC_API_VERSION ${MINIUPNPC_API_VERSION_STR})
+	endif()
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Ubuntu 14.04 (and the latest version of Mint, which is based on it) has miniupnpc 1.6.3

REGEX was failing because the string was empty, causing cmake to error and not generate a Makefile. This change allows systems with older versions of miniupnpc to fall back to the statically linked version in externals.