### PR TITLE
DolphinWX: Shut down cleanly on shutdown signal

### DIFF
--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -186,6 +186,7 @@ private:
   };
 
   wxTimer m_poll_hotkey_timer;
+  wxTimer m_handle_signal_timer;
 
   wxBitmap m_Bitmaps[EToolbar_Max];
 
@@ -328,6 +329,7 @@ private:
 
   void PollHotkeys(wxTimerEvent&);
   void ParseHotkeys();
+  void HandleSignal(wxTimerEvent&);
 
   bool InitControllers();
 


### PR DESCRIPTION
This makes DolphinWX shut down cleanly, just like it would with File->Exit or closing the main window.

I'm not sure if this should bypass Confirm on Stop or not (currently, it doesn't).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3991)
<!-- Reviewable:end -->
