### PR TITLE
Add support for specifying the GC/Wii system language per-game

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -83,6 +83,7 @@ private:
   int iSelectedLanguage;
   int iCPUCore;
   int Volume;
+  int m_wii_language;
   float m_EmulationSpeed;
   std::string strBackend;
   std::string sBackend;
@@ -117,6 +118,7 @@ void ConfigCache::SaveConfig(const SConfig& config)
   strBackend = config.m_strVideoBackend;
   sBackend = config.sBackend;
   m_strGPUDeterminismMode = config.m_strGPUDeterminismMode;
+  m_wii_language = config.m_wii_language;
 
   std::copy(std::begin(g_wiimote_sources), std::end(g_wiimote_sources), std::begin(iWiimoteSource));
   std::copy(std::begin(config.m_SIDevice), std::end(config.m_SIDevice), std::begin(Pads));
@@ -168,6 +170,8 @@ void ConfigCache::RestoreConfig(SConfig* config)
         WiimoteReal::ChangeWiimoteSource(i, iWiimoteSource[i]);
       }
     }
+
+    config->m_wii_language = m_wii_language;
   }
 
   for (unsigned int i = 0; i < MAX_SI_CHANNELS; ++i)
@@ -252,6 +256,7 @@ bool BootCore(const std::string& _rFilename)
     core_section->Get("HLE_BS2", &StartUp.bHLE_BS2, StartUp.bHLE_BS2);
     core_section->Get("ProgressiveScan", &StartUp.bProgressive, StartUp.bProgressive);
     core_section->Get("PAL60", &StartUp.bPAL60, StartUp.bPAL60);
+    core_section->Get("GameCubeLanguage", &StartUp.SelectedLanguage, StartUp.SelectedLanguage);
     if (core_section->Get("EmulationSpeed", &SConfig::GetInstance().m_EmulationSpeed,
                           SConfig::GetInstance().m_EmulationSpeed))
       config_cache.bSetEmulationSpeed = true;
@@ -300,6 +305,9 @@ bool BootCore(const std::string& _rFilename)
         g_wiimote_sources[WIIMOTE_BALANCE_BOARD] = source;
         WiimoteReal::ChangeWiimoteSource(WIIMOTE_BALANCE_BOARD, source);
       }
+
+      IniFile::Section* wii_section = game_ini.GetOrCreateSection("Wii");
+      wii_section->Get("Language", &StartUp.m_wii_language, StartUp.m_wii_language);
     }
   }
 


### PR DESCRIPTION
There are some Japanese Wii games that require you to set your wii system language to "Japanese" in order for them to run.  Being a native English speaker, I'd prefer to keep my system language to "English" and only change it to "Japanese" when playing these specific games.  This pull request allows me to specify the wii language in the specific game ini.

I've tested on my Japanese copy of Disaster Day Of Crisis.  Captain Rainbow didn't have this issue.  Still waiting to receive two more Japanese games in the mail so any testing would be helpful here (I'm thinking of updating the game specific inis in the future).  I've also noticed from the wiki that [Tales of Graces](https://wiki.dolphin-emu.org/index.php?title=Tales_of_Graces) exhibits this issue.

EDIT:  This is my first github merge request, so if I've done something wrong, please bear with me :)