### PR TITLE
HLE: Another DebugPrint case added

### DIFF
--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -32,12 +32,23 @@ void HLE_GeneralDebugPrint()
 {
   std::string report_message;
 
+  // Is gpr3 pointing to a pointer rather than an ASCII string
   if (PowerPC::HostRead_U32(GPR(3)) > 0x80000000)
   {
-    report_message = GetStringVA(4);
+    if (GPR(4) > 0x80000000)
+    {
+      // ___blank(void* this, const char* fmt, ...);
+      report_message = GetStringVA(4);
+    }
+    else
+    {
+      // ___blank(void* this, int log_type, const char* fmt, ...);
+      report_message = GetStringVA(5);
+    }
   }
   else
   {
+    // ___blank(const char* fmt, ...);
     report_message = GetStringVA();
   }
 


### PR DESCRIPTION
I found another "___blank" function but with another prototype. Otherwise, the code is exactly the same. Furthermore, this function is located in memory right before the currently supported __blank functions and is also used to print debug messages.

Ready to be reviewed & merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4301)
<!-- Reviewable:end -->
