### PR TITLE
Disconnect real Wiimotes when disconnected by games (not on all platforms)

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -72,7 +72,9 @@ void Pause()
 // An L2CAP packet is passed from the Core to the Wiimote on the HID CONTROL channel.
 void ControlChannel(int number, u16 channel_id, const void* data, u32 size)
 {
-  if (WIIMOTE_SRC_HYBRID & g_wiimote_sources[number])
+  if (WIIMOTE_SRC_REAL & g_wiimote_sources[number])
+    WiimoteReal::ControlChannel(number, channel_id, data, size);
+  else if (WIIMOTE_SRC_HYBRID & g_wiimote_sources[number])
     static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
         ->ControlChannel(channel_id, data, size);
 }

--- a/Source/Core/Core/HW/WiimoteReal/IONix.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IONix.cpp
@@ -145,6 +145,8 @@ void WiimoteScanner::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wiimote
 
 WiimoteLinux::WiimoteLinux(bdaddr_t bdaddr) : Wiimote(), m_bdaddr(bdaddr)
 {
+  m_really_disconnect = true;
+
   m_cmd_sock = -1;
   m_int_sock = -1;
 

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -125,7 +125,10 @@ void Wiimote::ControlChannel(const u16 channel, const void* const data, const u3
   // Check for custom communication
   if (99 == channel)
   {
-    EmuStop();
+    if (m_really_disconnect)
+      DisconnectInternal();
+    else
+      EmuStop();
   }
   else
   {

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -79,6 +79,10 @@ protected:
   Report m_last_input_report;
   u16 m_channel;
   u8 m_last_connect_request_counter;
+  // If true, the Wiimote will be really disconnected when it is disconnected by Dolphin,
+  // instead of just pausing data reporting.
+  // This is not enabled on all platforms as connecting a Wiimote can be a pain on some platforms.
+  bool m_really_disconnect = false;
 
 private:
   void ClearReadQueue();


### PR DESCRIPTION
This commit makes real Wiimotes really disconnect when they are disconnected by the emulated software, which is more similar to how it works with a real Wii and allows Wiimotes to be disconnected after timeout for power saving.

(will probably need some more testing; only tested on Linux)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3903)
<!-- Reviewable:end -->
