### PR TITLE
Attempt re-adding the missing AXWii DSP_SYNC

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -21,8 +21,7 @@ AXUCode::AXUCode(DSPHLE* dsphle, u32 crc)
 	, m_cmdlist_size(0)
 {
 	WARN_LOG(DSPHLE, "Instantiating AXUCode: crc=%08x", crc);
-	m_mail_handler.PushMail(DSP_INIT);
-	DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
+	m_mail_handler.PushMail(DSP_INIT, true);
 
 	LoadResamplingCoefficients();
 }
@@ -72,8 +71,7 @@ void AXUCode::LoadResamplingCoefficients()
 void AXUCode::SignalWorkEnd()
 {
 	// Signal end of processing
-	m_mail_handler.PushMail(DSP_YIELD);
-	DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
+	m_mail_handler.PushMail(DSP_YIELD, true);
 }
 
 void AXUCode::HandleCommandList()
@@ -619,8 +617,7 @@ void AXUCode::HandleMail(u32 mail)
 	else if (mail == MAIL_RESUME)
 	{
 		// Acknowledge the resume request
-		m_mail_handler.PushMail(DSP_RESUME);
-		DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
+		m_mail_handler.PushMail(DSP_RESUME, true);
 	}
 	else if (mail == MAIL_NEW_UCODE)
 	{
@@ -667,8 +664,7 @@ void AXUCode::Update()
 	// Used for UCode switching.
 	if (NeedsResumeMail())
 	{
-		m_mail_handler.PushMail(DSP_RESUME);
-		DSP::GenerateDSPInterruptFromDSPEmu(DSP::INT_DSP);
+		m_mail_handler.PushMail(DSP_RESUME, true);
 	}
 }
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -629,10 +629,7 @@ void AXWiiUCode::OutputSamples(u32 lr_addr, u32 surround_addr, u16 volume,
 	}
 
 	memcpy(HLEMemory_Get_Pointer(lr_addr), buffer, sizeof (buffer));
-
-	// There should be a DSP_SYNC message sent here. However, it looks like not
-	// sending it does not cause any issue, and sending it actually causes some
-	// sounds to go at half speed. I have no idea why.
+	m_mail_handler.PushMail(DSP_SYNC, true);
 }
 
 void AXWiiUCode::OutputWMSamples(u32* addresses)


### PR DESCRIPTION
I'm curious if this works better with the new MailHandler interrupt handling. Will probably break everything for no apparent reason... :)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3756)

<!-- Reviewable:end -->
