### PR TITLE
EmuCodeBlock: Make nearcode and farcode protected

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -105,9 +105,9 @@ public:
   void Clear();
 
 protected:
-  FarCodeCache farcode;
-  u8* nearcode;  // Backed up when we switch to far code.
+  FarCodeCache m_far_code;
+  u8* m_near_code;  // Backed up when we switch to far code.
 
-  std::unordered_map<u8*, TrampolineInfo> backPatchInfo;
-  std::unordered_map<u8*, u8*> exceptionHandlerAtLoc;
+  std::unordered_map<u8*, TrampolineInfo> m_back_patch_info;
+  std::unordered_map<u8*, u8*> m_exception_handler_at_loc;
 };

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.h
@@ -22,9 +22,6 @@ class Mapping;
 class EmuCodeBlock : public Gen::X64CodeBlock
 {
 public:
-  FarCodeCache farcode;
-  u8* nearcode;  // Backed up when we switch to far code.
-
   void MemoryExceptionCheck();
 
   // Simple functions to switch between near and far code emitting
@@ -108,6 +105,9 @@ public:
   void Clear();
 
 protected:
+  FarCodeCache farcode;
+  u8* nearcode;  // Backed up when we switch to far code.
+
   std::unordered_map<u8*, TrampolineInfo> backPatchInfo;
   std::unordered_map<u8*, u8*> exceptionHandlerAtLoc;
 };

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
@@ -44,8 +44,8 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
   if (!IsInSpace(codePtr))
     return false;  // this will become a regular crash real soon after this
 
-  auto it = backPatchInfo.find(codePtr);
-  if (it == backPatchInfo.end())
+  auto it = m_back_patch_info.find(codePtr);
+  if (it == m_back_patch_info.end())
   {
     PanicAlert("BackPatch: no register use entry for address %p", codePtr);
     return false;
@@ -56,8 +56,8 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
   u8* exceptionHandler = nullptr;
   if (jit->jo.memcheck)
   {
-    auto it2 = exceptionHandlerAtLoc.find(codePtr);
-    if (it2 != exceptionHandlerAtLoc.end())
+    auto it2 = m_exception_handler_at_loc.find(codePtr);
+    if (it2 != m_exception_handler_at_loc.end())
       exceptionHandler = it2->second;
   }
 

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -266,7 +266,7 @@ void JitIL::Init()
   blocks.Init();
   asm_routines.Init(nullptr);
 
-  farcode.Init(jo.memcheck ? FARCODE_SIZE_MMU : FARCODE_SIZE);
+  m_far_code.Init(jo.memcheck ? FARCODE_SIZE_MMU : FARCODE_SIZE);
   Clear();
 
   code_block.m_stats = &js.st;
@@ -283,7 +283,7 @@ void JitIL::ClearCache()
 {
   blocks.Clear();
   trampolines.ClearCodeSpace();
-  farcode.ClearCodeSpace();
+  m_far_code.ClearCodeSpace();
   ClearCodeSpace();
   Clear();
 }
@@ -300,7 +300,7 @@ void JitIL::Shutdown()
   blocks.Shutdown();
   trampolines.Shutdown();
   asm_routines.Shutdown();
-  farcode.Shutdown();
+  m_far_code.Shutdown();
 }
 
 void JitIL::FallBackToInterpreter(UGeckoInstruction _inst)
@@ -465,8 +465,8 @@ void JitIL::Trace()
 
 void JitIL::Jit(u32 em_address)
 {
-  if (IsAlmostFull() || farcode.IsAlmostFull() || trampolines.IsAlmostFull() || blocks.IsFull() ||
-      SConfig::GetInstance().bJITNoBlockCache)
+  if (IsAlmostFull() || m_far_code.IsAlmostFull() || trampolines.IsAlmostFull() ||
+      blocks.IsFull() || SConfig::GetInstance().bJITNoBlockCache)
   {
     ClearCache();
   }


### PR DESCRIPTION
There's no need for them to be publicly accessible