### PR TITLE
DolphinQt: Get rid of unneeded abbreviation macros.

### DIFF
--- a/Source/Core/DolphinQt/AboutDialog.cpp
+++ b/Source/Core/DolphinQt/AboutDialog.cpp
@@ -12,7 +12,6 @@
 
 #include "DolphinQt/AboutDialog.h"
 #include "DolphinQt/Utils/Resources.h"
-#include "DolphinQt/Utils/Utils.h"
 
 DAboutDialog::DAboutDialog(QWidget* parent_widget)
 	: QDialog(parent_widget)
@@ -23,13 +22,14 @@ DAboutDialog::DAboutDialog(QWidget* parent_widget)
 
 	m_ui = std::make_unique<Ui::DAboutDialog>();
 	m_ui->setupUi(this);
-	m_ui->lblGitRev->setText(SC(scm_desc_str));
-	m_ui->lblGitInfo->setText(m_ui->lblGitInfo->text().arg(SC(scm_branch_str), SC(scm_rev_git_str)));
-	m_ui->lblFinePrint->setText(m_ui->lblFinePrint->text().arg(SL("2015")));
+	m_ui->lblGitRev->setText(QString::fromUtf8(scm_desc_str));
+	m_ui->lblGitInfo->setText(m_ui->lblGitInfo->text().arg(QString::fromUtf8(scm_branch_str),
+		QString::fromUtf8(scm_rev_git_str)));
+	m_ui->lblFinePrint->setText(m_ui->lblFinePrint->text().arg(QStringLiteral("2015")));
 	m_ui->lblLicenseAuthorsSupport->setText(m_ui->lblLicenseAuthorsSupport->text()
-		.arg(SL("https://github.com/dolphin-emu/dolphin/blob/master/license.txt"))
-		.arg(SL("https://github.com/dolphin-emu/dolphin/graphs/contributors"))
-		.arg(SL("https://forums.dolphin-emu.org/")));
+		.arg(QStringLiteral("https://github.com/dolphin-emu/dolphin/blob/master/license.txt"))
+		.arg(QStringLiteral("https://github.com/dolphin-emu/dolphin/graphs/contributors"))
+		.arg(QStringLiteral("https://forums.dolphin-emu.org/")));
 	m_ui->lblLogo->setPixmap(Resources::GetPixmap(Resources::DOLPHIN_LOGO_LARGE));
 }
 

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -23,7 +23,6 @@
 #include "DiscIO/VolumeCreator.h"
 
 #include "DolphinQt/GameList/GameFile.h"
-#include "DolphinQt/Utils/Utils.h"
 
 static const u32 CACHE_REVISION = 0x00D; // Last changed in PR 3097
 static const u32 DATASTREAM_REVISION = 15; // Introduced in Qt 5.2
@@ -66,7 +65,7 @@ static QString GetLanguageString(DiscIO::IVolume::ELanguage language, QMap<DiscI
 	if (!strings.empty())
 		return strings.cbegin().value();
 
-	return SL("");
+	return QStringLiteral("");
 }
 
 GameFile::GameFile(const QString& fileName)
@@ -147,12 +146,12 @@ GameFile::GameFile(const QString& fileName)
 	// files with the same name as the main file is provided as an alternative for those who want to have
 	// multiple files in one folder instead of having a Homebrew Channel-style folder structure.
 
-	if (!ReadXML(directory.filePath(info.baseName() + SL(".xml"))))
-		ReadXML(directory.filePath(SL("meta.xml")));
+	if (!ReadXML(directory.filePath(info.baseName() + QStringLiteral(".xml"))))
+		ReadXML(directory.filePath(QStringLiteral("meta.xml")));
 
-	QImage banner(directory.filePath(info.baseName() + SL(".png")));
+	QImage banner(directory.filePath(info.baseName() + QStringLiteral(".png")));
 	if (banner.isNull())
-		banner.load(directory.filePath(SL("icon.png")));
+		banner.load(directory.filePath(QStringLiteral("icon.png")));
 	if (!banner.isNull())
 		m_banner = QPixmap::fromImage(banner);
 }
@@ -263,7 +262,7 @@ QString GameFile::CreateCacheFilename() const
 	SplitPath(m_file_name.toStdString(), &pathname, &filename, &extension);
 
 	if (filename.empty())
-		return SL(""); // must be a disc drive
+		return QStringLiteral(""); // must be a disc drive
 
 	// Filename.extension_HashOfFolderPath_Size.cache
 	// Append hash to prevent ISO name-clashing in different folders.
@@ -306,21 +305,21 @@ bool GameFile::ReadXML(const QString& file_path)
 		return false;
 
 	QXmlStreamReader reader(&file);
-	if (reader.readNextStartElement() && reader.name() == SL("app"))
+	if (reader.readNextStartElement() && reader.name() == QStringLiteral("app"))
 	{
 		while (reader.readNextStartElement())
 		{
 			QStringRef name = reader.name();
-			if (name == SL("name"))
+			if (name == QStringLiteral("name"))
 			{
 				m_short_names = { { DiscIO::IVolume::LANGUAGE_UNKNOWN, reader.readElementText() } };
 				m_long_names = m_short_names;
 			}
-			else if (name == SL("short_description"))
+			else if (name == QStringLiteral("short_description"))
 			{
 				m_descriptions = { { DiscIO::IVolume::LANGUAGE_UNKNOWN, reader.readElementText() } };
 			}
-			else if (name == SL("coder"))
+			else if (name == QStringLiteral("coder"))
 			{
 				m_company = reader.readElementText();
 			}

--- a/Source/Core/DolphinQt/Main.cpp
+++ b/Source/Core/DolphinQt/Main.cpp
@@ -11,7 +11,6 @@
 
 #include "MainWindow.h"
 
-#include "DolphinQt/Utils/Utils.h"
 #include "UICommon/UICommon.h"
 
 static bool IsOsSupported()
@@ -28,11 +27,11 @@ static bool IsOsSupported()
 static QString LowestSupportedOsVersion()
 {
 #ifdef Q_OS_OSX
-	return SL("Mac OS X 10.9");
+	return QStringLiteral("Mac OS X 10.9");
 #elif defined(Q_OS_WIN)
-	return SL("Windows Vista SP2");
+	return QStringLiteral("Windows Vista SP2");
 #else
-	return SL("Unknown");
+	return QStringLiteral("Unknown");
 #endif
 }
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -21,7 +21,6 @@
 #include "DolphinQt/MainWindow.h"
 #include "DolphinQt/SystemInfo.h"
 #include "DolphinQt/Utils/Resources.h"
-#include "DolphinQt/Utils/Utils.h"
 
 #include "VideoCommon/VideoConfig.h"
 
@@ -82,13 +81,13 @@ DMainWindow::DMainWindow(QWidget* parent_widget)
 	});
 
 	connect(m_ui->actionWebsite, &QAction::triggered, this, []() {
-		QDesktopServices::openUrl(QUrl(SL("https://dolphin-emu.org/")));
+		QDesktopServices::openUrl(QUrl(QStringLiteral("https://dolphin-emu.org/")));
 	});
 	connect(m_ui->actionOnlineDocs, &QAction::triggered, this, []() {
-		QDesktopServices::openUrl(QUrl(SL("https://dolphin-emu.org/docs/guides/")));
+		QDesktopServices::openUrl(QUrl(QStringLiteral("https://dolphin-emu.org/docs/guides/")));
 	});
 	connect(m_ui->actionGitHub, &QAction::triggered, this, []() {
-		QDesktopServices::openUrl(QUrl(SL("https://github.com/dolphin-emu/dolphin")));
+		QDesktopServices::openUrl(QUrl(QStringLiteral("https://github.com/dolphin-emu/dolphin")));
 	});
 	connect(m_ui->actionSystemInfo, &QAction::triggered, this, [&]() {
 		DSystemInfo* dlg = new DSystemInfo(this);
@@ -209,7 +208,7 @@ QString DMainWindow::ShowFileDialog()
 {
 	return QFileDialog::getOpenFileName(this, tr("Open File"), QString(),
 		tr("All supported ROMs (%1);;All files (*)")
-		.arg(SL("*.gcm *.iso *.ciso *.gcz *.wbfs *.elf *.dol *.dff *.tmd *.wad")));
+		.arg(QStringLiteral("*.gcm *.iso *.ciso *.gcz *.wbfs *.elf *.dol *.dff *.tmd *.wad")));
 }
 
 QString DMainWindow::ShowFolderDialog()

--- a/Source/Core/DolphinQt/SystemInfo.cpp
+++ b/Source/Core/DolphinQt/SystemInfo.cpp
@@ -13,7 +13,6 @@
 #include "Common/CPUDetect.h"
 
 #include "DolphinQt/SystemInfo.h"
-#include "DolphinQt/Utils/Utils.h"
 
 DSystemInfo::DSystemInfo(QWidget* parent_widget) :
 	QDialog(parent_widget)
@@ -44,17 +43,20 @@ void DSystemInfo::UpdateSystemInfo()
 {
 	QString sysinfo;
 
-	sysinfo += SL("System\n===========================\n");
-	sysinfo += SL("OS: %1\n").arg(GetOS());
-	sysinfo += SL("CPU: %1, %2 logical processors\n").arg(QString::fromStdString(cpu_info.Summarize()))
+	sysinfo += QStringLiteral("System\n===========================\n");
+	sysinfo += QStringLiteral("OS: %1\n").arg(GetOS());
+	sysinfo += QStringLiteral("CPU: %1, %2 logical processors\n")
+		.arg(QString::fromStdString(cpu_info.Summarize()))
 		.arg(QThread::idealThreadCount());
 
-	sysinfo += SL("\nDolphin\n===========================\n");
-	sysinfo += SL("SCM: branch %1, rev %2\n").arg(SC(scm_branch_str)).arg(SC(scm_rev_git_str));
+	sysinfo += QStringLiteral("\nDolphin\n===========================\n");
+	sysinfo += QStringLiteral("SCM: branch %1, rev %2\n")
+		.arg(QString::fromUtf8(scm_branch_str))
+		.arg(QString::fromUtf8(scm_rev_git_str));
 
-	sysinfo += SL("\nGUI\n===========================\n");
-	sysinfo += SL("Compiled for Qt: %1\n").arg(SL(QT_VERSION_STR));
-	sysinfo += SL("Running on Qt: %1").arg(SC(qVersion()));
+	sysinfo += QStringLiteral("\nGUI\n===========================\n");
+	sysinfo += QStringLiteral("Compiled for Qt: %1\n").arg(QStringLiteral(QT_VERSION_STR));
+	sysinfo += QStringLiteral("Running on Qt: %1").arg(QString::fromUtf8(qVersion()));
 
 	m_ui->txtSysInfo->setPlainText(sysinfo);
 }
@@ -64,43 +66,43 @@ QString DSystemInfo::GetOS() const
 	QString ret;
 	/* DON'T REORDER WITHOUT READING Qt DOCS! */
 #if defined(Q_OS_WIN)
-	ret += SL("Windows ");
+	ret += QStringLiteral("Windows ");
 	switch (QSysInfo::WindowsVersion) {
-	case QSysInfo::WV_VISTA: ret += SL("Vista"); break;
-	case QSysInfo::WV_WINDOWS7: ret += SL("7"); break;
-	case QSysInfo::WV_WINDOWS8: ret += SL("8"); break;
-	case QSysInfo::WV_WINDOWS8_1: ret += SL("8.1"); break;
-	case QSysInfo::WV_WINDOWS10: ret += SL("10"); break;
-	default: ret += SL("(unknown)"); break;
+	case QSysInfo::WV_VISTA: ret += QStringLiteral("Vista"); break;
+	case QSysInfo::WV_WINDOWS7: ret += QStringLiteral("7"); break;
+	case QSysInfo::WV_WINDOWS8: ret += QStringLiteral("8"); break;
+	case QSysInfo::WV_WINDOWS8_1: ret += QStringLiteral("8.1"); break;
+	case QSysInfo::WV_WINDOWS10: ret += QStringLiteral("10"); break;
+	default: ret += QStringLiteral("(unknown)"); break;
 	}
 #elif defined(Q_OS_MAC)
-	ret += SL("Mac OS X ");
+	ret += QStringLiteral("Mac OS X ");
 	switch (QSysInfo::MacintoshVersion) {
-	case QSysInfo::MV_10_9: ret += SL("10.9"); break;
-	case QSysInfo::MV_10_10: ret += SL("10.10"); break;
-	case QSysInfo::MV_10_11: ret += SL("10.11"); break;
-	default: ret += SL("(unknown)"); break;
+	case QSysInfo::MV_10_9: ret += QStringLiteral("10.9"); break;
+	case QSysInfo::MV_10_10: ret += QStringLiteral("10.10"); break;
+	case QSysInfo::MV_10_11: ret += QStringLiteral("10.11"); break;
+	default: ret += QStringLiteral("(unknown)"); break;
 	}
 #elif defined(Q_OS_LINUX)
-	ret += SL("Linux");
+	ret += QStringLiteral("Linux");
 #elif defined(Q_OS_FREEBSD)
-	ret += SL("FreeBSD");
+	ret += QStringLiteral("FreeBSD");
 #elif defined(Q_OS_OPENBSD)
-	ret += SL("OpenBSD");
+	ret += QStringLiteral("OpenBSD");
 #elif defined(Q_OS_NETBSD)
-	ret += SL("NetBSD");
+	ret += QStringLiteral("NetBSD");
 #elif defined(Q_OS_BSD4)
-	ret += SL("Other BSD");
+	ret += QStringLiteral("Other BSD");
 #elif defined(Q_OS_UNIX)
-	ret += SL("Unix");
+	ret += QStringLiteral("Unix");
 #else
-	ret += SL("Unknown");
+	ret += QStringLiteral("Unknown");
 #endif
 
 #if defined(Q_WS_X11) || defined(Q_OS_X11)
-	ret += SL(" X11");
+	ret += QStringLiteral(" X11");
 #elif defined(Q_WS_WAYLAND)
-	ret += SL(" Wayland");
+	ret += QStringLiteral(" Wayland");
 #endif
 
 	return ret;

--- a/Source/Core/DolphinQt/Utils/Resources.cpp
+++ b/Source/Core/DolphinQt/Utils/Resources.cpp
@@ -9,88 +9,84 @@
 #include "Core/ConfigManager.h"
 
 #include "DolphinQt/Utils/Resources.h"
-#include "DolphinQt/Utils/Utils.h"
 
 QVector<QPixmap> Resources::m_platforms;
 QVector<QPixmap> Resources::m_regions;
 QVector<QPixmap> Resources::m_ratings;
 QVector<QPixmap> Resources::m_pixmaps;
 
-// Wrapper for GetImageFilename() so you don't have to to call it directly
-#define GIFN(file) GetImageFilename(SL(file), dir)
-
 void Resources::Init()
 {
 	QString dir = QString::fromStdString(File::GetSysDirectory() + "Resources/");
 
 	m_regions.resize(DiscIO::IVolume::NUMBER_OF_COUNTRIES);
-	m_regions[DiscIO::IVolume::COUNTRY_JAPAN].load(GIFN("Flag_Japan"));
-	m_regions[DiscIO::IVolume::COUNTRY_EUROPE].load(GIFN("Flag_Europe"));
-	m_regions[DiscIO::IVolume::COUNTRY_USA].load(GIFN("Flag_USA"));
+	m_regions[DiscIO::IVolume::COUNTRY_JAPAN].load(GetImageFilename("Flag_Japan", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_EUROPE].load(GetImageFilename("Flag_Europe", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_USA].load(GetImageFilename("Flag_USA", dir));
 
-	m_regions[DiscIO::IVolume::COUNTRY_AUSTRALIA].load(GIFN("Flag_Australia"));
-	m_regions[DiscIO::IVolume::COUNTRY_FRANCE].load(GIFN("Flag_France"));
-	m_regions[DiscIO::IVolume::COUNTRY_GERMANY].load(GIFN("Flag_Germany"));
-	m_regions[DiscIO::IVolume::COUNTRY_ITALY].load(GIFN("Flag_Italy"));
-	m_regions[DiscIO::IVolume::COUNTRY_KOREA].load(GIFN("Flag_Korea"));
-	m_regions[DiscIO::IVolume::COUNTRY_NETHERLANDS].load(GIFN("Flag_Netherlands"));
-	m_regions[DiscIO::IVolume::COUNTRY_RUSSIA].load(GIFN("Flag_Russia"));
-	m_regions[DiscIO::IVolume::COUNTRY_SPAIN].load(GIFN("Flag_Spain"));
-	m_regions[DiscIO::IVolume::COUNTRY_TAIWAN].load(GIFN("Flag_Taiwan"));
-	m_regions[DiscIO::IVolume::COUNTRY_WORLD].load(GIFN("Flag_International"));
-	m_regions[DiscIO::IVolume::COUNTRY_UNKNOWN].load(GIFN("Flag_Unknown"));
+	m_regions[DiscIO::IVolume::COUNTRY_AUSTRALIA].load(GetImageFilename("Flag_Australia", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_FRANCE].load(GetImageFilename("Flag_France", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_GERMANY].load(GetImageFilename("Flag_Germany", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_ITALY].load(GetImageFilename("Flag_Italy", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_KOREA].load(GetImageFilename("Flag_Korea", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_NETHERLANDS].load(GetImageFilename("Flag_Netherlands", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_RUSSIA].load(GetImageFilename("Flag_Russia", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_SPAIN].load(GetImageFilename("Flag_Spain", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_TAIWAN].load(GetImageFilename("Flag_Taiwan", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_WORLD].load(GetImageFilename("Flag_International", dir));
+	m_regions[DiscIO::IVolume::COUNTRY_UNKNOWN].load(GetImageFilename("Flag_Unknown", dir));
 
 	m_platforms.resize(4);
-	m_platforms[0].load(GIFN("Platform_Gamecube"));
-	m_platforms[1].load(GIFN("Platform_Wii"));
-	m_platforms[2].load(GIFN("Platform_Wad"));
+	m_platforms[0].load(GetImageFilename("Platform_Gamecube", dir));
+	m_platforms[1].load(GetImageFilename("Platform_Wii", dir));
+	m_platforms[2].load(GetImageFilename("Platform_Wad", dir));
 
 	m_ratings.resize(6);
-	m_ratings[0].load(GIFN("rating0"));
-	m_ratings[1].load(GIFN("rating1"));
-	m_ratings[2].load(GIFN("rating2"));
-	m_ratings[3].load(GIFN("rating3"));
-	m_ratings[4].load(GIFN("rating4"));
-	m_ratings[5].load(GIFN("rating5"));
+	m_ratings[0].load(GetImageFilename("rating0", dir));
+	m_ratings[1].load(GetImageFilename("rating1", dir));
+	m_ratings[2].load(GetImageFilename("rating2", dir));
+	m_ratings[3].load(GetImageFilename("rating3", dir));
+	m_ratings[4].load(GetImageFilename("rating4", dir));
+	m_ratings[5].load(GetImageFilename("rating5", dir));
 
 	m_pixmaps.resize(NUM_ICONS);
-	m_pixmaps[DOLPHIN_LOGO].load(GIFN("Dolphin"));
-	m_pixmaps[DOLPHIN_LOGO_LARGE].load(GIFN("dolphin_logo"));
+	m_pixmaps[DOLPHIN_LOGO].load(GetImageFilename("Dolphin", dir));
+	m_pixmaps[DOLPHIN_LOGO_LARGE].load(GetImageFilename("dolphin_logo", dir));
 	UpdatePixmaps();
 }
 
 void Resources::UpdatePixmaps()
 {
 	QString dir = QString::fromStdString(File::GetThemeDir(SConfig::GetInstance().theme_name));
-	m_pixmaps[TOOLBAR_OPEN].load(GIFN("open"));
-	m_pixmaps[TOOLBAR_REFRESH].load(GIFN("refresh"));
-	m_pixmaps[TOOLBAR_BROWSE].load(GIFN("browse"));
-	m_pixmaps[TOOLBAR_PLAY].load(GIFN("play"));
-	m_pixmaps[TOOLBAR_STOP].load(GIFN("stop"));
-	m_pixmaps[TOOLBAR_PAUSE].load(GIFN("pause"));
-	m_pixmaps[TOOLBAR_FULLSCREEN].load(GIFN("fullscreen"));
-	m_pixmaps[TOOLBAR_SCREENSHOT].load(GIFN("screenshot"));
-	m_pixmaps[TOOLBAR_CONFIGURE].load(GIFN("config"));
-	m_pixmaps[TOOLBAR_GRAPHICS].load(GIFN("graphics"));
-	m_pixmaps[TOOLBAR_CONTROLLERS].load(GIFN("classic"));
-	m_pixmaps[TOOLBAR_HELP].load(GIFN("nobanner")); // TODO
+	m_pixmaps[TOOLBAR_OPEN].load(GetImageFilename("open", dir));
+	m_pixmaps[TOOLBAR_REFRESH].load(GetImageFilename("refresh", dir));
+	m_pixmaps[TOOLBAR_BROWSE].load(GetImageFilename("browse", dir));
+	m_pixmaps[TOOLBAR_PLAY].load(GetImageFilename("play", dir));
+	m_pixmaps[TOOLBAR_STOP].load(GetImageFilename("stop", dir));
+	m_pixmaps[TOOLBAR_PAUSE].load(GetImageFilename("pause", dir));
+	m_pixmaps[TOOLBAR_FULLSCREEN].load(GetImageFilename("fullscreen", dir));
+	m_pixmaps[TOOLBAR_SCREENSHOT].load(GetImageFilename("screenshot", dir));
+	m_pixmaps[TOOLBAR_CONFIGURE].load(GetImageFilename("config", dir));
+	m_pixmaps[TOOLBAR_GRAPHICS].load(GetImageFilename("graphics", dir));
+	m_pixmaps[TOOLBAR_CONTROLLERS].load(GetImageFilename("classic", dir));
+	m_pixmaps[TOOLBAR_HELP].load(GetImageFilename("nobanner", dir)); // TODO
 	// TODO: toolbar[MEMCARD];
 	// TODO: toolbar[HOTKEYS];
-	m_pixmaps[BANNER_MISSING].load(GIFN("nobanner"));
+	m_pixmaps[BANNER_MISSING].load(GetImageFilename("nobanner", dir));
 	// TODO: Make this consistent with the other files
-	m_platforms[3].load(GIFN("fileplatform"));
+	m_platforms[3].load(GetImageFilename("fileplatform", dir));
 }
 
-QString Resources::GetImageFilename(QString name, QString dir)
+QString Resources::GetImageFilename(const char* name, QString dir)
 {
+	QString fileName = QString::fromUtf8(name);
 	if (qApp->devicePixelRatio() >= 2)
 	{
-		QString fileName = name;
-		fileName.prepend(dir).append(SL("@2x.png"));
+		fileName.prepend(dir).append(QStringLiteral("@2x.png"));
 		if (QFile::exists(fileName))
 			return fileName;
 	}
-	return name.prepend(dir).append(SL(".png"));
+	return fileName.prepend(dir).append(QStringLiteral(".png"));
 }
 
 QPixmap& Resources::GetRegionPixmap(DiscIO::IVolume::ECountry region)

--- a/Source/Core/DolphinQt/Utils/Resources.h
+++ b/Source/Core/DolphinQt/Utils/Resources.h
@@ -50,5 +50,5 @@ private:
 	static QVector<QPixmap> m_ratings;
 	static QVector<QPixmap> m_pixmaps;
 
-	static QString GetImageFilename(QString name, QString dir);
+	static QString GetImageFilename(const char* name, QString dir);
 };

--- a/Source/Core/DolphinQt/Utils/Utils.cpp
+++ b/Source/Core/DolphinQt/Utils/Utils.cpp
@@ -8,14 +8,21 @@
 
 QString NiceSizeFormat(s64 size)
 {
-	QStringList list = { SL("KB"), SL("MB"), SL("GB"), SL("TB"), SL("PB"), SL("EB") };
+	QStringList list = {
+		QStringLiteral("KB"),
+		QStringLiteral("MB"),
+		QStringLiteral("GB"),
+		QStringLiteral("TB"),
+		QStringLiteral("PB"),
+		QStringLiteral("EB")
+	};
 	QStringListIterator i(list);
-	QString unit = SL("b");
+	QString unit = QStringLiteral("b");
 	double num = size;
 	while (num >= 1024.0 && i.hasNext())
 	{
 		unit = i.next();
 		num /= 1024.0;
 	}
-	return SL("%1 %2").arg(QString::number(num, 'f', 1)).arg(unit);
+	return QStringLiteral("%1 %2").arg(QString::number(num, 'f', 1)).arg(unit);
 }

--- a/Source/Core/DolphinQt/Utils/Utils.h
+++ b/Source/Core/DolphinQt/Utils/Utils.h
@@ -8,11 +8,4 @@
 
 #include "Common/CommonTypes.h"
 
-// Use this to encapsulate ASCII string literals
-#define SL(str) QStringLiteral(str)
-
-// Use this to encapsulate string constants and functions that
-// return "char*"s
-#define SC(str) QString::fromLatin1(str)
-
 QString NiceSizeFormat(s64 size);


### PR DESCRIPTION
As requested by @lioncash.