### PR TITLE
[GameINI] Flag Mario Party 8 as a non-widescreen game

### DIFF
--- a/Data/Sys/GameSettings/RM8.ini
+++ b/Data/Sys/GameSettings/RM8.ini
@@ -1,15 +1,27 @@
 # RM8E01, RM8J01, RM8K01, RM8P01 - Mario Party 8
+
 [Core]
 # Values set here will override the main Dolphin settings.
+
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
 EmulationIssues = 
+
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
+
 [OnFrame]
+# Add memory patches to be applied every frame here.
+
 [ActionReplay]
+# Add action replay cheats here.
+
 [Video_Enhancements]
 ForceFiltering = False
+
 [Video_Hacks]
 EFBToTextureEnable = False
+
+[Wii]
+Widescreen = False


### PR DESCRIPTION
As a followup of PR #3607, flag Mario Party 8 as non-widescreen too, like @phire requested:

> It might be worth forcing Mario Party 8 to 4:3
>
> Even if it does add pillar boxing, it's doing so by sacrificing 33% of it's horizontal resolution. I really doubt any dolphin users want pillar boxing or the decreased resolution.

CC @delroth, @Linktothepast

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3651)
<!-- Reviewable:end -->
