### PR TITLE
GeckoCode: Provide operator== and operator!= overloads

### DIFF
--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <iterator>
 #include <mutex>
+#include <tuple>
 #include <vector>
 
 #include "Common/ChunkFile.h"
@@ -20,22 +21,32 @@ namespace Gecko
 {
 static constexpr u32 CODE_SIZE = 8;
 
+bool operator==(const GeckoCode& lhs, const GeckoCode& rhs)
+{
+  return lhs.codes == rhs.codes;
+}
+
+bool operator!=(const GeckoCode& lhs, const GeckoCode& rhs)
+{
+  return !operator==(lhs, rhs);
+}
+
+bool operator==(const GeckoCode::Code& lhs, const GeckoCode::Code& rhs)
+{
+  return std::tie(lhs.address, lhs.data) == std::tie(rhs.address, rhs.data);
+}
+
+bool operator!=(const GeckoCode::Code& lhs, const GeckoCode::Code& rhs)
+{
+  return !operator==(lhs, rhs);
+}
+
 // return true if a code exists
 bool GeckoCode::Exist(u32 address, u32 data) const
 {
   return std::find_if(codes.begin(), codes.end(), [&](const Code& code) {
            return code.address == address && code.data == data;
          }) != codes.end();
-}
-
-// return true if the code is identical
-bool GeckoCode::Compare(const GeckoCode& compare) const
-{
-  return codes.size() == compare.codes.size() &&
-         std::equal(codes.begin(), codes.end(), compare.codes.begin(),
-                    [](const Code& a, const Code& b) {
-                      return a.address == b.address && a.data == b.data;
-                    });
 }
 
 enum class Installation

--- a/Source/Core/Core/GeckoCode.h
+++ b/Source/Core/Core/GeckoCode.h
@@ -31,9 +31,14 @@ public:
   bool enabled;
   bool user_defined;
 
-  bool Compare(const GeckoCode& compare) const;
   bool Exist(u32 address, u32 data) const;
 };
+
+bool operator==(const GeckoCode& lhs, const GeckoCode& rhs);
+bool operator!=(const GeckoCode& lhs, const GeckoCode& rhs);
+
+bool operator==(const GeckoCode::Code& lhs, const GeckoCode::Code& rhs);
+bool operator!=(const GeckoCode::Code& lhs, const GeckoCode::Code& rhs);
 
 // Installation address for codehandler.bin in the Game's RAM
 constexpr u32 INSTALLER_BASE_ADDRESS = 0x80001800;

--- a/Source/Core/DolphinWX/Cheats/GeckoCodeDiag.cpp
+++ b/Source/Core/DolphinWX/Cheats/GeckoCodeDiag.cpp
@@ -275,8 +275,8 @@ void CodeConfigPanel::DownloadCodes(wxCommandEvent&)
       for (const GeckoCode& code : gcodes)
       {
         // only add codes which do not already exist
-        std::vector<GeckoCode>::const_iterator existing_gcodes_iter = m_gcodes.begin(),
-                                               existing_gcodes_end = m_gcodes.end();
+        auto existing_gcodes_iter = m_gcodes.begin();
+        auto existing_gcodes_end = m_gcodes.end();
         for (;; ++existing_gcodes_iter)
         {
           if (existing_gcodes_end == existing_gcodes_iter)
@@ -287,7 +287,7 @@ void CodeConfigPanel::DownloadCodes(wxCommandEvent&)
           }
 
           // code exists
-          if (existing_gcodes_iter->Compare(code))
+          if (*existing_gcodes_iter == code)
             break;
         }
       }


### PR DESCRIPTION
Noticed this in the recently merged #4216

Same thing but allows both GeckoCode and Code to be utilized directly without predicates for equality/inequality in stardard algorithms.

Also, rather than have `Compare` as a function, it makes more sense to use the comparison operators.

The size check for std::vectors is unnecessary, as this is built into std::vector's operator==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4276)
<!-- Reviewable:end -->
