### PR TITLE
DriverDetails: Disable dual-source blending on AMD OGL drivers.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -444,8 +444,9 @@ Renderer::Renderer()
   g_Config.backend_info.AdapterName = g_ogl_config.gl_renderer;
 
   g_Config.backend_info.bSupportsDualSourceBlend =
-      GLExtensions::Supports("GL_ARB_blend_func_extended") ||
-      GLExtensions::Supports("GL_EXT_blend_func_extended");
+      (GLExtensions::Supports("GL_ARB_blend_func_extended") ||
+       GLExtensions::Supports("GL_EXT_blend_func_extended")) &&
+      !DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING);
   g_Config.backend_info.bSupportsPrimitiveRestart =
       !DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVERESTART) &&
       ((GLExtensions::Version() >= 310) || GLExtensions::Supports("GL_NV_primitive_restart"));

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -86,6 +86,8 @@ static BugInfo m_known_bugs[] = {
      -1.0, true},
     {API_VULKAN, OS_ALL, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN,
      BUG_BROKEN_FRAGMENT_SHADER_INDEX_DECORATION, -1.0, -1.0, true},
+    {API_OPENGL, OS_WINDOWS, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN,
+     BUG_BROKEN_DUAL_SOURCE_BLENDING, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/DriverDetails.h
+++ b/Source/Core/VideoCommon/DriverDetails.h
@@ -230,6 +230,14 @@ enum Bug
   // the driver to fail to create graphics pipelines. The workaround for this is to specify the
   // index as a MRT location instead, or omit the binding completely.
   BUG_BROKEN_FRAGMENT_SHADER_INDEX_DECORATION,
+
+  // Bug: Dual-source outputs from fragment shaders are broken on AMD OpenGL drivers
+  // Started Version: -1
+  // Ended Version: -1
+  // Fragment shaders that specify dual-source outputs, cause the driver to crash
+  // sometimes this happens in the kernel mode part of the driver resulting in a BSOD.
+  // Disable dual-source blending support for now.
+  BUG_BROKEN_DUAL_SOURCE_BLENDING,
 };
 
 // Initializes our internal vendor, device family, and driver version


### PR DESCRIPTION
The bug has been reported to AMD and they're working on a fix in the new drivers. For now let's just make sure we don't crash anyone's computer.

We could also revert to the previous behavior as a workaround, where we only use dual source blending for Destination Alpha. However that requires maintaining two different code paths and we don't know if this doesn't just make them a bit more rare.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4393)
<!-- Reviewable:end -->
