### PR TITLE
VertexShaderGen: Clamp the q=0 case before the postmatrix.

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -646,9 +646,13 @@ ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, APIType ApiType,
     {
       out.Write("\tint2 fixpoint_uv%d = itrunc(", i);
       // optional perspective divides
+      // When q is 0, the GameCube appears to have a special case
+      // This can be seen in devkitPro's neheGX Lesson08 example for Wii
+      // Makes differences in Rogue Squadron 3 (Hoth sky) and The Last Story (shadow culling)
+      // TODO: check if this only affects XF_TEXGEN_REGULAR
       if (((uid_data->texMtxInfo_n_projection >> i) & 1) == XF_TEXPROJ_STQ)
       {
-        out.Write("(uv%d.z == 0.0 ? uv%d.xy : uv%d.xy / uv%d.z)", i, i, i, i);
+        out.Write("(uv%d.z == 0.0 ? uv%d.xy / 2.0 : uv%d.xy / uv%d.z)", i, i, i, i);
       }
       else
       {


### PR DESCRIPTION
Also set the q=2 in the vertex shader, no need anymore for the special case in the pixel shader.

This fixes the skybox fadeout in Rogue Squadron 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4182)
<!-- Reviewable:end -->
