### PR TITLE
PixelEngine: Add missing static specifier for `s_token_finish_mutex`.

### DIFF
--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -90,7 +90,7 @@ static UPEAlphaModeConfReg m_AlphaModeConf;
 static UPEAlphaReadReg m_AlphaRead;
 static UPECtrlReg m_Control;
 
-std::mutex s_token_finish_mutex;
+static std::mutex s_token_finish_mutex;
 static u16 s_token;
 static u16 s_token_pending;
 static bool s_token_interrupt_pending;


### PR DESCRIPTION
Another compiler warning here, I believe this variable should be static.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4171)
<!-- Reviewable:end -->
