### PR TITLE
GameINI: Force EFB to RAM for OoT Master Quest (D43)

### DIFF
--- a/Data/Sys/GameSettings/D43.ini
+++ b/Data/Sys/GameSettings/D43.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues =
+EmulationIssues = Needs EFB to RAM for the pause menu (background and Link).
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -17,3 +17,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
The Legend of Zelda: Ocarina of Time (Master Quest) needs EFB to RAM for the pause menu background to not be black and for Link to show up in the pause menu. These are the two most visible issues without EFB to RAM enabled.

This is consistent with the GameINI for the Collector's Edition version (PZL) which also forces EFB to RAM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3900)
<!-- Reviewable:end -->
