### PR TITLE
ControllerInterface: Make the ID assigning code common

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.cpp
@@ -27,10 +27,6 @@ std::string Touchscreen::GetSource() const
   return "Android";
 }
 
-int Touchscreen::GetId() const
-{
-  return _padID;
-}
 Touchscreen::Touchscreen(int padID) : _padID(padID)
 {
   // GC

--- a/Source/Core/InputCommon/ControllerInterface/Android/Android.h
+++ b/Source/Core/InputCommon/ControllerInterface/Android/Android.h
@@ -46,7 +46,6 @@ public:
   Touchscreen(int padID);
   ~Touchscreen() {}
   std::string GetName() const;
-  int GetId() const;
   std::string GetSource() const;
 
 private:

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -143,6 +143,20 @@ void ControllerInterface::Shutdown()
 void ControllerInterface::AddDevice(std::shared_ptr<ciface::Core::Device> device)
 {
   std::lock_guard<std::mutex> lk(m_devices_mutex);
+  // Try to find an ID for this device
+  int id = 0;
+  while (true)
+  {
+    const auto it = std::find_if(m_devices.begin(), m_devices.end(), [&device, &id](const auto& d) {
+      return d->GetSource() == device->GetSource() && d->GetName() == device->GetName() &&
+             d->GetId() == id;
+    });
+    if (it == m_devices.end())  // no device with the same name with this ID, so we can use it
+      break;
+    else
+      id++;
+  }
+  device->SetId(id);
   m_devices.emplace_back(std::move(device));
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.cpp
@@ -23,10 +23,6 @@ void InitJoystick(IDirectInput8* const idi8, HWND hwnd)
   idi8->EnumDevices(DI8DEVCLASS_GAMECTRL, DIEnumDevicesCallback, (LPVOID)&joysticks,
                     DIEDFL_ATTACHEDONLY);
 
-  // this is used to number the joysticks
-  // multiple joysticks with the same name shall get unique ids starting at 0
-  std::map<std::basic_string<TCHAR>, int> name_counts;
-
   std::vector<DWORD> xinput_guids;
   GetXInputGUIDS(&xinput_guids);
 
@@ -58,7 +54,7 @@ void InitJoystick(IDirectInput8* const idi8, HWND hwnd)
           }
         }
 
-        auto js = std::make_shared<Joystick>(js_device, name_counts[joystick.tszInstanceName]++);
+        auto js = std::make_shared<Joystick>(js_device);
         // only add if it has some inputs/outputs
         if (js->Inputs().size() || js->Outputs().size())
           g_controller_interface.AddDevice(std::move(js));
@@ -72,9 +68,8 @@ void InitJoystick(IDirectInput8* const idi8, HWND hwnd)
   }
 }
 
-Joystick::Joystick(/*const LPCDIDEVICEINSTANCE lpddi, */ const LPDIRECTINPUTDEVICE8 device,
-                   const unsigned int index)
-    : m_device(device), m_index(index)
+Joystick::Joystick(/*const LPCDIDEVICEINSTANCE lpddi, */ const LPDIRECTINPUTDEVICE8 device)
+    : m_device(device)
 //, m_name(TStringToString(lpddi->tszInstanceName))
 {
   // seems this needs to be done before GetCapabilities
@@ -165,11 +160,6 @@ Joystick::~Joystick()
 std::string Joystick::GetName() const
 {
   return GetDeviceName(m_device);
-}
-
-int Joystick::GetId() const
-{
-  return m_index;
 }
 
 std::string Joystick::GetSource() const

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputJoystick.h
@@ -62,16 +62,14 @@ private:
 public:
   void UpdateInput() override;
 
-  Joystick(const LPDIRECTINPUTDEVICE8 device, const unsigned int index);
+  Joystick(const LPDIRECTINPUTDEVICE8 device);
   ~Joystick();
 
   std::string GetName() const override;
-  int GetId() const override;
   std::string GetSource() const override;
 
 private:
   const LPDIRECTINPUTDEVICE8 m_device;
-  const unsigned int m_index;
 
   DIJOYSTATE m_state_in;
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -185,12 +185,6 @@ std::string KeyboardMouse::GetName() const
   return "Keyboard Mouse";
 }
 
-int KeyboardMouse::GetId() const
-{
-  // should this be -1, idk
-  return 0;
-}
-
 std::string KeyboardMouse::GetSource() const
 {
   return DINPUT_SOURCE_NAME;

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.h
@@ -89,7 +89,6 @@ public:
   ~KeyboardMouse();
 
   std::string GetName() const override;
-  int GetId() const override;
   std::string GetSource() const override;
 
 private:

--- a/Source/Core/InputCommon/ControllerInterface/Device.h
+++ b/Source/Core/InputCommon/ControllerInterface/Device.h
@@ -93,8 +93,9 @@ public:
 
   virtual ~Device();
 
+  int GetId() const { return m_id; }
+  void SetId(int id) { m_id = id; }
   virtual std::string GetName() const = 0;
-  virtual int GetId() const = 0;
   virtual std::string GetSource() const = 0;
   virtual void UpdateInput() {}
   const std::vector<Input*>& Inputs() const { return m_inputs; }
@@ -130,6 +131,7 @@ protected:
   }
 
 private:
+  int m_id;
   std::vector<Input*> m_inputs;
   std::vector<Output*> m_outputs;
 };

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSX.mm
@@ -21,7 +21,6 @@ namespace OSX
 {
 static IOHIDManagerRef HIDManager = nullptr;
 static CFStringRef OurRunLoop = CFSTR("DolphinOSXInput");
-static std::map<std::string, int> kbd_name_counts, joy_name_counts;
 
 void DeviceElementDebugPrint(const void* value, void* context)
 {
@@ -145,17 +144,13 @@ static void DeviceMatching_callback(void* inContext, IOReturn inResult, void* in
 
   // Add a device if it's of a type we want
   if (IOHIDDeviceConformsTo(inIOHIDDeviceRef, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard))
-    g_controller_interface.AddDevice(
-        std::make_shared<Keyboard>(inIOHIDDeviceRef, name, kbd_name_counts[name]++, g_window));
+    g_controller_interface.AddDevice(std::make_shared<Keyboard>(inIOHIDDeviceRef, name, g_window));
 #if 0
-	else if (IOHIDDeviceConformsTo(inIOHIDDeviceRef,
-		kHIDPage_GenericDesktop, kHIDUsage_GD_Mouse))
-		g_controller_interface.AddDevice(new Mouse(inIOHIDDeviceRef,
-			name, mouse_name_counts[name]++));
+  else if (IOHIDDeviceConformsTo(inIOHIDDeviceRef, kHIDPage_GenericDesktop, kHIDUsage_GD_Mouse))
+    g_controller_interface.AddDevice(new Mouse(inIOHIDDeviceRef, name));
 #endif
   else
-    g_controller_interface.AddDevice(
-        std::make_shared<Joystick>(inIOHIDDeviceRef, name, joy_name_counts[name]++));
+    g_controller_interface.AddDevice(std::make_shared<Joystick>(inIOHIDDeviceRef, name));
 }
 
 void Init(void* window)
@@ -175,9 +170,6 @@ void Init(void* window)
   IOHIDManagerScheduleWithRunLoop(HIDManager, CFRunLoopGetCurrent(), OurRunLoop);
   if (IOHIDManagerOpen(HIDManager, kIOHIDOptionsTypeNone) != kIOReturnSuccess)
     NSLog(@"Failed to open HID Manager");
-
-  kbd_name_counts.clear();
-  joy_name_counts.clear();
 
   // Wait while current devices are initialized
   while (CFRunLoopRunInMode(OurRunLoop, 0, TRUE) == kCFRunLoopRunHandledSource)

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.h
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.h
@@ -73,17 +73,15 @@ private:
   };
 
 public:
-  Joystick(IOHIDDeviceRef device, std::string name, int index);
+  Joystick(IOHIDDeviceRef device, std::string name);
   ~Joystick();
 
   std::string GetName() const override;
   std::string GetSource() const override;
-  int GetId() const override;
 
 private:
   const IOHIDDeviceRef m_device;
   const std::string m_device_name;
-  const int m_index;
 
   ForceFeedback::FFDeviceAdapterReference m_ff_device;
 };

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -14,8 +14,8 @@ namespace ciface
 {
 namespace OSX
 {
-Joystick::Joystick(IOHIDDeviceRef device, std::string name, int index)
-    : m_device(device), m_device_name(name), m_index(index), m_ff_device(nullptr)
+Joystick::Joystick(IOHIDDeviceRef device, std::string name)
+    : m_device(device), m_device_name(name), m_ff_device(nullptr)
 {
   // Buttons
   NSDictionary* buttonDict = @{
@@ -91,11 +91,6 @@ std::string Joystick::GetName() const
 std::string Joystick::GetSource() const
 {
   return "Input";
-}
-
-int Joystick::GetId() const
-{
-  return m_index;
 }
 
 ControlState Joystick::Button::GetState() const

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXKeyboard.h
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXKeyboard.h
@@ -60,11 +60,10 @@ private:
 public:
   void UpdateInput() override;
 
-  Keyboard(IOHIDDeviceRef device, std::string name, int index, void* window);
+  Keyboard(IOHIDDeviceRef device, std::string name, void* window);
 
   std::string GetName() const override;
   std::string GetSource() const override;
-  int GetId() const override;
 
 private:
   struct
@@ -74,7 +73,6 @@ private:
 
   const IOHIDDeviceRef m_device;
   const std::string m_device_name;
-  int m_index;
   uint32_t m_windowid;
   unsigned char m_mousebuttons[3];
 };

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXKeyboard.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXKeyboard.mm
@@ -14,8 +14,8 @@ namespace ciface
 {
 namespace OSX
 {
-Keyboard::Keyboard(IOHIDDeviceRef device, std::string name, int index, void* window)
-    : m_device(device), m_device_name(name), m_index(index)
+Keyboard::Keyboard(IOHIDDeviceRef device, std::string name, void* window)
+    : m_device(device), m_device_name(name)
 {
   // This class should only recieve Keyboard or Keypad devices
   // Now, filter on just the buttons we can handle sanely
@@ -96,11 +96,6 @@ std::string Keyboard::GetName() const
 std::string Keyboard::GetSource() const
 {
   return "Keyboard";
-}
-
-int Keyboard::GetId() const
-{
-  return m_index;
 }
 
 Keyboard::Key::Key(IOHIDElementRef element, IOHIDDeviceRef device)

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -46,7 +46,6 @@ void Init()
   // Search the Pipes directory for files that we can open in read-only,
   // non-blocking mode. The device name is the virtual name of the file.
   File::FSTEntry fst;
-  int found = 0;
   std::string dir_path = File::GetUserPath(D_PIPES_IDX);
   if (!File::Exists(dir_path))
     return;
@@ -61,11 +60,11 @@ void Init()
     int fd = open(child.physicalName.c_str(), O_RDONLY | O_NONBLOCK);
     if (fd < 0)
       continue;
-    g_controller_interface.AddDevice(std::make_shared<PipeDevice>(fd, child.virtualName, found++));
+    g_controller_interface.AddDevice(std::make_shared<PipeDevice>(fd, child.virtualName));
   }
 }
 
-PipeDevice::PipeDevice(int fd, const std::string& name, int id) : m_fd(fd), m_name(name), m_id(id)
+PipeDevice::PipeDevice(int fd, const std::string& name) : m_fd(fd), m_name(name)
 {
   for (const auto& tok : s_button_tokens)
   {

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
@@ -27,12 +27,11 @@ void Init();
 class PipeDevice : public Core::Device
 {
 public:
-  PipeDevice(int fd, const std::string& name, int id);
+  PipeDevice(int fd, const std::string& name);
   ~PipeDevice();
 
   void UpdateInput() override;
   std::string GetName() const override { return m_name; }
-  int GetId() const override { return m_id; }
   std::string GetSource() const override { return "Pipe"; }
 private:
   class PipeInput : public Input
@@ -53,7 +52,6 @@ private:
 
   const int m_fd;
   const std::string m_name;
-  const int m_id;
   std::string m_buf;
   std::map<std::string, PipeInput*> m_buttons;
   std::map<std::string, PipeInput*> m_axes;

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -35,10 +35,6 @@ static std::string GetJoystickName(int index)
 
 void Init()
 {
-  // this is used to number the joysticks
-  // multiple joysticks with the same name shall get unique ids starting at 0
-  std::map<std::string, int> name_counts;
-
 #ifdef USE_SDL_HAPTIC
   if (SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC) >= 0)
   {
@@ -58,7 +54,7 @@ void Init()
     SDL_Joystick* dev = SDL_JoystickOpen(i);
     if (dev)
     {
-      auto js = std::make_shared<Joystick>(dev, i, name_counts[GetJoystickName(i)]++);
+      auto js = std::make_shared<Joystick>(dev, i);
       // only add if it has some inputs/outputs
       if (js->Inputs().size() || js->Outputs().size())
         g_controller_interface.AddDevice(std::move(js));
@@ -66,8 +62,8 @@ void Init()
   }
 }
 
-Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsigned int index)
-    : m_joystick(joystick), m_sdl_index(sdl_index), m_index(index)
+Joystick::Joystick(SDL_Joystick* const joystick, const int sdl_index)
+    : m_joystick(joystick), m_sdl_index(sdl_index)
 {
 // really bad HACKS:
 // to not use SDL for an XInput device
@@ -288,11 +284,6 @@ std::string Joystick::GetName() const
 std::string Joystick::GetSource() const
 {
   return "SDL";
-}
-
-int Joystick::GetId() const
-{
-  return m_index;
 }
 
 std::string Joystick::Button::GetName() const

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -142,17 +142,15 @@ private:
 public:
   void UpdateInput() override;
 
-  Joystick(SDL_Joystick* const joystick, const int sdl_index, const unsigned int index);
+  Joystick(SDL_Joystick* const joystick, const int sdl_index);
   ~Joystick();
 
   std::string GetName() const override;
-  int GetId() const override;
   std::string GetSource() const override;
 
 private:
   SDL_Joystick* const m_joystick;
   const int m_sdl_index;
-  const unsigned int m_index;
 
 #ifdef USE_SDL_HAPTIC
   SDL_Haptic* m_haptic;

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
@@ -171,11 +171,6 @@ std::string Device::GetName() const
   }
 }
 
-int Device::GetId() const
-{
-  return m_index;
-}
-
 std::string Device::GetSource() const
 {
   return "XInput";

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
@@ -92,7 +92,6 @@ public:
   Device(const XINPUT_CAPABILITIES& capabilities, u8 index);
 
   std::string GetName() const override;
-  int GetId() const override;
   std::string GetSource() const override;
 
   void UpdateMotors();

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -300,11 +300,6 @@ std::string KeyboardMouse::GetSource() const
   return "XInput2";
 }
 
-int KeyboardMouse::GetId() const
-{
-  return -1;
-}
-
 KeyboardMouse::Key::Key(Display* const display, KeyCode keycode, const char* keyboard)
     : m_display(display), m_keyboard(keyboard), m_keycode(keycode)
 {

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -104,7 +104,6 @@ public:
 
   std::string GetName() const override;
   std::string GetSource() const override;
-  int GetId() const override;
 
 private:
   Window m_window;

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/Xlib.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/Xlib.cpp
@@ -80,11 +80,6 @@ std::string KeyboardMouse::GetSource() const
   return "Xlib";
 }
 
-int KeyboardMouse::GetId() const
-{
-  return 0;
-}
-
 KeyboardMouse::Key::Key(Display* const display, KeyCode keycode, const char* keyboard)
     : m_display(display), m_keyboard(keyboard), m_keycode(keycode)
 {

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/Xlib.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/Xlib.h
@@ -81,7 +81,6 @@ public:
 
   std::string GetName() const override;
   std::string GetSource() const override;
-  int GetId() const override;
 
 private:
   Window m_window;

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
@@ -63,11 +63,10 @@ private:
 public:
   void UpdateInput() override;
 
-  evdevDevice(const std::string& devnode, int id);
+  evdevDevice(const std::string& devnode);
   ~evdevDevice();
 
   std::string GetName() const override { return m_name; }
-  int GetId() const override { return m_id; }
   std::string GetSource() const override { return "evdev"; }
   bool IsInteresting() const { return m_initialized && m_interesting; }
 private:
@@ -75,7 +74,6 @@ private:
   int m_fd;
   libevdev* m_dev;
   std::string m_name;
-  const int m_id;
   bool m_initialized;
   bool m_interesting;
 };


### PR DESCRIPTION
This makes the device ID assigning code common to all backends, by
moving it to AddDevice() instead of copy-pasting or replicating
the logic in the backends.

Also, to prepare for hotplugging, instead of relying on a name usage
count, the new ID assigning system always starts from ID 0 and tries
to assign the first ID that is not used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4009)
<!-- Reviewable:end -->
