### PR TITLE
Jit: Check the FIFO on EIEIO instructions

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -241,4 +241,6 @@ public:
   void stmw(UGeckoInstruction inst);
 
   void dcbx(UGeckoInstruction inst);
+
+  void eieio(UGeckoInstruction inst);
 };

--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -309,7 +309,7 @@ static GekkoOPTemplate table31[] = {
     // Unused instructions on GC
     {310, &Jit64::FallBackToInterpreter},  // eciwx
     {438, &Jit64::FallBackToInterpreter},  // ecowx
-    {854, &Jit64::DoNothing},              // eieio
+    {854, &Jit64::eieio},                  // eieio
     {306, &Jit64::FallBackToInterpreter},  // tlbie
     {566, &Jit64::DoNothing},              // tlbsync
 };

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -598,3 +598,15 @@ void Jit64::stmw(UGeckoInstruction inst)
   }
   gpr.UnlockAllX();
 }
+
+void Jit64::eieio(UGeckoInstruction inst)
+{
+  INSTRUCTION_START
+  JITDISABLE(bJITLoadStoreOff);
+
+  // optimizeGatherPipe generally postpones FIFO checks to the end of the JIT block,
+  // which is generally safe. However postponing FIFO writes across eieio instructions
+  // is incorrect (would crash NBA2K11 strap screen if we improve our FIFO detection).
+  if (jo.optimizeGatherPipe && js.fifoBytesThisBlock > 0)
+    js.mustCheckFifo = true;
+}

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -405,6 +405,7 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitB
   js.assumeNoPairedQuantize = false;
   js.blockStart = em_address;
   js.fifoBytesThisBlock = 0;
+  js.mustCheckFifo = false;
   js.downcountAmount = 0;
   js.skipInstructions = 0;
   js.curBlock = b;
@@ -491,9 +492,11 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitB
     bool gatherPipeIntCheck =
         jit->js.fifoWriteAddresses.find(ops[i].address) != jit->js.fifoWriteAddresses.end();
 
-    if (jo.optimizeGatherPipe && js.fifoBytesThisBlock >= 32)
+    if (jo.optimizeGatherPipe && (js.fifoBytesThisBlock >= 32 || js.mustCheckFifo))
     {
-      js.fifoBytesThisBlock -= 32;
+      if (js.fifoBytesThisBlock >= 32)
+        js.fifoBytesThisBlock -= 32;
+      js.mustCheckFifo = false;
 
       gpr.Lock(W30);
       BitSet32 regs_in_use = gpr.GetCallerSavedUsed();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -116,6 +116,7 @@ public:
   void dcbx(UGeckoInstruction inst);
   void dcbt(UGeckoInstruction inst);
   void dcbz(UGeckoInstruction inst);
+  void eieio(UGeckoInstruction inst);
 
   // LoadStore floating point
   void lfXX(UGeckoInstruction inst);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -853,3 +853,15 @@ void JitArm64::dcbz(UGeckoInstruction inst)
 
   gpr.Unlock(W0);
 }
+
+void JitArm64::eieio(UGeckoInstruction inst)
+{
+  INSTRUCTION_START
+  JITDISABLE(bJITLoadStoreOff);
+
+  // optimizeGatherPipe generally postpones FIFO checks to the end of the JIT block,
+  // which is generally safe. However postponing FIFO writes across eieio instructions
+  // is incorrect (would crash NBA2K11 strap screen if we improve our FIFO detection).
+  if (jo.optimizeGatherPipe && js.fifoBytesThisBlock > 0)
+    js.mustCheckFifo = true;
+}

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -314,7 +314,7 @@ static GekkoOPTemplate table31[] = {
     // Unused instructions on GC
     {310, &JitArm64::FallBackToInterpreter},  // eciwx
     {438, &JitArm64::FallBackToInterpreter},  // ecowx
-    {854, &JitArm64::DoNothing},              // eieio
+    {854, &JitArm64::eieio},                  // eieio
     {306, &JitArm64::FallBackToInterpreter},  // tlbie
     {566, &JitArm64::DoNothing},              // tlbsync
 };

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -103,6 +103,7 @@ protected:
     bool generatingTrampoline = false;
     u8* trampolineExceptionHandler;
 
+    bool mustCheckFifo;
     int fifoBytesThisBlock;
 
     PPCAnalyst::BlockStats st;


### PR DESCRIPTION
The gather pipe optimization postpones checking the FIFO until the end of the current block (or 32 bytes have been written). This is usually safe, but is not correct across EIEIO instructions.

This is inferred from a block in NBA2K11 which synchronizes the FIFO by writing a byte to it, executing eieio, and checking if PI_FIFO_WPTR has changed. This is not currently an issue, but will become an issue if the gather pipe optimization is applied to more stores.

This issue was discovered in PR #1230 and I re-discovered it when I tried to proliferate optimized FIFO writes using a different approach. I'm submitting this separately because there's a (rather small) chance it's an existing problem in other games (that might crash with "FIFO: Unknown Opcode" or similar).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3894)
<!-- Reviewable:end -->
