### PR TITLE
AudioCommon: Remove unnecessary headers

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -16,9 +16,7 @@
 #include "Common/Common.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
-#include "Common/MsgHandler.h"
 #include "Core/ConfigManager.h"
-#include "Core/Movie.h"
 
 // This shouldn't be a global, at least not here.
 std::unique_ptr<SoundStream> g_sound_stream;

--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -5,9 +5,10 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "AudioCommon/SoundStream.h"
-#include "Common/CommonTypes.h"
 
 class CMixer;
 


### PR DESCRIPTION
Now AudioCommon.cpp code won't need to be recompiled if the TAS movie header is ever modified.

Also adds required headers to the actual header file.