### PR TITLE
DolphinWX: Change "AM-Baseboard" string to "AM Baseboard"

### DIFF
--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -51,7 +51,7 @@ ControllerConfigDiag::ControllerConfigDiag(wxWindow* const parent)
 		_("TaruKonga (Bongos)"),
 		_("GBA"),
 		_("Keyboard"),
-		_("AM-Baseboard")
+		_("AM Baseboard")
 	}};
 
 	wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);


### PR DESCRIPTION
It's so that the string in ControllerConfigDiag will match the string in GameCubeConfigPane. Right now, it unnecessarily appears twice in the list of strings to translate.