### PR TITLE
Silences an error during compilation due to an unused (but set) variable

### DIFF
--- a/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp
@@ -229,7 +229,6 @@ long CISOProperties::GetElementStyle(const char* section, const char* key)
 void CISOProperties::CreateGUIControls()
 {
   const int space5 = FromDIP(5);
-  const int space10 = FromDIP(10);
 
   wxButton* const EditConfig = new wxButton(this, ID_EDITCONFIG, _("Edit Config"));
   EditConfig->SetToolTip(_("This will let you manually edit the INI config file."));


### PR DESCRIPTION
Silences a warning during compilation:

    dolphin-emu/Source/Core/DolphinWX/ISOProperties/ISOProperties.cpp:232:13: warning: unused variable ‘space10’ [-Wunused-variable]

Would I also be able to remove the:

     const int spaceN = FromDIP(N);

From individual functions and add them as static global variables to reduce duplicated code? Or are they actually different values each time they're called? e.g.

    function foo {
        const int space10 = FromDIP(10);
        // space10 = 1234
    }
    
    function bar {
        const int space10 = FromDIP(10);
        // space10 = 5678
    }