### PR TITLE
[WIP/RFC] Add GPU Overclock to Advanced Menu

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -295,6 +295,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("FrameSkip", m_FrameSkip);
   core->Set("Overclock", m_OCFactor);
   core->Set("OverclockEnable", m_OCEnable);
+  core->Set("GPUOverclockEnable", m_GPUOCEnable);
   core->Set("GFXBackend", m_strVideoBackend);
   core->Set("GPUDeterminismMode", m_strGPUDeterminismMode);
   core->Set("PerfMapDir", m_perfDir);
@@ -613,6 +614,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("EmulationSpeed", &m_EmulationSpeed, 1.0f);
   core->Get("Overclock", &m_OCFactor, 1.0f);
   core->Get("OverclockEnable", &m_OCEnable, false);
+  core->Get("GPUOverclockEnable", &m_OCEnable, false);
   core->Get("FrameSkip", &m_FrameSkip, 0);
   core->Get("GFXBackend", &m_strVideoBackend, "");
   core->Get("GPUDeterminismMode", &m_strGPUDeterminismMode, "auto");

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -236,6 +236,7 @@ struct SConfig : NonCopyable
   std::string m_InterfaceLanguage;
   float m_EmulationSpeed;
   bool m_OCEnable;
+  bool m_GPUOCEnable;
   float m_OCFactor;
   // other interface settings
   bool m_InterfaceToolbar;

--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -26,15 +26,29 @@ AdvancedConfigPane::AdvancedConfigPane(wxWindow* parent, wxWindowID id) : wxPane
 
 void AdvancedConfigPane::InitializeGUI()
 {
-  m_clock_override_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable CPU Clock Override"));
-  m_clock_override_slider =
+  m_cpu_clock_override_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable CPU Clock Override"));
+  m_cpu_clock_override_slider =
       new DolphinSlider(this, wxID_ANY, 100, 0, 150, wxDefaultPosition, FromDIP(wxSize(200, -1)));
-  m_clock_override_text = new wxStaticText(this, wxID_ANY, "");
+  m_cpu_clock_override_text = new wxStaticText(this, wxID_ANY, "");
 
-  m_clock_override_checkbox->Bind(wxEVT_CHECKBOX,
-                                  &AdvancedConfigPane::OnClockOverrideCheckBoxChanged, this);
-  m_clock_override_slider->Bind(wxEVT_SLIDER, &AdvancedConfigPane::OnClockOverrideSliderChanged,
-                                this);
+  m_cpu_clock_override_checkbox->Bind(wxEVT_CHECKBOX,
+                                      &AdvancedConfigPane::OnClockOverrideCheckBoxChanged, this);
+  m_cpu_clock_override_slider->Bind(wxEVT_SLIDER, &AdvancedConfigPane::OnClockOverrideSliderChanged,
+                                    this);
+
+  m_gpu_clock_override_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable GPU Clock Override"));
+  m_gpu_clock_override_slider =
+      new DolphinSlider(this, wxID_ANY, 100, 0, 150, wxDefaultPosition, FromDIP(wxSize(200, -1)));
+  m_gpu_clock_override_text = new wxStaticText(this, wxID_ANY, "");
+
+  m_gpu_clock_override_checkbox->Bind(wxEVT_CHECKBOX,
+                                      &AdvancedConfigPane::OnGPUClockOverrideCheckBoxChanged, this);
+  m_gpu_clock_override_slider->Bind(wxEVT_SLIDER,
+                                    &AdvancedConfigPane::OnGPUClockOverrideSliderChanged, this);
+
+  m_sync_gpu_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Synchronous GPU"));
+
+  m_sync_gpu_checkbox->Bind(wxEVT_CHECKBOX, &AdvancedConfigPane::OnSyncGPUCheckBoxChanged, this);
 
   m_custom_rtc_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Custom RTC"));
   m_custom_rtc_date_picker = new wxDatePickerCtrl(this, wxID_ANY);
@@ -55,7 +69,7 @@ void AdvancedConfigPane::InitializeGUI()
                                          "WARNING: Changing this from the default (100%) "
                                          "can and will break games and cause glitches. "
                                          "Do so at your own risk. Please do not report "
-                                         "bugs that occur with a non-default clock. "));
+                                         "bugs that occur with a non-default clock."));
 
   wxStaticText* const custom_rtc_description = new wxStaticText(
       this, wxID_ANY,
@@ -73,15 +87,25 @@ void AdvancedConfigPane::InitializeGUI()
   const int space5 = FromDIP(5);
 
   wxBoxSizer* const clock_override_slider_sizer = new wxBoxSizer(wxHORIZONTAL);
-  clock_override_slider_sizer->Add(m_clock_override_slider, 1);
-  clock_override_slider_sizer->Add(m_clock_override_text, 1, wxLEFT, space5);
+  clock_override_slider_sizer->Add(m_cpu_clock_override_slider, 1);
+  clock_override_slider_sizer->Add(m_cpu_clock_override_text, 1, wxLEFT, space5);
+
+  wxBoxSizer* const gpu_clock_override_slider_sizer = new wxBoxSizer(wxHORIZONTAL);
+  gpu_clock_override_slider_sizer->Add(m_gpu_clock_override_slider, 1);
+  gpu_clock_override_slider_sizer->Add(m_gpu_clock_override_text, 1, wxLEFT, space5);
 
   wxStaticBoxSizer* const cpu_options_sizer =
-      new wxStaticBoxSizer(wxVERTICAL, this, _("CPU Options"));
+      new wxStaticBoxSizer(wxVERTICAL, this, _("Overclock Options"));
   cpu_options_sizer->AddSpacer(space5);
-  cpu_options_sizer->Add(m_clock_override_checkbox, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+  cpu_options_sizer->Add(m_cpu_clock_override_checkbox, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   cpu_options_sizer->AddSpacer(space5);
   cpu_options_sizer->Add(clock_override_slider_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+  cpu_options_sizer->AddSpacer(space5);
+  cpu_options_sizer->Add(m_sync_gpu_checkbox, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+  cpu_options_sizer->AddSpacer(space5);
+  cpu_options_sizer->Add(m_gpu_clock_override_checkbox, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+  cpu_options_sizer->AddSpacer(space5);
+  cpu_options_sizer->Add(gpu_clock_override_slider_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   cpu_options_sizer->AddSpacer(space5);
   cpu_options_sizer->Add(clock_override_description, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   cpu_options_sizer->AddSpacer(space5);
@@ -113,19 +137,17 @@ void AdvancedConfigPane::InitializeGUI()
 
 void AdvancedConfigPane::LoadGUIValues()
 {
-  int ocFactor = (int)(std::log2f(SConfig::GetInstance().m_OCFactor) * 25.f + 100.f + 0.5f);
-  bool oc_enabled = SConfig::GetInstance().m_OCEnable;
-  m_clock_override_checkbox->SetValue(oc_enabled);
-  m_clock_override_slider->SetValue(ocFactor);
-  m_clock_override_slider->Enable(oc_enabled);
+  LoadCPUOverclock();
+  LoadGPUOverclock();
   UpdateCPUClock();
+  UpdateGPUClock();
   LoadCustomRTC();
 }
 
 void AdvancedConfigPane::OnClockOverrideCheckBoxChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().m_OCEnable = m_clock_override_checkbox->IsChecked();
-  m_clock_override_slider->Enable(SConfig::GetInstance().m_OCEnable);
+  SConfig::GetInstance().m_OCEnable = m_cpu_clock_override_checkbox->IsChecked();
+  m_cpu_clock_override_slider->Enable(SConfig::GetInstance().m_OCEnable);
   UpdateCPUClock();
 }
 
@@ -133,8 +155,37 @@ void AdvancedConfigPane::OnClockOverrideSliderChanged(wxCommandEvent& event)
 {
   // Vaguely exponential scaling?
   SConfig::GetInstance().m_OCFactor =
-      std::exp2f((m_clock_override_slider->GetValue() - 100.f) / 25.f);
+      std::exp2f((m_cpu_clock_override_slider->GetValue() - 100.f) / 25.f);
   UpdateCPUClock();
+}
+
+void AdvancedConfigPane::OnGPUClockOverrideCheckBoxChanged(wxCommandEvent&)
+{
+  SConfig::GetInstance().m_GPUOCEnable = m_gpu_clock_override_checkbox->IsChecked();
+  m_gpu_clock_override_slider->Enable(SConfig::GetInstance().m_GPUOCEnable);
+  UpdateGPUClock();
+}
+
+void AdvancedConfigPane::OnGPUClockOverrideSliderChanged(wxCommandEvent&)
+{
+  // Vaguely exponential scaling?
+  SConfig::GetInstance().fSyncGpuOverclock =
+      std::exp2f((m_gpu_clock_override_slider->GetValue() - 100.f) / 25.f);
+  UpdateGPUClock();
+}
+
+void AdvancedConfigPane::OnSyncGPUCheckBoxChanged(wxCommandEvent&)
+{
+  SConfig::GetInstance().bSyncGPU = m_sync_gpu_checkbox->IsChecked();
+  m_gpu_clock_override_checkbox->Enable(SConfig::GetInstance().bSyncGPU);
+  if (!SConfig::GetInstance().bSyncGPU)
+  {
+    // Disable GPU Overclocking
+    m_gpu_clock_override_checkbox->SetValue(false);
+    SConfig::GetInstance().m_GPUOCEnable = false;
+  }
+  m_gpu_clock_override_slider->Enable(m_gpu_clock_override_checkbox->IsChecked());
+  UpdateGPUClock();
 }
 
 static u32 ToSeconds(wxDateTime date)
@@ -165,11 +216,19 @@ void AdvancedConfigPane::OnCustomRTCTimeChanged(wxCommandEvent& event)
 void AdvancedConfigPane::UpdateCPUClock()
 {
   bool wii = SConfig::GetInstance().bWii;
-  int percent = (int)(std::roundf(SConfig::GetInstance().m_OCFactor * 100.f));
-  int clock = (int)(std::roundf(SConfig::GetInstance().m_OCFactor * (wii ? 729.f : 486.f)));
+  int percent = static_cast<int>(std::roundf(SConfig::GetInstance().m_OCFactor * 100.f));
+  int clock =
+      static_cast<int>(std::roundf(SConfig::GetInstance().m_OCFactor * (wii ? 729.f : 486.f)));
 
-  m_clock_override_text->SetLabel(
+  m_cpu_clock_override_text->SetLabel(
       SConfig::GetInstance().m_OCEnable ? wxString::Format("%d %% (%d mhz)", percent, clock) : "");
+}
+
+void AdvancedConfigPane::UpdateGPUClock()
+{
+  int percent = static_cast<int>(std::roundf(SConfig::GetInstance().fSyncGpuOverclock * 100.f));
+  m_gpu_clock_override_text->SetLabel(
+      SConfig::GetInstance().m_GPUOCEnable ? wxString::Format("%d %%", percent) : "");
 }
 
 void AdvancedConfigPane::LoadCustomRTC()
@@ -211,17 +270,55 @@ void AdvancedConfigPane::UpdateCustomRTC(time_t date, time_t time)
 
 void AdvancedConfigPane::RefreshGUI()
 {
-  // Don't allow users to edit the RTC while the game is running
+  // Don't allow users to edit the RTC or toggle SyncGPU while the game is running
   if (Core::IsRunning())
   {
     m_custom_rtc_checkbox->Disable();
     m_custom_rtc_date_picker->Disable();
     m_custom_rtc_time_picker->Disable();
+    m_sync_gpu_checkbox->Disable();
   }
-  // Allow users to edit CPU clock speed in game, but not while needing determinism
+  // Allow users to edit CPU/GPU clock speed in game, but not while needing determinism
   if (Core::IsRunning() && Core::g_want_determinism)
   {
-    m_clock_override_checkbox->Disable();
-    m_clock_override_slider->Disable();
+    m_cpu_clock_override_checkbox->Disable();
+    m_cpu_clock_override_slider->Disable();
+    m_gpu_clock_override_checkbox->Disable();
+    m_gpu_clock_override_slider->Disable();
   }
+}
+
+void AdvancedConfigPane::LoadCPUOverclock()
+{
+  int cpu_oc_factor =
+      static_cast<int>(std::log2f(SConfig::GetInstance().m_OCFactor) * 25.f + 100.f + 0.5f);
+  bool cpu_oc_enabled = SConfig::GetInstance().m_OCEnable;
+  m_cpu_clock_override_checkbox->SetValue(cpu_oc_enabled);
+  m_cpu_clock_override_slider->SetValue(cpu_oc_factor);
+  m_cpu_clock_override_slider->Enable(cpu_oc_enabled);
+}
+
+void AdvancedConfigPane::LoadGPUOverclock()
+{
+  int gpu_oc_factor =
+      static_cast<int>(std::log2f(SConfig::GetInstance().fSyncGpuOverclock) * 25.f + 100.f + 0.5f);
+  bool gpu_oc_enabled = SConfig::GetInstance().m_GPUOCEnable;
+  bool sync_gpu_enabled = SConfig::GetInstance().bSyncGPU;
+  if (SConfig::GetInstance().bCPUThread)
+  {
+    m_sync_gpu_checkbox->Enable();
+    m_sync_gpu_checkbox->SetValue(sync_gpu_enabled);
+  }
+  else  // SyncGPU is always enabled in single core mode
+  {
+    m_sync_gpu_checkbox->Disable();
+    m_sync_gpu_checkbox->SetValue(true);
+  }
+  if (m_sync_gpu_checkbox->GetValue())
+    m_gpu_clock_override_checkbox->Enable();
+  else
+    m_gpu_clock_override_checkbox->Disable();
+  m_gpu_clock_override_checkbox->SetValue(gpu_oc_enabled);
+  m_gpu_clock_override_slider->SetValue(gpu_oc_factor);
+  m_gpu_clock_override_slider->Enable(gpu_oc_enabled);
 }

--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.h
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.h
@@ -24,11 +24,17 @@ private:
 
   void OnClockOverrideCheckBoxChanged(wxCommandEvent&);
   void OnClockOverrideSliderChanged(wxCommandEvent&);
+  void OnGPUClockOverrideCheckBoxChanged(wxCommandEvent&);
+  void OnGPUClockOverrideSliderChanged(wxCommandEvent&);
+  void OnSyncGPUCheckBoxChanged(wxCommandEvent&);
   void OnCustomRTCCheckBoxChanged(wxCommandEvent&);
   void OnCustomRTCDateChanged(wxCommandEvent&);
   void OnCustomRTCTimeChanged(wxCommandEvent&);
 
+  void LoadCPUOverclock();
+  void LoadGPUOverclock();
   void UpdateCPUClock();
+  void UpdateGPUClock();
 
   // Custom RTC
   void LoadCustomRTC();
@@ -36,9 +42,13 @@ private:
   u32 m_temp_date;
   u32 m_temp_time;
 
-  wxCheckBox* m_clock_override_checkbox;
-  DolphinSlider* m_clock_override_slider;
-  wxStaticText* m_clock_override_text;
+  wxCheckBox* m_cpu_clock_override_checkbox;
+  DolphinSlider* m_cpu_clock_override_slider;
+  wxStaticText* m_cpu_clock_override_text;
+  wxCheckBox* m_gpu_clock_override_checkbox;
+  DolphinSlider* m_gpu_clock_override_slider;
+  wxStaticText* m_gpu_clock_override_text;
+  wxCheckBox* m_sync_gpu_checkbox;
   wxCheckBox* m_custom_rtc_checkbox;
   wxDatePickerCtrl* m_custom_rtc_date_picker;
   wxTimePickerCtrl* m_custom_rtc_time_picker;

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -356,7 +356,8 @@ void RunGpuLoop()
 
             if (param.bSyncGPU)
             {
-              cyclesExecuted = (int)(cyclesExecuted / param.fSyncGpuOverclock);
+              if (param.m_GPUOCEnable)
+                cyclesExecuted = (int)(cyclesExecuted / param.fSyncGpuOverclock);
               int old = s_sync_ticks.fetch_sub(cyclesExecuted);
               if (old >= param.iSyncGpuMaxDistance &&
                   old - (int)cyclesExecuted < param.iSyncGpuMaxDistance)
@@ -432,11 +433,19 @@ void RunGpu()
   }
 }
 
+static int GetAvailableTicks(int ticks)
+{
+  if (SConfig::GetInstance().m_GPUOCEnable)
+    return static_cast<int>(ticks * SConfig::GetInstance().fSyncGpuOverclock) + s_sync_ticks.load();
+
+  return ticks + s_sync_ticks.load();
+}
+
 static int RunGpuOnCpu(int ticks)
 {
   SCPFifoStruct& fifo = CommandProcessor::fifo;
   bool reset_simd_state = false;
-  int available_ticks = int(ticks * SConfig::GetInstance().fSyncGpuOverclock) + s_sync_ticks.load();
+  int available_ticks = GetAvailableTicks(ticks);
   while (fifo.bFF_GPReadEnable && fifo.CPReadWriteDistance && !AtBreakpoint() &&
          available_ticks >= 0)
   {


### PR DESCRIPTION
![](http://i.imgur.com/aXctXZZ.png)

This adds GPU Overclocking to the Advanced menu. Requires SyncGPU to be enabled for overclocking to be used. SyncGPU is always enabled in single core mode.

This is untested, and may have some slight changes in look and possibly how it works, so marking as WIP/RFC.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4317)

<!-- Reviewable:end -->
