### PR TITLE
Fix handling of Wii NAND's /tmp directory during savestate loads.

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -530,6 +530,8 @@ FSTEntry ScanDirectoryTree(const std::string& directory, bool recursive)
 bool DeleteDirRecursively(const std::string& directory)
 {
 	INFO_LOG(COMMON, "DeleteDirRecursively: %s", directory.c_str());
+	bool success = true;
+
 #ifdef _WIN32
 	// Find the first file in the directory.
 	WIN32_FIND_DATA ffd;
@@ -568,22 +570,16 @@ bool DeleteDirRecursively(const std::string& directory)
 		{
 			if (!DeleteDirRecursively(newPath))
 			{
-				#ifndef _WIN32
-				closedir(dirp);
-				#endif
-
-				return false;
+				success = false;
+				break;
 			}
 		}
 		else
 		{
 			if (!File::Delete(newPath))
 			{
-				#ifndef _WIN32
-				closedir(dirp);
-				#endif
-
-				return false;
+				success = false;
+				break;
 			}
 		}
 
@@ -594,9 +590,10 @@ bool DeleteDirRecursively(const std::string& directory)
 	}
 	closedir(dirp);
 #endif
-	File::DeleteDir(directory);
+	if (success)
+		File::DeleteDir(directory);
 
-	return true;
+	return success;
 }
 
 // Create directory and copy contents (does not overwrite existing files)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -270,6 +270,13 @@ void DoState(PointerWrap &p)
 	p.Do(reply_queue);
 	p.Do(last_reply_time);
 
+	if (p.GetMode() == PointerWrap::MODE_READ)
+	{
+		// We need to make sure all file handles are closed so WII_IPC_Devices_fs::DoState can successfully re-create /tmp
+		for (u32 i = 0; i < IPC_MAX_FDS; i++)
+			g_FdMap[i].reset();
+	}
+
 	for (const auto& entry : g_DeviceMap)
 	{
 		if (entry.second->IsHardware())
@@ -280,7 +287,7 @@ void DoState(PointerWrap &p)
 
 	if (p.GetMode() == PointerWrap::MODE_READ)
 	{
-		for (u32 i=0; i<IPC_MAX_FDS; i++)
+		for (u32 i=0; i < IPC_MAX_FDS; i++)
 		{
 			u32 exists = 0;
 			p.Do(exists);
@@ -300,13 +307,9 @@ void DoState(PointerWrap &p)
 					g_FdMap[i]->DoState(p);
 				}
 			}
-			else
-			{
-				g_FdMap[i].reset();
-			}
 		}
 
-		for (u32 i=0; i<ES_MAX_COUNT; i++)
+		for (u32 i=0; i < ES_MAX_COUNT; i++)
 		{
 			p.Do(es_inuse[i]);
 			u32 handleID = es_handles[i]->GetDeviceID();
@@ -337,7 +340,7 @@ void DoState(PointerWrap &p)
 			}
 		}
 
-		for (u32 i=0; i<ES_MAX_COUNT; i++)
+		for (u32 i=0; i < ES_MAX_COUNT; i++)
 		{
 			p.Do(es_inuse[i]);
 			u32 handleID = es_handles[i]->GetDeviceID();


### PR DESCRIPTION
Fixes [issue 9496](https://bugs.dolphin-emu.org/issues/9496) and potentially other issues with savestates and wii games.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3798)
<!-- Reviewable:end -->
