### PR TITLE
Drop Dolphin patch to wxWidgets (and fix issues)

### DIFF
--- a/Externals/wxWidgets3/src/gtk/window.cpp
+++ b/Externals/wxWidgets3/src/gtk/window.cpp
@@ -3072,9 +3072,7 @@ void wxWindowGTK::DoSetClientSize( int width, int height )
 
     const wxSize size = GetSize();
     const wxSize clientSize = GetClientSize();
-    // XXX: Dolphin: This is an internal call, it should never trigger the SetSize path in derived classes.
-    //      This fixes wxAuiToolbar setting itself to 21 pixels wide regardless of content.
-    wxWindowGTK::DoSetSize(wxDefaultCoord, wxDefaultCoord, width + (size.x - clientSize.x), height + (size.y - clientSize.y), wxSIZE_USE_EXISTING);
+    SetSize(width + (size.x - clientSize.x), height + (size.y - clientSize.y));
 }
 
 void wxWindowGTK::DoGetClientSize( int *width, int *height ) const

--- a/Externals/wxWidgets3/src/osx/window_osx.cpp
+++ b/Externals/wxWidgets3/src/osx/window_osx.cpp
@@ -1212,8 +1212,7 @@ void wxWindowMac::DoSetClientSize(int clientwidth, int clientheight)
         GetClientSize( &currentclientwidth , &currentclientheight ) ;
         GetSize( &currentwidth , &currentheight ) ;
 
-	   // XXX: Dolphin. Do not allow internal semantic call to become visible to derived classes.
-        wxWindowMac::DoSetSize( wxDefaultCoord , wxDefaultCoord , currentwidth + clientwidth - currentclientwidth ,
+        DoSetSize( wxDefaultCoord , wxDefaultCoord , currentwidth + clientwidth - currentclientwidth ,
             currentheight + clientheight - currentclientheight , wxSIZE_USE_EXISTING ) ;
     }
 }

--- a/Source/Core/DolphinWX/AuiToolBar.h
+++ b/Source/Core/DolphinWX/AuiToolBar.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <wx/aui/auibar.h>
+#include <wx/window.h>
+
+// This fixes wxAuiToolBar setting itself to 21 pixels wide regardless of content
+// because of a wxWidgets issue as described here: https://dolp.in/pr4013#issuecomment-233096214
+// It overrides DoSetSize() to remove the clamping in the original WX code
+// which is causing display issues on Linux and OS X.
+class DolphinAuiToolBar : public wxAuiToolBar
+{
+public:
+  using wxAuiToolBar::wxAuiToolBar;
+
+protected:
+  void DoSetSize(int x, int y, int width, int height, int size_flags) override
+  {
+    wxWindow::DoSetSize(x, y, width, height, size_flags);
+  }
+};

--- a/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
@@ -4,7 +4,6 @@
 
 // clang-format off
 #include <wx/bitmap.h>
-#include <wx/aui/auibar.h>
 #include <wx/aui/framemanager.h>
 #include <wx/image.h>
 #include <wx/listbase.h>
@@ -23,14 +22,15 @@
 #include "DolphinWX/Debugger/BreakpointWindow.h"
 #include "DolphinWX/Debugger/CodeWindow.h"
 #include "DolphinWX/Debugger/MemoryCheckDlg.h"
+#include "DolphinWX/AuiToolBar.h"
 #include "DolphinWX/WxUtils.h"
 
-class CBreakPointBar : public wxAuiToolBar
+class CBreakPointBar : public DolphinAuiToolBar
 {
 public:
   CBreakPointBar(CBreakPointWindow* parent, const wxWindowID id)
-      : wxAuiToolBar(parent, id, wxDefaultPosition, wxDefaultSize,
-                     wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_TEXT)
+      : DolphinAuiToolBar(parent, id, wxDefaultPosition, wxDefaultSize,
+                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_TEXT)
   {
     SetToolBitmapSize(wxSize(24, 24));
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -8,7 +8,6 @@
 
 // clang-format off
 #include <wx/bitmap.h>
-#include <wx/aui/auibar.h>
 #include <wx/image.h>
 #include <wx/listbox.h>
 #include <wx/menu.h>
@@ -19,6 +18,7 @@
 #include <wx/textdlg.h>
 #include <wx/thread.h>
 #include <wx/toolbar.h>
+#include <wx/aui/auibar.h>
 #include <wx/aui/dockart.h>
 // clang-format on
 
@@ -45,6 +45,7 @@
 #include "DolphinWX/Debugger/JitWindow.h"
 #include "DolphinWX/Debugger/RegisterWindow.h"
 #include "DolphinWX/Debugger/WatchWindow.h"
+#include "DolphinWX/AuiToolBar.h"
 #include "DolphinWX/Frame.h"
 #include "DolphinWX/Globals.h"
 #include "DolphinWX/WxUtils.h"
@@ -74,8 +75,8 @@ CCodeWindow::CCodeWindow(const SConfig& _LocalCoreStartupParameter, CFrame* pare
   callers = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_SORT);
   callers->Bind(wxEVT_LISTBOX, &CCodeWindow::OnCallersListChange, this);
 
-  m_aui_toolbar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-                                   wxAUI_TB_HORIZONTAL | wxAUI_TB_PLAIN_BACKGROUND);
+  m_aui_toolbar = new DolphinAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                                        wxAUI_TB_HORIZONTAL | wxAUI_TB_PLAIN_BACKGROUND);
 
   wxSearchCtrl* const address_searchctrl = new wxSearchCtrl(m_aui_toolbar, IDM_ADDRBOX);
   address_searchctrl->Bind(wxEVT_TEXT, &CCodeWindow::OnAddrBoxChange, this);

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -23,7 +23,7 @@ class DSPDebuggerLLE;
 class GFXDebuggerPanel;
 struct SConfig;
 
-class wxAuiToolBar;
+class DolphinAuiToolBar;
 class wxListBox;
 class wxMenu;
 class wxMenuBar;
@@ -125,5 +125,5 @@ private:
   Common::Event sync_event;
 
   wxAuiManager m_aui_manager;
-  wxAuiToolBar* m_aui_toolbar;
+  DolphinAuiToolBar* m_aui_toolbar;
 };

--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdio>
 #include <wx/artprov.h>
-#include <wx/aui/auibar.h>
 #include <wx/aui/auibook.h>
 #include <wx/aui/framemanager.h>
 #include <wx/listbox.h>
@@ -20,6 +19,7 @@
 #include "Core/HW/DSPLLE/DSPDebugInterface.h"
 #include "Core/HW/DSPLLE/DSPSymbols.h"
 #include "Core/Host.h"
+#include "DolphinWX/AuiToolBar.h"
 #include "DolphinWX/Debugger/CodeView.h"
 #include "DolphinWX/Debugger/DSPDebugWindow.h"
 #include "DolphinWX/Debugger/DSPRegisterView.h"
@@ -42,7 +42,7 @@ DSPDebuggerLLE::DSPDebuggerLLE(wxWindow* parent, wxWindowID id)
   m_mgr.SetFlags(wxAUI_MGR_DEFAULT | wxAUI_MGR_LIVE_RESIZE);
 
   m_Toolbar =
-      new wxAuiToolBar(this, ID_TOOLBAR, wxDefaultPosition, wxDefaultSize, wxAUI_TB_HORZ_TEXT);
+      new DolphinAuiToolBar(this, ID_TOOLBAR, wxDefaultPosition, wxDefaultSize, wxAUI_TB_HORZ_TEXT);
   m_Toolbar->AddTool(ID_RUNTOOL, _("Pause"),
                      wxArtProvider::GetBitmap(wxART_TICK_MARK, wxART_OTHER, wxSize(10, 10)));
   m_Toolbar->AddTool(ID_STEPTOOL, _("Step"),

--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.h
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.h
@@ -14,7 +14,7 @@ class DSPRegisterView;
 class CCodeView;
 class CMemoryView;
 class wxAuiNotebook;
-class wxAuiToolBar;
+class DolphinAuiToolBar;
 class wxListBox;
 
 class DSPDebuggerLLE : public wxPanel
@@ -45,7 +45,7 @@ private:
 
   // GUI items
   wxAuiManager m_mgr;
-  wxAuiToolBar* m_Toolbar;
+  DolphinAuiToolBar* m_Toolbar;
   CCodeView* m_CodeView;
   CMemoryView* m_MemView;
   DSPRegisterView* m_Regs;

--- a/Source/Core/DolphinWX/Debugger/WatchWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchWindow.cpp
@@ -6,7 +6,6 @@
 
 // clang-format off
 #include <wx/bitmap.h>
-#include <wx/aui/auibar.h>
 #include <wx/panel.h>
 // clang-format on
 
@@ -16,14 +15,15 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "DolphinWX/Debugger/WatchView.h"
 #include "DolphinWX/Debugger/WatchWindow.h"
+#include "DolphinWX/AuiToolBar.h"
 #include "DolphinWX/WxUtils.h"
 
-class CWatchToolbar : public wxAuiToolBar
+class CWatchToolbar : public DolphinAuiToolBar
 {
 public:
   CWatchToolbar(CWatchWindow* parent, const wxWindowID id)
-      : wxAuiToolBar(parent, id, wxDefaultPosition, wxDefaultSize,
-                     wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_TEXT)
+      : DolphinAuiToolBar(parent, id, wxDefaultPosition, wxDefaultSize,
+                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_TEXT)
   {
     SetToolBitmapSize(wxSize(16, 16));
 


### PR DESCRIPTION
This removes a Dolphin-specific patch to the wxWidgets3 code
for the following reasons:

* Calling wxWindowGTK::DoSetSize on a top-level window can end up
  calling wxTopLevelWindowGTK::DoMoveWindow, which triggers an assert
  because it is not supposed to be called for a top-level wxWindow.

* We should not be patching the wxWidgets code because that means the
  toolbars will still be broken if someone builds without using the
  WX that is in our Externals.

Instead, we now use a derived class for wxAuiToolBar and override
DoSetSize() to remove the problematic behaviour to get the same effect
(fixing toolbars) but without changing Externals code and without
potentially causing asserts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4013)
<!-- Reviewable:end -->
