### PR TITLE
D3D11: Fix CPU EFB color reads when MSAA is enabled

### DIFF
--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -63,6 +63,7 @@ public:
 	~FramebufferManager();
 
 	static D3DTexture2D* &GetEFBColorTexture();
+	static D3DTexture2D* &GetEFBColorReadTexture();
 	static ID3D11Texture2D* &GetEFBColorStagingBuffer();
 
 	static D3DTexture2D* &GetEFBDepthTexture();
@@ -90,6 +91,7 @@ private:
 	{
 		D3DTexture2D* color_tex;
 		ID3D11Texture2D* color_staging_buf;
+		D3DTexture2D* color_read_texture;
 
 		D3DTexture2D* depth_tex;
 		ID3D11Texture2D* depth_staging_buf;


### PR DESCRIPTION
So it turns out CPU EFB reads are completely broken on D3D11 when MSAA is enabled (noticed the comment at the start of the method after I found out...).

This causes the strange movement discussed in https://bugs.dolphin-emu.org/issues/9503

Also swaps the byte order from RGBA->BGRA to match GL/D3D12, and what the read handler is expecting. This should fix the colours in some game that I forget the name of.

Depth reads will now return the minimum depth of all samples, instead of the average of all samples. This matches the behavior used by EFB2RAM.

IMO, #3652 is the proper solution to this issue, however this is a fix that doesn't introduce new "features".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3808)
<!-- Reviewable:end -->
