### PR TITLE
Android: fix joystick saving incorrect y-coordinate

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -231,7 +231,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 				case MotionEvent.ACTION_POINTER_UP:
 					if (mJoystickBeingConfigured != null)
 					{
-						saveControlPosition(mJoystickBeingConfigured.getSharedPrefsId(), mJoystickBeingConfigured.getBounds().left, mJoystickBeingConfigured.getBounds().right);
+						saveControlPosition(mJoystickBeingConfigured.getSharedPrefsId(), mJoystickBeingConfigured.getBounds().left, mJoystickBeingConfigured.getBounds().top);
 						mJoystickBeingConfigured = null;
 					}
 					break;


### PR DESCRIPTION
The y-coordinate was being saved incorrectly for joysticks. It was a very annoying bug!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4229)
<!-- Reviewable:end -->
