### PR TITLE
Remove leftover SkipIdle function

### DIFF
--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -137,7 +137,6 @@ bool IsConfigSaved();
 bool IsDualCore();
 bool IsProgressive();
 bool IsPAL60();
-bool IsSkipIdle();
 bool IsDSPHLE();
 bool IsFastDiscSpeed();
 int GetCPUMode();


### PR DESCRIPTION
Trivial commit, was leftover from the remove skip idle option PR.