### PR TITLE
POSIX includes portability

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -6,6 +6,11 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#ifndef _WIN32
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <poll.h>
+#endif
 
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"

--- a/Source/Core/Core/IPC_HLE/WII_Socket.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #ifndef _WIN32
+#include <arpa/inet.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
POSIX specifies that inet_ntoa() is declared in arpa/inet.h, and that
POLLRDNORM, etc. are defined in poll.h.

gethostbyname() is not specified by POSIX, but the manpages in OpenBSD,
FreeBSD, OS X, and glibc all state that it is declared in netdb.h.

Without these headers, the build fails on OpenBSD and possibly other
POSIX-conforming systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4019)
<!-- Reviewable:end -->
