### PR TITLE
Add audio output device changeability [WIP]

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.cpp
+++ b/Source/Core/AudioCommon/AlsaSoundStream.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 
 #include "AudioCommon/AlsaSoundStream.h"
+#include "AudioCommon/AudioDevice.h"
 #include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 #include "Common/Logging/Log.h"
@@ -97,7 +98,10 @@ bool AlsaSound::AlsaInit()
 	snd_pcm_uframes_t buffer_size,buffer_size_max;
 	unsigned int periods;
 
-	err = snd_pcm_open(&handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
+	AudioDevice audio_device = AudioDevice::GetSelectedDevice();
+	NOTICE_LOG(AUDIO, "Selected audio device: <%s> %s", audio_device.id.c_str(), audio_device.name.c_str());
+
+	err = snd_pcm_open(&handle, audio_device.id.c_str(), SND_PCM_STREAM_PLAYBACK, 0);
 	if (err < 0)
 	{
 		ERROR_LOG(AUDIO, "Audio open error: %s\n", snd_strerror(err));

--- a/Source/Core/AudioCommon/AudioCommon.vcxproj
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <ClCompile Include="aldlist.cpp" />
     <ClCompile Include="AudioCommon.cpp" />
+    <ClCompile Include="AudioDevice.cpp" />
     <ClCompile Include="DPL2Decoder.cpp" />
     <ClCompile Include="Mixer.cpp" />
     <ClCompile Include="NullSoundStream.cpp" />
@@ -52,6 +53,7 @@
     <ClInclude Include="AlsaSoundStream.h" />
     <ClInclude Include="AOSoundStream.h" />
     <ClInclude Include="AudioCommon.h" />
+    <ClInclude Include="AudioDevice.h" />
     <ClInclude Include="CoreAudioSoundStream.h" />
     <ClInclude Include="DPL2Decoder.h" />
     <ClInclude Include="Mixer.h" />

--- a/Source/Core/AudioCommon/AudioCommon.vcxproj.filters
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="SoundStreams">
@@ -21,6 +21,9 @@
       <Filter>SoundStreams</Filter>
     </ClCompile>
     <ClCompile Include="XAudio2_7Stream.cpp">
+      <Filter>SoundStreams</Filter>
+    </ClCompile>
+    <ClCompile Include="AudioDevice.cpp">
       <Filter>SoundStreams</Filter>
     </ClCompile>
   </ItemGroup>
@@ -58,6 +61,9 @@
       <Filter>SoundStreams</Filter>
     </ClInclude>
     <ClInclude Include="SoundStream.h">
+      <Filter>SoundStreams</Filter>
+    </ClInclude>
+    <ClInclude Include="AudioDevice.h">
       <Filter>SoundStreams</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Source/Core/AudioCommon/AudioDevice.cpp
+++ b/Source/Core/AudioCommon/AudioDevice.cpp
@@ -1,0 +1,212 @@
+
+#if defined _WIN32
+#include <Mmdeviceapi.h> // Must be included before devpkey:
+#include <Functiondiscoverykeys_devpkey.h>
+#elif defined HAVE_ALSA && HAVE_ALSA
+#include <alsa/asoundlib.h>
+#endif
+
+#include "AudioDevice.h"
+#include "Common/StringUtil.h"
+#include "Core/ConfigManager.h"
+
+std::vector<AudioDevice> AudioDevice::devices;
+// index 0 fits XAudio2_7 default, id "default" fits ALSA default
+AudioDevice AudioDevice::DEFAULT = AudioDevice(0, "Default audio device", "", "default");
+bool AudioDevice::loaded = false;
+
+void AudioDevice::LoadDevices()
+{
+	devices.clear();
+
+#if defined _WIN32
+#define THROW_ON_ERROR(hr) if(FAILED(hr)) { throw hr; }
+
+	HRESULT hr;
+
+	IMMDeviceEnumerator* device_enumerator = NULL;
+	IMMDeviceCollection* device_collection = NULL;
+	u32 count = 0;
+
+	// Some awful COM code to get the number of audio endpoints.
+	try
+	{
+		hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&device_enumerator);
+		THROW_ON_ERROR(hr);
+
+		hr = device_enumerator->EnumAudioEndpoints(EDataFlow::eRender, DEVICE_STATE_ACTIVE, &device_collection);
+		THROW_ON_ERROR(hr);
+
+		hr = device_collection->GetCount(&count);
+		THROW_ON_ERROR(hr);
+	}
+	catch (HRESULT hresult)
+	{
+		ERROR_LOG(AUDIO, "Error while loading audio device list: %#X", hresult);
+	}
+
+	// Retrieve details for each audio endpoint.
+	for (u32 i = 0; i < count; i++)
+	{
+		AudioDevice device;
+		device.index = i;
+
+		LPWSTR id = NULL;
+		IPropertyStore* propStore = NULL;
+		IMMDevice* device_endpoint = NULL;
+
+		PROPVARIANT devPath;
+		PROPVARIANT devName;
+
+		// some more awful COM code to retrieve the necessary device information.
+		try
+		{
+			hr = device_collection->Item(i, &device_endpoint);
+			THROW_ON_ERROR(hr);
+
+			hr = device_endpoint->GetId(&id);
+			THROW_ON_ERROR(hr);
+			device.id = TStrToUTF8(id);
+			
+			hr = device_endpoint->OpenPropertyStore(STGM_READ, &propStore);
+			THROW_ON_ERROR(hr);
+			
+			PropVariantInit(&devPath);
+			// wtf? the necessary propkey for device path isn't defined?
+			// see https://msdn.microsoft.com/en-us/library/windows/desktop/hh405048(v=vs.85).aspx comment 
+			hr = propStore->GetValue(PROPERTYKEY{ { 0x9c119480, 0xddc2, 0x4954,{ 0xa1, 0x50, 0x5b, 0xd2, 0x40, 0xd4, 0x54, 0xad } }, 1 }, &devPath);
+			THROW_ON_ERROR(hr);
+			device.path = TStrToUTF8(devPath.pwszVal);
+			
+			PropVariantInit(&devName);
+			hr = propStore->GetValue(PKEY_Device_FriendlyName, &devName);
+			THROW_ON_ERROR(hr);
+			device.name = TStrToUTF8(devName.pwszVal);
+			
+			devices.push_back(device);
+		}
+		catch (HRESULT hresult)
+		{
+			ERROR_LOG(AUDIO, "Error while loading audio device: %#X", hresult);
+		}
+
+		CoTaskMemFree(id);
+		PropVariantClear(&devPath);
+		PropVariantClear(&devName);
+		if (propStore != NULL)
+			propStore->Release();
+		if (device_endpoint != NULL)
+			device_endpoint->Release();
+		
+	}
+
+	if (device_enumerator != NULL)
+		device_enumerator->Release();
+	if (device_collection != NULL)
+		device_collection->Release();
+
+#undef THROW_ON_ERROR
+#elif defined HAVE_ALSA && HAVE_ALSA
+
+	// get all sound devices from all cards for pcm
+	char **hints;
+	int err = snd_device_name_hint(-1, "pcm", (void***)&hints);
+	if (err != 0)
+	{
+		ERROR_LOG(AUDIO, "Error while loading audio device list: %#X", err);
+		return;
+	}
+
+	// iterate over all retrieved sound devices
+	char** n = hints;
+	snd_pcm_t* handle;
+	while (*n != NULL)
+	{
+
+		char *name = snd_device_name_get_hint(*n, "NAME");
+		char *ioid = snd_device_name_get_hint(*n, "IOID");
+		char *desc = snd_device_name_get_hint(*n, "DESC");
+
+		// Name valid && description valid && is output device (NULL means both)
+		if (name != NULL && 0 != strcmp("null", name) && desc != NULL && 0 != strcmp("null", desc) && (ioid == NULL || 0 == strcmp("Output", ioid)))
+		{
+			AudioDevice device;
+			device.name = std::string(desc);
+			device.id = std::string(name);
+			// test if the device is available and applicable for PCM output
+			// TODO: Filter the mass of devices different. There are just too many options!
+			// But what's the criteria? I don't know.
+			if (snd_pcm_open(&handle, device.id.c_str(), SND_PCM_STREAM_PLAYBACK, 0) >= 0)
+			{
+				// That device works!
+				snd_pcm_close(handle);
+				// is this the default? If yes, overwrite the "default" default.
+				if (device.id == "default")
+				{
+					device.name = "Default audio device (" + device.name + ")";
+					AudioDevice::DEFAULT = device;
+				}
+				else
+				{
+					devices.push_back(device);
+				}
+			}
+		}
+		free(name);
+		free(ioid);
+		free(desc);
+		n++;
+	}
+
+	snd_device_name_free_hint((void**)hints);
+	
+#endif
+	// TODO: support other linux sound backends / PulseAudio?
+	// TODO: support osx?
+
+	// Show what we got
+	for (AudioDevice& dev : devices)
+	{
+		INFO_LOG(AUDIO, "Found audio device: Name: <%s>, id: %s", dev.name.c_str(), dev.id.c_str());
+	}
+
+	loaded = true;
+}
+
+std::vector<AudioDevice>& AudioDevice::GetDevices()
+{
+	if (!loaded)
+		LoadDevices();
+	return devices;
+}
+
+void AudioDevice::ReloadDevices()
+{
+	LoadDevices();
+}
+
+AudioDevice& AudioDevice::GetDeviceById(const std::string& id)
+{
+	for (AudioDevice& device : GetDevices())
+	{
+		if (device.id == id)
+		{
+			return device;
+		}
+	}
+	// TODO: maybe don't let invalid id's silently fall back to the default device (here)?
+	return AudioDevice::DEFAULT;
+}
+
+AudioDevice& AudioDevice::GetSelectedDevice()
+{
+	return GetDeviceById(SConfig::GetInstance().sAudioDevice);
+}
+
+AudioDevice& AudioDevice::GetDefaultDevice()
+{
+	// Make sure devices are loaded, because the default's name might change.
+	if (!loaded)
+		LoadDevices();
+	return AudioDevice::DEFAULT;
+}

--- a/Source/Core/AudioCommon/AudioDevice.h
+++ b/Source/Core/AudioCommon/AudioDevice.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct AudioDevice
+{
+
+public:
+	AudioDevice() {};
+	AudioDevice(u32 _index, std::string _name, std::string _path, std::string _id) : index(_index), name(_name), path(_path), id(_id) {};
+
+	inline bool operator==(const AudioDevice& other) { return id == other.id; }
+	inline bool operator!=(const AudioDevice& other) { return !operator==(other); }
+
+	static std::vector<AudioDevice>& GetDevices();
+	static void ReloadDevices();
+	static AudioDevice& GetDeviceById(const std::string& id);
+	static AudioDevice& GetSelectedDevice();
+	static AudioDevice& GetDefaultDevice();
+	
+	u32 index;
+	std::string name;
+	std::string path;
+	std::string id;
+
+private:
+	static void LoadDevices();
+
+	static std::vector<AudioDevice> devices;
+	static bool loaded;
+	static AudioDevice DEFAULT;
+
+};

--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SRCS	AudioCommon.cpp
+			AudioDevice.cpp
 			DPL2Decoder.cpp
 			Mixer.cpp
 			WaveFile.cpp

--- a/Source/Core/AudioCommon/XAudio2_7Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2_7Stream.cpp
@@ -8,6 +8,7 @@
 #include <XAudio2_7/XAudio2.h>
 
 #include "AudioCommon/AudioCommon.h"
+#include "AudioCommon/AudioDevice.h"
 #include "AudioCommon/XAudio2_7Stream.h"
 #include "Common/Event.h"
 #include "Common/MsgHandler.h"
@@ -173,9 +174,12 @@ bool XAudio2_7::Start()
 	}
 	m_xaudio2 = std::unique_ptr<IXAudio2, Releaser>(xaudptr);
 
+	AudioDevice audio_device = AudioDevice::GetSelectedDevice();
+	INFO_LOG(AUDIO, "Using Audio Device: %s", audio_device.name.c_str());
+
 	// XAudio2 master voice
 	// XAUDIO2_DEFAULT_CHANNELS instead of 2 for expansion?
-	if (FAILED(hr = m_xaudio2->CreateMasteringVoice(&m_mastering_voice, 2, m_mixer->GetSampleRate())))
+	if (FAILED(hr = m_xaudio2->CreateMasteringVoice(&m_mastering_voice, 2, m_mixer->GetSampleRate(), 0, audio_device.index)))
 	{
 		PanicAlert("XAudio2_7 master voice creation failed: %#X", hr);
 		Stop();

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -5,6 +5,7 @@
 #include <cinttypes>
 #include <memory>
 
+#include "AudioCommon/AudioDevice.h"
 #include "Common/CDUtils.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
@@ -298,6 +299,7 @@ void SConfig::SaveDSPSettings(IniFile& ini)
 	dsp->Set("DumpAudio", m_DumpAudio);
 	dsp->Set("DumpUCode", m_DumpUCode);
 	dsp->Set("Backend", sBackend);
+	dsp->Set("AudioDevice", sAudioDevice);
 	dsp->Set("Volume", m_Volume);
 	dsp->Set("CaptureLog", m_DSPCaptureLog);
 }
@@ -573,6 +575,7 @@ void SConfig::LoadDSPSettings(IniFile& ini)
 #else
 	dsp->Get("Backend", &sBackend, BACKEND_NULLSOUND);
 #endif
+	dsp->Get("AudioDevice", &sAudioDevice, AudioDevice::GetDefaultDevice().id);
 	dsp->Get("Volume", &m_Volume, 100);
 	dsp->Get("CaptureLog", &m_DSPCaptureLog, false);
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -262,6 +262,7 @@ struct SConfig : NonCopyable
 	bool m_DumpUCode;
 	int m_Volume;
 	std::string sBackend;
+	std::string sAudioDevice;
 
 	// Input settings
 	bool m_BackgroundInput;

--- a/Source/Core/DolphinWX/Config/AudioConfigPane.h
+++ b/Source/Core/DolphinWX/Config/AudioConfigPane.h
@@ -26,21 +26,25 @@ private:
 	void RefreshGUI();
 
 	void PopulateBackendChoiceBox();
+	void PopulateDeviceChoiceBox();
 	static bool SupportsVolumeChanges(const std::string&);
 
 	void OnDSPEngineRadioBoxChanged(wxCommandEvent&);
 	void OnDPL2DecoderCheckBoxChanged(wxCommandEvent&);
 	void OnVolumeSliderChanged(wxCommandEvent&);
 	void OnAudioBackendChanged(wxCommandEvent&);
+	void OnAudioDeviceChanged(wxCommandEvent&);
 	void OnLatencySpinCtrlChanged(wxCommandEvent&);
 
 	wxArrayString m_dsp_engine_strings;
 	wxArrayString m_audio_backend_strings;
+	wxArrayString m_audio_device_strings;
 
 	wxRadioBox* m_dsp_engine_radiobox;
 	wxCheckBox* m_dpl2_decoder_checkbox;
 	wxSlider* m_volume_slider;
 	wxStaticText* m_volume_text;
 	wxChoice* m_audio_backend_choice;
+	wxChoice* m_audio_device_choice;
 	wxSpinCtrl* m_audio_latency_spinctrl;
 };


### PR DESCRIPTION
This, as of the first commit, adds a dropdown menu to the audio settings, enabling the selection of the audio device to output to. It currently fully works on Windows, and a bit on Linux (displays too many devices atm, and only ALSA). This is a rather exotic feature to have, but I needed it for Windows, so I thought why not try to fully and cleanly implement it.

It still needs quite some work before this is actually mergeable, so please don't hold back giving feedback if required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3378)
<!-- Reviewable:end -->
