### PR TITLE
Stops netplay clients from failing to send settings on game start 

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -674,7 +674,6 @@ bool NetPlayClient::StartGame(const std::string &path)
 	sf::Packet* spac = new sf::Packet;
 	*spac << (MessageId)NP_MSG_START_GAME;
 	*spac << m_current_game;
-	*spac << (char *)&g_NetPlaySettings;
 	SendAsync(spac);
 
 	if (m_is_running.load())


### PR DESCRIPTION
Clients have no need to send their configuration information on start and the server straight out ignores it.
Not to mention it shouldn't try sending a struct as a null terminated string.

Cleans up how the server sends the configuration slightly as well.
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3541)
<!-- Reviewable:end -->
