### PR TITLE
OGL: Remove unnecessary c_str calls

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -364,9 +364,9 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
                                   "	}\n"
                                   "}\n";
 
-  ProgramShaderCache::CompileShader(m_pixel_format_shaders[0], vs, ps_rgb8_to_rgba6.c_str(),
+  ProgramShaderCache::CompileShader(m_pixel_format_shaders[0], vs, ps_rgb8_to_rgba6,
                                     (m_EFBLayers > 1) ? gs : "");
-  ProgramShaderCache::CompileShader(m_pixel_format_shaders[1], vs, ps_rgba6_to_rgb8.c_str(),
+  ProgramShaderCache::CompileShader(m_pixel_format_shaders[1], vs, ps_rgba6_to_rgb8,
                                     (m_EFBLayers > 1) ? gs : "");
 
   ProgramShaderCache::CompileShader(

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -399,14 +399,14 @@ void TextureCache::CompileShaders()
   const char* depth_layer = g_ActiveConfig.bStereoEFBMonoDepth ? "0.0" : "f_uv0.z";
 
   ProgramShaderCache::CompileShader(s_ColorCopyProgram,
-                                    StringFromFormat(vertex_program, prefix, prefix).c_str(),
+                                    StringFromFormat(vertex_program, prefix, prefix),
                                     color_copy_program, geo_program);
   ProgramShaderCache::CompileShader(s_ColorMatrixProgram,
-                                    StringFromFormat(vertex_program, prefix, prefix).c_str(),
+                                    StringFromFormat(vertex_program, prefix, prefix),
                                     color_matrix_program, geo_program);
   ProgramShaderCache::CompileShader(
-      s_DepthMatrixProgram, StringFromFormat(vertex_program, prefix, prefix).c_str(),
-      StringFromFormat(depth_matrix_program, depth_layer).c_str(), geo_program);
+      s_DepthMatrixProgram, StringFromFormat(vertex_program, prefix, prefix),
+      StringFromFormat(depth_matrix_program, depth_layer), geo_program);
 
   s_ColorMatrixUniform = glGetUniformLocation(s_ColorMatrixProgram.glprogid, "colmat");
   s_DepthMatrixUniform = glGetUniformLocation(s_DepthMatrixProgram.glprogid, "colmat");

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -198,13 +198,13 @@ void VertexManager::vFlush(bool useDstAlpha)
         "%sps%.3d.txt", File::GetUserPath(D_DUMPFRAMES_IDX).c_str(), g_ActiveConfig.iSaveTargetId);
     std::ofstream fps;
     OpenFStream(fps, filename, std::ios_base::out);
-    fps << prog.shader.strpprog.c_str();
+    fps << prog.shader.strpprog;
 
     filename = StringFromFormat("%svs%.3d.txt", File::GetUserPath(D_DUMPFRAMES_IDX).c_str(),
                                 g_ActiveConfig.iSaveTargetId);
     std::ofstream fvs;
     OpenFStream(fvs, filename, std::ios_base::out);
-    fvs << prog.shader.strvprog.c_str();
+    fvs << prog.shader.strvprog;
   }
 
   if (g_ActiveConfig.iLog & CONF_SAVETARGETS)


### PR DESCRIPTION
Noticed these while doing other texture cache work and figured I may as well split the easy stuff out.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4202)
<!-- Reviewable:end -->
