### PR TITLE
Fix broken game INIs (comments starting in the middle of lines)

### DIFF
--- a/Data/Sys/GameSettings/R64.ini
+++ b/Data/Sys/GameSettings/R64.ini
@@ -1,13 +1,13 @@
-# R64E01, R64J01, R64K01, R64P01 - RVL Wii Music
+# R64E01, R64J01, R64K01, R64P01 - Wii Music
 
 [Core]
 # Values set here will override the main Dolphin settings.
-SyncGPU = True # Prevent CPU/GPU desync
+SyncGPU = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues =
+EmulationIssues = Needs SyncGPU or single core to avoid CPU/GPU desyncs
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/R8P.ini
+++ b/Data/Sys/GameSettings/R8P.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 5
-EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
+EmulationIssues = Needs Efb to Ram and BBox (proper graphics and functionality).
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -18,5 +18,5 @@ EmulationIssues = Needs Efb to Ram for BBox (proper graphics).
 # Add action replay cheats here.
 
 [Video_Hacks]
-EFBToTextureEnable = False # Fix transitions
-BBoxEnable = True # Required for proper functionality
+EFBToTextureEnable = False
+BBoxEnable = True

--- a/Data/Sys/GameSettings/RMC.ini
+++ b/Data/Sys/GameSettings/RMC.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues =
+EmulationIssues = Disable anti-aliasing to avoid overbloom
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -24,4 +24,4 @@ EFBEmulateFormatChanges = True
 StereoConvergence = 613
 
 [Video_Settings]
-MSAA = 0 # Avoid overbloom
+MSAA = 0

--- a/Data/Sys/GameSettings/RSP.ini
+++ b/Data/Sys/GameSettings/RSP.ini
@@ -2,12 +2,12 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-CPUThread = False # Display Mii faces correctly
+CPUThread = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 5
-EmulationIssues =
+EmulationIssues = Dual core must be disabled to display Mii faces correctly
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/RZT.ini
+++ b/Data/Sys/GameSettings/RZT.ini
@@ -1,11 +1,12 @@
 # RZTE01, RZTJ01, RZTK01, RZTP01, RZTW01 - Wii Sports Resort
+
 [Core]
 # Values set here will override the main Dolphin settings.
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs real wiimote and motion plus.
+EmulationIssues = Needs real wiimote and motion plus. Proper aiming requires EFB Access from CPU.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,4 +17,4 @@ EmulationIssues = Needs real wiimote and motion plus.
 
 [Video_Hacks]
 EFBEmulateFormatChanges = True
-EFBAccessEnable = True # Fix aiming
+EFBAccessEnable = True


### PR DESCRIPTION
290204e added comments that start in the middle of lines, which isn't allowed. I moved all such comments to EmulationIssues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3827)
<!-- Reviewable:end -->
