### PR TITLE
Properly Handle Video Dumping from Power On

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -21,6 +21,7 @@ extern "C" {
 
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
+#include "Core/Movie.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/HW/VideoInterface.h" //for TargetRefreshRate
 #include "VideoCommon/AVIDump.h"
@@ -177,7 +178,9 @@ void AVIDump::AddFrame(const u8* data, int width, int height)
 	int error = 0;
 	u64 delta;
 	s64 last_pts;
-	if (!s_start_dumping && s_last_frame <= SystemTimers::GetTicksPerSecond())
+	// Check to see if the first frame being dumped is the first frame of output from the emulator.
+	// This prevents an issue with starting dumping later in emulation from placing the frames incorrectly.
+	if (!s_start_dumping && Movie::g_currentFrame < 1)
 	{
 		delta = CoreTiming::GetTicks();
 		last_pts = AV_NOPTS_VALUE;


### PR DESCRIPTION
Supersedes PR #3549 with a much more sane (and stupidly easy) solution to fix the problem.

Old behaviour would not account for video dumping from power on if the delay from power on to the first call of AVIDump::AddFrame() was greater than one second. To remedy this, ~~check to see if the delay is less than two seconds from power on to first call of AddFrame()~~ check to see if the first frame being dumped is actually the first frame being output by the emulator.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3551)
<!-- Reviewable:end -->
