### PR TITLE
WiimoteReal: Don't block on refresh

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -533,7 +533,9 @@ void EmuThread()
   if (core_parameter.bWii)
   {
     if (init_controllers)
-      Wiimote::Initialize(s_window_handle, !s_state_filename.empty());
+      Wiimote::Initialize(s_window_handle, !s_state_filename.empty() ?
+                                               Wiimote::InitializeMode::DO_WAIT_FOR_WIIMOTES :
+                                               Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
     else
       Wiimote::LoadConfig();
 

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -28,7 +28,7 @@ void Shutdown()
   g_controller_interface.Shutdown();
 }
 
-void Initialize(void* const hwnd, bool wait)
+void Initialize(void* const hwnd, InitializeMode init_mode)
 {
   if (s_config.ControllersNeedToBeCreated())
   {
@@ -40,7 +40,7 @@ void Initialize(void* const hwnd, bool wait)
 
   s_config.LoadConfig(false);
 
-  WiimoteReal::Initialize(wait);
+  WiimoteReal::Initialize(init_mode);
 
   // Reload Wiimotes with our settings
   if (Movie::IsMovieActive())

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -35,8 +35,14 @@ extern unsigned int g_wiimote_sources[MAX_BBMOTES];
 
 namespace Wiimote
 {
+enum class InitializeMode
+{
+  DO_WAIT_FOR_WIIMOTES,
+  DO_NOT_WAIT_FOR_WIIMOTES,
+};
+
 void Shutdown();
-void Initialize(void* const hwnd, bool wait = false);
+void Initialize(void* const hwnd, InitializeMode init_mode);
 void ResetAllWiimotes();
 void LoadConfig();
 void Resume();
@@ -54,7 +60,7 @@ void Update(int _number, bool _connected);
 
 namespace WiimoteReal
 {
-void Initialize(bool wait = false);
+void Initialize(::Wiimote::InitializeMode init_mode);
 void Stop();
 void Shutdown();
 void Resume();

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -231,7 +231,7 @@ void Wiimote::RequestStatus(const wm_request_status* const rs)
   {
     using namespace WiimoteReal;
 
-    std::lock_guard<std::recursive_mutex> lk(g_refresh_lock);
+    std::lock_guard<std::mutex> lk(g_wiimotes_mutex);
 
     if (g_wiimotes[m_index])
     {

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -662,7 +662,7 @@ void Wiimote::Update()
     {
       using namespace WiimoteReal;
 
-      std::lock_guard<std::recursive_mutex> lk(g_refresh_lock);
+      std::lock_guard<std::mutex> lk(g_wiimotes_mutex);
       if (g_wiimotes[m_index])
       {
         const Report& rpt = g_wiimotes[m_index]->ProcessReadQueue();

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -500,7 +500,7 @@ void WiimoteDarwinHid::RemoveCallback(void* context, IOReturn result, void*)
   IOBluetoothDevice* device = [l2capChannel device];
   WiimoteReal::WiimoteDarwin* wm = nullptr;
 
-  std::lock_guard<std::recursive_mutex> lk(WiimoteReal::g_refresh_lock);
+  std::lock_guard<std::mutex> lk(WiimoteReal::g_wiimotes_mutex);
 
   for (int i = 0; i < MAX_WIIMOTES; i++)
   {
@@ -541,7 +541,7 @@ void WiimoteDarwinHid::RemoveCallback(void* context, IOReturn result, void*)
   IOBluetoothDevice* device = [l2capChannel device];
   WiimoteReal::WiimoteDarwin* wm = nullptr;
 
-  std::lock_guard<std::recursive_mutex> lk(WiimoteReal::g_refresh_lock);
+  std::lock_guard<std::mutex> lk(WiimoteReal::g_wiimotes_mutex);
 
   for (int i = 0; i < MAX_WIIMOTES; i++)
   {

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -156,7 +156,7 @@ private:
 #endif
 };
 
-extern std::recursive_mutex g_refresh_lock;
+extern std::mutex g_wiimotes_mutex;
 extern WiimoteScanner g_wiimote_scanner;
 extern Wiimote* g_wiimotes[MAX_BBMOTES];
 

--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -59,7 +59,7 @@ private:
   void OnContinuousScanning(wxCommandEvent& event)
   {
     SConfig::GetInstance().m_WiimoteContinuousScanning = event.IsChecked();
-    WiimoteReal::Initialize();
+    WiimoteReal::Initialize(Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
     event.Skip();
   }
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -348,12 +348,14 @@ bool CFrame::InitControllers()
     Window win = X11Utils::XWindowFromHandle(GetHandle());
     Pad::Initialize(reinterpret_cast<void*>(win));
     Keyboard::Initialize(reinterpret_cast<void*>(win));
-    Wiimote::Initialize(reinterpret_cast<void*>(win));
+    Wiimote::Initialize(reinterpret_cast<void*>(win),
+                        Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
     HotkeyManagerEmu::Initialize(reinterpret_cast<void*>(win));
 #else
     Pad::Initialize(reinterpret_cast<void*>(GetHandle()));
     Keyboard::Initialize(reinterpret_cast<void*>(GetHandle()));
-    Wiimote::Initialize(reinterpret_cast<void*>(GetHandle()));
+    Wiimote::Initialize(reinterpret_cast<void*>(GetHandle()),
+                        Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
     HotkeyManagerEmu::Initialize(reinterpret_cast<void*>(GetHandle()));
 #endif
     return true;


### PR DESCRIPTION
This changes Refresh() to use the existing scanning thread to scan for devices, instead of running the scan on the UI thread and blocking it. (Should fix [issue 8992](https://dolp.in/i8992))

This also makes the UI thread not block when Continuous Scanning is enabled then disabled, and removes a random 0-500ms delay on exit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3988)
<!-- Reviewable:end -->
