### PR TITLE
WIP: Savestate spring cleaning

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SRCS Analytics.cpp
          BreakPoints.cpp
          CDUtils.cpp
+         ChunkFile.cpp
          ColorUtil.cpp
          ENetUtil.cpp
          FileSearch.cpp

--- a/Source/Core/Common/ChunkFile.cpp
+++ b/Source/Core/Common/ChunkFile.cpp
@@ -1,0 +1,105 @@
+// Copyright 2008 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Common/ChunkFile.h"
+#include "Common/StringUtil.h"
+
+PointerWrap PointerWrap::CreateForLoad(const void* start, size_t size)
+{
+  PointerWrap p;
+  p.m_ptr = (u8*)start;
+  p.m_remaining = size;
+  p.m_is_load = true;
+  p.m_is_good = true;
+  return p;
+}
+PointerWrap PointerWrap::CreateForStore(MallocBuffer initial_buffer)
+{
+  PointerWrap p;
+  p.m_buffer = std::move(initial_buffer);
+  p.m_ptr = p.m_buffer.ptr;
+  p.m_remaining = p.m_buffer.length;
+  p.m_is_load = false;
+  p.m_is_good = true;
+  return p;
+}
+
+MallocBuffer PointerWrap::TakeBuffer()
+{
+  _assert_(!m_is_load);
+  return std::move(m_buffer);
+}
+
+void PointerWrap::SetError(std::string&& error)
+{
+  m_error = std::move(error);
+  m_is_good = false;
+}
+
+void PointerWrap::SetErrorTruncatedLoad(u64 req_size)
+{
+  SetError(StringFromFormat("Truncated data; needed %llu more bytes",
+                            (unsigned long long)(req_size - m_remaining)));
+}
+
+void PointerWrap::ReallocBufferForRequestedSize(u64 req_size)
+{
+  _assert_(!m_is_load);
+  u8* base = m_buffer.ptr;
+  size_t size = m_buffer.length;
+  if ((u64)(SIZE_MAX - size) < req_size || SIZE_MAX - (size + req_size) < SLACK ||
+      !(m_buffer.ptr =
+            (u8*)realloc(m_buffer.ptr, (m_buffer.length = size + (size_t)req_size + SLACK))))
+  {
+    PanicAlertT("Out of memory saving state");
+    Crash();
+  }
+  m_ptr = m_buffer.ptr + (m_ptr - base);
+  m_remaining += req_size + SLACK;
+}
+
+void PointerWrap::DoMarker(const std::string& prevName, u32 arbitraryNumber)
+{
+  u32 cookie = arbitraryNumber;
+  Do(cookie);
+
+  if (IsLoad() && cookie != arbitraryNumber)
+  {
+    SetError(StringFromFormat("After \"%s\", found %d (0x%X) instead of save marker %d (0x%X).",
+                              prevName.c_str(), cookie, cookie, arbitraryNumber, arbitraryNumber));
+  }
+}
+
+u8* PointerWrap::GetPointerAndAdvance(u64 req_size)
+{
+  u8* here = m_ptr;
+  if (IsLoad())
+  {
+    if (req_size > m_remaining)
+    {
+      SetErrorTruncatedLoad(req_size);
+      return nullptr;
+    }
+  }
+  else
+  {
+    if (req_size > m_remaining || req_size > m_remaining + SLACK)
+      ReallocBufferForRequestedSize(req_size);
+  }
+  m_ptr = here + (size_t)req_size;
+  return here;
+}
+
+StateLoadStore StateLoadStore::CreateForLoad(const void* start, size_t size)
+{
+  StateLoadStore p;
+  p.PointerWrap::operator=(PointerWrap::CreateForLoad(start, size));
+  return p;
+}
+StateLoadStore StateLoadStore::CreateForStore(MallocBuffer initial_buffer)
+{
+  StateLoadStore p;
+  p.PointerWrap::operator=(PointerWrap::CreateForStore(std::move(initial_buffer)));
+  return p;
+}

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="Analytics.cpp" />
     <ClCompile Include="BreakPoints.cpp" />
     <ClCompile Include="CDUtils.cpp" />
+    <ClCompile Include="ChunkFile.cpp" />
     <ClCompile Include="ColorUtil.cpp" />
     <ClCompile Include="ENetUtil.cpp" />
     <ClCompile Include="FileSearch.cpp" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -228,6 +228,7 @@
   <ItemGroup>
     <ClCompile Include="BreakPoints.cpp" />
     <ClCompile Include="CDUtils.cpp" />
+    <ClCompile Include="ChunkFile.cpp" />
     <ClCompile Include="ColorUtil.cpp" />
     <ClCompile Include="ENetUtil.cpp" />
     <ClCompile Include="FileSearch.cpp" />

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -94,16 +94,20 @@ bool CreateFullPath(const std::string& fullPath);
 
 // Deletes a given filename, return true on success
 // Doesn't supports deleting a directory
-bool Delete(const std::string& filename);
+// If existed is non-null, whether filename existed is stored there, and a
+// warning isn't triggered if it didn't.
+bool Delete(const std::string& filename, bool* existed = nullptr);
 
 // Deletes a directory filename, returns true on success
 bool DeleteDir(const std::string& filename);
 
 // renames file srcFilename to destFilename, returns true on success
-bool Rename(const std::string& srcFilename, const std::string& destFilename);
+bool Rename(const std::string& srcFilename, const std::string& destFilename,
+            bool* src_existed = nullptr);
 
 // ditto, but syncs the source file and, on Unix, syncs the directories after rename
-bool RenameSync(const std::string& srcFilename, const std::string& destFilename);
+bool RenameSync(const std::string& srcFilename, const std::string& destFilename,
+                bool* src_existed = nullptr);
 
 // copies file srcFilename to destFilename, returns true on success
 bool Copy(const std::string& srcFilename, const std::string& destFilename);

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -176,12 +176,10 @@ static void EventDoState(PointerWrap& p, BaseEvent* ev)
   // we can't savestate ev->type directly because events might not get registered in the same order
   // (or at all) every time.
   // so, we savestate the event's type's name, and derive ev->type from that when loading.
-  std::string name;
-  if (p.GetMode() != PointerWrap::MODE_READ)
-    name = event_types[ev->type].name;
+  std::string name = event_types[ev->type].name;
 
   p.Do(name);
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsLoad())
   {
     bool foundMatch = false;
     for (unsigned int i = 0; i < event_types.size(); ++i)
@@ -203,7 +201,7 @@ static void EventDoState(PointerWrap& p, BaseEvent* ev)
   }
 }
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   std::lock_guard<std::mutex> lk(tsWriteLock);
   p.Do(g_slicelength);
@@ -214,8 +212,7 @@ void DoState(PointerWrap& p)
   p.Do(g_fakeTBStartValue);
   p.Do(g_fakeTBStartTicks);
   p.Do(s_lastOCFactor);
-  if (p.GetMode() == PointerWrap::MODE_READ)
-    g_lastOCFactor_inverted = 1.0f / s_lastOCFactor;
+  g_lastOCFactor_inverted = 1.0f / s_lastOCFactor;
 
   p.DoMarker("CoreTimingData");
 

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -20,7 +20,7 @@
 #include <string>
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 namespace CoreTiming
 {
@@ -41,7 +41,7 @@ typedef void (*TimedCallback)(u64 userdata, s64 cyclesLate);
 u64 GetTicks();
 u64 GetIdleTicks();
 
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 // Returns the event_type identifier. if name is not unique, an existing event_type will be
 // discarded.

--- a/Source/Core/Core/DSPEmulator.h
+++ b/Source/Core/Core/DSPEmulator.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 class DSPEmulator
 {
@@ -18,7 +18,7 @@ public:
   virtual bool Initialize(bool bWii, bool bDSPThread) = 0;
   virtual void Shutdown() = 0;
 
-  virtual void DoState(PointerWrap& p) = 0;
+  virtual void DoState(StateLoadStore& p) = 0;
   virtual void PauseAndLock(bool doLock, bool unpauseOnUnlock = true) = 0;
 
   virtual void DSP_WriteMailBoxHigh(bool _CPUMailbox, unsigned short) = 0;

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -114,7 +114,7 @@ static u64 g_CPUCyclesPerSample = 0xFFFFFFFFFFFULL;
 static unsigned int g_AISSampleRate = 48000;
 static unsigned int g_AIDSampleRate = 32000;
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.DoPOD(m_Control);
   p.DoPOD(m_Volume);

--- a/Source/Core/Core/HW/AudioInterface.h
+++ b/Source/Core/Core/HW/AudioInterface.h
@@ -8,7 +8,7 @@
 
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 namespace MMIO
 {
 class Mapping;
@@ -18,7 +18,7 @@ namespace AudioInterface
 {
 void Init();
 void Shutdown();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 bool IsPlaying();
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);

--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -6,7 +6,7 @@
 
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 class DSPEmulator;
 namespace MMIO
 {
@@ -67,7 +67,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 
 DSPEmulator* GetDSPEmulator();
 
-void DoState(PointerWrap& p);
+bool DoState(StateLoadStore& p);
 
 void GenerateDSPInterruptFromDSPEmu(DSPInterruptType _DSPInterruptType);
 

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -39,8 +39,7 @@ void DSPHLE::DSP_StopSoundStream()
 
 void DSPHLE::Shutdown()
 {
-  delete m_pUCode;
-  m_pUCode = nullptr;
+  m_pUCode.reset();
 }
 
 void DSPHLE::DSP_Update(int cycles)
@@ -67,14 +66,12 @@ void DSPHLE::SendMailToDSP(u32 _uMail)
 
 UCodeInterface* DSPHLE::GetUCode()
 {
-  return m_pUCode;
+  return m_pUCode.get();
 }
 
 void DSPHLE::SetUCode(u32 _crc)
 {
-  delete m_pUCode;
-
-  m_pUCode = nullptr;
+  m_pUCode.reset();
   m_MailHandler.Clear();
   m_pUCode = UCodeFactory(_crc, this, m_bWii);
 }
@@ -86,80 +83,27 @@ void DSPHLE::SwapUCode(u32 _crc)
 {
   m_MailHandler.Clear();
 
-  if (m_lastUCode == nullptr)
-  {
-    m_lastUCode = m_pUCode;
+  std::swap(m_lastUCode, m_pUCode);
+  if (!m_pUCode)
     m_pUCode = UCodeFactory(_crc, this, m_bWii);
-  }
-  else
-  {
-    delete m_pUCode;
-    m_pUCode = m_lastUCode;
-    m_lastUCode = nullptr;
-  }
 }
 
-void DSPHLE::DoState(PointerWrap& p)
+void DSPHLE::DoState(StateLoadStore& p)
 {
-  bool isHLE = true;
-  p.Do(isHLE);
-  if (isHLE != true && p.GetMode() == PointerWrap::MODE_READ)
-  {
-    Core::DisplayMessage("State is incompatible with current DSP engine. Aborting load state.",
-                         3000);
-    p.SetMode(PointerWrap::MODE_VERIFY);
-    return;
-  }
-
   p.DoPOD(m_DSPControl);
   p.DoPOD(m_dspState);
 
-  int ucode_crc = UCodeInterface::GetCRC(m_pUCode);
-  int ucode_crc_beforeLoad = ucode_crc;
-  int lastucode_crc = UCodeInterface::GetCRC(m_lastUCode);
-  int lastucode_crc_beforeLoad = lastucode_crc;
-
-  p.Do(ucode_crc);
-  p.Do(lastucode_crc);
-
-  // if a different type of ucode was being used when the savestate was created,
-  // we have to reconstruct the old type of ucode so that we have a valid thing to call DoState on.
-  UCodeInterface* ucode =
-      (ucode_crc == ucode_crc_beforeLoad) ? m_pUCode : UCodeFactory(ucode_crc, this, m_bWii);
-  UCodeInterface* lastucode = (lastucode_crc != lastucode_crc_beforeLoad) ?
-                                  m_lastUCode :
-                                  UCodeFactory(lastucode_crc, this, m_bWii);
-
-  if (ucode)
-    ucode->DoState(p);
-  if (lastucode)
-    lastucode->DoState(p);
-
-  // if a different type of ucode was being used when the savestate was created,
-  // discard it if we're not loading, otherwise discard the old one and keep the new one.
-  if (ucode != m_pUCode)
+  for (auto ucode_ptr : {&m_pUCode, &m_lastUCode})
   {
-    if (p.GetMode() != PointerWrap::MODE_READ)
-    {
-      delete ucode;
-    }
-    else
-    {
-      delete m_pUCode;
-      m_pUCode = ucode;
-    }
-  }
-  if (lastucode != m_lastUCode)
-  {
-    if (p.GetMode() != PointerWrap::MODE_READ)
-    {
-      delete lastucode;
-    }
-    else
-    {
-      delete m_lastUCode;
-      m_lastUCode = lastucode;
-    }
+    // if a different type of ucode was being used when the savestate was created,
+    // we have to reconstruct the old type of ucode so that we have a valid thing to call DoState
+    // on.
+    int crc = UCodeInterface::GetCRC(ucode_ptr->get()), crc_before_load = crc;
+    p.Do(crc);
+    if (p.IsLoad() && crc != crc_before_load)
+      *ucode_ptr = UCodeFactory(crc, this, m_bWii);
+    if (*ucode_ptr)
+      (*ucode_ptr)->DoState(p);
   }
 
   m_MailHandler.DoState(p);

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -8,9 +8,9 @@
 #include "Core/DSPEmulator.h"
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/MailHandler.h"
+#include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
-class PointerWrap;
-class UCodeInterface;
+class StateLoadStore;
 
 class DSPHLE : public DSPEmulator
 {
@@ -20,7 +20,7 @@ public:
   bool Initialize(bool bWii, bool bDSPThread) override;
   void Shutdown() override;
   bool IsLLE() override { return false; }
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
   void PauseAndLock(bool doLock, bool unpauseOnUnlock = true) override;
 
   void DSP_WriteMailBoxHigh(bool _CPUMailbox, unsigned short) override;
@@ -61,8 +61,8 @@ private:
   };
   DSPState m_dspState;
 
-  UCodeInterface* m_pUCode;
-  UCodeInterface* m_lastUCode;
+  std::unique_ptr<UCodeInterface> m_pUCode;
+  std::unique_ptr<UCodeInterface> m_lastUCode;
 
   DSP::UDSPControl m_DSPControl;
   CMailHandler m_MailHandler;

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.h
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.h
@@ -9,7 +9,7 @@
 
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 class CMailHandler
 {
@@ -20,7 +20,7 @@ public:
   void PushMail(u32 _Mail, bool interrupt = false);
   void Clear();
   void Halt(bool _Halt);
-  void DoState(PointerWrap& p);
+  void DoState(StateLoadStore& p);
   bool IsEmpty() const;
 
   u16 ReadDSPMailboxHigh();
@@ -28,5 +28,5 @@ public:
 
 private:
   // mail handler
-  std::queue<std::pair<u32, bool>> m_Mails;
+  std::deque<std::pair<u32, bool>> m_Mails;
 };

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -11,6 +11,7 @@
 #include "Common/MathUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/DSP.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/AXStructs.h"
 
 #define AX_GC
@@ -666,7 +667,7 @@ void AXUCode::Update()
   }
 }
 
-void AXUCode::DoAXState(PointerWrap& p)
+void AXUCode::DoAXState(StateLoadStore& p)
 {
   p.Do(m_cmdlist);
   p.Do(m_cmdlist_size);
@@ -682,7 +683,7 @@ void AXUCode::DoAXState(PointerWrap& p)
   p.Do(m_samples_auxB_surround);
 }
 
-void AXUCode::DoState(PointerWrap& p)
+void AXUCode::DoState(StateLoadStore& p)
 {
   DoStateShared(p);
   DoAXState(p);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -57,7 +57,7 @@ public:
 
   void HandleMail(u32 mail) override;
   void Update() override;
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 protected:
   enum MailType
@@ -121,7 +121,7 @@ protected:
                      u32 auxb_r_dl);
 
   // Handle save states for main AX.
-  void DoAXState(PointerWrap& p);
+  void DoAXState(StateLoadStore& p);
 
 private:
   enum CmdType

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -629,7 +629,7 @@ void AXWiiUCode::OutputWMSamples(u32* addresses)
   }
 }
 
-void AXWiiUCode::DoState(PointerWrap& p)
+void AXWiiUCode::DoState(StateLoadStore& p)
 {
   DoStateShared(p);
   DoAXState(p);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
@@ -14,7 +14,7 @@ public:
   AXWiiUCode(DSPHLE* dsphle, u32 crc);
   virtual ~AXWiiUCode();
 
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 protected:
   // Additional AUX buffers

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -7,6 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/DSP.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 void ProcessGBACrypto(u32 address)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
@@ -5,6 +5,7 @@
 #include "Core/HW/DSPHLE/UCodes/INIT.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 INITUCode::INITUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -15,6 +15,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/ROM.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
@@ -118,7 +119,7 @@ void ROMUCode::BootUCode()
   m_dsphle->SetUCode(ector_crc);
 }
 
-void ROMUCode::DoState(PointerWrap& p)
+void ROMUCode::DoState(StateLoadStore& p)
 {
   p.Do(m_current_ucode);
   p.Do(m_boot_task_num_steps);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
@@ -15,7 +15,7 @@ public:
   void HandleMail(u32 mail) override;
   void Update() override;
 
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 private:
   struct UCodeBootInfo

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
@@ -7,7 +7,6 @@
 #include <cstring>
 
 #include "Common/CommonTypes.h"
-#include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/Memmap.h"
 
 #define UCODE_ROM 0x00000000
@@ -15,7 +14,8 @@
 #define UCODE_NULL 0xFFFFFFFF
 
 class CMailHandler;
-class PointerWrap;
+class StateLoadStore;
+class DSPHLE;
 
 constexpr bool ExramRead(u32 address)
 {
@@ -65,18 +65,12 @@ inline void* HLEMemory_Get_Pointer(u32 address)
 class UCodeInterface
 {
 public:
-  UCodeInterface(DSPHLE* dsphle, u32 crc)
-      : m_mail_handler(dsphle->AccessMailHandler()), m_upload_setup_in_progress(false),
-        m_dsphle(dsphle), m_crc(crc), m_next_ucode(), m_next_ucode_steps(0),
-        m_needs_resume_mail(false)
-  {
-  }
-
+  UCodeInterface(DSPHLE* dsphle, u32 crc);
   virtual ~UCodeInterface() {}
   virtual void HandleMail(u32 mail) = 0;
   virtual void Update() = 0;
 
-  virtual void DoState(PointerWrap& p) { DoStateShared(p); }
+  virtual void DoState(StateLoadStore& p) { DoStateShared(p); }
   static u32 GetCRC(UCodeInterface* ucode) { return ucode ? ucode->m_crc : UCODE_NULL; }
 protected:
   void PrepareBootUCode(u32 mail);
@@ -86,7 +80,7 @@ protected:
   // The HLE can use this to
   bool NeedsResumeMail();
 
-  void DoStateShared(PointerWrap& p);
+  void DoStateShared(StateLoadStore& p);
 
   CMailHandler& m_mail_handler;
 
@@ -131,4 +125,4 @@ private:
   bool m_needs_resume_mail;
 };
 
-UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii);
+std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -9,6 +9,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/GBA.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
@@ -144,7 +145,7 @@ void ZeldaUCode::Update()
   }
 }
 
-void ZeldaUCode::DoState(PointerWrap& p)
+void ZeldaUCode::DoState(StateLoadStore& p)
 {
   p.Do(m_flags);
   p.Do(m_mail_current_state);
@@ -1766,7 +1767,7 @@ void ZeldaAudioRenderer::DownloadRawSamplesFromMRAM(s16* dst, VPB* vpb, u16 requ
   }
 }
 
-void ZeldaAudioRenderer::DoState(PointerWrap& p)
+void ZeldaAudioRenderer::DoState(StateLoadStore& p)
 {
   p.Do(m_flags);
   p.Do(m_prepared);

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -26,7 +26,7 @@ public:
   void SetOutputLeftBufferAddr(u32 addr) { m_output_lbuf_addr = addr; }
   void SetOutputRightBufferAddr(u32 addr) { m_output_rbuf_addr = addr; }
   void SetARAMBaseAddr(u32 addr) { m_aram_base_addr = addr; }
-  void DoState(PointerWrap& p);
+  void DoState(StateLoadStore& p);
 
 private:
   struct VPB;
@@ -191,7 +191,7 @@ public:
   void HandleMail(u32 mail) override;
   void Update() override;
 
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 private:
   // Flags that alter the behavior of the UCode. See Zelda.cpp for complete

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -38,17 +38,8 @@ static Common::Event dspEvent;
 static Common::Event ppcEvent;
 static bool requestDisableThread;
 
-void DSPLLE::DoState(PointerWrap& p)
+void DSPLLE::DoState(StateLoadStore& p)
 {
-  bool is_hle = false;
-  p.Do(is_hle);
-  if (is_hle && p.GetMode() == PointerWrap::MODE_READ)
-  {
-    Core::DisplayMessage("State is incompatible with current DSP engine. Aborting load state.",
-                         3000);
-    p.SetMode(PointerWrap::MODE_VERIFY);
-    return;
-  }
   p.Do(g_dsp.r);
   p.Do(g_dsp.pc);
 #if PROFILE
@@ -59,19 +50,15 @@ void DSPLLE::DoState(PointerWrap& p)
   p.Do(g_dsp.exceptions);
   p.Do(g_dsp.external_interrupt_waiting);
 
-  for (int i = 0; i < 4; i++)
-  {
-    p.Do(g_dsp.reg_stack[i]);
-  }
+  p.Do(g_dsp.reg_stack);
 
   p.Do(g_dsp.step_counter);
   p.DoArray(g_dsp.ifx_regs);
-  p.Do(g_dsp.mbox[0]);
-  p.Do(g_dsp.mbox[1]);
+  p.Do(g_dsp.mbox);
   UnWriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
   p.DoArray(g_dsp.iram, DSP_IRAM_SIZE);
   WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsLoad())
     DSPHost::CodeLoaded((const u8*)g_dsp.iram, DSP_IRAM_BYTE_SIZE);
   p.DoArray(g_dsp.dram, DSP_DRAM_SIZE);
   p.Do(g_cycles_left);

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.h
@@ -21,7 +21,7 @@ public:
   bool Initialize(bool bWii, bool bDSPThread) override;
   void Shutdown() override;
   bool IsLLE() override { return true; }
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
   void PauseAndLock(bool doLock, bool unpauseOnUnlock = true) override;
 
   void DSP_WriteMailBoxHigh(bool _CPUMailbox, unsigned short) override;

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -267,7 +267,7 @@ bool ExecuteReadCommand(u64 DVD_offset, u32 output_address, u32 DVD_length, u32 
 u64 SimulateDiscReadTime(u64 offset, u32 length);
 s64 CalculateRawDiscReadTime(u64 offset, s64 length);
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.DoPOD(s_DISR);
   p.DoPOD(s_DICVR);

--- a/Source/Core/Core/HW/DVDInterface.h
+++ b/Source/Core/Core/HW/DVDInterface.h
@@ -8,7 +8,7 @@
 
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 namespace DiscIO
 {
 class IVolume;
@@ -94,7 +94,7 @@ enum DIInterruptType : int
 
 void Init();
 void Shutdown();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 

--- a/Source/Core/Core/HW/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVDThread.cpp
@@ -75,7 +75,7 @@ void Stop()
   s_dvd_thread_exiting.Clear();
 }
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   WaitUntilIdle();
 

--- a/Source/Core/Core/HW/DVDThread.h
+++ b/Source/Core/Core/HW/DVDThread.h
@@ -11,7 +11,7 @@ namespace DVDThread
 {
 void Start();
 void Stop();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void WaitUntilIdle();
 void StartRead(u64 dvd_offset, u32 output_address, u32 length, bool decrypt, bool reply_to_ios,

--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -66,7 +66,7 @@ void Shutdown()
     channel.reset();
 }
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   for (auto& channel : g_Channels)
     channel->DoState(p);

--- a/Source/Core/Core/HW/EXI.h
+++ b/Source/Core/Core/HW/EXI.h
@@ -8,7 +8,7 @@
 
 class CEXIChannel;
 class IEXIDevice;
-class PointerWrap;
+class StateLoadStore;
 enum TEXIDevices : int;
 namespace MMIO
 {
@@ -24,7 +24,7 @@ namespace ExpansionInterface
 {
 void Init();
 void Shutdown();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 void PauseAndLock(bool doLock, bool unpauseOnUnlock);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);

--- a/Source/Core/Core/HW/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI_Channel.cpp
@@ -223,7 +223,7 @@ IEXIDevice* CEXIChannel::GetDevice(const u8 chip_select)
   return nullptr;
 }
 
-void CEXIChannel::DoState(PointerWrap& p)
+void CEXIChannel::DoState(StateLoadStore& p)
 {
   p.DoPOD(m_Status);
   p.Do(m_DMAMemoryAddress);

--- a/Source/Core/Core/HW/EXI_Channel.h
+++ b/Source/Core/Core/HW/EXI_Channel.h
@@ -105,7 +105,7 @@ public:
   void RemoveDevices();
 
   bool IsCausingInterrupt();
-  void DoState(PointerWrap& p);
+  void DoState(StateLoadStore& p);
   void PauseAndLock(bool doLock, bool unpauseOnUnlock);
 
   // This should only be used to transition interrupts from SP1 to Channel 2

--- a/Source/Core/Core/HW/EXI_Device.h
+++ b/Source/Core/Core/HW/EXI_Device.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 enum TEXIDevices : int
 {
@@ -42,7 +42,7 @@ public:
   virtual bool UseDelayedTransferCompletion() const { return false; }
   virtual bool IsPresent() const { return false; }
   virtual void SetCS(int) {}
-  virtual void DoState(PointerWrap&) {}
+  virtual void DoState(StateLoadStore&) {}
   virtual void PauseAndLock(bool doLock, bool unpauseOnUnlock = true) {}
   virtual IEXIDevice* FindDevice(TEXIDevices device_type, int customIndex = -1)
   {

--- a/Source/Core/Core/HW/EXI_DeviceAD16.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAD16.cpp
@@ -102,7 +102,7 @@ void CEXIAD16::TransferByte(u8& _byte)
   m_uPosition++;
 }
 
-void CEXIAD16::DoState(PointerWrap& p)
+void CEXIAD16::DoState(StateLoadStore& p)
 {
   p.Do(m_uPosition);
   p.Do(m_uCommand);

--- a/Source/Core/Core/HW/EXI_DeviceAD16.h
+++ b/Source/Core/Core/HW/EXI_DeviceAD16.h
@@ -6,7 +6,7 @@
 
 #include "Core/HW/EXI_Device.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 class CEXIAD16 : public IEXIDevice
 {
@@ -14,7 +14,7 @@ public:
   CEXIAD16();
   void SetCS(int _iCS) override;
   bool IsPresent() const override;
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 private:
   enum

--- a/Source/Core/Core/HW/EXI_DeviceAGP.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAGP.cpp
@@ -355,7 +355,7 @@ void CEXIAgp::ImmWrite(u32 _uData, u32 _uSize)
   }
 }
 
-void CEXIAgp::DoState(PointerWrap& p)
+void CEXIAgp::DoState(StateLoadStore& p)
 {
   p.Do(m_slot);
   p.Do(m_address);

--- a/Source/Core/Core/HW/EXI_DeviceAGP.h
+++ b/Source/Core/Core/HW/EXI_DeviceAGP.h
@@ -9,7 +9,7 @@
 
 #include "Core/HW/EXI_Device.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 class CEXIAgp : public IEXIDevice
 {
@@ -19,7 +19,7 @@ public:
   bool IsPresent() const override { return true; }
   void ImmWrite(u32 _uData, u32 _uSize) override;
   u32 ImmRead(u32 _uSize) override;
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 private:
   enum

--- a/Source/Core/Core/HW/EXI_DeviceAMBaseboard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceAMBaseboard.cpp
@@ -122,7 +122,7 @@ bool CEXIAMBaseboard::IsInterruptSet()
   return m_have_irq;
 }
 
-void CEXIAMBaseboard::DoState(PointerWrap& p)
+void CEXIAMBaseboard::DoState(StateLoadStore& p)
 {
   p.Do(m_position);
   p.Do(m_have_irq);

--- a/Source/Core/Core/HW/EXI_DeviceAMBaseboard.h
+++ b/Source/Core/Core/HW/EXI_DeviceAMBaseboard.h
@@ -6,7 +6,7 @@
 
 #include "Core/HW/EXI_Device.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 class CEXIAMBaseboard : public IEXIDevice
 {
@@ -16,7 +16,7 @@ public:
   void SetCS(int _iCS) override;
   bool IsPresent() const override;
   bool IsInterruptSet() override;
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 private:
   void TransferByte(u8& _uByte) override;

--- a/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
@@ -195,7 +195,7 @@ void CEXIETHERNET::DMARead(u32 addr, u32 size)
   transfer.address += size;
 }
 
-void CEXIETHERNET::DoState(PointerWrap& p)
+void CEXIETHERNET::DoState(StateLoadStore& p)
 {
   p.DoArray(tx_fifo.get(), BBA_TXFIFO_SIZE);
   p.DoArray(mBbaMem.get(), BBA_MEM_SIZE);

--- a/Source/Core/Core/HW/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.h
@@ -15,7 +15,7 @@
 #include "Common/Flag.h"
 #include "Core/HW/EXI_Device.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 // Network Control Register A
 enum NCRA
@@ -206,7 +206,7 @@ public:
   u32 ImmRead(u32 size) override;
   void DMAWrite(u32 addr, u32 size) override;
   void DMARead(u32 addr, u32 size) override;
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
   // private:
   struct

--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -140,7 +140,7 @@ CEXIIPL::~CEXIIPL()
     g_SRAM_netplay_initialized = false;
   }
 }
-void CEXIIPL::DoState(PointerWrap& p)
+void CEXIIPL::DoState(StateLoadStore& p)
 {
   p.Do(m_RTC);
   p.Do(m_uPosition);

--- a/Source/Core/Core/HW/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.h
@@ -8,7 +8,7 @@
 
 #include "Core/HW/EXI_Device.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 class CEXIIPL : public IEXIDevice
 {
@@ -18,7 +18,7 @@ public:
 
   void SetCS(int _iCS) override;
   bool IsPresent() const override;
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
   static u32 GetGCTime();
   static u64 NetPlay_GetGCTime();

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -502,7 +502,7 @@ void CEXIMemoryCard::TransferByte(u8& byte)
   DEBUG_LOG(EXPANSIONINTERFACE, "EXI MEMCARD: < %02x", byte);
 }
 
-void CEXIMemoryCard::DoState(PointerWrap& p)
+void CEXIMemoryCard::DoState(StateLoadStore& p)
 {
   // for movie sync, we need to save/load memory card contents (and other data) in savestates.
   // otherwise, we'll assume the user wants to keep their memcards and saves separate,

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
@@ -10,7 +10,7 @@
 #include "Core/HW/EXI_Device.h"
 
 class MemoryCardBase;
-class PointerWrap;
+class StateLoadStore;
 
 class CEXIMemoryCard : public IEXIDevice
 {
@@ -21,7 +21,7 @@ public:
   bool IsInterruptSet() override;
   bool UseDelayedTransferCompletion() const override;
   bool IsPresent() const override;
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
   IEXIDevice* FindDevice(TEXIDevices device_type, int customIndex = -1) override;
   void DMARead(u32 _uAddr, u32 _uSize) override;
   void DMAWrite(u32 _uAddr, u32 _uSize) override;

--- a/Source/Core/Core/HW/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard.h
@@ -73,7 +73,7 @@ public:
   virtual s32 Write(u32 destaddress, s32 length, u8* srcaddress) = 0;
   virtual void ClearBlock(u32 address) = 0;
   virtual void ClearAll() = 0;
-  virtual void DoState(PointerWrap& p) = 0;
+  virtual void DoState(StateLoadStore& p) = 0;
   u32 GetCardId() const { return nintendo_card_id; }
   bool IsAddressInBounds(u32 address) const { return address <= (memory_card_size - 1); }
 protected:
@@ -297,7 +297,7 @@ public:
     return false;
   }
 
-  void DoState(PointerWrap& p);
+  void DoState(StateLoadStore& p);
   DEntry m_gci_header;
   std::vector<GCMBlock> m_save_data;
   std::vector<u16> m_used_blocks;

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -643,7 +643,7 @@ void GCMemcardDirectory::FlushToFile()
 #endif
 }
 
-void GCMemcardDirectory::DoState(PointerWrap& p)
+void GCMemcardDirectory::DoState(StateLoadStore& p)
 {
   std::unique_lock<std::mutex> l(m_write_mutex);
   m_LastBlock = -1;
@@ -654,13 +654,7 @@ void GCMemcardDirectory::DoState(PointerWrap& p)
   p.DoPOD<Directory>(m_dir2);
   p.DoPOD<BlockAlloc>(m_bat1);
   p.DoPOD<BlockAlloc>(m_bat2);
-  int numSaves = (int)m_saves.size();
-  p.Do(numSaves);
-  m_saves.resize(numSaves);
-  for (auto itr = m_saves.begin(); itr != m_saves.end(); ++itr)
-  {
-    itr->DoState(p);
-  }
+  p.DoContainer(m_saves, [&](GCIFile& file) { file.DoState(p); });
 }
 
 bool GCIFile::LoadSaveBlocks()
@@ -698,18 +692,12 @@ int GCIFile::UsesBlock(u16 blocknum)
   return -1;
 }
 
-void GCIFile::DoState(PointerWrap& p)
+void GCIFile::DoState(StateLoadStore& p)
 {
   p.DoPOD<DEntry>(m_gci_header);
   p.Do(m_dirty);
   p.Do(m_filename);
-  int numBlocks = (int)m_save_data.size();
-  p.Do(numBlocks);
-  m_save_data.resize(numBlocks);
-  for (auto itr = m_save_data.begin(); itr != m_save_data.end(); ++itr)
-  {
-    p.DoPOD<GCMBlock>(*itr);
-  }
+  p.DoContainer(m_save_data, [&](GCMBlock& block) { p.DoPOD(block); });
   p.Do(m_used_blocks);
 }
 

--- a/Source/Core/Core/HW/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcardDirectory.h
@@ -33,7 +33,7 @@ public:
   s32 Write(u32 destaddress, s32 length, u8* srcaddress) override;
   void ClearBlock(u32 address) override;
   void ClearAll() override {}
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 private:
   int LoadGCI(const std::string& fileName, DiscIO::Country card_region, bool currentGameOnly);

--- a/Source/Core/Core/HW/GCMemcardRaw.cpp
+++ b/Source/Core/Core/HW/GCMemcardRaw.cpp
@@ -34,6 +34,7 @@ MemoryCard::MemoryCard(const std::string& filename, int _card_index, u16 sizeMb)
 
     INFO_LOG(EXPANSIONINTERFACE, "Reading memory card %s", m_filename.c_str());
     pFile.ReadBytes(&m_memcard_data[0], memory_card_size);
+    // TODO what if read fails?
   }
   else
   {
@@ -197,9 +198,11 @@ void MemoryCard::ClearAll()
   MakeDirty();
 }
 
-void MemoryCard::DoState(PointerWrap& p)
+void MemoryCard::DoState(StateLoadStore& p)
 {
   p.Do(card_index);
   p.Do(memory_card_size);
+  if (p.IsLoad())
+    m_memcard_data = std::make_unique<u8[]>(memory_card_size);
   p.DoArray(&m_memcard_data[0], memory_card_size);
 }

--- a/Source/Core/Core/HW/GCMemcardRaw.h
+++ b/Source/Core/Core/HW/GCMemcardRaw.h
@@ -26,7 +26,7 @@ public:
   s32 Write(u32 destaddress, s32 length, u8* srcaddress) override;
   void ClearBlock(u32 address) override;
   void ClearAll() override;
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 private:
   std::string m_filename;

--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -32,7 +32,7 @@ alignas(32) u8 m_gatherPipe[GATHER_PIPE_SIZE * 16];
 // pipe counter
 u32 m_gatherPipeCount = 0;
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.Do(m_gatherPipe);
   p.Do(m_gatherPipeCount);

--- a/Source/Core/Core/HW/GPFifo.h
+++ b/Source/Core/Core/HW/GPFifo.h
@@ -6,7 +6,7 @@
 
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 namespace GPFifo
 {
@@ -23,7 +23,7 @@ extern u32 m_gatherPipeCount;
 
 // Init
 void Init();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 // ResetGatherPipe
 void ResetGatherPipe();

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -80,7 +80,7 @@ void Shutdown()
   CoreTiming::Shutdown();
 }
 
-void DoState(PointerWrap& p)
+bool DoState(StateLoadStore& p)
 {
   Memory::DoState(p);
   p.DoMarker("Memory");
@@ -90,7 +90,8 @@ void DoState(PointerWrap& p)
   p.DoMarker("SerialInterface");
   ProcessorInterface::DoState(p);
   p.DoMarker("ProcessorInterface");
-  DSP::DoState(p);
+  if (!DSP::DoState(p))
+    return false;
   p.DoMarker("DSP");
   DVDInterface::DoState(p);
   p.DoMarker("DVDInterface");
@@ -110,5 +111,6 @@ void DoState(PointerWrap& p)
   }
 
   p.DoMarker("WIIHW");
+  return true;
 }
 }

--- a/Source/Core/Core/HW/HW.h
+++ b/Source/Core/Core/HW/HW.h
@@ -10,5 +10,5 @@ namespace HW
 {
 void Init();
 void Shutdown();
-void DoState(PointerWrap& p);
+bool DoState(StateLoadStore& p);
 }

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -197,7 +197,7 @@ void Init()
   m_IsInitialized = true;
 }
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   bool wii = SConfig::GetInstance().bWii;
   p.DoArray(m_pRAM, RAM_SIZE);

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -16,7 +16,7 @@
 #endif
 
 // Global declarations
-class PointerWrap;
+class StateLoadStore;
 namespace MMIO
 {
 class Mapping;
@@ -73,7 +73,7 @@ extern std::unique_ptr<MMIO::Mapping> mmio_mapping;
 bool IsInitialized();
 void Init();
 void Shutdown();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void Clear();
 bool AreMemoryBreakpointsActivated();

--- a/Source/Core/Core/HW/MemoryInterface.cpp
+++ b/Source/Core/Core/HW/MemoryInterface.cpp
@@ -135,7 +135,7 @@ struct MIMemStruct
 // STATE_TO_SAVE
 static MIMemStruct g_mi_mem;
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.Do(g_mi_mem);
 }

--- a/Source/Core/Core/HW/MemoryInterface.h
+++ b/Source/Core/Core/HW/MemoryInterface.h
@@ -10,11 +10,11 @@ namespace MMIO
 {
 class Mapping;
 }
-class PointerWrap;
+class StateLoadStore;
 
 namespace MemoryInterface
 {
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 }  // end of namespace MemoryInterface

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -34,7 +34,7 @@ static void ToggleResetButtonCallback(u64 userdata, s64 cyclesLate);
 // Let the PPC know that an external exception is set/cleared
 void UpdateException();
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.Do(m_InterruptMask);
   p.Do(m_InterruptCause);

--- a/Source/Core/Core/HW/ProcessorInterface.h
+++ b/Source/Core/Core/HW/ProcessorInterface.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
-class PointerWrap;
+class StateLoadStore;
 
 namespace MMIO
 {
@@ -59,7 +59,7 @@ extern u32 Fifo_CPUEnd;
 extern u32 Fifo_CPUWritePointer;
 
 void Init();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 

--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -206,13 +206,13 @@ static USIStatusReg g_StatusReg;
 static USIEXIClockCount g_EXIClockCount;
 static u8 g_SIBuffer[128];
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   for (int i = 0; i < MAX_SI_CHANNELS; i++)
   {
-    p.Do(g_Channel[i].m_InHi.Hex);
-    p.Do(g_Channel[i].m_InLo.Hex);
-    p.Do(g_Channel[i].m_Out.Hex);
+    p.DoPOD(g_Channel[i].m_InHi);
+    p.DoPOD(g_Channel[i].m_InLo);
+    p.DoPOD(g_Channel[i].m_Out);
 
     std::unique_ptr<ISIDevice>& device = g_Channel[i].m_device;
     SIDevices type = device->GetDeviceType();

--- a/Source/Core/Core/HW/SI.h
+++ b/Source/Core/Core/HW/SI.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 class ISIDevice;
 enum SIDevices : int;
 namespace MMIO
@@ -25,7 +25,7 @@ namespace SerialInterface
 {
 void Init();
 void Shutdown();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 

--- a/Source/Core/Core/HW/SI_Device.h
+++ b/Source/Core/Core/HW/SI_Device.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 // Devices can reply with these
 enum
@@ -92,7 +92,7 @@ public:
   virtual void SendCommand(u32 _Cmd, u8 _Poll) = 0;
 
   // Savestate support
-  virtual void DoState(PointerWrap& p) {}
+  virtual void DoState(StateLoadStore& p) {}
   int GetDeviceNumber() const { return m_iDeviceNumber; }
   SIDevices GetDeviceType() const { return m_deviceType; }
 };

--- a/Source/Core/Core/HW/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCController.cpp
@@ -318,7 +318,7 @@ void CSIDevice_GCController::SendCommand(u32 _Cmd, u8 _Poll)
 }
 
 // Savestate support
-void CSIDevice_GCController::DoState(PointerWrap& p)
+void CSIDevice_GCController::DoState(StateLoadStore& p)
 {
   p.Do(m_Calibrated);
   p.Do(m_Origin);

--- a/Source/Core/Core/HW/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI_DeviceGCController.h
@@ -95,7 +95,7 @@ public:
   void SendCommand(u32 _Cmd, u8 _Poll) override;
 
   // Savestate support
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
   virtual GCPadStatus GetPadStatus();
   virtual u32 MapPadStatus(const GCPadStatus& pad_status);

--- a/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.cpp
@@ -97,7 +97,7 @@ void CSIDevice_Keyboard::SendCommand(u32 _Cmd, u8 _Poll)
   }
 }
 
-void CSIDevice_Keyboard::DoState(PointerWrap& p)
+void CSIDevice_Keyboard::DoState(StateLoadStore& p)
 {
   p.Do(m_Counter);
 }

--- a/Source/Core/Core/HW/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.h
@@ -6,7 +6,7 @@
 
 #include "Core/HW/SI_Device.h"
 
-class PointerWrap;
+class StateLoadStore;
 struct KeyboardStatus;
 
 class CSIDevice_Keyboard : public ISIDevice
@@ -62,5 +62,5 @@ public:
   void SendCommand(u32 _Cmd, u8 _Poll) override;
 
   // Savestate support
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 };

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -67,7 +67,7 @@ static u32 s_odd_field_first_hl;   // index first halfline of the odd field
 static u32 s_even_field_last_hl;   // index last halfline of the even field
 static u32 s_odd_field_last_hl;    // index last halfline of the odd field
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.DoPOD(m_VerticalTimingRegister);
   p.DoPOD(m_DisplayControlRegister);

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -328,7 +328,7 @@ void Preset(bool _bNTSC);
 
 void Init();
 void SetRegionReg(char region);
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -101,7 +101,7 @@ static u32 sensorbar_power;  // do we need to care about this?
 static int updateInterrupts;
 static void UpdateInterrupts(u64 = 0, s64 cyclesLate = 0);
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.Do(ppc_msg);
   p.Do(arm_msg);

--- a/Source/Core/Core/HW/WII_IPC.h
+++ b/Source/Core/Core/HW/WII_IPC.h
@@ -6,7 +6,7 @@
 
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 namespace MMIO
 {
 class Mapping;
@@ -38,7 +38,7 @@ enum StarletInterruptCause
 void Init();
 void Reset();
 void Shutdown();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -117,7 +117,7 @@ unsigned int GetAttached()
 }
 
 // Save/Load state
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   for (int i = 0; i < MAX_BBMOTES; ++i)
     static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(i))->DoState(p);

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -8,7 +8,7 @@
 #include "Common/CommonTypes.h"
 
 class InputConfig;
-class PointerWrap;
+class StateLoadStore;
 
 enum
 {
@@ -49,7 +49,7 @@ void Resume();
 void Pause();
 
 unsigned int GetAttached();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 void EmuStateChange(EMUSTATE_CHANGE newState);
 InputConfig* GetConfig();
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -220,12 +220,7 @@ void Wiimote::Reset()
 
   memset(m_shake_step, 0, sizeof(m_shake_step));
 
-  // clear read request queue
-  while (!m_read_requests.empty())
-  {
-    delete[] m_read_requests.front().data;
-    m_read_requests.pop();
-  }
+  m_read_requests.clear();
 
   // Yamaha ADPCM state initialize
   m_adpcm_state.predictor = 0;
@@ -328,11 +323,8 @@ bool Wiimote::Step()
     // SendReadDataReply(rr.channel, rr);
 
     // if there is no more data, remove from queue
-    if (0 == rr.size)
-    {
-      delete[] rr.data;
-      m_read_requests.pop();
-    }
+    if (rr.position == rr.data.size())
+      m_read_requests.pop_front();
 
     // don't send any other reports
     return true;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -18,8 +18,6 @@
 #define WIIMOTE_REG_EXT_SIZE 0x100
 #define WIIMOTE_REG_IR_SIZE 0x34
 
-class PointerWrap;
-
 namespace WiimoteReal
 {
 class Wiimote;
@@ -112,7 +110,7 @@ public:
   void ConnectOnInput();
   void Reset();
 
-  void DoState(PointerWrap& p);
+  void DoState(StateLoadStore& p);
   void RealState();
 
   void LoadDefaults(const ControllerInterface& ciface) override;
@@ -136,7 +134,7 @@ private:
   {
     // u16 channel;
     u32 address, size, position;
-    u8* data;
+    std::vector<u8> data;
   };
 
   void ReportMode(const wm_report_mode* const dr);
@@ -185,7 +183,7 @@ private:
   // read data request queue
   // maybe it isn't actually a queue
   // maybe read requests cancel any current requests
-  std::queue<ReadRequest> m_read_requests;
+  std::deque<ReadRequest> m_read_requests;
 
   wiimote_key m_ext_key;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -20,6 +20,7 @@ in case of success they are
 They will also generate a true or false return for UpdateInterrupts() in WII_IPC.cpp.
 */
 
+#include <array>
 #include <list>
 #include <map>
 #include <string>
@@ -61,15 +62,14 @@ They will also generate a true or false return for UpdateInterrupts() in WII_IPC
 
 namespace WII_IPC_HLE_Interface
 {
-typedef std::map<u32, std::shared_ptr<IWII_IPC_HLE_Device>> TDeviceMap;
-static TDeviceMap g_DeviceMap;
+static std::vector<std::shared_ptr<IWII_IPC_HLE_Device>> g_DeviceMap;
 
 // STATE_TO_SAVE
 #define IPC_MAX_FDS 0x18
 #define ES_MAX_COUNT 2
-static std::shared_ptr<IWII_IPC_HLE_Device> g_FdMap[IPC_MAX_FDS];
-static bool es_inuse[ES_MAX_COUNT];
-static std::shared_ptr<IWII_IPC_HLE_Device> es_handles[ES_MAX_COUNT];
+static std::array<std::shared_ptr<IWII_IPC_HLE_Device>, IPC_MAX_FDS> g_FdMap;
+static std::array<bool, ES_MAX_COUNT> es_inuse;
+static std::array<std::shared_ptr<IWII_IPC_HLE_Device>, ES_MAX_COUNT> es_handles;
 
 typedef std::deque<u32> ipc_msg_queue;
 static ipc_msg_queue request_queue;  // ppc -> arm
@@ -108,14 +108,11 @@ static void SDIO_EventNotify_CPUThread(u64 userdata, s64 cycles_late)
     device->EventNotify();
 }
 
-static u32 num_devices;
-
 template <typename T>
 std::shared_ptr<T> AddDevice(const char* deviceName)
 {
-  auto device = std::make_shared<T>(num_devices, deviceName);
-  g_DeviceMap[num_devices] = device;
-  num_devices++;
+  auto device = std::make_shared<T>((u32)g_DeviceMap.size(), deviceName);
+  g_DeviceMap.push_back(device);
   return device;
 }
 
@@ -124,7 +121,7 @@ void Init()
   _dbg_assert_msg_(WII_IPC_HLE, g_DeviceMap.empty(), "DeviceMap isn't empty on init");
   CWII_IPC_HLE_Device_es::m_ContentFile = "";
 
-  num_devices = 0;
+  g_DeviceMap.clear();
 
   // Build hardware devices
   AddDevice<CWII_IPC_HLE_Device_usb_oh1_57e_305>("/dev/usb/oh1/57e/305");
@@ -165,29 +162,12 @@ void Reset(bool _bHard)
 {
   CoreTiming::RemoveAllEvents(event_enqueue);
 
-  for (auto& dev : g_FdMap)
+  g_FdMap.fill(nullptr);
+  es_inuse.fill(false);
+  for (const auto& dev : g_DeviceMap)
   {
-    if (dev && !dev->IsHardware())
-    {
-      // close all files and delete their resources
+    if (dev)
       dev->Close(0, true);
-    }
-
-    dev.reset();
-  }
-
-  for (bool& in_use : es_inuse)
-  {
-    in_use = false;
-  }
-
-  for (const auto& entry : g_DeviceMap)
-  {
-    if (entry.second)
-    {
-      // Force close
-      entry.second->Close(0, true);
-    }
   }
 
   if (_bHard)
@@ -207,11 +187,11 @@ void Shutdown()
 
 void SetDefaultContentFile(const std::string& _rFilename)
 {
-  for (const auto& entry : g_DeviceMap)
+  for (const auto& dev : g_DeviceMap)
   {
-    if (entry.second && entry.second->GetDeviceName().find("/dev/es") == 0)
+    if (dev && dev->GetDeviceName().find("/dev/es") == 0)
     {
-      static_cast<CWII_IPC_HLE_Device_es*>(entry.second.get())->LoadWAD(_rFilename);
+      static_cast<CWII_IPC_HLE_Device_es*>(dev.get())->LoadWAD(_rFilename);
     }
   }
 }
@@ -246,23 +226,18 @@ std::shared_ptr<IWII_IPC_HLE_Device> GetDeviceByName(const std::string& _rDevice
 {
   for (const auto& entry : g_DeviceMap)
   {
-    if (entry.second && entry.second->GetDeviceName() == _rDeviceName)
+    if (entry && entry->GetDeviceName() == _rDeviceName)
     {
-      return entry.second;
+      return entry;
     }
   }
 
   return nullptr;
 }
 
-std::shared_ptr<IWII_IPC_HLE_Device> AccessDeviceByID(u32 _ID)
+std::shared_ptr<IWII_IPC_HLE_Device> AccessDeviceByID(u32 id)
 {
-  if (g_DeviceMap.find(_ID) != g_DeviceMap.end())
-  {
-    return g_DeviceMap[_ID];
-  }
-
-  return nullptr;
+  return id < g_DeviceMap.size() ? g_DeviceMap[id] : nullptr;
 }
 
 // This is called from ExecuteCommand() COMMAND_OPEN_DEVICE
@@ -273,7 +248,7 @@ std::shared_ptr<IWII_IPC_HLE_Device> CreateFileIO(u32 _DeviceID, const std::stri
   return std::make_shared<CWII_IPC_HLE_Device_FileIO>(_DeviceID, _rDeviceName);
 }
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.Do(request_queue);
   p.Do(reply_queue);
@@ -284,79 +259,36 @@ void DoState(PointerWrap& p)
   for (auto& descriptor : g_FdMap)
   {
     if (descriptor)
-      descriptor->PrepareForState(p.GetMode());
+      descriptor->PrepareForState();
   }
 
-  for (const auto& entry : g_DeviceMap)
+  for (const auto& dev : g_DeviceMap)
   {
-    if (entry.second->IsHardware())
-    {
-      entry.second->DoState(p);
-    }
+    if (!p.IsGood())
+      return;
+    dev->DoState(p);
   }
 
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  u32 idx = 0;
+  for (auto& dev : g_FdMap)
   {
-    for (u32 i = 0; i < IPC_MAX_FDS; i++)
+    u32 device_id = dev ? dev->GetDeviceID() : -1;
+    p.Do(device_id);
+    if (p.IsLoad())
     {
-      u32 exists = 0;
-      p.Do(exists);
-      if (exists)
+      if (device_id == (u32)-1)
+        dev = nullptr;
+      else if (device_id < g_DeviceMap.size())
+        dev = g_DeviceMap[device_id];
+      else
       {
-        u32 isHw = 0;
-        p.Do(isHw);
-        if (isHw)
-        {
-          u32 hwId = 0;
-          p.Do(hwId);
-          g_FdMap[i] = AccessDeviceByID(hwId);
-        }
-        else
-        {
-          g_FdMap[i] = std::make_shared<CWII_IPC_HLE_Device_FileIO>(i, "");
-          g_FdMap[i]->DoState(p);
-        }
+        dev = std::make_shared<CWII_IPC_HLE_Device_FileIO>(idx, "");
+        dev->DoState(p);
       }
-    }
-
-    for (u32 i = 0; i < ES_MAX_COUNT; i++)
-    {
-      p.Do(es_inuse[i]);
-      u32 handleID = es_handles[i]->GetDeviceID();
-      p.Do(handleID);
-
-      es_handles[i] = AccessDeviceByID(handleID);
+      idx++;
     }
   }
-  else
-  {
-    for (auto& descriptor : g_FdMap)
-    {
-      u32 exists = descriptor ? 1 : 0;
-      p.Do(exists);
-      if (exists)
-      {
-        u32 isHw = descriptor->IsHardware() ? 1 : 0;
-        p.Do(isHw);
-        if (isHw)
-        {
-          u32 hwId = descriptor->GetDeviceID();
-          p.Do(hwId);
-        }
-        else
-        {
-          descriptor->DoState(p);
-        }
-      }
-    }
-
-    for (u32 i = 0; i < ES_MAX_COUNT; i++)
-    {
-      p.Do(es_inuse[i]);
-      u32 handleID = es_handles[i]->GetDeviceID();
-      p.Do(handleID);
-    }
-  }
+  p.Do(es_inuse);
 }
 
 void ExecuteCommand(u32 _Address)
@@ -615,9 +547,9 @@ void UpdateDevices()
   // Check if a hardware device must be updated
   for (const auto& entry : g_DeviceMap)
   {
-    if (entry.second->IsOpened())
+    if (entry->IsOpened())
     {
-      entry.second->Update();
+      entry->Update();
     }
   }
 }
@@ -625,10 +557,9 @@ void UpdateDevices()
 }  // end of namespace WII_IPC_HLE_Interface
 
 // TODO: create WII_IPC_HLE_Device.cpp ?
-void IWII_IPC_HLE_Device::DoStateShared(PointerWrap& p)
+void IWII_IPC_HLE_Device::DoStateShared(StateLoadStore& p)
 {
   p.Do(m_Name);
   p.Do(m_DeviceID);
-  p.Do(m_Hardware);
   p.Do(m_Active);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -13,7 +13,7 @@
 #include "Core/HW/SystemTimers.h"
 
 class IWII_IPC_HLE_Device;
-class PointerWrap;
+class StateLoadStore;
 
 struct IPCCommandResult
 {
@@ -51,7 +51,7 @@ void Shutdown();
 void Reset(bool _bHard = false);
 
 // Do State
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 // Set default content file
 void SetDefaultContentFile(const std::string& _rFilename);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -99,21 +99,16 @@ struct SIOCtlVBuffer
 class IWII_IPC_HLE_Device
 {
 public:
-  IWII_IPC_HLE_Device(u32 _DeviceID, const std::string& _rName, bool _Hardware = true)
-      : m_Name(_rName), m_DeviceID(_DeviceID), m_Hardware(_Hardware), m_Active(false)
+  IWII_IPC_HLE_Device(u32 _DeviceID, const std::string& _rName)
+      : m_Name(_rName), m_DeviceID(_DeviceID), m_Active(false)
   {
   }
 
   virtual ~IWII_IPC_HLE_Device() {}
   // Release any resources which might interfere with savestating.
-  virtual void PrepareForState(PointerWrap::Mode mode) {}
-  virtual void DoState(PointerWrap& p)
-  {
-    DoStateShared(p);
-    p.Do(m_Active);
-  }
-
-  void DoStateShared(PointerWrap& p);
+  virtual void PrepareForState() {}
+  virtual void DoState(StateLoadStore& p) { DoStateShared(p); }
+  void DoStateShared(StateLoadStore& p);
 
   const std::string& GetDeviceName() const { return m_Name; }
   u32 GetDeviceID() const { return m_DeviceID; }
@@ -146,7 +141,6 @@ public:
 #undef UNIMPLEMENTED_CMD
 
   virtual u32 Update() { return 0; }
-  virtual bool IsHardware() { return m_Hardware; }
   virtual bool IsOpened() { return m_Active; }
   // Returns an IPCCommandResult for a reply that takes 250 us (arbitrarily chosen value)
   static IPCCommandResult GetDefaultReply()
@@ -161,7 +155,6 @@ public:
 protected:
   // STATE_TO_SAVE
   u32 m_DeviceID;
-  bool m_Hardware;
   bool m_Active;
 
   // Write out the IPC struct from _CommandAddress to _NumberOfCommands numbers

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -26,7 +26,7 @@ CWII_IPC_HLE_Device_di::~CWII_IPC_HLE_Device_di()
 {
 }
 
-void CWII_IPC_HLE_Device_di::DoState(PointerWrap& p)
+void CWII_IPC_HLE_Device_di::DoState(StateLoadStore& p)
 {
   DoStateShared(p);
   p.Do(m_commands_to_execute);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
@@ -20,7 +20,7 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_di();
 
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
   IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
   IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -74,9 +74,7 @@ void HLE_IPC_CreateVirtualFATFilesystem()
 
 CWII_IPC_HLE_Device_FileIO::CWII_IPC_HLE_Device_FileIO(u32 _DeviceID,
                                                        const std::string& _rDeviceName)
-    : IWII_IPC_HLE_Device(_DeviceID, _rDeviceName, false)  // not a real hardware
-      ,
-      m_Mode(0), m_SeekPos(0), m_file()
+    : IWII_IPC_HLE_Device(_DeviceID, _rDeviceName), m_Mode(0), m_SeekPos(0), m_file()
 {
   Common::ReadReplacements(replacements);
 }
@@ -365,14 +363,14 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
   return GetDefaultReply();
 }
 
-void CWII_IPC_HLE_Device_FileIO::PrepareForState(PointerWrap::Mode mode)
+void CWII_IPC_HLE_Device_FileIO::PrepareForState()
 {
   // Temporally close the file, to prevent any issues with the savestating of /tmp
   // it can be opened again with another call to OpenFile()
   m_file.reset();
 }
 
-void CWII_IPC_HLE_Device_FileIO::DoState(PointerWrap& p)
+void CWII_IPC_HLE_Device_FileIO::DoState(StateLoadStore& p)
 {
   DoStateShared(p);
 
@@ -383,5 +381,6 @@ void CWII_IPC_HLE_Device_FileIO::DoState(PointerWrap& p)
 
   // The file was closed during state (and might now be pointing at another file)
   // Open it again
-  OpenFile();
+  if (p.IsLoad())
+    OpenFile();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
@@ -29,8 +29,8 @@ public:
   IPCCommandResult Read(u32 _CommandAddress) override;
   IPCCommandResult Write(u32 _CommandAddress) override;
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  void PrepareForState(PointerWrap::Mode mode) override;
-  void DoState(PointerWrap& p) override;
+  void PrepareForState() override;
+  void DoState(StateLoadStore& p) override;
 
   void OpenFile();
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
@@ -11,7 +11,7 @@
 
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
-class PointerWrap;
+class StateLoadStore;
 namespace DiscIO
 {
 class CNANDContentLoader;
@@ -29,7 +29,7 @@ public:
 
   void OpenInternal();
 
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
   IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
   IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -37,7 +37,7 @@ public:
   CWII_IPC_HLE_Device_fs(u32 _DeviceID, const std::string& _rDeviceName);
   virtual ~CWII_IPC_HLE_Device_fs();
 
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
   IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
   IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -34,13 +34,11 @@ CWII_IPC_HLE_Device_sdio_slot0::CWII_IPC_HLE_Device_sdio_slot0(u32 _DeviceID,
 {
 }
 
-void CWII_IPC_HLE_Device_sdio_slot0::DoState(PointerWrap& p)
+void CWII_IPC_HLE_Device_sdio_slot0::DoState(StateLoadStore& p)
 {
   DoStateShared(p);
-  if (p.GetMode() == PointerWrap::MODE_READ)
-  {
+  if (p.IsLoad())
     OpenInternal();
-  }
   p.Do(m_Status);
   p.Do(m_BlockLength);
   p.Do(m_BusWidth);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
@@ -20,7 +20,7 @@ class CWII_IPC_HLE_Device_sdio_slot0 : public IWII_IPC_HLE_Device
 public:
   CWII_IPC_HLE_Device_sdio_slot0(u32 _DeviceID, const std::string& _rDeviceName);
 
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
   IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
   IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.cpp
@@ -121,7 +121,7 @@ CWII_IPC_HLE_Device_usb_oh1_57e_305::~CWII_IPC_HLE_Device_usb_oh1_57e_305()
   SetUsbPointer(nullptr);
 }
 
-void CWII_IPC_HLE_Device_usb_oh1_57e_305::DoState(PointerWrap& p)
+void CWII_IPC_HLE_Device_usb_oh1_57e_305::DoState(StateLoadStore& p)
 {
   p.Do(m_Active);
   p.Do(m_ControllerBD);
@@ -523,6 +523,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305::ACLPool::Store(const u8* data, const u
   auto& packet = m_queue.back();
 
   std::copy(data, data + size, packet.data);
+  memset(packet.data + size, 0, sizeof(packet.data) - size);
   packet.size = size;
   packet.conn_handle = conn_handle;
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb.h
@@ -67,7 +67,7 @@ public:
   CWII_IPC_HLE_WiiMote* AccessWiiMote(const bdaddr_t& _rAddr);
   CWII_IPC_HLE_WiiMote* AccessWiiMote(u16 _ConnectionHandle);
 
-  void DoState(PointerWrap& p) override;
+  void DoState(StateLoadStore& p) override;
 
 private:
   enum USBIOCtl
@@ -158,7 +158,7 @@ private:
 
     bool IsEmpty() const { return m_queue.empty(); }
     // For SaveStates
-    void DoState(PointerWrap& p) { p.Do(m_queue); }
+    void DoState(StateLoadStore& p) { p.Do(m_queue); }
   } m_acl_pool;
 
   u32 m_PacketCount[MAX_BBMOTES];

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_WiiMote.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_WiiMote.cpp
@@ -69,10 +69,8 @@ CWII_IPC_HLE_WiiMote::CWII_IPC_HLE_WiiMote(CWII_IPC_HLE_Device_usb_oh1_57e_305* 
   lmp_subversion = 0x229;
 }
 
-void CWII_IPC_HLE_WiiMote::DoState(PointerWrap& p)
+void CWII_IPC_HLE_WiiMote::DoState(StateLoadStore& p)
 {
-  // this function is usually not called... see CWII_IPC_HLE_Device_usb_oh1_57e_305::DoState
-
   p.Do(m_ConnectionState);
 
   p.Do(m_HIDControlChannel_Connected);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_WiiMote.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_WiiMote.h
@@ -39,7 +39,7 @@ public:
                        bool ready = false);
 
   virtual ~CWII_IPC_HLE_WiiMote() {}
-  void DoState(PointerWrap& p);
+  void DoState(StateLoadStore& p);
 
   // ugly Host handling....
   // we really have to clean all this code

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -535,11 +535,11 @@ bool BeginRecordingInput(int controllers)
 
   if (Core::IsRunningAndStarted())
   {
-    const std::string save_path = File::GetUserPath(D_STATESAVES_IDX) + "dtm.sav";
+    std::string save_path = File::GetUserPath(D_STATESAVES_IDX) + "dtm.sav";
     if (File::Exists(save_path))
       File::Delete(save_path);
 
-    State::SaveAs(save_path);
+    State::SaveAs(std::move(save_path));
     s_bRecordingFromSaveState = true;
 
     // This is only done here if starting from save state because otherwise we won't have the
@@ -961,7 +961,7 @@ bool PlayInput(const std::string& filename)
   return true;
 }
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   // many of these could be useful to save even when no movie is active,
   // and the data is tiny, so let's just save it regardless of movie state.
@@ -1330,7 +1330,7 @@ void EndPlayInput(bool cont)
 }
 
 // NOTE: Save State + Host Thread
-void SaveRecording(const std::string& filename)
+bool SaveRecording(const std::string& filename)
 {
   File::IOFile save_record(filename, "wb");
   // Create the real header now and write it
@@ -1389,6 +1389,12 @@ void SaveRecording(const std::string& filename)
   save_record.WriteArray(&header, 1);
 
   bool success = save_record.WriteArray(tmpInput, (size_t)s_totalBytes);
+  return success;
+}
+
+void SaveRecordingUserRequested(const std::string& filename)
+{
+  bool success = SaveRecording(filename);
 
   if (success && s_bRecordingFromSaveState)
   {

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -9,7 +9,7 @@
 #include "Common/CommonTypes.h"
 
 struct GCPadStatus;
-class PointerWrap;
+class StateLoadStore;
 struct wiimote_key;
 
 namespace WiimoteEmu
@@ -169,8 +169,9 @@ void PlayController(GCPadStatus* PadStatus, int controllerID);
 bool PlayWiimote(int wiimote, u8* data, const struct WiimoteEmu::ReportFeatures& rptf, int ext,
                  const wiimote_key key);
 void EndPlayInput(bool cont);
-void SaveRecording(const std::string& filename);
-void DoState(PointerWrap& p);
+bool SaveRecording(const std::string& filename);
+void SaveRecordingUserRequested(const std::string& filename);
+void DoState(StateLoadStore& p);
 void CheckMD5();
 void GetMD5();
 void Shutdown();

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MemoryUtil.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -12,6 +12,9 @@
 #include "Common/PerformanceCounter.h"
 #endif
 
+#include "Common/ChunkFile.h"
+#include "Common/FileUtil.h"
+
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/PowerPC/CachedInterpreter.h"
@@ -35,9 +38,9 @@
 
 namespace JitInterface
 {
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
-  if (jit && p.GetMode() == PointerWrap::MODE_READ)
+  if (jit && p.IsLoad())
     jit->ClearCache();
 }
 CPUCoreBase* InitJitCore(int core)

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -5,10 +5,11 @@
 #pragma once
 
 #include <string>
-#include "Common/ChunkFile.h"
 #include "Core/MachineContext.h"
 #include "Core/PowerPC/CPUCoreBase.h"
 #include "Core/PowerPC/Profiler.h"
+
+class StateLoadStore;
 
 namespace JitInterface
 {
@@ -18,7 +19,7 @@ enum class ExceptionType
   EXCEPTIONS_PAIRED_QUANTIZE
 };
 
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 CPUCoreBase* InitJitCore(int core);
 void InitTables(int core);

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -6,6 +6,7 @@
 #include <cinttypes>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -53,7 +53,7 @@ void ExpandCR(u32 cr)
   }
 }
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   // some of this code has been disabled, because
   // it changes registers even in MODE_MEASURE (which is suspicious and seems like it could cause
@@ -65,6 +65,9 @@ void DoState(PointerWrap& p)
   // *((u64 *)&TL) = SystemTimers::GetFakeTimeBase(); //works since we are little endian and TL
   // comes first :)
 
+  // Lots of padding in here - don't want to leak random memory into save
+  // files, but as long as it's in a global, it should be zero initialized, so
+  // no big deal...
   p.DoPOD(ppcState);
 
   // SystemTimers::DecrementerSet();

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -15,7 +15,7 @@
 #include "Core/PowerPC/PPCCache.h"
 
 class CPUCoreBase;
-class PointerWrap;
+class StateLoadStore;
 
 namespace PowerPC
 {
@@ -137,7 +137,7 @@ extern PPCDebugInterface debug_interface;
 
 void Init(int cpu_core);
 void Shutdown();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 CoreMode GetMode();
 // [NOT THREADSAFE] CPU Thread or CPU::PauseAndLock or CORE_UNINITIALIZED

--- a/Source/Core/Core/State.h
+++ b/Source/Core/Core/State.h
@@ -36,31 +36,22 @@ bool ReadHeader(const std::string& filename, StateHeader& header);
 std::string GetInfoStringOfSlot(int slot);
 
 // These don't happen instantly - they get scheduled as events.
-// ...But only if we're not in the main CPU thread.
-//    If we're in the main CPU thread then they run immediately instead
-//    because some things (like Lua) need them to run immediately.
 // Slots from 0-99.
-void Save(int slot, bool wait = false);
+void Save(int slot);
 void Load(int slot);
-void Verify(int slot);
 
-void SaveAs(const std::string& filename, bool wait = false);
+void SaveAs(std::string&& filename, int for_slot = -1);
 void LoadAs(const std::string& filename);
-void VerifyAt(const std::string& filename);
 
 void SaveToBuffer(std::vector<u8>& buffer);
 void LoadFromBuffer(std::vector<u8>& buffer);
-void VerifyBuffer(std::vector<u8>& buffer);
 
 void LoadLastSaved(int i = 1);
 void SaveFirstSaved();
 void UndoSaveState();
 void UndoLoadState();
 
-// wait until previously scheduled savestate event (if any) is done
-void Flush();
-
 // for calling back into UI code without introducing a dependency on it in core
-typedef void (*CallbackFunc)(void);
-void SetOnAfterLoadCallback(CallbackFunc callback);
+typedef std::function<void()> CallbackFunc;
+void SetOnAfterLoadSaveCallback(CallbackFunc callback);
 }

--- a/Source/Core/DolphinQt2/MainWindow.cpp
+++ b/Source/Core/DolphinQt2/MainWindow.cpp
@@ -36,11 +36,13 @@ MainWindow::MainWindow() : QMainWindow(nullptr)
   ConnectRenderWidget();
   ConnectStack();
   ConnectMenuBar();
+  State::SetOnAfterLoadSaveCallback([= this]() { emit AfterLoadSave(); });
 }
 
 MainWindow::~MainWindow()
 {
   m_render_widget->deleteLater();
+  State::SetOnAfterLoadSaveCallback(nullptr);
 }
 
 void MainWindow::CreateComponents()
@@ -88,6 +90,7 @@ void MainWindow::ConnectMenuBar()
   connect(this, &MainWindow::EmulationStarted, m_menu_bar, &MenuBar::EmulationStarted);
   connect(this, &MainWindow::EmulationPaused, m_menu_bar, &MenuBar::EmulationPaused);
   connect(this, &MainWindow::EmulationStopped, m_menu_bar, &MenuBar::EmulationStopped);
+  connect(this, &MainWindow::AfterLoadSave, m_menu_bar, &MenuBar::UpdateStateSlotMenu);
 }
 
 void MainWindow::ConnectToolBar()
@@ -356,8 +359,7 @@ void MainWindow::StateLoadSlot()
 
 void MainWindow::StateSaveSlot()
 {
-  State::Save(m_state_slot, true);
-  m_menu_bar->UpdateStateSlotMenu();
+  State::Save(m_state_slot);
 }
 
 void MainWindow::StateLoadSlotAt(int slot)
@@ -367,8 +369,7 @@ void MainWindow::StateLoadSlotAt(int slot)
 
 void MainWindow::StateSaveSlotAt(int slot)
 {
-  State::Save(slot, true);
-  m_menu_bar->UpdateStateSlotMenu();
+  State::Save(slot);
 }
 
 void MainWindow::StateLoadUndo()

--- a/Source/Core/DolphinQt2/MainWindow.h
+++ b/Source/Core/DolphinQt2/MainWindow.h
@@ -29,6 +29,7 @@ signals:
   void EmulationStarted();
   void EmulationPaused();
   void EmulationStopped();
+  void AfterLoadSave();
 
 private slots:
   void Open();

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -478,7 +478,7 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, const wxPo
   Movie::SetGCInputManip(GCTASManipFunction);
   Movie::SetWiiInputManip(WiiTASManipFunction);
 
-  State::SetOnAfterLoadCallback(OnAfterLoadCallback);
+  State::SetOnAfterLoadSaveCallback(OnAfterLoadSaveCallback);
   Core::SetOnStoppedCallback(OnStoppedCallback);
 
   // Setup perspectives
@@ -1134,7 +1134,7 @@ int GetCmdForHotkey(unsigned int key)
   return -1;
 }
 
-void OnAfterLoadCallback()
+void OnAfterLoadSaveCallback()
 {
   // warning: this gets called from the CPU thread, so we should only queue things to do on the
   // proper thread

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -339,7 +339,7 @@ private:
 
 int GetCmdForHotkey(unsigned int key);
 
-void OnAfterLoadCallback();
+void OnAfterLoadSaveCallback();
 void OnStoppedCallback();
 
 // For TASInputDlg

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1263,7 +1263,7 @@ void CFrame::DoRecordingSave()
   if (path.IsEmpty())
     return;
 
-  Movie::SaveRecording(WxStrToStr(path));
+  Movie::SaveRecordingUserRequested(WxStrToStr(path));
 
   if (!paused)
     DoPause();

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -517,16 +517,7 @@ static void BPWritten(const BPCmd& bp)
   case BPMEM_TEV_COLOR_RA + 6:
   {
     int num = (bp.address >> 1) & 0x3;
-    if (bpmem.tevregs[num].type_ra)
-    {
-      PixelShaderManager::SetTevKonstColor(num, 0, (s32)bpmem.tevregs[num].red);
-      PixelShaderManager::SetTevKonstColor(num, 3, (s32)bpmem.tevregs[num].alpha);
-    }
-    else
-    {
-      PixelShaderManager::SetTevColor(num, 0, (s32)bpmem.tevregs[num].red);
-      PixelShaderManager::SetTevColor(num, 3, (s32)bpmem.tevregs[num].alpha);
-    }
+    PixelShaderManager::SetTevColorRA(num);
     return;
   }
 
@@ -536,16 +527,7 @@ static void BPWritten(const BPCmd& bp)
   case BPMEM_TEV_COLOR_BG + 6:
   {
     int num = (bp.address >> 1) & 0x3;
-    if (bpmem.tevregs[num].type_bg)
-    {
-      PixelShaderManager::SetTevKonstColor(num, 1, (s32)bpmem.tevregs[num].green);
-      PixelShaderManager::SetTevKonstColor(num, 2, (s32)bpmem.tevregs[num].blue);
-    }
-    else
-    {
-      PixelShaderManager::SetTevColor(num, 1, (s32)bpmem.tevregs[num].green);
-      PixelShaderManager::SetTevColor(num, 2, (s32)bpmem.tevregs[num].blue);
-    }
+    PixelShaderManager::SetTevColorBG(num);
     return;
   }
 

--- a/Source/Core/VideoCommon/BoundingBox.cpp
+++ b/Source/Core/VideoCommon/BoundingBox.cpp
@@ -13,7 +13,7 @@ bool active = false;
 u16 coords[4] = {0x80, 0xA0, 0x80, 0xA0};
 
 // Save state
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.Do(active);
   p.Do(coords);

--- a/Source/Core/VideoCommon/BoundingBox.h
+++ b/Source/Core/VideoCommon/BoundingBox.h
@@ -6,7 +6,7 @@
 
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 // Bounding Box manager
 namespace BoundingBox
@@ -26,6 +26,6 @@ enum
 };
 
 // Save state
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 };  // end of namespace BoundingBox

--- a/Source/Core/VideoCommon/CPMemory.cpp
+++ b/Source/Core/VideoCommon/CPMemory.cpp
@@ -20,7 +20,7 @@ void DoCPState(PointerWrap& p)
   p.Do(g_main_cp_state.vtx_desc.Hex);
   p.DoArray(g_main_cp_state.vtx_attr);
   p.DoMarker("CP Memory");
-  if (p.mode == PointerWrap::MODE_READ)
+  if (p.IsLoad())
   {
     CopyPreprocessCPStateFromMain();
     g_main_cp_state.bases_dirty = true;

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -51,7 +51,7 @@ static void UpdateInterrupts_Wrapper(u64 userdata, s64 cyclesLate)
   UpdateInterrupts(userdata);
 }
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.DoPOD(m_CPStatusReg);
   p.DoPOD(m_CPCtrlReg);

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -119,7 +119,7 @@ union UCPClearReg {
 
 // Init
 void Init();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -7,14 +7,14 @@
 #include <cstddef>
 #include "Common/CommonTypes.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 namespace Fifo
 {
 void Init();
 void Shutdown();
 void Prepare();  // Must be called from the CPU thread.
-void DoState(PointerWrap& f);
+bool DoState(StateLoadStore& f);
 void PauseAndLock(bool doLock, bool unpauseOnUnlock);
 void UpdateWantDeterminism(bool want);
 bool UseDeterministicGPUThread();

--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -104,14 +104,12 @@ void GeometryShaderManager::SetTexCoordChanged(u8 texmapid)
   dirty = true;
 }
 
-void GeometryShaderManager::DoState(PointerWrap& p)
+void GeometryShaderManager::DoState(StateLoadStore& p)
 {
   p.Do(s_projection_changed);
   p.Do(s_viewport_changed);
 
-  p.Do(constants);
-
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsLoad())
   {
     // Fixup the current state from global GPU state
     // NOTE: This requires that all GPU memory has been loaded already.

--- a/Source/Core/VideoCommon/GeometryShaderManager.h
+++ b/Source/Core/VideoCommon/GeometryShaderManager.h
@@ -15,7 +15,7 @@ class GeometryShaderManager
 public:
   static void Init();
   static void Dirty();
-  static void DoState(PointerWrap& p);
+  static void DoState(StateLoadStore& p);
 
   static void SetConstants();
   static void SetViewportChanged();

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -104,7 +104,7 @@ enum
   INT_CAUSE_PE_FINISH = 0x400,  // GP Finished
 };
 
-void DoState(PointerWrap& p)
+void DoState(StateLoadStore& p)
 {
   p.Do(m_ZConf);
   p.Do(m_AlphaConf);

--- a/Source/Core/VideoCommon/PixelEngine.h
+++ b/Source/Core/VideoCommon/PixelEngine.h
@@ -56,7 +56,7 @@ union UPEAlphaReadReg {
 };
 
 void Init();
-void DoState(PointerWrap& p);
+void DoState(StateLoadStore& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -7,7 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/ConstantManager.h"
 
-class PointerWrap;
+class StateLoadStore;
 
 // The non-API dependent parts.
 class PixelShaderManager
@@ -15,15 +15,15 @@ class PixelShaderManager
 public:
   static void Init();
   static void Dirty();
-  static void DoState(PointerWrap& p);
+  static void DoState(StateLoadStore& p);
 
   static void SetConstants();  // sets pixel shader constants
 
   // constant management
   // Some of these functions grab the constant values from global state,
   // so make sure to call them after memory is committed
-  static void SetTevColor(int index, int component, s32 value);
-  static void SetTevKonstColor(int index, int component, s32 value);
+  static void SetTevColorRA(int index);
+  static void SetTevColorBG(int index);
   static void SetAlpha();
   static void SetDestAlpha();
   static void SetTexDims(int texmapid, u32 width, u32 height);

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -287,10 +287,10 @@ void VertexManagerBase::Flush()
   s_cull_all = false;
 }
 
-void VertexManagerBase::DoState(PointerWrap& p)
+void VertexManagerBase::DoState(StateLoadStore& p)
 {
   p.Do(s_zslope);
-  g_vertex_manager->vDoState(p);
+  s_zslope.dirty = true;
 }
 
 void VertexManagerBase::CalculateZSlope(NativeVertexFormat* format)

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -12,7 +12,7 @@
 
 class DataReader;
 class NativeVertexFormat;
-class PointerWrap;
+class StateLoadStore;
 struct PortableVertexDeclaration;
 
 enum PrimitiveType
@@ -58,10 +58,9 @@ public:
   virtual NativeVertexFormat*
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) = 0;
 
-  static void DoState(PointerWrap& p);
+  static void DoState(StateLoadStore& p);
 
 protected:
-  virtual void vDoState(PointerWrap& p) {}
   static PrimitiveType current_primitive_type;
 
   virtual void ResetBuffer(u32 stride) = 0;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -220,6 +220,9 @@ void VertexShaderManager::Dirty()
 {
   // This function is called after a savestate is loaded.
   // Any constants that can changed based on settings should be re-calculated
+  Matrix44::LoadIdentity(s_viewportCorrection);
+  InvalidateXFRange(0, sizeof(XFMemory));
+  bViewportChanged = true;
   bProjectionChanged = true;
 
   dirty = true;
@@ -623,7 +626,7 @@ void VertexShaderManager::InvalidateXFRange(int start, int end)
 
   if (start < XFMEM_POSTMATRICES_END && end > XFMEM_POSTMATRICES)
   {
-    int _start = start < XFMEM_POSTMATRICES ? XFMEM_POSTMATRICES : start - XFMEM_POSTMATRICES;
+    int _start = start < XFMEM_POSTMATRICES ? 0 : start - XFMEM_POSTMATRICES;
     int _end = end < XFMEM_POSTMATRICES_END ? end - XFMEM_POSTMATRICES :
                                               XFMEM_POSTMATRICES_END - XFMEM_POSTMATRICES;
 
@@ -765,29 +768,14 @@ void VertexShaderManager::TransformToClipSpace(const float* data, float* out, u3
       t[0] * proj_matrix[12] + t[1] * proj_matrix[13] + t[2] * proj_matrix[14] + proj_matrix[15];
 }
 
-void VertexShaderManager::DoState(PointerWrap& p)
+void VertexShaderManager::DoState(StateLoadStore& p)
 {
-  p.Do(g_fProjectionMatrix);
-  p.Do(s_viewportCorrection);
+  // freelook state
   p.Do(s_viewRotationMatrix);
   p.Do(s_viewInvRotationMatrix);
   p.Do(s_fViewTranslationVector);
   p.Do(s_fViewRotation);
-
-  p.Do(nTransformMatricesChanged);
-  p.Do(nNormalMatricesChanged);
-  p.Do(nPostTransformMatricesChanged);
-  p.Do(nLightsChanged);
-
-  p.Do(nMaterialsChanged);
-  p.Do(bTexMatricesChanged);
-  p.Do(bPosNormalMatrixChanged);
-  p.Do(bProjectionChanged);
-  p.Do(bViewportChanged);
-
-  p.Do(constants);
-
-  if (p.GetMode() == PointerWrap::MODE_READ)
+  if (p.IsLoad())
   {
     Dirty();
   }

--- a/Source/Core/VideoCommon/VertexShaderManager.h
+++ b/Source/Core/VideoCommon/VertexShaderManager.h
@@ -19,7 +19,7 @@ class VertexShaderManager
 public:
   static void Init();
   static void Dirty();
-  static void DoState(PointerWrap& p);
+  static void DoState(StateLoadStore& p);
 
   // constant management
   static void SetConstants();

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -15,7 +15,7 @@ namespace MMIO
 {
 class Mapping;
 }
-class PointerWrap;
+class StateLoadStore;
 
 enum FieldType
 {
@@ -92,7 +92,7 @@ public:
 
   // the implementation needs not do synchronization logic, because calls to it are surrounded by
   // PauseAndLock now
-  void DoState(PointerWrap& p);
+  bool DoState(StateLoadStore& p);
 
   void CheckInvalidState();
 

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -19,7 +19,7 @@
 #include "VideoCommon/VideoState.h"
 #include "VideoCommon/XFMemory.h"
 
-void VideoCommon_DoState(PointerWrap& p)
+bool VideoCommon_DoState(StateLoadStore& p)
 {
   // BP Memory
   p.Do(bpmem);
@@ -37,7 +37,8 @@ void VideoCommon_DoState(PointerWrap& p)
   p.DoMarker("texMem");
 
   // FIFO
-  Fifo::DoState(p);
+  if (!Fifo::DoState(p))
+    return false;
   p.DoMarker("Fifo");
 
   CommandProcessor::DoState(p);
@@ -64,4 +65,5 @@ void VideoCommon_DoState(PointerWrap& p)
   p.DoMarker("BoundingBox");
 
   // TODO: search for more data that should be saved and add it here
+  return true;
 }

--- a/Source/Core/VideoCommon/VideoState.h
+++ b/Source/Core/VideoCommon/VideoState.h
@@ -4,6 +4,6 @@
 
 #pragma once
 
-class PointerWrap;
+class StateLoadStore;
 
-void VideoCommon_DoState(PointerWrap& p);
+bool VideoCommon_DoState(StateLoadStore& p);


### PR DESCRIPTION
Perhaps this should be split up, but basically I went through all the code that handles save states and attempted cleanup/simplification, to prepare for future changes.

```
ChunkFile.h:
  General refactoring:
    - Remove MODE_VERIFY because it was unused, and MODE_MEASURE because (a)
      having fewer modes to branch on is faster, (b) not having to go through
      the state twice to measure size should be faster overall, and (c) the old
      code could overrun a buffer if for some crazy reason the contents of Wii
      /tmp were changed between measuring and writing, and this is easier than
      giving it some special treatment.

      Now there is just a 'bool IsLoad()'.
    - Try to prevent crashing in the presence of invalid data.
    - Add StateLoadStore subclass to PointerWrap to distinguish use for
      savestates from other uses.  At the moment the subclass is empty and the
      only other use of PointerWrap is essentially vestigial, but I plan to add
      some stuff to support quick in-memory save/load that avoids saving and
      restoring state that hasn't changed (think GGPO), and it might be nice to
      use PointerWrap for netplay packets (my old fork did that).
ChunkFile.cpp:
    - Add file.
FileUtil.cpp:
    - Use a random filename for atomic writes so that multiple atomic writes to
      the same path are actually, y'know, atomic - not secure for public
      directories, but that probably doesn't matter.
    - Modify File::Delete to be atomic with respect to other deletions; add a
      parameter to request that no error message be generated if the file
      didn't exist.
    - Modify File::Rename, ditto.
Movie.cpp:
    - Remove error handling and backup logic from Movie::SaveRecording, which
      shouldn't apply when it's called from CompressAndDumpState.  Move that to
      a new function, SaveRecordingUserRequested.
State.cpp:
    - Remove unused Verify functions.
    - Remove wait argument to SaveAs, which made it synchronous; Lua is no
      longer supported, and any replacement can have better API design.
    - Have SaveAs use SaveToBuffer rather than duplicating logic, ditto LoadAs.
    - Stop the compression process from blocking later save/load operations.
      Make it fully asynchronous.
    - LoadFileStateData: prevent buffer overflow
    - Make g_use_compression atomic to avoid races.  Right now there is no way
      to change it from true, but who knows, maybe it will make sense to expose
      it in some libDolphin someday.
    - Change SetOnAfterLoadCallback to SetOnAfterLoadSaveCallback, change to
      std::function, and use it instead of calling the deprecated
      Host_UpdateMainFrame.
    - Make LoadLastSaved/SaveFirstSaved implementation less lame.
VertexShaderManager.cpp, PixelShaderManager.cpp:
    - When loading state, recalculate cached data from registers rather than
      putting it in the save data.
Fifo.cpp:
    - Only save the part of the internal FIFO buffer that's in use, not the
      whole 2MB buffer.
WII_IPC_HLE_Device_usb.cpp:
    - Zero the unused portion of ACL buffers so junk data doesn't get into saves.
DSPHLE.cpp/h, UCodes.cpp/h, about a million resulting juggled #includes:
    - Convert UCodeInterface code to use unique_ptr to make DSPHLE::DoState much shorter.
MailHandler.h:
    - queue->deque in order to use the standard container serialization routine
MainWindow.cpp (DolphinQt2):
    - Use SetOnAfterLoadSaveCallback rather than relying on synchronous saves.

... more stuff I need to put here ...

TODO:
    remove unnecessary 'class PointerWrap;'
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4037)

<!-- Reviewable:end -->
