### PR TITLE
DolphinWX: Print a message when a signal is received

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -537,7 +537,11 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, const wxPo
 
 #if defined(__unix__) || defined(__unix) || defined(__APPLE__)
   struct sigaction sa;
-  sa.sa_handler = [](int unused) { s_shutdown_signal_received.Set(); };
+  sa.sa_handler = [](int unused) {
+    char message[] = "A signal was received. A second signal will force Dolphin to stop.\n";
+    write(STDERR_FILENO, message, sizeof(message));
+    s_shutdown_signal_received.Set();
+  };
   sigemptyset(&sa.sa_mask);
   sa.sa_flags = SA_RESETHAND;
   sigaction(SIGINT, &sa, nullptr);


### PR DESCRIPTION
This makes it clear that sending a signal a second time will force stop
Dolphin (which is useful in case the GUI is deadlocked or otherwise
unable to react to the signal).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3993)
<!-- Reviewable:end -->
