### PR TITLE
VideoCommon: Use avg(color1, color2) for color3 in CMPR textures

### DIFF
--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -654,6 +654,11 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     int red1 = Convert5To8((c1 >> 11) & 0x1F);
     int red2 = Convert5To8((c2 >> 11) & 0x1F);
 
+    // Approximation of x/3: 3/8 (1/2 - 1/8)
+    int blue3 = ((blue2 - blue1) >> 1) - ((blue2 - blue1) >> 3);
+    int green3 = ((green2 - green1) >> 1) - ((green2 - green1) >> 3);
+    int red3 = ((red2 - red1) >> 1) - ((red2 - red1) >> 3);
+
     u16 ss = s & 3;
     u16 tt = t & 3;
 
@@ -675,19 +680,20 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
       color = MakeRGBA(red2, green2, blue2, 255);
       break;
     case 2:
-      color = MakeRGBA(red1 + (red2 - red1) / 3, green1 + (green2 - green1) / 3,
-                       blue1 + (blue2 - blue1) / 3, 255);
+      color = MakeRGBA(red1 + red3, green1 + green3, blue1 + blue3, 255);
       break;
     case 3:
-      color = MakeRGBA(red2 + (red1 - red2) / 3, green2 + (green1 - green2) / 3,
-                       blue2 + (blue1 - blue2) / 3, 255);
+      color = MakeRGBA(red2 - red3, green2 - green3, blue2 - blue3, 255);
       break;
     case 6:
-      color = MakeRGBA((int)ceil((float)(red1 + red2) / 2), (int)ceil((float)(green1 + green2) / 2),
-                       (int)ceil((float)(blue1 + blue2) / 2), 255);
+      color =
+          MakeRGBA((red1 + red2 + 1) / 2, (green1 + green2 + 1) / 2, (blue1 + blue2 + 1) / 2, 255);
       break;
     case 7:
-      color = MakeRGBA(red2, green2, blue2, 0);
+      // color[3] is the same as color[2] (average of both colors), but transparent.
+      // This differs from DXT1 where color[3] is transparent black.
+      color =
+          MakeRGBA((red1 + red2 + 1) / 2, (green1 + green2 + 1) / 2, (blue1 + blue2 + 1) / 2, 0);
       break;
     default:
       color = 0;

--- a/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
@@ -169,6 +169,7 @@ static void DecodeDXTBlock(u32* dst, const DXTBlock* src, int pitch)
   colors[1] = MakeRGBA(red2, green2, blue2, 255);
   if (c1 > c2)
   {
+    // Approximation of x/3: 3/8 (1/2 - 1/8)
     int blue3 = ((blue2 - blue1) >> 1) - ((blue2 - blue1) >> 3);
     int green3 = ((green2 - green1) >> 1) - ((green2 - green1) >> 3);
     int red3 = ((red2 - red1) >> 1) - ((red2 - red1) >> 3);
@@ -177,9 +178,12 @@ static void DecodeDXTBlock(u32* dst, const DXTBlock* src, int pitch)
   }
   else
   {
-    colors[2] = MakeRGBA((red1 + red2 + 1) / 2,  // Average
-                         (green1 + green2 + 1) / 2, (blue1 + blue2 + 1) / 2, 255);
-    colors[3] = MakeRGBA(red2, green2, blue2, 0);  // Color2 but transparent
+    // color[3] is the same as color[2] (average of both colors), but transparent.
+    // This differs from DXT1 where color[3] is transparent black.
+    colors[2] =
+        MakeRGBA((red1 + red2 + 1) / 2, (green1 + green2 + 1) / 2, (blue1 + blue2 + 1) / 2, 255);
+    colors[3] =
+        MakeRGBA((red1 + red2 + 1) / 2, (green1 + green2 + 1) / 2, (blue1 + blue2 + 1) / 2, 0);
   }
 
   for (int y = 0; y < 4; y++)


### PR DESCRIPTION
Previously we were using the second color as the RGB values in the transparent color of compressed textures. This caused a few issues:

https://bugs.dolphin-emu.org/issues/6760
https://bugs.dolphin-emu.org/issues/2701
https://bugs.dolphin-emu.org/issues/7708

As well as the ground textures in rs2-glass.

Taking the average of color1 and 2 seems to look a lot better, although I'm still not sure if it's 100% correct hardware behavior (in particular whether the average is the ceiling or floor of the division). A good test here is burnout 2, the flaps on the truck have a 4x4 block pattern on them if the texture is decoded incorrectly.

@JMC47 has confirmed that the artifacts around the edge of the textures are also present on hardware, so I think we're on the right track here.