### PR TITLE
[UI] Make NetPlay UI bigger and neater

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -51,45 +51,56 @@ NetPlaySetupFrame::NetPlaySetupFrame(wxWindow* const parent, const CGameListCtrl
 
 	// top row
 	wxBoxSizer* const trav_szr = new wxBoxSizer(wxHORIZONTAL);
-
-	m_direct_traversal = new wxChoice(panel, wxID_ANY, wxDefaultPosition, wxSize(75, -1));
-	m_direct_traversal->Bind(wxEVT_CHOICE, &NetPlaySetupFrame::OnChoice, this);
-	m_direct_traversal->Append(_("Direct"));
-	m_direct_traversal->Append(_("Traversal"));
-
-	std::string travChoice;
-	netplay_section.Get("TraversalChoice", &travChoice, "direct");
-
-	if (travChoice == "traversal")
-	{
-		m_direct_traversal->Select(1);
-	}
-	else
-	{
-		m_direct_traversal->Select(0);
-	}
-
-	trav_szr->Add(m_direct_traversal, 0, wxRIGHT);
-
-	m_trav_reset_btn = new wxButton(panel, wxID_ANY, _("Reset Traversal Settings"));
-	m_trav_reset_btn->Bind(wxEVT_BUTTON, &NetPlaySetupFrame::OnResetTraversal, this);
-	trav_szr->Add(m_trav_reset_btn, 0, wxCENTER | wxRIGHT);
-
 	wxBoxSizer* const nick_szr = new wxBoxSizer(wxHORIZONTAL);
-	wxStaticText* const nick_lbl = new wxStaticText(panel, wxID_ANY, _("Nickname :"));
-	std::string nickname;
-	netplay_section.Get("Nickname", &nickname, "Player");
-	m_nickname_text = new wxTextCtrl(panel, wxID_ANY, StrToWxStr(nickname));
-	nick_szr->Add(nick_lbl, 0, wxCENTER);
-	nick_szr->Add(m_nickname_text, 0, wxALL, 5);
+	{
+		// Connection Config
+		wxStaticText* const connectiontype_lbl = new wxStaticText(panel, wxID_ANY, _("Connection Type:"), wxDefaultPosition, wxSize(100, -1));
 
-	std::string centralPort;
-	GetTraversalPort(netplay_section, &centralPort);
-	std::string centralServer;
-	GetTraversalServer(netplay_section, &centralServer);
+		m_direct_traversal = new wxChoice(panel, wxID_ANY,  wxDefaultPosition, wxSize(150, -1));
+		m_direct_traversal->Bind(wxEVT_CHOICE, &NetPlaySetupFrame::OnChoice, this);
+		m_direct_traversal->Append(_("Direct Connection"));
+		m_direct_traversal->Append(_("Traversal Server"));
 
-	m_traversal_lbl = new wxStaticText(panel, wxID_ANY, _("Traversal: ") + centralServer + ":" + centralPort);
+		trav_szr->Add(connectiontype_lbl, 0, wxCENTER, 5);
+		trav_szr->AddSpacer(5);
+		trav_szr->Add(m_direct_traversal, 0, wxCENTER, 5);
 
+		m_trav_reset_btn = new wxButton(panel, wxID_ANY, _("Reset Traversal Settings"), wxDefaultPosition, wxSize(-1, 25));
+		m_trav_reset_btn->Bind(wxEVT_BUTTON, &NetPlaySetupFrame::OnResetTraversal, this);
+
+		trav_szr->AddSpacer(5);
+
+		trav_szr->Add(m_trav_reset_btn, 0, wxRIGHT);
+
+		// Nickname
+		wxStaticText* const nick_lbl = new wxStaticText(panel, wxID_ANY, _("Nickname:"), wxDefaultPosition, wxSize(100, -1));
+
+		std::string nickname;
+		netplay_section.Get("Nickname", &nickname, "Player");
+
+		m_nickname_text = new wxTextCtrl(panel, wxID_ANY, StrToWxStr(nickname), wxDefaultPosition, wxSize(150, -1));
+
+		nick_szr->Add(nick_lbl, 0, wxCENTER);
+		nick_szr->Add(m_nickname_text, 0, wxALL, 5);
+
+		std::string travChoice;
+		netplay_section.Get("TraversalChoice", &travChoice, "direct");
+		if (travChoice == "traversal")
+		{
+			m_direct_traversal->Select(1);
+		}
+		else
+		{
+			m_direct_traversal->Select(0);
+		}
+
+		std::string centralPort;
+		GetTraversalPort(netplay_section, &centralPort);
+		std::string centralServer;
+		GetTraversalServer(netplay_section, &centralServer);
+
+		m_traversal_lbl = new wxStaticText(panel, wxID_ANY, _("Traversal Server:") + " " + centralServer + ":" + centralPort);
+	}
 	// tabs
 	wxNotebook* const notebook = new wxNotebook(panel, wxID_ANY);
 	wxPanel* const connect_tab = new wxPanel(notebook, wxID_ANY);
@@ -198,7 +209,7 @@ NetPlaySetupFrame::NetPlaySetupFrame(wxWindow* const parent, const CGameListCtrl
 
 	// main sizer
 	wxBoxSizer* const main_szr = new wxBoxSizer(wxVERTICAL);
-	main_szr->Add(trav_szr, 0, wxALL | wxALIGN_LEFT);
+	main_szr->Add(trav_szr, 0, wxALL | wxALIGN_LEFT, 5);
 	main_szr->Add(nick_szr, 0, wxALL | wxALIGN_LEFT, 5);
 	main_szr->Add(m_traversal_lbl, 0, wxALL | wxALIGN_LEFT, 5);
 	main_szr->Add(notebook, 1, wxLEFT | wxRIGHT | wxEXPAND, 5);

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -123,11 +123,11 @@ NetPlayDialog::NetPlayDialog(wxWindow* const parent, const CGameListCtrl* const 
 		, wxDefaultPosition, wxDefaultSize, wxTE_READONLY | wxTE_MULTILINE);
 
 	m_chat_msg_text = new wxTextCtrl(panel, wxID_ANY, wxEmptyString
-		, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+		, wxDefaultPosition, wxSize(-1, 25), wxTE_PROCESS_ENTER);
 	m_chat_msg_text->Bind(wxEVT_TEXT_ENTER, &NetPlayDialog::OnChat, this);
 	m_chat_msg_text->SetMaxLength(2000);
 
-	wxButton* const chat_msg_btn = new wxButton(panel, wxID_ANY, _("Send"));
+	wxButton* const chat_msg_btn = new wxButton(panel, wxID_ANY, _("Send"), wxDefaultPosition, wxSize(-1, 26));
 	chat_msg_btn->Bind(wxEVT_BUTTON, &NetPlayDialog::OnChat, this);
 
 	wxBoxSizer* const chat_msg_szr = new wxBoxSizer(wxHORIZONTAL);
@@ -146,9 +146,9 @@ NetPlayDialog::NetPlayDialog(wxWindow* const parent, const CGameListCtrl* const 
 	if (m_is_hosting && g_TraversalClient)
 	{
 		wxBoxSizer* const host_szr = new wxBoxSizer(wxHORIZONTAL);
-		m_host_type_choice = new wxChoice(panel, wxID_ANY, wxDefaultPosition, wxSize(60, -1));
+		m_host_type_choice = new wxChoice(panel, wxID_ANY, wxDefaultPosition, wxSize(76, -1));
 		m_host_type_choice->Bind(wxEVT_CHOICE, &NetPlayDialog::OnChoice, this);
-		m_host_type_choice->Append(_("ID:"));
+		m_host_type_choice->Append(_("Room ID:"));
 		host_szr->Add(m_host_type_choice);
 
 		m_host_label = new wxStaticText(panel, wxID_ANY, "555.555.555.555:55555", wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE | wxALIGN_LEFT);
@@ -186,7 +186,7 @@ NetPlayDialog::NetPlayDialog(wxWindow* const parent, const CGameListCtrl* const 
 	mid_szr->Add(player_szr, 0, wxEXPAND);
 
 	// bottom crap
-	wxButton* const quit_btn = new wxButton(panel, wxID_ANY, _("Quit"));
+	wxButton* const quit_btn = new wxButton(panel, wxID_ANY, _("Quit Netplay"));
 	quit_btn->Bind(wxEVT_BUTTON, &NetPlayDialog::OnQuit, this);
 
 	wxBoxSizer* const bottom_szr = new wxBoxSizer(wxHORIZONTAL);
@@ -200,13 +200,15 @@ NetPlayDialog::NetPlayDialog(wxWindow* const parent, const CGameListCtrl* const 
 		wxSpinCtrl* const padbuf_spin = new wxSpinCtrl(panel, wxID_ANY, std::to_string(INITIAL_PAD_BUFFER_SIZE)
 			, wxDefaultPosition, wxSize(64, -1), wxSP_ARROW_KEYS, 0, 200, INITIAL_PAD_BUFFER_SIZE);
 		padbuf_spin->Bind(wxEVT_SPINCTRL, &NetPlayDialog::OnAdjustBuffer, this);
+		bottom_szr->AddSpacer(3);
 		bottom_szr->Add(padbuf_spin, 0, wxCENTER);
-
-		m_memcard_write = new wxCheckBox(panel, wxID_ANY, _("Write memcards/SD"));
+		bottom_szr->AddSpacer(5);
+		m_memcard_write = new wxCheckBox(panel, wxID_ANY, _("Write to memcards/SD"));
 		bottom_szr->Add(m_memcard_write, 0, wxCENTER);
 	}
 
-	m_record_chkbox = new wxCheckBox(panel, wxID_ANY, _("Record input"));
+	bottom_szr->AddSpacer(5);
+	m_record_chkbox = new wxCheckBox(panel, wxID_ANY, _("Record inputs"));
 	bottom_szr->Add(m_record_chkbox, 0, wxCENTER);
 
 	bottom_szr->AddStretchSpacer(1);
@@ -221,7 +223,7 @@ NetPlayDialog::NetPlayDialog(wxWindow* const parent, const CGameListCtrl* const 
 	panel->SetSizerAndFit(main_szr);
 
 	main_szr->SetSizeHints(this);
-	SetSize(512, 512 - 128);
+	SetSize(768, 768 - 128);
 
 	Center();
 }
@@ -512,7 +514,6 @@ void NetPlayDialog::OnChoice(wxCommandEvent& event)
 {
 	UpdateHostLabel();
 }
-
 
 void NetPlayDialog::UpdateHostLabel()
 {


### PR DESCRIPTION
This PR does 5 things:
* It increases the default small size of the NetPlay window to a larger
and more appealing size.
* It cleans up and reorganizes a bit of the NetPlay Setup UI code.
* It moves the Direct or Transversal Selector to be more appealing and
nice looking.
* The Direct or Transversal also gets a label and nicer text, and a
spacer.
* The language and text of the Netplay Window have been improved.

Images:

Before:
![ss 2016-05-01 at 10 19 56](https://cloud.githubusercontent.com/assets/866151/14947607/ecc634e0-0fea-11e6-95c1-e028aa34ce9d.png)
![ss 2016-05-01 at 10 20 05](https://cloud.githubusercontent.com/assets/866151/14947608/edff5878-0fea-11e6-96c4-42def11dda95.png)

After:
![ss 2016-05-01 at 11 52 29](https://cloud.githubusercontent.com/assets/866151/14948736/86882496-0ff8-11e6-8d71-4e405a1f3332.png)
![ss 2016-05-02 at 12 29 15](https://cloud.githubusercontent.com/assets/866151/14949245/419a424c-0ffd-11e6-8506-8072219c17aa.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3809)
<!-- Reviewable:end -->
