### PR TITLE
PixelShaderGen: Remove redundant branch in BBOX HW emulation

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -802,10 +802,10 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, APIType ApiType,
   if (uid_data->bounding_box)
   {
     const char* atomic_op = ApiType == APIType::OpenGL ? "atomic" : "Interlocked";
-    out.Write("\tif(bbox_data[0] > int(rawpos.x)) %sMin(bbox_data[0], int(rawpos.x));\n"
-              "\tif(bbox_data[1] < int(rawpos.x)) %sMax(bbox_data[1], int(rawpos.x));\n"
-              "\tif(bbox_data[2] > int(rawpos.y)) %sMin(bbox_data[2], int(rawpos.y));\n"
-              "\tif(bbox_data[3] < int(rawpos.y)) %sMax(bbox_data[3], int(rawpos.y));\n",
+    out.Write("\t%sMin(bbox_data[0], int(rawpos.x));\n"
+              "\t%sMax(bbox_data[1], int(rawpos.x));\n"
+              "\t%sMin(bbox_data[2], int(rawpos.y));\n"
+              "\t%sMax(bbox_data[3], int(rawpos.y));\n",
               atomic_op, atomic_op, atomic_op, atomic_op);
   }
 


### PR DESCRIPTION
We're currently doing the equivalent of:
```
if (x > y)
{
  x = min(x, y);
}
```

Since y will always be smaller, we can replace this with:
```
if (x > y)
{
  x = y;
}
```

Which is just
```
x = min(x, y);
```

Tested with Paper Mario: TTYD (only bbox game I have, sorry :/) on Arch Linux (OpenGL) and Windows 7 (OpenGL & Direct3D 11), both on an NVIDIA card.

While I'm not seeing any significant performance improvements on a GTX 760Ti, I'd imagine older, more SIMD-ey cards could benefit from the lack of these branches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4157)
<!-- Reviewable:end -->
