### PR TITLE
_DEFAULT_SOURCE flag added, and clang check version for IsTriviallyCopyable m…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ endmacro()
 # Enabling all warnings in MSVC spams too much
 if(NOT MSVC)
 	add_definitions(-Wall)
-
+	add_definitions(-D_DEFAULT_SOURCE)
 	# TODO: would like these but they produce overwhelming amounts of warnings
 	#check_and_add_flag(EXTRA -Wextra)
 	#check_and_add_flag(MISSING_FIELD_INITIALIZERS -Wmissing-field-initializers)

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -32,7 +32,12 @@
 #include "Common/Logging/Log.h"
 
 // ewww
-#if _LIBCPP_VERSION || __GNUC__ >= 5
+
+#ifndef __has_feature
+ #define __has_feature(x) (0)
+#endif
+
+#if (__has_feature(is_trivially_copyable) && (defined(_LIBCPP_VERSION) || defined(__GLIBCXX__))) || (defined(__GNUC__) && __GNUC__ >= 5)
 #define IsTriviallyCopyable(T) std::is_trivially_copyable<typename std::remove_volatile<T>::type>::value
 #elif __GNUC__
 #define IsTriviallyCopyable(T) std::has_trivial_copy_constructor<T>::value


### PR DESCRIPTION
…acro

So, I was getting some warnings when compiling dolphin on GNU/Linux with gcc 6.1 and clang 3.8

FIRST ( when compiling with both gcc and clang ):
'''
In file included from /usr/include/stdio.h:27:0,
                 from /dolphin/Externals/miniupnpc/src/igd_desc_parse.c:10:
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
'''
I solve this by adding a compiler flag to define _DEFAULT_SOURCE on the CMakeLists.txt 

SECOND (when compiling with clang):
The other warning is that the std::has_trivial_copy_constructor  was being used when I used clang 3.8 to compile, which has support to std::is_trivially_copyable. Adding a check for the clang's version solved that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3904)
<!-- Reviewable:end -->
