### PR TITLE
TextureCache, fix an incorrect assert.

### DIFF
--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -355,7 +355,7 @@ void TextureCache::ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* uncon
 	D3D::stateman->SetTexture(1, palette_buf_srv);
 
 	// TODO: Add support for C14X2 format.  (Different multiplier, more palette entries.)
-	float params[4] = { (unconverted->format & 0xf) == 0 ? 15.f : 255.f };
+	float params[4] = { (unconverted->format & 0xf) == GX_TF_I4 ? 15.f : 255.f };
 	D3D::context->UpdateSubresource(palette_uniform, 0, nullptr, &params, 0, 0);
 	D3D::stateman->SetPixelConstants(palette_uniform);
 

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -570,7 +570,8 @@ void TextureCache::ConvertTexture(TCacheEntryBase* _entry, TCacheEntryBase* _unc
 	glViewport(0, 0, entry->config.width, entry->config.height);
 	s_palette_pixel_shader[format].Bind();
 
-	int size = unconverted->format == 0 ? 32 : 512;
+	// C14 textures are currently unsupported
+	int size = (unconverted->format & 0xf) == GX_TF_I4 ? 32 : 512;
 	auto buffer = s_palette_stream_buffer->Map(size);
 	memcpy(buffer.first, palette, size);
 	s_palette_stream_buffer->Unmap(size);

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -216,9 +216,9 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::DoPartialTextureUpdates(Tex
 		|| isPaletteTexture)
 		return entry_to_update;
 
-	u32 block_width = TexDecoder_GetBlockWidthInTexels(entry_to_update->format);
-	u32 block_height = TexDecoder_GetBlockHeightInTexels(entry_to_update->format);
-	u32 block_size = block_width * block_height * TexDecoder_GetTexelSizeInNibbles(entry_to_update->format) / 2;
+	u32 block_width = TexDecoder_GetBlockWidthInTexels(entry_to_update->format & 0xf);
+	u32 block_height = TexDecoder_GetBlockHeightInTexels(entry_to_update->format & 0xf);
+	u32 block_size = block_width * block_height * TexDecoder_GetTexelSizeInNibbles(entry_to_update->format & 0xf) / 2;
 
 	u32 numBlocksX = (entry_to_update->native_width + block_width - 1) / block_width;
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -52,7 +52,7 @@ public:
 		u32 size_in_bytes;
 		u64 base_hash;
 		u64 hash; // for paletted textures, hash = base_hash ^ palette_hash
-		u32 format;
+		u32 format; // bits 0-3 will contain the in-memory format.
 		bool is_efb_copy;
 		bool is_custom_tex;
 		u32 memory_stride;
@@ -68,7 +68,6 @@ public:
 
 		void SetGeneralParameters(u32 _addr, u32 _size, u32 _format)
 		{
-			_dbg_assert_msg_(VIDEO, _format < 0x10, "You shouldn't use dolphin's \"Extra\" texture formats in a texture cache entry");
 			addr = _addr;
 			size_in_bytes = _size;
 			format = _format;


### PR DESCRIPTION
This was introduced in #3299, but it only hit people who compiled dolphin in debug mode