### PR TITLE
Re-enable Assert Messages that are definitely valid

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -198,8 +198,7 @@ static T GenerateVertexShader(API_TYPE api_type)
 		switch (texinfo.sourcerow)
 		{
 		case XF_SRCGEOM_INROW:
-			// The following assert was triggered in Super Smash Bros. Project M 3.6.
-			//_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
+			_assert_(texinfo.inputform == XF_TEXINPUT_ABC1);
 			out.Write("coord = rawpos;\n"); // pos.w is 1
 			break;
 		case XF_SRCNORMAL_INROW:
@@ -249,8 +248,7 @@ static T GenerateVertexShader(API_TYPE api_type)
 				}
 				else
 				{
-					// The following assert was triggered in House of the Dead Overkill and Star Wars Rogue Squadron 2
-					//_assert_(0); // should have normals
+					_assert_(0); // should have normals
 					uid_data->texMtxInfo[i].embosssourceshift = xfmem.texMtxInfo[i].embosssourceshift;
 					out.Write("o.tex%d.xyz = o.tex%d.xyz;\n", i, texinfo.embosssourceshift);
 				}


### PR DESCRIPTION
Turns out these asserts were actually correct.  Dolphin doesn't emulate the sand-ridge effect in Rogue Squadron 2 at all currently.  Who's the dumbass that disabled them?

CONSOLE
![sandridges](https://cloud.githubusercontent.com/assets/6598209/13456464/485063a6-e031-11e5-9f20-929ce80a335c.jpg)

Dolphin
![gswe64-46](https://cloud.githubusercontent.com/assets/6598209/13456467/4c7817c6-e031-11e5-8710-09a57e9a4ddc.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3696)
<!-- Reviewable:end -->
