### PR TITLE
Aspect Ratio improvements from #2796.

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -468,43 +468,46 @@ static u32 GetTicksPerOddField()
 	return GetTicksPerHalfLine() * GetHalfLinesPerOddField();
 }
 
-float GetAspectRatio(bool wide)
+float GetAspectRatio(bool wide, bool scale, bool par_correct)
 {
 	u32 multiplier = static_cast<u32>(m_PictureConfiguration.STD / m_PictureConfiguration.WPL);
 	int height = (multiplier * m_VerticalTimingRegister.ACV);
 	int width = ((2 * m_HTiming0.HLW) - (m_HTiming0.HLW - m_HTiming1.HBS640)
 		- m_HTiming1.HBE640);
 	float pixelAR;
-	if (m_DisplayControlRegister.FMT == 1)
+
+	if (!par_correct)
 	{
-		//PAL active frame is 702*576
-		//In square pixels, 1024*576 is 16:9, and 768*576 is 4:3
-		//Therefore a 16:9 TV would have a "pixel" aspect ratio of 1024/702
-		//Similarly a 4:3 TV would have a ratio of 768/702
-		if (wide)
-		{
-			pixelAR = 1024.0f / 702.0f;
-		}
-		else
-		{
-			pixelAR = 768.0f / 702.0f;
-		}
+		pixelAR = 1.0f;
 	}
 	else
 	{
-		//NTSC active frame is 710.85*486
-		//In square pixels, 864*486 is 16:9, and 648*486 is 4:3
-		//Therefore a 16:9 TV would have a "pixel" aspect ratio of 864/710.85
-		//Similarly a 4:3 TV would have a ratio of 648/710.85
-		if (wide)
+		if (m_DisplayControlRegister.FMT == 1)
 		{
-			pixelAR = 864.0f / 710.85f;
+			// PAL active frame is 702*576
+			// In square pixels, 768*576 is 4:3
+			// Therefore a 4:3 TV would have a ratio of 768/702
+			pixelAR = 768.0f / 702.0f;
 		}
 		else
 		{
+			// NTSC active frame is 710.85*486
+			// In square pixels, 648*486 is 4:3
+			// Therefore a 4:3 TV would have a ratio of 648/710.85
 			pixelAR = 648.0f / 710.85f;
 		}
 	}
+
+	if (wide)
+	{
+		pixelAR *= 4.0f / 3.0f;
+	}
+
+	if (!scale)
+	{
+		width = 8 * m_PictureConfiguration.STD;
+	}
+
 	if (width == 0 || height == 0)
 	{
 		if (wide)

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -334,5 +334,5 @@ union UVIHorizontalStepping
 	u32 GetTicksPerField();
 
 	//For VI Scaling and Aspect Ratio Correction
-	float GetAspectRatio(bool);
+	float GetAspectRatio(bool wide, bool scale, bool par_correct);
 }

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -135,6 +135,8 @@ static wxString use_ffv1_desc = wxTRANSLATE("Encode frame dumps using the FFV1 c
 #endif
 static wxString free_look_desc = wxTRANSLATE("This feature allows you to change the game's camera.\nMove the mouse while holding the right mouse button to pan and while holding the middle button to move.\nHold SHIFT and press one of the WASD keys to move the camera by a certain step distance (SHIFT+2 to move faster and SHIFT+1 to move slower). Press SHIFT+R to reset the camera and SHIFT+F to reset the speed.\n\nIf unsure, leave this unchecked.");
 static wxString crop_desc = wxTRANSLATE("Crop the picture from its native aspect ratio to 4:3 or 16:9.\n\nIf unsure, leave this unchecked.");
+static wxString vi_scale_desc = wxTRANSLATE("Enable emulation of horizontal VI scaling.\n\nIf unsure, leave this checked.");
+static wxString par_correction_desc = wxTRANSLATE("Enable correction of the pixel aspect ratio based on analog TV standards.\n\nIf unsure, leave this checked.");
 static wxString ppshader_desc = wxTRANSLATE("Apply a post-processing effect after finishing a frame.\n\nIf unsure, select (off).");
 static wxString cache_efb_copies_desc = wxTRANSLATE("Slightly speeds up EFB to RAM copies by sacrificing emulation accuracy.\nIf you're experiencing any issues, try raising texture cache accuracy or disable this option.\n\nIf unsure, leave this unchecked.");
 static wxString stereo_3d_desc = wxTRANSLATE("Selects the stereoscopic 3D mode. Stereoscopy allows you to get a better feeling of depth if you have the necessary hardware.\nSide-by-Side and Top-and-Bottom are used by most 3D TVs.\nAnaglyph is used for Red-Cyan colored glasses.\nHeavily decreases emulation speed and sometimes causes issues.\n\nIf unsure, select Off.");
@@ -584,6 +586,9 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	szr_misc->Add(progressive_scan_checkbox);
 	}
+
+	szr_misc->Add(CreateCheckBox(page_advanced, _("Enable Video Interface Scaling"), wxGetTranslation(vi_scale_desc), vconfig.bVIScale));
+	szr_misc->Add(CreateCheckBox(page_advanced, _("Enable Pixel Aspect Ratio Correction"), wxGetTranslation(par_correction_desc), vconfig.bPARCorrect));
 
 #if defined WIN32
 	// Borderless Fullscreen

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -135,7 +135,6 @@ static wxString use_ffv1_desc = wxTRANSLATE("Encode frame dumps using the FFV1 c
 #endif
 static wxString free_look_desc = wxTRANSLATE("This feature allows you to change the game's camera.\nMove the mouse while holding the right mouse button to pan and while holding the middle button to move.\nHold SHIFT and press one of the WASD keys to move the camera by a certain step distance (SHIFT+2 to move faster and SHIFT+1 to move slower). Press SHIFT+R to reset the camera and SHIFT+F to reset the speed.\n\nIf unsure, leave this unchecked.");
 static wxString crop_desc = wxTRANSLATE("Crop the picture from its native aspect ratio to 4:3 or 16:9.\n\nIf unsure, leave this unchecked.");
-static wxString vi_scale_desc = wxTRANSLATE("Enable emulation of horizontal VI scaling.\n\nIf unsure, leave this checked.");
 static wxString par_correction_desc = wxTRANSLATE("Enable correction of the pixel aspect ratio based on analog TV standards.\n\nIf unsure, leave this checked.");
 static wxString ppshader_desc = wxTRANSLATE("Apply a post-processing effect after finishing a frame.\n\nIf unsure, select (off).");
 static wxString cache_efb_copies_desc = wxTRANSLATE("Slightly speeds up EFB to RAM copies by sacrificing emulation accuracy.\nIf you're experiencing any issues, try raising texture cache accuracy or disable this option.\n\nIf unsure, leave this unchecked.");
@@ -568,11 +567,21 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	group_utility->Add(szr_utility, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 	}
 
+	// Aspect Ratio options
+	{
+	wxGridSizer* const szr_ar = new wxGridSizer(2, 5, 5);
+
+	szr_ar->Add(CreateCheckBox(page_advanced, _("Crop"), wxGetTranslation(crop_desc), vconfig.bCrop));
+	szr_ar->Add(CreateCheckBox(page_advanced, _("Pixel Aspect Ratio Correction"), wxGetTranslation(par_correction_desc), vconfig.bPARCorrect));
+
+	wxStaticBoxSizer* const group_ar = new wxStaticBoxSizer(wxVERTICAL, page_advanced, _("Aspect Ratio"));
+	szr_advanced->Add(group_ar, 0, wxEXPAND | wxALL, 5);
+	group_ar->Add(szr_ar, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+	}
+
 	// - misc
 	{
 	wxGridSizer* const szr_misc = new wxGridSizer(2, 5, 5);
-
-	szr_misc->Add(CreateCheckBox(page_advanced, _("Crop"), wxGetTranslation(crop_desc), vconfig.bCrop));
 
 	// Progressive Scan
 	{
@@ -586,9 +595,6 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 
 	szr_misc->Add(progressive_scan_checkbox);
 	}
-
-	szr_misc->Add(CreateCheckBox(page_advanced, _("Enable Video Interface Scaling"), wxGetTranslation(vi_scale_desc), vconfig.bVIScale));
-	szr_misc->Add(CreateCheckBox(page_advanced, _("Enable Pixel Aspect Ratio Correction"), wxGetTranslation(par_correction_desc), vconfig.bPARCorrect));
 
 #if defined WIN32
 	// Borderless Fullscreen

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -431,7 +431,7 @@ void Renderer::UpdateDrawRectangle(int backbuffer_width, int backbuffer_height)
 	// Don't know if there is a better place for this code so there isn't a 1 frame delay
 	if (g_ActiveConfig.bWidescreenHack)
 	{
-		float source_aspect = VideoInterface::GetAspectRatio(Core::g_aspect_wide);
+		float source_aspect = VideoInterface::GetAspectRatio(Core::g_aspect_wide, g_ActiveConfig.bVIScale, g_ActiveConfig.bPARCorrect);
 		float target_aspect;
 
 		switch (g_ActiveConfig.iAspectRatio)
@@ -440,10 +440,10 @@ void Renderer::UpdateDrawRectangle(int backbuffer_width, int backbuffer_height)
 			target_aspect = WinWidth / WinHeight;
 			break;
 		case ASPECT_ANALOG:
-			target_aspect = VideoInterface::GetAspectRatio(false);
+			target_aspect = VideoInterface::GetAspectRatio(false, g_ActiveConfig.bVIScale, g_ActiveConfig.bPARCorrect);
 			break;
 		case ASPECT_ANALOG_WIDE:
-			target_aspect = VideoInterface::GetAspectRatio(true);
+			target_aspect = VideoInterface::GetAspectRatio(true, g_ActiveConfig.bVIScale, g_ActiveConfig.bPARCorrect);
 			break;
 		default:
 			// ASPECT_AUTO
@@ -479,13 +479,13 @@ void Renderer::UpdateDrawRectangle(int backbuffer_width, int backbuffer_height)
 	switch (g_ActiveConfig.iAspectRatio)
 	{
 		case ASPECT_ANALOG_WIDE:
-			Ratio = (WinWidth / WinHeight) / VideoInterface::GetAspectRatio(true);
+			Ratio = (WinWidth / WinHeight) / VideoInterface::GetAspectRatio(true, g_ActiveConfig.bVIScale, g_ActiveConfig.bPARCorrect);
 			break;
 		case ASPECT_ANALOG:
-			Ratio = (WinWidth / WinHeight) / VideoInterface::GetAspectRatio(false);
+			Ratio = (WinWidth / WinHeight) / VideoInterface::GetAspectRatio(false, g_ActiveConfig.bVIScale, g_ActiveConfig.bPARCorrect);
 			break;
 		default:
-			Ratio = (WinWidth / WinHeight) / VideoInterface::GetAspectRatio(Core::g_aspect_wide);
+			Ratio = (WinWidth / WinHeight) / VideoInterface::GetAspectRatio(Core::g_aspect_wide, g_ActiveConfig.bVIScale, g_ActiveConfig.bPARCorrect);
 			break;
 	}
 
@@ -515,13 +515,13 @@ void Renderer::UpdateDrawRectangle(int backbuffer_width, int backbuffer_height)
 		switch (g_ActiveConfig.iAspectRatio)
 		{
 		case ASPECT_ANALOG_WIDE:
-			Ratio = (16.0f / 9.0f) / VideoInterface::GetAspectRatio(true);
+			Ratio = (16.0f / 9.0f) / VideoInterface::GetAspectRatio(true, g_ActiveConfig.bVIScale, g_ActiveConfig.bPARCorrect);
 			break;
 		case ASPECT_ANALOG:
-			Ratio = (4.0f / 3.0f) / VideoInterface::GetAspectRatio(false);
+			Ratio = (4.0f / 3.0f) / VideoInterface::GetAspectRatio(false, g_ActiveConfig.bVIScale, g_ActiveConfig.bPARCorrect);
 			break;
 		default:
-			Ratio = (!Core::g_aspect_wide ? (4.0f / 3.0f) : (16.0f / 9.0f)) / VideoInterface::GetAspectRatio(Core::g_aspect_wide);
+			Ratio = (!Core::g_aspect_wide ? (4.0f / 3.0f) : (16.0f / 9.0f)) / VideoInterface::GetAspectRatio(Core::g_aspect_wide, g_ActiveConfig.bVIScale, g_ActiveConfig.bPARCorrect);
 			break;
 		}
 		if (Ratio <= 1.0f)

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -110,6 +110,10 @@ void VideoConfig::Load(const std::string& ini_file)
 	iPhackvalue[0] = 0;
 	bPerfQueriesEnable = false;
 
+	// aspect ratio defaults
+	bVIScale = true;
+	bPARCorrect = true;
+
 	// Load common settings
 	iniFile.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
 	IniFile::Section* interface = iniFile.GetOrCreateSection("Interface");

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -61,6 +61,8 @@ void VideoConfig::Load(const std::string& ini_file)
 	settings->Get("wideScreenHack", &bWidescreenHack, false);
 	settings->Get("AspectRatio", &iAspectRatio, (int)ASPECT_AUTO);
 	settings->Get("Crop", &bCrop, false);
+	settings->Get("VIScale", &bVIScale, true);
+	settings->Get("PARCorrect", &bPARCorrect, true);
 	settings->Get("UseXFB", &bUseXFB, 0);
 	settings->Get("UseRealXFB", &bUseRealXFB, 0);
 	settings->Get("SafeTextureCacheColorSamples", &iSafeTextureCache_ColorSamples, 128);
@@ -110,10 +112,6 @@ void VideoConfig::Load(const std::string& ini_file)
 	iPhackvalue[0] = 0;
 	bPerfQueriesEnable = false;
 
-	// aspect ratio defaults
-	bVIScale = true;
-	bPARCorrect = true;
-
 	// Load common settings
 	iniFile.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
 	IniFile::Section* interface = iniFile.GetOrCreateSection("Interface");
@@ -158,6 +156,8 @@ void VideoConfig::GameIniLoad()
 	CHECK_SETTING("Video_Settings", "wideScreenHack", bWidescreenHack);
 	CHECK_SETTING("Video_Settings", "AspectRatio", iAspectRatio);
 	CHECK_SETTING("Video_Settings", "Crop", bCrop);
+	CHECK_SETTING("Video_Settings", "VIScale", bVIScale);
+	CHECK_SETTING("Video_Settings", "PARCorrect", bPARCorrect);
 	CHECK_SETTING("Video_Settings", "UseXFB", bUseXFB);
 	CHECK_SETTING("Video_Settings", "UseRealXFB", bUseRealXFB);
 	CHECK_SETTING("Video_Settings", "SafeTextureCacheColorSamples", iSafeTextureCache_ColorSamples);
@@ -264,6 +264,8 @@ void VideoConfig::Save(const std::string& ini_file)
 	IniFile::Section* settings = iniFile.GetOrCreateSection("Settings");
 	settings->Set("AspectRatio", iAspectRatio);
 	settings->Set("Crop", bCrop);
+	settings->Set("VIScale", bVIScale);
+	settings->Set("PARCorrect", bPARCorrect);
 	settings->Set("wideScreenHack", bWidescreenHack);
 	settings->Set("UseXFB", bUseXFB);
 	settings->Set("UseRealXFB", bUseRealXFB);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -70,6 +70,8 @@ struct VideoConfig final
 	bool bWidescreenHack;
 	int iAspectRatio;
 	bool bCrop;   // Aspect ratio controls.
+	bool bVIScale;
+	bool bPARCorrect;
 	bool bUseXFB;
 	bool bUseRealXFB;
 


### PR DESCRIPTION
Since no one else apparently wanted to pick this up, here you go. I thought it would be nice to have these in 5.0.

This takes the Horizontal VI Scaling and Pixel Aspect Ratio Correction improvements from mirrorbender in #2796 without the Smart AR heuristics.

The Horizontal VI Scaling option is not in the GUI and just enabled by default. It's unlikely anyone actually wants to turn this off.

The Pixel Aspect Ratio Correction option is toggleable in the GUI.

See #2796 for more details.