### PR TITLE
VideoSW: Fix XFB config.

### DIFF
--- a/Source/Core/DolphinWX/SoftwareVideoConfigDialog.cpp
+++ b/Source/Core/DolphinWX/SoftwareVideoConfigDialog.cpp
@@ -35,7 +35,7 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
 	wxDialog(parent, wxID_ANY,
 	wxString(wxString::Format(_("Dolphin %s Graphics Configuration"), title)))
 {
-	VideoConfig& vconfig = g_ActiveConfig;
+	VideoConfig& vconfig = g_Config;
 
 	if (File::Exists(File::GetUserPath(D_CONFIG_IDX) + "GFX.ini"))
 		vconfig.Load(File::GetUserPath(D_CONFIG_IDX) + "GFX.ini");
@@ -139,5 +139,5 @@ SoftwareVideoConfigDialog::SoftwareVideoConfigDialog(wxWindow* parent, const std
 
 SoftwareVideoConfigDialog::~SoftwareVideoConfigDialog()
 {
-	g_ActiveConfig.Save((File::GetUserPath(D_CONFIG_IDX) + "GFX.ini").c_str());
+	g_Config.Save((File::GetUserPath(D_CONFIG_IDX) + "GFX.ini").c_str());
 }

--- a/Source/Core/VideoBackends/Software/EfbCopy.cpp
+++ b/Source/Core/VideoBackends/Software/EfbCopy.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include "Common/CommonTypes.h"
-#include "Common/GL/GLInterfaceBase.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
 #include "VideoBackends/Software/EfbCopy.h"
@@ -25,8 +24,6 @@ namespace EfbCopy
 {
 	static void CopyToXfb(u32 xfbAddr, u32 fbWidth, u32 fbHeight, const EFBRectangle& sourceRc, float Gamma)
 	{
-		GLInterface->Update(); // update the render window position and the backbuffer size
-
 		INFO_LOG(VIDEO, "xfbaddr: %x, fbwidth: %i, fbheight: %i, source: (%i, %i, %i, %i), Gamma %f",
 				 xfbAddr, fbWidth, fbHeight, sourceRc.top, sourceRc.left, sourceRc.bottom, sourceRc.right, Gamma);
 

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -152,6 +152,10 @@ void SWRenderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, 
 	SWOGLWindow::s_instance->ShowImage(GetCurrentColorTexture(), fbWidth * 4, fbWidth, fbHeight, 1.0);
 
 	UpdateActiveConfig();
+
+	// virtual XFB is not supported
+	if (g_ActiveConfig.bUseXFB)
+		g_ActiveConfig.bUseRealXFB = true;
 }
 
 u32 SWRenderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)


### PR DESCRIPTION
g_ActiveConfig is overwritten per frame, so we need to configure g_Config. Also force-disable virtual XFB as it's not supported within VideoSW.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3846)
<!-- Reviewable:end -->
