### PR TITLE
[DVD] Ignore buffer when seeking backwards

### DIFF
--- a/Data/Sys/GameSettings/RPJ.ini
+++ b/Data/Sys/GameSettings/RPJ.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -1301,7 +1301,11 @@ u64 SimulateDiscReadTime(u64 offset, u32 length)
 	u64 disk_read_duration = CalculateRawDiscReadTime(offset, length) +
 		SystemTimers::GetTicksPerSecond() / 1000 * DISC_ACCESS_TIME_MS;
 
-	if (offset + length > s_last_read_offset + 1024 * 1024)
+	// Assume unbuffered read if the read we are performing asks for data >
+	// 1MB past the end of the last read *or* asks for data before the last
+	// read. It assumes the buffer is only used when reading small amounts
+	// forward.
+	if (offset + length > s_last_read_offset + 1024 * 1024 || offset < s_last_read_offset)
 	{
 		// No buffer; just use the simple seek time + read time.
 		DEBUG_LOG(DVDINTERFACE, "Seeking %" PRId64 " bytes",


### PR DESCRIPTION
This fixes Shrek 2, but needs some testing on other titles that might have broken with the previous signedness fix.

The buffer definitely shouldn't be used for large backwards seeks, but with this patch we're also ignoring it for small backwards seeks. This may be a reasonable assumption.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3673)
<!-- Reviewable:end -->
