### PR TITLE
Fix frame dumps on file close in certain situations

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -923,8 +923,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
   {
     if (bLastFrameDumped && bAVIDumping)
     {
-      std::vector<u8>().swap(frame_data);
       AVIDump::Stop();
+      std::vector<u8>().swap(frame_data);
       bAVIDumping = false;
       OSD::AddMessage("Stop dumping frames to AVI", 2000);
     }

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -508,9 +508,10 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha
   D3D12_DEPTH_STENCIL_DESC* depth_stencil_desc = nullptr;
 
   // EXISTINGD3D11TODO: Should we enable Z testing here?
-  /*if (!bpmem.zmode.testenable) depth_stencil_desc = &s_clear_depth_descs[CLEAR_DEPTH_DESC_DEPTH_DISABLED];
-	else */ if (
-      z_enable)
+  /*if (!bpmem.zmode.testenable) depth_stencil_desc =
+  &s_clear_depth_descs[CLEAR_DEPTH_DESC_DEPTH_DISABLED];
+  else */
+  if (z_enable)
     depth_stencil_desc = &s_clear_depth_descs[CLEAR_DEPTH_DESC_DEPTH_ENABLED_WRITES_ENABLED];
   else /*if (!z_enable)*/
     depth_stencil_desc = &s_clear_depth_descs[CLEAR_DEPTH_DESC_DEPTH_ENABLED_WRITES_DISABLED];
@@ -903,9 +904,8 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
   {
     if (bLastFrameDumped && bAVIDumping)
     {
-      std::vector<u8>().swap(frame_data);
-
       AVIDump::Stop();
+      std::vector<u8>().swap(frame_data);
       bAVIDumping = false;
       OSD::AddMessage("Stop dumping frames to AVI", 2000);
     }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1530,9 +1530,9 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
   {
     if (bLastFrameDumped && bAVIDumping)
     {
+      AVIDump::Stop();
       std::vector<u8>().swap(frame_data);
       w = h = 0;
-      AVIDump::Stop();
       bAVIDumping = false;
       OSD::AddMessage("Stop dumping frames", 2000);
     }

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -185,7 +185,7 @@ void AVIDump::AddFrame(const u8* data, int width, int height)
 {
   // Store current frame data in case frame dumping stops before next frame update,
   // but make sure that you don't store the last stored frame and check the resolution upon
-  // closing the file or else you store recusion, and dolphins don't like recursion.
+  // closing the file or else you store recursion, and dolphins don't like recursion.
   if (!s_stop_dumping)
   {
     StoreFrameData(data, width, height);


### PR DESCRIPTION
This is yet another regression from #4148 where if you pause emulation while doing a frame dump and stop the frame dump, it crashed Dolphin.

Thanks @shuffle2 for finding the reason for the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4296)
<!-- Reviewable:end -->
