### PR TITLE
[Netplay] Remove reference to WiimoteReal in NetPlayClient.cpp

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -17,7 +17,6 @@
 #include "Core/HW/SI_DeviceGCController.h"
 #include "Core/HW/Sram.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
-#include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
 
 static const char* NETPLAY_VERSION = scm_rev_git_str;
@@ -727,24 +726,6 @@ bool NetPlayClient::StartGame(const std::string &path)
 	m_dialog->BootGame(path);
 
 	UpdateDevices();
-
-	if (SConfig::GetInstance().bWii)
-	{
-		for (unsigned int i = 0; i < 4; ++i)
-			WiimoteReal::ChangeWiimoteSource(i, m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);
-
-		// Needed to prevent locking up at boot if (when) the wiimotes connect out of order.
-		NetWiimote nw;
-		nw.resize(4, 0);
-
-		for (unsigned int w = 0; w < 4; ++w)
-		{
-			if (m_wiimote_map[w] != -1)
-				// probably overkill, but whatever
-				for (unsigned int i = 0; i < 7; ++i)
-					m_wiimote_buffer[w].Push(nw);
-		}
-	}
 
 	return true;
 }

--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -119,11 +119,10 @@ NetPlaySetupFrame::NetPlaySetupFrame(wxWindow* const parent, const CGameListCtrl
 			_("ALERT:\n\n"
 			"Netplay will only work with the following settings:\n"
 			" - DSP Emulator Engine Must be the same on all computers!\n"
-			" - Manually set the extensions for each Wiimote\n"
 			"\n"
 			"All players should use the same Dolphin version and settings.\n"
 			"All memory cards must be identical between players or disabled.\n"
-			"Wiimote support is probably terrible. Don't use it.\n"
+			"Wiimote support is broken in netplay and therefore disabled.\n"
 			"\n"
 			"If connecting directly, the host must have the chosen UDP port open/forwarded!\n"));
 


### PR DESCRIPTION
@mathieui made a comment in my last PR that a reference to WiimoteReal could muck things up, and requested that I fix and test it. So here that is.

I ran my tests over a locally hosted netplay session with MKWii. Worked fine as far as I could tell.

Also, this includes a small text cleanup in the netplay UI. @MaJoRoesch here is a screenshot.

![image](https://i.imgur.com/taBeNew.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3662)
<!-- Reviewable:end -->
