### PR TITLE
InputConfigDialog: use SelectObjectAsSource in UpdateBitmaps

### DIFF
--- a/Source/Core/DolphinWX/InputConfigDiagBitmaps.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiagBitmaps.cpp
@@ -500,7 +500,7 @@ void InputConfigDialog::UpdateBitmaps(wxTimerEvent& WXUNUSED(event))
 
     wxBitmap bitmap(g->static_bitmap->GetBitmap());
     // NOTE: Selecting the bitmap inherits the bitmap's ScaleFactor onto the DC as well.
-    dc.SelectObject(bitmap);
+    dc.SelectObjectAsSource(bitmap);
     dc.SetBackground(*wxWHITE_BRUSH);
     dc.Clear();
 


### PR DESCRIPTION
Fixes issue: [Configuring an Emulated Wiimote crashes the application on OS X 10.12 Sierra][1]. Not sure what effect it has on other platforms.

[1]: https://bugs.dolphin-emu.org/issues/9832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4334)
<!-- Reviewable:end -->
