### PR TITLE
[OpenSLES] Fix a delay in audio processing.

### DIFF
--- a/Source/Core/AudioCommon/OpenSLESStream.cpp
+++ b/Source/Core/AudioCommon/OpenSLESStream.cpp
@@ -37,19 +37,15 @@ static void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void *context)
 	assert(bq == bqPlayerBufferQueue);
 	assert(nullptr == context);
 
-	short *nextBuffer = buffer[curBuffer];
-	int nextSize = sizeof(buffer[0]);
-
-	SLresult result = (*bqPlayerBufferQueue)->Enqueue(bqPlayerBufferQueue, nextBuffer, nextSize);
+	// Render to the fresh buffer
+	g_mixer->Mix(reinterpret_cast<short *>(buffer[curBuffer]), BUFFER_SIZE_IN_SAMPLES);
+	SLresult result = (*bqPlayerBufferQueue)->Enqueue(bqPlayerBufferQueue, buffer[curBuffer], sizeof(buffer[0]));
+	curBuffer ^= 1; // Switch buffer
 
 	// Comment from sample code:
 	// the most likely other result is SL_RESULT_BUFFER_INSUFFICIENT,
 	// which for this code example would indicate a programming error
 	_assert_msg_(AUDIO, SL_RESULT_SUCCESS == result, "Couldn't enqueue audio stream.");
-
-	curBuffer ^= 1; // Switch buffer
-	// Render to the fresh buffer
-	g_mixer->Mix(reinterpret_cast<short *>(buffer[curBuffer]), BUFFER_SIZE_IN_SAMPLES);
 }
 
 bool OpenSLESStream::Start()


### PR DESCRIPTION
A failure on my part. I was updating the two buffers in the wrong order, so we were always a buffer behind in sending audio out to OpenSLES.