### PR TITLE
DolphinWX: VideoConfigDiag: Don't wrap text manually

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -1030,7 +1030,6 @@ void VideoConfigDiag::Evt_EnterControl(wxMouseEvent& ev)
   // look up the description of the selected control and assign it to the current description text
   // object's label
   descr_text->SetLabel(ctrl_descs[ctrl]);
-  descr_text->Wrap(descr_text->GetSize().GetWidth());
 
   ev.Skip();
 }
@@ -1046,7 +1045,6 @@ void VideoConfigDiag::Evt_LeaveControl(wxMouseEvent& ev)
     return;
 
   descr_text->SetLabel(wxGetTranslation(default_desc));
-  descr_text->Wrap(descr_text->GetSize().GetWidth());
 
   ev.Skip();
 }


### PR DESCRIPTION
Wrapping the description text manually causes it to be wrapped incorrectly and look dreadful, even when not using a HiDPI display.

It doesn't look like we need to do that anyway, since wxWidgets will take care of wrapping the text for us. And it'll do it automatically and without this issue.

master:

![master](https://cloud.githubusercontent.com/assets/4209061/20730237/991ed972-b685-11e6-8746-0a92a511847a.png)

In this PR:

![PR](https://cloud.githubusercontent.com/assets/4209061/20730239/9b53961a-b685-11e6-9429-51dd54cd6696.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4476)
<!-- Reviewable:end -->
