### PR TITLE
Add an EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+; Top-most EditorConfig file
+root = true
+
+; 2 space indentation by default
+[*]
+indent_style = space
+indent_size = 2
+
+; 4 space indentation for markdown
+[*.md]
+indent_style = space
+indent_size = 4
+
+; Tab indentation for python scripts
+[*.py]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
Since we've switched to the 2-space indentation scheme, it may be useful to add an [EditorConfig](http://editorconfig.org/) file. This is a [widely supported format](http://editorconfig.org/#download) either through native support or plugins for managing editor settings such as indentation per-project.

According to a [user feedback ticket](https://visualstudio.uservoice.com/forums/121579-visual-studio-2015/suggestions/6146845-support-editorconfig) it will also be natively supported in next version of Visual Studio.

We seem to use a different indentation style for python scripts and markdown files, as such I have added specific settings for those file types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4382)
<!-- Reviewable:end -->
