### PR TITLE
arm64: fixes around icache flushing

### DIFF
--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -346,6 +346,8 @@ void ARM64XEmitter::FlushIcacheSection(u8* start, u8* end)
 
   addr = (u64)start & ~(u64)(dsize - 1);
   for (; addr < (u64)end; addr += dsize)
+    // use "civac" instead of "cvau", as this is the suggested workaround for
+    // Cortex-A53 errata 819472, 826319, 827319 and 824069.
     __asm__ volatile("dc civac, %0" : : "r"(addr) : "memory");
   __asm__ volatile("dsb ish" : : : "memory");
 


### PR DESCRIPTION
The first hit on Google about "Exynos 8890 SIGILL" is a thread pointing out a dolphin crash on Samsung Galaxy S7.  We had a similar issue in mono, see https://github.com/mono/mono/pull/3549


Untested though: Anyone cares about testing it please?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4204)
<!-- Reviewable:end -->
