### PR TITLE
Vulkan: Don't use FIFO_RELAXED present mode for vsync.

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -198,25 +198,13 @@ bool SwapChain::SelectPresentMode()
     return it != present_modes.end();
   };
 
-  // If vsync is enabled, prefer VK_PRESENT_MODE_FIFO_KHR.
-  if (m_vsync_enabled)
+  // If vsync is enabled, use VK_PRESENT_MODE_FIFO_KHR.
+  // This check should not fail with conforming drivers, as the FIFO present mode is mandated by
+  // the specification (VK_KHR_swapchain). In case it isn't though, fall through to any other mode.
+  if (m_vsync_enabled && CheckForMode(VK_PRESENT_MODE_FIFO_KHR))
   {
-    // Try for relaxed vsync first, since it's likely the VI won't line up with
-    // the refresh rate of the system exactly, so tearing once is better than
-    // waiting for the next vblank.
-    if (CheckForMode(VK_PRESENT_MODE_FIFO_RELAXED_KHR))
-    {
-      m_present_mode = VK_PRESENT_MODE_FIFO_RELAXED_KHR;
-      return true;
-    }
-
-    // Fall back to strict vsync.
-    if (CheckForMode(VK_PRESENT_MODE_FIFO_KHR))
-    {
-      WARN_LOG(VIDEO, "Vulkan: FIFO_RELAXED not available, falling back to FIFO.");
-      m_present_mode = VK_PRESENT_MODE_FIFO_KHR;
-      return true;
-    }
+    m_present_mode = VK_PRESENT_MODE_FIFO_KHR;
+    return true;
   }
 
   // Prefer screen-tearing, if possible, for lowest latency.


### PR DESCRIPTION
Refer to https://bugs.dolphin-emu.org/issues/9877

I'm making a wild guess here that we're missing vblank each frame (or, at least a good chunk of the time) and it's therefore causing tearing.

The downside: If we miss a frame the video thread will get delayed until next vblank. But that's probably something people using vsync are used to, and matches behavior of the other backends.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4430)
<!-- Reviewable:end -->
