### PR TITLE
Make exceptions consistent across all JITs/Interpreters (Fixes Pokemon Box)

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -453,6 +453,11 @@ void Advance()
 			g_slicelength = maxslicelength;
 		PowerPC::ppcState.downcount = CyclesToDowncount(g_slicelength);
 	}
+
+	// Check for any external exceptions.
+	// It's important to do this after processing events otherwise any exceptions will be delayed until the next slice:
+	//        Pokemon Box refuses to boot if the first exception from the audio DMA is received late
+	PowerPC::CheckExternalExceptions();
 }
 
 void LogPendingEvents()

--- a/Source/Core/Core/PowerPC/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter.cpp
@@ -76,7 +76,6 @@ void CachedInterpreter::SingleStep()
 static void EndBlock(UGeckoInstruction data)
 {
 	PC = NPC;
-	PowerPC::CheckExceptions();
 	PowerPC::ppcState.downcount -= data.hex;
 	if (PowerPC::ppcState.downcount <= 0)
 	{

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -278,12 +278,6 @@ void Interpreter::Run()
 		}
 
 		CoreTiming::Advance();
-
-		if (PowerPC::ppcState.Exceptions)
-		{
-			PowerPC::CheckExceptions();
-			PC = NPC;
-		}
 	}
 
 	// Let the waiting thread know we are done leaving

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -73,21 +73,18 @@ void JitArm64AsmRoutineManager::Generate()
 
 	SetJumpTarget(bail);
 	doTiming = GetCodePtr();
+		// Write the current PC out to PPCSTATE
+		STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
+		STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(npc));
+
 		MOVI2R(X30, (u64)&CoreTiming::Advance);
 		BLR(X30);
 
-		// Does exception checking
-		LDR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF(Exceptions));
-		FixupBranch no_exceptions = CBZ(W0);
-			STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
-			STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(npc));
-			MOVI2R(X30, (u64)&PowerPC::CheckExceptions);
-			BLR(X30);
-			LDR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(npc));
-		SetJumpTarget(no_exceptions);
+		// Load the PC back into DISPATCHER_PC (the exception handler might have changed it)
+		LDR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
 
 		// Check the state pointer to see if we are exiting
-		// Gets checked on every exception check
+		// Gets checked on at the end of every slice
 		MOVI2R(X0, (u64)PowerPC::GetStatePtr());
 		LDR(INDEX_UNSIGNED, W0, X0, 0);
 


### PR DESCRIPTION
They all handled it differently, so I've just moved it into Advance()

This fixes Pokemon Box booting in JIT/JITIL which shared a bug where
exceptions set in a scheduled event would be ignored until the next
slice (upto 20,000 cycles).

This fixes Pokemon Box not booting on JIT/JITIL ([Issue 9480](https://bugs.dolphin-emu.org/issues/9480)) which is a 5.0 blocker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3800)
<!-- Reviewable:end -->
