### PR TITLE
ControllerEmu: Split the Setting class

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -247,9 +247,11 @@ bool TryParse(const std::string& str, u32* const output)
 
 bool TryParse(const std::string& str, bool* const output)
 {
-  if ("1" == str || !strcasecmp("true", str.c_str()))
+  float value;
+  const bool is_valid_float = TryParse(str, &value);
+  if ((is_valid_float && value == 1) || !strcasecmp("true", str.c_str()))
     *output = true;
-  else if ("0" == str || !strcasecmp("false", str.c_str()))
+  else if ((is_valid_float && value == 0) || !strcasecmp("false", str.c_str()))
     *output = false;
   else
     return false;

--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -73,9 +73,10 @@ GCKeyboard::GCKeyboard(const unsigned int index) : m_index(index)
 
   // options
   groups.emplace_back(m_options = new ControlGroup(_trans("Options")));
-  m_options->settings.emplace_back(
-      new ControlGroup::BackgroundInputSetting(_trans("Background Input")));
-  m_options->settings.emplace_back(new ControlGroup::IterateUI(_trans("Iterative Input")));
+  m_options->boolean_settings.emplace_back(
+      std::make_unique<ControlGroup::BackgroundInputSetting>(_trans("Background Input")));
+  m_options->boolean_settings.emplace_back(std::make_unique<ControlGroup::BooleanSetting>(
+      _trans("Iterative Input"), false, ControlGroup::SettingType::VIRTUAL));
 }
 
 std::string GCKeyboard::GetName() const

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -68,9 +68,10 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
 
   // options
   groups.emplace_back(m_options = new ControlGroup(_trans("Options")));
-  m_options->settings.emplace_back(
-      new ControlGroup::BackgroundInputSetting(_trans("Background Input")));
-  m_options->settings.emplace_back(new ControlGroup::IterateUI(_trans("Iterative Input")));
+  m_options->boolean_settings.emplace_back(
+      std::make_unique<ControlGroup::BackgroundInputSetting>(_trans("Background Input")));
+  m_options->boolean_settings.emplace_back(std::make_unique<ControlGroup::BooleanSetting>(
+      _trans("Iterative Input"), false, ControlGroup::SettingType::VIRTUAL));
 }
 
 std::string GCPad::GetName() const

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -115,7 +115,7 @@ void Wiimote::SpeakerData(wm_speaker_data* sd)
   }
 
   // Speaker Pan
-  unsigned int vol = (unsigned int)(m_options->settings[4]->GetValue() * 100);
+  unsigned int vol = (unsigned int)(m_options->numeric_settings[0]->GetValue() * 100);
 
   unsigned int sample_rate = sample_rate_dividend / m_reg_speaker.sample_rate;
   float speaker_volume_ratio = (float)m_reg_speaker.volume / volume_divisor;

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -222,9 +222,10 @@ HotkeyManager::HotkeyManager()
   }
 
   groups.emplace_back(m_options = new ControlGroup(_trans("Options")));
-  m_options->settings.emplace_back(
-      new ControlGroup::BackgroundInputSetting(_trans("Background Input")));
-  m_options->settings.emplace_back(new ControlGroup::IterateUI(_trans("Iterative Input")));
+  m_options->boolean_settings.emplace_back(
+      std::make_unique<ControlGroup::BackgroundInputSetting>(_trans("Background Input")));
+  m_options->boolean_settings.emplace_back(std::make_unique<ControlGroup::BooleanSetting>(
+      _trans("Iterative Input"), false, ControlGroup::SettingType::VIRTUAL));
 }
 
 HotkeyManager::~HotkeyManager()

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -100,8 +100,8 @@ void PadSettingExtension::UpdateValue()
 }
 
 PadSettingCheckBox::PadSettingCheckBox(wxWindow* const parent,
-                                       ControllerEmu::ControlGroup::Setting* const _setting)
-    : PadSetting(new wxCheckBox(parent, wxID_ANY, wxGetTranslation(StrToWxStr(_setting->name)))),
+                                       ControllerEmu::ControlGroup::BooleanSetting* const _setting)
+    : PadSetting(new wxCheckBox(parent, wxID_ANY, wxGetTranslation(StrToWxStr(_setting->m_name)))),
       setting(_setting)
 {
   UpdateGUI();
@@ -109,13 +109,12 @@ PadSettingCheckBox::PadSettingCheckBox(wxWindow* const parent,
 
 void PadSettingCheckBox::UpdateGUI()
 {
-  ((wxCheckBox*)wxcontrol)->SetValue(!!setting->GetValue());
+  ((wxCheckBox*)wxcontrol)->SetValue(setting->GetValue());
 }
 
 void PadSettingCheckBox::UpdateValue()
 {
-  // 0.01 so its saved to the ini file as just 1. :(
-  setting->SetValue(0.01 * ((wxCheckBox*)wxcontrol)->GetValue());
+  setting->SetValue(((wxCheckBox*)wxcontrol)->GetValue());
 }
 
 void PadSettingSpin::UpdateGUI()
@@ -827,13 +826,13 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
                                        wxBITMAP_TYPE_BMP);
 
     wxBoxSizer* const szr = new wxBoxSizer(wxVERTICAL);
-    for (auto& groupSetting : group->settings)
+    for (auto& groupSetting : group->numeric_settings)
     {
       PadSettingSpin* setting = new PadSettingSpin(parent, groupSetting.get());
       setting->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
       options.push_back(setting);
       szr->Add(
-          new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name))));
+          new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->m_name))));
       szr->Add(setting->wxcontrol, 0, wxLEFT, 0);
     }
 
@@ -856,7 +855,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
     static_bitmap = new wxStaticBitmap(parent, wxID_ANY, bitmap, wxDefaultPosition, wxDefaultSize,
                                        wxBITMAP_TYPE_BMP);
 
-    PadSettingSpin* const threshold_cbox = new PadSettingSpin(parent, group->settings[0].get());
+    auto* const threshold_cbox = new PadSettingSpin(parent, group->numeric_settings[0].get());
     threshold_cbox->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
 
     threshold_cbox->wxcontrol->SetToolTip(
@@ -865,9 +864,9 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
     options.push_back(threshold_cbox);
 
     wxBoxSizer* const szr = new wxBoxSizer(wxHORIZONTAL);
-    szr->Add(
-        new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(group->settings[0]->name))),
-        0, wxCENTER | wxRIGHT, 3);
+    szr->Add(new wxStaticText(parent, wxID_ANY,
+                              wxGetTranslation(StrToWxStr(group->numeric_settings[0]->m_name))),
+             0, wxCENTER | wxRIGHT, 3);
     szr->Add(threshold_cbox->wxcontrol, 0, wxRIGHT, 3);
 
     Add(szr, 0, wxALL | wxCENTER, 3);
@@ -893,14 +892,15 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
     static_bitmap = new wxStaticBitmap(parent, wxID_ANY, bitmap, wxDefaultPosition, wxDefaultSize,
                                        wxBITMAP_TYPE_BMP);
 
-    for (auto& groupSetting : group->settings)
+    for (auto& groupSetting : group->numeric_settings)
     {
       PadSettingSpin* setting = new PadSettingSpin(parent, groupSetting.get());
       setting->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
       options.push_back(setting);
       wxBoxSizer* const szr = new wxBoxSizer(wxHORIZONTAL);
-      szr->Add(new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name))),
-               0, wxCENTER | wxRIGHT, 3);
+      szr->Add(
+          new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->m_name))), 0,
+          wxCENTER | wxRIGHT, 3);
       szr->Add(setting->wxcontrol, 0, wxRIGHT, 3);
       Add(szr, 0, wxALL | wxCENTER, 3);
     }
@@ -926,35 +926,32 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
   default:
   {
     // options
-    for (auto& groupSetting : group->settings)
+    for (auto& groupSetting : group->boolean_settings)
     {
-      if (groupSetting->high == DEFAULT_HIGH_VALUE)
+      PadSettingCheckBox* setting_cbox = new PadSettingCheckBox(parent, groupSetting.get());
+      if (groupSetting->m_name == "Iterative Input")
       {
-        PadSettingCheckBox* setting_cbox = new PadSettingCheckBox(parent, groupSetting.get());
-        if (groupSetting->is_iterate == true)
-        {
-          setting_cbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustSettingUI, eventsink);
-          groupSetting->value = 0;
-        }
-        else
-        {
-          setting_cbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustSetting, eventsink);
-        }
-        options.push_back(setting_cbox);
-        Add(setting_cbox->wxcontrol, 0, wxALL | wxLEFT, 5);
+        setting_cbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustSettingUI, eventsink);
+        groupSetting->SetValue(false);
       }
       else
       {
-        PadSettingSpin* setting = new PadSettingSpin(parent, groupSetting.get());
-        setting->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
-        options.push_back(setting);
-        wxBoxSizer* const szr = new wxBoxSizer(wxHORIZONTAL);
-        szr->Add(
-            new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->name))), 0,
-            wxCENTER | wxRIGHT, 3);
-        szr->Add(setting->wxcontrol, 0, wxRIGHT, 3);
-        Add(szr, 0, wxALL | wxCENTER, 3);
+        setting_cbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustSetting, eventsink);
       }
+      options.push_back(setting_cbox);
+      Add(setting_cbox->wxcontrol, 0, wxALL | wxLEFT, 5);
+    }
+    for (auto& groupSetting : group->numeric_settings)
+    {
+      PadSettingSpin* setting = new PadSettingSpin(parent, groupSetting.get());
+      setting->wxcontrol->Bind(wxEVT_SPINCTRL, &GamepadPage::AdjustSetting, eventsink);
+      options.push_back(setting);
+      wxBoxSizer* const szr = new wxBoxSizer(wxHORIZONTAL);
+      szr->Add(
+          new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->m_name))), 0,
+          wxCENTER | wxRIGHT, 3);
+      szr->Add(setting->wxcontrol, 0, wxRIGHT, 3);
+      Add(szr, 0, wxALL | wxCENTER, 3);
     }
   }
   break;
@@ -980,7 +977,8 @@ ControlGroupsSizer::ControlGroupsSizer(ControllerEmu* const controller, wxWindow
         new wxStaticBoxSizer(wxVERTICAL, parent, wxGetTranslation(StrToWxStr(group->ui_name)));
     control_group->Add(control_group_box);
 
-    const size_t grp_size = group->controls.size() + group->settings.size();
+    const size_t grp_size =
+        group->controls.size() + group->numeric_settings.size() + group->boolean_settings.size();
     col_size += grp_size;
     if (col_size > 8 || nullptr == stacked_groups)
     {

--- a/Source/Core/DolphinWX/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/InputConfigDiag.h
@@ -61,10 +61,11 @@ public:
 class PadSettingSpin : public PadSetting
 {
 public:
-  PadSettingSpin(wxWindow* const parent, ControllerEmu::ControlGroup::Setting* const _setting)
+  PadSettingSpin(wxWindow* const parent,
+                 ControllerEmu::ControlGroup::NumericSetting* const _setting)
       : PadSetting(new wxSpinCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition,
-                                  wxSize(54, -1), 0, _setting->low, _setting->high,
-                                  (int)(_setting->value * 100))),
+                                  wxSize(54, -1), 0, _setting->m_low, _setting->m_high,
+                                  (int)(_setting->GetValue() * 100))),
         setting(_setting)
   {
   }
@@ -72,17 +73,18 @@ public:
   void UpdateGUI() override;
   void UpdateValue() override;
 
-  ControllerEmu::ControlGroup::Setting* const setting;
+  ControllerEmu::ControlGroup::NumericSetting* const setting;
 };
 
 class PadSettingCheckBox : public PadSetting
 {
 public:
-  PadSettingCheckBox(wxWindow* const parent, ControllerEmu::ControlGroup::Setting* const setting);
+  PadSettingCheckBox(wxWindow* const parent,
+                     ControllerEmu::ControlGroup::BooleanSetting* const setting);
   void UpdateGUI() override;
   void UpdateValue() override;
 
-  ControllerEmu::ControlGroup::Setting* const setting;
+  ControllerEmu::ControlGroup::BooleanSetting* const setting;
 };
 
 class InputEventFilter : public wxEventFilter

--- a/Source/Core/DolphinWX/InputConfigDiagBitmaps.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiagBitmaps.cpp
@@ -228,7 +228,7 @@ static void DrawControlGroupBox(wxDC& dc, ControlGroupBox* g)
     {
       // deadzone circle
       dc.SetBrush(*wxLIGHT_GREY_BRUSH);
-      dc.DrawCircle(32, 32, g->control_group->settings[SETTING_DEADZONE]->value * 32);
+      dc.DrawCircle(32, 32, g->control_group->numeric_settings[SETTING_DEADZONE]->GetValue() * 32);
     }
 
     // raw dot
@@ -259,7 +259,7 @@ static void DrawControlGroupBox(wxDC& dc, ControlGroupBox* g)
   {
     ControlState raw_dot[3];
     ControlState adj_dot[3];
-    const ControlState deadzone = g->control_group->settings[0]->value;
+    const ControlState deadzone = g->control_group->numeric_settings[0]->GetValue();
 
     // adjusted
     ((ControllerEmu::Force*)g->control_group)->GetState(adj_dot);
@@ -358,7 +358,7 @@ static void DrawControlGroupBox(wxDC& dc, ControlGroupBox* g)
 
     // draw the shit
     dc.SetPen(*wxGREY_PEN);
-    ControlState deadzone = g->control_group->settings[0]->value;
+    ControlState deadzone = g->control_group->numeric_settings[0]->GetValue();
 
     ControlState* const trigs = new ControlState[trigger_count];
     ((ControllerEmu::Triggers*)g->control_group)->GetState(trigs);
@@ -398,7 +398,7 @@ static void DrawControlGroupBox(wxDC& dc, ControlGroupBox* g)
 
     // draw the shit
     dc.SetPen(*wxGREY_PEN);
-    ControlState thresh = g->control_group->settings[0]->value;
+    ControlState thresh = g->control_group->numeric_settings[0]->GetValue();
 
     for (unsigned int n = 0; n < trigger_count; ++n)
     {
@@ -428,7 +428,7 @@ static void DrawControlGroupBox(wxDC& dc, ControlGroupBox* g)
   break;
   case GROUP_TYPE_SLIDER:
   {
-    const ControlState deadzone = g->control_group->settings[0]->value;
+    const ControlState deadzone = g->control_group->numeric_settings[0]->GetValue();
 
     ControlState state = g->control_group->controls[1]->control_ref->State() -
                          g->control_group->controls[0]->control_ref->State();

--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -44,14 +44,18 @@ void ControllerEmu::ControlGroup::LoadConfig(IniFile::Section* sec, const std::s
   std::string group(base + name + "/");
 
   // settings
-  for (auto& s : settings)
+  for (auto& s : numeric_settings)
   {
-    if (s->is_virtual)
+    if (s->m_type == SettingType::VIRTUAL)
       continue;
-    if (s->is_iterate)
+    sec->Get(group + s->m_name, &s->m_value, s->m_default_value * 100);
+    s->m_value /= 100;
+  }
+  for (auto& s : boolean_settings)
+  {
+    if (s->m_type == SettingType::VIRTUAL)
       continue;
-    sec->Get(group + s->name, &s->value, s->default_value * 100);
-    s->value /= 100;
+    sec->Get(group + s->m_name, &s->m_value, s->m_default_value);
   }
 
   for (auto& c : controls)
@@ -105,14 +109,17 @@ void ControllerEmu::ControlGroup::SaveConfig(IniFile::Section* sec, const std::s
 {
   std::string group(base + name + "/");
 
-  for (auto& s : settings)
+  for (auto& s : numeric_settings)
   {
-    if (s->is_virtual)
+    if (s->m_type == SettingType::VIRTUAL)
       continue;
-    if (s->is_iterate)
+    sec->Set(group + s->m_name, s->m_value * 100.0, s->m_default_value * 100.0);
+  }
+  for (auto& s : boolean_settings)
+  {
+    if (s->m_type == SettingType::VIRTUAL)
       continue;
-
-    sec->Set(group + s->name, s->value * 100.0, s->default_value * 100.0);
+    sec->Set(group + s->m_name, s->m_value, s->m_default_value);
   }
 
   for (auto& c : controls)
@@ -163,25 +170,26 @@ ControllerEmu::AnalogStick::AnalogStick(const char* const _name, const char* con
     controls.emplace_back(std::make_unique<Input>(named_direction));
 
   controls.emplace_back(std::make_unique<Input>(_trans("Modifier")));
-  settings.emplace_back(std::make_unique<Setting>(_trans("Radius"), default_radius, 0, 100));
-  settings.emplace_back(std::make_unique<Setting>(_trans("Dead Zone"), 0, 0, 50));
+  numeric_settings.emplace_back(
+      std::make_unique<NumericSetting>(_trans("Radius"), default_radius, 0, 100));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
 }
 
 ControllerEmu::Buttons::Buttons(const std::string& _name) : ControlGroup(_name, GROUP_TYPE_BUTTONS)
 {
-  settings.emplace_back(std::make_unique<Setting>(_trans("Threshold"), 0.5));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Threshold"), 0.5));
 }
 
 ControllerEmu::MixedTriggers::MixedTriggers(const std::string& _name)
     : ControlGroup(_name, GROUP_TYPE_MIXED_TRIGGERS)
 {
-  settings.emplace_back(std::make_unique<Setting>(_trans("Threshold"), 0.9));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Threshold"), 0.9));
 }
 
 ControllerEmu::Triggers::Triggers(const std::string& _name)
     : ControlGroup(_name, GROUP_TYPE_TRIGGERS)
 {
-  settings.emplace_back(std::make_unique<Setting>(_trans("Dead Zone"), 0, 0, 50));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
 }
 
 ControllerEmu::Slider::Slider(const std::string& _name) : ControlGroup(_name, GROUP_TYPE_SLIDER)
@@ -189,7 +197,7 @@ ControllerEmu::Slider::Slider(const std::string& _name) : ControlGroup(_name, GR
   controls.emplace_back(std::make_unique<Input>("Left"));
   controls.emplace_back(std::make_unique<Input>("Right"));
 
-  settings.emplace_back(std::make_unique<Setting>(_trans("Dead Zone"), 0, 0, 50));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
 }
 
 ControllerEmu::Force::Force(const std::string& _name) : ControlGroup(_name, GROUP_TYPE_FORCE)
@@ -203,7 +211,7 @@ ControllerEmu::Force::Force(const std::string& _name) : ControlGroup(_name, GROU
   controls.emplace_back(std::make_unique<Input>(_trans("Forward")));
   controls.emplace_back(std::make_unique<Input>(_trans("Backward")));
 
-  settings.emplace_back(std::make_unique<Setting>(_trans("Dead Zone"), 0, 0, 50));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
 }
 
 ControllerEmu::Tilt::Tilt(const std::string& _name) : ControlGroup(_name, GROUP_TYPE_TILT)
@@ -217,9 +225,9 @@ ControllerEmu::Tilt::Tilt(const std::string& _name) : ControlGroup(_name, GROUP_
 
   controls.emplace_back(std::make_unique<Input>(_trans("Modifier")));
 
-  settings.emplace_back(std::make_unique<Setting>(_trans("Dead Zone"), 0, 0, 50));
-  settings.emplace_back(std::make_unique<Setting>(_trans("Circle Stick"), 0));
-  settings.emplace_back(std::make_unique<Setting>(_trans("Angle"), 0.9, 0, 180));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Circle Stick"), 0));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Angle"), 0.9, 0, 180));
 }
 
 ControllerEmu::Cursor::Cursor(const std::string& _name)
@@ -231,9 +239,9 @@ ControllerEmu::Cursor::Cursor(const std::string& _name)
   controls.emplace_back(std::make_unique<Input>("Backward"));
   controls.emplace_back(std::make_unique<Input>(_trans("Hide")));
 
-  settings.emplace_back(std::make_unique<Setting>(_trans("Center"), 0.5));
-  settings.emplace_back(std::make_unique<Setting>(_trans("Width"), 0.5));
-  settings.emplace_back(std::make_unique<Setting>(_trans("Height"), 0.5));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.5));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.5));
 }
 
 void ControllerEmu::LoadDefaults(const ControllerInterface& ciface)

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -71,48 +71,62 @@ public:
       Output(const std::string& _name) : Control(new ControllerInterface::OutputReference, _name) {}
     };
 
-    class Setting
+    enum class SettingType
     {
-    public:
-      Setting(const std::string& _name, const ControlState def_value, const unsigned int _low = 0,
-              const unsigned int _high = 100)
-          : name(_name), value(def_value), default_value(def_value), low(_low), high(_high),
-            is_virtual(false), is_iterate(false)
-      {
-      }
-
-      virtual ~Setting() {}
-      const std::string name;
-      ControlState value;
-      const ControlState default_value;
-      const unsigned int low, high;
-      bool is_virtual;
-      bool is_iterate;
-
-      virtual void SetValue(ControlState new_value) { value = new_value; }
-      virtual ControlState GetValue() { return value; }
+      NORMAL,   // normal settings are saved to configuration files
+      VIRTUAL,  // virtual settings are not saved at all
     };
 
-    class BackgroundInputSetting : public Setting
+    class NumericSetting
     {
     public:
-      BackgroundInputSetting(const std::string& _name) : Setting(_name, false)
+      NumericSetting(const std::string& name, const ControlState default_value,
+                     const unsigned int low = 0, const unsigned int high = 100,
+                     const SettingType type = SettingType::NORMAL)
+          : m_type(type), m_name(name), m_default_value(default_value), m_low(low), m_high(high)
       {
-        is_virtual = true;
       }
 
-      void SetValue(ControlState new_value) override
-      {
-        SConfig::GetInstance().m_BackgroundInput = !!new_value;
-      }
-
-      ControlState GetValue() override { return SConfig::GetInstance().m_BackgroundInput; }
+      ControlState GetValue() const { return m_value; }
+      void SetValue(ControlState value) { m_value = value; }
+      const SettingType m_type;
+      const std::string m_name;
+      const ControlState m_default_value;
+      const unsigned int m_low, m_high;
+      ControlState m_value;
     };
 
-    class IterateUI : public Setting
+    class BooleanSetting
     {
     public:
-      IterateUI(const std::string& _name) : Setting(_name, false) { is_iterate = true; }
+      BooleanSetting(const std::string& name, const bool default_value,
+                     const SettingType type = SettingType::NORMAL)
+          : m_type(type), m_name(name), m_default_value(default_value)
+      {
+      }
+
+      virtual bool GetValue() const { return m_value; }
+      virtual void SetValue(bool value) { m_value = value; }
+      const SettingType m_type;
+      const std::string m_name;
+      const bool m_default_value;
+      bool m_value;
+    };
+
+    class BackgroundInputSetting : public BooleanSetting
+    {
+    public:
+      BackgroundInputSetting(const std::string& name)
+          : BooleanSetting(name, false, SettingType::VIRTUAL)
+      {
+      }
+
+      bool GetValue() const override { return SConfig::GetInstance().m_BackgroundInput; }
+      void SetValue(bool value) override
+      {
+        m_value = value;
+        SConfig::GetInstance().m_BackgroundInput = value;
+      }
     };
 
     ControlGroup(const std::string& _name, const unsigned int _type = GROUP_TYPE_OTHER)
@@ -137,7 +151,8 @@ public:
     const unsigned int type;
 
     std::vector<std::unique_ptr<Control>> controls;
-    std::vector<std::unique_ptr<Setting>> settings;
+    std::vector<std::unique_ptr<NumericSetting>> numeric_settings;
+    std::vector<std::unique_ptr<BooleanSetting>> boolean_settings;
   };
 
   class AnalogStick : public ControlGroup
@@ -152,8 +167,8 @@ public:
       ControlState yy = controls[0]->control_ref->State() - controls[1]->control_ref->State();
       ControlState xx = controls[3]->control_ref->State() - controls[2]->control_ref->State();
 
-      ControlState radius = settings[SETTING_RADIUS]->value;
-      ControlState deadzone = settings[SETTING_DEADZONE]->value;
+      ControlState radius = numeric_settings[SETTING_RADIUS]->GetValue();
+      ControlState deadzone = numeric_settings[SETTING_DEADZONE]->GetValue();
       ControlState m = controls[4]->control_ref->State();
 
       ControlState ang = atan2(yy, xx);
@@ -192,7 +207,7 @@ public:
     {
       for (auto& control : controls)
       {
-        if (control->control_ref->State() > settings[0]->value)  // threshold
+        if (control->control_ref->State() > numeric_settings[0]->GetValue())  // threshold
           *buttons |= *bitmasks;
 
         bitmasks++;
@@ -210,7 +225,7 @@ public:
       const unsigned int trig_count = ((unsigned int)(controls.size() / 2));
       for (unsigned int i = 0; i < trig_count; ++i, ++bitmasks, ++analog)
       {
-        if (controls[i]->control_ref->State() > settings[0]->value)  // threshold
+        if (controls[i]->control_ref->State() > numeric_settings[0]->GetValue())  // threshold
         {
           *analog = 1.0;
           *digital |= *bitmasks;
@@ -231,7 +246,7 @@ public:
     void GetState(ControlState* analog)
     {
       const unsigned int trig_count = ((unsigned int)(controls.size()));
-      const ControlState deadzone = settings[0]->value;
+      const ControlState deadzone = numeric_settings[0]->GetValue();
       for (unsigned int i = 0; i < trig_count; ++i, ++analog)
         *analog = std::max(controls[i]->control_ref->State() - deadzone, 0.0) / (1 - deadzone);
     }
@@ -244,7 +259,7 @@ public:
 
     void GetState(ControlState* const slider)
     {
-      const ControlState deadzone = settings[0]->value;
+      const ControlState deadzone = numeric_settings[0]->GetValue();
       const ControlState state =
           controls[1]->control_ref->State() - controls[0]->control_ref->State();
 
@@ -262,7 +277,7 @@ public:
 
     void GetState(ControlState* axis)
     {
-      const ControlState deadzone = settings[0]->value;
+      const ControlState deadzone = numeric_settings[0]->GetValue();
       for (unsigned int i = 0; i < 6; i += 2)
       {
         ControlState tmpf = 0;
@@ -293,9 +308,9 @@ public:
       ControlState yy = controls[0]->control_ref->State() - controls[1]->control_ref->State();
       ControlState xx = controls[3]->control_ref->State() - controls[2]->control_ref->State();
 
-      ControlState deadzone = settings[0]->value;
-      ControlState circle = settings[1]->value;
-      auto const angle = settings[2]->value / 1.8;
+      ControlState deadzone = numeric_settings[0]->GetValue();
+      ControlState circle = numeric_settings[1]->GetValue();
+      auto const angle = numeric_settings[2]->GetValue() / 1.8;
       ControlState m = controls[4]->control_ref->State();
 
       // deadzone / circle stick code
@@ -386,9 +401,9 @@ public:
         // adjust cursor according to settings
         if (adjusted)
         {
-          xx *= (settings[1]->value * 2);
-          yy *= (settings[2]->value * 2);
-          yy += (settings[0]->value - 0.5);
+          xx *= (numeric_settings[1]->GetValue() * 2);
+          yy *= (numeric_settings[2]->GetValue() * 2);
+          yy += (numeric_settings[0]->GetValue() - 0.5);
         }
 
         *x = xx;


### PR DESCRIPTION
The Setting class was used for both numeric values and booleans, and
other parts of the code had "hacks" to make it work with booleans.

By splitting Setting into NumericSetting and BooleanSetting, it is
clearer which settings are numeric, and which are boolean, so there is
no need to guess by checking the default values or anything like that.
Also, booleans are stored as booleans in config files, instead of 1.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4001)
<!-- Reviewable:end -->
