### PR TITLE
[Gameini] Serious Sam: Next Encounter

### DIFF
--- a/Data/Sys/GameSettings/G3B.ini
+++ b/Data/Sys/GameSettings/G3B.ini
@@ -5,8 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationStateId = 4
-EmulationIssues = Needs EFB to Ram for transition scenes.
+EmulationStateId = 5
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,6 +15,3 @@ EmulationIssues = Needs EFB to Ram for transition scenes.
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False


### PR DESCRIPTION
Game works perfectly on Dolphin 5.0. It does not need 'EFB to RAM' anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4199)
<!-- Reviewable:end -->
