### PR TITLE
COM Smart Pointer (Windows Runtime Library version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Source/Core/Common/scmrev.h
 *.vcxproj.user
 *.obj
 *.tlog
+*.VC.opendb
 # Ignore build info file created by QtCreator
 CMakeLists.txt.user
 # Ignore files created by posix people

--- a/Source/Core/VideoBackends/D3D/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D/BoundingBox.cpp
@@ -10,13 +10,13 @@
 namespace DX11
 {
 
-static ID3D11Buffer* s_bbox_buffer;
-static ID3D11Buffer* s_bbox_staging_buffer;
-static ID3D11UnorderedAccessView*  s_bbox_uav;
+static ComPtr<ID3D11Buffer> s_bbox_buffer;
+static ComPtr<ID3D11Buffer> s_bbox_staging_buffer;
+static ComPtr<ID3D11UnorderedAccessView> s_bbox_uav;
 
-ID3D11UnorderedAccessView* &BBox::GetUAV()
+ID3D11UnorderedAccessView* BBox::GetUAV()
 {
-	return s_bbox_uav;
+	return s_bbox_uav.Get();
 }
 
 void BBox::Init()
@@ -32,17 +32,17 @@ void BBox::Init()
 		data.SysMemPitch = 4 * sizeof(s32);
 		data.SysMemSlicePitch = 0;
 		HRESULT hr;
-		hr = D3D::device->CreateBuffer(&desc, &data, &s_bbox_buffer);
+		hr = D3D::device->CreateBuffer(&desc, &data, s_bbox_buffer.GetAddressOf());
 		CHECK(SUCCEEDED(hr), "Create BoundingBox Buffer.");
-		D3D::SetDebugObjectName(s_bbox_buffer, "BoundingBox Buffer");
+		D3D::SetDebugObjectName(s_bbox_buffer.Get(), "BoundingBox Buffer");
 
 		// Second to use as a staging buffer.
 		desc.Usage = D3D11_USAGE_STAGING;
 		desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
 		desc.BindFlags = 0;
-		hr = D3D::device->CreateBuffer(&desc, nullptr, &s_bbox_staging_buffer);
+		hr = D3D::device->CreateBuffer(&desc, nullptr, s_bbox_staging_buffer.GetAddressOf());
 		CHECK(SUCCEEDED(hr), "Create BoundingBox Staging Buffer.");
-		D3D::SetDebugObjectName(s_bbox_staging_buffer, "BoundingBox Staging Buffer");
+		D3D::SetDebugObjectName(s_bbox_staging_buffer.Get(), "BoundingBox Staging Buffer");
 
 		// UAV is required to allow concurrent access.
 		D3D11_UNORDERED_ACCESS_VIEW_DESC UAVdesc = {};
@@ -51,36 +51,36 @@ void BBox::Init()
 		UAVdesc.Buffer.FirstElement = 0;
 		UAVdesc.Buffer.Flags = 0;
 		UAVdesc.Buffer.NumElements = 4;
-		hr = D3D::device->CreateUnorderedAccessView(s_bbox_buffer, &UAVdesc, &s_bbox_uav);
+		hr = D3D::device->CreateUnorderedAccessView(s_bbox_buffer.Get(), &UAVdesc, s_bbox_uav.GetAddressOf());
 		CHECK(SUCCEEDED(hr), "Create BoundingBox UAV.");
-		D3D::SetDebugObjectName(s_bbox_uav, "BoundingBox UAV");
+		D3D::SetDebugObjectName(s_bbox_uav.Get(), "BoundingBox UAV");
 	}
 }
 
 void BBox::Shutdown()
 {
-	SAFE_RELEASE(s_bbox_buffer);
-	SAFE_RELEASE(s_bbox_staging_buffer);
-	SAFE_RELEASE(s_bbox_uav);
+	s_bbox_buffer.Reset();
+	s_bbox_staging_buffer.Reset();
+	s_bbox_uav.Reset();
 }
 
 void BBox::Set(int index, int value)
 {
 	D3D11_BOX box{ index * sizeof(s32), 0, 0, (index + 1) * sizeof(s32), 1, 1 };
-	D3D::context->UpdateSubresource(s_bbox_buffer, 0, &box, &value, 0, 0);
+	D3D::context->UpdateSubresource(s_bbox_buffer.Get(), 0, &box, &value, 0, 0);
 }
 
 int BBox::Get(int index)
 {
 	int data = 0;
-	D3D::context->CopyResource(s_bbox_staging_buffer, s_bbox_buffer);
+	D3D::context->CopyResource(s_bbox_staging_buffer.Get(), s_bbox_buffer.Get());
 	D3D11_MAPPED_SUBRESOURCE map;
-	HRESULT hr = D3D::context->Map(s_bbox_staging_buffer, 0, D3D11_MAP_READ, 0, &map);
+	HRESULT hr = D3D::context->Map(s_bbox_staging_buffer.Get(), 0, D3D11_MAP_READ, 0, &map);
 	if (SUCCEEDED(hr))
 	{
 		data = ((s32*)map.pData)[index];
 	}
-	D3D::context->Unmap(s_bbox_staging_buffer, 0);
+	D3D::context->Unmap(s_bbox_staging_buffer.Get(), 0);
 	return data;
 }
 

--- a/Source/Core/VideoBackends/D3D/BoundingBox.h
+++ b/Source/Core/VideoBackends/D3D/BoundingBox.h
@@ -11,7 +11,7 @@ namespace DX11
 class BBox
 {
 public:
-	static ID3D11UnorderedAccessView* &GetUAV();
+	static ID3D11UnorderedAccessView* GetUAV();
 	static void Init();
 	static void Shutdown();
 

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -8,13 +8,15 @@
 #include <d3dcompiler.h>
 #include <dxgi.h>
 #include <vector>
+#include <wrl/client.h>
 
 #include "Common/Common.h"
 
 namespace DX11
 {
 
-#define SAFE_RELEASE(x) { if (x) (x)->Release(); (x) = nullptr; }
+using Microsoft::WRL::ComPtr;
+
 #define SAFE_DELETE(x) { delete (x); (x) = nullptr; }
 #define SAFE_DELETE_ARRAY(x) { delete[] (x); (x) = nullptr; }
 #define CHECK(cond, Message, ...) if (!(cond)) { PanicAlert(__FUNCTION__ " failed in %s at line %d: " Message, __FILE__, __LINE__, __VA_ARGS__); }
@@ -37,8 +39,8 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter);
 HRESULT Create(HWND wnd);
 void Close();
 
-extern ID3D11Device* device;
-extern ID3D11DeviceContext* context;
+extern ComPtr<ID3D11Device> device;
+extern ComPtr<ID3D11DeviceContext> context;
 extern HWND hWnd;
 extern bool bFrameInProgress;
 
@@ -49,7 +51,7 @@ void Present();
 
 unsigned int GetBackBufferWidth();
 unsigned int GetBackBufferHeight();
-D3DTexture2D* &GetBackBuffer();
+D3DTexture2D* GetBackBuffer();
 const char* PixelShaderVersionString();
 const char* GeometryShaderVersionString();
 const char* VertexShaderVersionString();
@@ -63,34 +65,10 @@ HRESULT GetFullscreenState(bool* fullscreen_state);
 // This function will assign a name to the given resource.
 // The DirectX debug layer will make it easier to identify resources that way,
 // e.g. when listing up all resources who have unreleased references.
-template <typename T>
-void SetDebugObjectName(T resource, const char* name)
-{
-	static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
-		"resource must be convertible to ID3D11DeviceChild*");
-#if defined(_DEBUG) || defined(DEBUGFAST)
-	if (resource)
-		resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)(name ? strlen(name) : 0), name);
-#endif
-}
+void SetDebugObjectName(ID3D11DeviceChild* resource, const char* name);
+std::string GetDebugObjectName(ID3D11DeviceChild* resource);
 
-template <typename T>
-std::string GetDebugObjectName(T resource)
-{
-	static_assert(std::is_convertible<T, ID3D11DeviceChild*>::value,
-		"resource must be convertible to ID3D11DeviceChild*");
-	std::string name;
-#if defined(_DEBUG) || defined(DEBUGFAST)
-	if (resource)
-	{
-		UINT size = 0;
-		resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, nullptr); //get required size
-		name.resize(size);
-		resource->GetPrivateData(WKPDID_D3DDebugObjectName, &size, const_cast<char*>(name.data()));
-	}
-#endif
-	return name;
-}
+void SetRenderTarget(ID3D11RenderTargetView* rtv, ID3D11DepthStencilView* dsv = nullptr);
 
 }  // namespace D3D
 

--- a/Source/Core/VideoBackends/D3D/D3DShader.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DShader.cpp
@@ -20,10 +20,10 @@ namespace D3D
 {
 
 // bytecode->shader
-ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len)
+ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len)
 {
-	ID3D11VertexShader* v_shader;
-	HRESULT hr = D3D::device->CreateVertexShader(bytecode, len, nullptr, &v_shader);
+	ComPtr<ID3D11VertexShader> v_shader;
+	HRESULT hr = D3D::device->CreateVertexShader(bytecode, len, nullptr, v_shader.GetAddressOf());
 	if (FAILED(hr))
 		return nullptr;
 
@@ -73,10 +73,10 @@ bool CompileVertexShader(const std::string& code, D3DBlob** blob)
 }
 
 // bytecode->shader
-ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len)
+ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len)
 {
-	ID3D11GeometryShader* g_shader;
-	HRESULT hr = D3D::device->CreateGeometryShader(bytecode, len, nullptr, &g_shader);
+	ComPtr<ID3D11GeometryShader> g_shader;
+	HRESULT hr = D3D::device->CreateGeometryShader(bytecode, len, nullptr, g_shader.GetAddressOf());
 	if (FAILED(hr))
 		return nullptr;
 
@@ -127,10 +127,10 @@ bool CompileGeometryShader(const std::string& code, D3DBlob** blob, const D3D_SH
 }
 
 // bytecode->shader
-ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len)
+ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len)
 {
-	ID3D11PixelShader* p_shader;
-	HRESULT hr = D3D::device->CreatePixelShader(bytecode, len, nullptr, &p_shader);
+	ComPtr<ID3D11PixelShader> p_shader;
+	HRESULT hr = D3D::device->CreatePixelShader(bytecode, len, nullptr, p_shader.GetAddressOf());
 	if (FAILED(hr))
 	{
 		PanicAlert("CreatePixelShaderFromByteCode failed at %s %d\n", __FILE__, __LINE__);
@@ -183,37 +183,37 @@ bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADE
 	return SUCCEEDED(hr);
 }
 
-ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code)
+ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(const std::string& code)
 {
 	D3DBlob* blob = nullptr;
 	if (CompileVertexShader(code, &blob))
 	{
-		ID3D11VertexShader* v_shader = CreateVertexShaderFromByteCode(blob);
+		ComPtr<ID3D11VertexShader> v_shader = CreateVertexShaderFromByteCode(blob);
 		blob->Release();
 		return v_shader;
 	}
 	return nullptr;
 }
 
-ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines)
+ComPtr<ID3D11GeometryShader> CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines)
 {
 	D3DBlob* blob = nullptr;
 	if (CompileGeometryShader(code, &blob, pDefines))
 	{
-		ID3D11GeometryShader* g_shader = CreateGeometryShaderFromByteCode(blob);
+		ComPtr<ID3D11GeometryShader> g_shader = CreateGeometryShaderFromByteCode(blob);
 		blob->Release();
 		return g_shader;
 	}
 	return nullptr;
 }
 
-ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code)
+ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(const std::string& code)
 {
 	D3DBlob* blob = nullptr;
 	CompilePixelShader(code, &blob);
 	if (blob)
 	{
-		ID3D11PixelShader* p_shader = CreatePixelShaderFromByteCode(blob);
+		ComPtr<ID3D11PixelShader> p_shader = CreatePixelShaderFromByteCode(blob);
 		blob->Release();
 		return p_shader;
 	}

--- a/Source/Core/VideoBackends/D3D/D3DShader.h
+++ b/Source/Core/VideoBackends/D3D/D3DShader.h
@@ -17,9 +17,9 @@ namespace DX11
 
 namespace D3D
 {
-	ID3D11VertexShader* CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len);
-	ID3D11GeometryShader* CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len);
-	ID3D11PixelShader* CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len);
+	ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(const void* bytecode, unsigned int len);
+	ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(const void* bytecode, unsigned int len);
+	ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(const void* bytecode, unsigned int len);
 
 	// The returned bytecode buffers should be Release()d.
 	bool CompileVertexShader(const std::string& code, D3DBlob** blob);
@@ -27,28 +27,28 @@ namespace D3D
 	bool CompilePixelShader(const std::string& code, D3DBlob** blob, const D3D_SHADER_MACRO* pDefines = nullptr);
 
 	// Utility functions
-	ID3D11VertexShader* CompileAndCreateVertexShader(const std::string& code);
-	ID3D11GeometryShader* CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines = nullptr);
-	ID3D11PixelShader* CompileAndCreatePixelShader(const std::string& code);
+	ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(const std::string& code);
+	ComPtr<ID3D11GeometryShader> CompileAndCreateGeometryShader(const std::string& code, const D3D_SHADER_MACRO* pDefines = nullptr);
+	ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(const std::string& code);
 
-	inline ID3D11VertexShader* CreateVertexShaderFromByteCode(D3DBlob* bytecode)
+	inline ComPtr<ID3D11VertexShader> CreateVertexShaderFromByteCode(D3DBlob* bytecode)
 	{ return CreateVertexShaderFromByteCode(bytecode->Data(), bytecode->Size()); }
-	inline ID3D11GeometryShader* CreateGeometryShaderFromByteCode(D3DBlob* bytecode)
+	inline ComPtr<ID3D11GeometryShader> CreateGeometryShaderFromByteCode(D3DBlob* bytecode)
 	{ return CreateGeometryShaderFromByteCode(bytecode->Data(), bytecode->Size()); }
-	inline ID3D11PixelShader* CreatePixelShaderFromByteCode(D3DBlob* bytecode)
+	inline ComPtr<ID3D11PixelShader> CreatePixelShaderFromByteCode(D3DBlob* bytecode)
 	{ return CreatePixelShaderFromByteCode(bytecode->Data(), bytecode->Size()); }
 
-	inline ID3D11VertexShader* CompileAndCreateVertexShader(D3DBlob* code)
+	inline ComPtr<ID3D11VertexShader> CompileAndCreateVertexShader(D3DBlob* code)
 	{
 		return CompileAndCreateVertexShader((const char*)code->Data());
 	}
 
-	inline ID3D11GeometryShader* CompileAndCreateGeometryShader(D3DBlob* code, const D3D_SHADER_MACRO* pDefines = nullptr)
+	inline ComPtr<ID3D11GeometryShader> CompileAndCreateGeometryShader(D3DBlob* code, const D3D_SHADER_MACRO* pDefines = nullptr)
 	{
 		return CompileAndCreateGeometryShader((const char*)code->Data(), pDefines);
 	}
 
-	inline ID3D11PixelShader* CompileAndCreatePixelShader(D3DBlob* code)
+	inline ComPtr<ID3D11PixelShader> CompileAndCreatePixelShader(D3DBlob* code)
 	{
 		return CompileAndCreatePixelShader((const char*)code->Data());
 	}

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -68,10 +68,10 @@ public:
 
 private:
 
-	std::unordered_map<u32, ID3D11DepthStencilState*> m_depth;
-	std::unordered_map<u32, ID3D11RasterizerState*> m_raster;
-	std::unordered_map<u32, ID3D11BlendState*> m_blend;
-	std::unordered_map<u64, ID3D11SamplerState*> m_sampler;
+	std::unordered_map<u32, ComPtr<ID3D11DepthStencilState>> m_depth;
+	std::unordered_map<u32, ComPtr<ID3D11RasterizerState>> m_raster;
+	std::unordered_map<u32, ComPtr<ID3D11BlendState>> m_blend;
+	std::unordered_map<u64, ComPtr<ID3D11SamplerState>> m_sampler;
 };
 
 namespace D3D

--- a/Source/Core/VideoBackends/D3D/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.cpp
@@ -44,77 +44,93 @@ void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned 
 
 }  // namespace
 
-D3DTexture2D* D3DTexture2D::Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind, D3D11_USAGE usage, DXGI_FORMAT fmt, unsigned int levels, unsigned int slices, D3D11_SUBRESOURCE_DATA* data)
+void D3DTexture2D::Create(DXGI_FORMAT format, unsigned int width, unsigned int height,
+	D3D11_BIND_FLAG bind, D3D11_USAGE usage,
+	unsigned int levels, unsigned int slices,
+	const D3D11_SUBRESOURCE_DATA* data)
 {
-	ID3D11Texture2D* pTexture = nullptr;
+	ComPtr<ID3D11Texture2D> pTexture = nullptr;
 	HRESULT hr;
 
 	D3D11_CPU_ACCESS_FLAG cpuflags;
 	if (usage == D3D11_USAGE_STAGING)
-		cpuflags = (D3D11_CPU_ACCESS_FLAG)((int)D3D11_CPU_ACCESS_WRITE|(int)D3D11_CPU_ACCESS_READ);
+		cpuflags = (D3D11_CPU_ACCESS_FLAG)(D3D11_CPU_ACCESS_WRITE | D3D11_CPU_ACCESS_READ);
 	else if (usage == D3D11_USAGE_DYNAMIC)
 		cpuflags = D3D11_CPU_ACCESS_WRITE;
 	else
 		cpuflags = (D3D11_CPU_ACCESS_FLAG)0;
-	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(fmt, width, height, slices, levels, bind, usage, cpuflags);
-	hr = D3D::device->CreateTexture2D(&texdesc, data, &pTexture);
+	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(format, width, height, slices, levels, bind, usage, cpuflags);
+	hr = D3D::device->CreateTexture2D(&texdesc, data, pTexture.GetAddressOf());
 	if (FAILED(hr))
 	{
 		PanicAlert("Failed to create texture at %s, line %d: hr=%#x\n", __FILE__, __LINE__, hr);
+		return;
+	}
+
+	CreateFromExisting(pTexture.Get(), bind);
+}
+
+void D3DTexture2D::CreateFromExisting(ID3D11Texture2D* tex, D3D11_BIND_FLAG bind,
+	DXGI_FORMAT srv_format, DXGI_FORMAT dsv_format, DXGI_FORMAT rtv_format, bool multisampled)
+{
+	Reset();
+	m_tex = tex;
+
+	if (bind & D3D11_BIND_SHADER_RESOURCE)
+	{
+		D3D11_SRV_DIMENSION srv_dim = multisampled ?
+			D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY :
+			D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+		D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = CD3D11_SHADER_RESOURCE_VIEW_DESC(srv_dim, srv_format);
+		D3D::device->CreateShaderResourceView(tex, &srv_desc, m_srv.GetAddressOf());
+	}
+	if (bind & D3D11_BIND_RENDER_TARGET)
+	{
+		D3D11_RTV_DIMENSION rtv_dim = multisampled ?
+			D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY :
+			D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+		D3D11_RENDER_TARGET_VIEW_DESC rtv_desc = CD3D11_RENDER_TARGET_VIEW_DESC(rtv_dim, rtv_format);
+		D3D::device->CreateRenderTargetView(tex, &rtv_desc, m_rtv.GetAddressOf());
+	}
+	if (bind & D3D11_BIND_DEPTH_STENCIL)
+	{
+		D3D11_DSV_DIMENSION dsv_dim = multisampled ?
+			D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY :
+			D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
+		D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc = CD3D11_DEPTH_STENCIL_VIEW_DESC(dsv_dim, dsv_format);
+		D3D::device->CreateDepthStencilView(tex, &dsv_desc, m_dsv.GetAddressOf());
+	}
+}
+
+void D3DTexture2D::Reset()
+{
+	m_dsv.Reset();
+	m_rtv.Reset();
+	m_srv.Reset();
+	m_tex.Reset();
+}
+
+ID3D11Texture2D* D3DTexture2D::GetTex() { return m_tex.Get(); }
+ID3D11ShaderResourceView* D3DTexture2D::GetSRV() { return m_srv.Get(); }
+ID3D11RenderTargetView* D3DTexture2D::GetRTV() { return m_rtv.Get(); }
+ID3D11DepthStencilView* D3DTexture2D::GetDSV() { return m_dsv.Get(); }
+
+ComPtr<ID3D11Texture2D> CreateStagingTexture(DXGI_FORMAT format,
+	unsigned int width, unsigned int height,
+	unsigned int levels, unsigned int slices,
+	D3D11_CPU_ACCESS_FLAG cpuAccess)
+{
+	ComPtr<ID3D11Texture2D> result;
+
+	D3D11_TEXTURE2D_DESC texdesc = CD3D11_TEXTURE2D_DESC(format, width, height, slices, levels, 0, D3D11_USAGE_STAGING, cpuAccess);
+	HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, result.GetAddressOf());
+	if (FAILED(hr))
+	{
+		PanicAlert("Failed to create staging texture at %s, line %d: hr=%#x\n", __FILE__, __LINE__, hr);
 		return nullptr;
 	}
 
-	D3DTexture2D* ret = new D3DTexture2D(pTexture, bind);
-	SAFE_RELEASE(pTexture);
-	return ret;
-}
-
-void D3DTexture2D::AddRef()
-{
-	++ref;
-}
-
-UINT D3DTexture2D::Release()
-{
-	--ref;
-	if (ref == 0)
-	{
-		delete this;
-		return 0;
-	}
-	return ref;
-}
-
-ID3D11Texture2D* &D3DTexture2D::GetTex() { return tex; }
-ID3D11ShaderResourceView* &D3DTexture2D::GetSRV() { return srv; }
-ID3D11RenderTargetView* &D3DTexture2D::GetRTV() { return rtv; }
-ID3D11DepthStencilView* &D3DTexture2D::GetDSV() { return dsv; }
-
-D3DTexture2D::D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind,
-							DXGI_FORMAT srv_format, DXGI_FORMAT dsv_format, DXGI_FORMAT rtv_format, bool multisampled)
-							: ref(1), tex(texptr), srv(nullptr), rtv(nullptr), dsv(nullptr)
-{
-	D3D11_SRV_DIMENSION srv_dim = multisampled ? D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY : D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
-	D3D11_DSV_DIMENSION dsv_dim = multisampled ? D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY : D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
-	D3D11_RTV_DIMENSION rtv_dim = multisampled ? D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY : D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
-	D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc = CD3D11_SHADER_RESOURCE_VIEW_DESC(srv_dim, srv_format);
-	D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc = CD3D11_DEPTH_STENCIL_VIEW_DESC(dsv_dim, dsv_format);
-	D3D11_RENDER_TARGET_VIEW_DESC rtv_desc = CD3D11_RENDER_TARGET_VIEW_DESC(rtv_dim, rtv_format);
-	if (bind & D3D11_BIND_SHADER_RESOURCE)
-		D3D::device->CreateShaderResourceView(tex, &srv_desc, &srv);
-	if (bind & D3D11_BIND_RENDER_TARGET)
-		D3D::device->CreateRenderTargetView(tex, &rtv_desc, &rtv);
-	if (bind & D3D11_BIND_DEPTH_STENCIL)
-		D3D::device->CreateDepthStencilView(tex, &dsv_desc, &dsv);
-	tex->AddRef();
-}
-
-D3DTexture2D::~D3DTexture2D()
-{
-	SAFE_RELEASE(srv);
-	SAFE_RELEASE(rtv);
-	SAFE_RELEASE(dsv);
-	SAFE_RELEASE(tex);
+	return result;
 }
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -17,31 +17,35 @@ namespace D3D
 class D3DTexture2D
 {
 public:
-	// there are two ways to create a D3DTexture2D object:
-	//     either create an ID3D11Texture2D object, pass it to the constructor and specify what views to create
-	//     or let the texture automatically be created by D3DTexture2D::Create
+	void Create(DXGI_FORMAT format, unsigned int width, unsigned int height, 
+		D3D11_BIND_FLAG bind, D3D11_USAGE usage = D3D11_USAGE_DEFAULT,
+		unsigned int levels = 1, unsigned int slices = 1,
+		const D3D11_SUBRESOURCE_DATA* data = nullptr);
 
-	D3DTexture2D(ID3D11Texture2D* texptr, D3D11_BIND_FLAG bind, DXGI_FORMAT srv_format = DXGI_FORMAT_UNKNOWN, DXGI_FORMAT dsv_format = DXGI_FORMAT_UNKNOWN, DXGI_FORMAT rtv_format = DXGI_FORMAT_UNKNOWN, bool multisampled = false);
-	static D3DTexture2D* Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind, D3D11_USAGE usage, DXGI_FORMAT, unsigned int levels = 1, unsigned int slices = 1, D3D11_SUBRESOURCE_DATA* data = nullptr);
+	// Create from an existing ID3D11Texture2D. This function calls AddRef on
+	// the texture. The caller should Release their pointer.
+	void CreateFromExisting(ID3D11Texture2D* tex, D3D11_BIND_FLAG bind,
+		DXGI_FORMAT srv_format = DXGI_FORMAT_UNKNOWN,
+		DXGI_FORMAT dsv_format = DXGI_FORMAT_UNKNOWN,
+		DXGI_FORMAT rtv_format = DXGI_FORMAT_UNKNOWN, bool multisampled = false);
 
-	// reference counting, use AddRef() when creating a new reference and Release() it when you don't need it anymore
-	void AddRef();
-	UINT Release();
+	void Reset();
 
-	ID3D11Texture2D* &GetTex();
-	ID3D11ShaderResourceView* &GetSRV();
-	ID3D11RenderTargetView* &GetRTV();
-	ID3D11DepthStencilView* &GetDSV();
+	ID3D11Texture2D* GetTex();
+	ID3D11ShaderResourceView* GetSRV();
+	ID3D11RenderTargetView* GetRTV();
+	ID3D11DepthStencilView* GetDSV();
 
 private:
-	~D3DTexture2D();
-
-	ID3D11Texture2D* tex;
-	ID3D11ShaderResourceView* srv;
-	ID3D11RenderTargetView* rtv;
-	ID3D11DepthStencilView* dsv;
-	D3D11_BIND_FLAG bindflags;
-	UINT ref;
+	ComPtr<ID3D11Texture2D> m_tex;
+	ComPtr<ID3D11ShaderResourceView> m_srv;
+	ComPtr<ID3D11RenderTargetView> m_rtv;
+	ComPtr<ID3D11DepthStencilView> m_dsv;
 };
+
+ComPtr<ID3D11Texture2D> CreateStagingTexture(DXGI_FORMAT format,
+	unsigned int width, unsigned int height,
+	unsigned int levels = 1, unsigned int slices = 1,
+	D3D11_CPU_ACCESS_FLAG cpuAccess = D3D11_CPU_ACCESS_READ);
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/D3DUtil.h
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.h
@@ -24,13 +24,13 @@ namespace D3D
 
 	class CD3DFont
 	{
-		ID3D11ShaderResourceView* m_pTexture;
-		ID3D11Buffer* m_pVB;
-		ID3D11InputLayout* m_InputLayout;
-		ID3D11PixelShader* m_pshader;
-		ID3D11VertexShader* m_vshader;
-		ID3D11BlendState* m_blendstate;
-		ID3D11RasterizerState* m_raststate;
+		ComPtr<ID3D11ShaderResourceView> m_pTexture;
+		ComPtr<ID3D11Buffer> m_pVB;
+		ComPtr<ID3D11InputLayout> m_InputLayout;
+		ComPtr<ID3D11PixelShader> m_pshader;
+		ComPtr<ID3D11VertexShader> m_vshader;
+		ComPtr<ID3D11BlendState> m_blendstate;
+		ComPtr<ID3D11RasterizerState> m_raststate;
 		const int m_dwTexWidth;
 		const int m_dwTexHeight;
 		unsigned int m_LineHeight;

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -24,28 +24,33 @@ static XFBEncoder s_xfbEncoder;
 FramebufferManager::Efb FramebufferManager::m_efb;
 unsigned int FramebufferManager::m_target_width;
 unsigned int FramebufferManager::m_target_height;
-ID3D11DepthStencilState* FramebufferManager::m_depth_resolve_depth_state;
+ComPtr<ID3D11DepthStencilState> FramebufferManager::m_depth_resolve_depth_state;
 
-D3DTexture2D* &FramebufferManager::GetEFBColorTexture() { return m_efb.color_tex; }
-ID3D11Texture2D* &FramebufferManager::GetEFBColorStagingBuffer() { return m_efb.color_staging_buf; }
+D3DTexture2D &FramebufferManager::GetEFBColorTexture() { return m_efb.color_tex; }
+ID3D11Texture2D* FramebufferManager::GetEFBColorStagingBuffer() {
+	return m_efb.color_staging_buf.Get();
+}
 
-D3DTexture2D* &FramebufferManager::GetEFBDepthTexture() { return m_efb.depth_tex; }
-D3DTexture2D* &FramebufferManager::GetEFBDepthReadTexture() { return m_efb.depth_read_texture; }
-ID3D11Texture2D* &FramebufferManager::GetEFBDepthStagingBuffer() { return m_efb.depth_staging_buf; }
+D3DTexture2D &FramebufferManager::GetEFBDepthTexture() { return m_efb.depth_tex; }
+D3DTexture2D &FramebufferManager::GetEFBDepthReadTexture() { return m_efb.depth_read_texture; }
+ID3D11Texture2D* FramebufferManager::GetEFBDepthStagingBuffer() {
+	return m_efb.depth_staging_buf.Get();
+}
 
-D3DTexture2D* &FramebufferManager::GetResolvedEFBColorTexture()
+D3DTexture2D &FramebufferManager::GetResolvedEFBColorTexture()
 {
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
-		for (int i = 0; i < m_efb.slices; i++)
-			D3D::context->ResolveSubresource(m_efb.resolved_color_tex->GetTex(), D3D11CalcSubresource(0, i, 1), m_efb.color_tex->GetTex(), D3D11CalcSubresource(0, i, 1), DXGI_FORMAT_R8G8B8A8_UNORM);
+		for (int i = 0; i < m_efb.slices; i++) {
+			D3D::context->ResolveSubresource(m_efb.resolved_color_tex.GetTex(), D3D11CalcSubresource(0, i, 1), m_efb.color_tex.GetTex(), D3D11CalcSubresource(0, i, 1), DXGI_FORMAT_R8G8B8A8_UNORM);
+		}
 		return m_efb.resolved_color_tex;
 	}
 	else
 		return m_efb.color_tex;
 }
 
-D3DTexture2D* &FramebufferManager::GetResolvedEFBDepthTexture()
+D3DTexture2D &FramebufferManager::GetResolvedEFBDepthTexture()
 {
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
@@ -54,21 +59,22 @@ D3DTexture2D* &FramebufferManager::GetResolvedEFBDepthTexture()
 
 		// Clear render state, and enable depth writes.
 		g_renderer->ResetAPIState();
-		D3D::stateman->PushDepthState(m_depth_resolve_depth_state);
+		D3D::stateman->PushDepthState(m_depth_resolve_depth_state.Get());
 
 		// Set up to render to resolved depth texture.
 		const D3D11_VIEWPORT viewport = CD3D11_VIEWPORT(0.f, 0.f, (float)m_target_width, (float)m_target_height);
 		D3D::context->RSSetViewports(1, &viewport);
-		D3D::context->OMSetRenderTargets(0, nullptr, m_efb.resolved_depth_tex->GetDSV());
+		D3D::context->OMSetRenderTargets(0, nullptr, m_efb.resolved_depth_tex.GetDSV());
 
 		// Render a quad covering the entire target, writing SV_Depth.
 		const D3D11_RECT source_rect = CD3D11_RECT(0, 0, m_target_width, m_target_height);
-		D3D::drawShadedTexQuad(m_efb.depth_tex->GetSRV(), &source_rect, m_target_width, m_target_height,
+		D3D::drawShadedTexQuad(m_efb.depth_tex.GetSRV(), &source_rect, m_target_width, m_target_height,
 			PixelShaderCache::GetDepthResolveProgram(), VertexShaderCache::GetSimpleVertexShader(),
 			VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
 
 		// Restore render state.
-		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
+		ID3D11RenderTargetView* rtv = FramebufferManager::GetEFBColorTexture().GetRTV();
+		D3D::context->OMSetRenderTargets(1, &rtv, FramebufferManager::GetEFBDepthTexture().GetDSV());
 		D3D::stateman->PopDepthState();
 		g_renderer->RestoreAPIState();
 
@@ -94,7 +100,7 @@ FramebufferManager::FramebufferManager()
 	sample_desc.Count = g_ActiveConfig.iMultisamples;
 	sample_desc.Quality = 0;
 
-	ID3D11Texture2D* buf;
+	ComPtr<ID3D11Texture2D> buf;
 	D3D11_TEXTURE2D_DESC texdesc;
 	HRESULT hr;
 
@@ -102,88 +108,84 @@ FramebufferManager::FramebufferManager()
 
 	// EFB color texture - primary render target
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB color texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.color_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
-	SAFE_RELEASE(buf);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetTex(), "EFB color texture");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetSRV(), "EFB color texture shader resource view");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_tex->GetRTV(), "EFB color texture render target view");
+	m_efb.color_tex.CreateFromExisting(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
+	buf.Reset();
+	D3D::SetDebugObjectName(m_efb.color_tex.GetTex(), "EFB color texture");
+	D3D::SetDebugObjectName(m_efb.color_tex.GetSRV(), "EFB color texture shader resource view");
+	D3D::SetDebugObjectName(m_efb.color_tex.GetRTV(), "EFB color texture render target view");
 
 	// Temporary EFB color texture - used in ReinterpretPixelData
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB color temp texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.color_temp_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
-	SAFE_RELEASE(buf);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetTex(), "EFB color temp texture");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetSRV(), "EFB color temp texture shader resource view");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_temp_tex->GetRTV(), "EFB color temp texture render target view");
+	m_efb.color_temp_tex.CreateFromExisting(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE|D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1));
+	buf.Reset();
+	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetTex(), "EFB color temp texture");
+	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetSRV(), "EFB color temp texture shader resource view");
+	D3D::SetDebugObjectName(m_efb.color_temp_tex.GetRTV(), "EFB color temp texture render target view");
 
 	// AccessEFB - Sysmem buffer used to retrieve the pixel data from color_tex
-	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.color_staging_buf);
-	CHECK(hr==S_OK, "create EFB color staging buffer (hr=%#x)", hr);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_staging_buf, "EFB color staging texture (used for Renderer::AccessEFB)");
+	m_efb.color_staging_buf = CreateStagingTexture(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, 1, m_efb.slices);
+	D3D::SetDebugObjectName(m_efb.color_staging_buf.Get(), "EFB color staging texture (used for Renderer::AccessEFB)");
 
 	// EFB depth buffer - primary depth buffer
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, sample_desc.Count, sample_desc.Quality);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB depth texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-	m_efb.depth_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL|D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1));
-	SAFE_RELEASE(buf);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetTex(), "EFB depth texture");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetDSV(), "EFB depth texture depth stencil view");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_tex->GetSRV(), "EFB depth texture shader resource view");
+	m_efb.depth_tex.CreateFromExisting(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL|D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1));
+	buf.Reset();
+	D3D::SetDebugObjectName(m_efb.depth_tex.GetTex(), "EFB depth texture");
+	D3D::SetDebugObjectName(m_efb.depth_tex.GetDSV(), "EFB depth texture depth stencil view");
+	D3D::SetDebugObjectName(m_efb.depth_tex.GetSRV(), "EFB depth texture shader resource view");
 
 	// Render buffer for AccessEFB (depth data)
 	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, D3D11_BIND_RENDER_TARGET);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 	CHECK(hr==S_OK, "create EFB depth read texture (hr=%#x)", hr);
-	m_efb.depth_read_texture = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
-	SAFE_RELEASE(buf);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_read_texture->GetTex(), "EFB depth read texture (used in Renderer::AccessEFB)");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_read_texture->GetRTV(), "EFB depth read texture render target view (used in Renderer::AccessEFB)");
+	m_efb.depth_read_texture.CreateFromExisting(buf.Get(), D3D11_BIND_RENDER_TARGET);
+	buf.Reset();
+	D3D::SetDebugObjectName(m_efb.depth_read_texture.GetTex(), "EFB depth read texture (used in Renderer::AccessEFB)");
+	D3D::SetDebugObjectName(m_efb.depth_read_texture.GetRTV(), "EFB depth read texture render target view (used in Renderer::AccessEFB)");
 
 	// AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture
-	texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, 1, 1, m_efb.slices, 1, 0, D3D11_USAGE_STAGING, D3D11_CPU_ACCESS_READ);
-	hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &m_efb.depth_staging_buf);
-	CHECK(hr==S_OK, "create EFB depth staging buffer (hr=%#x)", hr);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_staging_buf, "EFB depth staging texture (used for Renderer::AccessEFB)");
+	m_efb.depth_staging_buf = CreateStagingTexture(DXGI_FORMAT_R32_FLOAT, 1, 1, 1, m_efb.slices);
+	D3D::SetDebugObjectName(m_efb.depth_staging_buf.Get(), "EFB depth staging texture (used for Renderer::AccessEFB)");
 
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
 		// Framebuffer resolve textures (color+depth)
 		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0, 1);
-		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 		CHECK(hr==S_OK, "create EFB color resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_color_tex = new D3DTexture2D(buf, D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM);
-		SAFE_RELEASE(buf);
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetTex(), "EFB color resolve texture");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetSRV(), "EFB color resolve texture shader resource view");
+		m_efb.resolved_color_tex.CreateFromExisting(buf.Get(), D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM);
+		buf.Reset();
+		D3D::SetDebugObjectName(m_efb.resolved_color_tex.GetTex(), "EFB color resolve texture");
+		D3D::SetDebugObjectName(m_efb.resolved_color_tex.GetSRV(), "EFB color resolve texture shader resource view");
 
 		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL);
-		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
+		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, buf.GetAddressOf());
 		CHECK(hr==S_OK, "create EFB depth resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_depth_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL), DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT);
-		SAFE_RELEASE(buf);
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetTex(), "EFB depth resolve texture");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetSRV(), "EFB depth resolve texture shader resource view");
+		m_efb.resolved_depth_tex.CreateFromExisting(buf.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT);
+		buf.Reset();
+		D3D::SetDebugObjectName(m_efb.resolved_depth_tex.GetTex(), "EFB depth resolve texture");
+		D3D::SetDebugObjectName(m_efb.resolved_depth_tex.GetSRV(), "EFB depth resolve texture shader resource view");
 
 		// Depth state used when writing resolved depth texture
 		D3D11_DEPTH_STENCIL_DESC depth_resolve_depth_state = CD3D11_DEPTH_STENCIL_DESC(CD3D11_DEFAULT());
 		depth_resolve_depth_state.DepthEnable = TRUE;
 		depth_resolve_depth_state.DepthFunc = D3D11_COMPARISON_ALWAYS;
 		depth_resolve_depth_state.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;
-		hr = D3D::device->CreateDepthStencilState(&depth_resolve_depth_state, &m_depth_resolve_depth_state);
+		hr = D3D::device->CreateDepthStencilState(&depth_resolve_depth_state, m_depth_resolve_depth_state.GetAddressOf());
 		CHECK(hr == S_OK, "create depth resolve depth stencil state");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_depth_resolve_depth_state, "depth resolve depth stencil state");
+		D3D::SetDebugObjectName(m_depth_resolve_depth_state.Get(), "depth resolve depth stencil state");
 	}
 	else
 	{
-		m_efb.resolved_color_tex = nullptr;
-		m_efb.resolved_depth_tex = nullptr;
-		m_depth_resolve_depth_state = nullptr;
+		m_efb.resolved_color_tex.Reset();
+		m_efb.resolved_depth_tex.Reset();
+		m_depth_resolve_depth_state.Reset();
 	}
 
 	s_xfbEncoder.Init();
@@ -193,15 +195,15 @@ FramebufferManager::~FramebufferManager()
 {
 	s_xfbEncoder.Shutdown();
 
-	SAFE_RELEASE(m_efb.color_tex);
-	SAFE_RELEASE(m_efb.color_temp_tex);
-	SAFE_RELEASE(m_efb.color_staging_buf);
-	SAFE_RELEASE(m_efb.resolved_color_tex);
-	SAFE_RELEASE(m_efb.depth_tex);
-	SAFE_RELEASE(m_efb.depth_staging_buf);
-	SAFE_RELEASE(m_efb.depth_read_texture);
-	SAFE_RELEASE(m_efb.resolved_depth_tex);
-	SAFE_RELEASE(m_depth_resolve_depth_state);
+	m_efb.color_tex.Reset();
+	m_efb.color_temp_tex.Reset();
+	m_efb.color_staging_buf.Reset();
+	m_efb.resolved_color_tex.Reset();
+	m_efb.depth_tex.Reset();
+	m_efb.depth_staging_buf.Reset();
+	m_efb.depth_read_texture.Reset();
+	m_efb.resolved_depth_tex.Reset();
+	m_depth_resolve_depth_state.Reset();
 }
 
 void FramebufferManager::CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, const EFBRectangle& sourceRc,float Gamma)
@@ -213,9 +215,11 @@ void FramebufferManager::CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, 
 
 std::unique_ptr<XFBSourceBase> FramebufferManager::CreateXFBSource(unsigned int target_width, unsigned int target_height, unsigned int layers)
 {
-	return std::make_unique<XFBSource>(D3DTexture2D::Create(target_width, target_height,
-		(D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET|D3D11_BIND_SHADER_RESOURCE),
-		D3D11_USAGE_DEFAULT, DXGI_FORMAT_R8G8B8A8_UNORM, 1, layers), layers);
+	D3DTexture2D texture;
+	texture.Create(DXGI_FORMAT_R8G8B8A8_UNORM, target_width, target_height,
+		(D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE),
+		D3D11_USAGE_DEFAULT, 1, layers);
+	return std::make_unique<XFBSource>(std::move(texture), layers);
 }
 
 void FramebufferManager::GetTargetSize(unsigned int *width, unsigned int *height)
@@ -239,16 +243,16 @@ void XFBSource::CopyEFB(float Gamma)
 	const D3D11_RECT rect = CD3D11_RECT(0, 0, texWidth, texHeight);
 
 	D3D::context->RSSetViewports(1, &vp);
-	D3D::context->OMSetRenderTargets(1, &tex->GetRTV(), nullptr);
+	D3D::SetRenderTarget(tex.GetRTV(), nullptr);
 	D3D::SetPointCopySampler();
 
-	D3D::drawShadedTexQuad(FramebufferManager::GetEFBColorTexture()->GetSRV(), &rect,
+	D3D::drawShadedTexQuad(FramebufferManager::GetEFBColorTexture().GetSRV(), &rect,
 		Renderer::GetTargetWidth(), Renderer::GetTargetHeight(), PixelShaderCache::GetColorCopyProgram(true),
 		VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
 		GeometryShaderCache::GetCopyGeometryShader(), Gamma);
 
-	D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
-		FramebufferManager::GetEFBDepthTexture()->GetDSV());
+	D3D::SetRenderTarget(FramebufferManager::GetEFBColorTexture().GetRTV(),
+		FramebufferManager::GetEFBDepthTexture().GetDSV());
 
 	g_renderer->RestoreAPIState();
 }

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -46,13 +46,12 @@ namespace DX11
 
 struct XFBSource : public XFBSourceBase
 {
-	XFBSource(D3DTexture2D *_tex, int slices) : tex(_tex), m_slices(slices) {}
-	~XFBSource() { tex->Release(); }
+	XFBSource(D3DTexture2D&& _tex, int slices) : tex(_tex), m_slices(slices) {}
 
 	void DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight) override;
 	void CopyEFB(float Gamma) override;
 
-	D3DTexture2D* const tex;
+	D3DTexture2D tex;
 	const int m_slices;
 };
 
@@ -62,22 +61,20 @@ public:
 	FramebufferManager();
 	~FramebufferManager();
 
-	static D3DTexture2D* &GetEFBColorTexture();
-	static ID3D11Texture2D* &GetEFBColorStagingBuffer();
+	static D3DTexture2D& GetEFBColorTexture();
+	static ID3D11Texture2D* GetEFBColorStagingBuffer();
 
-	static D3DTexture2D* &GetEFBDepthTexture();
-	static D3DTexture2D* &GetEFBDepthReadTexture();
-	static ID3D11Texture2D* &GetEFBDepthStagingBuffer();
+	static D3DTexture2D& GetEFBDepthTexture();
+	static D3DTexture2D& GetEFBDepthReadTexture();
+	static ID3D11Texture2D* GetEFBDepthStagingBuffer();
 
-	static D3DTexture2D* &GetResolvedEFBColorTexture();
-	static D3DTexture2D* &GetResolvedEFBDepthTexture();
+	static D3DTexture2D& GetResolvedEFBColorTexture();
+	static D3DTexture2D& GetResolvedEFBDepthTexture();
 
-	static D3DTexture2D* &GetEFBColorTempTexture() { return m_efb.color_temp_tex; }
+	static D3DTexture2D& GetEFBColorTempTexture() { return m_efb.color_temp_tex; }
 	static void SwapReinterpretTexture()
 	{
-		D3DTexture2D* swaptex = GetEFBColorTempTexture();
-		m_efb.color_temp_tex = GetEFBColorTexture();
-		m_efb.color_tex = swaptex;
+		std::swap(GetEFBColorTexture(), GetEFBColorTempTexture());
 	}
 
 private:
@@ -88,24 +85,24 @@ private:
 
 	static struct Efb
 	{
-		D3DTexture2D* color_tex;
-		ID3D11Texture2D* color_staging_buf;
+		D3DTexture2D color_tex;
+		ComPtr<ID3D11Texture2D> color_staging_buf;
 
-		D3DTexture2D* depth_tex;
-		ID3D11Texture2D* depth_staging_buf;
-		D3DTexture2D* depth_read_texture;
+		D3DTexture2D depth_tex;
+		ComPtr<ID3D11Texture2D> depth_staging_buf;
+		D3DTexture2D depth_read_texture;
 
-		D3DTexture2D* color_temp_tex;
+		D3DTexture2D color_temp_tex;
 
-		D3DTexture2D* resolved_color_tex;
-		D3DTexture2D* resolved_depth_tex;
+		D3DTexture2D resolved_color_tex;
+		D3DTexture2D resolved_depth_tex;
 
 		int slices;
 	} m_efb;
 
 	static unsigned int m_target_width;
 	static unsigned int m_target_height;
-	static ID3D11DepthStencilState* m_depth_resolve_depth_state;
+	static ComPtr<ID3D11DepthStencilState> m_depth_resolve_depth_state;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -30,30 +30,30 @@ GeometryShaderUid GeometryShaderCache::last_uid;
 UidChecker<GeometryShaderUid,ShaderCode> GeometryShaderCache::geometry_uid_checker;
 const GeometryShaderCache::GSCacheEntry GeometryShaderCache::pass_entry;
 
-ID3D11GeometryShader* ClearGeometryShader = nullptr;
-ID3D11GeometryShader* CopyGeometryShader = nullptr;
+ComPtr<ID3D11GeometryShader> ClearGeometryShader = nullptr;
+ComPtr<ID3D11GeometryShader> CopyGeometryShader = nullptr;
 
 LinearDiskCache<GeometryShaderUid, u8> g_gs_disk_cache;
 
-ID3D11GeometryShader* GeometryShaderCache::GetClearGeometryShader() { return (g_ActiveConfig.iStereoMode > 0) ? ClearGeometryShader: nullptr; }
-ID3D11GeometryShader* GeometryShaderCache::GetCopyGeometryShader() { return (g_ActiveConfig.iStereoMode > 0) ? CopyGeometryShader : nullptr; }
+ID3D11GeometryShader* GeometryShaderCache::GetClearGeometryShader() { return (g_ActiveConfig.iStereoMode > 0) ? ClearGeometryShader.Get() : nullptr; }
+ID3D11GeometryShader* GeometryShaderCache::GetCopyGeometryShader() { return (g_ActiveConfig.iStereoMode > 0) ? CopyGeometryShader.Get() : nullptr; }
 
-ID3D11Buffer* gscbuf = nullptr;
+ComPtr<ID3D11Buffer> gscbuf = nullptr;
 
-ID3D11Buffer* &GeometryShaderCache::GetConstantBuffer()
+ID3D11Buffer* GeometryShaderCache::GetConstantBuffer()
 {
 	// TODO: divide the global variables of the generated shaders into about 5 constant buffers to speed this up
 	if (GeometryShaderManager::dirty)
 	{
 		D3D11_MAPPED_SUBRESOURCE map;
-		D3D::context->Map(gscbuf, 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
+		D3D::context->Map(gscbuf.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
 		memcpy(map.pData, &GeometryShaderManager::constants, sizeof(GeometryShaderConstants));
-		D3D::context->Unmap(gscbuf, 0);
+		D3D::context->Unmap(gscbuf.Get(), 0);
 		GeometryShaderManager::dirty = false;
 
 		ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(GeometryShaderConstants));
 	}
-	return gscbuf;
+	return gscbuf.Get();
 }
 
 // this class will load the precompiled shaders into our cache
@@ -134,19 +134,19 @@ void GeometryShaderCache::Init()
 {
 	unsigned int gbsize = ROUND_UP(sizeof(GeometryShaderConstants), 16); // must be a multiple of 16
 	D3D11_BUFFER_DESC gbdesc = CD3D11_BUFFER_DESC(gbsize, D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
-	HRESULT hr = D3D::device->CreateBuffer(&gbdesc, nullptr, &gscbuf);
+	HRESULT hr = D3D::device->CreateBuffer(&gbdesc, nullptr, gscbuf.GetAddressOf());
 	CHECK(hr == S_OK, "Create geometry shader constant buffer (size=%u)", gbsize);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)gscbuf, "geometry shader constant buffer used to emulate the GX pipeline");
+	D3D::SetDebugObjectName(gscbuf.Get(), "geometry shader constant buffer used to emulate the GX pipeline");
 
 	// used when drawing clear quads
 	ClearGeometryShader = D3D::CompileAndCreateGeometryShader(clear_shader_code);
 	CHECK(ClearGeometryShader != nullptr, "Create clear geometry shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)ClearGeometryShader, "clear geometry shader");
+	D3D::SetDebugObjectName(ClearGeometryShader.Get(), "clear geometry shader");
 
 	// used for buffer copy
 	CopyGeometryShader = D3D::CompileAndCreateGeometryShader(copy_shader_code);
 	CHECK(CopyGeometryShader != nullptr, "Create copy geometry shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)CopyGeometryShader, "copy geometry shader");
+	D3D::SetDebugObjectName(CopyGeometryShader.Get(), "copy geometry shader");
 
 	Clear();
 
@@ -177,10 +177,9 @@ void GeometryShaderCache::Clear()
 
 void GeometryShaderCache::Shutdown()
 {
-	SAFE_RELEASE(gscbuf);
-
-	SAFE_RELEASE(ClearGeometryShader);
-	SAFE_RELEASE(CopyGeometryShader);
+	gscbuf.Reset();
+	ClearGeometryShader.Reset();
+	CopyGeometryShader.Reset();
 
 	Clear();
 	g_gs_disk_cache.Sync();
@@ -253,12 +252,12 @@ bool GeometryShaderCache::SetShader(u32 primitive_type)
 
 bool GeometryShaderCache::InsertByteCode(const GeometryShaderUid &uid, const void* bytecode, unsigned int bytecodelen)
 {
-	ID3D11GeometryShader* shader = D3D::CreateGeometryShaderFromByteCode(bytecode, bytecodelen);
+	ComPtr<ID3D11GeometryShader> shader = D3D::CreateGeometryShaderFromByteCode(bytecode, bytecodelen);
 	if (shader == nullptr)
 		return false;
 
 	// TODO: Somehow make the debug name a bit more specific
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)shader, "a pixel shader of GeometryShaderCache");
+	D3D::SetDebugObjectName(shader.Get(), "a pixel shader of GeometryShaderCache");
 
 	// Make an entry in the table
 	GSCacheEntry newentry;

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
@@ -24,18 +24,18 @@ public:
 	static ID3D11GeometryShader* GeometryShaderCache::GetClearGeometryShader();
 	static ID3D11GeometryShader* GeometryShaderCache::GetCopyGeometryShader();
 
-	static ID3D11GeometryShader* GetActiveShader() { return last_entry->shader; }
-	static ID3D11Buffer* &GetConstantBuffer();
+	static ID3D11GeometryShader* GetActiveShader() { return last_entry->shader.Get(); }
+	static ID3D11Buffer* GetConstantBuffer();
 
 private:
 	struct GSCacheEntry
 	{
-		ID3D11GeometryShader* shader;
+		ComPtr<ID3D11GeometryShader> shader;
 
 		std::string code;
 
 		GSCacheEntry() : shader(nullptr) {}
-		void Destroy() { SAFE_RELEASE(shader); }
+		void Destroy() { shader.Reset(); }
 	};
 
 	typedef std::map<GeometryShaderUid, GSCacheEntry> GSCache;

--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -18,7 +18,6 @@ class D3DVertexFormat : public NativeVertexFormat
 {
 public:
 	D3DVertexFormat(const PortableVertexDeclaration& vtx_decl);
-	~D3DVertexFormat() { SAFE_RELEASE(m_layout); }
 
 	void SetupVertexPointers() override;
 
@@ -26,7 +25,7 @@ private:
 	std::array<D3D11_INPUT_ELEMENT_DESC, 32> m_elems{};
 	UINT m_num_elems = 0;
 
-	ID3D11InputLayout* m_layout = nullptr;
+	ComPtr<ID3D11InputLayout> m_layout = nullptr;
 };
 
 NativeVertexFormat* VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
@@ -136,11 +135,11 @@ void D3DVertexFormat::SetupVertexPointers()
 		// changes.
 		D3DBlob* vs_bytecode = DX11::VertexShaderCache::GetActiveShaderBytecode();
 
-		HRESULT hr = DX11::D3D::device->CreateInputLayout(m_elems.data(), m_num_elems, vs_bytecode->Data(), vs_bytecode->Size(), &m_layout);
+		HRESULT hr = DX11::D3D::device->CreateInputLayout(m_elems.data(), m_num_elems, vs_bytecode->Data(), vs_bytecode->Size(), m_layout.GetAddressOf());
 		if (FAILED(hr)) PanicAlert("Failed to create input layout, %s %d\n", __FILE__, __LINE__);
-		DX11::D3D::SetDebugObjectName((ID3D11DeviceChild*)m_layout, "input layout used to emulate the GX pipeline");
+		DX11::D3D::SetDebugObjectName(m_layout.Get(), "input layout used to emulate the GX pipeline");
 	}
-	DX11::D3D::stateman->SetInputLayout(m_layout);
+	DX11::D3D::stateman->SetInputLayout(m_layout.Get());
 }
 
 } // namespace DX11

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -27,8 +27,7 @@ struct EFBEncodeParams
 };
 
 PSTextureEncoder::PSTextureEncoder()
-	: m_ready(false), m_out(nullptr), m_outRTV(nullptr), m_outStage(nullptr),
-	m_encodeParams(nullptr)
+	: m_ready(false)
 {
 }
 
@@ -39,34 +38,20 @@ void PSTextureEncoder::Init()
 	HRESULT hr;
 
 	// Create output texture RGBA format
-	D3D11_TEXTURE2D_DESC t2dd = CD3D11_TEXTURE2D_DESC(
-		DXGI_FORMAT_B8G8R8A8_UNORM,
-		EFB_WIDTH * 4, EFB_HEIGHT / 4, 1, 1, D3D11_BIND_RENDER_TARGET);
-	hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_out);
-	CHECK(SUCCEEDED(hr), "create efb encode output texture");
-	D3D::SetDebugObjectName(m_out, "efb encoder output texture");
-
-	// Create output render target view
-	D3D11_RENDER_TARGET_VIEW_DESC rtvd = CD3D11_RENDER_TARGET_VIEW_DESC(m_out,
-		D3D11_RTV_DIMENSION_TEXTURE2D, DXGI_FORMAT_B8G8R8A8_UNORM);
-	hr = D3D::device->CreateRenderTargetView(m_out, &rtvd, &m_outRTV);
-	CHECK(SUCCEEDED(hr), "create efb encode output render target view");
-	D3D::SetDebugObjectName(m_outRTV, "efb encoder output rtv");
+	m_out.Create(DXGI_FORMAT_B8G8R8A8_UNORM, EFB_WIDTH * 4, EFB_HEIGHT / 4, D3D11_BIND_RENDER_TARGET);
+	D3D::SetDebugObjectName(m_out.GetTex(), "efb encoder output texture");
+	D3D::SetDebugObjectName(m_out.GetRTV(), "efb encoder output rtv");
 
 	// Create output staging buffer
-	t2dd.Usage = D3D11_USAGE_STAGING;
-	t2dd.BindFlags = 0;
-	t2dd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-	hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_outStage);
-	CHECK(SUCCEEDED(hr), "create efb encode output staging buffer");
-	D3D::SetDebugObjectName(m_outStage, "efb encoder output staging buffer");
+	m_outStage = CreateStagingTexture(DXGI_FORMAT_B8G8R8A8_UNORM, EFB_WIDTH * 4, EFB_HEIGHT / 4);
+	D3D::SetDebugObjectName(m_outStage.Get(), "efb encoder output staging buffer");
 
 	// Create constant buffer for uploading data to shaders
 	D3D11_BUFFER_DESC bd = CD3D11_BUFFER_DESC(sizeof(EFBEncodeParams),
 		D3D11_BIND_CONSTANT_BUFFER);
-	hr = D3D::device->CreateBuffer(&bd, nullptr, &m_encodeParams);
+	hr = D3D::device->CreateBuffer(&bd, nullptr, m_encodeParams.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create efb encode params buffer");
-	D3D::SetDebugObjectName(m_encodeParams, "efb encoder params buffer");
+	D3D::SetDebugObjectName(m_encodeParams.Get(), "efb encoder params buffer");
 
 	m_ready = true;
 }
@@ -75,16 +60,11 @@ void PSTextureEncoder::Shutdown()
 {
 	m_ready = false;
 
-	for (auto& it : m_staticShaders)
-	{
-		SAFE_RELEASE(it.second);
-	}
 	m_staticShaders.clear();
 
-	SAFE_RELEASE(m_encodeParams);
-	SAFE_RELEASE(m_outStage);
-	SAFE_RELEASE(m_outRTV);
-	SAFE_RELEASE(m_out);
+	m_encodeParams.Reset();
+	m_outStage.Reset();
+	m_out.Reset();
 }
 
 void PSTextureEncoder::Encode(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
@@ -98,11 +78,11 @@ void PSTextureEncoder::Encode(u8* dst, u32 format, u32 native_width, u32 bytes_p
 
 	// Resolve MSAA targets before copying.
 	ID3D11ShaderResourceView* pEFB = (srcFormat == PEControl::Z24) ?
-			FramebufferManager::GetResolvedEFBDepthTexture()->GetSRV() :
+			FramebufferManager::GetResolvedEFBDepthTexture().GetSRV() :
 			// FIXME: Instead of resolving EFB, it would be better to pick out a
 			// single sample from each pixel. The game may break if it isn't
 			// expecting the blurred edges around multisampled shapes.
-			FramebufferManager::GetResolvedEFBColorTexture()->GetSRV();
+			FramebufferManager::GetResolvedEFBColorTexture().GetSRV();
 
 	// Reset API
 	g_renderer->ResetAPIState();
@@ -117,15 +97,15 @@ void PSTextureEncoder::Encode(u8* dst, u32 format, u32 native_width, u32 bytes_p
 		constexpr EFBRectangle fullSrcRect(0, 0, EFB_WIDTH, EFB_HEIGHT);
 		TargetRectangle targetRect = g_renderer->ConvertEFBRectangle(fullSrcRect);
 
-		D3D::context->OMSetRenderTargets(1, &m_outRTV, nullptr);
+		D3D::SetRenderTarget(m_out.GetRTV(), nullptr);
 
 		EFBEncodeParams params;
 		params.SrcLeft = srcRect.left;
 		params.SrcTop = srcRect.top;
 		params.DestWidth = native_width;
 		params.ScaleFactor = scaleByHalf ? 2 : 1;
-		D3D::context->UpdateSubresource(m_encodeParams, 0, nullptr, &params, 0, 0);
-		D3D::stateman->SetPixelConstants(m_encodeParams);
+		D3D::context->UpdateSubresource(m_encodeParams.Get(), 0, nullptr, &params, 0, 0);
+		D3D::stateman->SetPixelConstants(m_encodeParams.Get());
 
 		// Use linear filtering if (bScaleByHalf), use point filtering otherwise
 		if (scaleByHalf)
@@ -143,11 +123,11 @@ void PSTextureEncoder::Encode(u8* dst, u32 format, u32 native_width, u32 bytes_p
 
 		// Copy to staging buffer
 		D3D11_BOX srcBox = CD3D11_BOX(0, 0, 0, words_per_row, num_blocks_y, 1);
-		D3D::context->CopySubresourceRegion(m_outStage, 0, 0, 0, 0, m_out, 0, &srcBox);
+		D3D::context->CopySubresourceRegion(m_outStage.Get(), 0, 0, 0, 0, m_out.GetTex(), 0, &srcBox);
 
 		// Transfer staging buffer to GameCube/Wii RAM
 		D3D11_MAPPED_SUBRESOURCE map = { 0 };
-		hr = D3D::context->Map(m_outStage, 0, D3D11_MAP_READ, 0, &map);
+		hr = D3D::context->Map(m_outStage.Get(), 0, D3D11_MAP_READ, 0, &map);
 		CHECK(SUCCEEDED(hr), "map staging buffer (0x%x)", hr);
 
 		u8* src = (u8*)map.pData;
@@ -159,14 +139,14 @@ void PSTextureEncoder::Encode(u8* dst, u32 format, u32 native_width, u32 bytes_p
 			src += map.RowPitch;
 		}
 
-		D3D::context->Unmap(m_outStage, 0);
+		D3D::context->Unmap(m_outStage.Get(), 0);
 	}
 
 	// Restore API
 	g_renderer->RestoreAPIState();
-	D3D::context->OMSetRenderTargets(1,
-		&FramebufferManager::GetEFBColorTexture()->GetRTV(),
-		FramebufferManager::GetEFBDepthTexture()->GetDSV());
+	D3D::SetRenderTarget(
+		FramebufferManager::GetEFBColorTexture().GetRTV(),
+		FramebufferManager::GetEFBDepthTexture().GetDSV());
 }
 
 ID3D11PixelShader* PSTextureEncoder::SetStaticShader(unsigned int dstFormat, PEControl::PixelFormat srcFormat,
@@ -211,20 +191,20 @@ ID3D11PixelShader* PSTextureEncoder::SetStaticShader(unsigned int dstFormat, PEC
 			return nullptr;
 		}
 
-		ID3D11PixelShader* newShader;
-		HRESULT hr = D3D::device->CreatePixelShader(bytecode->Data(), bytecode->Size(), nullptr, &newShader);
+		ComPtr<ID3D11PixelShader> newShader;
+		HRESULT hr = D3D::device->CreatePixelShader(bytecode->Data(), bytecode->Size(), nullptr, newShader.GetAddressOf());
 		CHECK(SUCCEEDED(hr), "create efb encoder pixel shader");
 
 		char debugName[255] = {};
 		sprintf_s(debugName, "efb encoder pixel shader (dst:%d, src:%d, intensity:%d, scale:%d)",
 			dstFormat, srcFormat, isIntensity, scaleByHalf);
-		D3D::SetDebugObjectName(newShader, debugName);
+		D3D::SetDebugObjectName(newShader.Get(), debugName);
 
 		it = m_staticShaders.emplace(key, newShader).first;
 		bytecode->Release();
 	}
 
-	return it->second;
+	return it->second.Get();
 }
 
 }

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -6,6 +6,7 @@
 
 #include "VideoBackends/D3D/TextureEncoder.h"
 
+#include "VideoBackends/D3D/D3DTexture.h"
 #include "VideoCommon/TextureCacheBase.h"
 
 struct ID3D11Texture2D;
@@ -38,10 +39,9 @@ public:
 private:
 	bool m_ready;
 
-	ID3D11Texture2D* m_out;
-	ID3D11RenderTargetView* m_outRTV;
-	ID3D11Texture2D* m_outStage;
-	ID3D11Buffer* m_encodeParams;
+	D3DTexture2D m_out;
+	ComPtr<ID3D11Texture2D> m_outStage;
+	ComPtr<ID3D11Buffer> m_encodeParams;
 
 	ID3D11PixelShader* SetStaticShader(unsigned int dstFormat,
 		PEControl::PixelFormat srcFormat, bool isIntensity, bool scaleByHalf);
@@ -55,7 +55,7 @@ private:
 			| (scaleByHalf ? (1<<0) : 0);
 	}
 
-	typedef std::map<ComboKey, ID3D11PixelShader*> ComboMap;
+	typedef std::map<ComboKey, ComPtr<ID3D11PixelShader>> ComboMap;
 
 	ComboMap m_staticShaders;
 };

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -31,15 +31,15 @@ UidChecker<PixelShaderUid, ShaderCode> PixelShaderCache::pixel_uid_checker;
 
 LinearDiskCache<PixelShaderUid, u8> g_ps_disk_cache;
 
-ID3D11PixelShader* s_ColorMatrixProgram[2] = {nullptr};
-ID3D11PixelShader* s_ColorCopyProgram[2] = {nullptr};
-ID3D11PixelShader* s_DepthMatrixProgram[2] = {nullptr};
-ID3D11PixelShader* s_ClearProgram = nullptr;
-ID3D11PixelShader* s_AnaglyphProgram = nullptr;
-ID3D11PixelShader* s_DepthResolveProgram = nullptr;
-ID3D11PixelShader* s_rgba6_to_rgb8[2] = {nullptr};
-ID3D11PixelShader* s_rgb8_to_rgba6[2] = {nullptr};
-ID3D11Buffer* pscbuf = nullptr;
+ComPtr<ID3D11PixelShader> s_ColorMatrixProgram[2] = {nullptr};
+ComPtr<ID3D11PixelShader> s_ColorCopyProgram[2] = {nullptr};
+ComPtr<ID3D11PixelShader> s_DepthMatrixProgram[2] = {nullptr};
+ComPtr<ID3D11PixelShader> s_ClearProgram = nullptr;
+ComPtr<ID3D11PixelShader> s_AnaglyphProgram = nullptr;
+ComPtr<ID3D11PixelShader> s_DepthResolveProgram = nullptr;
+ComPtr<ID3D11PixelShader> s_rgba6_to_rgb8[2] = {nullptr};
+ComPtr<ID3D11PixelShader> s_rgb8_to_rgba6[2] = {nullptr};
+ComPtr<ID3D11Buffer> pscbuf = nullptr;
 
 const char clear_program_code[] = {
 	"void main(\n"
@@ -310,9 +310,9 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGBA6ToRGB8(bool multisampled)
 		{
 			s_rgba6_to_rgb8[0] = D3D::CompileAndCreatePixelShader(reint_rgba6_to_rgb8);
 			CHECK(s_rgba6_to_rgb8[0], "Create RGBA6 to RGB8 pixel shader");
-			D3D::SetDebugObjectName(s_rgba6_to_rgb8[0], "RGBA6 to RGB8 pixel shader");
+			D3D::SetDebugObjectName(s_rgba6_to_rgb8[0].Get(), "RGBA6 to RGB8 pixel shader");
 		}
-		return s_rgba6_to_rgb8[0];
+		return s_rgba6_to_rgb8[0].Get();
 	}
 	else if (!s_rgba6_to_rgb8[1])
 	{
@@ -321,9 +321,9 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGBA6ToRGB8(bool multisampled)
 		s_rgba6_to_rgb8[1] = D3D::CompileAndCreatePixelShader(buf);
 
 		CHECK(s_rgba6_to_rgb8[1], "Create RGBA6 to RGB8 MSAA pixel shader");
-		D3D::SetDebugObjectName(s_rgba6_to_rgb8[1], "RGBA6 to RGB8 MSAA pixel shader");
+		D3D::SetDebugObjectName(s_rgba6_to_rgb8[1].Get(), "RGBA6 to RGB8 MSAA pixel shader");
 	}
-	return s_rgba6_to_rgb8[1];
+	return s_rgba6_to_rgb8[1].Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
@@ -334,9 +334,9 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
 		{
 			s_rgb8_to_rgba6[0] = D3D::CompileAndCreatePixelShader(reint_rgb8_to_rgba6);
 			CHECK(s_rgb8_to_rgba6[0], "Create RGB8 to RGBA6 pixel shader");
-			D3D::SetDebugObjectName(s_rgb8_to_rgba6[0], "RGB8 to RGBA6 pixel shader");
+			D3D::SetDebugObjectName(s_rgb8_to_rgba6[0].Get(), "RGB8 to RGBA6 pixel shader");
 		}
-		return s_rgb8_to_rgba6[0];
+		return s_rgb8_to_rgba6[0].Get();
 	}
 	else if (!s_rgb8_to_rgba6[1])
 	{
@@ -345,20 +345,20 @@ ID3D11PixelShader* PixelShaderCache::ReinterpRGB8ToRGBA6(bool multisampled)
 		s_rgb8_to_rgba6[1] = D3D::CompileAndCreatePixelShader(buf);
 
 		CHECK(s_rgb8_to_rgba6[1], "Create RGB8 to RGBA6 MSAA pixel shader");
-		D3D::SetDebugObjectName(s_rgb8_to_rgba6[1], "RGB8 to RGBA6 MSAA pixel shader");
+		D3D::SetDebugObjectName(s_rgb8_to_rgba6[1].Get(), "RGB8 to RGBA6 MSAA pixel shader");
 	}
-	return s_rgb8_to_rgba6[1];
+	return s_rgb8_to_rgba6[1].Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::GetColorCopyProgram(bool multisampled)
 {
 	if (!multisampled || g_ActiveConfig.iMultisamples <= 1)
 	{
-		return s_ColorCopyProgram[0];
+		return s_ColorCopyProgram[0].Get();
 	}
 	else if (s_ColorCopyProgram[1])
 	{
-		return s_ColorCopyProgram[1];
+		return s_ColorCopyProgram[1].Get();
 	}
 	else
 	{
@@ -366,8 +366,8 @@ ID3D11PixelShader* PixelShaderCache::GetColorCopyProgram(bool multisampled)
 		std::string buf = StringFromFormat(color_copy_program_code_msaa, g_ActiveConfig.iMultisamples);
 		s_ColorCopyProgram[1] = D3D::CompileAndCreatePixelShader(buf);
 		CHECK(s_ColorCopyProgram[1]!=nullptr, "Create color copy MSAA pixel shader");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[1], "color copy MSAA pixel shader");
-		return s_ColorCopyProgram[1];
+		D3D::SetDebugObjectName(s_ColorCopyProgram[1].Get(), "color copy MSAA pixel shader");
+		return s_ColorCopyProgram[1].Get();
 	}
 }
 
@@ -375,11 +375,11 @@ ID3D11PixelShader* PixelShaderCache::GetColorMatrixProgram(bool multisampled)
 {
 	if (!multisampled || g_ActiveConfig.iMultisamples <= 1)
 	{
-		return s_ColorMatrixProgram[0];
+		return s_ColorMatrixProgram[0].Get();
 	}
 	else if (s_ColorMatrixProgram[1])
 	{
-		return s_ColorMatrixProgram[1];
+		return s_ColorMatrixProgram[1].Get();
 	}
 	else
 	{
@@ -387,8 +387,8 @@ ID3D11PixelShader* PixelShaderCache::GetColorMatrixProgram(bool multisampled)
 		std::string buf = StringFromFormat(color_matrix_program_code_msaa, g_ActiveConfig.iMultisamples);
 		s_ColorMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
 		CHECK(s_ColorMatrixProgram[1]!=nullptr, "Create color matrix MSAA pixel shader");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[1], "color matrix MSAA pixel shader");
-		return s_ColorMatrixProgram[1];
+		D3D::SetDebugObjectName(s_ColorMatrixProgram[1].Get(), "color matrix MSAA pixel shader");
+		return s_ColorMatrixProgram[1].Get();
 	}
 }
 
@@ -396,11 +396,11 @@ ID3D11PixelShader* PixelShaderCache::GetDepthMatrixProgram(bool multisampled)
 {
 	if (!multisampled || g_ActiveConfig.iMultisamples <= 1)
 	{
-		return s_DepthMatrixProgram[0];
+		return s_DepthMatrixProgram[0].Get();
 	}
 	else if (s_DepthMatrixProgram[1])
 	{
-		return s_DepthMatrixProgram[1];
+		return s_DepthMatrixProgram[1].Get();
 	}
 	else
 	{
@@ -408,48 +408,48 @@ ID3D11PixelShader* PixelShaderCache::GetDepthMatrixProgram(bool multisampled)
 		std::string buf = StringFromFormat(depth_matrix_program_msaa, g_ActiveConfig.iMultisamples);
 		s_DepthMatrixProgram[1] = D3D::CompileAndCreatePixelShader(buf);
 		CHECK(s_DepthMatrixProgram[1]!=nullptr, "Create depth matrix MSAA pixel shader");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[1], "depth matrix MSAA pixel shader");
-		return s_DepthMatrixProgram[1];
+		D3D::SetDebugObjectName(s_DepthMatrixProgram[1].Get(), "depth matrix MSAA pixel shader");
+		return s_DepthMatrixProgram[1].Get();
 	}
 }
 
 ID3D11PixelShader* PixelShaderCache::GetClearProgram()
 {
-	return s_ClearProgram;
+	return s_ClearProgram.Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::GetAnaglyphProgram()
 {
-	return s_AnaglyphProgram;
+	return s_AnaglyphProgram.Get();
 }
 
 ID3D11PixelShader* PixelShaderCache::GetDepthResolveProgram()
 {
 	if (s_DepthResolveProgram != nullptr)
-		return s_DepthResolveProgram;
+		return s_DepthResolveProgram.Get();
 
 	// create MSAA shader for current AA mode
 	std::string buf = StringFromFormat(depth_resolve_program, g_ActiveConfig.iMultisamples);
 	s_DepthResolveProgram = D3D::CompileAndCreatePixelShader(buf);
 	CHECK(s_DepthResolveProgram != nullptr, "Create depth matrix MSAA pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthResolveProgram, "depth resolve pixel shader");
-	return s_DepthResolveProgram;
+	D3D::SetDebugObjectName(s_DepthResolveProgram.Get(), "depth resolve pixel shader");
+	return s_DepthResolveProgram.Get();
 }
 
-ID3D11Buffer* &PixelShaderCache::GetConstantBuffer()
+ID3D11Buffer* PixelShaderCache::GetConstantBuffer()
 {
 	// TODO: divide the global variables of the generated shaders into about 5 constant buffers to speed this up
 	if (PixelShaderManager::dirty)
 	{
 		D3D11_MAPPED_SUBRESOURCE map;
-		D3D::context->Map(pscbuf, 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
+		D3D::context->Map(pscbuf.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
 		memcpy(map.pData, &PixelShaderManager::constants, sizeof(PixelShaderConstants));
-		D3D::context->Unmap(pscbuf, 0);
+		D3D::context->Unmap(pscbuf.Get(), 0);
 		PixelShaderManager::dirty = false;
 
 		ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(PixelShaderConstants));
 	}
-	return pscbuf;
+	return pscbuf.Get();
 }
 
 // this class will load the precompiled shaders into our cache
@@ -466,34 +466,34 @@ void PixelShaderCache::Init()
 {
 	unsigned int cbsize = ROUND_UP(sizeof(PixelShaderConstants), 16); // must be a multiple of 16
 	D3D11_BUFFER_DESC cbdesc = CD3D11_BUFFER_DESC(cbsize, D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
-	D3D::device->CreateBuffer(&cbdesc, nullptr, &pscbuf);
+	D3D::device->CreateBuffer(&cbdesc, nullptr, pscbuf.GetAddressOf());
 	CHECK(pscbuf!=nullptr, "Create pixel shader constant buffer");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)pscbuf, "pixel shader constant buffer used to emulate the GX pipeline");
+	D3D::SetDebugObjectName(pscbuf.Get(), "pixel shader constant buffer used to emulate the GX pipeline");
 
 	// used when drawing clear quads
 	s_ClearProgram = D3D::CompileAndCreatePixelShader(clear_program_code);
 	CHECK(s_ClearProgram!=nullptr, "Create clear pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ClearProgram, "clear pixel shader");
+	D3D::SetDebugObjectName(s_ClearProgram.Get(), "clear pixel shader");
 
 	// used for anaglyph stereoscopy
 	s_AnaglyphProgram = D3D::CompileAndCreatePixelShader(anaglyph_program_code);
 	CHECK(s_AnaglyphProgram != nullptr, "Create anaglyph pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_AnaglyphProgram, "anaglyph pixel shader");
+	D3D::SetDebugObjectName(s_AnaglyphProgram.Get(), "anaglyph pixel shader");
 
 	// used when copying/resolving the color buffer
 	s_ColorCopyProgram[0] = D3D::CompileAndCreatePixelShader(color_copy_program_code);
 	CHECK(s_ColorCopyProgram[0]!=nullptr, "Create color copy pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorCopyProgram[0], "color copy pixel shader");
+	D3D::SetDebugObjectName(s_ColorCopyProgram[0].Get(), "color copy pixel shader");
 
 	// used for color conversion
 	s_ColorMatrixProgram[0] = D3D::CompileAndCreatePixelShader(color_matrix_program_code);
 	CHECK(s_ColorMatrixProgram[0]!=nullptr, "Create color matrix pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_ColorMatrixProgram[0], "color matrix pixel shader");
+	D3D::SetDebugObjectName(s_ColorMatrixProgram[0].Get(), "color matrix pixel shader");
 
 	// used for depth copy
 	s_DepthMatrixProgram[0] = D3D::CompileAndCreatePixelShader(depth_matrix_program);
 	CHECK(s_DepthMatrixProgram[0]!=nullptr, "Create depth matrix pixel shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)s_DepthMatrixProgram[0], "depth matrix pixel shader");
+	D3D::SetDebugObjectName(s_DepthMatrixProgram[0].Get(), "depth matrix pixel shader");
 
 	Clear();
 
@@ -528,28 +528,28 @@ void PixelShaderCache::Clear()
 // Used in Swap() when AA mode has changed
 void PixelShaderCache::InvalidateMSAAShaders()
 {
-	SAFE_RELEASE(s_ColorCopyProgram[1]);
-	SAFE_RELEASE(s_ColorMatrixProgram[1]);
-	SAFE_RELEASE(s_DepthMatrixProgram[1]);
-	SAFE_RELEASE(s_rgb8_to_rgba6[1]);
-	SAFE_RELEASE(s_rgba6_to_rgb8[1]);
-	SAFE_RELEASE(s_DepthResolveProgram);
+	s_ColorCopyProgram[1].Reset();
+	s_ColorMatrixProgram[1].Reset();
+	s_DepthMatrixProgram[1].Reset();
+	s_rgb8_to_rgba6[1].Reset();
+	s_rgba6_to_rgb8[1].Reset();
+	s_DepthResolveProgram.Reset();
 }
 
 void PixelShaderCache::Shutdown()
 {
-	SAFE_RELEASE(pscbuf);
+	pscbuf.Reset();
 
-	SAFE_RELEASE(s_ClearProgram);
-	SAFE_RELEASE(s_AnaglyphProgram);
-	SAFE_RELEASE(s_DepthResolveProgram);
+	s_ClearProgram.Reset();
+	s_AnaglyphProgram.Reset();
+	s_DepthResolveProgram.Reset();
 	for (int i = 0; i < 2; ++i)
 	{
-		SAFE_RELEASE(s_ColorCopyProgram[i]);
-		SAFE_RELEASE(s_ColorMatrixProgram[i]);
-		SAFE_RELEASE(s_DepthMatrixProgram[i]);
-		SAFE_RELEASE(s_rgba6_to_rgb8[i]);
-		SAFE_RELEASE(s_rgb8_to_rgba6[i]);
+		s_ColorCopyProgram[i].Reset();
+		s_ColorMatrixProgram[i].Reset();
+		s_DepthMatrixProgram[i].Reset();
+		s_rgba6_to_rgb8[i].Reset();
+		s_rgb8_to_rgba6[i].Reset();
 	}
 
 	Clear();
@@ -617,12 +617,12 @@ bool PixelShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode)
 
 bool PixelShaderCache::InsertByteCode(const PixelShaderUid &uid, const void* bytecode, unsigned int bytecodelen)
 {
-	ID3D11PixelShader* shader = D3D::CreatePixelShaderFromByteCode(bytecode, bytecodelen);
+	ComPtr<ID3D11PixelShader> shader = D3D::CreatePixelShaderFromByteCode(bytecode, bytecodelen);
 	if (shader == nullptr)
 		return false;
 
 	// TODO: Somehow make the debug name a bit more specific
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)shader, "a pixel shader of PixelShaderCache");
+	D3D::SetDebugObjectName(shader.Get(), "a pixel shader of PixelShaderCache");
 
 	// Make an entry in the table
 	PSCacheEntry newentry;

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.h
@@ -23,8 +23,8 @@ public:
 	static bool SetShader(DSTALPHA_MODE dstAlphaMode); // TODO: Should be renamed to LoadShader
 	static bool InsertByteCode(const PixelShaderUid &uid, const void* bytecode, unsigned int bytecodelen);
 
-	static ID3D11PixelShader* GetActiveShader() { return last_entry->shader; }
-	static ID3D11Buffer* &GetConstantBuffer();
+	static ID3D11PixelShader* GetActiveShader() { return last_entry->shader.Get(); }
+	static ID3D11Buffer* GetConstantBuffer();
 
 	static ID3D11PixelShader* GetColorMatrixProgram(bool multisampled);
 	static ID3D11PixelShader* GetColorCopyProgram(bool multisampled);
@@ -40,12 +40,12 @@ public:
 private:
 	struct PSCacheEntry
 	{
-		ID3D11PixelShader* shader;
+		ComPtr<ID3D11PixelShader> shader;
 
 		std::string code;
 
 		PSCacheEntry() : shader(nullptr) {}
-		void Destroy() { SAFE_RELEASE(shader); }
+		void Destroy() { shader.Reset(); }
 	};
 
 	typedef std::map<PixelShaderUid, PSCacheEntry> PSCache;

--- a/Source/Core/VideoBackends/D3D/Television.cpp
+++ b/Source/Core/VideoBackends/D3D/Television.cpp
@@ -59,10 +59,6 @@ static const char YUYV_DECODER_PS[] =
 "}\n"
 ;
 
-Television::Television()
-	: m_yuyvTexture(nullptr), m_yuyvTextureSRV(nullptr), m_pShader(nullptr)
-{ }
-
 void Television::Init()
 {
 	HRESULT hr;
@@ -82,26 +78,15 @@ void Television::Init()
 	D3D11_SUBRESOURCE_DATA srd = { fill.data(), 2*(MAX_XFB_WIDTH), 0 };
 
 	// This texture format is designed for YUYV data.
-	D3D11_TEXTURE2D_DESC t2dd = CD3D11_TEXTURE2D_DESC(
-		DXGI_FORMAT_G8R8_G8B8_UNORM, MAX_XFB_WIDTH, MAX_XFB_HEIGHT, 1, 1);
-	hr = D3D::device->CreateTexture2D(&t2dd, &srd, &m_yuyvTexture);
-	CHECK(SUCCEEDED(hr), "create tv yuyv texture");
-	D3D::SetDebugObjectName(m_yuyvTexture, "tv yuyv texture");
-
-	// Create shader resource view for YUYV texture
-
-	D3D11_SHADER_RESOURCE_VIEW_DESC srvd = CD3D11_SHADER_RESOURCE_VIEW_DESC(
-		m_yuyvTexture, D3D11_SRV_DIMENSION_TEXTURE2D,
-		DXGI_FORMAT_G8R8_G8B8_UNORM);
-	hr = D3D::device->CreateShaderResourceView(m_yuyvTexture, &srvd, &m_yuyvTextureSRV);
-	CHECK(SUCCEEDED(hr), "create tv yuyv texture srv");
-	D3D::SetDebugObjectName(m_yuyvTextureSRV, "tv yuyv texture srv");
+	m_yuyvTexture.Create(DXGI_FORMAT_G8R8_G8B8_UNORM, MAX_XFB_WIDTH, MAX_XFB_HEIGHT, D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 1, 1, &srd);
+	D3D::SetDebugObjectName(m_yuyvTexture.GetTex(), "tv yuyv texture");
+	D3D::SetDebugObjectName(m_yuyvTexture.GetSRV(), "tv yuyv texture srv");
 
 	// Create YUYV-decoding pixel shader
 
 	m_pShader = D3D::CompileAndCreatePixelShader(YUYV_DECODER_PS);
 	CHECK(m_pShader != nullptr, "compile and create yuyv decoder pixel shader");
-	D3D::SetDebugObjectName(m_pShader, "yuyv decoder pixel shader");
+	D3D::SetDebugObjectName(m_pShader.Get(), "yuyv decoder pixel shader");
 
 	// Create sampler state and set border color
 	//
@@ -114,17 +99,16 @@ void Television::Init()
 	D3D11_SAMPLER_DESC samDesc = CD3D11_SAMPLER_DESC(D3D11_FILTER_MIN_MAG_MIP_LINEAR,
 		D3D11_TEXTURE_ADDRESS_BORDER, D3D11_TEXTURE_ADDRESS_BORDER, D3D11_TEXTURE_ADDRESS_BORDER,
 		0.f, 1, D3D11_COMPARISON_ALWAYS, border, 0.f, 0.f);
-	hr = D3D::device->CreateSamplerState(&samDesc, &m_samplerState);
+	hr = D3D::device->CreateSamplerState(&samDesc, m_samplerState.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create yuyv decoder sampler state");
-	D3D::SetDebugObjectName(m_samplerState, "yuyv decoder sampler state");
+	D3D::SetDebugObjectName(m_samplerState.Get(), "yuyv decoder sampler state");
 }
 
 void Television::Shutdown()
 {
-	SAFE_RELEASE(m_pShader);
-	SAFE_RELEASE(m_yuyvTextureSRV);
-	SAFE_RELEASE(m_yuyvTexture);
-	SAFE_RELEASE(m_samplerState);
+	m_pShader.Reset();
+	m_yuyvTexture.Reset();
+	m_samplerState.Reset();
 }
 
 void Television::Submit(u32 xfbAddr, u32 stride, u32 width, u32 height)
@@ -136,7 +120,7 @@ void Television::Submit(u32 xfbAddr, u32 stride, u32 width, u32 height)
 	// Load data from GameCube RAM to YUYV texture
 	u8* yuyvSrc = Memory::GetPointer(xfbAddr);
 	D3D11_BOX box = CD3D11_BOX(0, 0, 0, stride, height, 1);
-	D3D::context->UpdateSubresource(m_yuyvTexture, 0, &box, yuyvSrc, 2 * stride, 2 * stride * height);
+	D3D::context->UpdateSubresource(m_yuyvTexture.GetTex(), 0, &box, yuyvSrc, 2 * stride, 2 * stride * height);
 }
 
 void Television::Render()
@@ -150,12 +134,12 @@ void Television::Render()
 
 		D3D11_RECT sourceRc = CD3D11_RECT(0, 0, int(m_curWidth), int(m_curHeight));
 
-		D3D::stateman->SetSampler(0, m_samplerState);
+		D3D::stateman->SetSampler(0, m_samplerState.Get());
 
 		D3D::drawShadedTexQuad(
-			m_yuyvTextureSRV, &sourceRc,
+			m_yuyvTexture.GetSRV(), &sourceRc,
 			MAX_XFB_WIDTH, MAX_XFB_HEIGHT,
-			m_pShader,
+			m_pShader.Get(),
 			VertexShaderCache::GetSimpleVertexShader(),
 			VertexShaderCache::GetSimpleInputLayout());
 	}

--- a/Source/Core/VideoBackends/D3D/Television.h
+++ b/Source/Core/VideoBackends/D3D/Television.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "VideoCommon/VideoCommon.h"
+#include "VideoBackends/D3D/D3DTexture.h"
 
 struct ID3D11Texture2D;
 struct ID3D11ShaderResourceView;
@@ -18,9 +19,6 @@ class Television
 {
 
 public:
-
-	Television();
-
 	void Init();
 	void Shutdown();
 
@@ -41,10 +39,9 @@ private:
 
 	// Used for real XFB mode
 
-	ID3D11Texture2D* m_yuyvTexture;
-	ID3D11ShaderResourceView* m_yuyvTextureSRV;
-	ID3D11PixelShader* m_pShader;
-	ID3D11SamplerState* m_samplerState;
+	D3DTexture2D m_yuyvTexture;
+	ComPtr<ID3D11PixelShader> m_pShader;
+	ComPtr<ID3D11SamplerState> m_samplerState;
 
 };
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -19,12 +19,10 @@ public:
 private:
 	struct TCacheEntry : TCacheEntryBase
 	{
-		D3DTexture2D *const texture;
-
+		D3DTexture2D texture;
 		D3D11_USAGE usage;
 
-		TCacheEntry(const TCacheEntryConfig& config, D3DTexture2D *_tex) : TCacheEntryBase(config), texture(_tex) {}
-		~TCacheEntry();
+		TCacheEntry(const TCacheEntryConfig& config, D3DTexture2D&& _tex) : TCacheEntryBase(config), texture(_tex) {}
 
 		void CopyRectangleFromTexture(
 			const TCacheEntryBase* source,
@@ -54,10 +52,10 @@ private:
 	void CompileShaders() override { }
 	void DeleteShaders() override { }
 
-	ID3D11Buffer* palette_buf;
-	ID3D11ShaderResourceView* palette_buf_srv;
-	ID3D11Buffer* palette_uniform;
-	ID3D11PixelShader* palette_pixel_shader[3];
+	ComPtr<ID3D11Buffer> palette_buf;
+	ComPtr<ID3D11ShaderResourceView> palette_buf_srv;
+	ComPtr<ID3D11Buffer> palette_uniform;
+	ComPtr<ID3D11PixelShader> palette_pixel_shader[3];
 };
 
 }

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -36,7 +36,7 @@ private:
 	u32 m_bufferCursor;
 
 	enum { MAX_BUFFER_COUNT = 2 };
-	ID3D11Buffer* m_buffers[MAX_BUFFER_COUNT];
+	ComPtr<ID3D11Buffer> m_buffers[MAX_BUFFER_COUNT];
 
 	std::vector<u8> LocalVBuffer;
 	std::vector<u16> LocalIBuffer;

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -26,34 +26,34 @@ const VertexShaderCache::VSCacheEntry *VertexShaderCache::last_entry;
 VertexShaderUid VertexShaderCache::last_uid;
 UidChecker<VertexShaderUid, ShaderCode> VertexShaderCache::vertex_uid_checker;
 
-static ID3D11VertexShader* SimpleVertexShader = nullptr;
-static ID3D11VertexShader* ClearVertexShader = nullptr;
-static ID3D11InputLayout* SimpleLayout = nullptr;
-static ID3D11InputLayout* ClearLayout = nullptr;
+static ComPtr<ID3D11VertexShader> SimpleVertexShader = nullptr;
+static ComPtr<ID3D11VertexShader> ClearVertexShader = nullptr;
+static ComPtr<ID3D11InputLayout> SimpleLayout = nullptr;
+static ComPtr<ID3D11InputLayout> ClearLayout = nullptr;
 
 LinearDiskCache<VertexShaderUid, u8> g_vs_disk_cache;
 
-ID3D11VertexShader* VertexShaderCache::GetSimpleVertexShader() { return SimpleVertexShader; }
-ID3D11VertexShader* VertexShaderCache::GetClearVertexShader() { return ClearVertexShader; }
-ID3D11InputLayout* VertexShaderCache::GetSimpleInputLayout() { return SimpleLayout; }
-ID3D11InputLayout* VertexShaderCache::GetClearInputLayout() { return ClearLayout; }
+ID3D11VertexShader* VertexShaderCache::GetSimpleVertexShader() { return SimpleVertexShader.Get(); }
+ID3D11VertexShader* VertexShaderCache::GetClearVertexShader() { return ClearVertexShader.Get(); }
+ID3D11InputLayout* VertexShaderCache::GetSimpleInputLayout() { return SimpleLayout.Get(); }
+ID3D11InputLayout* VertexShaderCache::GetClearInputLayout() { return ClearLayout.Get(); }
 
-ID3D11Buffer* vscbuf = nullptr;
+ComPtr<ID3D11Buffer> vscbuf = nullptr;
 
-ID3D11Buffer* &VertexShaderCache::GetConstantBuffer()
+ID3D11Buffer* VertexShaderCache::GetConstantBuffer()
 {
 	// TODO: divide the global variables of the generated shaders into about 5 constant buffers to speed this up
 	if (VertexShaderManager::dirty)
 	{
 		D3D11_MAPPED_SUBRESOURCE map;
-		D3D::context->Map(vscbuf, 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
+		D3D::context->Map(vscbuf.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &map);
 		memcpy(map.pData, &VertexShaderManager::constants, sizeof(VertexShaderConstants));
-		D3D::context->Unmap(vscbuf, 0);
+		D3D::context->Unmap(vscbuf.Get(), 0);
 		VertexShaderManager::dirty = false;
 
 		ADDSTAT(stats.thisFrame.bytesUniformStreamed, sizeof(VertexShaderConstants));
 	}
-	return vscbuf;
+	return vscbuf.Get();
 }
 
 // this class will load the precompiled shaders into our cache
@@ -117,28 +117,28 @@ void VertexShaderCache::Init()
 
 	unsigned int cbsize = ROUND_UP(sizeof(VertexShaderConstants), 16); // must be a multiple of 16
 	D3D11_BUFFER_DESC cbdesc = CD3D11_BUFFER_DESC(cbsize, D3D11_BIND_CONSTANT_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
-	HRESULT hr = D3D::device->CreateBuffer(&cbdesc, nullptr, &vscbuf);
+	HRESULT hr = D3D::device->CreateBuffer(&cbdesc, nullptr, vscbuf.GetAddressOf());
 	CHECK(hr==S_OK, "Create vertex shader constant buffer (size=%u)", cbsize);
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)vscbuf, "vertex shader constant buffer used to emulate the GX pipeline");
+	D3D::SetDebugObjectName(vscbuf.Get(), "vertex shader constant buffer used to emulate the GX pipeline");
 
 	D3DBlob* blob;
 	D3D::CompileVertexShader(simple_shader_code, &blob);
-	D3D::device->CreateInputLayout(simpleelems, 2, blob->Data(), blob->Size(), &SimpleLayout);
+	D3D::device->CreateInputLayout(simpleelems, 2, blob->Data(), blob->Size(), SimpleLayout.GetAddressOf());
 	SimpleVertexShader = D3D::CreateVertexShaderFromByteCode(blob);
 	if (SimpleLayout == nullptr || SimpleVertexShader == nullptr)
 		PanicAlert("Failed to create simple vertex shader or input layout at %s %d\n", __FILE__, __LINE__);
 	blob->Release();
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)SimpleVertexShader, "simple vertex shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)SimpleLayout, "simple input layout");
+	D3D::SetDebugObjectName(SimpleVertexShader.Get(), "simple vertex shader");
+	D3D::SetDebugObjectName(SimpleLayout.Get(), "simple input layout");
 
 	D3D::CompileVertexShader(clear_shader_code, &blob);
-	D3D::device->CreateInputLayout(clearelems, 2, blob->Data(), blob->Size(), &ClearLayout);
+	D3D::device->CreateInputLayout(clearelems, 2, blob->Data(), blob->Size(), ClearLayout.GetAddressOf());
 	ClearVertexShader = D3D::CreateVertexShaderFromByteCode(blob);
 	if (ClearLayout == nullptr || ClearVertexShader == nullptr)
 		PanicAlert("Failed to create clear vertex shader or input layout at %s %d\n", __FILE__, __LINE__);
 	blob->Release();
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)ClearVertexShader, "clear vertex shader");
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)ClearLayout, "clear input layout");
+	D3D::SetDebugObjectName(ClearVertexShader.Get(), "clear vertex shader");
+	D3D::SetDebugObjectName(ClearLayout.Get(), "clear input layout");
 
 	Clear();
 
@@ -171,13 +171,13 @@ void VertexShaderCache::Clear()
 
 void VertexShaderCache::Shutdown()
 {
-	SAFE_RELEASE(vscbuf);
+	vscbuf.Reset();
 
-	SAFE_RELEASE(SimpleVertexShader);
-	SAFE_RELEASE(ClearVertexShader);
+	SimpleVertexShader.Reset();
+	ClearVertexShader.Reset();
 
-	SAFE_RELEASE(SimpleLayout);
-	SAFE_RELEASE(ClearLayout);
+	SimpleLayout.Reset();
+	ClearLayout.Reset();
 
 	Clear();
 	g_vs_disk_cache.Sync();
@@ -240,12 +240,12 @@ bool VertexShaderCache::SetShader()
 
 bool VertexShaderCache::InsertByteCode(const VertexShaderUid &uid, D3DBlob* bcodeblob)
 {
-	ID3D11VertexShader* shader = D3D::CreateVertexShaderFromByteCode(bcodeblob);
+	ComPtr<ID3D11VertexShader> shader = D3D::CreateVertexShaderFromByteCode(bcodeblob);
 	if (shader == nullptr)
 		return false;
 
 	// TODO: Somehow make the debug name a bit more specific
-	D3D::SetDebugObjectName((ID3D11DeviceChild*)shader, "a vertex shader of VertexShaderCache");
+	D3D::SetDebugObjectName(shader.Get(), "a vertex shader of VertexShaderCache");
 
 	// Make an entry in the table
 	VSCacheEntry entry;

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.h
@@ -21,9 +21,9 @@ public:
 	static void Shutdown();
 	static bool SetShader(); // TODO: Should be renamed to LoadShader
 
-	static ID3D11VertexShader* GetActiveShader() { return last_entry->shader; }
-	static D3DBlob* GetActiveShaderBytecode() { return last_entry->bytecode; }
-	static ID3D11Buffer* &GetConstantBuffer();
+	static ID3D11VertexShader* GetActiveShader() { return last_entry->shader.Get(); }
+	static D3DBlob* GetActiveShaderBytecode() { return last_entry->bytecode.Get(); }
+	static ID3D11Buffer* GetConstantBuffer();
 
 	static ID3D11VertexShader* GetSimpleVertexShader();
 	static ID3D11VertexShader* GetClearVertexShader();
@@ -35,22 +35,20 @@ public:
 private:
 	struct VSCacheEntry
 	{
-		ID3D11VertexShader* shader;
-		D3DBlob* bytecode; // needed to initialize the input layout
+		ComPtr<ID3D11VertexShader> shader;
+		ComPtr<D3DBlob> bytecode; // needed to initialize the input layout
 
 		std::string code;
 
 		VSCacheEntry() : shader(nullptr), bytecode(nullptr) {}
 		void SetByteCode(D3DBlob* blob)
 		{
-			SAFE_RELEASE(bytecode);
 			bytecode = blob;
-			blob->AddRef();
 		}
 		void Destroy()
 		{
-			SAFE_RELEASE(shader);
-			SAFE_RELEASE(bytecode);
+			shader.Reset();
+			bytecode.Reset();
 		}
 	};
 	typedef std::map<VertexShaderUid, VSCacheEntry> VSCache;

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
@@ -133,13 +133,6 @@ static const struct QuadVertex
 	float posY;
 } QUAD_VERTS[4] = { { 0, 0 }, { 1, 0 }, { 0, 1 }, { 1, 1 } };
 
-XFBEncoder::XFBEncoder()
-	: m_out(nullptr), m_outRTV(nullptr), m_outStage(nullptr), m_encodeParams(nullptr),
-	m_quad(nullptr), m_vShader(nullptr), m_quadLayout(nullptr), m_pShader(nullptr),
-	m_xfbEncodeBlendState(nullptr), m_xfbEncodeDepthState(nullptr),
-	m_xfbEncodeRastState(nullptr), m_efbSampler(nullptr)
-{ }
-
 void XFBEncoder::Init()
 {
 	HRESULT hr;
@@ -148,37 +141,21 @@ void XFBEncoder::Init()
 
 	// The pixel shader can generate one YUYV entry per pixel. One YUYV entry
 	// is created for every two EFB pixels.
-	D3D11_TEXTURE2D_DESC t2dd = CD3D11_TEXTURE2D_DESC(
-		DXGI_FORMAT_R8G8B8A8_UNORM, MAX_XFB_WIDTH/2, MAX_XFB_HEIGHT, 1, 1,
-		D3D11_BIND_RENDER_TARGET);
-	hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_out);
-	CHECK(SUCCEEDED(hr), "create xfb encoder output texture");
-	D3D::SetDebugObjectName(m_out, "xfb encoder output texture");
-
-	// Create output render target view
-
-	D3D11_RENDER_TARGET_VIEW_DESC rtvd = CD3D11_RENDER_TARGET_VIEW_DESC(m_out,
-		D3D11_RTV_DIMENSION_TEXTURE2D, DXGI_FORMAT_R8G8B8A8_UNORM);
-	hr = D3D::device->CreateRenderTargetView(m_out, &rtvd, &m_outRTV);
-	CHECK(SUCCEEDED(hr), "create xfb encoder output texture rtv");
-	D3D::SetDebugObjectName(m_outRTV, "xfb encoder output rtv");
+	m_out.Create(DXGI_FORMAT_R8G8B8A8_UNORM, MAX_XFB_WIDTH/2, MAX_XFB_HEIGHT, D3D11_BIND_RENDER_TARGET);
+	D3D::SetDebugObjectName(m_out.GetTex(), "xfb encoder output texture");
+	D3D::SetDebugObjectName(m_out.GetRTV(), "xfb encoder output rtv");
 
 	// Create output staging buffer
-
-	t2dd.Usage = D3D11_USAGE_STAGING;
-	t2dd.BindFlags = 0;
-	t2dd.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-	hr = D3D::device->CreateTexture2D(&t2dd, nullptr, &m_outStage);
-	CHECK(SUCCEEDED(hr), "create xfb encoder output staging buffer");
-	D3D::SetDebugObjectName(m_outStage, "xfb encoder output staging buffer");
+	m_outStage = CreateStagingTexture(DXGI_FORMAT_R8G8B8A8_UNORM, MAX_XFB_WIDTH/2, MAX_XFB_HEIGHT);
+	D3D::SetDebugObjectName(m_outStage.Get(), "xfb encoder output staging buffer");
 
 	// Create constant buffer for uploading params to shaders
 
 	D3D11_BUFFER_DESC bd = CD3D11_BUFFER_DESC(sizeof(XFBEncodeParams),
 		D3D11_BIND_CONSTANT_BUFFER);
-	hr = D3D::device->CreateBuffer(&bd, nullptr, &m_encodeParams);
+	hr = D3D::device->CreateBuffer(&bd, nullptr, m_encodeParams.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode params buffer");
-	D3D::SetDebugObjectName(m_encodeParams, "xfb encoder params buffer");
+	D3D::SetDebugObjectName(m_encodeParams.Get(), "xfb encoder params buffer");
 
 	// Create vertex quad
 
@@ -186,9 +163,9 @@ void XFBEncoder::Init()
 		D3D11_USAGE_IMMUTABLE);
 	D3D11_SUBRESOURCE_DATA srd = { QUAD_VERTS, 0, 0 };
 
-	hr = D3D::device->CreateBuffer(&bd, &srd, &m_quad);
+	hr = D3D::device->CreateBuffer(&bd, &srd, m_quad.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode quad vertex buffer");
-	D3D::SetDebugObjectName(m_quad, "xfb encoder quad vertex buffer");
+	D3D::SetDebugObjectName(m_quad.Get(), "xfb encoder quad vertex buffer");
 
 	// Create vertex shader
 
@@ -199,17 +176,17 @@ void XFBEncoder::Init()
 		return;
 	}
 
-	hr = D3D::device->CreateVertexShader(bytecode->Data(), bytecode->Size(), nullptr, &m_vShader);
+	hr = D3D::device->CreateVertexShader(bytecode->Data(), bytecode->Size(), nullptr, m_vShader.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode vertex shader");
-	D3D::SetDebugObjectName(m_vShader, "xfb encoder vertex shader");
+	D3D::SetDebugObjectName(m_vShader.Get(), "xfb encoder vertex shader");
 
 	// Create input layout for vertex quad using bytecode from vertex shader
 
 	hr = D3D::device->CreateInputLayout(QUAD_LAYOUT_DESC,
 		sizeof(QUAD_LAYOUT_DESC)/sizeof(D3D11_INPUT_ELEMENT_DESC),
-		bytecode->Data(), bytecode->Size(), &m_quadLayout);
+		bytecode->Data(), bytecode->Size(), m_quadLayout.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode quad vertex layout");
-	D3D::SetDebugObjectName(m_quadLayout, "xfb encoder quad layout");
+	D3D::SetDebugObjectName(m_quadLayout.Get(), "xfb encoder quad layout");
 
 	bytecode->Release();
 
@@ -221,55 +198,54 @@ void XFBEncoder::Init()
 		ERROR_LOG(VIDEO, "XFB encode pixel shader failed to compile");
 		return;
 	}
-	D3D::SetDebugObjectName(m_pShader, "xfb encoder pixel shader");
+	D3D::SetDebugObjectName(m_pShader.Get(), "xfb encoder pixel shader");
 
 	// Create blend state
 
 	D3D11_BLEND_DESC bld = CD3D11_BLEND_DESC(CD3D11_DEFAULT());
-	hr = D3D::device->CreateBlendState(&bld, &m_xfbEncodeBlendState);
+	hr = D3D::device->CreateBlendState(&bld, m_xfbEncodeBlendState.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode blend state");
-	D3D::SetDebugObjectName(m_xfbEncodeBlendState, "xfb encoder blend state");
+	D3D::SetDebugObjectName(m_xfbEncodeBlendState.Get(), "xfb encoder blend state");
 
 	// Create depth state
 
 	D3D11_DEPTH_STENCIL_DESC dsd = CD3D11_DEPTH_STENCIL_DESC(CD3D11_DEFAULT());
 	dsd.DepthEnable = FALSE;
-	hr = D3D::device->CreateDepthStencilState(&dsd, &m_xfbEncodeDepthState);
+	hr = D3D::device->CreateDepthStencilState(&dsd, m_xfbEncodeDepthState.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode depth state");
-	D3D::SetDebugObjectName(m_xfbEncodeDepthState, "xfb encoder depth state");
+	D3D::SetDebugObjectName(m_xfbEncodeDepthState.Get(), "xfb encoder depth state");
 
 	// Create rasterizer state
 
 	D3D11_RASTERIZER_DESC rd = CD3D11_RASTERIZER_DESC(CD3D11_DEFAULT());
 	rd.CullMode = D3D11_CULL_NONE;
 	rd.DepthClipEnable = FALSE;
-	hr = D3D::device->CreateRasterizerState(&rd, &m_xfbEncodeRastState);
+	hr = D3D::device->CreateRasterizerState(&rd, m_xfbEncodeRastState.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode rasterizer state");
-	D3D::SetDebugObjectName(m_xfbEncodeRastState, "xfb encoder rast state");
+	D3D::SetDebugObjectName(m_xfbEncodeRastState.Get(), "xfb encoder rast state");
 
 	// Create EFB texture sampler
 
 	D3D11_SAMPLER_DESC sd = CD3D11_SAMPLER_DESC(CD3D11_DEFAULT());
 	sd.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
-	hr = D3D::device->CreateSamplerState(&sd, &m_efbSampler);
+	hr = D3D::device->CreateSamplerState(&sd, m_efbSampler.GetAddressOf());
 	CHECK(SUCCEEDED(hr), "create xfb encode texture sampler");
-	D3D::SetDebugObjectName(m_efbSampler, "xfb encoder texture sampler");
+	D3D::SetDebugObjectName(m_efbSampler.Get(), "xfb encoder texture sampler");
 }
 
 void XFBEncoder::Shutdown()
 {
-	SAFE_RELEASE(m_efbSampler);
-	SAFE_RELEASE(m_xfbEncodeRastState);
-	SAFE_RELEASE(m_xfbEncodeDepthState);
-	SAFE_RELEASE(m_xfbEncodeBlendState);
-	SAFE_RELEASE(m_pShader);
-	SAFE_RELEASE(m_quadLayout);
-	SAFE_RELEASE(m_vShader);
-	SAFE_RELEASE(m_quad);
-	SAFE_RELEASE(m_encodeParams);
-	SAFE_RELEASE(m_outStage);
-	SAFE_RELEASE(m_outRTV);
-	SAFE_RELEASE(m_out);
+	m_efbSampler.Reset();
+	m_xfbEncodeRastState.Reset();
+	m_xfbEncodeDepthState.Reset();
+	m_xfbEncodeBlendState.Reset();
+	m_pShader.Reset();
+	m_quadLayout.Reset();
+	m_vShader.Reset();
+	m_quad.Reset();
+	m_encodeParams.Reset();
+	m_outStage.Reset();
+	m_out.Reset();
 }
 
 void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcRect, float gamma)
@@ -282,22 +258,22 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 
 	// Set up all the state for XFB encoding
 
-	D3D::stateman->SetPixelShader(m_pShader);
-	D3D::stateman->SetVertexShader(m_vShader);
+	D3D::stateman->SetPixelShader(m_pShader.Get());
+	D3D::stateman->SetVertexShader(m_vShader.Get());
 	D3D::stateman->SetGeometryShader(nullptr);
 
-	D3D::stateman->PushBlendState(m_xfbEncodeBlendState);
-	D3D::stateman->PushDepthState(m_xfbEncodeDepthState);
-	D3D::stateman->PushRasterizerState(m_xfbEncodeRastState);
+	D3D::stateman->PushBlendState(m_xfbEncodeBlendState.Get());
+	D3D::stateman->PushDepthState(m_xfbEncodeDepthState.Get());
+	D3D::stateman->PushRasterizerState(m_xfbEncodeRastState.Get());
 
 	D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, FLOAT(width/2), FLOAT(height));
 	D3D::context->RSSetViewports(1, &vp);
 
-	D3D::stateman->SetInputLayout(m_quadLayout);
+	D3D::stateman->SetInputLayout(m_quadLayout.Get());
 	D3D::stateman->SetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 	UINT stride = sizeof(QuadVertex);
 	UINT offset = 0;
-	D3D::stateman->SetVertexBuffer(m_quad, stride, offset);
+	D3D::stateman->SetVertexBuffer(m_quad.Get(), stride, offset);
 
 	TargetRectangle targetRect = g_renderer->ConvertEFBRectangle(srcRect);
 
@@ -309,16 +285,16 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 	params.TexRight = FLOAT(targetRect.right) / g_renderer->GetTargetWidth();
 	params.TexBottom = FLOAT(targetRect.bottom) / g_renderer->GetTargetHeight();
 	params.Gamma = gamma;
-	D3D::context->UpdateSubresource(m_encodeParams, 0, nullptr, &params, 0, 0);
+	D3D::context->UpdateSubresource(m_encodeParams.Get(), 0, nullptr, &params, 0, 0);
 
-	D3D::context->OMSetRenderTargets(1, &m_outRTV, nullptr);
+	D3D::SetRenderTarget(m_out.GetRTV(), nullptr);
 
-	ID3D11ShaderResourceView* pEFB = FramebufferManager::GetResolvedEFBColorTexture()->GetSRV();
+	ID3D11ShaderResourceView* pEFB = FramebufferManager::GetResolvedEFBColorTexture().GetSRV();
 
-	D3D::stateman->SetVertexConstants(m_encodeParams);
-	D3D::stateman->SetPixelConstants(m_encodeParams);
+	D3D::stateman->SetVertexConstants(m_encodeParams.Get());
+	D3D::stateman->SetPixelConstants(m_encodeParams.Get());
 	D3D::stateman->SetTexture(0, pEFB);
-	D3D::stateman->SetSampler(0, m_efbSampler);
+	D3D::stateman->SetSampler(0, m_efbSampler.Get());
 
 	// Encode!
 
@@ -328,7 +304,7 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 	// Copy to staging buffer
 
 	D3D11_BOX srcBox = CD3D11_BOX(0, 0, 0, width/2, height, 1);
-	D3D::context->CopySubresourceRegion(m_outStage, 0, 0, 0, 0, m_out, 0, &srcBox);
+	D3D::context->CopySubresourceRegion(m_outStage.Get(), 0, 0, 0, 0, m_out.GetTex(), 0, &srcBox);
 
 	// Clean up state
 
@@ -349,7 +325,7 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 	// Transfer staging buffer to GameCube/Wii RAM
 
 	D3D11_MAPPED_SUBRESOURCE map = { 0 };
-	hr = D3D::context->Map(m_outStage, 0, D3D11_MAP_READ, 0, &map);
+	hr = D3D::context->Map(m_outStage.Get(), 0, D3D11_MAP_READ, 0, &map);
 	CHECK(SUCCEEDED(hr), "map staging buffer");
 
 	u8* src = (u8*)map.pData;
@@ -360,14 +336,14 @@ void XFBEncoder::Encode(u8* dst, u32 width, u32 height, const EFBRectangle& srcR
 		src += map.RowPitch;
 	}
 
-	D3D::context->Unmap(m_outStage, 0);
+	D3D::context->Unmap(m_outStage.Get(), 0);
 
 	// Restore API
 	g_renderer->RestoreAPIState();
 	D3D::stateman->Apply(); // force unbind efb texture as shader resource
-	D3D::context->OMSetRenderTargets(1,
-		&FramebufferManager::GetEFBColorTexture()->GetRTV(),
-		FramebufferManager::GetEFBDepthTexture()->GetDSV());
+	D3D::SetRenderTarget(
+		FramebufferManager::GetEFBColorTexture().GetRTV(),
+		FramebufferManager::GetEFBDepthTexture().GetDSV());
 }
 
 }

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.h
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.h
@@ -24,9 +24,6 @@ class XFBEncoder
 {
 
 public:
-
-	XFBEncoder();
-
 	void Init();
 	void Shutdown();
 
@@ -34,18 +31,18 @@ public:
 
 private:
 
-	ID3D11Texture2D* m_out;
-	ID3D11RenderTargetView* m_outRTV;
-	ID3D11Texture2D* m_outStage;
-	ID3D11Buffer* m_encodeParams;
-	ID3D11Buffer* m_quad;
-	ID3D11VertexShader* m_vShader;
-	ID3D11InputLayout* m_quadLayout;
-	ID3D11PixelShader* m_pShader;
-	ID3D11BlendState* m_xfbEncodeBlendState;
-	ID3D11DepthStencilState* m_xfbEncodeDepthState;
-	ID3D11RasterizerState* m_xfbEncodeRastState;
-	ID3D11SamplerState* m_efbSampler;
+	D3DTexture2D m_out;
+	ComPtr<ID3D11Texture2D> m_outStage;
+
+	ComPtr<ID3D11Buffer> m_encodeParams;
+	ComPtr<ID3D11Buffer> m_quad;
+	ComPtr<ID3D11VertexShader> m_vShader;
+	ComPtr<ID3D11InputLayout> m_quadLayout;
+	ComPtr<ID3D11PixelShader> m_pShader;
+	ComPtr<ID3D11BlendState> m_xfbEncodeBlendState;
+	ComPtr<ID3D11DepthStencilState> m_xfbEncodeDepthState;
+	ComPtr<ID3D11RasterizerState> m_xfbEncodeRastState;
+	ComPtr<ID3D11SamplerState> m_efbSampler;
 
 };
 

--- a/Source/Core/VideoBackends/D3D12/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.h
@@ -15,6 +15,7 @@
 #include <dxgi1_4.h>
 #include <memory>
 #include <vector>
+#include <wrl/client.h>
 
 #include "../../Externals/d3dx12/d3dx12.h"
 
@@ -24,6 +25,8 @@
 
 namespace DX12
 {
+
+using Microsoft::WRL::ComPtr;
 
 #define SAFE_RELEASE(x) { if (x) (x)->Release(); (x) = nullptr; }
 #define CHECK(cond, Message, ...) if (!(cond)) { __debugbreak(); PanicAlert(__FUNCTION__ " failed in %s at line %d: " Message, __FILE__, __LINE__, __VA_ARGS__); }

--- a/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.cpp
@@ -18,7 +18,7 @@ bool operator==(const D3DDescriptorHeapManager::SamplerStateSet& lhs, const D3DD
 D3DDescriptorHeapManager::D3DDescriptorHeapManager(D3D12_DESCRIPTOR_HEAP_DESC* desc, ID3D12Device* device, unsigned int temporarySlots) :
 	m_device(device)
 {
-	CheckHR(device->CreateDescriptorHeap(desc, IID_PPV_ARGS(&m_descriptor_heap)));
+	CheckHR(device->CreateDescriptorHeap(desc, IID_PPV_ARGS(m_descriptor_heap.GetAddressOf())));
 
 	m_descriptor_heap_size = desc->NumDescriptors;
 	m_descriptor_increment_size = device->GetDescriptorHandleIncrementSize(desc->Type);
@@ -29,7 +29,7 @@ D3DDescriptorHeapManager::D3DDescriptorHeapManager(D3D12_DESCRIPTOR_HEAP_DESC* d
 		D3D12_DESCRIPTOR_HEAP_DESC cpu_shadow_heap_desc = *desc;
 		cpu_shadow_heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
 
-		CheckHR(device->CreateDescriptorHeap(&cpu_shadow_heap_desc, IID_PPV_ARGS(&m_descriptor_heap_cpu_shadow)));
+		CheckHR(device->CreateDescriptorHeap(&cpu_shadow_heap_desc, IID_PPV_ARGS(m_descriptor_heap_cpu_shadow.GetAddressOf())));
 
 		m_heap_base_gpu = m_descriptor_heap->GetGPUDescriptorHandleForHeapStart();
 		m_heap_base_gpu_cpu_shadow = m_descriptor_heap_cpu_shadow->GetCPUDescriptorHandleForHeapStart();
@@ -157,13 +157,7 @@ D3D12_GPU_DESCRIPTOR_HANDLE D3DDescriptorHeapManager::GetHandleForSamplerGroup(S
 
 ID3D12DescriptorHeap* D3DDescriptorHeapManager::GetDescriptorHeap() const
 {
-	return m_descriptor_heap;
-}
-
-D3DDescriptorHeapManager::~D3DDescriptorHeapManager()
-{
-	SAFE_RELEASE(m_descriptor_heap);
-	SAFE_RELEASE(m_descriptor_heap_cpu_shadow);
+	return m_descriptor_heap.Get();
 }
 
 }  // namespace DX12

--- a/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.h
+++ b/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.h
@@ -18,7 +18,6 @@ class D3DDescriptorHeapManager
 public:
 
 	D3DDescriptorHeapManager(D3D12_DESCRIPTOR_HEAP_DESC* desc, ID3D12Device* device, unsigned int temporarySlots = 0);
-	~D3DDescriptorHeapManager();
 
 	bool Allocate(D3D12_CPU_DESCRIPTOR_HANDLE* cpu_handle, D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handle = nullptr, D3D12_CPU_DESCRIPTOR_HANDLE* gpu_handle_cpu_shadow = nullptr, bool temporary = false);
 	bool AllocateGroup(D3D12_CPU_DESCRIPTOR_HANDLE* cpu_handles, unsigned int num_handles, D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handles = nullptr, D3D12_CPU_DESCRIPTOR_HANDLE* gpu_handle_cpu_shadows = nullptr, bool temporary = false);
@@ -42,8 +41,8 @@ public:
 private:
 
 	ID3D12Device* m_device = nullptr;
-	ID3D12DescriptorHeap* m_descriptor_heap = nullptr;
-	ID3D12DescriptorHeap* m_descriptor_heap_cpu_shadow = nullptr;
+	ComPtr<ID3D12DescriptorHeap> m_descriptor_heap = nullptr;
+	ComPtr<ID3D12DescriptorHeap> m_descriptor_heap_cpu_shadow = nullptr;
 
 	D3D12_CPU_DESCRIPTOR_HANDLE m_heap_base_cpu;
 	D3D12_GPU_DESCRIPTOR_HANDLE m_heap_base_gpu;

--- a/Source/Core/VideoBackends/D3D12/D3DState.h
+++ b/Source/Core/VideoBackends/D3D12/D3DState.h
@@ -146,7 +146,7 @@ private:
 		}
 	};
 
-	std::unordered_map<D3D12_GRAPHICS_PIPELINE_STATE_DESC, ID3D12PipelineState*, hash_pso_desc, equality_pipeline_state_desc> m_pso_map;
+	std::unordered_map<D3D12_GRAPHICS_PIPELINE_STATE_DESC, ComPtr<ID3D12PipelineState>, hash_pso_desc, equality_pipeline_state_desc> m_pso_map;
 
 	struct hash_small_pso_desc
 	{
@@ -186,7 +186,7 @@ private:
 		}
 	};
 
-	std::unordered_map<SmallPsoDesc, ID3D12PipelineState*, hash_small_pso_desc, equality_small_pipeline_state_desc> m_small_pso_map;
+	std::unordered_map<SmallPsoDesc, ComPtr<ID3D12PipelineState>, hash_small_pso_desc, equality_small_pipeline_state_desc> m_small_pso_map;
 };
 
 }  // namespace DX12

--- a/Source/Core/VideoBackends/D3D12/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D12/D3DTexture.h
@@ -47,7 +47,7 @@ public:
 private:
 	~D3DTexture2D();
 
-	ID3D12Resource* m_tex12 = nullptr;
+	ComPtr<ID3D12Resource> m_tex12 = nullptr;
 
 	D3D12_CPU_DESCRIPTOR_HANDLE m_srv12_cpu = {};
 	D3D12_GPU_DESCRIPTOR_HANDLE m_srv12_gpu = {};

--- a/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
@@ -314,16 +314,16 @@ int CD3DFont::Init()
 	DeleteObject(hFont);
 
 	// setup device objects for drawing
-	ID3DBlob* psbytecode = nullptr;
-	D3D::CompilePixelShader(fontpixshader, &psbytecode);
+	ComPtr<ID3DBlob> psbytecode = nullptr;
+	D3D::CompilePixelShader(fontpixshader, psbytecode.GetAddressOf());
 	if (psbytecode == nullptr)
 		PanicAlert("Failed to compile pixel shader, %s %d\n", __FILE__, __LINE__);
 
 	m_pshader12.pShaderBytecode = psbytecode->GetBufferPointer();
 	m_pshader12.BytecodeLength = psbytecode->GetBufferSize();
 
-	ID3DBlob* vsbytecode = nullptr;
-	D3D::CompileVertexShader(fontvertshader, &vsbytecode);
+	ComPtr<ID3DBlob> vsbytecode = nullptr;
+	D3D::CompileVertexShader(fontvertshader, vsbytecode.GetAddressOf());
 	if (vsbytecode == nullptr)
 		PanicAlert("Failed to compile vertex shader, %s %d\n", __FILE__, __LINE__);
 
@@ -384,9 +384,6 @@ int CD3DFont::Init()
 	};
 
 	CheckHR(DX12::gx_state_cache.GetPipelineStateObjectFromCache(&text_pso_desc, &m_pso));
-
-	SAFE_RELEASE(psbytecode);
-	SAFE_RELEASE(vsbytecode);
 
 	return S_OK;
 }

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
@@ -78,7 +78,7 @@ FramebufferManager::FramebufferManager()
 	sample_desc.Count = g_ActiveConfig.iMultisamples;
 	sample_desc.Quality = 0;
 
-	ID3D12Resource* buf12;
+	ComPtr<ID3D12Resource> buf12;
 	D3D12_RESOURCE_DESC texdesc12;
 	D3D12_CLEAR_VALUE optimized_clear_valueRTV = { DXGI_FORMAT_R8G8B8A8_UNORM, { 0.0f, 0.0f, 0.0f, 1.0f } };
 	D3D12_CLEAR_VALUE optimized_clear_valueDSV = CD3DX12_CLEAR_VALUE(DXGI_FORMAT_D32_FLOAT, 0.0f, 0);
@@ -89,41 +89,41 @@ FramebufferManager::FramebufferManager()
 
 	// EFB color texture - primary render target
 	texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, sample_desc.Count, sample_desc.Quality, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
-	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueRTV, IID_PPV_ARGS(&buf12));
+	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueRTV, IID_PPV_ARGS(buf12.GetAddressOf()));
 
-	m_efb.color_tex = new D3DTexture2D(buf12, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
-	SAFE_RELEASE(buf12);
+	m_efb.color_tex = new D3DTexture2D(buf12.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
+	buf12.Reset();
 
 	// Temporary EFB color texture - used in ReinterpretPixelData
 	texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1, sample_desc.Count, sample_desc.Quality, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
-	CheckHR(D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueRTV, IID_PPV_ARGS(&buf12)));
-	m_efb.color_temp_tex = new D3DTexture2D(buf12, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
-	SAFE_RELEASE(buf12);
+	CheckHR(D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueRTV, IID_PPV_ARGS(buf12.GetAddressOf())));
+	m_efb.color_temp_tex = new D3DTexture2D(buf12.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R8G8B8A8_UNORM, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
+	buf12.Reset();
 	D3D::SetDebugObjectName12(m_efb.color_temp_tex->GetTex12(), "EFB color temp texture");
 
 	// EFB depth buffer - primary depth buffer
 	texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, sample_desc.Count, sample_desc.Quality, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
-	CheckHR(D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueDSV, IID_PPV_ARGS(&buf12)));
+	CheckHR(D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, &optimized_clear_valueDSV, IID_PPV_ARGS(buf12.GetAddressOf())));
 
-	m_efb.depth_tex = new D3DTexture2D(buf12, (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
-	SAFE_RELEASE(buf12);
+	m_efb.depth_tex = new D3DTexture2D(buf12.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_D32_FLOAT, DXGI_FORMAT_UNKNOWN, (sample_desc.Count > 1), D3D12_RESOURCE_STATE_COMMON);
+	buf12.Reset();
 	D3D::SetDebugObjectName12(m_efb.depth_tex->GetTex12(), "EFB depth texture");
 
 	if (g_ActiveConfig.iMultisamples > 1)
 	{
 		// Framebuffer resolve textures (color+depth)
 		texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM, m_target_width, m_target_height, m_efb.slices, 1);
-		hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&buf12));
+		hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(buf12.GetAddressOf()));
 		CHECK(hr == S_OK, "create EFB color resolve texture (size: %dx%d)", m_target_width, m_target_height);
-		m_efb.resolved_color_tex = new D3DTexture2D(buf12, D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_COMMON);
-		SAFE_RELEASE(buf12);
+		m_efb.resolved_color_tex = new D3DTexture2D(buf12.Get(), D3D11_BIND_SHADER_RESOURCE, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_COMMON);
+		buf12.Reset();
 		D3D::SetDebugObjectName12(m_efb.resolved_color_tex->GetTex12(), "EFB color resolve texture shader resource view");
 
 		texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R32_FLOAT, m_target_width, m_target_height, m_efb.slices, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
-		hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&buf12));
+		hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(buf12.GetAddressOf()));
 		CHECK(hr == S_OK, "create EFB depth resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_depth_tex = new D3DTexture2D(buf12, (D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_COMMON);
-		SAFE_RELEASE(buf12);
+		m_efb.resolved_depth_tex = new D3DTexture2D(buf12.Get(), (D3D11_BIND_FLAG)(D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_UNKNOWN, false, D3D12_RESOURCE_STATE_COMMON);
+		buf12.Reset();
 		D3D::SetDebugObjectName12(m_efb.resolved_depth_tex->GetTex12(), "EFB depth resolve texture shader resource view");
 	}
 	else
@@ -262,8 +262,8 @@ void FramebufferManager::InitializeEFBAccessCopies()
 	// EFB access - color staging/readback buffer
 	m_efb.color_access_readback_pitch = D3D::AlignValue(EFB_WIDTH * sizeof(u32), D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
 	texdesc12 = CD3DX12_RESOURCE_DESC::Buffer(m_efb.color_access_readback_pitch * EFB_HEIGHT);
-	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&m_efb.color_access_readback_buffer));
-	D3D::SetDebugObjectName12(m_efb.color_access_readback_buffer, "EFB access color readback buffer");
+	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(m_efb.color_access_readback_buffer.GetAddressOf()));
+	D3D::SetDebugObjectName12(m_efb.color_access_readback_buffer.Get(), "EFB access color readback buffer");
 
 	// EFB access - depth resize buffer
 	texdesc12 = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R32_FLOAT, EFB_WIDTH, EFB_HEIGHT, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET, D3D12_TEXTURE_LAYOUT_UNKNOWN, 0);
@@ -276,8 +276,8 @@ void FramebufferManager::InitializeEFBAccessCopies()
 	// EFB access - depth staging/readback buffer
 	m_efb.depth_access_readback_pitch = D3D::AlignValue(EFB_WIDTH * sizeof(float), D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
 	texdesc12 = CD3DX12_RESOURCE_DESC::Buffer(m_efb.depth_access_readback_pitch * EFB_HEIGHT);
-	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&m_efb.depth_access_readback_buffer));
-	D3D::SetDebugObjectName12(m_efb.color_access_readback_buffer, "EFB access depth readback buffer");
+	hr = D3D::device12->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK), D3D12_HEAP_FLAG_NONE, &texdesc12, D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(m_efb.depth_access_readback_buffer.GetAddressOf()));
+	D3D::SetDebugObjectName12(m_efb.color_access_readback_buffer.Get(), "EFB access depth readback buffer");
 }
 
 void FramebufferManager::MapEFBColorAccessCopy()
@@ -313,7 +313,7 @@ void FramebufferManager::MapEFBColorAccessCopy()
 
 	// Copy to staging resource
 	D3D12_PLACED_SUBRESOURCE_FOOTPRINT dst_footprint = { 0, { DXGI_FORMAT_R8G8B8A8_UNORM, EFB_WIDTH, EFB_HEIGHT, 1, m_efb.color_access_readback_pitch } };
-	CD3DX12_TEXTURE_COPY_LOCATION dst_location(m_efb.color_access_readback_buffer, dst_footprint);
+	CD3DX12_TEXTURE_COPY_LOCATION dst_location(m_efb.color_access_readback_buffer.Get(), dst_footprint);
 	CD3DX12_TEXTURE_COPY_LOCATION src_location(src_resource, 0);
 	D3D::current_command_list->CopyTextureRegion(&dst_location, 0, 0, 0, &src_location, nullptr);
 
@@ -365,7 +365,7 @@ void FramebufferManager::MapEFBDepthAccessCopy()
 
 	// Copy to staging resource
 	D3D12_PLACED_SUBRESOURCE_FOOTPRINT dst_footprint = { 0,{ DXGI_FORMAT_R32_FLOAT, EFB_WIDTH, EFB_HEIGHT, 1, m_efb.depth_access_readback_pitch } };
-	CD3DX12_TEXTURE_COPY_LOCATION dst_location(m_efb.depth_access_readback_buffer, dst_footprint);
+	CD3DX12_TEXTURE_COPY_LOCATION dst_location(m_efb.depth_access_readback_buffer.Get(), dst_footprint);
 	CD3DX12_TEXTURE_COPY_LOCATION src_location(src_resource, 0);
 	D3D::current_command_list->CopyTextureRegion(&dst_location, 0, 0, 0, &src_location, nullptr);
 
@@ -404,12 +404,10 @@ void FramebufferManager::DestroyEFBAccessCopies()
 	InvalidateEFBAccessCopies();
 
 	SAFE_RELEASE(m_efb.color_access_resize_tex);
-	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_efb.color_access_readback_buffer);
-	m_efb.color_access_readback_buffer = nullptr;
+	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_efb.color_access_readback_buffer.Detach());
 
 	SAFE_RELEASE(m_efb.depth_access_resize_tex);
-	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_efb.depth_access_readback_buffer);
-	m_efb.depth_access_readback_buffer = nullptr;
+	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_efb.depth_access_readback_buffer.Detach());
 }
 
 void XFBSource::DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight)

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.h
@@ -99,12 +99,12 @@ private:
 		D3DTexture2D* resolved_depth_tex;
 
 		D3DTexture2D* color_access_resize_tex;
-		ID3D12Resource* color_access_readback_buffer;
+		ComPtr<ID3D12Resource> color_access_readback_buffer;
 		u8* color_access_readback_map;
 		u32 color_access_readback_pitch;
 
 		D3DTexture2D* depth_access_resize_tex;
-		ID3D12Resource* depth_access_readback_buffer;
+		ComPtr<ID3D12Resource> depth_access_readback_buffer;
 		u8* depth_access_readback_map;
 		u32 depth_access_readback_pitch;
 

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
@@ -118,11 +118,6 @@ void PSTextureEncoder::Shutdown()
 	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_out_readback_buffer);
 	D3D::command_list_mgr->DestroyResourceAfterCurrentCommandListExecuted(m_encode_params_buffer);
 
-	for (auto& it : m_static_shaders_blobs)
-	{
-		SAFE_RELEASE(it);
-	}
-
 	m_static_shaders_blobs.clear();
 	m_static_shaders_map.clear();
 }
@@ -273,13 +268,13 @@ D3D12_SHADER_BYTECODE PSTextureEncoder::SetStaticShader(unsigned int dst_format,
 				format |= _GX_TF_CTF;
 		}
 
-		ID3DBlob* bytecode = nullptr;
+		ComPtr<ID3DBlob> bytecode = nullptr;
 		const char* shader = TextureConversionShader::GenerateEncodingShader(format, API_D3D);
-		if (!D3D::CompilePixelShader(shader, &bytecode))
+		if (!D3D::CompilePixelShader(shader, bytecode.GetAddressOf()))
 		{
 			WARN_LOG(VIDEO, "EFB encoder shader for dst_format 0x%X, src_format %d, is_intensity %d, scale_by_half %d failed to compile",
 				dst_format, static_cast<int>(src_format), is_intensity ? 1 : 0, scale_by_half ? 1 : 0);
-			m_static_shaders_blobs[key] = {};
+			m_static_shaders_blobs[key] = nullptr;
 			return {};
 		}
 

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.h
@@ -46,7 +46,7 @@ private:
 
 	using ComboMap = std::map<ComboKey, D3D12_SHADER_BYTECODE>;
 	ComboMap m_static_shaders_map;
-	std::vector<ID3DBlob*> m_static_shaders_blobs;
+	std::vector<ComPtr<ID3DBlob>> m_static_shaders_blobs;
 };
 
 }

--- a/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
@@ -28,7 +28,7 @@ PsBytecodeCache s_ps_bytecode_cache;
 VsBytecodeCache s_vs_bytecode_cache;
 
 // Used to keep track of blobs to release at Shutdown time.
-static std::vector<ID3DBlob*> s_shader_blob_list;
+static std::vector<ComPtr<ID3DBlob>> s_shader_blob_list;
 
 // Only used for shader debugging..
 using GsHlslCache = std::map<GeometryShaderUid, std::string>;
@@ -112,9 +112,6 @@ void ShaderCache::Init()
 
 void ShaderCache::Clear()
 {
-	for (auto& iter : s_shader_blob_list)
-		SAFE_RELEASE(iter);
-
 	s_shader_blob_list.clear();
 
 	s_gs_bytecode_cache.clear();

--- a/Source/Core/VideoBackends/D3D12/StaticShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/StaticShaderCache.cpp
@@ -12,18 +12,18 @@ namespace DX12
 {
 
 // Pixel Shader blobs
-static ID3DBlob* s_color_matrix_program_blob[2] = {};
-static ID3DBlob* s_color_copy_program_blob[2] = {};
-static ID3DBlob* s_depth_matrix_program_blob[2] = {};
-static ID3DBlob* s_depth_resolve_to_color_program_blob = {};
-static ID3DBlob* s_clear_program_blob = {};
-static ID3DBlob* s_anaglyph_program_blob = {};
-static ID3DBlob* s_rgba6_to_rgb8_program_blob[2] = {};
-static ID3DBlob* s_rgb8_to_rgba6_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_color_matrix_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_color_copy_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_depth_matrix_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_depth_resolve_to_color_program_blob = {};
+static ComPtr<ID3DBlob> s_clear_program_blob = {};
+static ComPtr<ID3DBlob> s_anaglyph_program_blob = {};
+static ComPtr<ID3DBlob> s_rgba6_to_rgb8_program_blob[2] = {};
+static ComPtr<ID3DBlob> s_rgb8_to_rgba6_program_blob[2] = {};
 
 // Vertex Shader blobs/input layouts
-static ID3DBlob* s_simple_vertex_shader_blob = {};
-static ID3DBlob* s_simple_clear_vertex_shader_blob = {};
+static ComPtr<ID3DBlob> s_simple_vertex_shader_blob = {};
+static ComPtr<ID3DBlob> s_simple_clear_vertex_shader_blob = {};
 
 static const D3D12_INPUT_ELEMENT_DESC s_simple_vertex_shader_input_elements[] = {
 	{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,  0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
@@ -48,8 +48,8 @@ static const D3D12_INPUT_LAYOUT_DESC s_clear_vertex_shader_input_layout =
 };
 
 // Geometry Shader blobs
-static ID3DBlob* s_clear_geometry_shader_blob = nullptr;
-static ID3DBlob* s_copy_geometry_shader_blob = nullptr;
+static ComPtr<ID3DBlob> s_clear_geometry_shader_blob = nullptr;
+static ComPtr<ID3DBlob> s_copy_geometry_shader_blob = nullptr;
 
 // Pixel Shader HLSL
 static constexpr const char s_clear_program_hlsl[] = {
@@ -419,7 +419,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetReinterpRGBA6ToRGB8PixelShader(bool 
 	{
 		if (!s_rgba6_to_rgb8_program_blob[0])
 		{
-			D3D::CompilePixelShader(s_reint_rgba6_to_rgb8_program_hlsl, &s_rgba6_to_rgb8_program_blob[0]);
+			D3D::CompilePixelShader(s_reint_rgba6_to_rgb8_program_hlsl, s_rgba6_to_rgb8_program_blob[0].GetAddressOf());
 		}
 
 		bytecode = { s_rgba6_to_rgb8_program_blob[0]->GetBufferPointer(), s_rgba6_to_rgb8_program_blob[0]->GetBufferSize() };
@@ -430,7 +430,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetReinterpRGBA6ToRGB8PixelShader(bool 
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_reint_rgba6_to_rgb8_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_rgba6_to_rgb8_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_rgba6_to_rgb8_program_blob[1].GetAddressOf());
 		bytecode = { s_rgba6_to_rgb8_program_blob[1]->GetBufferPointer(), s_rgba6_to_rgb8_program_blob[1]->GetBufferSize() };
 	}
 	return bytecode;
@@ -444,7 +444,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetReinterpRGB8ToRGBA6PixelShader(bool 
 	{
 		if (!s_rgb8_to_rgba6_program_blob[0])
 		{
-			D3D::CompilePixelShader(s_reint_rgb8_to_rgba6_program_hlsl, &s_rgb8_to_rgba6_program_blob[0]);
+			D3D::CompilePixelShader(s_reint_rgb8_to_rgba6_program_hlsl, s_rgb8_to_rgba6_program_blob[0].GetAddressOf());
 		}
 
 		bytecode = { s_rgb8_to_rgba6_program_blob[0]->GetBufferPointer(), s_rgb8_to_rgba6_program_blob[0]->GetBufferSize() };
@@ -455,7 +455,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetReinterpRGB8ToRGBA6PixelShader(bool 
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_reint_rgb8_to_rgba6_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_rgb8_to_rgba6_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_rgb8_to_rgba6_program_blob[1].GetAddressOf());
 		bytecode = { s_rgb8_to_rgba6_program_blob[1]->GetBufferPointer(), s_rgb8_to_rgba6_program_blob[1]->GetBufferSize() };
 	}
 
@@ -479,7 +479,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetColorCopyPixelShader(bool multisampl
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_color_copy_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_color_copy_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_color_copy_program_blob[1].GetAddressOf());
 		bytecode = { s_color_copy_program_blob[1]->GetBufferPointer(), s_color_copy_program_blob[1]->GetBufferSize() };
 	}
 
@@ -499,7 +499,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetDepthResolveToColorPixelShader()
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_depth_resolve_to_color_program_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_depth_resolve_to_color_program_blob);
+		D3D::CompilePixelShader(buf, s_depth_resolve_to_color_program_blob.GetAddressOf());
 		bytecode = { s_depth_resolve_to_color_program_blob->GetBufferPointer(), s_depth_resolve_to_color_program_blob->GetBufferSize() };
 	}
 
@@ -523,7 +523,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetColorMatrixPixelShader(bool multisam
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_color_matrix_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_color_matrix_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_color_matrix_program_blob[1].GetAddressOf());
 		bytecode = { s_color_matrix_program_blob[1]->GetBufferPointer(), s_color_matrix_program_blob[1]->GetBufferSize() };
 	}
 
@@ -547,7 +547,7 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetDepthMatrixPixelShader(bool multisam
 		// create MSAA shader for current AA mode
 		std::string buf = StringFromFormat(s_depth_matrix_program_msaa_hlsl, g_ActiveConfig.iMultisamples);
 
-		D3D::CompilePixelShader(buf, &s_depth_matrix_program_blob[1]);
+		D3D::CompilePixelShader(buf, s_depth_matrix_program_blob[1].GetAddressOf());
 
 		bytecode = { s_depth_matrix_program_blob[1]->GetBufferPointer(), s_depth_matrix_program_blob[1]->GetBufferSize() };
 	}
@@ -628,58 +628,58 @@ D3D12_SHADER_BYTECODE StaticShaderCache::GetCopyGeometryShader()
 void StaticShaderCache::Init()
 {
 	// Compile static pixel shaders
-	D3D::CompilePixelShader(s_clear_program_hlsl, &s_clear_program_blob);
-	D3D::CompilePixelShader(s_anaglyph_program_hlsl, &s_anaglyph_program_blob);
-	D3D::CompilePixelShader(s_color_copy_program_hlsl, &s_color_copy_program_blob[0]);
-	D3D::CompilePixelShader(s_color_matrix_program_hlsl, &s_color_matrix_program_blob[0]);
-	D3D::CompilePixelShader(s_depth_matrix_program_hlsl, &s_depth_matrix_program_blob[0]);
+	D3D::CompilePixelShader(s_clear_program_hlsl, s_clear_program_blob.GetAddressOf());
+	D3D::CompilePixelShader(s_anaglyph_program_hlsl, s_anaglyph_program_blob.GetAddressOf());
+	D3D::CompilePixelShader(s_color_copy_program_hlsl, s_color_copy_program_blob[0].GetAddressOf());
+	D3D::CompilePixelShader(s_color_matrix_program_hlsl, s_color_matrix_program_blob[0].GetAddressOf());
+	D3D::CompilePixelShader(s_depth_matrix_program_hlsl, s_depth_matrix_program_blob[0].GetAddressOf());
 
 	// Compile static vertex shaders
-	D3D::CompileVertexShader(s_simple_vertex_shader_hlsl, &s_simple_vertex_shader_blob);
-	D3D::CompileVertexShader(s_clear_vertex_shader_hlsl, &s_simple_clear_vertex_shader_blob);
+	D3D::CompileVertexShader(s_simple_vertex_shader_hlsl, s_simple_vertex_shader_blob.GetAddressOf());
+	D3D::CompileVertexShader(s_clear_vertex_shader_hlsl, s_simple_clear_vertex_shader_blob.GetAddressOf());
 
 	// Compile static geometry shaders
-	D3D::CompileGeometryShader(s_clear_geometry_shader_hlsl, &s_clear_geometry_shader_blob);
-	D3D::CompileGeometryShader(s_copy_geometry_shader_hlsl, &s_copy_geometry_shader_blob);
+	D3D::CompileGeometryShader(s_clear_geometry_shader_hlsl, s_clear_geometry_shader_blob.GetAddressOf());
+	D3D::CompileGeometryShader(s_copy_geometry_shader_hlsl, s_copy_geometry_shader_blob.GetAddressOf());
 }
 
 // Call this when multisampling mode changes, and shaders need to be regenerated.
 void StaticShaderCache::InvalidateMSAAShaders()
 {
-	SAFE_RELEASE(s_color_copy_program_blob[1]);
-	SAFE_RELEASE(s_color_matrix_program_blob[1]);
-	SAFE_RELEASE(s_depth_matrix_program_blob[1]);
-	SAFE_RELEASE(s_rgb8_to_rgba6_program_blob[1]);
-	SAFE_RELEASE(s_rgba6_to_rgb8_program_blob[1]);
-	SAFE_RELEASE(s_depth_resolve_to_color_program_blob);
+	s_color_copy_program_blob[1].Reset();
+	s_color_matrix_program_blob[1].Reset();
+	s_depth_matrix_program_blob[1].Reset();
+	s_rgb8_to_rgba6_program_blob[1].Reset();
+	s_rgba6_to_rgb8_program_blob[1].Reset();
+	s_depth_resolve_to_color_program_blob.Reset();
 }
 
 void StaticShaderCache::Shutdown()
 {
 	// Free pixel shader blobs
 
-	SAFE_RELEASE(s_clear_program_blob);
-	SAFE_RELEASE(s_anaglyph_program_blob);
-	SAFE_RELEASE(s_depth_resolve_to_color_program_blob);
+	s_clear_program_blob.Reset();
+	s_anaglyph_program_blob.Reset();
+	s_depth_resolve_to_color_program_blob.Reset();
 
 	for (unsigned int i = 0; i < 2; ++i)
 	{
-		SAFE_RELEASE(s_color_copy_program_blob[i]);
-		SAFE_RELEASE(s_color_matrix_program_blob[i]);
-		SAFE_RELEASE(s_depth_matrix_program_blob[i]);
-		SAFE_RELEASE(s_rgba6_to_rgb8_program_blob[i]);
-		SAFE_RELEASE(s_rgb8_to_rgba6_program_blob[i]);
+		s_color_copy_program_blob[i].Reset();
+		s_color_matrix_program_blob[i].Reset();
+		s_depth_matrix_program_blob[i].Reset();
+		s_rgba6_to_rgb8_program_blob[i].Reset();
+		s_rgb8_to_rgba6_program_blob[i].Reset();
 	}
 
 	// Free vertex shader blobs
 
-	SAFE_RELEASE(s_simple_vertex_shader_blob);
-	SAFE_RELEASE(s_simple_clear_vertex_shader_blob);
+	s_simple_vertex_shader_blob.Reset();
+	s_simple_clear_vertex_shader_blob.Reset();
 
 	// Free geometry shader blobs
 
-	SAFE_RELEASE(s_clear_geometry_shader_blob);
-	SAFE_RELEASE(s_copy_geometry_shader_blob);
+	s_clear_geometry_shader_blob.Reset();
+	s_copy_geometry_shader_blob.Reset();
 }
 
 }

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -198,7 +198,7 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 	}
 	else
 	{
-		ID3D12Resource* texture_resource = nullptr;
+		ComPtr<ID3D12Resource> texture_resource = nullptr;
 
 		D3D12_RESOURCE_DESC texture_resource_desc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM,
 			config.width, config.height, 1, config.levels);
@@ -210,12 +210,12 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 			&CD3DX12_RESOURCE_DESC(texture_resource_desc),
 			D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
 			nullptr,
-			IID_PPV_ARGS(&texture_resource)
+			IID_PPV_ARGS(texture_resource.GetAddressOf())
 			)
 			);
 
 		D3DTexture2D* texture = new D3DTexture2D(
-			texture_resource,
+			texture_resource.Get(),
 			D3D11_BIND_SHADER_RESOURCE,
 			DXGI_FORMAT_UNKNOWN,
 			DXGI_FORMAT_UNKNOWN,
@@ -234,8 +234,6 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 
 		// EXISTINGD3D11TODO: better debug names
 		D3D::SetDebugObjectName12(entry->m_texture->GetTex12(), "a texture of the TextureCache");
-
-		SAFE_RELEASE(texture_resource);
 
 		return entry;
 	}


### PR DESCRIPTION
This branch changes the D3D11 and D3D12 backends. They now make use of ComPtr from the Windows Runtime Library.

Smart pointers make it harder to forget to release COM objects, and make it easier to reason about object ownership.

This is an updated version of my pull request from earlier. The older one had a custom-written COM Smart Pointer. On the suggestions of other devs, I removed the custom smart-pointer in favor of the one provided by WRL.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3714)

<!-- Reviewable:end -->
