### PR TITLE
WX: Fix pop-under (win) / game list garbage (win) / language support (Linux)

### DIFF
--- a/Externals/wxWidgets3/build/msw/wx_base.vcxproj
+++ b/Externals/wxWidgets3/build/msw/wx_base.vcxproj
@@ -1273,7 +1273,9 @@
     <ClCompile Include="..\..\src\msw\printwin.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\src\msw\progdlg.cpp" />
+    <ClCompile Include="..\..\src\msw\progdlg.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\msw\radiobox.cpp" />
     <ClCompile Include="..\..\src\msw\radiobut.cpp" />
     <ClCompile Include="..\..\src\msw\regconf.cpp" />

--- a/Externals/wxWidgets3/wx/wxmsw.h
+++ b/Externals/wxWidgets3/wx/wxmsw.h
@@ -1209,7 +1209,7 @@
 
 // Set to 0 to disable the use of the native progress dialog (currently only
 // available under MSW and suffering from some bugs there, hence this option).
-#define wxUSE_NATIVE_PROGRESSDLG 1
+#define wxUSE_NATIVE_PROGRESSDLG 0
 
 // support for startup tips (wxShowTip &c)
 #define wxUSE_STARTUP_TIPS 1

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -173,6 +173,13 @@ CGameListCtrl::CGameListCtrl(wxWindow* parent, const wxWindowID id, const wxPoin
   Bind(wxEVT_MENU, &CGameListCtrl::OnChangeDisc, this, IDM_LIST_CHANGE_DISC);
 
   wxTheApp->Bind(DOLPHIN_EVT_LOCAL_INI_CHANGED, &CGameListCtrl::OnLocalIniModified, this);
+
+#ifdef _WIN32
+  // Default Windows Themes (Aero, Win10) draw column separators which do not appear when
+  // using the default unthemed appearance. This is a new behavior in wx3.1 since wx3.0
+  // and lower did not support themes at all.
+  EnableSystemTheme(false);
+#endif
 }
 
 CGameListCtrl::~CGameListCtrl()

--- a/Source/Core/DolphinWX/GameListCtrl.h
+++ b/Source/Core/DolphinWX/GameListCtrl.h
@@ -61,6 +61,10 @@ public:
     NUMBER_OF_COLUMN
   };
 
+#ifdef __WXMSW__
+  bool MSWOnNotify(int id, WXLPARAM lparam, WXLPARAM* result) override;
+#endif
+
 private:
   std::vector<int> m_FlagImageIndex;
   std::vector<int> m_PlatformImageIndex;

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -307,11 +307,11 @@ void DolphinApp::InitLanguageSupport()
     m_locale.reset(new wxLocale(language));
 
 // Specify where dolphins *.gmo files are located on each operating system
-#ifdef _WIN32
+#ifdef __WXMSW__
     m_locale->AddCatalogLookupPathPrefix(StrToWxStr(File::GetExeDirectory() + DIR_SEP "Languages"));
-#elif defined(__LINUX__)
+#elif defined(__WXGTK__)
     m_locale->AddCatalogLookupPathPrefix(StrToWxStr(DATA_DIR "../locale"));
-#elif defined(__APPLE__)
+#elif defined(__WXOSX__)
     m_locale->AddCatalogLookupPathPrefix(
         StrToWxStr(File::GetBundleDirectory() + "Contents/Resources"));
 #endif


### PR DESCRIPTION
Problems:
 - Pop-under is caused by wxWidgets not knowing how to use task dialogs correctly. It creates the progress dialog from `CGameListCtrl::ScanForISOs` on another thread with no parent. This causes the task dialog to bond with the Desktop window (i.e. windows explorer) while Dolphin is starting so when the dialog closes it brings its "parent" to the front causing Dolphin to be lowered underneath.
  - I reverted `CGameListCtrl` to use the generic platform independent progress dialog (wx3.0 behavior). Patching the internals of `wxProgressDialog` is difficult because parenting the task dialog causes the Input Queues from the main thread and the helper thread to become Attached which triggers a deadlock when the main thread blocks waiting for the dialog thread to close.
 - Columns have vertical ruler lines when System Themes are enabled on `wxListCtrl` on Windows. This is new and doesn't seem to look very good (RFC?) so I've reimplemented `NM_CUSTOMDRAW` to eliminate them.
 - Localisation broke on Linux because `__LINUX__` is not a real platform macro. Swapped it for `__WXGTK__` instead (which will also work on BSD).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4015)
<!-- Reviewable:end -->
