### PR TITLE
DVDInterface: Remove unused Triforce buffer.

### DIFF
--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -244,9 +244,6 @@ static int s_dtk = 0;
 static u64 s_last_read_offset;
 static u64 s_last_read_time;
 
-// GC-AM only
-static unsigned char s_media_buffer[0x40];
-
 static int s_eject_disc;
 static int s_insert_disc;
 


### PR DESCRIPTION
Looks like we forgot to remove a global variable here. It's not actually used anywhere, so compilers are warning about an unused variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4169)
<!-- Reviewable:end -->
