### PR TITLE
VideoSW: Drop stupid state setters.

### DIFF
--- a/Source/Core/VideoBackends/Software/Clipper.cpp
+++ b/Source/Core/VideoBackends/Software/Clipper.cpp
@@ -52,8 +52,6 @@ namespace Clipper
 		NUM_INDICES = NUM_CLIPPED_VERTICES + 3
 	};
 
-	static float m_ViewOffset[2];
-
 	static OutputVertexData ClippedVertices[NUM_CLIPPED_VERTICES];
 	static OutputVertexData *Vertices[NUM_INDICES];
 
@@ -61,12 +59,6 @@ namespace Clipper
 	{
 		for (int i = 0; i < NUM_CLIPPED_VERTICES; ++i)
 			Vertices[i+3] = &ClippedVertices[i];
-	}
-
-	void SetViewOffset()
-	{
-		m_ViewOffset[0] = xfmem.viewport.xOrig - 342;
-		m_ViewOffset[1] = xfmem.viewport.yOrig - 342;
 	}
 
 
@@ -444,8 +436,8 @@ namespace Clipper
 		Vec3 &screen = vertex->screenPosition;
 
 		float wInverse = 1.0f/projected.w;
-		screen.x = projected.x * wInverse * xfmem.viewport.wd + m_ViewOffset[0];
-		screen.y = projected.y * wInverse * xfmem.viewport.ht + m_ViewOffset[1];
+		screen.x = projected.x * wInverse * xfmem.viewport.wd + xfmem.viewport.xOrig - 342;
+		screen.y = projected.y * wInverse * xfmem.viewport.ht + xfmem.viewport.yOrig - 342;
 		screen.z = projected.z * wInverse * xfmem.viewport.zRange + xfmem.viewport.farZ;
 	}
 

--- a/Source/Core/VideoBackends/Software/Clipper.h
+++ b/Source/Core/VideoBackends/Software/Clipper.h
@@ -10,8 +10,6 @@ namespace Clipper
 {
 	void Init();
 
-	void SetViewOffset();
-
 	void ProcessTriangle(OutputVertexData *v0, OutputVertexData *v1, OutputVertexData *v2);
 
 	void ProcessLine(OutputVertexData *v0, OutputVertexData *v1);

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -64,9 +64,9 @@ static inline int iround(float x)
 	return t;
 }
 
-void SetTevReg(int reg, int comp, bool konst, s16 color)
+void SetTevReg(int reg, int comp, s16 color)
 {
-	tev.SetRegColor(reg, comp, konst, color);
+	tev.SetRegColor(reg, comp, color);
 }
 
 static void Draw(s32 x, s32 y, s32 xi, s32 yi)

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -29,11 +29,6 @@ static s32 vertex0Y;
 static float vertexOffsetX;
 static float vertexOffsetY;
 
-static s32 scissorLeft = 0;
-static s32 scissorTop = 0;
-static s32 scissorRight = 0;
-static s32 scissorBottom = 0;
-
 static Tev tev;
 static RasterBlock rasterBlock;
 
@@ -67,28 +62,6 @@ static inline int iround(float x)
 		return t + 1;
 
 	return t;
-}
-
-void SetScissor()
-{
-	int xoff = bpmem.scissorOffset.x * 2 - 342;
-	int yoff = bpmem.scissorOffset.y * 2 - 342;
-
-	scissorLeft = bpmem.scissorTL.x - xoff - 342;
-	if (scissorLeft < 0)
-		scissorLeft = 0;
-
-	scissorTop = bpmem.scissorTL.y - yoff - 342;
-	if (scissorTop < 0)
-		scissorTop = 0;
-
-	scissorRight = bpmem.scissorBR.x - xoff - 341;
-	if (scissorRight > EFB_WIDTH)
-		scissorRight = EFB_WIDTH;
-
-	scissorBottom = bpmem.scissorBR.y - yoff - 341;
-	if (scissorBottom > EFB_HEIGHT)
-		scissorBottom = EFB_HEIGHT;
 }
 
 void SetTevReg(int reg, int comp, bool konst, s16 color)
@@ -330,6 +303,25 @@ void DrawTriangleFrontFace(OutputVertexData *v0, OutputVertexData *v1, OutputVer
 	s32 maxy = (std::max(std::max(Y1, Y2), Y3) + 0xF) >> 4;
 
 	// scissor
+	int xoff = bpmem.scissorOffset.x * 2 - 342;
+	int yoff = bpmem.scissorOffset.y * 2 - 342;
+
+	s32 scissorLeft = bpmem.scissorTL.x - xoff - 342;
+	if (scissorLeft < 0)
+		scissorLeft = 0;
+
+	s32 scissorTop = bpmem.scissorTL.y - yoff - 342;
+	if (scissorTop < 0)
+		scissorTop = 0;
+
+	s32 scissorRight = bpmem.scissorBR.x - xoff - 341;
+	if (scissorRight > EFB_WIDTH)
+		scissorRight = EFB_WIDTH;
+
+	s32 scissorBottom = bpmem.scissorBR.y - yoff - 341;
+	if (scissorBottom > EFB_HEIGHT)
+		scissorBottom = EFB_HEIGHT;
+
 	minx = std::max(minx, scissorLeft);
 	maxx = std::min(maxx, scissorRight);
 	miny = std::max(miny, scissorTop);

--- a/Source/Core/VideoBackends/Software/Rasterizer.h
+++ b/Source/Core/VideoBackends/Software/Rasterizer.h
@@ -14,7 +14,7 @@ namespace Rasterizer
 
 	void DrawTriangleFrontFace(OutputVertexData *v0, OutputVertexData *v1, OutputVertexData *v2);
 
-	void SetTevReg(int reg, int comp, bool konst, s16 color);
+	void SetTevReg(int reg, int comp, s16 color);
 
 	struct Slope
 	{

--- a/Source/Core/VideoBackends/Software/Rasterizer.h
+++ b/Source/Core/VideoBackends/Software/Rasterizer.h
@@ -14,8 +14,6 @@ namespace Rasterizer
 
 	void DrawTriangleFrontFace(OutputVertexData *v0, OutputVertexData *v1, OutputVertexData *v2);
 
-	void SetScissor();
-
 	void SetTevReg(int reg, int comp, bool konst, s16 color);
 
 	struct Slope

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -79,7 +79,6 @@ void SWVertexLoader::vFlush(bool useDstAlpha)
 	m_SetupUnit->Init(primitiveType);
 
 	// set all states with are stored within video sw
-	Clipper::SetViewOffset();
 	Rasterizer::SetScissor();
 	for (int i = 0; i < 4; i++)
 	{

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -81,14 +81,10 @@ void SWVertexLoader::vFlush(bool useDstAlpha)
 	// set all states with are stored within video sw
 	for (int i = 0; i < 4; i++)
 	{
-		Rasterizer::SetTevReg(i, Tev::RED_C, false, PixelShaderManager::constants.colors[i][0]);
-		Rasterizer::SetTevReg(i, Tev::GRN_C, false, PixelShaderManager::constants.colors[i][1]);
-		Rasterizer::SetTevReg(i, Tev::BLU_C, false, PixelShaderManager::constants.colors[i][2]);
-		Rasterizer::SetTevReg(i, Tev::ALP_C, false, PixelShaderManager::constants.colors[i][3]);
-		Rasterizer::SetTevReg(i, Tev::RED_C, true, PixelShaderManager::constants.kcolors[i][0]);
-		Rasterizer::SetTevReg(i, Tev::GRN_C, true, PixelShaderManager::constants.kcolors[i][1]);
-		Rasterizer::SetTevReg(i, Tev::BLU_C, true, PixelShaderManager::constants.kcolors[i][2]);
-		Rasterizer::SetTevReg(i, Tev::ALP_C, true, PixelShaderManager::constants.kcolors[i][3]);
+		Rasterizer::SetTevReg(i, Tev::RED_C, PixelShaderManager::constants.kcolors[i][0]);
+		Rasterizer::SetTevReg(i, Tev::GRN_C, PixelShaderManager::constants.kcolors[i][1]);
+		Rasterizer::SetTevReg(i, Tev::BLU_C, PixelShaderManager::constants.kcolors[i][2]);
+		Rasterizer::SetTevReg(i, Tev::ALP_C, PixelShaderManager::constants.kcolors[i][3]);
 	}
 
 	for (u32 i = 0; i < IndexGenerator::GetIndexLen(); i++)

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -79,7 +79,6 @@ void SWVertexLoader::vFlush(bool useDstAlpha)
 	m_SetupUnit->Init(primitiveType);
 
 	// set all states with are stored within video sw
-	Rasterizer::SetScissor();
 	for (int i = 0; i < 4; i++)
 	{
 		Rasterizer::SetTevReg(i, Tev::RED_C, false, PixelShaderManager::constants.colors[i][0]);

--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -13,6 +13,7 @@
 
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/PerfQueryBase.h"
+#include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
@@ -513,6 +514,15 @@ void Tev::Draw()
 
 	INCSTAT(stats.thisFrame.tevPixelsIn);
 
+	// initial color values
+	for (int i = 0; i < 4; i++)
+	{
+		Reg[i][RED_C] = PixelShaderManager::constants.colors[i][0];
+		Reg[i][GRN_C] = PixelShaderManager::constants.colors[i][1];
+		Reg[i][BLU_C] = PixelShaderManager::constants.colors[i][2];
+		Reg[i][ALP_C] = PixelShaderManager::constants.colors[i][3];
+	}
+
 	for (unsigned int stageNum = 0; stageNum < bpmem.genMode.numindstages; stageNum++)
 	{
 		int stageNum2 = stageNum >> 1;
@@ -800,15 +810,8 @@ void Tev::Draw()
 	EfbInterface::BlendTev(Position[0], Position[1], output);
 }
 
-void Tev::SetRegColor(int reg, int comp, bool konst, s16 color)
+void Tev::SetRegColor(int reg, int comp, s16 color)
 {
-	if (konst)
-	{
-		KonstantColors[reg][comp] = color;
-	}
-	else
-	{
-		Reg[reg][comp] = color;
-	}
+	KonstantColors[reg][comp] = color;
 }
 

--- a/Source/Core/VideoBackends/Software/Tev.h
+++ b/Source/Core/VideoBackends/Software/Tev.h
@@ -87,5 +87,5 @@ public:
 
 	void Draw();
 
-	void SetRegColor(int reg, int comp, bool konst, s16 color);
+	void SetRegColor(int reg, int comp, s16 color);
 };


### PR DESCRIPTION
Just access the global state directly. Global state is bad, but having a bad global state fetcher is worse.

This likely also fixes a bug with colors.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3717)
<!-- Reviewable:end -->
