### PR TITLE
Refine copyright line

### DIFF
--- a/Source/Core/DolphinQt2/AboutDialog.cpp
+++ b/Source/Core/DolphinQt2/AboutDialog.cpp
@@ -44,7 +44,7 @@ AboutDialog::AboutDialog(QWidget* parent)
 	text_label->setOpenExternalLinks(true);
 
 	QLabel* copyright = new QLabel(tr(
-		"© 2003-%1 Dolphin Team. “GameCube” and “Wii” are"
+		"Copyright © 2003–%1 Dolphin authors. “GameCube” and “Wii” are"
 		" trademarks of Nintendo. Dolphin is not affiliated with Nintendo in any way."
 	).arg(QStringLiteral(__DATE__).right(4)));
 


### PR DESCRIPTION
"Dolphin Team" is not a legal entity and even if it were, it wouldn't hold the contributors' copyrights.
OTOH there's already an "Authors" link to the contributors on Github.

Even though not strictly necessary, using the spelled-out word "Copyright" is a common convention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3723)
<!-- Reviewable:end -->
