### PR TITLE
CFrame: Fix Confirm Close

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -576,8 +576,6 @@ void CFrame::OnActive(wxActivateEvent& event)
 
 void CFrame::OnClose(wxCloseEvent& event)
 {
-	m_bClosing = true;
-
 	// Before closing the window we need to shut down the emulation core.
 	// We'll try to close this window again once that is done.
 	if (Core::GetState() != Core::CORE_UNINITIALIZED)
@@ -587,6 +585,9 @@ void CFrame::OnClose(wxCloseEvent& event)
 		{
 			event.Veto();
 		}
+		// Tell OnStopped to resubmit the Close event
+		if (m_confirmStop)
+			m_bClosing = true;
 		return;
 	}
 


### PR DESCRIPTION
Steps to reproduce:

1. Enable Confirm On Stop, start a game
2. Try to close the game list window
3. Click "no" on the confirmation
4. Click "stop", click "yes"
5. Dolphin spontaneously closes on its own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3788)
<!-- Reviewable:end -->
