### PR TITLE
D3D: Fix crash on some drivers with small textures

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.cpp
@@ -15,9 +15,8 @@ namespace DX11
 namespace D3D
 {
 
-void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned int width, unsigned int height, unsigned int expanded_width, unsigned int level, D3D11_USAGE usage)
+void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned int width, unsigned int height, unsigned int src_pitch, unsigned int level, D3D11_USAGE usage)
 {
-	unsigned int src_pitch = 4 * expanded_width;
 	if (usage == D3D11_USAGE_DYNAMIC || usage == D3D11_USAGE_STAGING)
 	{
 		D3D11_MAPPED_SUBRESOURCE map;
@@ -32,7 +31,7 @@ void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned 
 			// pitch to what the driver returns, so copy whichever is smaller.
 			unsigned int copy_size = std::min(src_pitch, map.RowPitch);
 			for (unsigned int y = 0; y < height; ++y)
-				memcpy((u8*)map.pData + y * map.RowPitch, (u8*)buffer + y * src_pitch, copy_size);
+				memcpy((u8*)map.pData + y * map.RowPitch, buffer + y * src_pitch, copy_size);
 		}
 		D3D::context->Unmap(pTexture, level);
 	}

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -11,7 +11,7 @@ namespace DX11
 
 namespace D3D
 {
-	void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned int width, unsigned int height, unsigned int pitch, unsigned int level, D3D11_USAGE usage);
+	void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned int width, unsigned int height, unsigned int expanded_width, unsigned int level, D3D11_USAGE usage);
 }
 
 class D3DTexture2D

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -11,7 +11,7 @@ namespace DX11
 
 namespace D3D
 {
-	void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned int width, unsigned int height, unsigned int expanded_width, unsigned int level, D3D11_USAGE usage);
+	void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned int width, unsigned int height, unsigned int src_pitch, unsigned int level, D3D11_USAGE usage);
 }
 
 class D3DTexture2D

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -142,7 +142,8 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 void TextureCache::TCacheEntry::Load(unsigned int width, unsigned int height,
 	unsigned int expanded_width, unsigned int level)
 {
-	D3D::ReplaceRGBATexture2D(texture->GetTex(), TextureCache::temp, width, height, expanded_width, level, usage);
+	unsigned int src_pitch = 4 * expanded_width;
+	D3D::ReplaceRGBATexture2D(texture->GetTex(), TextureCache::temp, width, height, src_pitch, level, usage);
 }
 
 TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntryConfig& config)


### PR DESCRIPTION
This crash occurred when a small texture with a width that was rounded up to block size was uploaded, and the driver returned a row size smaller than the aligned source data. Did not occur on the NV driver because the map buffer always had a larger alignment. Intel driver returned a smaller row pitch, resulting in the memcpy writing out-of-bounds, and crashing in various locations some time afterwards. Also renamed the pitch parameter to expanded_width, to match the name where the function is called.

Should address this issue: https://bugs.dolphin-emu.org/issues/8910 (Tested on Win10 1511 x64, with NV, Intel and WARP drivers)
