### PR TITLE
[WXGUI] Adjust layout of ControllerConfigDiag

### DIFF
--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -33,6 +33,7 @@ set(GUI_SRCS
 	Debugger/RegisterWindow.cpp
 	Debugger/WatchView.cpp
 	Debugger/WatchWindow.cpp
+	DolphinSlider.cpp
 	NetPlay/ChangeGameDialog.cpp
 	NetPlay/NetPlaySetupFrame.cpp
 	NetPlay/NetWindow.cpp

--- a/Source/Core/DolphinWX/DolphinSlider.cpp
+++ b/Source/Core/DolphinWX/DolphinSlider.cpp
@@ -1,0 +1,43 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinWX/DolphinSlider.h"
+#include "DolphinWX/WxUtils.h"
+
+
+bool DolphinSlider::Create(wxWindow* parent, wxWindowID id, int value, int min_val, int max_val,
+                           const wxPoint& pos, const wxSize& size, long style,
+                           const wxValidator& validator, const wxString& name)
+{
+	// Sanitise the style flags.
+	// We don't want any label flags because those break DPI scaling on wxMSW,
+	// wxWidgets will internally lock the height of the slider to 32 pixels.
+	style &= ~wxSL_LABELS;
+
+	return wxSlider::Create(parent, id, value, min_val, max_val, pos, size, style, validator, name);
+}
+
+wxSize DolphinSlider::DoGetBestSize() const
+{
+#ifdef _WIN32
+	// Convert the 96DPI pixel size into screen pixel size.
+	return WxUtils::FromDIP(wxSlider::DoGetBestSize(), this);
+#else
+	// GTK Styles sometimes don't return a default length.
+	wxSize best_size = wxSlider::DoGetBestSize();
+	// Vertical is the dominant flag if both are set.
+	if (HasFlag(wxSL_VERTICAL))
+	{
+		if (best_size.GetHeight() < 1)
+		{
+			best_size.SetHeight(WxUtils::FromDIP(100, this, wxVERTICAL));
+		}
+	}
+	else if (best_size.GetWidth() < 1)
+	{
+		best_size.SetWidth(WxUtils::FromDIP(100, this, wxHORIZONTAL));
+	}
+	return best_size;
+#endif
+}

--- a/Source/Core/DolphinWX/DolphinSlider.h
+++ b/Source/Core/DolphinWX/DolphinSlider.h
@@ -1,0 +1,47 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "wx/slider.h"
+
+// wxSlider has several bugs, including not scaling with DPI.
+// This extended slider class tries to paper over the flaws.
+class DolphinSlider : public wxSlider
+{
+public:
+	DolphinSlider()
+	{
+	}
+
+	DolphinSlider(const DolphinSlider&) = delete;
+
+	DolphinSlider(wxWindow* parent, wxWindowID id,
+	              int value, int min_value, int max_value,
+	              const wxPoint& pos = wxDefaultPosition,
+	              const wxSize& size = wxDefaultSize,
+	              long style = wxSL_HORIZONTAL,
+	              const wxValidator& validator = wxDefaultValidator,
+	              const wxString& name = wxSliderNameStr)
+	{
+		Create(parent, id, value, min_value, max_value, pos, size, style, validator, name);
+	}
+
+	DolphinSlider& operator=(const DolphinSlider&) = delete;
+
+	bool Create(wxWindow* parent, wxWindowID id,
+	            int value, int min_value, int max_value,
+	            const wxPoint& pos = wxDefaultPosition,
+	            const wxSize& size = wxDefaultSize,
+	            long style = wxSL_HORIZONTAL,
+	            const wxValidator& validator = wxDefaultValidator,
+	            const wxString& name = wxSliderNameStr);
+
+protected:
+	// The base implementation in wxMSW::wxSlider is borked.
+	// This is called by GetEffectiveMinSize() which is used by
+	// wxSizers to decide the size of the widget for generating layout.
+	wxSize DoGetBestSize() const override;
+};
+

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -50,6 +50,9 @@
     </ResourceCompile>
     <ClCompile />
     <ClCompile />
+    <Manifest>
+      <EnableDpiAwareness>true</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AboutDolphin.cpp" />
@@ -85,6 +88,7 @@
     <ClCompile Include="Debugger\RegisterWindow.cpp" />
     <ClCompile Include="Debugger\WatchView.cpp" />
     <ClCompile Include="Debugger\WatchWindow.cpp" />
+    <ClCompile Include="DolphinSlider.cpp" />
     <ClCompile Include="NetPlay\ChangeGameDialog.cpp" />
     <ClCompile Include="NetPlay\NetPlaySetupFrame.cpp" />
     <ClCompile Include="NetPlay\NetWindow.cpp" />
@@ -123,6 +127,7 @@
     <ClInclude Include="Config\InterfaceConfigPane.h" />
     <ClInclude Include="Config\PathConfigPane.h" />
     <ClInclude Include="Config\WiiConfigPane.h" />
+    <ClInclude Include="DolphinSlider.h" />
     <ClInclude Include="NetPlay\ChangeGameDialog.h" />
     <ClInclude Include="NetPlay\NetPlaySetupFrame.h" />
     <ClInclude Include="NetPlay\PadMapDialog.h" />

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="GUI">
@@ -27,6 +27,9 @@
     </Filter>
     <Filter Include="GUI\Config">
       <UniqueIdentifier>{9d8b4144-f335-4fa4-b995-852533298474}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Widgets">
+      <UniqueIdentifier>{daeb9aa8-dae9-481c-94f0-e5b15a688a89}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -199,6 +202,9 @@
     <ClCompile Include="NetPlay\PadMapDialog.cpp">
       <Filter>GUI\NetPlay</Filter>
     </ClCompile>
+    <ClCompile Include="DolphinSlider.cpp">
+      <Filter>Widgets</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Main.h" />
@@ -362,6 +368,9 @@
     </ClInclude>
     <ClInclude Include="NetPlay\PadMapDialog.h">
       <Filter>GUI\NetPlay</Filter>
+    </ClInclude>
+    <ClInclude Include="DolphinSlider.h">
+      <Filter>Widgets</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/DolphinWX/WxUtils.cpp
+++ b/Source/Core/DolphinWX/WxUtils.cpp
@@ -2,9 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <string>
 #include <wx/app.h>
 #include <wx/bitmap.h>
+#include <wx/dcclient.h>
 #include <wx/gdicmn.h>
 #include <wx/image.h>
 #include <wx/msgdlg.h>
@@ -104,6 +106,68 @@ void AddToolbarButton(wxToolBar* toolbar, int toolID, const wxString& label, con
 	// Must explicitly set the disabled button bitmap because wxWidgets
 	// incorrectly desaturates it instead of lightening it.
 	toolbar->AddTool(toolID, label, bitmap, WxUtils::CreateDisabledButtonBitmap(bitmap), wxITEM_NORMAL, shortHelp);
+}
+
+// NOTE: In wxWidgets 3.1.0 there is a native function (wxWindowBase::FromDIP()) which
+//	is functionally similar and can be used instead.
+wxPoint FromDIP(wxPoint dip_pixels, const wxWindow* context)
+{
+	static constexpr int CSS_PPI = 96;
+
+	wxSize ppi;
+	{
+		wxClientDC dc(const_cast<wxWindow*>(context));
+		ppi = dc.GetPPI();
+	}
+
+	// Clamp PPI to >= 96. We only want to scale UP, never down.
+	// Scaling down will result in bad things happening (too small to read, etc).
+	// [Values less than 96 are possible on Linux, since Linux actually tries to
+	//  be accurate about this but monitors lie about their dimensions]
+	// NOTE: OS X may just return 72 as PPI always. On OS X,
+	//	wxWindow::GetContentScaleFactor() will return 2.0 for Retina mode which
+	//	can be used to scale raster images, but you can't actually get the DPI.
+	//	(Not that you would want to since native widgets scale themselves).
+	ppi.IncTo(wxSize(CSS_PPI, CSS_PPI));
+
+	// MulDiv rounds the result.
+	if (dip_pixels.x != wxDefaultCoord)
+		dip_pixels.x = wxMulDivInt32(dip_pixels.x, ppi.GetWidth(), CSS_PPI);
+	if (dip_pixels.y != wxDefaultCoord)
+		dip_pixels.y = wxMulDivInt32(dip_pixels.y, ppi.GetHeight(), CSS_PPI);
+	return dip_pixels;
+}
+
+int FromDIP(int value, const wxWindow* context, wxOrientation direction)
+{
+	if (value < 1)
+		return value;
+
+	wxPoint result = FromDIP(wxPoint(value, value), context);
+	if ((direction & wxBOTH) == wxBOTH)
+		return std::max(result.x, result.y);
+	else if (direction & wxVERTICAL)
+		return result.y;
+	return result.x;
+}
+
+void SetSizeRange(wxWindow* window, wxSize min_size, wxSize max_size)
+{
+	window->SetMinSize(wxDefaultSize);
+	window->SetMaxSize(wxDefaultSize);
+
+	wxSize best_size = window->GetBestSize();
+	best_size.DecToIfSpecified(max_size);
+	min_size.DecToIfSpecified(max_size);
+
+	if (min_size.GetWidth() == wxDefaultCoord)
+		best_size.SetWidth(wxDefaultCoord);
+	if (min_size.GetHeight() == wxDefaultCoord)
+		best_size.SetHeight(wxDefaultCoord);
+	min_size.IncTo(best_size);
+
+	window->SetMinSize(min_size);
+	window->SetMaxSize(max_size);
 }
 
 }  // namespace

--- a/Source/Core/DolphinWX/WxUtils.h
+++ b/Source/Core/DolphinWX/WxUtils.h
@@ -10,6 +10,7 @@
 
 class wxBitmap;
 class wxToolBar;
+class wxWindow;
 
 namespace WxUtils
 {
@@ -31,6 +32,32 @@ wxBitmap CreateDisabledButtonBitmap(const wxBitmap& original);
 
 // Helper function to add a button to a toolbar
 void AddToolbarButton(wxToolBar* toolbar, int toolID, const wxString& label, const wxBitmap& bitmap, const wxString& shortHelp);
+
+// Convert a coordinate from 96DPI "device independent pixel" coordinates (aka "CSS Pixels")
+// to 'real' screen pixels. This is more convenient than wxDLG_UNIT for things like drawing,
+// borders and element spacing.
+// NOTE: This function exists natively in wxWidgets 3.1.0 as wxWindowBase::FromDIP()
+wxPoint FromDIP(wxPoint dip_pixels, const wxWindow* context);
+inline wxSize FromDIP(const wxSize& size, const wxWindow* context)
+{
+	wxPoint tmp = FromDIP(wxPoint(size.GetWidth(), size.GetHeight()), context);
+	return { tmp.x, tmp.y };
+}
+// NOTE: wxSize/wxPoint versions should usually be used instead where possible to properly handle
+//	rectangular DPIs.
+int FromDIP(int value, const wxWindow* context, wxOrientation direction = wxBOTH);
+
+// wxSizers use the minimum size when computing layout instead of best size.
+// The best size is only taken when the minsize is -1,-1 (i.e. undefined).
+// This means that elements with a MinSize specified will always have that
+// size unless wxEXPAND-ed.
+// This function increases MinSize up to BestSize while clamping to the
+// given MaxSize if specified.
+void SetSizeRange(wxWindow* window, wxSize min_size, wxSize max_size = wxDefaultSize);
+inline void SetSizeRangeDIP(wxWindow* window, const wxSize& min_size, const wxSize& max_size = wxDefaultSize)
+{
+	SetSizeRange(window, FromDIP(min_size, window), FromDIP(max_size, window));
+}
 
 }  // namespace
 


### PR DESCRIPTION
The UI layout in Dolphin's controller configuration has always looked kind of... off. The wiimote section has never properly aligned with the gamecube section and the buttons are different sizes so I took a stab at trying to 'gridize' it.
![uipatchv3](https://cloud.githubusercontent.com/assets/17393426/13700752/eb1e6158-e7d6-11e5-876f-2c0a44807921.png)

Lioncash also pointed out that several of Dolphin's GUIs have problems with HiDPI display modes so I also tried to fix that as well:
![hidpiv1](https://cloud.githubusercontent.com/assets/17393426/13700778/11e63f04-e7d7-11e5-9b55-f5ce1d21efb9.png)

Code has only been tested on Windows, but I have tried multiple languages.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3720)
<!-- Reviewable:end -->
