### PR TITLE
Enable relocatable linux builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,12 @@ if(WIN32)
 	add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
 endif(WIN32)
 
+# Add an option to build relocatable binaries on Linux
+# The Sys folder will need to be copied to the Binaries folder.
+if(UNIX)
+	add_definitions(-DLINUX_LOCAL_DEV=0)
+endif(UNIX)
+
 # Dolphin requires threads.
 # The Apple build may not need an explicit flag because one of the
 # frameworks may already provide it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,10 @@ endif(WIN32)
 # Add an option to build relocatable binaries on Linux
 # The Sys folder will need to be copied to the Binaries folder.
 if(UNIX)
-	add_definitions(-DLINUX_LOCAL_DEV=0)
+	option(LINUX_LOCAL_DEV "Enable relocatable binary" OFF)
+	if(LINUX_LOCAL_DEV)
+		add_definitions('-DLINUX_LOCAL_DEV')
+	endif(LINUX_LOCAL_DEV)
 endif(UNIX)
 
 # Dolphin requires threads.

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -32,7 +32,7 @@
 #endif
 
 // Shared data dirs (Sys and shared User for Linux)
-#ifdef _WIN32
+#if defined(_WIN32) || defined(LINUX_LOCAL_DEV)
 	#define SYSDATA_DIR "Sys"
 #elif defined __APPLE__
 	#define SYSDATA_DIR "Contents/Resources/Sys"

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -145,9 +145,7 @@ std::string GetSysDirectory();
 std::string GetBundleDirectory();
 #endif
 
-#ifdef _WIN32
 std::string &GetExeDirectory();
-#endif
 
 bool WriteStringToFile(const std::string& str, const std::string& filename);
 bool ReadFileToString(const std::string& filename, std::string& str);


### PR DESCRIPTION
This patch allows to build Dolphin on Linux so that it will look for the "Sys" folder where the executable is located, making it possible to run it from anywhere in the filesystem.

For this functionality to work, the LINUX_LOCAL_DEV flag has to be set, otherwise it will keep the default behavior. 