### PR TITLE
DiscIO: Fix NAND Memory Leak

### DIFF
--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -29,6 +29,8 @@
 
 namespace DiscIO
 {
+CNANDContentData::~CNANDContentData() = default;
+
 CSharedContent::CSharedContent()
 {
   UpdateLocation();

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -25,6 +25,7 @@ bool AddTicket(u64 title_id, const std::vector<u8>& ticket);
 class CNANDContentData
 {
 public:
+  virtual ~CNANDContentData() = 0;
   virtual void Open(){};
   virtual const std::vector<u8> Get() = 0;
   virtual bool GetRange(u32 start, u32 size, u8* buffer) = 0;


### PR DESCRIPTION
`CNANDContentData` is an interface base class with a non-virtual destructor so the derived classes don't get destroyed when deleting a pointer to the base. The derived classes leak various resources (strings and open file handles) because of this.

Fixes the "memory leaks detected" log messages after closing a debug build of Dolphin in the Visual Studio debugger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4212)
<!-- Reviewable:end -->
