### PR TITLE
MainNoGUI: Shut down cleanly on SIGINT/SIGTERM

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -33,7 +33,6 @@
 
 namespace Common
 {
-
 #if !defined(_WIN32)
 #include <unistd.h>
 static uintptr_t RoundPage(uintptr_t addr)

--- a/Source/Core/Common/MemoryUtil.h
+++ b/Source/Core/Common/MemoryUtil.h
@@ -9,7 +9,6 @@
 
 namespace Common
 {
-
 void* AllocateExecutableMemory(size_t size, bool low = true);
 void* AllocateMemoryPages(size_t size);
 void FreeMemoryPages(void* ptr, size_t size);


### PR DESCRIPTION
This is the same as PR #3991, but for MainNoGUI.

nogui/headless will shut down cleanly on SIGINT and SIGTERM, just like it would when closing the render window.

The default signal handler will be restored after a first shutdown signal so a second signal will exit Dolphin forcefully.

Fixes [issue 9423](https://dolp.in/i9423).
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4243)
<!-- Reviewable:end -->
