### PR TITLE
Don't check w/h when deciding to load EFB copy

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -487,8 +487,7 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
 	{
 		TCacheEntryBase* entry = iter->second;
 		// Do not load strided EFB copies, they are not meant to be used directly
-		if (entry->IsEfbCopy() && entry->native_width == nativeW && entry->native_height == nativeH &&
-			entry->memory_stride == entry->BytesPerRow())
+		if (entry->IsEfbCopy() && entry->memory_stride == entry->BytesPerRow())
 		{
 			// EFB copies have slightly different rules as EFB copy formats have different
 			// meanings from texture formats.


### PR DESCRIPTION
This PR fixes [Issue #9120](https://bugs.dolphin-emu.org/issues/9120) by only checking memory stride when deciding to load an EFB copy, allowing games like Donkey Kong Country Returns to load their textures when they should be loaded.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3631)
<!-- Reviewable:end -->
