### PR TITLE
[Android] Add UI support for the so-called "Overclock" feature

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SliderPreference.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SliderPreference.java
@@ -11,6 +11,7 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.dolphinemu.dolphinemu.R;
 
@@ -20,6 +21,7 @@ public class SliderPreference extends DialogPreference implements SeekBar.OnSeek
 
 	// SeekBar
 	private int m_max, m_value;
+	private String m_key;
 	private SeekBar m_seekbar;
 
 	// TextView
@@ -32,19 +34,35 @@ public class SliderPreference extends DialogPreference implements SeekBar.OnSeek
 		// Seekbar values
 		m_value = attrs.getAttributeIntValue(androidns, "defaultValue", 0);
 		m_max = attrs.getAttributeIntValue(androidns, "max", 100);
+		m_key = attrs.getAttributeValue(androidns, "key");
 	}
 
 	@Override
 	protected View onCreateDialogView()
 	{
 		LayoutInflater inflater = LayoutInflater.from(getContext());
-		LinearLayout layout = (LinearLayout)inflater.inflate(R.layout.slider_layout, null, false);
+		LinearLayout layout = (LinearLayout) inflater.inflate(R.layout.slider_layout, null, false);
 
-		m_seekbar = (SeekBar)layout.findViewById(R.id.sliderSeekBar);
-		m_textview = (TextView)layout.findViewById(R.id.sliderTextView);
+		m_seekbar = (SeekBar) layout.findViewById(R.id.sliderSeekBar);
+		m_textview = (TextView) layout.findViewById(R.id.sliderTextView);
 
 		if (shouldPersist())
-			m_value = Integer.valueOf(getPersistedString(Integer.toString(m_value)));
+		{
+			if (m_key != null && m_key.equals("Overclock"))
+			{
+				Toast.makeText(getContext(), getContext().getString(R.string.overclock_warning),
+						Toast.LENGTH_LONG).show();
+
+				float valueAsFloat = Float.valueOf(getPersistedString(Integer.toString(m_value)));
+				float valueAsPercent = valueAsFloat * 100;
+
+				m_value = Math.round(valueAsPercent);
+			}
+			else
+			{
+				m_value = Integer.valueOf(getPersistedString(Integer.toString(m_value)));
+			}
+		}
 
 		m_seekbar.setMax(m_max);
 		m_seekbar.setProgress(m_value);
@@ -63,9 +81,14 @@ public class SliderPreference extends DialogPreference implements SeekBar.OnSeek
 	}
 
 	@Override
-	public void onStartTrackingTouch(SeekBar seek) {}
+	public void onStartTrackingTouch(SeekBar seek)
+	{
+	}
+
 	@Override
-	public void onStopTrackingTouch(SeekBar seek) {}
+	public void onStopTrackingTouch(SeekBar seek)
+	{
+	}
 
 	void setProgressText(int value)
 	{
@@ -86,7 +109,18 @@ public class SliderPreference extends DialogPreference implements SeekBar.OnSeek
 	{
 		if (shouldPersist())
 		{
-			persistString(Integer.toString(m_seekbar.getProgress()));
+			String valueToSave;
+			if (m_key != null && m_key.equals("Overclock"))
+			{
+				float valueAsFloat = m_value / 100.0f;
+				valueToSave = Float.toString(valueAsFloat);
+			}
+			else
+			{
+				valueToSave = Integer.toString(m_seekbar.getProgress());
+			}
+
+			persistString(valueToSave);
 			callChangeListener(m_seekbar.getProgress());
 		}
 		((AlertDialog) getDialog()).dismiss();

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/UserPreferences.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/UserPreferences.java
@@ -46,6 +46,8 @@ public final class UserPreferences
 			editor.putString("cpuCorePref",   getConfig("Dolphin.ini", "Core", "CPUCore", "3"));
 
 		editor.putBoolean("dualCorePref", getConfig("Dolphin.ini", "Core", "CPUThread", "True").equals("True"));
+		editor.putBoolean("OverclockEnable", getConfig("Dolphin.ini", "Core", "OverclockEnable", "False").equals("True"));
+		editor.putString("Overclock", getConfig("Dolphin.ini", "Core", "Overclock", "100"));
 
 		editor.putString("WiimoteExtension_4", getConfig("WiimoteNew.ini", "Wiimote1", "Extension", "None"));
 		editor.putString("WiimoteExtension_5", getConfig("WiimoteNew.ini", "Wiimote2", "Extension", "None"));
@@ -142,6 +144,9 @@ public final class UserPreferences
 		// Current CPU core being used. Falls back to interpreter upon error.
 		String currentEmuCore = prefs.getString("cpuCorePref", "0");
 
+		boolean overclockEnabled = prefs.getBoolean("OverclockEnable", false);
+		String overclockSetting =  prefs.getString("Overclock", "100");
+
 		// Current wiimote extension setup. Falls back to no extension upon error.
 		String WiimoteExtension_4 = prefs.getString("WiimoteExtension_4", "None");
 		String WiimoteExtension_5 = prefs.getString("WiimoteExtension_5", "None");
@@ -224,6 +229,9 @@ public final class UserPreferences
 		// CPU related Settings
 		NativeLibrary.SetConfig("Dolphin.ini", "Core", "CPUCore", currentEmuCore);
 		NativeLibrary.SetConfig("Dolphin.ini", "Core", "CPUThread", isUsingDualCore ? "True" : "False");
+
+		NativeLibrary.SetConfig("Dolphin.ini", "Core", "OverclockEnable", overclockEnabled ? "True" : "False");
+		NativeLibrary.SetConfig("Dolphin.ini", "Core", "Overclock", overclockSetting);
 
 		// Wiimote Extension Settings
 		NativeLibrary.SetConfig("WiimoteNew.ini", "Wiimote1", "Extension", WiimoteExtension_4);

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -252,6 +252,10 @@
     <string name="dual_core_descrip">Split workload to two CPU cores instead of one. Increases speed.</string>
     <string name="fastmem">Fastmem</string>
     <string name="fastmem_desc">Uses potentially unsafe optimizations for memory access.</string>
+    <string name="overclock_enable">Override Emulated CPU Clock Speed</string>
+    <string name="overclock_enable_description">Higher values can make variable-framerate games run at a higher framerate, requiring a powerful device. Lower values make games run at a lower framerate, increasing emulation speed, but reducing the emulated console\'s performance.</string>
+    <string name="overclock_title">Emulated CPU Clock Speed</string>
+    <string name="overclock_warning">WARNING: Changing this from the default (100%) WILL break games and cause glitches. Please do not report bugs that occur with a non-default clock.</string>
 
     <!-- Video Preference Fragment -->
     <string name="video_settings">Video</string>

--- a/Source/Android/app/src/main/res/xml/preferences.xml
+++ b/Source/Android/app/src/main/res/xml/preferences.xml
@@ -19,6 +19,21 @@
             android:entries="@array/string_emu_cores"
             android:entryValues="@array/int_emu_cores"/>
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="OverclockEnable"
+            android:summary="@string/overclock_enable_description"
+            android:title="@string/overclock_enable"
+            />
+
+        <org.dolphinemu.dolphinemu.utils.SliderPreference
+            android:dependency="OverclockEnable"
+            android:defaultValue="100"
+            android:key="Overclock"
+            android:max="400"
+            android:title="@string/overclock_title"
+            />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
I thought it was important to add this because Android users are using it anyway, but they're editing Dolphin.ini directly, where it's referred to as "Overclock" instead of the more accurate and informative ways it's referred to in the desktop UI. This is causing a lot of them to actually think it's overclocking their *phone* CPU.

I've implemented support for the feature, and copious warning messages to try and educate a little more clearly.

The actual implementation is rather verbose, but I think I'll soon work on a massive stream-lining of the preference system to simplify adding the rest of the options to the UI, because there's still a lot missing.