### PR TITLE
XFB: Send image to screen at start of field (Reduce VirtualXFB latency)

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -700,13 +700,16 @@ static void BeginField(FieldType field)
   DEBUG_LOG(VIDEOINTERFACE, "HorizScaling: %04x | fbwidth %d | %u | %u", m_HorizontalScaling.Hex,
             m_FBWidth.Hex, GetTicksPerEvenField(), GetTicksPerOddField());
 
+  // This assumes the game isn't going to change the VI registers while a
+  // frame is scanning out.
+  // To correctly handle that case we would need to collate all changes
+  // to VI during scanout and delay outputting the frame till then.
   if (xfbAddr)
     g_video_backend->Video_BeginField(xfbAddr, fbWidth, fbStride, fbHeight);
 }
 
 static void EndField()
 {
-  g_video_backend->Video_EndField();
   Core::VideoThrottle();
 }
 

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -49,18 +49,6 @@ void VideoBackendBase::Video_ExitLoop()
 // Run from the CPU thread (from VideoInterface.cpp)
 void VideoBackendBase::Video_BeginField(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight)
 {
-  if (m_initialized && g_ActiveConfig.bUseXFB)
-  {
-    s_beginFieldArgs.xfbAddr = xfbAddr;
-    s_beginFieldArgs.fbWidth = fbWidth;
-    s_beginFieldArgs.fbStride = fbStride;
-    s_beginFieldArgs.fbHeight = fbHeight;
-  }
-}
-
-// Run from the CPU thread (from VideoInterface.cpp)
-void VideoBackendBase::Video_EndField()
-{
   if (m_initialized && g_ActiveConfig.bUseXFB && g_renderer)
   {
     Fifo::SyncGPU(Fifo::SYNC_GPU_SWAP);
@@ -69,10 +57,10 @@ void VideoBackendBase::Video_EndField()
     e.time = 0;
     e.type = AsyncRequests::Event::SWAP_EVENT;
 
-    e.swap_event.xfbAddr = s_beginFieldArgs.xfbAddr;
-    e.swap_event.fbWidth = s_beginFieldArgs.fbWidth;
-    e.swap_event.fbStride = s_beginFieldArgs.fbStride;
-    e.swap_event.fbHeight = s_beginFieldArgs.fbHeight;
+    e.swap_event.xfbAddr = xfbAddr;
+    e.swap_event.fbWidth = fbWidth;
+    e.swap_event.fbStride = fbStride;
+    e.swap_event.fbHeight = fbHeight;
     AsyncRequests::GetInstance()->PushEvent(e, false);
   }
 }

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -81,7 +81,6 @@ public:
   virtual void Video_Cleanup() = 0;  // called from gl/d3d thread
 
   void Video_BeginField(u32, u32, u32, u32);
-  void Video_EndField();
 
   u32 Video_AccessEFB(EFBAccessType, u32, u32, u32);
   u32 Video_GetQueryResult(PerfQueryType type);


### PR DESCRIPTION
This is much more accurate to the hardware, and saves around 16ms of latency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3961)
<!-- Reviewable:end -->
