### PR TITLE
DQt2: Add a message if the game list is empty

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <QLabel>
 #include <QListView>
 #include <QSortFilterProxyModel>
 #include <QStackedWidget>
@@ -22,18 +23,22 @@ public:
 	QString GetSelectedGame() const;
 
 public slots:
-	void SetTableView() { setCurrentWidget(m_table); }
-	void SetListView() { setCurrentWidget(m_list); }
+	void SetTableView() { SetPreferredView(true); }
+	void SetListView() { SetPreferredView(false); }
 	void SetViewColumn(int col, bool view) { m_table->setColumnHidden(col, !view); }
 
 signals:
 	void GameSelected();
-	void DirectoryAdded(QString dir);
-	void DirectoryRemoved(QString dir);
+	void DirectoryAdded(const QString& dir);
+	void DirectoryRemoved(const QString& dir);
 
 private:
 	void MakeTableView();
 	void MakeListView();
+	void MakeEmptyView();
+	// We only have two views, just use a bool to distinguish.
+	void SetPreferredView(bool table);
+	void ConsiderViewChange();
 
 	GameListModel* m_model;
 	QSortFilterProxyModel* m_table_proxy;
@@ -41,4 +46,6 @@ private:
 
 	QListView* m_list;
 	QTableView* m_table;
+	QLabel* m_empty;
+	bool m_prefer_table;
 };

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -81,7 +81,7 @@ void GameListModel::UpdateGame(QSharedPointer<GameFile> game)
 	endInsertRows();
 }
 
-void GameListModel::RemoveGame(QString path)
+void GameListModel::RemoveGame(const QString& path)
 {
 	int entry = FindGame(path);
 	if (entry < 0)

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -42,11 +42,11 @@ public:
 
 public slots:
 	void UpdateGame(QSharedPointer<GameFile> game);
-	void RemoveGame(QString path);
+	void RemoveGame(const QString& path);
 
 signals:
-	void DirectoryAdded(QString dir);
-	void DirectoryRemoved(QString dir);
+	void DirectoryAdded(const QString& dir);
+	void DirectoryRemoved(const QString& dir);
 
 private:
 	// Index in m_games, or -1 if it isn't found

--- a/Source/Core/DolphinQt2/GameList/GameTracker.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.cpp
@@ -45,7 +45,7 @@ GameTracker::~GameTracker()
 	m_loader_thread.wait();
 }
 
-void GameTracker::AddDirectory(QString dir)
+void GameTracker::AddDirectory(const QString& dir)
 {
 	if (!QFileInfo(dir).exists())
 		return;
@@ -53,7 +53,7 @@ void GameTracker::AddDirectory(QString dir)
 	UpdateDirectory(dir);
 }
 
-void GameTracker::RemoveDirectory(QString dir)
+void GameTracker::RemoveDirectory(const QString& dir)
 {
 	removePath(dir);
 	QDirIterator it(dir, game_filters, QDir::NoFilter, QDirIterator::Subdirectories);

--- a/Source/Core/DolphinQt2/GameList/GameTracker.h
+++ b/Source/Core/DolphinQt2/GameList/GameTracker.h
@@ -30,14 +30,14 @@ public:
 	~GameTracker();
 
 public slots:
-	void AddDirectory(QString dir);
-	void RemoveDirectory(QString dir);
+	void AddDirectory(const QString& dir);
+	void RemoveDirectory(const QString& dir);
 
 signals:
 	void GameLoaded(QSharedPointer<GameFile> game);
-	void GameRemoved(QString path);
+	void GameRemoved(const QString& path);
 
-	void PathChanged(QString path);
+	void PathChanged(const QString& path);
 
 private:
 	void UpdateDirectory(const QString& dir);
@@ -54,7 +54,7 @@ class GameLoader final : public QObject
 	Q_OBJECT
 
 public slots:
-	void LoadGame(QString path)
+	void LoadGame(const QString& path)
 	{
 		GameFile* game = new GameFile(path);
 		if (game->IsValid())

--- a/Source/Core/DolphinQt2/Host.h
+++ b/Source/Core/DolphinQt2/Host.h
@@ -30,7 +30,7 @@ public slots:
 	void SetRenderFullscreen(bool fullscreen);
 
 signals:
-	void RequestTitle(QString title);
+	void RequestTitle(const QString& title);
 	void RequestStop();
 	void RequestRenderSize(int w, int h);
 

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -6,6 +6,7 @@
 #include <QActionGroup>
 
 #include "DolphinQt2/MenuBar.h"
+#include "DolphinQt2/Settings.h"
 
 MenuBar::MenuBar(QWidget* parent)
 	: QMenuBar(parent)
@@ -46,8 +47,9 @@ void MenuBar::AddGameListTypeSection(QMenu* view_menu)
 	list_group->addAction(table_view);
 	list_group->addAction(list_view);
 
-	// TODO load this from settings
-	table_view->setChecked(true);
+	bool prefer_table = Settings().GetPreferredView();
+	table_view->setChecked(prefer_table);
+	list_view->setChecked(!prefer_table);
 
 	connect(table_view, &QAction::triggered, this, &MenuBar::ShowTable);
 	connect(list_view, &QAction::triggered, this, &MenuBar::ShowList);

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -105,6 +105,16 @@ DiscIO::IVolume::ELanguage Settings::GetGCSystemLanguage() const
 	return SConfig::GetInstance().GetCurrentLanguage(false);
 }
 
+bool Settings::GetPreferredView() const
+{
+	return value(QStringLiteral("PreferredView"), true).toBool();
+}
+
+void Settings::SetPreferredView(bool table)
+{
+	setValue(QStringLiteral("PreferredView"), table);
+}
+
 bool Settings::GetConfirmStop() const
 {
 	return value(QStringLiteral("Emulation/ConfirmStop"), true).toBool();

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -35,6 +35,8 @@ public:
 	void SetWiiNAND(const QString& path);
 	DiscIO::IVolume::ELanguage GetWiiSystemLanguage() const;
 	DiscIO::IVolume::ELanguage GetGCSystemLanguage() const;
+	bool GetPreferredView() const;
+	void SetPreferredView(bool table);
 
 	// Emulation
 	bool GetConfirmStop() const;


### PR DESCRIPTION
The game list now remembers your view style preference. If it is empty, it will show a message telling you to open the Paths dialog. We can bikeshed how this message looks now. It's possible to do basic HTML in QLabels, so I could add a Paths icon, or make it a link that opens the Paths dialog when you click it, or whatever, but I like it the way it is. Simple.

![ss](https://cloud.githubusercontent.com/assets/7368979/12070537/fb264554-b02f-11e5-84cb-d894bf02185f.jpg)

Also some small consistency improvements. It turns out it's fine to pass signal/slot arguments by const reference. Qt will make a copy if they go into another thread.