### PR TITLE
JitRegCache: Move FlushMode enum into RegCache

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -760,8 +760,8 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
                  ProcessorInterface::INT_CAUSE_PE_FINISH));
       FixupBranch noCPInt = J_CC(CC_Z, true);
 
-      gpr.Flush(FLUSH_MAINTAIN_STATE);
-      fpr.Flush(FLUSH_MAINTAIN_STATE);
+      gpr.Flush(RegCache::FlushMode::MaintainState);
+      fpr.Flush(RegCache::FlushMode::MaintainState);
 
       MOV(32, PPCSTATE(pc), Imm32(ops[i].address));
       WriteExternalExceptionExit();
@@ -802,8 +802,8 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
 
         SwitchToFarCode();
         SetJumpTarget(b1);
-        gpr.Flush(FLUSH_MAINTAIN_STATE);
-        fpr.Flush(FLUSH_MAINTAIN_STATE);
+        gpr.Flush(RegCache::FlushMode::MaintainState);
+        fpr.Flush(RegCache::FlushMode::MaintainState);
 
         // If a FPU exception occurs, the exception handler will read
         // from PC.  Update PC with the latest value in case that happens.
@@ -891,8 +891,8 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
           gprToFlush[js.revertGprLoad] = false;
         if (js.revertFprLoad >= 0)
           fprToFlush[js.revertFprLoad] = false;
-        gpr.Flush(FLUSH_MAINTAIN_STATE, gprToFlush);
-        fpr.Flush(FLUSH_MAINTAIN_STATE, fprToFlush);
+        gpr.Flush(RegCache::FlushMode::MaintainState, gprToFlush);
+        fpr.Flush(RegCache::FlushMode::MaintainState, fprToFlush);
 
         // If a memory exception occurs, the exception handler will read
         // from PC.  Update PC with the latest value in case that happens.

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.cpp
@@ -213,7 +213,7 @@ void RegCache::StoreFromRegister(size_t i, FlushMode mode)
     {
       X64Reg xr = RX(i);
       doStore = m_xregs[xr].dirty;
-      if (mode == FLUSH_ALL)
+      if (mode == FlushMode::All)
       {
         m_xregs[xr].free = true;
         m_xregs[xr].ppcReg = INVALID_REG;
@@ -228,7 +228,7 @@ void RegCache::StoreFromRegister(size_t i, FlushMode mode)
     OpArg newLoc = GetDefaultLocation(i);
     if (doStore)
       StoreRegister(i, newLoc);
-    if (mode == FLUSH_ALL)
+    if (mode == FlushMode::All)
     {
       m_regs[i].location = newLoc;
       m_regs[i].away = false;

--- a/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitRegCache.h
@@ -12,12 +12,6 @@
 
 class Jit64;
 
-enum FlushMode
-{
-  FLUSH_ALL,
-  FLUSH_MAINTAIN_STATE,
-};
-
 struct PPCCachedReg
 {
   Gen::OpArg location;
@@ -36,6 +30,12 @@ struct X64CachedReg
 class RegCache
 {
 public:
+  enum class FlushMode
+  {
+    All,
+    MaintainState,
+  };
+
   static constexpr size_t NUM_XREGS = 16;
 
   explicit RegCache(Jit64& jit);
@@ -50,7 +50,7 @@ public:
   void DiscardRegContentsIfCached(size_t preg);
   void SetEmitter(Gen::XEmitter* emitter);
 
-  void Flush(FlushMode mode = FLUSH_ALL, BitSet32 regsToFlush = BitSet32::AllTrue(32));
+  void Flush(FlushMode mode = FlushMode::All, BitSet32 regsToFlush = BitSet32::AllTrue(32));
 
   void FlushR(Gen::X64Reg reg);
   void FlushR(Gen::X64Reg reg, Gen::X64Reg reg2);
@@ -64,7 +64,7 @@ public:
   // TODO - instead of doload, use "read", "write"
   // read only will not set dirty flag
   void BindToRegister(size_t preg, bool doLoad = true, bool makeDirty = true);
-  void StoreFromRegister(size_t preg, FlushMode mode = FLUSH_ALL);
+  void StoreFromRegister(size_t preg, FlushMode mode = FlushMode::All);
 
   const Gen::OpArg& R(size_t preg) const;
   Gen::X64Reg RX(size_t preg) const;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Branch.cpp
@@ -137,8 +137,8 @@ void Jit64::bcx(UGeckoInstruction inst)
   else
     destination = js.compilerPC + SignExt16(inst.BD << 2);
 
-  gpr.Flush(FLUSH_MAINTAIN_STATE);
-  fpr.Flush(FLUSH_MAINTAIN_STATE);
+  gpr.Flush(RegCache::FlushMode::MaintainState);
+  fpr.Flush(RegCache::FlushMode::MaintainState);
   WriteExit(destination, inst.LK, js.compilerPC + 4);
 
   if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)
@@ -192,8 +192,8 @@ void Jit64::bcctrx(UGeckoInstruction inst)
     if (inst.LK_3)
       MOV(32, PPCSTATE_LR, Imm32(js.compilerPC + 4));  // LR = PC + 4;
 
-    gpr.Flush(FLUSH_MAINTAIN_STATE);
-    fpr.Flush(FLUSH_MAINTAIN_STATE);
+    gpr.Flush(RegCache::FlushMode::MaintainState);
+    fpr.Flush(RegCache::FlushMode::MaintainState);
     WriteExitDestInRSCRATCH(inst.LK_3, js.compilerPC + 4);
     // Would really like to continue the block here, but it ends. TODO.
     SetJumpTarget(b);
@@ -246,8 +246,8 @@ void Jit64::bclrx(UGeckoInstruction inst)
   if (inst.LK)
     MOV(32, PPCSTATE_LR, Imm32(js.compilerPC + 4));
 
-  gpr.Flush(FLUSH_MAINTAIN_STATE);
-  fpr.Flush(FLUSH_MAINTAIN_STATE);
+  gpr.Flush(RegCache::FlushMode::MaintainState);
+  fpr.Flush(RegCache::FlushMode::MaintainState);
   WriteBLRExit();
 
   if ((inst.BO & BO_DONT_CHECK_CONDITION) == 0)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -187,7 +187,7 @@ OpArg Jit64::ExtractFromReg(int reg, int offset)
   // store to load forwarding should handle this case efficiently
   if (offset)
   {
-    gpr.StoreFromRegister(reg, FLUSH_MAINTAIN_STATE);
+    gpr.StoreFromRegister(reg, RegCache::FlushMode::MaintainState);
     src = gpr.GetDefaultLocation(reg);
     src.AddMemOffset(offset);
   }
@@ -415,8 +415,8 @@ void Jit64::DoMergedBranchCondition()
   else  // SO bit, do not branch (we don't emulate SO for cmp).
     pDontBranch = J(true);
 
-  gpr.Flush(FLUSH_MAINTAIN_STATE);
-  fpr.Flush(FLUSH_MAINTAIN_STATE);
+  gpr.Flush(RegCache::FlushMode::MaintainState);
+  fpr.Flush(RegCache::FlushMode::MaintainState);
 
   DoMergedBranch();
 
@@ -1907,8 +1907,8 @@ void Jit64::twX(UGeckoInstruction inst)
   LOCK();
   OR(32, PPCSTATE(Exceptions), Imm32(EXCEPTION_PROGRAM));
 
-  gpr.Flush(FLUSH_MAINTAIN_STATE);
-  fpr.Flush(FLUSH_MAINTAIN_STATE);
+  gpr.Flush(RegCache::FlushMode::MaintainState);
+  fpr.Flush(RegCache::FlushMode::MaintainState);
 
   WriteExceptionExit();
 


### PR DESCRIPTION
This also makes it a strongly-typed enum.

Considering that the flushing mode is a trait/behavior for the register cache, it doesn't really make sense to have the enum separate from it.

This also has the benefit of removing constants from global scope.