### PR TITLE
DolphinWX: Add 'DisableTooltips' config option (R2)

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -188,6 +188,7 @@ void SConfig::SaveInterfaceSettings(IniFile& ini)
   interface->Set("ExtendedFPSInfo", m_InterfaceExtendedFPSInfo);
   interface->Set("ThemeName", theme_name);
   interface->Set("PauseOnFocusLost", m_PauseOnFocusLost);
+  interface->Set("DisableTooltips", m_DisableTooltips);
 }
 
 void SConfig::SaveDisplaySettings(IniFile& ini)
@@ -491,6 +492,7 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
   interface->Get("ExtendedFPSInfo", &m_InterfaceExtendedFPSInfo, false);
   interface->Get("ThemeName", &theme_name, DEFAULT_THEME_DIR);
   interface->Get("PauseOnFocusLost", &m_PauseOnFocusLost, false);
+  interface->Get("DisableTooltips", &m_DisableTooltips, false);
 }
 
 void SConfig::LoadDisplaySettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -292,6 +292,8 @@ struct SConfig : NonCopyable
 
   bool m_PauseOnFocusLost;
 
+  bool m_DisableTooltips;
+
   // DSP settings
   bool m_DSPEnableJIT;
   bool m_DSPCaptureLog;

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -18,6 +18,7 @@
 #include <wx/msgdlg.h>
 #include <wx/thread.h>
 #include <wx/timer.h>
+#include <wx/tooltip.h>
 #include <wx/utils.h>
 #include <wx/window.h>
 
@@ -109,6 +110,8 @@ bool DolphinApp::OnInit()
   VideoBackendBase::ActivateBackend(SConfig::GetInstance().m_strVideoBackend);
 
   DolphinAnalytics::Instance()->ReportDolphinStart("wx");
+
+  wxToolTip::Enable(!SConfig::GetInstance().m_DisableTooltips);
 
   // Enable the PNG image handler for screenshots
   wxImage::AddHandler(new wxPNGHandler);


### PR DESCRIPTION
(Revision 2: Remove checkbox from WX GUI)

This is a follow-up for #4498.