### PR TITLE
ShaderGen: Remove virtual methods and string from ShaderGeneratorInterface.

### DIFF
--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <fstream>
 #include <string>
+#include <type_traits>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
@@ -52,6 +53,15 @@ public:
 	u32 OpenAndRead(const std::string& filename, LinearDiskCacheReader<K, V> &reader)
 	{
 		using std::ios_base;
+
+		// Since we're reading/writing directly to the storage of K instances,
+		// K must be trivially copyable. TODO: Remove #if once GCC 5.0 is a
+		// minimum requirement.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+		static_assert(std::has_trivial_copy_constructor<K>::value, "K must be a trivially copyable type");
+#else
+		static_assert(std::is_trivially_copyable<K>::value, "K must be a trivially copyable type");
+#endif
 
 		// close any currently opened file
 		Close();

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -23,10 +23,6 @@ public:
 	PixelShaderUid puid;
 	GeometryShaderUid guid;
 
-	SHADERUID() {}
-
-	SHADERUID(const SHADERUID& r) : vuid(r.vuid), puid(r.puid), guid(r.guid) {}
-
 	bool operator <(const SHADERUID& r) const
 	{
 		if (puid < r.puid)

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -34,7 +34,9 @@ static T GenerateGeometryShader(u32 primitive_type, API_TYPE ApiType)
 	// Non-uid template parameters will write to the dummy data (=> gets optimized out)
 	geometry_shader_uid_data dummy_data;
 	geometry_shader_uid_data* uid_data = out.template GetUidData<geometry_shader_uid_data>();
-	if (uid_data == nullptr)
+	if (uid_data != nullptr)
+		memset(uid_data, 0, sizeof(*uid_data));
+	else
 		uid_data = &dummy_data;
 
 	uid_data->primitive_type = primitive_type;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -168,7 +168,9 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 	// Non-uid template parameters will write to the dummy data (=> gets optimized out)
 	pixel_shader_uid_data dummy_data;
 	pixel_shader_uid_data* uid_data = out.template GetUidData<pixel_shader_uid_data>();
-	if (uid_data == nullptr)
+	if (uid_data != nullptr)
+		memset(uid_data, 0, sizeof(*uid_data));
+	else
 		uid_data = &dummy_data;
 
 	unsigned int numStages = bpmem.genMode.numtevstages + 1;

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -19,7 +19,9 @@ static T GenerateVertexShader(API_TYPE api_type)
 	// Non-uid template parameters will write to the dummy data (=> gets optimized out)
 	vertex_shader_uid_data dummy_data;
 	vertex_shader_uid_data* uid_data = out.template GetUidData<vertex_shader_uid_data>();
-	if (uid_data == nullptr)
+	if (uid_data != nullptr)
+		memset(uid_data, 0, sizeof(*uid_data));
+	else
 		uid_data = &dummy_data;
 
 	_assert_(bpmem.genMode.numtexgens == xfmem.numTexGen.numTexGens);


### PR DESCRIPTION
Addresses [issue 9219](https://bugs.dolphin-emu.org/issues/9219). This is because LinearDiskCache reads/writes to the storage of ShaderUid, therefore ShaderUid must be a POD struct. So I've removed the constructor of the uid classes (moving this to the shader gen function themselves), and the virtual methods/string from the base class.

Since all the callers of these methods take a template parameter of the derived class anyway, there was no benefit to them being virtual. ShaderGeneratorInterface is now acting as a fallback for the methods unimplemented by the derived classes.

Additionally, adds a static assert to LinearDiskCache to ensure no non-POD types are used in the future.

gcc and clang both correctly optimize out all the Write() calls in the shader generation method. MSVC does it for some of them, but not all (some of the varargs cases and where a function is called, eg GetInterpolationQualifier, which is not being inlined for some reason). Aside from duplicating the shader generation code to include only the uid-writing parts, I can't think of a more straightforward solution to this problem.