### PR TITLE
Allow to change Wii sd card path in config pane

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -133,6 +133,7 @@ void SConfig::SaveGeneralSettings(IniFile& ini)
   general->Set("DumpPath", m_DumpPath);
   CreateDumpPath(m_DumpPath);
   general->Set("WirelessMac", m_WirelessMac);
+  general->Set("WiiSDCardPath", m_strWiiSDCardPath);
 
 #ifdef USE_GDBSTUB
 #ifndef _WIN32
@@ -405,6 +406,8 @@ void SConfig::LoadGeneralSettings(IniFile& ini)
   general->Get("DumpPath", &m_DumpPath);
   CreateDumpPath(m_DumpPath);
   general->Get("WirelessMac", &m_WirelessMac);
+  general->Get("WiiSDCardPath", &m_strWiiSDCardPath, File::GetUserPath(F_WIISDCARD_IDX));
+  File::SetUserPath(F_WIISDCARD_IDX, m_strWiiSDCardPath);
 }
 
 void SConfig::LoadInterfaceSettings(IniFile& ini)
@@ -648,6 +651,7 @@ void SConfig::LoadDefaults()
   iBBDumpPort = -1;
   bSyncGPU = false;
   bFastDiscSpeed = false;
+  m_strWiiSDCardPath = File::GetUserPath(F_WIISDCARD_IDX);
   bEnableMemcardSdWriting = true;
   SelectedLanguage = 0;
   bOverrideGCLanguage = false;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -177,6 +177,7 @@ struct SConfig : NonCopyable
   std::string m_strApploader;
   std::string m_strUniqueID;
   std::string m_strName;
+  std::string m_strWiiSDCardPath;
   u16 m_revision;
 
   std::string m_perfDir;

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -58,6 +58,9 @@ void PathConfigPane::InitializeGUI()
   m_dump_path_dirpicker =
       new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, _("Choose a dump directory:"),
                           wxDefaultPosition, wxDefaultSize, wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
+  m_wii_sdcard_filepicker = new wxFilePickerCtrl(
+      this, wxID_ANY, wxEmptyString, _("Choose an SD Card file:"), wxFileSelectorDefaultWildcardStr,
+      wxDefaultPosition, wxDefaultSize, wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
 
   m_iso_paths_listbox->Bind(wxEVT_LISTBOX, &PathConfigPane::OnISOPathSelectionChanged, this);
   m_recursive_iso_paths_checkbox->Bind(wxEVT_CHECKBOX,
@@ -71,6 +74,8 @@ void PathConfigPane::InitializeGUI()
                                     &PathConfigPane::OnApploaderPathChanged, this);
   m_nand_root_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnNANDRootChanged, this);
   m_dump_path_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnDumpPathChanged, this);
+  m_wii_sdcard_filepicker->Bind(wxEVT_FILEPICKER_CHANGED, &PathConfigPane::OnSdCardPathChanged,
+                                this);
 
   wxBoxSizer* const iso_button_sizer = new wxBoxSizer(wxHORIZONTAL);
   iso_button_sizer->Add(m_recursive_iso_paths_checkbox, 0, wxALL | wxALIGN_CENTER);
@@ -101,6 +106,10 @@ void PathConfigPane::InitializeGUI()
   picker_sizer->Add(new wxStaticText(this, wxID_ANY, _("Dump Path:")), wxGBPosition(4, 0),
                     wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxALL, 5);
   picker_sizer->Add(m_dump_path_dirpicker, wxGBPosition(4, 1), wxDefaultSpan, wxEXPAND | wxALL, 5);
+  picker_sizer->Add(new wxStaticText(this, wxID_ANY, _("SD Card Path:")), wxGBPosition(5, 0),
+                    wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  picker_sizer->Add(m_wii_sdcard_filepicker, wxGBPosition(5, 1), wxDefaultSpan, wxEXPAND | wxALL,
+                    5);
   picker_sizer->AddGrowableCol(1);
 
   // Populate the Paths page
@@ -121,6 +130,7 @@ void PathConfigPane::LoadGUIValues()
   m_apploader_path_filepicker->SetPath(StrToWxStr(startup_params.m_strApploader));
   m_nand_root_dirpicker->SetPath(StrToWxStr(SConfig::GetInstance().m_NANDPath));
   m_dump_path_dirpicker->SetPath(StrToWxStr(SConfig::GetInstance().m_DumpPath));
+  m_wii_sdcard_filepicker->SetPath(StrToWxStr(SConfig::GetInstance().m_strWiiSDCardPath));
 
   // Update selected ISO paths
   for (const std::string& folder : SConfig::GetInstance().m_ISOFolder)
@@ -192,6 +202,13 @@ void PathConfigPane::OnDVDRootChanged(wxCommandEvent& event)
 void PathConfigPane::OnApploaderPathChanged(wxCommandEvent& event)
 {
   SConfig::GetInstance().m_strApploader = WxStrToStr(m_apploader_path_filepicker->GetPath());
+}
+
+void PathConfigPane::OnSdCardPathChanged(wxCommandEvent& event)
+{
+  std::string sd_card_path = WxStrToStr(m_wii_sdcard_filepicker->GetPath());
+  SConfig::GetInstance().m_strWiiSDCardPath = sd_card_path;
+  File::SetUserPath(F_WIISDCARD_IDX, sd_card_path);
 }
 
 void PathConfigPane::OnNANDRootChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/PathConfigPane.h
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.h
@@ -31,6 +31,7 @@ private:
   void OnApploaderPathChanged(wxCommandEvent&);
   void OnNANDRootChanged(wxCommandEvent&);
   void OnDumpPathChanged(wxCommandEvent&);
+  void OnSdCardPathChanged(wxCommandEvent&);
 
   void SaveISOPathChanges();
 
@@ -44,4 +45,5 @@ private:
   wxFilePickerCtrl* m_default_iso_filepicker;
   wxFilePickerCtrl* m_apploader_path_filepicker;
   wxDirPickerCtrl* m_dump_path_dirpicker;
+  wxFilePickerCtrl* m_wii_sdcard_filepicker;
 };


### PR DESCRIPTION
Add a setting in the "Paths" config pane to select which file should be
used as wii sd card.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4061)
<!-- Reviewable:end -->
