### PR TITLE
Enable Anisotropic filtering in ES.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -465,6 +465,7 @@ Renderer::Renderer()
 	g_ogl_config.bSupports2DTextureStorage = GLExtensions::Supports("GL_ARB_texture_storage_multisample");
 	g_ogl_config.bSupportsEarlyFragmentTests = GLExtensions::Supports("GL_ARB_shader_image_load_store");
 	g_ogl_config.bSupportsConservativeDepth = GLExtensions::Supports("GL_ARB_conservative_depth");
+	g_ogl_config.bSupportsAniso = GLExtensions::Supports("GL_EXT_texture_filter_anisotropic");
 
 	if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGLES3)
 	{

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -52,6 +52,7 @@ struct VideoConfig
 	bool bSupports3DTextureStorage;
 	bool bSupportsEarlyFragmentTests;
 	bool bSupportsConservativeDepth;
+	bool bSupportsAniso;
 
 	const char* gl_vendor;
 	const char* gl_renderer;

--- a/Source/Core/VideoBackends/OGL/SamplerCache.cpp
+++ b/Source/Core/VideoBackends/OGL/SamplerCache.cpp
@@ -129,12 +129,10 @@ void SamplerCache::SetParameters(GLuint sampler_id, const Params& params)
 	glSamplerParameterf(sampler_id, GL_TEXTURE_MAX_LOD, tm1.max_lod / 16.f);
 
 	if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGL)
-	{
 		glSamplerParameterf(sampler_id, GL_TEXTURE_LOD_BIAS, (s32)tm0.lod_bias / 32.f);
 
-		if (g_ActiveConfig.iMaxAnisotropy > 0)
-			glSamplerParameterf(sampler_id, GL_TEXTURE_MAX_ANISOTROPY_EXT, (float)(1 << g_ActiveConfig.iMaxAnisotropy));
-	}
+	if (g_ActiveConfig.iMaxAnisotropy > 0 && g_ogl_config.bSupportsAniso)
+		glSamplerParameterf(sampler_id, GL_TEXTURE_MAX_ANISOTROPY_EXT, (float)(1 << g_ActiveConfig.iMaxAnisotropy));
 }
 
 void SamplerCache::Clear()


### PR DESCRIPTION
This adds a check to make sure the vendor supports anisotropic filtering.
Pretty much all vendors support this, even the mobile ones.