### PR TITLE
CPU: Fix deadlocks by periodically yielding to the UI message pump.

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -148,6 +148,10 @@ void Host_ShowVideoConfig(void*, const std::string&)
 {
 }
 
+void Host_YieldToUI()
+{
+}
+
 static bool MsgAlert(const char* caption, const char* text, bool yes_no, int /*Style*/)
 {
   __android_log_print(ANDROID_LOG_ERROR, DOLPHIN_TAG, "%s:%s", caption, text);

--- a/Source/Core/Core/Host.h
+++ b/Source/Core/Core/Host.h
@@ -38,6 +38,7 @@ void Host_UpdateDisasmDialog();
 void Host_UpdateMainFrame();
 void Host_UpdateTitle(const std::string& title);
 void Host_ShowVideoConfig(void* parent, const std::string& backend_name);
+void Host_YieldToUI();
 
 // TODO (neobrain): Remove this from host!
 void* Host_GetRenderHandle();

--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -89,6 +89,9 @@ bool Host_RendererIsFullscreen()
 {
   return Host::GetInstance()->GetRenderFullscreen();
 }
+void Host_YieldToUI()
+{
+}
 
 // We ignore these, and their purpose should be questioned individually.
 // In particular, RequestRenderWindowSize, RequestFullscreen, and

--- a/Source/Core/DolphinQt2/Host.cpp
+++ b/Source/Core/DolphinQt2/Host.cpp
@@ -91,6 +91,7 @@ bool Host_RendererIsFullscreen()
 }
 void Host_YieldToUI()
 {
+  qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 }
 
 // We ignore these, and their purpose should be questioned individually.

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -10,6 +10,7 @@
 #include <wx/app.h>
 #include <wx/buffer.h>
 #include <wx/cmdline.h>
+#include <wx/evtloop.h>
 #include <wx/image.h>
 #include <wx/imagpng.h>
 #include <wx/intl.h>
@@ -546,4 +547,9 @@ void Host_ShowVideoConfig(void* parent, const std::string& backend_name)
     VideoConfigDiag diag((wxWindow*)parent, backend_name);
     diag.ShowModal();
   }
+}
+
+void Host_YieldToUI()
+{
+  wxGetApp().GetMainLoop()->YieldFor(wxEVT_CATEGORY_UI);
 }

--- a/Source/Core/DolphinWX/MainNoGUI.cpp
+++ b/Source/Core/DolphinWX/MainNoGUI.cpp
@@ -161,6 +161,10 @@ void Host_ShowVideoConfig(void*, const std::string&)
 {
 }
 
+void Host_YieldToUI()
+{
+}
+
 #if HAVE_X11
 #include <X11/keysym.h>
 #include "DolphinWX/X11Utils.h"

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -18,6 +18,7 @@
 #include "Core/CoreTiming.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
+#include "Core/Host.h"
 #include "Core/NetPlayProto.h"
 
 #include "VideoCommon/AsyncRequests.h"
@@ -94,7 +95,13 @@ void PauseAndLock(bool doLock, bool unpauseOnUnlock)
   {
     SyncGPU(SyncGPUReason::Other);
     EmulatorState(false);
-    FlushGpu();
+
+    const SConfig& param = SConfig::GetInstance();
+
+    if (!param.bCPUThread || s_use_deterministic_gpu_thread)
+      return;
+
+    s_gpu_mainloop.WaitYield(std::chrono::milliseconds(100), Host_YieldToUI);
   }
   else
   {

--- a/Source/UnitTests/TestUtils/StubHost.cpp
+++ b/Source/UnitTests/TestUtils/StubHost.cpp
@@ -63,6 +63,9 @@ void Host_SetWiiMoteConnectionState(int)
 void Host_ShowVideoConfig(void*, const std::string&)
 {
 }
+void Host_YieldToUI()
+{
+}
 std::unique_ptr<cInterfaceBase> HostGL_CreateGLInterface()
 {
   return nullptr;


### PR DESCRIPTION
This is the second PR to fix known deadlocks between the Video Thread and the UI Thread. This is a more thorough approach, by replacing some condition variables with loops that periodically enter the message pump (currently every 100ms).

We need to watch out though that the user doesn't trigger the UI during the time it is blocked. The yield filters out input event, so it *should* not be possible for the user to trigger anything during the block,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4439)
<!-- Reviewable:end -->
