### PR TITLE
WII_IPC_HLE: Fix Reinit

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -119,9 +119,9 @@ std::shared_ptr<T> AddDevice(const char* deviceName)
   return device;
 }
 
-void Init()
+void Reinit()
 {
-  _dbg_assert_msg_(WII_IPC_HLE, g_DeviceMap.empty(), "DeviceMap isn't empty on init");
+  _assert_msg_(WII_IPC_HLE, g_DeviceMap.empty(), "Reinit called while already initialized");
   CWII_IPC_HLE_Device_es::m_ContentFile = "";
 
   num_devices = 0;
@@ -156,6 +156,11 @@ void Init()
 #endif
   AddDevice<CWII_IPC_HLE_Device_stub>("/dev/usb/oh1");
   AddDevice<IWII_IPC_HLE_Device>("_Unimplemented_Device_");
+}
+
+void Init()
+{
+  Reinit();
 
   event_enqueue = CoreTiming::RegisterEvent("IPCEvent", EnqueueEvent);
   event_sdio_notify = CoreTiming::RegisterEvent("SDIO_EventNotify", SDIO_EventNotify_CPUThread);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -45,6 +45,9 @@ namespace WII_IPC_HLE_Interface
 // Init
 void Init();
 
+// Needs to be called after Reset(true) to recreate the device tree
+void Reinit();
+
 // Shutdown
 void Shutdown();
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -1000,7 +1000,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
         wiiMoteConnected[i] = s_Usb->m_WiiMotes[i].IsConnected();
 
       WII_IPC_HLE_Interface::Reset(true);
-      WII_IPC_HLE_Interface::Init();
+      WII_IPC_HLE_Interface::Reinit();
       s_Usb = GetUsbPointer();
       for (unsigned int i = 0; i < s_Usb->m_WiiMotes.size(); i++)
       {


### PR DESCRIPTION
ES_Launch kills all the WII_IPC_HLE internal state then tries to re-initialize the system. This doesn't work (it never worked, but it works even less now) as it triggers the assertions I added to CoreTiming.

Split Init into 2 stages, the part which should only ever be done once and the part that's needed after the "hard reset".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4184)
<!-- Reviewable:end -->
