### PR TITLE
Videocommon API cleanup

### DIFF
--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -20,16 +20,15 @@ class D3DVertexFormat : public NativeVertexFormat
 	ID3D11InputLayout* m_layout;
 
 public:
-	D3DVertexFormat() : m_num_elems(0), m_layout(nullptr) {}
+	D3DVertexFormat(const PortableVertexDeclaration& vtx_decl);
 	~D3DVertexFormat() { SAFE_RELEASE(m_layout); }
 
-	void Initialize(const PortableVertexDeclaration &_vtx_decl);
 	void SetupVertexPointers();
 };
 
-NativeVertexFormat* VertexManager::CreateNativeVertexFormat()
+NativeVertexFormat* VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
 {
-	return new D3DVertexFormat();
+	return new D3DVertexFormat(vtx_decl);
 }
 
 static const DXGI_FORMAT d3d_format_lookup[5*4*2] =
@@ -57,9 +56,10 @@ DXGI_FORMAT VarToD3D(VarType t, int size, bool integer)
 	return retval;
 }
 
-void D3DVertexFormat::Initialize(const PortableVertexDeclaration &_vtx_decl)
+D3DVertexFormat::D3DVertexFormat(const PortableVertexDeclaration& _vtx_decl)
+ : m_num_elems(0), m_layout(nullptr)
 {
-	vtx_decl = _vtx_decl;
+	this->vtx_decl = _vtx_decl;
 	memset(m_elems, 0, sizeof(m_elems));
 	const AttributeFormat* format = &_vtx_decl.position;
 

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -15,7 +15,7 @@ public:
 	VertexManager();
 	~VertexManager();
 
-	NativeVertexFormat* CreateNativeVertexFormat() override;
+	NativeVertexFormat* CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
 	void CreateDeviceObjects() override;
 	void DestroyDeviceObjects() override;
 

--- a/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
@@ -21,19 +21,9 @@
 namespace OGL
 {
 
-NativeVertexFormat* VertexManager::CreateNativeVertexFormat()
+NativeVertexFormat* VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
 {
-	return new GLVertexFormat();
-}
-
-GLVertexFormat::GLVertexFormat()
-{
-
-}
-
-GLVertexFormat::~GLVertexFormat()
-{
-	glDeleteVertexArrays(1, &VAO);
+	return new GLVertexFormat(vtx_decl);
 }
 
 static inline GLuint VarToGL(VarType t)
@@ -56,7 +46,7 @@ static void SetPointer(u32 attrib, u32 stride, const AttributeFormat &format)
 		glVertexAttribPointer(attrib, format.components, VarToGL(format.type), true, stride, (u8*)nullptr + format.offset);
 }
 
-void GLVertexFormat::Initialize(const PortableVertexDeclaration &_vtx_decl)
+GLVertexFormat::GLVertexFormat(const PortableVertexDeclaration& _vtx_decl)
 {
 	this->vtx_decl = _vtx_decl;
 	u32 vertex_stride = _vtx_decl.stride;
@@ -74,20 +64,25 @@ void GLVertexFormat::Initialize(const PortableVertexDeclaration &_vtx_decl)
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vm->m_index_buffers);
 	glBindBuffer(GL_ARRAY_BUFFER, vm->m_vertex_buffers);
 
-	SetPointer(SHADER_POSITION_ATTRIB, vertex_stride, vtx_decl.position);
+	SetPointer(SHADER_POSITION_ATTRIB, vertex_stride, _vtx_decl.position);
 
 	for (int i = 0; i < 3; i++)
-		SetPointer(SHADER_NORM0_ATTRIB+i, vertex_stride, vtx_decl.normals[i]);
+		SetPointer(SHADER_NORM0_ATTRIB+i, vertex_stride, _vtx_decl.normals[i]);
 
 	for (int i = 0; i < 2; i++)
-		SetPointer(SHADER_COLOR0_ATTRIB+i, vertex_stride, vtx_decl.colors[i]);
+		SetPointer(SHADER_COLOR0_ATTRIB+i, vertex_stride, _vtx_decl.colors[i]);
 
 	for (int i = 0; i < 8; i++)
-		SetPointer(SHADER_TEXTURE0_ATTRIB+i, vertex_stride, vtx_decl.texcoords[i]);
+		SetPointer(SHADER_TEXTURE0_ATTRIB+i, vertex_stride, _vtx_decl.texcoords[i]);
 
-	SetPointer(SHADER_POSMTX_ATTRIB, vertex_stride, vtx_decl.posmtx);
+	SetPointer(SHADER_POSMTX_ATTRIB, vertex_stride, _vtx_decl.posmtx);
 
 	vm->m_last_vao = VAO;
+}
+
+GLVertexFormat::~GLVertexFormat()
+{
+	glDeleteVertexArrays(1, &VAO);
 }
 
 void GLVertexFormat::SetupVertexPointers()

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -83,10 +83,6 @@ public:
 	void SetInterlacingMode() override;
 	void SetViewport() override;
 
-	// TODO: Implement and use these
-	void ApplyState(bool bUseDstAlpha) override {}
-	void RestoreState() override {}
-
 	void RenderText(const std::string& text, int left, int top, u32 color) override;
 	void FlipImageData(u8 *data, int w, int h, int pixel_width = 3);
 

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -15,10 +15,9 @@ namespace OGL
 	class GLVertexFormat : public NativeVertexFormat
 	{
 	public:
-		GLVertexFormat();
+		GLVertexFormat(const PortableVertexDeclaration& vtx_decl);
 		~GLVertexFormat();
 
-		void Initialize(const PortableVertexDeclaration &_vtx_decl) override;
 		void SetupVertexPointers() override;
 
 		GLuint VAO;
@@ -31,7 +30,7 @@ class VertexManager : public VertexManagerBase
 public:
 	VertexManager();
 	~VertexManager();
-	NativeVertexFormat* CreateNativeVertexFormat() override;
+	NativeVertexFormat* CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
 	void CreateDeviceObjects() override;
 	void DestroyDeviceObjects() override;
 

--- a/Source/Core/VideoCommon/FramebufferManagerBase.cpp
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.cpp
@@ -62,6 +62,9 @@ const XFBSourceBase* const* FramebufferManagerBase::GetRealXFBSource(u32 xfbAddr
 	if (!m_realXFBSource)
 		m_realXFBSource = g_framebuffer_manager->CreateXFBSource(fbWidth, fbHeight, 1);
 
+	if (!m_realXFBSource)
+		return nullptr;
+
 	m_realXFBSource->srcAddr = xfbAddr;
 
 	m_realXFBSource->srcWidth = MAX_XFB_WIDTH;
@@ -160,6 +163,9 @@ void FramebufferManagerBase::CopyToVirtualXFB(u32 xfbAddr, u32 fbStride, u32 fbH
 	if (!vxfb->xfbSource)
 	{
 		vxfb->xfbSource = g_framebuffer_manager->CreateXFBSource(target_width, target_height, m_EFBLayers);
+		if (!vxfb->xfbSource)
+			return;
+
 		vxfb->xfbSource->texWidth = target_width;
 		vxfb->xfbSource->texHeight = target_height;
 	}

--- a/Source/Core/VideoCommon/FramebufferManagerBase.cpp
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.cpp
@@ -59,7 +59,7 @@ const XFBSourceBase* const* FramebufferManagerBase::GetRealXFBSource(u32 xfbAddr
 		m_realXFBSource = nullptr;
 	}
 
-	if (!m_realXFBSource)
+	if (!m_realXFBSource && g_framebuffer_manager)
 		m_realXFBSource = g_framebuffer_manager->CreateXFBSource(fbWidth, fbHeight, 1);
 
 	if (!m_realXFBSource)
@@ -121,13 +121,21 @@ const XFBSourceBase* const* FramebufferManagerBase::GetVirtualXFBSource(u32 xfbA
 void FramebufferManagerBase::CopyToXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, const EFBRectangle& sourceRc, float Gamma)
 {
 	if (g_ActiveConfig.bUseRealXFB)
-		g_framebuffer_manager->CopyToRealXFB(xfbAddr, fbStride, fbHeight, sourceRc, Gamma);
+	{
+		if (g_framebuffer_manager)
+			g_framebuffer_manager->CopyToRealXFB(xfbAddr, fbStride, fbHeight, sourceRc, Gamma);
+	}
 	else
+	{
 		CopyToVirtualXFB(xfbAddr, fbStride, fbHeight, sourceRc, Gamma);
+	}
 }
 
 void FramebufferManagerBase::CopyToVirtualXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, const EFBRectangle& sourceRc, float Gamma)
 {
+	if (!g_framebuffer_manager)
+		return;
+
 	VirtualXFBListType::iterator vxfb = FindVirtualXFB(xfbAddr, sourceRc.GetWidth(), fbHeight);
 
 	if (m_virtualXFBList.end() == vxfb)

--- a/Source/Core/VideoCommon/NativeVertexFormat.h
+++ b/Source/Core/VideoCommon/NativeVertexFormat.h
@@ -108,7 +108,6 @@ class NativeVertexFormat : NonCopyable
 public:
 	virtual ~NativeVertexFormat() {}
 
-	virtual void Initialize(const PortableVertexDeclaration &vtx_decl) = 0;
 	virtual void SetupVertexPointers() = 0;
 
 	u32 GetVertexStride() const { return vtx_decl.stride; }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -58,19 +58,22 @@ public:
 		PP_EFB_COPY_CLOCKS
 	};
 
-	virtual void SetColorMask() = 0;
-	virtual void SetBlendMode(bool forceUpdate) = 0;
-	virtual void SetScissorRect(const EFBRectangle& rc) = 0;
-	virtual void SetGenerationMode() = 0;
-	virtual void SetDepthMode() = 0;
-	virtual void SetLogicOpMode() = 0;
-	virtual void SetDitherMode() = 0;
-	virtual void SetSamplerState(int stage, int texindex, bool custom_tex) = 0;
-	virtual void SetInterlacingMode() = 0;
-	virtual void SetViewport() = 0;
+	virtual void SetColorMask() {}
+	virtual void SetBlendMode(bool forceUpdate) {}
+	virtual void SetScissorRect(const EFBRectangle& rc) {}
+	virtual void SetGenerationMode() {}
+	virtual void SetDepthMode() {}
+	virtual void SetLogicOpMode() {}
+	virtual void SetDitherMode() {}
+	virtual void SetSamplerState(int stage, int texindex, bool custom_tex) {}
+	virtual void SetInterlacingMode() {}
+	virtual void SetViewport() {}
 
-	virtual void ApplyState(bool bUseDstAlpha) = 0;
-	virtual void RestoreState() = 0;
+	virtual void ApplyState(bool bUseDstAlpha) {}
+	virtual void RestoreState() {}
+
+	virtual void ResetAPIState() {}
+	virtual void RestoreAPIState() {}
 
 	// Ideal internal resolution - determined by display resolution (automatic scaling) and/or a multiple of the native EFB resolution
 	static int GetTargetWidth() { return s_target_width; }
@@ -116,10 +119,6 @@ public:
 
 	virtual u16 BBoxRead(int index) = 0;
 	virtual void BBoxWrite(int index, u16 value) = 0;
-
-	// What's the real difference between these? Too similar names.
-	virtual void ResetAPIState() = 0;
-	virtual void RestoreAPIState() = 0;
 
 	// Finish up the current frame, print some stats
 	static void Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,float Gamma = 1.0f);

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -152,8 +152,7 @@ static VertexLoaderBase* RefreshLoader(int vtx_attr_group, bool preprocess = fal
 			std::unique_ptr<NativeVertexFormat>& native = s_native_vertex_map[format];
 			if (!native)
 			{
-				native.reset(g_vertex_manager->CreateNativeVertexFormat());
-				native->Initialize(format);
+				native.reset(g_vertex_manager->CreateNativeVertexFormat(format));
 			}
 			loader->m_native_vertex_format = native.get();
 		}

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -50,7 +50,7 @@ public:
 
 	static void Flush();
 
-	virtual ::NativeVertexFormat* CreateNativeVertexFormat() = 0;
+	virtual NativeVertexFormat* CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) = 0;
 
 	static void DoState(PointerWrap& p);
 


### PR DESCRIPTION
This PR gives some default implementations for optional backend methods. Next it allows some globals to be nullptr, so videosw and null backend should benefit a bit of it.

For reviewing, please look at those commits separatly.