### PR TITLE
Core: Fix build with portaudio enabled and pch disabled

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMic.cpp
@@ -7,6 +7,8 @@
 
 #if HAVE_PORTAUDIO
 
+#include <cstring>
+
 #include "Core/CoreTiming.h"
 #include "Core/HW/EXI.h"
 #include "Core/HW/EXI_Device.h"
@@ -121,7 +123,7 @@ void CEXIMic::StreamReadOne()
 	if (samples_avail >= buff_size_samples)
 	{
 		s16 *last_buffer = &stream_buffer[stream_rpos];
-		memcpy(ring_buffer, last_buffer, buff_size);
+		std::memcpy(ring_buffer, last_buffer, buff_size);
 
 		samples_avail -= buff_size_samples;
 
@@ -151,7 +153,7 @@ CEXIMic::CEXIMic(int index)
 	buff_size_samples = buff_size / sample_size;
 
 	ring_pos = 0;
-	memset(ring_buffer, 0, sizeof(ring_buffer));
+	std::memset(ring_buffer, 0, sizeof(ring_buffer));
 
 	next_int_ticks = 0;
 


### PR DESCRIPTION
Includes cstring in EXI_DeviceMic.cpp to fix the undeclared function
errors for memset and memcpy when building with portaudio enabled and
pch disabled.

Thanks to David Brooke for noticing this!