### PR TITLE
Fix dialog closing buttons

### DIFF
--- a/Source/Core/DolphinWX/Config/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/Config/ConfigMain.cpp
@@ -34,7 +34,7 @@ CConfigMain::CConfigMain(wxWindow* parent, wxWindowID id, const wxString& title,
   m_refresh_game_list_on_close = false;
 
   Bind(wxEVT_CLOSE_WINDOW, &CConfigMain::OnClose, this);
-  Bind(wxEVT_BUTTON, &CConfigMain::OnOk, this, wxID_OK);
+  Bind(wxEVT_BUTTON, &CConfigMain::OnCloseButton, this, wxID_CLOSE);
   Bind(wxDOLPHIN_CFG_REFRESH_LIST, &CConfigMain::OnSetRefreshGameListOnClose, this);
 
   CreateGUIControls();
@@ -80,7 +80,7 @@ void CConfigMain::CreateGUIControls()
 
   wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);
   main_sizer->Add(Notebook, 1, wxEXPAND | wxALL, 5);
-  main_sizer->Add(CreateButtonSizer(wxOK), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+  main_sizer->Add(CreateButtonSizer(wxCLOSE), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
 #ifdef __APPLE__
   main_sizer->SetMinSize(550, 0);
@@ -101,7 +101,7 @@ void CConfigMain::OnClose(wxCloseEvent& WXUNUSED(event))
   SConfig::GetInstance().SaveSettings();
 }
 
-void CConfigMain::OnOk(wxCommandEvent& WXUNUSED(event))
+void CConfigMain::OnCloseButton(wxCommandEvent& WXUNUSED(event))
 {
   Close();
 }

--- a/Source/Core/DolphinWX/Config/ConfigMain.h
+++ b/Source/Core/DolphinWX/Config/ConfigMain.h
@@ -38,7 +38,7 @@ public:
 private:
   void CreateGUIControls();
   void OnClose(wxCloseEvent& event);
-  void OnOk(wxCommandEvent& event);
+  void OnCloseButton(wxCommandEvent& event);
   void OnSetRefreshGameListOnClose(wxCommandEvent& event);
 
   wxNotebook* Notebook;

--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
@@ -46,7 +46,7 @@ GCAdapterConfigDiag::GCAdapterConfigDiag(wxWindow* const parent, const wxString&
   szr->Add(m_adapter_status, 0, wxEXPAND);
   szr->Add(gamecube_rumble, 0, wxEXPAND);
   szr->Add(gamecube_konga, 0, wxEXPAND);
-  szr->Add(CreateButtonSizer(wxOK | wxNO_DEFAULT), 0, wxEXPAND | wxALL, 5);
+  szr->Add(CreateButtonSizer(wxCLOSE), 0, wxEXPAND | wxALL, 5);
 
   SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
   SetSizerAndFit(szr);

--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -23,15 +23,6 @@ public:
   ControllerConfigDiag(wxWindow* const parent);
 
 private:
-  void RefreshRealWiimotes(wxCommandEvent& event);
-
-  void ConfigEmulatedWiimote(wxCommandEvent& event);
-
-  void SelectSource(wxCommandEvent& event);
-  void RevertSource();
-
-  void Save(wxCommandEvent& event);
-
   void OnSensorBarPos(wxCommandEvent& event)
   {
     SConfig::GetInstance().m_SYSCONF->SetData("BT.BAR", event.GetInt());
@@ -75,18 +66,23 @@ private:
   wxStaticBoxSizer* CreateRealWiimoteSizer();
   wxStaticBoxSizer* CreateGeneralWiimoteSettingsSizer();
 
-  void Cancel(wxCommandEvent& event);
+  void OnClose(wxCloseEvent& event);
+  void OnCloseButton(wxCommandEvent& event);
+
   void OnGameCubePortChanged(wxCommandEvent& event);
   void OnGameCubeConfigButton(wxCommandEvent& event);
 
-  std::map<wxWindowID, unsigned int> m_gc_port_choice_ids;
-  std::map<wxWindowID, unsigned int> m_gc_port_config_ids;
+  void OnWiimoteSourceChanged(wxCommandEvent& event);
+  void OnWiimoteConfigButton(wxCommandEvent& event);
+  void OnWiimoteRefreshButton(wxCommandEvent& event);
+  void SaveWiimoteSource();
+
+  std::map<wxWindowID, unsigned int> m_gc_port_from_choice_id;
+  std::map<wxWindowID, unsigned int> m_gc_port_from_config_id;
+  std::array<wxButton*, 4> m_gc_port_configure_button;
   std::array<wxString, 8> m_gc_pad_type_strs;
 
-  std::map<wxWindowID, unsigned int> m_wiimote_index_from_ctrl_id;
-  unsigned int m_orig_wiimote_sources[MAX_BBMOTES];
-
-  wxButton* wiimote_configure_bt[MAX_WIIMOTES];
-  wxButton* gamecube_configure_bt[4];
-  std::map<wxWindowID, unsigned int> m_wiimote_index_from_conf_bt_id;
+  std::map<wxWindowID, unsigned int> m_wiimote_index_from_choice_id;
+  std::map<wxWindowID, unsigned int> m_wiimote_index_from_config_id;
+  std::array<wxButton*, MAX_WIIMOTES> m_wiimote_configure_button;
 };

--- a/Source/Core/DolphinWX/FifoPlayerDlg.cpp
+++ b/Source/Core/DolphinWX/FifoPlayerDlg.cpp
@@ -284,19 +284,7 @@ void FifoPlayerDlg::CreateGUIControls()
   }
 
   sMain->Add(m_Notebook, 1, wxEXPAND | wxALL, 5);
-
-  wxBoxSizer* sButtons;
-  sButtons = new wxBoxSizer(wxHORIZONTAL);
-
-  wxBoxSizer* sCloseButtonExpander;
-  sCloseButtonExpander = new wxBoxSizer(wxHORIZONTAL);
-
-  sButtons->Add(sCloseButtonExpander, 1, wxEXPAND, 5);
-
-  m_Close = new wxButton(this, wxID_ANY, _("Close"));
-  sButtons->Add(m_Close, 0, wxALL, 5);
-
-  sMain->Add(sButtons, 0, wxEXPAND, 5);
+  sMain->Add(CreateButtonSizer(wxCLOSE), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
   SetSizer(sMain);
   Layout();

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -202,10 +202,15 @@ void InputConfigDialog::UpdateControlReferences()
   }
 }
 
-void InputConfigDialog::ClickSave(wxCommandEvent& event)
+void InputConfigDialog::OnClose(wxCloseEvent& event)
 {
   m_config.SaveConfig();
-  event.Skip();
+  EndModal(wxID_OK);
+}
+
+void InputConfigDialog::OnCloseButton(wxCommandEvent& event)
+{
+  Close();
 }
 
 int ControlDialog::GetRangeSliderValue() const
@@ -1097,11 +1102,12 @@ InputConfigDialog::InputConfigDialog(wxWindow* const parent, InputConfig& config
   UpdateDeviceComboBox();
   UpdateProfileComboBox();
 
-  Bind(wxEVT_BUTTON, &InputConfigDialog::ClickSave, this, wxID_OK);
+  Bind(wxEVT_CLOSE_WINDOW, &InputConfigDialog::OnClose, this);
+  Bind(wxEVT_BUTTON, &InputConfigDialog::OnCloseButton, this, wxID_CLOSE);
 
   wxBoxSizer* const szr = new wxBoxSizer(wxVERTICAL);
   szr->Add(m_pad_notebook, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, 5);
-  szr->Add(CreateButtonSizer(wxOK | wxCANCEL | wxNO_DEFAULT), 0, wxEXPAND | wxALL, 5);
+  szr->Add(CreateButtonSizer(wxCLOSE), 0, wxEXPAND | wxALL, 5);
 
   SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
   SetSizerAndFit(szr);

--- a/Source/Core/DolphinWX/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/InputConfigDiag.h
@@ -252,7 +252,8 @@ public:
   InputConfigDialog(wxWindow* const parent, InputConfig& config, const wxString& name,
                     const int tab_num = 0);
 
-  void ClickSave(wxCommandEvent& event);
+  void OnClose(wxCloseEvent& event);
+  void OnCloseButton(wxCommandEvent& event);
 
   void UpdateDeviceComboBox();
   void UpdateProfileComboBox();


### PR DESCRIPTION
For consistency the following dialogs were changed to have only one 'Close' labeled button:
- Main Dolphin Configuration (previously 'OK')
- Input Config Dialogs: _Hotkeys, Gamecube Configuration, Wiimote Emulation Configuration_ (previously 'OK' and 'Cancel', though no difference between those two)
- GC Adapter Configuration (previously 'OK')
- Controller Configuration Dialog (previously 'OK' and 'Cancel', on 'Cancel' the Wiimote Sources were reverted)

'Close' was chosen over 'OK', as the 'OK' label is more suited for acknowledgment dialogs and those changed are settings dialogs. Additionally with the 'x' in the window corner, a user may think that the 'x' will revert the changes, whereas only 'OK' would apply them. With 'Close' it should be clear that all changes are applied immediately.

The Controller Configuration as well as the Input Configuration dialog were fixed so in any closing cause the changes are written to the ini-Files.

The 'revert' functionality for the Wiimote Sources was removed as it seemed to be some left-over and legacy code from the time back when each Wiimote had its own Config Dialog and the source wasn't allowed to be changed when the emulator was running. Also no other settings dialog features any cancel and revert functionality. I would bet almost no one even knew the Wiimote Sources did so, when hitting 'cancel' :smiley: 
 
_Commits will be squashed after review_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4127)
<!-- Reviewable:end -->
