### PR TITLE
Fix the memChecks breaking a second time after hitting one and unpausing

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -92,10 +92,12 @@ void Run()
         if (PowerPC::breakpoints.IsAddressBreakPoint(PC))
 #endif
         {
+          s_state = CPU_STEPPING;
           PowerPC::CoreMode old_mode = PowerPC::GetMode();
           PowerPC::SetMode(PowerPC::MODE_INTERPRETER);
           PowerPC::SingleStep();
           PowerPC::SetMode(old_mode);
+          s_state = CPU_RUNNING;
         }
       }
 


### PR DESCRIPTION
This is quite the pecular and weird issue so I will explain what went wrong here.

When the CPU is unpaused and memchecks are enabled, it needs to perform a single step to prevent issues with the debugger control features (according to a comment in CPU.cpp).  The problem is this single step will perform the current instruction again and so, this includes doing another check with the memChecks list.  Naturally, this check will trigger a break if a matching one with appropriate flags has been found.

So consider the following scenario: the user adds a memCheck, eventually this memCheck would hit and after that, the user unpause the emulator.

When unpausing, it will single step on the same instruction the memCheck hit earlier which means it would be the same load/store instruction used to hit the memCheck in the first place.  Because of this, it will pass and trigger a second break, but this break would happen just before unpausing which is enough time to break after one or two instructions.

I propose this solution: simply put the state of the cpu to CPU_RUNNING before the step and put it back to CPU_RUNNING after it.

So I went ahead and changed the break condition.  MemChecks only triggers once now.

EDIT: I decided to use a temporary flag instead of the break flag to allow to still have the break flag intact so they could still be toggable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4198)
<!-- Reviewable:end -->
