### PR TITLE
DolphinQt2 Disable Screensavers on game launch

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -22,6 +22,8 @@
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
 
+#include "UICommon/UICommon.h"
+
 MainWindow::MainWindow() : QMainWindow(nullptr)
 {
   setWindowTitle(tr("Dolphin"));
@@ -137,7 +139,8 @@ void MainWindow::Open()
 {
   QString file = QFileDialog::getOpenFileName(
       this, tr("Select a File"), QDir::currentPath(),
-      tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.wbfs *.ciso *.gcz *.wad);;"
+      tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.wbfs *.ciso *.gcz "
+         "*.wad);;"
          "All Files (*)"));
   if (!file.isEmpty())
     StartGame(file);
@@ -153,6 +156,7 @@ void MainWindow::Play()
   if (Core::GetState() == Core::CORE_PAUSE)
   {
     Core::SetState(Core::CORE_RUN);
+    EnableScreensaver(false);
     emit EmulationStarted();
   }
   else
@@ -185,6 +189,7 @@ void MainWindow::Pause()
 {
   Core::SetState(Core::CORE_PAUSE);
   emit EmulationPaused();
+  EnableScreensaver(true);
 }
 
 bool MainWindow::Stop()
@@ -199,14 +204,7 @@ bool MainWindow::Stop()
   }
 
   if (stop)
-  {
     ForceStop();
-
-#ifdef Q_OS_WIN
-    // Allow windows to idle or turn off display again
-    SetThreadExecutionState(ES_CONTINUOUS);
-#endif
-  }
   return stop;
 }
 
@@ -214,6 +212,7 @@ void MainWindow::ForceStop()
 {
   BootManager::Stop();
   HideRenderWidget();
+  EnableScreensaver(true);
   emit EmulationStopped();
 }
 
@@ -264,14 +263,8 @@ void MainWindow::StartGame(const QString& path)
   }
   Settings().SetLastGame(path);
   ShowRenderWidget();
+  EnableScreensaver(false);
   emit EmulationStarted();
-
-#ifdef Q_OS_WIN
-  // Prevents Windows from sleeping, turning off the display, or idling
-  EXECUTION_STATE shouldScreenSave =
-      SConfig::GetInstance().bDisableScreenSaver ? ES_DISPLAY_REQUIRED : 0;
-  SetThreadExecutionState(ES_CONTINUOUS | shouldScreenSave | ES_SYSTEM_REQUIRED);
-#endif
 }
 
 void MainWindow::ShowRenderWidget()
@@ -279,7 +272,8 @@ void MainWindow::ShowRenderWidget()
   Settings settings;
   if (settings.GetRenderToMain())
   {
-    // If we're rendering to main, add it to the stack and update our title when necessary.
+    // If we're rendering to main, add it to the stack and update our title when
+    // necessary.
     m_rendering_to_main = true;
     m_stack->setCurrentIndex(m_stack->addWidget(m_render_widget));
     connect(Host::GetInstance(), &Host::RequestTitle, this, &MainWindow::setWindowTitle);
@@ -304,7 +298,8 @@ void MainWindow::HideRenderWidget()
 {
   if (m_rendering_to_main)
   {
-    // Remove the widget from the stack and reparent it to nullptr, so that it can draw
+    // Remove the widget from the stack and reparent it to nullptr, so that it
+    // can draw
     // itself in a new window if it wants. Disconnect the title updates.
     m_stack->removeWidget(m_render_widget);
     m_render_widget->setParent(nullptr);
@@ -390,4 +385,10 @@ void MainWindow::SetStateSlot(int slot)
 {
   Settings().SetStateSlot(slot);
   m_state_slot = slot;
+}
+
+void MainWindow::EnableScreensaver(bool enable)
+{
+  const std::string window_id = std::to_string(winId());
+  UICommon::EnableScreensaver(enable, window_id);
 }

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -67,6 +67,7 @@ private:
   void StartGame(const QString& path);
   void ShowRenderWidget();
   void HideRenderWidget();
+  void EnableScreensaver(bool enable);
 
   void ShowPathsDialog();
   void ShowSettingsWindow();

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -152,18 +152,6 @@ WXLRESULT CRenderFrame::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lPa
 {
   switch (nMsg)
   {
-  case WM_SYSCOMMAND:
-    switch (wParam)
-    {
-    case SC_SCREENSAVE:
-    case SC_MONITORPOWER:
-      if (Core::GetState() == Core::CORE_RUN && SConfig::GetInstance().bDisableScreenSaver)
-        break;
-    default:
-      return wxFrame::MSWWindowProc(nMsg, wParam, lParam);
-    }
-    break;
-
   case WM_USER:
     switch (wParam)
     {
@@ -582,7 +570,8 @@ void CFrame::OnClose(wxCloseEvent& event)
 
 // Post events
 
-// Warning: This may cause an endless loop if the event is propagated back to its parent
+// Warning: This may cause an endless loop if the event is propagated back to
+// its parent
 void CFrame::PostEvent(wxCommandEvent& event)
 {
   if (g_pCodeWindow && event.GetId() >= IDM_INTERPRETER && event.GetId() <= IDM_ADDRBOX)
@@ -632,11 +621,7 @@ void CFrame::OnResize(wxSizeEvent& event)
 #ifdef _WIN32
 WXLRESULT CFrame::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
 {
-  if (WM_SYSCOMMAND == nMsg && (SC_SCREENSAVE == wParam || SC_MONITORPOWER == wParam))
-  {
-    return 0;
-  }
-  else if (nMsg == WM_QUERYENDSESSION)
+  if (nMsg == WM_QUERYENDSESSION)
   {
     // Indicate that the application will be able to close
     return 1;
@@ -1005,7 +990,8 @@ static int GetMenuIDFromHotkey(unsigned int key)
 
 void OnAfterLoadCallback()
 {
-  // warning: this gets called from the CPU thread, so we should only queue things to do on the
+  // warning: this gets called from the CPU thread, so we should only queue
+  // things to do on the
   // proper thread
   if (main_frame)
   {
@@ -1016,7 +1002,8 @@ void OnAfterLoadCallback()
 
 void OnStoppedCallback()
 {
-  // warning: this gets called from the EmuThread, so we should only queue things to do on the
+  // warning: this gets called from the EmuThread, so we should only queue
+  // things to do on the
   // proper thread
   if (main_frame)
   {
@@ -1056,7 +1043,8 @@ void CFrame::OnKeyDown(wxKeyEvent& event)
 
 void CFrame::OnMouse(wxMouseEvent& event)
 {
-  // next handlers are all for FreeLook, so we don't need to check them if disabled
+  // next handlers are all for FreeLook, so we don't need to check them if
+  // disabled
   if (!g_Config.bFreeLook)
   {
     event.Skip();

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -330,6 +330,8 @@ private:
 
   // Event table
   DECLARE_EVENT_TABLE();
+
+  void EnableScreensaver(bool enable);
 };
 
 void OnAfterLoadCallback();

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -80,6 +80,8 @@
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
+#include "UICommon/UICommon.h"
+
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
@@ -87,7 +89,8 @@
 class InputConfig;
 class wxFrame;
 
-// This override allows returning a fake menubar object while removing the real one from the screen
+// This override allows returning a fake menubar object while removing the real
+// one from the screen
 wxMenuBar* CFrame::GetMenuBar() const
 {
   if (m_frameMenuBar)
@@ -330,12 +333,13 @@ void CFrame::DoOpen(bool Boot)
 {
   std::string currentDir = File::GetCurrentDir();
 
-  wxString path = wxFileSelector(
-      _("Select the file to load"), wxEmptyString, wxEmptyString, wxEmptyString,
-      _("All GC/Wii files (elf, dol, gcm, iso, wbfs, ciso, gcz, wad)") +
-          wxString::Format("|*.elf;*.dol;*.gcm;*.iso;*.wbfs;*.ciso;*.gcz;*.wad;*.dff;*.tmd|%s",
-                           wxGetTranslation(wxALL_FILES)),
-      wxFD_OPEN | wxFD_FILE_MUST_EXIST, this);
+  wxString path =
+      wxFileSelector(_("Select the file to load"), wxEmptyString, wxEmptyString, wxEmptyString,
+                     _("All GC/Wii files (elf, dol, gcm, iso, wbfs, ciso, gcz, wad)") +
+                         wxString::Format("|*.elf;*.dol;*.gcm;*.iso;*.wbfs;*.ciso;*.gcz;*.wad;"
+                                          "*.dff;*.tmd|%s",
+                                          wxGetTranslation(wxALL_FILES)),
+                     wxFD_OPEN | wxFD_FILE_MUST_EXIST, this);
 
   if (path.IsEmpty())
     return;
@@ -435,7 +439,8 @@ void CFrame::OnFrameStep(wxCommandEvent& event)
   Movie::DoFrameStep();
 
   bool isPaused = (Core::GetState() == Core::CORE_PAUSE);
-  if (isPaused && !wasPaused)  // don't update on unpause, otherwise the status would be wrong when
+  if (isPaused && !wasPaused)  // don't update on unpause, otherwise the status
+                               // would be wrong when
                                // pausing next frame
     UpdateGUI();
 }
@@ -594,7 +599,8 @@ void CFrame::ToggleDisplayMode(bool bFullscreen)
     dmScreenSettings.dmBitsPerPel = 32;
     dmScreenSettings.dmFields = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT;
 
-    // Try To Set Selected Mode And Get Results.  NOTE: CDS_FULLSCREEN Gets Rid Of Start Bar.
+    // Try To Set Selected Mode And Get Results.  NOTE: CDS_FULLSCREEN Gets Rid
+    // Of Start Bar.
     ChangeDisplaySettings(&dmScreenSettings, CDS_FULLSCREEN);
   }
   else
@@ -666,10 +672,12 @@ void CFrame::StartGame(const std::string& filename)
     m_RenderFrame->Bind(wxEVT_ACTIVATE, &CFrame::OnActive, this);
     m_RenderFrame->Bind(wxEVT_MOVE, &CFrame::OnRenderParentMove, this);
 #ifdef _WIN32
-    // The renderer should use a top-level window for exclusive fullscreen support.
+    // The renderer should use a top-level window for exclusive fullscreen
+    // support.
     m_RenderParent = m_RenderFrame;
 #else
-    // To capture key events on Linux and Mac OS X the frame needs at least one child.
+    // To capture key events on Linux and Mac OS X the frame needs at least one
+    // child.
     m_RenderParent = new wxPanel(m_RenderFrame, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
 #endif
 
@@ -697,18 +705,7 @@ void CFrame::StartGame(const std::string& filename)
   }
   else
   {
-#if defined(HAVE_X11) && HAVE_X11
-    if (SConfig::GetInstance().bDisableScreenSaver)
-      X11Utils::InhibitScreensaver(X11Utils::XDisplayFromHandle(GetHandle()),
-                                   X11Utils::XWindowFromHandle(GetHandle()), true);
-#endif
-
-#ifdef _WIN32
-    // Prevents Windows from sleeping, turning off the display, or idling
-    EXECUTION_STATE shouldScreenSave =
-        SConfig::GetInstance().bDisableScreenSaver ? ES_DISPLAY_REQUIRED : 0;
-    SetThreadExecutionState(ES_CONTINUOUS | shouldScreenSave | ES_SYSTEM_REQUIRED);
-#endif
+    EnableScreensaver(false);
 
     // We need this specifically to support setting the focus properly when using
     // the 'render to main window' feature on Windows
@@ -870,17 +867,7 @@ void CFrame::OnStopped()
   m_confirmStop = false;
   m_tried_graceful_shutdown = false;
 
-#if defined(HAVE_X11) && HAVE_X11
-  if (SConfig::GetInstance().bDisableScreenSaver)
-    X11Utils::InhibitScreensaver(X11Utils::XDisplayFromHandle(GetHandle()),
-                                 X11Utils::XWindowFromHandle(GetHandle()), false);
-#endif
-
-#ifdef _WIN32
-  // Allow windows to resume normal idling behavior
-  SetThreadExecutionState(ES_CONTINUOUS);
-#endif
-
+  EnableScreensaver(true);
   m_RenderFrame->SetTitle(StrToWxStr(scm_rev_str));
 
   // Destroy the renderer frame when not rendering to main
@@ -919,7 +906,8 @@ void CFrame::OnStopped()
   // Clear Wii Remote connection status from the status bar.
   GetStatusBar()->SetStatusText(" ", 1);
 
-  // If batch mode was specified on the command-line or we were already closing, exit now.
+  // If batch mode was specified on the command-line or we were already closing,
+  // exit now.
   if (m_bBatchMode || m_bClosing)
     Close(true);
 
@@ -1257,7 +1245,8 @@ void CFrame::OnConnectWiimote(wxCommandEvent& event)
   Core::PauseAndLock(false, was_unpaused);
 }
 
-// Toggle fullscreen. In Windows the fullscreen mode is accomplished by expanding the m_Panel to
+// Toggle fullscreen. In Windows the fullscreen mode is accomplished by
+// expanding the m_Panel to
 // cover
 // the entire screen (when we render to the main window).
 void CFrame::OnToggleFullscreen(wxCommandEvent& WXUNUSED(event))
@@ -1646,4 +1635,16 @@ void CFrame::OnChangeColumnsVisible(wxCommandEvent& event)
   }
   UpdateGameList();
   SConfig::GetInstance().SaveSettings();
+}
+
+void CFrame::EnableScreensaver(bool enable)
+{
+  std::string handle;
+
+#if defined(__linux__)
+  Window win = X11Utils::XWindowFromHandle(GetHandle());
+  handle = std::to_string(win);
+#endif
+
+  UICommon::EnableScreensaver(enable, handle);
 }

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -197,8 +197,13 @@ class PlatformX11 : public Platform
     XFlush(dpy);
     s_window_handle = (void*)win;
 
-    if (SConfig::GetInstance().bDisableScreenSaver)
-      X11Utils::InhibitScreensaver(dpy, win, true);
+    std::string handle;
+
+#if defined(__linux__)
+    handle = std::to_string(win);
+#endif
+
+    UICommon::EnableScreensaver(true, handle);
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
     XRRConfig = new X11Utils::XRRConfiguration(dpy, win);

--- a/Source/Core/DolphinWX/X11Utils.cpp
+++ b/Source/Core/DolphinWX/X11Utils.cpp
@@ -44,24 +44,6 @@ bool ToggleFullscreen(Display* dpy, Window win)
   return true;
 }
 
-void InhibitScreensaver(Display* dpy, Window win, bool suspend)
-{
-  char id[11];
-  snprintf(id, sizeof(id), "0x%lx", win);
-
-  // Call xdg-screensaver
-  char* argv[4] = {(char*)"xdg-screensaver", (char*)(suspend ? "suspend" : "resume"), id, nullptr};
-  pid_t pid;
-  if (!posix_spawnp(&pid, "xdg-screensaver", nullptr, nullptr, argv, environ))
-  {
-    int status;
-    while (waitpid(pid, &status, 0) == -1)
-      ;
-
-    INFO_LOG(VIDEO, "Started xdg-screensaver (PID = %d)", (int)pid);
-  }
-}
-
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
 XRRConfiguration::XRRConfiguration(Display* _dpy, Window _win)
     : dpy(_dpy), win(_win), screenResources(nullptr), outputInfo(nullptr), crtcInfo(nullptr),

--- a/Source/Core/DolphinWX/X11Utils.h
+++ b/Source/Core/DolphinWX/X11Utils.h
@@ -38,8 +38,6 @@ Window XWindowFromHandle(void* Handle);
 Display* XDisplayFromHandle(void* Handle);
 #endif
 
-void InhibitScreensaver(Display* dpy, Window win, bool suspend);
-
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
 class XRRConfiguration
 {

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -6,6 +6,12 @@
 #include <shlobj.h>  // for SHGetFolderPath
 #endif
 
+#if defined(__linux__) && !defined(__ANDROID__)
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/LogManager.h"
@@ -194,6 +200,36 @@ void SetUserDirectory(const std::string& custom_path)
   }
 #endif
   File::SetUserPath(D_USER_IDX, user_path);
+}
+
+void EnableScreensaver(bool enable, const std::string& window_id)
+{
+  if (!SConfig::GetInstance().bDisableScreenSaver)
+    return;
+
+#if defined(__linux__) && !defined(__ANDROID__)
+  // runs xdg-screensaver which will safely re-enable the screensaver should
+  // dolphin crash
+  std::array<char*, 4> argv{{const_cast<char*>("xdg-screensaver"),
+                             const_cast<char*>(enable ? "resume" : "suspend"),
+                             const_cast<char*>(window_id.c_str()), nullptr}};
+  pid_t pid;
+  if (!posix_spawnp(&pid, "xdg-screensaver", nullptr, nullptr, argv.data(), environ))
+  {
+    int status;
+    while (waitpid(pid, &status, 0) == -1)
+      continue;
+
+    DEBUG_LOG(VIDEO, "Started xdg-screensaver (PID = %d)", static_cast<int>(pid));
+  }
+#elif defined(_WIN32)
+  if (enable)
+    SetThreadExecutionState(ES_CONTINUOUS);
+  else
+    SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED | ES_SYSTEM_REQUIRED);
+#elif defined(__APPLE__)
+// TODO: need a dev with mac os
+#endif
 }
 
 }  // namespace UICommon

--- a/Source/Core/UICommon/UICommon.h
+++ b/Source/Core/UICommon/UICommon.h
@@ -11,5 +11,6 @@ void Shutdown();
 
 void CreateDirectories();
 void SetUserDirectory(const std::string& custom_path);
+void EnableScreensaver(bool enable, const std::string& window_id);
 
 }  // namespace UICommon


### PR DESCRIPTION
Qt doesn't provide a cross platform way to achieve this so it has to be done manually for each platform.
Screensaver disabling code has been relocated/implemented in UICommon, which neatly contains all the platform specific ifdef's for both Qt and Wx.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3590)

<!-- Reviewable:end -->
