### PR TITLE
VideoInterface: specify internal linkage on local variable

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -49,7 +49,7 @@ static UVIBorderBlankRegister    m_BorderHBlank;
 // 0xcc002076 - 0xcc00207f is full of 0x00FF: unknown
 // 0xcc002080 - 0xcc002100 even more unknown
 
-u32 s_target_refresh_rate = 0;
+static u32 s_target_refresh_rate = 0;
 
 static u32 s_clock_freqs[2] =
 {


### PR DESCRIPTION
Noticed this at work when I was on lunch and wanted to kick myself for forgetting to do this in #3540

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3545)
<!-- Reviewable:end -->
