### PR TITLE
Remove incorrect usage of _trans

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -1879,7 +1879,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305::DisplayDisconnectMessage(const int wii
 {
 	// TODO: If someone wants to be fancy we could also figure out what the values for pDiscon->reason mean
 	// and display things like "Wiimote %i disconnected due to inactivity!" etc.
-	Core::DisplayMessage(StringFromFormat(_trans("Wiimote %i disconnected by emulated software"), wiimoteNumber), 3000);
+	Core::DisplayMessage(StringFromFormat("Wiimote %i disconnected by emulated software", wiimoteNumber), 3000);
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305::LOG_LinkKey(const u8* _pLinkKey)


### PR DESCRIPTION
It only marks a string for translation. It doesn't actually do anything at runtime, so the message will always be displayed in English. Even if we would've had a way to make the translation work, we shouldn't translate this, because OSD doesn't support non-ASCII characters.

Caused by the recent merge 1c95cd5.