### PR TITLE
Remove Immediate variants of ScheduleEvent

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -263,27 +263,6 @@ void ScheduleEvent_Threadsafe(s64 cyclesIntoFuture, int event_type, u64 userdata
   tsQueue.Push(ne);
 }
 
-// Executes an event immediately, then returns.
-void ScheduleEvent_Immediate(int event_type, u64 userdata)
-{
-  _assert_msg_(POWERPC, Core::IsCPUThread(), "ScheduleEvent_Immediate from wrong thread");
-  event_types[event_type].callback(userdata, 0);
-}
-
-// Same as ScheduleEvent_Threadsafe(0, ...) EXCEPT if we are already on the CPU thread
-// in which case this is the same as ScheduleEvent_Immediate.
-void ScheduleEvent_Threadsafe_Immediate(int event_type, u64 userdata)
-{
-  if (Core::IsCPUThread())
-  {
-    event_types[event_type].callback(userdata, 0);
-  }
-  else
-  {
-    ScheduleEvent_Threadsafe(0, event_type, userdata);
-  }
-}
-
 // To be used from any thread, including the CPU thread
 void ScheduleEvent_AnyThread(s64 cyclesIntoFuture, int event_type, u64 userdata)
 {

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -50,9 +50,7 @@ void UnregisterAllEvents();
 
 // userdata MAY NOT CONTAIN POINTERS. userdata might get written and reloaded from savestates.
 void ScheduleEvent(s64 cyclesIntoFuture, int event_type, u64 userdata = 0);
-void ScheduleEvent_Immediate(int event_type, u64 userdata = 0);
 void ScheduleEvent_Threadsafe(s64 cyclesIntoFuture, int event_type, u64 userdata = 0);
-void ScheduleEvent_Threadsafe_Immediate(int event_type, u64 userdata = 0);
 void ScheduleEvent_AnyThread(s64 cyclesIntoFuture, int event_type, u64 userdata = 0);
 
 // We only permit one event of each type in the queue at a time.

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -464,8 +464,8 @@ static void GenerateDSPInterrupt(u64 DSPIntType, s64 cyclesLate)
 // CALLED FROM DSP EMULATOR, POSSIBLY THREADED
 void GenerateDSPInterruptFromDSPEmu(DSPInterruptType type)
 {
-  // TODO: Maybe rethink this? ScheduleEvent_Threadsafe_Immediate has unpredictable timing.
-  CoreTiming::ScheduleEvent_Threadsafe_Immediate(et_GenerateDSPInterrupt, type);
+  // TODO: Maybe rethink this? The timing is unpredictable.
+  CoreTiming::ScheduleEvent_AnyThread(0, et_GenerateDSPInterrupt, type);
 }
 
 // called whenever SystemTimers thinks the DSP deserves a few more cycles

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -565,11 +565,6 @@ void EnqueueReply_Threadsafe(u32 address, int cycles_in_future)
   CoreTiming::ScheduleEvent_Threadsafe(cycles_in_future, event_enqueue, address);
 }
 
-void EnqueueReply_Immediate(u32 address)
-{
-  EnqueueEvent(address);
-}
-
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future)
 {
   CoreTiming::ScheduleEvent(cycles_in_future, event_enqueue,

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -76,7 +76,6 @@ void ExecuteCommand(u32 _Address);
 void EnqueueRequest(u32 address);
 void EnqueueReply(u32 address, int cycles_in_future = 0);
 void EnqueueReply_Threadsafe(u32 address, int cycles_in_future = 0);
-void EnqueueReply_Immediate(u32 address);
 void EnqueueCommandAcknowledgement(u32 _Address, int cycles_in_future = 0);
 
 }  // end of namespace WII_IPC_HLE_Interface

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -113,7 +113,7 @@ void CWII_IPC_HLE_Device_di::FinishIOCtl(DVDInterface::DIInterruptType interrupt
   // IOS also seems to write back the command that was responded to in the FD field.
   Memory::Write_U32(Memory::Read_U32(command_address), command_address + 8);
   // Generate a reply to the IPC command
-  WII_IPC_HLE_Interface::EnqueueReply_Immediate(command_address);
+  WII_IPC_HLE_Interface::EnqueueReply(command_address);
 
   // DVDInterface is now ready to execute another command,
   // so we start executing a command from the queue if there is one

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -178,7 +178,7 @@ public:
     Memory::Write_U32(IPC_CMD_IOCTL, m_EventHookAddress + 8);
 
     // Generate a reply to the IPC command.
-    WII_IPC_HLE_Interface::EnqueueReply_Immediate(m_EventHookAddress);
+    WII_IPC_HLE_Interface::EnqueueReply(m_EventHookAddress);
   }
 
   // STATE_TO_SAVE


### PR DESCRIPTION
Usage of these are replaced with regular equivalents in order to avoid executing event handlers in the middle of JIT blocks.

Split from #3987.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4107)
<!-- Reviewable:end -->
