### PR TITLE
OGL: Clamp rectangle at window dimensions when saving screenshot with crop enabled, use Flag for setting screenshot event without pausing CPU

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -676,28 +676,14 @@ static std::string GenerateScreenshotName()
 
 void SaveScreenShot()
 {
-	const bool bPaused = (GetState() == CORE_PAUSE);
-
-	SetState(CORE_PAUSE);
-
 	g_video_backend->Video_Screenshot(GenerateScreenshotName());
-
-	if (!bPaused)
-		SetState(CORE_RUN);
 }
 
 void SaveScreenShot(const std::string& name)
 {
-	const bool bPaused = (GetState() == CORE_PAUSE);
-
-	SetState(CORE_PAUSE);
-
 	std::string filePath = GenerateScreenshotFolderPath() + name + ".png";
 
 	g_video_backend->Video_Screenshot(filePath);
-
-	if (!bPaused)
-	 	SetState(CORE_RUN);
 }
 
 void RequestRefreshInfo()

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -821,13 +821,12 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 	}
 
 	// done with drawing the game stuff, good moment to save a screenshot
-	if (s_bScreenshot)
+	if (s_screenshotFlag.TestAndClear())
 	{
 		std::lock_guard<std::mutex> guard(s_criticalScreenshot);
 
 		SaveScreenshot(s_sScreenshotName, GetTargetRectangle());
 		s_sScreenshotName.clear();
-		s_bScreenshot = false;
 		s_screenshotCompleted.Set();
 	}
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1384,7 +1384,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 
 	// Save screenshot
-	if (s_bScreenshot)
+	if (s_screenshotFlag.TestAndClear())
 	{
 		std::lock_guard<std::mutex> lk(s_criticalScreenshot);
 
@@ -1393,7 +1393,6 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 
 		// Reset settings
 		s_sScreenshotName.clear();
-		s_bScreenshot = false;
 		s_screenshotCompleted.Set();
 	}
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1404,16 +1404,20 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 #if defined _WIN32 || defined HAVE_LIBAV
 		if (SConfig::GetInstance().m_DumpFrames)
 		{
+			// Restrict the image being dumped to the dimensions of the backbuffer.
+			TargetRectangle image_rc(flipped_trc);
+			image_rc.ClampLL(0, s_backbuffer_height, s_backbuffer_width, 0);
+
 			std::lock_guard<std::mutex> lk(s_criticalScreenshot);
-			if (frame_data.empty() || w != flipped_trc.GetWidth() ||
-				     h != flipped_trc.GetHeight())
+			if (frame_data.empty() || w != image_rc.GetWidth() ||
+				     h != image_rc.GetHeight())
 			{
-				w = flipped_trc.GetWidth();
-				h = flipped_trc.GetHeight();
+				w = image_rc.GetWidth();
+				h = image_rc.GetHeight();
 				frame_data.resize(3 * w * h);
 			}
 			glPixelStorei(GL_PACK_ALIGNMENT, 1);
-			glReadPixels(flipped_trc.left, flipped_trc.bottom, w, h, GL_BGR, GL_UNSIGNED_BYTE, &frame_data[0]);
+			glReadPixels(image_rc.left, image_rc.bottom, w, h, GL_BGR, GL_UNSIGNED_BYTE, &frame_data[0]);
 			if (w > 0 && h > 0)
 			{
 				if (!bLastFrameDumped)
@@ -1465,13 +1469,16 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 #else
 		if (SConfig::GetInstance().m_DumpFrames)
 		{
+			TargetRectangle image_rc(GetTargetRectangle());
+			image_rc.ClampLL(0, s_backbuffer_height, s_backbuffer_width, 0);
+
 			std::lock_guard<std::mutex> lk(s_criticalScreenshot);
 			std::string movie_file_name;
-			w = GetTargetRectangle().GetWidth();
-			h = GetTargetRectangle().GetHeight();
+			w = image_rc.GetWidth();
+			h = image_rc.GetHeight();
 			frame_data.resize(3 * w * h);
 			glPixelStorei(GL_PACK_ALIGNMENT, 1);
-			glReadPixels(GetTargetRectangle().left, GetTargetRectangle().bottom, w, h, GL_BGR, GL_UNSIGNED_BYTE, &frame_data[0]);
+			glReadPixels(image_rc.left, image_rc.bottom, w, h, GL_BGR, GL_UNSIGNED_BYTE, &frame_data[0]);
 
 			if (!bLastFrameDumped)
 			{
@@ -1763,12 +1770,18 @@ namespace OGL
 
 bool Renderer::SaveScreenshot(const std::string &filename, const TargetRectangle &back_rc)
 {
-	u32 W = back_rc.GetWidth();
-	u32 H = back_rc.GetHeight();
+	// When cropping is enabled, back_rc can contain coordinates that are either negative,
+	// or outside the window dimensions, so the image size is clamped at the backbuffer
+	// dimensions to prevent leaving extra rows/columns uninitialized.
+	TargetRectangle image_rc(back_rc);
+	image_rc.ClampLL(0, s_backbuffer_height, s_backbuffer_width, 0);
+
+	u32 W = image_rc.GetWidth();
+	u32 H = image_rc.GetHeight();
 	std::unique_ptr<u8[]> data(new u8[W * 4 * H]);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
 
-	glReadPixels(back_rc.left, back_rc.bottom, W, H, GL_RGBA, GL_UNSIGNED_BYTE, data.get());
+	glReadPixels(image_rc.left, image_rc.bottom, W, H, GL_RGBA, GL_UNSIGNED_BYTE, data.get());
 
 	// Turn image upside down
 	FlipImageData(data.get(), W, H, 4);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -53,12 +53,11 @@ static int OSDTime;
 
 Renderer *g_renderer = nullptr;
 
+Common::Flag Renderer::s_screenshotFlag;
 std::mutex Renderer::s_criticalScreenshot;
 std::string Renderer::s_sScreenshotName;
 
 Common::Event Renderer::s_screenshotCompleted;
-
-volatile bool Renderer::s_bScreenshot;
 
 // The framebuffer size
 int Renderer::s_target_width;
@@ -283,8 +282,8 @@ void Renderer::ConvertStereoRectangle(const TargetRectangle& rc, TargetRectangle
 void Renderer::SetScreenshot(const std::string& filename)
 {
 	std::lock_guard<std::mutex> lk(s_criticalScreenshot);
-	s_sScreenshotName = filename;
-	s_bScreenshot = true;
+	if (s_screenshotFlag.TestAndSet())
+		s_sScreenshotName = filename;
 }
 
 // Create On-Screen-Messages

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "Common/Event.h"
+#include "Common/Flag.h"
 #include "Common/MathUtil.h"
 #include "Common/Thread.h"
 #include "VideoCommon/BPMemory.h"
@@ -143,7 +144,7 @@ protected:
 	static void CheckFifoRecording();
 	static void RecordVideoMemory();
 
-	static volatile bool s_bScreenshot;
+	static Common::Flag s_screenshotFlag;
 	static std::mutex s_criticalScreenshot;
 	static std::string s_sScreenshotName;
 


### PR DESCRIPTION
First commit is changing the GL behavior to match as in this commit: https://github.com/dolphin-emu/dolphin/commit/5dcd3cd4fd30cbe9cff872f952cea9f6d0b91376

Without clamping, glReadPixels was passed negative/out-of-range coordinates, and on nvidia, this just seemed to leave the extra pixels uninitialized, and the GL spec says it only reads 0<=x<width.

Second commit changes the screenshot flag to use a Flag instead of a volatile variable (videosw uses an atomic bool as well), and removes CPU pause/resume calls (it's simply setting a flag, which is checked by the GPU thread). This was causing CPU code to be executed on the UI thread, which at least in debug builds was causing warning messageboxes to be displayed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3354)

<!-- Reviewable:end -->
