### PR TITLE
Jit64: Fix Dispatcher ABI error

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -612,7 +612,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
 
   // Downcount flag check. The last block decremented downcounter, and the flag should still be
   // available.
-  FixupBranch skip = J_CC(CC_NBE);
+  FixupBranch skip = J_CC(CC_G);
   MOV(32, PPCSTATE(pc), Imm32(js.blockStart));
   JMP(asm_routines.doTiming, true);  // downcount hit zero - go doTiming.
   SetJumpTarget(skip);
@@ -675,7 +675,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
       ABI_CallFunctionC(JitInterface::CompileExceptionCheck,
                         (u32)JitInterface::ExceptionType::EXCEPTIONS_PAIRED_QUANTIZE);
       ABI_PopRegistersAndAdjustStack({}, 0);
-      JMP(asm_routines.dispatcher, true);
+      JMP(asm_routines.dispatcherNoCheck, true);
       SwitchToNearCode();
 
       // Insert a check that the GQRs are still the value we expect at

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -69,9 +69,9 @@ void Jit64AsmRoutineManager::Generate()
   SUB(32, PPCSTATE(downcount), R(RSCRATCH2));
 
   dispatcher = GetCodePtr();
-  // The result of slice decrementation should be in flags if somebody jumped here
-  // IMPORTANT - We jump on negative, not carry!!!
-  FixupBranch bail = J_CC(CC_BE, true);
+  // Expected result of SUB(32, PPCSTATE(downcount), Imm32(block_cycles)) is in RFLAGS.
+  // Branch if downcount is <= 0 (signed).
+  FixupBranch bail = J_CC(CC_LE, true);
 
   FixupBranch dbg_exit;
 


### PR DESCRIPTION
The dispatcher API/ABI requires that RFLAGS contains the state of subtracting the block cycle count from `ppcState.downcount`. There's one part of the JIT which doesn't bother setting the flags correctly.

The dispatcher loop is also using CC_BE (`Carry | Zero`) for the downcount check instead of CC_LE (`Zero | (Negative ^ Overflow)`) for some reason. This doesn't make much sense as downcount is signed. CC_BE is below/equal (unsigned).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4200)
<!-- Reviewable:end -->
