### PR TITLE
HLE_OS: Minor fixes (function patching, output encoding)

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -41,7 +41,11 @@ Symbol* SymbolDB::GetSymbolFromName(const std::string& name)
 {
   for (auto& func : functions)
   {
-    if (func.second.name == name)
+    // If name contains more than only the function name, only look for exact matches.
+    if (name.find('(') != std::string::npos && func.second.name == name)
+      return &func.second;
+    // If name only contains a function name, it is assumed that we only want to match by the name.
+    if (func.second.name.find(name) == 0)
       return &func.second;
   }
 

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -43,7 +43,7 @@ void HLE_GeneralDebugPrint()
 
   NPC = LR;
 
-  NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, report_message.c_str());
+  NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, SHIFTJISToUTF8(report_message).c_str());
 }
 
 // __write_console is slightly abnormal
@@ -53,7 +53,7 @@ void HLE_write_console()
 
   NPC = LR;
 
-  NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, report_message.c_str());
+  NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, SHIFTJISToUTF8(report_message).c_str());
 }
 
 std::string GetStringVA(u32 strReg)


### PR DESCRIPTION
This changes GetSymbolFromName to only require an exact match when the passed name is "complete" (i.e. it contains more than just the function name).

When the passed name only contains a function name, it is assumed that we only want to check if the function name contains the passed name.

This fixes a regression introduced by #4160, which prevented HLE::PatchFunctions() from working properly.

--

Also, it looks like the debug output is also output as SJIS (similar to OSReport text), so we need to convert it to UTF-8 to prevent it from all showing up as �.

This doesn't fix all display issues, but fixes all SJIS/UTF-8 related ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4249)
<!-- Reviewable:end -->
