### PR TITLE
EXI_DeviceIPL: Unify GetGCTime epoch handling

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -87,7 +87,7 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
   PowerPC::HostWrite_U32(0x4c000064, 0x80000800);  // Write default FPU Handler:     rfi
   PowerPC::HostWrite_U32(0x4c000064, 0x80000C00);  // Write default Syscall Handler: rfi
 
-  PowerPC::HostWrite_U64((u64)CEXIIPL::GetGCTime() * (u64)40500000,
+  PowerPC::HostWrite_U64((u64)CEXIIPL::GetEmulatedTime(CEXIIPL::GC_EPOCH) * (u64)40500000,
                          0x800030D8);  // Preset time base ticks
   // HIO checks this
   // PowerPC::HostWrite_U16(0x8200,     0x000030e6); // Console type

--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -430,23 +430,6 @@ u32 CEXIIPL::GetGCTime()
   }
 
   return ((u32)ltime - cJanuary2000);
-
-#if 0
-	// (mb2): I think we can get rid of the IPL bias.
-	// I know, it's another hack so I let the previous code for a while.
-
-	// Get SRAM bias
-	u32 Bias;
-
-	for (int i = 0; i < 4; i++)
-	{
-		((u8*)&Bias)[i] = sram_dump[0xc + (i^3)];
-	}
-
-	// Get the time ...
-	u64 ltime = Common::Timer::GetTimeSinceJan1970();
-	return ((u32)ltime - cJanuary2000 - Bias);
-#endif
 }
 
 u32 CEXIIPL::GetGCTimeJan1970()

--- a/Source/Core/Core/HW/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.h
@@ -20,9 +20,14 @@ public:
   bool IsPresent() const override;
   void DoState(PointerWrap& p) override;
 
-  static u32 GetGCTime();
-  static u32 GetGCTimeJan1970();
-  static u64 NetPlay_GetGCTime();
+  static constexpr u32 UNIX_EPOCH = 0;          // 1970-01-01 00:00:00
+  static constexpr u32 GC_EPOCH = 0x386D4380;   // 2000-01-01 00:00:00
+  static constexpr u32 WII_EPOCH = 0x477E5826;  // 2008-01-04 16:00:38
+  // The Wii epoch is suspiciously random, and the Wii was even
+  // released before it, but apparently it works anyway?
+
+  static u32 GetEmulatedTime(u32 epoch);
+  static u64 NetPlay_GetEmulatedTime();
 
   static void Descrambler(u8* data, u32 size);
 

--- a/Source/Core/Core/HW/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard.h
@@ -131,7 +131,7 @@ struct Header  // Offset    Size    Description
     memset(this, 0xFF, BLOCK_SIZE);
     *(u16*)SizeMb = BE16(sizeMb);
     Encoding = BE16(ascii ? 0 : 1);
-    u64 rand = CEXIIPL::GetGCTime();
+    u64 rand = CEXIIPL::GetEmulatedTime(CEXIIPL::GC_EPOCH);
     formatTime = Common::swap64(rand);
     for (int i = 0; i < 12; i++)
     {

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -253,7 +253,7 @@ void Init()
         Common::Timer::GetLocalTimeSinceJan1970() - SConfig::GetInstance().m_customRTCValue;
   }
   CoreTiming::SetFakeTBStartValue((u64)(s_cpu_core_clock / TIMER_RATIO) *
-                                  (u64)CEXIIPL::GetGCTime());
+                                  (u64)CEXIIPL::GetEmulatedTime(CEXIIPL::GC_EPOCH));
   CoreTiming::SetFakeTBStartTicks(CoreTiming::GetTicks());
 
   CoreTiming::SetFakeDecStartValue(0xFFFFFFFF);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -515,20 +515,19 @@ private:
   u64 rtc;
   s64 utcdiff;
 
-  // TODO: depending on CEXIIPL is a hack which I don't feel like removing
-  // because the function itself is pretty hackish; wait until I re-port my
-  // netplay rewrite; also, is that random 16:00:38 actually meaningful?
-  // seems very very doubtful since Wii was released in 2006
-
-  // Seconds between 1.1.2000 and 4.1.2008 16:00:38
-  static const u64 wii_bias = 0x477E5826 - 0x386D4380;
+  // TODO: depending on CEXIIPL is a hack which I don't feel like
+  // removing because the function itself is pretty hackish;
+  // wait until I re-port my netplay rewrite
 
   // Returns seconds since Wii epoch
   // +/- any bias set from IOCTL_NW24_SET_UNIVERSAL_TIME
-  u64 GetAdjustedUTC() const { return CEXIIPL::GetGCTime() - wii_bias + utcdiff; }
+  u64 GetAdjustedUTC() const { return CEXIIPL::GetEmulatedTime(CEXIIPL::WII_EPOCH) + utcdiff; }
   // Store the difference between what the Wii thinks is UTC and
   // what the host OS thinks
-  void SetAdjustedUTC(u64 wii_utc) { utcdiff = CEXIIPL::GetGCTime() - wii_bias - wii_utc; }
+  void SetAdjustedUTC(u64 wii_utc)
+  {
+    utcdiff = CEXIIPL::GetEmulatedTime(CEXIIPL::WII_EPOCH) - wii_utc;
+  }
 };
 
 enum NET_IOCTL

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -180,7 +180,7 @@ std::string GetInputDisplay()
 // NOTE: GPU Thread
 std::string GetRTCDisplay()
 {
-  time_t current_time = CEXIIPL::GetGCTimeJan1970();
+  time_t current_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
   tm* gm_time = gmtime(&current_time);
   char buffer[256];
   strftime(buffer, sizeof(buffer), "Date/Time: %c", gm_time);
@@ -552,7 +552,7 @@ bool BeginRecordingInput(int controllers)
   if (NetPlay::IsNetPlayRunning())
   {
     s_bNetPlay = true;
-    s_recordingStartTime = CEXIIPL::NetPlay_GetGCTime();
+    s_recordingStartTime = CEXIIPL::NetPlay_GetEmulatedTime();
   }
   else if (SConfig::GetInstance().bEnableCustomRTC)
   {

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -423,7 +423,7 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
       u32 time_low, time_high;
       packet >> time_low;
       packet >> time_high;
-      g_netplay_initial_gctime = time_low | ((u64)time_high << 32);
+      g_netplay_initial_rtc = time_low | ((u64)time_high << 32);
     }
 
     m_dialog->OnMsgStartGame();
@@ -1282,12 +1282,12 @@ bool WiimoteEmu::Wiimote::NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size,
 // so all players' games get the same time
 //
 // also called from ---GUI--- thread when starting input recording
-u64 CEXIIPL::NetPlay_GetGCTime()
+u64 CEXIIPL::NetPlay_GetEmulatedTime()
 {
   std::lock_guard<std::mutex> lk(crit_netplay_client);
 
   if (netplay_client)
-    return g_netplay_initial_gctime;
+    return g_netplay_initial_rtc;
   else
     return 0;
 }

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -27,7 +27,7 @@ struct NetSettings
 };
 
 extern NetSettings g_NetPlaySettings;
-extern u64 g_netplay_initial_gctime;
+extern u64 g_netplay_initial_rtc;
 
 struct Rpt : public std::vector<u8>
 {

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -27,7 +27,7 @@
 #include <arpa/inet.h>
 #endif
 
-u64 g_netplay_initial_gctime = 1272737767;
+u64 g_netplay_initial_rtc = 1272737767;
 
 NetPlayServer::~NetPlayServer()
 {
@@ -789,9 +789,9 @@ bool NetPlayServer::StartGame()
   AdjustPadBufferSize(m_target_buffer_size);
 
   if (SConfig::GetInstance().bEnableCustomRTC)
-    g_netplay_initial_gctime = SConfig::GetInstance().m_customRTCValue;
+    g_netplay_initial_rtc = SConfig::GetInstance().m_customRTCValue;
   else
-    g_netplay_initial_gctime = Common::Timer::GetLocalTimeSinceJan1970();
+    g_netplay_initial_rtc = Common::Timer::GetLocalTimeSinceJan1970();
 
   // tell clients to start game
   auto spac = std::make_unique<sf::Packet>();
@@ -811,8 +811,8 @@ bool NetPlayServer::StartGame()
   *spac << m_settings.m_OCFactor;
   *spac << m_settings.m_EXIDevice[0];
   *spac << m_settings.m_EXIDevice[1];
-  *spac << (u32)g_netplay_initial_gctime;
-  *spac << (u32)(g_netplay_initial_gctime >> 32);
+  *spac << (u32)g_netplay_initial_rtc;
+  *spac << (u32)(g_netplay_initial_rtc >> 32);
 
   SendAsyncToClients(std::move(spac));
 


### PR DESCRIPTION
At first, there was GetGCTime(), which returned the emulated GC's time in the GC time format (seconds since 2000). Very reasonable.

Then, as it became necessary to also get the emulated system's time in the Wii time format (seconds since some seemingly arbitrary time), code was written that subtracted a WII_BIAS constant from GetGCTime()'s return value. Still fairly reasonable (although it would've been better if the constant wasn't defined separately in separate parts of the code).

Then in 2016, GetGCTimeJan1970() was added. This function isn't only inconsistent with how Wii times are handled (separate function instead of callers having to add/subtract a value), the name also doesn't make much sense. It doesn't use the GC time format as the name implies (and the emulated system isn't even necessarily a GC, since it can be a Wii).

To improve the situation, this PR renames GetGCTime to GetEmulatedTime and turns the epoch it uses into a parameter. This makes wii_bias subtraction and GetGCTimeSinceJan1970 unnecessary.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4399)

<!-- Reviewable:end -->
