### PR TITLE
OpenGL: don't bind ocol1 if not in a dual-source blend mode

### DIFF
--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -99,11 +99,38 @@ void SHADER::SetProgramVariables()
   }
 }
 
+bool IsDualSourceBlendActive()
+{
+  if (!g_ActiveConfig.backend_info.bSupportsDualSourceBlend)
+    return false;
+
+  GLboolean blendEnabled;
+  glGetBooleanv(GL_BLEND, &blendEnabled);
+  if (!blendEnabled) return false;
+
+  GLint blendSrc;
+  GLint blendSrcAlpha;
+  GLint blendDest;
+  GLint blendDestAlpha;
+  glGetIntegerv(GL_BLEND_SRC_RGB, &blendSrc);
+  glGetIntegerv(GL_BLEND_DST_RGB, &blendDest);
+  glGetIntegerv(GL_BLEND_SRC_ALPHA, &blendSrcAlpha);
+  glGetIntegerv(GL_BLEND_DST_ALPHA, &blendDestAlpha);
+
+  return (
+    blendSrc == GL_SRC1_ALPHA || blendSrc == GL_ONE_MINUS_SRC1_ALPHA ||
+    blendSrcAlpha == GL_SRC1_ALPHA || blendSrcAlpha == GL_ONE_MINUS_SRC1_ALPHA ||
+    blendDest == GL_SRC1_ALPHA || blendDest == GL_ONE_MINUS_SRC1_ALPHA ||
+    blendDestAlpha == GL_SRC1_ALPHA || blendDestAlpha == GL_ONE_MINUS_SRC1_ALPHA
+  );
+}
+
+
 void SHADER::SetProgramBindings()
 {
-  if (g_ActiveConfig.backend_info.bSupportsDualSourceBlend)
+  if (IsDualSourceBlendActive())
   {
-    // So we do support extended blending
+    // So we do support and are using extended blending
     // So we need to set a few more things here.
     // Bind our out locations
     glBindFragDataLocationIndexed(glprogid, 0, 0, "ocol0");


### PR DESCRIPTION
Makes the vines and flowers appear again in the New Super Mario Bros. world map on World #5 on my computer, macOS w/ Intel graphics (a regression starting in 93109df). I have no idea what I'm doing with graphics shaders, and mostly just want to see what happens when this goes through FifoCI.

From a reading of [ARB_blend_func_extended](https://www.opengl.org/registry/specs/ARB/blend_func_extended.txt), it sounds like binding dual-source blending outputs might be undefined when a dual-source blend mode is not being used.

Here's what NSMB looks like on master:

![image](https://cloud.githubusercontent.com/assets/594093/19827321/f612783a-9d5a-11e6-8f59-a52f28b27534.png)

And here's what it looks like with this PR:

![image](https://cloud.githubusercontent.com/assets/594093/19827323/fa843584-9d5a-11e6-9790-74c06a418f3e.png)

(This is the more-informed evolution of #4396).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4397)
<!-- Reviewable:end -->
