### PR TITLE
Removes assert in CoreTiming.

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -222,7 +222,6 @@ u64 GetIdleTicks()
 // schedule things to be executed on the main thread.
 void ScheduleEvent_Threadsafe(int cyclesIntoFuture, int event_type, u64 userdata)
 {
-	_assert_msg_(POWERPC, !Core::IsCPUThread(), "ScheduleEvent_Threadsafe from wrong thread");
 	if (Core::g_want_determinism)
 	{
 		ERROR_LOG(POWERPC, "Someone scheduled an off-thread \"%s\" event while netplay or movie play/record "


### PR DESCRIPTION
This assert was added a while back to know when something on the CPU thread is scheduling an event in the in CoreTiming and didn't need to use the
threadsafe version.

This has gone unnoticed that this affects code that schedules events on both the CPU thread and not CPU thread.
Noticed this when testing the gamepad reset combination.