### PR TITLE
[UI] Improved Menu Text, made real frameskip visible.

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -801,6 +801,7 @@ void UpdateTitle()
 	float FPS   = (float)(s_drawn_frame.load() * 1000.0 / ElapseTime);
 	float VPS   = (float)(s_drawn_video.load() * 1000.0 / ElapseTime);
 	float Speed = (float)(s_drawn_video.load() * (100 * 1000.0) / (VideoInterface::GetTargetRefreshRate() * ElapseTime));
+	int SkippedFrames = Movie::GetLastSkippedFrames() - 1; // Subtract 1, as it has 1 frame regardless of if it's skipped
 
 	// Settings are shown the same for both extended and summary info
 	std::string SSettings = StringFromFormat("%s %s | %s | %s", cpu_core_base->GetName(), _CoreParameter.bCPUThread ? "DC" : "SC",
@@ -814,7 +815,7 @@ void UpdateTitle()
 		SFPS = StringFromFormat("VI: %u - Input: %u - FPS: %.0f - VPS: %.0f - %.0f%%", (u32)Movie::g_currentFrame, (u32)Movie::g_currentInputCount, FPS, VPS, Speed);
 	else
 	{
-		SFPS = StringFromFormat("FPS: %.0f - VPS: %.0f - %.0f%%", FPS, VPS, Speed);
+		SFPS = StringFromFormat("FPS: %.0f - VPS: %.0f - %.0f%% - Skip: %d", FPS, VPS, Speed, SkippedFrames);
 		if (SConfig::GetInstance().m_InterfaceExtendedFPSInfo)
 		{
 			// Use extended or summary information. The summary information does not print the ticks data,

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -48,7 +48,7 @@ static bool s_bReadOnly = true;
 static u32 s_rerecords = 0;
 static PlayMode s_playMode = MODE_NONE;
 
-static u32 s_framesToSkip = 0, s_frameSkipCounter = 0;
+static u32 s_framesToSkip = 0, s_frameSkipCounter = 0, s_lastFrameSkipCounter = 0;
 
 static u8 s_numPads = 0;
 static ControllerState s_padState;
@@ -274,10 +274,18 @@ void FrameSkipping()
 
 		s_frameSkipCounter++;
 		if (s_frameSkipCounter > s_framesToSkip || Core::ShouldSkipFrame(s_frameSkipCounter) == false)
+		{
+			s_lastFrameSkipCounter = s_frameSkipCounter;
 			s_frameSkipCounter = 0;
+		}
 
 		Fifo::SetRendering(!s_frameSkipCounter);
 	}
+}
+
+int GetLastSkippedFrames()
+{
+	return s_lastFrameSkipCounter;
 }
 
 bool IsRecordingInput()

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -157,6 +157,7 @@ void SetReadOnly(bool bEnabled);
 
 void SetFrameSkipping(unsigned int framesToSkip);
 void FrameSkipping();
+int  GetLastSkippedFrames();
 
 bool BeginRecordingInput(int controllers);
 void RecordInput(GCPadStatus* PadStatus, int controllerID);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -149,7 +149,7 @@ wxMenuBar* CFrame::CreateMenu()
 	emulationMenu->Append(IDM_FRAMESTEP, GetMenuLabel(HK_FRAME_ADVANCE), wxEmptyString);
 
 	wxMenu *skippingMenu = new wxMenu;
-	emulationMenu->AppendSubMenu(skippingMenu, _("Frame S&kipping"));
+	emulationMenu->AppendSubMenu(skippingMenu, _("Maximum Frames to S&kip"));
 	for (int i = 0; i < 10; i++)
 		skippingMenu->AppendRadioItem(IDM_FRAME_SKIP_0 + i, wxString::Format("%i", i));
 	skippingMenu->Check(IDM_FRAME_SKIP_0 + SConfig::GetInstance().m_FrameSkip, true);
@@ -231,7 +231,7 @@ wxMenuBar* CFrame::CreateMenu()
 
 	// Tools menu
 	wxMenu* toolsMenu = new wxMenu;
-	toolsMenu->Append(IDM_MEMCARD, _("&Memcard Manager (GC)"));
+	toolsMenu->Append(IDM_MEMCARD, _("&Memory Card Manager (GC)"));
 	toolsMenu->Append(IDM_IMPORT_SAVE, _("Import Wii Save"));
 	toolsMenu->Append(IDM_EXPORT_ALL_SAVE, _("Export All Wii Saves"));
 	toolsMenu->Append(IDM_CHEATS, _("&Cheat Manager"));


### PR DESCRIPTION
This PR updates the UI subtly to make understanding easier.

* Added a method to get the actual frameskip.
===> Use this method in UpdateTitle() to display actual frameskip.
* Change "Do you want to stop the current emulation?" to "Do you want to
stop the current game?"
* Changed "Frame Skipping" -> "Maximum frames to Skip", to be more accurate
* Changed "Memcard Manager" -> "Memory Card Manager"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3812)
<!-- Reviewable:end -->
