### PR TITLE
Don't read/store settings directly from/to SYSCONF (and fix config restore)

### DIFF
--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -9,6 +9,7 @@
 #include "AudioCommon/OpenALStream.h"
 #include "AudioCommon/aldlist.h"
 #include "Common/Logging/Log.h"
+#include "Common/MsgHandler.h"
 #include "Common/Thread.h"
 #include "Core/ConfigManager.h"
 

--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -7,6 +7,7 @@
 #include "AudioCommon/WaveFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Common/MsgHandler.h"
 #include "Core/ConfigManager.h"
 
 constexpr size_t WaveFileWriter::BUFFER_SIZE;

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -31,6 +31,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "Common/Logging/LogManager.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
 #include "Core/ARDecrypt.h"

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/MathUtil.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Boot/Boot.h"

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -26,7 +26,8 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
-#include "Common/SysConf.h"
+#include "Common/Logging/Log.h"
+#include "Common/MsgHandler.h"
 #include "Core/BootManager.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -35,7 +36,6 @@
 #include "Core/HW/Sram.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/Host.h"
-#include "Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
 #include "VideoCommon/VideoBackendBase.h"
@@ -152,9 +152,6 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->bPAL60 = bPAL60;
   config->SelectedLanguage = iSelectedLanguage;
   config->iCPUCore = iCPUCore;
-
-  config->m_SYSCONF->SetData("IPL.PGS", bProgressive);
-  config->m_SYSCONF->SetData("IPL.E60", bPAL60);
 
   // Only change these back if they were actually set by game ini, since they can be changed while a
   // game is running.
@@ -294,9 +291,6 @@ bool BootCore(const std::string& _rFilename)
     // Wii settings
     if (StartUp.bWii)
     {
-      // Flush possible changes to SYSCONF to file
-      SConfig::GetInstance().m_SYSCONF->Save();
-
       int source;
       for (unsigned int i = 0; i < MAX_WIIMOTES; ++i)
       {
@@ -385,19 +379,8 @@ bool BootCore(const std::string& _rFilename)
     StartUp.bPAL60 = false;
   }
 
-  SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", StartUp.bProgressive);
-  SConfig::GetInstance().m_SYSCONF->SetData("IPL.E60", StartUp.bPAL60);
-
   if (StartUp.bWii)
-  {
-    // Disable WiiConnect24's standby mode. If it is enabled, it prevents us from receiving
-    // shutdown commands in the State Transition Manager (STM).
-    // TODO: remove this if and once Dolphin supports WC24 standby mode.
-    SConfig::GetInstance().m_SYSCONF->SetData<u8>("IPL.IDL", 0x00);
-    NOTICE_LOG(BOOT, "Disabling WC24 'standby' (shutdown to idle) to avoid hanging on shutdown");
-
-    RestoreBTInfoSection();
-  }
+    SConfig::GetInstance().SaveSettingsToSysconf();
 
   // Run the game
   // Init the core
@@ -413,10 +396,14 @@ bool BootCore(const std::string& _rFilename)
 void Stop()
 {
   Core::Stop();
+  RestoreConfig();
+}
 
-  SConfig& StartUp = SConfig::GetInstance();
-  StartUp.m_strUniqueID = "00000000";
-  config_cache.RestoreConfig(&StartUp);
+void RestoreConfig()
+{
+  SConfig::GetInstance().LoadSettingsFromSysconf();
+  SConfig::GetInstance().m_strUniqueID = "00000000";
+  config_cache.RestoreConfig(&SConfig::GetInstance());
 }
 
 }  // namespace

--- a/Source/Core/Core/BootManager.h
+++ b/Source/Core/Core/BootManager.h
@@ -10,5 +10,9 @@ namespace BootManager
 {
 bool BootCore(const std::string& _rFilename);
 
+// Stop the emulation core and restore the configuration.
 void Stop();
+// Synchronise Dolphin's configuration with the SYSCONF (which may have changed during emulation),
+// and restore settings that were overriden by per-game INIs or for some other reason.
+void RestoreConfig();
 }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -10,7 +10,6 @@
 
 #include "Common/IniFile.h"
 #include "Common/NonCopyable.h"
-#include "Common/SysConf.h"
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/SI_Device.h"
 
@@ -150,6 +149,15 @@ struct SConfig : NonCopyable
   int m_bt_passthrough_pid = -1;
   int m_bt_passthrough_vid = -1;
   std::string m_bt_passthrough_link_keys;
+
+  // SYSCONF settings
+  int m_sensor_bar_position = 0x01;
+  int m_sensor_bar_sensitivity = 0x03;
+  int m_speaker_volume = 0x58;
+  bool m_wiimote_motor = true;
+  int m_wii_language = 0x01;
+  int m_wii_aspect_ratio = 0x01;
+  int m_wii_screensaver = 0x00;
 
   // Fifo Player related settings
   bool bLoopFifoReplay = true;
@@ -305,13 +313,14 @@ struct SConfig : NonCopyable
   bool m_SSLDumpRootCA;
   bool m_SSLDumpPeerCert;
 
-  SysConf* m_SYSCONF;
-
   // Save settings
   void SaveSettings();
 
   // Load settings
   void LoadSettings();
+
+  void LoadSettingsFromSysconf();
+  void SaveSettingsToSysconf();
 
   // Return the permanent and somewhat globally used instance of this struct
   static SConfig& GetInstance() { return (*m_Instance); }
@@ -334,6 +343,7 @@ private:
   void SaveNetworkSettings(IniFile& ini);
   void SaveAnalyticsSettings(IniFile& ini);
   void SaveBluetoothPassthroughSettings(IniFile& ini);
+  void SaveSysconfSettings(IniFile& ini);
 
   void LoadGeneralSettings(IniFile& ini);
   void LoadInterfaceSettings(IniFile& ini);
@@ -347,6 +357,7 @@ private:
   void LoadNetworkSettings(IniFile& ini);
   void LoadAnalyticsSettings(IniFile& ini);
   void LoadBluetoothPassthroughSettings(IniFile& ini);
+  void LoadSysconfSettings(IniFile& ini);
 
   static SConfig* m_Instance;
 };

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -27,6 +27,7 @@
 #include "Common/Timer.h"
 
 #include "Core/Analytics.h"
+#include "Core/BootManager.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -248,8 +249,8 @@ bool Init()
   if (g_aspect_wide)
   {
     IniFile gameIni = _CoreParameter.LoadGameIni();
-    gameIni.GetOrCreateSection("Wii")->Get(
-        "Widescreen", &g_aspect_wide, !!SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.AR"));
+    gameIni.GetOrCreateSection("Wii")->Get("Widescreen", &g_aspect_wide,
+                                           !!SConfig::GetInstance().m_wii_aspect_ratio);
   }
 
   s_window_handle = Host_GetRenderHandle();
@@ -661,9 +662,7 @@ void EmuThread()
   // Clear on screen messages that haven't expired
   OSD::ClearMessages();
 
-  // Reload sysconf file in order to see changes committed during emulation
-  if (core_parameter.bWii)
-    SConfig::GetInstance().m_SYSCONF->Reload();
+  BootManager::RestoreConfig();
 
   INFO_LOG(CONSOLE, "Stop [Video Thread]\t\t---- Shutdown complete ----");
   Movie::Shutdown();

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -7,6 +7,7 @@
 
 #include "Core/FifoPlayer/FifoRecorder.h"
 
+#include "Common/MsgHandler.h"
 #include "Common/Thread.h"
 #include "Core/ConfigManager.h"
 #include "Core/FifoPlayer/FifoAnalyzer.h"

--- a/Source/Core/Core/HW/Sram.cpp
+++ b/Source/Core/Core/HW/Sram.cpp
@@ -5,6 +5,7 @@
 #include "Core/HW/Sram.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/Logging/Log.h"
 #include "Core/ConfigManager.h"
 
 // english

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -304,7 +304,7 @@ Wiimote::Wiimote(const unsigned int index)
   m_hotkeys->AddInput(_trans("Upright Hold"), false);
 
   // TODO: This value should probably be re-read if SYSCONF gets changed
-  m_sensor_bar_on_top = SConfig::GetInstance().m_SYSCONF->GetData<u8>("BT.BAR") != 0;
+  m_sensor_bar_on_top = SConfig::GetInstance().m_sensor_bar_position != 0;
 
   // --- reset eeprom/register/values to default ---
   Reset();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
@@ -11,6 +11,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
+#include "Common/SysConf.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
@@ -18,15 +19,14 @@
 
 constexpr u16 BT_INFO_SECTION_LENGTH = 0x460;
 
-void BackUpBTInfoSection()
+void BackUpBTInfoSection(SysConf* sysconf)
 {
   const std::string filename = File::GetUserPath(D_SESSION_WIIROOT_IDX) + DIR_SEP WII_BTDINF_BACKUP;
   if (File::Exists(filename))
     return;
   File::IOFile backup(filename, "wb");
   std::vector<u8> section(BT_INFO_SECTION_LENGTH);
-  if (!SConfig::GetInstance().m_SYSCONF->GetArrayData("BT.DINF", section.data(),
-                                                      static_cast<u16>(section.size())))
+  if (!sysconf->GetArrayData("BT.DINF", section.data(), static_cast<u16>(section.size())))
   {
     ERROR_LOG(WII_IPC_WIIMOTE, "Failed to read source BT.DINF section");
     return;
@@ -35,7 +35,7 @@ void BackUpBTInfoSection()
     ERROR_LOG(WII_IPC_WIIMOTE, "Failed to back up BT.DINF section");
 }
 
-void RestoreBTInfoSection()
+void RestoreBTInfoSection(SysConf* sysconf)
 {
   const std::string filename = File::GetUserPath(D_SESSION_WIIROOT_IDX) + DIR_SEP WII_BTDINF_BACKUP;
   if (!File::Exists(filename))
@@ -47,9 +47,7 @@ void RestoreBTInfoSection()
     ERROR_LOG(WII_IPC_WIIMOTE, "Failed to read backed up BT.DINF section");
     return;
   }
-  SConfig::GetInstance().m_SYSCONF->SetArrayData("BT.DINF", section.data(),
-                                                 static_cast<u16>(section.size()));
-  SConfig::GetInstance().m_SYSCONF->Save();
+  sysconf->SetArrayData("BT.DINF", section.data(), static_cast<u16>(section.size()));
   File::Delete(filename);
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
@@ -7,8 +7,10 @@
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
-void BackUpBTInfoSection();
-void RestoreBTInfoSection();
+class SysConf;
+
+void BackUpBTInfoSection(SysConf* sysconf);
+void RestoreBTInfoSection(SysConf* sysconf);
 
 class CWII_IPC_HLE_Device_usb_oh1_57e_305_base : public IWII_IPC_HLE_Device
 {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -496,7 +496,6 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::SaveLinkKeys()
   if (!config_string.empty())
     config_string.pop_back();
   SConfig::GetInstance().m_bt_passthrough_link_keys = config_string;
-  SConfig::GetInstance().SaveSettings();
 }
 
 bool CWII_IPC_HLE_Device_usb_oh1_57e_305_real::OpenDevice(libusb_device* device)

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1520,7 +1520,7 @@ void GetSettings()
   s_bNetPlay = NetPlay::IsNetPlayRunning();
   if (SConfig::GetInstance().bWii)
   {
-    s_language = SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG");
+    s_language = SConfig::GetInstance().m_wii_language;
   }
   else
   {

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -10,6 +10,8 @@
 #include "Common/ENetUtil.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
+#include "Common/Logging/Log.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/EXI_DeviceIPL.h"

--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/PowerPC/JitCommon/JitCache.h"

--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -9,6 +9,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/PowerPC/PPCAnalyst.h"

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
@@ -19,6 +19,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
 #include "Common/FileUtil.h"
+#include "Common/MsgHandler.h"
 #include "Core/ConfigManager.h"
 #include "Core/HotkeyManager.h"
 #include "DolphinWX/Config/InterfaceConfigPane.h"

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -223,7 +223,6 @@ void PathConfigPane::OnNANDRootChanged(wxCommandEvent& event)
   File::SetUserPath(D_WIIROOT_IDX, nand_path);
   m_nand_root_dirpicker->SetPath(StrToWxStr(nand_path));
 
-  SConfig::GetInstance().m_SYSCONF->UpdateLocation();
   DiscIO::CNANDContentManager::Access().ClearCache();
 
   main_frame->UpdateWiiMenuChoice();

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.h
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.h
@@ -8,11 +8,6 @@
 #include <wx/panel.h>
 #include "Common/CommonTypes.h"
 
-namespace DiscIO
-{
-enum class Language;
-}
-
 class DolphinSlider;
 class wxCheckBox;
 class wxChoice;
@@ -39,8 +34,6 @@ private:
   void OnSensorBarSensChanged(wxCommandEvent&);
   void OnSpeakerVolumeChanged(wxCommandEvent&);
   void OnWiimoteMotorChanged(wxCommandEvent&);
-
-  static u8 GetSADRCountryCode(DiscIO::Language language);
 
   wxArrayString m_system_language_strings;
   wxArrayString m_aspect_ratio_strings;

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1187,7 +1187,7 @@ void CFrame::DoStop()
     if (NetPlayDialog::GetNetPlayClient())
       NetPlayDialog::GetNetPlayClient()->Stop();
 
-    BootManager::Stop();
+    Core::Stop();
     UpdateGUI();
   }
 }

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.cpp
@@ -32,6 +32,7 @@
 #include "Common/FifoQueue.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
+#include "Common/MsgHandler.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/HW/EXI_Device.h"

--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -886,10 +886,6 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string& title)
                                         this);
 
         progressive_scan_checkbox->SetValue(SConfig::GetInstance().bProgressive);
-        // A bit strange behavior, but this needs to stay in sync with the main progressive boolean;
-        // TODO: Is this still necessary?
-        SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", SConfig::GetInstance().bProgressive);
-
         szr_misc->Add(progressive_scan_checkbox);
       }
 

--- a/Source/Core/DolphinWX/VideoConfigDiag.h
+++ b/Source/Core/DolphinWX/VideoConfigDiag.h
@@ -130,9 +130,7 @@ protected:
 
   void Event_ProgressiveScan(wxCommandEvent& ev)
   {
-    SConfig::GetInstance().m_SYSCONF->SetData("IPL.PGS", ev.GetInt());
     SConfig::GetInstance().bProgressive = ev.IsChecked();
-
     ev.Skip();
   }
 

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -6,6 +6,7 @@
 
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
+#include "Common/MsgHandler.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/Wiimote.h"
 #include "InputCommon/ControllerEmu.h"

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -9,6 +9,7 @@
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/LogManager.h"
+#include "Common/MsgHandler.h"
 
 #include "Core/ConfigManager.h"
 #include "Core/HW/Wiimote.h"

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/Common.h"
+#include "Common/MsgHandler.h"
 
 namespace DX11
 {

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -8,6 +8,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"


### PR DESCRIPTION
Instead of directly reading/storing settings from/to the SYSCONF, we now store Wii settings to Dolphin's own configuration, and apply them on boot. This prevents issues with settings not being saved, being overridden and lost (if the user opens a dialog that writes to the SYSCONF while a game is running).

This also fixes restoring settings from the config cache after a graceful shutdown; for some reason, settings were only restored after a normal shutdown.

Fixes issue 9825 and 9826

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4319)
<!-- Reviewable:end -->
