### PR TITLE
GCAdapter: improve thread safety

### DIFF
--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -23,6 +23,8 @@ namespace GCAdapter
 static bool CheckDeviceAccess(libusb_device* device);
 static void AddGCAdapter(libusb_device* device);
 static void ResetRumbleLockNeeded();
+static void Reset();
+static void Setup();
 
 static bool s_detected = false;
 static libusb_device_handle* s_handle = nullptr;
@@ -183,7 +185,7 @@ void StopScanThread()
 	}
 }
 
-void Setup()
+static void Setup()
 {
 	libusb_device** list;
 	ssize_t cnt = libusb_get_device_list(s_libusb_context, &list);
@@ -333,7 +335,7 @@ void Shutdown()
 	s_libusb_driver_not_supported = false;
 }
 
-void Reset()
+static void Reset()
 {
 	std::unique_lock<std::mutex> lock(s_init_mutex, std::defer_lock);
 	if (!lock.try_lock())

--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -19,9 +19,7 @@ enum ControllerTypes
 	CONTROLLER_WIRELESS = 2
 };
 void Init();
-void Reset();
 void ResetRumble();
-void Setup();
 void Shutdown();
 void SetAdapterCallback(std::function<void(void)> func);
 void StartScanThread();

--- a/Source/Core/InputCommon/GCAdapter_Android.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Android.cpp
@@ -24,6 +24,9 @@ extern JavaVM* g_java_vm;
 
 namespace GCAdapter
 {
+static void Setup();
+static void Reset();
+
 // Java classes
 static jclass s_adapter_class;
 
@@ -207,7 +210,7 @@ void Init()
 		StartScanThread();
 }
 
-void Setup()
+static void Setup()
 {
 	s_fd = 0;
 	s_detected = true;
@@ -220,7 +223,7 @@ void Setup()
 	s_read_adapter_thread = std::thread(Read);
 }
 
-void Reset()
+static void Reset()
 {
 	if (!s_detected)
 		return;

--- a/Source/Core/InputCommon/GCAdapter_Null.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Null.cpp
@@ -9,9 +9,7 @@ namespace GCAdapter
 {
 
 void Init() {}
-void Reset() {}
 void ResetRumble() {}
-void Setup() {}
 void Shutdown() {}
 void SetAdapterCallback(std::function<void(void)> func) {}
 void StartScanThread() {}


### PR DESCRIPTION
make sure Reset() can’t be run concurrently with AddGCAdapter(), which can cause crashes (issue #9462).

As the crash happens only on windows, I can’t test this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3805)
<!-- Reviewable:end -->
