### PR TITLE
HiresTextures: Also look for directories with 3-character IDs

### DIFF
--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -86,11 +86,14 @@ void HiresTexture::Update()
 		s_textureCache.clear();
 	}
 
-	const std::string& gameCode = SConfig::GetInstance().m_strUniqueID;
+	const std::string& game_id = SConfig::GetInstance().m_strUniqueID;
+	std::string texture_directory = GetTextureFolder(game_id);
 
-	std::string szDir = StringFromFormat("%s%s", File::GetUserPath(D_HIRESTEXTURES_IDX).c_str(), gameCode.c_str());
+	// If there's no directory with the region-specific ID, look for a 3-character region-free one
+	if (!File::Exists(texture_directory))
+		texture_directory = GetTextureFolder(game_id.substr(0, 3));
 
-	std::vector<std::string> Extensions {
+	std::vector<std::string> extensions {
 		".png",
 		".bmp",
 		".tga",
@@ -98,12 +101,11 @@ void HiresTexture::Update()
 		".jpg" // Why not? Could be useful for large photo-like textures
 	};
 
-	auto rFilenames = DoFileSearch(Extensions, {szDir}, /*recursive*/ true);
+	std::vector<std::string> filenames = DoFileSearch(extensions, {texture_directory}, /*recursive*/ true);
 
-	const std::string code = StringFromFormat("%s_", gameCode.c_str());
-	const std::string code2 = "";
+	const std::string code = game_id + "_";
 
-	for (auto& rFilename : rFilenames)
+	for (auto& rFilename : filenames)
 	{
 		std::string FileName;
 		SplitPath(rFilename, nullptr, &FileName, nullptr);
@@ -435,6 +437,11 @@ std::unique_ptr<HiresTexture> HiresTexture::Load(const std::string& base_filenam
 	}
 
 	return ret;
+}
+
+std::string HiresTexture::GetTextureFolder(const std::string& game_id)
+{
+	return File::GetUserPath(D_HIRESTEXTURES_IDX) + game_id;
 }
 
 HiresTexture::~HiresTexture()

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -51,6 +51,8 @@ private:
 	static std::unique_ptr<HiresTexture> Load(const std::string& base_filename, u32 width, u32 height);
 	static void Prefetch();
 
+	static std::string GetTextureFolder(const std::string& game_id);
+
 	HiresTexture() {}
 
 };


### PR DESCRIPTION
People who make texture packs usually release them using a specific ID (for instance SX4E01). Users who have a different version of the game (like the PAL version SX4P01) then need to rename the custom texture folder to match. This is a lot simpler than renaming every texture file, as was required with the old texture format, but it's still something that users can forget to do. To make that unnecessary, this change makes it possible to use three-character region-free IDs for custom texture folders, similarly to how game INIs can use three-character IDs. Once most people have updated to Dolphin versions that include this change (hopefully 5.0!), those who make texture packs will be able to name them with three-character IDs, removing the need for users to rename anything.