### PR TITLE
Fix the Exit hotkey.

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1322,7 +1322,7 @@ void CFrame::ParseHotkeys()
 	if (IsHotkey(HK_SCREENSHOT))
 		Core::SaveScreenShot();
 	if (IsHotkey(HK_EXIT))
-		wxPostEvent(this, wxCommandEvent(wxID_EXIT));
+		wxPostEvent(this, wxCommandEvent(wxEVT_MENU, wxID_EXIT));
 	if (IsHotkey(HK_VOLUME_DOWN))
 		AudioCommon::DecreaseVolume(3);
 	if (IsHotkey(HK_VOLUME_UP))


### PR DESCRIPTION
We were constructing our wxCommandEvent incorrectly and using an ID as an event type instead of the ID.
Works properly now.