### PR TITLE
JitInterface: Get rid of a global variable

### DIFF
--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -34,7 +34,6 @@
 #endif
 
 static bool bFakeVMEM = false;
-bool bMMU = false;
 
 namespace JitInterface
 {
@@ -45,8 +44,7 @@ namespace JitInterface
 	}
 	CPUCoreBase *InitJitCore(int core)
 	{
-		bMMU = SConfig::GetInstance().bMMU;
-		bFakeVMEM = !bMMU;
+		bFakeVMEM = !SConfig::GetInstance().bMMU;
 
 		CPUCoreBase *ptr = nullptr;
 		switch (core)

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -44,5 +44,3 @@ namespace JitInterface
 
 	void Shutdown();
 }
-extern bool bMMU;
-


### PR DESCRIPTION
Guess someone just forgot to remove this or something.