### PR TITLE
Fix debugger address lookup search control.

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -87,7 +87,7 @@ CCodeWindow::CCodeWindow(const SConfig& _LocalCoreStartupParameter, CFrame *pare
 
 	m_aui_manager.SetManagedWindow(this);
 	m_aui_manager.SetFlags(wxAUI_MGR_DEFAULT | wxAUI_MGR_LIVE_RESIZE);
-	m_aui_manager.AddPane(m_aui_toolbar, wxAuiPaneInfo().ToolbarPane().Top().Floatable(false));
+	m_aui_manager.AddPane(m_aui_toolbar, wxAuiPaneInfo().MinSize(150, -1).ToolbarPane().Top().Floatable(false));
 	m_aui_manager.AddPane(callstack, wxAuiPaneInfo().MinSize(150, 100).Left().CloseButton(false).Floatable(false).Caption(_("Callstack")));
 	m_aui_manager.AddPane(symbols, wxAuiPaneInfo().MinSize(150, 100).Left().CloseButton(false).Floatable(false).Caption(_("Symbols")));
 	m_aui_manager.AddPane(calls, wxAuiPaneInfo().MinSize(150, 100).Left().CloseButton(false).Floatable(false).Caption(_("Function calls")));


### PR DESCRIPTION
The dumb wxAUI stuff isn't fully implemented for GTK. So the wxAuiToolBar doesn't properly deduce the size it needs to be when it contains a
wxSearchCtrl object.
Force the manager to set its minimum size to something reasonable.