### PR TITLE
VertexShaderGen: Move the sonic epsilon hack to the vertex shader.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -408,8 +408,11 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
 
     // Since we're adjusting z for the depth range before the perspective divide, we have to do our
     // own clipping. We want to clip so that -w <= z <= 0, which matches the console -1..0 range.
-    out.Write("o.clipDist0 = o.pos.z + o.pos.w;\n");  // Near: z < -w
-    out.Write("o.clipDist1 = -o.pos.z;\n");           // Far: z > 0
+    // We adjust our depth value for clipping purposes to match the perspective projection in the
+    // software backend, which is a hack to fix Sonic Adventure and Unleashed games.
+    out.Write("float clipDepth = o.pos.z * (1.0 - 1e-7);\n");
+    out.Write("o.clipDist0 = clipDepth + o.pos.w;\n");  // Near: z < -w
+    out.Write("o.clipDist1 = -clipDepth;\n");           // Far: z > 0
 
     // Adjust z for the depth range. We're using an equation which incorperates a depth inversion,
     // so we can map the console -1..0 range to the 0..1 range used in the depth buffer.

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -454,8 +454,7 @@ void VertexShaderManager::SetConstants()
       g_fProjectionMatrix[12] = 0.0f;
       g_fProjectionMatrix[13] = 0.0f;
 
-      // Hack to fix depth clipping precision issues (such as Sonic Adventure UI)
-      g_fProjectionMatrix[14] = -(1.0f + FLT_EPSILON);
+      g_fProjectionMatrix[14] = -1.0f;
       g_fProjectionMatrix[15] = 0.0f;
 
       // Heuristic to detect if a GameCube game is in 16:9 anamorphic widescreen mode.
@@ -511,9 +510,7 @@ void VertexShaderManager::SetConstants()
       g_fProjectionMatrix[13] = 0.0f;
 
       g_fProjectionMatrix[14] = 0.0f;
-
-      // Hack to fix depth clipping precision issues (such as Sonic Unleashed UI)
-      g_fProjectionMatrix[15] = 1.0f + FLT_EPSILON;
+      g_fProjectionMatrix[15] = 1.0f;
 
       SETSTAT_FT(stats.g2proj_0, g_fProjectionMatrix[0]);
       SETSTAT_FT(stats.g2proj_1, g_fProjectionMatrix[1]);


### PR DESCRIPTION
In the vertex shader we have control over the depth clipping planes, so we don't have to offset every floating point value and lose accuracy. This fixes z fighting in the Metroid Prime visor. It also make slow depth a lot more accurate.

It has also been confirmed that the only reason the SW backend rendered the Sonic Adventure/Unleashed UIs correctly was because of its own version of the epsilon hack: https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/VideoBackends/Software/TransformUnit.cpp#L60

We can't use the exact same hack as the SW backend because our depth comparison is done in floats instead of integers and is therefore sensitive to rounding errors introduced by adding an epsilon to all depth values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4164)
<!-- Reviewable:end -->
