### PR TITLE
VI: set the JP bit of VI's DTV reg when needed

### DIFF
--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -15,6 +15,7 @@
 #include "Core/Boot/Boot_DOL.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HW/Memmap.h"
+#include "Core/HW/VideoInterface.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -88,7 +89,11 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
 	// setup Wii memory
 	if (!SetupWiiMemory(ContentLoader.GetCountry()))
 		return false;
-
+	// this sets a bit that is used to detect NTSC-J
+	if (ContentLoader.GetCountry() == DiscIO::IVolume::COUNTRY_JAPAN)
+	{
+		VideoInterface::SetRegionReg('J');
+	}
 	// DOL
 	const DiscIO::SNANDContent* pContent = ContentLoader.GetContentByIndex(ContentLoader.GetBootIndex());
 	if (pContent == nullptr)

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -154,6 +154,7 @@ void Preset(bool _bNTSC)
 
 	// Say component cable is plugged
 	m_DTVStatus.component_plugged = SConfig::GetInstance().bProgressive;
+	m_DTVStatus.ntsc_j = SConfig::GetInstance().bForceNTSCJ;
 
 	s_ticks_last_line_start = 0;
 	s_half_line_count = 1;


### PR DESCRIPTION
The "Force NTSC-J" option was broken by 480dbb22f2cfddf7fa989f3a68fbfec075b3a1b4
 (i.e. field-timing). A side effect of this was that it exposed a bug
 where the JP region bit of VI's DTV reg was not automatically set for wads
 from the JP region.