### PR TITLE
EfbInterface: Make SetColor take a u32 instead of a pointer

### DIFF
--- a/Source/Core/VideoBackends/Software/EfbCopy.cpp
+++ b/Source/Core/VideoBackends/Software/EfbCopy.cpp
@@ -50,7 +50,7 @@ void ClearEfb()
   {
     for (u16 x = left; x <= right; x++)
     {
-      EfbInterface::SetColor(x, y, (u8*)(&clearColor));
+      EfbInterface::SetColor(x, y, clearColor);
       EfbInterface::SetDepth(x, y, bpmem.clearZValue);
     }
   }

--- a/Source/Core/VideoBackends/Software/EfbInterface.cpp
+++ b/Source/Core/VideoBackends/Software/EfbInterface.cpp
@@ -31,7 +31,7 @@ static inline u32 GetDepthOffset(u16 x, u16 y)
   return (x + y * EFB_WIDTH) * 3 + DEPTH_BUFFER_START;
 }
 
-static void SetPixelAlphaOnly(u32 offset, u8 a)
+static void SetPixelAlphaOnly(u32 offset, u32 pixel)
 {
   switch (bpmem.zcontrol.pixel_format)
   {
@@ -42,11 +42,13 @@ static void SetPixelAlphaOnly(u32 offset, u8 a)
     break;
   case PEControl::RGBA6_Z24:
   {
-    u32 a32 = a;
-    u32* dst = (u32*)&efb[offset];
-    u32 val = *dst & 0xffffffc0;
-    val |= (a32 >> 2) & 0x0000003f;
-    *dst = val;
+    const u32 alpha = pixel & 0xFF;
+    u32 efb_pixel;
+    std::memcpy(&efb_pixel, &efb[offset], sizeof(u32));
+
+    u32 val = efb_pixel & 0xffffffc0;
+    val |= (alpha >> 2) & 0x0000003f;
+    std::memcpy(&efb[offset], &val, sizeof(u32));
   }
   break;
   default:
@@ -54,39 +56,36 @@ static void SetPixelAlphaOnly(u32 offset, u8 a)
   }
 }
 
-static void SetPixelColorOnly(u32 offset, u8* rgb)
+static void SetPixelColorOnly(u32 offset, u32 rgb)
 {
+  u32 efb_pixel;
+  std::memcpy(&efb_pixel, &efb[offset], sizeof(u32));
+
   switch (bpmem.zcontrol.pixel_format)
   {
   case PEControl::RGB8_Z24:
   case PEControl::Z24:
   {
-    u32 src = *(u32*)rgb;
-    u32* dst = (u32*)&efb[offset];
-    u32 val = *dst & 0xff000000;
-    val |= src >> 8;
-    *dst = val;
+    u32 val = efb_pixel & 0xff000000;
+    val |= rgb >> 8;
+    std::memcpy(&efb[offset], &val, sizeof(u32));
   }
   break;
   case PEControl::RGBA6_Z24:
   {
-    u32 src = *(u32*)rgb;
-    u32* dst = (u32*)&efb[offset];
-    u32 val = *dst & 0xff00003f;
-    val |= (src >> 4) & 0x00000fc0;  // blue
-    val |= (src >> 6) & 0x0003f000;  // green
-    val |= (src >> 8) & 0x00fc0000;  // red
-    *dst = val;
+    u32 val = efb_pixel & 0xff00003f;
+    val |= (rgb >> 4) & 0x00000fc0;  // blue
+    val |= (rgb >> 6) & 0x0003f000;  // green
+    val |= (rgb >> 8) & 0x00fc0000;  // red
+    std::memcpy(&efb[offset], &val, sizeof(u32));
   }
   break;
   case PEControl::RGB565_Z16:
   {
     WARN_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
-    u32 src = *(u32*)rgb;
-    u32* dst = (u32*)&efb[offset];
-    u32 val = *dst & 0xff000000;
-    val |= src >> 8;
-    *dst = val;
+    u32 val = efb_pixel & 0xff000000;
+    val |= rgb >> 8;
+    std::memcpy(&efb[offset], &val, sizeof(u32));
   }
   break;
   default:
@@ -94,40 +93,37 @@ static void SetPixelColorOnly(u32 offset, u8* rgb)
   }
 }
 
-static void SetPixelAlphaColor(u32 offset, u8* color)
+static void SetPixelAlphaColor(u32 offset, u32 color)
 {
+  u32 efb_pixel;
+  std::memcpy(&efb_pixel, &efb[offset], sizeof(u32));
+
   switch (bpmem.zcontrol.pixel_format)
   {
   case PEControl::RGB8_Z24:
   case PEControl::Z24:
   {
-    u32 src = *(u32*)color;
-    u32* dst = (u32*)&efb[offset];
-    u32 val = *dst & 0xff000000;
-    val |= src >> 8;
-    *dst = val;
+    u32 val = efb_pixel & 0xff000000;
+    val |= color >> 8;
+    std::memcpy(&efb[offset], &val, sizeof(u32));
   }
   break;
   case PEControl::RGBA6_Z24:
   {
-    u32 src = *(u32*)color;
-    u32* dst = (u32*)&efb[offset];
-    u32 val = *dst & 0xff000000;
-    val |= (src >> 2) & 0x0000003f;  // alpha
-    val |= (src >> 4) & 0x00000fc0;  // blue
-    val |= (src >> 6) & 0x0003f000;  // green
-    val |= (src >> 8) & 0x00fc0000;  // red
-    *dst = val;
+    u32 val = efb_pixel & 0xff000000;
+    val |= (color >> 2) & 0x0000003f;  // alpha
+    val |= (color >> 4) & 0x00000fc0;  // blue
+    val |= (color >> 6) & 0x0003f000;  // green
+    val |= (color >> 8) & 0x00fc0000;  // red
+    std::memcpy(&efb[offset], &val, sizeof(u32));
   }
   break;
   case PEControl::RGB565_Z16:
   {
     WARN_LOG(VIDEO, "RGB565_Z16 is not supported correctly yet");
-    u32 src = *(u32*)color;
-    u32* dst = (u32*)&efb[offset];
-    u32 val = *dst & 0xff000000;
-    val |= src >> 8;
-    *dst = val;
+    u32 val = efb_pixel & 0xff000000;
+    val |= color >> 8;
+    std::memcpy(&efb[offset], &val, sizeof(u32));
   }
   break;
   default:
@@ -428,17 +424,17 @@ void BlendTev(u16 x, u16 y, u8* color)
   {
     Dither(x, y, dstClrPtr);
     if (bpmem.blendmode.alphaupdate)
-      SetPixelAlphaColor(offset, dstClrPtr);
+      SetPixelAlphaColor(offset, dstClr);
     else
-      SetPixelColorOnly(offset, dstClrPtr);
+      SetPixelColorOnly(offset, dstClr);
   }
   else if (bpmem.blendmode.alphaupdate)
   {
-    SetPixelAlphaOnly(offset, dstClrPtr[ALP_C]);
+    SetPixelAlphaOnly(offset, dstClr);
   }
 }
 
-void SetColor(u16 x, u16 y, u8* color)
+void SetColor(u16 x, u16 y, u32 color)
 {
   u32 offset = GetColorOffset(x, y);
   if (bpmem.blendmode.colorupdate)
@@ -450,7 +446,7 @@ void SetColor(u16 x, u16 y, u8* color)
   }
   else if (bpmem.blendmode.alphaupdate)
   {
-    SetPixelAlphaOnly(offset, color[ALP_C]);
+    SetPixelAlphaOnly(offset, color);
   }
 }
 

--- a/Source/Core/VideoBackends/Software/EfbInterface.h
+++ b/Source/Core/VideoBackends/Software/EfbInterface.h
@@ -48,7 +48,7 @@ void BlendTev(u16 x, u16 y, u8* color);
 bool ZCompare(u16 x, u16 y, u32 z);
 
 // sets the color and alpha
-void SetColor(u16 x, u16 y, u8* color);
+void SetColor(u16 x, u16 y, u32 color);
 void SetDepth(u16 x, u16 y, u32 depth);
 
 u32 GetColor(u16 x, u16 y);


### PR DESCRIPTION
Makes it consistent with SetDepth and also gets rid of some type punning.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4235)

<!-- Reviewable:end -->
