### PR TITLE
[netplay] Use the local type of each SI device

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -746,8 +746,11 @@ void NetPlayClient::UpdateDevices()
 {
 	for (PadMapping i = 0; i < 4; i++)
 	{
-		// XXX: add support for other device types? does it matter?
-		SerialInterface::AddDevice(m_pad_map[i] > 0 ? SIDEVICE_GC_CONTROLLER : SIDEVICE_NONE, i);
+		// Use local controller types for local controllers
+		if (m_pad_map[i] == m_local_player->pid)
+			SerialInterface::AddDevice(SConfig::GetInstance().m_SIDevice[i], i);
+		else
+			SerialInterface::AddDevice(m_pad_map[i] > 0 ? SIDEVICE_GC_CONTROLLER : SIDEVICE_NONE, i);
 	}
 }
 


### PR DESCRIPTION
Instead of using SI_GCcontroller which would make it not work with gc adapters, bongos, and other stuff. Trying to fix issue #9263.

This fixes at least the local issue, but I don’t know how it behaves on multiplayer netplay (which is arguably what people want). Edit: JMC said it worked fine.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3554)
<!-- Reviewable:end -->
