### PR TITLE
Move Memchecks support out of debug only builds

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -137,12 +137,12 @@ void PPCDebugInterface::ClearAllMemChecks()
 
 bool PPCDebugInterface::IsMemCheck(unsigned int address)
 {
-  return (Memory::AreMemoryBreakpointsActivated() && PowerPC::memchecks.GetMemCheck(address));
+  return (PowerPC::memchecks.HasAny() && PowerPC::memchecks.GetMemCheck(address));
 }
 
 void PPCDebugInterface::ToggleMemCheck(unsigned int address)
 {
-  if (Memory::AreMemoryBreakpointsActivated() && !PowerPC::memchecks.GetMemCheck(address))
+  if (PowerPC::memchecks.HasAny() && !PowerPC::memchecks.GetMemCheck(address))
   {
     // Add Memory Check
     TMemCheck MemCheck;

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -88,9 +88,7 @@ void Run()
       // If watchpoints are enabled, any instruction could be a breakpoint.
       if (PowerPC::GetMode() != PowerPC::MODE_INTERPRETER)
       {
-#ifndef ENABLE_MEM_CHECK
-        if (PowerPC::breakpoints.IsAddressBreakPoint(PC))
-#endif
+        if (PowerPC::breakpoints.IsAddressBreakPoint(PC) || PowerPC::memchecks.HasAny())
         {
           PowerPC::CoreMode old_mode = PowerPC::GetMode();
           PowerPC::SetMode(PowerPC::MODE_INTERPRETER);

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -316,15 +316,6 @@ void Clear()
     memset(m_pEXRAM, 0, EXRAM_SIZE);
 }
 
-bool AreMemoryBreakpointsActivated()
-{
-#ifdef ENABLE_MEM_CHECK
-  return true;
-#else
-  return false;
-#endif
-}
-
 static inline u8* GetPointerForRange(u32 address, size_t size)
 {
   // Make sure we don't have a range spanning 2 separate banks

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -11,11 +11,6 @@
 #include "Common/CommonTypes.h"
 #include "Core/PowerPC/PowerPC.h"
 
-// Enable memory checks in the Debug/DebugFast builds, but NOT in release
-#if defined(_DEBUG) || defined(DEBUGFAST)
-#define ENABLE_MEM_CHECK
-#endif
-
 // Global declarations
 class PointerWrap;
 namespace MMIO
@@ -72,7 +67,6 @@ void DoState(PointerWrap& p);
 void UpdateLogicalMemory(const PowerPC::BatTable& dbat_table);
 
 void Clear();
-bool AreMemoryBreakpointsActivated();
 
 // Routines to access physically addressed memory, designed for use by
 // emulated hardware outside the CPU. Use "Device_" prefix.

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -402,12 +402,10 @@ void CheckExceptions()
     INFO_LOG(POWERPC, "EXCEPTION_FPU_UNAVAILABLE");
     ppcState.Exceptions &= ~EXCEPTION_FPU_UNAVAILABLE;
   }
-#ifdef ENABLE_MEM_CHECK
   else if (exceptions & EXCEPTION_FAKE_MEMCHECK_HIT)
   {
     ppcState.Exceptions &= ~EXCEPTION_DSI & ~EXCEPTION_FAKE_MEMCHECK_HIT;
   }
-#endif
   else if (exceptions & EXCEPTION_DSI)
   {
     SRR0 = PC;

--- a/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
@@ -47,12 +47,8 @@ public:
     AddTool(ID_ADDBP, "+BP", m_Bitmaps[Toolbar_Add_BP]);
     Bind(wxEVT_TOOL, &CBreakPointWindow::OnAddBreakPoint, parent, ID_ADDBP);
 
-    // Add memory breakpoints if you can use them
-    if (Memory::AreMemoryBreakpointsActivated())
-    {
-      AddTool(ID_ADDMC, "+MC", m_Bitmaps[Toolbar_Add_MC]);
-      Bind(wxEVT_TOOL, &CBreakPointWindow::OnAddMemoryCheck, parent, ID_ADDMC);
-    }
+    AddTool(ID_ADDMC, "+MC", m_Bitmaps[Toolbar_Add_MC]);
+    Bind(wxEVT_TOOL, &CBreakPointWindow::OnAddMemoryCheck, parent, ID_ADDMC);
 
     AddTool(ID_LOAD, _("Load"), m_Bitmaps[Toolbar_Delete]);
     Bind(wxEVT_TOOL, &CBreakPointWindow::Event_LoadAll, parent, ID_LOAD);

--- a/Source/Core/DolphinWX/Debugger/WatchView.cpp
+++ b/Source/Core/DolphinWX/Debugger/WatchView.cpp
@@ -261,9 +261,7 @@ void CWatchView::OnMouseDownR(wxGridEvent& event)
 
   if (row != 0 && row != (int)(PowerPC::watches.GetWatches().size() + 1) && (col == 1 || col == 2))
   {
-#ifdef ENABLE_MEM_CHECK
     menu.Append(IDM_ADDMEMCHECK, _("Add memory &breakpoint"));
-#endif
     menu.Append(IDM_VIEWMEMORY, _("View &memory"));
   }
   PopupMenu(&menu);


### PR DESCRIPTION
There's some reason that support for this feature is safe and even should be included with every builds including release.

- This feature does not impact performance whatsover until the user starts to add at least one memchecks.  The only additional thing this PR brings with the removal of the preprocessor is a call to HasAny which just checks if any memchecks are present.  Not only this is very minimal, but even in the case the user adds one, the performance woudl restore back to normal as soon as the last memcheck is removed.  Basically, it's only beneficial performance wise and as for when memchecks are used, even there, optimisations to make them faster are possible.
- It is a very usefull debugging feature especially consideirng use cases like game reverse engineering and research.  Basically, if you want to trace back to what happened when a relevant address was touched, you cannot use only breakpoints if you have no idea where in the actuall assembly it is being tempered with.  This feature is almsot essential for this and currently, it requires to build in a specific configuration that simply doesn't really have much reasons to belong there only.
- This may be more subjective, but I personally think them being in debug only is silly.  Release has the full debugger with breakpoints enabled even in stable, but doesn't have a way to break on read/write which, as I just said, is almost essential in some use cases.  It doesn't seem complete as the debugger without them and release builds already having everything but this feature is just weird.

I tested using current master release version and this branch release version on the most stressful scene for the emulator I could find on Paper Mario TTYD and Super Paper Mario and I could not notice any difference performance wise when memchecks aren't used.  I also tested the current master in debugfast and it basically is also the same.

So yeah, TL;DR let's free memchecks as there's not much drawsback to do it :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4203)
<!-- Reviewable:end -->
