### PR TITLE
Restore saving logger settings to .ini

### DIFF
--- a/Source/Core/DolphinWX/LogConfigWindow.cpp
+++ b/Source/Core/DolphinWX/LogConfigWindow.cpp
@@ -30,6 +30,11 @@ LogConfigWindow::LogConfigWindow(wxWindow* parent, wxWindowID id)
   LoadSettings();
 }
 
+LogConfigWindow::~LogConfigWindow()
+{
+  SaveSettings();
+}
+
 void LogConfigWindow::CreateGUIControls()
 {
   // Verbosity

--- a/Source/Core/DolphinWX/LogConfigWindow.h
+++ b/Source/Core/DolphinWX/LogConfigWindow.h
@@ -15,6 +15,7 @@ class LogConfigWindow : public wxPanel
 {
 public:
   LogConfigWindow(wxWindow* parent, wxWindowID id = wxID_ANY);
+  ~LogConfigWindow();
 
   void SaveSettings();
   void LoadSettings();


### PR DESCRIPTION
This was broken by https://github.com/dolphin-emu/dolphin/pull/4231

The callstack is:
```
>	DolphinD.exe!LogConfigWindow::SaveSettings() Line 136	C++
 	DolphinD.exe!LogConfigWindow::~LogConfigWindow() Line 35	C++
 	DolphinD.exe!LogConfigWindow::`scalar deleting destructor'(unsigned int)	C++
 	DolphinD.exe!wxWindowBase::Destroy() Line 574	C++
 	DolphinD.exe!CFrame::DoRemovePage(wxWindow * Win, bool bHide) Line 453	C++
 	DolphinD.exe!CFrame::ToggleLogConfigWindow(bool bShow) Line 145	C++
 	DolphinD.exe!CFrame::ClosePages() Line 181	C++
 	DolphinD.exe!CFrame::~CFrame() Line 558	C++
 	DolphinD.exe!CFrame::`scalar deleting destructor'(unsigned int)	C++
 	DolphinD.exe!wxAppConsoleBase::DeletePendingObjects() Line 637	C++
 	DolphinD.exe!wxAppConsoleBase::ProcessIdle() Line 445	C++
 	DolphinD.exe!wxAppBase::ProcessIdle() Line 373	C++
 	DolphinD.exe!wxEventLoopBase::ProcessIdle() Line 98	C++
 	DolphinD.exe!wxEventLoopManual::DoRun() Line 263	C++
 	DolphinD.exe!wxEventLoopBase::Run() Line 76	C++
 	DolphinD.exe!wxAppConsoleBase::MainLoop() Line 380	C++
 	DolphinD.exe!wxAppConsoleBase::OnRun() Line 302	C++
 	DolphinD.exe!wxAppBase::OnRun() Line 312	C++
 	DolphinD.exe!wxEntryReal(int & argc, wchar_t * * argv) Line 503	C++
 	DolphinD.exe!wxEntry(int & argc, wchar_t * * argv) Line 181	C++
 	DolphinD.exe!wxEntry(HINSTANCE__ * hInstance, HINSTANCE__ * __formal, char * __formal, int nCmdShow) Line 290	C++
 	DolphinD.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * __formal, int nCmdShow) Line 59	C++
 	DolphinD.exe!invoke_main() Line 99	C++
 	DolphinD.exe!__scrt_common_main_seh() Line 253	C++
 	DolphinD.exe!__scrt_common_main() Line 296	C++
 	DolphinD.exe!WinMainCRTStartup() Line 17	C++
 	kernel32.dll!BaseThreadInitThunk()	Unknown
 	ntdll.dll!RtlUserThreadStart()	Unknown
```
Is this bad on OSX for some reason?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4292)
<!-- Reviewable:end -->
