### PR TITLE
CodeWindow: Migrate more menubar handling code to CFrame

### DIFF
--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinWX/Config/GeneralConfigPane.h"
+
 #include <wx/button.h>
 #include <wx/checkbox.h>
 #include <wx/choice.h>
@@ -16,10 +18,6 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/PowerPC/PowerPC.h"
-#include "DolphinWX/Config/GeneralConfigPane.h"
-#include "DolphinWX/Debugger/CodeWindow.h"
-#include "DolphinWX/Frame.h"
-#include "DolphinWX/Main.h"
 
 GeneralConfigPane::GeneralConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, id)
 {
@@ -200,15 +198,7 @@ void GeneralConfigPane::OnThrottlerChoiceChanged(wxCommandEvent& event)
 
 void GeneralConfigPane::OnCPUEngineRadioBoxChanged(wxCommandEvent& event)
 {
-  const int selection = m_cpu_engine_radiobox->GetSelection();
-
-  if (main_frame->g_pCodeWindow)
-  {
-    bool using_interp = (SConfig::GetInstance().iCPUCore == PowerPC::CORE_INTERPRETER);
-    main_frame->g_pCodeWindow->GetMenuBar()->Check(IDM_INTERPRETER, using_interp);
-  }
-
-  SConfig::GetInstance().iCPUCore = cpu_cores[selection].CPUid;
+  SConfig::GetInstance().iCPUCore = cpu_cores.at(event.GetSelection()).CPUid;
 }
 
 void GeneralConfigPane::OnAnalyticsCheckBoxChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -21,7 +21,7 @@
 
 GeneralConfigPane::GeneralConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, id)
 {
-  cpu_cores = {
+  m_cpu_cores = {
       {PowerPC::CORE_INTERPRETER, _("Interpreter (slowest)")},
       {PowerPC::CORE_CACHEDINTERPRETER, _("Cached Interpreter (slower)")},
 #ifdef _M_X86_64
@@ -48,7 +48,7 @@ void GeneralConfigPane::InitializeGUI()
       m_throttler_array_string.Add(wxString::Format(_("%i%%"), i));
   }
 
-  for (const CPUCore& cpu_core : cpu_cores)
+  for (const CPUCore& cpu_core : m_cpu_cores)
     m_cpu_engine_array_string.Add(cpu_core.name);
 
   m_dual_core_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Dual Core (speedup)"));
@@ -154,9 +154,9 @@ void GeneralConfigPane::LoadGUIValues()
   if (selection < m_throttler_array_string.size())
     m_throttler_choice->SetSelection(selection);
 
-  for (size_t i = 0; i < cpu_cores.size(); ++i)
+  for (size_t i = 0; i < m_cpu_cores.size(); ++i)
   {
-    if (cpu_cores[i].CPUid == startup_params.iCPUCore)
+    if (m_cpu_cores[i].CPUid == startup_params.iCPUCore)
       m_cpu_engine_radiobox->SetSelection(i);
   }
 }
@@ -198,7 +198,7 @@ void GeneralConfigPane::OnThrottlerChoiceChanged(wxCommandEvent& event)
 
 void GeneralConfigPane::OnCPUEngineRadioBoxChanged(wxCommandEvent& event)
 {
-  SConfig::GetInstance().iCPUCore = cpu_cores.at(event.GetSelection()).CPUid;
+  SConfig::GetInstance().iCPUCore = m_cpu_cores.at(event.GetSelection()).CPUid;
 }
 
 void GeneralConfigPane::OnAnalyticsCheckBoxChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.h
@@ -24,7 +24,7 @@ private:
     int CPUid;
     wxString name;
   };
-  std::vector<CPUCore> cpu_cores;
+  std::vector<CPUCore> m_cpu_cores;
   void InitializeGUI();
   void LoadGUIValues();
   void RefreshGUI();

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -132,7 +132,7 @@ CCodeWindow::~CCodeWindow()
   m_aui_manager.UnInit();
 }
 
-wxMenuBar* CCodeWindow::GetMenuBar()
+wxMenuBar* CCodeWindow::GetParentMenuBar()
 {
   return Parent->GetMenuBar();
 }
@@ -539,27 +539,27 @@ void CCodeWindow::OnJitMenu(wxCommandEvent& event)
 // Shortcuts
 bool CCodeWindow::UseInterpreter()
 {
-  return GetMenuBar()->IsChecked(IDM_INTERPRETER);
+  return GetParentMenuBar()->IsChecked(IDM_INTERPRETER);
 }
 
 bool CCodeWindow::BootToPause()
 {
-  return GetMenuBar()->IsChecked(IDM_BOOT_TO_PAUSE);
+  return GetParentMenuBar()->IsChecked(IDM_BOOT_TO_PAUSE);
 }
 
 bool CCodeWindow::AutomaticStart()
 {
-  return GetMenuBar()->IsChecked(IDM_AUTOMATIC_START);
+  return GetParentMenuBar()->IsChecked(IDM_AUTOMATIC_START);
 }
 
 bool CCodeWindow::JITNoBlockCache()
 {
-  return GetMenuBar()->IsChecked(IDM_JIT_NO_BLOCK_CACHE);
+  return GetParentMenuBar()->IsChecked(IDM_JIT_NO_BLOCK_CACHE);
 }
 
 bool CCodeWindow::JITNoBlockLinking()
 {
-  return GetMenuBar()->IsChecked(IDM_JIT_NO_BLOCK_LINKING);
+  return GetParentMenuBar()->IsChecked(IDM_JIT_NO_BLOCK_LINKING);
 }
 
 // Update GUI

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -213,7 +213,6 @@ void CCodeWindow::OnCodeStep(wxCommandEvent& event)
     break;
   }
 
-  UpdateButtonStates();
   // Update all toolbars in the aui manager
   Parent->UpdateGUI();
 }
@@ -502,9 +501,6 @@ void CCodeWindow::OnCPUMode(wxCommandEvent& event)
 
   // Clear the JIT cache to enable these changes
   JitInterface::ClearCache();
-
-  // Update
-  UpdateButtonStates();
 }
 
 void CCodeWindow::OnJitMenu(wxCommandEvent& event)
@@ -574,63 +570,20 @@ void CCodeWindow::Repopulate(bool refresh_codeview)
 
   if (refresh_codeview)
     codeview->Refresh();
+
   UpdateCallstack();
-  UpdateButtonStates();
 
   // Do not automatically show the current PC position when a breakpoint is hit or
   // when we pause since this can be called at other times too.
   // codeview->Center(PC);
 }
 
-void CCodeWindow::UpdateButtonStates()
+void CCodeWindow::UpdateFonts()
 {
-  bool Initialized = (Core::GetState() != Core::CORE_UNINITIALIZED);
-  bool Pause = (Core::GetState() == Core::CORE_PAUSE);
-  bool Stepping = CPU::IsStepping();
-  bool can_step = Initialized && Stepping;
-
-  GetMenuBar()->Enable(IDM_INTERPRETER, Pause);  // CPU Mode
-
-  GetMenuBar()->Enable(IDM_STEP, can_step);
-  GetMenuBar()->Enable(IDM_STEPOVER, can_step);
-  GetMenuBar()->Enable(IDM_STEPOUT, can_step);
-
-  GetMenuBar()->Enable(IDM_JIT_NO_BLOCK_CACHE, !Initialized);
-
-  GetMenuBar()->Enable(IDM_JIT_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_LS_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_LSLXZ_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_LSLWZ_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_LSLBZX_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_LSF_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_LSP_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_FP_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_I_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_P_OFF, Pause);
-  GetMenuBar()->Enable(IDM_JIT_SR_OFF, Pause);
-
-  GetMenuBar()->Enable(IDM_CLEAR_CODE_CACHE, Pause);  // JIT Menu
-  GetMenuBar()->Enable(IDM_SEARCH_INSTRUCTION, Initialized);
-
-  GetMenuBar()->Enable(IDM_CLEAR_SYMBOLS, Initialized);  // Symbols menu
-  GetMenuBar()->Enable(IDM_SCAN_FUNCTIONS, Initialized);
-  GetMenuBar()->Enable(IDM_LOAD_MAP_FILE, Initialized);
-  GetMenuBar()->Enable(IDM_SAVEMAPFILE, Initialized);
-  GetMenuBar()->Enable(IDM_LOAD_MAP_FILE_AS, Initialized);
-  GetMenuBar()->Enable(IDM_SAVE_MAP_FILE_AS, Initialized);
-  GetMenuBar()->Enable(IDM_LOAD_BAD_MAP_FILE, Initialized);
-  GetMenuBar()->Enable(IDM_SAVE_MAP_FILE_WITH_CODES, Initialized);
-  GetMenuBar()->Enable(IDM_CREATE_SIGNATURE_FILE, Initialized);
-  GetMenuBar()->Enable(IDM_APPEND_SIGNATURE_FILE, Initialized);
-  GetMenuBar()->Enable(IDM_COMBINE_SIGNATURE_FILES, Initialized);
-  GetMenuBar()->Enable(IDM_RENAME_SYMBOLS, Initialized);
-  GetMenuBar()->Enable(IDM_USE_SIGNATURE_FILE, Initialized);
-  GetMenuBar()->Enable(IDM_PATCH_HLE_FUNCTIONS, Initialized);
-
-  // Update Fonts
   callstack->SetFont(DebuggerFont);
   symbols->SetFont(DebuggerFont);
   callers->SetFont(DebuggerFont);
   calls->SetFont(DebuggerFont);
   m_aui_manager.GetArtProvider()->SetFont(wxAUI_DOCKART_CAPTION_FONT, DebuggerFont);
+  m_aui_manager.Update();
 }

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -83,9 +83,6 @@ public:
   void Load();
   void Save();
 
-  // Parent interaction
-  wxMenuBar* GetMenuBar();
-
   bool UseInterpreter();
   bool BootToPause();
   bool AutomaticStart();
@@ -97,7 +94,6 @@ public:
   void NotifyMapLoaded();
   void OpenPages();
 
-  // Menu bar
   // FIXME: This belongs in a separate class.
   void TogglePanel(int id, bool show);
   wxPanel* GetUntypedPanel(int id) const;
@@ -127,6 +123,9 @@ public:
   int iNbAffiliation[IDM_DEBUG_WINDOW_LIST_END - IDM_DEBUG_WINDOW_LIST_START];
 
 private:
+  // Parent interaction
+  wxMenuBar* GetMenuBar();
+
   void OnCPUMode(wxCommandEvent& event);
 
   void OnChangeFont(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -123,8 +123,7 @@ public:
   int iNbAffiliation[IDM_DEBUG_WINDOW_LIST_END - IDM_DEBUG_WINDOW_LIST_START];
 
 private:
-  // Parent interaction
-  wxMenuBar* GetMenuBar();
+  wxMenuBar* GetParentMenuBar();
 
   void OnCPUMode(wxCommandEvent& event);
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -95,7 +95,6 @@ public:
 
   void Repopulate(bool refresh_codeview = true);
   void NotifyMapLoaded();
-  void UpdateButtonStates();
   void OpenPages();
 
   // Menu bar
@@ -151,6 +150,7 @@ private:
   void StepOut();
   void ToggleBreakpoint();
 
+  void UpdateFonts();
   void UpdateLists();
   void UpdateCallstack();
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -93,8 +93,8 @@ void CCodeWindow::Save()
 
   IniFile::Section* general = ini.GetOrCreateSection("General");
   general->Set("DebuggerFont", WxStrToStr(DebuggerFont.GetNativeFontInfoUserDesc()));
-  general->Set("AutomaticStart", GetMenuBar()->IsChecked(IDM_AUTOMATIC_START));
-  general->Set("BootToPause", GetMenuBar()->IsChecked(IDM_BOOT_TO_PAUSE));
+  general->Set("AutomaticStart", GetParentMenuBar()->IsChecked(IDM_AUTOMATIC_START));
+  general->Set("BootToPause", GetParentMenuBar()->IsChecked(IDM_BOOT_TO_PAUSE));
 
   const char* SettingName[] = {"Log",    "LogConfig", "Console", "Registers", "Breakpoints",
                                "Memory", "JIT",       "Sound",   "Video",     "Code"};
@@ -102,7 +102,7 @@ void CCodeWindow::Save()
   // Save windows settings
   for (int i = IDM_LOG_WINDOW; i <= IDM_VIDEO_WINDOW; i++)
     ini.GetOrCreateSection("ShowOnStart")
-        ->Set(SettingName[i - IDM_LOG_WINDOW], GetMenuBar()->IsChecked(i));
+        ->Set(SettingName[i - IDM_LOG_WINDOW], GetParentMenuBar()->IsChecked(i));
 
   // Save notebook affiliations
   std::string section = "P - " + Parent->Perspectives[Parent->ActivePerspective].Name;
@@ -125,7 +125,7 @@ void CCodeWindow::OnProfilerMenu(wxCommandEvent& event)
     Core::SetState(Core::CORE_PAUSE);
     if (jit != nullptr)
       jit->ClearCache();
-    Profiler::g_ProfileBlocks = GetMenuBar()->IsChecked(IDM_PROFILE_BLOCKS);
+    Profiler::g_ProfileBlocks = GetParentMenuBar()->IsChecked(IDM_PROFILE_BLOCKS);
     Core::SetState(Core::CORE_RUN);
     break;
   case IDM_WRITE_PROFILE:
@@ -467,7 +467,7 @@ void CCodeWindow::TogglePanel(int id, bool show)
   wxPanel* panel = GetUntypedPanel(id);
 
   // Not all the panels (i.e. CodeWindow) have corresponding menu options.
-  wxMenuItem* item = GetMenuBar()->FindItem(id);
+  wxMenuItem* item = GetParentMenuBar()->FindItem(id);
   if (item)
     item->Check(show);
 

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -447,6 +447,7 @@ void CCodeWindow::OnChangeFont(wxCommandEvent& event)
   if (dialog.ShowModal() == wxID_OK)
     DebuggerFont = dialog.GetFontData().GetChosenFont();
 
+  UpdateFonts();
   // TODO: Send event to all panels that tells them to reload the font when it changes.
 }
 

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -429,16 +429,11 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
                                                X11Utils::XWindowFromHandle(GetHandle()));
 #endif
 
-  // -------------------------
   // Connect event handlers
-
   m_Mgr->Bind(wxEVT_AUI_RENDER, &CFrame::OnManagerResize, this);
-  // ----------
 
   // Update controls
   UpdateGUI();
-  if (g_pCodeWindow)
-    g_pCodeWindow->UpdateButtonStates();
 
   // check if game is running
   InitControllers();

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -241,6 +241,7 @@ private:
   void OnEnableMenuItemIfCoreUninitialized(wxUpdateUIEvent& event);
   void OnEnableMenuItemIfCorePaused(wxUpdateUIEvent& event);
   void OnEnableMenuItemIfCPUCanStep(wxUpdateUIEvent& event);
+  void OnUpdateInterpreterMenuItem(wxUpdateUIEvent& event);
 
   void OnOpen(wxCommandEvent& event);  // File menu
   void DoOpen(bool Boot);

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -179,6 +179,8 @@ private:
 
   void BindEvents();
   void BindMenuBarEvents();
+  void BindDebuggerMenuBarEvents();
+  void BindDebuggerMenuBarUpdateEvents();
 
   wxToolBar* OnCreateToolBar(long style, wxWindowID id, const wxString& name) override;
   wxMenuBar* CreateMenuBar() const;
@@ -234,6 +236,11 @@ private:
   void OnHelp(wxCommandEvent& event);
 
   void OnReloadThemeBitmaps(wxCommandEvent& event);
+
+  void OnEnableMenuItemIfCoreInitialized(wxUpdateUIEvent& event);
+  void OnEnableMenuItemIfCoreUninitialized(wxUpdateUIEvent& event);
+  void OnEnableMenuItemIfCorePaused(wxUpdateUIEvent& event);
+  void OnEnableMenuItemIfCPUCanStep(wxUpdateUIEvent& event);
 
   void OnOpen(wxCommandEvent& event);  // File menu
   void DoOpen(bool Boot);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -210,7 +210,8 @@ void CFrame::BindDebuggerMenuBarUpdateEvents()
   Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCPUCanStep, this, IDM_STEPOUT);
   Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCPUCanStep, this, IDM_STEPOVER);
 
-  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_INTERPRETER);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnUpdateInterpreterMenuItem, this, IDM_INTERPRETER);
+
   Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_OFF);
   Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_LS_OFF);
   Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_LSLXZ_OFF);
@@ -1084,6 +1085,16 @@ void CFrame::OnEnableMenuItemIfCorePaused(wxUpdateUIEvent& event)
 void CFrame::OnEnableMenuItemIfCPUCanStep(wxUpdateUIEvent& event)
 {
   event.Enable(Core::GetState() != Core::CORE_UNINITIALIZED && CPU::IsStepping());
+}
+
+void CFrame::OnUpdateInterpreterMenuItem(wxUpdateUIEvent& event)
+{
+  OnEnableMenuItemIfCorePaused(event);
+
+  if (GetMenuBar()->FindItem(IDM_INTERPRETER)->IsChecked())
+    return;
+
+  event.Check(SConfig::GetInstance().iCPUCore == PowerPC::CORE_INTERPRETER);
 }
 
 void CFrame::ClearStatusBar()

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -176,6 +176,18 @@ void CFrame::BindMenuBarEvents()
   Bind(wxEVT_MENU, &CFrame::GameListChanged, this, IDM_PURGE_GAME_LIST_CACHE);
   Bind(wxEVT_MENU, &CFrame::OnChangeColumnsVisible, this, IDM_SHOW_SYSTEM, IDM_SHOW_STATE);
 
+  // Help menu
+  Bind(wxEVT_MENU, &CFrame::OnHelp, this, IDM_HELP_WEBSITE);
+  Bind(wxEVT_MENU, &CFrame::OnHelp, this, IDM_HELP_ONLINE_DOCS);
+  Bind(wxEVT_MENU, &CFrame::OnHelp, this, IDM_HELP_GITHUB);
+  Bind(wxEVT_MENU, &CFrame::OnHelp, this, wxID_ABOUT);
+
+  if (UseDebugger)
+    BindDebuggerMenuBarEvents();
+}
+
+void CFrame::BindDebuggerMenuBarEvents()
+{
   // Debug menu
   Bind(wxEVT_MENU, &CFrame::OnPerspectiveMenu, this, IDM_SAVE_PERSPECTIVE);
   Bind(wxEVT_MENU, &CFrame::OnPerspectiveMenu, this, IDM_EDIT_PERSPECTIVES);
@@ -189,11 +201,50 @@ void CFrame::BindMenuBarEvents()
   Bind(wxEVT_MENU, &CFrame::OnPerspectiveMenu, this, IDM_TAB_SPLIT);
   Bind(wxEVT_MENU, &CFrame::OnPerspectiveMenu, this, IDM_NO_DOCKING);
 
-  // Help menu
-  Bind(wxEVT_MENU, &CFrame::OnHelp, this, IDM_HELP_WEBSITE);
-  Bind(wxEVT_MENU, &CFrame::OnHelp, this, IDM_HELP_ONLINE_DOCS);
-  Bind(wxEVT_MENU, &CFrame::OnHelp, this, IDM_HELP_GITHUB);
-  Bind(wxEVT_MENU, &CFrame::OnHelp, this, wxID_ABOUT);
+  BindDebuggerMenuBarUpdateEvents();
+}
+
+void CFrame::BindDebuggerMenuBarUpdateEvents()
+{
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCPUCanStep, this, IDM_STEP);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCPUCanStep, this, IDM_STEPOUT);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCPUCanStep, this, IDM_STEPOVER);
+
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_INTERPRETER);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_LS_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_LSLXZ_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_LSLWZ_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_LSLBZX_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_LSF_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_LSP_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_FP_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_I_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_P_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_JIT_SR_OFF);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCorePaused, this, IDM_CLEAR_CODE_CACHE);
+
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_SEARCH_INSTRUCTION);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_CLEAR_SYMBOLS);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_SCAN_FUNCTIONS);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_LOAD_MAP_FILE);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_SAVEMAPFILE);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_LOAD_MAP_FILE_AS);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_SAVE_MAP_FILE_AS);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_LOAD_BAD_MAP_FILE);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this,
+       IDM_SAVE_MAP_FILE_WITH_CODES);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this,
+       IDM_CREATE_SIGNATURE_FILE);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this,
+       IDM_APPEND_SIGNATURE_FILE);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this,
+       IDM_COMBINE_SIGNATURE_FILES);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_RENAME_SYMBOLS);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_USE_SIGNATURE_FILE);
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreInitialized, this, IDM_PATCH_HLE_FUNCTIONS);
+
+  Bind(wxEVT_UPDATE_UI, &CFrame::OnEnableMenuItemIfCoreUninitialized, this, IDM_JIT_NO_BLOCK_CACHE);
 }
 
 wxToolBar* CFrame::OnCreateToolBar(long style, wxWindowID id, const wxString& name)
@@ -1013,6 +1064,26 @@ void CFrame::OnReloadThemeBitmaps(wxCommandEvent& WXUNUSED(event))
   wxPostEvent(GetToolBar(), reload_event);
 
   UpdateGameList();
+}
+
+void CFrame::OnEnableMenuItemIfCoreInitialized(wxUpdateUIEvent& event)
+{
+  event.Enable(Core::GetState() != Core::CORE_UNINITIALIZED);
+}
+
+void CFrame::OnEnableMenuItemIfCoreUninitialized(wxUpdateUIEvent& event)
+{
+  event.Enable(Core::GetState() == Core::CORE_UNINITIALIZED);
+}
+
+void CFrame::OnEnableMenuItemIfCorePaused(wxUpdateUIEvent& event)
+{
+  event.Enable(Core::GetState() == Core::CORE_PAUSE);
+}
+
+void CFrame::OnEnableMenuItemIfCPUCanStep(wxUpdateUIEvent& event)
+{
+  event.Enable(Core::GetState() != Core::CORE_UNINITIALIZED && CPU::IsStepping());
 }
 
 void CFrame::ClearStatusBar()


### PR DESCRIPTION
Excises out menubar enable/disable code and puts it into a UI update event in CFrame where it belongs. It also hides GetMenuBar() from the public interface of CodeWindow, which will be removed in a follow up PR, as it'll allow for removal of other things which I think shouldn't clutter this one up.

Each commit has more in-depth explanations of what was done in each of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4422)
<!-- Reviewable:end -->
