### PR TITLE
JitArm64: Don't generate the carry if it's not used any more.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -50,6 +50,9 @@ void JitArm64::ComputeRC(u64 imm, int crf, bool needs_sext)
 
 void JitArm64::ComputeCarry(bool Carry)
 {
+	if (!js.op->wantsCA)
+		return;
+
 	if (Carry)
 	{
 		ARM64Reg WA = gpr.GetReg();
@@ -64,6 +67,9 @@ void JitArm64::ComputeCarry(bool Carry)
 
 void JitArm64::ComputeCarry()
 {
+	if (!js.op->wantsCA)
+		return;
+
 	ARM64Reg WA = gpr.GetReg();
 	CSINC(WA, WSP, WSP, CC_CC);
 	STRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));


### PR DESCRIPTION
About 10% of the emited instructions now skip the carry. Very slightly process, but still for free.

Credits goes to Fiora.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3681)
<!-- Reviewable:end -->
