### PR TITLE
JitArm64: Single precision tracking.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -86,7 +86,6 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode,
 			{
 				m_float_emit.LDR(32, EncodeRegToDouble(RS), X28, addr);
 				m_float_emit.REV32(8, EncodeRegToDouble(RS), EncodeRegToDouble(RS));
-				m_float_emit.FCVT(64, 32, EncodeRegToDouble(RS), EncodeRegToDouble(RS));
 			}
 			else
 			{
@@ -214,7 +213,6 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode,
 				MOVI2R(X30, (u64)&PowerPC::Read_U32);
 				BLR(X30);
 				m_float_emit.INS(32, RS, 0, X0);
-				m_float_emit.FCVT(64, 32, EncodeRegToDouble(RS), EncodeRegToDouble(RS));
 			}
 			else
 			{

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -73,6 +73,11 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode,
 				m_float_emit.REV32(8, D0, D0);
 				m_float_emit.STR(64, Q0, X28, addr);
 			}
+			else if (flags & BackPatchInfo::FLAG_SIZE_F32X2I)
+			{
+				m_float_emit.REV32(8, D0, RS);
+				m_float_emit.STR(64, Q0, X28, addr);
+			}
 			else
 			{
 				m_float_emit.REV64(8, Q0, RS);
@@ -193,6 +198,13 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode,
 			{
 				m_float_emit.FCVTN(32, D0, RS);
 				m_float_emit.UMOV(64, X0, D0, 0);
+				ORR(X0, SP, X0, ArithOption(X0, ST_ROR, 32));
+				MOVI2R(X30, (u64)PowerPC::Write_U64);
+				BLR(X30);
+			}
+			else if (flags & BackPatchInfo::FLAG_SIZE_F32X2I)
+			{
+				m_float_emit.UMOV(64, X0, RS, 0);
 				ORR(X0, SP, X0, ArithOption(X0, ST_ROR, 32));
 				MOVI2R(X30, (u64)PowerPC::Write_U64);
 				BLR(X30);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -196,8 +196,12 @@ void JitArm64::fcmpX(UGeckoInstruction inst)
 	u32 a = inst.FA, b = inst.FB;
 	int crf = inst.CRFD;
 
-	ARM64Reg VA = fpr.R(a, REG_IS_LOADED);
-	ARM64Reg VB = fpr.R(b, REG_IS_LOADED);
+	bool singles = fpr.IsSingle(a) && fpr.IsSingle(b);
+	RegType type = singles ? REG_IS_LOADED_SINGLE : REG_IS_LOADED;
+	ARM64Reg (*reg_encoder)(ARM64Reg) = singles ? EncodeRegToSingle : EncodeRegToDouble;
+
+	ARM64Reg VA = reg_encoder(fpr.R(a, type));
+	ARM64Reg VB = reg_encoder(fpr.R(b, type));
 
 	ARM64Reg WA = gpr.GetReg();
 	ARM64Reg XA = EncodeRegTo64(WA);
@@ -206,7 +210,7 @@ void JitArm64::fcmpX(UGeckoInstruction inst)
 	FixupBranch continue1, continue2, continue3;
 	ORR(XA, ZR, 32, 0, true);
 
-	m_float_emit.FCMP(EncodeRegToDouble(VA), EncodeRegToDouble(VB));
+	m_float_emit.FCMP(VA, VB);
 
 	if (a != b)
 	{

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -61,7 +61,7 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
 	}
 	else
 	{
-		RegType type = (inputs_are_singles && single) ? REG_IS_LOADED_SINGLE : REG_IS_LOADED;
+		RegType type = (inputs_are_singles && single) ? REG_LOWER_PAIR_SINGLE : REG_LOWER_PAIR;
 		RegType type_out = single ? (inputs_are_singles ? REG_DUP_SINGLE : REG_DUP) : REG_LOWER_PAIR;
 		ARM64Reg (*reg_encoder)(ARM64Reg) = (inputs_are_singles && single) ? EncodeRegToSingle : EncodeRegToDouble;
 
@@ -128,12 +128,11 @@ void JitArm64::fp_logic(UGeckoInstruction inst)
 	}
 	else
 	{
-		RegType type = single ? REG_IS_LOADED_SINGLE : REG_IS_LOADED;
-		RegType type2 = single ? REG_LOWER_PAIR_SINGLE : REG_LOWER_PAIR;
+		RegType type = single ? REG_LOWER_PAIR_SINGLE : REG_LOWER_PAIR;
 		ARM64Reg (*reg_encoder)(ARM64Reg) = single ? EncodeRegToSingle : EncodeRegToDouble;
 
 		ARM64Reg VB = fpr.R(b, type);
-		ARM64Reg VD = fpr.RW(d, type2);
+		ARM64Reg VD = fpr.RW(d, type);
 
 		switch (op10)
 		{
@@ -155,9 +154,9 @@ void JitArm64::fselx(UGeckoInstruction inst)
 
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 
-	ARM64Reg VA = fpr.R(a, REG_IS_LOADED);
-	ARM64Reg VB = fpr.R(b, REG_IS_LOADED);
-	ARM64Reg VC = fpr.R(c, REG_IS_LOADED);
+	ARM64Reg VA = fpr.R(a, REG_LOWER_PAIR);
+	ARM64Reg VB = fpr.R(b, REG_LOWER_PAIR);
+	ARM64Reg VC = fpr.R(c, REG_LOWER_PAIR);
 	ARM64Reg VD = fpr.RW(d);
 
 	m_float_emit.FCMPE(EncodeRegToDouble(VA));
@@ -176,7 +175,7 @@ void JitArm64::frspx(UGeckoInstruction inst)
 	if (fpr.IsSingle(b, true))
 	{
 		// Source is already in single precision, so no need to do anything but to copy to PSR1.
-		ARM64Reg VB = fpr.R(b, REG_IS_LOADED_SINGLE);
+		ARM64Reg VB = fpr.R(b, REG_LOWER_PAIR_SINGLE);
 		ARM64Reg VD = fpr.RW(d, REG_DUP_SINGLE);
 
 		if (b != d)
@@ -184,7 +183,7 @@ void JitArm64::frspx(UGeckoInstruction inst)
 	}
 	else
 	{
-		ARM64Reg VB = fpr.R(b, REG_IS_LOADED);
+		ARM64Reg VB = fpr.R(b, REG_LOWER_PAIR);
 		ARM64Reg VD = fpr.RW(d, REG_DUP_SINGLE);
 
 		m_float_emit.FCVT(32, 64, EncodeRegToDouble(VD), EncodeRegToDouble(VB));
@@ -201,7 +200,7 @@ void JitArm64::fcmpX(UGeckoInstruction inst)
 	int crf = inst.CRFD;
 
 	bool singles = fpr.IsSingle(a, true) && fpr.IsSingle(b, true);
-	RegType type = singles ? REG_IS_LOADED_SINGLE : REG_IS_LOADED;
+	RegType type = singles ? REG_LOWER_PAIR_SINGLE : REG_LOWER_PAIR;
 	ARM64Reg (*reg_encoder)(ARM64Reg) = singles ? EncodeRegToSingle : EncodeRegToDouble;
 
 	ARM64Reg VA = reg_encoder(fpr.R(a, type));
@@ -266,7 +265,7 @@ void JitArm64::fctiwzx(UGeckoInstruction inst)
 
 	u32 b = inst.FB, d = inst.FD;
 
-	ARM64Reg VB = fpr.R(b, REG_IS_LOADED);
+	ARM64Reg VB = fpr.R(b, REG_LOWER_PAIR);
 	ARM64Reg VD = fpr.RW(d);
 
 	ARM64Reg V0 = fpr.GetReg();

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -105,18 +105,24 @@ void JitArm64::fp_logic(UGeckoInstruction inst)
 	if (op10 == 72 && b == d)
 		return;
 
+	bool is_single = fpr.IsSingle(b);
+
 	if (packed)
 	{
-		ARM64Reg VB = fpr.R(b, REG_REG);
-		ARM64Reg VD = fpr.RW(d, REG_REG);
+		RegType type = is_single ? REG_REG_SINGLE : REG_REG;
+		u8 size = is_single ? 32 : 64;
+		ARM64Reg (*reg_encoder)(ARM64Reg) = is_single ? EncodeRegToDouble : EncodeRegToQuad;
+
+		ARM64Reg VB = reg_encoder(fpr.R(b, type));
+		ARM64Reg VD = reg_encoder(fpr.RW(d, type));
 
 		switch (op10)
 		{
-		case  40: m_float_emit.FNEG(64, VD, VB); break;
+		case  40: m_float_emit.FNEG(size, VD, VB); break;
 		case  72: m_float_emit.ORR(VD, VB, VB); break;
-		case 136: m_float_emit.FABS(64, VD, VB);
-		          m_float_emit.FNEG(64, VD, VD); break;
-		case 264: m_float_emit.FABS(64, VD, VB); break;
+		case 136: m_float_emit.FABS(size, VD, VB);
+		          m_float_emit.FNEG(size, VD, VD); break;
+		case 264: m_float_emit.FABS(size, VD, VB); break;
 		default: _assert_msg_(DYNA_REC, 0, "fp_logic"); break;
 		}
 	}

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -169,11 +169,22 @@ void JitArm64::frspx(UGeckoInstruction inst)
 
 	u32 b = inst.FB, d = inst.FD;
 
-	ARM64Reg VB = fpr.R(b, REG_IS_LOADED);
-	ARM64Reg VD = fpr.RW(d, REG_DUP);
+	if (fpr.IsSingle(b))
+	{
+		// Source is already in single precision, so no need to do anything but to copy to PSR1.
+		ARM64Reg VB = fpr.R(b, REG_IS_LOADED_SINGLE);
+		ARM64Reg VD = fpr.RW(d, REG_DUP_SINGLE);
 
-	m_float_emit.FCVT(32, 64, EncodeRegToDouble(VD), EncodeRegToDouble(VB));
-	m_float_emit.FCVT(64, 32, EncodeRegToDouble(VD), EncodeRegToDouble(VD));
+		if (b != d)
+			m_float_emit.FMOV(EncodeRegToSingle(VD), EncodeRegToSingle(VB));
+	}
+	else
+	{
+		ARM64Reg VB = fpr.R(b, REG_IS_LOADED);
+		ARM64Reg VD = fpr.RW(d, REG_DUP_SINGLE);
+
+		m_float_emit.FCVT(32, 64, EncodeRegToDouble(VD), EncodeRegToDouble(VB));
+	}
 }
 
 void JitArm64::fcmpX(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -33,34 +33,44 @@ void JitArm64::fp_arith(UGeckoInstruction inst)
 	bool use_c = op5 >= 25; // fmul and all kind of fmaddXX
 	bool use_b = op5 != 25; // fmul uses no B
 
+	bool inputs_are_singles = fpr.IsSingle(a) && (!use_b || fpr.IsSingle(b)) && (!use_c || fpr.IsSingle(c));
+
 	ARM64Reg VA, VB, VC, VD;
 
 	if (packed)
 	{
-		VA = fpr.R(a, REG_REG);
+		RegType type = inputs_are_singles ? REG_REG_SINGLE : REG_REG;
+		u8 size = inputs_are_singles ? 32 : 64;
+		ARM64Reg (*reg_encoder)(ARM64Reg) = inputs_are_singles ? EncodeRegToDouble : EncodeRegToQuad;
+
+		VA = reg_encoder(fpr.R(a, type));
 		if (use_b)
-			VB = fpr.R(b, REG_REG);
+			VB = reg_encoder(fpr.R(b, type));
 		if (use_c)
-			VC = fpr.R(c, REG_REG);
-		VD = fpr.RW(d, REG_REG);
+			VC = reg_encoder(fpr.R(c, type));
+		VD = reg_encoder(fpr.RW(d, type));
 
 		switch (op5)
 		{
-		case 18: m_float_emit.FDIV(64, VD, VA, VB); break;
-		case 20: m_float_emit.FSUB(64, VD, VA, VB); break;
-		case 21: m_float_emit.FADD(64, VD, VA, VB); break;
-		case 25: m_float_emit.FMUL(64, VD, VA, VC); break;
+		case 18: m_float_emit.FDIV(size, VD, VA, VB); break;
+		case 20: m_float_emit.FSUB(size, VD, VA, VB); break;
+		case 21: m_float_emit.FADD(size, VD, VA, VB); break;
+		case 25: m_float_emit.FMUL(size, VD, VA, VC); break;
 		default: _assert_msg_(DYNA_REC, 0, "fp_arith"); break;
 		}
 	}
 	else
 	{
-		VA = EncodeRegToDouble(fpr.R(a, REG_IS_LOADED));
+		RegType type = (inputs_are_singles && single) ? REG_IS_LOADED_SINGLE : REG_IS_LOADED;
+		RegType type_out = single ? (inputs_are_singles ? REG_DUP_SINGLE : REG_DUP) : REG_LOWER_PAIR;
+		ARM64Reg (*reg_encoder)(ARM64Reg) = (inputs_are_singles && single) ? EncodeRegToSingle : EncodeRegToDouble;
+
+		VA = reg_encoder(fpr.R(a, type));
 		if (use_b)
-			VB = EncodeRegToDouble(fpr.R(b, REG_IS_LOADED));
+			VB = reg_encoder(fpr.R(b, type));
 		if (use_c)
-			VC = EncodeRegToDouble(fpr.R(c, REG_IS_LOADED));
-		VD = EncodeRegToDouble(fpr.RW(d, single ? REG_DUP : REG_LOWER_PAIR));
+			VC = reg_encoder(fpr.R(c, type));
+		VD = reg_encoder(fpr.RW(d, type_out));
 
 		switch (op5)
 		{

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -76,7 +76,7 @@ void JitArm64::lfXX(UGeckoInstruction inst)
 	u32 imm_addr = 0;
 	bool is_immediate = false;
 
-	RegType type = !!(flags & BackPatchInfo::FLAG_SIZE_F64) ? REG_LOWER_PAIR : REG_DUP;
+	RegType type = !!(flags & BackPatchInfo::FLAG_SIZE_F64) ? REG_LOWER_PAIR : REG_DUP_SINGLE;
 
 	gpr.Lock(W0, W30);
 	fpr.Lock(Q0);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -272,7 +272,7 @@ void JitArm64::stfXX(UGeckoInstruction inst)
 
 	bool single = (flags & BackPatchInfo::FLAG_SIZE_F32) && fpr.IsSingle(inst.FS, true);
 
-	ARM64Reg V0 = fpr.R(inst.FS, single ? REG_IS_LOADED_SINGLE : REG_IS_LOADED);
+	ARM64Reg V0 = fpr.R(inst.FS, single ? REG_LOWER_PAIR_SINGLE : REG_LOWER_PAIR);
 
 	if (single)
 	{

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -270,7 +270,7 @@ void JitArm64::stfXX(UGeckoInstruction inst)
 	gpr.Lock(W0, W1, W30);
 	fpr.Lock(Q0);
 
-	bool single = (flags & BackPatchInfo::FLAG_SIZE_F32) && fpr.IsSingle(inst.FS);
+	bool single = (flags & BackPatchInfo::FLAG_SIZE_F32) && fpr.IsSingle(inst.FS, true);
 
 	ARM64Reg V0 = fpr.R(inst.FS, single ? REG_IS_LOADED_SINGLE : REG_IS_LOADED);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -62,20 +62,17 @@ void JitArm64::psq_l(UGeckoInstruction inst)
 
 	if (js.assumeNoPairedQuantize)
 	{
-		VS = fpr.RW(inst.RS, REG_REG);
+		VS = fpr.RW(inst.RS, REG_REG_SINGLE);
 		if (!inst.W)
 		{
 			ADD(EncodeRegTo64(addr_reg), EncodeRegTo64(addr_reg), X28);
 			m_float_emit.LD1(32, 1, EncodeRegToDouble(VS), EncodeRegTo64(addr_reg));
-			m_float_emit.REV32(8, VS, VS);
-			m_float_emit.FCVTL(64, VS, VS);
 		}
 		else
 		{
 			m_float_emit.LDR(32, VS, EncodeRegTo64(addr_reg), X28);
-			m_float_emit.REV32(8, VS, VS);
-			m_float_emit.FCVT(64, 32, EncodeRegToDouble(VS), EncodeRegToDouble(VS));
 		}
+		m_float_emit.REV32(8, EncodeRegToDouble(VS), EncodeRegToDouble(VS));
 	}
 	else
 	{
@@ -87,17 +84,14 @@ void JitArm64::psq_l(UGeckoInstruction inst)
 		LDR(X30, X30, ArithOption(EncodeRegTo64(type_reg), true));
 		BLR(X30);
 
-		VS = fpr.RW(inst.RS, REG_REG);
-		if (!inst.W)
-			m_float_emit.FCVTL(64, VS, D0);
-		else
-			m_float_emit.FCVT(64, 32, EncodeRegToDouble(VS), D0);
+		VS = fpr.RW(inst.RS, REG_REG_SINGLE);
+		m_float_emit.ORR(EncodeRegToDouble(VS), D0, D0);
 	}
 
 	if (inst.W)
 	{
-		m_float_emit.FMOV(D0, 0x70); // 1.0 as a Double
-		m_float_emit.INS(64, VS, 1, Q0, 0);
+		m_float_emit.FMOV(S0, 0x70); // 1.0 as a Single
+		m_float_emit.INS(32, VS, 1, Q0, 0);
 	}
 
 	gpr.Unlock(W0, W1, W2, W30);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -115,8 +115,10 @@ void JitArm64::psq_st(UGeckoInstruction inst)
 	gpr.Lock(W0, W1, W2, W30);
 	fpr.Lock(Q0, Q1);
 
+	bool single = fpr.IsSingle(inst.RS);
+
 	ARM64Reg arm_addr = gpr.R(inst.RA);
-	ARM64Reg VS = fpr.R(inst.RS, REG_REG);
+	ARM64Reg VS = fpr.R(inst.RS, single ? REG_REG_SINGLE : REG_REG);
 
 	ARM64Reg scale_reg = W0;
 	ARM64Reg addr_reg = W1;
@@ -150,7 +152,12 @@ void JitArm64::psq_st(UGeckoInstruction inst)
 	if (js.assumeNoPairedQuantize)
 	{
 		u32 flags = BackPatchInfo::FLAG_STORE;
-		flags |= (inst.W ? BackPatchInfo::FLAG_SIZE_F32 : BackPatchInfo::FLAG_SIZE_F32X2);
+
+		if (single)
+			flags |= (inst.W ? BackPatchInfo::FLAG_SIZE_F32I : BackPatchInfo::FLAG_SIZE_F32X2I);
+		else
+			flags |= (inst.W ? BackPatchInfo::FLAG_SIZE_F32 : BackPatchInfo::FLAG_SIZE_F32X2);
+
 		EmitBackpatchRoutine(flags,
 			jo.fastmem,
 			jo.fastmem,
@@ -160,10 +167,17 @@ void JitArm64::psq_st(UGeckoInstruction inst)
 	}
 	else
 	{
-		if (inst.W)
-			m_float_emit.FCVT(32, 64, D0, VS);
+		if (single)
+		{
+			m_float_emit.ORR(D0, VS, VS);
+		}
 		else
-			m_float_emit.FCVTN(32, D0, VS);
+		{
+			if (inst.W)
+				m_float_emit.FCVT(32, 64, D0, VS);
+			else
+				m_float_emit.FCVTN(32, D0, VS);
+		}
 
 		LDR(INDEX_UNSIGNED, scale_reg, X29, PPCSTATE_OFF(spr[SPR_GQR0 + inst.I]));
 		UBFM(type_reg, scale_reg, 0, 2); // Type

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -105,41 +105,49 @@ void JitArm64::ps_maddXX(UGeckoInstruction inst)
 	u32 a = inst.FA, b = inst.FB, c = inst.FC, d = inst.FD;
 	u32 op5 = inst.SUBOP5;
 
-	ARM64Reg VA = fpr.R(a, REG_REG);
-	ARM64Reg VB = fpr.R(b, REG_REG);
-	ARM64Reg VC = fpr.R(c, REG_REG);
-	ARM64Reg VD = fpr.RW(d, REG_REG);
-	ARM64Reg V0 = fpr.GetReg();
+	bool singles = fpr.IsSingle(a) && fpr.IsSingle(b) && fpr.IsSingle(c);
+	RegType type = singles ? REG_REG_SINGLE : REG_REG;
+	u8 size = singles ? 32 : 64;
+	ARM64Reg (*reg_encoder)(ARM64Reg) = singles ? EncodeRegToDouble : EncodeRegToQuad;
+
+	ARM64Reg VA = reg_encoder(fpr.R(a, type));
+	ARM64Reg VB = reg_encoder(fpr.R(b, type));
+	ARM64Reg VC = reg_encoder(fpr.R(c, type));
+	ARM64Reg VD = reg_encoder(fpr.RW(d, type));
+	ARM64Reg V0Q = fpr.GetReg();
+	ARM64Reg V0 = reg_encoder(V0Q);
+
+	// TODO: Do FMUL and FADD/FSUB in *one* host call to save accuracy.
 
 	switch (op5)
 	{
 	case 14: // ps_madds0
-		m_float_emit.DUP(64, V0, VC, 0);
-		m_float_emit.FMUL(64, V0, V0, VA);
-		m_float_emit.FADD(64, VD, V0, VB);
+		m_float_emit.DUP(size, V0, VC, 0);
+		m_float_emit.FMUL(size, V0, V0, VA);
+		m_float_emit.FADD(size, VD, V0, VB);
 		break;
 	case 15: // ps_madds1
-		m_float_emit.DUP(64, V0, VC, 1);
-		m_float_emit.FMUL(64, V0, V0, VA);
-		m_float_emit.FADD(64, VD, V0, VB);
+		m_float_emit.DUP(size, V0, VC, 1);
+		m_float_emit.FMUL(size, V0, V0, VA);
+		m_float_emit.FADD(size, VD, V0, VB);
 		break;
 	case 28: // ps_msub
-		m_float_emit.FMUL(64, V0, VA, VC);
-		m_float_emit.FSUB(64, VD, V0, VB);
+		m_float_emit.FMUL(size, V0, VA, VC);
+		m_float_emit.FSUB(size, VD, V0, VB);
 		break;
 	case 29: // ps_madd
-		m_float_emit.FMUL(64, V0, VA, VC);
-		m_float_emit.FADD(64, VD, V0, VB);
+		m_float_emit.FMUL(size, V0, VA, VC);
+		m_float_emit.FADD(size, VD, V0, VB);
 		break;
 	case 30: // ps_nmsub
-		m_float_emit.FMUL(64, V0, VA, VC);
-		m_float_emit.FSUB(64, VD, V0, VB);
-		m_float_emit.FNEG(64, VD, VD);
+		m_float_emit.FMUL(size, V0, VA, VC);
+		m_float_emit.FSUB(size, VD, V0, VB);
+		m_float_emit.FNEG(size, VD, VD);
 		break;
 	case 31: // ps_nmadd
-		m_float_emit.FMUL(64, V0, VA, VC);
-		m_float_emit.FADD(64, VD, V0, VB);
-		m_float_emit.FNEG(64, VD, VD);
+		m_float_emit.FMUL(size, V0, VA, VC);
+		m_float_emit.FADD(size, VD, V0, VB);
+		m_float_emit.FNEG(size, VD, VD);
 		break;
 	default:
 		_assert_msg_(DYNA_REC, 0, "ps_madd - invalid op");
@@ -147,7 +155,7 @@ void JitArm64::ps_maddXX(UGeckoInstruction inst)
 	}
 	fpr.FixSinglePrecision(d);
 
-	fpr.Unlock(V0);
+	fpr.Unlock(V0Q);
 }
 
 void JitArm64::ps_res(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -159,10 +159,16 @@ void JitArm64::ps_res(UGeckoInstruction inst)
 
 	u32 b = inst.FB, d = inst.FD;
 
-	ARM64Reg VB = fpr.R(b, REG_REG);
-	ARM64Reg VD = fpr.RW(d, REG_REG);
+	bool singles = fpr.IsSingle(b);
+	RegType type = singles ? REG_REG_SINGLE : REG_REG;
+	u8 size = singles ? 32 : 64;
+	ARM64Reg (*reg_encoder)(ARM64Reg) = singles ? EncodeRegToDouble : EncodeRegToQuad;
 
-	m_float_emit.FRSQRTE(64, VD, VB);
+	ARM64Reg VB = fpr.R(b, type);
+	ARM64Reg VD = fpr.RW(d, type);
+
+	m_float_emit.FRSQRTE(size, reg_encoder(VD), reg_encoder(VB));
+
 	fpr.FixSinglePrecision(d);
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -211,23 +211,29 @@ void JitArm64::ps_sumX(UGeckoInstruction inst)
 
 	bool upper = inst.SUBOP5 == 11;
 
-	ARM64Reg VA = fpr.R(a, REG_REG);
-	ARM64Reg VB = fpr.R(b, REG_REG);
-	ARM64Reg VC = fpr.R(c, REG_REG);
-	ARM64Reg VD = fpr.RW(d, REG_REG);
+	bool singles = fpr.IsSingle(a) && fpr.IsSingle(b) && fpr.IsSingle(c);
+	RegType type = singles ? REG_REG_SINGLE : REG_REG;
+	u8 size = singles ? 32 : 64;
+	ARM64Reg (*reg_encoder)(ARM64Reg) = singles ? EncodeRegToDouble : EncodeRegToQuad;
+
+	ARM64Reg VA = fpr.R(a, type);
+	ARM64Reg VB = fpr.R(b, type);
+	ARM64Reg VC = fpr.R(c, type);
+	ARM64Reg VD = fpr.RW(d, type);
 	ARM64Reg V0 = fpr.GetReg();
 
-	m_float_emit.DUP(64, V0, upper ? VA : VB, upper ? 0 : 1);
+	m_float_emit.DUP(size, reg_encoder(V0), reg_encoder(upper ? VA : VB), upper ? 0 : 1);
 	if (d != c)
 	{
-		m_float_emit.FADD(64, VD, V0, upper ? VB : VA);
-		m_float_emit.INS(64, VD, upper ? 0 : 1, VC, upper ? 0 : 1);
+		m_float_emit.FADD(size, reg_encoder(VD), reg_encoder(V0), reg_encoder(upper ? VB : VA));
+		m_float_emit.INS(size, VD, upper ? 0 : 1, VC, upper ? 0 : 1);
 	}
 	else
 	{
-		m_float_emit.FADD(64, V0, V0, upper ? VB : VA);
-		m_float_emit.INS(64, VD, upper ? 1 : 0, V0, upper ? 1 : 0);
+		m_float_emit.FADD(size, reg_encoder(V0), reg_encoder(V0), reg_encoder(upper ? VB : VA));
+		m_float_emit.INS(size, VD, upper ? 1 : 0, V0, upper ? 1 : 0);
 	}
+
 	fpr.FixSinglePrecision(d);
 
 	fpr.Unlock(V0);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Paired.cpp
@@ -25,36 +25,41 @@ void JitArm64::ps_mergeXX(UGeckoInstruction inst)
 
 	u32 a = inst.FA, b = inst.FB, d = inst.FD;
 
-	ARM64Reg VA = fpr.R(a, REG_REG);
-	ARM64Reg VB = fpr.R(b, REG_REG);
-	ARM64Reg VD = fpr.RW(d, REG_REG);
+	bool singles = fpr.IsSingle(a) && fpr.IsSingle(b);
+	RegType type = singles ? REG_REG_SINGLE : REG_REG;
+	u8 size = singles ? 32 : 64;
+	ARM64Reg (*reg_encoder)(ARM64Reg) = singles ? EncodeRegToDouble : EncodeRegToQuad;
+
+	ARM64Reg VA = fpr.R(a, type);
+	ARM64Reg VB = fpr.R(b, type);
+	ARM64Reg VD = fpr.RW(d, type);
 
 	switch (inst.SUBOP10)
 	{
 	case 528: //00
-		m_float_emit.TRN1(64, VD, VA, VB);
+		m_float_emit.TRN1(size, VD, VA, VB);
 		break;
 	case 560: //01
-		m_float_emit.INS(64, VD, 0, VA, 0);
-		m_float_emit.INS(64, VD, 1, VB, 1);
+		m_float_emit.INS(size, VD, 0, VA, 0);
+		m_float_emit.INS(size, VD, 1, VB, 1);
 		break;
 	case 592: //10
 		if (d != a && d != b)
 		{
-			m_float_emit.INS(64, VD, 0, VA, 1);
-			m_float_emit.INS(64, VD, 1, VB, 0);
+			m_float_emit.INS(size, VD, 0, VA, 1);
+			m_float_emit.INS(size, VD, 1, VB, 0);
 		}
 		else
 		{
 			ARM64Reg V0 = fpr.GetReg();
-			m_float_emit.INS(64, V0, 0, VA, 1);
-			m_float_emit.INS(64, V0, 1, VB, 0);
-			m_float_emit.ORR(VD, V0, V0);
+			m_float_emit.INS(size, V0, 0, VA, 1);
+			m_float_emit.INS(size, V0, 1, VB, 0);
+			m_float_emit.ORR(reg_encoder(VD), reg_encoder(V0), reg_encoder(V0));
 			fpr.Unlock(V0);
 		}
 		break;
 	case 624: //11
-		m_float_emit.TRN2(64, VD, VA, VB);
+		m_float_emit.TRN2(size, VD, VA, VB);
 		break;
 	default:
 		_assert_msg_(DYNA_REC, 0, "ps_merge - invalid op");

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
@@ -314,7 +314,7 @@ ARM64Reg Arm64FPRCache::R(u32 preg, RegType type)
 	case REG_REG_SINGLE:
 	{
 		// We're asked for singles, so just return the register.
-		if (type == REG_REG_SINGLE || type == REG_IS_LOADED_SINGLE)
+		if (type == REG_REG_SINGLE || type == REG_LOWER_PAIR_SINGLE)
 			return host_reg;
 
 		// Else convert this register back to doubles.
@@ -330,7 +330,7 @@ ARM64Reg Arm64FPRCache::R(u32 preg, RegType type)
 	case REG_LOWER_PAIR_SINGLE:
 	{
 		// We're asked for the lower single, so just return the register.
-		if (type == REG_IS_LOADED_SINGLE)
+		if (type == REG_LOWER_PAIR_SINGLE)
 			return host_reg;
 
 		// Else convert this register back to a double.
@@ -356,7 +356,7 @@ ARM64Reg Arm64FPRCache::R(u32 preg, RegType type)
 	}
 	case REG_DUP_SINGLE:
 	{
-		if (type == REG_IS_LOADED_SINGLE)
+		if (type == REG_LOWER_PAIR_SINGLE)
 			return host_reg;
 
 		if (type == REG_REG_SINGLE)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -23,6 +23,9 @@ enum RegType
 	REG_LOWER_PAIR, // Only the lower pair of a paired register
 	REG_DUP, // The lower reg is the same as the upper one (physical upper doesn't actually have the duplicated value)
 	REG_IS_LOADED, // We don't care what type it is, as long as the lower 64bits are loaded
+	REG_REG_SINGLE, // Both registers are loaded as single
+	REG_DUP_SINGLE, // The lower one contains both registers, as single
+	REG_IS_LOADED_SINGLE, // We only want to access the lower one as single
 };
 
 enum FlushMode
@@ -56,9 +59,19 @@ public:
 	{
 		return m_value;
 	}
+	void Load(ARM64Reg reg, RegType type)
+	{
+		m_type = type;
+		m_reg = reg;
+	}
 	void LoadToReg(ARM64Reg reg)
 	{
 		m_type = REG_REG;
+		m_reg = reg;
+	}
+	void LoadToRegSingle(ARM64Reg reg)
+	{
+		m_type = REG_REG_SINGLE;
 		m_reg = reg;
 	}
 	void LoadLowerReg(ARM64Reg reg)
@@ -69,6 +82,11 @@ public:
 	void LoadDup(ARM64Reg reg)
 	{
 		m_type = REG_DUP;
+		m_reg = reg;
+	}
+	void LoadDupSingle(ARM64Reg reg)
+	{
+		m_type = REG_DUP_SINGLE;
 		m_reg = reg;
 	}
 	void LoadToImm(u32 imm)
@@ -277,6 +295,8 @@ public:
 	ARM64Reg RW(u32 preg, RegType type = REG_LOWER_PAIR);
 
 	BitSet32 GetCallerSavedUsed() override;
+
+	bool IsSingle(u32 preg);
 
 	void FixSinglePrecision(u32 preg);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -24,6 +24,7 @@ enum RegType
 	REG_DUP, // The lower reg is the same as the upper one (physical upper doesn't actually have the duplicated value)
 	REG_IS_LOADED, // We don't care what type it is, as long as the lower 64bits are loaded
 	REG_REG_SINGLE, // Both registers are loaded as single
+	REG_LOWER_PAIR_SINGLE, // Only the lower pair of a paired register, as single
 	REG_DUP_SINGLE, // The lower one contains both registers, as single
 	REG_IS_LOADED_SINGLE, // We only want to access the lower one as single
 };
@@ -296,7 +297,7 @@ public:
 
 	BitSet32 GetCallerSavedUsed() override;
 
-	bool IsSingle(u32 preg);
+	bool IsSingle(u32 preg, bool lower_only = false);
 
 	void FixSinglePrecision(u32 preg);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -58,34 +58,9 @@ public:
 	{
 		return m_value;
 	}
-	void Load(ARM64Reg reg, RegType type)
+	void Load(ARM64Reg reg, RegType type = REG_REG)
 	{
 		m_type = type;
-		m_reg = reg;
-	}
-	void LoadToReg(ARM64Reg reg)
-	{
-		m_type = REG_REG;
-		m_reg = reg;
-	}
-	void LoadToRegSingle(ARM64Reg reg)
-	{
-		m_type = REG_REG_SINGLE;
-		m_reg = reg;
-	}
-	void LoadLowerReg(ARM64Reg reg)
-	{
-		m_type = REG_LOWER_PAIR;
-		m_reg = reg;
-	}
-	void LoadDup(ARM64Reg reg)
-	{
-		m_type = REG_DUP;
-		m_reg = reg;
-	}
-	void LoadDupSingle(ARM64Reg reg)
-	{
-		m_type = REG_DUP_SINGLE;
 		m_reg = reg;
 	}
 	void LoadToImm(u32 imm)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -22,11 +22,9 @@ enum RegType
 	REG_IMM, // Reg is really a IMM
 	REG_LOWER_PAIR, // Only the lower pair of a paired register
 	REG_DUP, // The lower reg is the same as the upper one (physical upper doesn't actually have the duplicated value)
-	REG_IS_LOADED, // We don't care what type it is, as long as the lower 64bits are loaded
 	REG_REG_SINGLE, // Both registers are loaded as single
 	REG_LOWER_PAIR_SINGLE, // Only the lower pair of a paired register, as single
 	REG_DUP_SINGLE, // The lower one contains both registers, as single
-	REG_IS_LOADED_SINGLE, // We only want to access the lower one as single
 };
 
 enum FlushMode

--- a/Source/Core/Core/PowerPC/JitArmCommon/BackPatch.h
+++ b/Source/Core/Core/PowerPC/JitArmCommon/BackPatch.h
@@ -9,22 +9,24 @@ struct BackPatchInfo
 {
 	enum
 	{
-		FLAG_STORE      = (1 << 0),
-		FLAG_LOAD       = (1 << 1),
-		FLAG_SIZE_8     = (1 << 2),
-		FLAG_SIZE_16    = (1 << 3),
-		FLAG_SIZE_32    = (1 << 4),
-		FLAG_SIZE_F32   = (1 << 5),
-		FLAG_SIZE_F32X2 = (1 << 6),
-		FLAG_SIZE_F64   = (1 << 7),
-		FLAG_REVERSE    = (1 << 8),
-		FLAG_EXTEND     = (1 << 9),
-		FLAG_SIZE_F32I  = (1 << 10),
-		FLAG_ZERO_256   = (1 << 11),
-		FLAG_MASK_FLOAT = FLAG_SIZE_F32 |
-		                  FLAG_SIZE_F32X2 |
-		                  FLAG_SIZE_F64 |
-		                  FLAG_SIZE_F32I,
+		FLAG_STORE       = (1 << 0),
+		FLAG_LOAD        = (1 << 1),
+		FLAG_SIZE_8      = (1 << 2),
+		FLAG_SIZE_16     = (1 << 3),
+		FLAG_SIZE_32     = (1 << 4),
+		FLAG_SIZE_F32    = (1 << 5),
+		FLAG_SIZE_F32X2  = (1 << 6),
+		FLAG_SIZE_F32X2I = (1 << 7),
+		FLAG_SIZE_F64    = (1 << 8),
+		FLAG_REVERSE     = (1 << 9),
+		FLAG_EXTEND      = (1 << 10),
+		FLAG_SIZE_F32I   = (1 << 11),
+		FLAG_ZERO_256    = (1 << 12),
+		FLAG_MASK_FLOAT  = FLAG_SIZE_F32 |
+		                   FLAG_SIZE_F32X2 |
+		                   FLAG_SIZE_F32X2I |
+		                   FLAG_SIZE_F64 |
+		                   FLAG_SIZE_F32I,
 	};
 
 	static u32 GetFlagSize(u32 flags)


### PR DESCRIPTION
This PR creates a new Floating-Point-Register-Cache state for each register: Deferred singles. We store all of our registers usually as doubles, so "single precision" instructions are implemented with doubles and two format convertion to fix the precision. After this PR, we only emit the first format convertion, and keep the single itself within our register. On access, this single will be converted back to double precision. All following commits implements some logic within each FP instruction: If all inputs are known as singles, we directly emit a single instruction without any format convertion. But bad luck, we only know this for about half the emitted instructions. Still, 100% accuracy for only 50% of the slowdown.

This PR still lacks:
- [x] fabs
- [x] psq_l with inst.w = 1
- [x] v2f32 instead of v4f32
- [x] ps_sel + fselx
- [x] fctiwzx

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3629)
<!-- Reviewable:end -->
