### PR TITLE
DolphinWX: Fix label change for the play/pause button

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1792,17 +1792,19 @@ void CFrame::UpdateGUI()
 
 		if (PlayTool)
 		{
+			int position = m_ToolBar->GetToolPos(IDM_PLAY);
+
 			if (Running)
 			{
-				PlayTool->SetLabel(_("Pause"));
-				PlayTool->SetShortHelp(_("Pause"));
-				m_ToolBar->SetToolNormalBitmap(IDM_PLAY, m_Bitmaps[Toolbar_Pause]);
+				m_ToolBar->DeleteTool(IDM_PLAY);
+				m_ToolBar->InsertTool(position, IDM_PLAY, _("Pause"), m_Bitmaps[Toolbar_Pause],
+				                      wxNullBitmap, wxITEM_NORMAL, _("Pause"));
 			}
 			else
 			{
-				PlayTool->SetLabel(_("Play"));
-				PlayTool->SetShortHelp(_("Play"));
-				m_ToolBar->SetToolNormalBitmap(IDM_PLAY, m_Bitmaps[Toolbar_Play]);
+				m_ToolBar->DeleteTool(IDM_PLAY);
+				m_ToolBar->InsertTool(position, IDM_PLAY, _("Play"), m_Bitmaps[Toolbar_Play],
+				                      wxNullBitmap, wxITEM_NORMAL, _("Play"));
 			}
 		}
 	}


### PR DESCRIPTION
This fixes changing the play/pause button's label depending on the
emulation state. Before, wxToolBarToolBase's SetLabel() function was
used. This function, however, is not implemented in wxGTK which leads to
the label not changing on linux when the button is clicked. Although the preferred
method (according to the wxWidgets documentation) to change the properties
of a tool is to use the toolbar's setters, there is no such setter for
the label. Therefore, this implements a workaround where the
button is deleted and readded afterwards with the updated properties.

Thanks to linkmauve for noticing this!