### PR TITLE
D3D: Correctly invert the viewport depth range.

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -580,8 +580,10 @@ void Renderer::SetViewport()
 
   // We do depth clipping and depth range in the vertex shader instead of relying
   // on the graphics API. However we still need to ensure depth values don't exceed
-  // the maximum value supported by the console GPU.
-  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(X, Y, Wd, Ht, D3D11_MIN_DEPTH, GX_MAX_DEPTH);
+  // the maximum value supported by the console GPU. We also need to account for the
+  // fact that the entire depth buffer is inverted on D3D, so we set GX_MAX_DEPTH as
+  // an inverted near value.
+  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(X, Y, Wd, Ht, 1.0f - GX_MAX_DEPTH, D3D11_MAX_DEPTH);
   D3D::context->RSSetViewports(1, &vp);
 }
 

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -484,8 +484,10 @@ void Renderer::SetViewport()
 
   // We do depth clipping and depth range in the vertex shader instead of relying
   // on the graphics API. However we still need to ensure depth values don't exceed
-  // the maximum value supported by the console GPU.
-  D3D12_VIEWPORT vp = {x, y, width, height, D3D12_MIN_DEPTH, GX_MAX_DEPTH};
+  // the maximum value supported by the console GPU. We also need to account for the
+  // fact that the entire depth buffer is inverted on D3D, so we set GX_MAX_DEPTH as
+  // an inverted near value.
+  D3D12_VIEWPORT vp = {x, y, width, height, 1.0f - GX_MAX_DEPTH, D3D12_MAX_DEPTH};
   D3D::current_command_list->RSSetViewports(1, &vp);
 }
 


### PR DESCRIPTION
I didn't account for reversed depth when setting the depth range in D3D. That the previous depth range worked for the Mii Channel FIFO log seems to be purely a coincidence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4140)
<!-- Reviewable:end -->
