### PR TITLE
Fix warnings

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -100,7 +100,7 @@ static void EnqueueEvent(u64 userdata, s64 cycles_late = 0)
   Update();
 }
 
-void SDIO_EventNotify_CPUThread(u64 userdata, s64 cycles_late)
+static void SDIO_EventNotify_CPUThread(u64 userdata, s64 cycles_late)
 {
   auto device =
       static_cast<CWII_IPC_HLE_Device_sdio_slot0*>(GetDeviceByName("/dev/sdio/slot0").get());

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -80,10 +80,11 @@ public:
     class NumericSetting
     {
     public:
-      NumericSetting(const std::string& name, const ControlState default_value,
+      NumericSetting(const std::string& setting_name, const ControlState default_value,
                      const unsigned int low = 0, const unsigned int high = 100,
-                     const SettingType type = SettingType::NORMAL)
-          : m_type(type), m_name(name), m_default_value(default_value), m_low(low), m_high(high)
+                     const SettingType setting_type = SettingType::NORMAL)
+          : m_type(setting_type), m_name(setting_name), m_default_value(default_value), m_low(low),
+            m_high(high)
       {
       }
 
@@ -99,9 +100,9 @@ public:
     class BooleanSetting
     {
     public:
-      BooleanSetting(const std::string& name, const bool default_value,
-                     const SettingType type = SettingType::NORMAL)
-          : m_type(type), m_name(name), m_default_value(default_value)
+      BooleanSetting(const std::string& setting_name, const bool default_value,
+                     const SettingType setting_type = SettingType::NORMAL)
+          : m_type(setting_type), m_name(setting_name), m_default_value(default_value)
       {
       }
 
@@ -116,8 +117,8 @@ public:
     class BackgroundInputSetting : public BooleanSetting
     {
     public:
-      BackgroundInputSetting(const std::string& name)
-          : BooleanSetting(name, false, SettingType::VIRTUAL)
+      BackgroundInputSetting(const std::string& setting_name)
+          : BooleanSetting(setting_name, false, SettingType::VIRTUAL)
       {
       }
 


### PR DESCRIPTION
This fixes warnings in:
- Source/Core/InputCommon/ControllerEmu.h: avoid shadowing other
  variables (my fault, sorry)
- Source/Core/Core/IPC_HLE/WII_IPC_HLE.h: missing declaration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4027)
<!-- Reviewable:end -->
