### PR TITLE
Fix the debugger font not appearing on the captions of panes (DSP)

### DIFF
--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <wx/artprov.h>
 #include <wx/aui/auibook.h>
+#include <wx/aui/dockart.h>
 #include <wx/aui/framemanager.h>
 #include <wx/listbox.h>
 #include <wx/panel.h>
@@ -23,6 +24,7 @@
 #include "DolphinWX/Debugger/CodeView.h"
 #include "DolphinWX/Debugger/DSPDebugWindow.h"
 #include "DolphinWX/Debugger/DSPRegisterView.h"
+#include "DolphinWX/Debugger/DebuggerUIUtil.h"
 #include "DolphinWX/Debugger/MemoryView.h"
 #include "DolphinWX/WxUtils.h"
 
@@ -97,6 +99,7 @@ DSPDebuggerLLE::DSPDebuggerLLE(wxWindow* parent, wxWindowID id)
   m_mgr.AddPane(m_Regs,
                 wxAuiPaneInfo().Right().CloseButton(false).Caption(_("Registers")).Dockable(true));
 
+  m_mgr.GetArtProvider()->SetFont(wxAUI_DOCKART_CAPTION_FONT, DebuggerFont);
   UpdateState();
 
   m_mgr.Update();


### PR DESCRIPTION
Forgot to fix that since PR #4152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4208)
<!-- Reviewable:end -->
