### PR TITLE
[WIP] VideoCommon: Add support for the RGBA6 source format for EFB copies.

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -103,6 +103,12 @@ const char color_matrix_program_code[] = {"sampler samp0 : register(s0);\n"
                                           "in float4 pos : SV_Position,\n"
                                           "in float3 uv0 : TEXCOORD0){\n"
                                           "float4 texcol = Tex0.Sample(samp0,uv0);\n"
+                                          "int alpha = int(texcol.a * 63.0);\n"
+
+                                          // Truncate alpha to 6-bit
+                                          "alpha = (alpha << 2) | (alpha >> 4);\n"
+                                          "texcol.a = alpha / 255.0;\n"
+
                                           "texcol = round(texcol * cColMatrix[5])*cColMatrix[6];\n"
                                           "ocol0 = "
                                           "float4(dot(texcol,cColMatrix[0]),dot(texcol,cColMatrix["
@@ -125,6 +131,12 @@ const char color_matrix_program_code_msaa[] = {
     "for(int i = 0; i < SAMPLES; ++i)\n"
     "	texcol += Tex0.Load(int3(uv0.x*(width), uv0.y*(height), uv0.z), i);\n"
     "texcol /= SAMPLES;\n"
+    "int alpha = int(texcol.a * 63.0);\n"
+
+    // Truncate alpha to 6-bit
+    "alpha = (alpha << 2) | (alpha >> 4);\n"
+    "texcol.a = alpha / 255.0;\n"
+
     "texcol = round(texcol * cColMatrix[5])*cColMatrix[6];\n"
     "ocol0 = "
     "float4(dot(texcol,cColMatrix[0]),dot(texcol,cColMatrix[1]),dot(texcol,cColMatrix[2]),dot("

--- a/Source/Core/VideoBackends/D3D12/StaticShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/StaticShaderCache.cpp
@@ -131,6 +131,12 @@ static constexpr const char s_color_matrix_program_hlsl[] = {
     "in float4 pos : SV_Position,\n"
     "in float3 uv0 : TEXCOORD0){\n"
     "float4 texcol = Tex0.Sample(samp0,uv0);\n"
+    "int alpha = int(texcol.a * 63.0);\n"
+
+    // Truncate alpha to 6-bit
+    "alpha = (alpha << 2) | (alpha >> 4);\n"
+    "texcol.a = alpha / 255.0;\n"
+
     "texcol = round(texcol * cColMatrix[5])*cColMatrix[6];\n"
     "ocol0 = "
     "float4(dot(texcol,cColMatrix[0]),dot(texcol,cColMatrix[1]),dot(texcol,cColMatrix[2]),dot("
@@ -152,6 +158,12 @@ static constexpr const char s_color_matrix_program_msaa_hlsl[] = {
     "for(int i = 0; i < SAMPLES; ++i)\n"
     "	texcol += Tex0.Load(int3(uv0.x*(width), uv0.y*(height), uv0.z), i);\n"
     "texcol /= SAMPLES;\n"
+    "int alpha = int(texcol.a * 63.0);\n"
+
+    // Truncate alpha to 6-bit
+    "alpha = (alpha << 2) | (alpha >> 4);\n"
+    "texcol.a = alpha / 255.0;\n"
+
     "texcol = round(texcol * cColMatrix[5])*cColMatrix[6];\n"
     "ocol0 = "
     "float4(dot(texcol,cColMatrix[0]),dot(texcol,cColMatrix[1]),dot(texcol,cColMatrix[2]),dot("

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -333,6 +333,12 @@ void TextureCache::CompileShaders()
       "\n"
       "void main(){\n"
       "	vec4 texcol = texture(samp9, f_uv0);\n"
+      " int alpha = int(texcol.a * 63.0);\n"
+
+      // Truncate alpha to 6-bit
+      " alpha = (alpha << 2) | (alpha >> 4);\n"
+      " texcol.a = alpha / 255.0;\n"
+
       "	texcol = round(texcol * colmat[5]) * colmat[6];\n"
       "	ocol0 = texcol * mat4(colmat[0], colmat[1], colmat[2], colmat[3]) + colmat[4];\n"
       "}\n";


### PR DESCRIPTION
Some games like Ed Edd n Eddy rely on the limited precision provided by the different EFB formats. This PR aims to support the RGBA6 format, which is the only other format (besides RGB8) supported by the SW backend.

In the future support for other formats should be added. Currently I am still working on adding support for this format the EFB2RAM copies and the D3D backends.

This change will reduce color precision in many games, so I will likely provide an option to ignore the source format and only enable it in games that need it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4175)
<!-- Reviewable:end -->
