### PR TITLE
OS X GUI: Fix truncated text

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -37,7 +37,12 @@ void AdvancedConfigPane::InitializeGUI()
 	    "can and will break games and cause glitches. "
 	    "Do so at your own risk. Please do not report "
 	    "bugs that occur with a non-default clock. "));
+
+#ifdef __APPLE__
+	clock_override_description->Wrap(550);
+#else
 	clock_override_description->Wrap(400);
+#endif
 
 	wxBoxSizer* const clock_override_checkbox_sizer = new wxBoxSizer(wxHORIZONTAL);
 	clock_override_checkbox_sizer->Add(m_clock_override_checkbox, 1, wxALL, 5);

--- a/Source/Core/DolphinWX/Config/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/Config/ConfigMain.cpp
@@ -81,7 +81,11 @@ void CConfigMain::CreateGUIControls()
 	main_sizer->Add(Notebook, 1, wxEXPAND | wxALL, 5);
 	main_sizer->Add(CreateButtonSizer(wxOK), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
+#ifdef __APPLE__
+	main_sizer->SetMinSize(550, 0);
+#else
 	main_sizer->SetMinSize(400, 0);
+#endif
 
 	SetSizerAndFit(main_sizer);
 	Center();

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -59,7 +59,11 @@ void GeneralConfigPane::InitializeGUI()
 	m_cheats_checkbox      = new wxCheckBox(this, wxID_ANY, _("Enable Cheats"));
 	m_force_ntscj_checkbox = new wxCheckBox(this, wxID_ANY, _("Force Console as NTSC-J"));
 	m_analytics_checkbox   = new wxCheckBox(this, wxID_ANY, _("Enable Usage Statistics Reporting"));
+#ifdef __APPLE__
+	m_analytics_new_id     = new wxButton(this, wxID_ANY, _("Generate a New Statistics Identity"), wxDefaultPosition, wxSize(350, 25));
+#else
 	m_analytics_new_id     = new wxButton(this, wxID_ANY, _("Generate a New Statistics Identity"));
+#endif
 	m_throttler_choice     = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_throttler_array_string);
 	m_cpu_engine_radiobox  = new wxRadioBox(this, wxID_ANY, _("CPU Emulator Engine"), wxDefaultPosition, wxDefaultSize, m_cpu_engine_array_string, 0, wxRA_SPECIFY_ROWS);
 


### PR DESCRIPTION
Before:
<img width="485" alt="before screenshot" src="https://cloud.githubusercontent.com/assets/9006595/16301626/aa569ac8-3989-11e6-9501-baf51c72a4f8.png">

After:
<img width="551" alt="after screenshot" src="https://cloud.githubusercontent.com/assets/9006595/16301664/f202adda-3989-11e6-863d-7b7ba5604530.png">

This is actually a regression from 4.0, I think:
<img width="443" alt="4 screenshot" src="https://cloud.githubusercontent.com/assets/9006595/16301706/2cd554f8-398a-11e6-81b0-a44eec892bf7.png">

It would be better to test with more languages to find places where internationalized text doesn't fit. Thanks to FRtranslator for pointing this issue out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3924)
<!-- Reviewable:end -->
