### PR TITLE
Use const reference, explicit, final, and override consistently in DQt2

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -29,7 +29,7 @@ static QMap<DiscIO::IVolume::ELanguage, QString> ConvertLanguageMap(
 	return result;
 }
 
-GameFile::GameFile(QString path) : m_path(path)
+GameFile::GameFile(const QString& path) : m_path(path)
 {
 	m_valid = false;
 
@@ -81,7 +81,7 @@ void GameFile::ReadBanner(const DiscIO::IVolume& volume)
 		m_banner = Resources::GetMisc(Resources::BANNER_MISSING);
 }
 
-bool GameFile::LoadFileInfo(QString path)
+bool GameFile::LoadFileInfo(const QString& path)
 {
 	QFileInfo info(path);
 	if (!info.exists() || !info.isReadable())
@@ -184,7 +184,7 @@ void GameFile::SaveCache()
 	// TODO
 }
 
-QString GameFile::GetLanguageString(QMap<DiscIO::IVolume::ELanguage, QString> m) const
+QString GameFile::GetLanguageString(const QMap<DiscIO::IVolume::ELanguage, QString>& m) const
 {
 	// Try the settings language, then English, then just pick one.
 	if (m.isEmpty())

--- a/Source/Core/DolphinQt2/GameList/GameFile.h
+++ b/Source/Core/DolphinQt2/GameList/GameFile.h
@@ -15,7 +15,7 @@
 class GameFile final
 {
 public:
-	explicit GameFile(QString path);
+	explicit GameFile(const QString& path);
 
 	bool IsValid()            const { return m_valid; }
 
@@ -62,11 +62,11 @@ public:
 
 private:
 	DiscIO::IVolume::ELanguage GetDefaultLanguage() const;
-	QString GetLanguageString(QMap<DiscIO::IVolume::ELanguage, QString> m) const;
+	QString GetLanguageString(const QMap<DiscIO::IVolume::ELanguage, QString>& m) const;
 
 	QString GetCacheFileName() const;
 	void ReadBanner(const DiscIO::IVolume& volume);
-	bool LoadFileInfo(QString path);
+	bool LoadFileInfo(const QString& path);
 	void LoadState();
 	bool IsElfOrDol();
 	bool TryLoadElfDol();

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -18,10 +18,10 @@ public:
 	explicit GameListModel(QObject* parent = nullptr);
 
 	// Qt's Model/View stuff uses these overrides.
-	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
-	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-	int rowCount(const QModelIndex& parent) const;
-	int columnCount(const QModelIndex& parent) const;
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+	QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+	int rowCount(const QModelIndex& parent) const override;
+	int columnCount(const QModelIndex& parent) const override;
 
 	// Path of the Game at the specified index.
 	QString GetPath(int index) const { return m_games[index]->GetPath(); }

--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -51,7 +51,7 @@ void GameTracker::AddDirectory(QString dir)
 	UpdateDirectory(dir);
 }
 
-void GameTracker::UpdateDirectory(QString dir)
+void GameTracker::UpdateDirectory(const QString& dir)
 {
 	QDirIterator it(dir, game_filters);
 	while (it.hasNext())
@@ -66,7 +66,7 @@ void GameTracker::UpdateDirectory(QString dir)
 	}
 }
 
-void GameTracker::UpdateFile(QString file)
+void GameTracker::UpdateFile(const QString& file)
 {
 	if (QFileInfo(file).exists())
 	{

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -18,7 +18,9 @@ class GameLoader;
 
 // Watches directories and loads GameFiles in a separate thread.
 // To use this, just add directories using AddDirectory, and listen for the
-// GameLoaded and GameRemoved signals.
+// GameLoaded and GameRemoved signals. Ignore the PathChanged signal, it's
+// only there because the Qt people made fileChanged and directoryChanged
+// private.
 class GameTracker final : public QFileSystemWatcher
 {
 	Q_OBJECT
@@ -37,15 +39,15 @@ signals:
 	void PathChanged(QString path);
 
 private:
-	void UpdateDirectory(QString dir);
-	void UpdateFile(QString path);
+	void UpdateDirectory(const QString& dir);
+	void UpdateFile(const QString& path);
 
 	QSet<QString> m_tracked_files;
 	QThread m_loader_thread;
 	GameLoader* m_loader;
 };
 
-class GameLoader : public QObject
+class GameLoader final : public QObject
 {
 	Q_OBJECT
 

--- a/Source/Core/DolphinQt2/GameList/ListProxyModel.h
+++ b/Source/Core/DolphinQt2/GameList/ListProxyModel.h
@@ -4,11 +4,13 @@
 
 #include <QSortFilterProxyModel>
 
+// This subclass of QSortFilterProxyModel transforms the raw data into a
+// single-column large icon + name to be displayed in a QListView.
 class ListProxyModel final : public QSortFilterProxyModel
 {
 	Q_OBJECT
 
 public:
-	ListProxyModel(QObject* parent = nullptr);
-	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+	explicit ListProxyModel(QObject* parent = nullptr);
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 };

--- a/Source/Core/DolphinQt2/GameList/TableProxyModel.h
+++ b/Source/Core/DolphinQt2/GameList/TableProxyModel.h
@@ -14,6 +14,6 @@ class TableProxyModel final : public QSortFilterProxyModel
 	Q_OBJECT
 
 public:
-	TableProxyModel(QObject* parent = nullptr);
-	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+	explicit TableProxyModel(QObject* parent = nullptr);
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 };

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -2,13 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <QAction>
 #include <QDir>
 #include <QFile>
 #include <QFileDialog>
 #include <QIcon>
-#include <QLineEdit>
-#include <QMenu>
 #include <QMessageBox>
 
 #include "Core/BootManager.h"
@@ -194,7 +191,7 @@ void MainWindow::ScreenShot()
 	Core::SaveScreenShot();
 }
 
-void MainWindow::StartGame(QString path)
+void MainWindow::StartGame(const QString& path)
 {
 	// If we're running, only start a new game once we've stopped the last.
 	if (Core::GetState() != Core::CORE_UNINITIALIZED)

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -32,8 +32,11 @@ private slots:
 	void Browse();
 	void Play();
 	void Pause();
+
+	// May ask for confirmation. Returns whether or not it actually stopped.
 	bool Stop();
 	void ForceStop();
+
 	void FullScreen();
 	void ScreenShot();
 
@@ -44,7 +47,7 @@ private:
 	void MakeStack();
 	void MakeToolBar();
 
-	void StartGame(QString path);
+	void StartGame(const QString& path);
 	void ShowRenderWidget();
 	void HideRenderWidget();
 

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -12,7 +12,7 @@ class MenuBar final : public QMenuBar
 	Q_OBJECT
 
 public:
-	MenuBar(QWidget* parent = nullptr);
+	explicit MenuBar(QWidget* parent = nullptr);
 
 signals:
 	void Open();

--- a/Source/Core/DolphinQt2/RenderWidget.h
+++ b/Source/Core/DolphinQt2/RenderWidget.h
@@ -12,7 +12,7 @@ class RenderWidget final : public QWidget
 	Q_OBJECT
 
 public:
-	RenderWidget(QWidget* parent = nullptr);
+	explicit RenderWidget(QWidget* parent = nullptr);
 
 	bool event(QEvent* event);
 

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -29,7 +29,7 @@ QString Settings::GetLastGame() const
 	return value(QStringLiteral("GameList/LastGame")).toString();
 }
 
-void Settings::SetLastGame(QString path)
+void Settings::SetLastGame(const QString& path)
 {
 	setValue(QStringLiteral("GameList/LastGame"), path);
 }
@@ -39,7 +39,7 @@ QStringList Settings::GetPaths() const
 	return value(QStringLiteral("GameList/Paths")).toStringList();
 }
 
-void Settings::SetPaths(QStringList paths)
+void Settings::SetPaths(const QStringList& paths)
 {
 	setValue(QStringLiteral("GameList/Paths"), paths);
 }

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -8,21 +8,22 @@
 
 #include "DiscIO/Volume.h"
 
+// UI settings to be stored in the config directory.
 class Settings final : public QSettings
 {
 	Q_OBJECT
 
 public:
-	Settings(QObject* parent = nullptr);
+	explicit Settings(QObject* parent = nullptr);
 
 	// UI
 	QString GetThemeDir() const;
 
 	// GameList
 	QString GetLastGame() const;
-	void SetLastGame(QString path);
+	void SetLastGame(const QString& path);
 	QStringList GetPaths() const;
-	void SetPaths(QStringList paths);
+	void SetPaths(const QStringList& paths);
 	DiscIO::IVolume::ELanguage GetWiiSystemLanguage() const;
 	DiscIO::IVolume::ELanguage GetGCSystemLanguage() const;
 

--- a/Source/Core/DolphinQt2/ToolBar.h
+++ b/Source/Core/DolphinQt2/ToolBar.h
@@ -13,7 +13,7 @@ class ToolBar final : public QToolBar
 	Q_OBJECT
 
 public:
-	ToolBar(QWidget* parent = nullptr);
+	explicit ToolBar(QWidget* parent = nullptr);
 
 public slots:
 	void EmulationStarted();


### PR DESCRIPTION
We don't want to use const reference in signals/slots because they may execute asynchronously. I think I got everywhere else.