### PR TITLE
DolphinWX: Unify the condition for the game list being empty

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -870,25 +870,7 @@ void CFrame::OnGameListCtrlItemActivated(wxListEvent& WXUNUSED(event))
 	// 1. Boot the selected iso
 	// 2. Boot the default or last loaded iso.
 	// 3. Call BrowseForDirectory if the gamelist is empty
-	if (!m_GameListCtrl->GetISO(0) &&
-		!((SConfig::GetInstance().m_ListGC &&
-		SConfig::GetInstance().m_ListWii &&
-		SConfig::GetInstance().m_ListWad &&
-		SConfig::GetInstance().m_ListElfDol) &&
-		(SConfig::GetInstance().m_ListJap &&
-		SConfig::GetInstance().m_ListUsa  &&
-		SConfig::GetInstance().m_ListPal  &&
-		SConfig::GetInstance().m_ListAustralia &&
-		SConfig::GetInstance().m_ListFrance &&
-		SConfig::GetInstance().m_ListGermany &&
-		SConfig::GetInstance().m_ListItaly &&
-		SConfig::GetInstance().m_ListKorea &&
-		SConfig::GetInstance().m_ListNetherlands &&
-		SConfig::GetInstance().m_ListRussia &&
-		SConfig::GetInstance().m_ListSpain &&
-		SConfig::GetInstance().m_ListTaiwan &&
-		SConfig::GetInstance().m_ListWorld &&
-		SConfig::GetInstance().m_ListUnknown)))
+	if (!m_GameListCtrl->GetISO(0) && CGameListCtrl::IsHidingItems())
 	{
 		SConfig::GetInstance().m_ListGC =
 		SConfig::GetInstance().m_ListWii =

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -310,20 +310,14 @@ void CGameListCtrl::Update()
 		wxString errorString;
 		// We just check for one hide setting to be enabled, as we may only
 		// have GC games for example, and hide them, so we should show the
-		// second message instead
-		if ((SConfig::GetInstance().m_ListGC     &&
-		    SConfig::GetInstance().m_ListWii     &&
-		    SConfig::GetInstance().m_ListWad     &&
-		    SConfig::GetInstance().m_ListElfDol) &&
-		    (SConfig::GetInstance().m_ListJap    &&
-		    SConfig::GetInstance().m_ListUsa     &&
-		    SConfig::GetInstance().m_ListPal))
+		// first message instead
+		if (IsHidingItems())
 		{
-			errorString = _("Dolphin could not find any GameCube/Wii ISOs or WADs. Double-click here to browse for files...");
+			errorString = _("Dolphin is currently set to hide all games. Double-click here to show all games...");
 		}
 		else
 		{
-			errorString = _("Dolphin is currently set to hide all games. Double-click here to show all games...");
+			errorString = _("Dolphin could not find any GameCube/Wii ISOs or WADs. Double-click here to browse for files...");
 		}
 		InsertColumn(0, "");
 		long index = InsertItem(0, errorString);
@@ -954,6 +948,28 @@ const GameListItem * CGameListCtrl::GetSelectedISO()
 			return m_ISOFiles[GetItemData(item)];
 		}
 	}
+}
+
+bool CGameListCtrl::IsHidingItems()
+{
+	return !(SConfig::GetInstance().m_ListGC &&
+	         SConfig::GetInstance().m_ListWii &&
+	         SConfig::GetInstance().m_ListWad &&
+	         SConfig::GetInstance().m_ListElfDol &&
+	         SConfig::GetInstance().m_ListJap &&
+	         SConfig::GetInstance().m_ListUsa &&
+	         SConfig::GetInstance().m_ListPal &&
+	         SConfig::GetInstance().m_ListAustralia &&
+	         SConfig::GetInstance().m_ListFrance &&
+	         SConfig::GetInstance().m_ListGermany &&
+	         SConfig::GetInstance().m_ListItaly &&
+	         SConfig::GetInstance().m_ListKorea &&
+	         SConfig::GetInstance().m_ListNetherlands &&
+	         SConfig::GetInstance().m_ListRussia &&
+	         SConfig::GetInstance().m_ListSpain &&
+	         SConfig::GetInstance().m_ListTaiwan &&
+	         SConfig::GetInstance().m_ListWorld &&
+	         SConfig::GetInstance().m_ListUnknown);
 }
 
 void CGameListCtrl::OnOpenContainingFolder(wxCommandEvent& WXUNUSED (event))

--- a/Source/Core/DolphinWX/GameListCtrl.h
+++ b/Source/Core/DolphinWX/GameListCtrl.h
@@ -39,6 +39,8 @@ public:
 	const GameListItem *GetSelectedISO();
 	const GameListItem *GetISO(size_t index) const;
 
+	static bool IsHidingItems();
+
 	enum
 	{
 		COLUMN_DUMMY = 0,


### PR DESCRIPTION
When there are no games to display in the game list, DolphinWX shows a message instead. Clicking the message will perform an action. If the game list truly is empty, the message and action are for opening a browse dialog, but if the user has hidden some games, they are instead for unhiding all games. However, the condition for checking which message to display lacked some parts that are in the condition for checking which action to use, so the two could be different in rare cases. This PR fixes that by breaking out the two conditions to a new unified function.