### PR TITLE
JitArm64: Implement MMU handling.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -467,6 +467,7 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 		js.compilerPC = ops[i].address;
 		js.op = &ops[i];
 		js.instructionNumber = i;
+		js.instructionsLeft = (code_block.m_num_instructions - 1) - i;
 		const GekkoOPInfo *opinfo = ops[i].opinfo;
 		js.downcountAmount += opinfo->numCycles;
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -615,7 +615,8 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 
 	if (code_block.m_broken)
 	{
-		printf("Broken Block going to 0x%08x\n", nextPC);
+		gpr.Flush(FLUSH_ALL);
+		fpr.Flush(FLUSH_ALL);
 		WriteExit(nextPC);
 	}
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -364,15 +364,9 @@ void JitArm64::Jit(u32)
 	{
 		ClearCache();
 	}
-	int block_num = blocks.AllocateBlock(PowerPC::ppcState.pc);
-	JitBlock *b = blocks.GetBlock(block_num);
-	const u8* BlockPtr = DoJit(PowerPC::ppcState.pc, &code_buffer, b);
-	blocks.FinalizeBlock(block_num, jo.enableBlocklink, BlockPtr);
-}
 
-const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlock *b)
-{
-	int blockSize = code_buf->GetSize();
+	int blockSize = code_buffer.GetSize();
+	u32 em_address = PowerPC::ppcState.pc;
 
 	if (SConfig::GetInstance().bEnableDebugging)
 	{
@@ -380,6 +374,28 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 		blockSize = 1;
 	}
 
+	// Analyze the block, collect all instructions it is made of (including inlining,
+	// if that is enabled), reorder instructions for optimal performance, and join joinable instructions.
+	u32 nextPC = analyzer.Analyze(em_address, &code_block, &code_buffer, blockSize);
+
+	if (code_block.m_memory_exception)
+	{
+		// Address of instruction could not be translated
+		NPC = nextPC;
+		PowerPC::ppcState.Exceptions |= EXCEPTION_ISI;
+		PowerPC::CheckExceptions();
+		WARN_LOG(POWERPC, "ISI exception at 0x%08x", nextPC);
+		return;
+	}
+
+	int block_num = blocks.AllocateBlock(em_address);
+	JitBlock *b = blocks.GetBlock(block_num);
+	const u8* BlockPtr = DoJit(em_address, &code_buffer, b, nextPC);
+	blocks.FinalizeBlock(block_num, jo.enableBlocklink, BlockPtr);
+}
+
+const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlock *b, u32 nextPC)
+{
 	if (em_address == 0)
 	{
 		Core::SetState(Core::CORE_PAUSE);
@@ -394,11 +410,6 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 	js.downcountAmount = 0;
 	js.skipInstructions = 0;
 	js.curBlock = b;
-
-	u32 nextPC = em_address;
-	// Analyze the block, collect all instructions it is made of (including inlining,
-	// if that is enabled), reorder instructions for optimal performance, and join joinable instructions.
-	nextPC = analyzer.Analyze(em_address, &code_block, code_buf, blockSize);
 
 	PPCAnalyst::CodeOp *ops = code_buf->codebuffer;
 
@@ -601,9 +612,6 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitB
 		i += js.skipInstructions;
 		js.skipInstructions = 0;
 	}
-
-	if (code_block.m_memory_exception)
-		BRK(0x500);
 
 	if (code_block.m_broken)
 	{

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -221,7 +221,7 @@ private:
 	void SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 offset, bool update);
 	void SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s32 offset);
 
-	const u8* DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlock *b);
+	const u8* DoJit(u32 em_address, PPCAnalyst::CodeBuffer *code_buf, JitBlock *b, u32 nextPC);
 
 	void DoDownCount();
 	void Cleanup();

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -446,11 +446,11 @@ void JitArm64::lXX(UGeckoInstruction inst)
 
 	// LWZ idle skipping
 	if (SConfig::GetInstance().bSkipIdle &&
-	    inst.OPCD == 32 &&
-	    (inst.hex & 0xFFFF0000) == 0x800D0000 &&
-	    (PowerPC::HostRead_U32(js.compilerPC + 4) == 0x28000000 ||
-	    (SConfig::GetInstance().bWii && PowerPC::HostRead_U32(js.compilerPC + 4) == 0x2C000000)) &&
-	    PowerPC::HostRead_U32(js.compilerPC + 8) == 0x4182fff8)
+	    inst.OPCD == 32 && MergeAllowedNextInstructions(2) &&
+	    (inst.hex & 0xFFFF0000) == 0x800D0000 && // lwz r0, XXXX(r13)
+	    (js.op[1].inst.hex == 0x28000000 ||
+	    (SConfig::GetInstance().bWii && js.op[1].inst.hex == 0x2C000000)) && // cmpXwi r0,0
+	    js.op[2].inst.hex == 0x4182fff8) // beq -8
 	{
 		// if it's still 0, we can wait until the next event
 		FixupBranch noIdle = CBNZ(gpr.R(d));

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -375,6 +375,7 @@ void JitArm64::lXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITLoadStoreOff);
+	FALLBACK_IF(jo.memcheck);
 
 	u32 a = inst.RA, b = inst.RB, d = inst.RD;
 	s32 offset = inst.SIMM_16;
@@ -480,6 +481,7 @@ void JitArm64::stX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITLoadStoreOff);
+	FALLBACK_IF(jo.memcheck);
 
 	u32 a = inst.RA, b = inst.RB, s = inst.RS;
 	s32 offset = inst.SIMM_16;
@@ -557,7 +559,7 @@ void JitArm64::lmw(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITLoadStoreOff);
-	FALLBACK_IF(!jo.fastmem);
+	FALLBACK_IF(!jo.fastmem || jo.memcheck);
 
 	u32 a = inst.RA;
 
@@ -643,7 +645,7 @@ void JitArm64::stmw(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITLoadStoreOff);
-	FALLBACK_IF(!jo.fastmem);
+	FALLBACK_IF(!jo.fastmem || jo.memcheck);
 
 	u32 a = inst.RA;
 
@@ -803,6 +805,7 @@ void JitArm64::dcbz(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITLoadStoreOff);
+	FALLBACK_IF(jo.memcheck);
 
 	int a = inst.RA, b = inst.RB;
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStoreFloating.cpp
@@ -23,6 +23,7 @@ void JitArm64::lfXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITLoadStoreFloatingOff);
+	FALLBACK_IF(jo.memcheck);
 
 	u32 a = inst.RA, b = inst.RB;
 
@@ -210,6 +211,7 @@ void JitArm64::stfXX(UGeckoInstruction inst)
 {
 	INSTRUCTION_START
 	JITDISABLE(bJITLoadStoreFloatingOff);
+	FALLBACK_IF(jo.memcheck);
 
 	u32 a = inst.RA, b = inst.RB;
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -57,7 +57,7 @@ void JitArm64::mtmsr(UGeckoInstruction inst)
 	gpr.Flush(FlushMode::FLUSH_ALL);
 	fpr.Flush(FlushMode::FLUSH_ALL);
 
-	WriteExit(js.compilerPC + 4);
+	WriteExceptionExit(js.compilerPC + 4, true);
 }
 
 void JitArm64::mfmsr(UGeckoInstruction inst)

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -46,6 +46,8 @@ void JitArm64::GenerateAsm()
 
 		dispatcherNoCheck = GetCodePtr();
 
+		STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
+
 		// This block of code gets the address of the compiled block of code
 		// It runs though to the compiling portion if it isn't found
 		BFM(DISPATCHER_PC, WSP, 3, 2); // Wipe the top 3 bits. Same as PC & JIT_ICACHE_MASK
@@ -63,10 +65,10 @@ void JitArm64::GenerateAsm()
 
 		SetJumpTarget(JitBlock);
 
-		STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
-
 		MOVI2R(X30, (u64)&::Jit);
 		BLR(X30);
+
+		LDR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
 
 		B(dispatcherNoCheck);
 


### PR DESCRIPTION
This PR implements ISI & DSI exceptions. It also fixes the dispatcher for vmem and exmem.

Performance impact with disabled MMU is minimal, with enabled MMU, all load/store instructions fall back to interpreter.

RS2 boots fine on my shield, and I get 15 fps ingame :D

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3854)
<!-- Reviewable:end -->
