### PR TITLE
Fix issues with Custom RTC when set past the year 2038

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -137,6 +137,11 @@ void AdvancedConfigPane::OnClockOverrideSliderChanged(wxCommandEvent& event)
   UpdateCPUClock();
 }
 
+u32 ToSeconds(wxDateTime date)
+{
+  return static_cast<u32>(date.GetValue().GetValue() / 1000);
+}
+
 void AdvancedConfigPane::OnCustomRTCCheckBoxChanged(wxCommandEvent& event)
 {
   const bool checked = m_custom_rtc_checkbox->IsChecked();
@@ -147,13 +152,13 @@ void AdvancedConfigPane::OnCustomRTCCheckBoxChanged(wxCommandEvent& event)
 
 void AdvancedConfigPane::OnCustomRTCDateChanged(wxCommandEvent& event)
 {
-  m_temp_date = m_custom_rtc_date_picker->GetValue().GetTicks();
+  m_temp_date = ToSeconds(m_custom_rtc_date_picker->GetValue());
   UpdateCustomRTC(m_temp_date, m_temp_time);
 }
 
 void AdvancedConfigPane::OnCustomRTCTimeChanged(wxCommandEvent& event)
 {
-  m_temp_time = m_custom_rtc_time_picker->GetValue().GetTicks() - m_temp_date;
+  m_temp_time = ToSeconds(m_custom_rtc_time_picker->GetValue()) - m_temp_date;
   UpdateCustomRTC(m_temp_date, m_temp_time);
 }
 
@@ -178,15 +183,11 @@ void AdvancedConfigPane::LoadCustomRTC()
     m_custom_rtc_date_picker->SetValue(custom_rtc);
     m_custom_rtc_time_picker->SetValue(custom_rtc);
   }
-  m_temp_date = m_custom_rtc_date_picker->GetValue().GetTicks();
-  m_temp_time = m_custom_rtc_time_picker->GetValue().GetTicks() - m_temp_date;
-  // Limit dates to valid ranges (2000 to 2099 for GC, 2000 to 2035 for Wii)
-  if (SConfig::GetInstance().bWii)
-    m_custom_rtc_date_picker->SetRange(wxDateTime(1, wxDateTime::Jan, 2000),
-                                       wxDateTime(31, wxDateTime::Dec, 2035));
-  else
-    m_custom_rtc_date_picker->SetRange(wxDateTime(1, wxDateTime::Jan, 2000),
-                                       wxDateTime(31, wxDateTime::Dec, 2099));
+  m_temp_date = ToSeconds(m_custom_rtc_date_picker->GetValue());
+  m_temp_time = ToSeconds(m_custom_rtc_time_picker->GetValue()) - m_temp_date;
+  // Limit dates to a valid range (Jan 1/2000 to Dec 31/2099)
+  m_custom_rtc_date_picker->SetRange(wxDateTime(1, wxDateTime::Jan, 2000),
+                                     wxDateTime(31, wxDateTime::Dec, 2099));
   if (Core::IsRunning())
   {
     m_custom_rtc_checkbox->Enable(false);
@@ -203,7 +204,7 @@ void AdvancedConfigPane::LoadCustomRTC()
 void AdvancedConfigPane::UpdateCustomRTC(time_t date, time_t time)
 {
   wxDateTime custom_rtc(date + time);
-  SConfig::GetInstance().m_customRTCValue = custom_rtc.FromUTC().GetTicks();
+  SConfig::GetInstance().m_customRTCValue = ToSeconds(custom_rtc.FromUTC());
   m_custom_rtc_date_picker->SetValue(custom_rtc);
   m_custom_rtc_time_picker->SetValue(custom_rtc);
 }


### PR DESCRIPTION
An issue which was not noticed with the original Custom RTC PR was that wxDateTime's GetTicks() limits itself to the max value of long (otherwise known as the "[Year 2038 Problem](https://en.wikipedia.org/wiki/Year_2038_problem)"). This PR rectifies this issue by using GetValue(), which returns the amount of milliseconds since Jan 1/1970, then convert that to seconds.

As an aside, it turns out that the bWii check is useless for any meaningful purpose of editing the RTC outside of game (you're not able to edit it within playing a game). Instead, we only limit to the limits of the Gamecube's BIOS (Jan 1/2000 to Dec 31/2099).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4135)
<!-- Reviewable:end -->
