### PR TITLE
Remove fake wiimote data that was causing desyncs.

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -820,18 +820,6 @@ bool NetPlayClient::StartGame(const std::string& path)
     for (unsigned int i = 0; i < 4; ++i)
       WiimoteReal::ChangeWiimoteSource(i,
                                        m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);
-
-    // Needed to prevent locking up at boot if (when) the wiimotes connect out of order.
-    NetWiimote nw;
-    nw.resize(4, 0);
-
-    for (unsigned int w = 0; w < 4; ++w)
-    {
-      if (m_wiimote_map[w] != -1)
-        // probably overkill, but whatever
-        for (unsigned int i = 0; i < 7; ++i)
-          m_wiimote_buffer[w].Push(nw);
-    }
   }
 
   UpdateDevices();


### PR DESCRIPTION
This seems to fix all games on Wiimote Netplay.  Tested games that previously crashed or froze on startup, like Mario Super Sluggers and they work.  3/4 player works. nunchucks and classic controllers work.

I have not experienced a desync since this change outside of setup issues.

Credit goes to [mimimi](https://github.com/mimimi) for pointing out the problematic code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4051)
<!-- Reviewable:end -->
