### PR TITLE
VideoConfig: Move all stereoscopy options to the stereoscopy section.

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/UserPreferences.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/UserPreferences.java
@@ -66,10 +66,10 @@ public final class UserPreferences
 		editor.putBoolean("disableFog",            getConfig("gfx_opengl.ini", "Settings", "DisableFog", "False").equals("True"));
 		editor.putBoolean("skipEFBAccess",         getConfig("gfx_opengl.ini", "Hacks", "EFBAccessEnable", "False").equals("True"));
 		editor.putBoolean("ignoreFormatChanges",   getConfig("gfx_opengl.ini", "Hacks", "EFBEmulateFormatChanges", "False").equals("True"));
-		editor.putString("stereoscopyMode",        getConfig("gfx_opengl.ini", "Enhancements", "StereoMode", "0"));
-		editor.putBoolean("stereoSwapEyes",        getConfig("gfx_opengl.ini", "Enhancements", "StereoSwapEyes", "False").equals("True"));
-		editor.putString("stereoDepth",            getConfig("gfx_opengl.ini", "Enhancements", "StereoDepth", "20"));
-		editor.putString("stereoConvergence",      getConfig("gfx_opengl.ini", "Enhancements", "StereoConvergence", "20"));
+		editor.putString("stereoscopyMode",        getConfig("gfx_opengl.ini", "Stereoscopy", "StereoMode", "0"));
+		editor.putBoolean("stereoSwapEyes",        getConfig("gfx_opengl.ini", "Stereoscopy", "StereoSwapEyes", "False").equals("True"));
+		editor.putString("stereoDepth",            getConfig("gfx_opengl.ini", "Stereoscopy", "StereoDepth", "20"));
+		editor.putString("stereoConvergencePercentage", getConfig("gfx_opengl.ini", "Stereoscopy", "StereoConvergencePercentage", "100"));
 		editor.putBoolean("enableController1",     getConfig("Dolphin.ini", "Settings", "SIDevice0", "6") == "6");
 		editor.putBoolean("enableController2",     getConfig("Dolphin.ini", "Settings", "SIDevice1", "0") == "6");
 		editor.putBoolean("enableController3",     getConfig("Dolphin.ini", "Settings", "SIDevice2", "0") == "6");
@@ -212,7 +212,7 @@ public final class UserPreferences
 		String stereoscopySeparation = prefs.getString("stereoDepth", "20");
 
 		// Stereoscopy convergence
-		String stereoscopyConvergence = prefs.getString("stereoConvergence", "20");
+		String stereoConvergencePercentage = prefs.getString("stereoConvergencePercentage", "100");
 
 		// Controllers
 		// Controller 1 never gets disconnected due to touch screen
@@ -224,7 +224,7 @@ public final class UserPreferences
 		// CPU related Settings
 		NativeLibrary.SetConfig("Dolphin.ini", "Core", "CPUCore", currentEmuCore);
 		NativeLibrary.SetConfig("Dolphin.ini", "Core", "CPUThread", isUsingDualCore ? "True" : "False");
-		
+
 		// Wiimote Extension Settings
 		NativeLibrary.SetConfig("WiimoteNew.ini", "Wiimote1", "Extension", WiimoteExtension_4);
 		NativeLibrary.SetConfig("WiimoteNew.ini", "Wiimote2", "Extension", WiimoteExtension_5);
@@ -294,10 +294,10 @@ public final class UserPreferences
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Settings", "EnablePixelLighting", usingPerPixelLighting ? "True" : "False");
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Enhancements", "ForceFiltering", isForcingTextureFiltering ? "True" : "False");
 		NativeLibrary.SetConfig("gfx_opengl.ini", "Settings", "DisableFog", fogIsDisabled ? "True" : "False");
-		NativeLibrary.SetConfig("gfx_opengl.ini", "Enhancements", "StereoMode", stereoscopyMode);
-		NativeLibrary.SetConfig("gfx_opengl.ini", "Enhancements", "StereoSwapEyes", stereoscopyEyeSwap ? "True" : "False");
-		NativeLibrary.SetConfig("gfx_opengl.ini", "Enhancements", "StereoDepth", stereoscopySeparation);
-		NativeLibrary.SetConfig("gfx_opengl.ini", "Enhancements", "StereoConvergence", stereoscopyConvergence);
+		NativeLibrary.SetConfig("gfx_opengl.ini", "Stereoscopy", "StereoMode", stereoscopyMode);
+		NativeLibrary.SetConfig("gfx_opengl.ini", "Stereoscopy", "StereoSwapEyes", stereoscopyEyeSwap ? "True" : "False");
+		NativeLibrary.SetConfig("gfx_opengl.ini", "Stereoscopy", "StereoDepth", stereoscopySeparation);
+		NativeLibrary.SetConfig("gfx_opengl.ini", "Stereoscopy", "StereoConvergence", stereoConvergencePercentage);
 		NativeLibrary.SetConfig("Dolphin.ini", "Settings", "SIDevice0", "6");
 		NativeLibrary.SetConfig("Dolphin.ini", "Settings", "SIDevice1", enableController2 ? "6" : "0");
 		NativeLibrary.SetConfig("Dolphin.ini", "Settings", "SIDevice2", enableController3 ? "6" : "0");

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -357,13 +357,13 @@ void CISOProperties::CreateGUIControls()
 	sDepthPercentage->Add(DepthPercentageText);
 	sDepthPercentage->Add(DepthPercentage);
 
-	wxBoxSizer* const sConvergenceMinimum = new wxBoxSizer(wxHORIZONTAL);
-	wxStaticText* const ConvergenceMinimumText = new wxStaticText(m_GameConfig, wxID_ANY, _("Convergence Minimum: "));
-	ConvergenceMinimum = new wxSpinCtrl(m_GameConfig, ID_CONVERGENCEMINIMUM);
-	ConvergenceMinimum->SetRange(0, INT32_MAX);
-	ConvergenceMinimum->SetToolTip(_("This value is added to the convergence value set in the graphics configuration."));
-	sConvergenceMinimum->Add(ConvergenceMinimumText);
-	sConvergenceMinimum->Add(ConvergenceMinimum);
+	wxBoxSizer* const sConvergence = new wxBoxSizer(wxHORIZONTAL);
+	wxStaticText* const ConvergenceText = new wxStaticText(m_GameConfig, wxID_ANY, _("Convergence: "));
+	Convergence = new wxSpinCtrl(m_GameConfig, ID_CONVERGENCE);
+	Convergence->SetRange(0, INT32_MAX);
+	Convergence->SetToolTip(_("This value is added to the convergence value set in the graphics configuration."));
+	sConvergence->Add(ConvergenceText);
+	sConvergence->Add(Convergence);
 
 	MonoDepth = new wxCheckBox(m_GameConfig, ID_MONODEPTH, _("Monoscopic Shadows"), wxDefaultPosition, wxDefaultSize, GetElementStyle("Video_Stereoscopy", "StereoEFBMonoDepth"));
 	MonoDepth->SetToolTip(_("Use a single depth buffer for both eyes. Needed for a few games."));
@@ -403,7 +403,7 @@ void CISOProperties::CreateGUIControls()
 	wxStaticBoxSizer* const sbStereoOverrides =
 		new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Stereoscopy"));
 	sbStereoOverrides->Add(sDepthPercentage);
-	sbStereoOverrides->Add(sConvergenceMinimum);
+	sbStereoOverrides->Add(sConvergence);
 	sbStereoOverrides->Add(MonoDepth);
 
 	wxStaticBoxSizer * const sbGameConfig = new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Game-Specific Settings"));
@@ -1073,9 +1073,9 @@ void CISOProperties::LoadGameConfig()
 	default_stereoscopy->Get("StereoDepthPercentage", &iTemp, 100);
 	GameIniLocal.GetIfExists("Video_Stereoscopy", "StereoDepthPercentage", &iTemp);
 	DepthPercentage->SetValue(iTemp);
-	default_stereoscopy->Get("StereoConvergenceMinimum", &iTemp, 0);
-	GameIniLocal.GetIfExists("Video_Stereoscopy", "StereoConvergenceMinimum", &iTemp);
-	ConvergenceMinimum->SetValue(iTemp);
+	default_stereoscopy->Get("StereoConvergence", &iTemp, 0);
+	GameIniLocal.GetIfExists("Video_Stereoscopy", "StereoConvergence", &iTemp);
+	Convergence->SetValue(iTemp);
 
 	PatchList_Load();
 	ActionReplayList_Load();
@@ -1154,7 +1154,7 @@ bool CISOProperties::SaveGameConfig()
 
 	int depth = DepthPercentage->GetValue() > 0 ? DepthPercentage->GetValue() : 100;
 	SAVE_IF_NOT_DEFAULT("Video_Stereoscopy", "StereoDepthPercentage", depth, 100);
-	SAVE_IF_NOT_DEFAULT("Video_Stereoscopy", "StereoConvergenceMinimum", ConvergenceMinimum->GetValue(), 0);
+	SAVE_IF_NOT_DEFAULT("Video_Stereoscopy", "StereoConvergence", Convergence->GetValue(), 0);
 
 	PatchList_Save();
 	ActionReplayList_Save();

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -98,7 +98,7 @@ private:
 
 	// Stereoscopy
 	wxSlider* DepthPercentage;
-	wxSpinCtrl* ConvergenceMinimum;
+	wxSpinCtrl* Convergence;
 	wxCheckBox* MonoDepth;
 
 	wxArrayString arrayStringFor_EmuState;
@@ -171,7 +171,7 @@ private:
 		ID_REMOVECHEAT,
 		ID_GPUDETERMINISM,
 		ID_DEPTHPERCENTAGE,
-		ID_CONVERGENCEMINIMUM,
+		ID_CONVERGENCE,
 		ID_MONODEPTH,
 
 		ID_NAME,

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -91,18 +91,20 @@ void VideoConfig::Load(const std::string& ini_file)
 	enhancements->Get("ForceFiltering", &bForceFiltering, 0);
 	enhancements->Get("MaxAnisotropy", &iMaxAnisotropy, 0);  // NOTE - this is x in (1 << x)
 	enhancements->Get("PostProcessingShader", &sPostProcessingShader, "");
-	enhancements->Get("StereoMode", &iStereoMode, 0);
-	enhancements->Get("StereoDepth", &iStereoDepth, 20);
-	enhancements->Get("StereoConvergencePercentage", &iStereoConvergencePercentage, 100);
-	enhancements->Get("StereoSwapEyes", &bStereoSwapEyes, false);
+
+	IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
+	stereoscopy->Get("StereoMode", &iStereoMode, 0);
+	stereoscopy->Get("StereoDepth", &iStereoDepth, 20);
+	stereoscopy->Get("StereoConvergencePercentage", &iStereoConvergencePercentage, 100);
+	stereoscopy->Get("StereoSwapEyes", &bStereoSwapEyes, false);
 
 	//currently these settings are not saved in global config, so we could've initialized them directly
 	for (size_t i = 0; i < oStereoPresets.size(); ++i)
 	{
-		enhancements->Get(StringFromFormat("StereoConvergence_%zu", i), &oStereoPresets[i].depth, iStereoConvergence);
-		enhancements->Get(StringFromFormat("StereoDepth_%zu", i), &oStereoPresets[i].convergence, iStereoDepth);
+		stereoscopy->Get(StringFromFormat("StereoConvergence_%zu", i), &oStereoPresets[i].depth, iStereoConvergence);
+		stereoscopy->Get(StringFromFormat("StereoDepth_%zu", i), &oStereoPresets[i].convergence, iStereoDepth);
 	}
-	enhancements->Get("StereoActivePreset", &iStereoActivePreset, 0);
+	stereoscopy->Get("StereoActivePreset", &iStereoActivePreset, 0);
 	iStereoConvergence = oStereoPresets[iStereoActivePreset].convergence;
 	iStereoDepth = oStereoPresets[iStereoActivePreset].depth;
 
@@ -317,10 +319,12 @@ void VideoConfig::Save(const std::string& ini_file)
 	enhancements->Set("ForceFiltering", bForceFiltering);
 	enhancements->Set("MaxAnisotropy", iMaxAnisotropy);
 	enhancements->Set("PostProcessingShader", sPostProcessingShader);
-	enhancements->Set("StereoMode", iStereoMode);
-	enhancements->Set("StereoDepth", iStereoDepth);
-	enhancements->Set("StereoConvergencePercentage", iStereoConvergencePercentage);
-	enhancements->Set("StereoSwapEyes", bStereoSwapEyes);
+
+	IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
+	stereoscopy->Set("StereoMode", iStereoMode);
+	stereoscopy->Set("StereoDepth", iStereoDepth);
+	stereoscopy->Set("StereoConvergencePercentage", iStereoConvergencePercentage);
+	stereoscopy->Set("StereoSwapEyes", bStereoSwapEyes);
 
 	IniFile::Section* hacks = iniFile.GetOrCreateSection("Hacks");
 	hacks->Set("EFBAccessEnable", bEFBAccessEnable);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -205,22 +205,22 @@ void VideoConfig::GameIniLoad()
 	CHECK_SETTING("Video_Enhancements", "ForceFiltering", bForceFiltering);
 	CHECK_SETTING("Video_Enhancements", "MaxAnisotropy", iMaxAnisotropy);  // NOTE - this is x in (1 << x)
 	CHECK_SETTING("Video_Enhancements", "PostProcessingShader", sPostProcessingShader);
-	CHECK_SETTING("Video_Enhancements", "StereoMode", iStereoMode);
-	CHECK_SETTING("Video_Enhancements", "StereoDepth", iStereoDepth);
-	CHECK_SETTING("Video_Enhancements", "StereoConvergence", iStereoConvergence);
-	CHECK_SETTING("Video_Enhancements", "StereoSwapEyes", bStereoSwapEyes);
 
 	//these are not overrides, they are per-game settings, hence no warning
-	IniFile::Section* enhancements = iniFile.GetOrCreateSection("Enhancements");
+	IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
 	for (size_t i = 0; i < oStereoPresets.size(); ++i)
 	{
-		enhancements->Get(StringFromFormat("StereoConvergence_%zu", i), &oStereoPresets[i].depth, iStereoConvergence);
-		enhancements->Get(StringFromFormat("StereoDepth_%zu", i), &oStereoPresets[i].convergence, iStereoDepth);
+		stereoscopy->Get(StringFromFormat("StereoConvergence_%zu", i), &oStereoPresets[i].depth, iStereoConvergence);
+		stereoscopy->Get(StringFromFormat("StereoDepth_%zu", i), &oStereoPresets[i].convergence, iStereoDepth);
 	}
-	enhancements->Get("StereoActivePreset", &iStereoActivePreset, 0);
+	stereoscopy->Get("StereoActivePreset", &iStereoActivePreset, 0);
 	iStereoConvergence = oStereoPresets[iStereoActivePreset].convergence;
 	iStereoDepth = oStereoPresets[iStereoActivePreset].depth;
 
+	CHECK_SETTING("Video_Stereoscopy", "StereoMode", iStereoMode);
+	CHECK_SETTING("Video_Stereoscopy", "StereoDepth", iStereoDepth);
+	CHECK_SETTING("Video_Stereoscopy", "StereoConvergence", iStereoConvergence);
+	CHECK_SETTING("Video_Stereoscopy", "StereoSwapEyes", bStereoSwapEyes);
 	CHECK_SETTING("Video_Stereoscopy", "StereoEFBMonoDepth", bStereoEFBMonoDepth);
 	CHECK_SETTING("Video_Stereoscopy", "StereoDepthPercentage", iStereoDepthPercentage);
 

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -101,11 +101,11 @@ void VideoConfig::Load(const std::string& ini_file)
 	//currently these settings are not saved in global config, so we could've initialized them directly
 	for (size_t i = 0; i < oStereoPresets.size(); ++i)
 	{
-		stereoscopy->Get(StringFromFormat("StereoConvergence_%zu", i), &oStereoPresets[i].depth, iStereoConvergence);
-		stereoscopy->Get(StringFromFormat("StereoDepth_%zu", i), &oStereoPresets[i].convergence, iStereoDepth);
+		stereoscopy->Get(StringFromFormat("StereoConvergencePercentage_%zu", i), &oStereoPresets[i].convergence, iStereoConvergencePercentage);
+		stereoscopy->Get(StringFromFormat("StereoDepth_%zu", i), &oStereoPresets[i].depth, iStereoDepth);
 	}
 	stereoscopy->Get("StereoActivePreset", &iStereoActivePreset, 0);
-	iStereoConvergence = oStereoPresets[iStereoActivePreset].convergence;
+	iStereoConvergencePercentage = oStereoPresets[iStereoActivePreset].convergence;
 	iStereoDepth = oStereoPresets[iStereoActivePreset].depth;
 
 	IniFile::Section* hacks = iniFile.GetOrCreateSection("Hacks");
@@ -212,11 +212,11 @@ void VideoConfig::GameIniLoad()
 	IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
 	for (size_t i = 0; i < oStereoPresets.size(); ++i)
 	{
-		stereoscopy->Get(StringFromFormat("StereoConvergence_%zu", i), &oStereoPresets[i].depth, iStereoConvergence);
-		stereoscopy->Get(StringFromFormat("StereoDepth_%zu", i), &oStereoPresets[i].convergence, iStereoDepth);
+		stereoscopy->Get(StringFromFormat("StereoConvergencePercentage_%zu", i), &oStereoPresets[i].convergence, iStereoConvergencePercentage);
+		stereoscopy->Get(StringFromFormat("StereoDepth_%zu", i), &oStereoPresets[i].depth, iStereoDepth);
 	}
 	stereoscopy->Get("StereoActivePreset", &iStereoActivePreset, 0);
-	iStereoConvergence = oStereoPresets[iStereoActivePreset].convergence;
+	iStereoConvergencePercentage = oStereoPresets[iStereoActivePreset].convergence;
 	iStereoDepth = oStereoPresets[iStereoActivePreset].depth;
 
 	CHECK_SETTING("Video_Stereoscopy", "StereoMode", iStereoMode);


### PR DESCRIPTION
The stereoscopy section makes much more sense with all stereoscopy options in there. This PR also updates the ISOProperties that still contained an earlier removed option.

The Game INIs currently assume the stereoscopy options are in the stereoscopy section.