### PR TITLE
constexpr added to BitSet.h

### DIFF
--- a/Source/Core/Common/BitSet.h
+++ b/Source/Core/Common/BitSet.h
@@ -14,7 +14,7 @@
 #include <intrin.h>
 
 template <typename T>
-static inline int CountSetBits(T v)
+constexpr int CountSetBits(T v)
 {
 	// from https://graphics.stanford.edu/~seander/bithacks.html
 	// GCC has this built in, but MSVC's intrinsic will only emit the actual
@@ -24,39 +24,45 @@ static inline int CountSetBits(T v)
 	v = (v + (v >> 4)) & (T)~(T)0/255*15;
 	return (T)(v * ((T)~(T)0/255)) >> (sizeof(T) - 1) * 8;
 }
-static inline int LeastSignificantSetBit(u8 val)
+
+
+inline int LeastSignificantSetBit(u8 val)
 {
 	unsigned long index;
 	_BitScanForward(&index, val);
 	return (int)index;
 }
-static inline int LeastSignificantSetBit(u16 val)
+
+inline int LeastSignificantSetBit(u16 val)
 {
 	unsigned long index;
 	_BitScanForward(&index, val);
 	return (int)index;
 }
-static inline int LeastSignificantSetBit(u32 val)
+
+inline int LeastSignificantSetBit(u32 val)
 {
 	unsigned long index;
 	_BitScanForward(&index, val);
 	return (int)index;
 }
-static inline int LeastSignificantSetBit(u64 val)
+
+inline int LeastSignificantSetBit(u64 val)
 {
 	unsigned long index;
 	_BitScanForward64(&index, val);
 	return (int)index;
 }
+
 #else
-static inline int CountSetBits(u8 val) { return __builtin_popcount(val); }
-static inline int CountSetBits(u16 val) { return __builtin_popcount(val); }
-static inline int CountSetBits(u32 val) { return __builtin_popcount(val); }
-static inline int CountSetBits(u64 val) { return __builtin_popcountll(val); }
-static inline int LeastSignificantSetBit(u8 val) { return __builtin_ctz(val); }
-static inline int LeastSignificantSetBit(u16 val) { return __builtin_ctz(val); }
-static inline int LeastSignificantSetBit(u32 val) { return __builtin_ctz(val); }
-static inline int LeastSignificantSetBit(u64 val) { return __builtin_ctzll(val); }
+constexpr int CountSetBits(u8 val) { return __builtin_popcount(val); }
+constexpr int CountSetBits(u16 val) { return __builtin_popcount(val); }
+constexpr int CountSetBits(u32 val) { return __builtin_popcount(val); }
+constexpr int CountSetBits(u64 val) { return __builtin_popcountll(val); }
+inline int LeastSignificantSetBit(u8 val) { return __builtin_ctz(val); }
+inline int LeastSignificantSetBit(u16 val) { return __builtin_ctz(val); }
+inline int LeastSignificantSetBit(u32 val) { return __builtin_ctz(val); }
+inline int LeastSignificantSetBit(u64 val) { return __builtin_ctzll(val); }
 #endif
 
 // namespace avoids conflict with OS X Carbon; don't use BitSet<T> directly
@@ -81,7 +87,7 @@ namespace BS
 //   operation.)
 // - Counting set bits using .Count() - see comment on that method.
 
-// TODO: use constexpr when MSVC gets out of the Dark Ages
+// TODO: add constexpr for non-const methods when dolphin requires C++14
 
 template <typename IntTy>
 class BitSet
@@ -92,9 +98,9 @@ public:
 	class Ref
 	{
 	public:
-		Ref(Ref&& other) : m_bs(other.m_bs), m_mask(other.m_mask) {}
-		Ref(BitSet* bs, IntTy mask) : m_bs(bs), m_mask(mask) {}
-		operator bool() const { return (m_bs->m_val & m_mask) != 0; }
+		constexpr Ref(Ref&& other) : m_bs(other.m_bs), m_mask(other.m_mask) {}
+		constexpr Ref(BitSet* bs, IntTy mask) : m_bs(bs), m_mask(mask) {}
+		constexpr operator bool() const { return (m_bs->m_val & m_mask) != 0; }
 		bool operator=(bool set)
 		{
 			m_bs->m_val = (m_bs->m_val & ~m_mask) | (set ? m_mask : 0);
@@ -109,10 +115,10 @@ public:
 	class Iterator
 	{
 	public:
-		Iterator(const Iterator& other) : m_val(other.m_val), m_bit(other.m_bit) {}
-		Iterator(IntTy val, int bit) : m_val(val), m_bit(bit) {}
+		constexpr Iterator(const Iterator& other) : m_val(other.m_val), m_bit(other.m_bit) {}
+		constexpr Iterator(IntTy val, int bit) : m_val(val), m_bit(bit) {}
 		Iterator& operator=(Iterator other) { new (this) Iterator(other); return *this; }
-		int operator*() { return m_bit; }
+		constexpr int operator*() const { return m_bit; }
 		Iterator& operator++()
 		{
 			if (m_val == 0)
@@ -127,21 +133,21 @@ public:
 			}
 			return *this;
 		}
-		Iterator operator++(int _)
+		Iterator operator++(int)
 		{
 			Iterator other(*this);
 			++*this;
 			return other;
 		}
-		bool operator==(Iterator other) const { return m_bit == other.m_bit; }
-		bool operator!=(Iterator other) const { return m_bit != other.m_bit; }
+		constexpr bool operator==(Iterator other) const { return m_bit == other.m_bit; }
+		constexpr bool operator!=(Iterator other) const { return m_bit != other.m_bit; }
 	private:
 		IntTy m_val;
 		int m_bit;
 	};
 
-	BitSet() : m_val(0) {}
-	explicit BitSet(IntTy val) : m_val(val) {}
+	constexpr BitSet() : m_val(0) {}
+	constexpr explicit BitSet(IntTy val) : m_val(val) {}
 	BitSet(std::initializer_list<int> init)
 	{
 		m_val = 0;
@@ -149,34 +155,33 @@ public:
 			m_val |= (IntTy)1 << bit;
 	}
 
-	static BitSet AllTrue(size_t count)
+	static constexpr BitSet AllTrue(size_t count)
 	{
 		return BitSet(count == sizeof(IntTy)*8 ? ~(IntTy)0 : (((IntTy)1 << count) - 1));
 	}
 
 	Ref operator[](size_t bit) { return Ref(this, (IntTy)1 << bit); }
-	const Ref operator[](size_t bit) const { return (*const_cast<BitSet*>(this))[bit]; }
-	bool operator==(BitSet other) const { return m_val == other.m_val; }
-	bool operator!=(BitSet other) const { return m_val != other.m_val; }
-	bool operator<(BitSet other) const { return m_val < other.m_val; }
-	bool operator>(BitSet other) const { return m_val > other.m_val; }
-	BitSet operator|(BitSet other) const { return BitSet(m_val | other.m_val); }
-	BitSet operator&(BitSet other) const { return BitSet(m_val & other.m_val); }
-	BitSet operator^(BitSet other) const { return BitSet(m_val ^ other.m_val); }
-	BitSet operator~() const { return BitSet(~m_val); }
+	constexpr const Ref operator[](size_t bit) const { return (*const_cast<BitSet*>(this))[bit]; }
+	constexpr bool operator==(BitSet other) const { return m_val == other.m_val; }
+	constexpr bool operator!=(BitSet other) const { return m_val != other.m_val; }
+	constexpr bool operator<(BitSet other) const { return m_val < other.m_val; }
+	constexpr bool operator>(BitSet other) const { return m_val > other.m_val; }
+	constexpr BitSet operator|(BitSet other) const { return BitSet(m_val | other.m_val); }
+	constexpr BitSet operator&(BitSet other) const { return BitSet(m_val & other.m_val); }
+	constexpr BitSet operator^(BitSet other) const { return BitSet(m_val ^ other.m_val); }
+	constexpr BitSet operator~() const { return BitSet(~m_val); }
 	BitSet& operator|=(BitSet other) { return *this = *this | other; }
 	BitSet& operator&=(BitSet other) { return *this = *this & other; }
 	BitSet& operator^=(BitSet other) { return *this = *this ^ other; }
-	explicit operator bool() const { return m_val != 0; }
+	constexpr explicit operator bool() const { return m_val != 0; }
 
 	// Warning: Even though on modern CPUs this is a single fast instruction,
 	// Dolphin's official builds do not currently assume POPCNT support on x86,
 	// so slower explicit bit twiddling is generated.  Still should generally
 	// be faster than a loop.
-	unsigned int Count() const { return CountSetBits(m_val); }
-
-	Iterator begin() const { Iterator it(m_val, 0); return ++it; }
-	Iterator end() const { return Iterator(m_val, -1); }
+	constexpr unsigned int Count() const { return CountSetBits(m_val); }
+	constexpr Iterator begin() const { return ++Iterator(m_val, 0); }
+	constexpr Iterator end() const { return Iterator(m_val, -1); }
 
 	IntTy m_val;
 };


### PR DESCRIPTION
Have been looking for some TODOs in the Core and found this. 
I've added constexpr only for functions within C++11 constexpr rules, the rest ( non const member functions ) need C++14 constexpr extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3918)
<!-- Reviewable:end -->
