### PR TITLE
Memory search: add the base address to the found offset

### DIFF
--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -384,10 +384,10 @@ void CMemoryWindow::OnSearch(wxCommandEvent& event)
     if (std::equal(search_bytes.begin(), search_bytes.end(), ptr))
     {
       m_search_result_msg->SetLabel(_("Match Found"));
-      u32 offset = static_cast<u32>(ptr - ram_ptr);
+      u32 found_addr = static_cast<u32>(ptr - ram_ptr) + 0x80000000;
       // NOTE: SetValue() generates a synthetic wxEVT_TEXT
-      addrbox->SetValue(wxString::Format("%08x", offset));
-      m_last_search_address = offset;
+      addrbox->SetValue(wxString::Format("%08x", found_addr));
+      m_last_search_address = found_addr;
       m_continue_search = true;
       break;
     }


### PR DESCRIPTION
This fixes [issue 10009](https://bugs.dolphin-emu.org/issues/10009)

If you search a value say the game ID in the debugger, instead of taking you to the actual address, it would take you to the offset of this address.  Since you need the actual address, the only thing needed to fix this is to add the base (0x80000000) to the resulting offset.

I know it's a magic number, I didn't really found a constant in memory mapping related files and idk if I should add one.  I can add a comment if it annoys people.