### PR TITLE
VideoConfig: Replace FastDepthCalc by ForcedSlowDepth.

### DIFF
--- a/Data/Sys/GameSettings/GBS.ini
+++ b/Data/Sys/GameSettings/GBS.ini
@@ -17,7 +17,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-FastDepthCalc = False
-

--- a/Data/Sys/GameSettings/GM2.ini
+++ b/Data/Sys/GameSettings/GM2.ini
@@ -7,7 +7,7 @@ FPRF = True
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Shadows need fast depth enabled.
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -17,6 +17,3 @@ EmulationIssues = Shadows need fast depth enabled.
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-FastDepthCalc = True

--- a/Data/Sys/GameSettings/GM3.ini
+++ b/Data/Sys/GameSettings/GM3.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Needs real xfb for the videos to display. Shadow issues with fastdepth (D3D).
+EmulationIssues = Needs real xfb for the videos to display.
 EmulationStateId = 4
 
 [OnLoad]
@@ -20,4 +20,3 @@ EmulationStateId = 4
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/GMD.ini
+++ b/Data/Sys/GameSettings/GMD.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Needs real xfb for the videos to display. Shadow issues with fastdepth (D3D).
+EmulationIssues = Needs real xfb for the videos to display.
 EmulationStateId = 4
 
 [OnLoad]
@@ -20,4 +20,3 @@ EmulationStateId = 4
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/GQX.ini
+++ b/Data/Sys/GameSettings/GQX.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Needs real xfb for the videos to display. Shadow issues with fastdepth (D3D).
+EmulationIssues = Needs real xfb for the videos to display.
 EmulationStateId = 4
 
 [OnLoad]
@@ -20,4 +20,3 @@ EmulationStateId = 4
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/GZL.ini
+++ b/Data/Sys/GameSettings/GZL.ini
@@ -21,8 +21,5 @@ EmulationIssues =
 EFBAccessEnable = True
 EFBToTextureEnable = False
 
-[Video_Settings]
-FastDepthCalc = False
-
 [Video_Stereoscopy]
 StereoConvergence = 115

--- a/Data/Sys/GameSettings/NAE.ini
+++ b/Data/Sys/GameSettings/NAE.ini
@@ -17,9 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Settings]
-FastDepthCalc = True
-
 [Video_Hacks]
 EFBToTextureEnable = False
 

--- a/Data/Sys/GameSettings/R44.ini
+++ b/Data/Sys/GameSettings/R44.ini
@@ -21,4 +21,3 @@ EmulationIssues =
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/RNJ.ini
+++ b/Data/Sys/GameSettings/RNJ.ini
@@ -18,4 +18,4 @@ EmulationIssues =
 # Add action replay cheats here.
 
 [Video_Settings]
-FastDepthCalc = False
+ForcedSlowDepth = True

--- a/Data/Sys/GameSettings/S59.ini
+++ b/Data/Sys/GameSettings/S59.ini
@@ -19,5 +19,4 @@ EmulationStateId = 4
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-FastDepthCalc = False
 

--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -18,7 +18,7 @@ EmulationIssues = Sound crackling can be fixed by lle audio.
 # Add action replay cheats here.
 
 [Video_Settings]
-FastDepthCalc = False
+ForcedSlowDepth = True
 SafeTextureCacheColorSamples = 512
 
 [Video_Stereoscopy]

--- a/Data/Sys/GameSettings/SOU.ini
+++ b/Data/Sys/GameSettings/SOU.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs real wiimote and motion plus. Time stone transition needs Fast Depth off. 
+EmulationIssues = Needs real wiimote and motion plus.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -18,6 +18,3 @@ EmulationIssues = Needs real wiimote and motion plus. Time stone transition need
 [Video_Hacks]
 EFBAccessEnable = True
 EFBEmulateFormatChanges = True
-
-[Video_Settings]
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/WMJ.ini
+++ b/Data/Sys/GameSettings/WMJ.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Glitches in the game menu with fast depth enabled.
+EmulationIssues =
 EmulationStateId = 4
 
 [OnLoad]
@@ -16,6 +16,3 @@ EmulationStateId = 4
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-FastDepthCalc = False

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -241,7 +241,6 @@ public final class SettingsFragmentPresenter
 		Setting efbToTexture = mSettings.get(SettingsFile.SECTION_GFX_HACKS).getSetting(SettingsFile.KEY_EFB_TEXTURE);
 		Setting texCacheAccuracy = mSettings.get(SettingsFile.SECTION_GFX_HACKS).getSetting(SettingsFile.KEY_TEXCACHE_ACCURACY);
 		IntSetting xfb = new IntSetting(SettingsFile.KEY_XFB, SettingsFile.SECTION_GFX_HACKS, xfbValue);
-		Setting fastDepth = mSettings.get(SettingsFile.SECTION_GFX_HACKS).getSetting(SettingsFile.KEY_FAST_DEPTH);
 		Setting aspectRatio = mSettings.get(SettingsFile.SECTION_GFX_HACKS).getSetting(SettingsFile.KEY_ASPECT_RATIO);
 
 		sl.add(new HeaderSetting(null, null, R.string.embedded_frame_buffer, 0));
@@ -256,7 +255,6 @@ public final class SettingsFragmentPresenter
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_XFB_METHOD, SettingsFile.SECTION_GFX_HACKS, R.string.external_frame_buffer, R.string.external_frame_buffer_descrip, R.array.externalFrameBufferEntries, R.array.externalFrameBufferValues, 0, xfb));
 
 		sl.add(new HeaderSetting(null, null, R.string.other, 0));
-		sl.add(new CheckBoxSetting(SettingsFile.KEY_FAST_DEPTH, SettingsFile.SECTION_GFX_HACKS, R.string.fast_depth_calculation, R.string.fast_depth_calculation_descrip, true, fastDepth));
 		sl.add(new SingleChoiceSetting(SettingsFile.KEY_ASPECT_RATIO, SettingsFile.SECTION_GFX_HACKS, R.string.aspect_ratio, R.string.aspect_ratio_descrip, R.array.aspectRatioEntries, R.array.aspectRatioValues, 0, aspectRatio));
 	}
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -70,7 +70,6 @@ public final class SettingsFile
 	public static final String KEY_TEXCACHE_ACCURACY = "SafeTextureCacheColorSamples";
 	public static final String KEY_XFB = "UseXFB";
 	public static final String KEY_XFB_REAL = "UseRealXFB";
-	public static final String KEY_FAST_DEPTH = "FastDepthCalc";
 	public static final String KEY_ASPECT_RATIO = "AspectRatio";
 
 	public static final String KEY_GCPAD_TYPE = "SIDevice";

--- a/Source/Android/app/src/main/res/values-ja/strings.xml
+++ b/Source/Android/app/src/main/res/values-ja/strings.xml
@@ -195,8 +195,6 @@
     <string name="external_frame_buffer_real">実機</string>
     <string name="disable_destination_alpha">Disable Destination Alpha</string>
     <string name="disable_destination_alpha_descrip">多くのタイトルで画面効果に使用されている、アルファ透過処理をスキップ 。</string>
-    <string name="fast_depth_calculation">高速奥行き計算</string>
-    <string name="fast_depth_calculation_descrip">深度値を計算するために精度の低いアルゴリズムを使用します。</string>
 
     <!-- Miscellaneous -->
     <string name="yes">はい</string>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -304,8 +304,6 @@
     <string name="external_frame_buffer_real">Real</string>
     <string name="disable_destination_alpha">Disable Destination Alpha</string>
     <string name="disable_destination_alpha_descrip">Disables emulation of a hardware feature called destination alpha, which is used in many games for various effects.</string>
-    <string name="fast_depth_calculation">Fast Depth Calculation</string>
-    <string name="fast_depth_calculation_descrip">Uses a less accurate algorithm to calculate depth values.</string>
     <string name="aspect_ratio">Aspect Ratio</string>
     <string name="aspect_ratio_descrip">Select what aspect ratio to use when rendering</string>
 

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -108,7 +108,6 @@ static wxString af_desc = wxTRANSLATE("Enable anisotropic filtering.\nEnhances v
 static wxString aa_desc = wxTRANSLATE("Reduces the amount of aliasing caused by rasterizing 3D graphics. This smooths out jagged edges on objects.\nIncreases GPU load and sometimes causes graphical issues. SSAA is significantly more demanding than MSAA, but provides top quality geometry anti-aliasing and also applies anti-aliasing to lighting, shader effects, and textures.\n\nIf unsure, select None.");
 static wxString scaled_efb_copy_desc = wxTRANSLATE("Greatly increases quality of textures generated using render-to-texture effects.\nRaising the internal resolution will improve the effect of this setting.\nSlightly increases GPU load and causes relatively few graphical issues.\n\nIf unsure, leave this checked.");
 static wxString pixel_lighting_desc = wxTRANSLATE("Calculates lighting of 3D objects per-pixel rather than per-vertex, smoothing out the appearance of lit polygons and making individual triangles less noticeable.\nRarely causes slowdowns or graphical issues.\n\nIf unsure, leave this unchecked.");
-static wxString fast_depth_calc_desc = wxTRANSLATE("Use a less accurate algorithm to calculate depth values.\nCauses issues in a few games, but can give a decent speedup depending on the game and/or your GPU.\n\nIf unsure, leave this checked.");
 static wxString disable_bbox_desc = wxTRANSLATE("Disable the bounding box emulation.\nThis may improve the GPU performance a lot, but some games will break.\n\nIf unsure, leave this checked.");
 static wxString force_filtering_desc = wxTRANSLATE("Filter all textures, including any that the game explicitly set as unfiltered.\nMay improve quality of certain textures in some games, but will cause issues in others.\nOn Direct3D, setting Anisotropic Filtering above 1x will also have the same effect as enabling this option.\n\nIf unsure, leave this unchecked.");
 static wxString borderless_fullscreen_desc = wxTRANSLATE("Implement fullscreen mode with a borderless window spanning the whole screen instead of using exclusive mode.\nAllows for faster transitions between fullscreen and windowed mode, but slightly increases input latency, makes movement less smooth and slightly decreases performance.\nExclusive mode is required for Nvidia 3D Vision to work in the Direct3D backend.\n\nIf unsure, leave this unchecked.");
@@ -517,7 +516,6 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	// - other hacks
 	{
 	wxGridSizer* const szr_other = new wxGridSizer(2, 5, 5);
-	szr_other->Add(CreateCheckBox(page_hacks, _("Fast Depth Calculation"), wxGetTranslation(fast_depth_calc_desc), vconfig.bFastDepthCalc));
 	szr_other->Add(CreateCheckBox(page_hacks, _("Disable Bounding Box"), wxGetTranslation(disable_bbox_desc), vconfig.bBBoxEnable, true));
 
 	wxStaticBoxSizer* const group_other = new wxStaticBoxSizer(wxVERTICAL, page_hacks, _("Other"));

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -285,13 +285,14 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 	GenerateVSOutputMembers<T>(out, ApiType);
 	out.Write("};\n");
 
+	const bool forced_slow_depth = g_ActiveConfig.bForcedSlowDepth || !g_ActiveConfig.backend_info.bSupportsClipControl;
 	const bool forced_early_z = g_ActiveConfig.backend_info.bSupportsEarlyZ && bpmem.UseEarlyDepthTest()
-	                            && (g_ActiveConfig.bFastDepthCalc || bpmem.alpha_test.TestResult() == AlphaTest::UNDETERMINED)
+	                            && (!forced_slow_depth || bpmem.alpha_test.TestResult() == AlphaTest::UNDETERMINED)
 	                            // We can't allow early_ztest for zfreeze because depth is overridden per-pixel.
 	                            // This means it's impossible for zcomploc to be emulated on a zfrozen polygon.
 	                            && !(bpmem.zmode.testenable && bpmem.genMode.zfreeze);
 	const bool per_pixel_depth = (bpmem.ztex2.op != ZTEXTURE_DISABLE && bpmem.UseLateDepthTest())
-	                             || (!g_ActiveConfig.bFastDepthCalc && bpmem.zmode.testenable && !forced_early_z)
+	                             || (forced_slow_depth && bpmem.zmode.testenable && !forced_early_z)
 	                             || (bpmem.zmode.testenable && bpmem.genMode.zfreeze);
 
 	if (forced_early_z)
@@ -324,7 +325,7 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 		// D3D11 also has a way to force the driver to enable early-z, so we're fine here.
 		if(ApiType == API_OPENGL)
 		{
-			 // This is a #define which signals whatever early-z method the driver supports.
+			// This is a #define which signals whatever early-z method the driver supports.
 			out.Write("FORCE_EARLY_Z; \n");
 		}
 		else
@@ -332,7 +333,7 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 			out.Write("[earlydepthstencil]\n");
 		}
 	}
-	else if (bpmem.UseEarlyDepthTest() && (g_ActiveConfig.bFastDepthCalc || bpmem.alpha_test.TestResult() == AlphaTest::UNDETERMINED))
+	else if (bpmem.UseEarlyDepthTest() && (!forced_slow_depth || bpmem.alpha_test.TestResult() == AlphaTest::UNDETERMINED))
 	{
 		static bool warn_once = true;
 		if (warn_once)
@@ -561,11 +562,13 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 
 		out.Write("\tint zCoord = int(" I_ZSLOPE".z + " I_ZSLOPE".x * screenpos.x + " I_ZSLOPE".y * screenpos.y);\n");
 	}
-	else if (!g_ActiveConfig.bFastDepthCalc)
+	else if (forced_slow_depth)
 	{
-		// FastDepth means to trust the depth generated in perspective division.
-		// It should be correct, but it seems not to be as accurate as required. TODO: Find out why!
-		// For disabled FastDepth we just calculate the depth value again.
+		// Due to floating point round-trip issues some depth equations are not as accurate as required.
+		// Depth equations used in D3D and OGL with GL_ARB_clip_control are accurate, but older cards
+		// that do not support GL_ARB_clip_control are not accurate enough under OGL. So on these older
+		// cards we just calculate the depth value again.
+
 		// The performance impact of this additional calculation doesn't matter, but it prevents
 		// the host GPU driver from performing any early depth test optimizations.
 		out.SetConstantsUsed(C_ZBIAS+1, C_ZBIAS+1);
@@ -574,6 +577,7 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 	}
 	else
 	{
+		// Our D3D backend uses inverse depth values, so we invert them to the expected value here.
 		if (ApiType == API_D3D)
 			out.Write("\tint zCoord = int((1.0 - rawpos.z) * 16777216.0);\n");
 		else
@@ -587,7 +591,7 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 	uid_data->ztex_op = bpmem.ztex2.op;
 	uid_data->per_pixel_depth = per_pixel_depth;
 	uid_data->forced_early_z = forced_early_z;
-	uid_data->fast_depth_calc = g_ActiveConfig.bFastDepthCalc;
+	uid_data->forced_slow_depth = forced_slow_depth;
 	uid_data->early_ztest = bpmem.UseEarlyDepthTest();
 	uid_data->fog_fsel = bpmem.fog.c_proj_fsel.fsel;
 	uid_data->zfreeze = bpmem.genMode.zfreeze;
@@ -595,6 +599,7 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 	// Note: z-textures are not written to depth buffer if early depth test is used
 	if (per_pixel_depth && bpmem.UseEarlyDepthTest())
 	{
+		// Our D3D backend uses inverse depth values, so we invert them back to the depth buffer value here.
 		if (ApiType == API_D3D)
 			out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
 		else
@@ -614,6 +619,7 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 
 	if (per_pixel_depth && bpmem.UseLateDepthTest())
 	{
+		// Our D3D backend uses inverse depth values, so we invert them back to the depth buffer value here.
 		if (ApiType == API_D3D)
 			out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
 		else

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -42,7 +42,7 @@ struct pixel_shader_uid_data
 	u32 fog_fsel : 3;
 	u32 fog_RangeBaseEnabled : 1;
 	u32 ztex_op : 2;
-	u32 fast_depth_calc : 1;
+	u32 forced_slow_depth : 1;
 	u32 per_pixel_depth : 1;
 	u32 forced_early_z : 1;
 	u32 early_ztest : 1;

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -333,7 +333,7 @@ static T GenerateVertexShader(API_TYPE api_type)
 	else // OGL
 	{
 		// this results in a scale from -1..0 to -1..1 after perspective
-		// divide
+		// divide, but introduces a floating point round-trip error.
 		out.Write("o.pos.z = o.pos.z * -2.0 - o.pos.w;\n");
 
 		// the next steps of the OGL pipeline are:

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -71,7 +71,7 @@ void VideoConfig::Load(const std::string& ini_file)
 	settings->Get("FreeLook", &bFreeLook, 0);
 	settings->Get("UseFFV1", &bUseFFV1, 0);
 	settings->Get("EnablePixelLighting", &bEnablePixelLighting, 0);
-	settings->Get("FastDepthCalc", &bFastDepthCalc, true);
+	settings->Get("ForcedSlowDepth", &bForcedSlowDepth, false);
 	settings->Get("MSAA", &iMultisamples, 1);
 	settings->Get("SSAA", &bSSAA, false);
 	settings->Get("EFBScale", &iEFBScale, (int)SCALE_1X); // native
@@ -165,7 +165,7 @@ void VideoConfig::GameIniLoad()
 	CHECK_SETTING("Video_Settings", "ConvertHiresTextures", bConvertHiresTextures);
 	CHECK_SETTING("Video_Settings", "CacheHiresTextures", bCacheHiresTextures);
 	CHECK_SETTING("Video_Settings", "EnablePixelLighting", bEnablePixelLighting);
-	CHECK_SETTING("Video_Settings", "FastDepthCalc", bFastDepthCalc);
+	CHECK_SETTING("Video_Settings", "ForcedSlowDepth", bForcedSlowDepth);
 	CHECK_SETTING("Video_Settings", "MSAA", iMultisamples);
 	CHECK_SETTING("Video_Settings", "SSAA", bSSAA);
 
@@ -282,7 +282,7 @@ void VideoConfig::Save(const std::string& ini_file)
 	settings->Set("FreeLook", bFreeLook);
 	settings->Set("UseFFV1", bUseFFV1);
 	settings->Set("EnablePixelLighting", bEnablePixelLighting);
-	settings->Set("FastDepthCalc", bFastDepthCalc);
+	settings->Set("ForcedSlowDepth", bForcedSlowDepth);
 	settings->Set("MSAA", iMultisamples);
 	settings->Set("SSAA", bSSAA);
 	settings->Set("EFBScale", iEFBScale);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -117,7 +117,7 @@ struct VideoConfig final
 	std::string sPhackvalue[2];
 	float fAspectRatioHackW, fAspectRatioHackH;
 	bool bEnablePixelLighting;
-	bool bFastDepthCalc;
+	bool bForcedSlowDepth;
 	int iLog; // CONF_ bits
 	int iSaveTargetId; // TODO: Should be dropped
 


### PR DESCRIPTION
Fast depth is now more accurate than slow depth and should always be used.
The option will be kept in a different form as it is still used as a hack to fix some games.
Also, the slow depth code path will still be relied upon by cards that don't support GL_ARB_clip_control.

The GameINIs are also updated removing the fallback to slow depth for most games except for Mini Ninjas and Donkey Kong Country. The exact cause of the inaccuracy in Mini Ninjas is not yet known, so it still requires a fallback to slow depth. The cause of the inaccuracy in Donkey Kong Country is known and work is in progress to fix it in PR #3587.

I also took this opportunity to update all documentation relating to the depth equations.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3578)
<!-- Reviewable:end -->
