### PR TITLE
WxDebugger: Fix variable width fonts in Code/Memory views

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -546,7 +546,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
         // UnDecorateSymbolName(desc,temp,255,UNDNAME_COMPLETE);
         if (!desc.empty())
         {
-          ctx->DrawText(StrToWxStr(desc), text_col + 45 * char_width, row_y);
+          ctx->DrawText(StrToWxStr(desc), text_col + 44 * char_width, row_y);
         }
       }
 
@@ -570,7 +570,7 @@ void CCodeView::OnPaint(wxPaintEvent& event)
 
   for (int i = 0; i < num_branches; ++i)
   {
-    int x = text_col + 52 * char_width + (branches[i].srcAddr % 9) * 8;
+    int x = text_col + 60 * char_width + (branches[i].srcAddr % 9) * 8;
     branch_path.MoveToPoint(x - 2 * scale, branches[i].src);
 
     if (branches[i].dst < rc.height + 400 && branches[i].dst > -400)

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -390,8 +390,9 @@ void CCodeView::OnPaint(wxPaintEvent& event)
   {
     wxFontMetrics metrics = paint_dc.GetFontMetrics();
     char_width = metrics.averageWidth;
-    if (metrics.height > m_rowHeight)
-      m_rowHeight = metrics.height;
+    m_rowHeight = std::max(metrics.height, m_rowHeight);
+    if (!DebuggerFont.IsFixedWidth())
+      char_width = paint_dc.GetTextExtent("mxx").GetWidth() / 3;  // (1em + 2ex) / 3
   }
 
   std::unique_ptr<wxGraphicsContext> ctx(wxGraphicsContext::Create(paint_dc));

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -269,22 +269,15 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
   wxPaintDC dc(this);
   wxRect rc = GetClientRect();
 
-  if (DebuggerFont.IsFixedWidth())
-  {
-    dc.SetFont(DebuggerFont);
-  }
-  else
-  {
-    dc.SetFont(wxFont(DebuggerFont.GetPointSize(), wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL,
-                      wxFONTWEIGHT_NORMAL, false, "Courier"));
-  }
+  dc.SetFont(DebuggerFont);
 
   int font_width;
   {
     wxFontMetrics metrics = dc.GetFontMetrics();
     font_width = metrics.averageWidth;
-    if (metrics.height > rowHeight)
-      rowHeight = metrics.height;
+    rowHeight = std::max(rowHeight, metrics.height);
+    if (!DebuggerFont.IsFixedWidth())
+      font_width = dc.GetTextExtent("mxx").GetWidth() / 3;  // (1em + 2ex) / 3
   }
 
   const int row_start_x = m_left_col_width + 1;


### PR DESCRIPTION
I used the average character width from the font metrics for layout which turns out to be too narrow for variable width fonts. I've added a special case that takes the average of "m" and "x" instead. I don't know why you'd want to use variable width fonts in the debugger since the text won't line up vertically but whatever.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4290)
<!-- Reviewable:end -->
