### PR TITLE
SSX Tricky requires real XFB to display videos

### DIFF
--- a/Data/Sys/GameSettings/GST.ini
+++ b/Data/Sys/GameSettings/GST.ini
@@ -16,3 +16,6 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Settings]
+UseXFB = True
+UseRealXFB = True


### PR DESCRIPTION
This will avoid just getting a black screen when starting up. Dual-core lockup when enabling XFB no-longer seems to happen so this should be safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4159)
<!-- Reviewable:end -->
