### PR TITLE
Partial texture updates: Check the dimensions of the efb copy

### DIFF
--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -93,7 +93,7 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 		srcbox.right = srcrect.right;
 		srcbox.bottom = srcrect.bottom;
 		srcbox.front = 0;
-		srcbox.back = 1;
+		srcbox.back = srcentry->config.layers;
 
 		D3D::context->CopySubresourceRegion(
 			texture->GetTex(),
@@ -130,7 +130,7 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 		srcentry->config.width, srcentry->config.height,
 		PixelShaderCache::GetColorCopyProgram(false),
 		VertexShaderCache::GetSimpleVertexShader(),
-		VertexShaderCache::GetSimpleInputLayout(), nullptr, 1.0, 0);
+		VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader(), 1.0, 0);
 
 	D3D::context->OMSetRenderTargets(1,
 		&FramebufferManager::GetEFBColorTexture()->GetRTV(),

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -87,16 +87,14 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 	if (srcrect.GetWidth() == dstrect.GetWidth()
 		&& srcrect.GetHeight() == dstrect.GetHeight())
 	{
-		const D3D11_BOX *psrcbox = nullptr;
 		D3D11_BOX srcbox;
-		if (srcrect.left != 0 || srcrect.top != 0)
-		{
-			srcbox.left = srcrect.left;
-			srcbox.top = srcrect.top;
-			srcbox.right = srcrect.right;
-			srcbox.bottom = srcrect.bottom;
-			psrcbox = &srcbox;
-		}
+		srcbox.left = srcrect.left;
+		srcbox.top = srcrect.top;
+		srcbox.right = srcrect.right;
+		srcbox.bottom = srcrect.bottom;
+		srcbox.front = 0;
+		srcbox.back = 1;
+
 		D3D::context->CopySubresourceRegion(
 			texture->GetTex(),
 			0,
@@ -105,7 +103,7 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 			0,
 			srcentry->texture->GetTex(),
 			0,
-			psrcbox);
+			&srcbox);
 		return;
 	}
 	else if (!config.rendertarget)

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -168,7 +168,7 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 			0,
 			dstrect.GetWidth(),
 			dstrect.GetHeight(),
-			1);
+			srcentry->config.layers);
 		return;
 	}
 	else if (!framebuffer)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -226,6 +226,7 @@ void TextureCacheBase::ScaleTextureCacheEntryTo(TextureCacheBase::TCacheEntryBas
 	TextureCacheBase::TCacheEntryConfig newconfig;
 	newconfig.width = new_width;
 	newconfig.height = new_height;
+	newconfig.layers = (*entry)->config.layers;
 	newconfig.rendertarget = true;
 
 	TCacheEntryBase* newentry = AllocateTexture(newconfig);

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -153,6 +153,7 @@ protected:
 private:
 	typedef std::multimap<u64, TCacheEntryBase*> TexCache;
 	typedef std::unordered_multimap<TCacheEntryConfig, TCacheEntryBase*, TCacheEntryConfig::Hasher> TexPool;
+	static void ScaleTextureCacheEntryTo(TCacheEntryBase** entry, u32 new_width, u32 new_height);
 	static TCacheEntryBase* DoPartialTextureUpdates(TexCache::iterator iter);
 	static void DumpTexture(TCacheEntryBase* entry, std::string basename, unsigned int level);
 	static void CheckTempSize(size_t required_size);


### PR DESCRIPTION
and the target texture, not just the binary size.

A few other fixes around partial texture updates found their way into this pr as well:
- A bug in D3D's version of TextureCache::TCacheEntry::CopyRectangleFromTexture which would cause some issue when trying to use only a part of a source texture
- Forcing the scaling factor for both, the efb copy and the normal texture to be the current scaling factor. Before it was rescaling the normal texture with the scaling factor of the efb copy, but it might have calculated it wrong for small efb copies.
- Keeping track of the pointer for textures_by_hash


This should get Donkey Kong Country Returns characters to be as broken as they should be. They will be fixed in a later pr.



Expected result is:
efbtex: characters are always flickering or invisible, no matter what scaling or IR setting
efb2ram: characters are always working properly at 1xIR, no matter what scaling or IR setting

This is related to:
https://bugs.dolphin-emu.org/issues/9120

PS: Donkey Kong is supposed to be invisible with efb2tex, because the efb copy is 1 pixel/texel wider and heigher than the texture the game tries to use from the same offset. So the correct behavior is to not use that efb copy, because currently the efb copy is supposed to fit completely into the texture that is updated. But the partial texture updates code did only check the binary size for updates, so Dolphin refused to use the efb copy directly, but did a partial texture update. But why it was randomly working and not working with different IR settings, i don't know.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3355)
<!-- Reviewable:end -->
