### PR TITLE
Issue #8970: Check existence of ISO before opening properties window

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -1058,8 +1058,15 @@ void CGameListCtrl::OnDeleteISO(wxCommandEvent& WXUNUSED (event))
 void CGameListCtrl::OnProperties(wxCommandEvent& WXUNUSED (event))
 {
 	const GameListItem* iso = GetSelectedISO();
-	if (!iso)
+
+	if (!iso || !File::Exists(iso->GetFileName()))
+	{
+		WxUtils::ShowErrorDialog(
+			wxString::Format(_("Could not open %s. The file might have been renamed or deleted."),
+			iso->GetName().c_str()));
+		Update();
 		return;
+	}
 
 	CISOProperties* ISOProperties = new CISOProperties(*iso, this);
 	ISOProperties->Show();


### PR DESCRIPTION
Fixed a bug where Dolphin crashes when it tries to load an ISO that no
longer exists.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3625)

<!-- Reviewable:end -->
