### PR TITLE
[Android TV] Fix a screenshot glitch on game selector

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/adapters/GameRowPresenter.java
@@ -51,6 +51,8 @@ public final class GameRowPresenter extends Presenter
 
 		String screenPath = game.getScreenshotPath();
 
+		holder.imageScreenshot.setImageDrawable(null);
+
 		// Fill in the view contents.
 		Picasso.with(holder.imageScreenshot.getContext())
 				.load(screenPath)


### PR DESCRIPTION
Picasso, the image loading library we use, attempts to load screenshots for each game when it scrolls on screen. It can take some time to decide this operation is not completable - for example, if the screenshot is missing.

When this happens, it's quite likely the View that displays the screenshot will be left displaying the screenshot of the game that most recently scrolled off screen.

This should address that bug.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4409)

<!-- Reviewable:end -->
