### PR TITLE
Don't try to gracefully shut down Wii fifologs

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -65,6 +65,7 @@ public:
   // PowerPC state.
   std::unique_ptr<CPUCoreBase> GetCPUCore();
 
+  bool IsRunning() const { return m_File != nullptr; }
   FifoDataFile* GetFile() const { return m_File.get(); }
   u32 GetFrameObjectCount() const;
   u32 GetCurrentFrameNum() const { return m_CurrentFrame; }

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -32,6 +32,7 @@
 #include "Core/BootManager.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/HW/CPU.h"
 #include "Core/HW/DVDInterface.h"
 #include "Core/HW/GCKeyboard.h"
@@ -1153,7 +1154,8 @@ void CFrame::DoStop()
       }
     }
 
-    if (SConfig::GetInstance().bWii && !m_tried_graceful_shutdown)
+    if (SConfig::GetInstance().bWii && !FifoPlayer::GetInstance().IsRunning() &&
+        !m_tried_graceful_shutdown)
     {
       Core::DisplayMessage("Shutting down", 30000);
       Core::SetState(Core::CORE_RUN);

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -21,6 +21,7 @@
 #include "Core/BootManager.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/Host.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h"
@@ -232,7 +233,8 @@ class PlatformX11 : public Platform
     {
       if (s_shutdown_requested.TestAndClear())
       {
-        if (!s_tried_graceful_shutdown.IsSet() && SConfig::GetInstance().bWii)
+        if (!s_tried_graceful_shutdown.IsSet() && SConfig::GetInstance().bWii &&
+            !FifoPlayer::GetInstance().IsRunning())
         {
           ProcessorInterface::PowerButton_Tap();
           s_tried_graceful_shutdown.Set();


### PR DESCRIPTION
This sounds silly, but it turns out that we need to check if we're
running a fifolog (because bWii is true for Wii fifologs), or it would
try to shut down fifologs with the STM – which obviously won't work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4300)
<!-- Reviewable:end -->
