### PR TITLE
Change "Wiimote" to "Wii Remote" in Interface

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -24,19 +24,19 @@
 
     <!-- WARNING Do not move these controller entries AT ALL COSTS! They are indexed with ints, and an assumption
             is made that they are placed together so that we can access them sequentially in a loop. -->
-    <string name="wiimote_0">Wiimote 1</string>
-    <string name="wiimote_1">Wiimote 2</string>
-    <string name="wiimote_2">Wiimote 3</string>
-    <string name="wiimote_3">Wiimote 4</string>
+    <string name="wiimote_0">Wii Remote 1</string>
+    <string name="wiimote_1">Wii Remote 2</string>
+    <string name="wiimote_2">Wii Remote 3</string>
+    <string name="wiimote_3">Wii Remote 4</string>
     <!-- END WARNING -->
 
-    <string name="enable_wiimote">Enable Wiimote</string>
+    <string name="enable_wiimote">Enable Wii Remote</string>
     <string name="wiimote_ir">IR Motion Controls</string>
     <string name="wiimote_swing">Swing Navigation</string>
     <string name="wiimote_tilt">Tilt Navigation</string>
     <string name="wiimote_shake">Shake Controls</string>
     <string name="wiimote_stick">Analog Stick Navigation</string>
-    <string name="wiimote_extensions">Wiimote Extension</string>
+    <string name="wiimote_extensions">Wii Remote Extension</string>
     <string name="wiimote_extensions_descrip">Choose which Extension you want to use with the Wiimote</string>
     <string name="show_nunchuk">Nunchuk</string>
     <string name="show_classic">Classic Controller</string>
@@ -46,7 +46,7 @@
     <string name="input_binding">Input Binding</string>
     <string name="input_binding_descrip">Press or move an input to bind it to %1$s.</string>
 
-    <!-- GameCube buttons (May be shared with Wiimote stuff too) -->
+    <!-- GameCube buttons (May be shared with Wii Remote stuff too) -->
     <string name="button_a">Button A</string>
     <string name="button_b">Button B</string>
     <string name="button_start">Button Start</string>
@@ -68,7 +68,7 @@
     <string name="trigger_left">Trigger L</string>
     <string name="trigger_right">Trigger R</string>
 
-    <!-- Wiimote (+ extension) only buttons -->
+    <!-- Wii Remote (+ extension) only buttons -->
     <string name="button_one">Button 1</string>
     <string name="button_two">Button 2</string>
     <string name="button_plus">Button +</string>
@@ -167,9 +167,9 @@
     <string name="overclock_enable_description">Higher values can make variable-framerate games run at a higher framerate, requiring a powerful device. Lower values make games run at a lower framerate, increasing emulation speed, but reducing the emulated console\'s performance.</string>
     <string name="overclock_title">Emulated CPU Clock Speed</string>
     <string name="overclock_warning">WARNING: Changing this from the default (100%) WILL break games and cause glitches. Please do not report bugs that occur with a non-default clock.</string>
-    <string name="wiimote_scanning">Wiimote Continuous Scanning</string>
+    <string name="wiimote_scanning">Wii Remote Continuous Scanning</string>
     <string name="wiimote_scanning_description">Leave this on if you are using a DolphinBar for real Wiimote support.</string>
-    <string name="wiimote_speaker">Wiimote Speaker</string>
+    <string name="wiimote_speaker">Wii Remote Speaker</string>
     <string name="wiimote_speaker_description">Enable sound output through the speaker on a real Wiimote (DolphinBar required).</string>
 
 
@@ -265,7 +265,7 @@
     <string name="emulation_slot6">Slot 6</string>
     <string name="emulation_quicksave">Quick Save</string>
     <string name="emulation_quickload">Quick Load</string>
-    <string name="emulation_refresh_wiimotes">Refresh Wiimotes</string>
+    <string name="emulation_refresh_wiimotes">Refresh Wii Remotes</string>
     <string name="emulation_configure_controls">Configure Controls</string>
     <string name="emulation_edit_layout">Edit Layout</string>
     <string name="emulation_done">Done</string>
@@ -281,7 +281,7 @@
     <string name="gc_adapter_bongos">Bongo Controller</string>
     <string name="gc_adapter_bongos_description">Enable this if you are using bongos on this port.</string>
 
-    <!-- Wiimote Input Menu-->
+    <!-- Wii Remote Input Menu-->
     <string name="header_wiimote_general">General</string>
     <string name="header_controllers">Controllers</string>
 

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -12,7 +12,7 @@
 
 namespace Wiimote
 {
-static InputConfig s_config(WIIMOTE_INI_NAME, _trans("Wiimote"), "Wiimote");
+static InputConfig s_config(WIIMOTE_INI_NAME, _trans("Wii Remote"), "Wiimote");
 
 InputConfig* GetConfig()
 {

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -283,9 +283,9 @@ Wiimote::Wiimote(const unsigned int index)
   m_options->boolean_settings.emplace_back(
       std::make_unique<ControlGroup::BackgroundInputSetting>(_trans("Background Input")));
   m_options->boolean_settings.emplace_back(
-      std::make_unique<ControlGroup::BooleanSetting>(_trans("Sideways Wiimote"), false));
+      std::make_unique<ControlGroup::BooleanSetting>(_trans("Sideways Wii Remote"), false));
   m_options->boolean_settings.emplace_back(
-      std::make_unique<ControlGroup::BooleanSetting>(_trans("Upright Wiimote"), false));
+      std::make_unique<ControlGroup::BooleanSetting>(_trans("Upright Wii Remote"), false));
   m_options->boolean_settings.emplace_back(std::make_unique<ControlGroup::BooleanSetting>(
       _trans("Iterative Input"), false, ControlGroup::SettingType::VIRTUAL));
   m_options->numeric_settings.emplace_back(
@@ -295,7 +295,7 @@ Wiimote::Wiimote(const unsigned int index)
 
   // hotkeys
   groups.emplace_back(m_hotkeys = new ModifySettingsButton(_trans("Hotkeys")));
-  // hotkeys to temporarily modify the Wiimote orientation (sideways, upright)
+  // hotkeys to temporarily modify the Wii Remote orientation (sideways, upright)
   // this setting modifier is toggled
   m_hotkeys->AddInput(_trans("Sideways Toggle"), true);
   m_hotkeys->AddInput(_trans("Upright Toggle"), true);
@@ -349,7 +349,7 @@ bool Wiimote::Step()
   }
 
   // check if a status report needs to be sent
-  // this happens on Wiimote sync and when extensions are switched
+  // this happens on Wii Remote sync and when extensions are switched
   if (m_extension->active_extension != m_extension->switch_extension)
   {
     RequestStatus();
@@ -689,7 +689,7 @@ void Wiimote::Update()
     if (rptf.ext)
       GetExtData(data + rptf.ext);
 
-    // hybrid Wiimote stuff (for now, it's not supported while recording)
+    // hybrid Wii Remote stuff (for now, it's not supported while recording)
     if (WIIMOTE_SRC_HYBRID == g_wiimote_sources[m_index] && !Movie::IsRecordingInput())
     {
       using namespace WiimoteReal;
@@ -795,7 +795,7 @@ void Wiimote::ControlChannel(const u16 _channelID, const void* _pData, u32 _Size
   // Check for custom communication
   if (99 == _channelID)
   {
-    // Wiimote disconnected
+    // Wii Remote disconnected
     // reset eeprom/register/reporting mode
     Reset();
     if (WIIMOTE_SRC_REAL & g_wiimote_sources[m_index])
@@ -911,7 +911,7 @@ void Wiimote::ConnectOnInput()
   {
     Host_ConnectWiimote(m_index, true);
     // arbitrary value so it doesn't try to send multiple requests before Dolphin can react
-    // if Wiimotes are polled at 200Hz then this results in one request being sent per 500ms
+    // if Wii Remotes are polled at 200Hz then this results in one request being sent per 500ms
     m_last_connect_request_counter = 100;
   }
 }

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -33,10 +33,10 @@ const std::string hotkey_labels[] = {
     _trans("Exit"),
 
     _trans("Press Sync Button"),
-    _trans("Connect Wiimote 1"),
-    _trans("Connect Wiimote 2"),
-    _trans("Connect Wiimote 3"),
-    _trans("Connect Wiimote 4"),
+    _trans("Connect Wii Remote 1"),
+    _trans("Connect Wii Remote 2"),
+    _trans("Connect Wii Remote 3"),
+    _trans("Connect Wii Remote 4"),
     _trans("Connect Balance Board"),
 
     _trans("Volume Down"),

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -46,13 +46,13 @@ CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::CWII_IPC_HLE_Device_usb_oh1_57e_305_emu
     BackUpBTInfoSection(&sysconf);
   }
 
-  // Activate only first Wiimote by default
+  // Activate only first Wii Remote by default
 
   _conf_pads BT_DINF;
   SetUsbPointer(this);
   if (!sysconf.GetArrayData("BT.DINF", (u8*)&BT_DINF, sizeof(_conf_pads)))
   {
-    PanicAlertT("Trying to read from invalid SYSCONF\nWiimote bt ids are not available");
+    PanicAlertT("Trying to read from invalid SYSCONF\nWii Remote bt ids are not available");
   }
   else
   {
@@ -1906,7 +1906,7 @@ CWII_IPC_HLE_WiiMote* CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::AccessWiiMote(u16
   }
 
   ERROR_LOG(WII_IPC_WIIMOTE, "Can't find Wiimote by connection handle %02x", _ConnectionHandle);
-  PanicAlertT("Can't find Wiimote by connection handle %02x", _ConnectionHandle);
+  PanicAlertT("Can't find Wii Remote by connection handle %02x", _ConnectionHandle);
   return nullptr;
 }
 
@@ -1917,7 +1917,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::DisplayDisconnectMessage(const int
   // mean
   // and display things like "Wiimote %i disconnected due to inactivity!" etc.
   Core::DisplayMessage(
-      StringFromFormat("Wiimote %i disconnected by emulated software", wiimoteNumber), 3000);
+      StringFromFormat("Wii Remote %i disconnected by emulated software", wiimoteNumber), 3000);
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::LOG_LinkKey(const u8* _pLinkKey)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -223,14 +223,14 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::IOCtlV(u32 command_ad
     if (cmd_buffer.Parameter == USBV0_IOCTL_INTRMSG &&
         m_sync_button_state == SyncButtonState::Pressed)
     {
-      Core::DisplayMessage("Scanning for Wiimotes", 2000);
+      Core::DisplayMessage("Scanning for Wii Remotes", 2000);
       FakeSyncButtonPressedEvent(*buffer);
       return GetNoReply();
     }
     if (cmd_buffer.Parameter == USBV0_IOCTL_INTRMSG &&
         m_sync_button_state == SyncButtonState::LongPressed)
     {
-      Core::DisplayMessage("Reset saved Wiimote pairings", 2000);
+      Core::DisplayMessage("Reset saved Wii Remote pairings", 2000);
       FakeSyncButtonHeldEvent(*buffer);
       return GetNoReply();
     }

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -54,7 +54,7 @@ void WiiConfigPane::InitializeGUI()
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_bt_sensor_bar_pos_strings);
   m_bt_sensor_bar_sens = new DolphinSlider(this, wxID_ANY, 0, 0, 4);
   m_bt_speaker_volume = new DolphinSlider(this, wxID_ANY, 0, 0, 127);
-  m_bt_wiimote_motor = new wxCheckBox(this, wxID_ANY, _("Wiimote Motor"));
+  m_bt_wiimote_motor = new wxCheckBox(this, wxID_ANY, _("Wii Remote Motor"));
 
   m_screensaver_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnScreenSaverCheckBoxChanged, this);
   m_pal60_mode_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnPAL60CheckBoxChanged, this);

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -222,7 +222,7 @@ wxSizer* ControllerConfigDiag::CreateWiimoteConfigSizer()
   const int space5 = FromDIP(5);
   const int space20 = FromDIP(20);
 
-  auto* const box = new wxStaticBoxSizer(wxVERTICAL, this, _("Wiimotes"));
+  auto* const box = new wxStaticBoxSizer(wxVERTICAL, this, _("Wii Remotes"));
 
   m_passthrough_bt_radio = new wxRadioButton(this, wxID_ANY, _("Passthrough a Bluetooth adapter"),
                                              wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
@@ -253,13 +253,14 @@ wxSizer* ControllerConfigDiag::CreateWiimoteConfigSizer()
 
 wxSizer* ControllerConfigDiag::CreatePassthroughBTConfigSizer()
 {
-  m_passthrough_sync_text = new wxStaticText(this, wxID_ANY, _("Sync real Wiimotes and pair them"));
+  m_passthrough_sync_text =
+      new wxStaticText(this, wxID_ANY, _("Sync real Wii Remotes and pair them"));
   m_passthrough_sync_btn =
       new wxButton(this, wxID_ANY, _("Sync"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(60, -1)));
   m_passthrough_sync_btn->Bind(wxEVT_BUTTON, &ControllerConfigDiag::OnPassthroughScanButton, this);
 
   m_passthrough_reset_text =
-      new wxStaticText(this, wxID_ANY, _("Reset all saved Wiimote pairings"));
+      new wxStaticText(this, wxID_ANY, _("Reset all saved Wii Remote pairings"));
   m_passthrough_reset_btn =
       new wxButton(this, wxID_ANY, _("Reset"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(60, -1)));
   m_passthrough_reset_btn->Bind(wxEVT_BUTTON, &ControllerConfigDiag::OnPassthroughResetButton,
@@ -284,7 +285,7 @@ wxSizer* ControllerConfigDiag::CreatePassthroughBTConfigSizer()
 wxSizer* ControllerConfigDiag::CreateEmulatedBTConfigSizer()
 {
   const std::array<wxString, 4> src_choices{
-      {_("None"), _("Emulated Wiimote"), _("Real Wiimote"), _("Hybrid Wiimote")}};
+      {_("None"), _("Emulated Wii Remote"), _("Real Wii Remote"), _("Hybrid Wii Remote")}};
 
   const int space5 = FromDIP(5);
 
@@ -304,7 +305,7 @@ wxSizer* ControllerConfigDiag::CreateEmulatedBTConfigSizer()
     m_wiimote_index_from_config_id.emplace(config_bt_id, i);
 
     m_wiimote_labels[i] =
-        new wxStaticText(this, wxID_ANY, wxString::Format(_("Wiimote %i"), i + 1));
+        new wxStaticText(this, wxID_ANY, wxString::Format(_("Wii Remote %i"), i + 1));
     m_wiimote_sources[i] = new wxChoice(this, source_ctrl_id, wxDefaultPosition, wxDefaultSize,
                                         src_choices.size(), src_choices.data());
     m_wiimote_sources[i]->Bind(wxEVT_CHOICE, &ControllerConfigDiag::OnWiimoteSourceChanged, this);
@@ -330,7 +331,7 @@ wxSizer* ControllerConfigDiag::CreateEmulatedBTConfigSizer()
 
   m_unsupported_bt_text =
       new wxStaticText(this, wxID_ANY, _("A supported Bluetooth device could not be found,\n"
-                                         "so you must connect Wiimotes manually."));
+                                         "so you must connect Wii Remotes manually."));
   m_unsupported_bt_text->Show(!WiimoteReal::g_wiimote_scanner.IsReady());
 
   // Balance Board
@@ -452,7 +453,7 @@ void ControllerConfigDiag::OnGameCubeConfigButton(wxCommandEvent& event)
   }
   else if (SConfig::GetInstance().m_SIDevice[port_num] == SIDEVICE_WIIU_ADAPTER)
   {
-    GCAdapterConfigDiag config_diag(this, _("Wii U Gamecube Controller Adapter Configuration"),
+    GCAdapterConfigDiag config_diag(this, _("Wii U GameCube Controller Adapter Configuration"),
                                     port_num);
     config_diag.ShowModal();
   }
@@ -494,7 +495,7 @@ void ControllerConfigDiag::OnWiimoteConfigButton(wxCommandEvent& ev)
   HotkeyManagerEmu::Enable(false);
 
   InputConfigDialog m_ConfigFrame(this, *wiimote_plugin,
-                                  _("Dolphin Emulated Wiimote Configuration"),
+                                  _("Dolphin Emulated Wii Remote Configuration"),
                                   m_wiimote_index_from_config_id[ev.GetId()]);
   m_ConfigFrame.ShowModal();
 
@@ -512,8 +513,8 @@ void ControllerConfigDiag::OnPassthroughScanButton(wxCommandEvent& event)
 {
   if (!Core::IsRunning())
   {
-    wxMessageBox(_("A sync can only be triggered when a Wii game is running."), _("Sync Wiimotes"),
-                 wxICON_WARNING);
+    wxMessageBox(_("A sync can only be triggered when a Wii game is running."),
+                 _("Sync Wii Remotes"), wxICON_WARNING);
     return;
   }
   auto device = WII_IPC_HLE_Interface::GetDeviceByName("/dev/usb/oh1/57e/305");
@@ -526,8 +527,8 @@ void ControllerConfigDiag::OnPassthroughResetButton(wxCommandEvent& event)
 {
   if (!Core::IsRunning())
   {
-    wxMessageBox(_("Saved Wiimote pairings can only be reset when a Wii game is running."),
-                 _("Reset Wiimote pairings"), wxICON_WARNING);
+    wxMessageBox(_("Saved Wii Remote pairings can only be reset when a Wii game is running."),
+                 _("Reset Wii Remote pairings"), wxICON_WARNING);
     return;
   }
   auto device = WII_IPC_HLE_Interface::GetDeviceByName("/dev/usb/oh1/57e/305");

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -398,7 +398,7 @@ void CFrame::OnTASInput(wxCommandEvent& event)
     {
       g_TASInputDlg[i + 4]->CreateWiiLayout(i);
       g_TASInputDlg[i + 4]->Show();
-      g_TASInputDlg[i + 4]->SetTitle(wxString::Format(_("TAS Input - Wiimote %d"), i + 1));
+      g_TASInputDlg[i + 4]->SetTitle(wxString::Format(_("TAS Input - Wii Remote %d"), i + 1));
     }
   }
 }
@@ -930,7 +930,7 @@ void CFrame::OnStopped()
   // Clean framerate indications from the status bar.
   GetStatusBar()->SetStatusText(" ", 0);
 
-  // Clear wiimote connection status from the status bar.
+  // Clear Wii Remote connection status from the status bar.
   GetStatusBar()->SetStatusText(" ", 1);
 
   // If batch mode was specified on the command-line or we were already closing, exit now.
@@ -1227,7 +1227,7 @@ void CFrame::ConnectWiimote(int wm_idx, bool connect)
   {
     bool was_unpaused = Core::PauseAndLock(true);
     GetUsbPointer()->AccessWiiMote(wm_idx | 0x100)->Activate(connect);
-    const char* message = connect ? "Wiimote %i connected" : "Wiimote %i disconnected";
+    const char* message = connect ? "Wii Remote %i connected" : "Wii Remote %i disconnected";
     Core::DisplayMessage(StringFromFormat(message, wm_idx + 1), 3000);
     Host_UpdateMainFrame();
     Core::PauseAndLock(false, was_unpaused);

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -487,7 +487,7 @@ void Host_SetWiiMoteConnectionState(int _State)
     event.SetString(_("Connecting..."));
     break;
   case 2:
-    event.SetString(_("Wiimote Connected"));
+    event.SetString(_("Wii Remote Connected"));
     break;
   }
   // Update field 1 or 2

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -206,7 +206,7 @@ wxMenu* MainMenuBar::CreateToolsMenu() const
   for (int i = 0; i < 4; i++)
   {
     wiimote_menu->AppendCheckItem(IDM_CONNECT_WIIMOTE1 + i,
-                                  wxString::Format(_("Connect Wiimote %i"), i + 1));
+                                  wxString::Format(_("Connect Wii Remote %i"), i + 1));
   }
   wiimote_menu->AppendSeparator();
   wiimote_menu->AppendCheckItem(IDM_CONNECT_BALANCEBOARD, _("Connect Balance Board"));
@@ -221,7 +221,7 @@ wxMenu* MainMenuBar::CreateToolsMenu() const
   tools_menu->Append(IDM_LOAD_WII_MENU, dummy_string);
   tools_menu->Append(IDM_FIFOPLAYER, _("FIFO Player"));
   tools_menu->AppendSeparator();
-  tools_menu->AppendSubMenu(wiimote_menu, _("Connect Wiimotes"));
+  tools_menu->AppendSubMenu(wiimote_menu, _("Connect Wii Remotes"));
 
   return tools_menu;
 }

--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -196,7 +196,7 @@ wxNotebook* NetPlaySetupFrame::CreateNotebookGUI(wxWindow* parent)
           "If DSP LLE is used, DSP ROMs must be identical between players.\n"
           "If connecting directly, the host must have the chosen UDP port open/forwarded!\n"
           "\n"
-          "Wiimote netplay is experimental and should not be expected to work.\n"));
+          "Wii Remote support in netplay is experimental and should not be expected to work.\n"));
 
     wxBoxSizer* const top_szr = new wxBoxSizer(wxHORIZONTAL);
     top_szr->Add(m_ip_lbl, 0, wxALIGN_CENTER_VERTICAL);


### PR DESCRIPTION
The usage of "Wii Remote" and "Wiimote" in the interface is inconsistent. "Wiimote" is also not a real word nor is it an official product name. Therefore I have changed instances of "Wiimote" in the UI to instead say "Wii Remote". I also made a couple of minor grammatical changes as well.

This is mostly a resubmission of #4338 as I screwed up my original PR but there are some minor other changes as well.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4391)

<!-- Reviewable:end -->
