### PR TITLE
Install the GC Adapter udev rule on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,6 +966,9 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 		DESTINATION ${mandir}/man6)
 	install(FILES Data/dolphin-emu-nogui.6
 		DESTINATION ${mandir}/man6)
+	# Install the GameCube Controller Adapter and DolphinBar udev rules
+	install(FILES Data/51-usb-device.rules
+		DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d)
 endif()
 
 # packaging information


### PR DESCRIPTION
This makes it readable by the user, and thus usable without manual system modification.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3803)

<!-- Reviewable:end -->
