### PR TITLE
Fix: segfault in NetPlayServer::GetInterfaceListInternal for ifa_addr-less interfaces

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -828,6 +828,9 @@ std::vector<std::pair<std::string, std::string>> NetPlayServer::GetInterfaceList
 		for (ifaddrs* curifp = ifp; curifp; curifp = curifp->ifa_next)
 		{
 			sockaddr* sa = curifp->ifa_addr;
+
+			if (sa == nullptr)
+				continue;
 			if (sa->sa_family != AF_INET)
 				continue;
 			sockaddr_in* sai = (struct sockaddr_in*) sa;


### PR DESCRIPTION
`NetPlayServer::GetInterfaceListInternal` was crashing dolphin with a segfault when encountering a network interface without `ifa_addr`.

Encountered while using OpenVPN.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3610)
<!-- Reviewable:end -->
