### PR TITLE
Fix bug in interpreter's lswx. Was overwriting extra register.

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -742,7 +742,7 @@ void Interpreter::stswx(UGeckoInstruction _inst)
     if (i == 32)
     {
       i = 0;
-      r++;
+      r = (r + 1) & 0x1f;  // wrap
     }
   }
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -497,7 +497,6 @@ void Interpreter::lhzx(UGeckoInstruction _inst)
   }
 }
 
-// TODO: is this right?
 // FIXME: Should rollback if a DSI occurs
 void Interpreter::lswx(UGeckoInstruction _inst)
 {
@@ -506,6 +505,7 @@ void Interpreter::lswx(UGeckoInstruction _inst)
   int r = _inst.RD;
   int i = 0;
 
+  // Confirmed by hardware test that the zero case doesn't zero rGPR[r]
   if (n > 0)
   {
     rGPR[r] = 0;

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -509,7 +509,7 @@ void Interpreter::lswx(UGeckoInstruction _inst)
   if (n > 0)
   {
     rGPR[r] = 0;
-    do
+    while (true)
     {
       u32 TempValue = PowerPC::Read_U8(EA) << (24 - i);
       if (PowerPC::ppcState.Exceptions & EXCEPTION_DSI)
@@ -520,8 +520,10 @@ void Interpreter::lswx(UGeckoInstruction _inst)
       }
       rGPR[r] |= TempValue;
 
+      if (--n == 0)
+        return;
+
       EA++;
-      n--;
       i += 8;
       if (i == 32)
       {
@@ -529,7 +531,7 @@ void Interpreter::lswx(UGeckoInstruction _inst)
         r = (r + 1) & 31;
         rGPR[r] = 0;
       }
-    } while (n > 0);
+    }
   }
 }
 


### PR DESCRIPTION
When n was a multiple of 4, the old implementation would overwrite the following register with 0.

This was causing Not64 to crash.

Thanks to Extremis for spotting this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4151)
<!-- Reviewable:end -->
