### PR TITLE
Vulkan: Fix minor issues with frame dumping on Vulkan

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1521,7 +1521,7 @@ bool Renderer::CompileShaders()
 
     void main()
     {
-      ocol0 = texture(samp0, uv0);
+      ocol0 = float4(texture(samp0, uv0).xyz, 1.0);
     }
   )";
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -65,6 +65,15 @@ Renderer::Renderer(std::unique_ptr<SwapChain> swap_chain) : m_swap_chain(std::mo
 
 Renderer::~Renderer()
 {
+#if defined(HAVE_LIBAV) || defined(_WIN32)
+  // Stop frame dumping if it was left enabled at shutdown time.
+  if (bAVIDumping)
+  {
+    AVIDump::Stop();
+    bAVIDumping = false;
+  }
+#endif
+
   g_Config.bRunning = false;
   UpdateActiveConfig();
   DestroyScreenshotResources();

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -118,6 +118,10 @@ private:
 
   // Shaders used for clear/blit.
   VkShaderModule m_clear_fragment_shader = VK_NULL_HANDLE;
+
+  // NOTE: The blit shader here is used for the final copy from the source buffer(s) to the swap
+  // chain buffer for presentation. It ignores the alpha channel of the input image and sets the
+  // alpha channel to 1.0 to avoid issues with frame dumping and screenshots.
   VkShaderModule m_blit_fragment_shader = VK_NULL_HANDLE;
 
   // Texture used for screenshot/frame dumping


### PR DESCRIPTION
This allows Dolphin to produce framedumps suitable for use in fifoci.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4305)
<!-- Reviewable:end -->
