### PR TITLE
DebugInterface: Make GetRawMemoryString return a std::string

### DIFF
--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -13,10 +13,9 @@ protected:
   virtual ~DebugInterface() {}
 public:
   virtual std::string Disassemble(unsigned int /*address*/) { return "NODEBUGGER"; }
-  virtual void GetRawMemoryString(int /*memory*/, unsigned int /*address*/, char* dest,
-                                  int /*max_size*/)
+  virtual std::string GetRawMemoryString(int /*memory*/, unsigned int /*address*/)
   {
-    strcpy(dest, "NODEBUGGER");
+    return "NODEBUGGER";
   }
   virtual int GetInstructionSize(int /*instruction*/) { return 1; }
   virtual bool IsAlive() { return true; }

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -2,16 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/Debugger/PPCDebugInterface.h"
+
 #include <string>
 
 #include "Common/GekkoDisassembler.h"
+#include "Common/StringUtil.h"
 
 #include "Core/Core.h"
-#include "Core/Debugger/Debugger_SymbolMap.h"
-#include "Core/Debugger/PPCDebugInterface.h"
 #include "Core/HW/DSP.h"
-#include "Core/HW/Memmap.h"
-#include "Core/Host.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -48,24 +47,19 @@ std::string PPCDebugInterface::Disassemble(unsigned int address)
   }
 }
 
-void PPCDebugInterface::GetRawMemoryString(int memory, unsigned int address, char* dest,
-                                           int max_size)
+std::string PPCDebugInterface::GetRawMemoryString(int memory, unsigned int address)
 {
   if (IsAlive())
   {
-    if (memory || PowerPC::HostIsRAMAddress(address))
-    {
-      snprintf(dest, max_size, "%08X%s", ReadExtraMemory(memory, address), memory ? " (ARAM)" : "");
-    }
-    else
-    {
-      strcpy(dest, memory ? "--ARAM--" : "--------");
-    }
+    const bool is_aram = memory != 0;
+
+    if (is_aram || PowerPC::HostIsRAMAddress(address))
+      return StringFromFormat("%08X%s", ReadExtraMemory(memory, address), is_aram ? " (ARAM)" : "");
+
+    return is_aram ? "--ARAM--" : "--------";
   }
-  else
-  {
-    strcpy(dest, "<unknwn>");  // bad spelling - 8 chars
-  }
+
+  return "<unknwn>";  // bad spelling - 8 chars
 }
 
 unsigned int PPCDebugInterface::ReadMemory(unsigned int address)

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -15,7 +15,7 @@ class PPCDebugInterface final : public DebugInterface
 public:
   PPCDebugInterface() {}
   std::string Disassemble(unsigned int address) override;
-  void GetRawMemoryString(int memory, unsigned int address, char* dest, int max_size) override;
+  std::string GetRawMemoryString(int memory, unsigned int address) override;
   int GetInstructionSize(int /*instruction*/) override { return 4; }
   bool IsAlive() override;
   bool IsBreakpoint(unsigned int address) override;

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -2,12 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/DSPLLE/DSPDebugInterface.h"
+
 #include <string>
 
 #include "Common/MsgHandler.h"
+#include "Common/StringUtil.h"
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPMemoryMap.h"
-#include "Core/HW/DSPLLE/DSPDebugInterface.h"
 #include "Core/HW/DSPLLE/DSPSymbols.h"
 
 std::string DSPDebugInterface::Disassemble(unsigned int address)
@@ -16,14 +18,10 @@ std::string DSPDebugInterface::Disassemble(unsigned int address)
   return DSPSymbols::GetLineText(address);
 }
 
-void DSPDebugInterface::GetRawMemoryString(int memory, unsigned int address, char* dest,
-                                           int max_size)
+std::string DSPDebugInterface::GetRawMemoryString(int memory, unsigned int address)
 {
   if (DSPCore_GetState() == DSPCORE_STOP)
-  {
-    dest[0] = 0;
-    return;
-  }
+    return "";
 
   switch (memory)
   {
@@ -32,29 +30,25 @@ void DSPDebugInterface::GetRawMemoryString(int memory, unsigned int address, cha
     {
     case 0:
     case 0x8:
-      sprintf(dest, "%04x", dsp_imem_read(address));
-      break;
+      return StringFromFormat("%04x", dsp_imem_read(address));
     default:
-      sprintf(dest, "--IMEM--");
-      break;
+      return "--IMEM--";
     }
-    break;
+
   case 1:  // DMEM
     switch (address >> 12)
     {
     case 0:
     case 1:
-      sprintf(dest, "%04x (DMEM)", dsp_dmem_read(address));
-      break;
+      return StringFromFormat("%04x (DMEM)", dsp_dmem_read(address));
     case 0xf:
-      sprintf(dest, "%04x (MMIO)", g_dsp.ifx_regs[address & 0xFF]);
-      break;
+      return StringFromFormat("%04x (MMIO)", g_dsp.ifx_regs[address & 0xFF]);
     default:
-      sprintf(dest, "--DMEM--");
-      break;
+      return "--DMEM--";
     }
-    break;
   }
+
+  return "";
 }
 
 unsigned int DSPDebugInterface::ReadMemory(unsigned int address)

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -14,7 +14,7 @@ class DSPDebugInterface final : public DebugInterface
 public:
   DSPDebugInterface() {}
   std::string Disassemble(unsigned int address) override;
-  void GetRawMemoryString(int memory, unsigned int address, char* dest, int max_size) override;
+  std::string GetRawMemoryString(int memory, unsigned int address) override;
   int GetInstructionSize(int instruction) override { return 1; }
   bool IsAlive() override;
   bool IsBreakpoint(unsigned int address) override;

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -332,8 +332,7 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
 
     if (!IsHexMode())
     {
-      char mem[256];
-      debugger->GetRawMemoryString(memory, address, mem, 256);
+      const std::string mem = debugger->GetRawMemoryString(memory, address);
       dc.SetTextForeground(navy_color);
       draw_text(StrToWxStr(mem), 2);
     }


### PR DESCRIPTION
Makes it nicer to use; no need to care about buffer sizes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4316)
<!-- Reviewable:end -->
