### PR TITLE
HLE: Remove duplicate in OSPatches

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -59,9 +59,8 @@ static const SPatch OSPatches[] = {
     {"printf", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
     {"puts", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE,
      HLE_TYPE_DEBUG},  // gcc-optimized printf?
-    {"___blank(char *,...)", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE,
+    {"___blank", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE,
      HLE_TYPE_DEBUG},  // used for early init things (normally)
-    {"___blank", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
     {"__write_console", HLE_OS::HLE_write_console, HLE_HOOK_REPLACE,
      HLE_TYPE_DEBUG},  // used by sysmenu (+more?)
 


### PR DESCRIPTION
Name comparisons are based on stripped names, so there is a duplicate.

I will address another PR concerning the fact functions with the same name aren't patched because of stripped name comparison.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4297)
<!-- Reviewable:end -->
