### PR TITLE
OGL: Shader UID cache.

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -206,6 +206,11 @@ SHADER* ProgramShaderCache::SetShader(u32 primitive_type)
     return &last_entry->shader;
   }
 
+  return CompileShader(uid);
+}
+
+SHADER* ProgramShaderCache::CompileShader(const SHADERUID& uid)
+{
   // Make an entry in the table
   PCacheEntry& newentry = pshaders[uid];
   last_entry = &newentry;
@@ -277,9 +282,6 @@ bool ProgramShaderCache::CompileShader(SHADER& shader, const std::string& vcode,
   glAttachShader(pid, psid);
   if (gsid)
     glAttachShader(pid, gsid);
-
-  if (g_ogl_config.bSupportsGLSLCache)
-    glProgramParameteri(pid, GL_PROGRAM_BINARY_RETRIEVABLE_HINT, GL_TRUE);
 
   shader.SetProgramBindings();
 
@@ -402,6 +404,13 @@ ProgramShaderCache::PCacheEntry ProgramShaderCache::GetShaderProgram()
   return *last_entry;
 }
 
+void ProgramShaderCache::ProgramShaderCacheInserter::Read(const SHADERUID& key, const u8* value,
+                                                          u32 value_size)
+{
+  CompileShader(key);
+  last_entry->in_cache = true;
+}
+
 void ProgramShaderCache::Init()
 {
   // We have to get the UBO alignment here because
@@ -419,78 +428,37 @@ void ProgramShaderCache::Init()
   // Then once more to get bytes
   s_buffer = StreamBuffer::Create(GL_UNIFORM_BUFFER, UBO_LENGTH);
 
-  // Read our shader cache, only if supported
-  if (g_ogl_config.bSupportsGLSLCache)
-  {
-    GLint Supported;
-    glGetIntegerv(GL_NUM_PROGRAM_BINARY_FORMATS, &Supported);
-    if (!Supported)
-    {
-      ERROR_LOG(VIDEO, "GL_ARB_get_program_binary is supported, but no binary format is known. So "
-                       "disable shader cache.");
-      g_ogl_config.bSupportsGLSLCache = false;
-    }
-    else
-    {
-      if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-        File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
-
-      std::string cache_filename =
-          StringFromFormat("%sogl-%s-shaders.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                           SConfig::GetInstance().m_strGameID.c_str());
-
-      ProgramShaderCacheInserter inserter;
-      g_program_disk_cache.OpenAndRead(cache_filename, inserter);
-    }
-    SETSTAT(stats.numPixelShadersAlive, pshaders.size());
-  }
-
   CreateHeader();
 
   CurrentProgram = 0;
   last_entry = nullptr;
 }
 
+void ProgramShaderCache::LoadCache()
+{
+  // Read our shader cache
+  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
+    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
+
+  std::string cache_filename =
+      StringFromFormat("%sogl-%s-shaders.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
+                       SConfig::GetInstance().m_strGameID.c_str());
+
+  ProgramShaderCacheInserter inserter;
+  g_program_disk_cache.OpenAndRead(cache_filename, inserter);
+}
+
 void ProgramShaderCache::Shutdown()
 {
   // store all shaders in cache on disk
-  if (g_ogl_config.bSupportsGLSLCache)
+  for (const auto& entry : pshaders)
   {
-    for (auto& entry : pshaders)
+    if (!entry.second.in_cache)
     {
-      // Clear any prior error code
-      glGetError();
-
-      if (entry.second.in_cache)
-      {
-        continue;
-      }
-
-      GLint link_status = GL_FALSE, delete_status = GL_TRUE, binary_size = 0;
-      glGetProgramiv(entry.second.shader.glprogid, GL_LINK_STATUS, &link_status);
-      glGetProgramiv(entry.second.shader.glprogid, GL_DELETE_STATUS, &delete_status);
-      glGetProgramiv(entry.second.shader.glprogid, GL_PROGRAM_BINARY_LENGTH, &binary_size);
-      if (glGetError() != GL_NO_ERROR || link_status == GL_FALSE || delete_status == GL_TRUE ||
-          !binary_size)
-      {
-        continue;
-      }
-
-      std::vector<u8> data(binary_size + sizeof(GLenum));
-      u8* binary = &data[sizeof(GLenum)];
-      GLenum* prog_format = (GLenum*)&data[0];
-      glGetProgramBinary(entry.second.shader.glprogid, binary_size, nullptr, prog_format, binary);
-      if (glGetError() != GL_NO_ERROR)
-      {
-        continue;
-      }
-
-      g_program_disk_cache.Append(entry.first, &data[0], binary_size + sizeof(GLenum));
+      g_program_disk_cache.Append(entry.first, nullptr, 0);
     }
-
-    g_program_disk_cache.Sync();
-    g_program_disk_cache.Close();
   }
+  g_program_disk_cache.Close();
 
   glUseProgram(0);
 
@@ -644,32 +612,6 @@ void ProgramShaderCache::CreateHeader()
           "precision highp usamplerBuffer;" :
           "",
       v > GLSLES_300 ? "precision highp sampler2DMS;" : "");
-}
-
-void ProgramShaderCache::ProgramShaderCacheInserter::Read(const SHADERUID& key, const u8* value,
-                                                          u32 value_size)
-{
-  const u8* binary = value + sizeof(GLenum);
-  GLenum* prog_format = (GLenum*)value;
-  GLint binary_size = value_size - sizeof(GLenum);
-
-  PCacheEntry entry;
-  entry.in_cache = 1;
-  entry.shader.glprogid = glCreateProgram();
-  glProgramBinary(entry.shader.glprogid, *prog_format, binary, binary_size);
-
-  GLint success;
-  glGetProgramiv(entry.shader.glprogid, GL_LINK_STATUS, &success);
-
-  if (success)
-  {
-    pshaders[key] = entry;
-    entry.shader.SetProgramVariables();
-  }
-  else
-  {
-    glDeleteProgram(entry.shader.glprogid);
-  }
 }
 
 }  // namespace OGL

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -65,12 +65,14 @@ public:
   static SHADER* SetShader(u32 primitive_type);
   static void GetShaderId(SHADERUID* uid, u32 primitive_type);
 
+  static SHADER* CompileShader(const SHADERUID& uid);
   static bool CompileShader(SHADER& shader, const std::string& vcode, const std::string& pcode,
                             const std::string& gcode = "");
   static GLuint CompileSingleShader(GLuint type, const std::string& code);
   static void UploadConstants();
 
   static void Init();
+  static void LoadCache();
   static void Shutdown();
   static void CreateHeader();
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -475,7 +475,6 @@ Renderer::Renderer()
   // Clip distance support is useless without a method to clamp the depth range
   g_Config.backend_info.bSupportsDepthClamp = GLExtensions::Supports("GL_ARB_depth_clamp");
 
-  g_ogl_config.bSupportsGLSLCache = GLExtensions::Supports("GL_ARB_get_program_binary");
   g_ogl_config.bSupportsGLPinnedMemory = GLExtensions::Supports("GL_AMD_pinned_memory");
   g_ogl_config.bSupportsGLSync = GLExtensions::Supports("GL_ARB_sync");
   g_ogl_config.bSupportsGLBaseVertex = GLExtensions::Supports("GL_ARB_draw_elements_base_vertex") ||
@@ -511,7 +510,6 @@ Renderer::Renderer()
                                                 ES_TEXBUF_TYPE::TEXBUF_EXT :
                                                 ES_TEXBUF_TYPE::TEXBUF_NONE;
 
-    g_ogl_config.bSupportsGLSLCache = true;
     g_ogl_config.bSupportsGLSync = true;
 
     // TODO: Implement support for GL_EXT_clip_cull_distance when there is an extension for
@@ -666,12 +664,11 @@ Renderer::Renderer()
                                    g_ogl_config.gl_renderer, g_ogl_config.gl_version),
                   5000);
 
-  WARN_LOG(VIDEO, "Missing OGL Extensions: %s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+  WARN_LOG(VIDEO, "Missing OGL Extensions: %s%s%s%s%s%s%s%s%s%s%s%s%s",
            g_ActiveConfig.backend_info.bSupportsDualSourceBlend ? "" : "DualSourceBlend ",
            g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ? "" : "PrimitiveRestart ",
            g_ActiveConfig.backend_info.bSupportsEarlyZ ? "" : "EarlyZ ",
            g_ogl_config.bSupportsGLPinnedMemory ? "" : "PinnedMemory ",
-           g_ogl_config.bSupportsGLSLCache ? "" : "ShaderCache ",
            g_ogl_config.bSupportsGLBaseVertex ? "" : "BaseVertex ",
            g_ogl_config.bSupportsGLBufferStorage ? "" : "BufferStorage ",
            g_ogl_config.bSupportsGLSync ? "" : "Sync ", g_ogl_config.bSupportsMSAA ? "" : "MSAA ",

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -38,7 +38,6 @@ enum class ES_TEXBUF_TYPE
 // ogl-only config, so not in VideoConfig.h
 struct VideoConfig
 {
-  bool bSupportsGLSLCache;
   bool bSupportsGLPinnedMemory;
   bool bSupportsGLSync;
   bool bSupportsGLBaseVertex;

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -152,6 +152,7 @@ void VideoBackend::Video_Prepare()
   Renderer::Init();
   TextureConverter::Init();
   BoundingBox::Init();
+  ProgramShaderCache::LoadCache();
 }
 
 void VideoBackend::Shutdown()


### PR DESCRIPTION
This PR is more like a feature removal: It drops our shader cache. But it creates a new form of shader cache, an UID cache. This slows down the booting of dolphin a bit, but the cache now don't need any GL features.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4257)

<!-- Reviewable:end -->
