### PR TITLE
Stop PollHotkeys Timer while PollHotkeys Event is running

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1252,6 +1252,10 @@ void CFrame::PollHotkeys(wxTimerEvent& event)
 	if (!HotkeyManagerEmu::IsEnabled())
 		return;
 
+	// Stop the poll hotkey timer to prevent another
+	// poll hotkeys event being called while one is running
+	m_poll_hotkey_timer.Stop();
+
 	if (Core::GetState() == Core::CORE_UNINITIALIZED || Core::GetState() == Core::CORE_PAUSE)
 		g_controller_interface.UpdateInput();
 
@@ -1260,6 +1264,8 @@ void CFrame::PollHotkeys(wxTimerEvent& event)
 		HotkeyManagerEmu::GetStatus();
 		ParseHotkeys();
 	}
+
+	m_poll_hotkey_timer.Start();
 }
 
 void CFrame::ParseHotkeys()


### PR DESCRIPTION
Prevents possible race conditions where PollHotkeys could be called again while a PollHotkeys event is currently running.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3699)
<!-- Reviewable:end -->
