### PR TITLE
PixelShaderGen: Don't set ocol1 for DSTALPHA_NONE

### DIFF
--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -1207,7 +1207,7 @@ static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_dat
     out.Write(")) {\n");
 
   out.Write("\t\tocol0 = float4(0.0, 0.0, 0.0, 0.0);\n");
-  if (g_ActiveConfig.backend_info.bSupportsDualSourceBlend)
+  if (g_ActiveConfig.backend_info.bSupportsDualSourceBlend && uid_data->dstAlphaMode != DSTALPHA_NONE)
     out.Write("\t\tocol1 = float4(0.0, 0.0, 0.0, 0.0);\n");
   if (per_pixel_depth)
   {
@@ -1304,8 +1304,6 @@ static void WriteColor(ShaderCode& out, const pixel_shader_uid_data* uid_data)
   if (uid_data->dstAlphaMode == DSTALPHA_NONE)
   {
     out.Write("\tocol0.a = float(prev.a >> 2) / 63.0;\n");
-    if (g_ActiveConfig.backend_info.bSupportsDualSourceBlend)
-      out.Write("\tocol1.a = float(prev.a) / 255.0;\n");
   }
   else
   {


### PR DESCRIPTION
Makes the vines and flowers appear again in the New Super Mario Bros. world map on World #5 (a regression starting in 93109df). I have no idea what I'm doing with graphics shaders, and mostly just want to see what happens when this goes through FifoCI.

Here's what NSMB looks like on master:

![image](https://cloud.githubusercontent.com/assets/594093/19826568/e93ea420-9d42-11e6-8de2-777ebd328b2c.png)

And here's what it looks like with this PR:

![image](https://cloud.githubusercontent.com/assets/594093/19826566/d768b13c-9d42-11e6-837d-2fef36233375.png)

(Sorry for the lack of vines, I don't have a save lying around that hasn't beaten that world already. Trust me though, it's pretty jarring to be unable to walk over what-appear-to-only-be shadows.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4396)
<!-- Reviewable:end -->
