### PR TITLE
Mask GetPointer Differently on GameCube

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -391,7 +391,10 @@ u8* GetPointer(u32 address)
 {
   // TODO: Should we be masking off more bits here?  Can all devices access
   // EXRAM?
-  address &= 0x3FFFFFFF;
+  if (SConfig::GetInstance().bWii)
+    address &= 0x3FFFFFFF;
+  else
+    address &= 0x01FFFFFF;
   if (address < REALRAM_SIZE)
     return m_pRAM + address;
 


### PR DESCRIPTION
GameCube can't access EXRAM I'm guessing, so we need to wrap it different.  Number was verified by LibOGC or something by someone who wasn't me.

Fixes Starfox Assault crash better this time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4303)

<!-- Reviewable:end -->
