### PR TITLE
Star Wars: The Clone Wars INI

### DIFF
--- a/Data/Sys/GameSettings/GSX.ini
+++ b/Data/Sys/GameSettings/GSX.ini
@@ -1,0 +1,26 @@
+# GSXE64, GSXP64, GSXJ64 - Star Wars: The Clone Wars
+
+[Core]
+# Values set here will override the main Dolphin settings.
+MMU = 1
+# LLE audio enabled by default for a listenable output
+DSPHLE = False
+
+[DSP]
+# Ensure the LLE recompiler gets selected and not interpreter.
+EnableJIT = True 
+
+[EmuState]
+# The Emulation State. 1 is worst, 5 is best, 0 is not set.
+EmulationIssues = Needs LLE audio for proper sound.
+EmulationStateId = 4
+
+[OnLoad]
+# Add memory patches to be loaded once on boot here.
+
+[OnFrame]
+# Add memory patches to be applied every frame here.
+
+[ActionReplay]
+# Add action replay cheats here.
+


### PR DESCRIPTION
This is the necessary settings to make Star Wars: The Clone Wars boot once Dynamic BATs is merged.

Note:  DSP-LLE being required may not be permanent and seems to be a regression of the JIT Slice changes.  As such, on interpreter DSP-HLE can be used.  To prevent confusion, I decided to force DSP-LLE regardless so that people playing the game would just be able to boot it without issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4185)
<!-- Reviewable:end -->
