### PR TITLE
[WIP] Fix the order of the name of the hotkeys

### DIFF
--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -84,6 +84,7 @@ const std::string hotkey_labels[] = {
     _trans("Load State Slot 8"),
     _trans("Load State Slot 9"),
     _trans("Load State Slot 10"),
+    _trans("Load from selected slot"),
 
     _trans("Save State Slot 1"),
     _trans("Save State Slot 2"),
@@ -95,6 +96,7 @@ const std::string hotkey_labels[] = {
     _trans("Save State Slot 8"),
     _trans("Save State Slot 9"),
     _trans("Save State Slot 10"),
+    _trans("Save to selected slot"),
 
     _trans("Select State Slot 1"),
     _trans("Select State Slot 2"),
@@ -106,8 +108,6 @@ const std::string hotkey_labels[] = {
     _trans("Select State Slot 8"),
     _trans("Select State Slot 9"),
     _trans("Select State Slot 10"),
-    _trans("Save to selected slot"),
-    _trans("Load from selected slot"),
 
     _trans("Load State Last 1"),
     _trans("Load State Last 2"),


### PR DESCRIPTION
This pr is to fix issue [9919](https://bugs.dolphin-emu.org/issues/9919#change-727130) which has been introduced by pr #4461 

Don't merge/review it now, I need to do some test to confirm it fixes it using the builds from buildbot (I have builds problem right now, but it's trivial changes so it should build).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4475)
<!-- Reviewable:end -->
