### PR TITLE
D3D: Fix compilation error on windows

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -429,7 +429,7 @@ ID3D11PixelShader* PixelShaderCache::GetDepthResolveProgram()
 		return s_DepthResolveProgram;
 
 	// create MSAA shader for current AA mode
-	std::string buf = StringFromFormat(depth_resolve_program, D3D::GetAAMode(g_ActiveConfig.iMultisampleMode).Count);
+	std::string buf = StringFromFormat(depth_resolve_program, g_ActiveConfig.iMultisamples);
 	s_DepthResolveProgram = D3D::CompileAndCreatePixelShader(buf);
 	CHECK(s_DepthResolveProgram != nullptr, "Create depth matrix MSAA pixel shader");
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthResolveProgram, "depth resolve pixel shader");

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -193,7 +193,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, PEControl::PixelFormat
 	// When copying at half size, in multisampled mode, resolve the color/depth buffer first.
 	// This is because multisampled texture reads go through Load, not Sample, and the linear
 	// filter is ignored.
-	bool multisampled = (g_ActiveConfig.iMultisampleMode != 0);
+	bool multisampled = (g_ActiveConfig.iMultisamples > 1);
 	ID3D11ShaderResourceView* efbTexSRV = (srcFormat == PEControl::Z24) ?
 		FramebufferManager::GetEFBDepthTexture()->GetSRV() :
 		FramebufferManager::GetEFBColorTexture()->GetSRV();


### PR DESCRIPTION
Fixes compile error caused by merging https://github.com/dolphin-emu/dolphin/commit/294bb753164b58eb0a1e9317eaf05ce3d5bb0209

My PR was opened prior to the MSAA config changes, and wasn't rebased prior to being merged, hence the compile error