### PR TITLE
Fix loading save states with input recording with the adapter

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -406,17 +406,28 @@ void ChangePads(bool instantly)
 	int controllers = 0;
 
 	for (int i = 0; i < MAX_SI_CHANNELS; ++i)
-		if (SConfig::GetInstance().m_SIDevice[i] == SIDEVICE_GC_CONTROLLER || SConfig::GetInstance().m_SIDevice[i] == SIDEVICE_GC_TARUKONGA)
+		if (SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
 			controllers |= (1 << i);
 
 	if (instantly && (s_numPads & 0x0F) == controllers)
 		return;
 
 	for (int i = 0; i < MAX_SI_CHANNELS; ++i)
+	{
+		SIDevices device = SIDEVICE_NONE;
+		if (IsUsingPad(i))
+		{
+			if (SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
+				device = SConfig::GetInstance().m_SIDevice[i];
+			else
+				device = IsUsingBongo(i) ? SIDEVICE_GC_TARUKONGA : SIDEVICE_GC_CONTROLLER;
+		}
+
 		if (instantly) // Changes from savestates need to be instantaneous
-			SerialInterface::AddDevice(IsUsingPad(i) ? (IsUsingBongo(i) ? SIDEVICE_GC_TARUKONGA : SIDEVICE_GC_CONTROLLER) : SIDEVICE_NONE, i);
+			SerialInterface::AddDevice(device, i);
 		else
-			SerialInterface::ChangeDevice(IsUsingPad(i) ? (IsUsingBongo(i) ? SIDEVICE_GC_TARUKONGA : SIDEVICE_GC_CONTROLLER) : SIDEVICE_NONE, i);
+			SerialInterface::ChangeDevice(device, i);
+	}
 }
 
 void ChangeWiiPads(bool instantly)


### PR DESCRIPTION
Intended fix for issue #9507 (https://bugs.dolphin-emu.org/issues/9507).

This is the reason I wanted to add a SIDevice_IsGCController() function in the first place, but I forgot about it.

Now, I actually don’t know what is the expected/desired behavior when someone loads a savestate, special-casing of bongos, etc… So if some people using the feature could enlighten me about what should be done, it would be great.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3810)
<!-- Reviewable:end -->
