### PR TITLE
Fix a few asserts in the VertexShaderGen.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -227,9 +227,7 @@ static T GenerateVertexShader(API_TYPE api_type)
 				out.Write("coord = float4(tex%d.x, tex%d.y, 1.0, 1.0);\n", texinfo.sourcerow - XF_SRCTEX0_INROW, texinfo.sourcerow - XF_SRCTEX0_INROW);
 			break;
 		}
-		// An input form other than ABC1 or AB11 doesn't exist
-		// But the hardware has it as a two bit field
-		_assert_(texinfo.inputform == XF_TEXINPUT_ABC1 || texinfo.inputform == XF_TEXINPUT_AB11);
+		// Input form of AB11 sets z element to 1.0
 		uid_data->texMtxInfo[i].inputform = xfmem.texMtxInfo[i].inputform;
 		if (texinfo.inputform == XF_TEXINPUT_AB11)
 			out.Write("coord.z = 1.0;\n");

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -198,15 +198,12 @@ static T GenerateVertexShader(API_TYPE api_type)
 		switch (texinfo.sourcerow)
 		{
 		case XF_SRCGEOM_INROW:
-			// The following assert was triggered in Super Smash Bros. Project M 3.6.
-			//_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
-			out.Write("coord = rawpos;\n"); // pos.w is 1
+			out.Write("coord.xyz = rawpos.xyz;\n");
 			break;
 		case XF_SRCNORMAL_INROW:
 			if (components & VB_HAS_NRM0)
 			{
-				_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
-				out.Write("coord = float4(rawnorm0.xyz, 1.0);\n");
+				out.Write("coord.xyz = rawnorm0.xyz;\n");
 			}
 			break;
 		case XF_SRCCOLORS_INROW:
@@ -215,15 +212,13 @@ static T GenerateVertexShader(API_TYPE api_type)
 		case XF_SRCBINORMAL_T_INROW:
 			if (components & VB_HAS_NRM1)
 			{
-				_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
-				out.Write("coord = float4(rawnorm1.xyz, 1.0);\n");
+				out.Write("coord.xyz = rawnorm1.xyz;\n");
 			}
 			break;
 		case XF_SRCBINORMAL_B_INROW:
 			if (components & VB_HAS_NRM2)
 			{
-				_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
-				out.Write("coord = float4(rawnorm2.xyz, 1.0);\n");
+				out.Write("coord.xyz = rawnorm2.xyz;\n");
 			}
 			break;
 		default:
@@ -232,6 +227,12 @@ static T GenerateVertexShader(API_TYPE api_type)
 				out.Write("coord = float4(tex%d.x, tex%d.y, 1.0, 1.0);\n", texinfo.sourcerow - XF_SRCTEX0_INROW, texinfo.sourcerow - XF_SRCTEX0_INROW);
 			break;
 		}
+		// An input form other than ABC1 or AB11 doesn't exist
+		// But the hardware has it as a two bit field
+		_assert_(texinfo.inputform == XF_TEXINPUT_ABC1 || texinfo.inputform == XF_TEXINPUT_AB11);
+		uid_data->texMtxInfo[i].inputform = xfmem.texMtxInfo[i].inputform;
+		if (texinfo.inputform == XF_TEXINPUT_AB11)
+			out.Write("coord.z = 1.0;\n");
 
 		// first transformation
 		uid_data->texMtxInfo[i].texgentype = xfmem.texMtxInfo[i].texgentype;

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -256,11 +256,9 @@ static T GenerateVertexShader(API_TYPE api_type)
 
 				break;
 			case XF_TEXGEN_COLOR_STRGBC0:
-				_assert_(texinfo.sourcerow == XF_SRCCOLORS_INROW);
 				out.Write("o.tex%d.xyz = float3(o.colors_0.x, o.colors_0.y, 1);\n", i);
 				break;
 			case XF_TEXGEN_COLOR_STRGBC1:
-				_assert_(texinfo.sourcerow == XF_SRCCOLORS_INROW);
 				out.Write("o.tex%d.xyz = float3(o.colors_1.x, o.colors_1.y, 1);\n", i);
 				break;
 			case XF_TEXGEN_REGULAR:

--- a/Source/Core/VideoCommon/XFMemory.h
+++ b/Source/Core/VideoCommon/XFMemory.h
@@ -178,7 +178,8 @@ union TexMtxInfo
 	{
 		u32 unknown    : 1;
 		u32 projection : 1; // XF_TEXPROJ_X
-		u32 inputform  : 2; // XF_TEXINPUT_X
+		u32 inputform  : 1; // XF_TEXINPUT_X
+		u32 unknown2   : 1;
 		u32 texgentype : 3; // XF_TEXGEN_X
 		u32 sourcerow  : 5; // XF_SRCGEOM_X
 		u32 embosssourceshift : 3; // what generated texcoord to use


### PR DESCRIPTION
Removes a couple asserts in the vertex shader gen when dealing with the input form.
Typically input form ABC1 is used, so it'll pull in the first three elements and always set the fourth to 1.0
The other input form available is AB11, which sets the last two components to 1.0 (Theoretically).
No titles actually use this input form that we know of except for Project M, but it can have some fairly drastic visual differences.

Confirmed correct by hardware test

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3684)
<!-- Reviewable:end -->
