### PR TITLE
Vulkan: Fix assertion triggering when geometry shaders are unsupported

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -172,7 +172,7 @@ bool StateTracker::PrecachePipelineUID(const SerializedPipelineUID& uid)
     WARN_LOG(VIDEO, "Failed to get vertex shader from cached UID.");
     return false;
   }
-  if (!uid.gs_uid.GetUidData()->IsPassthrough())
+  if (g_vulkan_context->SupportsGeometryShaders() && !uid.gs_uid.GetUidData()->IsPassthrough())
   {
     pinfo.gs = g_object_cache->GetGeometryShaderForUid(uid.gs_uid);
     if (pinfo.gs == VK_NULL_HANDLE)


### PR DESCRIPTION
Happened when loading the pipeline UID cache and geometry shaders were not supported (because primitive == 0 which != PRIMITIVE_TRIANGLES => IsPassthrough returns false).

Should fix https://bugs.dolphin-emu.org/issues/9925

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4483)
<!-- Reviewable:end -->
