### PR TITLE
VideoCommon: Implement depth range equation in vertex shader.

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -440,7 +440,7 @@ ID3D11RasterizerState* StateCache::Get(RasterizerState state)
     return it->second;
 
   D3D11_RASTERIZER_DESC rastdc = CD3D11_RASTERIZER_DESC(D3D11_FILL_SOLID, state.cull_mode, false, 0,
-                                                        0.f, 0, true, true, false, false);
+                                                        0.f, 0, false, true, false, false);
 
   ID3D11RasterizerState* res = nullptr;
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -578,7 +578,10 @@ void Renderer::SetViewport()
   Wd = (X + Wd <= GetTargetWidth()) ? Wd : (GetTargetWidth() - X);
   Ht = (Y + Ht <= GetTargetHeight()) ? Ht : (GetTargetHeight() - Y);
 
-  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(X, Y, Wd, Ht, D3D11_MIN_DEPTH, 16777215.0f / 16777216.0f);
+  // We do depth clipping and depth range in the vertex shader instead of relying
+  // on the graphics API. However we still need to ensure depth values don't exceed
+  // the maximum value supported by the console GPU.
+  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(X, Y, Wd, Ht, D3D11_MIN_DEPTH, GX_MAX_DEPTH);
   D3D::context->RSSetViewports(1, &vp);
 }
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -578,14 +578,7 @@ void Renderer::SetViewport()
   Wd = (X + Wd <= GetTargetWidth()) ? Wd : (GetTargetWidth() - X);
   Ht = (Y + Ht <= GetTargetHeight()) ? Ht : (GetTargetHeight() - Y);
 
-  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(
-      X, Y, Wd, Ht,
-      1.0f - MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f,
-      1.0f -
-          MathUtil::Clamp<float>(xfmem.viewport.farZ - MathUtil::Clamp<float>(xfmem.viewport.zRange,
-                                                                              0.0f, 16777216.0f),
-                                 0.0f, 16777215.0f) /
-              16777216.0f);
+  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(X, Y, Wd, Ht, D3D11_MIN_DEPTH, 16777215.0f / 16777216.0f);
   D3D::context->RSSetViewports(1, &vp);
 }
 

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -71,6 +71,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsPostProcessing = false;
   g_Config.backend_info.bSupportsPaletteConversion = true;
   g_Config.backend_info.bSupportsClipControl = true;
+  g_Config.backend_info.bSupportsDepthClamp = true;
 
   IDXGIFactory* factory;
   IDXGIAdapter* ad;

--- a/Source/Core/VideoBackends/D3D12/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DState.cpp
@@ -329,7 +329,7 @@ D3D12_RASTERIZER_DESC StateCache::GetDesc12(RasterizerState state)
           0,
           0.f,
           0,
-          true,
+          false,
           true,
           false,
           0,

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -482,10 +482,7 @@ void Renderer::SetViewport()
   width = (x + width <= GetTargetWidth()) ? width : (GetTargetWidth() - x);
   height = (y + height <= GetTargetHeight()) ? height : (GetTargetHeight() - y);
 
-  D3D12_VIEWPORT vp = {
-      x, y, width, height,
-      D3D12_MIN_DEPTH,
-      16777215.0f / 16777216.0f };
+  D3D12_VIEWPORT vp = {x, y, width, height, D3D12_MIN_DEPTH, 16777215.0f / 16777216.0f};
 
   D3D::current_command_list->RSSetViewports(1, &vp);
 }

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -482,8 +482,10 @@ void Renderer::SetViewport()
   width = (x + width <= GetTargetWidth()) ? width : (GetTargetWidth() - x);
   height = (y + height <= GetTargetHeight()) ? height : (GetTargetHeight() - y);
 
-  D3D12_VIEWPORT vp = {x, y, width, height, D3D12_MIN_DEPTH, 16777215.0f / 16777216.0f};
-
+  // We do depth clipping and depth range in the vertex shader instead of relying
+  // on the graphics API. However we still need to ensure depth values don't exceed
+  // the maximum value supported by the console GPU.
+  D3D12_VIEWPORT vp = {x, y, width, height, D3D12_MIN_DEPTH, GX_MAX_DEPTH};
   D3D::current_command_list->RSSetViewports(1, &vp);
 }
 

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -484,12 +484,8 @@ void Renderer::SetViewport()
 
   D3D12_VIEWPORT vp = {
       x, y, width, height,
-      1.0f - MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f,
-      1.0f -
-          MathUtil::Clamp<float>(xfmem.viewport.farZ - MathUtil::Clamp<float>(xfmem.viewport.zRange,
-                                                                              0.0f, 16777216.0f),
-                                 0.0f, 16777215.0f) /
-              16777216.0f};
+      D3D12_MIN_DEPTH,
+      16777215.0f / 16777216.0f };
 
   D3D::current_command_list->RSSetViewports(1, &vp);
 }

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -74,6 +74,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsPostProcessing = false;
   g_Config.backend_info.bSupportsPaletteConversion = true;
   g_Config.backend_info.bSupportsClipControl = true;
+  g_Config.backend_info.bSupportsDepthClamp = true;
 
   IDXGIFactory* factory;
   IDXGIAdapter* ad;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1663,6 +1663,8 @@ void Renderer::ResetAPIState()
   glDisable(GL_BLEND);
   if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGL)
     glDisable(GL_COLOR_LOGIC_OP);
+  if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
+    glDisable(GL_CLIP_DISTANCE0);
   glDepthMask(GL_FALSE);
   glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 }
@@ -1671,6 +1673,8 @@ void Renderer::RestoreAPIState()
 {
   // Gets us back into a more game-like state.
   glEnable(GL_SCISSOR_TEST);
+  if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
+    glEnable(GL_CLIP_DISTANCE0);
   SetGenerationMode();
   BPFunctions::SetScissor();
   SetColorMask();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -482,7 +482,8 @@ Renderer::Renderer()
       GLExtensions::Supports("GL_ARB_shading_language_420pack");
 
   // Clip distance support is useless without a method to clamp the depth range
-  g_Config.backend_info.bSupportsDepthClamp = GLExtensions::Supports("GL_ARB_depth_clamp");
+  g_Config.backend_info.bSupportsDepthClamp = GLExtensions::Supports("GL_ARB_depth_clamp") &&
+    !DriverDetails::HasBug(DriverDetails::BUG_BROKENCLIPDISTANCE);
 
   g_ogl_config.bSupportsGLSLCache = GLExtensions::Supports("GL_ARB_get_program_binary");
   g_ogl_config.bSupportsGLPinnedMemory = GLExtensions::Supports("GL_AMD_pinned_memory");

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -725,6 +725,7 @@ Renderer::Renderer()
   glEnable(GL_DEPTH_TEST);
   glDepthFunc(GL_LEQUAL);
   glEnable(GL_CLIP_DISTANCE0);
+  glEnable(GL_DEPTH_CLAMP);
 
   glPixelStorei(GL_UNPACK_ALIGNMENT, 4);  // 4-byte pixel alignment
 
@@ -1137,7 +1138,7 @@ void Renderer::SetViewport()
     auto iceilf = [](float f) { return static_cast<GLint>(ceilf(f)); };
     glViewport(iceilf(X), iceilf(Y), iceilf(Width), iceilf(Height));
   }
-  glDepthRangef(0.0f, 1.0f);
+  glDepthRangef(0.0f, 16777215.0f / 16777216.0f);
 }
 
 void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1138,7 +1138,7 @@ void Renderer::SetViewport()
     auto iceilf = [](float f) { return static_cast<GLint>(ceilf(f)); };
     glViewport(iceilf(X), iceilf(Y), iceilf(Width), iceilf(Height));
   }
-  glDepthRangef(0.0f, 16777215.0f / 16777216.0f);
+  glDepthRangef(16777215.0f / 16777216.0f, 0.0f);
 }
 
 void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1115,12 +1115,6 @@ void Renderer::SetViewport()
                           (float)scissorYOff);
   float Width = EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float Height = EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-  float GLNear = MathUtil::Clamp<float>(
-                     xfmem.viewport.farZ -
-                         MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777216.0f, 16777216.0f),
-                     0.0f, 16777215.0f) /
-                 16777216.0f;
-  float GLFar = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
   if (Width < 0)
   {
     X += Width;
@@ -1142,7 +1136,7 @@ void Renderer::SetViewport()
     auto iceilf = [](float f) { return static_cast<GLint>(ceilf(f)); };
     glViewport(iceilf(X), iceilf(Y), iceilf(Width), iceilf(Height));
   }
-  glDepthRangef(GLFar, GLNear);
+  glDepthRangef(0.0f, 1.0f);
 }
 
 void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -482,8 +482,9 @@ Renderer::Renderer()
       GLExtensions::Supports("GL_ARB_shading_language_420pack");
 
   // Clip distance support is useless without a method to clamp the depth range
-  g_Config.backend_info.bSupportsDepthClamp = GLExtensions::Supports("GL_ARB_depth_clamp") &&
-    !DriverDetails::HasBug(DriverDetails::BUG_BROKENCLIPDISTANCE);
+  g_Config.backend_info.bSupportsDepthClamp =
+      GLExtensions::Supports("GL_ARB_depth_clamp") &&
+      !DriverDetails::HasBug(DriverDetails::BUG_BROKENCLIPDISTANCE);
 
   g_ogl_config.bSupportsGLSLCache = GLExtensions::Supports("GL_ARB_get_program_binary");
   g_ogl_config.bSupportsGLPinnedMemory = GLExtensions::Supports("GL_AMD_pinned_memory");
@@ -524,7 +525,8 @@ Renderer::Renderer()
     g_ogl_config.bSupportsGLSLCache = true;
     g_ogl_config.bSupportsGLSync = true;
 
-    // TODO: Implement support for GL_EXT_clip_cull_distance when there is an extension for depth clamping.
+    // TODO: Implement support for GL_EXT_clip_cull_distance when there is an extension for
+    // depth clamping.
     g_Config.backend_info.bSupportsDepthClamp = false;
 
     if (strstr(g_ogl_config.glsl_version, "3.0"))

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -724,6 +724,7 @@ Renderer::Renderer()
   glClearDepthf(1.0f);
   glEnable(GL_DEPTH_TEST);
   glDepthFunc(GL_LEQUAL);
+  glEnable(GL_CLIP_DISTANCE0);
 
   glPixelStorei(GL_UNPACK_ALIGNMENT, 4);  // 4-byte pixel alignment
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1159,8 +1159,12 @@ void Renderer::SetViewport()
     glViewport(iceilf(X), iceilf(Y), iceilf(Width), iceilf(Height));
   }
 
+  // Set the reversed depth range. If we do depth clipping and depth range in the
+  // vertex shader we only need to ensure depth values don't exceed the maximum
+  // value supported by the console GPU. If not, we simply clamp the near/far values
+  // themselves to the maximum value as done above.
   if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
-    glDepthRangef(16777215.0f / 16777216.0f, 0.0f);
+    glDepthRangef(GX_MAX_DEPTH, 0.0f);
   else
     glDepthRangef(GLFar, GLNear);
 }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -734,6 +734,7 @@ Renderer::Renderer()
   if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
   {
     glEnable(GL_CLIP_DISTANCE0);
+    glEnable(GL_CLIP_DISTANCE1);
     glEnable(GL_DEPTH_CLAMP);
   }
 
@@ -1664,7 +1665,10 @@ void Renderer::ResetAPIState()
   if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGL)
     glDisable(GL_COLOR_LOGIC_OP);
   if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
+  {
     glDisable(GL_CLIP_DISTANCE0);
+    glDisable(GL_CLIP_DISTANCE1);
+  }
   glDepthMask(GL_FALSE);
   glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 }
@@ -1674,7 +1678,10 @@ void Renderer::RestoreAPIState()
   // Gets us back into a more game-like state.
   glEnable(GL_SCISSOR_TEST);
   if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
+  {
     glEnable(GL_CLIP_DISTANCE0);
+    glEnable(GL_CLIP_DISTANCE1);
+  }
   SetGenerationMode();
   BPFunctions::SetScissor();
   SetColorMask();

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -482,9 +482,7 @@ Renderer::Renderer()
       GLExtensions::Supports("GL_ARB_shading_language_420pack");
 
   // Clip distance support is useless without a method to clamp the depth range
-  g_Config.backend_info.bSupportsDepthClamp =
-      GLExtensions::Supports("GL_ARB_depth_clamp") &&
-      !DriverDetails::HasBug(DriverDetails::BUG_BROKENCLIPDISTANCE);
+  g_Config.backend_info.bSupportsDepthClamp = GLExtensions::Supports("GL_ARB_depth_clamp");
 
   g_ogl_config.bSupportsGLSLCache = GLExtensions::Supports("GL_ARB_get_program_binary");
   g_ogl_config.bSupportsGLPinnedMemory = GLExtensions::Supports("GL_AMD_pinned_memory");

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -108,6 +108,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsPaletteConversion = true;
   g_Config.backend_info.bSupportsClipControl = true;
+  g_Config.backend_info.bSupportsDepthClamp = true;
 
   g_Config.backend_info.Adapters.clear();
 

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -74,6 +74,7 @@ static BugInfo m_known_bugs[] = {
     {OS_WINDOWS, VENDOR_INTEL, DRIVER_INTEL, Family::UNKNOWN, BUG_INTELBROKENBUFFERSTORAGE,
      101810.3907, 101810.3960, true},
     {OS_ALL, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN, BUG_SLOWGETBUFFERSUBDATA, -1.0, -1.0, true},
+    {OS_ALL, VENDOR_MESA, DRIVER_I965, Family::UNKNOWN, BUG_BROKENCLIPDISTANCE, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -205,12 +205,13 @@ enum Bug
   // everywhere else.
   BUG_SLOWGETBUFFERSUBDATA,
 
-  // Bug: Broken lines in geometry shaders when writing to gl_ClipDistance
+  // Bug: Broken lines in geometry shaders when writing to gl_ClipDistance in the vertex shader
   // Affected Devices: Mesa i965
   // Started Version: -1
   // Ended Version: -1
-  // Mesa hasn't tested geometry shaders on i965 with user-defined clipping planes.
-  // Causes misrenderings on a large amount of things that draw lines.
+  // Writing to gl_ClipDistance in both the vertex shader and the geometry shader will break
+  // the geometry shader. Current workaround is to make sure the geometry shader always consumes
+  // the gl_ClipDistance inputs from the vertex shader.
   BUG_BROKENCLIPDISTANCE,
 };
 

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -204,6 +204,14 @@ enum Bug
   // GPU memory to system memory. Use glMapBufferRange for BBox reads on AMD, and glGetBufferSubData
   // everywhere else.
   BUG_SLOWGETBUFFERSUBDATA,
+
+  // Bug: Broken lines in geometry shaders when writing to gl_ClipDistance
+  // Affected Devices: Mesa i965
+  // Started Version: -1
+  // Ended Version: -1
+  // Mesa hasn't tested geometry shaders on i965 with user-defined clipping planes.
+  // Causes misrenderings on a large amount of things that draw lines.
+  BUG_BROKENCLIPDISTANCE,
 };
 
 // Initializes our internal vendor, device family, and driver version

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/BPMemory.h"
+#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/GeometryShaderGen.h"
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/VideoCommon.h"
@@ -211,6 +212,15 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const geometry_shader_uid
   {
     out.Write("\tVS_OUTPUT f;\n");
     AssignVSOutputMembers(out, "f", "vs[i]", uid_data->numTexGens, uid_data->pixel_lighting);
+
+    if (g_ActiveConfig.backend_info.bSupportsDepthClamp &&
+        DriverDetails::HasBug(DriverDetails::BUG_BROKENCLIPDISTANCE))
+    {
+      // On certain GPUs we have to consume the clip distance from the vertex shader
+      // or else the other vertex shader outputs will get corrupted.
+      out.Write("\tf.clipDist0 = gl_in[i].gl_ClipDistance[0];\n");
+      out.Write("\tf.clipDist1 = gl_in[i].gl_ClipDistance[1];\n");
+    }
   }
   else
   {

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -313,7 +313,10 @@ static void EmitVertex(ShaderCode& out, const geometry_shader_uid_data* uid_data
   {
     out.Write("\tgl_Position = %s.pos;\n", vertex);
     if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
-      out.Write("\tgl_ClipDistance[0] = %s.clipDist;\n", vertex);
+    {
+      out.Write("\tgl_ClipDistance[0] = %s.clipDist0;\n", vertex);
+      out.Write("\tgl_ClipDistance[1] = %s.clipDist1;\n", vertex);
+    }
     AssignVSOutputMembers(out, "ps", vertex, uid_data->numTexGens, uid_data->pixel_lighting);
   }
   else

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -312,6 +312,8 @@ static void EmitVertex(ShaderCode& out, const geometry_shader_uid_data* uid_data
   if (ApiType == APIType::OpenGL)
   {
     out.Write("\tgl_Position = %s.pos;\n", vertex);
+    if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
+      out.Write("\tgl_ClipDistance[0] = %s.clipDist;\n", vertex);
     AssignVSOutputMembers(out, "ps", vertex, uid_data->numTexGens, uid_data->pixel_lighting);
   }
   else

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -86,6 +86,12 @@ unsigned int Renderer::efb_scale_numeratorY = 1;
 unsigned int Renderer::efb_scale_denominatorX = 1;
 unsigned int Renderer::efb_scale_denominatorY = 1;
 
+// The maximum depth that is written to the depth buffer should never exceed this value.
+// This is necessary because we use a 2^24 divisor for all our depth values to prevent
+// floating-point round-trip errors. However the console GPU doesn't ever write a value
+// to the depth buffer that exceeds 2^24 - 1.
+const float Renderer::GX_MAX_DEPTH = 16777215.0f / 16777216.0f;
+
 static float AspectToWidescreen(float aspect)
 {
   return aspect * ((16.0f / 9.0f) / (4.0f / 3.0f));

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -176,6 +176,8 @@ protected:
 
   static std::unique_ptr<PostProcessingShaderImplementation> m_post_processor;
 
+  static const float GX_MAX_DEPTH;
+
 private:
   static PEControl::PixelFormat prev_efb_format;
   static unsigned int efb_scale_numeratorX;

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -196,6 +196,8 @@ inline void GenerateVSOutputMembers(T& object, APIType api_type, u32 texgens,
     DefineOutputMember(object, api_type, qualifier, "float3", "WorldPos", -1, "TEXCOORD",
                        texgens + 2);
   }
+
+  DefineOutputMember(object, api_type, qualifier, "float", "clipDist", -1, "SV_ClipDistance");
 }
 
 template <class T>
@@ -216,6 +218,8 @@ inline void AssignVSOutputMembers(T& object, const char* a, const char* b, u32 t
     object.Write("\t%s.Normal = %s.Normal;\n", a, b);
     object.Write("\t%s.WorldPos = %s.WorldPos;\n", a, b);
   }
+
+  object.Write("\t%s.clipDist = %s.clipDist;\n", a, b);
 }
 
 // We use the flag "centroid" to fix some MSAA rendering bugs. With MSAA, the

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -197,7 +197,8 @@ inline void GenerateVSOutputMembers(T& object, APIType api_type, u32 texgens,
                        texgens + 2);
   }
 
-  DefineOutputMember(object, api_type, qualifier, "float", "clipDist", -1, "SV_ClipDistance");
+  DefineOutputMember(object, api_type, qualifier, "float", "clipDist", 0, "SV_ClipDistance", 0);
+  DefineOutputMember(object, api_type, qualifier, "float", "clipDist", 1, "SV_ClipDistance", 1);
 }
 
 template <class T>
@@ -219,7 +220,8 @@ inline void AssignVSOutputMembers(T& object, const char* a, const char* b, u32 t
     object.Write("\t%s.WorldPos = %s.WorldPos;\n", a, b);
   }
 
-  object.Write("\t%s.clipDist = %s.clipDist;\n", a, b);
+  object.Write("\t%s.clipDist0 = %s.clipDist0;\n", a, b);
+  object.Write("\t%s.clipDist1 = %s.clipDist1;\n", a, b);
 }
 
 // We use the flag "centroid" to fix some MSAA rendering bugs. With MSAA, the

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -399,13 +399,22 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
       out.Write("o.colors_1 = color1;\n");
   }
 
-  // Since we're adjusting z for the depth range before the perspective divide, we have to do our
-  // own clipping.
-  out.Write("o.clipDist = o.pos.z + o.pos.w;\n");
+  if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
+  {
+    // Since we're adjusting z for the depth range before the perspective divide, we have to do our
+    // own clipping.
+    out.Write("o.clipDist = o.pos.z + o.pos.w;\n");
 
-  // We have to handle the depth range in the vertex shader, because some games will use a depth range beyond
-  // the normal depth range of 0..1.
-  out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION".w - o.pos.z * " I_PIXELCENTERCORRECTION".z;\n");
+    // We have to handle the depth range in the vertex shader, because some games will use a depth range beyond
+    // the normal depth range of 0..1.
+    out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION".w - o.pos.z * " I_PIXELCENTERCORRECTION".z;\n");
+  }
+  else
+  {
+    // User-defined clipping is not supported, thus we rely on the API to handle the depth range for us.
+    // We still need to take care of the reversed depth, so we do that here.
+    out.Write("o.pos.z = -o.pos.z;\n");
+  }
 
   // write the true depth value, if the game uses depth textures pixel shaders will override with
   // the correct values
@@ -457,7 +466,8 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
       out.Write("colors_1 = o.colors_1;\n");
     }
 
-    out.Write("gl_ClipDistance[0] = o.clipDist;\n");
+    if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
+      out.Write("gl_ClipDistance[0] = o.clipDist;\n");
     out.Write("gl_Position = o.pos;\n");
   }
   else  // D3D

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -402,9 +402,9 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
   if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
   {
     // Since we're adjusting z for the depth range before the perspective divide, we have to do our
-    // own clipping.
-    out.Write("o.clipDist0 = o.pos.z + o.pos.w;\n");
-    out.Write("o.clipDist1 = o.pos.w * -o.pos.z;\n");
+    // own clipping. We want to clip so that -w <= z <= 0.
+    out.Write("o.clipDist0 = o.pos.z + o.pos.w;\n");  // Near: z < -w
+    out.Write("o.clipDist1 = -o.pos.z;\n");           // Far: z > 0
 
     // We have to handle the depth range in the vertex shader, because some games will use a depth range beyond
     // the normal depth range of 0..1.

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -405,7 +405,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
 
   // We have to handle the depth range in the vertex shader, because some games will use a depth range beyond
   // the normal depth range of 0..1.
-  out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION".w + o.pos.z * " I_PIXELCENTERCORRECTION".z;\n");
+  out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION".w - o.pos.z * " I_PIXELCENTERCORRECTION".z;\n");
 
   // write the true depth value, if the game uses depth textures pixel shaders will override with
   // the correct values
@@ -414,7 +414,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
   {
     // this results in a scale from -1..0 to -1..1 after perspective
     // divide
-    out.Write("o.pos.z = o.pos.z * -2.0 - o.pos.w;\n");
+    out.Write("o.pos.z = o.pos.z * 2.0 - o.pos.w;\n");
 
     // the next steps of the OGL pipeline are:
     // (x_c,y_c,z_c,w_c) = o.pos  //switch to OGL spec terminology

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -399,6 +399,10 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
       out.Write("o.colors_1 = color1;\n");
   }
 
+  // Since we're adjusting z for the depth range before the perspective divide, we have to do our
+  // own clipping.
+  out.Write("o.clipDist = o.pos.z + o.pos.w;\n");
+
   // We have to handle the depth range in the vertex shader, because some games will use a depth range beyond
   // the normal depth range of 0..1.
   out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION".w + o.pos.z * " I_PIXELCENTERCORRECTION".z;\n");
@@ -457,6 +461,7 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
       out.Write("colors_1 = o.colors_1;\n");
     }
 
+    out.Write("gl_ClipDistance[0] = o.clipDist;\n");
     out.Write("gl_Position = o.pos;\n");
   }
   else  // D3D

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -406,13 +406,14 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
     out.Write("o.clipDist0 = o.pos.z + o.pos.w;\n");  // Near: z < -w
     out.Write("o.clipDist1 = -o.pos.z;\n");           // Far: z > 0
 
-    // We have to handle the depth range in the vertex shader, because some games will use a depth range beyond
-    // the normal depth range of 0..1.
-    out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION".w - o.pos.z * " I_PIXELCENTERCORRECTION".z;\n");
+    // We have to handle the depth range in the vertex shader, because some games will use a depth
+    // range beyond the normal depth range of 0..1.
+    out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION ".w - "
+              "o.pos.z * " I_PIXELCENTERCORRECTION ".z;\n");
   }
   else
   {
-    // User-defined clipping is not supported, thus we rely on the API to handle the depth range for us.
+    // User-defined clipping is not supported, thus we rely on the API to handle the depth range.
     // We still need to take care of the reversed depth, so we do that here.
     out.Write("o.pos.z = -o.pos.z;\n");
   }

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -403,6 +403,10 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
   // the normal depth range of 0..1.
   out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION".w + o.pos.z * " I_PIXELCENTERCORRECTION".z;\n");
 
+  // We have to clamp to 2^24 - 1 here, because we map our depth range to 0..2^24 to prevent round-trip errors.
+  // Thus we test for values that will result in 2^24 or higher after the perspective divide.
+  out.Write("if (o.pos.z / o.pos.w >= 1.0) o.pos.z = 16777215.0 / 16777216.0 * o.pos.w;\n");
+
   // write the true depth value, if the game uses depth textures pixel shaders will override with
   // the correct values
   // if not early z culling will improve speed

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -399,43 +399,43 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
       out.Write("o.colors_1 = color1;\n");
   }
 
+  // Write the true depth value. If the game uses depth textures, then the pixel shader will
+  // override it with the correct values if not then early z culling will improve speed.
   if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
   {
+    // If we can disable the incorrect depth clipping planes using depth clamping, then we can do
+    // our own depth clipping and calculate the depth range before the perspective divide.
+
     // Since we're adjusting z for the depth range before the perspective divide, we have to do our
-    // own clipping. We want to clip so that -w <= z <= 0.
+    // own clipping. We want to clip so that -w <= z <= 0, which matches the console -1..0 range.
     out.Write("o.clipDist0 = o.pos.z + o.pos.w;\n");  // Near: z < -w
     out.Write("o.clipDist1 = -o.pos.z;\n");           // Far: z > 0
 
-    // We have to handle the depth range in the vertex shader, because some games will use a depth
-    // range beyond the normal depth range of 0..1.
+    // Adjust z for the depth range. We're using an equation which incorperates a depth inversion,
+    // so we can map the console -1..0 range to the 0..1 range used in the depth buffer.
+    // We have to handle the depth range in the vertex shader instead of after the perspective
+    // divide, because some games will use a depth range larger than what is allowed by the
+    // graphics API. These large depth ranges will still be clipped to the 0..1 range, so these
+    // games effectively add a depth bias to the values written to the depth buffer.
     out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION ".w - "
               "o.pos.z * " I_PIXELCENTERCORRECTION ".z;\n");
   }
   else
   {
-    // User-defined clipping is not supported, thus we rely on the API to handle the depth range.
-    // We still need to take care of the reversed depth, so we do that here.
+    // If we can't disable the incorrect depth clipping planes, then we need to rely on the
+    // graphics API to handle the depth range after the perspective divide. This can result in
+    // inaccurate depth values due to the missing depth bias, but that can be least corrected by
+    // overriding depth values in the pixel shader. We still need to take care of the reversed depth
+    // though, so we do that here.
     out.Write("o.pos.z = -o.pos.z;\n");
   }
 
-  // write the true depth value, if the game uses depth textures pixel shaders will override with
-  // the correct values
-  // if not early z culling will improve speed
   if (!g_ActiveConfig.backend_info.bSupportsClipControl)
   {
-    // this results in a scale from -1..0 to -1..1 after perspective
-    // divide
+    // If the graphics API doesn't support a depth range of 0..1, then we need to map z to
+    // the -1..1 range. Unfortunately we have to use a substraction, which is a lossy floating-point
+    // operation that can introduce a round-trip error.
     out.Write("o.pos.z = o.pos.z * 2.0 - o.pos.w;\n");
-
-    // the next steps of the OGL pipeline are:
-    // (x_c,y_c,z_c,w_c) = o.pos  //switch to OGL spec terminology
-    // clipping to -w_c <= (x_c,y_c,z_c) <= w_c
-    // (x_d,y_d,z_d) = (x_c,y_c,z_c)/w_c//perspective divide
-    // z_w = (f-n)/2*z_d + (n+f)/2
-    // z_w now contains the value to go to the 0..1 depth buffer
-
-    // trying to get the correct semantic while not using glDepthRange
-    // seems to get rather complicated
   }
 
   // The console GPU places the pixel center at 7/12 in screen space unless

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -399,14 +399,14 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
       out.Write("o.colors_1 = color1;\n");
   }
 
+  // We have to handle the depth range in the vertex shader, because some games will use a depth range beyond
+  // the normal depth range of 0..1.
+  out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION".w + o.pos.z * " I_PIXELCENTERCORRECTION".z;\n");
+
   // write the true depth value, if the game uses depth textures pixel shaders will override with
   // the correct values
   // if not early z culling will improve speed
-  if (g_ActiveConfig.backend_info.bSupportsClipControl)
-  {
-    out.Write("o.pos.z = -o.pos.z;\n");
-  }
-  else  // OGL
+  if (!g_ActiveConfig.backend_info.bSupportsClipControl)
   {
     // this results in a scale from -1..0 to -1..1 after perspective
     // divide

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -407,10 +407,6 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
   // the normal depth range of 0..1.
   out.Write("o.pos.z = o.pos.w * " I_PIXELCENTERCORRECTION".w + o.pos.z * " I_PIXELCENTERCORRECTION".z;\n");
 
-  // We have to clamp to 2^24 - 1 here, because we map our depth range to 0..2^24 to prevent round-trip errors.
-  // Thus we test for values that will result in 2^24 or higher after the perspective divide.
-  out.Write("if (o.pos.z / o.pos.w >= 1.0) o.pos.z = 16777215.0 / 16777216.0 * o.pos.w;\n");
-
   // write the true depth value, if the game uses depth textures pixel shaders will override with
   // the correct values
   // if not early z culling will improve speed

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -403,7 +403,8 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
   {
     // Since we're adjusting z for the depth range before the perspective divide, we have to do our
     // own clipping.
-    out.Write("o.clipDist = o.pos.z + o.pos.w;\n");
+    out.Write("o.clipDist0 = o.pos.z + o.pos.w;\n");
+    out.Write("o.clipDist1 = o.pos.w * -o.pos.z;\n");
 
     // We have to handle the depth range in the vertex shader, because some games will use a depth range beyond
     // the normal depth range of 0..1.
@@ -467,7 +468,10 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
     }
 
     if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
-      out.Write("gl_ClipDistance[0] = o.clipDist;\n");
+    {
+      out.Write("gl_ClipDistance[0] = o.clipDist0;\n");
+      out.Write("gl_ClipDistance[1] = o.clipDist1;\n");
+    }
     out.Write("gl_Position = o.pos;\n");
   }
   else  // D3D

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -389,8 +389,9 @@ void VertexShaderManager::SetConstants()
 
     // The depth range is handled in the vertex shader. We need to reverse
     // the far value to get a reversed depth range mapping. This is necessary
-    // because we have the most precision at the near plane, while the console
-    // has the most percision at the far plane.
+    // because the standard depth range equation pushes all depth values towards
+    // the back of the depth buffer where conventionally depth buffers have the
+    // least precision.
     constants.pixelcentercorrection[2] = xfmem.viewport.zRange / 16777215.0f;
     constants.pixelcentercorrection[3] = 1.0f - xfmem.viewport.farZ / 16777215.0f;
 

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -387,9 +387,12 @@ void VertexShaderManager::SetConstants()
     constants.pixelcentercorrection[0] = pixel_center_correction * pixel_size_x;
     constants.pixelcentercorrection[1] = pixel_center_correction * pixel_size_y;
 
-    // The depth range is handled in the vertex shader.
+    // The depth range is handled in the vertex shader. We need to reverse
+    // the far value to get a reversed depth range mapping. This is necessary
+    // because we have the most precision at the near plane, while the console
+    // has the most percision at the far plane.
     constants.pixelcentercorrection[2] = xfmem.viewport.zRange / 16777215.0f;
-    constants.pixelcentercorrection[3] = xfmem.viewport.farZ / 16777215.0f;
+    constants.pixelcentercorrection[3] = 1.0f - xfmem.viewport.farZ / 16777215.0f;
 
     dirty = true;
     // This is so implementation-dependent that we can't have it here.

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -386,6 +386,11 @@ void VertexShaderManager::SetConstants()
     const float pixel_size_y = 2.f / Renderer::EFBToScaledXf(2.f * xfmem.viewport.ht);
     constants.pixelcentercorrection[0] = pixel_center_correction * pixel_size_x;
     constants.pixelcentercorrection[1] = pixel_center_correction * pixel_size_y;
+
+    // The depth range is handled in the vertex shader.
+    constants.pixelcentercorrection[2] = (xfmem.viewport.zRange) / 16777216.0f;
+    constants.pixelcentercorrection[3] = (xfmem.viewport.farZ) / 16777216.0f;
+
     dirty = true;
     // This is so implementation-dependent that we can't have it here.
     g_renderer->SetViewport();

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -388,8 +388,8 @@ void VertexShaderManager::SetConstants()
     constants.pixelcentercorrection[1] = pixel_center_correction * pixel_size_y;
 
     // The depth range is handled in the vertex shader.
-    constants.pixelcentercorrection[2] = (xfmem.viewport.zRange) / 16777216.0f;
-    constants.pixelcentercorrection[3] = (xfmem.viewport.farZ) / 16777216.0f;
+    constants.pixelcentercorrection[2] = xfmem.viewport.zRange / 16777215.0f;
+    constants.pixelcentercorrection[3] = xfmem.viewport.farZ / 16777215.0f;
 
     dirty = true;
     // This is so implementation-dependent that we can't have it here.

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -171,7 +171,7 @@ struct VideoConfig final
     bool bSupportsPaletteConversion;
     bool bSupportsClipControl;  // Needed by VertexShaderGen, so must stay in VideoCommon
     bool bSupportsSSAA;
-    bool bSupportsDepthClamp;   // Needed by VertexShaderGen, so must stay in VideoCommon
+    bool bSupportsDepthClamp;  // Needed by VertexShaderGen, so must stay in VideoCommon
   } backend_info;
 
   // Utility

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -171,6 +171,7 @@ struct VideoConfig final
     bool bSupportsPaletteConversion;
     bool bSupportsClipControl;  // Needed by VertexShaderGen, so must stay in VideoCommon
     bool bSupportsSSAA;
+    bool bSupportsDepthClamp;   // Needed by VertexShaderGen, so must stay in VideoCommon
   } backend_info;
 
   // Utility


### PR DESCRIPTION
### Fixes

- [DKCR-fast-depth](https://fifoci.dolphin-emu.org/compare/1923906-1922806/)
- haruhi
- [metroid-visor](https://fifoci.dolphin-emu.org/compare/1923832-1922750/)
- [mini-ninjas](https://fifoci.dolphin-emu.org/compare/1923896-1922758/)
- [goldeneye-depth](https://fifoci.dolphin-emu.org/compare/1923875-1922805/)
- [ss-timestone on ogl-lin-mesa](https://fifoci.dolphin-emu.org/compare/1923824-1922716/), already works on other setups.
- [fifa-street on ogl-lin-mesa](https://fifoci.dolphin-emu.org/compare/1927370-1924784/), already works on other setups.

### Breaks

Only Mesa llvmpipe (software rasterizer) is affected by a bug that breaks these samples. Since a Mesa patch has already been created I chose not to use the fallback in this case. So these samples will intentionally seem broken right now:

- [mkdd-efb on ogl-lin-mesa](https://fifoci.dolphin-emu.org/compare/1923816-1922743/)
- [simpsons-game on ogl-lin-mesa](https://fifoci.dolphin-emu.org/compare/1923841-1922785/)
- [mii-channel on ogl-lin-mesa](https://fifoci.dolphin-emu.org/compare/1923867-1922762/)
- [mkwii-bluebox on ogl-lin-mesa](https://fifoci.dolphin-emu.org/compare/1923852-1922767/)

### Driver bug reports

[Bug 97231 - GL_DEPTH_CLAMP doesn't clamp to the far plane](https://bugs.freedesktop.org/show_bug.cgi?id=97231) (only affects llvmpipe)
[Bug 97232 - Line rendering broken in Dolphin when using gl_ClipDistance](https://bugs.freedesktop.org/show_bug.cgi?id=97232)

### Explanation

There are quite a few edge cases that use a depth range beyond 2^24. What that effectively does is apply a depth bias, but rather than try a bunch of workarounds again I've decided to move the depth range code to the vertex shader.

In the vertex shader we're not bound by the limitations of setting the depth range through the graphics API. Thus we can much more closely match the equation that the console uses, though with a compensation for the perspective division and the reversed depth: `z = farZ * w - zRange * z`.

However, since we're now processing the depth range before the perspective division we end up with depth clipping happening on `-w <= farZ * w + zRange * z <= 0` instead of `-w <= z <= 0`. To fix that we use a user-defined near/far clipping plane. We also disable depth clipping to get rid of the incorrect equation and to clamp depth values to `2^24 -1` to match console behavior.

At first I also wanted to revert the reversed depth trick, however this caused us to be inaccurate. This is caused by the fact that what we consider to be the far plane, the console considers to be the near plane. Without reversed depth we would place all objects at the far plane where the depth buffer has the least accuracy. With reversed depth we force these objects to be placed at the near plane where we have the most accuracy.

### Fallback

OpenGL ES doesn't support user-defined clipping nor depth clamping. In this case we will fallback to the old depth range code. This will cause the depth values to be incorrect again, but that can simply be solved with slow depth.

If we do not fall back to the old depth range code we will get inaccurate clipping, which slow depth can't solve. Therefore I think that it's more important to have accurate clipping than accurate depth in this case.

There are also potentially devices that do support user-defined clipping, but don't support depth clamping. In this we have no way to disable the incorrect  `-w <= farZ * w + zRange * z <= w` clipping, so that will still give inaccurate clipping. In this case we also fall back to the old depth range code.

And due to the current conflict between geometry shaders and gl_ClipDistance on the Mesa i965 driver, this fallback is also used on those drivers until there's a fix.

### Previous attempts

PR #3587 and PR #3676.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4085)
<!-- Reviewable:end -->
