### PR TITLE
IOS HLE cleanup

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -71,7 +71,6 @@ static std::mutex s_device_map_mutex;
 #define IPC_MAX_FDS 0x18
 #define ES_MAX_COUNT 2
 static std::shared_ptr<IWII_IPC_HLE_Device> s_fdmap[IPC_MAX_FDS];
-static bool s_es_inuse[ES_MAX_COUNT];
 static std::shared_ptr<IWII_IPC_HLE_Device> s_es_handles[ES_MAX_COUNT];
 
 using IPCMsgQueue = std::deque<u32>;
@@ -141,11 +140,8 @@ void Reinit()
   AddDevice<CWII_IPC_HLE_Device_fs>("/dev/fs");
 
   // IOS allows two ES devices at a time
-  for (u32 j = 0; j < ES_MAX_COUNT; j++)
-  {
-    s_es_handles[j] = AddDevice<CWII_IPC_HLE_Device_es>("/dev/es");
-    s_es_inuse[j] = false;
-  }
+  for (auto& es_device : s_es_handles)
+    es_device = AddDevice<CWII_IPC_HLE_Device_es>("/dev/es");
 
   AddDevice<CWII_IPC_HLE_Device_di>("/dev/di");
   AddDevice<CWII_IPC_HLE_Device_net_kd_request>("/dev/net/kd/request");
@@ -187,11 +183,6 @@ void Reset(bool hard)
     }
 
     dev.reset();
-  }
-
-  for (bool& in_use : s_es_inuse)
-  {
-    in_use = false;
   }
 
   {
@@ -329,13 +320,11 @@ void DoState(PointerWrap& p)
       }
     }
 
-    for (u32 i = 0; i < ES_MAX_COUNT; i++)
+    for (auto& es_device : s_es_handles)
     {
-      p.Do(s_es_inuse[i]);
-      u32 handleID = s_es_handles[i]->GetDeviceID();
-      p.Do(handleID);
-
-      s_es_handles[i] = AccessDeviceByID(handleID);
+      const u32 handle_id = es_device->GetDeviceID();
+      p.Do(handle_id);
+      es_device = AccessDeviceByID(handle_id);
     }
   }
   else
@@ -360,25 +349,19 @@ void DoState(PointerWrap& p)
       }
     }
 
-    for (u32 i = 0; i < ES_MAX_COUNT; i++)
+    for (const auto& es_device : s_es_handles)
     {
-      p.Do(s_es_inuse[i]);
-      u32 handleID = s_es_handles[i]->GetDeviceID();
-      p.Do(handleID);
+      const u32 handle_id = es_device->GetDeviceID();
+      p.Do(handle_id);
     }
   }
 }
 
 static std::shared_ptr<IWII_IPC_HLE_Device> GetUnusedESDevice()
 {
-  for (u32 es_number = 0; es_number < ES_MAX_COUNT; ++es_number)
-  {
-    if (s_es_inuse[es_number])
-      continue;
-    s_es_inuse[es_number] = true;
-    return s_es_handles[es_number];
-  }
-  return nullptr;
+  const auto iterator = std::find_if(std::begin(s_es_handles), std::end(s_es_handles),
+                                     [](const auto& es_device) { return !es_device->IsOpened(); });
+  return (iterator != std::end(s_es_handles)) ? *iterator : nullptr;
 }
 
 // Returns the FD for the newly opened device (on success) or an error code.
@@ -446,11 +429,6 @@ static IPCCommandResult HandleCommand(const u32 address)
   switch (command)
   {
   case IPC_CMD_CLOSE:
-    for (u32 j = 0; j < ES_MAX_COUNT; j++)
-    {
-      if (s_es_handles[j] == s_fdmap[fd])
-        s_es_inuse[j] = false;
-    }
     s_fdmap[fd].reset();
     // A close on a valid device returns FS_SUCCESS.
     Memory::Write_U32(FS_SUCCESS, address + 4);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -179,7 +179,7 @@ void Reset(bool hard)
     if (dev && !dev->IsHardware())
     {
       // close all files and delete their resources
-      dev->Close(0, true);
+      dev->Close();
     }
 
     dev.reset();
@@ -192,7 +192,7 @@ void Reset(bool hard)
       if (entry.second)
       {
         // Force close
-        entry.second->Close(0, true);
+        entry.second->Close();
       }
     }
 
@@ -365,12 +365,10 @@ static std::shared_ptr<IWII_IPC_HLE_Device> GetUnusedESDevice()
 }
 
 // Returns the FD for the newly opened device (on success) or an error code.
-static s32 OpenDevice(const u32 address)
+static s32 OpenDevice(IOSResourceOpenRequest& request)
 {
-  const std::string device_name = Memory::GetString(Memory::Read_U32(address + 0xC));
-  const u32 open_mode = Memory::Read_U32(address + 0x10);
   const s32 new_fd = GetFreeDeviceID();
-  INFO_LOG(WII_IPC_HLE, "Opening %s (mode %d, fd %d)", device_name.c_str(), open_mode, new_fd);
+  INFO_LOG(WII_IPC_HLE, "Opening %s (mode %d, fd %d)", request.path.c_str(), request.flags, new_fd);
   if (new_fd < 0 || new_fd >= IPC_MAX_FDS)
   {
     ERROR_LOG(WII_IPC_HLE, "Couldn't get a free fd, too many open files");
@@ -378,80 +376,95 @@ static s32 OpenDevice(const u32 address)
   }
 
   std::shared_ptr<IWII_IPC_HLE_Device> device;
-  if (device_name.find("/dev/es") == 0)
+  if (request.path == "/dev/es")
   {
     device = GetUnusedESDevice();
     if (!device)
       return IPC_EESEXHAUSTED;
   }
-  else if (device_name.find("/dev/") == 0)
+  else if (request.path.find("/dev/") == 0)
   {
-    device = GetDeviceByName(device_name);
+    device = GetDeviceByName(request.path);
   }
-  else if (device_name.find('/') == 0)
+  else if (request.path.find('/') == 0)
   {
-    device = std::make_shared<CWII_IPC_HLE_Device_FileIO>(new_fd, device_name);
+    device = std::make_shared<CWII_IPC_HLE_Device_FileIO>(new_fd, request.path);
   }
 
   if (!device)
   {
-    ERROR_LOG(WII_IPC_HLE, "Unknown device: %s", device_name.c_str());
+    ERROR_LOG(WII_IPC_HLE, "Unknown device: %s", request.path.c_str());
     return IPC_ENOENT;
   }
 
-  Memory::Write_U32(new_fd, address + 4);
-  device->Open(address, open_mode);
-  const s32 open_return_code = Memory::Read_U32(address + 4);
-  if (open_return_code < 0)
-    return open_return_code;
+  const IOSReturnCode code = device->Open(request);
+  if (code < IPC_SUCCESS)
+    return code;
   s_fdmap[new_fd] = device;
   return new_fd;
 }
 
-static IPCCommandResult HandleCommand(const u32 address)
+static IPCCommandResult HandleCommand(IOSResourceRequest& request)
 {
-  const auto command = static_cast<IPCCommandType>(Memory::Read_U32(address));
-  if (command == IPC_CMD_OPEN)
+  if (request.command == IPC_CMD_OPEN)
   {
-    const s32 new_fd = OpenDevice(address);
-    Memory::Write_U32(new_fd, address + 4);
+    IOSResourceOpenRequest open_request{request.address};
+    const s32 new_fd = OpenDevice(open_request);
+    open_request.SetReturnValue(new_fd);
     return IWII_IPC_HLE_Device::GetDefaultReply();
   }
 
-  const s32 fd = Memory::Read_U32(address + 8);
-  const auto device = (fd >= 0 && fd < IPC_MAX_FDS) ? s_fdmap[fd] : nullptr;
+  const auto device = (request.fd < IPC_MAX_FDS) ? s_fdmap[request.fd] : nullptr;
   if (!device)
   {
-    Memory::Write_U32(IPC_EINVAL, address + 4);
+    request.SetReturnValue(IPC_EINVAL);
     return IWII_IPC_HLE_Device::GetDefaultReply();
   }
 
-  switch (command)
+  switch (request.command)
   {
   case IPC_CMD_CLOSE:
-    s_fdmap[fd].reset();
-    // A close on a valid device returns IPC_SUCCESS.
-    Memory::Write_U32(IPC_SUCCESS, address + 4);
-    return device->Close(address);
+  {
+    s_fdmap[request.fd].reset();
+    device->Close();
+    request.SetReturnValue(IPC_SUCCESS);
+    return IWII_IPC_HLE_Device::GetDefaultReply();
+  }
   case IPC_CMD_READ:
-    return device->Read(address);
+  {
+    IOSResourceReadWriteRequest read_request{request.address};
+    return device->Read(read_request);
+  }
   case IPC_CMD_WRITE:
-    return device->Write(address);
+  {
+    IOSResourceReadWriteRequest write_request{request.address};
+    return device->Write(write_request);
+  }
   case IPC_CMD_SEEK:
-    return device->Seek(address);
+  {
+    IOSResourceSeekRequest seek_request{request.address};
+    return device->Seek(seek_request);
+  }
   case IPC_CMD_IOCTL:
-    return device->IOCtl(address);
+  {
+    IOSResourceIOCtlRequest ioctl_request{request.address};
+    return device->IOCtl(ioctl_request);
+  }
   case IPC_CMD_IOCTLV:
-    return device->IOCtlV(address);
+  {
+    IOSResourceIOCtlVRequest ioctlv_request{request.address};
+    return device->IOCtlV(ioctlv_request);
+  }
   default:
-    _assert_msg_(WII_IPC_HLE, false, "Unexpected command: %x", command);
+    _assert_msg_(WII_IPC_HLE, false, "Unexpected command: %x", request.command);
     return IWII_IPC_HLE_Device::GetDefaultReply();
   }
 }
 
 void ExecuteCommand(const u32 address)
 {
-  IPCCommandResult result = HandleCommand(address);
+  IOSResourceRequest request{address};
+  IPCCommandResult result = HandleCommand(request);
 
   // Ensure replies happen in order
   const s64 ticks_until_last_reply = s_last_reply_time - CoreTiming::GetTicks();
@@ -460,7 +473,7 @@ void ExecuteCommand(const u32 address)
   s_last_reply_time = CoreTiming::GetTicks() + result.reply_delay_ticks;
 
   if (result.send_reply)
-    EnqueueReply(address, static_cast<int>(result.reply_delay_ticks));
+    EnqueueReply(request, static_cast<int>(result.reply_delay_ticks));
 }
 
 // Happens AS SOON AS IPC gets a new pointer!
@@ -470,13 +483,14 @@ void EnqueueRequest(u32 address)
 }
 
 // Called to send a reply to an IOS syscall
-void EnqueueReply(u32 address, int cycles_in_future, CoreTiming::FromThread from)
+void EnqueueReply(const IOSResourceRequest& request, int cycles_in_future,
+                  CoreTiming::FromThread from)
 {
   // IOS writes back the command that was responded to in the FD field.
-  Memory::Write_U32(Memory::Read_U32(address), address + 8);
+  Memory::Write_U32(request.command, request.address + 8);
   // IOS also overwrites the command type with the reply type.
-  Memory::Write_U32(IPC_REPLY, address);
-  CoreTiming::ScheduleEvent(cycles_in_future, s_event_enqueue, address, from);
+  Memory::Write_U32(IPC_REPLY, request.address);
+  CoreTiming::ScheduleEvent(cycles_in_future, s_event_enqueue, request.address, from);
 }
 
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -382,7 +382,7 @@ static s32 OpenDevice(const u32 address)
   {
     device = GetUnusedESDevice();
     if (!device)
-      return FS_EESEXHAUSTED;
+      return IPC_EESEXHAUSTED;
   }
   else if (device_name.find("/dev/") == 0)
   {
@@ -396,7 +396,7 @@ static s32 OpenDevice(const u32 address)
   if (!device)
   {
     ERROR_LOG(WII_IPC_HLE, "Unknown device: %s", device_name.c_str());
-    return FS_ENOENT;
+    return IPC_ENOENT;
   }
 
   Memory::Write_U32(new_fd, address + 4);
@@ -422,7 +422,7 @@ static IPCCommandResult HandleCommand(const u32 address)
   const auto device = (fd >= 0 && fd < IPC_MAX_FDS) ? s_fdmap[fd] : nullptr;
   if (!device)
   {
-    Memory::Write_U32(FS_EINVAL, address + 4);
+    Memory::Write_U32(IPC_EINVAL, address + 4);
     return IWII_IPC_HLE_Device::GetDefaultReply();
   }
 
@@ -430,8 +430,8 @@ static IPCCommandResult HandleCommand(const u32 address)
   {
   case IPC_CMD_CLOSE:
     s_fdmap[fd].reset();
-    // A close on a valid device returns FS_SUCCESS.
-    Memory::Write_U32(FS_SUCCESS, address + 4);
+    // A close on a valid device returns IPC_SUCCESS.
+    Memory::Write_U32(IPC_SUCCESS, address + 4);
     return device->Close(address);
   case IPC_CMD_READ:
     return device->Read(address);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -452,6 +452,8 @@ static IPCCommandResult HandleCommand(const u32 address)
         s_es_inuse[j] = false;
     }
     s_fdmap[fd].reset();
+    // A close on a valid device returns FS_SUCCESS.
+    Memory::Write_U32(FS_SUCCESS, address + 4);
     return device->Close(address);
   case IPC_CMD_READ:
     return device->Read(address);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -474,8 +474,8 @@ void EnqueueReply(u32 address, int cycles_in_future, CoreTiming::FromThread from
 {
   // IOS writes back the command that was responded to in the FD field.
   Memory::Write_U32(Memory::Read_U32(address), address + 8);
-  // IOS also overwrites the command type with the async reply type.
-  Memory::Write_U32(IPC_REP_ASYNC, address);
+  // IOS also overwrites the command type with the reply type.
+  Memory::Write_U32(IPC_REPLY, address);
   CoreTiming::ScheduleEvent(cycles_in_future, s_event_enqueue, address, from);
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -30,17 +30,12 @@ enum IPCCommandType : u32
   IPC_CMD_SEEK = 5,
   IPC_CMD_IOCTL = 6,
   IPC_CMD_IOCTLV = 7,
-  // IPC_REP_ASYNC is used for messages that are automatically
-  // sent to an IOS queue when an asynchronous syscall completes.
-  // Reference: http://wiibrew.org/wiki/IOS
-  IPC_REP_ASYNC = 8
+  // This is used for replies to commands.
+  IPC_REPLY = 8,
 };
 
 namespace WII_IPC_HLE_Interface
 {
-#define IPC_FIRST_ID 0x00   // First IPC device ID
-#define IPC_MAX_FILES 0x10  // First IPC file ID
-
 // Init
 void Init();
 
@@ -51,19 +46,19 @@ void Reinit();
 void Shutdown();
 
 // Reset
-void Reset(bool _bHard = false);
+void Reset(bool hard = false);
 
 // Do State
 void DoState(PointerWrap& p);
 
 // Set default content file
-void SetDefaultContentFile(const std::string& _rFilename);
+void SetDefaultContentFile(const std::string& file_name);
 void ES_DIVerify(const std::vector<u8>& tmd);
 
 void SDIO_EventNotify();
 
-std::shared_ptr<IWII_IPC_HLE_Device> GetDeviceByName(const std::string& _rDeviceName);
-std::shared_ptr<IWII_IPC_HLE_Device> AccessDeviceByID(u32 _ID);
+std::shared_ptr<IWII_IPC_HLE_Device> GetDeviceByName(const std::string& device_name);
+std::shared_ptr<IWII_IPC_HLE_Device> AccessDeviceByID(u32 id);
 
 // Update
 void Update();
@@ -71,11 +66,11 @@ void Update();
 // Update Devices
 void UpdateDevices();
 
-void ExecuteCommand(u32 _Address);
+void ExecuteCommand(u32 address);
 
 void EnqueueRequest(u32 address);
 void EnqueueReply(u32 address, int cycles_in_future = 0,
                   CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
-void EnqueueCommandAcknowledgement(u32 _Address, int cycles_in_future = 0);
+void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future = 0);
 
 }  // end of namespace WII_IPC_HLE_Interface

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -62,8 +62,6 @@ void ES_DIVerify(const std::vector<u8>& tmd);
 
 void SDIO_EventNotify();
 
-std::shared_ptr<IWII_IPC_HLE_Device> CreateFileIO(u32 _DeviceID, const std::string& _rDeviceName);
-
 std::shared_ptr<IWII_IPC_HLE_Device> GetDeviceByName(const std::string& _rDeviceName);
 std::shared_ptr<IWII_IPC_HLE_Device> AccessDeviceByID(u32 _ID);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -12,6 +12,7 @@
 #include "Core/CoreTiming.h"
 #include "Core/HW/SystemTimers.h"
 
+struct IOSResourceRequest;
 class IWII_IPC_HLE_Device;
 class PointerWrap;
 
@@ -69,7 +70,7 @@ void UpdateDevices();
 void ExecuteCommand(u32 address);
 
 void EnqueueRequest(u32 address);
-void EnqueueReply(u32 address, int cycles_in_future = 0,
+void EnqueueReply(const IOSResourceRequest& request, int cycles_in_future = 0,
                   CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future = 0);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
@@ -68,17 +68,12 @@ void IWII_IPC_HLE_Device::DoStateShared(PointerWrap& p)
 
 IPCCommandResult IWII_IPC_HLE_Device::Open(u32 command_address, u32 mode)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Open()", m_Name.c_str());
-  Memory::Write_U32(FS_ENOENT, command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Close(u32 command_address, bool force)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Close()", m_Name.c_str());
-  if (!force)
-    Memory::Write_U32(FS_EINVAL, command_address + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
@@ -48,63 +48,63 @@ SIOCtlVBuffer::SIOCtlVBuffer(const u32 address) : m_Address(address)
 
 IWII_IPC_HLE_Device::IWII_IPC_HLE_Device(const u32 device_id, const std::string& device_name,
                                          const bool hardware)
-    : m_Name(device_name), m_DeviceID(device_id), m_Hardware(hardware)
+    : m_name(device_name), m_device_id(device_id), m_is_hardware(hardware)
 {
 }
 
 void IWII_IPC_HLE_Device::DoState(PointerWrap& p)
 {
   DoStateShared(p);
-  p.Do(m_Active);
+  p.Do(m_is_active);
 }
 
 void IWII_IPC_HLE_Device::DoStateShared(PointerWrap& p)
 {
-  p.Do(m_Name);
-  p.Do(m_DeviceID);
-  p.Do(m_Hardware);
-  p.Do(m_Active);
+  p.Do(m_name);
+  p.Do(m_device_id);
+  p.Do(m_is_hardware);
+  p.Do(m_is_active);
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Open(u32 command_address, u32 mode)
 {
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Close(u32 command_address, bool force)
 {
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Seek(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Seek()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support Seek()", m_name.c_str());
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Read(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Read()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support Read()", m_name.c_str());
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Write(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Write()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support Write()", m_name.c_str());
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::IOCtl(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support IOCtl()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support IOCtl()", m_name.c_str());
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::IOCtlV(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support IOCtlV()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support IOCtlV()", m_name.c_str());
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
@@ -2,47 +2,138 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Core/IPC_HLE/WII_IPC_HLE.h"
+#include <algorithm>
+
 #include "Common/StringUtil.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
+#include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
-SIOCtlVBuffer::SIOCtlVBuffer(const u32 address) : m_Address(address)
+IOSResourceRequest::IOSResourceRequest(const u32 command_address) : address(command_address)
 {
-  // These are the Ioctlv parameters in the IOS communication. The BufferVector
-  // is a memory address offset at where the in and out buffer addresses are
-  // stored.
-  Parameter = Memory::Read_U32(m_Address + 0x0C);            // command 3, arg0
-  NumberInBuffer = Memory::Read_U32(m_Address + 0x10);       // 4, arg1
-  NumberPayloadBuffer = Memory::Read_U32(m_Address + 0x14);  // 5, arg2
-  BufferVector = Memory::Read_U32(m_Address + 0x18);         // 6, arg3
+  command = static_cast<IPCCommandType>(Memory::Read_U32(command_address));  // 0x00
+  return_value = Memory::Read_U32(command_address + 4);                      // 0x04
+  fd = Memory::Read_U32(command_address + 8);                                // 0x08
+}
 
-  // The start of the out buffer
-  u32 BufferVectorOffset = BufferVector;
+void IOSResourceRequest::SetReturnValue(const s32 new_return_value)
+{
+  return_value = new_return_value;
+  Memory::Write_U32(static_cast<u32>(return_value), address + 4);
+}
 
-  // Write the address and size for all in messages
-  for (u32 i = 0; i < NumberInBuffer; i++)
+// Write out the IPC struct from command_address to num_commands numbers of 4 byte commands.
+void IOSResourceRequest::DumpCommands(size_t num_commands, LogTypes::LOG_TYPE log_type,
+                                      LogTypes::LOG_LEVELS verbosity) const
+{
+  GENERIC_LOG(log_type, verbosity, "Dump of request 0x%08x (fd %u)", address, fd);
+  for (size_t i = 0; i < num_commands; i++)
   {
-    SBuffer Buffer;
-    Buffer.m_Address = Memory::Read_U32(BufferVectorOffset);
-    BufferVectorOffset += 4;
-    Buffer.m_Size = Memory::Read_U32(BufferVectorOffset);
-    BufferVectorOffset += 4;
-    InBuffer.push_back(Buffer);
-    DEBUG_LOG(WII_IPC_HLE, "SIOCtlVBuffer in%i: 0x%08x, 0x%x", i, Buffer.m_Address, Buffer.m_Size);
+    GENERIC_LOG(log_type, verbosity, "    %02zu: 0x%08x", i,
+                Memory::Read_U32(static_cast<u32>(address + i * 4)));
   }
+}
 
-  // Write the address and size for all out or in-out messages
-  for (u32 i = 0; i < NumberPayloadBuffer; i++)
+IOSResourceOpenRequest::IOSResourceOpenRequest(const u32 command_address)
+    : IOSResourceRequest(command_address)
+{
+  path = Memory::GetString(Memory::Read_U32(address + 0xc));           // arg0
+  flags = static_cast<IOSOpenMode>(Memory::Read_U32(address + 0x10));  // arg1
+}
+
+IOSResourceReadWriteRequest::IOSResourceReadWriteRequest(const u32 command_address)
+    : IOSResourceRequest(command_address)
+{
+  data_addr = Memory::Read_U32(address + 0xc);  // arg0
+  length = Memory::Read_U32(address + 0x10);    // arg1
+}
+
+IOSResourceSeekRequest::IOSResourceSeekRequest(const u32 command_address)
+    : IOSResourceRequest(command_address)
+{
+  offset = Memory::Read_U32(address + 0xc);                        // arg0
+  mode = static_cast<SeekMode>(Memory::Read_U32(address + 0x10));  // arg1
+}
+
+IOSResourceIOCtlRequest::IOSResourceIOCtlRequest(const u32 command_address)
+    : IOSResourceRequest(command_address)
+{
+  request = Memory::Read_U32(address + 0x0c);   // arg0
+  in_addr = Memory::Read_U32(address + 0x10);   // arg1
+  in_size = Memory::Read_U32(address + 0x14);   // arg2
+  out_addr = Memory::Read_U32(address + 0x18);  // arg3
+  out_size = Memory::Read_U32(address + 0x1c);  // arg4
+}
+
+IOSResourceIOCtlVRequest::IOSResourceIOCtlVRequest(const u32 command_address)
+    : IOSResourceRequest(command_address)
+{
+  request = Memory::Read_U32(address + 0x0c);               // arg0
+  const u32 in_number = Memory::Read_U32(address + 0x10);   // arg1
+  const u32 out_number = Memory::Read_U32(address + 0x14);  // arg2
+  const u32 pairs_addr = Memory::Read_U32(address + 0x18);  // arg3 (address to io vectors)
+
+  u32 offset = 0;
+  for (size_t i = 0; i < (in_number + out_number); ++i)
   {
-    SBuffer Buffer;
-    Buffer.m_Address = Memory::Read_U32(BufferVectorOffset);
-    BufferVectorOffset += 4;
-    Buffer.m_Size = Memory::Read_U32(BufferVectorOffset);
-    BufferVectorOffset += 4;
-    PayloadBuffer.push_back(Buffer);
-    DEBUG_LOG(WII_IPC_HLE, "SIOCtlVBuffer io%i: 0x%08x, 0x%x", i, Buffer.m_Address, Buffer.m_Size);
+    IOVector vector;
+    vector.addr = Memory::Read_U32(pairs_addr + offset);
+    offset += 4;
+    vector.size = Memory::Read_U32(pairs_addr + offset);
+    offset += 4;
+    if (i < in_number)
+      in_vectors.emplace_back(vector);
+    else
+      io_vectors.emplace_back(vector);
+  }
+}
+
+bool IOSResourceIOCtlVRequest::HasInVectorWithAddress(const u32 vector_address) const
+{
+  return std::find_if(in_vectors.begin(), in_vectors.end(), [&](const auto& in_vector) {
+           return in_vector.addr == vector_address;
+         }) != in_vectors.end();
+}
+
+void IOSResourceIOCtlRequest::Dump(const std::string& device_name, LogTypes::LOG_TYPE type,
+                                   LogTypes::LOG_LEVELS verbosity) const
+{
+  Log(device_name, type, verbosity);
+  GENERIC_LOG(type, verbosity, "  in (size 0x%x):", in_size);
+  GENERIC_LOG(type, verbosity, "    %s",
+              ArrayToString(Memory::GetPointer(in_addr), in_size).c_str());
+  GENERIC_LOG(type, verbosity, "  out (size 0x%x):", out_size);
+  GENERIC_LOG(type, verbosity, "    %s",
+              ArrayToString(Memory::GetPointer(out_addr), out_size).c_str());
+}
+
+void IOSResourceIOCtlRequest::Log(const std::string& device_name, LogTypes::LOG_TYPE type,
+                                  LogTypes::LOG_LEVELS verbosity) const
+{
+  GENERIC_LOG(type, verbosity, "%s (fd %u) - IOCtl %d (in 0x%08x %u, out 0x%08x %u)",
+              device_name.c_str(), fd, request, in_addr, in_size, out_addr, out_size);
+}
+
+void IOSResourceIOCtlVRequest::Dump(const std::string& device_name, LogTypes::LOG_TYPE type,
+                                    LogTypes::LOG_LEVELS verbosity) const
+{
+  GENERIC_LOG(type, verbosity, "======= Dump ======");
+  GENERIC_LOG(type, verbosity, "%s (fd %u) - IOCtlV %d (%zu in, %zu io)", device_name.c_str(), fd,
+              request, in_vectors.size(), io_vectors.size());
+
+  size_t i = 0;
+  for (const auto& vector : in_vectors)
+  {
+    GENERIC_LOG(type, verbosity, "  in[%zu] (0x%08x, size 0x%x):", i, vector.addr, vector.size);
+    GENERIC_LOG(type, verbosity, "    %s",
+                ArrayToString(Memory::GetPointer(vector.addr), vector.size).c_str());
+    ++i;
+  }
+  for (const auto& vector : io_vectors)
+  {
+    GENERIC_LOG(type, verbosity, "  io[%zu] (0x%08x, size 0x%x)", i, vector.addr, vector.size);
+    ++i;
   }
 }
 
@@ -66,43 +157,42 @@ void IWII_IPC_HLE_Device::DoStateShared(PointerWrap& p)
   p.Do(m_is_active);
 }
 
-IPCCommandResult IWII_IPC_HLE_Device::Open(u32 command_address, u32 mode)
+IOSReturnCode IWII_IPC_HLE_Device::Open(IOSResourceOpenRequest& request)
 {
   m_is_active = true;
-  return GetDefaultReply();
+  return IPC_SUCCESS;
 }
 
-IPCCommandResult IWII_IPC_HLE_Device::Close(u32 command_address, bool force)
+void IWII_IPC_HLE_Device::Close()
 {
   m_is_active = false;
-  return GetDefaultReply();
 }
 
-IPCCommandResult IWII_IPC_HLE_Device::Seek(u32 command_address)
+IPCCommandResult IWII_IPC_HLE_Device::Seek(IOSResourceSeekRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support Seek()", m_name.c_str());
   return GetDefaultReply();
 }
 
-IPCCommandResult IWII_IPC_HLE_Device::Read(u32 command_address)
+IPCCommandResult IWII_IPC_HLE_Device::Read(IOSResourceReadWriteRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support Read()", m_name.c_str());
   return GetDefaultReply();
 }
 
-IPCCommandResult IWII_IPC_HLE_Device::Write(u32 command_address)
+IPCCommandResult IWII_IPC_HLE_Device::Write(IOSResourceReadWriteRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support Write()", m_name.c_str());
   return GetDefaultReply();
 }
 
-IPCCommandResult IWII_IPC_HLE_Device::IOCtl(u32 command_address)
+IPCCommandResult IWII_IPC_HLE_Device::IOCtl(IOSResourceIOCtlRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support IOCtl()", m_name.c_str());
   return GetDefaultReply();
 }
 
-IPCCommandResult IWII_IPC_HLE_Device::IOCtlV(u32 command_address)
+IPCCommandResult IWII_IPC_HLE_Device::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support IOCtlV()", m_name.c_str());
   return GetDefaultReply();
@@ -119,58 +209,4 @@ IPCCommandResult IWII_IPC_HLE_Device::GetDefaultReply()
 IPCCommandResult IWII_IPC_HLE_Device::GetNoReply()
 {
   return {false, 0};
-}
-
-// Write out the IPC struct from command_address to num_commands numbers
-// of 4 byte commands.
-void IWII_IPC_HLE_Device::DumpCommands(u32 command_address, size_t num_commands,
-                                       LogTypes::LOG_TYPE log_type, LogTypes::LOG_LEVELS verbosity)
-{
-  GENERIC_LOG(log_type, verbosity, "CommandDump of %s", GetDeviceName().c_str());
-  for (u32 i = 0; i < num_commands; i++)
-  {
-    GENERIC_LOG(log_type, verbosity, "    Command%02i: 0x%08x", i,
-                Memory::Read_U32(command_address + i * 4));
-  }
-}
-
-void IWII_IPC_HLE_Device::DumpAsync(u32 buffer_vector, u32 number_in_buffer, u32 number_io_buffer,
-                                    LogTypes::LOG_TYPE log_type, LogTypes::LOG_LEVELS verbosity)
-{
-  GENERIC_LOG(log_type, verbosity, "======= DumpAsync ======");
-
-  u32 BufferOffset = buffer_vector;
-  for (u32 i = 0; i < number_in_buffer; i++)
-  {
-    u32 InBuffer = Memory::Read_U32(BufferOffset);
-    BufferOffset += 4;
-    u32 InBufferSize = Memory::Read_U32(BufferOffset);
-    BufferOffset += 4;
-
-    GENERIC_LOG(log_type, LogTypes::LINFO, "%s - IOCtlV InBuffer[%i]:", GetDeviceName().c_str(), i);
-
-    std::string Temp;
-    for (u32 j = 0; j < InBufferSize; j++)
-    {
-      Temp += StringFromFormat("%02x ", Memory::Read_U8(InBuffer + j));
-    }
-
-    GENERIC_LOG(log_type, LogTypes::LDEBUG, "    Buffer: %s", Temp.c_str());
-  }
-
-  for (u32 i = 0; i < number_io_buffer; i++)
-  {
-    u32 OutBuffer = Memory::Read_U32(BufferOffset);
-    BufferOffset += 4;
-    u32 OutBufferSize = Memory::Read_U32(BufferOffset);
-    BufferOffset += 4;
-
-    GENERIC_LOG(log_type, LogTypes::LINFO, "%s - IOCtlV OutBuffer[%i]:", GetDeviceName().c_str(),
-                i);
-    GENERIC_LOG(log_type, LogTypes::LINFO, "    OutBuffer: 0x%08x (0x%x):", OutBuffer,
-                OutBufferSize);
-
-    if (verbosity >= LogTypes::LOG_LEVELS::LINFO)
-      DumpCommands(OutBuffer, OutBufferSize, log_type, verbosity);
-  }
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -14,30 +14,32 @@
 #include "Common/StringUtil.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 
-#define FS_SUCCESS (u32)0            // Success
-#define FS_EACCES (u32) - 1          // Permission denied
-#define FS_EEXIST (u32) - 2          // File exists
-#define FS_EINVAL (u32) - 4          // Invalid argument Invalid FD
-#define FS_ENOENT (u32) - 6          // File not found
-#define FS_EBUSY (u32) - 8           // Resource busy
-#define FS_EIO (u32) - 12            // Returned on ECC error
-#define FS_ENOMEM (u32) - 22         // Alloc failed during request
-#define FS_EFATAL (u32) - 101        // Fatal error
-#define FS_EACCESS (u32) - 102       // Permission denied
-#define FS_ECORRUPT (u32) - 103      // returned for "corrupted" NAND
-#define FS_EEXIST2 (u32) - 105       // File exists
-#define FS_ENOENT2 (u32) - 106       // File not found
-#define FS_ENFILE (u32) - 107        // Too many fds open
-#define FS_EFBIG (u32) - 108         // Max block count reached?
-#define FS_EFDEXHAUSTED (u32) - 109  // Too many fds open
-#define FS_ENAMELEN (u32) - 110      // Pathname is too long
-#define FS_EFDOPEN (u32) - 111       // FD is already open
-#define FS_EIO2 (u32) - 114          // Returned on ECC error
-#define FS_ENOTEMPTY (u32) - 115     // Directory not empty
-#define FS_EDIRDEPTH (u32) - 116     // Max directory depth exceeded
-#define FS_EBUSY2 (u32) - 118        // Resource busy
-//#define FS_EFATAL       (u32)-119   // Fatal error not used by IOS as fatal ERROR
-#define FS_EESEXHAUSTED (u32) - 1016  // Max of 2 ES handles at a time
+enum IOSReturnCode : s32
+{
+  IPC_SUCCESS = 0,           // Success
+  IPC_EACCES = -1,           // Permission denied
+  IPC_EEXIST = -2,           // File exists
+  IPC_EINVAL = -4,           // Invalid argument or fd
+  IPC_ENOENT = -6,           // File not found
+  IPC_EQUEUEFULL = -8,       // Queue full
+  IPC_EIO = -12,             // ECC error
+  IPC_ENOMEM = -22,          // Alloc failed during request
+  FS_EINVAL = -101,          // Invalid path
+  FS_EACCESS = -102,         // Permission denied
+  FS_ECORRUPT = -103,        // Corrupted NAND
+  FS_EEXIST = -105,          // File exists
+  FS_ENOENT = -106,          // No such file or directory
+  FS_ENFILE = -107,          // Too many fds open
+  FS_EFBIG = -108,           // Max block count reached?
+  FS_EFDEXHAUSTED = -109,    // Too many fds open
+  FS_ENAMELEN = -110,        // Pathname is too long
+  FS_EFDOPEN = -111,         // FD is already open
+  FS_EIO = -114,             // ECC error
+  FS_ENOTEMPTY = -115,       // Directory not empty
+  FS_EDIRDEPTH = -116,       // Max directory depth exceeded
+  FS_EBUSY = -118,           // Resource busy
+  IPC_EESEXHAUSTED = -1016,  // Max of 2 ES handles exceeded
+};
 
 // A struct for IOS ioctlv calls
 struct SIOCtlVBuffer

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -70,8 +70,8 @@ public:
   virtual void DoState(PointerWrap& p);
   void DoStateShared(PointerWrap& p);
 
-  const std::string& GetDeviceName() const { return m_Name; }
-  u32 GetDeviceID() const { return m_DeviceID; }
+  const std::string& GetDeviceName() const { return m_name; }
+  u32 GetDeviceID() const { return m_device_id; }
   virtual IPCCommandResult Open(u32 command_address, u32 mode);
   virtual IPCCommandResult Close(u32 command_address, bool force = false);
   virtual IPCCommandResult Seek(u32 command_address);
@@ -81,18 +81,18 @@ public:
   virtual IPCCommandResult IOCtlV(u32 command_address);
 
   virtual u32 Update() { return 0; }
-  virtual bool IsHardware() const { return m_Hardware; }
-  virtual bool IsOpened() const { return m_Active; }
+  virtual bool IsHardware() const { return m_is_hardware; }
+  virtual bool IsOpened() const { return m_is_active; }
   static IPCCommandResult GetDefaultReply();
   static IPCCommandResult GetNoReply();
 
-  std::string m_Name;
+  std::string m_name;
 
 protected:
   // STATE_TO_SAVE
-  u32 m_DeviceID;
-  bool m_Hardware;
-  bool m_Active = false;
+  u32 m_device_id;
+  bool m_is_hardware;
+  bool m_is_active = false;
 
   // Write out the IPC struct from command_address to number_of_commands numbers
   // of 4 byte commands.

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -75,6 +75,8 @@ struct IOSResourceReadWriteRequest final : IOSResourceRequest
 {
   u32 data_addr;
   u32 length;
+  std::vector<u8> MakeBuffer() const;
+  void FillBuffer(const void* data, size_t source_size) const;
   explicit IOSResourceReadWriteRequest(u32 command_address);
 };
 
@@ -99,6 +101,9 @@ struct IOSResourceIOCtlRequest final : IOSResourceRequest
   u32 out_addr;
   u32 out_size;
   explicit IOSResourceIOCtlRequest(u32 command_address);
+  std::vector<u8> MakeInBuffer() const;
+  std::vector<u8> MakeOutBuffer() const;
+  void FillOutBuffer(const void* data, size_t source_size) const;
   void Dump(const std::string& device_name, LogTypes::LOG_TYPE log_type = LogTypes::WII_IPC_HLE,
             LogTypes::LOG_LEVELS verbosity = LogTypes::LINFO) const;
   void Log(const std::string& device_name, LogTypes::LOG_TYPE log_type = LogTypes::WII_IPC_HLE,
@@ -111,6 +116,8 @@ struct IOSResourceIOCtlVRequest final : IOSResourceRequest
   {
     u32 addr;
     u32 size;
+    std::vector<u8> MakeBuffer() const;
+    void FillBuffer(const void* data, size_t source_size) const;
   };
   u32 request;
   std::vector<IOVector> in_vectors;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -34,7 +34,6 @@ void CWII_IPC_HLE_Device_di::DoState(PointerWrap& p)
 
 IPCCommandResult CWII_IPC_HLE_Device_di::Open(u32 _CommandAddress, u32 _Mode)
 {
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -32,20 +32,6 @@ void CWII_IPC_HLE_Device_di::DoState(PointerWrap& p)
   p.Do(m_commands_to_execute);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_di::Open(u32 _CommandAddress, u32 _Mode)
-{
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_di::Close(u32 _CommandAddress, bool _bForce)
-{
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
 {
   // DI IOCtls are handled in a special way by Dolphin

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -32,7 +32,7 @@ void CWII_IPC_HLE_Device_di::DoState(PointerWrap& p)
   p.Do(m_commands_to_execute);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(IOSResourceIOCtlRequest& request)
 {
   // DI IOCtls are handled in a special way by Dolphin
   // compared to other WII_IPC_HLE functions.
@@ -42,40 +42,25 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
   // are queued until DVDInterface is ready to handle them.
 
   bool ready_to_execute = m_commands_to_execute.empty();
-  m_commands_to_execute.push_back(_CommandAddress);
+  m_commands_to_execute.push_back(request.address);
   if (ready_to_execute)
-    StartIOCtl(_CommandAddress);
+    StartIOCtl(request);
 
   // DVDInterface handles the timing and we handle the reply,
   // so WII_IPC_HLE shouldn't handle anything.
   return GetNoReply();
 }
 
-void CWII_IPC_HLE_Device_di::StartIOCtl(u32 command_address)
+void CWII_IPC_HLE_Device_di::StartIOCtl(IOSResourceIOCtlRequest& request)
 {
-  u32 BufferIn = Memory::Read_U32(command_address + 0x10);
-  u32 BufferInSize = Memory::Read_U32(command_address + 0x14);
-  u32 BufferOut = Memory::Read_U32(command_address + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(command_address + 0x1C);
-
-  u32 command_0 = Memory::Read_U32(BufferIn);
-  u32 command_1 = Memory::Read_U32(BufferIn + 4);
-  u32 command_2 = Memory::Read_U32(BufferIn + 8);
-
-  DEBUG_LOG(WII_IPC_DVD, "IOCtl Command(0x%08x) BufferIn(0x%08x, 0x%x) BufferOut(0x%08x, 0x%x)",
-            command_0, BufferIn, BufferInSize, BufferOut, BufferOutSize);
-
-  // TATSUNOKO VS CAPCOM: Gets here with BufferOut == 0!!!
-  if (BufferOut != 0)
-  {
-    // Set out buffer to zeroes as a safety precaution
-    // to avoid answering nonsense values
-    Memory::Memset(BufferOut, 0, BufferOutSize);
-  }
+  const u32 command_0 = Memory::Read_U32(request.in_addr);
+  const u32 command_1 = Memory::Read_U32(request.in_addr + 4);
+  const u32 command_2 = Memory::Read_U32(request.in_addr + 8);
 
   // DVDInterface's ExecuteCommand handles most of the work.
   // The IOCtl callback is used to generate a reply afterwards.
-  DVDInterface::ExecuteCommand(command_0, command_1, command_2, BufferOut, BufferOutSize, true);
+  DVDInterface::ExecuteCommand(command_0, command_1, command_2, request.out_addr, request.out_size,
+                               true);
 }
 
 void CWII_IPC_HLE_Device_di::FinishIOCtl(DVDInterface::DIInterruptType interrupt_type)
@@ -89,61 +74,50 @@ void CWII_IPC_HLE_Device_di::FinishIOCtl(DVDInterface::DIInterruptType interrupt
   // This command has been executed, so it's removed from the queue
   u32 command_address = m_commands_to_execute.front();
   m_commands_to_execute.pop_front();
+  IOSResourceIOCtlRequest request{command_address};
 
-  // The DI interrupt type is used as a return value
-  Memory::Write_U32(interrupt_type, command_address + 4);
-  WII_IPC_HLE_Interface::EnqueueReply(command_address);
+  request.SetReturnValue(interrupt_type);
+  WII_IPC_HLE_Interface::EnqueueReply(request);
 
   // DVDInterface is now ready to execute another command,
   // so we start executing a command from the queue if there is one
   if (!m_commands_to_execute.empty())
-    StartIOCtl(m_commands_to_execute.front());
+  {
+    IOSResourceIOCtlRequest next_request{m_commands_to_execute.front()};
+    StartIOCtl(next_request);
+  }
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
-
-  // Prepare the out buffer(s) with zeros as a safety precaution
-  // to avoid returning bad values
-  for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; i++)
-  {
-    Memory::Memset(CommandBuffer.PayloadBuffer[i].m_Address, 0,
-                   CommandBuffer.PayloadBuffer[i].m_Size);
-  }
-
-  u32 ReturnValue = 0;
-  switch (CommandBuffer.Parameter)
+  s32 return_value = IPC_SUCCESS;
+  switch (request.request)
   {
   case DVDInterface::DVDLowOpenPartition:
   {
-    _dbg_assert_msg_(WII_IPC_DVD, CommandBuffer.InBuffer[1].m_Address == 0,
+    _dbg_assert_msg_(WII_IPC_DVD, request.in_vectors[1].addr == 0,
                      "DVDLowOpenPartition with ticket");
-    _dbg_assert_msg_(WII_IPC_DVD, CommandBuffer.InBuffer[2].m_Address == 0,
+    _dbg_assert_msg_(WII_IPC_DVD, request.in_vectors[2].addr == 0,
                      "DVDLowOpenPartition with cert chain");
 
-    u64 const partition_offset =
-        ((u64)Memory::Read_U32(CommandBuffer.InBuffer[0].m_Address + 4) << 2);
+    u64 const partition_offset = ((u64)Memory::Read_U32(request.in_vectors[0].addr + 4) << 2);
     DVDInterface::ChangePartition(partition_offset);
 
     INFO_LOG(WII_IPC_DVD, "DVDLowOpenPartition: partition_offset 0x%016" PRIx64, partition_offset);
 
     // Read TMD to the buffer
     std::vector<u8> tmd_buffer = DVDInterface::GetVolume().GetTMD();
-    Memory::CopyToEmu(CommandBuffer.PayloadBuffer[0].m_Address, tmd_buffer.data(),
-                      tmd_buffer.size());
+    Memory::CopyToEmu(request.io_vectors[0].addr, tmd_buffer.data(), tmd_buffer.size());
     WII_IPC_HLE_Interface::ES_DIVerify(tmd_buffer);
 
-    ReturnValue = 1;
-  }
-  break;
-
-  default:
-    ERROR_LOG(WII_IPC_DVD, "IOCtlV: %i", CommandBuffer.Parameter);
-    _dbg_assert_msg_(WII_IPC_DVD, 0, "IOCtlV: %i", CommandBuffer.Parameter);
+    return_value = 1;
     break;
   }
-
-  Memory::Write_U32(ReturnValue, _CommandAddress + 4);
+  default:
+    ERROR_LOG(WII_IPC_DVD, "IOCtlV: %u", request.request);
+    _dbg_assert_msg_(WII_IPC_DVD, 0, "IOCtlV: %u", request.request);
+    break;
+  }
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
@@ -27,9 +27,6 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
@@ -27,13 +27,13 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
   void FinishIOCtl(DVDInterface::DIInterruptType interrupt_type);
 
 private:
-  void StartIOCtl(u32 command_address);
+  void StartIOCtl(IOSResourceIOCtlRequest& request);
 
   std::deque<u32> m_commands_to_execute;
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -76,14 +76,14 @@ CWII_IPC_HLE_Device_FileIO::~CWII_IPC_HLE_Device_FileIO()
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bForce)
 {
-  INFO_LOG(WII_IPC_FILEIO, "FileIO: Close %s (DeviceID=%08x)", m_Name.c_str(), m_DeviceID);
+  INFO_LOG(WII_IPC_FILEIO, "FileIO: Close %s (DeviceID=%08x)", m_name.c_str(), m_device_id);
   m_Mode = 0;
 
   // Let go of our pointer to the file, it will automatically close if we are the last handle
   // accessing it.
   m_file.reset();
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 
@@ -93,13 +93,13 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 command_address, u32 mode)
 
   static const char* const Modes[] = {"Unk Mode", "Read only", "Write only", "Read and Write"};
 
-  m_filepath = HLE_IPC_BuildFilename(m_Name);
+  m_filepath = HLE_IPC_BuildFilename(m_name);
 
   // The file must exist before we can open it
   // It should be created by ISFS_CreateFile, not here
   if (File::Exists(m_filepath) && !File::IsDirectory(m_filepath))
   {
-    INFO_LOG(WII_IPC_FILEIO, "FileIO: Open %s (%s == %08X)", m_Name.c_str(), Modes[mode], mode);
+    INFO_LOG(WII_IPC_FILEIO, "FileIO: Open %s (%s == %08X)", m_name.c_str(), Modes[mode], mode);
     OpenFile();
   }
   else
@@ -110,7 +110,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 command_address, u32 mode)
       Memory::Write_U32(FS_ENOENT, command_address + 4);
   }
 
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -134,14 +134,14 @@ void CWII_IPC_HLE_Device_FileIO::OpenFile()
   //    - The Beatles: Rock Band (saving doesn't work)
 
   // Check if the file has already been opened.
-  auto search = openFiles.find(m_Name);
+  auto search = openFiles.find(m_name);
   if (search != openFiles.end())
   {
     m_file = search->second.lock();  // Lock a shared pointer to use.
   }
   else
   {
-    std::string path = m_Name;
+    std::string path = m_name;
     // This code will be called when all references to the shared pointer below have been removed.
     auto deleter = [path](File::IOFile* ptr) {
       delete ptr;             // IOFile's deconstructor closes the file.
@@ -170,7 +170,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Seek(u32 _CommandAddress)
 
     const s32 fileSize = (s32)m_file->GetSize();
     DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Seek Pos: 0x%08x, Mode: %i (%s, Length=0x%08x)",
-              SeekPosition, Mode, m_Name.c_str(), fileSize);
+              SeekPosition, Mode, m_name.c_str(), fileSize);
 
     switch (Mode)
     {
@@ -235,12 +235,12 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
     {
       WARN_LOG(WII_IPC_FILEIO,
                "FileIO: Attempted to read 0x%x bytes to 0x%08x on a write-only file %s", Size,
-               Address, m_Name.c_str());
+               Address, m_name.c_str());
     }
     else
     {
       DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Read 0x%x bytes to 0x%08x from %s", Size, Address,
-                m_Name.c_str());
+                m_name.c_str());
       m_file->Seek(m_SeekPos, SEEK_SET);  // File might be opened twice, need to seek before we read
       ReturnValue = (u32)fread(Memory::GetPointer(Address), 1, Size, m_file->GetHandle());
       if (ReturnValue != Size && ferror(m_file->GetHandle()))
@@ -257,7 +257,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
   {
     ERROR_LOG(WII_IPC_FILEIO, "FileIO: Failed to read from %s (Addr=0x%08x Size=0x%x) - file could "
                               "not be opened or does not exist",
-              m_Name.c_str(), Address, Size);
+              m_name.c_str(), Address, Size);
     ReturnValue = FS_ENOENT;
   }
 
@@ -278,12 +278,12 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
     {
       WARN_LOG(WII_IPC_FILEIO,
                "FileIO: Attempted to write 0x%x bytes from 0x%08x to a read-only file %s", Size,
-               Address, m_Name.c_str());
+               Address, m_name.c_str());
     }
     else
     {
       DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Write 0x%04x bytes from 0x%08x to %s", Size, Address,
-                m_Name.c_str());
+                m_name.c_str());
       m_file->Seek(m_SeekPos,
                    SEEK_SET);  // File might be opened twice, need to seek before we write
       if (m_file->WriteBytes(Memory::GetPointer(Address), Size))
@@ -297,7 +297,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
   {
     ERROR_LOG(WII_IPC_FILEIO, "FileIO: Failed to read from %s (Addr=0x%08x Size=0x%x) - file could "
                               "not be opened or does not exist",
-              m_Name.c_str(), Address, Size);
+              m_name.c_str(), Address, Size);
     ReturnValue = FS_ENOENT;
   }
 
@@ -307,7 +307,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
 {
-  DEBUG_LOG(WII_IPC_FILEIO, "FileIO: IOCtl (Device=%s)", m_Name.c_str());
+  DEBUG_LOG(WII_IPC_FILEIO, "FileIO: IOCtl (Device=%s)", m_name.c_str());
 #if defined(_DEBUG) || defined(DEBUGFAST)
   DumpCommands(_CommandAddress);
 #endif
@@ -323,7 +323,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
       u32 m_FileLength = (u32)m_file->GetSize();
 
       const u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-      DEBUG_LOG(WII_IPC_FILEIO, "  File: %s, Length: %i, Pos: %i", m_Name.c_str(), m_FileLength,
+      DEBUG_LOG(WII_IPC_FILEIO, "  File: %s, Length: %i, Pos: %i", m_name.c_str(), m_FileLength,
                 m_SeekPos);
 
       Memory::Write_U32(m_FileLength, BufferOut);
@@ -362,7 +362,7 @@ void CWII_IPC_HLE_Device_FileIO::DoState(PointerWrap& p)
   p.Do(m_Mode);
   p.Do(m_SeekPos);
 
-  m_filepath = HLE_IPC_BuildFilename(m_Name);
+  m_filepath = HLE_IPC_BuildFilename(m_name);
 
   // The file was closed during state (and might now be pointing at another file)
   // Open it again

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cinttypes>
 #include <cstdio>
 #include <map>
 #include <memory>
@@ -74,7 +75,7 @@ CWII_IPC_HLE_Device_FileIO::~CWII_IPC_HLE_Device_FileIO()
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bForce)
+void CWII_IPC_HLE_Device_FileIO::Close()
 {
   INFO_LOG(WII_IPC_FILEIO, "FileIO: Close %s (DeviceID=%08x)", m_name.c_str(), m_device_id);
   m_Mode = 0;
@@ -84,12 +85,11 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bF
   m_file.reset();
 
   m_is_active = false;
-  return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 command_address, u32 mode)
+IOSReturnCode CWII_IPC_HLE_Device_FileIO::Open(IOSResourceOpenRequest& request)
 {
-  m_Mode = mode;
+  m_Mode = request.flags;
 
   static const char* const Modes[] = {"Unk Mode", "Read only", "Write only", "Read and Write"};
 
@@ -97,21 +97,18 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 command_address, u32 mode)
 
   // The file must exist before we can open it
   // It should be created by ISFS_CreateFile, not here
-  if (File::Exists(m_filepath) && !File::IsDirectory(m_filepath))
+  if (!File::Exists(m_filepath) || File::IsDirectory(m_filepath))
   {
-    INFO_LOG(WII_IPC_FILEIO, "FileIO: Open %s (%s == %08X)", m_name.c_str(), Modes[mode], mode);
-    OpenFile();
-  }
-  else
-  {
-    WARN_LOG(WII_IPC_FILEIO, "FileIO: Open (%s) failed - File doesn't exist %s", Modes[mode],
+    WARN_LOG(WII_IPC_FILEIO, "FileIO: Open (%s) failed - File doesn't exist %s", Modes[m_Mode],
              m_filepath.c_str());
-    if (command_address)
-      Memory::Write_U32(FS_ENOENT, command_address + 4);
+    return FS_ENOENT;
   }
 
+  INFO_LOG(WII_IPC_FILEIO, "FileIO: Open %s (%s == %08X)", m_name.c_str(), Modes[m_Mode], m_Mode);
+  OpenFile();
+
   m_is_active = true;
-  return GetDefaultReply();
+  return IPC_SUCCESS;
 }
 
 // This isn't theadsafe, but it's only called from the CPU thread.
@@ -158,98 +155,91 @@ void CWII_IPC_HLE_Device_FileIO::OpenFile()
   }
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Seek(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Seek(IOSResourceSeekRequest& request)
 {
-  u32 ReturnValue = FS_EINVAL;
-  const s32 SeekPosition = Memory::Read_U32(_CommandAddress + 0xC);
-  const s32 Mode = Memory::Read_U32(_CommandAddress + 0x10);
+  u32 return_value = FS_EINVAL;
 
   if (m_file->IsOpen())
   {
-    ReturnValue = FS_EINVAL;
-
-    const s32 fileSize = (s32)m_file->GetSize();
+    const u32 file_size = static_cast<u32>(m_file->GetSize());
     DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Seek Pos: 0x%08x, Mode: %i (%s, Length=0x%08x)",
-              SeekPosition, Mode, m_name.c_str(), fileSize);
+              request.offset, request.mode, m_name.c_str(), file_size);
 
-    switch (Mode)
+    switch (request.mode)
     {
-    case WII_SEEK_SET:
+    case IOSResourceSeekRequest::IOS_SEEK_SET:
     {
-      if ((SeekPosition >= 0) && (SeekPosition <= fileSize))
+      if (request.offset <= file_size)
       {
-        m_SeekPos = SeekPosition;
-        ReturnValue = m_SeekPos;
+        m_SeekPos = request.offset;
+        return_value = m_SeekPos;
       }
       break;
     }
 
-    case WII_SEEK_CUR:
+    case IOSResourceSeekRequest::IOS_SEEK_CUR:
     {
-      s32 wantedPos = SeekPosition + m_SeekPos;
-      if (wantedPos >= 0 && wantedPos <= fileSize)
+      const u32 wanted_pos = request.offset + m_SeekPos;
+      if (wanted_pos <= file_size)
       {
-        m_SeekPos = wantedPos;
-        ReturnValue = m_SeekPos;
+        m_SeekPos = wanted_pos;
+        return_value = m_SeekPos;
       }
       break;
     }
 
-    case WII_SEEK_END:
+    case IOSResourceSeekRequest::IOS_SEEK_END:
     {
-      s32 wantedPos = SeekPosition + fileSize;
-      if (wantedPos >= 0 && wantedPos <= fileSize)
+      const u32 wanted_pos = request.offset + file_size;
+      if (wanted_pos <= file_size)
       {
-        m_SeekPos = wantedPos;
-        ReturnValue = m_SeekPos;
+        m_SeekPos = wanted_pos;
+        return_value = m_SeekPos;
       }
       break;
     }
 
     default:
     {
-      PanicAlert("CWII_IPC_HLE_Device_FileIO Unsupported seek mode %i", Mode);
-      ReturnValue = FS_EINVAL;
+      PanicAlert("CWII_IPC_HLE_Device_FileIO Unsupported seek mode %i", request.mode);
+      return_value = FS_EINVAL;
       break;
     }
     }
   }
   else
   {
-    ReturnValue = FS_ENOENT;
+    return_value = FS_ENOENT;
   }
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(IOSResourceReadWriteRequest& request)
 {
-  u32 ReturnValue = FS_EACCESS;
-  const u32 Address = Memory::Read_U32(_CommandAddress + 0xC);  // Read to this memory address
-  const u32 Size = Memory::Read_U32(_CommandAddress + 0x10);
-
+  s32 return_value = FS_EACCESS;
   if (m_file->IsOpen())
   {
-    if (m_Mode == ISFS_OPEN_WRITE)
+    if (m_Mode == IOS_OPEN_WRITE)
     {
       WARN_LOG(WII_IPC_FILEIO,
-               "FileIO: Attempted to read 0x%x bytes to 0x%08x on a write-only file %s", Size,
-               Address, m_name.c_str());
+               "FileIO: Attempted to read 0x%x bytes to 0x%08x on a write-only file %s",
+               request.length, request.data_addr, m_name.c_str());
     }
     else
     {
-      DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Read 0x%x bytes to 0x%08x from %s", Size, Address,
-                m_name.c_str());
+      DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Read 0x%x bytes to 0x%08x from %s", request.length,
+                request.data_addr, m_name.c_str());
       m_file->Seek(m_SeekPos, SEEK_SET);  // File might be opened twice, need to seek before we read
-      ReturnValue = (u32)fread(Memory::GetPointer(Address), 1, Size, m_file->GetHandle());
-      if (ReturnValue != Size && ferror(m_file->GetHandle()))
+      return_value = static_cast<u32>(
+          fread(Memory::GetPointer(request.data_addr), 1, request.length, m_file->GetHandle()));
+      if (static_cast<u32>(return_value) != request.length && ferror(m_file->GetHandle()))
       {
-        ReturnValue = FS_EACCESS;
+        return_value = FS_EACCESS;
       }
       else
       {
-        m_SeekPos += Size;
+        m_SeekPos += request.length;
       }
     }
   }
@@ -257,39 +247,35 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
   {
     ERROR_LOG(WII_IPC_FILEIO, "FileIO: Failed to read from %s (Addr=0x%08x Size=0x%x) - file could "
                               "not be opened or does not exist",
-              m_name.c_str(), Address, Size);
-    ReturnValue = FS_ENOENT;
+              m_name.c_str(), request.data_addr, request.length);
+    return_value = FS_ENOENT;
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(IOSResourceReadWriteRequest& request)
 {
-  u32 ReturnValue = FS_EACCESS;
-  const u32 Address =
-      Memory::Read_U32(_CommandAddress + 0xC);  // Write data from this memory address
-  const u32 Size = Memory::Read_U32(_CommandAddress + 0x10);
-
+  s32 return_value = FS_EACCESS;
   if (m_file->IsOpen())
   {
-    if (m_Mode == ISFS_OPEN_READ)
+    if (m_Mode == IOS_OPEN_READ)
     {
       WARN_LOG(WII_IPC_FILEIO,
-               "FileIO: Attempted to write 0x%x bytes from 0x%08x to a read-only file %s", Size,
-               Address, m_name.c_str());
+               "FileIO: Attempted to write 0x%x bytes from 0x%08x to a read-only file %s",
+               request.length, request.data_addr, m_name.c_str());
     }
     else
     {
-      DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Write 0x%04x bytes from 0x%08x to %s", Size, Address,
-                m_name.c_str());
+      DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Write 0x%04x bytes from 0x%08x to %s", request.length,
+                request.data_addr, m_name.c_str());
       m_file->Seek(m_SeekPos,
                    SEEK_SET);  // File might be opened twice, need to seek before we write
-      if (m_file->WriteBytes(Memory::GetPointer(Address), Size))
+      if (m_file->WriteBytes(Memory::GetPointer(request.data_addr), request.length))
       {
-        ReturnValue = Size;
-        m_SeekPos += Size;
+        return_value = request.length;
+        m_SeekPos += request.length;
       }
     }
   }
@@ -297,54 +283,45 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
   {
     ERROR_LOG(WII_IPC_FILEIO, "FileIO: Failed to read from %s (Addr=0x%08x Size=0x%x) - file could "
                               "not be opened or does not exist",
-              m_name.c_str(), Address, Size);
-    ReturnValue = FS_ENOENT;
+              m_name.c_str(), request.data_addr, request.length);
+    return_value = FS_ENOENT;
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(IOSResourceIOCtlRequest& request)
 {
   DEBUG_LOG(WII_IPC_FILEIO, "FileIO: IOCtl (Device=%s)", m_name.c_str());
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  DumpCommands(_CommandAddress);
-#endif
-  const u32 Parameter = Memory::Read_U32(_CommandAddress + 0xC);
-  u32 ReturnValue = 0;
+  s32 return_value = 0;
 
-  switch (Parameter)
+  switch (request.request)
   {
   case ISFS_IOCTL_GETFILESTATS:
   {
     if (m_file->IsOpen())
     {
-      u32 m_FileLength = (u32)m_file->GetSize();
-
-      const u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-      DEBUG_LOG(WII_IPC_FILEIO, "  File: %s, Length: %i, Pos: %i", m_name.c_str(), m_FileLength,
-                m_SeekPos);
-
-      Memory::Write_U32(m_FileLength, BufferOut);
-      Memory::Write_U32(m_SeekPos, BufferOut + 4);
+      DEBUG_LOG(WII_IPC_FILEIO, "File: %s, Length: %" PRIu64 ", Pos: %i", m_name.c_str(),
+                m_file->GetSize(), m_SeekPos);
+      Memory::Write_U32(static_cast<u32>(m_file->GetSize()), request.out_addr);
+      Memory::Write_U32(m_SeekPos, request.out_addr + 4);
     }
     else
     {
-      ReturnValue = FS_ENOENT;
+      return_value = FS_ENOENT;
     }
   }
   break;
 
   default:
   {
-    PanicAlert("CWII_IPC_HLE_Device_FileIO: Parameter %i", Parameter);
+    PanicAlert("CWII_IPC_HLE_Device_FileIO: Parameter %u", request.request);
   }
   break;
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
@@ -28,32 +28,18 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_FileIO();
 
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Seek(u32 _CommandAddress) override;
-  IPCCommandResult Read(u32 _CommandAddress) override;
-  IPCCommandResult Write(u32 _CommandAddress) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  void Close() override;
+  IOSReturnCode Open(IOSResourceOpenRequest& request) override;
+  IPCCommandResult Seek(IOSResourceSeekRequest& request) override;
+  IPCCommandResult Read(IOSResourceReadWriteRequest& request) override;
+  IPCCommandResult Write(IOSResourceReadWriteRequest& request) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
   void PrepareForState(PointerWrap::Mode mode) override;
   void DoState(PointerWrap& p) override;
 
   void OpenFile();
 
 private:
-  enum
-  {
-    ISFS_OPEN_READ = 1,
-    ISFS_OPEN_WRITE = 2,
-    ISFS_OPEN_RW = (ISFS_OPEN_READ | ISFS_OPEN_WRITE)
-  };
-
-  enum
-  {
-    WII_SEEK_SET = 0,
-    WII_SEEK_CUR = 1,
-    WII_SEEK_END = 2,
-  };
-
   enum
   {
     ISFS_FUNCNULL = 0,

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -198,8 +198,6 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce
   m_AccessIdentID = 0x6000000;
 
   INFO_LOG(WII_IPC_ES, "ES: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
   m_Active = false;
   // clear the NAND content cache to make sure nothing remains open.
   DiscIO::CNANDContentManager::Access().ClearCache();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -184,7 +184,6 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Open(u32 _CommandAddress, u32 _Mode)
 {
   OpenInternal();
 
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   if (m_Active)
     INFO_LOG(WII_IPC_ES, "Device was re-opened.");
   m_Active = true;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -184,9 +184,9 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Open(u32 _CommandAddress, u32 _Mode)
 {
   OpenInternal();
 
-  if (m_Active)
+  if (m_is_active)
     INFO_LOG(WII_IPC_ES, "Device was re-opened.");
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -198,7 +198,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce
   m_AccessIdentID = 0x6000000;
 
   INFO_LOG(WII_IPC_ES, "ES: Close");
-  m_Active = false;
+  m_is_active = false;
   // clear the NAND content cache to make sure nothing remains open.
   DiscIO::CNANDContentManager::Access().ClearCache();
   return GetDefaultReply();
@@ -1061,9 +1061,9 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
     if (!bReset)
     {
-      // The original hardware overwrites the command type with the async reply type.
-      Memory::Write_U32(IPC_REP_ASYNC, _CommandAddress);
-      // IOS also seems to write back the command that was responded to in the FD field.
+      // The command type is overwritten with the reply type.
+      Memory::Write_U32(IPC_REPLY, _CommandAddress);
+      // IOS also writes back the command that was responded to in the FD field.
       Memory::Write_U32(IPC_CMD_IOCTLV, _CommandAddress + 8);
     }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
@@ -34,10 +34,9 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IOSReturnCode Open(IOSResourceOpenRequest& request) override;
+  void Close() override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
   static u32 ES_DIVerify(const std::vector<u8>& tmd);
 
@@ -112,7 +111,7 @@ private:
     ES_INVALID_TMD = -106,  // or access denied
     ES_READ_LESS_DATA_THAN_EXPECTED = -1009,
     ES_WRITE_FAILURE = -1010,
-    ES_PARAMTER_SIZE_OR_ALIGNMENT = -1017,
+    ES_PARAMETER_SIZE_OR_ALIGNMENT = -1017,
     ES_HASH_DOESNT_MATCH = -1022,
     ES_MEM_ALLOC_FAILED = -1024,
     ES_INCORRECT_ACCESS_RIGHT = -1026,

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -73,7 +73,7 @@ static u64 ComputeTotalFileSize(const File::FSTEntry& parentEntry)
 
 IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
 {
-  u32 ReturnValue = FS_RESULT_OK;
+  u32 ReturnValue = IPC_SUCCESS;
   SIOCtlVBuffer CommandBuffer(_CommandAddress);
 
   // Prepare the out buffer(s) with zeros as a safety precaution
@@ -94,7 +94,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     if (!IsValidWiiPath(relative_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", relative_path.c_str());
-      ReturnValue = FS_RESULT_FATAL;
+      ReturnValue = FS_EINVAL;
       break;
     }
 
@@ -106,7 +106,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     if (!File::Exists(DirName))
     {
       WARN_LOG(WII_IPC_FILEIO, "FS: Search not found: %s", DirName.c_str());
-      ReturnValue = FS_FILE_NOT_EXIST;
+      ReturnValue = FS_ENOENT;
       break;
     }
     else if (!File::IsDirectory(DirName))
@@ -114,8 +114,8 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
       // It's not a directory, so error.
       // Games don't usually seem to care WHICH error they get, as long as it's <
       // Well the system menu CARES!
-      WARN_LOG(WII_IPC_FILEIO, "\tNot a directory - return FS_RESULT_FATAL");
-      ReturnValue = FS_RESULT_FATAL;
+      WARN_LOG(WII_IPC_FILEIO, "\tNot a directory - return FS_EINVAL");
+      ReturnValue = FS_EINVAL;
       break;
     }
 
@@ -166,7 +166,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
       Memory::Write_U32((u32)numFiles, CommandBuffer.PayloadBuffer[1].m_Address);
     }
 
-    ReturnValue = FS_RESULT_OK;
+    ReturnValue = IPC_SUCCESS;
   }
   break;
 
@@ -185,7 +185,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     if (!IsValidWiiPath(relativepath))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", relativepath.c_str());
-      ReturnValue = FS_RESULT_FATAL;
+      ReturnValue = FS_EINVAL;
       break;
     }
 
@@ -217,7 +217,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
 
         fsBlocks = (u32)(totalSize / (16 * 1024));  // one bock is 16kb
       }
-      ReturnValue = FS_RESULT_OK;
+      ReturnValue = IPC_SUCCESS;
 
       INFO_LOG(WII_IPC_FILEIO, "FS: fsBlock: %i, iNodes: %i", fsBlocks, iNodes);
     }
@@ -225,7 +225,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     {
       fsBlocks = 0;
       iNodes = 0;
-      ReturnValue = FS_RESULT_OK;
+      ReturnValue = IPC_SUCCESS;
       WARN_LOG(WII_IPC_FILEIO, "FS: fsBlock failed, cannot find directory: %s", path.c_str());
     }
 
@@ -290,7 +290,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
 
     std::memcpy(Memory::GetPointer(_BufferOut), &fs, sizeof(NANDStat));
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -307,7 +307,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string DirName(HLE_IPC_BuildFilename(wii_path));
     Addr += 64;
@@ -322,7 +322,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     _dbg_assert_msg_(WII_IPC_FILEIO, File::IsDirectory(DirName), "FS: CREATE_DIR %s failed",
                      DirName.c_str());
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -338,7 +338,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename = HLE_IPC_BuildFilename(wii_path);
     Addr += 64;
@@ -359,7 +359,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     DEBUG_LOG(WII_IPC_FILEIO, "    OtherPerm: 0x%02x", OtherPerm);
     DEBUG_LOG(WII_IPC_FILEIO, "    Attributes: 0x%02x", Attributes);
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -376,7 +376,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename = HLE_IPC_BuildFilename(wii_path);
     u8 OwnerPerm = 0x3;    // read/write
@@ -398,7 +398,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
       else
       {
         INFO_LOG(WII_IPC_FILEIO, "FS: GET_ATTR unknown %s", Filename.c_str());
-        return FS_FILE_NOT_EXIST;
+        return FS_ENOENT;
       }
     }
 
@@ -422,7 +422,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
       Addr += 1;
     }
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -435,7 +435,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename = HLE_IPC_BuildFilename(wii_path);
     Offset += 64;
@@ -452,7 +452,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
       WARN_LOG(WII_IPC_FILEIO, "FS: DeleteFile %s - failed!!!", Filename.c_str());
     }
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -465,7 +465,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename = HLE_IPC_BuildFilename(wii_path);
     Offset += 64;
@@ -474,7 +474,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path_rename))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path_rename.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string FilenameRename = HLE_IPC_BuildFilename(wii_path_rename);
     Offset += 64;
@@ -497,10 +497,10 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     {
       ERROR_LOG(WII_IPC_FILEIO, "FS: Rename %s to %s - failed", Filename.c_str(),
                 FilenameRename.c_str());
-      return FS_FILE_NOT_EXIST;
+      return FS_ENOENT;
     }
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -517,7 +517,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename(HLE_IPC_BuildFilename(wii_path));
     Addr += 64;
@@ -541,8 +541,8 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     // check if the file already exist
     if (File::Exists(Filename))
     {
-      INFO_LOG(WII_IPC_FILEIO, "\tresult = FS_RESULT_EXISTS");
-      return FS_FILE_EXIST;
+      INFO_LOG(WII_IPC_FILEIO, "\tresult = FS_EEXIST");
+      return FS_EEXIST;
     }
 
     // create the file
@@ -552,11 +552,11 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     {
       ERROR_LOG(WII_IPC_FILEIO, "CWII_IPC_HLE_Device_fs: couldn't create new file");
       PanicAlert("CWII_IPC_HLE_Device_fs: couldn't create new file");
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
 
-    INFO_LOG(WII_IPC_FILEIO, "\tresult = FS_RESULT_OK");
-    return FS_RESULT_OK;
+    INFO_LOG(WII_IPC_FILEIO, "\tresult = IPC_SUCCESS");
+    return IPC_SUCCESS;
   }
   break;
   case IOCTL_SHUTDOWN:
@@ -571,7 +571,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     break;
   }
 
-  return FS_RESULT_FATAL;
+  return FS_EINVAL;
 }
 
 void CWII_IPC_HLE_Device_fs::DoState(PointerWrap& p)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -52,7 +52,6 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::Open(u32 _CommandAddress, u32 _Mode)
     File::CreateDir(Path);
   }
 
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetFSReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -56,15 +56,6 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::Open(u32 _CommandAddress, u32 _Mode)
   return GetFSReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_fs::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_FILEIO, "Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetFSReply();
-}
-
 // Get total filesize of contents of a directory (recursive)
 // Only used for ES_GetUsage atm, could be useful elsewhere?
 static u64 ComputeTotalFileSize(const File::FSTEntry& parentEntry)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -52,7 +52,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::Open(u32 _CommandAddress, u32 _Mode)
     File::CreateDir(Path);
   }
 
-  m_Active = true;
+  m_is_active = true;
   return GetFSReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -43,7 +43,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::GetFSReply() const
   return {true, SystemTimers::GetTicksPerSecond() / 500};
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_fs::Open(u32 _CommandAddress, u32 _Mode)
+IOSReturnCode CWII_IPC_HLE_Device_fs::Open(IOSResourceOpenRequest& request)
 {
   // clear tmp folder
   {
@@ -53,7 +53,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::Open(u32 _CommandAddress, u32 _Mode)
   }
 
   m_is_active = true;
-  return GetFSReply();
+  return IPC_SUCCESS;
 }
 
 // Get total filesize of contents of a directory (recursive)
@@ -71,30 +71,20 @@ static u64 ComputeTotalFileSize(const File::FSTEntry& parentEntry)
   return sizeOfFiles;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
-  u32 ReturnValue = IPC_SUCCESS;
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
-
-  // Prepare the out buffer(s) with zeros as a safety precaution
-  // to avoid returning bad values
-  for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; i++)
-  {
-    Memory::Memset(CommandBuffer.PayloadBuffer[i].m_Address, 0,
-                   CommandBuffer.PayloadBuffer[i].m_Size);
-  }
-
-  switch (CommandBuffer.Parameter)
+  s32 return_value = IPC_SUCCESS;
+  switch (request.request)
   {
   case IOCTLV_READ_DIR:
   {
     const std::string relative_path =
-        Memory::GetString(CommandBuffer.InBuffer[0].m_Address, CommandBuffer.InBuffer[0].m_Size);
+        Memory::GetString(request.in_vectors[0].addr, request.in_vectors[0].size);
 
     if (!IsValidWiiPath(relative_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", relative_path.c_str());
-      ReturnValue = FS_EINVAL;
+      return_value = FS_EINVAL;
       break;
     }
 
@@ -106,7 +96,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     if (!File::Exists(DirName))
     {
       WARN_LOG(WII_IPC_FILEIO, "FS: Search not found: %s", DirName.c_str());
-      ReturnValue = FS_ENOENT;
+      return_value = FS_ENOENT;
       break;
     }
     else if (!File::IsDirectory(DirName))
@@ -115,19 +105,19 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
       // Games don't usually seem to care WHICH error they get, as long as it's <
       // Well the system menu CARES!
       WARN_LOG(WII_IPC_FILEIO, "\tNot a directory - return FS_EINVAL");
-      ReturnValue = FS_EINVAL;
+      return_value = FS_EINVAL;
       break;
     }
 
     File::FSTEntry entry = File::ScanDirectoryTree(DirName, false);
 
     // it is one
-    if ((CommandBuffer.InBuffer.size() == 1) && (CommandBuffer.PayloadBuffer.size() == 1))
+    if ((request.in_vectors.size() == 1) && (request.io_vectors.size() == 1))
     {
       size_t numFile = entry.children.size();
       INFO_LOG(WII_IPC_FILEIO, "\t%zu files found", numFile);
 
-      Memory::Write_U32((u32)numFile, CommandBuffer.PayloadBuffer[0].m_Address);
+      Memory::Write_U32((u32)numFile, request.io_vectors[0].addr);
     }
     else
     {
@@ -143,13 +133,12 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
                   return one.virtualName < two.virtualName;
                 });
 
-      u32 MaxEntries = Memory::Read_U32(CommandBuffer.InBuffer[0].m_Address);
+      u32 MaxEntries = Memory::Read_U32(request.in_vectors[0].addr);
 
-      memset(Memory::GetPointer(CommandBuffer.PayloadBuffer[0].m_Address), 0,
-             CommandBuffer.PayloadBuffer[0].m_Size);
+      memset(Memory::GetPointer(request.io_vectors[0].addr), 0, request.io_vectors[0].size);
 
       size_t numFiles = 0;
-      char* pFilename = (char*)Memory::GetPointer((u32)(CommandBuffer.PayloadBuffer[0].m_Address));
+      char* pFilename = (char*)Memory::GetPointer((u32)(request.io_vectors[0].addr));
 
       for (size_t i = 0; i < entry.children.size() && i < MaxEntries; i++)
       {
@@ -163,29 +152,29 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
         INFO_LOG(WII_IPC_FILEIO, "\tFound: %s", FileName.c_str());
       }
 
-      Memory::Write_U32((u32)numFiles, CommandBuffer.PayloadBuffer[1].m_Address);
+      Memory::Write_U32((u32)numFiles, request.io_vectors[1].addr);
     }
 
-    ReturnValue = IPC_SUCCESS;
+    return_value = IPC_SUCCESS;
   }
   break;
 
   case IOCTLV_GETUSAGE:
   {
-    _dbg_assert_(WII_IPC_FILEIO, CommandBuffer.PayloadBuffer.size() == 2);
-    _dbg_assert_(WII_IPC_FILEIO, CommandBuffer.PayloadBuffer[0].m_Size == 4);
-    _dbg_assert_(WII_IPC_FILEIO, CommandBuffer.PayloadBuffer[1].m_Size == 4);
+    _dbg_assert_(WII_IPC_FILEIO, request.io_vectors.size() == 2);
+    _dbg_assert_(WII_IPC_FILEIO, request.io_vectors[0].size == 4);
+    _dbg_assert_(WII_IPC_FILEIO, request.io_vectors[1].size == 4);
 
     // this command sucks because it asks of the number of used
     // fsBlocks and inodes
     // It should be correct, but don't count on it...
     std::string relativepath =
-        Memory::GetString(CommandBuffer.InBuffer[0].m_Address, CommandBuffer.InBuffer[0].m_Size);
+        Memory::GetString(request.in_vectors[0].addr, request.in_vectors[0].size);
 
     if (!IsValidWiiPath(relativepath))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", relativepath.c_str());
-      ReturnValue = FS_EINVAL;
+      return_value = FS_EINVAL;
       break;
     }
 
@@ -217,7 +206,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
 
         fsBlocks = (u32)(totalSize / (16 * 1024));  // one bock is 16kb
       }
-      ReturnValue = IPC_SUCCESS;
+      return_value = IPC_SUCCESS;
 
       INFO_LOG(WII_IPC_FILEIO, "FS: fsBlock: %i, iNodes: %i", fsBlocks, iNodes);
     }
@@ -225,54 +214,38 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     {
       fsBlocks = 0;
       iNodes = 0;
-      ReturnValue = IPC_SUCCESS;
+      return_value = IPC_SUCCESS;
       WARN_LOG(WII_IPC_FILEIO, "FS: fsBlock failed, cannot find directory: %s", path.c_str());
     }
 
-    Memory::Write_U32(fsBlocks, CommandBuffer.PayloadBuffer[0].m_Address);
-    Memory::Write_U32(iNodes, CommandBuffer.PayloadBuffer[1].m_Address);
+    Memory::Write_U32(fsBlocks, request.io_vectors[0].addr);
+    Memory::Write_U32(iNodes, request.io_vectors[1].addr);
   }
   break;
 
   default:
-    PanicAlert("CWII_IPC_HLE_Device_fs::IOCtlV: %i", CommandBuffer.Parameter);
+    PanicAlert("CWII_IPC_HLE_Device_fs::IOCtlV: %u", request.request);
     break;
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 4);
-
+  request.SetReturnValue(return_value);
   return GetFSReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtl(IOSResourceIOCtlRequest& request)
 {
-  // u32 DeviceID = Memory::Read_U32(_CommandAddress + 8);
-
-  u32 Parameter = Memory::Read_U32(_CommandAddress + 0xC);
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-
-  /* Prepare the out buffer(s) with zeroes as a safety precaution
-     to avoid returning bad values. */
-  // LOG(WII_IPC_FILEIO, "Cleared %u bytes of the out buffer", _BufferOutSize);
-  Memory::Memset(BufferOut, 0, BufferOutSize);
-
-  u32 ReturnValue = ExecuteCommand(Parameter, BufferIn, BufferInSize, BufferOut, BufferOutSize);
-  Memory::Write_U32(ReturnValue, _CommandAddress + 4);
-
+  const s32 return_value = ExecuteCommand(request);
+  request.SetReturnValue(return_value);
   return GetFSReply();
 }
 
-s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _BufferInSize,
-                                           u32 _BufferOut, u32 _BufferOutSize)
+s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(IOSResourceIOCtlRequest& request)
 {
-  switch (_Parameter)
+  switch (request.request)
   {
   case IOCTL_GET_STATS:
   {
-    if (_BufferOutSize < 0x1c)
+    if (request.out_size < 0x1c)
       return -1017;
 
     WARN_LOG(WII_IPC_FILEIO, "FS: GET STATS - returning static values for now");
@@ -288,7 +261,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     fs.Free_INodes = 0x146B;
     fs.Used_Inodes = 0x0394;
 
-    std::memcpy(Memory::GetPointer(_BufferOut), &fs, sizeof(NANDStat));
+    std::memcpy(Memory::GetPointer(request.out_addr), &fs, sizeof(NANDStat));
 
     return IPC_SUCCESS;
   }
@@ -296,8 +269,8 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
 
   case IOCTL_CREATE_DIR:
   {
-    _dbg_assert_(WII_IPC_FILEIO, _BufferOutSize == 0);
-    u32 Addr = _BufferIn;
+    _dbg_assert_(WII_IPC_FILEIO, request.out_size == 0);
+    u32 Addr = request.in_addr;
 
     u32 OwnerID = Memory::Read_U32(Addr);
     Addr += 4;
@@ -328,7 +301,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
 
   case IOCTL_SET_ATTR:
   {
-    u32 Addr = _BufferIn;
+    u32 Addr = request.in_addr;
 
     u32 OwnerID = Memory::Read_U32(Addr);
     Addr += 4;
@@ -365,14 +338,14 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
 
   case IOCTL_GET_ATTR:
   {
-    _dbg_assert_msg_(WII_IPC_FILEIO, _BufferOutSize == 76,
+    _dbg_assert_msg_(WII_IPC_FILEIO, request.out_size == 76,
                      "    GET_ATTR needs an 76 bytes large output buffer but it is %i bytes large",
-                     _BufferOutSize);
+                     request.out_size);
 
     u32 OwnerID = 0;
     u16 GroupID = 0x3031;  // this is also known as makercd, 01 (0x3031) for nintendo and 08
                            // (0x3038) for MH3 etc
-    const std::string wii_path = Memory::GetString(_BufferIn, 64);
+    const std::string wii_path = Memory::GetString(request.in_addr, 64);
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
@@ -403,14 +376,14 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     }
 
     // write answer to buffer
-    if (_BufferOutSize == 76)
+    if (request.out_size == 76)
     {
-      u32 Addr = _BufferOut;
+      u32 Addr = request.out_addr;
       Memory::Write_U32(OwnerID, Addr);
       Addr += 4;
       Memory::Write_U16(GroupID, Addr);
       Addr += 2;
-      memcpy(Memory::GetPointer(Addr), Memory::GetPointer(_BufferIn), 64);
+      memcpy(Memory::GetPointer(Addr), Memory::GetPointer(request.in_addr), 64);
       Addr += 64;
       Memory::Write_U8(OwnerPerm, Addr);
       Addr += 1;
@@ -428,10 +401,10 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
 
   case IOCTL_DELETE_FILE:
   {
-    _dbg_assert_(WII_IPC_FILEIO, _BufferOutSize == 0);
+    _dbg_assert_(WII_IPC_FILEIO, request.out_size == 0);
     int Offset = 0;
 
-    const std::string wii_path = Memory::GetString(_BufferIn + Offset, 64);
+    const std::string wii_path = Memory::GetString(request.in_addr + Offset, 64);
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
@@ -458,10 +431,10 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
 
   case IOCTL_RENAME_FILE:
   {
-    _dbg_assert_(WII_IPC_FILEIO, _BufferOutSize == 0);
+    _dbg_assert_(WII_IPC_FILEIO, request.out_size == 0);
     int Offset = 0;
 
-    const std::string wii_path = Memory::GetString(_BufferIn + Offset, 64);
+    const std::string wii_path = Memory::GetString(request.in_addr + Offset, 64);
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
@@ -470,7 +443,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     std::string Filename = HLE_IPC_BuildFilename(wii_path);
     Offset += 64;
 
-    const std::string wii_path_rename = Memory::GetString(_BufferIn + Offset, 64);
+    const std::string wii_path_rename = Memory::GetString(request.in_addr + Offset, 64);
     if (!IsValidWiiPath(wii_path_rename))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path_rename.c_str());
@@ -506,9 +479,9 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
 
   case IOCTL_CREATE_FILE:
   {
-    _dbg_assert_(WII_IPC_FILEIO, _BufferOutSize == 0);
+    _dbg_assert_(WII_IPC_FILEIO, request.out_size == 0);
 
-    u32 Addr = _BufferIn;
+    u32 Addr = request.in_addr;
     u32 OwnerID = Memory::Read_U32(Addr);
     Addr += 4;
     u16 GroupID = Memory::Read_U16(Addr);
@@ -566,8 +539,8 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
   }
   break;
   default:
-    ERROR_LOG(WII_IPC_FILEIO, "CWII_IPC_HLE_Device_fs::IOCtl: ni  0x%x", _Parameter);
-    PanicAlert("CWII_IPC_HLE_Device_fs::IOCtl: ni  0x%x", _Parameter);
+    ERROR_LOG(WII_IPC_FILEIO, "CWII_IPC_HLE_Device_fs::IOCtl: ni  0x%x", request.request);
+    PanicAlert("CWII_IPC_HLE_Device_fs::IOCtl: ni  0x%x", request.request);
     break;
   }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -23,18 +23,6 @@ struct NANDStat
   u32 Used_Inodes;
 };
 
-enum
-{
-  FS_RESULT_OK = 0,
-  FS_INVALID = -4,
-  FS_DIRFILE_NOT_FOUND = -6,
-  FS_RESULT_FATAL = -101,
-  FS_NO_ACCESS = -102,
-  FS_FILE_EXIST = -105,
-  FS_FILE_NOT_EXIST = -106,
-  FS_NO_HANDLE = -106,
-};
-
 class CWII_IPC_HLE_Device_fs : public IWII_IPC_HLE_Device
 {
 public:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -44,7 +44,6 @@ public:
   void DoState(PointerWrap& p) override;
 
   IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -31,10 +31,9 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IOSReturnCode Open(IOSResourceOpenRequest& request) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
 private:
   enum
@@ -52,6 +51,5 @@ private:
   };
 
   IPCCommandResult GetFSReply() const;
-  s32 ExecuteCommand(u32 Parameter, u32 _BufferIn, u32 _BufferInSize, u32 _BufferOut,
-                     u32 _BufferOutSize);
+  s32 ExecuteCommand(IOSResourceIOCtlRequest& request);
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -104,22 +104,6 @@ CWII_IPC_HLE_Device_hid::~CWII_IPC_HLE_Device_hid()
     libusb_exit(nullptr);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_hid::Open(u32 _CommandAddress, u32 _Mode)
-{
-  INFO_LOG(WII_IPC_HID, "HID::Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_hid::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_HID, "HID::Close");
-  m_Active = false;
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 {
   if (Core::g_want_determinism)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -108,7 +108,6 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::Open(u32 _CommandAddress, u32 _Mode)
 {
   INFO_LOG(WII_IPC_HID, "HID::Open");
   m_Active = true;
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -10,6 +10,7 @@
 
 #include <libusb.h>
 
+#include "Common/Align.h"
 #include "Common/CommonFuncs.h"
 #include "Common/Logging/Log.h"
 #include "Core/Core.h"
@@ -373,8 +374,8 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 
     WiiHIDDeviceDescriptor wii_device;
     ConvertDeviceToWii(&wii_device, &desc);
-    Memory::CopyToEmu(OffsetBuffer, &wii_device, Align(wii_device.bLength, 4));
-    OffsetBuffer += Align(wii_device.bLength, 4);
+    Memory::CopyToEmu(OffsetBuffer, &wii_device, Common::AlignUp(wii_device.bLength, 4));
+    OffsetBuffer += Common::AlignUp(wii_device.bLength, 4);
     bool deviceValid = true;
     bool isHID = false;
 
@@ -387,8 +388,8 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
       {
         WiiHIDConfigDescriptor wii_config;
         ConvertConfigToWii(&wii_config, config);
-        Memory::CopyToEmu(OffsetBuffer, &wii_config, Align(wii_config.bLength, 4));
-        OffsetBuffer += Align(wii_config.bLength, 4);
+        Memory::CopyToEmu(OffsetBuffer, &wii_config, Common::AlignUp(wii_config.bLength, 4));
+        OffsetBuffer += Common::AlignUp(wii_config.bLength, 4);
 
         for (ic = 0; ic < config->bNumInterfaces; ic++)
         {
@@ -404,8 +405,9 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 
             WiiHIDInterfaceDescriptor wii_interface;
             ConvertInterfaceToWii(&wii_interface, interface);
-            Memory::CopyToEmu(OffsetBuffer, &wii_interface, Align(wii_interface.bLength, 4));
-            OffsetBuffer += Align(wii_interface.bLength, 4);
+            Memory::CopyToEmu(OffsetBuffer, &wii_interface,
+                              Common::AlignUp(wii_interface.bLength, 4));
+            OffsetBuffer += Common::AlignUp(wii_interface.bLength, 4);
 
             for (e = 0; e < interface->bNumEndpoints; e++)
             {
@@ -413,8 +415,9 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 
               WiiHIDEndpointDescriptor wii_endpoint;
               ConvertEndpointToWii(&wii_endpoint, endpoint);
-              Memory::CopyToEmu(OffsetBuffer, &wii_endpoint, Align(wii_endpoint.bLength, 4));
-              OffsetBuffer += Align(wii_endpoint.bLength, 4);
+              Memory::CopyToEmu(OffsetBuffer, &wii_endpoint,
+                                Common::AlignUp(wii_endpoint.bLength, 4));
+              OffsetBuffer += Common::AlignUp(wii_endpoint.bLength, 4);
 
             }  // endpoints
           }    // interfaces
@@ -481,11 +484,6 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
   libusb_free_device_list(list, 1);
 
   Memory::Write_U32(0xFFFFFFFF, OffsetBuffer);  // no more devices
-}
-
-int CWII_IPC_HLE_Device_hid::Align(int num, int alignment)
-{
-  return (num + (alignment - 1)) & ~(alignment - 1);
 }
 
 libusb_device_handle* CWII_IPC_HLE_Device_hid::GetDeviceByDevNum(u32 devNum)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -37,13 +37,10 @@ void CWII_IPC_HLE_Device_hid::checkUsbUpdates(CWII_IPC_HLE_Device_hid* hid)
       std::lock_guard<std::mutex> lk(hid->m_device_list_reply_mutex);
       if (hid->deviceCommandAddress != 0)
       {
-        hid->FillOutDevices(Memory::Read_U32(hid->deviceCommandAddress + 0x18),
-                            Memory::Read_U32(hid->deviceCommandAddress + 0x1C));
-
-        // Return value
-        Memory::Write_U32(0, hid->deviceCommandAddress + 4);
-        WII_IPC_HLE_Interface::EnqueueReply(hid->deviceCommandAddress, 0,
-                                            CoreTiming::FromThread::NON_CPU);
+        IOSResourceIOCtlRequest request{hid->deviceCommandAddress};
+        hid->FillOutDevices(request);
+        request.SetReturnValue(IPC_SUCCESS);
+        WII_IPC_HLE_Interface::EnqueueReply(request, 0, CoreTiming::FromThread::NON_CPU);
         hid->deviceCommandAddress = 0;
       }
     }
@@ -56,16 +53,16 @@ void CWII_IPC_HLE_Device_hid::checkUsbUpdates(CWII_IPC_HLE_Device_hid* hid)
 
 void CWII_IPC_HLE_Device_hid::handleUsbUpdates(struct libusb_transfer* transfer)
 {
-  int ret = IPC_EINVAL;
+  s32 ret = IPC_EINVAL;
   u32 replyAddress = (u32)(size_t)transfer->user_data;
   if (transfer->status == LIBUSB_TRANSFER_COMPLETED)
   {
     ret = transfer->length;
   }
 
-  // Return value
-  Memory::Write_U32(ret, replyAddress + 4);
-  WII_IPC_HLE_Interface::EnqueueReply(replyAddress, 0, CoreTiming::FromThread::NON_CPU);
+  IOSResourceIOCtlRequest request{replyAddress};
+  request.SetReturnValue(ret);
+  WII_IPC_HLE_Interface::EnqueueReply(request, 0, CoreTiming::FromThread::NON_CPU);
 }
 
 CWII_IPC_HLE_Device_hid::CWII_IPC_HLE_Device_hid(u32 _DeviceID, const std::string& _rDeviceName)
@@ -105,53 +102,37 @@ CWII_IPC_HLE_Device_hid::~CWII_IPC_HLE_Device_hid()
     libusb_exit(nullptr);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(IOSResourceIOCtlRequest& request)
 {
   if (Core::g_want_determinism)
   {
-    Memory::Write_U32(-1, _CommandAddress + 0x4);
+    request.SetReturnValue(-1);
     return GetDefaultReply();
   }
 
-  u32 Parameter = Memory::Read_U32(_CommandAddress + 0xC);
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-
-  u32 ReturnValue = 0;
-  switch (Parameter)
+  s32 return_value = IPC_SUCCESS;
+  switch (request.request)
   {
   case IOCTL_HID_GET_ATTACHED:
   {
-    INFO_LOG(WII_IPC_HID, "HID::IOCtl(Get Attached) (BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             BufferIn, BufferInSize, BufferOut, BufferOutSize);
-    deviceCommandAddress = _CommandAddress;
+    deviceCommandAddress = request.address;
     return GetNoReply();
   }
   case IOCTL_HID_OPEN:
   {
-    INFO_LOG(WII_IPC_HID, "HID::IOCtl(Open) (BufferIn: (%08x, %i), BufferOut: (%08x, %i)", BufferIn,
-             BufferInSize, BufferOut, BufferOutSize);
-
     // hid version, apparently
-    ReturnValue = 0x40001;
+    return_value = 0x40001;
     break;
   }
   case IOCTL_HID_SET_SUSPEND:
   {
-    INFO_LOG(WII_IPC_HID, "HID::IOCtl(Set Suspend) (BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             BufferIn, BufferInSize, BufferOut, BufferOutSize);
     // not actually implemented in IOS
-    ReturnValue = 0;
+    return_value = IPC_SUCCESS;
     break;
   }
   case IOCTL_HID_CANCEL_INTERRUPT:
   {
-    DEBUG_LOG(WII_IPC_HID,
-              "HID::IOCtl(Cancel Interrupt) (BufferIn: (%08x, %i), BufferOut: (%08x, %i)", BufferIn,
-              BufferInSize, BufferOut, BufferOutSize);
-    ReturnValue = 0;
+    return_value = IPC_SUCCESS;
     break;
   }
   case IOCTL_HID_CONTROL:
@@ -161,15 +142,15 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
       -4 Can't find device specified
     */
 
-    u32 dev_num = Memory::Read_U32(BufferIn + 0x10);
-    u8 bmRequestType = Memory::Read_U8(BufferIn + 0x14);
-    u8 bRequest = Memory::Read_U8(BufferIn + 0x15);
-    u16 wValue = Memory::Read_U16(BufferIn + 0x16);
-    u16 wIndex = Memory::Read_U16(BufferIn + 0x18);
-    u16 wLength = Memory::Read_U16(BufferIn + 0x1A);
-    u32 data = Memory::Read_U32(BufferIn + 0x1C);
+    u32 dev_num = Memory::Read_U32(request.in_addr + 0x10);
+    u8 bmRequestType = Memory::Read_U8(request.in_addr + 0x14);
+    u8 bRequest = Memory::Read_U8(request.in_addr + 0x15);
+    u16 wValue = Memory::Read_U16(request.in_addr + 0x16);
+    u16 wIndex = Memory::Read_U16(request.in_addr + 0x18);
+    u16 wLength = Memory::Read_U16(request.in_addr + 0x1A);
+    u32 data = Memory::Read_U32(request.in_addr + 0x1C);
 
-    ReturnValue = IPC_EINVAL;
+    return_value = IPC_EINVAL;
 
     libusb_device_handle* dev_handle = GetDeviceByDevNum(dev_num);
 
@@ -185,12 +166,14 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
     libusb_fill_control_setup(buffer, bmRequestType, bRequest, wValue, wIndex, wLength);
     Memory::CopyFromEmu(buffer + LIBUSB_CONTROL_SETUP_SIZE, data, wLength);
     libusb_fill_control_transfer(transfer, dev_handle, buffer, handleUsbUpdates,
-                                 (void*)(size_t)_CommandAddress, /* no timeout */ 0);
+                                 (void*)(size_t)request.address, /* no timeout */ 0);
     libusb_submit_transfer(transfer);
 
-    // DEBUG_LOG(WII_IPC_HID, "HID::IOCtl(Control)(%02X, %02X) (BufferIn: (%08x, %i), BufferOut:
+    // DEBUG_LOG(WII_IPC_HID, "HID::IOCtl(Control)(%02X, %02X) (BufferIn: (%08x, %i),
+    // request.out_addr:
     // (%08x, %i)",
-    //          bmRequestType, bRequest, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    //          bmRequestType, bRequest, BufferIn, request.in_size, request.out_addr,
+    //          request.out_size);
 
     // It's the async way!
     return GetNoReply();
@@ -198,13 +181,13 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
   case IOCTL_HID_INTERRUPT_OUT:
   case IOCTL_HID_INTERRUPT_IN:
   {
-    u32 dev_num = Memory::Read_U32(BufferIn + 0x10);
-    u32 endpoint = Memory::Read_U32(BufferIn + 0x14);
-    u32 length = Memory::Read_U32(BufferIn + 0x18);
+    u32 dev_num = Memory::Read_U32(request.in_addr + 0x10);
+    u32 endpoint = Memory::Read_U32(request.in_addr + 0x14);
+    u32 length = Memory::Read_U32(request.in_addr + 0x18);
 
-    u32 data = Memory::Read_U32(BufferIn + 0x1C);
+    u32 data = Memory::Read_U32(request.in_addr + 0x1C);
 
-    ReturnValue = IPC_EINVAL;
+    return_value = IPC_EINVAL;
 
     libusb_device_handle* dev_handle = GetDeviceByDevNum(dev_num);
 
@@ -217,13 +200,8 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
     struct libusb_transfer* transfer = libusb_alloc_transfer(0);
     transfer->flags |= LIBUSB_TRANSFER_FREE_TRANSFER;
     libusb_fill_interrupt_transfer(transfer, dev_handle, endpoint, Memory::GetPointer(data), length,
-                                   handleUsbUpdates, (void*)(size_t)_CommandAddress, 0);
+                                   handleUsbUpdates, (void*)(size_t)request.address, 0);
     libusb_submit_transfer(transfer);
-
-    // DEBUG_LOG(WII_IPC_HID, "HID::IOCtl(Interrupt %s)(%d,%d,%X) (BufferIn: (%08x, %i), BufferOut:
-    // (%08x, %i)",
-    //          Parameter == IOCTL_HID_INTERRUPT_IN ? "In" : "Out", endpoint, length, data,
-    //          BufferIn, BufferInSize, BufferOut, BufferOutSize);
 
     // It's the async way!
     return GetNoReply();
@@ -233,27 +211,25 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
     std::lock_guard<std::mutex> lk(m_device_list_reply_mutex);
     if (deviceCommandAddress != 0)
     {
-      Memory::Write_U32(0xFFFFFFFF, Memory::Read_U32(deviceCommandAddress + 0x18));
-
-      // Return value
-      Memory::Write_U32(-1, deviceCommandAddress + 4);
-      WII_IPC_HLE_Interface::EnqueueReply(deviceCommandAddress);
+      IOSResourceIOCtlRequest pending_request{deviceCommandAddress};
+      Memory::Write_U32(0xFFFFFFFF, pending_request.out_addr);
+      pending_request.SetReturnValue(-1);
+      WII_IPC_HLE_Interface::EnqueueReply(pending_request);
       deviceCommandAddress = 0;
     }
     INFO_LOG(WII_IPC_HID, "HID::IOCtl(Shutdown) (BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             BufferIn, BufferInSize, BufferOut, BufferOutSize);
+             request.in_addr, request.in_size, request.out_addr, request.out_size);
     break;
   }
   default:
   {
     INFO_LOG(WII_IPC_HID, "HID::IOCtl(0x%x) (BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             Parameter, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+             request.request, request.in_addr, request.in_size, request.out_addr, request.out_size);
     break;
   }
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 4);
-
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
@@ -283,25 +259,13 @@ bool CWII_IPC_HLE_Device_hid::ClaimDevice(libusb_device_handle* dev)
   return true;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
   Dolphin_Debugger::PrintCallstack(LogTypes::WII_IPC_HID, LogTypes::LWARNING);
-  u32 ReturnValue = 0;
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
 
-  INFO_LOG(WII_IPC_HID, "%s - IOCtlV:", GetDeviceName().c_str());
-  INFO_LOG(WII_IPC_HID, "    Parameter: 0x%x", CommandBuffer.Parameter);
-  INFO_LOG(WII_IPC_HID, "    NumberIn: 0x%08x", CommandBuffer.NumberInBuffer);
-  INFO_LOG(WII_IPC_HID, "    NumberOut: 0x%08x", CommandBuffer.NumberPayloadBuffer);
-  INFO_LOG(WII_IPC_HID, "    BufferVector: 0x%08x", CommandBuffer.BufferVector);
-  INFO_LOG(WII_IPC_HID, "    PayloadAddr: 0x%08x", CommandBuffer.PayloadBuffer[0].m_Address);
-  INFO_LOG(WII_IPC_HID, "    PayloadSize: 0x%08x", CommandBuffer.PayloadBuffer[0].m_Size);
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  DumpAsync(CommandBuffer.BufferVector, CommandBuffer.NumberInBuffer,
-            CommandBuffer.NumberPayloadBuffer);
-#endif
-
-  Memory::Write_U32(ReturnValue, _CommandAddress + 4);
+  ERROR_LOG(WII_IPC_HID, "%s - Unknown IOCtlV", GetDeviceName().c_str());
+  request.Dump(GetDeviceName(), LogTypes::WII_IPC_HID, LogTypes::LWARNING);
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }
 
@@ -344,10 +308,10 @@ void CWII_IPC_HLE_Device_hid::ConvertEndpointToWii(WiiHIDEndpointDescriptor* des
   dest->wMaxPacketSize = Common::swap16(dest->wMaxPacketSize);
 }
 
-void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
+void CWII_IPC_HLE_Device_hid::FillOutDevices(IOSResourceIOCtlRequest& request)
 {
   static u16 check = 1;
-  int OffsetBuffer = BufferOut;
+  int OffsetBuffer = request.out_addr;
   int OffsetStart = 0;
   // int OffsetDevice = 0;
   int d, c, ic, i, e; /* config, interface container, interface, endpoint  */

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -55,7 +55,7 @@ void CWII_IPC_HLE_Device_hid::checkUsbUpdates(CWII_IPC_HLE_Device_hid* hid)
 
 void CWII_IPC_HLE_Device_hid::handleUsbUpdates(struct libusb_transfer* transfer)
 {
-  int ret = HIDERR_NO_DEVICE_FOUND;
+  int ret = IPC_EINVAL;
   u32 replyAddress = (u32)(size_t)transfer->user_data;
   if (transfer->status == LIBUSB_TRANSFER_COMPLETED)
   {
@@ -168,7 +168,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
     u16 wLength = Memory::Read_U16(BufferIn + 0x1A);
     u32 data = Memory::Read_U32(BufferIn + 0x1C);
 
-    ReturnValue = HIDERR_NO_DEVICE_FOUND;
+    ReturnValue = IPC_EINVAL;
 
     libusb_device_handle* dev_handle = GetDeviceByDevNum(dev_num);
 
@@ -203,7 +203,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 
     u32 data = Memory::Read_U32(BufferIn + 0x1C);
 
-    ReturnValue = HIDERR_NO_DEVICE_FOUND;
+    ReturnValue = IPC_EINVAL;
 
     libusb_device_handle* dev_handle = GetDeviceByDevNum(dev_num);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -40,9 +40,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_hid();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -31,8 +31,6 @@ struct libusb_transfer;
 #define HID_ID_MASK 0x0000FFFFFFFFFFFF
 #define MAX_HID_INTERFACES 1
 
-#define HIDERR_NO_DEVICE_FOUND -4
-
 class CWII_IPC_HLE_Device_hid : public IWII_IPC_HLE_Device
 {
 public:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -125,7 +125,6 @@ private:
                              const libusb_interface_descriptor* src);
   void ConvertEndpointToWii(WiiHIDEndpointDescriptor* dest, const libusb_endpoint_descriptor* src);
 
-  int Align(int num, int alignment);
   static void checkUsbUpdates(CWII_IPC_HLE_Device_hid* hid);
   static void LIBUSB_CALL handleUsbUpdates(libusb_transfer* transfer);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -38,8 +38,8 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_hid();
 
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
 
 private:
   enum
@@ -115,7 +115,7 @@ private:
   };
 
   u32 deviceCommandAddress;
-  void FillOutDevices(u32 BufferOut, u32 BufferOutSize);
+  void FillOutDevices(IOSResourceIOCtlRequest& request);
   int GetAvailableDevNum(u16 idVendor, u16 idProduct, u8 bus, u8 port, u16 check);
   bool ClaimDevice(libusb_device_handle* dev);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -75,7 +75,6 @@ CWII_IPC_HLE_Device_net_kd_request::~CWII_IPC_HLE_Device_net_kd_request()
 IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Open(u32 _CommandAddress, u32 _Mode)
 {
   INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: Open");
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }
@@ -357,7 +356,6 @@ CWII_IPC_HLE_Device_net_ncd_manage::~CWII_IPC_HLE_Device_net_ncd_manage()
 IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Open(u32 _CommandAddress, u32 _Mode)
 {
   INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: Open");
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }
@@ -456,7 +454,6 @@ CWII_IPC_HLE_Device_net_wd_command::~CWII_IPC_HLE_Device_net_wd_command()
 IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Open(u32 CommandAddress, u32 Mode)
 {
   INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND: Open");
-  Memory::Write_U32(GetDeviceID(), CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }
@@ -585,7 +582,6 @@ CWII_IPC_HLE_Device_net_ip_top::~CWII_IPC_HLE_Device_net_ip_top()
 IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Open(u32 _CommandAddress, u32 _Mode)
 {
   INFO_LOG(WII_IPC_NET, "NET_IP_TOP: Open");
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -72,22 +72,6 @@ CWII_IPC_HLE_Device_net_kd_request::~CWII_IPC_HLE_Device_net_kd_request()
   WiiSockMan::GetInstance().Clean();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Open(u32 _CommandAddress, u32 _Mode)
-{
-  INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 {
   u32 Parameter = Memory::Read_U32(_CommandAddress + 0xC);
@@ -353,22 +337,6 @@ CWII_IPC_HLE_Device_net_ncd_manage::~CWII_IPC_HLE_Device_net_ncd_manage()
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Open(u32 _CommandAddress, u32 _Mode)
-{
-  INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
 {
   u32 return_value = 0;
@@ -449,22 +417,6 @@ CWII_IPC_HLE_Device_net_wd_command::CWII_IPC_HLE_Device_net_wd_command(
 
 CWII_IPC_HLE_Device_net_wd_command::~CWII_IPC_HLE_Device_net_wd_command()
 {
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Open(u32 CommandAddress, u32 Mode)
-{
-  INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Close(u32 CommandAddress, bool Force)
-{
-  INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND: Close");
-  if (!Force)
-    Memory::Write_U32(0, CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
 }
 
 // This is just for debugging / playing around.
@@ -577,22 +529,6 @@ CWII_IPC_HLE_Device_net_ip_top::~CWII_IPC_HLE_Device_net_ip_top()
 #ifdef _WIN32
   WSACleanup();
 #endif
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Open(u32 _CommandAddress, u32 _Mode)
-{
-  INFO_LOG(WII_IPC_NET, "NET_IP_TOP: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_NET, "NET_IP_TOP: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
 }
 
 static int inet_pton(const char* src, unsigned char* dst)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -72,21 +72,15 @@ CWII_IPC_HLE_Device_net_kd_request::~CWII_IPC_HLE_Device_net_kd_request()
   WiiSockMan::GetInstance().Clean();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(IOSResourceIOCtlRequest& request)
 {
-  u32 Parameter = Memory::Read_U32(_CommandAddress + 0xC);
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-
-  u32 ReturnValue = 0;
-  switch (Parameter)
+  s32 return_value = 0;
+  switch (request.request)
   {
   case IOCTL_NWC24_SUSPEND_SCHEDULAR:
     // NWC24iResumeForCloseLib  from NWC24SuspendScheduler (Input: none, Output: 32 bytes)
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_SUSPEND_SCHEDULAR - NI");
-    Memory::Write_U32(0, BufferOut);  // no error
+    Memory::Write_U32(0, request.out_addr);  // no error
     break;
 
   case IOCTL_NWC24_EXEC_TRY_SUSPEND_SCHEDULAR:  // NWC24iResumeForCloseLib
@@ -95,18 +89,17 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 
   case IOCTL_NWC24_EXEC_RESUME_SCHEDULAR:  // NWC24iResumeForCloseLib
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_EXEC_RESUME_SCHEDULAR - NI");
-    Memory::Write_U32(0, BufferOut);  // no error
+    Memory::Write_U32(0, request.out_addr);  // no error
     break;
 
   case IOCTL_NWC24_STARTUP_SOCKET:  // NWC24iStartupSocket
-    Memory::Write_U32(0, BufferOut);
-    Memory::Write_U32(0, BufferOut + 4);
-    ReturnValue = 0;
+    Memory::Write_U32(0, request.out_addr);
+    Memory::Write_U32(0, request.out_addr + 4);
+    return_value = 0;
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_STARTUP_SOCKET - NI");
     break;
 
   case IOCTL_NWC24_CLEANUP_SOCKET:
-    Memory::Memset(BufferOut, 0, BufferOutSize);
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_CLEANUP_SOCKET - NI");
     break;
 
@@ -120,8 +113,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 
   case IOCTL_NWC24_REQUEST_REGISTER_USER_ID:
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_REGISTER_USER_ID");
-    Memory::Write_U32(0, BufferOut);
-    Memory::Write_U32(0, BufferOut + 4);
+    Memory::Write_U32(0, request.out_addr);
+    Memory::Write_U32(0, request.out_addr + 4);
     break;
 
   case IOCTL_NWC24_REQUEST_GENERATED_USER_ID:  // (Input: none, Output: 32 bytes)
@@ -161,23 +154,23 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
         config.SetCreationStage(NWC24::NWC24Config::NWC24_IDCS_GENERATED);
         config.WriteConfig();
 
-        Memory::Write_U32(ret, BufferOut);
+        Memory::Write_U32(ret, request.out_addr);
       }
       else
       {
-        Memory::Write_U32(NWC24::WC24_ERR_FATAL, BufferOut);
+        Memory::Write_U32(NWC24::WC24_ERR_FATAL, request.out_addr);
       }
     }
     else if (config.CreationStage() == NWC24::NWC24Config::NWC24_IDCS_GENERATED)
     {
-      Memory::Write_U32(NWC24::WC24_ERR_ID_GENERATED, BufferOut);
+      Memory::Write_U32(NWC24::WC24_ERR_ID_GENERATED, request.out_addr);
     }
     else if (config.CreationStage() == NWC24::NWC24Config::NWC24_IDCS_REGISTERED)
     {
-      Memory::Write_U32(NWC24::WC24_ERR_ID_REGISTERED, BufferOut);
+      Memory::Write_U32(NWC24::WC24_ERR_ID_REGISTERED, request.out_addr);
     }
-    Memory::Write_U64(config.Id(), BufferOut + 4);
-    Memory::Write_U32(config.CreationStage(), BufferOut + 0xC);
+    Memory::Write_U64(config.Id(), request.out_addr + 4);
+    Memory::Write_U32(config.CreationStage(), request.out_addr + 0xC);
     break;
 
   case IOCTL_NWC24_GET_SCHEDULAR_STAT:
@@ -194,13 +187,11 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
     break;
 
   default:
-    INFO_LOG(WII_IPC_WC24,
-             "/dev/net/kd/request::IOCtl request 0x%x (BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             Parameter, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
     break;
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
@@ -337,52 +328,49 @@ CWII_IPC_HLE_Device_net_ncd_manage::~CWII_IPC_HLE_Device_net_ncd_manage()
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
-  u32 return_value = 0;
+  s32 return_value = IPC_SUCCESS;
   u32 common_result = 0;
   u32 common_vector = 0;
 
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
-
-  switch (CommandBuffer.Parameter)
+  switch (request.request)
   {
   case IOCTLV_NCD_LOCKWIRELESSDRIVER:
     break;
 
   case IOCTLV_NCD_UNLOCKWIRELESSDRIVER:
-    // Memory::Read_U32(CommandBuffer.InBuffer.at(0).m_Address);
+    // Memory::Read_U32(request.in_vectors.at(0).addr);
     break;
 
   case IOCTLV_NCD_GETCONFIG:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_GETCONFIG");
-    config.WriteToMem(CommandBuffer.PayloadBuffer.at(0).m_Address);
+    config.WriteToMem(request.io_vectors.at(0).addr);
     common_vector = 1;
     break;
 
   case IOCTLV_NCD_SETCONFIG:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_SETCONFIG");
-    config.ReadFromMem(CommandBuffer.InBuffer.at(0).m_Address);
+    config.ReadFromMem(request.in_vectors.at(0).addr);
     break;
 
   case IOCTLV_NCD_READCONFIG:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_READCONFIG");
     config.ReadConfig();
-    config.WriteToMem(CommandBuffer.PayloadBuffer.at(0).m_Address);
+    config.WriteToMem(request.io_vectors.at(0).addr);
     common_vector = 1;
     break;
 
   case IOCTLV_NCD_WRITECONFIG:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_WRITECONFIG");
-    config.ReadFromMem(CommandBuffer.InBuffer.at(0).m_Address);
+    config.ReadFromMem(request.in_vectors.at(0).addr);
     config.WriteConfig();
     break;
 
   case IOCTLV_NCD_GETLINKSTATUS:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_GETLINKSTATUS");
     // Always connected
-    Memory::Write_U32(Net::ConnectionSettings::LINK_WIRED,
-                      CommandBuffer.PayloadBuffer.at(0).m_Address + 4);
+    Memory::Write_U32(Net::ConnectionSettings::LINK_WIRED, request.io_vectors.at(0).addr + 4);
     break;
 
   case IOCTLV_NCD_GETWIRELESSMACADDRESS:
@@ -390,20 +378,20 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
 
     u8 address[MAC_ADDRESS_SIZE];
     GetMacAddress(address);
-    Memory::CopyToEmu(CommandBuffer.PayloadBuffer.at(1).m_Address, address, sizeof(address));
+    Memory::CopyToEmu(request.io_vectors.at(1).addr, address, sizeof(address));
     break;
 
   default:
-    INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE IOCtlV: %#x", CommandBuffer.Parameter);
+    INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE IOCtlV: %#x", request.request);
     break;
   }
 
-  Memory::Write_U32(common_result, CommandBuffer.PayloadBuffer.at(common_vector).m_Address);
+  Memory::Write_U32(common_result, request.io_vectors.at(common_vector).addr);
   if (common_vector == 1)
   {
-    Memory::Write_U32(common_result, CommandBuffer.PayloadBuffer.at(common_vector).m_Address + 4);
+    Memory::Write_U32(common_result, request.io_vectors.at(common_vector).addr + 4);
   }
-  Memory::Write_U32(return_value, _CommandAddress + 4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
@@ -422,21 +410,19 @@ CWII_IPC_HLE_Device_net_wd_command::~CWII_IPC_HLE_Device_net_wd_command()
 // This is just for debugging / playing around.
 // There really is no reason to implement wd unless we can bend it such that
 // we can talk to the DS.
-IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
-  u32 return_value = 0;
+  s32 return_value = IPC_SUCCESS;
 
-  SIOCtlVBuffer CommandBuffer(CommandAddress);
-
-  switch (CommandBuffer.Parameter)
+  switch (request.request)
   {
   case IOCTLV_WD_SCAN:
   {
     // Gives parameters detailing type of scan and what to match
     // XXX - unused
-    // ScanInfo *scan = (ScanInfo *)Memory::GetPointer(CommandBuffer.InBuffer.at(0).m_Address);
+    // ScanInfo *scan = (ScanInfo *)Memory::GetPointer(request.in_vectors.at(0).m_Address);
 
-    u16* results = (u16*)Memory::GetPointer(CommandBuffer.PayloadBuffer.at(0).m_Address);
+    u16* results = (u16*)Memory::GetPointer(request.io_vectors.at(0).addr);
     // first u16 indicates number of BSSInfo following
     results[0] = Common::swap16(1);
 
@@ -459,7 +445,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
 
   case IOCTLV_WD_GET_INFO:
   {
-    Info* info = (Info*)Memory::GetPointer(CommandBuffer.PayloadBuffer.at(0).m_Address);
+    Info* info = (Info*)Memory::GetPointer(request.io_vectors.at(0).addr);
     memset(info, 0, sizeof(Info));
     // Probably used to disallow certain channels?
     memcpy(info->country, "US", 2);
@@ -488,27 +474,10 @@ IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
   case IOCTLV_WD_RECV_FRAME:
   case IOCTLV_WD_RECV_NOTIFICATION:
   default:
-    INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND IOCtlV %#x in %i out %i", CommandBuffer.Parameter,
-             CommandBuffer.NumberInBuffer, CommandBuffer.NumberPayloadBuffer);
-    for (u32 i = 0; i < CommandBuffer.NumberInBuffer; ++i)
-    {
-      DEBUG_LOG(WII_IPC_NET, "in %i addr %x size %i", i, CommandBuffer.InBuffer.at(i).m_Address,
-                CommandBuffer.InBuffer.at(i).m_Size);
-      DEBUG_LOG(WII_IPC_NET, "%s",
-                ArrayToString(Memory::GetPointer(CommandBuffer.InBuffer.at(i).m_Address),
-                              CommandBuffer.InBuffer.at(i).m_Size)
-                    .c_str());
-    }
-    for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; ++i)
-    {
-      DEBUG_LOG(WII_IPC_NET, "out %i addr %x size %i", i,
-                CommandBuffer.PayloadBuffer.at(i).m_Address,
-                CommandBuffer.PayloadBuffer.at(i).m_Size);
-    }
-    break;
+    request.Dump(GetDeviceName(), LogTypes::WII_IPC_NET, LogTypes::LINFO);
   }
 
-  Memory::Write_U32(return_value, CommandAddress + 4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
@@ -581,61 +550,54 @@ static unsigned int opt_level_mapping[][2] = {{SOL_SOCKET, 0xFFFF}};
 static unsigned int opt_name_mapping[][2] = {
     {SO_REUSEADDR, 0x4}, {SO_SNDBUF, 0x1001}, {SO_RCVBUF, 0x1002}, {SO_ERROR, 0x1009}};
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(IOSResourceIOCtlRequest& request)
 {
   if (Core::g_want_determinism)
   {
-    Memory::Write_U32(-1, _CommandAddress + 4);
+    request.SetReturnValue(-1);
     return GetDefaultReply();
   }
 
-  u32 Command = Memory::Read_U32(_CommandAddress + 0x0C);
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-
-  u32 ReturnValue = 0;
-  switch (Command)
+  s32 return_value = 0;
+  switch (request.request)
   {
   case IOCTL_SO_STARTUP:
   {
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_STARTUP "
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
     break;
   }
   case IOCTL_SO_SOCKET:
   {
-    u32 af = Memory::Read_U32(BufferIn);
-    u32 type = Memory::Read_U32(BufferIn + 0x04);
-    u32 prot = Memory::Read_U32(BufferIn + 0x08);
+    u32 af = Memory::Read_U32(request.in_addr);
+    u32 type = Memory::Read_U32(request.in_addr + 4);
+    u32 prot = Memory::Read_U32(request.in_addr + 8);
 
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    ReturnValue = sm.NewSocket(af, type, prot);
+    return_value = sm.NewSocket(af, type, prot);
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_SOCKET "
                           "Socket: %08x (%d,%d,%d), BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             ReturnValue, af, type, prot, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+             return_value, af, type, prot, request.in_addr, request.in_size, request.out_addr,
+             request.out_size);
     break;
   }
   case IOCTL_SO_ICMPSOCKET:
   {
-    u32 pf = Memory::Read_U32(BufferIn);
+    u32 pf = Memory::Read_U32(request.in_addr);
 
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    ReturnValue = sm.NewSocket(pf, SOCK_RAW, IPPROTO_ICMP);
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_ICMPSOCKET(%x) %d", pf, ReturnValue);
+    return_value = sm.NewSocket(pf, SOCK_RAW, IPPROTO_ICMP);
+    INFO_LOG(WII_IPC_NET, "IOCTL_SO_ICMPSOCKET(%x) %d", pf, return_value);
     break;
   }
   case IOCTL_SO_CLOSE:
   case IOCTL_SO_ICMPCLOSE:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
+    u32 fd = Memory::Read_U32(request.in_addr);
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    ReturnValue = sm.DeleteSocket(fd);
+    return_value = sm.DeleteSocket(fd);
     INFO_LOG(WII_IPC_NET, "%s(%x) %x",
-             Command == IOCTL_SO_ICMPCLOSE ? "IOCTL_SO_ICMPCLOSE" : "IOCTL_SO_CLOSE", fd,
-             ReturnValue);
+             request.request == IOCTL_SO_ICMPCLOSE ? "IOCTL_SO_ICMPCLOSE" : "IOCTL_SO_CLOSE", fd,
+             return_value);
     break;
   }
   case IOCTL_SO_ACCEPT:
@@ -643,9 +605,9 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
   case IOCTL_SO_CONNECT:
   case IOCTL_SO_FCNTL:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
+    u32 fd = Memory::Read_U32(request.in_addr);
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    sm.DoSock(fd, _CommandAddress, (NET_IOCTL)Command);
+    sm.DoSock(fd, request, static_cast<NET_IOCTL>(request.request));
     return GetNoReply();
   }
   /////////////////////////////////////////////////////////////
@@ -653,36 +615,30 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
   /////////////////////////////////////////////////////////////
   case IOCTL_SO_SHUTDOWN:
   {
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_SHUTDOWN "
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
 
-    u32 fd = Memory::Read_U32(BufferIn);
-    u32 how = Memory::Read_U32(BufferIn + 4);
+    u32 fd = Memory::Read_U32(request.in_addr);
+    u32 how = Memory::Read_U32(request.in_addr + 4);
     int ret = shutdown(fd, how);
-    ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_SHUTDOWN", false);
+    return_value = WiiSockMan::GetNetErrorCode(ret, "SO_SHUTDOWN", false);
     break;
   }
   case IOCTL_SO_LISTEN:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
-    u32 BACKLOG = Memory::Read_U32(BufferIn + 0x04);
+    u32 fd = Memory::Read_U32(request.in_addr);
+    u32 BACKLOG = Memory::Read_U32(request.in_addr + 0x04);
     u32 ret = listen(fd, BACKLOG);
-    ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_LISTEN", false);
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_LISTEN = %d "
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             ReturnValue, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    return_value = WiiSockMan::GetNetErrorCode(ret, "SO_LISTEN", false);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
     break;
   }
   case IOCTL_SO_GETSOCKOPT:
   {
-    u32 fd = Memory::Read_U32(BufferOut);
-    u32 level = Memory::Read_U32(BufferOut + 4);
-    u32 optname = Memory::Read_U32(BufferOut + 8);
+    u32 fd = Memory::Read_U32(request.out_addr);
+    u32 level = Memory::Read_U32(request.out_addr + 4);
+    u32 optname = Memory::Read_U32(request.out_addr + 8);
 
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETSOCKOPT(%08x, %08x, %08x)"
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             fd, level, optname, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
 
     // Do the level/optname translation
     int nat_level = -1, nat_optname = -1;
@@ -699,45 +655,45 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
     u32 optlen = 4;
 
     int ret = getsockopt(fd, nat_level, nat_optname, (char*)&optval, (socklen_t*)&optlen);
-    ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_GETSOCKOPT", false);
+    return_value = WiiSockMan::GetNetErrorCode(ret, "SO_GETSOCKOPT", false);
 
-    Memory::Write_U32(optlen, BufferOut + 0xC);
-    Memory::CopyToEmu(BufferOut + 0x10, optval, optlen);
+    Memory::Write_U32(optlen, request.out_addr + 0xC);
+    Memory::CopyToEmu(request.out_addr + 0x10, optval, optlen);
 
     if (optname == SO_ERROR)
     {
       s32 last_error = WiiSockMan::GetInstance().GetLastNetError();
 
-      Memory::Write_U32(sizeof(s32), BufferOut + 0xC);
-      Memory::Write_U32(last_error, BufferOut + 0x10);
+      Memory::Write_U32(sizeof(s32), request.out_addr + 0xC);
+      Memory::Write_U32(last_error, request.out_addr + 0x10);
     }
     break;
   }
 
   case IOCTL_SO_SETSOCKOPT:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
-    u32 level = Memory::Read_U32(BufferIn + 4);
-    u32 optname = Memory::Read_U32(BufferIn + 8);
-    u32 optlen = Memory::Read_U32(BufferIn + 0xc);
+    u32 fd = Memory::Read_U32(request.in_addr);
+    u32 level = Memory::Read_U32(request.in_addr + 4);
+    u32 optname = Memory::Read_U32(request.in_addr + 8);
+    u32 optlen = Memory::Read_U32(request.in_addr + 0xc);
     u8 optval[20];
     optlen = std::min(optlen, (u32)sizeof(optval));
-    Memory::CopyFromEmu(optval, BufferIn + 0x10, optlen);
+    Memory::CopyFromEmu(optval, request.in_addr + 0x10, optlen);
 
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_SETSOCKOPT(%08x, %08x, %08x, %08x) "
                           "BufferIn: (%08x, %i), BufferOut: (%08x, %i)"
                           "%02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx "
                           "%02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx",
-             fd, level, optname, optlen, BufferIn, BufferInSize, BufferOut, BufferOutSize,
-             optval[0], optval[1], optval[2], optval[3], optval[4], optval[5], optval[6], optval[7],
-             optval[8], optval[9], optval[10], optval[11], optval[12], optval[13], optval[14],
-             optval[15], optval[16], optval[17], optval[18], optval[19]);
+             fd, level, optname, optlen, request.in_addr, request.in_size, request.out_addr,
+             request.out_size, optval[0], optval[1], optval[2], optval[3], optval[4], optval[5],
+             optval[6], optval[7], optval[8], optval[9], optval[10], optval[11], optval[12],
+             optval[13], optval[14], optval[15], optval[16], optval[17], optval[18], optval[19]);
 
     // TODO: bug booto about this, 0x2005 most likely timeout related, default value on Wii is ,
     // 0x2001 is most likely tcpnodelay
     if (level == 6 && (optname == 0x2005 || optname == 0x2001))
     {
-      ReturnValue = 0;
+      return_value = 0;
       break;
     }
 
@@ -762,38 +718,36 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
     }
 
     int ret = setsockopt(fd, nat_level, nat_optname, (char*)optval, optlen);
-    ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_SETSOCKOPT", false);
+    return_value = WiiSockMan::GetNetErrorCode(ret, "SO_SETSOCKOPT", false);
     break;
   }
   case IOCTL_SO_GETSOCKNAME:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
+    u32 fd = Memory::Read_U32(request.in_addr);
 
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETSOCKNAME "
-                          "Socket: %08X, BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             fd, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
 
     sockaddr sa;
     socklen_t sa_len;
     sa_len = sizeof(sa);
     int ret = getsockname(fd, &sa, &sa_len);
 
-    if (BufferOutSize < 2 + sizeof(sa.sa_data))
+    if (request.out_size < 2 + sizeof(sa.sa_data))
       WARN_LOG(WII_IPC_NET, "IOCTL_SO_GETSOCKNAME output buffer is too small. Truncating");
 
-    if (BufferOutSize > 0)
-      Memory::Write_U8(BufferOutSize, BufferOut);
-    if (BufferOutSize > 1)
-      Memory::Write_U8(sa.sa_family & 0xFF, BufferOut + 1);
-    if (BufferOutSize > 2)
-      Memory::CopyToEmu(BufferOut + 2, &sa.sa_data,
-                        std::min<size_t>(sizeof(sa.sa_data), BufferOutSize - 2));
-    ReturnValue = ret;
+    if (request.out_size > 0)
+      Memory::Write_U8(request.out_size, request.out_addr);
+    if (request.out_size > 1)
+      Memory::Write_U8(sa.sa_family & 0xFF, request.out_addr + 1);
+    if (request.out_size > 2)
+      Memory::CopyToEmu(request.out_addr + 2, &sa.sa_data,
+                        std::min<size_t>(sizeof(sa.sa_data), request.out_size - 2));
+    return_value = ret;
     break;
   }
   case IOCTL_SO_GETPEERNAME:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
+    u32 fd = Memory::Read_U32(request.in_addr);
 
     sockaddr sa;
     socklen_t sa_len;
@@ -801,28 +755,26 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 
     int ret = getpeername(fd, &sa, &sa_len);
 
-    if (BufferOutSize < 2 + sizeof(sa.sa_data))
+    if (request.out_size < 2 + sizeof(sa.sa_data))
       WARN_LOG(WII_IPC_NET, "IOCTL_SO_GETPEERNAME output buffer is too small. Truncating");
 
-    if (BufferOutSize > 0)
-      Memory::Write_U8(BufferOutSize, BufferOut);
-    if (BufferOutSize > 1)
-      Memory::Write_U8(AF_INET, BufferOut + 1);
-    if (BufferOutSize > 2)
-      Memory::CopyToEmu(BufferOut + 2, &sa.sa_data,
-                        std::min<size_t>(sizeof(sa.sa_data), BufferOutSize - 2));
+    if (request.out_size > 0)
+      Memory::Write_U8(request.out_size, request.out_addr);
+    if (request.out_size > 1)
+      Memory::Write_U8(AF_INET, request.out_addr + 1);
+    if (request.out_size > 2)
+      Memory::CopyToEmu(request.out_addr + 2, &sa.sa_data,
+                        std::min<size_t>(sizeof(sa.sa_data), request.out_size - 2));
 
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETPEERNAME(%x)", fd);
 
-    ReturnValue = ret;
+    return_value = ret;
     break;
   }
 
   case IOCTL_SO_GETHOSTID:
   {
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETHOSTID "
-                          "(BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
 
 #ifdef _WIN32
     DWORD forwardTableSize, ipTableSize, result;
@@ -869,7 +821,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       {
         if (ipTable->table[i].dwIndex == ifIndex)
         {
-          ReturnValue = Common::swap32(ipTable->table[i].dwAddr);
+          return_value = Common::swap32(ipTable->table[i].dwAddr);
           break;
         }
       }
@@ -877,14 +829,14 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 #endif
 
     // default placeholder, in case of failure
-    if (ReturnValue == 0)
-      ReturnValue = 192 << 24 | 168 << 16 | 1 << 8 | 150;
+    if (return_value == 0)
+      return_value = 192 << 24 | 168 << 16 | 1 << 8 | 150;
     break;
   }
 
   case IOCTL_SO_INETATON:
   {
-    std::string hostname = Memory::GetString(BufferIn);
+    std::string hostname = Memory::GetString(request.in_addr);
     struct hostent* remoteHost = gethostbyname(hostname.c_str());
 
     if (remoteHost == nullptr || remoteHost->h_addr_list == nullptr ||
@@ -892,42 +844,43 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
     {
       INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = -1 "
                             "%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: None",
-               hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize);
-      ReturnValue = 0;
+               hostname.c_str(), request.in_addr, request.in_size, request.out_addr,
+               request.out_size);
+      return_value = 0;
     }
     else
     {
-      Memory::Write_U32(Common::swap32(*(u32*)remoteHost->h_addr_list[0]), BufferOut);
+      Memory::Write_U32(Common::swap32(*(u32*)remoteHost->h_addr_list[0]), request.out_addr);
       INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = 0 "
                             "%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: %08X",
-               hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize,
-               Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
-      ReturnValue = 1;
+               hostname.c_str(), request.in_addr, request.in_size, request.out_addr,
+               request.out_size, Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
+      return_value = 1;
     }
     break;
   }
 
   case IOCTL_SO_INETPTON:
   {
-    std::string address = Memory::GetString(BufferIn);
+    std::string address = Memory::GetString(request.in_addr);
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETPTON "
                           "(Translating: %s)",
              address.c_str());
-    ReturnValue = inet_pton(address.c_str(), Memory::GetPointer(BufferOut + 4));
+    return_value = inet_pton(address.c_str(), Memory::GetPointer(request.out_addr + 4));
     break;
   }
 
   case IOCTL_SO_INETNTOP:
   {
     // u32 af = Memory::Read_U32(BufferIn);
-    // u32 validAddress = Memory::Read_U32(BufferIn + 4);
-    // u32 src = Memory::Read_U32(BufferIn + 8);
+    // u32 validAddress = Memory::Read_U32(request.in_addr + 4);
+    // u32 src = Memory::Read_U32(request.in_addr + 8);
     char ip_s[16];
-    sprintf(ip_s, "%i.%i.%i.%i", Memory::Read_U8(BufferIn + 8), Memory::Read_U8(BufferIn + 8 + 1),
-            Memory::Read_U8(BufferIn + 8 + 2), Memory::Read_U8(BufferIn + 8 + 3));
+    sprintf(ip_s, "%i.%i.%i.%i", Memory::Read_U8(request.in_addr + 8),
+            Memory::Read_U8(request.in_addr + 8 + 1), Memory::Read_U8(request.in_addr + 8 + 2),
+            Memory::Read_U8(request.in_addr + 8 + 3));
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETNTOP %s", ip_s);
-    Memory::Memset(BufferOut, 0, BufferOutSize);
-    Memory::CopyToEmu(BufferOut, (u8*)ip_s, strlen(ip_s));
+    Memory::CopyToEmu(request.out_addr, (u8*)ip_s, strlen(ip_s));
     break;
   }
 
@@ -943,10 +896,10 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
         {POLLWRBAND, 0x0010}, {POLLERR, 0x0020},    {POLLHUP, 0x0040}, {POLLNVAL, 0x0080},
     };
 
-    u32 unknown = Memory::Read_U32(BufferIn);
-    u32 timeout = Memory::Read_U32(BufferIn + 4);
+    u32 unknown = Memory::Read_U32(request.in_addr);
+    u32 timeout = Memory::Read_U32(request.in_addr + 4);
 
-    int nfds = BufferOutSize / 0xc;
+    int nfds = request.out_size / 0xc;
     if (nfds == 0)
       ERROR_LOG(WII_IPC_NET, "Hidden POLL");
 
@@ -954,9 +907,9 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 
     for (int i = 0; i < nfds; ++i)
     {
-      ufds[i].fd = Memory::Read_U32(BufferOut + 0xc * i);           // fd
-      int events = Memory::Read_U32(BufferOut + 0xc * i + 4);       // events
-      ufds[i].revents = Memory::Read_U32(BufferOut + 0xc * i + 8);  // revents
+      ufds[i].fd = Memory::Read_U32(request.out_addr + 0xc * i);           // fd
+      int events = Memory::Read_U32(request.out_addr + 0xc * i + 4);       // events
+      ufds[i].revents = Memory::Read_U32(request.out_addr + 0xc * i + 8);  // revents
 
       // Translate Wii to native events
       int unhandled_events = events;
@@ -993,33 +946,34 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       }
 
       // No need to change fd or events as they are input only.
-      // Memory::Write_U32(ufds[i].fd, BufferOut + 0xc*i); //fd
-      // Memory::Write_U32(events, BufferOut + 0xc*i + 4); //events
-      Memory::Write_U32(revents, BufferOut + 0xc * i + 8);  // revents
+      // Memory::Write_U32(ufds[i].fd, request.out_addr + 0xc*i); //fd
+      // Memory::Write_U32(events, request.out_addr + 0xc*i + 4); //events
+      Memory::Write_U32(revents, request.out_addr + 0xc * i + 8);  // revents
 
       DEBUG_LOG(WII_IPC_NET, "IOCTL_SO_POLL socket %d wevents %08X events %08X revents %08X", i,
                 revents, ufds[i].events, ufds[i].revents);
     }
 
-    ReturnValue = ret;
+    return_value = ret;
     break;
   }
 
   case IOCTL_SO_GETHOSTBYNAME:
   {
-    if (BufferOutSize != 0x460)
+    if (request.out_size != 0x460)
     {
       ERROR_LOG(WII_IPC_NET, "Bad buffer size for IOCTL_SO_GETHOSTBYNAME");
-      ReturnValue = -1;
+      return_value = -1;
       break;
     }
 
-    std::string hostname = Memory::GetString(BufferIn);
+    std::string hostname = Memory::GetString(request.in_addr);
     hostent* remoteHost = gethostbyname(hostname.c_str());
 
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETHOSTBYNAME "
                           "Address: %s, BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize);
+             hostname.c_str(), request.in_addr, request.in_size, request.out_addr,
+             request.out_size);
 
     if (remoteHost)
     {
@@ -1036,8 +990,6 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
         DEBUG_LOG(WII_IPC_NET, "addr%i:%s", i, ip_s.c_str());
       }
 
-      Memory::Memset(BufferOut, 0, BufferOutSize);
-
       // Host name; located immediately after struct
       static const u32 GETHOSTBYNAME_STRUCT_SIZE = 0x10;
       static const u32 GETHOSTBYNAME_IP_LIST_OFFSET = 0x110;
@@ -1046,11 +998,12 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       if (name_length > (GETHOSTBYNAME_IP_LIST_OFFSET - GETHOSTBYNAME_STRUCT_SIZE))
       {
         ERROR_LOG(WII_IPC_NET, "Hostname too long in IOCTL_SO_GETHOSTBYNAME");
-        ReturnValue = -1;
+        return_value = -1;
         break;
       }
-      Memory::CopyToEmu(BufferOut + GETHOSTBYNAME_STRUCT_SIZE, remoteHost->h_name, name_length);
-      Memory::Write_U32(BufferOut + GETHOSTBYNAME_STRUCT_SIZE, BufferOut);
+      Memory::CopyToEmu(request.out_addr + GETHOSTBYNAME_STRUCT_SIZE, remoteHost->h_name,
+                        name_length);
+      Memory::Write_U32(request.out_addr + GETHOSTBYNAME_STRUCT_SIZE, request.out_addr);
 
       // IP address list; located at offset 0x110.
       u32 num_ip_addr = 0;
@@ -1062,7 +1015,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       num_ip_addr = std::min(num_ip_addr, GETHOSTBYNAME_MAX_ADDRESSES);
       for (u32 i = 0; i < num_ip_addr; ++i)
       {
-        u32 addr = BufferOut + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4;
+        u32 addr = request.out_addr + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4;
         Memory::Write_U32_Swap(*(u32*)(remoteHost->h_addr_list[i]), addr);
       }
 
@@ -1070,30 +1023,30 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       // This must be exact: PPC code to convert the struct hardcodes
       // this offset.
       static const u32 GETHOSTBYNAME_IP_PTR_LIST_OFFSET = 0x340;
-      Memory::Write_U32(BufferOut + GETHOSTBYNAME_IP_PTR_LIST_OFFSET, BufferOut + 12);
+      Memory::Write_U32(request.out_addr + GETHOSTBYNAME_IP_PTR_LIST_OFFSET, request.out_addr + 12);
       for (u32 i = 0; i < num_ip_addr; ++i)
       {
-        u32 addr = BufferOut + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + i * 4;
-        Memory::Write_U32(BufferOut + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4, addr);
+        u32 addr = request.out_addr + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + i * 4;
+        Memory::Write_U32(request.out_addr + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4, addr);
       }
-      Memory::Write_U32(0, BufferOut + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4);
+      Memory::Write_U32(0, request.out_addr + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4);
 
       // Aliases - empty. (Hardware doesn't return anything.)
-      Memory::Write_U32(BufferOut + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4,
-                        BufferOut + 4);
+      Memory::Write_U32(request.out_addr + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4,
+                        request.out_addr + 4);
 
       // Returned struct must be ipv4.
       _assert_msg_(WII_IPC_NET,
                    remoteHost->h_addrtype == AF_INET && remoteHost->h_length == sizeof(u32),
                    "returned host info is not IPv4");
-      Memory::Write_U16(AF_INET, BufferOut + 8);
-      Memory::Write_U16(sizeof(u32), BufferOut + 10);
+      Memory::Write_U16(AF_INET, request.out_addr + 8);
+      Memory::Write_U16(sizeof(u32), request.out_addr + 10);
 
-      ReturnValue = 0;
+      return_value = 0;
     }
     else
     {
-      ReturnValue = -1;
+      return_value = -1;
     }
 
     break;
@@ -1101,89 +1054,39 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 
   case IOCTL_SO_ICMPCANCEL:
     ERROR_LOG(WII_IPC_NET, "IOCTL_SO_ICMPCANCEL");
-    goto default_;
 
   default:
-    INFO_LOG(WII_IPC_NET, "0x%x "
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             Command, BufferIn, BufferInSize, BufferOut, BufferOutSize);
-  default_:
-    if (BufferInSize)
-    {
-      ERROR_LOG(WII_IPC_NET, "in addr %x size %x", BufferIn, BufferInSize);
-      ERROR_LOG(WII_IPC_NET, "\n%s",
-                ArrayToString(Memory::GetPointer(BufferIn), BufferInSize, 4).c_str());
-    }
-
-    if (BufferOutSize)
-    {
-      ERROR_LOG(WII_IPC_NET, "out addr %x size %x", BufferOut, BufferOutSize);
-    }
-    break;
+    request.Dump(GetDeviceName(), LogTypes::WII_IPC_NET, LogTypes::LWARNING);
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
-  SIOCtlVBuffer CommandBuffer(CommandAddress);
-
-  s32 ReturnValue = 0;
-
-  u32 _BufferIn = 0, _BufferIn2 = 0, _BufferIn3 = 0;
-  u32 BufferInSize = 0, BufferInSize2 = 0, BufferInSize3 = 0;
-
-  u32 _BufferOut = 0, _BufferOut2 = 0;
-  u32 BufferOutSize = 0;
-
-  if (CommandBuffer.InBuffer.size() > 0)
-  {
-    _BufferIn = CommandBuffer.InBuffer.at(0).m_Address;
-    BufferInSize = CommandBuffer.InBuffer.at(0).m_Size;
-  }
-  if (CommandBuffer.InBuffer.size() > 1)
-  {
-    _BufferIn2 = CommandBuffer.InBuffer.at(1).m_Address;
-    BufferInSize2 = CommandBuffer.InBuffer.at(1).m_Size;
-  }
-  if (CommandBuffer.InBuffer.size() > 2)
-  {
-    _BufferIn3 = CommandBuffer.InBuffer.at(2).m_Address;
-    BufferInSize3 = CommandBuffer.InBuffer.at(2).m_Size;
-  }
-
-  if (CommandBuffer.PayloadBuffer.size() > 0)
-  {
-    _BufferOut = CommandBuffer.PayloadBuffer.at(0).m_Address;
-    BufferOutSize = CommandBuffer.PayloadBuffer.at(0).m_Size;
-  }
-  if (CommandBuffer.PayloadBuffer.size() > 1)
-  {
-    _BufferOut2 = CommandBuffer.PayloadBuffer.at(1).m_Address;
-  }
+  s32 return_value = 0;
 
   u32 param = 0, param2 = 0, param3, param4, param5 = 0;
-
-  switch (CommandBuffer.Parameter)
+  switch (request.request)
   {
   case IOCTLV_SO_GETINTERFACEOPT:
   {
-    param = Memory::Read_U32(_BufferIn);
-    param2 = Memory::Read_U32(_BufferIn + 4);
-    param3 = Memory::Read_U32(_BufferOut);
-    param4 = Memory::Read_U32(_BufferOut2);
-    if (BufferOutSize >= 8)
+    param = Memory::Read_U32(request.in_vectors[0].addr);
+    param2 = Memory::Read_U32(request.in_vectors[0].addr + 4);
+    param3 = Memory::Read_U32(request.io_vectors[0].addr);
+    param4 = Memory::Read_U32(request.io_vectors[1].addr);
+    if (request.io_vectors[0].size >= 8)
     {
-      param5 = Memory::Read_U32(_BufferOut + 4);
+      param5 = Memory::Read_U32(request.io_vectors[0].addr + 4);
     }
 
     INFO_LOG(WII_IPC_NET, "IOCTLV_SO_GETINTERFACEOPT(%08X, %08X, %X, %X, %X) "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i) ",
-             param, param2, param3, param4, param5, _BufferIn, BufferInSize, _BufferIn2,
-             BufferInSize2);
+             param, param2, param3, param4, param5, request.in_vectors[0].addr,
+             request.in_vectors[0].size,
+             request.in_vectors.size() > 1 ? request.in_vectors[1].addr : 0,
+             request.in_vectors.size() > 1 ? request.in_vectors[1].size : 0);
 
     switch (param2)
     {
@@ -1257,33 +1160,33 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
       if (address == 0)
         address = 0x08080808;
 
-      Memory::Write_U32(address, _BufferOut);
-      Memory::Write_U32(0x08080404, _BufferOut + 4);
+      Memory::Write_U32(address, request.io_vectors[0].addr);
+      Memory::Write_U32(0x08080404, request.io_vectors[0].addr + 4);
       break;
     }
     case 0x1003:  // error
-      Memory::Write_U32(0, _BufferOut);
+      Memory::Write_U32(0, request.io_vectors[0].addr);
       break;
 
     case 0x1004:  // mac address
       u8 address[MAC_ADDRESS_SIZE];
       GetMacAddress(address);
-      Memory::CopyToEmu(_BufferOut, address, sizeof(address));
+      Memory::CopyToEmu(request.io_vectors[0].addr, address, sizeof(address));
       break;
 
     case 0x1005:  // link state
-      Memory::Write_U32(1, _BufferOut);
+      Memory::Write_U32(1, request.io_vectors[0].addr);
       break;
 
     case 0x4002:  // ip addr number
-      Memory::Write_U32(1, _BufferOut);
+      Memory::Write_U32(1, request.io_vectors[0].addr);
       break;
 
     case 0x4003:  // ip addr table
-      Memory::Write_U32(0xC, _BufferOut2);
-      Memory::Write_U32(10 << 24 | 1 << 8 | 30, _BufferOut);
-      Memory::Write_U32(255 << 24 | 255 << 16 | 255 << 8 | 0, _BufferOut + 4);
-      Memory::Write_U32(10 << 24 | 0 << 16 | 255 << 8 | 255, _BufferOut + 8);
+      Memory::Write_U32(0xC, request.io_vectors[1].addr);
+      Memory::Write_U32(10 << 24 | 1 << 8 | 30, request.io_vectors[0].addr);
+      Memory::Write_U32(255 << 24 | 255 << 16 | 255 << 8 | 0, request.io_vectors[0].addr + 4);
+      Memory::Write_U32(10 << 24 | 0 << 16 | 255 << 8 | 255, request.io_vectors[0].addr + 8);
       break;
 
     default:
@@ -1294,17 +1197,17 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
   }
   case IOCTLV_SO_SENDTO:
   {
-    u32 fd = Memory::Read_U32(_BufferIn2);
+    u32 fd = Memory::Read_U32(request.in_vectors[1].addr);
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    sm.DoSock(fd, CommandAddress, IOCTLV_SO_SENDTO);
+    sm.DoSock(fd, request, IOCTLV_SO_SENDTO);
     return GetNoReply();
     break;
   }
   case IOCTLV_SO_RECVFROM:
   {
-    u32 fd = Memory::Read_U32(_BufferIn);
+    u32 fd = Memory::Read_U32(request.in_vectors[0].addr);
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    sm.DoSock(fd, CommandAddress, IOCTLV_SO_RECVFROM);
+    sm.DoSock(fd, request, IOCTLV_SO_RECVFROM);
     return GetNoReply();
     break;
   }
@@ -1312,13 +1215,13 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
   {
     addrinfo hints;
 
-    if (BufferInSize3)
+    if (request.in_vectors.size() > 2 && request.in_vectors[2].size)
     {
-      hints.ai_flags = Memory::Read_U32(_BufferIn3);
-      hints.ai_family = Memory::Read_U32(_BufferIn3 + 0x4);
-      hints.ai_socktype = Memory::Read_U32(_BufferIn3 + 0x8);
-      hints.ai_protocol = Memory::Read_U32(_BufferIn3 + 0xC);
-      hints.ai_addrlen = Memory::Read_U32(_BufferIn3 + 0x10);
+      hints.ai_flags = Memory::Read_U32(request.in_vectors[2].addr);
+      hints.ai_family = Memory::Read_U32(request.in_vectors[2].addr + 0x4);
+      hints.ai_socktype = Memory::Read_U32(request.in_vectors[2].addr + 0x8);
+      hints.ai_protocol = Memory::Read_U32(request.in_vectors[2].addr + 0xC);
+      hints.ai_addrlen = Memory::Read_U32(request.in_vectors[2].addr + 0x10);
       hints.ai_canonname = nullptr;
       hints.ai_addr = nullptr;
       hints.ai_next = nullptr;
@@ -1328,23 +1231,25 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
     // So we have to do a bit of juggling here.
     std::string nodeNameStr;
     const char* pNodeName = nullptr;
-    if (BufferInSize > 0)
+    if (request.in_vectors.size() > 0 && request.in_vectors[0].size > 0)
     {
-      nodeNameStr = Memory::GetString(_BufferIn, BufferInSize);
+      nodeNameStr = Memory::GetString(request.in_vectors[0].addr, request.in_vectors[0].size);
       pNodeName = nodeNameStr.c_str();
     }
 
     std::string serviceNameStr;
     const char* pServiceName = nullptr;
-    if (BufferInSize2 > 0)
+    if (request.in_vectors.size() > 1 && request.in_vectors[1].size > 0)
     {
-      serviceNameStr = Memory::GetString(_BufferIn2, BufferInSize2);
+      serviceNameStr = Memory::GetString(request.in_vectors[1].addr, request.in_vectors[1].size);
       pServiceName = serviceNameStr.c_str();
     }
 
     addrinfo* result = nullptr;
-    int ret = getaddrinfo(pNodeName, pServiceName, BufferInSize3 ? &hints : nullptr, &result);
-    u32 addr = _BufferOut;
+    int ret = getaddrinfo(
+        pNodeName, pServiceName,
+        (request.in_vectors.size() > 2 && request.in_vectors[2].size) ? &hints : nullptr, &result);
+    u32 addr = request.io_vectors[0].addr;
     u32 sockoffset = addr + 0x460;
     if (ret == 0)
     {
@@ -1394,11 +1299,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
       ret = -305;
     }
 
-    INFO_LOG(WII_IPC_NET, "IOCTLV_SO_GETADDRINFO "
-                          "(BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferOut, BufferOutSize);
-    INFO_LOG(WII_IPC_NET, "IOCTLV_SO_GETADDRINFO: %s", Memory::GetString(_BufferIn).c_str());
-    ReturnValue = ret;
+    request.Dump(GetDeviceName(), LogTypes::WII_IPC_NET, LogTypes::LINFO);
+    return_value = ret;
     break;
   }
   case IOCTLV_SO_ICMPPING:
@@ -1411,19 +1313,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
       u32 ip;
     } ip_info;
 
-    u32 fd = Memory::Read_U32(_BufferIn);
-    u32 num_ip = Memory::Read_U32(_BufferIn + 4);
-    u64 timeout = Memory::Read_U64(_BufferIn + 8);
+    u32 fd = Memory::Read_U32(request.in_vectors[0].addr);
+    u32 num_ip = Memory::Read_U32(request.in_vectors[0].addr + 4);
+    u64 timeout = Memory::Read_U64(request.in_vectors[0].addr + 8);
 
     if (num_ip != 1)
     {
       INFO_LOG(WII_IPC_NET, "IOCTLV_SO_ICMPPING %i IPs", num_ip);
     }
 
-    ip_info.length = Memory::Read_U8(_BufferIn + 16);
-    ip_info.addr_family = Memory::Read_U8(_BufferIn + 17);
-    ip_info.icmp_id = Memory::Read_U16(_BufferIn + 18);
-    ip_info.ip = Memory::Read_U32(_BufferIn + 20);
+    ip_info.length = Memory::Read_U8(request.in_vectors[0].addr + 16);
+    ip_info.addr_family = Memory::Read_U8(request.in_vectors[0].addr + 17);
+    ip_info.icmp_id = Memory::Read_U16(request.in_vectors[0].addr + 18);
+    ip_info.ip = Memory::Read_U32(request.in_vectors[0].addr + 20);
 
     if (ip_info.length != 8 || ip_info.addr_family != AF_INET)
     {
@@ -1443,8 +1345,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
     memset(data, 0, sizeof(data));
     s32 icmp_length = sizeof(data);
 
-    if (BufferInSize2 == sizeof(data))
-      Memory::CopyFromEmu(data, _BufferIn2, BufferInSize2);
+    if (request.in_vectors.size() > 1 && request.in_vectors[1].size == sizeof(data))
+      Memory::CopyFromEmu(data, request.in_vectors[1].addr, request.in_vectors[1].size);
     else
     {
       // TODO sequence number is incremented either statically, by
@@ -1461,31 +1363,15 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
     }
 
     // TODO proper error codes
-    ReturnValue = 0;
+    return_value = 0;
     break;
   }
   default:
-    INFO_LOG(WII_IPC_NET, "0x%x (BufferIn: (%08x, %i), BufferIn2: (%08x, %i)",
-             CommandBuffer.Parameter, _BufferIn, BufferInSize, _BufferIn2, BufferInSize2);
-    for (u32 i = 0; i < CommandBuffer.NumberInBuffer; ++i)
-    {
-      ERROR_LOG(WII_IPC_NET, "in %i addr %x size %x", i, CommandBuffer.InBuffer.at(i).m_Address,
-                CommandBuffer.InBuffer.at(i).m_Size);
-      ERROR_LOG(WII_IPC_NET, "\n%s",
-                ArrayToString(Memory::GetPointer(CommandBuffer.InBuffer.at(i).m_Address),
-                              CommandBuffer.InBuffer.at(i).m_Size, 4)
-                    .c_str());
-    }
-    for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; ++i)
-    {
-      ERROR_LOG(WII_IPC_NET, "out %i addr %x size %x", i,
-                CommandBuffer.PayloadBuffer.at(i).m_Address,
-                CommandBuffer.PayloadBuffer.at(i).m_Size);
-    }
-    break;
+    ERROR_LOG(WII_IPC_NET, "Unknown IOCtlV");
+    request.Dump(GetDeviceName(), LogTypes::WII_IPC_NET, LogTypes::LERROR);
   }
 
-  Memory::Write_U32(ReturnValue, CommandAddress + 4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -91,7 +91,6 @@ public:
   IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override
   {
     INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Open");
-    Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
     return GetDefaultReply();
   }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -30,8 +30,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_kd_request();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
 
 private:
@@ -88,20 +86,6 @@ public:
   }
 
   virtual ~CWII_IPC_HLE_Device_net_kd_time() {}
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override
-  {
-    INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Open");
-    return GetDefaultReply();
-  }
-
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
-  {
-    INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Close");
-    if (!_bForce)
-      Memory::Write_U32(0, _CommandAddress + 4);
-    return GetDefaultReply();
-  }
-
   IPCCommandResult IOCtl(u32 _CommandAddress) override
   {
     u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
@@ -223,8 +207,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ip_top();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
@@ -245,8 +227,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ncd_manage();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
 private:
@@ -273,8 +253,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_wd_command();
 
-  IPCCommandResult Open(u32 CommandAddress, u32 Mode) override;
-  IPCCommandResult Close(u32 CommandAddress, bool Force) override;
   IPCCommandResult IOCtlV(u32 CommandAddress) override;
 
 private:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -30,7 +30,7 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_kd_request();
 
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
 
 private:
   enum
@@ -86,35 +86,31 @@ public:
   }
 
   virtual ~CWII_IPC_HLE_Device_net_kd_time() {}
-  IPCCommandResult IOCtl(u32 _CommandAddress) override
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override
   {
-    u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
-    u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-    u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-
-    u32 result = 0;
+    s32 result = 0;
     u32 common_result = 0;
     // TODO Writes stuff to /shared2/nwc24/misc.bin
     // u32 update_misc = 0;
 
-    switch (Parameter)
+    switch (request.request)
     {
     case IOCTL_NW24_GET_UNIVERSAL_TIME:
-      Memory::Write_U64(GetAdjustedUTC(), BufferOut + 4);
+      Memory::Write_U64(GetAdjustedUTC(), request.out_addr + 4);
       break;
 
     case IOCTL_NW24_SET_UNIVERSAL_TIME:
-      SetAdjustedUTC(Memory::Read_U64(BufferIn));
-      // update_misc = Memory::Read_U32(BufferIn + 8);
+      SetAdjustedUTC(Memory::Read_U64(request.in_addr));
+      // update_misc = Memory::Read_U32(request.in_addr + 8);
       break;
 
     case IOCTL_NW24_SET_RTC_COUNTER:
-      rtc = Memory::Read_U32(BufferIn);
-      // update_misc = Memory::Read_U32(BufferIn + 4);
+      rtc = Memory::Read_U32(request.in_addr);
+      // update_misc = Memory::Read_U32(request.in_addr + 4);
       break;
 
     case IOCTL_NW24_GET_TIME_DIFF:
-      Memory::Write_U64(GetAdjustedUTC() - rtc, BufferOut + 4);
+      Memory::Write_U64(GetAdjustedUTC() - rtc, request.out_addr + 4);
       break;
 
     case IOCTL_NW24_UNIMPLEMENTED:
@@ -122,13 +118,13 @@ public:
       break;
 
     default:
-      ERROR_LOG(WII_IPC_NET, "%s - unknown IOCtl: %x", GetDeviceName().c_str(), Parameter);
+      ERROR_LOG(WII_IPC_NET, "%s - unknown IOCtl: %x", GetDeviceName().c_str(), request.request);
       break;
     }
 
     // write return values
-    Memory::Write_U32(common_result, BufferOut);
-    Memory::Write_U32(result, _CommandAddress + 4);
+    Memory::Write_U32(common_result, request.out_addr);
+    request.SetReturnValue(result);
     return GetDefaultReply();
   }
 
@@ -207,8 +203,8 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ip_top();
 
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
   u32 Update() override;
 
@@ -227,7 +223,7 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ncd_manage();
 
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
 private:
   enum
@@ -253,7 +249,7 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_wd_command();
 
-  IPCCommandResult IOCtlV(u32 CommandAddress) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
 private:
   enum

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -75,22 +75,6 @@ int CWII_IPC_HLE_Device_net_ssl::GetSSLFreeID() const
   return 0;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Open(u32 _CommandAddress, u32 _Mode)
-{
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Close(u32 _CommandAddress, bool _bForce)
-{
-  if (!_bForce)
-  {
-    Memory::Write_U32(0, _CommandAddress + 4);
-  }
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(u32 _CommandAddress)
 {
   u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -77,7 +77,6 @@ int CWII_IPC_HLE_Device_net_ssl::GetSSLFreeID() const
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Open(u32 _CommandAddress, u32 _Mode)
 {
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -75,72 +75,62 @@ int CWII_IPC_HLE_Device_net_ssl::GetSSLFreeID() const
   return 0;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(IOSResourceIOCtlRequest& request)
 {
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-  u32 Command = Memory::Read_U32(_CommandAddress + 0x0C);
-
-  INFO_LOG(WII_IPC_SSL, "%s unknown %i "
-                        "(BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-           GetDeviceName().c_str(), Command, BufferIn, BufferInSize, BufferOut, BufferOutSize);
-  Memory::Write_U32(0, _CommandAddress + 0x4);
+  request.Log(GetDeviceName(), LogTypes::WII_IPC_SSL, LogTypes::LINFO);
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
-
-  u32 _BufferIn = 0, _BufferIn2 = 0, _BufferIn3 = 0;
+  u32 BufferIn = 0, BufferIn2 = 0, BufferIn3 = 0;
   u32 BufferInSize = 0, BufferInSize2 = 0, BufferInSize3 = 0;
 
   u32 BufferOut = 0, BufferOut2 = 0, BufferOut3 = 0;
   u32 BufferOutSize = 0, BufferOutSize2 = 0, BufferOutSize3 = 0;
 
-  if (CommandBuffer.InBuffer.size() > 0)
+  if (request.in_vectors.size() > 0)
   {
-    _BufferIn = CommandBuffer.InBuffer.at(0).m_Address;
-    BufferInSize = CommandBuffer.InBuffer.at(0).m_Size;
+    BufferIn = request.in_vectors.at(0).addr;
+    BufferInSize = request.in_vectors.at(0).size;
   }
-  if (CommandBuffer.InBuffer.size() > 1)
+  if (request.in_vectors.size() > 1)
   {
-    _BufferIn2 = CommandBuffer.InBuffer.at(1).m_Address;
-    BufferInSize2 = CommandBuffer.InBuffer.at(1).m_Size;
+    BufferIn2 = request.in_vectors.at(1).addr;
+    BufferInSize2 = request.in_vectors.at(1).size;
   }
-  if (CommandBuffer.InBuffer.size() > 2)
+  if (request.in_vectors.size() > 2)
   {
-    _BufferIn3 = CommandBuffer.InBuffer.at(2).m_Address;
-    BufferInSize3 = CommandBuffer.InBuffer.at(2).m_Size;
+    BufferIn3 = request.in_vectors.at(2).addr;
+    BufferInSize3 = request.in_vectors.at(2).size;
   }
 
-  if (CommandBuffer.PayloadBuffer.size() > 0)
+  if (request.io_vectors.size() > 0)
   {
-    BufferOut = CommandBuffer.PayloadBuffer.at(0).m_Address;
-    BufferOutSize = CommandBuffer.PayloadBuffer.at(0).m_Size;
+    BufferOut = request.io_vectors.at(0).addr;
+    BufferOutSize = request.io_vectors.at(0).size;
   }
-  if (CommandBuffer.PayloadBuffer.size() > 1)
+  if (request.io_vectors.size() > 1)
   {
-    BufferOut2 = CommandBuffer.PayloadBuffer.at(1).m_Address;
-    BufferOutSize2 = CommandBuffer.PayloadBuffer.at(1).m_Size;
+    BufferOut2 = request.io_vectors.at(1).addr;
+    BufferOutSize2 = request.io_vectors.at(1).size;
   }
-  if (CommandBuffer.PayloadBuffer.size() > 2)
+  if (request.io_vectors.size() > 2)
   {
-    BufferOut3 = CommandBuffer.PayloadBuffer.at(2).m_Address;
-    BufferOutSize3 = CommandBuffer.PayloadBuffer.at(2).m_Size;
+    BufferOut3 = request.io_vectors.at(2).addr;
+    BufferOutSize3 = request.io_vectors.at(2).size;
   }
 
   // I don't trust SSL to be deterministic, and this is never going to sync
   // as such (as opposed to forwarding IPC results or whatever), so -
   if (Core::g_want_determinism)
   {
-    Memory::Write_U32(-1, _CommandAddress + 0x4);
+    request.SetReturnValue(-1);
     return GetDefaultReply();
   }
 
-  switch (CommandBuffer.Parameter)
+  switch (request.request)
   {
   case IOCTLV_NET_SSL_NEW:
   {
@@ -187,20 +177,20 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       mbedtls_ssl_set_hostname(&ssl->ctx, ssl->hostname.c_str());
 
       ssl->active = true;
-      Memory::Write_U32(freeSSL, _BufferIn);
+      Memory::Write_U32(freeSSL, BufferIn);
     }
     else
     {
     _SSL_NEW_ERROR:
-      Memory::Write_U32(SSL_ERR_FAILED, _BufferIn);
+      Memory::Write_U32(SSL_ERR_FAILED, BufferIn);
     }
 
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_NEW (%d, %s) "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             verifyOption, hostname.c_str(), _BufferIn, BufferInSize, _BufferIn2, BufferInSize2,
-             _BufferIn3, BufferInSize3, BufferOut, BufferOutSize, BufferOut2, BufferOutSize2,
+             verifyOption, hostname.c_str(), BufferIn, BufferInSize, BufferIn2, BufferInSize2,
+             BufferIn3, BufferInSize3, BufferOut, BufferOutSize, BufferOut2, BufferOutSize2,
              BufferOut3, BufferOutSize3);
     break;
   }
@@ -226,18 +216,18 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
 
       ssl->active = false;
 
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SHUTDOWN "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
   case IOCTLV_NET_SSL_SETROOTCA:
@@ -246,8 +236,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
@@ -264,19 +254,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
 
       if (ret)
       {
-        Memory::Write_U32(SSL_ERR_FAILED, _BufferIn);
+        Memory::Write_U32(SSL_ERR_FAILED, BufferIn);
       }
       else
       {
         mbedtls_ssl_conf_ca_chain(&ssl->config, &ssl->cacert, nullptr);
-        Memory::Write_U32(SSL_OK, _BufferIn);
+        Memory::Write_U32(SSL_OK, BufferIn);
       }
 
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETROOTCA = %d", ret);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     break;
   }
@@ -286,8 +276,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
@@ -302,19 +292,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       {
         mbedtls_x509_crt_free(&ssl->clicert);
         mbedtls_pk_free(&ssl->pk);
-        Memory::Write_U32(SSL_ERR_FAILED, _BufferIn);
+        Memory::Write_U32(SSL_ERR_FAILED, BufferIn);
       }
       else
       {
         mbedtls_ssl_conf_own_cert(&ssl->config, &ssl->clicert, &ssl->pk);
-        Memory::Write_U32(SSL_OK, _BufferIn);
+        Memory::Write_U32(SSL_OK, BufferIn);
       }
 
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINCLIENTCERT = (%d, %d)", ret, pk_ret);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINCLIENTCERT invalid sslID = %d", sslID);
     }
     break;
@@ -325,8 +315,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
@@ -336,11 +326,11 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       mbedtls_pk_free(&ssl->pk);
 
       mbedtls_ssl_conf_own_cert(&ssl->config, nullptr, nullptr);
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINCLIENTCERT invalid sslID = %d", sslID);
     }
     break;
@@ -357,25 +347,25 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       if (ret)
       {
         mbedtls_x509_crt_free(&ssl->clicert);
-        Memory::Write_U32(SSL_ERR_FAILED, _BufferIn);
+        Memory::Write_U32(SSL_ERR_FAILED, BufferIn);
       }
       else
       {
         mbedtls_ssl_conf_ca_chain(&ssl->config, &ssl->cacert, nullptr);
-        Memory::Write_U32(SSL_OK, _BufferIn);
+        Memory::Write_U32(SSL_OK, BufferIn);
       }
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINROOTCA = %d", ret);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINROOTCA "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
   case IOCTLV_NET_SSL_CONNECT:
@@ -388,18 +378,18 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       ssl->sockfd = Memory::Read_U32(BufferOut2);
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_CONNECT socket = %d", ssl->sockfd);
       mbedtls_ssl_set_bio(&ssl->ctx, &ssl->sockfd, mbedtls_net_send, mbedtls_net_recv, nullptr);
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_CONNECT "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
   case IOCTLV_NET_SSL_DOHANDSHAKE:
@@ -408,12 +398,12 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
     if (SSLID_VALID(sslID))
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
-      sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_DOHANDSHAKE);
+      sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_DOHANDSHAKE);
       return GetNoReply();
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     break;
   }
@@ -423,19 +413,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
     if (SSLID_VALID(sslID))
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
-      sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_WRITE);
+      sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_WRITE);
       return GetNoReply();
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_WRITE "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     INFO_LOG(WII_IPC_SSL, "%s", Memory::GetString(BufferOut2).c_str());
     break;
   }
@@ -446,19 +436,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
     if (SSLID_VALID(sslID))
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
-      sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_READ);
+      sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_READ);
       return GetNoReply();
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
 
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_READ(%d)"
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             ret, _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
+             ret, BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3,
              BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
@@ -467,18 +457,18 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
     {
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETROOTCADEFAULT "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
   case IOCTLV_NET_SSL_SETCLIENTCERTDEFAULT:
@@ -487,33 +477,25 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
     {
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     break;
   }
   default:
-    ERROR_LOG(WII_IPC_SSL, "%i "
-                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
-                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
-                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-              CommandBuffer.Parameter, _BufferIn, BufferInSize, _BufferIn2, BufferInSize2,
-              _BufferIn3, BufferInSize3, BufferOut, BufferOutSize, BufferOut2, BufferOutSize2,
-              BufferOut3, BufferOutSize3);
-    break;
+    request.Dump(GetDeviceName(), LogTypes::WII_IPC_SSL, LogTypes::LERROR);
   }
 
   // SSL return codes are written to BufferIn
-  Memory::Write_U32(0, _CommandAddress + 4);
-
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -243,13 +243,15 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(IOSResourceIOCtlVRequest& r
     if (SSLID_VALID(sslID))
     {
       WII_SSL* ssl = &_SSL[sslID];
-      int ret =
-          mbedtls_x509_crt_parse_der(&ssl->cacert, Memory::GetPointer(BufferOut2), BufferOutSize2);
+      std::vector<u8> temp_buffer(BufferOutSize2);
+      Memory::CopyFromEmu(temp_buffer.data(), BufferOut2, temp_buffer.size());
+      int ret = mbedtls_x509_crt_parse_der(&ssl->cacert, temp_buffer.data(), temp_buffer.size());
+      Memory::CopyToEmu(BufferOut2, temp_buffer.data(), temp_buffer.size());
 
       if (SConfig::GetInstance().m_SSLDumpRootCA)
       {
         std::string filename = File::GetUserPath(D_DUMPSSL_IDX) + ssl->hostname + "_rootca.der";
-        File::IOFile(filename, "wb").WriteBytes(Memory::GetPointer(BufferOut2), BufferOutSize2);
+        File::IOFile(filename, "wb").WriteBytes(temp_buffer.data(), temp_buffer.size());
       }
 
       if (ret)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
@@ -87,9 +87,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ssl();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
@@ -87,8 +87,8 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ssl();
 
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
   int GetSSLFreeID() const;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -76,7 +76,6 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Open(u32 _CommandAddress, u32 _
 
   OpenInternal();
 
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 0x4);
   m_registers.fill(0);
   m_Active = true;
   return GetDefaultReply();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -89,8 +89,6 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool
   m_BlockLength = 0;
   m_BusWidth = 0;
 
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 0x4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -77,7 +77,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Open(u32 _CommandAddress, u32 _
   OpenInternal();
 
   m_registers.fill(0);
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -89,7 +89,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool
   m_BlockLength = 0;
   m_BusWidth = 0;
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -43,9 +43,8 @@ void CWII_IPC_HLE_Device_sdio_slot0::EventNotify()
   if ((SConfig::GetInstance().m_WiiSDCard && m_event.type == EVENT_INSERT) ||
       (!SConfig::GetInstance().m_WiiSDCard && m_event.type == EVENT_REMOVE))
   {
-    Memory::Write_U32(m_event.type, m_event.addr + 4);
-    WII_IPC_HLE_Interface::EnqueueReply(m_event.addr);
-    m_event.addr = 0;
+    m_event.request.SetReturnValue(m_event.type);
+    WII_IPC_HLE_Interface::EnqueueReply(m_event.request);
     m_event.type = EVENT_NONE;
   }
 }
@@ -70,50 +69,35 @@ void CWII_IPC_HLE_Device_sdio_slot0::OpenInternal()
   }
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Open(u32 _CommandAddress, u32 _Mode)
+IOSReturnCode CWII_IPC_HLE_Device_sdio_slot0::Open(IOSResourceOpenRequest& request)
 {
-  INFO_LOG(WII_IPC_SD, "Open");
-
   OpenInternal();
-
   m_registers.fill(0);
+
   m_is_active = true;
-  return GetDefaultReply();
+  return IPC_SUCCESS;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool _bForce)
+void CWII_IPC_HLE_Device_sdio_slot0::Close()
 {
-  INFO_LOG(WII_IPC_SD, "Close");
-
   m_Card.Close();
   m_BlockLength = 0;
   m_BusWidth = 0;
 
   m_is_active = false;
-  return GetDefaultReply();
 }
 
 // The front SD slot
-IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(IOSResourceIOCtlRequest& request)
 {
-  u32 Cmd = Memory::Read_U32(_CommandAddress + 0xC);
-
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-
-  // As a safety precaution we fill the out buffer with zeros to avoid
-  // returning nonsense values
-  Memory::Memset(BufferOut, 0, BufferOutSize);
-
-  u32 ReturnValue = 0;
-  switch (Cmd)
+  Memory::Memset(request.out_addr, 0, request.out_size);
+  s32 return_value = IPC_SUCCESS;
+  switch (request.request)
   {
   case IOCTL_WRITEHCR:
   {
-    u32 reg = Memory::Read_U32(BufferIn);
-    u32 val = Memory::Read_U32(BufferIn + 16);
+    u32 reg = Memory::Read_U32(request.in_addr);
+    u32 val = Memory::Read_U32(request.in_addr + 16);
 
     INFO_LOG(WII_IPC_SD, "IOCTL_WRITEHCR 0x%08x - 0x%08x", reg, val);
 
@@ -143,7 +127,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
 
   case IOCTL_READHCR:
   {
-    u32 reg = Memory::Read_U32(BufferIn);
+    u32 reg = Memory::Read_U32(request.in_addr);
 
     if (reg >= m_registers.size())
     {
@@ -155,7 +139,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
     INFO_LOG(WII_IPC_SD, "IOCTL_READHCR 0x%08x - 0x%08x", reg, val);
 
     // Just reading the register
-    Memory::Write_U32(val, BufferOut);
+    Memory::Write_U32(val, request.out_addr);
   }
   break;
 
@@ -164,7 +148,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
     if (m_Card)
       m_Status |= CARD_INITIALIZED;
     // Returns 16bit RCA and 16bit 0s (meaning success)
-    Memory::Write_U32(0x9f620000, BufferOut);
+    Memory::Write_U32(0x9f620000, request.out_addr);
     break;
 
   case IOCTL_SETCLK:
@@ -172,15 +156,17 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
     INFO_LOG(WII_IPC_SD, "IOCTL_SETCLK");
     // libogc only sets it to 1 and makes sure the return isn't negative...
     // one half of the sdclk divisor: a power of two or zero.
-    u32 clock = Memory::Read_U32(BufferIn);
+    u32 clock = Memory::Read_U32(request.in_addr);
     if (clock != 1)
       INFO_LOG(WII_IPC_SD, "Setting to %i, interesting", clock);
   }
   break;
 
   case IOCTL_SENDCMD:
-    INFO_LOG(WII_IPC_SD, "IOCTL_SENDCMD %x IPC:%08x", Memory::Read_U32(BufferIn), _CommandAddress);
-    ReturnValue = ExecuteCommand(BufferIn, BufferInSize, 0, 0, BufferOut, BufferOutSize);
+    INFO_LOG(WII_IPC_SD, "IOCTL_SENDCMD %x IPC:%08x", Memory::Read_U32(request.in_addr),
+             request.address);
+    return_value =
+        ExecuteCommand(request.in_addr, request.in_size, 0, 0, request.out_addr, request.out_size);
     break;
 
   case IOCTL_GETSTATUS:
@@ -191,88 +177,61 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
     INFO_LOG(WII_IPC_SD, "IOCTL_GETSTATUS. Replying that SD card is %s%s",
              (m_Status & CARD_INSERTED) ? "inserted" : "not present",
              (m_Status & CARD_INITIALIZED) ? " and initialized" : "");
-    Memory::Write_U32(m_Status, BufferOut);
+    Memory::Write_U32(m_Status, request.out_addr);
     break;
 
   case IOCTL_GETOCR:
     INFO_LOG(WII_IPC_SD, "IOCTL_GETOCR");
-    Memory::Write_U32(0x80ff8000, BufferOut);
+    Memory::Write_U32(0x80ff8000, request.out_addr);
     break;
 
   default:
-    ERROR_LOG(WII_IPC_SD, "Unknown SD IOCtl command (0x%08x)", Cmd);
+    ERROR_LOG(WII_IPC_SD, "Unknown SD IOCtl command (0x%08x)", request.request);
     break;
   }
 
-  // INFO_LOG(WII_IPC_SD, "InBuffer");
-  // DumpCommands(BufferIn, BufferInSize / 4, LogTypes::WII_IPC_SD);
-  // INFO_LOG(WII_IPC_SD, "OutBuffer");
-  // DumpCommands(BufferOut, BufferOutSize/4, LogTypes::WII_IPC_SD);
-
-  if (ReturnValue == RET_EVENT_REGISTER)
+  if (return_value == RET_EVENT_REGISTER)
   {
     // async
-    m_event.addr = _CommandAddress;
-    Memory::Write_U32(0, _CommandAddress + 0x4);
+    m_event.request = request;
+    request.SetReturnValue(IPC_SUCCESS);
     // Check if the condition is already true
     EventNotify();
     return GetNoReply();
   }
-  else if (ReturnValue == RET_EVENT_UNREGISTER)
+  if (return_value == RET_EVENT_UNREGISTER)
   {
     // release returns 0
     // unknown sd int
     // technically we do it out of order, oh well
-    Memory::Write_U32(EVENT_INVALID, m_event.addr + 4);
-    WII_IPC_HLE_Interface::EnqueueReply(m_event.addr);
-    m_event.addr = 0;
+    m_event.request.SetReturnValue(EVENT_INVALID);
+    WII_IPC_HLE_Interface::EnqueueReply(m_event.request);
     m_event.type = EVENT_NONE;
-    Memory::Write_U32(0, _CommandAddress + 0x4);
+    request.SetReturnValue(IPC_SUCCESS);
     return GetDefaultReply();
   }
-  else
-  {
-    Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-    return GetDefaultReply();
-  }
+  request.SetReturnValue(return_value);
+  return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
-  // PPC sending commands
-
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
-
-  // Prepare the out buffer(s) with zeros as a safety precaution
-  // to avoid returning bad values
-  for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; i++)
-  {
-    Memory::Memset(CommandBuffer.PayloadBuffer[i].m_Address, 0,
-                   CommandBuffer.PayloadBuffer[i].m_Size);
-  }
-
-  u32 ReturnValue = 0;
-  switch (CommandBuffer.Parameter)
+  s32 return_value = IPC_SUCCESS;
+  switch (request.request)
   {
   case IOCTLV_SENDCMD:
-    DEBUG_LOG(WII_IPC_SD, "IOCTLV_SENDCMD 0x%08x",
-              Memory::Read_U32(CommandBuffer.InBuffer[0].m_Address));
-    ReturnValue = ExecuteCommand(
-        CommandBuffer.InBuffer[0].m_Address, CommandBuffer.InBuffer[0].m_Size,
-        CommandBuffer.InBuffer[1].m_Address, CommandBuffer.InBuffer[1].m_Size,
-        CommandBuffer.PayloadBuffer[0].m_Address, CommandBuffer.PayloadBuffer[0].m_Size);
+    DEBUG_LOG(WII_IPC_SD, "IOCTLV_SENDCMD 0x%08x", Memory::Read_U32(request.in_vectors[0].addr));
+    Memory::Memset(request.io_vectors[0].addr, 0, request.io_vectors[0].size);
+    return_value = ExecuteCommand(request.in_vectors[0].addr, request.in_vectors[0].size,
+                                  request.in_vectors[1].addr, request.in_vectors[1].size,
+                                  request.io_vectors[0].addr, request.io_vectors[0].size);
     break;
 
   default:
-    ERROR_LOG(WII_IPC_SD, "Unknown SD IOCtlV command 0x%08x", CommandBuffer.Parameter);
-    break;
+    ERROR_LOG(WII_IPC_SD, "Unknown SD IOCtlV command 0x%08x", request.request);
   }
 
-  // DumpAsync(CommandBuffer.BufferVector, CommandBuffer.NumberInBuffer,
-  // CommandBuffer.NumberPayloadBuffer, LogTypes::WII_IPC_SD);
-
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -349,7 +349,9 @@ u32 CWII_IPC_HLE_Device_sdio_slot0::ExecuteCommand(u32 _BufferIn, u32 _BufferInS
       if (!m_Card.Seek(req.arg, SEEK_SET))
         ERROR_LOG(WII_IPC_SD, "Seek failed WTF");
 
-      if (m_Card.ReadBytes(Memory::GetPointer(req.addr), size))
+      std::vector<u8> buffer(size);
+      Memory::CopyFromEmu(buffer.data(), req.addr, size);
+      if (m_Card.ReadBytes(buffer.data(), buffer.size()))
       {
         DEBUG_LOG(WII_IPC_SD, "Outbuffer size %i got %i", _rwBufferSize, size);
       }
@@ -359,6 +361,7 @@ u32 CWII_IPC_HLE_Device_sdio_slot0::ExecuteCommand(u32 _BufferIn, u32 _BufferInS
                   feof(m_Card.GetHandle()));
         ret = RET_FAIL;
       }
+      Memory::CopyToEmu(req.addr, buffer.data(), buffer.size());
     }
   }
     Memory::Write_U32(0x900, _BufferOut);
@@ -378,7 +381,9 @@ u32 CWII_IPC_HLE_Device_sdio_slot0::ExecuteCommand(u32 _BufferIn, u32 _BufferInS
       if (!m_Card.Seek(req.arg, SEEK_SET))
         ERROR_LOG(WII_IPC_SD, "fseeko failed WTF");
 
-      if (!m_Card.WriteBytes(Memory::GetPointer(req.addr), size))
+      std::vector<u8> buffer(size);
+      Memory::CopyFromEmu(buffer.data(), req.addr, size);
+      if (!m_Card.WriteBytes(buffer.data(), buffer.size()))
       {
         ERROR_LOG(WII_IPC_SD, "Write Failed - error: %i, eof: %i", ferror(m_Card.GetHandle()),
                   feof(m_Card.GetHandle()));

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.h
@@ -23,11 +23,10 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IOSReturnCode Open(IOSResourceOpenRequest& request) override;
+  void Close() override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
   void EventNotify();
 
@@ -111,7 +110,7 @@ private:
   struct Event
   {
     EventType type = EVENT_NONE;
-    u32 addr = 0;
+    IOSResourceRequest request;
   } m_event;
 
   u32 m_Status = CARD_NOT_EXIST;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -42,11 +42,11 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
   case IOCTL_STM_RELEASE_EH:
     if (s_event_hook_address == 0)
     {
-      return_value = FS_ENOENT;
+      return_value = IPC_ENOENT;
       break;
     }
     Memory::Write_U32(0, Memory::Read_U32(s_event_hook_address + 0x18));
-    Memory::Write_U32(FS_SUCCESS, s_event_hook_address + 4);
+    Memory::Write_U32(IPC_SUCCESS, s_event_hook_address + 4);
     WII_IPC_HLE_Interface::EnqueueReply(s_event_hook_address);
     s_event_hook_address = 0;
     break;
@@ -102,7 +102,7 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 command_address)
   if (parameter != IOCTL_STM_EVENTHOOK)
   {
     ERROR_LOG(WII_IPC_STM, "Bad IOCtl in CWII_IPC_HLE_Device_stm_eventhook");
-    Memory::Write_U32(FS_EINVAL, command_address + 4);
+    Memory::Write_U32(IPC_EINVAL, command_address + 4);
     return GetDefaultReply();
   }
 
@@ -129,7 +129,7 @@ void CWII_IPC_HLE_Device_stm_eventhook::TriggerEvent(const u32 event) const
   u32 buffer_out = Memory::Read_U32(s_event_hook_address + 0x18);
   Memory::Write_U32(event, buffer_out);
 
-  Memory::Write_U32(FS_SUCCESS, s_event_hook_address + 4);
+  Memory::Write_U32(IPC_SUCCESS, s_event_hook_address + 4);
   WII_IPC_HLE_Interface::EnqueueReply(s_event_hook_address);
   s_event_hook_address = 0;
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -92,7 +92,7 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Close(u32 command_address, b
 {
   s_event_hook_address = 0;
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 
@@ -119,7 +119,7 @@ bool CWII_IPC_HLE_Device_stm_eventhook::HasHookInstalled() const
 
 void CWII_IPC_HLE_Device_stm_eventhook::TriggerEvent(const u32 event) const
 {
-  if (!m_Active || s_event_hook_address == 0)
+  if (!m_is_active || s_event_hook_address == 0)
   {
     // If the device isn't open, ignore the button press.
     return;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -18,22 +18,6 @@ void Stop();
 
 static u32 s_event_hook_address = 0;
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Open(u32 command_address, u32 mode)
-{
-  INFO_LOG(WII_IPC_STM, "STM immediate: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Close(u32 command_address, bool force)
-{
-  INFO_LOG(WII_IPC_STM, "STM immediate: Close");
-  if (!force)
-    Memory::Write_U32(0, command_address + 4);
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
 {
   u32 parameter = Memory::Read_U32(command_address + 0x0C);
@@ -104,19 +88,10 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Open(u32 command_address, u32 mode)
-{
-  m_Active = true;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Close(u32 command_address, bool force)
 {
   s_event_hook_address = 0;
 
-  INFO_LOG(WII_IPC_STM, "STM eventhook: Close");
-  if (!force)
-    Memory::Write_U32(0, command_address + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -21,7 +21,6 @@ static u32 s_event_hook_address = 0;
 IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Open(u32 command_address, u32 mode)
 {
   INFO_LOG(WII_IPC_STM, "STM immediate: Open");
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }
@@ -107,7 +106,6 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
 
 IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Open(u32 command_address, u32 mode)
 {
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -5,6 +5,7 @@
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_stm.h"
 
 #include <functional>
+#include <memory>
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
@@ -16,22 +17,12 @@ void QueueHostJob(std::function<void()> job, bool run_during_stop);
 void Stop();
 }
 
-static u32 s_event_hook_address = 0;
+static std::unique_ptr<IOSResourceIOCtlRequest> s_event_hook_request;
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(IOSResourceIOCtlRequest& request)
 {
-  u32 parameter = Memory::Read_U32(command_address + 0x0C);
-  u32 buffer_in = Memory::Read_U32(command_address + 0x10);
-  u32 buffer_in_size = Memory::Read_U32(command_address + 0x14);
-  u32 buffer_out = Memory::Read_U32(command_address + 0x18);
-  u32 buffer_out_size = Memory::Read_U32(command_address + 0x1C);
-
-  // Prepare the out buffer(s) with zeroes as a safety precaution
-  // to avoid returning bad values
-  Memory::Memset(buffer_out, 0, buffer_out_size);
-  u32 return_value = 0;
-
-  switch (parameter)
+  s32 return_value = IPC_SUCCESS;
+  switch (request.request)
   {
   case IOCTL_STM_IDLE:
   case IOCTL_STM_SHUTDOWN:
@@ -40,15 +31,15 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
     break;
 
   case IOCTL_STM_RELEASE_EH:
-    if (s_event_hook_address == 0)
+    if (!s_event_hook_request)
     {
       return_value = IPC_ENOENT;
       break;
     }
-    Memory::Write_U32(0, Memory::Read_U32(s_event_hook_address + 0x18));
-    Memory::Write_U32(IPC_SUCCESS, s_event_hook_address + 4);
-    WII_IPC_HLE_Interface::EnqueueReply(s_event_hook_address);
-    s_event_hook_address = 0;
+    Memory::Write_U32(0, s_event_hook_request->out_addr);
+    s_event_hook_request->SetReturnValue(IPC_SUCCESS);
+    WII_IPC_HLE_Interface::EnqueueReply(*s_event_hook_request);
+    s_event_hook_request.reset();
     break;
 
   case IOCTL_STM_HOTRESET:
@@ -70,73 +61,54 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
     break;
 
   default:
-  {
-    _dbg_assert_msg_(WII_IPC_STM, 0, "CWII_IPC_HLE_Device_stm_immediate: 0x%x", parameter);
-
-    INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
-    DEBUG_LOG(WII_IPC_STM, "    parameter: 0x%x", parameter);
-    DEBUG_LOG(WII_IPC_STM, "    InBuffer: 0x%08x", buffer_in);
-    DEBUG_LOG(WII_IPC_STM, "    InBufferSize: 0x%08x", buffer_in_size);
-    DEBUG_LOG(WII_IPC_STM, "    OutBuffer: 0x%08x", buffer_out);
-    DEBUG_LOG(WII_IPC_STM, "    OutBufferSize: 0x%08x", buffer_out_size);
-  }
-  break;
+    ERROR_LOG(WII_IPC_STM, "%s - Unknown IOCtl", GetDeviceName().c_str());
+    request.Dump(GetDeviceName(), LogTypes::WII_IPC_STM, LogTypes::LWARNING);
   }
 
-  // Write return value to the IPC call
-  Memory::Write_U32(return_value, command_address + 0x4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Close(u32 command_address, bool force)
+void CWII_IPC_HLE_Device_stm_eventhook::Close()
 {
-  s_event_hook_address = 0;
-
+  s_event_hook_request.reset();
   m_is_active = false;
-  return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(IOSResourceIOCtlRequest& request)
 {
-  u32 parameter = Memory::Read_U32(command_address + 0x0C);
-  if (parameter != IOCTL_STM_EVENTHOOK)
+  if (request.request != IOCTL_STM_EVENTHOOK)
   {
     ERROR_LOG(WII_IPC_STM, "Bad IOCtl in CWII_IPC_HLE_Device_stm_eventhook");
-    Memory::Write_U32(IPC_EINVAL, command_address + 4);
+    request.SetReturnValue(IPC_EINVAL);
     return GetDefaultReply();
   }
 
-  // IOCTL_STM_EVENTHOOK waits until the reset button or power button
-  // is pressed.
-  s_event_hook_address = command_address;
+  // IOCTL_STM_EVENTHOOK waits until the reset button or power button is pressed.
+  s_event_hook_request = std::make_unique<IOSResourceIOCtlRequest>(request.address);
   return GetNoReply();
 }
 
 bool CWII_IPC_HLE_Device_stm_eventhook::HasHookInstalled() const
 {
-  return s_event_hook_address != 0;
+  return s_event_hook_request != nullptr;
 }
 
 void CWII_IPC_HLE_Device_stm_eventhook::TriggerEvent(const u32 event) const
 {
-  if (!m_is_active || s_event_hook_address == 0)
-  {
-    // If the device isn't open, ignore the button press.
+  // If the device isn't open, ignore the button press.
+  if (!m_is_active || !s_event_hook_request)
     return;
-  }
 
-  // The reset button returns STM_EVENT_RESET.
-  u32 buffer_out = Memory::Read_U32(s_event_hook_address + 0x18);
-  Memory::Write_U32(event, buffer_out);
-
-  Memory::Write_U32(IPC_SUCCESS, s_event_hook_address + 4);
-  WII_IPC_HLE_Interface::EnqueueReply(s_event_hook_address);
-  s_event_hook_address = 0;
+  Memory::Write_U32(event, s_event_hook_request->out_addr);
+  s_event_hook_request->SetReturnValue(IPC_SUCCESS);
+  WII_IPC_HLE_Interface::EnqueueReply(*s_event_hook_request);
+  s_event_hook_request.reset();
 }
 
 void CWII_IPC_HLE_Device_stm_eventhook::ResetButton() const
 {
-  // The reset button returns STM_EVENT_RESET.
+  // The reset button triggers STM_EVENT_RESET.
   TriggerEvent(STM_EVENT_RESET);
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -44,8 +44,6 @@ public:
   }
 
   ~CWII_IPC_HLE_Device_stm_immediate() override = default;
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force) override;
   IPCCommandResult IOCtl(u32 command_address) override;
 };
 
@@ -59,7 +57,6 @@ public:
   }
 
   ~CWII_IPC_HLE_Device_stm_eventhook() override = default;
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
   IPCCommandResult Close(u32 command_address, bool force) override;
   IPCCommandResult IOCtl(u32 command_address) override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -43,8 +43,7 @@ public:
   {
   }
 
-  ~CWII_IPC_HLE_Device_stm_immediate() override = default;
-  IPCCommandResult IOCtl(u32 command_address) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
 };
 
 // The /dev/stm/eventhook
@@ -56,9 +55,8 @@ public:
   {
   }
 
-  ~CWII_IPC_HLE_Device_stm_eventhook() override = default;
-  IPCCommandResult Close(u32 command_address, bool force) override;
-  IPCCommandResult IOCtl(u32 command_address) override;
+  void Close() override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
 
   bool HasHookInstalled() const;
   void ResetButton() const;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -13,28 +13,28 @@ CWII_IPC_HLE_Device_stub::CWII_IPC_HLE_Device_stub(u32 device_id, const std::str
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::Open(u32 command_address, u32 mode)
 {
-  WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_Name.c_str());
-  m_Active = true;
+  WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_name.c_str());
+  m_is_active = true;
   return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::Close(u32 command_address, bool force)
 {
-  WARN_LOG(WII_IPC_HLE, "%s faking Close()", m_Name.c_str());
-  m_Active = false;
+  WARN_LOG(WII_IPC_HLE, "%s faking Close()", m_name.c_str());
+  m_is_active = false;
   return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtl(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_name.c_str());
   Memory::Write_U32(IPC_SUCCESS, command_address + 4);
   return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtlV(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_name.c_str());
   Memory::Write_U32(IPC_SUCCESS, command_address + 4);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -28,13 +28,13 @@ IPCCommandResult CWII_IPC_HLE_Device_stub::Close(u32 command_address, bool force
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtl(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_Name.c_str());
-  Memory::Write_U32(FS_SUCCESS, command_address + 4);
+  Memory::Write_U32(IPC_SUCCESS, command_address + 4);
   return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtlV(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_Name.c_str());
-  Memory::Write_U32(FS_SUCCESS, command_address + 4);
+  Memory::Write_U32(IPC_SUCCESS, command_address + 4);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -21,8 +21,6 @@ IPCCommandResult CWII_IPC_HLE_Device_stub::Open(u32 command_address, u32 mode)
 IPCCommandResult CWII_IPC_HLE_Device_stub::Close(u32 command_address, bool force)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking Close()", m_Name.c_str());
-  if (!force)
-    Memory::Write_U32(FS_SUCCESS, command_address + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -14,7 +14,6 @@ CWII_IPC_HLE_Device_stub::CWII_IPC_HLE_Device_stub(u32 device_id, const std::str
 IPCCommandResult CWII_IPC_HLE_Device_stub::Open(u32 command_address, u32 mode)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_Name.c_str());
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -4,37 +4,35 @@
 
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_stub.h"
 #include "Common/Logging/Log.h"
-#include "Core/HW/Memmap.h"
 
 CWII_IPC_HLE_Device_stub::CWII_IPC_HLE_Device_stub(u32 device_id, const std::string& device_name)
     : IWII_IPC_HLE_Device(device_id, device_name)
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stub::Open(u32 command_address, u32 mode)
+IOSReturnCode CWII_IPC_HLE_Device_stub::Open(IOSResourceOpenRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_name.c_str());
   m_is_active = true;
-  return GetDefaultReply();
+  return IPC_SUCCESS;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stub::Close(u32 command_address, bool force)
+void CWII_IPC_HLE_Device_stub::Close()
 {
   WARN_LOG(WII_IPC_HLE, "%s faking Close()", m_name.c_str());
   m_is_active = false;
-  return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtl(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtl(IOSResourceIOCtlRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_name.c_str());
-  Memory::Write_U32(IPC_SUCCESS, command_address + 4);
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtlV(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_name.c_str());
-  Memory::Write_U32(IPC_SUCCESS, command_address + 4);
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.h
@@ -15,8 +15,8 @@ class CWII_IPC_HLE_Device_stub : public IWII_IPC_HLE_Device
 public:
   CWII_IPC_HLE_Device_stub(u32 device_id, const std::string& device_name);
 
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force = false) override;
-  IPCCommandResult IOCtl(u32 command_address) override;
-  IPCCommandResult IOCtlV(u32 command_address) override;
+  IOSReturnCode Open(IOSResourceOpenRequest& request) override;
+  void Close() override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
@@ -54,7 +54,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_base::IOCtl(u32 command_add
 {
   // NeoGamma (homebrew) is known to use this path.
   ERROR_LOG(WII_IPC_WIIMOTE, "Bad IOCtl to /dev/usb/oh1/57e/305");
-  Memory::Write_U32(FS_EINVAL, command_address + 4);
+  Memory::Write_U32(IPC_EINVAL, command_address + 4);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
@@ -50,32 +50,31 @@ void RestoreBTInfoSection(SysConf* sysconf)
   File::Delete(filename);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_base::IOCtl(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_base::IOCtl(IOSResourceIOCtlRequest& request)
 {
   // NeoGamma (homebrew) is known to use this path.
   ERROR_LOG(WII_IPC_WIIMOTE, "Bad IOCtl to /dev/usb/oh1/57e/305");
-  Memory::Write_U32(IPC_EINVAL, command_address + 4);
+  request.SetReturnValue(IPC_EINVAL);
   return GetDefaultReply();
 }
 
-CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlMessage::CtrlMessage(const SIOCtlVBuffer& cmd_buffer)
+CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlMessage::CtrlMessage(IOSResourceIOCtlVRequest& ioctlv)
+    : ios_request(ioctlv)
 {
-  request_type = Memory::Read_U8(cmd_buffer.InBuffer[0].m_Address);
-  request = Memory::Read_U8(cmd_buffer.InBuffer[1].m_Address);
-  value = Common::swap16(Memory::Read_U16(cmd_buffer.InBuffer[2].m_Address));
-  index = Common::swap16(Memory::Read_U16(cmd_buffer.InBuffer[3].m_Address));
-  length = Common::swap16(Memory::Read_U16(cmd_buffer.InBuffer[4].m_Address));
-  payload_addr = cmd_buffer.PayloadBuffer[0].m_Address;
-  address = cmd_buffer.m_Address;
+  request_type = Memory::Read_U8(ioctlv.in_vectors[0].addr);
+  request = Memory::Read_U8(ioctlv.in_vectors[1].addr);
+  value = Common::swap16(Memory::Read_U16(ioctlv.in_vectors[2].addr));
+  index = Common::swap16(Memory::Read_U16(ioctlv.in_vectors[3].addr));
+  length = Common::swap16(Memory::Read_U16(ioctlv.in_vectors[4].addr));
+  payload_addr = ioctlv.io_vectors[0].addr;
 }
 
-CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::CtrlBuffer(const SIOCtlVBuffer& cmd_buffer,
-                                                                 const u32 command_address)
+CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::CtrlBuffer(IOSResourceIOCtlVRequest& ioctlv)
+    : ios_request(ioctlv)
 {
-  m_endpoint = Memory::Read_U8(cmd_buffer.InBuffer[0].m_Address);
-  m_length = Memory::Read_U16(cmd_buffer.InBuffer[1].m_Address);
-  m_payload_addr = cmd_buffer.PayloadBuffer[0].m_Address;
-  m_cmd_address = command_address;
+  m_endpoint = Memory::Read_U8(ioctlv.in_vectors[0].addr);
+  m_length = Memory::Read_U16(ioctlv.in_vectors[1].addr);
+  m_payload_addr = ioctlv.io_vectors[0].addr;
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::FillBuffer(const u8* src,
@@ -84,9 +83,4 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::FillBuffer(const u8* 
   _assert_msg_(WII_IPC_WIIMOTE, size <= m_length, "FillBuffer: size %li > payload length %i", size,
                m_length);
   Memory::CopyToEmu(m_payload_addr, src, size);
-}
-
-void CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::SetRetVal(const u32 retval) const
-{
-  Memory::Write_U32(retval, m_cmd_address + 4);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
@@ -24,15 +24,11 @@ public:
       : IWII_IPC_HLE_Device(device_id, device_name)
   {
   }
-  virtual ~CWII_IPC_HLE_Device_usb_oh1_57e_305_base() override = default;
 
-  virtual IPCCommandResult Open(u32 command_address, u32 mode) override = 0;
-  virtual IPCCommandResult Close(u32 command_address, bool force) override = 0;
-  IPCCommandResult IOCtl(u32 command_address) override;
-  virtual IPCCommandResult IOCtlV(u32 command_address) override = 0;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
+  virtual IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override = 0;
 
   virtual void DoState(PointerWrap& p) override = 0;
-  virtual u32 Update() override = 0;
 
   virtual void UpdateSyncButtonState(bool is_held) {}
   virtual void TriggerSyncButtonPressedEvent() {}
@@ -60,31 +56,23 @@ protected:
 
   struct CtrlMessage
   {
-    CtrlMessage() = default;
-    CtrlMessage(const SIOCtlVBuffer& cmd_buffer);
-
+    CtrlMessage(IOSResourceIOCtlVRequest& ioctlv);
+    IOSResourceIOCtlVRequest ios_request;
     u8 request_type = 0;
     u8 request = 0;
     u16 value = 0;
     u16 index = 0;
     u16 length = 0;
     u32 payload_addr = 0;
-    u32 address = 0;
   };
 
-  class CtrlBuffer
+  struct CtrlBuffer
   {
-  public:
-    CtrlBuffer() = default;
-    CtrlBuffer(const SIOCtlVBuffer& cmd_buffer, u32 command_address);
-
+    CtrlBuffer(IOSResourceIOCtlVRequest& ioctlv);
+    IOSResourceIOCtlVRequest ios_request;
     void FillBuffer(const u8* src, size_t size) const;
-    void SetRetVal(const u32 retval) const;
-    bool IsValid() const { return m_cmd_address != 0; }
-    void Invalidate() { m_cmd_address = m_payload_addr = 0; }
     u8 m_endpoint = 0;
     u16 m_length = 0;
     u32 m_payload_addr = 0;
-    u32 m_cmd_address = 0;
   };
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -123,7 +123,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::DoState(PointerWrap& p)
     return;
   }
 
-  p.Do(m_Active);
+  p.Do(m_is_active);
   p.Do(m_ControllerBD);
   p.Do(m_CtrlSetup);
   p.Do(m_ACLSetup);
@@ -154,7 +154,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Open(u32 _CommandAddre
   m_HCIEndpoint.m_cmd_address = 0;
   m_ACLEndpoint.m_cmd_address = 0;
 
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -168,7 +168,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Close(u32 _CommandAddr
   m_HCIEndpoint.m_cmd_address = 0;
   m_ACLEndpoint.m_cmd_address = 0;
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -168,8 +168,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Close(u32 _CommandAddr
   m_HCIEndpoint.m_cmd_address = 0;
   m_ACLEndpoint.m_cmd_address = 0;
 
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -154,7 +154,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Open(u32 _CommandAddre
   m_HCIEndpoint.m_cmd_address = 0;
   m_ACLEndpoint.m_cmd_address = 0;
 
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -176,7 +176,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::IOCtl(u32 _CommandAddr
 {
   // NeoGamma (homebrew) is known to use this path.
   ERROR_LOG(WII_IPC_WIIMOTE, "Bad IOCtl in CWII_IPC_HLE_Device_usb_oh1_57e_305");
-  Memory::Write_U32(FS_EINVAL, _CommandAddress + 4);
+  Memory::Write_U32(IPC_EINVAL, _CommandAddress + 4);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -101,8 +101,6 @@ CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::CWII_IPC_HLE_Device_usb_oh1_57e_305_emu
   m_ControllerBD.b[4] = 0x00;
   m_ControllerBD.b[5] = 0xFF;
 
-  memset(m_PacketCount, 0, sizeof(m_PacketCount));
-
   Host_SetWiiMoteConnectionState(0);
 }
 
@@ -110,6 +108,18 @@ CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::~CWII_IPC_HLE_Device_usb_oh1_57e_305_em
 {
   m_WiiMotes.clear();
   SetUsbPointer(nullptr);
+}
+
+template <typename T>
+static void DoStateForMessage(PointerWrap& p, std::unique_ptr<T>& message)
+{
+  u32 request_address = (message != nullptr) ? message->ios_request.address : 0;
+  p.Do(request_address);
+  if (request_address != 0)
+  {
+    IOSResourceIOCtlVRequest request{request_address};
+    message = std::make_unique<T>(request);
+  }
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::DoState(PointerWrap& p)
@@ -125,10 +135,9 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::DoState(PointerWrap& p)
 
   p.Do(m_is_active);
   p.Do(m_ControllerBD);
-  p.Do(m_CtrlSetup);
-  p.Do(m_ACLSetup);
-  p.DoPOD(m_HCIEndpoint);
-  p.DoPOD(m_ACLEndpoint);
+  DoStateForMessage(p, m_CtrlSetup);
+  DoStateForMessage(p, m_HCIEndpoint);
+  DoStateForMessage(p, m_ACLEndpoint);
   p.Do(m_last_ticks);
   p.DoArray(m_PacketCount);
   p.Do(m_ScanEnable);
@@ -144,83 +153,41 @@ bool CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::RemoteDisconnect(u16 _connectionHa
   return SendEventDisconnect(_connectionHandle, 0x13);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Open(u32 _CommandAddress, u32 _Mode)
+void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Close()
 {
+  // Clean up state
   m_ScanEnable = 0;
-
   m_last_ticks = 0;
   memset(m_PacketCount, 0, sizeof(m_PacketCount));
-
-  m_HCIEndpoint.m_cmd_address = 0;
-  m_ACLEndpoint.m_cmd_address = 0;
-
-  m_is_active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Close(u32 _CommandAddress, bool _bForce)
-{
-  m_ScanEnable = 0;
-
-  m_last_ticks = 0;
-  memset(m_PacketCount, 0, sizeof(m_PacketCount));
-
-  m_HCIEndpoint.m_cmd_address = 0;
-  m_ACLEndpoint.m_cmd_address = 0;
+  m_HCIEndpoint.reset();
+  m_ACLEndpoint.reset();
 
   m_is_active = false;
-  return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
-  // NeoGamma (homebrew) is known to use this path.
-  ERROR_LOG(WII_IPC_WIIMOTE, "Bad IOCtl in CWII_IPC_HLE_Device_usb_oh1_57e_305");
-  Memory::Write_U32(IPC_EINVAL, _CommandAddress + 4);
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::IOCtlV(u32 _CommandAddress)
-{
-  bool _SendReply = false;
-
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
-
-  switch (CommandBuffer.Parameter)
+  bool send_reply = true;
+  switch (request.request)
   {
   case USBV0_IOCTL_CTRLMSG:  // HCI command is received from the stack
   {
-    // This is the HCI datapath from CPU to Wii Remote, the USB stuff is little endian..
-    m_CtrlSetup.bRequestType = *(u8*)Memory::GetPointer(CommandBuffer.InBuffer[0].m_Address);
-    m_CtrlSetup.bRequest = *(u8*)Memory::GetPointer(CommandBuffer.InBuffer[1].m_Address);
-    m_CtrlSetup.wValue = *(u16*)Memory::GetPointer(CommandBuffer.InBuffer[2].m_Address);
-    m_CtrlSetup.wIndex = *(u16*)Memory::GetPointer(CommandBuffer.InBuffer[3].m_Address);
-    m_CtrlSetup.wLength = *(u16*)Memory::GetPointer(CommandBuffer.InBuffer[4].m_Address);
-    m_CtrlSetup.m_PayLoadAddr = CommandBuffer.PayloadBuffer[0].m_Address;
-    m_CtrlSetup.m_PayLoadSize = CommandBuffer.PayloadBuffer[0].m_Size;
-    m_CtrlSetup.m_Address = CommandBuffer.m_Address;
-
-    // check termination
-    _dbg_assert_msg_(WII_IPC_WIIMOTE,
-                     *(u8*)Memory::GetPointer(CommandBuffer.InBuffer[5].m_Address) == 0,
-                     "WIIMOTE: Termination != 0");
-
+    m_CtrlSetup = std::make_unique<CtrlMessage>(request);
     // Replies are generated inside
-    ExecuteHCICommandMessage(m_CtrlSetup);
+    ExecuteHCICommandMessage(*m_CtrlSetup);
+    m_CtrlSetup.reset();
+    send_reply = false;
+    break;
   }
-  break;
 
   case USBV0_IOCTL_BLKMSG:
   {
-    const CtrlBuffer ctrl(CommandBuffer, _CommandAddress);
+    const CtrlBuffer ctrl{request};
     switch (ctrl.m_endpoint)
     {
     case ACL_DATA_OUT:  // ACL data is received from the stack
     {
       // This is the ACL datapath from CPU to Wii Remote
-      // Here we only need to record the command address in case we need to delay the reply
-      m_ACLSetup = CommandBuffer.m_Address;
-
       const auto* acl_header =
           reinterpret_cast<hci_acldata_hdr_t*>(Memory::GetPointer(ctrl.m_payload_addr));
 
@@ -230,69 +197,44 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::IOCtlV(u32 _CommandAdd
       SendToDevice(HCI_CON_HANDLE(acl_header->con_handle),
                    Memory::GetPointer(ctrl.m_payload_addr + sizeof(hci_acldata_hdr_t)),
                    acl_header->length);
-
-      _SendReply = true;
+      break;
     }
-    break;
-
     case ACL_DATA_IN:  // We are given an ACL buffer to fill
     {
-      CtrlBuffer temp(CommandBuffer, _CommandAddress);
-      m_ACLEndpoint = temp;
-
-      DEBUG_LOG(WII_IPC_WIIMOTE, "ACL_DATA_IN: 0x%08x ", _CommandAddress);
+      m_ACLEndpoint = std::make_unique<CtrlBuffer>(request);
+      DEBUG_LOG(WII_IPC_WIIMOTE, "ACL_DATA_IN: 0x%08x ", request.address);
+      send_reply = false;
+      break;
     }
-    break;
-
     default:
-    {
       _dbg_assert_msg_(WII_IPC_WIIMOTE, 0, "Unknown USBV0_IOCTL_BLKMSG: %x", ctrl.m_endpoint);
     }
     break;
-    }
   }
-  break;
 
   case USBV0_IOCTL_INTRMSG:
   {
-    const CtrlBuffer ctrl(CommandBuffer, _CommandAddress);
+    const CtrlBuffer ctrl{request};
     if (ctrl.m_endpoint == HCI_EVENT)  // We are given a HCI buffer to fill
     {
-      CtrlBuffer temp(CommandBuffer, _CommandAddress);
-      m_HCIEndpoint = temp;
-
-      DEBUG_LOG(WII_IPC_WIIMOTE, "HCI_EVENT: 0x%08x ", _CommandAddress);
+      m_HCIEndpoint = std::make_unique<CtrlBuffer>(request);
+      DEBUG_LOG(WII_IPC_WIIMOTE, "HCI_EVENT: 0x%08x ", request.address);
+      send_reply = false;
     }
     else
     {
       _dbg_assert_msg_(WII_IPC_WIIMOTE, 0, "Unknown USBV0_IOCTL_INTRMSG: %x", ctrl.m_endpoint);
     }
+    break;
   }
-  break;
 
   default:
-  {
-    _dbg_assert_msg_(WII_IPC_WIIMOTE, 0, "Unknown CWII_IPC_HLE_Device_usb_oh1_57e_305: %x",
-                     CommandBuffer.Parameter);
-
-    INFO_LOG(WII_IPC_WIIMOTE, "%s - IOCtlV:", GetDeviceName().c_str());
-    INFO_LOG(WII_IPC_WIIMOTE, "    Parameter: 0x%x", CommandBuffer.Parameter);
-    INFO_LOG(WII_IPC_WIIMOTE, "    NumberIn: 0x%08x", CommandBuffer.NumberInBuffer);
-    INFO_LOG(WII_IPC_WIIMOTE, "    NumberOut: 0x%08x", CommandBuffer.NumberPayloadBuffer);
-    INFO_LOG(WII_IPC_WIIMOTE, "    BufferVector: 0x%08x", CommandBuffer.BufferVector);
-    INFO_LOG(WII_IPC_WIIMOTE, "    PayloadAddr: 0x%08x", CommandBuffer.PayloadBuffer[0].m_Address);
-    INFO_LOG(WII_IPC_WIIMOTE, "    PayloadSize: 0x%08x", CommandBuffer.PayloadBuffer[0].m_Size);
-#if defined(_DEBUG) || defined(DEBUGFAST)
-    DumpAsync(CommandBuffer.BufferVector, CommandBuffer.NumberInBuffer,
-              CommandBuffer.NumberPayloadBuffer);
-#endif
-  }
-  break;
+    _assert_msg_(WII_IPC_WIIMOTE, 0, "Unknown IOCtlV: %x", request.request);
+    request.Dump(GetDeviceName(), LogTypes::WII_IPC_WIIMOTE, LogTypes::LWARNING);
   }
 
-  // write return value
-  Memory::Write_U32(0, _CommandAddress + 4);
-  return _SendReply ? GetDefaultReply() : GetNoReply();
+  request.SetReturnValue(IPC_SUCCESS);
+  return send_reply ? GetDefaultReply() : GetNoReply();
 }
 
 // Here we handle the USBV0_IOCTL_BLKMSG Ioctlv
@@ -320,22 +262,22 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::SendACLPacket(u16 connection_handl
 {
   DEBUG_LOG(WII_IPC_WIIMOTE, "ACL packet from %x ready to send to stack...", connection_handle);
 
-  if (m_ACLEndpoint.IsValid() && !m_HCIEndpoint.IsValid() && m_EventQueue.empty())
+  if (m_ACLEndpoint && !m_HCIEndpoint && m_EventQueue.empty())
   {
     DEBUG_LOG(WII_IPC_WIIMOTE, "ACL endpoint valid, sending packet to %08x",
-              m_ACLEndpoint.m_cmd_address);
+              m_ACLEndpoint->ios_request.address);
 
     hci_acldata_hdr_t* header =
-        reinterpret_cast<hci_acldata_hdr_t*>(Memory::GetPointer(m_ACLEndpoint.m_payload_addr));
+        reinterpret_cast<hci_acldata_hdr_t*>(Memory::GetPointer(m_ACLEndpoint->m_payload_addr));
     header->con_handle = HCI_MK_CON_HANDLE(connection_handle, HCI_PACKET_START, HCI_POINT2POINT);
     header->length = size;
 
     // Write the packet to the buffer
     memcpy(reinterpret_cast<u8*>(header) + sizeof(hci_acldata_hdr_t), data, header->length);
 
-    m_ACLEndpoint.SetRetVal(sizeof(hci_acldata_hdr_t) + size);
-    WII_IPC_HLE_Interface::EnqueueReply(m_ACLEndpoint.m_cmd_address);
-    m_ACLEndpoint.Invalidate();
+    m_ACLEndpoint->ios_request.SetReturnValue(sizeof(hci_acldata_hdr_t) + size);
+    WII_IPC_HLE_Interface::EnqueueReply(m_ACLEndpoint->ios_request);
+    m_ACLEndpoint.reset();
   }
   else
   {
@@ -354,17 +296,17 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::AddEventToQueue(const SQueuedEvent
   DEBUG_LOG(WII_IPC_WIIMOTE, "HCI event %x completed...",
             ((hci_event_hdr_t*)_event.m_buffer)->event);
 
-  if (m_HCIEndpoint.IsValid())
+  if (m_HCIEndpoint)
   {
     if (m_EventQueue.empty())  // fast path :)
     {
       DEBUG_LOG(WII_IPC_WIIMOTE, "HCI endpoint valid, sending packet to %08x",
-                m_HCIEndpoint.m_cmd_address);
-      m_HCIEndpoint.FillBuffer(_event.m_buffer, _event.m_size);
-      m_HCIEndpoint.SetRetVal(_event.m_size);
+                m_HCIEndpoint->ios_request.address);
+      m_HCIEndpoint->FillBuffer(_event.m_buffer, _event.m_size);
+      m_HCIEndpoint->ios_request.SetReturnValue(_event.m_size);
       // Send a reply to indicate HCI buffer is filled
-      WII_IPC_HLE_Interface::EnqueueReply(m_HCIEndpoint.m_cmd_address);
-      m_HCIEndpoint.Invalidate();
+      WII_IPC_HLE_Interface::EnqueueReply(m_HCIEndpoint->ios_request);
+      m_HCIEndpoint.reset();
     }
     else  // push new one, pop oldest
     {
@@ -375,12 +317,12 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::AddEventToQueue(const SQueuedEvent
       DEBUG_LOG(WII_IPC_WIIMOTE, "HCI event %x "
                                  "being written from queue (%zu) to %08x...",
                 ((hci_event_hdr_t*)event.m_buffer)->event, m_EventQueue.size() - 1,
-                m_HCIEndpoint.m_cmd_address);
-      m_HCIEndpoint.FillBuffer(event.m_buffer, event.m_size);
-      m_HCIEndpoint.SetRetVal(event.m_size);
+                m_HCIEndpoint->ios_request.address);
+      m_HCIEndpoint->FillBuffer(event.m_buffer, event.m_size);
+      m_HCIEndpoint->ios_request.SetReturnValue(event.m_size);
       // Send a reply to indicate HCI buffer is filled
-      WII_IPC_HLE_Interface::EnqueueReply(m_HCIEndpoint.m_cmd_address);
-      m_HCIEndpoint.Invalidate();
+      WII_IPC_HLE_Interface::EnqueueReply(m_HCIEndpoint->ios_request);
+      m_HCIEndpoint.reset();
       m_EventQueue.pop_front();
     }
   }
@@ -397,26 +339,27 @@ u32 CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Update()
   bool packet_transferred = false;
 
   // check HCI queue
-  if (!m_EventQueue.empty() && m_HCIEndpoint.IsValid())
+  if (!m_EventQueue.empty() && m_HCIEndpoint)
   {
     // an endpoint has become available, and we have a stored response.
     const SQueuedEvent& event = m_EventQueue.front();
     DEBUG_LOG(WII_IPC_WIIMOTE, "HCI event %x being written from queue (%zu) to %08x...",
               ((hci_event_hdr_t*)event.m_buffer)->event, m_EventQueue.size() - 1,
-              m_HCIEndpoint.m_cmd_address);
-    m_HCIEndpoint.FillBuffer(event.m_buffer, event.m_size);
-    m_HCIEndpoint.SetRetVal(event.m_size);
+              m_HCIEndpoint->ios_request.address);
+    m_HCIEndpoint->FillBuffer(event.m_buffer, event.m_size);
+    m_HCIEndpoint->ios_request.SetReturnValue(event.m_size);
     // Send a reply to indicate HCI buffer is filled
-    WII_IPC_HLE_Interface::EnqueueReply(m_HCIEndpoint.m_cmd_address);
-    m_HCIEndpoint.Invalidate();
+    WII_IPC_HLE_Interface::EnqueueReply(m_HCIEndpoint->ios_request);
+    m_HCIEndpoint.reset();
     m_EventQueue.pop_front();
     packet_transferred = true;
   }
 
   // check ACL queue
-  if (!m_acl_pool.IsEmpty() && m_ACLEndpoint.IsValid() && m_EventQueue.empty())
+  if (!m_acl_pool.IsEmpty() && m_ACLEndpoint && m_EventQueue.empty())
   {
-    m_acl_pool.WriteToEndpoint(m_ACLEndpoint);
+    m_acl_pool.WriteToEndpoint(*m_ACLEndpoint);
+    m_ACLEndpoint.reset();
     packet_transferred = true;
   }
 
@@ -426,7 +369,7 @@ u32 CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Update()
   // FiRES: TODO find a better way to do this
 
   // Create ACL connection
-  if (m_HCIEndpoint.IsValid() && (m_ScanEnable & HCI_PAGE_SCAN_ENABLE))
+  if (m_HCIEndpoint && (m_ScanEnable & HCI_PAGE_SCAN_ENABLE))
   {
     for (auto& wiimote : m_WiiMotes)
     {
@@ -439,7 +382,7 @@ u32 CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Update()
   }
 
   // Link channels when connected
-  if (m_ACLEndpoint.IsValid())
+  if (m_ACLEndpoint)
   {
     for (auto& wiimote : m_WiiMotes)
     {
@@ -495,7 +438,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::ACLPool::WriteToEndpoint(CtrlBuffe
 
   DEBUG_LOG(WII_IPC_WIIMOTE, "ACL packet being written from "
                              "queue to %08x",
-            endpoint.m_cmd_address);
+            endpoint.ios_request.address);
 
   hci_acldata_hdr_t* pHeader = (hci_acldata_hdr_t*)Memory::GetPointer(endpoint.m_payload_addr);
   pHeader->con_handle = HCI_MK_CON_HANDLE(conn_handle, HCI_PACKET_START, HCI_POINT2POINT);
@@ -504,12 +447,11 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::ACLPool::WriteToEndpoint(CtrlBuffe
   // Write the packet to the buffer
   std::copy(data, data + size, (u8*)pHeader + sizeof(hci_acldata_hdr_t));
 
-  endpoint.SetRetVal(sizeof(hci_acldata_hdr_t) + size);
+  endpoint.ios_request.SetReturnValue(sizeof(hci_acldata_hdr_t) + size);
 
   m_queue.pop_front();
 
-  WII_IPC_HLE_Interface::EnqueueReply(endpoint.m_cmd_address);
-  endpoint.Invalidate();
+  WII_IPC_HLE_Interface::EnqueueReply(endpoint.ios_request);
 }
 
 bool CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::SendEventInquiryComplete()
@@ -1049,10 +991,10 @@ bool CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::SendEventConPacketTypeChange(u16 _
 // Command dispatcher
 // This is called from the USBV0_IOCTL_CTRLMSG Ioctlv
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::ExecuteHCICommandMessage(
-    const SHCICommandMessage& _rHCICommandMessage)
+    const CtrlMessage& ctrl_message)
 {
-  u8* pInput = Memory::GetPointer(_rHCICommandMessage.m_PayLoadAddr + 3);
-  SCommandMessage* pMsg = (SCommandMessage*)Memory::GetPointer(_rHCICommandMessage.m_PayLoadAddr);
+  u8* pInput = Memory::GetPointer(ctrl_message.payload_addr + 3);
+  SCommandMessage* pMsg = (SCommandMessage*)Memory::GetPointer(ctrl_message.payload_addr);
 
   u16 ocf = HCI_OCF(pMsg->Opcode);
   u16 ogf = HCI_OGF(pMsg->Opcode);
@@ -1136,11 +1078,11 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::ExecuteHCICommandMessage(
 
   // vendor specific...
   case 0xFC4C:
-    CommandVendorSpecific_FC4C(pInput, _rHCICommandMessage.m_PayLoadSize - 3);
+    CommandVendorSpecific_FC4C(pInput, ctrl_message.length - 3);
     break;
 
   case 0xFC4F:
-    CommandVendorSpecific_FC4F(pInput, _rHCICommandMessage.m_PayLoadSize - 3);
+    CommandVendorSpecific_FC4F(pInput, ctrl_message.length - 3);
     break;
 
   case HCI_CMD_INQUIRY_CANCEL:
@@ -1229,7 +1171,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::ExecuteHCICommandMessage(
   }
 
   // HCI command is finished, send a reply to command
-  WII_IPC_HLE_Interface::EnqueueReply(_rHCICommandMessage.m_Address);
+  WII_IPC_HLE_Interface::EnqueueReply(ctrl_message.ios_request);
 }
 
 //

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <memory>
 #include <queue>
 #include <string>
 #include <vector>
@@ -43,11 +44,8 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_usb_oh1_57e_305_emu();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  void Close() override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
   u32 Update() override;
 
@@ -63,30 +61,15 @@ public:
   void DoState(PointerWrap& p) override;
 
 private:
-  struct SHCICommandMessage
-  {
-    u8 bRequestType;
-    u8 bRequest;
-    u16 wValue;
-    u16 wIndex;
-    u16 wLength;
-
-    u32 m_PayLoadAddr;
-    u32 m_PayLoadSize;
-    u32 m_Address;
-  };
-
   bdaddr_t m_ControllerBD;
 
   // this is used to trigger connecting via ACL
   u8 m_ScanEnable = 0;
 
-  SHCICommandMessage m_CtrlSetup;
-  CtrlBuffer m_HCIEndpoint;
+  std::unique_ptr<CtrlMessage> m_CtrlSetup;
+  std::unique_ptr<CtrlBuffer> m_HCIEndpoint;
+  std::unique_ptr<CtrlBuffer> m_ACLEndpoint;
   std::deque<SQueuedEvent> m_EventQueue;
-
-  u32 m_ACLSetup;
-  CtrlBuffer m_ACLEndpoint;
 
   class ACLPool
   {
@@ -110,7 +93,7 @@ private:
     void DoState(PointerWrap& p) { p.Do(m_queue); }
   } m_acl_pool;
 
-  u32 m_PacketCount[MAX_BBMOTES];
+  u32 m_PacketCount[MAX_BBMOTES] = {};
   u64 m_last_ticks = 0;
 
   // Send ACL data to a device (wiimote)
@@ -139,7 +122,7 @@ private:
   bool SendEventLinkKeyNotification(const u8 num_to_send);
 
   // Execute HCI Message
-  void ExecuteHCICommandMessage(const SHCICommandMessage& _rCtrlMessage);
+  void ExecuteHCICommandMessage(const CtrlMessage& ctrl_message);
 
   // OGF 0x01 - Link control commands and return parameters
   void CommandWriteInquiryMode(const u8* input);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -141,7 +141,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Open(u32 command_addr
 
   StartTransferThread();
 
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -155,7 +155,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Close(u32 command_add
     m_handle = nullptr;
   }
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -153,7 +153,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Close(u32 command_add
     StopTransferThread();
     libusb_unref_device(m_device);
     m_handle = nullptr;
-    Memory::Write_U32(0, command_address + 4);
   }
 
   m_Active = false;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -141,7 +141,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Open(u32 command_addr
 
   StartTransferThread();
 
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -18,6 +18,7 @@
 
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"
+#include "Common/CommonFuncs.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/Network.h"
@@ -89,7 +90,7 @@ CWII_IPC_HLE_Device_usb_oh1_57e_305_real::~CWII_IPC_HLE_Device_usb_oh1_57e_305_r
   SaveLinkKeys();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Open(u32 command_address, u32 mode)
+IOSReturnCode CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Open(IOSResourceOpenRequest& request)
 {
   libusb_device** list;
   const ssize_t cnt = libusb_get_device_list(m_libusb_context, &list);
@@ -136,18 +137,18 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Open(u32 command_addr
     PanicAlertT("Bluetooth passthrough mode is enabled, "
                 "but no usable Bluetooth USB device was found. Aborting.");
     Core::QueueHostJob(Core::Stop);
-    return GetNoReply();
+    return IPC_ENOENT;
   }
 
   StartTransferThread();
 
   m_is_active = true;
-  return GetDefaultReply();
+  return IPC_SUCCESS;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Close(u32 command_address, bool force)
+void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Close()
 {
-  if (!force)
+  if (m_handle)
   {
     libusb_release_interface(m_handle, 0);
     StopTransferThread();
@@ -156,10 +157,9 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Close(u32 command_add
   }
 
   m_is_active = false;
-  return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::IOCtlV(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
   if (!m_is_wii_bt_module && s_need_reset_keys.TestAndClear())
   {
@@ -170,14 +170,13 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::IOCtlV(u32 command_ad
       WaitForHCICommandComplete(HCI_CMD_WRITE_STORED_LINK_KEY);
   }
 
-  const SIOCtlVBuffer cmd_buffer(command_address);
-  switch (cmd_buffer.Parameter)
+  switch (request.request)
   {
   // HCI commands to the Bluetooth adapter
   case USBV0_IOCTL_CTRLMSG:
   {
-    auto cmd = std::make_unique<CtrlMessage>(cmd_buffer);
-    const u16 opcode = *reinterpret_cast<u16*>(Memory::GetPointer(cmd->payload_addr));
+    auto cmd = std::make_unique<CtrlMessage>(request);
+    const u16 opcode = Common::swap16(Memory::Read_U16(cmd->payload_addr));
     if (opcode == HCI_CMD_READ_BUFFER_SIZE)
     {
       m_fake_read_buffer_size_reply.Set();
@@ -220,25 +219,24 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::IOCtlV(u32 command_ad
   case USBV0_IOCTL_BLKMSG:
   case USBV0_IOCTL_INTRMSG:
   {
-    auto buffer = std::make_unique<CtrlBuffer>(cmd_buffer, command_address);
-    if (cmd_buffer.Parameter == USBV0_IOCTL_INTRMSG && m_fake_read_buffer_size_reply.TestAndClear())
+    auto buffer = std::make_unique<CtrlBuffer>(request);
+    if (request.request == USBV0_IOCTL_INTRMSG && m_fake_read_buffer_size_reply.TestAndClear())
     {
       FakeReadBufferSizeReply(*buffer);
       return GetNoReply();
     }
-    if (cmd_buffer.Parameter == USBV0_IOCTL_INTRMSG && m_fake_vendor_command_reply.TestAndClear())
+    if (request.request == USBV0_IOCTL_INTRMSG && m_fake_vendor_command_reply.TestAndClear())
     {
       FakeVendorCommandReply(*buffer);
       return GetNoReply();
     }
-    if (cmd_buffer.Parameter == USBV0_IOCTL_INTRMSG &&
-        m_sync_button_state == SyncButtonState::Pressed)
+    if (request.request == USBV0_IOCTL_INTRMSG && m_sync_button_state == SyncButtonState::Pressed)
     {
       Core::DisplayMessage("Scanning for Wii Remotes", 2000);
       FakeSyncButtonPressedEvent(*buffer);
       return GetNoReply();
     }
-    if (cmd_buffer.Parameter == USBV0_IOCTL_INTRMSG &&
+    if (request.request == USBV0_IOCTL_INTRMSG &&
         m_sync_button_state == SyncButtonState::LongPressed)
     {
       Core::DisplayMessage("Reset saved Wii Remote pairings", 2000);
@@ -253,8 +251,8 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::IOCtlV(u32 command_ad
     transfer->flags |= LIBUSB_TRANSFER_FREE_TRANSFER;
     transfer->length = buffer->m_length;
     transfer->timeout = TIMEOUT;
-    transfer->type = cmd_buffer.Parameter == USBV0_IOCTL_BLKMSG ? LIBUSB_TRANSFER_TYPE_BULK :
-                                                                  LIBUSB_TRANSFER_TYPE_INTERRUPT;
+    transfer->type = request.request == USBV0_IOCTL_BLKMSG ? LIBUSB_TRANSFER_TYPE_BULK :
+                                                             LIBUSB_TRANSFER_TYPE_INTERRUPT;
     transfer->user_data = buffer.release();
     libusb_submit_transfer(transfer);
     break;
@@ -387,7 +385,7 @@ bool CWII_IPC_HLE_Device_usb_oh1_57e_305_real::SendHCIStoreLinkKeyCommand()
   return true;
 }
 
-void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeVendorCommandReply(const CtrlBuffer& ctrl)
+void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeVendorCommandReply(CtrlBuffer& ctrl)
 {
   u8* packet = Memory::GetPointer(ctrl.m_payload_addr);
   auto* hci_event = reinterpret_cast<SHCIEventCommand*>(packet);
@@ -395,8 +393,8 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeVendorCommandReply(const Ctrl
   hci_event->PayloadLength = sizeof(SHCIEventCommand) - 2;
   hci_event->PacketIndicator = 0x01;
   hci_event->Opcode = m_fake_vendor_command_reply_opcode;
-  ctrl.SetRetVal(sizeof(SHCIEventCommand));
-  WII_IPC_HLE_Interface::EnqueueReply(ctrl.m_cmd_address);
+  ctrl.ios_request.SetReturnValue(sizeof(SHCIEventCommand));
+  WII_IPC_HLE_Interface::EnqueueReply(ctrl.ios_request);
 }
 
 // Due to how the widcomm stack which Nintendo uses is coded, we must never
@@ -404,7 +402,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeVendorCommandReply(const Ctrl
 // - it will cause a u8 underflow and royally screw things up.
 // Therefore, the reply to this command has to be faked to avoid random, weird issues
 // (including Wiimote disconnects and "event mismatch" warning messages).
-void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeReadBufferSizeReply(const CtrlBuffer& ctrl)
+void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeReadBufferSizeReply(CtrlBuffer& ctrl)
 {
   u8* packet = Memory::GetPointer(ctrl.m_payload_addr);
   auto* hci_event = reinterpret_cast<SHCIEventCommand*>(packet);
@@ -421,11 +419,11 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeReadBufferSizeReply(const Ctr
   reply.num_sco_pkts = SCO_PKT_NUM;
 
   memcpy(packet + sizeof(SHCIEventCommand), &reply, sizeof(hci_read_buffer_size_rp));
-  ctrl.SetRetVal(sizeof(SHCIEventCommand) + sizeof(hci_read_buffer_size_rp));
-  WII_IPC_HLE_Interface::EnqueueReply(ctrl.m_cmd_address);
+  ctrl.ios_request.SetReturnValue(sizeof(SHCIEventCommand) + sizeof(hci_read_buffer_size_rp));
+  WII_IPC_HLE_Interface::EnqueueReply(ctrl.ios_request);
 }
 
-void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonEvent(const CtrlBuffer& ctrl,
+void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonEvent(CtrlBuffer& ctrl,
                                                                    const u8* payload, const u8 size)
 {
   u8* packet = Memory::GetPointer(ctrl.m_payload_addr);
@@ -433,15 +431,15 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonEvent(const CtrlBuf
   hci_event->event = HCI_EVENT_VENDOR;
   hci_event->length = size;
   memcpy(packet + sizeof(hci_event_hdr_t), payload, size);
-  ctrl.SetRetVal(sizeof(hci_event_hdr_t) + size);
-  WII_IPC_HLE_Interface::EnqueueReply(ctrl.m_cmd_address);
+  ctrl.ios_request.SetReturnValue(sizeof(hci_event_hdr_t) + size);
+  WII_IPC_HLE_Interface::EnqueueReply(ctrl.ios_request);
 }
 
 // When the red sync button is pressed, a HCI event is generated:
 //   > HCI Event: Vendor (0xff) plen 1
 //   08
 // This causes the emulated software to perform a BT inquiry and connect to found Wiimotes.
-void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonPressedEvent(const CtrlBuffer& ctrl)
+void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonPressedEvent(CtrlBuffer& ctrl)
 {
   NOTICE_LOG(WII_IPC_WIIMOTE, "Faking 'sync button pressed' (0x08) event packet");
   const u8 payload[1] = {0x08};
@@ -450,7 +448,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonPressedEvent(const 
 }
 
 // When the red sync button is held for 10 seconds, a HCI event with payload 09 is sent.
-void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonHeldEvent(const CtrlBuffer& ctrl)
+void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonHeldEvent(CtrlBuffer& ctrl)
 {
   NOTICE_LOG(WII_IPC_WIIMOTE, "Faking 'sync button held' (0x09) event packet");
   const u8 payload[1] = {0x09};
@@ -580,7 +578,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::CommandCallback(libusb_transfer* 
     s_showed_failed_transfer.Clear();
   }
 
-  WII_IPC_HLE_Interface::EnqueueReply(cmd->address, 0, CoreTiming::FromThread::NON_CPU);
+  WII_IPC_HLE_Interface::EnqueueReply(cmd->ios_request, 0, CoreTiming::FromThread::NON_CPU);
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::TransferCallback(libusb_transfer* tr)
@@ -624,6 +622,6 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::TransferCallback(libusb_transfer*
     }
   }
 
-  ctrl->SetRetVal(tr->actual_length);
-  WII_IPC_HLE_Interface::EnqueueReply(ctrl->m_cmd_address, 0, CoreTiming::FromThread::NON_CPU);
+  ctrl->ios_request.SetReturnValue(tr->actual_length);
+  WII_IPC_HLE_Interface::EnqueueReply(ctrl->ios_request, 0, CoreTiming::FromThread::NON_CPU);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
@@ -42,12 +42,11 @@ public:
   CWII_IPC_HLE_Device_usb_oh1_57e_305_real(u32 device_id, const std::string& device_name);
   ~CWII_IPC_HLE_Device_usb_oh1_57e_305_real() override;
 
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force) override;
-  IPCCommandResult IOCtlV(u32 command_address) override;
+  IOSReturnCode Open(IOSResourceOpenRequest& request) override;
+  void Close() override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
 
   void DoState(PointerWrap& p) override;
-  u32 Update() override { return 0; }
   void UpdateSyncButtonState(bool is_held) override;
   void TriggerSyncButtonPressedEvent() override;
   void TriggerSyncButtonHeldEvent() override;
@@ -81,11 +80,11 @@ private:
   void SendHCIResetCommand();
   void SendHCIDeleteLinkKeyCommand();
   bool SendHCIStoreLinkKeyCommand();
-  void FakeVendorCommandReply(const CtrlBuffer& ctrl);
-  void FakeReadBufferSizeReply(const CtrlBuffer& ctrl);
-  void FakeSyncButtonEvent(const CtrlBuffer& ctrl, const u8* payload, u8 size);
-  void FakeSyncButtonPressedEvent(const CtrlBuffer& ctrl);
-  void FakeSyncButtonHeldEvent(const CtrlBuffer& ctrl);
+  void FakeVendorCommandReply(CtrlBuffer& ctrl);
+  void FakeReadBufferSizeReply(CtrlBuffer& ctrl);
+  void FakeSyncButtonEvent(CtrlBuffer& ctrl, const u8* payload, u8 size);
+  void FakeSyncButtonPressedEvent(CtrlBuffer& ctrl);
+  void FakeSyncButtonHeldEvent(CtrlBuffer& ctrl);
 
   void LoadLinkKeys();
   void SaveLinkKeys();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.cpp
@@ -12,11 +12,11 @@ namespace Core
 void DisplayMessage(const std::string& message, int time_in_ms);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_stub::Open(u32 command_address, u32 mode)
+IOSReturnCode CWII_IPC_HLE_Device_usb_oh1_57e_305_stub::Open(IOSResourceOpenRequest& request)
 {
   PanicAlertT("Bluetooth passthrough mode is enabled, but Dolphin was built without libusb."
               " Passthrough mode cannot be used.");
-  return GetNoReply();
+  return IPC_ENOENT;
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_stub::DoState(PointerWrap& p)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.h
@@ -16,15 +16,11 @@ class CWII_IPC_HLE_Device_usb_oh1_57e_305_stub final
     : public CWII_IPC_HLE_Device_usb_oh1_57e_305_base
 {
 public:
-  CWII_IPC_HLE_Device_usb_oh1_57e_305_stub(u32 device_id, const std::string& device_name)
+  CWII_IPC_HLE_Device_usb_oh1_57e_305_stub(const u32 device_id, const std::string& device_name)
       : CWII_IPC_HLE_Device_usb_oh1_57e_305_base(device_id, device_name)
   {
   }
-  ~CWII_IPC_HLE_Device_usb_oh1_57e_305_stub() override {}
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force) override { return GetNoReply(); }
-  IPCCommandResult IOCtl(u32 command_address) override { return GetDefaultReply(); }
-  IPCCommandResult IOCtlV(u32 command_address) override { return GetNoReply(); }
+  IOSReturnCode Open(IOSResourceOpenRequest& request) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override { return GetDefaultReply(); }
   void DoState(PointerWrap& p) override;
-  u32 Update() override { return 0; }
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -67,8 +67,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _b
   INFO_LOG(WII_IPC_HLE, "CWII_IPC_HLE_Device_usb_kbd: Close");
   while (!m_MessageQueue.empty())
     m_MessageQueue.pop();
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -57,8 +57,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Open(u32 _CommandAddress, u32 _Mod
   m_OldModifiers = 0x00;
 
   // m_MessageQueue.push(SMessageData(MSG_KBD_CONNECT, 0, nullptr));
-  Memory::Write_U32(m_DeviceID, _CommandAddress + 4);
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -67,7 +66,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _b
   INFO_LOG(WII_IPC_HLE, "CWII_IPC_HLE_Device_usb_kbd: Close");
   while (!m_MessageQueue.empty())
     m_MessageQueue.pop();
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 
@@ -109,7 +108,7 @@ bool CWII_IPC_HLE_Device_usb_kbd::IsKeyPressed(int _Key)
 
 u32 CWII_IPC_HLE_Device_usb_kbd::Update()
 {
-  if (!SConfig::GetInstance().m_WiiKeyboard || Core::g_want_determinism || !m_Active)
+  if (!SConfig::GetInstance().m_WiiKeyboard || Core::g_want_determinism || !m_is_active)
     return 0;
 
   u8 Modifiers = 0x00;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -42,13 +42,14 @@ CWII_IPC_HLE_Device_usb_kbd::~CWII_IPC_HLE_Device_usb_kbd()
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Open(u32 _CommandAddress, u32 _Mode)
+IOSReturnCode CWII_IPC_HLE_Device_usb_kbd::Open(IOSResourceOpenRequest& request)
 {
   INFO_LOG(WII_IPC_HLE, "CWII_IPC_HLE_Device_usb_kbd: Open");
   IniFile ini;
   ini.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
   ini.GetOrCreateSection("USB Keyboard")->Get("Layout", &m_KeyboardLayout, KBD_LAYOUT_QWERTY);
 
+  m_MessageQueue = std::queue<SMessageData>();
   for (bool& pressed : m_OldKeyBuffer)
   {
     pressed = false;
@@ -58,38 +59,17 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Open(u32 _CommandAddress, u32 _Mod
 
   // m_MessageQueue.push(SMessageData(MSG_KBD_CONNECT, 0, nullptr));
   m_is_active = true;
-  return GetDefaultReply();
+  return IPC_SUCCESS;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _bForce)
+IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::IOCtl(IOSResourceIOCtlRequest& request)
 {
-  INFO_LOG(WII_IPC_HLE, "CWII_IPC_HLE_Device_usb_kbd: Close");
-  while (!m_MessageQueue.empty())
-    m_MessageQueue.pop();
-  m_is_active = false;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Write(u32 _CommandAddress)
-{
-  DEBUG_LOG(WII_IPC_HLE, "Ignoring write to CWII_IPC_HLE_Device_usb_kbd");
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  DumpCommands(_CommandAddress, 10, LogTypes::WII_IPC_HLE, LogTypes::LDEBUG);
-#endif
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::IOCtl(u32 _CommandAddress)
-{
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-
   if (SConfig::GetInstance().m_WiiKeyboard && !Core::g_want_determinism && !m_MessageQueue.empty())
   {
-    Memory::CopyToEmu(BufferOut, &m_MessageQueue.front(), sizeof(SMessageData));
+    Memory::CopyToEmu(request.out_addr, &m_MessageQueue.front(), sizeof(SMessageData));
     m_MessageQueue.pop();
   }
-
-  Memory::Write_U32(0, _CommandAddress + 0x4);
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
@@ -17,10 +17,8 @@ public:
   CWII_IPC_HLE_Device_usb_kbd(u32 _DeviceID, const std::string& _rDeviceName);
   virtual ~CWII_IPC_HLE_Device_usb_kbd();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-  IPCCommandResult Write(u32 _CommandAddress) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  IOSReturnCode Open(IOSResourceOpenRequest& request) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
   u32 Update() override;
 
 private:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
@@ -18,7 +18,6 @@ CWII_IPC_HLE_Device_usb_ven::~CWII_IPC_HLE_Device_usb_ven()
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_ven::Open(u32 command_address, u32 mode)
 {
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
@@ -16,21 +16,6 @@ CWII_IPC_HLE_Device_usb_ven::~CWII_IPC_HLE_Device_usb_ven()
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_ven::Open(u32 command_address, u32 mode)
-{
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_usb_ven::Close(u32 command_address, bool force)
-{
-  if (!force)
-    Memory::Write_U32(0, command_address + 4);
-
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtlV(u32 command_address)
 {
   SIOCtlVBuffer command_buffer(command_address);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
@@ -12,42 +12,23 @@ CWII_IPC_HLE_Device_usb_ven::CWII_IPC_HLE_Device_usb_ven(const u32 device_id,
 {
 }
 
-CWII_IPC_HLE_Device_usb_ven::~CWII_IPC_HLE_Device_usb_ven()
+IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtlV(IOSResourceIOCtlVRequest& request)
 {
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtlV(u32 command_address)
-{
-  SIOCtlVBuffer command_buffer(command_address);
-
-  INFO_LOG(OSHLE, "%s - IOCtlV:", GetDeviceName().c_str());
-  INFO_LOG(OSHLE, "  Parameter: 0x%x", command_buffer.Parameter);
-  INFO_LOG(OSHLE, "  NumberIn: 0x%08x", command_buffer.NumberInBuffer);
-  INFO_LOG(OSHLE, "  NumberOut: 0x%08x", command_buffer.NumberPayloadBuffer);
-  INFO_LOG(OSHLE, "  BufferVector: 0x%08x", command_buffer.BufferVector);
-  DumpAsync(command_buffer.BufferVector, command_buffer.NumberInBuffer,
-            command_buffer.NumberPayloadBuffer);
-
-  Memory::Write_U32(0, command_address + 4);
+  request.Dump(GetDeviceName());
+  request.SetReturnValue(IPC_SUCCESS);
   return GetNoReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(IOSResourceIOCtlRequest& request)
 {
+  request.Log(GetDeviceName(), LogTypes::OSHLE);
+  request.SetReturnValue(IPC_SUCCESS);
+
   IPCCommandResult reply = GetDefaultReply();
-  u32 command = Memory::Read_U32(command_address + 0x0c);
-  u32 buffer_in = Memory::Read_U32(command_address + 0x10);
-  u32 buffer_in_size = Memory::Read_U32(command_address + 0x14);
-  u32 buffer_out = Memory::Read_U32(command_address + 0x18);
-  u32 buffer_out_size = Memory::Read_U32(command_address + 0x1c);
-
-  INFO_LOG(OSHLE, "%s - IOCtl: %x", GetDeviceName().c_str(), command);
-  INFO_LOG(OSHLE, "%x:%x %x:%x", buffer_in, buffer_in_size, buffer_out, buffer_out_size);
-
-  switch (command)
+  switch (request.request)
   {
   case USBV5_IOCTL_GETVERSION:
-    Memory::Write_U32(0x50001, buffer_out);
+    Memory::Write_U32(0x50001, request.out_addr);
     reply = GetDefaultReply();
     break;
 
@@ -62,7 +43,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(u32 command_address)
     }
 
     // num devices
-    Memory::Write_U32(0, command_address + 4);
+    request.SetReturnValue(0);
     return reply;
   }
   break;
@@ -72,33 +53,28 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(u32 command_address)
     break;
 
   case USBV5_IOCTL_SUSPEND_RESUME:
-    DEBUG_LOG(OSHLE, "Device: %i Resumed: %i", Memory::Read_U32(buffer_in),
-              Memory::Read_U32(buffer_in + 4));
+    DEBUG_LOG(OSHLE, "Device: %i Resumed: %i", Memory::Read_U32(request.in_addr),
+              Memory::Read_U32(request.in_addr + 4));
     reply = GetDefaultReply();
     break;
 
   case USBV5_IOCTL_GETDEVPARAMS:
   {
-    s32 device = Memory::Read_U32(buffer_in);
-    u32 unk = Memory::Read_U32(buffer_in + 4);
+    s32 device = Memory::Read_U32(request.in_addr);
+    u32 unk = Memory::Read_U32(request.in_addr + 4);
 
     DEBUG_LOG(OSHLE, "USBV5_IOCTL_GETDEVPARAMS device: %i unk: %i", device, unk);
 
-    Memory::Write_U32(0, buffer_out);
+    Memory::Write_U32(0, request.out_addr);
 
     reply = GetDefaultReply();
   }
   break;
 
   default:
-    DEBUG_LOG(OSHLE, "%x:%x %x:%x", buffer_in, buffer_in_size, buffer_out, buffer_out_size);
+    DEBUG_LOG(OSHLE, "%x:%x %x:%x", request.in_addr, request.in_size, request.out_addr,
+              request.out_size);
     break;
   }
-
-  Memory::Write_U32(0, command_address + 4);
   return reply;
-}
-
-void CWII_IPC_HLE_Device_usb_ven::DoState(PointerWrap& p)
-{
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
@@ -19,9 +19,6 @@ public:
 
   ~CWII_IPC_HLE_Device_usb_ven() override;
 
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force) override;
-
   IPCCommandResult IOCtlV(u32 command_address) override;
   IPCCommandResult IOCtl(u32 command_address) override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
@@ -10,19 +10,13 @@
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
-class PointerWrap;
-
 class CWII_IPC_HLE_Device_usb_ven final : public IWII_IPC_HLE_Device
 {
 public:
   CWII_IPC_HLE_Device_usb_ven(u32 device_id, const std::string& device_name);
 
-  ~CWII_IPC_HLE_Device_usb_ven() override;
-
-  IPCCommandResult IOCtlV(u32 command_address) override;
-  IPCCommandResult IOCtl(u32 command_address) override;
-
-  void DoState(PointerWrap& p) override;
+  IPCCommandResult IOCtlV(IOSResourceIOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(IOSResourceIOCtlRequest& request) override;
 
 private:
   enum USBIOCtl

--- a/Source/Core/Core/IPC_HLE/WII_Socket.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.cpp
@@ -187,28 +187,23 @@ void WiiSocket::Update(bool read, bool write, bool except)
   {
     s32 ReturnValue = 0;
     bool forceNonBlock = false;
-    IPCCommandType ct = static_cast<IPCCommandType>(Memory::Read_U32(it->_CommandAddress));
+    IPCCommandType ct = it->request.command;
     if (!it->is_ssl && ct == IPC_CMD_IOCTL)
     {
-      u32 BufferIn = Memory::Read_U32(it->_CommandAddress + 0x10);
-      u32 BufferInSize = Memory::Read_U32(it->_CommandAddress + 0x14);
-      u32 BufferOut = Memory::Read_U32(it->_CommandAddress + 0x18);
-      u32 BufferOutSize = Memory::Read_U32(it->_CommandAddress + 0x1C);
-
+      IOSResourceIOCtlRequest ioctl{it->request.address};
       switch (it->net_type)
       {
       case IOCTL_SO_FCNTL:
       {
-        u32 cmd = Memory::Read_U32(BufferIn + 4);
-        u32 arg = Memory::Read_U32(BufferIn + 8);
+        u32 cmd = Memory::Read_U32(ioctl.in_addr + 4);
+        u32 arg = Memory::Read_U32(ioctl.in_addr + 8);
         ReturnValue = FCntl(cmd, arg);
         break;
       }
       case IOCTL_SO_BIND:
       {
-        // u32 has_addr = Memory::Read_U32(BufferIn + 0x04);
         sockaddr_in local_name;
-        WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(BufferIn + 0x08);
+        WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(ioctl.in_addr + 8);
         WiiSockMan::Convert(*wii_name, local_name);
 
         int ret = bind(fd, (sockaddr*)&local_name, sizeof(local_name));
@@ -220,9 +215,8 @@ void WiiSocket::Update(bool read, bool write, bool except)
       }
       case IOCTL_SO_CONNECT:
       {
-        // u32 has_addr = Memory::Read_U32(BufferIn + 0x04);
         sockaddr_in local_name;
-        WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(BufferIn + 0x08);
+        WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(ioctl.in_addr + 8);
         WiiSockMan::Convert(*wii_name, local_name);
 
         int ret = connect(fd, (sockaddr*)&local_name, sizeof(local_name));
@@ -234,10 +228,10 @@ void WiiSocket::Update(bool read, bool write, bool except)
       }
       case IOCTL_SO_ACCEPT:
       {
-        if (BufferOutSize > 0)
+        if (ioctl.out_size > 0)
         {
           sockaddr_in local_name;
-          WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(BufferOut);
+          WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(ioctl.out_addr);
           WiiSockMan::Convert(*wii_name, local_name);
 
           socklen_t addrlen = sizeof(sockaddr_in);
@@ -256,8 +250,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
 
         INFO_LOG(WII_IPC_NET, "IOCTL_SO_ACCEPT "
                               "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-                 BufferIn, BufferInSize, BufferOut, BufferOutSize);
-
+                 ioctl.in_addr, ioctl.in_size, ioctl.out_addr, ioctl.out_size);
         break;
       }
       default:
@@ -275,34 +268,34 @@ void WiiSocket::Update(bool read, bool write, bool except)
     }
     else if (ct == IPC_CMD_IOCTLV)
     {
-      SIOCtlVBuffer CommandBuffer(it->_CommandAddress);
+      IOSResourceIOCtlVRequest ioctlv{it->request.address};
       u32 BufferIn = 0, BufferIn2 = 0;
       u32 BufferInSize = 0, BufferInSize2 = 0;
       u32 BufferOut = 0, BufferOut2 = 0;
       u32 BufferOutSize = 0, BufferOutSize2 = 0;
 
-      if (CommandBuffer.InBuffer.size() > 0)
+      if (ioctlv.in_vectors.size() > 0)
       {
-        BufferIn = CommandBuffer.InBuffer.at(0).m_Address;
-        BufferInSize = CommandBuffer.InBuffer.at(0).m_Size;
+        BufferIn = ioctlv.in_vectors.at(0).addr;
+        BufferInSize = ioctlv.in_vectors.at(0).size;
       }
 
-      if (CommandBuffer.PayloadBuffer.size() > 0)
+      if (ioctlv.io_vectors.size() > 0)
       {
-        BufferOut = CommandBuffer.PayloadBuffer.at(0).m_Address;
-        BufferOutSize = CommandBuffer.PayloadBuffer.at(0).m_Size;
+        BufferOut = ioctlv.io_vectors.at(0).addr;
+        BufferOutSize = ioctlv.io_vectors.at(0).size;
       }
 
-      if (CommandBuffer.PayloadBuffer.size() > 1)
+      if (ioctlv.io_vectors.size() > 1)
       {
-        BufferOut2 = CommandBuffer.PayloadBuffer.at(1).m_Address;
-        BufferOutSize2 = CommandBuffer.PayloadBuffer.at(1).m_Size;
+        BufferOut2 = ioctlv.io_vectors.at(1).addr;
+        BufferOutSize2 = ioctlv.io_vectors.at(1).size;
       }
 
-      if (CommandBuffer.InBuffer.size() > 1)
+      if (ioctlv.in_vectors.size() > 1)
       {
-        BufferIn2 = CommandBuffer.InBuffer.at(1).m_Address;
-        BufferInSize2 = CommandBuffer.InBuffer.at(1).m_Size;
+        BufferIn2 = ioctlv.in_vectors.at(1).addr;
+        BufferInSize2 = ioctlv.in_vectors.at(1).size;
       }
 
       if (it->is_ssl)
@@ -576,8 +569,8 @@ void WiiSocket::Update(bool read, bool write, bool except)
                 "IOCTL(V) Sock: %08x ioctl/v: %d returned: %d nonBlock: %d forceNonBlock: %d", fd,
                 it->is_ssl ? (int)it->ssl_type : (int)it->net_type, ReturnValue, nonBlock,
                 forceNonBlock);
-      Memory::Write_U32(ReturnValue, it->_CommandAddress + 4);
-      WII_IPC_HLE_Interface::EnqueueReply(it->_CommandAddress);
+      it->request.SetReturnValue(ReturnValue);
+      WII_IPC_HLE_Interface::EnqueueReply(it->request);
       it = pending_sockops.erase(it);
     }
     else
@@ -587,16 +580,16 @@ void WiiSocket::Update(bool read, bool write, bool except)
   }
 }
 
-void WiiSocket::DoSock(u32 _CommandAddress, NET_IOCTL type)
+void WiiSocket::DoSock(IOSResourceRequest request, NET_IOCTL type)
 {
-  sockop so = {_CommandAddress, false};
+  sockop so = {request, false};
   so.net_type = type;
   pending_sockops.push_back(so);
 }
 
-void WiiSocket::DoSock(u32 _CommandAddress, SSL_IOCTL type)
+void WiiSocket::DoSock(IOSResourceRequest request, SSL_IOCTL type)
 {
-  sockop so = {_CommandAddress, true};
+  sockop so = {request, true};
   so.ssl_type = type;
   pending_sockops.push_back(so);
 }

--- a/Source/Core/Core/IPC_HLE/WII_Socket.h
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.h
@@ -172,7 +172,7 @@ class WiiSocket
 {
   struct sockop
   {
-    u32 _CommandAddress;
+    IOSResourceRequest request;
     bool is_ssl;
     union {
       NET_IOCTL net_type;
@@ -190,8 +190,8 @@ private:
   s32 CloseFd();
   s32 FCntl(u32 cmd, u32 arg);
 
-  void DoSock(u32 _CommandAddress, NET_IOCTL type);
-  void DoSock(u32 _CommandAddress, SSL_IOCTL type);
+  void DoSock(IOSResourceRequest request, NET_IOCTL type);
+  void DoSock(IOSResourceRequest request, SSL_IOCTL type);
   void Update(bool read, bool write, bool except);
   bool IsValid() const { return fd >= 0; }
 public:
@@ -222,19 +222,19 @@ public:
   void SetLastNetError(s32 error) { errno_last = error; }
   void Clean() { WiiSockets.clear(); }
   template <typename T>
-  void DoSock(s32 sock, u32 CommandAddress, T type)
+  void DoSock(s32 sock, IOSResourceRequest& request, T type)
   {
     auto socket_entry = WiiSockets.find(sock);
     if (socket_entry == WiiSockets.end())
     {
-      ERROR_LOG(WII_IPC_NET, "DoSock: Error, fd not found (%08x, %08X, %08X)", sock, CommandAddress,
-                type);
-      Memory::Write_U32(-SO_EBADF, CommandAddress + 4);
-      WII_IPC_HLE_Interface::EnqueueReply(CommandAddress);
+      ERROR_LOG(WII_IPC_NET, "DoSock: Error, fd not found (%08x, %08X, %08X)", sock,
+                request.address, type);
+      request.SetReturnValue(-SO_EBADF);
+      WII_IPC_HLE_Interface::EnqueueReply(request);
     }
     else
     {
-      socket_entry->second.DoSock(CommandAddress, type);
+      socket_entry->second.DoSock(request, type);
     }
   }
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 65;  // Last changed in PR 4120
+static const u32 STATE_VERSION = 66;  // Last changed in PR 4488
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
The first commit refactors ExecuteCommand to be less confusing and to not have duplicate checks; fyi there was a bug that caused the HBC homebrew launches to fail (and which was fixed only a few days ago in 288e75f), because the device check was duplicated inside of each `switch` case.

The second commit is a straightforward unused defines/naming cleanup.

The third and fifth remove dead/useless code duplicated all over IOS HLE; namely, the Open()/Close() methods. A lot of IOS device classes simply changed m_Active, wrote a return code to the emulated memory and returned a default reply… which resulted in loads of duplicated code, especially since that's what the base class methods already do…  (And it's been this way since the initial megacommit, but as years passed on, more devices were added, which meant more copy-and-pasted code.)

Another problem is that the devices' Open() method used GetDeviceID() and wrote its return value to the IOS return code, as if it were a IOS fd. It looks like that may have been true at one point, but that's definitely not the case anymore, so I have removed it because that is just both confusing (especially as someone who didn't have any experience with IOS HLE) and unnecessary.

The eighth commit deduplicates the resource parsing/reply code. Instead of doing memory reads/writes manually, command handlers are now passed parsed structs, which clarifies things like setting the return value.

The last commit drops GetPointer usages in the whole IPC_HLE code – except in USB code, since that's going to be replaced in #4408 anyway – to prepare for locking. These are replaced either with Memory::Read/Write/CopyFromEmu/CopyToEmu directly, and helper wrappers around them for ioctls and IO vectors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4488)
<!-- Reviewable:end -->
