### PR TITLE
x64EmitterTest: fill cpu_info with 0x01 instead of 0xFF to make gcc happier

### DIFF
--- a/Source/UnitTests/Common/x64EmitterTest.cpp
+++ b/Source/UnitTests/Common/x64EmitterTest.cpp
@@ -85,7 +85,7 @@ class x64EmitterTest : public testing::Test
 protected:
   void SetUp() override
   {
-    memset(&cpu_info, 0xFF, sizeof(cpu_info));
+    memset(&cpu_info, 0x01, sizeof(cpu_info));
 
     emitter.reset(new X64CodeBlock());
     emitter->AllocCodeSpace(4096);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3954)
<!-- Reviewable:end -->
