### PR TITLE
Update to D3D feature levels.

### DIFF
--- a/Source/Core/VideoBackends/D3D12/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.cpp
@@ -39,7 +39,10 @@ static int s_d3d12_dll_ref = 0;
 D3D12CREATEDEVICE d3d12_create_device = nullptr;
 D3D12SERIALIZEROOTSIGNATURE d3d12_serialize_root_signature = nullptr;
 D3D12GETDEBUGINTERFACE d3d12_get_debug_interface = nullptr;
-
+  
+#define NUM_SUPPORTED_FEATURE_LEVELS 3
+const  D3D_FEATURE_LEVEL supported_feature_levels[NUM_SUPPORTED_FEATURE_LEVELS] = {
+  D3D_FEATURE_LEVEL_12_1, D3D_FEATURE_LEVEL_12_0, D3D_FEATURE_LEVEL_11_1};
 namespace D3D
 {
 // Begin extern'd variables.


### PR DESCRIPTION
Defined and added support for feature levels 11.1, 12.0 and 12.1. Support for 11.1 should help with most GPUs that present issues when using the backend. Might need additional code (and of course some testing). I wonder and would really appreciate if someone could get to build this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4355)
<!-- Reviewable:end -->
