### PR TITLE
VolumeDirectory: Sort the FST

### DIFF
--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -85,8 +85,8 @@ private:
   // FST creation
   void WriteEntryData(u32& entryOffset, u8 type, u32 nameOffset, u64 dataOffset, u64 length);
   void WriteEntryName(u32& nameOffset, const std::string& name);
-  void WriteEntry(const File::FSTEntry& entry, u32& fstOffset, u32& nameOffset, u64& dataOffset,
-                  u32 parentEntryNum);
+  void WriteDirectory(const File::FSTEntry& parent_entry, u32& fstOffset, u32& nameOffset,
+                      u64& dataOffset, u32 parentEntryNum);
 
   // returns number of entries found in _Directory
   u64 AddDirectoryEntries(const std::string& _Directory, File::FSTEntry& parentEntry);


### PR DESCRIPTION
We can't rely on the OS returning files and directories in a deterministic order, so we should sort them on our own if we want VolumeDirectory to work for movies and netplay.