### PR TITLE
Add an empty spacer in the Mic Input config dialog

### DIFF
--- a/Source/Core/DolphinWX/Input/MicButtonConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/MicButtonConfigDiag.cpp
@@ -12,6 +12,7 @@ MicButtonConfigDialog::MicButtonConfigDialog(wxWindow* const parent, InputConfig
     : InputConfigDialog(parent, config, name, port_num)
 {
   const int space5 = FromDIP(5);
+  const int space150 = FromDIP(150);
 
   auto* const device_chooser = CreateDeviceChooserGroupBox();
 
@@ -20,6 +21,8 @@ MicButtonConfigDialog::MicButtonConfigDialog(wxWindow* const parent, InputConfig
 
   auto* const controls_sizer = new wxBoxSizer(wxHORIZONTAL);
   controls_sizer->Add(group_box_button, 0, wxEXPAND);
+  // Avoid having the device combo box to be too small.
+  controls_sizer->AddSpacer(space150);
 
   auto* const szr_main = new wxBoxSizer(wxVERTICAL);
   szr_main->AddSpacer(space5);
@@ -30,7 +33,7 @@ MicButtonConfigDialog::MicButtonConfigDialog(wxWindow* const parent, InputConfig
   szr_main->Add(CreateButtonSizer(wxCLOSE | wxNO_DEFAULT), 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   szr_main->AddSpacer(space5);
 
-  SetSizer(szr_main);
+  SetSizerAndFit(szr_main);
   Center();
   UpdateGUI();
 }

--- a/Source/Core/DolphinWX/Input/MicButtonConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/MicButtonConfigDiag.cpp
@@ -16,6 +16,11 @@ MicButtonConfigDialog::MicButtonConfigDialog(wxWindow* const parent, InputConfig
 
   auto* const device_chooser = CreateDeviceChooserGroupBox();
 
+  auto* const device_chooser_szr = new wxBoxSizer(wxHORIZONTAL);
+  device_chooser_szr->AddSpacer(space5);
+  device_chooser_szr->Add(device_chooser, 1, wxEXPAND);
+  device_chooser_szr->AddSpacer(space5);
+
   auto* const group_box_button =
       new ControlGroupBox(Pad::GetGroup(port_num, PadGroup::Mic), this, this);
 
@@ -26,7 +31,7 @@ MicButtonConfigDialog::MicButtonConfigDialog(wxWindow* const parent, InputConfig
 
   auto* const szr_main = new wxBoxSizer(wxVERTICAL);
   szr_main->AddSpacer(space5);
-  szr_main->Add(device_chooser, 0, wxEXPAND);
+  szr_main->Add(device_chooser_szr, 0, wxEXPAND);
   szr_main->AddSpacer(space5);
   szr_main->Add(controls_sizer, 1, wxEXPAND | wxLEFT | wxRIGHT, space5);
   szr_main->AddSpacer(space5);


### PR DESCRIPTION
This is done to not have the device combo box be too small in width when making the main sizer fit into the window.  Not fitting the sizer would alternatively break Hidpi so it was best to just add an empty sizer to workaround this problem.

Currently, there's no fitting done on the main sizer which create this Hidpi issue on Windows:

![cbi2uyk](https://cloud.githubusercontent.com/assets/8932978/21579294/81c8fb28-cf75-11e6-95f1-79645525d0e6.png)

This PR has the fitting with the spacer which fixes the issue:

<img width="224" alt="capture" src="https://cloud.githubusercontent.com/assets/8932978/21579580/c41e1100-cf86-11e6-906b-ef0a5170d80b.PNG">

This is the only input config window with such a problem because it's the only one that needs so few group boxes.