### PR TITLE
PatchEngine: Clear active codes on shutdown

### DIFF
--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -224,6 +224,9 @@ void ApplyFramePatches()
 void Shutdown()
 {
   onFrame.clear();
+  speedHacks.clear();
+  ActionReplay::ApplyCodes({});
+  Gecko::SetActiveCodes({});
 }
 
 }  // namespace


### PR DESCRIPTION
The active codes normally get cleared when a game boots, because LoadPatches gets called, replacing the codes from the previous game. However, there were cases where LoadPatches doesn't get called, and then codes from the previous game would be used for the current game. This commit clears the codes on shutdown so that it doesn't matter whether the boot process loads LoadPatches.

https://bugs.dolphin-emu.org/issues/9634

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3976)
<!-- Reviewable:end -->
