### PR TITLE
VolumeGC: Set m_banner_loaded when banner loading fails

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -205,6 +205,8 @@ void CVolumeGC::LoadBannerFile() const
   if (m_banner_loaded)
     return;
 
+  m_banner_loaded = true;
+
   GCBanner banner_file;
   std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this));
   size_t file_size = (size_t)file_system->GetFileSize("opening.bnr");
@@ -235,7 +237,6 @@ void CVolumeGC::LoadBannerFile() const
   }
 
   ExtractBannerInformation(banner_file, is_bnr1);
-  m_banner_loaded = true;
 }
 
 void CVolumeGC::ExtractBannerInformation(const GCBanner& banner_file, bool is_bnr1) const


### PR DESCRIPTION
If banner loading fails once, it will very likely fail again. Setting m_banner_loaded to true when banner loading fails prevents LoadBannerFile from wasting time if it's called again. Banner loading requires loading the file system, which takes a noticeable amount of time, so this matters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3963)
<!-- Reviewable:end -->
