### PR TITLE
Catered for the case where ADPCM audio would loop before the end of the stream

### DIFF
--- a/Source/Core/Core/DSP/DSPAccelerator.cpp
+++ b/Source/Core/Core/DSP/DSPAccelerator.cpp
@@ -121,10 +121,18 @@ u16 dsp_read_accelerator()
 	switch (g_dsp.ifx_regs[DSP_FORMAT])
 	{
 		case 0x00:  // ADPCM audio
-			if ((EndAddress & 15) == 0)
+			switch (EndAddress & 15)
+			{
+			case 0: // Tom and Jerry
 				step_size_bytes = 1;
-			else
+				break;
+			case 1: // Blazing Angels
+				step_size_bytes = 0;
+				break;
+			default:
 				step_size_bytes = 2;
+				break;
+			}
 			val = ADPCM_Step(Address);
 			break;
 		case 0x0A:  // 16-bit PCM audio

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -152,10 +152,18 @@ u16 AcceleratorGetSample()
 				*acc_cur_addr += 2;
 			}
 
-			if ((acc_end_addr & 15) == 0)
+			switch (acc_end_addr & 15)
+			{
+			case 0: // Tom and Jerry
 				step_size_bytes = 1;
-			else
+				break;
+			case 1: // Blazing Angels
+				step_size_bytes = 0;
+				break;
+			default:
 				step_size_bytes = 2;
+				break;
+			}
 
 			int scale = 1 << (acc_pb->adpcm.pred_scale & 0xF);
 			int coef_idx = (acc_pb->adpcm.pred_scale >> 4) & 0x7;


### PR DESCRIPTION
Catered for the case where ADPCM audio would loop before the end of the stream.  Patch by hk.konpie.