### PR TITLE
BreakPoints: ClearAllTemporary uses valid iterators

### DIFF
--- a/Source/Core/Common/BreakPoints.cpp
+++ b/Source/Core/Common/BreakPoints.cpp
@@ -115,13 +115,18 @@ void BreakPoints::Clear()
 
 void BreakPoints::ClearAllTemporary()
 {
-  for (const TBreakPoint& bp : m_BreakPoints)
+  auto bp = m_BreakPoints.begin();
+  while (bp != m_BreakPoints.end())
   {
-    if (bp.bTemporary)
+    if (bp->bTemporary)
     {
       if (jit)
-        jit->GetBlockCache()->InvalidateICache(bp.iAddress, 4, true);
-      Remove(bp.iAddress);
+        jit->GetBlockCache()->InvalidateICache(bp->iAddress, 4, true);
+      bp = m_BreakPoints.erase(bp);
+    }
+    else
+    {
+      ++bp;
     }
   }
 }


### PR DESCRIPTION
The old version triggers the following assertion:
> vector iterator not incrementable

Ready to be reviewed & merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4354)
<!-- Reviewable:end -->
