### PR TITLE
Provide better scmrev defaults without .git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,14 @@ else()
 	set(DOLPHIN_VERSION_PATCH ${DOLPHIN_WC_REVISION})
 endif()
 
+# If Dolphin is not built from a Git repository, default the version info to
+# reasonable values.
+if(NOT DOLPHIN_WC_REVISION)
+	set(DOLPHIN_WC_DESCRIBE "${DOLPHIN_VERSION_MAJOR}.${DOLPHIN_VERSION_MINOR}")
+	set(DOLPHIN_WC_REVISION "${DOLPHIN_WC_DESCRIBE} (no further info)")
+	set(DOLPHIN_WC_BRANCH "master")
+endif()
+
 # Architecture detection and arch specific settings
 message(${CMAKE_SYSTEM_PROCESSOR})
 


### PR DESCRIPTION
Use the default values from CMakeLists.txt (previously used for CPack). We
usually update these when tagging a new major version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3869)
<!-- Reviewable:end -->
