### PR TITLE
[WIP] VideoCommon: Add epsilon to work around Nvidia rounding issue in texture lookup

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -984,7 +984,7 @@ static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, i
         out.Write("\ttevcoord.xy = int2(0, 0);\n");
     }
     out.Write("\ttextemp = ");
-    SampleTexture(out, "float2(tevcoord.xy)", texswap, stage.tevorders_texmap, uid_data->stereo,
+    SampleTexture(out, "(float2(tevcoord.xy) + 0.25)", texswap, stage.tevorders_texmap, uid_data->stereo,
                   ApiType);
   }
   else


### PR DESCRIPTION
Fixes [ea-vp6](https://bugs.dolphin-emu.org/issues/7193) on Nvidia (at least on OS X). Also a terrible hack. ~~Probably breaks a lot of stuff.~~ I'm mostly posting this to see how much fifoci complains, and also to try and spur conversation about how to actually fix it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3807)

<!-- Reviewable:end -->
