### PR TITLE
TextureCacheBase: Handle textures loaded from address 0x0.

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -506,9 +506,6 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
   u32 tex_levels = use_mipmaps ? ((tex.texMode1[id].max_lod + 0xf) / 0x10 + 1) : 1;
   const bool from_tmem = tex.texImage1[id].image_type != 0;
 
-  if (0 == address)
-    return nullptr;
-
   // TexelSizeInNibbles(format) * width * height / 16;
   const unsigned int bsw = TexDecoder_GetBlockWidthInTexels(texformat);
   const unsigned int bsh = TexDecoder_GetBlockHeightInTexels(texformat);


### PR DESCRIPTION
Some games will load a texture from address 0x0 which we currently just ignore and print an error message for. However this causes the last texture used for that stage to fall through and cause issues in some games.

Address 0x0 is actually valid RAM and should be loaded as normal. The Gamecube doesn't have null pointer exceptions, so it will happily load whatever is stored there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4158)
<!-- Reviewable:end -->
