### PR TITLE
GameIni: Force LLE Audio on Star Wars Rogue Squadron II & III

### DIFF
--- a/Data/Sys/GameSettings/GLR.ini
+++ b/Data/Sys/GameSettings/GLR.ini
@@ -3,6 +3,8 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 MMU = 1
+# LLE audio enabled by default for a listenable output
+DSPHLE = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/GSW.ini
+++ b/Data/Sys/GameSettings/GSW.ini
@@ -3,6 +3,8 @@
 [Core]
 # Values set here will override the main Dolphin settings.
 MMU = 1
+# LLE audio enabled by default for a listenable output
+DSPHLE = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.


### PR DESCRIPTION
Force LLE audio output on all Star Wars: Rogue Squadron releases in order to fix the constant glitchy noise audio ouput.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3919)
<!-- Reviewable:end -->
