### PR TITLE
CoreAudioSound: Minor clean up

### DIFF
--- a/Source/Core/AudioCommon/CoreAudioSoundStream.cpp
+++ b/Source/Core/AudioCommon/CoreAudioSoundStream.cpp
@@ -73,7 +73,7 @@ bool CoreAudioSound::Start()
 
 	err = AudioUnitSetParameter(audioUnit,
 					kHALOutputParam_Volume,
-					kAudioUnitParameterFlag_Output, 0,
+					kAudioUnitScope_Output, 0,
 					m_volume / 100., 0);
 	if (err != noErr)
 		ERROR_LOG(AUDIO, "error setting volume");
@@ -102,7 +102,7 @@ void CoreAudioSound::SetVolume(int volume)
 
 	err = AudioUnitSetParameter(audioUnit,
 					kHALOutputParam_Volume,
-					kAudioUnitParameterFlag_Output, 0,
+					kAudioUnitScope_Output, 0,
 					volume / 100., 0);
 	if (err != noErr)
 		ERROR_LOG(AUDIO, "error setting volume");

--- a/Source/Core/AudioCommon/CoreAudioSoundStream.cpp
+++ b/Source/Core/AudioCommon/CoreAudioSoundStream.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <CoreServices/CoreServices.h>
+#include <AudioUnit/AudioUnit.h>
 
 #include "AudioCommon/CoreAudioSoundStream.h"
 #include "Common/Logging/Log.h"


### PR DESCRIPTION
Just some minor clean ups. I did not find any regressions on OS X 10.11, though everything should theoretically still work on all OS Xs going back to 10.4.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3602)
<!-- Reviewable:end -->
