### PR TITLE
Fix advanced config panel staying disabled after TAS recording

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -22,6 +22,7 @@ AdvancedConfigPane::AdvancedConfigPane(wxWindow* parent, wxWindowID id) : wxPane
 {
   InitializeGUI();
   LoadGUIValues();
+  RefreshGUI();
 }
 
 void AdvancedConfigPane::InitializeGUI()
@@ -207,4 +208,21 @@ void AdvancedConfigPane::UpdateCustomRTC(time_t date, time_t time)
   SConfig::GetInstance().m_customRTCValue = ToSeconds(custom_rtc.FromUTC());
   m_custom_rtc_date_picker->SetValue(custom_rtc);
   m_custom_rtc_time_picker->SetValue(custom_rtc);
+}
+
+void AdvancedConfigPane::RefreshGUI()
+{
+  // Don't allow users to edit the RTC while the game is running
+  if (Core::IsRunning())
+  {
+    m_custom_rtc_checkbox->Disable();
+    m_custom_rtc_date_picker->Disable();
+    m_custom_rtc_time_picker->Disable();
+  }
+  // Allow users to edit CPU clock speed in game, but not while needing determinism
+  if (Core::IsRunning() && Core::g_want_determinism)
+  {
+    m_clock_override_checkbox->Disable();
+    m_clock_override_slider->Disable();
+  }
 }

--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.h
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.h
@@ -20,6 +20,7 @@ public:
 private:
   void InitializeGUI();
   void LoadGUIValues();
+  void RefreshGUI();
 
   void OnClockOverrideCheckBoxChanged(wxCommandEvent&);
   void OnClockOverrideSliderChanged(wxCommandEvent&);

--- a/Source/Core/DolphinWX/Config/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/Config/ConfigMain.cpp
@@ -75,8 +75,6 @@ void CConfigMain::CreateGUIControls()
   Notebook->AddPage(wii_pane, _("Wii"));
   Notebook->AddPage(path_pane, _("Paths"));
   Notebook->AddPage(advanced_pane, _("Advanced"));
-  if (Core::g_want_determinism)
-    advanced_pane->Disable();
 
   wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);
   main_sizer->Add(Notebook, 1, wxEXPAND | wxALL, 5);


### PR DESCRIPTION
It didn't make sense to have the entire advanced config panel disable from within ConfigMain, so it's been moved to within AdvancedConfigPane, and only disabling what needed to be disabled.

This also happens to fix the issue of the Advanced config panel from staying disabled after a TAS recording.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4134)
<!-- Reviewable:end -->
