### PR TITLE
PixelShaderGen: Add support for RGBA6 EFB format truncation.

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -275,6 +275,10 @@ static wxString validation_layer_desc =
 static wxString backend_multithreading_desc =
     wxTRANSLATE("Enables multi-threading in the video backend, which may result in performance "
                 "gains in some scenarios.\n\nIf unsure, leave this unchecked.");
+static wxString true_color_desc =
+    wxTRANSLATE("Forces the game to render the RGB color channels in 24-bit, thereby increasing "
+                "quality by reducing color banding.\nIt has no impact on performance and causes "
+                "few graphical issues.\n\n\nIf unsure, leave this unchecked.");
 
 #if !defined(__APPLE__)
 // Search for available resolutions - TODO: Move to Common?
@@ -618,6 +622,8 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
                                vconfig.bWidescreenHack));
     cb_szr->Add(CreateCheckBox(page_enh, _("Disable Fog"), wxGetTranslation(disable_fog_desc),
                                vconfig.bDisableFog));
+    cb_szr->Add(CreateCheckBox(page_enh, _("Force True Color"), wxGetTranslation(true_color_desc),
+                               vconfig.bForceTrueColor));
     szr_enh->Add(cb_szr, wxGBPosition(row, 0), wxGBSpan(1, 3));
     row += 1;
 

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -622,7 +622,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
                                vconfig.bWidescreenHack));
     cb_szr->Add(CreateCheckBox(page_enh, _("Disable Fog"), wxGetTranslation(disable_fog_desc),
                                vconfig.bDisableFog));
-    cb_szr->Add(CreateCheckBox(page_enh, _("Force True Color"), wxGetTranslation(true_color_desc),
+    cb_szr->Add(CreateCheckBox(page_enh, _("Force 24-bit Color"), wxGetTranslation(true_color_desc),
                                vconfig.bForceTrueColor));
     szr_enh->Add(cb_szr, wxGBPosition(row, 0), wxGBSpan(1, 3));
     row += 1;

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -278,7 +278,7 @@ static wxString backend_multithreading_desc =
 static wxString true_color_desc =
     wxTRANSLATE("Forces the game to render the RGB color channels in 24-bit, thereby increasing "
                 "quality by reducing color banding.\nIt has no impact on performance and causes "
-                "few graphical issues.\n\n\nIf unsure, leave this unchecked.");
+                "few graphical issues.\n\n\nIf unsure, leave this checked.");
 
 #if !defined(__APPLE__)
 // Search for available resolutions - TODO: Move to Common?

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -380,7 +380,7 @@ ID3D11BlendState* StateCache::Get(BlendState state)
   blenddc.RenderTarget[0].BlendOpAlpha = state.blend_op;
 
   if (blenddc.RenderTarget[0].SrcBlend == D3D11_BLEND_SRC_COLOR)
-    blenddc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_SRC_ALPHA;
+    blenddc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_SRC1_ALPHA;
   else if (blenddc.RenderTarget[0].SrcBlend == D3D11_BLEND_INV_SRC_COLOR)
     blenddc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
   else if (blenddc.RenderTarget[0].SrcBlend == D3D11_BLEND_DEST_COLOR)
@@ -391,7 +391,7 @@ ID3D11BlendState* StateCache::Get(BlendState state)
     blenddc.RenderTarget[0].SrcBlendAlpha = blenddc.RenderTarget[0].SrcBlend;
 
   if (blenddc.RenderTarget[0].DestBlend == D3D11_BLEND_SRC_COLOR)
-    blenddc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_SRC_ALPHA;
+    blenddc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_SRC1_ALPHA;
   else if (blenddc.RenderTarget[0].DestBlend == D3D11_BLEND_INV_SRC_COLOR)
     blenddc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
   else if (blenddc.RenderTarget[0].DestBlend == D3D11_BLEND_DEST_COLOR)
@@ -403,18 +403,6 @@ ID3D11BlendState* StateCache::Get(BlendState state)
 
   if (state.use_dst_alpha)
   {
-    // Colors should blend against SRC1_ALPHA
-    if (blenddc.RenderTarget[0].SrcBlend == D3D11_BLEND_SRC_ALPHA)
-      blenddc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC1_ALPHA;
-    else if (blenddc.RenderTarget[0].SrcBlend == D3D11_BLEND_INV_SRC_ALPHA)
-      blenddc.RenderTarget[0].SrcBlend = D3D11_BLEND_INV_SRC1_ALPHA;
-
-    // Colors should blend against SRC1_ALPHA
-    if (blenddc.RenderTarget[0].DestBlend == D3D11_BLEND_SRC_ALPHA)
-      blenddc.RenderTarget[0].DestBlend = D3D11_BLEND_SRC1_ALPHA;
-    else if (blenddc.RenderTarget[0].DestBlend == D3D11_BLEND_INV_SRC_ALPHA)
-      blenddc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC1_ALPHA;
-
     blenddc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
     blenddc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
     blenddc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -675,8 +675,8 @@ void Renderer::SetBlendMode(bool forceUpdate)
       D3D11_BLEND_ONE,
       D3D11_BLEND_DEST_COLOR,
       D3D11_BLEND_INV_DEST_COLOR,
-      D3D11_BLEND_SRC_ALPHA,
-      D3D11_BLEND_INV_SRC_ALPHA,  // NOTE: Use SRC1_ALPHA if dst alpha is enabled!
+      D3D11_BLEND_SRC1_ALPHA,
+      D3D11_BLEND_INV_SRC1_ALPHA,
       (target_has_alpha) ? D3D11_BLEND_DEST_ALPHA : D3D11_BLEND_ONE,
       (target_has_alpha) ? D3D11_BLEND_INV_DEST_ALPHA : D3D11_BLEND_ZERO};
   const D3D11_BLEND d3dDestFactors[8] = {
@@ -684,8 +684,8 @@ void Renderer::SetBlendMode(bool forceUpdate)
       D3D11_BLEND_ONE,
       D3D11_BLEND_SRC_COLOR,
       D3D11_BLEND_INV_SRC_COLOR,
-      D3D11_BLEND_SRC_ALPHA,
-      D3D11_BLEND_INV_SRC_ALPHA,  // NOTE: Use SRC1_ALPHA if dst alpha is enabled!
+      D3D11_BLEND_SRC1_ALPHA,
+      D3D11_BLEND_INV_SRC1_ALPHA,
       (target_has_alpha) ? D3D11_BLEND_DEST_ALPHA : D3D11_BLEND_ONE,
       (target_has_alpha) ? D3D11_BLEND_INV_DEST_ALPHA : D3D11_BLEND_ZERO};
 

--- a/Source/Core/VideoBackends/D3D12/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DState.cpp
@@ -301,18 +301,6 @@ D3D12_BLEND_DESC StateCache::GetDesc12(BlendState state)
 
   if (state.use_dst_alpha)
   {
-    // Colors should blend against SRC1_ALPHA
-    if (blenddc.RenderTarget[0].SrcBlend == D3D12_BLEND_SRC_ALPHA)
-      blenddc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC1_ALPHA;
-    else if (blenddc.RenderTarget[0].SrcBlend == D3D12_BLEND_INV_SRC_ALPHA)
-      blenddc.RenderTarget[0].SrcBlend = D3D12_BLEND_INV_SRC1_ALPHA;
-
-    // Colors should blend against SRC1_ALPHA
-    if (blenddc.RenderTarget[0].DestBlend == D3D12_BLEND_SRC_ALPHA)
-      blenddc.RenderTarget[0].DestBlend = D3D12_BLEND_SRC1_ALPHA;
-    else if (blenddc.RenderTarget[0].DestBlend == D3D12_BLEND_INV_SRC_ALPHA)
-      blenddc.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC1_ALPHA;
-
     blenddc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
     blenddc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
     blenddc.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -592,8 +592,8 @@ void Renderer::SetBlendMode(bool force_update)
       D3D12_BLEND_ONE,
       D3D12_BLEND_DEST_COLOR,
       D3D12_BLEND_INV_DEST_COLOR,
-      D3D12_BLEND_SRC_ALPHA,
-      D3D12_BLEND_INV_SRC_ALPHA,  // NOTE: Use SRC1_ALPHA if dst alpha is enabled!
+      D3D12_BLEND_SRC1_ALPHA,
+      D3D12_BLEND_INV_SRC1_ALPHA,
       (target_has_alpha) ? D3D12_BLEND_DEST_ALPHA : D3D12_BLEND_ONE,
       (target_has_alpha) ? D3D12_BLEND_INV_DEST_ALPHA : D3D12_BLEND_ZERO};
   const D3D12_BLEND d3d_dst_factors[8] = {
@@ -601,8 +601,8 @@ void Renderer::SetBlendMode(bool force_update)
       D3D12_BLEND_ONE,
       D3D12_BLEND_SRC_COLOR,
       D3D12_BLEND_INV_SRC_COLOR,
-      D3D12_BLEND_SRC_ALPHA,
-      D3D12_BLEND_INV_SRC_ALPHA,  // NOTE: Use SRC1_ALPHA if dst alpha is enabled!
+      D3D12_BLEND_SRC1_ALPHA,
+      D3D12_BLEND_INV_SRC1_ALPHA,
       (target_has_alpha) ? D3D12_BLEND_DEST_ALPHA : D3D12_BLEND_ONE,
       (target_has_alpha) ? D3D12_BLEND_INV_DEST_ALPHA : D3D12_BLEND_ZERO};
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1241,7 +1241,7 @@ void Renderer::SetBlendMode(bool forceUpdate)
   bool target_has_alpha = bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24;
 
   bool useDstAlpha = bpmem.dstalpha.enable && bpmem.blendmode.alphaupdate && target_has_alpha;
-  bool useDualSource = useDstAlpha && g_ActiveConfig.backend_info.bSupportsDualSourceBlend;
+  bool useDualSource = g_ActiveConfig.backend_info.bSupportsDualSourceBlend;
 
   const GLenum glSrcFactors[8] = {
       GL_ZERO,
@@ -1269,7 +1269,7 @@ void Renderer::SetBlendMode(bool forceUpdate)
   // 3-5 - srcRGB function
   // 6-8 - dstRGB function
 
-  u32 newval = useDualSource << 1;
+  u32 newval = useDstAlpha << 1;
   newval |= bpmem.blendmode.subtract << 2;
 
   if (bpmem.blendmode.subtract)
@@ -1295,7 +1295,7 @@ void Renderer::SetBlendMode(bool forceUpdate)
   {
     // subtract enable change
     GLenum equation = newval & 4 ? GL_FUNC_REVERSE_SUBTRACT : GL_FUNC_ADD;
-    GLenum equationAlpha = useDualSource ? GL_FUNC_ADD : equation;
+    GLenum equationAlpha = useDstAlpha ? GL_FUNC_ADD : equation;
 
     glBlendEquationSeparate(equation, equationAlpha);
   }
@@ -1308,7 +1308,7 @@ void Renderer::SetBlendMode(bool forceUpdate)
     GLenum dstFactor = glDestFactors[dstidx];
 
     // adjust alpha factors
-    if (useDualSource)
+    if (useDstAlpha)
     {
       srcidx = BlendMode::ONE;
       dstidx = BlendMode::ZERO;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1107,8 +1107,8 @@ void Renderer::SetBlendMode(bool force_update)
   // Our render target always uses an alpha channel, so we need to override the blend functions to
   // assume a destination alpha of 1 if the render target isn't supposed to have an alpha channel.
   bool target_has_alpha = bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24;
-  bool use_dst_alpha = bpmem.dstalpha.enable && bpmem.blendmode.alphaupdate && target_has_alpha &&
-                       g_vulkan_context->SupportsDualSourceBlend();
+  bool use_dst_alpha = bpmem.dstalpha.enable && bpmem.blendmode.alphaupdate && target_has_alpha;
+  bool use_dual_src = g_vulkan_context->SupportsDualSourceBlend();
 
   new_blend_state.blend_enable = VK_TRUE;
   new_blend_state.blend_op = VK_BLEND_OP_ADD;
@@ -1129,11 +1129,11 @@ void Renderer::SetBlendMode(bool force_update)
     break;
   case BlendMode::SRCALPHA:
     new_blend_state.src_blend =
-        use_dst_alpha ? VK_BLEND_FACTOR_SRC1_ALPHA : VK_BLEND_FACTOR_SRC_ALPHA;
+        use_dual_src ? VK_BLEND_FACTOR_SRC1_ALPHA : VK_BLEND_FACTOR_SRC_ALPHA;
     break;
   case BlendMode::INVSRCALPHA:
     new_blend_state.src_blend =
-        use_dst_alpha ? VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA : VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+        use_dual_src ? VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA : VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     break;
   case BlendMode::DSTALPHA:
     new_blend_state.src_blend = target_has_alpha ? VK_BLEND_FACTOR_DST_ALPHA : VK_BLEND_FACTOR_ONE;
@@ -1163,11 +1163,11 @@ void Renderer::SetBlendMode(bool force_update)
     break;
   case BlendMode::SRCALPHA:
     new_blend_state.dst_blend =
-        use_dst_alpha ? VK_BLEND_FACTOR_SRC1_ALPHA : VK_BLEND_FACTOR_SRC_ALPHA;
+        use_dual_src ? VK_BLEND_FACTOR_SRC1_ALPHA : VK_BLEND_FACTOR_SRC_ALPHA;
     break;
   case BlendMode::INVSRCALPHA:
     new_blend_state.dst_blend =
-        use_dst_alpha ? VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA : VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+        use_dual_src ? VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA : VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     break;
   case BlendMode::DSTALPHA:
     new_blend_state.dst_blend = target_has_alpha ? VK_BLEND_FACTOR_DST_ALPHA : VK_BLEND_FACTOR_ONE;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -171,7 +171,7 @@ PixelShaderUid GetPixelShaderUid(DSTALPHA_MODE dstAlphaMode)
                            g_ActiveConfig.bBBoxEnable && BoundingBox::active;
   uid_data->rgba6_format =
       bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24 && !g_ActiveConfig.bForceTrueColor;
-  uid_data->dither = bpmem.blendmode.dither;
+  uid_data->dither = bpmem.blendmode.dither && uid_data->rgba6_format;
 
   u32 numStages = uid_data->genMode_numtevstages + 1;
 
@@ -782,7 +782,7 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data*
   }
 
   // No dithering for RGB8 mode
-  if (uid_data->dither && uid_data->rgba6_format)
+  if (uid_data->dither)
   {
     // Flipper uses a standard 2x2 Bayer Matrix for 6 bit dithering
     // Here the matrix is encoded into the two factor constants

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -169,7 +169,8 @@ PixelShaderUid GetPixelShaderUid(DSTALPHA_MODE dstAlphaMode)
   uid_data->per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
   uid_data->bounding_box = g_ActiveConfig.backend_info.bSupportsBBox &&
                            g_ActiveConfig.bBBoxEnable && BoundingBox::active;
-  uid_data->rgba6_format = bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24;
+  uid_data->rgba6_format =
+      bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24 && !g_ActiveConfig.bForceTrueColor;
   uid_data->dither = bpmem.blendmode.dither;
 
   u32 numStages = uid_data->genMode_numtevstages + 1;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -170,6 +170,7 @@ PixelShaderUid GetPixelShaderUid(DSTALPHA_MODE dstAlphaMode)
   uid_data->bounding_box = g_ActiveConfig.backend_info.bSupportsBBox &&
                            g_ActiveConfig.bBBoxEnable && BoundingBox::active;
   uid_data->rgba6_format = bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24;
+  uid_data->dither = bpmem.blendmode.dither;
 
   u32 numStages = uid_data->genMode_numtevstages + 1;
 
@@ -777,6 +778,12 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data*
       out.Write("\tdepth = 1.0 - float(zCoord) / 16777216.0;\n");
     else
       out.Write("\tdepth = float(zCoord) / 16777216.0;\n");
+  }
+
+  if (uid_data->dither && uid_data->rgba6_format)
+  {
+    out.Write("\tint2 dither = int2(rawpos.xy) & 1;\n");
+    out.Write("\tprev.rgb = (prev.rgb - (prev.rgb >> 6)) + abs(dither.y * 3 - dither.x * 2);\n");
   }
 
   if (uid_data->dstAlphaMode == DSTALPHA_ALPHA_PASS)

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -54,7 +54,8 @@ struct pixel_shader_uid_data
   u32 ssaa : 1;
   u32 numColorChans : 2;
   u32 rgba6_format : 1;
-  u32 pad : 13;
+  u32 dither : 1;
+  u32 pad : 12;
 
   u32 texMtxInfo_n_projection : 8;  // 8x1 bit
   u32 tevindref_bi0 : 3;

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -53,7 +53,8 @@ struct pixel_shader_uid_data
   u32 msaa : 1;
   u32 ssaa : 1;
   u32 numColorChans : 2;
-  u32 pad : 14;
+  u32 rgba6_format : 1;
+  u32 pad : 13;
 
   u32 texMtxInfo_n_projection : 8;  // 8x1 bit
   u32 tevindref_bi0 : 3;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -103,7 +103,7 @@ void VideoConfig::Load(const std::string& ini_file)
   enhancements->Get("ForceFiltering", &bForceFiltering, 0);
   enhancements->Get("MaxAnisotropy", &iMaxAnisotropy, 0);  // NOTE - this is x in (1 << x)
   enhancements->Get("PostProcessingShader", &sPostProcessingShader, "");
-  enhancements->Get("ForceTrueColor", &bForceTrueColor, false);
+  enhancements->Get("ForceTrueColor", &bForceTrueColor, true);
 
   IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
   stereoscopy->Get("StereoMode", &iStereoMode, 0);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -103,6 +103,7 @@ void VideoConfig::Load(const std::string& ini_file)
   enhancements->Get("ForceFiltering", &bForceFiltering, 0);
   enhancements->Get("MaxAnisotropy", &iMaxAnisotropy, 0);  // NOTE - this is x in (1 << x)
   enhancements->Get("PostProcessingShader", &sPostProcessingShader, "");
+  enhancements->Get("ForceTrueColor", &bForceTrueColor, false);
 
   IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
   stereoscopy->Get("StereoMode", &iStereoMode, 0);
@@ -167,6 +168,7 @@ void VideoConfig::GameIniLoad()
   CHECK_SETTING("Video_Settings", "FastDepthCalc", bFastDepthCalc);
   CHECK_SETTING("Video_Settings", "MSAA", iMultisamples);
   CHECK_SETTING("Video_Settings", "SSAA", bSSAA);
+  CHECK_SETTING("Video_Settings", "ForceTrueColor", bForceTrueColor);
 
   int tmp = -9000;
   CHECK_SETTING("Video_Settings", "EFBScale", tmp);  // integral
@@ -317,6 +319,7 @@ void VideoConfig::Save(const std::string& ini_file)
   enhancements->Set("ForceFiltering", bForceFiltering);
   enhancements->Set("MaxAnisotropy", iMaxAnisotropy);
   enhancements->Set("PostProcessingShader", sPostProcessingShader);
+  enhancements->Set("ForceTrueColor", bForceTrueColor);
 
   IniFile::Section* stereoscopy = iniFile.GetOrCreateSection("Stereoscopy");
   stereoscopy->Set("StereoMode", iStereoMode);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -79,6 +79,7 @@ struct VideoConfig final
   bool bForceFiltering;
   int iMaxAnisotropy;
   std::string sPostProcessingShader;
+  bool bForceTrueColor;
 
   // Information
   bool bShowFPS;


### PR DESCRIPTION
This is a more thorough approach than PR #4175. The previous PR only reduced the RGBA8 precision to RGBA6 when making an EFB copy. This PR reduces the precision of the entire pixel stage to RGBA6. This is more accurate to the console and doesn't require rewriting the EFB copy shaders.

To prevent an unnecessary reduction in quality an option is be provided to force RGB8 precision, as most games do not rely on RGB6 precision. However the alpha channel is always kept at 6-bit precision, since many games do rely on that.

Also, dithering support has been implemented as per PR #3742 which should help reduce the color banding with RGBA6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4194)
<!-- Reviewable:end -->
