### PR TITLE
D3D11: Implement non-blocking CPU EFB access

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -10,6 +10,7 @@
 #include "VideoBackends/D3D/D3DShader.h"
 #include "VideoBackends/D3D/D3DState.h"
 #include "VideoBackends/D3D/D3DUtil.h"
+#include "VideoBackends/D3D/FramebufferManager.h"
 #include "VideoBackends/D3D/GeometryShaderCache.h"
 #include "VideoBackends/D3D/PixelShaderCache.h"
 #include "VideoBackends/D3D/VertexShaderCache.h"
@@ -724,7 +725,7 @@ void DrawEFBPokeQuads(EFBAccessType type, const EfbPokeData* points, size_t num_
 			float x2 = float(point->x + 1) * 2.0f / EFB_WIDTH - 1.0f;
 			float y2 = -float(point->y + 1) * 2.0f / EFB_HEIGHT + 1.0f;
 			float z = (type == POKE_Z) ? (1.0f - float(point->data & 0xFFFFFF) / 16777216.0f) : 0.0f;
-			u32 col = (type == POKE_Z) ? 0 : ((point->data & 0xFF00FF00) | ((point->data >> 16) & 0xFF) | ((point->data << 16) & 0xFF0000));
+			u32 col = (type == POKE_Z) ? 0 : RGBA8ToBGRA8(point->data);
 			current_point_index++;
 
 			// quad -> triangles
@@ -735,6 +736,11 @@ void DrawEFBPokeQuads(EFBAccessType type, const EfbPokeData* points, size_t num_
 			InitColVertex(&vertex[3], x1, y2, z, col);
 			InitColVertex(&vertex[4], x2, y1, z, col);
 			InitColVertex(&vertex[5], x2, y2, z, col);
+
+			if (type == POKE_COLOR)
+				FramebufferManager::UpdateEFBColorAccessCopy(point->x, point->y, col);
+			else
+				FramebufferManager::UpdateEFBDepthAccessCopy(point->x, point->y, z);
 		}
 
 		// unmap the util buffer, and issue the draw

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -27,11 +27,7 @@ unsigned int FramebufferManager::m_target_height;
 ID3D11DepthStencilState* FramebufferManager::m_depth_resolve_depth_state;
 
 D3DTexture2D* &FramebufferManager::GetEFBColorTexture() { return m_efb.color_tex; }
-ID3D11Texture2D* &FramebufferManager::GetEFBColorStagingBuffer() { return m_efb.color_staging_buf; }
-
 D3DTexture2D* &FramebufferManager::GetEFBDepthTexture() { return m_efb.depth_tex; }
-D3DTexture2D* &FramebufferManager::GetEFBDepthReadTexture() { return m_efb.depth_read_texture; }
-ID3D11Texture2D* &FramebufferManager::GetEFBDepthStagingBuffer() { return m_efb.depth_staging_buf; }
 
 D3DTexture2D* &FramebufferManager::GetResolvedEFBColorTexture()
 {
@@ -120,12 +116,6 @@ FramebufferManager::FramebufferManager()
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetSRV(), "EFB color temp texture shader resource view");
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetRTV(), "EFB color temp texture render target view");
 
-	// AccessEFB - Sysmem buffer used to retrieve the pixel data from color_tex
-	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.color_staging_buf);
-	CHECK(hr==S_OK, "create EFB color staging buffer (hr=%#x)", hr);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_staging_buf, "EFB color staging texture (used for Renderer::AccessEFB)");
-
 	// EFB depth buffer - primary depth buffer
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
 	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
@@ -135,21 +125,6 @@ FramebufferManager::FramebufferManager()
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetTex(), "EFB depth texture");
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetDSV(), "EFB depth texture depth stencil view");
 	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetSRV(), "EFB depth texture shader resource view");
-
-	// Render buffer for AccessEFB (depth data)
-	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, D3D11_BIND_RENDER_TARGET);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
-	CHECK(hr==S_OK, "create EFB depth read texture (hr=%#x)", hr);
-	m_efb.depth_read_texture = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
-	SAFE_RELEASE(buf);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_read_texture->GetTex(), "EFB depth read texture (used in Renderer::AccessEFB)");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_read_texture->GetRTV(), "EFB depth read texture render target view (used in Renderer::AccessEFB)");
-
-	// AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
-	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.depth_staging_buf);
-	CHECK(hr==S_OK, "create EFB depth staging buffer (hr=%#x)", hr);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_staging_buf, "EFB depth staging texture (used for Renderer::AccessEFB)");
 
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
@@ -187,19 +162,20 @@ FramebufferManager::FramebufferManager()
 	}
 
 	s_xfbEncoder.Init();
+
+	InitializeEFBAccessCopies();
 }
 
 FramebufferManager::~FramebufferManager()
 {
 	s_xfbEncoder.Shutdown();
 
+	DestroyEFBAccessCopies();
+
 	SAFE_RELEASE(m_efb.color_tex);
-	SAFE_RELEASE(m_efb.color_temp_tex);
-	SAFE_RELEASE(m_efb.color_staging_buf);
-	SAFE_RELEASE(m_efb.resolved_color_tex);
 	SAFE_RELEASE(m_efb.depth_tex);
-	SAFE_RELEASE(m_efb.depth_staging_buf);
-	SAFE_RELEASE(m_efb.depth_read_texture);
+	SAFE_RELEASE(m_efb.color_temp_tex);
+	SAFE_RELEASE(m_efb.resolved_color_tex);
 	SAFE_RELEASE(m_efb.resolved_depth_tex);
 	SAFE_RELEASE(m_depth_resolve_depth_state);
 }
@@ -251,6 +227,181 @@ void XFBSource::CopyEFB(float Gamma)
 		FramebufferManager::GetEFBDepthTexture()->GetDSV());
 
 	g_renderer->RestoreAPIState();
+}
+
+u32 FramebufferManager::ReadEFBColorAccessCopy(u32 x, u32 y)
+{
+	if (!m_efb.color_access_staging_map.pData)
+		MapEFBColorAccessCopy();
+
+	u32 color;
+	size_t buffer_offset = y * m_efb.color_access_staging_map.RowPitch + x * sizeof(u32);
+	memcpy(&color, reinterpret_cast<u8*>(m_efb.color_access_staging_map.pData) + buffer_offset, sizeof(color));
+	return color;
+}
+
+float FramebufferManager::ReadEFBDepthAccessCopy(u32 x, u32 y)
+{
+	if (!m_efb.depth_access_staging_map.pData)
+		MapEFBDepthAccessCopy();
+
+	float depth;
+	size_t buffer_offset = y * m_efb.depth_access_staging_map.RowPitch + x * sizeof(float);
+	memcpy(&depth, reinterpret_cast<u8*>(m_efb.depth_access_staging_map.pData) + buffer_offset, sizeof(depth));
+	return depth;
+}
+
+void FramebufferManager::UpdateEFBColorAccessCopy(u32 x, u32 y, u32 color)
+{
+	if (!m_efb.color_access_staging_map.pData)
+		return;
+
+	size_t buffer_offset = y * m_efb.color_access_staging_map.RowPitch + x * sizeof(u32);
+	memcpy(reinterpret_cast<u8*>(m_efb.color_access_staging_map.pData) + buffer_offset, &color, sizeof(color));
+}
+
+void FramebufferManager::UpdateEFBDepthAccessCopy(u32 x, u32 y, float depth)
+{
+	if (!m_efb.depth_access_staging_map.pData)
+		return;
+
+	size_t buffer_offset = y * m_efb.depth_access_staging_map.RowPitch + x * sizeof(float);
+	memcpy(reinterpret_cast<u8*>(m_efb.depth_access_staging_map.pData) + buffer_offset, &depth, sizeof(depth));
+}
+
+void FramebufferManager::InitializeEFBAccessCopies()
+{
+	CD3D11_TEXTURE2D_DESC texdesc;
+	ID3D11Texture2D* buf;
+	HRESULT hr;
+
+	// EFB access - color resize buffer
+	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, EFB_WIDTH, EFB_HEIGHT, 1, 1, D3D11_BIND_RENDER_TARGET);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	CHECK(hr == S_OK, "create EFB color read texture (hr=%#x)", hr);
+	m_efb.color_access_resize_tex = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
+	SAFE_RELEASE(buf);
+	D3D::SetDebugObjectName(m_efb.color_access_resize_tex->GetTex(), "EFB access color resize buffer");
+	D3D::SetDebugObjectName(m_efb.color_access_resize_tex->GetRTV(), "EFB access color resize buffer render target view");
+
+	// EFB access - color staging/readback buffer
+	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, EFB_WIDTH, EFB_HEIGHT, 1, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.color_access_staging_tex);
+	CHECK(hr == S_OK, "create EFB color staging buffer (hr=%#x)", hr);
+	D3D::SetDebugObjectName(m_efb.color_access_staging_tex, "EFB access color staging buffer");
+
+	// Render buffer for AccessEFB (depth data)
+	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, EFB_WIDTH, EFB_HEIGHT, 1, 1, D3D11_BIND_RENDER_TARGET);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	CHECK(hr == S_OK, "create EFB depth read texture (hr=%#x)", hr);
+	m_efb.depth_access_resize_tex = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
+	SAFE_RELEASE(buf);
+	D3D::SetDebugObjectName(m_efb.depth_access_resize_tex->GetTex(), "EFB access depth resize buffer");
+	D3D::SetDebugObjectName(m_efb.depth_access_resize_tex->GetRTV(), "EFB access depth resize buffer render target view");
+
+	// AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
+	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, EFB_WIDTH, EFB_HEIGHT, 1, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.depth_access_staging_tex);
+	CHECK(hr == S_OK, "create EFB depth staging buffer (hr=%#x)", hr);
+	D3D::SetDebugObjectName(m_efb.depth_access_staging_tex, "EFB access depth staging buffer");
+}
+
+void FramebufferManager::MapEFBColorAccessCopy()
+{
+	ID3D11Texture2D* src_texture;
+	if (m_target_width != EFB_WIDTH || m_target_height != EFB_HEIGHT || g_ActiveConfig.iMultisamples > 1)
+	{
+		// for non-1xIR or multisampled cases, we need to copy to an intermediate texture first
+		g_renderer->ResetAPIState();
+
+		CD3D11_VIEWPORT vp(0.0f, 0.0f, EFB_WIDTH, EFB_HEIGHT);
+		D3D::context->RSSetViewports(1, &vp);
+		D3D::context->OMSetRenderTargets(1, &m_efb.color_access_resize_tex->GetRTV(), nullptr);
+		D3D::SetPointCopySampler();
+
+		CD3D11_RECT src_rect(0, 0, m_target_width, m_target_height);
+		D3D::drawShadedTexQuad(m_efb.color_tex->GetSRV(), &src_rect, m_target_width, m_target_height,
+							   PixelShaderCache::GetColorCopyProgram(true),
+							   VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
+							   nullptr, 1.0f, 0);
+
+		D3D::context->OMSetRenderTargets(1, &GetEFBColorTexture()->GetRTV(), GetEFBDepthTexture()->GetDSV());
+		g_renderer->RestoreAPIState();
+
+		src_texture = m_efb.color_access_resize_tex->GetTex();
+	}
+	else
+	{
+		// can copy directly from efb texture
+		src_texture = m_efb.color_tex->GetTex();
+	}
+
+	D3D::context->CopySubresourceRegion(m_efb.color_access_staging_tex, 0, 0, 0, 0, src_texture, 0, nullptr);
+
+	HRESULT hr = D3D::context->Map(m_efb.color_access_staging_tex, 0, D3D11_MAP_READ_WRITE, 0, &m_efb.color_access_staging_map);
+	CHECK(SUCCEEDED(hr), "failed to map EFB access color texture (hr=%08X)", hr);
+}
+
+void FramebufferManager::MapEFBDepthAccessCopy()
+{
+	ID3D11Texture2D* src_texture;
+	if (m_target_width != EFB_WIDTH || m_target_height != EFB_HEIGHT || g_ActiveConfig.iMultisamples > 1)
+	{
+		// for non-1xIR or multisampled cases, we need to copy to an intermediate texture first
+		g_renderer->ResetAPIState();
+
+		CD3D11_VIEWPORT vp(0.0f, 0.0f, EFB_WIDTH, EFB_HEIGHT);
+		D3D::context->RSSetViewports(1, &vp);
+		D3D::context->OMSetRenderTargets(1, &m_efb.depth_access_resize_tex->GetRTV(), nullptr);
+		D3D::SetPointCopySampler();
+
+		// MSAA has to go through a different path for depth
+		CD3D11_RECT src_rect(0, 0, m_target_width, m_target_height);
+		D3D::drawShadedTexQuad(m_efb.depth_tex->GetSRV(), &src_rect, m_target_width, m_target_height,
+							   (g_ActiveConfig.iMultisamples > 1) ? PixelShaderCache::GetDepthResolveProgram() : PixelShaderCache::GetColorCopyProgram(false),
+							   VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
+							   nullptr, 1.0f, 0);
+
+		D3D::context->OMSetRenderTargets(1, &GetEFBColorTexture()->GetRTV(), GetEFBDepthTexture()->GetDSV());
+		g_renderer->RestoreAPIState();
+
+		src_texture = m_efb.depth_access_resize_tex->GetTex();
+	}
+	else
+	{
+		// can copy directly from efb texture
+		src_texture = m_efb.depth_tex->GetTex();
+	}
+
+	D3D::context->CopySubresourceRegion(m_efb.depth_access_staging_tex, 0, 0, 0, 0, src_texture, 0, nullptr);
+
+	HRESULT hr = D3D::context->Map(m_efb.depth_access_staging_tex, 0, D3D11_MAP_READ_WRITE, 0, &m_efb.depth_access_staging_map);
+	CHECK(SUCCEEDED(hr), "failed to map EFB access depth texture (hr=%08X)", hr);
+}
+
+void FramebufferManager::InvalidateEFBAccessCopies()
+{
+	if (m_efb.color_access_staging_map.pData)
+	{
+		D3D::context->Unmap(m_efb.color_access_staging_tex, 0);
+		m_efb.color_access_staging_map.pData = nullptr;
+	}
+
+	if (m_efb.depth_access_staging_map.pData)
+	{
+		D3D::context->Unmap(m_efb.depth_access_staging_tex, 0);
+		m_efb.depth_access_staging_map.pData = nullptr;
+	}
+}
+
+void FramebufferManager::DestroyEFBAccessCopies()
+{
+	InvalidateEFBAccessCopies();
+
+	SAFE_RELEASE(m_efb.color_access_resize_tex);
+	SAFE_RELEASE(m_efb.color_access_staging_tex);
+	SAFE_RELEASE(m_efb.depth_access_resize_tex);
+	SAFE_RELEASE(m_efb.depth_access_staging_tex);
 }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -63,11 +63,7 @@ public:
 	~FramebufferManager();
 
 	static D3DTexture2D* &GetEFBColorTexture();
-	static ID3D11Texture2D* &GetEFBColorStagingBuffer();
-
 	static D3DTexture2D* &GetEFBDepthTexture();
-	static D3DTexture2D* &GetEFBDepthReadTexture();
-	static ID3D11Texture2D* &GetEFBDepthStagingBuffer();
 
 	static D3DTexture2D* &GetResolvedEFBColorTexture();
 	static D3DTexture2D* &GetResolvedEFBDepthTexture();
@@ -80,6 +76,17 @@ public:
 		m_efb.color_tex = swaptex;
 	}
 
+	// Access EFB from CPU
+	static u32 ReadEFBColorAccessCopy(u32 x, u32 y);
+	static float ReadEFBDepthAccessCopy(u32 x, u32 y);
+	static void UpdateEFBColorAccessCopy(u32 x, u32 y, u32 color);
+	static void UpdateEFBDepthAccessCopy(u32 x, u32 y, float depth);
+	static void InitializeEFBAccessCopies();
+	static void MapEFBColorAccessCopy();
+	static void MapEFBDepthAccessCopy();
+	static void InvalidateEFBAccessCopies();
+	static void DestroyEFBAccessCopies();
+
 private:
 	std::unique_ptr<XFBSourceBase> CreateXFBSource(unsigned int target_width, unsigned int target_height, unsigned int layers) override;
 	void GetTargetSize(unsigned int *width, unsigned int *height) override;
@@ -89,16 +96,21 @@ private:
 	static struct Efb
 	{
 		D3DTexture2D* color_tex;
-		ID3D11Texture2D* color_staging_buf;
 
 		D3DTexture2D* depth_tex;
-		ID3D11Texture2D* depth_staging_buf;
-		D3DTexture2D* depth_read_texture;
 
 		D3DTexture2D* color_temp_tex;
 
 		D3DTexture2D* resolved_color_tex;
 		D3DTexture2D* resolved_depth_tex;
+
+		D3DTexture2D* color_access_resize_tex;
+		ID3D11Texture2D* color_access_staging_tex;
+		D3D11_MAPPED_SUBRESOURCE color_access_staging_map;
+
+		D3DTexture2D* depth_access_resize_tex;
+		ID3D11Texture2D* depth_access_staging_tex;
+		D3D11_MAPPED_SUBRESOURCE depth_access_staging_map;
 
 		int slices;
 	} m_efb;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -47,7 +47,6 @@ static bool s_last_xfb_mode = false;
 
 static Television s_television;
 
-ID3D11Buffer* access_efb_cbuf = nullptr;
 ID3D11BlendState* clearblendstates[4] = {nullptr};
 ID3D11DepthStencilState* cleardepthstates[3] = {nullptr};
 ID3D11BlendState* resetblendstate = nullptr;
@@ -88,14 +87,6 @@ static void SetupDeviceObjects()
 	g_framebuffer_manager = std::make_unique<FramebufferManager>();
 
 	HRESULT hr;
-	float colmat[20]= {0.0f};
-	colmat[0] = colmat[5] = colmat[10] = 1.0f;
-	D3D11_BUFFER_DESC cbdesc = CD3D11_BUFFER_DESC(20*sizeof(float), D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DEFAULT);
-	D3D11_SUBRESOURCE_DATA data;
-	data.pSysMem = colmat;
-	hr = D3D::device->CreateBuffer(&cbdesc, &data, &access_efb_cbuf);
-	CHECK(hr==S_OK, "Create constant buffer for Renderer::AccessEFB");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)access_efb_cbuf, "constant buffer for Renderer::AccessEFB");
 
 	D3D11_DEPTH_STENCIL_DESC ddesc;
 	ddesc.DepthEnable      = FALSE;
@@ -170,7 +161,6 @@ static void TeardownDeviceObjects()
 {
 	g_framebuffer_manager.reset();
 
-	SAFE_RELEASE(access_efb_cbuf);
 	SAFE_RELEASE(clearblendstates[0]);
 	SAFE_RELEASE(clearblendstates[1]);
 	SAFE_RELEASE(clearblendstates[2]);
@@ -364,67 +354,13 @@ void Renderer::SetColorMask()
 //  - GX_PokeZMode (TODO)
 u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 {
-	// TODO: This function currently is broken if anti-aliasing is enabled
-	D3D11_MAPPED_SUBRESOURCE map;
-	ID3D11Texture2D* read_tex;
-
-	// Convert EFB dimensions to the ones of our render target
-	EFBRectangle efbPixelRc;
-	efbPixelRc.left = x;
-	efbPixelRc.top = y;
-	efbPixelRc.right = x + 1;
-	efbPixelRc.bottom = y + 1;
-	TargetRectangle targetPixelRc = Renderer::ConvertEFBRectangle(efbPixelRc);
-
-	// Take the mean of the resulting dimensions; TODO: Don't use the center pixel, compute the average color instead
-	D3D11_RECT RectToLock;
-	if (type == PEEK_COLOR || type == PEEK_Z)
-	{
-		RectToLock.left = (targetPixelRc.left + targetPixelRc.right) / 2;
-		RectToLock.top = (targetPixelRc.top + targetPixelRc.bottom) / 2;
-		RectToLock.right = RectToLock.left + 1;
-		RectToLock.bottom = RectToLock.top + 1;
-	}
-	else
-	{
-		RectToLock.left = targetPixelRc.left;
-		RectToLock.right = targetPixelRc.right;
-		RectToLock.top = targetPixelRc.top;
-		RectToLock.bottom = targetPixelRc.bottom;
-	}
-
 	if (type == PEEK_Z)
 	{
-		ResetAPIState(); // Reset any game specific settings
-
-		// depth buffers can only be completely CopySubresourceRegion'ed, so we're using drawShadedTexQuad instead
-		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, 1.f, 1.f);
-		D3D::context->RSSetViewports(1, &vp);
-		D3D::stateman->SetPixelConstants(0, access_efb_cbuf);
-		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBDepthReadTexture()->GetRTV(), nullptr);
-		D3D::SetPointCopySampler();
-		D3D::drawShadedTexQuad(FramebufferManager::GetEFBDepthTexture()->GetSRV(),
-								&RectToLock,
-								Renderer::GetTargetWidth(),
-								Renderer::GetTargetHeight(),
-								PixelShaderCache::GetColorCopyProgram(true),
-								VertexShaderCache::GetSimpleVertexShader(),
-								VertexShaderCache::GetSimpleInputLayout());
-
-		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
-
-		// copy to system memory
-		D3D11_BOX box = CD3D11_BOX(0, 0, 0, 1, 1, 1);
-		read_tex = FramebufferManager::GetEFBDepthStagingBuffer();
-		D3D::context->CopySubresourceRegion(read_tex, 0, 0, 0, 0, FramebufferManager::GetEFBDepthReadTexture()->GetTex(), 0, &box);
-
-		RestoreAPIState(); // restore game state
-
-		// read the data from system memory
-		D3D::context->Map(read_tex, 0, D3D11_MAP_READ, 0, &map);
+		float val = FramebufferManager::ReadEFBDepthAccessCopy(x, y);
 
 		// depth buffer is inverted in the d3d backend
-		float val = 1.0f - *(float*)map.pData;
+		val = 1.0f - val;
+
 		u32 ret = 0;
 		if (bpmem.zcontrol.pixel_format == PEControl::RGB565_Z16)
 		{
@@ -435,23 +371,15 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		{
 			ret = MathUtil::Clamp<u32>((u32)(val * 16777216.0f), 0, 0xFFFFFF);
 		}
-		D3D::context->Unmap(read_tex, 0);
 
 		return ret;
 	}
 	else if (type == PEEK_COLOR)
 	{
-		// we can directly copy to system memory here
-		read_tex = FramebufferManager::GetEFBColorStagingBuffer();
-		D3D11_BOX box = CD3D11_BOX(RectToLock.left, RectToLock.top, 0, RectToLock.right, RectToLock.bottom, 1);
-		D3D::context->CopySubresourceRegion(read_tex, 0, 0, 0, 0, FramebufferManager::GetEFBColorTexture()->GetTex(), 0, &box);
+		u32 ret = FramebufferManager::ReadEFBColorAccessCopy(x, y);
 
-		// read the data from system memory
-		D3D::context->Map(read_tex, 0, D3D11_MAP_READ, 0, &map);
-		u32 ret = 0;
-		if (map.pData)
-			ret = *(u32*)map.pData;
-		D3D::context->Unmap(read_tex, 0);
+		// our internal buffers are RGBA, yet a BGRA value is expected
+		ret = RGBA8ToBGRA8(ret);
 
 		// check what to do with the alpha channel (GX_PokeAlphaRead)
 		PixelEngine::UPEAlphaReadReg alpha_read_mode = PixelEngine::GetAlphaReadMode();
@@ -481,20 +409,17 @@ void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num
 {
 	ResetAPIState();
 
+	D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
+	D3D::context->RSSetViewports(1, &vp);
+
 	if (type == POKE_COLOR)
 	{
-		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
-		D3D::context->RSSetViewports(1, &vp);
 		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), nullptr);
 	}
 	else // if (type == POKE_Z)
 	{
 		D3D::stateman->PushBlendState(clearblendstates[3]);
 		D3D::stateman->PushDepthState(cleardepthstates[1]);
-
-		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
-
-		D3D::context->RSSetViewports(1, &vp);
 
 		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
 			FramebufferManager::GetEFBDepthTexture()->GetDSV());
@@ -582,6 +507,8 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaE
 	D3D::stateman->PopBlendState();
 
 	RestoreAPIState();
+
+	FramebufferManager::InvalidateEFBAccessCopies();
 }
 
 void Renderer::ReinterpretPixelData(unsigned int convtype)
@@ -613,6 +540,8 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
 
 	FramebufferManager::SwapReinterpretTexture();
 	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+
+	FramebufferManager::InvalidateEFBAccessCopies();
 }
 
 void Renderer::SetBlendMode(bool forceUpdate)
@@ -714,6 +643,8 @@ void formatBufferDump(const u8* in, u8* out, int w, int h, int p)
 // This function has the final picture. We adjust the aspect ratio here.
 void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc, float Gamma)
 {
+	FramebufferManager::InvalidateEFBAccessCopies();
+
 	if (Fifo::WillSkipCurrentFrame() || (!XFBWrited && !g_ActiveConfig.RealXFBEnabled()) || !fbWidth || !fbHeight)
 	{
 		if (SConfig::GetInstance().m_DumpFrames && !frame_data.empty())
@@ -1049,6 +980,9 @@ void Renderer::ApplyState(bool bUseDstAlpha)
 	D3D::stateman->SetPixelShader(PixelShaderCache::GetActiveShader());
 	D3D::stateman->SetVertexShader(VertexShaderCache::GetActiveShader());
 	D3D::stateman->SetGeometryShader(GeometryShaderCache::GetActiveShader());
+
+	// Always called prior to drawing, so we can invalidate the EFB CPU copies here.
+	FramebufferManager::InvalidateEFBAccessCopies();
 }
 
 void Renderer::RestoreState()

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -75,6 +75,16 @@ enum API_TYPE
 	API_NONE   = 3
 };
 
+// Can be used for RGBA->BGRA or BGRA->RGBA
+inline u32 RGBA8ToBGRA8(u32 src)
+{
+	u32 color = src;
+	color &= 0xFF00FF00;
+	color |= (src >> 16) & 0xFF;
+	color |= (src << 16) & 0xFF0000;
+	return color;
+}
+
 inline u32 RGBA8ToRGBA6ToRGBA8(u32 src)
 {
 	u32 color = src;


### PR DESCRIPTION
Trying implementing the EFB cache as a staging texture that is kept mapped until it is invalidated. Will be interesting to see what the overheads are here compared to the GL implementation which copies blocks at a time.

Should also work for MSAA and >1xIR cases.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3652)

<!-- Reviewable:end -->
