### PR TITLE
VertexShaderGen: turn pseudo-mod into a simple and

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -135,7 +135,7 @@ static T GenerateVertexShader(API_TYPE api_type)
 
 		if (components & VB_HAS_NRMALL)
 		{
-			out.Write("int normidx = posmtx >= 32 ? (posmtx-32) : posmtx;\n");
+			out.Write("int normidx = posmtx & 31;\n");
 			out.Write("float3 N0 = " I_NORMALMATRICES"[normidx].xyz, N1 = " I_NORMALMATRICES"[normidx+1].xyz, N2 = " I_NORMALMATRICES"[normidx+2].xyz;\n");
 		}
 


### PR DESCRIPTION
The type of posmtx has changed over time: half -> float -> int. I assume this is supposed to be a modulo.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3659)
<!-- Reviewable:end -->
