### PR TITLE
Use Common::Flag and Common::Event when possible

### DIFF
--- a/Source/Core/AudioCommon/AOSoundStream.cpp
+++ b/Source/Core/AudioCommon/AOSoundStream.cpp
@@ -34,7 +34,7 @@ void AOSound::SoundLoop()
 
   buf_size = format.bits / 8 * format.channels * format.rate;
 
-  while (m_run_thread.load())
+  while (m_run_thread.IsSet())
   {
     m_mixer->Mix(realtimeBuffer, numBytesToRender >> 2);
 
@@ -49,7 +49,7 @@ void AOSound::SoundLoop()
 
 bool AOSound::Start()
 {
-  m_run_thread.store(true);
+  m_run_thread.Set();
   memset(realtimeBuffer, 0, sizeof(realtimeBuffer));
 
   thread = std::thread(&AOSound::SoundLoop, this);
@@ -63,7 +63,7 @@ void AOSound::Update()
 
 void AOSound::Stop()
 {
-  m_run_thread.store(false);
+  m_run_thread.Clear();
   soundSyncEvent.Set();
 
   {

--- a/Source/Core/AudioCommon/AOSoundStream.h
+++ b/Source/Core/AudioCommon/AOSoundStream.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <mutex>
 #include <thread>
 
@@ -20,7 +19,7 @@ class AOSound final : public SoundStream
 {
 #if defined(HAVE_AO) && HAVE_AO
   std::thread thread;
-  std::atomic<bool> m_run_thread;
+  Common::Flag m_run_thread;
   std::mutex soundCriticalSection;
   Common::Event soundSyncEvent;
 

--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -25,7 +25,7 @@ static soundtouch::SoundTouch soundTouch;
 //
 bool OpenALStream::Start()
 {
-  m_run_thread.store(true);
+  m_run_thread.Set();
   bool bReturn = false;
 
   ALDeviceList pDeviceList;
@@ -75,7 +75,7 @@ bool OpenALStream::Start()
 
 void OpenALStream::Stop()
 {
-  m_run_thread.store(false);
+  m_run_thread.Clear();
   // kick the thread if it's waiting
   soundSyncEvent.Set();
 
@@ -207,7 +207,7 @@ void OpenALStream::SoundLoop()
   soundTouch.setSetting(SETTING_SEEKWINDOW_MS, 28);
   soundTouch.setSetting(SETTING_OVERLAP_MS, 12);
 
-  while (m_run_thread.load())
+  while (m_run_thread.IsSet())
   {
     // num_samples_to_render in this update - depends on SystemTimers::AUDIO_DMA_PERIOD.
     const u32 stereo_16_bit_size = 4;

--- a/Source/Core/AudioCommon/OpenALStream.h
+++ b/Source/Core/AudioCommon/OpenALStream.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <thread>
 
 #include "AudioCommon/SoundStream.h"
@@ -68,7 +67,7 @@ public:
   static bool isValid() { return true; }
 private:
   std::thread thread;
-  std::atomic<bool> m_run_thread;
+  Common::Flag m_run_thread;
 
   Common::Event soundSyncEvent;
 

--- a/Source/Core/AudioCommon/PulseAudioStream.cpp
+++ b/Source/Core/AudioCommon/PulseAudioStream.cpp
@@ -27,7 +27,7 @@ bool PulseAudio::Start()
 
   NOTICE_LOG(AUDIO, "PulseAudio backend using %d channels", m_channels);
 
-  m_run_thread = true;
+  m_run_thread.Set();
   m_thread = std::thread(&PulseAudio::SoundLoop, this);
 
   // Initialize DPL2 parameters
@@ -38,7 +38,7 @@ bool PulseAudio::Start()
 
 void PulseAudio::Stop()
 {
-  m_run_thread = false;
+  m_run_thread.Clear();
   m_thread.join();
 }
 
@@ -54,7 +54,7 @@ void PulseAudio::SoundLoop()
 
   if (PulseInit())
   {
-    while (m_run_thread.load() && m_pa_connected == 1 && m_pa_error >= 0)
+    while (m_run_thread.IsSet() && m_pa_connected == 1 && m_pa_error >= 0)
       m_pa_error = pa_mainloop_iterate(m_pa_ml, 1, nullptr);
 
     if (m_pa_error < 0)

--- a/Source/Core/AudioCommon/PulseAudioStream.h
+++ b/Source/Core/AudioCommon/PulseAudioStream.h
@@ -8,10 +8,9 @@
 #include <pulse/pulseaudio.h>
 #endif
 
-#include <atomic>
-
 #include "AudioCommon/SoundStream.h"
 #include "Common/CommonTypes.h"
+#include "Common/Flag.h"
 #include "Common/Thread.h"
 
 class PulseAudio final : public SoundStream
@@ -41,7 +40,7 @@ private:
   static void UnderflowCallback(pa_stream* s, void* userdata);
 
   std::thread m_thread;
-  std::atomic<bool> m_run_thread;
+  Common::Flag m_run_thread;
 
   bool m_stereo;  // stereo, else surround
   int m_bytespersample;

--- a/Source/Core/Core/HW/EXI_DeviceGecko.h
+++ b/Source/Core/Core/HW/EXI_DeviceGecko.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <SFML/Network.hpp>
-#include <atomic>
 #include <deque>
 #include <memory>
 #include <mutex>
@@ -13,6 +12,7 @@
 #include <thread>
 
 #include "Common/CommonTypes.h"
+#include "Common/Flag.h"
 #include "Core/HW/EXI_Device.h"
 
 class GeckoSockServer
@@ -33,13 +33,13 @@ public:
 
 private:
   static int client_count;
-  std::atomic<bool> client_running;
+  Common::Flag client_running;
 
   // Only ever one server thread
   static void GeckoConnectionWaiter();
 
   static u16 server_port;
-  static std::atomic<bool> server_running;
+  static Common::Flag server_running;
   static std::thread connectionThread;
   static std::mutex connection_lock;
   static std::queue<std::unique_ptr<sf::TcpSocket>> waiting_socks;

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -205,19 +205,13 @@ void GCMemcardDirectory::FlushThread()
     // no-op until signalled
     m_flush_trigger.Wait();
 
-    if (m_exiting)
-    {
-      m_exiting = false;
+    if (m_exiting.TestAndClear())
       return;
-    }
     // no-op as long as signalled within flush_interval
     while (m_flush_trigger.WaitFor(flush_interval))
     {
-      if (m_exiting)
-      {
-        m_exiting = false;
+      if (m_exiting.TestAndClear())
         return;
-      }
     }
 
     FlushToFile();
@@ -226,7 +220,7 @@ void GCMemcardDirectory::FlushThread()
 
 GCMemcardDirectory::~GCMemcardDirectory()
 {
-  m_exiting = true;
+  m_exiting.Set();
   m_flush_trigger.Set();
   m_flush_thread.join();
 

--- a/Source/Core/Core/HW/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcardDirectory.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <chrono>
 #include <mutex>
 #include <string>
@@ -57,6 +56,6 @@ private:
   const std::chrono::seconds flush_interval = std::chrono::seconds(1);
   Common::Event m_flush_trigger;
   std::mutex m_write_mutex;
-  std::atomic<bool> m_exiting;
+  Common::Flag m_exiting;
   std::thread m_flush_thread;
 };

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <atomic>
-#include <condition_variable>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -95,20 +94,16 @@ private:
   virtual void IOWakeup() = 0;
 
   void ThreadFunc();
-  void SetReady();
-  void WaitReady();
 
   bool m_rumble_state;
 
   std::thread m_wiimote_thread;
   // Whether to keep running the thread.
-  std::atomic<bool> m_run_thread{false};
+  Common::Flag m_run_thread;
   // Whether to call PrepareOnThread.
-  std::atomic<bool> m_need_prepare{false};
-  // Whether the thread has finished ConnectInternal.
-  std::atomic<bool> m_thread_ready{false};
-  std::mutex m_thread_ready_mutex;
-  std::condition_variable m_thread_ready_cond;
+  Common::Flag m_need_prepare;
+  // Triggered when the thread has finished ConnectInternal.
+  Common::Event m_thread_ready_event;
 
   Common::FifoQueue<Report> m_read_reports;
   Common::FifoQueue<Report> m_write_reports;

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -6,7 +6,6 @@
 
 #include <SFML/Network/Packet.hpp>
 #include <array>
-#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -124,8 +123,8 @@ protected:
   std::thread m_thread;
 
   std::string m_selected_game;
-  std::atomic<bool> m_is_running{false};
-  std::atomic<bool> m_do_loop{true};
+  Common::Flag m_is_running{false};
+  Common::Flag m_do_loop{true};
 
   unsigned int m_target_buffer_size = 20;
 

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -19,7 +19,7 @@ AsyncRequests::AsyncRequests() : m_enable(false), m_passthrough(true)
 void AsyncRequests::PullEventsInternal()
 {
   std::unique_lock<std::mutex> lock(m_mutex);
-  m_empty.store(true);
+  m_empty.Set();
 
   while (!m_queue.empty())
   {
@@ -76,7 +76,7 @@ void AsyncRequests::PushEvent(const AsyncRequests::Event& event, bool blocking)
     return;
   }
 
-  m_empty.store(false);
+  m_empty.Clear();
   m_wake_me_up_again |= blocking;
 
   if (!m_enable)

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <queue>
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Flag.h"
 
 struct EfbPokeData;
 
@@ -70,7 +70,7 @@ public:
 
   void PullEvents()
   {
-    if (!m_empty.load())
+    if (!m_empty.IsSet())
       PullEventsInternal();
   }
   void PushEvent(const Event& event, bool blocking = false);
@@ -84,7 +84,7 @@ private:
 
   static AsyncRequests s_singleton;
 
-  std::atomic<bool> m_empty;
+  Common::Flag m_empty;
   std::queue<Event> m_queue;
   std::mutex m_mutex;
   std::condition_variable m_cond;

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -9,6 +9,7 @@
 #include "Common/Atomic.h"
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/Flag.h"
 #include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
@@ -36,8 +37,8 @@ static u16 m_bboxright;
 static u16 m_bboxbottom;
 static u16 m_tokenReg;
 
-static std::atomic<bool> s_interrupt_set;
-static std::atomic<bool> s_interrupt_waiting;
+static Common::Flag s_interrupt_set;
+static Common::Flag s_interrupt_waiting;
 
 static bool IsOnThread()
 {
@@ -106,8 +107,8 @@ void Init()
   fifo.bFF_LoWatermark = 0;
   fifo.bFF_LoWatermarkInt = 0;
 
-  s_interrupt_set.store(false);
-  s_interrupt_waiting.store(false);
+  s_interrupt_set.Clear();
+  s_interrupt_waiting.Clear();
 
   et_UpdateInterrupts = CoreTiming::RegisterEvent("CPInterrupt", UpdateInterrupts_Wrapper);
 }
@@ -324,18 +325,18 @@ void UpdateInterrupts(u64 userdata)
 {
   if (userdata)
   {
-    s_interrupt_set.store(true);
+    s_interrupt_set.Set();
     INFO_LOG(COMMANDPROCESSOR, "Interrupt set");
     ProcessorInterface::SetInterrupt(INT_CAUSE_CP, true);
   }
   else
   {
-    s_interrupt_set.store(false);
+    s_interrupt_set.Clear();
     INFO_LOG(COMMANDPROCESSOR, "Interrupt cleared");
     ProcessorInterface::SetInterrupt(INT_CAUSE_CP, false);
   }
   CoreTiming::ForceExceptionCheck(0);
-  s_interrupt_waiting.store(false);
+  s_interrupt_waiting.Clear();
   Fifo::RunGpu();
 }
 
@@ -347,7 +348,7 @@ void UpdateInterruptsFromVideoBackend(u64 userdata)
 
 bool IsInterruptWaiting()
 {
-  return s_interrupt_waiting.load();
+  return s_interrupt_waiting.IsSet();
 }
 
 void SetCPStatusFromGPU()
@@ -387,7 +388,7 @@ void SetCPStatusFromGPU()
 
   bool interrupt = (bpInt || ovfInt || undfInt) && m_CPCtrlReg.GPReadEnable;
 
-  if (interrupt != s_interrupt_set.load() && !s_interrupt_waiting.load())
+  if (interrupt != s_interrupt_set.IsSet() && !s_interrupt_waiting.IsSet())
   {
     u64 userdata = interrupt ? 1 : 0;
     if (IsOnThread())
@@ -395,7 +396,7 @@ void SetCPStatusFromGPU()
       if (!interrupt || bpInt || undfInt || ovfInt)
       {
         // Schedule the interrupt asynchronously
-        s_interrupt_waiting.store(true);
+        s_interrupt_waiting.Set();
         CommandProcessor::UpdateInterruptsFromVideoBackend(userdata);
       }
     }
@@ -418,14 +419,14 @@ void SetCPStatusFromCPU()
 
   bool interrupt = (bpInt || ovfInt || undfInt) && m_CPCtrlReg.GPReadEnable;
 
-  if (interrupt != s_interrupt_set.load() && !s_interrupt_waiting.load())
+  if (interrupt != s_interrupt_set.IsSet() && !s_interrupt_waiting.IsSet())
   {
     u64 userdata = interrupt ? 1 : 0;
     if (IsOnThread())
     {
       if (!interrupt || bpInt || undfInt || ovfInt)
       {
-        s_interrupt_set.store(interrupt);
+        s_interrupt_set.Set(interrupt);
         INFO_LOG(COMMANDPROCESSOR, "Interrupt set");
         ProcessorInterface::SetInterrupt(INT_CAUSE_CP, interrupt);
       }

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -36,7 +36,7 @@ static bool s_skip_current_frame = false;
 
 static Common::BlockingLoop s_gpu_mainloop;
 
-static std::atomic<bool> s_emu_running_state;
+static Common::Flag s_emu_running_state;
 
 // Most of this array is unlikely to be faulted in...
 static u8 s_fifo_aux_data[FIFO_SIZE];
@@ -147,13 +147,13 @@ void ExitGpuLoop()
   FlushGpu();
 
   // Terminate GPU thread loop
-  s_emu_running_state.store(true);
+  s_emu_running_state.Set();
   s_gpu_mainloop.Stop(false);
 }
 
 void EmulatorState(bool running)
 {
-  s_emu_running_state.store(running);
+  s_emu_running_state.Set(running);
   if (running)
     s_gpu_mainloop.Wakeup();
   else
@@ -307,7 +307,7 @@ void RunGpuLoop()
         g_video_backend->PeekMessages();
 
         // Do nothing while paused
-        if (!s_emu_running_state.load())
+        if (!s_emu_running_state.IsSet())
           return;
 
         if (s_use_deterministic_gpu_thread)


### PR DESCRIPTION
Replaces old and simple usages of std::atomic<bool> with Common::Flag
(which was introduced after the initial usage), so it's clear that
the variable is a flag and because Common::Flag is well tested.

This also replaces the ready logic in WiimoteReal with Common::Event
since it was basically just unnecessarily reimplementing Common::Event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4093)
<!-- Reviewable:end -->
