### PR TITLE
Fix Prepare (Set LEDs and Rumble) on Connect and Refresh

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -518,13 +518,13 @@ void WiimoteDarwinHid::RemoveCallback(void* context, IOReturn result, void*)
 
 	if (length > MAX_PAYLOAD) {
 		WARN_LOG(WIIMOTE, "Dropping packet for Wiimote %i, too large",
-				wm->m_index + 1);
+				wm->GetIndex() + 1);
 		return;
 	}
 
 	if (wm->m_inputlen != -1) {
 		WARN_LOG(WIIMOTE, "Dropping packet for Wiimote %i, queue full",
-				wm->m_index + 1);
+				wm->GetIndex() + 1);
 		return;
 	}
 
@@ -556,7 +556,7 @@ void WiimoteDarwinHid::RemoveCallback(void* context, IOReturn result, void*)
 		return;
 	}
 
-	WARN_LOG(WIIMOTE, "Lost channel to Wiimote %i", wm->m_index + 1);
+	WARN_LOG(WIIMOTE, "Lost channel to Wiimote %i", wm->GetIndex() + 1);
 
 	wm->DisconnectInternal();
 }

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -60,12 +60,12 @@ public:
 	virtual bool ConnectInternal() = 0;
 	virtual void DisconnectInternal() = 0;
 
-	bool Connect();
+	bool Connect(int index);
 
 	// TODO: change to something like IsRelevant
 	virtual bool IsConnected() const = 0;
 
-	void Prepare(int index);
+	void Prepare();
 	bool PrepareOnThread();
 
 	void DisableDataReporting();
@@ -74,10 +74,11 @@ public:
 
 	void QueueReport(u8 rpt_id, const void* data, unsigned int size);
 
-	int m_index;
+	int GetIndex() const;
 
 protected:
 	Wiimote();
+	int m_index;
 	Report m_last_input_report;
 	u16 m_channel;
 	u8 m_last_connect_request_counter;


### PR DESCRIPTION
Fixes the Set LEDs and Rumble when Wiimotes are connected or "Refresh" is pressed in the Controller Dialog.

The Wiimote Device Thread is created in Wiimote::Connect, but the flag to prepare (i.e. set the LED and do a short rumble) is set afterwards. This left the Wiimote unprepared until a button is pressed. Similar for the "Refresh", prepare flag was set, but the WiimoteDevice Thread was not woken up from its Read-Sleep.

Cherry picked from #3245