### PR TITLE
MemoryWatcher: Initialize m_running

### DIFF
--- a/Source/Core/Core/MemoryWatcher.h
+++ b/Source/Core/Core/MemoryWatcher.h
@@ -36,7 +36,7 @@ private:
 	void WatcherThread();
 
 	std::thread m_watcher_thread;
-	std::atomic_bool m_running;
+	std::atomic_bool m_running{false};
 
 	int m_fd;
 	sockaddr_un m_addr;


### PR DESCRIPTION
This flag needs to be set to false, lest the destructor attempt to stop a thread that has never been started. 9 times out of 10 is was defaulting to the correct value of false.