### PR TITLE
Fix netplay rumble

### DIFF
--- a/Source/Core/Core/HW/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI_DeviceGCAdapter.h
@@ -14,5 +14,4 @@ public:
 	CSIDevice_GCAdapter(SIDevices device, int _iDeviceNumber);
 
 	GCPadStatus GetPadStatus() override;
-	void SendCommand(u32 _Cmd, u8 _Poll) override;
 };

--- a/Source/Core/Core/HW/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCController.cpp
@@ -290,9 +290,9 @@ void CSIDevice_GCController::SendCommand(u32 _Cmd, u8 _Poll)
 			if (numPAD < 4)
 			{
 				if (uType == 1 && uStrength > 2)
-					Pad::Rumble(numPAD, 1.0);
+					CSIDevice_GCController::Rumble(numPAD, 1.0);
 				else
-					Pad::Rumble(numPAD, 0.0);
+					CSIDevice_GCController::Rumble(numPAD, 0.0);
 			}
 
 			if (!_Poll)

--- a/Source/Core/Core/HW/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI_DeviceGCController.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Core/HW/GCPad.h"
 #include "Core/HW/SI_Device.h"
 #include "InputCommon/GCPadStatus.h"
 
@@ -106,6 +107,9 @@ public:
 	// Send and Receive pad input from network
 	static bool NetPlay_GetInput(u8 numPAD, GCPadStatus* status);
 	static u8 NetPlay_InGamePadToLocalPad(u8 numPAD);
+
+	// Direct rumble to the right GC Controller
+	static void Rumble(u8 numPad, ControlState strength);
 
 protected:
 	void Calibrate();


### PR DESCRIPTION
Rumble basically wouldn’t work for players who weren’t player 1 and used another input device than the default GC Controller (i.e. used a Wii U adapter).

We now call the appropriate rumble function for each SI Device, should fix issue #9331.
Ideally we wouldn’t have to do this, but since the way things are wired, fixing the root cause it out of the picture for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3792)
<!-- Reviewable:end -->
