### PR TITLE
Tools: Fix the lint script (for real, this time -- and the last time)

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -905,8 +905,8 @@ void UpdateTitle()
                             (u32)Movie::GetCurrentFrame(), FPS, VPS, Speed);
   else if (Movie::IsRecordingInput())
     SFPS = StringFromFormat("Input: %u - VI: %u - FPS: %.0f - VPS: %.0f - %.0f%%",
-                            (u32)Movie::GetCurrentInputCount(), (u32)Movie::GetCurrentFrame(), FPS, VPS,
-                            Speed);
+                            (u32)Movie::GetCurrentInputCount(), (u32)Movie::GetCurrentFrame(), FPS,
+                            VPS, Speed);
   else
   {
     SFPS = StringFromFormat("FPS: %.0f - VPS: %.0f - %.0f%%", FPS, VPS, Speed);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -53,7 +53,7 @@ void JitArm64::GenerateAsm()
   {
     // set the mem_base based on MSR flags
     LDR(INDEX_UNSIGNED, ARM64Reg::W28, PPC_REG, PPCSTATE_OFF(msr));
-    FixupBranch physmem = TBNZ(ARM64Reg::W28, 31-27);
+    FixupBranch physmem = TBNZ(ARM64Reg::W28, 31 - 27);
     MOVI2R(MEM_REG, (u64)Memory::physical_base);
     FixupBranch membaseend = B();
     SetJumpTarget(physmem);
@@ -103,7 +103,7 @@ void JitArm64::GenerateAsm()
 
   // set the mem_base based on MSR flags
   LDR(INDEX_UNSIGNED, ARM64Reg::W28, PPC_REG, PPCSTATE_OFF(msr));
-  FixupBranch physmem = TBNZ(ARM64Reg::W28, 31-27);
+  FixupBranch physmem = TBNZ(ARM64Reg::W28, 31 - 27);
   MOVI2R(MEM_REG, (u64)Memory::physical_base);
   FixupBranch membaseend = B();
   SetJumpTarget(physmem);

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -5,9 +5,9 @@
 #include <map>
 #include <string>
 
-#include "DiscIO/Enums.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "DiscIO/Enums.h"
 
 namespace DiscIO
 {

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -148,7 +148,8 @@ void Init()
   s_signal_token_interrupt = false;
   s_signal_finish_interrupt = false;
 
-  et_SetTokenFinishOnMainThread = CoreTiming::RegisterEvent("SetTokenFinish", SetTokenFinish_OnMainThread);
+  et_SetTokenFinishOnMainThread =
+      CoreTiming::RegisterEvent("SetTokenFinish", SetTokenFinish_OnMainThread);
 }
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
@@ -218,8 +219,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
                  }));
 
   // Token register, readonly.
-  mmio->Register(base | PE_TOKEN_REG,
-                 MMIO::ComplexRead<u16>([](u32) { return s_token; }),
+  mmio->Register(base | PE_TOKEN_REG, MMIO::ComplexRead<u16>([](u32) { return s_token; }),
                  MMIO::InvalidWrite<u16>());
 
   // BBOX registers, readonly and need to update a flag.

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -312,9 +312,9 @@ void Renderer::DrawDebugText()
     {
       final_cyan += StringFromFormat("Frame: %llu", (unsigned long long)Movie::GetCurrentFrame());
       if (Movie::IsPlayingInput())
-        final_cyan +=
-            StringFromFormat("\nInput: %llu / %llu", (unsigned long long)Movie::GetCurrentInputCount(),
-                             (unsigned long long)Movie::GetTotalInputCount());
+        final_cyan += StringFromFormat("\nInput: %llu / %llu",
+                                       (unsigned long long)Movie::GetCurrentInputCount(),
+                                       (unsigned long long)Movie::GetTotalInputCount());
     }
 
     final_cyan += "\n";

--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -5,7 +5,7 @@
 fail=0
 
 # Check for clang-format issues.
-for f in $(git diff --name-only --diff-filter=ACMRTUXB); do
+for f in $(git diff --name-only --diff-filter=ACMRTUXB --cached); do
   if ! echo "${f}" | egrep -q "[.](cpp|h|mm)$"; then
     continue
   fi


### PR DESCRIPTION
It turns out that last fix was only partial, and it didn't fix the issue completely as paths were fixed, but staged changes were not in the list. This should fix it for real this time. Apologies for the trouble…

(git diff needs --cached to include staged changes, unlike git status. also, `git apply` doesn't stage the changes, but `git apply -3 -p 1` does, and this is what the buildbots use)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4116)
<!-- Reviewable:end -->
