### PR TITLE
Frame: Remove unused menu variable

### DIFF
--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -124,8 +124,6 @@ public:
   X11Utils::XRRConfiguration* m_XRRConfig;
 #endif
 
-  wxMenu* m_SavedPerspectives = nullptr;
-
   // AUI
   wxAuiManager* m_Mgr = nullptr;
   bool bFloatWindow[IDM_DEBUG_WINDOW_LIST_END - IDM_DEBUG_WINDOW_LIST_START] = {};


### PR DESCRIPTION
This has been unused since the introduction of the MainMenuBar class that abstracts away all of the wxMenuBar UI loading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4438)
<!-- Reviewable:end -->
