### PR TITLE
Android: On-screen classic controller + Wii controller select

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -118,7 +118,7 @@ public final class NativeLibrary
 		public static final int CLASSIC_DPAD_UP              = 309;
 		public static final int CLASSIC_DPAD_DOWN            = 310;
 		public static final int CLASSIC_DPAD_LEFT            = 311;
-		public static final int CLASSIC_DPADON_RIGHT         = 312;
+		public static final int CLASSIC_DPAD_RIGHT           = 312;
 		public static final int CLASSIC_STICK_LEFT           = 313;
 		public static final int CLASSIC_STICK_LEFT_UP        = 314;
 		public static final int CLASSIC_STICK_LEFT_DOWN      = 315;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -323,6 +323,191 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		return true;
 	}
 
+	private void addGameCubeOverlayControls()
+	{
+		if (mPreferences.getBoolean("buttonToggleGc0", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_a, ButtonType.BUTTON_A));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc1", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_b, ButtonType.BUTTON_B));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc2", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_x, ButtonType.BUTTON_X));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc3", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_y, ButtonType.BUTTON_Y));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc4", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_z, ButtonType.BUTTON_Z));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc5", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_start, ButtonType.BUTTON_START));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc6", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_l, ButtonType.TRIGGER_L));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc7", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_r, ButtonType.TRIGGER_R));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc8", true))
+		{
+			overlayDpads.add(initializeOverlayDpad(getContext(), R.drawable.gcwii_dpad,
+					ButtonType.BUTTON_UP, ButtonType.BUTTON_DOWN,
+					ButtonType.BUTTON_LEFT, ButtonType.BUTTON_RIGHT));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc9", true))
+		{
+			overlayJoysticks.add(initializeOverlayJoystick(getContext(),
+					R.drawable.gcwii_joystick_range, R.drawable.gcwii_joystick,
+					ButtonType.STICK_MAIN));
+		}
+		if (mPreferences.getBoolean("buttonToggleGc10", true))
+		{
+			overlayJoysticks.add(initializeOverlayJoystick(getContext(),
+					R.drawable.gcwii_joystick_range, R.drawable.gcpad_c,
+					ButtonType.STICK_C));
+		}
+	}
+
+	private void addWiimoteOverlayControls()
+	{
+		if (mPreferences.getBoolean("buttonToggleWii0", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_a, ButtonType.WIIMOTE_BUTTON_A));
+		}
+		if (mPreferences.getBoolean("buttonToggleWii1", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_b, ButtonType.WIIMOTE_BUTTON_B));
+		}
+		if (mPreferences.getBoolean("buttonToggleWii2", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_one, ButtonType.WIIMOTE_BUTTON_1));
+		}
+		if (mPreferences.getBoolean("buttonToggleWii3", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_two, ButtonType.WIIMOTE_BUTTON_2));
+		}
+		if (mPreferences.getBoolean("buttonToggleWii4", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_plus, ButtonType.WIIMOTE_BUTTON_PLUS));
+		}
+		if (mPreferences.getBoolean("buttonToggleWii5", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_minus, ButtonType.WIIMOTE_BUTTON_MINUS));
+		}
+		if (mPreferences.getBoolean("buttonToggleWii6", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_home, ButtonType.WIIMOTE_BUTTON_HOME));
+		}
+		if (mPreferences.getBoolean("buttonToggleWii7", true))
+		{
+			if (mPreferences.getInt("wiiController", 3) == 2)
+			{
+				overlayDpads.add(initializeOverlayDpad(getContext(), R.drawable.gcwii_dpad,
+						ButtonType.WIIMOTE_RIGHT, ButtonType.WIIMOTE_LEFT,
+						ButtonType.WIIMOTE_UP, ButtonType.WIIMOTE_DOWN));
+			}
+			else
+			{
+				overlayDpads.add(initializeOverlayDpad(getContext(), R.drawable.gcwii_dpad,
+						ButtonType.WIIMOTE_UP, ButtonType.WIIMOTE_DOWN,
+						ButtonType.WIIMOTE_LEFT, ButtonType.WIIMOTE_RIGHT));
+			}
+		}
+	}
+
+	private void addNunchukOverlayControls()
+	{
+		if (mPreferences.getBoolean("buttonToggleWii8", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.nunchuk_c, ButtonType.NUNCHUK_BUTTON_C));
+		}
+		if (mPreferences.getBoolean("buttonToggleWii9", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.nunchuk_z, ButtonType.NUNCHUK_BUTTON_Z));
+		}
+		if (mPreferences.getBoolean("buttonToggleWii10", true))
+		{
+			overlayJoysticks.add(initializeOverlayJoystick(getContext(),
+					R.drawable.gcwii_joystick_range, R.drawable.gcwii_joystick,
+					ButtonType.NUNCHUK_STICK));
+		}
+	}
+
+	private void addClassicOverlayControls()
+	{
+		if (mPreferences.getBoolean("buttonToggleClassic0", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_a, ButtonType.CLASSIC_BUTTON_A));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic1", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_b, ButtonType.CLASSIC_BUTTON_B));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic2", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_x, ButtonType.CLASSIC_BUTTON_X));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic3", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_y, ButtonType.CLASSIC_BUTTON_Y));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic4", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_plus, ButtonType.CLASSIC_BUTTON_PLUS));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic5", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_minus, ButtonType.CLASSIC_BUTTON_MINUS));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic6", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_home, ButtonType.CLASSIC_BUTTON_HOME));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic7", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_l, ButtonType.CLASSIC_TRIGGER_L));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic8", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_r, ButtonType.CLASSIC_TRIGGER_R));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic9", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_zl, ButtonType.CLASSIC_BUTTON_ZL));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic10", true))
+		{
+			overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.classic_zr, ButtonType.CLASSIC_BUTTON_ZR));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic11", true))
+		{
+			overlayDpads.add(initializeOverlayDpad(getContext(), R.drawable.gcwii_dpad,
+					ButtonType.CLASSIC_DPAD_UP, ButtonType.CLASSIC_DPAD_DOWN,
+					ButtonType.CLASSIC_DPAD_LEFT, ButtonType.CLASSIC_DPAD_RIGHT));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic12", true))
+		{
+			overlayJoysticks.add(initializeOverlayJoystick(getContext(),
+					R.drawable.gcwii_joystick_range, R.drawable.gcwii_joystick,
+					ButtonType.CLASSIC_STICK_LEFT));
+		}
+		if (mPreferences.getBoolean("buttonToggleClassic13", true))
+		{
+			overlayJoysticks.add(initializeOverlayJoystick(getContext(),
+					R.drawable.gcwii_joystick_range, R.drawable.gcwii_joystick,
+					ButtonType.CLASSIC_STICK_RIGHT));
+		}
+	}
+
 	public void refreshControls()
 	{
 		// Remove all the overlay buttons from the HashSet.
@@ -331,110 +516,20 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		overlayJoysticks.removeAll(overlayJoysticks);
 
 		// Add all the enabled overlay items back to the HashSet.
-		if (EmulationActivity.isGameCubeGame())
+		if (EmulationActivity.isGameCubeGame() || mPreferences.getInt("wiiController", 3) == 0)
 		{
-			// GameCube
-			if (mPreferences.getBoolean("buttonToggleGc0", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_a, ButtonType.BUTTON_A));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc1", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_b, ButtonType.BUTTON_B));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc2", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_x, ButtonType.BUTTON_X));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc3", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_y, ButtonType.BUTTON_Y));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc4", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_z, ButtonType.BUTTON_Z));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc5", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_start, ButtonType.BUTTON_START));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc6", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_l, ButtonType.TRIGGER_L));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc7", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.gcpad_r, ButtonType.TRIGGER_R));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc8", true))
-			{
-				overlayDpads.add(initializeOverlayDpad(getContext(), R.drawable.gcwii_dpad,
-						ButtonType.BUTTON_UP, ButtonType.BUTTON_DOWN,
-						ButtonType.BUTTON_LEFT, ButtonType.BUTTON_RIGHT));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc9", true))
-			{
-				overlayJoysticks.add(initializeOverlayJoystick(getContext(),
-						R.drawable.gcwii_joystick_range, R.drawable.gcwii_joystick,
-						ButtonType.STICK_MAIN));
-			}
-			if (mPreferences.getBoolean("buttonToggleGc10", true))
-			{
-				overlayJoysticks.add(initializeOverlayJoystick(getContext(),
-						R.drawable.gcwii_joystick_range, R.drawable.gcpad_c,
-						ButtonType.STICK_C));
-			}
+			addGameCubeOverlayControls();
+		}
+		else if (mPreferences.getInt("wiiController", 3) == 4)
+		{
+			addClassicOverlayControls();
 		}
 		else
 		{
-			// Wiimote + Nunchuk
-			if (mPreferences.getBoolean("buttonToggleWii0", true))
+			addWiimoteOverlayControls();
+			if (mPreferences.getInt("wiiController", 3) == 3)
 			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_a, ButtonType.WIIMOTE_BUTTON_A));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii1", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_b, ButtonType.WIIMOTE_BUTTON_B));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii2", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_one, ButtonType.WIIMOTE_BUTTON_1));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii3", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_two, ButtonType.WIIMOTE_BUTTON_2));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii4", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_plus, ButtonType.WIIMOTE_BUTTON_PLUS));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii5", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_minus, ButtonType.WIIMOTE_BUTTON_MINUS));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii6", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.wiimote_home, ButtonType.WIIMOTE_BUTTON_HOME));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii7", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.nunchuk_c, ButtonType.NUNCHUK_BUTTON_C));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii8", true))
-			{
-				overlayButtons.add(initializeOverlayButton(getContext(), R.drawable.nunchuk_z, ButtonType.NUNCHUK_BUTTON_Z));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii9", true))
-			{
-				overlayDpads.add(initializeOverlayDpad(getContext(), R.drawable.gcwii_dpad,
-						ButtonType.WIIMOTE_UP, ButtonType.WIIMOTE_DOWN,
-						ButtonType.WIIMOTE_LEFT, ButtonType.WIIMOTE_RIGHT));
-			}
-			if (mPreferences.getBoolean("buttonToggleWii10", true))
-			{
-				overlayJoysticks.add(initializeOverlayJoystick(getContext(),
-						R.drawable.gcwii_joystick_range, R.drawable.gcwii_joystick,
-						ButtonType.NUNCHUK_STICK));
+				addNunchukOverlayControls();
 			}
 		}
 
@@ -506,7 +601,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		case ButtonType.BUTTON_Z:
 		case ButtonType.TRIGGER_L:
 		case ButtonType.TRIGGER_R:
-			scale = 0.22f;
+			scale = 0.225f;
 			break;
 		case ButtonType.BUTTON_START:
 			scale = 0.075f;
@@ -518,7 +613,16 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		case ButtonType.WIIMOTE_BUTTON_PLUS:
 		case ButtonType.WIIMOTE_BUTTON_MINUS:
 		case ButtonType.WIIMOTE_BUTTON_HOME:
+		case ButtonType.CLASSIC_BUTTON_PLUS:
+		case ButtonType.CLASSIC_BUTTON_MINUS:
+		case ButtonType.CLASSIC_BUTTON_HOME:
 			scale = 0.0625f;
+			break;
+		case ButtonType.CLASSIC_TRIGGER_L:
+		case ButtonType.CLASSIC_TRIGGER_R:
+		case ButtonType.CLASSIC_BUTTON_ZL:
+		case ButtonType.CLASSIC_BUTTON_ZR:
+			scale = 0.25f;
 			break;
 		default:
 			scale = 0.125f;
@@ -583,11 +687,11 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 		case ButtonType.BUTTON_UP:
 			scale = 0.2375f;
 			break;
-		case ButtonType.WIIMOTE_UP:
-			scale = 0.2125f;
+		case ButtonType.CLASSIC_DPAD_UP:
+			scale = 0.275f;
 			break;
 		default:
-			scale = 0.275f;
+			scale = 0.2125f;
 			break;
 		}
 

--- a/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
+++ b/Source/Android/app/src/main/res/menu/menu_emulation_wii.xml
@@ -94,6 +94,10 @@
             <item
                 android:id="@+id/menu_emulation_adjust_scale"
                 android:title="@string/emulation_control_scale"/>
+
+            <item
+                android:id="@+id/menu_emulation_choose_controller"
+                android:title="@string/emulation_choose_controller"/>
         </menu>
     </item>
 </menu>

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -32,7 +32,7 @@
         <item>3</item>
     </integer-array>
 
-    <!-- Wiimote extensions -->
+    <!-- Wii Remote extensions -->
     <string-array name="wiimoteExtEntries" translatable="false">
         <item>"None"</item>
         <item>"Nunchuk"</item>
@@ -179,6 +179,32 @@
         <item>12</item>
     </integer-array>
 
+    <string-array name="wiimoteTypeEntries">
+        <item>Disabled</item>
+        <item>Emulated</item>
+        <item>Real Wii Remote (DolphinBar required)</item>
+    </string-array>
+    <integer-array name="wiimoteTypeValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
+
+    <string-array name="controllersEntries">
+        <item>GameCube Controller</item>
+        <item>Wii Remote</item>
+        <item>Horizontal Wii Remote</item>
+        <item>Wii Remote + Nunchuk</item>
+        <item>Classic Controller</item>
+    </string-array>
+    <string-array name="controllersValues">
+        <item>None</item>
+        <item>None</item>
+        <item>None</item>
+        <item>Nunchuk</item>
+        <item>Classic</item>
+    </string-array>
+
     <string-array name="gcpadButtons">
         <item>A</item>
         <item>B</item>
@@ -193,17 +219,6 @@
         <item>C Stick</item>
     </string-array>
 
-    <string-array name="wiimoteTypeEntries">
-        <item>Disabled</item>
-        <item>Emulated</item>
-        <item>Real Wiimote (DolphinBar required)</item>
-    </string-array>
-    <integer-array name="wiimoteTypeValues">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-    </integer-array>
-
     <string-array name="wiimoteButtons">
         <item>A</item>
         <item>B</item>
@@ -212,10 +227,38 @@
         <item>+</item>
         <item>-</item>
         <item>Home</item>
+        <item>D-Pad</item>
+    </string-array>
+
+    <string-array name="nunchukButtons">
+        <item>A</item>
+        <item>B</item>
+        <item>1</item>
+        <item>2</item>
+        <item>+</item>
+        <item>-</item>
+        <item>Home</item>
+        <item>D-Pad</item>
         <item>C</item>
         <item>Z</item>
-        <item>D-Pad</item>
         <item>Nunchuk Stick</item>
+    </string-array>
+
+    <string-array name="classicButtons">
+        <item>a</item>
+        <item>b</item>
+        <item>x</item>
+        <item>y</item>
+        <item>+</item>
+        <item>-</item>
+        <item>Home</item>
+        <item>L</item>
+        <item>R</item>
+        <item>ZL</item>
+        <item>ZR</item>
+        <item>D-Pad</item>
+        <item>Left Stick</item>
+        <item>Right Stick</item>
     </string-array>
 
 </resources>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -364,6 +364,8 @@
     <string name="emulation_toggle_controls">Toggle Controls</string>
     <string name="emulation_toggle_all">Toggle All</string>
     <string name="emulation_control_scale">Adjust Scale</string>
+    <string name="emulation_choose_controller">Choose Controller</string>
+    <string name="emulation_controller_changed">You may have to reload the game after changing extensions.</string>
     
     <!-- GC Adapter Menu-->
     <string name="gc_adapter_rumble">Enable Vibration</string>


### PR DESCRIPTION
This adds support for an on-screen classic controller. There is also an option (for Wii games only!) to switch between the GameCube Controller, the Wii Remote + Nunchuk, or the Classic Controller. I also made a few minor changes like moving the Wii Remote d-pad up with the other Wii Remote controls. I used the phrasing "Wii Remote" instead of "Wiimote" as per #4338.

Here's a screenshot:
![screenshot oct 12 2016 6-27-08 pm](https://cloud.githubusercontent.com/assets/3057954/19330199/f857ef56-90aa-11e6-9b92-91202179cce5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4347)
<!-- Reviewable:end -->
