### PR TITLE
Movie: Fix null pointer dereference.

### DIFF
--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -772,15 +772,15 @@ static void SetWiiInputDisplayString(int remoteID, u8* const data,
       display_str += " 2";
     if (buttons.home)
       display_str += " HOME";
-  }
 
-  if (accelData)
-  {
-    wm_accel* dt = (wm_accel*)accelData;
-    display_str +=
-        StringFromFormat(" ACC:%d,%d,%d", dt->x << 2 | ((wm_buttons*)coreData)->acc_x_lsb,
-                         dt->y << 2 | ((wm_buttons*)coreData)->acc_y_lsb << 1,
-                         dt->z << 2 | ((wm_buttons*)coreData)->acc_z_lsb << 1);
+    // A few bits of accelData are actually inside the coreData struct.
+    if (accelData)
+    {
+      wm_accel* dt = (wm_accel*)accelData;
+      display_str += StringFromFormat(" ACC:%d,%d,%d", dt->x << 2 | buttons.acc_x_lsb,
+                                      dt->y << 2 | buttons.acc_y_lsb << 1,
+                                      dt->z << 2 | buttons.acc_z_lsb << 1);
+    }
   }
 
   if (irData)


### PR DESCRIPTION
Part of the acceleration data is packed in with the buttons. 

We always have button data when we have acceleration data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4176)
<!-- Reviewable:end -->
