### PR TITLE
Tony Hawk's American Wasteland (European Version) Crash Fix

### DIFF
--- a/Data/Sys/GameSettings/GH9.ini
+++ b/Data/Sys/GameSettings/GH9.ini
@@ -1,0 +1,18 @@
+# GH9P52 - Tony Hawk's American Wasteland
+
+[Core]
+# Values set here will override the main Dolphin settings.
+MMU = 1
+
+[EmuState]
+# The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationStateId = 4
+EmulationIssues = 
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+
+[ActionReplay]
+


### PR DESCRIPTION
Force MMU to ON like use the NTSC Release of Tony Hawk's American Wasteland to avoid a crash at startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3906)
<!-- Reviewable:end -->
