### PR TITLE
Vulkan: Minor fixes

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
@@ -184,7 +184,6 @@ public:
 
 private:
   std::unique_ptr<TextureCache::TCacheEntry> m_texture;
-  VkFramebuffer m_framebuffer;
 };
 
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -661,8 +661,15 @@ void Renderer::DrawScreen(const EFBRectangle& source_rect, u32 xfb_addr,
   VkResult res = m_swap_chain->AcquireNextImage(m_image_available_semaphore);
   if (res == VK_SUBOPTIMAL_KHR || res == VK_ERROR_OUT_OF_DATE_KHR)
   {
-    // Window has been resized. Update the swap chain and try again.
+    // There's an issue here. We can't resize the swap chain while the GPU is still busy with it,
+    // but calling WaitForGPUIdle would create a deadlock as PrepareToSubmitCommandBuffer has been
+    // called by SwapImpl. WaitForGPUIdle waits on the semaphore, which PrepareToSubmitCommandBuffer
+    // has already done, so it blocks indefinitely. To work around this, we submit the current
+    // command buffer, resize the swap chain (which calls WaitForGPUIdle), and then finally call
+    // PrepareToSubmitCommandBuffer to return to the state that the caller expects.
+    g_command_buffer_mgr->SubmitCommandBuffer(false);
     ResizeSwapChain();
+    g_command_buffer_mgr->PrepareToSubmitCommandBuffer();
     res = m_swap_chain->AcquireNextImage(m_image_available_semaphore);
   }
   if (res != VK_SUCCESS)

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -669,7 +669,7 @@ bool TextureCache::TCacheEntry::Save(const std::string& filename, unsigned int l
   Util::ExecuteCurrentCommandsAndRestoreState(false, true);
 
   // Map the staging texture so we can copy the contents out.
-  if (staging_texture->Map())
+  if (!staging_texture->Map())
   {
     PanicAlert("Failed to map staging texture");
     return false;

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -294,7 +294,7 @@ void VulkanContext::PopulateBackendInfoMultisampleModes(
   VkSampleCountFlags supported_sample_counts = properties.limits.framebufferColorSampleCounts &
                                                properties.limits.framebufferDepthSampleCounts &
                                                efb_color_properties.sampleCounts &
-                                               efb_color_properties.sampleCounts;
+                                               efb_depth_properties.sampleCounts;
 
   // No AA
   config->backend_info.AAModes.clear();

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -268,10 +268,10 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   // Disable geometry shader when shaderTessellationAndGeometryPointSize is not supported.
   // Seems this is needed for gl_Layer.
   if (!features.shaderTessellationAndGeometryPointSize)
+  {
     config->backend_info.bSupportsGeometryShaders = VK_FALSE;
-
-  // TODO: Investigate if there's a feature we can enable for GS instancing.
-  config->backend_info.bSupportsGSInstancing = VK_FALSE;
+    config->backend_info.bSupportsGSInstancing = VK_FALSE;
+  }
 
   // Depth clamping implies shaderClipDistance and depthClamp
   config->backend_info.bSupportsDepthClamp =

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -82,10 +82,11 @@ bool VulkanContext::CheckValidationLayerAvailablility()
           }) != layer_list.end());
 }
 
-VkInstance VulkanContext::CreateVulkanInstance(bool enable_surface, bool enable_validation_layer)
+VkInstance VulkanContext::CreateVulkanInstance(bool enable_surface, bool enable_debug_report,
+                                               bool enable_validation_layer)
 {
   ExtensionList enabled_extensions;
-  if (!SelectInstanceExtensions(&enabled_extensions, enable_surface, enable_validation_layer))
+  if (!SelectInstanceExtensions(&enabled_extensions, enable_surface, enable_debug_report))
     return VK_NULL_HANDLE;
 
   VkApplicationInfo app_info = {};
@@ -127,7 +128,7 @@ VkInstance VulkanContext::CreateVulkanInstance(bool enable_surface, bool enable_
 }
 
 bool VulkanContext::SelectInstanceExtensions(ExtensionList* extension_list, bool enable_surface,
-                                             bool enable_validation_layer)
+                                             bool enable_debug_report)
 {
   u32 extension_count = 0;
   VkResult res = vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr);
@@ -192,8 +193,8 @@ bool VulkanContext::SelectInstanceExtensions(ExtensionList* extension_list, bool
 #endif
 
   // VK_EXT_debug_report
-  if (enable_validation_layer && !CheckForExtension(VK_EXT_DEBUG_REPORT_EXTENSION_NAME, true))
-    return false;
+  if (enable_debug_report && !CheckForExtension(VK_EXT_DEBUG_REPORT_EXTENSION_NAME, true))
+    WARN_LOG(VIDEO, "Vulkan: Debug report requested, but extension is not available.");
 
   return true;
 }
@@ -327,6 +328,7 @@ void VulkanContext::PopulateBackendInfoMultisampleModes(
 
 std::unique_ptr<VulkanContext> VulkanContext::Create(VkInstance instance, VkPhysicalDevice gpu,
                                                      VkSurfaceKHR surface, VideoConfig* config,
+                                                     bool enable_debug_reports,
                                                      bool enable_validation_layer)
 {
   std::unique_ptr<VulkanContext> context = std::make_unique<VulkanContext>(instance, gpu);
@@ -338,8 +340,8 @@ std::unique_ptr<VulkanContext> VulkanContext::Create(VkInstance instance, VkPhys
                       static_cast<double>(context->m_device_properties.driverVersion),
                       DriverDetails::Family::UNKNOWN);
 
-  // Enable debug reports if validation layer is enabled.
-  if (enable_validation_layer)
+  // Enable debug reports if the "Host GPU" log category is enabled.
+  if (enable_debug_reports)
     context->EnableDebugReports();
 
   // Attempt to create the device.
@@ -358,8 +360,7 @@ std::unique_ptr<VulkanContext> VulkanContext::Create(VkInstance instance, VkPhys
   return context;
 }
 
-bool VulkanContext::SelectDeviceExtensions(ExtensionList* extension_list, bool enable_surface,
-                                           bool enable_validation_layer)
+bool VulkanContext::SelectDeviceExtensions(ExtensionList* extension_list, bool enable_surface)
 {
   u32 extension_count = 0;
   VkResult res =
@@ -405,9 +406,7 @@ bool VulkanContext::SelectDeviceExtensions(ExtensionList* extension_list, bool e
   };
 
   if (enable_surface && !CheckForExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME, true))
-  {
     return false;
-  }
 
   return true;
 }
@@ -527,8 +526,7 @@ bool VulkanContext::CreateDevice(VkSurfaceKHR surface, bool enable_validation_la
   device_info.pQueueCreateInfos = &queue_info;
 
   ExtensionList enabled_extensions;
-  if (!SelectDeviceExtensions(&enabled_extensions, (surface != VK_NULL_HANDLE),
-                              enable_validation_layer))
+  if (!SelectDeviceExtensions(&enabled_extensions, surface != VK_NULL_HANDLE))
     return false;
 
   device_info.enabledLayerCount = 0;

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.h
@@ -23,7 +23,8 @@ public:
   static bool CheckValidationLayerAvailablility();
 
   // Helper method to create a Vulkan instance.
-  static VkInstance CreateVulkanInstance(bool enable_surface, bool enable_validation_layer);
+  static VkInstance CreateVulkanInstance(bool enable_surface, bool enable_debug_report,
+                                         bool enable_validation_layer);
 
   // Returns a list of Vulkan-compatible GPUs.
   using GPUList = std::vector<VkPhysicalDevice>;
@@ -43,10 +44,10 @@ public:
   // been called for the specified VideoConfig.
   static std::unique_ptr<VulkanContext> Create(VkInstance instance, VkPhysicalDevice gpu,
                                                VkSurfaceKHR surface, VideoConfig* config,
+                                               bool enable_debug_reports,
                                                bool enable_validation_layer);
 
   // Enable/disable debug message runtime.
-  // In the future this could be hooked up to the Host GPU logging option.
   bool EnableDebugReports();
   void DisableDebugReports();
 
@@ -106,9 +107,8 @@ public:
 private:
   using ExtensionList = std::vector<const char*>;
   static bool SelectInstanceExtensions(ExtensionList* extension_list, bool enable_surface,
-                                       bool enable_validation_layer);
-  bool SelectDeviceExtensions(ExtensionList* extension_list, bool enable_surface,
-                              bool enable_validation_layer);
+                                       bool enable_debug_report);
+  bool SelectDeviceExtensions(ExtensionList* extension_list, bool enable_surface);
   bool SelectDeviceFeatures();
   bool CreateDevice(VkSurfaceKHR surface, bool enable_validation_layer);
 


### PR DESCRIPTION
Fixes some really minor copy/paste errors and texture dumping.

I've only experienced the resize deadlock on the anv driver, but it should be fixed now.

Debug reports can now be logged by Dolphin by booting the game with the Host GPU logging option checked. Not much gets logged in my experience without the validation layers enabled, but this may help debugging in some scenarios in the future without the overhead of the validation layers, or where they're not available (e.g. Android).

Lastly, enables geometry shader instancing, not sure why I had this disabled in the initial PR, it seems to work fine.