### PR TITLE
XFMem: Don't warn on writes of zero to unknown registers.

### DIFF
--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -184,7 +184,8 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
 		case 0x1017:
 
 		default:
-			WARN_LOG(VIDEO, "Unknown XF Reg: %x=%x", address, newValue);
+			if (newValue != 0) // Ignore writes of zero.
+				WARN_LOG(VIDEO, "Unknown XF Reg: %x=%x", address, newValue);
 			break;
 		}
 


### PR DESCRIPTION
This gets rid of these extra warnings in FifoCI:

    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1007=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1013=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1014=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1015=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1016=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1017=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1027=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1028=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1029=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 102a=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 102b=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 102c=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 102d=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 102e=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 102f=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1030=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1031=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1032=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1033=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1034=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1035=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1036=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1037=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1038=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 1039=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 103a=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 103b=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 103c=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 103d=0
    ../Source/Core/VideoCommon/XFStructs.cpp:187 W[Video]: Unknown XF Reg: 103e=0
