### PR TITLE
IniFile: Initialize with default value if key does not exist.

### DIFF
--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -123,6 +123,8 @@ public:
 	{
 		if (Exists(sectionName, key))
 			return GetOrCreateSection(sectionName)->Get(key, value, defaultValue);
+		else
+			*value = defaultValue;
 
 		return false;
 	}


### PR DESCRIPTION
I forgot about this case in PR #3464. Without this change stereoscopy is effectively broken.