### PR TITLE
TextureCache: Track efb copies used in a partially updated texture (fixes regression for 5.0)

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -98,16 +98,23 @@ public:
 		// This texture entry is used by the other entry as a sub-texture
 		void CreateReference(TCacheEntryBase* other_entry)
 		{
+			// References are two-way, so they can easily be destroyed later
 			this->references.emplace(other_entry);
 			other_entry->references.emplace(this);
 		}
 
+		void DestroyAllReferences()
+		{
+			for (auto& reference : references)
+				reference->references.erase(this);
+
+			references.clear();
+		}
+
 		void SetEfbCopy(u32 stride);
-		void Reset(); // Prepare for reuse
 
 		TCacheEntryBase(const TCacheEntryConfig& c) : config(c) {}
 		virtual ~TCacheEntryBase();
-
 
 		virtual void Bind(unsigned int stage) = 0;
 		virtual bool Save(const std::string& filename, unsigned int level) = 0;
@@ -179,7 +186,9 @@ private:
 
 	static TCacheEntryBase* AllocateTexture(const TCacheEntryConfig& config);
 	static TexCache::iterator GetTexCacheIter(TCacheEntryBase* entry);
-	static TexCache::iterator FreeTexture(TexCache::iterator t_iter);
+
+	// Removes and unlinks texture from texture cache and returns it to the pool
+	static TexCache::iterator InvalidateTexture(TexCache::iterator t_iter);
 
 	static TCacheEntryBase* ReturnEntry(unsigned int stage, TCacheEntryBase* entry);
 


### PR DESCRIPTION
Fixes a major performance regression in Skies of Arcadia during battle transitions, caused by #3752

I had plans for a more advanced version of this code after 5.0, but here is a minimal implementation for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3902)
<!-- Reviewable:end -->
