### PR TITLE
IPC_HLE: Fix emulated BT crash (uninitialised memory)

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
@@ -82,7 +82,7 @@ CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::CtrlBuffer(const SIOCtlVBu
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::FillBuffer(const u8* src,
                                                                       const size_t size) const
 {
-  _dbg_assert_msg_(WII_IPC_WIIMOTE, size <= m_length, "FillBuffer: size %li > payload length %i",
-                   size, m_length);
+  _assert_msg_(WII_IPC_WIIMOTE, size <= m_length, "FillBuffer: size %li > payload length %i", size,
+               m_length);
   Memory::CopyToEmu(m_payload_addr, src, size);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
@@ -58,13 +58,13 @@ protected:
     CtrlMessage() = default;
     CtrlMessage(const SIOCtlVBuffer& cmd_buffer);
 
-    u8 request_type;
-    u8 request;
-    u16 value;
-    u16 index;
-    u16 length;
-    u32 payload_addr;
-    u32 address;
+    u8 request_type = 0;
+    u8 request = 0;
+    u16 value = 0;
+    u16 index = 0;
+    u16 length = 0;
+    u32 payload_addr = 0;
+    u32 address = 0;
   };
 
   class CtrlBuffer
@@ -77,9 +77,9 @@ protected:
     void SetRetVal(const u32 retval) const { Memory::Write_U32(retval, m_cmd_address + 4); }
     bool IsValid() const { return m_cmd_address != 0; }
     void Invalidate() { m_cmd_address = m_payload_addr = 0; }
-    u8 m_endpoint;
-    u16 m_length;
-    u32 m_payload_addr;
-    u32 m_cmd_address;
+    u8 m_endpoint = 0;
+    u16 m_length = 0;
+    u32 m_payload_addr = 0;
+    u32 m_cmd_address = 0;
   };
 };


### PR DESCRIPTION
When the emulated BT device is created, m_HCIEndpoint (which is a CtrlBuffer)'s m_cmd_address is not initialised to 0. So it ends up holding a random value. This is normally not an issue… but the emulated Bluetooth code relies on m_cmd_address to know whether the HCI endpoint is still valid.

This is a problem with ES_Launch, because the bt_emu class is destructed and re-constructed, and while m_cmd_address is still uninitialised, the ES_Launch code disconnects all Wii remotes, which triggers a HCI event and hence the bug.

I've also changed FillBuffer to always check the length (instead of only in debug builds); had this assert showed up, it'd have been easier to fix the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4457)
<!-- Reviewable:end -->
