### PR TITLE
DQt2: Move menu bar into its own file.

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -4,18 +4,19 @@ add_definitions(-DQT_USE_QSTRINGBUILDER -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_
 set(CMAKE_AUTOMOC ON)
 
 set(SRCS
+	Host.cpp
 	Main.cpp
 	MainWindow.cpp
-	Host.cpp
+	MenuBar.cpp
 	RenderWidget.cpp
 	Resources.cpp
 	ToolBar.cpp
 	GameList/GameFile.cpp
 	GameList/GameList.cpp
-	GameList/GameTracker.cpp
 	GameList/GameListModel.cpp
-	GameList/TableProxyModel.cpp
+	GameList/GameTracker.cpp
 	GameList/ListProxyModel.cpp
+	GameList/TableProxyModel.cpp
 	)
 
 list(APPEND LIBS core uicommon)

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -40,6 +40,17 @@ void GameList::MakeTableView()
 	m_table->setSortingEnabled(true);
 	m_table->setCurrentIndex(QModelIndex());
 
+	// TODO load from config
+	m_table->setColumnHidden(GameListModel::COL_PLATFORM, false);
+	m_table->setColumnHidden(GameListModel::COL_ID, true);
+	m_table->setColumnHidden(GameListModel::COL_BANNER, false);
+	m_table->setColumnHidden(GameListModel::COL_TITLE, false);
+	m_table->setColumnHidden(GameListModel::COL_DESCRIPTION, true);
+	m_table->setColumnHidden(GameListModel::COL_MAKER, false);
+	m_table->setColumnHidden(GameListModel::COL_SIZE, false);
+	m_table->setColumnHidden(GameListModel::COL_COUNTRY, false);
+	m_table->setColumnHidden(GameListModel::COL_RATING, false);
+
 	// FIXME These icon image are overly wide and should be cut down to size,
 	// then we can remove these lines.
 	m_table->setColumnWidth(GameListModel::COL_PLATFORM, 52);

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -9,6 +9,7 @@
 #include <QString>
 #include <QToolBar>
 
+#include "DolphinQt2/MenuBar.h"
 #include "DolphinQt2/RenderWidget.h"
 #include "DolphinQt2/ToolBar.h"
 #include "DolphinQt2/GameList/GameList.h"
@@ -37,16 +38,11 @@ private slots:
 	void ScreenShot();
 
 private:
-	void MakeToolBar();
-	void MakeStack();
 	void MakeGameList();
+	void MakeMenuBar();
 	void MakeRenderWidget();
-
-	void MakeMenus();
-	void MakeFileMenu();
-	void MakeViewMenu();
-	void AddTableColumnsMenu(QMenu* view_menu);
-	void AddListTypePicker(QMenu* view_menu);
+	void MakeStack();
+	void MakeToolBar();
 
 	void StartGame(QString path);
 	void ShowRenderWidget();
@@ -54,6 +50,7 @@ private:
 
 	QStackedWidget* m_stack;
 	ToolBar* m_tool_bar;
+	MenuBar* m_menu_bar;
 	GameList* m_game_list;
 	RenderWidget* m_render_widget;
 	bool m_rendering_to_main;

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -1,0 +1,80 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QAction>
+#include <QActionGroup>
+
+#include "Core/ConfigManager.h"
+#include "DolphinQt2/MenuBar.h"
+
+MenuBar::MenuBar(QWidget* parent)
+	: QMenuBar(parent)
+{
+	AddFileMenu();
+	addMenu(tr("Emulation"));
+	addMenu(tr("Movie"));
+	addMenu(tr("Options"));
+	addMenu(tr("Tools"));
+	AddViewMenu();
+	addMenu(tr("Help"));
+}
+
+void MenuBar::AddFileMenu()
+{
+	QMenu* file_menu = addMenu(tr("File"));
+	file_menu->addAction(tr("Open"), this, SIGNAL(Open()));
+	file_menu->addAction(tr("Exit"), this, SIGNAL(Exit()));
+}
+
+void MenuBar::AddViewMenu()
+{
+	QMenu* view_menu = addMenu(tr("View"));
+	AddGameListTypeSection(view_menu);
+	view_menu->addSeparator();
+	AddTableColumnsMenu(view_menu);
+}
+
+void MenuBar::AddGameListTypeSection(QMenu* view_menu)
+{
+	QAction* table_view = view_menu->addAction(tr("Table"));
+	table_view->setCheckable(true);
+
+	QAction* list_view = view_menu->addAction(tr("List"));
+	list_view->setCheckable(true);
+
+	QActionGroup* list_group = new QActionGroup(this);
+	list_group->addAction(table_view);
+	list_group->addAction(list_view);
+
+	// TODO load this from settings
+	table_view->setChecked(true);
+
+	connect(table_view, &QAction::triggered, this, &MenuBar::ShowTable);
+	connect(list_view, &QAction::triggered, this, &MenuBar::ShowList);
+}
+
+// TODO implement this after we stop using SConfig.
+void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
+{
+	QActionGroup* column_group = new QActionGroup(this);
+	QMenu* cols_menu = view_menu->addMenu(tr("Table Columns"));
+	column_group->setExclusive(false);
+
+	QStringList col_names{
+		tr("Platform"),
+		tr("ID"),
+		tr("Banner"),
+		tr("Title"),
+		tr("Description"),
+		tr("Maker"),
+		tr("Size"),
+		tr("Country"),
+		tr("Quality")
+	};
+	for (int i = 0; i < col_names.count(); i++)
+	{
+		QAction* action = column_group->addAction(cols_menu->addAction(col_names[i]));
+		action->setCheckable(true);
+	}
+}

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -1,0 +1,30 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QMenu>
+#include <QMenuBar>
+
+class MenuBar final : public QMenuBar
+{
+	Q_OBJECT
+
+public:
+	MenuBar(QWidget* parent = nullptr);
+
+signals:
+	void Open();
+	void Exit();
+
+	void ShowTable();
+	void ShowList();
+
+private:
+	void AddFileMenu();
+	void AddViewMenu();
+
+	void AddGameListTypeSection(QMenu* view_menu);
+	void AddTableColumnsMenu(QMenu* view_menu);
+};


### PR DESCRIPTION
I disabled the table column pickers as well. That code was nasty. Once I replace SConfig with QSettings I'll add that functionality back in.

I think this is the last major MainWindow refactor. The next step is to replace SConfig, and then it'll be time to start implementing new features :)