### PR TITLE
[HLE] Set HLE_GeneralDebugPrint return value

### DIFF
--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -55,6 +55,8 @@ void HLE_GeneralDebugPrint()
   rGPR[3] = static_cast<u32>(report_message.length());
   NPC = LR;
 
+  if (!report_message.empty() && report_message.back() == '\n')
+    report_message.pop_back();
   NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, SHIFTJISToUTF8(report_message).c_str());
 }
 
@@ -159,9 +161,6 @@ std::string GetStringVA(u32 strReg)
       result += string[i];
     }
   }
-
-  if (!result.empty() && result.back() == '\n')
-    result.pop_back();
 
   return result;
 }

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -52,6 +52,7 @@ void HLE_GeneralDebugPrint()
     report_message = GetStringVA();
   }
 
+  rGPR[3] = static_cast<u32>(report_message.length());
   NPC = LR;
 
   NOTICE_LOG(OSREPORT, "%08x->%08x| %s", LR, PC, SHIFTJISToUTF8(report_message).c_str());


### PR DESCRIPTION
The following C code will behave differently if running with or without HLE.
```C
char str[] = "This string has a length of 31\n";
int n = 0;

n = printf("%s", str);
if (n == 31)
    printf("SUCCESS!\n");
else
    printf("FAILURE! (%d != 31)\n", n);
```

Results:
 * Without HLE_GeneralDebugPrint
> This string has a length of 31
SUCCESS!
 * With HLE_GeneralDebugPrint
> This string has a length of 31
FAILURE! (-2147351780 != 31)
 * With HLE_GeneralDebugPrint and its return value
> This string has a length of 31
FAILURE! (30 != 31)

I assume that some games could stop running or crash after checking printf/puts/... negative return value. According to the printf manual it has to return the number of characters written. Concerning puts manual, it should only return a positive integer so returning the number of characters written should be fine.

The second issue comes from the GetStringVA implementation that strips newlines. IMO, that function should return the string without alteration like that.

Ready to be reviewed and merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4473)
<!-- Reviewable:end -->
