### PR TITLE
Only force progressive if we are currently in an interlaced video mode (fix NES games on Zelda collectors edition)

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -634,7 +634,11 @@ u32 GetTicksPerField()
 
 static void BeginField(FieldType field)
 {
-	bool interlaced_xfb = ((m_PictureConfiguration.STD / m_PictureConfiguration.WPL)==2);
+	// Could we fit a second line of data in the stride?
+	bool potentially_interlaced_xfb = ((m_PictureConfiguration.STD / m_PictureConfiguration.WPL) == 2);
+	// Are there an odd number of half-lines per field (definition of interlaced video)
+	bool interlaced_video_mode = (GetHalfLinesPerEvenField() & 1) == 1;
+
 	u32 fbStride = m_PictureConfiguration.STD * 16;
 	u32 fbWidth = m_PictureConfiguration.WPL * 16;
 	u32 fbHeight = m_VerticalTimingRegister.ACV;
@@ -650,7 +654,7 @@ static void BeginField(FieldType field)
 		xfbAddr = GetXFBAddressTop();
 	}
 
-	if (interlaced_xfb && g_ActiveConfig.bForceProgressive)
+	if (potentially_interlaced_xfb && interlaced_video_mode && g_ActiveConfig.bForceProgressive)
 	{
 		// Strictly speaking, in interlaced mode, we're only supposed to read
 		// half of the lines of the XFB, and use that to display a field; the


### PR DESCRIPTION
The NES games on the Zelda Collecters Edition disk use a XFB which is
only 256 pixels wide, but has a stride of 640 pixels.

This fits our definition of a interlaced xfb, as a second line of data
could fit in the extra space. The solution is to check that we are
actually in a interlaced video mode before activating the force
progressive hack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3753)
<!-- Reviewable:end -->
