### PR TITLE
Normalize and check upper/lower bounds of hats input on OS X

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -227,11 +227,21 @@ Joystick::Hat::Hat(IOHIDElementRef element, IOHIDDeviceRef device, direction dir
 ControlState Joystick::Hat::GetState() const
 {
 	IOHIDValueRef value;
-	int position;
 
 	if (IOHIDDeviceGetValue(m_device, m_element, &value) == kIOReturnSuccess)
 	{
-		position = IOHIDValueGetIntegerValue(value);
+		int position = IOHIDValueGetIntegerValue(value);
+		int min = IOHIDElementGetLogicalMin(m_element);
+		int max = IOHIDElementGetLogicalMax(m_element);
+
+		// if the position is outside the min or max, don't register it as a valid button press
+		if (position < min || position > max)
+		{
+			return 0;
+		}
+
+		// normalize the position so that its lowest value is 0
+		position -= min;
 
 		switch (position)
 		{


### PR DESCRIPTION
This prevents issues like https://bugs.dolphin-emu.org/issues/8411 where the mapping gets completely screwed up if your hats default position is lower than the min (in my case, my default position was 0 while the allowable min was 1). This prevents the default position from being registered as a press as well as normalizes the inputs so that they always fall between 0 and 7 and work in the switch statement.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3592)
<!-- Reviewable:end -->
