### PR TITLE
analytics: Collect less data about controllers.

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -247,12 +247,10 @@ void DolphinAnalytics::MakePerGameBuilder()
 	builder.AddData("movie", Movie::IsMovieActive());
 
 	// Controller information
+	// We grab enough to tell what percentage of our users are playing with keyboard/mouse, some kind of gamepad
+	// or the official gamecube adapter.
 	builder.AddData("gcadapter-detected", GCAdapter::IsDetected());
-
-	// For privacy reasons, limit this to type of the first controller.
-	// The ControllersNeedToBeCreated() check is enough to ensure GetController(0) won't return nullptr or throw exceptions.
-	if (!Pad::GetConfig()->ControllersNeedToBeCreated())
-		builder.AddData("controller-type", Pad::GetConfig()->GetController(0)->default_device.name);
+	builder.AddData("has-controller", Pad::GetConfig()->IsControllerControlledByGamepadDevice(0) || GCAdapter::IsDetected());
 
 	m_per_game_builder = builder;
 }

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -117,3 +117,17 @@ bool InputConfig::ControllersNeedToBeCreated() const
 {
 	return m_controllers.empty();
 }
+
+bool InputConfig::IsControllerControlledByGamepadDevice(int index) const
+{
+	if (static_cast<size_t>(index) >= m_controllers.size())
+		return false;
+
+	const auto& controller = m_controllers.at(index).get()->default_device;
+
+	// Filter out anything which obviously not a gamepad
+	return !((controller.source == "Keyboard") // OSX Keyboard/Mouse
+		|| (controller.source == "XInput2") // Linux and BSD Keyboard/Mouse
+		|| (controller.source == "Android" && controller.name == "Touchscreen") // Android Touchscreen
+		|| (controller.source == "DInput" && controller.name == "Keyboard Mouse")); // Windows Keyboard/Mouse
+}

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -31,6 +31,7 @@ public:
 	ControllerEmu* GetController(int index);
 	void ClearControllers();
 	bool ControllersNeedToBeCreated() const;
+	bool IsControllerControlledByGamepadDevice(int index) const;
 
 	std::string GetGUIName() const { return m_gui_name; }
 	std::string GetProfileName() const { return m_profile_name; }


### PR DESCRIPTION
The name field can contain personal information, particularly in the
case of bluetooth devices on OSX which get configured with the user's
full name.

This limits the collected information to the main question we want to know
right now. The name field wasn't that helpful anyway, perhaps we can add
some better controller type detection later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3916)
<!-- Reviewable:end -->
