### PR TITLE
[Android] Fix android builds permanently.

### DIFF
--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-alpha5'
+        classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
In November, Google released a preview version of their 2.0 toolset. Key features included massive build time reductions and Instant Run, which allows devs to deploy differential APKs to their device when testing.

In January, I switched the Dolphin codebase to use the 2.0 tools. When I did this, there were two things I didn't know:

-Google were going to intentionally break out-of-date versions of these tools as soon as a new version was released, to prevent reports of fixed bugs;
-Google were going to do this for almost 6 months.

Truth be told, these are really annoying from a CI perspective. We've been patching the problem by updating to the newest alpha/beta builds, but this PR implements a permanent fix by rolling back to the most recent stable tools - 1.5.

Devs interested in using Instant Run can continue to do so by reverting this commit locally.

My apologies for the inconvenience, everyone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3765)
<!-- Reviewable:end -->
