### PR TITLE
GameSettings - Fix flickering cutscenes in Castlevania - The Adventure ReBirth

### DIFF
--- a/Data/Sys/GameSettings/WD9.ini
+++ b/Data/Sys/GameSettings/WD9.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+CPUThread = False
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
@@ -17,6 +18,5 @@ EmulationIssues =
 [ActionReplay]
 # Add action replay cheats here.
 
-[Core]
-CPUThread = False
-
+[Video_Hacks]
+EFBToTextureEnable = False


### PR DESCRIPTION
According to the wiki:
https://wiki.dolphin-emu.org/index.php?title=Castlevania:_The_Adventure_ReBirth

Disabling "Store EFB Copies to Texture Only" in the INI file (WD9) will fix the flickering cutscene problem.

I also tidied some of my previous sloppiness. :3 Apologies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4046)
<!-- Reviewable:end -->
