### PR TITLE
DolphinWX: Fix toolbar creation on macOS

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -324,7 +324,7 @@ CFrame::CFrame(wxFrame* parent, wxWindowID id, const wxString& title, wxRect geo
     g_pCodeWindow->Load();
   }
 
-  wxFrame::CreateToolBar(wxTB_DEFAULT_STYLE | wxTB_TEXT | wxTB_FLAT);
+  wxFrame::CreateToolBar(wxTB_DEFAULT_STYLE | wxTB_TEXT | wxTB_FLAT)->Realize();
 
   // Give it a status bar
   SetStatusBar(CreateStatusBar(2, wxST_SIZEGRIP, ID_STATUSBAR));

--- a/Source/Core/DolphinWX/MainToolBar.cpp
+++ b/Source/Core/DolphinWX/MainToolBar.cpp
@@ -21,7 +21,6 @@ MainToolBar::MainToolBar(ToolBarType type, wxWindow* parent, wxWindowID id, cons
   wxToolBar::SetToolBitmapSize(FromDIP(wxSize{32, 32}));
   InitializeBitmaps();
   AddToolBarButtons();
-  wxToolBar::Realize();
 
   BindEvents();
 }


### PR DESCRIPTION
This was a regression from #4380 tracked in [issue 9866](https://bugs.dolphin-emu.org/issues/9866). It seems the `wxToolBar::Realize` call must come after `SetToolBar` (called internally in `wxFrame::CreateToolBar` after creation).

It might be good to test on Windows and Linux just to be safe, but this was a pretty serious regression on macOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4454)
<!-- Reviewable:end -->
