### PR TITLE
Add Dump Path to Configuration Menu

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -87,6 +87,20 @@ void SConfig::SaveSettings()
   m_SYSCONF->Save();
 }
 
+namespace
+{
+void CreateDumpPath(const std::string& path)
+{
+  if (path.empty())
+    return;
+  File::SetUserPath(D_DUMP_IDX, path + '/');
+  File::CreateFullPath(File::GetUserPath(D_DUMPAUDIO_IDX));
+  File::CreateFullPath(File::GetUserPath(D_DUMPDSP_IDX));
+  File::CreateFullPath(File::GetUserPath(D_DUMPFRAMES_IDX));
+  File::CreateFullPath(File::GetUserPath(D_DUMPTEXTURES_IDX));
+}
+}  // namespace
+
 void SConfig::SaveGeneralSettings(IniFile& ini)
 {
   IniFile::Section* general = ini.GetOrCreateSection("General");
@@ -114,6 +128,8 @@ void SConfig::SaveGeneralSettings(IniFile& ini)
 
   general->Set("RecursiveISOPaths", m_RecursiveISOFolder);
   general->Set("NANDRootPath", m_NANDPath);
+  general->Set("DumpPath", m_DumpPath);
+  CreateDumpPath(m_DumpPath);
   general->Set("WirelessMac", m_WirelessMac);
 
 #ifdef USE_GDBSTUB
@@ -381,6 +397,8 @@ void SConfig::LoadGeneralSettings(IniFile& ini)
 
   general->Get("NANDRootPath", &m_NANDPath);
   File::SetUserPath(D_WIIROOT_IDX, m_NANDPath);
+  general->Get("DumpPath", &m_DumpPath);
+  CreateDumpPath(m_DumpPath);
   general->Get("WirelessMac", &m_WirelessMac);
 }
 
@@ -653,6 +671,7 @@ void SConfig::LoadDefaults()
   m_strUniqueID = "00000000";
   m_revision = 0;
 }
+
 static const char* GetRegionOfCountry(DiscIO::IVolume::ECountry country)
 {
   switch (country)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -190,6 +190,7 @@ struct SConfig : NonCopyable
   static std::vector<std::string> GetGameIniFilenames(const std::string& id, u16 revision);
 
   std::string m_NANDPath;
+  std::string m_DumpPath;
 
   std::string m_strMemoryCardA;
   std::string m_strMemoryCardB;

--- a/Source/Core/DolphinWX/Config/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/Config/ConfigMain.cpp
@@ -95,14 +95,14 @@ void CConfigMain::CreateGUIControls()
 void CConfigMain::OnClose(wxCloseEvent& WXUNUSED(event))
 {
   EndModal((m_refresh_game_list_on_close) ? wxID_OK : wxID_CANCEL);
+
+  // Save the config. Dolphin crashes too often to only save the settings on closing
+  SConfig::GetInstance().SaveSettings();
 }
 
 void CConfigMain::OnOk(wxCommandEvent& WXUNUSED(event))
 {
   Close();
-
-  // Save the config. Dolphin crashes too often to only save the settings on closing
-  SConfig::GetInstance().SaveSettings();
 }
 
 void CConfigMain::OnSetRefreshGameListOnClose(wxCommandEvent& WXUNUSED(event))

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -55,6 +55,9 @@ void PathConfigPane::InitializeGUI()
   m_nand_root_dirpicker =
       new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, _("Choose a NAND root directory:"),
                           wxDefaultPosition, wxDefaultSize, wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
+  m_dump_path_dirpicker =
+      new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, _("Choose a dump directory:"),
+                          wxDefaultPosition, wxDefaultSize, wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
 
   m_iso_paths_listbox->Bind(wxEVT_LISTBOX, &PathConfigPane::OnISOPathSelectionChanged, this);
   m_recursive_iso_paths_checkbox->Bind(wxEVT_CHECKBOX,
@@ -67,6 +70,7 @@ void PathConfigPane::InitializeGUI()
   m_apploader_path_filepicker->Bind(wxEVT_FILEPICKER_CHANGED,
                                     &PathConfigPane::OnApploaderPathChanged, this);
   m_nand_root_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnNANDRootChanged, this);
+  m_dump_path_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnDumpPathChanged, this);
 
   wxBoxSizer* const iso_button_sizer = new wxBoxSizer(wxHORIZONTAL);
   iso_button_sizer->Add(m_recursive_iso_paths_checkbox, 0, wxALL | wxALIGN_CENTER);
@@ -94,6 +98,9 @@ void PathConfigPane::InitializeGUI()
   picker_sizer->Add(new wxStaticText(this, wxID_ANY, _("Wii NAND Root:")), wxGBPosition(3, 0),
                     wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxALL, 5);
   picker_sizer->Add(m_nand_root_dirpicker, wxGBPosition(3, 1), wxDefaultSpan, wxEXPAND | wxALL, 5);
+  picker_sizer->Add(new wxStaticText(this, wxID_ANY, _("Dump Path:")), wxGBPosition(4, 0),
+                    wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  picker_sizer->Add(m_dump_path_dirpicker, wxGBPosition(4, 1), wxDefaultSpan, wxEXPAND | wxALL, 5);
   picker_sizer->AddGrowableCol(1);
 
   // Populate the Paths page
@@ -113,6 +120,7 @@ void PathConfigPane::LoadGUIValues()
   m_dvd_root_dirpicker->SetPath(StrToWxStr(startup_params.m_strDVDRoot));
   m_apploader_path_filepicker->SetPath(StrToWxStr(startup_params.m_strApploader));
   m_nand_root_dirpicker->SetPath(StrToWxStr(SConfig::GetInstance().m_NANDPath));
+  m_dump_path_dirpicker->SetPath(StrToWxStr(SConfig::GetInstance().m_DumpPath));
 
   // Update selected ISO paths
   for (const std::string& folder : SConfig::GetInstance().m_ISOFolder)
@@ -198,6 +206,14 @@ void PathConfigPane::OnNANDRootChanged(wxCommandEvent& event)
   DiscIO::CNANDContentManager::Access().ClearCache();
 
   main_frame->UpdateWiiMenuChoice();
+}
+
+void PathConfigPane::OnDumpPathChanged(wxCommandEvent& event)
+{
+  std::string dump_path = SConfig::GetInstance().m_DumpPath =
+      WxStrToStr(m_dump_path_dirpicker->GetPath());
+
+  m_dump_path_dirpicker->SetPath(StrToWxStr(dump_path));
 }
 
 void PathConfigPane::SaveISOPathChanges()

--- a/Source/Core/DolphinWX/Config/PathConfigPane.h
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.h
@@ -30,6 +30,7 @@ private:
   void OnDVDRootChanged(wxCommandEvent&);
   void OnApploaderPathChanged(wxCommandEvent&);
   void OnNANDRootChanged(wxCommandEvent&);
+  void OnDumpPathChanged(wxCommandEvent&);
 
   void SaveISOPathChanges();
 
@@ -42,4 +43,5 @@ private:
   wxDirPickerCtrl* m_nand_root_dirpicker;
   wxFilePickerCtrl* m_default_iso_filepicker;
   wxFilePickerCtrl* m_apploader_path_filepicker;
+  wxDirPickerCtrl* m_dump_path_dirpicker;
 };


### PR DESCRIPTION
![](https://i.gyazo.com/2f3b76288c131352ccd1c1ce3d07a404.png)

If path is not set, it defaults to Global User Directory for dumping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3944)
<!-- Reviewable:end -->
