### PR TITLE
DolphinWX: Move toolbar creation to a wxToolBar subclass

### DIFF
--- a/Externals/wxWidgets3/src/gtk/toolbar.cpp
+++ b/Externals/wxWidgets3/src/gtk/toolbar.cpp
@@ -56,6 +56,7 @@ public:
     void SetImage();
     void CreateDropDown();
     void ShowDropdown(GtkToggleButton* button);
+    virtual void SetLabel(const wxString& label) wxOVERRIDE;
 
     GtkToolItem* m_item;
 };
@@ -316,6 +317,36 @@ void wxToolBarTool::ShowDropdown(GtkToggleButton* button)
             toolbar->PopupMenu(menu, x, y);
         }
     }
+}
+
+void wxToolBarTool::SetLabel(const wxString& label)
+{
+    wxASSERT_MSG( IsButton(),
+       wxS("Label can be set for button tool only") );
+
+    if ( label == m_label )
+        return;
+
+    wxToolBarToolBase::SetLabel(label);
+    if ( IsButton() )
+    {
+        if ( !label.empty() )
+        {
+            wxString newLabel = wxControl::RemoveMnemonics(label);
+            gtk_tool_button_set_label(GTK_TOOL_BUTTON(m_item),
+                                      wxGTK_CONV(newLabel));
+            // To show the label for toolbar with wxTB_HORZ_LAYOUT.
+            gtk_tool_item_set_is_important(m_item, true);
+        }
+        else
+        {
+            gtk_tool_button_set_label(GTK_TOOL_BUTTON(m_item), NULL);
+            // To hide the label for toolbar with wxTB_HORZ_LAYOUT.
+            gtk_tool_item_set_is_important(m_item, false);
+        }
+    }
+
+    // TODO: Set label for control tool, if it's possible.
 }
 
 wxToolBarToolBase *wxToolBar::CreateTool(int id,

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -54,6 +54,7 @@ set(GUI_SRCS
 	LogWindow.cpp
 	Main.cpp
 	MainMenuBar.cpp
+	MainToolBar.cpp
 	MemcardManager.cpp
 	PatchAddEdit.cpp
 	PostProcessingConfigDiag.cpp

--- a/Source/Core/DolphinWX/Config/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/Config/ConfigMain.cpp
@@ -37,6 +37,8 @@ CConfigMain::CConfigMain(wxWindow* parent, wxWindowID id, const wxString& title,
   Bind(wxEVT_BUTTON, &CConfigMain::OnCloseButton, this, wxID_CLOSE);
   Bind(wxDOLPHIN_CFG_REFRESH_LIST, &CConfigMain::OnSetRefreshGameListOnClose, this);
 
+  wxDialog::SetExtraStyle(GetExtraStyle() & ~wxWS_EX_BLOCK_EVENTS);
+
   CreateGUIControls();
 }
 

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
@@ -25,7 +25,6 @@
 #include "DolphinWX/Config/InterfaceConfigPane.h"
 #include "DolphinWX/Frame.h"
 #include "DolphinWX/InputConfigDiag.h"
-#include "DolphinWX/Main.h"
 #include "DolphinWX/WxUtils.h"
 
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
@@ -241,6 +240,7 @@ void InterfaceConfigPane::OnThemeSelected(wxCommandEvent& event)
 {
   SConfig::GetInstance().theme_name = WxStrToStr(m_theme_choice->GetStringSelection());
 
-  main_frame->InitBitmaps();
-  main_frame->UpdateGameList();
+  wxCommandEvent theme_event{DOLPHIN_EVT_RELOAD_THEME_BITMAPS};
+  theme_event.SetEventObject(this);
+  ProcessEvent(theme_event);
 }

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -18,7 +18,6 @@
 #include <wx/textctrl.h>
 #include <wx/textdlg.h>
 #include <wx/thread.h>
-#include <wx/toolbar.h>
 #include <wx/aui/auibar.h>
 #include <wx/aui/dockart.h>
 // clang-format on
@@ -58,8 +57,6 @@ CCodeWindow::CCodeWindow(const SConfig& _LocalCoreStartupParameter, CFrame* pare
     : wxPanel(parent, id, position, size, style, name), m_sibling_panels(), Parent(parent),
       codeview(nullptr)
 {
-  InitBitmaps();
-
   DebugInterface* di = &PowerPC::debug_interface;
 
   codeview = new CCodeView(di, &g_symbolDB, this, wxID_ANY);
@@ -138,11 +135,6 @@ CCodeWindow::~CCodeWindow()
 wxMenuBar* CCodeWindow::GetMenuBar()
 {
   return Parent->GetMenuBar();
-}
-
-wxToolBar* CCodeWindow::GetToolBar()
-{
-  return Parent->m_ToolBar;
 }
 
 // ----------
@@ -574,36 +566,6 @@ bool CCodeWindow::JITNoBlockLinking()
   return GetMenuBar()->IsChecked(IDM_JIT_NO_BLOCK_LINKING);
 }
 
-// Toolbar
-void CCodeWindow::InitBitmaps()
-{
-  static constexpr std::array<const char* const, Toolbar_Debug_Bitmap_Max> s_image_names{
-      {"toolbar_debugger_step", "toolbar_debugger_step_over", "toolbar_debugger_step_out",
-       "toolbar_debugger_skip", "toolbar_debugger_goto_pc", "toolbar_debugger_set_pc"}};
-  const wxSize tool_size = Parent->GetToolbarBitmapSize();
-  for (std::size_t i = 0; i < s_image_names.size(); ++i)
-    m_Bitmaps[i] =
-        WxUtils::LoadScaledResourceBitmap(s_image_names[i], Parent, tool_size, wxDefaultSize,
-                                          WxUtils::LSI_SCALE_DOWN | WxUtils::LSI_ALIGN_CENTER);
-}
-
-void CCodeWindow::PopulateToolbar(wxToolBar* toolBar)
-{
-  WxUtils::AddToolbarButton(toolBar, IDM_STEP, _("Step"), m_Bitmaps[Toolbar_Step],
-                            _("Step into the next instruction"));
-  WxUtils::AddToolbarButton(toolBar, IDM_STEPOVER, _("Step Over"), m_Bitmaps[Toolbar_StepOver],
-                            _("Step over the next instruction"));
-  WxUtils::AddToolbarButton(toolBar, IDM_STEPOUT, _("Step Out"), m_Bitmaps[Toolbar_StepOut],
-                            _("Step out of the current function"));
-  WxUtils::AddToolbarButton(toolBar, IDM_SKIP, _("Skip"), m_Bitmaps[Toolbar_Skip],
-                            _("Skips the next instruction completely"));
-  toolBar->AddSeparator();
-  WxUtils::AddToolbarButton(toolBar, IDM_GOTOPC, _("Show PC"), m_Bitmaps[Toolbar_GotoPC],
-                            _("Go to the current instruction"));
-  WxUtils::AddToolbarButton(toolBar, IDM_SETPC, _("Set PC"), m_Bitmaps[Toolbar_SetPC],
-                            _("Set the current instruction"));
-}
-
 // Update GUI
 void CCodeWindow::Repopulate()
 {
@@ -625,21 +587,7 @@ void CCodeWindow::UpdateButtonStates()
   bool Pause = (Core::GetState() == Core::CORE_PAUSE);
   bool Stepping = CPU::IsStepping();
   bool can_step = Initialized && Stepping;
-  wxToolBar* ToolBar = GetToolBar();
 
-  // Toolbar
-  if (!ToolBar)
-    return;
-
-  ToolBar->EnableTool(IDM_STEP, can_step);
-  ToolBar->EnableTool(IDM_STEPOVER, can_step);
-  ToolBar->EnableTool(IDM_STEPOUT, can_step);
-  ToolBar->EnableTool(IDM_SKIP, can_step);
-  ToolBar->EnableTool(IDM_SETPC, Pause);
-  ToolBar->Realize();
-
-  // Menu bar
-  // ------------------
   GetMenuBar()->Enable(IDM_INTERPRETER, Pause);  // CPU Mode
 
   GetMenuBar()->Enable(IDM_STEP, can_step);

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -7,7 +7,6 @@
 #include <array>
 
 #include <wx/aui/framemanager.h>
-#include <wx/bitmap.h>
 #include <wx/panel.h>
 
 #include "Common/CommonTypes.h"
@@ -86,7 +85,6 @@ public:
 
   // Parent interaction
   wxMenuBar* GetMenuBar();
-  wxToolBar* GetToolBar();
 
   bool UseInterpreter();
   bool BootToPause();
@@ -97,7 +95,6 @@ public:
 
   void Repopulate();
   void NotifyMapLoaded();
-  void PopulateToolbar(wxToolBar* toolBar);
   void UpdateButtonStates();
   void OpenPages();
 
@@ -157,10 +154,7 @@ private:
   void UpdateLists();
   void UpdateCallstack();
 
-  void InitBitmaps();
   wxPanel* CreateSiblingPanel(int id);
-
-  wxBitmap m_Bitmaps[Toolbar_Debug_Bitmap_Max];
 
   // Sibling debugger panels
   // FIXME: This obviously belongs in some manager class above this one.

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj
@@ -111,6 +111,7 @@
     <ClCompile Include="MainNoGUI.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="MainToolBar.cpp" />
     <ClCompile Include="MemcardManager.cpp" />
     <ClCompile Include="NetPlay\PadMapDialog.cpp" />
     <ClCompile Include="PatchAddEdit.cpp" />
@@ -175,6 +176,7 @@
     <ClInclude Include="LogWindow.h" />
     <ClInclude Include="Main.h" />
     <ClInclude Include="MainMenuBar.h" />
+    <ClInclude Include="MainToolBar.h" />
     <ClInclude Include="MemcardManager.h" />
     <ClInclude Include="PatchAddEdit.h" />
     <ClInclude Include="SoftwareVideoConfigDialog.h" />

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
@@ -151,6 +151,9 @@
     <ClCompile Include="MainMenuBar.cpp">
       <Filter>GUI</Filter>
     </ClCompile>
+    <ClCompile Include="MainToolBar.cpp">
+      <Filter>GUI</Filter>
+    </ClCompile>
     <ClCompile Include="MemcardManager.cpp">
       <Filter>GUI</Filter>
     </ClCompile>
@@ -328,6 +331,9 @@
       <Filter>GUI</Filter>
     </ClInclude>
     <ClInclude Include="MainMenuBar.h">
+      <Filter>GUI</Filter>
+    </ClInclude>
+    <ClInclude Include="MainToolBar.h">
       <Filter>GUI</Filter>
     </ClInclude>
     <ClInclude Include="MemcardManager.h">

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -59,6 +59,8 @@ private:
 #endif
 };
 
+wxDECLARE_EVENT(DOLPHIN_EVT_RELOAD_THEME_BITMAPS, wxCommandEvent);
+
 class CFrame : public CRenderFrame
 {
 public:
@@ -84,7 +86,6 @@ public:
   wxCheatsWindow* g_CheatsWindow = nullptr;
   TASInputDlg* g_TASInputDlg[8];
 
-  void InitBitmaps();
   void DoPause();
   void DoStop();
   void OnStopped();
@@ -112,7 +113,6 @@ public:
 
   const CGameListCtrl* GetGameListCtrl() const;
   wxMenuBar* GetMenuBar() const override;
-  const wxSize& GetToolbarBitmapSize() const;  // Needed before the toolbar exists
 
 #ifdef __WXGTK__
   Common::Event panic_event;
@@ -126,7 +126,6 @@ public:
 
   wxMenu* m_SavedPerspectives = nullptr;
 
-  wxToolBar* m_ToolBar = nullptr;
   // AUI
   wxAuiManager* m_Mgr = nullptr;
   bool bFloatWindow[IDM_DEBUG_WINDOW_LIST_END - IDM_DEBUG_WINDOW_LIST_START] = {};
@@ -164,21 +163,6 @@ private:
 
   std::vector<std::string> drives;
 
-  enum EToolbar
-  {
-    Toolbar_FileOpen,
-    Toolbar_Refresh,
-    Toolbar_Play,
-    Toolbar_Stop,
-    Toolbar_Pause,
-    Toolbar_Screenshot,
-    Toolbar_FullScreen,
-    Toolbar_ConfigMain,
-    Toolbar_ConfigGFX,
-    Toolbar_Controller,
-    EToolbar_Max
-  };
-
   enum
   {
     ADD_PANE_TOP,
@@ -191,16 +175,13 @@ private:
   wxTimer m_poll_hotkey_timer;
   wxTimer m_handle_signal_timer;
 
-  wxSize m_toolbar_bitmap_size;
-  wxBitmap m_Bitmaps[EToolbar_Max];
-
   wxMenuBar* m_menubar_shadow = nullptr;
 
-  void PopulateToolbar(wxToolBar* toolBar);
-  void RecreateToolbar();
-
-  wxMenuBar* CreateMenuBar() const;
+  void BindEvents();
   void BindMenuBarEvents();
+
+  wxToolBar* OnCreateToolBar(long style, wxWindowID id, const wxString& name) override;
+  wxMenuBar* CreateMenuBar() const;
 
   // Utility
   wxWindow* GetNotebookPageFromId(wxWindowID Id);
@@ -251,6 +232,8 @@ private:
   // Event functions
   void OnQuit(wxCommandEvent& event);
   void OnHelp(wxCommandEvent& event);
+
+  void OnReloadThemeBitmaps(wxCommandEvent& event);
 
   void OnOpen(wxCommandEvent& event);  // File menu
   void DoOpen(bool Boot);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -68,6 +68,7 @@
 #include "DolphinWX/InputConfigDiag.h"
 #include "DolphinWX/LogWindow.h"
 #include "DolphinWX/MainMenuBar.h"
+#include "DolphinWX/MainToolBar.h"
 #include "DolphinWX/MemcardManager.h"
 #include "DolphinWX/NetPlay/NetPlaySetupFrame.h"
 #include "DolphinWX/NetPlay/NetWindow.h"
@@ -95,11 +96,6 @@ wxMenuBar* CFrame::GetMenuBar() const
   {
     return m_menubar_shadow;
   }
-}
-
-const wxSize& CFrame::GetToolbarBitmapSize() const
-{
-  return m_toolbar_bitmap_size;
 }
 
 // Create menu items
@@ -200,69 +196,12 @@ void CFrame::BindMenuBarEvents()
   Bind(wxEVT_MENU, &CFrame::OnHelp, this, wxID_ABOUT);
 }
 
-// Create toolbar items
-// ---------------------
-void CFrame::PopulateToolbar(wxToolBar* ToolBar)
+wxToolBar* CFrame::OnCreateToolBar(long style, wxWindowID id, const wxString& name)
 {
-  WxUtils::AddToolbarButton(ToolBar, wxID_OPEN, _("Open"), m_Bitmaps[Toolbar_FileOpen],
-                            _("Open file..."));
-  WxUtils::AddToolbarButton(ToolBar, wxID_REFRESH, _("Refresh"), m_Bitmaps[Toolbar_Refresh],
-                            _("Refresh game list"));
-  ToolBar->AddSeparator();
-  WxUtils::AddToolbarButton(ToolBar, IDM_PLAY, _("Play"), m_Bitmaps[Toolbar_Play], _("Play"));
-  WxUtils::AddToolbarButton(ToolBar, IDM_STOP, _("Stop"), m_Bitmaps[Toolbar_Stop], _("Stop"));
-  WxUtils::AddToolbarButton(ToolBar, IDM_TOGGLE_FULLSCREEN, _("FullScr"),
-                            m_Bitmaps[Toolbar_FullScreen], _("Toggle fullscreen"));
-  WxUtils::AddToolbarButton(ToolBar, IDM_SCREENSHOT, _("ScrShot"), m_Bitmaps[Toolbar_Screenshot],
-                            _("Take screenshot"));
-  ToolBar->AddSeparator();
-  WxUtils::AddToolbarButton(ToolBar, wxID_PREFERENCES, _("Config"), m_Bitmaps[Toolbar_ConfigMain],
-                            _("Configure..."));
-  WxUtils::AddToolbarButton(ToolBar, IDM_CONFIG_GFX_BACKEND, _("Graphics"),
-                            m_Bitmaps[Toolbar_ConfigGFX], _("Graphics settings"));
-  WxUtils::AddToolbarButton(ToolBar, IDM_CONFIG_CONTROLLERS, _("Controllers"),
-                            m_Bitmaps[Toolbar_Controller], _("Controller settings"));
-}
+  const auto type =
+      UseDebugger ? MainToolBar::ToolBarType::Debug : MainToolBar::ToolBarType::Regular;
 
-// Delete and recreate the toolbar
-void CFrame::RecreateToolbar()
-{
-  static constexpr long TOOLBAR_STYLE = wxTB_DEFAULT_STYLE | wxTB_TEXT | wxTB_FLAT;
-
-  if (m_ToolBar != nullptr)
-  {
-    m_ToolBar->Destroy();
-    m_ToolBar = nullptr;
-  }
-
-  m_ToolBar = CreateToolBar(TOOLBAR_STYLE, wxID_ANY);
-  m_ToolBar->SetToolBitmapSize(m_toolbar_bitmap_size);
-
-  if (g_pCodeWindow)
-  {
-    g_pCodeWindow->PopulateToolbar(m_ToolBar);
-    m_ToolBar->AddSeparator();
-  }
-
-  PopulateToolbar(m_ToolBar);
-  // after adding the buttons to the toolbar, must call Realize() to reflect
-  // the changes
-  m_ToolBar->Realize();
-
-  UpdateGUI();
-}
-
-void CFrame::InitBitmaps()
-{
-  static constexpr std::array<const char* const, EToolbar_Max> s_image_names{
-      {"open", "refresh", "play", "stop", "pause", "screenshot", "fullscreen", "config", "graphics",
-       "classic"}};
-  for (std::size_t i = 0; i < s_image_names.size(); ++i)
-    m_Bitmaps[i] = WxUtils::LoadScaledThemeBitmap(s_image_names[i], this, m_toolbar_bitmap_size);
-
-  // Update in case the bitmap has been updated
-  if (m_ToolBar != nullptr)
-    RecreateToolbar();
+  return new MainToolBar{type, this, id, wxDefaultPosition, wxDefaultSize, style};
 }
 
 void CFrame::OpenGeneralConfiguration(int tab)
@@ -629,8 +568,7 @@ void CFrame::StartGame(const std::string& filename)
     return;
   m_bGameLoading = true;
 
-  if (m_ToolBar)
-    m_ToolBar->EnableTool(IDM_PLAY, false);
+  GetToolBar()->EnableTool(IDM_PLAY, false);
   GetMenuBar()->FindItem(IDM_PLAY)->Enable(false);
 
   if (SConfig::GetInstance().bRenderToMain)
@@ -1066,6 +1004,15 @@ void CFrame::OnHelp(wxCommandEvent& event)
   }
 }
 
+void CFrame::OnReloadThemeBitmaps(wxCommandEvent& WXUNUSED(event))
+{
+  wxCommandEvent reload_event{DOLPHIN_EVT_RELOAD_TOOLBAR_BITMAPS};
+  reload_event.SetEventObject(this);
+  wxPostEvent(GetToolBar(), reload_event);
+
+  UpdateGameList();
+}
+
 void CFrame::ClearStatusBar()
 {
   if (this->GetStatusBar()->IsEnabled())
@@ -1368,18 +1315,7 @@ void CFrame::UpdateGUI()
   bool Paused = Core::GetState() == Core::CORE_PAUSE;
   bool Stopping = Core::GetState() == Core::CORE_STOPPING;
 
-  // Make sure that we have a toolbar
-  if (m_ToolBar)
-  {
-    // Enable/disable the Config and Stop buttons
-    m_ToolBar->EnableTool(wxID_OPEN, !Initialized);
-    // Don't allow refresh when we don't show the list
-    m_ToolBar->EnableTool(wxID_REFRESH, !Initialized);
-    m_ToolBar->EnableTool(IDM_STOP, Running || Paused);
-    m_ToolBar->EnableTool(IDM_TOGGLE_FULLSCREEN, Running || Paused);
-    m_ToolBar->EnableTool(IDM_SCREENSHOT, Running || Paused);
-  }
-
+  GetToolBar()->Refresh(false);
   GetMenuBar()->Refresh(false);
 
   // File
@@ -1436,33 +1372,6 @@ void CFrame::UpdateGUI()
     Core::PauseAndLock(false, was_unpaused);
   }
 
-  if (m_ToolBar)
-  {
-    // Get the tool that controls pausing/playing
-    wxToolBarToolBase* PlayTool = m_ToolBar->FindById(IDM_PLAY);
-
-    if (PlayTool)
-    {
-      int position = m_ToolBar->GetToolPos(IDM_PLAY);
-
-      if (Running)
-      {
-        m_ToolBar->DeleteTool(IDM_PLAY);
-        m_ToolBar->InsertTool(position, IDM_PLAY, _("Pause"), m_Bitmaps[Toolbar_Pause],
-                              WxUtils::CreateDisabledButtonBitmap(m_Bitmaps[Toolbar_Pause]),
-                              wxITEM_NORMAL, _("Pause"));
-      }
-      else
-      {
-        m_ToolBar->DeleteTool(IDM_PLAY);
-        m_ToolBar->InsertTool(position, IDM_PLAY, _("Play"), m_Bitmaps[Toolbar_Play],
-                              WxUtils::CreateDisabledButtonBitmap(m_Bitmaps[Toolbar_Play]),
-                              wxITEM_NORMAL, _("Play"));
-      }
-      m_ToolBar->Realize();
-    }
-  }
-
   GetMenuBar()->FindItem(IDM_RECORD_READ_ONLY)->Enable(Running || Paused);
 
   if (!Initialized && !m_bGameLoading)
@@ -1472,8 +1381,7 @@ void CFrame::UpdateGUI()
       // Prepare to load Default ISO, enable play button
       if (!SConfig::GetInstance().m_strDefaultISO.empty())
       {
-        if (m_ToolBar)
-          m_ToolBar->EnableTool(IDM_PLAY, true);
+        GetToolBar()->EnableTool(IDM_PLAY, true);
         GetMenuBar()->FindItem(IDM_PLAY)->Enable();
         GetMenuBar()->FindItem(IDM_RECORD)->Enable();
         GetMenuBar()->FindItem(IDM_PLAY_RECORD)->Enable();
@@ -1482,8 +1390,7 @@ void CFrame::UpdateGUI()
       else if (!SConfig::GetInstance().m_LastFilename.empty() &&
                File::Exists(SConfig::GetInstance().m_LastFilename))
       {
-        if (m_ToolBar)
-          m_ToolBar->EnableTool(IDM_PLAY, true);
+        GetToolBar()->EnableTool(IDM_PLAY, true);
         GetMenuBar()->FindItem(IDM_PLAY)->Enable();
         GetMenuBar()->FindItem(IDM_RECORD)->Enable();
         GetMenuBar()->FindItem(IDM_PLAY_RECORD)->Enable();
@@ -1491,8 +1398,7 @@ void CFrame::UpdateGUI()
       else
       {
         // No game has been selected yet, disable play button
-        if (m_ToolBar)
-          m_ToolBar->EnableTool(IDM_PLAY, false);
+        GetToolBar()->EnableTool(IDM_PLAY, false);
         GetMenuBar()->FindItem(IDM_PLAY)->Enable(false);
         GetMenuBar()->FindItem(IDM_RECORD)->Enable(false);
         GetMenuBar()->FindItem(IDM_PLAY_RECORD)->Enable(false);
@@ -1508,8 +1414,7 @@ void CFrame::UpdateGUI()
     // Game has been selected but not started, enable play button
     if (m_GameListCtrl->GetSelectedISO() != nullptr && m_GameListCtrl->IsEnabled())
     {
-      if (m_ToolBar)
-        m_ToolBar->EnableTool(IDM_PLAY, true);
+      GetToolBar()->EnableTool(IDM_PLAY, true);
       GetMenuBar()->FindItem(IDM_PLAY)->Enable();
       GetMenuBar()->FindItem(IDM_RECORD)->Enable();
       GetMenuBar()->FindItem(IDM_PLAY_RECORD)->Enable();
@@ -1518,19 +1423,14 @@ void CFrame::UpdateGUI()
   else if (Initialized)
   {
     // Game has been loaded, enable the pause button
-    if (m_ToolBar)
-      m_ToolBar->EnableTool(IDM_PLAY, !Stopping);
+    GetToolBar()->EnableTool(IDM_PLAY, !Stopping);
     GetMenuBar()->FindItem(IDM_PLAY)->Enable(!Stopping);
 
     // Reset game loading flag
     m_bGameLoading = false;
   }
 
-  // Refresh toolbar
-  if (m_ToolBar)
-  {
-    m_ToolBar->Refresh();
-  }
+  GetToolBar()->Refresh(false);
 
   // Commit changes to manager
   m_Mgr->Update();

--- a/Source/Core/DolphinWX/Globals.h
+++ b/Source/Core/DolphinWX/Globals.h
@@ -11,17 +11,6 @@
 
 enum
 {
-  Toolbar_Step,
-  Toolbar_StepOver,
-  Toolbar_StepOut,
-  Toolbar_Skip,
-  Toolbar_GotoPC,
-  Toolbar_SetPC,
-  Toolbar_Debug_Bitmap_Max
-};
-
-enum
-{
   // Emulation menu
   IDM_LOAD_STATE = 200,
   IDM_SAVE_STATE,

--- a/Source/Core/DolphinWX/MainToolBar.cpp
+++ b/Source/Core/DolphinWX/MainToolBar.cpp
@@ -1,0 +1,255 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinWX/MainToolBar.h"
+
+#include <array>
+#include <utility>
+
+#include "Core/Core.h"
+#include "Core/HW/CPU.h"
+#include "DolphinWX/Globals.h"
+#include "DolphinWX/WxUtils.h"
+
+wxDEFINE_EVENT(DOLPHIN_EVT_RELOAD_TOOLBAR_BITMAPS, wxCommandEvent);
+
+MainToolBar::MainToolBar(ToolBarType type, wxWindow* parent, wxWindowID id, const wxPoint& pos,
+                         const wxSize& size, long style, const wxString& name)
+    : wxToolBar{parent, id, pos, size, style, name}, m_type{type}
+{
+  wxToolBar::SetToolBitmapSize(FromDIP(wxSize{32, 32}));
+  InitializeBitmaps();
+  AddToolBarButtons();
+  wxToolBar::Realize();
+
+  BindEvents();
+}
+
+void MainToolBar::BindEvents()
+{
+  Bind(DOLPHIN_EVT_RELOAD_TOOLBAR_BITMAPS, &MainToolBar::OnReloadBitmaps, this);
+
+  BindMainButtonEvents();
+
+  if (m_type == ToolBarType::Debug)
+    BindDebuggerButtonEvents();
+}
+
+void MainToolBar::BindMainButtonEvents()
+{
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCoreNotRunning, this, wxID_OPEN);
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCoreNotRunning, this, wxID_REFRESH);
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCoreRunningOrPaused, this, IDM_STOP);
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCoreRunningOrPaused, this, IDM_TOGGLE_FULLSCREEN);
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCoreRunningOrPaused, this, IDM_SCREENSHOT);
+}
+
+void MainToolBar::BindDebuggerButtonEvents()
+{
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCPUCanStep, this, IDM_STEP);
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCPUCanStep, this, IDM_STEPOVER);
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCPUCanStep, this, IDM_STEPOUT);
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCPUCanStep, this, IDM_SKIP);
+  Bind(wxEVT_UPDATE_UI, &MainToolBar::OnUpdateIfCorePaused, this, IDM_SETPC);
+}
+
+void MainToolBar::OnUpdateIfCoreNotRunning(wxUpdateUIEvent& event)
+{
+  event.Enable(!Core::IsRunning());
+}
+
+void MainToolBar::OnUpdateIfCorePaused(wxUpdateUIEvent& event)
+{
+  event.Enable(Core::GetState() == Core::CORE_PAUSE);
+}
+
+void MainToolBar::OnUpdateIfCoreRunningOrPaused(wxUpdateUIEvent& event)
+{
+  const auto state = Core::GetState();
+
+  event.Enable(state == Core::CORE_RUN || state == Core::CORE_PAUSE);
+}
+
+void MainToolBar::OnUpdateIfCPUCanStep(wxUpdateUIEvent& event)
+{
+  event.Enable(Core::IsRunning() && CPU::IsStepping());
+}
+
+void MainToolBar::OnReloadBitmaps(wxCommandEvent& WXUNUSED(event))
+{
+  Freeze();
+
+  m_icon_bitmaps.clear();
+  InitializeBitmaps();
+  ApplyThemeBitmaps();
+
+  if (m_type == ToolBarType::Debug)
+    ApplyDebuggerBitmaps();
+
+  Thaw();
+}
+
+void MainToolBar::Refresh(bool erase_background, const wxRect* rect)
+{
+  wxToolBar::Refresh(erase_background, rect);
+
+  RefreshPlayButton();
+}
+
+void MainToolBar::InitializeBitmaps()
+{
+  InitializeThemeBitmaps();
+
+  if (m_type == ToolBarType::Debug)
+    InitializeDebuggerBitmaps();
+}
+
+void MainToolBar::InitializeThemeBitmaps()
+{
+  m_icon_bitmaps.insert({{TOOLBAR_FILEOPEN, CreateBitmap("open")},
+                         {TOOLBAR_REFRESH, CreateBitmap("refresh")},
+                         {TOOLBAR_PLAY, CreateBitmap("play")},
+                         {TOOLBAR_STOP, CreateBitmap("stop")},
+                         {TOOLBAR_PAUSE, CreateBitmap("pause")},
+                         {TOOLBAR_SCREENSHOT, CreateBitmap("screenshot")},
+                         {TOOLBAR_FULLSCREEN, CreateBitmap("fullscreen")},
+                         {TOOLBAR_CONFIGMAIN, CreateBitmap("config")},
+                         {TOOLBAR_CONFIGGFX, CreateBitmap("graphics")},
+                         {TOOLBAR_CONTROLLER, CreateBitmap("classic")}});
+}
+
+void MainToolBar::InitializeDebuggerBitmaps()
+{
+  m_icon_bitmaps.insert(
+      {{TOOLBAR_DEBUG_STEP, CreateDebuggerBitmap("toolbar_debugger_step")},
+       {TOOLBAR_DEBUG_STEPOVER, CreateDebuggerBitmap("toolbar_debugger_step_over")},
+       {TOOLBAR_DEBUG_STEPOUT, CreateDebuggerBitmap("toolbar_debugger_step_out")},
+       {TOOLBAR_DEBUG_SKIP, CreateDebuggerBitmap("toolbar_debugger_skip")},
+       {TOOLBAR_DEBUG_GOTOPC, CreateDebuggerBitmap("toolbar_debugger_goto_pc")},
+       {TOOLBAR_DEBUG_SETPC, CreateDebuggerBitmap("toolbar_debugger_set_pc")}});
+}
+
+wxBitmap MainToolBar::CreateBitmap(const std::string& name) const
+{
+  return WxUtils::LoadScaledThemeBitmap(name, this, GetToolBitmapSize());
+}
+
+wxBitmap MainToolBar::CreateDebuggerBitmap(const std::string& name) const
+{
+  constexpr auto scale_flags = WxUtils::LSI_SCALE_DOWN | WxUtils::LSI_ALIGN_CENTER;
+
+  return WxUtils::LoadScaledResourceBitmap(name, this, GetToolBitmapSize(), wxDefaultSize,
+                                           scale_flags);
+}
+
+void MainToolBar::ApplyThemeBitmaps()
+{
+  constexpr std::array<std::pair<int, ToolBarBitmapID>, 8> bitmap_entries{
+      {{wxID_OPEN, TOOLBAR_FILEOPEN},
+       {wxID_REFRESH, TOOLBAR_REFRESH},
+       {IDM_STOP, TOOLBAR_STOP},
+       {IDM_TOGGLE_FULLSCREEN, TOOLBAR_FULLSCREEN},
+       {IDM_SCREENSHOT, TOOLBAR_SCREENSHOT},
+       {wxID_PREFERENCES, TOOLBAR_CONFIGMAIN},
+       {IDM_CONFIG_GFX_BACKEND, TOOLBAR_CONFIGGFX},
+       {IDM_CONFIG_CONTROLLERS, TOOLBAR_CONTROLLER}}};
+
+  for (const auto& entry : bitmap_entries)
+    ApplyBitmap(entry.first, entry.second);
+
+  // Separate, as the play button is dual-state and doesn't have a fixed bitmap.
+  RefreshPlayButton();
+}
+
+void MainToolBar::ApplyDebuggerBitmaps()
+{
+  constexpr std::array<std::pair<int, ToolBarBitmapID>, 6> bitmap_entries{
+      {{IDM_STEP, TOOLBAR_DEBUG_STEP},
+       {IDM_STEPOVER, TOOLBAR_DEBUG_STEPOVER},
+       {IDM_STEPOUT, TOOLBAR_DEBUG_STEPOUT},
+       {IDM_SKIP, TOOLBAR_DEBUG_SKIP},
+       {IDM_GOTOPC, TOOLBAR_DEBUG_GOTOPC},
+       {IDM_SETPC, TOOLBAR_DEBUG_SETPC}}};
+
+  for (const auto& entry : bitmap_entries)
+    ApplyBitmap(entry.first, entry.second);
+}
+
+void MainToolBar::ApplyBitmap(int tool_id, ToolBarBitmapID bitmap_id)
+{
+  const auto& bitmap = m_icon_bitmaps[bitmap_id];
+
+  SetToolDisabledBitmap(tool_id, WxUtils::CreateDisabledButtonBitmap(bitmap));
+  SetToolNormalBitmap(tool_id, bitmap);
+}
+
+void MainToolBar::AddToolBarButtons()
+{
+  if (m_type == ToolBarType::Debug)
+  {
+    AddDebuggerToolBarButtons();
+    AddSeparator();
+  }
+
+  AddMainToolBarButtons();
+}
+
+void MainToolBar::AddMainToolBarButtons()
+{
+  AddToolBarButton(wxID_OPEN, TOOLBAR_FILEOPEN, _("Open"), _("Open file..."));
+  AddToolBarButton(wxID_REFRESH, TOOLBAR_REFRESH, _("Refresh"), _("Refresh game list"));
+  AddSeparator();
+  AddToolBarButton(IDM_PLAY, TOOLBAR_PLAY, _("Play"), _("Play"));
+  AddToolBarButton(IDM_STOP, TOOLBAR_STOP, _("Stop"), _("Stop"));
+  AddToolBarButton(IDM_TOGGLE_FULLSCREEN, TOOLBAR_FULLSCREEN, _("FullScr"), _("Toggle fullscreen"));
+  AddToolBarButton(IDM_SCREENSHOT, TOOLBAR_SCREENSHOT, _("ScrShot"), _("Take screenshot"));
+  AddSeparator();
+  AddToolBarButton(wxID_PREFERENCES, TOOLBAR_CONFIGMAIN, _("Config"), _("Configure..."));
+  AddToolBarButton(IDM_CONFIG_GFX_BACKEND, TOOLBAR_CONFIGGFX, _("Graphics"),
+                   _("Graphics settings"));
+  AddToolBarButton(IDM_CONFIG_CONTROLLERS, TOOLBAR_CONTROLLER, _("Controllers"),
+                   _("Controller settings"));
+}
+
+void MainToolBar::AddDebuggerToolBarButtons()
+{
+  AddToolBarButton(IDM_STEP, TOOLBAR_DEBUG_STEP, _("Step"), _("Step into the next instruction"));
+  AddToolBarButton(IDM_STEPOVER, TOOLBAR_DEBUG_STEPOVER, _("Step Over"),
+                   _("Step over the next instruction"));
+  AddToolBarButton(IDM_STEPOUT, TOOLBAR_DEBUG_STEPOUT, _("Step Out"),
+                   _("Step out of the current function"));
+  AddToolBarButton(IDM_SKIP, TOOLBAR_DEBUG_SKIP, _("Skip"),
+                   _("Skips the next instruction completely"));
+  AddSeparator();
+  AddToolBarButton(IDM_GOTOPC, TOOLBAR_DEBUG_GOTOPC, _("Show PC"),
+                   _("Go to the current instruction"));
+  AddToolBarButton(IDM_SETPC, TOOLBAR_DEBUG_SETPC, _("Set PC"), _("Set the current instruction"));
+}
+
+void MainToolBar::AddToolBarButton(int tool_id, ToolBarBitmapID bitmap_id, const wxString& label,
+                                   const wxString& short_help)
+{
+  WxUtils::AddToolbarButton(this, tool_id, label, m_icon_bitmaps[bitmap_id], short_help);
+}
+
+void MainToolBar::RefreshPlayButton()
+{
+  ToolBarBitmapID bitmap_id;
+  wxString label;
+
+  if (Core::GetState() == Core::CORE_RUN)
+  {
+    bitmap_id = TOOLBAR_PAUSE;
+    label = _("Pause");
+  }
+  else
+  {
+    bitmap_id = TOOLBAR_PLAY;
+    label = _("Play");
+  }
+
+  FindById(IDM_PLAY)->SetLabel(label);
+  SetToolShortHelp(IDM_PLAY, label);
+  ApplyBitmap(IDM_PLAY, bitmap_id);
+}

--- a/Source/Core/DolphinWX/MainToolBar.h
+++ b/Source/Core/DolphinWX/MainToolBar.h
@@ -1,0 +1,84 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <wx/bitmap.h>
+#include <wx/toolbar.h>
+
+wxDECLARE_EVENT(DOLPHIN_EVT_RELOAD_TOOLBAR_BITMAPS, wxCommandEvent);
+
+class MainToolBar final : public wxToolBar
+{
+public:
+  enum class ToolBarType
+  {
+    Regular,
+    Debug
+  };
+
+  MainToolBar(ToolBarType type, wxWindow* parent, wxWindowID id,
+              const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+              long style = wxTB_HORIZONTAL, const wxString& name = wxToolBarNameStr);
+
+  void Refresh(bool erase_background, const wxRect* rect = nullptr) override;
+
+private:
+  enum ToolBarBitmapID : int
+  {
+    TOOLBAR_DEBUG_STEP,
+    TOOLBAR_DEBUG_STEPOVER,
+    TOOLBAR_DEBUG_STEPOUT,
+    TOOLBAR_DEBUG_SKIP,
+    TOOLBAR_DEBUG_GOTOPC,
+    TOOLBAR_DEBUG_SETPC,
+
+    TOOLBAR_FILEOPEN,
+    TOOLBAR_REFRESH,
+    TOOLBAR_PLAY,
+    TOOLBAR_STOP,
+    TOOLBAR_PAUSE,
+    TOOLBAR_SCREENSHOT,
+    TOOLBAR_FULLSCREEN,
+    TOOLBAR_CONFIGMAIN,
+    TOOLBAR_CONFIGGFX,
+    TOOLBAR_CONTROLLER,
+  };
+
+  void BindEvents();
+  void BindMainButtonEvents();
+  void BindDebuggerButtonEvents();
+
+  void OnUpdateIfCoreNotRunning(wxUpdateUIEvent&);
+  void OnUpdateIfCorePaused(wxUpdateUIEvent&);
+  void OnUpdateIfCoreRunningOrPaused(wxUpdateUIEvent&);
+  void OnUpdateIfCPUCanStep(wxUpdateUIEvent&);
+
+  void OnReloadBitmaps(wxCommandEvent&);
+
+  void InitializeBitmaps();
+  void InitializeThemeBitmaps();
+  void InitializeDebuggerBitmaps();
+
+  wxBitmap CreateBitmap(const std::string& name) const;
+  wxBitmap CreateDebuggerBitmap(const std::string& name) const;
+
+  void ApplyThemeBitmaps();
+  void ApplyDebuggerBitmaps();
+  void ApplyBitmap(int tool_id, ToolBarBitmapID bitmap_id);
+
+  void AddToolBarButtons();
+  void AddMainToolBarButtons();
+  void AddDebuggerToolBarButtons();
+  void AddToolBarButton(int tool_id, ToolBarBitmapID bitmap_id, const wxString& label,
+                        const wxString& short_help = wxEmptyString);
+
+  void RefreshPlayButton();
+
+  ToolBarType m_type{};
+  std::unordered_map<ToolBarBitmapID, wxBitmap, std::hash<int>> m_icon_bitmaps;
+};


### PR DESCRIPTION
Completely excises toolbar code from CodeWindow and merges both the debugger and main menu toolbar creation under a wxToolBar subclass. It also centralizes all of the bitmap loading into that class as well.

Overriding `OnCreateToolBar()` in the main frame is done, as it will instantiate an instance of the custom toolbar whenever `CreateToolBar()` is called, rather than instantiating a generic wxToolBar instance. This also gets rid of the need to manually manage the toolbar.

This also makes the toolbar less silly with regards to lifetime. The main frame used to destroy and recreate the entire toolbar whenever the theme was changed instead of just updating the toolbar items.

All that's left after this, is to remove the remaining menubar code from CodeWindow, and then I can start work on making CodeWindow a proper leaf-class in the window hierarchy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4380)
<!-- Reviewable:end -->
