### PR TITLE
ShaderManagers: Use aggregate initialization for some variables.

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderManager.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderManager.cpp
@@ -21,7 +21,7 @@ static bool s_viewport_changed;
 
 void GeometryShaderManager::Init()
 {
-  memset(&constants, 0, sizeof(constants));
+  constants = {};
 
   // Init any intial constants which aren't zero when bpmem is zero.
   SetViewportChanged();

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -21,7 +21,7 @@ bool PixelShaderManager::dirty;
 
 void PixelShaderManager::Init()
 {
-  memset(&constants, 0, sizeof(constants));
+  constants = {};
 
   // Init any intial constants which aren't zero when bpmem is zero.
   s_bFogRangeAdjustChanged = true;

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -203,8 +203,8 @@ void VertexShaderManager::Init()
   bProjectionChanged = true;
   bViewportChanged = false;
 
-  memset(&xfmem, 0, sizeof(xfmem));
-  memset(&constants, 0, sizeof(constants));
+  xfmem = {};
+  constants = {};
   ResetView();
 
   // TODO: should these go inside ResetView()?


### PR DESCRIPTION
These provide essentially the same behavior ([preemptive godbolt to avoid shedding the bikes](https://tinyurl.com/hwmtqct)), however aggregate initialization doesn't force the structs to be trivially copyable in order to get sane behavior, making them potentially more flexible.