### PR TITLE
Add Gamecube Language to DTM Header

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -336,6 +336,8 @@ bool BootCore(const std::string& _rFilename)
     StartUp.bFastDiscSpeed = Movie::IsFastDiscSpeed();
     StartUp.iCPUCore = Movie::GetCPUMode();
     StartUp.bSyncGPU = Movie::IsSyncGPU();
+    if (!StartUp.bWii)
+      StartUp.SelectedLanguage = Movie::GetLanguage();
     for (int i = 0; i < 2; ++i)
     {
       if (Movie::IsUsingMemcard(i) && Movie::IsStartingFromClearSave() && !StartUp.bWii)

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1515,9 +1515,15 @@ void GetSettings()
   s_bSyncGPU = SConfig::GetInstance().bSyncGPU;
   s_iCPUCore = SConfig::GetInstance().iCPUCore;
   s_bNetPlay = NetPlay::IsNetPlayRunning();
-  s_language = SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG");
-  if (!SConfig::GetInstance().bWii)
+  if (SConfig::GetInstance().bWii)
+  {
+    s_language = SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG");
+  }
+  else
+  {
     s_bClearSave = !File::Exists(SConfig::GetInstance().m_strMemoryCardA);
+    s_language = SConfig::GetInstance().SelectedLanguage;
+  }
   s_memcards |= (SConfig::GetInstance().m_EXIDevice[0] == EXIDEVICE_MEMORYCARD) << 0;
   s_memcards |= (SConfig::GetInstance().m_EXIDevice[1] == EXIDEVICE_MEMORYCARD) << 1;
 


### PR DESCRIPTION
Broke this out from the now closed PR #4081.

This uses the already existing language bit in the header which was used for Wii games, and re-purposes it for Gamecube as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4106)
<!-- Reviewable:end -->
