### PR TITLE
Fix a schedule event assert on ClearCacheThreadSafe

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -84,7 +84,7 @@ void JitBaseBlockCache::Clear()
 
 void JitBaseBlockCache::SchedulateClearCacheThreadSafe()
 {
-  CoreTiming::ScheduleEvent(0, s_clear_jit_cache_thread_safe);
+  CoreTiming::ScheduleEvent(0, s_clear_jit_cache_thread_safe, 0, CoreTiming::FromThread::NON_CPU);
 }
 
 void JitBaseBlockCache::Reset()


### PR DESCRIPTION
I didn't know that telling that you don't schedule from the CPU thread prevents an assert failling because it by default assumes you use the CPU thread, but in the case of ClearCacheThreadSafe, it's used from the GUI thread.

I really should be using panic handlers to catch these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4372)
<!-- Reviewable:end -->
