### PR TITLE
Disable descriptor check for BT passthrough in some cases

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
@@ -50,8 +50,6 @@ public:
 
 private:
   static constexpr u8 INTERFACE = 0x00;
-  static constexpr u8 SUBCLASS = 0x01;
-  static constexpr u8 PROTOCOL_BLUETOOTH = 0x01;
   // Arbitrarily chosen value that allows emulated software to send commands often enough
   // so that the sync button event is triggered at least every 200ms.
   // Ideally this should be equal to 0, so we don't trigger unnecessary libusb transfers.


### PR DESCRIPTION
Some adapters don't have the correct interface class, so they are not recognised as Bluetooth adapters. It seems that apart from hardcoding VIDs/PIDs (which is how it's done in the Linux kernel, and which I'm not very fond of), there is no other way to detect if a device is a Bluetooth adapter or not.

So I think adding an option to disable the descriptor check is the only sane way to allow such adapters to be used.

While this solution seems best for maintainability, it's not terribly user friendly. Does someone have any better idea?

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4385)

<!-- Reviewable:end -->
