### PR TITLE
Vulkan: Fix viewport depth when depth clamp is unsupported

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1663,8 +1663,8 @@ void Renderer::SetViewport()
                                             0.0f, 16777215.0f) /
                      16777216.0f;
     float far_val = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
-    min_depth = 1.0f - near_val;
-    max_depth = 1.0f - far_val;
+    min_depth = near_val;
+    max_depth = far_val;
   }
 
   VkViewport viewport = {x, y, width, height, min_depth, max_depth};


### PR DESCRIPTION
Really simple change, looks like I made this mistake when originally writing the backend (or rebasing it). Should fix games depth rendering on Adreno/Mali (assuming they aren't broken for other reasons).