### PR TITLE
HLE_OS: Minor fixes (function patching, output encoding)

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -41,7 +41,7 @@ Symbol* SymbolDB::GetSymbolFromName(const std::string& name)
 {
   for (auto& func : functions)
   {
-    if (func.second.name == name)
+    if (func.second.function_name == name)
       return &func.second;
   }
 

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -30,6 +30,7 @@ struct Symbol
   };
 
   std::string name;
+  std::string function_name;   // stripped function name
   std::vector<SCall> callers;  // addresses of functions that call this function
   std::vector<SCall> calls;    // addresses of functions that are called by this function
   u32 hash = 0;                // use for HLE function finding

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -43,7 +43,7 @@ void HLE_GeneralDebugPrint()
 
   NPC = LR;
 
-  NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, report_message.c_str());
+  NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, SHIFTJISToUTF8(report_message).c_str());
 }
 
 // __write_console is slightly abnormal
@@ -53,7 +53,7 @@ void HLE_write_console()
 
   NPC = LR;
 
-  NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, report_message.c_str());
+  NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, SHIFTJISToUTF8(report_message).c_str());
 }
 
 std::string GetStringVA(u32 strReg)

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -16,6 +16,15 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/SignatureDB.h"
 
+static std::string GetStrippedFunctionName(const std::string& symbol_name)
+{
+  std::string name = symbol_name.substr(0, symbol_name.find('('));
+  size_t position = name.find(' ');
+  if (position != std::string::npos)
+    name.erase(position);
+  return name;
+}
+
 PPCSymbolDB g_symbolDB;
 
 PPCSymbolDB::PPCSymbolDB()
@@ -62,6 +71,7 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
     // already got it, let's just update name, checksum & size to be sure.
     Symbol* tempfunc = &iter->second;
     tempfunc->name = name;
+    tempfunc->function_name = GetStrippedFunctionName(name);
     tempfunc->hash = SignatureDB::ComputeCodeChecksum(startAddr, startAddr + size - 4);
     tempfunc->type = type;
     tempfunc->size = size;
@@ -77,6 +87,7 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
     {
       PPCAnalyst::AnalyzeFunction(startAddr, tf, size);
       checksumToFunction[tf.hash] = &(functions[startAddr]);
+      tf.function_name = GetStrippedFunctionName(name);
     }
     tf.size = size;
     functions[startAddr] = tf;

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -112,7 +112,7 @@ Symbol* PPCSymbolDB::GetSymbolFromAddr(u32 addr)
   return nullptr;
 }
 
-const std::string PPCSymbolDB::GetDescription(u32 addr)
+std::string PPCSymbolDB::GetDescription(u32 addr)
 {
   Symbol* symbol = GetSymbolFromAddr(addr);
   if (symbol)

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.h
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.h
@@ -31,7 +31,7 @@ public:
 
   Symbol* GetSymbolFromAddr(u32 addr) override;
 
-  const std::string GetDescription(u32 addr);
+  std::string GetDescription(u32 addr);
 
   void FillInCallers();
 


### PR DESCRIPTION
Minor changes to the HLE patching stuff:

- Fix a regression introduced by #4160, which broke HLE::PatchFunctions() because it tries to find and patch functions by their names, but we were comparing with their full symbol names.

- Fix debug messages by converting them from SJIS to UTF-8 (like with OSReport text)

(opening a new PR because GitHub doesn't allow me to reopen the previous one…)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4250)
<!-- Reviewable:end -->
