### PR TITLE
[WIP] Fix emboss map path without any normals enabled.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -51,10 +51,6 @@ VertexShaderUid GetVertexShaderUid()
         texinfo.embosslightshift = xfmem.texMtxInfo[i].embosslightshift;
         texinfo.embosssourceshift = xfmem.texMtxInfo[i].embosssourceshift;
       }
-      else
-      {
-        texinfo.embosssourceshift = xfmem.texMtxInfo[i].embosssourceshift;
-      }
       break;
     case XF_TEXGEN_COLOR_STRGBC0:
     case XF_TEXGEN_COLOR_STRGBC1:
@@ -318,10 +314,8 @@ ShaderCode GenerateVertexShaderCode(API_TYPE api_type, const vertex_shader_uid_d
       }
       else
       {
-        // The following assert was triggered in House of the Dead Overkill and Star Wars Rogue
-        // Squadron 2
-        //_assert_(0); // should have normals
-        out.Write("o.tex%d.xyz = o.tex%d.xyz;\n", i, texinfo.embosssourceshift);
+        // Even if inputform ABC1 is set, it only uses AB11
+        out.Write("o.tex%d.xyz = float3(coord.xy, 1.0);\n", i);
       }
 
       break;


### PR DESCRIPTION
_This is a rebase of #3718_

Confirmed with a hardware test that it doesn't pull from the emboss source, but instead from the source row instead.

One thing left to test is to enable lighting and see if it effects the coordinates.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3990)

<!-- Reviewable:end -->
