### PR TITLE
Remove the shebang from the desktop file

### DIFF
--- a/Installer/dolphin-emu.desktop
+++ b/Installer/dolphin-emu.desktop
@@ -1,4 +1,3 @@
-#!/usr/bin/env xdg-open
 [Desktop Entry]
 Version=1.0
 Icon=dolphin-emu


### PR DESCRIPTION
Executing `xdg-open` on a desktop file opens the default text editor instead of running the application which I suspect is what was intended. Since the file is installed as non-executable, this should have no effect on anyone.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3654)
<!-- Reviewable:end -->
