### PR TITLE
Add linked list support to Memorywatcher

### DIFF
--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -71,8 +71,8 @@ void Clear();
 // Routines to access physically addressed memory, designed for use by
 // emulated hardware outside the CPU. Use "Device_" prefix.
 std::string GetString(u32 em_address, size_t size = 0);
-u8* GetPointer(u32 address);
-void CopyFromEmu(void* data, u32 address, size_t size);
+u8* GetPointer(const u32 address, bool panic_on_error = true);
+bool CopyFromEmu(void* data, u32 address, size_t size, bool panic_on_error = true);
 void CopyToEmu(u32 address, const void* data, size_t size);
 void Memset(u32 address, u8 value, size_t size);
 u8 Read_U8(u32 address);

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <fstream>
-#include <iostream>
+#include <iterator>
 #include <memory>
 #include <sstream>
 #include <unistd.h>
@@ -71,14 +71,50 @@ bool MemoryWatcher::LoadAddresses(const std::string& path)
 
 void MemoryWatcher::ParseLine(const std::string& line)
 {
-  m_values[line] = 0;
-  m_addresses[line] = std::vector<u32>();
+  // Ignore lines that start with a #
+  if (line.front() == '#')
+  {
+    return;
+  }
 
-  std::stringstream offsets(line);
-  offsets >> std::hex;
-  u32 offset;
-  while (offsets >> offset)
-    m_addresses[line].push_back(offset);
+  if (std::count( line.begin(), line.end(), ' ' ) == 3)
+  {
+    // This is a linked list line
+    //  First, split the string into its parts
+    std::istringstream iss(line);
+    std::vector<std::string> tokens{std::istream_iterator<std::string>{iss},
+                                    std::istream_iterator<std::string>{}};
+
+    m_linked_lists[tokens[0]] = LinkedList();
+
+    std::stringstream ss;
+    u32 converted;
+    ss << std::hex << tokens[1];
+    ss >> converted;
+    m_linked_lists[tokens[0]].m_pointer_offset = converted;
+
+    std::stringstream ss1;
+    ss1 << std::hex << tokens[2];
+    ss1 >> converted;
+    m_linked_lists[tokens[0]].m_data_pointer_offset = converted;
+
+    std::stringstream ss2;
+    ss2 << std::hex << tokens[3];
+    ss2 >> converted;
+    m_linked_lists[tokens[0]].m_data_struct_len = converted;
+  }
+  else
+  {
+    // This is a uint32 line
+    m_values[line] = 0;
+    m_addresses[line] = std::vector<u32>();
+
+    std::stringstream offsets(line);
+    offsets >> std::hex;
+    u32 offset;
+    while (offsets >> offset)
+      m_addresses[line].push_back(offset);
+  }
 }
 
 bool MemoryWatcher::OpenSocket(const std::string& path)
@@ -99,11 +135,101 @@ u32 MemoryWatcher::ChasePointer(const std::string& line)
   return value;
 }
 
+bool MemoryWatcher::ChaseLinkedList(const std::string& address, LinkedList& llist)
+{
+  u32 pointer;
+  std::stringstream ss;
+  ss << std::hex << address;
+  ss >> pointer;
+
+  // Follow the first pointer over
+  pointer = Memory::Read_U32(pointer);
+  LinkedList::ListData data;
+
+  bool changed = false;
+  size_t i = 0;
+  while (true)
+  {
+    // Quit on NULL pointer
+    if (pointer == 0)
+    {
+      if (i != llist.m_data.size())
+      {
+        changed = true;
+      }
+      break;
+    }
+
+    // Grab the data pointer from the current element
+    u32 data_pointer = 0;
+    if (!Memory::CopyFromEmu(&data_pointer, pointer + llist.m_data_pointer_offset,
+                             sizeof(data_pointer), false))
+    {
+      break;
+    }
+
+    data_pointer = Common::swap32(data_pointer);
+
+    // Read a blob at the data pointer address. This is the actual data we care about
+    // Read the next element in the list
+    LinkedList::Blob chunk(llist.m_data_struct_len);
+    if (!Memory::CopyFromEmu(chunk.data(), data_pointer, llist.m_data_struct_len,
+        false))
+    {
+      // If we get an error here, interpret it as a NULL pointer and just quit
+      // When we first boot up, this memory will be uninitialized and contain
+      // garbage. We have to gracefully handle that case.
+      break;
+    }
+
+    if (i < llist.m_data.size())
+    {
+      if (chunk != llist.m_data[i])
+      {
+        changed = true;
+      }
+    }
+    else
+    {
+      // This list has a different number of entries, so it's definitely changed
+      changed = true;
+    }
+
+    data.push_back(std::move(chunk));
+
+    // Follow the pointer to the location of the next object
+    if (!Memory::CopyFromEmu(&pointer, pointer + llist.m_pointer_offset, sizeof(data_pointer)), false)
+    {
+      break;
+    }
+    pointer = Common::swap32(pointer);
+    i++;
+  }
+
+  if (changed)
+  {
+    llist.m_data = std::move(data);;
+  }
+  return changed;
+}
+
 std::string MemoryWatcher::ComposeMessage(const std::string& line, u32 value)
 {
   std::stringstream message_stream;
   message_stream << line << '\n' << std::hex << value;
   return message_stream.str();
+}
+
+std::string MemoryWatcher::ComposeMessage(const std::string& line, const LinkedList::Blob& data)
+{
+  std::string message = line + '\n';
+
+  std::stringstream ss;
+  for (auto entry : data)
+  {
+    ss << std::setw(2) << std::setfill('0') << std::hex << static_cast<unsigned int>(entry);
+  }
+  return message + ss.str();
 }
 
 void MemoryWatcher::Step()
@@ -124,6 +250,31 @@ void MemoryWatcher::Step()
       std::string message = ComposeMessage(address, new_value);
       sendto(m_fd, message.c_str(), message.size() + 1, 0, reinterpret_cast<sockaddr*>(&m_addr),
              sizeof(m_addr));
+    }
+  }
+
+  // Process linked lists
+  for (auto& entry : m_linked_lists)
+  {
+    std::string address = entry.first;
+    LinkedList& llist = entry.second;
+    // Update the linked list entry for this pointer
+    if (ChaseLinkedList(address, llist))
+    {
+      // If the contents changed, then let the listener know
+      if (m_linked_lists[address].m_data.empty())
+      {
+        std::string message = address + "\n\n";
+        sendto(m_fd, message.c_str(), message.size() + 1, 0, reinterpret_cast<sockaddr*>(&m_addr),
+               sizeof(m_addr));
+      }
+
+      for (const auto& datum : m_linked_lists[address].m_data)
+      {
+        std::string message = ComposeMessage(address, datum);
+        sendto(m_fd, message.c_str(), message.size() + 1, 0, reinterpret_cast<sockaddr*>(&m_addr),
+               sizeof(m_addr));
+      }
     }
   }
 }

--- a/Source/Core/Core/MemoryWatcher.h
+++ b/Source/Core/Core/MemoryWatcher.h
@@ -13,13 +13,50 @@
 // changes to those memory addresses to a unix domain socket as the game runs.
 //
 // The input file is a newline-separated list of hex memory addresses, without
-// the "0x". To follow pointers, separate addresses with a space. For example,
-// "ABCD EF" will watch the address at (*0xABCD) + 0xEF.
-// The output to the socket is two lines. The first is the address from the
-// input file, and the second is the new value in hex.
+// the "0x". This can take one of three forms:
+// 1: Read four bytes at static memory address
+//    ex:
+//        ABCD
+//    Output: Two lines. The first is the address from the
+//      input file, and the second is the new value in hex.
+// 2: Read four bytes, followed at pointer
+//    ex:
+//        ABCD EF
+//        ^ will watch the address at (*0xABCD) + 0xEF.
+//    Output: Two lines. The first is the address from the
+//      input file, and the second is the new value in hex.
+// 3: Read linked list structure, with data in pointers
+//    If you're wondering what would use such a funny and specific data
+//      structure: Items in Melee, that's what.
+//    ex:
+//        ABCD EF GH
+//        ^ ABCD: Address of the initial pointer
+//          EF: Size (in bytes) of an element of the linked list
+//          GH: Offset within element to pointer to next element in list
+//          IJ: Data struct pointer offset
+//          KL: Data struct size
+//    NOTE: MemoryWatcher will follow the linked list until the pointer to the
+//      next element is NULL.
+//    Output: N lines, where N is the number of objects found
+//      Each line contains space separated hex strings in the following format:
+//        ABCD DEADBEEF
+//        ^ ABCD: The initial address as passed in initially
+//          DEADBEEF: The hex contents of the object in two width string format.
+
 class MemoryWatcher final
 {
 public:
+  struct LinkedList
+  {
+    using Blob = std::vector<u8>;
+    using ListData = std::vector<Blob>;
+
+    u32 m_pointer_offset;
+    u32 m_data_pointer_offset;
+    u32 m_data_struct_len;
+    ListData m_data;
+  };
+
   MemoryWatcher();
   ~MemoryWatcher();
   void Step();
@@ -33,7 +70,10 @@ private:
 
   void ParseLine(const std::string& line);
   u32 ChasePointer(const std::string& line);
+  // Returns true if the contents changed
+  bool ChaseLinkedList(const std::string& address, LinkedList& llist);
   std::string ComposeMessage(const std::string& line, u32 value);
+  std::string ComposeMessage(const std::string& line, const LinkedList::Blob&);
 
   bool m_running;
 
@@ -44,4 +84,7 @@ private:
   std::map<std::string, std::vector<u32>> m_addresses;
   // Address as stored in the file -> current value
   std::map<std::string, u32> m_values;
+
+  // Starting address as stored in the file -> vector of data blobs
+  std::map<std::string, LinkedList> m_linked_lists;
 };

--- a/Source/Core/Core/MemoryWatcher.h
+++ b/Source/Core/Core/MemoryWatcher.h
@@ -19,10 +19,11 @@
 //        ABCD
 //    Output: Two lines. The first is the address from the
 //      input file, and the second is the new value in hex.
-// 2: Read four bytes, followed at pointer
+// 2: Read four bytes, following list of pointers
 //    ex:
-//        ABCD EF
-//        ^ will watch the address at (*0xABCD) + 0xEF.
+//        ABCD EF [XY] ..
+//        ^ will watch the address at *((*0xABCD) + 0xEF) + 0xXY
+//          continuing on following pointers for as many offsets are given
 //    Output: Two lines. The first is the address from the
 //      input file, and the second is the new value in hex.
 // 3: Read linked list structure, with data in pointers


### PR DESCRIPTION
Adds support to the MemoryWatcher API for reading linked list structures from game memory. This exact format is described in MemoryWatcher.h

A working external program that interfaces with this functionality can be found here:

https://github.com/altf4/SmashBot/tree/python-rewrite

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4407)

<!-- Reviewable:end -->
