### PR TITLE
[udev] Added udev rule for GC adapter

### DIFF
--- a/Data/51-usb-device.rules
+++ b/Data/51-usb-device.rules
@@ -1,0 +1,5 @@
+#GameCube Controller Adapter
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", TAG+="uaccess"
+
+#Mayflash DolphinBar
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0306", TAG+="uaccess"

--- a/Readme.md
+++ b/Readme.md
@@ -155,6 +155,12 @@ These folders are installed read-only and should not be changed:
 * `Resources`: icons that are theme-agnostic
 * `Wii`: default Wii NAND contents
 
+## Packaging and udev
+The Data folder contains a udev rule file for the official GameCube controller
+adapter and the Mayflash DolphinBar. Package maintainers can use that file in their packages for Dolphin.
+Users compiling Dolphin on Linux can also just copy the file to their udev 
+rules folder.
+
 ## User Folder Structure
 A number of user writeable directories are created for caching purposes or for
 allowing the user to edit their contents. On OS X and Linux these folders are


### PR DESCRIPTION
This fixes a blocker: https://bugs.dolphin-emu.org/issues/8664

The previous PR gave generous permissions to the udev rule which many didn't feel was ideal. This uses a built in udev function many modern distros have, which should work fine.

Note: I do not have a GC adapter and cannot test this. Somebody test this please. :3

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3670)
<!-- Reviewable:end -->
