### PR TITLE
[WIP] VertexShaderManager: Use new divisors and stuff.

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -141,6 +141,8 @@ public:
   static Common::Flag s_SurfaceNeedsChanged;
   static Common::Event s_ChangedSurface;
 
+  static const float GX_MAX_DEPTH;
+
 protected:
   static void CalculateTargetScale(int x, int y, int* scaledX, int* scaledY);
   bool CalculateTargetSize(unsigned int framebuffer_width, unsigned int framebuffer_height);
@@ -175,8 +177,6 @@ protected:
   FPSCounter m_fps_counter;
 
   static std::unique_ptr<PostProcessingShaderImplementation> m_post_processor;
-
-  static const float GX_MAX_DEPTH;
 
 private:
   static PEControl::PixelFormat prev_efb_format;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -398,19 +398,21 @@ void VertexShaderManager::SetConstants()
       // where the console also uses reversed depth with the same accuracy. We need
       // to make sure the depth range is positive here and then reverse the depth in
       // the backend viewport.
-      constants.pixelcentercorrection[2] = abs(xfmem.viewport.zRange) / 16777215.0f;
+      constants.pixelcentercorrection[2] = abs(xfmem.viewport.zRange) / 16777216.0f;
       if (xfmem.viewport.zRange < 0.0f)
-        constants.pixelcentercorrection[3] = xfmem.viewport.farZ / 16777215.0f;
+        constants.pixelcentercorrection[3] = xfmem.viewport.farZ / 16777216.0f;
       else
-        constants.pixelcentercorrection[3] = 1.0f - xfmem.viewport.farZ / 16777215.0f;
+        constants.pixelcentercorrection[3] =
+            Renderer::GX_MAX_DEPTH - xfmem.viewport.farZ / 16777216.0f;
     }
     else
     {
       // For backends that don't support reversing the depth range we can still render
       // cases where the console uses reversed depth correctly. But we simply can't
       // provide the same accuracy as the console.
-      constants.pixelcentercorrection[2] = xfmem.viewport.zRange / 16777215.0f;
-      constants.pixelcentercorrection[3] = 1.0f - xfmem.viewport.farZ / 16777215.0f;
+      constants.pixelcentercorrection[2] = xfmem.viewport.zRange / 16777216.0f;
+      constants.pixelcentercorrection[3] =
+          Renderer::GX_MAX_DEPTH - xfmem.viewport.farZ / 16777216.0f;
     }
 
     dirty = true;


### PR DESCRIPTION
So it looks like there are still some round-trip errors, which could've been expected from the divisors being used here. This is an attempt to fix those round-trip errors, but it needs a FIFOCI run to determine whether it is the correct solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4162)
<!-- Reviewable:end -->
