### PR TITLE
Fix crash introduced by input config code

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/EmulationFragment.java
@@ -105,14 +105,17 @@ public final class EmulationFragment extends Fragment implements SurfaceHolder.C
 	public void onViewCreated(View view, Bundle savedInstanceState)
 	{
 		Button doneButton = (Button) view.findViewById(R.id.done_control_config);
-		doneButton.setOnClickListener(new View.OnClickListener()
+		if (doneButton != null)
 		{
-			@Override
-			public void onClick(View v)
+			doneButton.setOnClickListener(new View.OnClickListener()
 			{
-				stopConfiguringControls();
-			}
-		});
+				@Override
+				public void onClick(View v)
+				{
+					stopConfiguringControls();
+				}
+			});
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Simple null-check to make sure we don't try to set onClickListeners for a button that doesn't exist on TV devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4069)
<!-- Reviewable:end -->
