### PR TITLE
Use a sane default for the controller update rate.

### DIFF
--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -282,7 +282,7 @@ void Init()
 	}
 
 	g_Poll.Hex = 0;
-	g_Poll.X = 7;
+	g_Poll.X = 492;
 
 	g_ComCSR.Hex = 0;
 


### PR DESCRIPTION
Previously the default queryed the controller 4500 times a second,
Wasn't really a problem for most games as they set it to a sane
value. But fifoplayer didn't, and so in my profile dolphin spends
12% of the cpu time reading the controllers.

This new default value (I just took what the gamecube bios set)
drops that to 1.2% of cpu time and increase the framerate of the
silent hill fifo by 10-12%

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3751)
<!-- Reviewable:end -->
