### PR TITLE
Expand Main Toolbar Labels

### DIFF
--- a/Source/Core/DolphinWX/MainToolBar.cpp
+++ b/Source/Core/DolphinWX/MainToolBar.cpp
@@ -180,10 +180,10 @@ void MainToolBar::AddMainToolBarButtons()
   AddSeparator();
   AddToolBarButton(IDM_PLAY, TOOLBAR_PLAY, _("Play"), _("Play"));
   AddToolBarButton(IDM_STOP, TOOLBAR_STOP, _("Stop"), _("Stop"));
-  AddToolBarButton(IDM_TOGGLE_FULLSCREEN, TOOLBAR_FULLSCREEN, _("FullScr"), _("Toggle fullscreen"));
-  AddToolBarButton(IDM_SCREENSHOT, TOOLBAR_SCREENSHOT, _("ScrShot"), _("Take screenshot"));
+  AddToolBarButton(IDM_TOGGLE_FULLSCREEN, TOOLBAR_FULLSCREEN, _("Fullscreen"), _("Toggle fullscreen"));
+  AddToolBarButton(IDM_SCREENSHOT, TOOLBAR_SCREENSHOT, _("Screenshot"), _("Take screenshot"));
   AddSeparator();
-  AddToolBarButton(wxID_PREFERENCES, TOOLBAR_CONFIGMAIN, _("Config"), _("Configure..."));
+  AddToolBarButton(wxID_PREFERENCES, TOOLBAR_CONFIGMAIN, _("Configure"), _("Configure..."));
   AddToolBarButton(IDM_CONFIG_GFX_BACKEND, TOOLBAR_CONFIGGFX, _("Graphics"),
                    _("Graphics settings"));
   AddToolBarButton(IDM_CONFIG_CONTROLLERS, TOOLBAR_CONTROLLER, _("Controllers"),


### PR DESCRIPTION
Expand the main toolbar titles to use full words instead of abbreviations. I understand the original approach was to limit the text to be roughly the same width as the icons but the use of abbreviations is kind of stupid looking, especially for text that is so visible (not to mention less immediately understandable). I think that having some slightly wider buttons with proper tiles is the better compromise to make.