### PR TITLE
Netplay: Add empty gamecube controller ports 1st

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -739,8 +739,25 @@ bool NetPlayClient::ChangeGame(const std::string&)
 // called from ---NETPLAY--- thread
 void NetPlayClient::UpdateDevices()
 {
+	// Add empty controller ports first
+	// TODO: Clean up the netplay controller mapping!
+	bool port_empty[4] = { false, false, false, false };
+	u8 i = 0;
+	for (auto player_id : m_pad_map)
+	{
+		if (player_id <= 0)
+		{
+			port_empty[i] = true;
+			SerialInterface::AddDevice(SIDEVICE_NONE, i);
+		}
+		i++;
+	}
+
 	u8 local_pad = 0;
-	// Add local pads first:
+	while (port_empty[local_pad])
+		local_pad++;
+
+	// Add local pads second:
 	// As stated in the comment in NetPlayClient::GetNetPads, the pads pertaining
 	// to the local user are always locally mapped to the first gamecube ports,
 	// so they should be added first.
@@ -758,16 +775,22 @@ void NetPlayClient::UpdateDevices()
 				SerialInterface::AddDevice(SIDEVICE_GC_CONTROLLER, local_pad);
 			}
 			local_pad++;
+			while (port_empty[local_pad])
+				local_pad++;
 		}
 	}
+
+	// Add remote pads third
 	for (auto player_id : m_pad_map)
 	{
-		if (player_id != m_local_player->pid)
+		if (player_id > 0 && player_id != m_local_player->pid)
 		{
 			// Only GCController-like controllers are supported, GBA and similar
 			// exotic devices are not supported on netplay.
-			SerialInterface::AddDevice(player_id > 0 ? SIDEVICE_GC_CONTROLLER : SIDEVICE_NONE, local_pad);
+			SerialInterface::AddDevice(SIDEVICE_GC_CONTROLLER, local_pad);
 			local_pad++;
+			while (port_empty[local_pad])
+				local_pad++;
 		}
 	}
 }


### PR DESCRIPTION
Partly fixes:
https://bugs.dolphin-emu.org/issues/9498

For example, now player 1 be set to pad 1, while player 2 is set to pad 3

Setting no player to pad 1 still does not work!

For some reason netplay maps the locally used controllers to the 1st ports, and the remote ones after that. But if port 2 for example is not used, port 2 must be set to an empty port. This pr just does that.

I'd like some testing done with 2 controllers for one player, and 3 player setups with and without empty ports between players.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3814)
<!-- Reviewable:end -->
