### PR TITLE
Analytics: fix build with libcurl/7.50.0 and higher (typedef conflict)

### DIFF
--- a/Source/Core/Common/Analytics.h
+++ b/Source/Core/Common/Analytics.h
@@ -16,7 +16,10 @@
 #include "Common/FifoQueue.h"
 #include "Common/Flag.h"
 
+// curl 7.50+ already defines this
+#if LIBCURL_VERSION_NUM < 0x073200
 typedef void CURL;
+#endif
 
 // Utilities for analytics reporting in Dolphin. This reporting is designed to
 // provide anonymous data about how well Dolphin performs in the wild. It also


### PR DESCRIPTION
curl 7.50 defines CURL (**typedef**) in its header which conflicts with the typedef from ```Analytics.h``` and causes compilation to fail with the latest curl version.

I added a preprocessor check for *LIBCURL_VERSION_NUM* to workaround this issue and fix the build for people with the latest curl release.

--

```
In file included from /build/emulators/dolphin/Source/Core/Common/Analytics.cpp:10:0:
/build/emulators/dolphin/Source/Core/Common/Analytics.h:19:14: error: conflicting declaration ‘typedef void CURL’
 typedef void CURL;
              ^~~~
In file included from /build/emulators/dolphin/Source/Core/Common/Analytics.cpp:7:0:
/usr/include/curl/curl.h:94:26: note: previous declaration as ‘typedef struct Curl_easy CURL’
 typedef struct Curl_easy CURL;
                          ^~~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4062)
<!-- Reviewable:end -->
