### PR TITLE
DiscIO: Add GetRegion function and Region enum

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -419,7 +419,7 @@ bool CBoot::BootUp()
 
     // Poor man's bootup
     if (_StartupPara.bWii)
-      SetupWiiMemory(DiscIO::Country::COUNTRY_UNKNOWN);
+      SetupWiiMemory(DiscIO::Region::UNKNOWN_REGION);
     else
       EmulatedBS2_GC(true);
 

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -9,10 +9,10 @@
 
 namespace DiscIO
 {
-enum class Country;
+enum class Region;
 }
 
-struct CountrySetting
+struct RegionSetting
 {
   const std::string area;
   const std::string video;
@@ -57,5 +57,5 @@ private:
   static bool Load_BS2(const std::string& _rBootROMFilename);
   static void Load_FST(bool _bIsWii);
 
-  static bool SetupWiiMemory(DiscIO::Country country);
+  static bool SetupWiiMemory(DiscIO::Region region);
 };

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -7,11 +7,6 @@
 #include <cstdlib>
 #include <string>
 
-namespace DiscIO
-{
-enum class Region;
-}
-
 struct RegionSetting
 {
   const std::string area;
@@ -57,5 +52,5 @@ private:
   static bool Load_BS2(const std::string& _rBootROMFilename);
   static void Load_FST(bool _bIsWii);
 
-  static bool SetupWiiMemory(DiscIO::Region region);
+  static bool SetupWiiMemory();
 };

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -89,13 +89,8 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
   if (titleID == TITLEID_SYSMENU)
     HLE_IPC_CreateVirtualFATFilesystem();
   // setup Wii memory
-  if (!SetupWiiMemory(ContentLoader.GetRegion()))
+  if (!SetupWiiMemory())
     return false;
-  // this sets a bit that is used to detect NTSC-J
-  if (ContentLoader.GetRegion() == DiscIO::Region::NTSC_J)
-  {
-    VideoInterface::SetRegionReg('J');
-  }
   // DOL
   const DiscIO::SNANDContent* pContent =
       ContentLoader.GetContentByIndex(ContentLoader.GetBootIndex());

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -89,10 +89,10 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
   if (titleID == TITLEID_SYSMENU)
     HLE_IPC_CreateVirtualFATFilesystem();
   // setup Wii memory
-  if (!SetupWiiMemory(ContentLoader.GetCountry()))
+  if (!SetupWiiMemory(ContentLoader.GetRegion()))
     return false;
   // this sets a bit that is used to detect NTSC-J
-  if (ContentLoader.GetCountry() == DiscIO::Country::COUNTRY_JAPAN)
+  if (ContentLoader.GetRegion() == DiscIO::Region::NTSC_J)
   {
     VideoInterface::SetRegionReg('J');
   }

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -28,6 +28,7 @@
 #include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+
 #include "Core/BootManager.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -38,6 +39,9 @@
 #include "Core/Host.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
+
+#include "DiscIO/Enums.h"
+
 #include "VideoCommon/VideoBackendBase.h"
 
 namespace BootManager
@@ -349,17 +353,19 @@ bool BootCore(const std::string& _rFilename)
     g_SRAM_netplay_initialized = false;
   }
 
+  const bool ntsc = DiscIO::IsNTSC(StartUp.m_region);
+
   // Apply overrides
-  // Some NTSC GameCube games such as Baten Kaitos react strangely to language settings that would
-  // be invalid on an NTSC system
-  if (!StartUp.bOverrideGCLanguage && StartUp.bNTSC)
+  // Some NTSC GameCube games such as Baten Kaitos react strangely to
+  // language settings that would be invalid on an NTSC system
+  if (!StartUp.bOverrideGCLanguage && ntsc)
   {
     StartUp.SelectedLanguage = 0;
   }
 
-  // Some NTSC Wii games such as Doc Louis's Punch-Out!! and 1942 (Virtual Console) crash if the
-  // PAL60 option is enabled
-  if (StartUp.bWii && StartUp.bNTSC)
+  // Some NTSC Wii games such as Doc Louis's Punch-Out!! and
+  // 1942 (Virtual Console) crash if the PAL60 option is enabled
+  if (StartUp.bWii && ntsc)
   {
     StartUp.bPAL60 = false;
   }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -16,6 +16,7 @@
 namespace DiscIO
 {
 enum class Language;
+enum class Region;
 }
 
 // DSP Backend Types
@@ -92,7 +93,6 @@ struct SConfig : NonCopyable
   bool bDSPThread = false;
   bool bDSPHLE = true;
   bool bSyncGPUOnSkipIdleHack = true;
-  bool bNTSC = false;
   bool bForceNTSCJ = false;
   bool bHLE_BS2 = true;
   bool bEnableCheats = false;
@@ -183,7 +183,9 @@ struct SConfig : NonCopyable
     BOOT_BS2,
     BOOT_DFF
   };
+
   EBootType m_BootType;
+  DiscIO::Region m_region;
 
   std::string m_strVideoBackend;
   std::string m_strGPUDeterminismMode;
@@ -206,6 +208,7 @@ struct SConfig : NonCopyable
   std::string m_perfDir;
 
   void LoadDefaults();
+  static const char* GetDirectoryForRegion(DiscIO::Region region);
   bool AutoSetup(EBootBS2 _BootBS2);
   const std::string& GetGameID() const { return m_strGameID; }
   void CheckMemcardPath(std::string& memcardPath, const std::string& gameRegion, bool isSlotA);

--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -13,6 +13,7 @@
 #include "Common/MemoryUtil.h"
 #include "Common/StringUtil.h"
 #include "Common/Timer.h"
+
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -21,6 +22,8 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
+
+#include "DiscIO/Enums.h"
 
 // We should provide an option to choose from the above, or figure out the checksum (the algo in
 // yagcd seems wrong)
@@ -89,7 +92,7 @@ void CEXIIPL::Descrambler(u8* data, u32 size)
 CEXIIPL::CEXIIPL() : m_uPosition(0), m_uAddress(0), m_uRWOffset(0), m_FontsLoaded(false)
 {
   // Determine region
-  m_bNTSC = SConfig::GetInstance().bNTSC;
+  m_bNTSC = DiscIO::IsNTSC(SConfig::GetInstance().m_region);
 
   // Create the IPL
   m_pIPL = static_cast<u8*>(Common::AllocateMemoryPages(ROM_SIZE));

--- a/Source/Core/Core/HW/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.cpp
@@ -91,17 +91,16 @@ void CEXIIPL::Descrambler(u8* data, u32 size)
 
 CEXIIPL::CEXIIPL() : m_uPosition(0), m_uAddress(0), m_uRWOffset(0), m_FontsLoaded(false)
 {
-  // Determine region
-  m_bNTSC = DiscIO::IsNTSC(SConfig::GetInstance().m_region);
-
   // Create the IPL
   m_pIPL = static_cast<u8*>(Common::AllocateMemoryPages(ROM_SIZE));
 
   if (SConfig::GetInstance().bHLE_BS2)
   {
     // Copy header
-    memcpy(m_pIPL, m_bNTSC ? iplverNTSC : iplverPAL,
-           m_bNTSC ? sizeof(iplverNTSC) : sizeof(iplverPAL));
+    if (DiscIO::IsNTSC(SConfig::GetInstance().m_region))
+      memcpy(m_pIPL, iplverNTSC, sizeof(iplverNTSC));
+    else
+      memcpy(m_pIPL, iplverPAL, sizeof(iplverPAL));
 
     // Load fonts
     LoadFontFile((File::GetSysDirectory() + GC_SYS_DIR + DIR_SEP + FONT_SHIFT_JIS), 0x1aff00);

--- a/Source/Core/Core/HW/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI_DeviceIPL.h
@@ -52,9 +52,6 @@ private:
     REGION_EUART = 0x300001
   };
 
-  // Region
-  bool m_bNTSC;
-
   //! IPL
   u8* m_pIPL;
 

--- a/Source/Core/Core/HW/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard.h
@@ -103,7 +103,7 @@ struct Header  // Offset    Size    Description
   // end Serial in libogc
   u8 deviceID[2];     // 0x0020    2       0 if formated in slot A 1 if formated in slot B
   u8 SizeMb[2];       // 0x0022    2       Size of memcard in Mbits
-  u16 Encoding;       // 0x0024    2       Encoding (ASCII or Japanese)
+  u16 Encoding;       // 0x0024    2       Encoding (Windows-1252 or Shift JIS)
   u8 Unused1[468];    // 0x0026    468     Unused (0xff)
   u16 UpdateCounter;  // 0x01fa    2       Update Counter (?, probably unused)
   u16 Checksum;       // 0x01fc    2       Additive Checksum

--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -24,7 +24,7 @@
 const int NO_INDEX = -1;
 static const char* MC_HDR = "MC_SYSTEM_AREA";
 
-int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::Country card_region,
+int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::Region card_region,
                                 bool currentGameOnly)
 {
   File::IOFile gcifile(fileName, "rb");
@@ -39,27 +39,12 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::Country car
       return NO_INDEX;
     }
 
-    DiscIO::Country gci_region;
-    // check region
-    switch (gci.m_gci_header.Gamecode[3])
-    {
-    case 'J':
-      gci_region = DiscIO::Country::COUNTRY_JAPAN;
-      break;
-    case 'E':
-      gci_region = DiscIO::Country::COUNTRY_USA;
-      break;
-    case 'C':
-      // Used by Datel Action Replay Save
-      // can be on any regions card
-      gci_region = card_region;
-      break;
-    default:
-      gci_region = DiscIO::Country::COUNTRY_EUROPE;
-      break;
-    }
-
-    if (gci_region != card_region)
+    DiscIO::Region gci_region = DiscIO::RegionSwitchGC(gci.m_gci_header.Gamecode[3]);
+    // Some special save files have game IDs that we parse as UNKNOWN_REGION. For instance:
+    // - Datel Action Replay uses C as the fourth character. (Can be on any region's card.)
+    // - Homeland's network config file only uses null bytes. (Homeland is exclusive to Japan,
+    //   but maybe the network config file ID was intended to be used in other regions too.)
+    if (card_region != gci_region && gci_region != DiscIO::Region::UNKNOWN_REGION)
     {
       PanicAlertT(
           "GCI save file was not loaded because it is the wrong region for this memory card:\n%s",
@@ -146,7 +131,7 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::Country car
 }
 
 GCMemcardDirectory::GCMemcardDirectory(const std::string& directory, int slot, u16 sizeMb,
-                                       bool shift_jis, DiscIO::Country card_region, int gameId)
+                                       bool shift_jis, DiscIO::Region card_region, int gameId)
     : MemoryCardBase(slot, sizeMb), m_GameId(gameId), m_LastBlock(-1),
       m_hdr(slot, sizeMb, shift_jis), m_bat1(sizeMb), m_saves(0), m_SaveDirectory(directory),
       m_exiting(false)

--- a/Source/Core/Core/HW/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcardDirectory.h
@@ -22,9 +22,8 @@ void MigrateFromMemcardFile(const std::string& strDirectoryName, int card_index)
 class GCMemcardDirectory : public MemoryCardBase, NonCopyable
 {
 public:
-  GCMemcardDirectory(const std::string& directory, int slot = 0, u16 sizeMb = MemCard2043Mb,
-                     bool shift_jis = false,
-                     DiscIO::Country card_region = DiscIO::Country::COUNTRY_EUROPE, int gameId = 0);
+  GCMemcardDirectory(const std::string& directory, int slot, u16 sizeMb, bool shift_jis,
+                     DiscIO::Region card_region, int gameId);
   ~GCMemcardDirectory();
   void FlushToFile();
   void FlushThread();
@@ -35,7 +34,7 @@ public:
   void DoState(PointerWrap& p) override;
 
 private:
-  int LoadGCI(const std::string& fileName, DiscIO::Country card_region, bool currentGameOnly);
+  int LoadGCI(const std::string& fileName, DiscIO::Region card_region, bool currentGameOnly);
   inline s32 SaveAreaRW(u32 block, bool writing = false);
   // s32 DirectoryRead(u32 offset, u32 length, u8* destaddress);
   s32 DirectoryWrite(u32 destaddress, u32 length, u8* srcaddress);

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -8,6 +8,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
+
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -16,6 +17,9 @@
 #include "Core/HW/SI.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/HW/VideoInterface.h"
+
+#include "DiscIO/Enums.h"
+
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -167,12 +171,14 @@ void Preset(bool _bNTSC)
   m_FilterCoefTables = {};
   m_UnkAARegister = 0;
 
+  DiscIO::Region region = SConfig::GetInstance().m_region;
+
   // 54MHz, capable of progressive scan
-  m_Clock = SConfig::GetInstance().bNTSC;
+  m_Clock = DiscIO::IsNTSC(region);
 
   // Say component cable is plugged
   m_DTVStatus.component_plugged = SConfig::GetInstance().bProgressive;
-  m_DTVStatus.ntsc_j = SConfig::GetInstance().bForceNTSCJ;
+  m_DTVStatus.ntsc_j = SConfig::GetInstance().bForceNTSCJ || region == DiscIO::Region::NTSC_J;
 
   m_FBWidth.Hex = 0;
   m_BorderHBlank.Hex = 0;
@@ -406,12 +412,6 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
     mmio->Register(base | i, MMIO::ReadToSmaller<u32>(mmio, base | i, base | (i + 2)),
                    MMIO::WriteToSmaller<u32>(mmio, base | i, base | (i + 2)));
   }
-}
-
-void SetRegionReg(char region)
-{
-  if (!SConfig::GetInstance().bForceNTSCJ)
-    m_DTVStatus.ntsc_j = region == 'J';
 }
 
 void UpdateInterrupts()

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -327,7 +327,6 @@ union UVIHorizontalStepping {
 void Preset(bool _bNTSC);
 
 void Init();
-void SetRegionReg(char region);
 void DoState(PointerWrap& p);
 
 void RegisterMMIO(MMIO::Mapping* mmio, u32 base);

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -11,6 +11,11 @@
 
 namespace DiscIO
 {
+bool IsNTSC(Region region)
+{
+  return region == Region::NTSC_J || region == Region::NTSC_U || region == Region::NTSC_K;
+}
+
 // Increment CACHE_REVISION (ISOFile.cpp & GameFile.cpp) if the code below is modified
 
 Region RegionSwitchGC(u8 country_code)

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -13,6 +13,50 @@ namespace DiscIO
 {
 // Increment CACHE_REVISION (ISOFile.cpp & GameFile.cpp) if the code below is modified
 
+Region RegionSwitchGC(u8 country_code)
+{
+  Region region = RegionSwitchWii(country_code);
+  return region == Region::NTSC_K ? Region::UNKNOWN_REGION : region;
+}
+
+Region RegionSwitchWii(u8 country_code)
+{
+  switch (country_code)
+  {
+  case 'J':
+  case 'W':
+    return Region::NTSC_J;
+
+  case 'B':
+  case 'E':
+  case 'N':
+  case 'Z':
+    return Region::NTSC_U;
+
+  case 'D':
+  case 'F':
+  case 'H':
+  case 'I':
+  case 'L':
+  case 'M':
+  case 'P':
+  case 'R':
+  case 'S':
+  case 'U':
+  case 'X':
+  case 'Y':
+    return Region::PAL;
+
+  case 'K':
+  case 'Q':
+  case 'T':
+    return Region::NTSC_K;
+
+  default:
+    return Region::UNKNOWN_REGION;
+  }
+}
+
 Country CountrySwitch(u8 country_code)
 {
   switch (country_code)

--- a/Source/Core/DiscIO/Enums.h
+++ b/Source/Core/DiscIO/Enums.h
@@ -66,6 +66,7 @@ enum class Language
   LANGUAGE_UNKNOWN
 };
 
+bool IsNTSC(Region region);
 Region RegionSwitchGC(u8 country_code);
 Region RegionSwitchWii(u8 country_code);
 Country CountrySwitch(u8 country_code);

--- a/Source/Core/DiscIO/Enums.h
+++ b/Source/Core/DiscIO/Enums.h
@@ -38,6 +38,16 @@ enum class Country
   NUMBER_OF_COUNTRIES
 };
 
+// Regions 0 - 2 and 4 match Nintendo's Wii region numbering.
+enum class Region
+{
+  NTSC_J = 0,          // Japan and Taiwan
+  NTSC_U = 1,          // Mainly North America
+  PAL = 2,             // Mainly Europe and Oceania
+  UNKNOWN_REGION = 3,  // 3 seems to be unused? Anyway, we need an UNKNOWN_REGION. Let's put it here
+  NTSC_K = 4           // South Korea (Wii only)
+};
+
 // Languages 0 - 9 match Nintendo's Wii language numbering.
 // Languages 1 - 6 match Nintendo's PAL GameCube languages 0 - 5.
 // NTSC GameCubes only support one language and thus don't number languages.
@@ -56,6 +66,8 @@ enum class Language
   LANGUAGE_UNKNOWN
 };
 
+Region RegionSwitchGC(u8 country_code);
+Region RegionSwitchWii(u8 country_code);
 Country CountrySwitch(u8 country_code);
 u8 GetSysMenuRegion(u16 title_version);
 std::string GetCompanyFromID(const std::string& company_id);

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -311,12 +311,12 @@ std::vector<u8> CNANDContentLoader::GetKeyFromTicket(const std::vector<u8>& tick
   return AESDecode(common_key, iv, &ticket[0x01BF], 16);
 }
 
-DiscIO::Country CNANDContentLoader::GetCountry() const
+DiscIO::Region CNANDContentLoader::GetRegion() const
 {
   if (!IsValid())
-    return DiscIO::Country::COUNTRY_UNKNOWN;
+    return DiscIO::Region::UNKNOWN_REGION;
 
-  return CountrySwitch(m_Country);
+  return RegionSwitchWii(m_Country);
 }
 
 CNANDContentManager::~CNANDContentManager()

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -20,7 +20,7 @@ class IOFile;
 
 namespace DiscIO
 {
-enum class Country;
+enum class Region;
 
 bool AddTicket(u64 title_id, const std::vector<u8>& ticket);
 
@@ -94,7 +94,7 @@ public:
   const std::vector<SNANDContent>& GetContent() const { return m_Content; }
   u16 GetTitleVersion() const { return m_TitleVersion; }
   u16 GetNumEntries() const { return m_NumEntries; }
-  DiscIO::Country GetCountry() const;
+  DiscIO::Region GetRegion() const;
   u8 GetCountryChar() const { return m_Country; }
   enum
   {

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -55,6 +55,7 @@ public:
   virtual bool SupportsIntegrityCheck() const { return false; }
   virtual bool CheckIntegrity() const { return false; }
   virtual bool ChangePartition(u64 offset) { return false; }
+  virtual Region GetRegion() const = 0;
   virtual Country GetCountry() const = 0;
   virtual BlobType GetBlobType() const = 0;
   // Size of virtual disc (not always accurate)
@@ -71,12 +72,7 @@ protected:
     // strnlen to trim NULLs
     std::string string(data, strnlen(data, sizeof(data)));
 
-    // There doesn't seem to be any GC discs with the country set to Taiwan...
-    // But maybe they would use Shift_JIS if they existed? Not sure
-    bool use_shift_jis =
-        (Country::COUNTRY_JAPAN == GetCountry() || Country::COUNTRY_TAIWAN == GetCountry());
-
-    if (use_shift_jis)
+    if (GetRegion() == Region::NTSC_J)
       return SHIFTJISToUTF8(string);
     else
       return CP1252ToUTF8(string);

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -166,6 +166,14 @@ void CVolumeDirectory::SetGameID(const std::string& id)
   memcpy(m_disk_header.data(), id.c_str(), std::min(id.length(), MAX_ID_LENGTH));
 }
 
+Region CVolumeDirectory::GetRegion() const
+{
+  if (m_is_wii)
+    return RegionSwitchWii(m_disk_header[3]);
+
+  return RegionSwitchGC(m_disk_header[3]);
+}
+
 Country CVolumeDirectory::GetCountry() const
 {
   return CountrySwitch(m_disk_header[3]);

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -26,6 +26,7 @@ namespace DiscIO
 enum class BlobType;
 enum class Country;
 enum class Language;
+enum class Region;
 enum class Platform;
 
 class CVolumeDirectory : public IVolume
@@ -56,6 +57,7 @@ public:
   std::string GetApploaderDate() const override;
   Platform GetVolumeType() const override;
 
+  Region GetRegion() const override;
   Country GetCountry() const override;
 
   BlobType GetBlobType() const override;

--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -61,13 +61,20 @@ std::string CVolumeGC::GetGameID() const
   return DecodeString(ID);
 }
 
+Region CVolumeGC::GetRegion() const
+{
+  u8 country_code;
+  if (!m_pReader->Read(3, 1, &country_code))
+    return Region::UNKNOWN_REGION;
+
+  return RegionSwitchGC(country_code);
+}
+
 Country CVolumeGC::GetCountry() const
 {
-  if (!m_pReader)
-    return Country::COUNTRY_UNKNOWN;
-
   u8 country_code;
-  m_pReader->Read(3, 1, &country_code);
+  if (!m_pReader->Read(3, 1, &country_code))
+    return Country::COUNTRY_UNKNOWN;
 
   return CountrySwitch(country_code);
 }
@@ -247,7 +254,7 @@ void CVolumeGC::ExtractBannerInformation(const GCBanner& banner_file, bool is_bn
 
   if (is_bnr1)  // NTSC
   {
-    bool is_japanese = GetCountry() == Country::COUNTRY_JAPAN;
+    bool is_japanese = GetRegion() == Region::NTSC_J;
     number_of_languages = 1;
     start_language = is_japanese ? Language::LANGUAGE_JAPANESE : Language::LANGUAGE_ENGLISH;
   }

--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -19,6 +19,7 @@ namespace DiscIO
 enum class BlobType;
 enum class Country;
 enum class Language;
+enum class Region;
 enum class Platform;
 
 class CVolumeGC : public IVolume
@@ -42,6 +43,7 @@ public:
   u8 GetDiscNumber() const override;
 
   Platform GetVolumeType() const override;
+  Region GetRegion() const override;
   Country GetCountry() const override;
   BlobType GetBlobType() const override;
   u64 GetSize() const override;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -57,14 +57,21 @@ bool CVolumeWAD::Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) cons
   return m_pReader->Read(_Offset, _Length, _pBuffer);
 }
 
+Region CVolumeWAD::GetRegion() const
+{
+  u8 country_code;
+  if (!Read(m_tmd_offset + 0x0193, 1, &country_code))
+    return Region::UNKNOWN_REGION;
+
+  return RegionSwitchWii(country_code);
+}
+
 Country CVolumeWAD::GetCountry() const
 {
-  if (!m_pReader)
-    return Country::COUNTRY_UNKNOWN;
-
   // read the last digit of the titleID in the ticket
   u8 country_code;
-  Read(m_tmd_offset + 0x0193, 1, &country_code);
+  if (!Read(m_tmd_offset + 0x0193, 1, &country_code))
+    return Country::COUNTRY_UNKNOWN;
 
   if (country_code == 2)  // SYSMENU
   {

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -21,6 +21,7 @@ namespace DiscIO
 enum class BlobType;
 enum class Country;
 enum class Language;
+enum class Region;
 enum class Platform;
 
 class CVolumeWAD : public IVolume
@@ -39,6 +40,7 @@ public:
   u64 GetFSTSize() const override { return 0; }
   std::string GetApploaderDate() const override { return ""; }
   Platform GetVolumeType() const override;
+  Region GetRegion() const override;
   Country GetCountry() const override;
 
   BlobType GetBlobType() const override;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -20,6 +20,7 @@ namespace DiscIO
 enum class BlobType;
 enum class Country;
 enum class Language;
+enum class Region;
 enum class Platform;
 
 class CVolumeWiiCrypted : public IVolume
@@ -46,6 +47,7 @@ public:
   bool CheckIntegrity() const override;
   bool ChangePartition(u64 offset) override;
 
+  Region GetRegion() const override;
   Country GetCountry() const override;
   BlobType GetBlobType() const override;
   u64 GetSize() const override;

--- a/Source/Core/DolphinQt2/GameList/GameFile.cpp
+++ b/Source/Core/DolphinQt2/GameList/GameFile.cpp
@@ -155,6 +155,7 @@ bool GameFile::TryLoadVolume()
   m_descriptions = ConvertLanguageMap(volume->GetDescriptions());
   m_disc_number = volume->GetDiscNumber();
   m_platform = volume->GetVolumeType();
+  m_region = volume->GetRegion();
   m_country = volume->GetCountry();
   m_blob_type = volume->GetBlobType();
   m_raw_size = volume->GetRawSize();
@@ -174,6 +175,7 @@ bool GameFile::TryLoadElfDol()
   m_revision = 0;
   m_long_names[DiscIO::Language::LANGUAGE_ENGLISH] = m_file_name;
   m_platform = DiscIO::Platform::ELF_DOL;
+  m_region = DiscIO::Region::UNKNOWN_REGION;
   m_country = DiscIO::Country::COUNTRY_UNKNOWN;
   m_blob_type = DiscIO::BlobType::DIRECTORY;
   m_raw_size = m_size;

--- a/Source/Core/DolphinQt2/GameList/GameFile.h
+++ b/Source/Core/DolphinQt2/GameList/GameFile.h
@@ -16,6 +16,7 @@ namespace DiscIO
 enum class BlobType;
 enum class Country;
 enum class Language;
+enum class Region;
 enum class Platform;
 class IVolume;
 }
@@ -47,6 +48,7 @@ public:
   QString GetApploaderDate() const { return m_apploader_date; }
   DiscIO::Platform GetPlatformID() const { return m_platform; }
   QString GetPlatform() const;
+  DiscIO::Region GetRegion() const { return m_region; }
   DiscIO::Country GetCountryID() const { return m_country; }
   QString GetCountry() const;
   DiscIO::BlobType GetBlobType() const { return m_blob_type; }
@@ -96,6 +98,7 @@ private:
   QMap<DiscIO::Language, QString> m_descriptions;
   QString m_company;
   u8 m_disc_number = 0;
+  DiscIO::Region m_region;
   DiscIO::Platform m_platform;
   DiscIO::Country m_country;
   DiscIO::BlobType m_blob_type;

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -36,7 +36,7 @@
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/WxUtils.h"
 
-static const u32 CACHE_REVISION = 0x127;  // Last changed in PR 3309
+static const u32 CACHE_REVISION = 0x128;  // Last changed in PR 4542
 
 static std::string GetLanguageString(DiscIO::Language language,
                                      std::map<DiscIO::Language, std::string> strings)
@@ -64,8 +64,9 @@ static std::string GetLanguageString(DiscIO::Language language,
 GameListItem::GameListItem(const std::string& _rFileName,
                            const std::unordered_map<std::string, std::string>& custom_titles)
     : m_FileName(_rFileName), m_title_id(0), m_emu_state(0), m_FileSize(0),
-      m_Country(DiscIO::Country::COUNTRY_UNKNOWN), m_Revision(0), m_Valid(false), m_ImageWidth(0),
-      m_ImageHeight(0), m_disc_number(0), m_has_custom_name(false)
+      m_region(DiscIO::Region::UNKNOWN_REGION), m_Country(DiscIO::Country::COUNTRY_UNKNOWN),
+      m_Revision(0), m_Valid(false), m_ImageWidth(0), m_ImageHeight(0), m_disc_number(0),
+      m_has_custom_name(false)
 {
   if (LoadFromCache())
   {
@@ -99,6 +100,7 @@ GameListItem::GameListItem(const std::string& _rFileName,
       if (m_company.empty())
         m_company = GetLanguageString(DiscIO::Language::LANGUAGE_ENGLISH, volume->GetShortMakers());
 
+      m_region = volume->GetRegion();
       m_Country = volume->GetCountry();
       m_blob_type = volume->GetBlobType();
       m_FileSize = volume->GetRawSize();
@@ -214,6 +216,7 @@ void GameListItem::DoState(PointerWrap& p)
   p.Do(m_title_id);
   p.Do(m_FileSize);
   p.Do(m_VolumeSize);
+  p.Do(m_region);
   p.Do(m_Country);
   p.Do(m_blob_type);
   p.Do(m_pImage);

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -21,6 +21,7 @@ namespace DiscIO
 enum class BlobType;
 enum class Country;
 enum class Language;
+enum class Region;
 enum class Platform;
 }
 
@@ -48,6 +49,7 @@ public:
   u16 GetRevision() const { return m_Revision; }
   const std::string& GetGameID() const { return m_game_id; }
   const std::string GetWiiFSPath() const;
+  DiscIO::Region GetRegion() const { return m_region; }
   DiscIO::Country GetCountry() const { return m_Country; }
   DiscIO::Platform GetPlatform() const { return m_Platform; }
   DiscIO::BlobType GetBlobType() const { return m_blob_type; }
@@ -82,6 +84,7 @@ private:
   u64 m_FileSize;
   u64 m_VolumeSize;
 
+  DiscIO::Region m_region;
   DiscIO::Country m_Country;
   DiscIO::Platform m_Platform;
   DiscIO::BlobType m_blob_type;


### PR DESCRIPTION
Instead of needing different switch cases for converting countries to regions in multiple places, we now only need a single country-to-region switch case (in DiscIO/Enums.cpp), and we get a nice Region type.

Additionally, the second commit replaces the bNTSC variable in SConfig with a variable of the new Region type, which lets us get rid of VideoInterface::SetRegionReg, a huge hack in CEXIMemoryCard, and some minor things.