### PR TITLE
[WIP] D3D12: Handle descriptor pool re-use, PSO disk cache issues

### DIFF
--- a/Source/Core/VideoBackends/D3D12/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/D3D12/BoundingBox.cpp
@@ -47,13 +47,16 @@ void BBox::Init()
       std::make_unique<D3DStreamBuffer>(BBOX_STREAM_BUFFER_SIZE, BBOX_STREAM_BUFFER_SIZE, nullptr);
 
   // D3D12 root signature UAV must be raw or structured buffers, not typed. Since we used a typed
-  // buffer,
-  // we have to use a descriptor table. Luckily, we only have to allocate this once, and it never
-  // changes.
+  // buffer, we have to use a descriptor table. Luckily, we only have to allocate this once, and
+  // it never changes.
   D3D12_CPU_DESCRIPTOR_HANDLE cpu_descriptor_handle;
-  if (!D3D::gpu_descriptor_heap_mgr->Allocate(&cpu_descriptor_handle, &s_bbox_descriptor_handle,
-                                              nullptr, false))
+  if (!D3D::gpu_descriptor_heap_mgr->Allocate(nullptr,
+                                              &cpu_descriptor_handle,
+                                              nullptr,
+                                              &s_bbox_descriptor_handle))
+  {
     PanicAlert("Failed to create bounding box UAV descriptor");
+  }
 
   D3D12_UNORDERED_ACCESS_VIEW_DESC view_desc = {DXGI_FORMAT_R32_SINT, D3D12_UAV_DIMENSION_BUFFER};
   view_desc.Buffer.FirstElement = 0;

--- a/Source/Core/VideoBackends/D3D12/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.cpp
@@ -476,6 +476,8 @@ HRESULT Create(HWND wnd)
   OSD::AddMessage(
       StringFromFormat("Using D3D Adapter: %s.", UTF16ToUTF8(adapter_desc.Description).c_str()));
 
+  StateCache::CheckDiskCacheState(adapter);
+
   SAFE_RELEASE(factory);
   SAFE_RELEASE(adapter);
 

--- a/Source/Core/VideoBackends/D3D12/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.h
@@ -56,6 +56,7 @@ inline void CheckHR(HRESULT hr)
 
 class D3DCommandListManager;
 class D3DDescriptorHeapManager;
+class D3DSamplerHeapManager;
 class D3DTexture2D;
 
 enum GRAPHICS_ROOT_PARAMETER : u32
@@ -94,9 +95,9 @@ extern ID3D12Device* device12;
 extern unsigned int resource_descriptor_size;
 extern unsigned int sampler_descriptor_size;
 extern std::unique_ptr<D3DDescriptorHeapManager> gpu_descriptor_heap_mgr;
-extern std::unique_ptr<D3DDescriptorHeapManager> sampler_descriptor_heap_mgr;
 extern std::unique_ptr<D3DDescriptorHeapManager> dsv_descriptor_heap_mgr;
 extern std::unique_ptr<D3DDescriptorHeapManager> rtv_descriptor_heap_mgr;
+extern std::unique_ptr<D3DSamplerHeapManager> sampler_descriptor_heap_mgr;
 extern std::array<ID3D12DescriptorHeap*, 2> gpu_descriptor_heaps;
 
 extern D3D12_CPU_DESCRIPTOR_HANDLE null_srv_cpu;

--- a/Source/Core/VideoBackends/D3D12/D3DCommandListManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DCommandListManager.cpp
@@ -185,6 +185,14 @@ void D3DCommandListManager::DestroyAllPendingResources()
 
     destruction_list.clear();
   }
+
+  for (auto& free_list : m_deferred_descriptor_free_lists)
+  {
+    for (auto& iter : free_list)
+      iter.first->Free(iter.second);
+
+    free_list.clear();
+  }
 }
 
 void D3DCommandListManager::ResetAllCommandAllocators()
@@ -248,8 +256,11 @@ void D3DCommandListManager::PerformGPURolloverChecks()
     CHECK(m_deferred_destruction_lists[safe_to_delete_deferred_destruction_list][i]->Release() == 0,
           "Resource leak.");
   }
-
   m_deferred_destruction_lists[safe_to_delete_deferred_destruction_list].clear();
+
+  for (auto& iter : m_deferred_descriptor_free_lists[safe_to_delete_deferred_destruction_list])
+    iter.first->Free(iter.second);
+  m_deferred_descriptor_free_lists[safe_to_delete_deferred_destruction_list].clear();
 
   m_deferred_destruction_list_fences[m_current_deferred_destruction_list] =
       m_queue_frame_fence_value;
@@ -306,6 +317,12 @@ void D3DCommandListManager::DestroyResourceAfterCurrentCommandListExecuted(ID3D1
   m_deferred_destruction_lists[m_current_deferred_destruction_list].push_back(resource);
 }
 
+void D3DCommandListManager::FreeDescriptorAfterCurrentCommandListExecuted(D3DDescriptorHeapManager* descriptor_heap,
+                                                                          size_t index)
+{
+  m_deferred_descriptor_free_lists[m_current_deferred_destruction_list].emplace_back(descriptor_heap, index);
+}
+
 D3DCommandListManager::~D3DCommandListManager()
 {
 #ifdef USE_D3D12_QUEUED_COMMAND_LISTS
@@ -316,6 +333,11 @@ D3DCommandListManager::~D3DCommandListManager()
   // The command list will still be open, close it before destroying.
   m_backing_command_list->Close();
 
+  // Descriptor heaps are already freed at this point, as they depend on us.
+  // Just throw away the descriptors.
+  for (auto& free_list : m_deferred_descriptor_free_lists)
+    free_list.clear();
+ 
   DestroyAllPendingResources();
 
   m_backing_command_list->Release();

--- a/Source/Core/VideoBackends/D3D12/D3DCommandListManager.h
+++ b/Source/Core/VideoBackends/D3D12/D3DCommandListManager.h
@@ -22,6 +22,8 @@ enum COMMAND_LIST_STATE
   COMMAND_LIST_STATE_VERTEX_BUFFER = 32
 };
 
+class D3DDescriptorHeapManager;
+
 // This class provides an abstraction for D3D12 descriptor heaps.
 class D3DCommandListManager
 {
@@ -38,6 +40,8 @@ public:
   void ExecuteQueuedWorkAndPresent(IDXGISwapChain* swap_chain, UINT sync_interval, UINT flags);
 
   void DestroyResourceAfterCurrentCommandListExecuted(ID3D12Resource* resource);
+  void FreeDescriptorAfterCurrentCommandListExecuted(D3DDescriptorHeapManager* descriptor_heap,
+                                                     size_t index);
 
   void SetCommandListDirtyState(unsigned int command_list_state, bool dirty);
   bool GetCommandListDirtyState(COMMAND_LIST_STATE command_list_state) const;
@@ -68,6 +72,8 @@ private:
   void MoveToNextCommandAllocator();
   void ResetCommandList();
 
+  using PendingDescriptorFree = std::pair<D3DDescriptorHeapManager*, size_t>;
+
   unsigned int m_command_list_dirty_state = UINT_MAX;
   D3D_PRIMITIVE_TOPOLOGY m_command_list_current_topology = D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
 
@@ -92,6 +98,7 @@ private:
 
   UINT m_current_deferred_destruction_list;
   std::array<std::vector<ID3D12Resource*>, 2> m_deferred_destruction_lists;
+  std::array<std::vector<PendingDescriptorFree>, 2> m_deferred_descriptor_free_lists;
   std::array<UINT64, 2> m_deferred_destruction_list_fences;
 };
 

--- a/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.cpp
@@ -2,142 +2,336 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/D3D12/D3DCommandListManager.h"
 #include "VideoBackends/D3D12/D3DDescriptorHeapManager.h"
 #include "VideoBackends/D3D12/D3DBase.h"
 #include "VideoBackends/D3D12/D3DState.h"
 
 namespace DX12
 {
-bool operator==(const D3DDescriptorHeapManager::SamplerStateSet& lhs,
-                const D3DDescriptorHeapManager::SamplerStateSet& rhs)
+D3DDescriptorHeapManager::D3DDescriptorHeapManager(ID3D12DescriptorHeap* descriptor_heap,
+                                                   ID3D12DescriptorHeap* shadow_descriptor_heap,
+                                                   size_t num_descriptors,
+                                                   size_t descriptor_increment_size,
+                                                   size_t temporary_slots)
+  : m_descriptor_heap(descriptor_heap), m_shadow_descriptor_heap(shadow_descriptor_heap),
+  m_num_descriptors(num_descriptors), m_descriptor_increment_size(descriptor_increment_size),
+  m_temporary_slots(temporary_slots),
+  m_heap_base_cpu(descriptor_heap->GetCPUDescriptorHandleForHeapStart()),
+  m_heap_base_gpu(descriptor_heap->GetGPUDescriptorHandleForHeapStart())
 {
-  // D3D12TODO: Do something more efficient than this.
-  return (!memcmp(&lhs, &rhs, sizeof(D3DDescriptorHeapManager::SamplerStateSet)));
+  if (shadow_descriptor_heap)
+    m_shadow_heap_base = shadow_descriptor_heap->GetCPUDescriptorHandleForHeapStart();
+
+  // Set all slots to unallocated (1)
+  size_t bitset_count = num_descriptors / BITSET_SIZE + (((num_descriptors % BITSET_SIZE) != 0) ? 1 : 0);
+  m_free_slots.resize(bitset_count);
+  for (BitSetType& bs : m_free_slots)
+    bs.flip();
+
+  // Uses temporary slots?
+  if (temporary_slots > 0)
+  {
+    _assert_(temporary_slots <= num_descriptors);
+
+    // Set all temporary slots to allocated so we don't allocate them as a fixed handle.
+    for (size_t i = 0; i < temporary_slots; i++)
+      m_free_slots[i / BITSET_SIZE][i % BITSET_SIZE] = false;
+
+    // Set up fence tracking callback.
+    m_fence = D3D::command_list_mgr->RegisterQueueFenceCallback(this, &D3DDescriptorHeapManager::QueueFenceCallback);
+  }
 }
 
-D3DDescriptorHeapManager::D3DDescriptorHeapManager(D3D12_DESCRIPTOR_HEAP_DESC* desc,
-                                                   ID3D12Device* device,
-                                                   unsigned int temporarySlots)
-    : m_device(device)
+D3DDescriptorHeapManager::~D3DDescriptorHeapManager()
 {
-  CheckHR(device->CreateDescriptorHeap(desc, IID_PPV_ARGS(&m_descriptor_heap)));
+  D3D::command_list_mgr->RemoveQueueFenceCallback(this);
+  if (m_shadow_descriptor_heap)
+    m_shadow_descriptor_heap->Release();
+  m_descriptor_heap->Release();
+}
 
-  m_descriptor_heap_size = desc->NumDescriptors;
-  m_descriptor_increment_size = device->GetDescriptorHandleIncrementSize(desc->Type);
-  m_gpu_visible = (desc->Flags == D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
-
-  if (m_gpu_visible)
+bool D3DDescriptorHeapManager::Allocate(size_t* out_index,
+                                        D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_handle,
+                                        D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_handle_shadow,
+                                        D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_handle)
+{
+  // Start past the temporary slots, no point in searching those.
+  for (size_t group = m_temporary_slots / BITSET_SIZE; group < m_free_slots.size(); group++)
   {
-    D3D12_DESCRIPTOR_HEAP_DESC cpu_shadow_heap_desc = *desc;
-    cpu_shadow_heap_desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+    BitSetType& bs = m_free_slots[group];
+    if (bs.none())
+      continue;
 
-    CheckHR(device->CreateDescriptorHeap(&cpu_shadow_heap_desc,
-                                         IID_PPV_ARGS(&m_descriptor_heap_cpu_shadow)));
+    size_t bit = 0;
+    for (; bit < BITSET_SIZE; bit++)
+    {
+      if (bs[bit])
+        break;
+    }
 
-    m_heap_base_gpu = m_descriptor_heap->GetGPUDescriptorHandleForHeapStart();
-    m_heap_base_gpu_cpu_shadow = m_descriptor_heap_cpu_shadow->GetCPUDescriptorHandleForHeapStart();
+    size_t index = group * BITSET_SIZE + bit;
+    bs[bit] = false;
+
+    if (out_index)
+      *out_index = index;
+    if (out_cpu_handle)
+      out_cpu_handle->ptr = m_heap_base_cpu.ptr + index * m_descriptor_increment_size;
+    if (out_cpu_handle_shadow && m_shadow_descriptor_heap)
+      out_cpu_handle_shadow->ptr = m_shadow_heap_base.ptr + index * m_descriptor_increment_size;
+    if (out_gpu_handle)
+      out_gpu_handle->ptr = m_heap_base_gpu.ptr + index * m_descriptor_increment_size;
+
+    return true;
   }
 
-  m_heap_base_cpu = m_descriptor_heap->GetCPUDescriptorHandleForHeapStart();
-
-  m_first_temporary_slot_in_heap = m_descriptor_heap_size - temporarySlots;
-  m_current_temporary_offset_in_heap = m_first_temporary_slot_in_heap;
+  PanicAlert("Out of fixed descriptors");
+  return false;
 }
 
-bool D3DDescriptorHeapManager::Allocate(D3D12_CPU_DESCRIPTOR_HANDLE* cpu_handle,
-                                        D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handle,
-                                        D3D12_CPU_DESCRIPTOR_HANDLE* gpu_handle_cpu_shadow,
-                                        bool temporary)
+void D3DDescriptorHeapManager::Free(size_t index)
+{
+  _assert_(index < m_num_descriptors);
+
+  size_t group = index / BITSET_SIZE;
+  size_t bit = index % BITSET_SIZE;
+  m_free_slots[group][bit] = true;
+}
+
+bool D3DDescriptorHeapManager::AllocateTemporary(size_t num_handles,
+                                                 D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_base_handle,
+                                                 D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_base_handle)
+{
+  // Try allocating without waiting.
+  if (TryAllocateTemporaryHandles(num_handles, out_cpu_base_handle, out_gpu_base_handle))
+    return true;
+
+  // Consume fences to create more space.
+  while (!m_fences.empty())
+  {
+    auto& iter = m_fences.begin();
+    D3D::command_list_mgr->WaitOnCPUForFence(m_fence, iter->first);
+    m_gpu_temporary_descriptor_index = iter->second;
+    m_fences.pop_front();
+
+    // Retry allocation.
+    if (TryAllocateTemporaryHandles(num_handles, out_cpu_base_handle, out_gpu_base_handle))
+      return true;
+  }
+
+  // No space. Need to execute command list.
+  return false;
+}
+
+bool D3DDescriptorHeapManager::TryAllocateTemporaryHandles(size_t num_handles,
+                                                           D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_base_handle,
+                                                           D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_base_handle)
+{
+  size_t allocation_start_index;
+
+  // In front of the GPU?
+  if (m_current_temporary_descriptor_index >= m_gpu_temporary_descriptor_index)
+  {
+    size_t remaining_slots = m_temporary_slots - m_current_temporary_descriptor_index;
+    if (num_handles <= remaining_slots)
+    {
+      // Allocate at current offset.
+      allocation_start_index = m_current_temporary_descriptor_index;
+    }
+    else
+    {
+      // Move behind the GPU?
+      if (num_handles < m_gpu_temporary_descriptor_index)
+      {
+        // Allocate at start of list.
+        allocation_start_index = 0;
+      }
+      else
+      {
+        // Can't allocate.
+        return false;
+      }
+    }
+  }
+  else
+  {
+    // Behind the GPU. We use < here because if we used <= gpu could equal current.
+    size_t remaining_slots = m_gpu_temporary_descriptor_index - m_current_temporary_descriptor_index;
+    if (num_handles < remaining_slots)
+    {
+      // Allocate at current offset.
+      allocation_start_index = m_current_temporary_descriptor_index;
+    }
+    else
+    {
+      // Can't allocate.
+      return false;
+    }
+  }
+
+  if (out_cpu_base_handle)
+    out_cpu_base_handle->ptr = m_heap_base_cpu.ptr + allocation_start_index * m_descriptor_increment_size;
+  if (out_gpu_base_handle)
+    out_gpu_base_handle->ptr = m_heap_base_gpu.ptr + allocation_start_index * m_descriptor_increment_size;
+
+  m_current_temporary_descriptor_index = allocation_start_index + num_handles;
+  return true;
+}
+
+void D3DDescriptorHeapManager::QueueFenceCallback(void* owner, u64 fence_value)
+{
+  D3DDescriptorHeapManager* this_ptr = reinterpret_cast<D3DDescriptorHeapManager*>(owner);
+
+  // Don't add a new entry when the offset doesn't change.
+  size_t current_index = this_ptr->m_current_temporary_descriptor_index;
+  if (!this_ptr->m_fences.empty() && this_ptr->m_fences.back().second == current_index)
+    return;
+  
+  this_ptr->m_fences.emplace_back(fence_value, current_index);
+}
+
+std::unique_ptr<D3DDescriptorHeapManager> D3DDescriptorHeapManager::Create(ID3D12Device* device,
+                                                                           D3D12_DESCRIPTOR_HEAP_TYPE type,
+                                                                           D3D12_DESCRIPTOR_HEAP_FLAGS flags,
+                                                                           size_t num_descriptors,
+                                                                           size_t temporary_slots)
+{
+  D3D12_DESCRIPTOR_HEAP_DESC desc = {
+    type,                               // D3D12_DESCRIPTOR_HEAP_TYPE Type
+    static_cast<UINT>(num_descriptors), // UINT NumDescriptors
+    flags,                              // D3D12_DESCRIPTOR_HEAP_FLAGS Flags
+    0                                   // UINT NodeMask
+  };
+
+  // So that we can bind a single texture as a descriptor table (and not run off the edge),
+  // we add 8 slots to the SRV heap.
+  if (type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV)
+    desc.NumDescriptors += 8;
+
+  ID3D12DescriptorHeap* descriptor_heap;
+  HRESULT hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&descriptor_heap));
+  if (FAILED(hr))
+  {
+    PanicAlert("Failed to create D3D12 descriptor heap: %x", hr);
+    return nullptr;
+  }
+
+  // Create shadow descriptor heap for shader-visible heaps to use as copy source.
+  ID3D12DescriptorHeap* shadow_descriptor_heap = nullptr;
+  if (desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)
+  {
+    desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+    hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&shadow_descriptor_heap));
+    if (FAILED(hr))
+    {
+      PanicAlert("Failed to create D3D12 descriptor heap: %x", hr);
+      descriptor_heap->Release();
+      return nullptr;
+    }
+  }
+
+  // Pave descriptors, needed for shader resource views.
+  size_t increment_size = device->GetDescriptorHandleIncrementSize(type);
+  if (type == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV)
+  {
+    D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {
+      DXGI_FORMAT_R8G8B8A8_UNORM,               // DXGI_FORMAT Format
+      D3D12_SRV_DIMENSION_TEXTURE2D,            // D3D12_SRV_DIMENSION ViewDimension
+      D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING  // UINT Shader4ComponentMapping
+    };
+
+    D3D12_CPU_DESCRIPTOR_HANDLE handle = descriptor_heap->GetCPUDescriptorHandleForHeapStart();
+    for (UINT i = 0; i < desc.NumDescriptors; i++)
+    {
+      device->CreateShaderResourceView(nullptr, &srv_desc, handle);
+      handle.ptr += increment_size;
+    }
+
+    if (shadow_descriptor_heap)
+    {
+      handle = shadow_descriptor_heap->GetCPUDescriptorHandleForHeapStart();
+      for (UINT i = 0; i < desc.NumDescriptors; i++)
+      {
+        device->CreateShaderResourceView(nullptr, &srv_desc, handle);
+        handle.ptr += increment_size;
+      }
+    }
+  }
+
+  return std::make_unique<D3DDescriptorHeapManager>(descriptor_heap,
+                                                    shadow_descriptor_heap,
+                                                    num_descriptors,
+                                                    increment_size,
+                                                    temporary_slots);
+}
+
+bool operator==(const D3DSamplerHeapManager::SamplerStateSet& lhs,
+                const D3DSamplerHeapManager::SamplerStateSet& rhs)
+{
+  // D3D12TODO: Do something more efficient than this.
+  return (!memcmp(&lhs, &rhs, sizeof(D3DSamplerHeapManager::SamplerStateSet)));
+}
+
+D3DSamplerHeapManager::D3DSamplerHeapManager(ID3D12DescriptorHeap* descriptor_heap,
+                                             size_t num_descriptors,
+                                             size_t descriptor_increment_size)
+    : m_descriptor_heap(descriptor_heap), m_descriptor_heap_size(num_descriptors),
+  m_descriptor_increment_size(descriptor_increment_size),
+  m_heap_base_cpu(descriptor_heap->GetCPUDescriptorHandleForHeapStart()),
+  m_heap_base_gpu(descriptor_heap->GetGPUDescriptorHandleForHeapStart())
+{
+
+}
+
+bool D3DSamplerHeapManager::Allocate(D3D12_CPU_DESCRIPTOR_HANDLE* cpu_handle,
+                                     D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handle)
 {
   bool allocated_from_current_heap = true;
 
-  if (m_current_permanent_offset_in_heap + 1 >= m_first_temporary_slot_in_heap)
+  if (m_current_offset + 1 >= m_descriptor_heap_size)
   {
     // If out of room in the heap, start back at beginning.
     allocated_from_current_heap = false;
-    m_current_permanent_offset_in_heap = 0;
+    m_current_offset = 0;
   }
 
-  CHECK(!gpu_handle || (gpu_handle && m_gpu_visible),
-        "D3D12_GPU_DESCRIPTOR_HANDLE used on non-GPU-visible heap.");
+  if (cpu_handle)
+    cpu_handle->ptr = m_heap_base_cpu.ptr + m_current_offset * m_descriptor_increment_size;
 
-  if (temporary && m_current_temporary_offset_in_heap + 1 >= m_descriptor_heap_size)
-  {
-    m_current_temporary_offset_in_heap = m_first_temporary_slot_in_heap;
-  }
+  if (gpu_handle)
+    gpu_handle->ptr = m_heap_base_gpu.ptr + m_current_offset * m_descriptor_increment_size;
 
-  unsigned int heapOffsetToUse =
-      temporary ? m_current_temporary_offset_in_heap : m_current_permanent_offset_in_heap;
-
-  if (m_gpu_visible)
-  {
-    gpu_handle->ptr = m_heap_base_gpu.ptr + heapOffsetToUse * m_descriptor_increment_size;
-
-    if (gpu_handle_cpu_shadow)
-      gpu_handle_cpu_shadow->ptr =
-          m_heap_base_gpu_cpu_shadow.ptr + heapOffsetToUse * m_descriptor_increment_size;
-  }
-
-  cpu_handle->ptr = m_heap_base_cpu.ptr + heapOffsetToUse * m_descriptor_increment_size;
-
-  if (!temporary)
-  {
-    m_current_permanent_offset_in_heap++;
-  }
+  m_current_offset++;
 
   return allocated_from_current_heap;
 }
 
-bool D3DDescriptorHeapManager::AllocateGroup(
-    D3D12_CPU_DESCRIPTOR_HANDLE* base_cpu_handle, unsigned int num_handles,
-    D3D12_GPU_DESCRIPTOR_HANDLE* base_gpu_handle,
-    D3D12_CPU_DESCRIPTOR_HANDLE* base_gpu_handle_cpu_shadow, bool temporary)
+bool D3DSamplerHeapManager::AllocateGroup(unsigned int num_handles,
+                                          D3D12_CPU_DESCRIPTOR_HANDLE* base_cpu_handle,
+                                          D3D12_GPU_DESCRIPTOR_HANDLE* base_gpu_handle)
 {
   bool allocated_from_current_heap = true;
 
-  if (m_current_permanent_offset_in_heap + num_handles >= m_first_temporary_slot_in_heap)
+  if (m_current_offset + num_handles >= m_descriptor_heap_size)
   {
     // If out of room in the heap, start back at beginning.
     allocated_from_current_heap = false;
-    m_current_permanent_offset_in_heap = 0;
+    m_current_offset = 0;
   }
 
-  CHECK(!base_gpu_handle || (base_gpu_handle && m_gpu_visible),
-        "D3D12_GPU_DESCRIPTOR_HANDLE used on non-GPU-visible heap.");
+  if (base_cpu_handle)
+    base_cpu_handle->ptr = m_heap_base_cpu.ptr + m_current_offset * m_descriptor_increment_size;
 
-  if (temporary && m_current_temporary_offset_in_heap + num_handles >= m_descriptor_heap_size)
-  {
-    m_current_temporary_offset_in_heap = m_first_temporary_slot_in_heap;
-  }
+  if (base_gpu_handle)
+    base_gpu_handle->ptr = m_heap_base_gpu.ptr + m_current_offset * m_descriptor_increment_size;
 
-  unsigned int heapOffsetToUse =
-      temporary ? m_current_temporary_offset_in_heap : m_current_permanent_offset_in_heap;
-
-  if (m_gpu_visible)
-  {
-    base_gpu_handle->ptr = m_heap_base_gpu.ptr + heapOffsetToUse * m_descriptor_increment_size;
-
-    if (base_gpu_handle_cpu_shadow)
-      base_gpu_handle_cpu_shadow->ptr =
-          m_heap_base_gpu_cpu_shadow.ptr + heapOffsetToUse * m_descriptor_increment_size;
-  }
-
-  base_cpu_handle->ptr = m_heap_base_cpu.ptr + heapOffsetToUse * m_descriptor_increment_size;
-
-  if (temporary)
-  {
-    m_current_temporary_offset_in_heap += num_handles;
-  }
-  else
-  {
-    m_current_permanent_offset_in_heap += num_handles;
-  }
+  m_current_offset += num_handles;
 
   return allocated_from_current_heap;
 }
 
 D3D12_GPU_DESCRIPTOR_HANDLE
-D3DDescriptorHeapManager::GetHandleForSamplerGroup(SamplerState* sampler_state,
+D3DSamplerHeapManager::GetHandleForSamplerGroup(SamplerState* sampler_state,
                                                    unsigned int num_sampler_samples)
 {
   auto it = m_sampler_map.find(*reinterpret_cast<SamplerStateSet*>(sampler_state));
@@ -147,8 +341,10 @@ D3DDescriptorHeapManager::GetHandleForSamplerGroup(SamplerState* sampler_state,
     D3D12_CPU_DESCRIPTOR_HANDLE base_sampler_cpu_handle;
     D3D12_GPU_DESCRIPTOR_HANDLE base_sampler_gpu_handle;
 
+    // This is going to be an issue when the heap wraps around.
+    // It'll end up rendering incorrectly for one frame.
     bool allocatedFromExistingHeap =
-        AllocateGroup(&base_sampler_cpu_handle, num_sampler_samples, &base_sampler_gpu_handle);
+        AllocateGroup(num_sampler_samples, &base_sampler_cpu_handle, &base_sampler_gpu_handle);
 
     if (!allocatedFromExistingHeap)
     {
@@ -173,15 +369,39 @@ D3DDescriptorHeapManager::GetHandleForSamplerGroup(SamplerState* sampler_state,
   }
 }
 
-ID3D12DescriptorHeap* D3DDescriptorHeapManager::GetDescriptorHeap() const
+ID3D12DescriptorHeap* D3DSamplerHeapManager::GetDescriptorHeap() const
 {
   return m_descriptor_heap;
 }
 
-D3DDescriptorHeapManager::~D3DDescriptorHeapManager()
+std::unique_ptr<D3DSamplerHeapManager> D3DSamplerHeapManager::Create(ID3D12Device* device,
+                                                                     size_t num_descriptors)
 {
-  SAFE_RELEASE(m_descriptor_heap);
-  SAFE_RELEASE(m_descriptor_heap_cpu_shadow);
+  D3D12_DESCRIPTOR_HEAP_DESC desc = {
+    D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,         // D3D12_DESCRIPTOR_HEAP_TYPE Type
+    static_cast<UINT>(num_descriptors),         // UINT NumDescriptors
+    D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE,  // D3D12_DESCRIPTOR_HEAP_FLAGS Flags
+    0                                           // UINT NodeMask
+  };
+
+  ID3D12DescriptorHeap* descriptor_heap;
+  HRESULT hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(&descriptor_heap));
+  if (FAILED(hr))
+  {
+    PanicAlert("Failed to create D3D12 descriptor heap: %x", hr);
+    return nullptr;
+  }
+
+  size_t increment_size = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+
+  return std::make_unique<D3DSamplerHeapManager>(descriptor_heap,
+                                                 num_descriptors,
+                                                 increment_size);
+}
+
+D3DSamplerHeapManager::~D3DSamplerHeapManager()
+{
+  m_descriptor_heap->Release();
 }
 
 }  // namespace DX12

--- a/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.h
+++ b/Source/Core/VideoBackends/D3D12/D3DDescriptorHeapManager.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <bitset>
 #include <d3d12.h>
+#include <memory>
 #include <unordered_map>
 
 #include "VideoBackends/D3D12/D3DState.h"
@@ -15,23 +17,83 @@ namespace DX12
 class D3DDescriptorHeapManager
 {
 public:
-  D3DDescriptorHeapManager(D3D12_DESCRIPTOR_HEAP_DESC* desc, ID3D12Device* device,
-                           unsigned int temporarySlots = 0);
+  D3DDescriptorHeapManager(ID3D12DescriptorHeap* descriptor_heap,
+                           ID3D12DescriptorHeap* shadow_descriptor_heap,
+                           size_t num_descriptors,
+                           size_t descriptor_increment_size,
+                           size_t temporary_slots);
   ~D3DDescriptorHeapManager();
 
+  ID3D12DescriptorHeap* GetDescriptorHeap() const { return m_descriptor_heap; }
+
+  bool Allocate(size_t* out_index,
+                D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_handle,
+                D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_handle_shadow,
+                D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_handle);
+
+  void Free(size_t index);
+
+  bool AllocateTemporary(size_t num_handles,
+                         D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_base_handle,
+                         D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_base_handle);
+
+  static std::unique_ptr<D3DDescriptorHeapManager> Create(ID3D12Device* device,
+                                                          D3D12_DESCRIPTOR_HEAP_TYPE type,
+                                                          D3D12_DESCRIPTOR_HEAP_FLAGS flags,
+                                                          size_t num_descriptors,
+                                                          size_t temporary_slots = 0);
+
+private:
+  static void QueueFenceCallback(void* owner, u64 fence_value);
+
+  bool TryAllocateTemporaryHandles(size_t num_handles,
+                                   D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_base_handle,
+                                   D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_base_handle);
+
+  ID3D12DescriptorHeap* m_descriptor_heap;
+  ID3D12DescriptorHeap* m_shadow_descriptor_heap;
+  size_t m_num_descriptors;
+  size_t m_descriptor_increment_size;
+  size_t m_temporary_slots;
+
+  D3D12_CPU_DESCRIPTOR_HANDLE m_heap_base_cpu = {};
+  D3D12_CPU_DESCRIPTOR_HANDLE m_shadow_heap_base = {};
+  D3D12_GPU_DESCRIPTOR_HANDLE m_heap_base_gpu = {};
+
+  static constexpr size_t BITSET_SIZE = 1024;
+  using BitSetType = std::bitset<BITSET_SIZE>;
+  std::vector<BitSetType> m_free_slots;
+
+  size_t m_current_temporary_descriptor_index = 0;
+  size_t m_gpu_temporary_descriptor_index = 0;
+
+  // Fences tracking GPU index
+  std::deque<std::pair<u64, size_t>> m_fences;
+  ID3D12Fence* m_fence = nullptr;
+};
+
+class D3DSamplerHeapManager
+{
+public:
+  D3DSamplerHeapManager(ID3D12DescriptorHeap* descriptor_heap,
+                        size_t num_descriptors,
+                        size_t descriptor_increment_size);
+  ~D3DSamplerHeapManager();
+
   bool Allocate(D3D12_CPU_DESCRIPTOR_HANDLE* cpu_handle,
-                D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handle = nullptr,
-                D3D12_CPU_DESCRIPTOR_HANDLE* gpu_handle_cpu_shadow = nullptr,
-                bool temporary = false);
-  bool AllocateGroup(D3D12_CPU_DESCRIPTOR_HANDLE* cpu_handles, unsigned int num_handles,
-                     D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handles = nullptr,
-                     D3D12_CPU_DESCRIPTOR_HANDLE* gpu_handle_cpu_shadows = nullptr,
-                     bool temporary = false);
+                D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handle);
+
+  bool AllocateGroup(unsigned int num_handles,
+                     D3D12_CPU_DESCRIPTOR_HANDLE* cpu_handles,
+                     D3D12_GPU_DESCRIPTOR_HANDLE* gpu_handles);
 
   D3D12_GPU_DESCRIPTOR_HANDLE GetHandleForSamplerGroup(SamplerState* sampler_state,
                                                        unsigned int num_sampler_samples);
 
   ID3D12DescriptorHeap* GetDescriptorHeap() const;
+
+  static std::unique_ptr<D3DSamplerHeapManager> Create(ID3D12Device* device,
+                                                       size_t num_descriptors);
 
   struct SamplerStateSet
   {
@@ -46,13 +108,13 @@ public:
   };
 
 private:
-  ID3D12Device* m_device = nullptr;
-  ID3D12DescriptorHeap* m_descriptor_heap = nullptr;
-  ID3D12DescriptorHeap* m_descriptor_heap_cpu_shadow = nullptr;
+  ID3D12DescriptorHeap* m_descriptor_heap;
+  size_t m_descriptor_heap_size;
+  size_t m_descriptor_increment_size;
+  size_t m_current_offset = 0;
 
   D3D12_CPU_DESCRIPTOR_HANDLE m_heap_base_cpu;
   D3D12_GPU_DESCRIPTOR_HANDLE m_heap_base_gpu;
-  D3D12_CPU_DESCRIPTOR_HANDLE m_heap_base_gpu_cpu_shadow;
 
   struct hash_sampler_desc
   {
@@ -63,15 +125,6 @@ private:
   };
 
   std::unordered_map<SamplerStateSet, D3D12_GPU_DESCRIPTOR_HANDLE, hash_sampler_desc> m_sampler_map;
-
-  unsigned int m_current_temporary_offset_in_heap = 0;
-  unsigned int m_current_permanent_offset_in_heap = 0;
-
-  unsigned int m_descriptor_increment_size;
-  unsigned int m_descriptor_heap_size;
-  bool m_gpu_visible;
-
-  unsigned int m_first_temporary_slot_in_heap;
 };
 
 }  // namespace

--- a/Source/Core/VideoBackends/D3D12/D3DState.h
+++ b/Source/Core/VideoBackends/D3D12/D3DState.h
@@ -82,6 +82,8 @@ public:
 
   static void Init();
 
+  static void CheckDiskCacheState(IDXGIAdapter* adapter);
+
   // Get D3D12 descs for the internal state bitfields.
   static D3D12_SAMPLER_DESC GetDesc12(SamplerState state);
   static D3D12_BLEND_DESC GetDesc12(BlendState state);
@@ -187,6 +189,8 @@ private:
   std::unordered_map<SmallPsoDesc, ID3D12PipelineState*, hash_small_pso_desc,
                      equality_small_pipeline_state_desc>
       m_small_pso_map;
+
+  bool m_enable_disk_cache;
 };
 
 }  // namespace DX12

--- a/Source/Core/VideoBackends/D3D12/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D12/D3DTexture.h
@@ -53,8 +53,8 @@ public:
   ID3D12Resource* GetTex12() const;
 
   D3D12_CPU_DESCRIPTOR_HANDLE GetSRV12CPU() const;
+  D3D12_CPU_DESCRIPTOR_HANDLE GetSRV12CPUShadow() const;
   D3D12_GPU_DESCRIPTOR_HANDLE GetSRV12GPU() const;
-  D3D12_CPU_DESCRIPTOR_HANDLE GetSRV12GPUCPUShadow() const;
   D3D12_CPU_DESCRIPTOR_HANDLE GetDSV12() const;
   D3D12_CPU_DESCRIPTOR_HANDLE GetRTV12() const;
 
@@ -66,13 +66,18 @@ private:
   ~D3DTexture2D();
 
   ID3D12Resource* m_tex12 = nullptr;
+  u32 m_bind_flags = 0;
 
   D3D12_CPU_DESCRIPTOR_HANDLE m_srv12_cpu = {};
+  D3D12_CPU_DESCRIPTOR_HANDLE m_srv12_cpu_shadow = {};
   D3D12_GPU_DESCRIPTOR_HANDLE m_srv12_gpu = {};
-  D3D12_CPU_DESCRIPTOR_HANDLE m_srv12_gpu_cpu_shadow = {};
+  size_t m_srv12_index = 0;
 
   D3D12_CPU_DESCRIPTOR_HANDLE m_dsv12 = {};
+  size_t m_dsv12_index = 0;
+
   D3D12_CPU_DESCRIPTOR_HANDLE m_rtv12 = {};
+  size_t m_rtv12_index = 0;
 
   D3D12_RESOURCE_STATES m_resource_state = D3D12_RESOURCE_STATE_COMMON;
 

--- a/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
@@ -276,7 +276,7 @@ int CD3DFont::Init()
 
   tex_initial_data.release();
 
-  D3D::gpu_descriptor_heap_mgr->Allocate(&m_texture12_cpu, &m_texture12_gpu);
+  D3D::gpu_descriptor_heap_mgr->Allocate(nullptr, &m_texture12_cpu, nullptr, &m_texture12_gpu);
 
   D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
   srv_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
@@ -55,7 +55,8 @@ void PSTextureEncoder::Init()
 
   tex_rtv_desc.Texture2D.MipSlice = 0;
 
-  D3D::rtv_descriptor_heap_mgr->Allocate(&m_out_rtv_cpu);
+  // Don't need to worry about the index, as we're never going to free this descriptor.
+  D3D::rtv_descriptor_heap_mgr->Allocate(nullptr, &m_out_rtv_cpu, nullptr, nullptr);
   D3D::device12->CreateRenderTargetView(m_out, &tex_rtv_desc, m_out_rtv_cpu);
 
   // Create output staging buffer

--- a/Source/Core/VideoBackends/D3D12/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.h
@@ -25,9 +25,6 @@ private:
   struct TCacheEntry : TCacheEntryBase
   {
     D3DTexture2D* const m_texture = nullptr;
-    D3D12_CPU_DESCRIPTOR_HANDLE m_texture_srv_cpu_handle = {};
-    D3D12_GPU_DESCRIPTOR_HANDLE m_texture_srv_gpu_handle = {};
-    D3D12_CPU_DESCRIPTOR_HANDLE m_texture_srv_gpu_handle_cpu_shadow = {};
 
     TCacheEntry(const TCacheEntryConfig& config, D3DTexture2D* tex)
         : TCacheEntryBase(config), m_texture(tex)


### PR DESCRIPTION
D3D12 does not handle running out of descriptors when the temporary pool is exhausted, which resulted in graphical corruption or driver resets when this occurred within a single frame.

This also sorts out the huge memory usage on recent AMD drivers (2-3GB memory usage after starting a game).

On AMD, the PSO cache seems to have issues when recreating the pipeline objects after reloading, in the earlier driver releases it caused bugchecks, and in the latest release seems to crash within the driver. I've double-checked that the state matches exactly when re-creating the PSO, which it does, but it is possible I've missed something, so I'm marking this WIP until I get a chance to investigate further.

Relevant issues:
https://bugs.dolphin-emu.org/issues/9701
https://bugs.dolphin-emu.org/issues/9652
https://bugs.dolphin-emu.org/issues/9640 (possibly)
https://bugs.dolphin-emu.org/issues/9461 (possibly)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4094)

<!-- Reviewable:end -->
