### PR TITLE
Fix SCMRevGen by running system native CScript

### DIFF
--- a/Source/Core/Common/SCMRevGen.vcxproj
+++ b/Source/Core/Common/SCMRevGen.vcxproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>cscript /nologo /E:JScript "make_scmrev.h.js"</Command>
+      <Command>"%windir%\Sysnative\cscript" /nologo /E:JScript "make_scmrev.h.js"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Build Events are run in an 32 bit environment, therefore both program files environment strings resolve to the x86 program files folder on 64 Bit systems. If Git is 64 bit and installed into the x64 program files it can't be found by the script.