### PR TITLE
Add symbol comments

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -3,13 +3,11 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
-#include <map>
-#include <string>
-#include <utility>
 
-#include "Common/CommonTypes.h"
 #include "Common/SymbolDB.h"
 #include "Common/Logging/Log.h"
+#include "Common/Fileutil.h"
+#include "Core/ConfigManager.h"
 
 void SymbolDB::List()
 {
@@ -37,6 +35,45 @@ void SymbolDB::Index()
 	{
 		func.second.index = i++;
 	}
+}
+
+void SymbolDB::PopulateSymbolComments()
+{
+	std::string filename = File::GetUserPath(D_MAPS_IDX) + SConfig::GetInstance().m_strUniqueID + "_comments.txt";
+	if (!File::Exists(filename))
+		return;
+	std::fstream line_parse;
+	line_parse.open(filename);
+	std::string line;
+	u32 address;
+	while(!(line_parse>>std::ws).eof())
+	{
+		std::getline(line_parse, line);
+		if (line.empty())
+			continue;
+		AsciiToHex(line.substr(0, 8),address);
+		std::string comment = line.substr(9, std::string::npos);
+		if (address < 0x80000010)
+			continue;
+		Symbol* f = GetSymbolFromAddr(address);
+		if (f)
+		{
+			char Offset = (address - f->address)/4;
+			f->comments[Offset] = comment;
+		}
+	}
+}
+
+const std::string SymbolDB::GetCommentFromAddr(u32 addr)
+{
+	Symbol *symbol = GetSymbolFromAddr(addr);
+	if (symbol)
+	{
+		unsigned int Offset = (addr - symbol->address)/4;
+		return symbol->comments[Offset];
+	}
+	else
+		return "";
 }
 
 Symbol* SymbolDB::GetSymbolFromName(const std::string& name)

--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -3,7 +3,9 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
-
+#include <string>		
+  		  
+#include "Common/CommonTypes.h"
 #include "Common/Fileutil.h"
 #include "Common/Logging/Log.h"
 #include "Common/SymbolDB.h"

--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -44,38 +44,33 @@ void SymbolDB::PopulateSymbolComments()
 	std::string filename = File::GetUserPath(D_MAPS_IDX) + SConfig::GetInstance().m_strUniqueID + "_comments.txt";
 	if (!File::Exists(filename))
 		return;
-	std::fstream line_parse;
-	line_parse.open(filename);
+	std::fstream line_parse(filename);
 	std::string line;
 	u32 address;
-	while(!(line_parse>>std::ws).eof())
+	while (std::getline(line_parse, line))
 	{
-		std::getline(line_parse, line);
 		if (line.empty())
 			continue;
-		AsciiToHex(line.substr(0, 8),address);
-		std::string comment = line.substr(9, std::string::npos);
-		if (address < 0x80000010)
-			continue;
+		AsciiToHex(line.substr(0,8),address);
+		std::string comment = line.substr(9);
 		Symbol* f = GetSymbolFromAddr(address);
 		if (f)
 		{
-			char Offset = (address - f->address)/4;
-			f->comments[Offset] = comment;
+			char offset = (address - f->address) / 4;
+			f->comments[offset] = comment;
 		}
 	}
 }
 
-const std::string SymbolDB::GetCommentFromAddr(u32 addr)
+std::string SymbolDB::GetCommentFromAddr(u32 address)
 {
-	Symbol *symbol = GetSymbolFromAddr(addr);
+	Symbol* symbol = GetSymbolFromAddr(address);
 	if (symbol)
 	{
-		unsigned int Offset = (addr - symbol->address)/4;
-		return symbol->comments[Offset];
+		unsigned int offset = (address - symbol->address) / 4;
+		return symbol->comments[offset];
 	}
-	else
-		return "";
+	return "";
 }
 
 Symbol* SymbolDB::GetSymbolFromName(const std::string& name)

--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -4,9 +4,9 @@
 
 #include <cstring>
 
-#include "Common/SymbolDB.h"
-#include "Common/Logging/Log.h"
 #include "Common/Fileutil.h"
+#include "Common/Logging/Log.h"
+#include "Common/SymbolDB.h"
 #include "Core/ConfigManager.h"
 
 void SymbolDB::List()

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -8,11 +8,9 @@
 #pragma once
 
 #include <map>
-#include <string>
 #include <utility>
+#include <unordered_map>
 #include <vector>
-
-#include "Common/CommonTypes.h"
 
 struct SCall
 {
@@ -83,6 +81,9 @@ public:
 	virtual Symbol *AddFunction(u32 startAddr) { return nullptr; }
 
 	void AddCompleteSymbol(const Symbol &symbol);
+	
+	void PopulateSymbolComments();
+	const std::string GetCommentFromAddr(u32 addr);
 
 	Symbol* GetSymbolFromName(const std::string& name);
 	Symbol* GetSymbolFromHash(u32 hash)

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -40,6 +40,7 @@ struct Symbol
 	{}
 
 	std::string name;
+	std::unordered_map<char, std::string> comments;
 	std::vector<SCall> callers; //addresses of functions that call this function
 	std::vector<SCall> calls;   //addresses of functions that are called by this function
 	u32 hash;            //use for HLE function finding

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -8,9 +8,12 @@
 #pragma once
 
 #include <map>
-#include <utility>
+#include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
+
+-#include "Common/CommonTypes.h"
 
 struct SCall
 {

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -317,8 +317,6 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 			Host_NotifyMapLoaded();
 			break;
 
-		case IDM_RENAMESYMBOL:
-			{
 		case IDM_RENAMESYMBOL:   // TODO: This option (as well as any other text entry options) is unusable 
 			{		 // on OSX while a game is running (caused by Frame.cpp:1059)
 				{

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -524,6 +524,12 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 			{
 				desc = m_debugger->GetDescription(address);
 			}
+			
+			if (comment.empty())
+			{
+				ctx->SetFont(DebuggerFont, *wxBLACK);
+				ctx->DrawText(StrToWxStr(comment), 17 + 50*charWidth, rowY1);
+			}
 
 			if (!m_plain)
 			{

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -6,20 +6,15 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <memory>
-#include <string>
-#include <vector>
 #include <wx/brush.h>
 #include <wx/clipbrd.h>
 #include <wx/colour.h>
 #include <wx/dataobj.h>
 #include <wx/dcclient.h>
-#include <wx/graphics.h>
 #include <wx/menu.h>
 #include <wx/pen.h>
 #include <wx/textdlg.h>
 
-#include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
 #include "Common/StringUtil.h"
 #include "Common/SymbolDB.h"

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -6,15 +6,20 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <memory>		
+#include <string>		
+#include <vector>
 #include <wx/brush.h>
 #include <wx/clipbrd.h>
 #include <wx/colour.h>
 #include <wx/dataobj.h>
 #include <wx/dcclient.h>
+#include <wx/graphics.h>
 #include <wx/menu.h>
 #include <wx/pen.h>
 #include <wx/textdlg.h>
 
+#include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
 #include "Common/StringUtil.h"
 #include "Common/SymbolDB.h"

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -317,8 +317,10 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 			Host_NotifyMapLoaded();
 			break;
 
-		case IDM_RENAMESYMBOL:   // TODO: This option (as well as any other text entry options) is unusable 
-			{		 // on OSX while a game is running (caused by Frame.cpp:1059)
+		case IDM_RENAMESYMBOL:
+			{
+				Symbol *symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
+				if (symbol)
 				{
 					wxTextEntryDialog input_symbol(this, _("Rename symbol:"),
 							wxGetTextFromUserPromptStr,

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -324,8 +324,8 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 
 		case IDM_RENAMESYMBOL:
 			{
-				Symbol *symbol = m_symbol_db->GetSymbolFromAddr(m_selection);
-				if (symbol)
+		case IDM_RENAMESYMBOL:   // TODO: This option (as well as any other text entry options) is unusable 
+			{		 // on OSX while a game is running (caused by Frame.cpp:1059)
 				{
 					wxTextEntryDialog input_symbol(this, _("Rename symbol:"),
 							wxGetTextFromUserPromptStr,
@@ -434,6 +434,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 	ctx->DrawRectangle(0, 0, 16, rc.height);
 	ctx->DrawRectangle(0, 0, rc.width, 5);
 	// ------------
+	m_symbol_db->PopulateSymbolComments();
 
 	// -----------------------------
 	// Walk through all visible rows
@@ -483,6 +484,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 			const std::string& opcode   = dis[0];
 			const std::string& operands = dis[1];
 			std::string desc;
+			std::string comment = m_symbol_db->GetCommentFromAddr(address);
 
 			// look for hex strings to decode branches
 			std::string hex_str;

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -522,7 +522,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 				desc = m_debugger->GetDescription(address);
 			}
 			
-			if (comment.empty())
+			if (!comment.empty())
 			{
 				ctx->SetFont(DebuggerFont, *wxBLACK);
 				ctx->DrawText(StrToWxStr(comment), 17 + 50*charWidth, rowY1);


### PR DESCRIPTION
Functionality for reading and displaying symbol comments from a .txt file in the format:
0x[address] [comment]

Also includes some header cleanup

Note that there is no means via GUI to alter the comments for now, so the only way to display them is to manually create a (gameID)_comments.txt file and put that in /Maps.

I have the code written for adding symbols via the context menu, but first I'd like to submit this PR with more simple functionality and make sure everything works correctly.

ALSO NOTE: This is some of the first real code I've written in c++, so it would be good to double check it for common mistakes. I wouldn't be surprised if most of this could be dramatically improved. (I actually didn't mean to submit this PR so early, but as long as it's here I might as well leave it)