### PR TITLE
IPC_HLE: Fix incorrect file path for IOCTL_SET_ATTR

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -344,7 +344,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     Addr += 4;
     u16 GroupID = Memory::Read_U16(Addr);
     Addr += 2;
-    const std::string wii_path = Memory::GetString(_BufferIn, 64);
+    const std::string wii_path = Memory::GetString(Addr, 64);
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());


### PR DESCRIPTION
We were reading the string from the wrong location…

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4500)
<!-- Reviewable:end -->
