### PR TITLE
Remove Blob nullptr checks from Volume code

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/ColorUtil.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -25,6 +26,7 @@ namespace DiscIO
 {
 CVolumeGC::CVolumeGC(std::unique_ptr<IBlobReader> reader) : m_pReader(std::move(reader))
 {
+  _assert_(m_pReader);
 }
 
 CVolumeGC::~CVolumeGC()
@@ -35,9 +37,6 @@ bool CVolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const
 {
   if (decrypt)
     PanicAlertT("Tried to decrypt data from a non-Wii volume");
-
-  if (m_pReader == nullptr)
-    return false;
 
   FileMon::FindFilename(_Offset);
 
@@ -162,17 +161,17 @@ std::string CVolumeGC::GetApploaderDate() const
 
 BlobType CVolumeGC::GetBlobType() const
 {
-  return m_pReader ? m_pReader->GetBlobType() : BlobType::PLAIN;
+  return m_pReader->GetBlobType();
 }
 
 u64 CVolumeGC::GetSize() const
 {
-  return m_pReader ? m_pReader->GetDataSize() : 0;
+  return m_pReader->GetDataSize();
 }
 
 u64 CVolumeGC::GetRawSize() const
 {
-  return m_pReader ? m_pReader->GetRawSize() : 0;
+  return m_pReader->GetRawSize();
 }
 
 u8 CVolumeGC::GetDiscNumber() const

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Common/Align.h"
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -24,6 +25,8 @@ namespace DiscIO
 {
 CVolumeWAD::CVolumeWAD(std::unique_ptr<IBlobReader> reader) : m_reader(std::move(reader))
 {
+  _assert_(m_reader);
+
   // Source: http://wiibrew.org/wiki/WAD_files
   ReadSwapped(0x00, &m_hdr_size, false);
   ReadSwapped(0x08, &m_cert_size, false);
@@ -56,9 +59,6 @@ bool CVolumeWAD::Read(u64 offset, u64 length, u8* buffer, bool decrypt) const
 {
   if (decrypt)
     PanicAlertT("Tried to decrypt data from a non-Wii volume");
-
-  if (m_reader == nullptr)
-    return false;
 
   return m_reader->Read(offset, length, buffer);
 }
@@ -150,17 +150,17 @@ std::vector<u32> CVolumeWAD::GetBanner(int* width, int* height) const
 
 BlobType CVolumeWAD::GetBlobType() const
 {
-  return m_reader ? m_reader->GetBlobType() : BlobType::PLAIN;
+  return m_reader->GetBlobType();
 }
 
 u64 CVolumeWAD::GetSize() const
 {
-  return m_reader ? m_reader->GetDataSize() : 0;
+  return m_reader->GetDataSize();
 }
 
 u64 CVolumeWAD::GetRawSize() const
 {
-  return m_reader ? m_reader->GetRawSize() : 0;
+  return m_reader->GetRawSize();
 }
 
 }  // namespace

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -33,6 +34,8 @@ CVolumeWiiCrypted::CVolumeWiiCrypted(std::unique_ptr<IBlobReader> reader, u64 _V
     : m_pReader(std::move(reader)), m_AES_ctx(std::make_unique<mbedtls_aes_context>()),
       m_VolumeOffset(_VolumeOffset), m_dataOffset(0x20000), m_LastDecryptedBlockOffset(-1)
 {
+  _assert_(m_pReader);
+
   mbedtls_aes_setkey_dec(m_AES_ctx.get(), _pVolumeKey, 128);
 }
 
@@ -53,9 +56,6 @@ CVolumeWiiCrypted::~CVolumeWiiCrypted()
 
 bool CVolumeWiiCrypted::Read(u64 _ReadOffset, u64 _Length, u8* _pBuffer, bool decrypt) const
 {
-  if (m_pReader == nullptr)
-    return false;
-
   if (!decrypt)
     return m_pReader->Read(_ReadOffset, _Length, _pBuffer);
 
@@ -275,17 +275,17 @@ u8 CVolumeWiiCrypted::GetDiscNumber() const
 
 BlobType CVolumeWiiCrypted::GetBlobType() const
 {
-  return m_pReader ? m_pReader->GetBlobType() : BlobType::PLAIN;
+  return m_pReader->GetBlobType();
 }
 
 u64 CVolumeWiiCrypted::GetSize() const
 {
-  return m_pReader ? m_pReader->GetDataSize() : 0;
+  return m_pReader->GetDataSize();
 }
 
 u64 CVolumeWiiCrypted::GetRawSize() const
 {
-  return m_pReader ? m_pReader->GetRawSize() : 0;
+  return m_pReader->GetRawSize();
 }
 
 bool CVolumeWiiCrypted::CheckIntegrity() const


### PR DESCRIPTION
There's no point in creating a volume without a blob, since essentially all the functionality of a volume requires a blob to be used.

Also, VolumeCreator doesn't support creating volumes without blobs (it can't even figure out the volume type unless it gets a blob), so it's currently impossible for a volume to be created without a blob.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4411)
<!-- Reviewable:end -->
