### PR TITLE
VideoCommon: Don't process the depth range in the vertex shader if it's not oversized.

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -559,7 +559,7 @@ void Renderer::SetViewport()
   float Y = Renderer::EFBToScaledYf(xfmem.viewport.yOrig + xfmem.viewport.ht - scissorYOff);
   float Wd = Renderer::EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float Ht = Renderer::EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, 0.0f, 16777216.0f);
+  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, 0.0f, 16777215.0f);
   float min_depth =
       MathUtil::Clamp<float>(xfmem.viewport.farZ - range, 0.0f, 16777215.0f) / 16777216.0f;
   float max_depth = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -464,7 +464,7 @@ void Renderer::SetViewport()
   float y = Renderer::EFBToScaledYf(xfmem.viewport.yOrig + xfmem.viewport.ht - scissor_y_offset);
   float width = Renderer::EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float height = Renderer::EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, 0.0f, 16777216.0f);
+  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, 0.0f, 16777215.0f);
   float min_depth =
       MathUtil::Clamp<float>(xfmem.viewport.farZ - range, 0.0f, 16777215.0f) / 16777216.0f;
   float max_depth = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -478,10 +478,13 @@ void Renderer::SetViewport()
     y += height;
     height = -height;
   }
+
+  // If an inverted depth range is used, which D3D doesn't support,
+  // we need to calculate the depth range in the vertex shader.
   if (xfmem.viewport.zRange < 0.0f)
   {
-    min_depth = 1.0f - min_depth;
-    max_depth = 1.0f - max_depth;
+    min_depth = 0.0f;
+    max_depth = GX_MAX_DEPTH;
   }
 
   // In D3D, the viewport rectangle must fit within the render target.
@@ -490,11 +493,9 @@ void Renderer::SetViewport()
   width = (x + width <= GetTargetWidth()) ? width : (GetTargetWidth() - x);
   height = (y + height <= GetTargetHeight()) ? height : (GetTargetHeight() - y);
 
-  // We do depth clipping and depth range in the vertex shader instead of relying
-  // on the graphics API. However we still need to ensure depth values don't exceed
-  // the maximum value supported by the console GPU. We also need to account for the
-  // fact that the entire depth buffer is inverted on D3D, so we set GX_MAX_DEPTH as
-  // an inverted near value.
+  // We use an inverted depth range here to apply the Reverse Z trick.
+  // This trick makes sure we match the precision provided by the 1:0
+  // clipping depth range on the hardware.
   D3D12_VIEWPORT vp = {x, y, width, height, 1.0f - max_depth, 1.0f - min_depth};
   D3D::current_command_list->RSSetViewports(1, &vp);
 }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1122,12 +1122,10 @@ void Renderer::SetViewport()
                           (float)scissorYOff);
   float Width = EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float Height = EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-  float GLNear = MathUtil::Clamp<float>(
-                     xfmem.viewport.farZ -
-                         MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777216.0f, 16777216.0f),
-                     0.0f, 16777215.0f) /
-                 16777216.0f;
-  float GLFar = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
+  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777216.0f, 16777216.0f);
+  float min_depth =
+      MathUtil::Clamp<float>(xfmem.viewport.farZ - range, 0.0f, 16777215.0f) / 16777216.0f;
+  float max_depth = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
   if (Width < 0)
   {
     X += Width;
@@ -1154,17 +1152,7 @@ void Renderer::SetViewport()
   // vertex shader we only need to ensure depth values don't exceed the maximum
   // value supported by the console GPU. If not, we simply clamp the near/far values
   // themselves to the maximum value as done above.
-  if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
-  {
-    if (xfmem.viewport.zRange < 0.0f)
-      glDepthRangef(0.0f, GX_MAX_DEPTH);
-    else
-      glDepthRangef(GX_MAX_DEPTH, 0.0f);
-  }
-  else
-  {
-    glDepthRangef(GLFar, GLNear);
-  }
+  glDepthRangef(max_depth, min_depth);
 }
 
 void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1122,7 +1122,7 @@ void Renderer::SetViewport()
                           (float)scissorYOff);
   float Width = EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float Height = EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777216.0f, 16777216.0f);
+  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777215.0f, 16777215.0f);
   float min_depth =
       MathUtil::Clamp<float>(xfmem.viewport.farZ - range, 0.0f, 16777215.0f) / 16777216.0f;
   float max_depth = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1649,15 +1649,18 @@ void Renderer::SetViewport()
     y += height;
     height = -height;
   }
+
+  // If an inverted depth range is used, which D3D doesn't support,
+  // we need to calculate the depth range in the vertex shader.
   if (xfmem.viewport.zRange < 0.0f)
   {
-    min_depth = 1.0f - min_depth;
-    max_depth = 1.0f - max_depth;
+    min_depth = 0.0f;
+    max_depth = GX_MAX_DEPTH;
   }
 
-  // If we do depth clipping and depth range in the vertex shader we only need to ensure
-  // depth values don't exceed the maximum value supported by the console GPU. If not,
-  // we simply clamp the near/far values themselves to the maximum value as done above.
+  // We use an inverted depth range here to apply the Reverse Z trick.
+  // This trick makes sure we match the precision provided by the 1:0
+  // clipping depth range on the hardware.
   VkViewport viewport = {x, y, width, height, 1.0f - max_depth, 1.0f - min_depth};
   StateTracker::GetInstance()->SetViewport(viewport);
 }

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1635,6 +1635,10 @@ void Renderer::SetViewport()
   float y = Renderer::EFBToScaledYf(xfmem.viewport.yOrig + xfmem.viewport.ht - scissor_y_offset);
   float width = Renderer::EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float height = Renderer::EFBToScaledYf(-2.0f * xfmem.viewport.ht);
+  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777216.0f, 16777216.0f);
+  float min_depth =
+      MathUtil::Clamp<float>(xfmem.viewport.farZ - range, 0.0f, 16777215.0f) / 16777216.0f;
+  float max_depth = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
   if (width < 0.0f)
   {
     x += width;
@@ -1645,29 +1649,16 @@ void Renderer::SetViewport()
     y += height;
     height = -height;
   }
+  if (xfmem.viewport.zRange < 0.0f)
+  {
+    min_depth = 1.0f - min_depth;
+    max_depth = 1.0f - max_depth;
+  }
 
   // If we do depth clipping and depth range in the vertex shader we only need to ensure
   // depth values don't exceed the maximum value supported by the console GPU. If not,
   // we simply clamp the near/far values themselves to the maximum value as done above.
-  float min_depth, max_depth;
-  if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
-  {
-    min_depth = 1.0f - GX_MAX_DEPTH;
-    max_depth = 1.0f;
-  }
-  else
-  {
-    float near_val = MathUtil::Clamp<float>(xfmem.viewport.farZ -
-                                                MathUtil::Clamp<float>(xfmem.viewport.zRange,
-                                                                       -16777216.0f, 16777216.0f),
-                                            0.0f, 16777215.0f) /
-                     16777216.0f;
-    float far_val = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
-    min_depth = near_val;
-    max_depth = far_val;
-  }
-
-  VkViewport viewport = {x, y, width, height, min_depth, max_depth};
+  VkViewport viewport = {x, y, width, height, 1.0f - max_depth, 1.0f - min_depth};
   StateTracker::GetInstance()->SetViewport(viewport);
 }
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1635,7 +1635,7 @@ void Renderer::SetViewport()
   float y = Renderer::EFBToScaledYf(xfmem.viewport.yOrig + xfmem.viewport.ht - scissor_y_offset);
   float width = Renderer::EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float height = Renderer::EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777216.0f, 16777216.0f);
+  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777215.0f, 16777215.0f);
   float min_depth =
       MathUtil::Clamp<float>(xfmem.viewport.farZ - range, 0.0f, 16777215.0f) / 16777216.0f;
   float max_depth = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1650,8 +1650,9 @@ void Renderer::SetViewport()
     height = -height;
   }
 
-  // If an inverted depth range is used, which D3D doesn't support,
-  // we need to calculate the depth range in the vertex shader.
+  // If an inverted depth range is used, which the Vulkan drivers don't
+  // support, we need to calculate the depth range in the vertex shader.
+  // TODO: Make this into a DriverDetails bug and write a test for CTS.
   if (xfmem.viewport.zRange < 0.0f)
   {
     min_depth = 0.0f;

--- a/Source/Core/VideoCommon/VertexShaderGen.h
+++ b/Source/Core/VideoCommon/VertexShaderGen.h
@@ -43,7 +43,8 @@ struct vertex_shader_uid_data
   u32 texMtxInfo_n_projection : 16;  // Stored separately to guarantee that the texMtxInfo struct is
                                      // 8 bits wide
   u32 ssaa : 1;
-  u32 pad : 15;
+  u32 vertex_depth : 1;
+  u32 pad : 14;
 
   struct
   {


### PR DESCRIPTION
The depth equation that can handle oversized viewports is not completely accurate due to a compensation for the perspective division. However we can simply fallback to the host graphics API depth range equation as long as the range isn't oversized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4471)
<!-- Reviewable:end -->
