### PR TITLE
Android: Add custom control scaling

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -489,7 +489,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		// SharedPreference to retrieve the X and Y coordinates for the InputOverlayDrawableButton.
 		final SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 
-		// Decide scale based on button ID
+		// Decide scale based on button ID and user preference
 		float scale;
 
 		switch (buttonId)
@@ -524,6 +524,9 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 			scale = 0.125f;
 			break;
 		}
+
+		scale *= (sPrefs.getInt("controlScale", 50) + 50);
+		scale /= 100;
 
 		// Initialize the InputOverlayDrawableButton.
 		final Bitmap bitmap = resizeBitmap(context, BitmapFactory.decodeResource(res, resId), scale);
@@ -572,7 +575,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		// SharedPreference to retrieve the X and Y coordinates for the InputOverlayDrawableDpad.
 		final SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 
-		// Decide scale based on button ID
+		// Decide scale based on button ID and user preference
 		float scale;
 
 		switch (buttonUp)
@@ -587,6 +590,9 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 			scale = 0.275f;
 			break;
 		}
+
+		scale *= (sPrefs.getInt("controlScale", 50) + 50);
+		scale /= 100;
 
 		// Initialize the InputOverlayDrawableDpad.
 		final Bitmap bitmap = resizeBitmap(context, BitmapFactory.decodeResource(res, resId), scale);
@@ -632,8 +638,13 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		// SharedPreference to retrieve the X and Y coordinates for the InputOverlayDrawableJoystick.
 		final SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 
+		// Decide scale based on user preference
+		float scale = 0.275f;
+		scale *= (sPrefs.getInt("controlScale", 50) + 50);
+		scale /= 100;
+
 		// Initialize the InputOverlayDrawableJoystick.
-		final Bitmap bitmapOuter = resizeBitmap(context, BitmapFactory.decodeResource(res, resOuter), 0.275f);
+		final Bitmap bitmapOuter = resizeBitmap(context, BitmapFactory.decodeResource(res, resOuter), scale);
 		final Bitmap bitmapInner = BitmapFactory.decodeResource(res, resInner);
 
 		// The X and Y coordinates of the InputOverlayDrawableButton on the InputOverlay.
@@ -642,15 +653,15 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		int drawableY = (int) sPrefs.getFloat(joystick+"-Y", 0f);
 
 		// Decide inner scale based on joystick ID
-		float scale;
+		float innerScale;
 
 		switch (joystick)
 		{
 		case ButtonType.STICK_C:
-			scale = 1.833f;
+			innerScale = 1.833f;
 			break;
 		default:
-			scale = 1.375f;
+			innerScale = 1.375f;
 			break;
 		}
 
@@ -658,7 +669,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		// This will dictate where on the screen (and the what the size) the InputOverlayDrawableJoystick will be.
 		int outerSize = bitmapOuter.getWidth();
 		Rect outerRect = new Rect(drawableX, drawableY, drawableX + outerSize, drawableY + outerSize);
-		Rect innerRect = new Rect(0, 0, (int) (outerSize / scale), (int) (outerSize / scale));
+		Rect innerRect = new Rect(0, 0, (int) (outerSize / innerScale), (int) (outerSize / innerScale));
 
 		// Send the drawableId to the joystick so it can be referenced when saving control position.
 		final InputOverlayDrawableJoystick overlayDrawable

--- a/Source/Android/app/src/main/res/layout/dialog_seekbar.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_seekbar.xml
@@ -9,12 +9,12 @@
         android:id="@+id/seekbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/spacing_xlarge"
-        android:layout_marginRight="@dimen/spacing_xlarge"
+        android:layout_marginLeft="@dimen/spacing_large"
+        android:layout_marginRight="@dimen/spacing_large"
         android:layout_alignParentEnd="true"
         android:layout_alignParentStart="true"
         android:layout_below="@+id/text_value"
-        android:layout_marginBottom="@dimen/spacing_xlarge"/>
+        android:layout_marginBottom="@dimen/spacing_medlarge"/>
 
     <TextView
         android:layout_width="wrap_content"
@@ -23,8 +23,8 @@
         android:id="@+id/text_value"
         android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true"
-        android:layout_marginTop="@dimen/spacing_xlarge"
-        android:layout_marginBottom="@dimen/spacing_large"/>
+        android:layout_marginTop="@dimen/spacing_medlarge"
+        android:layout_marginBottom="@dimen/spacing_medlarge"/>
 
     <TextView
         android:layout_width="wrap_content"

--- a/Source/Android/app/src/main/res/menu/menu_emulation.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation.xml
@@ -25,18 +25,6 @@
         android:title="@string/emulation_quickload"
         />
 
-    <!-- Enable/Disable Input Overlay -->
-    <item
-        android:id="@+id/menu_emulation_input_overlay"
-        android:showAsAction="never"
-        android:title="@string/emulation_toggle_input"/>
-
-    <item
-        android:id="@+id/menu_emulation_configure_controls"
-        android:showAsAction="never"
-        android:title="@string/emulation_configure_controls">
-        </item>
-
     <!-- Save State Slots -->
     <item
         android:id="@+id/menu_emulation_save_root"
@@ -90,6 +78,25 @@
             <item
                 android:id="@+id/menu_emulation_load_5"
                 android:title="@string/overlay_slot5"/>
+        </menu>
+    </item>
+
+    <item
+        android:id="@+id/menu_emulation_configure_controls"
+        android:showAsAction="never"
+        android:title="@string/emulation_configure_controls">
+        <menu>
+            <item
+                android:id="@+id/menu_emulation_edit_layout"
+                android:title="@string/emulation_edit_layout"/>
+
+            <item
+                android:id="@+id/menu_emulation_toggle_controls"
+                android:title="@string/emulation_toggle_controls"/>
+
+            <item
+                android:id="@+id/menu_emulation_adjust_scale"
+                android:title="@string/emulation_control_scale"/>
         </menu>
     </item>
 </menu>

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -211,7 +211,7 @@
         <item>2</item>
         <item>+</item>
         <item>-</item>
-	<item>Home</item>
+        <item>Home</item>
         <item>C</item>
         <item>Z</item>
         <item>D-Pad</item>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -355,13 +355,15 @@
     <string name="dialog_seekbar_neg">Cancel</string>
 
     <!-- Emulation Menu -->
-    <string name="emulation_toggle_input">Toggle Touch Controls</string>
-    <string name="emulation_toggle_all">Toggle All</string>
     <string name="emulation_quicksave">Quick Save</string>
     <string name="emulation_quickload">Quick Load</string>
     <string name="emulation_refresh_wiimotes">Refresh Wiimotes</string>
     <string name="emulation_configure_controls">Configure Controls</string>
+    <string name="emulation_edit_layout">Edit Layout</string>
     <string name="emulation_done">Done</string>
+    <string name="emulation_toggle_controls">Toggle Controls</string>
+    <string name="emulation_toggle_all">Toggle All</string>
+    <string name="emulation_control_scale">Adjust Scale</string>
     
     <!-- GC Adapter Menu-->
     <string name="gc_adapter_rumble">Enable Vibration</string>


### PR DESCRIPTION
This allows scaling the on-screen buttons from the default size (100%) to anything between 50-200%. I also moved all the touch control-related settings under a "Configure Controls" submenu so the in-game menu isn't so cluttered.

Now for some screenshots:
The setting: https://i.imgur.com/EZnu0Ma.png
50% controls: https://i.imgur.com/Qvys44I.png
200% controls: https://i.imgur.com/IKNP6zB.png

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4335)
<!-- Reviewable:end -->
