### PR TITLE
IPC_HLE: Remove unused _Unimplemented_Device_ device

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -164,7 +164,6 @@ void Reinit()
   AddDevice<CWII_IPC_HLE_Device_stub>("/dev/usb/hid");
 #endif
   AddDevice<CWII_IPC_HLE_Device_stub>("/dev/usb/oh1");
-  AddDevice<IWII_IPC_HLE_Device>("_Unimplemented_Device_");
 }
 
 void Init()


### PR DESCRIPTION
Unless I'm misreading the code, it doesn't look like this serves any purpose, and is only polluting the logs and creating a useless device.

`_Unimplemented_Device_` is apparently a device that was used for devices that don't exist, but this hasn't been the case since 2012 (d95e31a removed the only usage of this fake device).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4351)
<!-- Reviewable:end -->
