### PR TITLE
VideoCommon: Support dumping frames to images

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -197,6 +197,7 @@ private:
   Common::Event m_frame_dump_start;
   Common::Event m_frame_dump_done;
   Common::Flag m_frame_dump_thread_running;
+  u32 m_frame_dump_image_counter = 0;
   bool m_frame_dump_frame_running = false;
   struct FrameDumpConfig
   {
@@ -207,6 +208,14 @@ private:
     bool upside_down;
     AVIDump::Frame state;
   } m_frame_dump_config;
+
+  // NOTE: The methods below are called on the framedumping thread.
+  bool StartFrameDumpToAVI(const FrameDumpConfig& config);
+  void DumpFrameToAVI(const FrameDumpConfig& config);
+  void StopFrameDumpToAVI();
+  std::string GetFrameDumpNextImageFileName() const;
+  bool StartFrameDumpToImage(const FrameDumpConfig& config);
+  void DumpFrameToImage(const FrameDumpConfig& config);
 };
 
 extern std::unique_ptr<Renderer> g_renderer;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -71,6 +71,7 @@ void VideoConfig::Load(const std::string& ini_file)
   settings->Get("ConvertHiresTextures", &bConvertHiresTextures, 0);
   settings->Get("CacheHiresTextures", &bCacheHiresTextures, 0);
   settings->Get("DumpEFBTarget", &bDumpEFBTarget, 0);
+  settings->Get("DumpFramesAsImages", &bDumpFramesAsImages, 0);
   settings->Get("FreeLook", &bFreeLook, 0);
   settings->Get("UseFFV1", &bUseFFV1, 0);
   settings->Get("EnablePixelLighting", &bEnablePixelLighting, 0);
@@ -287,6 +288,7 @@ void VideoConfig::Save(const std::string& ini_file)
   settings->Set("ConvertHiresTextures", bConvertHiresTextures);
   settings->Set("CacheHiresTextures", bCacheHiresTextures);
   settings->Set("DumpEFBTarget", bDumpEFBTarget);
+  settings->Set("DumpFramesAsImages", bDumpFramesAsImages);
   settings->Set("FreeLook", bFreeLook);
   settings->Set("UseFFV1", bUseFFV1);
   settings->Set("EnablePixelLighting", bEnablePixelLighting);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -99,6 +99,7 @@ struct VideoConfig final
   bool bConvertHiresTextures;
   bool bCacheHiresTextures;
   bool bDumpEFBTarget;
+  bool bDumpFramesAsImages;
   bool bUseFFV1;
   bool bFreeLook;
   bool bBorderlessFullscreen;


### PR DESCRIPTION
This enables support for dumping frames to a series of png files instead of an avi file.
Therefore, we can support frame dumping on Android, or other platforms where libav is not available.

I haven't tested this at all on Android, but I don't see why it shouldn't work.

**Note:** I haven't made any changes to the Android UI, if we were to add an option for it, it'd probably be best placed in menu that is accessible at runtime, rather than the main settings menu as you wouldn't want to leave it enabled for long, due to how many files would be created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4455)
<!-- Reviewable:end -->
