### PR TITLE
Fix frame dump crash when resolution changes

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -183,10 +183,14 @@ static void PreparePacket(AVPacket* pkt)
 
 void AVIDump::AddFrame(const u8* data, int width, int height)
 {
-  // Store current frame data in case frame dumping stops before next frame update
+  // Store current frame data in case frame dumping stops before next frame update,
+  // but make sure that you don't store the last stored frame and check the resolution upon
+  // closing the file or else you store recusion, and dolphins don't like recursion.
   if (!s_stop_dumping)
+  {
     StoreFrameData(data, width, height);
-  CheckResolution(width, height);
+    CheckResolution(width, height);
+  }
   s_src_frame->data[0] = const_cast<u8*>(data);
   s_src_frame->linesize[0] = width * s_bytes_per_pixel;
   s_src_frame->format = s_pix_fmt;


### PR DESCRIPTION
Fixes a regression introduced by #4148 where if the resolution changes during dumping, Dolphin would crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4285)
<!-- Reviewable:end -->
