### PR TITLE
Installer: add values for the Size, Location, and Comments columns

### DIFF
--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -14,6 +14,8 @@
 
 SetCompressor /SOLID lzma
 
+!include "FileFunc.nsh"
+
 ; MUI 1.67 compatible ------
 !include "MUI.nsh"
 
@@ -169,6 +171,11 @@ Section -Post
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayVersion" "${PRODUCT_VERSION}"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "URLInfoAbout" "${PRODUCT_WEB_SITE}"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "Publisher" "${PRODUCT_PUBLISHER}"
+  WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "InstallLocation" "$INSTDIR"
+  ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+  IntFmt $0 "0x%08X" $0
+  WriteRegDWORD ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "EstimatedSize" "$0"
+  WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "Comments" "GameCube and Wii emulator"
 SectionEnd
 
 ; Section descriptions


### PR DESCRIPTION
Add values for the Size, Location, and Comments columns of the Programs and Features (aka Add/Remove Programs) window used to uninstall programs in Windows. Most programs fill in the Location and Size columns, but Dolphin doesn't. Most programs unfortunately don't fill in the comments column, but I find that annoying when I go to uninstall things and can't work out what half the programs are for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3889)
<!-- Reviewable:end -->
