### PR TITLE
InputConfigDiag: Fix a segfault caused by missing check

### DIFF
--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -523,12 +523,14 @@ void ControlDialog::DetectControl(wxCommandEvent& event)
 
 void GamepadPage::DetectControl(wxCommandEvent& event)
 {
-  ControlButton* btn = (ControlButton*)event.GetEventObject();
-  if (DetectButton(btn) && m_iterate == true)
+  auto* btn = static_cast<ControlButton*>(event.GetEventObject());
+  if (DetectButton(btn) && m_iterate)
   {
     auto it = std::find(control_buttons.begin(), control_buttons.end(), btn);
+    // it can and will be control_buttons.end() for any control that is in the exclude list.
+    if (it == control_buttons.end())
+      return;
 
-    // std find will never return end since btn will always be found in control_buttons
     ++it;
     for (; it != control_buttons.end(); ++it)
     {


### PR DESCRIPTION
The original code assumed that we would always find a button in
control_buttons. However, this is incorrect, since the iterator can and
will be control_buttons.end() if the button that triggered the iterate
code is not in control_buttons, which happens when it's in an
exclude list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4125)
<!-- Reviewable:end -->
