### PR TITLE
DSPJitRegCache: Make single argument constructor explicit

### DIFF
--- a/Source/Core/Core/DSP/Jit/DSPJitRegCache.h
+++ b/Source/Core/Core/DSP/Jit/DSPJitRegCache.h
@@ -39,7 +39,7 @@ enum DSPJitSignExtend
 class DSPJitRegCache
 {
 public:
-  DSPJitRegCache(DSPEmitter& emitter);
+  explicit DSPJitRegCache(DSPEmitter& emitter);
 
   // For branching into multiple control flows
   DSPJitRegCache(const DSPJitRegCache& cache);


### PR DESCRIPTION
Prevents implicit conversions. Pretty trivial.