### PR TITLE
Fix a really stupid GLSL version parsing bug

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -352,7 +352,6 @@ Renderer::Renderer()
   g_ogl_config.gl_vendor = (const char*)glGetString(GL_VENDOR);
   g_ogl_config.gl_renderer = (const char*)glGetString(GL_RENDERER);
   g_ogl_config.gl_version = (const char*)glGetString(GL_VERSION);
-  g_ogl_config.glsl_version = (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION);
 
   InitDriverInfo();
 
@@ -527,13 +526,13 @@ Renderer::Renderer()
     // depth clamping.
     g_Config.backend_info.bSupportsDepthClamp = false;
 
-    if (strstr(g_ogl_config.glsl_version, "3.0"))
+    if (GLExtensions::Version() == 300)
     {
       g_ogl_config.eSupportedGLSLVersion = GLSLES_300;
       g_ogl_config.bSupportsAEP = false;
       g_Config.backend_info.bSupportsGeometryShaders = false;
     }
-    else if (strstr(g_ogl_config.glsl_version, "3.1"))
+    else if (GLExtensions::Version() == 310)
     {
       g_ogl_config.eSupportedGLSLVersion = GLSLES_310;
       g_ogl_config.bSupportsAEP = GLExtensions::Supports("GL_ANDROID_extension_pack_es31a");
@@ -575,16 +574,15 @@ Renderer::Renderer()
   }
   else
   {
-    if (strstr(g_ogl_config.glsl_version, "1.00") || strstr(g_ogl_config.glsl_version, "1.10") ||
-        strstr(g_ogl_config.glsl_version, "1.20"))
+    if (GLExtensions::Version() < 300)
     {
       PanicAlert("GPU: OGL ERROR: Need at least GLSL 1.30\n"
                  "GPU: Does your video card support OpenGL 3.0?\n"
                  "GPU: Your driver supports GLSL %s",
-                 g_ogl_config.glsl_version);
+                 (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION));
       bSuccess = false;
     }
-    else if (strstr(g_ogl_config.glsl_version, "1.30"))
+    else if (GLExtensions::Version() == 300)
     {
       g_ogl_config.eSupportedGLSLVersion = GLSL_130;
       g_ogl_config.bSupportsEarlyFragmentTests =
@@ -594,7 +592,7 @@ Renderer::Renderer()
       g_Config.backend_info.bSupportsGeometryShaders =
           false;  // geometry shaders are only supported on glsl150+
     }
-    else if (strstr(g_ogl_config.glsl_version, "1.40"))
+    else if (GLExtensions::Version() == 310)
     {
       g_ogl_config.eSupportedGLSLVersion = GLSL_140;
       g_ogl_config.bSupportsEarlyFragmentTests =
@@ -604,11 +602,11 @@ Renderer::Renderer()
       g_Config.backend_info.bSupportsGeometryShaders =
           false;  // geometry shaders are only supported on glsl150+
     }
-    else if (strstr(g_ogl_config.glsl_version, "1.50"))
+    else if (GLExtensions::Version() == 320)
     {
       g_ogl_config.eSupportedGLSLVersion = GLSL_150;
     }
-    else if (strstr(g_ogl_config.glsl_version, "3.30"))
+    else if (GLExtensions::Version() == 330)
     {
       g_ogl_config.eSupportedGLSLVersion = GLSL_330;
     }

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -55,7 +55,6 @@ struct VideoConfig
   const char* gl_vendor;
   const char* gl_renderer;
   const char* gl_version;
-  const char* glsl_version;
 
   s32 max_samples;
 };


### PR DESCRIPTION
GLSL version strings can have extra details which isn't necessary for us to determine the GLSL version number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4129)
<!-- Reviewable:end -->
