### PR TITLE
Analytics.h include curl.h

### DIFF
--- a/Source/Core/Common/Analytics.h
+++ b/Source/Core/Common/Analytics.h
@@ -11,18 +11,12 @@
 #include <utility>
 #include <vector>
 
-#include <curl/curlver.h>
+#include <curl/curl.h>
 
 #include "Common/CommonTypes.h"
 #include "Common/Event.h"
 #include "Common/FifoQueue.h"
 #include "Common/Flag.h"
-
-#if LIBCURL_VERSION_MAJOR >= 7 && LIBCURL_VERSION_MINOR >= 50
-typedef struct Curl_easy CURL;
-#else
-typedef void CURL;
-#endif
 
 // Utilities for analytics reporting in Dolphin. This reporting is designed to
 // provide anonymous data about how well Dolphin performs in the wild. It also


### PR DESCRIPTION
This should help prevent breakage when the curl.h header is changed.

As far as I can tell this only increases the compile time by a hair, but prevents needing to create a PR every time curl.h gets updated. Alternatively I'm experimenting with CURL_STRICTER defined per a conversion with booto:

>booto | krakn: try having CURL_STRICTER defined for the build?

Credit goes to: flacs for the suggestion to include curl.h

https://aur.archlinux.org/packages/dolphin-emu-git

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4092)
<!-- Reviewable:end -->
