### PR TITLE
Abbreviate controls shown to user in input config GUI, so they fit the box

### DIFF
--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -69,6 +69,7 @@ void GamepadPage::ConfigExtension(wxCommandEvent& event)
 		dlg.SetSizerAndFit(main_szr);
 		dlg.Center();
 
+		UpdateGUI();
 		dlg.ShowModal();
 
 		// remove the new groups that were just added, now that the window closed
@@ -272,6 +273,10 @@ void GamepadPage::UpdateGUI()
 		for (ControlButton* button : cgBox->control_buttons)
 		{
 			wxString expr = StrToWxStr(button->control_reference->expression);
+			if (button->control_reference->is_input)
+				button->SetToolTip(_("Left-click to detect input.\nMiddle-click to clear.\nRight-click for more options.") + "\n\n" + expr);
+			else
+				button->SetToolTip(_("Left/Right-click for more options.\nMiddle-click to clear.") + "\n\n" + expr);
 			expr.Replace("&", "&&");
 			button->SetLabel(expr);
 		}


### PR DESCRIPTION
Abbreviate controls shown to user in input config GUI, so they fit in the box. Also show them in the tooltip in case they still don't fit in the box. For example, instead of seeing in the tiny box a random unrecognisable part of the middle of this:
`((LMENU | RMENU) & !(LSHIFT | RSHIFT) & !(LCONTROL | RCONTROL)) & RETURN`
they now see this:
`Alt & RETURN`
and instead of seeing this:
(\`XInput/0/Gamepad:Shoulder L\` & !\`XInput/0/Gamepad:Shoulder R\` & !\`XInput/0/Gamepad:Trigger L\` & \`XInput/0/Gamepad:Button X\`) | ((!(\`DInput/0/Keyboard Mouse:LMENU\` | \`DInput/0/Keyboard Mouse:RMENU\`) & (\`DInput/0/Keyboard Mouse:LSHIFT\` | \`DInput/0/Keyboard Mouse:RSHIFT\`) & !(\`DInput/0/Keyboard Mouse:LCONTROL\` | \`DInput/0/Keyboard Mouse:RCONTROL\`)) & \`DInput/0/Keyboard Mouse:1\`)
they now see:
`(X:Shoulder L & !X:Shoulder R & !X:Trigger L & X:Button X) | (K:Shift & K:1)`
Which still doesn't fit the tiny box, but they can see it in the tooltip.
Right clicking it still always shows the long unabbreviated version for the user to edit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3899)
<!-- Reviewable:end -->
