### PR TITLE
Framedump: Use an object for the framedumping state.

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -824,8 +824,9 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     D3D11_MAPPED_SUBRESOURCE map;
     D3D::context->Map(s_screenshot_texture, 0, D3D11_MAP_READ, 0, &map);
 
+    AVIDump::Frame state = AVIDump::FetchState(ticks);
     DumpFrameData(reinterpret_cast<const u8*>(map.pData), source_width, source_height, map.RowPitch,
-                  ticks);
+                  state);
     FinishFrameData();
 
     D3D::context->Unmap(s_screenshot_texture, 0);

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -777,8 +777,9 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
     D3D12_RANGE read_range = {0, dst_location.PlacedFootprint.Footprint.RowPitch * source_height};
     CheckHR(s_screenshot_texture->Map(0, &read_range, &screenshot_texture_map));
 
+    AVIDump::Frame state = AVIDump::FetchState(ticks);
     DumpFrameData(reinterpret_cast<const u8*>(screenshot_texture_map), source_width, source_height,
-                  dst_location.PlacedFootprint.Footprint.RowPitch, ticks);
+                  dst_location.PlacedFootprint.Footprint.RowPitch, state);
     FinishFrameData();
 
     D3D12_RANGE write_range = {};

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1455,8 +1455,9 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     glReadPixels(flipped_trc.left, flipped_trc.bottom, flipped_trc.GetWidth(),
                  flipped_trc.GetHeight(), GL_RGBA, GL_UNSIGNED_BYTE, image.data());
 
+    AVIDump::Frame state = AVIDump::FetchState(ticks);
     DumpFrameData(image.data(), flipped_trc.GetWidth(), flipped_trc.GetHeight(),
-                  flipped_trc.GetWidth() * 4, ticks, true);
+                  flipped_trc.GetWidth() * 4, state, true);
     FinishFrameData();
   }
   // Finish up the current frame, print some stats

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -125,7 +125,8 @@ void SWRenderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
   // Save screenshot
   if (IsFrameDumping())
   {
-    DumpFrameData(GetCurrentColorTexture(), fbWidth, fbHeight, fbWidth * 4, ticks);
+    AVIDump::Frame state = AVIDump::FetchState(ticks);
+    DumpFrameData(GetCurrentColorTexture(), fbWidth, fbHeight, fbWidth * 4, state);
     FinishFrameData();
   }
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -747,10 +747,11 @@ bool Renderer::DrawFrameDump(const EFBRectangle& rc, u32 xfb_addr,
 
 void Renderer::DumpFrame(u64 ticks)
 {
+  AVIDump::Frame state = AVIDump::FetchState(ticks);
   DumpFrameData(reinterpret_cast<const u8*>(m_frame_dump_readback_texture->GetMapPointer()),
                 static_cast<int>(m_frame_dump_render_texture->GetWidth()),
                 static_cast<int>(m_frame_dump_render_texture->GetHeight()),
-                static_cast<int>(m_frame_dump_readback_texture->GetRowStride()), ticks);
+                static_cast<int>(m_frame_dump_readback_texture->GetRowStride()), state);
   FinishFrameData();
 }
 

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -23,7 +23,9 @@ extern "C" {
 #include "Core/HW/SystemTimers.h"
 #include "Core/HW/VideoInterface.h"  //for TargetRefreshRate
 #include "Core/Movie.h"
+
 #include "VideoCommon/AVIDump.h"
+#include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoConfig.h"
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 28, 1)
@@ -68,7 +70,10 @@ bool AVIDump::Start(int w, int h)
   InitAVCodec();
   bool success = CreateFile();
   if (!success)
+  {
     CloseFile();
+    OSD::AddMessage("AVIDump Start failed");
+  }
   return success;
 }
 
@@ -147,6 +152,9 @@ bool AVIDump::CreateFile()
     WARN_LOG(VIDEO, "Could not open %s", s_format_context->filename);
     return false;
   }
+
+  OSD::AddMessage(StringFromFormat("Dumping Frames to \"%s\" (%dx%d)", s_format_context->filename,
+                                   s_width, s_height));
 
   return true;
 }

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -43,8 +43,6 @@ static u64 s_last_frame;
 static bool s_last_frame_is_valid = false;
 static bool s_start_dumping = false;
 static u64 s_last_pts;
-static int s_current_width;
-static int s_current_height;
 static int s_file_index = 0;
 
 static void InitAVCodec()
@@ -63,8 +61,6 @@ bool AVIDump::Start(int w, int h)
 
   s_width = w;
   s_height = h;
-  s_current_width = w;
-  s_current_height = h;
 
   s_last_frame_is_valid = false;
   s_last_pts = 0;
@@ -171,8 +167,7 @@ void AVIDump::AddFrame(const u8* data, int width, int height, int stride, u64 ti
   s_src_frame->width = s_width;
   s_src_frame->height = s_height;
 
-  // Convert image from {BGR24, RGBA} to desired pixel format, and scale to initial
-  // width and height
+  // Convert image from {BGR24, RGBA} to desired pixel format
   if ((s_sws_context =
            sws_getCachedContext(s_sws_context, width, height, s_pix_fmt, s_width, s_height,
                                 s_stream->codec->pix_fmt, SWS_BICUBIC, nullptr, nullptr, nullptr)))
@@ -293,13 +288,11 @@ void AVIDump::CheckResolution(int width, int height)
   // (possibly width as well, but no examples known) to have a value of zero. This can occur as the
   // VI is able to be set to a zero value for height/width to disable output. If this is the case,
   // simply keep the last known resolution of the video for the added frame.
-  if ((width != s_current_width || height != s_current_height) && (width > 0 && height > 0))
+  if ((width != s_width || height != s_height) && (width > 0 && height > 0))
   {
     int temp_file_index = s_file_index;
     Stop();
     s_file_index = temp_file_index + 1;
     Start(width, height);
-    s_current_width = width;
-    s_current_height = height;
   }
 }

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -46,6 +46,8 @@ static bool s_last_frame_is_valid = false;
 static bool s_start_dumping = false;
 static u64 s_last_pts;
 static int s_file_index = 0;
+static int s_savestate_index = 0;
+static int s_last_savestate_index = 0;
 
 static void InitAVCodec()
 {
@@ -168,6 +170,14 @@ static void PreparePacket(AVPacket* pkt)
 
 void AVIDump::AddFrame(const u8* data, int width, int height, int stride, const Frame& state)
 {
+  // Assume that the timing is valid, if the savestate id of the new frame
+  // doesn't match the last one.
+  if (state.savestate_index != s_last_savestate_index)
+  {
+    s_last_savestate_index = state.savestate_index;
+    s_last_frame_is_valid = false;
+  }
+
   CheckResolution(width, height);
   s_src_frame->data[0] = const_cast<u8*>(data);
   s_src_frame->linesize[0] = stride;
@@ -285,7 +295,7 @@ void AVIDump::CloseFile()
 
 void AVIDump::DoState()
 {
-  s_last_frame_is_valid = false;
+  s_savestate_index++;
 }
 
 void AVIDump::CheckResolution(int width, int height)
@@ -310,5 +320,6 @@ AVIDump::Frame AVIDump::FetchState(u64 ticks)
   state.ticks = ticks;
   state.first_frame = Movie::GetCurrentFrame() < 1;
   state.ticks_per_second = SystemTimers::GetTicksPerSecond();
+  state.savestate_index = s_savestate_index;
   return state;
 }

--- a/Source/Core/VideoCommon/AVIDump.h
+++ b/Source/Core/VideoCommon/AVIDump.h
@@ -14,8 +14,21 @@ private:
   static void CheckResolution(int width, int height);
 
 public:
+  struct Frame
+  {
+    u64 ticks = 0;
+    u32 ticks_per_second = 0;
+    bool first_frame = false;
+  };
+
   static bool Start(int w, int h);
-  static void AddFrame(const u8* data, int width, int height, int stride, u64 ticks);
+  static void AddFrame(const u8* data, int width, int height, int stride, const Frame& state);
   static void Stop();
   static void DoState();
+
+#if defined(HAVE_LIBAV) || defined(_WIN32)
+  static Frame FetchState(u64 ticks);
+#else
+  static Frame FetchState(u64 ticks) { return {}; }
+#endif
 };

--- a/Source/Core/VideoCommon/AVIDump.h
+++ b/Source/Core/VideoCommon/AVIDump.h
@@ -12,7 +12,6 @@ private:
   static bool CreateFile();
   static void CloseFile();
   static void CheckResolution(int width, int height);
-  static void StoreFrameData(const u8* data, int width, int height, int stride, u64 ticks);
 
 public:
   static bool Start(int w, int h);

--- a/Source/Core/VideoCommon/AVIDump.h
+++ b/Source/Core/VideoCommon/AVIDump.h
@@ -19,6 +19,7 @@ public:
     u64 ticks = 0;
     u32 ticks_per_second = 0;
     bool first_frame = false;
+    int savestate_index = 0;
   };
 
   static bool Start(int w, int h);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -667,7 +667,7 @@ bool Renderer::IsFrameDumping()
   return false;
 }
 
-void Renderer::DumpFrameData(const u8* data, int w, int h, int stride, u64 ticks,
+void Renderer::DumpFrameData(const u8* data, int w, int h, int stride, const AVIDump::Frame& state,
                              bool swap_upside_down)
 {
   if (w == 0 || h == 0)
@@ -701,7 +701,7 @@ void Renderer::DumpFrameData(const u8* data, int w, int h, int stride, u64 ticks
     }
     if (m_AVI_dumping)
     {
-      AVIDump::AddFrame(m_frame_data.data(), w, h, stride, ticks);
+      AVIDump::AddFrame(m_frame_data.data(), w, h, stride, state);
     }
 
     m_last_frame_dumped = true;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -660,7 +660,7 @@ bool Renderer::IsFrameDumping()
     AVIDump::Stop();
     std::vector<u8>().swap(m_frame_data);
     m_AVI_dumping = false;
-    OSD::AddMessage("Stop dumping frames", 2000);
+    OSD::AddMessage("Stop dumping frames");
   }
   m_last_frame_dumped = false;
 #endif
@@ -698,16 +698,6 @@ void Renderer::DumpFrameData(const u8* data, int w, int h, int stride, u64 ticks
     if (!m_last_frame_dumped)
     {
       m_AVI_dumping = AVIDump::Start(w, h);
-      if (!m_AVI_dumping)
-      {
-        OSD::AddMessage("AVIDump Start failed", 2000);
-      }
-      else
-      {
-        OSD::AddMessage(StringFromFormat("Dumping Frames to \"%sframedump0.avi\" (%dx%d RGB24)",
-                                         File::GetUserPath(D_DUMPFRAMES_IDX).c_str(), w, h),
-                        2000);
-      }
     }
     if (m_AVI_dumping)
     {

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -147,7 +147,7 @@ protected:
   static void RecordVideoMemory();
 
   bool IsFrameDumping();
-  void DumpFrameData(const u8* data, int w, int h, int stride, u64 ticks,
+  void DumpFrameData(const u8* data, int w, int h, int stride, const AVIDump::Frame& state,
                      bool swap_upside_down = false);
   void FinishFrameData();
 


### PR DESCRIPTION
This will be required for threaded framedumping. After this PR, AddFrame uses no global state any more. Everything is hidden within a struct assembled in the backends.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4423)
<!-- Reviewable:end -->
