### PR TITLE
Don't build Vulkan video backend on macOS

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -236,7 +236,6 @@ set(LIBS
 	sfml-network
 	sfml-system
 	videonull
-	videovulkan
 	videoogl
 	videosoftware
 	z
@@ -248,6 +247,10 @@ if(LIBUSB_FOUND)
 	set(SRCS	${SRCS}	IPC_HLE/WII_IPC_HLE_Device_hid.cpp
 	        	       	IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp)
 endif(LIBUSB_FOUND)
+
+if(NOT APPLE)
+	set(LIBS ${LIBS} videovulkan)
+endif()
 
 set(LIBS ${LIBS} ${MBEDTLS_LIBRARIES})
 

--- a/Source/Core/VideoBackends/CMakeLists.txt
+++ b/Source/Core/VideoBackends/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(OGL)
 add_subdirectory(Null)
 add_subdirectory(Software)
+if(NOT APPLE)
 add_subdirectory(Vulkan)
+endif()
 # TODO: Add other backends here!

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -15,7 +15,9 @@
 #include "VideoBackends/Null/VideoBackend.h"
 #include "VideoBackends/OGL/VideoBackend.h"
 #include "VideoBackends/Software/VideoBackend.h"
+#ifndef __APPLE__
 #include "VideoBackends/Vulkan/VideoBackend.h"
+#endif
 
 #include "VideoCommon/VideoBackendBase.h"
 
@@ -49,7 +51,9 @@ void VideoBackendBase::PopulateList()
     g_available_video_backends.push_back(std::make_unique<DX12::VideoBackend>());
   }
 #endif
+#ifndef __APPLE__
   g_available_video_backends.push_back(std::make_unique<Vulkan::VideoBackend>());
+#endif
   g_available_video_backends.push_back(std::make_unique<SW::VideoSoftware>());
   g_available_video_backends.push_back(std::make_unique<Null::VideoBackend>());
 


### PR DESCRIPTION
There's no official implementation of the Vulkan API, and Dolphin isn't set-up to work with the (commercial) third-party implementation MoltenVK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4330)
<!-- Reviewable:end -->
