### PR TITLE
Android: scale buttons based on smaller screen dimension

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -54,12 +54,14 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 	 */
 	public static Bitmap resizeBitmap(Context context, Bitmap bitmap, float scale)
 	{
-		// Retrieve screen dimensions.
+		// Determine the button size based on the smaller screen dimension.
+		// This makes sure the buttons are the same size in both portrait and landscape.
 		DisplayMetrics dm = context.getResources().getDisplayMetrics();
+		int minDimension = Math.min(dm.widthPixels, dm.heightPixels);
 
 		return Bitmap.createScaledBitmap(bitmap,
-				(int)(dm.heightPixels * scale),
-				(int)(dm.heightPixels * scale),
+				(int)(minDimension * scale),
+				(int)(minDimension * scale),
 				true);
 	}
 


### PR DESCRIPTION
This makes playing in portrait mode on phones actually possible.
Before: http://i.imgur.com/J5uXtXE.png
After: http://i.imgur.com/BgqsTZO.png

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4222)
<!-- Reviewable:end -->
