### PR TITLE
Add debug i18n comments and revise existing i18n comments

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -28,13 +28,13 @@ static const char* const named_buttons[] = {"A",          "B", "X", "Y", "Z", _t
                                             _trans("Mic")};
 
 static const char* const named_triggers[] = {
-    // i18n:  Left
+    // i18n: The left trigger button (labeled L on real controllers)
     _trans("L"),
-    // i18n:  Right
+    // i18n: The right trigger button (labeled R on real controllers)
     _trans("R"),
-    // i18n:  Left-Analog
+    // i18n: The left trigger button (labeled L on real controllers) used as an analog input
     _trans("L-Analog"),
-    // i18n:  Right-Analog
+    // i18n: The right trigger button (labeled R on real controllers) used as an analog input
     _trans("R-Analog")};
 
 GCPad::GCPad(const unsigned int index) : m_index(index)

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -467,6 +467,7 @@ wxMenu* MainMenuBar::CreateSymbolsMenu() const
 wxMenu* MainMenuBar::CreateProfilerMenu() const
 {
   auto* const profiler_menu = new wxMenu;
+  // i18n: "Profile" is used as a verb, not a noun.
   profiler_menu->AppendCheckItem(IDM_PROFILE_BLOCKS, _("&Profile Blocks"));
   profiler_menu->AppendSeparator();
   profiler_menu->Append(IDM_WRITE_PROFILE, _("&Write to profile.txt, Show"));

--- a/Source/Core/DolphinWX/MainToolBar.cpp
+++ b/Source/Core/DolphinWX/MainToolBar.cpp
@@ -222,8 +222,10 @@ void MainToolBar::AddDebuggerToolBarButtons()
   AddToolBarButton(IDM_SKIP, TOOLBAR_DEBUG_SKIP, _("Skip"),
                    _("Skips the next instruction completely"));
   AddSeparator();
+  // i18n: Here, PC is an acronym for program counter, not personal computer.
   AddToolBarButton(IDM_GOTOPC, TOOLBAR_DEBUG_GOTOPC, _("Show PC"),
                    _("Go to the current instruction"));
+  // i18n: Here, PC is an acronym for program counter, not personal computer.
   AddToolBarButton(IDM_SETPC, TOOLBAR_DEBUG_SETPC, _("Set PC"), _("Set the current instruction"));
 }
 


### PR DESCRIPTION
Dolphin's `gettextize` script picks up on comments that start with `i18n`. They will be placed in the .pot file, and Transifex will display them to translators.

It seems like "&Profile Blocks" already has been mistranslated several times on Transifex (but I can't guarantee it, since I can't read most of the languages). The "Show PC" and "Set PC" strings aren't live on Transifex yet, so I'd like to get comments for them added before I sync with Transifex next time.

The comment before "Set PC" doesn't apply to the "Set the current instruction" string, even though those two strings are on the same line. I tested it by running `gettextize` manually and checking the .pot file.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4406)

<!-- Reviewable:end -->
