### PR TITLE
GeckoCodes: Don't run PPC code in CoreTiming callbacks

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -483,5 +483,9 @@ bool CBoot::BootUp()
   // Not part of the binary itself, but either we or Gecko OS might insert
   // this, and it doesn't clear the icache properly.
   HLE::Patch(Gecko::ENTRY_POINT, "GeckoCodehandler");
+  if (SConfig::GetInstance().bEnableCheats)
+  {
+    HLE::Patch(Gecko::HLE_TRAMPOLINE_ADDRESS, "GeckoHandlerReturnTrampoline");
+  }
   return true;
 }

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -483,9 +483,8 @@ bool CBoot::BootUp()
   // Not part of the binary itself, but either we or Gecko OS might insert
   // this, and it doesn't clear the icache properly.
   HLE::Patch(Gecko::ENTRY_POINT, "GeckoCodehandler");
-  if (SConfig::GetInstance().bEnableCheats)
-  {
-    HLE::Patch(Gecko::HLE_TRAMPOLINE_ADDRESS, "GeckoHandlerReturnTrampoline");
-  }
+  // This has to always be installed even if cheats are not enabled because of the possiblity of
+  // loading a savestate where PC is inside the code handler while cheats are disabled.
+  HLE::Patch(Gecko::HLE_TRAMPOLINE_ADDRESS, "GeckoHandlerReturnTrampoline");
   return true;
 }

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -17,6 +17,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/Debugger/Debugger_SymbolMap.h"
+#include "Core/GeckoCode.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HW/DVDInterface.h"
 #include "Core/HW/EXI_DeviceIPL.h"
@@ -481,6 +482,6 @@ bool CBoot::BootUp()
 
   // Not part of the binary itself, but either we or Gecko OS might insert
   // this, and it doesn't clear the icache properly.
-  HLE::Patch(0x800018a8, "GeckoCodehandler");
+  HLE::Patch(Gecko::ENTRY_POINT, "GeckoCodehandler");
   return true;
 }

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -178,10 +178,6 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
   // Load patches
   PatchEngine::LoadPatches();
 
-  // If we have any patches that need to be applied very early, here's a good place
-  bool patched = PatchEngine::ApplyFramePatches();
-  _assert_(patched);
-
   return true;
 }
 

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Common/Assert.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
@@ -178,7 +179,8 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
   PatchEngine::LoadPatches();
 
   // If we have any patches that need to be applied very early, here's a good place
-  PatchEngine::ApplyFramePatches();
+  bool patched = PatchEngine::ApplyFramePatches();
+  _assert_(patched);
 
   return true;
 }

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -38,6 +38,7 @@
 #endif
 #include "Core/Boot/Boot.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
+#include "Core/HLE/HLE.h"
 #include "Core/HW/AudioInterface.h"
 #include "Core/HW/CPU.h"
 #include "Core/HW/DSP.h"
@@ -674,6 +675,7 @@ void EmuThread()
   INFO_LOG(CONSOLE, "Stop [Video Thread]\t\t---- Shutdown complete ----");
   Movie::Shutdown();
   PatchEngine::Shutdown();
+  HLE::Clear();
 
   s_is_stopping = false;
 

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -18,10 +18,8 @@
 
 namespace Gecko
 {
-static constexpr u32 INSTALLER_BASE_ADDRESS = 0x80001800;
 static constexpr u32 INSTALLER_END_ADDRESS = 0x80003000;
 static constexpr u32 CODE_SIZE = 8;
-static constexpr u32 MAGIC_GAMEID = 0xD01F1BAD;
 
 // return true if a code exists
 bool GeckoCode::Exist(u32 address, u32 data) const
@@ -102,6 +100,7 @@ static bool InstallCodeHandlerLocked()
   const u32 codelist_end_address = INSTALLER_END_ADDRESS;
 
   // Write a magic value to 'gameid' (codehandleronly does not actually read this).
+  // This value will be read back and modified over time by HLE_Misc::HLEGeckoCodehandler.
   PowerPC::HostWrite_U32(MAGIC_GAMEID, INSTALLER_BASE_ADDRESS);
 
   // Create GCT in memory
@@ -161,7 +160,7 @@ void RunCodeHandler()
   if (s_active_codes.empty())
     return;
 
-  if (!s_code_handler_installed || PowerPC::HostRead_U32(INSTALLER_BASE_ADDRESS) - MAGIC_GAMEID > 5)
+  if (!s_code_handler_installed)
   {
     s_code_handler_installed = InstallCodeHandlerLocked();
 
@@ -175,7 +174,7 @@ void RunCodeHandler()
   // the original return address (which will still be in the link register) at the end.
   if (PC == LR)
   {
-    PC = NPC = INSTALLER_BASE_ADDRESS + 0xA8;
+    PC = NPC = ENTRY_POINT;
   }
 }
 

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -157,24 +157,10 @@ static Installation InstallCodeHandlerLocked()
   return Installation::Installed;
 }
 
-void RunCodeHandler(u32 msr_reg)
+void RunCodeHandler()
 {
   if (!SConfig::GetInstance().bEnableCheats)
     return;
-
-  // Dolphin's hook mechanism is less 'precise' than Gecko OS' which detects particular
-  // instruction sequences (uses configuration, not automatic) that only run once per frame
-  // which includes a BLR as one of the instructions. It then overwrites the BLR with a
-  // "B 0x800018A8" to establish the hook. Dolphin uses its own internal VI interrupt which
-  // means the PC is non-deterministic and could be anywhere.
-  UReg_MSR msr = msr_reg;
-  if (!msr.DR || !msr.IR)
-  {
-    WARN_LOG(ACTIONREPLAY, "GeckoCode: Skipping frame update. MSR.IR/DR is currently disabled. "
-                           "PC = 0x%08X, MSR = 0x%08X",
-             PC, msr_reg);
-    return;
-  }
 
   std::lock_guard<std::mutex> codes_lock(s_active_codes_lock);
   // Don't spam retry if the install failed. The corrupt / missing disk file is not likely to be

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -145,6 +145,7 @@ static Installation InstallCodeHandlerLocked()
   // Stop code. Tells the handler that this is the end of the list.
   PowerPC::HostWrite_U32(0xF0000000, next_address);
   PowerPC::HostWrite_U32(0x00000000, next_address + 4);
+  PowerPC::HostWrite_U32(0, HLE_TRAMPOLINE_ADDRESS);
 
   // Turn on codes
   PowerPC::HostWrite_U8(1, INSTALLER_BASE_ADDRESS + 7);
@@ -157,57 +158,62 @@ static Installation InstallCodeHandlerLocked()
   return Installation::Installed;
 }
 
+// FIXME: Gecko needs to participate in the savestate system (remember installation state).
+//   Current bug: Loading a savestate causes the handler to be replaced, if the PC is inside it
+//    and the on disk codehandler.bin is different then the PC will effectively be pointing to
+//    a random instruction different from the one when the state was created and break or crash.
+//    [Also, self-modifying handler will break it since the modifications will be reset]
 void RunCodeHandler()
 {
   if (!SConfig::GetInstance().bEnableCheats)
     return;
 
-  std::lock_guard<std::mutex> codes_lock(s_active_codes_lock);
-  // Don't spam retry if the install failed. The corrupt / missing disk file is not likely to be
-  // fixed within 1 frame of the last error.
-  if (s_active_codes.empty() || s_code_handler_installed == Installation::Failed)
-    return;
-
-  if (s_code_handler_installed != Installation::Installed)
+  // NOTE: Need to release the lock because of GUI deadlocks with PanicAlert in HostWrite_*
   {
-    s_code_handler_installed = InstallCodeHandlerLocked();
-
-    // A warning was already issued for the install failing
-    if (s_code_handler_installed != Installation::Installed)
+    std::lock_guard<std::mutex> codes_lock(s_active_codes_lock);
+    // Don't spam retry if the install failed. The corrupt / missing disk file is not likely to be
+    // fixed within 1 frame of the last error.
+    if (s_active_codes.empty() || s_code_handler_installed == Installation::Failed)
       return;
+
+    if (s_code_handler_installed != Installation::Installed)
+    {
+      s_code_handler_installed = InstallCodeHandlerLocked();
+
+      // A warning was already issued for the install failing
+      if (s_code_handler_installed != Installation::Installed)
+        return;
+    }
   }
 
-  // If the last block that just executed ended with a BLR instruction then we can intercept it and
-  // redirect control into the Gecko Code Handler. The Code Handler will automatically BLR back to
-  // the original return address (which will still be in the link register).
-  if (PC != LR)
+  // We always do this to avoid problems with the stack since we're branching in random locations.
+  // Even with function call return hooks (PC == LR), hand coded assembler won't necessarily
+  // follow the ABI. [Volatile FPR, GPR, CR may not be volatile]
+  // The codehandler will STMW all of the GPR registers, but we need to fix the Stack's Red
+  // Zone, the LR, PC (return address) and the volatile floating point registers.
+  // Build a function call stack frame.
+  u32 SFP = GPR(1);                     // Stack Frame Pointer
+  GPR(1) -= 256;                        // Stack's Red Zone
+  GPR(1) -= 16 + 2 * 14 * sizeof(u64);  // Our stack frame (HLE_Misc::GeckoReturnTrampoline)
+  GPR(1) -= 8;                          // Fake stack frame for codehandler
+  GPR(1) &= 0xFFFFFFF0;                 // Align stack to 16bytes
+  u32 SP = GPR(1);                      // Stack Pointer
+  PowerPC::HostWrite_U32(SP + 8, SP);
+  // SP + 4 is reserved for the codehandler to save LR to the stack.
+  PowerPC::HostWrite_U32(SFP, SP + 8);  // Real stack frame
+  PowerPC::HostWrite_U32(PC, SP + 12);
+  PowerPC::HostWrite_U32(LR, SP + 16);
+  PowerPC::HostWrite_U32(PowerPC::CompactCR(), SP + 20);
+  // Registers FPR0->13 are volatile
+  for (int i = 0; i < 14; ++i)
   {
-    // We're at a random address in the middle of something so we have to do this the hard way.
-    // The codehandler will STMW all of the GPR registers, but we need to fix the Stack's Red
-    // Zone, the LR, PC (return address) and the volatile floating point registers.
-    // Build a function call stack frame.
-    u32 SFP = GPR(1);                     // Stack Frame Pointer
-    GPR(1) -= 224;                        // Stack's Red Zone
-    GPR(1) -= 16 + 2 * 14 * sizeof(u64);  // Our stack frame (HLE_Misc::GeckoReturnTrampoline)
-    GPR(1) -= 8;                          // Fake stack frame for codehandler
-    GPR(1) &= 0xFFFFFFF0;                 // Align stack to 16bytes
-    u32 SP = GPR(1);                      // Stack Pointer
-    PowerPC::HostWrite_U32(SP + 8, SP);
-    // SP + 4 is reserved for the codehandler to save LR to the stack.
-    PowerPC::HostWrite_U32(SFP, SP + 8);  // Real stack frame
-    PowerPC::HostWrite_U32(PC, SP + 12);
-    PowerPC::HostWrite_U32(LR, SP + 16);
-    // Registers FPR0->13 are volatile
-    for (int i = 0; i < 14; ++i)
-    {
-      PowerPC::HostWrite_U64(riPS0(i), SP + 24 + 2 * i * sizeof(u64));
-      PowerPC::HostWrite_U64(riPS1(i), SP + 24 + (2 * i + 1) * sizeof(u64));
-    }
-    LR = HLE_TRAMPOLINE_ADDRESS;
-    DEBUG_LOG(ACTIONREPLAY, "GeckoCodes: Initiating phantom branch-and-link. "
-                            "PC = 0x%08X, SP = 0x%08X, SFP = 0x%08X",
-              PC, SP, SFP);
+    PowerPC::HostWrite_U64(riPS0(i), SP + 24 + 2 * i * sizeof(u64));
+    PowerPC::HostWrite_U64(riPS1(i), SP + 24 + (2 * i + 1) * sizeof(u64));
   }
+  DEBUG_LOG(ACTIONREPLAY, "GeckoCodes: Initiating phantom branch-and-link. "
+                          "PC = 0x%08X, SP = 0x%08X, SFP = 0x%08X",
+            PC, SP, SFP);
+  LR = HLE_TRAMPOLINE_ADDRESS;
   PC = NPC = ENTRY_POINT;
 }
 

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -33,6 +33,20 @@ public:
   bool Exist(u32 address, u32 data) const;
 };
 
+// Installation address for codehandler.bin in the Game's RAM
+constexpr u32 INSTALLER_BASE_ADDRESS = 0x80001800;
+constexpr u32 ENTRY_POINT = 0x800018A8;
+
+// This forms part of a communication protocol with HLE_Misc::HLEGeckoCodehandler.
+// Basically, codehandleronly.s doesn't use ICBI like it's supposed to when patching the
+// game's code. This results in the JIT happily ignoring all code patches for blocks that
+// are already compiled. The hack for getting around that is that the first 5 frames after
+// the handler is installed (0xD01F1BAD -> +5 -> 0xD01F1BB2) cause full ICache resets.
+//
+// HLEGeckoCodehandler will increment this value 5 times then cease flushing the ICache to
+// preserve the emulation performance.
+constexpr u32 MAGIC_GAMEID = 0xD01F1BAD;
+
 void SetActiveCodes(const std::vector<GeckoCode>& gcodes);
 void RunCodeHandler();
 

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -34,7 +34,6 @@ public:
 };
 
 void SetActiveCodes(const std::vector<GeckoCode>& gcodes);
-bool RunActiveCodes();
 void RunCodeHandler();
 
 }  // namespace Gecko

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -52,6 +52,6 @@ constexpr u32 HLE_TRAMPOLINE_ADDRESS = INSTALLER_END_ADDRESS - 4;
 constexpr u32 MAGIC_GAMEID = 0xD01F1BAD;
 
 void SetActiveCodes(const std::vector<GeckoCode>& gcodes);
-void RunCodeHandler(u32 msr_reg);
+void RunCodeHandler();
 
 }  // namespace Gecko

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -9,6 +9,8 @@
 
 #include "Common/CommonTypes.h"
 
+class PointerWrap;
+
 namespace Gecko
 {
 class GeckoCode
@@ -53,5 +55,7 @@ constexpr u32 MAGIC_GAMEID = 0xD01F1BAD;
 
 void SetActiveCodes(const std::vector<GeckoCode>& gcodes);
 void RunCodeHandler();
+void Shutdown();
+void DoState(PointerWrap&);
 
 }  // namespace Gecko

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -35,19 +35,23 @@ public:
 
 // Installation address for codehandler.bin in the Game's RAM
 constexpr u32 INSTALLER_BASE_ADDRESS = 0x80001800;
-constexpr u32 ENTRY_POINT = 0x800018A8;
+constexpr u32 INSTALLER_END_ADDRESS = 0x80003000;
+constexpr u32 ENTRY_POINT = INSTALLER_BASE_ADDRESS + 0xA8;
+// If the GCT is max-length then this is the second word of the End code (0xF0000000 0x00000000)
+// If the table is shorter than the max-length then this address is unused / contains trash.
+constexpr u32 HLE_TRAMPOLINE_ADDRESS = INSTALLER_END_ADDRESS - 4;
 
-// This forms part of a communication protocol with HLE_Misc::HLEGeckoCodehandler.
+// This forms part of a communication protocol with HLE_Misc::GeckoCodeHandlerICacheFlush.
 // Basically, codehandleronly.s doesn't use ICBI like it's supposed to when patching the
 // game's code. This results in the JIT happily ignoring all code patches for blocks that
 // are already compiled. The hack for getting around that is that the first 5 frames after
 // the handler is installed (0xD01F1BAD -> +5 -> 0xD01F1BB2) cause full ICache resets.
 //
-// HLEGeckoCodehandler will increment this value 5 times then cease flushing the ICache to
+// GeckoCodeHandlerICacheFlush will increment this value 5 times then cease flushing the ICache to
 // preserve the emulation performance.
 constexpr u32 MAGIC_GAMEID = 0xD01F1BAD;
 
 void SetActiveCodes(const std::vector<GeckoCode>& gcodes);
-void RunCodeHandler();
+void RunCodeHandler(u32 msr_reg);
 
 }  // namespace Gecko

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -60,7 +60,9 @@ static const SPatch OSPatches[] = {
     {"___blank", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
     {"__write_console", HLE_OS::HLE_write_console, HLE_HOOK_REPLACE,
      HLE_TYPE_DEBUG},  // used by sysmenu (+more?)
-    {"GeckoCodehandler", HLE_Misc::HLEGeckoCodehandler, HLE_HOOK_START, HLE_TYPE_GENERIC},
+    {"GeckoCodehandler", HLE_Misc::GeckoCodeHandlerICacheFlush, HLE_HOOK_START, HLE_TYPE_GENERIC},
+    {"GeckoHandlerReturnTrampoline", HLE_Misc::GeckoReturnTrampoline, HLE_HOOK_REPLACE,
+     HLE_TYPE_GENERIC},
 };
 
 static const SPatch OSBreakPoints[] = {

--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -10,23 +10,26 @@
 
 namespace HLE
 {
-enum
+enum HookType
 {
   HLE_HOOK_START = 0,    // Hook the beginning of the function and execute the function afterwards
   HLE_HOOK_REPLACE = 1,  // Replace the function with the HLE version
   HLE_HOOK_NONE = 2,     // Do not hook the function
 };
 
-enum
+enum HookFlag
 {
   HLE_TYPE_GENERIC = 0,  // Miscellaneous function
   HLE_TYPE_DEBUG = 1,    // Debug output function
+  HLE_TYPE_FIXED = 2,    // An arbitrary hook mapped to a fixed address instead of a symbol
 };
 
 void PatchFunctions();
+void Clear();
 
 void Patch(u32 pc, const char* func_name);
 u32 UnPatch(const std::string& patchName);
+bool UnPatch(u32 addr, const std::string& name = {});
 void Execute(u32 _CurrentPC, u32 _Instruction);
 
 u32 GetFunctionIndex(u32 em_address);

--- a/Source/Core/Core/HLE/HLE_Misc.cpp
+++ b/Source/Core/Core/HLE/HLE_Misc.cpp
@@ -7,6 +7,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Core/ConfigManager.h"
+#include "Core/GeckoCode.h"
 #include "Core/HLE/HLE_Misc.h"
 #include "Core/HW/CPU.h"
 #include "Core/Host.h"
@@ -47,17 +48,17 @@ void HLEGeckoCodehandler()
   // been read into memory, or such, so we do the first 5 frames.  More
   // robust alternative would be to actually detect memory writes, but that
   // would be even uglier.)
-  u32 magic = 0xd01f1bad;
-  u32 existing = PowerPC::HostRead_U32(0x80001800);
-  if (existing - magic == 5)
+  u32 gch_gameid = PowerPC::HostRead_U32(Gecko::INSTALLER_BASE_ADDRESS);
+  if (gch_gameid - Gecko::MAGIC_GAMEID == 5)
   {
     return;
   }
-  else if (existing - magic > 5)
+  else if (gch_gameid - Gecko::MAGIC_GAMEID > 5)
   {
-    existing = magic;
+    gch_gameid = Gecko::MAGIC_GAMEID;
   }
-  PowerPC::HostWrite_U32(existing + 1, 0x80001800);
+  PowerPC::HostWrite_U32(gch_gameid + 1, Gecko::INSTALLER_BASE_ADDRESS);
+
   PowerPC::ppcState.iCache.Reset();
 }
 }

--- a/Source/Core/Core/HLE/HLE_Misc.cpp
+++ b/Source/Core/Core/HLE/HLE_Misc.cpp
@@ -2,22 +2,17 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <cmath>
-#include <string>
-
-#include "Common/CommonTypes.h"
-#include "Core/ConfigManager.h"
-#include "Core/GeckoCode.h"
 #include "Core/HLE/HLE_Misc.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
+#include "Common/MsgHandler.h"
+#include "Core/GeckoCode.h"
 #include "Core/HW/CPU.h"
 #include "Core/Host.h"
-#include "Core/PowerPC/PPCCache.h"
 #include "Core/PowerPC/PowerPC.h"
 
 namespace HLE_Misc
 {
-static std::string args;
-
 // If you just want to kill a function, one of the three following are usually appropriate.
 // According to the PPC ABI, the return value is always in r3.
 void UnimplementedFunction()
@@ -40,7 +35,7 @@ void HBReload()
   Host_Message(WM_USER_STOP);
 }
 
-void HLEGeckoCodehandler()
+void GeckoCodeHandlerICacheFlush()
 {
   // Work around the codehandler not properly invalidating the icache, but
   // only the first few frames.
@@ -60,5 +55,23 @@ void HLEGeckoCodehandler()
   PowerPC::HostWrite_U32(gch_gameid + 1, Gecko::INSTALLER_BASE_ADDRESS);
 
   PowerPC::ppcState.iCache.Reset();
+}
+
+// Because Dolphin messes around with the CPU state instead of patching the game binary, we
+// need a way to branch into the GCH from an arbitrary PC address. Branching is easy, returning
+// back is the hard part. This HLE function acts as a trampoline that restores the original LR, SP,
+// and PC before the magic, invisible BL instruction happened.
+void GeckoReturnTrampoline()
+{
+  // Stack frame is built in GeckoCode.cpp, Gecko::RunCodeHandler.
+  u32 SP = GPR(1);
+  GPR(1) = PowerPC::HostRead_U32(SP + 8);
+  NPC = PowerPC::HostRead_U32(SP + 12);
+  LR = PowerPC::HostRead_U32(SP + 16);
+  for (int i = 0; i < 14; ++i)
+  {
+    riPS0(i) = PowerPC::HostRead_U64(SP + 24 + 2 * i * sizeof(u64));
+    riPS1(i) = PowerPC::HostRead_U64(SP + 24 + (2 * i + 1) * sizeof(u64));
+  }
 }
 }

--- a/Source/Core/Core/HLE/HLE_Misc.cpp
+++ b/Source/Core/Core/HLE/HLE_Misc.cpp
@@ -68,6 +68,7 @@ void GeckoReturnTrampoline()
   GPR(1) = PowerPC::HostRead_U32(SP + 8);
   NPC = PowerPC::HostRead_U32(SP + 12);
   LR = PowerPC::HostRead_U32(SP + 16);
+  PowerPC::ExpandCR(PowerPC::HostRead_U32(SP + 20));
   for (int i = 0; i < 14; ++i)
   {
     riPS0(i) = PowerPC::HostRead_U64(SP + 24 + 2 * i * sizeof(u64));

--- a/Source/Core/Core/HLE/HLE_Misc.h
+++ b/Source/Core/Core/HLE/HLE_Misc.h
@@ -9,5 +9,6 @@ namespace HLE_Misc
 void HLEPanicAlert();
 void UnimplementedFunction();
 void HBReload();
-void HLEGeckoCodehandler();
+void GeckoCodeHandlerICacheFlush();
+void GeckoReturnTrampoline();
 }

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -216,7 +216,7 @@ void ApplyFramePatches()
   ApplyPatches(onFrame);
 
   // Run the Gecko code handler
-  Gecko::RunCodeHandler();
+  Gecko::RunCodeHandler(oldMSR);
   ActionReplay::RunAllActive();
   MSR = oldMSR;
 }

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -260,7 +260,7 @@ void Shutdown()
   onFrame.clear();
   speedHacks.clear();
   ActionReplay::ApplyCodes({});
-  Gecko::SetActiveCodes({});
+  Gecko::Shutdown();
 }
 
 }  // namespace

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -43,7 +43,7 @@ int GetSpeedhackCycles(const u32 addr);
 void LoadPatchSection(const std::string& section, std::vector<Patch>& patches, IniFile& globalIni,
                       IniFile& localIni);
 void LoadPatches();
-void ApplyFramePatches();
+bool ApplyFramePatches();
 void Shutdown();
 
 inline int GetPatchTypeCharLength(PatchType type)

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -565,6 +565,11 @@ u32 HostRead_U32(const u32 address)
   return var;
 }
 
+u64 HostRead_U64(const u32 address)
+{
+  return ReadFromHardware<FLAG_NO_EXCEPTION, u64>(address);
+}
+
 void HostWrite_U8(const u8 var, const u32 address)
 {
   WriteToHardware<FLAG_NO_EXCEPTION, u8>(address, var);

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -209,6 +209,7 @@ void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst);
 u8 HostRead_U8(const u32 address);
 u16 HostRead_U16(const u32 address);
 u32 HostRead_U32(const u32 address);
+u64 HostRead_U64(const u32 address);
 u32 HostRead_Instruction(const u32 address);
 
 void HostWrite_U8(const u8 var, const u32 address);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -23,6 +23,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
+#include "Core/GeckoCode.h"
 #include "Core/HW/HW.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/Host.h"
@@ -70,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 60;  // Last changed in PR 4242
+static const u32 STATE_VERSION = 61;  // Last changed in PR 4216
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,
@@ -174,6 +175,8 @@ static std::string DoState(PointerWrap& p)
   p.DoMarker("HW");
   Movie::DoState(p);
   p.DoMarker("Movie");
+  Gecko::DoState(p);
+  p.DoMarker("Gecko");
 
 #if defined(HAVE_LIBAV) || defined(_WIN32)
   AVIDump::DoState();


### PR DESCRIPTION
`Gecko::RunCodeHandler` uses `PowerPC::SingleStep` inside a CoreTiming callback, this results in a recursive call to `CoreTiming::Advance` which doesn't make sense. Advance is not designed to be re-entrancy safe and we're technically inside the slice boundary between two blocks while trying to run sub-slices inside the previous boundary.

It seems that the Interpreter contains a hack specifically to deal with this situation by overriding the slice length through the exposed global variable. Unfortunately, I accidentally broke that in PR #4201 so Gecko Codes no longer work correctly (The handler is causing 20000 cycle forward time skips in CoreTiming).

I'm not sure what exactly the code was trying to accomplish that couldn't be accomplished by just overwriting `PC` and `NPC` with the code handler entrypoint which is what I've changed it to do. [Someone more familiar with the JIT should double check this]

There was also a race condition with s_active_codes and the code table builder had a weird flaw where it writes half of a code then truncates the rest if it won't fit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4216)
<!-- Reviewable:end -->
