### PR TITLE
TAP_Win32: Use vector assign instead of resize + memcpy

### DIFF
--- a/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
@@ -321,8 +321,7 @@ bool CEXIETHERNET::SendFrame(const u8* frame, u32 size)
   }
 
   // Copy to write buffer.
-  mWriteBuffer.resize(size);
-  memcpy(mWriteBuffer.data(), frame, size);
+  mWriteBuffer.assign(frame, frame + size);
   mWritePending = true;
 
   // Queue async write.


### PR DESCRIPTION
Noticed this when doing const correctness changes. Same thing less code essentially.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4034)
<!-- Reviewable:end -->
