### PR TITLE
Add MOV optimizations and MOV_sum

### DIFF
--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -310,6 +310,7 @@ struct OpArg
   }
   bool IsSimpleReg() const { return scale == SCALE_NONE; }
   bool IsSimpleReg(X64Reg reg) const { return IsSimpleReg() && GetSimpleReg() == reg; }
+  bool IsZero() const { return IsImm() && offset == 0; }
   int GetImmBits() const
   {
     switch (scale)
@@ -639,6 +640,7 @@ public:
   void TEST(int bits, const OpArg& a1, const OpArg& a2);
 
   void CMP_or_TEST(int bits, const OpArg& a1, const OpArg& a2);
+  void MOV_sum(int bits, X64Reg dest, const OpArg& a1, const OpArg& a2);
 
   // Are these useful at all? Consider removing.
   void XCHG(int bits, const OpArg& a1, const OpArg& a2);

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStoreFloating.cpp
@@ -50,14 +50,7 @@ void Jit64::lfXXX(UGeckoInstruction inst)
     else
     {
       addr = R(RSCRATCH2);
-      if (a && gpr.R(a).IsSimpleReg() && gpr.R(b).IsSimpleReg())
-        LEA(32, RSCRATCH2, MRegSum(gpr.RX(a), gpr.RX(b)));
-      else
-      {
-        MOV(32, addr, gpr.R(b));
-        if (a)
-          ADD(32, addr, gpr.R(a));
-      }
+      MOV_sum(32, RSCRATCH2, a ? gpr.R(a) : Imm32(0), gpr.R(b));
     }
   }
   else
@@ -162,14 +155,7 @@ void Jit64::stfXXX(UGeckoInstruction inst)
     gpr.BindToRegister(a, true, true);
   if (indexed)
   {
-    if (a && gpr.R(a).IsSimpleReg() && gpr.R(b).IsSimpleReg())
-      LEA(32, RSCRATCH2, MRegSum(gpr.RX(a), gpr.RX(b)));
-    else
-    {
-      MOV(32, R(RSCRATCH2), gpr.R(b));
-      if (a)
-        ADD(32, R(RSCRATCH2), gpr.R(a));
-    }
+    MOV_sum(32, RSCRATCH2, a ? gpr.R(a) : Imm32(0), gpr.R(b));
   }
   else
   {
@@ -209,9 +195,7 @@ void Jit64::stfiwx(UGeckoInstruction inst)
   int a = inst.RA;
   int b = inst.RB;
 
-  MOV(32, R(RSCRATCH2), gpr.R(b));
-  if (a)
-    ADD(32, R(RSCRATCH2), gpr.R(a));
+  MOV_sum(32, RSCRATCH2, a ? gpr.R(a) : Imm32(0), gpr.R(b));
 
   if (fpr.R(s).IsSimpleReg())
     MOVD_xmm(R(RSCRATCH), fpr.RX(s));

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -43,21 +43,9 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
   gpr.FlushLockX(RSCRATCH_EXTRA);
   if (update)
     gpr.BindToRegister(a, true, true);
-  if (gpr.R(a).IsSimpleReg() && gpr.R(b).IsSimpleReg() && (indexed || offset))
-  {
-    if (indexed)
-      LEA(32, RSCRATCH_EXTRA, MRegSum(gpr.RX(a), gpr.RX(b)));
-    else
-      LEA(32, RSCRATCH_EXTRA, MDisp(gpr.RX(a), offset));
-  }
-  else
-  {
-    MOV(32, R(RSCRATCH_EXTRA), gpr.R(a));
-    if (indexed)
-      ADD(32, R(RSCRATCH_EXTRA), gpr.R(b));
-    else if (offset)
-      ADD(32, R(RSCRATCH_EXTRA), Imm32((u32)offset));
-  }
+
+  MOV_sum(32, RSCRATCH_EXTRA, gpr.R(a), indexed ? gpr.R(b) : Imm32((u32)offset));
+
   // In memcheck mode, don't update the address until the exception check
   if (update && !jo.memcheck)
     MOV(32, gpr.R(a), R(RSCRATCH_EXTRA));
@@ -143,21 +131,9 @@ void Jit64::psq_lXX(UGeckoInstruction inst)
   gpr.FlushLockX(RSCRATCH_EXTRA);
   gpr.BindToRegister(a, true, update);
   fpr.BindToRegister(s, false, true);
-  if (gpr.R(a).IsSimpleReg() && gpr.R(b).IsSimpleReg() && (indexed || offset))
-  {
-    if (indexed)
-      LEA(32, RSCRATCH_EXTRA, MRegSum(gpr.RX(a), gpr.RX(b)));
-    else
-      LEA(32, RSCRATCH_EXTRA, MDisp(gpr.RX(a), offset));
-  }
-  else
-  {
-    MOV(32, R(RSCRATCH_EXTRA), gpr.R(a));
-    if (indexed)
-      ADD(32, R(RSCRATCH_EXTRA), gpr.R(b));
-    else if (offset)
-      ADD(32, R(RSCRATCH_EXTRA), Imm32((u32)offset));
-  }
+
+  MOV_sum(32, RSCRATCH_EXTRA, gpr.R(a), indexed ? gpr.R(b) : Imm32((u32)offset));
+
   // In memcheck mode, don't update the address until the exception check
   if (update && !jo.memcheck)
     MOV(32, gpr.R(a), R(RSCRATCH_EXTRA));


### PR DESCRIPTION
This is a simple refactoring that replaces the A=B+C pattern throughout the code with a `MOV_sum` meta-instruction so we can apply optimizations consistently.

This shouldn't have any performance implications one way or another, but it paves the way for the code refactoring in #3565 

Split into a separate PR per discussion w / @magumagu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3956)
<!-- Reviewable:end -->
