### PR TITLE
DolphinWX: Fix items vanishing from toolbar

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1804,6 +1804,7 @@ void CFrame::UpdateGUI()
 				m_ToolBar->InsertTool(position, IDM_PLAY, _("Play"), m_Bitmaps[Toolbar_Play],
 				                      wxNullBitmap, wxITEM_NORMAL, _("Play"));
 			}
+			m_ToolBar->Realize();
 		}
 	}
 


### PR DESCRIPTION
Commit 33487ab5f20309e33b4734dbea9201b5b0d893a2 introduced a regression
where items would vanish from the toolbar, that means that after a while -- probably after clicking the play/pause button a few times -- only Open, Refresh and Browse remain in the toolbar with the rest of it being empty. I assume the missing call to Realize(), which is required as per the wxWidgets documentation, after the reinsertions of the play/pause button is the culprit. Unfortunately, I cannot reproduce the issue as it seems to not show on every OS and I can only test on Linux. It would be great if someone with access to Windows and/or Mac OS X could test whether this really fixes the issue.

Edit: https://bugs.dolphin-emu.org/issues/9161 describes the issue including a video and steps to reproduce.