### PR TITLE
gettextize: Pipe list of file names to xgettext

### DIFF
--- a/Languages/gettextize
+++ b/Languages/gettextize
@@ -2,12 +2,11 @@
 
 cd ${0/gettextize/}/..
 SRCDIR=Source
-CPP_FILE_LIST=$(find $SRCDIR \( -name '*.cpp' -o -name '*.h' -o -name '*.c' \) \
-	-a ! -path '*Debug*')
-xgettext -d dolphin-emu -s --keyword=_ --keyword=wxTRANSLATE --keyword=SuccessAlertT \
+find $SRCDIR \( -name '*.cpp' -o -name '*.h' -o -name '*.c' \) -a ! -path '*Debug*' | \
+	xgettext -d dolphin-emu -s --keyword=_ --keyword=wxTRANSLATE --keyword=SuccessAlertT \
 	--keyword=PanicAlertT --keyword=PanicYesNoT --keyword=AskYesNoT --keyword=CriticalAlertT \
 	--keyword=GetStringT --keyword=_trans --add-comments=i18n -p ./Languages/po \
-	-o dolphin-emu.pot $CPP_FILE_LIST --package-name="Dolphin Emulator"
+	-o dolphin-emu.pot -f - --package-name="Dolphin Emulator"
 
 sed -i "s/SOME DESCRIPTIVE TITLE\./Translation of dolphin-emu.pot to LANGUAGE/" Languages/po/dolphin-emu.pot
 sed -i "s/YEAR THE PACKAGE'S COPYRIGHT HOLDER/2003-2013/" Languages/po/dolphin-emu.pot


### PR DESCRIPTION
This avoids an "Argument list too long" error with MINGW64 bash. $CPP_FILE_LIST is tens of kilobytes large.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4154)
<!-- Reviewable:end -->
