### PR TITLE
Fifo: Convert define into constant

### DIFF
--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -30,6 +30,8 @@
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoConfig.h"
 
+static constexpr u32 FIFO_SIZE = 2 * 1024 * 1024;
+
 bool g_bSkipCurrentFrame = false;
 
 static Common::BlockingLoop s_gpu_mainloop;

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -9,8 +9,6 @@
 
 class PointerWrap;
 
-#define FIFO_SIZE (2*1024*1024)
-
 extern bool g_bSkipCurrentFrame;
 
 // This could be in SConfig, but it depends on multiple settings


### PR DESCRIPTION
Also moves it to the cpp file where it's used. Gets it out of global scope