### PR TITLE
Strip the Android shared library file.

### DIFF
--- a/Source/Android/jni/CMakeLists.txt
+++ b/Source/Android/jni/CMakeLists.txt
@@ -3,32 +3,33 @@ list(APPEND LIBS core uicommon)
 set(SRCS ButtonManager.cpp
          MainAndroid.cpp)
 
-if(ANDROID)
-	set(DOLPHIN_EXE main)
-	add_library(${DOLPHIN_EXE} SHARED ${SRCS})
-	target_link_libraries(${DOLPHIN_EXE}
-	log
-	android
-	"-Wl,--no-warn-mismatch"
-	"-Wl,--whole-archive"
-	${LIBS}
-	"-Wl,--no-whole-archive"
-	)
-	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
-		COMMAND mkdir ARGS -p ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/jniLibs/${ANDROID_NDK_ABI_NAME}
-	)
-	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
-		COMMAND mkdir ARGS -p ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/
-	)
-	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
-		COMMAND cp ARGS ${LIBRARY_OUTPUT_PATH_ROOT}/libs/${ANDROID_NDK_ABI_NAME}/lib${DOLPHIN_EXE}.so ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/jniLibs/${ANDROID_NDK_ABI_NAME}/
-	)
-	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
-		COMMAND cp ARGS ${CMAKE_SOURCE_DIR}/Data/Sys/GC/* ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/
-	)
-	add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
-		COMMAND cp ARGS -r ${CMAKE_SOURCE_DIR}/Data/Sys/Shaders ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/
-	)
+set(SHARED_LIB main)
+add_library(${SHARED_LIB} SHARED ${SRCS})
+target_link_libraries(${SHARED_LIB}
+log
+android
+"-Wl,--no-warn-mismatch"
+"-Wl,--whole-archive"
+${LIBS}
+"-Wl,--no-whole-archive"
+)
+add_custom_command(TARGET ${SHARED_LIB} POST_BUILD
+	COMMAND mkdir ARGS -p ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/jniLibs/${ANDROID_NDK_ABI_NAME}
+)
+add_custom_command(TARGET ${SHARED_LIB} POST_BUILD
+	COMMAND mkdir ARGS -p ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/
+)
+add_custom_command(TARGET ${SHARED_LIB} POST_BUILD
+	COMMAND cp ARGS ${LIBRARY_OUTPUT_PATH_ROOT}/libs/${ANDROID_NDK_ABI_NAME}/lib${SHARED_LIB}.so ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/jniLibs/${ANDROID_NDK_ABI_NAME}/
+)
+add_custom_command(TARGET ${SHARED_LIB} POST_BUILD
+	COMMAND ${CMAKE_STRIP} ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/jniLibs/${ANDROID_NDK_ABI_NAME}/lib${SHARED_LIB}.so
+)
+add_custom_command(TARGET ${SHARED_LIB} POST_BUILD
+	COMMAND cp ARGS ${CMAKE_SOURCE_DIR}/Data/Sys/GC/* ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/
+)
+add_custom_command(TARGET ${SHARED_LIB} POST_BUILD
+	COMMAND cp ARGS -r ${CMAKE_SOURCE_DIR}/Data/Sys/Shaders ${CMAKE_SOURCE_DIR}/Source/Android/app/src/main/assets/
+)
 
-	set(CPACK_PACKAGE_EXECUTABLES ${CPACK_PACKAGE_EXECUTABLES} ${DOLPHIN_EXE})
-endif()
+set(CPACK_PACKAGE_EXECUTABLES ${CPACK_PACKAGE_EXECUTABLES} ${SHARED_LIB})

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -47,7 +47,9 @@ macro(add_dolphin_library lib srcs libs)
 endmacro(add_dolphin_library)
 
 add_subdirectory(Core)
-add_subdirectory(Android/jni)
+if (ANDROID)
+	add_subdirectory(Android/jni)
+endif()
 add_subdirectory(UnitTests)
 
 if (DSPTOOL)


### PR DESCRIPTION
This cuts down the shared library size from ~11MB to ~5.5MB

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3537)
<!-- Reviewable:end -->
