### PR TITLE
Emulated Wiimote Orientation Modifier

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -156,6 +156,7 @@ private:
   ControlGroup* m_rumble;
   Extension* m_extension;
   ControlGroup* m_options;
+  ModifySettingsButton* m_hotkeys;
 
   // Wiimote accel data
   AccelData m_accel;

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -217,6 +217,22 @@ public:
     }
   };
 
+  class ModifySettingsButton : public Buttons
+  {
+  public:
+    ModifySettingsButton(std::string button_name);
+    void AddInput(std::string button_name, bool toggle = false);
+
+    void GetState();
+
+    const std::vector<bool>& isSettingToggled() const { return associated_settings_toggle; }
+    const std::vector<bool>& getSettingsModifier() const { return associated_settings; }
+  private:
+    std::vector<bool> threshold_exceeded;  // internal calculation (if "state" was above threshold)
+    std::vector<bool> associated_settings_toggle;  // is setting toggled or hold?
+    std::vector<bool> associated_settings;         // result
+  };
+
   class MixedTriggers : public ControlGroup
   {
   public:


### PR DESCRIPTION
A past patch from another user was not merged due to some flaws.

Therefore this is my attempt to implement this feature (https://bugs.dolphin-emu.org/issues/2948).

This patch works by adding a new attribute that is xor-ed with the existing sideway/upright bool.
Therefore no wxWidgets shenanigans occur.

I tried to keep it as flexible as possible so additional hotkeys could be used to modify other settings as well.

One thing to mention: Toggled buttons persist through save states (obviously as it's implemented in the ControllerEmu and has nothing to do with the game state). However due to this, it is sometimes confusing when it is active and when it's not.
Therefore I've added an Onscreen-Display-Message whenever toggled buttons are pressed (second commit of this pull-request).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4145)
<!-- Reviewable:end -->
