### PR TITLE
D3D11: Fix EFB MSAA depth buffer copies, StateManager desyncs in some cases

### DIFF
--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -24,7 +24,6 @@ static XFBEncoder s_xfbEncoder;
 FramebufferManager::Efb FramebufferManager::m_efb;
 unsigned int FramebufferManager::m_target_width;
 unsigned int FramebufferManager::m_target_height;
-ID3D11DepthStencilState* FramebufferManager::m_depth_resolve_depth_state;
 
 D3DTexture2D* &FramebufferManager::GetEFBColorTexture() { return m_efb.color_tex; }
 ID3D11Texture2D* &FramebufferManager::GetEFBColorStagingBuffer() { return m_efb.color_staging_buf; }
@@ -42,7 +41,9 @@ D3DTexture2D* &FramebufferManager::GetResolvedEFBColorTexture()
 		return m_efb.resolved_color_tex;
 	}
 	else
+	{
 		return m_efb.color_tex;
+	}
 }
 
 D3DTexture2D* &FramebufferManager::GetResolvedEFBDepthTexture()
@@ -51,31 +52,26 @@ D3DTexture2D* &FramebufferManager::GetResolvedEFBDepthTexture()
 	{
 		// ResolveSubresource does not work with depth textures.
 		// Instead, we use a shader that selects the minimum depth from all samples.
-
-		// Clear render state, and enable depth writes.
 		g_renderer->ResetAPIState();
-		D3D::stateman->PushDepthState(m_depth_resolve_depth_state);
 
-		// Set up to render to resolved depth texture.
-		const D3D11_VIEWPORT viewport = CD3D11_VIEWPORT(0.f, 0.f, (float)m_target_width, (float)m_target_height);
+		CD3D11_VIEWPORT viewport(0.f, 0.f, (float)m_target_width, (float)m_target_height);
 		D3D::context->RSSetViewports(1, &viewport);
-		D3D::context->OMSetRenderTargets(0, nullptr, m_efb.resolved_depth_tex->GetDSV());
+		D3D::context->OMSetRenderTargets(1, &m_efb.resolved_depth_tex->GetRTV(), nullptr);
 
-		// Render a quad covering the entire target, writing SV_Depth.
 		const D3D11_RECT source_rect = CD3D11_RECT(0, 0, m_target_width, m_target_height);
 		D3D::drawShadedTexQuad(m_efb.depth_tex->GetSRV(), &source_rect, m_target_width, m_target_height,
 			PixelShaderCache::GetDepthResolveProgram(), VertexShaderCache::GetSimpleVertexShader(),
 			VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
 
-		// Restore render state.
 		D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(), FramebufferManager::GetEFBDepthTexture()->GetDSV());
-		D3D::stateman->PopDepthState();
 		g_renderer->RestoreAPIState();
 
 		return m_efb.resolved_depth_tex;
 	}
 	else
+	{
 		return m_efb.depth_tex;
+	}
 }
 
 FramebufferManager::FramebufferManager()
@@ -162,28 +158,18 @@ FramebufferManager::FramebufferManager()
 		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetTex(), "EFB color resolve texture");
 		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_color_tex->GetSRV(), "EFB color resolve texture shader resource view");
 
-		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_TYPELESS, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL);
+		texdesc = CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R32_FLOAT, m_target_width, m_target_height, m_efb.slices, 1, D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET);
 		hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &buf);
 		CHECK(hr==S_OK, "create EFB depth resolve texture (size: %dx%d; hr=%#x)", m_target_width, m_target_height, hr);
-		m_efb.resolved_depth_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_DEPTH_STENCIL), DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_D32_FLOAT);
+		m_efb.resolved_depth_tex = new D3DTexture2D(buf, (D3D11_BIND_FLAG)(D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET), DXGI_FORMAT_R32_FLOAT, DXGI_FORMAT_UNKNOWN, DXGI_FORMAT_R32_FLOAT);
 		SAFE_RELEASE(buf);
 		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetTex(), "EFB depth resolve texture");
 		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.resolved_depth_tex->GetSRV(), "EFB depth resolve texture shader resource view");
-
-		// Depth state used when writing resolved depth texture
-		D3D11_DEPTH_STENCIL_DESC depth_resolve_depth_state = CD3D11_DEPTH_STENCIL_DESC(CD3D11_DEFAULT());
-		depth_resolve_depth_state.DepthEnable = TRUE;
-		depth_resolve_depth_state.DepthFunc = D3D11_COMPARISON_ALWAYS;
-		depth_resolve_depth_state.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL;
-		hr = D3D::device->CreateDepthStencilState(&depth_resolve_depth_state, &m_depth_resolve_depth_state);
-		CHECK(hr == S_OK, "create depth resolve depth stencil state");
-		D3D::SetDebugObjectName((ID3D11DeviceChild*)m_depth_resolve_depth_state, "depth resolve depth stencil state");
 	}
 	else
 	{
 		m_efb.resolved_color_tex = nullptr;
 		m_efb.resolved_depth_tex = nullptr;
-		m_depth_resolve_depth_state = nullptr;
 	}
 
 	s_xfbEncoder.Init();
@@ -201,7 +187,6 @@ FramebufferManager::~FramebufferManager()
 	SAFE_RELEASE(m_efb.depth_staging_buf);
 	SAFE_RELEASE(m_efb.depth_read_texture);
 	SAFE_RELEASE(m_efb.resolved_depth_tex);
-	SAFE_RELEASE(m_depth_resolve_depth_state);
 }
 
 void FramebufferManager::CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, const EFBRectangle& sourceRc,float Gamma)

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -105,7 +105,6 @@ private:
 
 	static unsigned int m_target_width;
 	static unsigned int m_target_height;
-	static ID3D11DepthStencilState* m_depth_resolve_depth_state;
 };
 
 }  // namespace DX11

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -204,15 +204,15 @@ const char depth_resolve_program[] = {
 	"#define SAMPLES %d\n"
 	"Texture2DMSArray<float4, SAMPLES> Tex0 : register(t0);\n"
 	"void main(\n"
-	"	 out float depth : SV_Depth,\n"
+	"	 out float ocol0 : SV_Target,\n"
 	"    in float4 pos : SV_Position,\n"
 	"    in float3 uv0 : TEXCOORD0)\n"
 	"{\n"
 	"	int width, height, slices, samples;\n"
 	"	Tex0.GetDimensions(width, height, slices, samples);\n"
-	"	depth = Tex0.Load(int3(uv0.x*(width), uv0.y*(height), uv0.z), 0).x;\n"
+	"	ocol0 = Tex0.Load(int3(uv0.x*(width), uv0.y*(height), uv0.z), 0).x;\n"
 	"	for(int i = 1; i < SAMPLES; ++i)\n"
-	"		depth = min(depth, Tex0.Load(int3(uv0.x*(width), uv0.y*(height), uv0.z), i).x);\n"
+	"		ocol0 = min(ocol0, Tex0.Load(int3(uv0.x*(width), uv0.y*(height), uv0.z), i).x);\n"
 	"}\n"
 };
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -118,6 +118,9 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(
 		float(dstrect.GetWidth()),
 		float(dstrect.GetHeight()));
 
+	D3D::stateman->UnsetTexture(texture->GetSRV());
+	D3D::stateman->Apply();
+
 	D3D::context->OMSetRenderTargets(1, &texture->GetRTV(), nullptr);
 	D3D::context->RSSetViewports(1, &vp);
 	D3D::SetLinearCopySampler();
@@ -234,6 +237,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(u8* dst, PEControl::PixelFormat
 	// Make sure we don't draw with the texture set as both a source and target.
 	// (This can happen because we don't unbind textures when we free them.)
 	D3D::stateman->UnsetTexture(texture->GetSRV());
+	D3D::stateman->Apply();
 
 	D3D::context->OMSetRenderTargets(1, &texture->GetRTV(), nullptr);
 
@@ -364,6 +368,7 @@ void TextureCache::ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* uncon
 	// Make sure we don't draw with the texture set as both a source and target.
 	// (This can happen because we don't unbind textures when we free them.)
 	D3D::stateman->UnsetTexture(static_cast<TCacheEntry*>(entry)->texture->GetSRV());
+	D3D::stateman->Apply();
 
 	D3D::context->OMSetRenderTargets(1, &static_cast<TCacheEntry*>(entry)->texture->GetRTV(), nullptr);
 


### PR DESCRIPTION
Pulling these commits from my other D3D11 PR.

Sorts out the issues with #3266 not working for D3D11.

Also fixes https://bugs.dolphin-emu.org/issues/8247, it's a minor change, EFB depth buffer copies with MSAA is broken (regression introduced by #3495), if I remember correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3745)
<!-- Reviewable:end -->
