### PR TITLE
gettextize: Remove "Debug" check

### DIFF
--- a/Languages/gettextize
+++ b/Languages/gettextize
@@ -2,7 +2,7 @@
 
 cd ${0/gettextize/}/..
 SRCDIR=Source
-find $SRCDIR \( -name '*.cpp' -o -name '*.h' -o -name '*.c' \) -a ! -path '*Debug*' | \
+find $SRCDIR -name '*.cpp' -o -name '*.h' -o -name '*.c' | \
 	xgettext -d dolphin-emu -s --keyword=_ --keyword=wxTRANSLATE --keyword=SuccessAlertT \
 	--keyword=PanicAlertT --keyword=PanicYesNoT --keyword=AskYesNoT --keyword=CriticalAlertT \
 	--keyword=GetStringT --keyword=_trans --add-comments=i18n -p ./Languages/po \


### PR DESCRIPTION
If the strings for the debugger shouldn't be included in translations, we simply shouldn't use any translation macro for those strings, instead of having a special check to exclude debugger-related code from being searched for translatable strings.

The "Debug" check is a hack that essentially nobody has been aware of (including me). For instance, PR #4339 made a lot of strings translatable just because they were moved to a file that doesn't have "Debug" in its path, and as far as I know, nobody noticed that change until the newly translatable strings were live on Transifex.

I'm not sure if we should merge this PR as-is or if we want to remove the translation macros from debugger strings first. Any thoughts? Do we want the debugger to be fully localized?

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4371)

<!-- Reviewable:end -->
