### PR TITLE
Fifo: Fix SyncGPU.

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -498,6 +498,9 @@ void EmuThread()
 
 	CBoot::BootUp();
 
+	// This adds the SyncGPU handler to CoreTiming, so now CoreTiming::Advance might block.
+	Fifo::Prepare();
+
 	// Thread is no longer acting as CPU Thread
 	UndeclareAsCPUThread();
 

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -446,7 +446,7 @@ void Idle()
 		//the VI will be desynchronized. So, We are waiting until the FIFO finish and
 		//while we process only the events required by the FIFO.
 		ProcessFifoWaitEvents();
-		Fifo::Update(0);
+		Fifo::FlushGpu();
 	}
 
 	idledCycles += DowncountToCycles(PowerPC::ppcState.downcount);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 50; // Last changed in PR 3457
+static const u32 STATE_VERSION = 51; // Last changed in PR 3530
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -22,6 +22,7 @@ extern std::atomic<u8*> g_video_buffer_write_ptr_xthread;
 
 void Init();
 void Shutdown();
+void Prepare(); // Must be called from the CPU thread.
 void DoState(PointerWrap &f);
 void PauseAndLock(bool doLock, bool unpauseOnUnlock);
 void UpdateWantDeterminism(bool want);
@@ -52,6 +53,5 @@ void EmulatorState(bool running);
 bool AtBreakpoint();
 void ResetVideoBuffer();
 void SetRendering(bool bEnabled);
-int Update(int ticks);
 
 };


### PR DESCRIPTION
CBoot::BootUp() did call CoreTiming::Advance which itself blocks on the GPU,
but the GPU thread wasn't started already. This commit moves the SyncGPU
initialization into Fifo.cpp and call it after BootUp().

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3530)
<!-- Reviewable:end -->
