### PR TITLE
DolphinWX: Don't translate OSD messages

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -440,15 +440,15 @@ bool ReadHeader(const std::string& filename, StateHeader& header)
   return true;
 }
 
-std::string GetInfoStringOfSlot(int slot)
+std::string GetInfoStringOfSlot(int slot, bool translate)
 {
   std::string filename = MakeStateFilename(slot);
   if (!File::Exists(filename))
-    return GetStringT("Empty");
+    return translate ? GetStringT("Empty") : "Empty";
 
   State::StateHeader header;
   if (!ReadHeader(filename, header))
-    return GetStringT("Unknown");
+    return translate ? GetStringT("Unknown") : "Unknown";
 
   return Common::Timer::GetDateTimeFormatted(header.time);
 }

--- a/Source/Core/Core/State.h
+++ b/Source/Core/Core/State.h
@@ -33,7 +33,7 @@ bool ReadHeader(const std::string& filename, StateHeader& header);
 
 // Returns a string containing information of the savestate in the given slot
 // which can be presented to the user for identification purposes
-std::string GetInfoStringOfSlot(int slot);
+std::string GetInfoStringOfSlot(int slot, bool translate = true);
 
 // These don't happen instantly - they get scheduled as events.
 // ...But only if we're not in the main CPU thread.

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -30,6 +30,7 @@
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/NandPaths.h"
+#include "Common/StringUtil.h"
 
 #include "Core/BootManager.h"
 #include "Core/ConfigManager.h"
@@ -1553,9 +1554,8 @@ void CFrame::ConnectWiimote(int wm_idx, bool connect)
   {
     bool was_unpaused = Core::PauseAndLock(true);
     GetUsbPointer()->AccessWiiMote(wm_idx | 0x100)->Activate(connect);
-    wxString msg(wxString::Format(_("Wiimote %i %s"), wm_idx + 1,
-                                  connect ? _("Connected") : _("Disconnected")));
-    Core::DisplayMessage(WxStrToStr(msg), 3000);
+    const char* message = connect ? "Wiimote %i connected" : "Wiimote %i disconnected";
+    Core::DisplayMessage(StringFromFormat(message, wm_idx + 1), 3000);
     Host_UpdateMainFrame();
     Core::PauseAndLock(false, was_unpaused);
   }
@@ -1675,7 +1675,7 @@ void CFrame::OnSelectSlot(wxCommandEvent& event)
 {
   m_saveSlot = event.GetId() - IDM_SELECT_SLOT_1 + 1;
   Core::DisplayMessage(StringFromFormat("Selected slot %d - %s", m_saveSlot,
-                                        State::GetInfoStringOfSlot(m_saveSlot).c_str()),
+                                        State::GetInfoStringOfSlot(m_saveSlot, false).c_str()),
                        2500);
 }
 


### PR DESCRIPTION
OSD messages other than these one and a half aren't translated, and OSD only supports ASCII. (Also, that "Wiimote %i %s" uses %s like it does is bad for translation, but that's easy to fix.)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3275)
<!-- Reviewable:end -->
