### PR TITLE
Label debugger memchecks as "Memory Breakpoints" in the GUI

### DIFF
--- a/Source/Core/Common/BreakPoints.cpp
+++ b/Source/Core/Common/BreakPoints.cpp
@@ -214,7 +214,7 @@ bool TMemCheck::Action(DebugInterface* debug_interface, u32 iValue, u32 addr, bo
   {
     if (Log)
     {
-      NOTICE_LOG(MEMMAP, "CHK %08x (%s) %s%i %0*x at %08x (%s)", pc,
+      NOTICE_LOG(MEMMAP, "MBP %08x (%s) %s%i %0*x at %08x (%s)", pc,
                  debug_interface->GetDescription(pc).c_str(), write ? "Write" : "Read", size * 8,
                  size * 2, iValue, addr, debug_interface->GetDescription(addr).c_str());
     }

--- a/Source/Core/DolphinWX/Debugger/BreakpointView.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointView.cpp
@@ -63,7 +63,7 @@ void CBreakPointView::Repopulate()
   {
     wxString memcheck_on_str = StrToWxStr((rMemCheck.Break || rMemCheck.Log) ? "on" : " ");
     int item = InsertItem(0, memcheck_on_str);
-    SetItem(item, 1, StrToWxStr("MC"));
+    SetItem(item, 1, StrToWxStr("MBP"));
 
     Symbol* symbol = g_symbolDB.GetSymbolFromAddr(rMemCheck.StartAddress);
     if (symbol)

--- a/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
@@ -53,7 +53,7 @@ public:
     AddTool(ID_ADDBP, "+BP", m_Bitmaps[Toolbar_Add_BP]);
     Bind(wxEVT_TOOL, &CBreakPointWindow::OnAddBreakPoint, parent, ID_ADDBP);
 
-    AddTool(ID_ADDMC, "+MC", m_Bitmaps[Toolbar_Add_MC]);
+    AddTool(ID_ADDMC, "+MBP", m_Bitmaps[Toolbar_Add_MC]);
     Bind(wxEVT_TOOL, &CBreakPointWindow::OnAddMemoryCheck, parent, ID_ADDMC);
 
     AddTool(ID_LOAD, _("Load"), m_Bitmaps[Toolbar_Delete]);
@@ -167,7 +167,7 @@ void CBreakPointWindow::SaveAll()
   ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + SConfig::GetInstance().GetUniqueID() + ".ini",
            false);
   ini.SetLines("BreakPoints", PowerPC::breakpoints.GetStrings());
-  ini.SetLines("MemoryChecks", PowerPC::memchecks.GetStrings());
+  ini.SetLines("MemoryBreakPoints", PowerPC::memchecks.GetStrings());
   ini.Save(File::GetUserPath(D_GAMESETTINGS_IDX) + SConfig::GetInstance().GetUniqueID() + ".ini");
 }
 
@@ -196,7 +196,7 @@ void CBreakPointWindow::LoadAll()
     PowerPC::breakpoints.AddFromStrings(newbps);
   }
 
-  if (ini.GetLines("MemoryChecks", &newmcs, false))
+  if (ini.GetLines("MemoryBreakPoints", &newmcs, false))
   {
     PowerPC::memchecks.Clear();
     PowerPC::memchecks.AddFromStrings(newmcs);

--- a/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryCheckDlg.cpp
@@ -17,7 +17,7 @@
 #include "DolphinWX/WxUtils.h"
 
 MemoryCheckDlg::MemoryCheckDlg(CBreakPointWindow* parent)
-    : wxDialog(parent, wxID_ANY, _("Add a Memory Check")), m_parent(parent)
+    : wxDialog(parent, wxID_ANY, _("Add a Memory Breakpoint")), m_parent(parent)
 {
   Bind(wxEVT_BUTTON, &MemoryCheckDlg::OnOK, this, wxID_OK);
   Bind(wxEVT_RADIOBUTTON, &MemoryCheckDlg::OnRadioButtonClick, this);

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -117,7 +117,7 @@ CMemoryWindow::CMemoryWindow(wxWindow* parent, wxWindowID id, const wxPoint& pos
                                     wxDefaultSize, data_type_options, 1);
 
   wxStaticBoxSizer* const memcheck_options_sizer =
-      new wxStaticBoxSizer(wxVERTICAL, this, "Memory check options");
+      new wxStaticBoxSizer(wxVERTICAL, this, "Memory breakpoint options");
   memcheck_options_sizer->Add(rdbReadWrite = new wxRadioButton(this, IDM_MEMCHECK_OPTIONS_CHANGE,
                                                                "Read and Write", wxDefaultPosition,
                                                                wxDefaultSize, wxRB_GROUP));


### PR DESCRIPTION
This is done to remove confusions among potential debugger users and to also make it more clear what this feature is actually doing.  Despite being true that it is using a memcheck (and it certainly checks that memory), the idea being to break on a memory access isn't really obvious especially considering that memchecks are also used in full MMU emulation to handle exceptions.  It also doesn't help that memchecks are now supported in every builds.

It also changes the corresponding log because this log would be wanted by the user which means it should be more obvious that it was caused by the "memory breakpoint".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4308)
<!-- Reviewable:end -->
