### PR TITLE
PPCDebugInterface: Let ToggleMemCheck create the first memcheck

### DIFF
--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -137,12 +137,12 @@ void PPCDebugInterface::ClearAllMemChecks()
 
 bool PPCDebugInterface::IsMemCheck(unsigned int address)
 {
-  return (PowerPC::memchecks.HasAny() && PowerPC::memchecks.GetMemCheck(address));
+  return PowerPC::memchecks.GetMemCheck(address) != nullptr;
 }
 
 void PPCDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool write, bool log)
 {
-  if (PowerPC::memchecks.HasAny() && !PowerPC::memchecks.GetMemCheck(address))
+  if (!IsMemCheck(address))
   {
     // Add Memory Check
     TMemCheck MemCheck;
@@ -157,7 +157,9 @@ void PPCDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool wri
     PowerPC::memchecks.Add(MemCheck);
   }
   else
+  {
     PowerPC::memchecks.Remove(address);
+  }
 }
 
 void PPCDebugInterface::InsertBLR(unsigned int address, unsigned int value)


### PR DESCRIPTION
`ToggleMemCheck` fails to create a new memcheck if there isn't already an existing one which seems like an unnecessary limitation that prevents `CMemoryView` from being able to create memory checks without adding one via the breakpoint tool window first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4217)
<!-- Reviewable:end -->
