### PR TITLE
DolphinWX: Less duplication in code related to traversal server label

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -23,6 +23,9 @@
 #include "DolphinWX/NetPlay/NetWindow.h"
 #include "DolphinWX/WxUtils.h"
 
+static const std::string DEFAULT_TRAVERSAL_SERVER = "stun.dolphin-emu.org";
+static const std::string DEFAULT_TRAVERSAL_PORT = "6262";
+
 static std::string GetFromINI(IniFile::Section& section, const std::string& key,
                               const std::string& default_value)
 {
@@ -36,12 +39,12 @@ static std::string GetFromINI(IniFile::Section& section, const std::string& key,
 
 static std::string GetTraversalPort(IniFile::Section& section)
 {
-  return GetFromINI(section, "TraversalPort", "6262");
+  return GetFromINI(section, "TraversalPort", DEFAULT_TRAVERSAL_PORT);
 }
 
 static std::string GetTraversalServer(IniFile::Section& section)
 {
-  return GetFromINI(section, "TraversalServer", "stun.dolphin-emu.org");
+  return GetFromINI(section, "TraversalServer", DEFAULT_TRAVERSAL_SERVER);
 }
 
 NetPlaySetupFrame::NetPlaySetupFrame(wxWindow* const parent, const CGameListCtrl* const game_list)
@@ -452,8 +455,8 @@ void NetPlaySetupFrame::OnResetTraversal(wxCommandEvent& event)
   const std::string dolphin_ini = File::GetUserPath(F_DOLPHINCONFIG_IDX);
   inifile.Load(dolphin_ini);
   IniFile::Section& netplay_section = *inifile.GetOrCreateSection("NetPlay");
-  netplay_section.Set("TraversalServer", (std::string) "stun.dolphin-emu.org");
-  netplay_section.Set("TraversalPort", (std::string) "6262");
+  netplay_section.Set("TraversalServer", DEFAULT_TRAVERSAL_SERVER);
+  netplay_section.Set("TraversalPort", DEFAULT_TRAVERSAL_PORT);
   inifile.Save(dolphin_ini);
 
   m_traversal_lbl->SetLabelText(_("Traversal Server: ") + "stun.dolphin-emu.org:6262");

--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -47,6 +47,13 @@ static std::string GetTraversalServer(IniFile::Section& section)
   return GetFromINI(section, "TraversalServer", DEFAULT_TRAVERSAL_SERVER);
 }
 
+static wxString GetTraversalLabelText(IniFile::Section& section)
+{
+  std::string server = GetTraversalServer(section);
+  std::string port = GetTraversalPort(section);
+  return wxString::Format(_("Traversal Server: %s"), (server + ":" + port).c_str());
+}
+
 NetPlaySetupFrame::NetPlaySetupFrame(wxWindow* const parent, const CGameListCtrl* const game_list)
     : wxFrame(parent, wxID_ANY, _("Dolphin NetPlay Setup")), m_game_list(game_list)
 {
@@ -106,11 +113,7 @@ NetPlaySetupFrame::NetPlaySetupFrame(wxWindow* const parent, const CGameListCtrl
       m_direct_traversal->Select(DIRECT_CHOICE);
     }
 
-    std::string centralPort = GetTraversalPort(netplay_section);
-    std::string centralServer = GetTraversalServer(netplay_section);
-
-    m_traversal_lbl = new wxStaticText(panel, wxID_ANY, _("Traversal Server:") + " " +
-                                                            centralServer + ":" + centralPort);
+    m_traversal_lbl = new wxStaticText(panel, wxID_ANY, GetTraversalLabelText(netplay_section));
   }
   // tabs
   m_notebook = new wxNotebook(panel, wxID_ANY);
@@ -459,7 +462,7 @@ void NetPlaySetupFrame::OnResetTraversal(wxCommandEvent& event)
   netplay_section.Set("TraversalPort", DEFAULT_TRAVERSAL_PORT);
   inifile.Save(dolphin_ini);
 
-  m_traversal_lbl->SetLabelText(_("Traversal Server: ") + "stun.dolphin-emu.org:6262");
+  m_traversal_lbl->SetLabelText(GetTraversalLabelText(netplay_section));
 }
 
 void NetPlaySetupFrame::OnTraversalListenPortChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -458,8 +458,8 @@ void NetPlaySetupFrame::OnResetTraversal(wxCommandEvent& event)
   const std::string dolphin_ini = File::GetUserPath(F_DOLPHINCONFIG_IDX);
   inifile.Load(dolphin_ini);
   IniFile::Section& netplay_section = *inifile.GetOrCreateSection("NetPlay");
-  netplay_section.Set("TraversalServer", DEFAULT_TRAVERSAL_SERVER);
-  netplay_section.Set("TraversalPort", DEFAULT_TRAVERSAL_PORT);
+  netplay_section.Delete("TraversalServer");
+  netplay_section.Delete("TraversalPort");
   inifile.Save(dolphin_ini);
 
   m_traversal_lbl->SetLabelText(GetTraversalLabelText(netplay_section));


### PR DESCRIPTION
Earlier today, I noticed that Dolphin's strings to be localized contained both "Traversal Server:" and "Traversal Server: " (with a space at the end). This PR merges those two strings into one ("Traversal Server: %s") and also contains some other related cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4273)
<!-- Reviewable:end -->
