### PR TITLE
Stop Movie/Netplay before triggering STM shutdown

### DIFF
--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -90,6 +90,7 @@ public:
 
   void DoPause();
   void DoStop();
+  bool TriggerSTMPowerEvent();
   void OnStopped();
   void DoRecordingSave();
   void UpdateGUI();


### PR DESCRIPTION
This fixes a bug which caused Movie (input recording or playback) ornetplay not to be stopped. DolphinWX previously triggered a STM power event, and then the STM directly stopped the emulation; the code which stops Movie/Netplay was completely skipped.

This is fixed by doing so *before* sending the shutdown event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4545)
<!-- Reviewable:end -->
