### PR TITLE
JitArm64: Store the carry flag within the host flag.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -606,6 +606,8 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitB
       }
 
       JitArm64Tables::CompileInstruction(ops[i]);
+      if (!MergeAllowedNextInstructions(1) || js.op[1].opinfo->type != OPTYPE_INTEGER)
+        FlushCarry();
 
       // If we have a register that will never be used again, flush it.
       gpr.StoreRegisters(~ops[i].gprInUse);

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -54,6 +54,7 @@ void JitArm64::Init()
   code_block.m_gpa = &js.gpa;
   code_block.m_fpa = &js.fpa;
   analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CONDITIONAL_CONTINUE);
+  analyzer.SetOption(PPCAnalyst::PPCAnalyzer::OPTION_CARRY_MERGE);
 
   m_supports_cycle_counter = HasCycleCounters();
 }
@@ -79,6 +80,7 @@ void JitArm64::Shutdown()
 
 void JitArm64::FallBackToInterpreter(UGeckoInstruction inst)
 {
+  FlushCarry();
   gpr.Flush(FlushMode::FLUSH_ALL, js.op);
   fpr.Flush(FlushMode::FLUSH_ALL, js.op);
 
@@ -419,6 +421,7 @@ const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitB
   js.downcountAmount = 0;
   js.skipInstructions = 0;
   js.curBlock = b;
+  js.carryFlagSet = false;
 
   PPCAnalyst::CodeOp* ops = code_buf->codebuffer;
 

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -241,6 +241,7 @@ private:
   void ComputeRC(u64 imm, int crf = 0, bool needs_sext = true);
   void ComputeCarry(bool Carry);
   void ComputeCarry();
+  void FlushCarry();
 
   void reg_imm(u32 d, u32 a, u32 value, u32 (*do_op)(u32, u32),
                void (ARM64XEmitter::*op)(ARM64Reg, ARM64Reg, u64, ARM64Reg), bool Rc = false);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_FloatingPoint.cpp
@@ -313,8 +313,7 @@ void JitArm64::fcmpX(UGeckoInstruction inst)
   }
   SetJumpTarget(continue1);
 
-  STR(INDEX_UNSIGNED, XA, PPC_REG,
-      PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
+  STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[crf]));
 
   gpr.Unlock(WA);
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1305,10 +1305,16 @@ void JitArm64::srawx(UGeckoInstruction inst)
       ComputeRC(gpr.GetImm(a), 0);
     return;
   }
-  else if (gpr.IsImm(b) && (gpr.GetImm(b) & 0x20) == 0 && !js.op->wantsCA)
+
+  if (gpr.IsImm(b) && !js.op->wantsCA)
   {
+    int amount = gpr.GetImm(b);
+    if (amount & 0x20)
+      amount = 0x1F;
+    else
+      amount &= 0x1F;
     gpr.BindToRegister(a, a == s);
-    ASR(gpr.R(a), gpr.R(a), gpr.GetImm(b) & 0x1F);
+    ASR(gpr.R(a), gpr.R(s), amount);
   }
   else if (!js.op->wantsCA)
   {

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -423,8 +423,7 @@ void JitArm64::cmp(UGeckoInstruction inst)
   SXTW(XB, RB);
 
   SUB(XA, XA, XB);
-  STR(INDEX_UNSIGNED, XA, PPC_REG,
-      PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
+  STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[crf]));
 
   gpr.Unlock(WA, WB);
 }
@@ -451,8 +450,7 @@ void JitArm64::cmpl(UGeckoInstruction inst)
   ARM64Reg WA = gpr.GetReg();
   ARM64Reg XA = EncodeRegTo64(WA);
   SUB(XA, EncodeRegTo64(gpr.R(a)), EncodeRegTo64(gpr.R(b)));
-  STR(INDEX_UNSIGNED, XA, PPC_REG,
-      PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
+  STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[crf]));
   gpr.Unlock(WA);
 }
 
@@ -502,8 +500,7 @@ void JitArm64::cmpli(UGeckoInstruction inst)
 
   SUBI2R(XA, EncodeRegTo64(gpr.R(a)), inst.UIMM, XA);
 
-  STR(INDEX_UNSIGNED, XA, PPC_REG,
-      PPCSTATE_OFF(cr_val[0]) + (sizeof(PowerPC::ppcState.cr_val[0]) * crf));
+  STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[crf]));
   gpr.Unlock(WA);
 }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -74,7 +74,7 @@ void JitArm64::ComputeCarry()
     return;
 
   js.carryFlagSet = true;
-  if (MergeAllowedNextInstructions(1) && js.op[1].wantsCAInFlags)
+  if (MergeAllowedNextInstructions(1) && js.op[1].opinfo->type == OPTYPE_INTEGER)
   {
     return;
   }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -417,7 +417,7 @@ void JitArm64::crXXX(UGeckoInstruction inst)
 
     ARM64Reg WA = gpr.GetReg();
     ARM64Reg XA = EncodeRegTo64(WA);
-    LDR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * field);
+    LDR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[field]));
     switch (bit)
     {
     case CR_SO_BIT:
@@ -436,7 +436,7 @@ void JitArm64::crXXX(UGeckoInstruction inst)
       AND(XA, XA, 64 - 63, 62, true);  // XA & ~(1<<62)
       break;
     }
-    STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * field);
+    STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[field]));
     gpr.Unlock(WA);
     return;
   }
@@ -450,7 +450,7 @@ void JitArm64::crXXX(UGeckoInstruction inst)
 
     ARM64Reg WA = gpr.GetReg();
     ARM64Reg XA = EncodeRegTo64(WA);
-    LDR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * field);
+    LDR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[field]));
 
     if (bit != CR_GT_BIT)
     {
@@ -483,7 +483,7 @@ void JitArm64::crXXX(UGeckoInstruction inst)
 
     ORR(XA, XA, 32, 0, true);  // XA | 1<<32
 
-    STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * field);
+    STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[field]));
     gpr.Unlock(WA);
     return;
   }
@@ -509,7 +509,7 @@ void JitArm64::crXXX(UGeckoInstruction inst)
 
     ARM64Reg WC = gpr.GetReg();
     ARM64Reg XC = EncodeRegTo64(WC);
-    LDR(INDEX_UNSIGNED, XC, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * field);
+    LDR(INDEX_UNSIGNED, XC, PPC_REG, PPCSTATE_OFF(cr_val[field]));
     switch (bit)
     {
     case CR_SO_BIT:  // check bit 61 set
@@ -565,7 +565,7 @@ void JitArm64::crXXX(UGeckoInstruction inst)
   int field = inst.CRBD >> 2;
   int bit = 3 - (inst.CRBD & 3);
 
-  LDR(INDEX_UNSIGNED, XB, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * field);
+  LDR(INDEX_UNSIGNED, XB, PPC_REG, PPCSTATE_OFF(cr_val[field]));
 
   // Gross but necessary; if the input is totally zero and we set SO or LT,
   // or even just add the (1<<32), GT will suddenly end up set without us
@@ -603,7 +603,7 @@ void JitArm64::crXXX(UGeckoInstruction inst)
   }
 
   ORR(XA, XA, 32, 0, true);  // XA | 1<<32
-  STR(INDEX_UNSIGNED, XB, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * field);
+  STR(INDEX_UNSIGNED, XB, PPC_REG, PPCSTATE_OFF(cr_val[field]));
 
   gpr.Unlock(WA);
   gpr.Unlock(WB);
@@ -653,7 +653,7 @@ void JitArm64::mtcrf(UGeckoInstruction inst)
         }
 
         LDR(XA, XB, ArithOption(XA, true));
-        STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * i);
+        STR(INDEX_UNSIGNED, XA, PPC_REG, PPCSTATE_OFF(cr_val[i]));
       }
     }
     gpr.Unlock(WA, WB);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -629,7 +629,7 @@ void JitArm64::GenMfcr()
   const u8* start = GetCodePtr();
   for (int i = 0; i < 8; i++)
   {
-    LDR(INDEX_UNSIGNED, X1, PPC_REG, PPCSTATE_OFF(cr_val) + 8 * i);
+    LDR(INDEX_UNSIGNED, X1, PPC_REG, PPCSTATE_OFF(cr_val[i]));
 
     // SO
     if (i == 0)


### PR DESCRIPTION
Same kind of optimization as used on X64. Also a few optimized carry usages all over the place.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4400)

<!-- Reviewable:end -->
