### PR TITLE
Implement Dithering for video software

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -391,6 +391,20 @@ namespace EfbInterface
 		}
 	}
 
+	static void Dither(u16 x, u16 y, u8 *color)
+	{
+		// No blending for RGB8 mode
+		if (!bpmem.blendmode.dither || bpmem.zcontrol.pixel_format != PEControl::PixelFormat::RGBA6_Z24)
+			return;
+
+		// Flipper uses a standard 2x2 Bayer Matrix for 6 bit dithering
+		static const u8 dither[2][2] = {{0, 2}, {3, 1}};
+
+		// Only the color channels are dithered?
+		for (int i = BLU_C; i <= RED_C; i++)
+			color[i] = ((color[i] - (color[i] >> 6)) + dither[y & 1][x & 1]) & 0xfc;
+	}
+
 	void BlendTev(u16 x, u16 y, u8 *color)
 	{
 		u32 dstClr;
@@ -421,6 +435,7 @@ namespace EfbInterface
 
 		if (bpmem.blendmode.colorupdate)
 		{
+			Dither(x, y, dstClrPtr);
 			if (bpmem.blendmode.alphaupdate)
 				SetPixelAlphaColor(offset, dstClrPtr);
 			else


### PR DESCRIPTION
This implements dithering for 6bit colors.

5 bit dithering (used in AA mode with RGB565 colors) isn't implemented, I have no idea how the dither  pattern would be applied to the 3 super-samples (we don't implement super-sampling anyway)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3742)
<!-- Reviewable:end -->
