### PR TITLE
Minor fixes to graceful shutdown

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -135,6 +135,11 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 command_address)
   return GetNoReply();
 }
 
+bool CWII_IPC_HLE_Device_stm_eventhook::HasHookInstalled() const
+{
+  return s_event_hook_address != 0;
+}
+
 void CWII_IPC_HLE_Device_stm_eventhook::TriggerEvent(const u32 event) const
 {
   if (!m_Active || s_event_hook_address == 0)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -59,6 +59,7 @@ public:
   IPCCommandResult Close(u32 command_address, bool force) override;
   IPCCommandResult IOCtl(u32 command_address) override;
 
+  bool HasHookInstalled() const;
   void ResetButton() const;
   void PowerButton() const;
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -615,8 +615,7 @@ void CFrame::OnClose(wxCloseEvent& event)
       event.Veto();
     }
     // Tell OnStopped to resubmit the Close event
-    if (m_confirmStop)
-      m_bClosing = true;
+    m_bClosing = true;
     return;
   }
 
@@ -1716,6 +1715,7 @@ void CFrame::HandleSignal(wxTimerEvent& event)
 {
   if (!s_shutdown_signal_received.TestAndClear())
     return;
+  m_bClosing = true;
   Close();
 }
 

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -42,6 +42,8 @@
 #include "Core/HW/Wiimote.h"
 #include "Core/Host.h"
 #include "Core/HotkeyManager.h"
+#include "Core/IPC_HLE/WII_IPC_HLE.h"
+#include "Core/IPC_HLE/WII_IPC_HLE_Device_stm.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
 #include "Core/Movie.h"
@@ -1341,7 +1343,9 @@ void CFrame::DoStop()
       }
     }
 
-    if (SConfig::GetInstance().bWii && !m_tried_graceful_shutdown)
+    const auto& stm = WII_IPC_HLE_Interface::GetDeviceByName("/dev/stm/eventhook");
+    if (!m_tried_graceful_shutdown && stm &&
+        std::static_pointer_cast<CWII_IPC_HLE_Device_stm_eventhook>(stm)->HasHookInstalled())
     {
       Core::DisplayMessage("Shutting down", 30000);
       // Unpause because gracefully shutting down needs the game to actually request a shutdown

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1344,7 +1344,9 @@ void CFrame::DoStop()
     if (SConfig::GetInstance().bWii && !m_tried_graceful_shutdown)
     {
       Core::DisplayMessage("Shutting down", 30000);
-      Core::SetState(Core::CORE_RUN);
+      // Unpause because gracefully shutting down needs the game to actually request a shutdown
+      if (Core::GetState() == Core::CORE_PAUSE)
+        DoPause();
       ProcessorInterface::PowerButton_Tap();
       m_confirmStop = false;
       m_tried_graceful_shutdown = true;

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -23,6 +23,8 @@
 #include "Core/Core.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/Host.h"
+#include "Core/IPC_HLE/WII_IPC_HLE.h"
+#include "Core/IPC_HLE/WII_IPC_HLE_Device_stm.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_WiiMote.h"
 #include "Core/State.h"
@@ -232,7 +234,9 @@ class PlatformX11 : public Platform
     {
       if (s_shutdown_requested.TestAndClear())
       {
-        if (!s_tried_graceful_shutdown.IsSet() && SConfig::GetInstance().bWii)
+        const auto& stm = WII_IPC_HLE_Interface::GetDeviceByName("/dev/stm/eventhook");
+        if (!s_tried_graceful_shutdown.IsSet() && stm &&
+            std::static_pointer_cast<CWII_IPC_HLE_Device_stm_eventhook>(stm)->HasHookInstalled())
         {
           ProcessorInterface::PowerButton_Tap();
           s_tried_graceful_shutdown.Set();


### PR DESCRIPTION
This PR is a follow-up to #4244 and fixes some minor issues (mostly UX ones, but also the case where Dolphin tries to gracefully shut down Wii fifologs).

Details are in the commit messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4302)
<!-- Reviewable:end -->
