### PR TITLE
Make analog triggers on PS3 controllers accessible

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -145,7 +145,6 @@ Joystick::Axis::Axis(IOHIDElementRef element, IOHIDDeviceRef device, direction d
   default:
   {
     IOHIDElementCookie elementCookie = IOHIDElementGetCookie(m_element);
-    
     // Not a well-known axis so cook a descriptive name. Previously the usage
     // number was used for this but for the PS3 controller at least all the
     // unknown axes were returning kHIDUsage_GD_Pointer (1) so all unknown

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -145,12 +145,10 @@ Joystick::Axis::Axis(IOHIDElementRef element, IOHIDDeviceRef device, direction d
   default:
   {
     IOHIDElementCookie elementCookie = IOHIDElementGetCookie(m_element);
-    // Not a well-known axis so cook a descriptive name. Previously the usage
-    // number was used for this but for the PS3 controller at least all the
-    // unknown axes were returning kHIDUsage_GD_Pointer (1) so all unknown
-    // axes clashed on name as they were all called "1". Each element actually
-    // has a unique ID number available via IOHIDElementGetCookie() so we use
-    // that for the unique axis name instead
+    // This axis isn't a 'well-known' one so cook a descriptive and uniquely
+    // identifiable name. macOS provides a 'cookie' for each element that
+    // will persist between sessions and identify the same physical controller
+    // element so we can use that as a component of the axis name
     std::ostringstream s;
     s << "CK-";
     s << elementCookie;

--- a/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
+++ b/Source/Core/InputCommon/ControllerInterface/OSX/OSXJoystick.mm
@@ -144,8 +144,17 @@ Joystick::Axis::Axis(IOHIDElementRef element, IOHIDDeviceRef device, direction d
     break;
   default:
   {
+    IOHIDElementCookie elementCookie = IOHIDElementGetCookie(m_element);
+    
+    // Not a well-known axis so cook a descriptive name. Previously the usage
+    // number was used for this but for the PS3 controller at least all the
+    // unknown axes were returning kHIDUsage_GD_Pointer (1) so all unknown
+    // axes clashed on name as they were all called "1". Each element actually
+    // has a unique ID number available via IOHIDElementGetCookie() so we use
+    // that for the unique axis name instead
     std::ostringstream s;
-    s << usage;
+    s << "CK-";
+    s << elementCookie;
     description = StripSpaces(s.str());
     break;
   }


### PR DESCRIPTION
Use the IOHIDElement cookie as a part of the axis name for unknown axis. Previously the 'usage' value was used to identify the axis by name, but this is not unique. For example on a PS3 controller *all* axis other than the well known ones return a usage of '1' so there are 30 or more axis all named "1". This stops things such as analog triggers being usable.

Using the element cookie uniquely identifies each axis and allows them to be assigned successfully as controls

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4403)
<!-- Reviewable:end -->
