### PR TITLE
D3D12: Get rid of most explicit delete and new usages

### DIFF
--- a/Source/Core/VideoBackends/D3D12/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.h
@@ -13,6 +13,7 @@
 #include <d3d12.h>
 #include <d3dcompiler.h>
 #include <dxgi1_4.h>
+#include <memory>
 #include <vector>
 
 #include "../../Externals/d3dx12/d3dx12.h"
@@ -25,8 +26,6 @@ namespace DX12
 {
 
 #define SAFE_RELEASE(x) { if (x) (x)->Release(); (x) = nullptr; }
-#define SAFE_DELETE(x) { delete (x); (x) = nullptr; }
-#define SAFE_DELETE_ARRAY(x) { delete[] (x); (x) = nullptr; }
 #define CHECK(cond, Message, ...) if (!(cond)) { __debugbreak(); PanicAlert(__FUNCTION__ " failed in %s at line %d: " Message, __FILE__, __LINE__, __VA_ARGS__); }
 
 // DEBUGCHECK is for high-frequency functions that we only want to check on debug builds.
@@ -80,17 +79,17 @@ extern ID3D12Device* device12;
 
 extern unsigned int resource_descriptor_size;
 extern unsigned int sampler_descriptor_size;
-extern D3DDescriptorHeapManager* gpu_descriptor_heap_mgr;
-extern D3DDescriptorHeapManager* sampler_descriptor_heap_mgr;
-extern D3DDescriptorHeapManager* dsv_descriptor_heap_mgr;
-extern D3DDescriptorHeapManager* rtv_descriptor_heap_mgr;
+extern std::unique_ptr<D3DDescriptorHeapManager> gpu_descriptor_heap_mgr;
+extern std::unique_ptr<D3DDescriptorHeapManager> sampler_descriptor_heap_mgr;
+extern std::unique_ptr<D3DDescriptorHeapManager> dsv_descriptor_heap_mgr;
+extern std::unique_ptr<D3DDescriptorHeapManager> rtv_descriptor_heap_mgr;
 extern std::array<ID3D12DescriptorHeap*, 2> gpu_descriptor_heaps;
 
 
 extern D3D12_CPU_DESCRIPTOR_HANDLE null_srv_cpu;
 extern D3D12_CPU_DESCRIPTOR_HANDLE null_srv_cpu_shadow;
 
-extern D3DCommandListManager* command_list_mgr;
+extern std::unique_ptr<D3DCommandListManager> command_list_mgr;
 extern ID3D12GraphicsCommandList* current_command_list;
 
 extern ID3D12RootSignature* default_root_signature;

--- a/Source/Core/VideoBackends/D3D12/D3DStreamBuffer.h
+++ b/Source/Core/VideoBackends/D3D12/D3DStreamBuffer.h
@@ -14,29 +14,29 @@ namespace DX12
 class D3DStreamBuffer
 {
 public:
-	D3DStreamBuffer(unsigned int initial_size, unsigned int max_size, bool* buffer_reallocation_notification);
+	D3DStreamBuffer(size_t initial_size, size_t max_size, bool* buffer_reallocation_notification);
 	~D3DStreamBuffer();
 
-	bool AllocateSpaceInBuffer(unsigned int allocation_size, unsigned int alignment);
-	void OverrideSizeOfPreviousAllocation(unsigned int override_allocation_size);
+	bool AllocateSpaceInBuffer(size_t allocation_size, size_t alignment);
+	void OverrideSizeOfPreviousAllocation(size_t override_allocation_size);
 
 	void*                     GetBaseCPUAddress() const;
 	D3D12_GPU_VIRTUAL_ADDRESS GetBaseGPUAddress() const;
 	ID3D12Resource*           GetBuffer() const;
 	void*                     GetCPUAddressOfCurrentAllocation() const;
 	D3D12_GPU_VIRTUAL_ADDRESS GetGPUAddressOfCurrentAllocation() const;
-	unsigned int              GetOffsetOfCurrentAllocation() const;
-	unsigned int              GetSize() const;
+	size_t                    GetOffsetOfCurrentAllocation() const;
+	size_t                    GetSize() const;
 
 	static void QueueFenceCallback(void* owning_object, UINT64 fence_value);
 
 private:
-	void AllocateBuffer(unsigned int size);
-	bool AttemptBufferResizeOrElseStall(unsigned int new_size);
+	void AllocateBuffer(size_t size);
+	bool AttemptBufferResizeOrElseStall(size_t new_size);
 
-	bool AttemptToAllocateOutOfExistingUnusedSpaceInBuffer(unsigned int allocation_size);
+	bool AttemptToAllocateOutOfExistingUnusedSpaceInBuffer(size_t allocation_size);
 
-	bool AttemptToFindExistingFenceToStallOn(unsigned int allocation_size);
+	bool AttemptToFindExistingFenceToStallOn(size_t allocation_size);
 
 	void UpdateGPUProgress();
 	void QueueFence(UINT64 fence_value);
@@ -44,7 +44,7 @@ private:
 	struct FenceTrackingInformation
 	{
 		UINT64 fence_value;
-		unsigned int buffer_offset;
+		size_t buffer_offset;
 	};
 
 	std::queue<FenceTrackingInformation> m_queued_fences;
@@ -56,13 +56,13 @@ private:
 	void* m_buffer_cpu_address = nullptr;
 	D3D12_GPU_VIRTUAL_ADDRESS m_buffer_gpu_address = {};
 
-	unsigned int m_buffer_current_allocation_offset = 0;
-	unsigned int m_buffer_offset = 0;
-	unsigned int m_buffer_size = 0;
+	size_t m_buffer_current_allocation_offset = 0;
+	size_t m_buffer_offset = 0;
+	size_t m_buffer_size = 0;
 
-	const unsigned int m_buffer_max_size = 0;
+	const size_t m_buffer_max_size = 0;
 
-	unsigned int m_buffer_gpu_completion_offset = 0;
+	size_t m_buffer_gpu_completion_offset = 0;
 
 	bool* m_buffer_reallocation_notification = nullptr;
 };

--- a/Source/Core/VideoBackends/D3D12/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DTexture.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <memory>
+
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 #include "VideoBackends/D3D12/D3DBase.h"
@@ -19,11 +21,11 @@ namespace DX12
 namespace D3D
 {
 
-static D3DStreamBuffer* s_texture_upload_stream_buffer = nullptr;
+static std::unique_ptr<D3DStreamBuffer> s_texture_upload_stream_buffer;
 
 void CleanupPersistentD3DTextureResources()
 {
-	SAFE_DELETE(s_texture_upload_stream_buffer);
+	s_texture_upload_stream_buffer.reset();
 }
 
 void ReplaceRGBATexture2D(ID3D12Resource* texture12, const u8* buffer, unsigned int width, unsigned int height, unsigned int src_pitch, unsigned int level, D3D12_RESOURCE_STATES current_resource_state)
@@ -32,7 +34,7 @@ void ReplaceRGBATexture2D(ID3D12Resource* texture12, const u8* buffer, unsigned 
 
 	if (!s_texture_upload_stream_buffer)
 	{
-		s_texture_upload_stream_buffer = new D3DStreamBuffer(4 * 1024 * 1024, 64 * 1024 * 1024, nullptr);
+		s_texture_upload_stream_buffer = std::make_unique<D3DStreamBuffer>(4 * 1024 * 1024, 64 * 1024 * 1024, nullptr);
 	}
 
 	bool current_command_list_executed = s_texture_upload_stream_buffer->AllocateSpaceInBuffer(upload_size, D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT);

--- a/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
@@ -56,7 +56,7 @@ void ResourceBarrier(ID3D12GraphicsCommandList* command_list, ID3D12Resource* re
 class UtilVertexBuffer
 {
 public:
-	explicit UtilVertexBuffer(int size)
+	explicit UtilVertexBuffer(size_t size)
 	{
 		m_stream_buffer = new D3DStreamBuffer(size, size * 4, nullptr);
 	}
@@ -65,10 +65,10 @@ public:
 		SAFE_DELETE(m_stream_buffer);
 	}
 
-	unsigned int GetSize() const { return m_stream_buffer->GetSize(); }
+	size_t GetSize() const { return m_stream_buffer->GetSize(); }
 
 	// returns vertex offset to the new data
-	int AppendData(void* data, int size, int vertex_size)
+	size_t AppendData(const void* data, size_t size, size_t vertex_size)
 	{
 		m_stream_buffer->AllocateSpaceInBuffer(size, vertex_size);
 
@@ -77,7 +77,7 @@ public:
 		return m_stream_buffer->GetOffsetOfCurrentAllocation() / vertex_size;
 	}
 
-	int BeginAppendData(void** write_ptr, int size, int vertex_size)
+	size_t BeginAppendData(void** write_ptr, size_t size, size_t vertex_size)
 	{
 		m_stream_buffer->AllocateSpaceInBuffer(size, vertex_size);
 
@@ -535,9 +535,9 @@ struct
 } clear_quad_data;
 
 // ring buffer offsets
-int stq_offset;
-int cq_offset;
-int clearq_offset;
+static size_t stq_offset;
+static size_t cq_offset;
+static size_t clearq_offset;
 
 void InitUtils()
 {
@@ -660,7 +660,7 @@ void DrawShadedTexQuad(D3DTexture2D* texture,
 
 	D3D12_VERTEX_BUFFER_VIEW vb_view = {
 		util_vbuf_stq->GetBuffer12()->GetGPUVirtualAddress(), // D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
-		util_vbuf_stq->GetSize(),                             // UINT SizeInBytes; This is the size of the entire buffer, not just the size of the vertex data for one draw call, since the offsetting is done in the draw call itself.
+		static_cast<UINT>(util_vbuf_stq->GetSize()),          // UINT SizeInBytes; This is the size of the entire buffer, not just the size of the vertex data for one draw call, since the offsetting is done in the draw call itself.
 		sizeof(STQVertex)                                     // UINT StrideInBytes;
 	};
 
@@ -714,7 +714,7 @@ void DrawShadedTexQuad(D3DTexture2D* texture,
 	// 2 ^ D3D12_MAX_TEXTURE_DIMENSION_2_TO_EXP = 131072
 	D3D::current_command_list->RSSetScissorRects(1, &CD3DX12_RECT(0, 0, 131072, 131072));
 
-	D3D::current_command_list->DrawInstanced(4, 1, stq_offset, 0);
+	D3D::current_command_list->DrawInstanced(4, 1, static_cast<UINT>(stq_offset), 0);
 
 	g_renderer->RestoreAPIState();
 }
@@ -749,7 +749,7 @@ void DrawColorQuad(u32 Color, float z, float x1, float y1, float x2, float y2, D
 
 	D3D12_VERTEX_BUFFER_VIEW vb_view = {
 		util_vbuf_cq->GetBuffer12()->GetGPUVirtualAddress(), // D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
-		util_vbuf_cq->GetSize(),                             // UINT SizeInBytes; This is the size of the entire buffer, not just the size of the vertex data for one draw call, since the offsetting is done in the draw call itself.
+		static_cast<UINT>(util_vbuf_cq->GetSize()),          // UINT SizeInBytes; This is the size of the entire buffer, not just the size of the vertex data for one draw call, since the offsetting is done in the draw call itself.
 		sizeof(ColVertex)                                    // UINT StrideInBytes;
 	};
 
@@ -795,7 +795,7 @@ void DrawColorQuad(u32 Color, float z, float x1, float y1, float x2, float y2, D
 	// 2 ^ D3D12_MAX_TEXTURE_DIMENSION_2_TO_EXP = 131072
 	D3D::current_command_list->RSSetScissorRects(1, &CD3DX12_RECT(0, 0, 131072, 131072));
 
-	D3D::current_command_list->DrawInstanced(4, 1, cq_offset, 0);
+	D3D::current_command_list->DrawInstanced(4, 1, static_cast<UINT>(cq_offset), 0);
 
 	g_renderer->RestoreAPIState();
 }
@@ -822,7 +822,7 @@ void DrawClearQuad(u32 Color, float z, D3D12_BLEND_DESC* blend_desc, D3D12_DEPTH
 
 	D3D12_VERTEX_BUFFER_VIEW vb_view = {
 		util_vbuf_clearq->GetBuffer12()->GetGPUVirtualAddress(), // D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
-		util_vbuf_clearq->GetSize(),                             // UINT SizeInBytes; This is the size of the entire buffer, not just the size of the vertex data for one draw call, since the offsetting is done in the draw call itself.
+		static_cast<UINT>(util_vbuf_clearq->GetSize()),          // UINT SizeInBytes; This is the size of the entire buffer, not just the size of the vertex data for one draw call, since the offsetting is done in the draw call itself.
 		sizeof(ClearVertex)                                      // UINT StrideInBytes;
 	};
 
@@ -870,7 +870,7 @@ void DrawClearQuad(u32 Color, float z, D3D12_BLEND_DESC* blend_desc, D3D12_DEPTH
 	// 2 ^ D3D12_MAX_TEXTURE_DIMENSION_2_TO_EXP = 131072
 	D3D::current_command_list->RSSetScissorRects(1, &CD3DX12_RECT(0, 0, 131072, 131072));
 
-	D3D::current_command_list->DrawInstanced(4, 1, clearq_offset, 0);
+	D3D::current_command_list->DrawInstanced(4, 1, static_cast<UINT>(clearq_offset), 0);
 
 	g_renderer->RestoreAPIState();
 }
@@ -942,7 +942,7 @@ void DrawEFBPokeQuads(EFBAccessType type,
 		size_t required_bytes = COL_QUAD_SIZE * points_to_draw;
 
 		void* buffer_ptr = nullptr;
-		int base_vertex_index = util_vbuf_efbpokequads->BeginAppendData(&buffer_ptr, static_cast<int>(required_bytes), sizeof(ColVertex));
+		size_t base_vertex_index = util_vbuf_efbpokequads->BeginAppendData(&buffer_ptr, required_bytes, sizeof(ColVertex));
 
 		CHECK(base_vertex_index * 16 + required_bytes <= util_vbuf_efbpokequads->GetSize(), "Uh oh");
 
@@ -953,7 +953,7 @@ void DrawEFBPokeQuads(EFBAccessType type,
 
 		D3D12_VERTEX_BUFFER_VIEW vb_view = {
 			util_vbuf_efbpokequads->GetBuffer12()->GetGPUVirtualAddress(), // D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
-			util_vbuf_efbpokequads->GetSize(),                             // UINT SizeInBytes; This is the size of the entire buffer, not just the size of the vertex data for one draw call, since the offsetting is done in the draw call itself.
+			static_cast<UINT>(util_vbuf_efbpokequads->GetSize()),          // UINT SizeInBytes; This is the size of the entire buffer, not just the size of the vertex data for one draw call, since the offsetting is done in the draw call itself.
 			sizeof(ColVertex)                                              // UINT StrideInBytes;
 		};
 
@@ -991,7 +991,7 @@ void DrawEFBPokeQuads(EFBAccessType type,
 		}
 
 		// Issue the draw
-		D3D::current_command_list->DrawInstanced(6 * static_cast<unsigned int>(points_to_draw), 1, base_vertex_index, 0);
+		D3D::current_command_list->DrawInstanced(6 * static_cast<UINT>(points_to_draw), 1, static_cast<UINT>(base_vertex_index), 0);
 	}
 
 }

--- a/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
@@ -4,6 +4,7 @@
 
 #include <cctype>
 #include <list>
+#include <memory>
 #include <string>
 
 #include "VideoBackends/D3D12/D3DBase.h"
@@ -58,11 +59,11 @@ class UtilVertexBuffer
 public:
 	explicit UtilVertexBuffer(size_t size)
 	{
-		m_stream_buffer = new D3DStreamBuffer(size, size * 4, nullptr);
+		m_stream_buffer = std::make_unique<D3DStreamBuffer>(size, size * 4, nullptr);
 	}
+
 	~UtilVertexBuffer()
 	{
-		SAFE_DELETE(m_stream_buffer);
 	}
 
 	size_t GetSize() const { return m_stream_buffer->GetSize(); }
@@ -97,14 +98,14 @@ public:
 	}
 
 private:
-	D3DStreamBuffer* m_stream_buffer = nullptr;
+	std::unique_ptr<D3DStreamBuffer> m_stream_buffer;
 };
 
 CD3DFont font;
-UtilVertexBuffer* util_vbuf_stq = nullptr;
-UtilVertexBuffer* util_vbuf_cq = nullptr;
-UtilVertexBuffer* util_vbuf_clearq = nullptr;
-UtilVertexBuffer* util_vbuf_efbpokequads = nullptr;
+static std::unique_ptr<UtilVertexBuffer> util_vbuf_stq;
+static std::unique_ptr<UtilVertexBuffer> util_vbuf_cq;
+static std::unique_ptr<UtilVertexBuffer> util_vbuf_clearq;
+static std::unique_ptr<UtilVertexBuffer> util_vbuf_efbpokequads;
 
 static const unsigned int s_max_num_vertices = 8000 * 6;
 
@@ -541,10 +542,10 @@ static size_t clearq_offset;
 
 void InitUtils()
 {
-	util_vbuf_stq = new UtilVertexBuffer(0x10000);
-	util_vbuf_cq = new UtilVertexBuffer(0x10000);
-	util_vbuf_clearq = new UtilVertexBuffer(0x10000);
-	util_vbuf_efbpokequads = new UtilVertexBuffer(0x100000);
+	util_vbuf_stq          = std::make_unique<UtilVertexBuffer>(0x10000);
+	util_vbuf_cq           = std::make_unique<UtilVertexBuffer>(0x10000);
+	util_vbuf_clearq       = std::make_unique<UtilVertexBuffer>(0x10000);
+	util_vbuf_efbpokequads = std::make_unique<UtilVertexBuffer>(0x100000);
 
 	D3D12_SAMPLER_DESC point_sampler_desc = {
 		D3D12_FILTER_MIN_MAG_MIP_POINT,
@@ -590,10 +591,10 @@ void ShutdownUtils()
 {
 	font.Shutdown();
 
-	SAFE_DELETE(util_vbuf_stq);
-	SAFE_DELETE(util_vbuf_cq);
-	SAFE_DELETE(util_vbuf_clearq);
-	SAFE_DELETE(util_vbuf_efbpokequads);
+	util_vbuf_stq.reset();
+	util_vbuf_cq.reset();
+	util_vbuf_clearq.reset();
+	util_vbuf_efbpokequads.reset();
 }
 
 void SetPointCopySampler()

--- a/Source/Core/VideoBackends/D3D12/ShaderConstantsManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/ShaderConstantsManager.cpp
@@ -2,11 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "D3DBase.h"
-#include "D3DCommandListManager.h"
-#include "D3DStreamBuffer.h"
+#include <memory>
 
-#include "ShaderConstantsManager.h"
+#include "VideoBackends/D3D12/D3DBase.h"
+#include "VideoBackends/D3D12/D3DCommandListManager.h"
+#include "VideoBackends/D3D12/D3DStreamBuffer.h"
+#include "VideoBackends/D3D12/ShaderConstantsManager.h"
 
 #include "VideoCommon/GeometryShaderManager.h"
 #include "VideoCommon/PixelShaderManager.h"
@@ -25,7 +26,7 @@ enum SHADER_STAGE
 	SHADER_STAGE_COUNT = 3
 };
 
-static std::array<D3DStreamBuffer*, SHADER_STAGE_COUNT> s_shader_constant_stream_buffers = {};
+static std::array<std::unique_ptr<D3DStreamBuffer>, SHADER_STAGE_COUNT> s_shader_constant_stream_buffers;
 
 static const unsigned int s_shader_constant_buffer_padded_sizes[SHADER_STAGE_COUNT] = {
 	(sizeof(GeometryShaderConstants) + 0xff) & ~0xff,
@@ -37,14 +38,14 @@ void ShaderConstantsManager::Init()
 {
 	// Allow a large maximum size, as we want to minimize stalls here
 	std::generate(std::begin(s_shader_constant_stream_buffers), std::end(s_shader_constant_stream_buffers), []() {
-		return new D3DStreamBuffer(2 * 1024 * 1024, 64 * 1024 * 1024, nullptr);
+		return std::make_unique<D3DStreamBuffer>(2 * 1024 * 1024, 64 * 1024 * 1024, nullptr);
 	});
 }
 
 void ShaderConstantsManager::Shutdown()
 {
-	for (auto& it : s_shader_constant_stream_buffers)
-		SAFE_DELETE(it);
+	for (auto& buffer : s_shader_constant_stream_buffers)
+		buffer.reset();
 }
 
 bool ShaderConstantsManager::LoadAndSetGeometryShaderConstants()

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -563,7 +563,7 @@ TextureCache::TextureCache()
 	m_palette_pixel_shaders[GX_TL_RGB565] = GetConvertShader12(std::string("RGB565"));
 	m_palette_pixel_shaders[GX_TL_RGB5A3] = GetConvertShader12(std::string("RGB5A3"));
 
-	m_palette_stream_buffer = new D3DStreamBuffer(sizeof(u16) * 256 * 1024, sizeof(u16) * 256 * 1024 * 16, nullptr);
+	m_palette_stream_buffer = std::make_unique<D3DStreamBuffer>(sizeof(u16) * 256 * 1024, sizeof(u16) * 256 * 1024 * 16, nullptr);
 
 	// Right now, there are only two variants of palette_uniform data. So, we'll just create an upload heap to permanently store both of these.
 	CheckHR(
@@ -603,8 +603,6 @@ TextureCache::~TextureCache()
 	s_encoder.reset();
 
 	s_efb_copy_stream_buffer.reset();
-
-	SAFE_DELETE(m_palette_stream_buffer);
 
 	if (s_texture_cache_entry_readback_buffer)
 	{

--- a/Source/Core/VideoBackends/D3D12/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "VideoBackends/D3D12/D3DTexture.h"
 #include "VideoCommon/TextureCacheBase.h"
 
@@ -59,7 +61,7 @@ private:
 	void CompileShaders() override { }
 	void DeleteShaders() override { }
 
-	D3DStreamBuffer* m_palette_stream_buffer = nullptr;
+	std::unique_ptr<D3DStreamBuffer> m_palette_stream_buffer;
 
 	ID3D12Resource* m_palette_uniform_buffer = nullptr;
 	D3D12_SHADER_BYTECODE m_palette_pixel_shaders[3] = {};

--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -31,9 +31,9 @@ static constexpr unsigned int MAX_VBUFFER_SIZE = VertexManager::MAXVBUFFERSIZE *
 void VertexManager::SetIndexBuffer()
 {
 	D3D12_INDEX_BUFFER_VIEW ib_view = {
-		m_index_stream_buffer->GetBaseGPUAddress(), // D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
-		m_index_stream_buffer->GetSize(),           // UINT SizeInBytes;
-		DXGI_FORMAT_R16_UINT                        // DXGI_FORMAT Format;
+		m_index_stream_buffer->GetBaseGPUAddress(),          // D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
+		static_cast<UINT>(m_index_stream_buffer->GetSize()), // UINT SizeInBytes;
+		DXGI_FORMAT_R16_UINT                                 // DXGI_FORMAT Format;
 	};
 
 	D3D::current_command_list->IASetIndexBuffer(&ib_view);
@@ -95,9 +95,9 @@ void VertexManager::Draw(u32 stride)
 	if (D3D::command_list_mgr->GetCommandListDirtyState(COMMAND_LIST_STATE_VERTEX_BUFFER) || s_previous_stride != stride)
 	{
 		D3D12_VERTEX_BUFFER_VIEW vb_view = {
-			m_vertex_stream_buffer->GetBaseGPUAddress(), // D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
-			m_vertex_stream_buffer->GetSize(),           // UINT SizeInBytes;
-			stride                                       // UINT StrideInBytes;
+			m_vertex_stream_buffer->GetBaseGPUAddress(),          // D3D12_GPU_VIRTUAL_ADDRESS BufferLocation;
+			static_cast<UINT>(m_vertex_stream_buffer->GetSize()), // UINT SizeInBytes;
+			stride                                                // UINT StrideInBytes;
 		};
 
 		D3D::current_command_list->IASetVertexBuffers(0, 1, &vb_view);
@@ -194,11 +194,11 @@ void VertexManager::ResetBuffer(u32 stride)
 	}
 
 	s_pBaseBufferPointer = static_cast<u8*>(m_vertex_stream_buffer->GetBaseCPUAddress());
-	s_pEndBufferPointer = s_pBaseBufferPointer + m_vertex_stream_buffer->GetSize();
-	s_pCurBufferPointer = static_cast<u8*>(m_vertex_stream_buffer->GetCPUAddressOfCurrentAllocation());
-	m_vertex_draw_offset = m_vertex_stream_buffer->GetOffsetOfCurrentAllocation();
+	s_pEndBufferPointer  = s_pBaseBufferPointer + m_vertex_stream_buffer->GetSize();
+	s_pCurBufferPointer  = static_cast<u8*>(m_vertex_stream_buffer->GetCPUAddressOfCurrentAllocation());
+	m_vertex_draw_offset = static_cast<u32>(m_vertex_stream_buffer->GetOffsetOfCurrentAllocation());
 
-	command_list_executed |= m_index_stream_buffer->AllocateSpaceInBuffer(MAXIBUFFERSIZE  * sizeof(u16), sizeof(u16));
+	command_list_executed |= m_index_stream_buffer->AllocateSpaceInBuffer(MAXIBUFFERSIZE * sizeof(u16), sizeof(u16));
 	if (command_list_executed)
 	{
 		g_renderer->SetViewport();
@@ -211,8 +211,8 @@ void VertexManager::ResetBuffer(u32 stride)
 		m_index_stream_buffer_reallocated = false;
 	}
 
-	m_index_draw_offset = m_index_stream_buffer->GetOffsetOfCurrentAllocation();
-	IndexGenerator::Start(reinterpret_cast<u16*>(m_index_stream_buffer->GetCPUAddressOfCurrentAllocation()));
+	m_index_draw_offset = static_cast<u32>(m_index_stream_buffer->GetOffsetOfCurrentAllocation());
+	IndexGenerator::Start(static_cast<u16*>(m_index_stream_buffer->GetCPUAddressOfCurrentAllocation()));
 }
 
 }  // namespace

--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -44,8 +44,8 @@ void VertexManager::CreateDeviceObjects()
 	m_vertex_draw_offset = 0;
 	m_index_draw_offset = 0;
 
-	m_vertex_stream_buffer = new D3DStreamBuffer(VertexManager::MAXVBUFFERSIZE * 2, MAX_VBUFFER_SIZE, &m_vertex_stream_buffer_reallocated);
-	m_index_stream_buffer = new D3DStreamBuffer(VertexManager::MAXIBUFFERSIZE * sizeof(u16) * 2, VertexManager::MAXIBUFFERSIZE * sizeof(u16) * 16, &m_index_stream_buffer_reallocated);
+	m_vertex_stream_buffer = std::make_unique<D3DStreamBuffer>(MAXVBUFFERSIZE * 2, MAX_VBUFFER_SIZE, &m_vertex_stream_buffer_reallocated);
+	m_index_stream_buffer  = std::make_unique<D3DStreamBuffer>(MAXIBUFFERSIZE * sizeof(u16) * 2, MAXIBUFFERSIZE * sizeof(u16) * 16, &m_index_stream_buffer_reallocated);
 
 	SetIndexBuffer();
 
@@ -57,8 +57,8 @@ void VertexManager::CreateDeviceObjects()
 
 void VertexManager::DestroyDeviceObjects()
 {
-	SAFE_DELETE(m_vertex_stream_buffer);
-	SAFE_DELETE(m_index_stream_buffer);
+	m_vertex_stream_buffer.reset();
+	m_index_stream_buffer.reset();
 
 	m_vertex_cpu_buffer.clear();
 	m_index_cpu_buffer.clear();

--- a/Source/Core/VideoBackends/D3D12/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include "VideoCommon/VertexManagerBase.h"
 
 namespace DX12
@@ -34,8 +35,8 @@ private:
 	u32 m_vertex_draw_offset;
 	u32 m_index_draw_offset;
 
-	D3DStreamBuffer* m_vertex_stream_buffer = nullptr;
-	D3DStreamBuffer* m_index_stream_buffer = nullptr;
+	std::unique_ptr<D3DStreamBuffer> m_vertex_stream_buffer;
+	std::unique_ptr<D3DStreamBuffer> m_index_stream_buffer;
 
 	bool m_vertex_stream_buffer_reallocated = false;
 	bool m_index_stream_buffer_reallocated = false;


### PR DESCRIPTION
Only ones that remain are ones utilized by classes for reference counting.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3645)
<!-- Reviewable:end -->
