### PR TITLE
Vulkan: Use correct source format to determine palette size

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/PaletteTextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/PaletteTextureConverter.cpp
@@ -67,7 +67,7 @@ void PaletteTextureConverter::ConvertTexture(StateTracker* state_tracker,
                                              VkRenderPass render_pass,
                                              VkFramebuffer dst_framebuffer, Texture2D* src_texture,
                                              u32 width, u32 height, void* palette,
-                                             TlutFormat format)
+                                             TlutFormat format, u32 src_format)
 {
   struct PSUniformBlock
   {
@@ -78,7 +78,7 @@ void PaletteTextureConverter::ConvertTexture(StateTracker* state_tracker,
 
   _assert_(static_cast<size_t>(format) < NUM_PALETTE_CONVERSION_SHADERS);
 
-  size_t palette_size = ((format & 0xF) == GX_TF_I4) ? 32 : 512;
+  size_t palette_size = (src_format & 0xF) == GX_TF_I4 ? 32 : 512;
   VkDescriptorSet texel_buffer_descriptor_set;
 
   // Allocate memory for the palette, and descriptor sets for the buffer.
@@ -134,7 +134,7 @@ void PaletteTextureConverter::ConvertTexture(StateTracker* state_tracker,
 
   // PS Uniforms/Samplers
   PSUniformBlock uniforms = {};
-  uniforms.multiplier = ((format & 0xF)) == GX_TF_I4 ? 15.0f : 255.0f;
+  uniforms.multiplier = (src_format & 0xF) == GX_TF_I4 ? 15.0f : 255.0f;
   uniforms.texel_buffer_offset = static_cast<int>(palette_offset / sizeof(u16));
   draw.SetPushConstants(&uniforms, sizeof(uniforms));
   draw.SetPSSampler(0, src_texture->GetView(), g_object_cache->GetPointSampler());

--- a/Source/Core/VideoBackends/Vulkan/PaletteTextureConverter.h
+++ b/Source/Core/VideoBackends/Vulkan/PaletteTextureConverter.h
@@ -29,7 +29,7 @@ public:
   void ConvertTexture(StateTracker* state_tracker, VkCommandBuffer command_buffer,
                       VkRenderPass render_pass, VkFramebuffer dst_framebuffer,
                       Texture2D* src_texture, u32 width, u32 height, void* palette,
-                      TlutFormat format);
+                      TlutFormat format, u32 src_format);
 
 private:
   static const size_t NUM_PALETTE_CONVERSION_SHADERS = 3;

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -111,7 +111,7 @@ void TextureCache::ConvertTexture(TCacheEntryBase* base_entry, TCacheEntryBase* 
   m_palette_texture_converter->ConvertTexture(
       m_state_tracker, command_buffer, GetRenderPassForTextureUpdate(entry->GetTexture()),
       entry->GetFramebuffer(), unconverted->GetTexture(), entry->config.width, entry->config.height,
-      palette, format);
+      palette, format, unconverted->format);
 
   // Render pass transitions to SHADER_READ_ONLY.
   entry->GetTexture()->OverrideImageLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);


### PR DESCRIPTION
Fixes blur in fortune street fifologs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4307)
<!-- Reviewable:end -->
