### PR TITLE
Framedump: General code cleanup.

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -870,7 +870,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     D3D11_MAPPED_SUBRESOURCE map;
     D3D::context->Map(s_screenshot_texture, 0, D3D11_MAP_READ, 0, &map);
 
-    DumpFrameData(reinterpret_cast<const u8*>(map.pData), source_width, source_height,
+    DumpFrameData(reinterpret_cast<const u8*>(map.pData), source_width, source_height, map.RowPitch,
                   AVIDump::DumpFormat::FORMAT_RGBA);
     FinishFrameData();
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -891,6 +891,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     formatBufferDump((u8*)map.pData, image.data(), source_width, source_height, map.RowPitch);
 
     DumpFrameData(image.data(), source_width, source_height, AVIDump::DumpFormat::FORMAT_BGR, true);
+    FinishFrameData();
 
     D3D::context->Unmap(s_screenshot_texture, 0);
   }

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -745,22 +745,6 @@ bool Renderer::SaveScreenshot(const std::string& filename, const TargetRectangle
   return saved_png;
 }
 
-void formatBufferDump(const u8* in, u8* out, int w, int h, int p)
-{
-  for (int y = 0; y < h; ++y)
-  {
-    auto line = (in + (h - y - 1) * p);
-    for (int x = 0; x < w; ++x)
-    {
-      out[0] = line[2];
-      out[1] = line[1];
-      out[2] = line[0];
-      out += 3;
-      line += 4;
-    }
-  }
-}
-
 // This function has the final picture. We adjust the aspect ratio here.
 void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                         const EFBRectangle& rc, float Gamma)
@@ -886,11 +870,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     D3D11_MAPPED_SUBRESOURCE map;
     D3D::context->Map(s_screenshot_texture, 0, D3D11_MAP_READ, 0, &map);
 
-    // TODO: This convertion is not needed. Get rid of it.
-    std::vector<u8> image(source_width * source_height * 3);
-    formatBufferDump((u8*)map.pData, image.data(), source_width, source_height, map.RowPitch);
-
-    DumpFrameData(image.data(), source_width, source_height, AVIDump::DumpFormat::FORMAT_BGR, true);
+    DumpFrameData(reinterpret_cast<const u8*>(map.pData), source_width, source_height,
+                  AVIDump::DumpFormat::FORMAT_RGBA);
     FinishFrameData();
 
     D3D::context->Unmap(s_screenshot_texture, 0);

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -768,7 +768,6 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
   if (Fifo::WillSkipCurrentFrame() || (!XFBWrited && !g_ActiveConfig.RealXFBEnabled()) ||
       !fbWidth || !fbHeight)
   {
-    RepeatFrameDumpFrame();
     Core::Callback_VideoCopiedToXFB(false);
     return;
   }
@@ -778,7 +777,6 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
       FramebufferManager::GetXFBSource(xfbAddr, fbStride, fbHeight, &xfbCount);
   if ((!xfbSourceList || xfbCount == 0) && g_ActiveConfig.bUseXFB && !g_ActiveConfig.bUseRealXFB)
   {
-    RepeatFrameDumpFrame();
     Core::Callback_VideoCopiedToXFB(false);
     return;
   }

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -711,7 +711,6 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
   if (Fifo::WillSkipCurrentFrame() || (!XFBWrited && !g_ActiveConfig.RealXFBEnabled()) ||
       !fb_width || !fb_height)
   {
-    RepeatFrameDumpFrame();
     Core::Callback_VideoCopiedToXFB(false);
     return;
   }
@@ -721,7 +720,6 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
       FramebufferManager::GetXFBSource(xfb_addr, fb_stride, fb_height, &xfb_count);
   if ((!xfb_source_list || xfb_count == 0) && g_ActiveConfig.bUseXFB && !g_ActiveConfig.bUseRealXFB)
   {
-    RepeatFrameDumpFrame();
     Core::Callback_VideoCopiedToXFB(false);
     return;
   }

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -688,22 +688,6 @@ bool Renderer::SaveScreenshot(const std::string& filename, const TargetRectangle
   return saved_png;
 }
 
-void formatBufferDump(const u8* in, u8* out, int w, int h, int p)
-{
-  for (int y = 0; y < h; ++y)
-  {
-    auto line = (in + (h - y - 1) * p);
-    for (int x = 0; x < w; ++x)
-    {
-      out[0] = line[2];
-      out[1] = line[1];
-      out[2] = line[0];
-      out += 3;
-      line += 4;
-    }
-  }
-}
-
 // This function has the final picture. We adjust the aspect ratio here.
 void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height,
                         const EFBRectangle& rc, float gamma)
@@ -863,12 +847,8 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
     D3D12_RANGE read_range = {0, dst_location.PlacedFootprint.Footprint.RowPitch * source_height};
     CheckHR(s_screenshot_texture->Map(0, &read_range, &screenshot_texture_map));
 
-    // TODO: This convertion is not needed. Get rid of it.
-    std::vector<u8> image(source_width * source_height * 3);
-    formatBufferDump(static_cast<u8*>(screenshot_texture_map), image.data(), source_width,
-                     source_height, dst_location.PlacedFootprint.Footprint.RowPitch);
-
-    DumpFrameData(image.data(), source_width, source_height, AVIDump::DumpFormat::FORMAT_BGR, true);
+    DumpFrameData(reinterpret_cast<const u8*>(screenshot_texture_map), source_width, source_height,
+                  AVIDump::DumpFormat::FORMAT_RGBA);
     FinishFrameData();
 
     D3D12_RANGE write_range = {};

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -848,6 +848,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
     CheckHR(s_screenshot_texture->Map(0, &read_range, &screenshot_texture_map));
 
     DumpFrameData(reinterpret_cast<const u8*>(screenshot_texture_map), source_width, source_height,
+                  dst_location.PlacedFootprint.Footprint.RowPitch,
                   AVIDump::DumpFormat::FORMAT_RGBA);
     FinishFrameData();
 

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -869,6 +869,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
                      source_height, dst_location.PlacedFootprint.Footprint.RowPitch);
 
     DumpFrameData(image.data(), source_width, source_height, AVIDump::DumpFormat::FORMAT_BGR, true);
+    FinishFrameData();
 
     D3D12_RANGE write_range = {};
     s_screenshot_texture->Unmap(0, &write_range);

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1353,7 +1353,6 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
   if (Fifo::WillSkipCurrentFrame() || (!XFBWrited && !g_ActiveConfig.RealXFBEnabled()) ||
       !fbWidth || !fbHeight)
   {
-    RepeatFrameDumpFrame();
     Core::Callback_VideoCopiedToXFB(false);
     return;
   }
@@ -1363,7 +1362,6 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
       FramebufferManager::GetXFBSource(xfbAddr, fbStride, fbHeight, &xfbCount);
   if (g_ActiveConfig.VirtualXFBEnabled() && (!xfbSourceList || xfbCount == 0))
   {
-    RepeatFrameDumpFrame();
     Core::Callback_VideoCopiedToXFB(false);
     return;
   }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1470,6 +1470,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
     DumpFrameData(image.data(), flipped_trc.GetWidth(), flipped_trc.GetHeight(),
                   AVIDump::DumpFormat::FORMAT_RGBA, true);
+    FinishFrameData();
   }
   // Finish up the current frame, print some stats
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1469,7 +1469,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                  flipped_trc.GetHeight(), GL_RGBA, GL_UNSIGNED_BYTE, image.data());
 
     DumpFrameData(image.data(), flipped_trc.GetWidth(), flipped_trc.GetHeight(),
-                  AVIDump::DumpFormat::FORMAT_RGBA, true);
+                  flipped_trc.GetWidth() * 4, AVIDump::DumpFormat::FORMAT_RGBA, true);
     FinishFrameData();
   }
   // Finish up the current frame, print some stats

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -497,6 +497,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
                     static_cast<int>(m_screenshot_render_texture->GetWidth()),
                     static_cast<int>(m_screenshot_render_texture->GetHeight()),
                     AVIDump::DumpFormat::FORMAT_RGBA);
+      FinishFrameData();
     }
   }
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -496,6 +496,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
       DumpFrameData(reinterpret_cast<const u8*>(m_screenshot_readback_texture->GetMapPointer()),
                     static_cast<int>(m_screenshot_render_texture->GetWidth()),
                     static_cast<int>(m_screenshot_render_texture->GetHeight()),
+                    static_cast<int>(m_screenshot_readback_texture->GetRowStride()),
                     AVIDump::DumpFormat::FORMAT_RGBA);
       FinishFrameData();
     }

--- a/Source/Core/VideoCommon/AVIDump.h
+++ b/Source/Core/VideoCommon/AVIDump.h
@@ -12,7 +12,7 @@ private:
   static bool CreateFile();
   static void CloseFile();
   static void CheckResolution(int width, int height);
-  static void StoreFrameData(const u8* data, int width, int height);
+  static void StoreFrameData(const u8* data, int width, int height, int stride);
 
 public:
   enum class DumpFormat
@@ -22,7 +22,7 @@ public:
   };
 
   static bool Start(int w, int h, DumpFormat format);
-  static void AddFrame(const u8* data, int width, int height);
+  static void AddFrame(const u8* data, int width, int height, int stride);
   static void Stop();
   static void DoState();
 };

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -555,30 +555,20 @@ bool Renderer::IsFrameDumping()
   return false;
 }
 
-void Renderer::DumpFrameData(const u8* data, int w, int h, AVIDump::DumpFormat format,
+void Renderer::DumpFrameData(const u8* data, int w, int h, int stride, AVIDump::DumpFormat format,
                              bool swap_upside_down)
 {
 #if defined(HAVE_LIBAV) || defined(_WIN32)
   if (w == 0 || h == 0)
     return;
 
-  size_t image_size;
-  switch (format)
-  {
-  case AVIDump::DumpFormat::FORMAT_BGR:
-    image_size = 3 * w * h;
-    break;
-  case AVIDump::DumpFormat::FORMAT_RGBA:
-    image_size = 4 * w * h;
-    break;
-  }
-
   m_last_framedump_width = w;
   m_last_framedump_height = h;
   m_last_framedump_format = format;
+  m_last_framedump_stride = stride;
 
   // TODO: Refactor this. Right now it's needed for the implace flipping of the image.
-  m_frame_data.assign(data, data + image_size);
+  m_frame_data.assign(data, data + stride * h);
 
   if (!m_last_frame_dumped)
   {
@@ -598,7 +588,7 @@ void Renderer::DumpFrameData(const u8* data, int w, int h, AVIDump::DumpFormat f
   {
     if (swap_upside_down)
       FlipImageData(m_frame_data.data(), w, h, 4);
-    AVIDump::AddFrame(m_frame_data.data(), w, h);
+    AVIDump::AddFrame(m_frame_data.data(), w, h, stride);
   }
 
   m_last_frame_dumped = true;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -605,6 +605,10 @@ void Renderer::DumpFrameData(const u8* data, int w, int h, AVIDump::DumpFormat f
 #endif
 }
 
+void Renderer::FinishFrameData()
+{
+}
+
 void Renderer::FlipImageData(u8* data, int w, int h, int pixel_width)
 {
   for (int y = 0; y < h / 2; ++y)

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -578,7 +578,6 @@ void Renderer::DumpFrameData(const u8* data, int w, int h, AVIDump::DumpFormat f
   m_last_framedump_format = format;
 
   // TODO: Refactor this. Right now it's needed for the implace flipping of the image.
-  //       It's also used to repeat the last frame.
   m_frame_data.assign(data, data + image_size);
 
   if (!m_last_frame_dumped)
@@ -603,16 +602,6 @@ void Renderer::DumpFrameData(const u8* data, int w, int h, AVIDump::DumpFormat f
   }
 
   m_last_frame_dumped = true;
-#endif
-}
-
-void Renderer::RepeatFrameDumpFrame()
-{
-#if defined(HAVE_LIBAV) || defined(_WIN32)
-  if (SConfig::GetInstance().m_DumpFrames && m_AVI_dumping && !m_frame_data.empty())
-  {
-    AVIDump::AddFrame(m_frame_data.data(), m_last_framedump_width, m_last_framedump_height);
-  }
 #endif
 }
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -148,7 +148,7 @@ protected:
   static void RecordVideoMemory();
 
   bool IsFrameDumping();
-  void DumpFrameData(const u8* data, int w, int h, AVIDump::DumpFormat format,
+  void DumpFrameData(const u8* data, int w, int h, int stride, AVIDump::DumpFormat format,
                      bool swap_upside_down = false);
   void FinishFrameData();
 
@@ -194,6 +194,7 @@ private:
   bool m_last_frame_dumped = false;
   int m_last_framedump_width = 0;
   int m_last_framedump_height = 0;
+  int m_last_framedump_stride = 0;
   AVIDump::DumpFormat m_last_framedump_format;
 };
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -150,7 +150,6 @@ protected:
   bool IsFrameDumping();
   void DumpFrameData(const u8* data, int w, int h, AVIDump::DumpFormat format,
                      bool swap_upside_down = false);
-  void RepeatFrameDumpFrame();
 
   static volatile bool s_bScreenshot;
   static std::mutex s_criticalScreenshot;

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -150,6 +150,7 @@ protected:
   bool IsFrameDumping();
   void DumpFrameData(const u8* data, int w, int h, AVIDump::DumpFormat format,
                      bool swap_upside_down = false);
+  void FinishFrameData();
 
   static volatile bool s_bScreenshot;
   static std::mutex s_criticalScreenshot;


### PR DESCRIPTION
RepeatFrameDumpFrame was used to duplicate frames. As we do this internally for AVIDump, too, this is redundant.

This PR also creates a new stup function FinishFrameData, it shall be used to mark the pointer given by DumpFrameData as invalid. Right now, no threading is done, but this will conflict backend and VideoCommon parts. So I'm adding this patch now.

The last two patches adds custom row_strides, so we don't need to convert the D3D textures any more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4320)
<!-- Reviewable:end -->
