### PR TITLE
Fix frame dump issues where frame dumping stops before next drawn frame

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.h
+++ b/Source/Core/VideoCommon/AVIDump.h
@@ -12,6 +12,7 @@ private:
   static bool CreateFile();
   static void CloseFile();
   static void CheckResolution(int width, int height);
+  static void StoreFrameData(const u8* data, int width, int height);
 
 public:
   enum class DumpFormat


### PR DESCRIPTION
This is mostly a test for @JMC47 to test if this resolves an issue where frame dumps end before the next frame is drawn.

EDIT: Seems to work as intended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4148)
<!-- Reviewable:end -->
