### PR TITLE
PixelShaderGen: Fixes implicit type conversion or PR #3772.

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -836,7 +836,7 @@ static void WriteStage(T& out, pixel_shader_uid_data* uid_data, int n, API_TYPE 
 		uid_data->SetTevindrefTexmap(i, texmap);
 
 		out.Write("\ttextemp = ");
-		SampleTexture<T>(out, "(tevcoord.xy)", texswap, texmap, ApiType);
+		SampleTexture<T>(out, "float2(tevcoord.xy)", texswap, texmap, ApiType);
 	}
 	else
 	{


### PR DESCRIPTION
This regression did only happen on OpenGL ES.

Sorry...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3775)
<!-- Reviewable:end -->
