### PR TITLE
[Qt] Settings Window for Qt

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SRCS
 	Settings.cpp
 	ToolBar.cpp
 	Config/PathDialog.cpp
+	Config/SettingsWindow.cpp
 	GameList/GameFile.cpp
 	GameList/GameList.cpp
 	GameList/GameListModel.cpp

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -1,0 +1,93 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt2/Settings.h"
+#include "DolphinQt2/Config/SettingsWindow.h"
+
+SettingsWindow::SettingsWindow(QWidget* parent)
+    : QDialog(parent)
+{
+    // Set Window Properties
+    setWindowTitle(tr("Settings"));
+    resize(720, 600);
+
+    // Main Layout
+    QVBoxLayout* layout = new QVBoxLayout;
+    QHBoxLayout* content = new QHBoxLayout;
+    QVBoxLayout* content_inner = new QVBoxLayout;
+    // Content's widgets
+    {
+        // Category list
+        MakeCategoryList();
+        content->addWidget(m_categories);
+
+        // Actual Settings UI
+        SetupSettingsWidget();
+
+        MakeUnfinishedWarning();
+
+        content_inner->addWidget(m_warning_group);
+        content_inner->addWidget(m_settings_outer);
+
+        content->addLayout(content_inner);
+    }
+
+    // Add content to layout before dialog buttons.
+    layout->addLayout(content);
+
+    // Dialog box buttons
+    QDialogButtonBox* ok_box = new QDialogButtonBox(QDialogButtonBox::Ok);
+    connect(ok_box, &QDialogButtonBox::accepted, this, &SettingsWindow::accept);
+    layout->addWidget(ok_box);
+
+    setLayout(layout);
+}
+
+void SettingsWindow::SetupSettingsWidget()
+{
+    m_settings_outer = new QStackedWidget;
+    m_settings_outer->setCurrentIndex(0);
+}
+
+void SettingsWindow::MakeUnfinishedWarning()
+{
+    m_warning_group = new QGroupBox(tr("Warning"));
+    QHBoxLayout* m_warning_group_layout = new QHBoxLayout;
+    QLabel* warning_text = new QLabel(
+            tr("Some categories and settings will not work.\n"
+                "This Settings Window is under active development."));
+    m_warning_group_layout->addWidget(warning_text);
+    m_warning_group->setLayout(m_warning_group_layout);
+}
+
+void SettingsWindow::AddCategoryToList(const QString& title, const QString& icon)
+{
+    QListWidgetItem* button = new QListWidgetItem();
+    button->setIcon(QIcon(icon));
+    button->setText(title);
+    button->setTextAlignment(Qt::AlignVCenter);
+    button->setSizeHint(QSize(28, 28));
+    button->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+    m_categories->addItem(button);
+}
+
+void SettingsWindow::MakeCategoryList()
+{
+    QString dir = Settings().GetThemeDir();
+
+    m_categories = new QListWidget;
+    m_categories->setMaximumWidth(175);
+    m_categories->setIconSize(QSize(32, 32));
+    m_categories->setMovement(QListView::Static);
+    m_categories->setSpacing(0);
+
+    connect(m_categories, &QListWidget::currentItemChanged, this, &SettingsWindow::changePage);
+}
+
+void SettingsWindow::changePage(QListWidgetItem* current, QListWidgetItem* previous)
+{
+    if (!current)
+        current = previous;
+    m_settings_outer->setCurrentIndex(m_categories->row(current));
+}

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.h
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.h
@@ -1,0 +1,37 @@
+// Copyright 2015 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListView>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QStackedWidget>
+#include <QString>
+#include <QVBoxLayout>
+#include <QWidget>
+
+class SettingsWindow final : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit SettingsWindow(QWidget* parent = nullptr);
+
+public slots:
+    void changePage(QListWidgetItem* current, QListWidgetItem* previous);
+
+private:
+    void MakeCategoryList();
+    void MakeUnfinishedWarning();
+    void AddCategoryToList(const QString& title, const QString& icon);
+    void SetupSettingsWidget();
+    QStackedWidget* m_settings_outer;
+    QListWidget* m_categories;
+    QGroupBox* m_warning_group;
+};

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -12,12 +12,14 @@
 #include "Core/Movie.h"
 #include "Core/State.h"
 #include "Core/HW/ProcessorInterface.h"
+
 #include "DolphinQt2/AboutDialog.h"
 #include "DolphinQt2/Host.h"
 #include "DolphinQt2/MainWindow.h"
 #include "DolphinQt2/Resources.h"
 #include "DolphinQt2/Settings.h"
 #include "DolphinQt2/Config/PathDialog.h"
+#include "DolphinQt2/Config/SettingsWindow.h"
 
 MainWindow::MainWindow() : QMainWindow(nullptr)
 {
@@ -48,6 +50,7 @@ void MainWindow::CreateComponents()
 	m_render_widget = new RenderWidget;
 	m_stack = new QStackedWidget(this);
 	m_paths_dialog = new PathDialog(this);
+	m_settings_window = new SettingsWindow(this);
 }
 
 void MainWindow::ConnectMenuBar()
@@ -96,6 +99,7 @@ void MainWindow::ConnectToolBar()
 	connect(m_tool_bar, &ToolBar::FullScreenPressed, this, &MainWindow::FullScreen);
 	connect(m_tool_bar, &ToolBar::ScreenShotPressed, this, &MainWindow::ScreenShot);
 	connect(m_tool_bar, &ToolBar::PathsPressed, this, &MainWindow::ShowPathsDialog);
+	connect(m_tool_bar, &ToolBar::SettingsPressed, this, &MainWindow::ShowSettingsWindow);
 
 	connect(this, &MainWindow::EmulationStarted, m_tool_bar, &ToolBar::EmulationStarted);
 	connect(this, &MainWindow::EmulationPaused, m_tool_bar, &ToolBar::EmulationPaused);
@@ -303,6 +307,13 @@ void MainWindow::ShowPathsDialog()
 	m_paths_dialog->show();
 	m_paths_dialog->raise();
 	m_paths_dialog->activateWindow();
+}
+
+void MainWindow::ShowSettingsWindow()
+{
+	m_settings_window->show();
+	m_settings_window->raise();
+	m_settings_window->activateWindow();
 }
 
 void MainWindow::ShowAboutDialog()

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -15,6 +15,7 @@
 #include "DolphinQt2/GameList/GameList.h"
 
 class PathDialog;
+class SettingsWindow;
 
 class MainWindow final : public QMainWindow
 {
@@ -68,6 +69,7 @@ private:
 	void HideRenderWidget();
 
 	void ShowPathsDialog();
+	void ShowSettingsWindow();
 	void ShowAboutDialog();
 
 	QStackedWidget* m_stack;
@@ -79,4 +81,5 @@ private:
 	int m_state_slot = 1;
 
 	PathDialog* m_paths_dialog;
+	SettingsWindow* m_settings_window;
 };

--- a/Source/Core/DolphinQt2/ToolBar.cpp
+++ b/Source/Core/DolphinQt2/ToolBar.cpp
@@ -64,13 +64,7 @@ void ToolBar::MakeActions()
 	addSeparator();
 
 	m_paths_action = addAction(tr("Paths"), this, SIGNAL(PathsPressed()));
-
-	m_config_action = addAction(tr("Settings"));
-	m_config_action->setEnabled(false);
-
-	m_graphics_action = addAction(tr("Graphics"));
-	m_graphics_action->setEnabled(false);
-
+	m_config_action = addAction(tr("Settings"), this, SIGNAL(SettingsPressed()));
 	m_controllers_action = addAction(tr("Controllers"));
 	m_controllers_action->setEnabled(false);
 }
@@ -87,7 +81,6 @@ void ToolBar::UpdateIcons()
 	m_fullscreen_action->setIcon(QIcon(QStringLiteral("fullscreen.png").prepend(dir)));
 	m_screenshot_action->setIcon(QIcon(QStringLiteral("screenshot.png").prepend(dir)));
 	m_config_action->setIcon(QIcon(QStringLiteral("config.png").prepend(dir)));
-	m_graphics_action->setIcon(QIcon(QStringLiteral("graphics.png").prepend(dir)));
 	m_controllers_action->setIcon(QIcon(QStringLiteral("classic.png").prepend(dir)));
 }
 

--- a/Source/Core/DolphinQt2/ToolBar.h
+++ b/Source/Core/DolphinQt2/ToolBar.h
@@ -29,7 +29,7 @@ signals:
 	void ScreenShotPressed();
 
 	void PathsPressed();
-
+	void SettingsPressed();
 private:
 	void MakeActions();
 	void UpdateIcons();
@@ -42,6 +42,5 @@ private:
 	QAction* m_screenshot_action;
 	QAction* m_paths_action;
 	QAction* m_config_action;
-	QAction* m_graphics_action;
 	QAction* m_controllers_action;
 };


### PR DESCRIPTION
This is the _actual_ bare minimum settings window for Qt.

This pull request
-----------------------
![screen shot 2016-05-09 at 6 51 59 am](https://cloud.githubusercontent.com/assets/866151/15115185/95097e7e-15b2-11e6-8cbe-9b06d5305fbc.PNG)

Features
----------------------
- All in one window.
- Sidebar with categories. A small icon next to text denotes the category.
- Comes with unfinished warning.
- Easy to extend, only 2 lines of code to add a new page.

Side effects
----------------------
- Removes Graphics Option from the Main Window, as it did nothing and will be integrated into this Window.

- Kept paths in Main Window, as it's functional and required to get Dolphin to work at all. It will be removed once the required functionality is in the Settings Window

This is the skeleton. I will merge other Pages as I work on them. This comes with no pages at all, and displays a blank screen (like shown)

In the non-skeleton version, which I will break up and submit in many pull requests, it looks like this:
![screen shot 2016-05-08 at 8 59 03 pm](https://cloud.githubusercontent.com/assets/866151/15115246/e4ac1d38-15b2-11e6-8a0b-31f9591cb156.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3830)
<!-- Reviewable:end -->
