### PR TITLE
Jit: Remove unsafe MOV optimization

### DIFF
--- a/Source/Core/Common/x64Emitter.cpp
+++ b/Source/Core/Common/x64Emitter.cpp
@@ -1540,13 +1540,6 @@ void XEmitter::XOR(int bits, const OpArg& a1, const OpArg& a2)
 }
 void XEmitter::MOV(int bits, const OpArg& a1, const OpArg& a2)
 {
-  // Shortcut to zero a register
-  if (a2.IsZero() && a1.IsSimpleReg() && !flags_locked)
-  {
-    XOR(bits, a1, a1);
-    return;
-  }
-
   if (a1.IsSimpleReg() && a2.IsSimpleReg() && a1.GetSimpleReg() == a2.GetSimpleReg())
     ERROR_LOG(DYNA_REC, "Redundant MOV @ %p - bug in JIT?", code);
   WriteNormalOp(bits, nrmMOV, a1, a2);


### PR DESCRIPTION
This optimization broke arithXex in rare cases by emitting XOR where MOV was expected.

We could instead enforce locking of flags around MOV operations, but I'd prefer for the low level XEmitter interface to not optimize things.

Optimistically, this might fix https://dolp.in/i9661 but I haven't tried it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3968)
<!-- Reviewable:end -->
