### PR TITLE
Cleanup fifo analyzers (and fix major bugs with fifo recording)

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -25,11 +25,6 @@ namespace FifoAnalyzer
 
 	u32 AnalyzeCommand(u8* data, DecodeMode mode);
 
-	// TODO- move to video common
-	void InitBPMemory(BPMemory* bpMem);
-	BPCmd DecodeBPCmd(u32 value, const BPMemory &bpMem);
-	void LoadBPReg(const BPCmd& bp, BPMemory &bpMem);
-
 	struct CPMemory
 	{
 		TVtxDesc vtxDesc;
@@ -43,6 +38,5 @@ namespace FifoAnalyzer
 	void CalculateVertexElementSizes(int sizes[], int vatIndex, const CPMemory& cpMem);
 
 	extern bool s_DrawingObject;
-	extern BPMemory s_BpMem;
 	extern FifoAnalyzer::CPMemory s_CpMem;
 }

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -17,6 +17,14 @@ namespace FifoAnalyzer
 	u16 ReadFifo16(u8*& data);
 	u32 ReadFifo32(u8*& data);
 
+	enum DecodeMode
+	{
+		DECODE_RECORD,
+		DECODE_PLAYBACK,
+	};
+
+	u32 AnalyzeCommand(u8* data, DecodeMode mode);
+
 	// TODO- move to video common
 	void InitBPMemory(BPMemory* bpMem);
 	BPCmd DecodeBPCmd(u32 value, const BPMemory &bpMem);
@@ -32,6 +40,9 @@ namespace FifoAnalyzer
 
 	void LoadCPReg(u32 subCmd, u32 value, CPMemory& cpMem);
 
-	u32 CalculateVertexSize(int vatIndex, const CPMemory& cpMem);
 	void CalculateVertexElementSizes(int sizes[], int vatIndex, const CPMemory& cpMem);
+
+	extern bool s_DrawingObject;
+	extern BPMemory s_BpMem;
+	extern FifoAnalyzer::CPMemory s_CpMem;
 }

--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.h
@@ -21,7 +21,6 @@ namespace FifoAnalyzer
 	void InitBPMemory(BPMemory* bpMem);
 	BPCmd DecodeBPCmd(u32 value, const BPMemory &bpMem);
 	void LoadBPReg(const BPCmd& bp, BPMemory &bpMem);
-	void GetTlutLoadData(u32& tlutAddr, u32 &memAddr, u32 &tlutXferCount, BPMemory &bpMem);
 
 	struct CPMemory
 	{

--- a/Source/Core/Core/FifoPlayer/FifoFileStruct.h
+++ b/Source/Core/Core/FifoPlayer/FifoFileStruct.h
@@ -12,7 +12,7 @@ namespace FifoFileStruct
 enum
 {
 	FILE_ID            = 0x0d01f1f0,
-	VERSION_NUMBER     = 2,
+	VERSION_NUMBER     = 3,
 	MIN_LOADER_VERSION = 1,
 };
 

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.cpp
@@ -22,23 +22,8 @@ struct CmdData
 	u8* ptr;
 };
 
-struct MemoryRange
-{
-	u32 begin;
-	u32 end;
-};
-
-static std::vector<MemoryRange> s_WrittenMemory;
-
-static void AddMemoryUpdate(MemoryUpdate memUpdate, AnalyzedFrameInfo& frameInfo);
-static void StoreWrittenRegion(u32 address, u32 size);
-
 void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file, std::vector<AnalyzedFrameInfo>& frameInfo)
 {
-	// Load BP memory
-	u32* bpMem = file->GetBPMem();
-	memcpy(&s_BpMem, bpMem, sizeof(BPMemory));
-
 	u32* cpMem = file->GetCPMem();
 	FifoAnalyzer::LoadCPReg(0x50, cpMem[0x50], s_CpMem);
 	FifoAnalyzer::LoadCPReg(0x60, cpMem[0x60], s_CpMem);
@@ -73,7 +58,7 @@ void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file, std::vector<Analyze
 			// Add memory updates that have occurred before this point in the frame
 			while (nextMemUpdate < frame.memoryUpdates.size() && frame.memoryUpdates[nextMemUpdate].fifoPosition <= cmdStart)
 			{
-				AddMemoryUpdate(frame.memoryUpdates[nextMemUpdate], analyzed);
+				analyzed.memoryUpdates.push_back(frame.memoryUpdates[nextMemUpdate]);
 				++nextMemUpdate;
 			}
 
@@ -112,144 +97,5 @@ void FifoPlaybackAnalyzer::AnalyzeFrames(FifoDataFile* file, std::vector<Analyze
 
 		if (analyzed.objectEnds.size() < analyzed.objectStarts.size())
 			analyzed.objectEnds.push_back(cmdStart);
-	}
-}
-
-static void AddMemoryUpdate(MemoryUpdate memUpdate, AnalyzedFrameInfo& frameInfo)
-{
-	u32 begin = memUpdate.address;
-	u32 end = memUpdate.address + memUpdate.size;
-
-	// Remove portions of memUpdate that overlap with memory ranges that have been written by the GP
-	for (const auto& range : s_WrittenMemory)
-	{
-		if (range.begin < end &&
-		    range.end > begin)
-		{
-			s32 preSize = range.begin - begin;
-			s32 postSize = end - range.end;
-
-			if (postSize > 0)
-			{
-				if (preSize > 0)
-				{
-					memUpdate.size = preSize;
-					AddMemoryUpdate(memUpdate, frameInfo);
-				}
-
-				u32 bytesToRangeEnd = range.end - memUpdate.address;
-				memUpdate.data += bytesToRangeEnd;
-				memUpdate.size = postSize;
-				memUpdate.address = range.end;
-			}
-			else if (preSize > 0)
-			{
-				memUpdate.size = preSize;
-			}
-			else
-			{
-				// Ignore all of memUpdate
-				return;
-			}
-		}
-	}
-
-	frameInfo.memoryUpdates.push_back(memUpdate);
-}
-
-void FifoPlaybackAnalyzer::StoreEfbCopyRegion()
-{
-	UPE_Copy peCopy = s_BpMem.triggerEFBCopy;
-
-	u32 copyfmt = peCopy.tp_realFormat();
-	bool bFromZBuffer = s_BpMem.zcontrol.pixel_format == PEControl::Z24;
-	u32 address = bpmem.copyTexDest << 5;
-
-	u32 format = copyfmt;
-
-	if (peCopy.copy_to_xfb)
-	{
-		// Fake format to calculate size correctly
-		format = GX_TF_IA8;
-	}
-	else if (bFromZBuffer)
-	{
-		format |= _GX_TF_ZTF;
-		if (copyfmt == 11)
-		{
-			format = GX_TF_Z16;
-		}
-		else if (format < GX_TF_Z8 || format > GX_TF_Z24X8)
-		{
-			format |= _GX_TF_CTF;
-		}
-	}
-	else
-	{
-		if (copyfmt > GX_TF_RGBA8 || (copyfmt < GX_TF_RGB565 && !peCopy.intensity_fmt))
-			format |= _GX_TF_CTF;
-	}
-
-	int width = (s_BpMem.copyTexSrcWH.x + 1) >> peCopy.half_scale;
-	int height = (s_BpMem.copyTexSrcWH.y + 1) >> peCopy.half_scale;
-
-	u16 blkW = TexDecoder_GetBlockWidthInTexels(format) - 1;
-	u16 blkH = TexDecoder_GetBlockHeightInTexels(format) - 1;
-
-	s32 expandedWidth = (width + blkW) & (~blkW);
-	s32 expandedHeight = (height + blkH) & (~blkH);
-
-	int sizeInBytes = TexDecoder_GetTextureSizeInBytes(expandedWidth, expandedHeight, format);
-
-	StoreWrittenRegion(address, sizeInBytes);
-}
-
-static void StoreWrittenRegion(u32 address, u32 size)
-{
-	u32 end = address + size;
-	auto newRangeIter = s_WrittenMemory.end();
-
-	// Search for overlapping memory regions and expand them to include the new region
-	for (auto iter = s_WrittenMemory.begin(); iter != s_WrittenMemory.end();)
-	{
-		MemoryRange &range = *iter;
-
-		if (range.begin < end && range.end > address)
-		{
-			// range at iterator and new range overlap
-
-			if (newRangeIter == s_WrittenMemory.end())
-			{
-				// Expand range to include the written region
-				range.begin = std::min(address, range.begin);
-				range.end = std::max(end, range.end);
-				newRangeIter = iter;
-
-				++iter;
-			}
-			else
-			{
-				// Expand region at rangeIter to include this range
-				MemoryRange &used = *newRangeIter;
-				used.begin = std::min(used.begin, range.begin);
-				used.end = std::max(used.end, range.end);
-
-				// Remove this entry
-				iter = s_WrittenMemory.erase(iter);
-			}
-		}
-		else
-		{
-			++iter;
-		}
-	}
-
-	if (newRangeIter == s_WrittenMemory.end())
-	{
-		MemoryRange range;
-		range.begin = address;
-		range.end = end;
-
-		s_WrittenMemory.push_back(range);
 	}
 }

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
@@ -20,6 +20,4 @@ struct AnalyzedFrameInfo
 namespace FifoPlaybackAnalyzer
 {
 	void AnalyzeFrames(FifoDataFile* file, std::vector<AnalyzedFrameInfo>& frameInfo);
-
-	void StoreEfbCopyRegion();
 };

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
@@ -20,4 +20,6 @@ struct AnalyzedFrameInfo
 namespace FifoPlaybackAnalyzer
 {
 	void AnalyzeFrames(FifoDataFile* file, std::vector<AnalyzedFrameInfo>& frameInfo);
+
+	void StoreEfbCopyRegion();
 };

--- a/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlaybackAnalyzer.h
@@ -17,31 +17,7 @@ struct AnalyzedFrameInfo
 	std::vector<MemoryUpdate> memoryUpdates;
 };
 
-class FifoPlaybackAnalyzer
+namespace FifoPlaybackAnalyzer
 {
-public:
-	FifoPlaybackAnalyzer();
-
 	void AnalyzeFrames(FifoDataFile* file, std::vector<AnalyzedFrameInfo>& frameInfo);
-
-private:
-	struct MemoryRange
-	{
-		u32 begin;
-		u32 end;
-	};
-
-	void AddMemoryUpdate(MemoryUpdate memUpdate, AnalyzedFrameInfo& frameInfo);
-
-	u32 DecodeCommand(u8* data);
-
-	void StoreEfbCopyRegion();
-	void StoreWrittenRegion(u32 address, u32 size);
-
-	bool m_DrawingObject;
-
-	std::vector<MemoryRange> m_WrittenMemory;
-
-	BPMemory m_BpMem;
-	FifoAnalyzer::CPMemory m_CpMem;
 };

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -35,8 +35,8 @@ bool FifoPlayer::Open(const std::string& filename)
 
 	if (m_File)
 	{
-		FifoPlaybackAnalyzer analyzer;
-		analyzer.AnalyzeFrames(m_File, m_FrameInfo);
+		FifoAnalyzer::Init();
+		FifoPlaybackAnalyzer::AnalyzeFrames(m_File, m_FrameInfo);
 
 		m_FrameRangeEnd = m_File->GetFrameCount();
 	}

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.cpp
@@ -31,11 +31,6 @@ void FifoRecordAnalyzer::Initialize(u32* cpMem)
 	memcpy(s_CpMem.arrayStrides, cpMem + 0xB0, 16 * 4);
 }
 
-void FifoRecordAnalyzer::AnalyzeGPCommand(u8* data)
-{
-	FifoAnalyzer::AnalyzeCommand(data, DECODE_RECORD);
-}
-
 void FifoRecordAnalyzer::ProcessLoadIndexedXf(u32 val, int array)
 {
 	int index = val >> 16;

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
@@ -12,12 +12,8 @@
 
 namespace FifoRecordAnalyzer
 {
-	// Must call this before analyzing GP commands
+	// Must call this before analyzing Fifo commands with FifoAnalyzer::AnalyzeCommand()
 	void Initialize(u32* cpMem);
-
-	// Assumes data contains all information for the command
-	// Calls FifoRecorder::UseMemory
-	void AnalyzeGPCommand(u8* data);
 
 	void ProcessLoadIndexedXf(u32 val, int array);
 	void WriteVertexArray(int arrayIndex, u8* vertexData, int vertexSize, int numVertices);

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
@@ -10,28 +10,12 @@
 
 #include "VideoCommon/BPMemory.h"
 
-class FifoRecordAnalyzer
+namespace FifoRecordAnalyzer
 {
-public:
-	FifoRecordAnalyzer();
-
 	// Must call this before analyzing GP commands
-	void Initialize(u32* bpMem, u32* cpMem);
+	void Initialize(u32* cpMem);
 
 	// Assumes data contains all information for the command
 	// Calls FifoRecorder::UseMemory
 	void AnalyzeGPCommand(u8* data);
-
-private:
-	void DecodeOpcode(u8* data);
-
-	void ProcessLoadIndexedXf(u32 val, int array);
-	void ProcessVertexArrays(u8* data, u8 vtxAttrGroup);
-
-	void WriteVertexArray(int arrayIndex, u8* vertexData, int vertexSize, int numVertices);
-
-	bool m_DrawingObject;
-
-	BPMemory* m_BpMem;
-	FifoAnalyzer::CPMemory m_CpMem;
 };

--- a/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
+++ b/Source/Core/Core/FifoPlayer/FifoRecordAnalyzer.h
@@ -18,4 +18,7 @@ namespace FifoRecordAnalyzer
 	// Assumes data contains all information for the command
 	// Calls FifoRecorder::UseMemory
 	void AnalyzeGPCommand(u8* data);
+
+	void ProcessLoadIndexedXf(u32 val, int array);
+	void WriteVertexArray(int arrayIndex, u8* vertexData, int vertexSize, int numVertices);
 };

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -68,7 +68,9 @@ void FifoRecorder::WriteGPCommand(u8* data, u32 size)
 {
 	if (!m_SkipNextData)
 	{
-		FifoRecordAnalyzer::AnalyzeGPCommand(data);
+		// Assumes data contains all information for the command
+		// Calls FifoRecorder::UseMemory
+		FifoAnalyzer::AnalyzeCommand(data, FifoAnalyzer::DECODE_RECORD);
 
 		// Copy data to buffer
 		size_t currentSize = m_FifoData.size();

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -68,7 +68,7 @@ void FifoRecorder::WriteGPCommand(u8* data, u32 size)
 {
 	if (!m_SkipNextData)
 	{
-		m_RecordAnalyzer.AnalyzeGPCommand(data);
+		FifoRecordAnalyzer::AnalyzeGPCommand(data);
 
 		// Copy data to buffer
 		size_t currentSize = m_FifoData.size();
@@ -200,7 +200,7 @@ void FifoRecorder::SetVideoMemory(u32 *bpMem, u32 *cpMem, u32 *xfMem, u32 *xfReg
 		memcpy(m_File->GetXFRegs(), xfRegs, xfRegsCopySize * 4);
 	}
 
-	m_RecordAnalyzer.Initialize(bpMem, cpMem);
+	FifoRecordAnalyzer::Initialize(cpMem);
 
 	sMutex.unlock();
 }

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -40,6 +40,8 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
 
 	delete m_File;
 
+	FifoAnalyzer::Init();
+
 	m_File = new FifoDataFile;
 	std::fill(m_Ram.begin(), m_Ram.end(), 0);
 	std::fill(m_ExRam.begin(), m_ExRam.end(), 0);

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -70,7 +70,11 @@ void FifoRecorder::WriteGPCommand(u8* data, u32 size)
 	{
 		// Assumes data contains all information for the command
 		// Calls FifoRecorder::UseMemory
-		FifoAnalyzer::AnalyzeCommand(data, FifoAnalyzer::DECODE_RECORD);
+		u32 analyzed_size = FifoAnalyzer::AnalyzeCommand(data, FifoAnalyzer::DECODE_RECORD);
+
+		// Make sure FifoPlayer's command analyzer agrees about the size of the command.
+		if (analyzed_size != size)
+			PanicAlert("FifoRecorder: Expected command to be %i bytes long, we were given %i bytes", analyzed_size, size);
 
 		// Copy data to buffer
 		size_t currentSize = m_FifoData.size();

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.h
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.h
@@ -65,5 +65,4 @@ private:
 	std::vector<u8> m_FifoData;
 	std::vector<u8> m_Ram;
 	std::vector<u8> m_ExRam;
-	FifoRecordAnalyzer m_RecordAnalyzer;
 };


### PR DESCRIPTION
These changes simplify fifoplayer/fiforecorder a lot, combining recording/playback code, adding error checking to detect errors and removing some old broken-unused code.
It cuts down on about 300 lines of code.

In the development of this PR, two fiforecorder bugs were found and fixed. Actually it was the same kind of bug twice; Basically meant the size calculation of indexed vertex arrays was wrong, so vertex data would randomly be missing from the fifolog.