### PR TITLE
VideoSW: Fix uninitialized variable warnings

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -633,6 +633,7 @@ void SConfig::LoadDefaults()
 
 	m_strName = "NONE";
 	m_strUniqueID = "00000000";
+	m_revision = 0;
 }
 static const char* GetRegionOfCountry(DiscIO::IVolume::ECountry country)
 {

--- a/Source/Core/VideoBackends/Software/NativeVertexFormat.h
+++ b/Source/Core/VideoBackends/Software/NativeVertexFormat.h
@@ -37,12 +37,12 @@ struct OutputVertexData
 		ALP_C
 	};
 
-	Vec3 mvPosition;
-	Vec4 projectedPosition;
-	Vec3 screenPosition;
-	Vec3 normal[3];
-	u8 color[2][4];
-	Vec3 texCoords[8];
+	Vec3 mvPosition = {};
+	Vec4 projectedPosition = {};
+	Vec3 screenPosition = {};
+	Vec3 normal[3] = {};
+	u8 color[2][4] = {};
+	Vec3 texCoords[8] = {};
 
 	void Lerp(float t, OutputVertexData *a, OutputVertexData *b)
 	{


### PR DESCRIPTION
Those memsets aren't ideal, but they should not affect rendering. Maybe we should check further why those bits affects rendering at all?