### PR TITLE
PixelShaderGen: Fix UID issues.

### DIFF
--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -578,7 +578,7 @@ bool PixelShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode)
   }
 
   // Need to compile a new shader
-  ShaderCode code = GeneratePixelShaderCode(dstAlphaMode, APIType::D3D, uid.GetUidData());
+  ShaderCode code = GeneratePixelShaderCode(APIType::D3D, uid.GetUidData());
 
   D3DBlob* pbytecode;
   if (!D3D::CompilePixelShader(code.GetBuffer(), &pbytecode))

--- a/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
@@ -231,8 +231,7 @@ void ShaderCache::HandlePSUIDChange(PixelShaderUid ps_uid, DSTALPHA_MODE ps_dst_
   }
   else
   {
-    ShaderCode ps_code =
-        GeneratePixelShaderCode(ps_dst_alpha_mode, APIType::D3D, ps_uid.GetUidData());
+    ShaderCode ps_code = GeneratePixelShaderCode(APIType::D3D, ps_uid.GetUidData());
     ID3DBlob* ps_bytecode = nullptr;
 
     if (!D3D::CompilePixelShader(ps_code.GetBuffer(), &ps_bytecode))

--- a/Source/Core/VideoBackends/Null/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/Null/ShaderCache.cpp
@@ -60,7 +60,7 @@ bool ShaderCache<Uid>::SetShader(DSTALPHA_MODE dst_alpha_mode, u32 primitive_typ
   }
 
   // Need to compile a new shader
-  ShaderCode code = GenerateCode(dst_alpha_mode, APIType::OpenGL, uid);
+  ShaderCode code = GenerateCode(APIType::OpenGL, uid);
   m_shaders.emplace(uid, code.GetBuffer());
 
   GFX_DEBUGGER_PAUSE_AT(NEXT_PIXEL_SHADER_CHANGE, true);

--- a/Source/Core/VideoBackends/Null/ShaderCache.h
+++ b/Source/Core/VideoBackends/Null/ShaderCache.h
@@ -26,7 +26,7 @@ public:
 
 protected:
   virtual Uid GetUid(DSTALPHA_MODE dst_alpha_mode, u32 primitive_type, APIType api_type) = 0;
-  virtual ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, APIType api_type, Uid uid) = 0;
+  virtual ShaderCode GenerateCode(APIType api_type, Uid uid) = 0;
 
 private:
   std::map<Uid, std::string> m_shaders;
@@ -45,8 +45,7 @@ protected:
   {
     return GetVertexShaderUid();
   }
-  ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, APIType api_type,
-                          VertexShaderUid uid) override
+  ShaderCode GenerateCode(APIType api_type, VertexShaderUid uid) override
   {
     return GenerateVertexShaderCode(api_type, uid.GetUidData());
   }
@@ -63,8 +62,7 @@ protected:
   {
     return GetGeometryShaderUid(primitive_type);
   }
-  ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, APIType api_type,
-                          GeometryShaderUid uid) override
+  ShaderCode GenerateCode(APIType api_type, GeometryShaderUid uid) override
   {
     return GenerateGeometryShaderCode(api_type, uid.GetUidData());
   }
@@ -80,10 +78,9 @@ protected:
   {
     return GetPixelShaderUid(dst_alpha_mode);
   }
-  ShaderCode GenerateCode(DSTALPHA_MODE dst_alpha_mode, APIType api_type,
-                          PixelShaderUid uid) override
+  ShaderCode GenerateCode(APIType api_type, PixelShaderUid uid) override
   {
-    return GeneratePixelShaderCode(dst_alpha_mode, api_type, uid.GetUidData());
+    return GeneratePixelShaderCode(api_type, uid.GetUidData());
   }
 };
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -208,7 +208,7 @@ SHADER* ProgramShaderCache::SetShader(DSTALPHA_MODE dstAlphaMode, u32 primitive_
   newentry.in_cache = 0;
 
   ShaderCode vcode = GenerateVertexShaderCode(APIType::OpenGL, uid.vuid.GetUidData());
-  ShaderCode pcode = GeneratePixelShaderCode(dstAlphaMode, APIType::OpenGL, uid.puid.GetUidData());
+  ShaderCode pcode = GeneratePixelShaderCode(APIType::OpenGL, uid.puid.GetUidData());
   ShaderCode gcode;
   if (g_ActiveConfig.backend_info.bSupportsGeometryShaders &&
       !uid.guid.GetUidData()->IsPassthrough())

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -525,8 +525,7 @@ VkShaderModule ObjectCache::GetGeometryShaderForUid(const GeometryShaderUid& uid
   return module;
 }
 
-VkShaderModule ObjectCache::GetPixelShaderForUid(const PixelShaderUid& uid,
-                                                 DSTALPHA_MODE dstalpha_mode)
+VkShaderModule ObjectCache::GetPixelShaderForUid(const PixelShaderUid& uid)
 {
   auto it = m_ps_cache.shader_map.find(uid);
   if (it != m_ps_cache.shader_map.end())
@@ -535,8 +534,7 @@ VkShaderModule ObjectCache::GetPixelShaderForUid(const PixelShaderUid& uid,
   // Not in the cache, so compile the shader.
   ShaderCompiler::SPIRVCodeVector spv;
   VkShaderModule module = VK_NULL_HANDLE;
-  ShaderCode source_code =
-      GeneratePixelShaderCode(dstalpha_mode, APIType::Vulkan, uid.GetUidData());
+  ShaderCode source_code = GeneratePixelShaderCode(APIType::Vulkan, uid.GetUidData());
   if (ShaderCompiler::CompileFragmentShader(&spv, source_code.GetBuffer().c_str(),
                                             source_code.GetBuffer().length()))
   {

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.h
@@ -101,7 +101,7 @@ public:
   // Accesses ShaderGen shader caches
   VkShaderModule GetVertexShaderForUid(const VertexShaderUid& uid);
   VkShaderModule GetGeometryShaderForUid(const GeometryShaderUid& uid);
-  VkShaderModule GetPixelShaderForUid(const PixelShaderUid& uid, DSTALPHA_MODE dstalpha_mode);
+  VkShaderModule GetPixelShaderForUid(const PixelShaderUid& uid);
 
   // Static samplers
   VkSampler GetPointSampler() const { return m_point_sampler; }

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -223,7 +223,7 @@ bool StateTracker::CheckForShaderChanges(u32 gx_primitive_type, DSTALPHA_MODE ds
 
   if (ps_uid != m_ps_uid)
   {
-    m_pipeline_state.ps = g_object_cache->GetPixelShaderForUid(ps_uid, dstalpha_mode);
+    m_pipeline_state.ps = g_object_cache->GetPixelShaderForUid(ps_uid);
     m_ps_uid = ps_uid;
     changed = true;
   }

--- a/Source/Core/VideoCommon/LightingShaderGen.cpp
+++ b/Source/Core/VideoCommon/LightingShaderGen.cpp
@@ -72,9 +72,9 @@ static void GenerateLightShader(ShaderCode& object, const LightingUidData& uid_d
 // inColorName is color in vs and colors_ in ps
 // dest is o.colors_ in vs and colors_ in ps
 void GenerateLightingShaderCode(ShaderCode& object, const LightingUidData& uid_data, int components,
-                                const char* inColorName, const char* dest)
+                                u32 numColorChans, const char* inColorName, const char* dest)
 {
-  for (unsigned int j = 0; j < xfmem.numChan.numColorChans; j++)
+  for (unsigned int j = 0; j < numColorChans; j++)
   {
     object.Write("{\n");
 

--- a/Source/Core/VideoCommon/LightingShaderGen.h
+++ b/Source/Core/VideoCommon/LightingShaderGen.h
@@ -47,5 +47,5 @@ static const char s_lighting_struct[] = "struct Light {\n"
                                         "};\n";
 
 void GenerateLightingShaderCode(ShaderCode& object, const LightingUidData& uid_data, int components,
-                                const char* inColorName, const char* dest);
+                                u32 numColorChans, const char* inColorName, const char* dest);
 void GetLightingShaderUid(LightingUidData& uid_data);

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -207,7 +207,7 @@ PixelShaderUid GetPixelShaderUid(DSTALPHA_MODE dstAlphaMode)
     // The lighting shader only needs the two color bits of the 23bit component bit array.
     uid_data->components =
         (VertexLoaderManager::g_current_components & (VB_HAS_COL0 | VB_HAS_COL1)) >> VB_COL_SHIFT;
-    ;
+    uid_data->numColorChans = xfmem.numChan.numColorChans;
     GetLightingShaderUid(uid_data->lighting);
   }
 
@@ -649,7 +649,7 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data*
     // out.SetConstantsUsed(C_PLIGHTS, C_PLIGHTS+31); // TODO: Can be optimized further
     // out.SetConstantsUsed(C_PMATERIALS, C_PMATERIALS+3);
     GenerateLightingShaderCode(out, uid_data->lighting, uid_data->components << VB_COL_SHIFT,
-                               "colors_", "col");
+                               uid_data->numColorChans, "colors_", "col");
   }
 
   // HACK to handle cases where the tex gen is not enabled

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -500,17 +500,6 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data*
       out.Write("[earlydepthstencil]\n");
     }
   }
-  else if (bpmem.UseEarlyDepthTest() &&
-           (uid_data->fast_depth_calc || bpmem.alpha_test.TestResult() == AlphaTest::UNDETERMINED))
-  {
-    static bool warn_once = true;
-    if (warn_once)
-      WARN_LOG(VIDEO, "Early z test enabled but not possible to emulate with current "
-                      "configuration. Make sure to enable fast depth calculations. If this message "
-                      "still shows up your hardware isn't able to emulate the feature properly (a "
-                      "GPU with D3D 11.0 / OGL 4.2 support is required).");
-    warn_once = false;
-  }
 
   if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
   {

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -52,7 +52,8 @@ struct pixel_shader_uid_data
   u32 zfreeze : 1;
   u32 msaa : 1;
   u32 ssaa : 1;
-  u32 pad : 16;
+  u32 numColorChans : 2;
+  u32 pad : 14;
 
   u32 texMtxInfo_n_projection : 8;  // 8x1 bit
   u32 tevindref_bi0 : 3;

--- a/Source/Core/VideoCommon/PixelShaderGen.h
+++ b/Source/Core/VideoCommon/PixelShaderGen.h
@@ -166,6 +166,5 @@ struct pixel_shader_uid_data
 
 typedef ShaderUid<pixel_shader_uid_data> PixelShaderUid;
 
-ShaderCode GeneratePixelShaderCode(DSTALPHA_MODE dstAlphaMode, APIType ApiType,
-                                   const pixel_shader_uid_data* uid_data);
+ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data* uid_data);
 PixelShaderUid GetPixelShaderUid(DSTALPHA_MODE dstAlphaMode);

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -250,7 +250,8 @@ ShaderCode GenerateVertexShaderCode(APIType api_type, const vertex_shader_uid_da
       out.Write("o.colors_0 = float4(1.0, 1.0, 1.0, 1.0);\n");
   }
 
-  GenerateLightingShaderCode(out, uid_data->lighting, uid_data->components, "color", "o.colors_");
+  GenerateLightingShaderCode(out, uid_data->lighting, uid_data->components, uid_data->numColorChans,
+                             "color", "o.colors_");
 
   if (uid_data->numColorChans < 2)
   {


### PR DESCRIPTION
This PR fixes all global state accesses within the shader generators. So now all of the state is either the UID, or hardware features. This allows us to use the UID to generate and cache shaders.

This is a split of PR #4257

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4291)
<!-- Reviewable:end -->
