### PR TITLE
Filesystem: Return strings from GetFileName without the const qualifier

### DIFF
--- a/Source/Core/DiscIO/FileSystemGCWii.cpp
+++ b/Source/Core/DiscIO/FileSystemGCWii.cpp
@@ -44,7 +44,7 @@ u64 CFileSystemGCWii::GetFileSize(const std::string& _rFullPath)
   return 0;
 }
 
-const std::string CFileSystemGCWii::GetFileName(u64 _Address)
+std::string CFileSystemGCWii::GetFileName(u64 _Address)
 {
   if (!m_Initialized)
     InitFileSystem();

--- a/Source/Core/DiscIO/FileSystemGCWii.h
+++ b/Source/Core/DiscIO/FileSystemGCWii.h
@@ -24,7 +24,7 @@ public:
   bool IsValid() const override { return m_Valid; }
   u64 GetFileSize(const std::string& _rFullPath) override;
   const std::vector<SFileInfo>& GetFileList() override;
-  const std::string GetFileName(u64 _Address) override;
+  std::string GetFileName(u64 _Address) override;
   u64 ReadFile(const std::string& _rFullPath, u8* _pBuffer, u64 _MaxBufferSize,
                u64 _OffsetInFile) override;
   bool ExportFile(const std::string& _rFullPath, const std::string& _rExportFilename) override;

--- a/Source/Core/DiscIO/Filesystem.h
+++ b/Source/Core/DiscIO/Filesystem.h
@@ -46,7 +46,7 @@ public:
   virtual bool ExportFile(const std::string& _rFullPath, const std::string& _rExportFilename) = 0;
   virtual bool ExportApploader(const std::string& _rExportFolder) const = 0;
   virtual bool ExportDOL(const std::string& _rExportFolder) const = 0;
-  virtual const std::string GetFileName(u64 _Address) = 0;
+  virtual std::string GetFileName(u64 _Address) = 0;
   virtual u64 GetBootDOLOffset() const = 0;
   virtual u32 GetBootDOLSize(u64 dol_offset) const = 0;
 


### PR DESCRIPTION
This is mostly pointless and can inhibit move construction

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4226)
<!-- Reviewable:end -->
