### PR TITLE
Common: Handle trailing comments in INI parser, malformed GameIni resetting config values

### DIFF
--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -20,9 +20,6 @@
 
 void IniFile::ParseLine(const std::string& line, std::string* keyOut, std::string* valueOut)
 {
-  if (line[0] == '#')
-    return;
-
   size_t firstEquals = line.find("=", 0);
 
   if (firstEquals != std::string::npos)
@@ -354,6 +351,13 @@ bool IniFile::Load(const std::string& filename, bool keep_current_data)
       line.erase(line.size() - 1);
     }
 #endif
+
+    // Remove comments from lines. After the first # is encountered, the rest of the line
+    // is considered to be a comment. This handles cases where the line starts with #, as
+    // well as comments after the section or setting.
+    size_t comment_pos = line.find('#');
+    if (comment_pos != std::string::npos)
+      line = line.substr(0, comment_pos);
 
     if (line.size() > 0)
     {

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -134,11 +134,12 @@ void VideoConfig::GameIniLoad()
   do                                                                                               \
   {                                                                                                \
     decltype(var) temp = var;                                                                      \
-    if (iniFile.GetIfExists(section, key, &var) && var != temp)                                    \
+    if (iniFile.GetIfExists(section, key, &temp) && var != temp)                                   \
     {                                                                                              \
       std::string msg = StringFromFormat("Note: Option \"%s\" is overridden by game ini.", key);   \
       OSD::AddMessage(msg, 7500);                                                                  \
       gfx_override_exists = true;                                                                  \
+      var = temp;                                                                                  \
     }                                                                                              \
   } while (0)
 


### PR DESCRIPTION
This affected lines such as:
SomeBoolKey = True     # Comment here

Which would end up being parsed as false. The behavior now is to remove all characters afterwards, and including the #. 

Numerical values would still parse okay, since strtoul or stringstream would stop at the first non-digit, but failed for booleans, since we're comparing against 0/1/true/false.

I'm not sure if this is the best way to handle this, since from what I can tell, we're not following any formal INI file standard, so is permitting trailing comments after the best way to go? Or should we allow semicolon comments too?

Quickly searching, the closest thing I can find to a spec would suggest trailing comments should be a no, but that also uses semicolons, not hashes: http://stackoverflow.com/questions/1378219/do-standard-windows-ini-files-allow-comments (but some other applications that use ini-file configs permit hashes..)

The second commit stops this issue from happening in the first place. Currently, if a line fails to parse, the config value will get set to the default value according to the ini parser, instead of retaining its original value.

Example case where this causes issues: User sets bounding box enable to true, game ini has a malformed bbox enable line that doesn't parse correctly, bounding box enable gets set to false.

This affects some of our gameinis:

> $ egrep "^[^#]+#" *
> R64.ini:SyncGPU = True # Prevent CPU/GPU desync
> R8P.ini:EFBToTextureEnable = False # Fix transitions
> R8P.ini:BBoxEnable = True # Required for proper functionality
> RMC.ini:MSAA = 0 # Avoid overbloom
> RSP.ini:CPUThread = False # Display Mii faces correctly
> RZT.ini:EFBAccessEnable = True # Fix aiming

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3826)

<!-- Reviewable:end -->
