### PR TITLE
HW: Don't be responsible for g_controller_interface

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -510,8 +510,9 @@ void EmuThread()
   bool init_controllers = false;
   if (!g_controller_interface.IsInit())
   {
-    Pad::Initialize(s_window_handle);
-    Keyboard::Initialize(s_window_handle);
+    g_controller_interface.Initialize(s_window_handle);
+    Pad::Initialize();
+    Keyboard::Initialize();
     init_controllers = true;
   }
   else
@@ -525,9 +526,9 @@ void EmuThread()
   if (core_parameter.bWii && !SConfig::GetInstance().m_bt_passthrough_enabled)
   {
     if (init_controllers)
-      Wiimote::Initialize(s_window_handle, !s_state_filename.empty() ?
-                                               Wiimote::InitializeMode::DO_WAIT_FOR_WIIMOTES :
-                                               Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
+      Wiimote::Initialize(!s_state_filename.empty() ?
+                              Wiimote::InitializeMode::DO_WAIT_FOR_WIIMOTES :
+                              Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
     else
       Wiimote::LoadConfig();
 
@@ -651,6 +652,7 @@ void EmuThread()
     Wiimote::Shutdown();
     Keyboard::Shutdown();
     Pad::Shutdown();
+    g_controller_interface.Shutdown();
     init_controllers = false;
   }
 

--- a/Source/Core/Core/HW/GCKeyboard.cpp
+++ b/Source/Core/Core/HW/GCKeyboard.cpp
@@ -23,11 +23,9 @@ InputConfig* GetConfig()
 void Shutdown()
 {
   s_config.ClearControllers();
-
-  g_controller_interface.Shutdown();
 }
 
-void Initialize(void* const hwnd)
+void Initialize()
 {
   if (s_config.ControllersNeedToBeCreated())
   {
@@ -35,7 +33,6 @@ void Initialize(void* const hwnd)
       s_config.CreateController<GCKeyboard>(i);
   }
 
-  g_controller_interface.Initialize(hwnd);
   g_controller_interface.RegisterHotplugCallback(LoadConfig);
 
   // Load the saved controller config

--- a/Source/Core/Core/HW/GCKeyboard.h
+++ b/Source/Core/Core/HW/GCKeyboard.h
@@ -12,7 +12,7 @@ struct KeyboardStatus;
 namespace Keyboard
 {
 void Shutdown();
-void Initialize(void* const hwnd);
+void Initialize();
 void LoadConfig();
 
 InputConfig* GetConfig();

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -22,11 +22,9 @@ InputConfig* GetConfig()
 void Shutdown()
 {
   s_config.ClearControllers();
-
-  g_controller_interface.Shutdown();
 }
 
-void Initialize(void* const hwnd)
+void Initialize()
 {
   if (s_config.ControllersNeedToBeCreated())
   {
@@ -34,7 +32,6 @@ void Initialize(void* const hwnd)
       s_config.CreateController<GCPad>(i);
   }
 
-  g_controller_interface.Initialize(hwnd);
   g_controller_interface.RegisterHotplugCallback(LoadConfig);
 
   // Load the saved controller config

--- a/Source/Core/Core/HW/GCPad.h
+++ b/Source/Core/Core/HW/GCPad.h
@@ -13,7 +13,7 @@ struct GCPadStatus;
 namespace Pad
 {
 void Shutdown();
-void Initialize(void* const hwnd);
+void Initialize();
 void LoadConfig();
 
 InputConfig* GetConfig();

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -24,11 +24,9 @@ void Shutdown()
   s_config.ClearControllers();
 
   WiimoteReal::Stop();
-
-  g_controller_interface.Shutdown();
 }
 
-void Initialize(void* const hwnd, InitializeMode init_mode)
+void Initialize(InitializeMode init_mode)
 {
   if (s_config.ControllersNeedToBeCreated())
   {
@@ -36,7 +34,6 @@ void Initialize(void* const hwnd, InitializeMode init_mode)
       s_config.CreateController<WiimoteEmu::Wiimote>(i);
   }
 
-  g_controller_interface.Initialize(hwnd);
   g_controller_interface.RegisterHotplugCallback(LoadConfig);
 
   s_config.LoadConfig(false);

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -42,7 +42,7 @@ enum class InitializeMode
 };
 
 void Shutdown();
-void Initialize(void* const hwnd, InitializeMode init_mode);
+void Initialize(InitializeMode init_mode);
 void ResetAllWiimotes();
 void LoadConfig();
 void Resume();

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -182,12 +182,11 @@ bool IsPressed(int Id, bool held)
   return false;
 }
 
-void Initialize(void* const hwnd)
+void Initialize()
 {
   if (s_config.ControllersNeedToBeCreated())
     s_config.CreateController<HotkeyManager>();
 
-  g_controller_interface.Initialize(hwnd);
   g_controller_interface.RegisterHotplugCallback(LoadConfig);
 
   // load the saved controller config
@@ -207,8 +206,6 @@ void LoadConfig()
 void Shutdown()
 {
   s_config.ClearControllers();
-
-  g_controller_interface.Shutdown();
 }
 }
 

--- a/Source/Core/Core/HotkeyManager.h
+++ b/Source/Core/Core/HotkeyManager.h
@@ -155,7 +155,7 @@ private:
 
 namespace HotkeyManagerEmu
 {
-void Initialize(void* const hwnd);
+void Initialize();
 void Shutdown();
 void LoadConfig();
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -333,19 +333,16 @@ bool CFrame::InitControllers()
   if (!g_controller_interface.IsInit())
   {
 #if defined(HAVE_X11) && HAVE_X11
-    Window win = X11Utils::XWindowFromHandle(GetHandle());
-    Pad::Initialize(reinterpret_cast<void*>(win));
-    Keyboard::Initialize(reinterpret_cast<void*>(win));
-    Wiimote::Initialize(reinterpret_cast<void*>(win),
-                        Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
-    HotkeyManagerEmu::Initialize(reinterpret_cast<void*>(win));
+    void* win = reinterpret_cast<void*>(X11Utils::XWindowFromHandle(GetHandle()));
 #else
-    Pad::Initialize(reinterpret_cast<void*>(GetHandle()));
-    Keyboard::Initialize(reinterpret_cast<void*>(GetHandle()));
-    Wiimote::Initialize(reinterpret_cast<void*>(GetHandle()),
-                        Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
-    HotkeyManagerEmu::Initialize(reinterpret_cast<void*>(GetHandle()));
+    void* win = reinterpret_cast<void*>(GetHandle());
 #endif
+    g_controller_interface.Initialize(win);
+    Pad::Initialize();
+    Keyboard::Initialize();
+    Wiimote::Initialize(Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
+    HotkeyManagerEmu::Initialize();
+
     return true;
   }
   return false;
@@ -547,6 +544,7 @@ CFrame::~CFrame()
   Keyboard::Shutdown();
   Pad::Shutdown();
   HotkeyManagerEmu::Shutdown();
+  g_controller_interface.Shutdown();
 
   drives.clear();
 


### PR DESCRIPTION
Currently, `g_controller_interface` is initialized and shut down by each
of `GCKeyboard`, `GCPad`, `Wiimote`, and `HotkeyManager`.

This 1) is weird conceptually, because it necessitates passing a pointer
to the native window to each of those classes, which don't need it, and
2) can cause issues when controller backends are initialized or shutdown
multiple times in succession.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4357)
<!-- Reviewable:end -->
