### PR TITLE
Remove VI count limit on Movie playback

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -901,13 +901,12 @@ void UpdateTitle()
   std::string SFPS;
 
   if (Movie::IsPlayingInput())
-    SFPS = StringFromFormat("VI: %u/%u - Input: %u/%u - FPS: %.0f - VPS: %.0f - %.0f%%",
-                            (u32)Movie::g_currentFrame, (u32)Movie::g_totalFrames,
-                            (u32)Movie::g_currentInputCount, (u32)Movie::g_totalInputCount, FPS,
-                            VPS, Speed);
+    SFPS = StringFromFormat("Input: %u/%u - VI: %u - FPS: %.0f - VPS: %.0f - %.0f%%",
+                            (u32)Movie::g_currentInputCount, (u32)Movie::g_totalInputCount,
+                            (u32)Movie::g_currentFrame, FPS, VPS, Speed);
   else if (Movie::IsRecordingInput())
-    SFPS = StringFromFormat("VI: %u - Input: %u - FPS: %.0f - VPS: %.0f - %.0f%%",
-                            (u32)Movie::g_currentFrame, (u32)Movie::g_currentInputCount, FPS, VPS,
+    SFPS = StringFromFormat("Input: %u - VI: %u - FPS: %.0f - VPS: %.0f - %.0f%%",
+                            (u32)Movie::g_currentInputCount, (u32)Movie::g_currentFrame, FPS, VPS,
                             Speed);
   else
   {

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1035,10 +1035,10 @@ void LoadInput(const std::string& filename)
     {
       afterEnd = true;
       PanicAlertT("Warning: You loaded a save that's after the end of the current movie. (byte %u "
-                  "> %u) (frame %u > %u). You should load another save before continuing, or load "
+                  "> %u) (input %u > %u). You should load another save before continuing, or load "
                   "this state with read-only mode off.",
-                  (u32)s_currentByte + 256, (u32)s_totalBytes + 256, (u32)g_currentFrame,
-                  (u32)g_totalFrames);
+                  (u32)s_currentByte + 256, (u32)s_totalBytes + 256, (u32)g_currentInputCount,
+                  (u32)g_totalInputCount);
     }
     else if (s_currentByte > 0 && s_totalBytes > 0)
     {
@@ -1134,7 +1134,7 @@ void LoadInput(const std::string& filename)
 // NOTE: CPU Thread
 static void CheckInputEnd()
 {
-  if (g_currentFrame > g_totalFrames || s_currentByte >= s_totalBytes ||
+  if (s_currentByte >= s_totalBytes ||
       (CoreTiming::GetTicks() > s_totalTickCount && !IsRecordingInputFromSaveState()))
   {
     EndPlayInput(!s_bReadOnly);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -312,7 +312,9 @@ void Renderer::DrawDebugText()
     {
       final_cyan += StringFromFormat("Frame: %llu", (unsigned long long)Movie::g_currentFrame);
       if (Movie::IsPlayingInput())
-        final_cyan += StringFromFormat(" / %llu", (unsigned long long)Movie::g_totalFrames);
+        final_cyan +=
+            StringFromFormat("\nInput: %llu / %llu", (unsigned long long)Movie::g_currentInputCount,
+                             (unsigned long long)Movie::g_totalInputCount);
     }
 
     final_cyan += "\n";


### PR DESCRIPTION
This removes the check of VI count when playing back the movie. VI counts can differ between NoXFB, VirtualXFB, and RealXFB, but the inputs will work across all three without any issues.

Because we're no longer checking for VI count when playing back the movie, I've also de-prioritized the VI count when either recording or playing back a movie, with Input Count taking priority.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3995)
<!-- Reviewable:end -->
