### PR TITLE
Remove double newlines at the end of *_LOG messages

### DIFF
--- a/Source/Core/AudioCommon/AlsaSoundStream.cpp
+++ b/Source/Core/AudioCommon/AlsaSoundStream.cpp
@@ -98,7 +98,7 @@ bool AlsaSound::AlsaInit()
   err = snd_pcm_open(&handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Audio open error: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Audio open error: %s", snd_strerror(err));
     return false;
   }
 
@@ -107,21 +107,21 @@ bool AlsaSound::AlsaInit()
   err = snd_pcm_hw_params_any(handle, hwparams);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Broken configuration for this PCM: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Broken configuration for this PCM: %s", snd_strerror(err));
     return false;
   }
 
   err = snd_pcm_hw_params_set_access(handle, hwparams, SND_PCM_ACCESS_RW_INTERLEAVED);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Access type not available: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Access type not available: %s", snd_strerror(err));
     return false;
   }
 
   err = snd_pcm_hw_params_set_format(handle, hwparams, SND_PCM_FORMAT_S16_LE);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Sample format not available: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Sample format not available: %s", snd_strerror(err));
     return false;
   }
 
@@ -129,14 +129,14 @@ bool AlsaSound::AlsaInit()
   err = snd_pcm_hw_params_set_rate_near(handle, hwparams, &sample_rate, &dir);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Rate not available: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Rate not available: %s", snd_strerror(err));
     return false;
   }
 
   err = snd_pcm_hw_params_set_channels(handle, hwparams, CHANNEL_COUNT);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Channels count not available: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Channels count not available: %s", snd_strerror(err));
     return false;
   }
 
@@ -144,7 +144,7 @@ bool AlsaSound::AlsaInit()
   err = snd_pcm_hw_params_set_periods_max(handle, hwparams, &periods, &dir);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Cannot set maximum periods per buffer: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Cannot set maximum periods per buffer: %s", snd_strerror(err));
     return false;
   }
 
@@ -152,28 +152,28 @@ bool AlsaSound::AlsaInit()
   err = snd_pcm_hw_params_set_buffer_size_max(handle, hwparams, &buffer_size_max);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Cannot set maximum buffer size: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Cannot set maximum buffer size: %s", snd_strerror(err));
     return false;
   }
 
   err = snd_pcm_hw_params(handle, hwparams);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Unable to install hw params: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Unable to install hw params: %s", snd_strerror(err));
     return false;
   }
 
   err = snd_pcm_hw_params_get_buffer_size(hwparams, &buffer_size);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Cannot get buffer size: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Cannot get buffer size: %s", snd_strerror(err));
     return false;
   }
 
   err = snd_pcm_hw_params_get_periods_max(hwparams, &periods, &dir);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Cannot get periods: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Cannot get periods: %s", snd_strerror(err));
     return false;
   }
 
@@ -187,7 +187,7 @@ bool AlsaSound::AlsaInit()
   if ((unsigned int)frames_to_deliver > buffer_size)
     frames_to_deliver = buffer_size;
   NOTICE_LOG(AUDIO, "ALSA gave us a %ld sample \"hardware\" buffer with %d periods. Will send %d "
-                    "samples per fragments.\n",
+                    "samples per fragments.",
              buffer_size, periods, frames_to_deliver);
 
   snd_pcm_sw_params_alloca(&swparams);
@@ -195,31 +195,31 @@ bool AlsaSound::AlsaInit()
   err = snd_pcm_sw_params_current(handle, swparams);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "cannot init sw params: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "cannot init sw params: %s", snd_strerror(err));
     return false;
   }
 
   err = snd_pcm_sw_params_set_start_threshold(handle, swparams, 0U);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "cannot set start thresh: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "cannot set start thresh: %s", snd_strerror(err));
     return false;
   }
 
   err = snd_pcm_sw_params(handle, swparams);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "cannot set sw params: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "cannot set sw params: %s", snd_strerror(err));
     return false;
   }
 
   err = snd_pcm_prepare(handle);
   if (err < 0)
   {
-    ERROR_LOG(AUDIO, "Unable to prepare: %s\n", snd_strerror(err));
+    ERROR_LOG(AUDIO, "Unable to prepare: %s", snd_strerror(err));
     return false;
   }
-  NOTICE_LOG(AUDIO, "ALSA successfully initialized.\n");
+  NOTICE_LOG(AUDIO, "ALSA successfully initialized.");
   return true;
 }
 

--- a/Source/Core/Common/GL/GLInterface/EGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGL.cpp
@@ -66,7 +66,7 @@ void cInterfaceEGL::DetectMode()
     // Get how many configs there are
     if (!eglChooseConfig(egl_dpy, attribs, nullptr, 0, &num_configs))
     {
-      INFO_LOG(VIDEO, "Error: couldn't get an EGL visual config\n");
+      INFO_LOG(VIDEO, "Error: couldn't get an EGL visual config");
       continue;
     }
 
@@ -75,7 +75,7 @@ void cInterfaceEGL::DetectMode()
     // Get all the configurations
     if (!eglChooseConfig(egl_dpy, attribs, config, num_configs, &num_configs))
     {
-      INFO_LOG(VIDEO, "Error: couldn't get an EGL visual config\n");
+      INFO_LOG(VIDEO, "Error: couldn't get an EGL visual config");
       delete[] config;
       continue;
     }
@@ -123,13 +123,13 @@ bool cInterfaceEGL::Create(void* window_handle, bool core)
 
   if (!egl_dpy)
   {
-    INFO_LOG(VIDEO, "Error: eglGetDisplay() failed\n");
+    INFO_LOG(VIDEO, "Error: eglGetDisplay() failed");
     return false;
   }
 
   if (!eglInitialize(egl_dpy, &egl_major, &egl_minor))
   {
-    INFO_LOG(VIDEO, "Error: eglInitialize() failed\n");
+    INFO_LOG(VIDEO, "Error: eglInitialize() failed");
     return false;
   }
 
@@ -166,14 +166,14 @@ bool cInterfaceEGL::Create(void* window_handle, bool core)
     ctx_attribs = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE};
     break;
   default:
-    ERROR_LOG(VIDEO, "Unknown opengl mode set\n");
+    ERROR_LOG(VIDEO, "Unknown opengl mode set");
     return false;
     break;
   }
 
   if (!eglChooseConfig(egl_dpy, attribs, &m_config, 1, &num_configs))
   {
-    INFO_LOG(VIDEO, "Error: couldn't get an EGL visual config\n");
+    INFO_LOG(VIDEO, "Error: couldn't get an EGL visual config");
     return false;
   }
 
@@ -224,13 +224,13 @@ bool cInterfaceEGL::Create(void* window_handle, bool core)
 
   if (!egl_ctx)
   {
-    INFO_LOG(VIDEO, "Error: eglCreateContext failed\n");
+    INFO_LOG(VIDEO, "Error: eglCreateContext failed");
     return false;
   }
 
   if (!CreateWindowSurface())
   {
-    ERROR_LOG(VIDEO, "Error: CreateWindowSurface failed 0x%04x\n", eglGetError());
+    ERROR_LOG(VIDEO, "Error: CreateWindowSurface failed 0x%04x", eglGetError());
     return false;
   }
   return true;
@@ -269,7 +269,7 @@ bool cInterfaceEGL::Create(cInterfaceBase* main_context)
     ctx_attribs[1] = 3;
     break;
   default:
-    INFO_LOG(VIDEO, "Unknown opengl mode set\n");
+    INFO_LOG(VIDEO, "Unknown opengl mode set");
     return false;
     break;
   }
@@ -282,13 +282,13 @@ bool cInterfaceEGL::Create(cInterfaceBase* main_context)
   egl_ctx = eglCreateContext(egl_dpy, m_config, egl_context->egl_ctx, ctx_attribs);
   if (!egl_ctx)
   {
-    INFO_LOG(VIDEO, "Error: eglCreateContext failed 0x%04x\n", eglGetError());
+    INFO_LOG(VIDEO, "Error: eglCreateContext failed 0x%04x", eglGetError());
     return false;
   }
 
   if (!CreateWindowSurface())
   {
-    ERROR_LOG(VIDEO, "Error: CreateWindowSurface failed 0x%04x\n", eglGetError());
+    ERROR_LOG(VIDEO, "Error: CreateWindowSurface failed 0x%04x", eglGetError());
     return false;
   }
   return true;
@@ -302,7 +302,7 @@ bool cInterfaceEGL::CreateWindowSurface()
     egl_surf = eglCreateWindowSurface(egl_dpy, m_config, native_window, nullptr);
     if (!egl_surf)
     {
-      INFO_LOG(VIDEO, "Error: eglCreateWindowSurface failed\n");
+      INFO_LOG(VIDEO, "Error: eglCreateWindowSurface failed");
       return false;
     }
   }

--- a/Source/Core/Common/SDCardUtil.cpp
+++ b/Source/Core/Common/SDCardUtil.cpp
@@ -223,7 +223,7 @@ bool SDCardCreate(u64 disk_size /*in MB*/, const std::string& filename)
   FILE* const f = file.GetHandle();
   if (!f)
   {
-    ERROR_LOG(COMMON, "Could not create file '%s', aborting...\n", filename.c_str());
+    ERROR_LOG(COMMON, "Could not create file '%s', aborting...", filename.c_str());
     return false;
   }
 
@@ -284,8 +284,8 @@ bool SDCardCreate(u64 disk_size /*in MB*/, const std::string& filename)
   return true;
 
 FailWrite:
-  ERROR_LOG(COMMON, "Could not write to '%s', aborting...\n", filename.c_str());
+  ERROR_LOG(COMMON, "Could not write to '%s', aborting...", filename.c_str());
   if (unlink(filename.c_str()) < 0)
-    ERROR_LOG(COMMON, "unlink(%s) failed\n%s", filename.c_str(), GetLastErrorMsg().c_str());
+    ERROR_LOG(COMMON, "unlink(%s) failed: %s", filename.c_str(), GetLastErrorMsg().c_str());
   return false;
 }

--- a/Source/Core/Core/DSP/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/DSPEmitter.cpp
@@ -141,7 +141,7 @@ void DSPEmitter::EmitInstruction(UDSPInstruction inst)
         gpr.PushRegs();
         ABI_CallFunctionC16(extOpTable[inst & 0x7F]->intFunc, inst);
         gpr.PopRegs();
-        INFO_LOG(DSPLLE, "Instruction not JITed(ext part): %04x\n", inst);
+        INFO_LOG(DSPLLE, "Instruction not JITed(ext part): %04x", inst);
         ext_is_jit = false;
       }
       else
@@ -158,7 +158,7 @@ void DSPEmitter::EmitInstruction(UDSPInstruction inst)
         gpr.PushRegs();
         ABI_CallFunctionC16(extOpTable[inst & 0xFF]->intFunc, inst);
         gpr.PopRegs();
-        INFO_LOG(DSPLLE, "Instruction not JITed(ext part): %04x\n", inst);
+        INFO_LOG(DSPLLE, "Instruction not JITed(ext part): %04x", inst);
         ext_is_jit = false;
       }
       else
@@ -173,7 +173,7 @@ void DSPEmitter::EmitInstruction(UDSPInstruction inst)
   if (!opTable[inst]->jitFunc)
   {
     FallBackToInterpreter(inst);
-    INFO_LOG(DSPLLE, "Instruction not JITed(main part): %04x\n", inst);
+    INFO_LOG(DSPLLE, "Instruction not JITed(main part): %04x", inst);
   }
   else
   {

--- a/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/BBA-TAP/TAP_Win32.cpp
@@ -297,7 +297,7 @@ static void ReadThreadHandler(CEXIETHERNET* self)
     }
 
     // Copy to BBA buffer, and fire interrupt if enabled.
-    DEBUG_LOG(SP1, "Received %u bytes\n: %s", transferred,
+    DEBUG_LOG(SP1, "Received %u bytes:\n %s", transferred,
               ArrayToString(self->mRecvBuffer.get(), transferred, 0x10).c_str());
     if (self->readEnabled.IsSet())
     {

--- a/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceMemoryCard.cpp
@@ -510,7 +510,7 @@ void CEXIMemoryCard::TransferByte(u8& byte)
       break;
 
     default:
-      WARN_LOG(EXPANSIONINTERFACE, "EXI MEMCARD: unknown command byte %02x\n", byte);
+      WARN_LOG(EXPANSIONINTERFACE, "EXI MEMCARD: unknown command byte %02x", byte);
       byte = 0xFF;
     }
   }

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -110,7 +110,7 @@ void Wiimote::SpeakerData(wm_speaker_data* sd)
   }
   else
   {
-    ERROR_LOG(WII_IPC_WIIMOTE, "Unknown speaker format %x\n", m_reg_speaker.format);
+    ERROR_LOG(WII_IPC_WIIMOTE, "Unknown speaker format %x", m_reg_speaker.format);
     return;
   }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -492,7 +492,7 @@ public:
       break;
 
     default:
-      ERROR_LOG(WII_IPC_NET, "%s - unknown IOCtl: %x\n", GetDeviceName().c_str(), Parameter);
+      ERROR_LOG(WII_IPC_NET, "%s - unknown IOCtl: %x", GetDeviceName().c_str(), Parameter);
       break;
     }
 

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -63,7 +63,7 @@ static u8 hex2char(u8 hex)
   else if (hex >= 'A' && hex <= 'F')
     return hex - 'A' + 0xa;
 
-  ERROR_LOG(GDB_STUB, "Invalid nibble: %c (%02x)\n", hex, hex);
+  ERROR_LOG(GDB_STUB, "Invalid nibble: %c (%02x)", hex, hex);
   return 0;
 }
 
@@ -186,7 +186,7 @@ static void gdb_bp_remove(u32 type, u32 addr, u32 len)
     p = gdb_bp_find(type, addr, len);
     if (p != nullptr)
     {
-      DEBUG_LOG(GDB_STUB, "gdb: removed a breakpoint: %08x bytes at %08x\n", len, addr);
+      DEBUG_LOG(GDB_STUB, "gdb: removed a breakpoint: %08x bytes at %08x", len, addr);
       p->active = 0;
       memset(p, 0, sizeof(gdb_bp_t));
     }
@@ -253,7 +253,7 @@ static void gdb_read_command()
   }
   else if (c != GDB_STUB_START)
   {
-    DEBUG_LOG(GDB_STUB, "gdb: read invalid byte %02x\n", c);
+    DEBUG_LOG(GDB_STUB, "gdb: read invalid byte %02x", c);
     return;
   }
 
@@ -262,7 +262,7 @@ static void gdb_read_command()
     cmd_bfr[cmd_len++] = c;
     if (cmd_len == sizeof cmd_bfr)
     {
-      ERROR_LOG(GDB_STUB, "gdb: cmd_bfr overflow\n");
+      ERROR_LOG(GDB_STUB, "gdb: cmd_bfr overflow");
       gdb_nak();
       return;
     }
@@ -276,7 +276,7 @@ static void gdb_read_command()
   if (chk_calc != chk_read)
   {
     ERROR_LOG(GDB_STUB,
-              "gdb: invalid checksum: calculated %02x and read %02x for $%s# (length: %d)\n",
+              "gdb: invalid checksum: calculated %02x and read %02x for $%s# (length: %d)",
               chk_calc, chk_read, cmd_bfr, cmd_len);
     cmd_len = 0;
 
@@ -284,8 +284,7 @@ static void gdb_read_command()
     return;
   }
 
-  DEBUG_LOG(GDB_STUB, "gdb: read command %c with a length of %d: %s\n", cmd_bfr[0], cmd_len,
-            cmd_bfr);
+  DEBUG_LOG(GDB_STUB, "gdb: read command %c with a length of %d: %s", cmd_bfr[0], cmd_len, cmd_bfr);
   gdb_ack();
 }
 
@@ -337,7 +336,7 @@ static void gdb_reply(const char* reply)
   cmd_bfr[cmd_len + 2] = nibble2hex(chk >> 4);
   cmd_bfr[cmd_len + 3] = nibble2hex(chk);
 
-  DEBUG_LOG(GDB_STUB, "gdb: reply (len: %d): %s\n", cmd_len, cmd_bfr);
+  DEBUG_LOG(GDB_STUB, "gdb: reply (len: %d): %s", cmd_len, cmd_bfr);
 
   ptr = cmd_bfr;
   left = cmd_len + 4;
@@ -356,7 +355,7 @@ static void gdb_reply(const char* reply)
 
 static void gdb_handle_query()
 {
-  DEBUG_LOG(GDB_STUB, "gdb: query '%s'\n", cmd_bfr + 1);
+  DEBUG_LOG(GDB_STUB, "gdb: query '%s'", cmd_bfr + 1);
 
   if (!strcmp((const char*)(cmd_bfr + 1), "TStatus"))
   {
@@ -589,7 +588,7 @@ static void gdb_read_mem()
   len = 0;
   while (i < cmd_len)
     len = (len << 4) | hex2char(cmd_bfr[i++]);
-  DEBUG_LOG(GDB_STUB, "gdb: read memory: %08x bytes from %08x\n", len, addr);
+  DEBUG_LOG(GDB_STUB, "gdb: read memory: %08x bytes from %08x", len, addr);
 
   if (len * 2 > sizeof reply)
     gdb_reply("E01");
@@ -615,7 +614,7 @@ static void gdb_write_mem()
   len = 0;
   while (cmd_bfr[i] != ':')
     len = (len << 4) | hex2char(cmd_bfr[i++]);
-  DEBUG_LOG(GDB_STUB, "gdb: write memory: %08x bytes to %08x\n", len, addr);
+  DEBUG_LOG(GDB_STUB, "gdb: write memory: %08x bytes to %08x", len, addr);
 
   u8* dst = Memory::GetPointer(addr);
   if (!dst)
@@ -652,7 +651,7 @@ bool gdb_add_bp(u32 type, u32 addr, u32 len)
   bp->addr = addr;
   bp->len = len;
 
-  DEBUG_LOG(GDB_STUB, "gdb: added %d breakpoint: %08x bytes at %08x\n", type, bp->len, bp->addr);
+  DEBUG_LOG(GDB_STUB, "gdb: added %d breakpoint: %08x bytes at %08x", type, bp->len, bp->addr);
   return true;
 }
 
@@ -870,12 +869,12 @@ static void gdb_init_generic(int domain, const sockaddr* server_addr, socklen_t 
   if (listen(tmpsock, 1) < 0)
     ERROR_LOG(GDB_STUB, "Failed to listen to gdb socket");
 
-  INFO_LOG(GDB_STUB, "Waiting for gdb to connect...\n");
+  INFO_LOG(GDB_STUB, "Waiting for gdb to connect...");
 
   sock = accept(tmpsock, client_addr, client_addrlen);
   if (sock < 0)
     ERROR_LOG(GDB_STUB, "Failed to accept gdb client");
-  INFO_LOG(GDB_STUB, "Client connected.\n");
+  INFO_LOG(GDB_STUB, "Client connected.");
 
   close(tmpsock);
   tmpsock = -1;

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -48,7 +48,7 @@ void JitArm64::GenerateAsm()
   // } while (CPU::GetState() == CPU::CPU_RUNNING);
   AlignCodePage();
   dispatcher = GetCodePtr();
-  WARN_LOG(DYNA_REC, "Dispatcher is %p\n", dispatcher);
+  WARN_LOG(DYNA_REC, "Dispatcher is %p", dispatcher);
 
   // Downcount Check
   // The result of slice decrementation should be in flags if somebody jumped here

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -987,7 +987,7 @@ void CISOProperties::ExportDir(const std::string& _rFullPath, const std::string&
       }
     }
 
-    INFO_LOG(DISCIO, "Directory found from %u to %u\nextracting to:\n%s", index, size,
+    INFO_LOG(DISCIO, "Directory found from %u to %u\nextracting to: %s", index, size,
              _rExportFolder.c_str());
   }
 

--- a/Source/Core/VideoBackends/D3D/D3DShader.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DShader.cpp
@@ -44,7 +44,7 @@ bool CompileVertexShader(const std::string& code, D3DBlob** blob)
                            D3D::VertexShaderVersionString(), flags, 0, &shaderBuffer, &errorBuffer);
   if (errorBuffer)
   {
-    INFO_LOG(VIDEO, "Vertex shader compiler messages:\n%s\n",
+    INFO_LOG(VIDEO, "Vertex shader compiler messages:\n%s",
              (const char*)errorBuffer->GetBufferPointer());
   }
 
@@ -102,7 +102,7 @@ bool CompileGeometryShader(const std::string& code, D3DBlob** blob,
 
   if (errorBuffer)
   {
-    INFO_LOG(VIDEO, "Geometry shader compiler messages:\n%s\n",
+    INFO_LOG(VIDEO, "Geometry shader compiler messages:\n%s",
              (const char*)errorBuffer->GetBufferPointer());
   }
 

--- a/Source/Core/VideoBackends/D3D12/D3DShader.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DShader.cpp
@@ -34,7 +34,7 @@ bool CompileShader(const std::string& code, ID3DBlob** blob, const D3D_SHADER_MA
 
   if (error_buffer)
   {
-    WARN_LOG(VIDEO, "Warning generated when compiling %s shader:\n%s\n",
+    WARN_LOG(VIDEO, "Warning generated when compiling %s shader:\n%s",
              shader_version_string.c_str(),
              static_cast<const char*>(error_buffer->GetBufferPointer()));
   }

--- a/Source/Core/VideoBackends/Null/Render.cpp
+++ b/Source/Core/VideoBackends/Null/Render.cpp
@@ -25,7 +25,7 @@ Renderer::~Renderer()
 
 void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
 {
-  NOTICE_LOG(VIDEO, "RenderText: %s\n", text.c_str());
+  NOTICE_LOG(VIDEO, "RenderText: %s", text.c_str());
 }
 
 TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -200,7 +200,7 @@ void OnPixelFormatChange()
 
   if (convtype == -1)
   {
-    ERROR_LOG(VIDEO, "Unhandled EFB format change: %d to %d\n", static_cast<int>(old_format),
+    ERROR_LOG(VIDEO, "Unhandled EFB format change: %d to %d", static_cast<int>(old_format),
               static_cast<int>(new_format));
     goto skip;
   }

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -107,7 +107,7 @@ void PixelShaderManager::SetTevColor(int index, int component, s32 value)
   c[component] = value;
   dirty = true;
 
-  PRIM_LOG("tev color%d: %d %d %d %d\n", index, c[0], c[1], c[2], c[3]);
+  PRIM_LOG("tev color%d: %d %d %d %d", index, c[0], c[1], c[2], c[3]);
 }
 
 void PixelShaderManager::SetTevKonstColor(int index, int component, s32 value)
@@ -116,7 +116,7 @@ void PixelShaderManager::SetTevKonstColor(int index, int component, s32 value)
   c[component] = value;
   dirty = true;
 
-  PRIM_LOG("tev konst color%d: %d %d %d %d\n", index, c[0], c[1], c[2], c[3]);
+  PRIM_LOG("tev konst color%d: %d %d %d %d", index, c[0], c[1], c[2], c[3]);
 }
 
 void PixelShaderManager::SetAlpha()
@@ -201,7 +201,7 @@ void PixelShaderManager::SetIndMatrixChanged(int matrixidx)
   constants.indtexmtx[2 * matrixidx + 1][3] = 17 - scale;
   dirty = true;
 
-  PRIM_LOG("indmtx%d: scale=%d, mat=(%d %d %d; %d %d %d)\n", matrixidx, scale,
+  PRIM_LOG("indmtx%d: scale=%d, mat=(%d %d %d; %d %d %d)", matrixidx, scale,
            bpmem.indmtx[matrixidx].col0.ma, bpmem.indmtx[matrixidx].col1.mc,
            bpmem.indmtx[matrixidx].col2.me, bpmem.indmtx[matrixidx].col0.mb,
            bpmem.indmtx[matrixidx].col1.md, bpmem.indmtx[matrixidx].col2.mf);

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -540,8 +540,8 @@ void VertexShaderManager::SetConstants()
       ERROR_LOG(VIDEO, "Unknown projection type: %d", xfmem.projection.type);
     }
 
-    PRIM_LOG("Projection: %f %f %f %f %f %f\n", rawProjection[0], rawProjection[1],
-             rawProjection[2], rawProjection[3], rawProjection[4], rawProjection[5]);
+    PRIM_LOG("Projection: %f %f %f %f %f %f", rawProjection[0], rawProjection[1], rawProjection[2],
+             rawProjection[3], rawProjection[4], rawProjection[5]);
 
     if (g_ActiveConfig.bFreeLook && xfmem.projection.type == GX_PERSPECTIVE)
     {


### PR DESCRIPTION
These come from people using *_LOG functions like printf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4414)
<!-- Reviewable:end -->
