### PR TITLE
Just a minor cleanup. Totally not the cause of random FifoCi failures.

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.cpp
@@ -30,7 +30,7 @@ FifoDataFile::~FifoDataFile()
 
 bool FifoDataFile::HasBrokenEFBCopies() const
 {
-	return version < 2;
+	return m_Version < 2;
 }
 
 void FifoDataFile::SetIsWii(bool isWii)
@@ -150,6 +150,7 @@ FifoDataFile* FifoDataFile::Load(const std::string &filename, bool flagsOnly)
 	FifoDataFile* dataFile = new FifoDataFile;
 
 	dataFile->m_Flags = header.flags;
+	dataFile->m_Version = header.min_loader_version;
 
 	if (flagsOnly)
 	{

--- a/Source/Core/Core/FifoPlayer/FifoDataFile.h
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.h
@@ -94,7 +94,7 @@ private:
 	u32 m_XFRegs[XF_REGS_SIZE];
 
 	u32 m_Flags;
-	u32 version;
+	u32 m_Version;
 
 	std::vector<FifoFrameInfo> m_Frames;
 };


### PR DESCRIPTION
This 'absolutely not' a read of uninitialized memory is '100% not' uninitialized the cause of our non-deterministic behavior on the Intel NUC.

If there was a such an error, it would show up on all FifoCi backends equally. This is 'probably' unrelated to the fact that the Intel NUC is the only fifoci runner not running under virtualization.