### PR TITLE
[Qt] Add Interface Page to Settings

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SRCS
 	ToolBar.cpp
 	Config/PathDialog.cpp
 	Config/SettingsWindow.cpp
+	Config/Pages/InterfacePage.cpp
 	GameList/GameFile.cpp
 	GameList/GameList.cpp
 	GameList/GameListModel.cpp

--- a/Source/Core/DolphinQt2/Config/Pages/InterfacePage.cpp
+++ b/Source/Core/DolphinQt2/Config/Pages/InterfacePage.cpp
@@ -1,0 +1,146 @@
+#include <QCheckBox>
+#include <QComboBox>
+#include <QGroupBox>
+#include <QLabel>
+#include <QString>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "Common/CommonPaths.h"
+#include "Common/FileSearch.h"
+#include "Common/FileUtil.h"
+#include "Core/ConfigManager.h"
+#include "DolphinQt2/Settings.h"
+#include "DolphinQt2/Config/Pages/InterfacePage.h"
+
+
+InterfacePage::InterfacePage(QWidget* parent)
+	: QWidget(parent)
+{
+	m_mainLayout = new QVBoxLayout;
+	BuildOptions();
+	ConnectOptions();
+	LoadConfig();
+	m_mainLayout->addStretch(1);
+	setLayout(m_mainLayout);
+}
+
+void InterfacePage::LoadConfig()
+{
+	const SConfig& startup_params = SConfig::GetInstance();
+
+	// UI Options
+	m_checkbox_auto_adjust_window->setChecked(startup_params.bRenderWindowAutoSize);
+	m_checkbox_keep_dolphin_on_top->setChecked(startup_params.bKeepWindowOnTop);
+	m_checkbox_render_to_main_window->setChecked(startup_params.bRenderToMain);
+	m_combobox_theme_selector->setCurrentIndex(m_combobox_theme_selector->findText(QString::fromStdString(SConfig::GetInstance().theme_name)));
+
+	// In Game Options
+	m_checkbox_confirm_on_stop->setChecked(startup_params.bConfirmStop);
+	m_checkbox_use_panic_handlers->setChecked(startup_params.bUsePanicHandlers);
+	m_checkbox_enable_osd->setChecked(startup_params.bOnScreenDisplayMessages);
+	m_checkbox_pause_on_focus_lost->setChecked(startup_params.m_PauseOnFocusLost);
+	m_checkbox_hide_mouse->setChecked(startup_params.bAutoHideCursor);
+}
+
+void InterfacePage::SaveConfig()
+{
+	// UI Options
+	SConfig::GetInstance().bRenderWindowAutoSize = m_checkbox_auto_adjust_window->isChecked();
+	SConfig::GetInstance().bKeepWindowOnTop = m_checkbox_keep_dolphin_on_top->isChecked();
+	SConfig::GetInstance().bRenderToMain = m_checkbox_render_to_main_window->isChecked();
+	SConfig::GetInstance().theme_name = m_combobox_theme_selector->currentText().toStdString();
+
+	// In Game Options
+	SConfig::GetInstance().bConfirmStop = m_checkbox_confirm_on_stop->isChecked();
+	SConfig::GetInstance().bUsePanicHandlers = m_checkbox_use_panic_handlers->isChecked();
+	SConfig::GetInstance().bOnScreenDisplayMessages = m_checkbox_enable_osd->isChecked();
+	SConfig::GetInstance().m_PauseOnFocusLost = m_checkbox_pause_on_focus_lost->isChecked();
+	SConfig::GetInstance().bAutoHideCursor = m_checkbox_hide_mouse->isChecked();
+
+	SConfig::GetInstance().SaveSettings();
+}
+
+void InterfacePage::BuildUIOptions()
+{
+	QGroupBox* ui_group = new QGroupBox(tr("User Interface"));
+	QVBoxLayout* ui_group_layout = new QVBoxLayout;
+	ui_group->setLayout(ui_group_layout);
+	m_mainLayout->addWidget(ui_group);
+
+	{
+		QHBoxLayout* theme_layout = new QHBoxLayout;
+		QLabel* theme_label = new QLabel(tr("Theme:"));
+		m_combobox_theme_selector = new QComboBox;
+		auto file_search_results = DoFileSearch({""}, {
+			File::GetUserPath(D_THEMES_IDX),
+			File::GetSysDirectory() + THEMES_DIR
+		}, /*recursive*/ false);
+
+		for (const std::string& filename : file_search_results)
+		{
+			std::string name, ext;
+			SplitPath(filename, nullptr, &name, &ext);
+			name += ext;
+			QString qt_name = QString::fromStdString(name);
+			m_combobox_theme_selector->addItem(qt_name);
+		}
+
+		theme_label->setMaximumWidth(150);
+
+		theme_layout->addWidget(theme_label);
+		theme_layout->addWidget(m_combobox_theme_selector);
+
+		ui_group_layout->addLayout(theme_layout);
+	}
+
+	m_checkbox_auto_adjust_window = new QCheckBox(tr("Auto Adjust Window Size"));
+	m_checkbox_keep_dolphin_on_top = new QCheckBox(tr("Keep Dolphin on Top"));
+	m_checkbox_render_to_main_window = new QCheckBox(tr("Render to Main Window"));
+
+	ui_group_layout->addWidget(m_checkbox_auto_adjust_window);
+	ui_group_layout->addWidget(m_checkbox_keep_dolphin_on_top);
+	ui_group_layout->addWidget(m_checkbox_render_to_main_window);
+}
+
+void InterfacePage::BuildInGameOptions()
+{
+	QGroupBox* in_game_group = new QGroupBox(tr("In Game"));
+	QVBoxLayout* in_game_group_layout = new QVBoxLayout;
+	in_game_group->setLayout(in_game_group_layout);
+	m_mainLayout->addWidget(in_game_group);
+
+	m_checkbox_confirm_on_stop = new QCheckBox(tr("Confirm on Stop"));
+	m_checkbox_use_panic_handlers = new QCheckBox(tr("Use Panic Handlers"));
+	m_checkbox_enable_osd = new QCheckBox(tr("On Screen Messages"));
+	m_checkbox_pause_on_focus_lost = new QCheckBox(tr("Pause on Focus Lost"));
+	m_checkbox_hide_mouse = new QCheckBox(tr("Hide Mouse Cursor"));
+
+	in_game_group_layout->addWidget(m_checkbox_confirm_on_stop);
+	in_game_group_layout->addWidget(m_checkbox_use_panic_handlers);
+	in_game_group_layout->addWidget(m_checkbox_enable_osd);
+	in_game_group_layout->addWidget(m_checkbox_pause_on_focus_lost);
+	in_game_group_layout->addWidget(m_checkbox_hide_mouse);
+}
+
+void InterfacePage::BuildOptions()
+{
+	BuildUIOptions();
+	BuildInGameOptions();
+}
+
+void InterfacePage::ConnectOptions()
+{
+	// UI Options
+	connect(m_checkbox_auto_adjust_window, &QCheckBox::clicked, this, &InterfacePage::SaveConfig);
+	connect(m_checkbox_keep_dolphin_on_top, &QCheckBox::clicked, this, &InterfacePage::SaveConfig);
+	connect(m_checkbox_render_to_main_window, &QCheckBox::clicked, this, &InterfacePage::SaveConfig);
+	connect(m_combobox_theme_selector, static_cast<void(QComboBox::*)(const QString&)>(&QComboBox::activated),
+			[=](const QString& text){ SaveConfig(); });
+	// In Game
+	connect(m_checkbox_confirm_on_stop, &QCheckBox::clicked, this, &InterfacePage::SaveConfig);
+	connect(m_checkbox_use_panic_handlers, &QCheckBox::clicked, this, &InterfacePage::SaveConfig);
+	connect(m_checkbox_enable_osd, &QCheckBox::clicked, this, &InterfacePage::SaveConfig);
+	connect(m_checkbox_pause_on_focus_lost, &QCheckBox::clicked, this, &InterfacePage::SaveConfig);
+	connect(m_checkbox_hide_mouse, &QCheckBox::clicked, this, &InterfacePage::SaveConfig);
+}

--- a/Source/Core/DolphinQt2/Config/Pages/InterfacePage.h
+++ b/Source/Core/DolphinQt2/Config/Pages/InterfacePage.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QWidget>
+
+class QCheckBox;
+class QComboBox;
+class QVBoxLayout;
+
+class InterfacePage final : public QWidget
+{
+	Q_OBJECT
+
+public:
+	explicit InterfacePage(QWidget* parent = nullptr);
+	void LoadConfig();
+
+private slots:
+	void SaveConfig();
+
+private:
+	void ConnectOptions();
+	void BuildOptions();
+	void BuildUIOptions();
+	void BuildInGameOptions();
+	QVBoxLayout* m_mainLayout;
+	QCheckBox* m_checkbox_auto_adjust_window;
+	QCheckBox* m_checkbox_keep_dolphin_on_top;
+	QCheckBox* m_checkbox_render_to_main_window;
+	QComboBox* m_combobox_theme_selector;
+	QCheckBox* m_checkbox_confirm_on_stop;
+	QCheckBox* m_checkbox_use_panic_handlers;
+	QCheckBox* m_checkbox_enable_osd;
+	QCheckBox* m_checkbox_pause_on_focus_lost;
+	QCheckBox* m_checkbox_hide_mouse;
+};

--- a/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
+++ b/Source/Core/DolphinQt2/Config/SettingsWindow.cpp
@@ -4,6 +4,7 @@
 
 #include "DolphinQt2/Settings.h"
 #include "DolphinQt2/Config/SettingsWindow.h"
+#include "DolphinQt2/Config/Pages/InterfacePage.h"
 
 SettingsWindow::SettingsWindow(QWidget* parent)
     : QDialog(parent)
@@ -47,6 +48,7 @@ SettingsWindow::SettingsWindow(QWidget* parent)
 void SettingsWindow::SetupSettingsWidget()
 {
     m_settings_outer = new QStackedWidget;
+    m_settings_outer->addWidget(new InterfacePage);
     m_settings_outer->setCurrentIndex(0);
 }
 
@@ -81,6 +83,8 @@ void SettingsWindow::MakeCategoryList()
     m_categories->setIconSize(QSize(32, 32));
     m_categories->setMovement(QListView::Static);
     m_categories->setSpacing(0);
+
+    AddCategoryToList(tr("Interface"),dir.append(QStringLiteral("browse.png")));
 
     connect(m_categories, &QListWidget::currentItemChanged, this, &SettingsWindow::changePage);
 }

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -56,7 +56,7 @@
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/NODEFAULTLIB:libcmt</AdditionalOptions>
     </Link>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)\VideoInterface;$(ProjectDir)\GameList;$(ProjectDir)\Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\VideoInterface;$(ProjectDir)\GameList;$(ProjectDir)\Config;$(ProjectDir)\Config\Pages;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -80,6 +80,7 @@
     <QtMoc Include="AboutDialog.h" />
     <QtMoc Include="Config\PathDialog.h" />
     <QtMoc Include="Config\SettingsWindow.h" />
+    <QtMoc Include="Config\Pages\InterfacePage.h" />
     <QtMoc Include="GameList\GameFile.h" />
     <QtMoc Include="GameList\GameList.h" />
     <QtMoc Include="GameList\GameListModel.h" />
@@ -101,6 +102,7 @@
     <ClCompile Include="$(QtMocOutPrefix)GameListModel.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GameTracker.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)Host.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)InterfacePage.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ListProxyModel.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MainWindow.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MenuBar.cpp" />
@@ -111,6 +113,7 @@
     <ClCompile Include="$(QtMocOutPrefix)TableDelegate.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ToolBar.cpp" />
     <ClCompile Include="AboutDialog.cpp" />
+    <ClCompile Include="Config\Pages\InterfacePage.cpp" />
     <ClCompile Include="Config\PathDialog.cpp" />
     <ClCompile Include="Config\SettingsWindow.cpp" />
     <ClCompile Include="GameList\GameFile.cpp" />
@@ -205,6 +208,7 @@
     <AllInputFiles Include="@(DataDirFiles);@(ExternalDlls);@(BinaryFiles)" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Config\Pages\InterfacePage.h" />
     <ClInclude Include="Resources.h" />
   </ItemGroup>
   <!--Disable copying to binary dir for now on the buildbot to prevent packaging of the outputs-->

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="$(QtMocOutPrefix)SettingsWindow.cpp">
       <Filter>Generated Files</Filter>
     </ClCompile>
+    <ClCompile Include="Config\Pages\InterfacePage.cpp">
+      <Filter>Config\Pages</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="MainWindow.h" />
@@ -124,8 +127,14 @@
     <Filter Include="Config">
       <UniqueIdentifier>{42f8a963-563e-420d-8aca-5761657dcff5}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Config\Pages">
+      <UniqueIdentifier>{ad229af5-7b02-4a1e-911c-26e02ffba23a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Resources.h" />
+    <ClInclude Include="Config\Pages\InterfacePage.h">
+      <Filter>Config\Pages</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -132,7 +132,13 @@ void Settings::SetStateSlot(int slot)
 
 bool Settings::GetRenderToMain() const
 {
-	return value(QStringLiteral("Graphics/RenderToMain"), false).toBool();
+	return SConfig::GetInstance().bRenderToMain;
+}
+
+void Settings::SetRenderToMain(const bool render)
+{
+	SConfig::GetInstance().bRenderToMain = render;
+	SConfig::GetInstance().SaveSettings();
 }
 
 bool Settings::GetFullScreen() const

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -45,6 +45,7 @@ public:
 
 	// Graphics
 	bool GetRenderToMain() const;
+	void SetRenderToMain(bool render);
 	bool GetFullScreen() const;
 	QSize GetRenderWindowSize() const;
 };


### PR DESCRIPTION
Adds the "Interface" page to the settings dialog.
![screenshot from 2016-05-11 18-18-51](https://cloud.githubusercontent.com/assets/866151/15201335/e0e23360-17a4-11e6-8380-8ffcfc649d58.png)

The UI is complete, but some of the settings do not function properly with the Qt Backend.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3834)

<!-- Reviewable:end -->
