### PR TITLE
Fix D3D::SetDebugObjectName to bind to the EFB color_read_texture rat…

### DIFF
--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -163,10 +163,10 @@ FramebufferManager::FramebufferManager()
   CHECK(hr == S_OK, "create EFB color read texture (hr=%#x)", hr);
   m_efb.color_read_texture = new D3DTexture2D(buf, D3D11_BIND_RENDER_TARGET);
   SAFE_RELEASE(buf);
-  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.depth_read_texture->GetTex(),
+  D3D::SetDebugObjectName((ID3D11DeviceChild*)m_efb.color_read_texture->GetTex(),
                           "EFB color read texture (used in Renderer::AccessEFB)");
   D3D::SetDebugObjectName(
-      (ID3D11DeviceChild*)m_efb.depth_read_texture->GetRTV(),
+      (ID3D11DeviceChild*)m_efb.color_read_texture->GetRTV(),
       "EFB color read texture render target view (used in Renderer::AccessEFB)");
 
   // AccessEFB - Sysmem buffer used to retrieve the pixel data from depth_read_texture


### PR DESCRIPTION
…her than the depth_read_texture (probably a copy paste error)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4073)
<!-- Reviewable:end -->
