### PR TITLE
PixelShaderGen: Manually wrap negative indirect texture coordinates

### DIFF
--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -374,15 +374,15 @@ static inline s32 WrapIndirectCoord(s32 coord, int wrapMode)
 		case ITW_OFF:
 			return coord;
 		case ITW_256:
-			return (coord % (256 << 7));
+			return (coord & ((256 << 7) - 1));
 		case ITW_128:
-			return (coord % (128 << 7));
+			return (coord & ((128 << 7) - 1));
 		case ITW_64:
-			return (coord % (64 << 7));
+			return (coord & ((64 << 7) - 1));
 		case ITW_32:
-			return (coord % (32 << 7));
+			return (coord & ((32 << 7) - 1));
 		case ITW_16:
-			return (coord % (16 << 7));
+			return (coord & ((16 << 7) - 1));
 		case ITW_0:
 			return 0;
 		default:

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -764,7 +764,7 @@ static void WriteStage(T& out, pixel_shader_uid_data* uid_data, int n, API_TYPE 
 		else if (bpmem.tevind[n].sw == ITW_0)
 			out.Write("\twrappedcoord.x = 0;\n");
 		else
-			out.Write("\twrappedcoord.x = fixpoint_uv%d.x %% %s;\n", texcoord, tevIndWrapStart[bpmem.tevind[n].sw]);
+			out.Write("\twrappedcoord.x = fixpoint_uv%d.x & (%s - 1);\n", texcoord, tevIndWrapStart[bpmem.tevind[n].sw]);
 
 		// wrap T
 		if (bpmem.tevind[n].tw == ITW_OFF)
@@ -772,7 +772,7 @@ static void WriteStage(T& out, pixel_shader_uid_data* uid_data, int n, API_TYPE 
 		else if (bpmem.tevind[n].tw == ITW_0)
 			out.Write("\twrappedcoord.y = 0;\n");
 		else
-			out.Write("\twrappedcoord.y = fixpoint_uv%d.y %% %s;\n", texcoord, tevIndWrapStart[bpmem.tevind[n].tw]);
+			out.Write("\twrappedcoord.y = fixpoint_uv%d.y & (%s - 1);\n", texcoord, tevIndWrapStart[bpmem.tevind[n].tw]);
 
 		if (bpmem.tevind[n].fb_addprev) // add previous tevcoord
 			out.Write("\ttevcoord.xy += wrappedcoord + indtevtrans%d;\n", n);


### PR DESCRIPTION
(x % y) is not defined in GLSL when sign(x) != sign(y).
This also has the added benefit of behaving the same as sampler wrapping modes, in regards to negative inputs.

This was causing raindrops to render incorrectly in F-Zero GX with OGL on windows/intel and mesa/llvmpipe, as well as D3D, due to the previous implementation invoking UB when the coordinates were negative. (see GLSL spec re % operator, D3D seems to take the sign from the LHS)

Marked WIP because we're not sure if this actually matches hardware behavior in regards to how negative coordinates are handled.