### PR TITLE
Use proper D3D_FEATURE_LEVEL for d3d12

### DIFF
--- a/Source/Core/VideoBackends/D3D12/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.cpp
@@ -81,7 +81,7 @@ static bool s_frame_in_progress = false;
 
 static std::vector<DXGI_SAMPLE_DESC> s_aa_modes; // supported AA modes of the current adapter
 static const D3D_FEATURE_LEVEL s_supported_feature_levels[] = {
-	D3D_FEATURE_LEVEL_11_0
+	D3D_FEATURE_LEVEL_12_0
 };
 
 HRESULT LoadDXGI()
@@ -264,7 +264,7 @@ bool AlertUserIfSelectedAdapterDoesNotSupportD3D12()
 
 	if (SUCCEEDED(hr))
 	{
-		hr = d3d12_create_device(adapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device));
+		hr = d3d12_create_device(adapter, D3D_FEATURE_LEVEL_12_0, IID_PPV_ARGS(&device));
 
 		SAFE_RELEASE(device);
 		SAFE_RELEASE(adapter);
@@ -302,7 +302,7 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter)
 		return aa_modes;
 
 	ID3D12Device* device12 = nullptr;
-	d3d12_create_device(adapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device12));
+	d3d12_create_device(adapter, D3D_FEATURE_LEVEL_12_0, IID_PPV_ARGS(&device12));
 
 	if (device12)
 	{
@@ -332,7 +332,7 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(IDXGIAdapter* adapter)
 
 D3D_FEATURE_LEVEL GetFeatureLevel(IDXGIAdapter* adapter)
 {
-	return D3D_FEATURE_LEVEL_11_0;
+	return D3D_FEATURE_LEVEL_12_0;
 }
 
 HRESULT Create(HWND wnd)
@@ -424,8 +424,8 @@ HRESULT Create(HWND wnd)
 
 	if (SUCCEEDED(hr))
 	{
-		hr = d3d12_create_device(adapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device12));
-		s_feat_level = D3D_FEATURE_LEVEL_11_0;
+		hr = d3d12_create_device(adapter, D3D_FEATURE_LEVEL_12_0, IID_PPV_ARGS(&device12));
+		s_feat_level = D3D_FEATURE_LEVEL_12_0;
 	}
 
 	if (SUCCEEDED(hr))


### PR DESCRIPTION
The current D3D_FEATURE_LEVEL is D3D_FEATURE_LEVEL_11_0, which is less than is actually required for D3D12. Previously, if a GPU supported D3D11, but not 12, Dolphin would accept the adapter and crash, either when loading the Graphics config window, or when beginning emulation. Now, it will properly display the intended error message without crashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3789)
<!-- Reviewable:end -->
