### PR TITLE
Linux support for portable.txt + documentation in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,15 +50,45 @@ bundled with Dolphin and used if they're not installed on your system. CMake
 will inform you if a bundled library is used or if you need to install any
 missing packages yourself.
 
-### Build Steps:
-1. `mkdir Build`
-2. `cd Build`
+### OS X Build Steps:
+1. `mkdir build`
+2. `cd build`
 3. `cmake ..`
 4. `make`
 
-On OS X, an application bundle will be created in `./Binaries`.
+An application bundle will be created in `./Binaries`.
 
-On Linux, it's strongly recommended to perform a global installation via `sudo make install`.
+### Linux Global Build Steps:
+
+To install to your system.
+
+1. `mkdir build`
+2. `cd build`
+3. `cmake ..`
+4. `make`
+5. `sudo make install`
+
+### Linux Local Build Steps:
+
+Useful for development as root access is not required.
+
+1. `mkdir Build`
+2. `cd Build`
+3. `cmake .. -DLINUX_LOCAL_DEV=true`
+4. `make`
+5. `ln -s ../../Data/Sys Binaries/`
+
+### Linux Portable Build Steps:
+
+Can be stored on external storage and used on different Linux systems.
+Or useful for having multiple distinct Dolphin setups for testing/development/TAS.
+
+1. `mkdir Build`
+2. `cd Build`
+3. `cmake .. -DLINUX_LOCAL_DEV=true`
+4. `make`
+5. `cp -r ../Data/Sys/ Binaries/`
+6. `touch Binaries/portable.txt`
 
 ## Building for Android
 

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -78,8 +78,8 @@ void SetUserDirectory(const std::string& custom_path)
 
   std::string user_path = "";
 #ifdef _WIN32
-  // Detect where the User directory is. There are five different cases (on top of the
-  // command line flag, which overrides all this):
+  // Detect where the User directory is. There are five different cases
+  // (on top of the command line flag, which overrides all this):
   // 1. GetExeDirectory()\portable.txt exists
   //    -> Use GetExeDirectory()\User
   // 2. HKCU\Software\Dolphin Emulator\LocalUserConfig exists and is true
@@ -126,7 +126,8 @@ void SetUserDirectory(const std::string& custom_path)
   else  // Case 5
     user_path = File::GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
 
-  // Prettify the path: it will be displayed in some places, we don't want a mix of \ and /.
+  // Prettify the path: it will be displayed in some places, we don't want a mix
+  // of \ and /.
   user_path = ReplaceAll(user_path, "\\", DIR_SEP);
 
   // Make sure it ends in DIR_SEP.
@@ -149,12 +150,21 @@ void SetUserDirectory(const std::string& custom_path)
 #if defined(__APPLE__) || defined(ANDROID)
     user_path = home_path + DOLPHIN_DATA_DIR DIR_SEP;
 #else
-    // We are on a non-Apple and non-Android POSIX system, let's respect XDG basedir.
-    // The only case we don't is when there is an existing ~/.dolphin-emu directory.
-    // See http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-
+    // We are on a non-Apple and non-Android POSIX system, there are 3 cases:
+    // 1. GetExeDirectory()/portable.txt exists
+    //    -> Use GetExeDirectory/User
+    // 2. ~/.dolphin-emu directory exists
+    //    -> Use ~/.dolphin-emu
+    // 3. Default
+    //    -> Use XDG basedir, see
+    //    http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
     user_path = home_path + "." DOLPHIN_DATA_DIR DIR_SEP;
-    if (!File::Exists(user_path))
+    std::string exe_path = File::GetExeDirectory();
+    if (File::Exists(exe_path + DIR_SEP "portable.txt"))
+    {
+      user_path = exe_path + DIR_SEP "User" DIR_SEP;
+    }
+    else if (!File::Exists(user_path))
     {
       const char* data_home = getenv("XDG_DATA_HOME");
       std::string data_path =


### PR DESCRIPTION
Readme now instructs how to perform a local linux build as it was previously undocumented.

Edit: After reading Bhaal's comment I realised that a portable build would be really useful for linux, so I implemented and documented that as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3614)
<!-- Reviewable:end -->
