### PR TITLE
Mark Dual Core Hack as Deprecated (Post 5.0 release)

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -485,7 +485,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("Fastmem",           &bFastmem,      true);
 	core->Get("DSPHLE",            &bDSPHLE,       true);
 	core->Get("TimingVariance",    &iTimingVariance, 40);
-	core->Get("CPUThread",         &bCPUThread,    true);
+	core->Get("CPUThread",         &bCPUThread,    false);
 	core->Get("SkipIdle",          &bSkipIdle,     true);
 	core->Get("SyncOnSkipIdle",    &bSyncGPUOnSkipIdleHack, true);
 	core->Get("DefaultISO",        &m_strDefaultISO);

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -51,14 +51,14 @@ void GeneralConfigPane::InitializeGUI()
 	for (const CPUCore& cpu_core : cpu_cores)
 		m_cpu_engine_array_string.Add(cpu_core.name);
 
-	m_dual_core_checkbox   = new wxCheckBox(this, wxID_ANY, _("Enable Dual Core (speedup)"));
+	m_dual_core_checkbox   = new wxCheckBox(this, wxID_ANY, _("Enable Dual Core Hack (deprecated)"));
 	m_idle_skip_checkbox   = new wxCheckBox(this, wxID_ANY, _("Enable Idle Skipping (speedup)"));
 	m_cheats_checkbox      = new wxCheckBox(this, wxID_ANY, _("Enable Cheats"));
 	m_force_ntscj_checkbox = new wxCheckBox(this, wxID_ANY, _("Force Console as NTSC-J"));
 	m_throttler_choice     = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_throttler_array_string);
 	m_cpu_engine_radiobox  = new wxRadioBox(this, wxID_ANY, _("CPU Emulator Engine"), wxDefaultPosition, wxDefaultSize, m_cpu_engine_array_string, 0, wxRA_SPECIFY_ROWS);
 
-	m_dual_core_checkbox->SetToolTip(_("Splits the CPU and GPU threads so they can be run on separate cores.\nProvides major speed improvements on most modern PCs, but can cause occasional crashes/glitches."));
+	m_dual_core_checkbox->SetToolTip(_("Splits the CPU and GPU threads so they can be run on separate cores.\nProvides speed improvements on most modern PCs at the cost of random crashes/glitches.\nIt is recommended you avoid this feature."));
 	m_idle_skip_checkbox->SetToolTip(_("Attempt to detect and skip wait-loops.\nIf unsure, leave this checked."));
 	m_cheats_checkbox->SetToolTip(_("Enables the use of Action Replay and Gecko cheats."));
 	m_force_ntscj_checkbox->SetToolTip(_("Forces NTSC-J mode for using the Japanese ROM font.\nIf left unchecked, Dolphin defaults to NTSC-U and automatically enables this setting when playing Japanese games."));


### PR DESCRIPTION
And disable it by default for fresh dolphin installs. Users who already have
dual core mode enabled in their settings will keep it enabled, for now.
### Why Dual Core mode is bad?

Dual core mode does provide a nice speedup, but it lets the timings of
the host's GPU/API/Driver leak into the emulation, which can cause all
sorts of glitches and crashes.

FX-Zero is notably sensitive, crashing and restarting multiple times
during the intro sequence whenever a shader-stutter causes a frame to
take too long, but almost every game can have crashes when they encounter
weird timings.

It's not just crashes, dual core mode has be tracked as the cause of
various glitches like objects flicking, text disappearing, objects looking
glitched, the and sun shining though solid objects in bunches of games.

None of these glitches/crashes can be fixed, yet users encounter them
and assume something is wrong with Dolphin.

And dual core mode isn't always faster. There are occasional reports on IRC
of laptop users getting speedups when switching to single core mode. 
### Plans for the future

One of the goals for 6.0 is going to "removing dual core mode". This is the first step.

There are also plans to improve "Single Core Mode" to make it multithreaded in a
better way than "Dual Core Mode". it might even be possible to get dolphin's gpu code
to take advantage of more than one extra core cores (loading textures, compiling shaders
and loading vertices can easily be split onto separate threads).

There are also plans to add accurate GPU timing to Single Core Mode (instead of the
"infinitely fast GPU" we currently have) which will fix those games which are broken in
single core mode at the moment.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3804)

<!-- Reviewable:end -->
