### PR TITLE
[FifoCI Test]: AVIDump: use a separate AVCodecContext

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -35,6 +35,7 @@ extern "C" {
 
 static AVFormatContext* s_format_context = nullptr;
 static AVStream* s_stream = nullptr;
+static AVCodecContext* s_codec_context = nullptr;
 static AVFrame* s_src_frame = nullptr;
 static AVFrame* s_scaled_frame = nullptr;
 static AVPixelFormat s_pix_fmt = AV_PIX_FMT_BGR24;
@@ -57,6 +58,16 @@ static void InitAVCodec()
     av_register_all();
     first_run = false;
   }
+}
+
+static auto GetCodecPar(AVStream* stream)
+{
+#if (LIBAVCODEC_VERSION_MICRO >= 100 && LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 33, 100)) ||  \
+    (LIBAVCODEC_VERSION_MICRO < 100 && LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 5, 0))
+  return stream->codecpar;
+#else
+  return stream->codec;
+#endif
 }
 
 bool AVIDump::Start(int w, int h)
@@ -107,27 +118,29 @@ bool AVIDump::CreateFile()
   }
 
   if (!(s_format_context->oformat = av_guess_format("avi", nullptr, nullptr)) ||
-      !(s_stream = avformat_new_stream(s_format_context, codec)))
+      !(s_stream = avformat_new_stream(s_format_context, codec)) ||
+      !(s_codec_context = avcodec_alloc_context3(codec)))
   {
     return false;
   }
 
-  s_stream->codec->codec_id =
+  s_codec_context->codec_id = GetCodecPar(s_stream)->codec_id =
       g_Config.bUseFFV1 ? AV_CODEC_ID_FFV1 : s_format_context->oformat->video_codec;
   if (!g_Config.bUseFFV1)
-    s_stream->codec->codec_tag =
+    s_codec_context->codec_tag = GetCodecPar(s_stream)->codec_tag =
         MKTAG('X', 'V', 'I', 'D');  // Force XVID FourCC for better compatibility
-  s_stream->codec->codec_type = AVMEDIA_TYPE_VIDEO;
-  s_stream->codec->bit_rate = 400000;
-  s_stream->codec->width = s_width;
-  s_stream->codec->height = s_height;
-  s_stream->codec->time_base.num = 1;
-  s_stream->codec->time_base.den = VideoInterface::GetTargetRefreshRate();
-  s_stream->codec->gop_size = 12;
-  s_stream->codec->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGRA : AV_PIX_FMT_YUV420P;
+  s_codec_context->codec_type = GetCodecPar(s_stream)->codec_type = AVMEDIA_TYPE_VIDEO;
+  s_codec_context->bit_rate = GetCodecPar(s_stream)->bit_rate = 400000;
+  s_codec_context->width = GetCodecPar(s_stream)->width = s_width;
+  s_codec_context->height = GetCodecPar(s_stream)->height = s_height;
 
-  if (!(codec = avcodec_find_encoder(s_stream->codec->codec_id)) ||
-      (avcodec_open2(s_stream->codec, codec, nullptr) < 0))
+  s_codec_context->gop_size = 12;
+  s_codec_context->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGRA : AV_PIX_FMT_YUV420P;
+  s_codec_context->time_base.num = 1;
+  s_codec_context->time_base.den = VideoInterface::GetTargetRefreshRate();
+
+  if (!(codec = avcodec_find_encoder(s_codec_context->codec_id)) ||
+      (avcodec_open2(s_codec_context, codec, nullptr) < 0))
   {
     return false;
   }
@@ -135,7 +148,7 @@ bool AVIDump::CreateFile()
   s_src_frame = av_frame_alloc();
   s_scaled_frame = av_frame_alloc();
 
-  s_scaled_frame->format = s_stream->codec->pix_fmt;
+  s_scaled_frame->format = s_codec_context->pix_fmt;
   s_scaled_frame->width = s_width;
   s_scaled_frame->height = s_height;
 
@@ -143,7 +156,7 @@ bool AVIDump::CreateFile()
   if (av_frame_get_buffer(s_scaled_frame, 1))
     return false;
 #else
-  if (avcodec_default_get_buffer(s_stream->codec, s_scaled_frame))
+  if (avcodec_default_get_buffer(s_codec_context, s_scaled_frame))
     return false;
 #endif
 
@@ -188,7 +201,7 @@ void AVIDump::AddFrame(const u8* data, int width, int height, int stride, const 
   // Convert image from {BGR24, RGBA} to desired pixel format
   if ((s_sws_context =
            sws_getCachedContext(s_sws_context, width, height, s_pix_fmt, s_width, s_height,
-                                s_stream->codec->pix_fmt, SWS_BICUBIC, nullptr, nullptr, nullptr)))
+                                s_codec_context->pix_fmt, SWS_BICUBIC, nullptr, nullptr, nullptr)))
   {
     sws_scale(s_sws_context, s_src_frame->data, s_src_frame->linesize, 0, height,
               s_scaled_frame->data, s_scaled_frame->linesize);
@@ -218,29 +231,29 @@ void AVIDump::AddFrame(const u8* data, int width, int height, int stride, const 
   else
   {
     delta = state.ticks - s_last_frame;
-    last_pts = (s_last_pts * s_stream->codec->time_base.den) / state.ticks_per_second;
+    last_pts = (s_last_pts * s_codec_context->time_base.den) / state.ticks_per_second;
   }
   u64 pts_in_ticks = s_last_pts + delta;
-  s_scaled_frame->pts = (pts_in_ticks * s_stream->codec->time_base.den) / state.ticks_per_second;
+  s_scaled_frame->pts = (pts_in_ticks * s_codec_context->time_base.den) / state.ticks_per_second;
   if (s_scaled_frame->pts != last_pts)
   {
     s_last_frame = state.ticks;
     s_last_pts = pts_in_ticks;
-    error = avcodec_encode_video2(s_stream->codec, &pkt, s_scaled_frame, &got_packet);
+    error = avcodec_encode_video2(s_codec_context, &pkt, s_scaled_frame, &got_packet);
   }
   while (!error && got_packet)
   {
     // Write the compressed frame in the media file.
     if (pkt.pts != (s64)AV_NOPTS_VALUE)
     {
-      pkt.pts = av_rescale_q(pkt.pts, s_stream->codec->time_base, s_stream->time_base);
+      pkt.pts = av_rescale_q(pkt.pts, s_codec_context->time_base, s_stream->time_base);
     }
     if (pkt.dts != (s64)AV_NOPTS_VALUE)
     {
-      pkt.dts = av_rescale_q(pkt.dts, s_stream->codec->time_base, s_stream->time_base);
+      pkt.dts = av_rescale_q(pkt.dts, s_codec_context->time_base, s_stream->time_base);
     }
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56, 60, 100)
-    if (s_stream->codec->coded_frame->key_frame)
+    if (s_codec_context->coded_frame->key_frame)
       pkt.flags |= AV_PKT_FLAG_KEY;
 #endif
     pkt.stream_index = s_stream->index;
@@ -248,7 +261,7 @@ void AVIDump::AddFrame(const u8* data, int width, int height, int stride, const 
 
     // Handle delayed frames.
     PreparePacket(&pkt);
-    error = avcodec_encode_video2(s_stream->codec, &pkt, nullptr, &got_packet);
+    error = avcodec_encode_video2(s_codec_context, &pkt, nullptr, &got_packet);
   }
   if (error)
     ERROR_LOG(VIDEO, "Error while encoding video: %d", error);
@@ -286,6 +299,7 @@ void AVIDump::CloseFile()
       avio_close(s_format_context->pb);
     av_freep(&s_format_context);
   }
+  avcodec_free_context(&s_codec_context);
 
   if (s_sws_context)
   {


### PR DESCRIPTION
Testing single commits from #4596