### PR TITLE
ChunkFile: Handle bool in a stable way across platforms

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -213,6 +213,20 @@ public:
 		DoVoid((void*)&x, sizeof(x));
 	}
 
+
+	void Do(bool& x)
+	{
+		// bool's size can vary depending on platform, which can
+		// cause breakages. This treats all bools as if they were
+		// 8 bits in size.
+		u8 stable = static_cast<u8>(x);
+
+		Do(stable);
+
+		if (mode == MODE_READ)
+			x = stable != 0;
+	}
+
 	template <typename T>
 	void DoPointer(T*& x, T* const base)
 	{

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 53; // Last changed in PR 3759
+static const u32 STATE_VERSION = 54; // Last changed in PR 3782
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
bool is not always guaranteed to be the same size on every platform. On some platforms it may be one byte, on others it can be 8 bytes if the platform dictates it, it's implementation-defined.

This can be problematic when it comes to storing this data to disk (it can also be space-inefficient, but that's not really an issue in 2016). Also say for some reason you moved your savestates to another platform, it's possible they won't load correctly due to differences in size.

This change stores all bools to savestates as if they were a byte in size and handles the loading of them accordingly.

This was brought up by myself in #3759, and @delroth recommended that this be included within 5.0, so here it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3782)
<!-- Reviewable:end -->
