### PR TITLE
VertexShaderGen: Fix D3D11 X3014 compile error

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -388,7 +388,9 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
     if (texinfo.texgentype == XF_TEXGEN_REGULAR)
     {
       out.Write("if(o.tex%d.z == 0.0f)\n", i);
-      out.Write("\to.tex%d.xy = clamp(o.tex%d.xy / 2.0f, float2(-1.0f), float2(1.0f));\n", i, i);
+      out.Write(
+          "\to.tex%d.xy = clamp(o.tex%d.xy / 2.0f, float2(-1.0f,-1.0f), float2(1.0f,1.0f));\n", i,
+          i);
     }
 
     out.Write("}\n");


### PR DESCRIPTION
X3014: Incorrect number of arguments to numeric type constructor.

float2 requires 2 parameters in HLSL apparently.

Caused by PR #3707. Fixes Direct3D.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4167)
<!-- Reviewable:end -->
