### PR TITLE
Install manpages and XDG files on OpenBSD.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -999,10 +999,10 @@ add_subdirectory(Source)
 if(NOT APPLE)
 	install(DIRECTORY Data/Sys/ DESTINATION ${datadir}/sys PATTERN)
 endif()
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|Darwin")
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|OpenBSD|Darwin")
 	install(FILES Data/license.txt DESTINATION ${datadir})
 endif()
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|OpenBSD")
 	# Install the application icon and menu item
 	install(FILES Data/dolphin-emu.svg
 		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps)


### PR DESCRIPTION
I’m not really sure what the ideal is here. FreeBSD will probably want the same files. OS X will probably want the manpages but not the XDG files. Anyway, here’s what OpenBSD wants…

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4025)
<!-- Reviewable:end -->
