### PR TITLE
ConfigManager: Sync Dolphin settings to SYSCONF on exit

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -86,6 +86,7 @@ void SConfig::Shutdown()
 SConfig::~SConfig()
 {
   SaveSettings();
+  SaveSettingsToSysconf();
 }
 
 void SConfig::SaveSettings()


### PR DESCRIPTION
#4319 made Dolphin not read/write directly to the SYSCONF and read settings from the SYSCONF at boot, and only write Dolphin settings to the SYSCONF at emulation startup.

However, this also made it a bit confusing, because if settings were changed, then Dolphin was exited without starting a game in between, the settings wouldn't actually get persisted. This is fixed by syncing Dolphin settings with the SYSCONF when Dolphin exits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4332)
<!-- Reviewable:end -->
