### PR TITLE
Allow multiple GC adapters on one PC to be used with multiple Dolphin instances.

### DIFF
--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -190,7 +190,11 @@ void Setup()
 	{
 		libusb_device* device = list[d];
 		if (CheckDeviceAccess(device))
+		{
+			// Only connect to a single adapter in case the user has multiple connected
 			AddGCAdapter(device);
+			break;
+		}
 	}
 
 	libusb_free_device_list(list, 1);


### PR DESCRIPTION
Previously we would iterate through every GC adapter plugged in to the PC and steal ownership of it.
This causes issues all over the place in the implementation if this happens.
Break on the first adapter we can get access to.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3539)
<!-- Reviewable:end -->
