### PR TITLE
Fix a crash when adding the first memory check while the game is running

### DIFF
--- a/Source/Core/Common/BreakPoints.cpp
+++ b/Source/Core/Common/BreakPoints.cpp
@@ -171,7 +171,7 @@ void MemChecks::Add(const TMemCheck& _rMemoryCheck)
   // If this is the first one, clear the JIT cache so it can switch to
   // watchpoint-compatible code.
   if (!had_any && jit)
-    jit->ClearCache();
+    jit->GetBlockCache()->SchedulateClearCacheThreadSafe();
 }
 
 void MemChecks::Remove(u32 _Address)
@@ -181,11 +181,11 @@ void MemChecks::Remove(u32 _Address)
     if (i->StartAddress == _Address)
     {
       m_MemChecks.erase(i);
+      if (!HasAny() && jit)
+        jit->GetBlockCache()->SchedulateClearCacheThreadSafe();
       return;
     }
   }
-  if (!HasAny() && jit)
-    jit->ClearCache();
 }
 
 TMemCheck* MemChecks::GetMemCheck(u32 address)

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -159,6 +159,7 @@ public:
   void FinalizeBlock(int block_num, bool block_link, const u8* code_ptr);
 
   void Clear();
+  void SchedulateClearCacheThreadSafe();
   void Init();
   void Shutdown();
   void Reset();


### PR DESCRIPTION
Took me awhile to figure out how to do events with the CPU thread, but finally got it :)

The alternative was to pauseAndLock the CPU thread, clear the cache and then unlock it which was less ideal as it takes more time.  

I also found a silly mistake when deleting the last memory check, it was supposed to clear the jit cache, but the call was out of the for loop that finds it so I went ahead and fixed it, but it was also subject to the same crash so I simply did the same thing to fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4137)
<!-- Reviewable:end -->
