### PR TITLE
Add ability to change default GameID and GameName for DVD Root

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -244,6 +244,8 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("DefaultISO", m_strDefaultISO);
   core->Set("DVDRoot", m_strDVDRoot);
   core->Set("Apploader", m_strApploader);
+  core->Set("GameID", m_strGameID);
+  core->Set("GameName", m_strGameName);
   core->Set("EnableCheats", bEnableCheats);
   core->Set("SelectedLanguage", SelectedLanguage);
   core->Set("OverrideGCLang", bOverrideGCLanguage);
@@ -514,6 +516,8 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("DefaultISO", &m_strDefaultISO);
   core->Get("DVDRoot", &m_strDVDRoot);
   core->Get("Apploader", &m_strApploader);
+  core->Get("GameID", &m_strGameID, "AGBJ01");
+  core->Get("GameName", &m_strGameName, "Default Name");
   core->Get("EnableCheats", &bEnableCheats, false);
   core->Get("SelectedLanguage", &SelectedLanguage, 0);
   core->Get("OverrideGCLang", &bOverrideGCLanguage, false);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -175,6 +175,8 @@ struct SConfig : NonCopyable
   std::string m_strDefaultISO;
   std::string m_strDVDRoot;
   std::string m_strApploader;
+  std::string m_strGameID;
+  std::string m_strGameName;
   std::string m_strUniqueID;
   std::string m_strName;
   std::string m_strWiiSDCardPath;

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -16,6 +16,7 @@
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
+#include "Core/ConfigManager.h"
 #include "DiscIO/Blob.h"
 #include "DiscIO/Enums.h"
 #include "DiscIO/FileMonitor.h"
@@ -35,8 +36,9 @@ CVolumeDirectory::CVolumeDirectory(const std::string& _rDirectory, bool _bIsWii,
   m_rootDirectory = ExtractDirectoryName(_rDirectory);
 
   // create the default disk header
-  SetUniqueID("AGBJ01");
-  SetName("Default name");
+  SConfig& _Settings = SConfig::GetInstance();
+  SetUniqueID(_Settings.m_strGameID);
+  SetName(_Settings.m_strGameName);
 
   if (_bIsWii)
     SetDiskTypeWii();

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -12,6 +12,7 @@
 #include <wx/listbox.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
+#include <wx/textctrl.h>
 
 #include "Common/FileUtil.h"
 #include "Core/ConfigManager.h"
@@ -62,6 +63,9 @@ void PathConfigPane::InitializeGUI()
       this, wxID_ANY, wxEmptyString, _("Choose an SD Card file:"), wxFileSelectorDefaultWildcardStr,
       wxDefaultPosition, wxDefaultSize, wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
 
+  m_game_id_text = new wxTextCtrl(this, wxID_ANY);
+  m_game_name_text = new wxTextCtrl(this, wxID_ANY);
+
   m_iso_paths_listbox->Bind(wxEVT_LISTBOX, &PathConfigPane::OnISOPathSelectionChanged, this);
   m_recursive_iso_paths_checkbox->Bind(wxEVT_CHECKBOX,
                                        &PathConfigPane::OnRecursiveISOCheckBoxChanged, this);
@@ -76,6 +80,9 @@ void PathConfigPane::InitializeGUI()
   m_dump_path_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnDumpPathChanged, this);
   m_wii_sdcard_filepicker->Bind(wxEVT_FILEPICKER_CHANGED, &PathConfigPane::OnSdCardPathChanged,
                                 this);
+  m_game_id_text->Bind(wxEVT_TEXT, &PathConfigPane::OnGameIDChanged, this);
+  m_game_name_text->Bind(wxEVT_TEXT, &PathConfigPane::OnGameNameChanged, this);
+
 
   wxBoxSizer* const iso_button_sizer = new wxBoxSizer(wxHORIZONTAL);
   iso_button_sizer->Add(m_recursive_iso_paths_checkbox, 0, wxALL | wxALIGN_CENTER);
@@ -110,6 +117,12 @@ void PathConfigPane::InitializeGUI()
                     wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxALL, 5);
   picker_sizer->Add(m_wii_sdcard_filepicker, wxGBPosition(5, 1), wxDefaultSpan, wxEXPAND | wxALL,
                     5);
+  picker_sizer->Add(new wxStaticText(this, wxID_ANY, _("Game ID:")), wxGBPosition(6, 0),
+                    wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  picker_sizer->Add(m_game_id_text, wxGBPosition(6, 1), wxDefaultSpan, wxEXPAND | wxALL, 5);
+  picker_sizer->Add(new wxStaticText(this, wxID_ANY, _("Game Name:")), wxGBPosition(7, 0),
+                    wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  picker_sizer->Add(m_game_name_text, wxGBPosition(7, 1), wxDefaultSpan, wxEXPAND | wxALL, 5);
   picker_sizer->AddGrowableCol(1);
 
   // Populate the Paths page
@@ -131,6 +144,8 @@ void PathConfigPane::LoadGUIValues()
   m_nand_root_dirpicker->SetPath(StrToWxStr(SConfig::GetInstance().m_NANDPath));
   m_dump_path_dirpicker->SetPath(StrToWxStr(SConfig::GetInstance().m_DumpPath));
   m_wii_sdcard_filepicker->SetPath(StrToWxStr(SConfig::GetInstance().m_strWiiSDCardPath));
+  m_game_id_text->SetValue(SConfig::GetInstance().m_strGameID);
+  m_game_name_text->SetValue(SConfig::GetInstance().m_strGameName);
 
   // Update selected ISO paths
   for (const std::string& folder : SConfig::GetInstance().m_ISOFolder)
@@ -209,6 +224,18 @@ void PathConfigPane::OnSdCardPathChanged(wxCommandEvent& event)
   std::string sd_card_path = WxStrToStr(m_wii_sdcard_filepicker->GetPath());
   SConfig::GetInstance().m_strWiiSDCardPath = sd_card_path;
   File::SetUserPath(F_WIISDCARD_IDX, sd_card_path);
+}
+
+void PathConfigPane::OnGameIDChanged(wxCommandEvent &)
+{
+    std::string game_id = WxStrToStr(m_game_id_text->GetValue());
+    SConfig::GetInstance().m_strGameID = game_id;
+}
+
+void PathConfigPane::OnGameNameChanged(wxCommandEvent &)
+{
+    std::string game_name = WxStrToStr(m_game_name_text->GetValue());
+    SConfig::GetInstance().m_strGameName = game_name;
 }
 
 void PathConfigPane::OnNANDRootChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/PathConfigPane.h
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.h
@@ -11,6 +11,7 @@ class wxCheckBox;
 class wxListBox;
 class wxDirPickerCtrl;
 class wxFilePickerCtrl;
+class wxTextCtrl;
 
 class PathConfigPane final : public wxPanel
 {
@@ -32,6 +33,8 @@ private:
   void OnNANDRootChanged(wxCommandEvent&);
   void OnDumpPathChanged(wxCommandEvent&);
   void OnSdCardPathChanged(wxCommandEvent&);
+  void OnGameIDChanged(wxCommandEvent&);
+  void OnGameNameChanged(wxCommandEvent&);
 
   void SaveISOPathChanges();
 
@@ -46,4 +49,6 @@ private:
   wxFilePickerCtrl* m_apploader_path_filepicker;
   wxDirPickerCtrl* m_dump_path_dirpicker;
   wxFilePickerCtrl* m_wii_sdcard_filepicker;
+  wxTextCtrl* m_game_id_text;
+  wxTextCtrl* m_game_name_text;
 };


### PR DESCRIPTION
Having the ability to explicitly set the GameID and Name for DVD Root games is useful for ISO hacks, especially when those hacks are compatible with the game's saves.

This PR makes the following change to PathConfigPane:
![game_name_id_conf](https://dl.dropboxusercontent.com/u/21757902/game_name_id_conf.png)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4149)
<!-- Reviewable:end -->
