### PR TITLE
ConfigManager: Don't overwrite the SYSCONF country

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -29,39 +29,6 @@
 #include "DiscIO/Volume.h"
 #include "DiscIO/VolumeCreator.h"
 
-// Change from IPL.LNG value to IPL.SADR country code.
-// http://wiibrew.org/wiki/Country_Codes
-static u8 GetSADRCountryCode(DiscIO::Language language)
-{
-  switch (language)
-  {
-  case DiscIO::Language::LANGUAGE_JAPANESE:
-    return 1;  // Japan
-  case DiscIO::Language::LANGUAGE_ENGLISH:
-    return 49;  // USA
-  case DiscIO::Language::LANGUAGE_GERMAN:
-    return 78;  // Germany
-  case DiscIO::Language::LANGUAGE_FRENCH:
-    return 77;  // France
-  case DiscIO::Language::LANGUAGE_SPANISH:
-    return 105;  // Spain
-  case DiscIO::Language::LANGUAGE_ITALIAN:
-    return 83;  // Italy
-  case DiscIO::Language::LANGUAGE_DUTCH:
-    return 94;  // Netherlands
-  case DiscIO::Language::LANGUAGE_SIMPLIFIED_CHINESE:
-  case DiscIO::Language::LANGUAGE_TRADITIONAL_CHINESE:
-    return 157;  // China
-  case DiscIO::Language::LANGUAGE_KOREAN:
-    return 136;  // Korea
-  case DiscIO::Language::LANGUAGE_UNKNOWN:
-    break;
-  }
-
-  PanicAlert("Invalid language. Defaulting to Japanese.");
-  return 1;
-}
-
 SConfig* SConfig::m_Instance;
 
 SConfig::SConfig()
@@ -391,8 +358,6 @@ void SConfig::SaveSettingsToSysconf()
 
   sysconf.SetData<u8>("IPL.SSV", m_wii_screensaver);
   sysconf.SetData<u8>("IPL.LNG", m_wii_language);
-  u8 country_code = GetSADRCountryCode(static_cast<DiscIO::Language>(m_wii_language));
-  sysconf.SetArrayData("IPL.SADR", &country_code, 1);
 
   sysconf.SetData<u8>("IPL.AR", m_wii_aspect_ratio);
   sysconf.SetData<u8>("BT.BAR", m_sensor_bar_position);


### PR DESCRIPTION
Currently, the country is always overridden depending on the Wii language setting. This makes it impossible to change the country independently from the language, unlike on a Wii, since a language will always be associated to an unique country (which is hardcoded in Dolphin's codebase).

This behaviour was added in c881262 and changed in PR 4319 to happen every time emulation is started. It doesn't seem to be needed anymore, as a quick testing shows that a Japanese system menu is able to load in Japanese even with the region set to France, or anything other than Japan in fact. So what this commit does is drop this code.

Fixes [issue 9884](https://dolp.in/i9884).