### PR TITLE
D3D: Implement vectored efb pokes

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DUtil.h
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "Common/MathUtil.h"
+#include "VideoCommon/RenderBase.h"
 
 namespace DX11
 {
@@ -67,6 +68,8 @@ namespace D3D
 						u32 slice = 0);
 	void drawClearQuad(u32 Color, float z);
 	void drawColorQuad(u32 Color, float z, float x1, float y1, float x2, float y2);
+
+	void DrawEFBPokeQuads(EFBAccessType type, const EfbPokeData* points, size_t num_points);
 }
 
 }

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -474,21 +474,11 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		else if (alpha_read_mode.ReadMode == 1) return (ret | 0xFF000000); // GX_READ_FF
 		else /*if(alpha_read_mode.ReadMode == 0)*/ return (ret & 0x00FFFFFF); // GX_READ_00
 	}
-	else // if (type == POKE_COLOR || type == POKE_Z)
-	{
-		std::vector<EfbPokeData> vector;
-		EfbPokeData d;
-		d.x = x;
-		d.y = y;
-		d.data = poke_data;
-		vector.push_back(d);
-		PokeEFB(type, vector);
-	}
 
 	return 0;
 }
 
-void Renderer::PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data)
+void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points)
 {
 	ResetAPIState();
 
@@ -513,7 +503,7 @@ void Renderer::PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data)
 			FramebufferManager::GetEFBDepthTexture()->GetDSV());
 	}
 
-	D3D::DrawEFBPokeQuads(type, data.data(), data.size());
+	D3D::DrawEFBPokeQuads(type, points, num_points);
 
 	if (type == POKE_Z)
 	{

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -474,55 +474,55 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		else if (alpha_read_mode.ReadMode == 1) return (ret | 0xFF000000); // GX_READ_FF
 		else /*if(alpha_read_mode.ReadMode == 0)*/ return (ret & 0x00FFFFFF); // GX_READ_00
 	}
-	else if (type == POKE_COLOR)
+	else // if (type == POKE_COLOR || type == POKE_Z)
 	{
-		u32 rgbaColor = (poke_data & 0xFF00FF00) | ((poke_data >> 16) & 0xFF) | ((poke_data << 16) & 0xFF0000);
+		std::vector<EfbPokeData> vector;
+		EfbPokeData d;
+		d.x = x;
+		d.y = y;
+		d.data = poke_data;
+		vector.push_back(d);
+		PokeEFB(type, vector);
+	}
 
-		// TODO: The first five PE registers may change behavior of EFB pokes, this isn't implemented, yet.
-		ResetAPIState();
+	return 0;
+}
 
+void Renderer::PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data)
+{
+	ResetAPIState();
+
+	if (type == POKE_COLOR)
+	{
 		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
 		D3D::context->RSSetViewports(1, &vp);
-
 		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), nullptr);
-		D3D::drawColorQuad(rgbaColor, 0.f,
-		                  (float)RectToLock.left   * 2.f / GetTargetWidth()  - 1.f,
-		                - (float)RectToLock.top    * 2.f / GetTargetHeight() + 1.f,
-		                  (float)RectToLock.right  * 2.f / GetTargetWidth()  - 1.f,
-		                - (float)RectToLock.bottom * 2.f / GetTargetHeight() + 1.f);
-
-		RestoreAPIState();
 	}
 	else // if (type == POKE_Z)
 	{
-		// TODO: The first five PE registers may change behavior of EFB pokes, this isn't implemented, yet.
-		ResetAPIState();
-
 		D3D::stateman->PushBlendState(clearblendstates[3]);
 		D3D::stateman->PushDepthState(cleardepthstates[1]);
 
 		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight(),
 			1.0f - MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f,
 			1.0f - MathUtil::Clamp<float>((xfmem.viewport.farZ - MathUtil::Clamp<float>(xfmem.viewport.zRange, 0.0f, 16777215.0f)), 0.0f, 16777215.0f) / 16777216.0f);
+
 		D3D::context->RSSetViewports(1, &vp);
 
 		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
 			FramebufferManager::GetEFBDepthTexture()->GetDSV());
-		D3D::drawColorQuad(0, 1.0f - float(poke_data & 0xFFFFFF) / 16777216.0f,
-		                  (float)RectToLock.left   * 2.f / GetTargetWidth()  - 1.f,
-		                - (float)RectToLock.top    * 2.f / GetTargetHeight() + 1.f,
-		                  (float)RectToLock.right  * 2.f / GetTargetWidth()  - 1.f,
-		                - (float)RectToLock.bottom * 2.f / GetTargetHeight() + 1.f);
-
-		D3D::stateman->PopDepthState();
-		D3D::stateman->PopBlendState();
-
-		RestoreAPIState();
 	}
 
-	return 0;
-}
+	D3D::DrawEFBPokeQuads(type, data.data(), data.size());
 
+	if (type == POKE_Z)
+	{
+		D3D::stateman->PopDepthState();
+		D3D::stateman->PopBlendState();
+	}
+
+	RestoreAPIState();
+}
 
 void Renderer::SetViewport()
 {

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -37,6 +37,8 @@ public:
 	void RenderText(const std::string& text, int left, int top, u32 color) override;
 
 	u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
+	void PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data) override;
+
 	u16 BBoxRead(int index) override;
 	void BBoxWrite(int index, u16 value) override;
 

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -37,7 +37,7 @@ public:
 	void RenderText(const std::string& text, int left, int top, u32 color) override;
 
 	u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
-	void PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data) override;
+	void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override;
 
 	u16 BBoxRead(int index) override;
 	void BBoxWrite(int index, u16 value) override;

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -643,7 +643,7 @@ void FramebufferManager::GetTargetSize(unsigned int *width, unsigned int *height
 	*height = m_targetHeight;
 }
 
-void FramebufferManager::PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data)
+void FramebufferManager::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points)
 {
 	g_renderer->ResetAPIState();
 
@@ -657,10 +657,10 @@ void FramebufferManager::PokeEFB(EFBAccessType type, const std::vector<EfbPokeDa
 
 	glBindVertexArray(m_EfbPokes_VAO);
 	glBindBuffer(GL_ARRAY_BUFFER, m_EfbPokes_VBO);
-	glBufferData(GL_ARRAY_BUFFER, sizeof(EfbPokeData) * data.size(), data.data(), GL_STREAM_DRAW);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(EfbPokeData) * num_points, points, GL_STREAM_DRAW);
 	m_EfbPokes.Bind();
 	glViewport(0, 0, m_targetWidth, m_targetHeight);
-	glDrawArrays(GL_POINTS, 0, (GLsizei)data.size());
+	glDrawArrays(GL_POINTS, 0, (GLsizei)num_points);
 
 	g_renderer->RestoreAPIState();
 

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.h
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.h
@@ -92,7 +92,7 @@ public:
 	// convtype=0 -> rgb8->rgba6, convtype=2 -> rgba6->rgb8
 	static void ReinterpretPixelData(unsigned int convtype);
 
-	static void PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data);
+	static void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points);
 
 private:
 	XFBSourceBase* CreateXFBSource(unsigned int target_width, unsigned int target_height, unsigned int layers) override;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -944,19 +944,6 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 			}
 		}
 
-	case POKE_COLOR:
-	case POKE_Z:
-	{
-		std::vector<EfbPokeData> vector;
-		EfbPokeData d;
-		d.x = x;
-		d.y = y;
-		d.data = poke_data;
-		vector.push_back(d);
-		PokeEFB(type, vector);
-		break;
-	}
-
 	default:
 		break;
 	}
@@ -964,9 +951,9 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 	return 0;
 }
 
-void Renderer::PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data)
+void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points)
 {
-	FramebufferManager::PokeEFB(type, data);
+	FramebufferManager::PokeEFB(type, points, num_points);
 }
 
 u16 Renderer::BBoxRead(int index)

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -87,7 +87,7 @@ public:
 	void FlipImageData(u8 *data, int w, int h, int pixel_width = 3);
 
 	u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override;
-	void PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data) override;
+	void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override;
 
 	u16 BBoxRead(int index) override;
 	void BBoxWrite(int index, u16 value) override;

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -44,7 +44,7 @@ void AsyncRequests::PullEventsInternal()
 			} while(!m_queue.empty() && m_queue.front().type == first_event.type);
 
 			lock.unlock();
-			g_renderer->PokeEFB(t, m_merged_efb_pokes);
+			g_renderer->PokeEFB(t, m_merged_efb_pokes.data(), m_merged_efb_pokes.size());
 			lock.lock();
 			continue;
 		}
@@ -109,11 +109,17 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
 	switch (e.type)
 	{
 		case Event::EFB_POKE_COLOR:
-			g_renderer->AccessEFB(POKE_COLOR, e.efb_poke.x, e.efb_poke.y, e.efb_poke.data);
+			{
+				EfbPokeData poke = { e.efb_poke.x, e.efb_poke.y, e.efb_poke.data };
+				g_renderer->PokeEFB(POKE_COLOR, &poke, 1);
+			}
 			break;
 
 		case Event::EFB_POKE_Z:
-			g_renderer->AccessEFB(POKE_Z, e.efb_poke.x, e.efb_poke.y, e.efb_poke.data);
+			{
+				EfbPokeData poke = { e.efb_poke.x, e.efb_poke.y, e.efb_poke.data };
+				g_renderer->PokeEFB(POKE_Z, &poke, 1);
+			}
 			break;
 
 		case Event::EFB_PEEK_COLOR:

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -617,10 +617,3 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
 	XFBWrited = false;
 }
 
-void Renderer::PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data)
-{
-	for (EfbPokeData poke : data)
-	{
-		AccessEFB(type, poke.x, poke.y, poke.data);
-	}
-}

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -115,7 +115,7 @@ public:
 	static void RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbStride, u32 fbHeight, float Gamma = 1.0f);
 
 	virtual u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) = 0;
-	virtual void PokeEFB(EFBAccessType type, const std::vector<EfbPokeData>& data);
+	virtual void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) = 0;
 
 	virtual u16 BBoxRead(int index) = 0;
 	virtual void BBoxWrite(int index, u16 value) = 0;


### PR DESCRIPTION
Implementing the vectored EFB poke path for the D3D backend that is currently present in the GL backend.

This needs testing, I haven't identified any regressions, but if there is anyone who has titles that heavily use EFB pokes, could you please confirm this does not change anything, visually. Performance should be on par with GL now.

Additionally, I've increased the util vertex buffer to 64KiB, to reduce the number of draws which have to be issued to draw an entire frame with efb pokes. That buffer class is rather iffy though, and I had to modify it in order to not have to have an intermediate buffer, probably would be an idea in the future to create a general "streaming" buffer (and perhaps share with the vertex loader).