### PR TITLE
GCI Folder support for TAS Recording/Playback

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -344,6 +344,8 @@ bool BootCore(const std::string& _rFilename)
                          StringFromFormat("Movie%s.raw", (i == 0) ? "A" : "B")))
           File::Delete(File::GetUserPath(D_GCUSER_IDX) +
                        StringFromFormat("Movie%s.raw", (i == 0) ? "A" : "B"));
+        if (File::Exists(File::GetUserPath(D_GCUSER_IDX) + "Movie"))
+          File::DeleteDirRecursively(File::GetUserPath(D_GCUSER_IDX) + "Movie");
       }
     }
   }

--- a/Source/Core/Core/HW/EXI/EXI.h
+++ b/Source/Core/Core/HW/EXI/EXI.h
@@ -21,6 +21,7 @@ class Mapping;
 
 enum
 {
+  MAX_MEMORYCARD_SLOTS = 2,
   MAX_EXI_CHANNELS = 3
 };
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -163,9 +163,14 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 
   const bool shift_jis = region == DiscIO::Region::NTSC_J;
 
-  std::string strDirectoryName = File::GetUserPath(D_GCUSER_IDX) +
-                                 SConfig::GetDirectoryForRegion(region) + DIR_SEP +
-                                 StringFromFormat("Card %c", 'A' + card_index);
+  std::string strDirectoryName = File::GetUserPath(D_GCUSER_IDX);
+
+  if (Movie::IsPlayingInput() && Movie::IsConfigSaved() && Movie::IsUsingMemcard(card_index) &&
+      Movie::IsStartingFromClearSave())
+    strDirectoryName += "Movie" DIR_SEP;
+
+  strDirectoryName = strDirectoryName + SConfig::GetDirectoryForRegion(region) + DIR_SEP +
+                     StringFromFormat("Card %c", 'A' + card_index);
 
   if (!File::Exists(strDirectoryName))  // first use of memcard folder, migrate automatically
   {

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -465,6 +465,7 @@ bool IsUsingMemcard(int memcard)
 {
   return (s_memcards & (1 << memcard)) != 0;
 }
+
 bool IsSyncGPU()
 {
   return s_bSyncGPU;
@@ -1486,8 +1487,12 @@ void GetSettings()
     s_bClearSave = !File::Exists(SConfig::GetInstance().m_strMemoryCardA);
     s_language = SConfig::GetInstance().SelectedLanguage;
   }
-  s_memcards |= (SConfig::GetInstance().m_EXIDevice[0] == EXIDEVICE_MEMORYCARD) << 0;
-  s_memcards |= (SConfig::GetInstance().m_EXIDevice[1] == EXIDEVICE_MEMORYCARD) << 1;
+  s_memcards |= (SConfig::GetInstance().m_EXIDevice[0] == EXIDEVICE_MEMORYCARD ||
+                 SConfig::GetInstance().m_EXIDevice[0] == EXIDEVICE_MEMORYCARDFOLDER)
+                << 0;
+  s_memcards |= (SConfig::GetInstance().m_EXIDevice[1] == EXIDEVICE_MEMORYCARD ||
+                 SConfig::GetInstance().m_EXIDevice[1] == EXIDEVICE_MEMORYCARDFOLDER)
+                << 1;
 
   std::array<u8, 20> revision = ConvertGitRevisionToBytes(scm_rev_git_str);
   std::copy(std::begin(revision), std::end(revision), std::begin(s_revision));


### PR DESCRIPTION
This allows GCI folders to be used for both playback and recording of TASes. The memory card check has been updated to check if either a memory card or GCI folder is selected in the GC config, and will also allow a blank GCI folder to be used for playback with a clean memory card.