### PR TITLE
PixelShaderGen: Get rid of a struct offset macro

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cmath>
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 
@@ -520,10 +521,9 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 	for (unsigned int i = 0; i < numStages; i++)
 		WriteStage<T>(out, uid_data, i, ApiType, swapModeTable); // build the equation for this stage
 
-#define MY_STRUCT_OFFSET(str,elem) ((u32)((u64)&(str).elem-(u64)&(str)))
 	bool enable_pl = g_ActiveConfig.bEnablePixelLighting;
-	uid_data->num_values = (enable_pl) ? sizeof(*uid_data) : MY_STRUCT_OFFSET(*uid_data,stagehash[numStages]);
-
+	uid_data->num_values = enable_pl ? sizeof(*uid_data)
+	                                 : static_cast<u32>(offsetof(pixel_shader_uid_data, stagehash[numStages]));
 
 	if (numStages)
 	{

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "Common/CommonTypes.h"
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/ShaderGenCommon.h"
@@ -112,6 +114,9 @@ struct pixel_shader_uid_data
 	LightingUidData lighting;
 };
 #pragma pack()
+
+// Necessary, as it's undefined behavior to use offsetof on a struct that doesn't have a standard layout.
+static_assert(std::is_standard_layout<pixel_shader_uid_data>(), "pixel_shader_uid_data must be a standard layout type.");
 
 typedef ShaderUid<pixel_shader_uid_data> PixelShaderUid;
 


### PR DESCRIPTION
There's already a standard variant of this: offsetof. This also adds a compile-time assert to ensure offset retrieval will always remain valid.

codegen is the [same](http://goo.gl/AqpQMe) on GCC and better on clang 3.7.1 (it generates one less instruction with the standardized macro)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3604)
<!-- Reviewable:end -->
