### PR TITLE
Make Dolphin remember the NetPlay window size/position

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -324,6 +324,24 @@ void NetPlaySetupFrame::MakeNetPlayDiag(int port, const std::string& game, bool 
                                      trav, centralServer, (u16)centralPort);
   if (netplay_client->IsConnected())
   {
+    int winPosX, winPosY, winWidth, winHeight;
+
+    // Remember the window size and position for NetWindow
+    netplay_section.Get("NetWindowPosX", &winPosX, -1);
+    netplay_section.Get("NetWindowPosY", &winPosY, -1);
+    netplay_section.Get("NetWindowWidth", &winWidth, 768);
+    netplay_section.Get("NetWindowHeight", &winHeight, 768 - 128);
+
+    if (winPosX == -1 || winPosY == -1)
+    {
+      npd->SetSize(768, 768 - 128);
+      npd->Center();
+    }
+    else
+    {
+      npd->SetSize(winPosX, winPosY, winWidth, winHeight);
+    }
+
     npd->Show();
     Destroy();
   }

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -243,13 +243,22 @@ NetPlayDialog::NetPlayDialog(wxWindow* const parent, const CGameListCtrl* const 
   panel->SetSizerAndFit(main_szr);
 
   main_szr->SetSizeHints(this);
-  SetSize(768, 768 - 128);
-
-  Center();
 }
 
 NetPlayDialog::~NetPlayDialog()
 {
+  IniFile inifile;
+  const std::string dolphin_ini = File::GetUserPath(F_DOLPHINCONFIG_IDX);
+  inifile.Load(dolphin_ini);
+  IniFile::Section& netplay_config = *inifile.GetOrCreateSection("NetPlay");
+
+  netplay_config.Set("NetWindowPosX", GetPosition().x);
+  netplay_config.Set("NetWindowPosY", GetPosition().y);
+  netplay_config.Set("NetWindowWidth", GetSize().GetWidth());
+  netplay_config.Set("NetWindowHeight", GetSize().GetHeight());
+
+  inifile.Save(dolphin_ini);
+
   if (netplay_client)
   {
     delete netplay_client;


### PR DESCRIPTION
The default size for NetWindow might be too big for some screens. This allows the user to modify the window as they see fit and has Dolphin remember those settings. People who are happy with the default size and position will not be affected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4083)
<!-- Reviewable:end -->
