### PR TITLE
Netplay Wii Remote Removal

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -17,7 +17,6 @@
 #include "Core/HW/SI_DeviceGCController.h"
 #include "Core/HW/Sram.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
-#include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
 
 static const char* NETPLAY_VERSION = scm_rev_git_str;
@@ -727,24 +726,6 @@ bool NetPlayClient::StartGame(const std::string &path)
 	m_dialog->BootGame(path);
 
 	UpdateDevices();
-
-	if (SConfig::GetInstance().bWii)
-	{
-		for (unsigned int i = 0; i < 4; ++i)
-			WiimoteReal::ChangeWiimoteSource(i, m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);
-
-		// Needed to prevent locking up at boot if (when) the wiimotes connect out of order.
-		NetWiimote nw;
-		nw.resize(4, 0);
-
-		for (unsigned int w = 0; w < 4; ++w)
-		{
-			if (m_wiimote_map[w] != -1)
-				// probably overkill, but whatever
-				for (unsigned int i = 0; i < 7; ++i)
-					m_wiimote_buffer[w].Push(nw);
-		}
-	}
 
 	return true;
 }

--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -117,15 +117,12 @@ NetPlaySetupFrame::NetPlaySetupFrame(wxWindow* const parent, const CGameListCtrl
 
 		wxStaticText* const alert_lbl = new wxStaticText(connect_tab, wxID_ANY,
 			_("ALERT:\n\n"
-			"Netplay will only work with the following settings:\n"
-			" - DSP Emulator Engine Must be the same on all computers!\n"
-			" - Manually set the extensions for each Wiimote\n"
+			"All players must use the same Dolphin version.\n"
+			"All memory cards, SD cards and cheats must be identical between players or disabled.\n"
+			"If DSP LLE is used, DSP ROMs must be identical between players.\n"
+			"If connecting directly, the host must have the chosen UDP port open/forwarded!\n"
 			"\n"
-			"All players should use the same Dolphin version and settings.\n"
-			"All memory cards must be identical between players or disabled.\n"
-			"Wiimote support is probably terrible. Don't use it.\n"
-			"\n"
-			"If connecting directly, the host must have the chosen UDP port open/forwarded!\n"));
+			"Wiimote support is broken in netplay and therefore disabled.\n"));
 
 		wxBoxSizer* const top_szr = new wxBoxSizer(wxHORIZONTAL);
 

--- a/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
+++ b/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
@@ -67,11 +67,6 @@ PadMappingArray PadMapDialog::GetModifiedPadMappings() const
 	return m_pad_mapping;
 }
 
-PadMappingArray PadMapDialog::GetModifiedWiimoteMappings() const
-{
-	return m_wii_mapping;
-}
-
 void PadMapDialog::OnAdjust(wxCommandEvent& WXUNUSED(event))
 {
 	for (unsigned int i = 0; i < 4; i++)
@@ -81,11 +76,5 @@ void PadMapDialog::OnAdjust(wxCommandEvent& WXUNUSED(event))
 			m_pad_mapping[i] = m_player_list[player_idx - 1]->pid;
 		else
 			m_pad_mapping[i] = -1;
-
-		player_idx = m_map_cbox[i + 4]->GetSelection();
-		if (player_idx > 0)
-			m_wii_mapping[i] = m_player_list[player_idx - 1]->pid;
-		else
-			m_wii_mapping[i] = -1;
 	}
 }

--- a/Source/Core/DolphinWX/NetPlay/PadMapDialog.h
+++ b/Source/Core/DolphinWX/NetPlay/PadMapDialog.h
@@ -20,13 +20,11 @@ public:
 	PadMapDialog(wxWindow* parent, NetPlayServer* server, NetPlayClient* client);
 
 	PadMappingArray GetModifiedPadMappings() const;
-	PadMappingArray GetModifiedWiimoteMappings() const;
 
 private:
 	void OnAdjust(wxCommandEvent& event);
 
-	wxChoice* m_map_cbox[8];
+	wxChoice* m_map_cbox[4];
 	PadMappingArray m_pad_mapping;
-	PadMappingArray m_wii_mapping;
 	std::vector<const Player*> m_player_list;
 };


### PR DESCRIPTION
Finishes Helios' PR  #3662, as it hasnt been touched in 10 days and I have fixed a segfault as well.

Fully removes wii remote netplay code from the UI, fixing a segfault when assigning controller ports that is currently present in master.

![wiiremotenetplayremoval](https://cloud.githubusercontent.com/assets/5120858/13426090/6200c21e-dfff-11e5-9964-2946e12840b9.png)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3691)
<!-- Reviewable:end -->
