### PR TITLE
Fix GameIniLoad incorrectly overriding user settings with 0 or false

### DIFF
--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -144,7 +144,7 @@ void VideoConfig::GameIniLoad()
 	// XXX: This will add an OSD message for each projection hack value... meh
 #define CHECK_SETTING(section, key, var) do { \
 		decltype(var) temp = var; \
-		if (iniFile.GetIfExists(section, key, &var) && var != temp) { \
+		if (iniFile.GetIfExists(section, key, &var, var) && var != temp) { \
 			std::string msg = StringFromFormat("Note: Option \"%s\" is overridden by game ini.", key); \
 			OSD::AddMessage(msg, 7500); \
 			gfx_override_exists = true; \


### PR DESCRIPTION
The following currently forces EFBToTextureEnable to false (EFB2Ram), even though the intent was the opposite:

```
# FAKE01 - The Legend of Zelda

[Video_Hacks]
# All US NES VC titles released before Feb 2007 don't require EFB2Ram
EFBToTextureEnable =
```

That's because CHECK_SETTING uses iniFile.GetIfExists without specifying a default, so a default of 0 or false is used when it is unable to parse the empty string, and GetIfExists returns ~~success because it exists~~ *failure, despite already setting the value to 0 or false*. 0 or false is usually different from the current value, so that is ~~considered~~ a forced override.

Instead we should pass the current value as the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3920)
<!-- Reviewable:end -->
