### PR TITLE
MemoryView: Don't segfault if Core isn't running

### DIFF
--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -312,11 +312,11 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
       dc.SetTextForeground(*wxBLACK);
     }
 
-    if (!PowerPC::HostIsRAMAddress(address))
-      continue;
-
     if (debugger->IsAlive())
     {
+      if (!PowerPC::HostIsRAMAddress(address))
+        continue;
+
       std::string dis;
       u32 mem_data = debugger->ReadExtraMemory(memory, address);
 


### PR DESCRIPTION
There was a bug that caused MemoryView to indirectly cause a segfault; the simplest way to reproduce it is 1) start a game; 2) stop the game; 3) click on the Refresh button and watch Dolphin segfault.

This commit fixes it by only calling PowerPC::HostIsRAMAddress when emulation is running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4284)
<!-- Reviewable:end -->
