### PR TITLE
[WIP] MMIO: Add MMIO Debug handler to dump all MMIO usages.

### DIFF
--- a/Source/Core/Core/HW/MMIO.cpp
+++ b/Source/Core/Core/HW/MMIO.cpp
@@ -195,6 +195,105 @@ WriteHandlingMethod<T>* InvalidWrite()
   });
 }
 
+// Debug: specialization of the complex handling type which acts as wrapper for all other handler.
+// It will additionally show each memory access.
+template <typename T>
+class DebugHandlingMethod : public ReadHandlingMethod<T>,
+                            public WriteHandlingMethod<T>,
+                            ReadHandlingMethodVisitor<T>,
+                            WriteHandlingMethodVisitor<T>
+{
+public:
+  explicit DebugHandlingMethod(ReadHandlingMethod<T>* read_handler) : read_handler_(read_handler)
+  {
+    read_handler_->AcceptReadVisitor(*this);
+  }
+
+  explicit DebugHandlingMethod(WriteHandlingMethod<T>* write_handler)
+      : write_handler_(write_handler)
+  {
+    write_handler_->AcceptWriteVisitor(*this);
+  }
+
+  virtual ~DebugHandlingMethod() {}
+  void AcceptReadVisitor(ReadHandlingMethodVisitor<T>& v) const override
+  {
+    v.VisitComplex(&read_lambda_);
+  }
+
+  void AcceptWriteVisitor(WriteHandlingMethodVisitor<T>& v) const override
+  {
+    v.VisitComplex(&write_lambda_);
+  }
+
+  void VisitConstant(T value) override
+  {
+    read_lambda_ = [value](u32 addr) {
+      ERROR_LOG(MEMMAP, "MMIO: Read %d bytes from constant register 0x%08x -> 0x%x", sizeof(T),
+                addr, value);
+      return value;
+    };
+  }
+  void VisitDirect(const T* addr, u32 mask) override
+  {
+    read_lambda_ = [addr, mask](u32 addr2) {
+      T value = *addr & mask;
+      ERROR_LOG(MEMMAP, "MMIO: Read %d bytes from direct register 0x%08x -> 0x%x", sizeof(T), addr2,
+                value);
+      return value;
+    };
+  }
+  void VisitComplex(const std::function<T(u32)>* lambda) override
+  {
+    read_lambda_ = [lambda](u32 addr) {
+      T value = (*lambda)(addr);
+      ERROR_LOG(MEMMAP, "MMIO: Read %d bytes from complex register 0x%08x -> 0x%x", sizeof(T), addr,
+                value);
+      return value;
+    };
+  }
+
+  void VisitNop() override
+  {
+    write_lambda_ = [](u32 addr, T value) {
+      ERROR_LOG(MEMMAP, "MMIO: Write %d bytes to nop register 0x%08x -> 0x%x", sizeof(T), addr,
+                value);
+    };
+  }
+  void VisitDirect(T* addr, u32 mask) override
+  {
+    write_lambda_ = [addr, mask](u32 addr2, T value) {
+      ERROR_LOG(MEMMAP, "MMIO: Write %d bytes to direct register 0x%08x -> 0x%x", sizeof(T), addr2,
+                value);
+      *addr = value & mask;
+    };
+  }
+  void VisitComplex(const std::function<void(u32, T)>* lambda) override
+  {
+    write_lambda_ = [lambda](u32 addr, T value) {
+      ERROR_LOG(MEMMAP, "MMIO: Write %d bytes to complex register 0x%08x -> 0x%x", sizeof(T), addr,
+                value);
+      (*lambda)(addr, value);
+    };
+  }
+
+private:
+  std::unique_ptr<ReadHandlingMethod<T>> read_handler_;
+  std::unique_ptr<WriteHandlingMethod<T>> write_handler_;
+  std::function<T(u32)> read_lambda_;
+  std::function<void(u32, T)> write_lambda_;
+};
+template <typename T>
+ReadHandlingMethod<T>* DebugRead(ReadHandlingMethod<T>* handler)
+{
+  return new DebugHandlingMethod<T>(handler);
+}
+template <typename T>
+WriteHandlingMethod<T>* DebugWrite(WriteHandlingMethod<T>* handler)
+{
+  return new DebugHandlingMethod<T>(handler);
+}
+
 // Converters to larger and smaller size. Probably the most complex of these
 // handlers to implement. They do not define new handling method types but
 // instead will internally use the types defined above.

--- a/Source/Core/Core/HW/MMIO.h
+++ b/Source/Core/Core/HW/MMIO.h
@@ -99,22 +99,29 @@ public:
   // Example usages can be found in just about any HW/ module in Dolphin's
   // codebase.
   template <typename Unit>
-  void RegisterRead(u32 addr, ReadHandlingMethod<Unit>* read)
+  void RegisterRead(u32 addr, ReadHandlingMethod<Unit>* read, bool debug = false)
   {
+    if (debug)
+      read = DebugRead(read);
+
     GetHandlerForRead<Unit>(addr).ResetMethod(read);
   }
 
   template <typename Unit>
-  void RegisterWrite(u32 addr, WriteHandlingMethod<Unit>* write)
+  void RegisterWrite(u32 addr, WriteHandlingMethod<Unit>* write, bool debug = false)
   {
+    if (debug)
+      write = DebugWrite(write);
+
     GetHandlerForWrite<Unit>(addr).ResetMethod(write);
   }
 
   template <typename Unit>
-  void Register(u32 addr, ReadHandlingMethod<Unit>* read, WriteHandlingMethod<Unit>* write)
+  void Register(u32 addr, ReadHandlingMethod<Unit>* read, WriteHandlingMethod<Unit>* write,
+                bool debug = false)
   {
-    RegisterRead(addr, read);
-    RegisterWrite(addr, write);
+    RegisterRead(addr, read, debug);
+    RegisterWrite(addr, write, debug);
   }
 
   // Direct read/write interface.

--- a/Source/Core/Core/HW/MMIOHandlers.h
+++ b/Source/Core/Core/HW/MMIOHandlers.h
@@ -68,6 +68,12 @@ ReadHandlingMethod<T>* InvalidRead();
 template <typename T>
 WriteHandlingMethod<T>* InvalidWrite();
 
+// Debug: Dump all register access, and call the wrapped handler afterwards.
+template <typename T>
+ReadHandlingMethod<T>* DebugRead(ReadHandlingMethod<T>*);
+template <typename T>
+WriteHandlingMethod<T>* DebugWrite(WriteHandlingMethod<T>*);
+
 // {Read,Write}To{Smaller,Larger}: these functions are not themselves handling
 // methods but will try to combine accesses to two handlers into one new
 // handler object.
@@ -212,6 +218,8 @@ private:
   MaybeExtern template WriteHandlingMethod<T>* ComplexWrite<T>(std::function<void(u32, T)>);       \
   MaybeExtern template ReadHandlingMethod<T>* InvalidRead<T>();                                    \
   MaybeExtern template WriteHandlingMethod<T>* InvalidWrite<T>();                                  \
+  MaybeExtern template ReadHandlingMethod<T>* DebugRead<T>(ReadHandlingMethod<T>*);                \
+  MaybeExtern template WriteHandlingMethod<T>* DebugWrite<T>(WriteHandlingMethod<T>*);             \
   MaybeExtern template class ReadHandler<T>;                                                       \
   MaybeExtern template class WriteHandler<T>
 


### PR DESCRIPTION
This PR tries to give an easy way to dump all MMIO usage of a few register.
In non-debugging contexts, this PR has no effect.

Do you think it's worth to have such a framework in master?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4105)

<!-- Reviewable:end -->
