### PR TITLE
Don't use GetEmulatedTime in GCMemcard

### DIFF
--- a/Source/Core/Core/HW/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard.h
@@ -11,6 +11,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/NandPaths.h"
 #include "Common/NonCopyable.h"
+#include "Common/Timer.h"
 
 #include "Core/HW/EXI_DeviceIPL.h"
 #include "Core/HW/Sram.h"
@@ -131,7 +132,7 @@ struct Header  // Offset    Size    Description
     memset(this, 0xFF, BLOCK_SIZE);
     *(u16*)SizeMb = BE16(sizeMb);
     Encoding = BE16(shift_jis ? 1 : 0);
-    u64 rand = CEXIIPL::GetEmulatedTime(CEXIIPL::GC_EPOCH);
+    u64 rand = Common::Timer::GetLocalTimeSinceJan1970() - CEXIIPL::GC_EPOCH;
     formatTime = Common::swap64(rand);
     for (int i = 0; i < 12; i++)
     {


### PR DESCRIPTION
GCMemcard is only used outside of the core and has no real reason to use the core's RTC. GetEmulatedTime isn't designed to be called when the core isn't running. Should fix https://bugs.dolphin-emu.org/issues/9871

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4420)
<!-- Reviewable:end -->
