### PR TITLE
[Netplay] Disable Wiimotes

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -466,7 +466,6 @@ void NetPlayDialog::OnAssignPads(wxCommandEvent&)
 	pmd.ShowModal();
 
 	netplay_server->SetPadMapping(pmd.GetModifiedPadMappings());
-	netplay_server->SetWiimoteMapping(pmd.GetModifiedWiimoteMappings());
 }
 
 void NetPlayDialog::OnKick(wxCommandEvent&)

--- a/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
+++ b/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
@@ -11,10 +11,11 @@
 #include "Core/NetPlayServer.h"
 #include "DolphinWX/NetPlay/PadMapDialog.h"
 
+// Removed Wiimote UI elements due to Wiimotes being flat out broken in netplay.
+
 PadMapDialog::PadMapDialog(wxWindow* parent, NetPlayServer* server, NetPlayClient* client)
 	: wxDialog(parent, wxID_ANY, _("Controller Ports"))
 	, m_pad_mapping(server->GetPadMapping())
-	, m_wii_mapping(server->GetWiimoteMapping())
 	, m_player_list(client->GetPlayers())
 {
 	wxBoxSizer* const h_szr = new wxBoxSizer(wxHORIZONTAL);
@@ -47,33 +48,6 @@ PadMapDialog::PadMapDialog(wxWindow* parent, NetPlayServer* server, NetPlayClien
 		}
 
 		v_szr->Add(m_map_cbox[i], 1);
-
-		h_szr->Add(v_szr, 1, wxTOP | wxEXPAND, 20);
-		h_szr->AddSpacer(10);
-	}
-
-	for (unsigned int i = 0; i < 4; ++i)
-	{
-		wxBoxSizer* const v_szr = new wxBoxSizer(wxVERTICAL);
-		v_szr->Add(new wxStaticText(this, wxID_ANY, (wxString(_("Wiimote ")) + (wxChar)('1' + i))),
-			1, wxALIGN_CENTER_HORIZONTAL);
-
-		m_map_cbox[i + 4] = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, player_names);
-		m_map_cbox[i + 4]->Bind(wxEVT_CHOICE, &PadMapDialog::OnAdjust, this);
-		if (m_wii_mapping[i] == -1)
-		{
-			m_map_cbox[i + 4]->Select(0);
-		}
-		else
-		{
-			for (unsigned int j = 0; j < m_player_list.size(); j++)
-			{
-				if (m_wii_mapping[i] == m_player_list[j]->pid)
-					m_map_cbox[i + 4]->Select(j + 1);
-			}
-		}
-
-		v_szr->Add(m_map_cbox[i + 4], 1);
 
 		h_szr->Add(v_szr, 1, wxTOP | wxEXPAND, 20);
 		h_szr->AddSpacer(10);


### PR DESCRIPTION
This closes a blocker: https://bugs.dolphin-emu.org/issues/9296

I agree with @delroth in that there's no way netplay can be fixed for wiimotes, tested, and merged without delaying 5.0 for gods know how long. So this just disables them.

I removed the UI code for Wiimote selection in netplay UI, so now all the user can assign players in netplay to is gcpads. Naturally, this does not affect normal play. I didn't go through and remove all Wiimote code (functions, some vars) in the netplay specific code because I didn't want to cause unnecessary work for when/if netplay gets fixed. They can just re-add the UI code. I can go through and remove the code entirely if people prefer a cleaner PR.

EDIT: Fog in IRC asked if netplay controller settings persist. They do not. They default to no Wiimotes connected on every launch, so without the UI the user can't really get stuck with Wiimotes on.

Kill the Wiimotes, save the users.

Screenshot of the UI change.

![image](https://i.imgur.com/LopPA55.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3660)
<!-- Reviewable:end -->
