### PR TITLE
GCAdapterConfigDiag: Make public functions private

### DIFF
--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
@@ -56,7 +56,7 @@ GCAdapterConfigDiag::GCAdapterConfigDiag(wxWindow* const parent, const wxString&
   SetSizerAndFit(szr);
   Center();
 
-  Bind(wxEVT_ADAPTER_UPDATE, &GCAdapterConfigDiag::UpdateAdapter, this);
+  Bind(wxEVT_ADAPTER_UPDATE, &GCAdapterConfigDiag::OnUpdateAdapter, this);
 }
 
 GCAdapterConfigDiag::~GCAdapterConfigDiag()
@@ -69,7 +69,7 @@ void GCAdapterConfigDiag::ScheduleAdapterUpdate()
   wxQueueEvent(this, new wxCommandEvent(wxEVT_ADAPTER_UPDATE));
 }
 
-void GCAdapterConfigDiag::UpdateAdapter(wxCommandEvent& ev)
+void GCAdapterConfigDiag::OnUpdateAdapter(wxCommandEvent& ev)
 {
   bool unpause = Core::PauseAndLock(true);
   if (GCAdapter::IsDetected())

--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
@@ -69,7 +69,7 @@ void GCAdapterConfigDiag::ScheduleAdapterUpdate()
   wxQueueEvent(this, new wxCommandEvent(wxEVT_ADAPTER_UPDATE));
 }
 
-void GCAdapterConfigDiag::OnUpdateAdapter(wxCommandEvent& ev)
+void GCAdapterConfigDiag::OnUpdateAdapter(wxCommandEvent& WXUNUSED(event))
 {
   bool unpause = Core::PauseAndLock(true);
   if (GCAdapter::IsDetected())

--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.h
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.h
@@ -17,7 +17,7 @@ public:
 private:
   void ScheduleAdapterUpdate();
 
-  void OnUpdateAdapter(wxCommandEvent& ev);
+  void OnUpdateAdapter(wxCommandEvent& event);
   void OnAdapterRumble(wxCommandEvent& event);
   void OnAdapterKonga(wxCommandEvent& event);
 

--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.h
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.h
@@ -14,13 +14,13 @@ public:
   GCAdapterConfigDiag(wxWindow* const parent, const wxString& name, const int tab_num = 0);
   ~GCAdapterConfigDiag();
 
+private:
   void ScheduleAdapterUpdate();
   void UpdateAdapter(wxCommandEvent& ev);
 
-private:
-  wxStaticText* m_adapter_status;
-  int m_pad_id;
-
   void OnAdapterRumble(wxCommandEvent& event);
   void OnAdapterKonga(wxCommandEvent& event);
+
+  wxStaticText* m_adapter_status;
+  int m_pad_id;
 };

--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.h
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.h
@@ -16,8 +16,8 @@ public:
 
 private:
   void ScheduleAdapterUpdate();
-  void UpdateAdapter(wxCommandEvent& ev);
 
+  void OnUpdateAdapter(wxCommandEvent& ev);
   void OnAdapterRumble(wxCommandEvent& event);
   void OnAdapterKonga(wxCommandEvent& event);
 


### PR DESCRIPTION
These aren't used outside of the class, and event functions shouldn't really be public anyways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4440)
<!-- Reviewable:end -->
