### PR TITLE
Movie: Better safety when writing to s_revision

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <mutex>
 #include <mbedtls/config.h>
 #include <mbedtls/md.h>
@@ -1329,12 +1330,16 @@ void GetSettings()
 		g_bClearSave = !File::Exists(SConfig::GetInstance().m_strMemoryCardA);
 	s_memcards |= (SConfig::GetInstance().m_EXIDevice[0] == EXIDEVICE_MEMORYCARD) << 0;
 	s_memcards |= (SConfig::GetInstance().m_EXIDevice[1] == EXIDEVICE_MEMORYCARD) << 1;
+
 	unsigned int tmp;
-	for (size_t i = 0; i < scm_rev_git_str.size() / 2 ; ++i)
+	memset(s_revision, 0, sizeof(s_revision));
+	size_t revision_bytes_to_copy = std::min(scm_rev_git_str.size() / 2, ArraySize(s_revision));
+	for (size_t i = 0; i < revision_bytes_to_copy; ++i)
 	{
 		sscanf(&scm_rev_git_str[2 * i], "%02x", &tmp);
 		s_revision[i] = tmp;
 	}
+
 	if (!s_bDSPHLE)
 	{
 		std::string irom_file = File::GetUserPath(D_GCUSER_IDX) + DSP_IROM;


### PR DESCRIPTION
PR #3815 introduced safety problems with `s_revision` when fixing safety problems with `scm_rev_git_str`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3851)
<!-- Reviewable:end -->
