### PR TITLE
WX: Open control config dialog on mouse down

### DIFF
--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -808,7 +808,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
     }
 
     control_button->Bind(wxEVT_MIDDLE_DOWN, &GamepadPage::ClearControl, eventsink);
-    control_button->Bind(wxEVT_RIGHT_UP, &GamepadPage::ConfigControl, eventsink);
+    control_button->Bind(wxEVT_RIGHT_DOWN, &GamepadPage::ConfigControl, eventsink);
 
     wxBoxSizer* const control_sizer = new wxBoxSizer(wxHORIZONTAL);
     control_sizer->AddStretchSpacer(1);


### PR DESCRIPTION
Opening on mouse up has the effect of my PR #3068 not working when right clicking the button, because the mouse up event is triggered after the event filter is already disabled again.

Another possible solution would be modifying the event filter to block a single mouse up event if it received a mouse down event while it was active.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3353)

<!-- Reviewable:end -->
