### PR TITLE
lens distortion post-processing shader

### DIFF
--- a/Data/Sys/Shaders/lens_distortion.glsl
+++ b/Data/Sys/Shaders/lens_distortion.glsl
@@ -59,7 +59,7 @@ void main()
   }
   else
   {
-    offsetAdd = 0 - stereoOffset;
+    offsetAdd = 0.0 - stereoOffset;
   }
 
   // convert coordinates to NDC space
@@ -69,7 +69,7 @@ void main()
   float destR = length(fragPos);
 
   // find the radius multiplier
-  float srcR = destR * sizeAdjust + ( ka * pow(destR,2) + kb * pow(destR,4));
+  float srcR = destR * sizeAdjust + ( ka * pow(destR, 2.0) + kb * pow(destR, 4.0));
 
   // Calculate the source vector (radial)
   vec2 correctedRadial = normalize(fragPos) * srcR;
@@ -81,10 +81,10 @@ void main()
   vec2 uv = (widenedRadial/2.0f) + vec2(0.5f) + vec2(offsetAdd, 0.0f);
 
   // Sample the texture at the source location
-  if (uv[0] > 1.0 || uv[1] > 1.0 || uv[0] < 0.0 || uv[1] < 0.0)
+  if(clamp(uv, 0.0, 1.0) != uv)
   {
     // black if beyond bounds
-    SetOutput(float4(0,0,0,0));
+    SetOutput(float4(0.0, 0.0, 0.0, 0.0));
   }
   else
   {

--- a/Data/Sys/Shaders/lens_distortion.glsl
+++ b/Data/Sys/Shaders/lens_distortion.glsl
@@ -1,0 +1,93 @@
+/*
+[configuration]
+
+[OptionRangeFloat]
+GUIName = Distortion amount
+OptionName = DISTORTION_FACTOR
+MinValue = 1.0
+MaxValue = 10.0
+StepAmount = 0.5
+DefaultValue = 4.0
+
+[OptionRangeFloat]
+GUIName = Eye Distance Offset
+OptionName = EYE_OFFSET
+MinValue = 0.0
+MaxValue = 10.0
+StepAmount = 0.25
+DefaultValue = 5.0
+
+[OptionRangeFloat]
+GUIName = Zoom adjustment
+OptionName = SIZE_ADJUST
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.025
+DefaultValue = 0.5
+
+[OptionRangeFloat]
+GUIName = Aspect Ratio adjustment
+OptionName = ASPECT_ADJUST
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.025
+DefaultValue = 0.5
+
+[/configuration]
+*/
+
+
+void main()
+{
+  // Base Cardboard distortion parameters
+  float factor = GetOption(DISTORTION_FACTOR) * 0.01f;
+  float ka = factor * 3.0f;
+  float kb = factor * 5.0f;
+
+  // size and aspect adjustment
+  float sizeAdjust = 1.0f - GetOption(SIZE_ADJUST) + 0.5f;
+  float aspectAdjustment = 1.25f - GetOption(ASPECT_ADJUST);
+
+  // offset centering per eye
+  float stereoOffset = GetOption(EYE_OFFSET) * 0.01f;
+  float offsetAdd;
+
+  // layer0 = left eye, layer1 = right eye
+  if (layer == 1)
+  {
+    offsetAdd = stereoOffset;
+  }
+  else
+  {
+    offsetAdd = 0 - stereoOffset;
+  }
+
+  // convert coordinates to NDC space
+  float2 fragPos = (GetCoordinates() - 0.5f - vec2(offsetAdd, 0.0f)) * 2.0f;
+
+  // Calculate the source location "radius" (distance from the centre of the viewport)
+  float destR = length(fragPos);
+
+  // find the radius multiplier
+  float srcR = destR * sizeAdjust + ( ka * pow(destR,2) + kb * pow(destR,4));
+
+  // Calculate the source vector (radial)
+  vec2 correctedRadial = normalize(fragPos) * srcR;
+
+  // fix aspect ratio
+  vec2 widenedRadial = correctedRadial * vec2(aspectAdjustment, 1.0f);
+
+  // Transform the coordinates (from [-1,1]^2 to [0, 1]^2)
+  vec2 uv = (widenedRadial/2.0f) + vec2(0.5f) + vec2(offsetAdd, 0.0f);
+
+  // Sample the texture at the source location
+  if (uv[0] > 1.0 || uv[1] > 1.0 || uv[0] < 0.0 || uv[1] < 0.0)
+  {
+    // black if beyond bounds
+    SetOutput(float4(0,0,0,0));
+  }
+  else
+  {
+    SetOutput(SampleLocation(uv));
+  }
+}


### PR DESCRIPTION
This is a post-processing shader for lens distortion, in order to make the side-by-side 3D mode usable in lens-based viewers (Cardboard, etc).  It allows UI-configurable levels of distortion, size adjustment, and eye separation. 

Based on my prior gist (screenshots here): https://gist.github.com/jasonphillips/4cc91e85f128eae4f086118a59241ca1

The lens distortion algorithm is adapted from Google Cardboard SDKs, but the configurable sliders should allow it to be comfortably used on most lenses.

The main rationale for this is to make the base Dolphin's existing side-by-side 3D mode viable for VR viewers. I'm aware that Dolphin VR exists as a separate project, but it has the limitations of (1) being Windows-only, and (2) being a more complex, comprehensive approach (with head tracking, and sizable VR SDKs required). This shader instead provides the simple ability to enjoy the excellent existing stereo 3D capabilities of Dolphin on any platform using cheap VR viewers that are now ubiquitous. 

Thoughts welcome. If this is not a reasonable addition to the core of the project, I'll just update my gist and leave it at that for the users who are interested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4209)
<!-- Reviewable:end -->
