### PR TITLE
Framedump: Inplace encoding.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -768,6 +768,7 @@ Renderer::Renderer()
 Renderer::~Renderer()
 {
   FlushFrameDump();
+  FinishFrameData();
   if (m_frame_dumping_pbo[0])
     glDeleteBuffers(2, m_frame_dumping_pbo.data());
 }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1450,7 +1450,6 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
   glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 
-  FlushFrameDump();
   DumpFrame(flipped_trc, ticks);
 
   // Finish up the current frame, print some stats
@@ -1609,6 +1608,7 @@ void Renderer::DumpFrame(const TargetRectangle& flipped_trc, u64 ticks)
   }
   else
   {
+    FlushFrameDump();
     std::swap(m_frame_dumping_pbo[0], m_frame_dumping_pbo[1]);
     std::swap(m_frame_pbo_is_mapped[0], m_frame_pbo_is_mapped[1]);
     std::swap(m_last_frame_width[0], m_last_frame_width[1]);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -757,16 +757,3 @@ void Renderer::RunFrameDumps()
   }
 #endif
 }
-
-void Renderer::FlipImageData(u8* data, int w, int h, int pixel_width)
-{
-  for (int y = 0; y < h / 2; ++y)
-  {
-    for (int x = 0; x < w; ++x)
-    {
-      for (int delta = 0; delta < pixel_width; ++delta)
-        std::swap(data[(y * w + x) * pixel_width + delta],
-                  data[((h - 1 - y) * w + x) * pixel_width + delta]);
-    }
-  }
-}

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -705,23 +705,20 @@ void Renderer::RunFrameDumps()
     if (!m_frame_dump_thread_running.IsSet())
       break;
 
-    const auto config = m_frame_dump_config;
-
-    // TODO: Refactor this. Right now it's needed for the implace flipping of the image.
-    data.assign(config.data, config.data + config.stride * config.height);
-
-    // As we've done a copy now, there is no need to block the GPU thread any longer.
-    m_frame_dump_done.Set();
+    auto config = m_frame_dump_config;
 
     if (config.upside_down)
-      FlipImageData(data.data(), config.width, config.height, 4);
+    {
+      config.data = config.data + (config.height - 1) * config.stride;
+      config.stride = -config.stride;
+    }
 
     // Save screenshot
     if (s_screenshot.TestAndClear())
     {
       std::lock_guard<std::mutex> lk(s_criticalScreenshot);
 
-      if (TextureToPng(data.data(), config.stride, s_sScreenshotName, config.width, config.height,
+      if (TextureToPng(config.data, config.stride, s_sScreenshotName, config.width, config.height,
                        false))
         OSD::AddMessage("Screenshot saved to " + s_sScreenshotName);
 
@@ -745,9 +742,11 @@ void Renderer::RunFrameDumps()
         }
       }
 
-      AVIDump::AddFrame(data.data(), config.width, config.height, config.stride, config.state);
+      AVIDump::AddFrame(config.data, config.width, config.height, config.stride, config.state);
     }
 #endif
+
+    m_frame_dump_done.Set();
   }
 
 #if defined(HAVE_LIBAV) || defined(_WIN32)

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -122,8 +122,6 @@ public:
   virtual u16 BBoxRead(int index) = 0;
   virtual void BBoxWrite(int index, u16 value) = 0;
 
-  static void FlipImageData(u8* data, int w, int h, int pixel_width = 3);
-
   // Finish up the current frame, print some stats
   static void Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
                    u64 ticks, float Gamma = 1.0f);


### PR DESCRIPTION
This PR make the frame dumping code zero-copy.
Should be a bit faster on OGL, but as we have to stall the GPU thread until encoding is done, this is much slower on all other backends. Their fault for not supporting asynchronous dumping ;)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4432)
<!-- Reviewable:end -->
