### PR TITLE
Windows: Allow a wireless Xbox controller to work. Fixes issue #6047

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
@@ -109,7 +109,17 @@ void Init(std::vector<Core::Device*>& devices)
 	XINPUT_CAPABILITIES caps;
 	for (int i = 0; i != 4; ++i)
 		if (ERROR_SUCCESS == PXInputGetCapabilities(i, 0, &caps))
+		{
 			devices.push_back(new Device(caps, i));
+		}
+		else if (i == 0)
+		{
+			ZeroMemory(&caps, sizeof(caps));
+			caps.SubType = XINPUT_DEVSUBTYPE_GAMEPAD;
+			FillMemory(&caps.Gamepad, sizeof(caps.Gamepad), 0xFF);
+			FillMemory(&caps.Vibration, sizeof(caps.Vibration), 0xFF);
+			devices.push_back(new Device(caps, i));
+		}
 }
 
 void DeInit()


### PR DESCRIPTION
One standard wireless Xbox 360 gamepad will be assumed to be present if none are detected at startup. That allows the user to turn on their gamepad after launching Dolphin and have it work, rather than it mysteriously not working. This is needed for basic usability for anyone with a wireless Xbox 360 or Xbone gamepad, and should prevent a lot of complaints and bug reports.

It fixes https://bugs.dolphin-emu.org/issues/6047

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3927)
<!-- Reviewable:end -->
