### PR TITLE
Fix Frame Advance (Reverts PR 2396, Fixes issue 8718)

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter.cpp
@@ -36,9 +36,6 @@ void CachedInterpreter::Run()
 	{
 		SingleStep();
 	}
-
-	// Let the waiting thread know we are done leaving
-	PowerPC::FinishStateMove();
 }
 
 void CachedInterpreter::SingleStep()

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -285,9 +285,6 @@ void Interpreter::Run()
 			PC = NPC;
 		}
 	}
-
-	// Let the waiting thread know we are done leaving
-	PowerPC::FinishStateMove();
 }
 
 void Interpreter::unknown_instruction(UGeckoInstruction _inst)

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -222,11 +222,6 @@ void Jit64AsmRoutineManager::Generate()
 		POP(RSP);
 	}
 
-	// Let the waiting thread know we are done leaving
-	ABI_PushRegistersAndAdjustStack({}, 0);
-	ABI_CallFunction(reinterpret_cast<void *>(&PowerPC::FinishStateMove));
-	ABI_PopRegistersAndAdjustStack({}, 0);
-
 	ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8, 16);
 	RET();
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -99,10 +99,6 @@ void JitArm64AsmRoutineManager::Generate()
 	SetJumpTarget(Exit);
 	STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
 
-	// Let the waiting thread know we are done leaving
-	MOVI2R(X0, (u64)&PowerPC::FinishStateMove);
-	BLR(X0);
-
 	ABI_PopRegisters(regs_to_save);
 	RET(X30);
 

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -5,7 +5,6 @@
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-#include "Common/Event.h"
 #include "Common/FPURoundMode.h"
 #include "Common/MathUtil.h"
 #include "Common/Logging/Log.h"
@@ -32,7 +31,6 @@ static volatile CPUState state = CPU_POWERDOWN;
 
 Interpreter * const interpreter = Interpreter::getInstance();
 static CoreMode mode;
-static Common::Event s_state_change;
 
 Watches watches;
 BreakPoints breakpoints;
@@ -238,29 +236,14 @@ void Start()
 
 void Pause()
 {
-	volatile CPUState old_state = state;
 	state = CPU_STEPPING;
-
-	// Wait for the CPU core to leave
-	if (old_state == CPU_RUNNING)
-		s_state_change.WaitFor(std::chrono::seconds(1));
 	Host_UpdateDisasmDialog();
 }
 
 void Stop()
 {
-	volatile CPUState old_state = state;
 	state = CPU_POWERDOWN;
-
-	// Wait for the CPU core to leave
-	if (old_state == CPU_RUNNING)
-		s_state_change.WaitFor(std::chrono::seconds(1));
 	Host_UpdateDisasmDialog();
-}
-
-void FinishStateMove()
-{
-	s_state_change.Set();
 }
 
 void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst)

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -158,7 +158,6 @@ void RunLoop();
 void Start();
 void Pause();
 void Stop();
-void FinishStateMove();
 CPUState GetState();
 volatile CPUState *GetStatePtr();  // this oddity is here instead of an extern declaration to easily be able to find all direct accesses throughout the code.
 


### PR DESCRIPTION
This reverts PR #2396, which caused frame advance to unpause randomly instead of properly stepping through frames.

This fixes issue 8718: https://bugs.dolphin-emu.org/issues/8718

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3712)
<!-- Reviewable:end -->
