### PR TITLE
Remove uses of __DATE__ and __TIME__

### DIFF
--- a/Source/Core/Common/Assert.h
+++ b/Source/Core/Common/Assert.h
@@ -37,8 +37,8 @@
 #endif
 
 #define _assert_(_a_) \
-	_assert_msg_(MASTER_LOG, _a_, "Error...\n\n  Line: %d\n  File: %s\n  Time: %s\n\nIgnore and continue?", \
-	             __LINE__, __FILE__, __TIME__)
+	_assert_msg_(MASTER_LOG, _a_, "Error...\n\n  Line: %d\n  File: %s\n\nIgnore and continue?", \
+	             __LINE__, __FILE__)
 
 #define _dbg_assert_(_t_, _a_) \
 	if (MAX_LOGLEVEL >= LogTypes::LOG_LEVELS::LDEBUG) \

--- a/Source/Core/DolphinQt/AboutDialog.cpp
+++ b/Source/Core/DolphinQt/AboutDialog.cpp
@@ -24,8 +24,7 @@ DAboutDialog::DAboutDialog(QWidget* parent_widget)
 	m_ui = std::make_unique<Ui::DAboutDialog>();
 	m_ui->setupUi(this);
 	m_ui->lblGitRev->setText(SC(scm_desc_str));
-	m_ui->lblGitInfo->setText(m_ui->lblGitInfo->text().arg(SC(scm_branch_str), SC(scm_rev_git_str),
-		SL(__DATE__), SL(__TIME__)));
+	m_ui->lblGitInfo->setText(m_ui->lblGitInfo->text().arg(SC(scm_branch_str), SC(scm_rev_git_str)));
 	m_ui->lblFinePrint->setText(m_ui->lblFinePrint->text().arg(SL("2015")));
 	m_ui->lblLicenseAuthorsSupport->setText(m_ui->lblLicenseAuthorsSupport->text()
 		.arg(SL("https://github.com/dolphin-emu/dolphin/blob/master/license.txt"))

--- a/Source/Core/DolphinQt/AboutDialog.ui
+++ b/Source/Core/DolphinQt/AboutDialog.ui
@@ -43,8 +43,7 @@
      </property>
      <property name="text">
       <string>Branch: %1
-Revision: %2
-Compiled: %3 @ %4</string>
+Revision: %2</string>
      </property>
      <property name="textFormat">
       <enum>Qt::PlainText</enum>

--- a/Source/Core/DolphinQt/SystemInfo.cpp
+++ b/Source/Core/DolphinQt/SystemInfo.cpp
@@ -51,7 +51,6 @@ void DSystemInfo::UpdateSystemInfo()
 
 	sysinfo += SL("\nDolphin\n===========================\n");
 	sysinfo += SL("SCM: branch %1, rev %2\n").arg(SC(scm_branch_str)).arg(SC(scm_rev_git_str));
-	sysinfo += SL("Compiled: %1, %2\n").arg(SL(__DATE__)).arg(SL(__TIME__));
 
 	sysinfo += SL("\nGUI\n===========================\n");
 	sysinfo += SL("Compiled for Qt: %1\n").arg(SL(QT_VERSION_STR));

--- a/Source/Core/DolphinWX/AboutDolphin.cpp
+++ b/Source/Core/DolphinWX/AboutDolphin.cpp
@@ -51,7 +51,6 @@ AboutDolphin::AboutDolphin(wxWindow *parent, wxWindowID id,
 	const wxString CopyrightText = _("(c) 2003-2015+ Dolphin Team. \"GameCube\" and \"Wii\" are trademarks of Nintendo. Dolphin is not affiliated with Nintendo in any way.");
 	const wxString BranchText = wxString::Format(_("Branch: %s"), scm_branch_str);
 	const wxString BranchRevText = wxString::Format(_("Revision: %s"), scm_rev_git_str);
-	const wxString CompiledText = wxString::Format(_("Compiled: %s @ %s"), __DATE__, __TIME__);
 	const wxString CheckUpdateText = _("Check for updates: ");
 	const wxString Text = _("\n"
 		"Dolphin is a free and open-source GameCube and Wii emulator.\n"
@@ -65,7 +64,7 @@ AboutDolphin::AboutDolphin(wxWindow *parent, wxWindowID id,
 	wxStaticText* const Revision = new wxStaticText(this, wxID_ANY, RevisionText);
 
 	wxStaticText* const Copyright = new wxStaticText(this, wxID_ANY, CopyrightText);
-	wxStaticText* const Branch = new wxStaticText(this, wxID_ANY, BranchText + "\n" + BranchRevText + "\n" + CompiledText+"\n");
+	wxStaticText* const Branch = new wxStaticText(this, wxID_ANY, BranchText + "\n" + BranchRevText + "\n");
 	wxStaticText* const Message = new wxStaticText(this, wxID_ANY, Text);
 	wxStaticText* const UpdateText = new wxStaticText(this, wxID_ANY, CheckUpdateText);
 	wxStaticText* const FirstSpacer = new wxStaticText(this, wxID_ANY, "  |  ");


### PR DESCRIPTION
Like the title suggests, this PR simply removes all occurrences of `__DATE__` and `__TIME__` from Dolphin (ignoring anything in externals).

After doing this, the build should become reproducible (at least on linux). That is, if you build dolphin twice, the binaries produced should be completely identical. I'm also not entirely sure about what the benefit of having these dates included are in the first place.

There is some more info about reproducible builds here:
https://reproducible-builds.org/
https://wiki.debian.org/ReproducibleBuilds