### PR TITLE
DolphinWX: Fix booting from DVD

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -468,8 +468,6 @@ CFrame::~CFrame()
   HotkeyManagerEmu::Shutdown();
   g_controller_interface.Shutdown();
 
-  drives.clear();
-
 #if defined(HAVE_XRANDR) && HAVE_XRANDR
   delete m_XRRConfig;
 #endif

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -162,8 +162,6 @@ private:
   bool m_tried_graceful_shutdown = false;
   int m_saveSlot = 1;
 
-  std::vector<std::string> drives;
-
   enum
   {
     ADD_PANE_TOP,

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -733,7 +733,8 @@ void CFrame::StartGame(const std::string& filename)
 
 void CFrame::OnBootDrive(wxCommandEvent& event)
 {
-  BootGame(drives[event.GetId() - IDM_DRIVE1]);
+  const auto* menu = static_cast<wxMenu*>(event.GetEventObject());
+  BootGame(WxStrToStr(menu->GetLabelText(event.GetId())));
 }
 
 void CFrame::OnRefresh(wxCommandEvent& WXUNUSED(event))


### PR DESCRIPTION
OnBootDrive used the "drives" member std::vector for drive paths, but
since PR #4363, this vector is not populated anymore, so we were
accessing it out of bounds.

Actually, drives was not needed in the first place, since we can
get the wxMenu from the event, and from there, get the label directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4527)
<!-- Reviewable:end -->
