### PR TITLE
Use the standard stat()/fstat() interfaces, not nonstandard *64().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,15 @@ else()
 	add_definitions(-DDATA_DIR="${datadir}/")
 endif()
 
+# Set file offset size to 64 bits.
+#
+# On modern Unixes, this is typically already the case. The lone exception is
+# glibc, which may default to 32 bits. glibc allows this to be configured
+# by setting _FILE_OFFSET_BITS.
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+	add_definitions(-D_FILE_OFFSET_BITS=64)
+endif()
+
 # Set where the binary files will be built.  The program will not execute from
 # here.  You must run "make install" to install these to the proper location
 # as defined above.

--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -84,8 +84,8 @@ inline u64 _rotr64(u64 x, unsigned int shift)
 #define fseeko _fseeki64
 #define ftello _ftelli64
 #define atoll _atoi64
-#define stat64 _stat64
-#define fstat64 _fstat64
+#define stat _stat64
+#define fstat _fstat64
 #define fileno _fileno
 
 extern "C" {

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -45,11 +45,6 @@
 #define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
 #endif
 
-#if defined BSD4_4 || defined __FreeBSD__
-#define stat64 stat
-#define fstat64 fstat
-#endif
-
 // This namespace has various generic functions related to files and paths.
 // The code still needs a ton of cleanup.
 // REMEMBER: strdup considered harmful!
@@ -69,7 +64,7 @@ static void StripTailDirSlashes(std::string& fname)
 // Returns true if file filename exists
 bool Exists(const std::string& filename)
 {
-  struct stat64 file_info;
+  struct stat file_info;
 
   std::string copy(filename);
   StripTailDirSlashes(copy);
@@ -77,7 +72,7 @@ bool Exists(const std::string& filename)
 #ifdef _WIN32
   int result = _tstat64(UTF8ToTStr(copy).c_str(), &file_info);
 #else
-  int result = stat64(copy.c_str(), &file_info);
+  int result = stat(copy.c_str(), &file_info);
 #endif
 
   return (result == 0);
@@ -86,7 +81,7 @@ bool Exists(const std::string& filename)
 // Returns true if filename is a directory
 bool IsDirectory(const std::string& filename)
 {
-  struct stat64 file_info;
+  struct stat file_info;
 
   std::string copy(filename);
   StripTailDirSlashes(copy);
@@ -94,7 +89,7 @@ bool IsDirectory(const std::string& filename)
 #ifdef _WIN32
   int result = _tstat64(UTF8ToTStr(copy).c_str(), &file_info);
 #else
-  int result = stat64(copy.c_str(), &file_info);
+  int result = stat(copy.c_str(), &file_info);
 #endif
 
   if (result < 0)
@@ -381,11 +376,11 @@ u64 GetSize(const std::string& filename)
     return 0;
   }
 
-  struct stat64 buf;
+  struct stat buf;
 #ifdef _WIN32
   if (_tstat64(UTF8ToTStr(filename).c_str(), &buf) == 0)
 #else
-  if (stat64(filename.c_str(), &buf) == 0)
+  if (stat(filename.c_str(), &buf) == 0)
 #endif
   {
     DEBUG_LOG(COMMON, "GetSize: %s: %lld", filename.c_str(), (long long)buf.st_size);
@@ -399,8 +394,8 @@ u64 GetSize(const std::string& filename)
 // Overloaded GetSize, accepts file descriptor
 u64 GetSize(const int fd)
 {
-  struct stat64 buf;
-  if (fstat64(fd, &buf) != 0)
+  struct stat buf;
+  if (fstat(fd, &buf) != 0)
   {
     ERROR_LOG(COMMON, "GetSize: stat failed %i: %s", fd, GetLastErrorMsg().c_str());
     return 0;


### PR DESCRIPTION
Most modern Unix environments use 64-bit off_t by default: OpenBSD,
FreeBSD, OS X, and Linux libc implementations such as Musl.

glibc is the lone exception; it can default to 32 bits but this is
configurable by setting _FILE_OFFSET_BITS.

Avoiding the stat64()/fstat64() interfaces is desirable because they
are nonstandard and not implemented on many systems (including
OpenBSD and FreeBSD), and using 64 bits for stat()/fstat() is either
the default or trivial to set up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4020)
<!-- Reviewable:end -->
