### PR TITLE
Map: Prevents symbols from being stripped

### DIFF
--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -348,16 +348,6 @@ bool PPCSymbolDB::LoadMap(const std::string& filename, bool bad)
       strcpy(name, namepos);
     name[strlen(name) - 1] = 0;
 
-    // we want the function names only .... TODO: or do we really? aren't we wasting information
-    // here?
-    for (size_t i = 0; i < strlen(name); i++)
-    {
-      if (name[i] == ' ')
-        name[i] = 0x00;
-      if (name[i] == '(')
-        name[i] = 0x00;
-    }
-
     // Check if this is a valid entry.
     if (strcmp(name, ".text") != 0 && strcmp(name, ".init") != 0 && strlen(name) > 0)
     {


### PR DESCRIPTION
Symbol maps can contain C++ mangled symbols. Demangling them with c++filt works, but Dolphin strips the whole function prototype and only keeps the name. Overloaded function can't be differentiated when demangled as well. This also prevents to manually complete function prototypes.

Is there any good reason to strip symbol's name?

**EDIT**: Zelda TP symbol map uses (not mangled) C++ symbols and valuable prototype informations are in there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4160)
<!-- Reviewable:end -->
