### PR TITLE
Fix window focus detection on Linux

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -554,18 +554,17 @@ void CFrame::OnQuit(wxCommandEvent& WXUNUSED (event))
 // Events
 void CFrame::OnActive(wxActivateEvent& event)
 {
-	if (Core::GetState() == Core::CORE_RUN
-	||  Core::GetState() == Core::CORE_PAUSE)
+	if (Core::GetState() == Core::CORE_RUN || Core::GetState() == Core::CORE_PAUSE)
 	{
 		if (event.GetActive() && event.GetEventObject() == m_RenderFrame)
 		{
-			//gained focus
+			// Gained focus
 			m_bHasFocus = true;
 			if (SConfig::GetInstance().bRenderToMain)
 				m_RenderParent->SetFocus();
 
-			if (SConfig::GetInstance().m_PauseOnFocusLost
-			&&  Core::GetState() == Core::CORE_PAUSE)
+			if (SConfig::GetInstance().m_PauseOnFocusLost &&
+					Core::GetState() == Core::CORE_PAUSE)
 				Core::SetState(Core::CORE_RUN);
 
 			if (SConfig::GetInstance().bHideCursor &&
@@ -574,10 +573,10 @@ void CFrame::OnActive(wxActivateEvent& event)
 		}
 		else
 		{
-			//lost focus
+			// Lost focus
 			m_bHasFocus = false;
-			if (SConfig::GetInstance().m_PauseOnFocusLost
-			&&  Core::GetState() == Core::CORE_RUN)
+			if (SConfig::GetInstance().m_PauseOnFocusLost &&
+					Core::GetState() == Core::CORE_RUN)
 				Core::SetState(Core::CORE_PAUSE);
 
 			if (SConfig::GetInstance().bHideCursor)

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -370,7 +370,8 @@ CFrame::CFrame(wxFrame* parent,
 	, m_LogWindow(nullptr), m_LogConfigWindow(nullptr)
 	, m_FifoPlayerDlg(nullptr), UseDebugger(_UseDebugger)
 	, m_bBatchMode(_BatchMode), m_bEdit(false), m_bTabSplit(false), m_bNoDocking(false)
-	, m_bGameLoading(false), m_bClosing(false), m_confirmStop(false), m_menubar_shadow(nullptr)
+	, m_bGameLoading(false), m_bClosing(false), m_bHasFocus(false), m_confirmStop(false)
+	, m_menubar_shadow(nullptr)
 {
 	for (int i = 0; i <= IDM_CODE_WINDOW - IDM_LOG_WINDOW; i++)
 		bFloatWindow[i] = false;
@@ -553,12 +554,19 @@ void CFrame::OnQuit(wxCommandEvent& WXUNUSED (event))
 // Events
 void CFrame::OnActive(wxActivateEvent& event)
 {
-	if (Core::GetState() == Core::CORE_RUN || Core::GetState() == Core::CORE_PAUSE)
+	if (Core::GetState() == Core::CORE_RUN
+	||  Core::GetState() == Core::CORE_PAUSE)
 	{
 		if (event.GetActive() && event.GetEventObject() == m_RenderFrame)
 		{
+			//gained focus
+			m_bHasFocus = true;
 			if (SConfig::GetInstance().bRenderToMain)
 				m_RenderParent->SetFocus();
+
+			if (SConfig::GetInstance().m_PauseOnFocusLost
+			&&  Core::GetState() == Core::CORE_PAUSE)
+				Core::SetState(Core::CORE_RUN);
 
 			if (SConfig::GetInstance().bHideCursor &&
 					Core::GetState() == Core::CORE_RUN)
@@ -566,9 +574,16 @@ void CFrame::OnActive(wxActivateEvent& event)
 		}
 		else
 		{
+			//lost focus
+			m_bHasFocus = false;
+			if (SConfig::GetInstance().m_PauseOnFocusLost
+			&&  Core::GetState() == Core::CORE_RUN)
+				Core::SetState(Core::CORE_PAUSE);
+
 			if (SConfig::GetInstance().bHideCursor)
 				m_RenderParent->SetCursor(wxNullCursor);
 		}
+		UpdateGUI();
 	}
 	event.Skip();
 }
@@ -837,16 +852,7 @@ bool CFrame::RendererHasFocus()
 	if (m_RenderFrame->GetHWND() == window)
 		return true;
 #else
-	wxWindow *window = wxWindow::FindFocus();
-	if (window == nullptr)
-		return false;
-	// Why these different cases?
-	if (m_RenderParent == window ||
-	    m_RenderParent == window->GetParent() ||
-	    m_RenderParent->GetParent() == window->GetParent())
-	{
-		return true;
-	}
+	return m_bHasFocus;
 #endif
 	return false;
 }
@@ -860,8 +866,7 @@ bool CFrame::UIHasFocus()
 	// focus. If it's not one of our windows, then it will return
 	// null.
 
-	wxWindow *focusWindow = wxWindow::FindFocus();
-	return (focusWindow != nullptr);
+	return m_bHasFocus;
 }
 
 void CFrame::OnGameListCtrlItemActivated(wxListEvent& WXUNUSED(event))
@@ -1127,34 +1132,6 @@ void CFrame::OnMouse(wxMouseEvent& event)
 	event.Skip();
 }
 
-void CFrame::OnFocusChange(wxFocusEvent& event)
-{
-	if (SConfig::GetInstance().m_PauseOnFocusLost && Core::IsRunningAndStarted())
-	{
-		if (RendererHasFocus())
-		{
-			if (Core::GetState() == Core::CORE_PAUSE)
-			{
-				Core::SetState(Core::CORE_RUN);
-				if (SConfig::GetInstance().bHideCursor)
-					m_RenderParent->SetCursor(wxCURSOR_BLANK);
-			}
-		}
-		else
-		{
-			if (Core::GetState() == Core::CORE_RUN)
-			{
-				Core::SetState(Core::CORE_PAUSE);
-				if (SConfig::GetInstance().bHideCursor)
-					m_RenderParent->SetCursor(wxNullCursor);
-				Core::UpdateTitle();
-			}
-		}
-		UpdateGUI();
-	}
-
-	event.Skip();
-}
 
 void CFrame::DoFullscreen(bool enable_fullscreen)
 {

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -166,6 +166,7 @@ private:
 	bool m_bNoDocking;
 	bool m_bGameLoading;
 	bool m_bClosing;
+	bool m_bHasFocus;
 	bool m_confirmStop;
 
 	std::vector<std::string> drives;
@@ -309,8 +310,6 @@ private:
 
 	void OnKeyDown(wxKeyEvent& event); // Keyboard
 	void OnMouse(wxMouseEvent& event); // Mouse
-
-	void OnFocusChange(wxFocusEvent& event);
 
 	void OnHostMessage(wxCommandEvent& event);
 

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1045,8 +1045,6 @@ void CFrame::StartGame(const std::string& filename)
 		wxTheApp->Bind(wxEVT_MIDDLE_DOWN,  &CFrame::OnMouse,       this);
 		wxTheApp->Bind(wxEVT_MIDDLE_UP,    &CFrame::OnMouse,       this);
 		wxTheApp->Bind(wxEVT_MOTION,       &CFrame::OnMouse,       this);
-		wxTheApp->Bind(wxEVT_SET_FOCUS,    &CFrame::OnFocusChange, this);
-		wxTheApp->Bind(wxEVT_KILL_FOCUS,   &CFrame::OnFocusChange, this);
 		m_RenderParent->Bind(wxEVT_SIZE, &CFrame::OnRenderParentResize, this);
 	}
 


### PR DESCRIPTION
Wx focus events seem to be relating to widgets within the window; we want activate events. This fixes Dolphin thinking it always has focus in some environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3843)
<!-- Reviewable:end -->
