### PR TITLE
[AArch64] Fix fcmp.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -244,8 +244,7 @@ void JitArm64::fcmpX(UGeckoInstruction inst)
 
 	SetJumpTarget(pNaN);
 
-	ORR(XA, XA, 64 - 61, 0, true);
-	ORR(XA, XA, 0, 0, true);
+	MOVI2R(XA, PPCCRToInternal(CR_SO));
 
 	if (a != b)
 	{


### PR DESCRIPTION
Fixes Luigi's head vanishing. Was due to a mishandling of nans.
Confirmed fixed by hardware test.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3683)
<!-- Reviewable:end -->
