### PR TITLE
VertexManagerBase: Get rid of static state

### DIFF
--- a/Source/Core/VideoBackends/D3D12/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.cpp
@@ -111,7 +111,7 @@ void VertexManager::Draw(u32 stride)
 
   D3D_PRIMITIVE_TOPOLOGY d3d_primitive_topology = D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
 
-  switch (current_primitive_type)
+  switch (m_current_primitive_type)
   {
   case PRIMITIVE_POINTS:
     d3d_primitive_topology = D3D_PRIMITIVE_TOPOLOGY_POINTLIST;
@@ -138,7 +138,7 @@ void VertexManager::Draw(u32 stride)
 void VertexManager::vFlush(bool use_dst_alpha)
 {
   ShaderCache::LoadAndSetActiveShaders(use_dst_alpha ? DSTALPHA_DUAL_SOURCE_BLEND : DSTALPHA_NONE,
-                                       current_primitive_type);
+                                       m_current_primitive_type);
 
   if (g_ActiveConfig.backend_info.bSupportsBBox && BoundingBox::active)
     BBox::Invalidate();
@@ -180,11 +180,11 @@ void VertexManager::vFlush(bool use_dst_alpha)
 
 void VertexManager::ResetBuffer(u32 stride)
 {
-  if (s_cull_all)
+  if (m_cull_all)
   {
-    s_pCurBufferPointer = m_vertex_cpu_buffer.data();
-    s_pBaseBufferPointer = m_vertex_cpu_buffer.data();
-    s_pEndBufferPointer = m_vertex_cpu_buffer.data() + MAXVBUFFERSIZE;
+    m_cur_buffer_pointer = m_vertex_cpu_buffer.data();
+    m_base_buffer_pointer = m_vertex_cpu_buffer.data();
+    m_end_buffer_pointer = m_vertex_cpu_buffer.data() + MAXVBUFFERSIZE;
 
     IndexGenerator::Start(reinterpret_cast<u16*>(m_index_cpu_buffer.data()));
     return;
@@ -198,9 +198,9 @@ void VertexManager::ResetBuffer(u32 stride)
     m_vertex_stream_buffer_reallocated = false;
   }
 
-  s_pBaseBufferPointer = static_cast<u8*>(m_vertex_stream_buffer->GetBaseCPUAddress());
-  s_pEndBufferPointer = s_pBaseBufferPointer + m_vertex_stream_buffer->GetSize();
-  s_pCurBufferPointer =
+  m_base_buffer_pointer = static_cast<u8*>(m_vertex_stream_buffer->GetBaseCPUAddress());
+  m_end_buffer_pointer = m_base_buffer_pointer + m_vertex_stream_buffer->GetSize();
+  m_cur_buffer_pointer =
       static_cast<u8*>(m_vertex_stream_buffer->GetCPUAddressOfCurrentAllocation());
   m_vertex_draw_offset = static_cast<u32>(m_vertex_stream_buffer->GetOffsetOfCurrentAllocation());
 

--- a/Source/Core/VideoBackends/Null/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Null/VertexManager.cpp
@@ -35,19 +35,19 @@ VertexManager::~VertexManager()
 
 void VertexManager::ResetBuffer(u32 stride)
 {
-  s_pCurBufferPointer = s_pBaseBufferPointer = m_local_v_buffer.data();
-  s_pEndBufferPointer = s_pCurBufferPointer + m_local_v_buffer.size();
+  m_cur_buffer_pointer = m_base_buffer_pointer = m_local_v_buffer.data();
+  m_end_buffer_pointer = m_cur_buffer_pointer + m_local_v_buffer.size();
   IndexGenerator::Start(&m_local_i_buffer[0]);
 }
 
 void VertexManager::vFlush(bool use_dst_alpha)
 {
   VertexShaderCache::s_instance->SetShader(
-      use_dst_alpha ? DSTALPHA_DUAL_SOURCE_BLEND : DSTALPHA_NONE, current_primitive_type);
+      use_dst_alpha ? DSTALPHA_DUAL_SOURCE_BLEND : DSTALPHA_NONE, m_current_primitive_type);
   GeometryShaderCache::s_instance->SetShader(
-      use_dst_alpha ? DSTALPHA_DUAL_SOURCE_BLEND : DSTALPHA_NONE, current_primitive_type);
+      use_dst_alpha ? DSTALPHA_DUAL_SOURCE_BLEND : DSTALPHA_NONE, m_current_primitive_type);
   PixelShaderCache::s_instance->SetShader(
-      use_dst_alpha ? DSTALPHA_DUAL_SOURCE_BLEND : DSTALPHA_NONE, current_primitive_type);
+      use_dst_alpha ? DSTALPHA_DUAL_SOURCE_BLEND : DSTALPHA_NONE, m_current_primitive_type);
 }
 
 }  // namespace

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -75,19 +75,19 @@ void VertexManager::PrepareDrawBuffers(u32 stride)
 
 void VertexManager::ResetBuffer(u32 stride)
 {
-  if (s_cull_all)
+  if (m_cull_all)
   {
     // This buffer isn't getting sent to the GPU. Just allocate it on the cpu.
-    s_pCurBufferPointer = s_pBaseBufferPointer = m_cpu_v_buffer.data();
-    s_pEndBufferPointer = s_pBaseBufferPointer + m_cpu_v_buffer.size();
+    m_cur_buffer_pointer = m_base_buffer_pointer = m_cpu_v_buffer.data();
+    m_end_buffer_pointer = m_base_buffer_pointer + m_cpu_v_buffer.size();
 
     IndexGenerator::Start((u16*)m_cpu_i_buffer.data());
   }
   else
   {
     auto buffer = s_vertexBuffer->Map(MAXVBUFFERSIZE, stride);
-    s_pCurBufferPointer = s_pBaseBufferPointer = buffer.first;
-    s_pEndBufferPointer = buffer.first + MAXVBUFFERSIZE;
+    m_cur_buffer_pointer = m_base_buffer_pointer = buffer.first;
+    m_end_buffer_pointer = buffer.first + MAXVBUFFERSIZE;
     s_baseVertex = buffer.second / stride;
 
     buffer = s_indexBuffer->Map(MAXIBUFFERSIZE * sizeof(u16));
@@ -102,7 +102,7 @@ void VertexManager::Draw(u32 stride)
   u32 max_index = IndexGenerator::GetNumVerts();
   GLenum primitive_mode = 0;
 
-  switch (current_primitive_type)
+  switch (m_current_primitive_type)
   {
   case PRIMITIVE_POINTS:
     primitive_mode = GL_POINTS;
@@ -131,7 +131,7 @@ void VertexManager::Draw(u32 stride)
 
   INCSTAT(stats.thisFrame.numDrawCalls);
 
-  if (current_primitive_type != PRIMITIVE_TRIANGLES)
+  if (m_current_primitive_type != PRIMITIVE_TRIANGLES)
     static_cast<Renderer*>(g_renderer.get())->SetGenerationMode();
 }
 
@@ -155,11 +155,11 @@ void VertexManager::vFlush(bool useDstAlpha)
   // the same pass as regular rendering.
   if (useDstAlpha && dualSourcePossible)
   {
-    ProgramShaderCache::SetShader(DSTALPHA_DUAL_SOURCE_BLEND, current_primitive_type);
+    ProgramShaderCache::SetShader(DSTALPHA_DUAL_SOURCE_BLEND, m_current_primitive_type);
   }
   else
   {
-    ProgramShaderCache::SetShader(DSTALPHA_NONE, current_primitive_type);
+    ProgramShaderCache::SetShader(DSTALPHA_NONE, m_current_primitive_type);
   }
 
   // upload global constants
@@ -173,7 +173,7 @@ void VertexManager::vFlush(bool useDstAlpha)
   // run through vertex groups again to set alpha
   if (useDstAlpha && !dualSourcePossible)
   {
-    ProgramShaderCache::SetShader(DSTALPHA_ALPHA_PASS, current_primitive_type);
+    ProgramShaderCache::SetShader(DSTALPHA_ALPHA_PASS, m_current_primitive_type);
 
     // only update alpha
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -54,8 +54,8 @@ SWVertexLoader::~SWVertexLoader()
 
 void SWVertexLoader::ResetBuffer(u32 stride)
 {
-  s_pCurBufferPointer = s_pBaseBufferPointer = LocalVBuffer.data();
-  s_pEndBufferPointer = s_pCurBufferPointer + LocalVBuffer.size();
+  m_cur_buffer_pointer = m_base_buffer_pointer = LocalVBuffer.data();
+  m_end_buffer_pointer = m_cur_buffer_pointer + LocalVBuffer.size();
   IndexGenerator::Start(GetIndexBuffer());
 }
 
@@ -64,7 +64,7 @@ void SWVertexLoader::vFlush(bool useDstAlpha)
   DebugUtil::OnObjectBegin();
 
   u8 primitiveType = 0;
-  switch (current_primitive_type)
+  switch (m_current_primitive_type)
   {
   case PRIMITIVE_POINTS:
     primitiveType = GX_DRAW_POINTS;

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -23,7 +23,7 @@ namespace BPFunctions
 
 void FlushPipeline()
 {
-  VertexManagerBase::Flush();
+  g_vertex_manager->Flush();
 }
 
 void SetGenerationMode()

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -390,7 +390,7 @@ void RunGpuLoop()
 
           // The fifo is empty and it's unlikely we will get any more work in the near future.
           // Make sure VertexManager finishes drawing any primitives it has stored in it's buffer.
-          VertexManagerBase::Flush();
+          g_vertex_manager->Flush();
         }
       },
       100);

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -196,7 +196,7 @@ int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bo
   if (loader->m_native_vertex_format != s_current_vtx_fmt ||
       loader->m_native_components != g_current_components)
   {
-    VertexManagerBase::Flush();
+    g_vertex_manager->Flush();
   }
   s_current_vtx_fmt = loader->m_native_vertex_format;
   g_current_components = loader->m_native_components;
@@ -206,14 +206,14 @@ int RunVertices(int vtx_attr_group, int primitive, int count, DataReader src, bo
   // slope.
   bool cullall = (bpmem.genMode.cullmode == GenMode::CULL_ALL && primitive < 5);
 
-  DataReader dst = VertexManagerBase::PrepareForAdditionalData(
+  DataReader dst = g_vertex_manager->PrepareForAdditionalData(
       primitive, count, loader->m_native_vtx_decl.stride, cullall);
 
   count = loader->RunVertices(src, dst, count);
 
   IndexGenerator::AddIndices(primitive, count);
 
-  VertexManagerBase::FlushData(count, loader->m_native_vtx_decl.stride);
+  g_vertex_manager->FlushData(count, loader->m_native_vtx_decl.stride);
 
   ADDSTAT(stats.thisFrame.numPrims, count);
   INCSTAT(stats.thisFrame.numPrimitiveJoins);

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -81,7 +81,7 @@ DataReader VertexManagerBase::PrepareForAdditionalData(int primitive, u32 count,
   }
 
   m_cull_all = cullall;
-  
+
   // need to alloc new buffer
   if (m_is_flushed)
   {

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -50,36 +50,36 @@ public:
   // needs to be virtual for DX11's dtor
   virtual ~VertexManagerBase();
 
-  static DataReader PrepareForAdditionalData(int primitive, u32 count, u32 stride, bool cullall);
-  static void FlushData(u32 count, u32 stride);
+  DataReader PrepareForAdditionalData(int primitive, u32 count, u32 stride, bool cullall);
+  void FlushData(u32 count, u32 stride);
 
-  static void Flush();
+  void Flush();
 
   virtual NativeVertexFormat*
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) = 0;
 
-  static void DoState(PointerWrap& p);
+  void DoState(PointerWrap& p);
 
 protected:
   virtual void vDoState(PointerWrap& p) {}
-  static PrimitiveType current_primitive_type;
+  PrimitiveType m_current_primitive_type = PrimitiveType::PRIMITIVE_POINTS;
 
   virtual void ResetBuffer(u32 stride) = 0;
 
-  static u8* s_pCurBufferPointer;
-  static u8* s_pBaseBufferPointer;
-  static u8* s_pEndBufferPointer;
+  u8* m_cur_buffer_pointer = nullptr;
+  u8* m_base_buffer_pointer = nullptr;
+  u8* m_end_buffer_pointer = nullptr;
 
-  static u32 GetRemainingSize();
+  u32 GetRemainingSize() const;
   static u32 GetRemainingIndices(int primitive);
 
-  static Slope s_zslope;
-  static void CalculateZSlope(NativeVertexFormat* format);
+  Slope m_zslope = {};
+  void CalculateZSlope(NativeVertexFormat* format);
 
-  static bool s_cull_all;
+  bool m_cull_all = false;
 
 private:
-  static bool s_is_flushed;
+  bool m_is_flushed = true;
 
   virtual void vFlush(bool useDstAlpha) = 0;
 

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -676,7 +676,7 @@ void VertexShaderManager::SetTexMatrixChangedA(u32 Value)
 {
   if (g_main_cp_state.matrix_index_a.Hex != Value)
   {
-    VertexManagerBase::Flush();
+    g_vertex_manager->Flush();
     if (g_main_cp_state.matrix_index_a.PosNormalMtxIdx != (Value & 0x3f))
       bPosNormalMatrixChanged = true;
     bTexMatricesChanged[0] = true;
@@ -688,7 +688,7 @@ void VertexShaderManager::SetTexMatrixChangedB(u32 Value)
 {
   if (g_main_cp_state.matrix_index_b.Hex != Value)
   {
-    VertexManagerBase::Flush();
+    g_vertex_manager->Flush();
     bTexMatricesChanged[1] = true;
     g_main_cp_state.matrix_index_b.Hex = Value;
   }

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -57,7 +57,7 @@ void VideoCommon_DoState(PointerWrap& p)
   GeometryShaderManager::DoState(p);
   p.DoMarker("GeometryShaderManager");
 
-  VertexManagerBase::DoState(p);
+  g_vertex_manager->DoState(p);
   p.DoMarker("VertexManager");
 
   BoundingBox::DoState(p);

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -17,7 +17,7 @@
 
 static void XFMemWritten(u32 transferSize, u32 baseAddress)
 {
-  VertexManagerBase::Flush();
+  g_vertex_manager->Flush();
   VertexShaderManager::InvalidateXFRange(baseAddress, baseAddress + transferSize);
 }
 
@@ -53,7 +53,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
 
     case XFMEM_SETNUMCHAN:
       if (xfmem.numChan.numColorChans != (newValue & 3))
-        VertexManagerBase::Flush();
+        g_vertex_manager->Flush();
       break;
 
     case XFMEM_SETCHAN0_AMBCOLOR:  // Channel Ambient Color
@@ -62,7 +62,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
       u8 chan = address - XFMEM_SETCHAN0_AMBCOLOR;
       if (xfmem.ambColor[chan] != newValue)
       {
-        VertexManagerBase::Flush();
+        g_vertex_manager->Flush();
         VertexShaderManager::SetMaterialColorChanged(chan);
       }
       break;
@@ -74,7 +74,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
       u8 chan = address - XFMEM_SETCHAN0_MATCOLOR;
       if (xfmem.matColor[chan] != newValue)
       {
-        VertexManagerBase::Flush();
+        g_vertex_manager->Flush();
         VertexShaderManager::SetMaterialColorChanged(chan + 2);
       }
       break;
@@ -85,12 +85,12 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
     case XFMEM_SETCHAN0_ALPHA:  // Channel Alpha
     case XFMEM_SETCHAN1_ALPHA:
       if (((u32*)&xfmem)[address] != (newValue & 0x7fff))
-        VertexManagerBase::Flush();
+        g_vertex_manager->Flush();
       break;
 
     case XFMEM_DUALTEX:
       if (xfmem.dualTexTrans.enabled != (newValue & 1))
-        VertexManagerBase::Flush();
+        g_vertex_manager->Flush();
       break;
 
     case XFMEM_SETMATRIXINDA:
@@ -108,7 +108,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
     case XFMEM_SETVIEWPORT + 3:
     case XFMEM_SETVIEWPORT + 4:
     case XFMEM_SETVIEWPORT + 5:
-      VertexManagerBase::Flush();
+      g_vertex_manager->Flush();
       VertexShaderManager::SetViewportChanged();
       PixelShaderManager::SetViewportChanged();
       GeometryShaderManager::SetViewportChanged();
@@ -123,7 +123,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
     case XFMEM_SETPROJECTION + 4:
     case XFMEM_SETPROJECTION + 5:
     case XFMEM_SETPROJECTION + 6:
-      VertexManagerBase::Flush();
+      g_vertex_manager->Flush();
       VertexShaderManager::SetProjectionChanged();
       GeometryShaderManager::SetProjectionChanged();
 
@@ -132,7 +132,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
 
     case XFMEM_SETNUMTEXGENS:  // GXSetNumTexGens
       if (xfmem.numTexGen.numTexGens != (newValue & 15))
-        VertexManagerBase::Flush();
+        g_vertex_manager->Flush();
       break;
 
     case XFMEM_SETTEXMTXINFO:
@@ -143,7 +143,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
     case XFMEM_SETTEXMTXINFO + 5:
     case XFMEM_SETTEXMTXINFO + 6:
     case XFMEM_SETTEXMTXINFO + 7:
-      VertexManagerBase::Flush();
+      g_vertex_manager->Flush();
 
       nextAddress = XFMEM_SETTEXMTXINFO + 8;
       break;
@@ -156,7 +156,7 @@ static void XFRegWritten(int transferSize, u32 baseAddress, DataReader src)
     case XFMEM_SETPOSMTXINFO + 5:
     case XFMEM_SETPOSMTXINFO + 6:
     case XFMEM_SETPOSMTXINFO + 7:
-      VertexManagerBase::Flush();
+      g_vertex_manager->Flush();
 
       nextAddress = XFMEM_SETPOSMTXINFO + 8;
       break;


### PR DESCRIPTION
To work towards actually consolidating the crap that is VideoCommon's state, in order to eliminate globals and try to make things look somewhat decent, the mish-mash of static and non-static object state has to go. Unfortunately, this also requires tearing the band-aids off and utilizing the globals (though static interfacess were just a cute way of hiding the fact that a global is present anyways).

Essentially we want to actually have objects that function like an actual object and not a state minefield. This is just a starting point to kick things off.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4141)
<!-- Reviewable:end -->
