### PR TITLE
[netplay] Fix a regression

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -269,7 +269,7 @@ bool BootCore(const std::string& _rFilename)
 		{
 			int source;
 			controls_section->Get(StringFromFormat("PadType%u", i), &source, -1);
-			if (source >= (int) SIDEVICE_NONE && source <= (int) SIDEVICE_AM_BASEBOARD)
+			if (source >= (int) SIDEVICE_NONE && source <= (int) SIDEVICE_WIIU_ADAPTER)
 			{
 				SConfig::GetInstance().m_SIDevice[i] = (SIDevices) source;
 				config_cache.bSetPads[i] = true;

--- a/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
@@ -40,12 +40,14 @@ int CSIDevice_GCAdapter::RunBuffer(u8* _pBuffer, int _iLength)
 	// Read the command
 	EBufferCommands command = static_cast<EBufferCommands>(_pBuffer[3]);
 
-	// get the correct pad number that should rumble locally when using netplay
 	const u8 numPAD = NetPlay_InGamePadToLocalPad(ISIDevice::m_iDeviceNumber);
-	if (!GCAdapter::DeviceConnected(numPAD))
+	if (numPAD < 4)
 	{
-		reinterpret_cast<u32*>(_pBuffer)[0] = SI_NONE;
-		return 4;
+		if (!GCAdapter::DeviceConnected(numPAD))
+		{
+			reinterpret_cast<u32*>(_pBuffer)[0] = SI_NONE;
+			return 4;
+		}
 	}
 
 	// Handle it

--- a/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
@@ -16,7 +16,8 @@ CSIDevice_GCAdapter::CSIDevice_GCAdapter(SIDevices device, int _iDeviceNumber)
 {
 	// get the correct pad number that should rumble locally when using netplay
 	const u8 numPAD = NetPlay_InGamePadToLocalPad(ISIDevice::m_iDeviceNumber);
-	m_simulate_konga = SConfig::GetInstance().m_AdapterKonga[numPAD];
+	if (numPAD < 4)
+		m_simulate_konga = SConfig::GetInstance().m_AdapterKonga[numPAD];
 }
 
 GCPadStatus CSIDevice_GCAdapter::GetPadStatus()

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -768,7 +768,14 @@ void NetPlayClient::UpdateDevices()
 		// Use local controller types for local controllers
 		if (player_id == m_local_player->pid)
 		{
-			SerialInterface::AddDevice(SConfig::GetInstance().m_SIDevice[local_pad], local_pad);
+			if (SConfig::GetInstance().m_SIDevice[local_pad] != SIDEVICE_NONE)
+			{
+				SerialInterface::AddDevice(SConfig::GetInstance().m_SIDevice[local_pad], local_pad);
+			}
+			else
+			{
+				SerialInterface::AddDevice(SIDEVICE_GC_CONTROLLER, local_pad);
+			}
 			local_pad++;
 		}
 	}

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -758,13 +758,29 @@ bool NetPlayClient::ChangeGame(const std::string&)
 // called from ---NETPLAY--- thread
 void NetPlayClient::UpdateDevices()
 {
-	for (PadMapping i = 0; i < 4; i++)
+	u8 local_pad = 0;
+	// Add local pads first:
+	// As stated in the comment in NetPlayClient::GetNetPads, the pads pertaining
+	// to the local user are always locally mapped to the first gamecube ports,
+	// so they should be added first.
+	for (auto player_id : m_pad_map)
 	{
 		// Use local controller types for local controllers
-		if (m_pad_map[i] == m_local_player->pid)
-			SerialInterface::AddDevice(SConfig::GetInstance().m_SIDevice[i], i);
-		else
-			SerialInterface::AddDevice(m_pad_map[i] > 0 ? SIDEVICE_GC_CONTROLLER : SIDEVICE_NONE, i);
+		if (player_id == m_local_player->pid)
+		{
+			SerialInterface::AddDevice(SConfig::GetInstance().m_SIDevice[local_pad], local_pad);
+			local_pad++;
+		}
+	}
+	for (auto player_id : m_pad_map)
+	{
+		if (player_id != m_local_player->pid)
+		{
+			// Only GCController-like controllers are supported, GBA and similar
+			// exotic devices are not supported on netplay.
+			SerialInterface::AddDevice(player_id > 0 ? SIDEVICE_GC_CONTROLLER : SIDEVICE_NONE, local_pad);
+			local_pad++;
+		}
 	}
 }
 


### PR DESCRIPTION
Introduced in 6e13496d8, pads would get assigned to their netplay position, which breaks assumptions. With this behavior, the SI devices should be mapped properly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3569)
<!-- Reviewable:end -->
