### PR TITLE
DolphinWX: pass wxMsgAlert to main thread on non-GTK too

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -701,7 +701,6 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
       m_RenderParent->SetCursor(wxCURSOR_BLANK);
     break;
 
-#ifdef __WXGTK__
   case IDM_PANIC:
   {
     wxString caption = event.GetString().BeforeFirst(':');
@@ -711,7 +710,6 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
     panic_event.Set();
   }
   break;
-#endif
 
   case WM_USER_STOP:
     DoStop();

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -116,9 +116,10 @@ public:
   const CGameListCtrl* GetGameListCtrl() const;
   wxMenuBar* GetMenuBar() const override;
 
-#ifdef __WXGTK__
   Common::Event panic_event;
   bool bPanicResult;
+
+#ifdef __WXGTK__
   std::recursive_mutex keystate_lock;
 #endif
 

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -352,10 +352,8 @@ void DolphinApp::OnIdle(wxIdleEvent& ev)
 
 bool wxMsgAlert(const char* caption, const char* text, bool yes_no, int /*Style*/)
 {
-#ifdef __WXGTK__
   if (wxIsMainThread())
   {
-#endif
     NetPlayDialog*& npd = NetPlayDialog::GetInstance();
     if (npd != nullptr && npd->IsShown())
     {
@@ -364,7 +362,6 @@ bool wxMsgAlert(const char* caption, const char* text, bool yes_no, int /*Style*
     }
     return wxYES == wxMessageBox(StrToWxStr(text), StrToWxStr(caption), (yes_no) ? wxYES_NO : wxOK,
                                  wxWindow::FindFocus());
-#ifdef __WXGTK__
   }
   else
   {
@@ -375,7 +372,6 @@ bool wxMsgAlert(const char* caption, const char* text, bool yes_no, int /*Style*
     main_frame->panic_event.Wait();
     return main_frame->bPanicResult;
   }
-#endif
 }
 
 std::string wxStringTranslator(const char* text)


### PR DESCRIPTION
Fixes [10027](https://bugs.dolphin-emu.org/issues/10027), where on macOS `wxMessageBox` always returns `wxCANCEL` when not called from main thread. Seems to work fine on Windows.

Found during investigation of [9930](https://bugs.dolphin-emu.org/issues/9930), where responding "Yes" to continue after an assertion error still crashes Dolphin.

This title sucks, I'm open to suggestions to improve it.