### PR TITLE
JitArm64: Small improvements.

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -1389,6 +1389,10 @@ void ARM64XEmitter::UMADDL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ARM64Reg Ra)
 {
 	EncodeData3SrcInst(5, Rd, Rn, Rm, Ra);
 }
+void ARM64XEmitter::UMULL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
+{
+	UMADDL(Rd, Rn, Rm, SP);
+}
 void ARM64XEmitter::UMSUBL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ARM64Reg Ra)
 {
 	EncodeData3SrcInst(6, Rd, Rn, Rm, Ra);

--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -517,6 +517,7 @@ public:
 	void SMSUBL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ARM64Reg Ra);
 	void SMULH(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void UMADDL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ARM64Reg Ra);
+	void UMULL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void UMSUBL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ARM64Reg Ra);
 	void UMULH(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void MUL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -490,7 +490,7 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 
 				gpr.Flush(FLUSH_MAINTAIN_STATE);
 				fpr.Flush(FLUSH_MAINTAIN_STATE);
-				MOVI2R(W30, ops[i].address);
+				MOVI2R(W30, js.compilerPC);
 				WriteExceptionExit(W30, true);
 			SwitchToNearCode();
 			SetJumpTarget(exit);
@@ -522,7 +522,7 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 
 				gpr.Flush(FLUSH_MAINTAIN_STATE);
 				fpr.Flush(FLUSH_MAINTAIN_STATE);
-				MOVI2R(WA, ops[i].address);
+				MOVI2R(WA, js.compilerPC);
 				WriteExceptionExit(WA, true);
 			SwitchToNearCode();
 			SetJumpTarget(NoExtException);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -225,29 +225,6 @@ void JitArm64::WriteExceptionExit(ARM64Reg dest)
 	BR(EncodeRegTo64(dest));
 }
 
-void JitArm64::WriteExceptionExit()
-{
-	Cleanup();
-	DoDownCount();
-
-	if (Profiler::g_ProfileBlocks)
-		EndTimeProfile(js.curBlock);
-
-	ARM64Reg WA = gpr.GetReg();
-	ARM64Reg XA = EncodeRegTo64(WA);
-	LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(pc));
-	STR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(npc));
-		MOVI2R(XA, (u64)&PowerPC::CheckExceptions);
-		BLR(XA);
-	LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(npc));
-	STR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(pc));
-
-	MOVI2R(XA, (u64)asm_routines.dispatcher);
-	BR(XA);
-
-	gpr.Unlock(WA);
-}
-
 void JitArm64::WriteExternalExceptionExit(ARM64Reg dest)
 {
 	STR(INDEX_UNSIGNED, dest, X29, PPCSTATE_OFF(pc));

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -205,6 +205,7 @@ void JitArm64::WriteExit(u32 destination)
 
 	b->linkData.push_back(linkData);
 }
+
 void JitArm64::WriteExceptionExit(ARM64Reg dest)
 {
 	Cleanup();
@@ -463,10 +464,6 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 
 	gpr.Start(js.gpa);
 	fpr.Start(js.fpa);
-
-	// Setup memory base register
-	u8* base = UReg_MSR(MSR).DR ? Memory::logical_base : Memory::physical_base;
-	MOVI2R(X28, (u64)base);
 
 	if (!SConfig::GetInstance().bEnableDebugging)
 		js.downcountAmount += PatchEngine::GetSpeedhackCycles(em_address);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -87,6 +87,8 @@ public:
 	void rlwnmx(UGeckoInstruction inst);
 	void srawix(UGeckoInstruction inst);
 	void mullwx(UGeckoInstruction inst);
+	void mulhwx(UGeckoInstruction inst);
+	void mulhwux(UGeckoInstruction inst);
 	void addic(UGeckoInstruction inst);
 	void mulli(UGeckoInstruction inst);
 	void addzex(UGeckoInstruction inst);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -17,14 +17,6 @@
 #include "Core/PowerPC/JitArmCommon/BackPatch.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 
-#define PPCSTATE_OFF(elem) (offsetof(PowerPC::PowerPCState, elem))
-
-// Some asserts to make sure we will be able to load everything
-static_assert(PPCSTATE_OFF(spr[1023]) <= 16380, "LDR(32bit) can't reach the last SPR");
-static_assert((PPCSTATE_OFF(ps[0][0]) % 8) == 0, "LDR(64bit VFP) requires FPRs to be 8 byte aligned");
-static_assert(PPCSTATE_OFF(xer_ca) < 4096, "STRB can't store xer_ca!");
-static_assert(PPCSTATE_OFF(xer_so_ov) < 4096, "STRB can't store xer_so_ov!");
-
 class JitArm64 : public JitBase, public Arm64Gen::ARM64CodeBlock
 {
 public:

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -230,6 +230,7 @@ private:
 	// Exits
 	void WriteExit(u32 destination);
 	void WriteExit(Arm64Gen::ARM64Reg dest);
+	void WriteExceptionExit(u32 destination, bool only_external = false);
 	void WriteExceptionExit(Arm64Gen::ARM64Reg dest, bool only_external = false);
 
 	FixupBranch JumpIfCRFieldBit(int field, int bit, bool jump_if_set);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -238,7 +238,6 @@ private:
 	// Exits
 	void WriteExit(u32 destination);
 	void WriteExceptionExit(Arm64Gen::ARM64Reg dest);
-	void WriteExceptionExit();
 	void WriteExternalExceptionExit(ARM64Reg dest);
 	void WriteExitDestInR(Arm64Gen::ARM64Reg dest);
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -198,6 +198,7 @@ private:
 	{
 		nearcode = GetWritableCodePtr();
 		SetCodePtrUnsafe(farcode.GetWritableCodePtr());
+		AlignCode16();
 	}
 
 	void SwitchToNearCode()

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -237,9 +237,8 @@ private:
 
 	// Exits
 	void WriteExit(u32 destination);
-	void WriteExceptionExit(Arm64Gen::ARM64Reg dest);
-	void WriteExternalExceptionExit(ARM64Reg dest);
-	void WriteExitDestInR(Arm64Gen::ARM64Reg dest);
+	void WriteExit(Arm64Gen::ARM64Reg dest);
+	void WriteExceptionExit(Arm64Gen::ARM64Reg dest, bool only_external = false);
 
 	FixupBranch JumpIfCRFieldBit(int field, int bit, bool jump_if_set);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
@@ -31,7 +31,7 @@ void JitArm64BlockCache::WriteDestroyBlock(const u8* location, u32 address)
 	ARM64XEmitter emit((u8 *)location);
 	emit.MOVI2R(W0, address);
 	emit.MOVI2R(X30, (u64)jit->GetAsmRoutines()->dispatcher);
-	emit.STR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(pc));
+	emit.STR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF(pc));
 	emit.BR(X30);
 	emit.FlushIcache();
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64Cache.cpp
@@ -29,9 +29,8 @@ void JitArm64BlockCache::WriteDestroyBlock(const u8* location, u32 address)
 {
 	// must fit within the code generated in JitArm64::WriteExit
 	ARM64XEmitter emit((u8 *)location);
-	emit.MOVI2R(W0, address);
 	emit.MOVI2R(X30, (u64)jit->GetAsmRoutines()->dispatcher);
-	emit.STR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF(pc));
+	emit.MOVI2R(DISPATCHER_PC, address);
 	emit.BR(X30);
 	emit.FlushIcache();
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -60,28 +60,28 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode,
 			{
 				m_float_emit.FCVT(32, 64, D0, RS);
 				m_float_emit.REV32(8, D0, D0);
-				m_float_emit.STR(32, D0, X28, addr);
+				m_float_emit.STR(32, D0, MEM_REG, addr);
 			}
 			else if (flags & BackPatchInfo::FLAG_SIZE_F32I)
 			{
 				m_float_emit.REV32(8, D0, RS);
-				m_float_emit.STR(32, D0, X28, addr);
+				m_float_emit.STR(32, D0, MEM_REG, addr);
 			}
 			else if (flags & BackPatchInfo::FLAG_SIZE_F32X2)
 			{
 				m_float_emit.FCVTN(32, D0, RS);
 				m_float_emit.REV32(8, D0, D0);
-				m_float_emit.STR(64, Q0, X28, addr);
+				m_float_emit.STR(64, Q0, MEM_REG, addr);
 			}
 			else if (flags & BackPatchInfo::FLAG_SIZE_F32X2I)
 			{
 				m_float_emit.REV32(8, D0, RS);
-				m_float_emit.STR(64, Q0, X28, addr);
+				m_float_emit.STR(64, Q0, MEM_REG, addr);
 			}
 			else
 			{
 				m_float_emit.REV64(8, Q0, RS);
-				m_float_emit.STR(64, Q0, X28, addr);
+				m_float_emit.STR(64, Q0, MEM_REG, addr);
 			}
 		}
 		else if (flags & BackPatchInfo::FLAG_LOAD &&
@@ -89,12 +89,12 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode,
 		{
 			if (flags & BackPatchInfo::FLAG_SIZE_F32)
 			{
-				m_float_emit.LDR(32, EncodeRegToDouble(RS), X28, addr);
+				m_float_emit.LDR(32, EncodeRegToDouble(RS), MEM_REG, addr);
 				m_float_emit.REV32(8, EncodeRegToDouble(RS), EncodeRegToDouble(RS));
 			}
 			else
 			{
-				m_float_emit.LDR(64, EncodeRegToDouble(RS), X28, addr);
+				m_float_emit.LDR(64, EncodeRegToDouble(RS), MEM_REG, addr);
 				m_float_emit.REV64(8, EncodeRegToDouble(RS), EncodeRegToDouble(RS));
 			}
 		}
@@ -107,27 +107,27 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, bool fastmem, bool do_farcode,
 				REV16(temp, RS);
 
 			if (flags & BackPatchInfo::FLAG_SIZE_32)
-				STR(temp, X28, addr);
+				STR(temp, MEM_REG, addr);
 			else if (flags & BackPatchInfo::FLAG_SIZE_16)
-				STRH(temp, X28, addr);
+				STRH(temp, MEM_REG, addr);
 			else
-				STRB(RS, X28, addr);
+				STRB(RS, MEM_REG, addr);
 		}
 		else if (flags & BackPatchInfo::FLAG_ZERO_256)
 		{
 			// This literally only stores 32bytes of zeros to the target address
-			ADD(addr, addr, X28);
+			ADD(addr, addr, MEM_REG);
 			STP(INDEX_SIGNED, ZR, ZR, addr, 0);
 			STP(INDEX_SIGNED, ZR, ZR, addr, 16);
 		}
 		else
 		{
 			if (flags & BackPatchInfo::FLAG_SIZE_32)
-				LDR(RS, X28, addr);
+				LDR(RS, MEM_REG, addr);
 			else if (flags & BackPatchInfo::FLAG_SIZE_16)
-				LDRH(RS, X28, addr);
+				LDRH(RS, MEM_REG, addr);
 			else if (flags & BackPatchInfo::FLAG_SIZE_8)
-				LDRB(RS, X28, addr);
+				LDRB(RS, MEM_REG, addr);
 
 			if (!(flags & BackPatchInfo::FLAG_REVERSE))
 			{

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -26,12 +26,12 @@ void JitArm64::sc(UGeckoInstruction inst)
 
 	ARM64Reg WA = gpr.GetReg();
 
-	LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(Exceptions));
+	LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
 	ORR(WA, WA, 31, 0); // Same as WA | EXCEPTION_SYSCALL
-	STR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(Exceptions));
+	STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
 
 	MOVI2R(WA, js.compilerPC + 4);
-	STR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(pc));
+	STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(pc));
 
 	// WA is unlocked in this function
 	WriteExceptionExit(WA);
@@ -60,18 +60,18 @@ void JitArm64::rfi(UGeckoInstruction inst)
 	MOVI2R(WA, (~mask) & clearMSR13);
 	MOVI2R(WB, mask & clearMSR13);
 
-	LDR(INDEX_UNSIGNED, WC, X29, PPCSTATE_OFF(msr));
+	LDR(INDEX_UNSIGNED, WC, PPC_REG, PPCSTATE_OFF(msr));
 
 	AND(WC, WC, WB, ArithOption(WC, ST_LSL, 0)); // rD = Masked MSR
 
-	LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_SRR1])); // rB contains SRR1 here
+	LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_SRR1])); // rB contains SRR1 here
 
 	AND(WA, WA, WB, ArithOption(WA, ST_LSL, 0)); // rB contains masked SRR1 here
 	ORR(WA, WA, WC, ArithOption(WA, ST_LSL, 0)); // rB = Masked MSR OR masked SRR1
 
-	STR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(msr)); // STR rB in to rA
+	STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(msr)); // STR rB in to rA
 
-	LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_SRR0]));
+	LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_SRR0]));
 	gpr.Unlock(WB, WC);
 
 	// WA is unlocked in this function
@@ -97,7 +97,7 @@ void JitArm64::bx(UGeckoInstruction inst)
 		u32 Jumpto = js.compilerPC + 4;
 		ARM64Reg WA = gpr.GetReg();
 		MOVI2R(WA, Jumpto);
-		STR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_LR]));
+		STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
 		gpr.Unlock(WA);
 	}
 
@@ -125,9 +125,9 @@ void JitArm64::bcx(UGeckoInstruction inst)
 	FixupBranch pCTRDontBranch;
 	if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
 	{
-		LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_CTR]));
+		LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
 		SUBS(WA, WA, 1);
-		STR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_CTR]));
+		STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
 
 		if (inst.BO & BO_BRANCH_IF_CTR_0)
 			pCTRDontBranch = B(CC_NEQ);
@@ -151,7 +151,7 @@ void JitArm64::bcx(UGeckoInstruction inst)
 	{
 		u32 Jumpto = js.compilerPC + 4;
 		MOVI2R(WA, Jumpto);
-		STR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_LR]));
+		STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
 	}
 	gpr.Unlock(WA);
 
@@ -205,13 +205,13 @@ void JitArm64::bcctrx(UGeckoInstruction inst)
 		ARM64Reg WB = gpr.GetReg();
 		u32 Jumpto = js.compilerPC + 4;
 		MOVI2R(WB, Jumpto);
-		STR(INDEX_UNSIGNED, WB, X29, PPCSTATE_OFF(spr[SPR_LR]));
+		STR(INDEX_UNSIGNED, WB, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
 		gpr.Unlock(WB);
 	}
 
 	ARM64Reg WA = gpr.GetReg();
 
-	LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_CTR]));
+	LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
 	AND(WA, WA, 30, 29); // Wipe the bottom 2 bits.
 	WriteExit(WA);
 }
@@ -225,9 +225,9 @@ void JitArm64::bclrx(UGeckoInstruction inst)
 	FixupBranch pCTRDontBranch;
 	if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
 	{
-		LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_CTR]));
+		LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
 		SUBS(WA, WA, 1);
-		STR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_CTR]));
+		STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
 
 		if (inst.BO & BO_BRANCH_IF_CTR_0)
 			pCTRDontBranch = B(CC_NEQ);
@@ -246,7 +246,7 @@ void JitArm64::bclrx(UGeckoInstruction inst)
 	SwitchToFarCode();
 	SetJumpTarget(far);
 
-	LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_LR]));
+	LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
 	AND(WA, WA, 30, 29); // Wipe the bottom 2 bits.
 
 	if (inst.LK)
@@ -254,7 +254,7 @@ void JitArm64::bclrx(UGeckoInstruction inst)
 		ARM64Reg WB = gpr.GetReg();
 		u32 Jumpto = js.compilerPC + 4;
 		MOVI2R(WB, Jumpto);
-		STR(INDEX_UNSIGNED, WB, X29, PPCSTATE_OFF(spr[SPR_LR]));
+		STR(INDEX_UNSIGNED, WB, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
 		gpr.Unlock(WB);
 	}
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -30,11 +30,9 @@ void JitArm64::sc(UGeckoInstruction inst)
 	ORR(WA, WA, 31, 0); // Same as WA | EXCEPTION_SYSCALL
 	STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
 
-	MOVI2R(WA, js.compilerPC + 4);
-	STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(pc));
+	gpr.Unlock(WA);
 
-	// WA is unlocked in this function
-	WriteExceptionExit(WA);
+	WriteExceptionExit(js.compilerPC + 4);
 }
 
 void JitArm64::rfi(UGeckoInstruction inst)
@@ -108,8 +106,9 @@ void JitArm64::bx(UGeckoInstruction inst)
 
 		MOVI2R(XA, (u64)&CoreTiming::Idle);
 		BLR(XA);
-		MOVI2R(WA, js.compilerPC);
-		WriteExceptionExit(WA);
+		gpr.Unlock(WA);
+
+		WriteExceptionExit(js.compilerPC);
 	}
 
 	WriteExit(destination);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -94,9 +94,8 @@ void JitArm64::bx(UGeckoInstruction inst)
 
 	if (inst.LK)
 	{
-		u32 Jumpto = js.compilerPC + 4;
 		ARM64Reg WA = gpr.GetReg();
-		MOVI2R(WA, Jumpto);
+		MOVI2R(WA, js.compilerPC + 4);
 		STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
 		gpr.Unlock(WA);
 	}
@@ -149,8 +148,7 @@ void JitArm64::bcx(UGeckoInstruction inst)
 
 	if (inst.LK)
 	{
-		u32 Jumpto = js.compilerPC + 4;
-		MOVI2R(WA, Jumpto);
+		MOVI2R(WA, js.compilerPC + 4);
 		STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
 	}
 	gpr.Unlock(WA);
@@ -203,8 +201,7 @@ void JitArm64::bcctrx(UGeckoInstruction inst)
 	if (inst.LK_3)
 	{
 		ARM64Reg WB = gpr.GetReg();
-		u32 Jumpto = js.compilerPC + 4;
-		MOVI2R(WB, Jumpto);
+		MOVI2R(WB, js.compilerPC + 4);
 		STR(INDEX_UNSIGNED, WB, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
 		gpr.Unlock(WB);
 	}
@@ -252,8 +249,7 @@ void JitArm64::bclrx(UGeckoInstruction inst)
 	if (inst.LK)
 	{
 		ARM64Reg WB = gpr.GetReg();
-		u32 Jumpto = js.compilerPC + 4;
-		MOVI2R(WB, Jumpto);
+		MOVI2R(WB, js.compilerPC + 4);
 		STR(INDEX_UNSIGNED, WB, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
 		gpr.Unlock(WB);
 	}

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -213,7 +213,7 @@ void JitArm64::bcctrx(UGeckoInstruction inst)
 
 	LDR(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(spr[SPR_CTR]));
 	AND(WA, WA, 30, 29); // Wipe the bottom 2 bits.
-	WriteExitDestInR(WA);
+	WriteExit(WA);
 }
 
 void JitArm64::bclrx(UGeckoInstruction inst)
@@ -261,7 +261,7 @@ void JitArm64::bclrx(UGeckoInstruction inst)
 	gpr.Flush(FlushMode::FLUSH_MAINTAIN_STATE);
 	fpr.Flush(FlushMode::FLUSH_MAINTAIN_STATE);
 
-	WriteExitDestInR(WA);
+	WriteExit(WA);
 
 	SwitchToNearCode();
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -264,7 +264,7 @@ void JitArm64::fcmpX(UGeckoInstruction inst)
 	}
 	SetJumpTarget(continue1);
 
-	STR(INDEX_UNSIGNED, XA, X29, PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
+	STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
 
 	gpr.Unlock(WA);
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -704,7 +704,6 @@ void JitArm64::mulli(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITIntegerOff);
-	FALLBACK_IF(inst.OE);
 
 	int a = inst.RA, d = inst.RD;
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -747,6 +747,56 @@ void JitArm64::mullwx(UGeckoInstruction inst)
 	}
 }
 
+void JitArm64::mulhwx(UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	JITDISABLE(bJITIntegerOff);
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	if (gpr.IsImm(a) && gpr.IsImm(b))
+	{
+		s32 i = (s32)gpr.GetImm(a), j = (s32)gpr.GetImm(b);
+		gpr.SetImmediate(d, (u32)((u64)(((s64)i * (s64)j) ) >> 32));
+		if (inst.Rc)
+			ComputeRC(gpr.GetImm(d), 0);
+	}
+	else
+	{
+		gpr.BindToRegister(d, d == a || d == b);
+		SMULL(EncodeRegTo64(gpr.R(d)), gpr.R(a), gpr.R(b));
+		LSR(EncodeRegTo64(gpr.R(d)), EncodeRegTo64(gpr.R(d)), 32);
+
+		if (inst.Rc)
+			ComputeRC(gpr.R(d), 0);
+	}
+}
+
+void JitArm64::mulhwux(UGeckoInstruction inst)
+{
+	INSTRUCTION_START
+	JITDISABLE(bJITIntegerOff);
+
+	int a = inst.RA, b = inst.RB, d = inst.RD;
+
+	if (gpr.IsImm(a) && gpr.IsImm(b))
+	{
+		u32 i = gpr.GetImm(a), j = gpr.GetImm(b);
+		gpr.SetImmediate(d, (u32)( ( (u64)i * (u64)j) >> 32) );
+		if (inst.Rc)
+			ComputeRC(gpr.GetImm(d), 0);
+	}
+	else
+	{
+		gpr.BindToRegister(d, d == a || d == b);
+		UMULL(EncodeRegTo64(gpr.R(d)), gpr.R(a), gpr.R(b));
+		LSR(EncodeRegTo64(gpr.R(d)), EncodeRegTo64(gpr.R(d)), 32);
+
+		if (inst.Rc)
+			ComputeRC(gpr.R(d), 0);
+	}
+}
+
 void JitArm64::addzex(UGeckoInstruction inst)
 {
 	INSTRUCTION_START

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -26,12 +26,12 @@ void JitArm64::ComputeRC(ARM64Reg reg, int crf, bool needs_sext)
 
 		SXTW(XA, reg);
 
-		STR(INDEX_UNSIGNED, XA, X29, PPCSTATE_OFF(cr_val[crf]));
+		STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[crf]));
 		gpr.Unlock(WA);
 	}
 	else
 	{
-		STR(INDEX_UNSIGNED, EncodeRegTo64(reg), X29, PPCSTATE_OFF(cr_val[crf]));
+		STR(INDEX_UNSIGNED, EncodeRegTo64(reg), PPC_REG, PPCSTATE_OFF(cr_val[crf]));
 	}
 }
 
@@ -44,7 +44,7 @@ void JitArm64::ComputeRC(u64 imm, int crf, bool needs_sext)
 	if (imm & 0x80000000 && needs_sext)
 		SXTW(XA, WA);
 
-	STR(INDEX_UNSIGNED, XA, X29, PPCSTATE_OFF(cr_val[crf]));
+	STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[crf]));
 	gpr.Unlock(WA);
 }
 
@@ -57,12 +57,12 @@ void JitArm64::ComputeCarry(bool Carry)
 	{
 		ARM64Reg WA = gpr.GetReg();
 		MOVI2R(WA, 1);
-		STRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
+		STRB(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
 		gpr.Unlock(WA);
 		return;
 	}
 
-	STRB(INDEX_UNSIGNED, WSP, X29, PPCSTATE_OFF(xer_ca));
+	STRB(INDEX_UNSIGNED, WSP, PPC_REG, PPCSTATE_OFF(xer_ca));
 }
 
 void JitArm64::ComputeCarry()
@@ -72,7 +72,7 @@ void JitArm64::ComputeCarry()
 
 	ARM64Reg WA = gpr.GetReg();
 	CSINC(WA, WSP, WSP, CC_CC);
-	STRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
+	STRB(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
 	gpr.Unlock(WA);
 }
 
@@ -447,7 +447,7 @@ void JitArm64::cmp(UGeckoInstruction inst)
 	SXTW(XB, RB);
 
 	SUB(XA, XA, XB);
-	STR(INDEX_UNSIGNED, XA, X29, PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
+	STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
 
 	gpr.Unlock(WA, WB);
 }
@@ -474,7 +474,7 @@ void JitArm64::cmpl(UGeckoInstruction inst)
 	ARM64Reg WA = gpr.GetReg();
 	ARM64Reg XA = EncodeRegTo64(WA);
 	SUB(XA, EncodeRegTo64(gpr.R(a)), EncodeRegTo64(gpr.R(b)));
-	STR(INDEX_UNSIGNED, XA, X29, PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
+	STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
 	gpr.Unlock(WA);
 }
 
@@ -540,7 +540,7 @@ void JitArm64::cmpli(UGeckoInstruction inst)
 		SUB(XA, EncodeRegTo64(gpr.R(a)), XA);
 	}
 
-	STR(INDEX_UNSIGNED, XA, X29, PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
+	STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
 	gpr.Unlock(WA);
 }
 
@@ -641,7 +641,7 @@ void JitArm64::srawix(UGeckoInstruction inst)
 
 		ANDS(WSP, WA, RA, ArithOption(RA, ST_LSL, 0));
 		CSINC(WA, WSP, WSP, CC_EQ);
-		STRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
+		STRB(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
 		gpr.Unlock(WA);
 	}
 	else
@@ -650,7 +650,7 @@ void JitArm64::srawix(UGeckoInstruction inst)
 		ARM64Reg RA = gpr.R(a);
 		ARM64Reg RS = gpr.R(s);
 		MOV(RA, RS);
-		STRB(INDEX_UNSIGNED, WSP, X29, PPCSTATE_OFF(xer_ca));
+		STRB(INDEX_UNSIGNED, WSP, PPC_REG, PPCSTATE_OFF(xer_ca));
 	}
 }
 
@@ -759,14 +759,14 @@ void JitArm64::addzex(UGeckoInstruction inst)
 	{
 		gpr.BindToRegister(d, true);
 		ARM64Reg WA = gpr.GetReg();
-		LDRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
+		LDRB(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
 		ADDS(gpr.R(d), gpr.R(a), WA);
 		gpr.Unlock(WA);
 	}
 	else
 	{
 		gpr.BindToRegister(d, false);
-		LDRB(INDEX_UNSIGNED, gpr.R(d), X29, PPCSTATE_OFF(xer_ca));
+		LDRB(INDEX_UNSIGNED, gpr.R(d), PPC_REG, PPCSTATE_OFF(xer_ca));
 		ADDS(gpr.R(d), gpr.R(a), gpr.R(d));
 	}
 
@@ -814,7 +814,7 @@ void JitArm64::subfex(UGeckoInstruction inst)
 		gpr.BindToRegister(d, false);
 		MOVI2R(gpr.R(d), ~i + j);
 		ARM64Reg WA = gpr.GetReg();
-		LDRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
+		LDRB(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
 		ADD(gpr.R(d), gpr.R(d), WA);
 		gpr.Unlock(WA);
 
@@ -840,7 +840,7 @@ void JitArm64::subfex(UGeckoInstruction inst)
 		gpr.BindToRegister(d, d == a || d == b);
 
 		// upload the carry state
-		LDRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
+		LDRB(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
 		CMP(WA, 1);
 
 		// d = ~a + b + carry;
@@ -935,7 +935,7 @@ void JitArm64::addex(UGeckoInstruction inst)
 		gpr.BindToRegister(d, false);
 		MOVI2R(gpr.R(d), i + j);
 		ARM64Reg WA = gpr.GetReg();
-		LDRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
+		LDRB(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
 		ADD(gpr.R(d), gpr.R(d), WA);
 		gpr.Unlock(WA);
 
@@ -961,7 +961,7 @@ void JitArm64::addex(UGeckoInstruction inst)
 
 		// upload the carry state
 		ARM64Reg WA = gpr.GetReg();
-		LDRB(INDEX_UNSIGNED, WA, X29, PPCSTATE_OFF(xer_ca));
+		LDRB(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(xer_ca));
 		CMP(WA, 1);
 		gpr.Unlock(WA);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -467,15 +467,13 @@ void JitArm64::lXX(UGeckoInstruction inst)
 		MOVI2R(XA, (u64)&CoreTiming::Idle);
 		BLR(XA);
 
-		gpr.Unlock(WA);
-		WriteExceptionExit();
+		MOVI2R(WA, js.compilerPC);
+
+		WriteExceptionExit(WA);
 
 		SwitchToNearCode();
 
 		SetJumpTarget(noIdle);
-
-		//js.compilerPC += 8;
-		return;
 	}
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -595,7 +595,7 @@ void JitArm64::lmw(UGeckoInstruction inst)
 		MOVI2R(WA, (u32)(s32)(s16)inst.SIMM_16);
 	}
 
-	ADD(XA, XA, X28);
+	ADD(XA, XA, MEM_REG);
 
 	for (int i = inst.RD; i < 32; i++)
 	{

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -463,13 +463,11 @@ void JitArm64::lXX(UGeckoInstruction inst)
 
 		ARM64Reg WA = gpr.GetReg();
 		ARM64Reg XA = EncodeRegTo64(WA);
-
 		MOVI2R(XA, (u64)&CoreTiming::Idle);
 		BLR(XA);
+		gpr.Unlock(WA);
 
-		MOVI2R(WA, js.compilerPC);
-
-		WriteExceptionExit(WA);
+		WriteExceptionExit(js.compilerPC);
 
 		SwitchToNearCode();
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -45,9 +45,9 @@ void JitArm64::psq_l(UGeckoInstruction inst)
 	if (inst.RA || update) // Always uses the register on update
 	{
 		if (offset >= 0)
-			ADD(addr_reg, gpr.R(inst.RA), offset);
+			ADD(addr_reg, arm_addr, offset);
 		else
-			SUB(addr_reg, gpr.R(inst.RA), std::abs(offset));
+			SUB(addr_reg, arm_addr, std::abs(offset));
 	}
 	else
 	{

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
@@ -65,18 +65,18 @@ void JitArm64::psq_l(UGeckoInstruction inst)
 		VS = fpr.RW(inst.RS, REG_REG_SINGLE);
 		if (!inst.W)
 		{
-			ADD(EncodeRegTo64(addr_reg), EncodeRegTo64(addr_reg), X28);
+			ADD(EncodeRegTo64(addr_reg), EncodeRegTo64(addr_reg), MEM_REG);
 			m_float_emit.LD1(32, 1, EncodeRegToDouble(VS), EncodeRegTo64(addr_reg));
 		}
 		else
 		{
-			m_float_emit.LDR(32, VS, EncodeRegTo64(addr_reg), X28);
+			m_float_emit.LDR(32, VS, EncodeRegTo64(addr_reg), MEM_REG);
 		}
 		m_float_emit.REV32(8, EncodeRegToDouble(VS), EncodeRegToDouble(VS));
 	}
 	else
 	{
-		LDR(INDEX_UNSIGNED, scale_reg, X29, PPCSTATE_OFF(spr[SPR_GQR0 + inst.I]));
+		LDR(INDEX_UNSIGNED, scale_reg, PPC_REG, PPCSTATE_OFF(spr[SPR_GQR0 + inst.I]));
 		UBFM(type_reg, scale_reg, 16, 18); // Type
 		UBFM(scale_reg, scale_reg, 24, 29); // Scale
 
@@ -179,7 +179,7 @@ void JitArm64::psq_st(UGeckoInstruction inst)
 				m_float_emit.FCVTN(32, D0, VS);
 		}
 
-		LDR(INDEX_UNSIGNED, scale_reg, X29, PPCSTATE_OFF(spr[SPR_GQR0 + inst.I]));
+		LDR(INDEX_UNSIGNED, scale_reg, PPC_REG, PPCSTATE_OFF(spr[SPR_GQR0 + inst.I]));
 		UBFM(type_reg, scale_reg, 0, 2); // Type
 		UBFM(scale_reg, scale_reg, 8, 13); // Scale
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -13,6 +13,7 @@
 
 // Dedicated host registers
 // X29 = ppcState pointer
+// X28 = memory base register
 using namespace Arm64Gen;
 
 enum RegType

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -17,6 +17,7 @@ using namespace Arm64Gen;
 // Dedicated host registers
 static const ARM64Reg MEM_REG = X28; // memory base register
 static const ARM64Reg PPC_REG = X29; // ppcState pointer
+static const ARM64Reg DISPATCHER_PC = W26; // register for PC when calling the dispatcher
 
 #define PPCSTATE_OFF(elem) (offsetof(PowerPC::PowerPCState, elem))
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -9,12 +9,22 @@
 
 #include "Common/Arm64Emitter.h"
 #include "Core/PowerPC/Gekko.h"
+#include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 
-// Dedicated host registers
-// X29 = ppcState pointer
-// X28 = memory base register
 using namespace Arm64Gen;
+
+// Dedicated host registers
+static const ARM64Reg MEM_REG = X28; // memory base register
+static const ARM64Reg PPC_REG = X29; // ppcState pointer
+
+#define PPCSTATE_OFF(elem) (offsetof(PowerPC::PowerPCState, elem))
+
+// Some asserts to make sure we will be able to load everything
+static_assert(PPCSTATE_OFF(spr[1023]) <= 16380, "LDR(32bit) can't reach the last SPR");
+static_assert((PPCSTATE_OFF(ps[0][0]) % 8) == 0, "LDR(64bit VFP) requires FPRs to be 8 byte aligned");
+static_assert(PPCSTATE_OFF(xer_ca) < 4096, "STRB can't store xer_ca!");
+static_assert(PPCSTATE_OFF(xer_so_ov) < 4096, "STRB can't store xer_so_ov!");
 
 enum RegType
 {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -196,11 +196,9 @@ void JitArm64::twx(UGeckoInstruction inst)
 	LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
 	ORR(WA, WA, 24, 0); // Same as WA | EXCEPTION_PROGRAM
 	STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(Exceptions));
+	gpr.Unlock(WA);
 
-	MOVI2R(WA, js.compilerPC);
-
-	// WA is unlocked in this function
-	WriteExceptionExit(WA);
+	WriteExceptionExit(js.compilerPC);
 
 	SwitchToNearCode();
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -184,8 +184,8 @@ static GekkoOPTemplate table31[] =
 	{1003, &JitArm64::FallBackToInterpreter},   // divwox
 	{459,  &JitArm64::divwux},                  // divwux
 	{971,  &JitArm64::divwux},                  // divwuox
-	{75,   &JitArm64::FallBackToInterpreter},   // mulhwx
-	{11,   &JitArm64::FallBackToInterpreter},   // mulhwux
+	{75,   &JitArm64::mulhwx},                  // mulhwx
+	{11,   &JitArm64::mulhwux},                 // mulhwux
 	{235,  &JitArm64::mullwx},                  // mullwx
 	{747,  &JitArm64::mullwx},                  // mullwox
 	{104,  &JitArm64::negx},                    // negx

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -25,8 +25,8 @@ void JitArm64AsmRoutineManager::Generate()
 
 	ABI_PushRegisters(regs_to_save);
 
-	MOVI2R(X29, (u64)&PowerPC::ppcState);
-	MOVI2R(X28, (u64)Memory::logical_base);
+	MOVI2R(PPC_REG, (u64)&PowerPC::ppcState);
+	MOVI2R(MEM_REG, (u64)Memory::logical_base);
 
 	FixupBranch to_dispatcher = B();
 
@@ -46,7 +46,7 @@ void JitArm64AsmRoutineManager::Generate()
 
 		// This block of code gets the address of the compiled block of code
 		// It runs though to the compiling portion if it isn't found
-		LDR(INDEX_UNSIGNED, W26, X29, PPCSTATE_OFF(pc)); // Load the current PC into W26
+		LDR(INDEX_UNSIGNED, W26, PPC_REG, PPCSTATE_OFF(pc)); // Load the current PC into W26
 		BFM(W26, WSP, 3, 2); // Wipe the top 3 bits. Same as PC & JIT_ICACHE_MASK
 
 		MOVI2R(X27, (u64)jit->GetBlockCache()->iCache.data());
@@ -73,14 +73,14 @@ void JitArm64AsmRoutineManager::Generate()
 		BLR(X30);
 
 		// Does exception checking
-		LDR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(Exceptions));
+		LDR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF(Exceptions));
 		FixupBranch no_exceptions = CBZ(W0);
-		LDR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(pc));
-		STR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(npc));
+		LDR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF(pc));
+		STR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF(npc));
 			MOVI2R(X30, (u64)&PowerPC::CheckExceptions);
 			BLR(X30);
-		LDR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(npc));
-		STR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(pc));
+		LDR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF(npc));
+		STR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF(pc));
 		SetJumpTarget(no_exceptions);
 
 		// Check the state pointer to see if we are exiting
@@ -588,7 +588,7 @@ void JitArm64AsmRoutineManager::GenMfcr()
 	const u8* start = GetCodePtr();
 	for (int i = 0; i < 8; i++)
 	{
-		LDR(INDEX_UNSIGNED, X1, X29, PPCSTATE_OFF(cr_val) + 8 * i);
+		LDR(INDEX_UNSIGNED, X1, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * i);
 
 		// SO
 		if (i == 0)

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -71,12 +71,15 @@ void JitArm64AsmRoutineManager::Generate()
 		BLR(X30);
 
 		// Does exception checking
+		LDR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(Exceptions));
+		FixupBranch no_exceptions = CBZ(W0);
 		LDR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(pc));
 		STR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(npc));
 			MOVI2R(X30, (u64)&PowerPC::CheckExceptions);
 			BLR(X30);
 		LDR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(npc));
 		STR(INDEX_UNSIGNED, W0, X29, PPCSTATE_OFF(pc));
+		SetJumpTarget(no_exceptions);
 
 		// Check the state pointer to see if we are exiting
 		// Gets checked on every exception check

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -26,6 +26,8 @@ void JitArm64AsmRoutineManager::Generate()
 	ABI_PushRegisters(regs_to_save);
 
 	MOVI2R(X29, (u64)&PowerPC::ppcState);
+	MOVI2R(X28, (u64)Memory::logical_base);
+
 	FixupBranch to_dispatcher = B();
 
 	// If we align the dispatcher to a page then we can load its location with one ADRP instruction
@@ -44,11 +46,11 @@ void JitArm64AsmRoutineManager::Generate()
 
 		// This block of code gets the address of the compiled block of code
 		// It runs though to the compiling portion if it isn't found
-		LDR(INDEX_UNSIGNED, W28, X29, PPCSTATE_OFF(pc)); // Load the current PC into W28
-		BFM(W28, WSP, 3, 2); // Wipe the top 3 bits. Same as PC & JIT_ICACHE_MASK
+		LDR(INDEX_UNSIGNED, W26, X29, PPCSTATE_OFF(pc)); // Load the current PC into W26
+		BFM(W26, WSP, 3, 2); // Wipe the top 3 bits. Same as PC & JIT_ICACHE_MASK
 
 		MOVI2R(X27, (u64)jit->GetBlockCache()->iCache.data());
-		LDR(W27, X27, X28);
+		LDR(W27, X27, X26);
 
 		FixupBranch JitBlock = TBNZ(W27, 7); // Test the 7th bit
 			// Success, it is our Jitblock.


### PR DESCRIPTION
LWZ idle skipping was broken because it restarts the block instead of only the loop.
The two optimizations are first to skip CheckException if no exception is set, second to have a persistent memory register instead of loading it once per block.

As an additonal optimization, PC is now given to the dispatcher by a register. So calling the dispatcher now doesn't require a STR() LDR() combo.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3694)
<!-- Reviewable:end -->
