### PR TITLE
DQt2: Connect column view menu buttons to the game list

### DIFF
--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -56,16 +56,10 @@ void GameList::MakeTableView()
   m_table->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(m_table, &QTableView::customContextMenuRequested, this, &GameList::ShowContextMenu);
 
-  // TODO load from config
-  m_table->setColumnHidden(GameListModel::COL_PLATFORM, false);
-  m_table->setColumnHidden(GameListModel::COL_ID, true);
-  m_table->setColumnHidden(GameListModel::COL_BANNER, false);
-  m_table->setColumnHidden(GameListModel::COL_TITLE, false);
-  m_table->setColumnHidden(GameListModel::COL_DESCRIPTION, true);
-  m_table->setColumnHidden(GameListModel::COL_MAKER, false);
-  m_table->setColumnHidden(GameListModel::COL_SIZE, false);
-  m_table->setColumnHidden(GameListModel::COL_COUNTRY, false);
-  m_table->setColumnHidden(GameListModel::COL_RATING, false);
+  for (int i = 0; i < GameListModel::NUM_COLS; ++i)
+  {
+    m_table->setColumnHidden(i, !Settings().GetViewColumn(i));
+  }
 
   QHeaderView* hor_header = m_table->horizontalHeader();
   hor_header->setSectionResizeMode(GameListModel::COL_PLATFORM, QHeaderView::ResizeToContents);
@@ -180,6 +174,7 @@ void GameList::ConsiderViewChange()
     setCurrentWidget(m_empty);
   }
 }
+
 void GameList::keyReleaseEvent(QKeyEvent* event)
 {
   if (event->key() == Qt::Key_Return)

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -50,25 +50,7 @@ QVariant GameListModel::headerData(int section, Qt::Orientation orientation, int
 {
   if (orientation == Qt::Vertical || role != Qt::DisplayRole)
     return QVariant();
-
-  switch (section)
-  {
-  case COL_TITLE:
-    return tr("Title");
-  case COL_ID:
-    return tr("ID");
-  case COL_BANNER:
-    return tr("Banner");
-  case COL_DESCRIPTION:
-    return tr("Description");
-  case COL_MAKER:
-    return tr("Maker");
-  case COL_SIZE:
-    return tr("Size");
-  case COL_RATING:
-    return tr("Quality");
-  }
-  return QVariant();
+  return GetColumnName(section);
 }
 
 int GameListModel::rowCount(const QModelIndex& parent) const
@@ -115,4 +97,49 @@ int GameListModel::FindGame(const QString& path) const
       return i;
   }
   return -1;
+}
+
+QString GameListModel::GetColumnName(int column_id)
+{
+  switch (column_id)
+  {
+  case GameListModel::COL_PLATFORM:
+    return tr("Platform");
+  case GameListModel::COL_ID:
+    return tr("ID");
+  case GameListModel::COL_BANNER:
+    return tr("Banner");
+  case GameListModel::COL_TITLE:
+    return tr("Title");
+  case GameListModel::COL_DESCRIPTION:
+    return tr("Description");
+  case GameListModel::COL_MAKER:
+    return tr("Maker");
+  case GameListModel::COL_SIZE:
+    return tr("Size");
+  case GameListModel::COL_COUNTRY:
+    return tr("Country");
+  case GameListModel::COL_RATING:
+    return tr("Quality");
+  default:
+    Q_ASSERT(false);
+    return QStringLiteral("");
+  }
+}
+
+bool GameListModel::GetDefaultColumnEnable(int column_id)
+{
+  switch (column_id)
+  {
+  case GameListModel::COL_PLATFORM:
+  case GameListModel::COL_BANNER:
+  case GameListModel::COL_TITLE:
+  case GameListModel::COL_MAKER:
+  case GameListModel::COL_SIZE:
+  case GameListModel::COL_COUNTRY:
+  case GameListModel::COL_RATING:
+    return true;
+  default:
+    return false;
+  }
 }

--- a/Source/Core/DolphinQt2/GameList/GameListModel.h
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.h
@@ -26,6 +26,9 @@ public:
 
   // Path of the Game at the specified index.
   QString GetPath(int index) const { return m_games[index]->GetFilePath(); }
+  static QString GetColumnName(int column_id);
+  static bool GetDefaultColumnEnable(int column_id);
+
   enum
   {
     COL_PLATFORM = 0,

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -82,6 +82,9 @@ void MainWindow::ConnectMenuBar()
   // View
   connect(m_menu_bar, &MenuBar::ShowTable, m_game_list, &GameList::SetTableView);
   connect(m_menu_bar, &MenuBar::ShowList, m_game_list, &GameList::SetListView);
+  connect(m_menu_bar, &MenuBar::SetViewColumn, m_game_list, &GameList::SetViewColumn);
+
+  // Help
   connect(m_menu_bar, &MenuBar::ShowAboutDialog, this, &MainWindow::ShowAboutDialog);
 
   connect(this, &MainWindow::EmulationStarted, m_menu_bar, &MenuBar::EmulationStarted);
@@ -136,7 +139,8 @@ void MainWindow::Open()
 {
   QString file = QFileDialog::getOpenFileName(
       this, tr("Select a File"), QDir::currentPath(),
-      tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.wbfs *.ciso *.gcz *.wad);;"
+      tr("All GC/Wii files (*.elf *.dol *.gcm *.iso *.wbfs *.ciso *.gcz "
+         "*.wad);;"
          "All Files (*)"));
   if (!file.isEmpty())
     StartGame(file);
@@ -290,8 +294,8 @@ void MainWindow::HideRenderWidget()
 {
   if (m_rendering_to_main)
   {
-    // Remove the widget from the stack and reparent it to nullptr, so that it can draw
-    // itself in a new window if it wants. Disconnect the title updates.
+    // Remove the widget from the stack and reparent it to nullptr, so that it
+    // can draw itself in a new window if it wants. Disconnect the title updates.
     m_stack->removeWidget(m_render_widget);
     m_render_widget->setParent(nullptr);
     m_rendering_to_main = false;

--- a/Source/Core/DolphinQt2/MenuBar.cpp
+++ b/Source/Core/DolphinQt2/MenuBar.cpp
@@ -8,6 +8,7 @@
 
 #include "Core/State.h"
 #include "DolphinQt2/AboutDialog.h"
+#include "DolphinQt2/GameList/GameListModel.h"
 #include "DolphinQt2/MenuBar.h"
 #include "DolphinQt2/Settings.h"
 
@@ -191,18 +192,22 @@ void MenuBar::AddGameListTypeSection(QMenu* view_menu)
   connect(list_view, &QAction::triggered, this, &MenuBar::ShowList);
 }
 
-// TODO implement this
 void MenuBar::AddTableColumnsMenu(QMenu* view_menu)
 {
   QActionGroup* column_group = new QActionGroup(this);
-  QMenu* cols_menu = view_menu->addMenu(tr("Table Columns"));
+  QMenu* column_menu = view_menu->addMenu(tr("Table Columns"));
   column_group->setExclusive(false);
 
-  QStringList col_names{tr("Platform"), tr("ID"),   tr("Banner"),  tr("Title"),  tr("Description"),
-                        tr("Maker"),    tr("Size"), tr("Country"), tr("Quality")};
-  for (int i = 0; i < col_names.count(); i++)
+  for (int i = 0; i < GameListModel::NUM_COLS; i++)
   {
-    QAction* action = column_group->addAction(cols_menu->addAction(col_names[i]));
+    QAction* action =
+        column_group->addAction(column_menu->addAction(GameListModel::GetColumnName(i)));
     action->setCheckable(true);
+    action->setChecked(Settings().GetViewColumn(i));
+    connect(action, &QAction::toggled, this, [=]() {
+      bool show = action->isChecked();
+      Settings().SetViewColumn(i, show);
+      emit SetViewColumn(i, show);
+    });
   }
 }

--- a/Source/Core/DolphinQt2/MenuBar.h
+++ b/Source/Core/DolphinQt2/MenuBar.h
@@ -41,6 +41,7 @@ signals:
   // View
   void ShowTable();
   void ShowList();
+  void SetViewColumn(int col, bool view);
 
   void ShowAboutDialog();
 

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -6,6 +6,7 @@
 
 #include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
+#include "DolphinQt2/GameList/GameListModel.h"
 #include "DolphinQt2/Settings.h"
 
 static QString GetSettingsPath()
@@ -142,4 +143,15 @@ bool Settings::GetFullScreen() const
 QSize Settings::GetRenderWindowSize() const
 {
   return value(QStringLiteral("Graphics/RenderWindowSize"), QSize(640, 480)).toSize();
+}
+
+void Settings::SetViewColumn(int column, bool view)
+{
+  setValue(QStringLiteral("GameList/ViewColumn%1").arg(column), view);
+}
+
+bool Settings::GetViewColumn(int column) const
+{
+  bool default_view = GameListModel::GetDefaultColumnEnable(column);
+  return value(QStringLiteral("GameList/ViewColumn%1").arg(column), default_view).toBool();
 }

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -37,6 +37,8 @@ public:
   DiscIO::IVolume::ELanguage GetGCSystemLanguage() const;
   bool GetPreferredView() const;
   void SetPreferredView(bool table);
+  void SetViewColumn(int column, bool view);
+  bool GetViewColumn(int column) const;
 
   // Emulation
   bool GetConfirmStop() const;


### PR DESCRIPTION
Each column of the gamelist's TableView can be set via the MenuBar, configuration is saved to disk.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3619)

<!-- Reviewable:end -->

With only the Platform and Banner columns enabled.
![2columngamelist](https://cloud.githubusercontent.com/assets/5120858/12971989/5ff422d6-d0f5-11e5-9f22-54f3a9fcead1.png)

The now functional menu.
![3619menu](https://cloud.githubusercontent.com/assets/5120858/15390118/7fef4eee-1dfd-11e6-97c7-f99ffac3e6a8.png)
