### PR TITLE
Add the configuration of how a memory check is added via the memory window

### DIFF
--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -28,7 +28,9 @@ public:
   virtual void AddWatch(unsigned int /*address*/) {}
   virtual void ClearAllMemChecks() {}
   virtual bool IsMemCheck(unsigned int /*address*/) { return false; }
-  virtual void ToggleMemCheck(unsigned int /*address*/) {}
+  virtual void ToggleMemCheck(unsigned int /*address*/, bool /*read*/, bool /*write*/, bool /*log*/)
+  {
+  }
   virtual unsigned int ReadMemory(unsigned int /*address*/) { return 0; }
   virtual void WriteExtraMemory(int /*memory*/, unsigned int /*value*/, unsigned int /*address*/) {}
   virtual unsigned int ReadExtraMemory(int /*memory*/, unsigned int /*address*/) { return 0; }

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -140,7 +140,7 @@ bool PPCDebugInterface::IsMemCheck(unsigned int address)
   return (Memory::AreMemoryBreakpointsActivated() && PowerPC::memchecks.GetMemCheck(address));
 }
 
-void PPCDebugInterface::ToggleMemCheck(unsigned int address)
+void PPCDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool write, bool log)
 {
   if (Memory::AreMemoryBreakpointsActivated() && !PowerPC::memchecks.GetMemCheck(address))
   {
@@ -148,10 +148,10 @@ void PPCDebugInterface::ToggleMemCheck(unsigned int address)
     TMemCheck MemCheck;
     MemCheck.StartAddress = address;
     MemCheck.EndAddress = address;
-    MemCheck.OnRead = true;
-    MemCheck.OnWrite = true;
+    MemCheck.OnRead = read;
+    MemCheck.OnWrite = write;
 
-    MemCheck.Log = true;
+    MemCheck.Log = log;
     MemCheck.Break = true;
 
     PowerPC::memchecks.Add(MemCheck);

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -26,7 +26,8 @@ public:
   void ToggleBreakpoint(unsigned int address) override;
   void ClearAllMemChecks() override;
   bool IsMemCheck(unsigned int address) override;
-  void ToggleMemCheck(unsigned int address) override;
+  void ToggleMemCheck(unsigned int address, bool read = true, bool write = true,
+                      bool log = true) override;
   unsigned int ReadMemory(unsigned int address) override;
 
   enum

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -132,7 +132,7 @@ void DSPDebugInterface::ClearAllMemChecks()
   PanicAlert("MemCheck functionality not supported in DSP module.");
 }
 
-void DSPDebugInterface::ToggleMemCheck(unsigned int address)
+void DSPDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool write, bool log)
 {
   PanicAlert("MemCheck functionality not supported in DSP module.");
 }

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -24,7 +24,8 @@ public:
   void ToggleBreakpoint(unsigned int address) override;
   void ClearAllMemChecks() override;
   bool IsMemCheck(unsigned int address) override;
-  void ToggleMemCheck(unsigned int address) override;
+  void ToggleMemCheck(unsigned int address, bool read = true, bool write = true,
+                      bool log = true) override;
   unsigned int ReadMemory(unsigned int address) override;
   unsigned int ReadInstruction(unsigned int address) override;
   unsigned int GetPC() override;

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -82,7 +82,7 @@ void CMemoryView::OnMouseDownL(wxMouseEvent& event)
   }
   else
   {
-    debugger->ToggleMemCheck(YToAddress(y));
+    debugger->ToggleMemCheck(YToAddress(y), memCheckRead, memCheckWrite, memCheckLog);
 
     Refresh();
 

--- a/Source/Core/DolphinWX/Debugger/MemoryView.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.h
@@ -35,6 +35,13 @@ public:
     Refresh();
   }
 
+  void SetMemCheckOptions(bool read, bool write, bool log)
+  {
+    memCheckRead = read;
+    memCheckWrite = write;
+    memCheckLog = log;
+  }
+
 private:
   void OnPaint(wxPaintEvent& event);
   void OnMouseDownL(wxMouseEvent& event);
@@ -59,6 +66,10 @@ private:
   int memory;
   int curAddress;
   MemoryDataType dataType;
+
+  bool memCheckRead;
+  bool memCheckWrite;
+  bool memCheckLog;
 
   enum EViewAsType
   {

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -12,6 +12,7 @@
 #include <wx/listbox.h>
 #include <wx/msgdlg.h>
 #include <wx/panel.h>
+#include <wx/radiobut.h>
 #include <wx/sizer.h>
 #include <wx/srchctrl.h>
 #include <wx/textctrl.h>
@@ -47,7 +48,8 @@ enum
   IDM_U32,
   IDM_SEARCH,
   IDM_ASCII,
-  IDM_HEX
+  IDM_HEX,
+  IDM_MEMCHECK_OPTIONS_CHANGE
 };
 
 BEGIN_EVENT_TABLE(CMemoryWindow, wxPanel)
@@ -63,6 +65,8 @@ EVT_CHECKBOX(IDM_U32, CMemoryWindow::U32)
 EVT_BUTTON(IDM_SEARCH, CMemoryWindow::onSearch)
 EVT_CHECKBOX(IDM_ASCII, CMemoryWindow::onAscii)
 EVT_CHECKBOX(IDM_HEX, CMemoryWindow::onHex)
+EVT_RADIOBUTTON(IDM_MEMCHECK_OPTIONS_CHANGE, CMemoryWindow::onMemCheckOptionChange)
+EVT_CHECKBOX(IDM_MEMCHECK_OPTIONS_CHANGE, CMemoryWindow::onMemCheckOptionChange)
 END_EVENT_TABLE()
 
 CMemoryWindow::CMemoryWindow(CCodeWindow* code_window, wxWindow* parent, wxWindowID id,
@@ -104,12 +108,24 @@ CMemoryWindow::CMemoryWindow(CCodeWindow* code_window, wxWindow* parent, wxWindo
   sizerDataTypes->Add(chk16 = new wxCheckBox(this, IDM_U16, "U16"));
   sizerDataTypes->Add(chk32 = new wxCheckBox(this, IDM_U32, "U32"));
 
+  wxStaticBoxSizer* const sizerMemCheckOptions =
+      new wxStaticBoxSizer(wxVERTICAL, this, "Memory check options");
+  sizerMemCheckOptions->Add(rdbReadWrite = new wxRadioButton(this, IDM_MEMCHECK_OPTIONS_CHANGE,
+                                                             "Read and Write", wxDefaultPosition,
+                                                             wxDefaultSize, wxRB_GROUP));
+  sizerMemCheckOptions->Add(rdbRead =
+                                new wxRadioButton(this, IDM_MEMCHECK_OPTIONS_CHANGE, "Read only"));
+  sizerMemCheckOptions->Add(rdbWrite =
+                                new wxRadioButton(this, IDM_MEMCHECK_OPTIONS_CHANGE, "Write only"));
+  sizerMemCheckOptions->Add(chkLog = new wxCheckBox(this, IDM_MEMCHECK_OPTIONS_CHANGE, "Log"));
+
   wxBoxSizer* const sizerRight = new wxBoxSizer(wxVERTICAL);
   sizerRight->Add(search_sizer);
   sizerRight->AddSpacer(5);
   sizerRight->Add(dump_sizer);
   sizerRight->Add(sizerSearchType);
   sizerRight->Add(sizerDataTypes);
+  sizerRight->Add(sizerMemCheckOptions);
 
   wxBoxSizer* const sizerBig = new wxBoxSizer(wxHORIZONTAL);
   sizerBig->Add(memview, 20, wxEXPAND);
@@ -118,6 +134,7 @@ CMemoryWindow::CMemoryWindow(CCodeWindow* code_window, wxWindow* parent, wxWindo
   SetSizer(sizerBig);
   chkHex->SetValue(1);  // Set defaults
   chk8->SetValue(1);
+  chkLog->SetValue(1);
 
   sizerRight->Fit(this);
   sizerBig->Fit(this);
@@ -449,4 +466,12 @@ void CMemoryWindow::onAscii(wxCommandEvent& event)
 void CMemoryWindow::onHex(wxCommandEvent& event)
 {
   chkAscii->SetValue(0);
+}
+
+void CMemoryWindow::onMemCheckOptionChange(wxCommandEvent& event)
+{
+  if (rdbReadWrite->GetValue())
+    memview->SetMemCheckOptions(true, true, chkLog->GetValue());
+  else
+    memview->SetMemCheckOptions(rdbRead->GetValue(), rdbWrite->GetValue(), chkLog->GetValue());
 }

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.h
@@ -15,6 +15,7 @@ class wxCheckBox;
 class wxListBox;
 class wxSearchCtrl;
 class wxTextCtrl;
+class wxRadioButton;
 
 class CMemoryWindow : public wxPanel
 {
@@ -48,6 +49,7 @@ private:
   void OnDumpMemory(wxCommandEvent& event);
   void OnDumpMem2(wxCommandEvent& event);
   void OnDumpFakeVMEM(wxCommandEvent& event);
+  void onMemCheckOptionChange(wxCommandEvent& event);
 
   wxCheckBox* chk8;
   wxCheckBox* chk16;
@@ -55,6 +57,10 @@ private:
   wxButton* btnSearch;
   wxCheckBox* chkAscii;
   wxCheckBox* chkHex;
+  wxCheckBox* chkLog;
+  wxRadioButton* rdbRead;
+  wxRadioButton* rdbWrite;
+  wxRadioButton* rdbReadWrite;
 
   CCodeWindow* m_code_window;
 


### PR DESCRIPTION
I am adding this feature because not only it allows the same options as when adding via the breakpoint list, but it actually is quicker when adding a single address instead of a region as memory check and you don't want some options (like read for example).  It's basically still a quick add, but now it has the same options as when using the list.

The toggleMemCheck in debugInterface assumed that the memCheck would have read, write and log at on so to get thsi to work, I had to add the oiptions in the interface.  The other solution would have been to add or remove them manually, but I felt this would have been too complicated.  Plus, the method still toggles, it just can now set the options.

As for the UI, I kept the default behaviour like it used to be, but my only concern is it might be confusing when looking at the blue square which option was chosen.  Thankfully, the breakpoint list shows them (you do have to workaround a bug when it doesn't update by adding a breakpoint or apply pr #4115 ), but it might be possible to simply change the color depending on the settings (or perhapd do the same in the breakpoint list by putting the letter flags?).

Here's how it would look for the GUI part:
![screenshot from 2016-09-14 02-37-36](https://cloud.githubusercontent.com/assets/8932978/18502348/a4b4a1e2-7a24-11e6-88a6-a2d1d011c0f6.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4131)
<!-- Reviewable:end -->
