### PR TITLE
TextureConversionShader: Invert depth for Z24 encoder with D3D

### DIFF
--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -557,8 +557,8 @@ static void WriteZ24Encoder(char*& p, API_TYPE ApiType)
 	WRITE(p, "  float3 expanded0;\n");
 	WRITE(p, "  float3 expanded1;\n");
 
-	WriteSampleColor(p, "r", "depth0", 0, ApiType);
-	WriteSampleColor(p, "r", "depth1", 1, ApiType);
+	WriteSampleColor(p, "r", "depth0", 0, ApiType, true);
+	WriteSampleColor(p, "r", "depth1", 1, ApiType, true);
 
 	for (int i = 0; i < 2; i++)
 	{


### PR DESCRIPTION
Fixes a regression introduced by #3505 for Z24 formats not being inverted when generating D3D shaders.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3664)
<!-- Reviewable:end -->
