### PR TITLE
[GameINI] Set MSAA and MaxAnisotropy to 0 for Sonic Heroes

### DIFF
--- a/Data/Sys/GameSettings/G9S.ini
+++ b/Data/Sys/GameSettings/G9S.ini
@@ -20,4 +20,5 @@ EmulationIssues = Use directx11 backend with efb scale set at 1x to deal with bl
 [Video_Settings]
 SafeTextureCacheColorSamples = 0
 EFBScale = 2
-
+MSAA = 0
+MaxAnisotropy = 0


### PR DESCRIPTION
Makes the game more playable than the current config file as of 5th Sep 2016.

Set MSAA and MaxAnisotropy to 0 to remove odd black shadows, see here https://wiki.dolphin-emu.org/index.php?title=Sonic_Heroes#Graphical_Glitches_with_IR.3E1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4181)
<!-- Reviewable:end -->
