### PR TITLE
CoreTiming: Ensure FIFO Order for events in the same time slot

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -70,7 +70,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 57;
+static const u32 STATE_VERSION = 58;
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
There are various parts of Dolphin that do things like
```cpp
CoreTiming::ScheduleEvent(0, ev_a);
CoreTiming::ScheduleEvent(0, ev_b);
```
Or
```cpp
CoreTiming::ScheduleEvent(0, my_event);
SomeFunction();
// SomeFunction2();
//  SomeFunction3();
//   CoreTiming::ScheduleEvent(0, next_event_after_my_event);
```

The min-heap timer queue in CoreTiming doesn't guarantee any particular order when this happens so events effectively get dispatched pseudo-randomly. The `WII_IPC` systems particularly seem to rely on queuing multiple events with the same cycles_in_future values in a FIFO order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4190)
<!-- Reviewable:end -->
