### PR TITLE
Fix configStrings in Android’s ButtonManager

### DIFF
--- a/Source/Android/jni/ButtonManager.cpp
+++ b/Source/Android/jni/ButtonManager.cpp
@@ -23,9 +23,7 @@ std::vector<std::string> configStrings = {
     "WiimoteUp", "WiimoteDown", "WiimoteLeft", "WiimoteRight", "IRUp", "IRDown", "IRLeft",
     "IRRight", "IRForward", "IRBackward", "IRHide", "SwingUp", "SwingDown", "SwingLeft",
     "SwingRight", "SwingForward", "SwingBackward", "TiltForward", "TiltBackward", "TiltLeft",
-    "TiltRight", "TiltModifier"
-                 "ShakeX",
-    "ShakeY", "ShakeZ",
+    "TiltRight", "TiltModifier", "ShakeX", "ShakeY", "ShakeZ",
     // Nunchuk
     "NunchukC", "NunchukZ", "NunchukUp", "NunchukDown", "NunchukLeft", "NunchukRight",
     "NunchukSwingUp", "NunchukSwingDown", "NunchukSwingLeft", "NunchukSwingRight",


### PR DESCRIPTION
The bug was exposed by clang-format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3929)
<!-- Reviewable:end -->
