### PR TITLE
WiimoteReal: Call Update() less often

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -472,7 +472,6 @@ void WiimoteScanner::ThreadFunc()
   {
     m_scan_mode_changed_event.WaitFor(std::chrono::milliseconds(500));
 
-    Update();  // Does stuff needed to detect disconnects on Windows
     CheckForDisconnectedWiimotes();
 
     if (m_scan_mode.load() == WiimoteScanMode::DO_NOT_SCAN)
@@ -489,6 +488,10 @@ void WiimoteScanner::ThreadFunc()
         if (found_board)
           TryToConnectBalanceBoard(found_board);
       }
+    }
+    else
+    {
+      Update();  // Does stuff needed to detect disconnects on Windows
     }
 
     if (m_scan_mode.load() == WiimoteScanMode::SCAN_ONCE)


### PR DESCRIPTION
This moves back the WiimoteScanner:Update() call to where it originally
was, since according to a comment it is intended to be called only when
"when not looking for more Wiimotes", and calling it too often causes
the Bluetooth module to be loaded/unloaded a lot of times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4002)
<!-- Reviewable:end -->
