### PR TITLE
Add relative input for the Wiimote IR

### DIFF
--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -843,6 +843,13 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
           new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(groupSetting->m_name))));
       szr->Add(setting->wxcontrol, 0, wxLEFT, 0);
     }
+    for (auto& groupSetting : group->boolean_settings)
+    {
+      auto* checkbox = new PadSettingCheckBox(parent, groupSetting.get());
+      checkbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustSetting, eventsink);
+      options.push_back(checkbox);
+      Add(checkbox->wxcontrol, 0, wxALL | wxLEFT, 5);
+    }
 
     wxBoxSizer* const h_szr = new wxBoxSizer(wxHORIZONTAL);
     h_szr->Add(szr, 1, 0, 5);

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -799,6 +799,8 @@ void GamepadPage::RefreshDevices(wxCommandEvent&)
   Pad::LoadConfig();
   HotkeyManagerEmu::LoadConfig();
 
+  UpdateGUI();
+
   Core::PauseAndLock(false, was_unpaused);
 }
 

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -18,6 +18,7 @@
 #include <wx/control.h>
 #include <wx/dcmemory.h>
 #include <wx/dialog.h>
+#include <wx/event.h>
 #include <wx/font.h>
 #include <wx/listbox.h>
 #include <wx/msgdlg.h>
@@ -110,6 +111,10 @@ PadSettingCheckBox::PadSettingCheckBox(wxWindow* const parent,
 void PadSettingCheckBox::UpdateGUI()
 {
   ((wxCheckBox*)wxcontrol)->SetValue(setting->GetValue());
+  // Force WX to trigger an event after updating the value
+  wxCommandEvent event(wxEVT_CHECKBOX);
+  event.SetEventObject(wxcontrol);
+  wxPostEvent(wxcontrol, event);
 }
 
 void PadSettingCheckBox::UpdateValue()
@@ -452,15 +457,48 @@ void ControlDialog::AppendControl(wxCommandEvent& event)
   UpdateGUI();
 }
 
-void GamepadPage::AdjustSetting(wxCommandEvent& event)
+void GamepadPage::EnableSettingControl(const std::string& group_name, const std::string& name,
+                                       const bool enabled)
 {
-  ((PadSetting*)((wxControl*)event.GetEventObject())->GetClientData())->UpdateValue();
+  const auto box_iterator =
+      std::find_if(control_groups.begin(), control_groups.end(), [&group_name](const auto& box) {
+        return group_name == box->control_group->name;
+      });
+  if (box_iterator == control_groups.end())
+    return;
+
+  const auto* box = *box_iterator;
+  const auto it =
+      std::find_if(box->options.begin(), box->options.end(), [&name](const auto& pad_setting) {
+        return pad_setting->wxcontrol->GetLabelText() == name;
+      });
+  if (it == box->options.end())
+    return;
+  (*it)->wxcontrol->Enable(enabled);
 }
 
-void GamepadPage::AdjustSettingUI(wxCommandEvent& event)
+void GamepadPage::AdjustSetting(wxCommandEvent& event)
 {
-  m_iterate = !m_iterate;
-  ((PadSetting*)((wxControl*)event.GetEventObject())->GetClientData())->UpdateValue();
+  const auto* const control = static_cast<wxControl*>(event.GetEventObject());
+  auto* const pad_setting = static_cast<PadSetting*>(control->GetClientData());
+  pad_setting->UpdateValue();
+}
+
+void GamepadPage::AdjustBooleanSetting(wxCommandEvent& event)
+{
+  const auto* const control = static_cast<wxControl*>(event.GetEventObject());
+  auto* const pad_setting = static_cast<PadSettingCheckBox*>(control->GetClientData());
+  pad_setting->UpdateValue();
+
+  // TODO: find a cleaner way to have actions depending on the setting
+  if (control->GetLabelText() == "Iterative Input")
+  {
+    m_iterate = pad_setting->setting->GetValue();
+  }
+  else if (control->GetLabelText() == "Relative Input")
+  {
+    EnableSettingControl("IR", "Dead Zone", pad_setting->setting->GetValue());
+  }
 }
 
 void GamepadPage::AdjustControlOption(wxCommandEvent&)
@@ -846,7 +884,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
     for (auto& groupSetting : group->boolean_settings)
     {
       auto* checkbox = new PadSettingCheckBox(parent, groupSetting.get());
-      checkbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustSetting, eventsink);
+      checkbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustBooleanSetting, eventsink);
       options.push_back(checkbox);
       Add(checkbox->wxcontrol, 0, wxALL | wxLEFT, 5);
     }
@@ -944,15 +982,9 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
     for (auto& groupSetting : group->boolean_settings)
     {
       PadSettingCheckBox* setting_cbox = new PadSettingCheckBox(parent, groupSetting.get());
+      setting_cbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustBooleanSetting, eventsink);
       if (groupSetting->m_name == "Iterative Input")
-      {
-        setting_cbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustSettingUI, eventsink);
         groupSetting->SetValue(false);
-      }
-      else
-      {
-        setting_cbox->wxcontrol->Bind(wxEVT_CHECKBOX, &GamepadPage::AdjustSetting, eventsink);
-      }
       options.push_back(setting_cbox);
       Add(setting_cbox->wxcontrol, 0, wxALL | wxLEFT, 5);
     }

--- a/Source/Core/DolphinWX/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/InputConfigDiag.h
@@ -68,6 +68,7 @@ public:
                                   (int)(_setting->GetValue() * 100))),
         setting(_setting)
   {
+    wxcontrol->SetLabel(setting->m_name);
   }
 
   void UpdateGUI() override;
@@ -222,8 +223,9 @@ public:
   void LoadDefaults(wxCommandEvent& event);
 
   void AdjustControlOption(wxCommandEvent& event);
+  void EnableSettingControl(const std::string& group_name, const std::string& name, bool enabled);
   void AdjustSetting(wxCommandEvent& event);
-  void AdjustSettingUI(wxCommandEvent& event);
+  void AdjustBooleanSetting(wxCommandEvent& event);
 
   void GetProfilePath(std::string& path);
 

--- a/Source/Core/DolphinWX/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/InputConfigDiag.h
@@ -165,9 +165,10 @@ class ControlButton : public wxButton
 {
 public:
   ControlButton(wxWindow* const parent, ControllerInterface::ControlReference* const _ref,
-                const unsigned int width, const std::string& label = "");
+                const std::string& name, const unsigned int width, const std::string& label = "");
 
   ControllerInterface::ControlReference* const control_reference;
+  const std::string m_name;
 };
 
 class ControlGroupBox : public wxBoxSizer
@@ -223,7 +224,8 @@ public:
   void LoadDefaults(wxCommandEvent& event);
 
   void AdjustControlOption(wxCommandEvent& event);
-  void EnableSettingControl(const std::string& group_name, const std::string& name, bool enabled);
+  void EnablePadSetting(const std::string& group_name, const std::string& name, bool enabled);
+  void EnableControlButton(const std::string& group_name, const std::string& name, bool enabled);
   void AdjustSetting(wxCommandEvent& event);
   void AdjustBooleanSetting(wxCommandEvent& event);
 

--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -299,6 +299,8 @@ ControllerEmu::Cursor::Cursor(const std::string& _name)
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.5));
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Height"), 0.5));
+  numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 20));
+  boolean_settings.emplace_back(std::make_unique<BooleanSetting>(_trans("Relative Input"), false));
 }
 
 void ControllerEmu::LoadDefaults(const ControllerInterface& ciface)

--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -295,6 +295,7 @@ ControllerEmu::Cursor::Cursor(const std::string& _name)
   controls.emplace_back(std::make_unique<Input>("Forward"));
   controls.emplace_back(std::make_unique<Input>("Backward"));
   controls.emplace_back(std::make_unique<Input>(_trans("Hide")));
+  controls.emplace_back(std::make_unique<Input>("Recenter"));
 
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Center"), 0.5));
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Width"), 0.5));

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "Common/IniFile.h"
+#include "Common/MathUtil.h"
 #include "Core/ConfigManager.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCPadStatus.h"
@@ -424,12 +425,36 @@ public:
           yy += (numeric_settings[0]->GetValue() - 0.5);
         }
 
-        *x = xx;
-        *y = yy;
+        // relative input
+        if (boolean_settings[0]->GetValue())
+        {
+          const ControlState deadzone = numeric_settings[3]->GetValue();
+          // deadzone to avoid the cursor slowly drifting
+          if (std::abs(xx) > deadzone)
+            m_x = MathUtil::Clamp(m_x + xx * SPEED_MULTIPLIER, -1.0, 1.0);
+          if (std::abs(yy) > deadzone)
+            m_y = MathUtil::Clamp(m_y + yy * SPEED_MULTIPLIER, -1.0, 1.0);
+        }
+        else
+        {
+          m_x = xx;
+          m_y = yy;
+        }
+
+        *x = m_x;
+        *y = m_y;
       }
     }
 
     ControlState m_z;
+
+  private:
+    // This is used to reduce the cursor speed for relative input
+    // to something that makes sense with the default range.
+    static constexpr double SPEED_MULTIPLIER = 0.04;
+
+    ControlState m_x = 0.0;
+    ControlState m_y = 0.0;
   };
 
   class Extension : public ControlGroup

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -434,6 +434,13 @@ public:
             m_x = MathUtil::Clamp(m_x + xx * SPEED_MULTIPLIER, -1.0, 1.0);
           if (std::abs(yy) > deadzone)
             m_y = MathUtil::Clamp(m_y + yy * SPEED_MULTIPLIER, -1.0, 1.0);
+
+          // recenter
+          if (controls[7]->control_ref->State() > 0.5)
+          {
+            m_x = 0.0;
+            m_y = 0.0;
+          }
         }
         else
         {


### PR DESCRIPTION
This adds an option to enable relative input for the Wiimote IR as described in [issue 9014](https://bugs.dolphin-emu.org/issues/9014).

Enabling it will result in the pointer not going back to the centre and the inputs will control the direction, not the absolute position.

Also adds a Dead Zone setting which is really needed when relative input is enabled to prevent the cursor from slowly drifting on most controllers. (Note: the Deadzone setting has no effect when relative input is disabled, so the field is disabled when relative input is disabled)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4010)
<!-- Reviewable:end -->
