### PR TITLE
Use default SRAM when movie is active

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -356,10 +356,11 @@ bool BootCore(const std::string& _rFilename)
     config_cache.bSetEXIDevice[0] = true;
     config_cache.bSetEXIDevice[1] = true;
   }
+
+  if (NetPlay::IsNetPlayRunning() || Movie::IsMovieActive())
+    g_SRAM_determinism_initialized = true;
   else
-  {
-    g_SRAM_netplay_initialized = false;
-  }
+    g_SRAM_determinism_initialized = false;
 
   const bool ntsc = DiscIO::IsNTSC(StartUp.m_region);
 

--- a/Source/Core/Core/HW/EXI/EXI.cpp
+++ b/Source/Core/Core/HW/EXI/EXI.cpp
@@ -21,7 +21,7 @@
 #include "Core/Movie.h"
 
 SRAM g_SRAM;
-bool g_SRAM_netplay_initialized = false;
+bool g_SRAM_determinism_initialized = false;
 
 namespace ExpansionInterface
 {
@@ -35,10 +35,7 @@ static void UpdateInterruptsCallback(u64 userdata, s64 cycles_late);
 
 void Init()
 {
-  if (!g_SRAM_netplay_initialized)
-  {
-    InitSRAM();
-  }
+  InitSRAM();
 
   CEXIMemoryCard::Init();
   for (u32 i = 0; i < MAX_EXI_CHANNELS; i++)

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -134,14 +134,14 @@ CEXIIPL::~CEXIIPL()
   m_pIPL = nullptr;
 
   // SRAM
-  if (!g_SRAM_netplay_initialized)
+  if (!g_SRAM_determinism_initialized)
   {
     File::IOFile file(SConfig::GetInstance().m_strSRAM, "wb");
     file.WriteArray(&g_SRAM, 1);
   }
   else
   {
-    g_SRAM_netplay_initialized = false;
+    g_SRAM_determinism_initialized = false;
   }
 }
 void CEXIIPL::DoState(PointerWrap& p)

--- a/Source/Core/Core/HW/Sram.cpp
+++ b/Source/Core/Core/HW/Sram.cpp
@@ -45,7 +45,7 @@ SRAM sram_dump_german = {{
 void InitSRAM()
 {
   File::IOFile file(SConfig::GetInstance().m_strSRAM, "rb");
-  if (file)
+  if (file && !g_SRAM_determinism_initialized)
   {
     if (!file.ReadArray(&g_SRAM, 1))
     {

--- a/Source/Core/Core/HW/Sram.h
+++ b/Source/Core/Core/HW/Sram.h
@@ -86,4 +86,4 @@ void FixSRAMChecksums();
 
 extern SRAM sram_dump;
 extern SRAM g_SRAM;
-extern bool g_SRAM_netplay_initialized;
+extern bool g_SRAM_determinism_initialized;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -496,7 +496,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
     {
       std::lock_guard<std::recursive_mutex> lkg(m_crit.game);
       memcpy(g_SRAM.p_SRAM, sram, sizeof(g_SRAM.p_SRAM));
-      g_SRAM_netplay_initialized = true;
+      g_SRAM_determinism_initialized = true;
     }
   }
   break;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -302,11 +302,11 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
   Send(player.socket, spac);
 
   // sync GC SRAM with new client
-  if (!g_SRAM_netplay_initialized)
+  if (!g_SRAM_determinism_initialized)
   {
     SConfig::GetInstance().m_strSRAM = File::GetUserPath(F_GCSRAM_IDX);
+    g_SRAM_determinism_initialized = true;
     InitSRAM();
-    g_SRAM_netplay_initialized = true;
   }
   spac.clear();
   spac << (MessageId)NP_MSG_SYNC_GC_SRAM;


### PR DESCRIPTION
This should hopefully resolve issues where Movie playback would desync due to SRAM not matching the SRAM used by the original Movie creator.

~~This is untested, so marked as WIP until I'm able to fully test it.~~ Seems to be working for me, but still need testing for GameCube language support.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4081)

<!-- Reviewable:end -->
