### PR TITLE
Fix the Debugger font not appearing on the captions of panes

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -19,6 +19,7 @@
 #include <wx/textdlg.h>
 #include <wx/thread.h>
 #include <wx/toolbar.h>
+#include <wx/aui/dockart.h>
 // clang-format on
 
 #include "Common/BreakPoints.h"
@@ -779,4 +780,5 @@ void CCodeWindow::UpdateButtonStates()
   symbols->SetFont(DebuggerFont);
   callers->SetFont(DebuggerFont);
   calls->SetFont(DebuggerFont);
+  m_aui_manager.GetArtProvider()->SetFont(wxAUI_DOCKART_CAPTION_FONT, DebuggerFont);
 }

--- a/Source/Core/DolphinWX/FrameAui.cpp
+++ b/Source/Core/DolphinWX/FrameAui.cpp
@@ -21,6 +21,7 @@
 #include <wx/statusbr.h>
 #include <wx/textdlg.h>
 #include <wx/toplevel.h>
+#include <wx/aui/dockart.h>
 // clang-format on
 
 #include "Common/CommonTypes.h"
@@ -36,6 +37,7 @@
 #include "DolphinWX/LogConfigWindow.h"
 #include "DolphinWX/LogWindow.h"
 #include "DolphinWX/WxUtils.h"
+#include "DolphinWX/Debugger/DebuggerUIUtil.h"
 
 // ------------
 // Aui events
@@ -622,6 +624,7 @@ void CFrame::TogglePaneStyle(bool On, int EventId)
       Pane.Dockable(!m_bNoDocking);
     }
   }
+  m_Mgr->GetArtProvider()->SetFont(wxAUI_DOCKART_CAPTION_FONT, DebuggerFont);
   m_Mgr->Update();
 }
 


### PR DESCRIPTION
Both those in the code window and the ones that appears when the user select edit perpective. 

There is however one case I wasn't able to fix (not knowing enough of the codebase/wxWidget) and that is if you are in edit perspective mode and try to drag a pane so the pane now floats.  The pane's caption will not have the Debugger font and I don't really know how to fix that one.

Also just so we are not confused by what I meant by pane's captions, here's a visual sample:

Master
![screenshot from 2016-08-27 12-24-43](https://cloud.githubusercontent.com/assets/8932978/18028625/e9fbdc38-6c51-11e6-86c2-c377020ef29c.png)

This PR
![screenshot from 2016-08-27 12-22-18](https://cloud.githubusercontent.com/assets/8932978/18028629/111c2160-6c52-11e6-8d12-a36b22fa7e15.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4152)
<!-- Reviewable:end -->
