### PR TITLE
Remove Global Declarations from Frame

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -66,8 +66,6 @@
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoConfig.h"
 
-int g_saveSlot = 1;
-
 #if defined(HAVE_X11) && HAVE_X11
 // X11Utils nastiness that's only used here
 namespace X11Utils
@@ -1528,11 +1526,11 @@ void CFrame::ParseHotkeys()
   }
   if (IsHotkey(HK_SAVE_STATE_SLOT_SELECTED))
   {
-    State::Save(g_saveSlot);
+    State::Save(m_saveSlot);
   }
   if (IsHotkey(HK_LOAD_STATE_SLOT_SELECTED))
   {
-    State::Load(g_saveSlot);
+    State::Load(m_saveSlot);
   }
 
   if (IsHotkey(HK_TOGGLE_STEREO_SBS))

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -158,6 +158,7 @@ private:
   bool m_bGameLoading;
   bool m_bClosing;
   bool m_confirmStop;
+  int m_saveSlot = 1;
 
   std::vector<std::string> drives;
 
@@ -347,4 +348,3 @@ void OnStoppedCallback();
 void GCTASManipFunction(GCPadStatus* PadStatus, int controllerID);
 void WiiTASManipFunction(u8* data, WiimoteEmu::ReportFeatures rptf, int controllerID, int ext,
                          const wiimote_key key);
-extern int g_saveSlot;

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1673,9 +1673,9 @@ void CFrame::OnFrameSkip(wxCommandEvent& event)
 
 void CFrame::OnSelectSlot(wxCommandEvent& event)
 {
-  g_saveSlot = event.GetId() - IDM_SELECT_SLOT_1 + 1;
-  Core::DisplayMessage(StringFromFormat("Selected slot %d - %s", g_saveSlot,
-                                        State::GetInfoStringOfSlot(g_saveSlot).c_str()),
+  m_saveSlot = event.GetId() - IDM_SELECT_SLOT_1 + 1;
+  Core::DisplayMessage(StringFromFormat("Selected slot %d - %s", m_saveSlot,
+                                        State::GetInfoStringOfSlot(m_saveSlot).c_str()),
                        2500);
 }
 
@@ -1683,7 +1683,7 @@ void CFrame::OnLoadCurrentSlot(wxCommandEvent& event)
 {
   if (Core::IsRunningAndStarted())
   {
-    State::Load(g_saveSlot);
+    State::Load(m_saveSlot);
   }
 }
 
@@ -1691,7 +1691,7 @@ void CFrame::OnSaveCurrentSlot(wxCommandEvent& event)
 {
   if (Core::IsRunningAndStarted())
   {
-    State::Save(g_saveSlot);
+    State::Save(m_saveSlot);
   }
 }
 


### PR DESCRIPTION
Removes the save slot global declaration from Frame, and replaces it with a getter and a setter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4089)
<!-- Reviewable:end -->
