### PR TITLE
Backport: Don't log error from wxMSW wxWakeUpIdle().

### DIFF
--- a/Externals/wxWidgets3/src/msw/app.cpp
+++ b/Externals/wxWidgets3/src/msw/app.cpp
@@ -819,11 +819,15 @@ void wxApp::WakeUpIdle()
         if ( !::PeekMessage(&msg, hwndTop, 0, 1, PM_NOREMOVE) ||
               ::PeekMessage(&msg, hwndTop, 1, 1, PM_NOREMOVE) )
         {
-            if ( !::PostMessage(hwndTop, WM_NULL, 0, 0) )
-            {
-                // should never happen
-                wxLogLastError(wxT("PostMessage(WM_NULL)"));
-            }
+            // If this fails too, there is really not much we can do, but then
+            // neither do we need to, as it normally indicates that the window
+            // queue is full to the brim with the messages and so the main loop
+            // is running and doesn't need to be woken up.
+            //
+            // Notice that we especially should not try use wxLogLastError()
+            // here as this would lead to another call to wxWakeUpIdle() from
+            // inside wxLog and stack overflow due to the resulting recursion.
+            ::PostMessage(hwndTop, WM_NULL, 0, 0);
         }
     }
 #if wxUSE_THREADS


### PR DESCRIPTION
> This is not necessary as there is nothing that can be done about this error
anyhow and the function still "works" even if it occurs (it doesn't wake up
anything but it is not necessary to do it if the message queue is already
full) and, worse, results in a crash due to stack overflow.

===========

Backported from wxWidgets SVN 75835, fixes a stack overflow that dolphin sometimes runs into when something is updating the GUI too fast.

If we don't include an updated version of wxWidgets in dolphin 5.0, we should at least backport this patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3750)
<!-- Reviewable:end -->
