### PR TITLE
Fix bug with texture coordinate q value being 0

### DIFF
--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -106,24 +106,26 @@ void TransformNormal(const InputVertexData* src, bool nbt, OutputVertexData* dst
 static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bool specialCase,
                                      const InputVertexData* srcVertex, OutputVertexData* dstVertex)
 {
-  const Vec3* src;
+  Vec3 src;
   switch (texinfo.sourcerow)
   {
   case XF_SRCGEOM_INROW:
-    src = &srcVertex->position;
+    src = srcVertex->position;
     break;
   case XF_SRCNORMAL_INROW:
-    src = &srcVertex->normal[0];
+    src = srcVertex->normal[0];
     break;
   case XF_SRCBINORMAL_T_INROW:
-    src = &srcVertex->normal[1];
+    src = srcVertex->normal[1];
     break;
   case XF_SRCBINORMAL_B_INROW:
-    src = &srcVertex->normal[2];
+    src = srcVertex->normal[2];
     break;
   default:
     _assert_(texinfo.sourcerow >= XF_SRCTEX0_INROW && texinfo.sourcerow <= XF_SRCTEX7_INROW);
-    src = (Vec3*)srcVertex->texCoords[texinfo.sourcerow - XF_SRCTEX0_INROW];
+    src.x = srcVertex->texCoords[texinfo.sourcerow - XF_SRCTEX0_INROW][0];
+    src.y = srcVertex->texCoords[texinfo.sourcerow - XF_SRCTEX0_INROW][1];
+    src.z = 1.0f;
     break;
   }
 
@@ -133,18 +135,18 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
   if (texinfo.projection == XF_TEXPROJ_ST)
   {
     if (texinfo.inputform == XF_TEXINPUT_AB11 || specialCase)
-      MultiplyVec2Mat24(*src, mat, *dst);
+      MultiplyVec2Mat24(src, mat, *dst);
     else
-      MultiplyVec3Mat24(*src, mat, *dst);
+      MultiplyVec3Mat24(src, mat, *dst);
   }
   else  // texinfo.projection == XF_TEXPROJ_STQ
   {
     _assert_(!specialCase);
 
     if (texinfo.inputform == XF_TEXINPUT_AB11)
-      MultiplyVec2Mat34(*src, mat, *dst);
+      MultiplyVec2Mat34(src, mat, *dst);
     else
-      MultiplyVec3Mat34(*src, mat, *dst);
+      MultiplyVec3Mat34(src, mat, *dst);
   }
 
   // normalize

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -147,13 +147,13 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
       MultiplyVec3Mat34(*src, mat, *dst);
   }
 
+  // normalize
+  const PostMtxInfo& postInfo = xfmem.postMtxInfo[coordNum];
+  const float* postMat = &xfmem.postMatrices[postInfo.index * 4];
+
   if (xfmem.dualTexTrans.enabled)
   {
     Vec3 tempCoord;
-
-    // normalize
-    const PostMtxInfo& postInfo = xfmem.postMtxInfo[coordNum];
-    const float* postMat = &xfmem.postMatrices[postInfo.index * 4];
 
     if (specialCase)
     {
@@ -175,6 +175,23 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
         tempCoord = *dst;
 
       MultiplyVec3Mat34(tempCoord, postMat, *dst);
+    }
+  }
+
+  // TODO write comment
+  if(dst->z == 0.0f)
+  {
+    if(mat[8] != 0.0f || (xfmem.dualTexTrans.enabled && postMat[8] != 0.0f) ||
+       mat[9] != 0.0f || (xfmem.dualTexTrans.enabled && postMat[9] != 0.0f))
+    {
+      // TODO test this case more
+      dst->x = 0.0f;
+      dst->y = 0.0f;
+    }
+    else
+    {
+      dst->x = MathUtil::Clamp(dst->x / 2.0f, -1.0f, 1.0f);
+      dst->y = MathUtil::Clamp(dst->y / 2.0f, -1.0f, 1.0f);
     }
   }
 }

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -149,13 +149,13 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
       MultiplyVec3Mat34(src, mat, *dst);
   }
 
-  // normalize
-  const PostMtxInfo& postInfo = xfmem.postMtxInfo[coordNum];
-  const float* postMat = &xfmem.postMatrices[postInfo.index * 4];
-
   if (xfmem.dualTexTrans.enabled)
   {
     Vec3 tempCoord;
+
+    // normalize
+    const PostMtxInfo& postInfo = xfmem.postMtxInfo[coordNum];
+    const float* postMat = &xfmem.postMatrices[postInfo.index * 4];
 
     if (specialCase)
     {

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -180,7 +180,9 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
     }
   }
 
-  // TODO write comment
+  // When q is 0, the GameCube appears to have a special case
+  // This can be seen in devkitPro's neheGX Lesson08 example for Wii
+  // Makes differences in Rogue Squadron 3 (Hoth sky) and The Last Story (shadow culling)
   if (dst->z == 0.0f)
   {
     dst->x = MathUtil::Clamp(dst->x / 2.0f, -1.0f, 1.0f);

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -181,10 +181,10 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
   }
 
   // TODO write comment
-  if(dst->z == 0.0f)
+  if (dst->z == 0.0f)
   {
-    if(mat[8] != 0.0f || (xfmem.dualTexTrans.enabled && postMat[8] != 0.0f) ||
-       mat[9] != 0.0f || (xfmem.dualTexTrans.enabled && postMat[9] != 0.0f))
+    if (mat[8] != 0.0f || (xfmem.dualTexTrans.enabled && postMat[8] != 0.0f) || mat[9] != 0.0f ||
+        (xfmem.dualTexTrans.enabled && postMat[9] != 0.0f))
     {
       // TODO test this case more
       dst->x = 0.0f;

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -183,18 +183,8 @@ static void TransformTexCoordRegular(const TexMtxInfo& texinfo, int coordNum, bo
   // TODO write comment
   if (dst->z == 0.0f)
   {
-    if (mat[8] != 0.0f || (xfmem.dualTexTrans.enabled && postMat[8] != 0.0f) || mat[9] != 0.0f ||
-        (xfmem.dualTexTrans.enabled && postMat[9] != 0.0f))
-    {
-      // TODO test this case more
-      dst->x = 0.0f;
-      dst->y = 0.0f;
-    }
-    else
-    {
-      dst->x = MathUtil::Clamp(dst->x / 2.0f, -1.0f, 1.0f);
-      dst->y = MathUtil::Clamp(dst->y / 2.0f, -1.0f, 1.0f);
-    }
+    dst->x = MathUtil::Clamp(dst->x / 2.0f, -1.0f, 1.0f);
+    dst->y = MathUtil::Clamp(dst->y / 2.0f, -1.0f, 1.0f);
   }
 }
 

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -381,6 +381,14 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
                 i, i, i, i);
     }
 
+    // TODO write comment
+    // TODO check if it only affects XF_TEXGEN_REGULAR more
+    if (texinfo.texgentype == XF_TEXGEN_REGULAR)
+    {
+      out.Write("if(o.tex%d.z == 0.0f)\n", i);
+      out.Write("\to.tex%d.xy = clamp(o.tex%d.xy / 2.0f, float2(-1.0f), float2(1.0f));\n", i, i);
+    }
+
     out.Write("}\n");
   }
 

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -381,8 +381,10 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
                 i, i, i, i);
     }
 
-    // TODO write comment
-    // TODO check if it only affects XF_TEXGEN_REGULAR more
+    // When q is 0, the GameCube appears to have a special case
+    // This can be seen in devkitPro's neheGX Lesson08 example for Wii
+    // Makes differences in Rogue Squadron 3 (Hoth sky) and The Last Story (shadow culling)
+    // TODO: check if this only affects XF_TEXGEN_REGULAR
     if (texinfo.texgentype == XF_TEXGEN_REGULAR)
     {
       out.Write("if(o.tex%d.z == 0.0f)\n", i);


### PR DESCRIPTION
This exists only to get fifoci diffs and for JMC47 to play with for now.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3707)
<!-- Reviewable:end -->
