### PR TITLE
DiscScrubber: Turn into a class

### DIFF
--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -173,9 +173,10 @@ bool CompressFileToBlob(const std::string& infile, const std::string& outfile, u
     return false;
   }
 
+  DiscScrubber disc_scrubber;
   if (sub_type == 1)
   {
-    if (!DiscScrubber::SetupScrub(infile, block_size))
+    if (!disc_scrubber.SetupScrub(infile, block_size))
     {
       PanicAlertT("\"%s\" failed to be scrubbed. Probably the image is corrupt.", infile.c_str());
       return false;
@@ -186,10 +187,7 @@ bool CompressFileToBlob(const std::string& infile, const std::string& outfile, u
 
   z_stream z = {};
   if (deflateInit(&z, 9) != Z_OK)
-  {
-    DiscScrubber::Cleanup();
     return false;
-  }
 
   callback(GetStringT("Files opened, ready to compress."), 0, arg);
 
@@ -243,7 +241,7 @@ bool CompressFileToBlob(const std::string& infile, const std::string& outfile, u
 
     size_t read_bytes;
     if (scrubbing)
-      read_bytes = DiscScrubber::GetNextBlock(inf, in_buf.data());
+      read_bytes = disc_scrubber.GetNextBlock(inf, in_buf.data());
     else
       inf.ReadArray(in_buf.data(), header.block_size, &read_bytes);
     if (read_bytes < header.block_size)
@@ -318,7 +316,6 @@ bool CompressFileToBlob(const std::string& infile, const std::string& outfile, u
 
   // Cleanup
   deflateEnd(&z);
-  DiscScrubber::Cleanup();
 
   if (success)
   {

--- a/Source/Core/DiscIO/DiscScrubber.cpp
+++ b/Source/Core/DiscIO/DiscScrubber.cpp
@@ -27,14 +27,13 @@ DiscScrubber::~DiscScrubber() = default;
 
 bool DiscScrubber::SetupScrub(const std::string& filename, int block_size)
 {
-  bool success = true;
-  m_Filename = filename;
-  m_BlockSize = block_size;
+  m_filename = filename;
+  m_block_size = block_size;
 
-  if (CLUSTER_SIZE % m_BlockSize != 0)
+  if (CLUSTER_SIZE % m_block_size != 0)
   {
     ERROR_LOG(DISCIO, "Block size %i is not a factor of 0x8000, scrubbing not possible",
-              m_BlockSize);
+              m_block_size);
     return false;
   }
 
@@ -42,9 +41,9 @@ bool DiscScrubber::SetupScrub(const std::string& filename, int block_size)
   if (!m_disc)
     return false;
 
-  m_FileSize = m_disc->GetSize();
+  m_file_size = m_disc->GetSize();
 
-  u32 numClusters = (u32)(m_FileSize / CLUSTER_SIZE);
+  u32 numClusters = (u32)(m_file_size / CLUSTER_SIZE);
 
   // Warn if not DVD5 or DVD9 size
   if (numClusters != 0x23048 && numClusters != 0x46090)
@@ -54,53 +53,53 @@ bool DiscScrubber::SetupScrub(const std::string& filename, int block_size)
   }
 
   // Table of free blocks
-  m_FreeTable.resize(numClusters, 1);
+  m_free_table.resize(numClusters, 1);
 
   // Fill out table of free blocks
-  success = ParseDisc();
+  const bool success = ParseDisc();
 
   // Done with it; need it closed for the next part
   m_disc.reset();
-  m_BlockCount = 0;
+  m_block_count = 0;
 
-  m_isScrubbing = success;
+  m_is_scrubbing = success;
   return success;
 }
 
 size_t DiscScrubber::GetNextBlock(File::IOFile& in, u8* buffer)
 {
-  u64 CurrentOffset = m_BlockCount * m_BlockSize;
-  u64 i = CurrentOffset / CLUSTER_SIZE;
+  const u64 current_offset = m_block_count * m_block_size;
+  const u64 i = current_offset / CLUSTER_SIZE;
 
-  size_t ReadBytes = 0;
-  if (m_isScrubbing && m_FreeTable[i])
+  size_t read_bytes = 0;
+  if (m_is_scrubbing && m_free_table[i])
   {
-    DEBUG_LOG(DISCIO, "Freeing 0x%016" PRIx64, CurrentOffset);
-    std::fill(buffer, buffer + m_BlockSize, 0x00);
-    in.Seek(m_BlockSize, SEEK_CUR);
-    ReadBytes = m_BlockSize;
+    DEBUG_LOG(DISCIO, "Freeing 0x%016" PRIx64, current_offset);
+    std::fill(buffer, buffer + m_block_size, 0x00);
+    in.Seek(m_block_size, SEEK_CUR);
+    read_bytes = m_block_size;
   }
   else
   {
-    DEBUG_LOG(DISCIO, "Used    0x%016" PRIx64, CurrentOffset);
-    in.ReadArray(buffer, m_BlockSize, &ReadBytes);
+    DEBUG_LOG(DISCIO, "Used    0x%016" PRIx64, current_offset);
+    in.ReadArray(buffer, m_block_size, &read_bytes);
   }
 
-  m_BlockCount++;
-  return ReadBytes;
+  m_block_count++;
+  return read_bytes;
 }
 
-void DiscScrubber::MarkAsUsed(u64 _Offset, u64 _Size)
+void DiscScrubber::MarkAsUsed(u64 offset, u64 size)
 {
-  u64 CurrentOffset = _Offset;
-  u64 EndOffset = CurrentOffset + _Size;
+  u64 current_offset = offset;
+  const u64 end_offset = current_offset + size;
 
-  DEBUG_LOG(DISCIO, "Marking 0x%016" PRIx64 " - 0x%016" PRIx64 " as used", _Offset, EndOffset);
+  DEBUG_LOG(DISCIO, "Marking 0x%016" PRIx64 " - 0x%016" PRIx64 " as used", offset, end_offset);
 
-  while ((CurrentOffset < EndOffset) && (CurrentOffset < m_FileSize))
+  while (current_offset < end_offset && current_offset < m_file_size)
   {
-    m_FreeTable[CurrentOffset / CLUSTER_SIZE] = 0;
-    CurrentOffset += CLUSTER_SIZE;
+    m_free_table[current_offset / CLUSTER_SIZE] = 0;
+    current_offset += CLUSTER_SIZE;
   }
 }
 
@@ -124,17 +123,17 @@ void DiscScrubber::MarkAsUsedE(u64 partition_data_offset, u64 offset, u64 size)
 }
 
 // Helper functions for reading the BE volume
-bool DiscScrubber::ReadFromVolume(u64 _Offset, u32& _Buffer, bool _Decrypt)
+bool DiscScrubber::ReadFromVolume(u64 offset, u32& buffer, bool decrypt)
 {
-  return m_disc->ReadSwapped(_Offset, &_Buffer, _Decrypt);
+  return m_disc->ReadSwapped(offset, &buffer, decrypt);
 }
 
-bool DiscScrubber::ReadFromVolume(u64 _Offset, u64& _Buffer, bool _Decrypt)
+bool DiscScrubber::ReadFromVolume(u64 offset, u64& buffer, bool decrypt)
 {
   u32 temp_buffer;
-  if (!m_disc->ReadSwapped(_Offset, &temp_buffer, _Decrypt))
+  if (!m_disc->ReadSwapped(offset, &temp_buffer, decrypt))
     return false;
-  _Buffer = static_cast<u64>(temp_buffer) << 2;
+  buffer = static_cast<u64>(temp_buffer) << 2;
   return true;
 }
 
@@ -145,49 +144,53 @@ bool DiscScrubber::ParseDisc()
 
   for (int x = 0; x < 4; x++)
   {
-    if (!ReadFromVolume(0x40000 + (x * 8) + 0, PartitionGroup[x].numPartitions, false) ||
-        !ReadFromVolume(0x40000 + (x * 8) + 4, PartitionGroup[x].PartitionsOffset, false))
-      return false;
-
-    // Read all partitions
-    for (u32 i = 0; i < PartitionGroup[x].numPartitions; i++)
+    if (!ReadFromVolume(0x40000 + (x * 8) + 0, m_partition_group[x].num_partitions, false) ||
+        !ReadFromVolume(0x40000 + (x * 8) + 4, m_partition_group[x].partitions_offset, false))
     {
-      SPartition Partition;
-
-      Partition.GroupNumber = x;
-      Partition.Number = i;
-
-      if (!ReadFromVolume(PartitionGroup[x].PartitionsOffset + (i * 8) + 0, Partition.Offset,
-                          false) ||
-          !ReadFromVolume(PartitionGroup[x].PartitionsOffset + (i * 8) + 4, Partition.Type,
-                          false) ||
-          !ReadFromVolume(Partition.Offset + 0x2a4, Partition.Header.TMDSize, false) ||
-          !ReadFromVolume(Partition.Offset + 0x2a8, Partition.Header.TMDOffset, false) ||
-          !ReadFromVolume(Partition.Offset + 0x2ac, Partition.Header.CertChainSize, false) ||
-          !ReadFromVolume(Partition.Offset + 0x2b0, Partition.Header.CertChainOffset, false) ||
-          !ReadFromVolume(Partition.Offset + 0x2b4, Partition.Header.H3Offset, false) ||
-          !ReadFromVolume(Partition.Offset + 0x2b8, Partition.Header.DataOffset, false) ||
-          !ReadFromVolume(Partition.Offset + 0x2bc, Partition.Header.DataSize, false))
-        return false;
-
-      PartitionGroup[x].PartitionsVec.push_back(Partition);
+      return false;
     }
 
-    for (auto& rPartition : PartitionGroup[x].PartitionsVec)
+    // Read all partitions
+    for (u32 i = 0; i < m_partition_group[x].num_partitions; i++)
     {
-      const SPartitionHeader& rHeader = rPartition.Header;
+      Partition partition;
 
-      MarkAsUsed(rPartition.Offset, 0x2c0);
+      partition.group_number = x;
+      partition.number = i;
 
-      MarkAsUsed(rPartition.Offset + rHeader.TMDOffset, rHeader.TMDSize);
-      MarkAsUsed(rPartition.Offset + rHeader.CertChainOffset, rHeader.CertChainSize);
-      MarkAsUsed(rPartition.Offset + rHeader.H3Offset, 0x18000);
+      if (!ReadFromVolume(m_partition_group[x].partitions_offset + (i * 8) + 0, partition.offset,
+                          false) ||
+          !ReadFromVolume(m_partition_group[x].partitions_offset + (i * 8) + 4, partition.type,
+                          false) ||
+          !ReadFromVolume(partition.offset + 0x2a4, partition.header.tmd_size, false) ||
+          !ReadFromVolume(partition.offset + 0x2a8, partition.header.tmd_offset, false) ||
+          !ReadFromVolume(partition.offset + 0x2ac, partition.header.cert_chain_size, false) ||
+          !ReadFromVolume(partition.offset + 0x2b0, partition.header.cert_chain_offset, false) ||
+          !ReadFromVolume(partition.offset + 0x2b4, partition.header.h3_offset, false) ||
+          !ReadFromVolume(partition.offset + 0x2b8, partition.header.data_offset, false) ||
+          !ReadFromVolume(partition.offset + 0x2bc, partition.header.data_size, false))
+      {
+        return false;
+      }
+
+      m_partition_group[x].partitions.push_back(partition);
+    }
+
+    for (auto& partition : m_partition_group[x].partitions)
+    {
+      const PartitionHeader& header = partition.header;
+
+      MarkAsUsed(partition.offset, 0x2c0);
+
+      MarkAsUsed(partition.offset + header.tmd_offset, header.tmd_size);
+      MarkAsUsed(partition.offset + header.cert_chain_offset, header.cert_chain_size);
+      MarkAsUsed(partition.offset + header.h3_offset, 0x18000);
       // This would mark the whole (encrypted) data area
       // we need to parse FST and other crap to find what's free within it!
-      // MarkAsUsed(rPartition.Offset + rHeader.DataOffset, rHeader.DataSize);
+      // MarkAsUsed(partition.offset + header.data_offset, header.data_size);
 
       // Parse Data! This is where the big gain is
-      if (!ParsePartitionData(rPartition))
+      if (!ParsePartitionData(partition))
         return false;
     }
   }
@@ -196,7 +199,7 @@ bool DiscScrubber::ParseDisc()
 }
 
 // Operations dealing with encrypted space are done here - the volume is swapped to allow this
-bool DiscScrubber::ParsePartitionData(SPartition& partition)
+bool DiscScrubber::ParsePartitionData(Partition& partition)
 {
   bool parsed_ok = true;
 
@@ -205,10 +208,10 @@ bool DiscScrubber::ParsePartitionData(SPartition& partition)
   m_disc.swap(old_volume);
 
   // Ready some stuff
-  m_disc = CreateVolumeFromFilename(m_Filename, partition.GroupNumber, partition.Number);
+  m_disc = CreateVolumeFromFilename(m_filename, partition.group_number, partition.number);
   if (m_disc == nullptr)
   {
-    ERROR_LOG(DISCIO, "Failed to create volume from file %s", m_Filename.c_str());
+    ERROR_LOG(DISCIO, "Failed to create volume from file %s", m_filename.c_str());
     m_disc.swap(old_volume);
     return false;
   }
@@ -217,38 +220,41 @@ bool DiscScrubber::ParsePartitionData(SPartition& partition)
   if (!filesystem)
   {
     ERROR_LOG(DISCIO, "Failed to create filesystem for group %d partition %u",
-              partition.GroupNumber, partition.Number);
+              partition.group_number, partition.number);
     parsed_ok = false;
   }
   else
   {
     // Mark things as used which are not in the filesystem
     // Header, Header Information, Apploader
-    parsed_ok = parsed_ok && ReadFromVolume(0x2440 + 0x14, partition.Header.ApploaderSize, true);
+    parsed_ok = parsed_ok && ReadFromVolume(0x2440 + 0x14, partition.header.apploader_size, true);
     parsed_ok =
-        parsed_ok && ReadFromVolume(0x2440 + 0x18, partition.Header.ApploaderTrailerSize, true);
-    MarkAsUsedE(partition.Offset + partition.Header.DataOffset, 0,
-                0x2440 + partition.Header.ApploaderSize + partition.Header.ApploaderTrailerSize);
+        parsed_ok && ReadFromVolume(0x2440 + 0x18, partition.header.apploader_trailer_size, true);
+    MarkAsUsedE(partition.offset + partition.header.data_offset, 0,
+                0x2440 + partition.header.apploader_size + partition.header.apploader_trailer_size);
 
     // DOL
-    partition.Header.DOLOffset = filesystem->GetBootDOLOffset();
-    partition.Header.DOLSize = filesystem->GetBootDOLSize(partition.Header.DOLOffset);
-    parsed_ok = parsed_ok && partition.Header.DOLOffset && partition.Header.DOLSize;
-    MarkAsUsedE(partition.Offset + partition.Header.DataOffset, partition.Header.DOLOffset,
-                partition.Header.DOLSize);
+    partition.header.dol_offset = filesystem->GetBootDOLOffset();
+    partition.header.dol_size = filesystem->GetBootDOLSize(partition.header.dol_offset);
+    parsed_ok = parsed_ok && partition.header.dol_offset && partition.header.dol_size;
+    MarkAsUsedE(partition.offset + partition.header.data_offset, partition.header.dol_offset,
+                partition.header.dol_size);
 
     // FST
-    parsed_ok = parsed_ok && ReadFromVolume(0x424, partition.Header.FSTOffset, true);
-    parsed_ok = parsed_ok && ReadFromVolume(0x428, partition.Header.FSTSize, true);
-    MarkAsUsedE(partition.Offset + partition.Header.DataOffset, partition.Header.FSTOffset,
-                partition.Header.FSTSize);
+    parsed_ok = parsed_ok && ReadFromVolume(0x424, partition.header.fst_offset, true);
+    parsed_ok = parsed_ok && ReadFromVolume(0x428, partition.header.fst_size, true);
+    MarkAsUsedE(partition.offset + partition.header.data_offset, partition.header.fst_offset,
+                partition.header.fst_size);
 
     // Go through the filesystem and mark entries as used
     for (SFileInfo file : filesystem->GetFileList())
     {
       DEBUG_LOG(DISCIO, "%s", file.m_FullPath.empty() ? "/" : file.m_FullPath.c_str());
       if ((file.m_NameOffset & 0x1000000) == 0)
-        MarkAsUsedE(partition.Offset + partition.Header.DataOffset, file.m_Offset, file.m_FileSize);
+      {
+        MarkAsUsedE(partition.offset + partition.header.data_offset, file.m_Offset,
+                    file.m_FileSize);
+      }
     }
   }
 

--- a/Source/Core/DiscIO/DiscScrubber.h
+++ b/Source/Core/DiscIO/DiscScrubber.h
@@ -37,40 +37,40 @@ public:
   size_t GetNextBlock(File::IOFile& in, u8* buffer);
 
 private:
-  struct SPartitionHeader final
+  struct PartitionHeader final
   {
-    u8* Ticket[0x2a4];
-    u32 TMDSize;
-    u64 TMDOffset;
-    u32 CertChainSize;
-    u64 CertChainOffset;
+    u8* ticket[0x2a4];
+    u32 tmd_size;
+    u64 tmd_offset;
+    u32 cert_chain_size;
+    u64 cert_chain_offset;
     // H3Size is always 0x18000
-    u64 H3Offset;
-    u64 DataOffset;
-    u64 DataSize;
+    u64 h3_offset;
+    u64 data_offset;
+    u64 data_size;
     // TMD would be here
-    u64 DOLOffset;
-    u64 DOLSize;
-    u64 FSTOffset;
-    u64 FSTSize;
-    u32 ApploaderSize;
-    u32 ApploaderTrailerSize;
+    u64 dol_offset;
+    u64 dol_size;
+    u64 fst_offset;
+    u64 fst_size;
+    u32 apploader_size;
+    u32 apploader_trailer_size;
   };
 
-  struct SPartition final
+  struct Partition final
   {
-    u32 GroupNumber;
-    u32 Number;
-    u64 Offset;
-    u32 Type;
-    SPartitionHeader Header;
+    u32 group_number;
+    u32 number;
+    u64 offset;
+    u32 type;
+    PartitionHeader header;
   };
 
-  struct SPartitionGroup final
+  struct PartitionGroup final
   {
-    u32 numPartitions;
-    u64 PartitionsOffset;
-    std::vector<SPartition> PartitionsVec;
+    u32 num_partitions;
+    u64 partitions_offset;
+    std::vector<Partition> partitions;
   };
 
   void MarkAsUsed(u64 offset, u64 size);
@@ -78,18 +78,18 @@ private:
   bool ReadFromVolume(u64 offset, u32& buffer, bool decrypt);
   bool ReadFromVolume(u64 offset, u64& buffer, bool decrypt);
   bool ParseDisc();
-  bool ParsePartitionData(SPartition& partition);
+  bool ParsePartitionData(Partition& partition);
 
-  std::string m_Filename;
+  std::string m_filename;
   std::unique_ptr<IVolume> m_disc;
 
-  std::array<SPartitionGroup, 4> PartitionGroup{};
+  std::array<PartitionGroup, 4> m_partition_group{};
 
-  std::vector<u8> m_FreeTable;
-  u64 m_FileSize = 0;
-  u64 m_BlockCount = 0;
-  u32 m_BlockSize = 0;
-  bool m_isScrubbing = false;
+  std::vector<u8> m_free_table;
+  u64 m_file_size = 0;
+  u64 m_block_count = 0;
+  u32 m_block_size = 0;
+  bool m_is_scrubbing = false;
 };
 
 }  // namespace DiscIO

--- a/Source/Core/DiscIO/DiscScrubber.h
+++ b/Source/Core/DiscIO/DiscScrubber.h
@@ -12,7 +12,10 @@
 
 #pragma once
 
+#include <array>
+#include <memory>
 #include <string>
+#include <vector>
 #include "Common/CommonTypes.h"
 
 namespace File
@@ -22,12 +25,71 @@ class IOFile;
 
 namespace DiscIO
 {
-namespace DiscScrubber
-{
-bool SetupScrub(const std::string& filename, int block_size);
-size_t GetNextBlock(File::IOFile& in, u8* buffer);
-void Cleanup();
+class IVolume;
 
-}  // namespace DiscScrubber
+class DiscScrubber final
+{
+public:
+  DiscScrubber();
+  ~DiscScrubber();
+
+  bool SetupScrub(const std::string& filename, int block_size);
+  size_t GetNextBlock(File::IOFile& in, u8* buffer);
+
+private:
+  struct SPartitionHeader final
+  {
+    u8* Ticket[0x2a4];
+    u32 TMDSize;
+    u64 TMDOffset;
+    u32 CertChainSize;
+    u64 CertChainOffset;
+    // H3Size is always 0x18000
+    u64 H3Offset;
+    u64 DataOffset;
+    u64 DataSize;
+    // TMD would be here
+    u64 DOLOffset;
+    u64 DOLSize;
+    u64 FSTOffset;
+    u64 FSTSize;
+    u32 ApploaderSize;
+    u32 ApploaderTrailerSize;
+  };
+
+  struct SPartition final
+  {
+    u32 GroupNumber;
+    u32 Number;
+    u64 Offset;
+    u32 Type;
+    SPartitionHeader Header;
+  };
+
+  struct SPartitionGroup final
+  {
+    u32 numPartitions;
+    u64 PartitionsOffset;
+    std::vector<SPartition> PartitionsVec;
+  };
+
+  void MarkAsUsed(u64 offset, u64 size);
+  void MarkAsUsedE(u64 partition_data_offset, u64 offset, u64 size);
+  bool ReadFromVolume(u64 offset, u32& buffer, bool decrypt);
+  bool ReadFromVolume(u64 offset, u64& buffer, bool decrypt);
+  bool ParseDisc();
+  bool ParsePartitionData(SPartition& partition);
+
+  std::string m_Filename;
+  std::unique_ptr<IVolume> m_disc;
+
+  std::array<SPartitionGroup, 4> PartitionGroup{};
+
+  std::vector<u8> m_FreeTable;
+  u64 m_FileSize = 0;
+  u64 m_BlockCount = 0;
+  u32 m_BlockSize = 0;
+  bool m_isScrubbing = false;
+};
 
 }  // namespace DiscIO


### PR DESCRIPTION
Gets things out of global lifetime scope and gets rid of the need to explicitly clean up things when done using an instance of it, since object destructors can do it themselves upon going out of scope.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3352)

<!-- Reviewable:end -->
