### PR TITLE
Vulkan: Handle maxImageCount of zero when creating swap chain

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -302,8 +302,11 @@ bool SwapChain::CreateSwapChain()
     return false;
 
   // Select number of images in swap chain, we prefer one buffer in the background to work on
-  uint32_t image_count =
-      std::min(surface_capabilities.minImageCount + 1, surface_capabilities.maxImageCount);
+  uint32_t image_count = surface_capabilities.minImageCount + 1;
+
+  // maxImageCount can be zero, in which case there isn't an upper limit on the number of buffers.
+  if (surface_capabilities.maxImageCount > 0)
+    image_count = std::min(image_count, surface_capabilities.maxImageCount);
 
   // Determine the dimensions of the swap chain. Values of -1 indicate the size we specify here
   // determines window size?


### PR DESCRIPTION
anv seems to set this to zero, which is fine according to the spec, but we were using it as a maximum, which was resulting in a swap chain without any buffers being created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4441)
<!-- Reviewable:end -->
