### PR TITLE
Stop parenting RenderWidget.

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -32,12 +32,17 @@ MainWindow::MainWindow() : QMainWindow(nullptr)
 	ConnectMenuBar();
 }
 
+MainWindow::~MainWindow()
+{
+	m_render_widget->deleteLater();
+}
+
 void MainWindow::CreateComponents()
 {
 	m_menu_bar = new MenuBar(this);
 	m_tool_bar = new ToolBar(this);
 	m_game_list = new GameList(this);
-	m_render_widget = new RenderWidget(this);
+	m_render_widget = new RenderWidget;
 	m_stack = new QStackedWidget(this);
 	m_paths_dialog = new PathDialog(this);
 }

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -22,6 +22,7 @@ class MainWindow final : public QMainWindow
 
 public:
 	explicit MainWindow();
+	~MainWindow();
 
 signals:
 	void EmulationStarted();


### PR DESCRIPTION
#3605 made the RenderWidget a child of the MainWindow, which was a mistake.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3634)
<!-- Reviewable:end -->
