### PR TITLE
This fixes the issue where the installer deletes the User folder

### DIFF
--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -124,9 +124,17 @@ Section "Base" SEC01
   ; TODO: Make a nice subsection-ized display
   SetOutPath "$INSTDIR"
   SetOverwrite ifnewer
-  ; Delete old install directory if it exists
-  IfFileExists "$INSTDIR\*.*" 0 +2
-  RMDir /r "$INSTDIR"
+  ; Only delete what we put there; all $INSTDIR\User is left as is
+  Delete "$INSTDIR\uninst.exe"
+  Delete "$INSTDIR\license.txt"
+  Delete "$INSTDIR\*.dll"
+  Delete "$INSTDIR\Dolphin.exe"
+  Delete "$INSTDIR\DSPTool.exe"
+  Delete "$INSTDIR\cpack_package_description.txt"
+  Delete "$INSTDIR\qt.conf"
+  RMDir /r "$INSTDIR\Sys"
+  RMDir /r "$INSTDIR\Languages"
+
   File "${BASE_DIR}\Dolphin.exe"
   File "${BASE_DIR}\license.txt"
   File "${BASE_DIR}\*.dll"


### PR DESCRIPTION
This fixes the issue where the installer deletes the User folder, possibly including saved-games, and deletes everything else in the install folder, possibly including games that took hours to dump.

We still delete the Sys folder though, because otherwise games will use the wrong settings due to our wildcard support. And we delete the Languages folder, any DLL and EXE files, and the qt.conf and cpack_package_description.txt that older Dolphin installers create.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3887)
<!-- Reviewable:end -->
