### PR TITLE
TextureCache: Don't re-use pooled textures within the same frame

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -1353,7 +1353,7 @@ void TextureCacheBase::CopyRenderTargetToTexture(u32 dstAddr, unsigned int dstFo
 TextureCacheBase::TCacheEntryBase*
 TextureCacheBase::AllocateTexture(const TCacheEntryConfig& config)
 {
-  TexPool::iterator iter = texture_pool.find(config);
+  TexPool::iterator iter = FindMatchingTextureFromPool(config);
   TextureCacheBase::TCacheEntryBase* entry;
   if (iter != texture_pool.end())
   {
@@ -1371,6 +1371,19 @@ TextureCacheBase::AllocateTexture(const TCacheEntryConfig& config)
 
   entry->textures_by_hash_iter = textures_by_hash.end();
   return entry;
+}
+
+TextureCacheBase::TexPool::iterator
+TextureCacheBase::FindMatchingTextureFromPool(const TCacheEntryConfig& config)
+{
+  // Find a texture from the pool that does not have a frameCount of FRAMECOUNT_INVALID.
+  // This prevents a texture from being used twice in a single frame with different data,
+  // which potentially means that a driver has to maintain two copies of the texture anyway.
+  auto range = texture_pool.equal_range(config);
+  auto matching_iter = std::find_if(range.first, range.second, [](const auto& iter) {
+    return iter.second->frameCount != FRAMECOUNT_INVALID;
+  });
+  return matching_iter != range.second ? matching_iter : texture_pool.end();
 }
 
 TextureCacheBase::TexCache::iterator

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -193,6 +193,7 @@ private:
   static void CheckTempSize(size_t required_size);
 
   static TCacheEntryBase* AllocateTexture(const TCacheEntryConfig& config);
+  static TexPool::iterator FindMatchingTextureFromPool(const TCacheEntryConfig& config);
   static TexCache::iterator GetTexCacheIter(TCacheEntryBase* entry);
 
   // Removes and unlinks texture from texture cache and returns it to the pool


### PR DESCRIPTION
This is an issue because a driver may have to maintain two copies of a texture if it batches all uploads together at the start of a frame.

In the Vulkan backend, we do something similar to avoid breaking out of a render pass to copy a texture from the streaming buffer to the destination image.

This was causing issues in the sms-bubbles fifolog, where an EFB copy to the same address of a previously-used texture caused the previous texture to be re-used again for a different image later on in the frame, causing the original contents to be discarded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4304)
<!-- Reviewable:end -->
