### PR TITLE
GameIni: Disable Broken Progressive Scan in BMX XXX

### DIFF
--- a/Data/Sys/GameSettings/GB3.ini
+++ b/Data/Sys/GameSettings/GB3.ini
@@ -2,6 +2,8 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+# Progressive Scan is broken by the game by default, disabled feature
+ProgressiveScan = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.


### PR DESCRIPTION
BMX XXX can detect forced Progressive Scan in Dolphin but the game will not be playable, the emulator will freeze.
On an original GameCube, GC-Forever reported that "Game does not support component video output.".
By default, it's better to disable the forced Progressive Scan feature on this game to make it playable and also not stuck in a broken startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3912)
<!-- Reviewable:end -->
