### PR TITLE
[DO NOT MERGE] Add delay to SetFinish for Datel Products

### DIFF
--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -309,9 +309,9 @@ void SetFinish()
 	CommandProcessor::SetInterruptFinishWaiting(true);
 
 	if (!SConfig::GetInstance().bCPUThread || Fifo::UseDeterministicGPUThread())
-		CoreTiming::ScheduleEvent(0, et_SetFinishOnMainThread, 0);
+		CoreTiming::ScheduleEvent(250000, et_SetFinishOnMainThread, 0);
 	else
-		CoreTiming::ScheduleEvent_Threadsafe(0, et_SetFinishOnMainThread, 0);
+		CoreTiming::ScheduleEvent_Threadsafe(250000, et_SetFinishOnMainThread, 0);
 
 	INFO_LOG(PIXELENGINE, "VIDEO Set Finish");
 }


### PR DESCRIPTION
This is basically a blind adjustment for me to test some bugs I've been running into.  Assuming I didn't set it too high, it should fix various Datel products from hanging.  Also wanted to test it on random hangs in Pokemon Colosseum's bonus disc (which consequentially happens in Pokemon Box as well.)

Also this is based off of Fiora's stuff, but the code has slightly changed meaning I could have broken everything.

Please note I have no idea what I'm doing.
