### PR TITLE
Clean up context definition errors.

### DIFF
--- a/Source/Core/Core/MachineContext.h
+++ b/Source/Core/Core/MachineContext.h
@@ -116,6 +116,30 @@ typedef mcontext_t SContext;
 #else
 #error No context definition for architecture
 #endif
+#elif defined(__OpenBSD__)
+#include <signal.h>
+typedef ucontext_t SContext;
+#if _M_X86_64
+#define CTX_RAX sc_rax
+#define CTX_RBX sc_rbx
+#define CTX_RCX sc_rcx
+#define CTX_RDX sc_rdx
+#define CTX_RDI sc_rdi
+#define CTX_RSI sc_rsi
+#define CTX_RBP sc_rbp
+#define CTX_RSP sc_rsp
+#define CTX_R8 sc_r8
+#define CTX_R9 sc_r9
+#define CTX_R10 sc_r10
+#define CTX_R11 sc_r11
+#define CTX_R12 sc_r12
+#define CTX_R13 sc_r13
+#define CTX_R14 sc_r14
+#define CTX_R15 sc_r15
+#define CTX_RIP sc_rip
+#else
+#error No context definition for architecture
+#endif
 #elif defined(__NetBSD__)
 #include <ucontext.h>
 typedef mcontext_t SContext;

--- a/Source/Core/Core/MachineContext.h
+++ b/Source/Core/Core/MachineContext.h
@@ -114,7 +114,7 @@ typedef mcontext_t SContext;
 #define CTX_SP sp
 #define CTX_PC pc
 #else
-#warning No context definition for OS
+#error No context definition for OS
 #endif
 #elif defined(__NetBSD__)
 #include <ucontext.h>
@@ -164,6 +164,8 @@ typedef mcontext_t SContext;
 #else
 #error No context definition for OS
 #endif
+#else
+#error No context definition for OS
 #endif
 
 #if _M_X86_64

--- a/Source/Core/Core/MachineContext.h
+++ b/Source/Core/Core/MachineContext.h
@@ -34,7 +34,7 @@ typedef CONTEXT SContext;
 #define CTX_R15 R15
 #define CTX_RIP Rip
 #else
-#error No context definition for OS
+#error No context definition for architecture
 #endif
 #elif defined(__APPLE__) && !defined(USE_SIGACTION_ON_APPLE)
 // for modules:
@@ -63,7 +63,7 @@ typedef x86_thread_state64_t SContext;
 #define CTX_R15 __r15
 #define CTX_RIP __rip
 #else
-#error No context definition for OS
+#error No context definition for architecture
 #endif
 #elif defined(__APPLE__)
 #include <signal.h>
@@ -114,7 +114,7 @@ typedef mcontext_t SContext;
 #define CTX_SP sp
 #define CTX_PC pc
 #else
-#error No context definition for OS
+#error No context definition for architecture
 #endif
 #elif defined(__NetBSD__)
 #include <ucontext.h>
@@ -138,7 +138,7 @@ typedef mcontext_t SContext;
 #define CTX_R15 __gregs[_REG_R15]
 #define CTX_RIP __gregs[_REG_RIP]
 #else
-#error No context definition for OS
+#error No context definition for architecture
 #endif
 #elif defined(__FreeBSD__)
 #include <ucontext.h>
@@ -162,7 +162,7 @@ typedef mcontext_t SContext;
 #define CTX_R15 mc_r15
 #define CTX_RIP mc_rip
 #else
-#error No context definition for OS
+#error No context definition for architecture
 #endif
 #else
 #error No context definition for OS

--- a/Source/Core/Core/MemTools.cpp
+++ b/Source/Core/Core/MemTools.cpp
@@ -248,8 +248,12 @@ static void sigsegv_handler(int sig, siginfo_t* info, void* raw_context)
   }
   uintptr_t bad_address = (uintptr_t)info->si_addr;
 
-  // Get all the information we can out of the context.
+// Get all the information we can out of the context.
+#ifdef __OpenBSD__
+  ucontext_t* ctx = context;
+#else
   mcontext_t* ctx = &context->uc_mcontext;
+#endif
   // assume it's not a write
   if (!JitInterface::HandleFault(bad_address,
 #ifdef __APPLE__


### PR DESCRIPTION
Add a fallback error condition when no context is defined. If there is no context definition in a non-generic build, compilation will error out anyway, but in a less obvious place.

Then define a context for OpenBSD amd64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4023)
<!-- Reviewable:end -->
