### PR TITLE
SysConf: Add support for the LongLong type

### DIFF
--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -153,6 +153,10 @@ bool SysConf::LoadFromFileInternal(FILE* fh)
       curEntry.dataLength = 4;
       break;
 
+    case Type_LongLong:
+      curEntry.dataLength = 8;
+      break;
+
     default:
       PanicAlertT("Unknown entry type %i in SYSCONF (%s@%x)!", curEntry.type, curEntry.name,
                   curEntry.offset);

--- a/Source/Core/Common/SysConf.h
+++ b/Source/Core/Common/SysConf.h
@@ -27,7 +27,7 @@ enum SysconfType
   Type_Byte,
   Type_Short,
   Type_Long,
-  Type_Unknown,
+  Type_LongLong,
   Type_Bool
 };
 


### PR DESCRIPTION
This should fix the "unknown entry type" panic alerts when an existing SYSCONF from a real Wii NAND is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4272)
<!-- Reviewable:end -->
