### PR TITLE
[WIP/RFC] Jit64: FPR lazy conversions

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -2768,6 +2768,23 @@ void XEmitter::PSHUFHW(X64Reg regOp, const OpArg& arg, u8 shuffle)
 }
 
 // VEX
+void XEmitter::VADDSS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)
+{
+  WriteAVXOp(0xF3, sseADD, regOp1, regOp2, arg);
+}
+void XEmitter::VSUBSS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)
+{
+  WriteAVXOp(0xF3, sseSUB, regOp1, regOp2, arg);
+}
+void XEmitter::VMULSS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)
+{
+  WriteAVXOp(0xF3, sseMUL, regOp1, regOp2, arg);
+}
+void XEmitter::VDIVSS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)
+{
+  WriteAVXOp(0xF3, sseDIV, regOp1, regOp2, arg);
+}
+
 void XEmitter::VADDSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg)
 {
   WriteAVXOp(0xF2, sseADD, regOp1, regOp2, arg);

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -868,6 +868,10 @@ public:
   void BLENDPD(X64Reg dest, const OpArg& arg, u8 blend);
 
   // AVX
+  void VADDSS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+  void VSUBSS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+  void VMULSS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
+  void VDIVSS(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
   void VADDSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
   void VSUBSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);
   void VMULSD(X64Reg regOp1, X64Reg regOp2, const OpArg& arg);

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -853,7 +853,10 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
         if (fpr.NumFreeRegisters() < 2)
           break;
         if (ops[i].fprInXmm[reg])
-          fpr.BindToRegister(reg, true, false);
+        {
+          if (!fpr.IsLazySingle(reg))
+            fpr.BindToRegister(reg, true, false);
+        }
       }
 
       Jit64Tables::CompileInstruction(ops[i]);

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -38,6 +38,7 @@ void RegCache::Start()
     regs[i].location = GetDefaultLocation(i);
     regs[i].away = false;
     regs[i].locked = false;
+    regs[i].shape = SHAPE_DEFAULT;
   }
 
   // todo: sort to find the most popular regs
@@ -223,6 +224,7 @@ void RegCache::DiscardRegContentsIfCached(size_t preg)
     xregs[xr].dirty = false;
     xregs[xr].ppcReg = INVALID_REG;
     regs[preg].away = false;
+    regs[preg].shape = SHAPE_DEFAULT;
     regs[preg].location = GetDefaultLocation(preg);
   }
 }
@@ -282,8 +284,11 @@ void RegCache::KillImmediate(size_t preg, bool doLoad, bool makeDirty)
   }
 }
 
-void RegCache::BindToRegister(size_t i, bool doLoad, bool makeDirty)
+void RegCache::BindToRegister(size_t i, bool doLoad, bool makeDirty, int shape)
 {
+  if (doLoad && shape != SHAPE_DEFAULT)
+    PanicAlert("can only load to default shape");
+
   if (!regs[i].away || regs[i].location.IsImm())
   {
     X64Reg xr = GetFreeXReg();
@@ -311,7 +316,10 @@ void RegCache::BindToRegister(size_t i, bool doLoad, bool makeDirty)
     // reg location must be simplereg; memory locations
     // and immediates are taken care of above.
     xregs[RX(i)].dirty |= makeDirty;
+    if (doLoad)
+      ConvertRegister(i, shape);
   }
+  regs[i].shape = shape;
 
   if (xregs[RX(i)].locked)
   {
@@ -342,11 +350,21 @@ void RegCache::StoreFromRegister(size_t i, FlushMode mode)
     }
     OpArg newLoc = GetDefaultLocation(i);
     if (doStore)
+    {
+      if (regs[i].shape != SHAPE_DEFAULT)
+      {
+        uint8_t oldShape = regs[i].shape;
+        ConvertRegister(i, SHAPE_DEFAULT);
+        if (mode == FLUSH_MAINTAIN_STATE)
+          regs[i].shape = oldShape;
+      }
       StoreRegister(i, newLoc);
+    }
     if (mode == FLUSH_ALL)
     {
       regs[i].location = newLoc;
       regs[i].away = false;
+      regs[i].shape = SHAPE_DEFAULT;
     }
   }
 }
@@ -369,6 +387,40 @@ void FPURegCache::LoadRegister(size_t preg, X64Reg newLoc)
 void FPURegCache::StoreRegister(size_t preg, const OpArg& newLoc)
 {
   emit->MOVAPD(newLoc, regs[preg].location.GetSimpleReg());
+}
+
+void GPRRegCache::ConvertRegister(size_t preg, int shape)
+{
+}
+
+void FPURegCache::ConvertRegister(size_t preg, int shape)
+{
+  if (shape == regs[preg].shape)
+    return;
+
+  if (shape == SHAPE_DEFAULT)
+  {
+    if (regs[preg].shape == SHAPE_LAZY_SINGLE)
+    {
+      emit->ConvertSingleToDouble(regs[preg].location.GetSimpleReg(),
+                                  regs[preg].location.GetSimpleReg());
+      regs[preg].shape = SHAPE_DEFAULT;
+    }
+    else if (regs[preg].shape == SHAPE_SAFE_LAZY_SINGLE)
+    {
+      emit->CVTSS2SD(regs[preg].location.GetSimpleReg(), regs[preg].location);
+      emit->MOVDDUP(regs[preg].location.GetSimpleReg(), regs[preg].location);
+    }
+    else
+    {
+      PanicAlert("FPURegCache::ConvertRegister failed");
+    }
+    regs[preg].shape = SHAPE_DEFAULT;
+  }
+  else
+  {
+    PanicAlert("FPURegCache::ConvertRegister can only convert to SHAPE_DEFAULT");
+  }
 }
 
 void RegCache::Flush(FlushMode mode, BitSet32 regsToFlush)

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -16,11 +16,56 @@ enum FlushMode
   FLUSH_MAINTAIN_STATE,
 };
 
+// FPR shape is an optimization to allow deferring conversions (and thereby
+// allowing them to be omitted entirely in many cases).
+//
+// This optimization introduces a number of implicit float-to-double
+// conversions, but no implicit double-to-float conversions and so is correct
+// even if flush-to-zero is modified (as all denormal floats are normal
+// doubles).
+enum FPRShape
+{
+  // The default shape, a pair of doubles. This is the only shape which
+  // can exist in PowerPC::ppcState (other shapes only exist in registers).
+  // It is also the only shape which can always be converted to safely.
+  SHAPE_DEFAULT,
+
+  // A single 32-bit floating point value, loaded from memory. This may
+  // contain any pattern of bits, and must be converted to double losslessly,
+  // safely checking for NaN.
+  SHAPE_LAZY_SINGLE,
+
+  // A single 32-bit floating point value which is the result of a floating
+  // point operation. It is "safe" because the NaN results will not contain
+  // arbitrary bits, so it may be converted to double without preserving NaN
+  // values.
+  SHAPE_SAFE_LAZY_SINGLE,
+
+  // Potential future shapes:
+  //
+  //  SHAPE_PAIRED_SINGLES
+  //    A pair of 32-bit floats. Seems like a good idea - could improve paired
+  //    singles code by avoiding repeated CVTPD2PS, CVTPS2PD rounding.
+  //
+  //  SHAPE_LAZY_DOUBLE
+  //    The value has been promoted to double, but not duplicated. This
+  //    might avoid MOVDDUP in places, although there's already a similar
+  //    optimization implemented, so I doubt this would impact performance
+  //    much.
+  //
+  //  SHAPE_DOUBLE_PRESERVED
+  //    Value has been promoted to double, but the high part hasn't been
+  //    loaded yet. Could spill by only writing the low 64-bits and never
+  //    loading the full register. I suspect this wouldn't be great for
+  //    performance, but it might be worth trying.
+};
+
 struct PPCCachedReg
 {
   Gen::OpArg location;
   bool away;  // value not in source register
   bool locked;
+  uint8_t shape;
 };
 
 struct X64CachedReg
@@ -47,7 +92,7 @@ protected:
   virtual BitSet32 GetRegUtilization() = 0;
   virtual BitSet32 CountRegsIn(size_t preg, u32 lookahead) = 0;
 
-  Gen::XEmitter* emit;
+  EmuCodeBlock* emit;
 
   float ScoreRegister(Gen::X64Reg xreg);
 
@@ -57,7 +102,7 @@ public:
   void Start();
 
   void DiscardRegContentsIfCached(size_t preg);
-  void SetEmitter(Gen::XEmitter* emitter) { emit = emitter; }
+  void SetEmitter(EmuCodeBlock* emitter) { emit = emitter; }
   void FlushR(Gen::X64Reg reg);
   void FlushR(Gen::X64Reg reg, Gen::X64Reg reg2)
   {
@@ -85,13 +130,15 @@ public:
 
   // TODO - instead of doload, use "read", "write"
   // read only will not set dirty flag
-  void BindToRegister(size_t preg, bool doLoad = true, bool makeDirty = true);
+  void BindToRegister(size_t preg, bool doLoad = true, bool makeDirty = true,
+                      int shape = SHAPE_DEFAULT);
   void StoreFromRegister(size_t preg, FlushMode mode = FLUSH_ALL);
   virtual void StoreRegister(size_t preg, const Gen::OpArg& newLoc) = 0;
   virtual void LoadRegister(size_t preg, Gen::X64Reg newLoc) = 0;
+  virtual void ConvertRegister(size_t preg, int shape) = 0;
 
-  const Gen::OpArg& R(size_t preg) const { return regs[preg].location; }
-  Gen::X64Reg RX(size_t preg) const
+  const Gen::OpArg& R(size_t preg) { return regs[preg].location; }
+  Gen::X64Reg RX(size_t preg)
   {
     if (IsBound(preg))
       return regs[preg].location.GetSimpleReg();
@@ -103,6 +150,7 @@ public:
 
   // Register locking.
 
+  void LockAnyShape(size_t p) { regs[p].locked = true; }
   // these are powerpc reg indices
   template <typename T>
   void Lock(T p)
@@ -164,6 +212,7 @@ public:
   void SetImmediate32(size_t preg, u32 immValue, bool dirty = true);
   BitSet32 GetRegUtilization() override;
   BitSet32 CountRegsIn(size_t preg, u32 lookahead) override;
+  void ConvertRegister(size_t preg, int shape) override;
 };
 
 class FPURegCache final : public RegCache
@@ -175,4 +224,55 @@ public:
   Gen::OpArg GetDefaultLocation(size_t reg) const override;
   BitSet32 GetRegUtilization() override;
   BitSet32 CountRegsIn(size_t preg, u32 lookahead) override;
+  void ConvertRegister(size_t preg, int shape) override;
+
+  bool IsLazySingle(size_t preg)
+  {
+    return regs[preg].shape == SHAPE_LAZY_SINGLE || regs[preg].shape == SHAPE_SAFE_LAZY_SINGLE;
+  }
+
+  const Gen::OpArg& R(size_t preg) { return regs[preg].location; }
+  Gen::X64Reg RX(size_t preg)
+  {
+    if (IsBound(preg))
+    {
+      return regs[preg].location.GetSimpleReg();
+    }
+
+    PanicAlert("Unbound register - %zu", preg);
+    return Gen::INVALID_REG;
+  }
+
+  const Gen::OpArg& R_lazy_single(size_t preg)
+  {
+    if (!IsLazySingle(preg))
+      PanicAlert("Not a lazy single!");
+    return regs[preg].location;
+  }
+
+  Gen::X64Reg RX_lazy_single(size_t preg)
+  {
+    if (IsBound(preg))
+    {
+      return R_lazy_single(preg).GetSimpleReg();
+    }
+
+    PanicAlert("Unbound register - %zu", preg);
+    return Gen::INVALID_REG;
+  }
+
+  void MarkSafeLazySingle(size_t preg) { regs[preg].shape = SHAPE_SAFE_LAZY_SINGLE; }
+  // these are powerpc reg indices
+  template <typename T>
+  void EnsureDefaultShape(T p)
+  {
+    if (regs[p].shape != SHAPE_DEFAULT)
+      ConvertRegister(p, SHAPE_DEFAULT);
+  }
+  template <typename T, typename... Args>
+  void EnsureDefaultShape(T first, Args... args)
+  {
+    EnsureDefaultShape(first);
+    EnsureDefaultShape(args...);
+  }
 };

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -185,14 +185,14 @@ void Jit64::bcctrx(UGeckoInstruction inst)
 
     FixupBranch b =
         JumpIfCRFieldBit(inst.BI >> 2, 3 - (inst.BI & 3), !(inst.BO_2 & BO_BRANCH_IF_TRUE));
+    gpr.Flush(FLUSH_MAINTAIN_STATE);
+    fpr.Flush(FLUSH_MAINTAIN_STATE);
     MOV(32, R(RSCRATCH), PPCSTATE_CTR);
     AND(32, R(RSCRATCH), Imm32(0xFFFFFFFC));
     // MOV(32, PPCSTATE(pc), R(RSCRATCH)); => Already done in WriteExitDestInRSCRATCH()
     if (inst.LK_3)
       MOV(32, PPCSTATE_LR, Imm32(js.compilerPC + 4));  // LR = PC + 4;
 
-    gpr.Flush(FLUSH_MAINTAIN_STATE);
-    fpr.Flush(FLUSH_MAINTAIN_STATE);
     WriteExitDestInRSCRATCH(inst.LK_3, js.compilerPC + 4);
     // Would really like to continue the block here, but it ends. TODO.
     SetJumpTarget(b);
@@ -234,6 +234,9 @@ void Jit64::bclrx(UGeckoInstruction inst)
   AND(32, PPCSTATE(cr), Imm32(~(0xFF000000)));
 #endif
 
+  gpr.Flush(FLUSH_MAINTAIN_STATE);
+  fpr.Flush(FLUSH_MAINTAIN_STATE);
+
   MOV(32, R(RSCRATCH), PPCSTATE_LR);
   // We don't have to do this because WriteBLRExit handles it for us. Specifically, since we only
   // ever push
@@ -245,8 +248,6 @@ void Jit64::bclrx(UGeckoInstruction inst)
   if (inst.LK)
     MOV(32, PPCSTATE_LR, Imm32(js.compilerPC + 4));
 
-  gpr.Flush(FLUSH_MAINTAIN_STATE);
-  fpr.Flush(FLUSH_MAINTAIN_STATE);
   WriteBLRExit();
 
   if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -31,6 +31,7 @@ X64Reg Jit64::fp_tri_op(int d, int a, int b, bool reversible, bool single,
                         bool preserve_inputs, bool roundRHS)
 {
   fpr.Lock(d, a, b);
+  fpr.EnsureDefaultShape(a, b);
   fpr.BindToRegister(d, d == a || d == b || !single);
   X64Reg dest = preserve_inputs ? XMM1 : fpr.RX(d);
   if (roundRHS)
@@ -196,36 +197,102 @@ void Jit64::fp_arith(UGeckoInstruction inst)
   if (inst.OPCD == 59 && (inst.SUBOP5 == 18 || cpu_info.bAtom))
     packed = false;
 
-  bool round_input = single && !jit->js.op->fprIsSingle[inst.FC];
-  bool preserve_inputs = SConfig::GetInstance().bAccurateNaNs;
-
-  X64Reg dest = INVALID_REG;
-  switch (inst.SUBOP5)
+  // lazy single optimization for "add" and "sub"
+  if (single && fpr.IsLazySingle(a) && fpr.IsLazySingle(arg2) &&
+      !SConfig::GetInstance().bAccurateNaNs && !(SConfig::GetInstance().bFPRF && js.op->wantsFPRF))
   {
-  case 18:
-    dest = fp_tri_op(d, a, b, false, single, packed ? &XEmitter::VDIVPD : &XEmitter::VDIVSD,
-                     packed ? &XEmitter::DIVPD : &XEmitter::DIVSD, packed, preserve_inputs);
-    break;
-  case 20:
-    dest = fp_tri_op(d, a, b, false, single, packed ? &XEmitter::VSUBPD : &XEmitter::VSUBSD,
-                     packed ? &XEmitter::SUBPD : &XEmitter::SUBSD, packed, preserve_inputs);
-    break;
-  case 21:
-    dest = fp_tri_op(d, a, b, true, single, packed ? &XEmitter::VADDPD : &XEmitter::VADDSD,
-                     packed ? &XEmitter::ADDPD : &XEmitter::ADDSD, packed, preserve_inputs);
-    break;
-  case 25:
-    dest = fp_tri_op(d, a, c, true, single, packed ? &XEmitter::VMULPD : &XEmitter::VMULSD,
-                     packed ? &XEmitter::MULPD : &XEmitter::MULSD, packed, preserve_inputs,
-                     round_input);
-    break;
-  default:
-    _assert_msg_(DYNA_REC, 0, "fp_arith WTF!!!");
+    // this assumes that lazy singles are always in dirty registers
+    fpr.LockAnyShape(a);
+    fpr.LockAnyShape(arg2);
+
+    Gen::X64Reg opa = fpr.RX_lazy_single(a);
+    Gen::X64Reg opb = fpr.RX_lazy_single(arg2);
+
+    Gen::X64Reg dest;
+    if (d == a)
+    {
+      dest = opa;
+    }
+    else if (d == arg2)
+    {
+      dest = opb;
+    }
+    else
+    {
+      fpr.BindToRegister(d, false, true, SHAPE_LAZY_SINGLE);
+      dest = fpr.RX_lazy_single(d);
+    }
+
+    switch (inst.SUBOP5)
+    {
+    case 18:
+      avx_op(&XEmitter::VDIVSS, &XEmitter::DIVSS, dest, R(opa), R(opb), false, false);
+      break;
+    case 20:
+      avx_op(&XEmitter::VSUBSS, &XEmitter::SUBSS, dest, R(opa), R(opb), false, false);
+      break;
+    case 21:
+      avx_op(&XEmitter::VADDSS, &XEmitter::ADDSS, dest, R(opa), R(opb), false, true);
+      break;
+    case 25:
+      avx_op(&XEmitter::VMULSS, &XEmitter::MULSS, dest, R(opa), R(opb), false, true);
+      break;
+    default:
+      _assert_msg_(DYNA_REC, 0, "fp_arith lazy WTF!!!");
+    }
+    fpr.MarkSafeLazySingle(d);
   }
-  HandleNaNs(inst, fpr.RX(d), dest);
-  if (single)
-    ForceSinglePrecision(fpr.RX(d), fpr.R(d), packed, true);
-  SetFPRFIfNeeded(fpr.RX(d));
+  else
+  {
+    fpr.EnsureDefaultShape(a, arg2);
+    if (!single)
+      fpr.EnsureDefaultShape(d);
+
+    bool round_input = single && !jit->js.op->fprIsSingle[inst.FC];
+    bool preserve_inputs = SConfig::GetInstance().bAccurateNaNs;
+
+    X64Reg dest = INVALID_REG;
+    switch (inst.SUBOP5)
+    {
+    case 18:
+      dest = fp_tri_op(d, a, b, false, single, packed ? &XEmitter::VDIVPD : &XEmitter::VDIVSD,
+                       packed ? &XEmitter::DIVPD : &XEmitter::DIVSD, packed, preserve_inputs);
+      break;
+    case 20:
+      dest = fp_tri_op(d, a, b, false, single, packed ? &XEmitter::VSUBPD : &XEmitter::VSUBSD,
+                       packed ? &XEmitter::SUBPD : &XEmitter::SUBSD, packed, preserve_inputs);
+      break;
+    case 21:
+      dest = fp_tri_op(d, a, b, true, single, packed ? &XEmitter::VADDPD : &XEmitter::VADDSD,
+                       packed ? &XEmitter::ADDPD : &XEmitter::ADDSD, packed, preserve_inputs);
+      break;
+    case 25:
+      dest = fp_tri_op(d, a, c, true, single, packed ? &XEmitter::VMULPD : &XEmitter::VMULSD,
+                       packed ? &XEmitter::MULPD : &XEmitter::MULSD, packed, preserve_inputs,
+                       round_input);
+      break;
+    default:
+      _assert_msg_(DYNA_REC, 0, "fp_arith WTF!!!");
+    }
+    HandleNaNs(inst, fpr.RX(d), dest);
+    if (single)
+    {
+      if (!packed)
+      {
+        CVTSD2SS(fpr.RX(d), fpr.R(d));
+        fpr.MarkSafeLazySingle(d);
+      }
+      else
+      {
+        ForceSinglePrecision(fpr.RX(d), fpr.R(d), packed, true);
+      }
+    }
+
+    if (SConfig::GetInstance().bFPRF && js.op->wantsFPRF)
+    {
+      SetFPRFIfNeeded(fpr.RX(d));
+    }
+  }
   fpr.UnlockAll();
 }
 
@@ -246,6 +313,10 @@ void Jit64::fmaddXX(UGeckoInstruction inst)
                          jit->js.op->fprIsDuplicated[b] && jit->js.op->fprIsDuplicated[c]);
 
   fpr.Lock(a, b, c, d);
+
+  fpr.EnsureDefaultShape(a, b, c);
+  if (!single)
+    fpr.EnsureDefaultShape(d);
 
   switch (inst.SUBOP5)
   {
@@ -377,6 +448,8 @@ void Jit64::fsign(UGeckoInstruction inst)
   int b = inst.FB;
   bool packed = inst.OPCD == 4;
 
+  fpr.EnsureDefaultShape(b);
+
   fpr.Lock(b, d);
   OpArg src = fpr.R(b);
   fpr.BindToRegister(d, false);
@@ -414,6 +487,10 @@ void Jit64::fselx(UGeckoInstruction inst)
   int c = inst.FC;
 
   bool packed = inst.OPCD == 4;  // ps_sel
+
+  fpr.EnsureDefaultShape(a, b, c);
+  if (!packed)
+    fpr.EnsureDefaultShape(d);
 
   fpr.Lock(a, b, c, d);
   XORPD(XMM0, R(XMM0));
@@ -458,6 +535,7 @@ void Jit64::fmrx(UGeckoInstruction inst)
   if (d == b)
     return;
 
+  fpr.EnsureDefaultShape(b, d);
   fpr.Lock(b, d);
 
   if (fpr.IsBound(d))
@@ -502,23 +580,32 @@ void Jit64::FloatCompare(UGeckoInstruction inst, bool upper)
     output[3 - (next.CRBA & 3)] |= 1 << dst;
     output[3 - (next.CRBB & 3)] |= 1 << dst;
   }
-
-  fpr.Lock(a, b);
-  fpr.BindToRegister(b, true, false);
-
-  if (fprf)
-    AND(32, PPCSTATE(fpscr), Imm32(~FPRF_MASK));
-
-  if (upper)
+  if (fpr.IsLazySingle(a) && fpr.IsLazySingle(b) && !upper && !fprf)
   {
-    fpr.BindToRegister(a, true, false);
-    MOVHLPS(XMM0, fpr.RX(a));
-    MOVHLPS(XMM1, fpr.RX(b));
-    UCOMISD(XMM1, R(XMM0));
+    fpr.LockAnyShape(a);
+    fpr.LockAnyShape(b);
+    UCOMISS(fpr.RX_lazy_single(b), fpr.R_lazy_single(a));
   }
   else
   {
-    UCOMISD(fpr.RX(b), fpr.R(a));
+    fpr.EnsureDefaultShape(a, b);
+    fpr.Lock(a, b);
+    fpr.BindToRegister(b, true, false);
+
+    if (fprf)
+      AND(32, PPCSTATE(fpscr), Imm32(~FPRF_MASK));
+
+    if (upper)
+    {
+      fpr.BindToRegister(a, true, false);
+      MOVHLPS(XMM0, fpr.RX(a));
+      MOVHLPS(XMM1, fpr.RX(b));
+      UCOMISD(XMM1, R(XMM0));
+    }
+    else
+    {
+      UCOMISD(fpr.RX(b), fpr.R(a));
+    }
   }
 
   FixupBranch pNaN, pLesser, pGreater;
@@ -594,6 +681,8 @@ void Jit64::fctiwx(UGeckoInstruction inst)
 
   int d = inst.RD;
   int b = inst.RB;
+
+  fpr.EnsureDefaultShape(d, b);
   fpr.Lock(d, b);
   fpr.BindToRegister(d);
 
@@ -634,6 +723,9 @@ void Jit64::frspx(UGeckoInstruction inst)
   FALLBACK_IF(inst.Rc);
   int b = inst.FB;
   int d = inst.FD;
+
+  fpr.EnsureDefaultShape(b);
+
   bool packed = jit->js.op->fprIsDuplicated[b] && !cpu_info.bAtom;
 
   fpr.Lock(b, d);
@@ -651,6 +743,8 @@ void Jit64::frsqrtex(UGeckoInstruction inst)
   FALLBACK_IF(inst.Rc);
   int b = inst.FB;
   int d = inst.FD;
+
+  fpr.EnsureDefaultShape(d, b);
 
   gpr.FlushLockX(RSCRATCH_EXTRA);
   fpr.Lock(b, d);
@@ -670,6 +764,8 @@ void Jit64::fresx(UGeckoInstruction inst)
   FALLBACK_IF(inst.Rc);
   int b = inst.FB;
   int d = inst.FD;
+
+  fpr.EnsureDefaultShape(b);
 
   gpr.FlushLockX(RSCRATCH_EXTRA);
   fpr.Lock(b, d);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -31,6 +31,9 @@ void Jit64::lfXXX(UGeckoInstruction inst)
 
   FALLBACK_IF(!indexed && !a);
 
+  if (!single || jo.memcheck)
+    fpr.EnsureDefaultShape(d);
+
   gpr.BindToRegister(a, true, update);
 
   s32 offset = 0;
@@ -66,7 +69,23 @@ void Jit64::lfXXX(UGeckoInstruction inst)
     fpr.StoreFromRegister(d);
     js.revertFprLoad = d;
   }
-  fpr.BindToRegister(d, !single);
+  // TODO: get this from the analyst
+  bool generateLazySingle = true;
+  if (single)
+  {
+    if (generateLazySingle)
+    {
+      fpr.BindToRegister(d, false, true, SHAPE_LAZY_SINGLE);
+    }
+    else
+    {
+      fpr.BindToRegister(d, false);
+    }
+  }
+  else
+  {
+    fpr.BindToRegister(d, true);
+  }
   BitSet32 registersInUse = CallerSavedRegistersInUse();
   if (update && jo.memcheck)
     registersInUse[RSCRATCH2] = true;
@@ -74,7 +93,10 @@ void Jit64::lfXXX(UGeckoInstruction inst)
 
   if (single)
   {
-    ConvertSingleToDouble(fpr.RX(d), RSCRATCH, true);
+    if (generateLazySingle)
+      MOVD_xmm(fpr.RX_lazy_single(d), R(RSCRATCH));
+    else
+      ConvertSingleToDouble(fpr.RX(d), RSCRATCH, true);
   }
   else
   {
@@ -106,19 +128,27 @@ void Jit64::stfXXX(UGeckoInstruction inst)
 
   if (single)
   {
-    if (jit->js.op->fprIsStoreSafe[s])
+    if (fpr.IsLazySingle(s))
     {
+      MOVD_xmm(R(RSCRATCH), fpr.RX_lazy_single(s));
+    }
+    else if (jit->js.op->fprIsStoreSafe[s])
+    {
+      fpr.EnsureDefaultShape(s);
       CVTSD2SS(XMM0, fpr.R(s));
+      MOVD_xmm(R(RSCRATCH), XMM0);
     }
     else
     {
+      fpr.EnsureDefaultShape(s);
       fpr.BindToRegister(s, true, false);
       ConvertDoubleToSingle(XMM0, fpr.RX(s));
+      MOVD_xmm(R(RSCRATCH), XMM0);
     }
-    MOVD_xmm(R(RSCRATCH), XMM0);
   }
   else
   {
+    fpr.EnsureDefaultShape(s);
     if (fpr.R(s).IsSimpleReg())
       MOVQ_xmm(R(RSCRATCH), fpr.RX(s));
     else
@@ -193,6 +223,8 @@ void Jit64::stfiwx(UGeckoInstruction inst)
   int s = inst.RS;
   int a = inst.RA;
   int b = inst.RB;
+
+  fpr.EnsureDefaultShape(s);
 
   MOV_sum(32, RSCRATCH2, a ? gpr.R(a) : Imm32(0), gpr.R(b));
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -37,6 +37,8 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
   int w = indexed ? inst.Wx : inst.W;
   FALLBACK_IF(!a);
 
+  fpr.EnsureDefaultShape(s);
+
   auto it = js.constantGqr.find(i);
   bool gqrIsConstant = it != js.constantGqr.end();
   u32 gqrValue = gqrIsConstant ? it->second & 0xffff : 0;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Paired.cpp
@@ -22,6 +22,8 @@ void Jit64::ps_mr(UGeckoInstruction inst)
   if (d == b)
     return;
 
+  fpr.EnsureDefaultShape(b);
+
   fpr.BindToRegister(d, false);
   MOVAPD(fpr.RX(d), fpr.R(b));
 }
@@ -36,6 +38,9 @@ void Jit64::ps_sum(UGeckoInstruction inst)
   int a = inst.FA;
   int b = inst.FB;
   int c = inst.FC;
+
+  fpr.EnsureDefaultShape(a, b, c);
+
   fpr.Lock(a, b, c, d);
   OpArg op_a = fpr.R(a);
   fpr.BindToRegister(d, d == b || d == c);
@@ -85,6 +90,7 @@ void Jit64::ps_muls(UGeckoInstruction inst)
   int a = inst.FA;
   int c = inst.FC;
   bool round_input = !jit->js.op->fprIsSingle[c];
+  fpr.EnsureDefaultShape(a, c);
   fpr.Lock(a, c, d);
   switch (inst.SUBOP5)
   {
@@ -116,6 +122,7 @@ void Jit64::ps_mergeXX(UGeckoInstruction inst)
   int d = inst.FD;
   int a = inst.FA;
   int b = inst.FB;
+  fpr.EnsureDefaultShape(a, b);
   fpr.Lock(a, b, d);
   fpr.BindToRegister(d, d == a || d == b);
 
@@ -147,6 +154,8 @@ void Jit64::ps_rsqrte(UGeckoInstruction inst)
   int b = inst.FB;
   int d = inst.FD;
 
+  fpr.EnsureDefaultShape(b);
+
   gpr.FlushLockX(RSCRATCH_EXTRA);
   fpr.Lock(b, d);
   fpr.BindToRegister(b, true, false);
@@ -173,6 +182,8 @@ void Jit64::ps_res(UGeckoInstruction inst)
   FALLBACK_IF(inst.Rc);
   int b = inst.FB;
   int d = inst.FD;
+
+  fpr.EnsureDefaultShape(b);
 
   gpr.FlushLockX(RSCRATCH_EXTRA);
   fpr.Lock(b, d);

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.cpp
@@ -960,18 +960,31 @@ void EmuCodeBlock::ConvertSingleToDouble(X64Reg dst, X64Reg src, bool src_is_gpr
 
   UCOMISS(dst, R(dst));
   CVTSS2SD(dst, R(dst));
-  FixupBranch nanConversion = J_CC(CC_P, true);
 
-  SwitchToFarCode();
-  SetJumpTarget(nanConversion);
-  TEST(32, R(gprsrc), Imm32(0x00400000));
-  FixupBranch continue1 = J_CC(CC_NZ, true);
-  ANDPD(dst, M(&double_qnan_bit));
-  FixupBranch continue2 = J(true);
-  SwitchToNearCode();
+  if (!InFarCode())
+  {
+    FixupBranch nanConversion = J_CC(CC_P, true);
+    SwitchToFarCode();
+    SetJumpTarget(nanConversion);
+    TEST(32, R(gprsrc), Imm32(0x00400000));
+    FixupBranch continue1 = J_CC(CC_NZ, true);
+    ANDPD(dst, M(&double_qnan_bit));
+    FixupBranch continue2 = J(true);
+    SwitchToNearCode();
 
-  SetJumpTarget(continue1);
-  SetJumpTarget(continue2);
+    SetJumpTarget(continue1);
+    SetJumpTarget(continue2);
+  }
+  else
+  {
+    FixupBranch noNanConversion = J_CC(CC_NP);
+    TEST(32, R(gprsrc), Imm32(0x00400000));
+    FixupBranch continue1 = J_CC(CC_NZ);
+    ANDPD(dst, M(&double_qnan_bit));
+    SetJumpTarget(noNanConversion);
+    SetJumpTarget(continue1);
+  }
+
   MOVDDUP(dst, R(dst));
 }
 

--- a/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
+++ b/Source/Core/Core/PowerPC/JitCommon/Jit_Util.h
@@ -106,22 +106,30 @@ class EmuCodeBlock : public Gen::X64CodeBlock
 public:
   FarCodeCache farcode;
   u8* nearcode;  // Backed up when we switch to far code.
+  bool inFarCode = false;
 
   void MemoryExceptionCheck();
 
   // Simple functions to switch between near and far code emitting
   void SwitchToFarCode()
   {
+    if (inFarCode)
+      PanicAlert("SwitchToFarCode from far code");
+    inFarCode = true;
     nearcode = GetWritableCodePtr();
     SetCodePtr(farcode.GetWritableCodePtr());
   }
 
   void SwitchToNearCode()
   {
+    if (!inFarCode)
+      PanicAlert("SwitchToNearCode from near code");
+    inFarCode = false;
     farcode.SetCodePtr(GetWritableCodePtr());
     SetCodePtr(nearcode);
   }
 
+  bool InFarCode() { return inFarCode; }
   Gen::FixupBranch CheckIfSafeAddress(const Gen::OpArg& reg_value, Gen::X64Reg reg_addr,
                                       BitSet32 registers_in_use);
   void UnsafeLoadRegToReg(Gen::X64Reg reg_addr, Gen::X64Reg reg_value, int accessSize,


### PR DESCRIPTION
This'll conflict pretty heavily with #3565 so I thought I'd share it so we can start thinking about how best to combine the ideas (if people think this optimisation is worthwhile).

This makes a lot of single-float code generate many fewer instructions, sometimes just one x86-64 instructions per PPC float instruction.

I'm in no hurry to merge this, but would be interested in getting feedback on the idea, and maybe numbers on if it actually improves performance (as I hope it will :) )

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3955)

<!-- Reviewable:end -->
