### PR TITLE
GeometryShaderManager: Use IPD values defined in millimeters.

### DIFF
--- a/Data/Sys/GameSettings/G3L.ini
+++ b/Data/Sys/GameSettings/G3L.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 7
+StereoConvergence = 14

--- a/Data/Sys/GameSettings/G8M.ini
+++ b/Data/Sys/GameSettings/G8M.ini
@@ -22,4 +22,4 @@ EFBToTextureEnable = False
 BBoxEnable = True
 
 [Video_Stereoscopy]
-StereoConvergence = 545
+StereoConvergence = 1090

--- a/Data/Sys/GameSettings/GAF.ini
+++ b/Data/Sys/GameSettings/GAF.ini
@@ -21,4 +21,4 @@ EmulationIssues =
 SafeTextureCacheColorSamples = 512
 
 [Video_Stereoscopy]
-StereoConvergence = 623
+StereoConvergence = 1246

--- a/Data/Sys/GameSettings/GAL.ini
+++ b/Data/Sys/GameSettings/GAL.ini
@@ -21,4 +21,4 @@ EmulationIssues =
 EFBScale = -1
 
 [Video_Stereoscopy]
-StereoConvergence = 64
+StereoConvergence = 128

--- a/Data/Sys/GameSettings/GKY.ini
+++ b/Data/Sys/GameSettings/GKY.ini
@@ -21,4 +21,4 @@ EmulationIssues =
 EFBEmulateFormatChanges = True
 
 [Video_Stereoscopy]
-StereoConvergence = 6
+StereoConvergence = 12

--- a/Data/Sys/GameSettings/GL5.ini
+++ b/Data/Sys/GameSettings/GL5.ini
@@ -18,4 +18,4 @@ EmulationIssues = Slow
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 1
+StereoConvergence = 2

--- a/Data/Sys/GameSettings/GL7.ini
+++ b/Data/Sys/GameSettings/GL7.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 1
+StereoConvergence = 2

--- a/Data/Sys/GameSettings/GLM.ini
+++ b/Data/Sys/GameSettings/GLM.ini
@@ -19,4 +19,4 @@ EmulationIssues =
 
 [Video_Stereoscopy]
 StereoEFBMonoDepth = True
-StereoConvergence = 1445
+StereoConvergence = 2890

--- a/Data/Sys/GameSettings/GM4.ini
+++ b/Data/Sys/GameSettings/GM4.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 392
+StereoConvergence = 784

--- a/Data/Sys/GameSettings/GMS.ini
+++ b/Data/Sys/GameSettings/GMS.ini
@@ -34,4 +34,4 @@ MaxAnisotropy = 0
 ForceFiltering = False
 
 [Video_Stereoscopy]
-StereoConvergence = 732
+StereoConvergence = 1464

--- a/Data/Sys/GameSettings/GSR.ini
+++ b/Data/Sys/GameSettings/GSR.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 5
+StereoConvergence = 10

--- a/Data/Sys/GameSettings/GUP.ini
+++ b/Data/Sys/GameSettings/GUP.ini
@@ -21,4 +21,4 @@ EmulationIssues = 2P mode is playable only with EFB to RAM.
 EFBToTextureEnable = False
 
 [Video_Stereoscopy]
-StereoConvergence = 1
+StereoConvergence = 2

--- a/Data/Sys/GameSettings/GYQ.ini
+++ b/Data/Sys/GameSettings/GYQ.ini
@@ -20,4 +20,4 @@ EmulationIssues =
 [Video]
 
 [Video_Stereoscopy]
-StereoConvergence = 2
+StereoConvergence = 4

--- a/Data/Sys/GameSettings/GZL.ini
+++ b/Data/Sys/GameSettings/GZL.ini
@@ -25,4 +25,4 @@ EFBToTextureEnable = False
 FastDepthCalc = False
 
 [Video_Stereoscopy]
-StereoConvergence = 115
+StereoConvergence = 230

--- a/Data/Sys/GameSettings/NAB.ini
+++ b/Data/Sys/GameSettings/NAB.ini
@@ -18,4 +18,4 @@ EmulationStateId = 4
 EFBToTextureEnable = False
 
 [Video_Stereoscopy]
-StereoConvergence = 46
+StereoConvergence = 92

--- a/Data/Sys/GameSettings/NAD.ini
+++ b/Data/Sys/GameSettings/NAD.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 354
+StereoConvergence = 708

--- a/Data/Sys/GameSettings/NAE.ini
+++ b/Data/Sys/GameSettings/NAE.ini
@@ -24,4 +24,4 @@ FastDepthCalc = True
 EFBToTextureEnable = False
 
 [Video_Stereoscopy]
-StereoConvergence = 506
+StereoConvergence = 1012

--- a/Data/Sys/GameSettings/NAL.ini
+++ b/Data/Sys/GameSettings/NAL.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 5000
+StereoConvergence = 10000

--- a/Data/Sys/GameSettings/R25.ini
+++ b/Data/Sys/GameSettings/R25.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 1
+StereoConvergence = 2

--- a/Data/Sys/GameSettings/R92.ini
+++ b/Data/Sys/GameSettings/R92.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 838
+StereoConvergence = 1676

--- a/Data/Sys/GameSettings/RMC.ini
+++ b/Data/Sys/GameSettings/RMC.ini
@@ -21,4 +21,4 @@ EmulationIssues =
 EFBEmulateFormatChanges = True
 
 [Video_Stereoscopy]
-StereoConvergence = 613
+StereoConvergence = 1226

--- a/Data/Sys/GameSettings/RPB.ini
+++ b/Data/Sys/GameSettings/RPB.ini
@@ -21,4 +21,4 @@ EmulationIssues =
 SafeTextureCacheColorSamples = 0
 
 [Video_Stereoscopy]
-StereoConvergence = 38
+StereoConvergence = 76

--- a/Data/Sys/GameSettings/RSB.ini
+++ b/Data/Sys/GameSettings/RSB.ini
@@ -18,4 +18,4 @@ EmulationIssues = Classic mode score report needs real xfb. Nes masterpieces and
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 136
+StereoConvergence = 272

--- a/Data/Sys/GameSettings/RUU.ini
+++ b/Data/Sys/GameSettings/RUU.ini
@@ -19,4 +19,4 @@ EmulationIssues =
 EFBToTextureEnable = False
 
 [Video_Stereoscopy]
-StereoConvergence = 381
+StereoConvergence = 762

--- a/Data/Sys/GameSettings/SB4.ini
+++ b/Data/Sys/GameSettings/SB4.ini
@@ -21,4 +21,4 @@ EmulationIssues = Needs Efb Access from CPU.
 EFBAccessEnable = True
 
 [Video_Stereoscopy]
-StereoConvergence = 929
+StereoConvergence = 1858

--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -22,4 +22,4 @@ FastDepthCalc = False
 SafeTextureCacheColorSamples = 512
 
 [Video_Stereoscopy]
-StereoConvergence = 26
+StereoConvergence = 52

--- a/Data/Sys/GameSettings/SMN.ini
+++ b/Data/Sys/GameSettings/SMN.ini
@@ -23,4 +23,4 @@ SafeTextureCacheColorSamples = 512
 
 [Video_Stereoscopy]
 #Only affects overworld map
-StereoConvergence = 2211
+StereoConvergence = 4422

--- a/Data/Sys/GameSettings/WPS.ini
+++ b/Data/Sys/GameSettings/WPS.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Stereoscopy]
-StereoConvergence = 20
+StereoConvergence = 40

--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -111,10 +111,18 @@ public:
 	// Returns true if key exists in section
 	bool Exists(const std::string& sectionName, const std::string& key) const;
 
-	template<typename T> bool GetIfExists(const std::string& sectionName, const std::string& key, T value)
+	template<typename T> bool GetIfExists(const std::string& sectionName, const std::string& key, T* value)
 	{
 		if (Exists(sectionName, key))
 			return GetOrCreateSection(sectionName)->Get(key, value);
+
+		return false;
+	}
+
+	template<typename T> bool GetIfExists(const std::string& sectionName, const std::string& key, T* value, T defaultValue)
+	{
+		if (Exists(sectionName, key))
+			return GetOrCreateSection(sectionName)->Get(key, value, defaultValue);
 
 		return false;
 	}

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -53,11 +53,11 @@ void GeometryShaderManager::SetConstants()
 	{
 		s_projection_changed = false;
 
+		// Per-game scaling value
+		float mmInUnits = g_ActiveConfig.iStereoMetersInUnits / 1000.0f;
+
 		if (xfmem.projection.type == GX_PERSPECTIVE)
 		{
-			// Per-game scaling value
-			float mmInUnits = g_ActiveConfig.iStereoMetersInUnits / 1000.0f;
-
 			// The inter-camera offset in clipping coordinates
 			float offset = (g_ActiveConfig.iStereoDepth * mmInUnits) / Renderer::EFBToScaledXf(2.0f * xfmem.viewport.wd);
 
@@ -70,7 +70,7 @@ void GeometryShaderManager::SetConstants()
 			constants.stereoparams[0] = constants.stereoparams[1] = 0;
 		}
 
-		constants.stereoparams[2] = (float)(g_ActiveConfig.iStereoConvergence * (g_ActiveConfig.iStereoConvergencePercentage / 100.0f));
+		constants.stereoparams[2] = (g_ActiveConfig.iStereoConvergence * mmInUnits) * (g_ActiveConfig.iStereoConvergencePercentage / 100.0f);
 
 		dirty = true;
 	}

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -8,6 +8,7 @@
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/GeometryShaderGen.h"
 #include "VideoCommon/GeometryShaderManager.h"
+#include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
@@ -54,7 +55,13 @@ void GeometryShaderManager::SetConstants()
 
 		if (xfmem.projection.type == GX_PERSPECTIVE)
 		{
-			float offset = (g_ActiveConfig.iStereoDepth / 1000.0f) * (g_ActiveConfig.iStereoDepthPercentage / 100.0f);
+			// Per-game scaling value
+			float mmInUnits = g_ActiveConfig.iStereoMetersInUnits / 1000.0f;
+
+			// The inter-camera offset in clipping coordinates
+			float offset = (g_ActiveConfig.iStereoDepth * mmInUnits) / Renderer::EFBToScaledXf(2.0f * xfmem.viewport.wd);
+
+			// Set the per-eye offset values
 			constants.stereoparams[0] = g_ActiveConfig.bStereoSwapEyes ? offset : -offset;
 			constants.stereoparams[1] = g_ActiveConfig.bStereoSwapEyes ? -offset : offset;
 		}

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -41,11 +41,6 @@ VideoConfig::VideoConfig()
 	// disable all features by default
 	backend_info.APIType = API_NONE;
 	backend_info.bSupportsExclusiveFullscreen = false;
-
-	// Game-specific stereoscopy settings
-	bStereoEFBMonoDepth = false;
-	iStereoConvergence = 20;
-	iStereoMetersInUnits = 600;
 }
 
 void VideoConfig::Load(const std::string& ini_file)
@@ -198,12 +193,14 @@ void VideoConfig::GameIniLoad()
 	CHECK_SETTING("Video_Enhancements", "MaxAnisotropy", iMaxAnisotropy);  // NOTE - this is x in (1 << x)
 	CHECK_SETTING("Video_Enhancements", "PostProcessingShader", sPostProcessingShader);
 
+	// These are not overrides, they are per-game stereoscopy parameters, hence no warning
+	iniFile.GetIfExists("Video_Stereoscopy", "StereoConvergence", &iStereoConvergence, 20);
+	iniFile.GetIfExists("Video_Stereoscopy", "StereoMetersInUnits", &iStereoMetersInUnits, 600);
+	iniFile.GetIfExists("Video_Stereoscopy", "StereoEFBMonoDepth", &bStereoEFBMonoDepth, false);
+
 	CHECK_SETTING("Video_Stereoscopy", "StereoMode", iStereoMode);
 	CHECK_SETTING("Video_Stereoscopy", "StereoDepth", iStereoDepth);
-	CHECK_SETTING("Video_Stereoscopy", "StereoConvergence", iStereoConvergence);
 	CHECK_SETTING("Video_Stereoscopy", "StereoSwapEyes", bStereoSwapEyes);
-	CHECK_SETTING("Video_Stereoscopy", "StereoEFBMonoDepth", bStereoEFBMonoDepth);
-	CHECK_SETTING("Video_Stereoscopy", "StereoMetersInUnits", iStereoMetersInUnits);
 
 	CHECK_SETTING("Video_Hacks", "EFBAccessEnable", bEFBAccessEnable);
 	CHECK_SETTING("Video_Hacks", "BBoxEnable", bBBoxEnable);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -44,8 +44,8 @@ VideoConfig::VideoConfig()
 
 	// Game-specific stereoscopy settings
 	bStereoEFBMonoDepth = false;
-	iStereoDepthPercentage = 100;
 	iStereoConvergence = 20;
+	iStereoMetersInUnits = 600;
 }
 
 void VideoConfig::Load(const std::string& ini_file)
@@ -94,7 +94,7 @@ void VideoConfig::Load(const std::string& ini_file)
 
 	IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
 	stereoscopy->Get("StereoMode", &iStereoMode, 0);
-	stereoscopy->Get("StereoDepth", &iStereoDepth, 20);
+	stereoscopy->Get("StereoDepth", &iStereoDepth, 64);
 	stereoscopy->Get("StereoConvergencePercentage", &iStereoConvergencePercentage, 100);
 	stereoscopy->Get("StereoSwapEyes", &bStereoSwapEyes, false);
 
@@ -203,7 +203,7 @@ void VideoConfig::GameIniLoad()
 	CHECK_SETTING("Video_Stereoscopy", "StereoConvergence", iStereoConvergence);
 	CHECK_SETTING("Video_Stereoscopy", "StereoSwapEyes", bStereoSwapEyes);
 	CHECK_SETTING("Video_Stereoscopy", "StereoEFBMonoDepth", bStereoEFBMonoDepth);
-	CHECK_SETTING("Video_Stereoscopy", "StereoDepthPercentage", iStereoDepthPercentage);
+	CHECK_SETTING("Video_Stereoscopy", "StereoMetersInUnits", iStereoMetersInUnits);
 
 	CHECK_SETTING("Video_Hacks", "EFBAccessEnable", bEFBAccessEnable);
 	CHECK_SETTING("Video_Hacks", "BBoxEnable", bBBoxEnable);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -128,7 +128,7 @@ struct VideoConfig final
 	int iStereoConvergencePercentage;
 	bool bStereoSwapEyes;
 	bool bStereoEFBMonoDepth;
-	int iStereoDepthPercentage;
+	int iStereoMetersInUnits;
 
 	// D3D only config, mostly to be merged into the above
 	int iAdapter;


### PR DESCRIPTION
This gives the `StereoDepth` value an actual unit and allows GameINIs to provide a scaling factor for every game using the `StereoMeterInUnits` parameter. This new parameter is also very important to support positional tracking once VR functionality is added.

Another advantage of the `StereoMeterInUnits` parameter is that it allows use to provide a better default convergence value for games that have scaling defined, but have no convergence value. To do this we also change the convergence value to be defined in millimeters instead of game-specific units. However, this is still a point of discussion since it may be undesirable to have the convergence distance change when the scale is adjusted in `StereoMeterInUnits`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3395)

<!-- Reviewable:end -->
