### PR TITLE
Interpreter/CachedInterpreter/JitArm64: Fix CoreTiming::Advance usage

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter.h
@@ -56,7 +56,8 @@ private:
   };
 
   const u8* GetCodePtr() { return (u8*)(m_code.data() + m_code.size()); }
-  std::vector<Instruction> m_code;
+  void ExecuteOneBlock();
 
+  std::vector<Instruction> m_code;
   PPCAnalyst::CodeBuffer code_buffer;
 };


### PR DESCRIPTION
In PR #4168, phire explained that CoreTiming starts in the boundary between the initialization slice (-1) and the first actual slice (0). All dispatchers are therefore required to use `CoreTiming::Advance` to enter a timing slice, not leave it.

Unfortunately, only Jit64 actually adheres to this contract, everything else calls Advance afterwards. This PR makes all the PPC backends consistent with each other and adhere to the contract correctly. It's technically a follow up from PR #3800 which tried to make exception behavior consistent across all the backends but missed the problem with when CoreTiming is being called.

DISCLAIMER: The ARM changes aren't tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4201)
<!-- Reviewable:end -->
