### PR TITLE
Invalidate the icache when inserting a nop or a BLR

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -163,6 +163,7 @@ void PPCDebugInterface::ToggleMemCheck(unsigned int address)
 void PPCDebugInterface::InsertBLR(unsigned int address, unsigned int value)
 {
   PowerPC::HostWrite_U32(value, address);
+  PowerPC::ScheduleInvalidateCacheThreadSafe(address);
 }
 
 // =======================================================

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -138,6 +138,7 @@ extern PPCDebugInterface debug_interface;
 void Init(int cpu_core);
 void Shutdown();
 void DoState(PointerWrap& p);
+void ScheduleInvalidateCacheThreadSafe(u32 address);
 
 CoreMode GetMode();
 // [NOT THREADSAFE] CPU Thread or CPU::PauseAndLock or CORE_UNINITIALIZED


### PR DESCRIPTION
This fix the fact that they wouldn't take effect immediately after pausing.

Also make it invalidate asynchronously in the case when the emu thread is running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4144)
<!-- Reviewable:end -->
