### PR TITLE
Undefine OpenBSD's system byteswap macros to pick up generic functions.

### DIFF
--- a/Source/Core/Common/CommonFuncs.h
+++ b/Source/Core/Common/CommonFuncs.h
@@ -114,7 +114,7 @@ inline u32 swap24(const u8* _data)
   return (_data[0] << 16) | (_data[1] << 8) | _data[2];
 }
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(__OpenBSD__)
 #undef swap16
 #undef swap32
 #undef swap64


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4024)
<!-- Reviewable:end -->
