### PR TITLE
DSP: Namespace remaining un-namespaced DSP code

### DIFF
--- a/Source/Core/Core/DSP/DSPAccelerator.cpp
+++ b/Source/Core/Core/DSP/DSPAccelerator.cpp
@@ -11,6 +11,8 @@
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPHost.h"
 
+namespace DSP
+{
 // The hardware adpcm decoder :)
 static s16 ADPCM_Step(u32& _rSamplePos)
 {
@@ -18,7 +20,7 @@ static s16 ADPCM_Step(u32& _rSamplePos)
 
   if ((_rSamplePos & 15) == 0)
   {
-    g_dsp.ifx_regs[DSP_PRED_SCALE] = DSPHost::ReadHostMemory((_rSamplePos & ~15) >> 1);
+    g_dsp.ifx_regs[DSP_PRED_SCALE] = Host::ReadHostMemory((_rSamplePos & ~15) >> 1);
     _rSamplePos += 2;
   }
 
@@ -28,8 +30,8 @@ static s16 ADPCM_Step(u32& _rSamplePos)
   s32 coef1 = pCoefTable[coef_idx * 2 + 0];
   s32 coef2 = pCoefTable[coef_idx * 2 + 1];
 
-  int temp = (_rSamplePos & 1) ? (DSPHost::ReadHostMemory(_rSamplePos >> 1) & 0xF) :
-                                 (DSPHost::ReadHostMemory(_rSamplePos >> 1) >> 4);
+  int temp = (_rSamplePos & 1) ? (Host::ReadHostMemory(_rSamplePos >> 1) & 0xF) :
+                                 (Host::ReadHostMemory(_rSamplePos >> 1) >> 4);
 
   if (temp >= 8)
     temp -= 16;
@@ -60,11 +62,11 @@ u16 dsp_read_aram_d3()
   switch (g_dsp.ifx_regs[DSP_FORMAT])
   {
   case 0x5:  // u8 reads
-    val = DSPHost::ReadHostMemory(Address);
+    val = Host::ReadHostMemory(Address);
     Address++;
     break;
   case 0x6:  // u16 reads
-    val = (DSPHost::ReadHostMemory(Address * 2) << 8) | DSPHost::ReadHostMemory(Address * 2 + 1);
+    val = (Host::ReadHostMemory(Address * 2) << 8) | Host::ReadHostMemory(Address * 2 + 1);
     Address++;
     break;
   default:
@@ -94,8 +96,8 @@ void dsp_write_aram_d3(u16 value)
   switch (g_dsp.ifx_regs[DSP_FORMAT])
   {
   case 0xA:  // u16 writes
-    DSPHost::WriteHostMemory(value >> 8, Address * 2);
-    DSPHost::WriteHostMemory(value & 0xFF, Address * 2 + 1);
+    Host::WriteHostMemory(value >> 8, Address * 2);
+    Host::WriteHostMemory(value & 0xFF, Address * 2 + 1);
     Address++;
     break;
   default:
@@ -138,14 +140,14 @@ u16 dsp_read_accelerator()
     val = ADPCM_Step(Address);
     break;
   case 0x0A:  // 16-bit PCM audio
-    val = (DSPHost::ReadHostMemory(Address * 2) << 8) | DSPHost::ReadHostMemory(Address * 2 + 1);
+    val = (Host::ReadHostMemory(Address * 2) << 8) | Host::ReadHostMemory(Address * 2 + 1);
     g_dsp.ifx_regs[DSP_YN2] = g_dsp.ifx_regs[DSP_YN1];
     g_dsp.ifx_regs[DSP_YN1] = val;
     step_size_bytes = 2;
     Address++;
     break;
   case 0x19:  // 8-bit PCM audio
-    val = DSPHost::ReadHostMemory(Address) << 8;
+    val = Host::ReadHostMemory(Address) << 8;
     g_dsp.ifx_regs[DSP_YN2] = g_dsp.ifx_regs[DSP_YN1];
     g_dsp.ifx_regs[DSP_YN1] = val;
     step_size_bytes = 2;
@@ -179,3 +181,4 @@ u16 dsp_read_accelerator()
   g_dsp.ifx_regs[DSP_ACCAL] = Address & 0xffff;
   return val;
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPAccelerator.h
+++ b/Source/Core/Core/DSP/DSPAccelerator.h
@@ -6,7 +6,10 @@
 
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
 u16 dsp_read_accelerator();
 
 u16 dsp_read_aram_d3();
 void dsp_write_aram_d3(u16 value);
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPAnalyzer.cpp
+++ b/Source/Core/Core/DSP/DSPAnalyzer.cpp
@@ -12,7 +12,9 @@
 #include "Core/DSP/DSPMemoryMap.h"
 #include "Core/DSP/DSPTables.h"
 
-namespace DSPAnalyzer
+namespace DSP
+{
+namespace Analyzer
 {
 namespace
 {
@@ -165,4 +167,5 @@ u8 GetCodeFlags(u16 address)
   return code_flags[address];
 }
 
-}  // namespace DSPAnalyzer
+}  // namespace Analyzer
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPAnalyzer.h
+++ b/Source/Core/Core/DSP/DSPAnalyzer.h
@@ -7,7 +7,9 @@
 #include "Common/CommonTypes.h"
 
 // Basic code analysis.
-namespace DSPAnalyzer
+namespace DSP
+{
+namespace Analyzer
 {
 // Useful things to detect:
 // * Loop endpoints - so that we can avoid checking for loops every cycle.
@@ -33,4 +35,5 @@ void Analyze();
 // Retrieves the flags set during analysis for code in memory.
 u8 GetCodeFlags(u16 address);
 
-}  // namespace DSPAnalyzer
+}  // namespace Analyzer
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPAssembler.cpp
+++ b/Source/Core/Core/DSP/DSPAssembler.cpp
@@ -19,6 +19,8 @@
 #include "Core/DSP/DSPDisassembler.h"
 #include "Core/DSP/DSPTables.h"
 
+namespace DSP
+{
 static const char* err_string[] = {"",
                                    "Unknown Error",
                                    "Unknown opcode",
@@ -1031,3 +1033,4 @@ bool DSPAssembler::AssembleFile(const char* fname, int pass)
 
   return !failed;
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPAssembler.h
+++ b/Source/Core/Core/DSP/DSPAssembler.h
@@ -14,6 +14,8 @@
 #include "Core/DSP/DSPTables.h"
 #include "Core/DSP/LabelMap.h"
 
+namespace DSP
+{
 enum err_t
 {
   ERR_OK = 0,
@@ -116,3 +118,4 @@ private:
   int m_current_param;
   const AssemblerSettings settings_;
 };
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPBreakpoints.h
+++ b/Source/Core/Core/DSP/DSPBreakpoints.h
@@ -7,6 +7,8 @@
 #include <cstring>
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
 // super fast breakpoints for a limited range.
 // To be used interchangeably with the BreakPoints class.
 class DSPBreakpoints
@@ -44,3 +46,4 @@ public:
 private:
   u8 b[65536];
 };
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPCaptureLogger.cpp
+++ b/Source/Core/Core/DSP/DSPCaptureLogger.cpp
@@ -11,6 +11,8 @@
 
 #include "Core/DSP/DSPCaptureLogger.h"
 
+namespace DSP
+{
 // Definition of the packet structures stored in PCAP capture files.
 
 const u8 IFX_ACCESS_PACKET_MAGIC = 0;
@@ -77,3 +79,4 @@ void PCAPDSPCaptureLogger::LogDMA(u16 control, u32 gc_address, u16 dsp_address, 
 
   m_pcap->AddPacket(buffer, sizeof(DMAPacket) + length);
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPCaptureLogger.h
+++ b/Source/Core/Core/DSP/DSPCaptureLogger.h
@@ -12,6 +12,8 @@
 
 class PCAP;
 
+namespace DSP
+{
 // An interface used to capture and log structured data about internal DSP
 // data transfers.
 //
@@ -70,3 +72,4 @@ private:
 
   std::unique_ptr<PCAP> m_pcap;
 };
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPCodeUtil.cpp
+++ b/Source/Core/Core/DSP/DSPCodeUtil.cpp
@@ -15,6 +15,8 @@
 #include "Core/DSP/DSPCodeUtil.h"
 #include "Core/DSP/DSPDisassembler.h"
 
+namespace DSP
+{
 bool Assemble(const std::string& text, std::vector<u16>& code, bool force)
 {
   AssemblerSettings settings;
@@ -216,3 +218,4 @@ bool SaveBinary(const std::vector<u16>& code, const std::string& filename)
     return false;
   return true;
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPCodeUtil.h
+++ b/Source/Core/Core/DSP/DSPCodeUtil.h
@@ -9,6 +9,8 @@
 
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
 bool Assemble(const std::string& text, std::vector<u16>& code, bool force = false);
 bool Disassemble(const std::vector<u16>& code, bool line_numbers, std::string& text);
 bool Compare(const std::vector<u16>& code1, const std::vector<u16>& code2);
@@ -25,3 +27,4 @@ void BinaryStringBEToCode(const std::string& str, std::vector<u16>& code);
 // Load code (big endian binary).
 bool LoadBinary(const std::string& filename, std::vector<u16>& code);
 bool SaveBinary(const std::vector<u16>& code, const std::string& filename);
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPCommon.h
+++ b/Source/Core/Core/DSP/DSPCommon.h
@@ -6,4 +6,7 @@
 
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
 typedef u16 UDSPInstruction;
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -24,12 +24,14 @@
 #include "Core/DSP/Interpreter/DSPInterpreter.h"
 #include "Core/DSP/Jit/DSPEmitter.h"
 
+namespace DSP
+{
 SDSP g_dsp;
 DSPBreakpoints g_dsp_breakpoints;
 static DSPCoreState core_state = DSPCORE_STOP;
 u16 g_cycles_left = 0;
 bool g_init_hax = false;
-std::unique_ptr<DSP::JIT::x86::DSPEmitter> g_dsp_jit;
+std::unique_ptr<JIT::x86::DSPEmitter> g_dsp_jit;
 std::unique_ptr<DSPCaptureLogger> g_dsp_cap;
 static Common::Event step_event;
 
@@ -77,14 +79,14 @@ static bool VerifyRoms()
 
   if (rom_idx == 1)
   {
-    DSPHost::OSD_AddMessage("You are using an old free DSP ROM made by the Dolphin Team.", 6000);
-    DSPHost::OSD_AddMessage("Only games using the Zelda UCode will work correctly.", 6000);
+    Host::OSD_AddMessage("You are using an old free DSP ROM made by the Dolphin Team.", 6000);
+    Host::OSD_AddMessage("Only games using the Zelda UCode will work correctly.", 6000);
   }
   else if (rom_idx == 2 || rom_idx == 3)
   {
-    DSPHost::OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
-    DSPHost::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
-    DSPHost::OSD_AddMessage("also work fine, but the GBA/IPL/CARD UCodes will not work.", 8000);
+    Host::OSD_AddMessage("You are using a free DSP ROM made by the Dolphin Team.", 8000);
+    Host::OSD_AddMessage("All Wii games will work correctly, and most GC games should ", 8000);
+    Host::OSD_AddMessage("also work fine, but the GBA/IPL/CARD UCodes will not work.", 8000);
   }
 
   return true;
@@ -148,7 +150,7 @@ bool DSPCore_Init(const DSPInitOptions& opts)
 
   // Initialize JIT, if necessary
   if (opts.core_type == DSPInitOptions::CORE_JIT)
-    g_dsp_jit = std::make_unique<DSP::JIT::x86::DSPEmitter>();
+    g_dsp_jit = std::make_unique<JIT::x86::DSPEmitter>();
 
   g_dsp_cap.reset(opts.capture_logger);
 
@@ -176,7 +178,7 @@ void DSPCore_Reset()
 
   std::fill(std::begin(g_dsp.r.wr), std::end(g_dsp.r.wr), 0xffff);
 
-  DSPAnalyzer::Analyze();
+  Analyzer::Analyze();
 }
 
 void DSPCore_SetException(u8 level)
@@ -193,7 +195,7 @@ void DSPCore_SetExternalInterrupt(bool val)
 // Coming from the CPU
 void DSPCore_CheckExternalInterrupt()
 {
-  if (!DSP::Interpreter::dsp_SR_is_flag_set(SR_EXT_INT_ENABLE))
+  if (!Interpreter::dsp_SR_is_flag_set(SR_EXT_INT_ENABLE))
     return;
 
   // Signal the SPU about new mail
@@ -213,7 +215,7 @@ void DSPCore_CheckExceptions()
     // Seems exp int are not masked by sr_int_enable
     if (g_dsp.exceptions & (1 << i))
     {
-      if (DSP::Interpreter::dsp_SR_is_flag_set(SR_INT_ENABLE) || (i == EXP_INT))
+      if (Interpreter::dsp_SR_is_flag_set(SR_INT_ENABLE) || (i == EXP_INT))
       {
         // store pc and sr until RTI
         dsp_reg_store_stack(DSP_STACK_C, g_dsp.pc);
@@ -251,7 +253,7 @@ int DSPCore_RunCycles(int cycles)
     }
 
     g_cycles_left = cycles;
-    auto exec_addr = (DSP::JIT::x86::DSPEmitter::DSPCompiledCode)g_dsp_jit->enterDispatcher;
+    auto exec_addr = (JIT::x86::DSPEmitter::DSPCompiledCode)g_dsp_jit->enterDispatcher;
     exec_addr();
 
     if (g_dsp.reset_dspjit_codespace)
@@ -267,9 +269,9 @@ int DSPCore_RunCycles(int cycles)
     case DSPCORE_RUNNING:
 // Seems to slow things down
 #if defined(_DEBUG) || defined(DEBUGFAST)
-      cycles = DSP::Interpreter::RunCyclesDebug(cycles);
+      cycles = Interpreter::RunCyclesDebug(cycles);
 #else
-      cycles = DSP::Interpreter::RunCycles(cycles);
+      cycles = Interpreter::RunCycles(cycles);
 #endif
       break;
 
@@ -278,10 +280,10 @@ int DSPCore_RunCycles(int cycles)
       if (core_state != DSPCORE_STEPPING)
         continue;
 
-      DSP::Interpreter::Step();
+      Interpreter::Step();
       cycles--;
 
-      DSPHost::UpdateDebugger();
+      Host::UpdateDebugger();
       break;
     case DSPCORE_STOP:
       break;
@@ -293,11 +295,12 @@ int DSPCore_RunCycles(int cycles)
 void DSPCore_SetState(DSPCoreState new_state)
 {
   core_state = new_state;
+
   // kick the event, in case we are waiting
   if (new_state == DSPCORE_RUNNING)
     step_event.Set();
-  // Sleep(10);
-  DSPHost::UpdateDebugger();
+
+  Host::UpdateDebugger();
 }
 
 DSPCoreState DSPCore_GetState()
@@ -458,3 +461,4 @@ void DSPCore_WriteRegister(size_t reg, u16 val)
     break;
   }
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -23,7 +23,6 @@ namespace x86
 class DSPEmitter;
 }
 }
-}
 
 enum : u32
 {
@@ -311,7 +310,7 @@ extern SDSP g_dsp;
 extern DSPBreakpoints g_dsp_breakpoints;
 extern u16 g_cycles_left;
 extern bool g_init_hax;
-extern std::unique_ptr<DSP::JIT::x86::DSPEmitter> g_dsp_jit;
+extern std::unique_ptr<JIT::x86::DSPEmitter> g_dsp_jit;
 extern std::unique_ptr<DSPCaptureLogger> g_dsp_cap;
 
 struct DSPInitOptions
@@ -371,3 +370,4 @@ void DSPCore_Step();
 
 u16 DSPCore_ReadRegister(size_t reg);
 void DSPCore_WriteRegister(size_t reg, u16 val);
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPDisassembler.cpp
+++ b/Source/Core/Core/DSP/DSPDisassembler.cpp
@@ -17,6 +17,8 @@
 #include "Core/DSP/DSPTables.h"
 #include "Core/DSP/Interpreter/DSPInterpreter.h"
 
+namespace DSP
+{
 DSPDisassembler::DSPDisassembler(const AssemblerSettings& settings) : settings_(settings)
 {
 }
@@ -335,3 +337,4 @@ bool DSPDisassembler::DisassembleFile(const std::string& name, int base_addr, in
 
   return true;
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPDisassembler.h
+++ b/Source/Core/Core/DSP/DSPDisassembler.h
@@ -14,6 +14,8 @@
 #include "Core/DSP/DSPTables.h"
 #include "Core/DSP/LabelMap.h"
 
+namespace DSP
+{
 struct AssemblerSettings
 {
   AssemblerSettings()
@@ -57,3 +59,4 @@ private:
 
   LabelMap labels;
 };
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPHWInterface.cpp
+++ b/Source/Core/Core/DSP/DSPHWInterface.cpp
@@ -16,6 +16,8 @@
 #include "Core/DSP/DSPHost.h"
 #include "Core/DSP/DSPTables.h"
 
+namespace DSP
+{
 static void gdsp_do_dma();
 
 void gdsp_ifx_init()
@@ -98,7 +100,7 @@ void gdsp_ifx_write(u32 addr, u32 val)
   {
   case DSP_DIRQ:
     if (val & 0x1)
-      DSPHost::InterruptRequest();
+      Host::InterruptRequest();
     else
       WARN_LOG(DSPLLE, "Unknown Interrupt Request pc=%04x (%04x)", g_dsp.pc, val);
     break;
@@ -234,7 +236,7 @@ static const u8* gdsp_idma_in(u16 dsp_addr, u32 addr, u32 size)
   }
   Common::WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
 
-  DSPHost::CodeLoaded((const u8*)g_dsp.iram + dsp_addr, size);
+  Host::CodeLoaded((const u8*)g_dsp.iram + dsp_addr, size);
 
   NOTICE_LOG(DSPLLE, "*** Copy new UCode from 0x%08x to 0x%04x (crc: %8x)", addr, dsp_addr,
              g_dsp.iram_crc);
@@ -356,3 +358,4 @@ static void gdsp_do_dma()
   if (copied_data_ptr)
     g_dsp_cap->LogDMA(ctl, addr, dsp_addr, len, copied_data_ptr);
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPHWInterface.h
+++ b/Source/Core/Core/DSP/DSPHWInterface.h
@@ -7,6 +7,8 @@
 
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
 enum Mailbox
 {
   MAILBOX_CPU,
@@ -22,3 +24,4 @@ u16 gdsp_mbox_read_l(Mailbox mbx);
 void gdsp_ifx_init();
 void gdsp_ifx_write(u32 addr, u32 val);
 u16 gdsp_ifx_read(u16 addr);
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPHost.h
+++ b/Source/Core/Core/DSP/DSPHost.h
@@ -13,7 +13,9 @@
 // core isn't used, for example in an asm/disasm tool, then most of these
 // can be stubbed out.
 
-namespace DSPHost
+namespace DSP
+{
+namespace Host
 {
 u8 ReadHostMemory(u32 addr);
 void WriteHostMemory(u8 value, u32 addr);
@@ -23,4 +25,5 @@ bool IsWiiHost();
 void InterruptRequest();
 void CodeLoaded(const u8* ptr, int size);
 void UpdateDebugger();
-}
+}  // namespace Host
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPMemoryMap.cpp
+++ b/Source/Core/Core/DSP/DSPMemoryMap.cpp
@@ -11,6 +11,8 @@
 #include "Core/DSP/DSPHWInterface.h"
 #include "Core/DSP/DSPTables.h"
 
+namespace DSP
+{
 u16 dsp_imem_read(u16 addr)
 {
   switch (addr >> 12)
@@ -82,3 +84,4 @@ void dsp_skip_inst()
 {
   g_dsp.pc += opTable[dsp_peek_code()]->size;
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPMemoryMap.h
+++ b/Source/Core/Core/DSP/DSPMemoryMap.h
@@ -7,6 +7,8 @@
 
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
 u16 dsp_imem_read(u16 addr);
 void dsp_dmem_write(u16 addr, u16 val);
 u16 dsp_dmem_read(u16 addr);
@@ -14,3 +16,4 @@ u16 dsp_dmem_read(u16 addr);
 u16 dsp_fetch_code();
 u16 dsp_peek_code();
 void dsp_skip_inst();
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPStacks.cpp
+++ b/Source/Core/Core/DSP/DSPStacks.cpp
@@ -9,7 +9,8 @@
 #include "Core/DSP/DSPStacks.h"
 
 // Stacks. The stacks are outside the DSP RAM, in dedicated hardware.
-
+namespace DSP
+{
 static void dsp_reg_stack_push(int stack_reg)
 {
   g_dsp.reg_stack_ptr[stack_reg]++;
@@ -36,3 +37,4 @@ u16 dsp_reg_load_stack(int stack_reg)
   dsp_reg_stack_pop(stack_reg);
   return val;
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPStacks.h
+++ b/Source/Core/Core/DSP/DSPStacks.h
@@ -7,5 +7,8 @@
 
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
 void dsp_reg_store_stack(int stack_reg, u16 val);
 u16 dsp_reg_load_stack(int stack_reg);
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPTables.cpp
+++ b/Source/Core/Core/DSP/DSPTables.cpp
@@ -12,318 +12,320 @@
 #include "Core/DSP/Interpreter/DSPInterpreter.h"
 #include "Core/DSP/Jit/DSPEmitter.h"
 
-using DSP::JIT::x86::DSPEmitter;
+namespace DSP
+{
+using JIT::x86::DSPEmitter;
 
 // clang-format off
 const DSPOPCTemplate opcodes[] =
 {
-  //                                                           # of parameters----+   {type, size, loc, lshift, mask}                                                               branch        reads PC       // instruction approximation
-  // name      opcode  mask    interpreter function       JIT function    size-V  V   param 1                       param 2                       param 3                    extendable    uncond.       updates SR
-  {"NOP",      0x0000, 0xfffc, DSP::Interpreter::nop,     &DSPEmitter::nop,    1, 0, {},                                                                                     false, false, false, false, false}, // no operation
+  //                                                      # of parameters----+   {type, size, loc, lshift, mask}                                                               branch        reads PC       // instruction approximation
+  // name      opcode  mask    interpreter function  JIT function    size-V  V   param 1                       param 2                       param 3                    extendable    uncond.       updates SR
+  {"NOP",      0x0000, 0xfffc, Interpreter::nop,     &DSPEmitter::nop,    1, 0, {},                                                                                     false, false, false, false, false}, // no operation
 
-  {"DAR",      0x0004, 0xfffc, DSP::Interpreter::dar,     &DSPEmitter::dar,    1, 1, {{P_REG, 1, 0, 0, 0x0003}},                                                             false, false, false, false, false}, // $arD--
-  {"IAR",      0x0008, 0xfffc, DSP::Interpreter::iar,     &DSPEmitter::iar,    1, 1, {{P_REG, 1, 0, 0, 0x0003}},                                                             false, false, false, false, false}, // $arD++
-  {"SUBARN",   0x000c, 0xfffc, DSP::Interpreter::subarn,  &DSPEmitter::subarn, 1, 1, {{P_REG, 1, 0, 0, 0x0003}},                                                             false, false, false, false, false}, // $arD -= $ixS
-  {"ADDARN",   0x0010, 0xfff0, DSP::Interpreter::addarn,  &DSPEmitter::addarn, 1, 2, {{P_REG, 1, 0, 0, 0x0003},     {P_REG04, 1, 0, 2, 0x000c}},                             false, false, false, false, false}, // $arD += $ixS
+  {"DAR",      0x0004, 0xfffc, Interpreter::dar,     &DSPEmitter::dar,    1, 1, {{P_REG, 1, 0, 0, 0x0003}},                                                             false, false, false, false, false}, // $arD--
+  {"IAR",      0x0008, 0xfffc, Interpreter::iar,     &DSPEmitter::iar,    1, 1, {{P_REG, 1, 0, 0, 0x0003}},                                                             false, false, false, false, false}, // $arD++
+  {"SUBARN",   0x000c, 0xfffc, Interpreter::subarn,  &DSPEmitter::subarn, 1, 1, {{P_REG, 1, 0, 0, 0x0003}},                                                             false, false, false, false, false}, // $arD -= $ixS
+  {"ADDARN",   0x0010, 0xfff0, Interpreter::addarn,  &DSPEmitter::addarn, 1, 2, {{P_REG, 1, 0, 0, 0x0003},     {P_REG04, 1, 0, 2, 0x000c}},                             false, false, false, false, false}, // $arD += $ixS
 
-  {"HALT",     0x0021, 0xffff, DSP::Interpreter::halt,    &DSPEmitter::halt,   1, 0, {},                                                                                     false, true, true, false, false}, // halt until reset
+  {"HALT",     0x0021, 0xffff, Interpreter::halt,    &DSPEmitter::halt,   1, 0, {},                                                                                     false, true, true, false, false}, // halt until reset
 
-  {"RETGE",    0x02d0, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if greater or equal
-  {"RETL",     0x02d1, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if less
-  {"RETG",     0x02d2, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if greater
-  {"RETLE",    0x02d3, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if less or equal
-  {"RETNZ",    0x02d4, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if not zero
-  {"RETZ",     0x02d5, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if zero
-  {"RETNC",    0x02d6, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if not carry
-  {"RETC",     0x02d7, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if carry
-  {"RETx8",    0x02d8, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if TODO
-  {"RETx9",    0x02d9, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if TODO
-  {"RETxA",    0x02da, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if TODO
-  {"RETxB",    0x02db, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if TODO
-  {"RETLNZ",   0x02dc, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if logic not zero
-  {"RETLZ",    0x02dd, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if logic zero
-  {"RETO",     0x02de, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if overflow
-  {"RET",      0x02df, 0xffff, DSP::Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, true, false, false}, // unconditional return
+  {"RETGE",    0x02d0, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if greater or equal
+  {"RETL",     0x02d1, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if less
+  {"RETG",     0x02d2, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if greater
+  {"RETLE",    0x02d3, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if less or equal
+  {"RETNZ",    0x02d4, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if not zero
+  {"RETZ",     0x02d5, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if zero
+  {"RETNC",    0x02d6, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if not carry
+  {"RETC",     0x02d7, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if carry
+  {"RETx8",    0x02d8, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if TODO
+  {"RETx9",    0x02d9, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if TODO
+  {"RETxA",    0x02da, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if TODO
+  {"RETxB",    0x02db, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if TODO
+  {"RETLNZ",   0x02dc, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if logic not zero
+  {"RETLZ",    0x02dd, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if logic zero
+  {"RETO",     0x02de, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, false, true, false}, // return if overflow
+  {"RET",      0x02df, 0xffff, Interpreter::ret,     &DSPEmitter::ret,    1, 0, {},                                                                                     false, true, true, false, false}, // unconditional return
 
-  {"RTI",      0x02ff, 0xffff, DSP::Interpreter::rti,     &DSPEmitter::rti,    1, 0, {},                                                                                     false, true, true, false, false}, // return from interrupt
+  {"RTI",      0x02ff, 0xffff, Interpreter::rti,     &DSPEmitter::rti,    1, 0, {},                                                                                     false, true, true, false, false}, // return from interrupt
 
-  {"CALLGE",   0x02b0, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if greater or equal
-  {"CALLL",    0x02b1, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if less
-  {"CALLG",    0x02b2, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if greater
-  {"CALLLE",   0x02b3, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if less or equal
-  {"CALLNZ",   0x02b4, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if not zero
-  {"CALLZ",    0x02b5, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if zero
-  {"CALLNC",   0x02b6, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if not carry
-  {"CALLC",    0x02b7, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if carry
-  {"CALLx8",   0x02b8, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if TODO
-  {"CALLx9",   0x02b9, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if TODO
-  {"CALLxA",   0x02ba, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if TODO
-  {"CALLxB",   0x02bb, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if TODO
-  {"CALLLNZ",  0x02bc, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if logic not zero
-  {"CALLLZ",   0x02bd, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if logic zero
-  {"CALLO",    0x02be, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if overflow
-  {"CALL",     0x02bf, 0xffff, DSP::Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, true, true, false},  // unconditional call
+  {"CALLGE",   0x02b0, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if greater or equal
+  {"CALLL",    0x02b1, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if less
+  {"CALLG",    0x02b2, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if greater
+  {"CALLLE",   0x02b3, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if less or equal
+  {"CALLNZ",   0x02b4, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if not zero
+  {"CALLZ",    0x02b5, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if zero
+  {"CALLNC",   0x02b6, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if not carry
+  {"CALLC",    0x02b7, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if carry
+  {"CALLx8",   0x02b8, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if TODO
+  {"CALLx9",   0x02b9, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if TODO
+  {"CALLxA",   0x02ba, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if TODO
+  {"CALLxB",   0x02bb, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if TODO
+  {"CALLLNZ",  0x02bc, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if logic not zero
+  {"CALLLZ",   0x02bd, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if logic zero
+  {"CALLO",    0x02be, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // call if overflow
+  {"CALL",     0x02bf, 0xffff, Interpreter::call,    &DSPEmitter::call,   2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, true, true, false},  // unconditional call
 
-  {"IFGE",     0x0270, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if greater or equal
-  {"IFL",      0x0271, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if less
-  {"IFG",      0x0272, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if greater
-  {"IFLE",     0x0273, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if less or equal
-  {"IFNZ",     0x0274, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if not zero
-  {"IFZ",      0x0275, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if zero
-  {"IFNC",     0x0276, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if not carry
-  {"IFC",      0x0277, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if carry
-  {"IFx8",     0x0278, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if TODO
-  {"IFx9",     0x0279, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if TODO
-  {"IFxA",     0x027a, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if TODO
-  {"IFxB",     0x027b, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if TODO
-  {"IFLNZ",    0x027c, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if logic not zero
-  {"IFLZ",     0x027d, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if logic zero
-  {"IFO",      0x027e, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if overflow
-  {"IF",       0x027f, 0xffff, DSP::Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, true, true, false},  // what is this, I don't even...
+  {"IFGE",     0x0270, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if greater or equal
+  {"IFL",      0x0271, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if less
+  {"IFG",      0x0272, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if greater
+  {"IFLE",     0x0273, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if less or equal
+  {"IFNZ",     0x0274, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if not zero
+  {"IFZ",      0x0275, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if zero
+  {"IFNC",     0x0276, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if not carry
+  {"IFC",      0x0277, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if carry
+  {"IFx8",     0x0278, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if TODO
+  {"IFx9",     0x0279, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if TODO
+  {"IFxA",     0x027a, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if TODO
+  {"IFxB",     0x027b, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if TODO
+  {"IFLNZ",    0x027c, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if logic not zero
+  {"IFLZ",     0x027d, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if logic zero
+  {"IFO",      0x027e, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, false, true, false}, // if overflow
+  {"IF",       0x027f, 0xffff, Interpreter::ifcc,    &DSPEmitter::ifcc,   1, 0, {},                                                                                     false, true, true, true, false},  // what is this, I don't even...
 
-  {"JGE",      0x0290, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if greater or equal
-  {"JL",       0x0291, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if less
-  {"JG",       0x0292, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if greater
-  {"JLE",      0x0293, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if less or equal
-  {"JNZ",      0x0294, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if not zero
-  {"JZ",       0x0295, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if zero
-  {"JNC",      0x0296, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if not carry
-  {"JC",       0x0297, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if carry
-  {"JMPx8",    0x0298, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if TODO
-  {"JMPx9",    0x0299, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if TODO
-  {"JMPxA",    0x029a, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if TODO
-  {"JMPxB",    0x029b, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if TODO
-  {"JLNZ",     0x029c, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if logic not zero
-  {"JLZ",      0x029d, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if logic zero
-  {"JO",       0x029e, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if overflow
-  {"JMP",      0x029f, 0xffff, DSP::Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, true, true, false},  // unconditional jump
+  {"JGE",      0x0290, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if greater or equal
+  {"JL",       0x0291, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if less
+  {"JG",       0x0292, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if greater
+  {"JLE",      0x0293, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if less or equal
+  {"JNZ",      0x0294, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if not zero
+  {"JZ",       0x0295, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if zero
+  {"JNC",      0x0296, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if not carry
+  {"JC",       0x0297, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if carry
+  {"JMPx8",    0x0298, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if TODO
+  {"JMPx9",    0x0299, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if TODO
+  {"JMPxA",    0x029a, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if TODO
+  {"JMPxB",    0x029b, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if TODO
+  {"JLNZ",     0x029c, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if logic not zero
+  {"JLZ",      0x029d, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if logic zero
+  {"JO",       0x029e, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, false, true, false}, // jump if overflow
+  {"JMP",      0x029f, 0xffff, Interpreter::jcc,     &DSPEmitter::jcc,    2, 1, {{P_ADDR_I, 2, 1, 0, 0xffff}},                                                          false, true, true, true, false},  // unconditional jump
 
-  {"JRGE",     0x1700, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if greater or equal
-  {"JRL",      0x1701, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if less
-  {"JRG",      0x1702, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if greater
-  {"JRLE",     0x1703, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if less or equal
-  {"JRNZ",     0x1704, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if not zero
-  {"JRZ",      0x1705, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if zero
-  {"JRNC",     0x1706, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if not carry
-  {"JRC",      0x1707, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if carry
-  {"JMPRx8",   0x1708, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if TODO
-  {"JMPRx9",   0x1709, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if TODO
-  {"JMPRxA",   0x170a, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if TODO
-  {"JMPRxB",   0x170b, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if TODO
-  {"JRLNZ",    0x170c, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if logic not zero
-  {"JRLZ",     0x170d, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if logic zero
-  {"JRO",      0x170e, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if overflow
-  {"JMPR",     0x170f, 0xff1f, DSP::Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, true, false, false},  // jump to $R
+  {"JRGE",     0x1700, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if greater or equal
+  {"JRL",      0x1701, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if less
+  {"JRG",      0x1702, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if greater
+  {"JRLE",     0x1703, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if less or equal
+  {"JRNZ",     0x1704, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if not zero
+  {"JRZ",      0x1705, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if zero
+  {"JRNC",     0x1706, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if not carry
+  {"JRC",      0x1707, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if carry
+  {"JMPRx8",   0x1708, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if TODO
+  {"JMPRx9",   0x1709, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if TODO
+  {"JMPRxA",   0x170a, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if TODO
+  {"JMPRxB",   0x170b, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if TODO
+  {"JRLNZ",    0x170c, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if logic not zero
+  {"JRLZ",     0x170d, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if logic zero
+  {"JRO",      0x170e, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, false, false}, // jump to $R if overflow
+  {"JMPR",     0x170f, 0xff1f, Interpreter::jmprcc,  &DSPEmitter::jmprcc, 1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, true, false, false},  // jump to $R
 
-  {"CALLRGE",  0x1710, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if greater or equal
-  {"CALLRL",   0x1711, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if less
-  {"CALLRG",   0x1712, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if greater
-  {"CALLRLE",  0x1713, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if less or equal
-  {"CALLRNZ",  0x1714, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if not zero
-  {"CALLRZ",   0x1715, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if zero
-  {"CALLRNC",  0x1716, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if not carry
-  {"CALLRC",   0x1717, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if carry
-  {"CALLRx8",  0x1718, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if TODO
-  {"CALLRx9",  0x1719, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if TODO
-  {"CALLRxA",  0x171a, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if TODO
-  {"CALLRxB",  0x171b, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if TODO
-  {"CALLRLNZ", 0x171c, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if logic not zero
-  {"CALLRLZ",  0x171d, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if logic zero
-  {"CALLRO",   0x171e, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if overflow
-  {"CALLR",    0x171f, 0xff1f, DSP::Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, true, true, false},  // call $R
+  {"CALLRGE",  0x1710, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if greater or equal
+  {"CALLRL",   0x1711, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if less
+  {"CALLRG",   0x1712, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if greater
+  {"CALLRLE",  0x1713, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if less or equal
+  {"CALLRNZ",  0x1714, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if not zero
+  {"CALLRZ",   0x1715, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if zero
+  {"CALLRNC",  0x1716, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if not carry
+  {"CALLRC",   0x1717, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if carry
+  {"CALLRx8",  0x1718, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if TODO
+  {"CALLRx9",  0x1719, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if TODO
+  {"CALLRxA",  0x171a, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if TODO
+  {"CALLRxB",  0x171b, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if TODO
+  {"CALLRLNZ", 0x171c, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if logic not zero
+  {"CALLRLZ",  0x171d, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if logic zero
+  {"CALLRO",   0x171e, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, false, true, false}, // call $R if overflow
+  {"CALLR",    0x171f, 0xff1f, Interpreter::callr,   &DSPEmitter::callr,  1, 1, {{P_REG, 1, 0, 5, 0x00e0}},                                                             false, true, true, true, false},  // call $R
 
-  {"SBCLR",    0x1200, 0xff00, DSP::Interpreter::sbclr,   &DSPEmitter::sbclr,  1, 1, {{P_IMM, 1, 0, 0, 0x0007}},                                                             false, false, false, false, false}, // $sr &= ~(I + 6)
-  {"SBSET",    0x1300, 0xff00, DSP::Interpreter::sbset,   &DSPEmitter::sbset,  1, 1, {{P_IMM, 1, 0, 0, 0x0007}},                                                             false, false, false, false, false}, // $sr |= (I + 6)
+  {"SBCLR",    0x1200, 0xff00, Interpreter::sbclr,   &DSPEmitter::sbclr,  1, 1, {{P_IMM, 1, 0, 0, 0x0007}},                                                             false, false, false, false, false}, // $sr &= ~(I + 6)
+  {"SBSET",    0x1300, 0xff00, Interpreter::sbset,   &DSPEmitter::sbset,  1, 1, {{P_IMM, 1, 0, 0, 0x0007}},                                                             false, false, false, false, false}, // $sr |= (I + 6)
 
-  {"LSL",      0x1400, 0xfec0, DSP::Interpreter::lsl,     &DSPEmitter::lsl,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_IMM, 1, 0, 0, 0x003f}},                               false, false, false, false, true}, // $acR <<= I
-  {"LSR",      0x1440, 0xfec0, DSP::Interpreter::lsr,     &DSPEmitter::lsr,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_IMM, 1, 0, 0, 0x003f}},                               false, false, false, false, true}, // $acR >>= I (shifting in zeros)
-  {"ASL",      0x1480, 0xfec0, DSP::Interpreter::asl,     &DSPEmitter::asl,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_IMM, 1, 0, 0, 0x003f}},                               false, false, false, false, true}, // $acR <<= I
-  {"ASR",      0x14c0, 0xfec0, DSP::Interpreter::asr,     &DSPEmitter::asr,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_IMM, 1, 0, 0, 0x003f}},                               false, false, false, false, true}, // $acR >>= I (shifting in sign bits)
+  {"LSL",      0x1400, 0xfec0, Interpreter::lsl,     &DSPEmitter::lsl,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_IMM, 1, 0, 0, 0x003f}},                               false, false, false, false, true}, // $acR <<= I
+  {"LSR",      0x1440, 0xfec0, Interpreter::lsr,     &DSPEmitter::lsr,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_IMM, 1, 0, 0, 0x003f}},                               false, false, false, false, true}, // $acR >>= I (shifting in zeros)
+  {"ASL",      0x1480, 0xfec0, Interpreter::asl,     &DSPEmitter::asl,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_IMM, 1, 0, 0, 0x003f}},                               false, false, false, false, true}, // $acR <<= I
+  {"ASR",      0x14c0, 0xfec0, Interpreter::asr,     &DSPEmitter::asr,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_IMM, 1, 0, 0, 0x003f}},                               false, false, false, false, true}, // $acR >>= I (shifting in sign bits)
 
   // these two were discovered by ector
-  {"LSRN",     0x02ca, 0xffff, DSP::Interpreter::lsrn,    &DSPEmitter::lsrn,   1, 0, {},                                                                                     false, false, false, false, true}, // $ac0 >>=/<<= $ac1.m[0-6]
-  {"ASRN",     0x02cb, 0xffff, DSP::Interpreter::asrn,    &DSPEmitter::asrn,   1, 0, {},                                                                                     false, false, false, false, true}, // $ac0 >>=/<<= $ac1.m[0-6] (arithmetic)
+  {"LSRN",     0x02ca, 0xffff, Interpreter::lsrn,    &DSPEmitter::lsrn,   1, 0, {},                                                                                     false, false, false, false, true}, // $ac0 >>=/<<= $ac1.m[0-6]
+  {"ASRN",     0x02cb, 0xffff, Interpreter::asrn,    &DSPEmitter::asrn,   1, 0, {},                                                                                     false, false, false, false, true}, // $ac0 >>=/<<= $ac1.m[0-6] (arithmetic)
 
-  {"LRI",      0x0080, 0xffe0, DSP::Interpreter::lri,     &DSPEmitter::lri,    2, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, false}, // $D = I
-  {"LR",       0x00c0, 0xffe0, DSP::Interpreter::lr,      &DSPEmitter::lr,     2, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_MEM, 2, 1, 0, 0xffff}},                               false, false, false, true, false}, // $D = MEM[M]
-  {"SR",       0x00e0, 0xffe0, DSP::Interpreter::sr,      &DSPEmitter::sr,     2, 2, {{P_MEM, 2, 1, 0, 0xffff},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, true, false}, // MEM[M] = $S
+  {"LRI",      0x0080, 0xffe0, Interpreter::lri,     &DSPEmitter::lri,    2, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, false}, // $D = I
+  {"LR",       0x00c0, 0xffe0, Interpreter::lr,      &DSPEmitter::lr,     2, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_MEM, 2, 1, 0, 0xffff}},                               false, false, false, true, false}, // $D = MEM[M]
+  {"SR",       0x00e0, 0xffe0, Interpreter::sr,      &DSPEmitter::sr,     2, 2, {{P_MEM, 2, 1, 0, 0xffff},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, true, false}, // MEM[M] = $S
 
-  {"MRR",      0x1c00, 0xfc00, DSP::Interpreter::mrr,     &DSPEmitter::mrr,    1, 2, {{P_REG, 1, 0, 5, 0x03e0},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // $D = $S
+  {"MRR",      0x1c00, 0xfc00, Interpreter::mrr,     &DSPEmitter::mrr,    1, 2, {{P_REG, 1, 0, 5, 0x03e0},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // $D = $S
 
-  {"SI",       0x1600, 0xff00, DSP::Interpreter::si,      &DSPEmitter::si,     2, 2, {{P_MEM, 1, 0, 0, 0x00ff},     {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, false}, // MEM[M] = I
+  {"SI",       0x1600, 0xff00, Interpreter::si,      &DSPEmitter::si,     2, 2, {{P_MEM, 1, 0, 0, 0x00ff},     {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, false}, // MEM[M] = I
 
-  {"ADDIS",    0x0400, 0xfe00, DSP::Interpreter::addis,   &DSPEmitter::addis,  1, 2, {{P_ACCM,  1, 0, 8, 0x0100},   {P_IMM, 1, 0, 0, 0x00ff}},                               false, false, false, false, true}, // $acD.hm += I
-  {"CMPIS",    0x0600, 0xfe00, DSP::Interpreter::cmpis,   &DSPEmitter::cmpis,  1, 2, {{P_ACCM,  1, 0, 8, 0x0100},   {P_IMM, 1, 0, 0, 0x00ff}},                               false, false, false, false, true}, // FLAGS($acD - I)
-  {"LRIS",     0x0800, 0xf800, DSP::Interpreter::lris,    &DSPEmitter::lris,   1, 2, {{P_REG18, 1, 0, 8, 0x0700},   {P_IMM, 1, 0, 0, 0x00ff}},                               false, false, false, false, true}, // $(D+24) = I
+  {"ADDIS",    0x0400, 0xfe00, Interpreter::addis,   &DSPEmitter::addis,  1, 2, {{P_ACCM,  1, 0, 8, 0x0100},   {P_IMM, 1, 0, 0, 0x00ff}},                               false, false, false, false, true}, // $acD.hm += I
+  {"CMPIS",    0x0600, 0xfe00, Interpreter::cmpis,   &DSPEmitter::cmpis,  1, 2, {{P_ACCM,  1, 0, 8, 0x0100},   {P_IMM, 1, 0, 0, 0x00ff}},                               false, false, false, false, true}, // FLAGS($acD - I)
+  {"LRIS",     0x0800, 0xf800, Interpreter::lris,    &DSPEmitter::lris,   1, 2, {{P_REG18, 1, 0, 8, 0x0700},   {P_IMM, 1, 0, 0, 0x00ff}},                               false, false, false, false, true}, // $(D+24) = I
 
-  {"ADDI",     0x0200, 0xfeff, DSP::Interpreter::addi,    &DSPEmitter::addi,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $acD.hm += I
-  {"XORI",     0x0220, 0xfeff, DSP::Interpreter::xori,    &DSPEmitter::xori,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $acD.m ^= I
-  {"ANDI",     0x0240, 0xfeff, DSP::Interpreter::andi,    &DSPEmitter::andi,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $acD.m &= I
-  {"ORI",      0x0260, 0xfeff, DSP::Interpreter::ori,     &DSPEmitter::ori,    2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $acD.m |= I
-  {"CMPI",     0x0280, 0xfeff, DSP::Interpreter::cmpi,    &DSPEmitter::cmpi,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // FLAGS(($acD.hm - I) | $acD.l)
+  {"ADDI",     0x0200, 0xfeff, Interpreter::addi,    &DSPEmitter::addi,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $acD.hm += I
+  {"XORI",     0x0220, 0xfeff, Interpreter::xori,    &DSPEmitter::xori,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $acD.m ^= I
+  {"ANDI",     0x0240, 0xfeff, Interpreter::andi,    &DSPEmitter::andi,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $acD.m &= I
+  {"ORI",      0x0260, 0xfeff, Interpreter::ori,     &DSPEmitter::ori,    2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $acD.m |= I
+  {"CMPI",     0x0280, 0xfeff, Interpreter::cmpi,    &DSPEmitter::cmpi,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // FLAGS(($acD.hm - I) | $acD.l)
 
-  {"ANDF",     0x02a0, 0xfeff, DSP::Interpreter::andf,    &DSPEmitter::andf,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $sr.LZ = ($acD.m & I) == 0 ? 1 : 0
-  {"ANDCF",    0x02c0, 0xfeff, DSP::Interpreter::andcf,   &DSPEmitter::andcf,  2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $sr.LZ = ($acD.m & I) == I ? 1 : 0
+  {"ANDF",     0x02a0, 0xfeff, Interpreter::andf,    &DSPEmitter::andf,   2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $sr.LZ = ($acD.m & I) == 0 ? 1 : 0
+  {"ANDCF",    0x02c0, 0xfeff, Interpreter::andcf,   &DSPEmitter::andcf,  2, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_IMM, 2, 1, 0, 0xffff}},                               false, false, false, true, true}, // $sr.LZ = ($acD.m & I) == I ? 1 : 0
 
-  {"ILRR",     0x0210, 0xfefc, DSP::Interpreter::ilrr,    &DSPEmitter::ilrr,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_PRG, 1, 0, 0, 0x0003}},                               false, false, false, false, false}, // $acD.m = IMEM[$arS]
-  {"ILRRD",    0x0214, 0xfefc, DSP::Interpreter::ilrrd,   &DSPEmitter::ilrrd,  1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_PRG, 1, 0, 0, 0x0003}},                               false, false, false, false, false}, // $acD.m = IMEM[$arS--]
-  {"ILRRI",    0x0218, 0xfefc, DSP::Interpreter::ilrri,   &DSPEmitter::ilrri,  1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_PRG, 1, 0, 0, 0x0003}},                               false, false, false, false, false}, // $acD.m = IMEM[$arS++]
-  {"ILRRN",    0x021c, 0xfefc, DSP::Interpreter::ilrrn,   &DSPEmitter::ilrrn,  1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_PRG, 1, 0, 0, 0x0003}},                               false, false, false, false, false}, // $acD.m = IMEM[$arS]; $arS += $ixS
+  {"ILRR",     0x0210, 0xfefc, Interpreter::ilrr,    &DSPEmitter::ilrr,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_PRG, 1, 0, 0, 0x0003}},                               false, false, false, false, false}, // $acD.m = IMEM[$arS]
+  {"ILRRD",    0x0214, 0xfefc, Interpreter::ilrrd,   &DSPEmitter::ilrrd,  1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_PRG, 1, 0, 0, 0x0003}},                               false, false, false, false, false}, // $acD.m = IMEM[$arS--]
+  {"ILRRI",    0x0218, 0xfefc, Interpreter::ilrri,   &DSPEmitter::ilrri,  1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_PRG, 1, 0, 0, 0x0003}},                               false, false, false, false, false}, // $acD.m = IMEM[$arS++]
+  {"ILRRN",    0x021c, 0xfefc, Interpreter::ilrrn,   &DSPEmitter::ilrrn,  1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_PRG, 1, 0, 0, 0x0003}},                               false, false, false, false, false}, // $acD.m = IMEM[$arS]; $arS += $ixS
 
   // LOOPS
-  {"LOOP",     0x0040, 0xffe0, DSP::Interpreter::loop,    &DSPEmitter::loop,   1, 1, {{P_REG, 1, 0, 0, 0x001f}},                                                             false, true, true, true, false}, // run next instruction $R times
-  {"BLOOP",    0x0060, 0xffe0, DSP::Interpreter::bloop,   &DSPEmitter::bloop,  2, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_ADDR_I, 2, 1, 0, 0xffff}},                            false, true, true, true, false}, // COMEFROM addr $R times
-  {"LOOPI",    0x1000, 0xff00, DSP::Interpreter::loopi,   &DSPEmitter::loopi,  1, 1, {{P_IMM, 1, 0, 0, 0x00ff}},                                                             false, true, true, true, false}, // run next instruction I times
-  {"BLOOPI",   0x1100, 0xff00, DSP::Interpreter::bloopi,  &DSPEmitter::bloopi, 2, 2, {{P_IMM, 1, 0, 0, 0x00ff},     {P_ADDR_I, 2, 1, 0, 0xffff}},                            false, true, true, true, false}, // COMEFROM addr I times
+  {"LOOP",     0x0040, 0xffe0, Interpreter::loop,    &DSPEmitter::loop,   1, 1, {{P_REG, 1, 0, 0, 0x001f}},                                                             false, true, true, true, false}, // run next instruction $R times
+  {"BLOOP",    0x0060, 0xffe0, Interpreter::bloop,   &DSPEmitter::bloop,  2, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_ADDR_I, 2, 1, 0, 0xffff}},                            false, true, true, true, false}, // COMEFROM addr $R times
+  {"LOOPI",    0x1000, 0xff00, Interpreter::loopi,   &DSPEmitter::loopi,  1, 1, {{P_IMM, 1, 0, 0, 0x00ff}},                                                             false, true, true, true, false}, // run next instruction I times
+  {"BLOOPI",   0x1100, 0xff00, Interpreter::bloopi,  &DSPEmitter::bloopi, 2, 2, {{P_IMM, 1, 0, 0, 0x00ff},     {P_ADDR_I, 2, 1, 0, 0xffff}},                            false, true, true, true, false}, // COMEFROM addr I times
 
   // load and store value pointed by indexing reg and increment; LRR/SRR variants
-  {"LRR",      0x1800, 0xff80, DSP::Interpreter::lrr,     &DSPEmitter::lrr,    1, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_PRG, 1, 0, 5, 0x0060}},                               false, false, false, false, false}, // $D = MEM[$arS]
-  {"LRRD",     0x1880, 0xff80, DSP::Interpreter::lrrd,    &DSPEmitter::lrrd,   1, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_PRG, 1, 0, 5, 0x0060}},                               false, false, false, false, false}, // $D = MEM[$arS--]
-  {"LRRI",     0x1900, 0xff80, DSP::Interpreter::lrri,    &DSPEmitter::lrri,   1, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_PRG, 1, 0, 5, 0x0060}},                               false, false, false, false, false}, // $D = MEM[$arS++]
-  {"LRRN",     0x1980, 0xff80, DSP::Interpreter::lrrn,    &DSPEmitter::lrrn,   1, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_PRG, 1, 0, 5, 0x0060}},                               false, false, false, false, false}, // $D = MEM[$arS]; $arS += $ixS
+  {"LRR",      0x1800, 0xff80, Interpreter::lrr,     &DSPEmitter::lrr,    1, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_PRG, 1, 0, 5, 0x0060}},                               false, false, false, false, false}, // $D = MEM[$arS]
+  {"LRRD",     0x1880, 0xff80, Interpreter::lrrd,    &DSPEmitter::lrrd,   1, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_PRG, 1, 0, 5, 0x0060}},                               false, false, false, false, false}, // $D = MEM[$arS--]
+  {"LRRI",     0x1900, 0xff80, Interpreter::lrri,    &DSPEmitter::lrri,   1, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_PRG, 1, 0, 5, 0x0060}},                               false, false, false, false, false}, // $D = MEM[$arS++]
+  {"LRRN",     0x1980, 0xff80, Interpreter::lrrn,    &DSPEmitter::lrrn,   1, 2, {{P_REG, 1, 0, 0, 0x001f},     {P_PRG, 1, 0, 5, 0x0060}},                               false, false, false, false, false}, // $D = MEM[$arS]; $arS += $ixS
 
-  {"SRR",      0x1a00, 0xff80, DSP::Interpreter::srr,     &DSPEmitter::srr,    1, 2, {{P_PRG, 1, 0, 5, 0x0060},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // MEM[$arD] = $S
-  {"SRRD",     0x1a80, 0xff80, DSP::Interpreter::srrd,    &DSPEmitter::srrd,   1, 2, {{P_PRG, 1, 0, 5, 0x0060},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // MEM[$arD--] = $S
-  {"SRRI",     0x1b00, 0xff80, DSP::Interpreter::srri,    &DSPEmitter::srri,   1, 2, {{P_PRG, 1, 0, 5, 0x0060},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // MEM[$arD++] = $S
-  {"SRRN",     0x1b80, 0xff80, DSP::Interpreter::srrn,    &DSPEmitter::srrn,   1, 2, {{P_PRG, 1, 0, 5, 0x0060},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // MEM[$arD] = $S; $arD += $ixD
+  {"SRR",      0x1a00, 0xff80, Interpreter::srr,     &DSPEmitter::srr,    1, 2, {{P_PRG, 1, 0, 5, 0x0060},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // MEM[$arD] = $S
+  {"SRRD",     0x1a80, 0xff80, Interpreter::srrd,    &DSPEmitter::srrd,   1, 2, {{P_PRG, 1, 0, 5, 0x0060},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // MEM[$arD--] = $S
+  {"SRRI",     0x1b00, 0xff80, Interpreter::srri,    &DSPEmitter::srri,   1, 2, {{P_PRG, 1, 0, 5, 0x0060},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // MEM[$arD++] = $S
+  {"SRRN",     0x1b80, 0xff80, Interpreter::srrn,    &DSPEmitter::srrn,   1, 2, {{P_PRG, 1, 0, 5, 0x0060},     {P_REG, 1, 0, 0, 0x001f}},                               false, false, false, false, false}, // MEM[$arD] = $S; $arD += $ixD
 
   //2
-  {"LRS",      0x2000, 0xf800, DSP::Interpreter::lrs,     &DSPEmitter::lrs,    1, 2, {{P_REG18, 1, 0, 8, 0x0700},   {P_MEM, 1, 0, 0, 0x00ff}},                               false, false, false, false, false}, // $(D+24) = MEM[($cr[0-7] << 8) | I]
-  {"SRS",      0x2800, 0xf800, DSP::Interpreter::srs,     &DSPEmitter::srs,    1, 2, {{P_MEM,   1, 0, 0, 0x00ff},   {P_REG18, 1, 0, 8, 0x0700}},                             false, false, false, false, false}, // MEM[($cr[0-7] << 8) | I] = $(S+24)
+  {"LRS",      0x2000, 0xf800, Interpreter::lrs,     &DSPEmitter::lrs,    1, 2, {{P_REG18, 1, 0, 8, 0x0700},   {P_MEM, 1, 0, 0, 0x00ff}},                               false, false, false, false, false}, // $(D+24) = MEM[($cr[0-7] << 8) | I]
+  {"SRS",      0x2800, 0xf800, Interpreter::srs,     &DSPEmitter::srs,    1, 2, {{P_MEM,   1, 0, 0, 0x00ff},   {P_REG18, 1, 0, 8, 0x0700}},                             false, false, false, false, false}, // MEM[($cr[0-7] << 8) | I] = $(S+24)
 
   // opcodes that can be extended
 
   //3 - main opcode defined by 9 bits, extension defined by last 7 bits!!
-  {"XORR",     0x3000, 0xfc80, DSP::Interpreter::xorr,    &DSPEmitter::xorr,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD.m ^= $axS.h
-  {"ANDR",     0x3400, 0xfc80, DSP::Interpreter::andr,    &DSPEmitter::andr,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD.m &= $axS.h
-  {"ORR",      0x3800, 0xfc80, DSP::Interpreter::orr,     &DSPEmitter::orr,    1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD.m |= $axS.h
-  {"ANDC",     0x3c00, 0xfe80, DSP::Interpreter::andc,    &DSPEmitter::andc,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD.m &= $ac(1-D).m
-  {"ORC",      0x3e00, 0xfe80, DSP::Interpreter::orc,     &DSPEmitter::orc,    1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD.m |= $ac(1-D).m
-  {"XORC",     0x3080, 0xfe80, DSP::Interpreter::xorc,    &DSPEmitter::xorc,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD.m ^= $ac(1-D).m
-  {"NOT",      0x3280, 0xfe80, DSP::Interpreter::notc,    &DSPEmitter::notc,   1, 1, {{P_ACCM, 1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD.m = ~$acD.m
-  {"LSRNRX",   0x3480, 0xfc80, DSP::Interpreter::lsrnrx,  &DSPEmitter::lsrnrx, 1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD >>=/<<= $axS.h[0-6]
-  {"ASRNRX",   0x3880, 0xfc80, DSP::Interpreter::asrnrx,  &DSPEmitter::asrnrx, 1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD >>=/<<= $axS.h[0-6] (arithmetic)
-  {"LSRNR",    0x3c80, 0xfe80, DSP::Interpreter::lsrnr,   &DSPEmitter::lsrnr,  1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD >>=/<<= $ac(1-D).m[0-6]
-  {"ASRNR",    0x3e80, 0xfe80, DSP::Interpreter::asrnr,   &DSPEmitter::asrnr,  1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD >>=/<<= $ac(1-D).m[0-6] (arithmetic)
+  {"XORR",     0x3000, 0xfc80, Interpreter::xorr,    &DSPEmitter::xorr,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD.m ^= $axS.h
+  {"ANDR",     0x3400, 0xfc80, Interpreter::andr,    &DSPEmitter::andr,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD.m &= $axS.h
+  {"ORR",      0x3800, 0xfc80, Interpreter::orr,     &DSPEmitter::orr,    1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD.m |= $axS.h
+  {"ANDC",     0x3c00, 0xfe80, Interpreter::andc,    &DSPEmitter::andc,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD.m &= $ac(1-D).m
+  {"ORC",      0x3e00, 0xfe80, Interpreter::orc,     &DSPEmitter::orc,    1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD.m |= $ac(1-D).m
+  {"XORC",     0x3080, 0xfe80, Interpreter::xorc,    &DSPEmitter::xorc,   1, 2, {{P_ACCM, 1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD.m ^= $ac(1-D).m
+  {"NOT",      0x3280, 0xfe80, Interpreter::notc,    &DSPEmitter::notc,   1, 1, {{P_ACCM, 1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD.m = ~$acD.m
+  {"LSRNRX",   0x3480, 0xfc80, Interpreter::lsrnrx,  &DSPEmitter::lsrnrx, 1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD >>=/<<= $axS.h[0-6]
+  {"ASRNRX",   0x3880, 0xfc80, Interpreter::asrnrx,  &DSPEmitter::asrnrx, 1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_REG1A,  1, 0, 9, 0x0200}},                            true, false, false, false, true}, // $acD >>=/<<= $axS.h[0-6] (arithmetic)
+  {"LSRNR",    0x3c80, 0xfe80, Interpreter::lsrnr,   &DSPEmitter::lsrnr,  1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD >>=/<<= $ac(1-D).m[0-6]
+  {"ASRNR",    0x3e80, 0xfe80, Interpreter::asrnr,   &DSPEmitter::asrnr,  1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_ACCM_D, 1, 0, 8, 0x0100}},                            true, false, false, false, true}, // $acD >>=/<<= $ac(1-D).m[0-6] (arithmetic)
 
   //4
-  {"ADDR",     0x4000, 0xf800, DSP::Interpreter::addr,    &DSPEmitter::addr,   1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_REG18, 1, 0, 9, 0x0600}},                             true, false, false, false, true}, // $acD += $(S+24)
-  {"ADDAX",    0x4800, 0xfc00, DSP::Interpreter::addax,   &DSPEmitter::addax,  1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_AX, 1, 0, 9, 0x0200}},                                true, false, false, false, true}, // $acD += $axS
-  {"ADD",      0x4c00, 0xfe00, DSP::Interpreter::add,     &DSPEmitter::add,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_ACC_D, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $acD += $ac(1-D)
-  {"ADDP",     0x4e00, 0xfe00, DSP::Interpreter::addp,    &DSPEmitter::addp,   1, 1, {{P_ACC, 1, 0, 8, 0x0100}},                                                             true, false, false, false, true}, // $acD += $prod
+  {"ADDR",     0x4000, 0xf800, Interpreter::addr,    &DSPEmitter::addr,   1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_REG18, 1, 0, 9, 0x0600}},                             true, false, false, false, true}, // $acD += $(S+24)
+  {"ADDAX",    0x4800, 0xfc00, Interpreter::addax,   &DSPEmitter::addax,  1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_AX, 1, 0, 9, 0x0200}},                                true, false, false, false, true}, // $acD += $axS
+  {"ADD",      0x4c00, 0xfe00, Interpreter::add,     &DSPEmitter::add,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_ACC_D, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $acD += $ac(1-D)
+  {"ADDP",     0x4e00, 0xfe00, Interpreter::addp,    &DSPEmitter::addp,   1, 1, {{P_ACC, 1, 0, 8, 0x0100}},                                                             true, false, false, false, true}, // $acD += $prod
 
   //5
-  {"SUBR",     0x5000, 0xf800, DSP::Interpreter::subr,    &DSPEmitter::subr,   1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_REG18, 1, 0, 9, 0x0600}},                             true, false, false, false, true}, // $acD -= $(S+24)
-  {"SUBAX",    0x5800, 0xfc00, DSP::Interpreter::subax,   &DSPEmitter::subax,  1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_AX, 1, 0, 9, 0x0200}},                                true, false, false, false, true}, // $acD -= $axS
-  {"SUB",      0x5c00, 0xfe00, DSP::Interpreter::sub,     &DSPEmitter::sub,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_ACC_D, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $acD -= $ac(1-D)
-  {"SUBP",     0x5e00, 0xfe00, DSP::Interpreter::subp,    &DSPEmitter::subp,   1, 1, {{P_ACC, 1, 0, 8, 0x0100}},                                                             true, false, false, false, true}, // $acD -= $prod
+  {"SUBR",     0x5000, 0xf800, Interpreter::subr,    &DSPEmitter::subr,   1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_REG18, 1, 0, 9, 0x0600}},                             true, false, false, false, true}, // $acD -= $(S+24)
+  {"SUBAX",    0x5800, 0xfc00, Interpreter::subax,   &DSPEmitter::subax,  1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_AX, 1, 0, 9, 0x0200}},                                true, false, false, false, true}, // $acD -= $axS
+  {"SUB",      0x5c00, 0xfe00, Interpreter::sub,     &DSPEmitter::sub,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_ACC_D, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $acD -= $ac(1-D)
+  {"SUBP",     0x5e00, 0xfe00, Interpreter::subp,    &DSPEmitter::subp,   1, 1, {{P_ACC, 1, 0, 8, 0x0100}},                                                             true, false, false, false, true}, // $acD -= $prod
 
   //6
-  {"MOVR",     0x6000, 0xf800, DSP::Interpreter::movr,    &DSPEmitter::movr,   1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_REG18, 1, 0, 9, 0x0600}},                             true, false, false, false, true}, // $acD.hm = $(S+24); $acD.l = 0
-  {"MOVAX",    0x6800, 0xfc00, DSP::Interpreter::movax,   &DSPEmitter::movax,  1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_AX, 1, 0, 9, 0x0200}},                                true, false, false, false, true}, // $acD = $axS
-  {"MOV",      0x6c00, 0xfe00, DSP::Interpreter::mov,     &DSPEmitter::mov,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_ACC_D, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $acD = $ax(1-D)
-  {"MOVP",     0x6e00, 0xfe00, DSP::Interpreter::movp,    &DSPEmitter::movp,   1, 1, {{P_ACC, 1, 0, 8, 0x0100}},                                                             true, false, false, false, true}, // $acD = $prod
+  {"MOVR",     0x6000, 0xf800, Interpreter::movr,    &DSPEmitter::movr,   1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_REG18, 1, 0, 9, 0x0600}},                             true, false, false, false, true}, // $acD.hm = $(S+24); $acD.l = 0
+  {"MOVAX",    0x6800, 0xfc00, Interpreter::movax,   &DSPEmitter::movax,  1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_AX, 1, 0, 9, 0x0200}},                                true, false, false, false, true}, // $acD = $axS
+  {"MOV",      0x6c00, 0xfe00, Interpreter::mov,     &DSPEmitter::mov,    1, 2, {{P_ACC, 1, 0, 8, 0x0100},     {P_ACC_D, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $acD = $ax(1-D)
+  {"MOVP",     0x6e00, 0xfe00, Interpreter::movp,    &DSPEmitter::movp,   1, 1, {{P_ACC, 1, 0, 8, 0x0100}},                                                             true, false, false, false, true}, // $acD = $prod
 
   //7
-  {"ADDAXL",   0x7000, 0xfc00, DSP::Interpreter::addaxl,  &DSPEmitter::addaxl, 1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_REG18, 1, 0, 9, 0x0200}},                             true, false, false, false, true}, // $acD += $axS.l
-  {"INCM",     0x7400, 0xfe00, DSP::Interpreter::incm,    &DSPEmitter::incm,   1, 1, {{P_ACCM, 1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acsD++
-  {"INC",      0x7600, 0xfe00, DSP::Interpreter::inc,     &DSPEmitter::inc,    1, 1, {{P_ACC,  1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD++
-  {"DECM",     0x7800, 0xfe00, DSP::Interpreter::decm,    &DSPEmitter::decm,   1, 1, {{P_ACCM, 1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acsD--
-  {"DEC",      0x7a00, 0xfe00, DSP::Interpreter::dec,     &DSPEmitter::dec,    1, 1, {{P_ACC,  1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD--
-  {"NEG",      0x7c00, 0xfe00, DSP::Interpreter::neg,     &DSPEmitter::neg,    1, 1, {{P_ACC,  1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD = -$acD
-  {"MOVNP",    0x7e00, 0xfe00, DSP::Interpreter::movnp,   &DSPEmitter::movnp,  1, 1, {{P_ACC,  1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD = -$prod
+  {"ADDAXL",   0x7000, 0xfc00, Interpreter::addaxl,  &DSPEmitter::addaxl, 1, 2, {{P_ACC,  1, 0, 8, 0x0100},    {P_REG18, 1, 0, 9, 0x0200}},                             true, false, false, false, true}, // $acD += $axS.l
+  {"INCM",     0x7400, 0xfe00, Interpreter::incm,    &DSPEmitter::incm,   1, 1, {{P_ACCM, 1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acsD++
+  {"INC",      0x7600, 0xfe00, Interpreter::inc,     &DSPEmitter::inc,    1, 1, {{P_ACC,  1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD++
+  {"DECM",     0x7800, 0xfe00, Interpreter::decm,    &DSPEmitter::decm,   1, 1, {{P_ACCM, 1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acsD--
+  {"DEC",      0x7a00, 0xfe00, Interpreter::dec,     &DSPEmitter::dec,    1, 1, {{P_ACC,  1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD--
+  {"NEG",      0x7c00, 0xfe00, Interpreter::neg,     &DSPEmitter::neg,    1, 1, {{P_ACC,  1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD = -$acD
+  {"MOVNP",    0x7e00, 0xfe00, Interpreter::movnp,   &DSPEmitter::movnp,  1, 1, {{P_ACC,  1, 0, 8, 0x0100}},                                                            true, false, false, false, true}, // $acD = -$prod
 
   //8
-  {"NX",       0x8000, 0xf700, DSP::Interpreter::nx,      &DSPEmitter::nx,     1, 0, {},                                                                                     true, false, false, false, false}, // extendable nop
-  {"CLR",      0x8100, 0xf700, DSP::Interpreter::clr,     &DSPEmitter::clr,    1, 1, {{P_ACC,   1, 0, 11, 0x0800}},                                                          true, false, false, false, true},  // $acD = 0
-  {"CMP",      0x8200, 0xff00, DSP::Interpreter::cmp,     &DSPEmitter::cmp,    1, 0, {},                                                                                     true, false, false, false, true},  // FLAGS($ac0 - $ac1)
-  {"MULAXH",   0x8300, 0xff00, DSP::Interpreter::mulaxh,  &DSPEmitter::mulaxh, 1, 0, {},                                                                                     true, false, false, false, true},  // $prod = $ax0.h * $ax0.h
-  {"CLRP",     0x8400, 0xff00, DSP::Interpreter::clrp,    &DSPEmitter::clrp,   1, 0, {},                                                                                     true, false, false, false, true},  // $prod = 0
-  {"TSTPROD",  0x8500, 0xff00, DSP::Interpreter::tstprod, &DSPEmitter::tstprod,1, 0, {},                                                                                     true, false, false, false, true},  // FLAGS($prod)
-  {"TSTAXH",   0x8600, 0xfe00, DSP::Interpreter::tstaxh,  &DSPEmitter::tstaxh, 1, 1, {{P_REG1A, 1, 0, 8, 0x0100}},                                                           true, false, false, false, true},  // FLAGS($axR.h)
-  {"M2",       0x8a00, 0xff00, DSP::Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // enable "$prod *= 2" after every multiplication
-  {"M0",       0x8b00, 0xff00, DSP::Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // disable "$prod *= 2" after every multiplication
-  {"CLR15",    0x8c00, 0xff00, DSP::Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // set normal multiplication
-  {"SET15",    0x8d00, 0xff00, DSP::Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // set unsigned multiplication in MUL
-  {"SET16",    0x8e00, 0xff00, DSP::Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // set 16 bit sign extension width
-  {"SET40",    0x8f00, 0xff00, DSP::Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // set 40 bit sign extension width
+  {"NX",       0x8000, 0xf700, Interpreter::nx,      &DSPEmitter::nx,     1, 0, {},                                                                                     true, false, false, false, false}, // extendable nop
+  {"CLR",      0x8100, 0xf700, Interpreter::clr,     &DSPEmitter::clr,    1, 1, {{P_ACC,   1, 0, 11, 0x0800}},                                                          true, false, false, false, true},  // $acD = 0
+  {"CMP",      0x8200, 0xff00, Interpreter::cmp,     &DSPEmitter::cmp,    1, 0, {},                                                                                     true, false, false, false, true},  // FLAGS($ac0 - $ac1)
+  {"MULAXH",   0x8300, 0xff00, Interpreter::mulaxh,  &DSPEmitter::mulaxh, 1, 0, {},                                                                                     true, false, false, false, true},  // $prod = $ax0.h * $ax0.h
+  {"CLRP",     0x8400, 0xff00, Interpreter::clrp,    &DSPEmitter::clrp,   1, 0, {},                                                                                     true, false, false, false, true},  // $prod = 0
+  {"TSTPROD",  0x8500, 0xff00, Interpreter::tstprod, &DSPEmitter::tstprod,1, 0, {},                                                                                     true, false, false, false, true},  // FLAGS($prod)
+  {"TSTAXH",   0x8600, 0xfe00, Interpreter::tstaxh,  &DSPEmitter::tstaxh, 1, 1, {{P_REG1A, 1, 0, 8, 0x0100}},                                                           true, false, false, false, true},  // FLAGS($axR.h)
+  {"M2",       0x8a00, 0xff00, Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // enable "$prod *= 2" after every multiplication
+  {"M0",       0x8b00, 0xff00, Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // disable "$prod *= 2" after every multiplication
+  {"CLR15",    0x8c00, 0xff00, Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // set normal multiplication
+  {"SET15",    0x8d00, 0xff00, Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // set unsigned multiplication in MUL
+  {"SET16",    0x8e00, 0xff00, Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // set 16 bit sign extension width
+  {"SET40",    0x8f00, 0xff00, Interpreter::srbith,  &DSPEmitter::srbith, 1, 0, {},                                                                                     true, false, false, false, false}, // set 40 bit sign extension width
 
   //9
-  {"MUL",      0x9000, 0xf700, DSP::Interpreter::mul,     &DSPEmitter::mul,    1, 2, {{P_REG18, 1, 0, 11, 0x0800},  {P_REG1A, 1, 0, 11, 0x0800}},                            true, false, false, false, true}, // $prod = $axS.l * $axS.h
-  {"ASR16",    0x9100, 0xf700, DSP::Interpreter::asr16,   &DSPEmitter::asr16,  1, 1, {{P_ACC,   1, 0, 11, 0x0800}},                                                          true, false, false, false, true}, // $acD >>= 16 (shifting in sign bits)
-  {"MULMVZ",   0x9200, 0xf600, DSP::Interpreter::mulmvz,  &DSPEmitter::mulmvz, 1, 3, {{P_REG18, 1, 0, 11, 0x0800},  {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR.hm = $prod.hm; $acR.l = 0; $prod = $axS.l * $axS.h
-  {"MULAC",    0x9400, 0xf600, DSP::Interpreter::mulac,   &DSPEmitter::mulac,  1, 3, {{P_REG18, 1, 0, 11, 0x0800},  {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR += $prod; $prod = $axS.l * $axS.h
-  {"MULMV",    0x9600, 0xf600, DSP::Interpreter::mulmv,   &DSPEmitter::mulmv,  1, 3, {{P_REG18, 1, 0, 11, 0x0800},  {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR = $prod; $prod = $axS.l * $axS.h
+  {"MUL",      0x9000, 0xf700, Interpreter::mul,     &DSPEmitter::mul,    1, 2, {{P_REG18, 1, 0, 11, 0x0800},  {P_REG1A, 1, 0, 11, 0x0800}},                            true, false, false, false, true}, // $prod = $axS.l * $axS.h
+  {"ASR16",    0x9100, 0xf700, Interpreter::asr16,   &DSPEmitter::asr16,  1, 1, {{P_ACC,   1, 0, 11, 0x0800}},                                                          true, false, false, false, true}, // $acD >>= 16 (shifting in sign bits)
+  {"MULMVZ",   0x9200, 0xf600, Interpreter::mulmvz,  &DSPEmitter::mulmvz, 1, 3, {{P_REG18, 1, 0, 11, 0x0800},  {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR.hm = $prod.hm; $acR.l = 0; $prod = $axS.l * $axS.h
+  {"MULAC",    0x9400, 0xf600, Interpreter::mulac,   &DSPEmitter::mulac,  1, 3, {{P_REG18, 1, 0, 11, 0x0800},  {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR += $prod; $prod = $axS.l * $axS.h
+  {"MULMV",    0x9600, 0xf600, Interpreter::mulmv,   &DSPEmitter::mulmv,  1, 3, {{P_REG18, 1, 0, 11, 0x0800},  {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR = $prod; $prod = $axS.l * $axS.h
 
   //a-b
-  {"MULX",     0xa000, 0xe700, DSP::Interpreter::mulx,    &DSPEmitter::mulx,   1, 2, {{P_REGM18, 1, 0, 11, 0x1000}, {P_REGM19, 1, 0, 10, 0x0800}},                           true, false, false, false, true}, // $prod = $ax0.S * $ax1.T
-  {"ABS",      0xa100, 0xf700, DSP::Interpreter::abs,     &DSPEmitter::abs,    1, 1, {{P_ACC,    1, 0, 11, 0x0800}},                                                         true, false, false, false, true}, // $acD = abs($acD)
-  {"MULXMVZ",  0xa200, 0xe600, DSP::Interpreter::mulxmvz, &DSPEmitter::mulxmvz,1, 3, {{P_REGM18, 1, 0, 11, 0x1000}, {P_REGM19, 1, 0, 10, 0x0800}, {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR.hm = $prod.hm; $acR.l = 0; $prod = $ax0.S * $ax1.T
-  {"MULXAC",   0xa400, 0xe600, DSP::Interpreter::mulxac,  &DSPEmitter::mulxac, 1, 3, {{P_REGM18, 1, 0, 11, 0x1000}, {P_REGM19, 1, 0, 10, 0x0800}, {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR += $prod; $prod = $ax0.S * $ax1.T
-  {"MULXMV",   0xa600, 0xe600, DSP::Interpreter::mulxmv,  &DSPEmitter::mulxmv, 1, 3, {{P_REGM18, 1, 0, 11, 0x1000}, {P_REGM19, 1, 0, 10, 0x0800}, {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR = $prod; $prod = $ax0.S * $ax1.T
-  {"TST",      0xb100, 0xf700, DSP::Interpreter::tst,     &DSPEmitter::tst,    1, 1, {{P_ACC,    1, 0, 11, 0x0800}},                                                         true, false, false, false, true}, // FLAGS($acR)
+  {"MULX",     0xa000, 0xe700, Interpreter::mulx,    &DSPEmitter::mulx,   1, 2, {{P_REGM18, 1, 0, 11, 0x1000}, {P_REGM19, 1, 0, 10, 0x0800}},                           true, false, false, false, true}, // $prod = $ax0.S * $ax1.T
+  {"ABS",      0xa100, 0xf700, Interpreter::abs,     &DSPEmitter::abs,    1, 1, {{P_ACC,    1, 0, 11, 0x0800}},                                                         true, false, false, false, true}, // $acD = abs($acD)
+  {"MULXMVZ",  0xa200, 0xe600, Interpreter::mulxmvz, &DSPEmitter::mulxmvz,1, 3, {{P_REGM18, 1, 0, 11, 0x1000}, {P_REGM19, 1, 0, 10, 0x0800}, {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR.hm = $prod.hm; $acR.l = 0; $prod = $ax0.S * $ax1.T
+  {"MULXAC",   0xa400, 0xe600, Interpreter::mulxac,  &DSPEmitter::mulxac, 1, 3, {{P_REGM18, 1, 0, 11, 0x1000}, {P_REGM19, 1, 0, 10, 0x0800}, {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR += $prod; $prod = $ax0.S * $ax1.T
+  {"MULXMV",   0xa600, 0xe600, Interpreter::mulxmv,  &DSPEmitter::mulxmv, 1, 3, {{P_REGM18, 1, 0, 11, 0x1000}, {P_REGM19, 1, 0, 10, 0x0800}, {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR = $prod; $prod = $ax0.S * $ax1.T
+  {"TST",      0xb100, 0xf700, Interpreter::tst,     &DSPEmitter::tst,    1, 1, {{P_ACC,    1, 0, 11, 0x0800}},                                                         true, false, false, false, true}, // FLAGS($acR)
 
   //c-d
-  {"MULC",     0xc000, 0xe700, DSP::Interpreter::mulc,    &DSPEmitter::mulc,   1, 2, {{P_ACCM, 1, 0, 12, 0x1000},   {P_REG1A, 1, 0, 11, 0x0800}},                            true, false, false, false, true}, // $prod = $acS.m * $axS.h
-  {"CMPAR",    0xc100, 0xe700, DSP::Interpreter::cmpar,   &DSPEmitter::cmpar,  1, 2, {{P_ACC,  1, 0, 11, 0x0800},   {P_REG1A, 1, 0, 12, 0x1000}},                            true, false, false, false, true}, // FLAGS($acS - axR.h)
-  {"MULCMVZ",  0xc200, 0xe600, DSP::Interpreter::mulcmvz, &DSPEmitter::mulcmvz,1, 3, {{P_ACCM, 1, 0, 12, 0x1000},   {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR.hm, $acR.l, $prod = $prod.hm, 0, $acS.m * $axS.h
-  {"MULCAC",   0xc400, 0xe600, DSP::Interpreter::mulcac,  &DSPEmitter::mulcac, 1, 3, {{P_ACCM, 1, 0, 12, 0x1000},   {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR, $prod = $acR + $prod, $acS.m * $axS.h
-  {"MULCMV",   0xc600, 0xe600, DSP::Interpreter::mulcmv,  &DSPEmitter::mulcmv, 1, 3, {{P_ACCM, 1, 0, 12, 0x1000},   {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR, $prod = $prod, $acS.m * $axS.h
+  {"MULC",     0xc000, 0xe700, Interpreter::mulc,    &DSPEmitter::mulc,   1, 2, {{P_ACCM, 1, 0, 12, 0x1000},   {P_REG1A, 1, 0, 11, 0x0800}},                            true, false, false, false, true}, // $prod = $acS.m * $axS.h
+  {"CMPAR",    0xc100, 0xe700, Interpreter::cmpar,   &DSPEmitter::cmpar,  1, 2, {{P_ACC,  1, 0, 11, 0x0800},   {P_REG1A, 1, 0, 12, 0x1000}},                            true, false, false, false, true}, // FLAGS($acS - axR.h)
+  {"MULCMVZ",  0xc200, 0xe600, Interpreter::mulcmvz, &DSPEmitter::mulcmvz,1, 3, {{P_ACCM, 1, 0, 12, 0x1000},   {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR.hm, $acR.l, $prod = $prod.hm, 0, $acS.m * $axS.h
+  {"MULCAC",   0xc400, 0xe600, Interpreter::mulcac,  &DSPEmitter::mulcac, 1, 3, {{P_ACCM, 1, 0, 12, 0x1000},   {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR, $prod = $acR + $prod, $acS.m * $axS.h
+  {"MULCMV",   0xc600, 0xe600, Interpreter::mulcmv,  &DSPEmitter::mulcmv, 1, 3, {{P_ACCM, 1, 0, 12, 0x1000},   {P_REG1A, 1, 0, 11, 0x0800},  {P_ACC, 1, 0, 8, 0x0100}}, true, false, false, false, true}, // $acR, $prod = $prod, $acS.m * $axS.h
 
   //e
-  {"MADDX",    0xe000, 0xfc00, DSP::Interpreter::maddx,   &DSPEmitter::maddx,  1, 2, {{P_REGM18, 1, 0, 8, 0x0200},  {P_REGM19, 1, 0, 7, 0x0100}},                            true, false, false, false, true}, // $prod += $ax0.S * $ax1.T
-  {"MSUBX",    0xe400, 0xfc00, DSP::Interpreter::msubx,   &DSPEmitter::msubx,  1, 2, {{P_REGM18, 1, 0, 8, 0x0200},  {P_REGM19, 1, 0, 7, 0x0100}},                            true, false, false, false, true}, // $prod -= $ax0.S * $ax1.T
-  {"MADDC",    0xe800, 0xfc00, DSP::Interpreter::maddc,   &DSPEmitter::maddc,  1, 2, {{P_ACCM,   1, 0, 9, 0x0200},  {P_REG19, 1, 0, 7, 0x0100}},                             true, false, false, false, true}, // $prod += $acS.m * $axT.h
-  {"MSUBC",    0xec00, 0xfc00, DSP::Interpreter::msubc,   &DSPEmitter::msubc,  1, 2, {{P_ACCM,   1, 0, 9, 0x0200},  {P_REG19, 1, 0, 7, 0x0100}},                             true, false, false, false, true}, // $prod -= $acS.m * $axT.h
+  {"MADDX",    0xe000, 0xfc00, Interpreter::maddx,   &DSPEmitter::maddx,  1, 2, {{P_REGM18, 1, 0, 8, 0x0200},  {P_REGM19, 1, 0, 7, 0x0100}},                            true, false, false, false, true}, // $prod += $ax0.S * $ax1.T
+  {"MSUBX",    0xe400, 0xfc00, Interpreter::msubx,   &DSPEmitter::msubx,  1, 2, {{P_REGM18, 1, 0, 8, 0x0200},  {P_REGM19, 1, 0, 7, 0x0100}},                            true, false, false, false, true}, // $prod -= $ax0.S * $ax1.T
+  {"MADDC",    0xe800, 0xfc00, Interpreter::maddc,   &DSPEmitter::maddc,  1, 2, {{P_ACCM,   1, 0, 9, 0x0200},  {P_REG19, 1, 0, 7, 0x0100}},                             true, false, false, false, true}, // $prod += $acS.m * $axT.h
+  {"MSUBC",    0xec00, 0xfc00, Interpreter::msubc,   &DSPEmitter::msubc,  1, 2, {{P_ACCM,   1, 0, 9, 0x0200},  {P_REG19, 1, 0, 7, 0x0100}},                             true, false, false, false, true}, // $prod -= $acS.m * $axT.h
 
   //f
-  {"LSL16",    0xf000, 0xfe00, DSP::Interpreter::lsl16,   &DSPEmitter::lsl16,  1, 1, {{P_ACC,   1, 0,  8, 0x0100}},                                                          true, false, false, false, true}, // $acR <<= 16
-  {"MADD",     0xf200, 0xfe00, DSP::Interpreter::madd,    &DSPEmitter::madd,   1, 2, {{P_REG18, 1, 0,  8, 0x0100},  {P_REG1A, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $prod += $axS.l * $axS.h
-  {"LSR16",    0xf400, 0xfe00, DSP::Interpreter::lsr16,   &DSPEmitter::lsr16,  1, 1, {{P_ACC,   1, 0,  8, 0x0100}},                                                          true, false, false, false, true}, // $acR >>= 16
-  {"MSUB",     0xf600, 0xfe00, DSP::Interpreter::msub,    &DSPEmitter::msub,   1, 2, {{P_REG18, 1, 0,  8, 0x0100},  {P_REG1A, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $prod -= $axS.l * $axS.h
-  {"ADDPAXZ",  0xf800, 0xfc00, DSP::Interpreter::addpaxz, &DSPEmitter::addpaxz,1, 2, {{P_ACC,   1, 0,  9, 0x0200},  {P_AX, 1, 0, 8, 0x0100}},                                true, false, false, false, true}, // $acD.hm = $prod.hm + $ax.h; $acD.l = 0
-  {"CLRL",     0xfc00, 0xfe00, DSP::Interpreter::clrl,    &DSPEmitter::clrl,   1, 1, {{P_ACCL,  1, 0, 11, 0x0800}},                                                          true, false, false, false, true}, // $acR.l = 0
-  {"MOVPZ",    0xfe00, 0xfe00, DSP::Interpreter::movpz,   &DSPEmitter::movpz,  1, 1, {{P_ACC,   1, 0,  8, 0x0100}},                                                          true, false, false, false, true}, // $acD.hm = $prod.hm; $acD.l = 0
+  {"LSL16",    0xf000, 0xfe00, Interpreter::lsl16,   &DSPEmitter::lsl16,  1, 1, {{P_ACC,   1, 0,  8, 0x0100}},                                                          true, false, false, false, true}, // $acR <<= 16
+  {"MADD",     0xf200, 0xfe00, Interpreter::madd,    &DSPEmitter::madd,   1, 2, {{P_REG18, 1, 0,  8, 0x0100},  {P_REG1A, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $prod += $axS.l * $axS.h
+  {"LSR16",    0xf400, 0xfe00, Interpreter::lsr16,   &DSPEmitter::lsr16,  1, 1, {{P_ACC,   1, 0,  8, 0x0100}},                                                          true, false, false, false, true}, // $acR >>= 16
+  {"MSUB",     0xf600, 0xfe00, Interpreter::msub,    &DSPEmitter::msub,   1, 2, {{P_REG18, 1, 0,  8, 0x0100},  {P_REG1A, 1, 0, 8, 0x0100}},                             true, false, false, false, true}, // $prod -= $axS.l * $axS.h
+  {"ADDPAXZ",  0xf800, 0xfc00, Interpreter::addpaxz, &DSPEmitter::addpaxz,1, 2, {{P_ACC,   1, 0,  9, 0x0200},  {P_AX, 1, 0, 8, 0x0100}},                                true, false, false, false, true}, // $acD.hm = $prod.hm + $ax.h; $acD.l = 0
+  {"CLRL",     0xfc00, 0xfe00, Interpreter::clrl,    &DSPEmitter::clrl,   1, 1, {{P_ACCL,  1, 0, 11, 0x0800}},                                                          true, false, false, false, true}, // $acR.l = 0
+  {"MOVPZ",    0xfe00, 0xfe00, Interpreter::movpz,   &DSPEmitter::movpz,  1, 1, {{P_ACC,   1, 0,  8, 0x0100}},                                                          true, false, false, false, true}, // $acD.hm = $prod.hm; $acD.l = 0
 };
 
 const DSPOPCTemplate cw =
-  {"CW",     0x0000, 0x0000, DSP::Interpreter::nop, nullptr, 1, 1, {{P_VAL, 2, 0, 0, 0xffff}}, false, false, false, false, false};
+  {"CW",     0x0000, 0x0000, Interpreter::nop, nullptr, 1, 1, {{P_VAL, 2, 0, 0, 0xffff}}, false, false, false, false, false};
 
 // extended opcodes
 
 const DSPOPCTemplate opcodes_ext[] =
 {
-  {"XXX",    0x0000, 0x00fc, DSP::Interpreter::Ext::nop,  &DSPEmitter::nop,  1, 1, {{P_VAL, 1, 0, 0, 0x00ff}}, false, false, false, false, false}, // no operation
+  {"XXX",    0x0000, 0x00fc, Interpreter::Ext::nop,  &DSPEmitter::nop,  1, 1, {{P_VAL, 1, 0, 0, 0x00ff}}, false, false, false, false, false}, // no operation
 
-  {"DR",     0x0004, 0x00fc, DSP::Interpreter::Ext::dr,   &DSPEmitter::dr,   1, 1, {{P_REG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $arR--
-  {"IR",     0x0008, 0x00fc, DSP::Interpreter::Ext::ir,   &DSPEmitter::ir,   1, 1, {{P_REG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $arR++
-  {"NR",     0x000c, 0x00fc, DSP::Interpreter::Ext::nr,   &DSPEmitter::nr,   1, 1, {{P_REG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $arR += $ixR
-  {"MV",     0x0010, 0x00f0, DSP::Interpreter::Ext::mv,   &DSPEmitter::mv,   1, 2, {{P_REG18, 1, 0, 2, 0x000c}, {P_REG1C, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $(D+24) = $(S+28)
+  {"DR",     0x0004, 0x00fc, Interpreter::Ext::dr,   &DSPEmitter::dr,   1, 1, {{P_REG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $arR--
+  {"IR",     0x0008, 0x00fc, Interpreter::Ext::ir,   &DSPEmitter::ir,   1, 1, {{P_REG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $arR++
+  {"NR",     0x000c, 0x00fc, Interpreter::Ext::nr,   &DSPEmitter::nr,   1, 1, {{P_REG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $arR += $ixR
+  {"MV",     0x0010, 0x00f0, Interpreter::Ext::mv,   &DSPEmitter::mv,   1, 2, {{P_REG18, 1, 0, 2, 0x000c}, {P_REG1C, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $(D+24) = $(S+28)
 
-  {"S",      0x0020, 0x00e4, DSP::Interpreter::Ext::s,    &DSPEmitter::s,    1, 2, {{P_PRG, 1, 0, 0, 0x0003}, {P_REG1C, 1, 0, 3, 0x0018}}, false, false, false, false, false}, // MEM[$D++] = $(S+28)
-  {"SN",     0x0024, 0x00e4, DSP::Interpreter::Ext::sn,   &DSPEmitter::sn,   1, 2, {{P_PRG, 1, 0, 0, 0x0003}, {P_REG1C, 1, 0, 3, 0x0018}}, false, false, false, false, false}, // MEM[$D] = $(D+28); $D += $(D+4)
+  {"S",      0x0020, 0x00e4, Interpreter::Ext::s,    &DSPEmitter::s,    1, 2, {{P_PRG, 1, 0, 0, 0x0003}, {P_REG1C, 1, 0, 3, 0x0018}}, false, false, false, false, false}, // MEM[$D++] = $(S+28)
+  {"SN",     0x0024, 0x00e4, Interpreter::Ext::sn,   &DSPEmitter::sn,   1, 2, {{P_PRG, 1, 0, 0, 0x0003}, {P_REG1C, 1, 0, 3, 0x0018}}, false, false, false, false, false}, // MEM[$D] = $(D+28); $D += $(D+4)
 
-  {"L",      0x0040, 0x00c4, DSP::Interpreter::Ext::l,    &DSPEmitter::l,    1, 2, {{P_REG18, 1, 0, 3, 0x0038}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $(D+24) = MEM[$S++]
-  {"LN",     0x0044, 0x00c4, DSP::Interpreter::Ext::ln,   &DSPEmitter::ln,   1, 2, {{P_REG18, 1, 0, 3, 0x0038}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $(D+24) = MEM[$S]; $S += $(S+4)
+  {"L",      0x0040, 0x00c4, Interpreter::Ext::l,    &DSPEmitter::l,    1, 2, {{P_REG18, 1, 0, 3, 0x0038}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $(D+24) = MEM[$S++]
+  {"LN",     0x0044, 0x00c4, Interpreter::Ext::ln,   &DSPEmitter::ln,   1, 2, {{P_REG18, 1, 0, 3, 0x0038}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $(D+24) = MEM[$S]; $S += $(S+4)
 
-  {"LS",     0x0080, 0x00ce, DSP::Interpreter::Ext::ls,   &DSPEmitter::ls,   1, 2, {{P_REG18, 1, 0, 4, 0x0030}, {P_ACCM, 1, 0, 0, 0x0001}}, false, false, false, false, false}, // $(D+24) = MEM[$ar0++]; MEM[$ar3++] = $acS.m
-  {"SL",     0x0082, 0x00ce, DSP::Interpreter::Ext::sl,   &DSPEmitter::sl,   1, 2, {{P_ACCM, 1, 0, 0, 0x0001}, {P_REG18, 1, 0, 4, 0x0030}}, false, false, false, false, false}, // MEM[$ar0++] = $acS.m; $(D+24) = MEM[$ar3++]
-  {"LSN",    0x0084, 0x00ce, DSP::Interpreter::Ext::lsn,  &DSPEmitter::lsn,  1, 2, {{P_REG18, 1, 0, 4, 0x0030}, {P_ACCM, 1, 0, 0, 0x0001}}, false, false, false, false, false}, // $(D+24) = MEM[$ar0]; MEM[$ar3++] = $acS.m; $ar0 += $ix0
-  {"SLN",    0x0086, 0x00ce, DSP::Interpreter::Ext::sln,  &DSPEmitter::sln,  1, 2, {{P_ACCM, 1, 0, 0, 0x0001}, {P_REG18, 1, 0, 4, 0x0030}}, false, false, false, false, false}, // MEM[$ar0] = $acS.m; $(D+24) = MEM[$ar3++]; $ar0 += $ix0
-  {"LSM",    0x0088, 0x00ce, DSP::Interpreter::Ext::lsm,  &DSPEmitter::lsm,  1, 2, {{P_REG18, 1, 0, 4, 0x0030}, {P_ACCM, 1, 0, 0, 0x0001}}, false, false, false, false, false}, // $(D+24) = MEM[$ar0++]; MEM[$ar3] = $acS.m; $ar3 += $ix3
-  {"SLM",    0x008a, 0x00ce, DSP::Interpreter::Ext::slm,  &DSPEmitter::slm,  1, 2, {{P_ACCM, 1, 0, 0, 0x0001}, {P_REG18, 1, 0, 4, 0x0030}}, false, false, false, false, false}, // MEM[$ar0++] = $acS.m; $(D+24) = MEM[$ar3]; $ar3 += $ix3
-  {"LSNM",   0x008c, 0x00ce, DSP::Interpreter::Ext::lsnm, &DSPEmitter::lsnm, 1, 2, {{P_REG18, 1, 0, 4, 0x0030}, {P_ACCM, 1, 0, 0, 0x0001}}, false, false, false, false, false}, // $(D+24) = MEM[$ar0]; MEM[$ar3] = $acS.m; $ar0 += $ix0; $ar3 += $ix3
-  {"SLNM",   0x008e, 0x00ce, DSP::Interpreter::Ext::slnm, &DSPEmitter::slnm, 1, 2, {{P_ACCM, 1, 0, 0, 0x0001}, {P_REG18, 1, 0, 4, 0x0030}}, false, false, false, false, false}, // MEM[$ar0] = $acS.m; $(D+24) = MEM[$ar3]; $ar0 += $ix0; $ar3 += $ix3
+  {"LS",     0x0080, 0x00ce, Interpreter::Ext::ls,   &DSPEmitter::ls,   1, 2, {{P_REG18, 1, 0, 4, 0x0030}, {P_ACCM, 1, 0, 0, 0x0001}}, false, false, false, false, false}, // $(D+24) = MEM[$ar0++]; MEM[$ar3++] = $acS.m
+  {"SL",     0x0082, 0x00ce, Interpreter::Ext::sl,   &DSPEmitter::sl,   1, 2, {{P_ACCM, 1, 0, 0, 0x0001}, {P_REG18, 1, 0, 4, 0x0030}}, false, false, false, false, false}, // MEM[$ar0++] = $acS.m; $(D+24) = MEM[$ar3++]
+  {"LSN",    0x0084, 0x00ce, Interpreter::Ext::lsn,  &DSPEmitter::lsn,  1, 2, {{P_REG18, 1, 0, 4, 0x0030}, {P_ACCM, 1, 0, 0, 0x0001}}, false, false, false, false, false}, // $(D+24) = MEM[$ar0]; MEM[$ar3++] = $acS.m; $ar0 += $ix0
+  {"SLN",    0x0086, 0x00ce, Interpreter::Ext::sln,  &DSPEmitter::sln,  1, 2, {{P_ACCM, 1, 0, 0, 0x0001}, {P_REG18, 1, 0, 4, 0x0030}}, false, false, false, false, false}, // MEM[$ar0] = $acS.m; $(D+24) = MEM[$ar3++]; $ar0 += $ix0
+  {"LSM",    0x0088, 0x00ce, Interpreter::Ext::lsm,  &DSPEmitter::lsm,  1, 2, {{P_REG18, 1, 0, 4, 0x0030}, {P_ACCM, 1, 0, 0, 0x0001}}, false, false, false, false, false}, // $(D+24) = MEM[$ar0++]; MEM[$ar3] = $acS.m; $ar3 += $ix3
+  {"SLM",    0x008a, 0x00ce, Interpreter::Ext::slm,  &DSPEmitter::slm,  1, 2, {{P_ACCM, 1, 0, 0, 0x0001}, {P_REG18, 1, 0, 4, 0x0030}}, false, false, false, false, false}, // MEM[$ar0++] = $acS.m; $(D+24) = MEM[$ar3]; $ar3 += $ix3
+  {"LSNM",   0x008c, 0x00ce, Interpreter::Ext::lsnm, &DSPEmitter::lsnm, 1, 2, {{P_REG18, 1, 0, 4, 0x0030}, {P_ACCM, 1, 0, 0, 0x0001}}, false, false, false, false, false}, // $(D+24) = MEM[$ar0]; MEM[$ar3] = $acS.m; $ar0 += $ix0; $ar3 += $ix3
+  {"SLNM",   0x008e, 0x00ce, Interpreter::Ext::slnm, &DSPEmitter::slnm, 1, 2, {{P_ACCM, 1, 0, 0, 0x0001}, {P_REG18, 1, 0, 4, 0x0030}}, false, false, false, false, false}, // MEM[$ar0] = $acS.m; $(D+24) = MEM[$ar3]; $ar0 += $ix0; $ar3 += $ix3
 
-  {"LDAX",   0x00c3, 0x00cf, DSP::Interpreter::Ext::ldax,   &DSPEmitter::ldax,   1, 2, {{P_AX, 1, 0, 4, 0x0010}, {P_PRG, 1, 0, 5, 0x0020}}, false, false, false, false, false}, // $axR.h = MEM[$arS++]; $axR.l = MEM[$ar3++]
-  {"LDAXN",  0x00c7, 0x00cf, DSP::Interpreter::Ext::ldaxn,  &DSPEmitter::ldaxn,  1, 2, {{P_AX, 1, 0, 4, 0x0010}, {P_PRG, 1, 0, 5, 0x0020}}, false, false, false, false, false}, // $axR.h = MEM[$arS]; $axR.l = MEM[$ar3++]; $arS += $ixS
-  {"LDAXM",  0x00cb, 0x00cf, DSP::Interpreter::Ext::ldaxm,  &DSPEmitter::ldaxm,  1, 2, {{P_AX, 1, 0, 4, 0x0010}, {P_PRG, 1, 0, 5, 0x0020}}, false, false, false, false, false}, // $axR.h = MEM[$arS++]; $axR.l = MEM[$ar3]; $ar3 += $ix3
-  {"LDAXNM", 0x00cf, 0x00cf, DSP::Interpreter::Ext::ldaxnm, &DSPEmitter::ldaxnm, 1, 2, {{P_AX, 1, 0, 4, 0x0010}, {P_PRG, 1, 0, 5, 0x0020}}, false, false, false, false, false}, // $axR.h = MEM[$arS]; $axR.l = MEM[$ar3]; $arS += $ixS; $ar3 += $ix3
+  {"LDAX",   0x00c3, 0x00cf, Interpreter::Ext::ldax,   &DSPEmitter::ldax,   1, 2, {{P_AX, 1, 0, 4, 0x0010}, {P_PRG, 1, 0, 5, 0x0020}}, false, false, false, false, false}, // $axR.h = MEM[$arS++]; $axR.l = MEM[$ar3++]
+  {"LDAXN",  0x00c7, 0x00cf, Interpreter::Ext::ldaxn,  &DSPEmitter::ldaxn,  1, 2, {{P_AX, 1, 0, 4, 0x0010}, {P_PRG, 1, 0, 5, 0x0020}}, false, false, false, false, false}, // $axR.h = MEM[$arS]; $axR.l = MEM[$ar3++]; $arS += $ixS
+  {"LDAXM",  0x00cb, 0x00cf, Interpreter::Ext::ldaxm,  &DSPEmitter::ldaxm,  1, 2, {{P_AX, 1, 0, 4, 0x0010}, {P_PRG, 1, 0, 5, 0x0020}}, false, false, false, false, false}, // $axR.h = MEM[$arS++]; $axR.l = MEM[$ar3]; $ar3 += $ix3
+  {"LDAXNM", 0x00cf, 0x00cf, Interpreter::Ext::ldaxnm, &DSPEmitter::ldaxnm, 1, 2, {{P_AX, 1, 0, 4, 0x0010}, {P_PRG, 1, 0, 5, 0x0020}}, false, false, false, false, false}, // $axR.h = MEM[$arS]; $axR.l = MEM[$ar3]; $arS += $ixS; $ar3 += $ix3
 
-  {"LD",     0x00c0, 0x00cc, DSP::Interpreter::Ext::ld,   &DSPEmitter::ld,   1, 3, {{P_REGM18, 1, 0, 4, 0x0020}, {P_REGM19, 1, 0, 3, 0x0010}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $ax0.D = MEM[$arS++]; $ax1.R = MEM[$ar3++]
-  {"LDN",    0x00c4, 0x00cc, DSP::Interpreter::Ext::ldn,  &DSPEmitter::ldn,  1, 3, {{P_REGM18, 1, 0, 4, 0x0020}, {P_REGM19, 1, 0, 3, 0x0010}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $ax0.D = MEM[$arS]; $ax1.R = MEM[$ar3++]; $arS += $ixS
-  {"LDM",    0x00c8, 0x00cc, DSP::Interpreter::Ext::ldm,  &DSPEmitter::ldm,  1, 3, {{P_REGM18, 1, 0, 4, 0x0020}, {P_REGM19, 1, 0, 3, 0x0010}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $ax0.D = MEM[$arS++]; $ax1.R = MEM[$ar3]; $ar3 += $ix3
-  {"LDNM",   0x00cc, 0x00cc, DSP::Interpreter::Ext::ldnm, &DSPEmitter::ldnm, 1, 3, {{P_REGM18, 1, 0, 4, 0x0020}, {P_REGM19, 1, 0, 3, 0x0010}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $ax0.D = MEM[$arS]; $ax1.R = MEM[$ar3]; $arS += $ixS; $ar3 += $ix3
+  {"LD",     0x00c0, 0x00cc, Interpreter::Ext::ld,   &DSPEmitter::ld,   1, 3, {{P_REGM18, 1, 0, 4, 0x0020}, {P_REGM19, 1, 0, 3, 0x0010}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $ax0.D = MEM[$arS++]; $ax1.R = MEM[$ar3++]
+  {"LDN",    0x00c4, 0x00cc, Interpreter::Ext::ldn,  &DSPEmitter::ldn,  1, 3, {{P_REGM18, 1, 0, 4, 0x0020}, {P_REGM19, 1, 0, 3, 0x0010}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $ax0.D = MEM[$arS]; $ax1.R = MEM[$ar3++]; $arS += $ixS
+  {"LDM",    0x00c8, 0x00cc, Interpreter::Ext::ldm,  &DSPEmitter::ldm,  1, 3, {{P_REGM18, 1, 0, 4, 0x0020}, {P_REGM19, 1, 0, 3, 0x0010}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $ax0.D = MEM[$arS++]; $ax1.R = MEM[$ar3]; $ar3 += $ix3
+  {"LDNM",   0x00cc, 0x00cc, Interpreter::Ext::ldnm, &DSPEmitter::ldnm, 1, 3, {{P_REGM18, 1, 0, 4, 0x0020}, {P_REGM19, 1, 0, 3, 0x0010}, {P_PRG, 1, 0, 0, 0x0003}}, false, false, false, false, false}, // $ax0.D = MEM[$arS]; $ax1.R = MEM[$ar3]; $arS += $ixS; $ar3 += $ix3
 };
 
 const int opcodes_size = sizeof(opcodes) / sizeof(DSPOPCTemplate);
@@ -571,3 +573,4 @@ void InitInstructionTable()
     elem = -1;
   }
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/DSPTables.h
+++ b/Source/Core/Core/DSP/DSPTables.h
@@ -9,6 +9,8 @@
 #include "Core/DSP/DSPCommon.h"
 #include "Core/DSP/Jit/DSPEmitter.h"
 
+namespace DSP
+{
 // The non-ADDR ones that end with _D are the opposite one - if the bit specify
 // ACC0, then ACC_D will be ACC1.
 
@@ -123,3 +125,4 @@ void zeroWriteBackLog();
 void zeroWriteBackLogPreserveAcc(u8 acc);
 
 const DSPOPCTemplate* GetOpTemplate(const UDSPInstruction& inst);
+}  // namespace DSP

--- a/Source/Core/Core/DSP/Interpreter/DSPIntExtOps.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntExtOps.cpp
@@ -22,15 +22,14 @@
 // registers will wrap in odd ways, dictated by the corresponding wrapping
 // register, WR0-3.
 
-// Needs comments.
+namespace DSP
+{
 inline static void writeToBackLog(int i, int idx, u16 value)
 {
   writeBackLog[i] = value;
   writeBackLogIdx[i] = idx;
 }
 
-namespace DSP
-{
 namespace Interpreter
 {
 namespace Ext
@@ -500,7 +499,6 @@ void nop(const UDSPInstruction opc)
 
 }  // namespace Ext
 }  // namespace Interpeter
-}  // namespace DSP
 
 // The ext ops are calculated in parallel with the actual op. That means that
 // both the main op and the ext op see the same register state as input. The
@@ -518,9 +516,9 @@ void applyWriteBackLog()
   {
     u16 value = writeBackLog[i];
 #ifdef PRECISE_BACKLOG
-    value |= DSP::Interpreter::dsp_op_read_reg(writeBackLogIdx[i]);
+    value |= Interpreter::dsp_op_read_reg(writeBackLogIdx[i]);
 #endif
-    DSP::Interpreter::dsp_op_write_reg(writeBackLogIdx[i], value);
+    Interpreter::dsp_op_write_reg(writeBackLogIdx[i], value);
 
     // Clear back log
     writeBackLogIdx[i] = -1;
@@ -541,7 +539,7 @@ void zeroWriteBackLog()
   // infinitive loops
   for (int i = 0; writeBackLogIdx[i] != -1; i++)
   {
-    DSP::Interpreter::dsp_op_write_reg(writeBackLogIdx[i], 0);
+    Interpreter::dsp_op_write_reg(writeBackLogIdx[i], 0);
   }
 #endif
 }
@@ -563,7 +561,8 @@ void zeroWriteBackLogPreserveAcc(u8 acc)
          (writeBackLogIdx[i] == DSP_REG_ACH1)))
       continue;
 
-    DSP::Interpreter::dsp_op_write_reg(writeBackLogIdx[i], 0);
+    Interpreter::dsp_op_write_reg(writeBackLogIdx[i], 0);
   }
 #endif
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.cpp
@@ -102,7 +102,7 @@ void Step()
   u16 opc = dsp_fetch_code();
   ExecuteInstruction(UDSPInstruction(opc));
 
-  if (DSPAnalyzer::GetCodeFlags(static_cast<u16>(g_dsp.pc - 1u)) & DSPAnalyzer::CODE_LOOP_END)
+  if (Analyzer::GetCodeFlags(static_cast<u16>(g_dsp.pc - 1u)) & Analyzer::CODE_LOOP_END)
     HandleLoop();
 }
 
@@ -160,7 +160,7 @@ int RunCyclesDebug(int cycles)
         return cycles;
       }
       // Idle skipping.
-      if (DSPAnalyzer::GetCodeFlags(g_dsp.pc) & DSPAnalyzer::CODE_IDLE_SKIP)
+      if (Analyzer::GetCodeFlags(g_dsp.pc) & Analyzer::CODE_IDLE_SKIP)
         return 0;
       Step();
       cycles--;
@@ -210,7 +210,7 @@ int RunCycles(int cycles)
       if (g_dsp.cr & CR_HALT)
         return 0;
       // Idle skipping.
-      if (DSPAnalyzer::GetCodeFlags(g_dsp.pc) & DSPAnalyzer::CODE_IDLE_SKIP)
+      if (Analyzer::GetCodeFlags(g_dsp.pc) & Analyzer::CODE_IDLE_SKIP)
         return 0;
       Step();
       cycles--;

--- a/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
@@ -87,7 +87,7 @@ static void WriteBranchExit(DSPEmitter& emitter)
 {
   DSPJitRegCache c(emitter.gpr);
   emitter.gpr.SaveRegs();
-  if (DSPAnalyzer::GetCodeFlags(emitter.startAddr) & DSPAnalyzer::CODE_IDLE_SKIP)
+  if (Analyzer::GetCodeFlags(emitter.startAddr) & Analyzer::CODE_IDLE_SKIP)
   {
     emitter.MOV(16, R(EAX), Imm16(0x1000));
   }

--- a/Source/Core/Core/DSP/LabelMap.cpp
+++ b/Source/Core/Core/DSP/LabelMap.cpp
@@ -5,6 +5,8 @@
 #include "Core/DSP/LabelMap.h"
 #include "Core/DSP/DSPTables.h"
 
+namespace DSP
+{
 LabelMap::LabelMap()
 {
 }
@@ -71,3 +73,4 @@ void LabelMap::Clear()
 {
   labels.clear();
 }
+}  // namespace DSP

--- a/Source/Core/Core/DSP/LabelMap.h
+++ b/Source/Core/Core/DSP/LabelMap.h
@@ -9,6 +9,8 @@
 
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
 enum LabelType
 {
   LABEL_IADDR = 1,  // Jump addresses, etc
@@ -40,3 +42,4 @@ public:
   bool GetLabelValue(const std::string& label, u16* value, LabelType type = LABEL_ANY) const;
   void Clear();
 };
+}  // namespace DSP

--- a/Source/Core/Core/DSPEmulator.cpp
+++ b/Source/Core/Core/DSPEmulator.cpp
@@ -11,7 +11,7 @@
 std::unique_ptr<DSPEmulator> CreateDSPEmulator(bool hle)
 {
   if (hle)
-    return std::make_unique<DSPHLE>();
+    return std::make_unique<DSP::HLE::DSPHLE>();
 
-  return std::make_unique<DSPLLE>();
+  return std::make_unique<DSP::LLE::DSPLLE>();
 }

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -12,6 +12,10 @@
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/SystemTimers.h"
 
+namespace DSP
+{
+namespace HLE
+{
 DSPHLE::DSPHLE()
 {
 }
@@ -248,3 +252,5 @@ u16 DSPHLE::DSP_ReadControlRegister()
 void DSPHLE::PauseAndLock(bool doLock, bool unpauseOnUnlock)
 {
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -10,6 +10,11 @@
 #include "Core/HW/DSPHLE/MailHandler.h"
 
 class PointerWrap;
+
+namespace DSP
+{
+namespace HLE
+{
 class UCodeInterface;
 
 class DSPHLE : public DSPEmulator
@@ -67,3 +72,5 @@ private:
   bool m_bHalt;
   bool m_bAssertInt;
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.cpp
@@ -9,6 +9,10 @@
 #include "Common/MsgHandler.h"
 #include "Core/HW/DSP.h"
 
+namespace DSP
+{
+namespace HLE
+{
 CMailHandler::CMailHandler()
 {
 }
@@ -128,3 +132,5 @@ void CMailHandler::DoState(PointerWrap& p)
     }
   }
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/MailHandler.h
+++ b/Source/Core/Core/HW/DSPHLE/MailHandler.h
@@ -11,6 +11,10 @@
 
 class PointerWrap;
 
+namespace DSP
+{
+namespace HLE
+{
 class CMailHandler
 {
 public:
@@ -30,3 +34,5 @@ private:
   // mail handler
   std::queue<std::pair<u32, bool>> m_Mails;
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -15,6 +15,10 @@
 #define AX_GC
 #include "Core/HW/DSPHLE/UCodes/AXVoice.h"
 
+namespace DSP
+{
+namespace HLE
+{
 AXUCode::AXUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc), m_cmdlist_size(0)
 {
   INFO_LOG(DSPHLE, "Instantiating AXUCode: crc=%08x", crc);
@@ -690,3 +694,5 @@ void AXUCode::DoState(PointerWrap& p)
   DoStateShared(p);
   DoAXState(p);
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -15,6 +15,10 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 // We can't directly use the mixer_control field from the PB because it does
 // not mean the same in all AX versions. The AX UCode converts the
 // mixer_control value to an AXMixControl bitfield.
@@ -149,3 +153,5 @@ private:
     CMD_SEND_AUX_AND_MIX = 0x13,
   };
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXStructs.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXStructs.h
@@ -6,6 +6,10 @@
 
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 struct PBMixer
 {
   u16 left;
@@ -331,3 +335,5 @@ enum
   FILTER_LOWPASS = 1,
   FILTER_BIQUAD = 2,
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -21,6 +21,10 @@
 #include "Core/HW/DSPHLE/UCodes/AXStructs.h"
 #include "Core/HW/Memmap.h"
 
+namespace DSP
+{
+namespace HLE
+{
 #ifdef AX_GC
 #define PB_TYPE AXPB
 #define MAX_SAMPLES_PER_FRAME 32
@@ -573,3 +577,5 @@ void ProcessVoice(PB_TYPE& pb, const AXBuffers& buffers, u16 count, AXMixControl
 }
 
 }  // namespace
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -15,6 +15,10 @@
 #include "Core/HW/DSPHLE/UCodes/AXVoice.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 AXWiiUCode::AXWiiUCode(DSPHLE* dsphle, u32 crc) : AXUCode(dsphle, crc), m_last_main_volume(0x8000)
 {
   for (u16& volume : m_last_aux_volumes)
@@ -651,3 +655,5 @@ void AXWiiUCode::DoState(PointerWrap& p)
   p.Do(m_last_main_volume);
   p.Do(m_last_aux_volumes);
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
@@ -6,6 +6,10 @@
 
 #include "Core/HW/DSPHLE/UCodes/AX.h"
 
+namespace DSP
+{
+namespace HLE
+{
 struct AXPBWii;
 
 class AXWiiUCode : public AXUCode
@@ -109,3 +113,5 @@ private:
     CMD_END_OLD = 0x0F
   };
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -9,6 +9,10 @@
 #include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 CARDUCode::CARDUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 {
   INFO_LOG(DSPHLE, "CARDUCode - initialized");
@@ -47,3 +51,5 @@ void CARDUCode::HandleMail(u32 mail)
   m_mail_handler.PushMail(DSP_DONE);
   m_dsphle->SetUCode(UCODE_ROM);
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
@@ -6,6 +6,10 @@
 
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 class CARDUCode : public UCodeInterface
 {
 public:
@@ -16,3 +20,5 @@ public:
   void HandleMail(u32 mail) override;
   void Update() override;
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -9,6 +9,10 @@
 #include "Core/HW/DSP.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 void ProcessGBACrypto(u32 address)
 {
   struct sec_params_t
@@ -147,3 +151,5 @@ void GBAUCode::HandleMail(u32 mail)
     WARN_LOG(DSPHLE, "GBAUCode - unknown command: %08x", mail);
   }
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
@@ -6,6 +6,10 @@
 
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 // Computes two 32 bit integers to be returned to the game, based on the
 // provided crypto parameters at the provided MRAM address. The integers are
 // written back to RAM at the dest address provided in the crypto parameters.
@@ -20,3 +24,5 @@ struct GBAUCode : public UCodeInterface
   void HandleMail(u32 mail) override;
   void Update() override;
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
@@ -7,6 +7,10 @@
 #include "Common/Logging/Log.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 INITUCode::INITUCode(DSPHLE* dsphle, u32 crc) : UCodeInterface(dsphle, crc)
 {
   INFO_LOG(DSPHLE, "INITUCode - initialized");
@@ -32,3 +36,5 @@ void INITUCode::Update()
 void INITUCode::HandleMail(u32 mail)
 {
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
@@ -6,6 +6,10 @@
 
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 class INITUCode : public UCodeInterface
 {
 public:
@@ -17,3 +21,5 @@ public:
   void Update() override;
   void Init();
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -18,6 +18,10 @@
 #include "Core/HW/DSPHLE/UCodes/ROM.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 ROMUCode::ROMUCode(DSPHLE* dsphle, u32 crc)
     : UCodeInterface(dsphle, crc), m_current_ucode(), m_boot_task_num_steps(0), m_next_parameter(0)
 {
@@ -130,3 +134,5 @@ void ROMUCode::DoState(PointerWrap& p)
 
   DoStateShared(p);
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
@@ -6,6 +6,10 @@
 
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 class ROMUCode : public UCodeInterface
 {
 public:
@@ -34,3 +38,5 @@ private:
 
   void BootUCode();
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -24,6 +24,10 @@
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/DSPHLE/UCodes/Zelda.h"
 
+namespace DSP
+{
+namespace HLE
+{
 UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
 {
   switch (crc)
@@ -206,3 +210,5 @@ void UCodeInterface::DoStateShared(PointerWrap& p)
   p.Do(m_next_ucode_steps);
   p.Do(m_needs_resume_mail);
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
@@ -10,12 +10,17 @@
 #include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/Memmap.h"
 
+class PointerWrap;
+
+namespace DSP
+{
+namespace HLE
+{
+class CMailHandler;
+
 #define UCODE_ROM 0x00000000
 #define UCODE_INIT_AUDIO_SYSTEM 0x00000001
 #define UCODE_NULL 0xFFFFFFFF
-
-class CMailHandler;
-class PointerWrap;
 
 constexpr bool ExramRead(u32 address)
 {
@@ -133,3 +138,5 @@ private:
 };
 
 UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii);
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.cpp
@@ -13,6 +13,10 @@
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/DSPHLE/UCodes/Zelda.h"
 
+namespace DSP
+{
+namespace HLE
+{
 // Uncomment this to have a strict version of the HLE implementation, which
 // PanicAlerts on recoverable unknown behaviors instead of silently ignoring
 // them.  Recommended for development.
@@ -1806,3 +1810,5 @@ void ZeldaAudioRenderer::DoState(PointerWrap& p)
   p.Do(m_buf_front_left_reverb_last8);
   p.Do(m_buf_front_right_reverb_last8);
 }
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -8,6 +8,10 @@
 #include "Common/MathUtil.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
+namespace DSP
+{
+namespace HLE
+{
 class ZeldaAudioRenderer
 {
 public:
@@ -297,3 +301,5 @@ private:
   // Main object handling audio rendering logic and state.
   ZeldaAudioRenderer m_renderer;
 };
+}  // namespace HLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -12,10 +12,14 @@
 #include "Core/DSP/DSPMemoryMap.h"
 #include "Core/HW/DSPLLE/DSPSymbols.h"
 
+namespace DSP
+{
+namespace LLE
+{
 std::string DSPDebugInterface::Disassemble(unsigned int address)
 {
   // we'll treat addresses as line numbers.
-  return DSPSymbols::GetLineText(address);
+  return Symbols::GetLineText(address);
 }
 
 std::string DSPDebugInterface::GetRawMemoryString(int memory, unsigned int address)
@@ -68,7 +72,7 @@ bool DSPDebugInterface::IsAlive()
 
 bool DSPDebugInterface::IsBreakpoint(unsigned int address)
 {
-  int real_addr = DSPSymbols::Line2Addr(address);
+  int real_addr = Symbols::Line2Addr(address);
   if (real_addr >= 0)
     return g_dsp_breakpoints.IsAddressBreakPoint(real_addr);
 
@@ -77,25 +81,21 @@ bool DSPDebugInterface::IsBreakpoint(unsigned int address)
 
 void DSPDebugInterface::SetBreakpoint(unsigned int address)
 {
-  int real_addr = DSPSymbols::Line2Addr(address);
+  int real_addr = Symbols::Line2Addr(address);
 
   if (real_addr >= 0)
   {
-    if (g_dsp_breakpoints.Add(real_addr))
-    {
-    }
+    g_dsp_breakpoints.Add(real_addr);
   }
 }
 
 void DSPDebugInterface::ClearBreakpoint(unsigned int address)
 {
-  int real_addr = DSPSymbols::Line2Addr(address);
+  int real_addr = Symbols::Line2Addr(address);
 
   if (real_addr >= 0)
   {
-    if (g_dsp_breakpoints.Remove(real_addr))
-    {
-    }
+    g_dsp_breakpoints.Remove(real_addr);
   }
 }
 
@@ -106,7 +106,7 @@ void DSPDebugInterface::ClearAllBreakpoints()
 
 void DSPDebugInterface::ToggleBreakpoint(unsigned int address)
 {
-  int real_addr = DSPSymbols::Line2Addr(address);
+  int real_addr = Symbols::Line2Addr(address);
   if (real_addr >= 0)
   {
     if (g_dsp_breakpoints.IsAddressBreakPoint(real_addr))
@@ -154,14 +154,14 @@ int DSPDebugInterface::GetColor(unsigned int address)
   int addr = -1;
   for (int i = 0; i < 1; i++)
   {
-    addr = DSPSymbols::Line2Addr(address - i);
+    addr = Symbols::Line2Addr(address - i);
     if (addr >= 0)
       break;
   }
   if (addr == -1)
     return 0xFFFFFF;
 
-  Symbol* symbol = DSPSymbols::g_dsp_symbol_db.GetSymbolFromAddr(addr);
+  Symbol* symbol = Symbols::g_dsp_symbol_db.GetSymbolFromAddr(addr);
   if (!symbol)
     return 0xFFFFFF;
   if (symbol->type != Symbol::Type::Function)
@@ -177,12 +177,12 @@ std::string DSPDebugInterface::GetDescription(unsigned int address)
 
 unsigned int DSPDebugInterface::GetPC()
 {
-  return DSPSymbols::Addr2Line(g_dsp.pc);
+  return Symbols::Addr2Line(DSP::g_dsp.pc);
 }
 
 void DSPDebugInterface::SetPC(unsigned int address)
 {
-  int new_pc = DSPSymbols::Line2Addr(address);
+  int new_pc = Symbols::Line2Addr(address);
   if (new_pc > 0)
     g_dsp.pc = new_pc;
 }
@@ -190,3 +190,5 @@ void DSPDebugInterface::SetPC(unsigned int address)
 void DSPDebugInterface::RunToBreakpoint()
 {
 }
+}  // namespace LLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -9,6 +9,10 @@
 #include "Common/CommonTypes.h"
 #include "Common/DebugInterface.h"
 
+namespace DSP
+{
+namespace LLE
+{
 class DSPDebugInterface final : public DebugInterface
 {
 public:
@@ -36,3 +40,5 @@ public:
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
 };
+}  // namespace LLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -21,7 +21,9 @@
 // core isn't used, for example in an asm/disasm tool, then most of these
 // can be stubbed out.
 
-namespace DSPHost
+namespace DSP
+{
+namespace Host
 {
 u8 ReadHostMemory(u32 addr)
 {
@@ -59,48 +61,48 @@ void CodeLoaded(const u8* ptr, int size)
   g_dsp.iram_crc = HashEctor(ptr, size);
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
-  DumpDSPCode(ptr, size, g_dsp.iram_crc);
+  LLE::DumpDSPCode(ptr, size, g_dsp.iram_crc);
 #endif
 
-  DSPSymbols::Clear();
+  Symbols::Clear();
 
   // Auto load text file - if none just disassemble.
 
   NOTICE_LOG(DSPLLE, "g_dsp.iram_crc: %08x", g_dsp.iram_crc);
 
-  DSPSymbols::Clear();
+  Symbols::Clear();
   bool success = false;
   switch (g_dsp.iram_crc)
   {
   case 0x86840740:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_Zelda.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_Zelda.txt");
     break;
   case 0x42f64ac4:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_Luigi.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_Luigi.txt");
     break;
   case 0x07f88145:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_07F88145.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_07F88145.txt");
     break;
   case 0x3ad3b7ac:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_3AD3B7AC.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_3AD3B7AC.txt");
     break;
   case 0x3daf59b9:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_3DAF59B9.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_3DAF59B9.txt");
     break;
   case 0x4e8a8b21:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_4E8A8B21.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_4E8A8B21.txt");
     break;
   case 0xe2136399:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_E2136399.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AX_E2136399.txt");
     break;
   case 0xdd7e72d5:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_GBA.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_GBA.txt");
     break;
   case 0x347112BA:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AXWii.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_AXWii.txt");
     break;
   case 0xD643001F:
-    success = DSPSymbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_SuperMarioGalaxy.txt");
+    success = Symbols::ReadAnnotatedAssembly("../../docs/DSP/DSP_UC_SuperMarioGalaxy.txt");
     break;
   default:
     success = false;
@@ -109,22 +111,23 @@ void CodeLoaded(const u8* ptr, int size)
 
   if (!success)
   {
-    DSPSymbols::AutoDisassembly(0x0, 0x1000);
+    Symbols::AutoDisassembly(0x0, 0x1000);
   }
 
   // Always add the ROM.
-  DSPSymbols::AutoDisassembly(0x8000, 0x9000);
+  Symbols::AutoDisassembly(0x8000, 0x9000);
 
   UpdateDebugger();
 
   if (g_dsp_jit)
     g_dsp_jit->ClearIRAM();
 
-  DSPAnalyzer::Analyze();
+  Analyzer::Analyze();
 }
 
 void UpdateDebugger()
 {
   Host_RefreshDSPDebuggerWindow();
 }
-}
+}  // namespace Host
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -27,6 +27,10 @@
 #include "Core/HW/Memmap.h"
 #include "Core/Host.h"
 
+namespace DSP
+{
+namespace LLE
+{
 static Common::Event dspEvent;
 static Common::Event ppcEvent;
 static bool requestDisableThread;
@@ -67,7 +71,7 @@ void DSPLLE::DoState(PointerWrap& p)
   p.DoArray(g_dsp.iram, DSP_IRAM_SIZE);
   Common::WriteProtectMemory(g_dsp.iram, DSP_IRAM_BYTE_SIZE, false);
   if (p.GetMode() == PointerWrap::MODE_READ)
-    DSPHost::CodeLoaded((const u8*)g_dsp.iram, DSP_IRAM_BYTE_SIZE);
+    Host::CodeLoaded((const u8*)g_dsp.iram, DSP_IRAM_BYTE_SIZE);
   p.DoArray(g_dsp.dram, DSP_DRAM_SIZE);
   p.Do(g_cycles_left);
   p.Do(g_init_hax);
@@ -339,3 +343,5 @@ void DSPLLE::PauseAndLock(bool doLock, bool unpauseOnUnlock)
   else
     m_csDSPThreadActive.unlock();
 }
+}  // namespace LLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.h
@@ -14,6 +14,10 @@
 
 class PointerWrap;
 
+namespace DSP
+{
+namespace LLE
+{
 class DSPLLE : public DSPEmulator
 {
 public:
@@ -44,3 +48,5 @@ private:
   Common::Flag m_bIsRunning;
   std::atomic<u32> m_cycle_count{};
 };
+}  // namespace LLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.cpp
@@ -10,6 +10,8 @@
 #include "Core/DSP/DSPCore.h"
 #include "Core/HW/DSPLLE/DSPLLEGlobals.h"
 
+namespace DSP
+{
 #if PROFILE
 
 #define PROFILE_MAP_SIZE 0x10000
@@ -59,3 +61,4 @@ char SilenceLNK4221;
 };
 
 #endif
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLEGlobals.h
@@ -8,6 +8,8 @@
 
 // TODO: Get rid of this file.
 
+namespace DSP
+{
 #define PROFILE 0
 
 #if PROFILE
@@ -16,3 +18,4 @@ void ProfilerInit();
 void ProfilerAddDelta(int _addr, int _delta);
 void ProfilerStart();
 #endif
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPLLETools.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLETools.cpp
@@ -19,6 +19,10 @@
 #include "Core/DSP/DSPDisassembler.h"
 #include "Core/HW/DSPLLE/DSPLLETools.h"
 
+namespace DSP
+{
+namespace LLE
+{
 bool DumpDSPCode(const u8* code_be, int size_in_bytes, u32 crc)
 {
   const std::string binFile =
@@ -76,3 +80,5 @@ bool DumpCWCode(u32 _Address, u32 _Length)
 
   return false;
 }
+}  // namespace LLE
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPLLETools.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLETools.h
@@ -6,5 +6,11 @@
 
 #include "Common/CommonTypes.h"
 
+namespace DSP
+{
+namespace LLE
+{
 bool DumpDSPCode(const u8* code_be, int size_in_bytes, u32 crc);
 bool DumpCWCode(u32 _Address, u32 _Length);
+}  // namespace DSP
+}  // namespace LLE

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.cpp
@@ -15,7 +15,9 @@
 #include "Core/DSP/DSPDisassembler.h"
 #include "Core/HW/DSPLLE/DSPSymbols.h"
 
-namespace DSPSymbols
+namespace DSP
+{
+namespace Symbols
 {
 DSPSymbolDB g_dsp_symbol_db;
 
@@ -246,4 +248,5 @@ void Clear()
   line_counter = 0;
 }
 
-}  // namespace DSPSymbols
+}  // namespace Symbols
+}  // namespace DSP

--- a/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPSymbols.h
@@ -9,7 +9,9 @@
 #include "Common/CommonTypes.h"
 #include "Common/SymbolDB.h"
 
-namespace DSPSymbols
+namespace DSP
+{
+namespace Symbols
 {
 class DSPSymbolDB : public SymbolDB
 {
@@ -31,4 +33,5 @@ int Line2Addr(int line);  // -1 for not found
 
 const char* GetLineText(int line);
 
-}  // namespace DSPSymbols
+}  // namespace Symbols
+}  // namespace DSP

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1513,23 +1513,23 @@ void GetSettings()
       irom_file = File::GetSysDirectory() + GC_SYS_DIR DIR_SEP DSP_IROM;
     if (!File::Exists(coef_file))
       coef_file = File::GetSysDirectory() + GC_SYS_DIR DIR_SEP DSP_COEF;
-    std::vector<u16> irom(DSP_IROM_SIZE);
+    std::vector<u16> irom(DSP::DSP_IROM_SIZE);
     File::IOFile file_irom(irom_file, "rb");
 
-    file_irom.ReadArray(irom.data(), DSP_IROM_SIZE);
+    file_irom.ReadArray(irom.data(), irom.size());
     file_irom.Close();
-    for (u32 i = 0; i < DSP_IROM_SIZE; ++i)
-      irom[i] = Common::swap16(irom[i]);
+    for (u16& entry : irom)
+      entry = Common::swap16(entry);
 
-    std::vector<u16> coef(DSP_COEF_SIZE);
+    std::vector<u16> coef(DSP::DSP_COEF_SIZE);
     File::IOFile file_coef(coef_file, "rb");
 
-    file_coef.ReadArray(coef.data(), DSP_COEF_SIZE);
+    file_coef.ReadArray(coef.data(), coef.size());
     file_coef.Close();
-    for (u32 i = 0; i < DSP_COEF_SIZE; ++i)
-      coef[i] = Common::swap16(coef[i]);
-    s_DSPiromHash = HashAdler32((u8*)irom.data(), DSP_IROM_BYTE_SIZE);
-    s_DSPcoefHash = HashAdler32((u8*)coef.data(), DSP_COEF_BYTE_SIZE);
+    for (u16& entry : coef)
+      entry = Common::swap16(entry);
+    s_DSPiromHash = HashAdler32(reinterpret_cast<u8*>(irom.data()), DSP::DSP_IROM_BYTE_SIZE);
+    s_DSPcoefHash = HashAdler32(reinterpret_cast<u8*>(coef.data()), DSP::DSP_COEF_BYTE_SIZE);
   }
   else
   {

--- a/Source/Core/DolphinWX/Debugger/DSPDebugWindow.h
+++ b/Source/Core/DolphinWX/Debugger/DSPDebugWindow.h
@@ -34,7 +34,7 @@ private:
     ID_SHOWPCTOOL,
   };
 
-  DSPDebugInterface debug_interface;
+  DSP::LLE::DSPDebugInterface debug_interface;
   u64 m_CachedStepCounter;
 
   // GUI updaters

--- a/Source/Core/DolphinWX/Debugger/DSPRegisterView.cpp
+++ b/Source/Core/DolphinWX/Debugger/DSPRegisterView.cpp
@@ -18,9 +18,9 @@ wxString CDSPRegTable::GetValue(int row, int col)
     switch (col)
     {
     case 0:
-      return StrToWxStr(pdregname(row));
+      return StrToWxStr(DSP::pdregname(row));
     case 1:
-      return wxString::Format("0x%04x", DSPCore_ReadRegister(row));
+      return wxString::Format("0x%04x", DSP::DSPCore_ReadRegister(row));
     default:
       return wxEmptyString;
     }
@@ -34,16 +34,16 @@ void CDSPRegTable::SetValue(int, int, const wxString&)
 
 void CDSPRegTable::UpdateCachedRegs()
 {
-  if (m_CachedCounter == g_dsp.step_counter)
+  if (m_CachedCounter == DSP::g_dsp.step_counter)
   {
     return;
   }
 
-  m_CachedCounter = g_dsp.step_counter;
+  m_CachedCounter = DSP::g_dsp.step_counter;
 
   for (size_t i = 0; i < m_CachedRegs.size(); ++i)
   {
-    const u16 value = DSPCore_ReadRegister(i);
+    const u16 value = DSP::DSPCore_ReadRegister(i);
 
     m_CachedRegHasChanged[i] = m_CachedRegs[i] != value;
     m_CachedRegs[i] = value;


### PR DESCRIPTION
Follow-up to #4579 which only namespaced the DSP interpreter and JIT, but not the direct core code. This encompasses the DSP core code, DSP HLE code, and DSP LLE code.

Type names and function names remain unchanged currently, however, a follow up will be done that drops the `DSP` prefixing from identifiers where it makes sense to do so.