### PR TITLE
[RFC] SI: Base SI sampling on VSync & horiz lines

### DIFF
--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -565,25 +565,9 @@ void RunSIBuffer(u64 userdata, int cyclesLate)
 	}
 }
 
-int GetTicksToNextSIPoll()
+u32 GetPollXLines()
 {
-	// Poll for input at regular intervals (once per frame) when playing or recording a movie
-	if (Movie::IsMovieActive())
-	{
-		if (Movie::IsNetPlayRecording())
-			return SystemTimers::GetTicksPerSecond() / VideoInterface::TargetRefreshRate / 2;
-		else
-			return SystemTimers::GetTicksPerSecond() / VideoInterface::TargetRefreshRate;
-	}
-	if (NetPlay::IsNetPlayRunning())
-		return SystemTimers::GetTicksPerSecond() / VideoInterface::TargetRefreshRate / 2;
-
-	if (!g_Poll.Y && g_Poll.X)
-		return 2 * VideoInterface::GetTicksPerHalfLine() * g_Poll.X;
-	else if (!g_Poll.Y)
-		return SystemTimers::GetTicksPerSecond() / 60;
-
-	return std::min(VideoInterface::GetTicksPerField() / g_Poll.Y, 2 * VideoInterface::GetTicksPerHalfLine() * g_Poll.X);
+	return g_Poll.X;
 }
 
 } // end of namespace SerialInterface

--- a/Source/Core/Core/HW/SI.h
+++ b/Source/Core/Core/HW/SI.h
@@ -38,6 +38,6 @@ void ChangeDevice(SIDevices device, int channel);
 
 SIDevices GetDeviceType(int channel);
 
-int GetTicksToNextSIPoll();
+u32 GetPollXLines();
 
 } // end of namespace SerialInterface

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -55,7 +55,6 @@ IPC_HLE_PERIOD: For the Wiimote this is the call schedule:
 #include "Core/HW/AudioInterface.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/EXI_DeviceIPL.h"
-#include "Core/HW/SI.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/HW/VideoInterface.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
@@ -69,7 +68,6 @@ namespace SystemTimers
 
 static int et_Dec;
 static int et_VI;
-static int et_SI;
 static int et_CP;
 static int et_AudioDMA;
 static int et_DSP;
@@ -125,12 +123,6 @@ static void VICallback(u64 userdata, int cyclesLate)
 {
 	VideoInterface::Update();
 	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerHalfLine() - cyclesLate, et_VI);
-}
-
-static void SICallback(u64 userdata, int cyclesLate)
-{
-	SerialInterface::UpdateDevices();
-	CoreTiming::ScheduleEvent(SerialInterface::GetTicksToNextSIPoll() - cyclesLate, et_SI);
 }
 
 static void CPCallback(u64 userdata, int cyclesLate)
@@ -248,7 +240,6 @@ void Init()
 
 	et_Dec = CoreTiming::RegisterEvent("DecCallback", DecrementerCallback);
 	et_VI = CoreTiming::RegisterEvent("VICallback", VICallback);
-	et_SI = CoreTiming::RegisterEvent("SICallback", SICallback);
 	if (SConfig::GetInstance().bCPUThread && SConfig::GetInstance().bSyncGPU)
 		et_CP = CoreTiming::RegisterEvent("CPCallback", CPCallback);
 	et_DSP = CoreTiming::RegisterEvent("DSPCallback", DSPCallback);
@@ -259,7 +250,6 @@ void Init()
 
 	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerHalfLine(), et_VI);
 	CoreTiming::ScheduleEvent(0, et_DSP);
-	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerField(), et_SI);
 	CoreTiming::ScheduleEvent(s_audio_dma_period, et_AudioDMA);
 	CoreTiming::ScheduleEvent(0, et_Throttle, Common::Timer::GetTimeMs());
 	if (SConfig::GetInstance().bCPUThread && SConfig::GetInstance().bSyncGPU)

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -16,6 +16,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
+#include "Core/HW/SI.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/HW/VideoInterface.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -63,7 +64,8 @@ static u32 s_clock_freqs[2] =
 
 static u64 s_ticks_last_line_start;  // number of ticks when the current full scanline started
 static u32 s_half_line_count;  // number of halflines that have occurred for this full frame
-
+static u32 s_half_line_of_next_si_poll; // halfline when next SI poll results should be available
+static constexpr u32 num_half_lines_for_si_poll = (7 * 2) + 1; // this is how long an SI poll takes
 
 static FieldType s_current_field;
 
@@ -100,6 +102,7 @@ void DoState(PointerWrap &p)
 	p.Do(TargetRefreshRate);
 	p.Do(s_ticks_last_line_start);
 	p.Do(s_half_line_count);
+	p.Do(s_half_line_of_next_si_poll);
 	p.Do(s_current_field);
 	p.Do(s_even_field_first_hl);
 	p.Do(s_odd_field_first_hl);
@@ -158,6 +161,7 @@ void Preset(bool _bNTSC)
 
 	s_ticks_last_line_start = 0;
 	s_half_line_count = 1;
+	s_half_line_of_next_si_poll = num_half_lines_for_si_poll; // first sampling starts at vsync
 	s_current_field = FIELD_ODD;
 
 	UpdateParameters();
@@ -661,6 +665,11 @@ static void EndField()
 // Run when: When a frame is scanned (progressive/interlace)
 void Update()
 {
+	if (s_half_line_of_next_si_poll == s_half_line_count)
+	{
+		SerialInterface::UpdateDevices();
+		s_half_line_of_next_si_poll += SerialInterface::GetPollXLines();
+	}
 	if (s_half_line_count == s_even_field_first_hl)
 	{
 		BeginField(FIELD_EVEN);
@@ -688,11 +697,19 @@ void Update()
 
 	s_half_line_count++;
 
-	if (s_half_line_count > GetHalfLinesPerEvenField() + GetHalfLinesPerOddField()) {
+	if (s_half_line_count > GetHalfLinesPerEvenField() + GetHalfLinesPerOddField())
+	{
 		s_half_line_count = 1;
+		s_half_line_of_next_si_poll = num_half_lines_for_si_poll; // first results start at vsync
 	}
 
-	if (s_half_line_count & 1) {
+	if (s_half_line_count == GetHalfLinesPerEvenField())
+	{
+		s_half_line_of_next_si_poll = GetHalfLinesPerEvenField() + num_half_lines_for_si_poll;
+	}
+
+	if (s_half_line_count & 1)
+	{
 		s_ticks_last_line_start = CoreTiming::GetTicks();
 	}
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 49; // Last changed in PR 2149
+static const u32 STATE_VERSION = 50; // Last changed in PR 3457
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
The rate at which SI is polled is specified in terms of horizontal video lines (see SIPOLL at 0xCC006430). While dolphin tries to use this to calculate the interval between SI samplings, no attention is paid to sampling in the correct phase wrt vsync. This needs testing, and changes behaviour of movies and netplay - I'm not sure why they were special cased... see the removed function in SI.cpp "GetTicksToNextSIPoll".

This seems to address https://bugs.dolphin-emu.org/issues/960