### PR TITLE
Fix wxWidgets build for 32-bit arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -848,6 +848,10 @@ if(NOT DISABLE_WX)
 	include(FindwxWidgets OPTIONAL)
 	FIND_PACKAGE(wxWidgets COMPONENTS core aui adv)
 
+	if(_ARCH_32)
+		add_definitions(-DwxSIZE_T_IS_UINT)
+	endif()
+
 	if(wxWidgets_FOUND)
 		EXECUTE_PROCESS(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 			COMMAND sh "${wxWidgets_CONFIG_EXECUTABLE}"


### PR DESCRIPTION
wxWidgets build fails on 32-bit arch

I'm going to check this some more

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4161)
<!-- Reviewable:end -->
