### PR TITLE
VideoSoftware: Implement xfb copy filter (Deflickering/Brightness)

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbCopy.cpp
+++ b/Source/Core/VideoBackends/Software/EfbCopy.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <array>
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
@@ -22,14 +24,19 @@ static const float s_gammaLUT[] =
 
 namespace EfbCopy
 {
-	static void CopyToXfb(u32 xfbAddr, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc, float Gamma)
+	static void CopyToXfb(u32 xfbAddr, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc,
+                          bool clamp_top, bool clamp_bottom, float Gamma, const std::array<u8, 7> &filterCoefficients)
 	{
-		INFO_LOG(VIDEO, "xfbaddr: %x, fbwidth: %i, fbheight: %i, source: (%i, %i, %i, %i), Gamma %f",
-				 xfbAddr, fbWidth, fbHeight, sourceRc.top, sourceRc.left, sourceRc.bottom, sourceRc.right, Gamma);
+		INFO_LOG(VIDEO, "xfbaddr: %x, fbwidth: %i, fbheight: %i, source: (%i, %i, %i, %i), clamp_top: %s,"
+		         "clamp bottom: %s, Gamma %f, filterCoefficents: (%i, %i, %i, %i, %i, %i, %i)",
+		         xfbAddr, fbWidth, fbHeight, sourceRc.top, sourceRc.left, sourceRc.bottom, sourceRc.right,
+		         clamp_top ? "yes" : "no", clamp_bottom ? "yes" : "no", Gamma, filterCoefficients[0],
+		         filterCoefficients[1], filterCoefficients[2], filterCoefficients[3], filterCoefficients[4],
+		         filterCoefficients[5], filterCoefficients[6]);
 
 		EfbInterface::yuv422_packed* xfb_in_ram = (EfbInterface::yuv422_packed*) Memory::GetPointer(xfbAddr);
 
-		EfbInterface::CopyToXFB(xfb_in_ram, fbWidth, fbHeight, sourceRc, Gamma);
+		EfbInterface::CopyToXFB(xfb_in_ram, fbWidth, fbHeight, sourceRc, clamp_top, clamp_bottom, Gamma, filterCoefficients);
 	}
 
 	static void CopyToRam()
@@ -91,10 +98,13 @@ namespace EfbCopy
 				}
 
 				CopyToXfb(bpmem.copyTexDest << 5,
-						  bpmem.copyMipMapStrideChannels << 4,
-						  (u32)xfbLines,
-						  rc,
-						  s_gammaLUT[bpmem.triggerEFBCopy.gamma]);
+				          bpmem.copyMipMapStrideChannels << 4,
+				          (u32)xfbLines,
+				          rc,
+				          !!bpmem.triggerEFBCopy.clamp_top,
+				          !!bpmem.triggerEFBCopy.clamp_bottom,
+				          s_gammaLUT[bpmem.triggerEFBCopy.gamma],
+				          bpmem.copyfilter.GetCoefficients()); // TODO: Is this filter also used for the non-xfb copies.
 			}
 			else
 			{

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <array>
 
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
@@ -475,12 +476,30 @@ namespace EfbInterface
 		GetPixelColor(offset, color);
 	}
 
-	// For internal used only, return a non-normalized value, which saves work later.
-	void GetColorYUV(u16 x, u16 y, yuv444 *out)
+	static void VerticalFilter(u8 colors[3][4], const std::array<u8, 7> &filterCoefficients, u8 *out)
 	{
-		u8 color[4];
-		GetColor(x, y, color);
+		// All Coefficients should sum to 64, otherwise the total brightness will change, which many games do
+		// on purpose to implement a brightness filter across the whole copy.
+		for (int i = BLU_C; i <= RED_C; i++)
+		{
+			// TODO: implement support for multisampling.
+			// In non-multisampling mode:
+			//   * Coefficients 2, 3 and 4 sample from the current pixel.
+			//   * Coefficients 0 and 1 sample from the pixel above this one
+			//   * Coefficients 5 and 6 sample from the pixel below this one
 
+			int sum = colors[0][i] * (filterCoefficients[0] + filterCoefficients[1]) +
+			          colors[1][i] * (filterCoefficients[2] + filterCoefficients[3] + filterCoefficients[4]) +
+			          colors[2][i] * (filterCoefficients[5] + filterCoefficients[6]);
+
+			// TODO: this clamping behavior appears to be correct, but isn't confirmed on hardware.
+			out[i] = std::min(255, sum >> 6); // clamp larger values to 255
+		}
+	}
+
+	// For internal used only, return a non-normalized value, which saves work later.
+	static void ConvertColorToYUV(u8 *color, yuv444 *out)
+	{
 		// GameCube/Wii uses the BT.601 standard algorithm for converting to YCbCr; see
 		// http://www.equasys.de/colorconversion.html#YCbCr-RGBColorFormatConversion
 		out->Y = (u8)( 0.257f * color[RED_C] +  0.504f * color[GRN_C] +  0.098f * color[BLU_C]);
@@ -501,7 +520,7 @@ namespace EfbInterface
 		return &efb[GetColorOffset(x, y)];
 	}
 
-	void CopyToXFB(yuv422_packed* xfb_in_ram, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc, float Gamma)
+	void CopyToXFB(yuv422_packed* xfb_in_ram, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc, bool clamp_top, bool clamp_bottom, float Gamma, const std::array<u8, 7> &filterCoefficients)
 	{
 		// FIXME: We should do Gamma correction
 
@@ -536,14 +555,34 @@ namespace EfbInterface
 
 		for (u16 y = sourceRc.top; y < sourceRc.bottom; y++)
 		{
-			// Get a scanline of YUV pixels in 4:4:4 format
+			// Clamping behavior
+			//   NOTE: when the clamp bits aren't set, the hardware will happily read beyond the EFB,
+			//         which returns random garbage from the empty bus (confirmed by hardware tests).
+			//
+			//         In our implementation, the garbage just so happens to be the top or bottom row.
+			//         Statistically, that could happen.
+			u16 y_prev = std::max<u16>(clamp_top ? sourceRc.top : 0, y - 1);
+			u16 y_next = std::min<u16>(clamp_bottom ? sourceRc.bottom : EFB_HEIGHT, y + 1);
 
+			// Get a scanline of YUV pixels in 4:4:4 format
 			for (int i = 1, x = left; x < right; i++, x++)
 			{
-				GetColorYUV(x, y, &scanline[i]);
+				// Get RGB colors
+				u8 colors[3][4];
+				GetColor(x, y_prev, colors[0]);
+				GetColor(x, y,      colors[1]);
+				GetColor(x, y_next, colors[2]);
+
+				// Vertical Filter (Multisampling resolve, deflicker, brightness)
+				u8 filtered[4];
+				VerticalFilter(colors, filterCoefficients, filtered);
+
+				// TODO: Gamma correction happens here.
+
+				ConvertColorToYUV(filtered, &scanline[i]);
 			}
 
-			// And Downsample them to 4:2:2
+			// And downsample them to 4:2:2
 			for (int i = 1, x = left; x < right; i+=2, x+=2)
 			{
 				// YU pixel
@@ -557,6 +596,9 @@ namespace EfbInterface
 				// V[i] = 1/4 * V[i-1] + 1/2 * V[i] + 1/4 * V[i+1]
 				xfb_in_ram[x+1].UV = 128 + ((scanline[i].V + (scanline[i+1].V << 1) + scanline[i+2].V) >> 2);
 			}
+
+			// TODO: Vertical scaling happens here (after downsampling, before writing to ram)
+
 			xfb_in_ram += fbWidth;
 		}
 	}

--- a/Source/Core/VideoBackends/Software/EfbInterface.h
+++ b/Source/Core/VideoBackends/Software/EfbInterface.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "Common/CommonTypes.h"
 #include "VideoCommon/PerfQueryBase.h"
 #include "VideoCommon/VideoCommon.h"
@@ -52,12 +54,12 @@ namespace EfbInterface
 	void SetDepth(u16 x, u16 y, u32 depth);
 
 	void GetColor(u16 x, u16 y, u8 *color);
-	void GetColorYUV(u16 x, u16 y, yuv444 *color);
 	u32 GetDepth(u16 x, u16 y);
 
 	u8* GetPixelPointer(u16 x, u16 y, bool depth);
 
-	void CopyToXFB(yuv422_packed* xfb_in_ram, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc, float Gamma);
+	void CopyToXFB(yuv422_packed* xfb_in_ram, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc,
+	               bool clamp_top, bool clamp_bottom, float Gamma, const std::array<u8, 7> &filterCoefficients);
 	void BypassXFB(u8* texture, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc, float Gamma);
 
 	extern u32 perf_values[PQ_NUM_MEMBERS];

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 
 #include "Common/BitField.h"
@@ -993,8 +994,8 @@ union UPE_Copy
 {
 	u32 Hex;
 
-	BitField< 0,1,u32> clamp0;               // if set clamp top
-	BitField< 1,1,u32> clamp1;               // if set clamp bottom
+	BitField< 0,1,u32> clamp_top;               // if set clamp top
+	BitField< 1,1,u32> clamp_bottom;               // if set clamp bottom
 	BitField< 2,1,u32> yuv;                  // if set, color conversion from RGB to YUV
 	BitField< 3,4,u32> target_pixel_format;  // realformat is (fmt/2)+((fmt&1)*8).... for some reason the msb is the lsb (pattern: cycling right shift)
 	BitField< 7,2,u32> gamma;                // gamma correction.. 0 = 1.0 ; 1 = 1.7 ; 2 = 2.2 ; 3 is reserved
@@ -1009,6 +1010,32 @@ union UPE_Copy
 	u32 tp_realFormat()
 	{
 		return target_pixel_format / 2 + (target_pixel_format & 1) * 8;
+	}
+};
+
+union CopyFilterCoefficients
+{
+	u64 Hex;
+
+	BitField< 0, 6, u64> w0;
+	BitField< 6, 6, u64> w1;
+	BitField<12, 6, u64> w2;
+	BitField<18, 6, u64> w3;
+	BitField<32, 6, u64> w4;
+	BitField<38, 6, u64> w5;
+	BitField<44, 6, u64> w6;
+
+	std::array<u8, 7> GetCoefficients() const
+	{
+		return {
+			static_cast<u8>(w0),
+			static_cast<u8>(w1),
+			static_cast<u8>(w2),
+			static_cast<u8>(w3),
+			static_cast<u8>(w4),
+			static_cast<u8>(w5),
+			static_cast<u8>(w6),
+		};
 	}
 };
 
@@ -1085,7 +1112,7 @@ struct BPMemory
 	u32 clearcolorGB; //50
 	u32 clearZValue; //51
 	UPE_Copy triggerEFBCopy; //52
-	u32 copyfilter[2]; //53,54
+	CopyFilterCoefficients copyfilter; //53,54
 	u32 boundbox0;//55
 	u32 boundbox1;//56
 	u32 unknown7[2];//57,58

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -1005,7 +1005,7 @@ void GetBPRegInfo(const u8* data, std::string* name, std::string* desc)
 			                         "Copy to XFB: %s\n"
 			                         "Intensity format: %s\n"
 			                         "Automatic color conversion: %s",
-			                         (copy.clamp0 && copy.clamp1) ? "Top and Bottom" : (copy.clamp0) ? "Top only" : (copy.clamp1) ? "Bottom only" : "None",
+			                         (copy.clamp_top && copy.clamp_bottom) ? "Top and Bottom" : (copy.clamp_top) ? "Top only" : (copy.clamp_bottom) ? "Bottom only" : "None",
 			                         no_yes[copy.yuv],
 			                         copy.tp_realFormat(),
 			                         (copy.gamma==0)?"1.0":(copy.gamma==1)?"1.7":(copy.gamma==2)?"2.2":"Invalid value 0x3?",


### PR DESCRIPTION
The Copy filter does 3 things.

**1)** Resolve the Multisampled framebuffer. Games can specify 7 coefficients, the 3 samples from the current pixel, and two samples from the pixels above and below. 
Since dolphin hasn't implemented Multisampling, even in video software, I haven't implemented this fully.

When games aren't using the multisampling mode, the 3 middle coefficients all point at the current pixel, while the upper/lower coefficients also point at a single upper or lower pixel.

**2)** Deflicker filter. The game does a vertical blur across 3 lines, blending the odd and even fields together which minimises the flickering effect inherent to 480i consoles on interlaced TVs.
This is why 99.9% of games render all 480 lines each frame even when rendering at 60fps.

The filter is counter-productive for progressive displays, which is why dolphin hasn't implemented it before now, though it does blur away the dither pattern. 

When we implement this in the hardware backends, we can add an enhancement which points all 7 coefficients at the middle pixel, forcing the deflicker filter off.

**3)** Brightness filter. You are meant to choose coefficients that add up to 64. But some games cleverly break this rule to create a brightness filter. Resident Evil 4 uses this to implement a global brightness slider option, while other (Rogue Squadron 3?, mario galaxy?) games use it to implement a fade to black effect.

If it wasn't for **3**, there would be little reason to implement this, except so users of melee/brawl could see the deflicker on/off option in action. 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3845)

<!-- Reviewable:end -->
