### PR TITLE
FifoRecorder: Fix LOAD_XF_REG

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoFileStruct.h
+++ b/Source/Core/Core/FifoPlayer/FifoFileStruct.h
@@ -12,7 +12,7 @@ namespace FifoFileStruct
 enum
 {
 	FILE_ID            = 0x0d01f1f0,
-	VERSION_NUMBER     = 2,
+	VERSION_NUMBER     = 3,
 	MIN_LOADER_VERSION = 1,
 };
 

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
@@ -65,7 +65,14 @@ void FifoRecordAnalyzer::DecodeOpcode(u8* data)
 		break;
 
 	case GX_LOAD_XF_REG:
-		m_DrawingObject = false;
+		{
+			m_DrawingObject = false;
+
+			u32 cmd2 = ReadFifo32(data);
+			u8 streamSize = ((cmd2 >> 16) & 15) + 1;
+
+			data += streamSize * 4;
+		}
 		break;
 
 	case GX_LOAD_INDX_A:


### PR DESCRIPTION
We weren't skipping the body of this command, causing the dff to be corrupted as it was saved.
The load code works perfectly fine.

This fixes a crash when playing back a fifo recording of the 'gray cubes' bug in Super Mario Sunshine.