### PR TITLE
Fix outdated comments in ScanDirectoryTree

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -439,12 +439,10 @@ bool CreateEmptyFile(const std::string& filename)
   return true;
 }
 
-// Scans the directory tree gets, starting from _Directory and adds the
-// results into parentEntry. Returns the number of files+directories found
+// Recursive or non-recursive list of files and directories under directory.
 FSTEntry ScanDirectoryTree(const std::string& directory, bool recursive)
 {
   INFO_LOG(COMMON, "ScanDirectoryTree: directory %s", directory.c_str());
-  // How many files + directories we found
   FSTEntry parent_entry;
   parent_entry.physicalName = directory;
   parent_entry.isDirectory = true;
@@ -505,7 +503,7 @@ FSTEntry ScanDirectoryTree(const std::string& directory, bool recursive)
   }
   closedir(dirp);
 #endif
-  // Return number of entries found.
+
   return parent_entry;
 }
 

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -112,7 +112,7 @@ bool Copy(const std::string& srcFilename, const std::string& destFilename);
 // creates an empty file filename, returns true on success
 bool CreateEmptyFile(const std::string& filename);
 
-// Recursive or non-recursive list of files under directory.
+// Recursive or non-recursive list of files and directories under directory.
 FSTEntry ScanDirectoryTree(const std::string& directory, bool recursive);
 
 // deletes the given directory and anything under it. Returns true on success.


### PR DESCRIPTION
A while ago, the return value was changed from the count of items to the parent_entry.