### PR TITLE
Don't read from volume when reloading Wii banners

### DIFF
--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -90,7 +90,7 @@ public:
 	virtual std::map<ELanguage, std::string> GetNames(bool prefer_long) const = 0;
 	virtual std::map<ELanguage, std::string> GetDescriptions() const { return std::map<ELanguage, std::string>(); }
 	virtual std::string GetCompany() const { return std::string(); }
-	virtual std::vector<u32> GetBanner(int* width, int* height) const;
+	virtual std::vector<u32> GetBanner(int* width, int* height) const = 0;
 	virtual u64 GetFSTSize() const = 0;
 	virtual std::string GetApploaderDate() const = 0;
 	// 0 is the first disc, 1 is the second disc
@@ -107,6 +107,8 @@ public:
 	virtual u64 GetSize() const = 0;
 	// Size on disc (compressed size)
 	virtual u64 GetRawSize() const = 0;
+
+	static std::vector<u32> GetWiiBanner(int* width, int* height, u64 title_id);
 
 protected:
 	template <u32 N>

--- a/Source/Core/DiscIO/VolumeCommon.cpp
+++ b/Source/Core/DiscIO/VolumeCommon.cpp
@@ -24,13 +24,10 @@ static const unsigned int WII_BANNER_HEIGHT = 64;
 static const unsigned int WII_BANNER_SIZE = WII_BANNER_WIDTH * WII_BANNER_HEIGHT * 2;
 static const unsigned int WII_BANNER_OFFSET = 0xA0;
 
-std::vector<u32> IVolume::GetBanner(int* width, int* height) const
+std::vector<u32> IVolume::GetWiiBanner(int* width, int* height, u64 title_id)
 {
 	*width = 0;
 	*height = 0;
-
-	u64 title_id = 0;
-	GetTitleID(&title_id);
 
 	std::string file_name = StringFromFormat("%s/title/%08x/%08x/data/banner.bin",
 		File::GetUserPath(D_WIIROOT_IDX).c_str(), (u32)(title_id >> 32), (u32)title_id);

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -183,7 +183,8 @@ IVolume::ECountry CVolumeDirectory::GetCountry() const
 
 std::string CVolumeDirectory::GetMakerID() const
 {
-	return "VOID";
+	// Not implemented
+	return "00";
 }
 
 std::string CVolumeDirectory::GetInternalName() const
@@ -204,6 +205,14 @@ std::map<IVolume::ELanguage, std::string> CVolumeDirectory::GetNames(bool prefer
 	return names;
 }
 
+std::vector<u32> CVolumeDirectory::GetBanner(int* width, int* height) const
+{
+	// Not implemented
+	*width = 0;
+	*height = 0;
+	return std::vector<u32>();
+}
+
 void CVolumeDirectory::SetName(const std::string& name)
 {
 	size_t length = name.length();
@@ -216,11 +225,13 @@ void CVolumeDirectory::SetName(const std::string& name)
 
 u64 CVolumeDirectory::GetFSTSize() const
 {
+	// Not implemented
 	return 0;
 }
 
 std::string CVolumeDirectory::GetApploaderDate() const
 {
+	// Not implemented
 	return "VOID";
 }
 
@@ -239,12 +250,14 @@ BlobType CVolumeDirectory::GetBlobType() const
 
 u64 CVolumeDirectory::GetSize() const
 {
+	// Not implemented
 	return 0;
 }
 
 u64 CVolumeDirectory::GetRawSize() const
 {
-	return GetSize();
+	// Not implemented
+	return 0;
 }
 
 std::string CVolumeDirectory::ExtractDirectoryName(const std::string& _rDirectory)

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -43,6 +43,7 @@ public:
 	u16 GetRevision() const override { return 0; }
 	std::string GetInternalName() const override;
 	std::map<IVolume::ELanguage, std::string> GetNames(bool prefer_long) const override;
+	std::vector<u32> GetBanner(int* width, int* height) const override;
 	void SetName(const std::string&);
 
 	u64 GetFSTSize() const override;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -127,6 +127,18 @@ std::map<IVolume::ELanguage, std::string> CVolumeWAD::GetNames(bool prefer_long)
 	return ReadWiiNames(name_data);
 }
 
+std::vector<u32> CVolumeWAD::GetBanner(int* width, int* height) const
+{
+	*width = 0;
+	*height = 0;
+
+	u64 title_id;
+	if (!GetTitleID(&title_id))
+		return std::vector<u32>();
+
+	return GetWiiBanner(width, height, title_id);
+}
+
 BlobType CVolumeWAD::GetBlobType() const
 {
 	return m_pReader ? m_pReader->GetBlobType() : BlobType::PLAIN;

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -32,6 +32,7 @@ public:
 	u16 GetRevision() const override;
 	std::string GetInternalName() const override { return ""; }
 	std::map<IVolume::ELanguage, std::string> GetNames(bool prefer_long) const override;
+	std::vector<u32> GetBanner(int* width, int* height) const override;
 	u64 GetFSTSize() const override { return 0; }
 	std::string GetApploaderDate() const override { return ""; }
 

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -212,6 +212,18 @@ std::map<IVolume::ELanguage, std::string> CVolumeWiiCrypted::GetNames(bool prefe
 	return ReadWiiNames(opening_bnr);
 }
 
+std::vector<u32> CVolumeWiiCrypted::GetBanner(int* width, int* height) const
+{
+	*width = 0;
+	*height = 0;
+
+	u64 title_id;
+	if (!GetTitleID(&title_id))
+		return std::vector<u32>();
+
+	return GetWiiBanner(width, height, title_id);
+}
+
 u64 CVolumeWiiCrypted::GetFSTSize() const
 {
 	if (m_pReader == nullptr)

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -32,6 +32,7 @@ public:
 	u16 GetRevision() const override;
 	std::string GetInternalName() const override;
 	std::map<IVolume::ELanguage, std::string> GetNames(bool prefer_long) const override;
+	std::vector<u32> GetBanner(int* width, int* height) const override;
 	u64 GetFSTSize() const override;
 	std::string GetApploaderDate() const override;
 	u8 GetDiscNumber() const override;

--- a/Source/Core/DolphinQt/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt/GameList/GameFile.cpp
@@ -24,7 +24,7 @@
 
 #include "DolphinQt/GameList/GameFile.h"
 
-static const u32 CACHE_REVISION = 0x00D; // Last changed in PR 3097
+static const u32 CACHE_REVISION = 0x00E; // Last changed in PR 3309
 static const u32 DATASTREAM_REVISION = 15; // Introduced in Qt 5.2
 
 static QMap<DiscIO::IVolume::ELanguage, QString> ConvertLocalizedStrings(std::map<DiscIO::IVolume::ELanguage, std::string> strings)
@@ -84,13 +84,11 @@ GameFile::GameFile(const QString& fileName)
 		// if a banner has become available after the cache was made.
 		if (m_banner.isNull())
 		{
-			std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(fileName.toStdString()));
-			if (volume != nullptr)
-			{
-				ReadBanner(*volume);
-				if (!m_banner.isNull())
-					SaveToCache();
-			}
+			int width, height;
+			std::vector<u32> buffer = DiscIO::IVolume::GetWiiBanner(&width, &height, m_title_id);
+			ReadBanner(buffer, width, height);
+			if (!m_banner.isNull())
+				SaveToCache();
 		}
 	}
 	else
@@ -112,10 +110,13 @@ GameFile::GameFile(const QString& fileName)
 			m_volume_size = volume->GetSize();
 
 			m_unique_id = QString::fromStdString(volume->GetUniqueID());
+			volume->GetTitleID(&m_title_id);
 			m_disc_number = volume->GetDiscNumber();
 			m_revision = volume->GetRevision();
 
-			ReadBanner(*volume);
+			int width, height;
+			std::vector<u32> buffer = volume->GetBanner(&width, &height);
+			ReadBanner(buffer, width, height);
 
 			m_valid = true;
 			SaveToCache();
@@ -188,6 +189,7 @@ bool GameFile::LoadFromCache()
 	       >> descriptions
 	       >> m_company
 	       >> m_unique_id
+	       >> m_title_id
 	       >> blob_type
 	       >> m_file_size
 	       >> m_volume_size
@@ -231,6 +233,7 @@ void GameFile::SaveToCache()
 	       << CastLocalizedStrings<u8>(m_descriptions)
 	       << m_company
 	       << m_unique_id
+	       << m_title_id
 	       << (u32)m_blob_type
 	       << m_file_size
 	       << m_volume_size
@@ -267,10 +270,8 @@ QString GameFile::CreateCacheFilename() const
 }
 
 // Outputs to m_banner
-void GameFile::ReadBanner(const DiscIO::IVolume& volume)
+void GameFile::ReadBanner(const std::vector<u32>& buffer, int width, int height)
 {
-	int width, height;
-	std::vector<u32> buffer = volume.GetBanner(&width, &height);
 	QImage banner(width, height, QImage::Format_RGB888);
 	for (int i = 0; i < width * height; i++)
 	{

--- a/Source/Core/DolphinQt/GameList/GameFile.h
+++ b/Source/Core/DolphinQt/GameList/GameFile.h
@@ -64,6 +64,7 @@ private:
 	QString m_company;
 
 	QString m_unique_id;
+	u64 m_title_id;
 
 	QString m_issues;
 	int m_emu_state = 0;
@@ -87,7 +88,7 @@ private:
 	QString CreateCacheFilename() const;
 
 	// Outputs to m_banner
-	void ReadBanner(const DiscIO::IVolume& volume);
+	void ReadBanner(const std::vector<u32>& buffer, int width, int height);
 	// Outputs to m_short_names, m_long_names, m_descriptions, m_company.
 	// Returns whether a file was found, not whether it contained useful data.
 	bool ReadXML(const QString& file_path);

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -65,6 +65,7 @@ private:
 	std::string m_company;
 
 	std::string m_UniqueID;
+	u64 m_title_id;
 
 	std::string m_issues;
 	int m_emu_state;
@@ -95,7 +96,7 @@ private:
 	std::string CreateCacheFilename() const;
 
 	// Outputs to m_pImage
-	void ReadVolumeBanner(const DiscIO::IVolume& volume);
+	void ReadVolumeBanner(const std::vector<u32>& buffer, int width, int height);
 	// Outputs to m_Bitmap
 	bool ReadPNGBanner(const std::string& path);
 


### PR DESCRIPTION
Should make loading cached Wii games that lack banners slightly faster.

@Kolano Please test the speed of this when a cache is present. Switching between this PR and current versions of master will clear the cache, so open Dolphin, wait until the game list finishes loading, then press Refresh.