### PR TITLE
Netplay: Fix synchronization for the Wiinote netplay

### DIFF
--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -89,8 +89,6 @@ public:
   u8 InGamePadToLocalPad(u8 ingame_pad);
   u8 LocalPadToInGamePad(u8 localPad);
 
-  u8 LocalWiimoteToInGameWiimote(u8 local_pad);
-
   static void SendTimeBase();
   bool DoAllPlayersHaveGame();
 
@@ -109,7 +107,6 @@ protected:
 
   std::array<Common::FifoQueue<GCPadStatus>, 4> m_pad_buffer;
   std::array<Common::FifoQueue<NetWiimote>, 4> m_wiimote_buffer;
-  std::array<u32, 4> m_wiimote_current_data_size;
 
   NetPlayUI* m_dialog = nullptr;
 


### PR DESCRIPTION
The old implementation always polled the local 1st Wiimote and used that as input for the Wiimote that is mapped to the player. But the reporting mode for Wiimotes can be different, even when using the same extensions. So an input for Wiimote 1 with a data size 4 could be used for Wiimote 2, which actually requires data size 7 at that time for example.

The 2nd problem was that the code added a dummy input into the buffer, when the reporting mode changed. But when the data from the other player hasn't arrived yet, the data in the buffer is out of order. Well, i think this is the problem, i'm not 100% sure, because i don't fully understand how the buffer works. But on the other hand, i'm pretty sure this will just force sync the players on reporting mode changes, instead of allowing them to be apart.

Pros:
- No more desyncs caused by big bugs in the code.
- Can use different extensions for different players.

Cons:
- Higher latency, because instead of polling 1 controller per player at once, all controllers are polled in order, send to the other players, before the next is processed.
- Have to setup the Wiimote, which the player is going to use, instead of the 1st one.

Now, if the controller config could temporarily be overridden with the one from another slot, the 2nd problem could be fixed. But at the same time, we would lose the ability to use different extensions. (unless we hack around it somehow, or properly send the used extension to the other players)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4016)
<!-- Reviewable:end -->
