### PR TITLE
Interpreter: Update CR when FRSP's record bit is set

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -280,6 +280,9 @@ void Interpreter::frspx(UGeckoInstruction inst)  // round to single
 	FPSCR.FR = fabs(rounded) > fabs(b);
 	UpdateFPRF(rounded);
 	rPS0(inst.FD) = rPS1(inst.FD) = rounded;
+
+	if (inst.Rc)
+		Helper_UpdateCR1();
 }
 
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_FloatingPoint.cpp
@@ -272,15 +272,14 @@ void Interpreter::fselx(UGeckoInstruction _inst)
 // !!! warning !!!
 // PS1 must be set to the value of PS0 or DragonballZ will be f**ked up
 // PS1 is said to be undefined
-void Interpreter::frspx(UGeckoInstruction _inst)  // round to single
+void Interpreter::frspx(UGeckoInstruction inst)  // round to single
 {
-	double b = rPS0(_inst.FB);
+	double b = rPS0(inst.FB);
 	double rounded = ForceSingle(b);
 	SetFI(b != rounded);
 	FPSCR.FR = fabs(rounded) > fabs(b);
 	UpdateFPRF(rounded);
-	rPS0(_inst.FD) = rPS1(_inst.FD) = rounded;
-	return;
+	rPS0(inst.FD) = rPS1(inst.FD) = rounded;
 }
 
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -609,6 +609,7 @@ void Jit64::frspx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
+	FALLBACK_IF(inst.Rc);
 	int b = inst.FB;
 	int d = inst.FD;
 	bool packed = jit->js.op->fprIsDuplicated[b] && !cpu_info.bAtom;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -329,6 +329,7 @@ void JitArm64::frspx(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
+	FALLBACK_IF(inst.Rc);
 
 	u32 b = inst.FB, d = inst.FD;
 


### PR DESCRIPTION
Checked using my tests [here](https://github.com/lioncash/DolphinPPCTests)