### PR TITLE
Move code into Movie::SignalDiscChange

### DIFF
--- a/Source/Core/Core/HW/DVDInterface.h
+++ b/Source/Core/Core/HW/DVDInterface.h
@@ -108,8 +108,8 @@ bool VolumeIsValid();
 // Disc detection and swapping
 void SetDiscInside(bool _DiscInside);
 bool IsDiscInside();
-void ChangeDiscAsHost(const std::string& path);  // Can only be called by the host thread
-void ChangeDiscAsCPU(const std::string& path);   // Can only be called by the CPU thread
+void ChangeDiscAsHost(const std::string& new_path);  // Can only be called by the host thread
+void ChangeDiscAsCPU(const std::string& new_path);   // Can only be called by the CPU thread
 
 // DVD Access Functions
 bool ChangePartition(u64 offset);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -415,10 +415,22 @@ void SetClearSave(bool enabled)
   s_bClearSave = enabled;
 }
 
-void SignalDiscChange(const std::string& new_disc_filename)
+void SignalDiscChange(const std::string& new_path)
 {
-  s_discChange = new_disc_filename;
-  s_bDiscChange = true;
+  if (Movie::IsRecordingInput())
+  {
+    size_t size_of_path_without_filename = new_path.find_last_of("/\\") + 1;
+    std::string filename = new_path.substr(size_of_path_without_filename);
+    constexpr size_t maximum_length = sizeof(DTMHeader::discChange);
+    if (filename.length() > maximum_length)
+    {
+      PanicAlertT("The disc change to \"%s\" could not be saved in the .dtm file.\n"
+                  "The filename of the disc image must not be longer than 40 characters.",
+                  filename.c_str());
+    }
+    s_discChange = filename;
+    s_bDiscChange = true;
+  }
 }
 
 void SetReset(bool reset)

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -129,7 +129,7 @@ u64 GetCurrentLagCount();
 u64 GetTotalLagCount();
 
 void SetClearSave(bool enabled);
-void SignalDiscChange(const std::string& new_disc_filename);
+void SignalDiscChange(const std::string& new_path);
 void SetReset(bool reset);
 void SetTitleId(u64 title_id);
 


### PR DESCRIPTION
DVDInterface shouldn't need to know anything about the DTM format's 40-character limitation.

Also replacing "filename" in variable names with "path" to make it clearer which variables contain the whole path and which ones only contain the filename.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4138)
<!-- Reviewable:end -->
