### PR TITLE
Disable changing Custom RTC when game is running

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -421,18 +421,10 @@ u32 CEXIIPL::GetGCTime()
     // let's keep time moving forward, regardless of what it starts at
     ltime += CoreTiming::GetTicks() / SystemTimers::GetTicksPerSecond();
   }
-  else if (SConfig::GetInstance().bEnableCustomRTC)
-  {
-    _assert_(!Core::g_want_determinism);
-    ltime = SConfig::GetInstance().m_customRTCValue;
-
-    // let's keep time moving forward, regardless of what it starts at
-    ltime += Common::Timer::GetLocalTimeSinceJan1970() - SystemTimers::GetLocalTimeOnBoot();
-  }
   else
   {
     _assert_(!Core::g_want_determinism);
-    ltime = Common::Timer::GetLocalTimeSinceJan1970();
+    ltime = Common::Timer::GetLocalTimeSinceJan1970() - SystemTimers::GetLocalTimeRTCOffset();
   }
 
   return ((u32)ltime - cJanuary2000);

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -84,7 +84,7 @@ static int s_audio_dma_period;
 static int s_ipc_hle_period;
 
 // Custom RTC
-static u64 s_localtime_on_boot;
+static s64 s_localtime_rtc_offset = 0;
 
 u32 GetTicksPerSecond()
 {
@@ -160,9 +160,9 @@ u64 GetFakeTimeBase()
          ((CoreTiming::GetTicks() - CoreTiming::GetFakeTBStartTicks()) / TIMER_RATIO);
 }
 
-u64 GetLocalTimeOnBoot()
+s64 GetLocalTimeRTCOffset()
 {
-  return s_localtime_on_boot;
+  return s_localtime_rtc_offset;
 }
 
 static void PatchEngineCallback(u64 userdata, s64 cyclesLate)
@@ -228,7 +228,11 @@ void Init()
 
   Common::Timer::IncreaseResolution();
   // store and convert localtime at boot to timebase ticks
-  s_localtime_on_boot = Common::Timer::GetLocalTimeSinceJan1970();
+  if (SConfig::GetInstance().bEnableCustomRTC)
+  {
+    s_localtime_rtc_offset =
+        Common::Timer::GetLocalTimeSinceJan1970() - SConfig::GetInstance().m_customRTCValue;
+  }
   CoreTiming::SetFakeTBStartValue((u64)(s_cpu_core_clock / TIMER_RATIO) *
                                   (u64)CEXIIPL::GetGCTime());
   CoreTiming::SetFakeTBStartTicks(CoreTiming::GetTicks());
@@ -258,7 +262,7 @@ void Init()
 void Shutdown()
 {
   Common::Timer::RestoreResolution();
-  s_localtime_on_boot = 0;
+  s_localtime_rtc_offset = 0;
 }
 
 }  // namespace

--- a/Source/Core/Core/HW/SystemTimers.h
+++ b/Source/Core/Core/HW/SystemTimers.h
@@ -45,5 +45,5 @@ u32 GetFakeDecrementer();
 void TimeBaseSet();
 u64 GetFakeTimeBase();
 // Custom RTC
-u64 GetLocalTimeOnBoot();
+s64 GetLocalTimeRTCOffset();
 }

--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -15,6 +15,7 @@
 #include <wx/timectrl.h>
 
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "DolphinWX/Config/AdvancedConfigPane.h"
 
 AdvancedConfigPane::AdvancedConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, id)
@@ -186,8 +187,17 @@ void AdvancedConfigPane::LoadCustomRTC()
   else
     m_custom_rtc_date_picker->SetRange(wxDateTime(1, wxDateTime::Jan, 2000),
                                        wxDateTime(31, wxDateTime::Dec, 2099));
-  m_custom_rtc_date_picker->Enable(custom_rtc_enabled);
-  m_custom_rtc_time_picker->Enable(custom_rtc_enabled);
+  if (Core::IsRunning())
+  {
+    m_custom_rtc_checkbox->Enable(false);
+    m_custom_rtc_date_picker->Enable(false);
+    m_custom_rtc_time_picker->Enable(false);
+  }
+  else
+  {
+    m_custom_rtc_date_picker->Enable(custom_rtc_enabled);
+    m_custom_rtc_time_picker->Enable(custom_rtc_enabled);
+  }
 }
 
 void AdvancedConfigPane::UpdateCustomRTC(time_t date, time_t time)


### PR DESCRIPTION
Because I merged #4007 too early, I missed out on a glaringly obvious issue.

This should make it so you can't actually edit custom RTC via the GUI while a game is running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4033)
<!-- Reviewable:end -->
