### PR TITLE
Disable geometry shaders on mesa AMD/ATI drivers.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -385,7 +385,7 @@ Renderer::Renderer()
 	g_Config.backend_info.bSupportsBBox = GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
 	g_Config.backend_info.bSupportsGSInstancing = GLExtensions::Supports("GL_ARB_gpu_shader5");
 	g_Config.backend_info.bSupportsSSAA = GLExtensions::Supports("GL_ARB_gpu_shader5") && GLExtensions::Supports("GL_ARB_sample_shading");
-	g_Config.backend_info.bSupportsGeometryShaders = GLExtensions::Version() >= 320;
+	g_Config.backend_info.bSupportsGeometryShaders = GLExtensions::Version() >= 320 && !DriverDetails::HasBug(DriverDetails::BUG_BROKENGEOMETRYSHADERS);
 	g_Config.backend_info.bSupportsPaletteConversion = GLExtensions::Supports("GL_ARB_texture_buffer_object") ||
 	                                                   GLExtensions::Supports("GL_OES_texture_buffer") ||
 	                                                   GLExtensions::Supports("GL_EXT_texture_buffer");

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -51,6 +51,7 @@ namespace DriverDetails
 		{OS_ALL,    VENDOR_IMGTEC,   DRIVER_IMGTEC,       -1, BUG_BROKENBUFFERSTREAM,  -1.0, -1.0, true},
 		{OS_ALL,    VENDOR_MESA,     DRIVER_NOUVEAU,      -1, BUG_BROKENUBO,           900,  916, true},
 		{OS_ALL,    VENDOR_MESA,     DRIVER_R600,         -1, BUG_BROKENUBO,           900,  913, true},
+		{OS_ALL,    VENDOR_MESA,     DRIVER_R600,         -1, BUG_BROKENGEOMETRYSHADERS, -1.0, -1.0, true},
 		{OS_ALL,    VENDOR_MESA,     DRIVER_I965,         -1, BUG_BROKENUBO,           900,  920, true},
 		{OS_ALL,    VENDOR_MESA,     DRIVER_ALL,          -1, BUG_BROKENCOPYIMAGE,     -1.0, 1064.0, true},
 		{OS_LINUX,  VENDOR_ATI,      DRIVER_ATI,          -1, BUG_BROKENPINNEDMEMORY,  -1.0, -1.0, true},

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -180,6 +180,14 @@ namespace DriverDetails
 		// Example alpha test path
 		// if(( (prev.a >  alphaRef.r) && (prev.a >  alphaRef.g)) == false) {
 		BUG_BROKENALPHATEST,
+
+		// Bug: Broken lines in geometry shaders
+		// Affected Devices: Mesa r600/radeonsi
+		// Started Version: -1
+		// Ended Version: -1
+		// Mesa inroduced geometry shader support for radeon devices and failed to test it with us.
+		// Causes misrenderings on a large amount of things that draw lines.
+		BUG_BROKENGEOMETRYSHADERS,
 	};
 
 	// Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
Causes misrendering, disable it entirely for now.