### PR TITLE
Piping the wxMsgAlert through netplay window during netplay ...

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -42,6 +42,7 @@
 #include "DolphinWX/WxUtils.h"
 #include "DolphinWX/Debugger/CodeWindow.h"
 #include "DolphinWX/Debugger/JitWindow.h"
+#include "DolphinWX/NetPlay/NetWindow.h"
 
 #include "UICommon/UICommon.h"
 
@@ -366,10 +367,21 @@ bool wxMsgAlert(const char* caption, const char* text, bool yes_no, int /*Style*
 {
 #ifdef __WXGTK__
 	if (wxIsMainThread())
+	{
 #endif
-		return wxYES == wxMessageBox(StrToWxStr(text), StrToWxStr(caption),
-				(yes_no) ? wxYES_NO : wxOK, wxWindow::FindFocus());
+		NetPlayDialog*& npd = NetPlayDialog::GetInstance();
+		if (npd == nullptr)
+		{
+			return wxYES == wxMessageBox(StrToWxStr(text), StrToWxStr(caption),
+					(yes_no) ? wxYES_NO : wxOK, wxWindow::FindFocus());
+		}
+		else
+		{
+			npd->AppendChat("/!\\ " + std::string{text});
+			return true;
+		}
 #ifdef __WXGTK__
+	}
 	else
 	{
 		wxCommandEvent event(wxEVT_HOST_COMMAND, IDM_PANIC);


### PR DESCRIPTION
Instead of running a blocking messagebox. This is a hack that papers around some of the resource contention in netplay that causes crashes by not blocking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3823)
<!-- Reviewable:end -->
