### PR TITLE
[GameINI] Update INIs of newer Just Dance games

### DIFF
--- a/Data/Sys/GameSettings/SE3.ini
+++ b/Data/Sys/GameSettings/SE3.ini
@@ -5,8 +5,8 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationStateId = 1
-EmulationIssues = Freezes at boot, refer issue 6701
+EmulationStateId = 4
+EmulationIssues = Missing microphone emulation
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.
@@ -16,6 +16,3 @@ EmulationIssues = Freezes at boot, refer issue 6701
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Video_Hacks]
-EFBToTextureEnable = False

--- a/Data/Sys/GameSettings/SJN.ini
+++ b/Data/Sys/GameSettings/SJN.ini
@@ -1,4 +1,4 @@
-# SJOE41, SJOP41 - Just Dance 2014
+# SJNE41, SJNP41 - Just Dance 2016
 
 [Core]
 # Values set here will override the main Dolphin settings.

--- a/Data/Sys/GameSettings/SZ7.ini
+++ b/Data/Sys/GameSettings/SZ7.ini
@@ -1,4 +1,4 @@
-# SJOE41, SJOP41 - Just Dance 2014
+# SZ7E41, SZ7P41 - Just Dance 2017
 
 [Core]
 # Values set here will override the main Dolphin settings.


### PR DESCRIPTION
This PR drops EFB2RAM from Just Dance 2014 and Just Dance 2015 and add INI files for Just Dance 2016 and Just Dance 2017, which were missing from Dolphin's database. 

Regarding EFB2RAM removal, they were required to fix missing dancers on mashup songs but it's not needed anymore. I'm not 100% sure but it seems related to the partial/paletted EFB Copies stuff: since previously those games would boot only on custom builds with wiispeak code (and I compiled only some of them, with huge gaps between the base revisions) I couldn't do extensive testing, but as of Dolphin 5.0-546 (the first official Dolphin build which could boot those games) and onwards I can confirm they work fine without EFB2RAM.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4404)

<!-- Reviewable:end -->
