### PR TITLE
Fix build with MINIUPNPC_API_VERSION >= 16

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -942,8 +942,14 @@ bool NetPlayServer::initUPnP()
 
 	for (const UPNPDev* dev : igds)
 	{
-		char* descXML = (char*)miniwget(dev->descURL, &descXMLsize, 0);
-		if (descXML)
+		char* descXML;
+		int statusCode = 200;
+#if MINIUPNPC_API_VERSION >= 16
+		descXML = (char*)miniwget(dev->descURL, &descXMLsize, 0, &statusCode);
+#else
+		descXML = (char*)miniwget(dev->descURL, &descXMLsize, 0);
+#endif
+		if (descXML && (statusCode == 200))
 		{
 			parserootdesc(descXML, descXMLsize, &m_upnp_data);
 			free(descXML);
@@ -955,6 +961,11 @@ bool NetPlayServer::initUPnP()
 		}
 		else
 		{
+			if (descXML)
+			{
+				free(descXML);
+				descXML = nullptr;
+			}
 			WARN_LOG(NETPLAY, "Error getting info from IGD at %s.", dev->descURL);
 		}
 	}


### PR DESCRIPTION
miniupnp commit c4991916e5c12a7754e935e71a5313e75af6aeb9 introduced a 4th statusCode parameter to miniwget function. This parameter is set to a value returned by the UPnP device. We have to check if it's set to 200 to make sure the result is a success. Also, we now have to check
if descXML is set in the error case and free it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3708)
<!-- Reviewable:end -->
