### PR TITLE
Remove instant ARAM DMA hack (Fixes Sarge's War)

### DIFF
--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -80,8 +80,5 @@ u8* GetARAMPtr();
 
 void UpdateAudioDMA();
 void UpdateDSPSlice(int cycles);
-u64 DMAInProgress();
-void EnableInstantDMA();
-void FlushInstantDMA(u32 address);
 
 }  // end of namespace DSP

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -336,14 +336,6 @@ void Interpreter::dcbi(UGeckoInstruction _inst)
   // should use icbi consistently, but games aren't portable.)
   u32 address = Helper_Get_EA_X(_inst);
   JitInterface::InvalidateICache(address & ~0x1f, 32, false);
-
-  // The following detects a situation where the game is writing to the dcache at the address being
-  // DMA'd. As we do not
-  // have dcache emulation, invalid data is being DMA'd causing audio glitches. The following code
-  // detects this and
-  // enables the DMA to complete instantly before the invalid data is written. Resident Evil 2 & 3
-  // trigger this.
-  DSP::FlushInstantDMA(address);
 }
 
 void Interpreter::dcbst(UGeckoInstruction _inst)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -315,23 +315,6 @@ void Jit64::dcbx(UGeckoInstruction inst)
   SwitchToNearCode();
   SetJumpTarget(c);
 
-  // dcbi
-  if (inst.SUBOP10 == 470)
-  {
-    // Flush DSP DMA if DMAState bit is set
-    TEST(16, M(&DSP::g_dspState), Imm16(1 << 9));
-    c = J_CC(CC_NZ, true);
-    SwitchToFarCode();
-    SetJumpTarget(c);
-    ABI_PushRegistersAndAdjustStack(registersInUse, 0);
-    SHL(32, R(addr), Imm8(5));
-    ABI_CallFunctionR(DSP::FlushInstantDMA, addr);
-    ABI_PopRegistersAndAdjustStack(registersInUse, 0);
-    c = J(true);
-    SwitchToNearCode();
-    SetJumpTarget(c);
-  }
-
   gpr.UnlockAllX();
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -733,34 +733,6 @@ void JitArm64::dcbx(UGeckoInstruction inst)
   SetJumpTarget(bit_not_set);
   SetJumpTarget(near);
 
-  // dcbi
-  if (inst.SUBOP10 == 470)
-  {
-    // Flush DSP DMA if DMAState bit is set
-    MOVI2R(EncodeRegTo64(WA), (u64)&DSP::g_dspState);
-    LDRH(INDEX_UNSIGNED, WA, EncodeRegTo64(WA), 0);
-
-    bit_not_set = TBZ(WA, 9);
-    far = B();
-    SwitchToFarCode();
-    SetJumpTarget(far);
-
-    ABI_PushRegisters(gprs_to_push);
-    m_float_emit.ABI_PushRegisters(fprs_to_push, X30);
-
-    LSL(W0, addr, 5);
-    MOVI2R(X1, (u64)DSP::FlushInstantDMA);
-    BLR(X1);
-
-    m_float_emit.ABI_PopRegisters(fprs_to_push, X30);
-    ABI_PopRegisters(gprs_to_push);
-
-    near = B();
-    SwitchToNearCode();
-    SetJumpTarget(near);
-    SetJumpTarget(bit_not_set);
-  }
-
   gpr.Unlock(addr, value, W30);
 }
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -70,7 +70,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 56;
+static const u32 STATE_VERSION = 57;
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
Instant ARAM DMA is a blatant hack that only ever fixed things in RE2 and RE3. It activates for a lot of other games, but as far as I'm aware it doesn't fix any bugs. It just causes more bugs.

With scheduling fixes, it breaks ATV: Quad Power Racing 2 (causing all sorts of weird bugs) and stops Sarge's War from loading.

Both are regressions from #3601, though ATV Quad Racing was fixed in a hacky way by #3773. 

Maybe I could tweak the timings to get #3773 working for Sarge's War too, but the clean way is to just delete the horrendous hack. Now that Dolphin 5.0 has been released we can do this. 

Unfortunately, this PR causes audio glitches in RE2 and RE3, but they never should have been working in the first place. Someone else can fix them correctly next time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3771)
<!-- Reviewable:end -->
