### PR TITLE
Remove .tx from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,6 @@ CMakeLists.txt.user
 # Ignore emacs temp files
 \#*\#
 .\#*
-# Ignore transifex configuration directory
-.tx
 # Ignore kdevelop files/dirs
 *.kdev4
 # Ignore IDEA/Clion files/dirs

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[dolphin-emu.emulator]
+file_filter = Languages/po/<lang>.po
+source_file = Languages/po/dolphin-emu.pot
+source_lang = en-US
+type = PO


### PR DESCRIPTION
It contains a configuration that has no reason to be different for different people. It's not used for storing things like usernames or passwords.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4206)
<!-- Reviewable:end -->
