### PR TITLE
VideoSW: Clear Vertex data before usage

### DIFF
--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -34,6 +34,8 @@ SWVertexLoader::~SWVertexLoader()
 
 void SWVertexLoader::SetFormat(u8 attributeIndex, u8 primitiveType)
 {
+	memset(&m_Vertex, 0, sizeof(m_Vertex));
+
 	m_attributeIndex = attributeIndex;
 
 	VertexLoaderUID uid(g_main_cp_state.vtx_desc, g_main_cp_state.vtx_attr[m_attributeIndex]);

--- a/Source/Core/VideoBackends/Software/SetupUnit.cpp
+++ b/Source/Core/VideoBackends/Software/SetupUnit.cpp
@@ -21,6 +21,12 @@ void SetupUnit::Init(u8 primitiveType)
 	m_VertWritePointer = m_VertPointer[0];
 }
 
+OutputVertexData* SetupUnit::GetVertex()
+{
+	memset(m_VertWritePointer, 0, sizeof(*m_VertWritePointer));
+	return m_VertWritePointer;
+}
+
 void SetupUnit::SetupVertex()
 {
 	switch (m_PrimType)

--- a/Source/Core/VideoBackends/Software/SetupUnit.h
+++ b/Source/Core/VideoBackends/Software/SetupUnit.h
@@ -29,7 +29,7 @@ class SetupUnit
 public:
 	void Init(u8 primitiveType);
 
-	OutputVertexData* GetVertex() { return m_VertWritePointer; }
+	OutputVertexData* GetVertex();
 
 	void SetupVertex();
 	void DoState(PointerWrap &p);


### PR DESCRIPTION
This must have no effect, everything else is usage of uninitialized memory.