### PR TITLE
FrameTools: Avoid deadlock in UpdateGUI().

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1426,8 +1426,8 @@ void CFrame::UpdateGUI()
   // Tools
   GetMenuBar()->FindItem(IDM_CHEATS)->Enable(SConfig::GetInstance().bEnableCheats);
 
-  bool ShouldEnableWiimotes = Initialized && SConfig::GetInstance().bWii &&
-                              !SConfig::GetInstance().m_bt_passthrough_enabled;
+  bool ShouldEnableWiimotes =
+      Running && SConfig::GetInstance().bWii && !SConfig::GetInstance().m_bt_passthrough_enabled;
   GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE1)->Enable(ShouldEnableWiimotes);
   GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE2)->Enable(ShouldEnableWiimotes);
   GetMenuBar()->FindItem(IDM_CONNECT_WIIMOTE3)->Enable(ShouldEnableWiimotes);


### PR DESCRIPTION
This is should work around the deadlock exposed by PR #3510. We should never lock the UI thread before the renderer is initialized, as it is important to respond to window messages during initialization.

This is not a proper fix, as any interaction with DXGI during a UI thread lock has the potential to trigger a deadlock. I'm working on some stability fixes around exclusive mode for my next PR, though even that PR will depend on not locking the UI thread until after the renderer is initialized.

I trust that everyone agrees locking the UI thread during renderer initialization is never a good idea. This should fix issue 9723 for now.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4433)
<!-- Reviewable:end -->
