### PR TITLE
[Android] Fix builds when using newest version of NDK

### DIFF
--- a/Source/Core/Common/GL/GLInterface/EGLAndroid.h
+++ b/Source/Core/Common/GL/GLInterface/EGLAndroid.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <android/native_window.h>
 #include "Common/GL/GLInterface/EGL.h"
 
 class cInterfaceEGLAndroid : public cInterfaceEGL


### PR DESCRIPTION
Building for Android using a recent NDK fails without this include. Haven't tried it on the NDK version our CI uses, but it probably works. Only one way to find out, right?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3862)
<!-- Reviewable:end -->
