### PR TITLE
GLExtensions: Fix OpenGL ES 3.2 handling.

### DIFF
--- a/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
@@ -1977,10 +1977,11 @@ const GLFunc gl_function_array[] =
 	GLFUNC_SUFFIX(glMultiDrawElementsBaseVertex,     EXT, "GL_EXT_draw_elements_base_vertex GL_EXT_multi_draw_arrays !GL_OES_draw_elements_base_vertex !VERSION_GLES_3_2"),
 
 	// ARB_sample_shading
-	GLFUNC_SUFFIX(glMinSampleShading, ARB, "GL_ARB_sample_shading |VERSION_GLES_3_2"),
+	GLFUNC_SUFFIX(glMinSampleShading, ARB, "GL_ARB_sample_shading"),
 
 	// OES_sample_shading
 	GLFUNC_SUFFIX(glMinSampleShading, OES, "GL_OES_sample_shading !VERSION_GLES_3_2"),
+	GLFUNC_REQUIRES(glMinSampleShading,    "VERSION_GLES_3_2"),
 
 	// ARB_debug_output
 	GLFUNC_REQUIRES(glDebugMessageCallbackARB, "GL_ARB_debug_output"),


### PR DESCRIPTION
glMinSampleShading has no extension on ES3.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3848)
<!-- Reviewable:end -->
