### PR TITLE
DolphinWX: Add 'DisableTooltips' config option

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -188,6 +188,7 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
   interface->Set("ExtendedFPSInfo", m_InterfaceExtendedFPSInfo);
   interface->Set("ThemeName", theme_name);
   interface->Set("PauseOnFocusLost", m_PauseOnFocusLost);
+  interface->Set("DisableTooltips", m_DisableTooltips);
 }
 
 void SConfig::SaveDisplaySettings(IniFile& ini)
@@ -491,6 +492,7 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
   interface->Get("ExtendedFPSInfo", &m_InterfaceExtendedFPSInfo, false);
   interface->Get("ThemeName", &theme_name, DEFAULT_THEME_DIR);
   interface->Get("PauseOnFocusLost", &m_PauseOnFocusLost, false);
+  interface->Get("DisableTooltips", &m_DisableTooltips, false);
 }
 
 void SConfig::LoadDisplaySettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -292,6 +292,8 @@ struct SConfig : NonCopyable
 
   bool m_PauseOnFocusLost;
 
+  bool m_DisableTooltips;
+
   // DSP settings
   bool m_DSPEnableJIT;
   bool m_DSPCaptureLog;

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.cpp
@@ -14,6 +14,7 @@
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
+#include <wx/tooltip.h>
 
 #include "Common/CommonFuncs.h"
 #include "Common/CommonPaths.h"
@@ -87,6 +88,7 @@ void InterfaceConfigPane::InitializeGUI()
   m_panic_handlers_checkbox = new wxCheckBox(this, wxID_ANY, _("Use Panic Handlers"));
   m_osd_messages_checkbox = new wxCheckBox(this, wxID_ANY, _("On-Screen Display Messages"));
   m_pause_focus_lost_checkbox = new wxCheckBox(this, wxID_ANY, _("Pause on Focus Lost"));
+  m_disable_tooltips_checkbox = new wxCheckBox(this, wxID_ANY, _("Disable Tooltips"));
   m_interface_lang_choice =
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_interface_lang_strings);
   m_theme_choice = new wxChoice(this, wxID_ANY);
@@ -99,6 +101,8 @@ void InterfaceConfigPane::InitializeGUI()
                                 this);
   m_pause_focus_lost_checkbox->Bind(wxEVT_CHECKBOX,
                                     &InterfaceConfigPane::OnPauseOnFocusLostCheckBoxChanged, this);
+  m_disable_tooltips_checkbox->Bind(wxEVT_CHECKBOX,
+                                    &InterfaceConfigPane::OnDisableTooltipsCheckBoxChanged, this);
   m_interface_lang_choice->Bind(wxEVT_CHOICE,
                                 &InterfaceConfigPane::OnInterfaceLanguageChoiceChanged, this);
   m_theme_choice->Bind(wxEVT_CHOICE, &InterfaceConfigPane::OnThemeSelected, this);
@@ -113,6 +117,8 @@ void InterfaceConfigPane::InitializeGUI()
         "writes, video backend and CPU information, and JIT cache clearing."));
   m_pause_focus_lost_checkbox->SetToolTip(
       _("Pauses the emulator when focus is taken away from the emulation window."));
+  m_disable_tooltips_checkbox->SetToolTip(
+      _("Disables tooltip pop-ups when hovering over GUI elements."));
   m_interface_lang_choice->SetToolTip(
       _("Change the language of the user interface.\nRequires restart."));
 
@@ -139,6 +145,8 @@ void InterfaceConfigPane::InitializeGUI()
   main_static_box_sizer->AddSpacer(space5);
   main_static_box_sizer->Add(m_pause_focus_lost_checkbox, 0, wxLEFT | wxRIGHT, space5);
   main_static_box_sizer->AddSpacer(space5);
+  main_static_box_sizer->Add(m_disable_tooltips_checkbox, 0, wxLEFT | wxRIGHT, space5);
+  main_static_box_sizer->AddSpacer(space5);
   main_static_box_sizer->Add(language_and_theme_grid_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   main_static_box_sizer->AddSpacer(space5);
 
@@ -158,6 +166,7 @@ void InterfaceConfigPane::LoadGUIValues()
   m_panic_handlers_checkbox->SetValue(startup_params.bUsePanicHandlers);
   m_osd_messages_checkbox->SetValue(startup_params.bOnScreenDisplayMessages);
   m_pause_focus_lost_checkbox->SetValue(SConfig::GetInstance().m_PauseOnFocusLost);
+  m_disable_tooltips_checkbox->SetValue(SConfig::GetInstance().m_DisableTooltips);
 
   const std::string exact_language = SConfig::GetInstance().m_InterfaceLanguage;
   const std::string loose_language = exact_language.substr(0, exact_language.find('_'));
@@ -234,6 +243,13 @@ void InterfaceConfigPane::OnInterfaceLanguageChoiceChanged(wxCommandEvent& event
 void InterfaceConfigPane::OnPauseOnFocusLostCheckBoxChanged(wxCommandEvent& event)
 {
   SConfig::GetInstance().m_PauseOnFocusLost = m_pause_focus_lost_checkbox->IsChecked();
+}
+
+void InterfaceConfigPane::OnDisableTooltipsCheckBoxChanged(wxCommandEvent& event)
+{
+  const bool disable = m_disable_tooltips_checkbox->IsChecked();
+  SConfig::GetInstance().m_DisableTooltips = disable;
+  wxToolTip::Enable(!disable);
 }
 
 void InterfaceConfigPane::OnThemeSelected(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/InterfaceConfigPane.h
+++ b/Source/Core/DolphinWX/Config/InterfaceConfigPane.h
@@ -26,6 +26,7 @@ private:
   void OnOSDMessagesCheckBoxChanged(wxCommandEvent&);
   void OnInterfaceLanguageChoiceChanged(wxCommandEvent&);
   void OnPauseOnFocusLostCheckBoxChanged(wxCommandEvent&);
+  void OnDisableTooltipsCheckBoxChanged(wxCommandEvent&);
   void OnThemeSelected(wxCommandEvent&);
 
   wxArrayString m_interface_lang_strings;
@@ -34,6 +35,7 @@ private:
   wxCheckBox* m_panic_handlers_checkbox;
   wxCheckBox* m_osd_messages_checkbox;
   wxCheckBox* m_pause_focus_lost_checkbox;
+  wxCheckBox* m_disable_tooltips_checkbox;
   wxChoice* m_interface_lang_choice;
   wxChoice* m_theme_choice;
 };

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -18,6 +18,7 @@
 #include <wx/msgdlg.h>
 #include <wx/thread.h>
 #include <wx/timer.h>
+#include <wx/tooltip.h>
 #include <wx/utils.h>
 #include <wx/window.h>
 
@@ -109,6 +110,8 @@ bool DolphinApp::OnInit()
   VideoBackendBase::ActivateBackend(SConfig::GetInstance().m_strVideoBackend);
 
   DolphinAnalytics::Instance()->ReportDolphinStart("wx");
+
+  wxToolTip::Enable(!SConfig::GetInstance().m_DisableTooltips);
 
   // Enable the PNG image handler for screenshots
   wxImage::AddHandler(new wxPNGHandler);


### PR DESCRIPTION
This patch adds a config value and a checkbox in the "Interface" panel to prevent tooltips from appearing in the WX interface.

This is motivated by the current user experience on SteamOS; the SteamOS compositor takes the currently-focused window/panel, scales it to fit the full display, and refocuses the mouse cursor over the newly-scaled interface. In Dolphin's case, this includes the main window, config windows, drop-down menus, and tooltips. While the first three work reasonably well in SteamOS (provided you have a mouse or Steam Controller available), the tooltips cause a lot of flickering due to the "window" being so small compared to the host windows and the mouse repeatedly going in and out of focus of the GUI element in question (since it's trying to focus on the tooltip instead), making it hard to actually click on things in the window.

This is of course unchecked by default; it's only useful when using the SteamOS compositor so it's a pretty narrow use case, but it's also a use case where editing config files by hand isn't as easy as it is elsewhere.