### PR TITLE
CheatSearchTab: Use an enum for filter masks rather than ints

### DIFF
--- a/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
@@ -251,15 +251,35 @@ void CheatSearchTab::UpdateCheatSearchResultItem(long index)
 	m_lview_search_results->SetItem(index, 3, buf);
 }
 
+enum class ComparisonMask
+{
+	EQUAL        = 0x1,
+	GREATER_THAN = 0x2,
+	LESS_THAN    = 0x4
+};
+
+static ComparisonMask operator | (ComparisonMask comp1, ComparisonMask comp2)
+{
+	return static_cast<ComparisonMask>(static_cast<int>(comp1) |
+					   static_cast<int>(comp2));
+}
+
+static ComparisonMask operator & (ComparisonMask comp1, ComparisonMask comp2)
+{
+	return static_cast<ComparisonMask>(static_cast<int>(comp1) &
+					   static_cast<int>(comp2));
+}
+
 void CheatSearchTab::FilterCheatSearchResults(u32 value)
 {
-	// Determine the selected filter
-	// 1 : equal
-	// 2 : greater-than
-	// 4 : less-than
-	// 6 : not equal
-	static const int filters[] = { 6, 1, 2, 4 };
-	int filter_mask = filters[m_search_type->GetSelection()];
+	static const std::array<ComparisonMask, 5> filters{{
+	    ComparisonMask::EQUAL | ComparisonMask::GREATER_THAN | ComparisonMask::LESS_THAN, // Unknown
+	    ComparisonMask::GREATER_THAN | ComparisonMask::LESS_THAN, // Not Equal
+	    ComparisonMask::EQUAL,
+	    ComparisonMask::GREATER_THAN,
+	    ComparisonMask::LESS_THAN
+	}};
+	ComparisonMask filter_mask = filters[m_search_type->GetSelection()];
 
 	std::vector<CheatSearchResult> filtered_results;
 	filtered_results.reserve(m_search_results.size());
@@ -268,14 +288,15 @@ void CheatSearchTab::FilterCheatSearchResults(u32 value)
 	{
 		// with big endian, can just use memcmp for ><= comparison
 		int cmp_result = std::memcmp(&Memory::m_pRAM[result.address], &value, m_search_type_size);
+		ComparisonMask cmp_mask;
 		if (cmp_result < 0)
-			cmp_result = 4;
+			cmp_mask = ComparisonMask::LESS_THAN;
 		else if (cmp_result)
-			cmp_result = 2;
+			cmp_mask = ComparisonMask::GREATER_THAN;
 		else
-			cmp_result = 1;
+			cmp_mask = ComparisonMask::EQUAL;
 
-		if (cmp_result & filter_mask)
+		if (static_cast<int>(cmp_mask & filter_mask))
 		{
 			std::memcpy(&result.old_value, &Memory::m_pRAM[result.address], m_search_type_size);
 			filtered_results.push_back(result);


### PR DESCRIPTION
Also fixes issue 8974, which was the result of removing the first element of filters[] in dolphin-emu/dolphin#2813.