### PR TITLE
NetPlay: Fix GUI freeze

### DIFF
--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -14,6 +14,7 @@
 #include <thread>
 #include <vector>
 #include "Common/CommonTypes.h"
+#include "Common/Event.h"
 #include "Common/FifoQueue.h"
 #include "Common/TraversalClient.h"
 #include "Core/NetPlayProto.h"
@@ -175,6 +176,8 @@ private:
   TraversalClient* m_traversal_client = nullptr;
   std::thread m_MD5_thread;
   bool m_should_compute_MD5 = false;
+  Common::Event m_gc_pad_event;
+  Common::Event m_wii_pad_event;
 
   u32 m_timebase_frame = 0;
 };

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1132,10 +1132,17 @@ void CFrame::DoStop()
       // Pause the state during confirmation and restore it afterwards
       Core::EState state = Core::GetState();
 
+      // Do not pause if netplay is running as CPU thread might be blocked
+      // waiting on inputs
+      bool should_pause = !NetPlayDialog::GetNetPlayClient();
+
       // If exclusive fullscreen is not enabled then we can pause the emulation
       // before we've exited fullscreen. If not then we need to exit fullscreen first.
-      if (!RendererIsFullscreen() || !g_Config.ExclusiveFullscreenEnabled() ||
-          SConfig::GetInstance().bRenderToMain)
+      should_pause =
+          should_pause && (!RendererIsFullscreen() || !g_Config.ExclusiveFullscreenEnabled() ||
+                           SConfig::GetInstance().bRenderToMain);
+
+      if (should_pause)
       {
         Core::SetState(Core::CORE_PAUSE);
       }
@@ -1149,7 +1156,9 @@ void CFrame::DoStop()
       HotkeyManagerEmu::Enable(true);
       if (Ret != wxID_YES)
       {
-        Core::SetState(state);
+        if (should_pause)
+          Core::SetState(state);
+
         m_confirmStop = false;
         return;
       }


### PR DESCRIPTION
## Rewrite NetPlayClient input wait logic to use std::condition_variable's
Instead of sleeping in `NetPlayClient::GetNetPads` and `NetPlayClient::WiimoteUpdate`,
now use `std::condition_variable`. This allows for finer control over these blocking
areas.

## Do not pause emulation when confirming stop when using NetPlay
Pausing emulation requires to access the CPU thread, which might be blocked
waiting for inputs by netplay. Accessing it in this state would cause the
whole GUI to hang for set timeout (10s).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4058)
<!-- Reviewable:end -->
