### PR TITLE
DolphinQt2: InfoWidget: explicit type for std::min

### DIFF
--- a/Source/Core/DolphinQt2/Config/InfoWidget.cpp
+++ b/Source/Core/DolphinQt2/Config/InfoWidget.cpp
@@ -187,7 +187,7 @@ void InfoWidget::ComputeChecksum()
     if (progress->wasCanceled())
       return;
 
-    u64 read_size = std::min(file_data.size(), game_size - read_offset);
+    u64 read_size = std::min<u64>(file_data.size(), game_size - read_offset);
     file->Read(read_offset, read_size, file_data.data());
     hash.addData(reinterpret_cast<char*>(file_data.data()), read_size);
     read_offset += read_size;


### PR DESCRIPTION
Avoids an error on macOS:

```
Source/Core/DolphinQt2/Config/InfoWidget.cpp:190:21: error: no matching function for call to 'min'
    u64 read_size = std::min(file_data.size(), game_size - read_offset);
                    ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2589:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('unsigned long' vs. 'unsigned long long')
min(const _Tp& __a, const _Tp& __b)

```