### PR TITLE
Android: fix save and load state menus on non-TV devices

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -426,11 +426,17 @@ public final class EmulationActivity extends AppCompatActivity
 
 			// TV Menu only
 			case R.id.menu_emulation_save_root:
-				showMenu(SaveStateFragment.FRAGMENT_ID);
+				if (!mDeviceHasTouchScreen)
+				{
+					showMenu(SaveStateFragment.FRAGMENT_ID);
+				}
 				return;
 
 			case R.id.menu_emulation_load_root:
-				showMenu(LoadStateFragment.FRAGMENT_ID);
+				if (!mDeviceHasTouchScreen)
+				{
+					showMenu(LoadStateFragment.FRAGMENT_ID);
+				}
 				return;
 
 			// Save state slots


### PR DESCRIPTION
The save and load state menus would try to load the Android TV UI fragments regardless of device. On non-Android TV devices, this resulted in a crash because the layout doesn't exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4219)
<!-- Reviewable:end -->
