### PR TITLE
evdev: reduce startup time

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -175,12 +175,12 @@ void PopulateDevices()
     {
       // Unfortunately udev gives us no way to filter out the non event device interfaces.
       // So we open it and see if it works with evdev ioctls or not.
-      std::string name = GetName(devnode);
       auto input = std::make_shared<evdevDevice>(devnode);
 
       if (input->IsInteresting())
       {
         g_controller_interface.AddDevice(std::move(input));
+        std::string name = GetName(devnode);
         s_devnode_name_map.insert(std::pair<std::string, std::string>(devnode, name));
       }
     }


### PR DESCRIPTION
`GetName()` creates a new evdev device which calls tons of ioctls. But the main culprit is `close()` which for input devices appears to be a slow path in the kernel.

This commit reduces `PopulateDevices()` by 50% on my laptop, but ~730 ms is still ridiculously slow for something that isn't needed right away...