### PR TITLE
Android: Fix screenshots on game list

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/Game.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/Game.java
@@ -27,7 +27,7 @@ public final class Game
 	public static final int COUNTRY_WORLD = 12;
 	public static final int COUNTRY_UNKNOWN = 13;
 
-	private static final String PATH_SCREENSHOT_FOLDER = Environment.getExternalStorageDirectory().getPath() + "dolphin-emu/ScreenShots/";
+	private static final String PATH_SCREENSHOT_FOLDER = "file://" + Environment.getExternalStorageDirectory().getPath() + "/dolphin-emu/ScreenShots/";
 
 	private String mTitle;
 	private String mDescription;


### PR DESCRIPTION
Picasso expects a URL when given a string. Also, Environment.getExternalStorageDirectory().getPath() doesn't give us a "/" at the end.

You will have to refresh your library to update the screenshot paths of your current games.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4390)
<!-- Reviewable:end -->
