### PR TITLE
[HLE] Fixes XFB issues in Debug Mode

### DIFF
--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -55,17 +55,17 @@ static const SPatch OSPatches[] = {
     {"OSPanic",                      HLE_OS::HLE_OSPanic,                   HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
 
     // This needs to be put before vprintf (because vprintf is called indirectly by this)
-    {"JUTWarningConsole_f",          HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
+    {"JUTWarningConsole_f",          HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
 
-    {"OSReport",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
-    {"DEBUGPrint",                   HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
-    {"WUD_DEBUGPrint",               HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
-    {"vprintf",                      HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
-    {"printf",                       HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
-    {"nlPrintf",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_DEBUG},
-    {"puts",                         HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_DEBUG}, // gcc-optimized printf?
-    {"___blank",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_REPLACE, HLE_TYPE_DEBUG}, // used for early init things (normally)
-    {"__write_console",              HLE_OS::HLE_write_console,             HLE_HOOK_REPLACE, HLE_TYPE_DEBUG}, // used by sysmenu (+more?)
+    {"OSReport",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
+    {"DEBUGPrint",                   HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
+    {"WUD_DEBUGPrint",               HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
+    {"vprintf",                      HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
+    {"printf",                       HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
+    {"nlPrintf",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
+    {"puts",                         HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG}, // gcc-optimized printf?
+    {"___blank",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG}, // used for early init things (normally)
+    {"__write_console",              HLE_OS::HLE_write_console,             HLE_HOOK_START,   HLE_TYPE_DEBUG}, // used by sysmenu (+more?)
 
     {"GeckoCodehandler",             HLE_Misc::GeckoCodeHandlerICacheFlush, HLE_HOOK_START,   HLE_TYPE_FIXED},
     {"GeckoHandlerReturnTrampoline", HLE_Misc::GeckoReturnTrampoline,       HLE_HOOK_REPLACE, HLE_TYPE_FIXED},

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -183,10 +183,19 @@ void Execute(u32 _CurrentPC, u32 _Instruction)
   // OSPatches[pos].m_szPatchName);
 }
 
-u32 GetFunctionIndex(u32 addr)
+u32 GetFunctionIndex(u32 address)
 {
-  auto iter = s_original_instructions.find(addr);
+  auto iter = s_original_instructions.find(address);
   return (iter != s_original_instructions.end()) ? iter->second : 0;
+}
+
+u32 GetFirstFunctionIndex(u32 address)
+{
+  u32 index = GetFunctionIndex(address);
+  auto first = std::find_if(
+      s_original_instructions.begin(), s_original_instructions.end(),
+      [=](const auto& entry) { return entry.second == index && entry.first < address; });
+  return first == std::end(s_original_instructions) ? index : 0;
 }
 
 int GetFunctionTypeByIndex(u32 index)

--- a/Source/Core/Core/HLE/HLE.h
+++ b/Source/Core/Core/HLE/HLE.h
@@ -34,7 +34,10 @@ u32 UnPatch(const std::string& patchName);
 bool UnPatch(u32 addr, const std::string& name = {});
 void Execute(u32 _CurrentPC, u32 _Instruction);
 
-u32 GetFunctionIndex(u32 em_address);
+// Returns the HLE function index if the address is located in the function
+u32 GetFunctionIndex(u32 address);
+// Returns the HLE function index if the address matches the function start
+u32 GetFirstFunctionIndex(u32 address);
 int GetFunctionTypeByIndex(u32 index);
 int GetFunctionFlagsByIndex(u32 index);
 

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -205,7 +205,7 @@ void CachedInterpreter::Jit(u32 address)
   {
     js.downcountAmount += ops[i].opinfo->numCycles;
 
-    u32 function = HLE::GetFunctionIndex(ops[i].address);
+    u32 function = HLE::GetFirstFunctionIndex(ops[i].address);
     if (function != 0)
     {
       int type = HLE::GetFunctionTypeByIndex(function);

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -100,7 +100,7 @@ static void Trace(UGeckoInstruction& inst)
 int Interpreter::SingleStepInner()
 {
   static UGeckoInstruction instCode;
-  u32 function = HLE::GetFunctionIndex(PC);
+  u32 function = HLE::GetFirstFunctionIndex(PC);
   if (function != 0)
   {
     int type = HLE::GetFunctionTypeByIndex(function);

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -797,7 +797,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
       SetJumpTarget(noExtIntEnable);
     }
 
-    u32 function = HLE::GetFunctionIndex(ops[i].address);
+    u32 function = HLE::GetFirstFunctionIndex(ops[i].address);
     if (function != 0)
     {
       int type = HLE::GetFunctionTypeByIndex(function);

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -604,7 +604,7 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
     if (i == (code_block.m_num_instructions - 1))
       js.isLastInstruction = true;
 
-    u32 function = HLE::GetFunctionIndex(ops[i].address);
+    u32 function = HLE::GetFirstFunctionIndex(ops[i].address);
     if (function != 0)
     {
       int type = HLE::GetFunctionTypeByIndex(function);


### PR DESCRIPTION
When Dolphin is running in Debug Mode it will use HLE and patchs some functions. However, some functions shouldn't be replaced for several reasons. The first one is if we replace a wrong one it might crash the game. The second one is even if it's a debugging function it might do something useful not just printing a debug message. For instance, replacing a printf prevents it to be written to the XFB.

This PR fixes invisible texts in Debug Mode when using a real XFB. It replaced the REPLACE hooks with START ones. Each interpreter was patched with a new function which gets the HLE function index only if the start address is provided. Indeed, since we use a start hook, the rest of the function will be executed and will trigger multiple times the HLE function rather than just once. Some interpreters' HLE implementation wasn't working properly so I had to fix that as well.

Ready to be reviewed & merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4469)
<!-- Reviewable:end -->
