### PR TITLE
WIP: [netplay] enable dynamic "write to memcard" setting

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -108,6 +108,11 @@ void NetPlayDialog::FillWithGameNames(wxListBox* game_lbox, const CGameListCtrl&
     game_lbox->Append(StrToWxStr(BuildGameName(*game)));
 }
 
+void NetPlayDialog::OnMemcardWriteChange(wxCommandEvent& event)
+{
+  SConfig::GetInstance().bEnableMemcardSdWriting = event.IsChecked();
+}
+
 NetPlayDialog::NetPlayDialog(wxWindow* const parent, const CGameListCtrl* const game_list,
                              const std::string& game, const bool is_hosting)
     : wxFrame(parent, wxID_ANY, _("Dolphin NetPlay")), m_selected_game(game), m_start_btn(nullptr),
@@ -218,6 +223,7 @@ NetPlayDialog::NetPlayDialog(wxWindow* const parent, const CGameListCtrl* const 
     bottom_szr->Add(padbuf_spin, 0, wxCENTER);
     bottom_szr->AddSpacer(5);
     m_memcard_write = new wxCheckBox(panel, wxID_ANY, _("Write to memcards/SD"));
+    m_memcard_write->Bind(wxEVT_CHECKBOX, &NetPlayDialog::OnMemcardWriteChange, this);
     bottom_szr->Add(m_memcard_write, 0, wxCENTER);
   }
 
@@ -344,7 +350,6 @@ void NetPlayDialog::OnMsgStartGame()
   if (m_is_hosting)
   {
     m_start_btn->Disable();
-    m_memcard_write->Disable();
     m_game_btn->Disable();
     m_player_config_btn->Disable();
   }

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.h
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.h
@@ -72,6 +72,7 @@ private:
   void OnAssignPads(wxCommandEvent& event);
   void OnKick(wxCommandEvent& event);
   void OnPlayerSelect(wxCommandEvent& event);
+  void OnMemcardWriteChange(wxCommandEvent& event);
   void GetNetSettings(NetSettings& settings);
   std::string FindGame();
 


### PR DESCRIPTION
https://bugs.dolphin-emu.org/issues/9538

That feature appears to be controlled by one boolean only; so setting it to true in the global settings should be enough to enable writing to memcards.

Untested right now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3833)

<!-- Reviewable:end -->
