### PR TITLE
GCI Folder: Ignore region chech for GCI which doesn't have gameid

### DIFF
--- a/Source/Core/Core/HW/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcardDirectory.cpp
@@ -49,6 +49,8 @@ int GCMemcardDirectory::LoadGCI(const std::string& fileName, DiscIO::Country car
     case 'E':
       gci_region = DiscIO::Country::COUNTRY_USA;
       break;
+    case '\0':
+      // Used by Homeland Network Config File
     case 'C':
       // Used by Datel Action Replay Save
       // can be on any regions card


### PR DESCRIPTION
When Dolphin booted USA or Japan region game and trying to load GCI whose gameid is filled with null characters, Dolphin detect its region as Europe and can't load because of region mismatch.