### PR TITLE
Tools: Fix lint by removing unneeded awk

### DIFF
--- a/Source/Core/Common/Analytics.h
+++ b/Source/Core/Common/Analytics.h
@@ -10,6 +10,7 @@
 #include <thread>
 #include <utility>
 #include <vector>
+
 #include <curl/curlver.h>
 
 #include "Common/CommonTypes.h"

--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -5,7 +5,7 @@
 fail=0
 
 # Check for clang-format issues.
-for f in $(git diff --name-only --diff-filter=ACMRTUXB | awk '{print $2}'); do
+for f in $(git diff --name-only --diff-filter=ACMRTUXB); do
   if ! echo "${f}" | egrep -q "[.](cpp|h|mm)$"; then
     continue
   fi


### PR DESCRIPTION
git diff --name-only already took care of only returning the name, so
the awk is unneeded and makes it return only empty file names.

Facepalm, I know. Sorry for this oversight.

(Also fixes something that lint didn't catch because of this)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4082)
<!-- Reviewable:end -->
