### PR TITLE
IPC_HLE: Send HCI commands synchronously

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
@@ -92,7 +92,6 @@ private:
   void StartTransferThread();
   void StopTransferThread();
   void TransferThread();
-  static void CommandCallback(libusb_transfer* transfer);
   static void TransferCallback(libusb_transfer* transfer);
 };
 


### PR DESCRIPTION
This may theoretically cause frame drops if the transfer takes too much time to complete, but this improves the stability of Bluetooth connections in some games (such as Skyward Sword which repeatedly send the same command, at a rate that some adapters can't keep up with) and prevents disconnection issues or command timeouts (which cause games to drop packets for a while and make games unplayable).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4331)
<!-- Reviewable:end -->
