### PR TITLE
Fix GWL.ini mistake made in 2e02c10

### DIFF
--- a/Data/Sys/GameSettings/GWL.ini
+++ b/Data/Sys/GameSettings/GWL.ini
@@ -13,9 +13,6 @@ EmulationIssues =
 
 [OnFrame]
 # Add memory patches to be applied every frame here.
-$Bypass FIFO reset
-0x8028EE80:dword:0x48000638
 
 [ActionReplay]
 # Add action replay cheats here.
-

--- a/Data/Sys/GameSettings/GWLE6L.ini
+++ b/Data/Sys/GameSettings/GWLE6L.ini
@@ -1,0 +1,5 @@
+# GWLE6L - Project Zoo
+
+[OnFrame]
+$Bypass FIFO reset
+0x8028EF00:dword:0x48000638

--- a/Data/Sys/GameSettings/GWLX6L.ini
+++ b/Data/Sys/GameSettings/GWLX6L.ini
@@ -1,0 +1,5 @@
+# GWLX6L - Project Zoo
+
+[OnFrame]
+$Bypass FIFO reset
+0x8028EE80:dword:0x48000638


### PR DESCRIPTION
The patches are different, so they can't be in the region-neutral INI. Might fix https://bugs.dolphin-emu.org/issues/9685, but I need someone to test it since I don't have the game.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4049)
<!-- Reviewable:end -->
