### PR TITLE
VideoCommon: Header cleanup

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -23,8 +23,8 @@
 #include <string>
 #include <vector>
 
-#include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/SysConf.h"
 #include "Core/BootManager.h"
@@ -37,8 +37,6 @@
 #include "Core/HW/SI.h"
 #include "Core/HW/Sram.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
-#include "DiscIO/Volume.h"
-#include "DiscIO/VolumeCreator.h"
 #include "VideoCommon/VideoBackendBase.h"
 
 namespace BootManager

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -12,7 +12,6 @@
 #include "Common/Hash.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
-#include "Common/Thread.h"
 #include "Common/Timer.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -29,13 +28,12 @@
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/WiimoteHid.h"
-#include "Core/HW/WiimoteEmu/Attachment/Classic.h"
-#include "Core/HW/WiimoteEmu/Attachment/Nunchuk.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "InputCommon/GCPadStatus.h"
 #include "VideoCommon/Fifo.h"
+#include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 
 // The chunk to allocate movie data in multiples of.

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -10,8 +10,10 @@
 #include <vector>
 #include <lzo/lzo1x.h>
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
+#include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"
 #include "Common/ScopeGuard.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/VideoBackends/D3D/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D/BoundingBox.cpp
@@ -2,8 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
 #include "VideoBackends/D3D/BoundingBox.h"
-
 #include "VideoCommon/VideoConfig.h"
 
 namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -4,7 +4,10 @@
 
 #include <algorithm>
 
+#include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
+#include "Common/Logging/Log.h"
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DState.h"
 #include "VideoBackends/D3D/D3DTexture.h"

--- a/Source/Core/VideoBackends/D3D/D3DShader.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DShader.cpp
@@ -2,9 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <fstream>
 #include <string>
 
+#include "Common/FileUtil.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
+#include "Common/Logging/Log.h"
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DShader.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/PerfQuery.h"
 #include "VideoCommon/RenderBase.h"

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -9,8 +9,9 @@
 #include <strsafe.h>
 #include <unordered_map>
 
+#include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
-#include "Common/Timer.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -31,13 +32,10 @@
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/BPFunctions.h"
 #include "VideoCommon/Fifo.h"
-#include "VideoCommon/FPSCounter.h"
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
-#include "VideoCommon/Statistics.h"
-#include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace DX11

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
+#include "Common/Logging/Log.h"
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DBlob.h"
 #include "VideoBackends/D3D/D3DShader.h"

--- a/Source/Core/VideoBackends/OGL/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/OGL/PerfQuery.cpp
@@ -4,6 +4,8 @@
 
 #include <memory>
 
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/GL/GLInterfaceBase.h"
 #include "Common/GL/GLUtil.h"
 

--- a/Source/Core/VideoBackends/OGL/SamplerCache.cpp
+++ b/Source/Core/VideoBackends/OGL/SamplerCache.cpp
@@ -4,9 +4,10 @@
 
 #include <memory>
 
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/GL/GLInterfaceBase.h"
 #include "VideoBackends/OGL/SamplerCache.h"
-#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace OGL

--- a/Source/Core/VideoBackends/Software/EfbCopy.cpp
+++ b/Source/Core/VideoBackends/Software/EfbCopy.cpp
@@ -2,13 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonTypes.h"
 #include "Common/GL/GLInterfaceBase.h"
-#include "Core/Core.h"
+#include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
-#include "VideoBackends/Software/DebugUtil.h"
 #include "VideoBackends/Software/EfbCopy.h"
 #include "VideoBackends/Software/EfbInterface.h"
-#include "VideoBackends/Software/SWRenderer.h"
 #include "VideoBackends/Software/TextureEncoder.h"
 
 #include "VideoCommon/BPMemory.h"

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -6,13 +6,11 @@
 
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
-#include "Core/HW/Memmap.h"
-
+#include "Common/Logging/Log.h"
 #include "VideoBackends/Software/EfbInterface.h"
-
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/LookUpTables.h"
-#include "VideoCommon/PixelEngine.h"
+#include "VideoCommon/PerfQueryBase.h"
 
 
 static u8 efb[EFB_WIDTH*EFB_HEIGHT*6];

--- a/Source/Core/VideoBackends/Software/EfbInterface.h
+++ b/Source/Core/VideoBackends/Software/EfbInterface.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
+#include "VideoCommon/PerfQueryBase.h"
 #include "VideoCommon/VideoCommon.h"
 
 namespace EfbInterface

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -10,7 +10,7 @@
 #include "VideoBackends/Software/NativeVertexFormat.h"
 #include "VideoBackends/Software/Rasterizer.h"
 #include "VideoBackends/Software/Tev.h"
-#include "VideoCommon/BoundingBox.h"
+#include "VideoCommon/PerfQueryBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -8,10 +8,11 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
+#include "Common/Logging/Log.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 
 #include "VideoBackends/Software/EfbCopy.h"

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -22,7 +22,7 @@
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderBase.h"
 #include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexLoaderUtils.h"
+#include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
 
 class NullNativeVertexFormat : public NativeVertexFormat

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -8,14 +8,9 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
-#include "Common/StringUtil.h"
 #include "Common/Logging/LogManager.h"
 
-#include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/Host.h"
-#include "Core/HW/Memmap.h"
-#include "Core/HW/VideoInterface.h"
 
 #include "VideoBackends/Software/Clipper.h"
 #include "VideoBackends/Software/DebugUtil.h"
@@ -30,7 +25,7 @@
 #include "VideoCommon/BPStructs.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Fifo.h"
-#include "VideoCommon/Fifo.h"
+#include "VideoCommon/FramebufferManagerBase.h"
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/OpcodeDecoding.h"
@@ -40,7 +35,6 @@
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
-#include "VideoCommon/XFMemory.h"
 
 #define VSYNC_ENABLED 0
 

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -12,6 +12,7 @@
 #include "VideoBackends/Software/TextureSampler.h"
 
 #include "VideoCommon/BoundingBox.h"
+#include "VideoCommon/PerfQueryBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"

--- a/Source/Core/VideoBackends/Software/TextureEncoder.cpp
+++ b/Source/Core/VideoBackends/Software/TextureEncoder.cpp
@@ -2,6 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
+
 #include "VideoBackends/Software/EfbInterface.h"
 #include "VideoBackends/Software/TextureEncoder.h"
 

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -15,9 +15,8 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
-#include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
-#include "Common/StringUtil.h"
+#include "Common/MsgHandler.h"
 #include "Common/Logging/Log.h"
 
 #include "Core/ConfigManager.h"

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -2,9 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <mutex>
+
 #include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/RenderBase.h"
+#include "VideoCommon/VideoBackendBase.h"
+#include "VideoCommon/VideoCommon.h"
 
 AsyncRequests AsyncRequests::s_singleton;
 

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -8,6 +8,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <queue>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -3,14 +3,15 @@
 // Refer to the license.txt file included.
 
 #include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/HW/Memmap.h"
 
 #include "VideoCommon/BPFunctions.h"
+#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VertexManagerBase.h"
-#include "VideoCommon/VertexShaderManager.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace BPFunctions

--- a/Source/Core/VideoCommon/BPFunctions.h
+++ b/Source/Core/VideoCommon/BPFunctions.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/VideoCommon.h"
+
+struct BPCmd;
 
 namespace BPFunctions
 {

--- a/Source/Core/VideoCommon/BPMemory.cpp
+++ b/Source/Core/VideoCommon/BPMemory.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/CommonTypes.h"
 #include "VideoCommon/BPMemory.h"
 
 // BP state

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -3,16 +3,19 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
+#include <cstring>
+#include <string>
 
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/HW/Memmap.h"
 
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/BPFunctions.h"
+#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/BPStructs.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/GeometryShaderManager.h"
@@ -20,7 +23,6 @@
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/RenderBase.h"
-#include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VertexShaderManager.h"

--- a/Source/Core/VideoCommon/BPStructs.h
+++ b/Source/Core/VideoCommon/BPStructs.h
@@ -4,7 +4,5 @@
 
 #pragma once
 
-#include "VideoCommon/BPMemory.h"
-
 void BPInit();
 void BPReload();

--- a/Source/Core/VideoCommon/BoundingBox.cpp
+++ b/Source/Core/VideoCommon/BoundingBox.cpp
@@ -14,7 +14,7 @@ bool active = false;
 u16 coords[4] = { 0x80, 0xA0, 0x80, 0xA0 };
 
 // Save state
-void DoState(PointerWrap &p)
+void DoState(PointerWrap& p)
 {
 	p.Do(active);
 	p.Do(coords);

--- a/Source/Core/VideoCommon/BoundingBox.h
+++ b/Source/Core/VideoCommon/BoundingBox.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include "VideoCommon/VertexLoader.h"
+#include "Common/CommonTypes.h"
+
+class PointerWrap;
 
 // Bounding Box manager
-
 namespace BoundingBox
 {
 
@@ -26,6 +27,6 @@ enum
 };
 
 // Save state
-void DoState(PointerWrap &p);
+void DoState(PointerWrap& p);
 
 }; // end of namespace BoundingBox

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include "Common/ChunkFile.h"
-#include "Common/CommonTypes.h"
 #include "VideoCommon/CPMemory.h"
 
 // CP state

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -3,24 +3,20 @@
 // Refer to the license.txt file included.
 
 #include <atomic>
+#include <cstring>
 
+#include "Common/Assert.h"
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-#include "Common/MathUtil.h"
-#include "Common/Thread.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/GPFifo.h"
-#include "Core/HW/Memmap.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Fifo.h"
-#include "VideoCommon/PixelEngine.h"
-#include "VideoCommon/VideoCommon.h"
-#include "VideoCommon/VideoConfig.h"
 
 namespace CommandProcessor
 {

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
-#include "Common/Flag.h"
 #include "VideoCommon/VideoBackendBase.h"
 
 class PointerWrap;

--- a/Source/Core/VideoCommon/DataReader.h
+++ b/Source/Core/VideoCommon/DataReader.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstring>
+#include "Common/Common.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 

--- a/Source/Core/VideoCommon/Debugger.cpp
+++ b/Source/Core/VideoCommon/Debugger.cpp
@@ -5,14 +5,11 @@
 #include <string>
 
 #include "Common/FileUtil.h"
-#include "Common/IniFile.h"
+#include "Common/StringUtil.h"
 #include "Common/Thread.h"
 
+#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/Debugger.h"
-#include "VideoCommon/NativeVertexFormat.h"
-#include "VideoCommon/PixelShaderGen.h"
-#include "VideoCommon/TextureCacheBase.h"
-#include "VideoCommon/VertexShaderGen.h"
 #include "VideoCommon/VideoConfig.h"
 
 GFXDebuggerBase *g_pdebugger = nullptr;

--- a/Source/Core/VideoCommon/FPSCounter.cpp
+++ b/Source/Core/VideoCommon/FPSCounter.cpp
@@ -4,8 +4,8 @@
 
 #include <fstream>
 
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
-#include "Common/StringUtil.h"
 #include "Common/Timer.h"
 #include "VideoCommon/FPSCounter.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -3,19 +3,18 @@
 // Refer to the license.txt file included.
 
 #include <atomic>
+#include <cstring>
 
+#include "Common/Assert.h"
 #include "Common/Atomic.h"
 #include "Common/BlockingLoop.h"
 #include "Common/ChunkFile.h"
-#include "Common/CPUDetect.h"
 #include "Common/Event.h"
 #include "Common/FPURoundMode.h"
 #include "Common/MemoryUtil.h"
-#include "Common/Thread.h"
+#include "Common/MsgHandler.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Core.h"
-#include "Core/CoreTiming.h"
 #include "Core/NetPlayProto.h"
 #include "Core/HW/Memmap.h"
 
@@ -25,10 +24,8 @@
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/OpcodeDecoding.h"
-#include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
-#include "VideoCommon/VideoConfig.h"
 
 namespace Fifo
 {

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -4,8 +4,9 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstddef>
 #include "Common/CommonTypes.h"
-#include "VideoCommon/VideoBackendBase.h"
 
 class PointerWrap;
 

--- a/Source/Core/VideoCommon/FramebufferManagerBase.h
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.h
@@ -8,6 +8,7 @@
 #include <list>
 #include <memory>
 
+#include "Common/CommonTypes.h"
 #include "VideoCommon/VideoCommon.h"
 
 inline bool AddressRangesOverlap(u32 aLower, u32 aUpper, u32 bLower, u32 bUpper)

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -3,7 +3,9 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
+#include <cstring>
 
+#include "Common/CommonTypes.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/GeometryShaderGen.h"
 #include "VideoCommon/LightingShaderGen.h"

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -2,13 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <cfloat>
-#include <cmath>
+#include <cstring>
 
+#include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/BPMemory.h"
-#include "VideoCommon/GeometryShaderGen.h"
 #include "VideoCommon/GeometryShaderManager.h"
-#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
 

--- a/Source/Core/VideoCommon/GeometryShaderManager.h
+++ b/Source/Core/VideoCommon/GeometryShaderManager.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "VideoCommon/ConstantManager.h"
-#include "VideoCommon/GeometryShaderGen.h"
 
 class PointerWrap;
 

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -5,15 +5,16 @@
 #include <algorithm>
 #include <cinttypes>
 #include <cstring>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 #include <xxhash.h>
 #include <SOIL/SOIL.h>
 
-#include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
 #include "Common/Flag.h"
@@ -22,9 +23,8 @@
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
 #include "Common/Timer.h"
-
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
-
 #include "VideoCommon/HiresTextures.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoCommon/ImageWrite.cpp
+++ b/Source/Core/VideoCommon/ImageWrite.cpp
@@ -4,12 +4,11 @@
 
 #include <list>
 #include <string>
-#include <vector>
 
 #include "png.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MsgHandler.h"
-#include "Common/Logging/Log.h"
 #include "VideoCommon/ImageWrite.h"
 
 bool SaveData(const std::string& filename, const std::string& data)

--- a/Source/Core/VideoCommon/IndexGenerator.cpp
+++ b/Source/Core/VideoCommon/IndexGenerator.cpp
@@ -6,6 +6,7 @@
 
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoCommon/LightingShaderGen.h
+++ b/Source/Core/VideoCommon/LightingShaderGen.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "VideoCommon/ConstantManager.h"
-#include "VideoCommon/DriverDetails.h"
+#include "Common/Assert.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/XFMemory.h"

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -2,16 +2,16 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/Flag.h"
-#include "Core/ConfigManager.h"
-
+#include "Common/Logging/Log.h"
 #include "VideoCommon/AsyncRequests.h"
 #include "VideoCommon/BPStructs.h"
-#include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Fifo.h"
-#include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VertexLoaderManager.h"

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -13,9 +13,8 @@
 // when they are called. The reason is that the vertex format affects the sizes of the vertices.
 
 #include "Common/CommonTypes.h"
-#include "Common/CPUDetect.h"
-#include "Core/Core.h"
-#include "Core/Host.h"
+#include "Common/MsgHandler.h"
+#include "Common/Logging/Log.h"
 #include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/HW/Memmap.h"
 #include "VideoCommon/BPMemory.h"
@@ -24,11 +23,9 @@
 #include "VideoCommon/DataReader.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/OpcodeDecoding.h"
-#include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VideoCommon.h"
-#include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
 
 

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -10,18 +10,16 @@
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
-#include "Core/State.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/PixelEngine.h"
-#include "VideoCommon/RenderBase.h"
-#include "VideoCommon/VideoCommon.h"
 
 namespace PixelEngine
 {

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -2,11 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <cassert>
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 
-#include "Common/Common.h"
+#include "Common/Assert.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/DriverDetails.h"

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "VideoCommon/BPMemory.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/VideoCommon.h"

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -3,14 +3,15 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
+#include <cstring>
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/RenderBase.h"
-#include "VideoCommon/Statistics.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/XFMemory.h"
 
 bool PixelShaderManager::s_bFogRangeAdjustChanged;
 bool PixelShaderManager::s_bViewPortChanged;

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -4,16 +4,10 @@
 
 #pragma once
 
-#include <array>
-
-#include "VideoCommon/BPMemory.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/ConstantManager.h"
-#include "VideoCommon/PixelShaderGen.h"
-#include "VideoCommon/XFMemory.h"
 
 class PointerWrap;
-
-
 
 // The non-API dependent parts.
 class PixelShaderManager

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -2,12 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <sstream>
 #include <string>
 
 #include "Common/CommonPaths.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/StringUtil.h"
+#include "Common/Logging/Log.h"
 
 #include "VideoCommon/PostProcessing.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoCommon/PostProcessing.h
+++ b/Source/Core/VideoCommon/PostProcessing.h
@@ -8,9 +8,8 @@
 #include <string>
 #include <vector>
 
-#include "Common/StringUtil.h"
+#include "Common/CommonTypes.h"
 #include "Common/Timer.h"
-
 #include "VideoCommon/VideoCommon.h"
 
 class PostProcessingShaderConfiguration

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -15,9 +15,12 @@
 #include <cinttypes>
 #include <cmath>
 #include <memory>
+#include <mutex>
 #include <string>
 
+#include "Common/CommonTypes.h"
 #include "Common/Event.h"
+#include "Common/Flag.h"
 #include "Common/Profiler.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
@@ -27,7 +30,6 @@
 #include "Core/Host.h"
 #include "Core/Movie.h"
 #include "Core/FifoPlayer/FifoRecorder.h"
-
 #include "Core/HW/VideoInterface.h"
 
 #include "VideoCommon/AVIDump.h"

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -17,14 +17,15 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
+#include "Common/CommonTypes.h"
 #include "Common/Event.h"
+#include "Common/Flag.h"
 #include "Common/MathUtil.h"
-#include "Common/Thread.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/FPSCounter.h"
-#include "VideoCommon/FramebufferManagerBase.h"
-#include "VideoCommon/NativeVertexFormat.h"
+#include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoCommon.h"
 
 class PostProcessingShaderImplementation;

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -4,15 +4,18 @@
 
 #pragma once
 
-#include <algorithm>
 #include <cstdarg>
-#include <cstdio>
+#include <cstring>
+#include <fstream>
 #include <iomanip>
+#include <map>
 #include <string>
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
+#include "Common/Logging/Log.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
 #include <string>
 #include <utility>
 

--- a/Source/Core/VideoCommon/Statistics.h
+++ b/Source/Core/VideoCommon/Statistics.h
@@ -5,10 +5,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
-
-#include "Common/CommonTypes.h"
-#include "VideoCommon/VideoCommon.h"
 
 struct Statistics
 {

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -3,24 +3,32 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <string>
+#include <utility>
 
+#include "Common/Assert.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/Hash.h"
 #include "Common/MemoryUtil.h"
 #include "Common/StringUtil.h"
+#include "Common/Logging/Log.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/HW/Memmap.h"
 
+#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/FramebufferManagerBase.h"
 #include "VideoCommon/HiresTextures.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -4,14 +4,11 @@
 
 #pragma once
 
-#include <functional>
 #include <map>
 #include <memory>
 #include <unordered_map>
 
 #include "Common/CommonTypes.h"
-#include "Common/Thread.h"
-
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoCommon.h"

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -5,12 +5,12 @@
 #include <cmath>
 #include <cstdio>
 
+#include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
-#include "VideoCommon/BPMemory.h"
+#include "Common/MsgHandler.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/TextureDecoder.h"
-#include "VideoCommon/VideoConfig.h"
 
 #define WRITE p+=sprintf
 

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
-#include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoCommon.h"
 
 namespace TextureConversionShader

--- a/Source/Core/VideoCommon/TextureDecoder.h
+++ b/Source/Core/VideoCommon/TextureDecoder.h
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include "Common/Common.h"
-#include "Common/Hash.h"
+#include "Common/CommonTypes.h"
 
 enum
 {

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -8,7 +8,6 @@
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
-#include "Common/Logging/Log.h"
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/sfont.inc"
 #include "VideoCommon/TextureDecoder.h"

--- a/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
@@ -5,7 +5,8 @@
 #include <algorithm>
 #include <cmath>
 
-#include "Common/Common.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/TextureDecoder.h"

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -4,14 +4,15 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
-#include "Common/Common.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Common/Intrinsics.h"
 
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/TextureDecoder.h"
-#include "VideoCommon/VideoConfig.h"
 
 // GameCube/Wii texture decoder
 

--- a/Source/Core/VideoCommon/VertexLoader.cpp
+++ b/Source/Core/VideoCommon/VertexLoader.cpp
@@ -2,22 +2,18 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
-#include "Common/MemoryUtil.h"
-
-#include "Core/Host.h"
 
 #include "VideoCommon/DataReader.h"
-#include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoader_Color.h"
 #include "VideoCommon/VertexLoader_Normal.h"
 #include "VideoCommon/VertexLoader_Position.h"
 #include "VideoCommon/VertexLoader_TextCoord.h"
 #include "VideoCommon/VertexLoaderManager.h"
+#include "VideoCommon/VertexLoaderUtils.h"
 #include "VideoCommon/VideoCommon.h"
-#include "VideoCommon/VideoConfig.h"
 
 // This pointer is used as the source/dst for all fixed function loader calls
 u8* g_video_buffer_read_ptr;

--- a/Source/Core/VideoCommon/VertexLoader.h
+++ b/Source/Core/VideoCommon/VertexLoader.h
@@ -7,17 +7,11 @@
 // Top vertex loaders
 // Metroid Prime: P I16-flt N I16-s16 T0 I16-u16 T1 i16-flt
 
-#include <algorithm>
 #include <string>
 
 #include "Common/CommonTypes.h"
-
-#include "VideoCommon/CPMemory.h"
 #include "VideoCommon/DataReader.h"
-#include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/VertexLoaderBase.h"
-#include "VideoCommon/VertexLoaderUtils.h"
-
 
 class VertexLoader;
 typedef void (*TPipelineFunction)(VertexLoader* loader);

--- a/Source/Core/VideoCommon/VertexLoaderARM64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonTypes.h"
+#include "VideoCommon/DataReader.h"
 #include "VideoCommon/VertexLoaderARM64.h"
 #include "VideoCommon/VertexLoaderManager.h"
 

--- a/Source/Core/VideoCommon/VertexLoaderARM64.h
+++ b/Source/Core/VideoCommon/VertexLoaderARM64.h
@@ -3,7 +3,10 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
 #include "Common/Arm64Emitter.h"
+#include "Common/CommonTypes.h"
+#include "VideoCommon/DataReader.h"
 #include "VideoCommon/VertexLoaderBase.h"
 
 class VertexLoaderARM64 : public VertexLoaderBase, public Arm64Gen::ARM64CodeBlock

--- a/Source/Core/VideoCommon/VertexLoaderBase.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderBase.cpp
@@ -3,10 +3,12 @@
 // Refer to the license.txt file included.
 
 #include <cinttypes>
+#include <cstring>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -5,23 +5,24 @@
 #include <algorithm>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/Memmap.h"
 
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/IndexGenerator.h"
+#include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderBase.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VertexShaderManager.h"
-#include "VideoCommon/VideoCommon.h"
-
-
 
 namespace VertexLoaderManager
 {

--- a/Source/Core/VideoCommon/VertexLoaderManager.h
+++ b/Source/Core/VideoCommon/VertexLoaderManager.h
@@ -8,7 +8,8 @@
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/DataReader.h"
-#include "VideoCommon/NativeVertexFormat.h"
+
+class NativeVertexFormat;
 
 namespace VertexLoaderManager
 {

--- a/Source/Core/VideoCommon/VertexLoaderUtils.h
+++ b/Source/Core/VideoCommon/VertexLoaderUtils.h
@@ -5,12 +5,12 @@
 #pragma once
 
 #include <cstring>
+
 #include "Common/Common.h"
-#include "VideoCommon/VertexManagerBase.h"
+#include "Common/CommonTypes.h"
 
 extern u8* g_video_buffer_read_ptr;
 extern u8* g_vertex_manager_write_ptr;
-
 
 __forceinline void DataSkip(u32 skip)
 {

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -2,12 +2,18 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+#include <string>
+
 #include "Common/BitSet.h"
 #include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/CPUDetect.h"
 #include "Common/Intrinsics.h"
 #include "Common/JitRegister.h"
 #include "Common/x64ABI.h"
+#include "Common/x64Emitter.h"
+#include "VideoCommon/DataReader.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexLoaderX64.h"
 

--- a/Source/Core/VideoCommon/VertexLoaderX64.h
+++ b/Source/Core/VideoCommon/VertexLoaderX64.h
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/CommonTypes.h"
 #include "Common/x64Emitter.h"
 #include "VideoCommon/VertexLoaderBase.h"
 

--- a/Source/Core/VideoCommon/VertexLoader_Color.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Color.cpp
@@ -4,15 +4,12 @@
 
 #include <cstring>
 
-#include "Common/Common.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
-
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoader_Color.h"
 #include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexManagerBase.h"
-#include "VideoCommon/VideoCommon.h"
+#include "VideoCommon/VertexLoaderUtils.h"
 
 #define AMASK 0xFF000000
 

--- a/Source/Core/VideoCommon/VertexLoader_Color.h
+++ b/Source/Core/VideoCommon/VertexLoader_Color.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "VideoCommon/NativeVertexFormat.h"
-
 class VertexLoader;
 
 void Color_ReadDirect_24b_888(VertexLoader* loader);

--- a/Source/Core/VideoCommon/VertexLoader_Normal.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.cpp
@@ -6,12 +6,13 @@
 #include <type_traits>
 
 #include "Common/Common.h"
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
+#include "VideoCommon/DataReader.h"
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoader_Normal.h"
 #include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexManagerBase.h"
-#include "VideoCommon/VideoCommon.h"
+#include "VideoCommon/VertexLoaderUtils.h"
 
 // warning: mapping buffer should be disabled to use this
 #define LOG_NORM()  // PRIM_LOG("norm: %f %f %f, ", ((float*)g_vertex_manager_write_ptr)[-3], ((float*)g_vertex_manager_write_ptr)[-2], ((float*)g_vertex_manager_write_ptr)[-1]);

--- a/Source/Core/VideoCommon/VertexLoader_Normal.h
+++ b/Source/Core/VideoCommon/VertexLoader_Normal.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "VideoCommon/NativeVertexFormat.h"
+#include "Common/CommonTypes.h"
 
 class VertexLoader_Normal
 {

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -2,14 +2,16 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <limits>
 #include <type_traits>
 
-#include "Common/Common.h"
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
+#include "VideoCommon/DataReader.h"
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoader_Position.h"
 #include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexManagerBase.h"
+#include "VideoCommon/VertexLoaderUtils.h"
 #include "VideoCommon/VideoCommon.h"
 
 template <typename T>

--- a/Source/Core/VideoCommon/VertexLoader_Position.h
+++ b/Source/Core/VideoCommon/VertexLoader_Position.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "VideoCommon/NativeVertexFormat.h"
+#include "Common/CommonTypes.h"
 
 class VertexLoader_Position
 {

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -4,26 +4,25 @@
 
 #include <type_traits>
 
-#include "Common/Common.h"
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "VideoCommon/VertexLoader.h"
 #include "VideoCommon/VertexLoader_TextCoord.h"
 #include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexManagerBase.h"
-#include "VideoCommon/VideoCommon.h"
+#include "VideoCommon/VertexLoaderUtils.h"
 
 template <int N>
 void LOG_TEX();
 
 template <>
-__forceinline void LOG_TEX<1>()
+void LOG_TEX<1>()
 {
 	// warning: mapping buffer should be disabled to use this
 	// PRIM_LOG("tex: %f, ", ((float*)g_vertex_manager_write_ptr)[-1]);
 }
 
 template <>
-__forceinline void LOG_TEX<2>()
+void LOG_TEX<2>()
 {
 	// warning: mapping buffer should be disabled to use this
 	// PRIM_LOG("tex: %f %f, ", ((float*)g_vertex_manager_write_ptr)[-2], ((float*)g_vertex_manager_write_ptr)[-1]);

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.h
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "VideoCommon/NativeVertexFormat.h"
+#include "Common/CommonTypes.h"
 
 class VertexLoader_TextCoord
 {

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -4,9 +4,13 @@
 
 #include <memory>
 
+#include "Common/BitSet.h"
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 
-#include "VideoCommon/BPStructs.h"
+#include "VideoCommon/BPMemory.h"
+#include "VideoCommon/DataReader.h"
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/GeometryShaderManager.h"
 #include "VideoCommon/IndexGenerator.h"

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -10,10 +10,10 @@
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "VideoCommon/DataReader.h"
-#include "VideoCommon/NativeVertexFormat.h"
 
 class NativeVertexFormat;
 class PointerWrap;
+struct PortableVertexDeclaration;
 
 enum PrimitiveType {
 	PRIMITIVE_POINTS,

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -3,7 +3,10 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
+#include <cstring>
 
+#include "Common/Assert.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/NativeVertexFormat.h"

--- a/Source/Core/VideoCommon/VertexShaderGen.h
+++ b/Source/Core/VideoCommon/VertexShaderGen.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/VideoCommon.h"

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -6,11 +6,14 @@
 #include <cmath>
 #include <cstring>
 #include <sstream>
+#include <string>
 
 #include "Common/BitSet.h"
+#include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "VideoCommon/BPMemory.h"
@@ -18,7 +21,6 @@
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexManagerBase.h"
-#include "VideoCommon/VertexShaderGen.h"
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <string>
+
+#include "Common/CommonTypes.h"
 #include "VideoCommon/ConstantManager.h"
-#include "VideoCommon/VertexShaderGen.h"
 
 class PointerWrap;
 

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <string>
+#include <vector>
+
 // TODO: ugly
 #ifdef _WIN32
 #include "VideoBackends/D3D/VideoBackend.h"

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -7,11 +7,11 @@
 #include <string>
 #include <vector>
 
-#include "Common/ChunkFile.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/PerfQueryBase.h"
 
 namespace MMIO { class Mapping; }
-
+class PointerWrap;
 
 enum FieldType
 {

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -10,7 +10,6 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
-#include "VideoCommon/VideoBackendBase.h"
 
 // Global flag to signal if FifoRecorder is active.
 extern bool g_bRecordFifoData;

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "Common/ChunkFile.h"
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/BPMemory.h"

--- a/Source/Core/VideoCommon/XFMemory.cpp
+++ b/Source/Core/VideoCommon/XFMemory.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
 #include "VideoCommon/XFMemory.h"
 
 // STATE_TO_SAVE

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -2,7 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/DataReader.h"
@@ -11,7 +13,6 @@
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VertexShaderManager.h"
-#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/XFMemory.h"
 
 static void XFMemWritten(u32 transferSize, u32 baseAddress)


### PR DESCRIPTION
Also cleans up places where the video backends and core rely on things being indirectly included from it.

also ran this with precompiled headers disabled, so building without those should be covered as well.