### PR TITLE
VideoCommon: Make API_TYPE an enum class

### DIFF
--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -225,7 +225,7 @@ bool GeometryShaderCache::SetShader(u32 primitive_type)
   }
 
   // Need to compile a new shader
-  ShaderCode code = GenerateGeometryShaderCode(API_D3D, uid.GetUidData());
+  ShaderCode code = GenerateGeometryShaderCode(APIType::D3D, uid.GetUidData());
 
   D3DBlob* pbytecode;
   if (!D3D::CompileGeometryShader(code.GetBuffer(), &pbytecode))

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -14,6 +14,7 @@
 #include "VideoBackends/D3D/VertexShaderCache.h"
 
 #include "VideoCommon/TextureConversionShader.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace DX11
 {
@@ -198,7 +199,7 @@ ID3D11PixelShader* PSTextureEncoder::SetStaticShader(unsigned int dstFormat,
     }
 
     D3DBlob* bytecode = nullptr;
-    const char* shader = TextureConversionShader::GenerateEncodingShader(format, API_D3D);
+    const char* shader = TextureConversionShader::GenerateEncodingShader(format, APIType::D3D);
     if (!D3D::CompilePixelShader(shader, &bytecode))
     {
       WARN_LOG(VIDEO, "EFB encoder shader for dstFormat 0x%X, srcFormat %d, isIntensity %d, "

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -578,7 +578,7 @@ bool PixelShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode)
   }
 
   // Need to compile a new shader
-  ShaderCode code = GeneratePixelShaderCode(dstAlphaMode, API_D3D, uid.GetUidData());
+  ShaderCode code = GeneratePixelShaderCode(dstAlphaMode, APIType::D3D, uid.GetUidData());
 
   D3DBlob* pbytecode;
   if (!D3D::CompilePixelShader(code.GetBuffer(), &pbytecode))

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -217,7 +217,7 @@ bool VertexShaderCache::SetShader()
     return (entry.shader != nullptr);
   }
 
-  ShaderCode code = GenerateVertexShaderCode(API_D3D, uid.GetUidData());
+  ShaderCode code = GenerateVertexShaderCode(APIType::D3D, uid.GetUidData());
 
   D3DBlob* pbytecode = nullptr;
   D3D::CompileVertexShader(code.GetBuffer(), &pbytecode);

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -6,11 +6,9 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
-#include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Host.h"
 
 #include "VideoBackends/D3D/BoundingBox.h"
 #include "VideoBackends/D3D/D3DBase.h"
@@ -24,16 +22,7 @@
 #include "VideoBackends/D3D/VertexShaderCache.h"
 #include "VideoBackends/D3D/VideoBackend.h"
 
-#include "VideoCommon/BPStructs.h"
-#include "VideoCommon/CommandProcessor.h"
-#include "VideoCommon/Fifo.h"
-#include "VideoCommon/GeometryShaderManager.h"
-#include "VideoCommon/IndexGenerator.h"
-#include "VideoCommon/OpcodeDecoding.h"
-#include "VideoCommon/PixelEngine.h"
-#include "VideoCommon/PixelShaderManager.h"
-#include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexShaderManager.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace DX11
@@ -72,7 +61,7 @@ void VideoBackend::InitBackendInfo()
     return;
   }
 
-  g_Config.backend_info.APIType = API_D3D;
+  g_Config.backend_info.api_type = APIType::D3D;
   g_Config.backend_info.bSupportsExclusiveFullscreen = true;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
@@ -16,6 +16,7 @@
 #include "VideoBackends/D3D12/TextureCache.h"
 
 #include "VideoCommon/TextureConversionShader.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace DX12
 {
@@ -249,7 +250,7 @@ D3D12_SHADER_BYTECODE PSTextureEncoder::SetStaticShader(unsigned int dst_format,
     }
 
     ID3DBlob* bytecode = nullptr;
-    const char* shader = TextureConversionShader::GenerateEncodingShader(format, API_D3D);
+    const char* shader = TextureConversionShader::GenerateEncodingShader(format, APIType::D3D);
     if (!D3D::CompilePixelShader(shader, &bytecode))
     {
       WARN_LOG(VIDEO, "EFB encoder shader for dst_format 0x%X, src_format %d, is_intensity %d, "

--- a/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
@@ -12,6 +12,7 @@
 
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/Statistics.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace DX12
 {
@@ -203,7 +204,7 @@ void ShaderCache::HandleGSUIDChange(GeometryShaderUid gs_uid, u32 gs_primitive_t
   }
   else
   {
-    ShaderCode gs_code = GenerateGeometryShaderCode(API_D3D, gs_uid.GetUidData());
+    ShaderCode gs_code = GenerateGeometryShaderCode(APIType::D3D, gs_uid.GetUidData());
     ID3DBlob* gs_bytecode = nullptr;
 
     if (!D3D::CompileGeometryShader(gs_code.GetBuffer(), &gs_bytecode))
@@ -230,7 +231,8 @@ void ShaderCache::HandlePSUIDChange(PixelShaderUid ps_uid, DSTALPHA_MODE ps_dst_
   }
   else
   {
-    ShaderCode ps_code = GeneratePixelShaderCode(ps_dst_alpha_mode, API_D3D, ps_uid.GetUidData());
+    ShaderCode ps_code =
+        GeneratePixelShaderCode(ps_dst_alpha_mode, APIType::D3D, ps_uid.GetUidData());
     ID3DBlob* ps_bytecode = nullptr;
 
     if (!D3D::CompilePixelShader(ps_code.GetBuffer(), &ps_bytecode))
@@ -260,7 +262,7 @@ void ShaderCache::HandleVSUIDChange(VertexShaderUid vs_uid)
   }
   else
   {
-    ShaderCode vs_code = GenerateVertexShaderCode(API_D3D, vs_uid.GetUidData());
+    ShaderCode vs_code = GenerateVertexShaderCode(APIType::D3D, vs_uid.GetUidData());
     ID3DBlob* vs_bytecode = nullptr;
 
     if (!D3D::CompileVertexShader(vs_code.GetBuffer(), &vs_bytecode))

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -5,11 +5,9 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
-#include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
 #include "Core/ConfigManager.h"
-#include "Core/Host.h"
 
 #include "VideoBackends/D3D12/BoundingBox.h"
 #include "VideoBackends/D3D12/D3DBase.h"
@@ -25,16 +23,7 @@
 #include "VideoBackends/D3D12/VideoBackend.h"
 #include "VideoBackends/D3D12/XFBEncoder.h"
 
-#include "VideoCommon/BPStructs.h"
-#include "VideoCommon/CommandProcessor.h"
-#include "VideoCommon/Fifo.h"
-#include "VideoCommon/GeometryShaderManager.h"
-#include "VideoCommon/IndexGenerator.h"
-#include "VideoCommon/OpcodeDecoding.h"
-#include "VideoCommon/PixelEngine.h"
-#include "VideoCommon/PixelShaderManager.h"
-#include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexShaderManager.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace DX12
@@ -75,7 +64,7 @@ void VideoBackend::InitBackendInfo()
     return;
   }
 
-  g_Config.backend_info.APIType = API_D3D;
+  g_Config.backend_info.api_type = APIType::D3D;
   g_Config.backend_info.bSupportsExclusiveFullscreen = false;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -7,8 +7,6 @@
 // This backend tries not to do anything in the backend,
 // but everything in VideoCommon.
 
-#include "Core/Host.h"
-
 #include "VideoBackends/Null/FramebufferManager.h"
 #include "VideoBackends/Null/PerfQuery.h"
 #include "VideoBackends/Null/Render.h"
@@ -17,24 +15,15 @@
 #include "VideoBackends/Null/VertexManager.h"
 #include "VideoBackends/Null/VideoBackend.h"
 
-#include "VideoCommon/BPStructs.h"
-#include "VideoCommon/CommandProcessor.h"
-#include "VideoCommon/Fifo.h"
-#include "VideoCommon/IndexGenerator.h"
-#include "VideoCommon/OnScreenDisplay.h"
-#include "VideoCommon/OpcodeDecoding.h"
-#include "VideoCommon/PixelEngine.h"
-#include "VideoCommon/PixelShaderManager.h"
-#include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace Null
 {
 void VideoBackend::InitBackendInfo()
 {
-  g_Config.backend_info.APIType = API_NONE;
+  g_Config.backend_info.api_type = APIType::Nothing;
   g_Config.backend_info.bSupportsExclusiveFullscreen = true;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsEarlyZ = true;

--- a/Source/Core/VideoBackends/Null/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/Null/ShaderCache.cpp
@@ -6,6 +6,7 @@
 
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/Statistics.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace Null
 {
@@ -34,7 +35,7 @@ void ShaderCache<Uid>::Clear()
 template <typename Uid>
 bool ShaderCache<Uid>::SetShader(DSTALPHA_MODE dst_alpha_mode, u32 primitive_type)
 {
-  Uid uid = GetUid(dst_alpha_mode, primitive_type, API_OPENGL);
+  Uid uid = GetUid(dst_alpha_mode, primitive_type, APIType::OpenGL);
 
   // Check if the shader is already set
   if (m_last_entry)
@@ -59,7 +60,7 @@ bool ShaderCache<Uid>::SetShader(DSTALPHA_MODE dst_alpha_mode, u32 primitive_typ
   }
 
   // Need to compile a new shader
-  ShaderCode code = GenerateCode(dst_alpha_mode, API_OPENGL, uid);
+  ShaderCode code = GenerateCode(dst_alpha_mode, APIType::OpenGL, uid);
   m_shaders.emplace(uid, code.GetBuffer());
 
   GFX_DEBUGGER_PAUSE_AT(NEXT_PIXEL_SHADER_CHANGE, true);

--- a/Source/Core/VideoBackends/Null/ShaderCache.h
+++ b/Source/Core/VideoBackends/Null/ShaderCache.h
@@ -25,8 +25,8 @@ public:
   bool SetShader(DSTALPHA_MODE dst_alpha_mode, u32 primitive_type);
 
 protected:
-  virtual Uid GetUid(DSTALPHA_MODE dst_alpha_mode, u32 primitive_type, API_TYPE api_type) = 0;
-  virtual ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, API_TYPE api_type, Uid uid) = 0;
+  virtual Uid GetUid(DSTALPHA_MODE dst_alpha_mode, u32 primitive_type, APIType api_type) = 0;
+  virtual ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, APIType api_type, Uid uid) = 0;
 
 private:
   std::map<Uid, std::string> m_shaders;
@@ -41,11 +41,11 @@ public:
 
 protected:
   VertexShaderUid GetUid(DSTALPHA_MODE dst_alpha_mode, u32 primitive_type,
-                         API_TYPE api_type) override
+                         APIType api_type) override
   {
     return GetVertexShaderUid();
   }
-  ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, API_TYPE api_type,
+  ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, APIType api_type,
                           VertexShaderUid uid) override
   {
     return GenerateVertexShaderCode(api_type, uid.GetUidData());
@@ -59,11 +59,11 @@ public:
 
 protected:
   GeometryShaderUid GetUid(DSTALPHA_MODE dst_alpha_mode, u32 primitive_type,
-                           API_TYPE api_type) override
+                           APIType api_type) override
   {
     return GetGeometryShaderUid(primitive_type);
   }
-  ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, API_TYPE api_type,
+  ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, APIType api_type,
                           GeometryShaderUid uid) override
   {
     return GenerateGeometryShaderCode(api_type, uid.GetUidData());
@@ -76,12 +76,11 @@ public:
   static std::unique_ptr<PixelShaderCache> s_instance;
 
 protected:
-  PixelShaderUid GetUid(DSTALPHA_MODE dst_alpha_mode, u32 primitive_type,
-                        API_TYPE api_type) override
+  PixelShaderUid GetUid(DSTALPHA_MODE dst_alpha_mode, u32 primitive_type, APIType api_type) override
   {
     return GetPixelShaderUid(dst_alpha_mode);
   }
-  ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, API_TYPE api_type,
+  ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, APIType api_type,
                           PixelShaderUid uid) override
   {
     return GeneratePixelShaderCode(dst_alpha_mode, api_type, uid.GetUidData());

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -20,6 +20,7 @@
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexShaderManager.h"
+#include "VideoCommon/VideoCommon.h"
 
 namespace OGL
 {
@@ -206,12 +207,12 @@ SHADER* ProgramShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode, u32 primitive_
   last_entry = &newentry;
   newentry.in_cache = 0;
 
-  ShaderCode vcode = GenerateVertexShaderCode(API_OPENGL, uid.vuid.GetUidData());
-  ShaderCode pcode = GeneratePixelShaderCode(dstAlphaMode, API_OPENGL, uid.puid.GetUidData());
+  ShaderCode vcode = GenerateVertexShaderCode(APIType::OpenGL, uid.vuid.GetUidData());
+  ShaderCode pcode = GeneratePixelShaderCode(dstAlphaMode, APIType::OpenGL, uid.puid.GetUidData());
   ShaderCode gcode;
   if (g_ActiveConfig.backend_info.bSupportsGeometryShaders &&
       !uid.guid.GetUidData()->IsPassthrough())
-    gcode = GenerateGeometryShaderCode(API_OPENGL, uid.guid.GetUidData());
+    gcode = GenerateGeometryShaderCode(APIType::OpenGL, uid.guid.GetUidData());
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   if (g_ActiveConfig.iLog & CONF_SAVESHADERS)

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -22,6 +22,7 @@
 #include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/TextureConversionShader.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace OGL
@@ -140,7 +141,7 @@ static SHADER& GetOrCreateEncodingShader(u32 format)
 
   if (s_encodingPrograms[format].glprogid == 0)
   {
-    const char* shader = TextureConversionShader::GenerateEncodingShader(format, API_OPENGL);
+    const char* shader = TextureConversionShader::GenerateEncodingShader(format, APIType::OpenGL);
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
     if (g_ActiveConfig.iLog & CONF_SAVESHADERS && shader)

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -38,14 +38,10 @@ Make AA apply instantly during gameplay if possible
 #include <string>
 #include <vector>
 
-#include "Common/Atomic.h"
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
 #include "Common/GL/GLInterfaceBase.h"
 #include "Common/GL/GLUtil.h"
-
-#include "Core/ConfigManager.h"
-#include "Core/Host.h"
 
 #include "VideoBackends/OGL/BoundingBox.h"
 #include "VideoBackends/OGL/PerfQuery.h"
@@ -57,17 +53,8 @@ Make AA apply instantly during gameplay if possible
 #include "VideoBackends/OGL/VertexManager.h"
 #include "VideoBackends/OGL/VideoBackend.h"
 
-#include "VideoCommon/BPStructs.h"
-#include "VideoCommon/CommandProcessor.h"
-#include "VideoCommon/Fifo.h"
-#include "VideoCommon/GeometryShaderManager.h"
-#include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/OnScreenDisplay.h"
-#include "VideoCommon/OpcodeDecoding.h"
-#include "VideoCommon/PixelEngine.h"
-#include "VideoCommon/PixelShaderManager.h"
-#include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexShaderManager.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace OGL
@@ -108,7 +95,7 @@ static std::vector<std::string> GetShaders(const std::string& sub_dir = "")
 
 void VideoBackend::InitBackendInfo()
 {
-  g_Config.backend_info.APIType = API_OPENGL;
+  g_Config.backend_info.api_type = APIType::OpenGL;
   g_Config.backend_info.bSupportsExclusiveFullscreen = false;
   g_Config.backend_info.bSupportsOversizedViewports = true;
   g_Config.backend_info.bSupportsGeometryShaders = true;

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -2,15 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <atomic>
 #include <memory>
 #include <string>
 
 #include "Common/CommonTypes.h"
-#include "Common/FileUtil.h"
-#include "Common/Logging/LogManager.h"
-
-#include "Core/Host.h"
 
 #include "VideoBackends/Software/Clipper.h"
 #include "VideoBackends/Software/DebugUtil.h"
@@ -22,18 +17,11 @@
 #include "VideoBackends/Software/SWVertexLoader.h"
 #include "VideoBackends/Software/VideoBackend.h"
 
-#include "VideoCommon/BPStructs.h"
-#include "VideoCommon/CommandProcessor.h"
-#include "VideoCommon/Fifo.h"
 #include "VideoCommon/FramebufferManagerBase.h"
-#include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/OnScreenDisplay.h"
-#include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/PixelEngine.h"
-#include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/TextureCacheBase.h"
-#include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VertexShaderManager.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 #define VSYNC_ENABLED 0
@@ -136,7 +124,7 @@ std::string VideoSoftware::GetDisplayName() const
 
 void VideoSoftware::InitBackendInfo()
 {
-  g_Config.backend_info.APIType = API_NONE;
+  g_Config.backend_info.api_type = APIType::Nothing;
   g_Config.backend_info.bSupports3DVision = false;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsEarlyZ = true;

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -9,6 +9,7 @@
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/GeometryShaderGen.h"
 #include "VideoCommon/LightingShaderGen.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 static const char* primitives_ogl[] = {"points", "lines", "triangles"};
@@ -16,9 +17,9 @@ static const char* primitives_ogl[] = {"points", "lines", "triangles"};
 static const char* primitives_d3d[] = {"point", "line", "triangle"};
 
 template <class T>
-static void EmitVertex(T& out, const char* vertex, API_TYPE ApiType, bool first_vertex = false);
+static void EmitVertex(T& out, const char* vertex, APIType ApiType, bool first_vertex = false);
 template <class T>
-static void EndPrimitive(T& out, API_TYPE ApiType);
+static void EndPrimitive(T& out, APIType ApiType);
 
 GeometryShaderUid GetGeometryShaderUid(u32 primitive_type)
 {
@@ -38,11 +39,11 @@ GeometryShaderUid GetGeometryShaderUid(u32 primitive_type)
 }
 
 static void EmitVertex(ShaderCode& out, const geometry_shader_uid_data* uid_data,
-                       const char* vertex, API_TYPE ApiType, bool first_vertex = false);
+                       const char* vertex, APIType ApiType, bool first_vertex = false);
 static void EndPrimitive(ShaderCode& out, const geometry_shader_uid_data* uid_data,
-                         API_TYPE ApiType);
+                         APIType ApiType);
 
-ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_uid_data* uid_data)
+ShaderCode GenerateGeometryShaderCode(APIType ApiType, const geometry_shader_uid_data* uid_data)
 {
   ShaderCode out;
   // Non-uid template parameters will write to the dummy data (=> gets optimized out)
@@ -53,7 +54,7 @@ ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_ui
   if (uid_data->wireframe)
     vertex_out++;
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
   {
     // Insert layout parameters
     if (g_ActiveConfig.backend_info.bSupportsGSInstancing)
@@ -75,7 +76,7 @@ ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_ui
   out.Write("%s", s_lighting_struct);
 
   // uniforms
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
     out.Write("layout(std140%s) uniform GSBlock {\n",
               g_ActiveConfig.backend_info.bSupportsBindingLayout ? ", binding = 3" : "");
   else
@@ -90,7 +91,7 @@ ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_ui
                                       "");
   out.Write("};\n");
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
   {
     if (g_ActiveConfig.backend_info.bSupportsGSInstancing)
       out.Write("#define InstanceID gl_InvocationID\n");
@@ -144,7 +145,7 @@ ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_ui
 
   if (uid_data->primitive_type == PRIMITIVE_LINES)
   {
-    if (ApiType == API_OPENGL)
+    if (ApiType == APIType::OpenGL)
     {
       out.Write("\tVS_OUTPUT start, end;\n");
       AssignVSOutputMembers(out, "start", "vs[0]", uid_data->numTexGens, uid_data->pixel_lighting);
@@ -175,7 +176,7 @@ ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_ui
   }
   else if (uid_data->primitive_type == PRIMITIVE_POINTS)
   {
-    if (ApiType == API_OPENGL)
+    if (ApiType == APIType::OpenGL)
     {
       out.Write("\tVS_OUTPUT center;\n");
       AssignVSOutputMembers(out, "center", "vs[0]", uid_data->numTexGens, uid_data->pixel_lighting);
@@ -206,7 +207,7 @@ ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_ui
 
   out.Write("\tfor (int i = 0; i < %d; ++i) {\n", vertex_in);
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
   {
     out.Write("\tVS_OUTPUT f;\n");
     AssignVSOutputMembers(out, "f", "vs[i]", uid_data->numTexGens, uid_data->pixel_lighting);
@@ -220,7 +221,7 @@ ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_ui
   {
     // Select the output layer
     out.Write("\tps.layer = eye;\n");
-    if (ApiType == API_OPENGL)
+    if (ApiType == APIType::OpenGL)
       out.Write("\tgl_Layer = eye;\n");
 
     // For stereoscopy add a small horizontal offset in Normalized Device Coordinates proportional
@@ -303,12 +304,12 @@ ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_ui
 }
 
 static void EmitVertex(ShaderCode& out, const geometry_shader_uid_data* uid_data,
-                       const char* vertex, API_TYPE ApiType, bool first_vertex)
+                       const char* vertex, APIType ApiType, bool first_vertex)
 {
   if (uid_data->wireframe && first_vertex)
     out.Write("\tif (i == 0) first = %s;\n", vertex);
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
   {
     out.Write("\tgl_Position = %s.pos;\n", vertex);
     AssignVSOutputMembers(out, "ps", vertex, uid_data->numTexGens, uid_data->pixel_lighting);
@@ -318,19 +319,18 @@ static void EmitVertex(ShaderCode& out, const geometry_shader_uid_data* uid_data
     out.Write("\tps.o = %s;\n", vertex);
   }
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
     out.Write("\tEmitVertex();\n");
   else
     out.Write("\toutput.Append(ps);\n");
 }
 
-static void EndPrimitive(ShaderCode& out, const geometry_shader_uid_data* uid_data,
-                         API_TYPE ApiType)
+static void EndPrimitive(ShaderCode& out, const geometry_shader_uid_data* uid_data, APIType ApiType)
 {
   if (uid_data->wireframe)
     EmitVertex(out, uid_data, "first", ApiType);
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
     out.Write("\tEndPrimitive();\n");
   else
     out.Write("\toutput.RestartStrip();\n");

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -6,7 +6,8 @@
 
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/VertexManagerBase.h"
-#include "VideoCommon/VideoCommon.h"
+
+enum class APIType;
 
 #pragma pack(1)
 
@@ -31,5 +32,5 @@ struct geometry_shader_uid_data
 
 typedef ShaderUid<geometry_shader_uid_data> GeometryShaderUid;
 
-ShaderCode GenerateGeometryShaderCode(API_TYPE ApiType, const geometry_shader_uid_data* uid_data);
+ShaderCode GenerateGeometryShaderCode(APIType ApiType, const geometry_shader_uid_data* uid_data);
 GeometryShaderUid GetGeometryShaderUid(u32 primitive_type);

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -15,6 +15,7 @@
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/PixelShaderGen.h"
 #include "VideoCommon/VertexLoaderManager.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"  // for texture projection mode
 
@@ -335,16 +336,16 @@ PixelShaderUid GetPixelShaderUid(DSTALPHA_MODE dstAlphaMode)
 }
 
 static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, int n,
-                       API_TYPE ApiType);
+                       APIType ApiType);
 static void WriteTevRegular(ShaderCode& out, const char* components, int bias, int op, int clamp,
                             int shift);
 static void SampleTexture(ShaderCode& out, const char* texcoords, const char* texswap, int texmap,
-                          bool stereo, API_TYPE ApiType);
-static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_data, API_TYPE ApiType,
+                          bool stereo, APIType ApiType);
+static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_data, APIType ApiType,
                            DSTALPHA_MODE dstAlphaMode, bool per_pixel_depth);
 static void WriteFog(ShaderCode& out, const pixel_shader_uid_data* uid_data);
 
-ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
+ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, APIType ApiType,
                                    const pixel_shader_uid_data* uid_data)
 {
   ShaderCode out;
@@ -379,7 +380,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
             "int3 itrunc(float3 x) { return int3(trunc(x)); }\n"
             "int4 itrunc(float4 x) { return int4(trunc(x)); }\n\n");
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
   {
     out.Write("SAMPLER_BINDING(0) uniform sampler2DArray samp[8];\n");
   }
@@ -392,7 +393,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
   }
   out.Write("\n");
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
   {
     out.Write("layout(std140%s) uniform PSBlock {\n",
               g_ActiveConfig.backend_info.bSupportsBindingLayout ? ", binding = 1" : "");
@@ -419,7 +420,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
   {
     out.Write("%s", s_lighting_struct);
 
-    if (ApiType == API_OPENGL)
+    if (ApiType == APIType::OpenGL)
     {
       out.Write("layout(std140%s) uniform VSBlock {\n",
                 g_ActiveConfig.backend_info.bSupportsBindingLayout ? ", binding = 2" : "");
@@ -434,7 +435,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
 
   if (uid_data->bounding_box)
   {
-    if (ApiType == API_OPENGL)
+    if (ApiType == APIType::OpenGL)
     {
       out.Write("layout(std140, binding = 3) buffer BBox {\n"
                 "\tint4 bbox_data;\n"
@@ -487,7 +488,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
     // ARB_image_load_store extension yet.
 
     // D3D11 also has a way to force the driver to enable early-z, so we're fine here.
-    if (ApiType == API_OPENGL)
+    if (ApiType == APIType::OpenGL)
     {
       // This is a #define which signals whatever early-z method the driver supports.
       out.Write("FORCE_EARLY_Z; \n");
@@ -509,7 +510,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
     warn_once = false;
   }
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
   {
     out.Write("out vec4 ocol0;\n");
     if (dstAlphaMode == DSTALPHA_DUAL_SOURCE_BLEND)
@@ -715,7 +716,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
     out.Write("\tfloat2 screenpos = rawpos.xy * " I_EFBSCALE ".xy;\n");
 
     // Opengl has reversed vertical screenspace coordinates
-    if (ApiType == API_OPENGL)
+    if (ApiType == APIType::OpenGL)
       out.Write("\tscreenpos.y = %i.0 - screenpos.y;\n", EFB_HEIGHT);
 
     out.Write("\tint zCoord = int(" I_ZSLOPE ".z + " I_ZSLOPE ".x * screenpos.x + " I_ZSLOPE
@@ -735,7 +736,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
   }
   else
   {
-    if (ApiType == API_D3D)
+    if (ApiType == APIType::D3D)
       out.Write("\tint zCoord = int((1.0 - rawpos.z) * 16777216.0);\n");
     else
       out.Write("\tint zCoord = int(rawpos.z * 16777216.0);\n");
@@ -749,7 +750,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
   // Note: z-textures are not written to depth buffer if early depth test is used
   if (uid_data->per_pixel_depth && uid_data->early_ztest)
   {
-    if (ApiType == API_D3D)
+    if (ApiType == APIType::D3D)
       out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
     else
       out.Write("\tdepth = float(zCoord) / 16777216.0;\n");
@@ -770,7 +771,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
 
   if (uid_data->per_pixel_depth && uid_data->late_ztest)
   {
-    if (ApiType == API_D3D)
+    if (ApiType == APIType::D3D)
       out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
     else
       out.Write("\tdepth = float(zCoord) / 16777216.0;\n");
@@ -800,7 +801,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
 
   if (uid_data->bounding_box)
   {
-    const char* atomic_op = ApiType == API_OPENGL ? "atomic" : "Interlocked";
+    const char* atomic_op = ApiType == APIType::OpenGL ? "atomic" : "Interlocked";
     out.Write("\tif(bbox_data[0] > int(rawpos.x)) %sMin(bbox_data[0], int(rawpos.x));\n"
               "\tif(bbox_data[1] < int(rawpos.x)) %sMax(bbox_data[1], int(rawpos.x));\n"
               "\tif(bbox_data[2] > int(rawpos.y)) %sMin(bbox_data[2], int(rawpos.y));\n"
@@ -814,7 +815,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
 }
 
 static void WriteStage(ShaderCode& out, const pixel_shader_uid_data* uid_data, int n,
-                       API_TYPE ApiType)
+                       APIType ApiType)
 {
   auto& stage = uid_data->stagehash[n];
   out.Write("\n\t// TEV stage %d\n", n);
@@ -1142,11 +1143,11 @@ static void WriteTevRegular(ShaderCode& out, const char* components, int bias, i
 }
 
 static void SampleTexture(ShaderCode& out, const char* texcoords, const char* texswap, int texmap,
-                          bool stereo, API_TYPE ApiType)
+                          bool stereo, APIType ApiType)
 {
   out.SetConstantsUsed(C_TEXDIMS + texmap, C_TEXDIMS + texmap);
 
-  if (ApiType == API_D3D)
+  if (ApiType == APIType::D3D)
     out.Write("iround(255.0 * Tex[%d].Sample(samp[%d], float3(%s.xy * " I_TEXDIMS
               "[%d].xy, %s))).%s;\n",
               texmap, texmap, texcoords, texmap, stereo ? "layer" : "0.0", texswap);
@@ -1173,7 +1174,7 @@ static const char* tevAlphaFunclogicTable[] = {
     " == "   // xnor
 };
 
-static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_data, API_TYPE ApiType,
+static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_data, APIType ApiType,
                            DSTALPHA_MODE dstAlphaMode, bool per_pixel_depth)
 {
   static const char* alphaRef[2] = {I_ALPHA ".r", I_ALPHA ".g"};
@@ -1204,13 +1205,13 @@ static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_dat
   if (dstAlphaMode == DSTALPHA_DUAL_SOURCE_BLEND)
     out.Write("\t\tocol1 = float4(0.0, 0.0, 0.0, 0.0);\n");
   if (per_pixel_depth)
-    out.Write("\t\tdepth = %s;\n", (ApiType == API_D3D) ? "0.0" : "1.0");
+    out.Write("\t\tdepth = %s;\n", (ApiType == APIType::D3D) ? "0.0" : "1.0");
 
   // ZCOMPLOC HACK:
   if (!uid_data->alpha_test_use_zcomploc_hack)
   {
     out.Write("\t\tdiscard;\n");
-    if (ApiType != API_D3D)
+    if (ApiType != APIType::D3D)
       out.Write("\t\treturn;\n");
   }
 

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -7,7 +7,8 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/ShaderGenCommon.h"
-#include "VideoCommon/VideoCommon.h"
+
+enum class APIType;
 
 // Different ways to achieve rendering with destination alpha
 enum DSTALPHA_MODE
@@ -165,6 +166,6 @@ struct pixel_shader_uid_data
 
 typedef ShaderUid<pixel_shader_uid_data> PixelShaderUid;
 
-ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, API_TYPE ApiType,
+ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, APIType ApiType,
                                    const pixel_shader_uid_data* uid_data);
 PixelShaderUid GetPixelShaderUid(DSTALPHA_MODE dstAlphaMode);

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -156,16 +156,16 @@ private:
 };
 
 template <class T>
-inline void DefineOutputMember(T& object, API_TYPE api_type, const char* qualifier,
-                               const char* type, const char* name, int var_index,
-                               const char* semantic = "", int semantic_index = -1)
+inline void DefineOutputMember(T& object, APIType api_type, const char* qualifier, const char* type,
+                               const char* name, int var_index, const char* semantic = "",
+                               int semantic_index = -1)
 {
   object.Write("\t%s %s %s", qualifier, type, name);
 
   if (var_index != -1)
     object.Write("%d", var_index);
 
-  if (api_type == API_D3D && strlen(semantic) > 0)
+  if (api_type == APIType::D3D && strlen(semantic) > 0)
   {
     if (semantic_index != -1)
       object.Write(" : %s%d", semantic, semantic_index);
@@ -177,7 +177,7 @@ inline void DefineOutputMember(T& object, API_TYPE api_type, const char* qualifi
 }
 
 template <class T>
-inline void GenerateVSOutputMembers(T& object, API_TYPE api_type, u32 texgens,
+inline void GenerateVSOutputMembers(T& object, APIType api_type, u32 texgens,
                                     bool per_pixel_lighting, const char* qualifier)
 {
   DefineOutputMember(object, api_type, qualifier, "float4", "pos", -1, "POSITION");

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -30,7 +30,7 @@ std::string Statistics::ToString()
 {
   std::string str;
 
-  if (g_ActiveConfig.backend_info.APIType == API_TYPE::API_NONE)
+  if (g_ActiveConfig.backend_info.api_type == APIType::Nothing)
   {
     str += StringFromFormat("Objects:            %i\n", stats.thisFrame.numDrawnObjects);
     str += StringFromFormat("Vertices Loaded:    %i\n", stats.thisFrame.numVerticesLoaded);

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -11,6 +11,7 @@
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/TextureDecoder.h"
+#include "VideoCommon/VideoCommon.h"
 
 #define WRITE p += sprintf
 
@@ -76,7 +77,7 @@ u16 GetEncodedSampleCount(u32 format)
 
 // block dimensions : widthStride, heightStride
 // texture dims : width, height, x offset, y offset
-static void WriteSwizzler(char*& p, u32 format, API_TYPE ApiType)
+static void WriteSwizzler(char*& p, u32 format, APIType ApiType)
 {
   // left, top, of source rectangle within source texture
   // width of the destination rectangle, scale_factor (1 or 2)
@@ -86,7 +87,7 @@ static void WriteSwizzler(char*& p, u32 format, API_TYPE ApiType)
   int blkH = TexDecoder_GetBlockHeightInTexels(format);
   int samples = GetEncodedSampleCount(format);
 
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
   {
     WRITE(p, "#define samp0 samp9\n");
     WRITE(p, "SAMPLER_BINDING(9) uniform sampler2DArray samp0;\n");
@@ -134,7 +135,7 @@ static void WriteSwizzler(char*& p, u32 format, API_TYPE ApiType)
                                               // pixel)
   WRITE(p, "  uv0 += float2(position.xy);\n");                    // move to copied rect
   WRITE(p, "  uv0 /= float2(%d, %d);\n", EFB_WIDTH, EFB_HEIGHT);  // normalize to [0:1]
-  if (ApiType == API_OPENGL)                                      // ogl has to flip up and down
+  if (ApiType == APIType::OpenGL)                                 // ogl has to flip up and down
   {
     WRITE(p, "  uv0.y = 1.0-uv0.y;\n");
   }
@@ -143,9 +144,9 @@ static void WriteSwizzler(char*& p, u32 format, API_TYPE ApiType)
 }
 
 static void WriteSampleColor(char*& p, const char* colorComp, const char* dest, int xoffset,
-                             API_TYPE ApiType, bool depth = false)
+                             APIType ApiType, bool depth = false)
 {
-  if (ApiType == API_OPENGL)
+  if (ApiType == APIType::OpenGL)
   {
     WRITE(p, "  %s = texture(samp0, float3(uv0 + float2(%d, 0) * sample_offset, 0.0)).%s;\n", dest,
           xoffset, colorComp);
@@ -184,7 +185,7 @@ static void WriteEncoderEnd(char*& p)
   IntensityConstantAdded = false;
 }
 
-static void WriteI8Encoder(char*& p, API_TYPE ApiType)
+static void WriteI8Encoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_TF_I8, ApiType);
   WRITE(p, "  float3 texSample;\n");
@@ -206,7 +207,7 @@ static void WriteI8Encoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteI4Encoder(char*& p, API_TYPE ApiType)
+static void WriteI4Encoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_TF_I4, ApiType);
   WRITE(p, "  float3 texSample;\n");
@@ -247,7 +248,7 @@ static void WriteI4Encoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteIA8Encoder(char*& p, API_TYPE ApiType)
+static void WriteIA8Encoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_TF_IA8, ApiType);
   WRITE(p, "  float4 texSample;\n");
@@ -265,7 +266,7 @@ static void WriteIA8Encoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteIA4Encoder(char*& p, API_TYPE ApiType)
+static void WriteIA4Encoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_TF_IA4, ApiType);
   WRITE(p, "  float4 texSample;\n");
@@ -297,7 +298,7 @@ static void WriteIA4Encoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteRGB565Encoder(char*& p, API_TYPE ApiType)
+static void WriteRGB565Encoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_TF_RGB565, ApiType);
 
@@ -320,7 +321,7 @@ static void WriteRGB565Encoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteRGB5A3Encoder(char*& p, API_TYPE ApiType)
+static void WriteRGB5A3Encoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_TF_RGB5A3, ApiType);
 
@@ -384,7 +385,7 @@ static void WriteRGB5A3Encoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteRGBA8Encoder(char*& p, API_TYPE ApiType)
+static void WriteRGBA8Encoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_TF_RGBA8, ApiType);
 
@@ -409,7 +410,7 @@ static void WriteRGBA8Encoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteC4Encoder(char*& p, const char* comp, API_TYPE ApiType, bool depth = false)
+static void WriteC4Encoder(char*& p, const char* comp, APIType ApiType, bool depth = false)
 {
   WriteSwizzler(p, GX_CTF_R4, ApiType);
   WRITE(p, "  float4 color0;\n");
@@ -431,7 +432,7 @@ static void WriteC4Encoder(char*& p, const char* comp, API_TYPE ApiType, bool de
   WriteEncoderEnd(p);
 }
 
-static void WriteC8Encoder(char*& p, const char* comp, API_TYPE ApiType, bool depth = false)
+static void WriteC8Encoder(char*& p, const char* comp, APIType ApiType, bool depth = false)
 {
   WriteSwizzler(p, GX_CTF_R8, ApiType);
 
@@ -443,7 +444,7 @@ static void WriteC8Encoder(char*& p, const char* comp, API_TYPE ApiType, bool de
   WriteEncoderEnd(p);
 }
 
-static void WriteCC4Encoder(char*& p, const char* comp, API_TYPE ApiType)
+static void WriteCC4Encoder(char*& p, const char* comp, APIType ApiType)
 {
   WriteSwizzler(p, GX_CTF_RA4, ApiType);
   WRITE(p, "  float2 texSample;\n");
@@ -473,7 +474,7 @@ static void WriteCC4Encoder(char*& p, const char* comp, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteCC8Encoder(char*& p, const char* comp, API_TYPE ApiType)
+static void WriteCC8Encoder(char*& p, const char* comp, APIType ApiType)
 {
   WriteSwizzler(p, GX_CTF_RA8, ApiType);
 
@@ -483,7 +484,7 @@ static void WriteCC8Encoder(char*& p, const char* comp, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteZ8Encoder(char*& p, const char* multiplier, API_TYPE ApiType)
+static void WriteZ8Encoder(char*& p, const char* multiplier, APIType ApiType)
 {
   WriteSwizzler(p, GX_CTF_Z8M, ApiType);
 
@@ -504,7 +505,7 @@ static void WriteZ8Encoder(char*& p, const char* multiplier, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteZ16Encoder(char*& p, API_TYPE ApiType)
+static void WriteZ16Encoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_TF_Z16, ApiType);
 
@@ -536,7 +537,7 @@ static void WriteZ16Encoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteZ16LEncoder(char*& p, API_TYPE ApiType)
+static void WriteZ16LEncoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_CTF_Z16L, ApiType);
 
@@ -572,7 +573,7 @@ static void WriteZ16LEncoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-static void WriteZ24Encoder(char*& p, API_TYPE ApiType)
+static void WriteZ24Encoder(char*& p, APIType ApiType)
 {
   WriteSwizzler(p, GX_TF_Z24X8, ApiType);
 
@@ -612,7 +613,7 @@ static void WriteZ24Encoder(char*& p, API_TYPE ApiType)
   WriteEncoderEnd(p);
 }
 
-const char* GenerateEncodingShader(u32 format, API_TYPE ApiType)
+const char* GenerateEncodingShader(u32 format, APIType ApiType)
 {
   text[sizeof(text) - 1] = 0x7C;  // canary
 

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -5,11 +5,12 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
-#include "VideoCommon/VideoCommon.h"
+
+enum class APIType;
 
 namespace TextureConversionShader
 {
 u16 GetEncodedSampleCount(u32 format);
 
-const char* GenerateEncodingShader(u32 format, API_TYPE ApiType = API_OPENGL);
+const char* GenerateEncodingShader(u32 format, APIType ApiType);
 }

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -12,6 +12,7 @@
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderGen.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 VertexShaderUid GetVertexShaderUid()
@@ -78,13 +79,13 @@ VertexShaderUid GetVertexShaderUid()
   return out;
 }
 
-ShaderCode GenerateVertexShaderCode(API_TYPE api_type, const vertex_shader_uid_data* uid_data)
+ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_data* uid_data)
 {
   ShaderCode out;
   out.Write("%s", s_lighting_struct);
 
   // uniforms
-  if (api_type == API_OPENGL)
+  if (api_type == APIType::OpenGL)
     out.Write("layout(std140%s) uniform VSBlock {\n",
               g_ActiveConfig.backend_info.bSupportsBindingLayout ? ", binding = 2" : "");
   else
@@ -96,7 +97,7 @@ ShaderCode GenerateVertexShaderCode(API_TYPE api_type, const vertex_shader_uid_d
   GenerateVSOutputMembers(out, api_type, uid_data->numTexGens, uid_data->pixel_lighting, "");
   out.Write("};\n");
 
-  if (api_type == API_OPENGL)
+  if (api_type == APIType::OpenGL)
   {
     out.Write("in float4 rawpos; // ATTR%d,\n", SHADER_POSITION_ATTRIB);
     if (uid_data->components & VB_HAS_POSMTXIDX)
@@ -430,7 +431,7 @@ ShaderCode GenerateVertexShaderCode(API_TYPE api_type, const vertex_shader_uid_d
   // get rasterized correctly.
   out.Write("o.pos.xy = o.pos.xy - o.pos.w * " I_PIXELCENTERCORRECTION ".xy;\n");
 
-  if (api_type == API_OPENGL)
+  if (api_type == APIType::OpenGL)
   {
     if (g_ActiveConfig.backend_info.bSupportsGeometryShaders)
     {

--- a/Source/Core/VideoCommon/VertexShaderGen.h
+++ b/Source/Core/VideoCommon/VertexShaderGen.h
@@ -7,7 +7,8 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/ShaderGenCommon.h"
-#include "VideoCommon/VideoCommon.h"
+
+enum class APIType;
 
 // TODO should be reordered
 #define SHADER_POSITION_ATTRIB 0
@@ -67,4 +68,4 @@ struct vertex_shader_uid_data
 typedef ShaderUid<vertex_shader_uid_data> VertexShaderUid;
 
 VertexShaderUid GetVertexShaderUid();
-ShaderCode GenerateVertexShaderCode(API_TYPE api_type, const vertex_shader_uid_data* uid_data);
+ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_data* uid_data);

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -69,11 +69,11 @@ struct TargetRectangle : public MathUtil::Rectangle<int>
 
 #define LOG_VTX()
 
-enum API_TYPE
+enum class APIType
 {
-  API_OPENGL = 1,
-  API_D3D = 2,
-  API_NONE = 3
+  OpenGL,
+  D3D,
+  Nothing
 };
 
 inline u32 RGBA8ToRGBA6ToRGBA8(u32 src)

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -39,7 +39,7 @@ VideoConfig::VideoConfig()
   fAspectRatioHackH = 1;
 
   // disable all features by default
-  backend_info.APIType = API_NONE;
+  backend_info.api_type = APIType::Nothing;
   backend_info.bSupportsExclusiveFullscreen = false;
 }
 

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -145,7 +145,7 @@ struct VideoConfig final
   // TODO: Move this out of VideoConfig
   struct
   {
-    API_TYPE APIType;
+    APIType api_type;
 
     std::vector<std::string> Adapters;  // for D3D
     std::vector<int> AAModes;


### PR DESCRIPTION
Allows for forward declarations in most places, which prevents dumping unrelated VideoCommon.h contents directly into headers. Also renames it to APIType to be more consistent with our coding style.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4047)
<!-- Reviewable:end -->
