### PR TITLE
Windows IORead: return the actual report size

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteHid.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteHid.h
@@ -440,6 +440,11 @@ struct wm_report_core_accel
 };
 
 #define WM_REPORT_CORE_EXT8 0x32
+struct wm_report_core_ext8
+{
+  wm_buttons c;
+  u8 ext[8];
+};
 
 #define WM_REPORT_CORE_ACCEL_IR12 0x33
 struct wm_report_core_accel_ir12


### PR DESCRIPTION
This is kind of Voodoo PR as it intends to fix an issue with the DolphinBar on Windows and i don't have a DolphinBar to reproduce the issue.

The issue that this PR might fix is that sometimes Wiimotes don't work ingame when connected via DolphinBar (i.e. the game does not receive any input). When this occurs the battery level in the Wii Menu will show it's empty regardless of the actual battery level. (See https://forums.dolphin-emu.org/Thread-dolphin-bar-and-windows-10 & https://forums.dolphin-emu.org/Thread-dolphinbar-wiimote-does-not-work).

As @leoetlino stated in one of the threads he encountered the issue on Windows, whereas he didn't on Linux. One difference between Linux and Windows Wiimote LL handling is that on Windows the IORead function reports the wrong amount of bytes read (it is always 23 bytes => MAX_PAYLOAD). If a smaller report is received the remaining/unused bytes are filled with garbage or bytes from previous reports. It may be the case that sometimes those bytes contain certain values that do get interpreted.

_As this is a Voodoo PR let's wait until someone can actually confirm if this fixes the issue_

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4128)

<!-- Reviewable:end -->
