### PR TITLE
Replace some unnamed tick constants with GetTicksPerSecond()

### DIFF
--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -489,7 +489,7 @@ void ChangeDiscAsCPU(const std::string& newFileName)
 {
   std::string* _FileName = new std::string(newFileName);
   CoreTiming::ScheduleEvent(0, s_eject_disc);
-  CoreTiming::ScheduleEvent(500000000, s_insert_disc, (u64)_FileName);
+  CoreTiming::ScheduleEvent(SystemTimers::GetTicksPerSecond(), s_insert_disc, (u64)_FileName);
   if (Movie::IsRecordingInput())
   {
     std::string fileName = newFileName;

--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -15,6 +15,7 @@
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/Sram.h"
+#include "Core/HW/SystemTimers.h"
 #include "Core/Movie.h"
 
 SRAM g_SRAM;
@@ -104,11 +105,12 @@ static void ChangeDeviceCallback(u64 userdata, s64 cyclesLate)
 void ChangeDevice(const u8 channel, const TEXIDevices device_type, const u8 device_num)
 {
   // Called from GUI, so we need to make it thread safe.
-  // Let the hardware see no device for .5b cycles
+  // Let the hardware see no device for 1 second
   CoreTiming::ScheduleEvent_Threadsafe(
       0, changeDevice, ((u64)channel << 32) | ((u64)EXIDEVICE_NONE << 16) | device_num);
-  CoreTiming::ScheduleEvent_Threadsafe(
-      500000000, changeDevice, ((u64)channel << 32) | ((u64)device_type << 16) | device_num);
+  CoreTiming::ScheduleEvent_Threadsafe(SystemTimers::GetTicksPerSecond(), changeDevice,
+                                       ((u64)channel << 32) | ((u64)device_type << 16) |
+                                           device_num);
 }
 
 CEXIChannel* GetChannel(u32 index)

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -10,6 +10,7 @@
 #include "Core/CoreTiming.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
+#include "Core/HW/SystemTimers.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_stm.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -217,7 +218,8 @@ void ResetButton_Tap()
 {
   CoreTiming::ScheduleEvent_AnyThread(0, toggleResetButton, true);
   CoreTiming::ScheduleEvent_AnyThread(0, iosNotifyResetButton, 0);
-  CoreTiming::ScheduleEvent_AnyThread(243000000, toggleResetButton, false);
+  CoreTiming::ScheduleEvent_AnyThread(SystemTimers::GetTicksPerSecond() / 2, toggleResetButton,
+                                      false);
 }
 
 }  // namespace ProcessorInterface

--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -15,6 +15,7 @@
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SI.h"
 #include "Core/HW/SI_DeviceGBA.h"
+#include "Core/HW/SystemTimers.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
 
@@ -527,12 +528,13 @@ static void ChangeDeviceCallback(u64 userdata, s64 cyclesLate)
 void ChangeDevice(SIDevices device, int channel)
 {
   // Called from GUI, so we need to make it thread safe.
-  // Let the hardware see no device for .5b cycles
+  // Let the hardware see no device for 1 second
   // TODO: Calling GetDeviceType here isn't threadsafe.
   if (GetDeviceType(channel) != device)
   {
     CoreTiming::ScheduleEvent_Threadsafe(0, changeDevice, ((u64)channel << 32) | SIDEVICE_NONE);
-    CoreTiming::ScheduleEvent_Threadsafe(500000000, changeDevice, ((u64)channel << 32) | device);
+    CoreTiming::ScheduleEvent_Threadsafe(SystemTimers::GetTicksPerSecond(), changeDevice,
+                                         ((u64)channel << 32) | device);
   }
 }
 


### PR DESCRIPTION
These operations should always take the same amount of time, not the same amount of ticks. The number of ticks per second is different for GameCube and Wii.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3458)
<!-- Reviewable:end -->
