### PR TITLE
[WIP] Attempt to fix Metroid: Other M's timing issues.

### DIFF
--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -251,8 +251,11 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 		MMIO::ComplexWrite<u32>([](u32, u32 val) {
 			DEBUG_LOG(AUDIO_INTERFACE, "AI_INTERRUPT_TIMING=%08x@%08x", val, PowerPC::ppcState.pc);
 			m_InterruptTiming = val;
-			CoreTiming::RemoveEvent(et_AI);
-			CoreTiming::ScheduleEvent(GetAIPeriod(), et_AI);
+			if (g_CPUCyclesPerSample != 0xFFFFFFFFFFFULL)
+			{
+				CoreTiming::RemoveEvent(et_AI);
+				CoreTiming::ScheduleEvent(GetAIPeriod(), et_AI);
+			}
 		})
 	);
 }


### PR DESCRIPTION
AI callback was being scheduled in the past due to the way the game was setting the registers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3761)
<!-- Reviewable:end -->
