### PR TITLE
analytics: Collect controller information.

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -20,6 +20,10 @@
 #include "Core/ConfigManager.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
+#include "Core/HW/GCPad.h"
+#include "InputCommon/ControllerEmu.h"
+#include "InputCommon/GCAdapter.h"
+#include "InputCommon/InputConfig.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -241,6 +245,14 @@ void DolphinAnalytics::MakePerGameBuilder()
 	// NetPlay / recording.
 	builder.AddData("netplay", NetPlay::IsNetPlayRunning());
 	builder.AddData("movie", Movie::IsMovieActive());
+
+	// Controller information
+	builder.AddData("gcadapter-detected", GCAdapter::IsDetected());
+
+	// For privacy reasons, limit this to type of the first controller.
+	// The ControllersNeedToBeCreated() check is enough to ensure GetController(0) won't return nullptr or throw exceptions.
+	if (!Pad::GetConfig()->ControllersNeedToBeCreated())
+		builder.AddData("controller-type", Pad::GetConfig()->GetController(0)->default_device.name);
 
 	m_per_game_builder = builder;
 }


### PR DESCRIPTION
Collects the existence of a gamecube adapter, and the type of
whatever controller is configured for the first emulated gamepad.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3911)
<!-- Reviewable:end -->
