### PR TITLE
Move LogWindow/LogConfigWindow destructor logic -> OnClose

### DIFF
--- a/Source/Core/DolphinWX/LogConfigWindow.cpp
+++ b/Source/Core/DolphinWX/LogConfigWindow.cpp
@@ -25,13 +25,14 @@ LogConfigWindow::LogConfigWindow(wxWindow* parent, wxWindowID id)
               _("Log Configuration")),
       enableAll(true)
 {
+  Bind(wxEVT_CLOSE_WINDOW, &LogConfigWindow::OnClose, this);
   SetMinSize(wxSize(100, 100));
   m_LogManager = LogManager::GetInstance();
   CreateGUIControls();
   LoadSettings();
 }
 
-LogConfigWindow::~LogConfigWindow()
+void LogConfigWindow::OnClose(wxCloseEvent& event)
 {
   SaveSettings();
 }

--- a/Source/Core/DolphinWX/LogConfigWindow.h
+++ b/Source/Core/DolphinWX/LogConfigWindow.h
@@ -15,7 +15,6 @@ class LogConfigWindow : public wxPanel
 {
 public:
   LogConfigWindow(wxWindow* parent, wxWindowID id = wxID_ANY);
-  ~LogConfigWindow();
 
   void SaveSettings();
   void LoadSettings();
@@ -32,6 +31,7 @@ private:
 
   void CreateGUIControls();
   void OnVerbosityChange(wxCommandEvent& event);
+  void OnClose(wxCloseEvent& event);
   void OnWriteFileChecked(wxCommandEvent& event);
   void OnWriteConsoleChecked(wxCommandEvent& event);
   void OnWriteWindowChecked(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/LogWindow.cpp
+++ b/Source/Core/DolphinWX/LogWindow.cpp
@@ -149,18 +149,20 @@ void CLogWindow::CreateGUIControls()
   m_cmdline->SetFocus();
 }
 
-CLogWindow::~CLogWindow()
-{
-  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
-  {
-    m_LogManager->RemoveListener((LogTypes::LOG_TYPE)i, LogListener::LOG_WINDOW_LISTENER);
-  }
-}
-
 void CLogWindow::OnClose(wxCloseEvent& event)
 {
   SaveSettings();
   event.Skip();
+  RemoveAllListeners();
+}
+
+void CLogWindow::RemoveAllListeners()
+{
+  for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i)
+  {
+    m_LogManager->RemoveListener(static_cast<LogTypes::LOG_TYPE>(i),
+                                 LogListener::LOG_WINDOW_LISTENER);
+  }
 }
 
 void CLogWindow::SaveSettings()

--- a/Source/Core/DolphinWX/LogWindow.h
+++ b/Source/Core/DolphinWX/LogWindow.h
@@ -28,7 +28,6 @@ public:
   CLogWindow(CFrame* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition,
              const wxSize& size = wxDefaultSize, long style = wxTAB_TRAVERSAL,
              const wxString& name = _("Log"));
-  ~CLogWindow();
 
   void SaveSettings();
   void Log(LogTypes::LOG_LEVELS, const char* text) override;
@@ -63,5 +62,6 @@ private:
   void OnWrapLineCheck(wxCommandEvent& event);
   void OnClear(wxCommandEvent& event);
   void OnLogTimer(wxTimerEvent& WXUNUSED(event));
+  void RemoveAllListeners();
   void UpdateLog();
 };


### PR DESCRIPTION
Fixes the issue on macOS where quitting [Dolphin from the Dock causes a crash report](https://bugs.dolphin-emu.org/issues/9794). I'm not exactly sure why this works, but it feels 🌟right🌟 and it fixes the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4231)
<!-- Reviewable:end -->
