### PR TITLE
DQt2: Refactors.

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -9,11 +9,13 @@ set(SRCS
 	Host.cpp
 	RenderWidget.cpp
 	Resources.cpp
+	ToolBar.cpp
 	GameList/GameFile.cpp
 	GameList/GameList.cpp
 	GameList/GameTracker.cpp
 	GameList/GameListModel.cpp
-	GameList/GameListProxyModel.cpp
+	GameList/TableProxyModel.cpp
+	GameList/ListProxyModel.cpp
 	)
 
 list(APPEND LIBS core uicommon)

--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -35,7 +35,9 @@ private:
 	void MakeListView();
 
 	GameListModel* m_model;
-	QSortFilterProxyModel* m_proxy;
+	QSortFilterProxyModel* m_table_proxy;
+	QSortFilterProxyModel* m_list_proxy;
+
 	QListView* m_list;
 	QTableView* m_table;
 };

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -37,7 +37,6 @@ public:
 		COL_SIZE,
 		COL_COUNTRY,
 		COL_RATING,
-		COL_LARGE_ICON,
 		NUM_COLS
 	};
 

--- a/Source/Core/DolphinQt2/GameList/ListProxyModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/ListProxyModel.cpp
@@ -1,0 +1,38 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QSize>
+
+#include "DolphinQt2/GameList/GameListModel.h"
+#include "DolphinQt2/GameList/ListProxyModel.h"
+
+static constexpr QSize LARGE_BANNER_SIZE(144, 48);
+
+ListProxyModel::ListProxyModel(QObject* parent)
+	: QSortFilterProxyModel(parent)
+{
+	setSortCaseSensitivity(Qt::CaseInsensitive);
+	sort(GameListModel::COL_TITLE);
+}
+
+QVariant ListProxyModel::data(const QModelIndex& i, int role) const
+{
+	QModelIndex source_index = mapToSource(i);
+	if (role == Qt::DisplayRole)
+	{
+		return sourceModel()->data(
+			sourceModel()->index(source_index.row(), GameListModel::COL_TITLE),
+			Qt::DisplayRole);
+	}
+	else if (role == Qt::DecorationRole)
+	{
+		return sourceModel()->data(
+			sourceModel()->index(source_index.row(), GameListModel::COL_BANNER),
+			Qt::DisplayRole).value<QPixmap>().scaled(
+				LARGE_BANNER_SIZE,
+				Qt::KeepAspectRatio,
+				Qt::SmoothTransformation);
+	}
+	return QVariant();
+}

--- a/Source/Core/DolphinQt2/GameList/ListProxyModel.h
+++ b/Source/Core/DolphinQt2/GameList/ListProxyModel.h
@@ -1,0 +1,14 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QSortFilterProxyModel>
+
+class ListProxyModel final : public QSortFilterProxyModel
+{
+	Q_OBJECT
+
+public:
+	ListProxyModel(QObject* parent = nullptr);
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+};

--- a/Source/Core/DolphinQt2/GameList/TableProxyModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/TableProxyModel.cpp
@@ -4,10 +4,9 @@
 
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/GameList/GameListModel.h"
-#include "DolphinQt2/GameList/GameListProxyModel.h"
+#include "DolphinQt2/GameList/TableProxyModel.h"
 
 static constexpr QSize NORMAL_BANNER_SIZE(96, 32);
-static constexpr QSize LARGE_BANNER_SIZE(144, 48);
 
 // Convert an integer size to a friendly string representation.
 static QString FormatSize(qint64 size)
@@ -29,12 +28,13 @@ static QString FormatSize(qint64 size)
 	return QStringLiteral("%1 %2").arg(QString::number(num, 'f', 1)).arg(unit);
 }
 
-GameListProxyModel::GameListProxyModel(QObject* parent)
+TableProxyModel::TableProxyModel(QObject* parent)
 	: QSortFilterProxyModel(parent)
 {
+	setSortCaseSensitivity(Qt::CaseInsensitive);
 }
 
-QVariant GameListProxyModel::data(const QModelIndex& i, int role) const
+QVariant TableProxyModel::data(const QModelIndex& i, int role) const
 {
 	QModelIndex source_index = mapToSource(i);
 	QVariant source_data = sourceModel()->data(source_index, Qt::DisplayRole);
@@ -51,9 +51,6 @@ QVariant GameListProxyModel::data(const QModelIndex& i, int role) const
 		case GameListModel::COL_DESCRIPTION:
 		case GameListModel::COL_MAKER:
 			return source_data;
-		// Show the title in the display role of the icon view.
-		case GameListModel::COL_LARGE_ICON:
-			return data(index(i.row(), GameListModel::COL_TITLE), Qt::DisplayRole);
 		}
 	}
 	else if (role == Qt::DecorationRole)
@@ -74,13 +71,6 @@ QVariant GameListProxyModel::data(const QModelIndex& i, int role) const
 			return Resources::GetCountry(source_data.toInt());
 		case GameListModel::COL_RATING:
 			return Resources::GetRating(source_data.toInt());
-		// Show a scaled icon in the decoration role of the icon view.
-		case GameListModel::COL_LARGE_ICON:
-			return data(index(i.row(), GameListModel::COL_BANNER), Qt::DecorationRole)
-				.value<QPixmap>().scaled(
-					LARGE_BANNER_SIZE,
-					Qt::KeepAspectRatio,
-					Qt::SmoothTransformation);
 		}
 	}
 	return QVariant();

--- a/Source/Core/DolphinQt2/GameList/TableProxyModel.h
+++ b/Source/Core/DolphinQt2/GameList/TableProxyModel.h
@@ -9,11 +9,11 @@
 // For instance, the GameListModel exposes country as an integer, so this
 // class converts that into a flag, while still allowing sorting on the
 // underlying integer.
-class GameListProxyModel final : public QSortFilterProxyModel
+class TableProxyModel final : public QSortFilterProxyModel
 {
 	Q_OBJECT
 
 public:
-	GameListProxyModel(QObject* parent = nullptr);
+	TableProxyModel(QObject* parent = nullptr);
 	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
 };

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -10,6 +10,7 @@
 #include <QToolBar>
 
 #include "DolphinQt2/RenderWidget.h"
+#include "DolphinQt2/ToolBar.h"
 #include "DolphinQt2/GameList/GameList.h"
 
 class MainWindow final : public QMainWindow
@@ -47,14 +48,12 @@ private:
 	void AddTableColumnsMenu(QMenu* view_menu);
 	void AddListTypePicker(QMenu* view_menu);
 
-	void PopulateToolBar();
-
 	void StartGame(QString path);
 	void ShowRenderWidget();
 	void HideRenderWidget();
 
 	QStackedWidget* m_stack;
-	QToolBar* m_tool_bar;
+	ToolBar* m_tool_bar;
 	GameList* m_game_list;
 	RenderWidget* m_render_widget;
 	bool m_rendering_to_main;

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -1,0 +1,98 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QIcon>
+
+#include "Common/FileUtil.h"
+#include "Core/ConfigManager.h"
+#include "DolphinQt2/ToolBar.h"
+
+static constexpr QSize ICON_SIZE(32, 32);
+
+ToolBar::ToolBar(QWidget* parent)
+	: QToolBar(parent)
+{
+	setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+	setMovable(false);
+	setFloatable(false);
+	setIconSize(ICON_SIZE);
+
+	MakeActions();
+	UpdateIcons();
+}
+
+void ToolBar::EmulationStarted()
+{
+	m_play_action->setEnabled(false);
+	m_pause_action->setEnabled(true);
+	m_stop_action->setEnabled(true);
+	m_fullscreen_action->setEnabled(true);
+	m_screenshot_action->setEnabled(true);
+}
+
+void ToolBar::EmulationPaused()
+{
+	m_play_action->setEnabled(true);
+	m_pause_action->setEnabled(false);
+	m_stop_action->setEnabled(true);
+}
+
+void ToolBar::EmulationStopped()
+{
+	m_play_action->setEnabled(true);
+	m_pause_action->setEnabled(false);
+	m_stop_action->setEnabled(false);
+	m_fullscreen_action->setEnabled(false);
+	m_screenshot_action->setEnabled(false);
+}
+
+void ToolBar::MakeActions()
+{
+	m_open_action = addAction(tr("Open"), this, SIGNAL(OpenPressed()));
+	m_paths_action = addAction(tr("Paths"), this, SIGNAL(PathsPressed()));
+
+	addSeparator();
+
+	m_play_action = addAction(tr("Play"), this, SIGNAL(PlayPressed()));
+
+	m_pause_action = addAction(tr("Pause"), this, SIGNAL(PausePressed()));
+	m_pause_action->setEnabled(false);
+
+	m_stop_action = addAction(tr("Stop"), this, SIGNAL(StopPressed()));
+	m_stop_action->setEnabled(false);
+
+	m_fullscreen_action = addAction(tr("Full Screen"), this, SIGNAL(FullScreenPressed()));
+	m_fullscreen_action->setEnabled(false);
+
+	m_screenshot_action = addAction(tr("Screen Shot"), this, SIGNAL(ScreenShotPressed()));
+	m_screenshot_action->setEnabled(false);
+
+	addSeparator();
+
+	m_config_action = addAction(tr("Settings"));
+	m_config_action->setEnabled(false);
+
+	m_graphics_action = addAction(tr("Graphics"));
+	m_graphics_action->setEnabled(false);
+
+	m_controllers_action = addAction(tr("Controllers"));
+	m_controllers_action->setEnabled(false);
+}
+
+void ToolBar::UpdateIcons()
+{
+	QString dir = QString::fromStdString(File::GetThemeDir(SConfig::GetInstance().theme_name));
+
+	m_open_action->setIcon(QIcon(QStringLiteral("open.png").prepend(dir)));
+	m_paths_action->setIcon(QIcon(QStringLiteral("browse.png").prepend(dir)));
+	m_play_action->setIcon(QIcon(QStringLiteral("play.png").prepend(dir)));
+	m_pause_action->setIcon(QIcon(QStringLiteral("pause.png").prepend(dir)));
+	m_stop_action->setIcon(QIcon(QStringLiteral("stop.png").prepend(dir)));
+	m_fullscreen_action->setIcon(QIcon(QStringLiteral("fullscreen.png").prepend(dir)));
+	m_screenshot_action->setIcon(QIcon(QStringLiteral("screenshot.png").prepend(dir)));
+	m_config_action->setIcon(QIcon(QStringLiteral("config.png").prepend(dir)));
+	m_graphics_action->setIcon(QIcon(QStringLiteral("graphics.png").prepend(dir)));
+	m_controllers_action->setIcon(QIcon(QStringLiteral("classic.png").prepend(dir)));
+}
+

--- a/Source/Core/DolphinQt2/ToolBar.h
+++ b/Source/Core/DolphinQt2/ToolBar.h
@@ -1,0 +1,47 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QAction>
+#include <QLineEdit>
+#include <QToolBar>
+
+class ToolBar final : public QToolBar
+{
+	Q_OBJECT
+
+public:
+	ToolBar(QWidget* parent = nullptr);
+
+public slots:
+	void EmulationStarted();
+	void EmulationPaused();
+	void EmulationStopped();
+
+signals:
+	void OpenPressed();
+	void PathsPressed();
+
+	void PlayPressed();
+	void PausePressed();
+	void StopPressed();
+	void FullScreenPressed();
+	void ScreenShotPressed();
+
+private:
+	void MakeActions();
+	void UpdateIcons();
+
+	QAction* m_open_action;
+	QAction* m_paths_action;
+	QAction* m_play_action;
+	QAction* m_pause_action;
+	QAction* m_stop_action;
+	QAction* m_fullscreen_action;
+	QAction* m_screenshot_action;
+	QAction* m_config_action;
+	QAction* m_graphics_action;
+	QAction* m_controllers_action;
+};


### PR DESCRIPTION
Refactor PR. There was some debate about the search bar, so I got rid of it for now. It's easy to add back in.
* I moved the toolbar into its own file. It's likely a good idea to do this with the menus as well, but I'll do that when I add more to them.
* I split the proxy model into two. Previously I was using an ugly hack to get the same model to work with the icon view and the table view.

Next step: QSettings instead of SConfig for UI settings.