### PR TITLE
Call FinishStateMove in FifoPlayer

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -105,6 +105,9 @@ bool FifoPlayer::Play()
 		}
 	}
 
+	// Let the waiting thread know we are done leaving
+	PowerPC::FinishStateMove();
+
 	IsPlayingBackFifologWithBrokenEFBCopies = false;
 
 	return true;


### PR DESCRIPTION
~~Changes the delay from one second to 1/60th of a second. Prior code was introduced to potentially fix a race condition, but it's not clear what race condition was actually occurring. With the delay at one second, frame advancing FIFO logs was impossible without waiting a full second between each frame advance button press.~~

~~I've marked this as RFC as frankly, I'm not sure if this is correct behaviour or implementation. If anything, the discussion could possibly bring us in the right direction to fixing the real issue if such issue is not properly solved in this PR.~~

Forget everything I said above, this should be the correct behaviour.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3693)
<!-- Reviewable:end -->
