### PR TITLE
Fix typedef for CURL

### DIFF
--- a/Source/Core/Common/Analytics.h
+++ b/Source/Core/Common/Analytics.h
@@ -10,13 +10,18 @@
 #include <thread>
 #include <utility>
 #include <vector>
+#include <curl/curlver.h>
 
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/FifoQueue.h"
 #include "Common/Flag.h"
 
+#if LIBCURL_VERSION_MAJOR >= 7 && LIBCURL_VERSION_MINOR >= 50
+typedef struct Curl_easy CURL;
+#else
 typedef void CURL;
+#endif
 
 // Utilities for analytics reporting in Dolphin. This reporting is designed to
 // provide anonymous data about how well Dolphin performs in the wild. It also


### PR DESCRIPTION
Fix typedef for CURL, otherwise compile errors occur when using CURL 7.50 or newer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4066)
<!-- Reviewable:end -->
