### PR TITLE
RenderBase: Get rid of an undefined global extern

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -40,8 +40,6 @@ struct EfbPokeData
 extern int frameCount;
 extern int OSDChoice;
 
-extern bool bLastFrameDumped;
-
 // Renderer really isn't a very good name for this class - it's more like "Misc".
 // The long term goal is to get rid of this class and replace it with others that make
 // more sense.


### PR DESCRIPTION
This doesn't have an implementation, so into the trash it goes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3561)
<!-- Reviewable:end -->
