### PR TITLE
[WIP] Finite Impulse Response Resampler for Audio

### DIFF
--- a/Source/Core/AudioCommon/AOSoundStream.cpp
+++ b/Source/Core/AudioCommon/AOSoundStream.cpp
@@ -15,7 +15,8 @@ void AOSound::SoundLoop()
 {
 	Common::SetCurrentThreadName("Audio thread - ao");
 
-	uint_32 numBytesToRender = 256;
+	const uint_32 numBytesToMix = 512;
+	const uint_32 numBytesToOutput = numBytesToMix / 2;
 	ao_initialize();
 	default_driver = ao_default_driver_id();
 	format.bits = 16;
@@ -32,15 +33,23 @@ void AOSound::SoundLoop()
 		return;
 	}
 
+	// is buf_size being used?
 	buf_size = format.bits/8 * format.channels * format.rate;
 
 	while (m_run_thread.load())
 	{
-		m_mixer->Mix(realtimeBuffer, numBytesToRender >> 2);
+		m_mixer->Mix(realtimeBuffer, numBytesToMix / (sizeof(float) * 2));
+
+		// Convert the samples from float to short
+		s16 dest[MAX_AO_BUFFER];
+		for (u32 i = 0; i < numBytesToMix / sizeof(float); ++i)
+		{
+			dest[i] = CMixer::FloatToSigned16(realtimeBuffer[i]);
+		}
 
 		{
 		std::lock_guard<std::mutex> lk(soundCriticalSection);
-		ao_play(device, (char*)realtimeBuffer, numBytesToRender);
+		ao_play(device, (char*)realtimeBuffer, numBytesToOutput);
 		}
 
 		soundSyncEvent.Wait();

--- a/Source/Core/AudioCommon/AOSoundStream.cpp
+++ b/Source/Core/AudioCommon/AOSoundStream.cpp
@@ -49,7 +49,7 @@ void AOSound::SoundLoop()
 
 		{
 		std::lock_guard<std::mutex> lk(soundCriticalSection);
-		ao_play(device, (char*)realtimeBuffer, numBytesToOutput);
+		ao_play(device, (char*)dest, numBytesToOutput);
 		}
 
 		soundSyncEvent.Wait();

--- a/Source/Core/AudioCommon/AOSoundStream.h
+++ b/Source/Core/AudioCommon/AOSoundStream.h
@@ -14,6 +14,7 @@
 
 #if defined(HAVE_AO) && HAVE_AO
 #include <ao/ao.h>
+#define MAX_AO_BUFFER 1024 * 512
 #endif
 
 class AOSound final : public SoundStream
@@ -30,7 +31,7 @@ class AOSound final : public SoundStream
 	ao_sample_format format;
 	int default_driver;
 
-	short realtimeBuffer[1024 * 1024];
+	float realtimeBuffer[MAX_AO_BUFFER];
 
 public:
 	bool Start() override;

--- a/Source/Core/AudioCommon/AlsaSoundStream.cpp
+++ b/Source/Core/AudioCommon/AlsaSoundStream.cpp
@@ -120,7 +120,7 @@ bool AlsaSound::AlsaInit()
 		return false;
 	}
 
-	err = snd_pcm_hw_params_set_format(handle, hwparams, SND_PCM_FORMAT_S16_LE);
+	err = snd_pcm_hw_params_set_format(handle, hwparams, SND_PCM_FORMAT_FLOAT_LE);
 	if (err < 0)
 	{
 		ERROR_LOG(AUDIO, "Sample format not available: %s\n", snd_strerror(err));

--- a/Source/Core/AudioCommon/AlsaSoundStream.h
+++ b/Source/Core/AudioCommon/AlsaSoundStream.h
@@ -54,7 +54,7 @@ private:
 	bool AlsaInit();
 	void AlsaShutdown();
 
-	s16 mix_buffer[BUFFER_SIZE_MAX * CHANNEL_COUNT];
+	float mix_buffer[BUFFER_SIZE_MAX * CHANNEL_COUNT];
 	std::thread thread;
 	std::atomic<ALSAThreadStatus> m_thread_status;
 	std::condition_variable cv;

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -26,10 +26,17 @@ SoundStream* g_sound_stream = nullptr;
 
 static bool s_audio_dump_start = false;
 
+const std::map<std::string, std::pair<int, int> > AudioCommon::FILTER_PRESETS = {
+	{ FILTER_SINC_7PT, std::pair<int, int>{7, 512} },
+	{ FILTER_SINC_13PT, std::pair<int, int>{13, 65536} },
+	{ FILTER_SINC_27PT, std::pair<int, int>{27, 65536} },
+};
+
 namespace AudioCommon
 {
 	static const int AUDIO_VOLUME_MIN = 0;
 	static const int AUDIO_VOLUME_MAX = 100;
+	
 
 	SoundStream* InitSoundStream()
 	{

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -36,7 +36,6 @@ namespace AudioCommon
 {
 	static const int AUDIO_VOLUME_MIN = 0;
 	static const int AUDIO_VOLUME_MAX = 100;
-	
 
 	SoundStream* InitSoundStream()
 	{

--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <map>
+
 #include "AudioCommon/SoundStream.h"
 #include "Common/CommonTypes.h"
 
@@ -25,4 +27,5 @@ namespace AudioCommon
 	void IncreaseVolume(unsigned short offset);
 	void DecreaseVolume(unsigned short offset);
 	void ToggleMuteVolume();
+	extern const std::map<std::string, std::pair<int, int> > FILTER_PRESETS;
 }

--- a/Source/Core/AudioCommon/CoreAudioSoundStream.cpp
+++ b/Source/Core/AudioCommon/CoreAudioSoundStream.cpp
@@ -14,7 +14,7 @@ OSStatus CoreAudioSound::callback(void *inRefCon,
 {
 	for (UInt32 i = 0; i < ioData->mNumberBuffers; i++)
 		((CoreAudioSound *)inRefCon)->m_mixer->
-			Mix((short *)ioData->mBuffers[i].mData,
+			Mix((float *)ioData->mBuffers[i].mData,
 				ioData->mBuffers[i].mDataByteSize / 4);
 
 	return noErr;
@@ -48,7 +48,7 @@ bool CoreAudioSound::Start()
 	}
 
 	FillOutASBDForLPCM(format, m_mixer->GetSampleRate(),
-				2, 16, 16, false, false, false);
+				2, 32, 32, true, false, false);
 	err = AudioUnitSetProperty(audioUnit,
 				kAudioUnitProperty_StreamFormat,
 				kAudioUnitScope_Input, 0, &format,

--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -35,7 +35,7 @@ CMixer::CMixer(u32 BackendSampleRate)
 
 	//  no use trying to make wiimote speaker high quality
 	//  if the desire is there, use SincMixer with FIRFilter(5, 128, 0.125) is good enough
-	//  sources say ADPCM is x2 (3000 x 2 = 6000), but setting this input 
+	//  sources say ADPCM is x2 (3000 x 2 = 6000), but setting this input
 	//  rate to 6000 doesn't seem to produce the right result
 
 	m_wiimote_speaker_mixer = std::make_unique<LinearMixer>(this, 3000);
@@ -157,7 +157,7 @@ u32 CMixer::MixerFifo::Mix(float* samples, u32 numSamples, bool consider_frameli
 	{
 		float sample_l, sample_r;
 		Interpolate(indexR, &sample_l, &sample_r);
-		
+
 		samples[currentSample + 1] += sample_l * lvolume;
 		samples[currentSample] += sample_r * rvolume;
 
@@ -197,7 +197,7 @@ u32 CMixer::Mix(float* samples, u32 num_samples, bool consider_framelimit)
 		memset(samples, 0, num_samples * 2 * sizeof(s16));
 		return num_samples;
 	}
-	
+
 	m_dma_mixer->Mix(samples, num_samples, consider_framelimit);
 	m_streaming_mixer->Mix(samples, num_samples, consider_framelimit);
 	m_wiimote_speaker_mixer->Mix(samples, num_samples, consider_framelimit);
@@ -389,31 +389,31 @@ void CMixer::FIRFilter::PopulateFilterDeltas()
 
 void CMixer::FIRFilter::PopulateFilterCoeff()
 {
-		m_filter[0] = (float)(2 * m_lowpass_frequency);
-		double inv_I0_beta = 1.0 / ModBessel0th(m_kaiser_beta);
-		double inv_size = 1.0 / (m_wing_size - 1);
-		for (u32 i = 1; i < m_wing_size; ++i)
-		{
-			double offset = M_PI * (double)i / (double)m_samples_per_crossing;
-			double sinc = sin(offset * 2 * m_lowpass_frequency) / offset;
-			double radicand = (double)i * inv_size;
-			radicand = 1.0 - radicand * radicand;
-			radicand = (radicand < 0.0) ? 0.0 : radicand;
-			m_filter[i] = (float)(sinc * ModBessel0th(m_kaiser_beta * sqrt(radicand)) * inv_I0_beta);
-		}
+	m_filter[0] = (float)(2 * m_lowpass_frequency);
+	double inv_I0_beta = 1.0 / ModBessel0th(m_kaiser_beta);
+	double inv_size = 1.0 / (m_wing_size - 1);
+	for (u32 i = 1; i < m_wing_size; ++i)
+	{
+		double offset = M_PI * (double)i / (double)m_samples_per_crossing;
+		double sinc = sin(offset * 2 * m_lowpass_frequency) / offset;
+		double radicand = (double)i * inv_size;
+		radicand = 1.0 - radicand * radicand;
+		radicand = (radicand < 0.0) ? 0.0 : radicand;
+		m_filter[i] = (float)(sinc * ModBessel0th(m_kaiser_beta * sqrt(radicand)) * inv_I0_beta);
+	}
 
-		double dc_gain = 0;
-		for (u32 i = m_samples_per_crossing; i < m_wing_size; i += m_samples_per_crossing)
-		{
-			dc_gain += m_filter[i];
-		}
-		dc_gain *= 2;
-		dc_gain += m_filter[0];
-		dc_gain = 1.0 / dc_gain;
+	double dc_gain = 0;
+	for (u32 i = m_samples_per_crossing; i < m_wing_size; i += m_samples_per_crossing)
+	{
+		dc_gain += m_filter[i];
+	}
+	dc_gain *= 2;
+	dc_gain += m_filter[0];
+	dc_gain = 1.0 / dc_gain;
 
-		for (u32 i = 0; i < m_wing_size; ++i) {
-			m_filter[i] = (float)(m_filter[i] * dc_gain);
-		}
+	for (u32 i = 0; i < m_wing_size; ++i) {
+		m_filter[i] = (float)(m_filter[i] * dc_gain);
+	}
 }
 
 void CMixer::FIRFilter::CheckFilterCache()

--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -3,10 +3,12 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include <sstream>
 
 #include "AudioCommon/AudioCommon.h"
 #include "AudioCommon/Mixer.h"
 #include "Common/CPUDetect.h"
+#include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -15,34 +17,111 @@
 // UGLINESS
 #include "Core/PowerPC/PowerPC.h"
 
-#if _M_SSE >= 0x301 && !(defined __GNUC__ && !defined __SSSE3__)
-#include <tmmintrin.h>
-#endif
+//TODO put into constants header file
+#define M_PI	3.14159265358979323846
 
-CMixer::CMixer(unsigned int BackendSampleRate)
-	: m_dma_mixer(this, 32000)
-	, m_streaming_mixer(this, 48000)
-	, m_wiimote_speaker_mixer(this, 3000)
-	, m_sampleRate(BackendSampleRate)
+#define MAX_FREQ_SHIFT  200  // per 32000 Hz
+#define CONTROL_FACTOR  0.2f // in freq_shift per fifo size offset
+#define CONTROL_AVG     32
+
+CMixer::CMixer(u32 BackendSampleRate)
+	: m_sampleRate(BackendSampleRate)
 	, m_log_dtk_audio(false)
 	, m_log_dsp_audio(false)
 	, m_speed(0)
 {
+	std::string preset = SConfig::GetInstance().sFilterPreset;
+	u32 samples_per_crossing, num_crossings;
+
+	//  no use trying to make wiimote speaker high quality
+	//  if the desire is there, use SincMixer with FIRFilter(5, 128, 0.125) is good enough
+	//  sources say ADPCM is x2 (3000 x 2 = 6000), but setting this input 
+	//  rate to 6000 doesn't seem to produce the right result
+
+	m_wiimote_speaker_mixer = std::make_unique<LinearMixer>(this, 3000);
+
+	if (preset == FILTER_LINEAR) {
+		m_dma_mixer = std::make_unique<LinearMixer>(this, 32000);
+		m_streaming_mixer = std::make_unique<LinearMixer>(this, 48000);
+	} else {
+		if (preset == FILTER_SINC_CUSTOM) {
+			num_crossings = SConfig::GetInstance().iFilterTaps;
+			samples_per_crossing = SConfig::GetInstance().iFilterResolution;
+		}
+		else {
+			num_crossings = AudioCommon::FILTER_PRESETS.at(preset).first;
+			samples_per_crossing = AudioCommon::FILTER_PRESETS.at(preset).second;
+		}
+		std::shared_ptr<FIRFilter> firfilter(new FIRFilter(num_crossings, samples_per_crossing, 0.45));
+
+		m_dma_mixer = std::make_unique<SincMixer>(this, 32000, firfilter);
+		m_streaming_mixer = std::make_unique<SincMixer>(this, 48000, firfilter);
+	}
+
 	INFO_LOG(AUDIO_INTERFACE, "Mixer is initialized");
 }
 
-// Executed from sound stream thread
-unsigned int CMixer::MixerFifo::Mix(short* samples, unsigned int numSamples, bool consider_framelimit)
-{
-	unsigned int currentSample = 0;
+void CMixer::LinearMixer::Interpolate(u32 index, float* output_l, float* output_r) {
+	float l1 = m_floats[index & INDEX_MASK];
+	float r1 = m_floats[(index + 1) & INDEX_MASK];
+	float l2 = m_floats[(index + 2) & INDEX_MASK];
+	float r2 = m_floats[(index + 3) & INDEX_MASK];
 
-	// Cache access in non-volatile variable
-	// This is the only function changing the read value, so it's safe to
-	// cache it locally although it's written here.
-	// The writing pointer will be modified outside, but it will only increase,
-	// so we will just ignore new written data while interpolating.
-	// Without this cache, the compiler wouldn't be allowed to optimize the
-	// interpolation loop.
+	*output_l = lerp(l1, l2, m_frac);
+	*output_r = lerp(r1, r2, m_frac);
+}
+
+void CMixer::SincMixer::Interpolate(u32 index, float* output_l, float* output_r) {
+	double left_channel = 0.0, right_channel = 0.0;
+
+	float* filter = m_firfilter->m_filter;
+	float* deltas = m_firfilter->m_deltas;
+	const u32 samples_per_crossing = m_firfilter->m_samples_per_crossing;
+	const u32 wing_size = m_firfilter->m_wing_size;
+
+	double left_frac = (m_frac * samples_per_crossing);
+	u32 left_index = (u32)left_frac;
+	left_frac = left_frac - left_index;
+
+	u32 current_index = index;
+	while (left_index < wing_size)
+	{
+		double impulse = filter[left_index];
+		impulse += deltas[left_index] * left_frac;
+
+		left_channel += m_floats[current_index & INDEX_MASK] * impulse;
+		right_channel += m_floats[(current_index + 1) & INDEX_MASK] * impulse;
+
+		left_index += samples_per_crossing;
+		current_index -= 2;
+	}
+
+	double right_frac = (1 - m_frac) * samples_per_crossing;
+	u32 right_index = (u32)right_frac;
+	right_frac = right_frac - right_index;
+
+	current_index = index + 2;
+	while (right_index < wing_size)
+	{
+		double impulse = filter[right_index];
+		impulse += deltas[right_index] * right_frac;
+
+		left_channel += m_floats[current_index & INDEX_MASK] * impulse;
+		right_channel += m_floats[(current_index + 1) & INDEX_MASK] * impulse;
+
+		right_index += samples_per_crossing;
+		current_index += 2;
+	}
+
+	*output_l = (float)left_channel;
+	*output_r = (float)right_channel;
+}
+
+// Executed from sound stream thread
+u32 CMixer::MixerFifo::Mix(float* samples, u32 numSamples, bool consider_framelimit)
+{
+	u32 currentSample = 0;
+
 	u32 indexR = m_indexR.load();
 	u32 indexW = m_indexW.load();
 
@@ -50,14 +129,9 @@ unsigned int CMixer::MixerFifo::Mix(short* samples, unsigned int numSamples, boo
 	low_waterwark = std::min(low_waterwark, MAX_SAMPLES / 2);
 
 	float numLeft = (float)(((indexW - indexR) & INDEX_MASK) / 2);
-	m_numLeftI = (numLeft + m_numLeftI*(CONTROL_AVG-1)) / CONTROL_AVG;
+	m_numLeftI = (numLeft + m_numLeftI*(CONTROL_AVG - 1)) / CONTROL_AVG;
 	float offset = (m_numLeftI - low_waterwark) * CONTROL_FACTOR;
-	if (offset > MAX_FREQ_SHIFT) offset = MAX_FREQ_SHIFT;
-	if (offset < -MAX_FREQ_SHIFT) offset = -MAX_FREQ_SHIFT;
-
-	//render numleft sample pairs to samples[]
-	//advance indexR with sample position
-	//remember fractional offset
+	offset = MathUtil::Clamp(offset, (float)-MAX_FREQ_SHIFT, (float)MAX_FREQ_SHIFT);
 
 	float emulationspeed = SConfig::GetInstance().m_EmulationSpeed;
 	float aid_sample_rate = m_input_sample_rate + offset;
@@ -66,48 +140,43 @@ unsigned int CMixer::MixerFifo::Mix(short* samples, unsigned int numSamples, boo
 		aid_sample_rate = aid_sample_rate * emulationspeed;
 	}
 
-	const u32 ratio = (u32)(65536.0f * aid_sample_rate / (float)m_mixer->m_sampleRate);
+	const float ratio = aid_sample_rate / (float)m_mixer->m_sampleRate;
 
-	s32 lvolume = m_LVolume.load();
-	s32 rvolume = m_RVolume.load();
+	float lvolume = m_LVolume.load();
+	float rvolume = m_RVolume.load();
+	u32 floatI = m_floatI.load();
+	for (; ((indexW - floatI) & INDEX_MASK) > 0; ++floatI) {
+		m_floats[floatI & INDEX_MASK] = Signed16ToFloat(Common::swap16(m_buffer[floatI & INDEX_MASK]));
 
-	// TODO: consider a higher-quality resampling algorithm.
-	for (; currentSample < numSamples * 2 && ((indexW-indexR) & INDEX_MASK) > 2; currentSample += 2)
-	{
-		u32 indexR2 = indexR + 2; //next sample
-
-		s16 l1 = Common::swap16(m_buffer[indexR & INDEX_MASK]); //current
-		s16 l2 = Common::swap16(m_buffer[indexR2 & INDEX_MASK]); //next
-		int sampleL = ((l1 << 16) + (l2 - l1) * (u16)m_frac) >> 16;
-		sampleL = (sampleL * lvolume) >> 8;
-		sampleL += samples[currentSample + 1];
-		samples[currentSample + 1] = MathUtil::Clamp(sampleL, -32767, 32767);
-
-		s16 r1 = Common::swap16(m_buffer[(indexR + 1) & INDEX_MASK]); //current
-		s16 r2 = Common::swap16(m_buffer[(indexR2 + 1) & INDEX_MASK]); //next
-		int sampleR = ((r1 << 16) + (r2 - r1) * (u16)m_frac) >> 16;
-		sampleR = (sampleR * rvolume) >> 8;
-		sampleR += samples[currentSample];
-		samples[currentSample] = MathUtil::Clamp(sampleR, -32767, 32767);
-
-		m_frac += ratio;
-		indexR += 2 * (u16)(m_frac >> 16);
-		m_frac &= 0xffff;
 	}
 
+	m_floatI.store(floatI);
+
+	// TODO: consider a higher-quality resampling algorithm.
+	for (; currentSample < numSamples * 2 && ((indexW - indexR) & INDEX_MASK) > (m_filter_length + 5) * 2; currentSample += 2)
+	{
+		float sample_l, sample_r;
+		Interpolate(indexR, &sample_l, &sample_r);
+		
+		samples[currentSample + 1] += sample_l * lvolume;
+		samples[currentSample] += sample_r * rvolume;
+
+		m_frac += ratio;
+		indexR += 2 * (s32)m_frac;
+		m_frac = m_frac - (s32)m_frac;
+
+	}
+
+
 	// Padding
-	short s[2];
-	s[0] = Common::swap16(m_buffer[(indexR - 1) & INDEX_MASK]);
-	s[1] = Common::swap16(m_buffer[(indexR - 2) & INDEX_MASK]);
-	s[0] = (s[0] * rvolume) >> 8;
-	s[1] = (s[1] * lvolume) >> 8;
+	float s[2];
+	s[0] = m_floats[(indexR - 1) & INDEX_MASK] * rvolume;
+	s[1] = m_floats[(indexR - 2) & INDEX_MASK] * lvolume;
+
 	for (; currentSample < numSamples * 2; currentSample += 2)
 	{
-		int sampleR = MathUtil::Clamp(s[0] + samples[currentSample + 0], -32767, 32767);
-		int sampleL = MathUtil::Clamp(s[1] + samples[currentSample + 1], -32767, 32767);
-
-		samples[currentSample + 0] = sampleR;
-		samples[currentSample + 1] = sampleL;
+		samples[currentSample] += s[0];
+		samples[currentSample + 1] += s[1];
 	}
 
 	// Flush cached variable
@@ -116,26 +185,34 @@ unsigned int CMixer::MixerFifo::Mix(short* samples, unsigned int numSamples, boo
 	return numSamples;
 }
 
-unsigned int CMixer::Mix(short* samples, unsigned int num_samples, bool consider_framelimit)
+u32 CMixer::Mix(float* samples, u32 num_samples, bool consider_framelimit)
 {
 	if (!samples)
 		return 0;
 
-	memset(samples, 0, num_samples * 2 * sizeof(short));
+	memset(samples, 0, num_samples * 2 * sizeof(float));
 
 	if (PowerPC::GetState() != PowerPC::CPU_RUNNING)
 	{
-		// Silence
+		memset(samples, 0, num_samples * 2 * sizeof(s16));
 		return num_samples;
 	}
+	
+	m_dma_mixer->Mix(samples, num_samples, consider_framelimit);
+	m_streaming_mixer->Mix(samples, num_samples, consider_framelimit);
+	m_wiimote_speaker_mixer->Mix(samples, num_samples, consider_framelimit);
 
-	m_dma_mixer.Mix(samples, num_samples, consider_framelimit);
-	m_streaming_mixer.Mix(samples, num_samples, consider_framelimit);
-	m_wiimote_speaker_mixer.Mix(samples, num_samples, consider_framelimit);
+	// clamp values
+	for (u32 i = 0; i < num_samples * 2; i += 2)
+	{
+		samples[i + 1] = MathUtil::Clamp(samples[i + 1], -1.f, 1.f);
+		samples[i] = MathUtil::Clamp(samples[i], -1.f, 1.f);
+	}
+
 	return num_samples;
 }
 
-void CMixer::MixerFifo::PushSamples(const short *samples, unsigned int num_samples)
+void CMixer::MixerFifo::PushSamples(const s16 *samples, u32 num_samples)
 {
 	// Cache access in non-volatile variable
 	// indexR isn't allowed to cache in the audio throttling loop as it
@@ -150,7 +227,7 @@ void CMixer::MixerFifo::PushSamples(const short *samples, unsigned int num_sampl
 	// AyuanX: Actual re-sampling work has been moved to sound thread
 	// to alleviate the workload on main thread
 	// and we simply store raw data here to make fast mem copy
-	int over_bytes = num_samples * 4 - (MAX_SAMPLES * 2 - (indexW & INDEX_MASK)) * sizeof(short);
+	s32 over_bytes = num_samples * 4 - (MAX_SAMPLES * 2 - (indexW & INDEX_MASK)) * sizeof(short);
 	if (over_bytes > 0)
 	{
 		memcpy(&m_buffer[indexW & INDEX_MASK], samples, num_samples * 4 - over_bytes);
@@ -164,56 +241,56 @@ void CMixer::MixerFifo::PushSamples(const short *samples, unsigned int num_sampl
 	m_indexW.fetch_add(num_samples * 2);
 }
 
-void CMixer::PushSamples(const short *samples, unsigned int num_samples)
+void CMixer::PushSamples(const s16 *samples, u32 num_samples)
 {
-	m_dma_mixer.PushSamples(samples, num_samples);
+	m_dma_mixer->PushSamples(samples, num_samples);
 	if (m_log_dsp_audio)
 		m_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples);
 }
 
-void CMixer::PushStreamingSamples(const short *samples, unsigned int num_samples)
+void CMixer::PushStreamingSamples(const s16 *samples, u32 num_samples)
 {
-	m_streaming_mixer.PushSamples(samples, num_samples);
+	m_streaming_mixer->PushSamples(samples, num_samples);
 	if (m_log_dtk_audio)
 		m_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples);
 }
 
-void CMixer::PushWiimoteSpeakerSamples(const short *samples, unsigned int num_samples, unsigned int sample_rate)
+void CMixer::PushWiimoteSpeakerSamples(const s16 *samples, u32 num_samples, u32 sample_rate)
 {
-	short samples_stereo[MAX_SAMPLES * 2];
+	s16 samples_stereo[MAX_SAMPLES * 2];
 
 	if (num_samples < MAX_SAMPLES)
 	{
-		m_wiimote_speaker_mixer.SetInputSampleRate(sample_rate);
+		m_wiimote_speaker_mixer->SetInputSampleRate(sample_rate);
 
-		for (unsigned int i = 0; i < num_samples; ++i)
+		for (u32 i = 0; i < num_samples; ++i)
 		{
-			samples_stereo[i * 2] = Common::swap16(samples[i]);
-			samples_stereo[i * 2 + 1] = Common::swap16(samples[i]);
+			samples_stereo[i * 2 + 1] = samples_stereo[i * 2] =
+				Common::swap16(samples[i]);
 		}
 
-		m_wiimote_speaker_mixer.PushSamples(samples_stereo, num_samples);
+		m_wiimote_speaker_mixer->PushSamples(samples_stereo, num_samples);
 	}
 }
 
-void CMixer::SetDMAInputSampleRate(unsigned int rate)
+void CMixer::SetDMAInputSampleRate(u32 rate)
 {
-	m_dma_mixer.SetInputSampleRate(rate);
+	m_dma_mixer->SetInputSampleRate(rate);
 }
 
-void CMixer::SetStreamInputSampleRate(unsigned int rate)
+void CMixer::SetStreamInputSampleRate(u32 rate)
 {
-	m_streaming_mixer.SetInputSampleRate(rate);
+	m_streaming_mixer->SetInputSampleRate(rate);
 }
 
-void CMixer::SetStreamingVolume(unsigned int lvolume, unsigned int rvolume)
+void CMixer::SetStreamingVolume(u32 lvolume, u32 rvolume)
 {
-	m_streaming_mixer.SetVolume(lvolume, rvolume);
+	m_streaming_mixer->SetVolume(lvolume, rvolume);
 }
 
-void CMixer::SetWiimoteSpeakerVolume(unsigned int lvolume, unsigned int rvolume)
+void CMixer::SetWiimoteSpeakerVolume(u32 lvolume, u32 rvolume)
 {
-	m_wiimote_speaker_mixer.SetVolume(lvolume, rvolume);
+	m_wiimote_speaker_mixer->SetVolume(lvolume, rvolume);
 }
 
 void CMixer::StartLogDTKAudio(const std::string& filename)
@@ -274,13 +351,149 @@ void CMixer::StopLogDSPAudio()
 	}
 }
 
-void CMixer::MixerFifo::SetInputSampleRate(unsigned int rate)
+void CMixer::MixerFifo::SetInputSampleRate(u32 rate)
 {
 	m_input_sample_rate = rate;
 }
 
-void CMixer::MixerFifo::SetVolume(unsigned int lvolume, unsigned int rvolume)
+void CMixer::MixerFifo::SetVolume(u32 lvolume, u32 rvolume)
 {
-	m_LVolume.store(lvolume + (lvolume >> 7));
-	m_RVolume.store(rvolume + (rvolume >> 7));
+	m_LVolume.store(lvolume / 256.0f);
+	m_RVolume.store(rvolume / 256.0f);
+}
+
+double CMixer::FIRFilter::ModBessel0th(const double x) const
+{
+	double sum = 1.0;
+	s32 factorial_store = 1;
+	double half_x = x / 2.0;
+	double previous = 1.0;
+	do {
+		double temp = half_x / (double)factorial_store;
+		temp *= temp;
+		previous *= temp;
+		sum += previous;
+		factorial_store++;
+	} while (previous >= BESSEL_EPSILON * sum);
+	return sum;
+}
+
+void CMixer::FIRFilter::PopulateFilterDeltas()
+{
+	for (u32 i = 0; i < m_wing_size - 1; ++i)
+	{
+		m_deltas[i] = m_filter[i + 1] - m_filter[i];
+	}
+	m_deltas[m_wing_size - 1] = -m_filter[m_wing_size - 1];
+}
+
+void CMixer::FIRFilter::PopulateFilterCoeff()
+{
+		m_filter[0] = (float)(2 * m_lowpass_frequency);
+		double inv_I0_beta = 1.0 / ModBessel0th(m_kaiser_beta);
+		double inv_size = 1.0 / (m_wing_size - 1);
+		for (u32 i = 1; i < m_wing_size; ++i)
+		{
+			double offset = M_PI * (double)i / (double)m_samples_per_crossing;
+			double sinc = sin(offset * 2 * m_lowpass_frequency) / offset;
+			double radicand = (double)i * inv_size;
+			radicand = 1.0 - radicand * radicand;
+			radicand = (radicand < 0.0) ? 0.0 : radicand;
+			m_filter[i] = (float)(sinc * ModBessel0th(m_kaiser_beta * sqrt(radicand)) * inv_I0_beta);
+		}
+
+		double dc_gain = 0;
+		for (u32 i = m_samples_per_crossing; i < m_wing_size; i += m_samples_per_crossing)
+		{
+			dc_gain += m_filter[i];
+		}
+		dc_gain *= 2;
+		dc_gain += m_filter[0];
+		dc_gain = 1.0 / dc_gain;
+
+		for (u32 i = 0; i < m_wing_size; ++i) {
+			m_filter[i] = (float)(m_filter[i] * dc_gain);
+		}
+}
+
+void CMixer::FIRFilter::CheckFilterCache()
+{
+	const std::string audio_cache_path = File::GetUserPath(D_CACHE_IDX) + "Audio/";
+
+	if (!File::IsDirectory(audio_cache_path))
+	{
+		File::SetCurrentDir(File::GetUserPath(D_CACHE_IDX));
+		if (!File::CreateDir("Audio"))
+		{
+			WARN_LOG(AUDIO, "failed to create audio cache folder: %s", audio_cache_path.c_str());
+		}
+		File::SetCurrentDir(File::GetExeDirectory());
+	}
+
+	std::stringstream filter_specs;
+	filter_specs << m_num_crossings << "-"
+		<< m_samples_per_crossing << "-"
+		<< m_kaiser_beta << "-"
+		<< m_lowpass_frequency;
+
+	std::string filter_filename = audio_cache_path + "filter-" + filter_specs.str() + ".cache";
+	std::string deltas_filename = audio_cache_path + "deltas-" + filter_specs.str() + ".cache";
+
+	bool create_filter = true;
+	bool create_deltas = true;
+
+	if (GetFilterFromFile(filter_filename, m_filter))
+	{
+		INFO_LOG(AUDIO_INTERFACE, "filter successfully retrieved from cache: %s", filter_filename.c_str());
+		create_filter = false;
+
+		if (GetFilterFromFile(deltas_filename, m_deltas))
+		{
+			create_deltas = false;
+		}
+	}
+	else {
+		INFO_LOG(AUDIO_INTERFACE, "filter not retrieved from cache: %s", filter_filename.c_str());
+	}
+
+	if (create_filter)
+	{
+		PopulateFilterCoeff();
+
+		if (!PutFilterToFile(filter_filename, m_filter))
+		{
+			WARN_LOG(AUDIO_INTERFACE, "did not successfully store filter to cache: %s", filter_filename.c_str());
+		}
+	}
+
+	if (create_deltas)
+	{
+		PopulateFilterDeltas();
+
+		if (!PutFilterToFile(deltas_filename, m_deltas))
+		{
+			WARN_LOG(AUDIO_INTERFACE, "did not successfully store deltas to cache: %s", deltas_filename.c_str());
+		}
+	}
+}
+
+bool CMixer::FIRFilter::GetFilterFromFile(const std::string &filename, float* filter)
+{
+	File::IOFile cache(filename, "rb");
+	u32 cache_count = (u32)cache.GetSize() / sizeof(float);
+	if (cache_count != m_wing_size)
+	{
+		return false;
+	}
+	bool success = cache.ReadArray<float>(filter, m_wing_size);
+	cache.Close();
+	return success;
+}
+
+bool CMixer::FIRFilter::PutFilterToFile(const std::string &filename, float* filter)
+{
+	File::IOFile cache(filename, "wb");
+	bool success = cache.WriteArray<float>(filter, m_wing_size);
+	success = success && cache.Flush() && cache.Close();
+	return success;
 }

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <atomic>
 #include <array>
+#include <atomic>
 #include <cstring>
 #include <mutex>
 

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -96,7 +96,7 @@ protected:
 		const u32 m_num_crossings;
 		const u32 m_samples_per_crossing;
 		const u32 m_wing_size;
-		
+
 	};
 
 	class MixerFifo
@@ -115,8 +115,6 @@ protected:
 			, m_firfilter(filter)
 			, m_filter_length((filter) ? ((filter->m_num_crossings - 1) / 2) : 1) // one-sided length of filter
 		{
-			m_buffer.fill(0);
-			m_floats.fill(0.f);
 		}
 		virtual void Interpolate(u32 index, float* output_l, float* output_r) = 0;
 		void PushSamples(const s16* samples, u32 num_samples);
@@ -127,8 +125,8 @@ protected:
 	protected:
 		CMixer* m_mixer;
 		u32 m_input_sample_rate;
-		std::array<s16, MAX_SAMPLES * 2> m_buffer;
-		std::array<float, MAX_SAMPLES * 2> m_floats;
+		std::array<s16, MAX_SAMPLES * 2> m_buffer{};
+		std::array<float, MAX_SAMPLES * 2> m_floats{};
 		std::atomic<u32> m_indexW;
 		std::atomic<u32> m_indexR;
 		std::atomic<u32> m_floatI;
@@ -160,7 +158,7 @@ protected:
 		void Interpolate(u32 index, float* output_l, float* output_r);
 
 	};
-	
+
 	std::unique_ptr<MixerFifo> m_dma_mixer;
 	std::unique_ptr<MixerFifo> m_streaming_mixer;
 	std::unique_ptr<MixerFifo> m_wiimote_speaker_mixer;

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <atomic>
+#include <array>
 #include <cstring>
 #include <mutex>
 
@@ -14,29 +15,27 @@
 #define MAX_SAMPLES     (1024 * 4) // 128 ms
 #define INDEX_MASK      (MAX_SAMPLES * 2 - 1)
 
-#define MAX_FREQ_SHIFT  200  // per 32000 Hz
-#define CONTROL_FACTOR  0.2f // in freq_shift per fifo size offset
-#define CONTROL_AVG     32
+#define BESSEL_EPSILON			1e-21
 
 class CMixer
 {
 public:
-	CMixer(unsigned int BackendSampleRate);
+	CMixer(u32 BackendSampleRate);
 	virtual ~CMixer() {}
 
 	// Called from audio threads
-	virtual unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit = true);
+	u32 Mix(float* samples, u32 numSamples, bool consider_framelimit = true);
 
 	// Called from main thread
-	virtual void PushSamples(const short* samples, unsigned int num_samples);
-	virtual void PushStreamingSamples(const short* samples, unsigned int num_samples);
-	virtual void PushWiimoteSpeakerSamples(const short* samples, unsigned int num_samples, unsigned int sample_rate);
-	unsigned int GetSampleRate() const { return m_sampleRate; }
+	virtual void PushSamples(const s16* samples, u32 num_samples);
+	virtual void PushStreamingSamples(const s16* samples, u32 num_samples);
+	virtual void PushWiimoteSpeakerSamples(const s16* samples, u32 num_samples, u32 sample_rate);
+	u32 GetSampleRate() const { return m_sampleRate; }
 
-	void SetDMAInputSampleRate(unsigned int rate);
-	void SetStreamInputSampleRate(unsigned int rate);
-	void SetStreamingVolume(unsigned int lvolume, unsigned int rvolume);
-	void SetWiimoteSpeakerVolume(unsigned int lvolume, unsigned int rvolume);
+	void SetDMAInputSampleRate(u32 rate);
+	void SetStreamInputSampleRate(u32 rate);
+	void SetStreamingVolume(u32 lvolume, u32 rvolume);
+	void SetWiimoteSpeakerVolume(u32 lvolume, u32 rvolume);
 
 	void StartLogDTKAudio(const std::string& filename);
 	void StopLogDTKAudio();
@@ -47,41 +46,125 @@ public:
 	float GetCurrentSpeed() const { return m_speed.load(); }
 	void UpdateSpeed(float val) { m_speed.store(val); }
 
+	static inline float lerp(float sample1, float sample2, float fraction) {
+		return (1.f - fraction) * sample1 + fraction * sample2;
+	}
+
+	// converts [-32768, 32767] -> [-1.0, 1.0]
+	static inline float Signed16ToFloat(const s16 s)
+	{
+		return (s > 0) ? (float)(s / (float)0x7fff) : (float)(s / (float)0x8000);
+	}
+
+	// converts [-1.0, 1.0] -> [-32768, 32767]
+	static inline s16 FloatToSigned16(const float f)
+	{
+		return (f > 0) ? (s16)(f * 0x7fff) : (s16)(f * 0x8000);
+	}
+
 protected:
-	class MixerFifo {
+	class FIRFilter
+	{
+		void PopulateFilterCoeff();
+		void PopulateFilterDeltas();
+		void CheckFilterCache();
+		bool GetFilterFromFile(const std::string &filename, float* filter);
+		bool PutFilterToFile(const std::string &filename, float* filter);
+		double ModBessel0th(const double x) const;
+		const double m_kaiser_beta;
+		const double m_lowpass_frequency;
 	public:
-		MixerFifo(CMixer *mixer, unsigned sample_rate)
+		FIRFilter(u32 nz = 13, u32 nl = 65536, double fc = 0.45, double beta = 7.0)
+			: m_num_crossings(nz)
+			, m_samples_per_crossing(nl)
+			, m_kaiser_beta(beta)
+			, m_lowpass_frequency(fc)
+			, m_wing_size(m_samples_per_crossing * (m_num_crossings - 1) / 2)
+		{
+			m_filter = (float*)malloc(m_wing_size * sizeof(float));
+			m_deltas = (float*)malloc(m_wing_size * sizeof(float));
+			CheckFilterCache();
+		}
+		~FIRFilter()
+		{
+			free(m_filter);
+			free(m_deltas);
+			m_filter = m_deltas = nullptr;
+		}
+		float* m_filter;
+		float* m_deltas;
+		const u32 m_num_crossings;
+		const u32 m_samples_per_crossing;
+		const u32 m_wing_size;
+		
+	};
+
+	class MixerFifo
+	{
+	public:
+		MixerFifo(CMixer *mixer, u32 sample_rate, std::shared_ptr<FIRFilter> filter)
 			: m_mixer(mixer)
 			, m_input_sample_rate(sample_rate)
 			, m_indexW(0)
 			, m_indexR(0)
-			, m_LVolume(256)
-			, m_RVolume(256)
-			, m_numLeftI(0.0f)
-			, m_frac(0)
+			, m_floatI(0)
+			, m_LVolume(1.f)
+			, m_RVolume(1.f)
+			, m_numLeftI(0.f)
+			, m_frac(0.f)
+			, m_firfilter(filter)
+			, m_filter_length((filter) ? ((filter->m_num_crossings - 1) / 2) : 1) // one-sided length of filter
 		{
-			memset(m_buffer, 0, sizeof(m_buffer));
+			m_buffer.fill(0);
+			m_floats.fill(0.f);
 		}
-		void PushSamples(const short* samples, unsigned int num_samples);
-		unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit = true);
-		void SetInputSampleRate(unsigned int rate);
-		void SetVolume(unsigned int lvolume, unsigned int rvolume);
-	private:
-		CMixer *m_mixer;
-		unsigned m_input_sample_rate;
-		short m_buffer[MAX_SAMPLES * 2];
+		virtual void Interpolate(u32 index, float* output_l, float* output_r) = 0;
+		void PushSamples(const s16* samples, u32 num_samples);
+		unsigned int Mix(float* samples, u32 numSamples, bool consider_framelimit = true);
+		void SetInputSampleRate(u32 rate);
+		void SetVolume(u32 lvolume, u32 rvolume);
+		bool m_debug;
+	protected:
+		CMixer* m_mixer;
+		u32 m_input_sample_rate;
+		std::array<s16, MAX_SAMPLES * 2> m_buffer;
+		std::array<float, MAX_SAMPLES * 2> m_floats;
 		std::atomic<u32> m_indexW;
 		std::atomic<u32> m_indexR;
+		std::atomic<u32> m_floatI;
 		// Volume ranges from 0-256
-		std::atomic<s32> m_LVolume;
-		std::atomic<s32> m_RVolume;
+		std::atomic<float> m_LVolume;
+		std::atomic<float> m_RVolume;
 		float m_numLeftI;
-		u32 m_frac;
+		float m_frac;
+		std::shared_ptr<FIRFilter> m_firfilter;
+		u32 m_filter_length;
 	};
-	MixerFifo m_dma_mixer;
-	MixerFifo m_streaming_mixer;
-	MixerFifo m_wiimote_speaker_mixer;
-	unsigned int m_sampleRate;
+
+	class LinearMixer : public MixerFifo
+	{
+	public:
+		LinearMixer(CMixer* mixer, u32 sample_rate)
+			: MixerFifo(mixer, sample_rate, nullptr)
+		{}
+		void Interpolate(u32 index, float* output_l, float* output_r);
+
+	};
+
+	class SincMixer : public MixerFifo
+	{
+	public:
+		SincMixer(CMixer* mixer, u32 sample_rate, std::shared_ptr<FIRFilter> filter)
+			: MixerFifo(mixer, sample_rate, filter)
+		{}
+		void Interpolate(u32 index, float* output_l, float* output_r);
+
+	};
+	
+	std::unique_ptr<MixerFifo> m_dma_mixer;
+	std::unique_ptr<MixerFifo> m_streaming_mixer;
+	std::unique_ptr<MixerFifo> m_wiimote_speaker_mixer;
+	u32 m_sampleRate;
 
 	WaveFileWriter m_wave_writer_dtk;
 	WaveFileWriter m_wave_writer_dsp;

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -71,15 +71,13 @@ protected:
 		bool GetFilterFromFile(const std::string &filename, float* filter);
 		bool PutFilterToFile(const std::string &filename, float* filter);
 		double ModBessel0th(const double x) const;
-		const double m_kaiser_beta;
-		const double m_lowpass_frequency;
 	public:
 		FIRFilter(u32 nz = 13, u32 nl = 65536, double fc = 0.45, double beta = 7.0)
 			: m_num_crossings(nz)
 			, m_samples_per_crossing(nl)
 			, m_kaiser_beta(beta)
+			, m_wing_size(nl * (nz - 1) / 2)
 			, m_lowpass_frequency(fc)
-			, m_wing_size(m_samples_per_crossing * (m_num_crossings - 1) / 2)
 		{
 			m_filter = (float*)malloc(m_wing_size * sizeof(float));
 			m_deltas = (float*)malloc(m_wing_size * sizeof(float));
@@ -96,7 +94,9 @@ protected:
 		const u32 m_num_crossings;
 		const u32 m_samples_per_crossing;
 		const u32 m_wing_size;
-
+	private:
+		const double m_kaiser_beta;
+		const double m_lowpass_frequency;
 	};
 
 	class MixerFifo

--- a/Source/Core/AudioCommon/NullSoundStream.cpp
+++ b/Source/Core/AudioCommon/NullSoundStream.cpp
@@ -23,10 +23,10 @@ void NullSound::SetVolume(int volume)
 void NullSound::Update()
 {
 	// num_samples_to_render in this update - depends on SystemTimers::AUDIO_DMA_PERIOD.
-	constexpr u32 stereo_16_bit_size = 4;
+	constexpr u32 stereo_float_bit_size = 8;
 	constexpr u32 dma_length = 32;
-	const u64 audio_dma_period = SystemTimers::GetTicksPerSecond() / (AudioInterface::GetAIDSampleRate() * stereo_16_bit_size / dma_length);
-	const u64 ais_samples_per_second = 48000 * stereo_16_bit_size;
+	const u64 audio_dma_period = SystemTimers::GetTicksPerSecond() / (AudioInterface::GetAIDSampleRate() * stereo_float_bit_size / dma_length);
+	const u64 ais_samples_per_second = 48000 * stereo_float_bit_size;
 	const u64 num_samples_to_render = (audio_dma_period * ais_samples_per_second) / SystemTimers::GetTicksPerSecond();
 
 	m_mixer->Mix(m_realtime_buffer.data(), (unsigned int)num_samples_to_render);

--- a/Source/Core/AudioCommon/NullSoundStream.h
+++ b/Source/Core/AudioCommon/NullSoundStream.h
@@ -20,8 +20,8 @@ public:
 	static bool isValid() { return true; }
 
 private:
-	static constexpr size_t BUFFER_SIZE = 48000 * 4 / 32;
+	static constexpr size_t BUFFER_SIZE = 48000 * 8 / 32;
 
 	// Playback position
-	std::array<short, BUFFER_SIZE / sizeof(short)> m_realtime_buffer;
+	std::array<float, BUFFER_SIZE / sizeof(float)> m_realtime_buffer;
 };

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -76,7 +76,7 @@ private:
 
 	Common::Event soundSyncEvent;
 
-	short realtimeBuffer[OAL_MAX_SAMPLES * STEREO_CHANNELS];
+	float realtimeBuffer[OAL_MAX_SAMPLES * STEREO_CHANNELS];
 	soundtouch::SAMPLETYPE sampleBuffer[OAL_MAX_SAMPLES * SURROUND_CHANNELS * OAL_MAX_BUFFERS];
 	ALuint uiBuffers[OAL_MAX_BUFFERS];
 	ALuint uiSource;

--- a/Source/Core/AudioCommon/OpenSLESStream.cpp
+++ b/Source/Core/AudioCommon/OpenSLESStream.cpp
@@ -29,7 +29,7 @@ static CMixer *g_mixer;
 #define BUFFER_SIZE_IN_SAMPLES (BUFFER_SIZE / 2)
 
 // Double buffering.
-static short buffer[2][BUFFER_SIZE];
+static float buffer[2][BUFFER_SIZE];
 static int curBuffer = 0;
 
 static void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void *context)
@@ -38,7 +38,7 @@ static void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void *context)
 	assert(nullptr == context);
 
 	// Render to the fresh buffer
-	g_mixer->Mix(reinterpret_cast<short *>(buffer[curBuffer]), BUFFER_SIZE_IN_SAMPLES);
+	g_mixer->Mix(reinterpret_cast<float *>(buffer[curBuffer]), BUFFER_SIZE_IN_SAMPLES);
 	SLresult result = (*bqPlayerBufferQueue)->Enqueue(bqPlayerBufferQueue, buffer[curBuffer], sizeof(buffer[0]));
 	curBuffer ^= 1; // Switch buffer
 
@@ -64,14 +64,15 @@ bool OpenSLESStream::Start()
 	assert(SL_RESULT_SUCCESS == result);
 
 	SLDataLocator_AndroidSimpleBufferQueue loc_bufq = {SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, 2};
-	SLDataFormat_PCM format_pcm = {
-		SL_DATAFORMAT_PCM,
+	SLDataFormat_PCM_EX format_pcm = {
+		SL_DATAFORMAT_PCM_EX,
 		2,
 		m_mixer->GetSampleRate() * 1000,
-		SL_PCMSAMPLEFORMAT_FIXED_16,
-		SL_PCMSAMPLEFORMAT_FIXED_16,
+		SL_PCMSAMPLEFORMAT_FIXED_32,
+		SL_PCMSAMPLEFORMAT_FIXED_32,
 		SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT,
-		SL_BYTEORDER_LITTLEENDIAN
+		SL_BYTEORDER_LITTLEENDIAN,
+		SL_PCM_REPRESENTATION_FLOAT
 	};
 
 	SLDataSource audioSrc = {&loc_bufq, &format_pcm};

--- a/Source/Core/AudioCommon/PulseAudioStream.cpp
+++ b/Source/Core/AudioCommon/PulseAudioStream.cpp
@@ -96,8 +96,8 @@ bool PulseAudio::PulseInit()
 	pa_channel_map* channel_map_p = nullptr; // auto channel map
 	if (m_stereo)
 	{
-		ss.format = PA_SAMPLE_S16LE;
-		m_bytespersample = sizeof(s16);
+		ss.format = PA_SAMPLE_FLOAT32LE;
+		m_bytespersample = sizeof(float);
 	}
 	else
 	{
@@ -188,26 +188,26 @@ void PulseAudio::WriteCallback(pa_stream* s, size_t length)
 	if (m_stereo)
 	{
 		// use the raw s16 stereo mix
-		m_mixer->Mix((s16*) buffer, frames);
+		m_mixer->Mix((float*) buffer, frames);
 	}
 	else
 	{
 		// get a floating point mix
-		s16 s16buffer_stereo[frames * 2];
-		m_mixer->Mix(s16buffer_stereo, frames); // implicitly mixes to 16-bit stereo
+		float buffer_stereo[frames * 2];
+		m_mixer->Mix(buffer_stereo, frames); // implicitly mixes to 16-bit stereo
 
-		float floatbuffer_stereo[frames * 2];
+		//float floatbuffer_stereo[frames * 2];
 		// s16 to float
-		for (int i=0; i < frames * 2; ++i)
+		/*for (int i=0; i < frames * 2; ++i)
 		{
 			floatbuffer_stereo[i] = s16buffer_stereo[i] / float(1 << 15);
-		}
+		}*/
 
 		if (m_channels == 5) // Extract dpl2/5.0 Surround
 		{
 			float floatbuffer_6chan[frames * 6];
 			// DPL2Decode output: LEFTFRONT, RIGHTFRONT, CENTREFRONT, (sub), LEFTREAR, RIGHTREAR
-			DPL2Decode(floatbuffer_stereo, frames, floatbuffer_6chan);
+			DPL2Decode(buffer_stereo, frames, floatbuffer_6chan);
 
 			// Discard the subwoofer channel - DPL2Decode generates a pretty
 			// good 5.0 but not a good 5.1 output.

--- a/Source/Core/AudioCommon/XAudio2Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2Stream.cpp
@@ -46,7 +46,7 @@ const int SAMPLES_PER_BUFFER = 96;
 
 const int NUM_CHANNELS = 2;
 const int BUFFER_SIZE = SAMPLES_PER_BUFFER * NUM_CHANNELS;
-const int BUFFER_SIZE_BYTES = BUFFER_SIZE * sizeof(s16);
+const int BUFFER_SIZE_BYTES = BUFFER_SIZE * sizeof(float);
 
 void StreamingVoiceContext::SubmitBuffer(PBYTE buf_data)
 {
@@ -63,18 +63,19 @@ StreamingVoiceContext::StreamingVoiceContext(IXAudio2 *pXAudio2, CMixer *pMixer,
 	, m_sound_sync_event(pSyncEvent)
 	, xaudio_buffer(new BYTE[NUM_BUFFERS * BUFFER_SIZE_BYTES]())
 {
+	//WAVEFORMATIEEEFLOATEX wfx = {};
 	WAVEFORMATEXTENSIBLE wfx = {};
 
 	wfx.Format.wFormatTag       = WAVE_FORMAT_EXTENSIBLE;
 	wfx.Format.nSamplesPerSec   = m_mixer->GetSampleRate();
 	wfx.Format.nChannels        = 2;
-	wfx.Format.wBitsPerSample   = 16;
+	wfx.Format.wBitsPerSample   = 32;
 	wfx.Format.nBlockAlign      = wfx.Format.nChannels*wfx.Format.wBitsPerSample / 8;
 	wfx.Format.nAvgBytesPerSec  = wfx.Format.nSamplesPerSec * wfx.Format.nBlockAlign;
-	wfx.Format.cbSize           = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
-	wfx.Samples.wValidBitsPerSample = 16;
+	wfx.Format.cbSize			= sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+	wfx.Samples.wValidBitsPerSample = 32;
 	wfx.dwChannelMask           = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
-	wfx.SubFormat               = KSDATAFORMAT_SUBTYPE_PCM;
+	wfx.SubFormat               = KSDATAFORMAT_SUBTYPE_IEEE_FLOAT;
 
 	// create source voice
 	HRESULT hr;
@@ -122,7 +123,7 @@ void StreamingVoiceContext::OnBufferEnd(void* context)
 	//m_sound_sync_event->Wait(); // sync
 	//m_sound_sync_event->Spin(); // or tight sync
 
-	m_mixer->Mix(static_cast<short*>(context), SAMPLES_PER_BUFFER);
+	m_mixer->Mix(static_cast<float*>(context), SAMPLES_PER_BUFFER);
 	SubmitBuffer(static_cast<BYTE*>(context));
 }
 

--- a/Source/Core/AudioCommon/XAudio2_7Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2_7Stream.cpp
@@ -46,7 +46,7 @@ const int SAMPLES_PER_BUFFER = 96;
 
 const int NUM_CHANNELS = 2;
 const int BUFFER_SIZE = SAMPLES_PER_BUFFER * NUM_CHANNELS;
-const int BUFFER_SIZE_BYTES = BUFFER_SIZE * sizeof(s16);
+const int BUFFER_SIZE_BYTES = BUFFER_SIZE * sizeof(float);
 
 void StreamingVoiceContext2_7::SubmitBuffer(PBYTE buf_data)
 {
@@ -68,13 +68,13 @@ StreamingVoiceContext2_7::StreamingVoiceContext2_7(IXAudio2 *pXAudio2, CMixer *p
 	wfx.Format.wFormatTag      = WAVE_FORMAT_EXTENSIBLE;
 	wfx.Format.nSamplesPerSec  = m_mixer->GetSampleRate();
 	wfx.Format.nChannels       = 2;
-	wfx.Format.wBitsPerSample  = 16;
+	wfx.Format.wBitsPerSample  = 32;
 	wfx.Format.nBlockAlign     = wfx.Format.nChannels*wfx.Format.wBitsPerSample / 8;
 	wfx.Format.nAvgBytesPerSec = wfx.Format.nSamplesPerSec * wfx.Format.nBlockAlign;
 	wfx.Format.cbSize          = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
-	wfx.Samples.wValidBitsPerSample = 16;
+	wfx.Samples.wValidBitsPerSample = 32;
 	wfx.dwChannelMask          = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
-	wfx.SubFormat              = KSDATAFORMAT_SUBTYPE_PCM;
+	wfx.SubFormat              = KSDATAFORMAT_SUBTYPE_IEEE_FLOAT;
 
 	// create source voice
 	HRESULT hr;
@@ -122,7 +122,7 @@ void StreamingVoiceContext2_7::OnBufferEnd(void* context)
 	//m_sound_sync_event->Wait(); // sync
 	//m_sound_sync_event->Spin(); // or tight sync
 
-	m_mixer->Mix(static_cast<short*>(context), SAMPLES_PER_BUFFER);
+	m_mixer->Mix(static_cast<float*>(context), SAMPLES_PER_BUFFER);
 	SubmitBuffer(static_cast<BYTE*>(context));
 }
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -293,6 +293,9 @@ void SConfig::SaveDSPSettings(IniFile& ini)
 	dsp->Set("Backend", sBackend);
 	dsp->Set("Volume", m_Volume);
 	dsp->Set("CaptureLog", m_DSPCaptureLog);
+	dsp->Set("FilterPreset", sFilterPreset);
+	dsp->Set("FilterTaps", iFilterTaps);
+	dsp->Set("FilterResolution", iFilterResolution);
 }
 
 void SConfig::SaveInputSettings(IniFile& ini)
@@ -568,6 +571,9 @@ void SConfig::LoadDSPSettings(IniFile& ini)
 #endif
 	dsp->Get("Volume", &m_Volume, 100);
 	dsp->Get("CaptureLog", &m_DSPCaptureLog, false);
+	dsp->Get("FilterPreset", &sFilterPreset, FILTER_SINC_7PT);
+	dsp->Get("FilterTaps", &iFilterTaps, 7);
+	dsp->Get("FilterResolution", &iFilterResolution, 512);
 
 	m_IsMuted = false;
 }
@@ -620,6 +626,8 @@ void SConfig::LoadDefaults()
 	bWii = false;
 	bDPL2Decoder = false;
 	iLatency = 14;
+	iFilterTaps = 7;
+	iFilterResolution = 512;
 
 	iPosX = 100;
 	iPosY = 100;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -24,6 +24,13 @@
 #define BACKEND_XAUDIO2     "XAudio2"
 #define BACKEND_OPENSLES    "OpenSLES"
 
+// FIR Filter Presets
+#define FILTER_LINEAR		"Linear"
+#define FILTER_SINC_7PT		"Sinc 7pt"
+#define FILTER_SINC_13PT	"Sinc 13pt"
+#define FILTER_SINC_27PT	"Sinc 27pt"
+#define FILTER_SINC_CUSTOM	"Sinc Custom"
+
 enum GPUDeterminismMode
 {
 	GPU_DETERMINISM_AUTO,
@@ -93,6 +100,8 @@ struct SConfig : NonCopyable
 
 	bool bDPL2Decoder;
 	int iLatency;
+	int iFilterTaps;
+	int iFilterResolution;
 
 	bool bRunCompareServer;
 	bool bRunCompareClient;
@@ -261,6 +270,7 @@ struct SConfig : NonCopyable
 	bool m_DumpUCode;
 	int m_Volume;
 	std::string sBackend;
+	std::string sFilterPreset;
 
 	// Input settings
 	bool m_BackgroundInput;

--- a/Source/Core/DolphinWX/Config/AudioConfigPane.h
+++ b/Source/Core/DolphinWX/Config/AudioConfigPane.h
@@ -26,6 +26,7 @@ private:
 	void RefreshGUI();
 
 	void PopulateBackendChoiceBox();
+	void PopulateFilterBoxes();
 	static bool SupportsVolumeChanges(const std::string&);
 
 	void OnDSPEngineRadioBoxChanged(wxCommandEvent&);
@@ -33,9 +34,14 @@ private:
 	void OnVolumeSliderChanged(wxCommandEvent&);
 	void OnAudioBackendChanged(wxCommandEvent&);
 	void OnLatencySpinCtrlChanged(wxCommandEvent&);
+	void OnFilterPresetChange(wxCommandEvent&);
+	void OnFilterTapsChange(wxCommandEvent&);
+	void OnFilterResolutionChange(wxCommandEvent&);
+	void OnClearCachePress(wxCommandEvent&);
 
 	wxArrayString m_dsp_engine_strings;
 	wxArrayString m_audio_backend_strings;
+	wxArrayString m_filter_preset_strings;
 
 	wxRadioBox* m_dsp_engine_radiobox;
 	wxCheckBox* m_dpl2_decoder_checkbox;
@@ -43,4 +49,8 @@ private:
 	wxStaticText* m_volume_text;
 	wxChoice* m_audio_backend_choice;
 	wxSpinCtrl* m_audio_latency_spinctrl;
+	wxChoice* m_filter_preset_choice;
+	wxSpinCtrl* m_filter_taps_spinctrl;
+	wxSpinCtrl* m_filter_resolution_spinctrl;
+	wxButton* m_clear_cache_button;
 };


### PR DESCRIPTION
**I will fix the build errors in the coming days as the bots build them; I do need feedback on algorithmic choices and performance considerations. Thanks!**

This implements a Finite Impulse Response Filter resampler for the audio mixer. Needs testing.
1. Changes the mixer to use floats instead of shorts, and thus changes the audio backends to take float samples (interestingly, openal was already converting samples to float, so this actually saves some work). The short->sample conversion is done on audio thread, and only when new samples have been added. The part that needs testing is the audio backend (I can confirm my code works for OpenAL and xaudio2 on Windows 10, but cannot test any of the other ones).

Changing to float means we leave the dithering up to the backend (the OS should dither when it mixes sound from other applications, etc. No use worrying about it here), and we don't worry about overflows or integer math, and (according to some sources) may even be faster than doing integer math. Really, just makes the coding easier.
1. Implements a FIR filter class within CMixer (should this be extracted to be stand alone? Can be used elsewhere, and maybe even for multiple dimensions and graphics applications?). In addition, the ability to save and read from a filter cache file (located in Cache/Audio) is included, preventing need to compute filter each time Dolphin is run, given that the filter file settings are the same as the requested. In the Audio Config panel, there is the ability to change from Linear to various FIR presets, as well as an option to tweak the parameters and clear the stored filter cache. In addition to the actual impulse filter, there is also a delta table, to interpolate between two impulse values (and also is stored in a separate file).
2. Other changes:

Made dma, streaming, and wiimote mixers into unique_ptr
Various u32 and other typedef replacements
Volume in float instead of 0-256
1. Does not take into account some various simplifications that Lioncash made to mixer.cpp/.h in #3514. Can be incorporated if desired.

FIR parameters primer (correct me if I've gotten anything wrong):
. num_crossings (taps) is the length of the filter. Since the ideal filter is infinite, the longer our finite one is, the more "ideal" it is, meaning that our lowpass filter resembles more of a brickwall and has less of a slope (affects the transition bandwidth). Tradeoff is number of multiply-adds and filter size.
. samples_per_crossing is the resolution between each zero-crossing of the filter. This is the resolution of the fractional interpolation, more is more accurate (less error). In this case, we are additionally interpolating between adjacent filter values using the delta table. Tradeoff is filter size/memory usage.
. lowpass_frequency is the point at which we are cutting off the sound. The Nyquist-Shannon theorem states that we can perfectly reconstruct anything below Fs/2, so we must lowpass at Fs/2. For example, going from 32khz->48khz, we don't want any frequencies above 16khz, so we'll theoretically set the lowpass_frequency (in ratio of samplerate) to 0.5 (of 32khz). Since there is a transition band (the lowpass filter is not a perfect vertical brick wall), we set it a bit under at 0.45. Calculation of these parameters can be found at: http://www.labbookpages.co.uk/audio/firWindowing.html#kaiser
. beta parameter affects the amount of ripple, with tradeoff also for transition width (the less ripples the larger the transition width).

Short answer to why this is better than linear interpolation: antialiasing.

I've set the presets to be fairly innocuous, with 7 multiply adds for each channel necessary for the lowest preset (default), and 27 for the highest.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3577)

<!-- Reviewable:end -->
