### PR TITLE
Disable screensaver on OS X (and possibly on macOS Sierra, onwards as well)

### DIFF
--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -24,6 +24,10 @@
 #include "DolphinWX/X11Utils.h"
 #endif
 
+#if defined(__APPLE__)
+#import <IOKit/pwr_mgt/IOPMLib.h>
+#endif
+
 // Class declarations
 class CGameListCtrl;
 class CCodeWindow;
@@ -171,6 +175,11 @@ private:
     ADD_PANE_RIGHT,
     ADD_PANE_CENTER
   };
+
+#ifdef __APPLE__
+  IOPMAssertionID m_disable_screensaver_assertion_id;
+  IOReturn m_disable_screensaver_assertion_creation_success;
+#endif
 
   wxTimer m_poll_hotkey_timer;
   wxTimer m_handle_signal_timer;

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -84,6 +84,10 @@
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 
+#if defined(__APPLE__)
+#import <IOKit/pwr_mgt/IOPMLib.h>
+#endif
+
 class InputConfig;
 class wxFrame;
 
@@ -710,6 +714,15 @@ void CFrame::StartGame(const std::string& filename)
         SConfig::GetInstance().bDisableScreenSaver ? ES_DISPLAY_REQUIRED : 0;
     SetThreadExecutionState(ES_CONTINUOUS | shouldScreenSave | ES_SYSTEM_REQUIRED);
 #endif
+#ifdef __APPLE__
+    CFStringRef reason_for_activity = CFSTR("Emulation Running");
+     m_disable_screensaver_assertion_creation_success =
+      IOPMAssertionCreateWithName(
+        kIOPMAssertionTypeNoDisplaySleep,
+        kIOPMAssertionLevelOn,
+         reason_for_activity,
+        & m_disable_screensaver_assertion_id);
+#endif
 
     // We need this specifically to support setting the focus properly when using
     // the 'render to main window' feature on Windows
@@ -887,6 +900,13 @@ void CFrame::OnStopped()
 #ifdef _WIN32
   // Allow windows to resume normal idling behavior
   SetThreadExecutionState(ES_CONTINUOUS);
+#endif
+#ifdef __APPLE__
+    if (m_disable_screensaver_assertion_creation_success == kIOReturnSuccess)
+    { 
+       m_disable_screensaver_assertion_creation_success =
+        IOPMAssertionRelease( m_disable_screensaver_assertion_id);
+    }
 #endif
 
   m_RenderFrame->SetTitle(StrToWxStr(scm_rev_str));


### PR DESCRIPTION
Looking at the source code, I assume that Dolphin was designed to run with the screensaver disabled, during gameplay. At least it seems to be the case for Windows and X11.

However, this does not seem to be the case on OS X; the screensaver would interrupt gameplay (especially annoying if you have been in the middle of a heated 10-minute long game on Super Smash Bros. Melee, which is the time my system is set up to have the screensaver kick in). This behaviour seems to be contrary to that of Dolphin running on Windows and X11. In this pull request I'm extending the functionality of disabling the screensaver during gameplay, on OS X.

The changes proposed in this pull request have been tested on OS X, 10.11 (El Capitan).

I'm hoping that somebody with macOS Sierra installed can also take a look.