### PR TITLE
HW: Change u8 pad specifier params to int where applicable

### DIFF
--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -47,7 +47,7 @@ void LoadConfig()
   s_config.LoadConfig(true);
 }
 
-KeyboardStatus GetStatus(u8 port)
+KeyboardStatus GetStatus(int port)
 {
   return static_cast<GCKeyboard*>(s_config.GetController(port))->GetInput();
 }

--- a/Source/Core/Core/HW/GCKeyboard.h
+++ b/Source/Core/Core/HW/GCKeyboard.h
@@ -17,5 +17,5 @@ void LoadConfig();
 
 InputConfig* GetConfig();
 
-KeyboardStatus GetStatus(u8 port);
+KeyboardStatus GetStatus(int port);
 }

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -46,17 +46,17 @@ void LoadConfig()
   s_config.LoadConfig(true);
 }
 
-GCPadStatus GetStatus(u8 pad_num)
+GCPadStatus GetStatus(int pad_num)
 {
   return static_cast<GCPad*>(s_config.GetController(pad_num))->GetInput();
 }
 
-void Rumble(const u8 pad_num, const ControlState strength)
+void Rumble(const int pad_num, const ControlState strength)
 {
   static_cast<GCPad*>(s_config.GetController(pad_num))->SetOutput(strength);
 }
 
-bool GetMicButton(const u8 pad_num)
+bool GetMicButton(const int pad_num)
 {
   return static_cast<GCPad*>(s_config.GetController(pad_num))->GetMicButton();
 }

--- a/Source/Core/Core/HW/GCPad.h
+++ b/Source/Core/Core/HW/GCPad.h
@@ -18,8 +18,8 @@ void LoadConfig();
 
 InputConfig* GetConfig();
 
-GCPadStatus GetStatus(u8 pad_num);
-void Rumble(u8 pad_num, ControlState strength);
+GCPadStatus GetStatus(int pad_num);
+void Rumble(int pad_num, ControlState strength);
 
-bool GetMicButton(u8 pad_num);
+bool GetMicButton(int pad_num);
 }

--- a/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCAdapter.cpp
@@ -18,7 +18,7 @@ CSIDevice_GCAdapter::CSIDevice_GCAdapter(SIDevices device, int _iDeviceNumber)
     : CSIDevice_GCController(device, _iDeviceNumber)
 {
   // get the correct pad number that should rumble locally when using netplay
-  const u8 numPAD = NetPlay_InGamePadToLocalPad(ISIDevice::m_iDeviceNumber);
+  const int numPAD = NetPlay_InGamePadToLocalPad(ISIDevice::m_iDeviceNumber);
   if (numPAD < 4)
     m_simulate_konga = SConfig::GetInstance().m_AdapterKonga[numPAD];
 }
@@ -59,7 +59,7 @@ int CSIDevice_GCAdapter::RunBuffer(u8* buffer, int length)
   return CSIDevice_GCController::RunBuffer(buffer, length);
 }
 
-void CSIDevice_GCController::Rumble(u8 numPad, ControlState strength)
+void CSIDevice_GCController::Rumble(int numPad, ControlState strength)
 {
   SIDevices device = SConfig::GetInstance().m_SIDevice[numPad];
   if (device == SIDEVICE_WIIU_ADAPTER)

--- a/Source/Core/Core/HW/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCController.cpp
@@ -289,7 +289,7 @@ void CSIDevice_GCController::SendCommand(u32 _Cmd, u8 _Poll)
     unsigned int uStrength = command.Parameter2;
 
     // get the correct pad number that should rumble locally when using netplay
-    const u8 numPAD = NetPlay_InGamePadToLocalPad(ISIDevice::m_iDeviceNumber);
+    const int numPAD = NetPlay_InGamePadToLocalPad(ISIDevice::m_iDeviceNumber);
 
     if (numPAD < 4)
     {

--- a/Source/Core/Core/HW/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI_DeviceGCController.h
@@ -102,11 +102,11 @@ public:
   virtual EButtonCombo HandleButtonCombos(const GCPadStatus& pad_status);
 
   // Send and Receive pad input from network
-  static bool NetPlay_GetInput(u8 numPAD, GCPadStatus* status);
-  static u8 NetPlay_InGamePadToLocalPad(u8 numPAD);
+  static bool NetPlay_GetInput(int numPAD, GCPadStatus* status);
+  static int NetPlay_InGamePadToLocalPad(int numPAD);
 
   // Direct rumble to the right GC Controller
-  static void Rumble(u8 numPad, ControlState strength);
+  static void Rumble(int numPad, ControlState strength);
 
 protected:
   void Calibrate();

--- a/Source/Core/Core/HW/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI_DeviceGCSteeringWheel.cpp
@@ -82,7 +82,7 @@ void CSIDevice_GCSteeringWheel::SendCommand(u32 _Cmd, u8 _Poll)
     unsigned int uType = command.Parameter2;  // 06 = motor on, 04 = motor off
 
     // get the correct pad number that should rumble locally when using netplay
-    const u8 numPAD = NetPlay_InGamePadToLocalPad(ISIDevice::m_iDeviceNumber);
+    const int numPAD = NetPlay_InGamePadToLocalPad(ISIDevice::m_iDeviceNumber);
 
     if (numPAD < 4)
     {

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -739,11 +739,11 @@ void NetPlayClient::SendChatMessage(const std::string& msg)
 }
 
 // called from ---CPU--- thread
-void NetPlayClient::SendPadState(const PadMapping in_game_pad, const GCPadStatus& pad)
+void NetPlayClient::SendPadState(const int in_game_pad, const GCPadStatus& pad)
 {
   auto spac = std::make_unique<sf::Packet>();
   *spac << static_cast<MessageId>(NP_MSG_PAD_DATA);
-  *spac << in_game_pad;
+  *spac << static_cast<PadMapping>(in_game_pad);
   *spac << pad.button << pad.analogA << pad.analogB << pad.stickX << pad.stickY << pad.substickX
         << pad.substickY << pad.triggerLeft << pad.triggerRight;
 
@@ -751,11 +751,11 @@ void NetPlayClient::SendPadState(const PadMapping in_game_pad, const GCPadStatus
 }
 
 // called from ---CPU--- thread
-void NetPlayClient::SendWiimoteState(const PadMapping in_game_pad, const NetWiimote& nw)
+void NetPlayClient::SendWiimoteState(const int in_game_pad, const NetWiimote& nw)
 {
   auto spac = std::make_unique<sf::Packet>();
   *spac << static_cast<MessageId>(NP_MSG_WIIMOTE_DATA);
-  *spac << in_game_pad;
+  *spac << static_cast<PadMapping>(in_game_pad);
   *spac << static_cast<u8>(nw.size());
   for (auto it : nw)
   {
@@ -940,7 +940,7 @@ void NetPlayClient::OnConnectFailed(u8 reason)
 }
 
 // called from ---CPU--- thread
-bool NetPlayClient::GetNetPads(const u8 pad_nb, GCPadStatus* pad_status)
+bool NetPlayClient::GetNetPads(const int pad_nb, GCPadStatus* pad_status)
 {
   // The interface for this is extremely silly.
   //
@@ -965,8 +965,8 @@ bool NetPlayClient::GetNetPads(const u8 pad_nb, GCPadStatus* pad_status)
   // clients.
   if (IsFirstInGamePad(pad_nb))
   {
-    const u8 num_local_pads = NumLocalPads();
-    for (u8 local_pad = 0; local_pad < num_local_pads; local_pad++)
+    const int num_local_pads = NumLocalPads();
+    for (int local_pad = 0; local_pad < num_local_pads; local_pad++)
     {
       switch (SConfig::GetInstance().m_SIDevice[local_pad])
       {
@@ -979,7 +979,7 @@ bool NetPlayClient::GetNetPads(const u8 pad_nb, GCPadStatus* pad_status)
         break;
       }
 
-      u8 ingame_pad = LocalPadToInGamePad(local_pad);
+      int ingame_pad = LocalPadToInGamePad(local_pad);
 
       // adjust the buffer either up or down
       // inserting multiple padstates or dropping states
@@ -1140,20 +1140,20 @@ bool NetPlayClient::LocalPlayerHasControllerMapped() const
          std::any_of(m_wiimote_map.begin(), m_wiimote_map.end(), mapping_matches_player_id);
 }
 
-bool NetPlayClient::IsFirstInGamePad(u8 ingame_pad) const
+bool NetPlayClient::IsFirstInGamePad(int ingame_pad) const
 {
   return std::none_of(m_pad_map.begin(), m_pad_map.begin() + ingame_pad,
                       [](auto mapping) { return mapping > 0; });
 }
 
-u8 NetPlayClient::NumLocalPads() const
+int NetPlayClient::NumLocalPads() const
 {
-  return static_cast<u8>(std::count_if(m_pad_map.begin(), m_pad_map.end(), [this](auto mapping) {
+  return static_cast<int>(std::count_if(m_pad_map.begin(), m_pad_map.end(), [this](auto mapping) {
     return mapping == m_local_player->pid;
   }));
 }
 
-u8 NetPlayClient::InGamePadToLocalPad(u8 ingame_pad)
+int NetPlayClient::InGamePadToLocalPad(int ingame_pad)
 {
   // not our pad
   if (m_pad_map[ingame_pad] != m_local_player->pid)
@@ -1171,7 +1171,7 @@ u8 NetPlayClient::InGamePadToLocalPad(u8 ingame_pad)
   return local_pad;
 }
 
-u8 NetPlayClient::LocalPadToInGamePad(u8 local_pad)
+int NetPlayClient::LocalPadToInGamePad(int local_pad)
 {
   // Figure out which in-game pad maps to which local pad.
   // The logic we have here is that the local slots always
@@ -1258,7 +1258,7 @@ void NetPlayClient::ComputeMD5(const std::string& file_identifier)
 
 // called from ---CPU--- thread
 // Actual Core function which is called on every frame
-bool CSIDevice_GCController::NetPlay_GetInput(u8 numPAD, GCPadStatus* PadStatus)
+bool CSIDevice_GCController::NetPlay_GetInput(int numPAD, GCPadStatus* PadStatus)
 {
   std::lock_guard<std::mutex> lk(crit_netplay_client);
 
@@ -1294,7 +1294,7 @@ u64 CEXIIPL::NetPlay_GetGCTime()
 
 // called from ---CPU--- thread
 // return the local pad num that should rumble given a ingame pad num
-u8 CSIDevice_GCController::NetPlay_InGamePadToLocalPad(u8 numPAD)
+int CSIDevice_GCController::NetPlay_InGamePadToLocalPad(int numPAD)
 {
   std::lock_guard<std::mutex> lk(crit_netplay_client);
 

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -85,17 +85,17 @@ public:
 
   // Send and receive pads values
   bool WiimoteUpdate(int _number, u8* data, const u8 size, u8 reporting_mode);
-  bool GetNetPads(const u8 pad_nb, GCPadStatus* pad_status);
+  bool GetNetPads(int pad_nb, GCPadStatus* pad_status);
 
   void OnTraversalStateChanged() override;
   void OnConnectReady(ENetAddress addr) override;
   void OnConnectFailed(u8 reason) override;
 
-  bool IsFirstInGamePad(u8 ingame_pad) const;
-  u8 NumLocalPads() const;
+  bool IsFirstInGamePad(int ingame_pad) const;
+  int NumLocalPads() const;
 
-  u8 InGamePadToLocalPad(u8 ingame_pad);
-  u8 LocalPadToInGamePad(u8 localPad);
+  int InGamePadToLocalPad(int ingame_pad);
+  int LocalPadToInGamePad(int localPad);
 
   static void SendTimeBase();
   bool DoAllPlayersHaveGame();
@@ -154,8 +154,8 @@ private:
   void SendStopGamePacket();
 
   void UpdateDevices();
-  void SendPadState(const PadMapping in_game_pad, const GCPadStatus& np);
-  void SendWiimoteState(const PadMapping in_game_pad, const NetWiimote& nw);
+  void SendPadState(int in_game_pad, const GCPadStatus& np);
+  void SendWiimoteState(int in_game_pad, const NetWiimote& nw);
   unsigned int OnData(sf::Packet& packet);
   void Send(sf::Packet& packet);
   void Disconnect();


### PR DESCRIPTION
Using `u8` as indexers is kind of silly, since the rest of the public API essentially uses `int` for this sort of thing. Changing these to int also gets rid of quite a few implicit truncations.

This also allows for getting rid of similar silliness in the netplay API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4313)
<!-- Reviewable:end -->
