### PR TITLE
[WIP] Make a JumpToAdress event for the debugger code window

### DIFF
--- a/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/BreakpointWindow.cpp
@@ -130,7 +130,11 @@ void CBreakPointWindow::OnSelectBP(wxListEvent& event)
   {
     u32 Address = (u32)m_BreakPointListView->GetItemData(Index);
     if (m_pCodeWindow)
-      m_pCodeWindow->JumpToAddress(Address);
+    {
+      wxCommandEvent ev(wxEVT_JUMPTO_ADDRESS);
+      ev.SetString(wxString::Format("%08x", Address));
+      m_pCodeWindow->GetEventHandler()->ProcessEvent(ev);
+    }
   }
 }
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -52,6 +52,8 @@
 #include "DolphinWX/Globals.h"
 #include "DolphinWX/WxUtils.h"
 
+wxDEFINE_EVENT(wxEVT_JUMPTO_ADDRESS, wxCommandEvent);
+
 CCodeWindow::CCodeWindow(const SConfig& _LocalCoreStartupParameter, CFrame* parent, wxWindowID id,
                          const wxPoint& position, const wxSize& size, long style,
                          const wxString& name)
@@ -128,6 +130,7 @@ CCodeWindow::CCodeWindow(const SConfig& _LocalCoreStartupParameter, CFrame* pare
 
   // Other
   Bind(wxEVT_HOST_COMMAND, &CCodeWindow::OnHostMessage, this);
+  Bind(wxEVT_JUMPTO_ADDRESS, &CCodeWindow::OnJumpToAddress, this);
 }
 
 CCodeWindow::~CCodeWindow()
@@ -160,6 +163,7 @@ void CCodeWindow::OnHostMessage(wxCommandEvent& event)
 
   case IDM_UPDATE_DISASM_DIALOG:
     Repopulate();
+    JumpToAddress(PC);
     if (HasPanel<CRegisterWindow>())
       GetPanel<CRegisterWindow>()->NotifyUpdate();
     if (HasPanel<CWatchWindow>())
@@ -180,6 +184,13 @@ void CCodeWindow::OnHostMessage(wxCommandEvent& event)
     RequirePanel<CJitWindow>()->ViewAddr(codeview->GetSelection());
     break;
   }
+}
+
+void CCodeWindow::OnJumpToAddress(wxCommandEvent& event)
+{
+  unsigned long address;
+  event.GetString().ToCULong(&address, 16);
+  JumpToAddress(static_cast<u32>(address));
 }
 
 // The Play, Stop, Step, Skip, Go to PC and Show PC buttons go here
@@ -205,11 +216,13 @@ void CCodeWindow::OnCodeStep(wxCommandEvent& event)
 
   case IDM_SKIP:
     PC += 4;
+    JumpToAddress(PC);
     Repopulate();
     break;
 
   case IDM_SETPC:
     PC = codeview->GetSelection();
+    JumpToAddress(PC);
     Repopulate();
     break;
 
@@ -610,7 +623,6 @@ void CCodeWindow::Repopulate()
   if (!codeview)
     return;
 
-  codeview->Center(PC);
   UpdateCallstack();
   UpdateButtonStates();
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -31,6 +31,8 @@ class wxMenu;
 class wxMenuBar;
 class wxToolBar;
 
+wxDECLARE_EVENT(wxEVT_JUMPTO_ADDRESS, wxCommandEvent);
+
 namespace Details
 {
 template <class T>
@@ -136,6 +138,7 @@ private:
   void OnChangeFont(wxCommandEvent& event);
 
   void OnCodeStep(wxCommandEvent& event);
+  void OnJumpToAddress(wxCommandEvent& event);
   void OnAddrBoxChange(wxCommandEvent& event);
   void OnSymbolsMenu(wxCommandEvent& event);
   void OnJitMenu(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Debugger/RegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/RegisterView.cpp
@@ -513,6 +513,7 @@ void CRegisterView::OnPopupMenu(wxCommandEvent& event)
   CCodeWindow* code_window = cframe->g_pCodeWindow;
   CWatchWindow* watch_window = code_window->GetPanel<CWatchWindow>();
   CMemoryWindow* memory_window = code_window->GetPanel<CMemoryWindow>();
+  wxCommandEvent ev(wxEVT_JUMPTO_ADDRESS);
 
   switch (event.GetId())
   {
@@ -528,7 +529,8 @@ void CRegisterView::OnPopupMenu(wxCommandEvent& event)
     Refresh();
     break;
   case IDM_VIEWCODE:
-    code_window->JumpToAddress(m_selectedAddress);
+    ev.SetString(wxString::Format("%08x", m_selectedAddress));
+    code_window->GetEventHandler()->ProcessEvent(ev);
     Refresh();
     break;
   case IDM_VIEW_HEX8:


### PR DESCRIPTION
This allows other window such as the breakpoint window and the register view to fire an event to have the code window jump to a desired address instead of calling it directly from the window.  Also, it fixes a regression where adding a breakpoint via the code window causes a jump to the pc.

This is obviously not ready for merge because I was trying to figure out how events works in wxWidgets, and I couldn't propagate the event from the other window to the code window unless I call directly its handler which is not a good solution considering I am trying to avoid knowing the window exists in the first place.

@lioncash tagging you because I have some questions:

1. Should I wait your refactoring PR for this?  Because this event propagates to the CFrame and I recall you wanted to change the root to the CFrame instead of code window.  If you change the event handler to the CFrame, this could get handled and be passed to the code window.
2. Am I actually doing it the right way?  I have been a bit confused trying to figure this out and I feel I miss something out (like the fact it can't propagate).
3. Is it alright for the window itself to not fire the jump event, but instead call it directly?  I mean, I don't think there's reasons to call the event instead, but I was wondering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4333)
<!-- Reviewable:end -->
