### PR TITLE
Use the current commit hash in the netplay version

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Common.h"
 #include "Common/ENetUtil.h"
 #include "Common/Timer.h"
 #include "Core/ConfigManager.h"
@@ -19,6 +20,7 @@
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
 
+static const char* NETPLAY_VERSION = scm_rev_git_str;
 static std::mutex crit_netplay_client;
 static NetPlayClient * netplay_client = nullptr;
 NetSettings g_NetPlaySettings;

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -9,8 +9,6 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/EXI_Device.h"
 
-#define NETPLAY_VERSION  "Dolphin NetPlay 2015-06-24"
-
 struct NetSettings
 {
 	bool m_CPUthread;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "Common/Common.h"
 #include "Common/ENetUtil.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
@@ -24,6 +25,7 @@
 #include <arpa/inet.h>
 #endif
 
+static const char* NETPLAY_VERSION = scm_rev_git_str;
 u64 g_netplay_initial_gctime = 1272737767;
 
 NetPlayServer::~NetPlayServer()


### PR DESCRIPTION
So that it contains the current commit and not an arbitrary date that
may or may not be up-to-date. This will cause tears as people will not
be able to use netplay with one diverging commit that does not touch
anything related. On the other hand, users can’t be trusted.

I’m not sure how scmrev.h works but it appears to build and work fine here.