### PR TITLE
Remove Backtrace requirement as it is not needed for building Dolphin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -902,7 +902,8 @@ if(NOT DISABLE_WX)
 			# Check for required libs
 			check_lib(GTHREAD2 gthread-2.0 gthread-2.0 glib/gthread.h REQUIRED)
 			check_lib(PANGOCAIRO pangocairo pangocairo pango/pangocairo.h REQUIRED)
-			find_package(Backtrace REQUIRED)
+
+			find_package(Backtrace)
 		elseif(WIN32)
 			add_definitions(-D__WXMSW__)
 		else()


### PR DESCRIPTION
Unless BSD handles this differently, Dolphin doesn't need Backtrace to build.

wx might need it, but then that should be addressed in the proper `CMakeLists.txt` file

Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4028)
<!-- Reviewable:end -->
