### PR TITLE
CPMemory: Remove unnecessary extern specifiers from functions

### DIFF
--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -262,16 +262,15 @@ struct CPState final
 
 class PointerWrap;
 
-extern void DoCPState(PointerWrap& p);
-
-extern void CopyPreprocessCPStateFromMain();
-
 extern CPState g_main_cp_state;
 extern CPState g_preprocess_cp_state;
-
 
 // Might move this into its own file later.
 void LoadCPReg(u32 SubCmd, u32 Value, bool is_preprocess = false);
 
 // Fills memory with data from CP regs
 void FillCPMemoryArray(u32 *memory);
+
+void DoCPState(PointerWrap& p);
+
+void CopyPreprocessCPStateFromMain();


### PR DESCRIPTION
These are defined in CPMemory.cpp, as expected. There's no need for extern

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3562)
<!-- Reviewable:end -->
