### PR TITLE
Clarify Boot from DVD Message

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -732,10 +732,10 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       if (pVolume == nullptr)
       {
         if (bootDrive)
-          PanicAlertT("Could not read \"%s\".  "
-                      "There is no disc in the drive, or it is not a GC/Wii backup.  "
-                      "Please note that original GameCube and Wii discs cannot be read "
-                      "by most PC DVD drives.",
+          PanicAlertT("Could not read \"%s\". "
+                      "There is no disc in the drive or it is not a GameCube/Wii backup. "
+                      "Please note that Dolphin cannot play games directly from the original "
+                      "GameCube and Wii discs.",
                       m_strFilename.c_str());
         else
           PanicAlertT("\"%s\" is an invalid GCM/ISO file, or is not a GC/Wii ISO.",


### PR DESCRIPTION
The Boot from DVD Backup message I found a bit misleading as it could imply that Dolphin can play games off the original game discs if you owned certain DVD drives (which is still a fairly common misconception). I also made some minor grammatical changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4012)
<!-- Reviewable:end -->
