### PR TITLE
Restore wiimote netplay

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -717,7 +717,7 @@ bool NetPlayClient::StartGame(const std::string& path)
   {
     for (unsigned int i = 0; i < 4; ++i)
       WiimoteReal::ChangeWiimoteSource(i,
-        m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);
+                                       m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);
 
     // Needed to prevent locking up at boot if (when) the wiimotes connect out of order.
     NetWiimote nw;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -16,14 +16,12 @@
 #include "Core/HW/SI_DeviceGCController.h"
 #include "Core/HW/Sram.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
-#include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
 #include "Core/Movie.h"
 #include "InputCommon/GCAdapter.h"
 
 static std::mutex crit_netplay_client;
 static NetPlayClient* netplay_client = nullptr;
-static std::array<int, 4> s_wiimote_sources_cache;
 NetSettings g_NetPlaySettings;
 
 // called from ---GUI--- thread
@@ -714,17 +712,6 @@ bool NetPlayClient::StartGame(const std::string& path)
 
   m_dialog->BootGame(path);
 
-  // Disable wiimotes on game start
-  // TODO: remove this when re-implementing wiimote netplay
-  if (SConfig::GetInstance().bWii)
-  {
-    for (unsigned int i = 0; i < 4; ++i)
-    {
-      s_wiimote_sources_cache[i] = g_wiimote_sources[i];
-      WiimoteReal::ChangeWiimoteSource(i, WIIMOTE_SRC_NONE);
-    }
-  }
-
   UpdateDevices();
 
   return true;
@@ -1026,17 +1013,6 @@ bool NetPlayClient::StopGame()
 
   // stop game
   m_dialog->StopGame();
-
-  // Restore wiimote settings on game stop
-  // TODO: remove this when re-implementing wiimote netplay
-  if (SConfig::GetInstance().bWii)
-  {
-    for (unsigned int i = 0; i < 4; ++i)
-    {
-      g_wiimote_sources[i] = s_wiimote_sources_cache[i];
-      WiimoteReal::ChangeWiimoteSource(i, s_wiimote_sources_cache[i]);
-    }
-  }
 
   return true;
 }

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -16,6 +16,7 @@
 #include "Core/HW/SI_DeviceGCController.h"
 #include "Core/HW/Sram.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb.h"
 #include "Core/Movie.h"
 #include "InputCommon/GCAdapter.h"
@@ -711,6 +712,25 @@ bool NetPlayClient::StartGame(const std::string& path)
   // boot game
 
   m_dialog->BootGame(path);
+
+  if (SConfig::GetInstance().bWii)
+  {
+    for (unsigned int i = 0; i < 4; ++i)
+      WiimoteReal::ChangeWiimoteSource(i,
+        m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);
+
+    // Needed to prevent locking up at boot if (when) the wiimotes connect out of order.
+    NetWiimote nw;
+    nw.resize(4, 0);
+
+    for (unsigned int w = 0; w < 4; ++w)
+    {
+      if (m_wiimote_map[w] != -1)
+        // probably overkill, but whatever
+        for (unsigned int i = 0; i < 7; ++i)
+          m_wiimote_buffer[w].Push(nw);
+    }
+  }
 
   UpdateDevices();
 

--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -138,7 +138,7 @@ NetPlaySetupFrame::NetPlaySetupFrame(wxWindow* const parent, const CGameListCtrl
           "If DSP LLE is used, DSP ROMs must be identical between players.\n"
           "If connecting directly, the host must have the chosen UDP port open/forwarded!\n"
           "\n"
-          "Wiimote support is broken in netplay and therefore disabled.\n"));
+          "Wiimote netplay is experimental and should not be expected to work.\n"));
 
     wxBoxSizer* const top_szr = new wxBoxSizer(wxHORIZONTAL);
 

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -483,6 +483,7 @@ void NetPlayDialog::OnAssignPads(wxCommandEvent&)
   pmd.ShowModal();
 
   netplay_server->SetPadMapping(pmd.GetModifiedPadMappings());
+  netplay_server->SetWiimoteMapping(pmd.GetModifiedWiimoteMappings());
 }
 
 void NetPlayDialog::OnKick(wxCommandEvent&)

--- a/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
+++ b/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
@@ -66,6 +66,11 @@ PadMappingArray PadMapDialog::GetModifiedPadMappings() const
   return m_pad_mapping;
 }
 
+PadMappingArray PadMapDialog::GetModifiedWiimoteMappings() const
+{
+  return m_wii_mapping;
+}
+
 void PadMapDialog::OnAdjust(wxCommandEvent& WXUNUSED(event))
 {
   for (unsigned int i = 0; i < 4; i++)
@@ -75,5 +80,11 @@ void PadMapDialog::OnAdjust(wxCommandEvent& WXUNUSED(event))
       m_pad_mapping[i] = m_player_list[player_idx - 1]->pid;
     else
       m_pad_mapping[i] = -1;
+
+    player_idx = m_map_cbox[i + 4]->GetSelection();
+    if (player_idx > 0)
+      m_wii_mapping[i] = m_player_list[player_idx - 1]->pid;
+    else
+     m_wii_mapping[i] = -1;
   }
 }

--- a/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
+++ b/Source/Core/DolphinWX/NetPlay/PadMapDialog.cpp
@@ -11,11 +11,9 @@
 #include "Core/NetPlayServer.h"
 #include "DolphinWX/NetPlay/PadMapDialog.h"
 
-// Removed Wiimote UI elements due to Wiimotes being flat out broken in netplay.
-
 PadMapDialog::PadMapDialog(wxWindow* parent, NetPlayServer* server, NetPlayClient* client)
     : wxDialog(parent, wxID_ANY, _("Controller Ports")), m_pad_mapping(server->GetPadMapping()),
-      m_player_list(client->GetPlayers())
+      m_wii_mapping(server->GetWiimoteMapping()), m_player_list(client->GetPlayers())
 {
   wxBoxSizer* const h_szr = new wxBoxSizer(wxHORIZONTAL);
   h_szr->AddSpacer(10);
@@ -47,6 +45,34 @@ PadMapDialog::PadMapDialog(wxWindow* parent, NetPlayServer* server, NetPlayClien
     }
 
     v_szr->Add(m_map_cbox[i], 1);
+
+    h_szr->Add(v_szr, 1, wxTOP | wxEXPAND, 20);
+    h_szr->AddSpacer(10);
+  }
+
+  for (unsigned int i = 0; i < 4; ++i)
+  {
+    wxBoxSizer* const v_szr = new wxBoxSizer(wxVERTICAL);
+    v_szr->Add(new wxStaticText(this, wxID_ANY, (wxString(_("Wiimote ")) + (wxChar)('1' + i))), 1,
+               wxALIGN_CENTER_HORIZONTAL);
+
+    m_map_cbox[i + 4] =
+        new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, player_names);
+    m_map_cbox[i + 4]->Bind(wxEVT_CHOICE, &PadMapDialog::OnAdjust, this);
+    if (m_wii_mapping[i] == -1)
+    {
+      m_map_cbox[i + 4]->Select(0);
+    }
+    else
+    {
+      for (unsigned int j = 0; j < m_player_list.size(); j++)
+      {
+        if (m_wii_mapping[i] == m_player_list[j]->pid)
+          m_map_cbox[i + 4]->Select(j + 1);
+      }
+    }
+
+    v_szr->Add(m_map_cbox[i + 4], 1);
 
     h_szr->Add(v_szr, 1, wxTOP | wxEXPAND, 20);
     h_szr->AddSpacer(10);
@@ -85,6 +111,6 @@ void PadMapDialog::OnAdjust(wxCommandEvent& WXUNUSED(event))
     if (player_idx > 0)
       m_wii_mapping[i] = m_player_list[player_idx - 1]->pid;
     else
-     m_wii_mapping[i] = -1;
+      m_wii_mapping[i] = -1;
   }
 }

--- a/Source/Core/DolphinWX/NetPlay/PadMapDialog.h
+++ b/Source/Core/DolphinWX/NetPlay/PadMapDialog.h
@@ -20,11 +20,13 @@ public:
   PadMapDialog(wxWindow* parent, NetPlayServer* server, NetPlayClient* client);
 
   PadMappingArray GetModifiedPadMappings() const;
+  PadMappingArray GetModifiedWiimoteMappings() const;
 
 private:
   void OnAdjust(wxCommandEvent& event);
 
-  wxChoice* m_map_cbox[4];
+  wxChoice* m_map_cbox[8];
   PadMappingArray m_pad_mapping;
+  PadMappingArray m_wii_mapping;
   std::vector<const Player*> m_player_list;
 };


### PR DESCRIPTION
In its broken state.

Reverts prs https://github.com/dolphin-emu/dolphin/pull/3802, https://github.com/dolphin-emu/dolphin/pull/3691 and https://github.com/dolphin-emu/dolphin/pull/3660

The broken state will be useful when trying to fix wiimote netplay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3949)
<!-- Reviewable:end -->
