### PR TITLE
OGL: Move blending logic in VideoCommon.

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -72,13 +72,10 @@ public:
   static void Init();
   static void Shutdown();
 
-  void SetColorMask() override;
   void SetBlendMode(bool forceUpdate) override;
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
   void SetDepthMode() override;
-  void SetLogicOpMode() override;
-  void SetDitherMode() override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;
   void SetViewport() override;

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -142,6 +142,10 @@ static void BPWritten(const BPCmd& bp)
                (int)bpmem.blendmode.dstfactor, (int)bpmem.blendmode.srcfactor,
                (int)bpmem.blendmode.subtract, (int)bpmem.blendmode.logicmode);
 
+      // Set Blending Mode
+      if (bp.changes)
+        SetBlendMode();
+
       // Set LogicOp Blending Mode
       if (bp.changes & 0xF002)  // logicopenable | logicmode
         SetLogicOpMode();
@@ -149,10 +153,6 @@ static void BPWritten(const BPCmd& bp)
       // Set Dithering Mode
       if (bp.changes & 4)  // dither
         SetDitherMode();
-
-      // Set Blending Mode
-      if (bp.changes & 0xFF1)  // blendenable | alphaupdate | dstfactor | srcfactor | subtract
-        SetBlendMode();
 
       // Set Color Mask
       if (bp.changes & 0x18)  // colorupdate | alphaupdate
@@ -316,7 +316,10 @@ static void BPWritten(const BPCmd& bp)
     if (bp.changes & 0xFFFF)
       PixelShaderManager::SetAlpha();
     if (bp.changes)
+    {
       g_renderer->SetColorMask();
+      SetBlendMode();
+    }
     return;
   case BPMEM_BIAS:  // BIAS
     PRIM_LOG("ztex bias=0x%x", bpmem.ztex1.bias);

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SRCS	AsyncRequests.cpp
 			PixelShaderManager.cpp
 			PostProcessing.cpp
 			RenderBase.cpp
+			RenderState.cpp
 			Statistics.cpp
 			TextureCacheBase.cpp
 			TextureConversionShader.cpp

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -1,0 +1,119 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoCommon/RenderState.h"
+
+// If the framebuffer format has no alpha channel, it is assumed to
+// ONE on blending. As the backends may emulate this framebuffer
+// configuration with an alpha channel, we just drop all references
+// to the destination alpha channel.
+static BlendMode::BlendFactor RemoveDstAlphaUsage(BlendMode::BlendFactor factor)
+{
+  switch (factor)
+  {
+  case BlendMode::DSTALPHA:
+    return BlendMode::ONE;
+  case BlendMode::INVDSTALPHA:
+    return BlendMode::ZERO;
+  default:
+    return factor;
+  }
+}
+
+// We separate the blending parameter for rgb and alpha. For blending
+// the alpha component, CLR and ALPHA are indentical. So just always
+// use ALPHA as this makes it easier for the backends to use the second
+// alpha value of dual source blending.
+static BlendMode::BlendFactor RemoveSrcColorUsage(BlendMode::BlendFactor factor)
+{
+  switch (factor)
+  {
+  case BlendMode::SRCCLR:
+    return BlendMode::SRCALPHA;
+  case BlendMode::INVSRCCLR:
+    return BlendMode::INVSRCALPHA;
+  default:
+    return factor;
+  }
+}
+
+// Same as RemoveSrcColorUsage, but because of the overlapping enum,
+// this must be written as another function.
+static BlendMode::BlendFactor RemoveDstColorUsage(BlendMode::BlendFactor factor)
+{
+  switch (factor)
+  {
+  case BlendMode::DSTCLR:
+    return BlendMode::DSTALPHA;
+  case BlendMode::INVDSTCLR:
+    return BlendMode::INVDSTALPHA;
+  default:
+    return factor;
+  }
+}
+
+void BlendingState::Generate(const BPMemory& bp)
+{
+  // Start with everything disabled.
+  hex = 0;
+
+  bool target_has_alpha = bp.zcontrol.pixel_format == PEControl::RGBA6_Z24;
+  bool alpha_test_may_success = bp.alpha_test.TestResult() != AlphaTest::FAIL;
+
+  dither = bp.blendmode.dither;
+  colorupdate = bp.blendmode.colorupdate && alpha_test_may_success;
+  alphaupdate = bp.blendmode.alphaupdate && target_has_alpha && alpha_test_may_success;
+  dstalpha = bp.dstalpha.enable && alphaupdate;
+
+  // The subtract bit has the highest priority
+  if (bp.blendmode.subtract)
+  {
+    blendenable = true;
+    subtractAlpha = subtract = true;
+    srcfactoralpha = srcfactor = BlendMode::ONE;
+    dstfactoralpha = dstfactor = BlendMode::ONE;
+
+    if (dstalpha)
+    {
+      subtractAlpha = false;
+      srcfactoralpha = BlendMode::ONE;
+      dstfactoralpha = BlendMode::ZERO;
+    }
+  }
+
+  // The blendenable bit has the middle priority
+  else if (bp.blendmode.blendenable)
+  {
+    blendenable = true;
+    srcfactor = bp.blendmode.srcfactor;
+    dstfactor = bp.blendmode.dstfactor;
+    if (!target_has_alpha)
+    {
+      // uses ONE instead of DSTALPHA
+      srcfactor = RemoveDstAlphaUsage(srcfactor);
+      dstfactor = RemoveDstAlphaUsage(dstfactor);
+    }
+    // replaces SRCCLR with SRCALPHA
+    srcfactoralpha = RemoveSrcColorUsage(srcfactor);
+    dstfactoralpha = RemoveDstColorUsage(dstfactor);
+
+    if (dstalpha)
+    {
+      srcfactoralpha = BlendMode::ONE;
+      dstfactoralpha = BlendMode::ZERO;
+    }
+  }
+
+  // The logicop bit has the lowest priority
+  else if (bp.blendmode.logicopenable)
+  {
+    logicopenable = true;
+    logicmode = bp.blendmode.logicmode;
+
+    if (dstalpha)
+    {
+      // TODO: Not supported by backends.
+    }
+  }
+}

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -108,12 +108,21 @@ void BlendingState::Generate(const BPMemory& bp)
   // The logicop bit has the lowest priority
   else if (bp.blendmode.logicopenable)
   {
-    logicopenable = true;
-    logicmode = bp.blendmode.logicmode;
-
-    if (dstalpha)
+    if (bp.blendmode.logicmode == BlendMode::NOOP)
     {
-      // TODO: Not supported by backends.
+      // Fast path for Kirby's Return to Dreamland, they use it with dstAlpha.
+      colorupdate = false;
+      alphaupdate = alphaupdate && dstalpha;
+    }
+    else
+    {
+      logicopenable = true;
+      logicmode = bp.blendmode.logicmode;
+
+      if (dstalpha)
+      {
+        // TODO: Not supported by backends.
+      }
     }
   }
 }

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -1,0 +1,31 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/BitField.h"
+
+#include "VideoCommon/BPMemory.h"
+#include "VideoCommon/BPStructs.h"
+
+union BlendingState
+{
+  void Generate(const BPMemory& bp);
+
+  BitField<0, 1, u32> blendenable;
+  BitField<1, 1, u32> logicopenable;
+  BitField<2, 1, u32> dstalpha;
+  BitField<3, 1, u32> dither;
+  BitField<4, 1, u32> colorupdate;
+  BitField<5, 1, u32> alphaupdate;
+  BitField<6, 1, u32> subtract;
+  BitField<7, 1, u32> subtractAlpha;
+  BitField<8, 3, BlendMode::BlendFactor> dstfactor;
+  BitField<11, 3, BlendMode::BlendFactor> srcfactor;
+  BitField<14, 3, BlendMode::BlendFactor> dstfactoralpha;
+  BitField<17, 3, BlendMode::BlendFactor> srcfactoralpha;
+  BitField<20, 4, BlendMode::LogicOp> logicmode;
+
+  u32 hex;
+};

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="PixelShaderManager.cpp" />
     <ClCompile Include="PostProcessing.cpp" />
     <ClCompile Include="RenderBase.cpp" />
+    <ClCompile Include="RenderState.cpp" />
     <ClCompile Include="LightingShaderGen.cpp" />
     <ClCompile Include="Statistics.cpp" />
     <ClCompile Include="GeometryShaderGen.cpp" />
@@ -134,6 +135,7 @@
     <ClInclude Include="PixelShaderManager.h" />
     <ClInclude Include="PostProcessing.h" />
     <ClInclude Include="RenderBase.h" />
+    <ClInclude Include="RenderState.h" />
     <ClInclude Include="SamplerCommon.h" />
     <ClInclude Include="ShaderGenCommon.h" />
     <ClInclude Include="Statistics.h" />

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -44,6 +44,9 @@
     <ClCompile Include="RenderBase.cpp">
       <Filter>Base</Filter>
     </ClCompile>
+    <ClCompile Include="RenderState.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
     <ClCompile Include="TextureCacheBase.cpp">
       <Filter>Base</Filter>
     </ClCompile>
@@ -180,6 +183,9 @@
       <Filter>Base</Filter>
     </ClInclude>
     <ClInclude Include="RenderBase.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="RenderState.h">
       <Filter>Base</Filter>
     </ClInclude>
     <ClInclude Include="TextureCacheBase.h">


### PR DESCRIPTION
This PR tries to generates a backend independent blending state object in VideoCommon. It tries to map all emulation states to hardware states, which are easier to use by the backends.

This PR has a hack / optimization for Kirby's shadow. It's a tiny change in the last commit.

This is based on PR #4577.