### PR TITLE
NetWindow: Add missing override specifier

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetWindow.h
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.h
@@ -112,7 +112,7 @@ private:
   void OnPlayerSelect(wxCommandEvent& event);
   void GetNetSettings(NetSettings& settings);
   std::string FindCurrentGame();
-  std::string FindGame(const std::string& game);
+  std::string FindGame(const std::string& game) override;
   void AddChatMessage(ChatMessageType type, const std::string& msg);
 
   void OnCopyIP(wxCommandEvent&);


### PR DESCRIPTION
Clang 4.0 warns about this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4091)
<!-- Reviewable:end -->
