### PR TITLE
Vulkan: Clear alpha channel to 0 when pixel format has no alpha channel

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -233,10 +233,10 @@ FramebufferManager::FramebufferManager(int targetWidth, int targetHeight, int ms
     glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, m_efbDepth, 0, i);
   }
 
-  // EFB framebuffer is currently bound, make sure to clear its alpha value to 1.f
+  // EFB framebuffer is currently bound, make sure to clear it before use.
   glViewport(0, 0, m_targetWidth, m_targetHeight);
   glScissor(0, 0, m_targetWidth, m_targetHeight);
-  glClearColor(0.f, 0.f, 0.f, 1.f);
+  glClearColor(0.f, 0.f, 0.f, 0.f);
   glClearDepthf(1.0f);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -333,7 +333,7 @@ bool FramebufferManager::CreateEFBFramebuffer()
                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
   // Clear the contents of the buffers.
-  static const VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 1.0f}};
+  static const VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 0.0f}};
   static const VkClearDepthStencilValue clear_depth = {0.0f, 0};
   VkImageSubresourceRange clear_color_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, m_efb_layers};
   VkImageSubresourceRange clear_depth_range = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, m_efb_layers};

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -345,9 +345,10 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha
       bpmem.zcontrol.pixel_format == PEControl::RGB8_Z24 ||
       bpmem.zcontrol.pixel_format == PEControl::Z24)
   {
-    // Force alpha writes, and set the color to 0xFF.
+    // Force alpha writes, and clear the alpha channel. This is different to the other backends,
+    // where the existing values of the alpha channel are preserved.
     alpha_enable = true;
-    color |= 0xFF000000;
+    color &= 0x00FFFFFF;
   }
 
   // Convert RGBA8 -> floating-point values.


### PR DESCRIPTION
Fixes the ground being completely in shadow in Beach Spikers: https://bugs.dolphin-emu.org/issues/9996
I've also changed it to use 0 when creating the framebuffer, this fixes the first frame of the fifolog as well.

It still differs from the other backends in that the alpha channel is wiped out rather than being preserved when using a non-alpha format, fixing this properly would be more complex (and we'd likely want to know how the console behaves in this regard as well).

For now I've included the change in GL as well, will be interesting to see if this produces any diffs on fifoci.