### PR TITLE
[OGL] Workaround nvidia being weird with GL_MAX_TEXTURE_SIZE

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -52,7 +52,7 @@ void VideoConfig::UpdateProjectionHack()
 }
 
 static int OSDInternalW, OSDInternalH;
-static int s_max_texture_size;
+static int s_max_texture_size = 0;
 
 namespace OGL
 {
@@ -711,9 +711,6 @@ void Renderer::Init()
 	s_raster_font = std::make_unique<RasterFont>();
 
 	OpenGL_CreateAttributelessVAO();
-
-	// Cache this, because if you do this multiple times a frame, it shows up really high on a profile.
-	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &s_max_texture_size);
 }
 
 void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
@@ -1702,6 +1699,10 @@ bool Renderer::SaveScreenshot(const std::string &filename, const TargetRectangle
 
 int Renderer::GetMaxTextureSize()
 {
+	// Right now nvidia seems to do something very weird if we try to cache GL_MAX_TEXTURE_SIZE in init. This is a workaround that lets
+	// us keep the perf improvement that caching it gives us.
+	if (s_max_texture_size == 0)
+		glGetIntegerv(GL_MAX_TEXTURE_SIZE, &s_max_texture_size);
 	return s_max_texture_size;
 }
 


### PR DESCRIPTION
Fixes blocker https://bugs.dolphin-emu.org/issues/9575 - please tag this as appropriate

So, after troubleshooting with @phire, we came to the realization that nvidia was doing something strange with fetching GL_MAX_TEXTURE_SIZE during Init() that caused it to break Gecko OS (Probably others as well) on Optimus hardware.

This caching was originally implemented by @phire because it was a helped improve performance a bit. But because nvidia is doing something weird with it if we called it during Init, my idea to restore proper behavior and keep the perf++ was to move the glGetIntegerv() call back to where it originally was, but make a conditional to only call it once.

This seems to work. We don't know why.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3871)
<!-- Reviewable:end -->
