### PR TITLE
analytics: Report OpenGL's adapter name too.

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -219,6 +219,10 @@ void DolphinAnalytics::MakePerGameBuilder()
 	{
 		builder.AddData("gpu-adapter", g_Config.backend_info.Adapters[g_Config.iAdapter]);
 	}
+	else if (!g_Config.backend_info.AdapterName.empty())
+	{
+		builder.AddData("gpu-adapter", g_Config.backend_info.AdapterName);
+	}
 	builder.AddData("gpu-has-exclusive-fullscreen", g_Config.backend_info.bSupportsExclusiveFullscreen);
 	builder.AddData("gpu-has-dual-source-blend", g_Config.backend_info.bSupportsDualSourceBlend);
 	builder.AddData("gpu-has-primitive-restart", g_Config.backend_info.bSupportsPrimitiveRestart);

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -404,6 +404,9 @@ Renderer::Renderer()
 		}
 	}
 
+	// Copy the GPU name to g_Config, so Analytics can see it.
+	g_Config.backend_info.AdapterName = g_ogl_config.gl_renderer;
+
 	g_Config.backend_info.bSupportsDualSourceBlend = GLExtensions::Supports("GL_ARB_blend_func_extended") ||
 	                                                 GLExtensions::Supports("GL_EXT_blend_func_extended");
 	g_Config.backend_info.bSupportsPrimitiveRestart = !DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVERESTART) &&

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -156,6 +156,9 @@ struct VideoConfig final
 		std::vector<std::string> PPShaders; // post-processing shaders
 		std::vector<std::string> AnaglyphShaders; // anaglyph shaders
 
+		// TODO: merge AdapterName and Adapters array
+		std::string AdapterName; // for OpenGL
+
 		bool bSupportsExclusiveFullscreen;
 		bool bSupportsDualSourceBlend;
 		bool bSupportsPrimitiveRestart;


### PR DESCRIPTION
After 5.0, we can merge AdapterName into the Adapters array, but it requires initializing OpenGL before showing the opengl video config window (DirectX11 and DirectX12 already do this)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3909)
<!-- Reviewable:end -->
