### PR TITLE
Debug Builds: Fixed vector assertion

### DIFF
--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 #include <mbedtls/aes.h>
 
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
@@ -190,8 +191,14 @@ void CNANDContentLoader::InitializeContentEntries(const std::vector<u8>& tmd, co
 		content.m_Index     = Common::swap16(&tmd[entry_offset + 0x01E8]);
 		content.m_Type      = Common::swap16(&tmd[entry_offset + 0x01EA]);
 		content.m_Size      = static_cast<u32>(Common::swap64(&tmd[entry_offset + 0x01EC]));
-		std::copy(&tmd[entry_offset + 0x01E4], &tmd[entry_offset + 0x01E4 + 36], content.m_Header);
-		std::copy(&tmd[entry_offset + 0x01F4], &tmd[entry_offset + 0x01F4 + 20], content.m_SHA1Hash);
+
+		const auto header_begin = std::next(tmd.begin(), entry_offset + 0x01E4);
+		const auto header_end   = std::next(header_begin, ArraySize(content.m_Header));
+		std::copy(header_begin, header_end, content.m_Header);
+
+		const auto hash_begin = std::next(tmd.begin(), entry_offset + 0x01F4);
+		const auto hash_end   = std::next(hash_begin, ArraySize(content.m_SHA1Hash));
+		std::copy(hash_begin, hash_end, content.m_SHA1Hash);
 
 		if (m_isWAD)
 		{


### PR DESCRIPTION
Well... Thanks Microsoft again for checking indexes when making Debug Builds. It means that an assertion will be raised before an out of bound. Nonetheless, this is even checked during pointer operations. In other word, getting a pointer from an out of bound index isn't possible in Debug Builds, for instance using std::copy.

The PR #3362 created the [issue 9215](https://bugs.dolphin-emu.org/issues/9215) with those lines in [Source/Core/DiscIO/NANDContentLoader.cpp:193](https://github.com/dolphin-emu/dolphin/pull/3362/files#diff-39352a6d4347be526a5dd466a4909255R193). At the last iteration, two out of bound are performed.
```
std::copy(&tmd[entry_offset + 0x01E4], &tmd[entry_offset + 0x01E4 + 36], content.m_Header);
std::copy(&tmd[entry_offset + 0x01F4], &tmd[entry_offset + 0x01F4 + 20], content.m_SHA1Hash);
```

Two solutions:
1. Increase the size of the vector by one to avoid the out of bound
2. Doing something like this:
```
std::copy(&tmd[entry_offset + 0x01E4], &tmd[entry_offset + 0x01E4] + 36, content.m_Header);
std::copy(&tmd[entry_offset + 0x01F4], &tmd[entry_offset + 0x01F4] + 20, content.m_SHA1Hash);
```

I opted for the first one, probably the safer, faster and dirtier, IMO. If you prefer the other method I'll rebase this commit with the appropriate changes.