### PR TITLE
VideoCommon: Minor changes

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -1273,7 +1273,7 @@ void Renderer::SetInterlacingMode()
   // TODO
 }
 
-int Renderer::GetMaxTextureSize()
+u32 Renderer::GetMaxTextureSize()
 {
   return DX11::D3D::GetMaxTextureSize();
 }

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -58,7 +58,7 @@ public:
 
   static bool CheckForResize();
 
-  int GetMaxTextureSize() override;
+  u32 GetMaxTextureSize() override;
 
 private:
   void BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D* src_texture,

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -1287,7 +1287,7 @@ void Renderer::SetInterlacingMode()
   // EXISTINGD3D11TODO
 }
 
-int Renderer::GetMaxTextureSize()
+u32 Renderer::GetMaxTextureSize()
 {
   return DX12::D3D::GetMaxTextureSize();
 }

--- a/Source/Core/VideoBackends/D3D12/Render.h
+++ b/Source/Core/VideoBackends/D3D12/Render.h
@@ -58,7 +58,7 @@ public:
 
   static bool CheckForResize();
 
-  int GetMaxTextureSize() override;
+  u32 GetMaxTextureSize() override;
 
   static D3D12_BLEND_DESC GetResetBlendDesc();
   static D3D12_DEPTH_STENCIL_DESC GetResetDepthStencilDesc();

--- a/Source/Core/VideoBackends/Null/Render.h
+++ b/Source/Core/VideoBackends/Null/Render.h
@@ -19,7 +19,7 @@ public:
   void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override {}
   u16 BBoxRead(int index) override { return 0; }
   void BBoxWrite(int index, u16 value) override {}
-  int GetMaxTextureSize() override { return 16 * 1024; }
+  u32 GetMaxTextureSize() override { return 16 * 1024; }
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, const EFBRectangle& rc,

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1809,14 +1809,14 @@ bool Renderer::SaveScreenshot(const std::string& filename, const TargetRectangle
   return TextureToPng(data.get(), W * 4, filename, W, H, false);
 }
 
-int Renderer::GetMaxTextureSize()
+u32 Renderer::GetMaxTextureSize()
 {
   // Right now nvidia seems to do something very weird if we try to cache GL_MAX_TEXTURE_SIZE in
   // init. This is a workaround that lets
   // us keep the perf improvement that caching it gives us.
   if (s_max_texture_size == 0)
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &s_max_texture_size);
-  return s_max_texture_size;
+  return static_cast<u32>(s_max_texture_size);
 }
 
 void Renderer::ChangeSurface(void* new_surface_handle)

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -103,7 +103,7 @@ public:
 
   bool SaveScreenshot(const std::string& filename, const TargetRectangle& rc) override;
 
-  int GetMaxTextureSize() override;
+  u32 GetMaxTextureSize() override;
 
   void ChangeSurface(void* new_surface_handle) override;
 

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -30,7 +30,7 @@ public:
   u16 BBoxRead(int index) override;
   void BBoxWrite(int index, u16 value) override;
 
-  int GetMaxTextureSize() override { return 16 * 1024; };
+  u32 GetMaxTextureSize() override { return 16 * 1024; };
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -38,7 +38,7 @@ public:
   void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override;
   u16 BBoxRead(int index) override;
   void BBoxWrite(int index, u16 value) override;
-  int GetMaxTextureSize() override { return 16 * 1024; }
+  u32 GetMaxTextureSize() override { return 16 * 1024; }
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, const EFBRectangle& rc,

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -237,11 +237,10 @@ bool Renderer::CalculateTargetSize(unsigned int framebuffer_width, unsigned int 
     efb_scale_numeratorX = efb_scale_numeratorY = s_last_efb_scale - 3;
     efb_scale_denominatorX = efb_scale_denominatorY = 1;
 
-    int maxSize;
-    maxSize = GetMaxTextureSize();
-    if ((unsigned)maxSize < EFB_WIDTH * efb_scale_numeratorX / efb_scale_denominatorX)
+    const u32 max_size = GetMaxTextureSize();
+    if (max_size < EFB_WIDTH * efb_scale_numeratorX / efb_scale_denominatorX)
     {
-      efb_scale_numeratorX = efb_scale_numeratorY = (maxSize / EFB_WIDTH);
+      efb_scale_numeratorX = efb_scale_numeratorY = (max_size / EFB_WIDTH);
       efb_scale_denominatorX = efb_scale_denominatorY = 1;
     }
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -133,7 +133,7 @@ public:
   static void StorePixelFormat(PEControl::PixelFormat new_format) { prev_efb_format = new_format; }
   PostProcessingShaderImplementation* GetPostProcessor() { return m_post_processor.get(); }
   // Max height/width
-  virtual int GetMaxTextureSize() = 0;
+  virtual u32 GetMaxTextureSize() = 0;
 
   static Common::Event s_screenshotCompleted;
 


### PR DESCRIPTION
Make Renderer::GetMaxTextureSize return u32 instead of int.
Replaces https://github.com/dolphin-emu/dolphin/pull/3198

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4280)
<!-- Reviewable:end -->
