### PR TITLE
Keep tag consistent on traversal settings reset

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -457,7 +457,7 @@ void NetPlaySetupFrame::OnResetTraversal(wxCommandEvent& event)
   netplay_section.Set("TraversalPort", (std::string) "6262");
   inifile.Save(dolphin_ini);
 
-  m_traversal_lbl->SetLabelText(_("Traversal: ") + "stun.dolphin-emu.org:6262");
+  m_traversal_lbl->SetLabelText(_("Traversal Server: ") + "stun.dolphin-emu.org:6262");
 }
 
 void NetPlaySetupFrame::OnTraversalListenPortChanged(wxCommandEvent& event)


### PR DESCRIPTION
When you click the reset traversal settings button, the label for the settings changes in the setup window.

(yay trivial PRs...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4196)
<!-- Reviewable:end -->
