### PR TITLE
Tools: Don't run lint on deleted files

### DIFF
--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -5,7 +5,7 @@
 fail=0
 
 # Check for clang-format issues.
-for f in $(git status --porcelain | awk '{print $2}'); do
+for f in $(git diff --name-only --diff-filter=ACMRTUXB | awk '{print $2}'); do
   if ! echo "${f}" | egrep -q "[.](cpp|h|mm)$"; then
     continue
   fi


### PR DESCRIPTION
Otherwise, it generates a harmless "No such file or directory" (which is however noise) when a file is removed in a commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4059)
<!-- Reviewable:end -->
