### PR TITLE
FifoPlayer: Loop playback consistency, save texture memory to file

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoDataFile.h
+++ b/Source/Core/Core/FifoPlayer/FifoDataFile.h
@@ -51,6 +51,7 @@ public:
     CP_MEM_SIZE = 256,
     XF_MEM_SIZE = 4096,
     XF_REGS_SIZE = 96,
+    TEX_MEM_SIZE = 1024 * 1024,
   };
 
   FifoDataFile();
@@ -64,6 +65,7 @@ public:
   u32* GetCPMem() { return m_CPMem; }
   u32* GetXFMem() { return m_XFMem; }
   u32* GetXFRegs() { return m_XFRegs; }
+  u8* GetTexMem() { return m_TexMem; }
   void AddFrame(const FifoFrameInfo& frameInfo);
   const FifoFrameInfo& GetFrame(u32 frame) const { return m_Frames[frame]; }
   u32 GetFrameCount() const { return static_cast<u32>(m_Frames.size()); }
@@ -90,6 +92,7 @@ private:
   u32 m_CPMem[CP_MEM_SIZE];
   u32 m_XFMem[XF_MEM_SIZE];
   u32 m_XFRegs[XF_REGS_SIZE];
+  u8 m_TexMem[TEX_MEM_SIZE];
 
   u32 m_Flags;
   u32 m_Version;

--- a/Source/Core/Core/FifoPlayer/FifoFileStruct.h
+++ b/Source/Core/Core/FifoPlayer/FifoFileStruct.h
@@ -11,7 +11,7 @@ namespace FifoFileStruct
 enum
 {
   FILE_ID = 0x0d01f1f0,
-  VERSION_NUMBER = 3,
+  VERSION_NUMBER = 4,
   MIN_LOADER_VERSION = 1,
 };
 
@@ -34,6 +34,8 @@ union FileHeader {
     u64 frameListOffset;
     u32 frameCount;
     u32 flags;
+    u64 texMemOffset;
+    u32 texMemSize;
   };
   u32 rawData[32];
 };

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -535,6 +535,7 @@ bool FifoPlayer::ShouldLoadBP(u8 address)
   case BPMEM_PE_TOKEN_INT_ID:
   case BPMEM_TRIGGER_EFB_COPY:
   case BPMEM_LOADTLUT1:
+  case BPMEM_PRELOAD_MODE:
   case BPMEM_PERF1:
     return false;
   default:

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -110,6 +110,7 @@ private:
   void SetupFifo();
 
   void LoadMemory();
+  void LoadRegisters();
 
   void WriteCP(u32 address, u16 value);
   void WritePI(u32 address, u32 value);

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.h
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.h
@@ -111,6 +111,7 @@ private:
 
   void LoadMemory();
   void LoadRegisters();
+  void LoadTextureMemory();
 
   void WriteCP(u32 address, u16 value);
   void WritePI(u32 address, u32 value);

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -183,7 +183,7 @@ void FifoRecorder::EndFrame(u32 fifoStart, u32 fifoEnd)
 }
 
 void FifoRecorder::SetVideoMemory(const u32* bpMem, const u32* cpMem, const u32* xfMem,
-                                  const u32* xfRegs, u32 xfRegsSize)
+                                  const u32* xfRegs, u32 xfRegsSize, const u8* texMem)
 {
   std::lock_guard<std::recursive_mutex> lk(sMutex);
 
@@ -195,6 +195,8 @@ void FifoRecorder::SetVideoMemory(const u32* bpMem, const u32* cpMem, const u32*
 
     u32 xfRegsCopySize = std::min((u32)FifoDataFile::XF_REGS_SIZE, xfRegsSize);
     memcpy(m_File->GetXFRegs(), xfRegs, xfRegsCopySize * 4);
+
+    memcpy(m_File->GetTexMem(), texMem, FifoDataFile::TEX_MEM_SIZE);
   }
 
   FifoRecordAnalyzer::Initialize(cpMem);

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.h
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.h
@@ -37,7 +37,7 @@ public:
   // bpMem must point to the actual bp mem array used by the plugin because it will be read as fifo
   // data is recorded
   void SetVideoMemory(const u32* bpMem, const u32* cpMem, const u32* xfMem, const u32* xfRegs,
-                      u32 xfRegsSize);
+                      u32 xfRegsSize, const u8* texMem);
 
   // Checked once per frame prior to callng EndFrame()
   bool IsRecording() const { return m_IsRecording; }

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -51,6 +51,7 @@
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureCacheBase.h"
+#include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoConfig.h"
 #include "VideoCommon/XFMemory.h"
 
@@ -678,7 +679,8 @@ void Renderer::RecordVideoMemory()
 
   FillCPMemoryArray(cpmem);
 
-  FifoRecorder::GetInstance().SetVideoMemory(bpmem_ptr, cpmem, xfmem_ptr, xfregs_ptr, xfregs_size);
+  FifoRecorder::GetInstance().SetVideoMemory(bpmem_ptr, cpmem, xfmem_ptr, xfregs_ptr, xfregs_size,
+                                             texMem);
 }
 
 void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,


### PR DESCRIPTION
Currently, texture memory is not saved with a fifolog is recorded. This means that if a game preloaded data into texture memory before the fifolog was recorded, it would be all zeros when playing it back, causing different results (cel damage). **This change bumps the fifo log version to 4, but should retain compatibility with existing fifologs**, as well as new fifologs being able to be played back in earlier versions of Dolphin (albeit without restoring the contents of texmem).

The other change here restores the original state of the GPU when looping back to the first frame when playing back. As far as I could tell, previously if a game did not reset all the registers during the first frame, if they were different at the end of the last frame this would cause different results when playing back the fifolog with loop enabled. There could still be an issue when playing back if the first frame is not set to zero, but I'm not sure how this could be solved without storing the complete state for each frame.