### PR TITLE
macOS: Add missing includes to fix no-PCH build

### DIFF
--- a/Source/Core/Core/HW/BBA-TAP/TAP_Apple.cpp
+++ b/Source/Core/Core/HW/BBA-TAP/TAP_Apple.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <fcntl.h>
+#include <unistd.h>
 
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -2,10 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h"
+
+#include <map>
+
 #include <Carbon/Carbon.h>
 #include <Cocoa/Cocoa.h>
-
-#include "InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h"
 
 namespace ciface
 {


### PR DESCRIPTION
This is a simple issue that shows up on macOS when building with `-DENABLE_PCH=OFF` (which I've been using because it seems to work better with [rtags](https://github.com/Andersbakken/rtags))