### PR TITLE
PatchEngine: Get rid of a global variable

### DIFF
--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -66,5 +66,4 @@ inline int GetPatchTypeCharLength(PatchType type)
   return size;
 }
 
-}  // namespace
-extern std::vector<PatchEngine::Patch> onFrame;
+}  // namespace PatchEngine


### PR DESCRIPTION
This is actually an unused variable (externally), which makes removing it more convenient.