### PR TITLE
Remove the restriction to use efb copies only once as partial update

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -308,7 +308,6 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::DoPartialTextureUpdates(Tex
 		if (entry != entry_to_update
 			&& entry->IsEfbCopy()
 			&& entry->OverlapsMemoryRange(entry_to_update->addr, entry_to_update->size_in_bytes)
-			&& entry->frameCount == FRAMECOUNT_INVALID
 			&& entry->memory_stride == numBlocksX * block_size)
 		{
 			if (entry->hash == entry->CalculateHash())
@@ -367,8 +366,8 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::DoPartialTextureUpdates(Tex
 				dstrect.right = (dst_x + copy_width);
 				dstrect.bottom = (dst_y + copy_height);
 				entry_to_update->CopyRectangleFromTexture(entry, srcrect, dstrect);
-				// Mark the texture update as used, so it isn't applied more than once
-				entry->frameCount = frameCount;
+				// Mark the texture update as used, as if it was loaded directly
+				entry->frameCount = FRAMECOUNT_INVALID;
 			}
 			else
 			{


### PR DESCRIPTION
I'm not entirely sure what is happening, but this optimisation is causing an issue in Sonic Riders: Zero Gravity. Apparently the issue would also be fixed by PR#3747, but this PR should also fix similar issues.

Games that use partial updates might get slower with this, so some performance regression testing would be nice. Games like New Super Mario Bros, DK Returns and Silent Hill. Testing with high graphics settings makes sense, since this would mostly end up in more work for the GPU.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3752)
<!-- Reviewable:end -->
