### PR TITLE
"Instant" ARAM DMA shouldn't schedule and event too soon.

### DIFF
--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -212,6 +212,7 @@ void EnableInstantDMA()
 	CoreTiming::RemoveEvent(et_CompleteARAM);
 	CompleteARAM(0, 0);
 	instant_dma = true;
+	ERROR_LOG(DSPINTERFACE, "Enabling Instant ARAM DMA hack");
 }
 
 void FlushInstantDMA(u32 address)
@@ -544,13 +545,11 @@ static void Do_ARAM_DMA()
 	// ARAM DMA transfer rate has been measured on real hw
 	int ticksToTransfer = (g_arDMA.Cnt.count / 32) * 246;
 
+	// This is a huge hack that appears to be here only to fix Resident Evil 2/3
 	if (instant_dma)
-		ticksToTransfer = 0;
+		ticksToTransfer = std::min(ticksToTransfer, 100);
 
 	CoreTiming::ScheduleEvent(ticksToTransfer, et_CompleteARAM);
-
-	if (instant_dma)
-		CoreTiming::ForceExceptionCheck(100);
 
 	last_mmaddr = g_arDMA.MMAddr;
 	last_aram_dma_count = g_arDMA.Cnt.count;


### PR DESCRIPTION
Now that the accuracy of ScheduleEvent has changed, 0 cycles will schedule an event as soon as possible. But this breaks ATV 2.
So we schedule it 100 cycles out (unless it's a really short copy)

I'd really like to remove the whole hack, as it only appears to fix RE2/RE3 but I don't really want to make major changes to this code this close to the 5.0 release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3773)
<!-- Reviewable:end -->
