### PR TITLE
HW: Header cleanup

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <numeric>
 
 #include "Common/Assert.h"
 #include "Core/ConfigManager.h"

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -37,15 +37,13 @@ This file mainly deals with the [Drive I/F], however [AIDFR] controls
   TODO maybe the files should be merged?
 */
 
-#include "AudioCommon/AudioCommon.h"
+#include <algorithm>
 
+#include "AudioCommon/AudioCommon.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-#include "Common/MathUtil.h"
-
 #include "Core/CoreTiming.h"
 #include "Core/HW/AudioInterface.h"
-#include "Core/HW/CPU.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SystemTimers.h"

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -8,15 +8,11 @@
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Core/Core.h"
-#include "Core/DSPEmulator.h"
 #include "Core/Host.h"
-#include "Core/Movie.h"
 #include "Core/HW/CPU.h"
-#include "Core/HW/DSP.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "VideoCommon/Fifo.h"
-#include "VideoCommon/VideoBackendBase.h"
 
 namespace
 {

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -25,14 +25,12 @@
 
 #include "AudioCommon/AudioCommon.h"
 
+#include "Common/CommonTypes.h"
 #include "Common/MemoryUtil.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/DSPEmulator.h"
-#include "Core/HW/AudioInterface.h"
-#include "Core/HW/CPU.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/MMIO.h"

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -5,15 +5,10 @@
 #include <iostream>
 
 #include "Common/ChunkFile.h"
-#include "Common/IniFile.h"
-#include "Common/StringUtil.h"
-#include "Common/Logging/LogManager.h"
-
-#include "Core/ConfigManager.h"
+#include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
 #include "Core/Core.h"
-#include "Core/HW/AudioInterface.h"
 #include "Core/HW/SystemTimers.h"
-#include "Core/HW/VideoInterface.h"
 #include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "Core/DSPEmulator.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/MailHandler.h"

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -3,6 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
+#include "Common/Logging/Log.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/MailHandler.h"
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -2,13 +2,16 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/UCodes/AX.h"
+#include "Core/HW/DSPHLE/UCodes/AXStructs.h"
 
 #define AX_GC
 #include "Core/HW/DSPHLE/UCodes/AXVoice.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include "Core/HW/DSPHLE/UCodes/AXStructs.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 // We can't directly use the mixer_control field from the PB because it does

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -4,12 +4,12 @@
 //
 #define AX_WII // Used in AXVoice.
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Common/StringUtil.h"
-
-#include "Core/HW/DSPHLE/MailHandler.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/HW/DSPHLE/UCodes/AXStructs.h"
 #include "Core/HW/DSPHLE/UCodes/AXVoice.h"
 #include "Core/HW/DSPHLE/UCodes/AXWii.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
@@ -6,6 +6,8 @@
 
 #include "Core/HW/DSPHLE/UCodes/AX.h"
 
+struct AXPBWii;
+
 class AXWiiUCode : public AXUCode
 {
 public:

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -2,7 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Core/ConfigManager.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/CARD.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -2,7 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Core/ConfigManager.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/UCodes/GBA.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
@@ -2,7 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Core/ConfigManager.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Core/HW/DSPHLE/UCodes/INIT.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -2,15 +2,19 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <string>
+
 #ifdef _WIN32
 #include <Windows.h>
 #endif
 
+#include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/StringUtil.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-#include "Core/HW/Memmap.h"
 #include "Core/HW/DSPHLE/UCodes/ROM.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -2,13 +2,18 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <string>
+
 #ifdef _WIN32
 #include <Windows.h>
 #endif
 
+#include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/StringUtil.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/DSPHLE/UCodes/AX.h"
 #include "Core/HW/DSPHLE/UCodes/AXWii.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
@@ -5,9 +5,8 @@
 #pragma once
 
 #include <cstring>
-#include "Common/ChunkFile.h"
+
 #include "Common/CommonTypes.h"
-#include "Common/Thread.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/DSPHLE/DSPHLE.h"
 
@@ -16,6 +15,7 @@
 #define UCODE_NULL                  0xFFFFFFFF
 
 class CMailHandler;
+class PointerWrap;
 
 constexpr bool ExramRead(u32 address)
 {

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -2,6 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <array>
+
+#include "Common/ChunkFile.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/GBA.h"

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -4,8 +4,8 @@
 
 #include <string>
 
+#include "Common/MsgHandler.h"
 #include "Core/DSP/DSPCore.h"
-#include "Core/DSP/DSPDisassembler.h"
 #include "Core/DSP/DSPMemoryMap.h"
 #include "Core/HW/DSPLLE/DSPDebugInterface.h"
 #include "Core/HW/DSPLLE/DSPSymbols.h"

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -4,7 +4,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Hash.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/Host.h"
 #include "Core/DSP/DSPAnalyzer.h"
@@ -13,7 +13,6 @@
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPLLE/DSPLLETools.h"
 #include "Core/HW/DSPLLE/DSPSymbols.h"
-#include "Core/PowerPC/PowerPC.h"
 #include "VideoCommon/OnScreenDisplay.h"
 
 // The user of the DSPCore library must supply a few functions so that the

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -3,18 +3,16 @@
 // Refer to the license.txt file included.
 
 #include <mutex>
+#include <string>
 #include <thread>
 
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
-#include "Common/CPUDetect.h"
 #include "Common/Event.h"
-#include "Common/IniFile.h"
 #include "Common/Thread.h"
-#include "Common/Logging/LogManager.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/Host.h"
@@ -22,17 +20,13 @@
 #include "Core/NetPlayProto.h"
 #include "Core/DSP/DSPCaptureLogger.h"
 #include "Core/DSP/DSPCore.h"
-#include "Core/DSP/DSPDisassembler.h"
 #include "Core/DSP/DSPHost.h"
 #include "Core/DSP/DSPHWInterface.h"
 #include "Core/DSP/DSPInterpreter.h"
 #include "Core/DSP/DSPTables.h"
-#include "Core/HW/AudioInterface.h"
 #include "Core/HW/Memmap.h"
-
 #include "Core/HW/DSPLLE/DSPLLE.h"
 #include "Core/HW/DSPLLE/DSPLLEGlobals.h"
-#include "Core/HW/DSPLLE/DSPSymbols.h"
 
 DSPLLE::DSPLLE()
 	: m_hDSPThread()

--- a/Source/Core/Core/HW/DSPLLE/DSPLLETools.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLETools.cpp
@@ -9,16 +9,14 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
-
 #include "Core/DSP/DSPCodeUtil.h"
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPDisassembler.h"
-#include "Core/DSP/DSPInterpreter.h"
-#include "Core/HW/DSPLLE/DSPLLEGlobals.h"
 #include "Core/HW/DSPLLE/DSPLLETools.h"
 
 bool DumpDSPCode(const u8 *code_be, int size_in_bytes, u32 crc)

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -25,7 +25,6 @@
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/StreamADPCM.h"
 #include "Core/HW/SystemTimers.h"
-#include "Core/PowerPC/PowerPC.h"
 
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"

--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -16,7 +16,6 @@
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/Sram.h"
-#include "Core/PowerPC/PowerPC.h"
 
 SRAM g_SRAM;
 bool g_SRAM_netplay_initialized = false;

--- a/Source/Core/Core/HW/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI_Channel.cpp
@@ -4,16 +4,13 @@
 
 #include <memory>
 
+#include "Common/Assert.h"
 #include "Common/ChunkFile.h"
-#include "Core/ConfigManager.h"
-#include "Core/CoreTiming.h"
-#include "Core/Movie.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/EXI.h"
 #include "Core/HW/EXI_Channel.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/MMIO.h"
-#include "Core/HW/ProcessorInterface.h"
-#include "Core/PowerPC/PowerPC.h"
 
 enum
 {

--- a/Source/Core/Core/HW/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI_Device.cpp
@@ -5,8 +5,8 @@
 #include <memory>
 
 #include "Common/ChunkFile.h"
-#include "Core/ConfigManager.h"
-#include "Core/Core.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceAD16.h"
 #include "Core/HW/EXI_DeviceAGP.h"

--- a/Source/Core/Core/HW/EXI_DeviceAD16.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAD16.cpp
@@ -2,9 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Assert.h"
 #include "Common/ChunkFile.h"
-#include "Core/Core.h"
-#include "Core/HW/EXI_Device.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/EXI_DeviceAD16.h"
 
 CEXIAD16::CEXIAD16() :

--- a/Source/Core/Core/HW/EXI_DeviceAGP.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAGP.cpp
@@ -3,15 +3,14 @@
 // Refer to the license.txt file included.
 
 #include <memory>
+#include <string>
 
 #include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
-#include "Common/MemoryUtil.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
-#include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceAGP.h"
-#include "Core/HW/Memmap.h"
 
 CEXIAgp::CEXIAgp(int index)
 {

--- a/Source/Core/Core/HW/EXI_DeviceAMBaseboard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAMBaseboard.cpp
@@ -3,10 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-#include "Core/Core.h"
 #include "Core/HW/EXI.h"
-#include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceAMBaseboard.h"
 
 CEXIAMBaseboard::CEXIAMBaseboard()

--- a/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
@@ -2,11 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <string>
+
 #include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
 #include "Common/Network.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/EXI.h"
-#include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceEthernet.h"
 #include "Core/HW/Memmap.h"
 

--- a/Source/Core/Core/HW/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.h
@@ -5,12 +5,12 @@
 #pragma once
 
 #include <atomic>
+#include <thread>
 
 #ifdef _WIN32
 #include <Windows.h>
 #endif
 
-#include "Common/Thread.h"
 #include "Core/HW/EXI_Device.h"
 
 class PointerWrap;

--- a/Source/Core/Core/HW/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceGecko.cpp
@@ -2,15 +2,20 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <atomic>
 #include <memory>
+#include <mutex>
+#include <queue>
 #include <thread>
+#include <vector>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
+#include "Common/Logging/Log.h"
 #include "Core/Core.h"
-#include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceGecko.h"
 
 u16                       GeckoSockServer::server_port;

--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -10,9 +10,8 @@
 #include "Common/FileUtil.h"
 #include "Common/MemoryUtil.h"
 #include "Common/Timer.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -2,15 +2,19 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
 #include <memory>
+#include <string>
 
 #include "Common/ChunkFile.h"
+#include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/IniFile.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/Movie.h"
 #include "Core/HW/EXI.h"

--- a/Source/Core/Core/HW/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMic.cpp
@@ -2,16 +2,17 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+#include <mutex>
+
+#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
 #if HAVE_PORTAUDIO
 
-#include <cstring>
-
 #include "Core/CoreTiming.h"
 #include "Core/HW/EXI.h"
-#include "Core/HW/EXI_Device.h"
 #include "Core/HW/EXI_DeviceMic.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/SystemTimers.h"

--- a/Source/Core/Core/HW/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI_DeviceMic.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
+#include <mutex>
+#include "Common/Common.h"
 #include "Core/HW/EXI_Device.h"
 
 #if HAVE_PORTAUDIO
-
-#include <mutex>
 
 class CEXIMic : public IEXIDevice
 {

--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -2,9 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
-#include "Core/ConfigManager.h"
 #include "Core/HW/GCKeyboard.h"
 #include "Core/HW/GCKeyboardEmu.h"
 #include "InputCommon/InputConfig.h"

--- a/Source/Core/Core/HW/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard.cpp
@@ -5,11 +5,14 @@
 #include <algorithm>
 #include <cinttypes>
 #include <cstring>
+#include <vector>
 
 #include "Common/ColorUtil.h"
+#include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"
-#include "Common/Logging/Log.h"
+#include "Common/StringUtil.h"
 #include "Core/HW/GCMemcard.h"
 
 static void ByteSwap(u8 *valueA, u8 *valueB)

--- a/Source/Core/Core/HW/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard.h
@@ -8,11 +8,9 @@
 #include <string>
 
 #include "Common/CommonFuncs.h"
-#include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/NandPaths.h"
 #include "Common/NonCopyable.h"
-#include "Common/StringUtil.h"
 
 #include "Core/HW/EXI_DeviceIPL.h"
 #include "Core/HW/Sram.h"

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -3,13 +3,19 @@
 // Refer to the license.txt file included.
 
 #include <cinttypes>
+#include <cstring>
 #include <memory>
+#include <mutex>
+#include <string>
 
+#include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
+#include "Common/MsgHandler.h"
 #include "Common/Thread.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/GCMemcardDirectory.h"

--- a/Source/Core/Core/HW/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcardRaw.cpp
@@ -3,11 +3,15 @@
 // Refer to the license.txt file included.
 
 #include <chrono>
+#include <cstring>
 #include <memory>
+#include <string>
 
 #include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Thread.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/GCMemcard.h"

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -2,10 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
-
-#include "Core/ConfigManager.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/GCPadEmu.h"
 #include "InputCommon/GCPadStatus.h"

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/Host.h"
 #include "Core/HW/GCPadEmu.h"
 

--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -7,15 +7,11 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
-
 #include "Core/HW/GPFifo.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/PowerPC/JitInterface.h"
-#include "Core/PowerPC/PowerPC.h"
-
 #include "VideoCommon/CommandProcessor.h"
-#include "VideoCommon/VideoBackendBase.h"
 
 namespace GPFifo
 {

--- a/Source/Core/Core/HW/GPFifo.h
+++ b/Source/Core/Core/HW/GPFifo.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
 class PointerWrap;

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -24,8 +24,6 @@
 #include "Core/HW/VideoInterface.h"
 #include "Core/HW/WII_IPC.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
-#include "Core/PowerPC/PowerPC.h"
-#include "Core/PowerPC/PPCAnalyst.h"
 #include "DiscIO/NANDContentLoader.h"
 
 namespace HW

--- a/Source/Core/Core/HW/MMIO.cpp
+++ b/Source/Core/Core/HW/MMIO.cpp
@@ -4,6 +4,8 @@
 
 #include <functional>
 
+#include "Common/Assert.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/MMIOHandlers.h"
 

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -11,20 +11,15 @@
 #include <cstring>
 
 #include "Common/ChunkFile.h"
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/MemArena.h"
-#include "Common/MemoryUtil.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
-#include "Core/Debugger/Debugger_SymbolMap.h"
-#include "Core/HLE/HLE.h"
 #include "Core/HW/AudioInterface.h"
-#include "Core/HW/CPU.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/DVDInterface.h"
 #include "Core/HW/EXI.h"
-#include "Core/HW/GPFifo.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/MemoryInterface.h"
 #include "Core/HW/MMIO.h"
@@ -34,10 +29,8 @@
 #include "Core/HW/WII_IPC.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
-
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/PixelEngine.h"
-#include "VideoCommon/VideoBackendBase.h"
 
 namespace Memory
 {

--- a/Source/Core/Core/HW/MemoryInterface.cpp
+++ b/Source/Core/Core/HW/MemoryInterface.cpp
@@ -4,10 +4,8 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-
 #include "Core/HW/MemoryInterface.h"
 #include "Core/HW/MMIO.h"
-#include "Core/PowerPC/PowerPC.h"
 
 namespace MemoryInterface
 {

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -6,16 +6,11 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
-#include "Core/HW/CPU.h"
-#include "Core/HW/GPFifo.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/PowerPC/PowerPC.h"
-
-#include "VideoCommon/VideoBackendBase.h"
 
 namespace ProcessorInterface
 {

--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -4,11 +4,11 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <memory>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/Movie.h"
@@ -17,8 +17,6 @@
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SI.h"
 #include "Core/HW/SI_DeviceGBA.h"
-#include "Core/HW/SystemTimers.h"
-#include "Core/HW/VideoInterface.h"
 
 
 namespace SerialInterface

--- a/Source/Core/Core/HW/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI_Device.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/SI_Device.h"

--- a/Source/Core/Core/HW/SI_DeviceAMBaseboard.cpp
+++ b/Source/Core/Core/HW/SI_DeviceAMBaseboard.cpp
@@ -5,14 +5,12 @@
 #include <cstdio>
 #include <cstring>
 
+#include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 #include "Common/Logging/Log.h"
-
 #include "Core/HW/GCPad.h"
-#include "Core/HW/SI.h"
 #include "Core/HW/SI_Device.h"
 #include "Core/HW/SI_DeviceAMBaseboard.h"
-
 #include "InputCommon/GCPadStatus.h"
 
 // where to put baseboard debug

--- a/Source/Core/Core/HW/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI_DeviceDanceMat.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonTypes.h"
 #include "Core/HW/SI_DeviceDanceMat.h"
 #include "InputCommon/GCPadStatus.h"
 

--- a/Source/Core/Core/HW/SI_DeviceDanceMat.h
+++ b/Source/Core/Core/HW/SI_DeviceDanceMat.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "Core/HW/SI_DeviceGCController.h"
 
 struct GCPadStatus;

--- a/Source/Core/Core/HW/SI_DeviceGBA.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGBA.cpp
@@ -5,17 +5,16 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <thread>
 
-#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/Flag.h"
 #include "Common/Thread.h"
 #include "Common/Logging/Log.h"
-#include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/SI_Device.h"
 #include "Core/HW/SI_DeviceGBA.h"
 #include "Core/HW/SystemTimers.h"
-#include "Core/HW/VideoInterface.h"
 
 #include "SFML/Network.hpp"
 

--- a/Source/Core/Core/HW/SI_DeviceGBA.h
+++ b/Source/Core/Core/HW/SI_DeviceGBA.h
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <memory>
+#include <SFML/Network.hpp>
 
+#include "Common/CommonTypes.h"
 #include "Core/HW/SI_Device.h"
-
-#include "SFML/Network.hpp"
 
 // GameBoy Advance "Link Cable"
 

--- a/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
@@ -2,11 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
+#include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 #include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-#include "Core/Movie.h"
 #include "Core/HW/SI_DeviceGCAdapter.h"
+#include "InputCommon/GCAdapter.h"
 
 CSIDevice_GCAdapter::CSIDevice_GCAdapter(SIDevices device, int _iDeviceNumber)
 	: CSIDevice_GCController(device, _iDeviceNumber)

--- a/Source/Core/Core/HW/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI_DeviceGCAdapter.h
@@ -6,7 +6,6 @@
 
 #include "Core/HW/SI_Device.h"
 #include "Core/HW/SI_DeviceGCController.h"
-#include "InputCommon/GCAdapter.h"
 #include "InputCommon/GCPadStatus.h"
 
 class CSIDevice_GCAdapter : public CSIDevice_GCController

--- a/Source/Core/Core/HW/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCController.cpp
@@ -3,14 +3,13 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Core/Core.h"
+#include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
+#include "Common/Logging/Log.h"
 #include "Core/CoreTiming.h"
 #include "Core/Movie.h"
-#include "Core/HW/EXI_Device.h"
-#include "Core/HW/EXI_DeviceMic.h"
 #include "Core/HW/GCPad.h"
 #include "Core/HW/ProcessorInterface.h"
-#include "Core/HW/SI.h"
 #include "Core/HW/SI_Device.h"
 #include "Core/HW/SI_DeviceGCController.h"
 #include "Core/HW/SystemTimers.h"

--- a/Source/Core/Core/HW/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCSteeringWheel.cpp
@@ -2,9 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/MsgHandler.h"
+#include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-
 #include "Core/HW/GCPad.h"
 #include "Core/HW/SI_DeviceGCSteeringWheel.h"
 

--- a/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
@@ -3,6 +3,8 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Core/HW/GCKeyboard.h"
 #include "Core/HW/SI_DeviceKeyboard.h"
 #include "InputCommon/KeyboardStatus.h"

--- a/Source/Core/Core/HW/Sram.cpp
+++ b/Source/Core/Core/HW/Sram.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/Sram.h"

--- a/Source/Core/Core/HW/StreamADPCM.cpp
+++ b/Source/Core/Core/HW/StreamADPCM.cpp
@@ -4,6 +4,7 @@
 
 // Adapted from in_cube by hcs & destop
 
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Core/HW/StreamADPCM.h"
 

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -46,7 +46,7 @@ IPC_HLE_PERIOD: For the Wiimote this is the call schedule:
 #include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -59,9 +59,7 @@ IPC_HLE_PERIOD: For the Wiimote this is the call schedule:
 #include "Core/HW/VideoInterface.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/PowerPC/PowerPC.h"
-
 #include "VideoCommon/Fifo.h"
-#include "VideoCommon/VideoBackendBase.h"
 
 namespace SystemTimers
 {

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -7,20 +7,15 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
-#include "Common/StringUtil.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
-#include "Core/State.h"
-#include "Core/HW/Memmap.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SI.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/HW/VideoInterface.h"
-#include "Core/PowerPC/PowerPC.h"
-
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -2,16 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <map>
-#include <queue>
-#include <vector>
-
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/CoreTiming.h"
-#include "Core/HW/CPU.h"
-#include "Core/HW/Memmap.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/WII_IPC.h"

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -2,14 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-
-#include "Core/ConfigManager.h"
 #include "Core/Movie.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
-
 #include "InputCommon/InputConfig.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -4,9 +4,10 @@
 
 #pragma once
 
-#include "Common/ChunkFile.h"
+#include "Common/Common.h"
 
 class InputConfig;
+class PointerWrap;
 
 enum
 {

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Classic.h"
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Drums.h"
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Guitar.h"
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Nunchuk.h"

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Attachment/Turntable.h"
 

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -17,13 +17,16 @@
    0x30 - 0x3f   Input    This file: Update() */
 
 #include <fstream>
+#include <queue>
 #include <string>
 #include <vector>
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
-#include "Common/NandPaths.h"
-
+#include "Common/MsgHandler.h"
+#include "Common/Logging/Log.h"
+#include "Core/Core.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/WiimoteHid.h"
 #include "Core/HW/WiimoteEmu/Attachment/Attachment.h"

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -2,7 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <memory>
+
 #include "AudioCommon/AudioCommon.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 //#define WIIMOTE_SPEAKER_DUMP

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -3,12 +3,14 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
+#include <cstring>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
-#include "Common/Timer.h"
+#include "Common/MsgHandler.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/Host.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayClient.h"

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -6,9 +6,7 @@
 
 #include <queue>
 #include <string>
-#include <vector>
 
-#include "Core/Core.h"
 #include "Core/HW/WiimoteEmu/Encryption.h"
 #include "Core/HW/WiimoteEmu/WiimoteHid.h"
 #include "InputCommon/ControllerEmu.h"

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -19,10 +19,11 @@
 #include <dbt.h>           //NOLINT
 #include <setupapi.h>      //NOLINT
 
-#include "Common/Common.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/HW/WiimoteEmu/WiimoteHid.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -12,6 +12,7 @@
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/Host.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/WiimoteHid.h"

--- a/Source/Core/DolphinWX/TASInputDlg.cpp
+++ b/Source/Core/DolphinWX/TASInputDlg.cpp
@@ -12,7 +12,11 @@
 #include <wx/statbmp.h>
 #include <wx/textctrl.h>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
+#include "Common/Logging/Log.h"
+#include "Core/Core.h"
 #include "Core/Movie.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"

--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -6,6 +6,8 @@
 
 #include <functional>
 
+#include "Common/CommonTypes.h"
+
 struct GCPadStatus;
 
 namespace GCAdapter

--- a/Source/Core/InputCommon/GCAdapter_Null.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Null.cpp
@@ -2,9 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonTypes.h"
 #include "InputCommon/GCAdapter.h"
+
 namespace GCAdapter
 {
+
 void Init() {}
 void Reset() {}
 void ResetRumble() {}


### PR DESCRIPTION
I don't like having to recompile a pile of the core for minor header changes when implementing other features or fixes, so this'll minimize it a little

Also gets rid of more indirect inclusion