### PR TITLE
[Game INI] Flag some Wii titles without widescreen support

### DIFF
--- a/Data/Sys/GameSettings/RBI.ini
+++ b/Data/Sys/GameSettings/RBI.ini
@@ -17,5 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Video_Hacks]
-
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RBL.ini
+++ b/Data/Sys/GameSettings/RBL.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RBLE8P, RBLJ8P, RBLP8P - Bleach: Shattered Blade
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues =
 EmulationStateId = 5
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RBT.ini
+++ b/Data/Sys/GameSettings/RBT.ini
@@ -1,4 +1,4 @@
-# RBTP8P - SEGA BASS FISHING
+# RBTJ8P, RBTP8P - SEGA BASS FISHING
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -17,3 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RCC.ini
+++ b/Data/Sys/GameSettings/RCC.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RCCE5G, RCCJC0, RCCPGT - Cooking Mama: Cook Off
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues =
 EmulationStateId = 5
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RCP.ini
+++ b/Data/Sys/GameSettings/RCP.ini
@@ -1,4 +1,4 @@
-# RCPE18 - KORORINPA
+# RCPE18, RCPJ18, RCPP18 - KORORINPA
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -17,3 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RDB.ini
+++ b/Data/Sys/GameSettings/RDB.ini
@@ -1,4 +1,4 @@
-# RDBPAF - Dragon Ball Z Budokai Tenkaichi 2
+# RDBE70, RDBJAF, RDBPAF, RDBP70 - Dragon Ball Z Budokai Tenkaichi 2
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -20,3 +20,5 @@ EmulationIssues =
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RDS.ini
+++ b/Data/Sys/GameSettings/RDS.ini
@@ -1,12 +1,12 @@
-# RDSEAF, RDSJAF, RDSPAF - Dragon Ball Z Budokai Tenkaichi 3
+# RDSE70, RDSJAF, RDSPAF - Dragon Ball Z Budokai Tenkaichi 3
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues =
 EmulationStateId = 5
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -20,3 +20,5 @@ EmulationStateId = 5
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
 
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RG2.ini
+++ b/Data/Sys/GameSettings/RG2.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RG2EXS, RG2JJF, RG2PGT - Guilty Gear XX ^ Core
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues =
 EmulationStateId = 5
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RGB.ini
+++ b/Data/Sys/GameSettings/RGB.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RGBE08, RGBP08 - Harvey Birdman: Attorney at Law
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
 EmulationIssues =
-EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RGM.ini
+++ b/Data/Sys/GameSettings/RGM.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RGME5D, RGMP5D - The Grim Adventures of Billy & Mandy
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
 EmulationIssues =
-EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RGS.ini
+++ b/Data/Sys/GameSettings/RGS.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RGSE8P, RGSJ8P, RGSP8P - Ghost Squad
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
 EmulationIssues =
-EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RI3.ini
+++ b/Data/Sys/GameSettings/RI3.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RI3E5D, RI3P5D - The Ant Bully
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 0
 EmulationIssues =
-EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RLT.ini
+++ b/Data/Sys/GameSettings/RLT.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RLTENR, RLTPNR, RLTXUG - London Taxi: Rush Hour
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
 EmulationIssues =
-EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RMP.ini
+++ b/Data/Sys/GameSettings/RMP.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RMPE54, RPMJA4, RMPP54 - MLB Power Pros
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
 EmulationIssues =
-EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RNX.ini
+++ b/Data/Sys/GameSettings/RNX.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RNXEDA, RNXPDA - Naruto: Clash of Ninja Revolution
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
 EmulationIssues =
-EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/ROD.ini
+++ b/Data/Sys/GameSettings/ROD.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 5
-EmulationIssues = This game doesn't support widescreen
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -19,3 +19,6 @@ EmulationIssues = This game doesn't support widescreen
 
 [Video_Hacks]
 EFBEmulateFormatChanges = True
+
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RPG.ini
+++ b/Data/Sys/GameSettings/RPG.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RPGE5D, RPGP5D - Rampage: Total Destruction
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 3
 EmulationIssues =
-EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False

--- a/Data/Sys/GameSettings/RPY.ini
+++ b/Data/Sys/GameSettings/RPY.ini
@@ -17,3 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RQW.ini
+++ b/Data/Sys/GameSettings/RQW.ini
@@ -16,3 +16,6 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
+
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RRB.ini
+++ b/Data/Sys/GameSettings/RRB.ini
@@ -18,3 +18,5 @@ EmulationIssues = Needs Synchronise GPU thread for stability. Use direct3d11 for
 [ActionReplay]
 # Add action replay cheats here.
 
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RS5.ini
+++ b/Data/Sys/GameSettings/RS5.ini
@@ -20,3 +20,5 @@ EmulationIssues =
 [Video_Hacks]
 EFBEmulateFormatChanges = True
 
+[Wii]
+Widescreen = False

--- a/Data/Sys/GameSettings/RTR.ini
+++ b/Data/Sys/GameSettings/RTR.ini
@@ -1,12 +1,12 @@
-# RKDEEB, RKDJEB, RKDP01, RKDPEB - Trauma Center SO
+# RTRE18, RTRJ18, RTRP18 - Fishing Master
 
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
 EmulationIssues =
-EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,9 +16,6 @@ EmulationStateId = 5
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-SafeTextureCacheColorSamples = 512
 
 [Wii]
 Widescreen = False


### PR DESCRIPTION
As I noticed through the discussion of PR #3591, adding `Widescreen = false` to the Game INI of Wii games that lacks native widescreen support allows those titles to display properly at 4:3 even when using Dolphin's "Auto AR" feature. While PR #3591 takes care of Virtual Console titles, this one handles at least part of earlier Wii releases that lacks widescreen support.

The source of the games were mainly [this archived forum thread] (http://web.archive.org/web/20080905094932/http://www.cheapassgamer.com/forums/showthread.php?t=174129) but I also searched other places (generally reviews, back cover art, game manuals, etc) before including them.

**Notes**
- Some of those games didn't have a Game INI yet, I created them based on info from GameTDB and/or Dolphin Wiki
- There are some reports of Mario Party 8 being 4:3 only but it appears that this game check the Wii settings and adds pillarboxing when running in 16:9 to account that, so I didn't update its Game INI
- Although the Wiimote Safety Screen displayed at boot in Puzzle Quest Challenge of the Warlords display correctly accordingly to what is defined in Wii settings, the game itself is 4:3 only and displays stretched when running in 16:9, so I updated its Game INI too
- Naruto Clash of Ninja Revolution 2 and 3 probably are "4:3 only" games like the first game on the series, but I didn't update its Game INIs because of mixed responses (some sources claiming it does have widescreen support while others claiming it does not)

Since it's related to Game INIs I'm calling @Linktothepast and It's probably a good idea to have these on 5.0 as well, so I'm calling @delroth too...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3607)
<!-- Reviewable:end -->
