### PR TITLE
Wiimote netplay: Check the reporting mode instead of the size

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -750,7 +750,7 @@ void Wiimote::Update()
   }
   if (NetPlay::IsNetPlayRunning())
   {
-    NetPlay_GetWiimoteData(m_index, data, rptf.size);
+    NetPlay_GetWiimoteData(m_index, data, rptf.size, m_reporting_mode);
     if (rptf.core)
       m_status.buttons = *(wm_buttons*)(data + rptf.core);
   }

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -146,7 +146,7 @@ private:
   void WriteData(const wm_write_data* const wd);
   void SendReadDataReply(ReadRequest& _request);
   void SpeakerData(wm_speaker_data* sd);
-  bool NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size);
+  bool NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size, u8 reporting_mode);
 
   // control groups
   Buttons *m_buttons, *m_dpad, *m_shake;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1022,7 +1022,7 @@ bool NetPlayClient::GetNetPads(const u8 pad_nb, GCPadStatus* pad_status)
 }
 
 // called from ---CPU--- thread
-bool NetPlayClient::WiimoteUpdate(int _number, u8* data, const u8 size)
+bool NetPlayClient::WiimoteUpdate(int _number, u8* data, const u8 size, u8 reporting_mode)
 {
   NetWiimote nw;
   {
@@ -1060,10 +1060,10 @@ bool NetPlayClient::WiimoteUpdate(int _number, u8* data, const u8 size)
 
   // If the reporting mode has changed, we just need to pop through the buffer,
   // until we reach a good input
-  if (nw.size() != size)
+  if (nw[1] != reporting_mode)
   {
     u32 tries = 0;
-    while (nw.size() != size)
+    while (nw[1] != reporting_mode)
     {
       while (m_wiimote_buffer[_number].Size() == 0)
       {
@@ -1084,7 +1084,7 @@ bool NetPlayClient::WiimoteUpdate(int _number, u8* data, const u8 size)
     }
 
     // If it still mismatches, it surely desynced
-    if (size != nw.size())
+    if (nw[1] != reporting_mode)
     {
       PanicAlertT("Netplay has desynced. There is no way to recover from this.");
       return false;
@@ -1268,12 +1268,12 @@ bool CSIDevice_GCController::NetPlay_GetInput(u8 numPAD, GCPadStatus* PadStatus)
     return false;
 }
 
-bool WiimoteEmu::Wiimote::NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size)
+bool WiimoteEmu::Wiimote::NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size, u8 reporting_mode)
 {
   std::lock_guard<std::mutex> lk(crit_netplay_client);
 
   if (netplay_client)
-    return netplay_client->WiimoteUpdate(wiimote, data, size);
+    return netplay_client->WiimoteUpdate(wiimote, data, size, reporting_mode);
   else
     return false;
 }

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -84,7 +84,7 @@ public:
   void SendChatMessage(const std::string& msg);
 
   // Send and receive pads values
-  bool WiimoteUpdate(int _number, u8* data, const u8 size);
+  bool WiimoteUpdate(int _number, u8* data, const u8 size, u8 reporting_mode);
   bool GetNetPads(const u8 pad_nb, GCPadStatus* pad_status);
 
   void OnTraversalStateChanged() override;


### PR DESCRIPTION
Currently netplay detects that the wiimote reporting mode was changed by its size. But there are several different reporting modes that use 23 bytes. If a game was to switch from one of those modes to another, it could lead to an invalid input, which could cause all kinds of issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4124)
<!-- Reviewable:end -->
