### PR TITLE
EGL: Also check for higher GL versions.

### DIFF
--- a/Source/Core/Common/GL/GLInterface/EGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGL.cpp
@@ -196,8 +196,13 @@ bool cInterfaceEGL::Create(void *window_handle, bool core)
 
 	if (supports_core_profile && core && s_opengl_mode == GLInterfaceMode::MODE_OPENGL)
 	{
-		std::array<std::pair<int, int>, 2> versions_to_try =
+		std::array<std::pair<int, int>, 7> versions_to_try =
 		{{
+			{ 4, 5 },
+			{ 4, 4 },
+			{ 4, 3 },
+			{ 4, 2 },
+			{ 4, 1 },
 			{ 4, 0 },
 			{ 3, 3 },
 		}};


### PR DESCRIPTION
Seems like NVidia just ignores the forward compatible flag.
Additionally, they neither enable any extension which was designed later...
So either compatible profile, or a huge list of core profiles....

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3689)
<!-- Reviewable:end -->
