### PR TITLE
TextureCacheBase: Change CalculateLevelSize to match D3D/OGL sizes

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -328,7 +328,7 @@ void TextureCacheBase::DumpTexture(TCacheEntryBase* entry, std::string basename,
 
 static u32 CalculateLevelSize(u32 level_0_size, u32 level)
 {
-	return (level_0_size + ((1 << level) - 1)) >> level;
+	return std::max(level_0_size >> level, 1u);
 }
 
 // Used by TextureCacheBase::Load


### PR DESCRIPTION
This was causing crashes/driver resets when odd-dimension textures were being loaded, due to the size we were uploading being larger than the size of the higher-level texture calculated by the runtime.

Looking at this function seems to date back to 2013, and I'm not sure if there's a reason it was being calculated in this way, but with panic alerts on, OGL throws an error because it's not the expected size, anyway.

Issue reference: https://bugs.dolphin-emu.org/issues/9253