### PR TITLE
COM Smart Pointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Source/Core/Common/scmrev.h
 *.vcxproj.user
 *.obj
 *.tlog
+*.VC.opendb
 # Ignore build info file created by QtCreator
 CMakeLists.txt.user
 # Ignore files created by posix people

--- a/Source/Core/Common/ComPtr.h
+++ b/Source/Core/Common/ComPtr.h
@@ -1,0 +1,281 @@
+// Copyright 2010 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Common
+{
+
+// A strong reference to a COM object.
+template<typename Interface>
+class ComPtr
+{
+	// This is a COM smart-pointer. It has some advantages over the COM smart-
+	// pointers provided by ATL and Windows Runtime:
+	// - It includes a move constructor - ComPtr's can be stored in containers
+	// - It disallows direct usage of AddRef and Release but still allows
+	//   QueryInterface
+	// Adapted from:
+	// Kerr, Kenny. "Windows with C++ - COM Smart Pointers Revisited."
+	// MSDN Magazine. <https://msdn.microsoft.com/en-us/magazine/dn904668.aspx>
+
+	// TODO: This class may be incomplete. Feel free to tweak or extend.
+
+	template<typename OtherInterface> friend class ComPtr;
+public:
+	ComPtr() noexcept = default;
+
+	ComPtr(std::nullptr_t) noexcept { }
+
+	// Construct ComPtr<Interface> from ComPtr<Interface>.
+	ComPtr(const ComPtr& other) noexcept
+		: m_ptr(other.m_ptr)
+	{
+		InternalAddRef();
+	}
+
+	// Construct ComPtr<Interface> from ComPtr<OtherInterface>.
+	// OtherInterface must inherit from Interface.
+	template<typename OtherInterface>
+	ComPtr(const ComPtr<OtherInterface>& other) noexcept
+		: m_ptr(other.m_ptr)
+	{
+		// The constructor above seems redundant, but it cannot be omitted or
+		// else the compiler will assume the copy constructor is deleted and
+		// will reject assignments from ComPtr<Interface> to ComPtr<Interface>.
+		InternalAddRef();
+	}
+
+	// Construct ComPtr<Interface> by moving the contents of a
+	// ComPtr<OtherInterface>.
+	template<typename OtherInterface>
+	ComPtr(ComPtr<OtherInterface>&& other) noexcept
+		: m_ptr(other.m_ptr)
+	{
+		// A generic move constructor suffices for both cases:
+		// Move ComPtr<OtherInterface> to ComPtr<Interface>
+		// and Move ComPtr<Interface> to ComPtr<Interface>.
+		other.m_ptr = nullptr;
+	}
+
+	ComPtr& operator=(const ComPtr& other) noexcept
+	{
+		Copy(other.m_ptr);
+		return *this;
+	}
+
+	template<typename T>
+	ComPtr& operator=(const ComPtr<T>& other) noexcept
+	{
+		Copy(other.m_ptr);
+		return *this;
+	}
+
+	template<typename T>
+	ComPtr& operator=(ComPtr<T>&& other) noexcept
+	{
+		InternalMove(other);
+		return *this;
+	}
+
+	~ComPtr() noexcept
+	{
+		Release();
+	}
+
+	explicit operator bool() const noexcept
+	{
+		return m_ptr != nullptr;
+	}
+
+	template<typename T>
+	bool operator==(const ComPtr<T>& other) const noexcept
+	{
+		return m_ptr == other.m_ptr;
+	}
+
+	template<typename T>
+	bool operator!=(const ComPtr<T>& other) const noexcept
+	{
+		return !(*this == other);
+	}
+
+	bool operator==(const Interface* other) const noexcept
+	{
+		return m_ptr == other;
+	}
+
+	bool operator!=(const Interface* other) const noexcept
+	{
+		return !(*this == other);
+	}
+
+	bool operator==(std::nullptr_t) const noexcept
+	{
+		return m_ptr == nullptr;
+	}
+
+	bool operator!=(std::nullptr_t) const noexcept
+	{
+		return !(*this == nullptr);
+	}
+
+	// Release COM pointer and return number of remaining references.
+	ULONG Release() noexcept
+	{
+		Interface* temp = m_ptr;
+		if (temp)
+		{
+			// Null out m_ptr before releasing.
+			// This prevents breakage in special cases where Releasing might
+			// set off a chain of events causing this smart pointer to be
+			// released again.
+			m_ptr = nullptr;
+			return temp->Release();
+		}
+
+		return 0;
+	}
+
+	template<typename T>
+	ComPtr<T> As() const noexcept
+	{
+		ComPtr<T> temp;
+		if (m_ptr)
+		{
+			m_ptr->QueryInterface(temp.GetAddressOf());
+		}
+		return temp;
+	}
+
+	// Copy raw pointer and call AddRef.
+	void Copy(Interface* other) noexcept
+	{
+		if (m_ptr != other)
+		{
+			Release();
+			m_ptr = other;
+			InternalAddRef();
+		}
+	}
+
+	// AddRef and copy to raw pointer.
+	void CopyTo(Interface** other) const noexcept
+	{
+		InternalAddRef();
+		*other = m_ptr;
+	}
+
+	// Attach to existing pointer without calling AddRef.
+	void Attach(Interface* other) noexcept
+	{
+		Release();
+		m_ptr = other;
+	}
+
+	// Detach pointer without releasing.
+	Interface* Detach() noexcept
+	{
+		Interface* temp = m_ptr;
+		m_ptr = nullptr;
+		return temp;
+	}
+
+	Interface* Get() const noexcept
+	{
+		return m_ptr;
+	}
+
+	// Get address of Interface pointer.
+	// This can be passed to factory functions that return newly created
+	// objects in an Interface**. The currently held pointer must be null.
+	Interface** GetAddressOf() noexcept
+	{
+		assert(m_ptr == nullptr);
+		return &m_ptr;
+	}
+
+	class RemoveAddRefRelease : public Interface
+	{
+	private:
+		~RemoveAddRefRelease();
+		ULONG __stdcall AddRef();
+		ULONG __stdcall Release();
+	};
+
+	RemoveAddRefRelease* operator->() const noexcept
+	{
+		assert(m_ptr != nullptr);
+		return static_cast<RemoveAddRefRelease*>(m_ptr);
+	}
+
+private:
+	void InternalAddRef() const noexcept
+	{
+		if (m_ptr)
+		{
+			m_ptr->AddRef();
+		}
+	}
+
+	template<typename OtherInterface>
+	void InternalMove(ComPtr<OtherInterface>& other) noexcept
+	{
+		if (m_ptr != other.m_ptr)
+		{
+			Release();
+			m_ptr = other.m_ptr;
+			other.m_ptr = nullptr;
+		}
+	}
+
+	Interface* m_ptr = nullptr;
+};
+
+// operators with ComPtr on right-hand side
+
+template<typename Interface, typename OtherInterface>
+bool operator==(OtherInterface* p, const ComPtr<Interface>& rhs) noexcept
+{
+	return rhs == p;
+}
+
+template<typename Interface, typename OtherInterface>
+bool operator!=(OtherInterface* p, const ComPtr<Interface>& rhs) noexcept
+{
+	return rhs != p;
+}
+
+template<typename Interface>
+bool operator==(std::nullptr_t, const ComPtr<Interface>& rhs) noexcept
+{
+	return rhs == nullptr;
+}
+
+template<typename Interface>
+bool operator!=(std::nullptr_t, const ComPtr<Interface>& rhs) noexcept
+{
+	return rhs != nullptr;
+}
+
+// Create COM smart-pointer from existing raw COM pointer and call AddRef.
+template<typename Interface>
+ComPtr<Interface> CopyComPtr(Interface* p) noexcept
+{
+	ComPtr<Interface> result;
+	result.Copy(p);
+	return result;
+}
+
+// Create COM smart-pointer from existing raw COM pointer without calling
+// AddRef.
+template<typename Interface>
+ComPtr<Interface> AttachComPtr(Interface* p) noexcept
+{
+	ComPtr<Interface> result;
+	result.Attach(p);
+	return result;
+}
+
+} // End of namespace Common

--- a/Source/Core/Common/ComPtr.h
+++ b/Source/Core/Common/ComPtr.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cassert>
+
 namespace Common
 {
 

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -51,6 +51,7 @@
     <ClInclude Include="CommonFuncs.h" />
     <ClInclude Include="CommonPaths.h" />
     <ClInclude Include="CommonTypes.h" />
+    <ClInclude Include="ComPtr.h" />
     <ClInclude Include="CPUDetect.h" />
     <ClInclude Include="DebugInterface.h" />
     <ClInclude Include="ENetUtil.h" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -224,6 +224,7 @@
     </ClInclude>
     <ClInclude Include="Assert.h" />
     <ClInclude Include="NonCopyable.h" />
+    <ClInclude Include="ComPtr.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BreakPoints.cpp" />

--- a/Source/Core/VideoBackends/D3D/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D/BoundingBox.cpp
@@ -4,19 +4,22 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
+#include "Common/ComPtr.h"
 #include "VideoBackends/D3D/BoundingBox.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace DX11
 {
 
-static ID3D11Buffer* s_bbox_buffer;
-static ID3D11Buffer* s_bbox_staging_buffer;
-static ID3D11UnorderedAccessView*  s_bbox_uav;
+using Common::ComPtr;
 
-ID3D11UnorderedAccessView* &BBox::GetUAV()
+static ComPtr<ID3D11Buffer> s_bbox_buffer;
+static ComPtr<ID3D11Buffer> s_bbox_staging_buffer;
+static ComPtr<ID3D11UnorderedAccessView> s_bbox_uav;
+
+ID3D11UnorderedAccessView* BBox::GetUAV()
 {
-	return s_bbox_uav;
+	return s_bbox_uav.Get();
 }
 
 void BBox::Init()
@@ -32,17 +35,17 @@ void BBox::Init()
 		data.SysMemPitch = 4 * sizeof(s32);
 		data.SysMemSlicePitch = 0;
 		HRESULT hr;
-		hr = D3D::device->CreateBuffer(&desc, &data, &s_bbox_buffer);
+		hr = D3D::device->CreateBuffer(&desc, &data, s_bbox_buffer.GetAddressOf());
 		CHECK(SUCCEEDED(hr), "Create BoundingBox Buffer.");
-		D3D::SetDebugObjectName(s_bbox_buffer, "BoundingBox Buffer");
+		D3D::SetDebugObjectName(s_bbox_buffer.Get(), "BoundingBox Buffer");
 
 		// Second to use as a staging buffer.
 		desc.Usage = D3D11_USAGE_STAGING;
 		desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
 		desc.BindFlags = 0;
-		hr = D3D::device->CreateBuffer(&desc, nullptr, &s_bbox_staging_buffer);
+		hr = D3D::device->CreateBuffer(&desc, nullptr, s_bbox_staging_buffer.GetAddressOf());
 		CHECK(SUCCEEDED(hr), "Create BoundingBox Staging Buffer.");
-		D3D::SetDebugObjectName(s_bbox_staging_buffer, "BoundingBox Staging Buffer");
+		D3D::SetDebugObjectName(s_bbox_staging_buffer.Get(), "BoundingBox Staging Buffer");
 
 		// UAV is required to allow concurrent access.
 		D3D11_UNORDERED_ACCESS_VIEW_DESC UAVdesc = {};
@@ -51,36 +54,36 @@ void BBox::Init()
 		UAVdesc.Buffer.FirstElement = 0;
 		UAVdesc.Buffer.Flags = 0;
 		UAVdesc.Buffer.NumElements = 4;
-		hr = D3D::device->CreateUnorderedAccessView(s_bbox_buffer, &UAVdesc, &s_bbox_uav);
+		hr = D3D::device->CreateUnorderedAccessView(s_bbox_buffer.Get(), &UAVdesc, s_bbox_uav.GetAddressOf());
 		CHECK(SUCCEEDED(hr), "Create BoundingBox UAV.");
-		D3D::SetDebugObjectName(s_bbox_uav, "BoundingBox UAV");
+		D3D::SetDebugObjectName(s_bbox_uav.Get(), "BoundingBox UAV");
 	}
 }
 
 void BBox::Shutdown()
 {
-	SAFE_RELEASE(s_bbox_buffer);
-	SAFE_RELEASE(s_bbox_staging_buffer);
-	SAFE_RELEASE(s_bbox_uav);
+	s_bbox_buffer.Release();
+	s_bbox_staging_buffer.Release();
+	s_bbox_uav.Release();
 }
 
 void BBox::Set(int index, int value)
 {
 	D3D11_BOX box{ index * sizeof(s32), 0, 0, (index + 1) * sizeof(s32), 1, 1 };
-	D3D::context->UpdateSubresource(s_bbox_buffer, 0, &box, &value, 0, 0);
+	D3D::context->UpdateSubresource(s_bbox_buffer.Get(), 0, &box, &value, 0, 0);
 }
 
 int BBox::Get(int index)
 {
 	int data = 0;
-	D3D::context->CopyResource(s_bbox_staging_buffer, s_bbox_buffer);
+	D3D::context->CopyResource(s_bbox_staging_buffer.Get(), s_bbox_buffer.Get());
 	D3D11_MAPPED_SUBRESOURCE map;
-	HRESULT hr = D3D::context->Map(s_bbox_staging_buffer, 0, D3D11_MAP_READ, 0, &map);
+	HRESULT hr = D3D::context->Map(s_bbox_staging_buffer.Get(), 0, D3D11_MAP_READ, 0, &map);
 	if (SUCCEEDED(hr))
 	{
 		data = ((s32*)map.pData)[index];
 	}
-	D3D::context->Unmap(s_bbox_staging_buffer, 0);
+	D3D::context->Unmap(s_bbox_staging_buffer.Get(), 0);
 	return data;
 }
 

--- a/Source/Core/VideoBackends/D3D/BoundingBox.h
+++ b/Source/Core/VideoBackends/D3D/BoundingBox.h
@@ -11,7 +11,7 @@ namespace DX11
 class BBox
 {
 public:
-	static ID3D11UnorderedAccessView* &GetUAV();
+	static ID3D11UnorderedAccessView* GetUAV();
 	static void Init();
 	static void Shutdown();
 

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -364,7 +364,8 @@ HRESULT Create(HWND wnd)
 		swapchain.Release();
 		return E_FAIL;
 	}
-	backbuf.Attach(buf.Detach(), D3D11_BIND_RENDER_TARGET);
+	backbuf.CreateFromExisting(buf.Get(), D3D11_BIND_RENDER_TARGET);
+	buf.Release();
 	SetDebugObjectName(backbuf.GetTex(), "backbuffer texture");
 	SetDebugObjectName(backbuf.GetRTV(), "backbuffer render target view");
 
@@ -497,7 +498,8 @@ void Reset()
 		swapchain.Release();
 		return;
 	}
-	backbuf.Attach(buf.Detach(), D3D11_BIND_RENDER_TARGET);
+	backbuf.CreateFromExisting(buf.Get(), D3D11_BIND_RENDER_TARGET);
+	buf.Release();
 	SetDebugObjectName(backbuf.GetTex(), "backbuffer texture");
 	SetDebugObjectName(backbuf.GetRTV(), "backbuffer render target view");
 }

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -39,7 +39,7 @@ ComPtr<ID3D11DeviceContext> context = nullptr;
 static ComPtr<IDXGISwapChain> swapchain = nullptr;
 static ComPtr<ID3D11Debug> debug = nullptr;
 D3D_FEATURE_LEVEL featlevel;
-ComPtr<D3DTexture2D> backbuf = nullptr;
+D3DTexture2D backbuf;
 HWND hWnd;
 
 std::vector<DXGI_SAMPLE_DESC> aa_modes; // supported AA modes of the current adapter
@@ -364,13 +364,11 @@ HRESULT Create(HWND wnd)
 		swapchain.Release();
 		return E_FAIL;
 	}
-	backbuf.Attach(new D3DTexture2D(buf.Get(), D3D11_BIND_RENDER_TARGET));
-	buf.Release();
-	CHECK(backbuf!=nullptr, "Create back buffer texture");
-	SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetTex(), "backbuffer texture");
-	SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetRTV(), "backbuffer render target view");
+	backbuf.Attach(buf.Detach(), D3D11_BIND_RENDER_TARGET);
+	SetDebugObjectName(backbuf.GetTex(), "backbuffer texture");
+	SetDebugObjectName(backbuf.GetRTV(), "backbuffer render target view");
 
-	SetRenderTarget(backbuf->GetRTV());
+	SetRenderTarget(backbuf.GetRTV());
 
 	// BGRA textures are easier to deal with in TextureCache, but might not be supported by the hardware
 	UINT format_support;
@@ -446,7 +444,7 @@ const char* PixelShaderVersionString()
 	else /*if(featlevel == D3D_FEATURE_LEVEL_10_0)*/ return "ps_4_0";
 }
 
-D3DTexture2D* GetBackBuffer() { return backbuf.Get(); }
+D3DTexture2D* GetBackBuffer() { return &backbuf; }
 unsigned int GetBackBufferWidth() { return xres; }
 unsigned int GetBackBufferHeight() { return yres; }
 
@@ -499,11 +497,9 @@ void Reset()
 		swapchain.Release();
 		return;
 	}
-	backbuf.Attach(new D3DTexture2D(buf.Get(), D3D11_BIND_RENDER_TARGET));
-	buf.Release();
-	CHECK(backbuf!=nullptr, "Create back buffer texture");
-	SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetTex(), "backbuffer texture");
-	SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetRTV(), "backbuffer render target view");
+	backbuf.Attach(buf.Detach(), D3D11_BIND_RENDER_TARGET);
+	SetDebugObjectName(backbuf.GetTex(), "backbuffer texture");
+	SetDebugObjectName(backbuf.GetRTV(), "backbuffer render target view");
 }
 
 bool BeginFrame()

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -34,12 +34,12 @@ int d3d_dll_ref = 0;
 namespace D3D
 {
 
-ID3D11Device* device = nullptr;
-ID3D11DeviceContext* context = nullptr;
-static IDXGISwapChain* swapchain = nullptr;
-static ID3D11Debug* debug = nullptr;
+ComPtr<ID3D11Device> device = nullptr;
+ComPtr<ID3D11DeviceContext> context = nullptr;
+static ComPtr<IDXGISwapChain> swapchain = nullptr;
+static ComPtr<ID3D11Debug> debug = nullptr;
 D3D_FEATURE_LEVEL featlevel;
-D3DTexture2D* backbuf = nullptr;
+ComPtr<D3DTexture2D> backbuf = nullptr;
 HWND hWnd;
 
 std::vector<DXGI_SAMPLE_DESC> aa_modes; // supported AA modes of the current adapter
@@ -164,18 +164,16 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter)
 
 	// NOTE: D3D 10.0 doesn't support multisampled resources which are bound as depth buffers AND shader resources.
 	// Thus, we can't have MSAA with 10.0 level hardware.
-	ID3D11Device* _device;
-	ID3D11DeviceContext* _context;
+	ComPtr<ID3D11Device> _device;
+	ComPtr<ID3D11DeviceContext> _context;
 	D3D_FEATURE_LEVEL feat_level;
-	HRESULT hr = PD3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr, D3D11_CREATE_DEVICE_SINGLETHREADED, supported_feature_levels, NUM_SUPPORTED_FEATURE_LEVELS, D3D11_SDK_VERSION, &_device, &feat_level, &_context);
+	HRESULT hr = PD3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr, D3D11_CREATE_DEVICE_SINGLETHREADED, supported_feature_levels, NUM_SUPPORTED_FEATURE_LEVELS, D3D11_SDK_VERSION, _device.GetAddressOf(), &feat_level, _context.GetAddressOf());
 	if (FAILED(hr) || feat_level == D3D_FEATURE_LEVEL_10_0)
 	{
 		DXGI_SAMPLE_DESC desc;
 		desc.Count = 1;
 		desc.Quality = 0;
 		_aa_modes.push_back(desc);
-		SAFE_RELEASE(_context);
-		SAFE_RELEASE(_device);
 	}
 	else
 	{
@@ -191,8 +189,6 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter)
 			if (quality_levels > 0)
 				_aa_modes.push_back(desc);
 		}
-		_context->Release();
-		_device->Release();
 	}
 	return _aa_modes;
 }
@@ -225,39 +221,38 @@ HRESULT Create(HWND wnd)
 		return hr;
 	}
 
-	IDXGIFactory* factory;
-	IDXGIAdapter* adapter;
-	IDXGIOutput* output;
+	ComPtr<IDXGIFactory> factory;
+	ComPtr<IDXGIAdapter> adapter;
+	ComPtr<IDXGIOutput> output;
 	hr = PCreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&factory);
 	if (FAILED(hr)) MessageBox(wnd, _T("Failed to create IDXGIFactory object"), _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
 
-	hr = factory->EnumAdapters(g_ActiveConfig.iAdapter, &adapter);
+	hr = factory->EnumAdapters(g_ActiveConfig.iAdapter, adapter.GetAddressOf());
 	if (FAILED(hr))
 	{
 		// try using the first one
-		hr = factory->EnumAdapters(0, &adapter);
+		hr = factory->EnumAdapters(0, adapter.GetAddressOf());
 		if (FAILED(hr)) MessageBox(wnd, _T("Failed to enumerate adapters"), _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
 	}
 
 	// TODO: Make this configurable
-	hr = adapter->EnumOutputs(0, &output);
+	hr = adapter->EnumOutputs(0, output.GetAddressOf());
 	if (FAILED(hr))
 	{
 		// try using the first one
-		IDXGIAdapter* firstadapter;
-		hr = factory->EnumAdapters(0, &firstadapter);
+		ComPtr<IDXGIAdapter> firstadapter;
+		hr = factory->EnumAdapters(0, firstadapter.GetAddressOf());
 		if (!FAILED(hr))
-			hr = firstadapter->EnumOutputs(0, &output);
+			hr = firstadapter->EnumOutputs(0, output.GetAddressOf());
 		if (FAILED(hr)) MessageBox(wnd,
 			_T("Failed to enumerate outputs!\n")
 			_T("This usually happens when you've set your video adapter to the Nvidia GPU in an Optimus-equipped system.\n")
 			_T("Set Dolphin to use the high-performance graphics in Nvidia's drivers instead and leave Dolphin's video adapter set to the Intel GPU."),
 			_T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
-		SAFE_RELEASE(firstadapter);
 	}
 
 	// get supported AA modes
-	aa_modes = EnumAAModes(adapter);
+	aa_modes = EnumAAModes(adapter.Get());
 
 	if (std::find_if(
 		aa_modes.begin(),
@@ -300,11 +295,11 @@ HRESULT Create(HWND wnd)
 	// Creating debug devices can sometimes fail if the user doesn't have the correct
 	// version of the DirectX SDK. If it does, simply fallback to a non-debug device.
 	{
-		hr = PD3D11CreateDeviceAndSwapChain(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr,
+		hr = PD3D11CreateDeviceAndSwapChain(adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr,
 											D3D11_CREATE_DEVICE_SINGLETHREADED | D3D11_CREATE_DEVICE_DEBUG,
 											supported_feature_levels, NUM_SUPPORTED_FEATURE_LEVELS,
-											D3D11_SDK_VERSION, &swap_chain_desc, &swapchain, &device,
-											&featlevel, &context);
+											D3D11_SDK_VERSION, &swap_chain_desc, swapchain.GetAddressOf(),
+											device.GetAddressOf(), &featlevel, context.GetAddressOf());
 		// Debugbreak on D3D error
 		if (SUCCEEDED(hr) && SUCCEEDED(device->QueryInterface(__uuidof(ID3D11Debug), (void**)&debug)))
 		{
@@ -331,19 +326,20 @@ HRESULT Create(HWND wnd)
 	if (FAILED(hr))
 #endif
 	{
-		hr = PD3D11CreateDeviceAndSwapChain(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr,
+		hr = PD3D11CreateDeviceAndSwapChain(adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr,
 											D3D11_CREATE_DEVICE_SINGLETHREADED,
 											supported_feature_levels, NUM_SUPPORTED_FEATURE_LEVELS,
-											D3D11_SDK_VERSION, &swap_chain_desc, &swapchain, &device,
-											&featlevel, &context);
+											D3D11_SDK_VERSION, &swap_chain_desc,
+											swapchain.GetAddressOf(), device.GetAddressOf(),
+											&featlevel, context.GetAddressOf());
 	}
 
 	if (FAILED(hr))
 	{
 		MessageBox(wnd, _T("Failed to initialize Direct3D.\nMake sure your video card supports at least D3D 10.0"), _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
-		SAFE_RELEASE(device);
-		SAFE_RELEASE(context);
-		SAFE_RELEASE(swapchain);
+		device.Release();
+		context.Release();
+		swapchain.Release();
 		return E_FAIL;
 	}
 
@@ -353,28 +349,28 @@ HRESULT Create(HWND wnd)
 	hr = factory->MakeWindowAssociation(wnd, DXGI_MWA_NO_WINDOW_CHANGES);
 	if (FAILED(hr)) MessageBox(wnd, _T("Failed to associate the window"), _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
 
-	SetDebugObjectName((ID3D11DeviceChild*)context, "device context");
-	SAFE_RELEASE(factory);
-	SAFE_RELEASE(output);
-	SAFE_RELEASE(adapter);
+	SetDebugObjectName(context.Get(), "device context");
+	factory.Release();
+	output.Release();
+	adapter.Release();
 
-	ID3D11Texture2D* buf;
-	hr = swapchain->GetBuffer(0, IID_ID3D11Texture2D, (void**)&buf);
+	ComPtr<ID3D11Texture2D> buf;
+	hr = swapchain->GetBuffer(0, IID_ID3D11Texture2D, reinterpret_cast<void**>(buf.GetAddressOf()));
 	if (FAILED(hr))
 	{
 		MessageBox(wnd, _T("Failed to get swapchain buffer"), _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
-		SAFE_RELEASE(device);
-		SAFE_RELEASE(context);
-		SAFE_RELEASE(swapchain);
+		device.Release();
+		context.Release();
+		swapchain.Release();
 		return E_FAIL;
 	}
-	backbuf = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
-	SAFE_RELEASE(buf);
+	backbuf.Attach(new D3DTexture2D(buf.Get(), D3D11_BIND_RENDER_TARGET));
+	buf.Release();
 	CHECK(backbuf!=nullptr, "Create back buffer texture");
 	SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetTex(), "backbuffer texture");
 	SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetRTV(), "backbuffer render target view");
 
-	context->OMSetRenderTargets(1, &backbuf->GetRTV(), nullptr);
+	SetRenderTarget(backbuf->GetRTV());
 
 	// BGRA textures are easier to deal with in TextureCache, but might not be supported by the hardware
 	UINT format_support;
@@ -392,13 +388,13 @@ void Close()
 
 	// release all bound resources
 	context->ClearState();
-	SAFE_RELEASE(backbuf);
-	SAFE_RELEASE(swapchain);
+	backbuf.Release();
+	swapchain.Release();
 	SAFE_DELETE(stateman);
 	context->Flush();  // immediately destroy device objects
 
-	SAFE_RELEASE(context);
-	ULONG references = device->Release();
+	context.Release();
+	ULONG references = device.Release();
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
 	if (debug)
@@ -410,7 +406,7 @@ void Close()
 			// note this will also print out internal live objects to the debug console
 			debug->ReportLiveDeviceObjects(D3D11_RLDO_SUMMARY | D3D11_RLDO_DETAIL);
 		}
-		SAFE_RELEASE(debug)
+		debug.Release();
 	}
 #endif
 
@@ -450,7 +446,7 @@ const char* PixelShaderVersionString()
 	else /*if(featlevel == D3D_FEATURE_LEVEL_10_0)*/ return "ps_4_0";
 }
 
-D3DTexture2D* &GetBackBuffer() { return backbuf; }
+D3DTexture2D* GetBackBuffer() { return backbuf.Get(); }
 unsigned int GetBackBufferWidth() { return xres; }
 unsigned int GetBackBufferHeight() { return yres; }
 
@@ -483,7 +479,7 @@ unsigned int GetMaxTextureSize()
 void Reset()
 {
 	// release all back buffer references
-	SAFE_RELEASE(backbuf);
+	backbuf.Release();
 
 	// resize swapchain buffers
 	RECT client;
@@ -493,18 +489,18 @@ void Reset()
 	D3D::swapchain->ResizeBuffers(1, xres, yres, DXGI_FORMAT_R8G8B8A8_UNORM, 0);
 
 	// recreate back buffer texture
-	ID3D11Texture2D* buf;
-	HRESULT hr = swapchain->GetBuffer(0, IID_ID3D11Texture2D, (void**)&buf);
+	ComPtr<ID3D11Texture2D> buf;
+	HRESULT hr = swapchain->GetBuffer(0, IID_ID3D11Texture2D, reinterpret_cast<void**>(buf.GetAddressOf()));
 	if (FAILED(hr))
 	{
 		MessageBox(hWnd, _T("Failed to get swapchain buffer"), _T("Dolphin Direct3D 11 backend"), MB_OK | MB_ICONERROR);
-		SAFE_RELEASE(device);
-		SAFE_RELEASE(context);
-		SAFE_RELEASE(swapchain);
+		device.Release();
+		context.Release();
+		swapchain.Release();
 		return;
 	}
-	backbuf = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
-	SAFE_RELEASE(buf);
+	backbuf.Attach(new D3DTexture2D(buf.Get(), D3D11_BIND_RENDER_TARGET));
+	buf.Release();
 	CHECK(backbuf!=nullptr, "Create back buffer texture");
 	SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetTex(), "backbuffer texture");
 	SetDebugObjectName((ID3D11DeviceChild*)backbuf->GetRTV(), "backbuffer render target view");
@@ -553,6 +549,34 @@ HRESULT GetFullscreenState(bool* fullscreen_state)
 	HRESULT hr = swapchain->GetFullscreenState(&state, nullptr);
 	*fullscreen_state = !!state;
 	return hr;
+}
+
+void SetDebugObjectName(ID3D11DeviceChild* resource, const char* name)
+{
+#if defined(_DEBUG) || defined(DEBUGFAST)
+	if (resource)
+		resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)(name ? strlen(name) : 0), name);
+#endif
+}
+
+std::string GetDebugObjectName(ID3D11DeviceChild* resource)
+{
+	std::string name;
+#if defined(_DEBUG) || defined(DEBUGFAST)
+	if (resource)
+	{
+		UINT size = 0;
+		resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, nullptr); //get required size
+		name.resize(size);
+		resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, const_cast<char*>(name.data()));
+	}
+#endif
+	return name;
+}
+
+void SetRenderTarget(ID3D11RenderTargetView* rtv, ID3D11DepthStencilView* dsv)
+{
+	D3D::context->OMSetRenderTargets(1, &rtv, dsv);
 }
 
 }  // namespace D3D

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -10,11 +10,13 @@
 #include <vector>
 
 #include "Common/Common.h"
+#include "Common/ComPtr.h"
 
 namespace DX11
 {
 
-#define SAFE_RELEASE(x) { if (x) (x)->Release(); (x) = nullptr; }
+using Common::ComPtr;
+
 #define SAFE_DELETE(x) { delete (x); (x) = nullptr; }
 #define SAFE_DELETE_ARRAY(x) { delete[] (x); (x) = nullptr; }
 #define CHECK(cond, Message, ...) if (!(cond)) { PanicAlert(__FUNCTION__ " failed in %s at line %d: " Message, __FILE__, __LINE__, __VA_ARGS__); }
@@ -37,8 +39,8 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter);
 HRESULT Create(HWND wnd);
 void Close();
 
-extern ID3D11Device* device;
-extern ID3D11DeviceContext* context;
+extern ComPtr<ID3D11Device> device;
+extern ComPtr<ID3D11DeviceContext> context;
 extern HWND hWnd;
 extern bool bFrameInProgress;
 
@@ -49,7 +51,7 @@ void Present();
 
 unsigned int GetBackBufferWidth();
 unsigned int GetBackBufferHeight();
-D3DTexture2D* &GetBackBuffer();
+D3DTexture2D* GetBackBuffer();
 const char* PixelShaderVersionString();
 const char* GeometryShaderVersionString();
 const char* VertexShaderVersionString();
@@ -63,34 +65,10 @@ HRESULT GetFullscreenState(bool* fullscreen_state);
 // This function will assign a name to the given resource.
 // The DirectX debug layer will make it easier to identify resources that way,
 // e.g. when listing up all resources who have unreleased references.
-template <typename T>
-void SetDebugObjectName(T resource, const char* name)
-{
-	static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
-		"resource must be convertible to ID3D11DeviceChild*");
-#if defined(_DEBUG) || defined(DEBUGFAST)
-	if (resource)
-		resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)(name ? strlen(name) : 0), name);
-#endif
-}
+void SetDebugObjectName(ID3D11DeviceChild* resource, const char* name);
+std::string GetDebugObjectName(ID3D11DeviceChild* resource);
 
-template <typename T>
-std::string GetDebugObjectName(T resource)
-{
-	static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
-		"resource must be convertible to ID3D11DeviceChild*");
-	std::string name;
-#if defined(_DEBUG) || defined(DEBUGFAST)
-	if (resource)
-	{
-		UINT size = 0;
-		resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, nullptr); //get required size
-		name.resize(size);
-		resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, const_cast<char*>(name.data()));
-	}
-#endif
-	return name;
-}
+void SetRenderTarget(ID3D11RenderTargetView* rtv, ID3D11DepthStencilView* dsv = nullptr);
 
 }  // namespace D3D
 

--- a/Source/Core/VideoBackends/D3D/D3DShader.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DShader.cpp
@@ -20,10 +20,10 @@ namespace D3D
 {
 
 // bytecode->shader
-ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len)
+ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len)
 {
-	ID3D11VertexShader* v_shader;
-	HRESULT hr = D3D::device->CreateVertexShader(bytecode, len, nullptr, &v_shader);
+	ComPtr<ID3D11VertexShader> v_shader;
+	HRESULT hr = D3D::device->CreateVertexShader(bytecode, len, nullptr, v_shader.GetAddressOf());
 	if (FAILED(hr))
 		return nullptr;
 
@@ -73,10 +73,10 @@ bool CompileVertexShader(const std::string& code, D3DBlob** blob)
 }
 
 // bytecode->shader
-ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len)
+ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len)
 {
-	ID3D11GeometryShader* g_shader;
-	HRESULT hr = D3D::device->CreateGeometryShader(bytecode, len, nullptr, &g_shader);
+	ComPtr<ID3D11GeometryShader> g_shader;
+	HRESULT hr = D3D::device->CreateGeometryShader(bytecode, len, nullptr, g_shader.GetAddressOf());
 	if (FAILED(hr))
 		return nullptr;
 
@@ -127,10 +127,10 @@ bool CompileGeometryShader(const std::string& code, D3DBlob** blob, const D3D_SH
 }
 
 // bytecode->shader
-ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len)
+ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len)
 {
-	ID3D11PixelShader* p_shader;
-	HRESULT hr = D3D::device->CreatePixelShader(bytecode, len, nullptr, &p_shader);
+	ComPtr<ID3D11PixelShader> p_shader;
+	HRESULT hr = D3D::device->CreatePixelShader(bytecode, len, nullptr, p_shader.GetAddressOf());
 	if (FAILED(hr))
 	{
 		PanicAlert("CreatePixelShaderFromByteCode failed at %s %d\n", __FILE__, __LINE__);
@@ -183,37 +183,37 @@ bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADE
 	return SUCCEEDED(hr);
 }
 
-ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code)
+ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(const std::string& code)
 {
 	D3DBlob* blob = nullptr;
 	if (CompileVertexShader(code, &blob))
 	{
-		ID3D11VertexShader* v_shader = CreateVertexShaderFromByteCode(blob);
+		ComPtr<ID3D11VertexShader> v_shader = CreateVertexShaderFromByteCode(blob);
 		blob->Release();
 		return v_shader;
 	}
 	return nullptr;
 }
 
-ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines)
+ComPtr<ID3D11GeometryShader> CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines)
 {
 	D3DBlob* blob = nullptr;
 	if (CompileGeometryShader(code, &blob, pDefines))
 	{
-		ID3D11GeometryShader* g_shader = CreateGeometryShaderFromByteCode(blob);
+		ComPtr<ID3D11GeometryShader> g_shader = CreateGeometryShaderFromByteCode(blob);
 		blob->Release();
 		return g_shader;
 	}
 	return nullptr;
 }
 
-ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code)
+ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(const std::string& code)
 {
 	D3DBlob* blob = nullptr;
 	CompilePixelShader(code, &blob);
 	if (blob)
 	{
-		ID3D11PixelShader* p_shader = CreatePixelShaderFromByteCode(blob);
+		ComPtr<ID3D11PixelShader> p_shader = CreatePixelShaderFromByteCode(blob);
 		blob->Release();
 		return p_shader;
 	}

--- a/Source/Core/VideoBackends/D3D/D3DShader.h
+++ b/Source/Core/VideoBackends/D3D/D3DShader.h
@@ -17,9 +17,9 @@ namespace DX11
 
 namespace D3D
 {
-	ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len);
-	ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len);
-	ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len);
+	ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len);
+	ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len);
+	ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len);
 
 	// The returned bytecode buffers should be Release()d.
 	bool CompileVertexShader(const std::string& code, D3DBlob** blob);
@@ -27,28 +27,28 @@ namespace D3D
 	bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADER_MACRO* pDefines = nullptr);
 
 	// Utility functions
-	ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code);
-	ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines = nullptr);
-	ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code);
+	ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(const std::string& code);
+	ComPtr<ID3D11GeometryShader> CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines = nullptr);
+	ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(const std::string& code);
 
-	inline ID3D11VertexShader* CreateVertexShaderFromByteCode(D3DBlob* bytecode)
+	inline ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(D3DBlob* bytecode)
 	{ return CreateVertexShaderFromByteCode(bytecode->Data(), bytecode->Size()); }
-	inline ID3D11GeometryShader* CreateGeometryShaderFromByteCode(D3DBlob* bytecode)
+	inline ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(D3DBlob* bytecode)
 	{ return CreateGeometryShaderFromByteCode(bytecode->Data(), bytecode->Size()); }
-	inline ID3D11PixelShader* CreatePixelShaderFromByteCode(D3DBlob* bytecode)
+	inline ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(D3DBlob* bytecode)
 	{ return CreatePixelShaderFromByteCode(bytecode->Data(), bytecode->Size()); }
 
-	inline ID3D11VertexShader* CompileAndCreateVertexShader(D3DBlob* code)
+	inline ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(D3DBlob* code)
 	{
 		return CompileAndCreateVertexShader((const char*)code->Data());
 	}
 
-	inline ID3D11GeometryShader* CompileAndCreateGeometryShader(D3DBlob* code, const D3D_SHADER_MACRO* pDefines = nullptr)
+	inline ComPtr<ID3D11GeometryShader> CompileAndCreateGeometryShader(D3DBlob* code, const D3D_SHADER_MACRO* pDefines = nullptr)
 	{
 		return CompileAndCreateGeometryShader((const char*)code->Data(), pDefines);
 	}
 
-	inline ID3D11PixelShader* CompileAndCreatePixelShader(D3DBlob* code)
+	inline ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(D3DBlob* code)
 	{
 		return CompileAndCreatePixelShader((const char*)code->Data());
 	}

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -68,10 +68,10 @@ public:
 
 private:
 
-	std::unordered_map<u32, ID3D11DepthStencilState*> m_depth;
-	std::unordered_map<u32, ID3D11RasterizerState*> m_raster;
-	std::unordered_map<u32, ID3D11BlendState*> m_blend;
-	std::unordered_map<u64, ID3D11SamplerState*> m_sampler;
+	std::unordered_map<u32, ComPtr<ID3D11DepthStencilState>> m_depth;
+	std::unordered_map<u32, ComPtr<ID3D11RasterizerState>> m_raster;
+	std::unordered_map<u32, ComPtr<ID3D11BlendState>> m_blend;
+	std::unordered_map<u64, ComPtr<ID3D11SamplerState>> m_sampler;
 };
 
 namespace D3D

--- a/Source/Core/VideoBackends/D3D/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.cpp
@@ -46,7 +46,7 @@ void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned 
 
 D3DTexture2D* D3DTexture2D::Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind, D3D11_USAGE usage, DXGI_FORMAT fmt, unsigned int levels, unsigned int slices, D3D11_SUBRESOURCE_DATA* data)
 {
-	ID3D11Texture2D* pTexture = nullptr;
+	ComPtr<ID3D11Texture2D> pTexture = nullptr;
 	HRESULT hr;
 
 	D3D11_CPU_ACCESS_FLAG cpuflags;
@@ -57,15 +57,14 @@ D3DTexture2D* D3DTexture2D::Create(unsigned int width, unsigned int height, D3D1
 	else
 		cpuflags = (D3D11_CPU_ACCESS_FLAG)0;
 	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(fmt, width, height, slices, levels, bind, usage, cpuflags);
-	hr = D3D::device->CreateTexture2D(&texdesc, data, &pTexture);
+	hr = D3D::device->CreateTexture2D(&texdesc, data, pTexture.GetAddressOf());
 	if (FAILED(hr))
 	{
 		PanicAlert("Failed to create texture at %s, line %d: hr=%#x\n", __FILE__, __LINE__, hr);
 		return nullptr;
 	}
 
-	D3DTexture2D* ret = new D3DTexture2D(pTexture, bind);
-	SAFE_RELEASE(pTexture);
+	D3DTexture2D* ret = new D3DTexture2D(pTexture.Get(), bind);
 	return ret;
 }
 
@@ -85,14 +84,14 @@ UINT D3DTexture2D::Release()
 	return ref;
 }
 
-ID3D11Texture2D* &D3DTexture2D::GetTex() { return tex; }
-ID3D11ShaderResourceView* &D3DTexture2D::GetSRV() { return srv; }
-ID3D11RenderTargetView* &D3DTexture2D::GetRTV() { return rtv; }
-ID3D11DepthStencilView* &D3DTexture2D::GetDSV() { return dsv; }
+ID3D11Texture2D* D3DTexture2D::GetTex() { return tex.Get(); }
+ID3D11ShaderResourceView* D3DTexture2D::GetSRV() { return srv.Get(); }
+ID3D11RenderTargetView* D3DTexture2D::GetRTV() { return rtv.Get(); }
+ID3D11DepthStencilView* D3DTexture2D::GetDSV() { return dsv.Get(); }
 
 D3DTexture2D::D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind,
 							DXGI_FORMAT srv_format, DXGI_FORMAT dsv_format, DXGI_FORMAT rtv_format, bool multisampled)
-							: ref(1), tex(texptr), srv(nullptr), rtv(nullptr), dsv(nullptr)
+							: ref(1), tex(Common::CopyComPtr(texptr)), srv(nullptr), rtv(nullptr), dsv(nullptr)
 {
 	D3D11_SRV_DIMENSION srv_dim = multisampled ? D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY : D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
 	D3D11_DSV_DIMENSION dsv_dim = multisampled ? D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY : D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
@@ -101,20 +100,14 @@ D3DTexture2D::D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind,
 	D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc = CD3D11_DEPTH_STENCIL_VIEW_DESC(dsv_dim, dsv_format);
 	D3D11_RENDER_TARGET_VIEW_DESC rtv_desc = CD3D11_RENDER_TARGET_VIEW_DESC(rtv_dim, rtv_format);
 	if (bind & D3D11_BIND_SHADER_RESOURCE)
-		D3D::device->CreateShaderResourceView(tex, &srv_desc, &srv);
+		D3D::device->CreateShaderResourceView(tex.Get(), &srv_desc, srv.GetAddressOf());
 	if (bind & D3D11_BIND_RENDER_TARGET)
-		D3D::device->CreateRenderTargetView(tex, &rtv_desc, &rtv);
+		D3D::device->CreateRenderTargetView(tex.Get(), &rtv_desc, rtv.GetAddressOf());
 	if (bind & D3D11_BIND_DEPTH_STENCIL)
-		D3D::device->CreateDepthStencilView(tex, &dsv_desc, &dsv);
-	tex->AddRef();
+		D3D::device->CreateDepthStencilView(tex.Get(), &dsv_desc, dsv.GetAddressOf());
 }
 
 D3DTexture2D::~D3DTexture2D()
-{
-	SAFE_RELEASE(srv);
-	SAFE_RELEASE(rtv);
-	SAFE_RELEASE(dsv);
-	SAFE_RELEASE(tex);
-}
+{ }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.cpp
@@ -117,15 +117,12 @@ ID3D11DepthStencilView* D3DTexture2D::GetDSV() { return m_dsv.Get(); }
 
 ComPtr<ID3D11Texture2D> CreateStagingTexture(DXGI_FORMAT format,
 	unsigned int width, unsigned int height,
+	unsigned int levels, unsigned int slices,
 	D3D11_CPU_ACCESS_FLAG cpuAccess)
 {
 	ComPtr<ID3D11Texture2D> result;
 
-	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(format, width, height);
-	texdesc.MipLevels = 1;
-	texdesc.BindFlags = 0;
-	texdesc.Usage = D3D11_USAGE_STAGING;
-	texdesc.CPUAccessFlags = cpuAccess;
+	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(format, width, height, slices, levels, 0, D3D11_USAGE_STAGING, cpuAccess);
 	HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, result.GetAddressOf());
 	if (FAILED(hr))
 	{

--- a/Source/Core/VideoBackends/D3D/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.cpp
@@ -44,70 +44,95 @@ void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned 
 
 }  // namespace
 
-D3DTexture2D* D3DTexture2D::Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind, D3D11_USAGE usage, DXGI_FORMAT fmt, unsigned int levels, unsigned int slices, D3D11_SUBRESOURCE_DATA* data)
+void D3DTexture2D::Create(DXGI_FORMAT format, unsigned int width, unsigned int height,
+	D3D11_BIND_FLAG bind, D3D11_USAGE usage,
+	unsigned int levels, unsigned int slices,
+	const D3D11_SUBRESOURCE_DATA* data)
 {
-	ComPtr<ID3D11Texture2D> pTexture = nullptr;
+	ID3D11Texture2D* pTexture = nullptr;
 	HRESULT hr;
 
 	D3D11_CPU_ACCESS_FLAG cpuflags;
 	if (usage == D3D11_USAGE_STAGING)
-		cpuflags = (D3D11_CPU_ACCESS_FLAG)((int)D3D11_CPU_ACCESS_WRITE|(int)D3D11_CPU_ACCESS_READ);
+		cpuflags = (D3D11_CPU_ACCESS_FLAG)(D3D11_CPU_ACCESS_WRITE | D3D11_CPU_ACCESS_READ);
 	else if (usage == D3D11_USAGE_DYNAMIC)
 		cpuflags = D3D11_CPU_ACCESS_WRITE;
 	else
 		cpuflags = (D3D11_CPU_ACCESS_FLAG)0;
-	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(fmt, width, height, slices, levels, bind, usage, cpuflags);
-	hr = D3D::device->CreateTexture2D(&texdesc, data, pTexture.GetAddressOf());
+	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(format, width, height, slices, levels, bind, usage, cpuflags);
+	hr = D3D::device->CreateTexture2D(&texdesc, data, &pTexture);
 	if (FAILED(hr))
 	{
 		PanicAlert("Failed to create texture at %s, line %d: hr=%#x\n", __FILE__, __LINE__, hr);
+		return;
+	}
+
+	Attach(pTexture, bind);
+}
+
+void D3DTexture2D::Attach(ID3D11Texture2D* tex, D3D11_BIND_FLAG bind,
+	DXGI_FORMAT srv_format, DXGI_FORMAT dsv_format, DXGI_FORMAT rtv_format, bool multisampled)
+{
+	Release();
+	m_tex.Attach(tex);
+	if (bind & D3D11_BIND_SHADER_RESOURCE)
+	{
+		D3D11_SRV_DIMENSION srv_dim = multisampled ?
+			D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY :
+			D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+		D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = CD3D11_SHADER_RESOURCE_VIEW_DESC(srv_dim, srv_format);
+		D3D::device->CreateShaderResourceView(tex, &srv_desc, m_srv.GetAddressOf());
+	}
+	if (bind & D3D11_BIND_RENDER_TARGET)
+	{
+		D3D11_RTV_DIMENSION rtv_dim = multisampled ?
+			D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY :
+			D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+		D3D11_RENDER_TARGET_VIEW_DESC rtv_desc = CD3D11_RENDER_TARGET_VIEW_DESC(rtv_dim, rtv_format);
+		D3D::device->CreateRenderTargetView(tex, &rtv_desc, m_rtv.GetAddressOf());
+	}
+	if (bind & D3D11_BIND_DEPTH_STENCIL)
+	{
+		D3D11_DSV_DIMENSION dsv_dim = multisampled ?
+			D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY :
+			D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
+		D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc = CD3D11_DEPTH_STENCIL_VIEW_DESC(dsv_dim, dsv_format);
+		D3D::device->CreateDepthStencilView(tex, &dsv_desc, m_dsv.GetAddressOf());
+	}
+}
+
+void D3DTexture2D::Release()
+{
+	m_dsv.Release();
+	m_rtv.Release();
+	m_srv.Release();
+	m_tex.Release();
+}
+
+ID3D11Texture2D* D3DTexture2D::GetTex() { return m_tex.Get(); }
+ID3D11ShaderResourceView* D3DTexture2D::GetSRV() { return m_srv.Get(); }
+ID3D11RenderTargetView* D3DTexture2D::GetRTV() { return m_rtv.Get(); }
+ID3D11DepthStencilView* D3DTexture2D::GetDSV() { return m_dsv.Get(); }
+
+ComPtr<ID3D11Texture2D> CreateStagingTexture(DXGI_FORMAT format,
+	unsigned int width, unsigned int height,
+	D3D11_CPU_ACCESS_FLAG cpuAccess)
+{
+	ComPtr<ID3D11Texture2D> result;
+
+	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(format, width, height);
+	texdesc.MipLevels = 1;
+	texdesc.BindFlags = 0;
+	texdesc.Usage = D3D11_USAGE_STAGING;
+	texdesc.CPUAccessFlags = cpuAccess;
+	HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, result.GetAddressOf());
+	if (FAILED(hr))
+	{
+		PanicAlert("Failed to create staging texture at %s, line %d: hr=%#x\n", __FILE__, __LINE__, hr);
 		return nullptr;
 	}
 
-	D3DTexture2D* ret = new D3DTexture2D(pTexture.Get(), bind);
-	return ret;
+	return result;
 }
-
-void D3DTexture2D::AddRef()
-{
-	++ref;
-}
-
-UINT D3DTexture2D::Release()
-{
-	--ref;
-	if (ref == 0)
-	{
-		delete this;
-		return 0;
-	}
-	return ref;
-}
-
-ID3D11Texture2D* D3DTexture2D::GetTex() { return tex.Get(); }
-ID3D11ShaderResourceView* D3DTexture2D::GetSRV() { return srv.Get(); }
-ID3D11RenderTargetView* D3DTexture2D::GetRTV() { return rtv.Get(); }
-ID3D11DepthStencilView* D3DTexture2D::GetDSV() { return dsv.Get(); }
-
-D3DTexture2D::D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind,
-							DXGI_FORMAT srv_format, DXGI_FORMAT dsv_format, DXGI_FORMAT rtv_format, bool multisampled)
-							: ref(1), tex(Common::CopyComPtr(texptr)), srv(nullptr), rtv(nullptr), dsv(nullptr)
-{
-	D3D11_SRV_DIMENSION srv_dim = multisampled ? D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY : D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
-	D3D11_DSV_DIMENSION dsv_dim = multisampled ? D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY : D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
-	D3D11_RTV_DIMENSION rtv_dim = multisampled ? D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY : D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
-	D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = CD3D11_SHADER_RESOURCE_VIEW_DESC(srv_dim, srv_format);
-	D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc = CD3D11_DEPTH_STENCIL_VIEW_DESC(dsv_dim, dsv_format);
-	D3D11_RENDER_TARGET_VIEW_DESC rtv_desc = CD3D11_RENDER_TARGET_VIEW_DESC(rtv_dim, rtv_format);
-	if (bind & D3D11_BIND_SHADER_RESOURCE)
-		D3D::device->CreateShaderResourceView(tex.Get(), &srv_desc, srv.GetAddressOf());
-	if (bind & D3D11_BIND_RENDER_TARGET)
-		D3D::device->CreateRenderTargetView(tex.Get(), &rtv_desc, rtv.GetAddressOf());
-	if (bind & D3D11_BIND_DEPTH_STENCIL)
-		D3D::device->CreateDepthStencilView(tex.Get(), &dsv_desc, dsv.GetAddressOf());
-}
-
-D3DTexture2D::~D3DTexture2D()
-{ }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -45,6 +45,7 @@ private:
 
 ComPtr<ID3D11Texture2D> CreateStagingTexture(DXGI_FORMAT format,
 	unsigned int width, unsigned int height,
+	unsigned int levels = 1, unsigned int slices = 1,
 	D3D11_CPU_ACCESS_FLAG cpuAccess = D3D11_CPU_ACCESS_READ);
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -17,16 +17,20 @@ namespace D3D
 class D3DTexture2D
 {
 public:
-	// there are two ways to create a D3DTexture2D object:
-	//     either create an ID3D11Texture2D object, pass it to the constructor and specify what views to create
-	//     or let the texture automatically be created by D3DTexture2D::Create
+	void Create(DXGI_FORMAT format, unsigned int width, unsigned int height, 
+		D3D11_BIND_FLAG bind, D3D11_USAGE usage = D3D11_USAGE_DEFAULT,
+		unsigned int levels = 1, unsigned int slices = 1,
+		const D3D11_SUBRESOURCE_DATA* data = nullptr);
 
-	D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind, DXGI_FORMAT srv_format = DXGI_FORMAT_UNKNOWN, DXGI_FORMAT dsv_format = DXGI_FORMAT_UNKNOWN, DXGI_FORMAT rtv_format = DXGI_FORMAT_UNKNOWN, bool multisampled = false);
-	static D3DTexture2D* Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind, D3D11_USAGE usage, DXGI_FORMAT, unsigned int levels = 1, unsigned int slices = 1, D3D11_SUBRESOURCE_DATA* data = nullptr);
+	// Attach to an existing ID3D11Texture2D without calling AddRef.
+	// NOTE: Since this function does not call AddRef, the caller must not
+	// Release it or else D3DTexture2D will hold a dangling reference.
+	void Attach(ID3D11Texture2D* tex, D3D11_BIND_FLAG bind,
+		DXGI_FORMAT srv_format = DXGI_FORMAT_UNKNOWN,
+		DXGI_FORMAT dsv_format = DXGI_FORMAT_UNKNOWN,
+		DXGI_FORMAT rtv_format = DXGI_FORMAT_UNKNOWN, bool multisampled = false);
 
-	// reference counting, use AddRef() when creating a new reference and Release() it when you don't need it anymore
-	void AddRef();
-	UINT Release();
+	void Release();
 
 	ID3D11Texture2D* GetTex();
 	ID3D11ShaderResourceView* GetSRV();
@@ -34,14 +38,14 @@ public:
 	ID3D11DepthStencilView* GetDSV();
 
 private:
-	~D3DTexture2D();
-
-	ComPtr<ID3D11Texture2D> tex;
-	ComPtr<ID3D11ShaderResourceView> srv;
-	ComPtr<ID3D11RenderTargetView> rtv;
-	ComPtr<ID3D11DepthStencilView> dsv;
-	D3D11_BIND_FLAG bindflags;
-	UINT ref;
+	ComPtr<ID3D11Texture2D> m_tex;
+	ComPtr<ID3D11ShaderResourceView> m_srv;
+	ComPtr<ID3D11RenderTargetView> m_rtv;
+	ComPtr<ID3D11DepthStencilView> m_dsv;
 };
+
+ComPtr<ID3D11Texture2D> CreateStagingTexture(DXGI_FORMAT format,
+	unsigned int width, unsigned int height,
+	D3D11_CPU_ACCESS_FLAG cpuAccess = D3D11_CPU_ACCESS_READ);
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -22,10 +22,9 @@ public:
 		unsigned int levels = 1, unsigned int slices = 1,
 		const D3D11_SUBRESOURCE_DATA* data = nullptr);
 
-	// Attach to an existing ID3D11Texture2D without calling AddRef.
-	// NOTE: Since this function does not call AddRef, the caller must not
-	// Release it or else D3DTexture2D will hold a dangling reference.
-	void Attach(ID3D11Texture2D* tex, D3D11_BIND_FLAG bind,
+	// Create from an existing ID3D11Texture2D. This function calls AddRef on
+	// the texture. The caller should Release their pointer.
+	void CreateFromExisting(ID3D11Texture2D* tex, D3D11_BIND_FLAG bind,
 		DXGI_FORMAT srv_format = DXGI_FORMAT_UNKNOWN,
 		DXGI_FORMAT dsv_format = DXGI_FORMAT_UNKNOWN,
 		DXGI_FORMAT rtv_format = DXGI_FORMAT_UNKNOWN, bool multisampled = false);

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -28,18 +28,18 @@ public:
 	void AddRef();
 	UINT Release();
 
-	ID3D11Texture2D* &GetTex();
-	ID3D11ShaderResourceView* &GetSRV();
-	ID3D11RenderTargetView* &GetRTV();
-	ID3D11DepthStencilView* &GetDSV();
+	ID3D11Texture2D* GetTex();
+	ID3D11ShaderResourceView* GetSRV();
+	ID3D11RenderTargetView* GetRTV();
+	ID3D11DepthStencilView* GetDSV();
 
 private:
 	~D3DTexture2D();
 
-	ID3D11Texture2D* tex;
-	ID3D11ShaderResourceView* srv;
-	ID3D11RenderTargetView* rtv;
-	ID3D11DepthStencilView* dsv;
+	ComPtr<ID3D11Texture2D> tex;
+	ComPtr<ID3D11ShaderResourceView> srv;
+	ComPtr<ID3D11RenderTargetView> rtv;
+	ComPtr<ID3D11DepthStencilView> dsv;
 	D3D11_BIND_FLAG bindflags;
 	UINT ref;
 };

--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -247,21 +247,21 @@ int CD3DFont::Init()
 	// Create a new texture for the font
 	// possible optimization: store the converted data in a buffer and fill the texture on creation.
 	// That way, we can use a static texture
-	ID3D11Texture2D* buftex;
+	ComPtr<ID3D11Texture2D> buftex;
 	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_dwTexWidth, m_dwTexHeight,
 										1, 1, D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DYNAMIC,
 										D3D11_CPU_ACCESS_WRITE);
-	hr = device->CreateTexture2D(&texdesc, nullptr, &buftex);
+	hr = device->CreateTexture2D(&texdesc, nullptr, buftex.GetAddressOf());
 	if (FAILED(hr))
 	{
 		PanicAlert("Failed to create font texture");
 		return hr;
 	}
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)buftex, "texture of a CD3DFont object");
+	D3D::SetDebugObjectName(buftex.Get(), "texture of a CD3DFont object");
 
 	// Lock the surface and write the alpha values for the set pixels
 	D3D11_MAPPED_SUBRESOURCE texmap;
-	hr = context->Map(buftex, 0, D3D11_MAP_WRITE_DISCARD, 0, &texmap);
+	hr = context->Map(buftex.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &texmap);
 	if (FAILED(hr)) PanicAlert("Failed to map a texture at %s %d\n", __FILE__, __LINE__);
 
 	for (y = 0; y < m_dwTexHeight; y++)
@@ -275,10 +275,10 @@ int CD3DFont::Init()
 	}
 
 	// Done updating texture, so clean up used objects
-	context->Unmap(buftex, 0);
-	hr = D3D::device->CreateShaderResourceView(buftex, nullptr, &m_pTexture);
+	context->Unmap(buftex.Get(), 0);
+	hr = D3D::device->CreateShaderResourceView(buftex.Get(), nullptr, m_pTexture.GetAddressOf());
 	if (FAILED(hr)) PanicAlert("Failed to create shader resource view at %s %d\n", __FILE__, __LINE__);
-	SAFE_RELEASE(buftex);
+	buftex.Release();
 
 	SelectObject(hDC, hOldbmBitmap);
 	DeleteObject(hbmBitmap);
@@ -289,14 +289,14 @@ int CD3DFont::Init()
 	// setup device objects for drawing
 	m_pshader = D3D::CompileAndCreatePixelShader(fontpixshader);
 	if (m_pshader == nullptr) PanicAlert("Failed to create pixel shader, %s %d\n", __FILE__, __LINE__);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_pshader, "pixel shader of a CD3DFont object");
+	D3D::SetDebugObjectName(m_pshader.Get(), "pixel shader of a CD3DFont object");
 
-	D3DBlob* vsbytecode;
-	D3D::CompileVertexShader(fontvertshader, &vsbytecode);
+	ComPtr<D3DBlob> vsbytecode;
+	D3D::CompileVertexShader(fontvertshader, vsbytecode.GetAddressOf());
 	if (vsbytecode == nullptr) PanicAlert("Failed to compile vertex shader, %s %d\n", __FILE__, __LINE__);
-	m_vshader = D3D::CreateVertexShaderFromByteCode(vsbytecode);
+	m_vshader = D3D::CreateVertexShaderFromByteCode(vsbytecode.Get());
 	if (m_vshader == nullptr) PanicAlert("Failed to create vertex shader, %s %d\n", __FILE__, __LINE__);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_vshader, "vertex shader of a CD3DFont object");
+	D3D::SetDebugObjectName(m_vshader.Get(), "vertex shader of a CD3DFont object");
 
 	const D3D11_INPUT_ELEMENT_DESC desc[] =
 	{
@@ -304,9 +304,9 @@ int CD3DFont::Init()
 		{ "COLOR",    0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
 		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 28, D3D11_INPUT_PER_VERTEX_DATA, 0 },
 	};
-	hr = D3D::device->CreateInputLayout(desc, 3, vsbytecode->Data(), vsbytecode->Size(), &m_InputLayout);
+	hr = D3D::device->CreateInputLayout(desc, 3, vsbytecode->Data(), vsbytecode->Size(), m_InputLayout.GetAddressOf());
 	if (FAILED(hr)) PanicAlert("Failed to create input layout, %s %d\n", __FILE__, __LINE__);
-	SAFE_RELEASE(vsbytecode);
+	vsbytecode.Release();
 
 	D3D11_BLEND_DESC blenddesc;
 	blenddesc.AlphaToCoverageEnable = FALSE;
@@ -319,35 +319,34 @@ int CD3DFont::Init()
 	blenddesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_SRC_ALPHA;
 	blenddesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
 	blenddesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
-	hr = D3D::device->CreateBlendState(&blenddesc, &m_blendstate);
+	hr = D3D::device->CreateBlendState(&blenddesc, m_blendstate.GetAddressOf());
 	CHECK(hr==S_OK, "Create font blend state");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_blendstate, "blend state of a CD3DFont object");
+	D3D::SetDebugObjectName(m_blendstate.Get(), "blend state of a CD3DFont object");
 
 	D3D11_RASTERIZER_DESC rastdesc = CD3D11_RASTERIZER_DESC(D3D11_FILL_SOLID, D3D11_CULL_NONE, false, 0, 0.f, 0.f, false, false, false, false);
-	hr = D3D::device->CreateRasterizerState(&rastdesc, &m_raststate);
+	hr = D3D::device->CreateRasterizerState(&rastdesc, m_raststate.GetAddressOf());
 	CHECK(hr==S_OK, "Create font rasterizer state");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_raststate, "rasterizer state of a CD3DFont object");
+	D3D::SetDebugObjectName(m_raststate.Get(), "rasterizer state of a CD3DFont object");
 
 	D3D11_BUFFER_DESC vbdesc = CD3D11_BUFFER_DESC(MAX_NUM_VERTICES*sizeof(FONT2DVERTEX), D3D11_BIND_VERTEX_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
-	if (FAILED(hr = device->CreateBuffer(&vbdesc, nullptr, &m_pVB)))
+	if (FAILED(hr = device->CreateBuffer(&vbdesc, nullptr, m_pVB.GetAddressOf())))
 	{
 		PanicAlert("Failed to create font vertex buffer at %s, line %d\n", __FILE__, __LINE__);
 		return hr;
 	}
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_pVB, "vertex buffer of a CD3DFont object");
+	D3D::SetDebugObjectName(m_pVB.Get(), "vertex buffer of a CD3DFont object");
 	return S_OK;
 }
 
 int CD3DFont::Shutdown()
 {
-	SAFE_RELEASE(m_pVB);
-	SAFE_RELEASE(m_pTexture);
-	SAFE_RELEASE(m_InputLayout);
-	SAFE_RELEASE(m_pshader);
-	SAFE_RELEASE(m_vshader);
-
-	SAFE_RELEASE(m_blendstate);
-	SAFE_RELEASE(m_raststate);
+	m_pVB.Release();
+	m_pTexture.Release();
+	m_InputLayout.Release();
+	m_pshader.Release();
+	m_vshader.Release();
+	m_blendstate.Release();
+	m_raststate.Release();
 
 	return S_OK;
 }
@@ -373,21 +372,21 @@ int CD3DFont::DrawTextScaled(float x, float y, float size, float spacing, u32 dw
 	int dwNumTriangles = 0L;
 
 	D3D11_MAPPED_SUBRESOURCE vbmap;
-	HRESULT hr = context->Map(m_pVB, 0, D3D11_MAP_WRITE_DISCARD, 0, &vbmap);
+	HRESULT hr = context->Map(m_pVB.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &vbmap);
 	if (FAILED(hr)) PanicAlert("Mapping vertex buffer failed, %s %d\n", __FILE__, __LINE__);
 	pVertices = (D3D::FONT2DVERTEX*)vbmap.pData;
 
 	// set general pipeline state
-	D3D::stateman->PushBlendState(m_blendstate);
-	D3D::stateman->PushRasterizerState(m_raststate);
+	D3D::stateman->PushBlendState(m_blendstate.Get());
+	D3D::stateman->PushRasterizerState(m_raststate.Get());
 
-	D3D::stateman->SetPixelShader(m_pshader);
-	D3D::stateman->SetVertexShader(m_vshader);
+	D3D::stateman->SetPixelShader(m_pshader.Get());
+	D3D::stateman->SetVertexShader(m_vshader.Get());
 	D3D::stateman->SetGeometryShader(nullptr);
 
-	D3D::stateman->SetInputLayout(m_InputLayout);
+	D3D::stateman->SetInputLayout(m_InputLayout.Get());
 	D3D::stateman->SetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-	D3D::stateman->SetTexture(0, m_pTexture);
+	D3D::stateman->SetTexture(0, m_pTexture.Get());
 
 	float fStartX = sx;
 	for (char c : text)
@@ -424,16 +423,16 @@ int CD3DFont::DrawTextScaled(float x, float y, float size, float spacing, u32 dw
 
 		if (dwNumTriangles * 3 > (MAX_NUM_VERTICES - 6))
 		{
-			context->Unmap(m_pVB, 0);
+			context->Unmap(m_pVB.Get(), 0);
 
-			D3D::stateman->SetVertexBuffer(m_pVB, stride, bufoffset);
+			D3D::stateman->SetVertexBuffer(m_pVB.Get(), stride, bufoffset);
 
 			D3D::stateman->Apply();
 			D3D::context->Draw(3 * dwNumTriangles, 0);
 
 			dwNumTriangles = 0;
 			D3D11_MAPPED_SUBRESOURCE _vbmap;
-			hr = context->Map(m_pVB, 0, D3D11_MAP_WRITE_DISCARD, 0, &_vbmap);
+			hr = context->Map(m_pVB.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &_vbmap);
 			if (FAILED(hr)) PanicAlert("Mapping vertex buffer failed, %s %d\n", __FILE__, __LINE__);
 			pVertices = (D3D::FONT2DVERTEX*)_vbmap.pData;
 		}
@@ -441,10 +440,10 @@ int CD3DFont::DrawTextScaled(float x, float y, float size, float spacing, u32 dw
 	}
 
 	// Unlock and render the vertex buffer
-	context->Unmap(m_pVB, 0);
+	context->Unmap(m_pVB.Get(), 0);
 	if (dwNumTriangles > 0)
 	{
-		D3D::stateman->SetVertexBuffer(m_pVB, stride, bufoffset);
+		D3D::stateman->SetVertexBuffer(m_pVB.Get(), stride, bufoffset);
 
 		D3D::stateman->Apply();
 		D3D::context->Draw(3 * dwNumTriangles, 0);
@@ -454,8 +453,8 @@ int CD3DFont::DrawTextScaled(float x, float y, float size, float spacing, u32 dw
 	return S_OK;
 }
 
-ID3D11SamplerState* linear_copy_sampler = nullptr;
-ID3D11SamplerState* point_copy_sampler = nullptr;
+ComPtr<ID3D11SamplerState> linear_copy_sampler = nullptr;
+ComPtr<ID3D11SamplerState> point_copy_sampler = nullptr;
 
 struct STQVertex   { float x, y, z, u, v, w, g; };
 struct STSQVertex  { float x, y, z, u, v, w, g; };
@@ -497,14 +496,14 @@ void InitUtils()
 
 	float border[4] = { 0.f, 0.f, 0.f, 0.f };
 	D3D11_SAMPLER_DESC samDesc = CD3D11_SAMPLER_DESC(D3D11_FILTER_MIN_MAG_MIP_POINT, D3D11_TEXTURE_ADDRESS_BORDER, D3D11_TEXTURE_ADDRESS_BORDER, D3D11_TEXTURE_ADDRESS_BORDER, 0.f, 1, D3D11_COMPARISON_ALWAYS, border, 0.f, 0.f);
-	HRESULT hr = D3D::device->CreateSamplerState(&samDesc, &point_copy_sampler);
+	HRESULT hr = D3D::device->CreateSamplerState(&samDesc, point_copy_sampler.GetAddressOf());
 	if (FAILED(hr)) PanicAlert("Failed to create sampler state at %s %d\n", __FILE__, __LINE__);
-	else SetDebugObjectName((ID3D11DeviceChild*)point_copy_sampler, "point copy sampler state");
+	else SetDebugObjectName(point_copy_sampler.Get(), "point copy sampler state");
 
 	samDesc = CD3D11_SAMPLER_DESC(D3D11_FILTER_MIN_MAG_MIP_LINEAR, D3D11_TEXTURE_ADDRESS_BORDER, D3D11_TEXTURE_ADDRESS_BORDER, D3D11_TEXTURE_ADDRESS_BORDER, 0.f, 1, D3D11_COMPARISON_ALWAYS, border, 0.f, 0.f);
-	hr = D3D::device->CreateSamplerState(&samDesc, &linear_copy_sampler);
+	hr = D3D::device->CreateSamplerState(&samDesc, linear_copy_sampler.GetAddressOf());
 	if (FAILED(hr)) PanicAlert("Failed to create sampler state at %s %d\n", __FILE__, __LINE__);
-	else SetDebugObjectName((ID3D11DeviceChild*)linear_copy_sampler, "linear copy sampler state");
+	else SetDebugObjectName(linear_copy_sampler.Get(), "linear copy sampler state");
 
 	// cached data used to avoid unnecessarily reloading the vertex buffers
 	memset(&tex_quad_data, 0, sizeof(tex_quad_data));
@@ -525,19 +524,19 @@ void InitUtils()
 void ShutdownUtils()
 {
 	font.Shutdown();
-	SAFE_RELEASE(point_copy_sampler);
-	SAFE_RELEASE(linear_copy_sampler);
+	point_copy_sampler.Release();
+	linear_copy_sampler.Release();
 	SAFE_DELETE(util_vbuf);
 }
 
 void SetPointCopySampler()
 {
-	D3D::stateman->SetSampler(0, point_copy_sampler);
+	D3D::stateman->SetSampler(0, point_copy_sampler.Get());
 }
 
 void SetLinearCopySampler()
 {
-	D3D::stateman->SetSampler(0, linear_copy_sampler);
+	D3D::stateman->SetSampler(0, linear_copy_sampler.Get());
 }
 
 void drawShadedTexQuad(ID3D11ShaderResourceView* texture,

--- a/Source/Core/VideoBackends/D3D/D3DUtil.h
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.h
@@ -24,13 +24,13 @@ namespace D3D
 
 	class CD3DFont
 	{
-		ID3D11ShaderResourceView* m_pTexture;
-		ID3D11Buffer* m_pVB;
-		ID3D11InputLayout* m_InputLayout;
-		ID3D11PixelShader* m_pshader;
-		ID3D11VertexShader* m_vshader;
-		ID3D11BlendState* m_blendstate;
-		ID3D11RasterizerState* m_raststate;
+		ComPtr<ID3D11ShaderResourceView> m_pTexture;
+		ComPtr<ID3D11Buffer> m_pVB;
+		ComPtr<ID3D11InputLayout> m_InputLayout;
+		ComPtr<ID3D11PixelShader> m_pshader;
+		ComPtr<ID3D11VertexShader> m_vshader;
+		ComPtr<ID3D11BlendState> m_blendstate;
+		ComPtr<ID3D11RasterizerState> m_raststate;
 		const int m_dwTexWidth;
 		const int m_dwTexHeight;
 		unsigned int m_LineHeight;

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -26,26 +26,31 @@ unsigned int FramebufferManager::m_target_width;
 unsigned int FramebufferManager::m_target_height;
 ComPtr<ID3D11DepthStencilState> FramebufferManager::m_depth_resolve_depth_state;
 
-D3DTexture2D* FramebufferManager::GetEFBColorTexture() { return m_efb.color_tex.Get(); }
-ID3D11Texture2D* FramebufferManager::GetEFBColorStagingBuffer() { return m_efb.color_staging_buf.Get(); }
+D3DTexture2D &FramebufferManager::GetEFBColorTexture() { return m_efb.color_tex; }
+const ComPtr<ID3D11Texture2D>& FramebufferManager::GetEFBColorStagingBuffer() {
+	return m_efb.color_staging_buf;
+}
 
-D3DTexture2D* FramebufferManager::GetEFBDepthTexture() { return m_efb.depth_tex.Get(); }
-D3DTexture2D* FramebufferManager::GetEFBDepthReadTexture() { return m_efb.depth_read_texture.Get(); }
-ID3D11Texture2D* FramebufferManager::GetEFBDepthStagingBuffer() { return m_efb.depth_staging_buf.Get(); }
+D3DTexture2D &FramebufferManager::GetEFBDepthTexture() { return m_efb.depth_tex; }
+D3DTexture2D &FramebufferManager::GetEFBDepthReadTexture() { return m_efb.depth_read_texture; }
+const ComPtr<ID3D11Texture2D>& FramebufferManager::GetEFBDepthStagingBuffer() {
+	return m_efb.depth_staging_buf;
+}
 
-D3DTexture2D* FramebufferManager::GetResolvedEFBColorTexture()
+D3DTexture2D &FramebufferManager::GetResolvedEFBColorTexture()
 {
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
-		for (int i = 0; i < m_efb.slices; i++)
-			D3D::context->ResolveSubresource(m_efb.resolved_color_tex->GetTex(), D3D11CalcSubresource(0, i, 1), m_efb.color_tex->GetTex(), D3D11CalcSubresource(0, i, 1), DXGI_FORMAT_R8G8B8A8_UNORM);
-		return m_efb.resolved_color_tex.Get();
+		for (int i = 0; i < m_efb.slices; i++) {
+			D3D::context->ResolveSubresource(m_efb.resolved_color_tex.GetTex(), D3D11CalcSubresource(0, i, 1), m_efb.color_tex.GetTex(), D3D11CalcSubresource(0, i, 1), DXGI_FORMAT_R8G8B8A8_UNORM);
+		}
+		return m_efb.resolved_color_tex;
 	}
 	else
-		return m_efb.color_tex.Get();
+		return m_efb.color_tex;
 }
 
-D3DTexture2D* FramebufferManager::GetResolvedEFBDepthTexture()
+D3DTexture2D &FramebufferManager::GetResolvedEFBDepthTexture()
 {
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
@@ -59,23 +64,24 @@ D3DTexture2D* FramebufferManager::GetResolvedEFBDepthTexture()
 		// Set up to render to resolved depth texture.
 		const D3D11_VIEWPORT viewport = CD3D11_VIEWPORT(0.f, 0.f, (float)m_target_width, (float)m_target_height);
 		D3D::context->RSSetViewports(1, &viewport);
-		D3D::context->OMSetRenderTargets(0, nullptr, m_efb.resolved_depth_tex->GetDSV());
+		D3D::context->OMSetRenderTargets(0, nullptr, m_efb.resolved_depth_tex.GetDSV());
 
 		// Render a quad covering the entire target, writing SV_Depth.
 		const D3D11_RECT source_rect = CD3D11_RECT(0, 0, m_target_width, m_target_height);
-		D3D::drawShadedTexQuad(m_efb.depth_tex->GetSRV(), &source_rect, m_target_width, m_target_height,
+		D3D::drawShadedTexQuad(m_efb.depth_tex.GetSRV(), &source_rect, m_target_width, m_target_height,
 			PixelShaderCache::GetDepthResolveProgram(), VertexShaderCache::GetSimpleVertexShader(),
 			VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
 
 		// Restore render state.
-		D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+		ID3D11RenderTargetView* rtv = FramebufferManager::GetEFBColorTexture().GetRTV();
+		D3D::context->OMSetRenderTargets(1, &rtv, FramebufferManager::GetEFBDepthTexture().GetDSV());
 		D3D::stateman->PopDepthState();
 		g_renderer->RestoreAPIState();
 
-		return m_efb.resolved_depth_tex.Get();
+		return m_efb.resolved_depth_tex;
 	}
 	else
-		return m_efb.depth_tex.Get();
+		return m_efb.depth_tex;
 }
 
 FramebufferManager::FramebufferManager()
@@ -94,7 +100,7 @@ FramebufferManager::FramebufferManager()
 	sample_desc.Count = g_ActiveConfig.iMultisamples;
 	sample_desc.Quality = 0;
 
-	ComPtr<ID3D11Texture2D> buf;
+	ID3D11Texture2D* buf;
 	D3D11_TEXTURE2D_DESC texdesc;
 	HRESULT hr;
 
@@ -102,23 +108,21 @@ FramebufferManager::FramebufferManager()
 
 	// EFB color texture - primary render target
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
 	CHECK(hr==S_OK, "create EFB color texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.color_tex.Attach(new D3DTexture2D(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1)));
-	buf.Release();
-	D3D::SetDebugObjectName(m_efb.color_tex->GetTex(), "EFB color texture");
-	D3D::SetDebugObjectName(m_efb.color_tex->GetSRV(), "EFB color texture shader resource view");
-	D3D::SetDebugObjectName(m_efb.color_tex->GetRTV(), "EFB color texture render target view");
+	m_efb.color_tex.Attach(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
+	D3D::SetDebugObjectName(m_efb.color_tex.GetTex(), "EFB color texture");
+	D3D::SetDebugObjectName(m_efb.color_tex.GetSRV(), "EFB color texture shader resource view");
+	D3D::SetDebugObjectName(m_efb.color_tex.GetRTV(), "EFB color texture render target view");
 
 	// Temporary EFB color texture - used in ReinterpretPixelData
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
 	CHECK(hr==S_OK, "create EFB color temp texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.color_temp_tex.Attach(new D3DTexture2D(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1)));
-	buf.Release();
-	D3D::SetDebugObjectName(m_efb.color_temp_tex->GetTex(), "EFB color temp texture");
-	D3D::SetDebugObjectName(m_efb.color_temp_tex->GetSRV(), "EFB color temp texture shader resource view");
-	D3D::SetDebugObjectName(m_efb.color_temp_tex->GetRTV(), "EFB color temp texture render target view");
+	m_efb.color_temp_tex.Attach(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
+	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetTex(), "EFB color temp texture");
+	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetSRV(), "EFB color temp texture shader resource view");
+	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetRTV(), "EFB color temp texture render target view");
 
 	// AccessEFB - Sysmem buffer used to retrieve the pixel data from color_tex
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
@@ -128,22 +132,20 @@ FramebufferManager::FramebufferManager()
 
 	// EFB depth buffer - primary depth buffer
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
 	CHECK(hr==S_OK, "create EFB depth texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.depth_tex.Attach(new D3DTexture2D(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL|D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1)));
-	buf.Release();
-	D3D::SetDebugObjectName(m_efb.depth_tex->GetTex(), "EFB depth texture");
-	D3D::SetDebugObjectName(m_efb.depth_tex->GetDSV(), "EFB depth texture depth stencil view");
-	D3D::SetDebugObjectName(m_efb.depth_tex->GetSRV(), "EFB depth texture shader resource view");
+	m_efb.depth_tex.Attach(buf, (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL|D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1));
+	D3D::SetDebugObjectName(m_efb.depth_tex.GetTex(), "EFB depth texture");
+	D3D::SetDebugObjectName(m_efb.depth_tex.GetDSV(), "EFB depth texture depth stencil view");
+	D3D::SetDebugObjectName(m_efb.depth_tex.GetSRV(), "EFB depth texture shader resource view");
 
 	// Render buffer for AccessEFB (depth data)
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, D3D11_BIND_RENDER_TARGET);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
 	CHECK(hr==S_OK, "create EFB depth read texture (hr=%#x)", hr);
-	m_efb.depth_read_texture.Attach(new D3DTexture2D(buf.Get(), D3D11_BIND_RENDER_TARGET));
-	buf.Release();
-	D3D::SetDebugObjectName(m_efb.depth_read_texture->GetTex(), "EFB depth read texture (used in Renderer::AccessEFB)");
-	D3D::SetDebugObjectName(m_efb.depth_read_texture->GetRTV(), "EFB depth read texture render target view (used in Renderer::AccessEFB)");
+	m_efb.depth_read_texture.Attach(buf, D3D11_BIND_RENDER_TARGET);
+	D3D::SetDebugObjectName(m_efb.depth_read_texture.GetTex(), "EFB depth read texture (used in Renderer::AccessEFB)");
+	D3D::SetDebugObjectName(m_efb.depth_read_texture.GetRTV(), "EFB depth read texture render target view (used in Renderer::AccessEFB)");
 
 	// AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
@@ -155,20 +157,18 @@ FramebufferManager::FramebufferManager()
 	{
 		// Framebuffer resolve textures (color+depth)
 		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, 1);
-		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
+		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
 		CHECK(hr==S_OK, "create EFB color resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_color_tex.Attach(new D3DTexture2D(buf.Get(), D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM));
-		buf.Release();
-		D3D::SetDebugObjectName(m_efb.resolved_color_tex->GetTex(), "EFB color resolve texture");
-		D3D::SetDebugObjectName(m_efb.resolved_color_tex->GetSRV(), "EFB color resolve texture shader resource view");
+		m_efb.resolved_color_tex.Attach(buf, D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM);
+		D3D::SetDebugObjectName(m_efb.resolved_color_tex.GetTex(), "EFB color resolve texture");
+		D3D::SetDebugObjectName(m_efb.resolved_color_tex.GetSRV(), "EFB color resolve texture shader resource view");
 
 		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL);
-		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
+		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
 		CHECK(hr==S_OK, "create EFB depth resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_depth_tex.Attach(new D3DTexture2D(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL), DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT));
-		buf.Release();
-		D3D::SetDebugObjectName(m_efb.resolved_depth_tex->GetTex(), "EFB depth resolve texture");
-		D3D::SetDebugObjectName(m_efb.resolved_depth_tex->GetSRV(), "EFB depth resolve texture shader resource view");
+		m_efb.resolved_depth_tex.Attach(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL), DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT);
+		D3D::SetDebugObjectName(m_efb.resolved_depth_tex.GetTex(), "EFB depth resolve texture");
+		D3D::SetDebugObjectName(m_efb.resolved_depth_tex.GetSRV(), "EFB depth resolve texture shader resource view");
 
 		// Depth state used when writing resolved depth texture
 		D3D11_DEPTH_STENCIL_DESC depth_resolve_depth_state = CD3D11_DEPTH_STENCIL_DESC(CD3D11_DEFAULT());
@@ -213,9 +213,11 @@ void FramebufferManager::CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, 
 
 std::unique_ptr<XFBSourceBase> FramebufferManager::CreateXFBSource(unsigned int target_width, unsigned int target_height, unsigned int layers)
 {
-	return std::make_unique<XFBSource>(D3DTexture2D::Create(target_width, target_height,
-		(D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET|D3D11_BIND_SHADER_RESOURCE),
-		D3D11_USAGE_DEFAULT, DXGI_FORMAT_R8G8B8A8_UNORM, 1, layers), layers);
+	D3DTexture2D texture;
+	texture.Create(DXGI_FORMAT_R8G8B8A8_UNORM, target_width, target_height,
+		(D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE),
+		D3D11_USAGE_DEFAULT, 1, layers);
+	return std::make_unique<XFBSource>(std::move(texture), layers);
 }
 
 void FramebufferManager::GetTargetSize(unsigned int *width, unsigned int *height)
@@ -239,16 +241,16 @@ void XFBSource::CopyEFB(float Gamma)
 	const D3D11_RECT rect = CD3D11_RECT(0, 0, texWidth, texHeight);
 
 	D3D::context->RSSetViewports(1, &vp);
-	D3D::SetRenderTarget(tex->GetRTV());
+	D3D::SetRenderTarget(tex.GetRTV(), nullptr);
 	D3D::SetPointCopySampler();
 
-	D3D::drawShadedTexQuad(FramebufferManager::GetEFBColorTexture()->GetSRV(), &rect,
+	D3D::drawShadedTexQuad(FramebufferManager::GetEFBColorTexture().GetSRV(), &rect,
 		Renderer::GetTargetWidth(), Renderer::GetTargetHeight(), PixelShaderCache::GetColorCopyProgram(true),
 		VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
 		GeometryShaderCache::GetCopyGeometryShader(), Gamma);
 
-	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(),
-		FramebufferManager::GetEFBDepthTexture()->GetDSV());
+	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+		FramebufferManager::GetEFBDepthTexture().GetDSV());
 
 	g_renderer->RestoreAPIState();
 }

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -100,7 +100,7 @@ FramebufferManager::FramebufferManager()
 	sample_desc.Count = g_ActiveConfig.iMultisamples;
 	sample_desc.Quality = 0;
 
-	ID3D11Texture2D* buf;
+	ComPtr<ID3D11Texture2D> buf;
 	D3D11_TEXTURE2D_DESC texdesc;
 	HRESULT hr;
 
@@ -108,18 +108,20 @@ FramebufferManager::FramebufferManager()
 
 	// EFB color texture - primary render target
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB color texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.color_tex.Attach(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
+	m_efb.color_tex.CreateFromExisting(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
+	buf.Release();
 	D3D::SetDebugObjectName(m_efb.color_tex.GetTex(), "EFB color texture");
 	D3D::SetDebugObjectName(m_efb.color_tex.GetSRV(), "EFB color texture shader resource view");
 	D3D::SetDebugObjectName(m_efb.color_tex.GetRTV(), "EFB color texture render target view");
 
 	// Temporary EFB color texture - used in ReinterpretPixelData
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB color temp texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.color_temp_tex.Attach(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
+	m_efb.color_temp_tex.CreateFromExisting(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
+	buf.Release();
 	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetTex(), "EFB color temp texture");
 	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetSRV(), "EFB color temp texture shader resource view");
 	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetRTV(), "EFB color temp texture render target view");
@@ -132,18 +134,20 @@ FramebufferManager::FramebufferManager()
 
 	// EFB depth buffer - primary depth buffer
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB depth texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.depth_tex.Attach(buf, (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL|D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1));
+	m_efb.depth_tex.CreateFromExisting(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL|D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1));
+	buf.Release();
 	D3D::SetDebugObjectName(m_efb.depth_tex.GetTex(), "EFB depth texture");
 	D3D::SetDebugObjectName(m_efb.depth_tex.GetDSV(), "EFB depth texture depth stencil view");
 	D3D::SetDebugObjectName(m_efb.depth_tex.GetSRV(), "EFB depth texture shader resource view");
 
 	// Render buffer for AccessEFB (depth data)
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, D3D11_BIND_RENDER_TARGET);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB depth read texture (hr=%#x)", hr);
-	m_efb.depth_read_texture.Attach(buf, D3D11_BIND_RENDER_TARGET);
+	m_efb.depth_read_texture.CreateFromExisting(buf.Get(), D3D11_BIND_RENDER_TARGET);
+	buf.Release();
 	D3D::SetDebugObjectName(m_efb.depth_read_texture.GetTex(), "EFB depth read texture (used in Renderer::AccessEFB)");
 	D3D::SetDebugObjectName(m_efb.depth_read_texture.GetRTV(), "EFB depth read texture render target view (used in Renderer::AccessEFB)");
 
@@ -157,16 +161,18 @@ FramebufferManager::FramebufferManager()
 	{
 		// Framebuffer resolve textures (color+depth)
 		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, 1);
-		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 		CHECK(hr==S_OK, "create EFB color resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_color_tex.Attach(buf, D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM);
+		m_efb.resolved_color_tex.CreateFromExisting(buf.Get(), D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM);
+		buf.Release();
 		D3D::SetDebugObjectName(m_efb.resolved_color_tex.GetTex(), "EFB color resolve texture");
 		D3D::SetDebugObjectName(m_efb.resolved_color_tex.GetSRV(), "EFB color resolve texture shader resource view");
 
 		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL);
-		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 		CHECK(hr==S_OK, "create EFB depth resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_depth_tex.Attach(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL), DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT);
+		m_efb.resolved_depth_tex.CreateFromExisting(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL), DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT);
+		buf.Release();
 		D3D::SetDebugObjectName(m_efb.resolved_depth_tex.GetTex(), "EFB depth resolve texture");
 		D3D::SetDebugObjectName(m_efb.resolved_depth_tex.GetSRV(), "EFB depth resolve texture shader resource view");
 

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -27,14 +27,14 @@ unsigned int FramebufferManager::m_target_height;
 ComPtr<ID3D11DepthStencilState> FramebufferManager::m_depth_resolve_depth_state;
 
 D3DTexture2D &FramebufferManager::GetEFBColorTexture() { return m_efb.color_tex; }
-const ComPtr<ID3D11Texture2D>& FramebufferManager::GetEFBColorStagingBuffer() {
-	return m_efb.color_staging_buf;
+ID3D11Texture2D* FramebufferManager::GetEFBColorStagingBuffer() {
+	return m_efb.color_staging_buf.Get();
 }
 
 D3DTexture2D &FramebufferManager::GetEFBDepthTexture() { return m_efb.depth_tex; }
 D3DTexture2D &FramebufferManager::GetEFBDepthReadTexture() { return m_efb.depth_read_texture; }
-const ComPtr<ID3D11Texture2D>& FramebufferManager::GetEFBDepthStagingBuffer() {
-	return m_efb.depth_staging_buf;
+ID3D11Texture2D* FramebufferManager::GetEFBDepthStagingBuffer() {
+	return m_efb.depth_staging_buf.Get();
 }
 
 D3DTexture2D &FramebufferManager::GetResolvedEFBColorTexture()
@@ -127,9 +127,7 @@ FramebufferManager::FramebufferManager()
 	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetRTV(), "EFB color temp texture render target view");
 
 	// AccessEFB - Sysmem buffer used to retrieve the pixel data from color_tex
-	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, m_efb.color_staging_buf.GetAddressOf());
-	CHECK(hr==S_OK, "create EFB color staging buffer (hr=%#x)", hr);
+	m_efb.color_staging_buf = CreateStagingTexture(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, 1, m_efb.slices);
 	D3D::SetDebugObjectName(m_efb.color_staging_buf.Get(), "EFB color staging texture (used for Renderer::AccessEFB)");
 
 	// EFB depth buffer - primary depth buffer
@@ -152,9 +150,7 @@ FramebufferManager::FramebufferManager()
 	D3D::SetDebugObjectName(m_efb.depth_read_texture.GetRTV(), "EFB depth read texture render target view (used in Renderer::AccessEFB)");
 
 	// AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
-	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, m_efb.depth_staging_buf.GetAddressOf());
-	CHECK(hr==S_OK, "create EFB depth staging buffer (hr=%#x)", hr);
+	m_efb.depth_staging_buf = CreateStagingTexture(DXGI_FORMAT_R32_FLOAT, 1, 1, 1, m_efb.slices);
 	D3D::SetDebugObjectName(m_efb.depth_staging_buf.Get(), "EFB depth staging texture (used for Renderer::AccessEFB)");
 
 	if (g_ActiveConfig.iMultisamples > 1)

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -24,28 +24,28 @@ static XFBEncoder s_xfbEncoder;
 FramebufferManager::Efb FramebufferManager::m_efb;
 unsigned int FramebufferManager::m_target_width;
 unsigned int FramebufferManager::m_target_height;
-ID3D11DepthStencilState* FramebufferManager::m_depth_resolve_depth_state;
+ComPtr<ID3D11DepthStencilState> FramebufferManager::m_depth_resolve_depth_state;
 
-D3DTexture2D* &FramebufferManager::GetEFBColorTexture() { return m_efb.color_tex; }
-ID3D11Texture2D* &FramebufferManager::GetEFBColorStagingBuffer() { return m_efb.color_staging_buf; }
+D3DTexture2D* FramebufferManager::GetEFBColorTexture() { return m_efb.color_tex.Get(); }
+ID3D11Texture2D* FramebufferManager::GetEFBColorStagingBuffer() { return m_efb.color_staging_buf.Get(); }
 
-D3DTexture2D* &FramebufferManager::GetEFBDepthTexture() { return m_efb.depth_tex; }
-D3DTexture2D* &FramebufferManager::GetEFBDepthReadTexture() { return m_efb.depth_read_texture; }
-ID3D11Texture2D* &FramebufferManager::GetEFBDepthStagingBuffer() { return m_efb.depth_staging_buf; }
+D3DTexture2D* FramebufferManager::GetEFBDepthTexture() { return m_efb.depth_tex.Get(); }
+D3DTexture2D* FramebufferManager::GetEFBDepthReadTexture() { return m_efb.depth_read_texture.Get(); }
+ID3D11Texture2D* FramebufferManager::GetEFBDepthStagingBuffer() { return m_efb.depth_staging_buf.Get(); }
 
-D3DTexture2D* &FramebufferManager::GetResolvedEFBColorTexture()
+D3DTexture2D* FramebufferManager::GetResolvedEFBColorTexture()
 {
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
 		for (int i = 0; i < m_efb.slices; i++)
 			D3D::context->ResolveSubresource(m_efb.resolved_color_tex->GetTex(), D3D11CalcSubresource(0, i, 1), m_efb.color_tex->GetTex(), D3D11CalcSubresource(0, i, 1), DXGI_FORMAT_R8G8B8A8_UNORM);
-		return m_efb.resolved_color_tex;
+		return m_efb.resolved_color_tex.Get();
 	}
 	else
-		return m_efb.color_tex;
+		return m_efb.color_tex.Get();
 }
 
-D3DTexture2D* &FramebufferManager::GetResolvedEFBDepthTexture()
+D3DTexture2D* FramebufferManager::GetResolvedEFBDepthTexture()
 {
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
@@ -54,7 +54,7 @@ D3DTexture2D* &FramebufferManager::GetResolvedEFBDepthTexture()
 
 		// Clear render state, and enable depth writes.
 		g_renderer->ResetAPIState();
-		D3D::stateman->PushDepthState(m_depth_resolve_depth_state);
+		D3D::stateman->PushDepthState(m_depth_resolve_depth_state.Get());
 
 		// Set up to render to resolved depth texture.
 		const D3D11_VIEWPORT viewport = CD3D11_VIEWPORT(0.f, 0.f, (float)m_target_width, (float)m_target_height);
@@ -68,14 +68,14 @@ D3DTexture2D* &FramebufferManager::GetResolvedEFBDepthTexture()
 			VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
 
 		// Restore render state.
-		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+		D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
 		D3D::stateman->PopDepthState();
 		g_renderer->RestoreAPIState();
 
-		return m_efb.resolved_depth_tex;
+		return m_efb.resolved_depth_tex.Get();
 	}
 	else
-		return m_efb.depth_tex;
+		return m_efb.depth_tex.Get();
 }
 
 FramebufferManager::FramebufferManager()
@@ -94,7 +94,7 @@ FramebufferManager::FramebufferManager()
 	sample_desc.Count = g_ActiveConfig.iMultisamples;
 	sample_desc.Quality = 0;
 
-	ID3D11Texture2D* buf;
+	ComPtr<ID3D11Texture2D> buf;
 	D3D11_TEXTURE2D_DESC texdesc;
 	HRESULT hr;
 
@@ -102,88 +102,88 @@ FramebufferManager::FramebufferManager()
 
 	// EFB color texture - primary render target
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB color texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.color_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
-	SAFE_RELEASE(buf);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetTex(), "EFB color texture");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetSRV(), "EFB color texture shader resource view");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetRTV(), "EFB color texture render target view");
+	m_efb.color_tex.Attach(new D3DTexture2D(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1)));
+	buf.Release();
+	D3D::SetDebugObjectName(m_efb.color_tex->GetTex(), "EFB color texture");
+	D3D::SetDebugObjectName(m_efb.color_tex->GetSRV(), "EFB color texture shader resource view");
+	D3D::SetDebugObjectName(m_efb.color_tex->GetRTV(), "EFB color texture render target view");
 
 	// Temporary EFB color texture - used in ReinterpretPixelData
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB color temp texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.color_temp_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
-	SAFE_RELEASE(buf);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetTex(), "EFB color temp texture");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetSRV(), "EFB color temp texture shader resource view");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetRTV(), "EFB color temp texture render target view");
+	m_efb.color_temp_tex.Attach(new D3DTexture2D(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1)));
+	buf.Release();
+	D3D::SetDebugObjectName(m_efb.color_temp_tex->GetTex(), "EFB color temp texture");
+	D3D::SetDebugObjectName(m_efb.color_temp_tex->GetSRV(), "EFB color temp texture shader resource view");
+	D3D::SetDebugObjectName(m_efb.color_temp_tex->GetRTV(), "EFB color temp texture render target view");
 
 	// AccessEFB - Sysmem buffer used to retrieve the pixel data from color_tex
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.color_staging_buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, m_efb.color_staging_buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB color staging buffer (hr=%#x)", hr);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_staging_buf, "EFB color staging texture (used for Renderer::AccessEFB)");
+	D3D::SetDebugObjectName(m_efb.color_staging_buf.Get(), "EFB color staging texture (used for Renderer::AccessEFB)");
 
 	// EFB depth buffer - primary depth buffer
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB depth texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.depth_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL|D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1));
-	SAFE_RELEASE(buf);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetTex(), "EFB depth texture");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetDSV(), "EFB depth texture depth stencil view");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetSRV(), "EFB depth texture shader resource view");
+	m_efb.depth_tex.Attach(new D3DTexture2D(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL|D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1)));
+	buf.Release();
+	D3D::SetDebugObjectName(m_efb.depth_tex->GetTex(), "EFB depth texture");
+	D3D::SetDebugObjectName(m_efb.depth_tex->GetDSV(), "EFB depth texture depth stencil view");
+	D3D::SetDebugObjectName(m_efb.depth_tex->GetSRV(), "EFB depth texture shader resource view");
 
 	// Render buffer for AccessEFB (depth data)
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, D3D11_BIND_RENDER_TARGET);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB depth read texture (hr=%#x)", hr);
-	m_efb.depth_read_texture = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
-	SAFE_RELEASE(buf);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_read_texture->GetTex(), "EFB depth read texture (used in Renderer::AccessEFB)");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_read_texture->GetRTV(), "EFB depth read texture render target view (used in Renderer::AccessEFB)");
+	m_efb.depth_read_texture.Attach(new D3DTexture2D(buf.Get(), D3D11_BIND_RENDER_TARGET));
+	buf.Release();
+	D3D::SetDebugObjectName(m_efb.depth_read_texture->GetTex(), "EFB depth read texture (used in Renderer::AccessEFB)");
+	D3D::SetDebugObjectName(m_efb.depth_read_texture->GetRTV(), "EFB depth read texture render target view (used in Renderer::AccessEFB)");
 
 	// AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.depth_staging_buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, m_efb.depth_staging_buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB depth staging buffer (hr=%#x)", hr);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_staging_buf, "EFB depth staging texture (used for Renderer::AccessEFB)");
+	D3D::SetDebugObjectName(m_efb.depth_staging_buf.Get(), "EFB depth staging texture (used for Renderer::AccessEFB)");
 
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
 		// Framebuffer resolve textures (color+depth)
 		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, 1);
-		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 		CHECK(hr==S_OK, "create EFB color resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_color_tex = new D3DTexture2D(buf, D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM);
-		SAFE_RELEASE(buf);
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetTex(), "EFB color resolve texture");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetSRV(), "EFB color resolve texture shader resource view");
+		m_efb.resolved_color_tex.Attach(new D3DTexture2D(buf.Get(), D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM));
+		buf.Release();
+		D3D::SetDebugObjectName(m_efb.resolved_color_tex->GetTex(), "EFB color resolve texture");
+		D3D::SetDebugObjectName(m_efb.resolved_color_tex->GetSRV(), "EFB color resolve texture shader resource view");
 
 		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL);
-		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 		CHECK(hr==S_OK, "create EFB depth resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_depth_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL), DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT);
-		SAFE_RELEASE(buf);
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetTex(), "EFB depth resolve texture");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetSRV(), "EFB depth resolve texture shader resource view");
+		m_efb.resolved_depth_tex.Attach(new D3DTexture2D(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL), DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT));
+		buf.Release();
+		D3D::SetDebugObjectName(m_efb.resolved_depth_tex->GetTex(), "EFB depth resolve texture");
+		D3D::SetDebugObjectName(m_efb.resolved_depth_tex->GetSRV(), "EFB depth resolve texture shader resource view");
 
 		// Depth state used when writing resolved depth texture
 		D3D11_DEPTH_STENCIL_DESC depth_resolve_depth_state = CD3D11_DEPTH_STENCIL_DESC(CD3D11_DEFAULT());
 		depth_resolve_depth_state.DepthEnable = TRUE;
 		depth_resolve_depth_state.DepthFunc = D3D11_COMPARISON_ALWAYS;
 		depth_resolve_depth_state.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;
-		hr = D3D::device->CreateDepthStencilState(&depth_resolve_depth_state, &m_depth_resolve_depth_state);
+		hr = D3D::device->CreateDepthStencilState(&depth_resolve_depth_state, m_depth_resolve_depth_state.GetAddressOf());
 		CHECK(hr == S_OK, "create depth resolve depth stencil state");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_depth_resolve_depth_state, "depth resolve depth stencil state");
+		D3D::SetDebugObjectName(m_depth_resolve_depth_state.Get(), "depth resolve depth stencil state");
 	}
 	else
 	{
-		m_efb.resolved_color_tex = nullptr;
-		m_efb.resolved_depth_tex = nullptr;
-		m_depth_resolve_depth_state = nullptr;
+		m_efb.resolved_color_tex.Release();
+		m_efb.resolved_depth_tex.Release();
+		m_depth_resolve_depth_state.Release();
 	}
 
 	s_xfbEncoder.Init();
@@ -193,15 +193,15 @@ FramebufferManager::~FramebufferManager()
 {
 	s_xfbEncoder.Shutdown();
 
-	SAFE_RELEASE(m_efb.color_tex);
-	SAFE_RELEASE(m_efb.color_temp_tex);
-	SAFE_RELEASE(m_efb.color_staging_buf);
-	SAFE_RELEASE(m_efb.resolved_color_tex);
-	SAFE_RELEASE(m_efb.depth_tex);
-	SAFE_RELEASE(m_efb.depth_staging_buf);
-	SAFE_RELEASE(m_efb.depth_read_texture);
-	SAFE_RELEASE(m_efb.resolved_depth_tex);
-	SAFE_RELEASE(m_depth_resolve_depth_state);
+	m_efb.color_tex.Release();
+	m_efb.color_temp_tex.Release();
+	m_efb.color_staging_buf.Release();
+	m_efb.resolved_color_tex.Release();
+	m_efb.depth_tex.Release();
+	m_efb.depth_staging_buf.Release();
+	m_efb.depth_read_texture.Release();
+	m_efb.resolved_depth_tex.Release();
+	m_depth_resolve_depth_state.Release();
 }
 
 void FramebufferManager::CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, const EFBRectangle& sourceRc,float Gamma)
@@ -239,7 +239,7 @@ void XFBSource::CopyEFB(float Gamma)
 	const D3D11_RECT rect = CD3D11_RECT(0, 0, texWidth, texHeight);
 
 	D3D::context->RSSetViewports(1, &vp);
-	D3D::context->OMSetRenderTargets(1, &tex->GetRTV(), nullptr);
+	D3D::SetRenderTarget(tex->GetRTV());
 	D3D::SetPointCopySampler();
 
 	D3D::drawShadedTexQuad(FramebufferManager::GetEFBColorTexture()->GetSRV(), &rect,
@@ -247,7 +247,7 @@ void XFBSource::CopyEFB(float Gamma)
 		VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
 		GeometryShaderCache::GetCopyGeometryShader(), Gamma);
 
-	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
+	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(),
 		FramebufferManager::GetEFBDepthTexture()->GetDSV());
 
 	g_renderer->RestoreAPIState();

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -62,22 +62,22 @@ public:
 	FramebufferManager();
 	~FramebufferManager();
 
-	static D3DTexture2D* &GetEFBColorTexture();
-	static ID3D11Texture2D* &GetEFBColorStagingBuffer();
+	static D3DTexture2D* GetEFBColorTexture();
+	static ID3D11Texture2D* GetEFBColorStagingBuffer();
 
-	static D3DTexture2D* &GetEFBDepthTexture();
-	static D3DTexture2D* &GetEFBDepthReadTexture();
-	static ID3D11Texture2D* &GetEFBDepthStagingBuffer();
+	static D3DTexture2D* GetEFBDepthTexture();
+	static D3DTexture2D* GetEFBDepthReadTexture();
+	static ID3D11Texture2D* GetEFBDepthStagingBuffer();
 
-	static D3DTexture2D* &GetResolvedEFBColorTexture();
-	static D3DTexture2D* &GetResolvedEFBDepthTexture();
+	static D3DTexture2D* GetResolvedEFBColorTexture();
+	static D3DTexture2D* GetResolvedEFBDepthTexture();
 
-	static D3DTexture2D* &GetEFBColorTempTexture() { return m_efb.color_temp_tex; }
+	static D3DTexture2D* GetEFBColorTempTexture() { return m_efb.color_temp_tex.Get(); }
 	static void SwapReinterpretTexture()
 	{
 		D3DTexture2D* swaptex = GetEFBColorTempTexture();
-		m_efb.color_temp_tex = GetEFBColorTexture();
-		m_efb.color_tex = swaptex;
+		m_efb.color_temp_tex.Copy(GetEFBColorTexture());
+		m_efb.color_tex.Copy(swaptex);
 	}
 
 private:
@@ -88,24 +88,24 @@ private:
 
 	static struct Efb
 	{
-		D3DTexture2D* color_tex;
-		ID3D11Texture2D* color_staging_buf;
+		ComPtr<D3DTexture2D> color_tex;
+		ComPtr<ID3D11Texture2D> color_staging_buf;
 
-		D3DTexture2D* depth_tex;
-		ID3D11Texture2D* depth_staging_buf;
-		D3DTexture2D* depth_read_texture;
+		ComPtr<D3DTexture2D> depth_tex;
+		ComPtr<ID3D11Texture2D> depth_staging_buf;
+		ComPtr<D3DTexture2D> depth_read_texture;
 
-		D3DTexture2D* color_temp_tex;
+		ComPtr<D3DTexture2D> color_temp_tex;
 
-		D3DTexture2D* resolved_color_tex;
-		D3DTexture2D* resolved_depth_tex;
+		ComPtr<D3DTexture2D> resolved_color_tex;
+		ComPtr<D3DTexture2D> resolved_depth_tex;
 
 		int slices;
 	} m_efb;
 
 	static unsigned int m_target_width;
 	static unsigned int m_target_height;
-	static ID3D11DepthStencilState* m_depth_resolve_depth_state;
+	static ComPtr<ID3D11DepthStencilState> m_depth_resolve_depth_state;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -46,13 +46,12 @@ namespace DX11
 
 struct XFBSource : public XFBSourceBase
 {
-	XFBSource(D3DTexture2D *_tex, int slices) : tex(_tex), m_slices(slices) {}
-	~XFBSource() { tex->Release(); }
+	XFBSource(D3DTexture2D&& _tex, int slices) : tex(_tex), m_slices(slices) {}
 
 	void DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight) override;
 	void CopyEFB(float Gamma) override;
 
-	D3DTexture2D* const tex;
+	D3DTexture2D tex;
 	const int m_slices;
 };
 
@@ -62,22 +61,20 @@ public:
 	FramebufferManager();
 	~FramebufferManager();
 
-	static D3DTexture2D* GetEFBColorTexture();
-	static ID3D11Texture2D* GetEFBColorStagingBuffer();
+	static D3DTexture2D& GetEFBColorTexture();
+	static const ComPtr<ID3D11Texture2D>& GetEFBColorStagingBuffer();
 
-	static D3DTexture2D* GetEFBDepthTexture();
-	static D3DTexture2D* GetEFBDepthReadTexture();
-	static ID3D11Texture2D* GetEFBDepthStagingBuffer();
+	static D3DTexture2D& GetEFBDepthTexture();
+	static D3DTexture2D& GetEFBDepthReadTexture();
+	static const ComPtr<ID3D11Texture2D>& GetEFBDepthStagingBuffer();
 
-	static D3DTexture2D* GetResolvedEFBColorTexture();
-	static D3DTexture2D* GetResolvedEFBDepthTexture();
+	static D3DTexture2D& GetResolvedEFBColorTexture();
+	static D3DTexture2D& GetResolvedEFBDepthTexture();
 
-	static D3DTexture2D* GetEFBColorTempTexture() { return m_efb.color_temp_tex.Get(); }
+	static D3DTexture2D& GetEFBColorTempTexture() { return m_efb.color_temp_tex; }
 	static void SwapReinterpretTexture()
 	{
-		D3DTexture2D* swaptex = GetEFBColorTempTexture();
-		m_efb.color_temp_tex.Copy(GetEFBColorTexture());
-		m_efb.color_tex.Copy(swaptex);
+		std::swap(GetEFBColorTexture(), GetEFBColorTempTexture());
 	}
 
 private:
@@ -88,17 +85,17 @@ private:
 
 	static struct Efb
 	{
-		ComPtr<D3DTexture2D> color_tex;
+		D3DTexture2D color_tex;
 		ComPtr<ID3D11Texture2D> color_staging_buf;
 
-		ComPtr<D3DTexture2D> depth_tex;
+		D3DTexture2D depth_tex;
 		ComPtr<ID3D11Texture2D> depth_staging_buf;
-		ComPtr<D3DTexture2D> depth_read_texture;
+		D3DTexture2D depth_read_texture;
 
-		ComPtr<D3DTexture2D> color_temp_tex;
+		D3DTexture2D color_temp_tex;
 
-		ComPtr<D3DTexture2D> resolved_color_tex;
-		ComPtr<D3DTexture2D> resolved_depth_tex;
+		D3DTexture2D resolved_color_tex;
+		D3DTexture2D resolved_depth_tex;
 
 		int slices;
 	} m_efb;

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -62,11 +62,11 @@ public:
 	~FramebufferManager();
 
 	static D3DTexture2D& GetEFBColorTexture();
-	static const ComPtr<ID3D11Texture2D>& GetEFBColorStagingBuffer();
+	static ID3D11Texture2D* GetEFBColorStagingBuffer();
 
 	static D3DTexture2D& GetEFBDepthTexture();
 	static D3DTexture2D& GetEFBDepthReadTexture();
-	static const ComPtr<ID3D11Texture2D>& GetEFBDepthStagingBuffer();
+	static ID3D11Texture2D* GetEFBDepthStagingBuffer();
 
 	static D3DTexture2D& GetResolvedEFBColorTexture();
 	static D3DTexture2D& GetResolvedEFBDepthTexture();

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
@@ -24,18 +24,18 @@ public:
 	static ID3D11GeometryShader* GeometryShaderCache::GetClearGeometryShader();
 	static ID3D11GeometryShader* GeometryShaderCache::GetCopyGeometryShader();
 
-	static ID3D11GeometryShader* GetActiveShader() { return last_entry->shader; }
-	static ID3D11Buffer* &GetConstantBuffer();
+	static ID3D11GeometryShader* GetActiveShader() { return last_entry->shader.Get(); }
+	static ID3D11Buffer* GetConstantBuffer();
 
 private:
 	struct GSCacheEntry
 	{
-		ID3D11GeometryShader* shader;
+		ComPtr<ID3D11GeometryShader> shader;
 
 		std::string code;
 
 		GSCacheEntry() : shader(nullptr) {}
-		void Destroy() { SAFE_RELEASE(shader); }
+		void Destroy() { shader.Release(); }
 	};
 
 	typedef std::map<GeometryShaderUid, GSCacheEntry> GSCache;

--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -18,7 +18,6 @@ class D3DVertexFormat : public NativeVertexFormat
 {
 public:
 	D3DVertexFormat(const PortableVertexDeclaration& vtx_decl);
-	~D3DVertexFormat() { SAFE_RELEASE(m_layout); }
 
 	void SetupVertexPointers() override;
 
@@ -26,7 +25,7 @@ private:
 	std::array<D3D11_INPUT_ELEMENT_DESC, 32> m_elems{};
 	UINT m_num_elems = 0;
 
-	ID3D11InputLayout* m_layout = nullptr;
+	ComPtr<ID3D11InputLayout> m_layout = nullptr;
 };
 
 NativeVertexFormat* VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
@@ -136,11 +135,11 @@ void D3DVertexFormat::SetupVertexPointers()
 		// changes.
 		D3DBlob* vs_bytecode = DX11::VertexShaderCache::GetActiveShaderBytecode();
 
-		HRESULT hr = DX11::D3D::device->CreateInputLayout(m_elems.data(), m_num_elems, vs_bytecode->Data(), vs_bytecode->Size(), &m_layout);
+		HRESULT hr = DX11::D3D::device->CreateInputLayout(m_elems.data(), m_num_elems, vs_bytecode->Data(), vs_bytecode->Size(), m_layout.GetAddressOf());
 		if (FAILED(hr)) PanicAlert("Failed to create input layout, %s %d\n", __FILE__, __LINE__);
-		DX11::D3D::SetDebugObjectName((ID3D11DeviceChild*)m_layout, "input layout used to emulate the GX pipeline");
+		DX11::D3D::SetDebugObjectName(m_layout.Get(), "input layout used to emulate the GX pipeline");
 	}
-	DX11::D3D::stateman->SetInputLayout(m_layout);
+	DX11::D3D::stateman->SetInputLayout(m_layout.Get());
 }
 
 } // namespace DX11

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -94,11 +94,11 @@ void PSTextureEncoder::Encode(u8* dst, u32 format, u32 native_width, u32 bytes_p
 
 	// Resolve MSAA targets before copying.
 	ID3D11ShaderResourceView* pEFB = (srcFormat == PEControl::Z24) ?
-			FramebufferManager::GetResolvedEFBDepthTexture()->GetSRV() :
+			FramebufferManager::GetResolvedEFBDepthTexture().GetSRV() :
 			// FIXME: Instead of resolving EFB, it would be better to pick out a
 			// single sample from each pixel. The game may break if it isn't
 			// expecting the blurred edges around multisampled shapes.
-			FramebufferManager::GetResolvedEFBColorTexture()->GetSRV();
+			FramebufferManager::GetResolvedEFBColorTexture().GetSRV();
 
 	// Reset API
 	g_renderer->ResetAPIState();
@@ -161,8 +161,8 @@ void PSTextureEncoder::Encode(u8* dst, u32 format, u32 native_width, u32 bytes_p
 	// Restore API
 	g_renderer->RestoreAPIState();
 	D3D::SetRenderTarget(
-		FramebufferManager::GetEFBColorTexture()->GetRTV(),
-		FramebufferManager::GetEFBDepthTexture()->GetDSV());
+		FramebufferManager::GetEFBColorTexture().GetRTV(),
+		FramebufferManager::GetEFBDepthTexture().GetDSV());
 }
 
 ID3D11PixelShader* PSTextureEncoder::SetStaticShader(unsigned int dstFormat, PEControl::PixelFormat srcFormat,

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -6,6 +6,7 @@
 
 #include "VideoBackends/D3D/TextureEncoder.h"
 
+#include "VideoBackends/D3D/D3DTexture.h"
 #include "VideoCommon/TextureCacheBase.h"
 
 struct ID3D11Texture2D;
@@ -38,8 +39,7 @@ public:
 private:
 	bool m_ready;
 
-	ComPtr<ID3D11Texture2D> m_out;
-	ComPtr<ID3D11RenderTargetView> m_outRTV;
+	D3DTexture2D m_out;
 	ComPtr<ID3D11Texture2D> m_outStage;
 	ComPtr<ID3D11Buffer> m_encodeParams;
 

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -38,10 +38,10 @@ public:
 private:
 	bool m_ready;
 
-	ID3D11Texture2D* m_out;
-	ID3D11RenderTargetView* m_outRTV;
-	ID3D11Texture2D* m_outStage;
-	ID3D11Buffer* m_encodeParams;
+	ComPtr<ID3D11Texture2D> m_out;
+	ComPtr<ID3D11RenderTargetView> m_outRTV;
+	ComPtr<ID3D11Texture2D> m_outStage;
+	ComPtr<ID3D11Buffer> m_encodeParams;
 
 	ID3D11PixelShader* SetStaticShader(unsigned int dstFormat,
 		PEControl::PixelFormat srcFormat, bool isIntensity, bool scaleByHalf);
@@ -55,7 +55,7 @@ private:
 			| (scaleByHalf ? (1<<0) : 0);
 	}
 
-	typedef std::map<ComboKey, ID3D11PixelShader*> ComboMap;
+	typedef std::map<ComboKey, ComPtr<ID3D11PixelShader>> ComboMap;
 
 	ComboMap m_staticShaders;
 };

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -31,15 +31,15 @@ UidChecker<PixelShaderUid, ShaderCode> PixelShaderCache::pixel_uid_checker;
 
 LinearDiskCache<PixelShaderUid, u8> g_ps_disk_cache;
 
-ID3D11PixelShader* s_ColorMatrixProgram[2] = {nullptr};
-ID3D11PixelShader* s_ColorCopyProgram[2] = {nullptr};
-ID3D11PixelShader* s_DepthMatrixProgram[2] = {nullptr};
-ID3D11PixelShader* s_ClearProgram = nullptr;
-ID3D11PixelShader* s_AnaglyphProgram = nullptr;
-ID3D11PixelShader* s_DepthResolveProgram = nullptr;
-ID3D11PixelShader* s_rgba6_to_rgb8[2] = {nullptr};
-ID3D11PixelShader* s_rgb8_to_rgba6[2] = {nullptr};
-ID3D11Buffer* pscbuf = nullptr;
+ComPtr<ID3D11PixelShader> s_ColorMatrixProgram[2] = {nullptr};
+ComPtr<ID3D11PixelShader> s_ColorCopyProgram[2] = {nullptr};
+ComPtr<ID3D11PixelShader> s_DepthMatrixProgram[2] = {nullptr};
+ComPtr<ID3D11PixelShader> s_ClearProgram = nullptr;
+ComPtr<ID3D11PixelShader> s_AnaglyphProgram = nullptr;
+ComPtr<ID3D11PixelShader> s_DepthResolveProgram = nullptr;
+ComPtr<ID3D11PixelShader> s_rgba6_to_rgb8[2] = {nullptr};
+ComPtr<ID3D11PixelShader> s_rgb8_to_rgba6[2] = {nullptr};
+ComPtr<ID3D11Buffer> pscbuf = nullptr;
 
 const char clear_program_code[] = {
 	"void main(\n"
@@ -310,9 +310,9 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGBA6ToRGB8(bool multisampled)
 		{
 			s_rgba6_to_rgb8[0] = D3D::CompileAndCreatePixelShader(reint_rgba6_to_rgb8);
 			CHECK(s_rgba6_to_rgb8[0], "Create RGBA6 to RGB8 pixel shader");
-			D3D::SetDebugObjectName(s_rgba6_to_rgb8[0], "RGBA6 to RGB8 pixel shader");
+			D3D::SetDebugObjectName(s_rgba6_to_rgb8[0].Get(), "RGBA6 to RGB8 pixel shader");
 		}
-		return s_rgba6_to_rgb8[0];
+		return s_rgba6_to_rgb8[0].Get();
 	}
 	else if (!s_rgba6_to_rgb8[1])
 	{
@@ -321,9 +321,9 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGBA6ToRGB8(bool multisampled)
 		s_rgba6_to_rgb8[1] = D3D::CompileAndCreatePixelShader(buf);
 
 		CHECK(s_rgba6_to_rgb8[1], "Create RGBA6 to RGB8 MSAA pixel shader");
-		D3D::SetDebugObjectName(s_rgba6_to_rgb8[1], "RGBA6 to RGB8 MSAA pixel shader");
+		D3D::SetDebugObjectName(s_rgba6_to_rgb8[1].Get(), "RGBA6 to RGB8 MSAA pixel shader");
 	}
-	return s_rgba6_to_rgb8[1];
+	return s_rgba6_to_rgb8[1].Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
@@ -334,9 +334,9 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
 		{
 			s_rgb8_to_rgba6[0] = D3D::CompileAndCreatePixelShader(reint_rgb8_to_rgba6);
 			CHECK(s_rgb8_to_rgba6[0], "Create RGB8 to RGBA6 pixel shader");
-			D3D::SetDebugObjectName(s_rgb8_to_rgba6[0], "RGB8 to RGBA6 pixel shader");
+			D3D::SetDebugObjectName(s_rgb8_to_rgba6[0].Get(), "RGB8 to RGBA6 pixel shader");
 		}
-		return s_rgb8_to_rgba6[0];
+		return s_rgb8_to_rgba6[0].Get();
 	}
 	else if (!s_rgb8_to_rgba6[1])
 	{
@@ -345,20 +345,20 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
 		s_rgb8_to_rgba6[1] = D3D::CompileAndCreatePixelShader(buf);
 
 		CHECK(s_rgb8_to_rgba6[1], "Create RGB8 to RGBA6 MSAA pixel shader");
-		D3D::SetDebugObjectName(s_rgb8_to_rgba6[1], "RGB8 to RGBA6 MSAA pixel shader");
+		D3D::SetDebugObjectName(s_rgb8_to_rgba6[1].Get(), "RGB8 to RGBA6 MSAA pixel shader");
 	}
-	return s_rgb8_to_rgba6[1];
+	return s_rgb8_to_rgba6[1].Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::GetColorCopyProgram(bool multisampled)
 {
 	if (!multisampled || g_ActiveConfig.iMultisamples <= 1)
 	{
-		return s_ColorCopyProgram[0];
+		return s_ColorCopyProgram[0].Get();
 	}
 	else if (s_ColorCopyProgram[1])
 	{
-		return s_ColorCopyProgram[1];
+		return s_ColorCopyProgram[1].Get();
 	}
 	else
 	{
@@ -366,8 +366,8 @@ ID3D11PixelShader* PixelShaderCache::GetColorCopyProgram(bool multisampled)
 		std::string buf = StringFromFormat(color_copy_program_code_msaa, g_ActiveConfig.iMultisamples);
 		s_ColorCopyProgram[1] = D3D::CompileAndCreatePixelShader(buf);
 		CHECK(s_ColorCopyProgram[1]!=nullptr, "Create color copy MSAA pixel shader");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[1], "color copy MSAA pixel shader");
-		return s_ColorCopyProgram[1];
+		D3D::SetDebugObjectName(s_ColorCopyProgram[1].Get(), "color copy MSAA pixel shader");
+		return s_ColorCopyProgram[1].Get();
 	}
 }
 
@@ -375,11 +375,11 @@ ID3D11PixelShader* PixelShaderCache::GetColorMatrixProgram(bool multisampled)
 {
 	if (!multisampled || g_ActiveConfig.iMultisamples <= 1)
 	{
-		return s_ColorMatrixProgram[0];
+		return s_ColorMatrixProgram[0].Get();
 	}
 	else if (s_ColorMatrixProgram[1])
 	{
-		return s_ColorMatrixProgram[1];
+		return s_ColorMatrixProgram[1].Get();
 	}
 	else
 	{
@@ -387,8 +387,8 @@ ID3D11PixelShader* PixelShaderCache::GetColorMatrixProgram(bool multisampled)
 		std::string buf = StringFromFormat(color_matrix_program_code_msaa, g_ActiveConfig.iMultisamples);
 		s_ColorMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
 		CHECK(s_ColorMatrixProgram[1]!=nullptr, "Create color matrix MSAA pixel shader");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[1], "color matrix MSAA pixel shader");
-		return s_ColorMatrixProgram[1];
+		D3D::SetDebugObjectName(s_ColorMatrixProgram[1].Get(), "color matrix MSAA pixel shader");
+		return s_ColorMatrixProgram[1].Get();
 	}
 }
 
@@ -396,11 +396,11 @@ ID3D11PixelShader* PixelShaderCache::GetDepthMatrixProgram(bool multisampled)
 {
 	if (!multisampled || g_ActiveConfig.iMultisamples <= 1)
 	{
-		return s_DepthMatrixProgram[0];
+		return s_DepthMatrixProgram[0].Get();
 	}
 	else if (s_DepthMatrixProgram[1])
 	{
-		return s_DepthMatrixProgram[1];
+		return s_DepthMatrixProgram[1].Get();
 	}
 	else
 	{
@@ -408,48 +408,48 @@ ID3D11PixelShader* PixelShaderCache::GetDepthMatrixProgram(bool multisampled)
 		std::string buf = StringFromFormat(depth_matrix_program_msaa, g_ActiveConfig.iMultisamples);
 		s_DepthMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
 		CHECK(s_DepthMatrixProgram[1]!=nullptr, "Create depth matrix MSAA pixel shader");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[1], "depth matrix MSAA pixel shader");
-		return s_DepthMatrixProgram[1];
+		D3D::SetDebugObjectName(s_DepthMatrixProgram[1].Get(), "depth matrix MSAA pixel shader");
+		return s_DepthMatrixProgram[1].Get();
 	}
 }
 
 ID3D11PixelShader* PixelShaderCache::GetClearProgram()
 {
-	return s_ClearProgram;
+	return s_ClearProgram.Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::GetAnaglyphProgram()
 {
-	return s_AnaglyphProgram;
+	return s_AnaglyphProgram.Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::GetDepthResolveProgram()
 {
 	if (s_DepthResolveProgram != nullptr)
-		return s_DepthResolveProgram;
+		return s_DepthResolveProgram.Get();
 
 	// create MSAA shader for current AA mode
 	std::string buf = StringFromFormat(depth_resolve_program, g_ActiveConfig.iMultisamples);
 	s_DepthResolveProgram = D3D::CompileAndCreatePixelShader(buf);
 	CHECK(s_DepthResolveProgram != nullptr, "Create depth matrix MSAA pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthResolveProgram, "depth resolve pixel shader");
-	return s_DepthResolveProgram;
+	D3D::SetDebugObjectName(s_DepthResolveProgram.Get(), "depth resolve pixel shader");
+	return s_DepthResolveProgram.Get();
 }
 
-ID3D11Buffer* &PixelShaderCache::GetConstantBuffer()
+ID3D11Buffer* PixelShaderCache::GetConstantBuffer()
 {
 	// TODO: divide the global variables of the generated shaders into about 5 constant buffers to speed this up
 	if (PixelShaderManager::dirty)
 	{
 		D3D11_MAPPED_SUBRESOURCE map;
-		D3D::context->Map(pscbuf, 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
+		D3D::context->Map(pscbuf.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
 		memcpy(map.pData, &PixelShaderManager::constants, sizeof(PixelShaderConstants));
-		D3D::context->Unmap(pscbuf, 0);
+		D3D::context->Unmap(pscbuf.Get(), 0);
 		PixelShaderManager::dirty = false;
 
 		ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(PixelShaderConstants));
 	}
-	return pscbuf;
+	return pscbuf.Get();
 }
 
 // this class will load the precompiled shaders into our cache
@@ -466,34 +466,34 @@ void PixelShaderCache::Init()
 {
 	unsigned int cbsize = ROUND_UP(sizeof(PixelShaderConstants), 16); // must be a multiple of 16
 	D3D11_BUFFER_DESC cbdesc = CD3D11_BUFFER_DESC(cbsize, D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
-	D3D::device->CreateBuffer(&cbdesc, nullptr, &pscbuf);
+	D3D::device->CreateBuffer(&cbdesc, nullptr, pscbuf.GetAddressOf());
 	CHECK(pscbuf!=nullptr, "Create pixel shader constant buffer");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)pscbuf, "pixel shader constant buffer used to emulate the GX pipeline");
+	D3D::SetDebugObjectName(pscbuf.Get(), "pixel shader constant buffer used to emulate the GX pipeline");
 
 	// used when drawing clear quads
 	s_ClearProgram = D3D::CompileAndCreatePixelShader(clear_program_code);
 	CHECK(s_ClearProgram!=nullptr, "Create clear pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ClearProgram, "clear pixel shader");
+	D3D::SetDebugObjectName(s_ClearProgram.Get(), "clear pixel shader");
 
 	// used for anaglyph stereoscopy
 	s_AnaglyphProgram = D3D::CompileAndCreatePixelShader(anaglyph_program_code);
 	CHECK(s_AnaglyphProgram != nullptr, "Create anaglyph pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_AnaglyphProgram, "anaglyph pixel shader");
+	D3D::SetDebugObjectName(s_AnaglyphProgram.Get(), "anaglyph pixel shader");
 
 	// used when copying/resolving the color buffer
 	s_ColorCopyProgram[0] = D3D::CompileAndCreatePixelShader(color_copy_program_code);
 	CHECK(s_ColorCopyProgram[0]!=nullptr, "Create color copy pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[0], "color copy pixel shader");
+	D3D::SetDebugObjectName(s_ColorCopyProgram[0].Get(), "color copy pixel shader");
 
 	// used for color conversion
 	s_ColorMatrixProgram[0] = D3D::CompileAndCreatePixelShader(color_matrix_program_code);
 	CHECK(s_ColorMatrixProgram[0]!=nullptr, "Create color matrix pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[0], "color matrix pixel shader");
+	D3D::SetDebugObjectName(s_ColorMatrixProgram[0].Get(), "color matrix pixel shader");
 
 	// used for depth copy
 	s_DepthMatrixProgram[0] = D3D::CompileAndCreatePixelShader(depth_matrix_program);
 	CHECK(s_DepthMatrixProgram[0]!=nullptr, "Create depth matrix pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[0], "depth matrix pixel shader");
+	D3D::SetDebugObjectName(s_DepthMatrixProgram[0].Get(), "depth matrix pixel shader");
 
 	Clear();
 
@@ -528,28 +528,28 @@ void PixelShaderCache::Clear()
 // Used in Swap() when AA mode has changed
 void PixelShaderCache::InvalidateMSAAShaders()
 {
-	SAFE_RELEASE(s_ColorCopyProgram[1]);
-	SAFE_RELEASE(s_ColorMatrixProgram[1]);
-	SAFE_RELEASE(s_DepthMatrixProgram[1]);
-	SAFE_RELEASE(s_rgb8_to_rgba6[1]);
-	SAFE_RELEASE(s_rgba6_to_rgb8[1]);
-	SAFE_RELEASE(s_DepthResolveProgram);
+	s_ColorCopyProgram[1].Release();
+	s_ColorMatrixProgram[1].Release();
+	s_DepthMatrixProgram[1].Release();
+	s_rgb8_to_rgba6[1].Release();
+	s_rgba6_to_rgb8[1].Release();
+	s_DepthResolveProgram.Release();
 }
 
 void PixelShaderCache::Shutdown()
 {
-	SAFE_RELEASE(pscbuf);
+	pscbuf.Release();
 
-	SAFE_RELEASE(s_ClearProgram);
-	SAFE_RELEASE(s_AnaglyphProgram);
-	SAFE_RELEASE(s_DepthResolveProgram);
+	s_ClearProgram.Release();
+	s_AnaglyphProgram.Release();
+	s_DepthResolveProgram.Release();
 	for (int i = 0; i < 2; ++i)
 	{
-		SAFE_RELEASE(s_ColorCopyProgram[i]);
-		SAFE_RELEASE(s_ColorMatrixProgram[i]);
-		SAFE_RELEASE(s_DepthMatrixProgram[i]);
-		SAFE_RELEASE(s_rgba6_to_rgb8[i]);
-		SAFE_RELEASE(s_rgb8_to_rgba6[i]);
+		s_ColorCopyProgram[i].Release();
+		s_ColorMatrixProgram[i].Release();
+		s_DepthMatrixProgram[i].Release();
+		s_rgba6_to_rgb8[i].Release();
+		s_rgb8_to_rgba6[i].Release();
 	}
 
 	Clear();
@@ -617,12 +617,12 @@ bool PixelShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode)
 
 bool PixelShaderCache::InsertByteCode(const PixelShaderUid &uid, const void* bytecode, unsigned int bytecodelen)
 {
-	ID3D11PixelShader* shader = D3D::CreatePixelShaderFromByteCode(bytecode, bytecodelen);
+	ComPtr<ID3D11PixelShader> shader = D3D::CreatePixelShaderFromByteCode(bytecode, bytecodelen);
 	if (shader == nullptr)
 		return false;
 
 	// TODO: Somehow make the debug name a bit more specific
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)shader, "a pixel shader of PixelShaderCache");
+	D3D::SetDebugObjectName(shader.Get(), "a pixel shader of PixelShaderCache");
 
 	// Make an entry in the table
 	PSCacheEntry newentry;

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.h
@@ -23,8 +23,8 @@ public:
 	static bool SetShader(DSTALPHA_MODE dstAlphaMode); // TODO: Should be renamed to LoadShader
 	static bool InsertByteCode(const PixelShaderUid &uid, const void* bytecode, unsigned int bytecodelen);
 
-	static ID3D11PixelShader* GetActiveShader() { return last_entry->shader; }
-	static ID3D11Buffer* &GetConstantBuffer();
+	static ID3D11PixelShader* GetActiveShader() { return last_entry->shader.Get(); }
+	static ID3D11Buffer* GetConstantBuffer();
 
 	static ID3D11PixelShader* GetColorMatrixProgram(bool multisampled);
 	static ID3D11PixelShader* GetColorCopyProgram(bool multisampled);
@@ -40,12 +40,12 @@ public:
 private:
 	struct PSCacheEntry
 	{
-		ID3D11PixelShader* shader;
+		ComPtr<ID3D11PixelShader> shader;
 
 		std::string code;
 
 		PSCacheEntry() : shader(nullptr) {}
-		void Destroy() { SAFE_RELEASE(shader); }
+		void Destroy() { shader.Release(); }
 	};
 
 	typedef std::map<PixelShaderUid, PSCacheEntry> PSCache;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -47,15 +47,15 @@ static bool s_last_xfb_mode = false;
 
 static Television s_television;
 
-ID3D11Buffer* access_efb_cbuf = nullptr;
-ID3D11BlendState* clearblendstates[4] = {nullptr};
-ID3D11DepthStencilState* cleardepthstates[3] = {nullptr};
-ID3D11BlendState* resetblendstate = nullptr;
-ID3D11DepthStencilState* resetdepthstate = nullptr;
-ID3D11RasterizerState* resetraststate = nullptr;
+ComPtr<ID3D11Buffer> access_efb_cbuf = nullptr;
+ComPtr<ID3D11BlendState> clearblendstates[4] = {nullptr};
+ComPtr<ID3D11DepthStencilState> cleardepthstates[3] = {nullptr};
+ComPtr<ID3D11BlendState> resetblendstate = nullptr;
+ComPtr<ID3D11DepthStencilState> resetdepthstate = nullptr;
+ComPtr<ID3D11RasterizerState> resetraststate = nullptr;
 
-static ID3D11Texture2D* s_screenshot_texture = nullptr;
-static D3DTexture2D* s_3d_vision_texture = nullptr;
+static ComPtr<ID3D11Texture2D> s_screenshot_texture = nullptr;
+static ComPtr<D3DTexture2D> s_3d_vision_texture = nullptr;
 
 // Nvidia stereo blitting struct defined in "nvstereo.h" from the Nvidia SDK
 typedef struct _Nv_Stereo_Image_Header
@@ -93,9 +93,9 @@ static void SetupDeviceObjects()
 	D3D11_BUFFER_DESC cbdesc = CD3D11_BUFFER_DESC(20*sizeof(float), D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DEFAULT);
 	D3D11_SUBRESOURCE_DATA data;
 	data.pSysMem = colmat;
-	hr = D3D::device->CreateBuffer(&cbdesc, &data, &access_efb_cbuf);
+	hr = D3D::device->CreateBuffer(&cbdesc, &data, access_efb_cbuf.GetAddressOf());
 	CHECK(hr==S_OK, "Create constant buffer for Renderer::AccessEFB");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)access_efb_cbuf, "constant buffer for Renderer::AccessEFB");
+	D3D::SetDebugObjectName(access_efb_cbuf.Get(), "constant buffer for Renderer::AccessEFB");
 
 	D3D11_DEPTH_STENCIL_DESC ddesc;
 	ddesc.DepthEnable      = FALSE;
@@ -104,18 +104,18 @@ static void SetupDeviceObjects()
 	ddesc.StencilEnable    = FALSE;
 	ddesc.StencilReadMask  = D3D11_DEFAULT_STENCIL_READ_MASK;
 	ddesc.StencilWriteMask = D3D11_DEFAULT_STENCIL_WRITE_MASK;
-	hr = D3D::device->CreateDepthStencilState(&ddesc, &cleardepthstates[0]);
+	hr = D3D::device->CreateDepthStencilState(&ddesc, cleardepthstates[0].GetAddressOf());
 	CHECK(hr==S_OK, "Create depth state for Renderer::ClearScreen");
 	ddesc.DepthWriteMask   = D3D11_DEPTH_WRITE_MASK_ALL;
 	ddesc.DepthEnable      = TRUE;
-	hr = D3D::device->CreateDepthStencilState(&ddesc, &cleardepthstates[1]);
+	hr = D3D::device->CreateDepthStencilState(&ddesc, cleardepthstates[1].GetAddressOf());
 	CHECK(hr==S_OK, "Create depth state for Renderer::ClearScreen");
 	ddesc.DepthWriteMask   = D3D11_DEPTH_WRITE_MASK_ZERO;
-	hr = D3D::device->CreateDepthStencilState(&ddesc, &cleardepthstates[2]);
+	hr = D3D::device->CreateDepthStencilState(&ddesc, cleardepthstates[2].GetAddressOf());
 	CHECK(hr==S_OK, "Create depth state for Renderer::ClearScreen");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)cleardepthstates[0], "depth state for Renderer::ClearScreen (depth buffer disabled)");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)cleardepthstates[1], "depth state for Renderer::ClearScreen (depth buffer enabled, writing enabled)");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)cleardepthstates[2], "depth state for Renderer::ClearScreen (depth buffer enabled, writing disabled)");
+	D3D::SetDebugObjectName(cleardepthstates[0].Get(), "depth state for Renderer::ClearScreen (depth buffer disabled)");
+	D3D::SetDebugObjectName(cleardepthstates[1].Get(), "depth state for Renderer::ClearScreen (depth buffer enabled, writing enabled)");
+	D3D::SetDebugObjectName(cleardepthstates[2].Get(), "depth state for Renderer::ClearScreen (depth buffer enabled, writing disabled)");
 
 	D3D11_BLEND_DESC blenddesc;
 	blenddesc.AlphaToCoverageEnable = FALSE;
@@ -128,23 +128,22 @@ static void SetupDeviceObjects()
 	blenddesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
 	blenddesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
 	blenddesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
-	hr = D3D::device->CreateBlendState(&blenddesc, &resetblendstate);
+	hr = D3D::device->CreateBlendState(&blenddesc, resetblendstate.GetAddressOf());
 	CHECK(hr==S_OK, "Create blend state for Renderer::ResetAPIState");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)resetblendstate, "blend state for Renderer::ResetAPIState");
+	D3D::SetDebugObjectName(resetblendstate.Get(), "blend state for Renderer::ResetAPIState");
 
 	clearblendstates[0] = resetblendstate;
-	resetblendstate->AddRef();
 
 	blenddesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_RED|D3D11_COLOR_WRITE_ENABLE_GREEN|D3D11_COLOR_WRITE_ENABLE_BLUE;
-	hr = D3D::device->CreateBlendState(&blenddesc, &clearblendstates[1]);
+	hr = D3D::device->CreateBlendState(&blenddesc, clearblendstates[1].GetAddressOf());
 	CHECK(hr==S_OK, "Create blend state for Renderer::ClearScreen");
 
 	blenddesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALPHA;
-	hr = D3D::device->CreateBlendState(&blenddesc, &clearblendstates[2]);
+	hr = D3D::device->CreateBlendState(&blenddesc, clearblendstates[2].GetAddressOf());
 	CHECK(hr==S_OK, "Create blend state for Renderer::ClearScreen");
 
 	blenddesc.RenderTarget[0].RenderTargetWriteMask = 0;
-	hr = D3D::device->CreateBlendState(&blenddesc, &clearblendstates[3]);
+	hr = D3D::device->CreateBlendState(&blenddesc, clearblendstates[3].GetAddressOf());
 	CHECK(hr==S_OK, "Create blend state for Renderer::ClearScreen");
 
 	ddesc.DepthEnable      = FALSE;
@@ -153,14 +152,14 @@ static void SetupDeviceObjects()
 	ddesc.StencilEnable    = FALSE;
 	ddesc.StencilReadMask  = D3D11_DEFAULT_STENCIL_READ_MASK;
 	ddesc.StencilWriteMask = D3D11_DEFAULT_STENCIL_WRITE_MASK;
-	hr = D3D::device->CreateDepthStencilState(&ddesc, &resetdepthstate);
+	hr = D3D::device->CreateDepthStencilState(&ddesc, resetdepthstate.GetAddressOf());
 	CHECK(hr==S_OK, "Create depth state for Renderer::ResetAPIState");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)resetdepthstate, "depth stencil state for Renderer::ResetAPIState");
+	D3D::SetDebugObjectName(resetdepthstate.Get(), "depth stencil state for Renderer::ResetAPIState");
 
 	D3D11_RASTERIZER_DESC rastdesc = CD3D11_RASTERIZER_DESC(D3D11_FILL_SOLID, D3D11_CULL_NONE, false, 0, 0.f, 0.f, false, false, false, false);
-	hr = D3D::device->CreateRasterizerState(&rastdesc, &resetraststate);
+	hr = D3D::device->CreateRasterizerState(&rastdesc, resetraststate.GetAddressOf());
 	CHECK(hr==S_OK, "Create rasterizer state for Renderer::ResetAPIState");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)resetraststate, "rasterizer state for Renderer::ResetAPIState");
+	D3D::SetDebugObjectName(resetraststate.Get(), "rasterizer state for Renderer::ResetAPIState");
 
 	s_screenshot_texture = nullptr;
 }
@@ -170,19 +169,19 @@ static void TeardownDeviceObjects()
 {
 	g_framebuffer_manager.reset();
 
-	SAFE_RELEASE(access_efb_cbuf);
-	SAFE_RELEASE(clearblendstates[0]);
-	SAFE_RELEASE(clearblendstates[1]);
-	SAFE_RELEASE(clearblendstates[2]);
-	SAFE_RELEASE(clearblendstates[3]);
-	SAFE_RELEASE(cleardepthstates[0]);
-	SAFE_RELEASE(cleardepthstates[1]);
-	SAFE_RELEASE(cleardepthstates[2]);
-	SAFE_RELEASE(resetblendstate);
-	SAFE_RELEASE(resetdepthstate);
-	SAFE_RELEASE(resetraststate);
-	SAFE_RELEASE(s_screenshot_texture);
-	SAFE_RELEASE(s_3d_vision_texture);
+	access_efb_cbuf.Release();
+	clearblendstates[0].Release();
+	clearblendstates[1].Release();
+	clearblendstates[2].Release();
+	clearblendstates[3].Release();
+	cleardepthstates[0].Release();
+	cleardepthstates[1].Release();
+	cleardepthstates[2].Release();
+	resetblendstate.Release();
+	resetdepthstate.Release();
+	resetraststate.Release();
+	s_screenshot_texture.Release();
+	s_3d_vision_texture.Release();
 
 	s_television.Shutdown();
 
@@ -194,9 +193,9 @@ static void CreateScreenshotTexture()
 	// We can't render anything outside of the backbuffer anyway, so use the backbuffer size as the screenshot buffer size.
 	// This texture is released to be recreated when the window is resized in Renderer::SwapImpl.
 	D3D11_TEXTURE2D_DESC scrtex_desc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, D3D::GetBackBufferWidth(), D3D::GetBackBufferHeight(), 1, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ|D3D11_CPU_ACCESS_WRITE);
-	HRESULT hr = D3D::device->CreateTexture2D(&scrtex_desc, nullptr, &s_screenshot_texture);
+	HRESULT hr = D3D::device->CreateTexture2D(&scrtex_desc, nullptr, s_screenshot_texture.GetAddressOf());
 	CHECK(hr==S_OK, "Create screenshot staging texture");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_screenshot_texture, "staging screenshot texture");
+	D3D::SetDebugObjectName(s_screenshot_texture.Get(), "staging screenshot texture");
 }
 
 static D3D11_BOX GetScreenshotSourceBox(const TargetRectangle& targetRc)
@@ -229,7 +228,7 @@ static void Create3DVisionTexture(int width, int height)
 	header->dwBPP = 32;
 	header->dwFlags = 0;
 
-	s_3d_vision_texture = D3DTexture2D::Create(width * 2, height + 1, D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, &sysData);
+	s_3d_vision_texture.Attach(D3DTexture2D::Create(width * 2, height + 1, D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, &sysData));
 	delete[] sysData.pSysMem;
 }
 
@@ -280,7 +279,7 @@ Renderer::Renderer(void *&window_handle)
 
 	D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, (float)s_target_width, (float)s_target_height);
 	D3D::context->RSSetViewports(1, &vp);
-	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
 	D3D::BeginFrame();
 }
 
@@ -400,8 +399,8 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 		// depth buffers can only be completely CopySubresourceRegion'ed, so we're using drawShadedTexQuad instead
 		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, 1.f, 1.f);
 		D3D::context->RSSetViewports(1, &vp);
-		D3D::stateman->SetPixelConstants(0, access_efb_cbuf);
-		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBDepthReadTexture()->GetRTV(), nullptr);
+		D3D::stateman->SetPixelConstants(0, access_efb_cbuf.Get());
+		D3D::SetRenderTarget(FramebufferManager::GetEFBDepthReadTexture()->GetRTV(), nullptr);
 		D3D::SetPointCopySampler();
 		D3D::drawShadedTexQuad(FramebufferManager::GetEFBDepthTexture()->GetSRV(),
 								&RectToLock,
@@ -411,7 +410,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 								VertexShaderCache::GetSimpleVertexShader(),
 								VertexShaderCache::GetSimpleInputLayout());
 
-		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+		D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
 
 		// copy to system memory
 		D3D11_BOX box = CD3D11_BOX(0, 0, 0, 1, 1, 1);
@@ -485,18 +484,18 @@ void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num
 	{
 		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
 		D3D::context->RSSetViewports(1, &vp);
-		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), nullptr);
+		D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(), nullptr);
 	}
 	else // if (type == POKE_Z)
 	{
-		D3D::stateman->PushBlendState(clearblendstates[3]);
-		D3D::stateman->PushDepthState(cleardepthstates[1]);
+		D3D::stateman->PushBlendState(clearblendstates[3].Get());
+		D3D::stateman->PushDepthState(cleardepthstates[1].Get());
 
 		D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
 
 		D3D::context->RSSetViewports(1, &vp);
 
-		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
+		D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(),
 			FramebufferManager::GetEFBDepthTexture()->GetDSV());
 	}
 
@@ -559,15 +558,15 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaE
 {
 	ResetAPIState();
 
-	if (colorEnable && alphaEnable) D3D::stateman->PushBlendState(clearblendstates[0]);
-	else if (colorEnable) D3D::stateman->PushBlendState(clearblendstates[1]);
-	else if (alphaEnable) D3D::stateman->PushBlendState(clearblendstates[2]);
-	else D3D::stateman->PushBlendState(clearblendstates[3]);
+	if (colorEnable && alphaEnable) D3D::stateman->PushBlendState(clearblendstates[0].Get());
+	else if (colorEnable) D3D::stateman->PushBlendState(clearblendstates[1].Get());
+	else if (alphaEnable) D3D::stateman->PushBlendState(clearblendstates[2].Get());
+	else D3D::stateman->PushBlendState(clearblendstates[3].Get());
 
 	// TODO: Should we enable Z testing here?
-	/*if (!bpmem.zmode.testenable) D3D::stateman->PushDepthState(cleardepthstates[0]);
-	else */if (zEnable) D3D::stateman->PushDepthState(cleardepthstates[1]);
-	else /*if (!zEnable)*/ D3D::stateman->PushDepthState(cleardepthstates[2]);
+	/*if (!bpmem.zmode.testenable) D3D::stateman->PushDepthState(cleardepthstates[0].Get());
+	else */if (zEnable) D3D::stateman->PushDepthState(cleardepthstates[1].Get());
+	else /*if (!zEnable)*/ D3D::stateman->PushDepthState(cleardepthstates[2].Get());
 
 	// Update the view port for clearing the picture
 	TargetRectangle targetRc = Renderer::ConvertEFBRectangle(rc);
@@ -604,7 +603,7 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
 	D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, (float)g_renderer->GetTargetWidth(), (float)g_renderer->GetTargetHeight());
 	D3D::context->RSSetViewports(1, &vp);
 
-	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTempTexture()->GetRTV(), nullptr);
+	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTempTexture()->GetRTV(), nullptr);
 	D3D::SetPointCopySampler();
 	D3D::drawShadedTexQuad(FramebufferManager::GetEFBColorTexture()->GetSRV(), &source, g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight(),
 		pixel_shader, VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
@@ -612,7 +611,7 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
 	g_renderer->RestoreAPIState();
 
 	FramebufferManager::SwapReinterpretTexture();
-	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
 }
 
 void Renderer::SetBlendMode(bool forceUpdate)
@@ -672,14 +671,14 @@ bool Renderer::SaveScreenshot(const std::string &filename, const TargetRectangle
 
 	// copy back buffer to system memory
 	D3D11_BOX source_box = GetScreenshotSourceBox(rc);
-	D3D::context->CopySubresourceRegion(s_screenshot_texture, 0, 0, 0, 0, (ID3D11Resource*)D3D::GetBackBuffer()->GetTex(), 0, &source_box);
+	D3D::context->CopySubresourceRegion(s_screenshot_texture.Get(), 0, 0, 0, 0, D3D::GetBackBuffer()->GetTex(), 0, &source_box);
 
 	D3D11_MAPPED_SUBRESOURCE map;
-	D3D::context->Map(s_screenshot_texture, 0, D3D11_MAP_READ_WRITE, 0, &map);
+	D3D::context->Map(s_screenshot_texture.Get(), 0, D3D11_MAP_READ_WRITE, 0, &map);
 
 	bool saved_png = TextureToPng((u8*)map.pData, map.RowPitch, filename, source_box.right - source_box.left, source_box.bottom - source_box.top, false);
 
-	D3D::context->Unmap(s_screenshot_texture, 0);
+	D3D::context->Unmap(s_screenshot_texture.Get(), 0);
 
 
 	if (saved_png)
@@ -740,7 +739,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 	UpdateDrawRectangle(s_backbuffer_width, s_backbuffer_height);
 	TargetRectangle targetRc = GetTargetRectangle();
 
-	D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
+	D3D::SetRenderTarget(D3D::GetBackBuffer()->GetRTV(), nullptr);
 
 	float ClearColor[4] = { 0.f, 0.f, 0.f, 1.f };
 	D3D::context->ClearRenderTargetView(D3D::GetBackBuffer()->GetRTV(), ClearColor);
@@ -831,7 +830,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 		D3D11_BOX source_box = GetScreenshotSourceBox(targetRc);
 		unsigned int source_width = source_box.right - source_box.left;
 		unsigned int source_height = source_box.bottom - source_box.top;
-		D3D::context->CopySubresourceRegion(s_screenshot_texture, 0, 0, 0, 0, (ID3D11Resource*)D3D::GetBackBuffer()->GetTex(), 0, &source_box);
+		D3D::context->CopySubresourceRegion(s_screenshot_texture.Get(), 0, 0, 0, 0, D3D::GetBackBuffer()->GetTex(), 0, &source_box);
 		if (!bLastFrameDumped)
 		{
 			s_recordWidth = source_width;
@@ -852,7 +851,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 		if (bAVIDumping)
 		{
 			D3D11_MAPPED_SUBRESOURCE map;
-			D3D::context->Map(s_screenshot_texture, 0, D3D11_MAP_READ, 0, &map);
+			D3D::context->Map(s_screenshot_texture.Get(), 0, D3D11_MAP_READ, 0, &map);
 
 			if (frame_data.empty() || w != s_recordWidth || h != s_recordHeight)
 			{
@@ -863,7 +862,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 			formatBufferDump((u8*)map.pData, &frame_data[0], source_width, source_height, map.RowPitch);
 			FlipImageData(&frame_data[0], w, h);
 			AVIDump::AddFrame(&frame_data[0], source_width, source_height);
-			D3D::context->Unmap(s_screenshot_texture, 0);
+			D3D::context->Unmap(s_screenshot_texture.Get(), 0);
 		}
 		bLastFrameDumped = true;
 	}
@@ -972,8 +971,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 
 			// TODO: Aren't we still holding a reference to the back buffer right now?
 			D3D::Reset();
-			SAFE_RELEASE(s_screenshot_texture);
-			SAFE_RELEASE(s_3d_vision_texture);
+			s_screenshot_texture.Release();
+			s_3d_vision_texture.Release();
 			s_backbuffer_width = D3D::GetBackBufferWidth();
 			s_backbuffer_height = D3D::GetBackBufferHeight();
 		}
@@ -985,7 +984,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 
 		PixelShaderManager::SetEfbScaleChanged();
 
-		D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
+		D3D::SetRenderTarget(D3D::GetBackBuffer()->GetRTV(), nullptr);
 
 		g_framebuffer_manager.reset();
 		g_framebuffer_manager = std::make_unique<FramebufferManager>();
@@ -997,16 +996,16 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, co
 	// begin next frame
 	RestoreAPIState();
 	D3D::BeginFrame();
-	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
 	SetViewport();
 }
 
 // ALWAYS call RestoreAPIState for each ResetAPIState call you're doing
 void Renderer::ResetAPIState()
 {
-	D3D::stateman->PushBlendState(resetblendstate);
-	D3D::stateman->PushDepthState(resetdepthstate);
-	D3D::stateman->PushRasterizerState(resetraststate);
+	D3D::stateman->PushBlendState(resetblendstate.Get());
+	D3D::stateman->PushDepthState(resetdepthstate.Get());
+	D3D::stateman->PushRasterizerState(resetraststate.Get());
 }
 
 void Renderer::RestoreAPIState()
@@ -1296,7 +1295,7 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D
 		D3D11_VIEWPORT rightVp = CD3D11_VIEWPORT((float)(dst.left + s_backbuffer_width), (float)dst.top, (float)dst.GetWidth(), (float)dst.GetHeight());
 
 		// Render to staging texture which is double the width of the backbuffer
-		D3D::context->OMSetRenderTargets(1, &s_3d_vision_texture->GetRTV(), nullptr);
+		D3D::SetRenderTarget(s_3d_vision_texture->GetRTV(), nullptr);
 
 		D3D::context->RSSetViewports(1, &leftVp);
 		D3D::drawShadedTexQuad(src_texture->GetSRV(), src.AsRECT(), src_width, src_height, PixelShaderCache::GetColorCopyProgram(false), VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(), nullptr, Gamma, 0);
@@ -1310,7 +1309,7 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D
 		D3D::context->CopySubresourceRegion(D3D::GetBackBuffer()->GetTex(), 0, 0, 0, 0, s_3d_vision_texture->GetTex(), 0, &box);
 
 		// Restore render target to backbuffer
-		D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
+		D3D::SetRenderTarget(D3D::GetBackBuffer()->GetRTV(), nullptr);
 	}
 	else
 	{

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -414,7 +414,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 
 		// copy to system memory
 		D3D11_BOX box = CD3D11_BOX(0, 0, 0, 1, 1, 1);
-		read_tex = FramebufferManager::GetEFBDepthStagingBuffer().Get();
+		read_tex = FramebufferManager::GetEFBDepthStagingBuffer();
 		D3D::context->CopySubresourceRegion(read_tex, 0, 0, 0, 0, FramebufferManager::GetEFBDepthReadTexture().GetTex(), 0, &box);
 
 		RestoreAPIState(); // restore game state
@@ -441,7 +441,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 	else if (type == PEEK_COLOR)
 	{
 		// we can directly copy to system memory here
-		read_tex = FramebufferManager::GetEFBColorStagingBuffer().Get();
+		read_tex = FramebufferManager::GetEFBColorStagingBuffer();
 		D3D11_BOX box = CD3D11_BOX(RectToLock.left, RectToLock.top, 0, RectToLock.right, RectToLock.bottom, 1);
 		D3D::context->CopySubresourceRegion(read_tex, 0, 0, 0, 0, FramebufferManager::GetEFBColorTexture().GetTex(), 0, &box);
 

--- a/Source/Core/VideoBackends/D3D/Television.cpp
+++ b/Source/Core/VideoBackends/D3D/Television.cpp
@@ -84,24 +84,24 @@ void Television::Init()
 	// This texture format is designed for YUYV data.
 	D3D11_TEXTURE2D_DESC t2dd = CD3D11_TEXTURE2D_DESC(
 		DXGI_FORMAT_G8R8_G8B8_UNORM, MAX_XFB_WIDTH, MAX_XFB_HEIGHT, 1, 1);
-	hr = D3D::device->CreateTexture2D(&t2dd, &srd, &m_yuyvTexture);
+	hr = D3D::device->CreateTexture2D(&t2dd, &srd, m_yuyvTexture.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create tv yuyv texture");
-	D3D::SetDebugObjectName(m_yuyvTexture, "tv yuyv texture");
+	D3D::SetDebugObjectName(m_yuyvTexture.Get(), "tv yuyv texture");
 
 	// Create shader resource view for YUYV texture
 
 	D3D11_SHADER_RESOURCE_VIEW_DESC srvd = CD3D11_SHADER_RESOURCE_VIEW_DESC(
-		m_yuyvTexture, D3D11_SRV_DIMENSION_TEXTURE2D,
+		m_yuyvTexture.Get(), D3D11_SRV_DIMENSION_TEXTURE2D,
 		DXGI_FORMAT_G8R8_G8B8_UNORM);
-	hr = D3D::device->CreateShaderResourceView(m_yuyvTexture, &srvd, &m_yuyvTextureSRV);
+	hr = D3D::device->CreateShaderResourceView(m_yuyvTexture.Get(), &srvd, m_yuyvTextureSRV.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create tv yuyv texture srv");
-	D3D::SetDebugObjectName(m_yuyvTextureSRV, "tv yuyv texture srv");
+	D3D::SetDebugObjectName(m_yuyvTextureSRV.Get(), "tv yuyv texture srv");
 
 	// Create YUYV-decoding pixel shader
 
 	m_pShader = D3D::CompileAndCreatePixelShader(YUYV_DECODER_PS);
 	CHECK(m_pShader != nullptr, "compile and create yuyv decoder pixel shader");
-	D3D::SetDebugObjectName(m_pShader, "yuyv decoder pixel shader");
+	D3D::SetDebugObjectName(m_pShader.Get(), "yuyv decoder pixel shader");
 
 	// Create sampler state and set border color
 	//
@@ -114,17 +114,17 @@ void Television::Init()
 	D3D11_SAMPLER_DESC samDesc = CD3D11_SAMPLER_DESC(D3D11_FILTER_MIN_MAG_MIP_LINEAR,
 		D3D11_TEXTURE_ADDRESS_BORDER, D3D11_TEXTURE_ADDRESS_BORDER, D3D11_TEXTURE_ADDRESS_BORDER,
 		0.f, 1, D3D11_COMPARISON_ALWAYS, border, 0.f, 0.f);
-	hr = D3D::device->CreateSamplerState(&samDesc, &m_samplerState);
+	hr = D3D::device->CreateSamplerState(&samDesc, m_samplerState.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create yuyv decoder sampler state");
-	D3D::SetDebugObjectName(m_samplerState, "yuyv decoder sampler state");
+	D3D::SetDebugObjectName(m_samplerState.Get(), "yuyv decoder sampler state");
 }
 
 void Television::Shutdown()
 {
-	SAFE_RELEASE(m_pShader);
-	SAFE_RELEASE(m_yuyvTextureSRV);
-	SAFE_RELEASE(m_yuyvTexture);
-	SAFE_RELEASE(m_samplerState);
+	m_pShader.Release();
+	m_yuyvTextureSRV.Release();
+	m_yuyvTexture.Release();
+	m_samplerState.Release();
 }
 
 void Television::Submit(u32 xfbAddr, u32 stride, u32 width, u32 height)
@@ -136,7 +136,7 @@ void Television::Submit(u32 xfbAddr, u32 stride, u32 width, u32 height)
 	// Load data from GameCube RAM to YUYV texture
 	u8* yuyvSrc = Memory::GetPointer(xfbAddr);
 	D3D11_BOX box = CD3D11_BOX(0, 0, 0, stride, height, 1);
-	D3D::context->UpdateSubresource(m_yuyvTexture, 0, &box, yuyvSrc, 2 * stride, 2 * stride * height);
+	D3D::context->UpdateSubresource(m_yuyvTexture.Get(), 0, &box, yuyvSrc, 2 * stride, 2 * stride * height);
 }
 
 void Television::Render()
@@ -150,12 +150,12 @@ void Television::Render()
 
 		D3D11_RECT sourceRc = CD3D11_RECT(0, 0, int(m_curWidth), int(m_curHeight));
 
-		D3D::stateman->SetSampler(0, m_samplerState);
+		D3D::stateman->SetSampler(0, m_samplerState.Get());
 
 		D3D::drawShadedTexQuad(
-			m_yuyvTextureSRV, &sourceRc,
+			m_yuyvTextureSRV.Get(), &sourceRc,
 			MAX_XFB_WIDTH, MAX_XFB_HEIGHT,
-			m_pShader,
+			m_pShader.Get(),
 			VertexShaderCache::GetSimpleVertexShader(),
 			VertexShaderCache::GetSimpleInputLayout());
 	}

--- a/Source/Core/VideoBackends/D3D/Television.h
+++ b/Source/Core/VideoBackends/D3D/Television.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "VideoCommon/VideoCommon.h"
+#include "VideoBackends/D3D/D3DTexture.h"
 
 struct ID3D11Texture2D;
 struct ID3D11ShaderResourceView;
@@ -18,9 +19,6 @@ class Television
 {
 
 public:
-
-	Television();
-
 	void Init();
 	void Shutdown();
 
@@ -41,8 +39,7 @@ private:
 
 	// Used for real XFB mode
 
-	ComPtr<ID3D11Texture2D> m_yuyvTexture;
-	ComPtr<ID3D11ShaderResourceView> m_yuyvTextureSRV;
+	D3DTexture2D m_yuyvTexture;
 	ComPtr<ID3D11PixelShader> m_pShader;
 	ComPtr<ID3D11SamplerState> m_samplerState;
 

--- a/Source/Core/VideoBackends/D3D/Television.h
+++ b/Source/Core/VideoBackends/D3D/Television.h
@@ -41,10 +41,10 @@ private:
 
 	// Used for real XFB mode
 
-	ID3D11Texture2D* m_yuyvTexture;
-	ID3D11ShaderResourceView* m_yuyvTextureSRV;
-	ID3D11PixelShader* m_pShader;
-	ID3D11SamplerState* m_samplerState;
+	ComPtr<ID3D11Texture2D> m_yuyvTexture;
+	ComPtr<ID3D11ShaderResourceView> m_yuyvTextureSRV;
+	ComPtr<ID3D11PixelShader> m_pShader;
+	ComPtr<ID3D11SamplerState> m_samplerState;
 
 };
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -25,7 +25,7 @@ namespace DX11
 
 static std::unique_ptr<TextureEncoder> g_encoder;
 const size_t MAX_COPY_BUFFERS = 32;
-ID3D11Buffer* efbcopycbuf[MAX_COPY_BUFFERS] = { 0 };
+ComPtr<ID3D11Buffer> efbcopycbuf[MAX_COPY_BUFFERS] = { 0 };
 
 TextureCache::TCacheEntry::~TCacheEntry()
 {
@@ -48,7 +48,7 @@ bool TextureCache::TCacheEntry::Save(const std::string& filename, unsigned int l
 		return false;
 	}
 
-	ID3D11Texture2D* pNewTexture = nullptr;
+	ComPtr<ID3D11Texture2D> pNewTexture = nullptr;
 	ID3D11Texture2D* pSurface = texture->GetTex();
 	D3D11_TEXTURE2D_DESC desc;
 	pSurface->GetDesc(&desc);
@@ -57,22 +57,21 @@ bool TextureCache::TCacheEntry::Save(const std::string& filename, unsigned int l
 	desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE;
 	desc.Usage = D3D11_USAGE_STAGING;
 
-	HRESULT hr = D3D::device->CreateTexture2D(&desc, nullptr, &pNewTexture);
+	HRESULT hr = D3D::device->CreateTexture2D(&desc, nullptr, pNewTexture.GetAddressOf());
 
 	bool saved_png = false;
 
 	if (SUCCEEDED(hr) && pNewTexture)
 	{
-		D3D::context->CopyResource(pNewTexture, pSurface);
+		D3D::context->CopyResource(pNewTexture.Get(), pSurface);
 
 		D3D11_MAPPED_SUBRESOURCE map;
-		hr = D3D::context->Map(pNewTexture, 0, D3D11_MAP_READ_WRITE, 0, &map);
+		hr = D3D::context->Map(pNewTexture.Get(), 0, D3D11_MAP_READ_WRITE, 0, &map);
 		if (SUCCEEDED(hr))
 		{
 			saved_png = TextureToPng((u8*)map.pData, map.RowPitch, filename, desc.Width, desc.Height);
-			D3D::context->Unmap(pNewTexture, 0);
+			D3D::context->Unmap(pNewTexture.Get(), 0);
 		}
-		SAFE_RELEASE(pNewTexture);
 	}
 
 	return saved_png;
@@ -118,7 +117,7 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 		float(dstrect.GetWidth()),
 		float(dstrect.GetHeight()));
 
-	D3D::context->OMSetRenderTargets(1, &texture->GetRTV(), nullptr);
+	D3D::SetRenderTarget(texture->GetRTV(), nullptr);
 	D3D::context->RSSetViewports(1, &vp);
 	D3D::SetLinearCopySampler();
 	D3D11_RECT srcRC;
@@ -132,8 +131,8 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 		VertexShaderCache::GetSimpleVertexShader(),
 		VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader(), 1.0, 0);
 
-	D3D::context->OMSetRenderTargets(1,
-		&FramebufferManager::GetEFBColorTexture()->GetRTV(),
+	D3D::SetRenderTarget(
+		FramebufferManager::GetEFBColorTexture()->GetRTV(),
 		FramebufferManager::GetEFBDepthTexture()->GetDSV());
 
 	g_renderer->RestoreAPIState();
@@ -168,18 +167,16 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 		const D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM,
 			config.width, config.height, 1, config.levels, D3D11_BIND_SHADER_RESOURCE, usage, cpu_access);
 
-		ID3D11Texture2D *pTexture;
-		const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &pTexture);
+		ComPtr<ID3D11Texture2D> pTexture;
+		const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, pTexture.GetAddressOf());
 		CHECK(SUCCEEDED(hr), "Create texture of the TextureCache");
 
-		TCacheEntry* const entry = new TCacheEntry(config, new D3DTexture2D(pTexture, D3D11_BIND_SHADER_RESOURCE));
+		TCacheEntry* const entry = new TCacheEntry(config, new D3DTexture2D(pTexture.Get(), D3D11_BIND_SHADER_RESOURCE));
 		entry->usage = usage;
 
 		// TODO: better debug names
 		D3D::SetDebugObjectName((ID3D11DeviceChild*)entry->texture->GetTex(), "a texture of the TextureCache");
 		D3D::SetDebugObjectName((ID3D11DeviceChild*)entry->texture->GetSRV(), "shader resource view of a texture of the TextureCache");
-
-		SAFE_RELEASE(pTexture);
 
 		return entry;
 	}
@@ -215,11 +212,11 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, PEControl::PixelFormat
 		const D3D11_BUFFER_DESC cbdesc = CD3D11_BUFFER_DESC(28 * sizeof(float), D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DEFAULT);
 		D3D11_SUBRESOURCE_DATA data;
 		data.pSysMem = colmat;
-		HRESULT hr = D3D::device->CreateBuffer(&cbdesc, &data, &efbcopycbuf[cbufid]);
+		HRESULT hr = D3D::device->CreateBuffer(&cbdesc, &data, efbcopycbuf[cbufid].GetAddressOf());
 		CHECK(SUCCEEDED(hr), "Create efb copy constant buffer %d", cbufid);
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)efbcopycbuf[cbufid], "a constant buffer used in TextureCache::CopyRenderTargetToTexture");
+		D3D::SetDebugObjectName(efbcopycbuf[cbufid].Get(), "a constant buffer used in TextureCache::CopyRenderTargetToTexture");
 	}
-	D3D::stateman->SetPixelConstants(efbcopycbuf[cbufid]);
+	D3D::stateman->SetPixelConstants(efbcopycbuf[cbufid].Get());
 
 	const TargetRectangle targetSource = g_renderer->ConvertEFBRectangle(srcRect);
 	// TODO: try targetSource.asRECT();
@@ -235,7 +232,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, PEControl::PixelFormat
 	// (This can happen because we don't unbind textures when we free them.)
 	D3D::stateman->UnsetTexture(texture->GetSRV());
 
-	D3D::context->OMSetRenderTargets(1, &texture->GetRTV(), nullptr);
+	D3D::SetRenderTarget(texture->GetRTV(), nullptr);
 
 	// Create texture copy
 	D3D::drawShadedTexQuad(
@@ -247,7 +244,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, PEControl::PixelFormat
 		VertexShaderCache::GetSimpleInputLayout(),
 		GeometryShaderCache::GetCopyGeometryShader());
 
-	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
 
 	g_renderer->RestoreAPIState();
 }
@@ -348,14 +345,14 @@ void TextureCache::ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* uncon
 	D3D::context->RSSetViewports(1, &vp);
 
 	D3D11_BOX box{ 0, 0, 0, 512, 1, 1 };
-	D3D::context->UpdateSubresource(palette_buf, 0, &box, palette, 0, 0);
+	D3D::context->UpdateSubresource(palette_buf.Get(), 0, &box, palette, 0, 0);
 
-	D3D::stateman->SetTexture(1, palette_buf_srv);
+	D3D::stateman->SetTexture(1, palette_buf_srv.Get());
 
 	// TODO: Add support for C14X2 format.  (Different multiplier, more palette entries.)
 	float params[4] = { (unconverted->format & 0xf) == GX_TF_I4 ? 15.f : 255.f };
-	D3D::context->UpdateSubresource(palette_uniform, 0, nullptr, &params, 0, 0);
-	D3D::stateman->SetPixelConstants(palette_uniform);
+	D3D::context->UpdateSubresource(palette_uniform.Get(), 0, nullptr, &params, 0, 0);
+	D3D::stateman->SetPixelConstants(palette_uniform.Get());
 
 	const D3D11_RECT sourcerect = CD3D11_RECT(0, 0, unconverted->config.width, unconverted->config.height);
 
@@ -365,22 +362,22 @@ void TextureCache::ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* uncon
 	// (This can happen because we don't unbind textures when we free them.)
 	D3D::stateman->UnsetTexture(static_cast<TCacheEntry*>(entry)->texture->GetSRV());
 
-	D3D::context->OMSetRenderTargets(1, &static_cast<TCacheEntry*>(entry)->texture->GetRTV(), nullptr);
+	D3D::SetRenderTarget(static_cast<TCacheEntry*>(entry)->texture->GetRTV(), nullptr);
 
 	// Create texture copy
 	D3D::drawShadedTexQuad(
 		static_cast<TCacheEntry*>(unconverted)->texture->GetSRV(),
 		&sourcerect, unconverted->config.width, unconverted->config.height,
-		palette_pixel_shader[format],
+		palette_pixel_shader[format].Get(),
 		VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
 		GeometryShaderCache::GetCopyGeometryShader());
 
-	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
 
 	g_renderer->RestoreAPIState();
 }
 
-ID3D11PixelShader *GetConvertShader(const char* Type)
+static ComPtr<ID3D11PixelShader> GetConvertShader(const char* Type)
 {
 	std::string shader = "#define DECODE DecodePixel_";
 	shader.append(Type);
@@ -402,33 +399,33 @@ TextureCache::TextureCache()
 	palette_pixel_shader[GX_TL_RGB565] = GetConvertShader("RGB565");
 	palette_pixel_shader[GX_TL_RGB5A3] = GetConvertShader("RGB5A3");
 	auto lutBd = CD3D11_BUFFER_DESC(sizeof(u16) * 256, D3D11_BIND_SHADER_RESOURCE);
-	HRESULT hr = D3D::device->CreateBuffer(&lutBd, nullptr, &palette_buf);
+	HRESULT hr = D3D::device->CreateBuffer(&lutBd, nullptr, palette_buf.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create palette decoder lut buffer");
-	D3D::SetDebugObjectName(palette_buf, "texture decoder lut buffer");
+	D3D::SetDebugObjectName(palette_buf.Get(), "texture decoder lut buffer");
 	// TODO: C14X2 format.
-	auto outlutUavDesc = CD3D11_SHADER_RESOURCE_VIEW_DESC(palette_buf, DXGI_FORMAT_R16_UINT, 0, 256, 0);
-	hr = D3D::device->CreateShaderResourceView(palette_buf, &outlutUavDesc, &palette_buf_srv);
+	auto outlutUavDesc = CD3D11_SHADER_RESOURCE_VIEW_DESC(palette_buf.Get(), DXGI_FORMAT_R16_UINT, 0, 256, 0);
+	hr = D3D::device->CreateShaderResourceView(palette_buf.Get(), &outlutUavDesc, palette_buf_srv.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create palette decoder lut srv");
-	D3D::SetDebugObjectName(palette_buf_srv, "texture decoder lut srv");
+	D3D::SetDebugObjectName(palette_buf_srv.Get(), "texture decoder lut srv");
 	const D3D11_BUFFER_DESC cbdesc = CD3D11_BUFFER_DESC(16, D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DEFAULT);
-	hr = D3D::device->CreateBuffer(&cbdesc, nullptr, &palette_uniform);
+	hr = D3D::device->CreateBuffer(&cbdesc, nullptr, palette_uniform.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "Create palette decoder constant buffer");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)palette_uniform, "a constant buffer used in TextureCache::CopyRenderTargetToTexture");
+	D3D::SetDebugObjectName(palette_uniform.Get(), "a constant buffer used in TextureCache::CopyRenderTargetToTexture");
 }
 
 TextureCache::~TextureCache()
 {
 	for (unsigned int k = 0; k < MAX_COPY_BUFFERS; ++k)
-		SAFE_RELEASE(efbcopycbuf[k]);
+		efbcopycbuf[k].Release();
 
 	g_encoder->Shutdown();
 	g_encoder.reset();
 
-	SAFE_RELEASE(palette_buf);
-	SAFE_RELEASE(palette_buf_srv);
-	SAFE_RELEASE(palette_uniform);
-	for (ID3D11PixelShader*& shader : palette_pixel_shader)
-		SAFE_RELEASE(shader);
+	palette_buf.Release();
+	palette_buf_srv.Release();
+	palette_uniform.Release();
+	for (ComPtr<ID3D11PixelShader>& shader : palette_pixel_shader)
+		shader.Release();
 }
 
 }

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -166,12 +166,13 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 		const D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM,
 			config.width, config.height, 1, config.levels, D3D11_BIND_SHADER_RESOURCE, usage, cpu_access);
 
-		ID3D11Texture2D* pTexture;
-		const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &pTexture);
+		ComPtr<ID3D11Texture2D> pTexture;
+		const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, pTexture.GetAddressOf());
 		CHECK(SUCCEEDED(hr), "Create texture of the TextureCache");
 		
 		D3DTexture2D newTex;
-		newTex.Attach(pTexture, D3D11_BIND_SHADER_RESOURCE);
+		newTex.CreateFromExisting(pTexture.Get(), D3D11_BIND_SHADER_RESOURCE);
+		pTexture.Release();
 		TCacheEntry* const entry = new TCacheEntry(config, std::move(newTex));
 		entry->usage = usage;
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -155,24 +155,14 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 	else
 	{
 		D3D11_USAGE usage = D3D11_USAGE_DEFAULT;
-		D3D11_CPU_ACCESS_FLAG cpu_access = (D3D11_CPU_ACCESS_FLAG)0;
 
 		if (config.levels == 1)
 		{
 			usage = D3D11_USAGE_DYNAMIC;
-			cpu_access = D3D11_CPU_ACCESS_WRITE;
 		}
 
-		const D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM,
-			config.width, config.height, 1, config.levels, D3D11_BIND_SHADER_RESOURCE, usage, cpu_access);
-
-		ComPtr<ID3D11Texture2D> pTexture;
-		const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, pTexture.GetAddressOf());
-		CHECK(SUCCEEDED(hr), "Create texture of the TextureCache");
-		
 		D3DTexture2D newTex;
-		newTex.CreateFromExisting(pTexture.Get(), D3D11_BIND_SHADER_RESOURCE);
-		pTexture.Release();
+		newTex.Create(DXGI_FORMAT_R8G8B8A8_UNORM, config.width, config.height, D3D11_BIND_SHADER_RESOURCE, usage, config.levels);
 		TCacheEntry* const entry = new TCacheEntry(config, std::move(newTex));
 		entry->usage = usage;
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -54,10 +54,10 @@ private:
 	void CompileShaders() override { }
 	void DeleteShaders() override { }
 
-	ID3D11Buffer* palette_buf;
-	ID3D11ShaderResourceView* palette_buf_srv;
-	ID3D11Buffer* palette_uniform;
-	ID3D11PixelShader* palette_pixel_shader[3];
+	ComPtr<ID3D11Buffer> palette_buf;
+	ComPtr<ID3D11ShaderResourceView> palette_buf_srv;
+	ComPtr<ID3D11Buffer> palette_uniform;
+	ComPtr<ID3D11PixelShader> palette_pixel_shader[3];
 };
 
 }

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -19,12 +19,10 @@ public:
 private:
 	struct TCacheEntry : TCacheEntryBase
 	{
-		D3DTexture2D *const texture;
-
+		D3DTexture2D texture;
 		D3D11_USAGE usage;
 
-		TCacheEntry(const TCacheEntryConfig& config, D3DTexture2D *_tex) : TCacheEntryBase(config), texture(_tex) {}
-		~TCacheEntry();
+		TCacheEntry(const TCacheEntryConfig& config, D3DTexture2D&& _tex) : TCacheEntryBase(config), texture(_tex) {}
 
 		void CopyRectangleFromTexture(
 			const TCacheEntryBase* source,

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -40,8 +40,8 @@ void VertexManager::CreateDeviceObjects()
 	for (int i = 0; i < MAX_BUFFER_COUNT; i++)
 	{
 		m_buffers[i] = nullptr;
-		CHECK(SUCCEEDED(D3D::device->CreateBuffer(&bufdesc, nullptr, &m_buffers[i])), "Failed to create buffer.");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_buffers[i], "Buffer of VertexManager");
+		CHECK(SUCCEEDED(D3D::device->CreateBuffer(&bufdesc, nullptr, m_buffers[i].GetAddressOf())), "Failed to create buffer.");
+		D3D::SetDebugObjectName(m_buffers[i].Get(), "Buffer of VertexManager");
 	}
 
 	m_currentBuffer = 0;
@@ -52,7 +52,7 @@ void VertexManager::DestroyDeviceObjects()
 {
 	for (int i = 0; i < MAX_BUFFER_COUNT; i++)
 	{
-		SAFE_RELEASE(m_buffers[i]);
+		m_buffers[i].Release();
 	}
 
 }
@@ -101,11 +101,11 @@ void VertexManager::PrepareDrawBuffers(u32 stride)
 	m_vertexDrawOffset = cursor;
 	m_indexDrawOffset = cursor + vertexBufferSize;
 
-	D3D::context->Map(m_buffers[m_currentBuffer], 0, MapType, 0, &map);
+	D3D::context->Map(m_buffers[m_currentBuffer].Get(), 0, MapType, 0, &map);
 	u8* mappedData = reinterpret_cast<u8*>(map.pData);
 	memcpy(mappedData + m_vertexDrawOffset, s_pBaseBufferPointer, vertexBufferSize);
 	memcpy(mappedData + m_indexDrawOffset, GetIndexBuffer(), indexBufferSize);
-	D3D::context->Unmap(m_buffers[m_currentBuffer], 0);
+	D3D::context->Unmap(m_buffers[m_currentBuffer].Get(), 0);
 
 	m_bufferCursor = cursor + totalBufferSize;
 
@@ -117,8 +117,8 @@ void VertexManager::Draw(u32 stride)
 {
 	u32 indices = IndexGenerator::GetIndexLen();
 
-	D3D::stateman->SetVertexBuffer(m_buffers[m_currentBuffer], stride, 0);
-	D3D::stateman->SetIndexBuffer(m_buffers[m_currentBuffer]);
+	D3D::stateman->SetVertexBuffer(m_buffers[m_currentBuffer].Get(), stride, 0);
+	D3D::stateman->SetIndexBuffer(m_buffers[m_currentBuffer].Get());
 
 	u32 baseVertex = m_vertexDrawOffset / stride;
 	u32 startIndex = m_indexDrawOffset / sizeof(u16);
@@ -170,7 +170,8 @@ void VertexManager::vFlush(bool useDstAlpha)
 
 	if (g_ActiveConfig.backend_info.bSupportsBBox && BoundingBox::active)
 	{
-		D3D::context->OMSetRenderTargetsAndUnorderedAccessViews(D3D11_KEEP_RENDER_TARGETS_AND_DEPTH_STENCIL, nullptr, nullptr, 2, 1, &BBox::GetUAV(), nullptr);
+		ID3D11UnorderedAccessView* uav = BBox::GetUAV();
+		D3D::context->OMSetRenderTargetsAndUnorderedAccessViews(D3D11_KEEP_RENDER_TARGETS_AND_DEPTH_STENCIL, nullptr, nullptr, 2, 1, &uav, nullptr);
 	}
 
 	u32 stride = VertexLoaderManager::GetCurrentVertexFormat()->GetVertexStride();

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -36,7 +36,7 @@ private:
 	u32 m_bufferCursor;
 
 	enum { MAX_BUFFER_COUNT = 2 };
-	ID3D11Buffer* m_buffers[MAX_BUFFER_COUNT];
+	ComPtr<ID3D11Buffer> m_buffers[MAX_BUFFER_COUNT];
 
 	std::vector<u8> LocalVBuffer;
 	std::vector<u16> LocalIBuffer;

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.h
@@ -21,9 +21,9 @@ public:
 	static void Shutdown();
 	static bool SetShader(); // TODO: Should be renamed to LoadShader
 
-	static ID3D11VertexShader* GetActiveShader() { return last_entry->shader; }
-	static D3DBlob* GetActiveShaderBytecode() { return last_entry->bytecode; }
-	static ID3D11Buffer* &GetConstantBuffer();
+	static ID3D11VertexShader* GetActiveShader() { return last_entry->shader.Get(); }
+	static D3DBlob* GetActiveShaderBytecode() { return last_entry->bytecode.Get(); }
+	static ID3D11Buffer* GetConstantBuffer();
 
 	static ID3D11VertexShader* GetSimpleVertexShader();
 	static ID3D11VertexShader* GetClearVertexShader();
@@ -35,22 +35,20 @@ public:
 private:
 	struct VSCacheEntry
 	{
-		ID3D11VertexShader* shader;
-		D3DBlob* bytecode; // needed to initialize the input layout
+		ComPtr<ID3D11VertexShader> shader;
+		ComPtr<D3DBlob> bytecode; // needed to initialize the input layout
 
 		std::string code;
 
 		VSCacheEntry() : shader(nullptr), bytecode(nullptr) {}
 		void SetByteCode(D3DBlob* blob)
 		{
-			SAFE_RELEASE(bytecode);
-			bytecode = blob;
-			blob->AddRef();
+			bytecode.Copy(blob);
 		}
 		void Destroy()
 		{
-			SAFE_RELEASE(shader);
-			SAFE_RELEASE(bytecode);
+			shader.Release();
+			bytecode.Release();
 		}
 	};
 	typedef std::map<VertexShaderUid, VSCacheEntry> VSCache;

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
@@ -151,34 +151,34 @@ void XFBEncoder::Init()
 	D3D11_TEXTURE2D_DESC t2dd = CD3D11_TEXTURE2D_DESC(
 		DXGI_FORMAT_R8G8B8A8_UNORM, MAX_XFB_WIDTH/2, MAX_XFB_HEIGHT, 1, 1,
 		D3D11_BIND_RENDER_TARGET);
-	hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_out);
+	hr = D3D::device->CreateTexture2D(&t2dd, nullptr, m_out.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encoder output texture");
-	D3D::SetDebugObjectName(m_out, "xfb encoder output texture");
+	D3D::SetDebugObjectName(m_out.Get(), "xfb encoder output texture");
 
 	// Create output render target view
 
-	D3D11_RENDER_TARGET_VIEW_DESC rtvd = CD3D11_RENDER_TARGET_VIEW_DESC(m_out,
+	D3D11_RENDER_TARGET_VIEW_DESC rtvd = CD3D11_RENDER_TARGET_VIEW_DESC(m_out.Get(),
 		D3D11_RTV_DIMENSION_TEXTURE2D, DXGI_FORMAT_R8G8B8A8_UNORM);
-	hr = D3D::device->CreateRenderTargetView(m_out, &rtvd, &m_outRTV);
+	hr = D3D::device->CreateRenderTargetView(m_out.Get(), &rtvd, m_outRTV.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encoder output texture rtv");
-	D3D::SetDebugObjectName(m_outRTV, "xfb encoder output rtv");
+	D3D::SetDebugObjectName(m_outRTV.Get(), "xfb encoder output rtv");
 
 	// Create output staging buffer
 
 	t2dd.Usage = D3D11_USAGE_STAGING;
 	t2dd.BindFlags = 0;
 	t2dd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-	hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_outStage);
+	hr = D3D::device->CreateTexture2D(&t2dd, nullptr, m_outStage.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encoder output staging buffer");
-	D3D::SetDebugObjectName(m_outStage, "xfb encoder output staging buffer");
+	D3D::SetDebugObjectName(m_outStage.Get(), "xfb encoder output staging buffer");
 
 	// Create constant buffer for uploading params to shaders
 
 	D3D11_BUFFER_DESC bd = CD3D11_BUFFER_DESC(sizeof(XFBEncodeParams),
 		D3D11_BIND_CONSTANT_BUFFER);
-	hr = D3D::device->CreateBuffer(&bd, nullptr, &m_encodeParams);
+	hr = D3D::device->CreateBuffer(&bd, nullptr, m_encodeParams.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode params buffer");
-	D3D::SetDebugObjectName(m_encodeParams, "xfb encoder params buffer");
+	D3D::SetDebugObjectName(m_encodeParams.Get(), "xfb encoder params buffer");
 
 	// Create vertex quad
 
@@ -186,9 +186,9 @@ void XFBEncoder::Init()
 		D3D11_USAGE_IMMUTABLE);
 	D3D11_SUBRESOURCE_DATA srd = { QUAD_VERTS, 0, 0 };
 
-	hr = D3D::device->CreateBuffer(&bd, &srd, &m_quad);
+	hr = D3D::device->CreateBuffer(&bd, &srd, m_quad.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode quad vertex buffer");
-	D3D::SetDebugObjectName(m_quad, "xfb encoder quad vertex buffer");
+	D3D::SetDebugObjectName(m_quad.Get(), "xfb encoder quad vertex buffer");
 
 	// Create vertex shader
 
@@ -199,17 +199,17 @@ void XFBEncoder::Init()
 		return;
 	}
 
-	hr = D3D::device->CreateVertexShader(bytecode->Data(), bytecode->Size(), nullptr, &m_vShader);
+	hr = D3D::device->CreateVertexShader(bytecode->Data(), bytecode->Size(), nullptr, m_vShader.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode vertex shader");
-	D3D::SetDebugObjectName(m_vShader, "xfb encoder vertex shader");
+	D3D::SetDebugObjectName(m_vShader.Get(), "xfb encoder vertex shader");
 
 	// Create input layout for vertex quad using bytecode from vertex shader
 
 	hr = D3D::device->CreateInputLayout(QUAD_LAYOUT_DESC,
 		sizeof(QUAD_LAYOUT_DESC)/sizeof(D3D11_INPUT_ELEMENT_DESC),
-		bytecode->Data(), bytecode->Size(), &m_quadLayout);
+		bytecode->Data(), bytecode->Size(), m_quadLayout.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode quad vertex layout");
-	D3D::SetDebugObjectName(m_quadLayout, "xfb encoder quad layout");
+	D3D::SetDebugObjectName(m_quadLayout.Get(), "xfb encoder quad layout");
 
 	bytecode->Release();
 
@@ -221,55 +221,55 @@ void XFBEncoder::Init()
 		ERROR_LOG(VIDEO, "XFB encode pixel shader failed to compile");
 		return;
 	}
-	D3D::SetDebugObjectName(m_pShader, "xfb encoder pixel shader");
+	D3D::SetDebugObjectName(m_pShader.Get(), "xfb encoder pixel shader");
 
 	// Create blend state
 
 	D3D11_BLEND_DESC bld = CD3D11_BLEND_DESC(CD3D11_DEFAULT());
-	hr = D3D::device->CreateBlendState(&bld, &m_xfbEncodeBlendState);
+	hr = D3D::device->CreateBlendState(&bld, m_xfbEncodeBlendState.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode blend state");
-	D3D::SetDebugObjectName(m_xfbEncodeBlendState, "xfb encoder blend state");
+	D3D::SetDebugObjectName(m_xfbEncodeBlendState.Get(), "xfb encoder blend state");
 
 	// Create depth state
 
 	D3D11_DEPTH_STENCIL_DESC dsd = CD3D11_DEPTH_STENCIL_DESC(CD3D11_DEFAULT());
 	dsd.DepthEnable = FALSE;
-	hr = D3D::device->CreateDepthStencilState(&dsd, &m_xfbEncodeDepthState);
+	hr = D3D::device->CreateDepthStencilState(&dsd, m_xfbEncodeDepthState.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode depth state");
-	D3D::SetDebugObjectName(m_xfbEncodeDepthState, "xfb encoder depth state");
+	D3D::SetDebugObjectName(m_xfbEncodeDepthState.Get(), "xfb encoder depth state");
 
 	// Create rasterizer state
 
 	D3D11_RASTERIZER_DESC rd = CD3D11_RASTERIZER_DESC(CD3D11_DEFAULT());
 	rd.CullMode = D3D11_CULL_NONE;
 	rd.DepthClipEnable = FALSE;
-	hr = D3D::device->CreateRasterizerState(&rd, &m_xfbEncodeRastState);
+	hr = D3D::device->CreateRasterizerState(&rd, m_xfbEncodeRastState.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode rasterizer state");
-	D3D::SetDebugObjectName(m_xfbEncodeRastState, "xfb encoder rast state");
+	D3D::SetDebugObjectName(m_xfbEncodeRastState.Get(), "xfb encoder rast state");
 
 	// Create EFB texture sampler
 
 	D3D11_SAMPLER_DESC sd = CD3D11_SAMPLER_DESC(CD3D11_DEFAULT());
 	sd.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
-	hr = D3D::device->CreateSamplerState(&sd, &m_efbSampler);
+	hr = D3D::device->CreateSamplerState(&sd, m_efbSampler.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode texture sampler");
-	D3D::SetDebugObjectName(m_efbSampler, "xfb encoder texture sampler");
+	D3D::SetDebugObjectName(m_efbSampler.Get(), "xfb encoder texture sampler");
 }
 
 void XFBEncoder::Shutdown()
 {
-	SAFE_RELEASE(m_efbSampler);
-	SAFE_RELEASE(m_xfbEncodeRastState);
-	SAFE_RELEASE(m_xfbEncodeDepthState);
-	SAFE_RELEASE(m_xfbEncodeBlendState);
-	SAFE_RELEASE(m_pShader);
-	SAFE_RELEASE(m_quadLayout);
-	SAFE_RELEASE(m_vShader);
-	SAFE_RELEASE(m_quad);
-	SAFE_RELEASE(m_encodeParams);
-	SAFE_RELEASE(m_outStage);
-	SAFE_RELEASE(m_outRTV);
-	SAFE_RELEASE(m_out);
+	m_efbSampler.Release();
+	m_xfbEncodeRastState.Release();
+	m_xfbEncodeDepthState.Release();
+	m_xfbEncodeBlendState.Release();
+	m_pShader.Release();
+	m_quadLayout.Release();
+	m_vShader.Release();
+	m_quad.Release();
+	m_encodeParams.Release();
+	m_outStage.Release();
+	m_outRTV.Release();
+	m_out.Release();
 }
 
 void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcRect, float gamma)
@@ -282,22 +282,22 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 
 	// Set up all the state for XFB encoding
 
-	D3D::stateman->SetPixelShader(m_pShader);
-	D3D::stateman->SetVertexShader(m_vShader);
+	D3D::stateman->SetPixelShader(m_pShader.Get());
+	D3D::stateman->SetVertexShader(m_vShader.Get());
 	D3D::stateman->SetGeometryShader(nullptr);
 
-	D3D::stateman->PushBlendState(m_xfbEncodeBlendState);
-	D3D::stateman->PushDepthState(m_xfbEncodeDepthState);
-	D3D::stateman->PushRasterizerState(m_xfbEncodeRastState);
+	D3D::stateman->PushBlendState(m_xfbEncodeBlendState.Get());
+	D3D::stateman->PushDepthState(m_xfbEncodeDepthState.Get());
+	D3D::stateman->PushRasterizerState(m_xfbEncodeRastState.Get());
 
 	D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, FLOAT(width/2), FLOAT(height));
 	D3D::context->RSSetViewports(1, &vp);
 
-	D3D::stateman->SetInputLayout(m_quadLayout);
+	D3D::stateman->SetInputLayout(m_quadLayout.Get());
 	D3D::stateman->SetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 	UINT stride = sizeof(QuadVertex);
 	UINT offset = 0;
-	D3D::stateman->SetVertexBuffer(m_quad, stride, offset);
+	D3D::stateman->SetVertexBuffer(m_quad.Get(), stride, offset);
 
 	TargetRectangle targetRect = g_renderer->ConvertEFBRectangle(srcRect);
 
@@ -309,16 +309,16 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 	params.TexRight = FLOAT(targetRect.right) / g_renderer->GetTargetWidth();
 	params.TexBottom = FLOAT(targetRect.bottom) / g_renderer->GetTargetHeight();
 	params.Gamma = gamma;
-	D3D::context->UpdateSubresource(m_encodeParams, 0, nullptr, &params, 0, 0);
+	D3D::context->UpdateSubresource(m_encodeParams.Get(), 0, nullptr, &params, 0, 0);
 
-	D3D::context->OMSetRenderTargets(1, &m_outRTV, nullptr);
+	D3D::SetRenderTarget(m_outRTV.Get(), nullptr);
 
 	ID3D11ShaderResourceView* pEFB = FramebufferManager::GetResolvedEFBColorTexture()->GetSRV();
 
-	D3D::stateman->SetVertexConstants(m_encodeParams);
-	D3D::stateman->SetPixelConstants(m_encodeParams);
+	D3D::stateman->SetVertexConstants(m_encodeParams.Get());
+	D3D::stateman->SetPixelConstants(m_encodeParams.Get());
 	D3D::stateman->SetTexture(0, pEFB);
-	D3D::stateman->SetSampler(0, m_efbSampler);
+	D3D::stateman->SetSampler(0, m_efbSampler.Get());
 
 	// Encode!
 
@@ -328,7 +328,7 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 	// Copy to staging buffer
 
 	D3D11_BOX srcBox = CD3D11_BOX(0, 0, 0, width/2, height, 1);
-	D3D::context->CopySubresourceRegion(m_outStage, 0, 0, 0, 0, m_out, 0, &srcBox);
+	D3D::context->CopySubresourceRegion(m_outStage.Get(), 0, 0, 0, 0, m_out.Get(), 0, &srcBox);
 
 	// Clean up state
 
@@ -349,7 +349,7 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 	// Transfer staging buffer to GameCube/Wii RAM
 
 	D3D11_MAPPED_SUBRESOURCE map = { 0 };
-	hr = D3D::context->Map(m_outStage, 0, D3D11_MAP_READ, 0, &map);
+	hr = D3D::context->Map(m_outStage.Get(), 0, D3D11_MAP_READ, 0, &map);
 	CHECK(SUCCEEDED(hr), "map staging buffer");
 
 	u8* src = (u8*)map.pData;
@@ -360,13 +360,13 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 		src += map.RowPitch;
 	}
 
-	D3D::context->Unmap(m_outStage, 0);
+	D3D::context->Unmap(m_outStage.Get(), 0);
 
 	// Restore API
 	g_renderer->RestoreAPIState();
 	D3D::stateman->Apply(); // force unbind efb texture as shader resource
-	D3D::context->OMSetRenderTargets(1,
-		&FramebufferManager::GetEFBColorTexture()->GetRTV(),
+	D3D::SetRenderTarget(
+		FramebufferManager::GetEFBColorTexture()->GetRTV(),
 		FramebufferManager::GetEFBDepthTexture()->GetDSV());
 }
 

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
@@ -313,7 +313,7 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 
 	D3D::SetRenderTarget(m_outRTV.Get(), nullptr);
 
-	ID3D11ShaderResourceView* pEFB = FramebufferManager::GetResolvedEFBColorTexture()->GetSRV();
+	ID3D11ShaderResourceView* pEFB = FramebufferManager::GetResolvedEFBColorTexture().GetSRV();
 
 	D3D::stateman->SetVertexConstants(m_encodeParams.Get());
 	D3D::stateman->SetPixelConstants(m_encodeParams.Get());
@@ -366,8 +366,8 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 	g_renderer->RestoreAPIState();
 	D3D::stateman->Apply(); // force unbind efb texture as shader resource
 	D3D::SetRenderTarget(
-		FramebufferManager::GetEFBColorTexture()->GetRTV(),
-		FramebufferManager::GetEFBDepthTexture()->GetDSV());
+		FramebufferManager::GetEFBColorTexture().GetRTV(),
+		FramebufferManager::GetEFBDepthTexture().GetDSV());
 }
 
 }

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.h
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.h
@@ -24,9 +24,6 @@ class XFBEncoder
 {
 
 public:
-
-	XFBEncoder();
-
 	void Init();
 	void Shutdown();
 
@@ -34,9 +31,9 @@ public:
 
 private:
 
-	ComPtr<ID3D11Texture2D> m_out;
-	ComPtr<ID3D11RenderTargetView> m_outRTV;
+	D3DTexture2D m_out;
 	ComPtr<ID3D11Texture2D> m_outStage;
+
 	ComPtr<ID3D11Buffer> m_encodeParams;
 	ComPtr<ID3D11Buffer> m_quad;
 	ComPtr<ID3D11VertexShader> m_vShader;

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.h
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.h
@@ -34,18 +34,18 @@ public:
 
 private:
 
-	ID3D11Texture2D* m_out;
-	ID3D11RenderTargetView* m_outRTV;
-	ID3D11Texture2D* m_outStage;
-	ID3D11Buffer* m_encodeParams;
-	ID3D11Buffer* m_quad;
-	ID3D11VertexShader* m_vShader;
-	ID3D11InputLayout* m_quadLayout;
-	ID3D11PixelShader* m_pShader;
-	ID3D11BlendState* m_xfbEncodeBlendState;
-	ID3D11DepthStencilState* m_xfbEncodeDepthState;
-	ID3D11RasterizerState* m_xfbEncodeRastState;
-	ID3D11SamplerState* m_efbSampler;
+	ComPtr<ID3D11Texture2D> m_out;
+	ComPtr<ID3D11RenderTargetView> m_outRTV;
+	ComPtr<ID3D11Texture2D> m_outStage;
+	ComPtr<ID3D11Buffer> m_encodeParams;
+	ComPtr<ID3D11Buffer> m_quad;
+	ComPtr<ID3D11VertexShader> m_vShader;
+	ComPtr<ID3D11InputLayout> m_quadLayout;
+	ComPtr<ID3D11PixelShader> m_pShader;
+	ComPtr<ID3D11BlendState> m_xfbEncodeBlendState;
+	ComPtr<ID3D11DepthStencilState> m_xfbEncodeDepthState;
+	ComPtr<ID3D11RasterizerState> m_xfbEncodeRastState;
+	ComPtr<ID3D11SamplerState> m_efbSampler;
 
 };
 

--- a/Source/Core/VideoBackends/D3D12/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.cpp
@@ -65,12 +65,12 @@ std::array<ID3D12DescriptorHeap*, 2> gpu_descriptor_heaps;
 HWND hWnd;
 // End extern'd variables.
 
-static IDXGISwapChain* s_swap_chain = nullptr;
+static ComPtr<IDXGISwapChain> s_swap_chain = nullptr;
 static unsigned int s_monitor_refresh_rate = 0;
 
 static LARGE_INTEGER s_qpc_frequency;
 
-static ID3D12DebugDevice* s_debug_device12 = nullptr;
+static ComPtr<ID3D12DebugDevice> s_debug_device12 = nullptr;
 
 static D3D_FEATURE_LEVEL s_feat_level;
 static D3DTexture2D* s_backbuf[SWAP_CHAIN_BUFFER_COUNT];
@@ -248,9 +248,9 @@ bool AlertUserIfSelectedAdapterDoesNotSupportD3D12()
 		return false;
 	}
 
-	IDXGIFactory* factory = nullptr;
-	IDXGIAdapter* adapter = nullptr;
-	ID3D12Device* device = nullptr;
+	ComPtr<IDXGIFactory> factory = nullptr;
+	ComPtr<IDXGIAdapter> adapter = nullptr;
+	ComPtr<ID3D12Device> device = nullptr;
 
 	if (SUCCEEDED(hr))
 	{
@@ -259,16 +259,16 @@ bool AlertUserIfSelectedAdapterDoesNotSupportD3D12()
 
 	if (SUCCEEDED(hr))
 	{
-		hr = factory->EnumAdapters(g_ActiveConfig.iAdapter, &adapter);
+		hr = factory->EnumAdapters(g_ActiveConfig.iAdapter, adapter.GetAddressOf());
 	}
 
 	if (SUCCEEDED(hr))
 	{
-		hr = d3d12_create_device(adapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device));
+		hr = d3d12_create_device(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(device.GetAddressOf()));
 
-		SAFE_RELEASE(device);
-		SAFE_RELEASE(adapter);
-		SAFE_RELEASE(factory);
+		device.Release();
+		adapter.Release();
+		factory.Release();
 
 		if (FAILED(hr))
 		{
@@ -284,8 +284,8 @@ bool AlertUserIfSelectedAdapterDoesNotSupportD3D12()
 
 	// DXGI failed to create factory/enumerate adapter. This should be very uncommon.
 	MessageBoxA(nullptr, "Failed to create enumerate selected adapter. Please select a different graphics adapter.", "Critical error", MB_OK | MB_ICONERROR);
-	SAFE_RELEASE(adapter);
-	SAFE_RELEASE(factory);
+	adapter.Release();
+	factory.Release();
 
 	UnloadD3D();
 	UnloadDXGI();
@@ -360,23 +360,23 @@ HRESULT Create(HWND wnd)
 		return hr;
 	}
 
-	IDXGIFactory* factory;
-	IDXGIAdapter* adapter;
+	ComPtr<IDXGIFactory> factory;
+	ComPtr<IDXGIAdapter> adapter;
 	hr = create_dxgi_factory(__uuidof(IDXGIFactory), (void**)&factory);
 	if (FAILED(hr))
 		MessageBox(wnd, _T("Failed to create IDXGIFactory object"), _T("Dolphin Direct3D 12 backend"), MB_OK | MB_ICONERROR);
 
-	hr = factory->EnumAdapters(g_ActiveConfig.iAdapter, &adapter);
+	hr = factory->EnumAdapters(g_ActiveConfig.iAdapter, adapter.GetAddressOf());
 	if (FAILED(hr))
 	{
 		// try using the first one
-		hr = factory->EnumAdapters(0, &adapter);
+		hr = factory->EnumAdapters(0, adapter.GetAddressOf());
 		if (FAILED(hr))
 			MessageBox(wnd, _T("Failed to enumerate adapters"), _T("Dolphin Direct3D 12 backend"), MB_OK | MB_ICONERROR);
 	}
 
 	// get supported AA modes
-	s_aa_modes = EnumAAModes(adapter);
+	s_aa_modes = EnumAAModes(adapter.Get());
 
 	if (std::find_if(
 		s_aa_modes.begin(),
@@ -424,7 +424,7 @@ HRESULT Create(HWND wnd)
 
 	if (SUCCEEDED(hr))
 	{
-		hr = d3d12_create_device(adapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device12));
+		hr = d3d12_create_device(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device12));
 		s_feat_level = D3D_FEATURE_LEVEL_11_0;
 	}
 
@@ -442,7 +442,7 @@ HRESULT Create(HWND wnd)
 		IDXGIFactory* factory = nullptr;
 		adapter->GetParent(IID_PPV_ARGS(&factory));
 
-		CheckHR(factory->CreateSwapChain(command_queue, &swap_chain_desc, &s_swap_chain));
+		CheckHR(factory->CreateSwapChain(command_queue, &swap_chain_desc, s_swap_chain.GetAddressOf()));
 
 		s_current_back_buf = 0;
 
@@ -471,7 +471,7 @@ HRESULT Create(HWND wnd)
 	if (FAILED(hr))
 	{
 		MessageBox(wnd, _T("Failed to initialize Direct3D.\nMake sure your video card supports Direct3D 12 and your drivers are up-to-date."), _T("Dolphin Direct3D 12 backend"), MB_OK | MB_ICONERROR);
-		SAFE_RELEASE(s_swap_chain);
+		s_swap_chain.Release();
 		return E_FAIL;
 	}
 
@@ -495,7 +495,7 @@ HRESULT Create(HWND wnd)
 		info_queue->Release();
 
 		// Used at Close time to report live objects.
-		CheckHR(device12->QueryInterface(&s_debug_device12));
+		CheckHR(device12->QueryInterface(s_debug_device12.GetAddressOf()));
 	}
 
 	// prevent DXGI from responding to Alt+Enter, unfortunately DXGI_MWA_NO_ALT_ENTER
@@ -505,8 +505,8 @@ HRESULT Create(HWND wnd)
 	if (FAILED(hr))
 		MessageBox(wnd, _T("Failed to associate the window"), _T("Dolphin Direct3D 12 backend"), MB_OK | MB_ICONERROR);
 
-	SAFE_RELEASE(factory);
-	SAFE_RELEASE(adapter)
+	factory.Release();
+	adapter.Release();
 
 	CreateDescriptorHeaps();
 	CreateRootSignatures();
@@ -522,12 +522,12 @@ HRESULT Create(HWND wnd)
 
 	for (UINT i = 0; i < SWAP_CHAIN_BUFFER_COUNT; i++)
 	{
-		ID3D12Resource* buf12 = nullptr;
-		hr = s_swap_chain->GetBuffer(i, IID_PPV_ARGS(&buf12));
+		ComPtr<ID3D12Resource> buf12 = nullptr;
+		hr = s_swap_chain->GetBuffer(i, IID_PPV_ARGS(buf12.GetAddressOf()));
 
 		CHECK(SUCCEEDED(hr), "Retrieve back buffer texture");
 
-		s_backbuf[i] = new D3DTexture2D(buf12,
+		s_backbuf[i] = new D3DTexture2D(buf12.Get(),
 			D3D11_BIND_RENDER_TARGET,
 			DXGI_FORMAT_UNKNOWN,
 			DXGI_FORMAT_UNKNOWN,
@@ -536,7 +536,7 @@ HRESULT Create(HWND wnd)
 			D3D12_RESOURCE_STATE_PRESENT // Swap Chain back buffers start out in D3D12_RESOURCE_STATE_PRESENT.
 			);
 
-		SAFE_RELEASE(buf12);
+		buf12.Release();
 		SetDebugObjectName12(s_backbuf[i]->GetTex12(), "backbuffer texture");
 	}
 
@@ -706,7 +706,7 @@ void Close()
 
 	D3D::CleanupPersistentD3DTextureResources();
 
-	SAFE_RELEASE(s_swap_chain);
+	s_swap_chain.Release();
 
 	command_list_mgr.reset();
 	command_queue->Release();
@@ -738,7 +738,7 @@ void Close()
 			// note this will also print out internal live objects to the debug console
 			s_debug_device12->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL);
 		}
-		SAFE_RELEASE(s_debug_device12);
+		s_debug_device12.Release();
 	}
 #endif
 
@@ -813,12 +813,12 @@ void Reset()
 
 	for (UINT i = 0; i < SWAP_CHAIN_BUFFER_COUNT; i++)
 	{
-		ID3D12Resource* buf12 = nullptr;
-		hr = s_swap_chain->GetBuffer(i, IID_PPV_ARGS(&buf12));
+		ComPtr<ID3D12Resource> buf12 = nullptr;
+		hr = s_swap_chain->GetBuffer(i, IID_PPV_ARGS(buf12.GetAddressOf()));
 
 		CHECK(SUCCEEDED(hr), "Retrieve back buffer texture");
 
-		s_backbuf[i] = new D3DTexture2D(buf12,
+		s_backbuf[i] = new D3DTexture2D(buf12.Get(),
 			D3D11_BIND_RENDER_TARGET,
 			DXGI_FORMAT_UNKNOWN,
 			DXGI_FORMAT_UNKNOWN,
@@ -827,7 +827,7 @@ void Reset()
 			D3D12_RESOURCE_STATE_PRESENT
 			);
 
-		SAFE_RELEASE(buf12);
+		buf12.Release();
 		SetDebugObjectName12(s_backbuf[i]->GetTex12(), "backbuffer texture");
 	}
 
@@ -896,7 +896,7 @@ void Present()
 		s_current_back_buf = (s_current_back_buf + 1) % SWAP_CHAIN_BUFFER_COUNT;
 	}
 
-	command_list_mgr->ExecuteQueuedWorkAndPresent(s_swap_chain, g_ActiveConfig.IsVSync() ? 1 : 0, present_flags);
+	command_list_mgr->ExecuteQueuedWorkAndPresent(s_swap_chain.Get(), g_ActiveConfig.IsVSync() ? 1 : 0, present_flags);
 
 	command_list_mgr->m_cpu_access_last_frame = command_list_mgr->m_cpu_access_this_frame;
 	command_list_mgr->m_cpu_access_this_frame = false;

--- a/Source/Core/VideoBackends/D3D12/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.h
@@ -21,9 +21,12 @@
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
+#include "Common/ComPtr.h"
 
 namespace DX12
 {
+
+using Common::ComPtr;
 
 #define SAFE_RELEASE(x) { if (x) (x)->Release(); (x) = nullptr; }
 #define CHECK(cond, Message, ...) if (!(cond)) { __debugbreak(); PanicAlert(__FUNCTION__ " failed in %s at line %d: " Message, __FILE__, __LINE__, __VA_ARGS__); }

--- a/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.cpp
@@ -18,7 +18,7 @@ bool operator==(const D3DDescriptorHeapManager::SamplerStateSet& lhs, const D3DD
 D3DDescriptorHeapManager::D3DDescriptorHeapManager(D3D12_DESCRIPTOR_HEAP_DESC* desc, ID3D12Device* device, unsigned int temporarySlots) :
 	m_device(device)
 {
-	CheckHR(device->CreateDescriptorHeap(desc, IID_PPV_ARGS(&m_descriptor_heap)));
+	CheckHR(device->CreateDescriptorHeap(desc, IID_PPV_ARGS(m_descriptor_heap.GetAddressOf())));
 
 	m_descriptor_heap_size = desc->NumDescriptors;
 	m_descriptor_increment_size = device->GetDescriptorHandleIncrementSize(desc->Type);
@@ -29,7 +29,7 @@ D3DDescriptorHeapManager::D3DDescriptorHeapManager(D3D12_DESCRIPTOR_HEAP_DESC* d
 		D3D12_DESCRIPTOR_HEAP_DESC cpu_shadow_heap_desc = *desc;
 		cpu_shadow_heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
 
-		CheckHR(device->CreateDescriptorHeap(&cpu_shadow_heap_desc, IID_PPV_ARGS(&m_descriptor_heap_cpu_shadow)));
+		CheckHR(device->CreateDescriptorHeap(&cpu_shadow_heap_desc, IID_PPV_ARGS(m_descriptor_heap_cpu_shadow.GetAddressOf())));
 
 		m_heap_base_gpu = m_descriptor_heap->GetGPUDescriptorHandleForHeapStart();
 		m_heap_base_gpu_cpu_shadow = m_descriptor_heap_cpu_shadow->GetCPUDescriptorHandleForHeapStart();
@@ -157,13 +157,7 @@ D3D12_GPU_DESCRIPTOR_HANDLE D3DDescriptorHeapManager::GetHandleForSamplerGroup(S
 
 ID3D12DescriptorHeap* D3DDescriptorHeapManager::GetDescriptorHeap() const
 {
-	return m_descriptor_heap;
-}
-
-D3DDescriptorHeapManager::~D3DDescriptorHeapManager()
-{
-	SAFE_RELEASE(m_descriptor_heap);
-	SAFE_RELEASE(m_descriptor_heap_cpu_shadow);
+	return m_descriptor_heap.Get();
 }
 
 }  // namespace DX12

--- a/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.h
+++ b/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.h
@@ -18,7 +18,6 @@ class D3DDescriptorHeapManager
 public:
 
 	D3DDescriptorHeapManager(D3D12_DESCRIPTOR_HEAP_DESC* desc, ID3D12Device* device, unsigned int temporarySlots = 0);
-	~D3DDescriptorHeapManager();
 
 	bool Allocate(D3D12_CPU_DESCRIPTOR_HANDLE* cpu_handle, D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handle = nullptr, D3D12_CPU_DESCRIPTOR_HANDLE* gpu_handle_cpu_shadow = nullptr, bool temporary = false);
 	bool AllocateGroup(D3D12_CPU_DESCRIPTOR_HANDLE* cpu_handles, unsigned int num_handles, D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handles = nullptr, D3D12_CPU_DESCRIPTOR_HANDLE* gpu_handle_cpu_shadows = nullptr, bool temporary = false);
@@ -42,8 +41,8 @@ public:
 private:
 
 	ID3D12Device* m_device = nullptr;
-	ID3D12DescriptorHeap* m_descriptor_heap = nullptr;
-	ID3D12DescriptorHeap* m_descriptor_heap_cpu_shadow = nullptr;
+	ComPtr<ID3D12DescriptorHeap> m_descriptor_heap = nullptr;
+	ComPtr<ID3D12DescriptorHeap> m_descriptor_heap_cpu_shadow = nullptr;
 
 	D3D12_CPU_DESCRIPTOR_HANDLE m_heap_base_cpu;
 	D3D12_GPU_DESCRIPTOR_HANDLE m_heap_base_gpu;

--- a/Source/Core/VideoBackends/D3D12/D3DState.h
+++ b/Source/Core/VideoBackends/D3D12/D3DState.h
@@ -146,7 +146,7 @@ private:
 		}
 	};
 
-	std::unordered_map<D3D12_GRAPHICS_PIPELINE_STATE_DESC, ID3D12PipelineState*, hash_pso_desc, equality_pipeline_state_desc> m_pso_map;
+	std::unordered_map<D3D12_GRAPHICS_PIPELINE_STATE_DESC, ComPtr<ID3D12PipelineState>, hash_pso_desc, equality_pipeline_state_desc> m_pso_map;
 
 	struct hash_small_pso_desc
 	{
@@ -186,7 +186,7 @@ private:
 		}
 	};
 
-	std::unordered_map<SmallPsoDesc, ID3D12PipelineState*, hash_small_pso_desc, equality_small_pipeline_state_desc> m_small_pso_map;
+	std::unordered_map<SmallPsoDesc, ComPtr<ID3D12PipelineState>, hash_small_pso_desc, equality_small_pipeline_state_desc> m_small_pso_map;
 };
 
 }  // namespace DX12

--- a/Source/Core/VideoBackends/D3D12/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DTexture.cpp
@@ -73,7 +73,7 @@ void ReplaceRGBATexture2D(ID3D12Resource* texture12, const u8* buffer, unsigned 
 
 D3DTexture2D* D3DTexture2D::Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind, D3D11_USAGE usage, DXGI_FORMAT fmt, unsigned int levels, unsigned int slices, D3D12_SUBRESOURCE_DATA* data)
 {
-	ID3D12Resource* texture12 = nullptr;
+	ComPtr<ID3D12Resource> texture12 = nullptr;
 
 	D3D12_RESOURCE_DESC texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(
 		fmt,
@@ -109,19 +109,18 @@ D3DTexture2D* D3DTexture2D::Create(unsigned int width, unsigned int height, D3D1
 			&CD3DX12_RESOURCE_DESC(texdesc12),
 			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
 			&optimized_clear_value,
-			IID_PPV_ARGS(&texture12)
+			IID_PPV_ARGS(texture12.GetAddressOf())
 			)
 		);
 
-	D3D::SetDebugObjectName12(texture12, "Texture created via D3DTexture2D::Create");
-	D3DTexture2D* ret = new D3DTexture2D(texture12, bind, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+	D3D::SetDebugObjectName12(texture12.Get(), "Texture created via D3DTexture2D::Create");
+	D3DTexture2D* ret = new D3DTexture2D(texture12.Get(), bind, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
 	if (data)
 	{
-		DX12::D3D::ReplaceRGBATexture2D(texture12, reinterpret_cast<const u8*>(data->pData), width, height, static_cast<unsigned int>(data->RowPitch), 0, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		DX12::D3D::ReplaceRGBATexture2D(texture12.Get(), reinterpret_cast<const u8*>(data->pData), width, height, static_cast<unsigned int>(data->RowPitch), 0, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 	}
 
-	SAFE_RELEASE(texture12);
 	return ret;
 }
 
@@ -153,7 +152,7 @@ bool D3DTexture2D::GetMultisampled() const
 
 ID3D12Resource* D3DTexture2D::GetTex12() const
 {
-	return m_tex12;
+	return m_tex12.Get();
 }
 
 D3D12_CPU_DESCRIPTOR_HANDLE D3DTexture2D::GetSRV12CPU() const
@@ -183,7 +182,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE D3DTexture2D::GetRTV12() const
 
 D3DTexture2D::D3DTexture2D(ID3D12Resource* texptr, D3D11_BIND_FLAG bind,
 							DXGI_FORMAT srv_format, DXGI_FORMAT dsv_format, DXGI_FORMAT rtv_format, bool multisampled, D3D12_RESOURCE_STATES resource_state)
-							: m_tex12(texptr), m_resource_state(resource_state), m_multisampled(multisampled)
+							: m_tex12(Common::CopyComPtr(texptr)), m_resource_state(resource_state), m_multisampled(multisampled)
 {
 	D3D12_SRV_DIMENSION srv_dim12 = multisampled ? D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY : D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
 	D3D12_DSV_DIMENSION dsv_dim12 = multisampled ? D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY : D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
@@ -212,8 +211,8 @@ D3DTexture2D::D3DTexture2D(ID3D12Resource* texptr, D3D11_BIND_FLAG bind,
 
 		CHECK(D3D::gpu_descriptor_heap_mgr->Allocate(&m_srv12_cpu, &m_srv12_gpu, &m_srv12_gpu_cpu_shadow), "Error: Ran out of permenant slots in GPU descriptor heap, but don't support rolling over heap.");
 
-		D3D::device12->CreateShaderResourceView(m_tex12, &srv_desc, m_srv12_cpu);
-		D3D::device12->CreateShaderResourceView(m_tex12, &srv_desc, m_srv12_gpu_cpu_shadow);
+		D3D::device12->CreateShaderResourceView(m_tex12.Get(), &srv_desc, m_srv12_cpu);
+		D3D::device12->CreateShaderResourceView(m_tex12.Get(), &srv_desc, m_srv12_gpu_cpu_shadow);
 	}
 
 	if (bind & D3D11_BIND_DEPTH_STENCIL)
@@ -230,7 +229,7 @@ D3DTexture2D::D3DTexture2D(ID3D12Resource* texptr, D3D11_BIND_FLAG bind,
 			dsv_desc.Texture2DMSArray.ArraySize = -1;
 
 		D3D::dsv_descriptor_heap_mgr->Allocate(&m_dsv12);
-		D3D::device12->CreateDepthStencilView(m_tex12, &dsv_desc, m_dsv12);
+		D3D::device12->CreateDepthStencilView(m_tex12.Get(), &dsv_desc, m_dsv12);
 	}
 
 	if (bind & D3D11_BIND_RENDER_TARGET)
@@ -246,21 +245,19 @@ D3DTexture2D::D3DTexture2D(ID3D12Resource* texptr, D3D11_BIND_FLAG bind,
 			rtv_desc.Texture2DMSArray.ArraySize = -1;
 
 		D3D::rtv_descriptor_heap_mgr->Allocate(&m_rtv12);
-		D3D::device12->CreateRenderTargetView(m_tex12, &rtv_desc, m_rtv12);
+		D3D::device12->CreateRenderTargetView(m_tex12.Get(), &rtv_desc, m_rtv12);
 	}
-
-	m_tex12->AddRef();
 }
 
 void D3DTexture2D::TransitionToResourceState(ID3D12GraphicsCommandList* command_list, D3D12_RESOURCE_STATES state_after)
 {
-	DX12::D3D::ResourceBarrier(command_list, m_tex12, m_resource_state, state_after, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES);
+	DX12::D3D::ResourceBarrier(command_list, m_tex12.Get(), m_resource_state, state_after, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES);
 	m_resource_state = state_after;
 }
 
 D3DTexture2D::~D3DTexture2D()
 {
-	DX12::D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_tex12);
+	DX12::D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_tex12.Detach());
 }
 
 }  // namespace DX12

--- a/Source/Core/VideoBackends/D3D12/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D12/D3DTexture.h
@@ -47,7 +47,7 @@ public:
 private:
 	~D3DTexture2D();
 
-	ID3D12Resource* m_tex12 = nullptr;
+	ComPtr<ID3D12Resource> m_tex12 = nullptr;
 
 	D3D12_CPU_DESCRIPTOR_HANDLE m_srv12_cpu = {};
 	D3D12_GPU_DESCRIPTOR_HANDLE m_srv12_gpu = {};

--- a/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
@@ -314,16 +314,16 @@ int CD3DFont::Init()
 	DeleteObject(hFont);
 
 	// setup device objects for drawing
-	ID3DBlob* psbytecode = nullptr;
-	D3D::CompilePixelShader(fontpixshader, &psbytecode);
+	ComPtr<ID3DBlob> psbytecode = nullptr;
+	D3D::CompilePixelShader(fontpixshader, psbytecode.GetAddressOf());
 	if (psbytecode == nullptr)
 		PanicAlert("Failed to compile pixel shader, %s %d\n", __FILE__, __LINE__);
 
 	m_pshader12.pShaderBytecode = psbytecode->GetBufferPointer();
 	m_pshader12.BytecodeLength = psbytecode->GetBufferSize();
 
-	ID3DBlob* vsbytecode = nullptr;
-	D3D::CompileVertexShader(fontvertshader, &vsbytecode);
+	ComPtr<ID3DBlob> vsbytecode = nullptr;
+	D3D::CompileVertexShader(fontvertshader, vsbytecode.GetAddressOf());
 	if (vsbytecode == nullptr)
 		PanicAlert("Failed to compile vertex shader, %s %d\n", __FILE__, __LINE__);
 
@@ -384,9 +384,6 @@ int CD3DFont::Init()
 	};
 
 	CheckHR(DX12::gx_state_cache.GetPipelineStateObjectFromCache(&text_pso_desc, &m_pso));
-
-	SAFE_RELEASE(psbytecode);
-	SAFE_RELEASE(vsbytecode);
 
 	return S_OK;
 }

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
@@ -78,7 +78,7 @@ FramebufferManager::FramebufferManager()
 	sample_desc.Count = g_ActiveConfig.iMultisamples;
 	sample_desc.Quality = 0;
 
-	ID3D12Resource* buf12;
+	ComPtr<ID3D12Resource> buf12;
 	D3D12_RESOURCE_DESC texdesc12;
 	D3D12_CLEAR_VALUE optimized_clear_valueRTV = { DXGI_FORMAT_R8G8B8A8_UNORM, { 0.0f, 0.0f, 0.0f, 1.0f } };
 	D3D12_CLEAR_VALUE optimized_clear_valueDSV = CD3DX12_CLEAR_VALUE(DXGI_FORMAT_D32_FLOAT, 0.0f, 0);
@@ -89,41 +89,41 @@ FramebufferManager::FramebufferManager()
 
 	// EFB color texture - primary render target
 	texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, sample_desc.Count, sample_desc.Quality, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
-	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueRTV, IID_PPV_ARGS(&buf12));
+	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueRTV, IID_PPV_ARGS(buf12.GetAddressOf()));
 
-	m_efb.color_tex = new D3DTexture2D(buf12, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
-	SAFE_RELEASE(buf12);
+	m_efb.color_tex = new D3DTexture2D(buf12.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
+	buf12.Release();
 
 	// Temporary EFB color texture - used in ReinterpretPixelData
 	texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, sample_desc.Count, sample_desc.Quality, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
-	CheckHR(D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueRTV, IID_PPV_ARGS(&buf12)));
-	m_efb.color_temp_tex = new D3DTexture2D(buf12, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
-	SAFE_RELEASE(buf12);
+	CheckHR(D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueRTV, IID_PPV_ARGS(buf12.GetAddressOf())));
+	m_efb.color_temp_tex = new D3DTexture2D(buf12.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
+	buf12.Release();
 	D3D::SetDebugObjectName12(m_efb.color_temp_tex->GetTex12(), "EFB color temp texture");
 
 	// EFB depth buffer - primary depth buffer
 	texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, sample_desc.Count, sample_desc.Quality, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
-	CheckHR(D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueDSV, IID_PPV_ARGS(&buf12)));
+	CheckHR(D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueDSV, IID_PPV_ARGS(buf12.GetAddressOf())));
 
-	m_efb.depth_tex = new D3DTexture2D(buf12, (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
-	SAFE_RELEASE(buf12);
+	m_efb.depth_tex = new D3DTexture2D(buf12.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
+	buf12.Release();
 	D3D::SetDebugObjectName12(m_efb.depth_tex->GetTex12(), "EFB depth texture");
 
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
 		// Framebuffer resolve textures (color+depth)
 		texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1);
-		hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&buf12));
+		hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(buf12.GetAddressOf()));
 		CHECK(hr == S_OK, "create EFB color resolve texture (size: %dx%d)", m_target_width, m_target_height);
-		m_efb.resolved_color_tex = new D3DTexture2D(buf12, D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_COMMON);
-		SAFE_RELEASE(buf12);
+		m_efb.resolved_color_tex = new D3DTexture2D(buf12.Get(), D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_COMMON);
+		buf12.Release();
 		D3D::SetDebugObjectName12(m_efb.resolved_color_tex->GetTex12(), "EFB color resolve texture shader resource view");
 
 		texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R32_FLOAT, m_target_width, m_target_height, m_efb.slices, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
-		hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&buf12));
+		hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(buf12.GetAddressOf()));
 		CHECK(hr == S_OK, "create EFB depth resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_depth_tex = new D3DTexture2D(buf12, (D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_COMMON);
-		SAFE_RELEASE(buf12);
+		m_efb.resolved_depth_tex = new D3DTexture2D(buf12.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_COMMON);
+		buf12.Release();
 		D3D::SetDebugObjectName12(m_efb.resolved_depth_tex->GetTex12(), "EFB depth resolve texture shader resource view");
 	}
 	else
@@ -262,8 +262,8 @@ void FramebufferManager::InitializeEFBAccessCopies()
 	// EFB access - color staging/readback buffer
 	m_efb.color_access_readback_pitch = D3D::AlignValue(EFB_WIDTH * sizeof(u32), D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
 	texdesc12 = CD3DX12_RESOURCE_DESC::Buffer(m_efb.color_access_readback_pitch * EFB_HEIGHT);
-	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&m_efb.color_access_readback_buffer));
-	D3D::SetDebugObjectName12(m_efb.color_access_readback_buffer, "EFB access color readback buffer");
+	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(m_efb.color_access_readback_buffer.GetAddressOf()));
+	D3D::SetDebugObjectName12(m_efb.color_access_readback_buffer.Get(), "EFB access color readback buffer");
 
 	// EFB access - depth resize buffer
 	texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R32_FLOAT, EFB_WIDTH, EFB_HEIGHT, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET, D3D12_TEXTURE_LAYOUT_UNKNOWN, 0);
@@ -276,8 +276,8 @@ void FramebufferManager::InitializeEFBAccessCopies()
 	// EFB access - depth staging/readback buffer
 	m_efb.depth_access_readback_pitch = D3D::AlignValue(EFB_WIDTH * sizeof(float), D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
 	texdesc12 = CD3DX12_RESOURCE_DESC::Buffer(m_efb.depth_access_readback_pitch * EFB_HEIGHT);
-	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&m_efb.depth_access_readback_buffer));
-	D3D::SetDebugObjectName12(m_efb.color_access_readback_buffer, "EFB access depth readback buffer");
+	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(m_efb.depth_access_readback_buffer.GetAddressOf()));
+	D3D::SetDebugObjectName12(m_efb.color_access_readback_buffer.Get(), "EFB access depth readback buffer");
 }
 
 void FramebufferManager::MapEFBColorAccessCopy()
@@ -313,7 +313,7 @@ void FramebufferManager::MapEFBColorAccessCopy()
 
 	// Copy to staging resource
 	D3D12_PLACED_SUBRESOURCE_FOOTPRINT dst_footprint = { 0, { DXGI_FORMAT_R8G8B8A8_UNORM, EFB_WIDTH, EFB_HEIGHT, 1, m_efb.color_access_readback_pitch } };
-	CD3DX12_TEXTURE_COPY_LOCATION dst_location(m_efb.color_access_readback_buffer, dst_footprint);
+	CD3DX12_TEXTURE_COPY_LOCATION dst_location(m_efb.color_access_readback_buffer.Get(), dst_footprint);
 	CD3DX12_TEXTURE_COPY_LOCATION src_location(src_resource, 0);
 	D3D::current_command_list->CopyTextureRegion(&dst_location, 0, 0, 0, &src_location, nullptr);
 
@@ -365,7 +365,7 @@ void FramebufferManager::MapEFBDepthAccessCopy()
 
 	// Copy to staging resource
 	D3D12_PLACED_SUBRESOURCE_FOOTPRINT dst_footprint = { 0,{ DXGI_FORMAT_R32_FLOAT, EFB_WIDTH, EFB_HEIGHT, 1, m_efb.depth_access_readback_pitch } };
-	CD3DX12_TEXTURE_COPY_LOCATION dst_location(m_efb.depth_access_readback_buffer, dst_footprint);
+	CD3DX12_TEXTURE_COPY_LOCATION dst_location(m_efb.depth_access_readback_buffer.Get(), dst_footprint);
 	CD3DX12_TEXTURE_COPY_LOCATION src_location(src_resource, 0);
 	D3D::current_command_list->CopyTextureRegion(&dst_location, 0, 0, 0, &src_location, nullptr);
 
@@ -404,12 +404,10 @@ void FramebufferManager::DestroyEFBAccessCopies()
 	InvalidateEFBAccessCopies();
 
 	SAFE_RELEASE(m_efb.color_access_resize_tex);
-	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_efb.color_access_readback_buffer);
-	m_efb.color_access_readback_buffer = nullptr;
+	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_efb.color_access_readback_buffer.Detach());
 
 	SAFE_RELEASE(m_efb.depth_access_resize_tex);
-	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_efb.depth_access_readback_buffer);
-	m_efb.depth_access_readback_buffer = nullptr;
+	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_efb.depth_access_readback_buffer.Detach());
 }
 
 void XFBSource::DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight)

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.h
@@ -99,12 +99,12 @@ private:
 		D3DTexture2D* resolved_depth_tex;
 
 		D3DTexture2D* color_access_resize_tex;
-		ID3D12Resource* color_access_readback_buffer;
+		ComPtr<ID3D12Resource> color_access_readback_buffer;
 		u8* color_access_readback_map;
 		u32 color_access_readback_pitch;
 
 		D3DTexture2D* depth_access_resize_tex;
-		ID3D12Resource* depth_access_readback_buffer;
+		ComPtr<ID3D12Resource> depth_access_readback_buffer;
 		u8* depth_access_readback_map;
 		u32 depth_access_readback_pitch;
 

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
@@ -118,11 +118,6 @@ void PSTextureEncoder::Shutdown()
 	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_out_readback_buffer);
 	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_encode_params_buffer);
 
-	for (auto& it : m_static_shaders_blobs)
-	{
-		SAFE_RELEASE(it);
-	}
-
 	m_static_shaders_blobs.clear();
 	m_static_shaders_map.clear();
 }
@@ -273,9 +268,9 @@ D3D12_SHADER_BYTECODE PSTextureEncoder::SetStaticShader(unsigned int dst_format,
 				format |= _GX_TF_CTF;
 		}
 
-		ID3DBlob* bytecode = nullptr;
+		ComPtr<ID3DBlob> bytecode = nullptr;
 		const char* shader = TextureConversionShader::GenerateEncodingShader(format, API_D3D);
-		if (!D3D::CompilePixelShader(shader, &bytecode))
+		if (!D3D::CompilePixelShader(shader, bytecode.GetAddressOf()))
 		{
 			WARN_LOG(VIDEO, "EFB encoder shader for dst_format 0x%X, src_format %d, is_intensity %d, scale_by_half %d failed to compile",
 				dst_format, static_cast<int>(src_format), is_intensity ? 1 : 0, scale_by_half ? 1 : 0);

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.h
@@ -46,7 +46,7 @@ private:
 
 	using ComboMap = std::map<ComboKey, D3D12_SHADER_BYTECODE>;
 	ComboMap m_static_shaders_map;
-	std::vector<ID3DBlob*> m_static_shaders_blobs;
+	std::vector<ComPtr<ID3DBlob>> m_static_shaders_blobs;
 };
 
 }

--- a/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
@@ -28,7 +28,7 @@ PsBytecodeCache s_ps_bytecode_cache;
 VsBytecodeCache s_vs_bytecode_cache;
 
 // Used to keep track of blobs to release at Shutdown time.
-static std::vector<ID3DBlob*> s_shader_blob_list;
+static std::vector<ComPtr<ID3DBlob>> s_shader_blob_list;
 
 // Only used for shader debugging..
 using GsHlslCache = std::map<GeometryShaderUid, std::string>;
@@ -112,9 +112,6 @@ void ShaderCache::Init()
 
 void ShaderCache::Clear()
 {
-	for (auto& iter : s_shader_blob_list)
-		SAFE_RELEASE(iter);
-
 	s_shader_blob_list.clear();
 
 	s_gs_bytecode_cache.clear();
@@ -337,7 +334,7 @@ D3D12_SHADER_BYTECODE ShaderCache::InsertByteCode(const UidType& uid, ShaderCach
 	// Note: Don't release the incoming bytecode, we need it to stick around, since in D3D12
 	// the raw bytecode itself is bound. It is released at Shutdown() time.
 
-	s_shader_blob_list.push_back(bytecode_blob);
+	s_shader_blob_list.push_back(Common::AttachComPtr(bytecode_blob));
 
 	D3D12_SHADER_BYTECODE shader_bytecode;
 	shader_bytecode.pShaderBytecode = bytecode_blob->GetBufferPointer();

--- a/Source/Core/VideoBackends/D3D12/StaticShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/StaticShaderCache.cpp
@@ -12,18 +12,18 @@ namespace DX12
 {
 
 // Pixel Shader blobs
-static ID3DBlob* s_color_matrix_program_blob[2] = {};
-static ID3DBlob* s_color_copy_program_blob[2] = {};
-static ID3DBlob* s_depth_matrix_program_blob[2] = {};
-static ID3DBlob* s_depth_resolve_to_color_program_blob = {};
-static ID3DBlob* s_clear_program_blob = {};
-static ID3DBlob* s_anaglyph_program_blob = {};
-static ID3DBlob* s_rgba6_to_rgb8_program_blob[2] = {};
-static ID3DBlob* s_rgb8_to_rgba6_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_color_matrix_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_color_copy_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_depth_matrix_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_depth_resolve_to_color_program_blob = {};
+static ComPtr<ID3DBlob> s_clear_program_blob = {};
+static ComPtr<ID3DBlob> s_anaglyph_program_blob = {};
+static ComPtr<ID3DBlob> s_rgba6_to_rgb8_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_rgb8_to_rgba6_program_blob[2] = {};
 
 // Vertex Shader blobs/input layouts
-static ID3DBlob* s_simple_vertex_shader_blob = {};
-static ID3DBlob* s_simple_clear_vertex_shader_blob = {};
+static ComPtr<ID3DBlob> s_simple_vertex_shader_blob = {};
+static ComPtr<ID3DBlob> s_simple_clear_vertex_shader_blob = {};
 
 static const D3D12_INPUT_ELEMENT_DESC s_simple_vertex_shader_input_elements[] = {
 	{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,  0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
@@ -48,8 +48,8 @@ static const D3D12_INPUT_LAYOUT_DESC s_clear_vertex_shader_input_layout =
 };
 
 // Geometry Shader blobs
-static ID3DBlob* s_clear_geometry_shader_blob = nullptr;
-static ID3DBlob* s_copy_geometry_shader_blob = nullptr;
+static ComPtr<ID3DBlob> s_clear_geometry_shader_blob = nullptr;
+static ComPtr<ID3DBlob> s_copy_geometry_shader_blob = nullptr;
 
 // Pixel Shader HLSL
 static constexpr const char s_clear_program_hlsl[] = {
@@ -419,7 +419,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetReinterpRGBA6ToRGB8PixelShader(bool 
 	{
 		if (!s_rgba6_to_rgb8_program_blob[0])
 		{
-			D3D::CompilePixelShader(s_reint_rgba6_to_rgb8_program_hlsl, &s_rgba6_to_rgb8_program_blob[0]);
+			D3D::CompilePixelShader(s_reint_rgba6_to_rgb8_program_hlsl, s_rgba6_to_rgb8_program_blob[0].GetAddressOf());
 		}
 
 		bytecode = { s_rgba6_to_rgb8_program_blob[0]->GetBufferPointer(), s_rgba6_to_rgb8_program_blob[0]->GetBufferSize() };
@@ -430,7 +430,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetReinterpRGBA6ToRGB8PixelShader(bool 
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_reint_rgba6_to_rgb8_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_rgba6_to_rgb8_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_rgba6_to_rgb8_program_blob[1].GetAddressOf());
 		bytecode = { s_rgba6_to_rgb8_program_blob[1]->GetBufferPointer(), s_rgba6_to_rgb8_program_blob[1]->GetBufferSize() };
 	}
 	return bytecode;
@@ -444,7 +444,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetReinterpRGB8ToRGBA6PixelShader(bool 
 	{
 		if (!s_rgb8_to_rgba6_program_blob[0])
 		{
-			D3D::CompilePixelShader(s_reint_rgb8_to_rgba6_program_hlsl, &s_rgb8_to_rgba6_program_blob[0]);
+			D3D::CompilePixelShader(s_reint_rgb8_to_rgba6_program_hlsl, s_rgb8_to_rgba6_program_blob[0].GetAddressOf());
 		}
 
 		bytecode = { s_rgb8_to_rgba6_program_blob[0]->GetBufferPointer(), s_rgb8_to_rgba6_program_blob[0]->GetBufferSize() };
@@ -455,7 +455,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetReinterpRGB8ToRGBA6PixelShader(bool 
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_reint_rgb8_to_rgba6_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_rgb8_to_rgba6_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_rgb8_to_rgba6_program_blob[1].GetAddressOf());
 		bytecode = { s_rgb8_to_rgba6_program_blob[1]->GetBufferPointer(), s_rgb8_to_rgba6_program_blob[1]->GetBufferSize() };
 	}
 
@@ -479,7 +479,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetColorCopyPixelShader(bool multisampl
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_color_copy_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_color_copy_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_color_copy_program_blob[1].GetAddressOf());
 		bytecode = { s_color_copy_program_blob[1]->GetBufferPointer(), s_color_copy_program_blob[1]->GetBufferSize() };
 	}
 
@@ -499,7 +499,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetDepthResolveToColorPixelShader()
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_depth_resolve_to_color_program_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_depth_resolve_to_color_program_blob);
+		D3D::CompilePixelShader(buf, s_depth_resolve_to_color_program_blob.GetAddressOf());
 		bytecode = { s_depth_resolve_to_color_program_blob->GetBufferPointer(), s_depth_resolve_to_color_program_blob->GetBufferSize() };
 	}
 
@@ -523,7 +523,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetColorMatrixPixelShader(bool multisam
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_color_matrix_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_color_matrix_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_color_matrix_program_blob[1].GetAddressOf());
 		bytecode = { s_color_matrix_program_blob[1]->GetBufferPointer(), s_color_matrix_program_blob[1]->GetBufferSize() };
 	}
 
@@ -547,7 +547,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetDepthMatrixPixelShader(bool multisam
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_depth_matrix_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_depth_matrix_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_depth_matrix_program_blob[1].GetAddressOf());
 
 		bytecode = { s_depth_matrix_program_blob[1]->GetBufferPointer(), s_depth_matrix_program_blob[1]->GetBufferSize() };
 	}
@@ -628,58 +628,58 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetCopyGeometryShader()
 void StaticShaderCache::Init()
 {
 	// Compile static pixel shaders
-	D3D::CompilePixelShader(s_clear_program_hlsl, &s_clear_program_blob);
-	D3D::CompilePixelShader(s_anaglyph_program_hlsl, &s_anaglyph_program_blob);
-	D3D::CompilePixelShader(s_color_copy_program_hlsl, &s_color_copy_program_blob[0]);
-	D3D::CompilePixelShader(s_color_matrix_program_hlsl, &s_color_matrix_program_blob[0]);
-	D3D::CompilePixelShader(s_depth_matrix_program_hlsl, &s_depth_matrix_program_blob[0]);
+	D3D::CompilePixelShader(s_clear_program_hlsl, s_clear_program_blob.GetAddressOf());
+	D3D::CompilePixelShader(s_anaglyph_program_hlsl, s_anaglyph_program_blob.GetAddressOf());
+	D3D::CompilePixelShader(s_color_copy_program_hlsl, s_color_copy_program_blob[0].GetAddressOf());
+	D3D::CompilePixelShader(s_color_matrix_program_hlsl, s_color_matrix_program_blob[0].GetAddressOf());
+	D3D::CompilePixelShader(s_depth_matrix_program_hlsl, s_depth_matrix_program_blob[0].GetAddressOf());
 
 	// Compile static vertex shaders
-	D3D::CompileVertexShader(s_simple_vertex_shader_hlsl, &s_simple_vertex_shader_blob);
-	D3D::CompileVertexShader(s_clear_vertex_shader_hlsl, &s_simple_clear_vertex_shader_blob);
+	D3D::CompileVertexShader(s_simple_vertex_shader_hlsl, s_simple_vertex_shader_blob.GetAddressOf());
+	D3D::CompileVertexShader(s_clear_vertex_shader_hlsl, s_simple_clear_vertex_shader_blob.GetAddressOf());
 
 	// Compile static geometry shaders
-	D3D::CompileGeometryShader(s_clear_geometry_shader_hlsl, &s_clear_geometry_shader_blob);
-	D3D::CompileGeometryShader(s_copy_geometry_shader_hlsl, &s_copy_geometry_shader_blob);
+	D3D::CompileGeometryShader(s_clear_geometry_shader_hlsl, s_clear_geometry_shader_blob.GetAddressOf());
+	D3D::CompileGeometryShader(s_copy_geometry_shader_hlsl, s_copy_geometry_shader_blob.GetAddressOf());
 }
 
 // Call this when multisampling mode changes, and shaders need to be regenerated.
 void StaticShaderCache::InvalidateMSAAShaders()
 {
-	SAFE_RELEASE(s_color_copy_program_blob[1]);
-	SAFE_RELEASE(s_color_matrix_program_blob[1]);
-	SAFE_RELEASE(s_depth_matrix_program_blob[1]);
-	SAFE_RELEASE(s_rgb8_to_rgba6_program_blob[1]);
-	SAFE_RELEASE(s_rgba6_to_rgb8_program_blob[1]);
-	SAFE_RELEASE(s_depth_resolve_to_color_program_blob);
+	s_color_copy_program_blob[1].Release();
+	s_color_matrix_program_blob[1].Release();
+	s_depth_matrix_program_blob[1].Release();
+	s_rgb8_to_rgba6_program_blob[1].Release();
+	s_rgba6_to_rgb8_program_blob[1].Release();
+	s_depth_resolve_to_color_program_blob.Release();
 }
 
 void StaticShaderCache::Shutdown()
 {
 	// Free pixel shader blobs
 
-	SAFE_RELEASE(s_clear_program_blob);
-	SAFE_RELEASE(s_anaglyph_program_blob);
-	SAFE_RELEASE(s_depth_resolve_to_color_program_blob);
+	s_clear_program_blob.Release();
+	s_anaglyph_program_blob.Release();
+	s_depth_resolve_to_color_program_blob.Release();
 
 	for (unsigned int i = 0; i < 2; ++i)
 	{
-		SAFE_RELEASE(s_color_copy_program_blob[i]);
-		SAFE_RELEASE(s_color_matrix_program_blob[i]);
-		SAFE_RELEASE(s_depth_matrix_program_blob[i]);
-		SAFE_RELEASE(s_rgba6_to_rgb8_program_blob[i]);
-		SAFE_RELEASE(s_rgb8_to_rgba6_program_blob[i]);
+		s_color_copy_program_blob[i].Release();
+		s_color_matrix_program_blob[i].Release();
+		s_depth_matrix_program_blob[i].Release();
+		s_rgba6_to_rgb8_program_blob[i].Release();
+		s_rgb8_to_rgba6_program_blob[i].Release();
 	}
 
 	// Free vertex shader blobs
 
-	SAFE_RELEASE(s_simple_vertex_shader_blob);
-	SAFE_RELEASE(s_simple_clear_vertex_shader_blob);
+	s_simple_vertex_shader_blob.Release();
+	s_simple_clear_vertex_shader_blob.Release();
 
 	// Free geometry shader blobs
 
-	SAFE_RELEASE(s_clear_geometry_shader_blob);
-	SAFE_RELEASE(s_copy_geometry_shader_blob);
+	s_clear_geometry_shader_blob.Release();
+	s_copy_geometry_shader_blob.Release();
 }
 
 }

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -203,7 +203,7 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 	}
 	else
 	{
-		ID3D12Resource* texture_resource = nullptr;
+		ComPtr<ID3D12Resource> texture_resource = nullptr;
 
 		D3D12_RESOURCE_DESC texture_resource_desc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM,
 			config.width, config.height, 1, config.levels);
@@ -215,12 +215,12 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 			&CD3DX12_RESOURCE_DESC(texture_resource_desc),
 			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
 			nullptr,
-			IID_PPV_ARGS(&texture_resource)
+			IID_PPV_ARGS(texture_resource.GetAddressOf())
 			)
 			);
 
 		D3DTexture2D* texture = new D3DTexture2D(
-			texture_resource,
+			texture_resource.Get(),
 			D3D11_BIND_SHADER_RESOURCE,
 			DXGI_FORMAT_UNKNOWN,
 			DXGI_FORMAT_UNKNOWN,
@@ -239,8 +239,6 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 
 		// EXISTINGD3D11TODO: better debug names
 		D3D::SetDebugObjectName12(entry->m_texture->GetTex12(), "a texture of the TextureCache");
-
-		SAFE_RELEASE(texture_resource);
 
 		return entry;
 	}


### PR DESCRIPTION
This branch adds a new COM Smart Pointer called ComPtr and uses it throughout the D3D11 and D3D12 backends.

The ComPtr included in this branch is a hand-written version similar to the ComPtr provided by Windows Runtime Library, but it is not necessary to have WRL on your system to compile.

There is no longer any need to remember to call SAFE_RELEASE on COM objects. ComPtr releases objects automatically.

All uses of the SAFE_RELEASE macro are eliminated in the D3D11 backend, and the macro is removed. Most uses are eliminated in the D3D12 backend.

This branch makes it harder to accidentally forget to release COM objects, and makes it easier to reason about COM object ownership.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3706)
<!-- Reviewable:end -->
