### PR TITLE
RFC - Revert "Remove AtBreakpoint() from ReadIdle

### DIFF
--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -493,7 +493,7 @@ void SetCpStatusRegister()
 {
 	// Here always there is one fifo attached to the GPU
 	m_CPStatusReg.Breakpoint = fifo.bFF_Breakpoint;
-	m_CPStatusReg.ReadIdle = !fifo.CPReadWriteDistance || (fifo.CPReadPointer == fifo.CPWritePointer);
+	m_CPStatusReg.ReadIdle = !fifo.CPReadWriteDistance ||  AtBreakpoint() || (fifo.CPReadPointer == fifo.CPWritePointer);
 	m_CPStatusReg.CommandIdle = !fifo.CPReadWriteDistance || AtBreakpoint() || !fifo.bFF_GPReadEnable;
 	m_CPStatusReg.UnderflowLoWatermark = fifo.bFF_LoWatermark;
 	m_CPStatusReg.OverflowHiWatermark = fifo.bFF_HiWatermark;


### PR DESCRIPTION
Reverts dolphin-emu/dolphin#1778

Block GPU Thread change made this change not really matter; RS2 is broken in Dualcore, and Gladius is apparently broken in single core according to other users.

I don't think a blind guess change should be in dolphin if it has any downsides, which it seems there is now.  The expected behavior of this revert is fixing Gladius in Single Core, and breaking RS2 in single core when using the targeting computer or pausing.