### PR TITLE
Properly clear JIT cache on save states

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -604,7 +604,11 @@ void Wiimote::DoState(PointerWrap& p)
 		{
 			//clear
 			while (!m_read_requests.empty())
+			{
+				delete[] m_read_requests.front().data;
 				m_read_requests.pop();
+			}
+
 
 			p.Do(size);
 			while (size--)

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -203,6 +203,7 @@ void Jit64::Init()
 	// important: do this *after* generating the global asm routines, because we can't use farcode in them.
 	// it'll crash because the farcode functions get cleared on JIT clears.
 	farcode.Init(jo.memcheck ? FARCODE_SIZE_MMU : FARCODE_SIZE);
+	Clear();
 
 	code_block.m_stats = &js.st;
 	code_block.m_gpa = &js.gpa;
@@ -216,6 +217,7 @@ void Jit64::ClearCache()
 	trampolines.ClearCodeSpace();
 	farcode.ClearCodeSpace();
 	ClearCodeSpace();
+	Clear();
 	UpdateMemoryOptions();
 	m_clear_cache_asap = false;
 }

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -254,6 +254,7 @@ void JitIL::Init()
 	asm_routines.Init(nullptr);
 
 	farcode.Init(jo.memcheck ? FARCODE_SIZE_MMU : FARCODE_SIZE);
+	Clear();
 
 	code_block.m_stats = &js.st;
 	code_block.m_gpa = &js.gpa;
@@ -269,7 +270,9 @@ void JitIL::ClearCache()
 {
 	blocks.Clear();
 	trampolines.ClearCodeSpace();
+	farcode.ClearCodeSpace();
 	ClearCodeSpace();
+	Clear();
 }
 
 void JitIL::Shutdown()
@@ -455,7 +458,7 @@ void JitIL::Trace()
 
 void JitIL::Jit(u32 em_address)
 {
-	if (IsAlmostFull() || farcode.IsAlmostFull() || blocks.IsFull() ||
+	if (IsAlmostFull() || farcode.IsAlmostFull() || trampolines.IsAlmostFull() || blocks.IsFull() ||
 		SConfig::GetInstance().bJITNoBlockCache)
 	{
 		ClearCache();

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -1014,3 +1014,11 @@ void EmuCodeBlock::JitClearCA()
 {
 	MOV(8, PPCSTATE(xer_ca), Imm8(0));
 }
+
+void EmuCodeBlock::Clear()
+{
+	registersInUseAtLoc.clear();
+	pcAtLoc.clear();
+	exceptionHandlerAtLoc.clear();
+}
+

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -128,6 +128,7 @@ public:
 	void ConvertSingleToDouble(Gen::X64Reg dst, Gen::X64Reg src, bool src_is_gpr = false);
 	void ConvertDoubleToSingle(Gen::X64Reg dst, Gen::X64Reg src);
 	void SetFPRF(Gen::X64Reg xmm);
+	void Clear();
 protected:
 	std::unordered_map<u8 *, BitSet32> registersInUseAtLoc;
 	std::unordered_map<u8 *, u32> pcAtLoc;

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -41,7 +41,7 @@ namespace JitInterface
 	void DoState(PointerWrap &p)
 	{
 		if (jit && p.GetMode() == PointerWrap::MODE_READ)
-			jit->GetBlockCache()->Clear();
+			jit->ClearCache();
 	}
 	CPUCoreBase *InitJitCore(int core)
 	{


### PR DESCRIPTION
Fixes issue 8738: https://bugs.dolphin-emu.org/issues/8738

Old behaviour only cleared the block cache on save states, but not unordered maps.

Thanks to hk.konpie for his patch which I used in part to resolve the issue and skid_au for pointing me in the right direction where the JIT was clearing the cache on DoState().

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3535)
<!-- Reviewable:end -->
