### PR TITLE
ShaderGen: Handle AMD bug with storage qualifiers in interface blocks

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -90,16 +90,15 @@ static T GenerateGeometryShader(u32 primitive_type, API_TYPE ApiType)
 		if (g_ActiveConfig.backend_info.bSupportsGSInstancing)
 			out.Write("#define InstanceID gl_InvocationID\n");
 
-		out.Write("// The interface block qualifier is duplicated to its member due to Apple OS X bug 24983074\n");
 		out.Write("in VertexData {\n");
-		GenerateVSOutputMembers<T>(out, ApiType, "in", GetInterpolationQualifier());
+		GenerateVSOutputMembers<T>(out, ApiType, GetInterpolationQualifier(true, true));
 		out.Write("} vs[%d];\n", vertex_in);
 
 		out.Write("out VertexData {\n");
-		GenerateVSOutputMembers<T>(out, ApiType, "out", GetInterpolationQualifier());
+		GenerateVSOutputMembers<T>(out, ApiType, GetInterpolationQualifier(true, false));
 
 		if (g_ActiveConfig.iStereoMode > 0)
-			out.Write("\tflat out int layer;\n");
+			out.Write("\tflat int layer;\n");
 
 		out.Write("} ps;\n");
 

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -354,12 +354,11 @@ static T GeneratePixelShader(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType)
 		uid_data->stereo = g_ActiveConfig.iStereoMode > 0;
 		if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
 		{
-			out.Write("// The interface block qualifier is duplicated to its member due to Apple OS X bug 24983074\n");
 			out.Write("in VertexData {\n");
-			GenerateVSOutputMembers<T>(out, ApiType, "in", GetInterpolationQualifier());
+			GenerateVSOutputMembers<T>(out, ApiType, GetInterpolationQualifier(true, true));
 
 			if (g_ActiveConfig.iStereoMode > 0)
-				out.Write("\tflat in int layer;\n");
+				out.Write("\tflat int layer;\n");
 
 			out.Write("};\n");
 		}

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -74,9 +74,8 @@ static T GenerateVertexShader(API_TYPE api_type)
 
 		if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
 		{
-			out.Write("// The interface block qualifier is duplicated to its member due to Apple OS X bug 24983074\n");
 			out.Write("out VertexData {\n");
-			GenerateVSOutputMembers<T>(out, api_type, "out", GetInterpolationQualifier());
+			GenerateVSOutputMembers<T>(out, api_type, GetInterpolationQualifier(true, false));
 			out.Write("} vs;\n");
 		}
 		else


### PR DESCRIPTION
OSX requires the in/out qualifier be specified when using centroid interpolation (PR 3719), and AMD breaks if it is specified. Re-specifying the qualifier is valid GLSL, so add a driver bug and don't include for AMD drivers.

Can't test this myself as I don't have any AMD HW on hand, waiting for the reporter to confirm.

See: https://bugs.dolphin-emu.org/issues/9463

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3757)
<!-- Reviewable:end -->
