### PR TITLE
Fix regression for .elf files in Netplay Game Selector

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -80,6 +80,8 @@ static std::string BuildGameName(const GameListItem& game)
 	}
 
 	std::string name(game.GetName(lang));
+	if (name.empty())
+		name = game.GetName();
 
 	int disc_number = game.GetDiscNumber() + 1;
 
@@ -92,16 +94,12 @@ static std::string BuildGameName(const GameListItem& game)
 		std::string disc_text = "Disc ";
 		info.push_back(disc_text + std::to_string(disc_number));
 	}
-
 	if (info.empty())
 		return name;
-	else
-	{
-		std::ostringstream ss;
-		std::copy(info.begin(), info.end() -1, std::ostream_iterator<std::string>(ss, ", "));
-		ss << info.back();
-		return name + " (" + ss.str() + ")";
-	}
+	std::ostringstream ss;
+	std::copy(info.begin(), info.end() -1, std::ostream_iterator<std::string>(ss, ", "));
+	ss << info.back();
+	return name + " (" + ss.str() + ")";
 }
 
 void NetPlayDialog::FillWithGameNames(wxListBox* game_lbox, const CGameListCtrl& game_list)


### PR DESCRIPTION
Fixes an issue in PR #3793 that made ELF files show up as blank (This made Project M Netplay very confusing).

It's a one line fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3820)
<!-- Reviewable:end -->
