### PR TITLE
DolphinWX: Add ability to filter symbols (by name)

### DIFF
--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -78,8 +78,13 @@ CCodeWindow::CCodeWindow(CFrame* parent, wxWindowID id, const wxPoint& position,
   wxSearchCtrl* const address_searchctrl = new wxSearchCtrl(m_aui_toolbar, IDM_ADDRBOX);
   address_searchctrl->Bind(wxEVT_TEXT, &CCodeWindow::OnAddrBoxChange, this);
   address_searchctrl->SetDescriptiveText(_("Search Address"));
+  m_symbol_filter_ctrl = new wxSearchCtrl(m_aui_toolbar, wxID_ANY);
+  m_symbol_filter_ctrl->Bind(wxEVT_TEXT, &CCodeWindow::OnSymbolFilterText, this);
+  m_symbol_filter_ctrl->SetDescriptiveText(_("Filter Symbols"));
+  m_symbol_filter_ctrl->SetToolTip(_("Filter the symbol list by name. This is case-sensitive."));
 
   m_aui_toolbar->AddControl(address_searchctrl);
+  m_aui_toolbar->AddControl(m_symbol_filter_ctrl);
   m_aui_toolbar->Realize();
 
   m_aui_manager.SetManagedWindow(this);
@@ -258,6 +263,11 @@ void CCodeWindow::OnAddrBoxChange(wxCommandEvent& event)
   pAddrCtrl->Refresh();
 
   event.Skip();
+}
+
+void CCodeWindow::OnSymbolFilterText(wxCommandEvent&)
+{
+  ReloadSymbolListBox();
 }
 
 void CCodeWindow::OnCallstackListChange(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.h
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.h
@@ -28,6 +28,7 @@ class DolphinAuiToolBar;
 class wxListBox;
 class wxMenu;
 class wxMenuBar;
+class wxSearchCtrl;
 class wxToolBar;
 
 namespace Details
@@ -132,6 +133,7 @@ private:
 
   void OnCodeStep(wxCommandEvent& event);
   void OnAddrBoxChange(wxCommandEvent& event);
+  void OnSymbolFilterText(wxCommandEvent& event);
   void OnSymbolsMenu(wxCommandEvent& event);
   void OnJitMenu(wxCommandEvent& event);
   void OnProfilerMenu(wxCommandEvent& event);
@@ -153,6 +155,8 @@ private:
   void UpdateLists();
   void UpdateCallstack();
 
+  void ReloadSymbolListBox();
+
   wxPanel* CreateSiblingPanel(int id);
 
   // Sibling debugger panels
@@ -161,6 +165,7 @@ private:
 
   CFrame* Parent;
   CCodeView* codeview;
+  wxSearchCtrl* m_symbol_filter_ctrl;
   wxListBox* callstack;
   wxListBox* symbols;
   wxListBox* callers;

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -14,6 +14,7 @@
 #include <wx/listbox.h>
 #include <wx/menu.h>
 #include <wx/mimetype.h>
+#include <wx/srchctrl.h>
 #include <wx/textdlg.h>
 
 #include "Common/CommonPaths.h"
@@ -398,20 +399,28 @@ void CCodeWindow::OnSymbolsMenu(wxCommandEvent& event)
   }
 }
 
+void CCodeWindow::ReloadSymbolListBox()
+{
+  symbols->Freeze();  // HyperIris: wx style fast filling
+  symbols->Clear();
+  const wxString filtering_string = m_symbol_filter_ctrl->GetValue().Trim().Trim(false);
+  for (const auto& symbol : g_symbolDB.Symbols())
+  {
+    if (symbol.second.name.find(filtering_string) == std::string::npos)
+      continue;
+    int idx = symbols->Append(StrToWxStr(symbol.second.name));
+    symbols->SetClientData(idx, (void*)&symbol.second);
+  }
+  symbols->Thaw();
+}
+
 void CCodeWindow::NotifyMapLoaded()
 {
   if (!codeview)
     return;
 
   g_symbolDB.FillInCallers();
-  symbols->Freeze();  // HyperIris: wx style fast filling
-  symbols->Clear();
-  for (const auto& symbol : g_symbolDB.Symbols())
-  {
-    int idx = symbols->Append(StrToWxStr(symbol.second.name));
-    symbols->SetClientData(idx, (void*)&symbol.second);
-  }
-  symbols->Thaw();
+  ReloadSymbolListBox();
   Repopulate();
 }
 


### PR DESCRIPTION
This allows the user to filter symbols by name, instead of having to scroll through a very, very long listbox…

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4491)
<!-- Reviewable:end -->
