### PR TITLE
Fix bogus UPnP requests

### DIFF
--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -134,6 +134,7 @@ private:
 
   static struct UPNPUrls m_upnp_urls;
   static struct IGDdatas m_upnp_data;
+  static std::string m_upnp_ourip;
   static u16 m_upnp_mapped;
   static bool m_upnp_inited;
   static bool m_upnp_error;


### PR DESCRIPTION
I've been noticing that Dolphin netplay tries to request some strange UPnP port forwards:

```
N[NETPLAY]: Successfully mapped port 2626 to codl-PC
```

```
N[NETPLAY]: Successfully mapped port 2626 to 0.0.0.0
```

These should use my local IP address, not my host name and certainly not 0.0.0.0 (the fact that my router accepts these is funny in its own right, but out of scope.)

`enet_address_get_host` will return 0.0.0.0 or a host name in most cases. This gets our IP address from the socket to the IGD instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4053)
<!-- Reviewable:end -->
