### PR TITLE
PathConfigPane: Eliminate main frame global usage

### DIFF
--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -21,7 +21,6 @@
 #include "DiscIO/NANDContentLoader.h"
 #include "DolphinWX/Config/ConfigMain.h"
 #include "DolphinWX/Frame.h"
-#include "DolphinWX/Main.h"
 #include "DolphinWX/WxEventUtils.h"
 #include "DolphinWX/WxUtils.h"
 
@@ -226,7 +225,9 @@ void PathConfigPane::OnNANDRootChanged(wxCommandEvent& event)
 
   DiscIO::CNANDContentManager::Access().ClearCache();
 
-  main_frame->UpdateWiiMenuChoice();
+  wxCommandEvent update_event{DOLPHIN_EVT_UPDATE_LOAD_WII_MENU_ITEM, GetId()};
+  update_event.SetEventObject(this);
+  AddPendingEvent(update_event);
 }
 
 void PathConfigPane::OnDumpPathChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -226,6 +226,7 @@ bool CRenderFrame::ShowFullScreen(bool show, long style)
 wxDEFINE_EVENT(wxEVT_HOST_COMMAND, wxCommandEvent);
 wxDEFINE_EVENT(DOLPHIN_EVT_LOCAL_INI_CHANGED, wxCommandEvent);
 wxDEFINE_EVENT(DOLPHIN_EVT_RELOAD_THEME_BITMAPS, wxCommandEvent);
+wxDEFINE_EVENT(DOLPHIN_EVT_UPDATE_LOAD_WII_MENU_ITEM, wxCommandEvent);
 
 // Event tables
 BEGIN_EVENT_TABLE(CFrame, CRenderFrame)
@@ -493,6 +494,7 @@ void CFrame::BindEvents()
 
   Bind(DOLPHIN_EVT_RELOAD_THEME_BITMAPS, &CFrame::OnReloadThemeBitmaps, this);
   Bind(DOLPHIN_EVT_RELOAD_GAMELIST, &CFrame::OnReloadGameList, this);
+  Bind(DOLPHIN_EVT_UPDATE_LOAD_WII_MENU_ITEM, &CFrame::OnUpdateLoadWiiMenuItem, this);
 }
 
 bool CFrame::RendererIsFullscreen()

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -61,6 +61,7 @@ private:
 };
 
 wxDECLARE_EVENT(DOLPHIN_EVT_RELOAD_THEME_BITMAPS, wxCommandEvent);
+wxDECLARE_EVENT(DOLPHIN_EVT_UPDATE_LOAD_WII_MENU_ITEM, wxCommandEvent);
 
 class CFrame : public CRenderFrame
 {
@@ -106,7 +107,6 @@ public:
   bool RendererIsFullscreen();
   void DoFullscreen(bool bF);
   void ToggleDisplayMode(bool bFullscreen);
-  void UpdateWiiMenuChoice(wxMenuItem* WiiMenuItem = nullptr);
   static void ConnectWiimote(int wm_idx, bool connect);
   void UpdateTitle(const std::string& str);
   void OpenGeneralConfiguration(wxWindowID tab_id = wxID_ANY);
@@ -241,6 +241,9 @@ private:
   void OnReloadGameList(wxCommandEvent& event);
 
   void OnUpdateInterpreterMenuItem(wxUpdateUIEvent& event);
+
+  void OnUpdateLoadWiiMenuItem(wxCommandEvent&);
+  void UpdateLoadWiiMenuItem() const;
 
   void OnOpen(wxCommandEvent& event);  // File menu
   void DoOpen(bool Boot);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1072,6 +1072,11 @@ void CFrame::OnUpdateInterpreterMenuItem(wxUpdateUIEvent& event)
   event.Check(SConfig::GetInstance().iCPUCore == PowerPC::CORE_INTERPRETER);
 }
 
+void CFrame::OnUpdateLoadWiiMenuItem(wxCommandEvent& WXUNUSED(event))
+{
+  UpdateLoadWiiMenuItem();
+}
+
 void CFrame::ClearStatusBar()
 {
   if (this->GetStatusBar()->IsEnabled())
@@ -1184,16 +1189,13 @@ void CFrame::OnInstallWAD(wxCommandEvent& event)
   u64 titleID = DiscIO::CNANDContentManager::Access().Install_WiiWAD(fileName);
   if (titleID == TITLEID_SYSMENU)
   {
-    UpdateWiiMenuChoice();
+    UpdateLoadWiiMenuItem();
   }
 }
 
-void CFrame::UpdateWiiMenuChoice(wxMenuItem* WiiMenuItem)
+void CFrame::UpdateLoadWiiMenuItem() const
 {
-  if (!WiiMenuItem)
-  {
-    WiiMenuItem = GetMenuBar()->FindItem(IDM_LOAD_WII_MENU);
-  }
+  auto* const WiiMenuItem = GetMenuBar()->FindItem(IDM_LOAD_WII_MENU);
 
   const DiscIO::CNANDContentLoader& SysMenu_Loader =
       DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU,

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1195,23 +1195,22 @@ void CFrame::OnInstallWAD(wxCommandEvent& event)
 
 void CFrame::UpdateLoadWiiMenuItem() const
 {
-  auto* const WiiMenuItem = GetMenuBar()->FindItem(IDM_LOAD_WII_MENU);
+  auto* const menu_item = GetMenuBar()->FindItem(IDM_LOAD_WII_MENU);
 
-  const DiscIO::CNANDContentLoader& SysMenu_Loader =
-      DiscIO::CNANDContentManager::Access().GetNANDLoader(TITLEID_SYSMENU,
-                                                          Common::FROM_CONFIGURED_ROOT);
-  if (SysMenu_Loader.IsValid())
+  const auto& sys_menu_loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(
+      TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT);
+
+  if (sys_menu_loader.IsValid())
   {
-    int sysmenuVersion = SysMenu_Loader.GetTitleVersion();
-    char sysmenuRegion = SysMenu_Loader.GetCountryChar();
-    WiiMenuItem->Enable();
-    WiiMenuItem->SetItemLabel(
-        wxString::Format(_("Load Wii System Menu %d%c"), sysmenuVersion, sysmenuRegion));
+    const int version = sys_menu_loader.GetTitleVersion();
+    const char region = sys_menu_loader.GetCountryChar();
+    menu_item->Enable();
+    menu_item->SetItemLabel(wxString::Format(_("Load Wii System Menu %d%c"), version, region));
   }
   else
   {
-    WiiMenuItem->Enable(false);
-    WiiMenuItem->SetItemLabel(_("Load Wii System Menu"));
+    menu_item->Enable(false);
+    menu_item->SetItemLabel(_("Load Wii System Menu"));
   }
 }
 


### PR DESCRIPTION
UI event systems are made specifically to avoid this sort of coupling between window types, so we may as well use it.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4434)
<!-- Reviewable:end -->
