### PR TITLE
[GameINI] Disable Fast Depth Calculation for Donkey Kong Country Returns

### DIFF
--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -18,6 +18,7 @@ EmulationIssues = Sound crackling can be fixed by lle audio.
 # Add action replay cheats here.
 
 [Video_Settings]
+FastDepthCalc = False
 SafeTextureCacheColorSamples = 512
 
 [Video_Stereoscopy]


### PR DESCRIPTION
Fast Depth causes Z-Order issues in various places on Donkey Kong Country Returns, look at the example below:

With Fast Depth (broken):
![DKCR_Z-Order_broken.png](https://wiki.dolphin-emu.org/images/0/0d/DKCR_Z-Order_broken.png)

Without Fast Depth (proper):
![DKCR_Z-Order_proper.png](https://wiki.dolphin-emu.org/images/1/1d/DKCR_Z-Order_proper.png)
