### PR TITLE
DSP: Fix array out of bounds

### DIFF
--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -67,7 +67,7 @@ static void Reset()
 	code_flags.fill(0);
 }
 
-static void AnalyzeRange(int start_addr, int end_addr)
+static void AnalyzeRange(u16 start_addr, u16 end_addr)
 {
 	// First we run an extremely simplified version of a disassembler to find
 	// where all instructions start.
@@ -75,7 +75,7 @@ static void AnalyzeRange(int start_addr, int end_addr)
 	// This may not be 100% accurate in case of jump tables!
 	// It could get desynced, which would be bad. We'll see if that's an issue.
 	u16 last_arithmetic = 0;
-	for (int addr = start_addr; addr < end_addr;)
+	for (u16 addr = start_addr; addr < end_addr;)
 	{
 		UDSPInstruction inst = dsp_imem_read(addr);
 		const DSPOPCTemplate *opcode = GetOpTemplate(inst);
@@ -97,7 +97,7 @@ static void AnalyzeRange(int start_addr, int end_addr)
 		{
 			// LOOP, LOOPI
 			code_flags[addr] |= CODE_LOOP_START;
-			code_flags[addr + 1] |= CODE_LOOP_END;
+			code_flags[static_cast<u16>(addr + 1u)] |= CODE_LOOP_END;
 		}
 
 		// Mark the last arithmetic/multiplier instruction before a branch.
@@ -122,7 +122,7 @@ static void AnalyzeRange(int start_addr, int end_addr)
 			opcode->opcode == 0x2000 ||
 			opcode->extended
 			)
-		code_flags[addr + opcode->size] |= CODE_CHECK_INT;
+		code_flags[static_cast<u16>(addr + opcode->size)] |= CODE_CHECK_INT;
 
 		addr += opcode->size;
 	}
@@ -130,7 +130,7 @@ static void AnalyzeRange(int start_addr, int end_addr)
 	// Next, we'll scan for potential idle skips.
 	for (int s = 0; s < NUM_IDLE_SIGS; s++)
 	{
-		for (int addr = start_addr; addr < end_addr; addr++)
+		for (u16 addr = start_addr; addr < end_addr; addr++)
 		{
 			bool found = false;
 			for (int i = 0; i < MAX_IDLE_SIG_SIZE + 1; i++)

--- a/Source/Core/Core/DSP/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/DSPEmitter.cpp
@@ -243,7 +243,7 @@ void DSPEmitter::Compile(u16 start_addr)
 
 		// Handle loop condition, only if current instruction was flagged as a loop destination
 		// by the analyzer.
-		if (DSPAnalyzer::code_flags[compilePC-1] & DSPAnalyzer::CODE_LOOP_END)
+		if (DSPAnalyzer::code_flags[static_cast<u16>(compilePC - 1u)] & DSPAnalyzer::CODE_LOOP_END)
 		{
 			MOVZX(32, 16, EAX, M(&(g_dsp.r.st[2])));
 			TEST(32, R(EAX), R(EAX));

--- a/Source/Core/Core/DSP/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/DSPInterpreter.cpp
@@ -76,7 +76,7 @@ void Step()
 	u16 opc = dsp_fetch_code();
 	ExecuteInstruction(UDSPInstruction(opc));
 
-	if (DSPAnalyzer::code_flags[g_dsp.pc - 1] & DSPAnalyzer::CODE_LOOP_END)
+	if (DSPAnalyzer::code_flags[static_cast<u16>(g_dsp.pc - 1u)] & DSPAnalyzer::CODE_LOOP_END)
 		HandleLoop();
 }
 


### PR DESCRIPTION
Some of the code in the DSP seems to have been relying on integer types to perform implicit modulo on addresses but it doesn't actually work because of the integer promotion rules where anything smaller than an int (like a u16) becomes an int when you do arithmetic to it. This means that `g_dsp.pc - 1` becomes `0 - 1` which is `0xFFFFFFFF` and out of range for an array with only 65536 entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3770)
<!-- Reviewable:end -->
