### PR TITLE
VideoBackendBase: Store video backends as unique_ptr

### DIFF
--- a/Source/Core/DolphinWX/SoftwareVideoConfigDialog.cpp
+++ b/Source/Core/DolphinWX/SoftwareVideoConfigDialog.cpp
@@ -61,7 +61,7 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
 	wxStaticText* const label_backend = new wxStaticText(page_general, wxID_ANY, _("Backend:"));
 	wxChoice* const choice_backend = new wxChoice(page_general, wxID_ANY);
 
-	for (const VideoBackendBase* backend : g_available_video_backends)
+	for (const auto& backend : g_available_video_backends)
 	{
 		choice_backend->AppendString(StrToWxStr(backend->GetDisplayName()));
 	}

--- a/Source/Core/DolphinWX/SoftwareVideoConfigDialog.h
+++ b/Source/Core/DolphinWX/SoftwareVideoConfigDialog.h
@@ -24,17 +24,18 @@ public:
 
 	void Event_Backend(wxCommandEvent &ev)
 	{
-		VideoBackendBase* new_backend = g_available_video_backends[ev.GetInt()];
+		auto& new_backend = g_available_video_backends[ev.GetInt()];
 
-		if (g_video_backend != new_backend)
+		if (g_video_backend != new_backend.get())
 		{
 			Close();
 
-			g_video_backend = new_backend;
+			g_video_backend = new_backend.get();
 			SConfig::GetInstance().m_strVideoBackend = g_video_backend->GetName();
 
 			g_video_backend->ShowConfig(GetParent());
 		}
+
 		ev.Skip();
 	}
 };

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -235,7 +235,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title, con
 	choice_backend = new wxChoice(page_general, wxID_ANY);
 	RegisterControl(choice_backend, wxGetTranslation(backend_desc));
 
-	for (const VideoBackendBase* backend : g_available_video_backends)
+	for (const auto& backend : g_available_video_backends)
 	{
 		choice_backend->AppendString(wxGetTranslation(StrToWxStr(backend->GetDisplayName())));
 	}

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -82,8 +82,9 @@ public:
 protected:
 	void Event_Backend(wxCommandEvent &ev)
 	{
-		VideoBackendBase* new_backend = g_available_video_backends[ev.GetInt()];
-		if (g_video_backend != new_backend)
+		auto& new_backend = g_available_video_backends[ev.GetInt()];
+
+		if (g_video_backend != new_backend.get())
 		{
 			bool do_switch = !Core::IsRunning();
 			if (new_backend->GetName() == "Software Renderer")
@@ -99,7 +100,7 @@ protected:
 				// reopen the dialog
 				Close();
 
-				g_video_backend = new_backend;
+				g_video_backend = new_backend.get();
 				SConfig::GetInstance().m_strVideoBackend = g_video_backend->GetName();
 
 				g_video_backend->ShowConfig(GetParent());

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -15,7 +17,7 @@
 
 #include "VideoCommon/VideoBackendBase.h"
 
-std::vector<VideoBackendBase*> g_available_video_backends;
+std::vector<std::unique_ptr<VideoBackendBase>> g_available_video_backends;
 VideoBackendBase* g_video_backend = nullptr;
 static VideoBackendBase* s_default_backend = nullptr;
 
@@ -32,48 +34,49 @@ __declspec(dllexport) DWORD NvOptimusEnablement = 1;
 
 void VideoBackendBase::PopulateList()
 {
-	VideoBackendBase* backends[4] = { nullptr };
-
 	// OGL > D3D11 > D3D12 > SW
-	g_available_video_backends.push_back(backends[0] = new OGL::VideoBackend);
+	g_available_video_backends.push_back(std::make_unique<OGL::VideoBackend>());
 #ifdef _WIN32
-	g_available_video_backends.push_back(backends[1] = new DX11::VideoBackend);
+	g_available_video_backends.push_back(std::make_unique<DX11::VideoBackend>());
 
 	// More robust way to check for D3D12 support than (unreliable) OS version checks.
 	HMODULE d3d12_module = LoadLibraryA("d3d12.dll");
-	if (d3d12_module != NULL)
+	if (d3d12_module != nullptr)
 	{
 		FreeLibrary(d3d12_module);
-		g_available_video_backends.push_back(backends[2] = new DX12::VideoBackend);
+		g_available_video_backends.push_back(std::make_unique<DX12::VideoBackend>());
 	}
 #endif
-	g_available_video_backends.push_back(backends[3] = new SW::VideoSoftware);
+	g_available_video_backends.push_back(std::make_unique<SW::VideoSoftware>());
 
-	for (VideoBackendBase* backend : backends)
-	{
-		if (backend)
-		{
-			s_default_backend = g_video_backend = backend;
-			break;
-		}
-	}
+	const auto iter = std::find_if(g_available_video_backends.begin(), g_available_video_backends.end(), [](const auto& backend) {
+		return backend != nullptr;
+	});
+
+	if (iter == g_available_video_backends.end())
+		return;
+
+	s_default_backend = iter->get();
+	g_video_backend   = iter->get();
 }
 
 void VideoBackendBase::ClearList()
 {
-	while (!g_available_video_backends.empty())
-	{
-		delete g_available_video_backends.back();
-		g_available_video_backends.pop_back();
-	}
+	g_available_video_backends.clear();
 }
 
 void VideoBackendBase::ActivateBackend(const std::string& name)
 {
-	if (name.length() == 0) // If nullptr, set it to the default backend (expected behavior)
+	// If empty, set it to the default backend (expected behavior)
+	if (name.empty())
 		g_video_backend = s_default_backend;
 
-	for (VideoBackendBase* backend : g_available_video_backends)
-		if (name == backend->GetName())
-			g_video_backend = backend;
+	const auto iter = std::find_if(g_available_video_backends.begin(), g_available_video_backends.end(), [&name](const auto& backend) {
+		return name == backend->GetName();
+	});
+
+	if (iter == g_available_video_backends.end())
+		return;
+
+	g_video_backend = iter->get();
 }

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -99,5 +100,5 @@ protected:
 	bool m_invalid = false;
 };
 
-extern std::vector<VideoBackendBase*> g_available_video_backends;
+extern std::vector<std::unique_ptr<VideoBackendBase>> g_available_video_backends;
 extern VideoBackendBase* g_video_backend;


### PR DESCRIPTION
Next I'll be looking at getting rid of the direct exposing of the vector itself. Ideally (at least I think so), the collection of backends shouldn't be managed by the VideoBackendBase class itself, since a video backend class shouldn't be concerned with how it's externally managed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3642)
<!-- Reviewable:end -->
