### PR TITLE
Fix Wiimotes not reconnecting on button press

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -71,9 +71,7 @@ void Pause()
 // An L2CAP packet is passed from the Core to the Wiimote on the HID CONTROL channel.
 void ControlChannel(int number, u16 channel_id, const void* data, u32 size)
 {
-  if (WIIMOTE_SRC_REAL & g_wiimote_sources[number])
-    WiimoteReal::ControlChannel(number, channel_id, data, size);
-  else if (WIIMOTE_SRC_HYBRID & g_wiimote_sources[number])
+  if (WIIMOTE_SRC_HYBRID & g_wiimote_sources[number])
     static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))
         ->ControlChannel(channel_id, data, size);
 }

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -771,6 +771,8 @@ void Wiimote::ControlChannel(const u16 _channelID, const void* _pData, u32 _Size
     // Wiimote disconnected
     // reset eeprom/register/reporting mode
     Reset();
+    if (WIIMOTE_SRC_REAL & g_wiimote_sources[m_index])
+      WiimoteReal::ControlChannel(m_index, _channelID, _pData, _Size);
     return;
   }
 

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -121,12 +121,10 @@ void Wiimote::ClearReadQueue()
 void Wiimote::ControlChannel(const u16 channel, const void* const data, const u32 size)
 {
   // Check for custom communication
-  if (99 == channel)
+  if (channel == 99)
   {
     if (m_really_disconnect)
       DisconnectInternal();
-    else
-      EmuStop();
   }
   else
   {

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -81,8 +81,8 @@ protected:
   Report m_last_input_report;
   u16 m_channel;
   u8 m_last_connect_request_counter;
-  // If true, the Wiimote will be really disconnected when it is disconnected by Dolphin,
-  // instead of just pausing data reporting.
+  // If true, the Wiimote will be really disconnected when it is disconnected by Dolphin.
+  // In any other case, data reporting is not paused to allow reconnecting on any button press.
   // This is not enabled on all platforms as connecting a Wiimote can be a pain on some platforms.
   bool m_really_disconnect = false;
 


### PR DESCRIPTION
5.0-56 broke reconnecting a Wiimote on button press; this is because
data reporting was now always stopped for real Wii remotes on
disconnect, making it impossible to know a button was pressed in the
first place (to reconnect the Wiimote).

This semi-reverts to the previous behaviour, where data reporting is
never stopped.

(Also, control channels now go through WiimoteEmu, just like before,
to make sure some things are reset on disconnection.)

Hopefully fixes issue [9711](https://dolp.in/i9711). Sorry for the regression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4052)
<!-- Reviewable:end -->
