### PR TITLE
Set g_vertex_manager to nullptr on DX11 backend shutdown

### DIFF
--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -231,6 +231,8 @@ void VideoBackend::Shutdown()
 		delete g_renderer;
 		g_renderer = nullptr;
 		g_texture_cache = nullptr;
+		g_vertex_manager = nullptr;
+		g_perf_query = nullptr;
 	}
 }
 


### PR DESCRIPTION
OpenGL backend already does this.. the (in RFC CR) DX12 backend gets tripped up if this is not set to nullptr, when it might not actually exist (if shutting down a game when on DX11, then switching to DX12).