### PR TITLE
Convert OSREPORT text from SJIS to UTF-8

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -11,6 +11,7 @@
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MemoryUtil.h"
+#include "Common/StringUtil.h"
 #include "Common/Timer.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -340,7 +341,7 @@ void CEXIIPL::TransferByte(u8& _uByte)
 
         if (_uByte == '\r')
         {
-          NOTICE_LOG(OSREPORT, "%s", m_buffer.c_str());
+          NOTICE_LOG(OSREPORT, "%s", SHIFTJISToUTF8(m_buffer).c_str());
           m_buffer.clear();
         }
       }


### PR DESCRIPTION
I'm not sure this is the correct fix, but it looks like OSREPORT output is Shift-JIS, so we need to convert it to UTF-8. Most characters work fine without and with this conversion, but Japanese text completely fails and results in outputting invalid UTF-8 (which gets shown as �).

Example of an affected game:

<pre>
Dolphin OS
Kernel built : Nov 10 2004 06:26:41
[...]
�R�}���h�q�[�v           = 80a3c280-80a3d280 size=4 KB
�A�[�J�C�u�q�[�v         = 80a3d290-8131c690 size=9085 KB
�i�Q�c�p�q�[�v           = 8131c6a0-813996a0 size=500 KB
�Q�[���q�[�v             = 813996b0-817e76b0 size=4408 KB
�[���_�q�[�v             = 805043e0-80a2a9ec size=5273 KB
</pre>

After: (everything else looks the same; symbols, etc. still work)

<pre>
Dolphin OS
Kernel built : Nov 10 2004 06:26:41
[...]
コマンドヒープ           = 80a3c280-80a3d280 size=4 KB
アーカイブヒープ         = 80a3d290-8131c690 size=9085 KB
Ｊ２Ｄ用ヒープ           = 8131c6a0-813996a0 size=500 KB
ゲームヒープ             = 813996b0-817e76b0 size=4408 KB
ゼルダヒープ             = 805043e0-80a2a9ec size=5273 KB
</pre>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4121)
<!-- Reviewable:end -->
