### PR TITLE
Shut down Wii software gracefully

### DIFF
--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -310,7 +310,7 @@ void SysConf::GenerateSysConf()
 
   // IPL.IDL
   current_offset += create_item(items[23], Type_SmallArray, "IPL.IDL", 1, current_offset);
-  items[23].data[0] = 0x01;
+  items[23].data[0] = 0x00;
 
   // IPL.EULA
   current_offset += create_item(items[24], Type_Bool, "IPL.EULA", 1, current_offset);

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -392,6 +392,15 @@ bool BootCore(const std::string& _rFilename)
   SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", StartUp.bProgressive);
   SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", StartUp.bPAL60);
 
+  if (StartUp.bWii)
+  {
+    // Disable WiiConnect24's standby mode. If it is enabled, it prevents us from receiving
+    // shutdown commands in the State Transition Manager (STM).
+    // TODO: remove this if and once Dolphin supports WC24 standby mode.
+    SConfig::GetInstance().m_SYSCONF->SetData("IPL.IDL", 0x00);
+    NOTICE_LOG(BOOT, "Disabling WC24 'standby' (shutdown to idle) to avoid hanging on shutdown");
+  }
+
   // Run the game
   // Init the core
   if (!Core::Init())

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -143,6 +143,7 @@ set(SRCS	ActionReplay.cpp
 			IPC_HLE/WII_Socket.cpp
 			IPC_HLE/WII_IPC_HLE_Device_net.cpp
 			IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+			IPC_HLE/WII_IPC_HLE_Device_stm.cpp
 			IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
 			IPC_HLE/WII_IPC_HLE_Device_usb.cpp
 			IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -183,6 +183,7 @@
     </ClCompile>
     <ClCompile Include="IPC_HLE\WII_IPC_HLE_Device_net.cpp" />
     <ClCompile Include="IPC_HLE\WII_IPC_HLE_Device_net_ssl.cpp" />
+    <ClCompile Include="IPC_HLE\WII_IPC_HLE_Device_stm.cpp" />
     <ClCompile Include="IPC_HLE\WII_IPC_HLE_Device_sdio_slot0.cpp" />
     <ClCompile Include="IPC_HLE\WII_IPC_HLE_Device_usb.cpp" />
     <ClCompile Include="IPC_HLE\WII_IPC_HLE_Device_usb_kbd.cpp" />
@@ -386,8 +387,8 @@
     <ClInclude Include="IPC_HLE\WII_IPC_HLE_Device_hid.h" />
     <ClInclude Include="IPC_HLE\WII_IPC_HLE_Device_net.h" />
     <ClInclude Include="IPC_HLE\WII_IPC_HLE_Device_net_ssl.h" />
-    <ClInclude Include="IPC_HLE\WII_IPC_HLE_Device_sdio_slot0.h" />
     <ClInclude Include="IPC_HLE\WII_IPC_HLE_Device_stm.h" />
+    <ClInclude Include="IPC_HLE\WII_IPC_HLE_Device_sdio_slot0.h" />
     <ClInclude Include="IPC_HLE\WII_IPC_HLE_Device_usb.h" />
     <ClInclude Include="IPC_HLE\WII_IPC_HLE_Device_usb_kbd.h" />
     <ClInclude Include="IPC_HLE\WII_IPC_HLE_Device_usb_ven.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -585,6 +585,9 @@
     <ClCompile Include="IPC_HLE\WII_IPC_HLE_Device_sdio_slot0.cpp">
       <Filter>IPC HLE %28IOS/Starlet%29\SDIO - SD Card</Filter>
     </ClCompile>
+    <ClCompile Include="IPC_HLE\WII_IPC_HLE_Device_stm.cpp">
+      <Filter>IPC HLE %28IOS/Starlet%29</Filter>
+    </ClCompile>
     <ClCompile Include="IPC_HLE\WII_IPC_HLE_Device_hid.cpp">
       <Filter>IPC HLE %28IOS/Starlet%29\USB</Filter>
     </ClCompile>

--- a/Source/Core/Core/HW/ProcessorInterface.h
+++ b/Source/Core/Core/HW/ProcessorInterface.h
@@ -76,5 +76,6 @@ void SetInterrupt(u32 _causemask, bool _bSet = true);
 
 // Thread-safe func which sets and clears reset button state automagically
 void ResetButton_Tap();
+void PowerButton_Tap();
 
 }  // namespace ProcessorInterface

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -1,0 +1,134 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/IPC_HLE/WII_IPC_HLE_Device_stm.h"
+
+IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Open(u32 _CommandAddress, u32 _Mode)
+{
+  INFO_LOG(WII_IPC_STM, "STM immediate: Open");
+  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
+  m_Active = true;
+  return GetDefaultReply();
+}
+
+IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Close(u32 _CommandAddress, bool _bForce)
+{
+  INFO_LOG(WII_IPC_STM, "STM immediate: Close");
+  if (!_bForce)
+    Memory::Write_U32(0, _CommandAddress + 4);
+  m_Active = false;
+  return GetDefaultReply();
+}
+
+IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 _CommandAddress)
+{
+  u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
+  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
+  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
+  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
+  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
+
+  // Prepare the out buffer(s) with zeroes as a safety precaution
+  // to avoid returning bad values
+  Memory::Memset(BufferOut, 0, BufferOutSize);
+  u32 ReturnValue = 0;
+
+  switch (Parameter)
+  {
+  case IOCTL_STM_RELEASE_EH:
+    INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
+    INFO_LOG(WII_IPC_STM, "    IOCTL_STM_RELEASE_EH");
+    break;
+
+  case IOCTL_STM_HOTRESET:
+    INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
+    INFO_LOG(WII_IPC_STM, "    IOCTL_STM_HOTRESET");
+    break;
+
+  case IOCTL_STM_VIDIMMING:  // (Input: 20 bytes, Output: 20 bytes)
+    INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
+    INFO_LOG(WII_IPC_STM, "    IOCTL_STM_VIDIMMING");
+    // DumpCommands(BufferIn, BufferInSize / 4, LogTypes::WII_IPC_STM);
+    // Memory::Write_U32(1, BufferOut);
+    // ReturnValue = 1;
+    break;
+
+  case IOCTL_STM_LEDMODE:  // (Input: 20 bytes, Output: 20 bytes)
+    INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
+    INFO_LOG(WII_IPC_STM, "    IOCTL_STM_LEDMODE");
+    break;
+
+  default:
+  {
+    _dbg_assert_msg_(WII_IPC_STM, 0, "CWII_IPC_HLE_Device_stm_immediate: 0x%x", Parameter);
+
+    INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
+    DEBUG_LOG(WII_IPC_STM, "    Parameter: 0x%x", Parameter);
+    DEBUG_LOG(WII_IPC_STM, "    InBuffer: 0x%08x", BufferIn);
+    DEBUG_LOG(WII_IPC_STM, "    InBufferSize: 0x%08x", BufferInSize);
+    DEBUG_LOG(WII_IPC_STM, "    OutBuffer: 0x%08x", BufferOut);
+    DEBUG_LOG(WII_IPC_STM, "    OutBufferSize: 0x%08x", BufferOutSize);
+  }
+  break;
+  }
+
+  // Write return value to the IPC call
+  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
+  return GetDefaultReply();
+}
+
+IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Open(u32 _CommandAddress, u32 _Mode)
+{
+  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
+  m_Active = true;
+  return GetDefaultReply();
+}
+
+IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Close(u32 _CommandAddress, bool _bForce)
+{
+  m_EventHookAddress = 0;
+
+  INFO_LOG(WII_IPC_STM, "STM eventhook: Close");
+  if (!_bForce)
+    Memory::Write_U32(0, _CommandAddress + 4);
+  m_Active = false;
+  return GetDefaultReply();
+}
+
+IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 _CommandAddress)
+{
+  u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
+  if (Parameter != IOCTL_STM_EVENTHOOK)
+  {
+    ERROR_LOG(WII_IPC_STM, "Bad IOCtl in CWII_IPC_HLE_Device_stm_eventhook");
+    Memory::Write_U32(FS_EINVAL, _CommandAddress + 4);
+    return GetDefaultReply();
+  }
+
+  // IOCTL_STM_EVENTHOOK waits until the reset button or power button
+  // is pressed.
+  m_EventHookAddress = _CommandAddress;
+  return GetNoReply();
+}
+
+void CWII_IPC_HLE_Device_stm_eventhook::ResetButton()
+{
+  if (!m_Active || m_EventHookAddress == 0)
+  {
+    // If the device isn't open, ignore the button press.
+    return;
+  }
+
+  // The reset button returns STM_EVENT_RESET.
+  u32 BufferOut = Memory::Read_U32(m_EventHookAddress + 0x18);
+  Memory::Write_U32(STM_EVENT_RESET, BufferOut);
+
+  // Fill in command buffer.
+  Memory::Write_U32(FS_SUCCESS, m_EventHookAddress + 4);
+  Memory::Write_U32(IPC_REP_ASYNC, m_EventHookAddress);
+  Memory::Write_U32(IPC_CMD_IOCTL, m_EventHookAddress + 8);
+
+  // Generate a reply to the IPC command.
+  WII_IPC_HLE_Interface::EnqueueReply(m_EventHookAddress);
+}

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -4,37 +4,37 @@
 
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_stm.h"
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Open(u32 command_address, u32 mode)
 {
   INFO_LOG(WII_IPC_STM, "STM immediate: Open");
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
+  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Close(u32 command_address, bool force)
 {
   INFO_LOG(WII_IPC_STM, "STM immediate: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
+  if (!force)
+    Memory::Write_U32(0, command_address + 4);
   m_Active = false;
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
 {
-  u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
+  u32 parameter = Memory::Read_U32(command_address + 0x0C);
+  u32 buffer_in = Memory::Read_U32(command_address + 0x10);
+  u32 buffer_in_size = Memory::Read_U32(command_address + 0x14);
+  u32 buffer_out = Memory::Read_U32(command_address + 0x18);
+  u32 buffer_out_size = Memory::Read_U32(command_address + 0x1C);
 
   // Prepare the out buffer(s) with zeroes as a safety precaution
   // to avoid returning bad values
-  Memory::Memset(BufferOut, 0, BufferOutSize);
-  u32 ReturnValue = 0;
+  Memory::Memset(buffer_out, 0, buffer_out_size);
+  u32 return_value = 0;
 
-  switch (Parameter)
+  switch (parameter)
   {
   case IOCTL_STM_RELEASE_EH:
     INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
@@ -49,9 +49,9 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 _CommandAddress)
   case IOCTL_STM_VIDIMMING:  // (Input: 20 bytes, Output: 20 bytes)
     INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
     INFO_LOG(WII_IPC_STM, "    IOCTL_STM_VIDIMMING");
-    // DumpCommands(BufferIn, BufferInSize / 4, LogTypes::WII_IPC_STM);
-    // Memory::Write_U32(1, BufferOut);
-    // ReturnValue = 1;
+    // DumpCommands(buffer_in, buffer_in_size / 4, LogTypes::WII_IPC_STM);
+    // Memory::Write_U32(1, buffer_out);
+    // return_value = 1;
     break;
 
   case IOCTL_STM_LEDMODE:  // (Input: 20 bytes, Output: 20 bytes)
@@ -61,74 +61,74 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 _CommandAddress)
 
   default:
   {
-    _dbg_assert_msg_(WII_IPC_STM, 0, "CWII_IPC_HLE_Device_stm_immediate: 0x%x", Parameter);
+    _dbg_assert_msg_(WII_IPC_STM, 0, "CWII_IPC_HLE_Device_stm_immediate: 0x%x", parameter);
 
     INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
-    DEBUG_LOG(WII_IPC_STM, "    Parameter: 0x%x", Parameter);
-    DEBUG_LOG(WII_IPC_STM, "    InBuffer: 0x%08x", BufferIn);
-    DEBUG_LOG(WII_IPC_STM, "    InBufferSize: 0x%08x", BufferInSize);
-    DEBUG_LOG(WII_IPC_STM, "    OutBuffer: 0x%08x", BufferOut);
-    DEBUG_LOG(WII_IPC_STM, "    OutBufferSize: 0x%08x", BufferOutSize);
+    DEBUG_LOG(WII_IPC_STM, "    parameter: 0x%x", parameter);
+    DEBUG_LOG(WII_IPC_STM, "    InBuffer: 0x%08x", buffer_in);
+    DEBUG_LOG(WII_IPC_STM, "    InBufferSize: 0x%08x", buffer_in_size);
+    DEBUG_LOG(WII_IPC_STM, "    OutBuffer: 0x%08x", buffer_out);
+    DEBUG_LOG(WII_IPC_STM, "    OutBufferSize: 0x%08x", buffer_out_size);
   }
   break;
   }
 
   // Write return value to the IPC call
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
+  Memory::Write_U32(return_value, command_address + 0x4);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Open(u32 _CommandAddress, u32 _Mode)
+IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Open(u32 command_address, u32 mode)
 {
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
+  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Close(u32 command_address, bool force)
 {
-  m_EventHookAddress = 0;
+  m_event_hook_address = 0;
 
   INFO_LOG(WII_IPC_STM, "STM eventhook: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
+  if (!force)
+    Memory::Write_U32(0, command_address + 4);
   m_Active = false;
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 command_address)
 {
-  u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
-  if (Parameter != IOCTL_STM_EVENTHOOK)
+  u32 parameter = Memory::Read_U32(command_address + 0x0C);
+  if (parameter != IOCTL_STM_EVENTHOOK)
   {
     ERROR_LOG(WII_IPC_STM, "Bad IOCtl in CWII_IPC_HLE_Device_stm_eventhook");
-    Memory::Write_U32(FS_EINVAL, _CommandAddress + 4);
+    Memory::Write_U32(FS_EINVAL, command_address + 4);
     return GetDefaultReply();
   }
 
   // IOCTL_STM_EVENTHOOK waits until the reset button or power button
   // is pressed.
-  m_EventHookAddress = _CommandAddress;
+  m_event_hook_address = command_address;
   return GetNoReply();
 }
 
 void CWII_IPC_HLE_Device_stm_eventhook::ResetButton()
 {
-  if (!m_Active || m_EventHookAddress == 0)
+  if (!m_Active || m_event_hook_address == 0)
   {
     // If the device isn't open, ignore the button press.
     return;
   }
 
   // The reset button returns STM_EVENT_RESET.
-  u32 BufferOut = Memory::Read_U32(m_EventHookAddress + 0x18);
-  Memory::Write_U32(STM_EVENT_RESET, BufferOut);
+  u32 buffer_out = Memory::Read_U32(m_event_hook_address + 0x18);
+  Memory::Write_U32(STM_EVENT_RESET, buffer_out);
 
   // Fill in command buffer.
-  Memory::Write_U32(FS_SUCCESS, m_EventHookAddress + 4);
-  Memory::Write_U32(IPC_REP_ASYNC, m_EventHookAddress);
-  Memory::Write_U32(IPC_CMD_IOCTL, m_EventHookAddress + 8);
+  Memory::Write_U32(FS_SUCCESS, m_event_hook_address + 4);
+  Memory::Write_U32(IPC_REP_ASYNC, m_event_hook_address);
+  Memory::Write_U32(IPC_CMD_IOCTL, m_event_hook_address + 8);
 
   // Generate a reply to the IPC command.
-  WII_IPC_HLE_Interface::EnqueueReply(m_EventHookAddress);
+  WII_IPC_HLE_Interface::EnqueueReply(m_event_hook_address);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -112,7 +112,7 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 command_address)
   return GetNoReply();
 }
 
-void CWII_IPC_HLE_Device_stm_eventhook::ResetButton()
+void CWII_IPC_HLE_Device_stm_eventhook::ResetButton() const
 {
   if (!m_Active || m_event_hook_address == 0)
   {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -59,7 +59,7 @@ public:
   IPCCommandResult Close(u32 command_address, bool force) override;
   IPCCommandResult IOCtl(u32 command_address) override;
 
-  void ResetButton();
+  void ResetButton() const;
 
   // STATE_TO_SAVE
   u32 m_event_hook_address = 0;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -60,4 +60,8 @@ public:
   IPCCommandResult IOCtl(u32 command_address) override;
 
   void ResetButton() const;
+  void PowerButton() const;
+
+private:
+  void TriggerEvent(u32 event) const;
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -31,36 +31,36 @@ enum
 };
 
 // The /dev/stm/immediate
-class CWII_IPC_HLE_Device_stm_immediate : public IWII_IPC_HLE_Device
+class CWII_IPC_HLE_Device_stm_immediate final : public IWII_IPC_HLE_Device
 {
 public:
-  CWII_IPC_HLE_Device_stm_immediate(u32 _DeviceID, const std::string& _rDeviceName)
-      : IWII_IPC_HLE_Device(_DeviceID, _rDeviceName)
+  CWII_IPC_HLE_Device_stm_immediate(u32 device_id, const std::string& device_name)
+      : IWII_IPC_HLE_Device(device_id, device_name)
   {
   }
 
   ~CWII_IPC_HLE_Device_stm_immediate() override = default;
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  IPCCommandResult Open(u32 command_address, u32 mode) override;
+  IPCCommandResult Close(u32 command_address, bool force) override;
+  IPCCommandResult IOCtl(u32 command_address) override;
 };
 
 // The /dev/stm/eventhook
-class CWII_IPC_HLE_Device_stm_eventhook : public IWII_IPC_HLE_Device
+class CWII_IPC_HLE_Device_stm_eventhook final : public IWII_IPC_HLE_Device
 {
 public:
-  CWII_IPC_HLE_Device_stm_eventhook(u32 _DeviceID, const std::string& _rDeviceName)
-      : IWII_IPC_HLE_Device(_DeviceID, _rDeviceName), m_EventHookAddress(0)
+  CWII_IPC_HLE_Device_stm_eventhook(u32 device_id, const std::string& device_name)
+      : IWII_IPC_HLE_Device(device_id, device_name)
   {
   }
 
   ~CWII_IPC_HLE_Device_stm_eventhook() override = default;
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  IPCCommandResult Open(u32 command_address, u32 mode) override;
+  IPCCommandResult Close(u32 command_address, bool force) override;
+  IPCCommandResult IOCtl(u32 command_address) override;
 
   void ResetButton();
 
   // STATE_TO_SAVE
-  u32 m_EventHookAddress;
+  u32 m_event_hook_address = 0;
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <string>
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
 enum
@@ -40,80 +39,10 @@ public:
   {
   }
 
-  virtual ~CWII_IPC_HLE_Device_stm_immediate() {}
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override
-  {
-    INFO_LOG(WII_IPC_STM, "STM immediate: Open");
-    Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
-    m_Active = true;
-    return GetDefaultReply();
-  }
-
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
-  {
-    INFO_LOG(WII_IPC_STM, "STM immediate: Close");
-    if (!_bForce)
-      Memory::Write_U32(0, _CommandAddress + 4);
-    m_Active = false;
-    return GetDefaultReply();
-  }
-
-  IPCCommandResult IOCtl(u32 _CommandAddress) override
-  {
-    u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
-    u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-    u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-    u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-    u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-
-    // Prepare the out buffer(s) with zeroes as a safety precaution
-    // to avoid returning bad values
-    Memory::Memset(BufferOut, 0, BufferOutSize);
-    u32 ReturnValue = 0;
-
-    switch (Parameter)
-    {
-    case IOCTL_STM_RELEASE_EH:
-      INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
-      INFO_LOG(WII_IPC_STM, "    IOCTL_STM_RELEASE_EH");
-      break;
-
-    case IOCTL_STM_HOTRESET:
-      INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
-      INFO_LOG(WII_IPC_STM, "    IOCTL_STM_HOTRESET");
-      break;
-
-    case IOCTL_STM_VIDIMMING:  // (Input: 20 bytes, Output: 20 bytes)
-      INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
-      INFO_LOG(WII_IPC_STM, "    IOCTL_STM_VIDIMMING");
-      // DumpCommands(BufferIn, BufferInSize / 4, LogTypes::WII_IPC_STM);
-      // Memory::Write_U32(1, BufferOut);
-      // ReturnValue = 1;
-      break;
-
-    case IOCTL_STM_LEDMODE:  // (Input: 20 bytes, Output: 20 bytes)
-      INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
-      INFO_LOG(WII_IPC_STM, "    IOCTL_STM_LEDMODE");
-      break;
-
-    default:
-    {
-      _dbg_assert_msg_(WII_IPC_STM, 0, "CWII_IPC_HLE_Device_stm_immediate: 0x%x", Parameter);
-
-      INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
-      DEBUG_LOG(WII_IPC_STM, "    Parameter: 0x%x", Parameter);
-      DEBUG_LOG(WII_IPC_STM, "    InBuffer: 0x%08x", BufferIn);
-      DEBUG_LOG(WII_IPC_STM, "    InBufferSize: 0x%08x", BufferInSize);
-      DEBUG_LOG(WII_IPC_STM, "    OutBuffer: 0x%08x", BufferOut);
-      DEBUG_LOG(WII_IPC_STM, "    OutBufferSize: 0x%08x", BufferOutSize);
-    }
-    break;
-    }
-
-    // Write return value to the IPC call
-    Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-    return GetDefaultReply();
-  }
+  ~CWII_IPC_HLE_Device_stm_immediate() override = default;
+  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
+  IPCCommandResult IOCtl(u32 _CommandAddress) override;
 };
 
 // The /dev/stm/eventhook
@@ -125,61 +54,12 @@ public:
   {
   }
 
-  virtual ~CWII_IPC_HLE_Device_stm_eventhook() {}
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override
-  {
-    Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
-    m_Active = true;
-    return GetDefaultReply();
-  }
+  ~CWII_IPC_HLE_Device_stm_eventhook() override = default;
+  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
+  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
+  IPCCommandResult IOCtl(u32 _CommandAddress) override;
 
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
-  {
-    m_EventHookAddress = 0;
-
-    INFO_LOG(WII_IPC_STM, "STM eventhook: Close");
-    if (!_bForce)
-      Memory::Write_U32(0, _CommandAddress + 4);
-    m_Active = false;
-    return GetDefaultReply();
-  }
-
-  IPCCommandResult IOCtl(u32 _CommandAddress) override
-  {
-    u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
-    if (Parameter != IOCTL_STM_EVENTHOOK)
-    {
-      ERROR_LOG(WII_IPC_STM, "Bad IOCtl in CWII_IPC_HLE_Device_stm_eventhook");
-      Memory::Write_U32(FS_EINVAL, _CommandAddress + 4);
-      return GetDefaultReply();
-    }
-
-    // IOCTL_STM_EVENTHOOK waits until the reset button or power button
-    // is pressed.
-    m_EventHookAddress = _CommandAddress;
-    return GetNoReply();
-  }
-
-  void ResetButton()
-  {
-    if (!m_Active || m_EventHookAddress == 0)
-    {
-      // If the device isn't open, ignore the button press.
-      return;
-    }
-
-    // The reset button returns STM_EVENT_RESET.
-    u32 BufferOut = Memory::Read_U32(m_EventHookAddress + 0x18);
-    Memory::Write_U32(STM_EVENT_RESET, BufferOut);
-
-    // Fill in command buffer.
-    Memory::Write_U32(FS_SUCCESS, m_EventHookAddress + 4);
-    Memory::Write_U32(IPC_REP_ASYNC, m_EventHookAddress);
-    Memory::Write_U32(IPC_CMD_IOCTL, m_EventHookAddress + 8);
-
-    // Generate a reply to the IPC command.
-    WII_IPC_HLE_Interface::EnqueueReply(m_EventHookAddress);
-  }
+  void ResetButton();
 
   // STATE_TO_SAVE
   u32 m_EventHookAddress;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -60,7 +60,4 @@ public:
   IPCCommandResult IOCtl(u32 command_address) override;
 
   void ResetButton() const;
-
-  // STATE_TO_SAVE
-  u32 m_event_hook_address = 0;
 };

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -158,6 +158,7 @@ private:
   bool m_bGameLoading = false;
   bool m_bClosing = false;
   bool m_confirmStop = false;
+  bool m_tried_graceful_shutdown = false;
   int m_saveSlot = 1;
 
   std::vector<std::string> drives;

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1155,9 +1155,12 @@ void CFrame::DoStop()
         Core::SetState(Core::CORE_PAUSE);
       }
 
-      wxMessageDialog m_StopDlg(this, _("Do you want to stop the current emulation?"),
-                                _("Please confirm..."),
-                                wxYES_NO | wxSTAY_ON_TOP | wxICON_EXCLAMATION, wxDefaultPosition);
+      wxMessageDialog m_StopDlg(
+          this, !m_tried_graceful_shutdown ? _("Do you want to stop the current emulation?") :
+                                             _("A shutdown is already in progress. Unsaved data "
+                                               "may be lost if you stop the current emulation "
+                                               "before it completes. Force stop?"),
+          _("Please confirm..."), wxYES_NO | wxSTAY_ON_TOP | wxICON_EXCLAMATION, wxDefaultPosition);
 
       HotkeyManagerEmu::Enable(false);
       int Ret = m_StopDlg.ShowModal();
@@ -1170,6 +1173,16 @@ void CFrame::DoStop()
         m_confirmStop = false;
         return;
       }
+    }
+
+    if (SConfig::GetInstance().bWii && !m_tried_graceful_shutdown)
+    {
+      Core::DisplayMessage("Shutting down", 30000);
+      Core::SetState(Core::CORE_RUN);
+      ProcessorInterface::PowerButton_Tap();
+      m_confirmStop = false;
+      m_tried_graceful_shutdown = true;
+      return;
     }
 
     if (UseDebugger && g_pCodeWindow)
@@ -1207,6 +1220,7 @@ void CFrame::DoStop()
 void CFrame::OnStopped()
 {
   m_confirmStop = false;
+  m_tried_graceful_shutdown = false;
 
 #if defined(HAVE_X11) && HAVE_X11
   if (SConfig::GetInstance().bDisableScreenSaver)


### PR DESCRIPTION
This adds support for triggering the power event (in the STM), so that stopping emulation first triggers a shutdown event, which notably gives emulated software time to save game data (issue 8979) and clean up SYSCONF (to disconnect Wiimotes and update their state in the SYSCONF).

On the first press, the stop button/hotkey/whatever will trigger a STM power event, and we immediately show an OSD message, so it doesn't look like Dolphin is ignoring the stop command. On a second try, we will forcefully stop emulation, just like how it was working before.

Note: this still doesn't allow Wiimotes to trigger a poweroff when the last Wiimote is powered off. Not sure why; this will likely be something to look into in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4244)
<!-- Reviewable:end -->
