### PR TITLE
evdev: Clamp axis values to the 0.0-1.0 range

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
+#include "Common/MathUtil.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/evdev/evdev.h"
 
@@ -196,7 +197,7 @@ ControlState evdevDevice::Axis::GetState() const
   libevdev_fetch_event_value(m_dev, EV_ABS, m_code, &value);
 
   // Value from 0.0 to 1.0
-  ControlState fvalue = double(value - m_min) / double(m_range);
+  ControlState fvalue = MathUtil::Clamp(double(value - m_min) / double(m_range), 0.0, 1.0);
 
   // Split into two axis, each covering half the range from 0.0 to 1.0
   if (m_upper)


### PR DESCRIPTION
The values are expected to be in the 0.0-1.0 range (as indicated by the
comment), and other parts of Dolphin also expect it to be in that range
since the "full" axis has a -1.0 to 1.0 range.  However, this is not
always the case and fvalue can end up being outside of the range. This
clamps fvalue to always be in the 0.0 and 1.0 range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/3999)
<!-- Reviewable:end -->
