### PR TITLE
Save GUI language as string instead of wxLanguage enum

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -156,7 +156,7 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
   interface->Set("MainWindowPosY", (iPosY == -32000) ? 0 : iPosY);  // TODO - HAX
   interface->Set("MainWindowWidth", iWidth);
   interface->Set("MainWindowHeight", iHeight);
-  interface->Set("Language", m_InterfaceLanguage);
+  interface->Set("LanguageCode", m_InterfaceLanguage);
   interface->Set("ShowToolbar", m_InterfaceToolbar);
   interface->Set("ShowStatusbar", m_InterfaceStatusbar);
   interface->Set("ShowLogWindow", m_InterfaceLogWindow);
@@ -423,7 +423,7 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
   interface->Get("MainWindowPosY", &iPosY, 100);
   interface->Get("MainWindowWidth", &iWidth, 800);
   interface->Get("MainWindowHeight", &iHeight, 600);
-  interface->Get("Language", &m_InterfaceLanguage, 0);
+  interface->Get("LanguageCode", &m_InterfaceLanguage, "");
   interface->Get("ShowToolbar", &m_InterfaceToolbar, true);
   interface->Get("ShowStatusbar", &m_InterfaceStatusbar, true);
   interface->Get("ShowLogWindow", &m_InterfaceLogWindow, false);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -210,7 +210,7 @@ struct SConfig : NonCopyable
   std::string m_bba_mac;
 
   // interface language
-  int m_InterfaceLanguage;
+  std::string m_InterfaceLanguage;
   float m_EmulationSpeed;
   bool m_OCEnable;
   float m_OCFactor;

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
@@ -27,38 +27,14 @@
 #include "DolphinWX/X11Utils.h"
 #endif
 
-static const wxLanguage language_ids[] = {
-    wxLANGUAGE_DEFAULT,
+static const std::string language_ids[] = {
+    "",
 
-    wxLANGUAGE_MALAY,
-    wxLANGUAGE_CATALAN,
-    wxLANGUAGE_CZECH,
-    wxLANGUAGE_DANISH,
-    wxLANGUAGE_GERMAN,
-    wxLANGUAGE_ENGLISH,
-    wxLANGUAGE_SPANISH,
-    wxLANGUAGE_FRENCH,
-    wxLANGUAGE_CROATIAN,
-    wxLANGUAGE_ITALIAN,
-    wxLANGUAGE_HUNGARIAN,
-    wxLANGUAGE_DUTCH,
-    wxLANGUAGE_NORWEGIAN_BOKMAL,
-    wxLANGUAGE_POLISH,
-    wxLANGUAGE_PORTUGUESE,
-    wxLANGUAGE_PORTUGUESE_BRAZILIAN,
-    wxLANGUAGE_ROMANIAN,
-    wxLANGUAGE_SERBIAN,
-    wxLANGUAGE_SWEDISH,
-    wxLANGUAGE_TURKISH,
+    "ms", "ca", "cs",    "da", "de", "en", "es",    "fr",    "hr", "it", "hu", "nl",
+    "nb",  // wxWidgets won't accept "no"
+    "pl", "pt", "pt_BR", "ro", "sr", "sv", "tr",
 
-    wxLANGUAGE_GREEK,
-    wxLANGUAGE_RUSSIAN,
-    wxLANGUAGE_ARABIC,
-    wxLANGUAGE_FARSI,
-    wxLANGUAGE_KOREAN,
-    wxLANGUAGE_JAPANESE,
-    wxLANGUAGE_CHINESE_SIMPLIFIED,
-    wxLANGUAGE_CHINESE_TRADITIONAL,
+    "el", "ru", "ar",    "fa", "ko", "ja", "zh_CN", "zh_TW",
 };
 
 InterfaceConfigPane::InterfaceConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, id)

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <array>
+#include <limits>
 #include <string>
 
 #include <wx/button.h>
@@ -12,6 +14,7 @@
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
+#include "Common/CommonFuncs.h"
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
@@ -27,7 +30,7 @@
 #include "DolphinWX/X11Utils.h"
 #endif
 
-static const std::string language_ids[] = {
+static const std::array<std::string, 29> language_ids = {
     "",
 
     "ms", "ca", "cs",    "da", "de", "en", "es",    "fr",    "hr", "it", "hu", "nl",
@@ -146,14 +149,26 @@ void InterfaceConfigPane::LoadGUIValues()
   m_osd_messages_checkbox->SetValue(startup_params.bOnScreenDisplayMessages);
   m_pause_focus_lost_checkbox->SetValue(SConfig::GetInstance().m_PauseOnFocusLost);
 
-  for (size_t i = 0; i < sizeof(language_ids) / sizeof(wxLanguage); i++)
+  const std::string exact_language = SConfig::GetInstance().m_InterfaceLanguage;
+  const std::string loose_language = exact_language.substr(0, exact_language.find('_'));
+  size_t exact_match_index = std::numeric_limits<size_t>::max();
+  size_t loose_match_index = std::numeric_limits<size_t>::max();
+  for (size_t i = 0; i < language_ids.size(); i++)
   {
-    if (language_ids[i] == SConfig::GetInstance().m_InterfaceLanguage)
+    if (language_ids[i] == exact_language)
     {
-      m_interface_lang_choice->SetSelection(i);
+      exact_match_index = i;
       break;
     }
+    else if (language_ids[i] == loose_language)
+    {
+      loose_match_index = i;
+    }
   }
+  if (exact_match_index != std::numeric_limits<size_t>::max())
+    m_interface_lang_choice->SetSelection(exact_match_index);
+  else if (loose_match_index != std::numeric_limits<size_t>::max())
+    m_interface_lang_choice->SetSelection(loose_match_index);
 
   LoadThemes();
 }

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -295,11 +295,23 @@ void DolphinApp::AfterInit()
 
 void DolphinApp::InitLanguageSupport()
 {
-  unsigned int language = 0;
-
-  IniFile ini;
-  ini.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
-  ini.GetOrCreateSection("Interface")->Get("Language", &language, wxLANGUAGE_DEFAULT);
+  std::string language_code;
+  {
+    IniFile ini;
+    ini.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
+    ini.GetOrCreateSection("Interface")->Get("LanguageCode", &language_code, "");
+  }
+  int language = wxLANGUAGE_UNKNOWN;
+  if (language_code.empty())
+  {
+    language = wxLANGUAGE_DEFAULT;
+  }
+  else
+  {
+    const wxLanguageInfo* language_info = wxLocale::FindLanguageInfo(StrToWxStr(language_code));
+    if (language_info)
+      language = language_info->Language;
+  }
 
   // Load language if possible, fall back to system default otherwise
   if (wxLocale::IsAvailable(language))


### PR DESCRIPTION
When 5.0-211 updated wxWidgets to 3.1.0, some entries in the wxLanguage enum were moved and added, changing the wxLanguage values. Because we save Dolphin's interface language to disk as a wxLanguage, the language you have set will mean something different depending on whether you have the updated wx version or not. For instance, setting the language to English with the updated version and then using an older version will make Dolphin use Dutch. Because we can't rely on the enum anymore, I'm replacing the "Language" setting with a "LanguageCode" setting that uses standard ISO 639 codes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4117)
<!-- Reviewable:end -->
