### PR TITLE
DolphinWX: Center the links in the About dialog

### DIFF
--- a/Source/Core/DolphinWX/AboutDolphin.cpp
+++ b/Source/Core/DolphinWX/AboutDolphin.cpp
@@ -82,16 +82,19 @@ AboutDolphin::AboutDolphin(wxWindow* parent, wxWindowID id, const wxString& titl
   Copyright->SetFont(CopyrightFont);
   Copyright->SetFocus();
 
+  wxSizerFlags center_flag;
+  center_flag.Center();
+
   wxBoxSizer* const sCheckUpdates = new wxBoxSizer(wxHORIZONTAL);
-  sCheckUpdates->Add(UpdateText);
-  sCheckUpdates->Add(Download);
+  sCheckUpdates->Add(UpdateText, center_flag);
+  sCheckUpdates->Add(Download, center_flag);
 
   wxBoxSizer* const sLinks = new wxBoxSizer(wxHORIZONTAL);
-  sLinks->Add(License);
-  sLinks->Add(FirstSpacer);
-  sLinks->Add(Authors);
-  sLinks->Add(SecondSpacer);
-  sLinks->Add(Support);
+  sLinks->Add(License, center_flag);
+  sLinks->Add(FirstSpacer, center_flag);
+  sLinks->Add(Authors, center_flag);
+  sLinks->Add(SecondSpacer, center_flag);
+  sLinks->Add(Support, center_flag);
 
   wxBoxSizer* const sInfo = new wxBoxSizer(wxVERTICAL);
   sInfo->Add(Dolphin);


### PR DESCRIPTION
This makes the links explicitly vertically centered in the DolphinWX
About dialog. It is not needed on Windows, because the links have the
same height as text (and look just like text links). However, this is
required on other platforms or the links would look misaligned.

Before:

![Before](https://cloud.githubusercontent.com/assets/4209061/16903009/93285332-4c71-11e6-85d3-89a0605c3d12.png)

After:

![Fixed](https://cloud.githubusercontent.com/assets/4209061/16903007/6e471382-4c71-11e6-8659-aa13b8af5faa.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4022)
<!-- Reviewable:end -->
