### PR TITLE
Fix in-tree build (cmake .) on OS X.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -942,7 +942,7 @@ file(WRITE ${PROJECT_BINARY_DIR}/Source/Core/Common/scmrev.h
 	"#define SCM_IS_MASTER " ${DOLPHIN_WC_IS_STABLE} "\n"
 	"#define SCM_DISTRIBUTOR_STR \"" ${DISTRIBUTOR} "\"\n"
 	)
-include_directories("${PROJECT_BINARY_DIR}/Source/Core/Common")
+include_directories("${PROJECT_BINARY_DIR}/Source/Core")
 
 ########################################
 # Unit testing.

--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Common/Common.h"
-#include "scmrev.h"
+#include "Common/scmrev.h"
 
 #ifdef _DEBUG
 #define BUILD_TYPE_STR "Debug "


### PR DESCRIPTION
OS X uses a case insensitive filesystem by default: when I try to build, a system header does #include <assert.h>, which picks up Source/Core/Common/Assert.h.  This only happens because CMakeLists adds '${PROJECT_BINARY_DIR}/Source/Core/Common' as an include directory: in an out-of-tree build, that directory contains no other source files, but in an in-tree build PROJECT_BINARY_DIR is just the source root.
    
This is only used for scmrev.h.  Change the include directory to '${PROJECT_BINARY_DIR}/Source/Core' and the include to "Common/scmrev.h", which is more consistent with normal headers anyway.

(edited because I completely missed the real source of the issue the first time around)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3942)
<!-- Reviewable:end -->