### PR TITLE
HW: Fix libusb support for older libusb APIs

### DIFF
--- a/CMakeTests/FindLibUSB.cmake
+++ b/CMakeTests/FindLibUSB.cmake
@@ -23,7 +23,7 @@ elseif (NOT LIBUSB_FOUND)
        /usr/local/include
     )
 
-    find_library(LIBUSB_LIBRARIES NAMES usb-1.0
+    find_library(LIBUSB_LIBRARIES NAMES usb-1.0 usb
        PATHS
        ${LIBUSB_PKG_LIBRARY_DIRS}
        /usr/lib


### PR DESCRIPTION
Fixes libusb support for old versions of libusb that don't have hotplug support, especially the one shipped with FreeBSD. Shouldn't affect newer versions at all. Adapted from #3190.