### PR TITLE
VideoSW: Fix special case.

### DIFF
--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -154,10 +154,10 @@ void SWVertexLoader::SetFormat(u8 attributeIndex, u8 primitiveType)
 
 
 	// special case if only pos and tex coord 0 and tex coord input is AB11
+	// http://libogc.devkitpro.org/gx_8h.html#a55a426a3ff796db584302bddd829f002
 	m_TexGenSpecialCase =
-		((g_main_cp_state.vtx_desc.Hex & 0x60600L) == g_main_cp_state.vtx_desc.Hex) && // only pos and tex coord 0
-		(g_main_cp_state.vtx_desc.Tex0Coord != NOT_PRESENT) &&
-		(xfmem.texMtxInfo[0].projection == XF_TEXPROJ_ST);
+		VertexLoaderManager::g_current_components == VB_HAS_UV0 &&
+		xfmem.texMtxInfo[0].projection == XF_TEXPROJ_ST;
 }
 
 template <typename T, typename I>


### PR DESCRIPTION
I have no clue what this special case shall be, but accessing g_main_cp_state within Flush() is not allowed.
We likely still have a bad behavior, but now it only depends on the current state, not on the next one after flushing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3744)
<!-- Reviewable:end -->
