### PR TITLE
VertexShaderGen: Add a depth bias for large far values.

### DIFF
--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -18,7 +18,6 @@ EmulationIssues = Sound crackling can be fixed by lle audio.
 # Add action replay cheats here.
 
 [Video_Settings]
-FastDepthCalc = False
 SafeTextureCacheColorSamples = 512
 
 [Video_Stereoscopy]

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -324,6 +324,9 @@ static T GenerateVertexShader(API_TYPE api_type)
 			out.Write("o.colors_1 = color1;\n");
 	}
 
+	// Some games apply a depth bias by setting the far value beyond 2^24-1.
+	out.Write("o.pos.z = o.pos.z + o.pos.w * " I_PIXELCENTERCORRECTION".z;\n");
+
 	//write the true depth value, if the game uses depth textures pixel shaders will override with the correct values
 	//if not early z culling will improve speed
 	if (g_ActiveConfig.backend_info.bSupportsClipControl)

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -394,7 +394,11 @@ void VertexShaderManager::SetConstants()
 		const float pixel_size_y = 2.f / Renderer::EFBToScaledXf(2.f * xfmem.viewport.ht);
 		constants.pixelcentercorrection[0] = pixel_center_correction * pixel_size_x;
 		constants.pixelcentercorrection[1] = pixel_center_correction * pixel_size_y;
+
+		// Some games apply a depth bias by setting the far value beyond 2^24-1.
+		constants.pixelcentercorrection[2] = MathUtil::Clamp<float>(xfmem.viewport.farZ - 16777216.0f, 0.0f, 16777215.0f) / 16777216.0f;
 		dirty = true;
+
 		// This is so implementation-dependent that we can't have it here.
 		g_renderer->SetViewport();
 


### PR DESCRIPTION
This PR fixes Donkey Kong Country Returns.

Any result from the depth equation needs to be clamped to 2^24-1, since that is the maximum value supported in the depth buffer. Some games are setting the far value beyond this value, this results in the maximum depth value being clamped and a minimum depth value that you can never go below.

This basically fits the description of a depth bias. Unfortunately PC hardware don't support doing depth biases by using an oversized depth range, so we do it in the shader instead. Another option is applying the depth bias in the project matrix. If someone prefers that approach let me know.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3587)
<!-- Reviewable:end -->
