### PR TITLE
NonCopyable: Minor changes

### DIFF
--- a/Source/Core/Common/NonCopyable.h
+++ b/Source/Core/Common/NonCopyable.h
@@ -11,7 +11,6 @@ protected:
 	constexpr NonCopyable() = default;
 	~NonCopyable() = default;
 
-private:
 	NonCopyable(const NonCopyable&) = delete;
 	NonCopyable& operator=(const NonCopyable&) = delete;
 };

--- a/Source/Core/Common/NonCopyable.h
+++ b/Source/Core/Common/NonCopyable.h
@@ -12,6 +12,6 @@ protected:
 	~NonCopyable() = default;
 
 private:
-	NonCopyable(NonCopyable&) = delete;
-	NonCopyable& operator=(NonCopyable&) = delete;
+	NonCopyable(const NonCopyable&) = delete;
+	NonCopyable& operator=(const NonCopyable&) = delete;
 };


### PR DESCRIPTION
The compiler auto-generates the copy constructor/assignment functions with const qualified parameters, so we should specify those instead.

Also, this removes the private access specifier, since this isn't necessary, as the members are deleted. This will also change the compiler error on attempted copies to indicate that the constructor/member function is deleted, rather than inaccessible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3730)
<!-- Reviewable:end -->
