### PR TITLE
Add hack to IPCHLE to make NeoGamma work.

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -178,8 +178,10 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::Close(u32 _CommandAddress,
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::IOCtl(u32 _CommandAddress)
 {
-	//ERROR_LOG(WII_IPC_WIIMOTE, "Passing ioctl to ioctlv");
-	return IOCtlV(_CommandAddress); // FIXME: Hack
+	// NeoGamma (homebrew) is known to use this path.
+	ERROR_LOG(WII_IPC_WIIMOTE, "Bad IOCtl in CWII_IPC_HLE_Device_usb_oh1_57e_305");
+	Memory::Write_U32(FS_EINVAL, _CommandAddress + 4);
+	return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305::IOCtlV(u32 _CommandAddress)


### PR DESCRIPTION
NeoGamma is explicitly sending a nonsense command to the Bluetooth module;
make sure to respond with something sane.

Fixes issue 9470, a regression from PR #1856.

Yes, it's a bit hacky, but @JMC47 encouraged me to submit this.  Feedback from anyone with a better understanding of how error handling works on IOS would be welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3816)
<!-- Reviewable:end -->
