### PR TITLE
Android: Fix "up one level" button

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/AddDirectoryActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/AddDirectoryActivity.java
@@ -10,10 +10,10 @@ import android.os.Environment;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.widget.Toolbar;
 
 import org.dolphinemu.dolphinemu.BuildConfig;
 import org.dolphinemu.dolphinemu.R;
@@ -41,7 +41,7 @@ public class AddDirectoryActivity extends AppCompatActivity implements FileAdapt
 		setContentView(R.layout.activity_add_directory);
 
 		mToolbar = (Toolbar) findViewById(R.id.toolbar_folder_list);
-		setActionBar(mToolbar);
+		setSupportActionBar(mToolbar);
 
 		RecyclerView recyclerView = (RecyclerView) findViewById(R.id.list_files);
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/FileAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/FileAdapter.java
@@ -1,5 +1,6 @@
 package org.dolphinemu.dolphinemu.adapters;
 
+import android.os.Environment;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -197,12 +198,15 @@ public final class FileAdapter extends RecyclerView.Adapter<FileViewHolder> impl
 
 	public void upOneLevel()
 	{
-		File currentDirectory = new File(mPath);
-		File parentDirectory = currentDirectory.getParentFile();
+		if (!mPath.equals(Environment.getExternalStorageDirectory().getPath()))
+		{
+			File currentDirectory = new File(mPath);
+			File parentDirectory = currentDirectory.getParentFile();
 
-		mFileList = generateFileList(parentDirectory);
-		notifyDataSetChanged();
-		mListener.updateSubtitle(mPath);
+			mFileList = generateFileList(parentDirectory);
+			notifyDataSetChanged();
+			mListener.updateSubtitle(mPath);
+		}
 	}
 
 	/**

--- a/Source/Android/app/src/main/res/layout/activity_add_directory.xml
+++ b/Source/Android/app/src/main/res/layout/activity_add_directory.xml
@@ -5,7 +5,7 @@
               android:layout_height="match_parent"
               android:orientation="vertical">
 
-    <Toolbar
+    <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar_folder_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
I did two things here:
 -Made the button actually show up by using a support toolbar
 -Prevent going up a level if the current directory is the storage directory

Leaving the storage directory brings us to "empty" folders that we don't have access to, and going up at "/" crashes the app, hence the restriction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4384)
<!-- Reviewable:end -->
