### PR TITLE
Fix unnecessary Center PC calls in the CodeWindow

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -159,7 +159,8 @@ void CCodeWindow::OnHostMessage(wxCommandEvent& event)
     break;
 
   case IDM_UPDATE_DISASM_DIALOG:
-    Repopulate();
+    codeview->Center(PC);
+    Repopulate(false);
     if (HasPanel<CRegisterWindow>())
       GetPanel<CRegisterWindow>()->NotifyUpdate();
     if (HasPanel<CWatchWindow>())
@@ -205,12 +206,14 @@ void CCodeWindow::OnCodeStep(wxCommandEvent& event)
 
   case IDM_SKIP:
     PC += 4;
-    Repopulate();
+    codeview->Center(PC);
+    Repopulate(false);
     break;
 
   case IDM_SETPC:
     PC = codeview->GetSelection();
-    Repopulate();
+    codeview->Center(PC);
+    Repopulate(false);
     break;
 
   case IDM_GOTOPC:
@@ -383,11 +386,8 @@ void CCodeWindow::StepOut()
     PowerPC::SetMode(old_mode);
     CPU::PauseAndLock(false, false);
 
-    JumpToAddress(PC);
-    {
-      wxCommandEvent ev(wxEVT_HOST_COMMAND, IDM_UPDATE_DISASM_DIALOG);
-      GetEventHandler()->ProcessEvent(ev);
-    }
+    wxCommandEvent ev(wxEVT_HOST_COMMAND, IDM_UPDATE_DISASM_DIALOG);
+    GetEventHandler()->ProcessEvent(ev);
 
     // Update all toolbars in the aui manager
     Parent->UpdateGUI();
@@ -605,12 +605,13 @@ void CCodeWindow::PopulateToolbar(wxToolBar* toolBar)
 }
 
 // Update GUI
-void CCodeWindow::Repopulate()
+void CCodeWindow::Repopulate(bool refresh_codeview)
 {
   if (!codeview)
     return;
 
-  codeview->Center(PC);
+  if (refresh_codeview)
+    codeview->Refresh();
   UpdateCallstack();
   UpdateButtonStates();
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -95,7 +95,7 @@ public:
   bool JITNoBlockLinking();
   bool JumpToAddress(u32 address);
 
-  void Repopulate();
+  void Repopulate(bool refresh_codeview = true);
   void NotifyMapLoaded();
   void PopulateToolbar(wxToolBar* toolBar);
   void UpdateButtonStates();

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -523,13 +523,15 @@ void CFrame::OnPlay(wxCommandEvent& WXUNUSED(event))
     // Core is initialized and emulator is running
     if (UseDebugger)
     {
-      CPU::EnableStepping(!CPU::IsStepping());
-
-      wxThread::Sleep(20);
-      g_pCodeWindow->JumpToAddress(PC);
-      g_pCodeWindow->Repopulate();
-      // Update toolbar with Play/Pause status
-      UpdateGUI();
+      bool was_stopped = CPU::IsStepping();
+      CPU::EnableStepping(!was_stopped);
+      // When the CPU stops it generates a IDM_UPDATE_DISASM_DIALOG which automatically refreshes
+      // the UI, the UI only needs to be refreshed manually when unpausing.
+      if (was_stopped)
+      {
+        g_pCodeWindow->Repopulate();
+        UpdateGUI();
+      }
     }
     else
     {


### PR DESCRIPTION
This not only fixes a regression where toggling a breakpoint using the CodeWindow would cause a Center PC, but it also removes several redundant JumpToAddress(PC) calls.

The regression was due to an improper fix I did in pr #4218 and was undone in the Hi-dpi pr.  Not only it didn't made sense to have the center pc in the repopulate function, but there was other ways to cause a center for the events that desires one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4377)
<!-- Reviewable:end -->
