### PR TITLE
CustomTexture: Drop old texture format.

### DIFF
--- a/Source/Core/Common/Hash.cpp
+++ b/Source/Core/Common/Hash.cpp
@@ -332,64 +332,6 @@ static u64 GetCRC32(const u8* src, u32 len, u32 samples)
 
 #endif
 
-/*
- * NOTE: This hash function is used for custom texture loading/dumping, so
- * it should not be changed, which would require all custom textures to be
- * recalculated for their new hash values. If the hashing function is
- * changed, make sure this one is still used when the legacy parameter is
- * true.
- */
-u64 GetHashHiresTexture(const u8* src, u32 len, u32 samples)
-{
-  const u64 m = 0xc6a4a7935bd1e995;
-  u64 h = len * m;
-  const int r = 47;
-  u32 Step = (len / 8);
-  const u64* data = (const u64*)src;
-  const u64* end = data + Step;
-  if (samples == 0)
-    samples = std::max(Step, 1u);
-  Step = Step / samples;
-  if (Step < 1)
-    Step = 1;
-  while (data < end)
-  {
-    u64 k = data[0];
-    data += Step;
-    k *= m;
-    k ^= k >> r;
-    k *= m;
-    h ^= k;
-    h *= m;
-  }
-
-  const u8* data2 = (const u8*)end;
-
-  switch (len & 7)
-  {
-  case 7:
-    h ^= u64(data2[6]) << 48;
-  case 6:
-    h ^= u64(data2[5]) << 40;
-  case 5:
-    h ^= u64(data2[4]) << 32;
-  case 4:
-    h ^= u64(data2[3]) << 24;
-  case 3:
-    h ^= u64(data2[2]) << 16;
-  case 2:
-    h ^= u64(data2[1]) << 8;
-  case 1:
-    h ^= u64(data2[0]);
-    h *= m;
-  };
-
-  h ^= h >> r;
-  h *= m;
-  h ^= h >> r;
-
-  return h;
-}
 #else
 
 // CRC32 hash using the SSE4.2 instruction
@@ -552,63 +494,6 @@ static u64 GetMurmurHash3(const u8* src, u32 len, u32 samples)
   out[1] = h2;
 
   return *((u64*)&out);
-}
-
-/*
- * FIXME: The old 32-bit version of this hash made different hashes than the
- * 64-bit version. Until someone can make a new version of the 32-bit one that
- * makes identical hashes, this is just a c/p of the 64-bit one.
- */
-u64 GetHashHiresTexture(const u8* src, u32 len, u32 samples)
-{
-  const u64 m = 0xc6a4a7935bd1e995ULL;
-  u64 h = len * m;
-  const int r = 47;
-  u32 Step = (len / 8);
-  const u64* data = (const u64*)src;
-  const u64* end = data + Step;
-  if (samples == 0)
-    samples = std::max(Step, 1u);
-  Step = Step / samples;
-  if (Step < 1)
-    Step = 1;
-  while (data < end)
-  {
-    u64 k = data[0];
-    data += Step;
-    k *= m;
-    k ^= k >> r;
-    k *= m;
-    h ^= k;
-    h *= m;
-  }
-
-  const u8* data2 = (const u8*)end;
-
-  switch (len & 7)
-  {
-  case 7:
-    h ^= u64(data2[6]) << 48;
-  case 6:
-    h ^= u64(data2[5]) << 40;
-  case 5:
-    h ^= u64(data2[4]) << 32;
-  case 4:
-    h ^= u64(data2[3]) << 24;
-  case 3:
-    h ^= u64(data2[2]) << 16;
-  case 2:
-    h ^= u64(data2[1]) << 8;
-  case 1:
-    h ^= u64(data2[0]);
-    h *= m;
-  };
-
-  h ^= h >> r;
-  h *= m;
-  h ^= h >> r;
-
-  return h;
 }
 #endif
 

--- a/Source/Core/Common/Hash.h
+++ b/Source/Core/Common/Hash.h
@@ -11,6 +11,5 @@
 u32 HashFletcher(const u8* data_u8, size_t length);  // FAST. Length & 1 == 0.
 u32 HashAdler32(const u8* data, size_t len);         // Fairly accurate, slightly slower
 u32 HashEctor(const u8* ptr, int length);            // JUNK. DO NOT USE FOR NEW THINGS
-u64 GetHashHiresTexture(const u8* src, u32 len, u32 samples = 0);
 u64 GetHash64(const u8* src, u32 len, u32 samples);
 void SetHash64Function();

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -38,8 +38,6 @@ const ConfigInfo<bool> GFX_OVERLAY_STATS{{System::GFX, "Settings", "OverlayStats
 const ConfigInfo<bool> GFX_OVERLAY_PROJ_STATS{{System::GFX, "Settings", "OverlayProjStats"}, false};
 const ConfigInfo<bool> GFX_DUMP_TEXTURES{{System::GFX, "Settings", "DumpTextures"}, false};
 const ConfigInfo<bool> GFX_HIRES_TEXTURES{{System::GFX, "Settings", "HiresTextures"}, false};
-const ConfigInfo<bool> GFX_CONVERT_HIRES_TEXTURES{{System::GFX, "Settings", "ConvertHiresTextures"},
-                                                  false};
 const ConfigInfo<bool> GFX_CACHE_HIRES_TEXTURES{{System::GFX, "Settings", "CacheHiresTextures"},
                                                 false};
 const ConfigInfo<bool> GFX_DUMP_EFB_TARGET{{System::GFX, "Settings", "DumpEFBTarget"}, false};

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -32,7 +32,6 @@ extern const ConfigInfo<bool> GFX_OVERLAY_STATS;
 extern const ConfigInfo<bool> GFX_OVERLAY_PROJ_STATS;
 extern const ConfigInfo<bool> GFX_DUMP_TEXTURES;
 extern const ConfigInfo<bool> GFX_HIRES_TEXTURES;
-extern const ConfigInfo<bool> GFX_CONVERT_HIRES_TEXTURES;
 extern const ConfigInfo<bool> GFX_CACHE_HIRES_TEXTURES;
 extern const ConfigInfo<bool> GFX_DUMP_EFB_TARGET;
 extern const ConfigInfo<bool> GFX_DUMP_XFB_TARGET;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -33,7 +33,6 @@ bool IsSettingSaveable(const Config::ConfigLocation& config_location)
       Config::GFX_SHOW_NETPLAY_MESSAGES.location, Config::GFX_LOG_RENDER_TIME_TO_FILE.location,
       Config::GFX_OVERLAY_STATS.location, Config::GFX_OVERLAY_PROJ_STATS.location,
       Config::GFX_DUMP_TEXTURES.location, Config::GFX_HIRES_TEXTURES.location,
-      Config::GFX_CONVERT_HIRES_TEXTURES.location, Config::GFX_CACHE_HIRES_TEXTURES.location,
       Config::GFX_DUMP_EFB_TARGET.location, Config::GFX_DUMP_FRAMES_AS_IMAGES.location,
       Config::GFX_FREE_LOOK.location, Config::GFX_USE_FFV1.location,
       Config::GFX_DUMP_FORMAT.location, Config::GFX_DUMP_CODEC.location,

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -75,7 +75,6 @@ void VideoConfig::Refresh()
   bOverlayProjStats = Config::Get(Config::GFX_OVERLAY_PROJ_STATS);
   bDumpTextures = Config::Get(Config::GFX_DUMP_TEXTURES);
   bHiresTextures = Config::Get(Config::GFX_HIRES_TEXTURES);
-  bConvertHiresTextures = Config::Get(Config::GFX_CONVERT_HIRES_TEXTURES);
   bCacheHiresTextures = Config::Get(Config::GFX_CACHE_HIRES_TEXTURES);
   bDumpEFBTarget = Config::Get(Config::GFX_DUMP_EFB_TARGET);
   bDumpXFBTarget = Config::Get(Config::GFX_DUMP_XFB_TARGET);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -93,7 +93,6 @@ struct VideoConfig final
   // Utility
   bool bDumpTextures;
   bool bHiresTextures;
-  bool bConvertHiresTextures;
   bool bCacheHiresTextures;
   bool bDumpEFBTarget;
   bool bDumpXFBTarget;


### PR DESCRIPTION
The stable release 5.0 has a built-in converter between this formats, so there is no need to keep the old format in current development builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4453)
<!-- Reviewable:end -->
