### PR TITLE
Do not include the Dolphin version in the install directory name

### DIFF
--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -105,7 +105,7 @@ SetCompressor /SOLID lzma
 
 ; MUI end ------
 
-Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
+Name "${PRODUCT_NAME}"
 !define UN_NAME "Uninstall $(^Name)"
 OutFile "dolphin-${DOLPHIN_ARCH}-${PRODUCT_VERSION}.exe"
 InstallDir "${BASE_INSTALL_DIR}\$(^Name)"


### PR DESCRIPTION
This change was introduced for 4.0.1 and never ported to the master branch until now. It would be awkward to have 5.0 go back to the 4.0 behavior after we already changed the behavior once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3884)
<!-- Reviewable:end -->
