### PR TITLE
Strip whitespace from Evdev and OSX controller names.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
@@ -6,6 +6,8 @@
 #include <Foundation/Foundation.h>
 #include <IOKit/hid/IOHIDLib.h>
 
+#include "Common/StringUtil.h"
+
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/OSX/OSX.h"
 #include "InputCommon/ControllerInterface/OSX/OSXJoystick.h"
@@ -137,7 +139,7 @@ static void DeviceMatching_callback(void* inContext, IOReturn inResult, void* in
                                     IOHIDDeviceRef inIOHIDDeviceRef)
 {
   NSString* pName = (NSString*)IOHIDDeviceGetProperty(inIOHIDDeviceRef, CFSTR(kIOHIDProductKey));
-  std::string name = (pName != nullptr) ? [pName UTF8String] : "Unknown device";
+  std::string name = (pName != nullptr) ? StripSpaces([pName UTF8String]) : "Unknown device";
 
   DeviceDebugPrint(inIOHIDDeviceRef);
 

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -7,6 +7,7 @@
 #include <Foundation/Foundation.h>
 #include <IOKit/hid/IOHIDLib.h>
 
+#include "Common/StringUtil.h"
 #include "InputCommon/ControllerInterface/OSX/OSXJoystick.h"
 
 namespace ciface
@@ -110,7 +111,7 @@ std::string Joystick::Button::GetName() const
 {
   std::ostringstream s;
   s << IOHIDElementGetUsage(m_element);
-  return std::string("Button ") + s.str();
+  return std::string("Button ") + StripSpaces(s.str());
 }
 
 Joystick::Axis::Axis(IOHIDElementRef element, IOHIDDeviceRef device, direction dir)
@@ -150,7 +151,7 @@ Joystick::Axis::Axis(IOHIDElementRef element, IOHIDDeviceRef device, direction d
   {
     std::ostringstream s;
     s << usage;
-    description = s.str();
+    description = StripSpaces(s.str());
     break;
   }
   }

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -10,6 +10,7 @@
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
+#include "Common/StringUtil.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/evdev/evdev.h"
 
@@ -97,7 +98,7 @@ evdevDevice::evdevDevice(const std::string& devnode, int id) : m_devfile(devnode
     return;
   }
 
-  m_name = libevdev_get_name(m_dev);
+  m_name = StripSpaces(libevdev_get_name(m_dev));
 
   // Controller buttons (and keyboard keys)
   int num_buttons = 0;
@@ -165,7 +166,7 @@ std::string evdevDevice::Button::GetName() const
   {
     const char* name = libevdev_event_code_get_name(EV_KEY, m_code);
     if (name)
-      return std::string(name);
+      return StripSpaces(name);
   }
   // But controllers use codes above 0x100, and the standard label often doesn't match.
   // We are better off with Button 0 and so on.
@@ -223,7 +224,7 @@ std::string evdevDevice::ForceFeedback::GetName() const
   {
     const char* name = libevdev_event_code_get_name(EV_FF, m_type);
     if (name)
-      return std::string(name);
+      return StripSpaces(name);
     return "Unknown";
   }
   }


### PR DESCRIPTION
Extra spaces were causing serialization to fail with Evdev. I added some striping to OSX too, for good measure (DInput on windows already strips)

Fixes [Issue 9665](https://bugs.dolphin-emu.org/issues/9665)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3973)
<!-- Reviewable:end -->
