### PR TITLE
DolphinQt2: Set a minimum width for toolbar buttons + fix stop button

### DIFF
--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -28,6 +28,8 @@ void ToolBar::EmulationStarted()
   m_play_action->setVisible(false);
   m_pause_action->setEnabled(true);
   m_pause_action->setVisible(true);
+  m_stop_action->setEnabled(true);
+  m_stop_action->setVisible(true);
   m_fullscreen_action->setEnabled(true);
   m_screenshot_action->setEnabled(true);
 }
@@ -38,6 +40,8 @@ void ToolBar::EmulationPaused()
   m_play_action->setVisible(true);
   m_pause_action->setEnabled(false);
   m_pause_action->setVisible(false);
+  m_stop_action->setEnabled(true);
+  m_stop_action->setVisible(true);
 }
 
 void ToolBar::EmulationStopped()
@@ -53,18 +57,35 @@ void ToolBar::EmulationStopped()
 
 void ToolBar::MakeActions()
 {
+  constexpr int button_width = 65;
   m_open_action = addAction(tr("Open"), this, SIGNAL(OpenPressed()));
+  widgetForAction(m_open_action)->setMinimumWidth(button_width);
+
   m_play_action = addAction(tr("Play"), this, SIGNAL(PlayPressed()));
+  widgetForAction(m_play_action)->setMinimumWidth(button_width);
+
   m_pause_action = addAction(tr("Pause"), this, SIGNAL(PausePressed()));
+  widgetForAction(m_pause_action)->setMinimumWidth(button_width);
+
   m_stop_action = addAction(tr("Stop"), this, SIGNAL(StopPressed()));
+  widgetForAction(m_stop_action)->setMinimumWidth(button_width);
+
   m_fullscreen_action = addAction(tr("Full Screen"), this, SIGNAL(FullScreenPressed()));
+  widgetForAction(m_fullscreen_action)->setMinimumWidth(button_width);
+
   m_screenshot_action = addAction(tr("Screen Shot"), this, SIGNAL(ScreenShotPressed()));
+  widgetForAction(m_screenshot_action)->setMinimumWidth(button_width);
 
   addSeparator();
 
   m_paths_action = addAction(tr("Paths"), this, SIGNAL(PathsPressed()));
+  widgetForAction(m_paths_action)->setMinimumWidth(button_width);
+
   m_config_action = addAction(tr("Settings"), this, SIGNAL(SettingsPressed()));
+  widgetForAction(m_config_action)->setMinimumWidth(button_width);
+
   m_controllers_action = addAction(tr("Controllers"));
+  widgetForAction(m_controllers_action)->setMinimumWidth(button_width);
   m_controllers_action->setEnabled(false);
 }
 


### PR DESCRIPTION
Using a minimum width is a good compromise between setting all buttons to the same width and letting them all decide their own width.
This is because the small buttons are kept tidy and regular while allowing the biggest buttons to fit their contents.

Bottom: before
Top: after
![toolbarwidth](https://cloud.githubusercontent.com/assets/5120858/13903076/2299bf9a-eebe-11e5-903e-43a746c1c324.png)

I also snuck in a simple fix for the stop button, for which reenabling on start and pause was deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3740)
<!-- Reviewable:end -->
