### PR TITLE
DSPAnalyzer: Hide implementation details

### DIFF
--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -5,6 +5,7 @@
 #include "Core/DSP/DSPAnalyzer.h"
 
 #include <array>
+#include <cstddef>
 
 #include "Common/Logging/Log.h"
 
@@ -13,6 +14,10 @@
 
 namespace DSPAnalyzer
 {
+namespace
+{
+constexpr size_t ISPACE = 65536;
+
 // Holds data about all instructions in RAM.
 std::array<u8, ISPACE> code_flags;
 
@@ -21,11 +26,11 @@ std::array<u8, ISPACE> code_flags;
 // as well give up its time slice immediately, after executing once.
 
 // Max signature length is 6. A 0 in a signature is ignored.
-#define NUM_IDLE_SIGS 8
-#define MAX_IDLE_SIG_SIZE 6
+constexpr size_t NUM_IDLE_SIGS = 8;
+constexpr size_t MAX_IDLE_SIG_SIZE = 6;
 
 // 0xFFFF means ignore.
-const u16 idle_skip_sigs[NUM_IDLE_SIGS][MAX_IDLE_SIG_SIZE + 1] = {
+constexpr u16 idle_skip_sigs[NUM_IDLE_SIGS][MAX_IDLE_SIG_SIZE + 1] = {
     // From AX:
     {0x26fc,          // LRS   $30, @DMBH
      0x02c0, 0x8000,  // ANDCF $30, #0x8000
@@ -62,12 +67,12 @@ const u16 idle_skip_sigs[NUM_IDLE_SIGS][MAX_IDLE_SIG_SIZE + 1] = {
      0x0295, 0xFFFF,  // JZ    0x????
      0, 0}};
 
-static void Reset()
+void Reset()
 {
   code_flags.fill(0);
 }
 
-static void AnalyzeRange(u16 start_addr, u16 end_addr)
+void AnalyzeRange(u16 start_addr, u16 end_addr)
 {
   // First we run an extremely simplified version of a disassembler to find
   // where all instructions start.
@@ -146,6 +151,7 @@ static void AnalyzeRange(u16 start_addr, u16 end_addr)
   }
   INFO_LOG(DSPLLE, "Finished analysis.");
 }
+}  // Anonymous namespace
 
 void Analyze()
 {
@@ -154,4 +160,9 @@ void Analyze()
   AnalyzeRange(0x8000, 0x9000);  // IROM
 }
 
-}  // namespace
+u8 GetCodeFlags(u16 address)
+{
+  return code_flags[address];
+}
+
+}  // namespace DSPAnalyzer

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -4,14 +4,11 @@
 
 #pragma once
 
-#include <array>
 #include "Common/CommonTypes.h"
 
 // Basic code analysis.
 namespace DSPAnalyzer
 {
-#define ISPACE 65536
-
 // Useful things to detect:
 // * Loop endpoints - so that we can avoid checking for loops every cycle.
 
@@ -25,11 +22,6 @@ enum
   CODE_CHECK_INT = 32,
 };
 
-// Easy to query array covering the whole of instruction memory.
-// Just index by address.
-// This one will be helpful for debuggers and jits.
-extern std::array<u8, ISPACE> code_flags;
-
 // This one should be called every time IRAM changes - which is basically
 // every time that a new ucode gets uploaded, and never else. At that point,
 // we can do as much static analysis as we want - but we should always throw
@@ -38,4 +30,7 @@ extern std::array<u8, ISPACE> code_flags;
 // some pretty expensive analysis if necessary.
 void Analyze();
 
-}  // namespace
+// Retrieves the flags set during analysis for code in memory.
+u8 GetCodeFlags(u16 address);
+
+}  // namespace DSPAnalyzer

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -100,7 +100,7 @@ void Step()
   u16 opc = dsp_fetch_code();
   ExecuteInstruction(UDSPInstruction(opc));
 
-  if (DSPAnalyzer::code_flags[static_cast<u16>(g_dsp.pc - 1u)] & DSPAnalyzer::CODE_LOOP_END)
+  if (DSPAnalyzer::GetCodeFlags(static_cast<u16>(g_dsp.pc - 1u)) & DSPAnalyzer::CODE_LOOP_END)
     HandleLoop();
 }
 
@@ -158,7 +158,7 @@ int RunCyclesDebug(int cycles)
         return cycles;
       }
       // Idle skipping.
-      if (DSPAnalyzer::code_flags[g_dsp.pc] & DSPAnalyzer::CODE_IDLE_SKIP)
+      if (DSPAnalyzer::GetCodeFlags(g_dsp.pc) & DSPAnalyzer::CODE_IDLE_SKIP)
         return 0;
       Step();
       cycles--;
@@ -208,7 +208,7 @@ int RunCycles(int cycles)
       if (g_dsp.cr & CR_HALT)
         return 0;
       // Idle skipping.
-      if (DSPAnalyzer::code_flags[g_dsp.pc] & DSPAnalyzer::CODE_IDLE_SKIP)
+      if (DSPAnalyzer::GetCodeFlags(g_dsp.pc) & DSPAnalyzer::CODE_IDLE_SKIP)
         return 0;
       Step();
       cycles--;

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
@@ -90,7 +90,7 @@ void DSPEmitter::checkExceptions(u32 retval)
   SetJumpTarget(skipCheck);
 }
 
-bool DSPEmitter::FlagsNeeded()
+bool DSPEmitter::FlagsNeeded() const
 {
   const u8 flags = DSPAnalyzer::GetCodeFlags(compilePC);
 

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -34,7 +34,7 @@ public:
   Block CompileStub();
   void Compile(u16 start_addr);
 
-  bool FlagsNeeded();
+  bool FlagsNeeded() const;
 
   void FallBackToInterpreter(UDSPInstruction inst);
 

--- a/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
@@ -81,7 +81,7 @@ static void WriteBranchExit(DSPEmitter& emitter)
 {
   DSPJitRegCache c(emitter.gpr);
   emitter.gpr.SaveRegs();
-  if (DSPAnalyzer::code_flags[emitter.startAddr] & DSPAnalyzer::CODE_IDLE_SKIP)
+  if (DSPAnalyzer::GetCodeFlags(emitter.startAddr) & DSPAnalyzer::CODE_IDLE_SKIP)
   {
     emitter.MOV(16, R(EAX), Imm16(0x1000));
   }


### PR DESCRIPTION
Allows for removing a bit of details in the header.