### PR TITLE
DolphinWX: Move debugger menu item creation to CFrame

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -459,110 +459,6 @@ void CCodeWindow::UpdateCallstack()
     callstack->Append(StrToWxStr("invalid callstack"));
 }
 
-// Create CPU Mode menus
-void CCodeWindow::CreateMenu(const SConfig& core_startup_parameter, wxMenuBar* pMenuBar)
-{
-  // CPU Mode
-  wxMenu* pCoreMenu = new wxMenu;
-
-  wxMenuItem* interpreter = pCoreMenu->Append(
-      IDM_INTERPRETER, _("&Interpreter Core"),
-      _("This is necessary to get break points"
-        " and stepping to work as explained in the Developer Documentation. But it can be very"
-        " slow, perhaps slower than 1 fps."),
-      wxITEM_CHECK);
-  interpreter->Check(core_startup_parameter.iCPUCore == PowerPC::CORE_INTERPRETER);
-  pCoreMenu->AppendSeparator();
-
-  pCoreMenu->Append(IDM_JIT_NO_BLOCK_LINKING, _("&JIT Block Linking Off"),
-                    _("Provide safer execution by not linking the JIT blocks."), wxITEM_CHECK);
-
-  pCoreMenu->Append(IDM_JIT_NO_BLOCK_CACHE, _("&Disable JIT Cache"),
-                    _("Avoid any involuntary JIT cache clearing, this may prevent Zelda TP from "
-                      "crashing.\n[This option must be selected before a game is started.]"),
-                    wxITEM_CHECK);
-  pCoreMenu->Append(IDM_CLEAR_CODE_CACHE, _("&Clear JIT Cache"));
-
-  pCoreMenu->AppendSeparator();
-  pCoreMenu->Append(IDM_LOG_INSTRUCTIONS, _("&Log JIT Instruction Coverage"));
-  pCoreMenu->Append(IDM_SEARCH_INSTRUCTION, _("&Search for an Instruction"));
-
-  pCoreMenu->AppendSeparator();
-  pCoreMenu->Append(IDM_JIT_OFF, _("&JIT Off (JIT Core)"),
-                    _("Turn off all JIT functions, but still use the JIT core from Jit.cpp"),
-                    wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_LS_OFF, _("&JIT LoadStore Off"), wxEmptyString, wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_LSLBZX_OFF, _("    &JIT LoadStore lbzx Off"), wxEmptyString,
-                    wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_LSLXZ_OFF, _("    &JIT LoadStore lXz Off"), wxEmptyString,
-                    wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_LSLWZ_OFF, _("&JIT LoadStore lwz Off"), wxEmptyString, wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_LSF_OFF, _("&JIT LoadStore Floating Off"), wxEmptyString, wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_LSP_OFF, _("&JIT LoadStore Paired Off"), wxEmptyString, wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_FP_OFF, _("&JIT FloatingPoint Off"), wxEmptyString, wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_I_OFF, _("&JIT Integer Off"), wxEmptyString, wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_P_OFF, _("&JIT Paired Off"), wxEmptyString, wxITEM_CHECK);
-  pCoreMenu->Append(IDM_JIT_SR_OFF, _("&JIT SystemRegisters Off"), wxEmptyString, wxITEM_CHECK);
-
-  pMenuBar->Append(pCoreMenu, _("&JIT"));
-
-  // Debug Menu
-  wxMenu* pDebugMenu = new wxMenu;
-
-  pDebugMenu->Append(IDM_STEP, _("Step &Into\tF11"));
-  pDebugMenu->Append(IDM_STEPOVER, _("Step &Over\tF10"));
-  pDebugMenu->Append(IDM_STEPOUT, _("Step O&ut\tSHIFT+F11"));
-  pDebugMenu->Append(IDM_TOGGLE_BREAKPOINT, _("Toggle &Breakpoint\tF9"));
-  pDebugMenu->AppendSeparator();
-
-  wxMenu* pPerspectives = new wxMenu;
-  Parent->m_SavedPerspectives = new wxMenu;
-  pDebugMenu->AppendSubMenu(pPerspectives, _("Perspectives"), _("Edit Perspectives"));
-  pPerspectives->Append(IDM_SAVE_PERSPECTIVE, _("Save Perspectives"),
-                        _("Save currently-toggled perspectives"));
-  pPerspectives->Append(IDM_EDIT_PERSPECTIVES, _("Edit Perspectives"),
-                        _("Toggle editing of perspectives"), wxITEM_CHECK);
-  pPerspectives->AppendSeparator();
-  pPerspectives->Append(IDM_ADD_PERSPECTIVE, _("Create New Perspective"));
-  pPerspectives->AppendSubMenu(Parent->m_SavedPerspectives, _("Saved Perspectives"));
-  Parent->PopulateSavedPerspectives();
-  pPerspectives->AppendSeparator();
-  wxMenu* pAddPane = new wxMenu;
-  pPerspectives->AppendSubMenu(pAddPane, _("Add New Pane To"));
-  pAddPane->Append(IDM_PERSPECTIVES_ADD_PANE_TOP, _("Top"));
-  pAddPane->Append(IDM_PERSPECTIVES_ADD_PANE_BOTTOM, _("Bottom"));
-  pAddPane->Append(IDM_PERSPECTIVES_ADD_PANE_LEFT, _("Left"));
-  pAddPane->Append(IDM_PERSPECTIVES_ADD_PANE_RIGHT, _("Right"));
-  pAddPane->Append(IDM_PERSPECTIVES_ADD_PANE_CENTER, _("Center"));
-  pPerspectives->Append(IDM_TAB_SPLIT, _("Tab Split"), "", wxITEM_CHECK);
-  pPerspectives->Append(IDM_NO_DOCKING, _("Disable Docking"),
-                        "Disable docking of perspective panes to main window", wxITEM_CHECK);
-
-  pMenuBar->Append(pDebugMenu, _("&Debug"));
-
-  CreateMenuSymbols(pMenuBar);
-}
-
-void CCodeWindow::CreateMenuOptions(wxMenu* pMenu)
-{
-  wxMenuItem* boottopause =
-      pMenu->Append(IDM_BOOT_TO_PAUSE, _("Boot to Pause"),
-                    _("Start the game directly instead of booting to pause"), wxITEM_CHECK);
-  boottopause->Check(bBootToPause);
-
-  wxMenuItem* automaticstart = pMenu->Append(
-      IDM_AUTOMATIC_START, _("&Automatic Start"),
-      _("Automatically load the Default ISO when Dolphin starts, or the last game you loaded,"
-        " if you have not given it an elf file with the --elf command line. [This can be"
-        " convenient if you are bug-testing with a certain game and want to rebuild"
-        " and retry it several times, either with changes to Dolphin or if you are"
-        " developing a homebrew game.]"),
-      wxITEM_CHECK);
-  automaticstart->Check(bAutomaticStart);
-
-  pMenu->Append(IDM_FONT_PICKER, _("&Font..."));
-}
-
 // CPU Mode and JIT Menu
 void CCodeWindow::OnCPUMode(wxCommandEvent& event)
 {
@@ -572,10 +468,10 @@ void CCodeWindow::OnCPUMode(wxCommandEvent& event)
     PowerPC::SetMode(UseInterpreter() ? PowerPC::MODE_INTERPRETER : PowerPC::MODE_JIT);
     break;
   case IDM_BOOT_TO_PAUSE:
-    bBootToPause = !bBootToPause;
+    SConfig::GetInstance().bBootToPause = event.IsChecked();
     return;
   case IDM_AUTOMATIC_START:
-    bAutomaticStart = !bAutomaticStart;
+    SConfig::GetInstance().bAutomaticStart = event.IsChecked();
     return;
   case IDM_JIT_OFF:
     SConfig::GetInstance().bJITOff = event.IsChecked();

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -97,9 +97,6 @@ public:
 
   void Repopulate();
   void NotifyMapLoaded();
-  void CreateMenu(const SConfig& _LocalCoreStartupParameter, wxMenuBar* pMenuBar);
-  void CreateMenuOptions(wxMenu* pMenu);
-  void CreateMenuSymbols(wxMenuBar* pMenuBar);
   void PopulateToolbar(wxToolBar* toolBar);
   void UpdateButtonStates();
   void OpenPages();
@@ -130,8 +127,6 @@ public:
   }
 
   // Settings
-  bool bAutomaticStart;
-  bool bBootToPause;
   bool bShowOnStart[IDM_DEBUG_WINDOW_LIST_END - IDM_DEBUG_WINDOW_LIST_START];
   int iNbAffiliation[IDM_DEBUG_WINDOW_LIST_END - IDM_DEBUG_WINDOW_LIST_START];
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -56,10 +56,12 @@ void CCodeWindow::Load()
   // The font to override DebuggerFont with
   std::string fontDesc;
 
+  auto& config_instance = SConfig::GetInstance();
+
   IniFile::Section* general = ini.GetOrCreateSection("General");
   general->Get("DebuggerFont", &fontDesc);
-  general->Get("AutomaticStart", &bAutomaticStart, false);
-  general->Get("BootToPause", &bBootToPause, true);
+  general->Get("AutomaticStart", &config_instance.bAutomaticStart, false);
+  general->Get("BootToPause", &config_instance.bBootToPause, true);
 
   if (!fontDesc.empty())
     DebuggerFont.SetNativeFontInfoUserDesc(StrToWxStr(fontDesc));
@@ -113,68 +115,6 @@ void CCodeWindow::Save()
                                          !!FindWindowById(i));
 
   ini.Save(File::GetUserPath(F_DEBUGGERCONFIG_IDX));
-}
-
-// Symbols, JIT, Profiler
-// ----------------
-void CCodeWindow::CreateMenuSymbols(wxMenuBar* pMenuBar)
-{
-  wxMenu* pSymbolsMenu = new wxMenu;
-  pSymbolsMenu->Append(IDM_CLEAR_SYMBOLS, _("&Clear Symbols"),
-                       _("Remove names from all functions and variables."));
-  pSymbolsMenu->Append(IDM_SCAN_FUNCTIONS, _("&Generate Symbol Map"),
-                       _("Recognise standard functions from sys\\totaldb.dsy, and use generic zz_ "
-                         "names for other functions."));
-  pSymbolsMenu->AppendSeparator();
-  pSymbolsMenu->Append(IDM_LOAD_MAP_FILE, _("&Load Symbol Map"),
-                       _("Try to load this game's function names automatically - but doesn't check "
-                         ".map files stored on the disc image yet."));
-  pSymbolsMenu->Append(IDM_SAVEMAPFILE, _("&Save Symbol Map"),
-                       _("Save the function names for each address to a .map file in your user "
-                         "settings map folder, named after the title id."));
-  pSymbolsMenu->AppendSeparator();
-  pSymbolsMenu->Append(
-      IDM_LOAD_MAP_FILE_AS, _("Load &Other Map File..."),
-      _("Load any .map file containing the function names and addresses for this game."));
-  pSymbolsMenu->Append(
-      IDM_LOAD_BAD_MAP_FILE, _("Load &Bad Map File..."),
-      _("Try to load a .map file that might be from a slightly different version."));
-  pSymbolsMenu->Append(IDM_SAVE_MAP_FILE_AS, _("Save Symbol Map &As..."),
-                       _("Save the function names and addresses for this game as a .map file. If "
-                         "you want to open it in IDA pro, use the .idc script."));
-  pSymbolsMenu->AppendSeparator();
-  pSymbolsMenu->Append(
-      IDM_SAVE_MAP_FILE_WITH_CODES, _("Save Code"),
-      _("Save the entire disassembled code. This may take a several seconds"
-        " and may require between 50 and 100 MB of hard drive space. It will only save code"
-        " that are in the first 4 MB of memory, if you are debugging a game that load .rel"
-        " files with code to memory you may want to increase that to perhaps 8 MB, you can do"
-        " that from SymbolDB::SaveMap()."));
-
-  pSymbolsMenu->AppendSeparator();
-  pSymbolsMenu->Append(
-      IDM_CREATE_SIGNATURE_FILE, _("&Create Signature File..."),
-      _("Create a .dsy file that can be used to recognise these same functions in other games."));
-  pSymbolsMenu->Append(IDM_APPEND_SIGNATURE_FILE, _("Append to &Existing Signature File..."),
-                       _("Add any named functions missing from a .dsy file, so it can also "
-                         "recognise these additional functions in other games."));
-  pSymbolsMenu->Append(IDM_COMBINE_SIGNATURE_FILES, _("Combine Two Signature Files..."),
-                       _("Make a new .dsy file which can recognise more functions, by combining "
-                         "two existing files. The first input file has priority."));
-  pSymbolsMenu->Append(
-      IDM_USE_SIGNATURE_FILE, _("Apply Signat&ure File..."),
-      _("Must use Generate symbol map first! Recognise names of any standard library functions "
-        "used in multiple games, by loading them from a .dsy file."));
-  pSymbolsMenu->AppendSeparator();
-  pSymbolsMenu->Append(IDM_PATCH_HLE_FUNCTIONS, _("&Patch HLE Functions"));
-  pSymbolsMenu->Append(IDM_RENAME_SYMBOLS, _("&Rename Symbols from File..."));
-  pMenuBar->Append(pSymbolsMenu, _("&Symbols"));
-
-  wxMenu* pProfilerMenu = new wxMenu;
-  pProfilerMenu->Append(IDM_PROFILE_BLOCKS, _("&Profile Blocks"), wxEmptyString, wxITEM_CHECK);
-  pProfilerMenu->AppendSeparator();
-  pProfilerMenu->Append(IDM_WRITE_PROFILE, _("&Write to profile.txt, Show"));
-  pMenuBar->Append(pProfilerMenu, _("&Profiler"));
 }
 
 void CCodeWindow::OnProfilerMenu(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -401,10 +401,10 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
     GetStatusBar()->Hide();
 
   // Give it a menu bar
-  wxMenuBar* menubar_active = CreateMenu();
+  wxMenuBar* menubar_active = CreateMenuBar();
   SetMenuBar(menubar_active);
   // Create a menubar to service requests while the real menubar is hidden from the screen
-  m_menubar_shadow = CreateMenu();
+  m_menubar_shadow = CreateMenuBar();
 
   // ---------------
   // Main panel
@@ -1306,7 +1306,7 @@ void CFrame::DoFullscreen(bool enable_fullscreen)
       // Recreate the menubar if needed.
       if (wxFrame::GetMenuBar() == nullptr)
       {
-        SetMenuBar(CreateMenu());
+        SetMenuBar(CreateMenuBar());
       }
 
       // Show statusbar if enabled

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -206,6 +206,10 @@ private:
   wxMenu* CreateOptionsMenu();
   wxMenu* CreateToolsMenu();
   wxMenu* CreateViewMenu();
+  wxMenu* CreateJITMenu();
+  wxMenu* CreateDebugMenu();
+  wxMenu* CreateSymbolsMenu();
+  wxMenu* CreateProfilerMenu();
   wxMenu* CreateHelpMenu();
 
   // Utility

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -199,7 +199,14 @@ private:
 
   void PopulateToolbar(wxToolBar* toolBar);
   void RecreateToolbar();
-  wxMenuBar* CreateMenu();
+  wxMenuBar* CreateMenuBar();
+  wxMenu* CreateFileMenu();
+  wxMenu* CreateEmulationMenu();
+  wxMenu* CreateMovieMenu();
+  wxMenu* CreateOptionsMenu();
+  wxMenu* CreateToolsMenu();
+  wxMenu* CreateViewMenu();
+  wxMenu* CreateHelpMenu();
 
   // Utility
   wxString GetMenuLabel(int Id);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -101,156 +101,247 @@ const wxSize& CFrame::GetToolbarBitmapSize() const
 
 // Create menu items
 // ---------------------
-wxMenuBar* CFrame::CreateMenu()
+wxMenuBar* CFrame::CreateMenuBar()
 {
-  wxMenuBar* menubar = new wxMenuBar();
+  auto* const menu_bar = new wxMenuBar;
+  menu_bar->Append(CreateFileMenu(), _("&File"));
+  menu_bar->Append(CreateEmulationMenu(), _("&Emulation"));
+  menu_bar->Append(CreateMovieMenu(), _("&Movie"));
+  menu_bar->Append(CreateOptionsMenu(), _("&Options"));
+  menu_bar->Append(CreateToolsMenu(), _("&Tools"));
+  menu_bar->Append(CreateViewMenu(), _("&View"));
 
-  // file menu
-  wxMenu* fileMenu = new wxMenu;
-  fileMenu->Append(wxID_OPEN, GetMenuLabel(HK_OPEN));
-  fileMenu->Append(IDM_CHANGE_DISC, GetMenuLabel(HK_CHANGE_DISC));
+  if (g_pCodeWindow)
+  {
+    g_pCodeWindow->CreateMenu(SConfig::GetInstance(), menu_bar);
+  }
 
-  wxMenu* externalDrive = new wxMenu;
-  fileMenu->Append(IDM_DRIVES, _("&Boot from DVD Backup"), externalDrive);
+  menu_bar->Append(CreateHelpMenu(), _("&Help"));
+
+  return menu_bar;
+}
+
+wxMenu* CFrame::CreateFileMenu()
+{
+  auto* const external_drive_menu = new wxMenu;
 
   drives = cdio_get_devices();
   // Windows Limitation of 24 character drives
   for (unsigned int i = 0; i < drives.size() && i < 24; i++)
   {
-    externalDrive->Append(IDM_DRIVE1 + i, StrToWxStr(drives[i]));
+    external_drive_menu->Append(IDM_DRIVE1 + i, StrToWxStr(drives[i]));
   }
 
-  fileMenu->AppendSeparator();
-  fileMenu->Append(wxID_REFRESH, GetMenuLabel(HK_REFRESH_LIST));
-  fileMenu->AppendSeparator();
-  fileMenu->Append(wxID_EXIT, _("E&xit") + wxString("\tAlt+F4"));
-  menubar->Append(fileMenu, _("&File"));
+  auto* const file_menu = new wxMenu;
+  file_menu->Append(wxID_OPEN, GetMenuLabel(HK_OPEN));
+  file_menu->Append(IDM_CHANGE_DISC, GetMenuLabel(HK_CHANGE_DISC));
+  file_menu->Append(IDM_DRIVES, _("&Boot from DVD Backup"), external_drive_menu);
+  file_menu->AppendSeparator();
+  file_menu->Append(wxID_REFRESH, GetMenuLabel(HK_REFRESH_LIST));
+  file_menu->AppendSeparator();
+  file_menu->Append(wxID_EXIT, _("E&xit") + "\tAlt+F4");
 
-  // Emulation menu
-  wxMenu* emulationMenu = new wxMenu;
-  emulationMenu->Append(IDM_PLAY, GetMenuLabel(HK_PLAY_PAUSE));
-  emulationMenu->Append(IDM_STOP, GetMenuLabel(HK_STOP));
-  emulationMenu->Append(IDM_RESET, GetMenuLabel(HK_RESET));
-  emulationMenu->AppendSeparator();
-  emulationMenu->Append(IDM_TOGGLE_FULLSCREEN, GetMenuLabel(HK_FULLSCREEN));
-  emulationMenu->Append(IDM_FRAMESTEP, GetMenuLabel(HK_FRAME_ADVANCE), wxEmptyString);
+  return file_menu;
+}
 
-  emulationMenu->AppendSeparator();
-  emulationMenu->Append(IDM_SCREENSHOT, GetMenuLabel(HK_SCREENSHOT));
+wxMenu* CFrame::CreateEmulationMenu()
+{
+  auto* const load_state_menu = new wxMenu;
+  load_state_menu->Append(IDM_LOAD_STATE_FILE, GetMenuLabel(HK_LOAD_STATE_FILE));
+  load_state_menu->Append(IDM_LOAD_SELECTED_SLOT, GetMenuLabel(HK_LOAD_STATE_SLOT_SELECTED));
+  load_state_menu->Append(IDM_UNDO_LOAD_STATE, GetMenuLabel(HK_UNDO_LOAD_STATE));
+  load_state_menu->AppendSeparator();
 
-  emulationMenu->AppendSeparator();
-  wxMenu* saveMenu = new wxMenu;
-  wxMenu* loadMenu = new wxMenu;
-  wxMenu* slotSelectMenu = new wxMenu;
-  emulationMenu->Append(IDM_LOAD_STATE, _("&Load State"), loadMenu);
-  emulationMenu->Append(IDM_SAVE_STATE, _("Sa&ve State"), saveMenu);
-  emulationMenu->Append(IDM_SELECT_SLOT, _("Select State Slot"), slotSelectMenu);
+  auto* const save_state_menu = new wxMenu;
+  save_state_menu->Append(IDM_SAVE_STATE_FILE, GetMenuLabel(HK_SAVE_STATE_FILE));
+  save_state_menu->Append(IDM_SAVE_SELECTED_SLOT, GetMenuLabel(HK_SAVE_STATE_SLOT_SELECTED));
+  save_state_menu->Append(IDM_SAVE_FIRST_STATE, GetMenuLabel(HK_SAVE_FIRST_STATE));
+  save_state_menu->Append(IDM_UNDO_SAVE_STATE, GetMenuLabel(HK_UNDO_SAVE_STATE));
+  save_state_menu->AppendSeparator();
 
-  saveMenu->Append(IDM_SAVE_STATE_FILE, GetMenuLabel(HK_SAVE_STATE_FILE));
-  saveMenu->Append(IDM_SAVE_SELECTED_SLOT, GetMenuLabel(HK_SAVE_STATE_SLOT_SELECTED));
-  saveMenu->Append(IDM_SAVE_FIRST_STATE, GetMenuLabel(HK_SAVE_FIRST_STATE));
-  saveMenu->Append(IDM_UNDO_SAVE_STATE, GetMenuLabel(HK_UNDO_SAVE_STATE));
-  saveMenu->AppendSeparator();
-
-  loadMenu->Append(IDM_LOAD_STATE_FILE, GetMenuLabel(HK_LOAD_STATE_FILE));
-  loadMenu->Append(IDM_LOAD_SELECTED_SLOT, GetMenuLabel(HK_LOAD_STATE_SLOT_SELECTED));
-  loadMenu->Append(IDM_UNDO_LOAD_STATE, GetMenuLabel(HK_UNDO_LOAD_STATE));
-  loadMenu->AppendSeparator();
+  auto* const slot_select_menu = new wxMenu;
 
   for (unsigned int i = 0; i < State::NUM_STATES; i++)
   {
-    loadMenu->Append(IDM_LOAD_SLOT_1 + i, GetMenuLabel(HK_LOAD_STATE_SLOT_1 + i));
-    saveMenu->Append(IDM_SAVE_SLOT_1 + i, GetMenuLabel(HK_SAVE_STATE_SLOT_1 + i));
-    slotSelectMenu->Append(IDM_SELECT_SLOT_1 + i, GetMenuLabel(HK_SELECT_STATE_SLOT_1 + i));
+    load_state_menu->Append(IDM_LOAD_SLOT_1 + i, GetMenuLabel(HK_LOAD_STATE_SLOT_1 + i));
+    save_state_menu->Append(IDM_SAVE_SLOT_1 + i, GetMenuLabel(HK_SAVE_STATE_SLOT_1 + i));
+    slot_select_menu->Append(IDM_SELECT_SLOT_1 + i, GetMenuLabel(HK_SELECT_STATE_SLOT_1 + i));
   }
 
-  loadMenu->AppendSeparator();
+  load_state_menu->AppendSeparator();
   for (unsigned int i = 0; i < State::NUM_STATES; i++)
-    loadMenu->Append(IDM_LOAD_LAST_1 + i, GetMenuLabel(HK_LOAD_LAST_STATE_1 + i));
+    load_state_menu->Append(IDM_LOAD_LAST_1 + i, GetMenuLabel(HK_LOAD_LAST_STATE_1 + i));
 
-  menubar->Append(emulationMenu, _("&Emulation"));
+  auto* const emulation_menu = new wxMenu;
+  emulation_menu->Append(IDM_PLAY, GetMenuLabel(HK_PLAY_PAUSE));
+  emulation_menu->Append(IDM_STOP, GetMenuLabel(HK_STOP));
+  emulation_menu->Append(IDM_RESET, GetMenuLabel(HK_RESET));
+  emulation_menu->AppendSeparator();
+  emulation_menu->Append(IDM_TOGGLE_FULLSCREEN, GetMenuLabel(HK_FULLSCREEN));
+  emulation_menu->Append(IDM_FRAMESTEP, GetMenuLabel(HK_FRAME_ADVANCE));
+  emulation_menu->AppendSeparator();
+  emulation_menu->Append(IDM_SCREENSHOT, GetMenuLabel(HK_SCREENSHOT));
+  emulation_menu->AppendSeparator();
+  emulation_menu->Append(IDM_LOAD_STATE, _("&Load State"), load_state_menu);
+  emulation_menu->Append(IDM_SAVE_STATE, _("Sa&ve State"), save_state_menu);
+  emulation_menu->Append(IDM_SELECT_SLOT, _("Select State Slot"), slot_select_menu);
 
-  // Movie menu
-  wxMenu* movieMenu = new wxMenu;
-  movieMenu->Append(IDM_RECORD, GetMenuLabel(HK_START_RECORDING));
-  movieMenu->Append(IDM_PLAY_RECORD, GetMenuLabel(HK_PLAY_RECORDING));
-  movieMenu->Append(IDM_RECORD_EXPORT, GetMenuLabel(HK_EXPORT_RECORDING));
-  movieMenu->Append(IDM_RECORD_READ_ONLY, GetMenuLabel(HK_READ_ONLY_MODE), wxEmptyString,
-                    wxITEM_CHECK);
-  movieMenu->Append(IDM_TAS_INPUT, _("TAS Input"));
-  movieMenu->AppendSeparator();
-  movieMenu->AppendCheckItem(IDM_TOGGLE_PAUSE_MOVIE, _("Pause at End of Movie"));
-  movieMenu->Check(IDM_TOGGLE_PAUSE_MOVIE, SConfig::GetInstance().m_PauseMovie);
-  movieMenu->AppendCheckItem(IDM_SHOW_LAG, _("Show Lag Counter"));
-  movieMenu->Check(IDM_SHOW_LAG, SConfig::GetInstance().m_ShowLag);
-  movieMenu->AppendCheckItem(IDM_SHOW_FRAME_COUNT, _("Show Frame Counter"));
-  movieMenu->Check(IDM_SHOW_FRAME_COUNT, SConfig::GetInstance().m_ShowFrameCount);
-  movieMenu->Check(IDM_RECORD_READ_ONLY, true);
-  movieMenu->AppendCheckItem(IDM_SHOW_INPUT_DISPLAY, _("Show Input Display"));
-  movieMenu->Check(IDM_SHOW_INPUT_DISPLAY, SConfig::GetInstance().m_ShowInputDisplay);
-  movieMenu->AppendCheckItem(IDM_SHOW_RTC_DISPLAY, _("Show System Clock"));
-  movieMenu->Check(IDM_SHOW_RTC_DISPLAY, SConfig::GetInstance().m_ShowRTC);
-  movieMenu->AppendSeparator();
-  movieMenu->AppendCheckItem(IDM_TOGGLE_DUMP_FRAMES, _("Dump Frames"));
-  movieMenu->Check(IDM_TOGGLE_DUMP_FRAMES, SConfig::GetInstance().m_DumpFrames);
-  movieMenu->AppendCheckItem(IDM_TOGGLE_DUMP_AUDIO, _("Dump Audio"));
-  movieMenu->Check(IDM_TOGGLE_DUMP_AUDIO, SConfig::GetInstance().m_DumpAudio);
-  menubar->Append(movieMenu, _("&Movie"));
+  return emulation_menu;
+}
 
-  // Options menu
-  wxMenu* pOptionsMenu = new wxMenu;
-  pOptionsMenu->Append(wxID_PREFERENCES, _("Co&nfigure..."));
-  pOptionsMenu->AppendSeparator();
-  pOptionsMenu->Append(IDM_CONFIG_GFX_BACKEND, _("&Graphics Settings"));
-  pOptionsMenu->Append(IDM_CONFIG_AUDIO, _("&Audio Settings"));
-  pOptionsMenu->Append(IDM_CONFIG_CONTROLLERS, _("&Controller Settings"));
-  pOptionsMenu->Append(IDM_CONFIG_HOTKEYS, _("&Hotkey Settings"));
+wxMenu* CFrame::CreateMovieMenu()
+{
+  auto* const movie_menu = new wxMenu;
+  const auto& config_instance = SConfig::GetInstance();
+
+  movie_menu->Append(IDM_RECORD, GetMenuLabel(HK_START_RECORDING));
+  movie_menu->Append(IDM_PLAY_RECORD, GetMenuLabel(HK_PLAY_RECORDING));
+  movie_menu->Append(IDM_RECORD_EXPORT, GetMenuLabel(HK_EXPORT_RECORDING));
+  movie_menu->AppendCheckItem(IDM_RECORD_READ_ONLY, GetMenuLabel(HK_READ_ONLY_MODE));
+  movie_menu->Append(IDM_TAS_INPUT, _("TAS Input"));
+  movie_menu->AppendSeparator();
+  movie_menu->AppendCheckItem(IDM_TOGGLE_PAUSE_MOVIE, _("Pause at End of Movie"));
+  movie_menu->Check(IDM_TOGGLE_PAUSE_MOVIE, config_instance.m_PauseMovie);
+  movie_menu->AppendCheckItem(IDM_SHOW_LAG, _("Show Lag Counter"));
+  movie_menu->Check(IDM_SHOW_LAG, config_instance.m_ShowLag);
+  movie_menu->AppendCheckItem(IDM_SHOW_FRAME_COUNT, _("Show Frame Counter"));
+  movie_menu->Check(IDM_SHOW_FRAME_COUNT, config_instance.m_ShowFrameCount);
+  movie_menu->Check(IDM_RECORD_READ_ONLY, true);
+  movie_menu->AppendCheckItem(IDM_SHOW_INPUT_DISPLAY, _("Show Input Display"));
+  movie_menu->Check(IDM_SHOW_INPUT_DISPLAY, config_instance.m_ShowInputDisplay);
+  movie_menu->AppendCheckItem(IDM_SHOW_RTC_DISPLAY, _("Show System Clock"));
+  movie_menu->Check(IDM_SHOW_RTC_DISPLAY, config_instance.m_ShowRTC);
+  movie_menu->AppendSeparator();
+  movie_menu->AppendCheckItem(IDM_TOGGLE_DUMP_FRAMES, _("Dump Frames"));
+  movie_menu->Check(IDM_TOGGLE_DUMP_FRAMES, config_instance.m_DumpFrames);
+  movie_menu->AppendCheckItem(IDM_TOGGLE_DUMP_AUDIO, _("Dump Audio"));
+  movie_menu->Check(IDM_TOGGLE_DUMP_AUDIO, config_instance.m_DumpAudio);
+
+  return movie_menu;
+}
+
+wxMenu* CFrame::CreateOptionsMenu()
+{
+  auto* const options_menu = new wxMenu;
+  options_menu->Append(wxID_PREFERENCES, _("Co&nfigure..."));
+  options_menu->AppendSeparator();
+  options_menu->Append(IDM_CONFIG_GFX_BACKEND, _("&Graphics Settings"));
+  options_menu->Append(IDM_CONFIG_AUDIO, _("&Audio Settings"));
+  options_menu->Append(IDM_CONFIG_CONTROLLERS, _("&Controller Settings"));
+  options_menu->Append(IDM_CONFIG_HOTKEYS, _("&Hotkey Settings"));
+
   if (g_pCodeWindow)
   {
-    pOptionsMenu->AppendSeparator();
-    g_pCodeWindow->CreateMenuOptions(pOptionsMenu);
+    options_menu->AppendSeparator();
+    g_pCodeWindow->CreateMenuOptions(options_menu);
   }
-  menubar->Append(pOptionsMenu, _("&Options"));
 
-  // Tools menu
-  wxMenu* toolsMenu = new wxMenu;
-  toolsMenu->Append(IDM_MEMCARD, _("&Memcard Manager (GC)"));
-  toolsMenu->Append(IDM_IMPORT_SAVE, _("Import Wii Save..."));
-  toolsMenu->Append(IDM_EXPORT_ALL_SAVE, _("Export All Wii Saves"));
-  toolsMenu->Append(IDM_CHEATS, _("&Cheat Manager"));
+  return options_menu;
+}
 
-  toolsMenu->Append(IDM_NETPLAY, _("Start &NetPlay..."));
+wxMenu* CFrame::CreateToolsMenu()
+{
+  auto* const wiimote_menu = new wxMenu;
+  wiimote_menu->AppendCheckItem(IDM_CONNECT_WIIMOTE1, GetMenuLabel(HK_WIIMOTE1_CONNECT));
+  wiimote_menu->AppendCheckItem(IDM_CONNECT_WIIMOTE2, GetMenuLabel(HK_WIIMOTE2_CONNECT));
+  wiimote_menu->AppendCheckItem(IDM_CONNECT_WIIMOTE3, GetMenuLabel(HK_WIIMOTE3_CONNECT));
+  wiimote_menu->AppendCheckItem(IDM_CONNECT_WIIMOTE4, GetMenuLabel(HK_WIIMOTE4_CONNECT));
+  wiimote_menu->AppendSeparator();
+  wiimote_menu->AppendCheckItem(IDM_CONNECT_BALANCEBOARD, GetMenuLabel(HK_BALANCEBOARD_CONNECT));
 
-  toolsMenu->Append(IDM_MENU_INSTALL_WAD, _("Install WAD..."));
-  UpdateWiiMenuChoice(toolsMenu->Append(IDM_LOAD_WII_MENU, "Dummy string to keep wxw happy"));
+  auto* const tools_menu = new wxMenu;
+  tools_menu->Append(IDM_MEMCARD, _("&Memcard Manager (GC)"));
+  tools_menu->Append(IDM_IMPORT_SAVE, _("Import Wii Save..."));
+  tools_menu->Append(IDM_EXPORT_ALL_SAVE, _("Export All Wii Saves"));
+  tools_menu->Append(IDM_CHEATS, _("&Cheat Manager"));
+  tools_menu->Append(IDM_NETPLAY, _("Start &NetPlay..."));
+  tools_menu->Append(IDM_MENU_INSTALL_WAD, _("Install WAD..."));
 
-  toolsMenu->Append(IDM_FIFOPLAYER, _("FIFO Player"));
+  UpdateWiiMenuChoice(tools_menu->Append(IDM_LOAD_WII_MENU, "Dummy string to keep wxw happy"));
 
-  toolsMenu->AppendSeparator();
-  wxMenu* wiimoteMenu = new wxMenu;
-  toolsMenu->AppendSubMenu(wiimoteMenu, _("Connect Wiimotes"));
-  wiimoteMenu->AppendCheckItem(IDM_CONNECT_WIIMOTE1, GetMenuLabel(HK_WIIMOTE1_CONNECT));
-  wiimoteMenu->AppendCheckItem(IDM_CONNECT_WIIMOTE2, GetMenuLabel(HK_WIIMOTE2_CONNECT));
-  wiimoteMenu->AppendCheckItem(IDM_CONNECT_WIIMOTE3, GetMenuLabel(HK_WIIMOTE3_CONNECT));
-  wiimoteMenu->AppendCheckItem(IDM_CONNECT_WIIMOTE4, GetMenuLabel(HK_WIIMOTE4_CONNECT));
-  wiimoteMenu->AppendSeparator();
-  wiimoteMenu->AppendCheckItem(IDM_CONNECT_BALANCEBOARD, GetMenuLabel(HK_BALANCEBOARD_CONNECT));
+  tools_menu->Append(IDM_FIFOPLAYER, _("FIFO Player"));
+  tools_menu->AppendSeparator();
+  tools_menu->AppendSubMenu(wiimote_menu, _("Connect Wiimotes"));
 
-  menubar->Append(toolsMenu, _("&Tools"));
+  return tools_menu;
+}
 
-  wxMenu* viewMenu = new wxMenu;
-  viewMenu->AppendCheckItem(IDM_TOGGLE_TOOLBAR, _("Show &Toolbar"));
-  viewMenu->Check(IDM_TOGGLE_TOOLBAR, SConfig::GetInstance().m_InterfaceToolbar);
-  viewMenu->AppendCheckItem(IDM_TOGGLE_STATUSBAR, _("Show &Status Bar"));
-  viewMenu->Check(IDM_TOGGLE_STATUSBAR, SConfig::GetInstance().m_InterfaceStatusbar);
-  viewMenu->AppendSeparator();
-  viewMenu->AppendCheckItem(IDM_LOG_WINDOW, _("Show &Log"));
-  viewMenu->AppendCheckItem(IDM_LOG_CONFIG_WINDOW, _("Show Log &Configuration"));
-  viewMenu->AppendSeparator();
+wxMenu* CFrame::CreateViewMenu()
+{
+  const auto& config_instance = SConfig::GetInstance();
+
+  auto* const platform_menu = new wxMenu;
+  platform_menu->AppendCheckItem(IDM_LIST_WII, _("Show Wii"));
+  platform_menu->Check(IDM_LIST_WII, config_instance.m_ListWii);
+  platform_menu->AppendCheckItem(IDM_LIST_GC, _("Show GameCube"));
+  platform_menu->Check(IDM_LIST_GC, config_instance.m_ListGC);
+  platform_menu->AppendCheckItem(IDM_LIST_WAD, _("Show WAD"));
+  platform_menu->Check(IDM_LIST_WAD, config_instance.m_ListWad);
+  platform_menu->AppendCheckItem(IDM_LIST_ELFDOL, _("Show ELF/DOL"));
+  platform_menu->Check(IDM_LIST_ELFDOL, config_instance.m_ListElfDol);
+
+  auto* const region_menu = new wxMenu;
+  region_menu->AppendCheckItem(IDM_LIST_JAP, _("Show JAP"));
+  region_menu->Check(IDM_LIST_JAP, config_instance.m_ListJap);
+  region_menu->AppendCheckItem(IDM_LIST_PAL, _("Show PAL"));
+  region_menu->Check(IDM_LIST_PAL, config_instance.m_ListPal);
+  region_menu->AppendCheckItem(IDM_LIST_USA, _("Show USA"));
+  region_menu->Check(IDM_LIST_USA, config_instance.m_ListUsa);
+  region_menu->AppendSeparator();
+  region_menu->AppendCheckItem(IDM_LIST_AUSTRALIA, _("Show Australia"));
+  region_menu->Check(IDM_LIST_AUSTRALIA, config_instance.m_ListAustralia);
+  region_menu->AppendCheckItem(IDM_LIST_FRANCE, _("Show France"));
+  region_menu->Check(IDM_LIST_FRANCE, config_instance.m_ListFrance);
+  region_menu->AppendCheckItem(IDM_LIST_GERMANY, _("Show Germany"));
+  region_menu->Check(IDM_LIST_GERMANY, config_instance.m_ListGermany);
+  region_menu->AppendCheckItem(IDM_LIST_ITALY, _("Show Italy"));
+  region_menu->Check(IDM_LIST_ITALY, config_instance.m_ListItaly);
+  region_menu->AppendCheckItem(IDM_LIST_KOREA, _("Show Korea"));
+  region_menu->Check(IDM_LIST_KOREA, config_instance.m_ListKorea);
+  region_menu->AppendCheckItem(IDM_LIST_NETHERLANDS, _("Show Netherlands"));
+  region_menu->Check(IDM_LIST_NETHERLANDS, config_instance.m_ListNetherlands);
+  region_menu->AppendCheckItem(IDM_LIST_RUSSIA, _("Show Russia"));
+  region_menu->Check(IDM_LIST_RUSSIA, config_instance.m_ListRussia);
+  region_menu->AppendCheckItem(IDM_LIST_SPAIN, _("Show Spain"));
+  region_menu->Check(IDM_LIST_SPAIN, config_instance.m_ListSpain);
+  region_menu->AppendCheckItem(IDM_LIST_TAIWAN, _("Show Taiwan"));
+  region_menu->Check(IDM_LIST_TAIWAN, config_instance.m_ListTaiwan);
+  region_menu->AppendCheckItem(IDM_LIST_WORLD, _("Show World"));
+  region_menu->Check(IDM_LIST_WORLD, config_instance.m_ListWorld);
+  region_menu->AppendCheckItem(IDM_LIST_UNKNOWN, _("Show Unknown"));
+  region_menu->Check(IDM_LIST_UNKNOWN, config_instance.m_ListUnknown);
+
+  auto* const columns_menu = new wxMenu;
+  columns_menu->AppendCheckItem(IDM_SHOW_SYSTEM, _("Platform"));
+  columns_menu->Check(IDM_SHOW_SYSTEM, config_instance.m_showSystemColumn);
+  columns_menu->AppendCheckItem(IDM_SHOW_BANNER, _("Banner"));
+  columns_menu->Check(IDM_SHOW_BANNER, config_instance.m_showBannerColumn);
+  columns_menu->AppendCheckItem(IDM_SHOW_MAKER, _("Maker"));
+  columns_menu->Check(IDM_SHOW_MAKER, config_instance.m_showMakerColumn);
+  columns_menu->AppendCheckItem(IDM_SHOW_FILENAME, _("File Name"));
+  columns_menu->Check(IDM_SHOW_FILENAME, config_instance.m_showFileNameColumn);
+  columns_menu->AppendCheckItem(IDM_SHOW_ID, _("Game ID"));
+  columns_menu->Check(IDM_SHOW_ID, config_instance.m_showIDColumn);
+  columns_menu->AppendCheckItem(IDM_SHOW_REGION, _("Region"));
+  columns_menu->Check(IDM_SHOW_REGION, config_instance.m_showRegionColumn);
+  columns_menu->AppendCheckItem(IDM_SHOW_SIZE, _("File Size"));
+  columns_menu->Check(IDM_SHOW_SIZE, config_instance.m_showSizeColumn);
+  columns_menu->AppendCheckItem(IDM_SHOW_STATE, _("State"));
+  columns_menu->Check(IDM_SHOW_STATE, config_instance.m_showStateColumn);
+
+  auto* const view_menu = new wxMenu;
+  view_menu->AppendCheckItem(IDM_TOGGLE_TOOLBAR, _("Show &Toolbar"));
+  view_menu->Check(IDM_TOGGLE_TOOLBAR, config_instance.m_InterfaceToolbar);
+  view_menu->AppendCheckItem(IDM_TOGGLE_STATUSBAR, _("Show &Status Bar"));
+  view_menu->Check(IDM_TOGGLE_STATUSBAR, config_instance.m_InterfaceStatusbar);
+  view_menu->AppendSeparator();
+  view_menu->AppendCheckItem(IDM_LOG_WINDOW, _("Show &Log"));
+  view_menu->AppendCheckItem(IDM_LOG_CONFIG_WINDOW, _("Show Log &Configuration"));
+  view_menu->AppendSeparator();
 
   if (g_pCodeWindow)
   {
-    viewMenu->Check(IDM_LOG_WINDOW, g_pCodeWindow->bShowOnStart[0]);
+    view_menu->Check(IDM_LOG_WINDOW, g_pCodeWindow->bShowOnStart[0]);
 
     static const wxString menu_text[] = {_("&Registers"), _("&Watch"), _("&Breakpoints"),
                                          _("&Memory"),    _("&JIT"),   _("&Sound"),
@@ -258,103 +349,40 @@ wxMenuBar* CFrame::CreateMenu()
 
     for (int i = IDM_REGISTER_WINDOW; i <= IDM_VIDEO_WINDOW; i++)
     {
-      viewMenu->AppendCheckItem(i, menu_text[i - IDM_REGISTER_WINDOW]);
-      viewMenu->Check(i, g_pCodeWindow->bShowOnStart[i - IDM_LOG_WINDOW]);
+      view_menu->AppendCheckItem(i, menu_text[i - IDM_REGISTER_WINDOW]);
+      view_menu->Check(i, g_pCodeWindow->bShowOnStart[i - IDM_LOG_WINDOW]);
     }
 
-    viewMenu->AppendSeparator();
+    view_menu->AppendSeparator();
   }
   else
   {
-    viewMenu->Check(IDM_LOG_WINDOW, SConfig::GetInstance().m_InterfaceLogWindow);
-    viewMenu->Check(IDM_LOG_CONFIG_WINDOW, SConfig::GetInstance().m_InterfaceLogConfigWindow);
+    view_menu->Check(IDM_LOG_WINDOW, config_instance.m_InterfaceLogWindow);
+    view_menu->Check(IDM_LOG_CONFIG_WINDOW, config_instance.m_InterfaceLogConfigWindow);
   }
 
-  wxMenu* platformMenu = new wxMenu;
-  viewMenu->AppendSubMenu(platformMenu, _("Show Platforms"));
-  platformMenu->AppendCheckItem(IDM_LIST_WII, _("Show Wii"));
-  platformMenu->Check(IDM_LIST_WII, SConfig::GetInstance().m_ListWii);
-  platformMenu->AppendCheckItem(IDM_LIST_GC, _("Show GameCube"));
-  platformMenu->Check(IDM_LIST_GC, SConfig::GetInstance().m_ListGC);
-  platformMenu->AppendCheckItem(IDM_LIST_WAD, _("Show WAD"));
-  platformMenu->Check(IDM_LIST_WAD, SConfig::GetInstance().m_ListWad);
-  platformMenu->AppendCheckItem(IDM_LIST_ELFDOL, _("Show ELF/DOL"));
-  platformMenu->Check(IDM_LIST_ELFDOL, SConfig::GetInstance().m_ListElfDol);
+  view_menu->AppendSubMenu(platform_menu, _("Show Platforms"));
+  view_menu->AppendSubMenu(region_menu, _("Show Regions"));
 
-  wxMenu* regionMenu = new wxMenu;
-  viewMenu->AppendSubMenu(regionMenu, _("Show Regions"));
-  regionMenu->AppendCheckItem(IDM_LIST_JAP, _("Show JAP"));
-  regionMenu->Check(IDM_LIST_JAP, SConfig::GetInstance().m_ListJap);
-  regionMenu->AppendCheckItem(IDM_LIST_PAL, _("Show PAL"));
-  regionMenu->Check(IDM_LIST_PAL, SConfig::GetInstance().m_ListPal);
-  regionMenu->AppendCheckItem(IDM_LIST_USA, _("Show USA"));
-  regionMenu->Check(IDM_LIST_USA, SConfig::GetInstance().m_ListUsa);
-  regionMenu->AppendSeparator();
-  regionMenu->AppendCheckItem(IDM_LIST_AUSTRALIA, _("Show Australia"));
-  regionMenu->Check(IDM_LIST_AUSTRALIA, SConfig::GetInstance().m_ListAustralia);
-  regionMenu->AppendCheckItem(IDM_LIST_FRANCE, _("Show France"));
-  regionMenu->Check(IDM_LIST_FRANCE, SConfig::GetInstance().m_ListFrance);
-  regionMenu->AppendCheckItem(IDM_LIST_GERMANY, _("Show Germany"));
-  regionMenu->Check(IDM_LIST_GERMANY, SConfig::GetInstance().m_ListGermany);
-  regionMenu->AppendCheckItem(IDM_LIST_ITALY, _("Show Italy"));
-  regionMenu->Check(IDM_LIST_ITALY, SConfig::GetInstance().m_ListItaly);
-  regionMenu->AppendCheckItem(IDM_LIST_KOREA, _("Show Korea"));
-  regionMenu->Check(IDM_LIST_KOREA, SConfig::GetInstance().m_ListKorea);
-  regionMenu->AppendCheckItem(IDM_LIST_NETHERLANDS, _("Show Netherlands"));
-  regionMenu->Check(IDM_LIST_NETHERLANDS, SConfig::GetInstance().m_ListNetherlands);
-  regionMenu->AppendCheckItem(IDM_LIST_RUSSIA, _("Show Russia"));
-  regionMenu->Check(IDM_LIST_RUSSIA, SConfig::GetInstance().m_ListRussia);
-  regionMenu->AppendCheckItem(IDM_LIST_SPAIN, _("Show Spain"));
-  regionMenu->Check(IDM_LIST_SPAIN, SConfig::GetInstance().m_ListSpain);
-  regionMenu->AppendCheckItem(IDM_LIST_TAIWAN, _("Show Taiwan"));
-  regionMenu->Check(IDM_LIST_TAIWAN, SConfig::GetInstance().m_ListTaiwan);
-  regionMenu->AppendCheckItem(IDM_LIST_WORLD, _("Show World"));
-  regionMenu->Check(IDM_LIST_WORLD, SConfig::GetInstance().m_ListWorld);
-  regionMenu->AppendCheckItem(IDM_LIST_UNKNOWN, _("Show Unknown"));
-  regionMenu->Check(IDM_LIST_UNKNOWN, SConfig::GetInstance().m_ListUnknown);
+  view_menu->AppendCheckItem(IDM_LIST_DRIVES, _("Show Drives"));
+  view_menu->Check(IDM_LIST_DRIVES, config_instance.m_ListDrives);
 
-  viewMenu->AppendCheckItem(IDM_LIST_DRIVES, _("Show Drives"));
-  viewMenu->Check(IDM_LIST_DRIVES, SConfig::GetInstance().m_ListDrives);
-  viewMenu->Append(IDM_PURGE_GAME_LIST_CACHE, _("Purge Game List Cache"));
+  view_menu->Append(IDM_PURGE_GAME_LIST_CACHE, _("Purge Game List Cache"));
+  view_menu->AppendSubMenu(columns_menu, _("Select Columns"));
 
-  wxMenu* columnsMenu = new wxMenu;
-  viewMenu->AppendSubMenu(columnsMenu, _("Select Columns"));
-  columnsMenu->AppendCheckItem(IDM_SHOW_SYSTEM, _("Platform"));
-  columnsMenu->Check(IDM_SHOW_SYSTEM, SConfig::GetInstance().m_showSystemColumn);
-  columnsMenu->AppendCheckItem(IDM_SHOW_BANNER, _("Banner"));
-  columnsMenu->Check(IDM_SHOW_BANNER, SConfig::GetInstance().m_showBannerColumn);
-  columnsMenu->AppendCheckItem(IDM_SHOW_MAKER, _("Maker"));
-  columnsMenu->Check(IDM_SHOW_MAKER, SConfig::GetInstance().m_showMakerColumn);
-  columnsMenu->AppendCheckItem(IDM_SHOW_FILENAME, _("File Name"));
-  columnsMenu->Check(IDM_SHOW_FILENAME, SConfig::GetInstance().m_showFileNameColumn);
-  columnsMenu->AppendCheckItem(IDM_SHOW_ID, _("Game ID"));
-  columnsMenu->Check(IDM_SHOW_ID, SConfig::GetInstance().m_showIDColumn);
-  columnsMenu->AppendCheckItem(IDM_SHOW_REGION, _("Region"));
-  columnsMenu->Check(IDM_SHOW_REGION, SConfig::GetInstance().m_showRegionColumn);
-  columnsMenu->AppendCheckItem(IDM_SHOW_SIZE, _("File Size"));
-  columnsMenu->Check(IDM_SHOW_SIZE, SConfig::GetInstance().m_showSizeColumn);
-  columnsMenu->AppendCheckItem(IDM_SHOW_STATE, _("State"));
-  columnsMenu->Check(IDM_SHOW_STATE, SConfig::GetInstance().m_showStateColumn);
+  return view_menu;
+}
 
-  menubar->Append(viewMenu, _("&View"));
+wxMenu* CFrame::CreateHelpMenu()
+{
+  auto* const help_menu = new wxMenu;
+  help_menu->Append(IDM_HELP_WEBSITE, _("&Website"));
+  help_menu->Append(IDM_HELP_ONLINE_DOCS, _("Online &Documentation"));
+  help_menu->Append(IDM_HELP_GITHUB, _("&GitHub Repository"));
+  help_menu->AppendSeparator();
+  help_menu->Append(wxID_ABOUT, _("&About"));
 
-  if (g_pCodeWindow)
-  {
-    g_pCodeWindow->CreateMenu(SConfig::GetInstance(), menubar);
-  }
-
-  // Help menu
-  wxMenu* helpMenu = new wxMenu;
-  // Re-enable when there's something useful to display */
-  // helpMenu->Append(wxID_HELP, _("&Help"));
-  helpMenu->Append(IDM_HELP_WEBSITE, _("&Website"));
-  helpMenu->Append(IDM_HELP_ONLINE_DOCS, _("Online &Documentation"));
-  helpMenu->Append(IDM_HELP_GITHUB, _("&GitHub Repository"));
-  helpMenu->AppendSeparator();
-  helpMenu->Append(wxID_ABOUT, _("&About"));
-  menubar->Append(helpMenu, _("&Help"));
-
-  return menubar;
+  return help_menu;
 }
 
 wxString CFrame::GetMenuLabel(int Id)


### PR DESCRIPTION
Just to provide a little background (and so I can link to it in future PRs regarding this):
`CCodeWindow` is the window in the debugger that displays the disassembled code with inline labels and whatnot. However, it's also used as a central throwaway spot for anything debugger related, which is kind of gross. This also makes it kind of awkward to see how events pass around. Ideally  CFrame would post events into the respective debugger panel (or a handler specifically for handling the debugging panels) and then the handler would pass the event to the correct debug panel. In any case, the handling mechanism utilizing templates in CCodeWindow.h is gross because it adds an API that encourages retrieving the instance of a panel and calling it's member functions to do things. This is bad because it ties two window lifetimes together when they can, and should, be separate. All forms of windows should communicate through events. This is what should be worked towards, because it makes improving the debugger (and possibly other parts of the UI) less of a pain.

What this PR actually does towards that:
Since the main frame is what owns the menu bar and tool bar, it should be the only thing that makes changes to them, even in the case of the debugger being used. This resolves the part regarding the menu bar. I'll be opening subsequent PRs after this one that amends the other remaining issues. This is mainly so all the PRs stay compartmentalized and small. Eventually it'd be nice to move all handling directly related to the menu bar into a `wxMenuBar` subclass, and all of the tool bar handling into a `wxToolBar` subclass to keep things fully separate from the frame, but for now it's best to do one thing at a time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4339)
<!-- Reviewable:end -->
