### PR TITLE
AVIDump: Move CoreTiming into caller.

### DIFF
--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -119,7 +119,7 @@ static void IPC_HLE_UpdateCallback(u64 userdata, s64 cyclesLate)
 
 static void VICallback(u64 userdata, s64 cyclesLate)
 {
-  VideoInterface::Update();
+  VideoInterface::Update(CoreTiming::GetTicks() - cyclesLate);
   CoreTiming::ScheduleEvent(VideoInterface::GetTicksPerHalfLine() - cyclesLate, et_VI);
 }
 

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -638,7 +638,7 @@ u32 GetTicksPerField()
   return GetTicksPerEvenField();
 }
 
-static void BeginField(FieldType field)
+static void BeginField(FieldType field, u64 ticks)
 {
   // Could we fit a second line of data in the stride?
   bool potentially_interlaced_xfb =
@@ -707,7 +707,7 @@ static void BeginField(FieldType field)
   // To correctly handle that case we would need to collate all changes
   // to VI during scanout and delay outputting the frame till then.
   if (xfbAddr)
-    g_video_backend->Video_BeginField(xfbAddr, fbWidth, fbStride, fbHeight);
+    g_video_backend->Video_BeginField(xfbAddr, fbWidth, fbStride, fbHeight, ticks);
 }
 
 static void EndField()
@@ -717,7 +717,7 @@ static void EndField()
 
 // Purpose: Send VI interrupt when triggered
 // Run when: When a frame is scanned (progressive/interlace)
-void Update()
+void Update(u64 ticks)
 {
   if (s_half_line_of_next_si_poll == s_half_line_count)
   {
@@ -726,11 +726,11 @@ void Update()
   }
   if (s_half_line_count == s_even_field_first_hl)
   {
-    BeginField(FIELD_EVEN);
+    BeginField(FIELD_EVEN, ticks);
   }
   else if (s_half_line_count == s_odd_field_first_hl)
   {
-    BeginField(FIELD_ODD);
+    BeginField(FIELD_ODD, ticks);
   }
   else if (s_half_line_count == s_even_field_last_hl)
   {

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -337,7 +337,7 @@ u32 GetXFBAddressTop();
 u32 GetXFBAddressBottom();
 
 // Update and draw framebuffer
-void Update();
+void Update(u64 ticks);
 
 // UpdateInterrupts: check if we have to generate a new VI Interrupt
 void UpdateInterrupts();

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -713,7 +713,7 @@ void Renderer::SetBlendMode(bool forceUpdate)
 
 // This function has the final picture. We adjust the aspect ratio here.
 void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
-                        const EFBRectangle& rc, float Gamma)
+                        const EFBRectangle& rc, u64 ticks, float Gamma)
 {
   if ((!XFBWrited && !g_ActiveConfig.RealXFBEnabled()) || !fbWidth || !fbHeight)
   {
@@ -824,8 +824,8 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     D3D11_MAPPED_SUBRESOURCE map;
     D3D::context->Map(s_screenshot_texture, 0, D3D11_MAP_READ, 0, &map);
 
-    DumpFrameData(reinterpret_cast<const u8*>(map.pData), source_width, source_height,
-                  map.RowPitch);
+    DumpFrameData(reinterpret_cast<const u8*>(map.pData), source_width, source_height, map.RowPitch,
+                  ticks);
     FinishFrameData();
 
     D3D::context->Unmap(s_screenshot_texture, 0);

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -47,7 +47,7 @@ public:
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
-                float Gamma) override;
+                u64 ticks, float Gamma) override;
 
   void ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,
                    u32 color, u32 z) override;

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -632,7 +632,7 @@ void Renderer::SetBlendMode(bool force_update)
 
 // This function has the final picture. We adjust the aspect ratio here.
 void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height,
-                        const EFBRectangle& rc, float gamma)
+                        const EFBRectangle& rc, u64 ticks, float gamma)
 {
   if ((!XFBWrited && !g_ActiveConfig.RealXFBEnabled()) || !fb_width || !fb_height)
   {
@@ -778,7 +778,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
     CheckHR(s_screenshot_texture->Map(0, &read_range, &screenshot_texture_map));
 
     DumpFrameData(reinterpret_cast<const u8*>(screenshot_texture_map), source_width, source_height,
-                  dst_location.PlacedFootprint.Footprint.RowPitch);
+                  dst_location.PlacedFootprint.Footprint.RowPitch, ticks);
     FinishFrameData();
 
     D3D12_RANGE write_range = {};

--- a/Source/Core/VideoBackends/D3D12/Render.h
+++ b/Source/Core/VideoBackends/D3D12/Render.h
@@ -47,7 +47,7 @@ public:
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, const EFBRectangle& rc,
-                float gamma) override;
+                u64 ticks, float gamma) override;
 
   void ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha_enable, bool z_enable,
                    u32 color, u32 z) override;

--- a/Source/Core/VideoBackends/Null/Render.cpp
+++ b/Source/Core/VideoBackends/Null/Render.cpp
@@ -38,7 +38,7 @@ TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)
   return result;
 }
 
-void Renderer::SwapImpl(u32, u32, u32, u32, const EFBRectangle&, float)
+void Renderer::SwapImpl(u32, u32, u32, u32, const EFBRectangle&, u64, float)
 {
   UpdateActiveConfig();
 }

--- a/Source/Core/VideoBackends/Null/Render.h
+++ b/Source/Core/VideoBackends/Null/Render.h
@@ -23,7 +23,7 @@ public:
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, const EFBRectangle& rc,
-                float gamma) override;
+                u64 ticks, float gamma) override;
 
   void ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,
                    u32 color, u32 z) override

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1339,7 +1339,7 @@ void Renderer::SetBlendMode(bool forceUpdate)
 
 // This function has the final picture. We adjust the aspect ratio here.
 void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
-                        const EFBRectangle& rc, float Gamma)
+                        const EFBRectangle& rc, u64 ticks, float Gamma)
 {
   if (g_ogl_config.bSupportsDebug)
   {
@@ -1452,7 +1452,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                  flipped_trc.GetHeight(), GL_RGBA, GL_UNSIGNED_BYTE, image.data());
 
     DumpFrameData(image.data(), flipped_trc.GetWidth(), flipped_trc.GetHeight(),
-                  flipped_trc.GetWidth() * 4, true);
+                  flipped_trc.GetWidth() * 4, ticks, true);
     FinishFrameData();
   }
   // Finish up the current frame, print some stats

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -94,7 +94,7 @@ public:
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
-                float Gamma) override;
+                u64 ticks, float Gamma) override;
 
   void ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,
                    u32 color, u32 z) override;

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -110,7 +110,7 @@ void SWRenderer::UpdateColorTexture(EfbInterface::yuv422_packed* xfb, u32 fbWidt
 
 // Called on the GPU thread
 void SWRenderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
-                          const EFBRectangle& rc, float Gamma)
+                          const EFBRectangle& rc, u64 ticks, float Gamma)
 {
   if (g_ActiveConfig.bUseXFB)
   {

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -34,7 +34,7 @@ public:
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
-                float Gamma) override;
+                u64 ticks, float Gamma) override;
 
   void ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,
                    u32 color, u32 z) override;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -460,7 +460,7 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
 }
 
 void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height,
-                        const EFBRectangle& rc, float gamma)
+                        const EFBRectangle& rc, u64 ticks, float gamma)
 {
   // Flush any pending EFB pokes.
   m_framebuffer_mgr->FlushEFBPokes(m_state_tracker.get());
@@ -486,7 +486,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
     DumpFrameData(reinterpret_cast<const u8*>(m_screenshot_readback_texture->GetMapPointer()),
                   static_cast<int>(m_screenshot_render_texture->GetWidth()),
                   static_cast<int>(m_screenshot_render_texture->GetHeight()),
-                  static_cast<int>(m_screenshot_readback_texture->GetRowStride()));
+                  static_cast<int>(m_screenshot_readback_texture->GetRowStride()), ticks);
     FinishFrameData();
   }
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -42,7 +42,7 @@ public:
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, const EFBRectangle& rc,
-                float gamma) override;
+                u64 ticks, float gamma) override;
 
   void ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha_enable, bool z_enable,
                    u32 color, u32 z) override;

--- a/Source/Core/VideoCommon/AVIDump.h
+++ b/Source/Core/VideoCommon/AVIDump.h
@@ -12,11 +12,11 @@ private:
   static bool CreateFile();
   static void CloseFile();
   static void CheckResolution(int width, int height);
-  static void StoreFrameData(const u8* data, int width, int height, int stride);
+  static void StoreFrameData(const u8* data, int width, int height, int stride, u64 ticks);
 
 public:
   static bool Start(int w, int h);
-  static void AddFrame(const u8* data, int width, int height, int stride);
+  static void AddFrame(const u8* data, int width, int height, int stride, u64 ticks);
   static void Stop();
   static void DoState();
 };

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -135,7 +135,7 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
 
   case Event::SWAP_EVENT:
     Renderer::Swap(e.swap_event.xfbAddr, e.swap_event.fbWidth, e.swap_event.fbStride,
-                   e.swap_event.fbHeight, rc);
+                   e.swap_event.fbHeight, rc, e.time);
     break;
 
   case Event::BBOX_READ:

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -47,14 +47,15 @@ void VideoBackendBase::Video_ExitLoop()
 }
 
 // Run from the CPU thread (from VideoInterface.cpp)
-void VideoBackendBase::Video_BeginField(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight)
+void VideoBackendBase::Video_BeginField(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
+                                        u64 ticks)
 {
   if (m_initialized && g_ActiveConfig.bUseXFB && g_renderer)
   {
     Fifo::SyncGPU(Fifo::SyncGPUReason::Swap);
 
     AsyncRequests::Event e;
-    e.time = 0;
+    e.time = ticks;
     e.type = AsyncRequests::Event::SWAP_EVENT;
 
     e.swap_event.xfbAddr = xfbAddr;

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -123,9 +123,9 @@ public:
 
   // Finish up the current frame, print some stats
   static void Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
-                   float Gamma = 1.0f);
+                   u64 ticks, float Gamma = 1.0f);
   virtual void SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
-                        const EFBRectangle& rc, float Gamma = 1.0f) = 0;
+                        const EFBRectangle& rc, u64 ticks, float Gamma = 1.0f) = 0;
 
   static PEControl::PixelFormat GetPrevPixelFormat() { return prev_efb_format; }
   static void StorePixelFormat(PEControl::PixelFormat new_format) { prev_efb_format = new_format; }
@@ -146,7 +146,8 @@ protected:
   static void RecordVideoMemory();
 
   bool IsFrameDumping();
-  void DumpFrameData(const u8* data, int w, int h, int stride, bool swap_upside_down = false);
+  void DumpFrameData(const u8* data, int w, int h, int stride, u64 ticks,
+                     bool swap_upside_down = false);
   void FinishFrameData();
 
   static volatile bool s_bScreenshot;

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -75,7 +75,7 @@ public:
   void Video_ExitLoop();
   virtual void Video_Cleanup() = 0;  // called from gl/d3d thread
 
-  void Video_BeginField(u32, u32, u32, u32);
+  void Video_BeginField(u32, u32, u32, u32, u64);
 
   u32 Video_AccessEFB(EFBAccessType, u32, u32, u32);
   u32 Video_GetQueryResult(PerfQueryType type);


### PR DESCRIPTION
This makes predictable timings in dual core. But XFB needs to be enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4337)
<!-- Reviewable:end -->
