### PR TITLE
Reduce the filepath of logs

### DIFF
--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -9,6 +9,7 @@
 #include <set>
 #include <string>
 
+#include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/ConsoleListener.h"
@@ -28,6 +29,15 @@ void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char*
 }
 
 LogManager* LogManager::m_logManager = nullptr;
+
+static size_t DeterminePathCutOffPoint()
+{
+  constexpr const char* pattern = DIR_SEP "Source" DIR_SEP "Core" DIR_SEP;
+  size_t pos = std::string(__FILE__).find(pattern);
+  if (pos != std::string::npos)
+    return pos + strlen(pattern);
+  return 0;
+}
 
 LogManager::LogManager()
 {
@@ -102,6 +112,8 @@ LogManager::LogManager()
     if (enable && write_console)
       container->AddListener(LogListener::CONSOLE_LISTENER);
   }
+
+  m_path_cutoff_point = DeterminePathCutOffPoint();
 }
 
 LogManager::~LogManager()
@@ -125,8 +137,10 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const 
 
   CharArrayFromFormatV(temp, MAX_MSGLEN, format, args);
 
+  const char* path_to_print = file + m_path_cutoff_point;
+
   std::string msg = StringFromFormat(
-      "%s %s:%u %c[%s]: %s\n", Common::Timer::GetTimeFormatted().c_str(), file, line,
+      "%s %s:%u %c[%s]: %s\n", Common::Timer::GetTimeFormatted().c_str(), path_to_print, line,
       LogTypes::LOG_LEVEL_TO_CHAR[(int)level], log->GetShortName().c_str(), temp);
 
   for (auto listener_id : *log)

--- a/Source/Core/Common/Logging/LogManager.h
+++ b/Source/Core/Common/Logging/LogManager.h
@@ -87,6 +87,7 @@ private:
   LogContainer* m_Log[LogTypes::NUMBER_OF_LOGS];
   static LogManager* m_logManager;  // Singleton. Ugh.
   std::array<LogListener*, LogListener::NUMBER_OF_LISTENERS> m_listeners;
+  size_t m_path_cutoff_point = 0;
 
   LogManager();
   ~LogManager();


### PR DESCRIPTION
Using cmake and GCC, logs would contain the full file path when logging making logs line unnecessarily long.  This is solved by removing everything from the filepath before "/Source/Core/" (also including the removal of that string).  That way, all logs display a relative path from /Source/Core/ which is much less printing and you still can locate the source file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4288)
<!-- Reviewable:end -->
