### PR TITLE
Jit64: use domain-appropriate instructions

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -415,7 +415,7 @@ void Jit64::dcbz(UGeckoInstruction inst)
 	// FIXME: Work out why the AGP disc writes out of bounds
 	if (!SConfig::GetInstance().bWii)
 		AND(32, R(RSCRATCH), Imm32(Memory::RAM_MASK));
-	PXOR(XMM0, R(XMM0));
+	XORPS(XMM0, R(XMM0));
 	MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 0), XMM0);
 	MOVAPS(MComplex(RMEM, RSCRATCH, SCALE_1, 16), XMM0);
 	SetJumpTarget(exit);


### PR DESCRIPTION
These instructions are functionally equivalent but use the correct type of instruction to avoid data bypass delays which occur when floating point and integer vector instructions are mixed. (The reason I used these in the past was because Agner Fog said some processors can use more execution units for the integer variants. I looked up which but only found that NetBurst doesn't support XORPD for dependency breaking. Secondly, we are bound on latency, not throughput.)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3402)
<!-- Reviewable:end -->
