### PR TITLE
DQt2 logging dockable window

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_AUTOMOC ON)
 
 set(SRCS
 	Host.cpp
+	LogViewer.cpp
 	Main.cpp
 	MainWindow.cpp
 	MenuBar.cpp
@@ -12,6 +13,7 @@ set(SRCS
 	Resources.cpp
 	Settings.cpp
 	ToolBar.cpp
+	Config/LogDialog.cpp
 	Config/PathDialog.cpp
 	GameList/GameFile.cpp
 	GameList/GameList.cpp

--- a/Source/Core/DolphinQt2/Config/LogDialog.cpp
+++ b/Source/Core/DolphinQt2/Config/LogDialog.cpp
@@ -1,0 +1,17 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QDialog>
+#include <QString>
+
+#include "Common/IniFile.h"
+#include "Common/Logging/LogManager.h"
+#include "DolphinQt2/LogViewer.h"
+#include "DolphinQt2/Config/LogDialog.h"
+
+LogDialog::LogDialog(QWidget* parent)
+	: QDialog(parent)
+{
+	setAttribute(Qt::WA_DeleteOnClose);
+}

--- a/Source/Core/DolphinQt2/Config/LogDialog.h
+++ b/Source/Core/DolphinQt2/Config/LogDialog.h
@@ -1,0 +1,21 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+#include <QObject>
+
+#include "Common/IniFile.h"
+#include "Common/Logging/LogManager.h"
+#include "DolphinQt2/LogViewer.h"
+
+class LogDialog final : public QDialog
+{
+	Q_OBJECT
+public:
+	explicit LogDialog(QWidget* parent = nullptr);
+
+public slots:
+};

--- a/Source/Core/DolphinQt2/LogViewer.cpp
+++ b/Source/Core/DolphinQt2/LogViewer.cpp
@@ -1,0 +1,94 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <mutex>
+#include <QScrollBar>
+#include <QString>
+#include <QTextEdit>
+#include <QTimer>
+#include <queue>
+#include <QWidget>
+#include <utility>
+
+#include "Common/IniFile.h"
+#include "Common/Logging/LogManager.h"
+#include "DolphinQt2/LogViewer.h"
+
+LogViewer::LogViewer(QWidget* parent)
+	: QTextEdit(parent)
+{
+	setStyleSheet(QString::fromUtf8("QTextEdit{background-color: rgb(21, 21, 21)}"));
+	setReadOnly(true);
+
+	LogManager* m_LogManager = LogManager::GetInstance();
+	m_LogManager->RegisterListener(LogListener::LOG_WINDOW_LISTENER, this);
+	m_LogManager->OpenWindow();
+
+	QTimer *timer = new QTimer(this);
+	connect(timer, SIGNAL(timeout()), this, SLOT(displayLog()));
+	timer->start(200);
+}
+
+LogViewer::~LogViewer()
+{
+	LogManager* m_LogManager = LogManager::GetInstance();
+	if (m_LogManager)
+		m_LogManager->CloseWindow();
+}
+
+void LogViewer::Log(LogTypes::LOG_LEVELS level, const char* msg)
+{
+	std::lock_guard<std::mutex> lk(m_LogEntry);
+	QString qmsg = QString::fromUtf8(msg).trimmed();
+	msgQueue.emplace(std::make_pair(level, qmsg));
+}
+
+void LogViewer::displayLog()
+{
+	std::lock_guard<std::mutex> lk(m_LogEntry);
+	bool scroll = false;
+	// This function runs on the main gui thread, and needs to finish in a finite time otherwise
+	// the GUI will lock up, which could be an issue if new messages are flooding in faster than
+	// this function can render them to the screen.
+	// So we limit the number of times run via this for loop.
+	for (int i = 0; i < 100; i++)
+	{
+		if (msgQueue.empty())
+			break;
+		LogTypes::LOG_LEVELS level = msgQueue.front().first;
+		QString qmsg = msgQueue.front().second;
+		msgQueue.pop();
+
+		//display log time
+		setTextColor(QColor(221, 221, 221)); //white
+		append(qmsg.left(9));
+
+		//display log message
+		switch (level)
+		{//grab from .Xdefaults
+		case LogTypes::LOG_LEVELS::LERROR:
+			setTextColor(QColor(232, 79, 79)); //red
+			break;
+		case LogTypes::LOG_LEVELS::LWARNING:
+			setTextColor(QColor(225, 170, 93)); //yellow
+			break;
+		case LogTypes::LOG_LEVELS::LNOTICE:
+			setTextColor(QColor(184, 214, 140)); //green
+			break;
+		case LogTypes::LOG_LEVELS::LINFO:
+			setTextColor(QColor(109, 135, 189)); //cyan
+			break;
+		case LogTypes::LOG_LEVELS::LDEBUG:
+			setTextColor(QColor(70, 70, 70, 70)); //grey
+			break;
+		default:
+			setTextColor(QColor(221, 221, 221)); //white
+			break;
+		}
+		insertPlainText(qmsg.right(qmsg.length()-9));
+		scroll = true;
+	}
+	if (scroll)
+		this->verticalScrollBar()->setValue(this->verticalScrollBar()->maximum());
+}

--- a/Source/Core/DolphinQt2/LogViewer.h
+++ b/Source/Core/DolphinQt2/LogViewer.h
@@ -1,0 +1,29 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <mutex>
+#include <QObject>
+#include <QString>
+#include <QTextEdit>
+#include <queue>
+#include <QWidget>
+#include <utility>
+
+#include "Common/Logging/LogManager.h"
+
+class LogViewer final : public QTextEdit, LogListener
+{
+	Q_OBJECT
+public:
+	explicit LogViewer(QWidget* parent);
+	~LogViewer();
+	void Log(LogTypes::LOG_LEVELS, const char* msg) override;
+private slots:
+	void displayLog();
+private:
+	std::mutex m_LogEntry;
+	std::queue<std::pair<LogTypes::LOG_LEVELS, QString>> msgQueue;
+};

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -7,10 +7,12 @@
 #include <QFileDialog>
 #include <QIcon>
 #include <QMessageBox>
+#include <QTextEdit>
 
 #include "Core/BootManager.h"
 #include "Core/Core.h"
 #include "DolphinQt2/Host.h"
+#include "DolphinQt2/LogViewer.h"
 #include "DolphinQt2/MainWindow.h"
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -4,8 +4,12 @@
 
 #include <QAction>
 #include <QActionGroup>
+#include <QDockWidget>
+#include <QMainWindow>
 
+#include "DolphinQt2/LogViewer.h"
 #include "DolphinQt2/MenuBar.h"
+#include "DolphinQt2/Config/LogDialog.h"
 
 MenuBar::MenuBar(QWidget* parent)
 	: QMenuBar(parent)
@@ -30,8 +34,12 @@ void MenuBar::AddViewMenu()
 {
 	QMenu* view_menu = addMenu(tr("View"));
 	AddGameListTypeSection(view_menu);
+
 	view_menu->addSeparator();
 	AddTableColumnsMenu(view_menu);
+
+	view_menu->addSeparator();
+	AddLogMenu(view_menu);
 }
 
 void MenuBar::AddGameListTypeSection(QMenu* view_menu)
@@ -76,4 +84,39 @@ void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
 		QAction* action = column_group->addAction(cols_menu->addAction(col_names[i]));
 		action->setCheckable(true);
 	}
+}
+
+void MenuBar::AddLogMenu(QMenu* view_menu)
+{
+	QAction* show_log = view_menu->addAction(tr("Show Log"));
+	show_log->setCheckable(true);
+
+	QAction* configure_log = view_menu->addAction(tr("Configure Log"));
+	//TODO load this from settings
+	show_log->setChecked(false);
+
+	//setup  LogViewer
+	log_dock = new QDockWidget(tr("Log"), parentWidget());
+	log_dock->setAllowedAreas(Qt::AllDockWidgetAreas);
+	LogViewer* m_LogViewer = new LogViewer(log_dock);
+	log_dock->setWidget(m_LogViewer);
+	static_cast<QMainWindow*>(parentWidget())->addDockWidget(Qt::BottomDockWidgetArea, log_dock);
+	log_dock->hide();
+
+	connect(show_log, &QAction::toggled, this, &MenuBar::ToggleLogViewer);
+	connect(configure_log, &QAction::triggered, this, &MenuBar::OpenLogDialog);
+}
+
+void MenuBar::ToggleLogViewer(bool display)
+{
+	if (display)
+		log_dock->show();
+	else
+		log_dock->hide();
+}
+
+void MenuBar::OpenLogDialog()
+{
+	LogDialog* m_LogDialog = new LogDialog(parentWidget());
+	m_LogDialog->exec();
 }

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -7,6 +7,9 @@
 #include <QMenu>
 #include <QMenuBar>
 
+#include "DolphinQt2/LogViewer.h"
+#include "DolphinQt2/Config/LogDialog.h"
+
 class MenuBar final : public QMenuBar
 {
 	Q_OBJECT
@@ -21,10 +24,17 @@ signals:
 	void ShowTable();
 	void ShowList();
 
+private slots:
+	void ToggleLogViewer(bool display);
+	void OpenLogDialog();
+
 private:
 	void AddFileMenu();
 	void AddViewMenu();
 
 	void AddGameListTypeSection(QMenu* view_menu);
 	void AddTableColumnsMenu(QMenu* view_menu);
+
+	void AddLogMenu(QMenu* view_menu);
+	QDockWidget* log_dock;
 };

--- a/Source/Core/DolphinWX/LogConfigWindow.cpp
+++ b/Source/Core/DolphinWX/LogConfigWindow.cpp
@@ -170,9 +170,9 @@ void LogConfigWindow::OnWriteFileChecked(wxCommandEvent& event)
 		if (m_checks->IsChecked(i))
 		{
 			if (m_writeFile)
-				m_LogManager->AddListener((LogTypes::LOG_TYPE)i, LogListener::FILE_LISTENER);
+				m_LogManager->EnableListener((LogTypes::LOG_TYPE)i, LogListener::FILE_LISTENER);
 			else
-				m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::FILE_LISTENER);
+				m_LogManager->DisableListener((LogTypes::LOG_TYPE)i, LogListener::FILE_LISTENER);
 		}
 	}
 }
@@ -185,9 +185,9 @@ void LogConfigWindow::OnWriteConsoleChecked(wxCommandEvent& event)
 		if (m_checks->IsChecked(i))
 		{
 			if (m_writeConsole)
-				m_LogManager->AddListener((LogTypes::LOG_TYPE)i, LogListener::CONSOLE_LISTENER);
+				m_LogManager->EnableListener((LogTypes::LOG_TYPE)i, LogListener::CONSOLE_LISTENER);
 			else
-				m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::CONSOLE_LISTENER);
+				m_LogManager->DisableListener((LogTypes::LOG_TYPE)i, LogListener::CONSOLE_LISTENER);
 		}
 	}
 }
@@ -200,9 +200,9 @@ void LogConfigWindow::OnWriteWindowChecked(wxCommandEvent& event)
 		if (m_checks->IsChecked(i))
 		{
 			if (m_writeWindow)
-				m_LogManager->AddListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
+				m_LogManager->EnableListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
 			else
-				m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
+				m_LogManager->DisableListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
 		}
 	}
 }
@@ -226,17 +226,17 @@ void LogConfigWindow::ToggleLog(int _logType, bool enable)
 	if (enable)
 	{
 		if (m_writeWindow)
-			m_LogManager->AddListener(logType, LogListener::LOG_WINDOW_LISTENER);
+			m_LogManager->EnableListener(logType, LogListener::LOG_WINDOW_LISTENER);
 		if (m_writeFile)
-			m_LogManager->AddListener(logType, LogListener::FILE_LISTENER);
+			m_LogManager->EnableListener(logType, LogListener::FILE_LISTENER);
 		if (m_writeConsole)
-			m_LogManager->AddListener(logType, LogListener::CONSOLE_LISTENER);
+			m_LogManager->EnableListener(logType, LogListener::CONSOLE_LISTENER);
 	}
 	else
 	{
-		m_LogManager->RemoveListener(logType, LogListener::LOG_WINDOW_LISTENER);
-		m_LogManager->RemoveListener(logType, LogListener::FILE_LISTENER);
-		m_LogManager->RemoveListener(logType, LogListener::CONSOLE_LISTENER);
+		m_LogManager->DisableListener(logType, LogListener::LOG_WINDOW_LISTENER);
+		m_LogManager->DisableListener(logType, LogListener::FILE_LISTENER);
+		m_LogManager->DisableListener(logType, LogListener::CONSOLE_LISTENER);
 	}
 }
 

--- a/Source/Core/DolphinWX/LogWindow.cpp
+++ b/Source/Core/DolphinWX/LogWindow.cpp
@@ -64,39 +64,6 @@ void CLogWindow::CreateGUIControls()
 	log_window->Get("y", &y, Parent->GetSize().GetY());
 	log_window->Get("pos", &winpos, wxAUI_DOCK_RIGHT);
 
-	// Set up log listeners
-	int verbosity;
-	options->Get("Verbosity", &verbosity, 0);
-
-	// Ensure the verbosity level is valid
-	if (verbosity < 1)
-		verbosity = 1;
-	if (verbosity > MAX_LOGLEVEL)
-		verbosity = MAX_LOGLEVEL;
-
-	// Get the logger output settings from the config ini file.
-	options->Get("WriteToFile", &m_writeFile, false);
-	options->Get("WriteToWindow", &m_writeWindow, true);
-
-	IniFile::Section* logs = ini.GetOrCreateSection("Logs");
-	for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
-	{
-		bool enable;
-		logs->Get(m_LogManager->GetShortName((LogTypes::LOG_TYPE)i), &enable, false);
-
-		if (m_writeWindow && enable)
-			m_LogManager->AddListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
-		else
-			m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
-
-		if (m_writeFile && enable)
-			m_LogManager->AddListener((LogTypes::LOG_TYPE)i, LogListener::FILE_LISTENER);
-		else
-			m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::FILE_LISTENER);
-
-		m_LogManager->SetLogLevel((LogTypes::LOG_TYPE)i, (LogTypes::LOG_LEVELS)(verbosity));
-	}
-
 	// Font
 	m_FontChoice = new wxChoice(this, wxID_ANY);
 	m_FontChoice->Bind(wxEVT_CHOICE, &CLogWindow::OnFontChange, this);
@@ -148,14 +115,12 @@ void CLogWindow::CreateGUIControls()
 	SetSizer(sMain);
 
 	m_cmdline->SetFocus();
+	m_LogManager->OpenWindow();
 }
 
 CLogWindow::~CLogWindow()
 {
-	for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
-	{
-		m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
-	}
+	m_LogManager->CloseWindow();
 }
 
 void CLogWindow::OnClose(wxCloseEvent& event)

--- a/Source/Core/DolphinWX/LogWindow.h
+++ b/Source/Core/DolphinWX/LogWindow.h
@@ -46,7 +46,7 @@ private:
 	wxTimer m_LogTimer;
 	LogManager* m_LogManager;
 	std::queue<std::pair<u8, wxString> > msgQueue;
-	bool m_writeFile, m_writeWindow, m_LogAccess;
+	bool m_LogAccess;
 
 	// Controls
 	wxBoxSizer* sBottom;


### PR DESCRIPTION
Adds a log in the form of a docked window.
Colors were pulled from my terminal, let me know of better color schemes.
I cleaned up the LogManager code a bit, to make it more obvious what its doing and moved code from the GUI into LogManager.
I used a check box to toggle the log window on and off, alternatively I could have a standard menu option and let the user close it via the x button.
Log configuration is coming later.

![screenshot](https://cloud.githubusercontent.com/assets/5120858/12061365/14bc72b6-afd8-11e5-8dcc-d1f060500b6c.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3416)

<!-- Reviewable:end -->
