### PR TITLE
WIP: Fix Mac OS AMD shader issue

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -720,8 +720,8 @@ static void WriteStage(T& out, pixel_shader_uid_data* uid_data, int n, API_TYPE 
 				out.Write("\tint2 indtevtrans%d = int2(idot(" I_INDTEXMTX"[%d].xyz, iindtevcrd%d), idot(" I_INDTEXMTX"[%d].xyz, iindtevcrd%d));\n", n, mtxidx, n, mtxidx+1, n);
 
 				// TODO: should use a shader uid branch for this for better performance
-				out.Write("\tif (" I_INDTEXMTX"[%d].w >= -3) indtevtrans%d = indtevtrans%d >> " I_INDTEXMTX"[%d].w + 3;\n", mtxidx, n, n, mtxidx);
-				out.Write("\telse indtevtrans%d = indtevtrans%d << (-" I_INDTEXMTX"[%d].w - 3);\n", n, n, mtxidx);
+				out.Write("\tif (" I_INDTEXMTX"[%d].w >= -3) indtevtrans%d = indtevtrans%d >> ((" I_INDTEXMTX"[%d].w + 3) & 31);\n", mtxidx, n, n, mtxidx);
+				out.Write("\telse indtevtrans%d = indtevtrans%d << ((-" I_INDTEXMTX"[%d].w - 3) & 31);\n", n, n, mtxidx);
 			}
 			else if (bpmem.tevind[n].mid <= 7 && bHasTexCoord)
 			{ // s matrix
@@ -731,8 +731,8 @@ static void WriteStage(T& out, pixel_shader_uid_data* uid_data, int n, API_TYPE 
 
 				out.Write("\tint2 indtevtrans%d = int2(fixpoint_uv%d * iindtevcrd%d.xx);\n", n, texcoord, n);
 
-				out.Write("\tif (" I_INDTEXMTX"[%d].w >= -8) indtevtrans%d = indtevtrans%d >> " I_INDTEXMTX"[%d].w + 8;\n", mtxidx, n, n, mtxidx);
-				out.Write("\telse indtevtrans%d = indtevtrans%d << (-" I_INDTEXMTX"[%d].w - 8);\n", n, n, mtxidx);
+				out.Write("\tif (" I_INDTEXMTX"[%d].w >= -8) indtevtrans%d = indtevtrans%d >> ((" I_INDTEXMTX"[%d].w + 8) & 31);\n", mtxidx, n, n, mtxidx);
+				out.Write("\telse indtevtrans%d = indtevtrans%d << ((-" I_INDTEXMTX"[%d].w - 8) & 31);\n", n, n, mtxidx);
 			}
 			else if (bpmem.tevind[n].mid <= 11 && bHasTexCoord)
 			{ // t matrix
@@ -742,8 +742,8 @@ static void WriteStage(T& out, pixel_shader_uid_data* uid_data, int n, API_TYPE 
 
 				out.Write("\tint2 indtevtrans%d = int2(fixpoint_uv%d * iindtevcrd%d.yy);\n", n, texcoord, n);
 
-				out.Write("\tif (" I_INDTEXMTX"[%d].w >= -8) indtevtrans%d = indtevtrans%d >> " I_INDTEXMTX"[%d].w + 8;\n", mtxidx, n, n, mtxidx);
-				out.Write("\telse indtevtrans%d = indtevtrans%d << (-" I_INDTEXMTX"[%d].w - 8);\n", n, n, mtxidx);
+				out.Write("\tif (" I_INDTEXMTX"[%d].w >= -8) indtevtrans%d = indtevtrans%d >> ((" I_INDTEXMTX"[%d].w + 8) & 31);\n", mtxidx, n, n, mtxidx);
+				out.Write("\telse indtevtrans%d = indtevtrans%d << ((-" I_INDTEXMTX"[%d].w - 8) & 31);\n", n, n, mtxidx);
 			}
 			else
 			{


### PR DESCRIPTION
Trying to fix issue: https://bugs.dolphin-emu.org/issues/9468

According to phire, applying modulo 32 on the bitwise shifts is the correct behavior. This pr is just a test, to see if that is where the Mac OS drivers mess up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3784)
<!-- Reviewable:end -->
