### PR TITLE
Move the GameCube mic button configuration to the GameCube config dialog

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -24,8 +24,7 @@ static const u16 trigger_bitmasks[] = {
 static const u16 dpad_bitmasks[] = {PAD_BUTTON_UP, PAD_BUTTON_DOWN, PAD_BUTTON_LEFT,
                                     PAD_BUTTON_RIGHT};
 
-static const char* const named_buttons[] = {"A",          "B", "X", "Y", "Z", _trans("Start"),
-                                            _trans("Mic")};
+static const char* const named_buttons[] = {"A", "B", "X", "Y", "Z", _trans("Start")};
 
 static const char* const named_triggers[] = {
     // i18n: The left trigger button (labeled L on real controllers)
@@ -39,11 +38,9 @@ static const char* const named_triggers[] = {
 
 GCPad::GCPad(const unsigned int index) : m_index(index)
 {
-  int const mic_hax = index > 1;
-
   // buttons
   groups.emplace_back(m_buttons = new Buttons(_trans("Buttons")));
-  for (unsigned int i = 0; i < sizeof(named_buttons) / sizeof(*named_buttons) - mic_hax; ++i)
+  for (unsigned int i = 0; i < sizeof(named_buttons) / sizeof(*named_buttons); ++i)
     m_buttons->controls.emplace_back(new ControlGroup::Input(named_buttons[i]));
 
   // sticks
@@ -60,6 +57,10 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
   // rumble
   groups.emplace_back(m_rumble = new ControlGroup(_trans("Rumble")));
   m_rumble->controls.emplace_back(new ControlGroup::Output(_trans("Motor")));
+
+  // Microphone
+  groups.emplace_back(m_mic = new Buttons(_trans("Microphone")));
+  m_mic->controls.emplace_back(new ControlGroup::Input(_trans("Button")));
 
   // dpad
   groups.emplace_back(m_dpad = new Buttons(_trans("D-Pad")));
@@ -95,6 +96,8 @@ ControllerEmu::ControlGroup* GCPad::GetGroup(PadGroup group)
     return m_triggers;
   case PadGroup::Rumble:
     return m_rumble;
+  case PadGroup::Mic:
+    return m_mic;
   case PadGroup::Options:
     return m_options;
   default:
@@ -220,5 +223,5 @@ void GCPad::LoadDefaults(const ControllerInterface& ciface)
 bool GCPad::GetMicButton() const
 {
   auto lock = ControllerEmu::GetStateLock();
-  return (0.0f != m_buttons->controls.back()->control_ref->State());
+  return (0.0f != m_mic->controls.back()->control_ref->State());
 }

--- a/Source/Core/Core/HW/GCPadEmu.h
+++ b/Source/Core/Core/HW/GCPadEmu.h
@@ -18,6 +18,7 @@ enum class PadGroup
   DPad,
   Triggers,
   Rumble,
+  Mic,
   Options
 };
 
@@ -43,6 +44,7 @@ private:
   Buttons* m_dpad;
   MixedTriggers* m_triggers;
   ControlGroup* m_rumble;
+  Buttons* m_mic;
   ControlGroup* m_options;
 
   const unsigned int m_index;

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -46,6 +46,7 @@ set(GUI_SRCS
 	Input/InputConfigDiagBitmaps.cpp
 	Input/HotkeyInputConfigDiag.cpp
 	Input/GCPadInputConfigDiag.cpp
+	Input/MicButtonConfigDiag.cpp
 	Input/GCKeyboardInputConfigDiag.cpp
 	Input/WiimoteInputConfigDiag.cpp
 	Input/NunchukInputConfigDiag.cpp

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -34,6 +34,7 @@ private:
   void OnSlotBButtonClick(wxCommandEvent&);
 
   void ChooseEXIDevice(const wxString& device_name, int device_id);
+  void HandleEXISlotChange(int slot, const wxString& title);
   void ChooseSlotPath(bool is_slot_a, TEXIDevices device_type);
 
   wxArrayString m_ipl_language_strings;

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj
@@ -106,6 +106,7 @@
     <ClCompile Include="Input\InputConfigDiagBitmaps.cpp" />
     <ClCompile Include="Input\HotkeyInputConfigDiag.cpp" />
     <ClCompile Include="Input\GCPadInputConfigDiag.cpp" />
+    <ClCompile Include="Input\MicButtonConfigDiag.cpp" />
     <ClCompile Include="Input\GCKeyboardInputConfigDiag.cpp" />
     <ClCompile Include="Input\WiimoteInputConfigDiag.cpp" />
     <ClCompile Include="Input\NunchukInputConfigDiag.cpp" />
@@ -185,6 +186,7 @@
     <ClInclude Include="Input\InputConfigDiag.h" />
     <ClInclude Include="Input\HotkeyInputConfigDiag.h" />
     <ClInclude Include="Input\GCPadInputConfigDiag.h" />
+    <ClInclude Include="Input\MicButtonConfigDiag.h" />
     <ClInclude Include="Input\GCKeyboardInputConfigDiag.h" />
     <ClInclude Include="Input\WiimoteInputConfigDiag.h" />
     <ClInclude Include="Input\NunchukInputConfigDiag.h" />

--- a/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
+++ b/Source/Core/DolphinWX/DolphinWX.vcxproj.filters
@@ -119,6 +119,9 @@
     <ClCompile Include="Input\GCPadInputConfigDiag.cpp">
       <Filter>GUI\InputConfig</Filter>
     </ClCompile>
+    <ClCompile Include="Input\MicButtonConfigDiag.cpp">
+      <Filter>GUI\InputConfig</Filter>
+    </ClCompile>
     <ClCompile Include="Input\GCKeyboardInputConfigDiag.cpp">
       <Filter>GUI\InputConfig</Filter>
     </ClCompile>
@@ -330,6 +333,9 @@
       <Filter>GUI\InputConfig</Filter>
     </ClInclude>
     <ClInclude Include="Input\GCPadInputConfigDiag.h">
+      <Filter>GUI\InputConfig</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\MicButtonConfigDiag.h">
       <Filter>GUI\InputConfig</Filter>
     </ClInclude>
     <ClInclude Include="Input\GCKeyboardInputConfigDiag.h">

--- a/Source/Core/DolphinWX/Input/MicButtonConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/MicButtonConfigDiag.cpp
@@ -1,0 +1,36 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinWX/Input/MicButtonConfigDiag.h"
+
+#include "Core/HW/GCPad.h"
+#include "Core/HW/GCPadEmu.h"
+
+MicButtonConfigDialog::MicButtonConfigDialog(wxWindow* const parent, InputConfig& config,
+                                             const wxString& name, const int port_num)
+    : InputConfigDialog(parent, config, name, port_num)
+{
+  const int space5 = FromDIP(5);
+
+  auto* const device_chooser = CreateDeviceChooserGroupBox();
+
+  auto* const group_box_button =
+      new ControlGroupBox(Pad::GetGroup(port_num, PadGroup::Mic), this, this);
+
+  auto* const controls_sizer = new wxBoxSizer(wxHORIZONTAL);
+  controls_sizer->Add(group_box_button, 0, wxEXPAND);
+
+  auto* const szr_main = new wxBoxSizer(wxVERTICAL);
+  szr_main->AddSpacer(space5);
+  szr_main->Add(device_chooser, 0, wxEXPAND);
+  szr_main->AddSpacer(space5);
+  szr_main->Add(controls_sizer, 1, wxEXPAND | wxLEFT | wxRIGHT, space5);
+  szr_main->AddSpacer(space5);
+  szr_main->Add(CreateButtonSizer(wxCLOSE | wxNO_DEFAULT), 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+  szr_main->AddSpacer(space5);
+
+  SetSizer(szr_main);
+  Center();
+  UpdateGUI();
+}

--- a/Source/Core/DolphinWX/Input/MicButtonConfigDiag.h
+++ b/Source/Core/DolphinWX/Input/MicButtonConfigDiag.h
@@ -1,0 +1,14 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "DolphinWX/Input/InputConfigDiag.h"
+
+class MicButtonConfigDialog final : public InputConfigDialog
+{
+public:
+  MicButtonConfigDialog(wxWindow* parent, InputConfig& config, const wxString& name,
+                        int port_num = 0);
+};


### PR DESCRIPTION
The current configuration of the mic button is done on the GCPad configuration and each gcpad dialog does allow to configure it.  However, this is wrong because the mic button is only used by the EXI port 1 and 2 which for the GCPad, it would be only used by the port 1 and 2 of that inputConfig.  This means that if you configured the slot B to have a mic, but configured the mic button on port 1, it wouldn't work as you need to configure the button on port 2.  It also means that the presence of this button on port 3 and 4 is unecessary.

This pr first moves the mic button to another group entirely leaving it hidden for any GCPad configuration dialog.  The only way to see this group is to use the new dialog on the GameCube tab of the Config dialog (after selecting a mic, the "..." button activates).  That way, the right port number can be passed and as of the input configuration UI rewrite, it was possible to simplify the dialog to only have the device chooser and the new group.

The new dialog looks like this:

![screenshot from 2016-12-04 18-04-03](https://cloud.githubusercontent.com/assets/8932978/20869948/14227740-ba4c-11e6-8767-1e0242633fcc.png)

Also please note that this will break old configuration for the Mic button because since I moved it to its own group, it won't load the old one from the INI since the names aren't the same.  There might be a way to prevent this like I did for the hotkeys, but I don't think this will be desirable in this case.  Not only it would be confusing as the INI would say that the mic button still is in the buttons group (and it doesn't appear in the GCPad dialog), but it would also allow illogical entries for port 3 and 4 which shouldn't even appear from this PR.  Ideally, you wouldn't even use the GCPad inputConfig, but considering how this solution is already much better, I decided it would be worth it for now, not to mention I don't feel confortable to redo the mic controller.

This PR is submitted untested as I have no way to test it so I would like to ask @JMC47 to please test it if the input for both slots does work.

EDIT:  This has been tested and it works as intended.

The only problem is clearing or reverting to default the gcpad port 1 or 2 will also affect the mic button slot a or b by clearing it too.  This is the drawback of keeping the mic inside the gcpad controller, but as said above, considering how much this solution is improving it, I think it will be fine for now.