### PR TITLE
Adjust cycle counts so they are accurate to the JIT block level (Fixes OoT virtual console and other games)

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -50,13 +50,16 @@ static Common::FifoQueue<BaseEvent, false> tsQueue;
 // event pools
 static Event *eventPool = nullptr;
 
-static float lastOCFactor;
+float lastOCFactor;
 int slicelength;
 static int maxSliceLength = MAX_SLICE_LENGTH;
 
 static s64 idledCycles;
 static u32 fakeDecStartValue;
 static u64 fakeDecStartTicks;
+
+// Are we in a function that has been called from Advance()
+static bool GlobalTimerIsSane;
 
 s64 globalTimer;
 u64 fakeTBStartValue;
@@ -137,6 +140,7 @@ void Init()
 	slicelength = maxSliceLength;
 	globalTimer = 0;
 	idledCycles = 0;
+	GlobalTimerIsSane = true;
 
 	ev_lost = RegisterEvent("_lost_event", &EmptyTimedCallback);
 }
@@ -209,9 +213,16 @@ void DoState(PointerWrap &p)
 	p.DoMarker("CoreTimingEvents");
 }
 
+// This should only be called from the CPU thread, if you are calling it any other thread, you are doing something evil
 u64 GetTicks()
 {
-	return (u64)globalTimer;
+	u64 ticks = (u64)globalTimer;
+	if (!GlobalTimerIsSane)
+	{
+		int downcount = DowncountToCycles(PowerPC::ppcState.downcount);
+		ticks += slicelength - downcount;
+	}
+	return ticks;
 }
 
 u64 GetIdleTicks()
@@ -303,10 +314,16 @@ void ScheduleEvent(int cyclesIntoFuture, int event_type, u64 userdata)
 {
 	_assert_msg_(POWERPC, Core::IsCPUThread() || Core::GetState() == Core::CORE_PAUSE,
 				 "ScheduleEvent from wrong thread");
+
 	Event *ne = GetNewEvent();
 	ne->userdata = userdata;
 	ne->type = event_type;
-	ne->time = globalTimer + cyclesIntoFuture;
+	ne->time = GetTicks() + cyclesIntoFuture;
+
+	// If this event needs to be scheduled before the next advance(), force one early
+	if (!GlobalTimerIsSane)
+		ForceExceptionCheck(cyclesIntoFuture);
+
 	AddEventToQueue(ne);
 }
 
@@ -402,6 +419,8 @@ void Advance()
 	lastOCFactor = SConfig::GetInstance().m_OCEnable ? SConfig::GetInstance().m_OCFactor : 1.0f;
 	PowerPC::ppcState.downcount = CyclesToDowncount(slicelength);
 
+	GlobalTimerIsSane = true;
+
 	while (first && first->time <= globalTimer)
 	{
 		//LOG(POWERPC, "[Scheduler] %s     (%lld, %lld) ",
@@ -411,6 +430,8 @@ void Advance()
 		event_types[evt->type].callback(evt->userdata, (int)(globalTimer - evt->time));
 		FreeEvent(evt);
 	}
+
+	GlobalTimerIsSane = false;
 
 	if (!first)
 	{

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -34,6 +34,7 @@ void Shutdown();
 
 typedef void (*TimedCallback)(u64 userdata, int cyclesLate);
 
+// This should only be called from the CPU thread, if you are calling it any other thread, you are doing something evil
 u64 GetTicks();
 u64 GetIdleTicks();
 
@@ -79,5 +80,6 @@ void SetFakeTBStartTicks(u64 val);
 void ForceExceptionCheck(int cycles);
 
 extern int slicelength;
+extern float lastOCFactor;
 
 } // end of namespace

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -25,9 +25,12 @@ class PointerWrap;
 namespace CoreTiming
 {
 
-extern s64 globalTimer;
-extern u64 fakeTBStartValue;
-extern u64 fakeTBStartTicks;
+// These really shouldn't be global, but jit64 accesses them directly
+extern s64 g_globalTimer;
+extern u64 g_fakeTBStartValue;
+extern u64 g_fakeTBStartTicks;
+extern int g_slicelength;
+extern float g_lastOCFactor;
 
 void Init();
 void Shutdown();
@@ -79,7 +82,6 @@ void SetFakeTBStartTicks(u64 val);
 
 void ForceExceptionCheck(s64 cycles);
 
-extern int slicelength;
-extern float lastOCFactor;
+
 
 } // end of namespace

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -30,7 +30,7 @@ extern s64 g_globalTimer;
 extern u64 g_fakeTBStartValue;
 extern u64 g_fakeTBStartTicks;
 extern int g_slicelength;
-extern float g_lastOCFactor;
+extern float g_lastOCFactor_inverted;
 
 void Init();
 void Shutdown();

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -45,11 +45,11 @@ int RegisterEvent(const std::string& name, TimedCallback callback);
 void UnregisterAllEvents();
 
 // userdata MAY NOT CONTAIN POINTERS. userdata might get written and reloaded from savestates.
-void ScheduleEvent(int cyclesIntoFuture, int event_type, u64 userdata = 0);
+void ScheduleEvent(s64 cyclesIntoFuture, int event_type, u64 userdata = 0);
 void ScheduleEvent_Immediate(int event_type, u64 userdata = 0);
-void ScheduleEvent_Threadsafe(int cyclesIntoFuture, int event_type, u64 userdata = 0);
+void ScheduleEvent_Threadsafe(s64 cyclesIntoFuture, int event_type, u64 userdata = 0);
 void ScheduleEvent_Threadsafe_Immediate(int event_type, u64 userdata = 0);
-void ScheduleEvent_AnyThread(int cyclesIntoFuture, int event_type, u64 userdata = 0);
+void ScheduleEvent_AnyThread(s64 cyclesIntoFuture, int event_type, u64 userdata = 0);
 
 // We only permit one event of each type in the queue at a time.
 void RemoveEvent(int event_type);
@@ -77,7 +77,7 @@ void SetFakeTBStartValue(u64 val);
 u64 GetFakeTBStartTicks();
 void SetFakeTBStartTicks(u64 val);
 
-void ForceExceptionCheck(int cycles);
+void ForceExceptionCheck(s64 cycles);
 
 extern int slicelength;
 extern float lastOCFactor;

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -178,7 +178,7 @@ void Interpreter::SingleStep()
 {
 	SingleStepInner();
 
-	CoreTiming::slicelength = 1;
+	CoreTiming::g_slicelength = 1;
 	PowerPC::ppcState.downcount = 0;
 	CoreTiming::Advance();
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -283,7 +283,13 @@ void Jit64::mfspr(UGeckoInstruction inst)
 
 		// An inline implementation of CoreTiming::GetFakeTimeBase, since in timer-heavy games the
 		// cost of calling out to C for this is actually significant.
-		MOV(64, R(RAX), M(&CoreTiming::globalTimer));
+		// Scale downcount by the CPU overclocking factor.
+		CVTSI2SS(XMM0, PPCSTATE(downcount));
+		DIVSS(XMM0, M(&CoreTiming::lastOCFactor));
+		CVTSS2SI(RDX, R(XMM0)); // RDX is downcount scaled by the overclocking factor
+		MOV(32, R(RAX), M(&CoreTiming::slicelength));
+		SUB(64, R(RAX), R(RDX)); // cycles since the last CoreTiming::Advance() event is (slicelength - Scaled_downcount)
+		ADD(64, R(RAX), M(&CoreTiming::globalTimer));
 		SUB(64, R(RAX), M(&CoreTiming::fakeTBStartTicks));
 		// It might seem convenient to correct the timer for the block position here for even more accurate
 		// timing, but as of currently, this can break games. If we end up reading a time *after* the time

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -285,12 +285,12 @@ void Jit64::mfspr(UGeckoInstruction inst)
 		// cost of calling out to C for this is actually significant.
 		// Scale downcount by the CPU overclocking factor.
 		CVTSI2SS(XMM0, PPCSTATE(downcount));
-		DIVSS(XMM0, M(&CoreTiming::lastOCFactor));
+		DIVSS(XMM0, M(&CoreTiming::g_lastOCFactor));
 		CVTSS2SI(RDX, R(XMM0)); // RDX is downcount scaled by the overclocking factor
-		MOV(32, R(RAX), M(&CoreTiming::slicelength));
+		MOV(32, R(RAX), M(&CoreTiming::g_slicelength));
 		SUB(64, R(RAX), R(RDX)); // cycles since the last CoreTiming::Advance() event is (slicelength - Scaled_downcount)
-		ADD(64, R(RAX), M(&CoreTiming::globalTimer));
-		SUB(64, R(RAX), M(&CoreTiming::fakeTBStartTicks));
+		ADD(64, R(RAX), M(&CoreTiming::g_globalTimer));
+		SUB(64, R(RAX), M(&CoreTiming::g_fakeTBStartTicks));
 		// It might seem convenient to correct the timer for the block position here for even more accurate
 		// timing, but as of currently, this can break games. If we end up reading a time *after* the time
 		// at which an interrupt was supposed to occur, e.g. because we're 100 cycles into a block with only
@@ -298,10 +298,11 @@ void Jit64::mfspr(UGeckoInstruction inst)
 		// which won't get past the loading screen.
 		//if (js.downcountAmount)
 		//	ADD(64, R(RAX), Imm32(js.downcountAmount));
+
 		// a / 12 = (a * 0xAAAAAAAAAAAAAAAB) >> 67
 		MOV(64, R(RDX), Imm64(0xAAAAAAAAAAAAAAABULL));
 		MUL(64, R(RDX));
-		MOV(64, R(RAX), M(&CoreTiming::fakeTBStartValue));
+		MOV(64, R(RAX), M(&CoreTiming::g_fakeTBStartValue));
 		SHR(64, R(RDX), Imm8(3));
 		ADD(64, R(RAX), R(RDX));
 		MOV(64, PPCSTATE(spr[SPR_TL]), R(RAX));

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -285,7 +285,7 @@ void Jit64::mfspr(UGeckoInstruction inst)
 		// cost of calling out to C for this is actually significant.
 		// Scale downcount by the CPU overclocking factor.
 		CVTSI2SS(XMM0, PPCSTATE(downcount));
-		DIVSS(XMM0, M(&CoreTiming::g_lastOCFactor));
+		MULSS(XMM0, M(&CoreTiming::g_lastOCFactor_inverted));
 		CVTSS2SI(RDX, R(XMM0)); // RDX is downcount scaled by the overclocking factor
 		MOV(32, R(RAX), M(&CoreTiming::g_slicelength));
 		SUB(64, R(RAX), R(RDX)); // cycles since the last CoreTiming::Advance() event is (slicelength - Scaled_downcount)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -224,6 +224,10 @@ void JitArm64::mfspr(UGeckoInstruction inst)
 	case SPR_TL:
 	case SPR_TU:
 	{
+		// The inline implementation here is inaccurate and out of date as of PR3601
+		FALLBACK_IF(true); // Fallback to interpreted version.
+
+		/*
 		ARM64Reg WA = gpr.GetReg();
 		ARM64Reg WB = gpr.GetReg();
 		ARM64Reg XA = EncodeRegTo64(WA);
@@ -231,9 +235,9 @@ void JitArm64::mfspr(UGeckoInstruction inst)
 
 		// An inline implementation of CoreTiming::GetFakeTimeBase, since in timer-heavy games the
 		// cost of calling out to C for this is actually significant.
-		MOVI2R(XA, (u64)&CoreTiming::globalTimer);
+		MOVI2R(XA, (u64)&CoreTiming::g_globalTimer);
 		LDR(INDEX_UNSIGNED, XA, XA, 0);
-		MOVI2R(XB, (u64)&CoreTiming::fakeTBStartTicks);
+		MOVI2R(XB, (u64)&CoreTiming::g_fakeTBStartTicks);
 		LDR(INDEX_UNSIGNED, XB, XB, 0);
 		SUB(XA, XA, XB);
 
@@ -247,7 +251,7 @@ void JitArm64::mfspr(UGeckoInstruction inst)
 		ADD(XB, XB, 1);
 		UMULH(XA, XA, XB);
 
-		MOVI2R(XB, (u64)&CoreTiming::fakeTBStartValue);
+		MOVI2R(XB, (u64)&CoreTiming::g_fakeTBStartValue);
 		LDR(INDEX_UNSIGNED, XB, XB, 0);
 		ADD(XA, XB, XA, ArithOption(XA, ST_LSR, 3));
 		STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(spr[SPR_TL]));
@@ -285,7 +289,7 @@ void JitArm64::mfspr(UGeckoInstruction inst)
 			ORR(EncodeRegTo64(gpr.R(d)), SP, XA, ArithOption(XA, ST_LSR, 32));
 		else
 			MOV(gpr.R(d), WA);
-		gpr.Unlock(WA, WB);
+		gpr.Unlock(WA, WB);*/
 	}
 	break;
 	case SPR_XER:


### PR DESCRIPTION
Previously GlobalTimer was only updated at the end of each slice when CoreTiming::Advance() was called, so it could be upto 20,000 cycles off. This was causing huge problems with games which made heavy use of the time base register, such as OoT (virtual console) and Pokemon puzzle.

I've also made it so event scheduling will be accurate to the JIT block level, instead of accurate to the slice.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3601)
<!-- Reviewable:end -->
