### PR TITLE
[WIP] Wrap Vertex Array Pointer Access

### DIFF
--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -82,7 +82,7 @@ void UpdateVertexArrayPointers()
   {
     // Only update the array base if the vertex description states we are going to use it.
     if (g_main_cp_state.vtx_desc.GetVertexArrayStatus(i) & MASK_INDEXED)
-      cached_arraybases[i] = Memory::GetPointer(g_main_cp_state.array_bases[i]);
+		cached_arraybases[i] = Memory::GetPointer(g_main_cp_state.array_bases[i] & 0x1fffffff);
   }
 
   g_main_cp_state.bases_dirty = false;


### PR DESCRIPTION
I have no idea if that's the correct description.

Not entirely sure if this is the correct behavior either, but it seems like a good idea to not allow the games to access out of range memory and crash Dolphin outright.  I more or less wanted to make a Pull Request now so this issue doesn't get forgotten; since this crash has been around for many, many years.

Fixes issue [8935](https://bugs.dolphin-emu.org/issues/8935) and possibly other weird crashes with no explanation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4266)
<!-- Reviewable:end -->
