### PR TITLE
fix El Capitan WiimoteReal pairing problem and refresh crash problem

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -169,7 +169,8 @@ void WiimoteScanner::FindWiimotes(std::vector<Wiimote*> & found_wiimotes, Wiimot
 			@{ @kIOHIDVendorIDKey: @0x057e, @kIOHIDProductIDKey: @0x0330 },
 		];
 		IOHIDManagerSetDeviceMatchingMultiple(hid, (CFArrayRef)criteria);
-		CFRunLoopRun();
+		if (IOHIDManagerOpen(hid, kIOHIDOptionsTypeNone) != kIOReturnSuccess)
+			WARN_LOG(WIIMOTE, "Failed to open HID Manager");
 		CFSetRef devices = IOHIDManagerCopyDevices(hid);
 		if (devices)
 		{


### PR DESCRIPTION
For this bug: https://bugs.dolphin-emu.org/issues/8993
Just fix one line in previous patch https://github.com/dolphin-emu/dolphin/pull/2670, seems the difference introduced in a subversion of 10.11.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3574)
<!-- Reviewable:end -->
