### PR TITLE
[DVD] Signedness fix in realistic timing path

### DIFF
--- a/Data/Sys/GameSettings/RPJ.ini
+++ b/Data/Sys/GameSettings/RPJ.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -1301,7 +1301,7 @@ u64 SimulateDiscReadTime(u64 offset, u32 length)
 	u64 disk_read_duration = CalculateRawDiscReadTime(offset, length) +
 		SystemTimers::GetTicksPerSecond() / 1000 * DISC_ACCESS_TIME_MS;
 
-	if (offset + length - s_last_read_offset > 1024 * 1024)
+	if (offset + length > s_last_read_offset + 1024 * 1024)
 	{
 		// No buffer; just use the simple seek time + read time.
 		DEBUG_LOG(DVDINTERFACE, "Seeking %" PRId64 " bytes",


### PR DESCRIPTION
Fix for https://bugs.dolphin-emu.org/issues/8516. offset+length may be less than s_last_read_offset, which I believe causes undefined behaviour in the compiler. I did not confirm this with disassembly of the method, but I have a save state that crashes without the patch and works with the patch.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3632)
<!-- Reviewable:end -->
