### PR TITLE
mandir added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ if(APPLE)
 else()
 	set(bindir  ${CMAKE_INSTALL_PREFIX}/bin               CACHE PATH "bindir")
 	set(datadir ${CMAKE_INSTALL_PREFIX}/share/dolphin-emu CACHE PATH "datadir")
+	set(mandir  ${CMAKE_INSTALL_PREFIX}/share/man         CACHE PATH "mandir")
 	add_definitions(-DDATA_DIR="${datadir}/")
 endif()
 
@@ -962,9 +963,9 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
 	# Install manpages
 	install(FILES Data/dolphin-emu.6
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man6)
+		DESTINATION ${mandir}/man6)
 	install(FILES Data/dolphin-emu-nogui.6
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man6)
+		DESTINATION ${mandir}/man6)
 endif()
 
 # packaging information


### PR DESCRIPTION
This will add a `mandir` target to the main `CMakeLists.txt`.

By default it will still install the manpages to:
```
usr/share/man/man6/dolphin-emu-nogui.6
usr/share/man/man6/dolphin-emu.6
```
However not all distros use `usr/share/man` such as Slackware which uses `usr/man` instead so if `-Dmandir=/usr/man` is used it will install the manpages to:
```
usr/man/man6/dolphin-emu.6
usr/man/man6/dolphin-emu-nogui.6
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3766)
<!-- Reviewable:end -->
