### PR TITLE
BootManager: Remove unnecessary LoadGameIni condition

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -98,7 +98,6 @@ bool BootCore(const std::string& _rFilename)
 		return false;
 
 	// Load game specific settings
-	if (StartUp.GetUniqueID().size() == 6)
 	{
 		IniFile game_ini = StartUp.LoadGameIni();
 


### PR DESCRIPTION
Besides being cleanup, I made this commit to fix this problem:

1. The user has the skip GC BIOS setting (bHLE_BS2) turned off.
2. The user boots the Wii Menu.
3. BootManager::BootCore stores bHLE_BS2 in config_cache.
4. SConfig::AutoSetup overwrites bHLE_BS2.
5. Because the ID length isn't 6, config_cache.valid doesn't become true.
6. At exit, BootManager::Stop won't restore bHLE_BS2 from config_cache.
7. The skip GC BIOS setting will now incorrectly remain turned on.