### PR TITLE
Delete apprsrc.h

### DIFF
--- a/Externals/wxWidgets3/src/osx/carbon/apprsrc.h
+++ b/Externals/wxWidgets3/src/osx/carbon/apprsrc.h
@@ -1,1 +1,0 @@
-// TODO REMOVE


### PR DESCRIPTION
I was casually browsing the "// TODO"s and came across this file. Is it still needed? I'm unable to find anything that references it... (I'm using the default GitHub search, so I may have missed something)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3828)
<!-- Reviewable:end -->
