### PR TITLE
SectorReader: Minor cache bias bug

### DIFF
--- a/Source/Core/DiscIO/Blob.cpp
+++ b/Source/Core/DiscIO/Blob.cpp
@@ -57,12 +57,15 @@ SectorReader::Cache* SectorReader::GetEmptyCacheLine()
 {
   Cache* oldest = &m_cache[0];
   // Find the Least Recently Used cache line to replace.
-  for (auto& cache_entry : m_cache)
-  {
-    if (cache_entry.IsLessRecentlyUsedThan(*oldest))
-      oldest = &cache_entry;
-    cache_entry.ShiftLRU();
-  }
+  std::for_each(m_cache.begin() + 1, m_cache.end(), [&](Cache& line) {
+    if (line.IsLessRecentlyUsedThan(*oldest))
+    {
+      oldest->ShiftLRU();
+      oldest = &line;
+      return;
+    }
+    line.ShiftLRU();
+  });
   oldest->Reset();
   return oldest;
 }

--- a/Source/Core/DiscIO/DriveBlob.cpp
+++ b/Source/Core/DiscIO/DriveBlob.cpp
@@ -138,9 +138,9 @@ bool DriveReader::ReadMultipleAlignedBlocks(u64 block_num, u64 num_blocks, u8* o
 #ifdef _WIN32
   LARGE_INTEGER offset;
   offset.QuadPart = GetSectorSize() * block_num;
-  SetFilePointerEx(m_disc_handle, offset, nullptr, FILE_BEGIN);
   DWORD bytes_read;
-  if (!ReadFile(m_disc_handle, out_ptr, static_cast<DWORD>(GetSectorSize() * num_blocks),
+  if (!SetFilePointerEx(m_disc_handle, offset, nullptr, FILE_BEGIN) ||
+      !ReadFile(m_disc_handle, out_ptr, static_cast<DWORD>(GetSectorSize() * num_blocks),
                 &bytes_read, nullptr))
   {
     PanicAlertT("Disc Read Error");


### PR DESCRIPTION
There's a minor bug in `SectorReader::GetEmptyCacheLine()` where it is biased towards the first hit due to the way `ShiftLRU` was being called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4005)
<!-- Reviewable:end -->
