### PR TITLE
GameSettings - Fix glowing effects in Star Fox Adventures

### DIFF
--- a/Data/Sys/GameSettings/GSA.ini
+++ b/Data/Sys/GameSettings/GSA.ini
@@ -17,3 +17,6 @@ EmulationStateId = 4
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+EFBToTextureEnable = False
+


### PR DESCRIPTION
As seen here:
https://wiki.dolphin-emu.org/index.php?title=Star_Fox_Adventures

This tweak (disabling EFB to texture only) will fix the glowing effects in Star Fox Adventures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4163)
<!-- Reviewable:end -->
