### PR TITLE
D3D: Fix crash on start with BBox enabled

### DIFF
--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -162,6 +162,7 @@ void VideoBackend::Video_Prepare()
   PixelShaderCache::Init();
   GeometryShaderCache::Init();
   D3D::InitUtils();
+  BBox::Init();
 }
 
 void VideoBackend::Shutdown()

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -181,6 +181,7 @@ void VideoBackend::Video_Prepare()
   StaticShaderCache::Init();
   StateCache::Init();  // PSO cache is populated here, after constituent shaders are loaded.
   D3D::InitUtils();
+  BBox::Init();
 }
 
 void VideoBackend::Shutdown()


### PR DESCRIPTION
Someone removed the BBox::Init(), causing crashes when BBox is enabled.

Fixes issue [#9643](https://bugs.dolphin-emu.org/issues/9643).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3959)
<!-- Reviewable:end -->
