### PR TITLE
Android: Allow accessing all folders

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/FileAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/FileAdapter.java
@@ -198,7 +198,7 @@ public final class FileAdapter extends RecyclerView.Adapter<FileViewHolder> impl
 
 	public void upOneLevel()
 	{
-		if (!mPath.equals(Environment.getExternalStorageDirectory().getPath()))
+		if (!mPath.equals("/"))
 		{
 			File currentDirectory = new File(mPath);
 			File parentDirectory = currentDirectory.getParentFile();


### PR DESCRIPTION
This was talked about over at #4384 

Basically, restricting users to the storage directory is a bad idea because it prevents accessing the SD card, and I should've done it like this in the first place. The restriction is still needed to prevent the crash when trying to go up from "/".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4389)
<!-- Reviewable:end -->
