### PR TITLE
Android: Fix Wii bindings resetting everything

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -403,8 +403,6 @@ public final class SettingsFragmentPresenter
 
 	private void addWiimoteSubSettings(ArrayList<SettingsItem> sl, int wiimoteNumber)
 	{
-		mSettings.get(SettingsFile.SETTINGS_DOLPHIN).put(SettingsFile.SECTION_BINDINGS, new SettingSection(SettingsFile.SECTION_BINDINGS));
-
 		IntSetting extension = null;
 		Setting bindA = null;
 		Setting bindB = null;


### PR DESCRIPTION
This line of code isn't supposed to be here. I was supposed to get rid of it, but somehow I overlooked it and it slipped in. Every time the user opens the Wii bindings, this line of code was clearing the entire bindings section of the ini!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4478)
<!-- Reviewable:end -->
