### PR TITLE
CMake: Fix macOS compile by always setting LIBUSB_FOUND=true

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -749,6 +749,7 @@ if(NOT ANDROID)
         	add_subdirectory(Externals/libusb)
 	        set(LIBUSB_LIBRARIES usb)
         endif()
+        set(LIBUSB_FOUND true)
 endif()
 
 set(SFML_REQD_VERSION 2.1)


### PR DESCRIPTION
Without this, compilation complains about undefined symbols related to
`CWII_IPC_HLE_Device_hid` and `CWII_IPC_HLE_Device_usb_oh1_57e_305_real`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4356)
<!-- Reviewable:end -->
