### PR TITLE
[Android] Fix extra character in screenshot folder path

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/Game.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/Game.java
@@ -27,7 +27,7 @@ public final class Game
 	public static final int COUNTRY_WORLD = 12;
 	public static final int COUNTRY_UNKNOWN = 13;
 
-	private static final String PATH_SCREENSHOT_FOLDER = Environment.getExternalStorageDirectory().getPath() + "/dolphin-emu/ScreenShots/";
+	private static final String PATH_SCREENSHOT_FOLDER = Environment.getExternalStorageDirectory().getPath() + "dolphin-emu/ScreenShots/";
 
 	private String mTitle;
 	private String mDescription;


### PR DESCRIPTION
Environment.getExternalStorageDirectory().getPath() covers the end of the path with a slash, get rid of the extra slash to fix the path.

Fixes https://bugs.dolphin-emu.org/issues/9560

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3855)
<!-- Reviewable:end -->
