### PR TITLE
HLE: Fix warnings

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -185,13 +185,12 @@ bool IsEnabled(int flags)
 
 u32 UnPatch(const std::string& patch_name)
 {
-  auto* patch = std::find_if(std::begin(OSPatches), std::end(OSPatches), [&](const SPatch& patch) {
-    return patch_name == patch.m_szPatchName;
-  });
+  auto* patch = std::find_if(std::begin(OSPatches), std::end(OSPatches),
+                             [&](const SPatch& p) { return patch_name == p.m_szPatchName; });
   if (patch == std::end(OSPatches))
     return 0;
 
-  if (patch->type == HLE_TYPE_FIXED)
+  if (patch->flags == HLE_TYPE_FIXED)
   {
     u32 patch_idx = static_cast<u32>(patch - OSPatches);
     u32 addr = 0;


### PR DESCRIPTION
PR #4216 caused a shadowed variable warning. There's also a bug where I compared `type` instead of `flags` (The enum values are weirdly named, `HLE_TYPE_*` is a flag, `HLE_HOOK_*` is the type).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4277)
<!-- Reviewable:end -->
