### PR TITLE
Backends: Remove unnecessary references to the renderer global

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -628,8 +628,7 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaE
 void Renderer::ReinterpretPixelData(unsigned int convtype)
 {
   // TODO: MSAA support..
-  D3D11_RECT source =
-      CD3D11_RECT(0, 0, g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight());
+  D3D11_RECT source = CD3D11_RECT(0, 0, GetTargetWidth(), GetTargetHeight());
 
   ID3D11PixelShader* pixel_shader;
   if (convtype == 0)
@@ -644,21 +643,21 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
   }
 
   // convert data and set the target texture as our new EFB
-  g_renderer->ResetAPIState();
+  ResetAPIState();
 
-  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, (float)g_renderer->GetTargetWidth(),
-                                      (float)g_renderer->GetTargetHeight());
+  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, static_cast<float>(GetTargetWidth()),
+                                      static_cast<float>(GetTargetHeight()));
   D3D::context->RSSetViewports(1, &vp);
 
   D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTempTexture()->GetRTV(),
                                    nullptr);
   D3D::SetPointCopySampler();
   D3D::drawShadedTexQuad(
-      FramebufferManager::GetEFBColorTexture()->GetSRV(), &source, g_renderer->GetTargetWidth(),
-      g_renderer->GetTargetHeight(), pixel_shader, VertexShaderCache::GetSimpleVertexShader(),
+      FramebufferManager::GetEFBColorTexture()->GetSRV(), &source, GetTargetWidth(),
+      GetTargetHeight(), pixel_shader, VertexShaderCache::GetSimpleVertexShader(),
       VertexShaderCache::GetSimpleInputLayout(), GeometryShaderCache::GetCopyGeometryShader());
 
-  g_renderer->RestoreAPIState();
+  RestoreAPIState();
 
   FramebufferManager::SwapReinterpretTexture();
   D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -527,7 +527,7 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha
                      FramebufferManager::GetEFBColorTexture()->GetMultisampled());
 
   // Restores proper viewport/scissor settings.
-  g_renderer->SetViewport();
+  SetViewport();
   BPFunctions::SetScissor();
 
   FramebufferManager::InvalidateEFBAccessCopies();
@@ -536,9 +536,7 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha
 void Renderer::ReinterpretPixelData(unsigned int convtype)
 {
   // EXISTINGD3D11TODO: MSAA support..
-  D3D12_RECT source =
-      CD3DX12_RECT(0, 0, g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight());
-
+  D3D12_RECT source = CD3DX12_RECT(0, 0, GetTargetWidth(), GetTargetHeight());
   D3D12_SHADER_BYTECODE pixel_shader = {};
 
   if (convtype == 0)
@@ -556,7 +554,7 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
     return;
   }
 
-  D3D::SetViewportAndScissor(0, 0, g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight());
+  D3D::SetViewportAndScissor(0, 0, GetTargetWidth(), GetTargetHeight());
 
   FramebufferManager::GetEFBColorTempTexture()->TransitionToResourceState(
       D3D::current_command_list, D3D12_RESOURCE_STATE_RENDER_TARGET);
@@ -565,8 +563,8 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
 
   D3D::SetPointCopySampler();
   D3D::DrawShadedTexQuad(
-      FramebufferManager::GetEFBColorTexture(), &source, g_renderer->GetTargetWidth(),
-      g_renderer->GetTargetHeight(), pixel_shader, StaticShaderCache::GetSimpleVertexShader(),
+      FramebufferManager::GetEFBColorTexture(), &source, GetTargetWidth(), GetTargetHeight(),
+      pixel_shader, StaticShaderCache::GetSimpleVertexShader(),
       StaticShaderCache::GetSimpleVertexShaderInputLayout(),
       StaticShaderCache::GetCopyGeometryShader(), 1.0f, 0, DXGI_FORMAT_R8G8B8A8_UNORM, false,
       FramebufferManager::GetEFBColorTempTexture()->GetMultisampled());

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -833,7 +833,7 @@ TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)
 // therefore the width and height are (scissorBR + 1) - scissorTL
 void Renderer::SetScissorRect(const EFBRectangle& rc)
 {
-  TargetRectangle trc = g_renderer->ConvertEFBRectangle(rc);
+  TargetRectangle trc = ConvertEFBRectangle(rc);
   glScissor(trc.left, trc.bottom, trc.GetWidth(), trc.GetHeight());
 }
 
@@ -952,13 +952,13 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
     {
       if (s_MSAASamples > 1)
       {
-        g_renderer->ResetAPIState();
+        ResetAPIState();
 
         // Resolve our rectangle.
         FramebufferManager::GetEFBDepthTexture(efbPixelRc);
         glBindFramebuffer(GL_READ_FRAMEBUFFER, FramebufferManager::GetResolvedFramebuffer());
 
-        g_renderer->RestoreAPIState();
+        RestoreAPIState();
       }
 
       std::unique_ptr<float[]> depthMap(new float[targetPixelRcWidth * targetPixelRcHeight]);
@@ -991,13 +991,13 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
     {
       if (s_MSAASamples > 1)
       {
-        g_renderer->ResetAPIState();
+        ResetAPIState();
 
         // Resolve our rectangle.
         FramebufferManager::GetEFBColorTexture(efbPixelRc);
         glBindFramebuffer(GL_READ_FRAMEBUFFER, FramebufferManager::GetResolvedFramebuffer());
 
-        g_renderer->RestoreAPIState();
+        RestoreAPIState();
       }
 
       std::unique_ptr<u32[]> colorMap(new u32[targetPixelRcWidth * targetPixelRcHeight]);


### PR DESCRIPTION
Calling out to the renderer global within the actual renderer API is pretty silly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4165)
<!-- Reviewable:end -->
