### PR TITLE
[RFC] Core: Implement argv loading

### DIFF
--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -57,4 +57,6 @@ private:
 	static void Load_FST(bool _bIsWii);
 
 	static bool SetupWiiMemory(DiscIO::IVolume::ECountry country);
+
+	static void PatchArgs();
 };

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -217,6 +217,7 @@ bool BootCore(const std::string& _rFilename)
 
 	StartUp.m_BootType = SConfig::BOOT_ISO;
 	StartUp.m_strFilename = _rFilename;
+	StartUp.m_args.push_back(_rFilename);
 	SConfig::GetInstance().m_LastFilename = _rFilename;
 	SConfig::GetInstance().SaveSettings();
 	StartUp.bRunCompareClient = false;
@@ -384,6 +385,7 @@ void Stop()
 
 	SConfig& StartUp = SConfig::GetInstance();
 	StartUp.m_strUniqueID = "00000000";
+	StartUp.m_args.clear();
 	config_cache.RestoreConfig(&StartUp);
 }
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -166,6 +166,8 @@ struct SConfig : NonCopyable
 	std::string m_strName;
 	u16 m_revision;
 
+	std::vector<std::string> m_args;
+
 	std::string m_perfDir;
 
 	void LoadDefaults();


### PR DESCRIPTION
Dolphin currently lacks argument loading, which can make it difficult to do things like test homebrews. This patch adds support for passing arguments to the emulated program, if it detects that the program supports it.

Currently, it uses a magic constant for where to put the arguments in the program's memory space. This should be fixed, but I'm not sure to what. Additionally, there's no interface for setting arguments; they're hardcoded based on the path of the file you're loading (for argv[0]). This will need to change for passing argv[1..].

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3481)

<!-- Reviewable:end -->
