### PR TITLE
JitCommon: Move x86-64 specifics out of the JitState struct

### DIFF
--- a/Source/Core/Common/BreakPoints.cpp
+++ b/Source/Core/Common/BreakPoints.cpp
@@ -9,6 +9,7 @@
 #include "Common/BreakPoints.h"
 #include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
+#include "Common/Logging/Log.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/JitCommon/JitCache.h"
 

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Util.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Util.cpp
@@ -39,11 +39,13 @@ void EmuCodeBlock::MemoryExceptionCheck()
   // If memcheck (ie: MMU) mode is enabled and we haven't generated an
   // exception handler for this instruction yet, we will generate an
   // exception check.
-  if (jit->jo.memcheck && !jit->js.fastmemLoadStore && !jit->js.fixupExceptionHandler)
+  auto* const jit64_base = static_cast<Jitx86Base*>(jit);
+  if (jit64_base->jo.memcheck && !jit64_base->js.fastmemLoadStore &&
+      !jit64_base->JIT64State().fixup_exception_handler)
   {
     TEST(32, PPCSTATE(Exceptions), Gen::Imm32(EXCEPTION_DSI));
-    jit->js.exceptionHandler = J_CC(Gen::CC_NZ, true);
-    jit->js.fixupExceptionHandler = true;
+    jit64_base->JIT64State().exception_handler = J_CC(Gen::CC_NZ, true);
+    jit64_base->JIT64State().fixup_exception_handler = true;
   }
 }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -12,7 +12,6 @@
 #include <unordered_set>
 
 #include "Common/CommonTypes.h"
-#include "Common/x64Emitter.h"
 #include "Core/ConfigManager.h"
 #include "Core/MachineContext.h"
 #include "Core/PowerPC/CPUCoreBase.h"
@@ -65,10 +64,6 @@ protected:
     u32 numFloatingPointInst;
     // If this is set, we need to generate an exception handler for the fastmem load.
     u8* fastmemLoadStore;
-    // If this is set, a load or store already prepared a jump to the exception handler for us,
-    // so just fixup that branch instead of testing for a DSI again.
-    bool fixupExceptionHandler;
-    Gen::FixupBranch exceptionHandler;
     // If these are set, we've stored the old value of a register which will be loaded in
     // revertLoad,
     // which lets us revert it on the exception path.

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -15,6 +15,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/JitRegister.h"
+#include "Common/x64Emitter.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -20,6 +20,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/IniFile.h"
+#include "Common/MsgHandler.h"
 #include "Common/SymbolDB.h"
 
 #include "Core/Boot/Boot.h"

--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -3,9 +3,10 @@
 // Refer to the license.txt file included.
 
 #include <chrono>
+#include <cstdio>
 
 #include "Common/CommonTypes.h"
-#include "Common/Timer.h"
+#include "Common/MemoryUtil.h"
 #include "Core/MemTools.h"
 #include "Core/PowerPC/JitCommon/JitBase.h"
 


### PR DESCRIPTION
Moves it to a Jit64State struct within Jitx86Base.

Downcasting kind of sucks, but it's kind of hard to change that due to the fact the currently active jit instance is a global variable of type JitBase*. Ideally all the necessary JIT backing data structures would be initialized or referenced via non-global storage, which would allow for keeping around type information.

Not to mention the kind-of-ridiculous inheritance tree the JIT code routines have, which consists of the following (multiple entries on the same level of indentation signify multiple inheritance). This also makes it infeasible to just past the correctly typed JIT instance through to EmuCodeBlock, because it's not a direct parent class.

- Jit64AsmRoutineManager
  - CommonAsmRoutines
    - CommonAsmRoutinesBase
    - QuantizedMemoryRoutines
      - EmuCodeBlock
        - Gen::X64CodeBlock
