### PR TITLE
VideoCommon: return code/uid from shader gens

### DIFF
--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -190,12 +190,10 @@ void GeometryShaderCache::Shutdown()
 
 bool GeometryShaderCache::SetShader(u32 primitive_type)
 {
-	GeometryShaderUid uid;
-	GetGeometryShaderUid(uid, primitive_type, API_D3D);
+	GeometryShaderUid uid = GetGeometryShaderUid(primitive_type, API_D3D);
 	if (g_ActiveConfig.bEnableShaderDebugging)
 	{
-		ShaderCode code;
-		GenerateGeometryShaderCode(code, primitive_type, API_D3D);
+		ShaderCode code = GenerateGeometryShaderCode(primitive_type, API_D3D);
 		geometry_uid_checker.AddToIndexAndCheck(code, uid, "Geometry", "g");
 	}
 
@@ -231,8 +229,7 @@ bool GeometryShaderCache::SetShader(u32 primitive_type)
 	}
 
 	// Need to compile a new shader
-	ShaderCode code;
-	GenerateGeometryShaderCode(code, primitive_type, API_D3D);
+	ShaderCode code = GenerateGeometryShaderCode(primitive_type, API_D3D);
 
 	D3DBlob* pbytecode;
 	if (!D3D::CompileGeometryShader(code.GetBuffer(), &pbytecode))

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -527,12 +527,10 @@ void PixelShaderCache::Shutdown()
 
 bool PixelShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode)
 {
-	PixelShaderUid uid;
-	GetPixelShaderUid(uid, dstAlphaMode, API_D3D);
+	PixelShaderUid uid = GetPixelShaderUid(dstAlphaMode, API_D3D);
 	if (g_ActiveConfig.bEnableShaderDebugging)
 	{
-		ShaderCode code;
-		GeneratePixelShaderCode(code, dstAlphaMode, API_D3D);
+		ShaderCode code = GeneratePixelShaderCode(dstAlphaMode, API_D3D);
 		pixel_uid_checker.AddToIndexAndCheck(code, uid, "Pixel", "p");
 	}
 
@@ -561,8 +559,7 @@ bool PixelShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode)
 	}
 
 	// Need to compile a new shader
-	ShaderCode code;
-	GeneratePixelShaderCode(code, dstAlphaMode, API_D3D);
+	ShaderCode code = GeneratePixelShaderCode(dstAlphaMode, API_D3D);
 
 	D3DBlob* pbytecode;
 	if (!D3D::CompilePixelShader(code.GetBuffer(), &pbytecode))

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -186,12 +186,10 @@ void VertexShaderCache::Shutdown()
 
 bool VertexShaderCache::SetShader()
 {
-	VertexShaderUid uid;
-	GetVertexShaderUid(uid, API_D3D);
+	VertexShaderUid uid = GetVertexShaderUid(API_D3D);
 	if (g_ActiveConfig.bEnableShaderDebugging)
 	{
-		ShaderCode code;
-		GenerateVertexShaderCode(code, API_D3D);
+		ShaderCode code = GenerateVertexShaderCode(API_D3D);
 		vertex_uid_checker.AddToIndexAndCheck(code, uid, "Vertex", "v");
 	}
 
@@ -216,8 +214,7 @@ bool VertexShaderCache::SetShader()
 		return (entry.shader != nullptr);
 	}
 
-	ShaderCode code;
-	GenerateVertexShaderCode(code, API_D3D);
+	ShaderCode code = GenerateVertexShaderCode(API_D3D);
 
 	D3DBlob* pbytecode = nullptr;
 	D3D::CompileVertexShader(code.GetBuffer(), &pbytecode);

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -211,13 +211,11 @@ SHADER* ProgramShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode, u32 primitive_
 	last_entry = &newentry;
 	newentry.in_cache = 0;
 
-	ShaderCode vcode;
-	ShaderCode pcode;
+	ShaderCode vcode = GenerateVertexShaderCode(API_OPENGL);
+	ShaderCode pcode = GeneratePixelShaderCode(dstAlphaMode, API_OPENGL);
 	ShaderCode gcode;
-	GenerateVertexShaderCode(vcode, API_OPENGL);
-	GeneratePixelShaderCode(pcode, dstAlphaMode, API_OPENGL);
 	if (g_ActiveConfig.backend_info.bSupportsGeometryShaders && !uid.guid.GetUidData()->IsPassthrough())
-		GenerateGeometryShaderCode(gcode, primitive_type, API_OPENGL);
+		gcode = GenerateGeometryShaderCode(primitive_type, API_OPENGL);
 
 	if (g_ActiveConfig.bEnableShaderDebugging)
 	{
@@ -398,22 +396,19 @@ GLuint ProgramShaderCache::CompileSingleShader(GLuint type, const char* code)
 
 void ProgramShaderCache::GetShaderId(SHADERUID* uid, DSTALPHA_MODE dstAlphaMode, u32 primitive_type)
 {
-	GetPixelShaderUid(uid->puid, dstAlphaMode, API_OPENGL);
-	GetVertexShaderUid(uid->vuid, API_OPENGL);
-	GetGeometryShaderUid(uid->guid, primitive_type, API_OPENGL);
+	uid->puid = GetPixelShaderUid(dstAlphaMode, API_OPENGL);
+	uid->vuid = GetVertexShaderUid(API_OPENGL);
+	uid->guid = GetGeometryShaderUid(primitive_type, API_OPENGL);
 
 	if (g_ActiveConfig.bEnableShaderDebugging)
 	{
-		ShaderCode pcode;
-		GeneratePixelShaderCode(pcode, dstAlphaMode, API_OPENGL);
+		ShaderCode pcode = GeneratePixelShaderCode(dstAlphaMode, API_OPENGL);
 		pixel_uid_checker.AddToIndexAndCheck(pcode, uid->puid, "Pixel", "p");
 
-		ShaderCode vcode;
-		GenerateVertexShaderCode(vcode, API_OPENGL);
+		ShaderCode vcode = GenerateVertexShaderCode(API_OPENGL);
 		vertex_uid_checker.AddToIndexAndCheck(vcode, uid->vuid, "Vertex", "v");
 
-		ShaderCode gcode;
-		GenerateGeometryShaderCode(gcode, primitive_type, API_OPENGL);
+		ShaderCode gcode = GenerateGeometryShaderCode(primitive_type, API_OPENGL);
 		geometry_uid_checker.AddToIndexAndCheck(gcode, uid->guid, "Geometry", "g");
 	}
 }

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -30,8 +30,9 @@ template<class T> static inline void EmitVertex(T& out, const char* vertex, API_
 template<class T> static inline void EndPrimitive(T& out, API_TYPE ApiType);
 
 template<class T>
-static inline void GenerateGeometryShader(T& out, u32 primitive_type, API_TYPE ApiType)
+static inline T GenerateGeometryShader(u32 primitive_type, API_TYPE ApiType)
 {
+	T out;
 	// Non-uid template parameters will write to the dummy data (=> gets optimized out)
 	geometry_shader_uid_data dummy_data;
 	geometry_shader_uid_data* uid_data = out.template GetUidData<geometry_shader_uid_data>();
@@ -292,6 +293,8 @@ static inline void GenerateGeometryShader(T& out, u32 primitive_type, API_TYPE A
 		if (text[sizeof(text) - 1] != 0x7C)
 			PanicAlert("GeometryShader generator - buffer too small, canary has been eaten!");
 	}
+
+	return out;
 }
 
 template<class T>
@@ -327,12 +330,12 @@ static inline void EndPrimitive(T& out, API_TYPE ApiType)
 		out.Write("\toutput.RestartStrip();\n");
 }
 
-void GetGeometryShaderUid(GeometryShaderUid& object, u32 primitive_type, API_TYPE ApiType)
+GeometryShaderUid GetGeometryShaderUid(u32 primitive_type, API_TYPE ApiType)
 {
-	GenerateGeometryShader<GeometryShaderUid>(object, primitive_type, ApiType);
+	return GenerateGeometryShader<GeometryShaderUid>(primitive_type, ApiType);
 }
 
-void GenerateGeometryShaderCode(ShaderCode& object, u32 primitive_type, API_TYPE ApiType)
+ShaderCode GenerateGeometryShaderCode(u32 primitive_type, API_TYPE ApiType)
 {
-	GenerateGeometryShader<ShaderCode>(object, primitive_type, ApiType);
+	return GenerateGeometryShader<ShaderCode>(primitive_type, ApiType);
 }

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -26,5 +26,5 @@ struct geometry_shader_uid_data
 
 typedef ShaderUid<geometry_shader_uid_data> GeometryShaderUid;
 
-void GenerateGeometryShaderCode(ShaderCode& object, u32 primitive_type, API_TYPE ApiType);
-void GetGeometryShaderUid(GeometryShaderUid& object, u32 primitive_type, API_TYPE ApiType);
+ShaderCode GenerateGeometryShaderCode(u32 primitive_type, API_TYPE ApiType);
+GeometryShaderUid GetGeometryShaderUid(u32 primitive_type, API_TYPE ApiType);

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -166,8 +166,9 @@ template<class T> static inline void WriteAlphaTest(T& out, pixel_shader_uid_dat
 template<class T> static inline void WriteFog(T& out, pixel_shader_uid_data* uid_data);
 
 template<class T>
-static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
+static inline T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 {
+	T out;
 	const u32 components = VertexLoaderManager::g_current_components;
 	// Non-uid template parameters will write to the dummy data (=> gets optimized out)
 	pixel_shader_uid_data dummy_data;
@@ -667,6 +668,8 @@ static inline void GeneratePixelShader(T& out, DSTALPHA_MODE dstAlphaMode, API_T
 		if (text[sizeof(text) - 1] != 0x7C)
 			PanicAlert("PixelShader generator - buffer too small, canary has been eaten!");
 	}
+
+	return out;
 }
 
 
@@ -1170,17 +1173,12 @@ static inline void WriteFog(T& out, pixel_shader_uid_data* uid_data)
 	out.Write("\tprev.rgb = (prev.rgb * (256 - ifog) + " I_FOGCOLOR".rgb * ifog) >> 8;\n");
 }
 
-void GetPixelShaderUid(PixelShaderUid& object, DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
+PixelShaderUid GetPixelShaderUid(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 {
-	GeneratePixelShader<PixelShaderUid>(object, dstAlphaMode, ApiType);
+	return GeneratePixelShader<PixelShaderUid>(dstAlphaMode, ApiType);
 }
 
-void GeneratePixelShaderCode(ShaderCode& object, DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
+ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 {
-	GeneratePixelShader<ShaderCode>(object, dstAlphaMode, ApiType);
-}
-
-void GetPixelShaderConstantProfile(PixelShaderConstantProfile& object, DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
-{
-	GeneratePixelShader<PixelShaderConstantProfile>(object, dstAlphaMode, ApiType);
+	return GeneratePixelShader<ShaderCode>(dstAlphaMode, ApiType);
 }

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -114,8 +114,6 @@ struct pixel_shader_uid_data
 #pragma pack()
 
 typedef ShaderUid<pixel_shader_uid_data> PixelShaderUid;
-typedef ShaderConstantProfile PixelShaderConstantProfile; // TODO: Obsolete
 
-void GeneratePixelShaderCode(ShaderCode& object, DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType);
-void GetPixelShaderUid(PixelShaderUid& object, DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType);
-void GetPixelShaderConstantProfile(PixelShaderConstantProfile& object, DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType);
+ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType);
+PixelShaderUid GetPixelShaderUid(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType);

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -16,8 +16,9 @@
 static char text[16768];
 
 template<class T>
-static inline void GenerateVertexShader(T& out, API_TYPE api_type)
+static inline T GenerateVertexShader(API_TYPE api_type)
 {
+	T out;
 	const u32 components = VertexLoaderManager::g_current_components;
 	// Non-uid template parameters will write to the dummy data (=> gets optimized out)
 	vertex_shader_uid_data dummy_data;
@@ -394,14 +395,16 @@ static inline void GenerateVertexShader(T& out, API_TYPE api_type)
 		if (text[sizeof(text) - 1] != 0x7C)
 			PanicAlert("VertexShader generator - buffer too small, canary has been eaten!");
 	}
+
+	return out;
 }
 
-void GetVertexShaderUid(VertexShaderUid& object, API_TYPE api_type)
+VertexShaderUid GetVertexShaderUid(API_TYPE api_type)
 {
-	GenerateVertexShader<VertexShaderUid>(object, api_type);
+	return GenerateVertexShader<VertexShaderUid>(api_type);
 }
 
-void GenerateVertexShaderCode(ShaderCode& object, API_TYPE api_type)
+ShaderCode GenerateVertexShaderCode(API_TYPE api_type)
 {
-	GenerateVertexShader<ShaderCode>(object, api_type);
+	return GenerateVertexShader<ShaderCode>(api_type);
 }

--- a/Source/Core/VideoCommon/VertexShaderGen.h
+++ b/Source/Core/VideoCommon/VertexShaderGen.h
@@ -60,5 +60,5 @@ struct vertex_shader_uid_data
 
 typedef ShaderUid<vertex_shader_uid_data> VertexShaderUid;
 
-void GetVertexShaderUid(VertexShaderUid& object, API_TYPE api_type);
-void GenerateVertexShaderCode(ShaderCode& object, API_TYPE api_type);
+VertexShaderUid GetVertexShaderUid(API_TYPE api_type);
+ShaderCode GenerateVertexShaderCode(API_TYPE api_type);


### PR DESCRIPTION
rather than passing in non-const references.