### PR TITLE
Vulkan: Fix crash on EFB poke

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -1181,6 +1181,7 @@ void FramebufferManager::DrawPokeVertices(const EFBPokeVertex* vertices, size_t 
   pipeline_info.ps = m_poke_fragment_shader;
   pipeline_info.render_pass = m_efb_load_render_pass;
   pipeline_info.rasterization_state.bits = Util::GetNoCullRasterizationState().bits;
+  pipeline_info.rasterization_state.samples = m_efb_samples;
   pipeline_info.depth_stencil_state.bits = Util::GetNoDepthTestingDepthStencilState().bits;
   pipeline_info.blend_state.bits = Util::GetNoBlendingBlendState().bits;
   pipeline_info.blend_state.write_mask = 0;

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -103,6 +103,12 @@ bool FramebufferManager::Initialize()
     return false;
   }
 
+  if (!CompilePokeShaders())
+  {
+    PanicAlert("Failed to compile poke shaders");
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Not sure how this one slipped through, must have been when I was refactoring things and forgot to include the method call. Also fixes an issue with EFB pokes where the rasterization state sample count did not match the sample count being rendered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4451)
<!-- Reviewable:end -->
