### PR TITLE
DolphinWX: Separate the information panel from ISOProperties

### DIFF
--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -34,6 +34,8 @@ set(GUI_SRCS
 	Debugger/RegisterWindow.cpp
 	Debugger/WatchView.cpp
 	Debugger/WatchWindow.cpp
+	ISOProperties/InfoPanel.cpp
+	ISOProperties/ISOProperties.cpp
 	NetPlay/ChangeGameDialog.cpp
 	NetPlay/MD5Dialog.cpp
 	NetPlay/NetPlayLauncher.cpp
@@ -58,7 +60,6 @@ set(GUI_SRCS
 	FrameTools.cpp
 	GameListCtrl.cpp
 	ISOFile.cpp
-	ISOProperties.cpp
 	LogConfigWindow.cpp
 	LogWindow.cpp
 	Main.cpp

--- a/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
+++ b/Source/Core/DolphinWX/Cheats/CreateCodeDialog.cpp
@@ -11,7 +11,6 @@
 #include "Core/ActionReplay.h"
 #include "DolphinWX/Cheats/CheatsWindow.h"
 #include "DolphinWX/Cheats/CreateCodeDialog.h"
-#include "DolphinWX/ISOProperties.h"
 #include "DolphinWX/WxUtils.h"
 
 CreateCodeDialog::CreateCodeDialog(wxWindow* const parent, const u32 address)

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj
@@ -90,6 +90,8 @@
     <ClCompile Include="Debugger\WatchView.cpp" />
     <ClCompile Include="Debugger\WatchWindow.cpp" />
     <ClCompile Include="DolphinSlider.cpp" />
+    <ClCompile Include="ISOProperties\InfoPanel.cpp" />
+    <ClCompile Include="ISOProperties\ISOProperties.cpp" />
     <ClCompile Include="NetPlay\ChangeGameDialog.cpp" />
     <ClCompile Include="NetPlay\MD5Dialog.cpp" />
     <ClCompile Include="NetPlay\NetPlayLauncher.cpp" />
@@ -112,7 +114,6 @@
     <ClCompile Include="Input\DrumsInputConfigDiag.cpp" />
     <ClCompile Include="Input\TurntableInputConfigDiag.cpp" />
     <ClCompile Include="ISOFile.cpp" />
-    <ClCompile Include="ISOProperties.cpp" />
     <ClCompile Include="LogConfigWindow.cpp" />
     <ClCompile Include="LogWindow.cpp" />
     <ClCompile Include="Main.cpp" />
@@ -145,6 +146,8 @@
     <ClInclude Include="Config\PathConfigPane.h" />
     <ClInclude Include="Config\WiiConfigPane.h" />
     <ClInclude Include="DolphinSlider.h" />
+    <ClInclude Include="ISOProperties\InfoPanel.h" />
+    <ClInclude Include="ISOProperties\ISOProperties.h" />
     <ClInclude Include="NetPlay\ChangeGameDialog.h" />
     <ClInclude Include="NetPlay\MD5Dialog.h" />
     <ClInclude Include="NetPlay\NetPlayLauncher.h" />
@@ -190,7 +193,6 @@
     <ClInclude Include="Input\DrumsInputConfigDiag.h" />
     <ClInclude Include="Input\TurntableInputConfigDiag.h" />
     <ClInclude Include="ISOFile.h" />
-    <ClInclude Include="ISOProperties.h" />
     <ClInclude Include="LogConfigWindow.h" />
     <ClInclude Include="LogWindow.h" />
     <ClInclude Include="Main.h" />

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="GUI">
@@ -30,6 +30,9 @@
     </Filter>
     <Filter Include="GUI\Widgets">
       <UniqueIdentifier>{a894e2e3-e577-4b65-8572-055699f23a49}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="GUI\ISOProperties">
+      <UniqueIdentifier>{d72aa7f0-ed24-4fed-9d3a-38b82d1b753c}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -167,9 +170,6 @@
     <ClCompile Include="GameListCtrl.cpp">
       <Filter>GUI</Filter>
     </ClCompile>
-    <ClCompile Include="ISOProperties.cpp">
-      <Filter>GUI</Filter>
-    </ClCompile>
     <ClCompile Include="LogConfigWindow.cpp">
       <Filter>GUI</Filter>
     </ClCompile>
@@ -223,6 +223,12 @@
     </ClCompile>
     <ClCompile Include="Config\AdvancedConfigPane.cpp">
       <Filter>GUI\Config</Filter>
+    </ClCompile>
+    <ClCompile Include="ISOProperties\InfoPanel.cpp">
+      <Filter>GUI\ISOProperties</Filter>
+    </ClCompile>
+    <ClCompile Include="ISOProperties\ISOProperties.cpp">
+      <Filter>GUI\ISOProperties</Filter>
     </ClCompile>
     <ClCompile Include="NetPlay\NetPlaySetupFrame.cpp">
       <Filter>GUI\NetPlay</Filter>
@@ -377,9 +383,6 @@
     <ClInclude Include="Globals.h">
       <Filter>GUI</Filter>
     </ClInclude>
-    <ClInclude Include="ISOProperties.h">
-      <Filter>GUI</Filter>
-    </ClInclude>
     <ClInclude Include="LogConfigWindow.h">
       <Filter>GUI</Filter>
     </ClInclude>
@@ -433,6 +436,12 @@
     </ClInclude>
     <ClInclude Include="Config\AdvancedConfigPane.h">
       <Filter>GUI\Config</Filter>
+    </ClInclude>
+    <ClInclude Include="ISOProperties\InfoPanel.h">
+      <Filter>GUI\ISOProperties</Filter>
+    </ClInclude>
+    <ClInclude Include="ISOProperties\ISOProperties.h">
+      <Filter>GUI\ISOProperties</Filter>
     </ClInclude>
     <ClInclude Include="NetPlay\NetPlaySetupFrame.h">
       <Filter>GUI\NetPlay</Filter>

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -58,7 +58,7 @@
 #include "DolphinWX/GameListCtrl.h"
 #include "DolphinWX/Globals.h"
 #include "DolphinWX/ISOFile.h"
-#include "DolphinWX/ISOProperties.h"
+#include "DolphinWX/ISOProperties/ISOProperties.h"
 #include "DolphinWX/Main.h"
 #include "DolphinWX/NetPlay/NetPlayLauncher.h"
 #include "DolphinWX/WxUtils.h"

--- a/Source/Core/DolphinWX/ISOProperties/ISOProperties.h
+++ b/Source/Core/DolphinWX/ISOProperties/ISOProperties.h
@@ -62,6 +62,8 @@ struct PHackData
   std::string PHZFar;
 };
 
+wxDECLARE_EVENT(DOLPHIN_EVT_CHANGE_ISO_PROPERTIES_TITLE, wxCommandEvent);
+
 class CISOProperties : public wxDialog
 {
 public:
@@ -101,22 +103,6 @@ private:
   wxCheckListBox* Patches;
   wxButton* EditPatch;
   wxButton* RemovePatch;
-
-  wxTextCtrl* m_InternalName;
-  wxTextCtrl* m_GameID;
-  wxTextCtrl* m_Country;
-  wxTextCtrl* m_MakerID;
-  wxTextCtrl* m_Revision;
-  wxTextCtrl* m_Date;
-  wxTextCtrl* m_FST;
-  wxTextCtrl* m_MD5Sum;
-  wxButton* m_MD5SumCompute;
-  wxArrayString arrayStringFor_Lang;
-  wxChoice* m_Lang;
-  wxTextCtrl* m_Name;
-  wxTextCtrl* m_Maker;
-  wxTextCtrl* m_Comment;
-  wxStaticBitmap* m_Banner;
 
   wxTreeCtrl* m_Treectrl;
   wxTreeItemId RootId;
@@ -162,29 +148,12 @@ private:
     ID_CONVERGENCE,
     ID_MONODEPTH,
 
-    ID_NAME,
-    ID_GAMEID,
-    ID_COUNTRY,
-    ID_MAKERID,
-    ID_REVISION,
-    ID_DATE,
-    ID_FST,
-    ID_MD5SUM,
-    ID_MD5SUMCOMPUTE,
-    ID_VERSION,
-    ID_LANG,
-    ID_SHORTNAME,
-    ID_LONGNAME,
-    ID_MAKER,
-    ID_COMMENT,
-    ID_BANNER,
     IDM_EXTRACTDIR,
     IDM_EXTRACTALL,
     IDM_EXTRACTFILE,
     IDM_EXTRACTAPPLOADER,
     IDM_EXTRACTDOL,
     IDM_CHECKINTEGRITY,
-    IDM_BNRSAVEAS
   };
 
   void LaunchExternalEditor(const std::string& filename, bool wait_until_closed);
@@ -193,24 +162,19 @@ private:
   void OnClose(wxCloseEvent& event);
   void OnCloseClick(wxCommandEvent& event);
   void OnEditConfig(wxCommandEvent& event);
-  void OnComputeMD5Sum(wxCommandEvent& event);
   void OnShowDefaultConfig(wxCommandEvent& event);
   void PatchListSelectionChanged(wxCommandEvent& event);
   void PatchButtonClicked(wxCommandEvent& event);
-  void RightClickOnBanner(wxMouseEvent& event);
-  void OnBannerImageSave(wxCommandEvent& event);
   void OnRightClickOnTree(wxTreeEvent& event);
   void OnExtractFile(wxCommandEvent& event);
   void OnExtractDir(wxCommandEvent& event);
   void OnExtractDataFromHeader(wxCommandEvent& event);
   void CheckPartitionIntegrity(wxCommandEvent& event);
   void OnEmustateChanged(wxCommandEvent& event);
-  void OnChangeBannerLang(wxCommandEvent& event);
   void OnCheatCodeToggled(wxCommandEvent& event);
+  void OnChangeTitle(wxCommandEvent& event);
 
   const GameListItem OpenGameListItem;
-
-  typedef std::vector<const DiscIO::SFileInfo*>::iterator fileIter;
 
   size_t CreateDirectoryTree(wxTreeItemId& parent, const std::vector<DiscIO::SFileInfo>& fileInfos);
   size_t CreateDirectoryTree(wxTreeItemId& parent, const std::vector<DiscIO::SFileInfo>& fileInfos,
@@ -231,7 +195,6 @@ private:
   void GenerateLocalIniModified();
   void PatchList_Load();
   void PatchList_Save();
-  void ChangeBannerDetails(DiscIO::Language language);
 
   long GetElementStyle(const char* section, const char* key);
   void SetCheckboxValueFromGameini(const char* section, const char* key, wxCheckBox* checkbox);

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
@@ -1,0 +1,402 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinWX/ISOProperties/InfoPanel.h"
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include <wx/arrstr.h>
+#include <wx/bitmap.h>
+#include <wx/button.h>
+#include <wx/choice.h>
+#include <wx/filedlg.h>
+#include <wx/gbsizer.h>
+#include <wx/menu.h>
+#include <wx/progdlg.h>
+#include <wx/sizer.h>
+#include <wx/statbmp.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/utils.h>
+
+#include "Common/MD5.h"
+#include "Common/StringUtil.h"
+#include "Core/ConfigManager.h"
+#include "DiscIO/Enums.h"
+#include "DiscIO/Volume.h"
+#include "DolphinWX/ISOFile.h"
+#include "DolphinWX/ISOProperties/ISOProperties.h"
+#include "DolphinWX/WxUtils.h"
+
+namespace
+{
+wxArrayString GetLanguageChoiceStrings(const std::vector<DiscIO::Language>& languages)
+{
+  wxArrayString available_languages;
+
+  for (auto language : languages)
+  {
+    switch (language)
+    {
+    case DiscIO::Language::LANGUAGE_JAPANESE:
+      available_languages.Add(_("Japanese"));
+      break;
+    case DiscIO::Language::LANGUAGE_ENGLISH:
+      available_languages.Add(_("English"));
+      break;
+    case DiscIO::Language::LANGUAGE_GERMAN:
+      available_languages.Add(_("German"));
+      break;
+    case DiscIO::Language::LANGUAGE_FRENCH:
+      available_languages.Add(_("French"));
+      break;
+    case DiscIO::Language::LANGUAGE_SPANISH:
+      available_languages.Add(_("Spanish"));
+      break;
+    case DiscIO::Language::LANGUAGE_ITALIAN:
+      available_languages.Add(_("Italian"));
+      break;
+    case DiscIO::Language::LANGUAGE_DUTCH:
+      available_languages.Add(_("Dutch"));
+      break;
+    case DiscIO::Language::LANGUAGE_SIMPLIFIED_CHINESE:
+      available_languages.Add(_("Simplified Chinese"));
+      break;
+    case DiscIO::Language::LANGUAGE_TRADITIONAL_CHINESE:
+      available_languages.Add(_("Traditional Chinese"));
+      break;
+    case DiscIO::Language::LANGUAGE_KOREAN:
+      available_languages.Add(_("Korean"));
+      break;
+    case DiscIO::Language::LANGUAGE_UNKNOWN:
+    default:
+      available_languages.Add(_("Unknown"));
+      break;
+    }
+  }
+
+  return available_languages;
+}
+
+wxString GetCountryName(DiscIO::Country country)
+{
+  switch (country)
+  {
+  case DiscIO::Country::COUNTRY_AUSTRALIA:
+    return _("Australia");
+  case DiscIO::Country::COUNTRY_EUROPE:
+    return _("Europe");
+  case DiscIO::Country::COUNTRY_FRANCE:
+    return _("France");
+  case DiscIO::Country::COUNTRY_ITALY:
+    return _("Italy");
+  case DiscIO::Country::COUNTRY_GERMANY:
+    return _("Germany");
+  case DiscIO::Country::COUNTRY_NETHERLANDS:
+    return _("Netherlands");
+  case DiscIO::Country::COUNTRY_RUSSIA:
+    return _("Russia");
+  case DiscIO::Country::COUNTRY_SPAIN:
+    return _("Spain");
+  case DiscIO::Country::COUNTRY_USA:
+    return _("USA");
+  case DiscIO::Country::COUNTRY_JAPAN:
+    return _("Japan");
+  case DiscIO::Country::COUNTRY_KOREA:
+    return _("Korea");
+  case DiscIO::Country::COUNTRY_TAIWAN:
+    return _("Taiwan");
+  case DiscIO::Country::COUNTRY_WORLD:
+    return _("World");
+  case DiscIO::Country::COUNTRY_UNKNOWN:
+  default:
+    return _("Unknown");
+  }
+}
+
+int FindPreferredLanguageIndex(DiscIO::Language preferred_language,
+                               const std::vector<DiscIO::Language>& languages)
+{
+  const auto iter =
+      std::find_if(languages.begin(), languages.end(),
+                   [preferred_language](auto language) { return language == preferred_language; });
+
+  if (iter == languages.end())
+    return 0;
+
+  return static_cast<int>(std::distance(languages.begin(), iter));
+}
+}  // Anonymous namespace
+
+InfoPanel::InfoPanel(wxWindow* parent, wxWindowID id, const GameListItem& item,
+                     const std::unique_ptr<DiscIO::IVolume>& opened_iso)
+    : wxPanel{parent, id}, m_game_list_item{item}, m_opened_iso{opened_iso}
+{
+  CreateGUI();
+  BindEvents();
+  LoadGUIData();
+}
+
+void InfoPanel::CreateGUI()
+{
+  const int space_5 = FromDIP(5);
+
+  auto* const main_sizer = new wxBoxSizer(wxVERTICAL);
+  main_sizer->AddSpacer(space_5);
+  main_sizer->Add(CreateISODetailsSizer(), 0, wxEXPAND | wxLEFT | wxRIGHT, space_5);
+  main_sizer->AddSpacer(space_5);
+  main_sizer->Add(CreateBannerDetailsSizer(), 0, wxEXPAND | wxLEFT | wxRIGHT, space_5);
+  main_sizer->AddSpacer(space_5);
+
+  SetSizer(main_sizer);
+}
+
+void InfoPanel::BindEvents()
+{
+  m_md5_sum_compute->Bind(wxEVT_BUTTON, &InfoPanel::OnComputeMD5, this);
+  m_languages->Bind(wxEVT_CHOICE, &InfoPanel::OnChangeBannerLanguage, this);
+
+  Bind(wxEVT_MENU, &InfoPanel::OnSaveBannerImage, this, IDM_SAVE_BANNER);
+}
+
+void InfoPanel::LoadGUIData()
+{
+  LoadISODetails();
+  LoadBannerDetails();
+}
+
+void InfoPanel::LoadISODetails()
+{
+  m_internal_name->SetValue(StrToWxStr(m_opened_iso->GetInternalName()));
+  m_game_id->SetValue(StrToWxStr(m_opened_iso->GetGameID()));
+  m_country->SetValue(GetCountryName(m_opened_iso->GetCountry()));
+  m_maker_id->SetValue("0x" + StrToWxStr(m_opened_iso->GetMakerID()));
+  m_revision->SetValue(StrToWxStr(std::to_string(m_opened_iso->GetRevision())));
+  m_date->SetValue(StrToWxStr(m_opened_iso->GetApploaderDate()));
+  m_fst->SetValue(StrToWxStr(std::to_string(m_opened_iso->GetFSTSize())));
+}
+
+void InfoPanel::LoadBannerDetails()
+{
+  LoadBannerImage();
+
+  const bool is_wii = m_opened_iso->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC;
+  ChangeBannerDetails(SConfig::GetInstance().GetCurrentLanguage(is_wii));
+}
+
+void InfoPanel::LoadBannerImage()
+{
+  const auto& banner_image = m_game_list_item.GetBannerImage();
+  const auto banner_min_size = m_banner->GetMinSize();
+
+  if (banner_image.IsOk())
+  {
+    m_banner->SetBitmap(WxUtils::ScaleImageToBitmap(banner_image, this, banner_min_size));
+    m_banner->Bind(wxEVT_RIGHT_DOWN, &InfoPanel::OnRightClickBanner, this);
+  }
+  else
+  {
+    m_banner->SetBitmap(WxUtils::LoadScaledResourceBitmap("nobanner", this, banner_min_size));
+  }
+}
+
+wxStaticBoxSizer* InfoPanel::CreateISODetailsSizer()
+{
+  auto* const internal_name_text = new wxStaticText(this, wxID_ANY, _("Internal Name:"));
+  m_internal_name =
+      new wxTextCtrl(this, ID_NAME, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+
+  auto* const game_id_text = new wxStaticText(this, wxID_ANY, _("Game ID:"));
+  m_game_id = new wxTextCtrl(this, ID_GAME_ID, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                             wxTE_READONLY);
+  auto* const country_text = new wxStaticText(this, wxID_ANY, _("Country:"));
+  m_country = new wxTextCtrl(this, ID_COUNTRY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                             wxTE_READONLY);
+  auto* const maker_id_text = new wxStaticText(this, wxID_ANY, _("Maker ID:"));
+  m_maker_id = new wxTextCtrl(this, ID_MAKER_ID, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                              wxTE_READONLY);
+  auto* const revision_text = new wxStaticText(this, wxID_ANY, _("Revision:"));
+  m_revision = new wxTextCtrl(this, ID_REVISION, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                              wxTE_READONLY);
+
+  auto* const date_text = new wxStaticText(this, wxID_ANY, _("Apploader Date:"));
+  m_date =
+      new wxTextCtrl(this, ID_DATE, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+
+  auto* const fst_text = new wxStaticText(this, wxID_ANY, _("FST Size:"));
+  m_fst =
+      new wxTextCtrl(this, ID_FST, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+
+  auto* const md5_sum_text = new wxStaticText(this, wxID_ANY, _("MD5 Checksum:"));
+  m_md5_sum = new wxTextCtrl(this, ID_MD5_SUM, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                             wxTE_READONLY);
+  m_md5_sum_compute = new wxButton(this, ID_MD5_SUM_COMPUTE, _("Compute"));
+
+  const int space_10 = FromDIP(10);
+  auto* const iso_details = new wxGridBagSizer(space_10, space_10);
+  iso_details->Add(internal_name_text, wxGBPosition(0, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  iso_details->Add(m_internal_name, wxGBPosition(0, 1), wxGBSpan(1, 2), wxEXPAND);
+  iso_details->Add(game_id_text, wxGBPosition(1, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  iso_details->Add(m_game_id, wxGBPosition(1, 1), wxGBSpan(1, 2), wxEXPAND);
+  iso_details->Add(country_text, wxGBPosition(2, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  iso_details->Add(m_country, wxGBPosition(2, 1), wxGBSpan(1, 2), wxEXPAND);
+  iso_details->Add(maker_id_text, wxGBPosition(3, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  iso_details->Add(m_maker_id, wxGBPosition(3, 1), wxGBSpan(1, 2), wxEXPAND);
+  iso_details->Add(revision_text, wxGBPosition(4, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  iso_details->Add(m_revision, wxGBPosition(4, 1), wxGBSpan(1, 2), wxEXPAND);
+  iso_details->Add(date_text, wxGBPosition(5, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  iso_details->Add(m_date, wxGBPosition(5, 1), wxGBSpan(1, 2), wxEXPAND);
+  iso_details->Add(fst_text, wxGBPosition(6, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  iso_details->Add(m_fst, wxGBPosition(6, 1), wxGBSpan(1, 2), wxEXPAND);
+  iso_details->Add(md5_sum_text, wxGBPosition(7, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  iso_details->Add(m_md5_sum, wxGBPosition(7, 1), wxGBSpan(1, 1), wxEXPAND);
+  iso_details->Add(m_md5_sum_compute, wxGBPosition(7, 2), wxGBSpan(1, 1), wxEXPAND);
+  iso_details->AddGrowableCol(1);
+
+  const int space_5 = FromDIP(5);
+  auto* const iso_details_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("ISO Details"));
+  iso_details_sizer->AddSpacer(space_5);
+  iso_details_sizer->Add(iso_details, 0, wxEXPAND | wxLEFT | wxRIGHT, space_5);
+  iso_details_sizer->AddSpacer(space_5);
+
+  return iso_details_sizer;
+}
+
+wxStaticBoxSizer* InfoPanel::CreateBannerDetailsSizer()
+{
+  auto* const name_text = new wxStaticText(this, wxID_ANY, _("Name:"));
+  m_name = new wxTextCtrl(this, ID_SHORT_NAME, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                          wxTE_READONLY);
+  auto* const maker_text = new wxStaticText(this, wxID_ANY, _("Maker:"));
+  m_maker = new wxTextCtrl(this, ID_MAKER, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                           wxTE_READONLY);
+  auto* const comment_text = new wxStaticText(this, wxID_ANY, _("Description:"));
+  m_comment = new wxTextCtrl(this, ID_COMMENT, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+                             wxTE_MULTILINE | wxTE_READONLY);
+  auto* const banner_text = new wxStaticText(this, wxID_ANY, _("Banner:"));
+  m_banner =
+      new wxStaticBitmap(this, ID_BANNER, wxNullBitmap, wxDefaultPosition, FromDIP(wxSize(96, 32)));
+
+  auto* const languages_text = new wxStaticText(this, wxID_ANY, _("Show Language:"));
+  m_languages = CreateCommentLanguageChoice();
+
+  const int space_10 = FromDIP(10);
+  auto* const banner_details = new wxGridBagSizer(space_10, space_10);
+  banner_details->Add(languages_text, wxGBPosition(0, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  // Comboboxes cannot be safely stretched vertically on Windows.
+  banner_details->Add(WxUtils::GiveMinSize(m_languages, wxDefaultSize), wxGBPosition(0, 1),
+                      wxGBSpan(1, 1), wxEXPAND);
+  banner_details->Add(name_text, wxGBPosition(1, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  banner_details->Add(m_name, wxGBPosition(1, 1), wxGBSpan(1, 1), wxEXPAND);
+  banner_details->Add(maker_text, wxGBPosition(2, 0), wxGBSpan(1, 1), wxALIGN_CENTER_VERTICAL);
+  banner_details->Add(m_maker, wxGBPosition(2, 1), wxGBSpan(1, 1), wxEXPAND);
+  banner_details->Add(comment_text, wxGBPosition(3, 0), wxGBSpan(1, 1));
+  banner_details->Add(m_comment, wxGBPosition(3, 1), wxGBSpan(1, 1), wxEXPAND);
+  banner_details->Add(banner_text, wxGBPosition(4, 0), wxGBSpan(1, 1));
+  banner_details->Add(m_banner, wxGBPosition(4, 1), wxGBSpan(1, 1));
+  banner_details->AddGrowableCol(1);
+
+  const int space_5 = FromDIP(5);
+  auto* const banner_details_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Banner Details"));
+  banner_details_sizer->AddSpacer(space_5);
+  banner_details_sizer->Add(banner_details, 0, wxEXPAND | wxLEFT | wxRIGHT, space_5);
+  banner_details_sizer->AddSpacer(space_5);
+
+  return banner_details_sizer;
+}
+
+wxChoice* InfoPanel::CreateCommentLanguageChoice()
+{
+  const auto languages = m_game_list_item.GetLanguages();
+  const bool is_wii = m_opened_iso->GetVolumeType() != DiscIO::Platform::GAMECUBE_DISC;
+  const auto preferred_language = SConfig::GetInstance().GetCurrentLanguage(is_wii);
+  const int preferred_language_index = FindPreferredLanguageIndex(preferred_language, languages);
+  const auto choices = GetLanguageChoiceStrings(languages);
+
+  auto* const choice = new wxChoice(this, ID_LANGUAGE, wxDefaultPosition, wxDefaultSize, choices);
+  choice->SetSelection(preferred_language_index);
+
+  if (choice->GetCount() <= 1)
+    choice->Disable();
+
+  return choice;
+}
+
+void InfoPanel::OnComputeMD5(wxCommandEvent& WXUNUSED(event))
+{
+  wxProgressDialog progress_dialog(_("Computing MD5 checksum"), _("Working..."), 100, this,
+                                   wxPD_APP_MODAL | wxPD_AUTO_HIDE | wxPD_CAN_ABORT |
+                                       wxPD_ELAPSED_TIME | wxPD_ESTIMATED_TIME |
+                                       wxPD_REMAINING_TIME | wxPD_SMOOTH);
+
+  const auto result = MD5::MD5Sum(m_game_list_item.GetFileName(), [&progress_dialog](int progress) {
+    return progress_dialog.Update(progress);
+  });
+
+  if (progress_dialog.WasCancelled())
+    return;
+
+  m_md5_sum->SetValue(result);
+}
+
+void InfoPanel::OnChangeBannerLanguage(wxCommandEvent& event)
+{
+  ChangeBannerDetails(m_game_list_item.GetLanguages()[event.GetSelection()]);
+}
+
+void InfoPanel::OnRightClickBanner(wxMouseEvent& WXUNUSED(event))
+{
+  wxMenu menu;
+  menu.Append(IDM_SAVE_BANNER, _("Save as..."));
+  PopupMenu(&menu);
+}
+
+void InfoPanel::OnSaveBannerImage(wxCommandEvent& WXUNUSED(event))
+{
+  wxFileDialog dialog(this, _("Save as..."), wxGetHomeDir(),
+                      wxString::Format("%s.png", m_game_id->GetValue().c_str()),
+                      wxALL_FILES_PATTERN, wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+  if (dialog.ShowModal() == wxID_OK)
+  {
+    m_game_list_item.GetBannerImage().SaveFile(dialog.GetPath());
+  }
+
+  Raise();
+}
+
+void InfoPanel::ChangeBannerDetails(DiscIO::Language language)
+{
+  const auto name = StrToWxStr(m_game_list_item.GetName(language));
+  const auto comment = StrToWxStr(m_game_list_item.GetDescription(language));
+  const auto maker = StrToWxStr(m_game_list_item.GetCompany());
+
+  m_name->SetValue(name);
+  m_comment->SetValue(comment);
+  m_maker->SetValue(maker);
+
+  std::string path, filename, extension;
+  SplitPath(m_game_list_item.GetFileName(), &path, &filename, &extension);
+
+  // Real disk drives don't have filenames on Windows
+  if (filename.empty() && extension.empty())
+    filename = path + ' ';
+
+  const auto game_id = m_game_list_item.GetGameID();
+  const auto new_title = wxString::Format("%s%s: %s - %s", filename.c_str(), extension.c_str(),
+                                          game_id.c_str(), name.c_str());
+
+  EmitTitleChangeEvent(new_title);
+}
+
+void InfoPanel::EmitTitleChangeEvent(const wxString& new_title)
+{
+  wxCommandEvent event{DOLPHIN_EVT_CHANGE_ISO_PROPERTIES_TITLE, GetId()};
+  event.SetEventObject(this);
+  event.SetString(new_title);
+  AddPendingEvent(event);
+}

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.h
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.h
@@ -1,0 +1,88 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <wx/panel.h>
+
+class GameListItem;
+class wxButton;
+class wxChoice;
+class wxStaticBitmap;
+class wxStaticBoxSizer;
+class wxTextCtrl;
+
+namespace DiscIO
+{
+class IVolume;
+enum class Language;
+}
+
+class InfoPanel final : public wxPanel
+{
+public:
+  InfoPanel(wxWindow* parent, wxWindowID id, const GameListItem& item,
+            const std::unique_ptr<DiscIO::IVolume>& opened_iso);
+
+private:
+  enum
+  {
+    ID_NAME = 10000,
+    ID_GAME_ID,
+    ID_COUNTRY,
+    ID_MAKER_ID,
+    ID_REVISION,
+    ID_DATE,
+    ID_FST,
+    ID_MD5_SUM,
+    ID_MD5_SUM_COMPUTE,
+    ID_VERSION,
+    ID_LANGUAGE,
+    ID_SHORT_NAME,
+    ID_MAKER,
+    ID_COMMENT,
+    ID_BANNER,
+
+    IDM_SAVE_BANNER
+  };
+
+  void CreateGUI();
+  void BindEvents();
+  void LoadGUIData();
+  void LoadISODetails();
+  void LoadBannerDetails();
+  void LoadBannerImage();
+
+  wxStaticBoxSizer* CreateISODetailsSizer();
+  wxStaticBoxSizer* CreateBannerDetailsSizer();
+  wxChoice* CreateCommentLanguageChoice();
+
+  void OnComputeMD5(wxCommandEvent&);
+  void OnChangeBannerLanguage(wxCommandEvent&);
+  void OnRightClickBanner(wxMouseEvent&);
+  void OnSaveBannerImage(wxCommandEvent&);
+
+  void ChangeBannerDetails(DiscIO::Language language);
+
+  void EmitTitleChangeEvent(const wxString& new_title);
+
+  const GameListItem& m_game_list_item;
+  const std::unique_ptr<DiscIO::IVolume>& m_opened_iso;
+
+  wxTextCtrl* m_internal_name;
+  wxTextCtrl* m_game_id;
+  wxTextCtrl* m_country;
+  wxTextCtrl* m_maker_id;
+  wxTextCtrl* m_revision;
+  wxTextCtrl* m_date;
+  wxTextCtrl* m_fst;
+  wxTextCtrl* m_md5_sum;
+  wxButton* m_md5_sum_compute;
+  wxChoice* m_languages;
+  wxTextCtrl* m_name;
+  wxTextCtrl* m_maker;
+  wxTextCtrl* m_comment;
+  wxStaticBitmap* m_banner;
+};


### PR DESCRIPTION
Makes the information panel self-contained.

This was done first, as opposed to isolating the GameConfig panel—the first panel in the group—as this panel had code all over the place in ISOProperties, so I figured it'd be best to fix this one up first.

I only did one panel, as I'd like to PR them one at a time so the changeset is actually somewhat readable. This would easily be 1000+ lines if done all at once and nobody wants to read changes that long (rightly so).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4448)
<!-- Reviewable:end -->
