### PR TITLE
DQt2: Use a separate INI file for UI settings

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRCS
 	MenuBar.cpp
 	RenderWidget.cpp
 	Resources.cpp
+	Settings.cpp
 	ToolBar.cpp
 	GameList/GameFile.cpp
 	GameList/GameList.cpp

--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -14,6 +14,7 @@
 #include "Core/ConfigManager.h"
 #include "DiscIO/VolumeCreator.h"
 #include "DolphinQt2/Resources.h"
+#include "DolphinQt2/Settings.h"
 #include "DolphinQt2/GameList/GameFile.h"
 
 static const int CACHE_VERSION = 13; // Last changed in PR #3261
@@ -48,12 +49,6 @@ GameFile::GameFile(QString path) : m_path(path)
 	}
 
 	m_valid = true;
-}
-
-DiscIO::IVolume::ELanguage GameFile::GetDefaultLanguage() const
-{
-	bool wii = m_platform != DiscIO::IVolume::GAMECUBE_DISC;
-	return SConfig::GetInstance().GetCurrentLanguage(wii);
 }
 
 QString GameFile::GetCacheFileName() const
@@ -194,7 +189,14 @@ QString GameFile::GetLanguageString(QMap<DiscIO::IVolume::ELanguage, QString> m)
 	// Try the settings language, then English, then just pick one.
 	if (m.isEmpty())
 		return QString();
-	DiscIO::IVolume::ELanguage current_lang = GetDefaultLanguage();
+
+	bool wii = m_platform != DiscIO::IVolume::GAMECUBE_DISC;
+	DiscIO::IVolume::ELanguage current_lang;
+	if (wii)
+		current_lang = Settings().GetWiiSystemLanguage();
+	else
+		current_lang = Settings().GetGCSystemLanguage();
+
 	if (m.contains(current_lang))
 		return m[current_lang];
 	if (m.contains(DiscIO::IVolume::LANGUAGE_ENGLISH))

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -4,7 +4,6 @@
 
 #include <QHeaderView>
 
-#include "Core/ConfigManager.h"
 #include "DolphinQt2/GameList/GameList.h"
 #include "DolphinQt2/GameList/ListProxyModel.h"
 #include "DolphinQt2/GameList/TableProxyModel.h"

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -39,10 +39,8 @@ signals:
 private:
 	void UpdateDirectory(QString dir);
 	void UpdateFile(QString path);
-	void GenerateFilters();
 
 	QSet<QString> m_tracked_files;
-	QStringList m_filters;
 	QThread m_loader_thread;
 	GameLoader* m_loader;
 };

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -5,7 +5,6 @@
 #include <QAction>
 #include <QActionGroup>
 
-#include "Core/ConfigManager.h"
 #include "DolphinQt2/MenuBar.h"
 
 MenuBar::MenuBar(QWidget* parent)
@@ -54,7 +53,7 @@ void MenuBar::AddGameListTypeSection(QMenu* view_menu)
 	connect(list_view, &QAction::triggered, this, &MenuBar::ShowList);
 }
 
-// TODO implement this after we stop using SConfig.
+// TODO implement this
 void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
 {
 	QActionGroup* column_group = new QActionGroup(this);

--- a/Source/Core/DolphinQt2/Resources.cpp
+++ b/Source/Core/DolphinQt2/Resources.cpp
@@ -6,7 +6,6 @@
 
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
-#include "Core/ConfigManager.h"
 #include "DolphinQt2/Resources.h"
 
 QList<QPixmap> Resources::m_platforms;

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -1,0 +1,75 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QSize>
+
+#include "Common/FileUtil.h"
+#include "Core/ConfigManager.h"
+#include "DolphinQt2/Settings.h"
+
+static QString GetSettingsPath()
+{
+	return QString::fromStdString(File::GetUserPath(D_CONFIG_IDX)) + QStringLiteral("/UI.ini");
+}
+
+Settings::Settings(QObject* parent)
+	: QSettings(GetSettingsPath(), QSettings::IniFormat, parent)
+{
+}
+
+QString Settings::GetThemeDir() const
+{
+	QString theme_name = value(QStringLiteral("Theme"), QStringLiteral("Clean")).toString();
+	return QString::fromStdString(File::GetThemeDir(theme_name.toStdString()));
+}
+
+QString Settings::GetLastGame() const
+{
+	return value(QStringLiteral("GameList/LastGame")).toString();
+}
+
+void Settings::SetLastGame(QString path)
+{
+	setValue(QStringLiteral("GameList/LastGame"), path);
+}
+
+QStringList Settings::GetPaths() const
+{
+	return value(QStringLiteral("GameList/Paths")).toStringList();
+}
+
+void Settings::SetPaths(QStringList paths)
+{
+	setValue(QStringLiteral("GameList/Paths"), paths);
+}
+
+DiscIO::IVolume::ELanguage Settings::GetWiiSystemLanguage() const
+{
+	return SConfig::GetInstance().GetCurrentLanguage(true);
+}
+
+DiscIO::IVolume::ELanguage Settings::GetGCSystemLanguage() const
+{
+	return SConfig::GetInstance().GetCurrentLanguage(false);
+}
+
+bool Settings::GetConfirmStop() const
+{
+	return value(QStringLiteral("Emulation/ConfirmStop"), true).toBool();
+}
+
+bool Settings::GetRenderToMain() const
+{
+	return value(QStringLiteral("Graphics/RenderToMain"), false).toBool();
+}
+
+bool Settings::GetFullScreen() const
+{
+	return value(QStringLiteral("Graphics/FullScreen"), false).toBool();
+}
+
+QSize Settings::GetRenderWindowSize() const
+{
+	return value(QStringLiteral("Graphics/RenderWindowSize"), QSize(640, 480)).toSize();
+}

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -1,0 +1,36 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QSettings>
+
+#include "DiscIO/Volume.h"
+
+class Settings final : public QSettings
+{
+	Q_OBJECT
+
+public:
+	Settings(QObject* parent = nullptr);
+
+	// UI
+	QString GetThemeDir() const;
+
+	// GameList
+	QString GetLastGame() const;
+	void SetLastGame(QString path);
+	QStringList GetPaths() const;
+	void SetPaths(QStringList paths);
+	DiscIO::IVolume::ELanguage GetWiiSystemLanguage() const;
+	DiscIO::IVolume::ELanguage GetGCSystemLanguage() const;
+
+	// Emulation
+	bool GetConfirmStop() const;
+
+	// Graphics
+	bool GetRenderToMain() const;
+	bool GetFullScreen() const;
+	QSize GetRenderWindowSize() const;
+};

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -4,8 +4,7 @@
 
 #include <QIcon>
 
-#include "Common/FileUtil.h"
-#include "Core/ConfigManager.h"
+#include "DolphinQt2/Settings.h"
 #include "DolphinQt2/ToolBar.h"
 
 static constexpr QSize ICON_SIZE(32, 32);
@@ -82,7 +81,7 @@ void ToolBar::MakeActions()
 
 void ToolBar::UpdateIcons()
 {
-	QString dir = QString::fromStdString(File::GetThemeDir(SConfig::GetInstance().theme_name));
+	QString dir = Settings().GetThemeDir();
 
 	m_open_action->setIcon(QIcon(QStringLiteral("open.png").prepend(dir)));
 	m_paths_action->setIcon(QIcon(QStringLiteral("browse.png").prepend(dir)));


### PR DESCRIPTION
Been wanting to do this for a while. This creates `UI.ini` next to the current `Config.ini` which stores UI settings such as window position, last game played, render window size, and so on.  Most of the config dialogs will still have to set SConfig, since that's what the core uses, but I'll have them go through Settings to do so.

I removed the platform filter from the game tracker as that's really the job of a filter proxy model.

The decision to have getters/setters for individual settings wasn't an obvious one but I think it's right.