### PR TITLE
DolphinQt - Functioning Fullscreen button, Fix for Fullscreen on linux, follow renderToMainWindow setting

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -41,6 +41,7 @@ private slots:
 	// Emulation
 	void StartGame(const QString filename);
 	void OnCoreStateChanged(Core::EState state);
+	void OnFullscreen();
 
 	// Main toolbar
 	void OnBrowse();

--- a/Source/Core/DolphinQt/MainWindow.ui
+++ b/Source/Core/DolphinQt/MainWindow.ui
@@ -53,6 +53,8 @@
     <addaction name="actionStop"/>
     <addaction name="actionReset"/>
     <addaction name="separator"/>
+    <addaction name="actionFullscreen"/>
+    <addaction name="separator"/>
     <addaction name="actionScreenshot"/>
    </widget>
    <widget class="QMenu" name="mnuOptions">
@@ -122,6 +124,7 @@
    <addaction name="actionPlay"/>
    <addaction name="actionStop"/>
    <addaction name="actionScreenshot"/>
+   <addaction name="actionFullscreen"/>
   </widget>
   <action name="actionWebsite">
    <property name="text">
@@ -242,6 +245,17 @@
   <action name="actionScreenshot">
    <property name="text">
     <string>Screenshot</string>
+   </property>
+   <property name="iconVisibleInMenu">
+    <bool>false</bool>
+   </property>
+  </action>
+  <action name="actionFullscreen">
+   <property name="text">
+    <string>&amp;Fullscreen</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+Enter</string>
    </property>
    <property name="iconVisibleInMenu">
     <bool>false</bool>


### PR DESCRIPTION
# Fullscreen fix on linux
Fullscreen for dolphinQt was broken on my machine (arch linux with i3 window manager) and removing this line has fixed it.
[BypassWindowManagerHint](http://doc.qt.io/qt-5.5/qt.html#WindowType-enum) is stated to "Behave different depending on what operating system the application is running on" 

It appears fine on windows and my linux system. I would love to hear from mac os x and linux users using different window managers, to check that it wasn't making your system work.

# Fullscreen button
Added a fullscreen button and menu option that toggles the fullscreen state.

# Render To Main Window
Previously dolphinQt would either render to main window or fullscreen.
Now it follows the renderToMainWindow setting.