### PR TITLE
DolphinWX: Enable/disable config UI options based on core state

### DIFF
--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -61,6 +61,7 @@ set(GUI_SRCS
 	SoftwareVideoConfigDialog.cpp
 	TASInputDlg.cpp
 	VideoConfigDiag.cpp
+	WxEventUtils.cpp
 	WXInputBase.cpp
 	WxUtils.cpp)
 

--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.h
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.h
@@ -23,7 +23,10 @@ public:
 private:
   void InitializeGUI();
   void LoadGUIValues();
-  void RefreshGUI();
+  void BindEvents();
+
+  void OnUpdateCPUClockControls(wxUpdateUIEvent&);
+  void OnUpdateRTCDateTimeEntries(wxUpdateUIEvent&);
 
   void OnClockOverrideCheckBoxChanged(wxCommandEvent&);
   void OnClockOverrideSliderChanged(wxCommandEvent&);

--- a/Source/Core/DolphinWX/Config/AudioConfigPane.h
+++ b/Source/Core/DolphinWX/Config/AudioConfigPane.h
@@ -23,7 +23,7 @@ public:
 private:
   void InitializeGUI();
   void LoadGUIValues();
-  void RefreshGUI();
+  void BindEvents();
 
   void PopulateBackendChoiceBox();
   void ToggleBackendSpecificControls(const std::string& backend);

--- a/Source/Core/DolphinWX/Config/ConfigMain.h
+++ b/Source/Core/DolphinWX/Config/ConfigMain.h
@@ -21,7 +21,7 @@ public:
               long style = wxDEFAULT_DIALOG_STYLE);
   virtual ~CConfigMain();
 
-  void SetSelectedTab(int tab);
+  void SetSelectedTab(wxWindowID tab_id);
 
   enum
   {
@@ -39,6 +39,7 @@ private:
   void CreateGUIControls();
   void OnClose(wxCloseEvent& event);
   void OnCloseButton(wxCommandEvent& event);
+  void OnShow(wxShowEvent& event);
   void OnSetRefreshGameListOnClose(wxCommandEvent& event);
 
   wxNotebook* Notebook;

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -22,7 +22,7 @@ public:
 private:
   void InitializeGUI();
   void LoadGUIValues();
-  void RefreshGUI();
+  void BindEvents();
 
   void OnSystemLanguageChange(wxCommandEvent&);
   void OnOverrideLanguageCheckBoxChanged(wxCommandEvent&);

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -18,6 +18,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "DolphinWX/WxEventUtils.h"
 
 GeneralConfigPane::GeneralConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, id)
 {
@@ -34,7 +35,7 @@ GeneralConfigPane::GeneralConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(
 
   InitializeGUI();
   LoadGUIValues();
-  RefreshGUI();
+  BindEvents();
 }
 
 void GeneralConfigPane::InitializeGUI()
@@ -85,15 +86,6 @@ void GeneralConfigPane::InitializeGUI()
   m_throttler_choice->SetToolTip(_("Limits the emulation speed to the specified percentage.\nNote "
                                    "that raising or lowering the emulation speed will also raise "
                                    "or lower the audio pitch to prevent audio from stuttering."));
-
-  m_dual_core_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnDualCoreCheckBoxChanged, this);
-  m_cheats_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnCheatCheckBoxChanged, this);
-  m_force_ntscj_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnForceNTSCJCheckBoxChanged,
-                               this);
-  m_analytics_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnAnalyticsCheckBoxChanged, this);
-  m_analytics_new_id->Bind(wxEVT_BUTTON, &GeneralConfigPane::OnAnalyticsNewIdButtonClick, this);
-  m_throttler_choice->Bind(wxEVT_CHOICE, &GeneralConfigPane::OnThrottlerChoiceChanged, this);
-  m_cpu_engine_radiobox->Bind(wxEVT_RADIOBOX, &GeneralConfigPane::OnCPUEngineRadioBoxChanged, this);
 
   const int space5 = FromDIP(5);
 
@@ -161,15 +153,26 @@ void GeneralConfigPane::LoadGUIValues()
   }
 }
 
-void GeneralConfigPane::RefreshGUI()
+void GeneralConfigPane::BindEvents()
 {
-  if (Core::IsRunning())
-  {
-    m_dual_core_checkbox->Disable();
-    m_cheats_checkbox->Disable();
-    m_force_ntscj_checkbox->Disable();
-    m_cpu_engine_radiobox->Disable();
-  }
+  m_dual_core_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnDualCoreCheckBoxChanged, this);
+  m_dual_core_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+  m_cheats_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnCheatCheckBoxChanged, this);
+  m_cheats_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+  m_force_ntscj_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnForceNTSCJCheckBoxChanged,
+                               this);
+  m_force_ntscj_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+  m_analytics_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnAnalyticsCheckBoxChanged, this);
+
+  m_analytics_new_id->Bind(wxEVT_BUTTON, &GeneralConfigPane::OnAnalyticsNewIdButtonClick, this);
+
+  m_throttler_choice->Bind(wxEVT_CHOICE, &GeneralConfigPane::OnThrottlerChoiceChanged, this);
+
+  m_cpu_engine_radiobox->Bind(wxEVT_RADIOBOX, &GeneralConfigPane::OnCPUEngineRadioBoxChanged, this);
+  m_cpu_engine_radiobox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 }
 
 void GeneralConfigPane::OnDualCoreCheckBoxChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.h
@@ -27,7 +27,7 @@ private:
   std::vector<CPUCore> m_cpu_cores;
   void InitializeGUI();
   void LoadGUIValues();
-  void RefreshGUI();
+  void BindEvents();
 
   void OnDualCoreCheckBoxChanged(wxCommandEvent&);
   void OnCheatCheckBoxChanged(wxCommandEvent&);

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinWX/Config/PathConfigPane.h"
+
 #include <string>
 
 #include <wx/button.h>
@@ -18,16 +20,16 @@
 #include "Core/Core.h"
 #include "DiscIO/NANDContentLoader.h"
 #include "DolphinWX/Config/ConfigMain.h"
-#include "DolphinWX/Config/PathConfigPane.h"
 #include "DolphinWX/Frame.h"
 #include "DolphinWX/Main.h"
+#include "DolphinWX/WxEventUtils.h"
 #include "DolphinWX/WxUtils.h"
 
 PathConfigPane::PathConfigPane(wxWindow* panel, wxWindowID id) : wxPanel(panel, id)
 {
   InitializeGUI();
   LoadGUIValues();
-  RefreshGUI();
+  BindEvents();
 }
 
 void PathConfigPane::InitializeGUI()
@@ -61,21 +63,6 @@ void PathConfigPane::InitializeGUI()
   m_wii_sdcard_filepicker = new wxFilePickerCtrl(
       this, wxID_ANY, wxEmptyString, _("Choose an SD Card file:"), wxFileSelectorDefaultWildcardStr,
       wxDefaultPosition, wxDefaultSize, wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
-
-  m_iso_paths_listbox->Bind(wxEVT_LISTBOX, &PathConfigPane::OnISOPathSelectionChanged, this);
-  m_recursive_iso_paths_checkbox->Bind(wxEVT_CHECKBOX,
-                                       &PathConfigPane::OnRecursiveISOCheckBoxChanged, this);
-  m_add_iso_path_button->Bind(wxEVT_BUTTON, &PathConfigPane::OnAddISOPath, this);
-  m_remove_iso_path_button->Bind(wxEVT_BUTTON, &PathConfigPane::OnRemoveISOPath, this);
-  m_default_iso_filepicker->Bind(wxEVT_FILEPICKER_CHANGED, &PathConfigPane::OnDefaultISOChanged,
-                                 this);
-  m_dvd_root_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnDVDRootChanged, this);
-  m_apploader_path_filepicker->Bind(wxEVT_FILEPICKER_CHANGED,
-                                    &PathConfigPane::OnApploaderPathChanged, this);
-  m_nand_root_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnNANDRootChanged, this);
-  m_dump_path_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnDumpPathChanged, this);
-  m_wii_sdcard_filepicker->Bind(wxEVT_FILEPICKER_CHANGED, &PathConfigPane::OnSdCardPathChanged,
-                                this);
 
   const int space5 = FromDIP(5);
 
@@ -141,10 +128,24 @@ void PathConfigPane::LoadGUIValues()
     m_iso_paths_listbox->Append(StrToWxStr(folder));
 }
 
-void PathConfigPane::RefreshGUI()
+void PathConfigPane::BindEvents()
 {
-  if (Core::IsRunning())
-    Disable();
+  m_iso_paths_listbox->Bind(wxEVT_LISTBOX, &PathConfigPane::OnISOPathSelectionChanged, this);
+  m_recursive_iso_paths_checkbox->Bind(wxEVT_CHECKBOX,
+                                       &PathConfigPane::OnRecursiveISOCheckBoxChanged, this);
+  m_add_iso_path_button->Bind(wxEVT_BUTTON, &PathConfigPane::OnAddISOPath, this);
+  m_remove_iso_path_button->Bind(wxEVT_BUTTON, &PathConfigPane::OnRemoveISOPath, this);
+  m_default_iso_filepicker->Bind(wxEVT_FILEPICKER_CHANGED, &PathConfigPane::OnDefaultISOChanged,
+                                 this);
+  m_dvd_root_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnDVDRootChanged, this);
+  m_apploader_path_filepicker->Bind(wxEVT_FILEPICKER_CHANGED,
+                                    &PathConfigPane::OnApploaderPathChanged, this);
+  m_nand_root_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnNANDRootChanged, this);
+  m_dump_path_dirpicker->Bind(wxEVT_DIRPICKER_CHANGED, &PathConfigPane::OnDumpPathChanged, this);
+  m_wii_sdcard_filepicker->Bind(wxEVT_FILEPICKER_CHANGED, &PathConfigPane::OnSdCardPathChanged,
+                                this);
+
+  Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 }
 
 void PathConfigPane::OnISOPathSelectionChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/PathConfigPane.h
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.h
@@ -20,7 +20,7 @@ public:
 private:
   void InitializeGUI();
   void LoadGUIValues();
-  void RefreshGUI();
+  void BindEvents();
 
   void OnISOPathSelectionChanged(wxCommandEvent&);
   void OnRecursiveISOCheckBoxChanged(wxCommandEvent&);

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinWX/Config/WiiConfigPane.h"
+
 #include <wx/checkbox.h>
 #include <wx/choice.h>
 #include <wx/gbsizer.h>
@@ -12,15 +14,15 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
-#include "DolphinWX/Config/WiiConfigPane.h"
 #include "DolphinWX/DolphinSlider.h"
+#include "DolphinWX/WxEventUtils.h"
 #include "DolphinWX/WxUtils.h"
 
 WiiConfigPane::WiiConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, id)
 {
   InitializeGUI();
   LoadGUIValues();
-  RefreshGUI();
+  BindEvents();
 }
 
 void WiiConfigPane::InitializeGUI()
@@ -55,18 +57,6 @@ void WiiConfigPane::InitializeGUI()
   m_bt_sensor_bar_sens = new DolphinSlider(this, wxID_ANY, 0, 0, 4);
   m_bt_speaker_volume = new DolphinSlider(this, wxID_ANY, 0, 0, 127);
   m_bt_wiimote_motor = new wxCheckBox(this, wxID_ANY, _("Wii Remote Motor"));
-
-  m_screensaver_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnScreenSaverCheckBoxChanged, this);
-  m_pal60_mode_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnPAL60CheckBoxChanged, this);
-  m_aspect_ratio_choice->Bind(wxEVT_CHOICE, &WiiConfigPane::OnAspectRatioChoiceChanged, this);
-  m_system_language_choice->Bind(wxEVT_CHOICE, &WiiConfigPane::OnSystemLanguageChoiceChanged, this);
-  m_sd_card_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnSDCardCheckBoxChanged, this);
-  m_connect_keyboard_checkbox->Bind(wxEVT_CHECKBOX,
-                                    &WiiConfigPane::OnConnectKeyboardCheckBoxChanged, this);
-  m_bt_sensor_bar_pos->Bind(wxEVT_CHOICE, &WiiConfigPane::OnSensorBarPosChanged, this);
-  m_bt_sensor_bar_sens->Bind(wxEVT_SLIDER, &WiiConfigPane::OnSensorBarSensChanged, this);
-  m_bt_speaker_volume->Bind(wxEVT_SLIDER, &WiiConfigPane::OnSpeakerVolumeChanged, this);
-  m_bt_wiimote_motor->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnWiimoteMotorChanged, this);
 
   m_screensaver_checkbox->SetToolTip(_("Dims the screen after five minutes of inactivity."));
   m_pal60_mode_checkbox->SetToolTip(_("Sets the Wii display mode to 60Hz (480i) instead of 50Hz "
@@ -167,20 +157,35 @@ void WiiConfigPane::LoadGUIValues()
   m_bt_wiimote_motor->SetValue(SConfig::GetInstance().m_wiimote_motor);
 }
 
-void WiiConfigPane::RefreshGUI()
+void WiiConfigPane::BindEvents()
 {
-  if (Core::IsRunning())
-  {
-    m_screensaver_checkbox->Disable();
-    m_pal60_mode_checkbox->Disable();
-    m_aspect_ratio_choice->Disable();
-    m_system_language_choice->Disable();
+  m_screensaver_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnScreenSaverCheckBoxChanged, this);
+  m_screensaver_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 
-    m_bt_sensor_bar_pos->Disable();
-    m_bt_sensor_bar_sens->Disable();
-    m_bt_speaker_volume->Disable();
-    m_bt_wiimote_motor->Disable();
-  }
+  m_pal60_mode_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnPAL60CheckBoxChanged, this);
+  m_pal60_mode_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+  m_aspect_ratio_choice->Bind(wxEVT_CHOICE, &WiiConfigPane::OnAspectRatioChoiceChanged, this);
+  m_aspect_ratio_choice->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+  m_system_language_choice->Bind(wxEVT_CHOICE, &WiiConfigPane::OnSystemLanguageChoiceChanged, this);
+  m_system_language_choice->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+  m_sd_card_checkbox->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnSDCardCheckBoxChanged, this);
+  m_connect_keyboard_checkbox->Bind(wxEVT_CHECKBOX,
+                                    &WiiConfigPane::OnConnectKeyboardCheckBoxChanged, this);
+
+  m_bt_sensor_bar_pos->Bind(wxEVT_CHOICE, &WiiConfigPane::OnSensorBarPosChanged, this);
+  m_bt_sensor_bar_pos->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+  m_bt_sensor_bar_sens->Bind(wxEVT_SLIDER, &WiiConfigPane::OnSensorBarSensChanged, this);
+  m_bt_sensor_bar_sens->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+  m_bt_speaker_volume->Bind(wxEVT_SLIDER, &WiiConfigPane::OnSpeakerVolumeChanged, this);
+  m_bt_speaker_volume->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+  m_bt_wiimote_motor->Bind(wxEVT_CHECKBOX, &WiiConfigPane::OnWiimoteMotorChanged, this);
+  m_bt_wiimote_motor->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 }
 
 void WiiConfigPane::OnScreenSaverCheckBoxChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/WiiConfigPane.h
+++ b/Source/Core/DolphinWX/Config/WiiConfigPane.h
@@ -21,7 +21,7 @@ public:
 private:
   void InitializeGUI();
   void LoadGUIValues();
-  void RefreshGUI();
+  void BindEvents();
 
   void OnScreenSaverCheckBoxChanged(wxCommandEvent&);
   void OnPAL60CheckBoxChanged(wxCommandEvent&);

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj
@@ -120,6 +120,7 @@
     <ClCompile Include="VideoConfigDiag.cpp" />
     <ClCompile Include="PostProcessingConfigDiag.cpp" />
     <ClCompile Include="ControllerConfigDiag.cpp" />
+    <ClCompile Include="WxEventUtils.cpp" />
     <ClCompile Include="WXInputBase.cpp" />
     <ClCompile Include="WxUtils.cpp" />
   </ItemGroup>
@@ -184,6 +185,7 @@
     <ClInclude Include="VideoConfigDiag.h" />
     <ClInclude Include="PostProcessingConfigDiag.h" />
     <ClInclude Include="ControllerConfigDiag.h" />
+    <ClInclude Include="WxEventUtils.h" />
     <ClInclude Include="WXInputBase.h" />
     <ClInclude Include="WxUtils.h" />
   </ItemGroup>

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
@@ -35,6 +35,7 @@
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="MainNoGUI.cpp" />
+    <ClCompile Include="WxEventUtils.cpp" />
     <ClCompile Include="WXInputBase.cpp" />
     <ClCompile Include="WxUtils.cpp" />
     <ClCompile Include="Cheats\CheatsWindow.cpp">
@@ -223,6 +224,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Main.h" />
+    <ClInclude Include="WxEventUtils.h" />
     <ClInclude Include="WXInputBase.h" />
     <ClInclude Include="WxUtils.h" />
     <ClInclude Include="Cheats\CheatSearchTab.h">

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinWX/Frame.h"
+
 #include <atomic>
 #include <cstddef>
 #include <fstream>
@@ -49,8 +51,8 @@
 #include "Core/Movie.h"
 #include "Core/State.h"
 
+#include "DolphinWX/Config/ConfigMain.h"
 #include "DolphinWX/Debugger/CodeWindow.h"
-#include "DolphinWX/Frame.h"
 #include "DolphinWX/GameListCtrl.h"
 #include "DolphinWX/Globals.h"
 #include "DolphinWX/LogWindow.h"
@@ -310,6 +312,8 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
 {
   BindEvents();
 
+  m_main_config_dialog = new CConfigMain(this);
+
   for (int i = 0; i <= IDM_CODE_WINDOW - IDM_LOG_WINDOW; i++)
     bFloatWindow[i] = false;
 
@@ -488,6 +492,7 @@ void CFrame::BindEvents()
   BindMenuBarEvents();
 
   Bind(DOLPHIN_EVT_RELOAD_THEME_BITMAPS, &CFrame::OnReloadThemeBitmaps, this);
+  Bind(DOLPHIN_EVT_RELOAD_GAMELIST, &CFrame::OnReloadGameList, this);
 }
 
 bool CFrame::RendererIsFullscreen()

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -27,6 +27,7 @@
 // Class declarations
 class CGameListCtrl;
 class CCodeWindow;
+class CConfigMain;
 class CLogWindow;
 class FifoPlayerDlg;
 class LogConfigWindow;
@@ -108,7 +109,7 @@ public:
   void UpdateWiiMenuChoice(wxMenuItem* WiiMenuItem = nullptr);
   static void ConnectWiimote(int wm_idx, bool connect);
   void UpdateTitle(const std::string& str);
-  void OpenGeneralConfiguration(int tab = -1);
+  void OpenGeneralConfiguration(wxWindowID tab_id = wxID_ANY);
 
   const CGameListCtrl* GetGameListCtrl() const;
   wxMenuBar* GetMenuBar() const override;
@@ -143,6 +144,7 @@ public:
 
 private:
   CGameListCtrl* m_GameListCtrl = nullptr;
+  CConfigMain* m_main_config_dialog = nullptr;
   wxPanel* m_Panel = nullptr;
   CRenderFrame* m_RenderFrame = nullptr;
   wxWindow* m_RenderParent = nullptr;
@@ -236,6 +238,7 @@ private:
   void OnHelp(wxCommandEvent& event);
 
   void OnReloadThemeBitmaps(wxCommandEvent& event);
+  void OnReloadGameList(wxCommandEvent& event);
 
   void OnEnableMenuItemIfCoreInitialized(wxUpdateUIEvent& event);
   void OnEnableMenuItemIfCoreUninitialized(wxUpdateUIEvent& event);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -256,18 +256,13 @@ wxToolBar* CFrame::OnCreateToolBar(long style, wxWindowID id, const wxString& na
   return new MainToolBar{type, this, id, wxDefaultPosition, wxDefaultSize, style};
 }
 
-void CFrame::OpenGeneralConfiguration(int tab)
+void CFrame::OpenGeneralConfiguration(wxWindowID tab_id)
 {
-  CConfigMain config_main(this);
-  if (tab > -1)
-    config_main.SetSelectedTab(tab);
+  if (tab_id > wxID_ANY)
+    m_main_config_dialog->SetSelectedTab(tab_id);
 
-  HotkeyManagerEmu::Enable(false);
-  if (config_main.ShowModal() == wxID_OK)
-    UpdateGameList();
-  HotkeyManagerEmu::Enable(true);
-
-  UpdateGUI();
+  m_main_config_dialog->Show();
+  m_main_config_dialog->SetFocus();
 }
 
 // Menu items
@@ -734,13 +729,11 @@ void CFrame::OnBootDrive(wxCommandEvent& event)
   BootGame(drives[event.GetId() - IDM_DRIVE1]);
 }
 
-// Refresh the file list and browse for a favorites directory
 void CFrame::OnRefresh(wxCommandEvent& WXUNUSED(event))
 {
   UpdateGameList();
 }
 
-// Create screenshot
 void CFrame::OnScreenshot(wxCommandEvent& WXUNUSED(event))
 {
   Core::SaveScreenShot();
@@ -1064,6 +1057,11 @@ void CFrame::OnReloadThemeBitmaps(wxCommandEvent& WXUNUSED(event))
   reload_event.SetEventObject(this);
   wxPostEvent(GetToolBar(), reload_event);
 
+  UpdateGameList();
+}
+
+void CFrame::OnReloadGameList(wxCommandEvent& WXUNUSED(event))
+{
   UpdateGameList();
 }
 
@@ -1531,8 +1529,9 @@ void CFrame::UpdateGUI()
 
 void CFrame::UpdateGameList()
 {
-  if (m_GameListCtrl)
-    m_GameListCtrl->ReloadList();
+  wxCommandEvent event{DOLPHIN_EVT_RELOAD_GAMELIST, GetId()};
+  event.SetEventObject(this);
+  wxPostEvent(m_GameListCtrl, event);
 }
 
 void CFrame::GameListChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -155,6 +155,8 @@ static int CompareGameListItems(const GameListItem* iso1, const GameListItem* is
   return 0;
 }
 
+wxDEFINE_EVENT(DOLPHIN_EVT_RELOAD_GAMELIST, wxCommandEvent);
+
 CGameListCtrl::CGameListCtrl(wxWindow* parent, const wxWindowID id, const wxPoint& pos,
                              const wxSize& size, long style)
     : wxListCtrl(parent, id, pos, size, style), toolTip(nullptr)
@@ -179,6 +181,8 @@ CGameListCtrl::CGameListCtrl(wxWindow* parent, const wxWindowID id, const wxPoin
   Bind(wxEVT_MENU, &CGameListCtrl::OnDeleteISO, this, IDM_DELETE_ISO);
   Bind(wxEVT_MENU, &CGameListCtrl::OnChangeDisc, this, IDM_LIST_CHANGE_DISC);
   Bind(wxEVT_MENU, &CGameListCtrl::OnNetPlayHost, this, IDM_START_NETPLAY);
+
+  Bind(DOLPHIN_EVT_RELOAD_GAMELIST, &CGameListCtrl::OnReloadGameList, this);
 
   wxTheApp->Bind(DOLPHIN_EVT_LOCAL_INI_CHANGED, &CGameListCtrl::OnLocalIniModified, this);
 }
@@ -706,6 +710,11 @@ void CGameListCtrl::ScanForISOs()
   }
 
   std::sort(m_ISOFiles.begin(), m_ISOFiles.end());
+}
+
+void CGameListCtrl::OnReloadGameList(wxCommandEvent& WXUNUSED(event))
+{
+  ReloadList();
 }
 
 void CGameListCtrl::OnLocalIniModified(wxCommandEvent& ev)

--- a/Source/Core/DolphinWX/GameListCtrl.h
+++ b/Source/Core/DolphinWX/GameListCtrl.h
@@ -31,14 +31,14 @@ public:
   }
 };
 
+wxDECLARE_EVENT(DOLPHIN_EVT_RELOAD_GAMELIST, wxCommandEvent);
+
 class CGameListCtrl : public wxListCtrl
 {
 public:
   CGameListCtrl(wxWindow* parent, const wxWindowID id, const wxPoint& pos, const wxSize& size,
                 long style);
   ~CGameListCtrl();
-
-  void ReloadList();
 
   void BrowseForDirectory();
   const GameListItem* GetISO(size_t index) const;
@@ -67,17 +67,9 @@ public:
 #endif
 
 private:
-  std::vector<int> m_FlagImageIndex;
-  std::vector<int> m_PlatformImageIndex;
-  std::vector<int> m_EmuStateImageIndex;
-  std::vector<int> m_utility_game_banners;
-  std::vector<std::unique_ptr<GameListItem>> m_ISOFiles;
+  void ReloadList();
 
   void ClearIsoFiles() { m_ISOFiles.clear(); }
-  int last_column;
-  int last_sort;
-  wxSize lastpos;
-  wxEmuStateTip* toolTip;
   void InitBitmaps();
   void UpdateItemAtColumn(long _Index, int column);
   void InsertItemInReportView(long _Index);
@@ -85,6 +77,7 @@ private:
   void ScanForISOs();
 
   // events
+  void OnReloadGameList(wxCommandEvent& event);
   void OnLeftClick(wxMouseEvent& event);
   void OnRightClick(wxMouseEvent& event);
   void OnMouseMotion(wxMouseEvent& event);
@@ -113,4 +106,15 @@ private:
   static bool CompressCB(const std::string& text, float percent, void* arg);
   static bool MultiCompressCB(const std::string& text, float percent, void* arg);
   static bool WiiCompressWarning();
+
+  std::vector<int> m_FlagImageIndex;
+  std::vector<int> m_PlatformImageIndex;
+  std::vector<int> m_EmuStateImageIndex;
+  std::vector<int> m_utility_game_banners;
+  std::vector<std::unique_ptr<GameListItem>> m_ISOFiles;
+
+  int last_column;
+  int last_sort;
+  wxSize lastpos;
+  wxEmuStateTip* toolTip;
 };

--- a/Source/Core/DolphinWX/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinWX/ISOProperties.h"
+
 #include <array>
 #include <cinttypes>
 #include <cstddef>
@@ -63,11 +65,11 @@
 #include "DiscIO/VolumeCreator.h"
 #include "DolphinWX/Cheats/ActionReplayCodesPanel.h"
 #include "DolphinWX/Cheats/GeckoCodeDiag.h"
+#include "DolphinWX/Config/ConfigMain.h"
 #include "DolphinWX/DolphinSlider.h"
 #include "DolphinWX/Frame.h"
 #include "DolphinWX/Globals.h"
 #include "DolphinWX/ISOFile.h"
-#include "DolphinWX/ISOProperties.h"
 #include "DolphinWX/Main.h"
 #include "DolphinWX/PatchAddEdit.h"
 #include "DolphinWX/WxUtils.h"
@@ -133,7 +135,7 @@ private:
 
   void OnConfigureClicked(wxCommandEvent&)
   {
-    main_frame->OpenGeneralConfiguration();
+    main_frame->OpenGeneralConfiguration(CConfigMain::ID_GENERALPAGE);
     UpdateState();
   }
 

--- a/Source/Core/DolphinWX/WxEventUtils.cpp
+++ b/Source/Core/DolphinWX/WxEventUtils.cpp
@@ -1,0 +1,22 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinWX/WxEventUtils.h"
+
+#include <wx/event.h>
+#include "Core/Core.h"
+#include "Core/NetPlayProto.h"
+
+namespace WxEventUtils
+{
+void OnEnableIfCoreNotRunning(wxUpdateUIEvent& event)
+{
+  event.Enable(!Core::IsRunning());
+}
+
+void OnEnableIfNetplayNotRunning(wxUpdateUIEvent& event)
+{
+  event.Enable(!NetPlay::IsNetPlayRunning());
+}
+}  // namespace WxEventUtils

--- a/Source/Core/DolphinWX/WxEventUtils.h
+++ b/Source/Core/DolphinWX/WxEventUtils.h
@@ -1,0 +1,17 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+// Intended for containing event functions that are bound to
+// different window controls through wxEvtHandler's Bind()
+// function.
+
+class wxUpdateUIEvent;
+
+namespace WxEventUtils
+{
+void OnEnableIfCoreNotRunning(wxUpdateUIEvent&);
+void OnEnableIfNetplayNotRunning(wxUpdateUIEvent&);
+}  // namespace WxEventUtils


### PR DESCRIPTION
Noticed this was doable when finishing up #4422 

This makes the UI options in the config dialog dynamically enable and disable in realtime based on what the core state is (and any pre-conditions in the UI code itself, of course). This allows for making the main config window modeless if preferable, since there's no worry about UI options not properly enabling/disabling.

I didn't make it modeless yet, since I'm not sure on opinions regarding that (IMO, it'd lead to better UX, since you can leave the config open if you ever need to quickly change something if the window is modeless). If making it modeless is desired, I can just update this PR with the necessary code, considering it's pretty trivial to do. If not, then this PR is good as is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4427)
<!-- Reviewable:end -->
