### PR TITLE
Split Audio Dumps on Sample Rate Changes

### DIFF
--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -158,15 +158,17 @@ void CMixer::MixerFifo::PushSamples(const short* samples, unsigned int num_sampl
 void CMixer::PushSamples(const short* samples, unsigned int num_samples)
 {
   m_dma_mixer.PushSamples(samples, num_samples);
+  int sample_rate = m_dma_mixer.GetInputSampleRate();
   if (m_log_dsp_audio)
-    m_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples);
+    m_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples, sample_rate);
 }
 
 void CMixer::PushStreamingSamples(const short* samples, unsigned int num_samples)
 {
   m_streaming_mixer.PushSamples(samples, num_samples);
+  int sample_rate = m_streaming_mixer.GetInputSampleRate();
   if (m_log_dtk_audio)
-    m_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples);
+    m_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples, sample_rate);
 }
 
 void CMixer::PushWiimoteSpeakerSamples(const short* samples, unsigned int num_samples,
@@ -213,7 +215,7 @@ void CMixer::StartLogDTKAudio(const std::string& filename)
   if (!m_log_dtk_audio)
   {
     m_log_dtk_audio = true;
-    m_wave_writer_dtk.Start(filename, 48000);
+    m_wave_writer_dtk.Start(filename, m_streaming_mixer.GetInputSampleRate());
     m_wave_writer_dtk.SetSkipSilence(false);
     NOTICE_LOG(AUDIO, "Starting DTK Audio logging");
   }
@@ -242,7 +244,7 @@ void CMixer::StartLogDSPAudio(const std::string& filename)
   if (!m_log_dsp_audio)
   {
     m_log_dsp_audio = true;
-    m_wave_writer_dsp.Start(filename, 32000);
+    m_wave_writer_dsp.Start(filename, m_dma_mixer.GetInputSampleRate());
     m_wave_writer_dsp.SetSkipSilence(false);
     NOTICE_LOG(AUDIO, "Starting DSP Audio logging");
   }
@@ -269,6 +271,11 @@ void CMixer::StopLogDSPAudio()
 void CMixer::MixerFifo::SetInputSampleRate(unsigned int rate)
 {
   m_input_sample_rate = rate;
+}
+
+unsigned int CMixer::MixerFifo::GetInputSampleRate() const
+{
+  return m_input_sample_rate;
 }
 
 void CMixer::MixerFifo::SetVolume(unsigned int lvolume, unsigned int rvolume)

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -55,6 +55,7 @@ private:
     void PushSamples(const short* samples, unsigned int num_samples);
     unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit = true);
     void SetInputSampleRate(unsigned int rate);
+    unsigned int GetInputSampleRate() const;
     void SetVolume(unsigned int lvolume, unsigned int rvolume);
 
   private:

--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -41,6 +41,11 @@ bool WaveFileWriter::Start(const std::string& filename, unsigned int HLESampleRa
 
   audio_size = 0;
 
+  if (basename.empty())
+    SplitPath(filename, nullptr, &basename, nullptr);
+
+  current_sample_rate = HLESampleRate;
+
   // -----------------
   // Write file header
   // -----------------
@@ -89,7 +94,7 @@ void WaveFileWriter::Write4(const char* ptr)
   file.WriteBytes(ptr, 4);
 }
 
-void WaveFileWriter::AddStereoSamples(const short* sample_data, u32 count)
+void WaveFileWriter::AddStereoSamples(const short* sample_data, u32 count, int sample_rate)
 {
   if (!file)
     PanicAlertT("WaveFileWriter - file not open.");
@@ -108,11 +113,13 @@ void WaveFileWriter::AddStereoSamples(const short* sample_data, u32 count)
       return;
   }
 
+  CheckSampleRate(sample_rate);
+
   file.WriteBytes(sample_data, count * 4);
   audio_size += count * 4;
 }
 
-void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count)
+void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count, int sample_rate)
 {
   if (!file)
     PanicAlertT("WaveFileWriter - file not open.");
@@ -141,6 +148,21 @@ void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count)
     conv_buffer[2 * i + 1] = Common::swap16((u16)sample_data[2 * i]);
   }
 
+  CheckSampleRate(sample_rate);
+
   file.WriteBytes(conv_buffer.data(), count * 4);
   audio_size += count * 4;
+}
+
+void WaveFileWriter::CheckSampleRate(int sample_rate)
+{
+  if (sample_rate != current_sample_rate)
+  {
+    Stop();
+    file_index++;
+    std::stringstream filename;
+    filename << File::GetUserPath(D_DUMPAUDIO_IDX) << basename << file_index << ".wav";
+    Start(filename.str(), sample_rate);
+    current_sample_rate = sample_rate;
+  }
 }

--- a/Source/Core/AudioCommon/WaveFile.h
+++ b/Source/Core/AudioCommon/WaveFile.h
@@ -30,8 +30,8 @@ public:
   void Stop();
 
   void SetSkipSilence(bool skip) { skip_silence = skip; }
-  void AddStereoSamples(const short* sample_data, u32 count);
-  void AddStereoSamplesBE(const short* sample_data, u32 count);  // big endian
+  void AddStereoSamples(const short* sample_data, u32 count, int sample_rate);
+  void AddStereoSamplesBE(const short* sample_data, u32 count, int sample_rate);  // big endian
   u32 GetAudioSize() const { return audio_size; }
 private:
   static constexpr size_t BUFFER_SIZE = 32 * 1024;
@@ -42,4 +42,8 @@ private:
   std::array<short, BUFFER_SIZE> conv_buffer{};
   void Write(u32 value);
   void Write4(const char* ptr);
+  void CheckSampleRate(int sample_rate);
+  std::string basename;
+  int current_sample_rate;
+  int file_index = 0;
 };


### PR DESCRIPTION
This is somewhat of a port of the dolphin-avsync functionality of splitting audio files based on sample rate changes. It's also an alternative to PR #3542, which would resample all audio to 48khz.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3891)
<!-- Reviewable:end -->
