### PR TITLE
D3D/Vulkan: Handle strided XFB copies

### DIFF
--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -275,8 +275,10 @@ void FramebufferManager::CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight,
                                        const EFBRectangle& sourceRc, float Gamma)
 {
   u8* dst = Memory::GetPointer(xfbAddr);
-  // below div2 due to dx using pixel width
-  s_xfbEncoder.Encode(dst, fbStride / 2, fbHeight, sourceRc, Gamma);
+
+  // The destination stride can differ from the copy region width, in which case the pixels
+  // outside the copy region should not be written to.
+  s_xfbEncoder.Encode(dst, static_cast<u32>(sourceRc.GetWidth()), fbHeight, sourceRc, Gamma);
 }
 
 std::unique_ptr<XFBSourceBase> FramebufferManager::CreateXFBSource(unsigned int target_width,

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -1415,9 +1415,11 @@ void FramebufferManager::CopyToRealXFB(u32 xfb_addr, u32 fb_stride, u32 fb_heigh
       {static_cast<u32>(scaled_rc.GetWidth()), static_cast<u32>(scaled_rc.GetHeight())}};
   Texture2D* src_texture = ResolveEFBColorTexture(scaled_rc_vk);
 
-  // 2 bytes per pixel, so divide fb_stride by 2 to get the width.
-  TextureCache::GetInstance()->EncodeYUYVTextureToMemory(xfb_ptr, fb_stride / 2, fb_stride,
-                                                         fb_height, src_texture, scaled_rc);
+  // The destination stride can differ from the copy region width, in which case the pixels
+  // outside the copy region should not be written to.
+  TextureCache::GetInstance()->EncodeYUYVTextureToMemory(
+      xfb_ptr, static_cast<u32>(source_rc.GetWidth()), fb_stride, fb_height, src_texture,
+      scaled_rc);
 
   // If we sourced directly from the EFB framebuffer, restore it to a color attachment.
   if (src_texture == m_efb_color_texture.get())

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -888,7 +888,7 @@ void TextureCache::EncodeYUYVTextureToMemory(void* dst_ptr, u32 dst_width, u32 d
                          m_rgb_to_yuyv_shader);
   VkRect2D region = {{0, 0}, {output_width, dst_height}};
   draw.BeginRenderPass(m_texture_encoder->GetEncodingTextureFramebuffer(), region);
-  draw.SetPSSampler(0, src_texture->GetView(), g_object_cache->GetPointSampler());
+  draw.SetPSSampler(0, src_texture->GetView(), g_object_cache->GetLinearSampler());
   draw.DrawQuad(0, 0, static_cast<int>(output_width), static_cast<int>(dst_height), src_rect.left,
                 src_rect.top, 0, src_rect.GetWidth(), src_rect.GetHeight(),
                 static_cast<int>(src_texture->GetWidth()),


### PR DESCRIPTION
The two backends assumed that the stride would always be equal to the width of the copy region * 2. It's possible to specify a larger stride, in which case the region outside the copy region should be untouched. GL was already behaving correctly in this regard.

Vulkan was also using a point sampler instead of a linear sampler, which would result in a lack of filtering if y-scaling was enabled for the copy.

Should hopefully fix VC Earthworm Jim, possibly others that rely on this behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4458)
<!-- Reviewable:end -->
