### PR TITLE
HLE: Wrong array used in BP patching fixed

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -125,7 +125,7 @@ void PatchFunctions()
   {
     for (size_t i = 1; i < ArraySize(OSBreakPoints); ++i)
     {
-      Symbol* symbol = g_symbolDB.GetSymbolFromName(OSPatches[i].m_szPatchName);
+      Symbol* symbol = g_symbolDB.GetSymbolFromName(OSBreakPoints[i].m_szPatchName);
       if (symbol)
       {
         PowerPC::breakpoints.Add(symbol->address, false);


### PR DESCRIPTION
The wrong array is used during breakpoints patching. Hopefully, the BP array is smaller so nothing tragic happens.

Ready to be reviewed & merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4298)
<!-- Reviewable:end -->
