### PR TITLE
Reword "Toggle Frame Limit" to better explain function

### DIFF
--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -50,7 +50,7 @@ const std::string hotkey_labels[] =
 	_trans("Toggle Aspect Ratio"),
 	_trans("Toggle EFB Copies"),
 	_trans("Toggle Fog"),
-	_trans("Toggle Frame limit"),
+	_trans("Disable Emulation Speed Limit"),
 	_trans("Decrease Emulation Speed"),
 	_trans("Increase Emulation Speed"),
 


### PR DESCRIPTION
This addresses [Issue #9337](https://bugs.dolphin-emu.org/issues/9337) by more clearly labeling the function of the "Toggle Frame Limit" hotkey to "Disable Emulation Speed Limit".

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3639)
<!-- Reviewable:end -->
