### PR TITLE
Fix registerView updates issues when stepping over or stepping out

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -251,7 +251,6 @@ void SingleStep()
 
 void RunLoop()
 {
-  Host_UpdateDisasmDialog();
   s_cpu_core_base->Run();
   Host_UpdateDisasmDialog();
 }

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -365,6 +365,7 @@ void CCodeWindow::StepOut()
 
     JumpToAddress(PC);
     Update();
+    Host_UpdateDisasmDialog();
 
     UpdateButtonStates();
     // Update all toolbars in the aui manager


### PR DESCRIPTION
For step over, it was updating twice which actually made the red display on the register view (when a register changes since) malfunction.  Since it doesn't seem to be usefull to update before AND after the run, the one before the run was removed.

For step out, well, because there was no chances given for the thread to run as it is single stepping all the time, I only added a call to update after it was done.

Before merge, I just want to know, is the call to host_updateDisasmDialog appropriate in codeWindow?  I was wondering if I shoudl either create an event or just manually triggers the notify updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4186)
<!-- Reviewable:end -->
