### PR TITLE
Move DiscIO enums to a new file

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -33,6 +33,7 @@
 #include "Core/PowerPC/Profiler.h"
 #include "Core/State.h"
 
+#include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 
@@ -226,15 +227,14 @@ static int GetCountry(std::string filename)
 
   if (pVolume != nullptr)
   {
-    DiscIO::IVolume::ECountry country = pVolume->GetCountry();
+    int country = static_cast<int>(pVolume->GetCountry());
 
     __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Country Code: %i", country);
 
     return country;
   }
 
-  // Return UNKNOWN
-  return 13;
+  return static_cast<int>(DiscIO::Country::COUNTRY_UNKNOWN);
 }
 
 static int GetPlatform(std::string filename)
@@ -245,13 +245,13 @@ static int GetPlatform(std::string filename)
   {
     switch (pVolume->GetVolumeType())
     {
-    case DiscIO::IVolume::GAMECUBE_DISC:
+    case DiscIO::Platform::GAMECUBE_DISC:
       __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a GameCube disc.");
       return 0;
-    case DiscIO::IVolume::WII_DISC:
+    case DiscIO::Platform::WII_DISC:
       __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a Wii disc.");
       return 1;
-    case DiscIO::IVolume::WII_WAD:
+    case DiscIO::Platform::WII_WAD:
       __android_log_print(ANDROID_LOG_INFO, DOLPHIN_TAG, "Volume is a Wii WAD.");
       return 2;
     }
@@ -269,13 +269,13 @@ static std::string GetTitle(std::string filename)
 
   if (pVolume != nullptr)
   {
-    std::map<DiscIO::IVolume::ELanguage, std::string> titles = pVolume->GetLongNames();
+    std::map<DiscIO::Language, std::string> titles = pVolume->GetLongNames();
     if (titles.empty())
       titles = pVolume->GetShortNames();
 
     /*
-    bool is_wii_title = pVolume->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;
-    DiscIO::IVolume::ELanguage language = SConfig::GetInstance().GetCurrentLanguage(is_wii_title);
+    bool is_wii_title = pVolume->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC;
+    DiscIO::Language language = SConfig::GetInstance().GetCurrentLanguage(is_wii_title);
 
     auto it = titles.find(language);
     if (it != end)
@@ -284,8 +284,8 @@ static std::string GetTitle(std::string filename)
     auto end = titles.end();
 
     // English tends to be a good fallback when the requested language isn't available
-    // if (language != DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH) {
-    auto it = titles.find(DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH);
+    // if (language != DiscIO::Language::LANGUAGE_ENGLISH) {
+    auto it = titles.find(DiscIO::Language::LANGUAGE_ENGLISH);
     if (it != end)
       return it->second;
     //}
@@ -312,11 +312,11 @@ static std::string GetDescription(std::string filename)
 
   if (volume != nullptr)
   {
-    std::map<DiscIO::IVolume::ELanguage, std::string> descriptions = volume->GetDescriptions();
+    std::map<DiscIO::Language, std::string> descriptions = volume->GetDescriptions();
 
     /*
-    bool is_wii_title = pVolume->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;
-    DiscIO::IVolume::ELanguage language = SConfig::GetInstance().GetCurrentLanguage(is_wii_title);
+    bool is_wii_title = pVolume->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC;
+    DiscIO::Language language = SConfig::GetInstance().GetCurrentLanguage(is_wii_title);
 
     auto it = descriptions.find(language);
     if (it != end)
@@ -325,8 +325,8 @@ static std::string GetDescription(std::string filename)
     auto end = descriptions.end();
 
     // English tends to be a good fallback when the requested language isn't available
-    // if (language != DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH) {
-    auto it = descriptions.find(DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH);
+    // if (language != DiscIO::Language::LANGUAGE_ENGLISH) {
+    auto it = descriptions.find(DiscIO::Language::LANGUAGE_ENGLISH);
     if (it != end)
       return it->second;
     //}

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -31,7 +31,9 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/SignatureDB.h"
 
+#include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"
+#include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 
 bool CBoot::DVDRead(u64 dvd_offset, u32 output_address, u32 length, bool decrypt)
@@ -263,7 +265,7 @@ bool CBoot::BootUp()
 
     const DiscIO::IVolume& pVolume = DVDInterface::GetVolume();
 
-    if ((pVolume.GetVolumeType() == DiscIO::IVolume::WII_DISC) != _StartupPara.bWii)
+    if ((pVolume.GetVolumeType() == DiscIO::Platform::WII_DISC) != _StartupPara.bWii)
     {
       PanicAlertT("Warning - starting ISO in wrong console mode!");
     }
@@ -278,7 +280,7 @@ bool CBoot::BootUp()
       WII_IPC_HLE_Interface::ES_DIVerify(tmd_buffer);
     }
 
-    _StartupPara.bWii = pVolume.GetVolumeType() == DiscIO::IVolume::WII_DISC;
+    _StartupPara.bWii = pVolume.GetVolumeType() == DiscIO::Platform::WII_DISC;
 
     // HLE BS2 or not
     if (_StartupPara.bHLE_BS2)
@@ -338,7 +340,7 @@ bool CBoot::BootUp()
       BS2Success = EmulatedBS2(dolWii);
     }
     else if ((!DVDInterface::VolumeIsValid() ||
-              DVDInterface::GetVolume().GetVolumeType() != DiscIO::IVolume::WII_DISC) &&
+              DVDInterface::GetVolume().GetVolumeType() != DiscIO::Platform::WII_DISC) &&
              !_StartupPara.m_strDefaultISO.empty())
     {
       DVDInterface::SetVolumeName(_StartupPara.m_strDefaultISO);
@@ -409,7 +411,7 @@ bool CBoot::BootUp()
 
     // Poor man's bootup
     if (_StartupPara.bWii)
-      SetupWiiMemory(DiscIO::IVolume::COUNTRY_UNKNOWN);
+      SetupWiiMemory(DiscIO::Country::COUNTRY_UNKNOWN);
     else
       EmulatedBS2_GC(true);
 

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -7,7 +7,10 @@
 #include <cstdlib>
 #include <string>
 
-#include "DiscIO/Volume.h"
+namespace DiscIO
+{
+enum class Country;
+}
 
 struct CountrySetting
 {
@@ -54,5 +57,5 @@ private:
   static bool Load_BS2(const std::string& _rBootROMFilename);
   static void Load_FST(bool _bIsWii);
 
-  static bool SetupWiiMemory(DiscIO::IVolume::ECountry country);
+  static bool SetupWiiMemory(DiscIO::Country country);
 };

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -20,6 +20,9 @@
 #include "Core/PatchEngine.h"
 #include "Core/PowerPC/PowerPC.h"
 
+#include "DiscIO/Enums.h"
+#include "DiscIO/Volume.h"
+
 void CBoot::RunFunction(u32 _iAddr)
 {
   PC = _iAddr;
@@ -178,21 +181,21 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
   return true;
 }
 
-bool CBoot::SetupWiiMemory(DiscIO::IVolume::ECountry country)
+bool CBoot::SetupWiiMemory(DiscIO::Country country)
 {
   static const CountrySetting SETTING_EUROPE = {"EUR", "PAL", "EU", "LE"};
   static const CountrySetting SETTING_USA = {"USA", "NTSC", "US", "LU"};
   static const CountrySetting SETTING_JAPAN = {"JPN", "NTSC", "JP", "LJ"};
   static const CountrySetting SETTING_KOREA = {"KOR", "NTSC", "KR", "LKH"};
-  static const std::map<DiscIO::IVolume::ECountry, const CountrySetting> country_settings = {
-      {DiscIO::IVolume::COUNTRY_EUROPE, SETTING_EUROPE},
-      {DiscIO::IVolume::COUNTRY_USA, SETTING_USA},
-      {DiscIO::IVolume::COUNTRY_JAPAN, SETTING_JAPAN},
-      {DiscIO::IVolume::COUNTRY_KOREA, SETTING_KOREA},
+  static const std::map<DiscIO::Country, const CountrySetting> country_settings = {
+      {DiscIO::Country::COUNTRY_EUROPE, SETTING_EUROPE},
+      {DiscIO::Country::COUNTRY_USA, SETTING_USA},
+      {DiscIO::Country::COUNTRY_JAPAN, SETTING_JAPAN},
+      {DiscIO::Country::COUNTRY_KOREA, SETTING_KOREA},
       // TODO: Determine if Taiwan have their own specific settings.
       //      Also determine if there are other specific settings
       //      for other countries.
-      {DiscIO::IVolume::COUNTRY_TAIWAN, SETTING_JAPAN}};
+      {DiscIO::Country::COUNTRY_TAIWAN, SETTING_JAPAN}};
   auto entryPos = country_settings.find(country);
   const CountrySetting& country_setting =
       (entryPos != country_settings.end()) ?
@@ -333,7 +336,7 @@ bool CBoot::EmulatedBS2_Wii()
   INFO_LOG(BOOT, "Faking Wii BS2...");
 
   // Setup Wii memory
-  DiscIO::IVolume::ECountry country_code = DiscIO::IVolume::COUNTRY_UNKNOWN;
+  DiscIO::Country country_code = DiscIO::Country::COUNTRY_UNKNOWN;
   if (DVDInterface::VolumeIsValid())
     country_code = DVDInterface::GetVolume().GetCountry();
   if (SetupWiiMemory(country_code) == false)
@@ -342,7 +345,7 @@ bool CBoot::EmulatedBS2_Wii()
   // Execute the apploader
   bool apploaderRan = false;
   if (DVDInterface::VolumeIsValid() &&
-      DVDInterface::GetVolume().GetVolumeType() == DiscIO::IVolume::WII_DISC)
+      DVDInterface::GetVolume().GetVolumeType() == DiscIO::Platform::WII_DISC)
   {
     // This is some kind of consistency check that is compared to the 0x00
     // values as the game boots. This location keeps the 4 byte ID for as long

--- a/Source/Core/Core/Boot/Boot_ELF.cpp
+++ b/Source/Core/Core/Boot/Boot_ELF.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 
+#include "Common/CommonFuncs.h"
 #include "Common/FileUtil.h"
 #include "Core/Boot/Boot.h"
 #include "Core/Boot/ElfReader.h"

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -20,6 +20,7 @@
 #include "Core/PatchEngine.h"
 #include "Core/PowerPC/PowerPC.h"
 
+#include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
@@ -92,7 +93,7 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
   if (!SetupWiiMemory(ContentLoader.GetCountry()))
     return false;
   // this sets a bit that is used to detect NTSC-J
-  if (ContentLoader.GetCountry() == DiscIO::IVolume::COUNTRY_JAPAN)
+  if (ContentLoader.GetCountry() == DiscIO::Country::COUNTRY_JAPAN)
   {
     VideoInterface::SetRegionReg('J');
   }

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -19,7 +19,9 @@
 #include "Core/HW/SI.h"
 #include "Core/PowerPC/PowerPC.h"
 
+#include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"
+#include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 
 SConfig* SConfig::m_Instance;
@@ -672,31 +674,31 @@ void SConfig::LoadDefaults()
   m_revision = 0;
 }
 
-static const char* GetRegionOfCountry(DiscIO::IVolume::ECountry country)
+static const char* GetRegionOfCountry(DiscIO::Country country)
 {
   switch (country)
   {
-  case DiscIO::IVolume::COUNTRY_USA:
+  case DiscIO::Country::COUNTRY_USA:
     return USA_DIR;
 
-  case DiscIO::IVolume::COUNTRY_TAIWAN:
-  case DiscIO::IVolume::COUNTRY_KOREA:
+  case DiscIO::Country::COUNTRY_TAIWAN:
+  case DiscIO::Country::COUNTRY_KOREA:
   // TODO: Should these have their own Region Dir?
-  case DiscIO::IVolume::COUNTRY_JAPAN:
+  case DiscIO::Country::COUNTRY_JAPAN:
     return JAP_DIR;
 
-  case DiscIO::IVolume::COUNTRY_AUSTRALIA:
-  case DiscIO::IVolume::COUNTRY_EUROPE:
-  case DiscIO::IVolume::COUNTRY_FRANCE:
-  case DiscIO::IVolume::COUNTRY_GERMANY:
-  case DiscIO::IVolume::COUNTRY_ITALY:
-  case DiscIO::IVolume::COUNTRY_NETHERLANDS:
-  case DiscIO::IVolume::COUNTRY_RUSSIA:
-  case DiscIO::IVolume::COUNTRY_SPAIN:
-  case DiscIO::IVolume::COUNTRY_WORLD:
+  case DiscIO::Country::COUNTRY_AUSTRALIA:
+  case DiscIO::Country::COUNTRY_EUROPE:
+  case DiscIO::Country::COUNTRY_FRANCE:
+  case DiscIO::Country::COUNTRY_GERMANY:
+  case DiscIO::Country::COUNTRY_ITALY:
+  case DiscIO::Country::COUNTRY_NETHERLANDS:
+  case DiscIO::Country::COUNTRY_RUSSIA:
+  case DiscIO::Country::COUNTRY_SPAIN:
+  case DiscIO::Country::COUNTRY_WORLD:
     return EUR_DIR;
 
-  case DiscIO::IVolume::COUNTRY_UNKNOWN:
+  case DiscIO::Country::COUNTRY_UNKNOWN:
   default:
     return nullptr;
   }
@@ -745,7 +747,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       m_revision = pVolume->GetRevision();
 
       // Check if we have a Wii disc
-      bWii = pVolume->GetVolumeType() == DiscIO::IVolume::WII_DISC;
+      bWii = pVolume->GetVolumeType() == DiscIO::Platform::WII_DISC;
 
       const char* retrieved_region_dir = GetRegionOfCountry(pVolume->GetCountry());
       if (!retrieved_region_dir)
@@ -947,17 +949,19 @@ void SConfig::CheckMemcardPath(std::string& memcardPath, const std::string& game
   }
 }
 
-DiscIO::IVolume::ELanguage SConfig::GetCurrentLanguage(bool wii) const
+DiscIO::Language SConfig::GetCurrentLanguage(bool wii) const
 {
-  DiscIO::IVolume::ELanguage language;
+  int language_value;
   if (wii)
-    language = (DiscIO::IVolume::ELanguage)SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG");
+    language_value = SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG");
   else
-    language = (DiscIO::IVolume::ELanguage)(SConfig::GetInstance().SelectedLanguage + 1);
+    language_value = SConfig::GetInstance().SelectedLanguage + 1;
+  DiscIO::Language language = static_cast<DiscIO::Language>(language_value);
 
   // Get rid of invalid values (probably doesn't matter, but might as well do it)
-  if (language > DiscIO::IVolume::ELanguage::LANGUAGE_UNKNOWN || language < 0)
-    language = DiscIO::IVolume::ELanguage::LANGUAGE_UNKNOWN;
+  if (language > DiscIO::Language::LANGUAGE_UNKNOWN ||
+      language < DiscIO::Language::LANGUAGE_JAPANESE)
+    language = DiscIO::Language::LANGUAGE_UNKNOWN;
   return language;
 }
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -12,7 +12,11 @@
 #include "Common/SysConf.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/SI_Device.h"
-#include "DiscIO/Volume.h"
+
+namespace DiscIO
+{
+enum class Language;
+}
 
 // DSP Backend Types
 #define BACKEND_NULLSOUND _trans("No audio output")
@@ -177,7 +181,7 @@ struct SConfig : NonCopyable
   bool AutoSetup(EBootBS2 _BootBS2);
   const std::string& GetUniqueID() const { return m_strUniqueID; }
   void CheckMemcardPath(std::string& memcardPath, const std::string& gameRegion, bool isSlotA);
-  DiscIO::IVolume::ELanguage GetCurrentLanguage(bool wii) const;
+  DiscIO::Language GetCurrentLanguage(bool wii) const;
 
   IniFile LoadDefaultGameIni() const;
   IniFile LoadLocalGameIni() const;

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -28,6 +28,7 @@
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_DI.h"
 #include "Core/Movie.h"
 
+#include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 
@@ -1417,7 +1418,7 @@ s64 CalculateRawDiscReadTime(u64 offset, s64 length)
   // Note that the speed at a track (in bytes per second) is the same as
   // the radius of that track because of the length unit used.
   double speed;
-  if (s_inserted_volume->GetVolumeType() == DiscIO::IVolume::WII_DISC)
+  if (s_inserted_volume->GetVolumeType() == DiscIO::Platform::WII_DISC)
   {
     speed = std::sqrt(((average_offset - WII_DISC_LOCATION_1_OFFSET) / WII_BYTES_PER_AREA_UNIT +
                        WII_DISC_AREA_UP_TO_LOCATION_1) /

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -27,6 +27,7 @@
 #include "Core/HW/Sram.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/Movie.h"
+#include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"
 
 #define MC_STATUS_BUSY 0x80
@@ -135,7 +136,7 @@ CEXIMemoryCard::CEXIMemoryCard(const int index, bool gciFolder) : card_index(ind
 
 void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 {
-  DiscIO::IVolume::ECountry country_code = DiscIO::IVolume::COUNTRY_UNKNOWN;
+  DiscIO::Country country_code = DiscIO::Country::COUNTRY_UNKNOWN;
   auto strUniqueID = SConfig::GetInstance().m_strUniqueID;
 
   u32 CurrentGameId = 0;
@@ -158,14 +159,14 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
   std::string strDirectoryName = File::GetUserPath(D_GCUSER_IDX);
   switch (country_code)
   {
-  case DiscIO::IVolume::COUNTRY_JAPAN:
+  case DiscIO::Country::COUNTRY_JAPAN:
     ascii = false;
     strDirectoryName += JAP_DIR DIR_SEP;
     break;
-  case DiscIO::IVolume::COUNTRY_USA:
+  case DiscIO::Country::COUNTRY_USA:
     strDirectoryName += USA_DIR DIR_SEP;
     break;
-  case DiscIO::IVolume::COUNTRY_UNKNOWN:
+  case DiscIO::Country::COUNTRY_UNKNOWN:
   {
     // The current game's region is not passed down to the EXI device level.
     // Usually, we can retrieve the region from SConfig::GetInstance().m_strUniqueId.
@@ -185,20 +186,20 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
     std::string region = memcardFilename.substr(memcardFilename.size() - 7, 3);
     if (region == JAP_DIR)
     {
-      country_code = DiscIO::IVolume::COUNTRY_JAPAN;
+      country_code = DiscIO::Country::COUNTRY_JAPAN;
       ascii = false;
       strDirectoryName += JAP_DIR DIR_SEP;
       break;
     }
     else if (region == USA_DIR)
     {
-      country_code = DiscIO::IVolume::COUNTRY_USA;
+      country_code = DiscIO::Country::COUNTRY_USA;
       strDirectoryName += USA_DIR DIR_SEP;
       break;
     }
   }
   default:
-    country_code = DiscIO::IVolume::COUNTRY_EUROPE;
+    country_code = DiscIO::Country::COUNTRY_EUROPE;
     strDirectoryName += EUR_DIR DIR_SEP;
   }
   strDirectoryName += StringFromFormat("Card %c", 'A' + card_index);

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -24,7 +24,7 @@
 const int NO_INDEX = -1;
 static const char* MC_HDR = "MC_SYSTEM_AREA";
 
-int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::IVolume::ECountry card_region,
+int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::Country card_region,
                                 bool currentGameOnly)
 {
   File::IOFile gcifile(fileName, "rb");
@@ -39,15 +39,15 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::IVolume::EC
       return NO_INDEX;
     }
 
-    DiscIO::IVolume::ECountry gci_region;
+    DiscIO::Country gci_region;
     // check region
     switch (gci.m_gci_header.Gamecode[3])
     {
     case 'J':
-      gci_region = DiscIO::IVolume::COUNTRY_JAPAN;
+      gci_region = DiscIO::Country::COUNTRY_JAPAN;
       break;
     case 'E':
-      gci_region = DiscIO::IVolume::COUNTRY_USA;
+      gci_region = DiscIO::Country::COUNTRY_USA;
       break;
     case 'C':
       // Used by Datel Action Replay Save
@@ -55,7 +55,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::IVolume::EC
       gci_region = card_region;
       break;
     default:
-      gci_region = DiscIO::IVolume::COUNTRY_EUROPE;
+      gci_region = DiscIO::Country::COUNTRY_EUROPE;
       break;
     }
 
@@ -146,8 +146,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::IVolume::EC
 }
 
 GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u16 sizeMb,
-                                       bool ascii, DiscIO::IVolume::ECountry card_region,
-                                       int gameId)
+                                       bool ascii, DiscIO::Country card_region, int gameId)
     : MemoryCardBase(slot, sizeMb), m_GameId(gameId), m_LastBlock(-1), m_hdr(slot, sizeMb, ascii),
       m_bat1(sizeMb), m_saves(0), m_SaveDirectory(directory), m_exiting(false)
 {

--- a/Source/Core/Core/HW/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcardDirectory.h
@@ -14,7 +14,7 @@
 #include "Common/Event.h"
 #include "Common/NonCopyable.h"
 #include "Core/HW/GCMemcard.h"
-#include "DiscIO/Volume.h"
+#include "DiscIO/Enums.h"
 
 // Uncomment this to write the system data of the memorycard from directory to disc
 //#define _WRITE_MC_HEADER 1
@@ -25,8 +25,7 @@ class GCMemcardDirectory : public MemoryCardBase, NonCopyable
 public:
   GCMemcardDirectory(const std::string& directory, int slot = 0, u16 sizeMb = MemCard2043Mb,
                      bool ascii = true,
-                     DiscIO::IVolume::ECountry card_region = DiscIO::IVolume::COUNTRY_EUROPE,
-                     int gameId = 0);
+                     DiscIO::Country card_region = DiscIO::Country::COUNTRY_EUROPE, int gameId = 0);
   ~GCMemcardDirectory();
   void FlushToFile();
   void FlushThread();
@@ -37,8 +36,7 @@ public:
   void DoState(PointerWrap& p) override;
 
 private:
-  int LoadGCI(const std::string& fileName, DiscIO::IVolume::ECountry card_region,
-              bool currentGameOnly);
+  int LoadGCI(const std::string& fileName, DiscIO::Country card_region, bool currentGameOnly);
   inline s32 SaveAreaRW(u32 block, bool writing = false);
   // s32 DirectoryRead(u32 offset, u32 length, u8* destaddress);
   s32 DirectoryWrite(u32 destaddress, u32 length, u8* srcaddress);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -15,6 +15,7 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_DI.h"
+#include "DiscIO/Volume.h"
 
 CWII_IPC_HLE_Device_di::CWII_IPC_HLE_Device_di(u32 _DeviceID, const std::string& _rDeviceName)
     : IWII_IPC_HLE_Device(_DeviceID, _rDeviceName)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -53,6 +53,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/ec_wii.h"
 #include "DiscIO/NANDContentLoader.h"
+#include "DiscIO/Volume.h"
 
 #ifdef _WIN32
 #include <Windows.h>

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -34,6 +34,7 @@
 #include "Core/NetPlayProto.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/State.h"
+#include "DiscIO/Enums.h"
 #include "InputCommon/GCPadStatus.h"
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/VideoBackendBase.h"
@@ -82,7 +83,7 @@ static u8 s_bongos, s_memcards;
 static u8 s_revision[20];
 static u32 s_DSPiromHash = 0;
 static u32 s_DSPcoefHash = 0;
-static u8 s_language = 10;  // Set to unknown until language is known
+static u8 s_language = static_cast<u8>(DiscIO::Language::LANGUAGE_UNKNOWN);
 
 static bool s_bRecordingFromSaveState = false;
 static bool s_bPolled = false;

--- a/Source/Core/DiscIO/Blob.h
+++ b/Source/Core/DiscIO/Blob.h
@@ -22,7 +22,7 @@
 
 namespace DiscIO
 {
-// Increment CACHE_REVISION if the enum below is modified (ISOFile.cpp & GameFile.cpp)
+// Increment CACHE_REVISION (ISOFile.cpp & GameFile.cpp) if the enum below is modified
 enum class BlobType
 {
   PLAIN,

--- a/Source/Core/DiscIO/CMakeLists.txt
+++ b/Source/Core/DiscIO/CMakeLists.txt
@@ -4,12 +4,13 @@ set(SRCS	Blob.cpp
 			CompressedBlob.cpp
 			DiscScrubber.cpp
 			DriveBlob.cpp
+			Enums.cpp
 			FileBlob.cpp
 			FileMonitor.cpp
 			FileSystemGCWii.cpp
 			Filesystem.cpp
 			NANDContentLoader.cpp
-			VolumeCommon.cpp
+			Volume.cpp
 			VolumeCreator.cpp
 			VolumeDirectory.cpp
 			VolumeGC.cpp

--- a/Source/Core/DiscIO/DiscIO.vcxproj
+++ b/Source/Core/DiscIO/DiscIO.vcxproj
@@ -40,12 +40,13 @@
     <ClCompile Include="CompressedBlob.cpp" />
     <ClCompile Include="DiscScrubber.cpp" />
     <ClCompile Include="DriveBlob.cpp" />
+    <ClCompile Include="Enums.cpp" />
     <ClCompile Include="FileBlob.cpp" />
     <ClCompile Include="FileMonitor.cpp" />
     <ClCompile Include="Filesystem.cpp" />
     <ClCompile Include="FileSystemGCWii.cpp" />
     <ClCompile Include="NANDContentLoader.cpp" />
-    <ClCompile Include="VolumeCommon.cpp" />
+    <ClCompile Include="Volume.cpp" />
     <ClCompile Include="VolumeCreator.cpp" />
     <ClCompile Include="VolumeDirectory.cpp" />
     <ClCompile Include="VolumeGC.cpp" />
@@ -60,6 +61,7 @@
     <ClInclude Include="CompressedBlob.h" />
     <ClInclude Include="DiscScrubber.h" />
     <ClInclude Include="DriveBlob.h" />
+    <ClInclude Include="Enums.h" />
     <ClInclude Include="FileBlob.h" />
     <ClInclude Include="FileMonitor.h" />
     <ClInclude Include="Filesystem.h" />

--- a/Source/Core/DiscIO/DiscIO.vcxproj.filters
+++ b/Source/Core/DiscIO/DiscIO.vcxproj.filters
@@ -54,9 +54,6 @@
     <ClCompile Include="FileMonitor.cpp">
       <Filter>Volume</Filter>
     </ClCompile>
-    <ClCompile Include="VolumeCommon.cpp">
-      <Filter>Volume</Filter>
-    </ClCompile>
     <ClCompile Include="VolumeCreator.cpp">
       <Filter>Volume</Filter>
     </ClCompile>
@@ -70,6 +67,12 @@
       <Filter>Volume</Filter>
     </ClCompile>
     <ClCompile Include="VolumeWiiCrypted.cpp">
+      <Filter>Volume</Filter>
+    </ClCompile>
+    <ClCompile Include="Enums.cpp">
+      <Filter>Volume</Filter>
+    </ClCompile>
+    <ClCompile Include="Volume.cpp">
       <Filter>Volume</Filter>
     </ClCompile>
   </ItemGroup>
@@ -126,6 +129,9 @@
       <Filter>Volume</Filter>
     </ClInclude>
     <ClInclude Include="VolumeWiiCrypted.h">
+      <Filter>Volume</Filter>
+    </ClInclude>
+    <ClInclude Include="Enums.h">
       <Filter>Volume</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Source/Core/DiscIO/Enums.h
+++ b/Source/Core/DiscIO/Enums.h
@@ -1,0 +1,62 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+
+namespace DiscIO
+{
+// Increment CACHE_REVISION (ISOFile.cpp & GameFile.cpp) if these enums are modified
+
+enum class Platform
+{
+  GAMECUBE_DISC = 0,
+  WII_DISC,
+  WII_WAD,
+  ELF_DOL,
+  NUMBER_OF_PLATFORMS
+};
+
+enum class Country
+{
+  COUNTRY_EUROPE = 0,
+  COUNTRY_JAPAN,
+  COUNTRY_USA,
+  COUNTRY_AUSTRALIA,
+  COUNTRY_FRANCE,
+  COUNTRY_GERMANY,
+  COUNTRY_ITALY,
+  COUNTRY_KOREA,
+  COUNTRY_NETHERLANDS,
+  COUNTRY_RUSSIA,
+  COUNTRY_SPAIN,
+  COUNTRY_TAIWAN,
+  COUNTRY_WORLD,
+  COUNTRY_UNKNOWN,
+  NUMBER_OF_COUNTRIES
+};
+
+// Languages 0 - 9 match Nintendo's Wii language numbering.
+// Languages 1 - 6 match Nintendo's PAL GameCube languages 0 - 5.
+// NTSC GameCubes only support one language and thus don't number languages.
+enum class Language
+{
+  LANGUAGE_JAPANESE = 0,
+  LANGUAGE_ENGLISH = 1,
+  LANGUAGE_GERMAN = 2,
+  LANGUAGE_FRENCH = 3,
+  LANGUAGE_SPANISH = 4,
+  LANGUAGE_ITALIAN = 5,
+  LANGUAGE_DUTCH = 6,
+  LANGUAGE_SIMPLIFIED_CHINESE = 7,
+  LANGUAGE_TRADITIONAL_CHINESE = 8,
+  LANGUAGE_KOREAN = 9,
+  LANGUAGE_UNKNOWN
+};
+
+Country CountrySwitch(u8 country_code);
+u8 GetSysMenuRegion(u16 title_version);
+std::string GetCompanyFromID(const std::string& company_id);
+}

--- a/Source/Core/DiscIO/FileMonitor.cpp
+++ b/Source/Core/DiscIO/FileMonitor.cpp
@@ -18,6 +18,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
+#include "DiscIO/Enums.h"
 #include "DiscIO/FileMonitor.h"
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
@@ -67,7 +68,7 @@ void ReadFileSystem(const std::string& filename)
   if (!s_open_iso)
     return;
 
-  if (s_open_iso->GetVolumeType() != DiscIO::IVolume::WII_WAD)
+  if (s_open_iso->GetVolumeType() != DiscIO::Platform::WII_WAD)
   {
     s_filesystem = DiscIO::CreateFileSystem(s_open_iso.get());
 

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -23,8 +23,8 @@
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
 
+#include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"
-#include "DiscIO/Volume.h"
 #include "DiscIO/WiiWad.h"
 
 namespace DiscIO
@@ -303,10 +303,10 @@ std::vector<u8> CNANDContentLoader::GetKeyFromTicket(const std::vector<u8>& tick
   return AESDecode(common_key, iv, &ticket[0x01BF], 16);
 }
 
-DiscIO::IVolume::ECountry CNANDContentLoader::GetCountry() const
+DiscIO::Country CNANDContentLoader::GetCountry() const
 {
   if (!IsValid())
-    return DiscIO::IVolume::COUNTRY_UNKNOWN;
+    return DiscIO::Country::COUNTRY_UNKNOWN;
 
   return CountrySwitch(m_Country);
 }

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -5,13 +5,18 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/NandPaths.h"
-#include "DiscIO/Volume.h"
+
+namespace DiscIO
+{
+enum class Country;
+}
 
 namespace DiscIO
 {
@@ -86,7 +91,7 @@ public:
   const std::vector<SNANDContent>& GetContent() const { return m_Content; }
   u16 GetTitleVersion() const { return m_TitleVersion; }
   u16 GetNumEntries() const { return m_NumEntries; }
-  DiscIO::IVolume::ECountry GetCountry() const;
+  DiscIO::Country GetCountry() const;
   u8 GetCountryChar() const { return m_Country; }
   enum
   {

--- a/Source/Core/DiscIO/Volume.cpp
+++ b/Source/Core/DiscIO/Volume.cpp
@@ -1,0 +1,77 @@
+// Copyright 2009 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Common/ColorUtil.h"
+#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
+#include "Common/StringUtil.h"
+#include "DiscIO/Enums.h"
+#include "DiscIO/Volume.h"
+
+namespace DiscIO
+{
+static const unsigned int WII_BANNER_WIDTH = 192;
+static const unsigned int WII_BANNER_HEIGHT = 64;
+static const unsigned int WII_BANNER_SIZE = WII_BANNER_WIDTH * WII_BANNER_HEIGHT * 2;
+static const unsigned int WII_BANNER_OFFSET = 0xA0;
+
+std::vector<u32> IVolume::GetWiiBanner(int* width, int* height, u64 title_id)
+{
+  *width = 0;
+  *height = 0;
+
+  std::string file_name = StringFromFormat("%s/title/%08x/%08x/data/banner.bin",
+                                           File::GetUserPath(D_WIIROOT_IDX).c_str(),
+                                           (u32)(title_id >> 32), (u32)title_id);
+  if (!File::Exists(file_name))
+    return std::vector<u32>();
+
+  if (File::GetSize(file_name) < WII_BANNER_OFFSET + WII_BANNER_SIZE)
+    return std::vector<u32>();
+
+  File::IOFile file(file_name, "rb");
+  if (!file.Seek(WII_BANNER_OFFSET, SEEK_SET))
+    return std::vector<u32>();
+
+  std::vector<u8> banner_file(WII_BANNER_SIZE);
+  if (!file.ReadBytes(banner_file.data(), banner_file.size()))
+    return std::vector<u32>();
+
+  std::vector<u32> image_buffer(WII_BANNER_WIDTH * WII_BANNER_HEIGHT);
+  ColorUtil::decode5A3image(image_buffer.data(), (u16*)banner_file.data(), WII_BANNER_WIDTH,
+                            WII_BANNER_HEIGHT);
+
+  *width = WII_BANNER_WIDTH;
+  *height = WII_BANNER_HEIGHT;
+  return image_buffer;
+}
+
+std::map<Language, std::string> IVolume::ReadWiiNames(const std::vector<u8>& data)
+{
+  std::map<Language, std::string> names;
+  for (size_t i = 0; i < NUMBER_OF_LANGUAGES; ++i)
+  {
+    size_t name_start = NAME_BYTES_LENGTH * i;
+    size_t name_end = name_start + NAME_BYTES_LENGTH;
+    if (data.size() >= name_end)
+    {
+      u16* temp = (u16*)(data.data() + name_start);
+      std::wstring out_temp(NAME_STRING_LENGTH, '\0');
+      std::transform(temp, temp + out_temp.size(), out_temp.begin(), (u16(&)(u16))Common::swap16);
+      out_temp.erase(std::find(out_temp.begin(), out_temp.end(), 0x00), out_temp.end());
+      std::string name = UTF16ToUTF8(out_temp);
+      if (!name.empty())
+        names[static_cast<Language>(i)] = name;
+    }
+  }
+  return names;
+}
+}

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -12,59 +12,15 @@
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
-#include "DiscIO/Blob.h"
+#include "DiscIO/Enums.h"
 
 namespace DiscIO
 {
+enum class BlobType;
+
 class IVolume
 {
 public:
-  // Increment CACHE_REVISION if the enums below are modified (ISOFile.cpp & GameFile.cpp)
-  enum EPlatform
-  {
-    GAMECUBE_DISC = 0,
-    WII_DISC,
-    WII_WAD,
-    ELF_DOL,
-    NUMBER_OF_PLATFORMS
-  };
-
-  enum ECountry
-  {
-    COUNTRY_EUROPE = 0,
-    COUNTRY_JAPAN,
-    COUNTRY_USA,
-    COUNTRY_AUSTRALIA,
-    COUNTRY_FRANCE,
-    COUNTRY_GERMANY,
-    COUNTRY_ITALY,
-    COUNTRY_KOREA,
-    COUNTRY_NETHERLANDS,
-    COUNTRY_RUSSIA,
-    COUNTRY_SPAIN,
-    COUNTRY_TAIWAN,
-    COUNTRY_WORLD,
-    COUNTRY_UNKNOWN,
-    NUMBER_OF_COUNTRIES
-  };
-
-  // Languages 0 - 9 match the official Wii language numbering.
-  // Languages 1 - 6 match the official GC PAL languages 0 - 5.
-  enum ELanguage
-  {
-    LANGUAGE_JAPANESE = 0,
-    LANGUAGE_ENGLISH = 1,
-    LANGUAGE_GERMAN = 2,
-    LANGUAGE_FRENCH = 3,
-    LANGUAGE_SPANISH = 4,
-    LANGUAGE_ITALIAN = 5,
-    LANGUAGE_DUTCH = 6,
-    LANGUAGE_SIMPLIFIED_CHINESE = 7,
-    LANGUAGE_TRADITIONAL_CHINESE = 8,
-    LANGUAGE_KOREAN = 9,
-    LANGUAGE_UNKNOWN
-  };
-
   IVolume() {}
   virtual ~IVolume() {}
   // decrypt parameter must be false if not reading a Wii disc
@@ -85,36 +41,21 @@ public:
   virtual std::string GetMakerID() const = 0;
   virtual u16 GetRevision() const = 0;
   virtual std::string GetInternalName() const = 0;
-  virtual std::map<ELanguage, std::string> GetShortNames() const
-  {
-    return std::map<ELanguage, std::string>();
-  }
-  virtual std::map<ELanguage, std::string> GetLongNames() const
-  {
-    return std::map<ELanguage, std::string>();
-  }
-  virtual std::map<ELanguage, std::string> GetShortMakers() const
-  {
-    return std::map<ELanguage, std::string>();
-  }
-  virtual std::map<ELanguage, std::string> GetLongMakers() const
-  {
-    return std::map<ELanguage, std::string>();
-  }
-  virtual std::map<ELanguage, std::string> GetDescriptions() const
-  {
-    return std::map<ELanguage, std::string>();
-  }
+  virtual std::map<Language, std::string> GetShortNames() const { return {{}}; }
+  virtual std::map<Language, std::string> GetLongNames() const { return {{}}; }
+  virtual std::map<Language, std::string> GetShortMakers() const { return {{}}; }
+  virtual std::map<Language, std::string> GetLongMakers() const { return {{}}; }
+  virtual std::map<Language, std::string> GetDescriptions() const { return {{}}; }
   virtual std::vector<u32> GetBanner(int* width, int* height) const = 0;
   virtual u64 GetFSTSize() const = 0;
   virtual std::string GetApploaderDate() const = 0;
   // 0 is the first disc, 1 is the second disc
   virtual u8 GetDiscNumber() const { return 0; }
-  virtual EPlatform GetVolumeType() const = 0;
+  virtual Platform GetVolumeType() const = 0;
   virtual bool SupportsIntegrityCheck() const { return false; }
   virtual bool CheckIntegrity() const { return false; }
   virtual bool ChangePartition(u64 offset) { return false; }
-  virtual ECountry GetCountry() const = 0;
+  virtual Country GetCountry() const = 0;
   virtual BlobType GetBlobType() const = 0;
   // Size of virtual disc (not always accurate)
   virtual u64 GetSize() const = 0;
@@ -132,7 +73,8 @@ protected:
 
     // There doesn't seem to be any GC discs with the country set to Taiwan...
     // But maybe they would use Shift_JIS if they existed? Not sure
-    bool use_shift_jis = (COUNTRY_JAPAN == GetCountry() || COUNTRY_TAIWAN == GetCountry());
+    bool use_shift_jis =
+        (Country::COUNTRY_JAPAN == GetCountry() || Country::COUNTRY_TAIWAN == GetCountry());
 
     if (use_shift_jis)
       return SHIFTJISToUTF8(string);
@@ -140,17 +82,12 @@ protected:
       return CP1252ToUTF8(string);
   }
 
-  static std::map<IVolume::ELanguage, std::string> ReadWiiNames(const std::vector<u8>& data);
+  static std::map<Language, std::string> ReadWiiNames(const std::vector<u8>& data);
 
   static const size_t NUMBER_OF_LANGUAGES = 10;
   static const size_t NAME_STRING_LENGTH = 42;
   static const size_t NAME_BYTES_LENGTH = NAME_STRING_LENGTH * sizeof(u16);
   static const size_t NAMES_TOTAL_BYTES = NAME_BYTES_LENGTH * NUMBER_OF_LANGUAGES;
 };
-
-// Generic Switch function for all volumes
-IVolume::ECountry CountrySwitch(u8 country_code);
-u8 GetSysMenuRegion(u16 _TitleVersion);
-std::string GetCompanyFromID(const std::string& company_id);
 
 }  // namespace

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -17,6 +17,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 #include "DiscIO/Blob.h"
+#include "DiscIO/Enums.h"
 #include "DiscIO/FileMonitor.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeDirectory.h"
@@ -163,7 +164,7 @@ void CVolumeDirectory::SetUniqueID(const std::string& id)
   memcpy(m_diskHeader.data(), id.c_str(), std::min(id.length(), MAX_ID_LENGTH));
 }
 
-IVolume::ECountry CVolumeDirectory::GetCountry() const
+Country CVolumeDirectory::GetCountry() const
 {
   return CountrySwitch(m_diskHeader[3]);
 }
@@ -183,12 +184,12 @@ std::string CVolumeDirectory::GetInternalName() const
     return "";
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeDirectory::GetLongNames() const
+std::map<Language, std::string> CVolumeDirectory::GetLongNames() const
 {
   std::string name = GetInternalName();
   if (name.empty())
     return {{}};
-  return {{IVolume::LANGUAGE_UNKNOWN, name}};
+  return {{Language::LANGUAGE_UNKNOWN, name}};
 }
 
 std::vector<u32> CVolumeDirectory::GetBanner(int* width, int* height) const
@@ -218,9 +219,9 @@ std::string CVolumeDirectory::GetApploaderDate() const
   return "VOID";
 }
 
-IVolume::EPlatform CVolumeDirectory::GetVolumeType() const
+Platform CVolumeDirectory::GetVolumeType() const
 {
-  return m_is_wii ? WII_DISC : GAMECUBE_DISC;
+  return m_is_wii ? Platform::WII_DISC : Platform::GAMECUBE_DISC;
 }
 
 BlobType CVolumeDirectory::GetBlobType() const

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 
 namespace File
@@ -24,6 +23,11 @@ struct FSTEntry;
 
 namespace DiscIO
 {
+enum class BlobType;
+enum class Country;
+enum class Language;
+enum class Platform;
+
 class CVolumeDirectory : public IVolume
 {
 public:
@@ -43,16 +47,16 @@ public:
 
   u16 GetRevision() const override { return 0; }
   std::string GetInternalName() const override;
-  std::map<IVolume::ELanguage, std::string> GetLongNames() const override;
+  std::map<Language, std::string> GetLongNames() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
   void SetName(const std::string&);
 
   u64 GetFSTSize() const override;
 
   std::string GetApploaderDate() const override;
-  EPlatform GetVolumeType() const override;
+  Platform GetVolumeType() const override;
 
-  ECountry GetCountry() const override;
+  Country GetCountry() const override;
 
   BlobType GetBlobType() const override;
   u64 GetSize() const override;

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -15,6 +15,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "DiscIO/Blob.h"
+#include "DiscIO/Enums.h"
 #include "DiscIO/FileMonitor.h"
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
@@ -60,10 +61,10 @@ std::string CVolumeGC::GetUniqueID() const
   return DecodeString(ID);
 }
 
-IVolume::ECountry CVolumeGC::GetCountry() const
+Country CVolumeGC::GetCountry() const
 {
   if (!m_pReader)
-    return COUNTRY_UNKNOWN;
+    return Country::COUNTRY_UNKNOWN;
 
   u8 country_code;
   m_pReader->Read(3, 1, &country_code);
@@ -104,31 +105,31 @@ std::string CVolumeGC::GetInternalName() const
   return "";
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeGC::GetShortNames() const
+std::map<Language, std::string> CVolumeGC::GetShortNames() const
 {
   LoadBannerFile();
   return m_short_names;
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeGC::GetLongNames() const
+std::map<Language, std::string> CVolumeGC::GetLongNames() const
 {
   LoadBannerFile();
   return m_long_names;
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeGC::GetShortMakers() const
+std::map<Language, std::string> CVolumeGC::GetShortMakers() const
 {
   LoadBannerFile();
   return m_short_makers;
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeGC::GetLongMakers() const
+std::map<Language, std::string> CVolumeGC::GetLongMakers() const
 {
   LoadBannerFile();
   return m_long_makers;
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeGC::GetDescriptions() const
+std::map<Language, std::string> CVolumeGC::GetDescriptions() const
 {
   LoadBannerFile();
   return m_descriptions;
@@ -194,9 +195,9 @@ u8 CVolumeGC::GetDiscNumber() const
   return disc_number;
 }
 
-IVolume::EPlatform CVolumeGC::GetVolumeType() const
+Platform CVolumeGC::GetVolumeType() const
 {
-  return GAMECUBE_DISC;
+  return Platform::GAMECUBE_DISC;
 }
 
 void CVolumeGC::LoadBannerFile() const
@@ -241,18 +242,18 @@ void CVolumeGC::LoadBannerFile() const
 void CVolumeGC::ExtractBannerInformation(const GCBanner& banner_file, bool is_bnr1) const
 {
   u32 number_of_languages = 0;
-  ELanguage start_language = LANGUAGE_UNKNOWN;
-  bool is_japanese = GetCountry() == ECountry::COUNTRY_JAPAN;
+  Language start_language = Language::LANGUAGE_UNKNOWN;
 
   if (is_bnr1)  // NTSC
   {
+    bool is_japanese = GetCountry() == Country::COUNTRY_JAPAN;
     number_of_languages = 1;
-    start_language = is_japanese ? ELanguage::LANGUAGE_JAPANESE : ELanguage::LANGUAGE_ENGLISH;
+    start_language = is_japanese ? Language::LANGUAGE_JAPANESE : Language::LANGUAGE_ENGLISH;
   }
   else  // PAL
   {
     number_of_languages = 6;
-    start_language = ELanguage::LANGUAGE_ENGLISH;
+    start_language = Language::LANGUAGE_ENGLISH;
   }
 
   m_image_width = GC_BANNER_WIDTH;
@@ -264,7 +265,7 @@ void CVolumeGC::ExtractBannerInformation(const GCBanner& banner_file, bool is_bn
   for (u32 i = 0; i < number_of_languages; ++i)
   {
     const GCBannerInformation& info = banner_file.information[i];
-    ELanguage language = static_cast<ELanguage>(start_language + i);
+    Language language = static_cast<Language>(static_cast<int>(start_language) + i);
 
     std::string description = DecodeString(info.description);
     if (!description.empty())

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -10,13 +10,17 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 
 // --- this volume type is used for GC disc images ---
 
 namespace DiscIO
 {
+enum class BlobType;
+enum class Country;
+enum class Language;
+enum class Platform;
+
 class CVolumeGC : public IVolume
 {
 public:
@@ -27,18 +31,18 @@ public:
   std::string GetMakerID() const override;
   u16 GetRevision() const override;
   std::string GetInternalName() const override;
-  std::map<ELanguage, std::string> GetShortNames() const override;
-  std::map<ELanguage, std::string> GetLongNames() const override;
-  std::map<ELanguage, std::string> GetShortMakers() const override;
-  std::map<ELanguage, std::string> GetLongMakers() const override;
-  std::map<ELanguage, std::string> GetDescriptions() const override;
+  std::map<Language, std::string> GetShortNames() const override;
+  std::map<Language, std::string> GetLongNames() const override;
+  std::map<Language, std::string> GetShortMakers() const override;
+  std::map<Language, std::string> GetLongMakers() const override;
+  std::map<Language, std::string> GetDescriptions() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
   u64 GetFSTSize() const override;
   std::string GetApploaderDate() const override;
   u8 GetDiscNumber() const override;
 
-  EPlatform GetVolumeType() const override;
-  ECountry GetCountry() const override;
+  Platform GetVolumeType() const override;
+  Country GetCountry() const override;
   BlobType GetBlobType() const override;
   u64 GetSize() const override;
   u64 GetRawSize() const override;
@@ -73,12 +77,12 @@ private:
   static const size_t BNR1_SIZE = sizeof(GCBanner) - sizeof(GCBannerInformation) * 5;
   static const size_t BNR2_SIZE = sizeof(GCBanner);
 
-  mutable std::map<ELanguage, std::string> m_short_names;
+  mutable std::map<Language, std::string> m_short_names;
 
-  mutable std::map<ELanguage, std::string> m_long_names;
-  mutable std::map<ELanguage, std::string> m_short_makers;
-  mutable std::map<ELanguage, std::string> m_long_makers;
-  mutable std::map<ELanguage, std::string> m_descriptions;
+  mutable std::map<Language, std::string> m_long_names;
+  mutable std::map<Language, std::string> m_short_makers;
+  mutable std::map<Language, std::string> m_long_makers;
+  mutable std::map<Language, std::string> m_descriptions;
 
   mutable bool m_banner_loaded = false;
   mutable std::vector<u32> m_image_buffer;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -16,6 +16,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "DiscIO/Blob.h"
+#include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeWad.h"
 
@@ -54,10 +55,10 @@ bool CVolumeWAD::Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) cons
   return m_pReader->Read(_Offset, _Length, _pBuffer);
 }
 
-IVolume::ECountry CVolumeWAD::GetCountry() const
+Country CVolumeWAD::GetCountry() const
 {
   if (!m_pReader)
-    return COUNTRY_UNKNOWN;
+    return Country::COUNTRY_UNKNOWN;
 
   // read the last digit of the titleID in the ticket
   u8 country_code;
@@ -114,16 +115,16 @@ u16 CVolumeWAD::GetRevision() const
   return Common::swap16(revision);
 }
 
-IVolume::EPlatform CVolumeWAD::GetVolumeType() const
+Platform CVolumeWAD::GetVolumeType() const
 {
-  return WII_WAD;
+  return Platform::WII_WAD;
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeWAD::GetLongNames() const
+std::map<Language, std::string> CVolumeWAD::GetLongNames() const
 {
   std::vector<u8> name_data(NAMES_TOTAL_BYTES);
   if (!Read(m_opening_bnr_offset + 0x9C, NAMES_TOTAL_BYTES, name_data.data()))
-    return std::map<IVolume::ELanguage, std::string>();
+    return std::map<Language, std::string>();
   return ReadWiiNames(name_data);
 }
 

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 
 // --- this volume type is used for Wad files ---
@@ -19,6 +18,11 @@
 
 namespace DiscIO
 {
+enum class BlobType;
+enum class Country;
+enum class Language;
+enum class Platform;
+
 class CVolumeWAD : public IVolume
 {
 public:
@@ -30,12 +34,12 @@ public:
   std::string GetMakerID() const override;
   u16 GetRevision() const override;
   std::string GetInternalName() const override { return ""; }
-  std::map<IVolume::ELanguage, std::string> GetLongNames() const override;
+  std::map<Language, std::string> GetLongNames() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
   u64 GetFSTSize() const override { return 0; }
   std::string GetApploaderDate() const override { return ""; }
-  EPlatform GetVolumeType() const override;
-  ECountry GetCountry() const override;
+  Platform GetVolumeType() const override;
+  Country GetCountry() const override;
 
   BlobType GetBlobType() const override;
   u64 GetSize() const override;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -17,6 +17,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "DiscIO/Blob.h"
+#include "DiscIO/Enums.h"
 #include "DiscIO/FileMonitor.h"
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
@@ -152,53 +153,49 @@ std::string CVolumeWiiCrypted::GetUniqueID() const
   return DecodeString(ID);
 }
 
-IVolume::ECountry CVolumeWiiCrypted::GetCountry() const
+Country CVolumeWiiCrypted::GetCountry() const
 {
   if (!m_pReader)
-    return COUNTRY_UNKNOWN;
+    return Country::COUNTRY_UNKNOWN;
 
   u8 country_byte;
   if (!m_pReader->Read(3, 1, &country_byte))
-  {
-    return COUNTRY_UNKNOWN;
-  }
+    return Country::COUNTRY_UNKNOWN;
 
-  IVolume::ECountry country_value = CountrySwitch(country_byte);
+  Country country_value = CountrySwitch(country_byte);
 
   u32 region_code;
   if (!ReadSwapped(0x4E000, &region_code, false))
-  {
     return country_value;
-  }
 
   switch (region_code)
   {
   case 0:
     switch (country_value)
     {
-    case IVolume::COUNTRY_TAIWAN:
-      return IVolume::COUNTRY_TAIWAN;
+    case Country::COUNTRY_TAIWAN:
+      return Country::COUNTRY_TAIWAN;
     default:
-      return IVolume::COUNTRY_JAPAN;
+      return Country::COUNTRY_JAPAN;
     }
   case 1:
-    return IVolume::COUNTRY_USA;
+    return Country::COUNTRY_USA;
   case 2:
     switch (country_value)
     {
-    case IVolume::COUNTRY_FRANCE:
-    case IVolume::COUNTRY_GERMANY:
-    case IVolume::COUNTRY_ITALY:
-    case IVolume::COUNTRY_NETHERLANDS:
-    case IVolume::COUNTRY_RUSSIA:
-    case IVolume::COUNTRY_SPAIN:
-    case IVolume::COUNTRY_AUSTRALIA:
+    case Country::COUNTRY_FRANCE:
+    case Country::COUNTRY_GERMANY:
+    case Country::COUNTRY_ITALY:
+    case Country::COUNTRY_NETHERLANDS:
+    case Country::COUNTRY_RUSSIA:
+    case Country::COUNTRY_SPAIN:
+    case Country::COUNTRY_AUSTRALIA:
       return country_value;
     default:
-      return IVolume::COUNTRY_EUROPE;
+      return Country::COUNTRY_EUROPE;
     }
   case 4:
-    return IVolume::COUNTRY_KOREA;
+    return Country::COUNTRY_KOREA;
   default:
     return country_value;
   }
@@ -238,12 +235,12 @@ std::string CVolumeWiiCrypted::GetInternalName() const
   return "";
 }
 
-std::map<IVolume::ELanguage, std::string> CVolumeWiiCrypted::GetLongNames() const
+std::map<Language, std::string> CVolumeWiiCrypted::GetLongNames() const
 {
   std::unique_ptr<IFileSystem> file_system(CreateFileSystem(this));
   std::vector<u8> opening_bnr(NAMES_TOTAL_BYTES);
-  opening_bnr.resize(
-      file_system->ReadFile("opening.bnr", opening_bnr.data(), opening_bnr.size(), 0x5C));
+  size_t size = file_system->ReadFile("opening.bnr", opening_bnr.data(), opening_bnr.size(), 0x5C);
+  opening_bnr.resize(size);
   return ReadWiiNames(opening_bnr);
 }
 
@@ -285,9 +282,9 @@ std::string CVolumeWiiCrypted::GetApploaderDate() const
   return DecodeString(date);
 }
 
-IVolume::EPlatform CVolumeWiiCrypted::GetVolumeType() const
+Platform CVolumeWiiCrypted::GetVolumeType() const
 {
-  return WII_DISC;
+  return Platform::WII_DISC;
 }
 
 u8 CVolumeWiiCrypted::GetDiscNumber() const

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -11,13 +11,17 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "DiscIO/Blob.h"
 #include "DiscIO/Volume.h"
 
 // --- this volume type is used for encrypted Wii images ---
 
 namespace DiscIO
 {
+enum class BlobType;
+enum class Country;
+enum class Language;
+enum class Platform;
+
 class CVolumeWiiCrypted : public IVolume
 {
 public:
@@ -31,18 +35,18 @@ public:
   std::string GetMakerID() const override;
   u16 GetRevision() const override;
   std::string GetInternalName() const override;
-  std::map<IVolume::ELanguage, std::string> GetLongNames() const override;
+  std::map<Language, std::string> GetLongNames() const override;
   std::vector<u32> GetBanner(int* width, int* height) const override;
   u64 GetFSTSize() const override;
   std::string GetApploaderDate() const override;
   u8 GetDiscNumber() const override;
 
-  EPlatform GetVolumeType() const override;
+  Platform GetVolumeType() const override;
   bool SupportsIntegrityCheck() const override { return true; }
   bool CheckIntegrity() const override;
   bool ChangePartition(u64 offset) override;
 
-  ECountry GetCountry() const override;
+  Country GetCountry() const override;
   BlobType GetBlobType() const override;
   u64 GetSize() const override;
   u64 GetRawSize() const override;

--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -13,6 +13,8 @@
 #include <QPushButton>
 #include <QTextEdit>
 
+#include "DiscIO/Blob.h"
+#include "DiscIO/Enums.h"
 #include "DolphinQt2/Config/InfoWidget.h"
 
 InfoWidget::InfoWidget(const GameFile& game) : m_game(game)
@@ -71,7 +73,7 @@ QGroupBox* InfoWidget::CreateBannerDetails()
   CreateLanguageSelector();
 
   layout->addRow(tr("Show Language:"), m_language_selector);
-  if (m_game.GetPlatformID() == DiscIO::IVolume::GAMECUBE_DISC)
+  if (m_game.GetPlatformID() == DiscIO::Platform::GAMECUBE_DISC)
   {
     layout->addRow(tr("Short Name:"), m_short_name);
     layout->addRow(tr("Short Maker:"), m_short_maker);
@@ -79,7 +81,7 @@ QGroupBox* InfoWidget::CreateBannerDetails()
     layout->addRow(tr("Long Maker:"), m_long_maker);
     layout->addRow(tr("Description:"), m_description);
   }
-  else if (m_game.GetPlatformID() == DiscIO::IVolume::WII_DISC)
+  else if (m_game.GetPlatformID() == DiscIO::Platform::WII_DISC)
   {
     layout->addRow(tr("Name:"), m_long_name);
   }
@@ -123,11 +125,11 @@ QLineEdit* InfoWidget::CreateValueDisplay(const QString& value)
 void InfoWidget::CreateLanguageSelector()
 {
   m_language_selector = new QComboBox();
-  QList<DiscIO::IVolume::ELanguage> languages = m_game.GetAvailableLanguages();
+  QList<DiscIO::Language> languages = m_game.GetAvailableLanguages();
   for (int i = 0; i < languages.count(); i++)
   {
-    DiscIO::IVolume::ELanguage language = languages.at(i);
-    m_language_selector->addItem(m_game.GetLanguage(language), language);
+    DiscIO::Language language = languages.at(i);
+    m_language_selector->addItem(m_game.GetLanguage(language), static_cast<int>(language));
   }
   if (m_language_selector->count() == 1)
     m_language_selector->setDisabled(true);
@@ -137,8 +139,8 @@ void InfoWidget::CreateLanguageSelector()
 
 void InfoWidget::ChangeLanguage()
 {
-  DiscIO::IVolume::ELanguage language =
-      static_cast<DiscIO::IVolume::ELanguage>(m_language_selector->currentData().toInt());
+  DiscIO::Language language =
+      static_cast<DiscIO::Language>(m_language_selector->currentData().toInt());
   m_short_name->setText(m_game.GetShortName(language));
   m_short_maker->setText(m_game.GetShortMaker(language));
   m_long_name->setText(m_game.GetLongName(language));

--- a/Source/Core/DolphinQt2/GameList/GameFile.h
+++ b/Source/Core/DolphinQt2/GameList/GameFile.h
@@ -9,7 +9,16 @@
 #include <QPixmap>
 #include <QString>
 
-#include "DiscIO/Volume.h"
+#include "Common/CommonTypes.h"
+
+namespace DiscIO
+{
+enum class BlobType;
+enum class Country;
+enum class Language;
+enum class Platform;
+class IVolume;
+}
 
 // TODO cache
 class GameFile final
@@ -36,26 +45,26 @@ public:
   QString GetIssues() const { return m_issues; }
   int GetRating() const { return m_rating; }
   QString GetApploaderDate() const { return m_apploader_date; }
-  DiscIO::IVolume::EPlatform GetPlatformID() const { return m_platform; }
+  DiscIO::Platform GetPlatformID() const { return m_platform; }
   QString GetPlatform() const;
-  DiscIO::IVolume::ECountry GetCountryID() const { return m_country; }
+  DiscIO::Country GetCountryID() const { return m_country; }
   QString GetCountry() const;
   DiscIO::BlobType GetBlobType() const { return m_blob_type; }
   // Banner details
-  QString GetLanguage(DiscIO::IVolume::ELanguage lang) const;
-  QList<DiscIO::IVolume::ELanguage> GetAvailableLanguages() const;
+  QString GetLanguage(DiscIO::Language lang) const;
+  QList<DiscIO::Language> GetAvailableLanguages() const;
   QString GetShortName() const { return GetBannerString(m_short_names); }
   QString GetShortMaker() const { return GetBannerString(m_short_makers); }
   QString GetLongName() const { return GetBannerString(m_long_names); }
   QString GetLongMaker() const { return GetBannerString(m_long_makers); }
   QString GetDescription() const { return GetBannerString(m_descriptions); }
-  QString GetShortName(DiscIO::IVolume::ELanguage lang) const { return m_short_names[lang]; }
-  QString GetShortMaker(DiscIO::IVolume::ELanguage lang) const { return m_short_makers[lang]; }
-  QString GetLongName(DiscIO::IVolume::ELanguage lang) const { return m_long_names[lang]; }
-  QString GetLongMaker(DiscIO::IVolume::ELanguage lang) const { return m_long_makers[lang]; }
-  QString GetDescription(DiscIO::IVolume::ELanguage lang) const { return m_descriptions[lang]; }
+  QString GetShortName(DiscIO::Language lang) const { return m_short_names[lang]; }
+  QString GetShortMaker(DiscIO::Language lang) const { return m_short_makers[lang]; }
+  QString GetLongName(DiscIO::Language lang) const { return m_long_names[lang]; }
+  QString GetLongMaker(DiscIO::Language lang) const { return m_long_makers[lang]; }
+  QString GetDescription(DiscIO::Language lang) const { return m_descriptions[lang]; }
 private:
-  QString GetBannerString(const QMap<DiscIO::IVolume::ELanguage, QString>& m) const;
+  QString GetBannerString(const QMap<DiscIO::Language, QString>& m) const;
 
   QString GetCacheFileName() const;
   void ReadBanner(const DiscIO::IVolume& volume);
@@ -80,15 +89,15 @@ private:
   QString m_maker_id;
   u16 m_revision = 0;
   QString m_internal_name;
-  QMap<DiscIO::IVolume::ELanguage, QString> m_short_names;
-  QMap<DiscIO::IVolume::ELanguage, QString> m_long_names;
-  QMap<DiscIO::IVolume::ELanguage, QString> m_short_makers;
-  QMap<DiscIO::IVolume::ELanguage, QString> m_long_makers;
-  QMap<DiscIO::IVolume::ELanguage, QString> m_descriptions;
+  QMap<DiscIO::Language, QString> m_short_names;
+  QMap<DiscIO::Language, QString> m_long_names;
+  QMap<DiscIO::Language, QString> m_short_makers;
+  QMap<DiscIO::Language, QString> m_long_makers;
+  QMap<DiscIO::Language, QString> m_descriptions;
   QString m_company;
   u8 m_disc_number = 0;
-  DiscIO::IVolume::EPlatform m_platform;
-  DiscIO::IVolume::ECountry m_country;
+  DiscIO::Platform m_platform;
+  DiscIO::Country m_country;
   DiscIO::BlobType m_blob_type;
   u64 m_raw_size = 0;
   QPixmap m_banner;

--- a/Source/Core/DolphinQt2/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameList.cpp
@@ -8,6 +8,8 @@
 #include <QMenu>
 #include <QUrl>
 
+#include "DiscIO/Enums.h"
+
 #include "DolphinQt2/Config/PropertiesDialog.h"
 #include "DolphinQt2/GameList/GameList.h"
 #include "DolphinQt2/GameList/ListProxyModel.h"
@@ -104,8 +106,8 @@ void GameList::MakeListView()
 void GameList::ShowContextMenu(const QPoint&)
 {
   QMenu* menu = new QMenu(this);
-  DiscIO::IVolume::EPlatform platform = GameFile(GetSelectedGame()).GetPlatformID();
-  if (platform == DiscIO::IVolume::GAMECUBE_DISC || platform == DiscIO::IVolume::WII_DISC)
+  DiscIO::Platform platform = GameFile(GetSelectedGame()).GetPlatformID();
+  if (platform == DiscIO::Platform::GAMECUBE_DISC || platform == DiscIO::Platform::WII_DISC)
   {
     menu->addAction(tr("Properties"), this, SLOT(OpenProperties()));
     menu->addAction(tr("Open Wiki Page"), this, SLOT(OpenWiki()));

--- a/Source/Core/DolphinQt2/GameList/GameListModel.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameListModel.cpp
@@ -38,7 +38,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
     case COL_SIZE:
       return game->GetFileSize();
     case COL_COUNTRY:
-      return game->GetCountryID();
+      return static_cast<int>(game->GetCountryID());
     case COL_RATING:
       return game->GetRating();
     }

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -101,12 +101,12 @@ void Settings::SetWiiNAND(const QString& path)
   SConfig::GetInstance().SaveSettings();
 }
 
-DiscIO::IVolume::ELanguage Settings::GetWiiSystemLanguage() const
+DiscIO::Language Settings::GetWiiSystemLanguage() const
 {
   return SConfig::GetInstance().GetCurrentLanguage(true);
 }
 
-DiscIO::IVolume::ELanguage Settings::GetGCSystemLanguage() const
+DiscIO::Language Settings::GetGCSystemLanguage() const
 {
   return SConfig::GetInstance().GetCurrentLanguage(false);
 }

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -6,7 +6,10 @@
 
 #include <QSettings>
 
-#include "DiscIO/Volume.h"
+namespace DiscIO
+{
+enum class Language;
+}
 
 // UI settings to be stored in the config directory.
 class Settings final : public QSettings
@@ -34,8 +37,8 @@ public:
   void SetApploader(const QString& path);
   QString GetWiiNAND() const;
   void SetWiiNAND(const QString& path);
-  DiscIO::IVolume::ELanguage GetWiiSystemLanguage() const;
-  DiscIO::IVolume::ELanguage GetGCSystemLanguage() const;
+  DiscIO::Language GetWiiSystemLanguage() const;
+  DiscIO::Language GetGCSystemLanguage() const;
   bool GetPreferredView() const;
   void SetPreferredView(bool table);
 

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -11,7 +11,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
-#include "DiscIO/Volume.h"
+#include "DiscIO/Enums.h"
 #include "DolphinWX/Config/WiiConfigPane.h"
 #include "DolphinWX/WxUtils.h"
 
@@ -139,8 +139,8 @@ void WiiConfigPane::OnConnectKeyboardCheckBoxChanged(wxCommandEvent& event)
 
 void WiiConfigPane::OnSystemLanguageChoiceChanged(wxCommandEvent& event)
 {
-  DiscIO::IVolume::ELanguage wii_system_lang =
-      (DiscIO::IVolume::ELanguage)m_system_language_choice->GetSelection();
+  DiscIO::Language wii_system_lang =
+      static_cast<DiscIO::Language>(m_system_language_choice->GetSelection());
   SConfig::GetInstance().m_SYSCONF->SetData("IPL.LNG", wii_system_lang);
   u8 country_code = GetSADRCountryCode(wii_system_lang);
 
@@ -155,30 +155,30 @@ void WiiConfigPane::OnAspectRatioChoiceChanged(wxCommandEvent& event)
 
 // Change from IPL.LNG value to IPL.SADR country code.
 // http://wiibrew.org/wiki/Country_Codes
-u8 WiiConfigPane::GetSADRCountryCode(DiscIO::IVolume::ELanguage language)
+u8 WiiConfigPane::GetSADRCountryCode(DiscIO::Language language)
 {
   switch (language)
   {
-  case DiscIO::IVolume::LANGUAGE_JAPANESE:
+  case DiscIO::Language::LANGUAGE_JAPANESE:
     return 1;  // Japan
-  case DiscIO::IVolume::LANGUAGE_ENGLISH:
+  case DiscIO::Language::LANGUAGE_ENGLISH:
     return 49;  // USA
-  case DiscIO::IVolume::LANGUAGE_GERMAN:
+  case DiscIO::Language::LANGUAGE_GERMAN:
     return 78;  // Germany
-  case DiscIO::IVolume::LANGUAGE_FRENCH:
+  case DiscIO::Language::LANGUAGE_FRENCH:
     return 77;  // France
-  case DiscIO::IVolume::LANGUAGE_SPANISH:
+  case DiscIO::Language::LANGUAGE_SPANISH:
     return 105;  // Spain
-  case DiscIO::IVolume::LANGUAGE_ITALIAN:
+  case DiscIO::Language::LANGUAGE_ITALIAN:
     return 83;  // Italy
-  case DiscIO::IVolume::LANGUAGE_DUTCH:
+  case DiscIO::Language::LANGUAGE_DUTCH:
     return 94;  // Netherlands
-  case DiscIO::IVolume::LANGUAGE_SIMPLIFIED_CHINESE:
-  case DiscIO::IVolume::LANGUAGE_TRADITIONAL_CHINESE:
+  case DiscIO::Language::LANGUAGE_SIMPLIFIED_CHINESE:
+  case DiscIO::Language::LANGUAGE_TRADITIONAL_CHINESE:
     return 157;  // China
-  case DiscIO::IVolume::LANGUAGE_KOREAN:
+  case DiscIO::Language::LANGUAGE_KOREAN:
     return 136;  // Korea
-  case DiscIO::IVolume::LANGUAGE_UNKNOWN:
+  case DiscIO::Language::LANGUAGE_UNKNOWN:
     break;
   }
 

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.h
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.h
@@ -7,7 +7,11 @@
 #include <wx/arrstr.h>
 #include <wx/panel.h>
 #include "Common/CommonTypes.h"
-#include "DiscIO/Volume.h"
+
+namespace DiscIO
+{
+enum class Language;
+}
 
 class wxCheckBox;
 class wxChoice;
@@ -29,7 +33,7 @@ private:
   void OnSystemLanguageChoiceChanged(wxCommandEvent&);
   void OnAspectRatioChoiceChanged(wxCommandEvent&);
 
-  static u8 GetSADRCountryCode(DiscIO::IVolume::ELanguage language);
+  static u8 GetSADRCountryCode(DiscIO::Language language);
 
   wxArrayString m_system_language_strings;
   wxArrayString m_aspect_ratio_strings;

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -45,6 +45,7 @@
 #include "Core/HW/WiiSaveCrypted.h"
 #include "Core/Movie.h"
 #include "DiscIO/Blob.h"
+#include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 #include "DolphinWX/Frame.h"
@@ -179,59 +180,48 @@ CGameListCtrl::~CGameListCtrl()
   ClearIsoFiles();
 }
 
-void CGameListCtrl::InitBitmaps()
+template <typename T>
+static void InitBitmap(wxImageList* img_list, std::vector<int>* vector, T index,
+                       const std::string& name)
 {
   wxSize size(96, 32);
+  (*vector)[static_cast<size_t>(index)] = img_list->Add(WxUtils::LoadResourceBitmap(name, size));
+}
+
+void CGameListCtrl::InitBitmaps()
+{
   wxImageList* img_list = new wxImageList(96, 32);
   AssignImageList(img_list, wxIMAGE_LIST_SMALL);
 
-  m_FlagImageIndex.resize(DiscIO::IVolume::NUMBER_OF_COUNTRIES);
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_JAPAN] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Japan", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_EUROPE] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Europe", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_USA] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_USA", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_AUSTRALIA] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Australia", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_FRANCE] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_France", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_GERMANY] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Germany", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_ITALY] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Italy", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_KOREA] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Korea", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_NETHERLANDS] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Netherlands", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_RUSSIA] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Russia", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_SPAIN] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Spain", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_TAIWAN] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Taiwan", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_WORLD] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_International", size));
-  m_FlagImageIndex[DiscIO::IVolume::COUNTRY_UNKNOWN] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Flag_Unknown", size));
+  m_FlagImageIndex.resize(static_cast<size_t>(DiscIO::Country::NUMBER_OF_COUNTRIES));
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_JAPAN, "Flag_Japan");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_EUROPE, "Flag_Europe");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_USA, "Flag_USA");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_AUSTRALIA, "Flag_Australia");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_FRANCE, "Flag_France");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_GERMANY, "Flag_Germany");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_ITALY, "Flag_Italy");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_KOREA, "Flag_Korea");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_NETHERLANDS, "Flag_Netherlands");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_RUSSIA, "Flag_Russia");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_SPAIN, "Flag_Spain");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_TAIWAN, "Flag_Taiwan");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_WORLD, "Flag_International");
+  InitBitmap(img_list, &m_FlagImageIndex, DiscIO::Country::COUNTRY_UNKNOWN, "Flag_Unknown");
 
-  m_PlatformImageIndex.resize(4);
-  m_PlatformImageIndex[DiscIO::IVolume::GAMECUBE_DISC] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Platform_Gamecube", size));
-  m_PlatformImageIndex[DiscIO::IVolume::WII_DISC] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Platform_Wii", size));
-  m_PlatformImageIndex[DiscIO::IVolume::WII_WAD] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Platform_Wad", size));
-  m_PlatformImageIndex[DiscIO::IVolume::ELF_DOL] =
-      img_list->Add(WxUtils::LoadResourceBitmap("Platform_File", size));
+  m_PlatformImageIndex.resize(static_cast<size_t>(DiscIO::Platform::NUMBER_OF_PLATFORMS));
+  InitBitmap(img_list, &m_PlatformImageIndex, DiscIO::Platform::GAMECUBE_DISC, "Platform_Gamecube");
+  InitBitmap(img_list, &m_PlatformImageIndex, DiscIO::Platform::WII_DISC, "Platform_Wii");
+  InitBitmap(img_list, &m_PlatformImageIndex, DiscIO::Platform::WII_WAD, "Platform_Wad");
+  InitBitmap(img_list, &m_PlatformImageIndex, DiscIO::Platform::ELF_DOL, "Platform_File");
 
   m_EmuStateImageIndex.resize(6);
-  m_EmuStateImageIndex[0] = img_list->Add(WxUtils::LoadResourceBitmap("rating0", size));
-  m_EmuStateImageIndex[1] = img_list->Add(WxUtils::LoadResourceBitmap("rating1", size));
-  m_EmuStateImageIndex[2] = img_list->Add(WxUtils::LoadResourceBitmap("rating2", size));
-  m_EmuStateImageIndex[3] = img_list->Add(WxUtils::LoadResourceBitmap("rating3", size));
-  m_EmuStateImageIndex[4] = img_list->Add(WxUtils::LoadResourceBitmap("rating4", size));
-  m_EmuStateImageIndex[5] = img_list->Add(WxUtils::LoadResourceBitmap("rating5", size));
+  InitBitmap(img_list, &m_EmuStateImageIndex, 0, "rating0");
+  InitBitmap(img_list, &m_EmuStateImageIndex, 1, "rating1");
+  InitBitmap(img_list, &m_EmuStateImageIndex, 2, "rating2");
+  InitBitmap(img_list, &m_EmuStateImageIndex, 3, "rating3");
+  InitBitmap(img_list, &m_EmuStateImageIndex, 4, "rating4");
+  InitBitmap(img_list, &m_EmuStateImageIndex, 5, "rating5");
 }
 
 void CGameListCtrl::BrowseForDirectory()
@@ -403,7 +393,8 @@ void CGameListCtrl::UpdateItemAtColumn(long _Index, int column)
   {
   case COLUMN_PLATFORM:
   {
-    SetItemColumnImage(_Index, COLUMN_PLATFORM, m_PlatformImageIndex[rISOFile.GetPlatform()]);
+    SetItemColumnImage(_Index, COLUMN_PLATFORM,
+                       m_PlatformImageIndex[static_cast<size_t>(rISOFile.GetPlatform())]);
     break;
   }
   case COLUMN_BANNER:
@@ -442,7 +433,8 @@ void CGameListCtrl::UpdateItemAtColumn(long _Index, int column)
                        m_EmuStateImageIndex[rISOFile.GetEmuState()]);
     break;
   case COLUMN_COUNTRY:
-    SetItemColumnImage(_Index, COLUMN_COUNTRY, m_FlagImageIndex[rISOFile.GetCountry()]);
+    SetItemColumnImage(_Index, COLUMN_COUNTRY,
+                       m_FlagImageIndex[static_cast<size_t>(rISOFile.GetCountry())]);
     break;
   case COLUMN_SIZE:
     SetItem(_Index, COLUMN_SIZE, NiceSizeFormat(rISOFile.GetFileSize()), -1);
@@ -576,15 +568,15 @@ void CGameListCtrl::ScanForISOs()
 
         switch (iso_file->GetPlatform())
         {
-        case DiscIO::IVolume::WII_DISC:
+        case DiscIO::Platform::WII_DISC:
           if (!SConfig::GetInstance().m_ListWii)
             list = false;
           break;
-        case DiscIO::IVolume::WII_WAD:
+        case DiscIO::Platform::WII_WAD:
           if (!SConfig::GetInstance().m_ListWad)
             list = false;
           break;
-        case DiscIO::IVolume::ELF_DOL:
+        case DiscIO::Platform::ELF_DOL:
           if (!SConfig::GetInstance().m_ListElfDol)
             list = false;
           break;
@@ -596,59 +588,59 @@ void CGameListCtrl::ScanForISOs()
 
         switch (iso_file->GetCountry())
         {
-        case DiscIO::IVolume::COUNTRY_AUSTRALIA:
+        case DiscIO::Country::COUNTRY_AUSTRALIA:
           if (!SConfig::GetInstance().m_ListAustralia)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_EUROPE:
+        case DiscIO::Country::COUNTRY_EUROPE:
           if (!SConfig::GetInstance().m_ListPal)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_FRANCE:
+        case DiscIO::Country::COUNTRY_FRANCE:
           if (!SConfig::GetInstance().m_ListFrance)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_GERMANY:
+        case DiscIO::Country::COUNTRY_GERMANY:
           if (!SConfig::GetInstance().m_ListGermany)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_ITALY:
+        case DiscIO::Country::COUNTRY_ITALY:
           if (!SConfig::GetInstance().m_ListItaly)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_JAPAN:
+        case DiscIO::Country::COUNTRY_JAPAN:
           if (!SConfig::GetInstance().m_ListJap)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_KOREA:
+        case DiscIO::Country::COUNTRY_KOREA:
           if (!SConfig::GetInstance().m_ListKorea)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_NETHERLANDS:
+        case DiscIO::Country::COUNTRY_NETHERLANDS:
           if (!SConfig::GetInstance().m_ListNetherlands)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_RUSSIA:
+        case DiscIO::Country::COUNTRY_RUSSIA:
           if (!SConfig::GetInstance().m_ListRussia)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_SPAIN:
+        case DiscIO::Country::COUNTRY_SPAIN:
           if (!SConfig::GetInstance().m_ListSpain)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_TAIWAN:
+        case DiscIO::Country::COUNTRY_TAIWAN:
           if (!SConfig::GetInstance().m_ListTaiwan)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_USA:
+        case DiscIO::Country::COUNTRY_USA:
           if (!SConfig::GetInstance().m_ListUsa)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_WORLD:
+        case DiscIO::Country::COUNTRY_WORLD:
           if (!SConfig::GetInstance().m_ListWorld)
             list = false;
           break;
-        case DiscIO::IVolume::COUNTRY_UNKNOWN:
+        case DiscIO::Country::COUNTRY_UNKNOWN:
         default:
           if (!SConfig::GetInstance().m_ListUnknown)
             list = false;
@@ -937,22 +929,22 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
     if (selected_iso)
     {
       wxMenu popupMenu;
-      DiscIO::IVolume::EPlatform platform = selected_iso->GetPlatform();
+      DiscIO::Platform platform = selected_iso->GetPlatform();
 
-      if (platform != DiscIO::IVolume::ELF_DOL)
+      if (platform != DiscIO::Platform::ELF_DOL)
       {
         popupMenu.Append(IDM_PROPERTIES, _("&Properties"));
         popupMenu.Append(IDM_GAME_WIKI, _("&Wiki"));
         popupMenu.AppendSeparator();
       }
-      if (platform == DiscIO::IVolume::WII_DISC || platform == DiscIO::IVolume::WII_WAD)
+      if (platform == DiscIO::Platform::WII_DISC || platform == DiscIO::Platform::WII_WAD)
       {
         popupMenu.Append(IDM_OPEN_SAVE_FOLDER, _("Open Wii &save folder"));
         popupMenu.Append(IDM_EXPORT_SAVE, _("Export Wii save (Experimental)"));
       }
       popupMenu.Append(IDM_OPEN_CONTAINING_FOLDER, _("Open &containing folder"));
 
-      if (platform != DiscIO::IVolume::ELF_DOL)
+      if (platform != DiscIO::Platform::ELF_DOL)
         popupMenu.AppendCheckItem(IDM_SET_DEFAULT_ISO, _("Set as &default ISO"));
 
       // First we have to decide a starting value when we append it
@@ -962,7 +954,7 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
       popupMenu.AppendSeparator();
       popupMenu.Append(IDM_DELETE_ISO, _("&Delete File..."));
 
-      if (platform == DiscIO::IVolume::GAMECUBE_DISC || platform == DiscIO::IVolume::WII_DISC)
+      if (platform == DiscIO::Platform::GAMECUBE_DISC || platform == DiscIO::Platform::WII_DISC)
       {
         if (selected_iso->GetBlobType() == DiscIO::BlobType::GCZ)
           popupMenu.Append(IDM_COMPRESS_ISO, _("Decompress ISO..."));
@@ -973,7 +965,7 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
         changeDiscItem->Enable(Core::IsRunning());
       }
 
-      if (platform == DiscIO::IVolume::WII_WAD)
+      if (platform == DiscIO::Platform::WII_WAD)
         popupMenu.Append(IDM_LIST_INSTALL_WAD, _("Install to Wii Menu"));
 
       PopupMenu(&popupMenu);
@@ -1156,8 +1148,8 @@ void CGameListCtrl::CompressSelection(bool _compress)
   for (const GameListItem* iso : GetAllSelectedISOs())
   {
     // Don't include items that we can't do anything with
-    if (iso->GetPlatform() != DiscIO::IVolume::GAMECUBE_DISC &&
-        iso->GetPlatform() != DiscIO::IVolume::WII_DISC)
+    if (iso->GetPlatform() != DiscIO::Platform::GAMECUBE_DISC &&
+        iso->GetPlatform() != DiscIO::Platform::WII_DISC)
       continue;
     if (iso->GetBlobType() != DiscIO::BlobType::PLAIN &&
         iso->GetBlobType() != DiscIO::BlobType::GCZ)
@@ -1167,7 +1159,7 @@ void CGameListCtrl::CompressSelection(bool _compress)
 
     // Show the Wii compression warning if it's relevant and it hasn't been shown already
     if (!wii_compression_warning_accepted && _compress && !iso->IsCompressed() &&
-        iso->GetPlatform() == DiscIO::IVolume::WII_DISC)
+        iso->GetPlatform() == DiscIO::Platform::WII_DISC)
     {
       if (WiiCompressWarning())
         wii_compression_warning_accepted = true;
@@ -1216,7 +1208,7 @@ void CGameListCtrl::CompressSelection(bool _compress)
 
         all_good &=
             DiscIO::CompressFileToBlob(iso->GetFileName(), OutputFileName,
-                                       (iso->GetPlatform() == DiscIO::IVolume::WII_DISC) ? 1 : 0,
+                                       (iso->GetPlatform() == DiscIO::Platform::WII_DISC) ? 1 : 0,
                                        16384, &MultiCompressCB, &progress);
       }
       else if (iso->IsCompressed() && !_compress)
@@ -1224,7 +1216,7 @@ void CGameListCtrl::CompressSelection(bool _compress)
         std::string FileName;
         SplitPath(iso->GetFileName(), nullptr, &FileName, nullptr);
         progress.current_filename = FileName;
-        if (iso->GetPlatform() == DiscIO::IVolume::WII_DISC)
+        if (iso->GetPlatform() == DiscIO::Platform::WII_DISC)
           FileName.append(".iso");
         else
           FileName.append(".gcm");
@@ -1275,7 +1267,7 @@ void CGameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED(event))
     if (is_compressed)
     {
       wxString FileType;
-      if (iso->GetPlatform() == DiscIO::IVolume::WII_DISC)
+      if (iso->GetPlatform() == DiscIO::Platform::WII_DISC)
         FileType = _("All Wii ISO files (iso)") + "|*.iso";
       else
         FileType = _("All GameCube GCM files (gcm)") + "|*.gcm";
@@ -1286,7 +1278,7 @@ void CGameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED(event))
     }
     else
     {
-      if (iso->GetPlatform() == DiscIO::IVolume::WII_DISC && !WiiCompressWarning())
+      if (iso->GetPlatform() == DiscIO::Platform::WII_DISC && !WiiCompressWarning())
         return;
 
       path = wxFileSelector(_("Save compressed GCM/ISO"), StrToWxStr(FilePath),
@@ -1317,7 +1309,7 @@ void CGameListCtrl::OnCompressISO(wxCommandEvent& WXUNUSED(event))
     else
       all_good = DiscIO::CompressFileToBlob(
           iso->GetFileName(), WxStrToStr(path),
-          (iso->GetPlatform() == DiscIO::IVolume::WII_DISC) ? 1 : 0, 16384, &CompressCB, &dialog);
+          (iso->GetPlatform() == DiscIO::Platform::WII_DISC) ? 1 : 0, 16384, &CompressCB, &dialog);
   }
 
   if (!all_good)

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -28,6 +28,8 @@
 #include "Core/Boot/Boot.h"
 #include "Core/ConfigManager.h"
 
+#include "DiscIO/Blob.h"
+#include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 
@@ -39,8 +41,8 @@ static const u32 CACHE_REVISION = 0x127;  // Last changed in PR 3309
 #define DVD_BANNER_WIDTH 96
 #define DVD_BANNER_HEIGHT 32
 
-static std::string GetLanguageString(DiscIO::IVolume::ELanguage language,
-                                     std::map<DiscIO::IVolume::ELanguage, std::string> strings)
+static std::string GetLanguageString(DiscIO::Language language,
+                                     std::map<DiscIO::Language, std::string> strings)
 {
   auto end = strings.end();
   auto it = strings.find(language);
@@ -48,9 +50,9 @@ static std::string GetLanguageString(DiscIO::IVolume::ELanguage language,
     return it->second;
 
   // English tends to be a good fallback when the requested language isn't available
-  if (language != DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH)
+  if (language != DiscIO::Language::LANGUAGE_ENGLISH)
   {
-    it = strings.find(DiscIO::IVolume::ELanguage::LANGUAGE_ENGLISH);
+    it = strings.find(DiscIO::Language::LANGUAGE_ENGLISH);
     if (it != end)
       return it->second;
   }
@@ -65,7 +67,7 @@ static std::string GetLanguageString(DiscIO::IVolume::ELanguage language,
 GameListItem::GameListItem(const std::string& _rFileName,
                            const std::unordered_map<std::string, std::string>& custom_titles)
     : m_FileName(_rFileName), m_title_id(0), m_emu_state(0), m_FileSize(0),
-      m_Country(DiscIO::IVolume::COUNTRY_UNKNOWN), m_Revision(0), m_Valid(false), m_ImageWidth(0),
+      m_Country(DiscIO::Country::COUNTRY_UNKNOWN), m_Revision(0), m_Valid(false), m_ImageWidth(0),
       m_ImageHeight(0), m_disc_number(0), m_has_custom_name(false)
 {
   if (LoadFromCache())
@@ -96,9 +98,9 @@ GameListItem::GameListItem(const std::string& _rFileName,
       m_names = volume->GetLongNames();
       if (m_names.empty())
         m_names = volume->GetShortNames();
-      m_company = GetLanguageString(DiscIO::IVolume::LANGUAGE_ENGLISH, volume->GetLongMakers());
+      m_company = GetLanguageString(DiscIO::Language::LANGUAGE_ENGLISH, volume->GetLongMakers());
       if (m_company.empty())
-        m_company = GetLanguageString(DiscIO::IVolume::LANGUAGE_ENGLISH, volume->GetShortMakers());
+        m_company = GetLanguageString(DiscIO::Language::LANGUAGE_ENGLISH, volume->GetShortMakers());
 
       m_Country = volume->GetCountry();
       m_blob_type = volume->GetBlobType();
@@ -126,7 +128,7 @@ GameListItem::GameListItem(const std::string& _rFileName,
     std::string game_id = m_UniqueID;
 
     // Ignore publisher ID for WAD files
-    if (m_Platform == DiscIO::IVolume::WII_WAD && game_id.size() > 4)
+    if (m_Platform == DiscIO::Platform::WII_WAD && game_id.size() > 4)
       game_id.erase(4);
 
     auto it = custom_titles.find(game_id);
@@ -142,7 +144,7 @@ GameListItem::GameListItem(const std::string& _rFileName,
   {
     m_Valid = true;
     m_FileSize = File::GetSize(_rFileName);
-    m_Platform = DiscIO::IVolume::ELF_DOL;
+    m_Platform = DiscIO::Platform::ELF_DOL;
     m_blob_type = DiscIO::BlobType::DIRECTORY;
   }
 
@@ -296,18 +298,18 @@ wxBitmap GameListItem::ScaleBanner(wxImage* image)
 #endif
 }
 
-std::string GameListItem::GetDescription(DiscIO::IVolume::ELanguage language) const
+std::string GameListItem::GetDescription(DiscIO::Language language) const
 {
   return GetLanguageString(language, m_descriptions);
 }
 
 std::string GameListItem::GetDescription() const
 {
-  bool wii = m_Platform != DiscIO::IVolume::GAMECUBE_DISC;
+  bool wii = m_Platform != DiscIO::Platform::GAMECUBE_DISC;
   return GetDescription(SConfig::GetInstance().GetCurrentLanguage(wii));
 }
 
-std::string GameListItem::GetName(DiscIO::IVolume::ELanguage language) const
+std::string GameListItem::GetName(DiscIO::Language language) const
 {
   return GetLanguageString(language, m_names);
 }
@@ -317,7 +319,7 @@ std::string GameListItem::GetName() const
   if (m_has_custom_name)
     return m_custom_name;
 
-  bool wii = m_Platform != DiscIO::IVolume::GAMECUBE_DISC;
+  bool wii = m_Platform != DiscIO::Platform::GAMECUBE_DISC;
   std::string name = GetName(SConfig::GetInstance().GetCurrentLanguage(wii));
   if (!name.empty())
     return name;
@@ -328,10 +330,10 @@ std::string GameListItem::GetName() const
   return name + ext;
 }
 
-std::vector<DiscIO::IVolume::ELanguage> GameListItem::GetLanguages() const
+std::vector<DiscIO::Language> GameListItem::GetLanguages() const
 {
-  std::vector<DiscIO::IVolume::ELanguage> languages;
-  for (std::pair<DiscIO::IVolume::ELanguage, std::string> name : m_names)
+  std::vector<DiscIO::Language> languages;
+  for (std::pair<DiscIO::Language, std::string> name : m_names)
     languages.push_back(name.first);
   return languages;
 }
@@ -344,7 +346,7 @@ const std::string GameListItem::GetWiiFSPath() const
   if (iso == nullptr)
     return ret;
 
-  if (iso->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC)
+  if (iso->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC)
   {
     u64 title_id = 0;
     iso->GetTitleID(&title_id);
@@ -363,4 +365,10 @@ const std::string GameListItem::GetWiiFSPath() const
   }
 
   return ret;
+}
+
+bool GameListItem::IsCompressed() const
+{
+  return m_blob_type == DiscIO::BlobType::GCZ || m_blob_type == DiscIO::BlobType::CISO ||
+         m_blob_type == DiscIO::BlobType::WBFS;
 }

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -10,15 +10,22 @@
 #include <vector>
 
 #include "Common/Common.h"
-#include "DiscIO/Blob.h"
-#include "DiscIO/Volume.h"
 
 #if defined(HAVE_WX) && HAVE_WX
 #include <wx/bitmap.h>
 #include <wx/image.h>
 #endif
 
+namespace DiscIO
+{
+enum class BlobType;
+enum class Country;
+enum class Language;
+enum class Platform;
+}
+
 class PointerWrap;
+
 class GameListItem
 {
 public:
@@ -31,25 +38,21 @@ public:
 
   bool IsValid() const { return m_Valid; }
   const std::string& GetFileName() const { return m_FileName; }
-  std::string GetName(DiscIO::IVolume::ELanguage language) const;
+  std::string GetName(DiscIO::Language language) const;
   std::string GetName() const;
-  std::string GetDescription(DiscIO::IVolume::ELanguage language) const;
+  std::string GetDescription(DiscIO::Language language) const;
   std::string GetDescription() const;
-  std::vector<DiscIO::IVolume::ELanguage> GetLanguages() const;
+  std::vector<DiscIO::Language> GetLanguages() const;
   std::string GetCompany() const { return m_company; }
   u16 GetRevision() const { return m_Revision; }
   const std::string& GetUniqueID() const { return m_UniqueID; }
   const std::string GetWiiFSPath() const;
-  DiscIO::IVolume::ECountry GetCountry() const { return m_Country; }
-  DiscIO::IVolume::EPlatform GetPlatform() const { return m_Platform; }
+  DiscIO::Country GetCountry() const { return m_Country; }
+  DiscIO::Platform GetPlatform() const { return m_Platform; }
   DiscIO::BlobType GetBlobType() const { return m_blob_type; }
   const std::string& GetIssues() const { return m_issues; }
   int GetEmuState() const { return m_emu_state; }
-  bool IsCompressed() const
-  {
-    return m_blob_type == DiscIO::BlobType::GCZ || m_blob_type == DiscIO::BlobType::CISO ||
-           m_blob_type == DiscIO::BlobType::WBFS;
-  }
+  bool IsCompressed() const;
   u64 GetFileSize() const { return m_FileSize; }
   u64 GetVolumeSize() const { return m_VolumeSize; }
   // 0 is the first disc, 1 is the second disc
@@ -63,8 +66,8 @@ public:
 private:
   std::string m_FileName;
 
-  std::map<DiscIO::IVolume::ELanguage, std::string> m_names;
-  std::map<DiscIO::IVolume::ELanguage, std::string> m_descriptions;
+  std::map<DiscIO::Language, std::string> m_names;
+  std::map<DiscIO::Language, std::string> m_descriptions;
   std::string m_company;
 
   std::string m_UniqueID;
@@ -76,8 +79,8 @@ private:
   u64 m_FileSize;
   u64 m_VolumeSize;
 
-  DiscIO::IVolume::ECountry m_Country;
-  DiscIO::IVolume::EPlatform m_Platform;
+  DiscIO::Country m_Country;
+  DiscIO::Platform m_Platform;
   DiscIO::BlobType m_blob_type;
   u16 m_Revision;
 

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -59,6 +59,7 @@
 #include "Core/GeckoCodeConfig.h"
 #include "Core/PatchEngine.h"
 #include "DiscIO/Blob.h"
+#include "DiscIO/Enums.h"
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
@@ -123,46 +124,46 @@ CISOProperties::CISOProperties(const GameListItem& game_list_item, wxWindow* par
   m_GameID->SetValue(StrToWxStr(m_open_iso->GetUniqueID()));
   switch (m_open_iso->GetCountry())
   {
-  case DiscIO::IVolume::COUNTRY_AUSTRALIA:
+  case DiscIO::Country::COUNTRY_AUSTRALIA:
     m_Country->SetValue(_("Australia"));
     break;
-  case DiscIO::IVolume::COUNTRY_EUROPE:
+  case DiscIO::Country::COUNTRY_EUROPE:
     m_Country->SetValue(_("Europe"));
     break;
-  case DiscIO::IVolume::COUNTRY_FRANCE:
+  case DiscIO::Country::COUNTRY_FRANCE:
     m_Country->SetValue(_("France"));
     break;
-  case DiscIO::IVolume::COUNTRY_ITALY:
+  case DiscIO::Country::COUNTRY_ITALY:
     m_Country->SetValue(_("Italy"));
     break;
-  case DiscIO::IVolume::COUNTRY_GERMANY:
+  case DiscIO::Country::COUNTRY_GERMANY:
     m_Country->SetValue(_("Germany"));
     break;
-  case DiscIO::IVolume::COUNTRY_NETHERLANDS:
+  case DiscIO::Country::COUNTRY_NETHERLANDS:
     m_Country->SetValue(_("Netherlands"));
     break;
-  case DiscIO::IVolume::COUNTRY_RUSSIA:
+  case DiscIO::Country::COUNTRY_RUSSIA:
     m_Country->SetValue(_("Russia"));
     break;
-  case DiscIO::IVolume::COUNTRY_SPAIN:
+  case DiscIO::Country::COUNTRY_SPAIN:
     m_Country->SetValue(_("Spain"));
     break;
-  case DiscIO::IVolume::COUNTRY_USA:
+  case DiscIO::Country::COUNTRY_USA:
     m_Country->SetValue(_("USA"));
     break;
-  case DiscIO::IVolume::COUNTRY_JAPAN:
+  case DiscIO::Country::COUNTRY_JAPAN:
     m_Country->SetValue(_("Japan"));
     break;
-  case DiscIO::IVolume::COUNTRY_KOREA:
+  case DiscIO::Country::COUNTRY_KOREA:
     m_Country->SetValue(_("Korea"));
     break;
-  case DiscIO::IVolume::COUNTRY_TAIWAN:
+  case DiscIO::Country::COUNTRY_TAIWAN:
     m_Country->SetValue(_("Taiwan"));
     break;
-  case DiscIO::IVolume::COUNTRY_WORLD:
+  case DiscIO::Country::COUNTRY_WORLD:
     m_Country->SetValue(_("World"));
     break;
-  case DiscIO::IVolume::COUNTRY_UNKNOWN:
+  case DiscIO::Country::COUNTRY_UNKNOWN:
   default:
     m_Country->SetValue(_("Unknown"));
     break;
@@ -175,7 +176,7 @@ CISOProperties::CISOProperties(const GameListItem& game_list_item, wxWindow* par
   m_FST->SetValue(StrToWxStr(std::to_string(m_open_iso->GetFSTSize())));
 
   // Here we set all the info to be shown + we set the window title
-  bool wii = m_open_iso->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;
+  bool wii = m_open_iso->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC;
   ChangeBannerDetails(SConfig::GetInstance().GetCurrentLanguage(wii));
 
   m_Banner->SetBitmap(OpenGameListItem.GetBitmap());
@@ -183,9 +184,9 @@ CISOProperties::CISOProperties(const GameListItem& game_list_item, wxWindow* par
 
   // Filesystem browser/dumper
   // TODO : Should we add a way to browse the wad file ?
-  if (m_open_iso->GetVolumeType() != DiscIO::IVolume::WII_WAD)
+  if (m_open_iso->GetVolumeType() != DiscIO::Platform::WII_WAD)
   {
-    if (m_open_iso->GetVolumeType() == DiscIO::IVolume::WII_DISC)
+    if (m_open_iso->GetVolumeType() == DiscIO::Platform::WII_DISC)
     {
       int partition_count = 0;
       for (int group = 0; group < 4; group++)
@@ -426,7 +427,7 @@ void CISOProperties::CreateGUIControls()
 
   wxStaticBoxSizer* const sbWiiOverrides =
       new wxStaticBoxSizer(wxVERTICAL, m_GameConfig, _("Wii Console"));
-  if (m_open_iso->GetVolumeType() == DiscIO::IVolume::GAMECUBE_DISC)
+  if (m_open_iso->GetVolumeType() == DiscIO::Platform::GAMECUBE_DISC)
   {
     sbWiiOverrides->ShowItems(false);
     EnableWideScreen->Hide();
@@ -523,10 +524,10 @@ void CISOProperties::CreateGUIControls()
 
   wxStaticText* const m_LangText = new wxStaticText(m_Information, wxID_ANY, _("Show Language:"));
 
-  bool wii = m_open_iso->GetVolumeType() != DiscIO::IVolume::GAMECUBE_DISC;
-  DiscIO::IVolume::ELanguage preferred_language = SConfig::GetInstance().GetCurrentLanguage(wii);
+  bool wii = m_open_iso->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC;
+  DiscIO::Language preferred_language = SConfig::GetInstance().GetCurrentLanguage(wii);
 
-  std::vector<DiscIO::IVolume::ELanguage> languages = OpenGameListItem.GetLanguages();
+  std::vector<DiscIO::Language> languages = OpenGameListItem.GetLanguages();
   int preferred_language_index = 0;
   for (size_t i = 0; i < languages.size(); ++i)
   {
@@ -535,37 +536,37 @@ void CISOProperties::CreateGUIControls()
 
     switch (languages[i])
     {
-    case DiscIO::IVolume::LANGUAGE_JAPANESE:
+    case DiscIO::Language::LANGUAGE_JAPANESE:
       arrayStringFor_Lang.Add(_("Japanese"));
       break;
-    case DiscIO::IVolume::LANGUAGE_ENGLISH:
+    case DiscIO::Language::LANGUAGE_ENGLISH:
       arrayStringFor_Lang.Add(_("English"));
       break;
-    case DiscIO::IVolume::LANGUAGE_GERMAN:
+    case DiscIO::Language::LANGUAGE_GERMAN:
       arrayStringFor_Lang.Add(_("German"));
       break;
-    case DiscIO::IVolume::LANGUAGE_FRENCH:
+    case DiscIO::Language::LANGUAGE_FRENCH:
       arrayStringFor_Lang.Add(_("French"));
       break;
-    case DiscIO::IVolume::LANGUAGE_SPANISH:
+    case DiscIO::Language::LANGUAGE_SPANISH:
       arrayStringFor_Lang.Add(_("Spanish"));
       break;
-    case DiscIO::IVolume::LANGUAGE_ITALIAN:
+    case DiscIO::Language::LANGUAGE_ITALIAN:
       arrayStringFor_Lang.Add(_("Italian"));
       break;
-    case DiscIO::IVolume::LANGUAGE_DUTCH:
+    case DiscIO::Language::LANGUAGE_DUTCH:
       arrayStringFor_Lang.Add(_("Dutch"));
       break;
-    case DiscIO::IVolume::LANGUAGE_SIMPLIFIED_CHINESE:
+    case DiscIO::Language::LANGUAGE_SIMPLIFIED_CHINESE:
       arrayStringFor_Lang.Add(_("Simplified Chinese"));
       break;
-    case DiscIO::IVolume::LANGUAGE_TRADITIONAL_CHINESE:
+    case DiscIO::Language::LANGUAGE_TRADITIONAL_CHINESE:
       arrayStringFor_Lang.Add(_("Traditional Chinese"));
       break;
-    case DiscIO::IVolume::LANGUAGE_KOREAN:
+    case DiscIO::Language::LANGUAGE_KOREAN:
       arrayStringFor_Lang.Add(_("Korean"));
       break;
-    case DiscIO::IVolume::LANGUAGE_UNKNOWN:
+    case DiscIO::Language::LANGUAGE_UNKNOWN:
     default:
       arrayStringFor_Lang.Add(_("Unknown"));
       break;
@@ -650,7 +651,7 @@ void CISOProperties::CreateGUIControls()
   sInfoPage->Add(sbBannerDetails, 0, wxEXPAND | wxALL, 5);
   m_Information->SetSizer(sInfoPage);
 
-  if (m_open_iso->GetVolumeType() != DiscIO::IVolume::WII_WAD)
+  if (m_open_iso->GetVolumeType() != DiscIO::Platform::WII_WAD)
   {
     wxPanel* const filesystem_panel = new wxPanel(m_Notebook, ID_FILESYSTEM);
     m_Notebook->AddPage(filesystem_panel, _("Filesystem"));
@@ -758,7 +759,7 @@ void CISOProperties::OnRightClickOnTree(wxTreeEvent& event)
 
   popupMenu.Append(IDM_EXTRACTALL, _("Extract All Files..."));
 
-  if (m_open_iso->GetVolumeType() != DiscIO::IVolume::WII_DISC ||
+  if (m_open_iso->GetVolumeType() != DiscIO::Platform::WII_DISC ||
       (m_Treectrl->GetItemImage(m_Treectrl->GetSelection()) == 0 &&
        m_Treectrl->GetFirstVisibleItem() != m_Treectrl->GetSelection()))
   {
@@ -797,7 +798,7 @@ void CISOProperties::OnExtractFile(wxCommandEvent& WXUNUSED(event))
     m_Treectrl->SelectItem(m_Treectrl->GetItemParent(m_Treectrl->GetSelection()));
   }
 
-  if (m_open_iso->GetVolumeType() == DiscIO::IVolume::WII_DISC)
+  if (m_open_iso->GetVolumeType() == DiscIO::Platform::WII_DISC)
   {
     const wxTreeItemId tree_selection = m_Treectrl->GetSelection();
     WiiPartition* partition =
@@ -815,9 +816,8 @@ void CISOProperties::OnExtractFile(wxCommandEvent& WXUNUSED(event))
 void CISOProperties::ExportDir(const std::string& _rFullPath, const std::string& _rExportFolder,
                                const WiiPartition* partition)
 {
-  DiscIO::IFileSystem* const fs = m_open_iso->GetVolumeType() == DiscIO::IVolume::WII_DISC ?
-                                      partition->FileSystem.get() :
-                                      m_filesystem.get();
+  bool is_wii = m_open_iso->GetVolumeType() == DiscIO::Platform::WII_DISC;
+  DiscIO::IFileSystem* const fs = is_wii ? partition->FileSystem.get() : m_filesystem.get();
 
   const std::vector<DiscIO::SFileInfo>& fst = fs->GetFileList();
 
@@ -831,7 +831,7 @@ void CISOProperties::ExportDir(const std::string& _rFullPath, const std::string&
     size = (u32)fst.size();
 
     fs->ExportApploader(_rExportFolder);
-    if (m_open_iso->GetVolumeType() != DiscIO::IVolume::WII_DISC)
+    if (m_open_iso->GetVolumeType() != DiscIO::Platform::WII_DISC)
       fs->ExportDOL(_rExportFolder);
   }
   else
@@ -913,7 +913,7 @@ void CISOProperties::OnExtractDir(wxCommandEvent& event)
 
   if (event.GetId() == IDM_EXTRACTALL)
   {
-    if (m_open_iso->GetVolumeType() == DiscIO::IVolume::WII_DISC)
+    if (m_open_iso->GetVolumeType() == DiscIO::Platform::WII_DISC)
     {
       wxTreeItemIdValue cookie;
       wxTreeItemId root = m_Treectrl->GetRootItem();
@@ -943,7 +943,7 @@ void CISOProperties::OnExtractDir(wxCommandEvent& event)
 
   Directory += DIR_SEP_CHR;
 
-  if (m_open_iso->GetVolumeType() == DiscIO::IVolume::WII_DISC)
+  if (m_open_iso->GetVolumeType() == DiscIO::Platform::WII_DISC)
   {
     const wxTreeItemId tree_selection = m_Treectrl->GetSelection();
     WiiPartition* partition =
@@ -967,7 +967,7 @@ void CISOProperties::OnExtractDataFromHeader(wxCommandEvent& event)
   if (Path.empty())
     return;
 
-  if (m_open_iso->GetVolumeType() == DiscIO::IVolume::WII_DISC)
+  if (m_open_iso->GetVolumeType() == DiscIO::Platform::WII_DISC)
   {
     WiiPartition* partition =
         reinterpret_cast<WiiPartition*>(m_Treectrl->GetItemData(m_Treectrl->GetSelection()));
@@ -1011,7 +1011,7 @@ void CISOProperties::CheckPartitionIntegrity(wxCommandEvent& event)
 {
   // Normally we can't enter this function if we aren't analyzing a Wii disc
   // anyway, but let's still check to be sure.
-  if (m_open_iso->GetVolumeType() != DiscIO::IVolume::WII_DISC)
+  if (m_open_iso->GetVolumeType() != DiscIO::Platform::WII_DISC)
     return;
 
   wxProgressDialog dialog(_("Checking integrity..."), _("Working..."), 1000, this,
@@ -1546,7 +1546,7 @@ void CISOProperties::OnChangeBannerLang(wxCommandEvent& event)
   ChangeBannerDetails(OpenGameListItem.GetLanguages()[event.GetSelection()]);
 }
 
-void CISOProperties::ChangeBannerDetails(DiscIO::IVolume::ELanguage language)
+void CISOProperties::ChangeBannerDetails(DiscIO::Language language)
 {
   wxString const name = StrToWxStr(OpenGameListItem.GetName(language));
   wxString const comment = StrToWxStr(OpenGameListItem.GetDescription(language));

--- a/Source/Core/DolphinWX/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties.h
@@ -17,7 +17,6 @@
 #include "Core/ActionReplay.h"
 #include "DiscIO/Filesystem.h"
 #include "DiscIO/Volume.h"
-#include "DiscIO/VolumeCreator.h"
 #include "DolphinWX/ARCodeAddEdit.h"
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/PatchAddEdit.h"
@@ -35,7 +34,7 @@ class wxTreeCtrl;
 
 namespace DiscIO
 {
-struct SFileInfo;
+enum class Language;
 }
 namespace Gecko
 {
@@ -242,7 +241,7 @@ private:
   void PatchList_Save();
   void ActionReplayList_Load();
   void ActionReplayList_Save();
-  void ChangeBannerDetails(DiscIO::IVolume::ELanguage language);
+  void ChangeBannerDetails(DiscIO::Language language);
 
   long GetElementStyle(const char* section, const char* key);
   void SetCheckboxValueFromGameini(const char* section, const char* key, wxCheckBox* checkbox);

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -34,6 +34,8 @@
 #include "Core/NetPlayProto.h"
 #include "Core/NetPlayServer.h"
 
+#include "DiscIO/Enums.h"
+
 #include "DolphinWX/Frame.h"
 #include "DolphinWX/GameListCtrl.h"
 #include "DolphinWX/ISOFile.h"
@@ -69,7 +71,7 @@ static wxString FailureReasonStringForHostLabel(int reason)
 static std::string BuildGameName(const GameListItem& game)
 {
   // Lang needs to be consistent
-  DiscIO::IVolume::ELanguage const lang = DiscIO::IVolume::LANGUAGE_ENGLISH;
+  const DiscIO::Language lang = DiscIO::Language::LANGUAGE_ENGLISH;
   std::vector<std::string> info;
   if (!game.GetUniqueID().empty())
     info.push_back(game.GetUniqueID());


### PR DESCRIPTION
At first there weren't many enums in Volume.h, but the number has been growing, and I'm planning to add one more for regions. To not make Volume.h too large, and to avoid needing to include Volume.h in code that doesn't use volume objects, I'm moving the enums to a new file. I'm also turning them into enum classes while I'm at it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3983)
<!-- Reviewable:end -->
