### PR TITLE
Prevent windows from idling while playing a game with a gc controller

### DIFF
--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -198,8 +198,14 @@ bool MainWindow::Stop()
   }
 
   if (stop)
+  {
     ForceStop();
 
+#ifdef Q_OS_WIN
+    // Allow windows to idle or turn off display again
+    SetThreadExecutionState(ES_CONTINUOUS);
+#endif
+  }
   return stop;
 }
 
@@ -258,6 +264,13 @@ void MainWindow::StartGame(const QString& path)
   Settings().SetLastGame(path);
   ShowRenderWidget();
   emit EmulationStarted();
+
+#ifdef Q_OS_WIN
+  // Prevents Windows from sleeping, turning off the display, or idling
+  EXECUTION_STATE shouldScreenSave =
+      SConfig::GetInstance().bDisableScreenSaver ? ES_DISPLAY_REQUIRED : 0;
+  SetThreadExecutionState(ES_CONTINUOUS | shouldScreenSave | ES_SYSTEM_REQUIRED);
+#endif
 }
 
 void MainWindow::ShowRenderWidget()

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1034,6 +1034,13 @@ void CFrame::StartGame(const std::string& filename)
                                    X11Utils::XWindowFromHandle(GetHandle()), true);
 #endif
 
+#ifdef _WIN32
+    // Prevents Windows from sleeping, turning off the display, or idling
+    EXECUTION_STATE shouldScreenSave =
+        SConfig::GetInstance().bDisableScreenSaver ? ES_DISPLAY_REQUIRED : 0;
+    SetThreadExecutionState(ES_CONTINUOUS | shouldScreenSave | ES_SYSTEM_REQUIRED);
+#endif
+
     m_RenderParent->SetFocus();
 
     wxTheApp->Bind(wxEVT_KEY_DOWN, &CFrame::OnKeyDown, this);
@@ -1181,6 +1188,12 @@ void CFrame::OnStopped()
     X11Utils::InhibitScreensaver(X11Utils::XDisplayFromHandle(GetHandle()),
                                  X11Utils::XWindowFromHandle(GetHandle()), false);
 #endif
+
+#ifdef _WIN32
+  // Allow windows to resume normal idling behavior
+  SetThreadExecutionState(ES_CONTINUOUS);
+#endif
+
   m_RenderFrame->SetTitle(StrToWxStr(scm_rev_str));
 
   // Destroy the renderer frame when not rendering to main


### PR DESCRIPTION
I don't have a build environment to test this and the setup for VS2015 gives me errors so if someone could take this over, I'd appreciate it. This is basically https://github.com/dolphin-emu/dolphin/pull/3008 which got lost in the move to qt2, except I added a flag that prevents windows from idling. Basically, if there are no keyboard or mouse inputs for a certain amount of time, windows will enter an idle state and start running background processes which make dolphin lag pretty bad. Hopefully this code will fix this issue: https://bugs.dolphin-emu.org/issues/9655

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3985)
<!-- Reviewable:end -->
