### PR TITLE
OGL: Fall back to the old dual-source blending behaviour.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -445,8 +445,7 @@ Renderer::Renderer()
 
   g_Config.backend_info.bSupportsDualSourceBlend =
       (GLExtensions::Supports("GL_ARB_blend_func_extended") ||
-       GLExtensions::Supports("GL_EXT_blend_func_extended")) &&
-      !DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING);
+       GLExtensions::Supports("GL_EXT_blend_func_extended"));
   g_Config.backend_info.bSupportsPrimitiveRestart =
       !DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVERESTART) &&
       ((GLExtensions::Version() >= 310) || GLExtensions::Supports("GL_NV_primitive_restart"));
@@ -1243,6 +1242,10 @@ void Renderer::SetBlendMode(bool forceUpdate)
 
   bool useDstAlpha = bpmem.dstalpha.enable && bpmem.blendmode.alphaupdate && target_has_alpha;
   bool useDualSource = g_ActiveConfig.backend_info.bSupportsDualSourceBlend;
+
+  // Only use dual-source blending when required on drivers that don't support it very well.
+  if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) && !useDstAlpha)
+    useDualSource = false;
 
   const GLenum glSrcFactors[8] = {
       GL_ZERO,

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -88,6 +88,8 @@ static BugInfo m_known_bugs[] = {
      BUG_BROKEN_FRAGMENT_SHADER_INDEX_DECORATION, -1.0, -1.0, true},
     {API_OPENGL, OS_WINDOWS, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN,
      BUG_BROKEN_DUAL_SOURCE_BLENDING, -1.0, -1.0, true},
+    {API_OPENGL, OS_OSX, VENDOR_INTEL, DRIVER_INTEL, Family::UNKNOWN,
+     BUG_BROKEN_DUAL_SOURCE_BLENDING, -1.0, -1.0, true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -345,9 +345,10 @@ static void WriteTevRegular(ShaderCode& out, const char* components, int bias, i
 static void SampleTexture(ShaderCode& out, const char* texcoords, const char* texswap, int texmap,
                           bool stereo, APIType ApiType);
 static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_data, APIType ApiType,
-                           bool per_pixel_depth);
+                           bool per_pixel_depth, bool use_dual_source);
 static void WriteFog(ShaderCode& out, const pixel_shader_uid_data* uid_data);
-static void WriteColor(ShaderCode& out, const pixel_shader_uid_data* uid_data);
+static void WriteColor(ShaderCode& out, const pixel_shader_uid_data* uid_data,
+                       bool use_dual_source);
 
 ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data* uid_data)
 {
@@ -505,11 +506,15 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data*
     }
   }
 
+  // Only use dual-source blending when required on drivers that don't support it very well.
+  const bool use_dual_source =
+      g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
+      (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) ||
+       uid_data->dstAlphaMode == DSTALPHA_DUAL_SOURCE_BLEND);
+
   if (ApiType == APIType::OpenGL || ApiType == APIType::Vulkan)
   {
-    if (g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
-        (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) ||
-         uid_data->dstAlphaMode == DSTALPHA_DUAL_SOURCE_BLEND))
+    if (use_dual_source)
     {
       if (DriverDetails::HasBug(DriverDetails::BUG_BROKEN_FRAGMENT_SHADER_INDEX_DECORATION))
       {
@@ -711,7 +716,7 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data*
   // testing result)
   if (uid_data->Pretest == AlphaTest::UNDETERMINED ||
       (uid_data->Pretest == AlphaTest::FAIL && uid_data->late_ztest))
-    WriteAlphaTest(out, uid_data, ApiType, uid_data->per_pixel_depth);
+    WriteAlphaTest(out, uid_data, ApiType, uid_data->per_pixel_depth, use_dual_source);
 
   if (uid_data->zfreeze)
   {
@@ -795,7 +800,7 @@ ShaderCode GeneratePixelShaderCode(APIType ApiType, const pixel_shader_uid_data*
     WriteFog(out, uid_data);
 
   // Write the color and alpha values to the framebuffer
-  WriteColor(out, uid_data);
+  WriteColor(out, uid_data, use_dual_source);
 
   if (uid_data->bounding_box)
   {
@@ -1183,7 +1188,7 @@ static const char* tevAlphaFunclogicTable[] = {
 };
 
 static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_data, APIType ApiType,
-                           bool per_pixel_depth)
+                           bool per_pixel_depth, bool use_dual_source)
 {
   static const char* alphaRef[2] = {I_ALPHA ".r", I_ALPHA ".g"};
 
@@ -1210,7 +1215,8 @@ static void WriteAlphaTest(ShaderCode& out, const pixel_shader_uid_data* uid_dat
     out.Write(")) {\n");
 
   out.Write("\t\tocol0 = float4(0.0, 0.0, 0.0, 0.0);\n");
-  out.Write("\t\tocol1 = float4(0.0, 0.0, 0.0, 0.0);\n");
+  if (use_dual_source)
+    out.Write("\t\tocol1 = float4(0.0, 0.0, 0.0, 0.0);\n");
   if (per_pixel_depth)
   {
     out.Write("\t\tdepth = %s;\n",
@@ -1294,7 +1300,7 @@ static void WriteFog(ShaderCode& out, const pixel_shader_uid_data* uid_data)
   out.Write("\tprev.rgb = (prev.rgb * (256 - ifog) + " I_FOGCOLOR ".rgb * ifog) >> 8;\n");
 }
 
-static void WriteColor(ShaderCode& out, const pixel_shader_uid_data* uid_data)
+static void WriteColor(ShaderCode& out, const pixel_shader_uid_data* uid_data, bool use_dual_source)
 {
   if (uid_data->rgba6_format)
     out.Write("\tocol0.rgb = float3(prev.rgb >> 2) / 63.0;\n");
@@ -1306,7 +1312,8 @@ static void WriteColor(ShaderCode& out, const pixel_shader_uid_data* uid_data)
   if (uid_data->dstAlphaMode == DSTALPHA_NONE)
   {
     out.Write("\tocol0.a = float(prev.a >> 2) / 63.0;\n");
-    out.Write("\tocol1.a = float(prev.a) / 255.0;\n");
+    if (use_dual_source)
+      out.Write("\tocol1.a = float(prev.a) / 255.0;\n");
   }
   else
   {
@@ -1314,9 +1321,12 @@ static void WriteColor(ShaderCode& out, const pixel_shader_uid_data* uid_data)
     out.Write("\tocol0.a = float(" I_ALPHA ".a >> 2) / 63.0;\n");
 
     // Use dual-source color blending to perform dst alpha in a single pass
-    if (uid_data->dstAlphaMode == DSTALPHA_DUAL_SOURCE_BLEND)
-      out.Write("\tocol1.a = float(prev.a) / 255.0;\n");
-    else
-      out.Write("\tocol1.a = float(" I_ALPHA ".a) / 255.0;\n");
+    if (use_dual_source)
+    {
+      if (uid_data->dstAlphaMode == DSTALPHA_DUAL_SOURCE_BLEND)
+        out.Write("\tocol1.a = float(prev.a) / 255.0;\n");
+      else
+        out.Write("\tocol1.a = float(" I_ALPHA ".a) / 255.0;\n");
+    }
   }
 }


### PR DESCRIPTION
This allows us to still use dual-source blending in cases where it is required for accurate emulation and not just for small precision enhancements where it could crash some driver.

I also added OS X Intel to the bug, as those drivers seem to be affected by a similar bug. The OS X Nvidia drivers are not affected. I've tested it on my own MacBook Pro and confirmed this PR works correctly.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4402)

<!-- Reviewable:end -->
