### PR TITLE
Always clear memory when booting

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -50,9 +50,6 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
 	PowerPC::ppcState.spr[SPR_DBAT1U] = 0xc0001fff;
 	PowerPC::ppcState.spr[SPR_DBAT1L] = 0x0000002a;
 
-	// Clear ALL memory
-	Memory::Clear();
-
 	// Write necessary values
 	// Here we write values to memory that the apploader does not take care of. Game info goes
 	// to 0x80000000 according to YAGCD 4.2.

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -380,8 +380,6 @@ void FifoPlayer::LoadMemory()
 	PowerPC::ppcState.spr[SPR_DBAT1U] = 0xc0001fff;
 	PowerPC::ppcState.spr[SPR_DBAT1L] = 0x0000002a;
 
-	Memory::Clear();
-
 	SetupFifo();
 
 	u32 *regs = m_File->GetBPMem();

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -180,8 +180,10 @@ void Init()
 #endif
 
 	u32 flags = 0;
-	if (wii) flags |= MV_WII_ONLY;
-	if (bFakeVMEM) flags |= MV_FAKE_VMEM;
+	if (wii)
+		flags |= MV_WII_ONLY;
+	if (bFakeVMEM)
+		flags |= MV_FAKE_VMEM;
 	physical_base = MemoryMap_Setup(views, num_views, flags, &g_arena);
 #ifndef _ARCH_32
 	logical_base = physical_base + 0x200000000;
@@ -191,6 +193,8 @@ void Init()
 		mmio_mapping = InitMMIOWii();
 	else
 		mmio_mapping = InitMMIO();
+
+	Clear();
 
 	INFO_LOG(MEMMAP, "Memory system initialized. RAM at %p", m_pRAM);
 	m_IsInitialized = true;


### PR DESCRIPTION
Reading uninitalized memory is non-deterministic. We used to only clear the memory when using EmulatedBS2_GC or FifoPlayer, but we now do it during Memory::Init instead so it always gets done.

I'm not especially familiar with this part of the code, so I'm not sure if the change is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3763)
<!-- Reviewable:end -->
