### PR TITLE
GameSettings: Remove forced slow depth from fixed titles.

### DIFF
--- a/Data/Sys/GameSettings/GBS.ini
+++ b/Data/Sys/GameSettings/GBS.ini
@@ -17,7 +17,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-FastDepthCalc = False
-

--- a/Data/Sys/GameSettings/GM3.ini
+++ b/Data/Sys/GameSettings/GM3.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Needs real xfb for the videos to display. Shadow issues with fastdepth (D3D).
+EmulationIssues = Needs real xfb for the videos to display.
 EmulationStateId = 4
 
 [OnLoad]
@@ -20,4 +20,3 @@ EmulationStateId = 4
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/GMD.ini
+++ b/Data/Sys/GameSettings/GMD.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Needs real xfb for the videos to display. Shadow issues with fastdepth (D3D).
+EmulationIssues = Needs real xfb for the videos to display.
 EmulationStateId = 4
 
 [OnLoad]
@@ -20,4 +20,3 @@ EmulationStateId = 4
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/GQX.ini
+++ b/Data/Sys/GameSettings/GQX.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Needs real xfb for the videos to display. Shadow issues with fastdepth (D3D).
+EmulationIssues = Needs real xfb for the videos to display.
 EmulationStateId = 4
 
 [OnLoad]
@@ -20,4 +20,3 @@ EmulationStateId = 4
 [Video_Settings]
 UseXFB = True
 UseRealXFB = True
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/GZL.ini
+++ b/Data/Sys/GameSettings/GZL.ini
@@ -21,8 +21,5 @@ EmulationIssues =
 EFBAccessEnable = True
 EFBToTextureEnable = False
 
-[Video_Settings]
-FastDepthCalc = False
-
 [Video_Stereoscopy]
 StereoConvergence = 115

--- a/Data/Sys/GameSettings/R44.ini
+++ b/Data/Sys/GameSettings/R44.ini
@@ -21,4 +21,3 @@ EmulationIssues =
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/RNJ.ini
+++ b/Data/Sys/GameSettings/RNJ.ini
@@ -16,6 +16,3 @@ EmulationIssues =
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/S59.ini
+++ b/Data/Sys/GameSettings/S59.ini
@@ -19,5 +19,3 @@ EmulationStateId = 4
 
 [Video_Settings]
 SafeTextureCacheColorSamples = 512
-FastDepthCalc = False
-

--- a/Data/Sys/GameSettings/SF8.ini
+++ b/Data/Sys/GameSettings/SF8.ini
@@ -18,7 +18,6 @@ EmulationIssues = Sound crackling can be fixed by lle audio.
 # Add action replay cheats here.
 
 [Video_Settings]
-FastDepthCalc = False
 SafeTextureCacheColorSamples = 512
 
 [Video_Stereoscopy]

--- a/Data/Sys/GameSettings/SOU.ini
+++ b/Data/Sys/GameSettings/SOU.ini
@@ -6,7 +6,7 @@
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Needs real wiimote and motion plus. Time stone transition needs Fast Depth off. 
+EmulationIssues = Needs real wiimote and motion plus.
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -18,6 +18,3 @@ EmulationIssues = Needs real wiimote and motion plus. Time stone transition need
 [Video_Hacks]
 EFBAccessEnable = True
 EFBEmulateFormatChanges = True
-
-[Video_Settings]
-FastDepthCalc = False

--- a/Data/Sys/GameSettings/WMJ.ini
+++ b/Data/Sys/GameSettings/WMJ.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues = Glitches in the game menu with fast depth enabled.
+EmulationIssues =
 EmulationStateId = 4
 
 [OnLoad]
@@ -16,6 +16,3 @@ EmulationStateId = 4
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Settings]
-FastDepthCalc = False

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -158,7 +158,7 @@ static void WriteSampleColor(char*& p, const char* colorComp, const char* dest, 
 
     // Handle D3D depth inversion.
     if (depth)
-      WRITE(p, "  %s = 1.0f - %s;\n", dest, dest);
+      WRITE(p, "  %s = 1.0 - %s;\n", dest, dest);
   }
 }
 


### PR DESCRIPTION
Each game has been tested and is confirmed working with fast depth. There are no more instances of forced slow depth in the Game INIs.

I also added a small cosmetic change in TextureConversionShader I came across to this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4147)
<!-- Reviewable:end -->
