### PR TITLE
SCM: Use std::string.

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -475,7 +475,7 @@ JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetPlatform(
 
 JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetVersionString(JNIEnv *env, jobject obj)
 {
-	return env->NewStringUTF(scm_rev_str);
+	return env->NewStringUTF(scm_rev_str.c_str());
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SupportsNEON(JNIEnv *env, jobject obj)

--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -7,13 +7,14 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 // Git version number
-extern const char* scm_desc_str;
-extern const char* scm_branch_str;
-extern const char* scm_rev_str;
-extern const char* scm_rev_git_str;
-extern const char* netplay_dolphin_ver;
+extern const std::string scm_desc_str;
+extern const std::string scm_branch_str;
+extern const std::string scm_rev_str;
+extern const std::string scm_rev_git_str;
+extern const std::string netplay_dolphin_ver;
 
 // Force enable logging in the right modes. For some reason, something had changed
 // so that debugfast no longer logged.

--- a/Source/Core/Common/LinearDiskCache.h
+++ b/Source/Core/Common/LinearDiskCache.h
@@ -77,6 +77,7 @@ public:
 		std::fstream::pos_type start_pos = m_file.tellg();
 		std::streamoff file_size = end_pos - start_pos;
 
+		m_header.Init();
 		if (m_file.is_open() && ValidateHeader())
 		{
 			// good header, read some key/value pairs
@@ -180,18 +181,17 @@ private:
 
 	struct Header
 	{
-		Header()
-			: key_t_size(sizeof(K))
-			, value_t_size(sizeof(V))
+		void Init()
 		{
 			// Null-terminator is intentionally not copied.
 			std::memcpy(&id, "DCAC", sizeof(u32));
-			std::memcpy(ver, scm_rev_git_str, 40);
+			std::memcpy(ver, scm_rev_git_str.c_str(), std::min(scm_rev_git_str.size(), sizeof(ver)));
 		}
 
 		u32 id;
-		const u16 key_t_size, value_t_size;
-		char ver[40];
+		const u16 key_t_size = sizeof(K);
+		const u16 value_t_size = sizeof(V);
+		char ver[40] = {};
 
 	} m_header;
 

--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -13,7 +13,7 @@
 	#define BUILD_TYPE_STR ""
 #endif
 
-const char* scm_rev_str = "Dolphin "
+const std::string scm_rev_str = "Dolphin "
 #if !SCM_IS_MASTER
 	"[" SCM_BRANCH_STR "] "
 #endif
@@ -25,14 +25,14 @@ const char* scm_rev_str = "Dolphin "
 #endif
 
 #ifdef _WIN32
-const char* netplay_dolphin_ver = SCM_DESC_STR " Win";
+const std::string netplay_dolphin_ver = SCM_DESC_STR " Win";
 #elif __APPLE__
-const char* netplay_dolphin_ver = SCM_DESC_STR " Mac";
+const std::string netplay_dolphin_ver = SCM_DESC_STR " Mac";
 #else
-const char* netplay_dolphin_ver = SCM_DESC_STR " Lin";
+const std::string netplay_dolphin_ver = SCM_DESC_STR " Lin";
 #endif
 
-const char* scm_rev_git_str = SCM_REV_STR;
+const std::string scm_rev_git_str = SCM_REV_STR;
 
-const char* scm_desc_str = SCM_DESC_STR;
-const char* scm_branch_str = SCM_BRANCH_STR;
+const std::string scm_desc_str = SCM_DESC_STR;
+const std::string scm_branch_str = SCM_BRANCH_STR;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1319,7 +1319,7 @@ void GetSettings()
 	s_memcards |= (SConfig::GetInstance().m_EXIDevice[0] == EXIDEVICE_MEMORYCARD) << 0;
 	s_memcards |= (SConfig::GetInstance().m_EXIDevice[1] == EXIDEVICE_MEMORYCARD) << 1;
 	unsigned int tmp;
-	for (int i = 0; i < 20; ++i)
+	for (size_t i = 0; i < scm_rev_git_str.size() / 2 ; ++i)
 	{
 		sscanf(&scm_rev_git_str[2 * i], "%02x", &tmp);
 		s_revision[i] = tmp;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -19,7 +19,6 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
 
-static const char* NETPLAY_VERSION = scm_rev_git_str;
 static std::mutex crit_netplay_client;
 static NetPlayClient * netplay_client = nullptr;
 NetSettings g_NetPlaySettings;
@@ -162,7 +161,7 @@ bool NetPlayClient::Connect()
 {
 	// send connect message
 	sf::Packet spac;
-	spac << NETPLAY_VERSION;
+	spac << scm_rev_git_str;
 	spac << netplay_dolphin_ver;
 	spac << m_player_name;
 	Send(spac);

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -25,7 +25,6 @@
 #include <arpa/inet.h>
 #endif
 
-static const char* NETPLAY_VERSION = scm_rev_git_str;
 u64 g_netplay_initial_gctime = 1272737767;
 
 NetPlayServer::~NetPlayServer()
@@ -241,7 +240,7 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
 	std::string npver;
 	rpac >> npver;
 	// Dolphin netplay version
-	if (npver != NETPLAY_VERSION)
+	if (npver != scm_rev_git_str)
 		return CON_ERR_VERSION_MISMATCH;
 
 	// game is currently running

--- a/Source/Core/DolphinQt2/AboutDialog.cpp
+++ b/Source/Core/DolphinQt2/AboutDialog.cpp
@@ -23,10 +23,10 @@ AboutDialog::AboutDialog(QWidget* parent)
 	text.append(QStringLiteral("<p style='font-size:50pt; font-weight:400; margin-bottom:0px;'>") +
 		tr("Dolphin") + QStringLiteral("</p>"));
 	text.append(QStringLiteral("<p style='font-size:18pt; margin-top:0px;'>%1</p>")
-		.arg(QString::fromUtf8(scm_desc_str)));
+		.arg(QString::fromUtf8(scm_desc_str.c_str())));
 
-	text.append(small + tr("Branch: ") + QString::fromUtf8(scm_branch_str) + QStringLiteral("</p>"));
-	text.append(small + tr("Revision: ") + QString::fromUtf8(scm_rev_git_str) + QStringLiteral("</p>"));
+	text.append(small + tr("Branch: ") + QString::fromUtf8(scm_branch_str.c_str()) + QStringLiteral("</p>"));
+	text.append(small + tr("Revision: ") + QString::fromUtf8(scm_rev_git_str.c_str()) + QStringLiteral("</p>"));
 	text.append(small + tr("Compiled: ") + QStringLiteral(__DATE__ " " __TIME__ "</p>"));
 
 	text.append(medium + tr("Check for updates: ") +

--- a/Source/Core/DolphinWX/AboutDolphin.cpp
+++ b/Source/Core/DolphinWX/AboutDolphin.cpp
@@ -31,8 +31,8 @@ AboutDolphin::AboutDolphin(wxWindow *parent, wxWindowID id,
 	const wxString DolphinText = _("Dolphin");
 	const wxString RevisionText = scm_desc_str;
 	const wxString CopyrightText = _("(c) 2003-2015+ Dolphin Team. \"GameCube\" and \"Wii\" are trademarks of Nintendo. Dolphin is not affiliated with Nintendo in any way.");
-	const wxString BranchText = wxString::Format(_("Branch: %s"), scm_branch_str);
-	const wxString BranchRevText = wxString::Format(_("Revision: %s"), scm_rev_git_str);
+	const wxString BranchText = wxString::Format(_("Branch: %s"), scm_branch_str.c_str());
+	const wxString BranchRevText = wxString::Format(_("Revision: %s"), scm_rev_git_str.c_str());
 	const wxString CheckUpdateText = _("Check for updates: ");
 	const wxString Text = _("\n"
 		"Dolphin is a free and open-source GameCube and Wii emulator.\n"

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -705,7 +705,7 @@ void CFrame::UpdateTitle(const std::string &str)
 	}
 	else
 	{
-		std::string titleStr = StringFromFormat("%s | %s", scm_rev_str, str.c_str());
+		std::string titleStr = StringFromFormat("%s | %s", scm_rev_str.c_str(), str.c_str());
 		m_RenderFrame->SetTitle(titleStr);
 	}
 }

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -320,14 +320,14 @@ int main(int argc, char* argv[])
 			help = 1;
 			break;
 		case 'v':
-			fprintf(stderr, "%s\n", scm_rev_str);
+			fprintf(stderr, "%s\n", scm_rev_str.c_str());
 			return 1;
 		}
 	}
 
 	if (help == 1 || argc == optind)
 	{
-		fprintf(stderr, "%s\n\n", scm_rev_str);
+		fprintf(stderr, "%s\n\n", scm_rev_str.c_str());
 		fprintf(stderr, "A multi-platform GameCube/Wii emulator\n\n");
 		fprintf(stderr, "Usage: %s [-e <file>] [-h] [-v]\n", argv[0]);
 		fprintf(stderr, "  -e, --exec     Load the specified file\n");


### PR DESCRIPTION
Those macros may be defined, or not. We should support both cases, so use std::string as it also defines the length of the string.

This partially fixes issue 9233, at least the out-of-bounds behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3815)
<!-- Reviewable:end -->
