### PR TITLE
Change Bluetooth device discovery on Linux to use LIAC (updated #3327)

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IONix.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IONix.cpp
@@ -12,7 +12,6 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-#include "Core/HW/WiimoteEmu/WiimoteHid.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 
 namespace WiimoteReal
@@ -22,6 +21,7 @@ class WiimoteLinux final : public Wiimote
 public:
   WiimoteLinux(bdaddr_t bdaddr);
   ~WiimoteLinux() override;
+  const bdaddr_t& Address() const;
 
 protected:
   bool ConnectInternal() override;
@@ -82,10 +82,13 @@ void WiimoteScanner::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wiimote
   inquiry_info scan_infos[max_infos] = {};
   auto* scan_infos_ptr = scan_infos;
   found_board = nullptr;
+  // Use Limited Dedicated Inquiry Access Code (LIAC) to query, since third-party Wiimotes
+  // cannot be discovered without it.
+  const u8 lap[3] = {0x00, 0x8b, 0x9e};
 
   // Scan for Bluetooth devices
   int const found_devices =
-      hci_inquiry(device_id, wait_len, max_infos, nullptr, &scan_infos_ptr, IREQ_CACHE_FLUSH);
+      hci_inquiry(device_id, wait_len, max_infos, lap, &scan_infos_ptr, IREQ_CACHE_FLUSH);
   if (found_devices < 0)
   {
     ERROR_LOG(WIIMOTE, "Error searching for Bluetooth devices.");
@@ -112,14 +115,16 @@ void WiimoteScanner::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wiimote
     {
       bool new_wiimote = true;
 
-      // TODO: do this
-
       // Determine if this Wiimote has already been found.
-      // for (int j = 0; j < MAX_WIIMOTES && new_wiimote; ++j)
-      //{
-      //	if (wm[j] && bacmp(&scan_infos[i].bdaddr,&wm[j]->bdaddr) == 0)
-      //		new_wiimote = false;
-      //}
+      for (int j = 0; j < MAX_BBMOTES && new_wiimote; ++j)
+      {
+        // compare this address with the stored addresses in our global array
+        // static_cast is OK here, since we're only ever going to have this subclass in g_wiimotes
+        // on Linux (and likewise, only WiimoteWindows on Windows, etc)
+        auto connected_wiimote = static_cast<WiimoteLinux*>(g_wiimotes[j]);
+        if (connected_wiimote && bacmp(&scan_infos[i].bdaddr, &connected_wiimote->Address()) == 0)
+          new_wiimote = false;
+      }
 
       if (new_wiimote)
       {
@@ -163,6 +168,11 @@ WiimoteLinux::~WiimoteLinux()
   Shutdown();
   close(m_wakeup_pipe_w);
   close(m_wakeup_pipe_r);
+}
+
+const bdaddr_t& WiimoteLinux::Address() const
+{
+  return m_bdaddr;
 }
 
 // Connect to a Wiimote with a known address.


### PR DESCRIPTION
This is basically an updated version of #3327; since it seemed to be abandoned and was not building anymore, I updated it with the suggested changes from code review, a compiler warning fix and some formatting fixes. And the build fix too. Of course, credits go to bryangrim. As for testing, I tried it and it worked for my DBPower 3rd party Wiimote too, just like it would work with an official Wiimote.

Original description:

>Changed Bluetooth device discovery on Linux to use LIAC (Limited
>Dedicated Inquiry Access Code) since third-party Wiimotes (such as Rock
>Candy Wiimotes) are not discovered without it.
>
>Also added accessor function in IONix class to help with checking if
>the discovered Wiimote has already been found.
>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3865)
<!-- Reviewable:end -->
