### PR TITLE
Fix more warnings:

### DIFF
--- a/Externals/soundtouch/CMakeLists.txt
+++ b/Externals/soundtouch/CMakeLists.txt
@@ -16,3 +16,4 @@ set(SRCS
 	)
 
 add_library(SoundTouch STATIC ${SRCS})
+add_definitions(-w)

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -722,7 +722,7 @@ bool NetPlayClient::StartGame(const std::string& path)
     // Needed to prevent locking up at boot if (when) the wiimotes connect out of order.
     NetWiimote nw;
     nw.resize(4, 0);
-    m_wiimote_current_data_size = {4, 4, 4, 4};
+    m_wiimote_current_data_size.fill(4);
 
     for (unsigned int w = 0; w < 4; ++w)
     {


### PR DESCRIPTION
- Externals/soundtouch/CMakeLists.txt: add -w (since it's not our code) to
silence an unused variable warning
- Source/Core/Core/NetPlayClient.cpp: Work around a Clang/libc++ bug where
initializing a std::array the way the standard says you're supposed to produces
a warning.  (libc++'s implementation of std::array, like any sane
implementation, has a C array as a field, so the most explicit form of
initialization would use two braces, one for the struct and one for the array.
Clang has a general warning for not being explicit with braces, which is
usually sane.  But the standard only guarantees that initializing std::array
works with a single pair of braces!)  There are other places in Dolphin that
incorrectly use double braces, presumably to avoid the warning, so maybe the
warning should just be turned off, but in any case here I just switch to an
equivalent .fill().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3998)
<!-- Reviewable:end -->
