### PR TITLE
Re-order emulated Wii Remote and Nunchuk configuration windows

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -25,8 +25,11 @@ Nunchuk::Nunchuk(WiimoteEmu::ExtensionReg& _reg) : Attachment(_trans("Nunchuk"),
   m_buttons->controls.emplace_back(new ControlGroup::Input("C"));
   m_buttons->controls.emplace_back(new ControlGroup::Input("Z"));
 
-  // stick
-  groups.emplace_back(m_stick = new AnalogStick("Stick", DEFAULT_ATTACHMENT_STICK_RADIUS));
+  // shake
+  groups.emplace_back(m_shake = new Buttons("Shake"));
+  m_shake->controls.emplace_back(new ControlGroup::Input("X"));
+  m_shake->controls.emplace_back(new ControlGroup::Input("Y"));
+  m_shake->controls.emplace_back(new ControlGroup::Input("Z"));
 
   // swing
   groups.emplace_back(m_swing = new Force("Swing"));
@@ -34,11 +37,8 @@ Nunchuk::Nunchuk(WiimoteEmu::ExtensionReg& _reg) : Attachment(_trans("Nunchuk"),
   // tilt
   groups.emplace_back(m_tilt = new Tilt("Tilt"));
 
-  // shake
-  groups.emplace_back(m_shake = new Buttons("Shake"));
-  m_shake->controls.emplace_back(new ControlGroup::Input("X"));
-  m_shake->controls.emplace_back(new ControlGroup::Input("Y"));
-  m_shake->controls.emplace_back(new ControlGroup::Input("Z"));
+  // stick
+  groups.emplace_back(m_stick = new AnalogStick("Stick", DEFAULT_ATTACHMENT_STICK_RADIUS));
 
   // id
   memcpy(&id, nunchuk_id, sizeof(nunchuk_id));

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -242,20 +242,25 @@ Wiimote::Wiimote(const unsigned int index)
   for (auto& named_button : named_buttons)
     m_buttons->controls.emplace_back(new ControlGroup::Input(named_button));
 
+  // dpad
+  groups.emplace_back(m_dpad = new Buttons("D-Pad"));
+  for (auto& named_direction : named_directions)
+    m_dpad->controls.emplace_back(new ControlGroup::Input(named_direction));
+
   // ir
   groups.emplace_back(m_ir = new Cursor(_trans("IR")));
-
-  // swing
-  groups.emplace_back(m_swing = new Force(_trans("Swing")));
-
-  // tilt
-  groups.emplace_back(m_tilt = new Tilt(_trans("Tilt")));
 
   // shake
   groups.emplace_back(m_shake = new Buttons(_trans("Shake")));
   m_shake->controls.emplace_back(new ControlGroup::Input("X"));
   m_shake->controls.emplace_back(new ControlGroup::Input("Y"));
   m_shake->controls.emplace_back(new ControlGroup::Input("Z"));
+
+  // swing
+  groups.emplace_back(m_swing = new Force(_trans("Swing")));
+
+  // tilt
+  groups.emplace_back(m_tilt = new Tilt(_trans("Tilt")));
 
   // extension
   groups.emplace_back(m_extension = new Extension(_trans("Extension")));
@@ -273,10 +278,15 @@ Wiimote::Wiimote(const unsigned int index)
   groups.emplace_back(m_rumble = new ControlGroup(_trans("Rumble")));
   m_rumble->controls.emplace_back(new ControlGroup::Output(_trans("Motor")));
 
-  // dpad
-  groups.emplace_back(m_dpad = new Buttons("D-Pad"));
-  for (auto& named_direction : named_directions)
-    m_dpad->controls.emplace_back(new ControlGroup::Input(named_direction));
+  // hotkeys
+  groups.emplace_back(m_hotkeys = new ModifySettingsButton(_trans("Hotkeys")));
+  // hotkeys to temporarily modify the Wii Remote orientation (sideways, upright)
+  // this setting modifier is toggled
+  m_hotkeys->AddInput(_trans("Sideways Toggle"), true);
+  m_hotkeys->AddInput(_trans("Upright Toggle"), true);
+  // this setting modifier is not toggled
+  m_hotkeys->AddInput(_trans("Sideways Hold"), false);
+  m_hotkeys->AddInput(_trans("Upright Hold"), false);
 
   // options
   groups.emplace_back(m_options = new ControlGroup(_trans("Options")));
@@ -292,16 +302,6 @@ Wiimote::Wiimote(const unsigned int index)
       std::make_unique<ControlGroup::NumericSetting>(_trans("Speaker Pan"), 0, -127, 127));
   m_options->numeric_settings.emplace_back(
       std::make_unique<ControlGroup::NumericSetting>(_trans("Battery"), 95.0 / 100, 0, 255));
-
-  // hotkeys
-  groups.emplace_back(m_hotkeys = new ModifySettingsButton(_trans("Hotkeys")));
-  // hotkeys to temporarily modify the Wii Remote orientation (sideways, upright)
-  // this setting modifier is toggled
-  m_hotkeys->AddInput(_trans("Sideways Toggle"), true);
-  m_hotkeys->AddInput(_trans("Upright Toggle"), true);
-  // this setting modifier is not toggled
-  m_hotkeys->AddInput(_trans("Sideways Hold"), false);
-  m_hotkeys->AddInput(_trans("Upright Hold"), false);
 
   // TODO: This value should probably be re-read if SYSCONF gets changed
   m_sensor_bar_on_top = SConfig::GetInstance().m_sensor_bar_position != 0;

--- a/Source/Core/DolphinWX/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/InputConfigDiag.cpp
@@ -1128,8 +1128,12 @@ ControlGroupsSizer::ControlGroupsSizer(ControllerEmu* const controller, wxWindow
     : wxBoxSizer(wxHORIZONTAL)
 {
   const int space5 = parent->FromDIP(5);
-  size_t col_size = 0;
 
+  size_t max_column_size = 8;
+  for (auto& group : controller->groups)
+    max_column_size = std::max(max_column_size, group->GetSize());
+
+  size_t col_size = 0;
   wxBoxSizer* stacked_groups = nullptr;
   for (auto& group : controller->groups)
   {
@@ -1139,10 +1143,9 @@ ControlGroupsSizer::ControlGroupsSizer(ControllerEmu* const controller, wxWindow
         new ControlGroupBox(group.get(), control_group->GetStaticBox(), eventsink);
     control_group->Add(control_group_box, 0, wxEXPAND);
 
-    const size_t grp_size =
-        group->controls.size() + group->numeric_settings.size() + group->boolean_settings.size();
+    const size_t grp_size = group->GetSize();
     col_size += grp_size;
-    if (col_size > 8 || nullptr == stacked_groups)
+    if (col_size > max_column_size || nullptr == stacked_groups)
     {
       if (stacked_groups)
       {

--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -169,6 +169,11 @@ void ControllerEmu::ControlGroup::SetControlExpression(int index, const std::str
   controls.at(index)->control_ref->expression = expression;
 }
 
+size_t ControllerEmu::ControlGroup::GetSize()
+{
+  return controls.size() + numeric_settings.size() + boolean_settings.size();
+}
+
 ControllerEmu::AnalogStick::AnalogStick(const char* const _name, ControlState default_radius)
     : AnalogStick(_name, _name, GROUP_TYPE_STICK)
 {

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -149,6 +149,8 @@ public:
 
     void SetControlExpression(int index, const std::string& expression);
 
+    size_t GetSize();
+
     const std::string name;
     const std::string ui_name;
     const unsigned int type;


### PR DESCRIPTION
When I opened the emulated Wii Remote window today, I saw that it couldn't fully fit on my screen anymore. That wasn't especially nice, so I started working on this PR.

DolphinWX used to not allow having more than one group of controls in each column unless the total number of controls would be 8 or less. I've changed it so that if there's a group with more than 8 controls (like the IR group for Wii Remotes), the maximum number of controls per column is the same as the number of controls in the group with the most controls. I also re-arranged the order of the controls (including the Nunchuk controls while I was at it) to fit more neatly.

Before:
![](https://cloud.githubusercontent.com/assets/6716818/19967978/d43ccc70-a1d2-11e6-9aa2-61010681995d.png)
![](https://cloud.githubusercontent.com/assets/6716818/19967983/d8452024-a1d2-11e6-9477-aa98a026a3d9.png)

After:
![](https://cloud.githubusercontent.com/assets/6716818/19967991/dfb966e4-a1d2-11e6-9bc3-78e17466ecf6.png)
![](https://cloud.githubusercontent.com/assets/6716818/19967996/e4cf8fdc-a1d2-11e6-80f5-9e79d6cd28d9.png)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4417)
<!-- Reviewable:end -->
