### PR TITLE
Fix a race condition on shutdown between Memory and CWII_IPC_HLE_Device_hid

### DIFF
--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -56,27 +56,27 @@ namespace HW
 			DiscIO::cUIDsys::AccessInstance().UpdateLocation();
 			DiscIO::CSharedContent::AccessInstance().UpdateLocation();
 			WII_IPCInterface::Init();
-			WII_IPC_HLE_Interface::Init();
+			WII_IPC_HLE_Interface::Init(); // Depends on Memory
 		}
 	}
 
 	void Shutdown()
 	{
+		if (SConfig::GetInstance().bWii)
+		{
+			WII_IPC_HLE_Interface::Shutdown(); // Depends on Memory
+			WII_IPCInterface::Shutdown();
+			Common::ShutdownWiiRoot();
+		}
+
 		SystemTimers::Shutdown();
 		CPU::Shutdown();
-		ExpansionInterface::Shutdown();
 		DVDInterface::Shutdown();
 		DSP::Shutdown();
 		Memory::Shutdown();
+		ExpansionInterface::Shutdown();
 		SerialInterface::Shutdown();
 		AudioInterface::Shutdown();
-
-		if (SConfig::GetInstance().bWii)
-		{
-			WII_IPCInterface::Shutdown();
-			WII_IPC_HLE_Interface::Shutdown();
-			Common::ShutdownWiiRoot();
-		}
 
 		State::Shutdown();
 		CoreTiming::Shutdown();


### PR DESCRIPTION
During shutdown, Memory is shut down before CWII_IPC_HLE_Device_hid::usb_thread is stopped. Under very rare circumstances (I must have been lucky) this can lead to a crash when CWII_IPC_HLE_Device_hid::FillOutDevices tries to access Memory which has already been shut down.