### PR TITLE
HW: Add missing header for sprintf()

### DIFF
--- a/Source/Core/Core/HW/SI_DeviceAMBaseboard.cpp
+++ b/Source/Core/Core/HW/SI_DeviceAMBaseboard.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstdio>
 #include <cstring>
 
 #include "Common/MsgHandler.h"


### PR DESCRIPTION
Only missing include from a #3190 commit that's still missing. Pulled in the commit wholesale since it's still valid.