### PR TITLE
VideoSW: Clear normal vertex data.

### DIFF
--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -196,6 +196,7 @@ void SWVertexLoader::LoadVertex()
 	// transform this vertex so that it can be used for rasterization (outVertex)
 	OutputVertexData* outVertex = m_SetupUnit->GetVertex();
 	TransformUnit::TransformPosition(&m_Vertex, outVertex);
+	memset(&outVertex->normal, 0, sizeof(outVertex->normal));
 	if (g_main_cp_state.vtx_desc.Normal != NOT_PRESENT)
 	{
 		TransformUnit::TransformNormal(&m_Vertex, m_CurrentVat->g0.NormalElements, outVertex);


### PR DESCRIPTION
This data might not be initialized but used for lighting.
This matches our ShaderGen usage in VertexShaderGen.cpp:166.