### PR TITLE
MAX_XFB_HEIGHT: PAL value off by two fixed

### DIFF
--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -26,10 +26,10 @@ enum
 // The VI can do horizontal scaling (TODO: emulate).
 const u32 MAX_XFB_WIDTH = 720;
 
-// Although EFB height is 528, 574-line XFB's can be created either with
+// Although EFB height is 528, 576-line XFB's can be created either with
 // vertical scaling by the EFB copy operation or copying to multiple XFB's
 // that are next to each other in memory (TODO: handle that situation).
-const u32 MAX_XFB_HEIGHT = 574;
+const u32 MAX_XFB_HEIGHT = 576;
 
 // This structure should only be used to represent a rectangle in EFB
 // coordinates, where the origin is at the upper left and the frame dimensions


### PR DESCRIPTION
I figured out recently that most of my homebrews compiled with DevkitPPC can't run with the DirectX11 backend when compiled in Debug Build on Windows 7. Most of the time I'm getting:
> D3D11 ERROR: ID3D11DeviceContext::UpdateSubresource: pDstBox is not a valid box for the destination subresource. *pDstBox = { left:0, top:0, front:0, right:640, bottom:576, back:1 }. DstSubresource = { left:0, top:0, front:0, right:720, bottom:574, back:1 }. [ RESOURCE_MANIPULATION ERROR #288: UPDATESUBRESOURCE_INVALIDDESTINATIONBOX]

With the following callstack:
>  	KernelBase.dll!RaiseException()	Unknown
 	dxgidebug.dll!000007fef7dbd4e3()	Unknown
 	d3d11_1sdklayers.dll!000007fed9aabd32()	Unknown
 	d3d11_1sdklayers.dll!000007fed9ab364a()	Unknown
 	d3d11_1sdklayers.dll!000007fed9af9477()	Unknown
 	d3d11_1sdklayers.dll!000007fed9abe130()	Unknown
>	DolphinD.exe!DX11::Television::Submit(unsigned int xfbAddr, unsigned int stride, unsigned int width, unsigned int height) Line 137	C++
 	DolphinD.exe!DX11::Renderer::SwapImpl(unsigned int xfbAddr, unsigned int fbWidth, unsigned int fbStride, unsigned int fbHeight, const MathUtil::Rectangle<int> & rc, unsigned __int64 ticks, float Gamma) Line 755	C++
 	DolphinD.exe!Renderer::Swap(unsigned int xfbAddr, unsigned int fbWidth, unsigned int fbStride, unsigned int fbHeight, const MathUtil::Rectangle<int> & rc, unsigned __int64 ticks, float Gamma) Line 628	C++
 	DolphinD.exe!AsyncRequests::HandleEvent(const AsyncRequests::Event & e) Line 139	C++
 	DolphinD.exe!AsyncRequests::PullEventsInternal() Line 57	C++
 	DolphinD.exe!AsyncRequests::PullEvents() Line 75	C++
 	DolphinD.exe!Fifo::RunGpuLoop::__l2::<lambda>() Line 324	C++
 	DolphinD.exe!Common::BlockingLoop::Run<void <lambda>(void) >(Fifo::RunGpuLoop::__l2::void <lambda>(void) payload, __int64 timeout) Line 103	C++
 	DolphinD.exe!Fifo::RunGpuLoop() Line 389	C++
 	DolphinD.exe!Core::EmuThread() Line 606	C++
 	[External Code]	

I tried to diff the assembly code of the release and debug build and well.... Seeing the debug build calling a constructor, then copies that created instance onto the stack, calls its destructor and passes the stack pointer to the variable, is a strange optimisation rather than just passing the instance pointer to the variable.
 - [Release Build](http://pastebin.com/GffBnerD)
 - [Debug Build](http://pastebin.com/0dRa7HnN)

After being deeper into the assembly code, I figured out that more verification functions are called in Debug Build and these are the ones crashing Dolphin. According to their complaints, Dolphin is trying to write using a ```pDstBox (bottom:576)``` into a ```DstSubresource (bottom:574)``` and obviously it doesn't fit.

 * The XFB's height is changed by my homebrews ([compiled with the libogc](https://github.com/devkitPro/libogc/blob/master/libogc/video.c#L843)) to 576
 * The MAX_XFB_HEIGHT defined by Dolphin is 574 ([which was an old value that get replaced](https://github.com/devkitPro/libogc/commit/0a757d2c83f8c53e627e5714393a74e730294944) apparently)

Now the question is... Which value is correct? The MAX_XFB_HEIGHT of Dolphin or the one defined by the libogc?

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4437)
<!-- Reviewable:end -->
