### PR TITLE
DSPAnalyzer: Fix two clang warnings about sign mismatched types

### DIFF
--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -128,23 +128,23 @@ void AnalyzeRange(u16 start_addr, u16 end_addr)
   }
 
   // Next, we'll scan for potential idle skips.
-  for (int s = 0; s < NUM_IDLE_SIGS; s++)
+  for (size_t s = 0; s < NUM_IDLE_SIGS; s++)
   {
     for (u16 addr = start_addr; addr < end_addr; addr++)
     {
       bool found = false;
-      for (int i = 0; i < MAX_IDLE_SIG_SIZE + 1; i++)
+      for (size_t i = 0; i < MAX_IDLE_SIG_SIZE + 1; i++)
       {
         if (idle_skip_sigs[s][i] == 0)
           found = true;
         if (idle_skip_sigs[s][i] == 0xFFFF)
           continue;
-        if (idle_skip_sigs[s][i] != dsp_imem_read(addr + i))
+        if (idle_skip_sigs[s][i] != dsp_imem_read(static_cast<u16>(addr + i)))
           break;
       }
       if (found)
       {
-        INFO_LOG(DSPLLE, "Idle skip location found at %02x (sigNum:%d)", addr, s + 1);
+        INFO_LOG(DSPLLE, "Idle skip location found at %02x (sigNum:%zu)", addr, s + 1);
         code_flags[addr] |= CODE_IDLE_SKIP;
       }
     }


### PR DESCRIPTION
> [10:05] \<flacs\> Lioncash: you introduced two clang warnings in a8459fc1893d2cedf5fc8c24f32c8dd7e61477cc
> [10:06] \<flacs\> by replacing a #define with a size_t variable you made it unsigned, but it's being compared to a signed value
> [10:07] \<flacs\> (NUM_IDLE_SIGS and MAX_IDLE_SIG_SIZE)