### PR TITLE
Improve PerfQuery accuracy

### DIFF
--- a/Source/Core/VideoBackends/D3D/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D/PerfQuery.cpp
@@ -86,7 +86,7 @@ u32 PerfQuery::GetQueryResult(PerfQueryType type)
   else if (type == PQ_EFB_COPY_CLOCKS)
     result = m_results[PQG_EFB_COPY_CLOCKS];
 
-  return result / 4;
+  return result;
 }
 
 void PerfQuery::FlushOne()
@@ -102,6 +102,8 @@ void PerfQuery::FlushOne()
   }
 
   // NOTE: Reported pixel metrics should be referenced to native resolution
+  // TODO: Dropping the lower 2 bits from this count should be closer to actual
+  // hardware behavior when drawing triangles.
   m_results[entry.query_type] += (u32)(result * EFB_WIDTH / g_renderer->GetTargetWidth() *
                                        EFB_HEIGHT / g_renderer->GetTargetHeight());
 

--- a/Source/Core/VideoBackends/D3D12/PerfQuery.cpp
+++ b/Source/Core/VideoBackends/D3D12/PerfQuery.cpp
@@ -98,7 +98,7 @@ u32 PerfQuery::GetQueryResult(PerfQueryType type)
   else if (type == PQ_EFB_COPY_CLOCKS)
     result = m_results[PQG_EFB_COPY_CLOCKS];
 
-  return result / 4;
+  return result;
 }
 
 void PerfQuery::FlushOne()
@@ -126,6 +126,8 @@ void PerfQuery::FlushOne()
   m_query_readback_buffer->Unmap(0, &write_range);
 
   // NOTE: Reported pixel metrics should be referenced to native resolution
+  // TODO: Dropping the lower 2 bits from this count should be closer to actual
+  // hardware behavior when drawing triangles.
   m_results[entry.query_type] += (u32)(result * EFB_WIDTH / g_renderer->GetTargetWidth() *
                                        EFB_HEIGHT / g_renderer->GetTargetHeight());
 
@@ -179,6 +181,8 @@ void PerfQuery::FlushResults()
            sizeof(UINT64));
 
     // NOTE: Reported pixel metrics should be referenced to native resolution
+    // TODO: Dropping the lower 2 bits from this count should be closer to actual
+    // hardware behavior when drawing triangles.
     m_results[entry.query_type] += (u32)(result * EFB_WIDTH / g_renderer->GetTargetWidth() *
                                          EFB_HEIGHT / g_renderer->GetTargetHeight());
 


### PR DESCRIPTION
In TimeSplitters: Future Perfect, PRIMITIVE_POINTS is used with PerfQuery to detect the visibility of lights and draw coronas. The point count was incorrectly being divided by four leading to dim coronas.

Using 4x antialiasing was a workaround because of another bug where antialiasing multiplied the PerfQuery results. This fixes that bug too (for OpenGL).

This should address https://bugs.dolphin-emu.org/issues/8181 in the OpenGL backend. This can probably be pretty closely copied to the other backends, but it's a bit of a hassle for me to test them, so I didn't try. I moved the location of the division, potentially increasing rounding error in other games. Can anyone test this on Super Mario Sunshine?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3893)
<!-- Reviewable:end -->
