### PR TITLE
VertexShaderManager: Explicitly use floating-point variant of abs.

### DIFF
--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -398,7 +398,7 @@ void VertexShaderManager::SetConstants()
       // where the console also uses reversed depth with the same accuracy. We need
       // to make sure the depth range is positive here and then reverse the depth in
       // the backend viewport.
-      constants.pixelcentercorrection[2] = abs(xfmem.viewport.zRange) / 16777215.0f;
+      constants.pixelcentercorrection[2] = fabs(xfmem.viewport.zRange) / 16777215.0f;
       if (xfmem.viewport.zRange < 0.0f)
         constants.pixelcentercorrection[3] = xfmem.viewport.farZ / 16777215.0f;
       else


### PR DESCRIPTION
Some compilers don't have an automatic abs() overload for floats. Doesn't really matter if they use the integer variant here, but it's better to be explicit about the fact that we're using floats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4170)
<!-- Reviewable:end -->
