### PR TITLE
In-class initialise member variables

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -33,7 +33,6 @@
 
 namespace Common
 {
-
 #if !defined(_WIN32)
 #include <unistd.h>
 static uintptr_t RoundPage(uintptr_t addr)

--- a/Source/Core/Common/MemoryUtil.h
+++ b/Source/Core/Common/MemoryUtil.h
@@ -9,7 +9,6 @@
 
 namespace Common
 {
-
 void* AllocateExecutableMemory(size_t size, bool low = true);
 void* AllocateMemoryPages(size_t size);
 void FreeMemoryPages(void* ptr, size_t size);

--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -17,7 +17,7 @@
 
 #include "Core/Movie.h"
 
-SysConf::SysConf() : m_IsValid(false)
+SysConf::SysConf()
 {
   UpdateLocation();
 }

--- a/Source/Core/Common/SysConf.h
+++ b/Source/Core/Common/SysConf.h
@@ -182,5 +182,5 @@ private:
   std::string m_Filename;
   std::string m_FilenameDefault;
   std::vector<SSysConfEntry> m_Entries;
-  bool m_IsValid;
+  bool m_IsValid = false;
 };

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -27,24 +27,6 @@
 SConfig* SConfig::m_Instance;
 
 SConfig::SConfig()
-    : bEnableDebugging(false), bAutomaticStart(false), bBootToPause(false), bJITNoBlockCache(false),
-      bJITNoBlockLinking(false), bJITOff(false), bJITLoadStoreOff(false),
-      bJITLoadStorelXzOff(false), bJITLoadStorelwzOff(false), bJITLoadStorelbzxOff(false),
-      bJITLoadStoreFloatingOff(false), bJITLoadStorePairedOff(false), bJITFloatingPointOff(false),
-      bJITIntegerOff(false), bJITPairedOff(false), bJITSystemRegistersOff(false),
-      bJITBranchOff(false), bJITILTimeProfiling(false), bJITILOutputIR(false), bFPRF(false),
-      bAccurateNaNs(false), iTimingVariance(40), bCPUThread(true), bDSPThread(false), bDSPHLE(true),
-      bSkipIdle(true), bSyncGPUOnSkipIdleHack(true), bNTSC(false), bForceNTSCJ(false),
-      bHLE_BS2(true), bEnableCheats(false), bEnableMemcardSdWriting(true), bDPL2Decoder(false),
-      iLatency(14), bRunCompareServer(false), bRunCompareClient(false), bMMU(false),
-      bDCBZOFF(false), iBBDumpPort(0), bFastDiscSpeed(false), bSyncGPU(false), SelectedLanguage(0),
-      bOverrideGCLanguage(false), bWii(false), bConfirmStop(false), bHideCursor(false),
-      bAutoHideCursor(false), bUsePanicHandlers(true), bOnScreenDisplayMessages(true),
-      iRenderWindowXPos(-1), iRenderWindowYPos(-1), iRenderWindowWidth(640),
-      iRenderWindowHeight(480), bRenderWindowAutoSize(false), bKeepWindowOnTop(false),
-      bFullscreen(false), bRenderToMain(false), bProgressive(false), bPAL60(false),
-      bDisableScreenSaver(false), iPosX(100), iPosY(100), iWidth(800), iHeight(600),
-      m_analytics_enabled(false), m_analytics_permission_asked(false), bLoopFifoReplay(true)
 {
   LoadDefaults();
   // Make sure we have log manager

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -53,91 +53,98 @@ struct SConfig : NonCopyable
   bool m_RecursiveISOFolder;
 
   // Settings
-  bool bEnableDebugging;
+  bool bEnableDebugging = false;
 #ifdef USE_GDBSTUB
   int iGDBPort;
 #ifndef _WIN32
   std::string gdb_socket;
 #endif
 #endif
-  bool bAutomaticStart;
-  bool bBootToPause;
+  bool bAutomaticStart = false;
+  bool bBootToPause = false;
 
   int iCPUCore;
 
   // JIT (shared between JIT and JITIL)
-  bool bJITNoBlockCache, bJITNoBlockLinking;
-  bool bJITOff;
-  bool bJITLoadStoreOff, bJITLoadStorelXzOff, bJITLoadStorelwzOff, bJITLoadStorelbzxOff;
-  bool bJITLoadStoreFloatingOff;
-  bool bJITLoadStorePairedOff;
-  bool bJITFloatingPointOff;
-  bool bJITIntegerOff;
-  bool bJITPairedOff;
-  bool bJITSystemRegistersOff;
-  bool bJITBranchOff;
-  bool bJITILTimeProfiling;
-  bool bJITILOutputIR;
+  bool bJITNoBlockCache = false;
+  bool bJITNoBlockLinking = false;
+  bool bJITOff = false;
+  bool bJITLoadStoreOff = false;
+  bool bJITLoadStorelXzOff = false;
+  bool bJITLoadStorelwzOff = false;
+  bool bJITLoadStorelbzxOff = false;
+  bool bJITLoadStoreFloatingOff = false;
+  bool bJITLoadStorePairedOff = false;
+  bool bJITFloatingPointOff = false;
+  bool bJITIntegerOff = false;
+  bool bJITPairedOff = false;
+  bool bJITSystemRegistersOff = false;
+  bool bJITBranchOff = false;
+  bool bJITILTimeProfiling = false;
+  bool bJITILOutputIR = false;
 
   bool bFastmem;
-  bool bFPRF;
-  bool bAccurateNaNs;
+  bool bFPRF = false;
+  bool bAccurateNaNs = false;
 
-  int iTimingVariance;  // in milli secounds
-  bool bCPUThread;
-  bool bDSPThread;
-  bool bDSPHLE;
-  bool bSkipIdle;
-  bool bSyncGPUOnSkipIdleHack;
-  bool bNTSC;
-  bool bForceNTSCJ;
-  bool bHLE_BS2;
-  bool bEnableCheats;
-  bool bEnableMemcardSdWriting;
+  int iTimingVariance = 40;  // in milli secounds
+  bool bCPUThread = true;
+  bool bDSPThread = false;
+  bool bDSPHLE = true;
+  bool bSkipIdle = true;
+  bool bSyncGPUOnSkipIdleHack = true;
+  bool bNTSC = false;
+  bool bForceNTSCJ = false;
+  bool bHLE_BS2 = true;
+  bool bEnableCheats = false;
+  bool bEnableMemcardSdWriting = true;
 
-  bool bDPL2Decoder;
-  int iLatency;
+  bool bDPL2Decoder = false;
+  int iLatency = 14;
 
-  bool bRunCompareServer;
-  bool bRunCompareClient;
+  bool bRunCompareServer = false;
+  bool bRunCompareClient = false;
 
-  bool bMMU;
-  bool bDCBZOFF;
-  int iBBDumpPort;
-  bool bFastDiscSpeed;
+  bool bMMU = false;
+  bool bDCBZOFF = false;
+  int iBBDumpPort = 0;
+  bool bFastDiscSpeed = false;
 
-  bool bSyncGPU;
+  bool bSyncGPU = false;
   int iSyncGpuMaxDistance;
   int iSyncGpuMinDistance;
   float fSyncGpuOverclock;
 
-  int SelectedLanguage;
-  bool bOverrideGCLanguage;
+  int SelectedLanguage = 0;
+  bool bOverrideGCLanguage = false;
 
-  bool bWii;
+  bool bWii = false;
 
   // Interface settings
-  bool bConfirmStop, bHideCursor, bAutoHideCursor, bUsePanicHandlers, bOnScreenDisplayMessages;
+  bool bConfirmStop = false;
+  bool bHideCursor = false, bAutoHideCursor = false;
+  bool bUsePanicHandlers = true;
+  bool bOnScreenDisplayMessages = true;
   std::string theme_name;
 
   // Display settings
   std::string strFullscreenResolution;
-  int iRenderWindowXPos, iRenderWindowYPos;
-  int iRenderWindowWidth, iRenderWindowHeight;
-  bool bRenderWindowAutoSize, bKeepWindowOnTop;
-  bool bFullscreen, bRenderToMain;
-  bool bProgressive, bPAL60;
-  bool bDisableScreenSaver;
+  int iRenderWindowXPos = -1, iRenderWindowYPos = -1;
+  int iRenderWindowWidth = 640, iRenderWindowHeight = 480;
+  bool bRenderWindowAutoSize = false, bKeepWindowOnTop = false;
+  bool bFullscreen = false, bRenderToMain = false;
+  bool bProgressive = false, bPAL60 = false;
+  bool bDisableScreenSaver = false;
 
   int iPosX, iPosY, iWidth, iHeight;
 
   // Analytics settings.
   std::string m_analytics_id;
-  bool m_analytics_enabled;
-  bool m_analytics_permission_asked;
+  bool m_analytics_enabled = false;
+  bool m_analytics_permission_asked = false;
 
   // Fifo Player related settings
-  bool bLoopFifoReplay;
+  bool bLoopFifoReplay = true;
 
   // Custom RTC
   bool bEnableCustomRTC;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -61,8 +61,8 @@
 
 std::string CWII_IPC_HLE_Device_es::m_ContentFile;
 
-CWII_IPC_HLE_Device_es::CWII_IPC_HLE_Device_es(u32 _DeviceID, const std::string& _rDeviceName)
-    : IWII_IPC_HLE_Device(_DeviceID, _rDeviceName), m_TitleID(-1), m_AccessIdentID(0x6000000)
+CWII_IPC_HLE_Device_es::CWII_IPC_HLE_Device_es(u32 device_id, const std::string& device_name)
+    : IWII_IPC_HLE_Device(device_id, device_name)
 {
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
@@ -132,8 +132,8 @@ private:
   CContentAccessMap m_ContentAccessMap;
 
   std::vector<u64> m_TitleIDs;
-  u64 m_TitleID;
-  u32 m_AccessIdentID;
+  u64 m_TitleID = -1;
+  u32 m_AccessIdentID = 0x6000000;
 
   static u8* keyTable[11];
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -386,13 +386,8 @@ static BOOL WINAPI s_ctrl_handler(DWORD fdwCtrlType)
 CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, const wxPoint& pos,
                const wxSize& size, bool _UseDebugger, bool _BatchMode, bool ShowLogWindow,
                long style)
-    : CRenderFrame(parent, id, title, pos, size, style), g_pCodeWindow(nullptr),
-      g_NetPlaySetupDiag(nullptr), g_CheatsWindow(nullptr), m_SavedPerspectives(nullptr),
-      m_ToolBar(nullptr), m_GameListCtrl(nullptr), m_Panel(nullptr), m_RenderFrame(nullptr),
-      m_RenderParent(nullptr), m_LogWindow(nullptr), m_LogConfigWindow(nullptr),
-      m_FifoPlayerDlg(nullptr), UseDebugger(_UseDebugger), m_bBatchMode(_BatchMode), m_bEdit(false),
-      m_bTabSplit(false), m_bNoDocking(false), m_bGameLoading(false), m_bClosing(false),
-      m_confirmStop(false), m_menubar_shadow(nullptr)
+    : CRenderFrame(parent, id, title, pos, size, style), UseDebugger(_UseDebugger),
+      m_bBatchMode(_BatchMode)
 {
   for (int i = 0; i <= IDM_CODE_WINDOW - IDM_LOG_WINDOW; i++)
     bFloatWindow[i] = false;

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -79,9 +79,9 @@ public:
   }
 
   // These have to be public
-  CCodeWindow* g_pCodeWindow;
-  NetPlaySetupFrame* g_NetPlaySetupDiag;
-  wxCheatsWindow* g_CheatsWindow;
+  CCodeWindow* g_pCodeWindow = nullptr;
+  NetPlaySetupFrame* g_NetPlaySetupDiag = nullptr;
+  wxCheatsWindow* g_CheatsWindow = nullptr;
   TASInputDlg* g_TASInputDlg[8];
 
   void InitBitmaps();
@@ -123,11 +123,11 @@ public:
   X11Utils::XRRConfiguration* m_XRRConfig;
 #endif
 
-  wxMenu* m_SavedPerspectives;
+  wxMenu* m_SavedPerspectives = nullptr;
 
-  wxToolBar* m_ToolBar;
+  wxToolBar* m_ToolBar = nullptr;
   // AUI
-  wxAuiManager* m_Mgr;
+  wxAuiManager* m_Mgr = nullptr;
   bool bFloatWindow[IDM_CODE_WINDOW - IDM_LOG_WINDOW + 1];
 
   // Perspectives (Should find a way to make all of this private)
@@ -143,21 +143,21 @@ public:
   u32 ActivePerspective;
 
 private:
-  CGameListCtrl* m_GameListCtrl;
-  wxPanel* m_Panel;
-  CRenderFrame* m_RenderFrame;
-  wxWindow* m_RenderParent;
-  CLogWindow* m_LogWindow;
-  LogConfigWindow* m_LogConfigWindow;
-  FifoPlayerDlg* m_FifoPlayerDlg;
-  bool UseDebugger;
-  bool m_bBatchMode;
-  bool m_bEdit;
-  bool m_bTabSplit;
-  bool m_bNoDocking;
-  bool m_bGameLoading;
-  bool m_bClosing;
-  bool m_confirmStop;
+  CGameListCtrl* m_GameListCtrl = nullptr;
+  wxPanel* m_Panel = nullptr;
+  CRenderFrame* m_RenderFrame = nullptr;
+  wxWindow* m_RenderParent = nullptr;
+  CLogWindow* m_LogWindow = nullptr;
+  LogConfigWindow* m_LogConfigWindow = nullptr;
+  FifoPlayerDlg* m_FifoPlayerDlg = nullptr;
+  bool UseDebugger = false;
+  bool m_bBatchMode = false;
+  bool m_bEdit = false;
+  bool m_bTabSplit = false;
+  bool m_bNoDocking = false;
+  bool m_bGameLoading = false;
+  bool m_bClosing = false;
+  bool m_confirmStop = false;
   int m_saveSlot = 1;
 
   std::vector<std::string> drives;
@@ -191,7 +191,7 @@ private:
 
   wxBitmap m_Bitmaps[EToolbar_Max];
 
-  wxMenuBar* m_menubar_shadow;
+  wxMenuBar* m_menubar_shadow = nullptr;
 
   void PopulateToolbar(wxToolBar* toolBar);
   void RecreateToolbar();


### PR DESCRIPTION
Just a few things I noticed while working on my recent PRs.

In-class initialising variables is more concise and avoids huge initialiser lists like in ConfigManager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4246)
<!-- Reviewable:end -->
