### PR TITLE
FIR Resampling, dither, wiimote-emu speaker fix

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -180,10 +180,13 @@ void StartAudioDump()
 {
   std::string audio_file_name_dtk = File::GetUserPath(D_DUMPAUDIO_IDX) + "dtkdump.wav";
   std::string audio_file_name_dsp = File::GetUserPath(D_DUMPAUDIO_IDX) + "dspdump.wav";
+  std::string audio_file_name_mix = File::GetUserPath(D_DUMPAUDIO_IDX) + "mixdump.wav";
   File::CreateFullPath(audio_file_name_dtk);
   File::CreateFullPath(audio_file_name_dsp);
+  File::CreateFullPath(audio_file_name_mix);
   g_sound_stream->GetMixer()->StartLogDTKAudio(audio_file_name_dtk);
   g_sound_stream->GetMixer()->StartLogDSPAudio(audio_file_name_dsp);
+  g_sound_stream->GetMixer()->StartLogMixAudio(audio_file_name_mix);
   s_audio_dump_start = true;
 }
 
@@ -191,6 +194,7 @@ void StopAudioDump()
 {
   g_sound_stream->GetMixer()->StopLogDTKAudio();
   g_sound_stream->GetMixer()->StopLogDSPAudio();
+  g_sound_stream->GetMixer()->StopLogMixAudio();
   s_audio_dump_start = false;
 }
 

--- a/Source/Core/AudioCommon/AudioCommon.vcxproj
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj
@@ -37,8 +37,10 @@
   <ItemGroup>
     <ClCompile Include="aldlist.cpp" />
     <ClCompile Include="AudioCommon.cpp" />
+    <ClCompile Include="BaseFilter.cpp" />
     <ClCompile Include="Dither.cpp" />
     <ClCompile Include="DPL2Decoder.cpp" />
+    <ClCompile Include="LinearFilter.cpp" />
     <ClCompile Include="Mixer.cpp" />
     <ClCompile Include="NullSoundStream.cpp" />
     <ClCompile Include="OpenALStream.cpp" />

--- a/Source/Core/AudioCommon/AudioCommon.vcxproj
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj
@@ -37,11 +37,13 @@
   <ItemGroup>
     <ClCompile Include="aldlist.cpp" />
     <ClCompile Include="AudioCommon.cpp" />
+    <ClCompile Include="Dither.cpp" />
     <ClCompile Include="DPL2Decoder.cpp" />
     <ClCompile Include="Mixer.cpp" />
     <ClCompile Include="NullSoundStream.cpp" />
     <ClCompile Include="OpenALStream.cpp" />
     <ClCompile Include="WaveFile.cpp" />
+    <ClCompile Include="WindowedSincFilter.cpp" />
     <ClCompile Include="XAudio2Stream.cpp" />
     <ClCompile Include="XAudio2_7Stream.cpp">
       <AdditionalIncludeDirectories>$(ExternalsDir)XAudio2_7;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -52,8 +54,11 @@
     <ClInclude Include="AlsaSoundStream.h" />
     <ClInclude Include="AOSoundStream.h" />
     <ClInclude Include="AudioCommon.h" />
+    <ClInclude Include="BaseFilter.h" />
     <ClInclude Include="CoreAudioSoundStream.h" />
+    <ClInclude Include="Dither.h" />
     <ClInclude Include="DPL2Decoder.h" />
+    <ClInclude Include="LinearFilter.h" />
     <ClInclude Include="Mixer.h" />
     <ClInclude Include="NullSoundStream.h" />
     <ClInclude Include="OpenALStream.h" />
@@ -61,6 +66,7 @@
     <ClInclude Include="PulseAudioStream.h" />
     <ClInclude Include="SoundStream.h" />
     <ClInclude Include="WaveFile.h" />
+    <ClInclude Include="WindowedSincFilter.h" />
     <ClInclude Include="XAudio2Stream.h" />
     <ClInclude Include="XAudio2_7Stream.h" />
   </ItemGroup>

--- a/Source/Core/AudioCommon/AudioCommon.vcxproj.filters
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj.filters
@@ -30,6 +30,12 @@
     <ClCompile Include="WindowedSincFilter.cpp">
       <Filter>InterpolationFilters</Filter>
     </ClCompile>
+    <ClCompile Include="BaseFilter.cpp">
+      <Filter>InterpolationFilters</Filter>
+    </ClCompile>
+    <ClCompile Include="LinearFilter.cpp">
+      <Filter>InterpolationFilters</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="aldlist.h" />

--- a/Source/Core/AudioCommon/AudioCommon.vcxproj.filters
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj.filters
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="SoundStreams">
       <UniqueIdentifier>{25ec8f16-fc60-4a63-bc3e-ad0272fd5942}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="InterpolationFilters">
+      <UniqueIdentifier>{81e8c4a8-a15d-4389-84c2-dfbb8c110ccd}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -22,6 +25,10 @@
     </ClCompile>
     <ClCompile Include="XAudio2_7Stream.cpp">
       <Filter>SoundStreams</Filter>
+    </ClCompile>
+    <ClCompile Include="Dither.cpp" />
+    <ClCompile Include="WindowedSincFilter.cpp">
+      <Filter>InterpolationFilters</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -59,6 +66,16 @@
     </ClInclude>
     <ClInclude Include="SoundStream.h">
       <Filter>SoundStreams</Filter>
+    </ClInclude>
+    <ClInclude Include="Dither.h" />
+    <ClInclude Include="WindowedSincFilter.h">
+      <Filter>InterpolationFilters</Filter>
+    </ClInclude>
+    <ClInclude Include="BaseFilter.h">
+      <Filter>InterpolationFilters</Filter>
+    </ClInclude>
+    <ClInclude Include="LinearFilter.h">
+      <Filter>InterpolationFilters</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Core/AudioCommon/BaseFilter.cpp
+++ b/Source/Core/AudioCommon/BaseFilter.cpp
@@ -1,0 +1,14 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "AudioCommon/BaseFilter.h"
+
+BaseFilter::BaseFilter(u32 taps) : m_num_taps(taps)
+{
+}
+
+u32 BaseFilter::GetNumTaps() const
+{
+  return m_num_taps;
+}

--- a/Source/Core/AudioCommon/BaseFilter.h
+++ b/Source/Core/AudioCommon/BaseFilter.h
@@ -1,0 +1,19 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/RingBuffer.h"
+
+class BaseFilter
+{
+public:
+  BaseFilter(u32 taps = 0) : m_num_taps(taps) {}
+  ~BaseFilter() {}
+  // ratio is out_rate / in_rate
+  virtual void ConvolveStereo(const RingBuffer<float>& input, u32 index, float* output_l,
+                              float* output_r, const float fraction, const float ratio) const = 0;
+
+  const u32 m_num_taps;  // one-sided
+};

--- a/Source/Core/AudioCommon/BaseFilter.h
+++ b/Source/Core/AudioCommon/BaseFilter.h
@@ -9,11 +9,13 @@
 class BaseFilter
 {
 public:
-  BaseFilter(u32 taps = 0) : m_num_taps(taps) {}
-  ~BaseFilter() {}
+  BaseFilter(u32 taps = 0);
+  virtual ~BaseFilter() = default;
   // ratio is out_rate / in_rate
-  virtual void ConvolveStereo(const RingBuffer<float>& input, u32 index, float* output_l,
-                              float* output_r, const float fraction, const float ratio) const = 0;
+  virtual void ConvolveStereo(const RingBuffer<float>& input, size_t index, float* output_l,
+                              float* output_r, float fraction, float ratio) const = 0;
+  u32 GetNumTaps() const;
 
+protected:
   const u32 m_num_taps;  // one-sided
 };

--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -1,4 +1,8 @@
 set(SRCS	AudioCommon.cpp
+			BaseFilter.cpp
+			LinearFilter.cpp
+			WindowedSincFilter.cpp
+			Dither.cpp
 			DPL2Decoder.cpp
 			Mixer.cpp
 			WaveFile.cpp

--- a/Source/Core/AudioCommon/Dither.cpp
+++ b/Source/Core/AudioCommon/Dither.cpp
@@ -1,0 +1,54 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Dither.h"
+
+#include "Common/MathUtil.h"
+
+void TriangleDither::DitherStereoSample(const float* in, s16* out)
+{
+  float random_l = GenerateNoise();
+  float random_r = GenerateNoise();
+
+  float temp_l = ScaleFloatToInt(MathUtil::Clamp(in[0], -1.f, 1.f)) + random_l - state_l;
+  float temp_r = ScaleFloatToInt(MathUtil::Clamp(in[1], -1.f, 1.f)) + random_r - state_r;
+  out[0] = (s16)MathUtil::Clamp((s32)lrintf(temp_l), -32768, 32767);
+  out[1] = (s16)MathUtil::Clamp((s32)lrintf(temp_r), -32768, 32767);
+  state_l = random_l;
+  state_r = random_r;
+}
+
+void ShapedDither::DitherStereoSample(const float* in, s16* out)
+{
+  float random_l = GenerateNoise() + GenerateNoise();
+  float random_r = GenerateNoise() + GenerateNoise();
+
+  float conv_l = ScaleFloatToInt(MathUtil::Clamp(in[0], -1.f, 1.f));
+  float conv_r = ScaleFloatToInt(MathUtil::Clamp(in[1], -1.f, 1.f));
+
+  conv_l += m_buffer_l[m_phase] * FIR[0];
+  conv_r += m_buffer_r[m_phase] * FIR[0];
+
+  conv_l += m_buffer_l[(m_phase - 1) & MASK] * FIR[1];
+  conv_r += m_buffer_r[(m_phase - 1) & MASK] * FIR[1];
+
+  conv_l += m_buffer_l[(m_phase - 2) & MASK] * FIR[2];
+  conv_r += m_buffer_r[(m_phase - 2) & MASK] * FIR[2];
+
+  conv_l += m_buffer_l[(m_phase - 3) & MASK] * FIR[3];
+  conv_r += m_buffer_r[(m_phase - 3) & MASK] * FIR[3];
+
+  conv_l += m_buffer_l[(m_phase - 4) & MASK] * FIR[4];
+  conv_r += m_buffer_r[(m_phase - 4) & MASK] * FIR[4];
+
+  float result_l = conv_l + random_l;
+  float result_r = conv_r + random_r;
+
+  out[0] = (s16)MathUtil::Clamp((s32)lrintf(result_l), -32768, 32767);
+  out[1] = (s16)MathUtil::Clamp((s32)lrintf(result_r), -32768, 32767);
+
+  m_phase = (m_phase + 1) & MASK;
+  m_buffer_l[m_phase] = conv_l - (float)out[0];
+  m_buffer_r[m_phase] = conv_r - (float)out[1];
+}

--- a/Source/Core/AudioCommon/Dither.h
+++ b/Source/Core/AudioCommon/Dither.h
@@ -7,58 +7,50 @@
 #include <array>
 #include <random>
 
-#include <Common/CommonTypes.h>
+#include "Common/CommonTypes.h"
 
 class Dither
 {
 public:
   Dither() { m_mersenne_twister.seed(std::random_device{}()); }
-  ~Dither() {}
-  void ProcessStereo(const float* input, s16* output, u32 num_samples)
-  {
-    for (u32 i = 0; i < num_samples * 2; i += 2)
-    {
-      DitherStereoSample(&input[i], &output[i]);
-    }
-  }
+  ~Dither() = default;
+  void ProcessStereo(const float* input, s16* output, u32 num_samples);
 
   // function also clamps inputs to -1, 1
   virtual void DitherStereoSample(const float* in, s16* out) = 0;
 
 protected:
   float GenerateNoise() { return m_real_dist(m_mersenne_twister); }
-  static float ScaleFloatToInt(float in)
-  {
-    return (in > 0) ? (in * (float)0x7fff) : (in * (float)0x8000);
-  }
+  static float ScaleFloatToInt(float in);
 
   std::mt19937 m_mersenne_twister;
   std::uniform_real_distribution<float> m_real_dist{-0.5, 0.5};
 };
 
-class TriangleDither : public Dither
+class TriangleDither final : public Dither
 {
 public:
   TriangleDither() : Dither() {}
-  ~TriangleDither() {}
-  void DitherStereoSample(const float* in, s16* out);
+  ~TriangleDither() = default;
+  void DitherStereoSample(const float* in, s16* out) override;
 
 private:
-  float state_l = 0, state_r = 0;
+  float m_state_l = 0;
+  float m_state_r = 0;
 };
 
-class ShapedDither : public Dither
+class ShapedDither final : public Dither
 {
 public:
   ShapedDither() : Dither() {}
-  ~ShapedDither() {}
-  void DitherStereoSample(const float* in, s16* out);
+  ~ShapedDither() = default;
+  void DitherStereoSample(const float* in, s16* out) override;
 
 private:
   int m_phase = 0;
   static constexpr int MASK = 7;
   static constexpr int SIZE = 8;
-  static constexpr float FIR[] = {2.033f, -2.165f, 1.959f, -1.590f, 0.6149f};
+  static const std::array<float, 5> FIR;
   std::array<float, SIZE> m_buffer_l{};
   std::array<float, SIZE> m_buffer_r{};
 };

--- a/Source/Core/AudioCommon/Dither.h
+++ b/Source/Core/AudioCommon/Dither.h
@@ -1,0 +1,64 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <random>
+
+#include <Common/CommonTypes.h>
+
+class Dither
+{
+public:
+  Dither() { m_mersenne_twister.seed(std::random_device{}()); }
+  ~Dither() {}
+  void ProcessStereo(const float* input, s16* output, u32 num_samples)
+  {
+    for (u32 i = 0; i < num_samples * 2; i += 2)
+    {
+      DitherStereoSample(&input[i], &output[i]);
+    }
+  }
+
+  // function also clamps inputs to -1, 1
+  virtual void DitherStereoSample(const float* in, s16* out) = 0;
+
+protected:
+  float GenerateNoise() { return m_real_dist(m_mersenne_twister); }
+  static float ScaleFloatToInt(float in)
+  {
+    return (in > 0) ? (in * (float)0x7fff) : (in * (float)0x8000);
+  }
+
+  std::mt19937 m_mersenne_twister;
+  std::uniform_real_distribution<float> m_real_dist{-0.5, 0.5};
+};
+
+class TriangleDither : public Dither
+{
+public:
+  TriangleDither() : Dither() {}
+  ~TriangleDither() {}
+  void DitherStereoSample(const float* in, s16* out);
+
+private:
+  float state_l = 0, state_r = 0;
+};
+
+class ShapedDither : public Dither
+{
+public:
+  ShapedDither() : Dither() {}
+  ~ShapedDither() {}
+  void DitherStereoSample(const float* in, s16* out);
+
+private:
+  int m_phase = 0;
+  static constexpr int MASK = 7;
+  static constexpr int SIZE = 8;
+  static constexpr float FIR[] = {2.033f, -2.165f, 1.959f, -1.590f, 0.6149f};
+  std::array<float, SIZE> m_buffer_l{};
+  std::array<float, SIZE> m_buffer_r{};
+};

--- a/Source/Core/AudioCommon/LinearFilter.cpp
+++ b/Source/Core/AudioCommon/LinearFilter.cpp
@@ -1,0 +1,26 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "AudioCommon/LinearFilter.h"
+
+LinearFilter::LinearFilter() : BaseFilter(1)
+{
+}
+
+void LinearFilter::ConvolveStereo(const RingBuffer<float>& input, size_t index, float* output_l,
+                                  float* output_r, const float fraction, const float ratio) const
+{
+  float l1 = input[index - 2];
+  float r1 = input[index - 1];
+  float l2 = input[index];
+  float r2 = input[index + 1];
+
+  *output_l = Lerp(l1, l2, fraction);
+  *output_r = Lerp(r1, r2, fraction);
+}
+
+float LinearFilter::Lerp(float sample1, float sample2, float fraction)
+{
+  return (1.f - fraction) * sample1 + fraction * sample2;
+}

--- a/Source/Core/AudioCommon/LinearFilter.h
+++ b/Source/Core/AudioCommon/LinearFilter.h
@@ -9,23 +9,11 @@
 class LinearFilter final : public BaseFilter
 {
 public:
-  LinearFilter() : BaseFilter(1) {}
-  ~LinearFilter() {}
-  void ConvolveStereo(const RingBuffer<float>& input, u32 index, float* output_l, float* output_r,
-                      const float fraction, const float ratio) const
-  {
-    float l1 = input[index - 2];
-    float r1 = input[index - 1];
-    float l2 = input[index];
-    float r2 = input[index + 1];
-
-    *output_l = lerp(l1, l2, fraction);
-    *output_r = lerp(r1, r2, fraction);
-  }
+  LinearFilter();
+  ~LinearFilter() = default;
+  void ConvolveStereo(const RingBuffer<float>& input, size_t index, float* output_l,
+                      float* output_r, float fraction, float ratio) const override;
 
 private:
-  static inline float lerp(float sample1, float sample2, float fraction)
-  {
-    return (1.f - fraction) * sample1 + fraction * sample2;
-  }
+  static float Lerp(float sample1, float sample2, float fraction);
 };

--- a/Source/Core/AudioCommon/LinearFilter.h
+++ b/Source/Core/AudioCommon/LinearFilter.h
@@ -1,0 +1,31 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "AudioCommon/BaseFilter.h"
+
+class LinearFilter final : public BaseFilter
+{
+public:
+  LinearFilter() : BaseFilter(1) {}
+  ~LinearFilter() {}
+  void ConvolveStereo(const RingBuffer<float>& input, u32 index, float* output_l, float* output_r,
+                      const float fraction, const float ratio) const
+  {
+    float l1 = input[index - 2];
+    float r1 = input[index - 1];
+    float l2 = input[index];
+    float r2 = input[index + 1];
+
+    *output_l = lerp(l1, l2, fraction);
+    *output_r = lerp(r1, r2, fraction);
+  }
+
+private:
+  static inline float lerp(float sample1, float sample2, float fraction)
+  {
+    return (1.f - fraction) * sample1 + fraction * sample2;
+  }
+};

--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -2,34 +2,47 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "AudioCommon/Mixer.h"
+
+#include <algorithm>
 #include <cstring>
 
-#include "AudioCommon/AudioCommon.h"
-#include "AudioCommon/Mixer.h"
+#include "AudioCommon/LinearFilter.h"
+#include "AudioCommon/WindowedSincFilter.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 #include "Core/ConfigManager.h"
+#include "Core/HW/Wiimote.h"
 
-#if _M_SSE >= 0x301 && !(defined __GNUC__ && !defined __SSSE3__)
-#include <tmmintrin.h>
-#endif
-
-CMixer::CMixer(unsigned int BackendSampleRate) : m_sampleRate(BackendSampleRate)
+CMixer::CMixer(u32 BackendSampleRate) : m_output_sample_rate(BackendSampleRate)
 {
+  std::shared_ptr<WindowedSincFilter> FIR_filter =
+      std::make_shared<WindowedSincFilter>(17, 512, 0.8f, 6.f);
+  std::shared_ptr<LinearFilter> linear_filter = std::make_shared<LinearFilter>();
+
+  m_dma_mixer = std::make_unique<MixerFifo>(this, 32000, FIR_filter);
+  m_streaming_mixer = std::make_unique<MixerFifo>(this, 48000, FIR_filter);
+
+  m_dither = std::make_unique<ShapedDither>();
+
+  // wiimote mixers should just use linear interpolation
+  for (u32 i = 0; i < MAX_WIIMOTES; ++i)
+  {
+    m_wiimote_speaker_mixers[i] = (g_wiimote_sources[i] == WIIMOTE_SRC_EMU) ?
+                                      std::make_unique<MixerFifo>(this, 6000, linear_filter) :
+                                      nullptr;
+  }
+
   INFO_LOG(AUDIO_INTERFACE, "Mixer is initialized");
 }
 
-CMixer::~CMixer()
-{
-}
-
 // Executed from sound stream thread
-unsigned int CMixer::MixerFifo::Mix(short* samples, unsigned int numSamples,
-                                    bool consider_framelimit)
+u32 CMixer::MixerFifo::Mix(std::array<float, MAX_SAMPLES * 2>& samples, u32 numSamples,
+                           bool consider_framelimit)
 {
-  unsigned int currentSample = 0;
+  u32 currentSample = 0;
 
   // Cache access in non-volatile variable
   // This is the only function changing the read value, so it's safe to
@@ -38,8 +51,8 @@ unsigned int CMixer::MixerFifo::Mix(short* samples, unsigned int numSamples,
   // so we will just ignore new written data while interpolating.
   // Without this cache, the compiler wouldn't be allowed to optimize the
   // interpolation loop.
-  u32 indexR = m_indexR.load();
-  u32 indexW = m_indexW.load();
+  u32 indexR = m_shorts.LoadTail();
+  u32 indexW = m_shorts.LoadHead();
 
   u32 low_waterwark = m_input_sample_rate * SConfig::GetInstance().iTimingVariance / 1000;
   low_waterwark = std::min(low_waterwark, MAX_SAMPLES / 2);
@@ -47,10 +60,7 @@ unsigned int CMixer::MixerFifo::Mix(short* samples, unsigned int numSamples,
   float numLeft = (float)(((indexW - indexR) & INDEX_MASK) / 2);
   m_numLeftI = (numLeft + m_numLeftI * (CONTROL_AVG - 1)) / CONTROL_AVG;
   float offset = (m_numLeftI - low_waterwark) * CONTROL_FACTOR;
-  if (offset > MAX_FREQ_SHIFT)
-    offset = MAX_FREQ_SHIFT;
-  if (offset < -MAX_FREQ_SHIFT)
-    offset = -MAX_FREQ_SHIFT;
+  offset = MathUtil::Clamp(offset, (float)-MAX_FREQ_SHIFT, (float)MAX_FREQ_SHIFT);
 
   // render numleft sample pairs to samples[]
   // advance indexR with sample position
@@ -60,154 +70,141 @@ unsigned int CMixer::MixerFifo::Mix(short* samples, unsigned int numSamples,
   float aid_sample_rate = m_input_sample_rate + offset;
   if (consider_framelimit && emulationspeed > 0.0f)
   {
-    aid_sample_rate = aid_sample_rate * emulationspeed;
+    aid_sample_rate *= emulationspeed;
   }
 
-  const u32 ratio = (u32)(65536.0f * aid_sample_rate / (float)m_mixer->m_sampleRate);
+  const float ratio = aid_sample_rate / (float)m_mixer->m_output_sample_rate;
 
-  s32 lvolume = m_LVolume.load();
-  s32 rvolume = m_RVolume.load();
+  float lvolume = (float)m_LVolume.load() / 256.f;
+  float rvolume = (float)m_RVolume.load() / 256.f;
 
-  // TODO: consider a higher-quality resampling algorithm.
+  u32 floatI = m_floats.LoadHead();
+
+  // Since we know that samples come in two-channel pairs,
+  // might as well unroll a bit
+  for (; ((indexW - floatI) & INDEX_MASK) > 0; floatI += 2)
+  {
+    m_floats[floatI] = MathUtil::SignedShortToFloat(Common::swap16(m_shorts[floatI]));
+    m_floats[floatI + 1] = MathUtil::SignedShortToFloat(Common::swap16(m_shorts[floatI + 1]));
+  }
+
+  m_floats.StoreHead(floatI);
+
+  const float rho = 1.f / ratio;  // since Interpolate takes out_rate / in_rate
+
+  // Resampling loop
   for (; currentSample < numSamples * 2 && ((indexW - indexR) & INDEX_MASK) > 2; currentSample += 2)
   {
-    u32 indexR2 = indexR + 2;  // next sample
+    float sample_l, sample_r;
+    m_filter->ConvolveStereo(m_floats, indexR, &sample_l, &sample_r, m_frac, rho);
 
-    s16 l1 = Common::swap16(m_buffer[indexR & INDEX_MASK]);   // current
-    s16 l2 = Common::swap16(m_buffer[indexR2 & INDEX_MASK]);  // next
-    int sampleL = ((l1 << 16) + (l2 - l1) * (u16)m_frac) >> 16;
-    sampleL = (sampleL * lvolume) >> 8;
-    sampleL += samples[currentSample + 1];
-    samples[currentSample + 1] = MathUtil::Clamp(sampleL, -32767, 32767);
-
-    s16 r1 = Common::swap16(m_buffer[(indexR + 1) & INDEX_MASK]);   // current
-    s16 r2 = Common::swap16(m_buffer[(indexR2 + 1) & INDEX_MASK]);  // next
-    int sampleR = ((r1 << 16) + (r2 - r1) * (u16)m_frac) >> 16;
-    sampleR = (sampleR * rvolume) >> 8;
-    sampleR += samples[currentSample];
-    samples[currentSample] = MathUtil::Clamp(sampleR, -32767, 32767);
+    samples[currentSample] += sample_r * rvolume;
+    samples[currentSample + 1] += sample_l * lvolume;
 
     m_frac += ratio;
-    indexR += 2 * (u16)(m_frac >> 16);
-    m_frac &= 0xffff;
+    indexR += 2 * (s32)m_frac;
+    m_frac -= (s32)m_frac;
   }
 
   // Padding
-  short s[2];
-  s[0] = Common::swap16(m_buffer[(indexR - 1) & INDEX_MASK]);
-  s[1] = Common::swap16(m_buffer[(indexR - 2) & INDEX_MASK]);
-  s[0] = (s[0] * rvolume) >> 8;
-  s[1] = (s[1] * lvolume) >> 8;
+  float s[2];
+  s[0] = m_floats[indexR - 1] * rvolume;
+  s[1] = m_floats[indexR - 2] * lvolume;
+
   for (; currentSample < numSamples * 2; currentSample += 2)
   {
-    int sampleR = MathUtil::Clamp(s[0] + samples[currentSample + 0], -32767, 32767);
-    int sampleL = MathUtil::Clamp(s[1] + samples[currentSample + 1], -32767, 32767);
-
-    samples[currentSample + 0] = sampleR;
-    samples[currentSample + 1] = sampleL;
+    samples[currentSample] += s[0];
+    samples[currentSample + 1] += s[1];
   }
 
   // Flush cached variable
-  m_indexR.store(indexR);
+  m_shorts.StoreTail(indexR);
 
   return numSamples;
 }
 
-unsigned int CMixer::Mix(short* samples, unsigned int num_samples, bool consider_framelimit)
+u32 CMixer::Mix(s16* samples, u32 num_samples, bool consider_framelimit)
 {
   if (!samples)
     return 0;
 
-  memset(samples, 0, num_samples * 2 * sizeof(short));
+  memset(samples, 0, num_samples * 2 * sizeof(s16));
+  std::fill_n(m_accumulator.begin(), num_samples * 2, 0.f);
 
-  m_dma_mixer.Mix(samples, num_samples, consider_framelimit);
-  m_streaming_mixer.Mix(samples, num_samples, consider_framelimit);
-  m_wiimote_speaker_mixer.Mix(samples, num_samples, consider_framelimit);
+  m_dma_mixer->Mix(m_accumulator, num_samples, consider_framelimit);
+  m_streaming_mixer->Mix(m_accumulator, num_samples, consider_framelimit);
+
+  for (std::unique_ptr<CMixer::MixerFifo>& wiimote_mixer : m_wiimote_speaker_mixers)
+  {
+    if (wiimote_mixer)
+      wiimote_mixer->Mix(m_accumulator, num_samples, consider_framelimit);
+  }
+
+  m_dither->ProcessStereo(m_accumulator.data(), samples, num_samples);
+
   return num_samples;
 }
 
-void CMixer::MixerFifo::PushSamples(const short* samples, unsigned int num_samples)
+void CMixer::MixerFifo::PushSamples(const s16* samples, u32 num_samples)
 {
-  // Cache access in non-volatile variable
-  // indexR isn't allowed to cache in the audio throttling loop as it
-  // needs to get updates to not deadlock.
-  u32 indexW = m_indexW.load();
-
-  // Check if we have enough free space
-  // indexW == m_indexR results in empty buffer, so indexR must always be smaller than indexW
-  if (num_samples * 2 + ((indexW - m_indexR.load()) & INDEX_MASK) >= MAX_SAMPLES * 2)
-    return;
-
-  // AyuanX: Actual re-sampling work has been moved to sound thread
-  // to alleviate the workload on main thread
-  // and we simply store raw data here to make fast mem copy
-  int over_bytes = num_samples * 4 - (MAX_SAMPLES * 2 - (indexW & INDEX_MASK)) * sizeof(short);
-  if (over_bytes > 0)
-  {
-    memcpy(&m_buffer[indexW & INDEX_MASK], samples, num_samples * 4 - over_bytes);
-    memcpy(&m_buffer[0], samples + (num_samples * 4 - over_bytes) / sizeof(short), over_bytes);
-  }
-  else
-  {
-    memcpy(&m_buffer[indexW & INDEX_MASK], samples, num_samples * 4);
-  }
-
-  m_indexW.fetch_add(num_samples * 2);
+  // Ringbuffer write
+  m_shorts.Write(samples, num_samples * 2);
 }
 
-void CMixer::PushSamples(const short* samples, unsigned int num_samples)
+void CMixer::PushSamples(const s16* samples, u32 num_samples)
 {
-  m_dma_mixer.PushSamples(samples, num_samples);
-  int sample_rate = m_dma_mixer.GetInputSampleRate();
+  m_dma_mixer->PushSamples(samples, num_samples);
+  int sample_rate = m_dma_mixer->GetInputSampleRate();
   if (m_log_dsp_audio)
     m_wave_writer_dsp.AddStereoSamplesBE(samples, num_samples, sample_rate);
 }
 
-void CMixer::PushStreamingSamples(const short* samples, unsigned int num_samples)
+void CMixer::PushStreamingSamples(const s16* samples, u32 num_samples)
 {
-  m_streaming_mixer.PushSamples(samples, num_samples);
-  int sample_rate = m_streaming_mixer.GetInputSampleRate();
+  m_streaming_mixer->PushSamples(samples, num_samples);
+  int sample_rate = m_streaming_mixer->GetInputSampleRate();
   if (m_log_dtk_audio)
     m_wave_writer_dtk.AddStereoSamplesBE(samples, num_samples, sample_rate);
 }
 
-void CMixer::PushWiimoteSpeakerSamples(const short* samples, unsigned int num_samples,
-                                       unsigned int sample_rate)
+void CMixer::PushWiimoteSpeakerSamples(u32 wiimote_index, const s16* samples, u32 num_samples,
+                                       u32 sample_rate)
 {
-  short samples_stereo[MAX_SAMPLES * 2];
+  s16 samples_stereo[MAX_SAMPLES * 2];
 
-  if (num_samples < MAX_SAMPLES)
+  if (num_samples < MAX_SAMPLES && m_wiimote_speaker_mixers[wiimote_index])
   {
-    m_wiimote_speaker_mixer.SetInputSampleRate(sample_rate);
+    m_wiimote_speaker_mixers[wiimote_index]->SetInputSampleRate(sample_rate);
 
-    for (unsigned int i = 0; i < num_samples; ++i)
+    for (u32 i = 0; i < num_samples; ++i)
     {
       samples_stereo[i * 2] = Common::swap16(samples[i]);
       samples_stereo[i * 2 + 1] = Common::swap16(samples[i]);
     }
 
-    m_wiimote_speaker_mixer.PushSamples(samples_stereo, num_samples);
+    m_wiimote_speaker_mixers[wiimote_index]->PushSamples(samples_stereo, num_samples);
   }
 }
 
-void CMixer::SetDMAInputSampleRate(unsigned int rate)
+void CMixer::SetDMAInputSampleRate(u32 rate)
 {
-  m_dma_mixer.SetInputSampleRate(rate);
+  m_dma_mixer->SetInputSampleRate(rate);
 }
 
-void CMixer::SetStreamInputSampleRate(unsigned int rate)
+void CMixer::SetStreamInputSampleRate(u32 rate)
 {
-  m_streaming_mixer.SetInputSampleRate(rate);
+  m_streaming_mixer->SetInputSampleRate(rate);
 }
 
-void CMixer::SetStreamingVolume(unsigned int lvolume, unsigned int rvolume)
+void CMixer::SetStreamingVolume(u32 lvolume, u32 rvolume)
 {
-  m_streaming_mixer.SetVolume(lvolume, rvolume);
+  m_streaming_mixer->SetVolume(lvolume, rvolume);
 }
 
-void CMixer::SetWiimoteSpeakerVolume(unsigned int lvolume, unsigned int rvolume)
+void CMixer::SetWiimoteSpeakerVolume(u32 wiimote_index, u32 lvolume, u32 rvolume)
 {
-  m_wiimote_speaker_mixer.SetVolume(lvolume, rvolume);
+  if (m_wiimote_speaker_mixers[wiimote_index])
+    m_wiimote_speaker_mixers[wiimote_index]->SetVolume(lvolume, rvolume);
 }
 
 void CMixer::StartLogDTKAudio(const std::string& filename)
@@ -215,7 +212,7 @@ void CMixer::StartLogDTKAudio(const std::string& filename)
   if (!m_log_dtk_audio)
   {
     m_log_dtk_audio = true;
-    m_wave_writer_dtk.Start(filename, m_streaming_mixer.GetInputSampleRate());
+    m_wave_writer_dtk.Start(filename, m_streaming_mixer->GetInputSampleRate());
     m_wave_writer_dtk.SetSkipSilence(false);
     NOTICE_LOG(AUDIO, "Starting DTK Audio logging");
   }
@@ -244,7 +241,7 @@ void CMixer::StartLogDSPAudio(const std::string& filename)
   if (!m_log_dsp_audio)
   {
     m_log_dsp_audio = true;
-    m_wave_writer_dsp.Start(filename, m_dma_mixer.GetInputSampleRate());
+    m_wave_writer_dsp.Start(filename, m_dma_mixer->GetInputSampleRate());
     m_wave_writer_dsp.SetSkipSilence(false);
     NOTICE_LOG(AUDIO, "Starting DSP Audio logging");
   }
@@ -268,18 +265,18 @@ void CMixer::StopLogDSPAudio()
   }
 }
 
-void CMixer::MixerFifo::SetInputSampleRate(unsigned int rate)
+void CMixer::MixerFifo::SetInputSampleRate(u32 rate)
 {
   m_input_sample_rate = rate;
 }
 
-unsigned int CMixer::MixerFifo::GetInputSampleRate() const
+u32 CMixer::MixerFifo::GetInputSampleRate() const
 {
   return m_input_sample_rate;
 }
 
-void CMixer::MixerFifo::SetVolume(unsigned int lvolume, unsigned int rvolume)
+void CMixer::MixerFifo::SetVolume(u32 lvolume, u32 rvolume)
 {
-  m_LVolume.store(lvolume + (lvolume >> 7));
-  m_RVolume.store(rvolume + (rvolume >> 7));
+  m_LVolume.store(lvolume);
+  m_RVolume.store(rvolume);
 }

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -7,28 +7,30 @@
 #include <array>
 #include <atomic>
 
+#include "AudioCommon/BaseFilter.h"
+#include "AudioCommon/Dither.h"
 #include "AudioCommon/WaveFile.h"
 #include "Common/CommonTypes.h"
+#include "Common/RingBuffer.h"
 
 class CMixer final
 {
 public:
-  explicit CMixer(unsigned int BackendSampleRate);
-  ~CMixer();
-
+  explicit CMixer(u32 BackendSampleRate);
+  ~CMixer() {}
   // Called from audio threads
-  unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit = true);
+  u32 Mix(s16* samples, u32 numSamples, bool consider_framelimit = true);
 
   // Called from main thread
-  void PushSamples(const short* samples, unsigned int num_samples);
-  void PushStreamingSamples(const short* samples, unsigned int num_samples);
-  void PushWiimoteSpeakerSamples(const short* samples, unsigned int num_samples,
-                                 unsigned int sample_rate);
-  unsigned int GetSampleRate() const { return m_sampleRate; }
-  void SetDMAInputSampleRate(unsigned int rate);
-  void SetStreamInputSampleRate(unsigned int rate);
-  void SetStreamingVolume(unsigned int lvolume, unsigned int rvolume);
-  void SetWiimoteSpeakerVolume(unsigned int lvolume, unsigned int rvolume);
+  void PushSamples(const s16* samples, u32 num_samples);
+  void PushStreamingSamples(const s16* samples, u32 num_samples);
+  void PushWiimoteSpeakerSamples(u32 wiimote_index, const s16* samples, u32 num_samples,
+                                 u32 sample_rate);
+  u32 GetSampleRate() const { return m_output_sample_rate; }
+  void SetDMAInputSampleRate(u32 rate);
+  void SetStreamInputSampleRate(u32 rate);
+  void SetStreamingVolume(u32 lvolume, u32 rvolume);
+  void SetWiimoteSpeakerVolume(u32 wiimote_index, u32 lvolume, u32 rvolume);
 
   void StartLogDTKAudio(const std::string& filename);
   void StopLogDTKAudio();
@@ -45,42 +47,54 @@ private:
   static constexpr float CONTROL_FACTOR = 0.2f;
   static constexpr u32 CONTROL_AVG = 32;  // In freq_shift per FIFO size offset
 
-  class MixerFifo final
+  class MixerFifo
   {
   public:
-    MixerFifo(CMixer* mixer, unsigned sample_rate)
-        : m_mixer(mixer), m_input_sample_rate(sample_rate)
+    MixerFifo(CMixer* mixer, unsigned sample_rate, std::shared_ptr<BaseFilter> filter = nullptr)
+        : m_mixer(mixer), m_filter(std::move(filter)), m_input_sample_rate(sample_rate)
     {
+      m_floats.Resize(MAX_SAMPLES * 2);
+      m_shorts.Resize(MAX_SAMPLES * 2);
     }
-    void PushSamples(const short* samples, unsigned int num_samples);
-    unsigned int Mix(short* samples, unsigned int numSamples, bool consider_framelimit = true);
-    void SetInputSampleRate(unsigned int rate);
-    unsigned int GetInputSampleRate() const;
-    void SetVolume(unsigned int lvolume, unsigned int rvolume);
+
+    void PushSamples(const s16* samples, u32 num_samples);
+    u32 Mix(std::array<float, MAX_SAMPLES * 2>& samples, u32 numSamples,
+            bool consider_framelimit = true);
+    void SetInputSampleRate(u32 rate);
+    u32 GetInputSampleRate() const;
+    void SetVolume(u32 lvolume, u32 rvolume);
 
   private:
     CMixer* m_mixer;
+    std::shared_ptr<BaseFilter> m_filter;
+    RingBuffer<float> m_floats;
+    RingBuffer<s16> m_shorts;
+
     unsigned m_input_sample_rate;
-    std::array<short, MAX_SAMPLES * 2> m_buffer{};
-    std::atomic<u32> m_indexW{0};
-    std::atomic<u32> m_indexR{0};
+
+    float m_numLeftI = 0.0f;
+    float m_frac = 0;
     // Volume ranges from 0-256
     std::atomic<s32> m_LVolume{256};
     std::atomic<s32> m_RVolume{256};
-    float m_numLeftI = 0.0f;
-    u32 m_frac = 0;
   };
-  MixerFifo m_dma_mixer{this, 32000};
-  MixerFifo m_streaming_mixer{this, 48000};
-  MixerFifo m_wiimote_speaker_mixer{this, 3000};
-  unsigned int m_sampleRate;
+
+  std::array<float, MAX_SAMPLES * 2> m_accumulator{};
+
+  std::unique_ptr<MixerFifo> m_dma_mixer;
+  std::unique_ptr<MixerFifo> m_streaming_mixer;
+  std::array<std::unique_ptr<MixerFifo>, 4>
+      m_wiimote_speaker_mixers;  // max # wiimotes = 4, one mixer per wiimote
+  std::unique_ptr<Dither> m_dither;
 
   WaveFileWriter m_wave_writer_dtk;
   WaveFileWriter m_wave_writer_dsp;
+  WaveFileWriter m_wave_writer_debug;
 
   bool m_log_dtk_audio = false;
   bool m_log_dsp_audio = false;
 
+  u32 m_output_sample_rate;
   // Current rate of emulation (1.0 = 100% speed)
   std::atomic<float> m_speed{0.0f};
 };

--- a/Source/Core/AudioCommon/WaveFile.cpp
+++ b/Source/Core/AudioCommon/WaveFile.cpp
@@ -137,3 +137,46 @@ void WaveFileWriter::AddStereoSamplesBE(const short* sample_data, u32 count, int
   file.WriteBytes(conv_buffer.data(), count * 4);
   audio_size += count * 4;
 }
+
+void WaveFileWriter::AddStereoSamplesLE(const short* sample_data, u32 count, int sample_rate)
+{
+  if (!file)
+    PanicAlertT("WaveFileWriter - file not open.");
+
+  if (count > BUFFER_SIZE * 2)
+    PanicAlert("WaveFileWriter - buffer too small (count = %u).", count);
+
+  if (skip_silence)
+  {
+    bool all_zero = true;
+
+    for (u32 i = 0; i < count * 2; i++)
+    {
+      if (sample_data[i])
+        all_zero = false;
+    }
+
+    if (all_zero)
+      return;
+  }
+
+  for (u32 i = 0; i < count; i++)
+  {
+    // Channels don't need to be flipped for LE
+    conv_buffer[2 * i] = sample_data[2 * i];
+    conv_buffer[2 * i + 1] = sample_data[2 * i + 1];
+  }
+
+  if (sample_rate != current_sample_rate)
+  {
+    Stop();
+    file_index++;
+    std::stringstream filename;
+    filename << File::GetUserPath(D_DUMPAUDIO_IDX) << basename << file_index << ".wav";
+    Start(filename.str(), sample_rate);
+    current_sample_rate = sample_rate;
+  }
+
+  file.WriteBytes(conv_buffer.data(), count * 4);
+  audio_size += count * 4;
+}

--- a/Source/Core/AudioCommon/WaveFile.h
+++ b/Source/Core/AudioCommon/WaveFile.h
@@ -31,6 +31,7 @@ public:
 
   void SetSkipSilence(bool skip) { skip_silence = skip; }
   void AddStereoSamplesBE(const short* sample_data, u32 count, int sample_rate);  // big endian
+  void AddStereoSamplesLE(const short* sample_data, u32 count, int sample_rate);
   u32 GetAudioSize() const { return audio_size; }
 private:
   static constexpr size_t BUFFER_SIZE = 32 * 1024;

--- a/Source/Core/AudioCommon/WaveFile.h
+++ b/Source/Core/AudioCommon/WaveFile.h
@@ -30,8 +30,7 @@ public:
   void Stop();
 
   void SetSkipSilence(bool skip) { skip_silence = skip; }
-  void AddStereoSamplesBE(const short* sample_data, u32 count, int sample_rate);  // big endian
-  void AddStereoSamplesLE(const short* sample_data, u32 count, int sample_rate);
+  void AddStereoSamples(const short* sample_data, u32 count, int sample_rate, bool big_endian);
   u32 GetAudioSize() const { return audio_size; }
 private:
   static constexpr size_t BUFFER_SIZE = 32 * 1024;

--- a/Source/Core/AudioCommon/WindowedSincFilter.cpp
+++ b/Source/Core/AudioCommon/WindowedSincFilter.cpp
@@ -4,6 +4,22 @@
 
 #include "AudioCommon/WindowedSincFilter.h"
 
+#include <cmath>
+
+// makes sure num_crossings is odd; there are no restrictions on samples_per_crossing
+// cutoff frequency must be below nyquist (which we are counting as 1.0)
+WindowedSincFilter::WindowedSincFilter(u32 num_crossings, u32 samples_per_crossing,
+                                       float cutoff_cycle, float beta)
+    : BaseFilter(num_crossings / 2), m_samples_per_crossing(samples_per_crossing),
+      m_wing_size(samples_per_crossing * (num_crossings / 2)),
+      m_cutoff_cycle(std::min(cutoff_cycle, 1.f)), m_kaiser_beta(beta)
+{
+  m_coeffs.resize(m_wing_size);
+  m_deltas.resize(m_wing_size);
+  PopulateFilterCoeffs();
+  PopulateFilterDeltas();
+}
+
 // iteratively generates zero-order modified Bessel function of the first kind
 // stop when improvements fall below threshold
 double WindowedSincFilter::ModBesselZeroth(const double x) const
@@ -14,7 +30,7 @@ double WindowedSincFilter::ModBesselZeroth(const double x) const
   double previous = 1.0;
   do
   {
-    double temp = half_x / (double)factorial_store;
+    double temp = half_x / static_cast<double>(factorial_store);
     temp *= temp;
     previous *= temp;
     factorial_store++;
@@ -25,7 +41,7 @@ double WindowedSincFilter::ModBesselZeroth(const double x) const
 
 void WindowedSincFilter::PopulateFilterDeltas()
 {
-  for (u32 i = 0; i < m_wing_size - 1; ++i)
+  for (size_t i = 0; i < m_wing_size - 1; ++i)
   {
     m_deltas[i] = m_coeffs[i + 1] - m_coeffs[i];
   }
@@ -38,17 +54,19 @@ void WindowedSincFilter::PopulateFilterCoeffs()
   double inv_size = 1.0 / (m_wing_size - 1);
   for (u32 i = 0; i < m_wing_size; ++i)
   {
-    double offset = PI * (double)i / (double)m_samples_per_crossing;
-    double sinc = (offset == 0.f) ? (double)m_cutoff_cycle : sin(offset * m_cutoff_cycle) / offset;
-    double radicand = (double)i * inv_size;
+    double offset = PI * static_cast<double>(i) / static_cast<double>(m_samples_per_crossing);
+    double sinc = (offset == 0.f) ? static_cast<double>(m_cutoff_cycle) :
+                                    sin(offset * m_cutoff_cycle) / offset;
+    double radicand = static_cast<double>(i) * inv_size;
     radicand = 1.0 - radicand * radicand;
     // apply Kaiser window to sinc
-    m_coeffs[i] = (float)(sinc * ModBesselZeroth(m_kaiser_beta * sqrt(radicand)) * inv_I0_beta);
+    m_coeffs[i] =
+        static_cast<float>(sinc * ModBesselZeroth(m_kaiser_beta * sqrt(radicand)) * inv_I0_beta);
   }
 
   // Scale so that DC signals have unity gain
   double dc_gain = 0;
-  for (u32 i = m_samples_per_crossing; i < m_wing_size; i += m_samples_per_crossing)
+  for (size_t i = m_samples_per_crossing; i < m_wing_size; i += m_samples_per_crossing)
   {
     dc_gain += m_coeffs[i];
   }
@@ -56,14 +74,14 @@ void WindowedSincFilter::PopulateFilterCoeffs()
   dc_gain += m_coeffs[0];
   double inv_dc_gain = 1.0 / dc_gain;
 
-  for (u32 i = 0; i < m_wing_size; ++i)
+  for (size_t i = 0; i < m_wing_size; ++i)
   {
-    m_coeffs[i] = (float)(m_coeffs[i] * inv_dc_gain);
+    m_coeffs[i] = static_cast<float>(m_coeffs[i] * inv_dc_gain);
   }
 }
 
-void WindowedSincFilter::ConvolveStereo(const RingBuffer<float>& input, u32 index, float* output_l,
-                                        float* output_r, const float fraction,
+void WindowedSincFilter::ConvolveStereo(const RingBuffer<float>& input, size_t index,
+                                        float* output_l, float* output_r, const float fraction,
                                         const float ratio) const
 {
   if (ratio >= 1.f)
@@ -72,17 +90,19 @@ void WindowedSincFilter::ConvolveStereo(const RingBuffer<float>& input, u32 inde
     DownSampleStereo(input, index, output_l, output_r, fraction, ratio);
 }
 
-void WindowedSincFilter::UpSampleStereo(const RingBuffer<float>& input, u32 index, float* output_l,
-                                        float* output_r, const float fraction) const
+void WindowedSincFilter::UpSampleStereo(const RingBuffer<float>& input, size_t index,
+                                        float* output_l, float* output_r,
+                                        const float fraction) const
 {
-  float left_channel = 0.0, right_channel = 0.0;
+  float left_channel = 0.0;
+  float right_channel = 0.0;
 
   // Convolve left wing first
   float left_frac = (fraction * m_samples_per_crossing);
-  u32 left_index = (u32)left_frac;
-  left_frac -= (float)left_index;
+  size_t left_index = static_cast<size_t>(left_frac);
+  left_frac -= static_cast<float>(left_index);
 
-  u32 current_index = index - m_num_taps;
+  size_t current_index = index - m_num_taps;
 
   for (; left_index < m_wing_size; left_index += m_samples_per_crossing, current_index -= 2)
   {
@@ -94,7 +114,7 @@ void WindowedSincFilter::UpSampleStereo(const RingBuffer<float>& input, u32 inde
   }
 
   float right_frac = 0.f;
-  u32 right_index = 0;
+  size_t right_index = 0;
   if (fraction == 0.f)
   {
     right_frac = 0.f;
@@ -103,8 +123,8 @@ void WindowedSincFilter::UpSampleStereo(const RingBuffer<float>& input, u32 inde
   else
   {
     right_frac = (1 - fraction) * m_samples_per_crossing;
-    right_index = (u32)right_frac;
-    right_frac -= (float)right_index;
+    right_index = static_cast<size_t>(right_frac);
+    right_frac -= static_cast<float>(right_index);
   }
 
   current_index = index - m_num_taps + 2;
@@ -122,18 +142,19 @@ void WindowedSincFilter::UpSampleStereo(const RingBuffer<float>& input, u32 inde
   *output_r = right_channel;
 }
 
-void WindowedSincFilter::DownSampleStereo(const RingBuffer<float>& input, u32 index,
+void WindowedSincFilter::DownSampleStereo(const RingBuffer<float>& input, size_t index,
                                           float* output_l, float* output_r, const float fraction,
                                           const float ratio) const
 {
-  float left_channel = 0.0, right_channel = 0.0;
+  float left_channel = 0.0;
+  float right_channel = 0.0;
 
   float left_frac = (fraction * m_samples_per_crossing);
   left_frac *= ratio;
-  u32 left_index = (u32)left_frac;
-  left_frac -= (float)left_index;
+  size_t left_index = static_cast<size_t>(left_frac);
+  left_frac -= static_cast<float>(left_index);
 
-  u32 current_index = index - m_num_taps;
+  size_t current_index = index - m_num_taps;
 
   for (; left_index < m_wing_size; current_index -= 2)
   {
@@ -143,26 +164,26 @@ void WindowedSincFilter::DownSampleStereo(const RingBuffer<float>& input, u32 in
     left_channel += input[current_index] * impulse;
     right_channel += input[current_index + 1] * impulse;
 
-    left_frac += (float)left_index;
-    left_frac += ratio * (float)m_samples_per_crossing;
-    left_index = (u32)left_frac;
-    left_frac -= (float)left_index;
+    left_frac += static_cast<float>(left_index);
+    left_frac += ratio * static_cast<float>(m_samples_per_crossing);
+    left_index = static_cast<size_t>(left_frac);
+    left_frac -= static_cast<float>(left_index);
   }
 
   float right_frac = 0.f;
-  u32 right_index = 0;
+  size_t right_index = 0;
   if (fraction == 0.f)
   {
     right_frac = ratio * m_samples_per_crossing;
-    right_index = (u32)right_index;
-    right_frac -= (float)right_index;
+    right_index = static_cast<size_t>(right_index);
+    right_frac -= static_cast<float>(right_index);
   }
   else
   {
     right_frac = (1 - fraction) * m_samples_per_crossing;
     right_frac *= ratio;
-    right_index = (u32)right_frac;
-    right_frac -= (float)right_index;
+    right_index = static_cast<size_t>(right_frac);
+    right_frac -= static_cast<float>(right_index);
   }
 
   current_index = index - m_num_taps + 2;
@@ -175,10 +196,10 @@ void WindowedSincFilter::DownSampleStereo(const RingBuffer<float>& input, u32 in
     left_channel += input[current_index] * impulse;
     right_channel += input[current_index + 1] * impulse;
 
-    right_frac += (float)right_index;
-    right_frac += ratio * (float)m_samples_per_crossing;
-    right_index = (u32)right_frac;
-    right_frac -= (float)right_index;
+    right_frac += static_cast<float>(right_index);
+    right_frac += ratio * static_cast<float>(m_samples_per_crossing);
+    right_index = static_cast<size_t>(right_frac);
+    right_frac -= static_cast<float>(right_index);
   }
 
   *output_l = left_channel;

--- a/Source/Core/AudioCommon/WindowedSincFilter.cpp
+++ b/Source/Core/AudioCommon/WindowedSincFilter.cpp
@@ -1,0 +1,186 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "AudioCommon/WindowedSincFilter.h"
+
+// iteratively generates zero-order modified Bessel function of the first kind
+// stop when improvements fall below threshold
+double WindowedSincFilter::ModBesselZeroth(const double x) const
+{
+  double sum = 1.0;
+  s32 factorial_store = 1;
+  double half_x = x / 2.0;
+  double previous = 1.0;
+  do
+  {
+    double temp = half_x / (double)factorial_store;
+    temp *= temp;
+    previous *= temp;
+    factorial_store++;
+    sum += previous;
+  } while (previous >= BESSEL_EPSILON * sum);
+  return sum;
+}
+
+void WindowedSincFilter::PopulateFilterDeltas()
+{
+  for (u32 i = 0; i < m_wing_size - 1; ++i)
+  {
+    m_deltas[i] = m_coeffs[i + 1] - m_coeffs[i];
+  }
+  m_deltas[m_wing_size - 1] = -m_coeffs[m_wing_size - 1];
+}
+
+void WindowedSincFilter::PopulateFilterCoeffs()
+{
+  double inv_I0_beta = 1.0 / ModBesselZeroth(m_kaiser_beta);
+  double inv_size = 1.0 / (m_wing_size - 1);
+  for (u32 i = 0; i < m_wing_size; ++i)
+  {
+    double offset = PI * (double)i / (double)m_samples_per_crossing;
+    double sinc = (offset == 0.f) ? (double)m_cutoff_cycle : sin(offset * m_cutoff_cycle) / offset;
+    double radicand = (double)i * inv_size;
+    radicand = 1.0 - radicand * radicand;
+    // apply Kaiser window to sinc
+    m_coeffs[i] = (float)(sinc * ModBesselZeroth(m_kaiser_beta * sqrt(radicand)) * inv_I0_beta);
+  }
+
+  // Scale so that DC signals have unity gain
+  double dc_gain = 0;
+  for (u32 i = m_samples_per_crossing; i < m_wing_size; i += m_samples_per_crossing)
+  {
+    dc_gain += m_coeffs[i];
+  }
+  dc_gain *= 2;
+  dc_gain += m_coeffs[0];
+  double inv_dc_gain = 1.0 / dc_gain;
+
+  for (u32 i = 0; i < m_wing_size; ++i)
+  {
+    m_coeffs[i] = (float)(m_coeffs[i] * inv_dc_gain);
+  }
+}
+
+void WindowedSincFilter::ConvolveStereo(const RingBuffer<float>& input, u32 index, float* output_l,
+                                        float* output_r, const float fraction,
+                                        const float ratio) const
+{
+  if (ratio >= 1.f)
+    UpSampleStereo(input, index, output_l, output_r, fraction);
+  else
+    DownSampleStereo(input, index, output_l, output_r, fraction, ratio);
+}
+
+void WindowedSincFilter::UpSampleStereo(const RingBuffer<float>& input, u32 index, float* output_l,
+                                        float* output_r, const float fraction) const
+{
+  float left_channel = 0.0, right_channel = 0.0;
+
+  // Convolve left wing first
+  float left_frac = (fraction * m_samples_per_crossing);
+  u32 left_index = (u32)left_frac;
+  left_frac -= (float)left_index;
+
+  u32 current_index = index - m_num_taps;
+
+  for (; left_index < m_wing_size; left_index += m_samples_per_crossing, current_index -= 2)
+  {
+    float impulse = m_coeffs[left_index];
+    impulse += m_deltas[left_index] * left_frac;
+
+    left_channel += input[current_index] * impulse;
+    right_channel += input[current_index + 1] * impulse;
+  }
+
+  float right_frac = 0.f;
+  u32 right_index = 0;
+  if (fraction == 0.f)
+  {
+    right_frac = 0.f;
+    right_index = m_samples_per_crossing;
+  }
+  else
+  {
+    right_frac = (1 - fraction) * m_samples_per_crossing;
+    right_index = (u32)right_frac;
+    right_frac -= (float)right_index;
+  }
+
+  current_index = index - m_num_taps + 2;
+
+  for (; right_index < m_wing_size; right_index += m_samples_per_crossing, current_index += 2)
+  {
+    float impulse = m_coeffs[right_index];
+    impulse += m_deltas[right_index] * right_frac;
+
+    left_channel += input[current_index] * impulse;
+    right_channel += input[current_index + 1] * impulse;
+  }
+
+  *output_l = left_channel;
+  *output_r = right_channel;
+}
+
+void WindowedSincFilter::DownSampleStereo(const RingBuffer<float>& input, u32 index,
+                                          float* output_l, float* output_r, const float fraction,
+                                          const float ratio) const
+{
+  float left_channel = 0.0, right_channel = 0.0;
+
+  float left_frac = (fraction * m_samples_per_crossing);
+  left_frac *= ratio;
+  u32 left_index = (u32)left_frac;
+  left_frac -= (float)left_index;
+
+  u32 current_index = index - m_num_taps;
+
+  for (; left_index < m_wing_size; current_index -= 2)
+  {
+    float impulse = m_coeffs[left_index];
+    impulse += m_deltas[left_index] * left_frac;
+
+    left_channel += input[current_index] * impulse;
+    right_channel += input[current_index + 1] * impulse;
+
+    left_frac += (float)left_index;
+    left_frac += ratio * (float)m_samples_per_crossing;
+    left_index = (u32)left_frac;
+    left_frac -= (float)left_index;
+  }
+
+  float right_frac = 0.f;
+  u32 right_index = 0;
+  if (fraction == 0.f)
+  {
+    right_frac = ratio * m_samples_per_crossing;
+    right_index = (u32)right_index;
+    right_frac -= (float)right_index;
+  }
+  else
+  {
+    right_frac = (1 - fraction) * m_samples_per_crossing;
+    right_frac *= ratio;
+    right_index = (u32)right_frac;
+    right_frac -= (float)right_index;
+  }
+
+  current_index = index - m_num_taps + 2;
+
+  for (; right_index < m_wing_size; current_index += 2)
+  {
+    float impulse = m_coeffs[right_index];
+    impulse += m_deltas[right_index] * right_frac;
+
+    left_channel += input[current_index] * impulse;
+    right_channel += input[current_index + 1] * impulse;
+
+    right_frac += (float)right_index;
+    right_frac += ratio * (float)m_samples_per_crossing;
+    right_index = (u32)right_frac;
+    right_frac -= (float)right_index;
+  }
+
+  *output_l = left_channel;
+  *output_r = right_channel;
+}

--- a/Source/Core/AudioCommon/WindowedSincFilter.h
+++ b/Source/Core/AudioCommon/WindowedSincFilter.h
@@ -1,0 +1,62 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <vector>
+
+#include "AudioCommon/BaseFilter.h"
+#include "Common/CommonTypes.h"
+
+// Creates kaiser-windowed ideal lowpass filter
+// Generates and stores only one side of the impulse response as it is symmetrical.
+// Thus, when performing convolution, first apply the filter as is stored to samples
+// before current time, and then to samples after.
+class WindowedSincFilter final : public BaseFilter
+{
+public:
+  // Default parameters give medium quality
+  WindowedSincFilter(u32 num_crossings = 17, u32 samples_per_crossing = 512,
+                     float cutoff_cycle = 0.5, float beta = 7.0)
+      : BaseFilter((num_crossings - 1) / 2), m_num_crossings(num_crossings),
+        m_samples_per_crossing(samples_per_crossing),
+        m_wing_size(samples_per_crossing * (num_crossings - 1) / 2), m_cutoff_cycle(cutoff_cycle),
+        m_kaiser_beta(beta)
+  {
+    m_coeffs.resize(m_wing_size);
+    m_deltas.resize(m_wing_size);
+    PopulateFilterCoeffs();
+    PopulateFilterDeltas();
+  }
+
+  ~WindowedSincFilter() {}
+  void ConvolveStereo(const RingBuffer<float>& input, u32 index, float* output_l, float* output_r,
+                      const float fraction, const float ratio) const;
+
+  const u32 m_num_crossings;         // filter taps
+  const u32 m_samples_per_crossing;  // filter resolution
+  const u32 m_wing_size;             // one-sided length of filter
+
+  std::vector<float> m_coeffs;
+  std::vector<float> m_deltas;  // store deltas for interpolating between filter values
+
+private:
+  static constexpr double BESSEL_EPSILON = 1e-21;
+  static constexpr double PI = 3.14159265358979323846;
+
+  void PopulateFilterCoeffs();
+  void PopulateFilterDeltas();
+  double ModBesselZeroth(const double x) const;
+
+  // upsampling is a bit simpler than downsampling so clearer to split into two functions
+  void UpSampleStereo(const RingBuffer<float>& input, u32 index, float* output_l, float* output_r,
+                      const float fraction) const;
+  void DownSampleStereo(const RingBuffer<float>& input, u32 index, float* output_l, float* output_r,
+                        const float fraction, const float ratio) const;
+
+  // cutoff frequency (ratio of nyquist frequency)
+  const float m_cutoff_cycle;
+  // parameter for Kaiser window (tradeoff between main-lobe width and side-lobes levels)
+  const float m_kaiser_beta;
+};

--- a/Source/Core/AudioCommon/WindowedSincFilter.h
+++ b/Source/Core/AudioCommon/WindowedSincFilter.h
@@ -8,38 +8,45 @@
 
 #include "AudioCommon/BaseFilter.h"
 #include "Common/CommonTypes.h"
-
 // Creates kaiser-windowed ideal lowpass filter
 // Generates and stores only one side of the impulse response as it is symmetrical.
 // Thus, when performing convolution, first apply the filter as is stored to samples
 // before current time, and then to samples after.
+//
+// Quality of filter = sharpness of rolloff + attenuation of stopband.
+//
+// num_crossings: affects transition-band-width, the sharper the rolloff, the more taps needed.
+//                also slightly affects stopband ripple magnitude. Quality divisions are subjective.
+//                For example, on the digital audio workstation software Reaper, "Fast" is 17, "Medium"
+//                is 65, "Good" is 193 (suitable for rendering), and "HQ" is 513. The following table
+//                seems more reasonable in the context of the emulator.
+//
+//                Quality:
+//                  low:    < 17
+//                  medium: between 17 and 35
+//                  high:   > 35
+//
+// samples_per_crossing: affects the accuracy of the filter response; this is dependent
+//                       on the bit-length of each filter sample. Since we are also storing
+//                       deltas between filter samples, samples_per_crossing
+//                       should be around 2 ^ (sample_bit_length / 2). In this case,
+//                       since float = 32bit, the minimum is 512.
+//                       Refer to ccrma.standford.edu/~jos/resample/ for analysis
+//
+// beta: parameter for Kaiser window (tradeoff between main-lobe width and side-lobes levels).
+//       This affects the stopband ripple attenuation: 8.0 = about 70db attenuation
+//
+// CCRMA uses 27 taps x 512 samples for high quality.
+//
+// cutoff_cycle: the center of the transition band (in terms of nyquist = samplerate/2);
+//               1.0 gives center of nyquist freq.
 class WindowedSincFilter final : public BaseFilter
 {
 public:
-  // Default parameters give medium quality
-  WindowedSincFilter(u32 num_crossings = 17, u32 samples_per_crossing = 512,
-                     float cutoff_cycle = 0.5, float beta = 7.0)
-      : BaseFilter((num_crossings - 1) / 2), m_num_crossings(num_crossings),
-        m_samples_per_crossing(samples_per_crossing),
-        m_wing_size(samples_per_crossing * (num_crossings - 1) / 2), m_cutoff_cycle(cutoff_cycle),
-        m_kaiser_beta(beta)
-  {
-    m_coeffs.resize(m_wing_size);
-    m_deltas.resize(m_wing_size);
-    PopulateFilterCoeffs();
-    PopulateFilterDeltas();
-  }
-
-  ~WindowedSincFilter() {}
-  void ConvolveStereo(const RingBuffer<float>& input, u32 index, float* output_l, float* output_r,
-                      const float fraction, const float ratio) const;
-
-  const u32 m_num_crossings;         // filter taps
-  const u32 m_samples_per_crossing;  // filter resolution
-  const u32 m_wing_size;             // one-sided length of filter
-
-  std::vector<float> m_coeffs;
-  std::vector<float> m_deltas;  // store deltas for interpolating between filter values
+  WindowedSincFilter(u32 num_crossings, u32 samples_per_crossing, float cutoff_cycle, float beta);
+  ~WindowedSincFilter() = default;
+  void ConvolveStereo(const RingBuffer<float>& input, size_t index, float* output_l,
+                      float* output_r, float fraction, float ratio) const override;
 
 private:
   static constexpr double BESSEL_EPSILON = 1e-21;
@@ -50,13 +57,17 @@ private:
   double ModBesselZeroth(const double x) const;
 
   // upsampling is a bit simpler than downsampling so clearer to split into two functions
-  void UpSampleStereo(const RingBuffer<float>& input, u32 index, float* output_l, float* output_r,
-                      const float fraction) const;
-  void DownSampleStereo(const RingBuffer<float>& input, u32 index, float* output_l, float* output_r,
-                        const float fraction, const float ratio) const;
+  void UpSampleStereo(const RingBuffer<float>& input, size_t index, float* output_l,
+                      float* output_r, const float fraction) const;
+  void DownSampleStereo(const RingBuffer<float>& input, size_t index, float* output_l,
+                        float* output_r, const float fraction, const float ratio) const;
 
-  // cutoff frequency (ratio of nyquist frequency)
-  const float m_cutoff_cycle;
-  // parameter for Kaiser window (tradeoff between main-lobe width and side-lobes levels)
+  const u32 m_samples_per_crossing;  // filter resolution
+  const u32 m_wing_size;             // one-sided length of filter
+
+  const float m_cutoff_cycle;  // cutoff frequency (ratio of samplerate)
   const float m_kaiser_beta;
+
+  std::vector<float> m_coeffs;
+  std::vector<float> m_deltas;  // store deltas for interpolating between filter values
 };

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -123,6 +123,7 @@
     <ClInclude Include="NonCopyable.h" />
     <ClInclude Include="PcapFile.h" />
     <ClInclude Include="Profiler.h" />
+    <ClInclude Include="RingBuffer.h" />
     <ClInclude Include="ScopeGuard.h" />
     <ClInclude Include="SDCardUtil.h" />
     <ClInclude Include="Semaphore.h" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -226,6 +226,7 @@
     <ClInclude Include="NonCopyable.h" />
     <ClInclude Include="Analytics.h" />
     <ClInclude Include="Semaphore.h" />
+    <ClInclude Include="RingBuffer.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BreakPoints.cpp" />

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -48,6 +48,18 @@ constexpr bool IsPow2(u32 imm)
   return (imm & (imm - 1)) == 0;
 }
 
+// Convert s16 to float
+constexpr float SignedShortToFloat(const s16 s)
+{
+  return (s > 0) ? (float)(s / (float)0x7fff) : (float)(s / (float)0x8000);
+}
+
+// Converts float to s16 without rounding
+constexpr s16 FloatToSignedShort(const float f)
+{
+  return (f > 0) ? (s16)(f * 0x7fff) : (s16)(f * 0x8000);
+}
+
 // The most significant bit of the fraction is an is-quiet bit on all architectures we care about.
 
 static const u64 DOUBLE_SIGN = 0x8000000000000000ULL, DOUBLE_EXP = 0x7FF0000000000000ULL,

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -51,13 +51,14 @@ constexpr bool IsPow2(u32 imm)
 // Convert s16 to float
 constexpr float SignedShortToFloat(const s16 s)
 {
-  return (s > 0) ? (float)(s / (float)0x7fff) : (float)(s / (float)0x8000);
+  return static_cast<float>((s > 0) ? (s / static_cast<float>(0x7fff)) :
+                                      (s / static_cast<float>(0x8000)));
 }
 
 // Converts float to s16 without rounding
 constexpr s16 FloatToSignedShort(const float f)
 {
-  return (f > 0) ? (s16)(f * 0x7fff) : (s16)(f * 0x8000);
+  return static_cast<s16>((f > 0) ? (f * 0x7fff) : (f * 0x8000));
 }
 
 // The most significant bit of the fraction is an is-quiet bit on all architectures we care about.
@@ -215,6 +216,13 @@ inline int IntLog2(u64 val)
   }
   return result;
 #endif
+}
+
+// returns a number greater than or equal to val that is also a power of 2.
+// 0 technically undefined, but return 0.
+inline u64 NextIntPow2(u64 val)
+{
+  return (val <= 1) ? val : (1ull << (IntLog2(val - 1) + 1));
 }
 
 // Tiny matrix/vector library.

--- a/Source/Core/Common/RingBuffer.h
+++ b/Source/Core/Common/RingBuffer.h
@@ -1,0 +1,71 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <vector>
+#include "Common/CommonTypes.h"
+
+// Simple Ring Buffer class.
+// Only implemented bulk data writing.
+// Add functions as necessary.
+
+template <class T>
+class RingBuffer
+{
+public:
+  RingBuffer() : m_size(0), m_mask(0) {}
+  RingBuffer(u32 size) : m_size(size), m_mask(size - 1) { m_data.resize(size); }
+  ~RingBuffer() {}
+  // Resize resets head and tail
+  void Resize(u32 size)
+  {
+    m_size = size;
+    m_mask = size - 1;
+    m_data.resize(size);
+    m_head.store(0);
+    m_tail.store(0);
+  }
+
+  T& operator[](u32 pos) { return m_data[pos & m_mask]; }
+  constexpr const T& operator[](u32 pos) const { return m_data[pos & m_mask]; }
+  void Write(const T* source, u32 length)
+  {
+    u32 head = m_head.load();
+    if (length + ((head - m_tail.load()) & m_mask) >= m_size)
+      return;  // if writing data will cause head to overtake tail, exit
+               // don't know if this is best default behavior...
+               // maybe write up to tail would be better?
+
+    // calculate if we need wraparound
+    s32 over = length - (m_size - (head & m_mask));
+
+    if (over > 0)
+    {
+      memcpy(&m_data[head & m_mask], source, (length - over) * sizeof(T));
+      memcpy(&m_data[0], source + (length - over), over * sizeof(T));
+    }
+    else
+    {
+      memcpy(&m_data[head & m_mask], source, length * sizeof(T));
+    }
+
+    m_head.fetch_add(length);
+  }
+
+  u32 LoadHead() const { return m_head.load(); }
+  u32 LoadTail() const { return m_tail.load(); }
+  void StoreHead(const u32 pos) { m_head.store(pos); }
+  void FetchAddTail(const u32 count) { m_tail.fetch_add(count); }
+  void StoreTail(const u32 pos) { m_tail.store(pos); }
+  u32 m_size;
+  u32 m_mask;
+
+private:
+  std::vector<T> m_data;
+  std::atomic<u32> m_head{0};
+  std::atomic<u32> m_tail{0};
+};

--- a/Source/Core/Common/RingBuffer.h
+++ b/Source/Core/Common/RingBuffer.h
@@ -6,66 +6,68 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstring>
 #include <vector>
-#include "Common/CommonTypes.h"
+
+#include "Common/MathUtil.h"
 
 // Simple Ring Buffer class.
+// Since we use bitwise & for circularity for speed, m_max_size will be adjusted to power of 2.
 // Only implemented bulk data writing.
 // Add functions as necessary.
-
 template <class T>
 class RingBuffer
 {
 public:
-  RingBuffer() : m_size(0), m_mask(0) {}
-  RingBuffer(u32 size) : m_size(size), m_mask(size - 1) { m_data.resize(size); }
-  ~RingBuffer() {}
-  // Resize resets head and tail
-  void Resize(u32 size)
+  RingBuffer() = default;
+  explicit RingBuffer(size_t max_size) : m_max_size(NextIntPow2(max_size)), m_mask(m_max_size - 1)
   {
-    m_size = size;
-    m_mask = size - 1;
-    m_data.resize(size);
+    m_data.resize(m_max_size);
+  }
+  ~RingBuffer() = default;
+  // Resize resets head and tail
+  void Resize(size_t max_size)
+  {
+    m_max_size = NextIntPow2(max_size);
+    m_mask = m_max_size - 1;
+    m_data.resize(m_max_size);
     m_head.store(0);
     m_tail.store(0);
   }
 
-  T& operator[](u32 pos) { return m_data[pos & m_mask]; }
-  constexpr const T& operator[](u32 pos) const { return m_data[pos & m_mask]; }
-  void Write(const T* source, u32 length)
+  T& operator[](size_t pos) { return m_data[pos & m_mask]; }
+  const T operator[](size_t pos) const { return m_data[pos & m_mask]; }
+  // will only write up to tail if write length is too big
+  void Write(const T* source, size_t length)
   {
-    u32 head = m_head.load();
-    if (length + ((head - m_tail.load()) & m_mask) >= m_size)
-      return;  // if writing data will cause head to overtake tail, exit
-               // don't know if this is best default behavior...
-               // maybe write up to tail would be better?
-
+    size_t head = m_head.load();
+    size_t adjusted = std::min(length, m_max_size - (head - m_tail.load()));
     // calculate if we need wraparound
-    s32 over = length - (m_size - (head & m_mask));
-
+    signed long long over = adjusted - (m_max_size - (head & m_mask));
     if (over > 0)
     {
-      memcpy(&m_data[head & m_mask], source, (length - over) * sizeof(T));
-      memcpy(&m_data[0], source + (length - over), over * sizeof(T));
+      memcpy(&m_data[head & m_mask], source, (adjusted - over) * sizeof(T));
+      memcpy(&m_data[0], source + (adjusted - over), over * sizeof(T));
     }
     else
     {
-      memcpy(&m_data[head & m_mask], source, length * sizeof(T));
+      memcpy(&m_data[head & m_mask], source, adjusted * sizeof(T));
     }
-
-    m_head.fetch_add(length);
+    m_head.fetch_add(adjusted);
   }
 
-  u32 LoadHead() const { return m_head.load(); }
-  u32 LoadTail() const { return m_tail.load(); }
-  void StoreHead(const u32 pos) { m_head.store(pos); }
-  void FetchAddTail(const u32 count) { m_tail.fetch_add(count); }
-  void StoreTail(const u32 pos) { m_tail.store(pos); }
-  u32 m_size;
-  u32 m_mask;
-
+  size_t LoadHead() const { return m_head.load(); }
+  size_t LoadTail() const { return m_tail.load(); }
+  void StoreHead(const size_t pos) { m_head.store(pos); }
+  void FetchAddTail(const size_t count) { m_tail.fetch_add(count); }
+  void StoreTail(const size_t pos) { m_tail.store(pos); }
+  size_t MaxSize() const { return m_max_size; }
+  size_t Mask() const { return m_mask; }
 private:
   std::vector<T> m_data;
-  std::atomic<u32> m_head{0};
-  std::atomic<u32> m_tail{0};
+  std::atomic<size_t> m_head{0};
+  std::atomic<size_t> m_tail{0};
+
+  size_t m_max_size;
+  size_t m_mask;
 };

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -122,17 +122,14 @@ void Wiimote::SpeakerData(wm_speaker_data* sd)
   unsigned int left_volume = (unsigned int)((128 + vol) * speaker_volume_ratio);
   unsigned int right_volume = (unsigned int)((128 - vol) * speaker_volume_ratio);
 
-  if (left_volume > 255)
-    left_volume = 255;
-  if (right_volume > 255)
-    right_volume = 255;
+  left_volume = std::min(left_volume, 256u);
+  right_volume = std::min(right_volume, 256u);
 
-  g_sound_stream->GetMixer()->SetWiimoteSpeakerVolume(left_volume, right_volume);
+  g_sound_stream->GetMixer()->SetWiimoteSpeakerVolume(m_index, left_volume, right_volume);
 
   // ADPCM sample rate is thought to be x2.(3000 x2 = 6000).
-  g_sound_stream->GetMixer()->PushWiimoteSpeakerSamples(samples.get(), sample_length,
+  g_sound_stream->GetMixer()->PushWiimoteSpeakerSamples(m_index, samples.get(), sample_length,
                                                         sample_rate * 2);
-
 #ifdef WIIMOTE_SPEAKER_DUMP
   static int num = 0;
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -289,7 +289,7 @@ Wiimote::Wiimote(const unsigned int index)
   m_options->boolean_settings.emplace_back(std::make_unique<ControlGroup::BooleanSetting>(
       _trans("Iterative Input"), false, ControlGroup::SettingType::VIRTUAL));
   m_options->numeric_settings.emplace_back(
-      std::make_unique<ControlGroup::NumericSetting>(_trans("Speaker Pan"), 0, -127, 127));
+      std::make_unique<ControlGroup::NumericSetting>(_trans("Speaker Pan"), 0, -128, 128));
   m_options->numeric_settings.emplace_back(
       std::make_unique<ControlGroup::NumericSetting>(_trans("Battery"), 95.0 / 100, 0, 255));
 

--- a/Source/UnitTests/Common/MathUtilTest.cpp
+++ b/Source/UnitTests/Common/MathUtilTest.cpp
@@ -45,6 +45,20 @@ TEST(MathUtil, IntLog2)
   EXPECT_EQ(63, IntLog2(0xFFFFFFFFFFFFFFFFull));
 }
 
+TEST(MathUtil, NextIntPow2)
+{
+  EXPECT_EQ(0, NextIntPow2(0));
+  EXPECT_EQ(1, NextIntPow2(1));
+  EXPECT_EQ(2, NextIntPow2(2));
+  EXPECT_EQ(4, NextIntPow2(3));
+  EXPECT_EQ(4, NextIntPow2(4));
+  EXPECT_EQ(8, NextIntPow2(5));
+  EXPECT_EQ(16, NextIntPow2(15));
+  EXPECT_EQ(256, NextIntPow2(240));
+  EXPECT_EQ(65536, NextIntPow2(48560));
+  EXPECT_EQ(0x1000000000000000ull, NextIntPow2(0x0FFFFFFFFFFFFFFFull));
+}
+
 TEST(MathUtil, FlushToZero)
 {
   // To test the software implementation we need to make sure FTZ and DAZ are disabled.

--- a/Source/UnitTests/RingBufferTest.cpp
+++ b/Source/UnitTests/RingBufferTest.cpp
@@ -1,0 +1,111 @@
+// Copyright 2014 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <array>
+#include <gtest/gtest.h>
+
+#include "Common/RingBuffer.h"
+
+TEST(RingBuffer, RingBuffer)
+{
+  //check unitialized ringbuffer
+  RingBuffer<u32> rb;
+
+  EXPECT_EQ(0u, rb.LoadHead());
+  EXPECT_EQ(0u, rb.LoadTail());
+
+  // check resize behavior for a few numbers (and round to next power of 2 size)
+  std::array<size_t, 3> query_sizes{ {1000, 512, 10} };
+  std::array<size_t, 3> actual_sizes{ {1024, 512, 16} };
+  for (size_t i = 0; i < query_sizes.size(); ++i)
+  {
+    rb.Resize(query_sizes[i]);
+    EXPECT_EQ(actual_sizes[i], rb.MaxSize());
+    EXPECT_EQ(actual_sizes[i] - 1, rb.Mask());
+  }
+
+  // resize should keep head and tail at 0
+  EXPECT_EQ(0u, rb.LoadHead());
+  EXPECT_EQ(0u, rb.LoadTail());
+
+  // check random access and circularity
+  for (size_t i = 0; i < rb.MaxSize(); ++i) {
+    rb[i] = static_cast<u32>(i);
+    EXPECT_EQ(static_cast<u32>(i), rb[i]);
+    EXPECT_EQ(static_cast<u32>(i), rb[i + rb.MaxSize() * i]);
+    rb[i + rb.MaxSize() * i] = static_cast<u32>(i + rb.MaxSize() * i);
+    EXPECT_EQ(static_cast<u32>(i + rb.MaxSize() * i), rb[i]);
+  }
+  // should not affect head and tail
+  EXPECT_EQ(0u, rb.LoadHead());
+  EXPECT_EQ(0u, rb.LoadTail());
+
+  // 0s the array
+  // we don't need to reset head and tail because they haven't been moved
+  std::fill_n(&rb[0], rb.MaxSize(), 0);
+  // should be zeroes
+
+  std::array<u32, 20> ones;
+  std::array<u32, 20> twos;
+  std::array<u32, 20> threes;
+  std::fill_n(ones.begin(), ones.size(), 1);
+  std::fill_n(twos.begin(), ones.size(), 2);
+  std::fill_n(threes.begin(), ones.size(), 3);
+
+  // write 5 items, check
+  // should be: [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+  //             ^tail          ^ head
+  rb.Write(ones.data(), 5);
+  EXPECT_EQ(1u, rb[0]);
+  EXPECT_EQ(1u, rb[4]);
+  EXPECT_EQ(0u, rb[5]);
+  EXPECT_EQ(5u, rb.LoadHead());
+  EXPECT_EQ(0u, rb.LoadTail());
+
+  // write 20 items, but since tail hasn't moved from 0,
+  // should only write 11 items (current head is at 5)
+  // should be: [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+  //             ^tail,head
+  rb.Write(twos.data(), 20);
+  EXPECT_EQ(16u, rb.LoadHead());
+  EXPECT_EQ(2u, rb[rb.LoadHead() - 1]);
+  EXPECT_EQ(1u, rb[rb.LoadHead()]);
+
+  // test store tail
+  rb.StoreTail(5);
+  EXPECT_EQ(5u, rb.LoadTail());
+  // now: [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+  //       ^head          ^tail
+
+  // test tail fetchadd
+  rb.FetchAddTail(5);
+  EXPECT_EQ(10u, rb.LoadTail());
+  // now: [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+  //       ^head                         ^tail
+
+  // test store head
+  rb.StoreHead(26);
+  EXPECT_EQ(26, rb.LoadHead());
+  // now: [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+  //                                     ^tail,head
+
+  // circle write
+  // start head at 26 and tail at 20
+  // start: [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+  //                     ^tail             ^head
+  // writing 10 elements should wrap around 4 elements
+  // head should be at 36
+  rb.StoreTail(20);
+  rb.Write(threes.data(), 10);
+  EXPECT_EQ(3u, rb[0]);
+  EXPECT_EQ(3u, rb[3]);
+  EXPECT_EQ(3u, rb[10]);
+  EXPECT_EQ(3u, rb[rb.MaxSize() - 1]);
+  EXPECT_EQ(36u, rb.LoadHead());
+  EXPECT_EQ(1u, rb[rb.LoadHead()]);
+  EXPECT_EQ(1u, rb[rb.LoadTail()]);
+  // end: [3, 3, 3, 3, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3]
+  //                   ^head,tail
+}

--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -61,6 +61,7 @@
     <ClCompile Include="$(ExternalsDir)gtest\src\gtest_main.cc" />
     <!--Lump all of the tests (and supporting code) into one binary-->
     <ClCompile Include="*\*.cpp" />
+    <ClCompile Include="RingBufferTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />


### PR DESCRIPTION
(third time's the charm?)

First the quick fixes: Wiimote emu speaker pan should go from -128 to 128; the code takes that and offsets from 128 (lines 122-123 in Core/HW/WiimoteEmu/Speaker.cpp), so if we only do -127 to 127, we won't ever get 100% pan on either side.

Previously the wiimote emu speaker data was being pushed to one mixer; we should instead have a separate mixer for each wiimote.

Changed signed short, int, etc. to s16, s32, etc.

Simplified some increment statements.

Removed SSE stuff that isn't being used.

Added a little-endian version for wave-file writing (I was using this to debug, but I think there was interest in dumping the final audio mix, so I'll leave this function).

Finally, a FIR filter for higher-quality resampling, all done on the audio thread, including:
  processing done with floats
  extraction of the windowed-sinc and linear filters to separate class (with base class for different filters if desired)
  a noise-shaped dither for float->short
  extract ring-buffer to a separate class

Again, all of the heavy lifting is done by the audio thread. The filter generation is done at mixer creation - this should take negligible time - and is only done once. As with all filters, there is a delay of N samples, where N is filter length. I have opted for a lightweight 17-tap filter (this default can be changed). 17 samples (0.35ms for 48khz) is negligible compared to the latency the OS mixer -> audio driver creates, so no worries there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4445)
<!-- Reviewable:end -->
