### PR TITLE
XInput: Apply Rumble/Motor output only on changes (again)

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
@@ -124,8 +124,6 @@ void DeInit()
 Device::Device(const XINPUT_CAPABILITIES& caps, u8 index)
 	: m_subtype(caps.SubType), m_index(index)
 {
-	ZeroMemory(&m_state_out, sizeof(m_state_out));
-
 	// XInputGetCaps seems to always claim all capabilities are supported
 	// but I will leave all this stuff in, incase m$ fixes xinput up a bit
 
@@ -213,7 +211,13 @@ void Device::UpdateInput()
 
 void Device::UpdateMotors()
 {
-	PXInputSetState(m_index, &m_state_out);
+	// this if statement is to make rumble work better when multiple ControllerInterfaces are using the device
+	// only calls XInputSetState if the state changed
+	if (memcmp(&m_state_out, &m_current_state_out, sizeof(m_state_out)))
+	{
+		m_current_state_out = m_state_out;
+		PXInputSetState(m_index, &m_state_out);
+	}
 }
 
 // GET name/source/id

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
@@ -90,7 +90,8 @@ public:
 
 private:
 	XINPUT_STATE m_state_in;
-	XINPUT_VIBRATION m_state_out;
+	XINPUT_VIBRATION m_state_out{};
+	XINPUT_VIBRATION m_current_state_out{};
 	const BYTE m_subtype;
 	const u8 m_index;
 };


### PR DESCRIPTION
Disclaimer: I can't test if this works on xbox one controllers, i don't have one. But i have confirmed that this UpdateMotors() is related to rumble for emulated wiimotes.

This partially reverts commit "XInput: Apply immediately as well" (1958a10b6f5ba8348268b077f6410dadb2a20c8f) from pr # https://github.com/dolphin-emu/dolphin/pull/1560

Hopefully this fixes the xbox one controller rumble issue:
https://bugs.dolphin-emu.org/issues/9071

And in theory it might reduce the used usb bandwidth, as it was originally intended before pr 1560.

@JMC47: Please do a good amount of testing, to see if this breaks rumble for wiimotes or gamecube controllers emulated with xinput devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3790)
<!-- Reviewable:end -->
