### PR TITLE
ActionReplay: Fix ISOProperties corrupting active code set

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -19,9 +19,12 @@
 // Zero Codes: any code with no address.  These codes are used to do special operations like memory copy, etc
 // -------------------------------------------------------------------------------------------------------------
 
-#include <list>
+#include <algorithm>
+#include <atomic>
+#include <iterator>
 #include <mutex>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -75,17 +78,14 @@ enum
 	SUB_MASTER_CODE   = 0x03,
 };
 
+// General lock. Protects codes list and internal log.
+static std::mutex s_lock;
+static std::vector<ARCode> s_active_codes;
+static std::vector<std::string> s_internal_log;
+static std::atomic<bool> s_use_internal_log{ false };
 // pointer to the code currently being run, (used by log messages that include the code name)
-static ARCode const* current_code = nullptr;
-
-static bool b_RanOnce = false;
-static std::vector<ARCode> arCodes;
-static std::vector<ARCode> activeCodes;
-static bool logSelf = false;
-static std::vector<std::string> arLog;
-
-static std::mutex s_callbacks_lock;
-static std::list<std::function<void()>> s_callbacks;
+static const ARCode* s_current_code = nullptr;
+static bool s_disable_logging = false;
 
 struct ARAddr
 {
@@ -106,13 +106,6 @@ struct ARAddr
 	operator u32() const { return address; }
 };
 
-static void RunCodeChangeCallbacks()
-{
-	std::lock_guard<std::mutex> guard(s_callbacks_lock);
-	for (const auto& cb : s_callbacks)
-		cb();
-}
-
 // ----------------------
 // AR Remote Functions
 void ApplyCodes(const std::vector<ARCode>& codes)
@@ -120,73 +113,59 @@ void ApplyCodes(const std::vector<ARCode>& codes)
 	if (!SConfig::GetInstance().bEnableCheats)
 		return;
 
-	arCodes = codes;
-	UpdateActiveList();
-	RunCodeChangeCallbacks();
+	std::lock_guard<std::mutex> guard(s_lock);
+	s_disable_logging = false;
+	s_active_codes.clear();
+	std::copy_if(codes.begin(), codes.end(), std::back_inserter(s_active_codes), [](const ARCode& code)
+	{
+		return code.active;
+	});
+	s_active_codes.shrink_to_fit();
 }
 
-void AddCode(const ARCode& code)
+void AddCode(ARCode code)
 {
 	if (!SConfig::GetInstance().bEnableCheats)
 		return;
 
-	arCodes.push_back(code);
 	if (code.active)
-		UpdateActiveList();
-	RunCodeChangeCallbacks();
-}
-
-void* RegisterCodeChangeCallback(std::function<void()> callback)
-{
-	if (!callback)
-		return nullptr;
-
-	std::lock_guard<std::mutex> guard(s_callbacks_lock);
-	s_callbacks.emplace_back(std::move(callback));
-	return &s_callbacks.back();
-}
-
-void UnregisterCodeChangeCallback(void* token)
-{
-	std::lock_guard<std::mutex> guard(s_callbacks_lock);
-	for (auto i = s_callbacks.begin(); i != s_callbacks.end(); ++i)
 	{
-		if (&*i == token)
-		{
-			s_callbacks.erase(i);
-			break;
-		}
+		std::lock_guard<std::mutex> guard(s_lock);
+		s_disable_logging = false;
+		s_active_codes.emplace_back(std::move(code));
 	}
 }
 
-void LoadAndApplyCodes(const IniFile& globalIni, const IniFile& localIni)
+void LoadAndApplyCodes(const IniFile& global_ini, const IniFile& local_ini)
 {
-	ApplyCodes(LoadCodes(globalIni, localIni));
+	ApplyCodes(LoadCodes(global_ini, local_ini));
 }
 
 // Parses the Action Replay section of a game ini file.
-std::vector<ARCode> LoadCodes(const IniFile& globalIni, const IniFile& localIni)
+std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_ini)
 {
 	std::vector<ARCode> codes;
 
-	std::vector<std::string> enabledLines;
-	std::set<std::string> enabledNames;
-	localIni.GetLines("ActionReplay_Enabled", &enabledLines);
-	for (const std::string& line : enabledLines)
+	std::unordered_set<std::string> enabled_names;
 	{
-		if (line.size() != 0 && line[0] == '$')
+		std::vector<std::string> enabled_lines;
+		local_ini.GetLines("ActionReplay_Enabled", &enabled_lines);
+		for (const std::string& line : enabled_lines)
 		{
-			std::string name = line.substr(1, line.size() - 1);
-			enabledNames.insert(name);
+			if (line.size() != 0 && line[0] == '$')
+			{
+				std::string name = line.substr(1, line.size() - 1);
+				enabled_names.insert(name);
+			}
 		}
 	}
 
-	const IniFile* inis[2] = {&globalIni, &localIni};
+	const IniFile* inis[2] = {&global_ini, &local_ini};
 	for (const IniFile* ini : inis)
 	{
 		std::vector<std::string> lines;
-		std::vector<std::string> encryptedLines;
-		ARCode currentCode;
+		std::vector<std::string> encrypted_lines;
+		ARCode current_code;
 
 		ini->GetLines("ActionReplay", &lines);
 
@@ -202,22 +181,22 @@ std::vector<ARCode> LoadCodes(const IniFile& globalIni, const IniFile& localIni)
 			// Check if the line is a name of the code
 			if (line[0] == '$')
 			{
-				if (currentCode.ops.size())
+				if (current_code.ops.size())
 				{
-					codes.push_back(currentCode);
-					currentCode.ops.clear();
+					codes.push_back(current_code);
+					current_code.ops.clear();
 				}
-				if (encryptedLines.size())
+				if (encrypted_lines.size())
 				{
-					DecryptARCode(encryptedLines, currentCode.ops);
-					codes.push_back(currentCode);
-					currentCode.ops.clear();
-					encryptedLines.clear();
+					DecryptARCode(encrypted_lines, current_code.ops);
+					codes.push_back(current_code);
+					current_code.ops.clear();
+					encrypted_lines.clear();
 				}
 
-				currentCode.name = line.substr(1, line.size() - 1);
-				currentCode.active = enabledNames.find(currentCode.name) != enabledNames.end();
-				currentCode.user_defined = (ini == &localIni);
+				current_code.name = line.substr(1, line.size() - 1);
+				current_code.active = enabled_names.find(current_code.name) != enabled_names.end();
+				current_code.user_defined = (ini == &local_ini);
 			}
 			else
 			{
@@ -232,7 +211,7 @@ std::vector<ARCode> LoadCodes(const IniFile& globalIni, const IniFile& localIni)
 
 					if (success_addr && success_val)
 					{
-						currentCode.ops.push_back(op);
+						current_code.ops.push_back(op);
 					}
 					else
 					{
@@ -253,105 +232,91 @@ std::vector<ARCode> LoadCodes(const IniFile& globalIni, const IniFile& localIni)
 						// Encrypted AR code
 						// Decryption is done in "blocks", so we must push blocks into a vector,
 						// then send to decrypt when a new block is encountered, or if it's the last block.
-						encryptedLines.push_back(pieces[0]+pieces[1]+pieces[2]);
+						encrypted_lines.emplace_back(pieces[0] + pieces[1] + pieces[2]);
 					}
 				}
 			}
 		}
 
 		// Handle the last code correctly.
-		if (currentCode.ops.size())
+		if (current_code.ops.size())
 		{
-			codes.push_back(currentCode);
+			codes.push_back(current_code);
 		}
-		if (encryptedLines.size())
+		if (encrypted_lines.size())
 		{
-			DecryptARCode(encryptedLines, currentCode.ops);
-			codes.push_back(currentCode);
+			DecryptARCode(encrypted_lines, current_code.ops);
+			codes.push_back(current_code);
 		}
 	}
 
 	return codes;
 }
 
-
-static void LogInfo(const char *format, ...)
+void SaveCodes(IniFile* local_ini, const std::vector<ARCode>& codes)
 {
-	if (!b_RanOnce)
+	std::vector<std::string> lines;
+	std::vector<std::string> enabled_lines;
+	for (const ActionReplay::ARCode& code : codes)
 	{
-		if (LogManager::GetMaxLevel() >= LogTypes::LINFO || logSelf)
-		{
-			va_list args;
-			va_start(args, format);
-			std::string text = StringFromFormatV(format, args);
-			va_end(args);
-			INFO_LOG(ACTIONREPLAY, "%s", text.c_str());
+		if (code.active)
+			enabled_lines.emplace_back("$" + code.name);
 
-			if (logSelf)
+		if (code.user_defined)
+		{
+			lines.emplace_back("$" + code.name);
+			for (const ActionReplay::AREntry& op : code.ops)
 			{
-				text += '\n';
-				arLog.push_back(text);
+				lines.emplace_back(StringFromFormat("%08X %08X", op.cmd_addr, op.value));
 			}
 		}
 	}
+	local_ini->SetLines("ActionReplay_Enabled", enabled_lines);
+	local_ini->SetLines("ActionReplay", lines);
 }
 
-size_t GetCodeListSize()
-{
-	return arCodes.size();
-}
 
-ARCode GetARCode(size_t index)
+static void LogInfo(const char* format, ...)
 {
-	if (index > arCodes.size())
-	{
-		PanicAlertT("GetARCode: Index is greater than "
-			"ar code list size %zu", index);
-		return ARCode();
-	}
-	return arCodes[index];
-}
-
-void SetARCode_IsActive(bool active, size_t index)
-{
-	if (index > arCodes.size())
-	{
-		PanicAlertT("SetARCode_IsActive: Index is greater than "
-			"ar code list size %zu", index);
+	if (s_disable_logging)
 		return;
-	}
-	arCodes[index].active = active;
-	UpdateActiveList();
-	RunCodeChangeCallbacks();
-}
+	bool use_internal_log = s_use_internal_log.load(std::memory_order_relaxed);
+	if (LogManager::GetMaxLevel() < LogTypes::LINFO && !use_internal_log)
+		return;
 
-void UpdateActiveList()
-{
-	bool old_value = SConfig::GetInstance().bEnableCheats;
-	SConfig::GetInstance().bEnableCheats = false;
-	b_RanOnce = false;
-	activeCodes.clear();
-	for (auto& arCode : arCodes)
+	va_list args;
+	va_start(args, format);
+	std::string text = StringFromFormatV(format, args);
+	va_end(args);
+	INFO_LOG(ACTIONREPLAY, "%s", text.c_str());
+
+	if (use_internal_log)
 	{
-		if (arCode.active)
-			activeCodes.push_back(arCode);
+		text += '\n';
+		s_internal_log.emplace_back(std::move(text));
 	}
-	SConfig::GetInstance().bEnableCheats = old_value;
 }
 
 void EnableSelfLogging(bool enable)
 {
-	logSelf = enable;
+	s_use_internal_log.store(enable, std::memory_order_relaxed);
 }
 
-const std::vector<std::string> &GetSelfLog()
+std::vector<std::string> GetSelfLog()
 {
-	return arLog;
+	std::lock_guard<std::mutex> guard(s_lock);
+	return s_internal_log;
+}
+
+void ClearSelfLog()
+{
+	std::lock_guard<std::mutex> guard(s_lock);
+	s_internal_log.clear();
 }
 
 bool IsSelfLogging()
 {
-	return logSelf;
+	return s_use_internal_log.load(std::memory_order_relaxed);
 }
 
 // ----------------------
@@ -405,8 +370,8 @@ static bool Subtype_RamWriteAndFill(const ARAddr& addr, const u32 data)
 	default:
 		LogInfo("Bad Size");
 		PanicAlertT("Action Replay Error: Invalid size "
-			"(%08x : address = %08x) in Ram Write And Fill (%s)",
-			addr.size, addr.gcaddr, current_code->name.c_str());
+		            "(%08x : address = %08x) in Ram Write And Fill (%s)",
+		            addr.size, addr.gcaddr, s_current_code->name.c_str());
 		return false;
 	}
 
@@ -443,7 +408,7 @@ static bool Subtype_WriteToPointer(const ARAddr& addr, const u32 data)
 		LogInfo("Write 16-bit to pointer");
 		LogInfo("--------");
 		const u16 theshort = data & 0xFFFF;
-		const u32 offset = (data >> 16) << 1;
+		const u32 offset   = (data >> 16) << 1;
 		LogInfo("Pointer: %08x", ptr);
 		LogInfo("Byte: %08x", theshort);
 		LogInfo("Offset: %08x", offset);
@@ -465,8 +430,8 @@ static bool Subtype_WriteToPointer(const ARAddr& addr, const u32 data)
 	default:
 		LogInfo("Bad Size");
 		PanicAlertT("Action Replay Error: Invalid size "
-			"(%08x : address = %08x) in Write To Pointer (%s)",
-			addr.size, addr.gcaddr, current_code->name.c_str());
+		            "(%08x : address = %08x) in Write To Pointer (%s)",
+		            addr.size, addr.gcaddr, s_current_code->name.c_str());
 		return false;
 	}
 	return true;
@@ -512,8 +477,10 @@ static bool Subtype_AddCode(const ARAddr& addr, const u32 data)
 		LogInfo("--------");
 
 		const u32 read = PowerPC::HostRead_U32(new_addr);
-		const float fread = *((float*)&read) + (float)data; // data contains an integer value
-		const u32 newval = *((u32*)&fread);
+		const float read_float = reinterpret_cast<const float&>(read);
+		// data contains an (unsigned?) integer value
+		const float fread = read_float + static_cast<float>(data);
+		const u32 newval  = reinterpret_cast<const u32&>(fread);
 		PowerPC::HostWrite_U32(newval, new_addr);
 		LogInfo("Old Value %08x", read);
 		LogInfo("Increment %08x", data);
@@ -525,8 +492,8 @@ static bool Subtype_AddCode(const ARAddr& addr, const u32 data)
 	default:
 		LogInfo("Bad Size");
 		PanicAlertT("Action Replay Error: Invalid size "
-			"(%08x : address = %08x) in Add Code (%s)",
-			addr.size, addr.gcaddr, current_code->name.c_str());
+		            "(%08x : address = %08x) in Add Code (%s)",
+		            addr.size, addr.gcaddr, s_current_code->name.c_str());
 		return false;
 	}
 	return true;
@@ -540,18 +507,20 @@ static bool Subtype_MasterCodeAndWriteToCCXXXXXX(const ARAddr& addr, const u32 d
 	// u8  mcode_count = (data & 0xFF00) >> 8;
 	// u8  mcode_number = data & 0xFF;
 	PanicAlertT("Action Replay Error: Master Code and Write To CCXXXXXX not implemented (%s)\n"
-		"Master codes are not needed. Do not use master codes.", current_code->name.c_str());
+	            "Master codes are not needed. Do not use master codes.",
+	            s_current_code->name.c_str());
 	return false;
 }
 
-static bool ZeroCode_FillAndSlide(const u32 val_last, const ARAddr& addr, const u32 data) // This needs more testing
+// This needs more testing
+static bool ZeroCode_FillAndSlide(const u32 val_last, const ARAddr& addr, const u32 data)
 {
-	const u32 new_addr = ((ARAddr*)&val_last)->GCAddress();
-	const u8 size = ((ARAddr*)&val_last)->size;
+	const u32 new_addr = ARAddr(val_last).GCAddress();
+	const u8  size     = ARAddr(val_last).size;
 
-	const s16 addr_incr = (s16)(data & 0xFFFF);
-	const s8  val_incr = (s8)(data >> 24);
-	const u8  write_num = (data & 0xFF0000) >> 16;
+	const s16 addr_incr = static_cast<s16>(data & 0xFFFF);
+	const s8  val_incr  = static_cast<s8>(data >> 24);
+	const u8  write_num = static_cast<u8>((data & 0xFF0000) >> 16);
 
 	u32 val = addr;
 	u32 curr_addr = new_addr;
@@ -612,7 +581,8 @@ static bool ZeroCode_FillAndSlide(const u32 val_last, const ARAddr& addr, const 
 
 	default:
 		LogInfo("Bad Size");
-		PanicAlertT("Action Replay Error: Invalid size (%08x : address = %08x) in Fill and Slide (%s)", size, new_addr, current_code->name.c_str());
+		PanicAlertT("Action Replay Error: Invalid size (%08x : address = %08x) in Fill and Slide (%s)",
+		            size, new_addr, s_current_code->name.c_str());
 		return false;
 	}
 	return true;
@@ -659,7 +629,8 @@ static bool ZeroCode_MemoryCopy(const u32 val_last, const ARAddr& addr, const u3
 	else
 	{
 		LogInfo("Bad Value");
-		PanicAlertT("Action Replay Error: Invalid value (%08x) in Memory Copy (%s)", (data & ~0x7FFF), current_code->name.c_str());
+		PanicAlertT("Action Replay Error: Invalid value (%08x) in Memory Copy (%s)",
+		            (data & ~0x7FFF), s_current_code->name.c_str());
 		return false;
 	}
 	return true;
@@ -695,9 +666,9 @@ static bool NormalCode(const ARAddr& addr, const u32 data)
 
 	default:
 		LogInfo("Bad Subtype");
-		PanicAlertT("Action Replay: Normal Code 0: Invalid Subtype %08x (%s)", addr.subtype, current_code->name.c_str());
+		PanicAlertT("Action Replay: Normal Code 0: Invalid Subtype %08x (%s)", addr.subtype,
+		            s_current_code->name.c_str());
 		return false;
-		break;
 	}
 
 	return true;
@@ -709,43 +680,36 @@ static bool CompareValues(const u32 val1, const u32 val2, const int type)
 	{
 	case CONDTIONAL_EQUAL:
 		LogInfo("Type 1: If Equal");
-		return (val1 == val2);
-		break;
+		return val1 == val2;
 
 	case CONDTIONAL_NOT_EQUAL:
 		LogInfo("Type 2: If Not Equal");
-		return (val1 != val2);
-		break;
+		return val1 != val2;
 
 	case CONDTIONAL_LESS_THAN_SIGNED:
 		LogInfo("Type 3: If Less Than (Signed)");
-		return ((int)val1 < (int)val2);
-		break;
+		return static_cast<s32>(val1) < static_cast<s32>(val2);
 
 	case CONDTIONAL_GREATER_THAN_SIGNED:
 		LogInfo("Type 4: If Greater Than (Signed)");
-		return ((int)val1 >(int)val2);
-		break;
+		return static_cast<s32>(val1) > static_cast<s32>(val2);
 
 	case CONDTIONAL_LESS_THAN_UNSIGNED:
 		LogInfo("Type 5: If Less Than (Unsigned)");
-		return (val1 < val2);
-		break;
+		return val1 < val2;
 
 	case CONDTIONAL_GREATER_THAN_UNSIGNED:
 		LogInfo("Type 6: If Greater Than (Unsigned)");
-		return (val1 > val2);
-		break;
+		return val1 > val2;
 
 	case CONDTIONAL_AND:
 		LogInfo("Type 7: If And");
 		return !!(val1 & val2); // bitwise AND
-		break;
 
 	default: LogInfo("Unknown Compare type");
-		PanicAlertT("Action Replay: Invalid Normal Code Type %08x (%s)", type, current_code->name.c_str());
+		PanicAlertT("Action Replay: Invalid Normal Code Type %08x (%s)",
+		            type, s_current_code->name.c_str());
 		return false;
-		break;
 	}
 }
 
@@ -761,11 +725,11 @@ static bool ConditionalCode(const ARAddr& addr, const u32 data, int* const pSkip
 	switch (addr.size)
 	{
 	case DATATYPE_8BIT:
-		result = CompareValues((u32)PowerPC::HostRead_U8(new_addr), (data & 0xFF), addr.type);
+		result = CompareValues(PowerPC::HostRead_U8(new_addr), (data & 0xFF), addr.type);
 		break;
 
 	case DATATYPE_16BIT:
-		result = CompareValues((u32)PowerPC::HostRead_U16(new_addr), (data & 0xFFFF), addr.type);
+		result = CompareValues(PowerPC::HostRead_U16(new_addr), (data & 0xFFFF), addr.type);
 		break;
 
 	case DATATYPE_32BIT_FLOAT:
@@ -775,9 +739,9 @@ static bool ConditionalCode(const ARAddr& addr, const u32 data, int* const pSkip
 
 	default:
 		LogInfo("Bad Size");
-		PanicAlertT("Action Replay: Conditional Code: Invalid Size %08x (%s)", addr.size, current_code->name.c_str());
+		PanicAlertT("Action Replay: Conditional Code: Invalid Size %08x (%s)", addr.size,
+		            s_current_code->name.c_str());
 		return false;
-		break;
 	}
 
 	// if the comparison failed we need to skip some lines
@@ -794,58 +758,41 @@ static bool ConditionalCode(const ARAddr& addr, const u32 data, int* const pSkip
 		// Skip lines until a "00000000 40000000" line is reached
 		case CONDTIONAL_ALL_LINES:
 		case CONDTIONAL_ALL_LINES_UNTIL:
-			*pSkipCount = -(int) addr.subtype;
+			*pSkipCount = -static_cast<int>(addr.subtype);
 			break;
 
 		default:
 			LogInfo("Bad Subtype");
-			PanicAlertT("Action Replay: Normal Code %i: Invalid subtype %08x (%s)", 1, addr.subtype, current_code->name.c_str());
+			PanicAlertT("Action Replay: Normal Code %i: Invalid subtype %08x (%s)",
+			            1, addr.subtype, s_current_code->name.c_str());
 			return false;
-			break;
 		}
 	}
 
 	return true;
 }
 
-
-void RunAllActive()
-{
-	if (SConfig::GetInstance().bEnableCheats)
-	{
-		for (auto& activeCode : activeCodes)
-		{
-			if (activeCode.active)
-			{
-				activeCode.active = RunCode(activeCode);
-				LogInfo("\n");
-			}
-		}
-
-		b_RanOnce = true;
-	}
-}
-
-bool RunCode(const ARCode &arcode)
+// NOTE: Lock needed to give mutual exclusion to s_current_code and LogInfo
+static bool RunCodeLocked(const ARCode& arcode)
 {
 	// The mechanism is different than what the real AR uses, so there may be compatibility problems.
 
-	bool doFillNSlide = false;
-	bool doMemoryCopy = false;
+	bool do_fill_and_slide = false;
+	bool do_memory_copy = false;
 
 	// used for conditional codes
 	int skip_count = 0;
 
 	u32 val_last = 0;
 
-	current_code = &arcode;
+	s_current_code = &arcode;
 
 	LogInfo("Code Name: %s", arcode.name.c_str());
 	LogInfo("Number of codes: %zu", arcode.ops.size());
 
 	for (const AREntry& entry : arcode.ops)
 	{
-		const ARAddr& addr = *(ARAddr*)&entry.cmd_addr;
+		const ARAddr addr(entry.cmd_addr);
 		const u32 data = entry.value;
 
 		// after a conditional code, skip lines if needed
@@ -877,9 +824,9 @@ bool RunCode(const ARCode &arcode)
 		//LogInfo("Command: %08x", cmd);
 
 		// Do Fill & Slide
-		if (doFillNSlide)
+		if (do_fill_and_slide)
 		{
-			doFillNSlide = false;
+			do_fill_and_slide = false;
 			LogInfo("Doing Fill And Slide");
 			if (false == ZeroCode_FillAndSlide(val_last, addr, data))
 				return false;
@@ -887,9 +834,9 @@ bool RunCode(const ARCode &arcode)
 		}
 
 		// Memory Copy
-		if (doMemoryCopy)
+		if (do_memory_copy)
 		{
-			doMemoryCopy = false;
+			do_memory_copy = false;
 			LogInfo("Doing Memory Copy");
 			if (false == ZeroCode_MemoryCopy(val_last, addr, data))
 				return false;
@@ -912,7 +859,7 @@ bool RunCode(const ARCode &arcode)
 		// Zero codes
 		if (0x0 == addr) // Check if the code is a zero code
 		{
-			const u8 zcode = (data >> 29);
+			const u8 zcode = data >> 29;
 
 			LogInfo("Doing Zero Code %08x", zcode);
 
@@ -921,7 +868,6 @@ bool RunCode(const ARCode &arcode)
 			case ZCODE_END: // END OF CODES
 				LogInfo("ZCode: End Of Codes");
 				return true;
-				break;
 
 				// TODO: the "00000000 40000000"(end if) codes fall into this case, I don't think that is correct
 			case ZCODE_NORM: // Normal execution of codes
@@ -934,19 +880,18 @@ bool RunCode(const ARCode &arcode)
 				LogInfo("ZCode: Executes all codes in the same row, Set register 1BB4 to 1 (zcode not supported)");
 				PanicAlertT("Zero 3 code not supported");
 				return false;
-				break;
 
 			case ZCODE_04: // Fill & Slide or Memory Copy
 				if (0x3 == ((data >> 25) & 0x03))
 				{
 					LogInfo("ZCode: Memory Copy");
-					doMemoryCopy = true;
+					do_memory_copy = true;
 					val_last = data;
 				}
 				else
 				{
 					LogInfo("ZCode: Fill And Slide");
-					doFillNSlide = true;
+					do_fill_and_slide = true;
 					val_last = data;
 				}
 				break;
@@ -955,7 +900,6 @@ bool RunCode(const ARCode &arcode)
 				LogInfo("ZCode: Unknown");
 				PanicAlertT("Zero code unknown to Dolphin: %08x", zcode);
 				return false;
-				break;
 			}
 
 			// done handling zero codes
@@ -981,9 +925,25 @@ bool RunCode(const ARCode &arcode)
 		}
 	}
 
-	b_RanOnce = true;
-
 	return true;
+}
+
+void RunAllActive()
+{
+	if (!SConfig::GetInstance().bEnableCheats)
+		return;
+
+	// If the mutex is idle then acquiring it should be cheap, fast mutexes
+	// are only atomic ops unless contested. It should be rare for this to
+	// be contested.
+	std::lock_guard<std::mutex> guard(s_lock);
+	s_active_codes.erase(std::remove_if(s_active_codes.begin(), s_active_codes.end(), [](const ARCode& code)
+	{
+		bool success = RunCodeLocked(code);
+		LogInfo("\n");
+		return !success;
+	}), s_active_codes.end());
+	s_disable_logging = true;
 }
 
 } // namespace ActionReplay

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <functional>
 #include <string>
 #include <vector>
 #include "Common/CommonTypes.h"
@@ -31,18 +30,16 @@ struct ARCode
 };
 
 void RunAllActive();
-bool RunCode(const ARCode &arcode);
+
 void ApplyCodes(const std::vector<ARCode>& codes);
-void AddCode(const ARCode& new_code);
-void* RegisterCodeChangeCallback(std::function<void()> callback);
-void  UnregisterCodeChangeCallback(void* token);
-void LoadAndApplyCodes(const IniFile& globalini, const IniFile& localIni);
-std::vector<ARCode> LoadCodes(const IniFile& globalini, const IniFile& localIni);
-size_t GetCodeListSize();
-ARCode GetARCode(size_t index);
-void SetARCode_IsActive(bool active, size_t index);
-void UpdateActiveList();
+void AddCode(ARCode new_code);
+void LoadAndApplyCodes(const IniFile& global_ini, const IniFile& local_ini);
+
+std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_ini);
+void SaveCodes(IniFile* local_ini, const std::vector<ARCode>& codes);
+
 void EnableSelfLogging(bool enable);
-const std::vector<std::string> &GetSelfLog();
+std::vector<std::string> GetSelfLog();
+void ClearSelfLog();
 bool IsSelfLogging();
 }  // namespace

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include <vector>
 #include "Common/CommonTypes.h"
@@ -31,8 +32,12 @@ struct ARCode
 
 void RunAllActive();
 bool RunCode(const ARCode &arcode);
-void LoadCodes(const IniFile &globalini, const IniFile &localIni, bool forceLoad);
-void LoadCodes(std::vector<ARCode> &_arCodes, IniFile &globalini, IniFile &localIni);
+void ApplyCodes(const std::vector<ARCode>& codes);
+void AddCode(const ARCode& new_code);
+void* RegisterCodeChangeCallback(std::function<void()> callback);
+void  UnregisterCodeChangeCallback(void* token);
+void LoadAndApplyCodes(const IniFile& globalini, const IniFile& localIni);
+std::vector<ARCode> LoadCodes(const IniFile& globalini, const IniFile& localIni);
 size_t GetCodeListSize();
 ARCode GetARCode(size_t index);
 void SetARCode_IsActive(bool active, size_t index);

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -166,7 +166,7 @@ void LoadPatches()
 	IniFile localIni = SConfig::GetInstance().LoadLocalGameIni();
 
 	LoadPatchSection("OnFrame", onFrame, globalIni, localIni);
-	ActionReplay::LoadCodes(globalIni, localIni, false);
+	ActionReplay::LoadAndApplyCodes(globalIni, localIni);
 
 	// lil silly
 	std::vector<Gecko::GeckoCode> gcodes;

--- a/Source/Core/DolphinWX/ARCodeAddEdit.cpp
+++ b/Source/Core/DolphinWX/ARCodeAddEdit.cpp
@@ -160,6 +160,7 @@ void CARCodeAddEdit::SaveCheatData(wxCommandEvent& WXUNUSED(event))
 		newCheat.name = WxStrToStr(EditCheatName->GetValue());
 		newCheat.ops = decryptedLines;
 		newCheat.active = true;
+		newCheat.user_defined = true;
 
 		arCodes->push_back(newCheat);
 	}

--- a/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatSearchTab.cpp
@@ -174,7 +174,6 @@ void CheatSearchTab::OnCreateARCodeClicked(wxCommandEvent&)
 	const u32 address = m_search_results[idx].address | ((m_search_type_size & ~1) << 24);
 
 	CreateCodeDialog arcode_dlg(this, address);
-	arcode_dlg.SetExtraStyle(arcode_dlg.GetExtraStyle() & ~wxWS_EX_BLOCK_EVENTS);
 	arcode_dlg.ShowModal();
 }
 

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
+#include <functional>
 #include <string>
 #include <vector>
 #include <wx/button.h>
@@ -38,11 +39,18 @@
 #include "DolphinWX/Cheats/CreateCodeDialog.h"
 #include "DolphinWX/Cheats/GeckoCodeDiag.h"
 
+namespace
+{
+wxDEFINE_EVENT(DOLPHIN_EVT_UPDATE_CHEAT_LIST, wxThreadEvent);
+}
+
 wxCheatsWindow::wxCheatsWindow(wxWindow* const parent)
 	: wxDialog(parent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX | wxMINIMIZE_BOX | wxDIALOG_NO_PARENT)
 {
 	// Create the GUI controls
 	Init_ChildControls();
+
+	m_ar_callback_token = ActionReplay::RegisterCodeChangeCallback(std::bind(&wxCheatsWindow::OnActionReplayModified, this));
 
 	// load codes
 	UpdateGUI();
@@ -54,6 +62,7 @@ wxCheatsWindow::wxCheatsWindow(wxWindow* const parent)
 
 wxCheatsWindow::~wxCheatsWindow()
 {
+	ActionReplay::UnregisterCodeChangeCallback(m_ar_callback_token);
 	main_frame->g_CheatsWindow = nullptr;
 }
 
@@ -126,7 +135,7 @@ void wxCheatsWindow::Init_ChildControls()
 	button_cancel->Bind(wxEVT_BUTTON, &wxCheatsWindow::OnEvent_ButtonClose_Press, this);
 
 	Bind(wxEVT_CLOSE_WINDOW, &wxCheatsWindow::OnEvent_Close, this);
-	Bind(UPDATE_CHEAT_LIST_EVENT, &wxCheatsWindow::OnEvent_CheatsList_Update, this);
+	Bind(DOLPHIN_EVT_UPDATE_CHEAT_LIST, &wxCheatsWindow::OnEvent_CheatsList_Update, this);
 
 	wxStdDialogButtonSizer* const sButtons = new wxStdDialogButtonSizer();
 	sButtons->AddButton(m_button_apply);
@@ -232,24 +241,30 @@ void wxCheatsWindow::OnEvent_CheatsList_ItemToggled(wxCommandEvent& WXUNUSED(eve
 	{
 		if ((int)code_index.uiIndex == index)
 		{
+			m_ar_ignore_callback = true;
 			ActionReplay::SetARCode_IsActive(m_checklistbox_cheats_list->IsChecked(index), code_index.index);
 		}
 	}
 }
 
-void wxCheatsWindow::OnEvent_CheatsList_Update(wxCommandEvent& event)
+void wxCheatsWindow::OnEvent_CheatsList_Update(wxThreadEvent&)
 {
+	if (m_ar_ignore_callback)
+	{
+		m_ar_ignore_callback = false;
+		return;
+	}
 	Load_ARCodes();
+}
+
+void wxCheatsWindow::OnActionReplayModified()
+{
+	// NOTE: This is an arbitrary thread context
+	GetEventHandler()->QueueEvent(new wxThreadEvent(DOLPHIN_EVT_UPDATE_CHEAT_LIST));
 }
 
 void wxCheatsWindow::OnEvent_ApplyChanges_Press(wxCommandEvent& ev)
 {
-	// Apply AR Code changes
-	for (const ARCodeIndex& code_index : m_index_list)
-	{
-		ActionReplay::SetARCode_IsActive(m_checklistbox_cheats_list->IsChecked(code_index.uiIndex), code_index.index);
-	}
-
 	// Apply Gecko Code changes
 	Gecko::SetActiveCodes(m_geckocode_panel->GetCodes());
 
@@ -265,11 +280,15 @@ void wxCheatsWindow::OnEvent_ApplyChanges_Press(wxCommandEvent& ev)
 
 void wxCheatsWindow::OnEvent_ButtonUpdateLog_Press(wxCommandEvent& WXUNUSED(event))
 {
+	wxBeginBusyCursor();
+	m_textctrl_log->Freeze();
 	m_textctrl_log->Clear();
 	for (const std::string& text : ActionReplay::GetSelfLog())
 	{
 		m_textctrl_log->AppendText(StrToWxStr(text));
 	}
+	m_textctrl_log->Thaw();
+	wxEndBusyCursor();
 }
 
 void wxCheatsWindow::OnEvent_CheckBoxEnableLogging_StateChange(wxCommandEvent& WXUNUSED(event))

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.h
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.h
@@ -72,6 +72,10 @@ private:
 	IniFile m_gameini_local;
 	std::string m_gameini_local_path;
 
+	// ActionReplay::UnregisterCodeChangeCallback handle
+	void* m_ar_callback_token = nullptr;
+	bool  m_ar_ignore_callback = false;
+
 	void Init_ChildControls();
 
 	void Load_ARCodes();
@@ -86,7 +90,8 @@ private:
 	// Cheats List
 	void OnEvent_CheatsList_ItemSelected(wxCommandEvent& event);
 	void OnEvent_CheatsList_ItemToggled(wxCommandEvent& event);
-	void OnEvent_CheatsList_Update(wxCommandEvent& event);
+	void OnEvent_CheatsList_Update(wxThreadEvent& event);
+	void OnActionReplayModified();
 
 	// Apply Changes Button
 	void OnEvent_ApplyChanges_Press(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.h
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.h
@@ -29,6 +29,8 @@ namespace Gecko
 	class CodeConfigPanel;
 }
 
+wxDECLARE_EVENT(DOLPHIN_EVT_ADD_NEW_ACTION_REPLAY_CODE, wxCommandEvent);
+
 class wxCheatsWindow final : public wxDialog
 {
 public:
@@ -37,11 +39,7 @@ public:
 	void UpdateGUI();
 
 private:
-	struct ARCodeIndex
-	{
-		u32 uiIndex;
-		size_t index;
-	};
+	struct CodeData;
 
 	// --- GUI Controls ---
 	wxButton* m_button_apply;
@@ -63,18 +61,14 @@ private:
 
 	wxStaticBox* m_groupbox_info;
 
-	wxArrayString m_cheat_string_list;
-
-	std::vector<ARCodeIndex> m_index_list;
-
 	Gecko::CodeConfigPanel* m_geckocode_panel;
 	IniFile m_gameini_default;
 	IniFile m_gameini_local;
 	std::string m_gameini_local_path;
+	std::string m_game_id;
+	u32 m_game_revision;
 
-	// ActionReplay::UnregisterCodeChangeCallback handle
-	void* m_ar_callback_token = nullptr;
-	bool  m_ar_ignore_callback = false;
+	bool m_ignore_ini_callback = false;
 
 	void Init_ChildControls();
 
@@ -82,6 +76,8 @@ private:
 	void Load_GeckoCodes();
 
 	// --- Wx Events Handlers ---
+	// Cheat Search
+	void OnNewARCodeCreated(wxCommandEvent& ev);
 
 	// Close Button
 	void OnEvent_ButtonClose_Press(wxCommandEvent& event);
@@ -89,15 +85,14 @@ private:
 
 	// Cheats List
 	void OnEvent_CheatsList_ItemSelected(wxCommandEvent& event);
-	void OnEvent_CheatsList_ItemToggled(wxCommandEvent& event);
-	void OnEvent_CheatsList_Update(wxThreadEvent& event);
-	void OnActionReplayModified();
+	void OnEvent_CheatsList_Update(wxCommandEvent& event);
 
 	// Apply Changes Button
 	void OnEvent_ApplyChanges_Press(wxCommandEvent& event);
 
 	// Update Log Button
 	void OnEvent_ButtonUpdateLog_Press(wxCommandEvent& event);
+	void OnClearActionReplayLog(wxCommandEvent& event);
 
 	// Enable Logging Checkbox
 	void OnEvent_CheckBoxEnableLogging_StateChange(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
+++ b/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
@@ -12,6 +12,7 @@
 #include "Core/ConfigManager.h"
 #include "DolphinWX/ISOProperties.h"
 #include "DolphinWX/WxUtils.h"
+#include "DolphinWX/Cheats/CheatsWindow.h"
 #include "DolphinWX/Cheats/CreateCodeDialog.h"
 
 CreateCodeDialog::CreateCodeDialog(wxWindow* const parent, const u32 address)
@@ -70,27 +71,16 @@ void CreateCodeDialog::PressOK(wxCommandEvent& ev)
 		return;
 	}
 
-	//wxString full_code = textctrl_code->GetValue();
-	//full_code += ' ';
-	//full_code += wxString::Format("0x%08x", code_value);
-
 	// create the new code
 	ActionReplay::ARCode new_cheat;
 	new_cheat.active = false;
 	new_cheat.user_defined = true;
 	new_cheat.name = WxStrToStr(code_name);
 	new_cheat.ops.emplace_back(ActionReplay::AREntry(m_code_address, code_value));
-	ActionReplay::AddCode(new_cheat);
 
-	// pretty hacky - add the code to the gameini
-	// FIXME: The save logic should be ActionReplay since it mirrors the parser
-	{
-	CISOProperties isoprops(GameListItem(SConfig::GetInstance().m_LastFilename, {}), this);
-	// add the code to the isoproperties arcode list
-	isoprops.AddARCode(new_cheat);
-	// save the gameini
-	isoprops.SaveGameConfig();
-	}
+	wxCommandEvent add_event(DOLPHIN_EVT_ADD_NEW_ACTION_REPLAY_CODE, GetId());
+	add_event.SetClientData(&new_cheat);
+	GetParent()->GetEventHandler()->ProcessEvent(add_event);
 
 	Close();
 }

--- a/Source/Core/DolphinWX/Cheats/CreateCodeDialog.h
+++ b/Source/Core/DolphinWX/Cheats/CreateCodeDialog.h
@@ -12,8 +12,6 @@
 class wxCheckBox;
 class wxTextCtrl;
 
-wxDECLARE_EVENT(UPDATE_CHEAT_LIST_EVENT, wxCommandEvent);
-
 class CreateCodeDialog final : public wxDialog
 {
 public:

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -223,6 +223,7 @@ bool CRenderFrame::ShowFullScreen(bool show, long style)
 // help button.
 
 wxDEFINE_EVENT(wxEVT_HOST_COMMAND, wxCommandEvent);
+wxDEFINE_EVENT(DOLPHIN_EVT_LOCAL_INI_CHANGED, wxCommandEvent);
 
 BEGIN_EVENT_TABLE(CFrame, CRenderFrame)
 

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <wx/app.h>
 #include <wx/bitmap.h>
 #include <wx/buffer.h>
 #include <wx/colour.h>
@@ -167,51 +168,50 @@ CGameListCtrl::CGameListCtrl(wxWindow* parent, const wxWindowID id, const
 	Bind(wxEVT_MENU, &CGameListCtrl::OnMultiDecompressISO, this, IDM_MULTI_DECOMPRESS_ISO);
 	Bind(wxEVT_MENU, &CGameListCtrl::OnDeleteISO, this, IDM_DELETE_ISO);
 	Bind(wxEVT_MENU, &CGameListCtrl::OnChangeDisc, this, IDM_LIST_CHANGE_DISC);
+
+	wxTheApp->Bind(DOLPHIN_EVT_LOCAL_INI_CHANGED, &CGameListCtrl::OnLocalIniModified, this);
 }
 
 CGameListCtrl::~CGameListCtrl()
 {
-	if (m_imageListSmall)
-		delete m_imageListSmall;
-
 	ClearIsoFiles();
 }
 
 void CGameListCtrl::InitBitmaps()
 {
 	wxSize size(96, 32);
-	m_imageListSmall = new wxImageList(96, 32);
-	SetImageList(m_imageListSmall, wxIMAGE_LIST_SMALL);
+	wxImageList* img_list = new wxImageList(96, 32);
+	AssignImageList(img_list, wxIMAGE_LIST_SMALL);
 
 	m_FlagImageIndex.resize(DiscIO::IVolume::NUMBER_OF_COUNTRIES);
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_JAPAN]       = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Japan", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_EUROPE]      = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Europe", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_USA]         = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_USA", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_AUSTRALIA]   = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Australia", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_FRANCE]      = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_France", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_GERMANY]     = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Germany", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_ITALY]       = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Italy", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_KOREA]       = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Korea", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_NETHERLANDS] = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Netherlands", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_RUSSIA]      = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Russia", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_SPAIN]       = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Spain", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_TAIWAN]      = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Taiwan", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_WORLD]       = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_International", size));
-	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_UNKNOWN]     = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Flag_Unknown", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_JAPAN]       = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Japan", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_EUROPE]      = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Europe", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_USA]         = img_list->Add(WxUtils::LoadResourceBitmap("Flag_USA", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_AUSTRALIA]   = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Australia", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_FRANCE]      = img_list->Add(WxUtils::LoadResourceBitmap("Flag_France", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_GERMANY]     = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Germany", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_ITALY]       = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Italy", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_KOREA]       = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Korea", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_NETHERLANDS] = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Netherlands", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_RUSSIA]      = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Russia", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_SPAIN]       = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Spain", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_TAIWAN]      = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Taiwan", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_WORLD]       = img_list->Add(WxUtils::LoadResourceBitmap("Flag_International", size));
+	m_FlagImageIndex[DiscIO::IVolume::COUNTRY_UNKNOWN]     = img_list->Add(WxUtils::LoadResourceBitmap("Flag_Unknown", size));
 
 	m_PlatformImageIndex.resize(4);
-	m_PlatformImageIndex[DiscIO::IVolume::GAMECUBE_DISC]   = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Platform_Gamecube", size));
-	m_PlatformImageIndex[DiscIO::IVolume::WII_DISC]        = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Platform_Wii", size));
-	m_PlatformImageIndex[DiscIO::IVolume::WII_WAD]         = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Platform_Wad", size));
-	m_PlatformImageIndex[DiscIO::IVolume::ELF_DOL]         = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("Platform_File", size));
+	m_PlatformImageIndex[DiscIO::IVolume::GAMECUBE_DISC]   = img_list->Add(WxUtils::LoadResourceBitmap("Platform_Gamecube", size));
+	m_PlatformImageIndex[DiscIO::IVolume::WII_DISC]        = img_list->Add(WxUtils::LoadResourceBitmap("Platform_Wii", size));
+	m_PlatformImageIndex[DiscIO::IVolume::WII_WAD]         = img_list->Add(WxUtils::LoadResourceBitmap("Platform_Wad", size));
+	m_PlatformImageIndex[DiscIO::IVolume::ELF_DOL]         = img_list->Add(WxUtils::LoadResourceBitmap("Platform_File", size));
 
 	m_EmuStateImageIndex.resize(6);
-	m_EmuStateImageIndex[0] = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("rating0", size));
-	m_EmuStateImageIndex[1] = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("rating1", size));
-	m_EmuStateImageIndex[2] = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("rating2", size));
-	m_EmuStateImageIndex[3] = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("rating3", size));
-	m_EmuStateImageIndex[4] = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("rating4", size));
-	m_EmuStateImageIndex[5] = m_imageListSmall->Add(WxUtils::LoadResourceBitmap("rating5", size));
+	m_EmuStateImageIndex[0] = img_list->Add(WxUtils::LoadResourceBitmap("rating0", size));
+	m_EmuStateImageIndex[1] = img_list->Add(WxUtils::LoadResourceBitmap("rating1", size));
+	m_EmuStateImageIndex[2] = img_list->Add(WxUtils::LoadResourceBitmap("rating2", size));
+	m_EmuStateImageIndex[3] = img_list->Add(WxUtils::LoadResourceBitmap("rating3", size));
+	m_EmuStateImageIndex[4] = img_list->Add(WxUtils::LoadResourceBitmap("rating4", size));
+	m_EmuStateImageIndex[5] = img_list->Add(WxUtils::LoadResourceBitmap("rating5", size));
 }
 
 void CGameListCtrl::BrowseForDirectory()
@@ -247,16 +247,9 @@ void CGameListCtrl::Update()
 	if (Core::GetState() != Core::CORE_UNINITIALIZED)
 		return;
 
-	if (m_imageListSmall)
-	{
-		delete m_imageListSmall;
-		m_imageListSmall = nullptr;
-	}
-
-	Hide();
-
 	ScanForISOs();
 
+	Freeze();
 	ClearAll();
 
 	if (m_ISOFiles.size() != 0)
@@ -320,6 +313,12 @@ void CGameListCtrl::Update()
 	}
 	else
 	{
+		// Remove existing image list and replace it with the smallest possible one.
+		// The list needs an image list because it reserves screen pixels for the
+		// image even if we aren't going to use one. It uses the dimensions of the
+		// last non-null list so assigning nullptr doesn't work.
+		AssignImageList(new wxImageList(1, 1), wxIMAGE_LIST_SMALL);
+
 		wxString errorString;
 		// We just check for one hide setting to be enabled, as we may only
 		// have GC games for example, and hide them, so we should show the
@@ -339,7 +338,9 @@ void CGameListCtrl::Update()
 	}
 	if (GetSelectedISO() == nullptr)
 		main_frame->UpdateGUI();
-	Show();
+	// Thaw before calling AutomaticColumnWidth so that GetClientSize will
+	// correctly account for the width of scrollbars if they appear.
+	Thaw();
 
 	AutomaticColumnWidth();
 	ScrollLines(scrollPos);
@@ -367,7 +368,7 @@ static wxString NiceSizeFormat(u64 size)
 // Update the column content of the item at _Index
 void CGameListCtrl::UpdateItemAtColumn(long _Index, int column)
 {
-	GameListItem& rISOFile = *m_ISOFiles[_Index];
+	GameListItem& rISOFile = *m_ISOFiles[GetItemData(_Index)];
 
 	switch(column)
 	{
@@ -382,7 +383,7 @@ void CGameListCtrl::UpdateItemAtColumn(long _Index, int column)
 			int ImageIndex = -1;
 
 			if (rISOFile.GetBitmap().IsOk())
-				ImageIndex = m_imageListSmall->Add(rISOFile.GetBitmap());
+				ImageIndex = GetImageList(wxIMAGE_LIST_SMALL)->Add(rISOFile.GetBitmap());
 
 			SetItemColumnImage(_Index, COLUMN_BANNER, ImageIndex);
 			break;
@@ -426,28 +427,32 @@ void CGameListCtrl::UpdateItemAtColumn(long _Index, int column)
 	}
 }
 
-void CGameListCtrl::InsertItemInReportView(long _Index)
+void CGameListCtrl::InsertItemInReportView(long index)
 {
 	// When using wxListCtrl, there is no hope of per-column text colors.
 	// But for reference, here are the old colors that were used: (BGR)
 	// title: 0xFF0000
 	// company: 0x007030
 
-	// Insert a first row with nothing in it, that will be used as the Index
-	long ItemIndex = InsertItem(_Index, wxEmptyString);
+	// Insert a first column with nothing in it, that will be used as the Index
+	long item_index;
+	{
+		wxListItem li;
+		li.SetId(index);
+		li.SetData(index);
+		li.SetMask(wxLIST_MASK_DATA);
+		item_index = InsertItem(li);
+	}
 
 	// Iterate over all columns and fill them with content if they are visible
 	for (int i = 1; i < NUMBER_OF_COLUMN; i++)
 	{
 		if (GetColumnWidth(i) != 0)
-			UpdateItemAtColumn(_Index, i);
+			UpdateItemAtColumn(item_index, i);
 	}
 
 	// Background color
 	SetBackgroundColor();
-
-	// Item data
-	SetItemData(_Index, ItemIndex);
 }
 
 static wxColour blend50(const wxColour& c1, const wxColour& c2)
@@ -651,6 +656,41 @@ void CGameListCtrl::ScanForISOs()
 	}
 
 	std::sort(m_ISOFiles.begin(), m_ISOFiles.end());
+}
+
+void CGameListCtrl::OnLocalIniModified(wxCommandEvent& ev)
+{
+	ev.Skip();
+	std::string game_id = WxStrToStr(ev.GetString());
+	// NOTE: The same game may occur multiple times if there are multiple
+	//   physical copies in the search paths.
+	for (std::size_t i = 0; i < m_ISOFiles.size(); ++i)
+	{
+		if (m_ISOFiles[i]->GetUniqueID() != game_id)
+			continue;
+		m_ISOFiles[i]->ReloadINI();
+
+		// The indexes in m_ISOFiles and the list do not line up.
+		// We need to find the corresponding item in the list (if it exists)
+		long item_id = 0;
+		for (; item_id < GetItemCount(); ++item_id)
+		{
+			if (i == static_cast<std::size_t>(GetItemData(item_id)))
+				break;
+		}
+		// If the item is not currently being displayed then we're done.
+		if (item_id == GetItemCount())
+			continue;
+
+		// Update all the columns
+		for (int j = 1; j < NUMBER_OF_COLUMN; ++j)
+		{
+			// NOTE: Banner is not modified by the INI and updating it will
+			//  duplicate it in memory which is not wanted.
+			if (j != COLUMN_BANNER && GetColumnWidth(j) != 0)
+				UpdateItemAtColumn(item_id, j);
+		}
+	}
 }
 
 void CGameListCtrl::OnColBeginDrag(wxListEvent& event)
@@ -1310,19 +1350,19 @@ void CGameListCtrl::OnChangeDisc(wxCommandEvent& WXUNUSED(event))
 
 void CGameListCtrl::OnSize(wxSizeEvent& event)
 {
+	event.Skip();
 	if (lastpos == event.GetSize())
 		return;
 
 	lastpos = event.GetSize();
 	AutomaticColumnWidth();
-
-	event.Skip();
 }
 
 void CGameListCtrl::AutomaticColumnWidth()
 {
 	wxRect rc(GetClientRect());
 
+	Freeze();
 	if (GetColumnCount() == 1)
 	{
 		SetColumnWidth(0, rc.GetWidth());
@@ -1359,6 +1399,7 @@ void CGameListCtrl::AutomaticColumnWidth()
 			SetColumnWidth(COLUMN_TITLE, resizable);
 		}
 	}
+	Thaw();
 }
 
 void CGameListCtrl::UnselectAll()

--- a/Source/Core/DolphinWX/GameListCtrl.h
+++ b/Source/Core/DolphinWX/GameListCtrl.h
@@ -102,6 +102,7 @@ private:
 	void OnMultiCompressISO(wxCommandEvent& event);
 	void OnMultiDecompressISO(wxCommandEvent& event);
 	void OnChangeDisc(wxCommandEvent& event);
+	void OnLocalIniModified(wxCommandEvent& event);
 
 	void CompressSelection(bool _compress);
 	void AutomaticColumnWidth();

--- a/Source/Core/DolphinWX/Globals.h
+++ b/Source/Core/DolphinWX/Globals.h
@@ -331,10 +331,11 @@ enum
 
 // custom message macro
 #define EVT_HOST_COMMAND(id, fn) \
-	DECLARE_EVENT_TABLE_ENTRY(\
-			wxEVT_HOST_COMMAND, id, wxID_ANY, \
-			(wxObjectEventFunction)(wxEventFunction) wxStaticCastEvent(wxCommandEventFunction, &fn), \
-			(wxObject*) nullptr \
-			),
+	EVT_COMMAND(id, wxEVT_HOST_COMMAND, fn)
 
 wxDECLARE_EVENT(wxEVT_HOST_COMMAND, wxCommandEvent);
+
+// Sent to wxTheApp
+// GetString() == Game's Unique ID
+// GetInt() == Game's Revision
+wxDECLARE_EVENT(DOLPHIN_EVT_LOCAL_INI_CHANGED, wxCommandEvent);

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -124,27 +124,19 @@ GameListItem::GameListItem(const std::string& _rFileName, const std::unordered_m
 
 	if (IsValid())
 	{
-		IniFile ini = SConfig::LoadGameIni(m_UniqueID, m_Revision);
-		ini.GetIfExists("EmuState", "EmulationStateId", &m_emu_state);
-		ini.GetIfExists("EmuState", "EmulationIssues", &m_issues);
-		m_has_custom_name = ini.GetIfExists("EmuState", "Title", &m_custom_name);
+		std::string game_id = m_UniqueID;
 
-		if (!m_has_custom_name)
+		// Ignore publisher ID for WAD files
+		if (m_Platform == DiscIO::IVolume::WII_WAD && game_id.size() > 4)
+			game_id.erase(4);
+
+		auto it = custom_titles.find(game_id);
+		if (it != custom_titles.end())
 		{
-			std::string game_id = m_UniqueID;
-
-			// Ignore publisher ID for WAD files
-			if (m_Platform == DiscIO::IVolume::WII_WAD && game_id.size() > 4)
-				game_id.erase(4);
-
-			auto end = custom_titles.end();
-			auto it = custom_titles.find(game_id);
-			if (it != end)
-			{
-				m_custom_name = it->second;
-				m_has_custom_name = true;
-			}
+			m_custom_name_titles_txt = it->second;
 		}
+
+		ReloadINI();
 	}
 
 	if (!IsValid() && IsElfOrDol())
@@ -181,6 +173,24 @@ GameListItem::GameListItem(const std::string& _rFileName, const std::unordered_m
 
 GameListItem::~GameListItem()
 {
+}
+
+void GameListItem::ReloadINI()
+{
+	if (!IsValid())
+		return;
+
+	IniFile ini = SConfig::LoadGameIni(m_UniqueID, m_Revision);
+	ini.GetIfExists("EmuState", "EmulationStateId", &m_emu_state, 0);
+	ini.GetIfExists("EmuState", "EmulationIssues", &m_issues, std::string());
+
+	m_custom_name.clear();
+	m_has_custom_name = ini.GetIfExists("EmuState", "Title", &m_custom_name);
+	if (!m_has_custom_name && !m_custom_name_titles_txt.empty())
+	{
+		m_custom_name = m_custom_name_titles_txt;
+		m_has_custom_name = true;
+	}
 }
 
 bool GameListItem::LoadFromCache()

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -25,6 +25,9 @@ public:
 	GameListItem(const std::string& _rFileName, const std::unordered_map<std::string, std::string>& custom_titles);
 	~GameListItem();
 
+	// Reload settings after INI changes
+	void ReloadINI();
+
 	bool IsValid() const {return m_Valid;}
 	const std::string& GetFileName() const {return m_FileName;}
 	std::string GetName(DiscIO::IVolume::ELanguage language) const;
@@ -86,7 +89,8 @@ private:
 	int m_ImageWidth, m_ImageHeight;
 	u8 m_disc_number;
 
-	std::string m_custom_name;
+	std::string m_custom_name_titles_txt; // Custom title from titles.txt
+	std::string m_custom_name;            // Custom title from INI or titles.txt
 	bool m_has_custom_name;
 
 	bool LoadFromCache();

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -95,6 +95,7 @@ BEGIN_EVENT_TABLE(CISOProperties, wxDialog)
 	EVT_MENU(IDM_EXTRACTDOL, CISOProperties::OnExtractDataFromHeader)
 	EVT_MENU(IDM_CHECKINTEGRITY, CISOProperties::CheckPartitionIntegrity)
 	EVT_CHOICE(ID_LANG, CISOProperties::OnChangeBannerLang)
+	EVT_CHECKLISTBOX(ID_CHEATS_LIST, CISOProperties::OnActionReplayCodeChecked)
 END_EVENT_TABLE()
 
 CISOProperties::CISOProperties(const GameListItem& game_list_item, wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& position, const wxSize& size, long style)
@@ -1314,6 +1315,11 @@ void CISOProperties::ListSelectionChanged(wxCommandEvent& event)
 	}
 }
 
+void CISOProperties::OnActionReplayCodeChecked(wxCommandEvent& event)
+{
+	arCodes[event.GetSelection()].active = Cheats->IsChecked(event.GetSelection());
+}
+
 void CISOProperties::PatchList_Load()
 {
 	onFrame.clear();
@@ -1399,9 +1405,8 @@ void CISOProperties::PatchButtonClicked(wxCommandEvent& event)
 
 void CISOProperties::ActionReplayList_Load()
 {
-	arCodes.clear();
 	Cheats->Clear();
-	ActionReplay::LoadCodes(arCodes, GameIniDefault, GameIniLocal);
+	arCodes = ActionReplay::LoadCodes(GameIniDefault, GameIniLocal);
 
 	u32 index = 0;
 	for (const ActionReplay::ARCode& arCode : arCodes)
@@ -1422,8 +1427,7 @@ void CISOProperties::ActionReplayList_Save()
 	u32 cheats_chkbox_count = Cheats->GetCount();
 	for (const ActionReplay::ARCode& code : arCodes)
 	{
-		// Check the index against the count because of the hacky way codes are added from the "Cheat Search" dialog
-		if ((index < cheats_chkbox_count) && Cheats->IsChecked(index))
+		if (code.active)
 			enabledLines.push_back("$" + code.name);
 
 		// Do not save default cheats.

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -63,7 +63,6 @@
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 #include "DolphinWX/ARCodeAddEdit.h"
-#include "DolphinWX/GameListCtrl.h"
 #include "DolphinWX/Globals.h"
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/ISOProperties.h"
@@ -77,8 +76,7 @@ BEGIN_EVENT_TABLE(CISOProperties, wxDialog)
 	EVT_BUTTON(ID_EDITCONFIG, CISOProperties::OnEditConfig)
 	EVT_BUTTON(ID_MD5SUMCOMPUTE, CISOProperties::OnComputeMD5Sum)
 	EVT_BUTTON(ID_SHOWDEFAULTCONFIG, CISOProperties::OnShowDefaultConfig)
-	EVT_CHOICE(ID_EMUSTATE, CISOProperties::SetRefresh)
-	EVT_CHOICE(ID_EMU_ISSUES, CISOProperties::SetRefresh)
+	EVT_CHOICE(ID_EMUSTATE, CISOProperties::OnEmustateChanged)
 	EVT_LISTBOX(ID_PATCHES_LIST, CISOProperties::ListSelectionChanged)
 	EVT_BUTTON(ID_EDITPATCH, CISOProperties::PatchButtonClicked)
 	EVT_BUTTON(ID_ADDPATCH, CISOProperties::PatchButtonClicked)
@@ -114,8 +112,6 @@ CISOProperties::CISOProperties(const GameListItem& game_list_item, wxWindow* par
 	GameIniLocal = SConfig::LoadLocalGameIni(game_id, m_open_iso->GetRevision());
 
 	// Setup GUI
-	bRefreshList = false;
-
 	CreateGUIControls();
 
 	LoadGameConfig();
@@ -647,8 +643,6 @@ void CISOProperties::OnClose(wxCloseEvent& WXUNUSED (event))
 {
 	if (!SaveGameConfig())
 		WxUtils::ShowErrorDialog(wxString::Format(_("Could not save %s."), GameIniFileLocal.c_str()));
-	if (bRefreshList)
-		((CGameListCtrl*)GetParent())->Update();
 	Destroy();
 }
 
@@ -991,12 +985,9 @@ void CISOProperties::CheckPartitionIntegrity(wxCommandEvent& event)
 	}
 }
 
-void CISOProperties::SetRefresh(wxCommandEvent& event)
+void CISOProperties::OnEmustateChanged(wxCommandEvent& event)
 {
-	bRefreshList = true;
-
-	if (event.GetId() == ID_EMUSTATE)
-		EmuIssues->Enable(event.GetSelection() != 0);
+	EmuIssues->Enable(event.GetSelection() != 0);
 }
 
 void CISOProperties::SetCheckboxValueFromGameini(const char* section, const char* key, wxCheckBox* checkbox)
@@ -1211,9 +1202,6 @@ void CISOProperties::LaunchExternalEditor(const std::string& filename, bool wait
 		WxUtils::ShowErrorDialog(_("wxExecute returned -1 on application run!"));
 		return;
 	}
-
-	if (wait_until_closed)
-		bRefreshList = true; // Just in case
 #endif
 }
 

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -208,6 +208,7 @@ private:
 	void OnComputeMD5Sum(wxCommandEvent& event);
 	void OnShowDefaultConfig(wxCommandEvent& event);
 	void ListSelectionChanged(wxCommandEvent& event);
+	void OnActionReplayCodeChecked(wxCommandEvent& event);
 	void PatchButtonClicked(wxCommandEvent& event);
 	void ActionReplayButtonClicked(wxCommandEvent& event);
 	void RightClickOnBanner(wxMouseEvent& event);

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -209,7 +209,7 @@ private:
 	void OnExtractDir(wxCommandEvent& event);
 	void OnExtractDataFromHeader(wxCommandEvent& event);
 	void CheckPartitionIntegrity(wxCommandEvent& event);
-	void SetRefresh(wxCommandEvent& event);
+	void OnEmustateChanged(wxCommandEvent& event);
 	void OnChangeBannerLang(wxCommandEvent& event);
 
 	const GameListItem OpenGameListItem;
@@ -232,8 +232,6 @@ private:
 
 	std::set<std::string> DefaultPatches;
 	std::set<std::string> DefaultCheats;
-
-	bool bRefreshList;
 
 	void LoadGameConfig();
 	bool SaveGameConfig();

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -68,15 +68,6 @@ public:
 			long style = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
 	virtual ~CISOProperties();
 
-	bool bRefreshList;
-
-	// These are only public because of the ugly hack in CreateCodeDialog.cpp
-	void ActionReplayList_Load();
-	bool SaveGameConfig();
-
-	// This only exists because of the ugly hack in CreateCodeDialog.cpp
-	void AddARCode(const ActionReplay::ARCode& code);
-
 private:
 	DECLARE_EVENT_TABLE();
 
@@ -242,9 +233,15 @@ private:
 	std::set<std::string> DefaultPatches;
 	std::set<std::string> DefaultCheats;
 
+	bool bRefreshList;
+
 	void LoadGameConfig();
+	bool SaveGameConfig();
+	void OnLocalIniModified(wxCommandEvent& ev);
+	void GenerateLocalIniModified();
 	void PatchList_Load();
 	void PatchList_Save();
+	void ActionReplayList_Load();
 	void ActionReplayList_Save();
 	void ChangeBannerDetails(DiscIO::IVolume::ELanguage language);
 


### PR DESCRIPTION
Steps to reproduce:

1. Enable Cheats and start a game
2. Right-click a different game and click properties, look at the AR Codes tab
3. Open Tools > Cheat Manager. Note that the active codes are those of the second game, not the one that's actually running. [Alternatively, pause Dolphin under a debugger and inspect the "arCodes" and "activeCodes" globals in ActionReplay.cpp]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3776)
<!-- Reviewable:end -->
