### PR TITLE
CoreTiming: Drop ProcessFifoWaitEvents.

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -389,30 +389,6 @@ void ForceExceptionCheck(s64 cycles)
   }
 }
 
-// This raise only the events required while the fifo is processing data
-void ProcessFifoWaitEvents()
-{
-  MoveEvents();
-
-  if (!first)
-    return;
-
-  while (first)
-  {
-    if (first->time <= g_globalTimer)
-    {
-      Event* evt = first;
-      first = first->next;
-      event_types[evt->type].callback(evt->userdata, (int)(g_globalTimer - evt->time));
-      FreeEvent(evt);
-    }
-    else
-    {
-      break;
-    }
-  }
-}
-
 void MoveEvents()
 {
   BaseEvent sevt;
@@ -480,14 +456,11 @@ void LogPendingEvents()
 
 void Idle()
 {
-  // DEBUG_LOG(POWERPC, "Idle");
-
   if (SConfig::GetInstance().bSyncGPUOnSkipIdleHack)
   {
     // When the FIFO is processing data we must not advance because in this way
     // the VI will be desynchronized. So, We are waiting until the FIFO finish and
     // while we process only the events required by the FIFO.
-    ProcessFifoWaitEvents();
     Fifo::FlushGpu();
   }
 

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -60,7 +60,6 @@ void RemoveEvent(int event_type);
 void RemoveAllEvents(int event_type);
 void Advance();
 void MoveEvents();
-void ProcessFifoWaitEvents();
 
 // Pretend that the main CPU has executed enough cycles to reach the next event.
 void Idle();

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -418,44 +418,9 @@ void CheckExceptions()
   }
 
   // EXTERNAL INTERRUPT
-  else if (MSR & 0x0008000)  // Handling is delayed until MSR.EE=1.
+  else
   {
-    if (exceptions & EXCEPTION_EXTERNAL_INT)
-    {
-      // Pokemon gets this "too early", it hasn't a handler yet
-      SRR0 = NPC;
-      SRR1 = MSR & 0x87C0FFFF;
-      MSR |= (MSR >> 16) & 1;
-      MSR &= ~0x04EF36;
-      PC = NPC = 0x00000500;
-
-      INFO_LOG(POWERPC, "EXCEPTION_EXTERNAL_INT");
-      ppcState.Exceptions &= ~EXCEPTION_EXTERNAL_INT;
-
-      _dbg_assert_msg_(POWERPC, (SRR1 & 0x02) != 0, "EXTERNAL_INT unrecoverable???");
-    }
-    else if (exceptions & EXCEPTION_PERFORMANCE_MONITOR)
-    {
-      SRR0 = NPC;
-      SRR1 = MSR & 0x87C0FFFF;
-      MSR |= (MSR >> 16) & 1;
-      MSR &= ~0x04EF36;
-      PC = NPC = 0x00000F00;
-
-      INFO_LOG(POWERPC, "EXCEPTION_PERFORMANCE_MONITOR");
-      ppcState.Exceptions &= ~EXCEPTION_PERFORMANCE_MONITOR;
-    }
-    else if (exceptions & EXCEPTION_DECREMENTER)
-    {
-      SRR0 = NPC;
-      SRR1 = MSR & 0x87C0FFFF;
-      MSR |= (MSR >> 16) & 1;
-      MSR &= ~0x04EF36;
-      PC = NPC = 0x00000900;
-
-      INFO_LOG(POWERPC, "EXCEPTION_DECREMENTER");
-      ppcState.Exceptions &= ~EXCEPTION_DECREMENTER;
-    }
+    CheckExternalExceptions();
   }
 }
 

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -276,7 +276,6 @@ void GatherPipeBursted()
   if (IsOnThread())
     SetCPStatusFromCPU();
 
-  ProcessFifoEvents();
   // if we aren't linked, we don't care about gather pipe data
   if (!m_CPCtrlReg.GPLinkEnable)
   {
@@ -452,13 +451,6 @@ void SetCPStatusFromCPU()
       CommandProcessor::UpdateInterrupts(userdata);
     }
   }
-}
-
-void ProcessFifoEvents()
-{
-  if (IsOnThread() && (s_interrupt_waiting.load() || s_interrupt_finish_waiting.load() ||
-                       s_interrupt_token_waiting.load()))
-    CoreTiming::ProcessFifoWaitEvents();
 }
 
 void Shutdown()

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -137,6 +137,5 @@ void SetInterruptFinishWaiting(bool waiting);
 void SetCpClearRegister();
 void SetCpControlRegister();
 void SetCpStatusRegister();
-void ProcessFifoEvents();
 
 }  // namespace CommandProcessor


### PR DESCRIPTION
globalTimer is only written in Advance, so this function should have no function.

Never ever in 5.0.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3716)
<!-- Reviewable:end -->
