### PR TITLE
Don't pipe PanicAlerts to netplay window if it isn't opened

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -372,16 +372,13 @@ bool wxMsgAlert(const char* caption, const char* text, bool yes_no, int /*Style*
   {
 #endif
     NetPlayDialog*& npd = NetPlayDialog::GetInstance();
-    if (npd == nullptr)
-    {
-      return wxYES == wxMessageBox(StrToWxStr(text), StrToWxStr(caption),
-                                   (yes_no) ? wxYES_NO : wxOK, wxWindow::FindFocus());
-    }
-    else
+    if (npd != nullptr && npd->IsShown())
     {
       npd->AppendChat("/!\\ " + std::string{text});
       return true;
     }
+    return wxYES == wxMessageBox(StrToWxStr(text), StrToWxStr(caption), (yes_no) ? wxYES_NO : wxOK,
+                                 wxWindow::FindFocus());
 #ifdef __WXGTK__
   }
   else


### PR DESCRIPTION
This is something that was quite confusing for me while trying to get netplay to work for me; once the Connect/Host buttons were pressed, the UI would hang, only to work again a few seconds later, but with no error message or explanation *at all*.

Turns out this is because panic alerts are shown in the netplay window instead during netplay, even before it is even shown.

This fixes it by "piping" the alerts to the netplay chat only if the netplay window is visible.

(regression introduced in #3823)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4042)
<!-- Reviewable:end -->
