### PR TITLE
Jit64: Treat branch-to-self instruction as an idle loop

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -105,6 +105,7 @@ void JitArm64::bx(UGeckoInstruction inst)
     gpr.Unlock(WA);
 
     WriteExceptionExit(js.compilerPC);
+    return;
   }
 
   WriteExit(destination);


### PR DESCRIPTION
I'm guessing this is the result of calling VIDEO_WaitVSync in libogc (perhaps indirectly, I haven't looked closely at the code for this function).

Both Interpreter and JitIL interpret this as an idle loop, Jit64 looked like it did at some point, but it has been commented out for a long time. Was there a reason for this?

JitArm64 has a similar optimization, except it was emitting redundant code as the exception exit would jump out of the block before the normal exit was executed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4452)
<!-- Reviewable:end -->
