### PR TITLE
VideoSoftware: Fix unsigned overflow bug in fog

### DIFF
--- a/Source/Core/VideoBackends/Software/Tev.cpp
+++ b/Source/Core/VideoBackends/Software/Tev.cpp
@@ -769,7 +769,8 @@ void Tev::Draw()
       // - scaling of the "k" coefficient isn't clear either.
 
       // First, calculate the offset from the viewport center (normalized to 0..1)
-      float offset = (Position[0] - (bpmem.fogRange.Base.Center - 342)) / (float)xfmem.viewport.wd;
+      float offset = (Position[0] - (static_cast<s32>(bpmem.fogRange.Base.Center) - 342)) /
+                     static_cast<float>(xfmem.viewport.wd);
 
       // Based on that, choose the index such that points which are far away from the z-axis use the
       // 10th "k" value and such that central points use the first value.


### PR DESCRIPTION
Was causing fog errors on the left half of the screen.

Only appeared to affect visual studio builds, GCC did the correct thing.

## Before:

![gzle01-26](https://cloud.githubusercontent.com/assets/138484/18186167/652c8d7e-70f5-11e6-9558-954d0b83f644.png)

## After:

![gzle01-36](https://cloud.githubusercontent.com/assets/138484/18186391/b13227d2-70f6-11e6-995e-1e7af2f628ba.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4172)
<!-- Reviewable:end -->
