### PR TITLE
DSP: Make DSP_CONTROL_MASK a concrete constant

### DIFF
--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -30,7 +30,7 @@ enum
 };
 
 // UDSPControl
-#define DSP_CONTROL_MASK 0x0C07
+constexpr u16 DSP_CONTROL_MASK = 0x0C07;
 union UDSPControl {
   u16 Hex;
   struct


### PR DESCRIPTION
Basic stuff. Gets rid of a define usage and gives it an actual enforced type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4071)
<!-- Reviewable:end -->
