### PR TITLE
Remove Unused Framestop Functions

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -44,7 +44,6 @@ static std::mutex cs_frameSkip;
 namespace Movie {
 
 static bool s_bFrameStep = false;
-static bool s_bFrameStop = false;
 static bool s_bReadOnly = true;
 static u32 s_rerecords = 0;
 static PlayMode s_playMode = MODE_NONE;
@@ -159,11 +158,6 @@ void FrameUpdate()
 		s_bFrameStep = false;
 	}
 
-	// ("framestop") the only purpose of this is to cause interpreter/jit Run() to return temporarily.
-	// after that we set it back to CPU_RUNNING and continue as normal.
-	if (s_bFrameStop)
-		*PowerPC::GetStatePtr() = PowerPC::CPU_STEPPING;
-
 	if (s_framesToSkip)
 		FrameSkipping();
 
@@ -176,7 +170,6 @@ void Init()
 {
 	s_bPolled = false;
 	s_bFrameStep = false;
-	s_bFrameStop = false;
 	s_bSaveConfig = false;
 	s_iCPUCore = SConfig::GetInstance().iCPUCore;
 	if (IsPlayingInput())
@@ -261,11 +254,6 @@ void DoFrameStep()
 		// if not paused yet, pause immediately instead
 		Core::SetState(Core::CORE_PAUSE);
 	}
-}
-
-void SetFrameStopping(bool bEnabled)
-{
-	s_bFrameStop = bEnabled;
 }
 
 void SetReadOnly(bool bEnabled)

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -151,7 +151,6 @@ void ChangePads(bool instantly = false);
 void ChangeWiiPads(bool instantly = false);
 
 void DoFrameStep();
-void SetFrameStopping(bool bEnabled);
 void SetReadOnly(bool bEnabled);
 
 void SetFrameSkipping(unsigned int framesToSkip);

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -225,7 +225,7 @@ CPUState GetState()
 	return state;
 }
 
-volatile CPUState *GetStatePtr()
+const volatile CPUState *GetStatePtr()
 {
 	return &state;
 }

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -160,7 +160,7 @@ void Pause();
 void Stop();
 void FinishStateMove();
 CPUState GetState();
-volatile CPUState *GetStatePtr();  // this oddity is here instead of an extern declaration to easily be able to find all direct accesses throughout the code.
+const volatile CPUState *GetStatePtr();  // this oddity is here instead of an extern declaration to easily be able to find all direct accesses throughout the code.
 
 u32 CompactCR();
 void ExpandCR(u32 cr);


### PR DESCRIPTION
These weren't actually being used for anything, so it only makes sense to remove them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3769)
<!-- Reviewable:end -->
