### PR TITLE
GameINI: NAC/NAR - Legend of Zelda: Ocarina of Time and Majora's Mask VC - Set EFBToTextureEnable to False

### DIFF
--- a/Data/Sys/GameSettings/NAC.ini
+++ b/Data/Sys/GameSettings/NAC.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues =
+EmulationIssues = Needs EFB to RAM for the pause menu (background and Link).
 EmulationStateId = 3
 
 [OnLoad]
@@ -17,3 +17,6 @@ EmulationStateId = 3
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+# Fixes Link preview not appearing in Equipment Menu screen
+EFBToTextureEnable = False 

--- a/Data/Sys/GameSettings/NAR.ini
+++ b/Data/Sys/GameSettings/NAR.ini
@@ -17,3 +17,6 @@ EmulationIssues = Very buggy
 [ActionReplay]
 # Add action replay cheats here.
 
+[Video_Hacks]
+# Fixes Link preview not appearing in Equipment Menu screen
+EFBToTextureEnable = False 


### PR DESCRIPTION
Fix [issue #9942,](https://bugs.dolphin-emu.org/issues/9942) make Link preview visible in Equipment Menu screen, with EFB to Textures Only enabled the preview simply stays black, rather than showing Link's current equipment.

Before:
![EFB Copies Disabled, No Link](http://i.imgur.com/IjP6EVm.png)

After:
![EFB Copies Enabled, Link is now visible](http://i.imgur.com/kcPDLtH.png)