### PR TITLE
[WIP] Resample dumped audio to 48khz

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -168,14 +168,14 @@ void CMixer::PushSamples(const short *samples, unsigned int num_samples)
 {
 	m_dma_mixer.PushSamples(samples, num_samples);
 	if (m_log_dsp_audio)
-		m_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples);
+		m_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples, AudioInterface::GetAIDSampleRate());
 }
 
 void CMixer::PushStreamingSamples(const short *samples, unsigned int num_samples)
 {
 	m_streaming_mixer.PushSamples(samples, num_samples);
 	if (m_log_dtk_audio)
-		m_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples);
+		m_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples, AudioInterface::GetAIDSampleRate());
 }
 
 void CMixer::PushWiimoteSpeakerSamples(const short *samples, unsigned int num_samples, unsigned int sample_rate)
@@ -250,7 +250,7 @@ void CMixer::StartLogDSPAudio(const std::string& filename)
 	if (!m_log_dsp_audio)
 	{
 		m_log_dsp_audio = true;
-		m_wave_writer_dsp.Start(filename, 32000);
+		m_wave_writer_dsp.Start(filename, 48000);
 		m_wave_writer_dsp.SetSkipSilence(false);
 		NOTICE_LOG(AUDIO, "Starting DSP Audio logging");
 	}

--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -135,28 +135,28 @@ void WaveFileWriter::AddStereoSamplesBE(const short *sample_data, u32 count, int
 	if (sample_rate == 32000)
 	{
 		static short *buff = NULL;
-		static int nsampf = 0;
 
 		static short old[2] = { 0, 0 };
+
+		u32 count_resampled = count * 3 / 2; //Converted sample count from 32khz to 48khz (3/2 more samples than 32khz)
 
 		if (count % 2)
 			return;
 
 		// 2->3
-		if (count < count * 3 / 2)
+		if (count < count_resampled)
 		{
-			buff = (short *)realloc(buff, count * 3 / 2 * 4);
-			nsampf = count * 3 / 2;
+			buff = (short *)realloc(buff, count_resampled * 4);
 		}
 		if (!buff)
 			return;
 
-		for (int i = 0; i < (int)count / 2; i++)
+		for (u32 i = 0; i < count / 2; i++)
 		{
-			buff[6 * i + 0] = (int)sample_data[4 * i + 0] * 2 / 3 + old[0] * 1 / 3;
-			buff[6 * i + 1] = (int)sample_data[4 * i + 1] * 2 / 3 + old[1] * 1 / 3;
-			buff[6 * i + 2] = (int)sample_data[4 * i + 0] * 2 / 3 + sample_data[4 * i + 2] * 1 / 3;
-			buff[6 * i + 3] = (int)sample_data[4 * i + 1] * 2 / 3 + sample_data[4 * i + 3] * 1 / 3;
+			buff[6 * i + 0] = static_cast<int>(sample_data[4 * i + 0]) * 2 / 3 + old[0] * 1 / 3;
+			buff[6 * i + 1] = static_cast<int>(sample_data[4 * i + 1]) * 2 / 3 + old[1] * 1 / 3;
+			buff[6 * i + 2] = static_cast<int>(sample_data[4 * i + 0]) * 2 / 3 + sample_data[4 * i + 2] * 1 / 3;
+			buff[6 * i + 3] = static_cast<int>(sample_data[4 * i + 1]) * 2 / 3 + sample_data[4 * i + 3] * 1 / 3;
 			buff[6 * i + 4] = sample_data[4 * i + 2];
 			buff[6 * i + 5] = sample_data[4 * i + 3];
 
@@ -164,7 +164,7 @@ void WaveFileWriter::AddStereoSamplesBE(const short *sample_data, u32 count, int
 			old[1] = sample_data[4 * i + 3];
 		}
 
-		count = count * 3 / 2;
+		count = count_resampled;
 		sample_data = buff;
 	}
 

--- a/Source/Core/AudioCommon/WaveFile.h
+++ b/Source/Core/AudioCommon/WaveFile.h
@@ -32,7 +32,7 @@ public:
 	void SetSkipSilence(bool skip) { skip_silence = skip; }
 
 	void AddStereoSamples(const short *sample_data, u32 count);
-	void AddStereoSamplesBE(const short *sample_data, u32 count);  // big endian
+	void AddStereoSamplesBE(const short *sample_data, u32 count, int sample_rate);  // big endian
 	u32 GetAudioSize() const { return audio_size; }
 
 private:


### PR DESCRIPTION
A slight re-working of audio re-sampling code from now unnecessary avsync hack (which was used to properly sync audio and video together when dumped). This should resample 32khz audio to 48khz audio if it works properly.

Marking as WIP as it's currently untested, but also looking for feedback.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3542)
<!-- Reviewable:end -->
