### PR TITLE
EfbInterface: Change out parameters on getters to return by value

### DIFF
--- a/Source/Core/VideoBackends/Software/DebugUtil.cpp
+++ b/Source/Core/VideoBackends/Software/DebugUtil.cpp
@@ -2,13 +2,17 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/Software/DebugUtil.h"
+
+#include <cstring>
+
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
 #include "Core/ConfigManager.h"
 
-#include "VideoBackends/Software/DebugUtil.h"
 #include "VideoBackends/Software/EfbInterface.h"
 #include "VideoBackends/Software/SWRenderer.h"
 #include "VideoBackends/Software/TextureSampler.h"
@@ -133,18 +137,16 @@ static void DumpEfb(const std::string& filename)
 {
   u8* data = new u8[EFB_WIDTH * EFB_HEIGHT * 4];
   u8* writePtr = data;
-  u8 sample[4];
 
   for (int y = 0; y < EFB_HEIGHT; y++)
   {
     for (int x = 0; x < EFB_WIDTH; x++)
     {
-      EfbInterface::GetColor(x, y, sample);
       // ABGR to RGBA
-      *(writePtr++) = sample[3];
-      *(writePtr++) = sample[2];
-      *(writePtr++) = sample[1];
-      *(writePtr++) = sample[0];
+      const u32 sample = Common::swap32(EfbInterface::GetColor(x, y));
+
+      std::memcpy(writePtr, &sample, sizeof(u32));
+      writePtr += sizeof(u32);
     }
   }
 

--- a/Source/Core/VideoBackends/Software/EfbInterface.h
+++ b/Source/Core/VideoBackends/Software/EfbInterface.h
@@ -51,8 +51,8 @@ bool ZCompare(u16 x, u16 y, u32 z);
 void SetColor(u16 x, u16 y, u8* color);
 void SetDepth(u16 x, u16 y, u32 depth);
 
-void GetColor(u16 x, u16 y, u8* color);
-void GetColorYUV(u16 x, u16 y, yuv444* color);
+u32 GetColor(u16 x, u16 y);
+yuv444 GetColorYUV(u16 x, u16 y);
 u32 GetDepth(u16 x, u16 y);
 
 u8* GetPixelPointer(u16 x, u16 y, bool depth);

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -176,8 +176,7 @@ u32 SWRenderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)
   }
   case PEEK_COLOR:
   {
-    u32 color = 0;
-    EfbInterface::GetColor(x, y, (u8*)&color);
+    const u32 color = EfbInterface::GetColor(x, y);
 
     // rgba to argb
     value = (color >> 8) | (color & 0xff) << 24;


### PR DESCRIPTION
Rather than use out parameters (and also reinterpret memory/type pun all over the place), we can just make the API consistent and handle accordingly. We still pun memory haphazardly all over the place in setters, but that's planned to be resolved in a follow-up PR after this one.

Let me know if anything looks off.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4233)
<!-- Reviewable:end -->
