### PR TITLE
DQt2: Implement Paths config dialog

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRCS
 	Resources.cpp
 	Settings.cpp
 	ToolBar.cpp
+	Config/PathDialog.cpp
 	GameList/GameFile.cpp
 	GameList/GameList.cpp
 	GameList/GameListModel.cpp

--- a/Source/Core/DolphinQt2/Config/PathDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/PathDialog.cpp
@@ -1,0 +1,185 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QAction>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QFileDialog>
+#include <QFont>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPushButton>
+#include <QSize>
+#include <QVBoxLayout>
+
+#include "DolphinQt2/Settings.h"
+#include "DolphinQt2/Config/PathDialog.h"
+
+PathDialog::PathDialog(QWidget* parent)
+	: QDialog(parent)
+{
+	setWindowTitle(tr("Paths"));
+	setAttribute(Qt::WA_DeleteOnClose);
+
+	QVBoxLayout* layout = new QVBoxLayout;
+	layout->addWidget(MakeGameFolderBox());
+	layout->addLayout(MakePathsLayout());
+
+	QDialogButtonBox* ok_box = new QDialogButtonBox(QDialogButtonBox::Ok);
+	connect(ok_box, &QDialogButtonBox::accepted, this, &PathDialog::accept);
+	layout->addWidget(ok_box);
+
+	setLayout(layout);
+}
+
+void PathDialog::Browse()
+{
+	QString dir = QFileDialog::getExistingDirectory(this,
+			tr("Select a Directory"),
+			QDir::currentPath());
+	if (!dir.isEmpty())
+	{
+		Settings settings;
+		QStringList game_folders = settings.GetPaths();
+		if (!game_folders.contains(dir))
+		{
+			game_folders << dir;
+			settings.SetPaths(game_folders);
+			m_path_list->addItem(dir);
+			emit PathAdded(dir);
+		}
+	}
+}
+
+void PathDialog::BrowseDefaultGame()
+{
+	QString file = QFileDialog::getOpenFileName(this,
+			tr("Select a Game"),
+			QDir::currentPath(),
+			tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.wbfs *.ciso *.gcz *.wad);;"
+			   "All Files (*)"));
+	if (!file.isEmpty())
+	{
+		m_game_edit->setText(file);
+		Settings().SetDefaultGame(file);
+	}
+}
+
+void PathDialog::BrowseDVDRoot()
+{
+	QString dir = QFileDialog::getExistingDirectory(this,
+			tr("Select DVD Root"),
+			QDir::currentPath());
+	if (!dir.isEmpty())
+	{
+		m_dvd_edit->setText(dir);
+		Settings().SetDVDRoot(dir);
+	}
+}
+
+void PathDialog::BrowseApploader()
+{
+	QString file = QFileDialog::getOpenFileName(this,
+			tr("Select an Apploader"),
+			QDir::currentPath(),
+			tr("Apploaders (*.img)"));
+	if (!file.isEmpty())
+	{
+		m_app_edit->setText(file);
+		Settings().SetApploader(file);
+	}
+}
+
+void PathDialog::BrowseWiiNAND()
+{
+	QString dir = QFileDialog::getExistingDirectory(this,
+			tr("Select Wii NAND Root"),
+			QDir::currentPath());
+	if (!dir.isEmpty())
+	{
+		m_nand_edit->setText(dir);
+		Settings().SetWiiNAND(dir);
+	}
+}
+
+QGroupBox* PathDialog::MakeGameFolderBox()
+{
+	QGroupBox* game_box = new QGroupBox(tr("Game Folders"));
+	game_box->setMinimumSize(QSize(400, 250));
+	QVBoxLayout* vlayout = new QVBoxLayout;
+
+	m_path_list = new QListWidget;
+	m_path_list->insertItems(0, Settings().GetPaths());
+	m_path_list->setSpacing(1);
+	vlayout->addWidget(m_path_list);
+
+	QHBoxLayout* hlayout = new QHBoxLayout;
+
+	hlayout->addStretch();
+	QPushButton* add = new QPushButton(tr("Add"));
+	QPushButton* remove = new QPushButton(tr("Remove"));
+	hlayout->addWidget(add);
+	hlayout->addWidget(remove);
+	vlayout->addLayout(hlayout);
+
+	connect(add, &QPushButton::clicked, this, &PathDialog::Browse);
+	connect(remove, &QPushButton::clicked, this, &PathDialog::RemovePath);
+
+	game_box->setLayout(vlayout);
+	return game_box;
+}
+
+QGridLayout* PathDialog::MakePathsLayout()
+{
+	QGridLayout* layout = new QGridLayout;
+	layout->setColumnStretch(1, 1);
+
+	m_game_edit = new QLineEdit(Settings().GetDefaultGame());
+	connect(m_game_edit, &QLineEdit::editingFinished,
+			[=]{ Settings().SetDefaultGame(m_game_edit->text()); });
+	QPushButton* game_open = new QPushButton;
+	connect(game_open, &QPushButton::clicked, this, &PathDialog::BrowseDefaultGame);
+	layout->addWidget(new QLabel(tr("Default Game")), 0, 0);
+	layout->addWidget(m_game_edit, 0, 1);
+	layout->addWidget(game_open, 0, 2);
+
+	m_dvd_edit = new QLineEdit(Settings().GetDVDRoot());
+	connect(m_dvd_edit, &QLineEdit::editingFinished,
+			[=]{ Settings().SetDVDRoot(m_dvd_edit->text()); });
+	QPushButton* dvd_open = new QPushButton;
+	connect(dvd_open, &QPushButton::clicked, this, &PathDialog::BrowseDVDRoot);
+	layout->addWidget(new QLabel(tr("DVD Root")), 1, 0);
+	layout->addWidget(m_dvd_edit, 1, 1);
+	layout->addWidget(dvd_open, 1, 2);
+
+	m_app_edit = new QLineEdit(Settings().GetApploader());
+	connect(m_app_edit, &QLineEdit::editingFinished,
+			[=]{ Settings().SetApploader(m_app_edit->text()); });
+	QPushButton* app_open = new QPushButton;
+	connect(app_open, &QPushButton::clicked, this, &PathDialog::BrowseApploader);
+	layout->addWidget(new QLabel(tr("Apploader")), 2, 0);
+	layout->addWidget(m_app_edit, 2, 1);
+	layout->addWidget(app_open, 2, 2);
+
+	m_nand_edit = new QLineEdit(Settings().GetWiiNAND());
+	connect(m_nand_edit, &QLineEdit::editingFinished,
+			[=]{ Settings().SetWiiNAND(m_nand_edit->text()); });
+	QPushButton* nand_open = new QPushButton;
+	connect(nand_open, &QPushButton::clicked, this, &PathDialog::BrowseWiiNAND);
+	layout->addWidget(new QLabel(tr("Wii NAND Root")), 3, 0);
+	layout->addWidget(m_nand_edit, 3, 1);
+	layout->addWidget(nand_open, 3, 2);
+
+	return layout;
+}
+
+void PathDialog::RemovePath()
+{
+	int row = m_path_list->currentRow();
+	if (row < 0)
+		return;
+	emit PathRemoved(m_path_list->takeItem(row)->text());
+	Settings().RemovePath(row);
+}

--- a/Source/Core/DolphinQt2/Config/PathDialog.h
+++ b/Source/Core/DolphinQt2/Config/PathDialog.h
@@ -1,0 +1,40 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QListWidget>
+
+class PathDialog final : public QDialog
+{
+	Q_OBJECT
+public:
+	explicit PathDialog(QWidget* parent = nullptr);
+
+public slots:
+	void Browse();
+	void BrowseDefaultGame();
+	void BrowseDVDRoot();
+	void BrowseApploader();
+	void BrowseWiiNAND();
+
+signals:
+	void PathAdded(QString path);
+	void PathRemoved(QString path);
+
+private:
+	QGroupBox* MakeGameFolderBox();
+	QGridLayout* MakePathsLayout();
+	void RemovePath();
+
+	QListWidget* m_path_list;
+	QLineEdit* m_game_edit;
+	QLineEdit* m_dvd_edit;
+	QLineEdit* m_app_edit;
+	QLineEdit* m_nand_edit;
+};

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -22,6 +22,7 @@ GameList::GameList(QWidget* parent): QStackedWidget(parent)
 	connect(m_table, &QTableView::doubleClicked, this, &GameList::GameSelected);
 	connect(m_list, &QListView::doubleClicked, this, &GameList::GameSelected);
 	connect(this, &GameList::DirectoryAdded, m_model, &GameListModel::DirectoryAdded);
+	connect(this, &GameList::DirectoryRemoved, m_model, &GameListModel::DirectoryRemoved);
 
 	addWidget(m_table);
 	addWidget(m_list);

--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -29,6 +29,7 @@ public slots:
 signals:
 	void GameSelected();
 	void DirectoryAdded(QString dir);
+	void DirectoryRemoved(QString dir);
 
 private:
 	void MakeTableView();

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -46,10 +46,12 @@ public slots:
 
 signals:
 	void DirectoryAdded(QString dir);
+	void DirectoryRemoved(QString dir);
 
 private:
+	// Index in m_games, or -1 if it isn't found
+	int FindGame(const QString& path) const;
+
 	GameTracker m_tracker;
 	QList<QSharedPointer<GameFile>> m_games;
-	// Path -> index in m_games
-	QMap<QString, int> m_entries;
 };

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <QFileSystemWatcher>
-#include <QSet>
+#include <QMap>
 #include <QSharedPointer>
 #include <QString>
 #include <QStringList>
@@ -31,6 +31,7 @@ public:
 
 public slots:
 	void AddDirectory(QString dir);
+	void RemoveDirectory(QString dir);
 
 signals:
 	void GameLoaded(QSharedPointer<GameFile> game);
@@ -42,7 +43,8 @@ private:
 	void UpdateDirectory(const QString& dir);
 	void UpdateFile(const QString& path);
 
-	QSet<QString> m_tracked_files;
+	// game path -> number of directories that track it
+	QMap<QString, int> m_tracked_files;
 	QThread m_loader_thread;
 	GameLoader* m_loader;
 };

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -29,7 +29,6 @@ signals:
 
 private slots:
 	void Open();
-	void Browse();
 	void Play();
 	void Pause();
 
@@ -39,6 +38,8 @@ private slots:
 
 	void FullScreen();
 	void ScreenShot();
+
+	void PathsConfig();
 
 private:
 	void MakeGameList();

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -44,6 +44,57 @@ void Settings::SetPaths(const QStringList& paths)
 	setValue(QStringLiteral("GameList/Paths"), paths);
 }
 
+void Settings::RemovePath(int i)
+{
+	QStringList paths = GetPaths();
+	paths.removeAt(i);
+	SetPaths(paths);
+}
+
+QString Settings::GetDefaultGame() const
+{
+	return QString::fromStdString(SConfig::GetInstance().m_strDefaultISO);
+}
+
+void Settings::SetDefaultGame(const QString& path)
+{
+	SConfig::GetInstance().m_strDefaultISO = path.toStdString();
+	SConfig::GetInstance().SaveSettings();
+}
+
+QString Settings::GetDVDRoot() const
+{
+	return QString::fromStdString(SConfig::GetInstance().m_strDVDRoot);
+}
+
+void Settings::SetDVDRoot(const QString& path)
+{
+	SConfig::GetInstance().m_strDVDRoot = path.toStdString();
+	SConfig::GetInstance().SaveSettings();
+}
+
+QString Settings::GetApploader() const
+{
+	return QString::fromStdString(SConfig::GetInstance().m_strApploader);
+}
+
+void Settings::SetApploader(const QString& path)
+{
+	SConfig::GetInstance().m_strApploader = path.toStdString();
+	SConfig::GetInstance().SaveSettings();
+}
+
+QString Settings::GetWiiNAND() const
+{
+	return QString::fromStdString(SConfig::GetInstance().m_NANDPath);
+}
+
+void Settings::SetWiiNAND(const QString& path)
+{
+	SConfig::GetInstance().m_NANDPath = path.toStdString();
+	SConfig::GetInstance().SaveSettings();
+}
+
 DiscIO::IVolume::ELanguage Settings::GetWiiSystemLanguage() const
 {
 	return SConfig::GetInstance().GetCurrentLanguage(true);

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -24,6 +24,15 @@ public:
 	void SetLastGame(const QString& path);
 	QStringList GetPaths() const;
 	void SetPaths(const QStringList& paths);
+	void RemovePath(int i);
+	QString GetDefaultGame() const;
+	void SetDefaultGame(const QString& path);
+	QString GetDVDRoot() const;
+	void SetDVDRoot(const QString& path);
+	QString GetApploader() const;
+	void SetApploader(const QString& path);
+	QString GetWiiNAND() const;
+	void SetWiiNAND(const QString& path);
 	DiscIO::IVolume::ELanguage GetWiiSystemLanguage() const;
 	DiscIO::IVolume::ELanguage GetGCSystemLanguage() const;
 

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -49,10 +49,6 @@ void ToolBar::EmulationStopped()
 void ToolBar::MakeActions()
 {
 	m_open_action = addAction(tr("Open"), this, SIGNAL(OpenPressed()));
-	m_paths_action = addAction(tr("Paths"), this, SIGNAL(PathsPressed()));
-
-	addSeparator();
-
 	m_play_action = addAction(tr("Play"), this, SIGNAL(PlayPressed()));
 
 	m_pause_action = addAction(tr("Pause"), this, SIGNAL(PausePressed()));
@@ -68,6 +64,8 @@ void ToolBar::MakeActions()
 	m_screenshot_action->setEnabled(false);
 
 	addSeparator();
+
+	m_paths_action = addAction(tr("Paths"), this, SIGNAL(PathsPressed()));
 
 	m_config_action = addAction(tr("Settings"));
 	m_config_action->setEnabled(false);

--- a/Source/Core/DolphinQt2/ToolBar.h
+++ b/Source/Core/DolphinQt2/ToolBar.h
@@ -22,25 +22,25 @@ public slots:
 
 signals:
 	void OpenPressed();
-	void PathsPressed();
-
 	void PlayPressed();
 	void PausePressed();
 	void StopPressed();
 	void FullScreenPressed();
 	void ScreenShotPressed();
 
+	void PathsPressed();
+
 private:
 	void MakeActions();
 	void UpdateIcons();
 
 	QAction* m_open_action;
-	QAction* m_paths_action;
 	QAction* m_play_action;
 	QAction* m_pause_action;
 	QAction* m_stop_action;
 	QAction* m_fullscreen_action;
 	QAction* m_screenshot_action;
+	QAction* m_paths_action;
 	QAction* m_config_action;
 	QAction* m_graphics_action;
 	QAction* m_controllers_action;


### PR DESCRIPTION
Sorry for the large commit. This turned out to be trickier than I expected. Future configs shouldn't be so tricky, since I'll reuse parts of this one, and they don't need to work so closely with the GameList.

![ss](https://cloud.githubusercontent.com/assets/7368979/11973321/700e21a4-a90d-11e5-86dd-2741848e187c.jpg)

* Paths is a config thing, not a confusingly-named "Browse" button.
* The game list will update in the background as you add and remove paths.
* It now reference-counts game paths, so if you add `/games` and `/games/smash`, then remove `/games` it won't remove the games under the latter. Recursive directory walking is on.
* When you press play, it now tries the selected game, then the default game, then the last played game, then it prompts the user for a path.

@lioncash I'm not sure if it's worth refactoring `PathDialog::MakePathsLayout`. Thoughts?