### PR TITLE
DebuggerViews: Fixed nullptr dereferences

### DIFF
--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -156,7 +156,7 @@ void CMemoryView::OnScrollWheel(wxMouseEvent& event)
 
 void CMemoryView::OnPopupMenu(wxCommandEvent& event)
 {
-	CFrame* main_frame = (CFrame*)(GetParent()->GetParent()->GetParent());
+	CFrame* main_frame = static_cast<CFrame*>(GetGrandParent()->GetParent());
 	CCodeWindow* code_window = main_frame->g_pCodeWindow;
 	CWatchWindow* watch_window = code_window->m_WatchWindow;
 

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -273,7 +273,7 @@ void CRegisterView::OnMouseDownR(wxGridEvent& event)
 
 void CRegisterView::OnPopupMenu(wxCommandEvent& event)
 {
-	CFrame* main_frame = (CFrame*)(GetParent()->GetParent());
+	CFrame* main_frame = static_cast<CFrame*>(GetGrandParent()->GetParent());
 	CCodeWindow* code_window = main_frame->g_pCodeWindow;
 	CWatchWindow* watch_window = code_window->m_WatchWindow;
 	CMemoryWindow* memory_window = code_window->m_MemoryWindow;

--- a/Source/Core/DolphinWX/Debugger/WatchView.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchView.cpp
@@ -261,7 +261,7 @@ void CWatchView::OnMouseDownR(wxGridEvent& event)
 
 void CWatchView::OnPopupMenu(wxCommandEvent& event)
 {
-	CFrame* main_frame = (CFrame*)(GetParent()->GetParent());
+	CFrame* main_frame = static_cast<CFrame*>(GetGrandParent()->GetParent());
 	CCodeWindow* code_window = main_frame->g_pCodeWindow;
 	CWatchWindow* watch_window = code_window->m_WatchWindow;
 	CMemoryWindow* memory_window = code_window->m_MemoryWindow;


### PR DESCRIPTION
```main_frame->g_pCodeWindow``` was null and caused a null pointer dereference.