### PR TITLE
Revert "Update OS X Requirement to 10.10"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 * OS
     * Windows (7 SP1 or higher is officially supported, but Vista SP2 might also work).
     * Linux.
-    * macOS (10.10 Yosemite or higher).
+    * macOS (10.9 Mavericks or higher).
     * Unix-like systems other than Linux are not officially supported but might work.
 * Processor
     * A CPU with SSE2 support.


### PR DESCRIPTION
Dolphin works on OS X 10.9 again nowadays.

This reverts commit 93d83ab4d30fd6c29e39fbc5ce14fa540ed90753.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4426)
<!-- Reviewable:end -->
