### PR TITLE
Core: CoreTiming Cleanup (Add UnitTests)

### DIFF
--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -282,11 +282,12 @@ void RemoveAllEvents(EventType* event_type)
 
 void ForceExceptionCheck(s64 cycles)
 {
+  cycles = std::max<s64>(0, cycles);
   if (DowncountToCycles(PowerPC::ppcState.downcount) > cycles)
   {
     // downcount is always (much) smaller than MAX_INT so we can safely cast cycles to an int here.
     // Account for cycles already executed by adjusting the g_slice_length
-    g_slice_length -= (DowncountToCycles(PowerPC::ppcState.downcount) - static_cast<int>(cycles));
+    g_slice_length -= DowncountToCycles(PowerPC::ppcState.downcount) - static_cast<int>(cycles);
     PowerPC::ppcState.downcount = CyclesToDowncount(static_cast<int>(cycles));
   }
 }

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -129,6 +129,11 @@ void Init()
   g_slice_length = MAX_SLICE_LENGTH;
   g_global_timer = 0;
   s_idled_cycles = 0;
+
+  // The time between CoreTiming being intialized and the first call to Advance() is considered
+  // the slice boundary between slice -1 and slice 0. Dispatcher loops must call Advance() before
+  // executing the first PPC cycle of each slice to prepare the slice length and downcount for
+  // that slice.
   s_is_global_timer_sane = true;
 
   s_ev_lost = RegisterEvent("_lost_event", &EmptyTimedCallback);

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -8,8 +8,10 @@
 #include <string>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/FifoQueue.h"
+#include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
 
@@ -31,22 +33,30 @@ struct EventType
 
 static std::vector<EventType> s_event_types;
 
-struct BaseEvent
+struct Event
 {
   s64 time;
   u64 userdata;
   int type;
 };
 
-typedef LinkedListItem<BaseEvent> Event;
+constexpr bool operator>(const Event& left, const Event& right)
+{
+  return left.time > right.time;
+}
+constexpr bool operator<(const Event& left, const Event& right)
+{
+  return left.time < right.time;
+}
 
 // STATE_TO_SAVE
-static Event* s_first_event;
+// The queue is a min-heap using std::make_heap/push_heap/pop_heap.
+// We don't use std::priority_queue because we need to be able to serialize, unserialize and
+// erase arbitrary events (RemoveEvent()) regardless of the queue order. These aren't accomodated
+// by the standard adaptor class.
+static std::vector<Event> s_event_queue;
 static std::mutex s_ts_write_lock;
-static Common::FifoQueue<BaseEvent, false> s_ts_queue;
-
-// event pools
-static Event* s_event_pool = nullptr;
+static Common::FifoQueue<Event, false> s_ts_queue;
 
 static float s_last_OC_factor;
 float g_last_OC_factor_inverted;
@@ -65,22 +75,6 @@ u64 g_fake_TB_start_value;
 u64 g_fake_TB_start_ticks;
 
 static int s_ev_lost;
-
-static Event* GetNewEvent()
-{
-  if (!s_event_pool)
-    return new Event;
-
-  Event* ev = s_event_pool;
-  s_event_pool = ev->next;
-  return ev;
-}
-
-static void FreeEvent(Event* ev)
-{
-  ev->next = s_event_pool;
-  s_event_pool = ev;
-}
 
 static void EmptyTimedCallback(u64 userdata, s64 cyclesLate)
 {
@@ -132,9 +126,9 @@ int RegisterEvent(const std::string& name, TimedCallback callback)
 
 void UnregisterAllEvents()
 {
-  if (s_first_event)
-    PanicAlert("Cannot unregister events with events pending");
+  _assert_msg_(POWERPC, s_event_queue.empty(), "Cannot unregister events with events pending");
   s_event_types.clear();
+  s_event_types.shrink_to_fit();
 }
 
 void Init()
@@ -156,50 +150,6 @@ void Shutdown()
   MoveEvents();
   ClearPendingEvents();
   UnregisterAllEvents();
-
-  while (s_event_pool)
-  {
-    Event* ev = s_event_pool;
-    s_event_pool = ev->next;
-    delete ev;
-  }
-}
-
-static void EventDoState(PointerWrap& p, BaseEvent* ev)
-{
-  p.Do(ev->time);
-
-  // this is why we can't have (nice things) pointers as userdata
-  p.Do(ev->userdata);
-
-  // we can't savestate ev->type directly because events might not get registered in the same order
-  // (or at all) every time.
-  // so, we savestate the event's type's name, and derive ev->type from that when loading.
-  std::string name;
-  if (p.GetMode() != PointerWrap::MODE_READ)
-    name = s_event_types[ev->type].name;
-
-  p.Do(name);
-  if (p.GetMode() == PointerWrap::MODE_READ)
-  {
-    bool foundMatch = false;
-    for (unsigned int i = 0; i < s_event_types.size(); ++i)
-    {
-      if (name == s_event_types[i].name)
-      {
-        ev->type = i;
-        foundMatch = true;
-        break;
-      }
-    }
-    if (!foundMatch)
-    {
-      WARN_LOG(POWERPC,
-               "Lost event from savestate because its type, \"%s\", has not been registered.",
-               name.c_str());
-      ev->type = s_ev_lost;
-    }
-  }
 }
 
 void DoState(PointerWrap& p)
@@ -218,9 +168,44 @@ void DoState(PointerWrap& p)
   p.DoMarker("CoreTimingData");
 
   MoveEvents();
+  p.DoEachElement(s_event_queue, [](PointerWrap& pw, Event& ev) {
+    pw.Do(ev.time);
 
-  p.DoLinkedList<BaseEvent, GetNewEvent, FreeEvent, EventDoState>(s_first_event);
+    // this is why we can't have (nice things) pointers as userdata
+    pw.Do(ev.userdata);
+
+    // we can't savestate ev.type directly because events might not get registered in the same
+    // order (or at all) every time.
+    // so, we savestate the event's type's name, and derive ev.type from that when loading.
+    std::string name;
+    if (pw.GetMode() != PointerWrap::MODE_READ)
+      name = s_event_types[ev.type].name;
+
+    pw.Do(name);
+    if (pw.GetMode() == PointerWrap::MODE_READ)
+    {
+      auto itr = std::find_if(s_event_types.begin(), s_event_types.end(),
+                              [&](const EventType& evt) { return evt.name == name; });
+      if (itr != s_event_types.end())
+      {
+        ev.type = static_cast<int>(itr - s_event_types.begin());
+      }
+      else
+      {
+        WARN_LOG(POWERPC,
+                 "Lost event from savestate because its type, \"%s\", has not been registered.",
+                 name.c_str());
+        ev.type = s_ev_lost;
+      }
+    }
+  });
   p.DoMarker("CoreTimingEvents");
+
+  // When loading from a save state, we must assume the Event order is random and meaningless.
+  // The exact layout of the heap in memory is implementation defined, therefore it is platform
+  // and library version specific.
+  if (p.GetMode() == PointerWrap::MODE_READ)
+    std::make_heap(s_event_queue.begin(), s_event_queue.end(), std::greater<Event>());
 }
 
 // This should only be called from the CPU thread. If you are calling
@@ -243,30 +228,7 @@ u64 GetIdleTicks()
 
 void ClearPendingEvents()
 {
-  while (s_first_event)
-  {
-    Event* e = s_first_event->next;
-    FreeEvent(s_first_event);
-    s_first_event = e;
-  }
-}
-
-static void AddEventToQueue(Event* ne)
-{
-  Event* prev = nullptr;
-  Event** pNext = &s_first_event;
-  for (;;)
-  {
-    Event*& next = *pNext;
-    if (!next || ne->time < next->time)
-    {
-      ne->next = next;
-      next = ne;
-      break;
-    }
-    prev = next;
-    pNext = &prev->next;
-  }
+  s_event_queue.clear();
 }
 
 void ScheduleEvent(s64 cycles_into_future, int event_type, u64 userdata, FromThread from)
@@ -285,16 +247,14 @@ void ScheduleEvent(s64 cycles_into_future, int event_type, u64 userdata, FromThr
 
   if (from_cpu_thread)
   {
-    Event* ne = GetNewEvent();
-    ne->time = GetTicks() + cycles_into_future;
-    ne->userdata = userdata;
-    ne->type = event_type;
+    s64 timeout = GetTicks() + cycles_into_future;
 
     // If this event needs to be scheduled before the next advance(), force one early
     if (!s_is_global_timer_sane)
       ForceExceptionCheck(cycles_into_future);
 
-    AddEventToQueue(ne);
+    s_event_queue.emplace_back(Event{timeout, userdata, event_type});
+    std::push_heap(s_event_queue.begin(), s_event_queue.end(), std::greater<Event>());
   }
   else
   {
@@ -306,41 +266,20 @@ void ScheduleEvent(s64 cycles_into_future, int event_type, u64 userdata, FromThr
     }
 
     std::lock_guard<std::mutex> lk(s_ts_write_lock);
-    Event ne;
-    ne.time = g_global_timer + cycles_into_future;
-    ne.type = event_type;
-    ne.userdata = userdata;
-    s_ts_queue.Push(ne);
+    s_ts_queue.Push(Event{g_global_timer + cycles_into_future, userdata, event_type});
   }
 }
 
 void RemoveEvent(int event_type)
 {
-  while (s_first_event && s_first_event->type == event_type)
-  {
-    Event* next = s_first_event->next;
-    FreeEvent(s_first_event);
-    s_first_event = next;
-  }
+  auto itr = std::remove_if(s_event_queue.begin(), s_event_queue.end(),
+                            [&](const Event& e) { return e.type == event_type; });
 
-  if (!s_first_event)
-    return;
-
-  Event* prev = s_first_event;
-  Event* ptr = prev->next;
-  while (ptr)
+  // Removing random items breaks the invariant so we have to re-establish it.
+  if (itr != s_event_queue.end())
   {
-    if (ptr->type == event_type)
-    {
-      prev->next = ptr->next;
-      FreeEvent(ptr);
-      ptr = prev->next;
-    }
-    else
-    {
-      prev = ptr;
-      ptr = ptr->next;
-    }
+    s_event_queue.erase(itr, s_event_queue.end());
+    std::make_heap(s_event_queue.begin(), s_event_queue.end(), std::greater<Event>());
   }
 }
 
@@ -363,14 +302,10 @@ void ForceExceptionCheck(s64 cycles)
 
 void MoveEvents()
 {
-  BaseEvent sevt;
-  while (s_ts_queue.Pop(sevt))
+  for (Event ev; s_ts_queue.Pop(ev);)
   {
-    Event* evt = GetNewEvent();
-    evt->time = sevt.time;
-    evt->userdata = sevt.userdata;
-    evt->type = sevt.type;
-    AddEventToQueue(evt);
+    s_event_queue.emplace_back(std::move(ev));
+    std::push_heap(s_event_queue.begin(), s_event_queue.end(), std::greater<Event>());
   }
 }
 
@@ -386,24 +321,23 @@ void Advance()
 
   s_is_global_timer_sane = true;
 
-  while (s_first_event && s_first_event->time <= g_global_timer)
+  while (!s_event_queue.empty() && s_event_queue.front().time <= g_global_timer)
   {
-    // LOG(POWERPC, "[Scheduler] %s     (%lld, %lld) ",
-    //             s_event_types[s_first_event->type].name ? s_event_types[s_first_event->type].name
-    //             : "?",
-    //             (u64)g_global_timer, (u64)s_first_event->time);
-    Event* evt = s_first_event;
-    s_first_event = s_first_event->next;
-    s_event_types[evt->type].callback(evt->userdata, g_global_timer - evt->time);
-    FreeEvent(evt);
+    Event evt = std::move(s_event_queue.front());
+    std::pop_heap(s_event_queue.begin(), s_event_queue.end(), std::greater<Event>());
+    s_event_queue.pop_back();
+    // NOTICE_LOG(POWERPC, "[Scheduler] %-20s (%lld, %lld)", evt.type->name->c_str(),
+    //            g_global_timer, evt.time);
+    s_event_types[evt.type].callback(evt.userdata, g_global_timer - evt.time);
   }
 
   s_is_global_timer_sane = false;
 
-  if (s_first_event)
+  // Still events left (scheduled in the future)
+  if (!s_event_queue.empty())
   {
-    g_slice_length =
-        static_cast<int>(std::min<s64>(s_first_event->time - g_global_timer, MAX_SLICE_LENGTH));
+    g_slice_length = static_cast<int>(
+        std::min<s64>(s_event_queue.front().time - g_global_timer, MAX_SLICE_LENGTH));
   }
 
   PowerPC::ppcState.downcount = CyclesToDowncount(g_slice_length);
@@ -417,12 +351,14 @@ void Advance()
 
 void LogPendingEvents()
 {
-  Event* ptr = s_first_event;
-  while (ptr)
+  auto clone = s_event_queue;
+  std::sort(clone.begin(), clone.end());
+  for (const Event& ev : clone)
   {
-    INFO_LOG(POWERPC, "PENDING: Now: %" PRId64 " Pending: %" PRId64 " Type: %d", g_global_timer,
-             ptr->time, ptr->type);
-    ptr = ptr->next;
+    INFO_LOG(POWERPC, "PENDING: Now: %" PRId64 " Pending: %" PRId64 " Type: %s (%d)",
+             g_global_timer, ev.time,
+             ev.type < s_event_types.size() ? s_event_types[ev.type].name.c_str() : "<INVALID>",
+             ev.type);
   }
 }
 
@@ -442,20 +378,24 @@ void Idle()
 
 std::string GetScheduledEventsSummary()
 {
-  Event* ptr = s_first_event;
   std::string text = "Scheduled events\n";
   text.reserve(1000);
-  while (ptr)
+
+  auto clone = s_event_queue;
+  std::sort(clone.begin(), clone.end());
+  for (const Event& ev : clone)
   {
-    unsigned int t = ptr->type;
+    unsigned int t = ev.type;
     if (t >= s_event_types.size())
+    {
       PanicAlertT("Invalid event type %i", t);
+      continue;
+    }
 
-    const std::string& name = s_event_types[ptr->type].name;
+    const std::string& name = s_event_types[ev.type].name;
 
-    text += StringFromFormat("%s : %" PRIi64 " %016" PRIx64 "\n", name.c_str(), ptr->time,
-                             ptr->userdata);
-    ptr = ptr->next;
+    text +=
+        StringFromFormat("%s : %" PRIi64 " %016" PRIx64 "\n", name.c_str(), ev.time, ev.userdata);
   }
   return text;
 }

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -43,9 +43,11 @@ u64 GetIdleTicks();
 
 void DoState(PointerWrap& p);
 
+struct EventType;
+
 // Returns the event_type identifier. if name is not unique, an existing event_type will be
 // discarded.
-int RegisterEvent(const std::string& name, TimedCallback callback);
+EventType* RegisterEvent(const std::string& name, TimedCallback callback);
 void UnregisterAllEvents();
 
 enum class FromThread
@@ -58,12 +60,12 @@ enum class FromThread
 };
 
 // userdata MAY NOT CONTAIN POINTERS. userdata might get written and reloaded from savestates.
-void ScheduleEvent(s64 cycles_into_future, int event_type, u64 userdata = 0,
+void ScheduleEvent(s64 cycles_into_future, EventType* event_type, u64 userdata = 0,
                    FromThread from = FromThread::CPU);
 
 // We only permit one event of each type in the queue at a time.
-void RemoveEvent(int event_type);
-void RemoveAllEvents(int event_type);
+void RemoveEvent(EventType* event_type);
+void RemoveAllEvents(EventType* event_type);
 void Advance();
 void MoveEvents();
 

--- a/Source/Core/Core/CoreTiming.h
+++ b/Source/Core/Core/CoreTiming.h
@@ -25,11 +25,11 @@ class PointerWrap;
 namespace CoreTiming
 {
 // These really shouldn't be global, but jit64 accesses them directly
-extern s64 g_globalTimer;
-extern u64 g_fakeTBStartValue;
-extern u64 g_fakeTBStartTicks;
-extern int g_slicelength;
-extern float g_lastOCFactor_inverted;
+extern s64 g_global_timer;
+extern u64 g_fake_TB_start_value;
+extern u64 g_fake_TB_start_ticks;
+extern int g_slice_length;
+extern float g_last_OC_factor_inverted;
 
 void Init();
 void Shutdown();

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -130,7 +130,7 @@ static void GenerateAudioInterrupt();
 static void UpdateInterrupts();
 static void IncreaseSampleCount(const u32 _uAmount);
 static int GetAIPeriod();
-static int et_AI;
+static CoreTiming::EventType* et_AI;
 static void Update(u64 userdata, s64 cyclesLate);
 
 void Init()

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -188,8 +188,8 @@ static void UpdateInterrupts();
 static void Do_ARAM_DMA();
 static void GenerateDSPInterrupt(u64 DSPIntType, s64 cyclesLate = 0);
 
-static int et_GenerateDSPInterrupt;
-static int et_CompleteARAM;
+static CoreTiming::EventType* et_GenerateDSPInterrupt;
+static CoreTiming::EventType* et_CompleteARAM;
 
 static void CompleteARAM(u64 userdata, s64 cyclesLate)
 {

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -238,14 +238,14 @@ static u32 s_error_code = 0;
 static bool s_disc_inside = false;
 static bool s_stream = false;
 static bool s_stop_at_track_end = false;
-static int s_finish_executing_command = 0;
-static int s_dtk = 0;
+static CoreTiming::EventType* s_finish_executing_command;
+static CoreTiming::EventType* s_dtk;
 
 static u64 s_last_read_offset;
 static u64 s_last_read_time;
 
-static int s_eject_disc;
-static int s_insert_disc;
+static CoreTiming::EventType* s_eject_disc;
+static CoreTiming::EventType* s_insert_disc;
 
 static void EjectDiscCallback(u64 userdata, s64 cyclesLate);
 static void InsertDiscCallback(u64 userdata, s64 cyclesLate);

--- a/Source/Core/Core/HW/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVDThread.cpp
@@ -30,7 +30,7 @@ namespace DVDThread
 static void DVDThread();
 
 static void FinishRead(u64 userdata, s64 cycles_late);
-static int s_finish_read;
+static CoreTiming::EventType* s_finish_read;
 
 static std::thread s_dvd_thread;
 static Common::Event s_dvd_thread_start_working;

--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -12,6 +12,7 @@
 #include "Core/CoreTiming.h"
 #include "Core/HW/EXI.h"
 #include "Core/HW/EXI_Channel.h"
+#include "Core/HW/EXI_DeviceMemoryCard.h"
 #include "Core/HW/MMIO.h"
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/Sram.h"
@@ -38,6 +39,7 @@ void Init()
     InitSRAM();
   }
 
+  CEXIMemoryCard::Init();
   for (u32 i = 0; i < MAX_EXI_CHANNELS; i++)
     g_Channels[i] = std::make_unique<CEXIChannel>(i);
 
@@ -65,6 +67,8 @@ void Shutdown()
 {
   for (auto& channel : g_Channels)
     channel.reset();
+
+  CEXIMemoryCard::Shutdown();
 }
 
 void DoState(PointerWrap& p)

--- a/Source/Core/Core/HW/EXI.cpp
+++ b/Source/Core/Core/HW/EXI.cpp
@@ -23,8 +23,8 @@ bool g_SRAM_netplay_initialized = false;
 
 namespace ExpansionInterface
 {
-static int changeDevice;
-static int updateInterrupts;
+static CoreTiming::EventType* changeDevice;
+static CoreTiming::EventType* updateInterrupts;
 
 static std::array<std::unique_ptr<CEXIChannel>, MAX_EXI_CHANNELS> g_Channels;
 

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <array>
 #include <cstring>
 #include <memory>
 #include <string>
@@ -41,6 +42,9 @@
 static const u32 MC_TRANSFER_RATE_READ = 512 * 1024;
 static const u32 MC_TRANSFER_RATE_WRITE = (u32)(96.125f * 1024.0f);
 
+static std::array<CoreTiming::EventType*, 2> s_et_cmd_done;
+static std::array<CoreTiming::EventType*, 2> s_et_transfer_complete;
+
 // Takes care of the nasty recovery of the 'this' pointer from card_index,
 // stored in the userdata parameter of the CoreTiming event.
 void CEXIMemoryCard::EventCompleteFindInstance(u64 userdata,
@@ -70,25 +74,37 @@ void CEXIMemoryCard::TransferCompleteCallback(u64 userdata, s64 cyclesLate)
                             [](CEXIMemoryCard* instance) { instance->TransferComplete(); });
 }
 
+void CEXIMemoryCard::Init()
+{
+  static constexpr char DONE_PREFIX[] = "memcardDone";
+  static constexpr char TRANSFER_COMPLETE_PREFIX[] = "memcardTransferComplete";
+
+  static_assert(s_et_cmd_done.size() == s_et_transfer_complete.size(), "Event array size differs");
+  for (unsigned int i = 0; i < s_et_cmd_done.size(); ++i)
+  {
+    std::string name = DONE_PREFIX;
+    name += static_cast<char>('A' + i);
+    s_et_cmd_done[i] = CoreTiming::RegisterEvent(name, CmdDoneCallback);
+
+    name = TRANSFER_COMPLETE_PREFIX;
+    name += static_cast<char>('A' + i);
+    s_et_transfer_complete[i] = CoreTiming::RegisterEvent(name, TransferCompleteCallback);
+  }
+}
+
+void CEXIMemoryCard::Shutdown()
+{
+  s_et_cmd_done.fill(nullptr);
+  s_et_transfer_complete.fill(nullptr);
+}
+
 CEXIMemoryCard::CEXIMemoryCard(const int index, bool gciFolder) : card_index(index)
 {
-  struct
-  {
-    const char* done;
-    const char* transfer_complete;
-  } const event_names[] = {
-      {"memcardDoneA", "memcardTransferCompleteA"}, {"memcardDoneB", "memcardTransferCompleteB"},
-  };
+  _assert_msg_(EXPANSIONINTERFACE, static_cast<std::size_t>(index) < s_et_cmd_done.size(),
+               "Trying to create invalid memory card index %d.", index);
 
-  if ((size_t)index >= ArraySize(event_names))
-  {
-    PanicAlertT("Trying to create invalid memory card index.");
-  }
-  // we're potentially leaking events here, since there's no RemoveEvent
-  // until emu shutdown, but I guess it's inconsequential
-  et_cmd_done = CoreTiming::RegisterEvent(event_names[index].done, CmdDoneCallback);
-  et_transfer_complete =
-      CoreTiming::RegisterEvent(event_names[index].transfer_complete, TransferCompleteCallback);
+  // NOTE: When loading a save state, DMA completion callbacks (s_et_transfer_complete) and such
+  //   may have been restored, we need to anticipate those arriving.
 
   interruptSwitch = 0;
   m_bInterruptSet = 0;
@@ -248,8 +264,8 @@ void CEXIMemoryCard::SetupRawMemcard(u16 sizeMb)
 
 CEXIMemoryCard::~CEXIMemoryCard()
 {
-  CoreTiming::RemoveEvent(et_cmd_done);
-  CoreTiming::RemoveEvent(et_transfer_complete);
+  CoreTiming::RemoveEvent(s_et_cmd_done[card_index]);
+  CoreTiming::RemoveEvent(s_et_transfer_complete[card_index]);
 }
 
 bool CEXIMemoryCard::UseDelayedTransferCompletion() const
@@ -279,8 +295,8 @@ void CEXIMemoryCard::TransferComplete()
 
 void CEXIMemoryCard::CmdDoneLater(u64 cycles)
 {
-  CoreTiming::RemoveEvent(et_cmd_done);
-  CoreTiming::ScheduleEvent((int)cycles, et_cmd_done, (u64)card_index);
+  CoreTiming::RemoveEvent(s_et_cmd_done[card_index]);
+  CoreTiming::ScheduleEvent((int)cycles, s_et_cmd_done[card_index], (u64)card_index);
 }
 
 void CEXIMemoryCard::SetCS(int cs)
@@ -547,7 +563,7 @@ void CEXIMemoryCard::DMARead(u32 _uAddr, u32 _uSize)
 
   // Schedule transfer complete later based on read speed
   CoreTiming::ScheduleEvent(_uSize * (SystemTimers::GetTicksPerSecond() / MC_TRANSFER_RATE_READ),
-                            et_transfer_complete, (u64)card_index);
+                            s_et_transfer_complete[card_index], (u64)card_index);
 }
 
 // DMA write are preceded by all of the necessary setup via IMMWrite
@@ -563,5 +579,5 @@ void CEXIMemoryCard::DMAWrite(u32 _uAddr, u32 _uSize)
 
   // Schedule transfer complete later based on write speed
   CoreTiming::ScheduleEvent(_uSize * (SystemTimers::GetTicksPerSecond() / MC_TRANSFER_RATE_WRITE),
-                            et_transfer_complete, (u64)card_index);
+                            s_et_transfer_complete[card_index], (u64)card_index);
 }

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
@@ -9,10 +9,6 @@
 
 #include "Core/HW/EXI_Device.h"
 
-namespace CoreTiming
-{
-struct EventType;
-}
 class MemoryCardBase;
 class PointerWrap;
 
@@ -29,6 +25,12 @@ public:
   IEXIDevice* FindDevice(TEXIDevices device_type, int customIndex = -1) override;
   void DMARead(u32 _uAddr, u32 _uSize) override;
   void DMAWrite(u32 _uAddr, u32 _uSize) override;
+
+  // CoreTiming events need to be registered during boot since CoreTiming is DoState()-ed
+  // before ExpansionInterface so we'll lose the save stated events if the callbacks are
+  // not already registered first.
+  static void Init();
+  static void Shutdown();
 
 private:
   void SetupGciFolder(u16 sizeMb);
@@ -71,8 +73,6 @@ private:
   };
 
   int card_index;
-  CoreTiming::EventType* et_cmd_done = nullptr;
-  CoreTiming::EventType* et_transfer_complete = nullptr;
   //! memory card state
 
   // STATE_TO_SAVE

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.h
@@ -9,6 +9,10 @@
 
 #include "Core/HW/EXI_Device.h"
 
+namespace CoreTiming
+{
+struct EventType;
+}
 class MemoryCardBase;
 class PointerWrap;
 
@@ -67,7 +71,8 @@ private:
   };
 
   int card_index;
-  int et_cmd_done, et_transfer_complete;
+  CoreTiming::EventType* et_cmd_done = nullptr;
+  CoreTiming::EventType* et_transfer_complete = nullptr;
   //! memory card state
 
   // STATE_TO_SAVE

--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -31,10 +31,10 @@ static u32 m_FlipperRev;
 static u32 m_Unknown;
 
 // ID and callback for scheduling reset button presses/releases
-static int toggleResetButton;
+static CoreTiming::EventType* toggleResetButton;
 static void ToggleResetButtonCallback(u64 userdata, s64 cyclesLate);
 
-static int iosNotifyResetButton;
+static CoreTiming::EventType* iosNotifyResetButton;
 static void IOSNotifyResetButtonCallback(u64 userdata, s64 cyclesLate);
 
 // Let the PPC know that an external exception is set/cleared

--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -23,8 +23,8 @@
 
 namespace SerialInterface
 {
-static int changeDevice;
-static int et_transfer_pending;
+static CoreTiming::EventType* changeDevice;
+static CoreTiming::EventType* et_transfer_pending;
 
 static void RunSIBuffer(u64 userdata, s64 cyclesLate);
 static void UpdateInterrupts();

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -64,13 +64,14 @@ IPC_HLE_PERIOD: For the Wiimote this is the call schedule:
 
 namespace SystemTimers
 {
-static int et_Dec;
-static int et_VI;
-static int et_AudioDMA;
-static int et_DSP;
-static int et_IPC_HLE;
-static int et_PatchEngine;  // PatchEngine updates every 1/60th of a second by default
-static int et_Throttle;
+static CoreTiming::EventType* et_Dec;
+static CoreTiming::EventType* et_VI;
+static CoreTiming::EventType* et_AudioDMA;
+static CoreTiming::EventType* et_DSP;
+static CoreTiming::EventType* et_IPC_HLE;
+// PatchEngine updates every 1/60th of a second by default
+static CoreTiming::EventType* et_PatchEngine;
+static CoreTiming::EventType* et_Throttle;
 
 static u32 s_cpu_core_clock = 486000000u;  // 486 mhz (its not 485, stop bugging me!)
 

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -98,7 +98,7 @@ static u32 arm_irq_masks;
 
 static u32 sensorbar_power;  // do we need to care about this?
 
-static int updateInterrupts;
+static CoreTiming::EventType* updateInterrupts;
 static void UpdateInterrupts(u64 = 0, s64 cyclesLate = 0);
 
 void DoState(PointerWrap& p)

--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -113,7 +113,7 @@ void DoState(PointerWrap& p)
   p.Do(sensorbar_power);
 }
 
-void Init()
+static void InitState()
 {
   ctrl = CtrlRegister();
   ppc_msg = 0;
@@ -127,14 +127,18 @@ void Init()
   sensorbar_power = 0;
 
   ppc_irq_masks |= INT_CAUSE_IPC_BROADWAY;
+}
 
+void Init()
+{
+  InitState();
   updateInterrupts = CoreTiming::RegisterEvent("IPCInterrupt", UpdateInterrupts);
 }
 
 void Reset()
 {
   INFO_LOG(WII_IPC, "Resetting ...");
-  Init();
+  InitState();
   WII_IPC_HLE_Interface::Reset();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -76,8 +76,8 @@ static ipc_msg_queue request_queue;  // ppc -> arm
 static ipc_msg_queue reply_queue;    // arm -> ppc
 static ipc_msg_queue ack_queue;      // arm -> ppc
 
-static int event_enqueue;
-static int event_sdio_notify;
+static CoreTiming::EventType* event_enqueue;
+static CoreTiming::EventType* event_sdio_notify;
 
 static u64 last_reply_time;
 

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -15,7 +15,7 @@
 #include "Core/MemoryWatcher.h"
 
 static std::unique_ptr<MemoryWatcher> s_memory_watcher;
-static int s_event;
+static CoreTiming::EventType* s_event;
 static const int MW_RATE = 600;  // Steps per second
 
 static void MWCallback(u64 userdata, s64 cyclesLate)

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -198,7 +198,7 @@ void Interpreter::SingleStep()
 {
   SingleStepInner();
 
-  CoreTiming::g_slicelength = 1;
+  CoreTiming::g_slice_length = 1;
   PowerPC::ppcState.downcount = 0;
   CoreTiming::Advance();
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -286,13 +286,13 @@ void Jit64::mfspr(UGeckoInstruction inst)
     // cost of calling out to C for this is actually significant.
     // Scale downcount by the CPU overclocking factor.
     CVTSI2SS(XMM0, PPCSTATE(downcount));
-    MULSS(XMM0, M(&CoreTiming::g_lastOCFactor_inverted));
+    MULSS(XMM0, M(&CoreTiming::g_last_OC_factor_inverted));
     CVTSS2SI(RDX, R(XMM0));  // RDX is downcount scaled by the overclocking factor
-    MOV(32, R(RAX), M(&CoreTiming::g_slicelength));
+    MOV(32, R(RAX), M(&CoreTiming::g_slice_length));
     SUB(64, R(RAX), R(RDX));  // cycles since the last CoreTiming::Advance() event is (slicelength -
                               // Scaled_downcount)
-    ADD(64, R(RAX), M(&CoreTiming::g_globalTimer));
-    SUB(64, R(RAX), M(&CoreTiming::g_fakeTBStartTicks));
+    ADD(64, R(RAX), M(&CoreTiming::g_global_timer));
+    SUB(64, R(RAX), M(&CoreTiming::g_fake_TB_start_ticks));
     // It might seem convenient to correct the timer for the block position here for even more
     // accurate
     // timing, but as of currently, this can break games. If we end up reading a time *after* the
@@ -308,7 +308,7 @@ void Jit64::mfspr(UGeckoInstruction inst)
     // a / 12 = (a * 0xAAAAAAAAAAAAAAAB) >> 67
     MOV(64, R(RDX), Imm64(0xAAAAAAAAAAAAAAABULL));
     MUL(64, R(RDX));
-    MOV(64, R(RAX), M(&CoreTiming::g_fakeTBStartValue));
+    MOV(64, R(RAX), M(&CoreTiming::g_fake_TB_start_value));
     SHR(64, R(RDX), Imm8(3));
     ADD(64, R(RAX), R(RDX));
     MOV(64, PPCSTATE(spr[SPR_TL]), R(RAX));

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -234,9 +234,9 @@ void JitArm64::mfspr(UGeckoInstruction inst)
 
     // An inline implementation of CoreTiming::GetFakeTimeBase, since in timer-heavy games the
     // cost of calling out to C for this is actually significant.
-    MOVI2R(XA, (u64)&CoreTiming::g_globalTimer);
+    MOVI2R(XA, (u64)&CoreTiming::g_global_timer);
     LDR(INDEX_UNSIGNED, XA, XA, 0);
-    MOVI2R(XB, (u64)&CoreTiming::g_fakeTBStartTicks);
+    MOVI2R(XB, (u64)&CoreTiming::g_fake_TB_start_ticks);
     LDR(INDEX_UNSIGNED, XB, XB, 0);
     SUB(XA, XA, XB);
 
@@ -254,7 +254,7 @@ void JitArm64::mfspr(UGeckoInstruction inst)
     ADD(XB, XB, 1);
     UMULH(XA, XA, XB);
 
-    MOVI2R(XB, (u64)&CoreTiming::g_fakeTBStartValue);
+    MOVI2R(XB, (u64)&CoreTiming::g_fake_TB_start_value);
     LDR(INDEX_UNSIGNED, XB, XB, 0);
     ADD(XA, XB, XA, ArithOption(XA, ST_LSR, 3));
     STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(spr[SPR_TL]));

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -36,7 +36,7 @@ BreakPoints breakpoints;
 MemChecks memchecks;
 PPCDebugInterface debug_interface;
 
-static int s_invalidate_cache_thread_safe;
+static CoreTiming::EventType* s_invalidate_cache_thread_safe;
 static void InvalidateCacheThreadSafe(u64 userdata, s64 cyclesLate)
 {
   ppcState.iCache.Invalidate(static_cast<u32>(userdata));

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -70,7 +70,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 55;
+static const u32 STATE_VERSION = 56;
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -142,7 +142,6 @@ bool VideoSoftware::Initialize(void* window_handle)
 
   SWOGLWindow::Init(window_handle);
 
-  PixelEngine::Init();
   Clipper::Init();
   Rasterizer::Init();
   SWRenderer::Init();

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -21,7 +21,7 @@
 
 namespace CommandProcessor
 {
-static int et_UpdateInterrupts;
+static CoreTiming::EventType* et_UpdateInterrupts;
 
 // TODO(ector): Warn on bbox read/write
 

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -48,7 +48,7 @@ static u8* s_fifo_aux_read_ptr;
 static bool s_use_deterministic_gpu_thread;
 
 static u64 s_last_sync_gpu_tick;
-static int s_event_sync_gpu;
+static CoreTiming::EventType* s_event_sync_gpu;
 
 // STATE_TO_SAVE
 static u8* s_video_buffer;

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -100,7 +100,7 @@ static bool s_event_raised;
 static bool s_signal_token_interrupt;
 static bool s_signal_finish_interrupt;
 
-static int et_SetTokenFinishOnMainThread;
+static CoreTiming::EventType* et_SetTokenFinishOnMainThread;
 
 enum
 {

--- a/Source/UnitTests/Core/CMakeLists.txt
+++ b/Source/UnitTests/Core/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_dolphin_test(MMIOTest MMIOTest.cpp)
 add_dolphin_test(PageFaultTest PageFaultTest.cpp)
+add_dolphin_test(CoreTimingTest CoreTimingTest.cpp)

--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -1,0 +1,313 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <bitset>
+
+#include "Core/ConfigManager.h"
+#include "Core/Core.h"
+#include "Core/CoreTiming.h"
+#include "Core/PowerPC/PowerPC.h"
+
+// Numbers are chosen randomly to make sure the correct one is given.
+static constexpr std::array<u64, 5> CB_IDS{{42, 144, 93, 1026, UINT64_C(0xFFFF7FFFF7FFFF)}};
+static constexpr int MAX_SLICE_LENGTH = 20000;  // Copied from CoreTiming internals
+
+static std::bitset<CB_IDS.size()> s_callbacks_ran_flags;
+static u64 s_expected_callback = 0;
+static s64 s_lateness = 0;
+
+template <unsigned int IDX>
+void CallbackTemplate(u64 userdata, s64 lateness)
+{
+  static_assert(IDX < CB_IDS.size(), "IDX out of range");
+  s_callbacks_ran_flags.set(IDX);
+  EXPECT_EQ(CB_IDS[IDX], userdata);
+  if (s_expected_callback)  // In SharedSlot, we don't care about this
+    EXPECT_EQ(CB_IDS[IDX], s_expected_callback);
+  EXPECT_EQ(s_lateness, lateness);
+}
+
+class ScopeInit final
+{
+public:
+  ScopeInit()
+  {
+    Core::DeclareAsCPUThread();
+    SConfig::Init();
+    PowerPC::Init(PowerPC::CORE_INTERPRETER);
+    CoreTiming::Init();
+  }
+  ~ScopeInit()
+  {
+    CoreTiming::Shutdown();
+    PowerPC::Shutdown();
+    SConfig::Shutdown();
+    Core::UndeclareAsCPUThread();
+  }
+};
+
+void AdvanceAndCheck(u32 idx, int downcount, int expected_lateness = 0, int cpu_downcount = 0)
+{
+  s_callbacks_ran_flags = 0;
+  s_expected_callback = CB_IDS[idx];
+  s_lateness = expected_lateness;
+
+  PowerPC::ppcState.downcount = cpu_downcount;  // Pretend we executed X cycles of instructions.
+  CoreTiming::Advance();
+
+  EXPECT_EQ(decltype(s_callbacks_ran_flags)().set(idx), s_callbacks_ran_flags);
+  EXPECT_EQ(downcount, PowerPC::ppcState.downcount);
+}
+
+TEST(CoreTiming, BasicOrder)
+{
+  ScopeInit guard;
+
+  CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
+  CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
+  CoreTiming::EventType* cb_c = CoreTiming::RegisterEvent("callbackC", CallbackTemplate<2>);
+  CoreTiming::EventType* cb_d = CoreTiming::RegisterEvent("callbackD", CallbackTemplate<3>);
+  CoreTiming::EventType* cb_e = CoreTiming::RegisterEvent("callbackE", CallbackTemplate<4>);
+
+  // Enter slice 0
+  CoreTiming::Advance();
+
+  // D -> B -> C -> A -> E
+  CoreTiming::ScheduleEvent(1000, cb_a, CB_IDS[0]);
+  EXPECT_EQ(1000, PowerPC::ppcState.downcount);
+  CoreTiming::ScheduleEvent(500, cb_b, CB_IDS[1]);
+  EXPECT_EQ(500, PowerPC::ppcState.downcount);
+  CoreTiming::ScheduleEvent(800, cb_c, CB_IDS[2]);
+  EXPECT_EQ(500, PowerPC::ppcState.downcount);
+  CoreTiming::ScheduleEvent(100, cb_d, CB_IDS[3]);
+  EXPECT_EQ(100, PowerPC::ppcState.downcount);
+  CoreTiming::ScheduleEvent(1200, cb_e, CB_IDS[4]);
+  EXPECT_EQ(100, PowerPC::ppcState.downcount);
+
+  AdvanceAndCheck(3, 400);
+  AdvanceAndCheck(1, 300);
+  AdvanceAndCheck(2, 200);
+  AdvanceAndCheck(0, 200);
+  AdvanceAndCheck(4, MAX_SLICE_LENGTH);
+}
+
+TEST(CoreTiming, SharedSlot)
+{
+  ScopeInit guard;
+
+  CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
+  CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
+  CoreTiming::EventType* cb_c = CoreTiming::RegisterEvent("callbackC", CallbackTemplate<2>);
+  CoreTiming::EventType* cb_d = CoreTiming::RegisterEvent("callbackD", CallbackTemplate<3>);
+  CoreTiming::EventType* cb_e = CoreTiming::RegisterEvent("callbackE", CallbackTemplate<4>);
+
+  CoreTiming::ScheduleEvent(1000, cb_a, CB_IDS[0]);
+  CoreTiming::ScheduleEvent(1000, cb_b, CB_IDS[1]);
+  CoreTiming::ScheduleEvent(1000, cb_c, CB_IDS[2]);
+  CoreTiming::ScheduleEvent(1000, cb_d, CB_IDS[3]);
+  CoreTiming::ScheduleEvent(1000, cb_e, CB_IDS[4]);
+
+  // Enter slice 0
+  CoreTiming::Advance();
+  EXPECT_EQ(1000, PowerPC::ppcState.downcount);
+
+  s_callbacks_ran_flags = 0;
+  s_lateness = 0;
+  s_expected_callback = 0;
+  PowerPC::ppcState.downcount = 0;
+  CoreTiming::Advance();
+  EXPECT_EQ(MAX_SLICE_LENGTH, PowerPC::ppcState.downcount);
+  EXPECT_EQ(0x1FULL, s_callbacks_ran_flags.to_ullong());
+}
+
+TEST(CoreTiming, PredictableLateness)
+{
+  ScopeInit guard;
+
+  CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
+  CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
+
+  // Enter slice 0
+  CoreTiming::Advance();
+
+  CoreTiming::ScheduleEvent(100, cb_a, CB_IDS[0]);
+  CoreTiming::ScheduleEvent(200, cb_b, CB_IDS[1]);
+
+  AdvanceAndCheck(0, 90, 10, -10);  // (100 - 10)
+  AdvanceAndCheck(1, MAX_SLICE_LENGTH, 50, -50);
+}
+
+namespace ChainSchedulingTest
+{
+static int s_reschedules = 0;
+
+static void RescheduleCallback(u64 userdata, s64 lateness)
+{
+  --s_reschedules;
+  EXPECT_TRUE(s_reschedules >= 0);
+  EXPECT_EQ(s_lateness, lateness);
+
+  if (s_reschedules > 0)
+    CoreTiming::ScheduleEvent(1000, reinterpret_cast<CoreTiming::EventType*>(userdata), userdata);
+}
+}
+
+TEST(CoreTiming, ChainScheduling)
+{
+  using namespace ChainSchedulingTest;
+
+  ScopeInit guard;
+
+  CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
+  CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
+  CoreTiming::EventType* cb_c = CoreTiming::RegisterEvent("callbackC", CallbackTemplate<2>);
+  CoreTiming::EventType* cb_rs =
+      CoreTiming::RegisterEvent("callbackReschedule", RescheduleCallback);
+
+  // Enter slice 0
+  CoreTiming::Advance();
+
+  CoreTiming::ScheduleEvent(800, cb_a, CB_IDS[0]);
+  CoreTiming::ScheduleEvent(1000, cb_b, CB_IDS[1]);
+  CoreTiming::ScheduleEvent(2200, cb_c, CB_IDS[2]);
+  CoreTiming::ScheduleEvent(1000, cb_rs, reinterpret_cast<u64>(cb_rs));
+  EXPECT_EQ(800, PowerPC::ppcState.downcount);
+
+  s_reschedules = 3;
+  AdvanceAndCheck(0, 200);   // cb_a
+  AdvanceAndCheck(1, 1000);  // cb_b, cb_rs
+  EXPECT_EQ(2, s_reschedules);
+
+  PowerPC::ppcState.downcount = 0;
+  CoreTiming::Advance();  // cb_rs
+  EXPECT_EQ(1, s_reschedules);
+  EXPECT_EQ(200, PowerPC::ppcState.downcount);
+
+  AdvanceAndCheck(2, 800);  // cb_c
+
+  PowerPC::ppcState.downcount = 0;
+  CoreTiming::Advance();  // cb_rs
+  EXPECT_EQ(0, s_reschedules);
+  EXPECT_EQ(MAX_SLICE_LENGTH, PowerPC::ppcState.downcount);
+}
+
+namespace ScheduleIntoPastTest
+{
+static CoreTiming::EventType* s_cb_next = nullptr;
+
+static void ChainCallback(u64 userdata, s64 lateness)
+{
+  EXPECT_EQ(CB_IDS[0] + 1, userdata);
+  EXPECT_EQ(0, lateness);
+
+  CoreTiming::ScheduleEvent(-1000, s_cb_next, userdata - 1);
+}
+}
+
+// This can happen when scheduling from outside the CPU Thread.
+// Also, if the callback is very late, it may reschedule itself for the next period which
+// is also in the past.
+TEST(CoreTiming, ScheduleIntoPast)
+{
+  using namespace ScheduleIntoPastTest;
+
+  ScopeInit guard;
+
+  s_cb_next = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
+  CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
+  CoreTiming::EventType* cb_chain = CoreTiming::RegisterEvent("callbackChain", ChainCallback);
+
+  // Enter slice 0
+  CoreTiming::Advance();
+
+  CoreTiming::ScheduleEvent(1000, cb_chain, CB_IDS[0] + 1);
+  EXPECT_EQ(1000, PowerPC::ppcState.downcount);
+
+  AdvanceAndCheck(0, MAX_SLICE_LENGTH, 1000);  // Run cb_chain into late cb_a
+
+  // Schedule late from wrong thread
+  // The problem with scheduling CPU events from outside the CPU Thread is that g_global_timer
+  // is not reliable outside the CPU Thread. It's possible for the other thread to sample the
+  // global timer right before the timer is updated by Advance() then submit a new event using
+  // the stale value, i.e. effectively half-way through the previous slice.
+  // NOTE: We're only testing that the scheduler doesn't break, not whether this makes sense.
+  Core::UndeclareAsCPUThread();
+  CoreTiming::g_global_timer -= 1000;
+  CoreTiming::ScheduleEvent(0, cb_b, CB_IDS[1], CoreTiming::FromThread::NON_CPU);
+  CoreTiming::g_global_timer += 1000;
+  Core::DeclareAsCPUThread();
+  AdvanceAndCheck(1, MAX_SLICE_LENGTH, MAX_SLICE_LENGTH + 1000);
+}
+
+TEST(CoreTiming, Overclocking)
+{
+  ScopeInit guard;
+
+  CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
+  CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
+  CoreTiming::EventType* cb_c = CoreTiming::RegisterEvent("callbackC", CallbackTemplate<2>);
+  CoreTiming::EventType* cb_d = CoreTiming::RegisterEvent("callbackD", CallbackTemplate<3>);
+  CoreTiming::EventType* cb_e = CoreTiming::RegisterEvent("callbackE", CallbackTemplate<4>);
+
+  // Overclock
+  SConfig::GetInstance().m_OCEnable = true;
+  SConfig::GetInstance().m_OCFactor = 2.0;
+
+  // Enter slice 0
+  // Updates s_last_OC_factor.
+  CoreTiming::Advance();
+
+  CoreTiming::ScheduleEvent(100, cb_a, CB_IDS[0]);
+  CoreTiming::ScheduleEvent(200, cb_b, CB_IDS[1]);
+  CoreTiming::ScheduleEvent(400, cb_c, CB_IDS[2]);
+  CoreTiming::ScheduleEvent(800, cb_d, CB_IDS[3]);
+  CoreTiming::ScheduleEvent(1600, cb_e, CB_IDS[4]);
+  EXPECT_EQ(200, PowerPC::ppcState.downcount);
+
+  AdvanceAndCheck(0, 200);   // (200 - 100) * 2
+  AdvanceAndCheck(1, 400);   // (400 - 200) * 2
+  AdvanceAndCheck(2, 800);   // (800 - 400) * 2
+  AdvanceAndCheck(3, 1600);  // (1600 - 800) * 2
+  AdvanceAndCheck(4, MAX_SLICE_LENGTH * 2);
+
+  // Underclock
+  SConfig::GetInstance().m_OCFactor = 0.5;
+  CoreTiming::Advance();
+
+  CoreTiming::ScheduleEvent(100, cb_a, CB_IDS[0]);
+  CoreTiming::ScheduleEvent(200, cb_b, CB_IDS[1]);
+  CoreTiming::ScheduleEvent(400, cb_c, CB_IDS[2]);
+  CoreTiming::ScheduleEvent(800, cb_d, CB_IDS[3]);
+  CoreTiming::ScheduleEvent(1600, cb_e, CB_IDS[4]);
+  EXPECT_EQ(50, PowerPC::ppcState.downcount);
+
+  AdvanceAndCheck(0, 50);   // (200 - 100) / 2
+  AdvanceAndCheck(1, 100);  // (400 - 200) / 2
+  AdvanceAndCheck(2, 200);  // (800 - 400) / 2
+  AdvanceAndCheck(3, 400);  // (1600 - 800) / 2
+  AdvanceAndCheck(4, MAX_SLICE_LENGTH / 2);
+
+  // Try switching the clock mid-emulation
+  SConfig::GetInstance().m_OCFactor = 1.0;
+  CoreTiming::Advance();
+
+  CoreTiming::ScheduleEvent(100, cb_a, CB_IDS[0]);
+  CoreTiming::ScheduleEvent(200, cb_b, CB_IDS[1]);
+  CoreTiming::ScheduleEvent(400, cb_c, CB_IDS[2]);
+  CoreTiming::ScheduleEvent(800, cb_d, CB_IDS[3]);
+  CoreTiming::ScheduleEvent(1600, cb_e, CB_IDS[4]);
+  EXPECT_EQ(100, PowerPC::ppcState.downcount);
+
+  AdvanceAndCheck(0, 100);  // (200 - 100)
+  SConfig::GetInstance().m_OCFactor = 2.0;
+  AdvanceAndCheck(1, 400);  // (400 - 200) * 2
+  AdvanceAndCheck(2, 800);  // (800 - 400) * 2
+  SConfig::GetInstance().m_OCFactor = 0.1f;
+  AdvanceAndCheck(3, 80);  // (1600 - 800) / 10
+  SConfig::GetInstance().m_OCFactor = 1.0;
+  AdvanceAndCheck(4, MAX_SLICE_LENGTH);
+}

--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -241,6 +241,13 @@ TEST(CoreTiming, ScheduleIntoPast)
   CoreTiming::g_global_timer += 1000;
   Core::DeclareAsCPUThread();
   AdvanceAndCheck(1, MAX_SLICE_LENGTH, MAX_SLICE_LENGTH + 1000);
+
+  // Schedule directly into the past from the CPU.
+  // This shouldn't happen in practice, but it's best if we don't mess up the slice length and
+  // downcount if we do.
+  CoreTiming::ScheduleEvent(-1000, s_cb_next, CB_IDS[0]);
+  EXPECT_EQ(0, PowerPC::ppcState.downcount);
+  AdvanceAndCheck(0, MAX_SLICE_LENGTH, 1000);
 }
 
 TEST(CoreTiming, Overclocking)


### PR DESCRIPTION
I've been poking around in the core and noticed that CoreTiming could use some tidying.

Changes:
* Convert camel case to snake case, add `s_` prefix to statics
* Replace `LinkedListItem` with a slightly modified `std::priority_queue`
* Made it more sensitive to overwriting existing callbacks
* Change the event key from `int` to `EventType*` (type safety)
* Added some UnitTests for CoreTiming.

I haven't measured any significant performance differences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4168)
<!-- Reviewable:end -->
