### PR TITLE
CodeBlock: Use static memory for JIT locations

### DIFF
--- a/Source/Core/Common/CodeBlock.h
+++ b/Source/Core/Common/CodeBlock.h
@@ -46,11 +46,9 @@ public:
       FreeCodeSpace();
   }
 
-  // Call this before you generate any code.
-  void AllocCodeSpace(size_t size, bool need_low = true)
+  void AllocCodeSpace(size_t size)
   {
-    region_size = size;
-    region = static_cast<u8*>(Common::AllocateExecutableMemory(region_size, need_low));
+    region = static_cast<u8*>(Common::AllocateMemoryPages(size));
     SetCodeSpace(region, size);
   }
 

--- a/Source/Core/Common/CodeBlock.h
+++ b/Source/Core/Common/CodeBlock.h
@@ -11,6 +11,11 @@
 #include "Common/MemoryUtil.h"
 #include "Common/NonCopyable.h"
 
+// We need to mark the JIT pages as read/write/executable. All current CPUs
+// support such checks within the MMU, but only with a granularity of 4 KB.
+// Se we force the JIT code area to be aligned by this page size.
+constexpr size_t JIT_MEM_ALIGNMENT = 4096;
+
 // Everything that needs to generate code should inherit from this.
 // You get memory management for free, plus, you can use all emitter functions without
 // having to prefix them with gen-> or something similar.
@@ -46,6 +51,15 @@ public:
   {
     region_size = size;
     region = static_cast<u8*>(Common::AllocateExecutableMemory(region_size, need_low));
+    SetCodeSpace(region, size);
+  }
+
+  // Call this before you generate any code.
+  void SetCodeSpace(u8* region_, size_t size)
+  {
+    region = region_;
+    region_size = size;
+    Common::UnWriteProtectMemory(region, region_size, true);
     T::SetCodePtr(region);
   }
 
@@ -61,6 +75,11 @@ public:
   void FreeCodeSpace()
   {
     Common::FreeMemoryPages(region, region_size);
+    ReleaseCodeSpace();
+  }
+
+  void ReleaseCodeSpace()
+  {
     region = nullptr;
     region_size = 0;
     parent_region_size = 0;

--- a/Source/Core/Common/MemoryUtil.h
+++ b/Source/Core/Common/MemoryUtil.h
@@ -9,7 +9,6 @@
 
 namespace Common
 {
-void* AllocateExecutableMemory(size_t size, bool low = true);
 void* AllocateMemoryPages(size_t size);
 void FreeMemoryPages(void* ptr, size_t size);
 void* AllocateAlignedMemory(size_t size, size_t alignment);

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
@@ -26,15 +26,16 @@ namespace JIT
 {
 namespace x86
 {
-constexpr size_t COMPILED_CODE_SIZE = 2097152;
 constexpr size_t MAX_BLOCK_SIZE = 250;
 constexpr u16 DSP_IDLE_SKIP_CYCLES = 0x1000;
+
+alignas(JIT_MEM_ALIGNMENT) std::array<u8, COMPILED_CODE_SIZE> DSPEmitter::code_area;
 
 DSPEmitter::DSPEmitter()
     : blockLinks(MAX_BLOCKS), blockSize(MAX_BLOCKS), blocks(MAX_BLOCKS),
       compileSR{SR_INT_ENABLE | SR_EXT_INT_ENABLE}
 {
-  AllocCodeSpace(COMPILED_CODE_SIZE);
+  SetCodeSpace(code_area.data(), code_area.size());
 
   CompileDispatcher();
   stubEntryPoint = CompileStub();
@@ -45,7 +46,7 @@ DSPEmitter::DSPEmitter()
 
 DSPEmitter::~DSPEmitter()
 {
-  FreeCodeSpace();
+  ReleaseCodeSpace();
 }
 
 void DSPEmitter::ClearIRAM()

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <list>
 #include <vector>
@@ -21,6 +22,8 @@ namespace JIT
 {
 namespace x86
 {
+constexpr size_t COMPILED_CODE_SIZE = 2097152;
+
 class DSPEmitter : public Gen::X64CodeBlock
 {
 public:
@@ -268,6 +271,8 @@ private:
 
   // Counts down.
   // int cycles;
+
+  static std::array<u8, COMPILED_CODE_SIZE> code_area;
 
   void Update_SR_Register(Gen::X64Reg val = Gen::EAX);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -227,7 +227,7 @@ void Jit64::Init()
   gpr.SetEmitter(this);
   fpr.SetEmitter(this);
 
-  trampolines.Init(jo.memcheck ? TRAMPOLINE_CODE_SIZE_MMU : TRAMPOLINE_CODE_SIZE);
+  trampolines.Init(TRAMPOLINE_CODE_SIZE);
   AllocCodeSpace(CODE_SIZE);
 
   // BLR optimization has the same consequences as block linking, as well as
@@ -246,7 +246,7 @@ void Jit64::Init()
   // important: do this *after* generating the global asm routines, because we can't use farcode in
   // them.
   // it'll crash because the farcode functions get cleared on JIT clears.
-  m_far_code.Init(jo.memcheck ? FARCODE_SIZE_MMU : FARCODE_SIZE);
+  m_far_code.Init(FARCODE_SIZE);
   Clear();
 
   code_block.m_stats = &js.st;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -18,6 +18,8 @@
 // ----------
 #pragma once
 
+#include <array>
+
 #include "Common/CommonTypes.h"
 #include "Common/x64ABI.h"
 #include "Common/x64Emitter.h"
@@ -34,6 +36,9 @@ class Jit64 : public Jitx86Base
 private:
   void AllocStack();
   void FreeStack();
+
+  // Code buffer for the actual x86_64 instructions.
+  static std::array<u8, CODE_SIZE> code_area;
 
   GPRRegCache gpr{*this};
   FPURegCache fpr{*this};

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Core/PowerPC/Jit64/Jit.h"
+#include "Core/PowerPC/Jit64/JitAsm.h"
 #include "Common/CommonTypes.h"
 #include "Common/JitRegister.h"
 #include "Common/x64ABI.h"
@@ -11,11 +11,13 @@
 #include "Core/CoreTiming.h"
 #include "Core/HW/CPU.h"
 #include "Core/HW/Memmap.h"
-#include "Core/PowerPC/Jit64/JitAsm.h"
+#include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
 #include "Core/PowerPC/PowerPC.h"
 
 using namespace Gen;
+
+alignas(JIT_MEM_ALIGNMENT) std::array<u8, ASM_CODE_SIZE> Jit64AsmRoutineManager::code_area;
 
 // Not PowerPC state.  Can't put in 'this' because it's out of range...
 static void* s_saved_rsp;

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "Common/CommonTypes.h"
 #include "Core/PowerPC/Jit64Common/Jit64AsmCommon.h"
 
@@ -21,6 +23,8 @@
 // To add a new asm routine, just add another const here, and add the code to Generate.
 // Also, possibly increase the size of the code buffer.
 
+constexpr size_t ASM_CODE_SIZE = 1024 * 16;
+
 class Jit64AsmRoutineManager : public CommonAsmRoutines
 {
 private:
@@ -28,17 +32,17 @@ private:
   void GenerateCommon();
   u8* m_stack_top;
 
+  static std::array<u8, ASM_CODE_SIZE> code_area;
+
 public:
   void Init(u8* stack_top)
   {
     m_stack_top = stack_top;
-    // NOTE: When making large additions to the AsmCommon code, you might
-    // want to ensure this number is big enough.
-    AllocCodeSpace(16384);
+    SetCodeSpace(code_area.data(), code_area.size());
     Generate();
     WriteProtect();
   }
 
-  void Shutdown() { FreeCodeSpace(); }
+  void Shutdown() { ReleaseCodeSpace(); }
   void ResetStack(X64CodeBlock& emitter);
 };

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <unordered_map>
 
 #include "Common/BitSet.h"

--- a/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.cpp
@@ -4,15 +4,17 @@
 
 #include "Core/PowerPC/Jit64Common/FarCodeCache.h"
 
-void FarCodeCache::Init(size_t size)
+alignas(JIT_MEM_ALIGNMENT) std::array<u8, FARCODE_SIZE> FarCodeCache::code_area;
+
+void FarCodeCache::Init()
 {
-  AllocCodeSpace(size);
+  SetCodeSpace(code_area.data(), code_area.size());
   m_enabled = true;
 }
 
 void FarCodeCache::Shutdown()
 {
-  FreeCodeSpace();
+  ReleaseCodeSpace();
   m_enabled = false;
 }
 

--- a/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.h
@@ -9,8 +9,7 @@
 
 // a bit of a hack; the MMU results in a vast amount more code ending up in the far cache,
 // mostly exception handling, so give it a whole bunch more space if the MMU is on.
-constexpr size_t FARCODE_SIZE = 1024 * 1024 * 8;
-constexpr size_t FARCODE_SIZE_MMU = 1024 * 1024 * 48;
+constexpr size_t FARCODE_SIZE = 1024 * 1024 * 48;
 
 // A place to throw blocks of code we don't want polluting the cache, e.g. rarely taken
 // exception branches.

--- a/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.h
@@ -16,11 +16,12 @@ constexpr size_t FARCODE_SIZE = 1024 * 1024 * 48;
 class FarCodeCache : public Gen::X64CodeBlock
 {
 public:
-  void Init(size_t size);
+  void Init();
   void Shutdown();
 
   bool Enabled() const;
 
 private:
+  static std::array<u8, FARCODE_SIZE> code_area;
   bool m_enabled = false;
 };

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -23,19 +23,16 @@
 
 using namespace Gen;
 
-void TrampolineCache::Init(size_t size)
-{
-  AllocCodeSpace(size);
-}
+alignas(JIT_MEM_ALIGNMENT) std::array<u8, TRAMPOLINE_CODE_SIZE> TrampolineCache::code_area;
 
-void TrampolineCache::ClearCodeSpace()
+void TrampolineCache::Init()
 {
-  X64CodeBlock::ClearCodeSpace();
+  SetCodeSpace(code_area.data(), code_area.size());
 }
 
 void TrampolineCache::Shutdown()
 {
-  FreeCodeSpace();
+  ReleaseCodeSpace();
 }
 
 const u8* TrampolineCache::GenerateTrampoline(const TrampolineInfo& info)

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include "Common/CommonTypes.h"
 #include "Core/PowerPC/Jit64Common/EmuCodeBlock.h"
@@ -22,9 +23,10 @@ class TrampolineCache : public EmuCodeBlock
   const u8* GenerateReadTrampoline(const TrampolineInfo& info);
   const u8* GenerateWriteTrampoline(const TrampolineInfo& info);
 
+  static std::array<u8, TRAMPOLINE_CODE_SIZE> code_area;
+
 public:
-  void Init(size_t size);
+  void Init();
   void Shutdown();
   const u8* GenerateTrampoline(const TrampolineInfo& info);
-  void ClearCodeSpace();
 };

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.h
@@ -12,8 +12,7 @@ struct TrampolineInfo;
 
 // a bit of a hack; the MMU results in more code ending up in the trampoline cache,
 // because fastmem results in far more backpatches in MMU mode
-constexpr size_t TRAMPOLINE_CODE_SIZE = 1024 * 1024 * 8;
-constexpr size_t TRAMPOLINE_CODE_SIZE_MMU = 1024 * 1024 * 32;
+constexpr size_t TRAMPOLINE_CODE_SIZE = 1024 * 1024 * 32;
 
 // We need at least this many bytes for backpatching.
 constexpr int BACKPATCH_SIZE = 5;

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -261,12 +261,12 @@ void JitIL::Init()
   jo.accurateSinglePrecision = false;
   UpdateMemoryOptions();
 
-  trampolines.Init(jo.memcheck ? TRAMPOLINE_CODE_SIZE_MMU : TRAMPOLINE_CODE_SIZE);
+  trampolines.Init(TRAMPOLINE_CODE_SIZE);
   AllocCodeSpace(CODE_SIZE);
   blocks.Init();
   asm_routines.Init(nullptr);
 
-  m_far_code.Init(jo.memcheck ? FARCODE_SIZE_MMU : FARCODE_SIZE);
+  m_far_code.Init(FARCODE_SIZE);
   Clear();
 
   code_block.m_stats = &js.st;

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -27,6 +27,8 @@
 using namespace Gen;
 using namespace PowerPC;
 
+alignas(JIT_MEM_ALIGNMENT) std::array<u8, CODE_SIZE> JitIL::code_area;
+
 // Dolphin's PowerPC->x86 JIT dynamic recompiler
 // (Nearly) all code by ector (hrydgard)
 // Features:
@@ -261,12 +263,12 @@ void JitIL::Init()
   jo.accurateSinglePrecision = false;
   UpdateMemoryOptions();
 
-  trampolines.Init(TRAMPOLINE_CODE_SIZE);
-  AllocCodeSpace(CODE_SIZE);
+  trampolines.Init();
+  SetCodeSpace(code_area.data(), code_area.size());
   blocks.Init();
   asm_routines.Init(nullptr);
 
-  m_far_code.Init(FARCODE_SIZE);
+  m_far_code.Init();
   Clear();
 
   code_block.m_stats = &js.st;
@@ -295,7 +297,7 @@ void JitIL::Shutdown()
     JitILProfiler::Shutdown();
   }
 
-  FreeCodeSpace();
+  ReleaseCodeSpace();
 
   blocks.Shutdown();
   trampolines.Shutdown();

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "Common/CommonTypes.h"
 #include "Common/x64ABI.h"
 #include "Common/x64Emitter.h"
@@ -77,4 +79,7 @@ public:
   void DynaRunTable31(UGeckoInstruction _inst) override;
   void DynaRunTable59(UGeckoInstruction _inst) override;
   void DynaRunTable63(UGeckoInstruction _inst) override;
+
+private:
+  static std::array<u8, CODE_SIZE> code_area;
 };

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -26,7 +26,6 @@
 
 using namespace Arm64Gen;
 
-static const int AARCH64_FARCODE_SIZE = 1024 * 1024 * 16;
 static bool HasCycleCounters()
 {
   // Bit needs to be set to support cycle counters
@@ -38,9 +37,8 @@ static bool HasCycleCounters()
 
 void JitArm64::Init()
 {
-  size_t child_code_size = SConfig::GetInstance().bMMU ? FARCODE_SIZE_MMU : AARCH64_FARCODE_SIZE;
-  AllocCodeSpace(CODE_SIZE + child_code_size);
-  AddChildCodeSpace(&farcode, child_code_size);
+  AllocCodeSpace(AARCH64_CODE_SIZE + AARCH64_FARCODE_SIZE, false);
+  AddChildCodeSpace(&farcode, AARCH64_FARCODE_SIZE);
   jo.enableBlocklink = true;
   jo.optimizeGatherPipe = true;
   UpdateMemoryOptions();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -37,7 +37,7 @@ static bool HasCycleCounters()
 
 void JitArm64::Init()
 {
-  AllocCodeSpace(AARCH64_CODE_SIZE + AARCH64_FARCODE_SIZE, false);
+  AllocCodeSpace(AARCH64_CODE_SIZE + AARCH64_FARCODE_SIZE);
   AddChildCodeSpace(&farcode, AARCH64_FARCODE_SIZE);
   jo.enableBlocklink = true;
   jo.optimizeGatherPipe = true;

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -18,8 +18,8 @@
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 
-constexpr size_t CODE_SIZE = 1024 * 1024 * 32;
-constexpr size_t FARCODE_SIZE_MMU = 1024 * 1024 * 48;
+constexpr size_t AARCH64_CODE_SIZE = 1024 * 1024 * 32;
+constexpr size_t AARCH64_FARCODE_SIZE = 1024 * 1024 * 48;
 
 class JitArm64 : public JitBase, public Arm64Gen::ARM64CodeBlock, public CommonAsmRoutinesBase
 {

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -46,7 +46,7 @@ VertexLoaderX64::VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att)
   if (!IsInitialized())
     return;
 
-  AllocCodeSpace(4096, false);
+  AllocCodeSpace(4096);
   ClearCodeSpace();
   GenerateVertexLoader();
   WriteProtect();


### PR DESCRIPTION
This PR uses a global array for the code region of the DSP LLE emitter. The idea is to get rid of the "AllocateExecutableMemory" function, which has shown to be an issue with PIE binaries.