### PR TITLE
[WIP] Software renderer's specialCase breaks sms-water

### DIFF
--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -115,7 +115,7 @@ void SWVertexLoader::vFlush(bool useDstAlpha)
 			TransformUnit::TransformNormal(&m_Vertex, (VertexLoaderManager::g_current_components & VB_HAS_NRM2) != 0, outVertex);
 		}
 		TransformUnit::TransformColor(&m_Vertex, outVertex);
-		TransformUnit::TransformTexCoord(&m_Vertex, outVertex, m_TexGenSpecialCase);
+		TransformUnit::TransformTexCoord(&m_Vertex, outVertex);
 
 		// assemble and rasterize the primitive
 		m_SetupUnit->SetupVertex();
@@ -151,13 +151,6 @@ void SWVertexLoader::SetFormat(u8 attributeIndex, u8 primitiveType)
 	m_Vertex.texMtx[5] = xfmem.MatrixIndexB.Tex5MtxIdx;
 	m_Vertex.texMtx[6] = xfmem.MatrixIndexB.Tex6MtxIdx;
 	m_Vertex.texMtx[7] = xfmem.MatrixIndexB.Tex7MtxIdx;
-
-
-	// special case if only pos and tex coord 0 and tex coord input is AB11
-	m_TexGenSpecialCase =
-		((g_main_cp_state.vtx_desc.Hex & 0x60600L) == g_main_cp_state.vtx_desc.Hex) && // only pos and tex coord 0
-		(g_main_cp_state.vtx_desc.Tex0Coord != NOT_PRESENT) &&
-		(xfmem.texMtxInfo[0].projection == XF_TEXPROJ_ST);
 }
 
 template <typename T, typename I>

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.h
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.h
@@ -39,8 +39,6 @@ private:
 
 	SetupUnit *m_SetupUnit;
 
-	bool m_TexGenSpecialCase;
-
 public:
 
 	void SetFormat(u8 attributeIndex, u8 primitiveType);

--- a/Source/Core/VideoBackends/Software/TransformUnit.cpp
+++ b/Source/Core/VideoBackends/Software/TransformUnit.cpp
@@ -103,7 +103,7 @@ void TransformNormal(const InputVertexData *src, bool nbt, OutputVertexData *dst
 	}
 }
 
-static void TransformTexCoordRegular(const TexMtxInfo &texinfo, int coordNum, bool specialCase, const InputVertexData *srcVertex, OutputVertexData *dstVertex)
+static void TransformTexCoordRegular(const TexMtxInfo &texinfo, int coordNum, const InputVertexData *srcVertex, OutputVertexData *dstVertex)
 {
 	const Vec3 *src;
 	switch (texinfo.sourcerow)
@@ -131,15 +131,13 @@ static void TransformTexCoordRegular(const TexMtxInfo &texinfo, int coordNum, bo
 
 	if (texinfo.projection == XF_TEXPROJ_ST)
 	{
-		if (texinfo.inputform == XF_TEXINPUT_AB11 || specialCase)
+		if (texinfo.inputform == XF_TEXINPUT_AB11)
 			MultiplyVec2Mat24(*src, mat, *dst);
 		else
 			MultiplyVec3Mat24(*src, mat, *dst);
 	}
 	else // texinfo.projection == XF_TEXPROJ_STQ
 	{
-		_assert_(!specialCase);
-
 		if (texinfo.inputform == XF_TEXINPUT_AB11)
 			MultiplyVec2Mat34(*src, mat, *dst);
 		else
@@ -154,27 +152,12 @@ static void TransformTexCoordRegular(const TexMtxInfo &texinfo, int coordNum, bo
 		const PostMtxInfo &postInfo = xfmem.postMtxInfo[coordNum];
 		const float* postMat = &xfmem.postMatrices[postInfo.index * 4];
 
-		if (specialCase)
-		{
-			// no normalization
-			// q of input is 1
-			// q of output is unknown
-			tempCoord.x = dst->x;
-			tempCoord.y = dst->y;
-
-			dst->x = postMat[0] * tempCoord.x + postMat[1] * tempCoord.y + postMat[2] + postMat[3];
-			dst->y = postMat[4] * tempCoord.x + postMat[5] * tempCoord.y + postMat[6] + postMat[7];
-			dst->z = 1.0f;
-		}
+		if (postInfo.normalize)
+			tempCoord = dst->Normalized();
 		else
-		{
-			if (postInfo.normalize)
-				tempCoord = dst->Normalized();
-			else
-				tempCoord = *dst;
+			tempCoord = *dst;
 
-			MultiplyVec3Mat34(tempCoord, postMat, *dst);
-		}
+		MultiplyVec3Mat34(tempCoord, postMat, *dst);
 	}
 }
 
@@ -382,7 +365,7 @@ void TransformColor(const InputVertexData *src, OutputVertexData *dst)
 	}
 }
 
-void TransformTexCoord(const InputVertexData *src, OutputVertexData *dst, bool specialCase)
+void TransformTexCoord(const InputVertexData *src, OutputVertexData *dst)
 {
 	for (u32 coordNum = 0; coordNum < xfmem.numTexGen.numTexGens; coordNum++)
 	{
@@ -391,7 +374,7 @@ void TransformTexCoord(const InputVertexData *src, OutputVertexData *dst, bool s
 		switch (texinfo.texgentype)
 		{
 		case XF_TEXGEN_REGULAR:
-			TransformTexCoordRegular(texinfo, coordNum, specialCase, src, dst);
+			TransformTexCoordRegular(texinfo, coordNum, src, dst);
 			break;
 		case XF_TEXGEN_EMBOSS_MAP:
 			{

--- a/Source/Core/VideoBackends/Software/TransformUnit.h
+++ b/Source/Core/VideoBackends/Software/TransformUnit.h
@@ -12,5 +12,5 @@ namespace TransformUnit
 	void TransformPosition(const InputVertexData *src, OutputVertexData *dst);
 	void TransformNormal(const InputVertexData *src, bool nbt, OutputVertexData *dst);
 	void TransformColor(const InputVertexData *src, OutputVertexData *dst);
-	void TransformTexCoord(const InputVertexData *src, OutputVertexData *dst, bool specialCase);
+	void TransformTexCoord(const InputVertexData *src, OutputVertexData *dst);
 }


### PR DESCRIPTION
If the current texture's projection is XF_TEXPROJ_STQ the specialCase still triggers, and messes up rendering in the post matrix stage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3743)
<!-- Reviewable:end -->
