### PR TITLE
Usable mouse-controlled emulated IR pointer under Linux

### DIFF
--- a/Data/Sys/GameSettings/RM3.ini
+++ b/Data/Sys/GameSettings/RM3.ini
@@ -22,3 +22,4 @@ SafeTextureCacheColorSamples = 512
 
 [Video_Hacks]
 EFBToTextureEnable = False
+MiddleSensorBar = True

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -23,6 +23,7 @@
 #include "Core/Host.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayClient.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace
 {
@@ -467,11 +468,23 @@ void Wiimote::GetIRData(u8* const data, bool use_accel)
 
   for (auto& vtx : v)
   {
-    vtx.x = xx * (bndright - bndleft) / 2 + (bndleft + bndright) / 2;
-    if (m_sensor_bar_on_top)
-      vtx.y = yy * (bndup - bnddown) / 2 + (bndup + bnddown) / 2;
+    if(!g_ActiveConfig.bMiddleSensorBar)
+    {
+      vtx.x = xx * (bndright - bndleft) / 2 + (bndleft + bndright) / 2;
+	  if(m_sensor_bar_on_top)
+	  {
+	    vtx.y = yy * (bndup - bnddown) / 2 + (bndup + bnddown) / 2;
+	  }
+	  else
+      {
+	    vtx.y = yy * (bndup - bnddown) / 2 - (bndup + bnddown) / 2;
+	  }
+    }
     else
-      vtx.y = yy * (bndup - bnddown) / 2 - (bndup + bnddown) / 2;
+    {
+	  vtx.x = -xx * 0.55;
+	  vtx.y = -yy * bnddown;
+    }
     vtx.z = 0;
   }
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -468,22 +468,22 @@ void Wiimote::GetIRData(u8* const data, bool use_accel)
 
   for (auto& vtx : v)
   {
-    if(!g_ActiveConfig.bMiddleSensorBar)
+    if (!g_ActiveConfig.bMiddleSensorBar)
     {
       vtx.x = xx * (bndright - bndleft) / 2 + (bndleft + bndright) / 2;
-	  if(m_sensor_bar_on_top)
-	  {
-	    vtx.y = yy * (bndup - bnddown) / 2 + (bndup + bnddown) / 2;
-	  }
-	  else
+      if (m_sensor_bar_on_top)
       {
-	    vtx.y = yy * (bndup - bnddown) / 2 - (bndup + bnddown) / 2;
-	  }
+        vtx.y = yy * (bndup - bnddown) / 2 + (bndup + bnddown) / 2;
+      }
+      else
+      {
+        vtx.y = yy * (bndup - bnddown) / 2 - (bndup + bnddown) / 2;
+      }
     }
     else
     {
-	  vtx.x = -xx * 0.55;
-	  vtx.y = -yy * bnddown;
+      vtx.x = -xx * 0.55;
+      vtx.y = -yy * bnddown;
     }
     vtx.z = 0;
   }

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/Xlib.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/Xlib.cpp
@@ -7,8 +7,8 @@
 #include <cstring>
 
 #include "Core/ConfigManager.h"
-#include "VideoCommon/VideoConfig.h"
 #include "InputCommon/ControllerInterface/Xlib/Xlib.h"
+#include "VideoCommon/VideoConfig.h"
 
 namespace ciface
 {
@@ -67,78 +67,80 @@ void KeyboardMouse::UpdateInput()
   // update mouse cursor
   XWindowAttributes win_attribs;
   XGetWindowAttributes(m_display, m_window, &win_attribs);
-  
+
   // the mouse position as a range from -1 to 1
-  static const int& root_xpos    = SConfig::GetInstance().iPosX;
-  static const int& root_ypos    = SConfig::GetInstance().iPosY;
-  static const int& root_width   = SConfig::GetInstance().iWidth;
-  static const int& root_height  = SConfig::GetInstance().iHeight;
-  
-  static const int& child_xpos   = SConfig::GetInstance().iRenderWindowXPos;
-  static const int& child_ypos   = SConfig::GetInstance().iRenderWindowYPos;
-  static const int& child_width  = SConfig::GetInstance().iRenderWindowWidth;
+  static const int& root_xpos = SConfig::GetInstance().iPosX;
+  static const int& root_ypos = SConfig::GetInstance().iPosY;
+  static const int& root_width = SConfig::GetInstance().iWidth;
+  static const int& root_height = SConfig::GetInstance().iHeight;
+
+  static const int& child_xpos = SConfig::GetInstance().iRenderWindowXPos;
+  static const int& child_ypos = SConfig::GetInstance().iRenderWindowYPos;
+  static const int& child_width = SConfig::GetInstance().iRenderWindowWidth;
   static const int& child_height = SConfig::GetInstance().iRenderWindowHeight;
-  
+
   static const bool& isfullscreen = !SConfig::GetInstance().bFullscreen;
   static const bool& rendertomain = !SConfig::GetInstance().bRenderToMain;
-  
-  static const int screen_number    = XScreenNumberOfScreen(win_attribs.screen);
-  static const int m_display_width  = XDisplayWidth(m_display,screen_number);
-  static const int m_display_height = XDisplayHeight(m_display,screen_number);
-  
-  static const double aspect = ASPECT_AUTO==2 ? 4.0/3.0: 16.0/9.0;
-  
-  double x_margin   = 0,   y_margin   = 0;
-  
-  int    x_offset   = 0,   y_offset   = 0,
-         x_offset2  = 0,   y_offset2  = 0,
-         win_width  = 640, win_height = 528,
-         suboffset1 = 0,   suboffset2 = 0;
-  
-  if(isfullscreen)
+
+  static const int screen_number = XScreenNumberOfScreen(win_attribs.screen);
+  static const int m_display_width = XDisplayWidth(m_display, screen_number);
+  static const int m_display_height = XDisplayHeight(m_display, screen_number);
+
+  static const double aspect = ASPECT_AUTO == 2 ? 4.0 / 3.0 : 16.0 / 9.0;
+
+  double x_margin = 0, y_margin = 0;
+
+  int x_offset = 0, y_offset = 0, x_offset2 = 0, y_offset2 = 0, win_width = 640, win_height = 528,
+      suboffset1 = 0, suboffset2 = 0;
+
+  if (isfullscreen)
   {
-    if(rendertomain)
+    if (rendertomain)
     {
-	  win_height = child_height;
-	  win_width  = child_width;
-      x_offset   = root_xpos-child_xpos + 6;
-      y_offset   = root_ypos-child_ypos - 5;
-      x_offset2  = 11;
-      y_offset2  = 10;
+      win_height = child_height;
+      win_width = child_width;
+      x_offset = root_xpos - child_xpos + 6;
+      y_offset = root_ypos - child_ypos - 5;
+      x_offset2 = 11;
+      y_offset2 = 10;
     }
-	else
-	{
+    else
+    {
       suboffset1 = 95;
       suboffset2 = 20;
-	  win_height = root_height - suboffset1 - suboffset2;
-	  win_width  = root_width;
-      x_offset   = -3;
-      y_offset   =  8;
-      x_offset2  = -18;
-      y_offset2  =  19;
+      win_height = root_height - suboffset1 - suboffset2;
+      win_width = root_width;
+      x_offset = -3;
+      y_offset = 8;
+      x_offset2 = -18;
+      y_offset2 = 19;
     }
   }
   else
   {
-	win_height = m_display_height;
-	win_width  = m_display_width;
-    x_offset   = root_xpos + 11;
-    y_offset   = root_ypos -  5;
-    x_offset2  = 11;
-    y_offset2  = 10;
+    win_height = m_display_height;
+    win_width = m_display_width;
+    x_offset = root_xpos + 11;
+    y_offset = root_ypos - 5;
+    x_offset2 = 11;
+    y_offset2 = 10;
   }
-  
-  if(win_width/win_height > aspect)
+
+  if (win_width / win_height > aspect)
   {
-    x_margin = win_width  - win_height*aspect;
+    x_margin = win_width - win_height * aspect;
   }
-  else if(win_width/win_height < aspect)
+  else if (win_width / win_height < aspect)
   {
-    y_margin = win_height - win_width/aspect;
+    y_margin = win_height - win_width / aspect;
   }
-  
-  m_state.cursor.x = (float)(win_x + x_offset              - x_margin/2.0) / (float)(win_width  - x_margin + x_offset2) * 2 - 1;
-  m_state.cursor.y = (float)(win_y + y_offset - suboffset1 - y_margin/2.0) / (float)(win_height - y_margin - y_offset2) * 2 - 1;
+
+  m_state.cursor.x =
+      (float)(win_x + x_offset - x_margin / 2.0) / (float)(win_width - x_margin + x_offset2) * 2 -
+      1;
+  m_state.cursor.y = (float)(win_y + y_offset - suboffset1 - y_margin / 2.0) /
+                         (float)(win_height - y_margin - y_offset2) * 2 -
+                     1;
 }
 
 std::string KeyboardMouse::GetName() const

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/Xlib.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/Xlib.cpp
@@ -3,8 +3,11 @@
 // Refer to the license.txt file included.
 
 #include <X11/XKBlib.h>
+#include <X11/Xlib.h>
 #include <cstring>
 
+#include "Core/ConfigManager.h"
+#include "VideoCommon/VideoConfig.h"
 #include "InputCommon/ControllerInterface/Xlib/Xlib.h"
 
 namespace ciface
@@ -64,10 +67,78 @@ void KeyboardMouse::UpdateInput()
   // update mouse cursor
   XWindowAttributes win_attribs;
   XGetWindowAttributes(m_display, m_window, &win_attribs);
-
+  
   // the mouse position as a range from -1 to 1
-  m_state.cursor.x = (float)win_x / (float)win_attribs.width * 2 - 1;
-  m_state.cursor.y = (float)win_y / (float)win_attribs.height * 2 - 1;
+  static const int& root_xpos    = SConfig::GetInstance().iPosX;
+  static const int& root_ypos    = SConfig::GetInstance().iPosY;
+  static const int& root_width   = SConfig::GetInstance().iWidth;
+  static const int& root_height  = SConfig::GetInstance().iHeight;
+  
+  static const int& child_xpos   = SConfig::GetInstance().iRenderWindowXPos;
+  static const int& child_ypos   = SConfig::GetInstance().iRenderWindowYPos;
+  static const int& child_width  = SConfig::GetInstance().iRenderWindowWidth;
+  static const int& child_height = SConfig::GetInstance().iRenderWindowHeight;
+  
+  static const bool& isfullscreen = !SConfig::GetInstance().bFullscreen;
+  static const bool& rendertomain = !SConfig::GetInstance().bRenderToMain;
+  
+  static const int screen_number    = XScreenNumberOfScreen(win_attribs.screen);
+  static const int m_display_width  = XDisplayWidth(m_display,screen_number);
+  static const int m_display_height = XDisplayHeight(m_display,screen_number);
+  
+  static const double aspect = ASPECT_AUTO==2 ? 4.0/3.0: 16.0/9.0;
+  
+  double x_margin   = 0,   y_margin   = 0;
+  
+  int    x_offset   = 0,   y_offset   = 0,
+         x_offset2  = 0,   y_offset2  = 0,
+         win_width  = 640, win_height = 528,
+         suboffset1 = 0,   suboffset2 = 0;
+  
+  if(isfullscreen)
+  {
+    if(rendertomain)
+    {
+	  win_height = child_height;
+	  win_width  = child_width;
+      x_offset   = root_xpos-child_xpos + 6;
+      y_offset   = root_ypos-child_ypos - 5;
+      x_offset2  = 11;
+      y_offset2  = 10;
+    }
+	else
+	{
+      suboffset1 = 95;
+      suboffset2 = 20;
+	  win_height = root_height - suboffset1 - suboffset2;
+	  win_width  = root_width;
+      x_offset   = -3;
+      y_offset   =  8;
+      x_offset2  = -18;
+      y_offset2  =  19;
+    }
+  }
+  else
+  {
+	win_height = m_display_height;
+	win_width  = m_display_width;
+    x_offset   = root_xpos + 11;
+    y_offset   = root_ypos -  5;
+    x_offset2  = 11;
+    y_offset2  = 10;
+  }
+  
+  if(win_width/win_height > aspect)
+  {
+    x_margin = win_width  - win_height*aspect;
+  }
+  else if(win_width/win_height < aspect)
+  {
+    y_margin = win_height - win_width/aspect;
+  }
+  
+  m_state.cursor.x = (float)(win_x + x_offset              - x_margin/2.0) / (float)(win_width  - x_margin + x_offset2) * 2 - 1;
+  m_state.cursor.y = (float)(win_y + y_offset - suboffset1 - y_margin/2.0) / (float)(win_height - y_margin - y_offset2) * 2 - 1;
 }
 
 std::string KeyboardMouse::GetName() const

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -316,7 +316,6 @@ void VideoConfig::Save(const std::string& ini_file)
   hacks->Set("EFBToTextureEnable", bSkipEFBCopyToRam);
   hacks->Set("EFBScaledCopy", bCopyEFBScaled);
   hacks->Set("EFBEmulateFormatChanges", bEFBEmulateFormatChanges);
-  hacks->Set("MiddleSensorBar", bMiddleSensorBar);
 
   iniFile.Save(ini_file);
 }

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -107,6 +107,7 @@ void VideoConfig::Load(const std::string& ini_file)
   hacks->Get("EFBToTextureEnable", &bSkipEFBCopyToRam, true);
   hacks->Get("EFBScaledCopy", &bCopyEFBScaled, true);
   hacks->Get("EFBEmulateFormatChanges", &bEFBEmulateFormatChanges, false);
+  hacks->Get("MiddleSensorBar", &bMiddleSensorBar, false);
 
   // hacks which are disabled by default
   iPhackvalue[0] = 0;
@@ -207,6 +208,7 @@ void VideoConfig::GameIniLoad()
   CHECK_SETTING("Video_Hacks", "EFBToTextureEnable", bSkipEFBCopyToRam);
   CHECK_SETTING("Video_Hacks", "EFBScaledCopy", bCopyEFBScaled);
   CHECK_SETTING("Video_Hacks", "EFBEmulateFormatChanges", bEFBEmulateFormatChanges);
+  iniFile.GetIfExists("Video_Hacks", "MiddleSensorBar", &bMiddleSensorBar, false);
 
   CHECK_SETTING("Video", "ProjectionHack", iPhackvalue[0]);
   CHECK_SETTING("Video", "PH_SZNear", iPhackvalue[1]);
@@ -314,6 +316,7 @@ void VideoConfig::Save(const std::string& ini_file)
   hacks->Set("EFBToTextureEnable", bSkipEFBCopyToRam);
   hacks->Set("EFBScaledCopy", bCopyEFBScaled);
   hacks->Set("EFBEmulateFormatChanges", bEFBEmulateFormatChanges);
+  hacks->Set("MiddleSensorBar", bMiddleSensorBar);
 
   iniFile.Save(ini_file);
 }

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -107,6 +107,7 @@ struct VideoConfig final
   bool bPerfQueriesEnable;
   bool bBBoxEnable;
   bool bForceProgressive;
+  bool bMiddleSensorBar;
 
   bool bEFBEmulateFormatChanges;
   bool bSkipEFBCopyToRam;


### PR DESCRIPTION
As I'm a total noob, I may not have done things the right way.
- Adds window-relative cursor position under linux
- Should work with any window proportions 
  (the black bars' size is determined using the window size and the current emulated aspect ratio)

And here comes the funny part : this is sometimes not enough. At least one game (MP3:Corruption)
Doesn't even care wether the sensor bar is placed above or under the screen.

Instead of applying the usual compensations on the received IR coordinates
it considers the sensor bar to be right in the middle of the screen and applies nothing,
which of course causes issues for the emulated IR that anticipate this compensation
using the sensor bar position given in the parameters. 

I added a configuration field in "video hacks" that can't be defined by user and is false by default
(I took example on the stereoscopy parameters), denoting the sensor bar to be in the 'middle'.
This parameter should be set to "True" in the "game.ini" if needed for correct emulation. 

That's a first try, I hope it's useful and not too stupid.

before relative cursor-position (not even close) :
![dem1](https://cloud.githubusercontent.com/assets/5473047/16635569/4de9d404-43d3-11e6-9944-e990c7d951b1.png)

after :
![dem2](https://cloud.githubusercontent.com/assets/5473047/16635603/6fb2c7d0-43d3-11e6-99a7-6f26c1d2c603.png)

before middle-screen sensor bar feature :
![dem3](https://cloud.githubusercontent.com/assets/5473047/16635723/e8d9d108-43d3-11e6-94b1-a5dbd21fae62.png)

after :
![dem4](https://cloud.githubusercontent.com/assets/5473047/16635732/f519f754-43d3-11e6-912b-6a5912241a97.png)

*Untested under Windows and OSX*
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3984)
<!-- Reviewable:end -->
