### PR TITLE
Remove '\n' from OSD messages; they would be converted to '?'

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -82,7 +82,7 @@ static bool VerifyRoms()
   {
     DSPHost::OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
     DSPHost::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
-    DSPHost::OSD_AddMessage("also work fine, but the GBA/IPL/CARD UCodes will not work.\n", 8000);
+    DSPHost::OSD_AddMessage("also work fine, but the GBA/IPL/CARD UCodes will not work.", 8000);
   }
 
   return true;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -735,7 +735,6 @@ static void SetInputDisplayString(ControllerState padState, int controllerID)
   display_str += Analog1DToString(padState.TriggerR, " R");
   display_str += Analog2DToString(padState.AnalogStickX, padState.AnalogStickY, " ANA");
   display_str += Analog2DToString(padState.CStickX, padState.CStickY, " C");
-  display_str += '\n';
 
   std::lock_guard<std::mutex> guard(s_input_display_lock);
   s_InputDisplay[controllerID] = std::move(display_str);
@@ -858,8 +857,6 @@ static void SetWiiInputDisplayString(int remoteID, u8* const data,
     display_str += Analog2DToString(cc.regular_data.lx, cc.regular_data.ly, " ANA", 63);
     display_str += Analog2DToString(cc.rx1 | (cc.rx2 << 1) | (cc.rx3 << 3), cc.ry, " R-ANA", 31);
   }
-
-  display_str += '\n';
 
   std::lock_guard<std::mutex> guard(s_input_display_lock);
   s_InputDisplay[controllerID] = std::move(display_str);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -326,7 +326,7 @@ void Renderer::DrawDebugText()
   if (SConfig::GetInstance().m_ShowLag)
   {
     draw_text(OSD::MessageType::MovieLag,
-              StringFromFormat("Lag: %" PRIu64 "\n", Movie::GetCurrentLagCount()));
+              StringFromFormat("Lag: %" PRIu64, Movie::GetCurrentLagCount()));
   }
 
   if (SConfig::GetInstance().m_ShowInputDisplay)


### PR DESCRIPTION
Recent commit replaces !isprint chars with '?', so the output started looking a bit funky...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4294)
<!-- Reviewable:end -->
