### PR TITLE
EXI: Fix incorrect byte order when writing 3-byte data to BBA_WRTXFIFOD

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceEthernet.cpp
@@ -345,6 +345,8 @@ void CEXIETHERNET::MXCommandHandler(u32 data, u32 size)
   case BBA_WRTXFIFOD:
     if (size == 2)
       data = Common::swap16(data & 0xffff);
+    else if (size == 3)
+      data = Common::swap32(data & 0xffffff) >> 8;
     else if (size == 4)
       data = Common::swap32(data);
     DirectFIFOWrite((u8*)&data, size);


### PR DESCRIPTION
Emulated BBA sometimes sends incorrect data because when it writes 3-byte data to BBA_WRTXFIFOD, the data are not byte-swapped.

Example
```
24:04:686 HW\EXI_DeviceEthernet.cpp:112 I[SP1]: mx  write 000003
```
```
24:04:687 HW\BBA-TAP\TAP_Win32.cpp:312 I[SP1]: SendFrame 67 bytes:
00 ff 9a b6 72 f9 00 09 bf 3b 47 1e 08 00 45 00
00 35 00 b3 00 00 78 06 bf 2d c0 a8 00 ca c0 a8
00 c8 07 5b 23 2b 18 dd 28 65 a9 8e 67 30 50 18
3f c0 f1 65 00 00 00 0b 01 24 00 00 01 00 7a 00
03 00 00
```
The last 3 bytes are "00 00 03" in real gamecube.

This commit fixes random crash and softlock when playing online multiplayer mode on Homeland.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4349)
<!-- Reviewable:end -->
