### PR TITLE
IPC_HLE: Fix warnings about missing override

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
@@ -14,15 +14,15 @@ public:
 
   ~CWII_IPC_HLE_Device_usb_ven() override;
 
-  virtual IPCCommandResult Open(u32 _CommandAddress, u32 _Mode);
-  virtual IPCCommandResult Close(u32 _CommandAddress, bool _bForce);
+  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
-  virtual IPCCommandResult IOCtlV(u32 _CommandAddress);
-  virtual IPCCommandResult IOCtl(u32 _CommandAddress);
+  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IPCCommandResult IOCtl(u32 _CommandAddress) override;
 
-  virtual u32 Update();
+  u32 Update() override;
 
-  void DoState(PointerWrap& p);
+  void DoState(PointerWrap& p) override;
 
 private:
   enum USBIOCtl


### PR DESCRIPTION
clang warns about missing overrides: 'FunctionName' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]

It also seems that `override` should be used instead of `virtual` here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4193)
<!-- Reviewable:end -->
