### PR TITLE
[HLE] Variable Argument Lists support

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SRCS
   HLE/HLE.cpp
   HLE/HLE_Misc.cpp
   HLE/HLE_OS.cpp
+  HLE/HLE_VarArgs.cpp
   HW/AudioInterface.cpp
   HW/CPU.cpp
   HW/DSP.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -343,6 +343,7 @@
     <ClInclude Include="HLE\HLE.h" />
     <ClInclude Include="HLE\HLE_Misc.h" />
     <ClInclude Include="HLE\HLE_OS.h" />
+    <ClInclude Include="HLE\HLE_VarArgs.h" />
     <ClInclude Include="Host.h" />
     <ClInclude Include="HotkeyManager.h" />
     <ClInclude Include="HW\AudioInterface.h" />

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile Include="HLE\HLE.cpp" />
     <ClCompile Include="HLE\HLE_Misc.cpp" />
     <ClCompile Include="HLE\HLE_OS.cpp" />
+    <ClCompile Include="HLE\HLE_VarArgs.cpp" />
     <ClCompile Include="HotkeyManager.cpp" />
     <ClCompile Include="HW\AudioInterface.cpp" />
     <ClCompile Include="HW\CPU.cpp" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -293,6 +293,9 @@
     <ClCompile Include="HLE\HLE_OS.cpp">
       <Filter>HLE</Filter>
     </ClCompile>
+    <ClCompile Include="HLE\HLE_VarArgs.cpp" />
+      <Filter>HLE</Filter>
+    </ClCompile>
     <ClCompile Include="PowerPC\BreakPoints.cpp">
       <Filter>PowerPC</Filter>
     </ClCompile>

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -955,6 +955,9 @@
     <ClInclude Include="HLE\HLE_OS.h">
       <Filter>HLE</Filter>
     </ClInclude>
+    <ClInclude Include="HLE\HLE_VarArgs.h">
+      <Filter>HLE</Filter>
+    </ClInclude>
     <ClInclude Include="PowerPC\CachedInterpreter\CachedInterpreter.h">
       <Filter>PowerPC\Cached Interpreter</Filter>
     </ClInclude>

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -60,7 +60,7 @@ static const SPatch OSPatches[] = {
     {"OSReport",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
     {"DEBUGPrint",                   HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
     {"WUD_DEBUGPrint",               HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
-    {"vprintf",                      HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
+    {"vprintf",                      HLE_OS::HLE_GeneralDebugVPrint,        HLE_HOOK_START,   HLE_TYPE_DEBUG},
     {"printf",                       HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
     {"nlPrintf",                     HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG},
     {"puts",                         HLE_OS::HLE_GeneralDebugPrint,         HLE_HOOK_START,   HLE_TYPE_DEBUG}, // gcc-optimized printf?

--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -95,7 +95,7 @@ std::string GetStringVA(u32 str_reg)
   std::string ArgumentBuffer;
   std::string result;
   std::string string = PowerPC::HostGetString(GPR(str_reg));
-  HLE::VAList ap(GPR(1) + 0x8, str_reg + 1);
+  HLE::SystemVABI::VAList ap(GPR(1) + 0x8, str_reg + 1);
 
   for (size_t i = 0; i < string.size(); i++)
   {
@@ -143,8 +143,8 @@ std::string GetStringVA(u32 str_reg)
         break;
 
       case 'n':
-        PowerPC::HostWrite_U32(static_cast<u32>(result.size()), ap.GetArgT<u32>());
         // %n doesn't output anything, so the result variable is untouched
+        PowerPC::HostWrite_U32(static_cast<u32>(result.size()), ap.GetArgT<u32>());
         break;
 
       default:

--- a/Source/Core/Core/HLE/HLE_OS.h
+++ b/Source/Core/Core/HLE/HLE_OS.h
@@ -7,6 +7,7 @@
 namespace HLE_OS
 {
 void HLE_GeneralDebugPrint();
+void HLE_GeneralDebugVPrint();
 void HLE_write_console();
 void HLE_OSPanic();
 }

--- a/Source/Core/Core/HLE/HLE_VarArgs.cpp
+++ b/Source/Core/Core/HLE/HLE_VarArgs.cpp
@@ -1,0 +1,17 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/HLE/HLE_VarArgs.h"
+
+HLE::SystemVABI::VAList::~VAList() = default;
+
+u32 HLE::SystemVABI::VAList::GetGPR(u32 gpr) const
+{
+  return GPR(gpr);
+}
+
+double HLE::SystemVABI::VAList::GetFPR(u32 fpr) const
+{
+  return rPS0(fpr);
+}

--- a/Source/Core/Core/HLE/HLE_VarArgs.cpp
+++ b/Source/Core/Core/HLE/HLE_VarArgs.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/HLE/HLE_VarArgs.h"
 
+#include "Common/Logging/Log.h"
+
 HLE::SystemVABI::VAList::~VAList() = default;
 
 u32 HLE::SystemVABI::VAList::GetGPR(u32 gpr) const
@@ -14,4 +16,52 @@ u32 HLE::SystemVABI::VAList::GetGPR(u32 gpr) const
 double HLE::SystemVABI::VAList::GetFPR(u32 fpr) const
 {
   return rPS0(fpr);
+}
+
+HLE::SystemVABI::VAListStruct::VAListStruct(u32 address)
+    : VAList(0), m_va_list{PowerPC::HostRead_U8(address), PowerPC::HostRead_U8(address + 1),
+                           PowerPC::HostRead_U32(address + 4), PowerPC::HostRead_U32(address + 8)},
+      m_address(address), m_has_fpr_area(GetCRBit(6) == 1)
+{
+  m_stack = m_va_list.overflow_arg_area;
+  m_gpr += m_va_list.gpr;
+  m_fpr += m_va_list.fpr;
+}
+
+u32 HLE::SystemVABI::VAListStruct::GetGPRArea() const
+{
+  return m_va_list.reg_save_area;
+}
+
+u32 HLE::SystemVABI::VAListStruct::GetFPRArea() const
+{
+  return GetGPRArea() + 4 * 8;
+}
+
+u32 HLE::SystemVABI::VAListStruct::GetGPR(u32 gpr) const
+{
+  if (gpr < 3 || gpr > 10)
+  {
+    ERROR_LOG(OSHLE, "VAListStruct at %08x doesn't have GPR%d!", m_address, gpr);
+    return 0;
+  }
+  const u32 gpr_address = Common::AlignUp(GetGPRArea() + 4 * (gpr - 3), 4);
+  return PowerPC::HostRead_U32(gpr_address);
+}
+
+double HLE::SystemVABI::VAListStruct::GetFPR(u32 fpr) const
+{
+  double value = 0.0;
+
+  if (!m_has_fpr_area || fpr < 1 || fpr > 8)
+  {
+    ERROR_LOG(OSHLE, "VAListStruct at %08x doesn't have FPR%d!", m_address, fpr);
+  }
+  else
+  {
+    const u32 fpr_address = Common::AlignUp(GetFPRArea() + 8 * (fpr - 1), 8);
+    const u64 integral = PowerPC::HostRead_U64(fpr_address);
+    std::memcpy(&value, &integral, sizeof(double));
+  }
+  return value;
 }

--- a/Source/Core/Core/HLE/HLE_VarArgs.h
+++ b/Source/Core/Core/HLE/HLE_VarArgs.h
@@ -1,0 +1,138 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/Align.h"
+#include "Common/CommonTypes.h"
+
+#include "Core/HW/Memmap.h"
+#include "Core/PowerPC/PowerPC.h"
+
+#include <type_traits>
+
+namespace HLE
+{
+// See System V ABI (SVR4) for more details
+//  -> 3-18 Parameter Passing
+//  -> 3-21 Variable Argument Lists
+//
+// Source:
+// http://refspecs.linux-foundation.org/elf/elfspec_ppc.pdf
+class VAList
+{
+public:
+  explicit VAList(u32 stack, u32 gpr = 3, u32 fpr = 1, u32 gpr_max = 10, u32 fpr_max = 8)
+      : m_gpr(gpr), m_fpr(fpr), m_gpr_max(gpr_max), m_fpr_max(fpr_max), m_stack(stack)
+  {
+  }
+  ~VAList() = default;
+
+  // SFINAE
+  template <typename T>
+  constexpr bool IS_ARG_POINTER = std::is_union<T>() || std::is_class<T>();
+  template <typename T>
+  constexpr bool IS_WORD = std::is_pointer<T>() || (std::is_integral<T>() && sizeof(T) <= 4);
+  template <typename T>
+  constexpr bool IS_DOUBLE_WORD = std::is_integral<T>() && sizeof(T) == 8;
+  template <typename T>
+  constexpr bool IS_ARG_REAL = std::is_floating_point<T>();
+
+  // 0 - arg_ARGPOINTER
+  template <typename T, typename std::enable_if_t<IS_ARG_POINTER<T>>* = nullptr>
+  T GetArg()
+  {
+    T obj;
+    u32 addr = GetArg<u32>();
+
+    for (size_t i = 0; i < sizeof(T); i += 1, addr += 1)
+    {
+      reinterpret_cast<u8*>(&obj)[i] = PowerPC::HostRead_U8(addr);
+    }
+
+    return obj;
+  }
+
+  // 1 - arg_WORD
+  template <typename T, typename std::enable_if_t<IS_WORD<T>>* = nullptr>
+  T GetArg()
+  {
+    static_assert(!std::is_pointer<T>(), "VAList doesn't support pointers");
+    u64 value;
+
+    if (m_gpr <= m_gpr_max)
+    {
+      value = GPR(m_gpr);
+      m_gpr += 1;
+    }
+    else
+    {
+      m_stack = Common::AlignUp(m_stack, 4);
+      value = PowerPC::HostRead_U32(m_stack);
+      m_stack += 4;
+    }
+
+    return static_cast<T>(value);
+  }
+
+  // 2 - arg_DOUBLEWORD
+  template <typename T, typename std::enable_if_t<IS_DOUBLE_WORD<T>>* = nullptr>
+  T GetArg()
+  {
+    u64 value;
+
+    if (m_gpr % 2 == 0)
+      m_gpr += 1;
+    if (m_gpr < m_gpr_max)
+    {
+      value = static_cast<u64>(GPR(m_gpr)) << 32 | GPR(m_gpr + 1);
+      m_gpr += 2;
+    }
+    else
+    {
+      m_stack = Common::AlignUp(m_stack, 8);
+      value = PowerPC::HostRead_U64(m_stack);
+      m_stack += 8;
+    }
+
+    return static_cast<T>(value);
+  }
+
+  // 3 - arg_ARGREAL
+  template <typename T, typename std::enable_if_t<IS_ARG_REAL<T>>* = nullptr>
+  T GetArg()
+  {
+    double value;
+
+    if (m_fpr <= m_fpr_max)
+    {
+      value = rPS0(m_fpr);
+      m_fpr += 1;
+    }
+    else
+    {
+      m_stack = Common::AlignUp(m_stack, 8);
+      const u64 integral = PowerPC::HostRead_U64(m_stack);
+      std::memcpy(&value, &integral, sizeof(double));
+      m_stack += 8;
+    }
+
+    return static_cast<T>(value);
+  }
+
+  // Helper
+  template <typename T>
+  T GetArgT()
+  {
+    return static_cast<T>(GetArg<T>());
+  }
+
+private:
+  u32 m_gpr = 3;
+  u32 m_fpr = 1;
+  const u32 m_gpr_max = 10;
+  const u32 m_fpr_max = 8;
+  u32 m_stack;
+};
+}

--- a/Source/Core/Core/HLE/HLE_VarArgs.h
+++ b/Source/Core/Core/HLE/HLE_VarArgs.h
@@ -130,15 +130,48 @@ public:
     return static_cast<T>(GetArg<T>());
   }
 
-private:
+protected:
   u32 m_gpr = 3;
   u32 m_fpr = 1;
   const u32 m_gpr_max = 10;
   const u32 m_fpr_max = 8;
   u32 m_stack;
 
+private:
   virtual u32 GetGPR(u32 gpr) const;
   virtual double GetFPR(u32 fpr) const;
 };
+
+// See System V ABI (SVR4) for more details
+//  -> 6-6 Required Routines
+//  -> 3-21 Variable Argument Lists
+//
+// Source:
+// http://refspecs.linux-foundation.org/elf/elfspec_ppc.pdf
+class VAListStruct : public VAList
+{
+public:
+  explicit VAListStruct(u32 address);
+  ~VAListStruct() = default;
+
+private:
+  struct svr4_va_list
+  {
+    u8 gpr;
+    u8 fpr;
+    u32 overflow_arg_area;
+    u32 reg_save_area;
+  };
+  const svr4_va_list m_va_list;
+  const u32 m_address;
+  const bool m_has_fpr_area;
+
+  u32 GetGPRArea() const;
+  u32 GetFPRArea() const;
+
+  u32 GetGPR(u32 gpr) const override;
+  double GetFPR(u32 fpr) const override;
+};
+
 }  // namespace SystemVABI
 }  // namespace HLE


### PR DESCRIPTION
I originally planned to rewrite the ```GetStringVA``` but each times I tried I figured out there are so many tricky things to handle and it will make code redundancy with so many "hacks" and makes it ugly really quickly. So, I had the idea to rewrite an implementation of varargs following the [SVR4 ABI](http://refspecs.linux-foundation.org/elf/elfspec_ppc.pdf).

It pays attention to registers parity for doubleword, stack alignment depending on the type and will grab values from registers or the stack when necessary.

Concerning the [long double](https://en.wikipedia.org/wiki/Long_double) support, it works and doesn't at the same time. DevkitPPC interpret them as double so it's no big deal and will work. Some compilers such as GCC use double-double arithmetic that we have no easy way to support or represent.

The varargs support will help to make that printf's like function better. Then it might help in the far future to do tricky things like grabbing a struct/class from the memory (the programmer will need to pay attention to the endianness though) and use them in its own code.

This PR needs tons of tests before being merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4481)
<!-- Reviewable:end -->
