### PR TITLE
[UI] Enable Qt on Mac

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -29,4 +29,47 @@ set(DOLPHINQT2_BINARY dolphin-emu-qt2)
 add_executable(${DOLPHINQT2_BINARY} ${SRCS} ${UI_HEADERS})
 target_link_libraries(${DOLPHINQT2_BINARY} ${LIBS} Qt5::Widgets)
 
-install(TARGETS ${DOLPHINQT2_BINARY} RUNTIME DESTINATION ${bindir})
+if(APPLE)
+	# Note: This is copied from DolphinQt, based on the DolphinWX version.
+
+	include(BundleUtilities)
+	set(BUNDLE_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${DOLPHINQT2_BINARY}.app)
+
+	# Ask for an application bundle.
+	set_target_properties(${DOLPHINQT2_BINARY} PROPERTIES
+		MACOSX_BUNDLE true
+		MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in
+		)
+
+	# get rid of any old copies
+	file (REMOVE_RECURSE ${BUNDLE_PATH}/Contents/Resources/Sys)
+	if(NOT SKIP_POSTPROCESS_BUNDLE)
+		# Fix up the bundle after it is finished.
+		# There does not seem to be an easy way to run CMake commands post-build,
+		# so we invoke CMake again on a generated script.
+		file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/postprocess_bundle.cmake "
+			include(BundleUtilities)
+			message(\"Fixing up application bundle: ${BUNDLE_PATH}\")
+			message(\"(Note: This is only necessary to produce a redistributable binary.\")
+			message(\"To skip, pass -DSKIP_POSTPROCESS_BUNDLE=1 to cmake.)\")
+			set(BU_CHMOD_BUNDLE_ITEMS ON)
+			execute_process(COMMAND ${CMAKE_SOURCE_DIR}/Tools/deploy-mac.py -p platforms/libqcocoa.dylib \"${BUNDLE_PATH}\")
+			file(INSTALL ${CMAKE_SOURCE_DIR}/Data/Sys
+				DESTINATION ${BUNDLE_PATH}/Contents/Resources
+				)
+			")
+		add_custom_command(TARGET ${DOLPHINQT2_BINARY} POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -P postprocess_bundle.cmake
+			)
+	else()
+		add_custom_command(OUTPUT ${BUNDLE_PATH}/Contents/Resources/Sys
+			COMMAND ln -nfs ${CMAKE_SOURCE_DIR}/Data/Sys ${BUNDLE_PATH}/Contents/Resources/Sys
+			VERBATIM
+			)
+		add_custom_target(CopyDataIntoBundleQt ALL
+			DEPENDS ${BUNDLE_PATH}/Contents/Resources/Sys
+			)
+	endif()
+else()
+	install(TARGETS ${DOLPHINQT2_BINARY} RUNTIME DESTINATION ${bindir})
+endif()

--- a/Source/Core/DolphinQt2/Info.plist.in
+++ b/Source/Core/DolphinQt2/Info.plist.in
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>ciso</string>
+                <string>dol</string>
+                <string>elf</string>
+                <string>gcm</string>
+                <string>gcz</string>
+                <string>iso</string>
+                <string>wad</string>
+                <string>wbfs</string>
+            </array>
+            <key>CFBundleTypeIconFile</key>
+            <string>Dolphin.icns</string>
+            <key>CFBundleTypeName</key>
+            <string>Nintendo GC/Wii file</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+        </dict>
+    </array>
+    <key>CFBundleExecutable</key>
+    <string>dolphin-emu-qt2</string>
+    <key>CFBundleIconFile</key>
+    <string>Resources/Dolphin.icns</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.dolphin-emu.dolphin</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleLocalizations</key>
+    <array>
+        <string>ar</string>
+        <string>ca</string>
+        <string>cs</string>
+        <string>de</string>
+        <string>el</string>
+        <string>en</string>
+        <string>es</string>
+        <string>fa</string>
+        <string>fr</string>
+        <string>he</string>
+        <string>hu</string>
+        <string>it</string>
+        <string>ja</string>
+        <string>ko</string>
+        <string>nb</string>
+        <string>nl</string>
+        <string>pl</string>
+        <string>pt</string>
+        <string>pt_BR</string>
+        <string>ru</string>
+        <string>sr</string>
+        <string>sv</string>
+        <string>tr</string>
+        <string>zh_CN</string>
+        <string>zh_TW</string>
+    </array>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${DOLPHIN_WC_DESCRIBE}</string>
+    <key>CFBundleLongVersionString</key>
+    <string>${DOLPHIN_WC_REVISION}</string>
+    <key>CFBundleVersion</key>
+    <string>${DOLPHIN_VERSION_MAJOR}.${DOLPHIN_VERSION_MINOR}</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>Licensed under GPL version 2 or later (GPLv2+)</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>${OSX_MIN_VERSION}</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>CSResourcesFileMapped</key>
+    <true/>
+</dict>
+</plist>

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -23,6 +23,7 @@ MainWindow::MainWindow() : QMainWindow(nullptr)
 {
 	setWindowTitle(tr("Dolphin"));
 	setWindowIcon(QIcon(Resources::GetMisc(Resources::LOGO_SMALL)));
+	setUnifiedTitleAndToolBarOnMac(true);
 
 	CreateComponents();
 


### PR DESCRIPTION
Enables the building of the Qt2 client on Mac.
This also themes the Qt2 client on OS X to look like a native Mac Application.
![screen shot 2016-05-04 at 7 19 45 pm](https://cloud.githubusercontent.com/assets/866151/15034711/38de1cc8-122d-11e6-9b85-1f369031f135.PNG)

This PR encourages both Mac and Qt development.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3817)
<!-- Reviewable:end -->
