### PR TITLE
DolphinWX: fixes the window growing slightly on every re-launch

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -469,6 +469,9 @@ CFrame::CFrame(wxFrame* parent,
 			ToggleLogConfigWindow(true);
 	}
 
+	// Set the size of the window after the UI has been built, but before we show it
+	SetSize(size);
+
 	// Show window
 	Show();
 


### PR DESCRIPTION
The size was set *before* the UI was set up which would cause the window bounds to shift slightly on every re-launch. This might have been happening on other platforms,but I'm not sure.

This change sets the size again just before the window is shown to ensure that any size changes made by setting up the UI are fixed up.