### PR TITLE
Re-add deleted Gecko Tag in Smash Netplay INI

### DIFF
--- a/Data/Sys/GameSettings/GALE01r2.ini
+++ b/Data/Sys/GameSettings/GALE01r2.ini
@@ -141,6 +141,7 @@ $True Special Message Delete [JMC47]
 0445C228 80000000
 0045C22C 00001111
 
+[Gecko]
 # General Codes
 $Netplay Community Settings
 *Boot to CSS, unlock everything, 4 stock 8 minute friendly fire on, trophy messages off,


### PR DESCRIPTION
Fixes the previous commit by making the netplay codes actually work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3877)
<!-- Reviewable:end -->
