### PR TITLE
Use $DOLPHIN_EMU_PATH as an alternative for the user directory

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -172,7 +172,8 @@ rules folder.
 A number of user writeable directories are created for caching purposes or for
 allowing the user to edit their contents. On macOS and Linux these folders are
 stored in `~/Library/Application Support/Dolphin/` and `~/.dolphin-emu`
-respectively. On Windows the user directory is stored in the `My Documents`
+respectively, but can be overwritten by setting the environment variable
+`DOLPHIN_EMU_USERPATH`. On Windows the user directory is stored in the `My Documents`
 folder by default, but there are various way to override this behavior:
 
 * Creating a file called `portable.txt` next to the Dolphin executable will

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -135,6 +135,7 @@ void SetUserDirectory(const std::string& custom_path)
   // Make sure it ends in DIR_SEP.
   if (*user_path.rbegin() != DIR_SEP_CHR)
     user_path += DIR_SEP;
+
 #else
   if (File::Exists(ROOT_DIR DIR_SEP USERDATA_DIR))
   {
@@ -142,6 +143,7 @@ void SetUserDirectory(const std::string& custom_path)
   }
   else
   {
+    const char* env_path = getenv("DOLPHIN_EMU_USERPATH");
     const char* home = getenv("HOME");
     if (!home)
       home = getenv("PWD");
@@ -150,14 +152,23 @@ void SetUserDirectory(const std::string& custom_path)
     std::string home_path = std::string(home) + DIR_SEP;
 
 #if defined(__APPLE__) || defined(ANDROID)
-    user_path = home_path + DOLPHIN_DATA_DIR DIR_SEP;
+    if (env_path)
+    {
+      user_path = env_path;
+    }
+    else
+    {
+      user_path = home_path + DOLPHIN_DATA_DIR DIR_SEP;
+    }
 #else
-    // We are on a non-Apple and non-Android POSIX system, there are 3 cases:
+    // We are on a non-Apple and non-Android POSIX system, there are 4 cases:
     // 1. GetExeDirectory()/portable.txt exists
-    //    -> Use GetExeDirectory/User
-    // 2. ~/.dolphin-emu directory exists
+    //    -> Use GetExeDirectory()/User
+    // 2. $DOLPHIN_EMU_USERPATH is set
+    //    -> Use $DOLPHIN_EMU_USERPATH
+    // 3. ~/.dolphin-emu directory exists
     //    -> Use ~/.dolphin-emu
-    // 3. Default
+    // 4. Default
     //    -> Use XDG basedir, see
     //    http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
     user_path = home_path + "." DOLPHIN_DATA_DIR DIR_SEP;
@@ -165,6 +176,10 @@ void SetUserDirectory(const std::string& custom_path)
     if (File::Exists(exe_path + DIR_SEP "portable.txt"))
     {
       user_path = exe_path + DIR_SEP "User" DIR_SEP;
+    }
+    else if (env_path)
+    {
+      user_path = env_path;
     }
     else if (!File::Exists(user_path))
     {


### PR DESCRIPTION
Allow to use the environment variable `DOLPHIN_EMU_PATH` to set the user directory. This has the advantage to be declared in their `.profile` or similar files, so they don't always have to use the command line parameter `-u` (or symlinking the default directory).

Please note that when there's no trailing slash (`/`), it'll create directories like (assuming `DOLPHIN_EMU_PATH` is set to `/tmp/dolphin`) `/tmp/dolphinGC/`, `/tmp/dolphinConfig/`, et cetera.

This was only made for POSIX systems and Mac OS X, because Windows got the somewhat similar Registry. However, I don't have Mac OS X, so I couldn't test it there. I briefly tested it in Ubuntu, where it works.

It is [based of this thread and post](https://forums.dolphin-emu.org/Thread-some-help-with-this-global-user-directory?pid=431063#pid431063).