### PR TITLE
Added option to let user accurately emulate sound with speed boost

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -55,7 +55,8 @@ SConfig::SConfig()
   bProgressive(false), bPAL60(false),
   bDisableScreenSaver(false),
   iPosX(100), iPosY(100), iWidth(800), iHeight(600),
-  bLoopFifoReplay(true)
+  bLoopFifoReplay(true),
+  bEmulationSpeedFixAudio(false)
 {
 	LoadDefaults();
 	// Make sure we have log manager
@@ -264,6 +265,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("RunCompareServer", bRunCompareServer);
 	core->Set("RunCompareClient", bRunCompareClient);
 	core->Set("EmulationSpeed", m_EmulationSpeed);
+	core->Set("EmulationSpeedFixAudio", bEmulationSpeedFixAudio);
 	core->Set("FrameSkip", m_FrameSkip);
 	core->Set("Overclock", m_OCFactor);
 	core->Set("OverclockEnable", m_OCEnable);
@@ -529,6 +531,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("FPRF",                      &bFPRF,             false);
 	core->Get("AccurateNaNs",              &bAccurateNaNs,     false);
 	core->Get("EmulationSpeed",            &m_EmulationSpeed,                              1.0f);
+	core->Get("EmulationSpeedFixAudio",    &bEmulationSpeedFixAudio,                       false);
 	core->Get("Overclock",                 &m_OCFactor,                                    1.0f);
 	core->Get("OverclockEnable",           &m_OCEnable,                                    false);
 	core->Get("FrameSkip",                 &m_FrameSkip,                                   0);
@@ -619,6 +622,7 @@ void SConfig::LoadDefaults()
 	bOverrideGCLanguage = false;
 	bWii = false;
 	bDPL2Decoder = false;
+	bEmulationSpeedFixAudio = false;
 	iLatency = 14;
 
 	iPosX = 100;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -197,6 +197,7 @@ struct SConfig : NonCopyable
 	// interface language
 	int m_InterfaceLanguage;
 	float m_EmulationSpeed;
+	bool bEmulationSpeedFixAudio;
 	bool m_OCEnable;
 	float m_OCFactor;
 	// other interface settings

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -102,6 +102,10 @@ static void DSPCallback(u64 userdata, s64 cyclesLate)
 static void AudioDMACallback(u64 userdata, s64 cyclesLate)
 {
 	int period = s_cpu_core_clock / (AudioInterface::GetAIDSampleRate() * 4 / 32);
+	if (SConfig::GetInstance().bEmulationSpeedFixAudio &&
+		SConfig::GetInstance().m_EmulationSpeed != 1.0f)
+		// times 10 divided by 10 greatly reduces crackling
+		period = (period * (int)(SConfig::GetInstance().m_EmulationSpeed * 10)) / 10;
 	DSP::UpdateAudioDMA();  // Push audio to speakers.
 	CoreTiming::ScheduleEvent(period - cyclesLate, et_AudioDMA);
 }

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.h
@@ -33,6 +33,7 @@ private:
 	void OnCheatCheckBoxChanged(wxCommandEvent&);
 	void OnForceNTSCJCheckBoxChanged(wxCommandEvent&);
 	void OnThrottlerChoiceChanged(wxCommandEvent&);
+	void OnThrottlerFixAudioCheckBoxChanged(wxCommandEvent&);
 	void OnCPUEngineRadioBoxChanged(wxCommandEvent&);
 
 	wxArrayString m_throttler_array_string;
@@ -44,6 +45,7 @@ private:
 	wxCheckBox* m_force_ntscj_checkbox;
 
 	wxChoice* m_throttler_choice;
+	wxCheckBox* m_throttler_fix_audio_checkbox;
 
 	wxRadioBox* m_cpu_engine_radiobox;
 };


### PR DESCRIPTION
The higher pitch when boosting FPS annoys me more than the crackling.  I'm sure I'm not the only person who feels the same way.
Also, the feature freeze doesn't apply to this because it's just adding a different workaround to the audio bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3835)
<!-- Reviewable:end -->
