### PR TITLE
NANDContentLoader: Add IOFile forward declaration

### DIFF
--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -96,6 +96,12 @@ std::string CSharedContent::AddSharedContent(const u8* hash)
   return filename;
 }
 
+CNANDContentDataFile::CNANDContentDataFile(const std::string& filename) : m_filename{filename}
+{
+}
+
+CNANDContentDataFile::~CNANDContentDataFile() = default;
+
 void CNANDContentDataFile::EnsureOpen()
 {
   if (!m_file)

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -13,13 +13,15 @@
 #include "Common/CommonTypes.h"
 #include "Common/NandPaths.h"
 
-namespace DiscIO
+namespace File
 {
-enum class Country;
+class IOFile;
 }
 
 namespace DiscIO
 {
+enum class Country;
+
 bool AddTicket(u64 title_id, const std::vector<u8>& ticket);
 
 class CNANDContentData
@@ -35,7 +37,9 @@ public:
 class CNANDContentDataFile final : public CNANDContentData
 {
 public:
-  explicit CNANDContentDataFile(const std::string& filename) : m_filename(filename) {}
+  explicit CNANDContentDataFile(const std::string& filename);
+  ~CNANDContentDataFile();
+
   void Open() override;
   std::vector<u8> Get() override;
   bool GetRange(u32 start, u32 size, u8* buffer) override;


### PR DESCRIPTION
This would previously fail to compile when included in files that do not include FileUtil.h (e.g. cases where CNANDContentDataFile is not used).

I have a branch that works on moving the menu bar-related tasks into their own wxMenuBar subclass in the wx code, and happened to get a compilation failure because of this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4352)
<!-- Reviewable:end -->
