### PR TITLE
DQT2: Add context menu to gamelist

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <QDesktopServices>
 #include <QHeaderView>
+#include <QMenu>
+#include <QUrl>
 
 #include "DolphinQt2/Settings.h"
 #include "DolphinQt2/GameList/GameList.h"
@@ -45,6 +48,8 @@ void GameList::MakeTableView()
 	m_table->setShowGrid(false);
 	m_table->setSortingEnabled(true);
 	m_table->setCurrentIndex(QModelIndex());
+	m_table->setContextMenuPolicy(Qt::CustomContextMenu);
+	connect(m_table, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
 
 	// TODO load from config
 	m_table->setColumnHidden(GameListModel::COL_PLATFORM, false);
@@ -84,6 +89,29 @@ void GameList::MakeListView()
 	m_list->setViewMode(QListView::IconMode);
 	m_list->setResizeMode(QListView::Adjust);
 	m_list->setUniformItemSizes(true);
+	m_list->setContextMenuPolicy(Qt::CustomContextMenu);
+	connect(m_list, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
+}
+
+void GameList::ShowContextMenu(const QPoint&)
+{
+	QMenu* menu = new QMenu(this);
+	menu->addAction(tr("Properties"));
+	menu->addAction(tr("Open Wiki Page"), this, SLOT(OpenWiki()));
+	menu->addAction(tr("Set as Default ISO"), this, SLOT(SetDefaultISO()));
+	menu->exec(QCursor::pos());
+}
+
+void GameList::OpenWiki()
+{
+	QString game_id = GameFile(GetSelectedGame()).GetUniqueID();
+	QString url = QStringLiteral("https://wiki.dolphin-emu.org/index.php?title=").append(game_id);
+	QDesktopServices::openUrl(QUrl(url));
+}
+
+void GameList::SetDefaultISO()
+{
+	Settings().SetDefaultGame(GetSelectedGame());
 }
 
 QString GameList::GetSelectedGame() const

--- a/Source/Core/DolphinQt2/GameList/GameList.h
+++ b/Source/Core/DolphinQt2/GameList/GameList.h
@@ -19,13 +19,17 @@ class GameList final : public QStackedWidget
 
 public:
 	explicit GameList(QWidget* parent = nullptr);
-
 	QString GetSelectedGame() const;
 
 public slots:
 	void SetTableView() { SetPreferredView(true); }
 	void SetListView() { SetPreferredView(false); }
 	void SetViewColumn(int col, bool view) { m_table->setColumnHidden(col, !view); }
+
+private slots:
+	void ShowContextMenu(const QPoint&);
+	void OpenWiki();
+	void SetDefaultISO();
 
 signals:
 	void GameSelected();


### PR DESCRIPTION
Context menu currently allows for setting the default game and opening the corresponding wiki page.
Properties currently does nothing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3616)
<!-- Reviewable:end -->
