### PR TITLE
Fix a hang with the GC Adapter

### DIFF
--- a/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
@@ -33,6 +33,86 @@ GCPadStatus CSIDevice_GCAdapter::GetPadStatus()
 	return PadStatus;
 }
 
+int CSIDevice_GCAdapter::RunBuffer(u8* _pBuffer, int _iLength)
+{
+	// For debug logging only
+	ISIDevice::RunBuffer(_pBuffer, _iLength);
+
+	// Read the command
+	EBufferCommands command = static_cast<EBufferCommands>(_pBuffer[3]);
+
+	const u8 numPAD = NetPlay_InGamePadToLocalPad(ISIDevice::m_iDeviceNumber);
+	if (numPAD < 4)
+	{
+		if (!GCAdapter::DeviceConnected(numPAD))
+		{
+			reinterpret_cast<u32*>(_pBuffer)[0] = SI_NONE;
+			return 4;
+		}
+	}
+
+	// Handle it
+	switch (command)
+	{
+	case CMD_RESET:
+	case CMD_ID:
+		*(u32*)&_pBuffer[0] = SI_GC_CONTROLLER;
+		break;
+
+	case CMD_DIRECT:
+		{
+			INFO_LOG(SERIALINTERFACE, "PAD - Direct (Length: %d)", _iLength);
+			u32 high, low;
+			GetData(high, low);
+			for (int i = 0; i < (_iLength - 1) / 2; i++)
+			{
+				_pBuffer[i + 0] = (high >> (i * 8)) & 0xff;
+				_pBuffer[i + 4] = (low >> (i * 8)) & 0xff;
+			}
+		}
+		break;
+
+	case CMD_ORIGIN:
+		{
+			INFO_LOG(SERIALINTERFACE, "PAD - Get Origin");
+
+			Calibrate();
+
+			u8* pCalibration = reinterpret_cast<u8*>(&m_Origin);
+			for (int i = 0; i < (int)sizeof(SOrigin); i++)
+			{
+				_pBuffer[i ^ 3] = *pCalibration++;
+			}
+		}
+		break;
+
+	// Recalibrate (FiRES: i am not 100 percent sure about this)
+	case CMD_RECALIBRATE:
+		{
+			INFO_LOG(SERIALINTERFACE, "PAD - Recalibrate");
+
+			Calibrate();
+
+			u8* pCalibration = reinterpret_cast<u8*>(&m_Origin);
+			for (int i = 0; i < (int)sizeof(SOrigin); i++)
+			{
+				_pBuffer[i ^ 3] = *pCalibration++;
+			}
+		}
+		break;
+
+	// DEFAULT
+	default:
+		{
+			ERROR_LOG(SERIALINTERFACE, "Unknown SI command     (0x%x)", command);
+			PanicAlert("SI: Unknown command (0x%x)", command);
+		}
+		break;
+	}
+
+	return _iLength;
+}
+
 void CSIDevice_GCController::Rumble(u8 numPad, ControlState strength)
 {
 	SIDevices device = SConfig::GetInstance().m_SIDevice[numPad];

--- a/Source/Core/Core/HW/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI_DeviceGCAdapter.h
@@ -14,5 +14,5 @@ public:
 	CSIDevice_GCAdapter(SIDevices device, int _iDeviceNumber);
 
 	GCPadStatus GetPadStatus() override;
-	int RunBuffer(u8* _pBuffer, int _iLength) override;
+	int RunBuffer(u8* buffer, int length) override;
 };

--- a/Source/Core/Core/HW/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI_DeviceGCAdapter.h
@@ -14,4 +14,5 @@ public:
 	CSIDevice_GCAdapter(SIDevices device, int _iDeviceNumber);
 
 	GCPadStatus GetPadStatus() override;
+	int RunBuffer(u8* _pBuffer, int _iLength) override;
 };

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -12,6 +12,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
+#include "Core/NetPlayProto.h"
 #include "Core/HW/SI.h"
 #include "Core/HW/SystemTimers.h"
 
@@ -417,8 +418,11 @@ void Input(int chan, GCPadStatus* pad)
 			pad->triggerLeft = controller_payload_copy[1 + (9 * chan) + 7];
 			pad->triggerRight = controller_payload_copy[1 + (9 * chan) + 8];
 		}
-		else
+		else if (!NetPlay::IsNetPlayRunning())
 		{
+			// This is a hack to prevent a netplay desync due to SI devices
+			// being different and returning different values.
+			// The corresponding code in DeviceGCAdapter has the same check
 			pad->button = PAD_ERR_STATUS;
 		}
 	}


### PR DESCRIPTION
Fix for https://bugs.dolphin-emu.org/issues/9502

The fix made for netplay in 3df4b09a9428fe08a8ca caused the behavior
introduced in 49410576e to provoke hangs, because it relied on both
functions having to handle the error cause. Since the error handling is
not available in the SI device anymore, this created an issue, so I
remove that handling from the Adapter code as well.

The behavior will need to be added back for correctness, so I am leaving a
note about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3821)
<!-- Reviewable:end -->
