### PR TITLE
DiscIO: Make factory methods return unique_ptrs

### DIFF
--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -429,14 +429,14 @@ const DiscIO::IVolume& GetVolume()
 bool SetVolumeName(const std::string& disc_path)
 {
 	DVDThread::WaitUntilIdle();
-	s_inserted_volume = std::unique_ptr<DiscIO::IVolume>(DiscIO::CreateVolumeFromFilename(disc_path));
+	s_inserted_volume = DiscIO::CreateVolumeFromFilename(disc_path);
 	return VolumeIsValid();
 }
 
 bool SetVolumeDirectory(const std::string& full_path, bool is_wii, const std::string& apploader_path, const std::string& DOL_path)
 {
 	DVDThread::WaitUntilIdle();
-	s_inserted_volume = std::unique_ptr<DiscIO::IVolume>(DiscIO::CreateVolumeFromDirectory(full_path, is_wii, apploader_path, DOL_path));
+	s_inserted_volume = DiscIO::CreateVolumeFromDirectory(full_path, is_wii, apploader_path, DOL_path);
 	return VolumeIsValid();
 }
 

--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <memory>
 #include <string>
 
 #include "Common/CDUtils.h"
@@ -114,7 +115,7 @@ bool SectorReader::ReadMultipleAlignedBlocks(u64 block_num, u64 num_blocks, u8 *
 	return true;
 }
 
-IBlobReader* CreateBlobReader(const std::string& filename)
+std::unique_ptr<IBlobReader> CreateBlobReader(const std::string& filename)
 {
 	if (cdio_is_cdrom(filename))
 		return DriveReader::Create(filename);

--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -14,6 +14,7 @@
 // detect whether the file is a compressed blob, or just a big hunk of data, or a drive, and
 // automatically do the right thing.
 
+#include <memory>
 #include <string>
 #include "Common/CommonTypes.h"
 
@@ -75,7 +76,7 @@ private:
 };
 
 // Factory function - examines the path to choose the right type of IBlobReader, and returns one.
-IBlobReader* CreateBlobReader(const std::string& filename);
+std::unique_ptr<IBlobReader> CreateBlobReader(const std::string& filename);
 
 typedef bool (*CompressCB)(const std::string& text, float percent, void* arg);
 

--- a/Source/Core/DiscIO/CISOBlob.cpp
+++ b/Source/Core/DiscIO/CISOBlob.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <memory>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
@@ -29,17 +30,15 @@ CISOFileReader::CISOFileReader(std::FILE* file)
 		m_ciso_map[idx] = (1 == header.map[idx]) ? count++ : UNUSED_BLOCK_ID;
 }
 
-CISOFileReader* CISOFileReader::Create(const std::string& filename)
+std::unique_ptr<CISOFileReader> CISOFileReader::Create(const std::string& filename)
 {
 	if (IsCISOBlob(filename))
 	{
 		File::IOFile f(filename, "rb");
-		return new CISOFileReader(f.ReleaseHandle());
+		return std::unique_ptr<CISOFileReader>(new CISOFileReader(f.ReleaseHandle()));
 	}
-	else
-	{
-		return nullptr;
-	}
+
+	return nullptr;
 }
 
 u64 CISOFileReader::GetDataSize() const

--- a/Source/Core/DiscIO/CISOBlob.h
+++ b/Source/Core/DiscIO/CISOBlob.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdio>
+#include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -34,7 +35,7 @@ struct CISOHeader
 class CISOFileReader : public IBlobReader
 {
 public:
-	static CISOFileReader* Create(const std::string& filename);
+	static std::unique_ptr<CISOFileReader> Create(const std::string& filename);
 
 	BlobType GetBlobType() const override { return BlobType::CISO; }
 

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -55,12 +55,12 @@ CompressedBlobReader::CompressedBlobReader(const std::string& filename) : m_file
 	memset(m_zlib_buffer, 0, m_zlib_buffer_size);
 }
 
-CompressedBlobReader* CompressedBlobReader::Create(const std::string& filename)
+std::unique_ptr<CompressedBlobReader> CompressedBlobReader::Create(const std::string& filename)
 {
 	if (IsGCZBlob(filename))
-		return new CompressedBlobReader(filename);
-	else
-		return nullptr;
+		return std::unique_ptr<CompressedBlobReader>(new CompressedBlobReader(filename));
+
+	return nullptr;
 }
 
 CompressedBlobReader::~CompressedBlobReader()

--- a/Source/Core/DiscIO/CompressedBlob.h
+++ b/Source/Core/DiscIO/CompressedBlob.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -46,7 +47,7 @@ struct CompressedBlobHeader // 32 bytes
 class CompressedBlobReader : public SectorReader
 {
 public:
-	static CompressedBlobReader* Create(const std::string& filename);
+	static std::unique_ptr<CompressedBlobReader> Create(const std::string& filename);
 	~CompressedBlobReader();
 	const CompressedBlobHeader &GetHeader() const { return m_header; }
 	BlobType GetBlobType() const override { return BlobType::GCZ; }

--- a/Source/Core/DiscIO/DriveBlob.cpp
+++ b/Source/Core/DiscIO/DriveBlob.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -84,15 +85,12 @@ DriveReader::~DriveReader()
 #endif
 }
 
-DriveReader* DriveReader::Create(const std::string& drive)
+std::unique_ptr<DriveReader> DriveReader::Create(const std::string& drive)
 {
-	DriveReader* reader = new DriveReader(drive);
+	auto reader = std::unique_ptr<DriveReader>(new DriveReader(drive));
 
 	if (!reader->IsOK())
-	{
-		delete reader;
-		return nullptr;
-	}
+		reader.reset();
 
 	return reader;
 }

--- a/Source/Core/DiscIO/DriveBlob.h
+++ b/Source/Core/DiscIO/DriveBlob.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -21,7 +22,7 @@ namespace DiscIO
 class DriveReader : public SectorReader
 {
 public:
-	static DriveReader* Create(const std::string& drive);
+	static std::unique_ptr<DriveReader> Create(const std::string& drive);
 	~DriveReader();
 	BlobType GetBlobType() const override { return BlobType::DRIVE; }
 	u64 GetDataSize() const override { return m_size; }

--- a/Source/Core/DiscIO/FileBlob.cpp
+++ b/Source/Core/DiscIO/FileBlob.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <memory>
 #include <string>
 #include "DiscIO/FileBlob.h"
 
@@ -14,13 +15,13 @@ PlainFileReader::PlainFileReader(std::FILE* file)
 	m_size = m_file.GetSize();
 }
 
-PlainFileReader* PlainFileReader::Create(const std::string& filename)
+std::unique_ptr<PlainFileReader> PlainFileReader::Create(const std::string& filename)
 {
 	File::IOFile f(filename, "rb");
 	if (f)
-		return new PlainFileReader(f.ReleaseHandle());
-	else
-		return nullptr;
+		return std::unique_ptr<PlainFileReader>(new PlainFileReader(f.ReleaseHandle()));
+
+	return nullptr;
 }
 
 bool PlainFileReader::Read(u64 offset, u64 nbytes, u8* out_ptr)

--- a/Source/Core/DiscIO/FileBlob.h
+++ b/Source/Core/DiscIO/FileBlob.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdio>
+#include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -17,7 +18,7 @@ namespace DiscIO
 class PlainFileReader : public IBlobReader
 {
 public:
-	static PlainFileReader* Create(const std::string& filename);
+	static std::unique_ptr<PlainFileReader> Create(const std::string& filename);
 
 	BlobType GetBlobType() const override { return BlobType::PLAIN; }
 	u64 GetDataSize() const override { return m_size; }

--- a/Source/Core/DiscIO/Filesystem.cpp
+++ b/Source/Core/DiscIO/Filesystem.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <memory>
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/FileSystemGCWii.h"
 
@@ -17,20 +18,17 @@ IFileSystem::~IFileSystem()
 {}
 
 
-IFileSystem* CreateFileSystem(const IVolume* _rVolume)
+std::unique_ptr<IFileSystem> CreateFileSystem(const IVolume* volume)
 {
-	IFileSystem* pFileSystem = new CFileSystemGCWii(_rVolume);
+	std::unique_ptr<IFileSystem> filesystem = std::make_unique<CFileSystemGCWii>(volume);
 
-	if (!pFileSystem)
+	if (!filesystem)
 		return nullptr;
 
-	if (!pFileSystem->IsValid())
-	{
-		delete pFileSystem;
-		pFileSystem = nullptr;
-	}
+	if (!filesystem->IsValid())
+		filesystem.reset();
 
-	return pFileSystem;
+	return filesystem;
 }
 
 } // namespace

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -57,6 +56,6 @@ protected:
 	const IVolume *m_rVolume;
 };
 
-IFileSystem* CreateFileSystem(const IVolume *_rVolume);
+std::unique_ptr<IFileSystem> CreateFileSystem(const IVolume* volume);
 
 } // namespace

--- a/Source/Core/DiscIO/VolumeCreator.cpp
+++ b/Source/Core/DiscIO/VolumeCreator.cpp
@@ -71,12 +71,12 @@ static const unsigned char s_master_key_korean[16] = {
 	0x13,0xf2,0xfe,0xfb,0xba,0x4c,0x9b,0x7e
 };
 
-static IVolume* CreateVolumeFromCryptedWiiImage(std::unique_ptr<IBlobReader> reader, u32 _PartitionGroup, u32 _VolumeType, u32 _VolumeNum);
+static std::unique_ptr<IVolume> CreateVolumeFromCryptedWiiImage(std::unique_ptr<IBlobReader> reader, u32 partition_group, u32 volume_type, u32 volume_number);
 EDiscType GetDiscType(IBlobReader& _rReader);
 
-IVolume* CreateVolumeFromFilename(const std::string& _rFilename, u32 _PartitionGroup, u32 _VolumeNum)
+std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename, u32 partition_group, u32 volume_number)
 {
-	std::unique_ptr<IBlobReader> reader(CreateBlobReader(_rFilename));
+	std::unique_ptr<IBlobReader> reader(CreateBlobReader(filename));
 	if (reader == nullptr)
 		return nullptr;
 
@@ -84,30 +84,30 @@ IVolume* CreateVolumeFromFilename(const std::string& _rFilename, u32 _PartitionG
 	{
 		case DISC_TYPE_WII:
 		case DISC_TYPE_GC:
-			return new CVolumeGC(std::move(reader));
+			return std::make_unique<CVolumeGC>(std::move(reader));
 
 		case DISC_TYPE_WAD:
-			return new CVolumeWAD(std::move(reader));
+			return std::make_unique<CVolumeWAD>(std::move(reader));
 
 		case DISC_TYPE_WII_CONTAINER:
-			return CreateVolumeFromCryptedWiiImage(std::move(reader), _PartitionGroup, 0, _VolumeNum);
+			return CreateVolumeFromCryptedWiiImage(std::move(reader), partition_group, 0, volume_number);
 
 		case DISC_TYPE_UNK:
 		default:
-			std::string Filename, ext;
-			SplitPath(_rFilename, nullptr, &Filename, &ext);
-			Filename += ext;
+			std::string name, extension;
+			SplitPath(filename, nullptr, &name, &extension);
+			name += extension;
 			NOTICE_LOG(DISCIO, "%s does not have the Magic word for a gcm, wiidisc or wad file\n"
-						"Set Log Verbosity to Warning and attempt to load the game again to view the values", Filename.c_str());
+						"Set Log Verbosity to Warning and attempt to load the game again to view the values", name.c_str());
 	}
 
 	return nullptr;
 }
 
-IVolume* CreateVolumeFromDirectory(const std::string& _rDirectory, bool _bIsWii, const std::string& _rApploader, const std::string& _rDOL)
+std::unique_ptr<IVolume> CreateVolumeFromDirectory(const std::string& directory, bool is_wii, const std::string& apploader, const std::string& dol)
 {
-	if (CVolumeDirectory::IsValidDirectory(_rDirectory))
-		return new CVolumeDirectory(_rDirectory, _bIsWii, _rApploader, _rDOL);
+	if (CVolumeDirectory::IsValidDirectory(directory))
+		return std::make_unique<CVolumeDirectory>(directory, is_wii, apploader, dol);
 
 	return nullptr;
 }
@@ -137,55 +137,55 @@ void VolumeKeyForPartition(IBlobReader& _rReader, u64 offset, u8* VolumeKey)
 	mbedtls_aes_crypt_cbc(&AES_ctx, MBEDTLS_AES_DECRYPT, 16, IV, SubKey, VolumeKey);
 }
 
-static IVolume* CreateVolumeFromCryptedWiiImage(std::unique_ptr<IBlobReader> reader, u32 _PartitionGroup, u32 _VolumeType, u32 _VolumeNum)
+static std::unique_ptr<IVolume> CreateVolumeFromCryptedWiiImage(std::unique_ptr<IBlobReader> reader, u32 partition_group, u32 volume_type, u32 volume_number)
 {
 	CBlobBigEndianReader big_endian_reader(*reader);
 
-	u32 numPartitions = big_endian_reader.Read32(0x40000 + (_PartitionGroup * 8));
-	u64 PartitionsOffset = (u64)big_endian_reader.Read32(0x40000 + (_PartitionGroup * 8) + 4) << 2;
+	u32 numPartitions = big_endian_reader.Read32(0x40000 + (partition_group * 8));
+	u64 PartitionsOffset = (u64)big_endian_reader.Read32(0x40000 + (partition_group * 8) + 4) << 2;
 
 	// Check if we're looking for a valid partition
-	if ((int)_VolumeNum != -1 && _VolumeNum > numPartitions)
+	if ((int)volume_number != -1 && volume_number > numPartitions)
 		return nullptr;
 
 	struct SPartition
 	{
-		u64 Offset;
-		u32 Type;
+		u64 offset;
+		u32 type;
 	};
 
 	struct SPartitionGroup
 	{
-		u32 numPartitions;
-		u64 PartitionsOffset;
-		std::vector<SPartition> PartitionsVec;
+		u32 num_partitions;
+		u64 partitions_offset;
+		std::vector<SPartition> partitions;
 	};
-	SPartitionGroup PartitionGroup[4];
+	SPartitionGroup partition_groups[4];
 
 	// Read all partitions
-	for (SPartitionGroup& group : PartitionGroup)
+	for (SPartitionGroup& group : partition_groups)
 	{
 		for (u32 i = 0; i < numPartitions; i++)
 		{
-			SPartition Partition;
-			Partition.Offset = ((u64)big_endian_reader.Read32(PartitionsOffset + (i * 8) + 0)) << 2;
-			Partition.Type   = big_endian_reader.Read32(PartitionsOffset + (i * 8) + 4);
-			group.PartitionsVec.push_back(Partition);
+			SPartition partition;
+			partition.offset = ((u64)big_endian_reader.Read32(PartitionsOffset + (i * 8) + 0)) << 2;
+			partition.type   = big_endian_reader.Read32(PartitionsOffset + (i * 8) + 4);
+			group.partitions.push_back(partition);
 		}
 	}
 
 	// Return the partition type specified or number
 	// types: 0 = game, 1 = firmware update, 2 = channel installer
 	//  some partitions on SSBB use the ASCII title id of the demo VC game they hold...
-	for (size_t i = 0; i < PartitionGroup[_PartitionGroup].PartitionsVec.size(); i++)
+	for (size_t i = 0; i < partition_groups[partition_group].partitions.size(); i++)
 	{
-		const SPartition& rPartition = PartitionGroup[_PartitionGroup].PartitionsVec.at(i);
+		const SPartition& partition = partition_groups[partition_group].partitions.at(i);
 
-		if ((rPartition.Type == _VolumeType && (int)_VolumeNum == -1) || i == _VolumeNum)
+		if ((partition.type == volume_type && (int)volume_number == -1) || i == volume_number)
 		{
-			u8 VolumeKey[16];
-			VolumeKeyForPartition(*reader, rPartition.Offset, VolumeKey);
-			return new CVolumeWiiCrypted(std::move(reader), rPartition.Offset, VolumeKey);
+			u8 volume_key[16];
+			VolumeKeyForPartition(*reader, partition.offset, volume_key);
+			return std::make_unique<CVolumeWiiCrypted>(std::move(reader), partition.offset, volume_key);
 		}
 	}
 

--- a/Source/Core/DiscIO/VolumeCreator.h
+++ b/Source/Core/DiscIO/VolumeCreator.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -14,8 +15,8 @@ namespace DiscIO
 class IVolume;
 class IBlobReader;
 
-IVolume* CreateVolumeFromFilename(const std::string& _rFilename, u32 _PartitionGroup = 0, u32 _VolumeNum = -1);
-IVolume* CreateVolumeFromDirectory(const std::string& _rDirectory, bool _bIsWii, const std::string& _rApploader = "", const std::string& _rDOL = "");
+std::unique_ptr<IVolume> CreateVolumeFromFilename(const std::string& filename, u32 partition_group = 0, u32 volume_number = -1);
+std::unique_ptr<IVolume> CreateVolumeFromDirectory(const std::string& directory, bool is_wii, const std::string& apploader = "", const std::string& dol = "");
 void VolumeKeyForPartition(IBlobReader& _rReader, u64 offset, u8* VolumeKey);
 
 } // namespace

--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -167,19 +168,14 @@ File::IOFile& WbfsFileReader::SeekToCluster(u64 offset, u64* available)
 	return m_files[0]->file;
 }
 
-WbfsFileReader* WbfsFileReader::Create(const std::string& filename)
+std::unique_ptr<WbfsFileReader> WbfsFileReader::Create(const std::string& filename)
 {
-	WbfsFileReader* reader = new WbfsFileReader(filename);
+	auto reader = std::unique_ptr<WbfsFileReader>(new WbfsFileReader(filename));
 
-	if (reader->IsGood())
-	{
-		return reader;
-	}
-	else
-	{
-		delete reader;
-		return nullptr;
-	}
+	if (!reader->IsGood())
+		reader.reset();
+
+	return reader;
 }
 
 bool IsWbfsBlob(const std::string& filename)

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -17,7 +18,9 @@ namespace DiscIO
 class WbfsFileReader : public IBlobReader
 {
 public:
-	static WbfsFileReader* Create(const std::string& filename);
+	~WbfsFileReader();
+
+	static std::unique_ptr<WbfsFileReader> Create(const std::string& filename);
 
 	BlobType GetBlobType() const override { return BlobType::WBFS; }
 
@@ -31,7 +34,6 @@ public:
 
 private:
 	WbfsFileReader(const std::string& filename);
-	~WbfsFileReader();
 
 	bool OpenFiles(const std::string& filename);
 	bool ReadHeader();

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -80,8 +80,8 @@ public:
 private:
 	DECLARE_EVENT_TABLE();
 
-	DiscIO::IVolume *OpenISO;
-	DiscIO::IFileSystem *pFileSystem;
+	std::unique_ptr<DiscIO::IVolume> m_open_iso;
+	std::unique_ptr<DiscIO::IFileSystem> m_filesystem;
 
 	std::vector<PatchEngine::Patch> onFrame;
 	std::vector<ActionReplay::ARCode> arCodes;

--- a/Source/Core/DolphinWX/MainAndroid.cpp
+++ b/Source/Core/DolphinWX/MainAndroid.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <jni.h>
+#include <memory>
 #include <android/log.h>
 #include <android/native_window_jni.h>
 #include <EGL/egl.h>
@@ -261,11 +262,11 @@ static std::string GetDescription(std::string filename)
 {
 	__android_log_print(ANDROID_LOG_WARN, DOLPHIN_TAG, "Getting Description for file: %s", filename.c_str());
 
-	DiscIO::IVolume* pVolume = DiscIO::CreateVolumeFromFilename(filename);
+	std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(filename));
 
-	if (pVolume != nullptr)
+	if (volume != nullptr)
 	{
-		std::map <DiscIO::IVolume::ELanguage, std::string> descriptions = pVolume->GetDescriptions();
+		std::map<DiscIO::IVolume::ELanguage, std::string> descriptions = volume->GetDescriptions();
 
 		/*
 		bool is_wii_title = pVolume->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;
@@ -289,53 +290,44 @@ static std::string GetDescription(std::string filename)
 			return descriptions.cbegin()->second;
 	}
 
-	return std::string ("");
+	return std::string();
 }
 
 static std::string GetGameId(std::string filename)
 {
 	__android_log_print(ANDROID_LOG_WARN, DOLPHIN_TAG, "Getting ID for file: %s", filename.c_str());
 
-	DiscIO::IVolume* pVolume = DiscIO::CreateVolumeFromFilename(filename);
-	if (pVolume != nullptr)
-	{
-		std::string id = pVolume->GetUniqueID();
-		__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Game ID: %s", id.c_str());
+	std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(filename));
+	if (volume == nullptr)
+		return std::string();
 
-		return id;
-	}
-	return std::string ("");
+	std::string id = volume->GetUniqueID();
+	__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Game ID: %s", id.c_str());
+	return id;
 }
 
 static std::string GetCompany(std::string filename)
 {
 	__android_log_print(ANDROID_LOG_WARN, DOLPHIN_TAG, "Getting Company for file: %s", filename.c_str());
 
-	DiscIO::IVolume* pVolume = DiscIO::CreateVolumeFromFilename(filename);
-	if (pVolume != nullptr)
-	{
-		std::string company = DiscIO::GetCompanyFromID(pVolume->GetMakerID());
-		__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Company: %s", company.c_str());
-		return company;
-	}
-	return std::string ("");
+	std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(filename));
+	if (volume == nullptr)
+		return std::string();
+
+	std::string company = DiscIO::GetCompanyFromID(volume->GetMakerID());
+	__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Company: %s", company.c_str());
+	return company;
 }
 
 static u64 GetFileSize(std::string filename)
 {
 	__android_log_print(ANDROID_LOG_WARN, DOLPHIN_TAG, "Getting size of file: %s", filename.c_str());
 
-	DiscIO::IVolume* pVolume = DiscIO::CreateVolumeFromFilename(filename);
-	if (pVolume != nullptr)
-	{
-		u64 size = pVolume->GetSize();
-		// Causes a warning because size is u64, not 'long unsigned'
-		//__android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Size: %lu", size);
+	std::unique_ptr<DiscIO::IVolume> volume(DiscIO::CreateVolumeFromFilename(filename));
+	if (volume == nullptr)
+		return -1;
 
-		return  size;
-	}
-
-	return -1;
+	return volume->GetSize();
 }
 
 static std::string GetJString(JNIEnv *env, jstring jstr)


### PR DESCRIPTION
Rather than rely on the developer to do the right thing, just make the default behavior safely deallocate resources.

If shared semantics are ever needed in the future, the constructor that takes a unique_ptr for shared_ptr can be used in conjunction with these functions.

This also fixes a few leaks on Android.