### PR TITLE
NetPlay: Fix build when miniupnpc is disabled

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetPlayLauncher.h
+++ b/Source/Core/DolphinWX/NetPlay/NetPlayLauncher.h
@@ -41,7 +41,9 @@ public:
 
   std::string game_name;
   u16 listen_port = 0;
+#ifdef USE_UPNP
   bool forward_port;
+#endif
 };
 
 class NetPlayJoinConfig : public NetPlayLaunchConfig

--- a/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
+++ b/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp
@@ -337,7 +337,9 @@ void NetPlaySetupFrame::DoHost()
   host_config.player_name = WxStrToStr(m_nickname_text->GetValue());
   host_config.game_list_ctrl = m_game_list;
   host_config.SetDialogInfo(netplay_section, m_parent);
+#ifdef USE_UPNP
   host_config.forward_port = m_upnp_chk->GetValue();
+#endif
 
   if (host_config.use_traversal)
   {


### PR DESCRIPTION
Building Dolphin with `-DUSE_UPNP=FALSE` currently leads to this error:
```
/home/linkmauve/packages/dolphin-emu-git/src/dolphin-emu/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp: In member function ‘void NetPlaySetupFrame::DoHost()’:
/home/linkmauve/packages/dolphin-emu-git/src/dolphin-emu/Source/Core/DolphinWX/NetPlay/NetPlaySetupFrame.cpp:340:30: error: ‘m_upnp_chk’ was not declared in this scope
   host_config.forward_port = m_upnp_chk->GetValue();
                              ^~~~~~~~~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4460)
<!-- Reviewable:end -->
