### PR TITLE
SI_DeviceKeyboard: const correctness

### DIFF
--- a/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
@@ -54,7 +54,7 @@ int CSIDevice_Keyboard::RunBuffer(u8* _pBuffer, int _iLength)
   return _iLength;
 }
 
-KeyboardStatus CSIDevice_Keyboard::GetKeyboardStatus()
+KeyboardStatus CSIDevice_Keyboard::GetKeyboardStatus() const
 {
   KeyboardStatus KeyStatus = {};
   Keyboard::GetStatus(ISIDevice::m_iDeviceNumber, &KeyStatus);
@@ -102,7 +102,7 @@ void CSIDevice_Keyboard::DoState(PointerWrap& p)
   p.Do(m_Counter);
 }
 
-void CSIDevice_Keyboard::MapKeys(KeyboardStatus& KeyStatus, u8* key)
+void CSIDevice_Keyboard::MapKeys(const KeyboardStatus& KeyStatus, u8* key)
 {
   u8 keys_held = 0;
   const u8 MAX_KEYS_HELD = 3;

--- a/Source/Core/Core/HW/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.h
@@ -55,8 +55,8 @@ public:
   // Return true on new data
   bool GetData(u32& _Hi, u32& _Low) override;
 
-  KeyboardStatus GetKeyboardStatus();
-  void MapKeys(KeyboardStatus& KeyStatus, u8* key);
+  KeyboardStatus GetKeyboardStatus() const;
+  void MapKeys(const KeyboardStatus& KeyStatus, u8* key);
 
   // Send a command directly
   void SendCommand(u32 _Cmd, u8 _Poll) override;


### PR DESCRIPTION
Just a minor thing I noticed while doing some cleanup related to device states. Figured I may as well stage this separately since it's not really related to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4035)
<!-- Reviewable:end -->
