### PR TITLE
Fifo: EmulatorState should call AllowSleep instead of Wakeup when pausing (Issue 9692)

### DIFF
--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -154,7 +154,10 @@ void ExitGpuLoop()
 void EmulatorState(bool running)
 {
   s_emu_running_state.store(running);
-  s_gpu_mainloop.Wakeup();
+  if (running)
+    s_gpu_mainloop.Wakeup();
+  else
+    s_gpu_mainloop.AllowSleep();
 }
 
 void SyncGPU(SyncGPUReason reason, bool may_move_read_ptr)


### PR DESCRIPTION
`Fifo::EmulatorState` always wakes the `BlockingLoop` even when the running state is false. This produces a race condition that can cause the loop to start busy spinning while emulation is paused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4032)
<!-- Reviewable:end -->
