### PR TITLE
SymbolDB: Multiple symbols detection allowed

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -61,6 +61,26 @@ std::vector<Symbol*> SymbolDB::GetSymbolsFromName(const std::string& name)
   return symbols;
 }
 
+Symbol* SymbolDB::GetSymbolFromHash(u32 hash)
+{
+  XFuncPtrMap::iterator iter = checksumToFunction.find(hash);
+  if (iter != checksumToFunction.end())
+    return iter->second;
+  else
+    return nullptr;
+}
+
+std::vector<Symbol*> SymbolDB::GetSymbolsFromHash(u32 hash)
+{
+  std::vector<Symbol*> symbols;
+
+  for (const auto& iter : checksumToFunction)
+    if (iter.first == hash)
+      symbols.push_back(iter.second);
+
+  return symbols;
+}
+
 void SymbolDB::AddCompleteSymbol(const Symbol& symbol)
 {
   functions.emplace(symbol.address, symbol);

--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -65,7 +65,7 @@ Symbol* SymbolDB::GetSymbolFromHash(u32 hash)
 {
   XFuncPtrMap::iterator iter = checksumToFunction.find(hash);
   if (iter != checksumToFunction.end())
-    return iter->second;
+    return *iter->second.begin();
   else
     return nullptr;
 }
@@ -76,7 +76,8 @@ std::vector<Symbol*> SymbolDB::GetSymbolsFromHash(u32 hash)
 
   for (const auto& iter : checksumToFunction)
     if (iter.first == hash)
-      symbols.push_back(iter.second);
+      for (const auto& symbol : iter.second)
+        symbols.push_back(symbol);
 
   return symbols;
 }

--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -48,6 +48,19 @@ Symbol* SymbolDB::GetSymbolFromName(const std::string& name)
   return nullptr;
 }
 
+std::vector<Symbol*> SymbolDB::GetSymbolsFromName(const std::string& name)
+{
+  std::vector<Symbol*> symbols;
+
+  for (auto& func : functions)
+  {
+    if (func.second.function_name == name)
+      symbols.push_back(&func.second);
+  }
+
+  return symbols;
+}
+
 void SymbolDB::AddCompleteSymbol(const Symbol& symbol)
 {
   functions.emplace(symbol.address, symbol);

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -72,14 +72,8 @@ public:
 
   Symbol* GetSymbolFromName(const std::string& name);
   std::vector<Symbol*> GetSymbolsFromName(const std::string& name);
-  Symbol* GetSymbolFromHash(u32 hash)
-  {
-    XFuncPtrMap::iterator iter = checksumToFunction.find(hash);
-    if (iter != checksumToFunction.end())
-      return iter->second;
-    else
-      return nullptr;
-  }
+  Symbol* GetSymbolFromHash(u32 hash);
+  std::vector<Symbol*> GetSymbolsFromHash(u32 hash);
 
   const XFuncMap& Symbols() const { return functions; }
   XFuncMap& AccessSymbols() { return functions; }

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -57,7 +58,7 @@ class SymbolDB
 {
 public:
   typedef std::map<u32, Symbol> XFuncMap;
-  typedef std::map<u32, Symbol*> XFuncPtrMap;
+  typedef std::map<u32, std::set<Symbol*>> XFuncPtrMap;
 
 protected:
   XFuncMap functions;

--- a/Source/Core/Common/SymbolDB.h
+++ b/Source/Core/Common/SymbolDB.h
@@ -71,6 +71,7 @@ public:
   void AddCompleteSymbol(const Symbol& symbol);
 
   Symbol* GetSymbolFromName(const std::string& name);
+  std::vector<Symbol*> GetSymbolsFromName(const std::string& name);
   Symbol* GetSymbolFromHash(u32 hash)
   {
     XFuncPtrMap::iterator iter = checksumToFunction.find(hash);

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -109,8 +109,7 @@ void PatchFunctions()
     if (OSPatches[i].flags == HLE_TYPE_FIXED)
       continue;
 
-    Symbol* symbol = g_symbolDB.GetSymbolFromName(OSPatches[i].m_szPatchName);
-    if (symbol)
+    for (const auto& symbol : g_symbolDB.GetSymbolsFromName(OSPatches[i].m_szPatchName))
     {
       for (u32 addr = symbol->address; addr < symbol->address + symbol->size; addr += 4)
       {
@@ -125,8 +124,7 @@ void PatchFunctions()
   {
     for (size_t i = 1; i < ArraySize(OSBreakPoints); ++i)
     {
-      Symbol* symbol = g_symbolDB.GetSymbolFromName(OSBreakPoints[i].m_szPatchName);
-      if (symbol)
+      for (const auto& symbol : g_symbolDB.GetSymbolsFromName(OSBreakPoints[i].m_szPatchName))
       {
         PowerPC::breakpoints.Add(symbol->address, false);
         INFO_LOG(OSHLE, "Adding BP to %s %08x", OSBreakPoints[i].m_szPatchName, symbol->address);
@@ -211,7 +209,7 @@ u32 UnPatch(const std::string& patch_name)
     return addr;
   }
 
-  if (Symbol* symbol = g_symbolDB.GetSymbolFromName(patch_name))
+  for (const auto& symbol : g_symbolDB.GetSymbolsFromName(patch_name))
   {
     for (u32 addr = symbol->address; addr < symbol->address + symbol->size; addr += 4)
     {

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -57,7 +57,7 @@ Symbol* PPCSymbolDB::AddFunction(u32 startAddr)
     // LOG(OSHLE, "Symbol found at %08x", startAddr);
     functions[startAddr] = tempFunc;
     tempFunc.type = Symbol::Type::Function;
-    checksumToFunction[tempFunc.hash] = &(functions[startAddr]);
+    checksumToFunction[tempFunc.hash].insert(&functions[startAddr]);
     return &functions[startAddr];
   }
 }
@@ -86,7 +86,7 @@ void PPCSymbolDB::AddKnownSymbol(u32 startAddr, u32 size, const std::string& nam
     if (tf.type == Symbol::Type::Function)
     {
       PPCAnalyst::AnalyzeFunction(startAddr, tf, size);
-      checksumToFunction[tf.hash] = &(functions[startAddr]);
+      checksumToFunction[tf.hash].insert(&functions[startAddr]);
       tf.function_name = GetStrippedFunctionName(name);
     }
     tf.size = size;

--- a/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
+++ b/Source/Core/Core/PowerPC/SignatureDB/SignatureDB.cpp
@@ -72,12 +72,10 @@ void SignatureDB::Apply(PPCSymbolDB* symbol_db)
 {
   for (const auto& entry : m_database)
   {
-    u32 hash = entry.first;
-    Symbol* function = symbol_db->GetSymbolFromHash(hash);
-    if (function)
+    for (const auto& function : symbol_db->GetSymbolsFromHash(entry.first))
     {
       // Found the function. Let's rename it according to the symbol file.
-      if (entry.second.size == (unsigned int)function->size)
+      if (entry.second.size == static_cast<unsigned int>(function->size))
       {
         function->name = entry.second.name;
         INFO_LOG(OSHLE, "Found %s at %08x (size: %08x)!", entry.second.name.c_str(),


### PR DESCRIPTION
This PR allows multiple functions with the same stripped name to be patched.

NB: This PR doesn't fix the misused array, check this [PR](https://github.com/dolphin-emu/dolphin/pull/4298) instead.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4299)

<!-- Reviewable:end -->
