### PR TITLE
Fix SCMRevGen for 64-bit MSBuild

### DIFF
--- a/Source/Core/Common/SCMRevGen.vcxproj
+++ b/Source/Core/Common/SCMRevGen.vcxproj
@@ -26,7 +26,10 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\..\VSProps\Base.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Label="UserMacros">
+    <CScript Condition="'$(ProgramFiles(x86))' != ''">%windir%\System32\cscript</CScript>
+    <CScript Condition="'$(ProgramFiles(x86))' == ''">%windir%\Sysnative\cscript</CScript>
+  </PropertyGroup>
   <!--
     OutDir is always created, which is annoying for SCMRevGen as it doesn't really have an outdir.
     Here it's redirected to some other place to hide the annoyance.
@@ -36,7 +39,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>"%windir%\Sysnative\cscript" /nologo /E:JScript "make_scmrev.h.js"</Command>
+      <Command>"$(CScript)" /nologo /E:JScript "make_scmrev.h.js"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This is an addition to the https://github.com/dolphin-emu/dolphin/pull/3512 PR. As @Nucleoprotein mentioned (https://github.com/dolphin-emu/dolphin/pull/3512#issuecomment-228617847) the "Sysnative" redirector is not available to 64-bit processes.

However "ProgramFiles(x86)" Macro is only set for 64-bit, otherwise it is empty. Therefore it can be used as condition to check whether the current MSBuild process is 32 or 64-bit.

**Note:** i do not have 64-bit MSBuild installed, therefore was not able to test it for 64-bit @delroth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3958)
<!-- Reviewable:end -->
