### PR TITLE
Movie: Reset wiimotes at at start of recording/playback to fix desync issues

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -51,6 +51,12 @@ void Initialize(void* const hwnd, bool wait)
 		Movie::ChangeWiiPads();
 }
 
+void ResetAllWiimotes()
+{
+	for (int i = WIIMOTE_CHAN_0; i < MAX_BBMOTES; ++i)
+	        static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->Reset();
+}
+
 void LoadConfig()
 {
 	s_config.LoadConfig(false);

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -37,6 +37,7 @@ namespace Wiimote
 
 void Shutdown();
 void Initialize(void* const hwnd, bool wait = false);
+void ResetAllWiimotes();
 void LoadConfig();
 void Resume();
 void Pause();

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -115,6 +115,7 @@ public:
 	void InterruptChannel(const u16 _channelID, const void* _pData, u32 _Size);
 	void ControlChannel(const u16 _channelID, const void* _pData, u32 _Size);
 	void ConnectOnInput();
+	void Reset();
 
 	void DoState(PointerWrap& p);
 	void RealState();
@@ -144,8 +145,6 @@ private:
 		u32 address, size, position;
 		u8* data;
 	};
-
-	void Reset();
 
 	void ReportMode(const wm_report_mode* const dr);
 	void SendAck(const u8 _reportID);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -500,6 +500,14 @@ bool BeginRecordingInput(int controllers)
 		md5thread.detach();
 		GetSettings();
 	}
+
+	// Wiimotes cause desync issues if they're not reset before launching the game
+	if (!Core::IsRunningAndStarted())
+	{
+	        // This will also reset the wiimotes for gamecube games, but that shouldn't do anything
+	        Wiimote::ResetAllWiimotes();
+	}
+
 	s_playMode = MODE_RECORDING;
 	s_author = SConfig::GetInstance().m_strMovieAuthor;
 	EnsureTmpInputSize(1);
@@ -853,6 +861,9 @@ bool PlayInput(const std::string& filename)
 	g_currentInputCount = 0;
 
 	s_playMode = MODE_PLAYING;
+
+	// Wiimotes cause desync issues if they're not reset before launching the game
+	Wiimote::ResetAllWiimotes();
 
 	Core::UpdateWantDeterminism();
 


### PR DESCRIPTION
When a game is started then closed, the wiimote's state (in particular the reporting mode, m_reporting_mode) is changed, which causes movies to desync.  Resetting the wiimotes give a consistent state to wiimotes on movie start, preventing any desyncs.