### PR TITLE
Fixes crash on Castlevania - The Adventure ReBirth (game INI update)

### DIFF
--- a/Data/Sys/GameSettings/WD9.ini
+++ b/Data/Sys/GameSettings/WD9.ini
@@ -17,3 +17,6 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
+[Core]
+CPUThread = False
+


### PR DESCRIPTION
Disables dual core in WD9.ini for game Castlevania - The Adventure ReBirth. Without this toggle, the game will crash after the title screen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4044)
<!-- Reviewable:end -->
