### PR TITLE
Don't ScheduleEvent from wrong thread when inserting SD card

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -32,6 +32,7 @@ They will also generate a true or false return for UpdateInterrupts() in WII_IPC
 #include "Common/Thread.h"
 
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/Debugger/Debugger_SymbolMap.h"
 #include "Core/HW/CPU.h"
@@ -76,6 +77,7 @@ static ipc_msg_queue reply_queue;    // arm -> ppc
 static ipc_msg_queue ack_queue;      // arm -> ppc
 
 static int event_enqueue;
+static int event_sdio_notify;
 
 static u64 last_reply_time;
 
@@ -96,6 +98,14 @@ static void EnqueueEvent(u64 userdata, s64 cycles_late = 0)
     reply_queue.push_back((u32)userdata);
   }
   Update();
+}
+
+void SDIO_EventNotify_CPUThread(u64 userdata, s64 cycles_late)
+{
+  auto device =
+      static_cast<CWII_IPC_HLE_Device_sdio_slot0*>(GetDeviceByName("/dev/sdio/slot0").get());
+  if (device)
+    device->EventNotify();
 }
 
 static u32 num_devices;
@@ -148,6 +158,7 @@ void Init()
   AddDevice<IWII_IPC_HLE_Device>("_Unimplemented_Device_");
 
   event_enqueue = CoreTiming::RegisterEvent("IPCEvent", EnqueueEvent);
+  event_sdio_notify = CoreTiming::RegisterEvent("SDIO_EventNotify", SDIO_EventNotify_CPUThread);
 }
 
 void Reset(bool _bHard)
@@ -212,10 +223,10 @@ void ES_DIVerify(const std::vector<u8>& tmd)
 
 void SDIO_EventNotify()
 {
-  auto pDevice =
-      static_cast<CWII_IPC_HLE_Device_sdio_slot0*>(GetDeviceByName("/dev/sdio/slot0").get());
-  if (pDevice)
-    pDevice->EventNotify();
+  // TODO: Potential race condition: If IsRunning() becomes false after
+  // it's checked, an event may be scheduled after CoreTiming shuts down.
+  if (SConfig::GetInstance().bWii && Core::IsRunning())
+    CoreTiming::ScheduleEvent_Threadsafe(0, event_sdio_notify);
 }
 
 int getFreeDeviceId()

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -49,6 +49,8 @@ void CWII_IPC_HLE_Device_sdio_slot0::DoState(PointerWrap& p)
 
 void CWII_IPC_HLE_Device_sdio_slot0::EventNotify()
 {
+  // Accessing SConfig variables like this isn't really threadsafe,
+  // but this is how it's done all over the place...
   if ((SConfig::GetInstance().m_WiiSDCard && m_event.type == EVENT_INSERT) ||
       (!SConfig::GetInstance().m_WiiSDCard && m_event.type == EVENT_REMOVE))
   {


### PR DESCRIPTION
/dev/sdio/slot0's EventNotify was being called from the UI thread even though it only should be called from the CPU thread for thread safety reasons. With this PR, the UI thread instead schedules an event that will call EventNotify on the CPU thread.

There is a potential race condition if IsRunning becomes false right after my newly added call to IsRunning, which can end up adding an event to CoreTiming after it has shut down. It's unlikely to occur in practice, and the old code had the same problem (with GetDeviceByName as the equivalent of IsRunning), but it's still a race condition. I'm not sure what to do about it. Suggestions?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3989)
<!-- Reviewable:end -->
