### PR TITLE
GeometryShaderGen: Use lower-left origin for point texture coordinates

### DIFF
--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -285,9 +285,9 @@ ShaderCode GenerateGeometryShaderCode(APIType ApiType, const geometry_shader_uid
     for (unsigned int i = 0; i < uid_data->numTexGens; ++i)
     {
       out.Write("\tif (((" I_TEXOFFSET "[1] >> %d) & 0x1) != 0) {\n", i);
-      out.Write("\t\tll.tex%d.xy += float2(0,1) * texOffset;\n", i);
-      out.Write("\t\tlr.tex%d.xy += texOffset;\n", i);
-      out.Write("\t\tur.tex%d.xy += float2(1,0) * texOffset;\n", i);
+      out.Write("\t\tul.tex%d.xy += float2(0,1) * texOffset;\n", i);
+      out.Write("\t\tur.tex%d.xy += texOffset;\n", i);
+      out.Write("\t\tlr.tex%d.xy += float2(1,0) * texOffset;\n", i);
       out.Write("\t}\n");
     }
     out.Write("\t}\n");


### PR DESCRIPTION
From a quick look, it seems that the GPU uses a lower-left origin, whereas we were assuming top-left when generating the texture coordinates for points.

Fixes upside-down A button in Mario Golf.