### PR TITLE
Fix games being invisible in the game list on non-TV devices

### DIFF
--- a/Source/Android/app/src/main/res/layout/card_game.xml
+++ b/Source/Android/app/src/main/res/layout/card_game.xml
@@ -2,7 +2,7 @@
 
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
                                     xmlns:tools="http://schemas.android.com/tools"
-                                    android:layout_width="0dp"
+                                    android:layout_width="match_parent"
                                     tools:layout_width="224dp"
                                     android:layout_height="256dp"
                                     android:transitionName="card_game"


### PR DESCRIPTION
There was a bug in the RecyclerView library when I wrote this screen that needed this workaround. They've since fixed it, so we can now use a more appropriate value here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4325)
<!-- Reviewable:end -->
