### PR TITLE
Add precision about the names of r1, r2 and r13 for the register view

### DIFF
--- a/Source/Core/Common/GekkoDisassembler.cpp
+++ b/Source/Core/Common/GekkoDisassembler.cpp
@@ -2289,10 +2289,10 @@ std::string GekkoDisassembler::Disassemble(u32 opcode, u32 current_instruction_a
   return m_opcode.append("\t").append(m_operands);
 }
 
-static const char* gprnames[] = {" r0", " r1", " r2", " r3", " r4", " r5", " r6", " r7",
-                                 " r8", " r9", "r10", "r11", "r12", "r13", "r14", "r15",
-                                 "r16", "r17", "r18", "r19", "r20", "r21", "r22", "r23",
-                                 "r24", "r25", "r26", "r27", "r28", "r29", "r30", "r31"};
+static const char* gprnames[] = {
+    " r0", " r1 (sp)", " r2 (rtoc)", " r3", " r4", " r5", " r6", " r7", " r8", " r9", "r10",
+    "r11", "r12",      "r13",        "r14", "r15", "r16", "r17", "r18", "r19", "r20", "r21",
+    "r22", "r23",      "r24",        "r25", "r26", "r27", "r28", "r29", "r30", "r31"};
 
 const char* GekkoDisassembler::GetGPRName(u32 index)
 {


### PR DESCRIPTION
In the code view, it would never say r1 or r2, but rather sp (stack pointer) and rtoc (register of the table of content) respectively.  In the register view, all it says is the register number.  This is an inconvenience considering it might not be obvious which register belongs to which of these terms.

Also make r13 named the "sda" for small data area with the same convention as above.

Should clear up confusion for people starting to use the debugger.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4387)

<!-- Reviewable:end -->
