### PR TITLE
Fix Metroid: Other M

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -84,7 +84,7 @@ static void FreeEvent(Event* ev)
 	eventPool = ev;
 }
 
-static void EmptyTimedCallback(u64 userdata, int cyclesLate) {}
+static void EmptyTimedCallback(u64 userdata, s64 cyclesLate) {}
 
 // Changing the CPU speed in Dolphin isn't actually done by changing the physical clock rate,
 // but by changing the amount of work done in a particular amount of time. This tends to be more

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -35,7 +35,7 @@ extern float g_lastOCFactor_inverted;
 void Init();
 void Shutdown();
 
-typedef void (*TimedCallback)(u64 userdata, int cyclesLate);
+typedef void (*TimedCallback)(u64 userdata, s64 cyclesLate);
 
 // This should only be called from the CPU thread, if you are calling it any other thread, you are doing something evil
 u64 GetTicks();

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -133,6 +133,7 @@ static void UpdateInterrupts();
 static void IncreaseSampleCount(const u32 _uAmount);
 static int GetAIPeriod();
 static int et_AI;
+static void Update(u64 userdata, s64 cyclesLate);
 
 void Init()
 {
@@ -299,7 +300,7 @@ unsigned int GetAIDSampleRate()
 	return g_AIDSampleRate;
 }
 
-void Update(u64 userdata, int cyclesLate)
+static void Update(u64 userdata, s64 cyclesLate)
 {
 	if (m_Control.PSTAT)
 	{

--- a/Source/Core/Core/HW/AudioInterface.h
+++ b/Source/Core/Core/HW/AudioInterface.h
@@ -21,8 +21,6 @@ bool IsPlaying();
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
-void Update(u64 userdata, int cyclesLate);
-
 // Get the audio rates (48000 or 32000 only)
 unsigned int GetAIDSampleRate();
 

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -196,12 +196,12 @@ void DoState(PointerWrap &p)
 
 static void UpdateInterrupts();
 static void Do_ARAM_DMA();
-static void GenerateDSPInterrupt(u64 DSPIntType, int cyclesLate = 0);
+static void GenerateDSPInterrupt(u64 DSPIntType, s64 cyclesLate = 0);
 
 static int et_GenerateDSPInterrupt;
 static int et_CompleteARAM;
 
-static void CompleteARAM(u64 userdata, int cyclesLate)
+static void CompleteARAM(u64 userdata, s64 cyclesLate)
 {
 	g_dspState.DMAState = 0;
 	GenerateDSPInterrupt(INT_ARAM);
@@ -467,7 +467,7 @@ static void UpdateInterrupts()
 	ProcessorInterface::SetInterrupt(ProcessorInterface::INT_CAUSE_DSP, ints_set);
 }
 
-static void GenerateDSPInterrupt(u64 DSPIntType, int cyclesLate)
+static void GenerateDSPInterrupt(u64 DSPIntType, s64 cyclesLate)
 {
 	// The INT_* enumeration members have values that reflect their bit positions in
 	// DSP_CONTROL - we mask by (INT_DSP | INT_ARAM | INT_AID) just to ensure people

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -256,8 +256,8 @@ static unsigned char s_media_buffer[0x40];
 static int s_eject_disc;
 static int s_insert_disc;
 
-void EjectDiscCallback(u64 userdata, int cyclesLate);
-void InsertDiscCallback(u64 userdata, int cyclesLate);
+static void EjectDiscCallback(u64 userdata, s64 cyclesLate);
+static void InsertDiscCallback(u64 userdata, s64 cyclesLate);
 
 void SetLidOpen(bool _bOpen);
 
@@ -301,7 +301,7 @@ void DoState(PointerWrap &p)
 	DVDThread::DoState(p);
 }
 
-static void FinishExecuteCommand(u64 userdata, int cyclesLate)
+static void FinishExecuteCommand(u64 userdata, s64 cyclesLate)
 {
 	if (s_DICR.TSTART)
 	{
@@ -354,7 +354,7 @@ static u32 ProcessDTKSamples(short *tempPCM, u32 num_samples)
 	return samples_processed;
 }
 
-static void DTKStreamingCallback(u64 userdata, int cyclesLate)
+static void DTKStreamingCallback(u64 userdata, s64 cyclesLate)
 {
 	// Send audio to the mixer.
 	static const int NUM_SAMPLES = 48000 / 2000 * 7;  // 3.5ms of 48kHz samples
@@ -461,14 +461,14 @@ bool IsDiscInside()
 // We want this in the "backend", NOT the gui
 // any !empty string will be deleted to ensure
 // that the userdata string exists when called
-void EjectDiscCallback(u64 userdata, int cyclesLate)
+static void EjectDiscCallback(u64 userdata, s64 cyclesLate)
 {
 	DVDThread::WaitUntilIdle();
 	s_inserted_volume.reset();
 	SetDiscInside(false);
 }
 
-void InsertDiscCallback(u64 userdata, int cyclesLate)
+static void InsertDiscCallback(u64 userdata, s64 cyclesLate)
 {
 	std::string& SavedFileName = SConfig::GetInstance().m_strFilename;
 	std::string *_FileName = (std::string *)userdata;

--- a/Source/Core/Core/HW/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVDThread.cpp
@@ -30,7 +30,7 @@ namespace DVDThread
 
 static void DVDThread();
 
-static void FinishRead(u64 userdata, int cyclesLate);
+static void FinishRead(u64 userdata, s64 cyclesLate);
 static int s_finish_read;
 
 static std::thread s_dvd_thread;
@@ -129,7 +129,7 @@ void StartRead(u64 dvd_offset, u32 output_address, u32 length, bool decrypt,
 	CoreTiming::ScheduleEvent(ticks_until_completion, s_finish_read);
 }
 
-static void FinishRead(u64 userdata, int cyclesLate)
+static void FinishRead(u64 userdata, s64 cyclesLate)
 {
 	WaitUntilIdle();
 

--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -28,8 +28,8 @@ static int updateInterrupts;
 
 static std::array<std::unique_ptr<CEXIChannel>, MAX_EXI_CHANNELS> g_Channels;
 
-static void ChangeDeviceCallback(u64 userdata, int cyclesLate);
-static void UpdateInterruptsCallback(u64 userdata, int cycles_late);
+static void ChangeDeviceCallback(u64 userdata, s64 cyclesLate);
+static void UpdateInterruptsCallback(u64 userdata, s64 cycles_late);
 
 void Init()
 {
@@ -91,7 +91,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 	}
 }
 
-static void ChangeDeviceCallback(u64 userdata, int cyclesLate)
+static void ChangeDeviceCallback(u64 userdata, s64 cyclesLate)
 {
 	u8 channel = (u8)(userdata >> 32);
 	u8 type = (u8)(userdata >> 16);
@@ -139,7 +139,7 @@ void UpdateInterrupts()
 	ProcessorInterface::SetInterrupt(ProcessorInterface::INT_CAUSE_EXI, causeInt);
 }
 
-static void UpdateInterruptsCallback(u64 userdata, int cycles_late)
+static void UpdateInterruptsCallback(u64 userdata, s64 cycles_late)
 {
 	UpdateInterrupts();
 }

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -58,7 +58,7 @@ void CEXIMemoryCard::EventCompleteFindInstance(u64 userdata, std::function<void(
 	}
 }
 
-void CEXIMemoryCard::CmdDoneCallback(u64 userdata, int cyclesLate)
+void CEXIMemoryCard::CmdDoneCallback(u64 userdata, s64 cyclesLate)
 {
 	EventCompleteFindInstance(userdata, [](CEXIMemoryCard* instance)
 	{
@@ -66,7 +66,7 @@ void CEXIMemoryCard::CmdDoneCallback(u64 userdata, int cyclesLate)
 	});
 }
 
-void CEXIMemoryCard::TransferCompleteCallback(u64 userdata, int cyclesLate)
+void CEXIMemoryCard::TransferCompleteCallback(u64 userdata, s64 cyclesLate)
 {
 	EventCompleteFindInstance(userdata, [](CEXIMemoryCard* instance)
 	{

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
@@ -32,10 +32,10 @@ private:
 	static void EventCompleteFindInstance(u64 userdata, std::function<void(CEXIMemoryCard*)> callback);
 
 	// Scheduled when a command that required delayed end signaling is done.
-	static void CmdDoneCallback(u64 userdata, int cyclesLate);
+	static void CmdDoneCallback(u64 userdata, s64 cyclesLate);
 
 	// Scheduled when memory card is done transferring data
-	static void TransferCompleteCallback(u64 userdata, int cyclesLate);
+	static void TransferCompleteCallback(u64 userdata, s64 cyclesLate);
 
 	// Signals that the command that was previously executed is now done.
 	void CmdDone();

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -31,7 +31,7 @@ static u32 m_Unknown;
 
 // ID and callback for scheduling reset button presses/releases
 static int toggleResetButton;
-void ToggleResetButtonCallback(u64 userdata, int cyclesLate);
+static void ToggleResetButtonCallback(u64 userdata, s64 cyclesLate);
 
 // Let the PPC know that an external exception is set/cleared
 void UpdateException();
@@ -196,7 +196,7 @@ static void SetResetButton(bool _bSet)
 	SetInterrupt(INT_CAUSE_RST_BUTTON, !_bSet);
 }
 
-void ToggleResetButtonCallback(u64 userdata, int cyclesLate)
+static void ToggleResetButtonCallback(u64 userdata, s64 cyclesLate)
 {
 	SetResetButton(!!userdata);
 }

--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -26,8 +26,8 @@ namespace SerialInterface
 static int changeDevice;
 static int et_transfer_pending;
 
-void RunSIBuffer(u64 userdata, int cyclesLate);
-void UpdateInterrupts();
+static void RunSIBuffer(u64 userdata, s64 cyclesLate);
+static void UpdateInterrupts();
 
 // SI Interrupt Types
 enum SIInterruptType
@@ -250,6 +250,8 @@ void DoState(PointerWrap &p)
 	p.Do(g_SIBuffer);
 }
 
+static void ChangeDeviceCallback(u64 userdata, s64 cyclesLate);
+static void RunSIBuffer(u64 userdata, s64 cyclesLate);
 
 void Init()
 {
@@ -430,7 +432,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 	);
 }
 
-void UpdateInterrupts()
+static void UpdateInterrupts()
 {
 	// check if we have to update the RDSTINT flag
 	if (g_StatusReg.RDST0 || g_StatusReg.RDST1 ||
@@ -496,7 +498,7 @@ static void SetNoResponse(u32 channel)
 	g_ComCSR.COMERR = 1;
 }
 
-void ChangeDeviceCallback(u64 userdata, int cyclesLate)
+static void ChangeDeviceCallback(u64 userdata, s64 cyclesLate)
 {
 	u8 channel = (u8)(userdata >> 32);
 	SIDevices device = (SIDevices)(u32)userdata;
@@ -559,7 +561,7 @@ SIDevices GetDeviceType(int channel)
 	return g_Channel[channel].m_device->GetDeviceType();
 }
 
-void RunSIBuffer(u64 userdata, int cyclesLate)
+static void RunSIBuffer(u64 userdata, s64 cyclesLate)
 {
 	if (g_ComCSR.TSTART)
 	{

--- a/Source/Core/Core/HW/SI.h
+++ b/Source/Core/Core/HW/SI.h
@@ -33,7 +33,6 @@ void RemoveDevice(int _iDeviceNumber);
 void AddDevice(const SIDevices _device, int _iDeviceNumber);
 void AddDevice(std::unique_ptr<ISIDevice> device);
 
-void ChangeDeviceCallback(u64 userdata, int cyclesLate);
 void ChangeDevice(SIDevices device, int channel);
 void ChangeDeviceDeterministic(SIDevices device, int channel);
 

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -118,7 +118,7 @@ static void IPC_HLE_UpdateCallback(u64 userdata, int cyclesLate)
 static void VICallback(u64 userdata, int cyclesLate)
 {
 	VideoInterface::Update();
-	CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerHalfLine() - cyclesLate, et_VI);
+	CoreTiming::ScheduleEvent(s64(VideoInterface::GetTicksPerHalfLine()) - cyclesLate, et_VI);
 }
 
 static void DecrementerCallback(u64 userdata, int cyclesLate)

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -98,6 +98,7 @@ static u32 arm_irq_masks;
 static u32 sensorbar_power; // do we need to care about this?
 
 static int updateInterrupts;
+static void UpdateInterrupts(u64 = 0, s64 cyclesLate = 0);
 
 void DoState(PointerWrap &p)
 {
@@ -200,7 +201,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 	mmio->Register(base | UNK_1D0, MMIO::Constant<u32>(0), MMIO::Nop<u32>());
 }
 
-void UpdateInterrupts(u64 userdata, int cyclesLate)
+static void UpdateInterrupts(u64 userdata, s64 cyclesLate)
 {
 	if ((ctrl.Y1 & ctrl.IY1) || (ctrl.Y2 & ctrl.IY2))
 	{

--- a/Source/Core/Core/HW/WII_IPC.h
+++ b/Source/Core/Core/HW/WII_IPC.h
@@ -40,7 +40,6 @@ void DoState(PointerWrap &p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
-void UpdateInterrupts(u64 userdata = 0, int cyclesLate = 0);
 void GenerateAck(u32 _Address);
 void GenerateReply(u32 _Address);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -83,7 +83,7 @@ static u64 last_reply_time;
 
 static const u64 ENQUEUE_REQUEST_FLAG = 0x100000000ULL;
 static const u64 ENQUEUE_ACKNOWLEDGEMENT_FLAG = 0x200000000ULL;
-static void EnqueueEvent(u64 userdata, int cycles_late = 0)
+static void EnqueueEvent(u64 userdata, s64 cycles_late = 0)
 {
 	if (userdata & ENQUEUE_ACKNOWLEDGEMENT_FLAG)
 	{

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -18,7 +18,7 @@
 
 static int ioctl_callback;
 
-static void IOCtlCallback(u64 userdata, int cycles_late)
+static void IOCtlCallback(u64 userdata, s64 cycles_late)
 {
 	std::shared_ptr<IWII_IPC_HLE_Device> di = WII_IPC_HLE_Interface::GetDeviceByName("/dev/di");
 	if (di)

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -47,7 +47,7 @@ static bool IsOnThread()
 	return SConfig::GetInstance().bCPUThread;
 }
 
-static void UpdateInterrupts_Wrapper(u64 userdata, int cyclesLate)
+static void UpdateInterrupts_Wrapper(u64 userdata, s64 cyclesLate)
 {
 	UpdateInterrupts(userdata);
 }

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -548,7 +548,7 @@ static int Update(int ticks)
 	return param.iSyncGpuMaxDistance - s_sync_ticks.load();
 }
 
-static void SyncGPUCallback(u64 userdata, int cyclesLate)
+static void SyncGPUCallback(u64 userdata, s64 cyclesLate)
 {
 	u64 now = CoreTiming::GetTicks();
 	int next = Fifo::Update((int)(now - s_last_sync_gpu_tick));

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -124,11 +124,11 @@ void DoState(PointerWrap &p)
 	p.Do(s_signal_finish_interrupt);
 }
 
-void UpdateInterrupts();
-void UpdateTokenInterrupt(bool active);
-void UpdateFinishInterrupt(bool active);
-void SetToken_OnMainThread(u64 userdata, int cyclesLate);
-void SetFinish_OnMainThread(u64 userdata, int cyclesLate);
+static void UpdateInterrupts();
+static void UpdateTokenInterrupt(bool active);
+static void UpdateFinishInterrupt(bool active);
+static void SetToken_OnMainThread(u64 userdata, s64 cyclesLate);
+static void SetFinish_OnMainThread(u64 userdata, s64 cyclesLate);
 
 void Init()
 {
@@ -237,7 +237,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 	}
 }
 
-void UpdateInterrupts()
+static void UpdateInterrupts()
 {
 	// check if there is a token-interrupt
 	UpdateTokenInterrupt((s_signal_token_interrupt.load() & m_Control.PETokenEnable) != 0);
@@ -246,12 +246,12 @@ void UpdateInterrupts()
 	UpdateFinishInterrupt((s_signal_finish_interrupt.load() & m_Control.PEFinishEnable) != 0);
 }
 
-void UpdateTokenInterrupt(bool active)
+static void UpdateTokenInterrupt(bool active)
 {
 	ProcessorInterface::SetInterrupt(INT_CAUSE_PE_TOKEN, active);
 }
 
-void UpdateFinishInterrupt(bool active)
+static void UpdateFinishInterrupt(bool active)
 {
 	ProcessorInterface::SetInterrupt(INT_CAUSE_PE_FINISH, active);
 }
@@ -261,7 +261,7 @@ void UpdateFinishInterrupt(bool active)
 //            Cleanup++
 
 // Called only if BPMEM_PE_TOKEN_INT_ID is ack by GP
-void SetToken_OnMainThread(u64 userdata, int cyclesLate)
+static void SetToken_OnMainThread(u64 userdata, s64 cyclesLate)
 {
 	// XXX: No 16-bit atomic store available, so cheat and use 32-bit.
 	// That's what we've always done. We're counting on fifo.PEToken to be
@@ -276,7 +276,7 @@ void SetToken_OnMainThread(u64 userdata, int cyclesLate)
 	CommandProcessor::SetInterruptTokenWaiting(false);
 }
 
-void SetFinish_OnMainThread(u64 userdata, int cyclesLate)
+static void SetFinish_OnMainThread(u64 userdata, s64 cyclesLate)
 {
 	s_signal_finish_interrupt.store(1);
 	UpdateInterrupts();


### PR DESCRIPTION
This will disappoint a large number of metroid fans. 

### Cause:
During boot of Other M, there is momentarily a period when VICallback's
cycles late is larger than GetTicksPerHalfLine(). Because
GetTicksPerHalfLine() returns a u32 and c++'s weird type promotion rules,
cycleslate gets promoted from a s32 to a u32 and the result of the
subtraction is a really large u32.

Before ScheduleEvent accuracy improvements, ScheduleEvent took a s32, so
the result got cast back to the small negative we expect. But it now takes
a s64 and the u32 to s64 conversion gives us a really large number (around
two seconds) and Other M times out while waiting for something.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3774)
<!-- Reviewable:end -->
