### PR TITLE
Dynamically detect the latest macOS SDK to build with.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,24 +284,13 @@ if(APPLE)
 
 	# Identify the target system:
 	# Ask for 64-bit binary.
-	set(TARGET_FLAGS "-arch x86_64")
+	set(TARGET_FLAGS "${TARGET_FLAGS} -arch x86_64")
 	# Minimum OS X version.
 	# This is inserted into the Info.plist as well.
 	# Note that the SDK determines the maximum version of which optional
 	# features can be used, not the minimum required version to run.
 	set(OSX_MIN_VERSION "10.9")
 	set(TARGET_FLAGS "${TARGET_FLAGS} -mmacosx-version-min=${OSX_MIN_VERSION}")
-	set(SYSROOT_LEGACY_PATH "/Developer/SDKs/MacOSX10.9.sdk")
-	set(SYSROOT_PATH "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk")
-	if(EXISTS "${SYSROOT_PATH}/")
-		set(TARGET_SYSROOT ${SYSROOT_PATH})
-	elseif(EXISTS "${SYSROOT_LEGACY_PATH}/")
-		set(TARGET_SYSROOT ${SYSROOT_LEGACY_PATH})
-	endif()
-	if(${TARGET_SYSROOT})
-		set(TARGET_FLAGS "${TARGET_FLAGS} -isysroot ${TARGET_SYSROOT}")
-		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-syslibroot,${TARGET_SYSROOT}")
-	endif()
 	# Do not warn about frameworks that are not available on all architectures.
 	# This avoids a warning when linking with QuickTime.
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no_arch_warnings")


### PR DESCRIPTION
I don't use the macOS Command Line Tools, so my builds require specifying an SDK. Previously, Dolphin hardcoded a path to Xcode as `/Applications/Xcode.app` and used a hardcoded SDK version, macOS 10.9. Since I have Xcode installed to a different path and use a newer version of Xcode which has the macOS 10.12 SDK, Dolphin wasn't able to find the right SDK. With this, Dolphin will search out the latest installed SDK, and fall back to the Command Line Tools if not available.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4350)

<!-- Reviewable:end -->
