### PR TITLE
DriverDetails: remove BUG_BROKENINFOLOG leftovers

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -353,9 +353,6 @@ GLuint ProgramShaderCache::CompileSingleShader(GLuint type, const char* code)
 	GLsizei length = 0;
 	glGetShaderiv(result, GL_INFO_LOG_LENGTH, &length);
 
-	if (DriverDetails::HasBug(DriverDetails::BUG_BROKENINFOLOG))
-		length = 1024;
-
 	if (compileStatus != GL_TRUE || (length > 1 && DEBUG_GLSL))
 	{
 		GLsizei charsWritten;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -58,7 +58,6 @@ namespace DriverDetails
 	// This'll ensure we know exactly what the issue is.
 	enum Bug
 	{
-		BUG_BROKENINFOLOG,
 		// Bug: UBO buffer offset broken
 		// Affected devices: all mesa drivers
 		// Started Version: 9.0 (mesa doesn't support ubo before)


### PR DESCRIPTION
It was removed in 961873827853891aba6bc43243c01bf70e2c1f4b.