### PR TITLE
Always load system fonts from IPL dump, if available

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -170,6 +170,7 @@ bool CBoot::Load_BS2(const std::string& _rBootROMFilename)
 	const u32 USA_v1_0 = 0x6D740AE7; // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385344#pid385344
 	const u32 USA_v1_1 = 0xD5E6FEEA; // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385334#pid385334
 	const u32 USA_v1_2 = 0x86573808; // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385399#pid385399
+	const u32 BRA_v1_0 = 0x667D0B64; // GameCubes sold in Brazil have this IPL. Same as USA v1.2 but localized
 	const u32 JAP_v1_0 = 0x6DAC1F2A; // Redump
 	const u32 JAP_v1_1 = 0xD235E3F9; // https://bugs.dolphin-emu.org/issues/8936
 	const u32 PAL_v1_0 = 0x4F319F43; // Redump
@@ -189,6 +190,7 @@ bool CBoot::Load_BS2(const std::string& _rBootROMFilename)
 	case USA_v1_0:
 	case USA_v1_1:
 	case USA_v1_2:
+	case BRA_v1_0:
 		ipl_region = USA_DIR;
 		break;
 	case JAP_v1_0:

--- a/Source/Core/Core/HW/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.h
@@ -71,4 +71,6 @@ private:
 	u32 CommandRegion() const { return (m_uAddress & ~(1 << 31)) >> 8; }
 
 	void LoadFileToIPL(const std::string& filename, u32 offset);
+	void LoadFontFile(const std::string& filename, u32 offset);
+	std::string FindIPLDump(const std::string& path_prefix);
 };


### PR DESCRIPTION
Dolphin currently ships with a set of free fonts but unfortunately they have different padding and this causes text issues in some games (right now I remember of [Pokémon Colosseum Bonus Disc](https://wiki.dolphin-emu.org/index.php?title=Pok%C3%A9mon_Colosseum_Bonus_Disc) but there're other titles as well). 

The user can fix that by providing an IPL dump and making sure "Skip BIOS" is disabled, however, this approach has one caveat, if the user wants to actually skip BIOS, Dolphin will load the free fonts even if there's an IPL dump available! So, this PR changes this behavior by making Dolphin **always** load the original fonts if an IPL dump is available. It's mainly to avoid things like [manually extracting the fonts](https://wiki.dolphin-emu.org/index.php?title=Extracting_Fonts_From_a_GameCube_BIOS).

Theoretically a Wii should have those fonts stored somewhere as well (for GC backwards compatibility), in future we may improve this by loading the fonts not only from the IPL dump but from the NAND as well...

*(also, this is my first "real" code contribution with Dolphin, I'm somewhat satisfied with the final result of this PR but one thing I would like to improve is the helper function to search for the IPL dumps, while it works as intended it also looks ugly, so if anyone have any advises or tips to improve it, please let me know!)*