### PR TITLE
Fix crash when using GFXBackend in per-game INIs (Issue 8876)

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -203,6 +203,7 @@ void ConfigCache::RestoreConfig(SConfig* config)
 }
 
 static ConfigCache config_cache;
+static Core::StoppedCallbackFunc s_next_stop_callback = nullptr;
 
 static GPUDeterminismMode ParseGPUDeterminismMode(const std::string& mode)
 {
@@ -403,13 +404,24 @@ bool BootCore(const std::string& _rFilename)
   return true;
 }
 
-void Stop()
+static void DoRestoreConfig()
 {
-  Core::Stop();
-
   SConfig& StartUp = SConfig::GetInstance();
   StartUp.m_strUniqueID = "00000000";
   config_cache.RestoreConfig(&StartUp);
+
+  // This function is one-shot, so dequeue it.
+  Core::StoppedCallbackFunc callback = s_next_stop_callback;
+  s_next_stop_callback = nullptr;
+  Core::SetOnStoppedCallback(callback);
+  if (callback)
+    callback();
+}
+
+void Stop()
+{
+  s_next_stop_callback = Core::SetOnStoppedCallback(DoRestoreConfig);
+  Core::Stop();
 }
 
 }  // namespace

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -964,9 +964,11 @@ void Shutdown()
   HostDispatchJobs();
 }
 
-void SetOnStoppedCallback(StoppedCallbackFunc callback)
+StoppedCallbackFunc SetOnStoppedCallback(StoppedCallbackFunc callback)
 {
+  StoppedCallbackFunc prev = s_on_stopped_callback;
   s_on_stopped_callback = callback;
+  return prev;
 }
 
 void UpdateWantDeterminism(bool initial)

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -85,7 +85,7 @@ bool PauseAndLock(bool doLock, bool unpauseOnUnlock = true);
 
 // for calling back into UI code without introducing a dependency on it in core
 typedef void (*StoppedCallbackFunc)(void);
-void SetOnStoppedCallback(StoppedCallbackFunc callback);
+StoppedCallbackFunc SetOnStoppedCallback(StoppedCallbackFunc callback);
 
 // Run on the Host thread when the factors change. [NOT THREADSAFE]
 void UpdateWantDeterminism(bool initial = false);


### PR DESCRIPTION
This patch fixes a race condition between BootManager::Stop() and Core::EmuThread().

BootManager::Stop() calls BootManager::ConfigCache::RestoreConfig() which then calls VideoBackendBase::ActivateBackend() which changes the value of g_video_backend. It does this on the UI thread almost immediately after calling Core::Stop(); Core::Stop() allows Core::EmuThread() to continue running asynchronously without joining it before returning. The result is that EmuThread will randomly call member functions of a different video backend than the one that it originally initialized resulting in a crash when the OpenGL backend tries to free resources that were never allocated to begin with.

Specific conditions to reproduce are:

1. Set global video backend to OpenGL
2. Edit a game INI to have "[Core] GFXBackend = D3D"
3. Start the game
4. Exit the game
5. If it does not crash, try opening the game a second time and exit it again. I've sometimes had it work once but never work twice.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3666)
<!-- Reviewable:end -->
