### PR TITLE
Build portaudio from Externals when not available on system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,22 +551,26 @@ if(ENCODE_FRAMEDUMPS)
 
 endif()
 
-set(CMAKE_REQUIRED_LIBRARIES portaudio)
-CHECK_CXX_SOURCE_RUNS(
-	"#include <portaudio.h>
-	int main(int argc, char **argv)
-	{ if(Pa_GetVersion() >= 1890) return 0; else return 1; }"
-	PORTAUDIO)
-unset(CMAKE_REQUIRED_LIBRARIES)
-if(PORTAUDIO)
-	message("PortAudio found, enabling mic support")
-	add_definitions(-DHAVE_PORTAUDIO=1)
+if(NOT ANDROID)
 	set(PORTAUDIO_FOUND TRUE)
-else()
-	message("PortAudio not found, disabling mic support")
-	add_definitions(-DHAVE_PORTAUDIO=0)
-	set(PORTAUDIO_FOUND FALSE)
-endif(PORTAUDIO)
+	add_definitions(-DHAVE_PORTAUDIO=1)
+
+	if(NOT APPLE)
+	    set(CMAKE_REQUIRED_LIBRARIES portaudio)
+	    CHECK_CXX_SOURCE_RUNS(
+		    "#include <portaudio.h>
+			int main(int argc, char **argv)
+			{ if(Pa_GetVersion() >= 1890) return 0; else return 1; }"
+			SYSTEM_PORTAUDIO)
+		unset(CMAKE_REQUIRED_LIBRARIES)
+	endif()
+	if(SYSTEM_PORTAUDIO AND NOT APPLE)
+		message("Using shared PortAudio for mic support")
+	else()
+		message("Using static PortAudio from Externals for mic support")
+		add_subdirectory(Externals/portaudio)
+	endif()
+endif()
 
 if(OPROFILING)
 	include(FindOProfile)

--- a/Externals/portaudio/CMakeLists.txt
+++ b/Externals/portaudio/CMakeLists.txt
@@ -1,0 +1,404 @@
+# $Id: $
+#
+# For a "How-To" please refer to the Portaudio documentation at:
+# http://www.portaudio.com/trac/wiki/TutorialDir/Compile/CMake
+#
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+
+# Check if the user is building PortAudio stand-alone or as part of a larger
+# project. If this is part of a larger project (i.e. the CMakeLists.txt has
+# been imported by some other CMakeLists.txt), we don't want to trump over
+# the top of that project's global settings.
+IF(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_LIST_DIR})
+  IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    MESSAGE(STATUS "Setting CMAKE_BUILD_TYPE type to 'Debug' as none was specified.")
+    SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
+    SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
+  ENDIF()
+
+  PROJECT(portaudio)
+
+  SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+
+  IF(WIN32 AND MSVC)
+    OPTION(PA_DLL_LINK_WITH_STATIC_RUNTIME "Link with static runtime libraries (minimizes runtime dependencies)" ON)
+    IF(PA_DLL_LINK_WITH_STATIC_RUNTIME)
+      FOREACH(flag_var
+        CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+        IF(${flag_var} MATCHES "/MD")
+          STRING(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+        ENDIF()
+      ENDFOREACH()
+    ENDIF()
+  ENDIF()
+ENDIF()
+
+SET(PA_PKGCONFIG_VERSION 19)
+
+# Most of the code from this point onwards is related to populating the
+# following variables:
+#   PA_PUBLIC_INCLUDES - This contains the list of public PortAudio header
+#       files. These files will be copied into /include paths on Unix'y
+#       systems when "make install" is invoked.
+#   PA_PRIVATE_INCLUDES - This contains the list of header files which
+#       are not part of PortAudio, but are required by the various hostapis.
+#       It is only used by CMake IDE generators (like Visual Studio) to
+#       provide quick-links to useful headers. It has no impact on build
+#       output.
+#   PA_PRIVATE_INCLUDE_PATHS - This contains the list of include paths which
+#       will be passed to the compiler while PortAudio is being built which
+#       are not required by applications using the PortAudio API.
+#   PA_PRIVATE_COMPILE_DEFINITIONS - This contains a list of preprocessor
+#       macro definitions which will be set when compiling PortAudio source
+#       files.
+#   PA_SOURCES - This contains the list of source files which will be built
+#       into the static and shared PortAudio libraries.
+#   PA_NON_UNICODE_SOURCES - This also contains a list of source files which
+#       will be build into the static and shared PortAudio libraries. However,
+#       these sources will not have any unicode compiler definitions added
+#       to them. This list should only contain external source dependencies.
+#   PA_EXTRA_SHARED_SOURCES - Contains a list of extra files which will be
+#       associated only with the shared PortAudio library. This only seems
+#       relevant for Windows shared libraries which require a list of export
+#       symbols.
+# Where other PA_* variables are set, these are almost always only used to
+# preserve the historic SOURCE_GROUP behavior (which again only has an impact
+# on IDE-style generators for visual appearance) or store the output of
+# find_library() calls.
+
+SET(PA_COMMON_INCLUDES
+  src/common/pa_allocation.h
+  src/common/pa_converters.h
+  src/common/pa_cpuload.h
+  src/common/pa_debugprint.h
+  src/common/pa_dither.h
+  src/common/pa_endianness.h
+  src/common/pa_hostapi.h
+  src/common/pa_memorybarrier.h
+  src/common/pa_process.h
+  src/common/pa_ringbuffer.h
+  src/common/pa_stream.h
+  src/common/pa_trace.h
+  src/common/pa_types.h
+  src/common/pa_util.h
+)
+
+SET(PA_COMMON_SOURCES
+  src/common/pa_allocation.c
+  src/common/pa_converters.c
+  src/common/pa_cpuload.c
+  src/common/pa_debugprint.c
+  src/common/pa_dither.c
+  src/common/pa_front.c
+  src/common/pa_process.c
+  src/common/pa_ringbuffer.c
+  src/common/pa_stream.c
+  src/common/pa_trace.c
+)
+
+SOURCE_GROUP("common" FILES ${PA_COMMON_INCLUDES} ${PA_COMMON_SOURCES})
+
+SET(PA_PUBLIC_INCLUDES include/portaudio.h)
+
+SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake_support)
+
+SET(PA_SKELETON_SOURCES src/hostapi/skeleton/pa_hostapi_skeleton.c)
+SOURCE_GROUP("hostapi\\skeleton" ${PA_SKELETON_SOURCES})
+SET(PA_SOURCES ${PA_COMMON_SOURCES} ${PA_SKELETON_SOURCES})
+SET(PA_PRIVATE_INCLUDE_PATHS src/common ${CMAKE_CURRENT_BINARY_DIR})
+
+IF(WIN32)
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} _CRT_SECURE_NO_WARNINGS)
+
+  SET(PA_PLATFORM_SOURCES
+    src/os/win/pa_win_hostapis.c
+    src/os/win/pa_win_util.c
+    src/os/win/pa_win_waveformat.c
+    src/os/win/pa_win_wdmks_utils.c
+    src/os/win/pa_win_coinitialize.c)
+  SET(PA_PLATFORM_INCLUDES
+    src/os/win/pa_win_coinitialize.h
+    src/os/win/pa_win_wdmks_utils.h)
+
+  IF(MSVC)
+    SET(PA_PLATFORM_SOURCES ${PA_PLATFORM_SOURCES} src/os/win/pa_x86_plain_converters.c)
+    SET(PA_PLATFORM_INCLUDES ${PA_PLATFORM_INCLUDES} src/os/win/pa_x86_plain_converters.h)
+  ELSE()
+    SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} _WIN32_WINNT=0x0501 WINVER=0x0501)
+    SET(DEF_EXCLUDE_X86_PLAIN_CONVERTERS ";")
+  ENDIF()
+
+  SOURCE_GROUP("os\\win" FILES ${PA_PLATFORM_SOURCES} ${PA_PLATFORM_INCLUDES})
+  SET(PA_SOURCES ${PA_SOURCES} ${PA_PLATFORM_SOURCES})
+  SET(PA_PRIVATE_INCLUDES ${PA_PRIVATE_INCLUDES} ${PA_PLATFORM_INCLUDES})
+  SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} src/os/win)
+
+  # Try to find ASIO SDK (assumes that portaudio and asiosdk folders are side-by-side, see
+  # http://www.portaudio.com/trac/wiki/TutorialDir/Compile/WindowsASIOMSVC)
+  FIND_PACKAGE(ASIOSDK)
+  IF(ASIOSDK_FOUND)
+    OPTION(PA_USE_ASIO "Enable support for ASIO" ON)
+  ELSE()
+    OPTION(PA_USE_ASIO "Enable support for ASIO" OFF)
+  ENDIF()
+  IF(PA_USE_ASIO)
+    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/common)
+    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host)
+    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ASIOSDK_ROOT_DIR}/host/pc)
+    SET(PA_ASIO_SOURCES src/hostapi/asio/pa_asio.cpp src/hostapi/asio/iasiothiscallresolver.cpp)
+    SET(PA_ASIOSDK_SOURCES ${ASIOSDK_ROOT_DIR}/common/asio.cpp ${ASIOSDK_ROOT_DIR}/host/pc/asiolist.cpp ${ASIOSDK_ROOT_DIR}/host/asiodrivers.cpp)
+    SOURCE_GROUP("hostapi\\ASIO" FILES ${PA_ASIO_SOURCES})
+    SOURCE_GROUP("hostapi\\ASIO\\ASIOSDK" FILES ${PA_ASIOSDK_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_asio.h)
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_ASIO_SOURCES})
+    SET(PA_NON_UNICODE_SOURCES ${PA_NON_UNICODE_SOURCES} ${PA_ASIOSDK_SOURCES})
+    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} winmm ole32 uuid)
+  ELSE()
+    # Set variables for DEF file expansion
+    SET(DEF_EXCLUDE_ASIO_SYMBOLS ";")
+  ENDIF()
+
+  # Try to find DirectX SDK
+  FIND_PACKAGE(DXSDK)
+  IF(DXSDK_FOUND)
+    OPTION(PA_USE_DS "Enable support for DirectSound" ON)
+  ELSE()
+    OPTION(PA_USE_DS "Enable support for DirectSound" OFF)
+  ENDIF()
+  IF(PA_USE_DS)
+    OPTION(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE "Use DirectSound full duplex create" ON)
+    MARK_AS_ADVANCED(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+    IF(PA_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+      SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PAWIN_USE_DIRECTSOUNDFULLDUPLEXCREATE)
+    ENDIF()
+    SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${DXSDK_INCLUDE_DIR})
+    SET(PA_DS_INCLUDES src/hostapi/dsound/pa_win_ds_dynlink.h)
+    SET(PA_DS_SOURCES src/hostapi/dsound/pa_win_ds.c src/hostapi/dsound/pa_win_ds_dynlink.c)
+    SOURCE_GROUP("hostapi\\dsound" FILES ${PA_DS_INCLUDES} ${PA_DS_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_win_ds.h)
+    SET(PA_PRIVATE_INCLUDES ${PA_PRIVATE_INCLUDES} ${PA_DS_INCLUDES})
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_DS_SOURCES})
+
+    # If we use DirectSound, we need this for the library to be found (if not in VS project settings)
+    IF(DXSDK_FOUND)
+      SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${DXSDK_DSOUND_LIBRARY})
+    ENDIF()
+  ENDIF()
+
+  OPTION(PA_USE_WMME "Enable support for MME" ON)
+  IF(PA_USE_WMME)
+    SET(PA_WMME_SOURCES src/hostapi/wmme/pa_win_wmme.c)
+    SOURCE_GROUP("hostapi\\wmme" FILES ${PA_WMME_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_win_wmme.h)
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_WMME_SOURCES})
+  ENDIF()
+
+  IF(MSVS)
+    OPTION(PA_USE_WASAPI "Enable support for WASAPI" ON)
+  ELSE()
+    # I was unable to get WASAPI to compile outside of Visual Studio. If
+    # anyone can figure out how to make this work with MinGW, please fix me.
+    SET(PA_USE_WASAPI OFF)
+  ENDIF()
+  IF(PA_USE_WASAPI)
+    SET(PA_WASAPI_SOURCES src/hostapi/wasapi/pa_win_wasapi.c)
+    SOURCE_GROUP("hostapi\\wasapi" FILES ${PA_WASAPI_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_win_wasapi.h)
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_WASAPI_SOURCES})
+    IF(NOT MSVC)
+      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} src/hostapi/wasapi/mingw-include)
+    ENDIF()
+  ELSE()
+    SET(DEF_EXCLUDE_WASAPI_SYMBOLS ";")
+  ENDIF()
+
+  OPTION(PA_USE_WDMKS "Enable support for WDMKS" ON)
+  IF(PA_USE_WDMKS)
+    SET(PA_WDMKS_SOURCES src/hostapi/wdmks/pa_win_wdmks.c)
+    SOURCE_GROUP("hostapi\\wdmks" FILES ${PA_WDMKS_SOURCES})
+    SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_win_wdmks.h)
+    SET(PA_SOURCES ${PA_SOURCES} ${PA_WDMKS_SOURCES})
+    # If we use WDM/KS we need setupapi.lib
+    SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} setupapi)
+  ENDIF()
+
+  OPTION(PA_USE_WDMKS_DEVICE_INFO "Use WDM/KS API for device info" ON)
+  MARK_AS_ADVANCED(PA_USE_WDMKS_DEVICE_INFO)
+  IF(PA_USE_WDMKS_DEVICE_INFO)
+    SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PAWIN_USE_WDMKS_DEVICE_INFO)
+  ENDIF()
+
+  SET(GENERATED_MESSAGE "CMake generated file, do NOT edit! Use CMake-GUI to change configuration instead.")
+  CONFIGURE_FILE(cmake_support/template_portaudio.def ${CMAKE_CURRENT_BINARY_DIR}/portaudio_cmake.def @ONLY)
+  CONFIGURE_FILE(cmake_support/options_cmake.h.in ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h @ONLY)
+  SET(PA_PRIVATE_INCLUDES ${PA_PRIVATE_INCLUDES} ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h)
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PORTAUDIO_CMAKE_GENERATED)
+  SOURCE_GROUP("cmake_generated" FILES ${CMAKE_CURRENT_BINARY_DIR}/portaudio_cmake.def ${CMAKE_CURRENT_BINARY_DIR}/options_cmake.h)
+
+  SET(PA_EXTRA_SHARED_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/portaudio_cmake.def)
+
+ELSE()
+
+  SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} src/os/unix)
+  SET(PA_PLATFORM_SOURCES src/os/unix/pa_unix_hostapis.c src/os/unix/pa_unix_util.c)
+  SOURCE_GROUP("os\\unix" FILES ${PA_PLATFORM_SOURCES})
+  SET(PA_SOURCES ${PA_SOURCES} ${PA_PLATFORM_SOURCES})
+
+  IF(APPLE)
+
+    # SET(CMAKE_MACOSX_RPATH 1)
+    OPTION(PA_USE_COREAUDIO "Enable support for CoreAudio" ON)
+    IF(PA_USE_COREAUDIO)
+      SET(PA_COREAUDIO_SOURCES
+        src/hostapi/coreaudio/pa_mac_core.c
+        src/hostapi/coreaudio/pa_mac_core_blocking.c
+        src/hostapi/coreaudio/pa_mac_core_utilities.c)
+      SET(PA_COREAUDIO_INCLUDES
+        src/hostapi/coreaudio/pa_mac_core_blocking.h
+        src/hostapi/coreaudio/pa_mac_core_utilities.h)
+      SOURCE_GROUP("hostapi\\coreaudio" FILES ${PA_COREAUDIO_SOURCES} ${PA_COREAUDIO_INCLUDES})
+      SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_mac_core.h)
+      SET(PA_PRIVATE_INCLUDES ${PA_PRIVATE_INCLUDES} ${PA_COREAUDIO_INCLUDES})
+      SET(PA_SOURCES ${PA_SOURCES} ${PA_COREAUDIO_SOURCES})
+
+      FIND_LIBRARY(COREAUDIO_LIBRARY CoreAudio REQUIRED)
+      FIND_LIBRARY(AUDIOTOOLBOX_LIBRARY AudioToolbox REQUIRED)
+      FIND_LIBRARY(AUDIOUNIT_LIBRARY AudioUnit REQUIRED)
+      FIND_LIBRARY(CARBON_LIBRARY Carbon REQUIRED)
+      MARK_AS_ADVANCED(COREAUDIO_LIBRARY AUDIOTOOLBOX_LIBRARY AUDIOUNIT_LIBRARY CARBON_LIBRARY)
+      SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${COREAUDIO_LIBRARY} ${AUDIOTOOLBOX_LIBRARY} ${AUDIOUNIT_LIBRARY} ${CARBON_LIBRARY})
+      SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_USE_COREAUDIO)
+      SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework Carbon")
+    ENDIF()
+
+  ELSEIF(UNIX)
+
+    FIND_PACKAGE(Jack)
+    IF(JACK_FOUND)
+      OPTION(PA_USE_JACK "Enable support for Jack" ON)
+    ELSE()
+      OPTION(PA_USE_JACK "Enable support for Jack" OFF)
+    ENDIF()
+    IF(PA_USE_JACK)
+      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${JACK_INCLUDE_DIRS})
+      SET(PA_JACK_SOURCES src/hostapi/jack/pa_jack.c)
+      SOURCE_GROUP("hostapi\\JACK" FILES ${PA_JACK_SOURCES})
+      SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_jack.h)
+      SET(PA_SOURCES ${PA_SOURCES} ${PA_JACK_SOURCES})
+      SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_USE_JACK)
+      SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${JACK_LIBRARIES})
+      SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -ljack")
+    ENDIF()
+
+    FIND_PACKAGE(ALSA)
+    IF(ALSA_FOUND)
+      OPTION(PA_USE_ALSA "Enable support for ALSA" ON)
+    ELSE()
+      OPTION(PA_USE_ALSA "Enable support for ALSA" OFF)
+    ENDIF()
+    IF(PA_USE_ALSA)
+      SET(PA_PRIVATE_INCLUDE_PATHS ${PA_PRIVATE_INCLUDE_PATHS} ${ALSA_INCLUDE_DIRS})
+      SET(PA_ALSA_SOURCES src/hostapi/alsa/pa_linux_alsa.c)
+      SOURCE_GROUP("hostapi\\ALSA" FILES ${PA_ALSA_SOURCES})
+      SET(PA_PUBLIC_INCLUDES ${PA_PUBLIC_INCLUDES} include/pa_linux_alsa.h)
+      SET(PA_SOURCES ${PA_SOURCES} ${PA_ALSA_SOURCES})
+      SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_USE_ALSA)
+      SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ${ALSA_LIBRARIES})
+      SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -lasound")
+    ENDIF()
+
+  ENDIF()
+
+  SET(PA_PKGCONFIG_LDFLAGS "${PA_PKGCONFIG_LDFLAGS} -lm -lpthread")
+  SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} m pthread)
+
+ENDIF()
+
+SOURCE_GROUP("include" FILES ${PA_PUBLIC_INCLUDES})
+
+SET(PA_INCLUDES ${PA_PRIVATE_INCLUDES} ${PA_PUBLIC_INCLUDES})
+
+IF(WIN32)
+  OPTION(PA_UNICODE_BUILD "Enable Portaudio Unicode build" ON)
+  IF(PA_UNICODE_BUILD)
+    SET_SOURCE_FILES_PROPERTIES(${PA_SOURCES} PROPERTIES COMPILE_DEFINITIONS "UNICODE;_UNICODE")
+  ENDIF()
+ENDIF()
+
+OPTION(PA_ENABLE_DEBUG_OUTPUT "Enable debug output for Portaudio" OFF)
+IF(PA_ENABLE_DEBUG_OUTPUT)
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_ENABLE_DEBUG_OUTPUT)
+ENDIF()
+
+INCLUDE(TestBigEndian)
+TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+IF(IS_BIG_ENDIAN)
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_BIG_ENDIAN)
+ELSE()
+  SET(PA_PRIVATE_COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS} PA_LITTLE_ENDIAN)
+ENDIF()
+
+ADD_LIBRARY(portaudio SHARED ${PA_INCLUDES} ${PA_COMMON_INCLUDES} ${PA_SOURCES} ${PA_NON_UNICODE_SOURCES} ${PA_EXTRA_SHARED_SOURCES})
+SET_PROPERTY(TARGET portaudio APPEND_STRING PROPERTY COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS})
+TARGET_INCLUDE_DIRECTORIES(portaudio PRIVATE ${PA_PRIVATE_INCLUDE_PATHS})
+TARGET_INCLUDE_DIRECTORIES(portaudio PUBLIC include)
+TARGET_LINK_LIBRARIES(portaudio ${PA_LIBRARY_DEPENDENCIES})
+
+ADD_LIBRARY(portaudio_static STATIC ${PA_INCLUDES} ${PA_COMMON_INCLUDES} ${PA_SOURCES} ${PA_NON_UNICODE_SOURCES})
+SET_PROPERTY(TARGET portaudio_static APPEND_STRING PROPERTY COMPILE_DEFINITIONS ${PA_PRIVATE_COMPILE_DEFINITIONS})
+TARGET_INCLUDE_DIRECTORIES(portaudio_static PRIVATE ${PA_PRIVATE_INCLUDE_PATHS})
+TARGET_INCLUDE_DIRECTORIES(portaudio_static PUBLIC include)
+TARGET_LINK_LIBRARIES(portaudio_static ${PA_LIBRARY_DEPENDENCIES})
+
+IF(WIN32 AND MSVC)
+  OPTION(PA_CONFIG_LIB_OUTPUT_PATH "Make sure that output paths are kept neat" OFF)
+  IF(CMAKE_CL_64)
+    SET(TARGET_POSTFIX x64)
+    IF(PA_CONFIG_LIB_OUTPUT_PATH)
+      SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin/x64)
+    ENDIF()
+  ELSE()
+    SET(TARGET_POSTFIX x86)
+    IF(PA_CONFIG_LIB_OUTPUT_PATH)
+      SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin/Win32)
+    ENDIF()
+  ENDIF()
+  SET_TARGET_PROPERTIES(portaudio PROPERTIES OUTPUT_NAME portaudio_${TARGET_POSTFIX} FOLDER "Portaudio")
+  SET_TARGET_PROPERTIES(portaudio_static PROPERTIES OUTPUT_NAME portaudio_static_${TARGET_POSTFIX} FOLDER "Portaudio")
+ELSE()
+  IF(APPLE AND CMAKE_VERSION VERSION_GREATER 3.4.2)
+    OPTION(PA_OUTPUT_OSX_FRAMEWORK "Generate an OS X framework instead of the simple library" OFF)
+    IF(PA_OUTPUT_OSX_FRAMEWORK)
+      SET_TARGET_PROPERTIES(portaudio PROPERTIES
+        FRAMEWORK TRUE
+        MACOSX_FRAMEWORK_IDENTIFIER com.portaudio
+        FRAMEWORK_VERSION A
+        PUBLIC_HEADER "${PA_PUBLIC_INCLUDES}"
+        VERSION 19.0
+        SOVERSION 19.0)
+    ENDIF()
+  ENDIF()
+
+  IF(NOT PA_OUTPUT_OSX_FRAMEWORK)
+    CONFIGURE_FILE(cmake_support/portaudio-2.0.pc.in ${CMAKE_CURRENT_BINARY_DIR}/portaudio-2.0.pc @ONLY)
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/portaudio-2.0.pc DESTINATION lib/pkgconfig)
+    INSTALL(FILES ${PA_PUBLIC_INCLUDES} DESTINATION include)
+    INSTALL(TARGETS portaudio DESTINATION lib)
+  ENDIF()
+ENDIF()
+
+# Prepared for inclusion of test files
+OPTION(PA_BUILD_TESTS "Include test projects" OFF)
+IF(PA_BUILD_TESTS)
+  SUBDIRS(test)
+ENDIF()
+
+# Prepared for inclusion of test files
+OPTION(PA_BUILD_EXAMPLES "Include example projects" OFF)
+IF(PA_BUILD_EXAMPLES)
+  SUBDIRS(examples)
+ENDIF()

--- a/Externals/portaudio/cmake_support/FindASIOSDK.cmake
+++ b/Externals/portaudio/cmake_support/FindASIOSDK.cmake
@@ -1,0 +1,41 @@
+# $Id: $
+#
+# - Try to find the ASIO SDK
+# Once done this will define
+#
+#  ASIOSDK_FOUND - system has ASIO SDK
+#  ASIOSDK_ROOT_DIR - path to the ASIO SDK base directory
+#  ASIOSDK_INCLUDE_DIR - the ASIO SDK include directory
+
+if(WIN32)
+else(WIN32)
+  message(FATAL_ERROR "FindASIOSDK.cmake: Unsupported platform ${CMAKE_SYSTEM_NAME}" )
+endif(WIN32)
+
+file(GLOB results "${CMAKE_CURRENT_SOURCE_DIR}/../as*")
+foreach(f ${results})
+  if(IS_DIRECTORY ${f})
+    set(ASIOSDK_PATH_HINT ${ASIOSDK_PATH_HINT} ${f})
+  endif()
+endforeach()
+
+find_path(ASIOSDK_ROOT_DIR
+  common/asio.h
+  HINTS
+    ${ASIOSDK_PATH_HINT}
+)
+
+find_path(ASIOSDK_INCLUDE_DIR
+  asio.h
+  PATHS
+    ${ASIOSDK_ROOT_DIR}/common 
+)  
+
+# handle the QUIETLY and REQUIRED arguments and set ASIOSDK_FOUND to TRUE if 
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(ASIOSDK DEFAULT_MSG ASIOSDK_ROOT_DIR ASIOSDK_INCLUDE_DIR)
+
+MARK_AS_ADVANCED(
+    ASIOSDK_ROOT_DIR ASIOSDK_INCLUDE_DIR
+)

--- a/Externals/portaudio/cmake_support/FindDXSDK.cmake
+++ b/Externals/portaudio/cmake_support/FindDXSDK.cmake
@@ -1,0 +1,59 @@
+# $Id: $
+#
+# - Try to find the DirectX SDK
+# Once done this will define
+#
+#  DXSDK_FOUND - system has DirectX SDK
+#  DXSDK_ROOT_DIR - path to the DirectX SDK base directory
+#  DXSDK_INCLUDE_DIR - the DirectX SDK include directory
+#  DXSDK_LIBRARY_DIR - DirectX SDK libraries path
+#
+#  DXSDK_DSOUND_LIBRARY - Path to dsound.lib
+#
+
+if(WIN32)
+else(WIN32)
+  message(FATAL_ERROR "FindDXSDK.cmake: Unsupported platform ${CMAKE_SYSTEM_NAME}" )
+endif(WIN32)
+
+find_path(DXSDK_ROOT_DIR
+  include/dxsdkver.h
+  HINTS
+    $ENV{DXSDK_DIR}
+)
+
+find_path(DXSDK_INCLUDE_DIR
+  dxsdkver.h
+  PATHS
+    ${DXSDK_ROOT_DIR}/include 
+)  
+
+IF(CMAKE_CL_64)
+find_path(DXSDK_LIBRARY_DIR
+  dsound.lib
+  PATHS
+  ${DXSDK_ROOT_DIR}/lib/x64
+)
+ELSE(CMAKE_CL_64)
+find_path(DXSDK_LIBRARY_DIR
+  dsound.lib
+  PATHS
+  ${DXSDK_ROOT_DIR}/lib/x86
+)
+ENDIF(CMAKE_CL_64)
+
+find_library(DXSDK_DSOUND_LIBRARY 
+  dsound.lib
+  PATHS
+  ${DXSDK_LIBRARY_DIR}
+)
+
+# handle the QUIETLY and REQUIRED arguments and set DXSDK_FOUND to TRUE if 
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(DXSDK DEFAULT_MSG DXSDK_ROOT_DIR DXSDK_INCLUDE_DIR)
+
+MARK_AS_ADVANCED(
+    DXSDK_ROOT_DIR DXSDK_INCLUDE_DIR
+    DXSDK_LIBRARY_DIR DXSDK_DSOUND_LIBRARY
+)

--- a/Externals/portaudio/cmake_support/FindJack.cmake
+++ b/Externals/portaudio/cmake_support/FindJack.cmake
@@ -1,0 +1,41 @@
+# - Try to find jack
+# Once done this will define
+#  JACK_FOUND - System has jack
+#  JACK_INCLUDE_DIRS - The jack include directories
+#  JACK_LIBRARIES - The libraries needed to use jack
+#  JACK_DEFINITIONS - Compiler switches required for using jack
+
+if (JACK_LIBRARIES AND JACK_INCLUDE_DIRS)
+
+	# in cache already
+	set(JACK_FOUND TRUE)
+
+else (JACK_LIBRARIES AND JACK_INCLUDE_DIRS)
+
+	set(JACK_DEFINITIONS "")
+
+	# Look for pkg-config and use it (if available) to find package
+	find_package(PkgConfig QUIET)
+	if (PKG_CONFIG_FOUND)
+		pkg_search_module(JACK QUIET jack)
+	endif (PKG_CONFIG_FOUND)
+
+	if (NOT JACK_FOUND)
+
+		find_path(JACK_INCLUDE_DIR jack/jack.h HINTS ${JACK_INCLUDEDIR} ${JACK_INCLUDE_DIRS} PATH_SUFFIXES jack)
+		find_library(JACK_LIBRARY NAMES jack HINTS ${JACK_LIBDIR} ${JACK_LIBRARY_DIRS})
+
+		set(JACK_LIBRARIES    ${JACK_LIBRARY})
+		set(JACK_INCLUDE_DIRS ${JACK_INCLUDE_DIR})
+
+		include(FindPackageHandleStandardArgs)
+
+		# Set JACK_FOUND if the library and include paths were found
+		find_package_handle_standard_args(jack DEFAULT_MSG JACK_LIBRARY JACK_INCLUDE_DIR)
+
+		# Don't show include/library paths in cmake GUI
+		mark_as_advanced(JACK_INCLUDE_DIR JACK_LIBRARY)
+
+	endif (NOT JACK_FOUND)
+
+endif (JACK_LIBRARIES AND JACK_INCLUDE_DIRS)

--- a/Externals/portaudio/cmake_support/options_cmake.h.in
+++ b/Externals/portaudio/cmake_support/options_cmake.h.in
@@ -1,0 +1,31 @@
+/* $Id: $
+
+   !!! @GENERATED_MESSAGE@ !!!
+
+   Header file configured by CMake to convert CMake options/vars to macros. It is done this way because if set via
+   preprocessor options, MSVC f.i. has no way of knowing when an option (or var) changes as there is no dependency chain.
+   
+   The generated "options_cmake.h" should be included like so:
+   
+   #ifdef PORTAUDIO_CMAKE_GENERATED
+   #include "options_cmake.h"
+   #endif
+   
+   so that non-CMake build environments are left intact.
+   
+   Source template: cmake_support/options_cmake.h.in
+*/
+
+#ifdef _WIN32
+#if defined(PA_USE_ASIO) || defined(PA_USE_DS) || defined(PA_USE_WMME) || defined(PA_USE_WASAPI) || defined(PA_USE_WDMKS)
+#error "This header needs to be included before pa_hostapi.h!!"
+#endif
+
+#cmakedefine01 PA_USE_ASIO
+#cmakedefine01 PA_USE_DS
+#cmakedefine01 PA_USE_WMME
+#cmakedefine01 PA_USE_WASAPI
+#cmakedefine01 PA_USE_WDMKS
+#else
+#error "Platform currently not supported by CMake script"
+#endif

--- a/Externals/portaudio/cmake_support/portaudio-2.0.pc.in
+++ b/Externals/portaudio/cmake_support/portaudio-2.0.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: PortAudio
+Description: Portable audio I/O
+Requires:
+Version: @PA_PKGCONFIG_VERSION@
+
+Libs: -L${libdir} -lportaudio @PA_PKGCONFIG_LDFLAGS@
+Cflags: -I${includedir} @PA_PKGCONFIG_CFLAGS@

--- a/Externals/portaudio/cmake_support/template_portaudio.def
+++ b/Externals/portaudio/cmake_support/template_portaudio.def
@@ -1,0 +1,53 @@
+; $Id: $
+;
+; !!! @GENERATED_MESSAGE@ !!!
+EXPORTS
+
+;
+Pa_GetVersion                       @1
+Pa_GetVersionText                   @2
+Pa_GetErrorText                     @3                 
+Pa_Initialize                       @4
+Pa_Terminate                        @5
+Pa_GetHostApiCount                  @6
+Pa_GetDefaultHostApi                @7
+Pa_GetHostApiInfo                   @8
+Pa_HostApiTypeIdToHostApiIndex      @9
+Pa_HostApiDeviceIndexToDeviceIndex  @10
+Pa_GetLastHostErrorInfo             @11
+Pa_GetDeviceCount                   @12
+Pa_GetDefaultInputDevice            @13
+Pa_GetDefaultOutputDevice           @14
+Pa_GetDeviceInfo                    @15
+Pa_IsFormatSupported                @16
+Pa_OpenStream                       @17
+Pa_OpenDefaultStream                @18
+Pa_CloseStream                      @19
+Pa_SetStreamFinishedCallback        @20
+Pa_StartStream                      @21
+Pa_StopStream                       @22
+Pa_AbortStream                      @23
+Pa_IsStreamStopped                  @24
+Pa_IsStreamActive                   @25
+Pa_GetStreamInfo                    @26
+Pa_GetStreamTime                    @27
+Pa_GetStreamCpuLoad                 @28
+Pa_ReadStream                       @29
+Pa_WriteStream                      @30
+Pa_GetStreamReadAvailable           @31
+Pa_GetStreamWriteAvailable          @32
+Pa_GetSampleSize                    @33
+Pa_Sleep                            @34
+@DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_GetAvailableBufferSizes      @50
+@DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_ShowControlPanel             @51
+@DEF_EXCLUDE_X86_PLAIN_CONVERTERS@PaUtil_InitializeX86PlainConverters @52
+@DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_GetInputChannelName          @53
+@DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_GetOutputChannelName         @54
+PaUtil_SetDebugPrintFunction        @55
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetDeviceDefaultFormat     @56
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetDeviceRole              @57
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_ThreadPriorityBoost        @58
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_ThreadPriorityRevert       @59
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetFramesPerHostBuffer     @60
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetJackDescription         @61
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetJackCount               @62


### PR DESCRIPTION
It already gets built for Windows, Dolphin should build it for other systems to have a consistent experience.

TL;DR: Enables mic support on macOS builds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4255)
<!-- Reviewable:end -->
