### PR TITLE
DolphinQt2: Startup Warning

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_AUTOMOC ON)
 set(SRCS
 	AboutDialog.cpp
 	Host.cpp
+	InDevelopmentWarning.cpp
 	Main.cpp
 	MainWindow.cpp
 	MenuBar.cpp

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -90,6 +90,7 @@
     <QtMoc Include="GameList\ListProxyModel.h" />
     <QtMoc Include="GameList\TableDelegate.h" />
     <QtMoc Include="Host.h" />
+    <QtMoc Include="InDevelopmentWarning.h" />
     <QtMoc Include="MainWindow.h" />
     <QtMoc Include="MenuBar.h" />
     <QtMoc Include="RenderWidget.h" />
@@ -105,6 +106,7 @@
     <ClCompile Include="$(QtMocOutPrefix)GameListModel.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)GameTracker.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)Host.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)InDevelopmentWarning.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)InfoWidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)ListProxyModel.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)MainWindow.cpp" />
@@ -129,6 +131,7 @@
     <ClCompile Include="GameList\ListProxyModel.cpp" />
     <ClCompile Include="GameList\TableDelegate.cpp" />
     <ClCompile Include="Host.cpp" />
+    <ClCompile Include="InDevelopmentWarning.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="MenuBar.cpp" />

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj
@@ -189,6 +189,9 @@
     <ProjectReference Include="$(CoreDir)VideoBackends\Software\Software.vcxproj">
       <Project>{a4c423aa-f57c-46c7-a172-d1a777017d29}</Project>
     </ProjectReference>
+    <ProjectReference Include="$(CoreDir)VideoBackends\Null\Null.vcxproj">
+      <Project>{53A5391B-737E-49A8-BC8F-312ADA00736F}</Project>
+    </ProjectReference>
     <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
       <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
     </ProjectReference>

--- a/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
+++ b/Source/Core/DolphinQt2/DolphinQt2.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
@@ -87,6 +87,10 @@
     <ClCompile Include="$(QtMocOutPrefix)FilesystemWidget.cpp">
       <Filter>Generated Files</Filter>
     </ClCompile>
+    <ClCompile Include="InDevelopmentWarning.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)InDevelopmentWarning.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="MainWindow.h" />
@@ -119,6 +123,7 @@
     <QtMoc Include="Config\PropertiesDialog.h" />
     <QtMoc Include="Config\FilesystemWidget.h" />
     <QtMoc Include="Config\InfoWidget.h" />
+    <QtMoc Include="InDevelopmentWarning.h" />
   </ItemGroup>
   <ItemGroup>
     <QtUi Include="*.ui" />

--- a/Source/Core/DolphinQt2/InDevelopmentWarning.cpp
+++ b/Source/Core/DolphinQt2/InDevelopmentWarning.cpp
@@ -1,0 +1,120 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <QApplication>
+#include <QBoxLayout>
+#include <QCommandLinkButton>
+#include <QDialogButtonBox>
+#include <QFileInfo>
+#include <QLabel>
+#include <QMessageBox>
+#include <QProcess>
+#include <QStyle>
+
+#include "DolphinQt2/InDevelopmentWarning.h"
+#include "DolphinQt2/Resources.h"
+
+static bool LaunchDolphinWX()
+{
+  QFileInfo file_info;
+  for (auto path : {"/Dolphin.exe", "/dolphin-emu", "/Dolphin"})
+  {
+    file_info.setFile(qApp->applicationDirPath() + QString::fromUtf8(path));
+    if (file_info.isExecutable())
+      return QProcess::startDetached(file_info.absoluteFilePath(), {});
+  }
+  return false;
+}
+
+InDevelopmentWarning::InDevelopmentWarning(QWidget* parent)
+    : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint)
+{
+  QWidget* container = new QWidget(this);
+  QDialogButtonBox* std_buttons =
+      new QDialogButtonBox(QDialogButtonBox::Cancel, Qt::Horizontal, this);
+  QLabel* heading = new QLabel(container);
+  QLabel* icon = new QLabel(container);
+  QLabel* body = new QLabel(container);
+
+  QCommandLinkButton* btn_dolphinwx = new QCommandLinkButton(
+      tr("Run DolphinWX Instead"), tr("Recommended for normal users"), container);
+  QCommandLinkButton* btn_run = new QCommandLinkButton(tr("Use DolphinQt Anyway"), container);
+
+  container->setForegroundRole(QPalette::Text);
+  container->setBackgroundRole(QPalette::Base);
+  container->setAutoFillBackground(true);
+
+  std_buttons->setContentsMargins(10, 0, 10, 0);
+
+  QFont heading_font{heading->font()};
+  heading_font.setPointSizeF(heading_font.pointSizeF() * 1.5);
+  heading->setFont(heading_font);
+  heading->setText(tr("DolphinQt Experimental GUI"));
+  heading->setForegroundRole(QPalette::Text);
+  heading->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+
+  icon->setPixmap(style()->standardPixmap(QStyle::SP_MessageBoxWarning, nullptr, this));
+  icon->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+  QString body_text = tr(
+      "<p>DolphinQt is a new experimental GUI that is eventually intended to replace "
+      "the current GUI based on wxWidgets. The implementation is <b>very "
+      "incomplete</b>, even basic functionality like changing settings and "
+      "attaching gamepads may be missing or not work at all.</p>\n"
+      "<p>Only developers working on the DolphinQt implementation should use it at "
+      "the present time; normal users are recommended to continue using the "
+      "older DolphinWX GUI for the time being.</p>\n"
+      "<p><big><b>Bug Reports:</b></big> At the current time there is no point making bug reports "
+      "about the DolphinQt GUI as the list of what is broken is much longer "
+      "than the list of things that work.</p>\n");
+  body->setText(body_text);
+  body->setWordWrap(true);
+  body->setForegroundRole(QPalette::Text);
+  body->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+  body->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+  btn_dolphinwx->setDefault(true);
+
+  connect(btn_dolphinwx, &QCommandLinkButton::clicked, this, [this](bool) {
+    if (!LaunchDolphinWX())
+      QMessageBox::critical(
+          this, tr("Failed to launch"),
+          tr("Could not start DolphinWX. Check for dolphin.exe in the installation directory."));
+    reject();
+  });
+  connect(btn_run, &QCommandLinkButton::clicked, this, [this](bool) { accept(); });
+  connect(std_buttons->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this,
+          [this](bool) { reject(); });
+
+  QVBoxLayout* body_column = new QVBoxLayout();
+  body_column->addWidget(heading);
+  body_column->addSpacing(10);
+  body_column->addWidget(body);
+  body_column->addWidget(btn_dolphinwx);
+  body_column->addSpacing(10);
+  body_column->addWidget(btn_run);
+  body_column->setMargin(0);
+  body_column->setSpacing(0);
+
+  QHBoxLayout* icon_layout = new QHBoxLayout(container);
+  icon_layout->addWidget(icon, 0, Qt::AlignTop);
+  icon_layout->addLayout(body_column);
+  icon_layout->setContentsMargins(15, 10, 10, 10);
+  icon_layout->setSpacing(15);
+
+  QVBoxLayout* top_layout = new QVBoxLayout(this);
+  top_layout->addWidget(container);
+  top_layout->addWidget(std_buttons);
+  top_layout->setSpacing(10);
+  top_layout->setContentsMargins(0, 0, 0, 10);
+
+  setWindowIcon(Resources::GetMisc(Resources::LOGO_SMALL));
+  setWindowTitle(tr("DolphinQt2 Experimental GUI"));
+  setMinimumSize(460, 320);
+  resize(minimumSizeHint());
+}
+
+InDevelopmentWarning::~InDevelopmentWarning()
+{
+}

--- a/Source/Core/DolphinQt2/InDevelopmentWarning.h
+++ b/Source/Core/DolphinQt2/InDevelopmentWarning.h
@@ -1,0 +1,16 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+class InDevelopmentWarning final : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit InDevelopmentWarning(QWidget* parent = nullptr);
+  ~InDevelopmentWarning();
+};

--- a/Source/Core/DolphinQt2/Main.cpp
+++ b/Source/Core/DolphinQt2/Main.cpp
@@ -8,8 +8,10 @@
 #include "Core/BootManager.h"
 #include "Core/Core.h"
 #include "DolphinQt2/Host.h"
+#include "DolphinQt2/InDevelopmentWarning.h"
 #include "DolphinQt2/MainWindow.h"
 #include "DolphinQt2/Resources.h"
+#include "DolphinQt2/Settings.h"
 #include "UICommon/UICommon.h"
 
 int main(int argc, char* argv[])
@@ -26,9 +28,18 @@ int main(int argc, char* argv[])
   QObject::connect(QAbstractEventDispatcher::instance(), &QAbstractEventDispatcher::aboutToBlock,
                    &app, &Core::HostDispatchJobs);
 
-  MainWindow win;
-  win.show();
-  int retval = app.exec();
+  int retval = 0;
+  if (Settings().IsInDevelopmentWarningEnabled())
+  {
+    InDevelopmentWarning warning_box;
+    retval = warning_box.exec() == QDialog::Rejected;
+  }
+  if (!retval)
+  {
+    MainWindow win;
+    win.show();
+    retval = app.exec();
+  }
 
   BootManager::Stop();
   Core::Shutdown();

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -8,6 +8,7 @@
 #include <QMessageBox>
 
 #include "Core/BootManager.h"
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/Movie.h"

--- a/Source/Core/DolphinQt2/Settings.cpp
+++ b/Source/Core/DolphinQt2/Settings.cpp
@@ -23,6 +23,13 @@ QString Settings::GetThemeDir() const
   return QString::fromStdString(File::GetThemeDir(theme_name.toStdString()));
 }
 
+bool Settings::IsInDevelopmentWarningEnabled() const
+{
+  // There's intentionally no way to set this from the UI.
+  // Add it to your INI manually instead.
+  return value(QStringLiteral("ShowDevelopmentWarning"), true).toBool();
+}
+
 QString Settings::GetLastGame() const
 {
   return value(QStringLiteral("GameList/LastGame")).toString();

--- a/Source/Core/DolphinQt2/Settings.h
+++ b/Source/Core/DolphinQt2/Settings.h
@@ -18,6 +18,7 @@ public:
 
   // UI
   QString GetThemeDir() const;
+  bool IsInDevelopmentWarningEnabled() const;
 
   // GameList
   QString GetLastGame() const;

--- a/Source/dolphin-emu.sln
+++ b/Source/dolphin-emu.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Dolphin", "Core\DolphinWX\DolphinWX.vcxproj", "{47411FDB-1BF2-48D0-AB4E-C7C41160F898}"
 EndProject
@@ -73,6 +73,7 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "curl", "..\Externals\curl\curl.vcxproj", "{BB00605C-125F-4A21-B33B-7BF418322DCB}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "D3D12", "Core\VideoBackends\D3D12\D3D12.vcxproj", "{570215B7-E32F-4438-95AE-C8D955F9FCA3}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DolphinQt2", "Core\DolphinQt2\DolphinQt2.vcxproj", "{FA3FA62B-6F58-4B86-9453-4D149940A066}"
 EndProject
 Global


### PR DESCRIPTION
In PR #3981 Phire suggested adding a warning prompt to DolphinQt so that users don't accidentally try to use it instead of DolphinWX if both binaries are included in the packages produced by the buildbot. [The other option is to produce a separate build package for DolphinQt so the binaries don't end up mixed together.] This needs someone to supply the text for whatever it should say.

![experimental](https://cloud.githubusercontent.com/assets/17393426/16788437/700fee96-48e8-11e6-88c2-05a73d1532a0.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4006)
<!-- Reviewable:end -->
