### PR TITLE
JITArm64: Single precision + FPRF

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -34,6 +34,7 @@ void JitArm64::faddsx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 
@@ -50,6 +51,7 @@ void JitArm64::faddx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 
@@ -65,6 +67,7 @@ void JitArm64::fmaddsx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -86,6 +89,7 @@ void JitArm64::fmaddx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -116,6 +120,7 @@ void JitArm64::fmsubsx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -137,6 +142,7 @@ void JitArm64::fmsubx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -153,6 +159,7 @@ void JitArm64::fmulsx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, c = inst.FC, d = inst.FD;
 
@@ -169,6 +176,7 @@ void JitArm64::fmulx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, c = inst.FC, d = inst.FD;
 
@@ -213,6 +221,7 @@ void JitArm64::fnmaddsx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -235,6 +244,7 @@ void JitArm64::fnmaddx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -251,6 +261,7 @@ void JitArm64::fnmsubsx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -273,6 +284,7 @@ void JitArm64::fnmsubx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -306,6 +318,7 @@ void JitArm64::fsubsx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 
@@ -322,6 +335,7 @@ void JitArm64::fsubx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 
@@ -337,6 +351,7 @@ void JitArm64::frspx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 b = inst.FB, d = inst.FD;
 
@@ -460,6 +475,7 @@ void JitArm64::fdivx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 
@@ -475,6 +491,7 @@ void JitArm64::fdivsx(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITFloatingPointOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -42,6 +42,7 @@ void JitArm64::faddsx(UGeckoInstruction inst)
 	ARM64Reg VD = fpr.RW(d, REG_DUP);
 
 	m_float_emit.FADD(EncodeRegToDouble(VD), EncodeRegToDouble(VA), EncodeRegToDouble(VB));
+	fpr.FixSinglePrecision(d);
 }
 
 void JitArm64::faddx(UGeckoInstruction inst)
@@ -75,6 +76,7 @@ void JitArm64::fmaddsx(UGeckoInstruction inst)
 
 	m_float_emit.FMUL(EncodeRegToDouble(V0), EncodeRegToDouble(VA), EncodeRegToDouble(VC));
 	m_float_emit.FADD(EncodeRegToDouble(VD), EncodeRegToDouble(V0), EncodeRegToDouble(VB));
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -125,6 +127,7 @@ void JitArm64::fmsubsx(UGeckoInstruction inst)
 
 	m_float_emit.FMUL(EncodeRegToDouble(V0), EncodeRegToDouble(VA), EncodeRegToDouble(VC));
 	m_float_emit.FSUB(EncodeRegToDouble(VD), EncodeRegToDouble(V0), EncodeRegToDouble(VB));
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -158,6 +161,7 @@ void JitArm64::fmulsx(UGeckoInstruction inst)
 	ARM64Reg VD = fpr.RW(d, REG_DUP);
 
 	m_float_emit.FMUL(EncodeRegToDouble(VD), EncodeRegToDouble(VA), EncodeRegToDouble(VC));
+	fpr.FixSinglePrecision(d);
 }
 
 void JitArm64::fmulx(UGeckoInstruction inst)
@@ -221,6 +225,7 @@ void JitArm64::fnmaddsx(UGeckoInstruction inst)
 	m_float_emit.FMUL(EncodeRegToDouble(V0), EncodeRegToDouble(VA), EncodeRegToDouble(VC));
 	m_float_emit.FADD(EncodeRegToDouble(VD), EncodeRegToDouble(V0), EncodeRegToDouble(VB));
 	m_float_emit.FNEG(EncodeRegToDouble(VD), EncodeRegToDouble(VD));
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -258,6 +263,7 @@ void JitArm64::fnmsubsx(UGeckoInstruction inst)
 	m_float_emit.FMUL(EncodeRegToDouble(V0), EncodeRegToDouble(VA), EncodeRegToDouble(VC));
 	m_float_emit.FSUB(EncodeRegToDouble(VD), EncodeRegToDouble(V0), EncodeRegToDouble(VB));
 	m_float_emit.FNEG(EncodeRegToDouble(VD), EncodeRegToDouble(VD));
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -308,6 +314,7 @@ void JitArm64::fsubsx(UGeckoInstruction inst)
 	ARM64Reg VD = fpr.RW(d, REG_DUP);
 
 	m_float_emit.FSUB(EncodeRegToDouble(VD), EncodeRegToDouble(VA), EncodeRegToDouble(VB));
+	fpr.FixSinglePrecision(d);
 }
 
 void JitArm64::fsubx(UGeckoInstruction inst)
@@ -476,4 +483,5 @@ void JitArm64::fdivsx(UGeckoInstruction inst)
 	ARM64Reg VD = fpr.RW(d, REG_DUP);
 
 	m_float_emit.FDIV(EncodeRegToDouble(VD), EncodeRegToDouble(VA), EncodeRegToDouble(VB));
+	fpr.FixSinglePrecision(d);
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -35,6 +35,7 @@ void JitArm64::ps_add(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 
@@ -51,6 +52,7 @@ void JitArm64::ps_div(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 
@@ -67,6 +69,7 @@ void JitArm64::ps_madd(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -88,6 +91,7 @@ void JitArm64::ps_madds0(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -110,6 +114,7 @@ void JitArm64::ps_madds1(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -222,6 +227,7 @@ void JitArm64::ps_mul(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, c = inst.FC, d = inst.FD;
 
@@ -238,6 +244,7 @@ void JitArm64::ps_muls0(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, c = inst.FC, d = inst.FD;
 
@@ -257,6 +264,7 @@ void JitArm64::ps_muls1(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, c = inst.FC, d = inst.FD;
 
@@ -276,6 +284,7 @@ void JitArm64::ps_msub(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -326,6 +335,7 @@ void JitArm64::ps_nmadd(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -348,6 +358,7 @@ void JitArm64::ps_nmsub(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -370,6 +381,7 @@ void JitArm64::ps_res(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 b = inst.FB, d = inst.FD;
 
@@ -413,6 +425,7 @@ void JitArm64::ps_sub(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 
@@ -429,6 +442,7 @@ void JitArm64::ps_sum0(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
@@ -459,6 +473,7 @@ void JitArm64::ps_sum1(UGeckoInstruction inst)
 	INSTRUCTION_START
 	JITDISABLE(bJITPairedOff);
 	FALLBACK_IF(inst.Rc);
+	FALLBACK_IF(SConfig::GetInstance().bFPRF && js.op->wantsFPRF);
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -43,6 +43,7 @@ void JitArm64::ps_add(UGeckoInstruction inst)
 	ARM64Reg VD = fpr.RW(d, REG_REG);
 
 	m_float_emit.FADD(64, VD, VA, VB);
+	fpr.FixSinglePrecision(d);
 }
 
 void JitArm64::ps_div(UGeckoInstruction inst)
@@ -58,6 +59,7 @@ void JitArm64::ps_div(UGeckoInstruction inst)
 	ARM64Reg VD = fpr.RW(d, REG_REG);
 
 	m_float_emit.FDIV(64, VD, VA, VB);
+	fpr.FixSinglePrecision(d);
 }
 
 void JitArm64::ps_madd(UGeckoInstruction inst)
@@ -76,6 +78,7 @@ void JitArm64::ps_madd(UGeckoInstruction inst)
 
 	m_float_emit.FMUL(64, V0, VA, VC);
 	m_float_emit.FADD(64, VD, V0, VB);
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -97,6 +100,7 @@ void JitArm64::ps_madds0(UGeckoInstruction inst)
 	m_float_emit.DUP(64, V0, VC, 0);
 	m_float_emit.FMUL(64, V0, V0, VA);
 	m_float_emit.FADD(64, VD, V0, VB);
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -118,6 +122,7 @@ void JitArm64::ps_madds1(UGeckoInstruction inst)
 	m_float_emit.DUP(64, V0, VC, 1);
 	m_float_emit.FMUL(64, V0, V0, VA);
 	m_float_emit.FADD(64, VD, V0, VB);
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -225,6 +230,7 @@ void JitArm64::ps_mul(UGeckoInstruction inst)
 	ARM64Reg VD = fpr.RW(d, REG_REG);
 
 	m_float_emit.FMUL(64, VD, VA, VC);
+	fpr.FixSinglePrecision(d);
 }
 
 void JitArm64::ps_muls0(UGeckoInstruction inst)
@@ -242,6 +248,7 @@ void JitArm64::ps_muls0(UGeckoInstruction inst)
 
 	m_float_emit.DUP(64, V0, VC, 0);
 	m_float_emit.FMUL(64, VD, VA, V0);
+	fpr.FixSinglePrecision(d);
 	fpr.Unlock(V0);
 }
 
@@ -260,6 +267,7 @@ void JitArm64::ps_muls1(UGeckoInstruction inst)
 
 	m_float_emit.DUP(64, V0, VC, 1);
 	m_float_emit.FMUL(64, VD, VA, V0);
+	fpr.FixSinglePrecision(d);
 	fpr.Unlock(V0);
 }
 
@@ -279,6 +287,7 @@ void JitArm64::ps_msub(UGeckoInstruction inst)
 
 	m_float_emit.FMUL(64, V0, VA, VC);
 	m_float_emit.FSUB(64, VD, V0, VB);
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -329,6 +338,7 @@ void JitArm64::ps_nmadd(UGeckoInstruction inst)
 	m_float_emit.FMUL(64, V0, VA, VC);
 	m_float_emit.FADD(64, VD, V0, VB);
 	m_float_emit.FNEG(64, VD, VD);
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -350,6 +360,7 @@ void JitArm64::ps_nmsub(UGeckoInstruction inst)
 	m_float_emit.FMUL(64, V0, VA, VC);
 	m_float_emit.FSUB(64, VD, V0, VB);
 	m_float_emit.FNEG(64, VD, VD);
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -366,6 +377,7 @@ void JitArm64::ps_res(UGeckoInstruction inst)
 	ARM64Reg VD = fpr.RW(d, REG_REG);
 
 	m_float_emit.FRSQRTE(64, VD, VB);
+	fpr.FixSinglePrecision(d);
 }
 
 void JitArm64::ps_sel(UGeckoInstruction inst)
@@ -409,6 +421,7 @@ void JitArm64::ps_sub(UGeckoInstruction inst)
 	ARM64Reg VD = fpr.RW(d, REG_REG);
 
 	m_float_emit.FSUB(64, VD, VA, VB);
+	fpr.FixSinglePrecision(d);
 }
 
 void JitArm64::ps_sum0(UGeckoInstruction inst)
@@ -436,6 +449,7 @@ void JitArm64::ps_sum0(UGeckoInstruction inst)
 		m_float_emit.FADD(64, V0, V0, VA);
 		m_float_emit.INS(64, VD, 0, V0, 0);
 	}
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }
@@ -465,6 +479,7 @@ void JitArm64::ps_sum1(UGeckoInstruction inst)
 		m_float_emit.FADD(64, V0, V0, VB);
 		m_float_emit.INS(64, VD, 1, V0, 1);
 	}
+	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -559,3 +559,21 @@ BitSet32 Arm64FPRCache::GetCallerSavedUsed()
 			registers[it.GetReg() - Q0] = 1;
 	return registers;
 }
+
+void Arm64FPRCache::FixSinglePrecision(u32 preg)
+{
+	ARM64Reg host_reg = m_guest_registers[preg].GetReg();
+	switch (m_guest_registers[preg].GetType())
+	{
+	case REG_DUP: // only PS0 needs to be converted
+		m_float_emit->FCVT(32, 64, EncodeRegToDouble(host_reg), EncodeRegToDouble(host_reg));
+		m_float_emit->FCVT(64, 32, EncodeRegToDouble(host_reg), EncodeRegToDouble(host_reg));
+		break;
+	case REG_REG: // PS0 and PS1 needs to be converted
+		m_float_emit->FCVTN(32, EncodeRegToDouble(host_reg), EncodeRegToDouble(host_reg));
+		m_float_emit->FCVTL(64, EncodeRegToDouble(host_reg), EncodeRegToDouble(host_reg));
+		break;
+	default:
+		break;
+	}
+}

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -277,6 +277,8 @@ public:
 
 	BitSet32 GetCallerSavedUsed() override;
 
+	void FixSinglePrecision(u32 preg);
+
 protected:
 	// Get the order of the host registers
 	void GetAllocationOrder();


### PR DESCRIPTION
OK, single precision is a big slowdown, but it's required to be get on the same level of accurency as our JIT64. But this implementation is designed to support lazy convertion, so most of this slowdown can be fixed again.