### PR TITLE
GameIni: Disable Broken Progressive Scan in BMX XXX

### DIFF
--- a/Data/Sys/GameSettings/GB3.ini
+++ b/Data/Sys/GameSettings/GB3.ini
@@ -9,8 +9,7 @@ EmulationStateId = 4
 EmulationIssues =
 
 [Core]
-# Progressive Scan is broken by the game by default, no need to enable it
-ProgressiveScan = False
+# Progressive Scan is broken by the game by default, disabled featureProgressiveScan = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GB3.ini
+++ b/Data/Sys/GameSettings/GB3.ini
@@ -8,6 +8,10 @@
 EmulationStateId = 4
 EmulationIssues =
 
+[Core]
+# Progressive Scan is broken by the game by default, no need to enable it
+ProgressiveScan = False
+
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
 

--- a/Data/Sys/GameSettings/GB3.ini
+++ b/Data/Sys/GameSettings/GB3.ini
@@ -9,7 +9,8 @@ EmulationStateId = 4
 EmulationIssues =
 
 [Core]
-# Progressive Scan is broken by the game by default, disabled featureProgressiveScan = False
+# Progressive Scan is broken by the game by default, disabled feature
+ProgressiveScan = False
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.


### PR DESCRIPTION
BMX XXX can detect forced Progressive Scan in Dolphin but the game will not be playable, the emulator will freeze.
On an original GameCube, GC-Forever reported that "Game does not support component video output.".
By default, it's better to disable the forced Progressive Scan feature on this game to make it playable and also not stuck in a broken startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3910)
<!-- Reviewable:end -->
