### PR TITLE
HLE: Logs nlPrintf calls

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -57,6 +57,7 @@ static const SPatch OSPatches[] = {
     {"WUD_DEBUGPrint", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
     {"vprintf", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
     {"printf", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
+    {"nlPrintf", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
     {"puts", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE,
      HLE_TYPE_DEBUG},  // gcc-optimized printf?
     {"___blank", HLE_OS::HLE_GeneralDebugPrint, HLE_HOOK_REPLACE,


### PR DESCRIPTION
The totaldb.dsy's ```nlPrintf``` function is also used as a debugging printf.

Ready to be reviewed & merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4306)
<!-- Reviewable:end -->
