### PR TITLE
Fix emboss map path without any normals enabled.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -249,10 +249,8 @@ static T GenerateVertexShader(API_TYPE api_type)
 				}
 				else
 				{
-					// The following assert was triggered in House of the Dead Overkill and Star Wars Rogue Squadron 2
-					//_assert_(0); // should have normals
-					uid_data->texMtxInfo[i].embosssourceshift = xfmem.texMtxInfo[i].embosssourceshift;
-					out.Write("o.tex%d.xyz = o.tex%d.xyz;\n", i, texinfo.embosssourceshift);
+					// Even if inputform ABC1 is set, it only uses AB11
+					out.Write("o.tex%d.xyz = float3(coord.xy, 1.0);\n", i);
 				}
 
 				break;


### PR DESCRIPTION
Confirmed with a hardware test that it doesn't pull from the emboss source, but instead from the source row instead.

One thing left to test is to enable lighting and see if it effects the coordinates.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3718)
<!-- Reviewable:end -->
