### PR TITLE
StartupHandler.java: Finish main activity if AutoStartFile is specified in intent

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/StartupHandler.java
@@ -42,10 +42,11 @@ public final class StartupHandler
 
 			if (!TextUtils.isEmpty(start_file))
 			{
-				// Start the emulation activity and send the ISO passed in.
+				// Start the emulation activity, send the ISO passed in and finish the main activity
 				Intent emulation_intent = new Intent(parent, EmulationActivity.class);
 				emulation_intent.putExtra("SelectedGame", start_file);
 				parent.startActivity(emulation_intent);
+				parent.finish();
 				return false;
 			}
 		}


### PR DESCRIPTION
Call finish() on parent (main/browser) activity after starting EmulationActivity if AutoStartFile was specified. This makes the experience more streamlined for users who want to start games from an external frontend, since they don't expect to return to the Dolphin main activity after they've played their game.