### PR TITLE
Make it so comments don't take up gecko space

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -23,11 +23,12 @@ void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<Ge
 
     GeckoCode gcode;
 
+    lines.erase(std::remove_if(lines.begin(), lines.end(),
+                               [](const auto& line) { return line.empty() || line[0] == '#'; }),
+                lines.end());
+
     for (auto& line : lines)
     {
-      if (line.empty())
-        continue;
-
       std::istringstream ss(line);
 
       switch ((line)[0])


### PR DESCRIPTION
Unlike notes, we want comments to be completely ignored

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4065)
<!-- Reviewable:end -->
