### PR TITLE
OGL: Use inversed depth values.

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -233,11 +233,11 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
     glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, m_efbDepth, 0, i);
   }
 
-  // EFB framebuffer is currently bound, make sure to clear its alpha value to 1.f
+  // EFB framebuffer is currently bound, make sure to clear its alpha value to 0.f
   glViewport(0, 0, m_targetWidth, m_targetHeight);
   glScissor(0, 0, m_targetWidth, m_targetHeight);
   glClearColor(0.f, 0.f, 0.f, 1.f);
-  glClearDepthf(1.0f);
+  glClearDepthf(0.0f);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
   // reinterpret pixel format
@@ -381,7 +381,7 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
                        "vec2(1.0, -1.0), 0.0, 1.0);\n"
                        "	gl_PointSize = %d.0 / 640.0;\n"
                        "	v_c = color0.bgra;\n"
-                       "	v_z = float(color1 & 0xFFFFFF) / 16777216.0;\n"
+                       "	v_z = 1.0 - float(color1 & 0xFFFFFF) / 16777216.0;\n"
                        "}\n",
                        m_targetWidth),
 

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -345,7 +345,7 @@ void TextureCache::CompileShaders()
       "\n"
       "void main(){\n"
       "	vec4 texcol = texture(samp9, vec3(f_uv0.xy, %s));\n"
-      "	int depth = int(texcol.x * 16777216.0);\n"
+      "	int depth = int((1.0 - texcol.x) * 16777216.0);\n"
 
       // Convert to Z24 format
       "	ivec4 workspace;\n"

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -728,10 +728,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, APIType ApiType,
   }
   else
   {
-    if (ApiType == APIType::D3D)
-      out.Write("\tint zCoord = int((1.0 - rawpos.z) * 16777216.0);\n");
-    else
-      out.Write("\tint zCoord = int(rawpos.z * 16777216.0);\n");
+    out.Write("\tint zCoord = int((1.0 - rawpos.z) * 16777216.0);\n");
   }
   out.Write("\tzCoord = clamp(zCoord, 0, 0xFFFFFF);\n");
 
@@ -742,10 +739,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, APIType ApiType,
   // Note: z-textures are not written to depth buffer if early depth test is used
   if (uid_data->per_pixel_depth && uid_data->early_ztest)
   {
-    if (ApiType == APIType::D3D)
-      out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
-    else
-      out.Write("\tdepth = float(zCoord) / 16777216.0;\n");
+    out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
   }
 
   // Note: depth texture output is only written to depth buffer if late depth test is used
@@ -763,10 +757,7 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, APIType ApiType,
 
   if (uid_data->per_pixel_depth && uid_data->late_ztest)
   {
-    if (ApiType == APIType::D3D)
-      out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
-    else
-      out.Write("\tdepth = float(zCoord) / 16777216.0;\n");
+    out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
   }
 
   if (dstAlphaMode == DSTALPHA_ALPHA_PASS)

--- a/Source/Core/VideoCommon/TextureConversionShader.cpp
+++ b/Source/Core/VideoCommon/TextureConversionShader.cpp
@@ -155,11 +155,11 @@ static void WriteSampleColor(char*& p, const char* colorComp, const char* dest, 
   {
     WRITE(p, "  %s = Tex0.Sample(samp0, float3(uv0 + float2(%d, 0) * sample_offset, 0.0)).%s;\n",
           dest, xoffset, colorComp);
-
-    // Handle D3D depth inversion.
-    if (depth)
-      WRITE(p, "  %s = 1.0 - %s;\n", dest, dest);
   }
+
+  // Handle depth inversion.
+  if (depth)
+    WRITE(p, "  %s = 1.0 - %s;\n", dest, dest);
 }
 
 static void WriteColorToIntensity(char*& p, const char* src, const char* dest)


### PR DESCRIPTION
This is not strictly necessary on OGL, but it is more consistent with the D3D backend and allows us to use a regular depth range in most cases. There's also potentially more accuracy as we get rid of a floating-point addition in the perspective divide.

This is especially useful for Vulkan right now, as not all drivers seem to support reversed depth ranges yet.

Note: Due to the depth buffer values being inverted this PR breaks the first frame on all FIFOs in FIFOCI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4174)
<!-- Reviewable:end -->
