### PR TITLE
Core: Use the thread_local keyword

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -73,15 +73,11 @@
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoBackendBase.h"
 
-// This can mostly be removed when we move to VS2015
-// to use the thread_local keyword
-#ifdef _MSC_VER
-#define ThreadLocalStorage __declspec(thread)
-#elif defined __ANDROID__ || defined __APPLE__
-// This will most likely have to stay, to support android
+// Android and OSX haven't implemented the keyword yet.
+#if defined __ANDROID__ || defined __APPLE__
 #include <pthread.h>
-#else  // Everything besides VS and Android
-#define ThreadLocalStorage __thread
+#else  // Everything besides OSX and Android
+#define ThreadLocalStorage thread_local
 #endif
 
 namespace Core


### PR DESCRIPTION
Android and OSX are still twiddling their thumbs though, so we have to keep pthreads around for them.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3594)
<!-- Reviewable:end -->
