### PR TITLE
Redo the MemCheck add dialog

### DIFF
--- a/Source/Core/Common/BreakPoints.cpp
+++ b/Source/Core/Common/BreakPoints.cpp
@@ -218,8 +218,8 @@ bool TMemCheck::Action(DebugInterface* debug_interface, u32 iValue, u32 addr, bo
                debug_interface->GetDescription(pc).c_str(), write ? "Write" : "Read", size * 8,
                size * 2, iValue, addr, debug_interface->GetDescription(addr).c_str());
     }
-
-    return true;
+    if (Break)
+      return true;
   }
   return false;
 }

--- a/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.h
@@ -7,7 +7,8 @@
 #include <wx/dialog.h>
 
 class CBreakPointWindow;
-class wxCheckBox;
+class wxRadioButton;
+class wxStaticText;
 class wxTextCtrl;
 
 class MemoryCheckDlg : public wxDialog
@@ -17,12 +18,21 @@ public:
 
 private:
   CBreakPointWindow* m_parent;
-  wxCheckBox* m_pReadFlag;
-  wxCheckBox* m_pWriteFlag;
-  wxCheckBox* m_log_flag;
-  wxCheckBox* m_break_flag;
+  wxStaticText* m_textAddress;
+  wxStaticText* m_textStartAddress;
+  wxStaticText* m_textEndAddress;
+  wxRadioButton* m_radioLog;
+  wxRadioButton* m_radioBreak;
+  wxRadioButton* m_radioBreakLog;
+  wxRadioButton* m_radioRead;
+  wxRadioButton* m_radioWrite;
+  wxRadioButton* m_radioReadWrite;
+  wxRadioButton* m_radioAddress;
+  wxRadioButton* m_radioRange;
+  wxTextCtrl* m_pEditAddress;
   wxTextCtrl* m_pEditEndAddress;
   wxTextCtrl* m_pEditStartAddress;
 
+  void OnRadioButtonClick(wxCommandEvent& event);
   void OnOK(wxCommandEvent& event);
 };


### PR DESCRIPTION
The old one wasn't very optimal because not only the user would likely want to enter an address instead of a range, but it also made entering just one address confusing (you had to have the same value on both start and end).  Also, you should only chose one option between read, write or both, there is no point to not have any.

This is why I made more clear how to add an address and it is the default option using radio buttons and I also made the action flags to be radio buttons.

It's a pretty big change to it so here's a comparison.

Master:
![screenshot from 2016-09-16 17-52-19](https://cloud.githubusercontent.com/assets/8932978/18602641/e599edd2-7c38-11e6-9678-80bc2a4e326a.png)

This PR:
![screenshot from 2016-09-25 18-09-53](https://cloud.githubusercontent.com/assets/8932978/18818603/a24195c0-834b-11e6-8bac-61898670d88c.png)

~~EDIT::  Don't merge this yet, I realised that I shoudl also put radio buttons on the flags part, plus, I should be fixing a thign with the break condition while I am at it.~~

This is now ready for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4220)
<!-- Reviewable:end -->
