### PR TITLE
specify custom brace style to fix unions

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -19,8 +19,20 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit:     100

--- a/Source/Core/Common/Arm64Emitter.cpp
+++ b/Source/Core/Common/Arm64Emitter.cpp
@@ -2665,7 +2665,8 @@ void ARM64FloatEmitter::EncodeLoadStoreRegisterOffset(u32 size, bool load, ARM64
 
 void ARM64FloatEmitter::EncodeModImm(bool Q, u8 op, u8 cmode, u8 o2, ARM64Reg Rd, u8 abcdefgh)
 {
-  union {
+  union
+  {
     u8 hex;
     struct
     {

--- a/Source/Core/Common/MathUtil.cpp
+++ b/Source/Core/Common/MathUtil.cpp
@@ -104,7 +104,8 @@ const int frsqrte_expected_dec[] = {
 
 double ApproximateReciprocalSquareRoot(double val)
 {
-  union {
+  union
+  {
     double valf;
     s64 vali;
   };
@@ -178,7 +179,8 @@ double ApproximateReciprocal(double val)
   // The workaround for this is to just use namespace std within this function's scope
   // That way on real toolchains it will use the std:: variant like normal.
   using namespace std;
-  union {
+  union
+  {
     double valf;
     s64 vali;
   };

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -57,14 +57,16 @@ static const u64 DOUBLE_SIGN = 0x8000000000000000ULL, DOUBLE_EXP = 0x7FF00000000
 static const u32 FLOAT_SIGN = 0x80000000, FLOAT_EXP = 0x7F800000, FLOAT_FRAC = 0x007FFFFF,
                  FLOAT_ZERO = 0x00000000;
 
-union IntDouble {
+union IntDouble
+{
   double d;
   u64 i;
 
   explicit IntDouble(u64 _i) : i(_i) {}
   explicit IntDouble(double _d) : d(_d) {}
 };
-union IntFloat {
+union IntFloat
+{
   float f;
   u32 i;
 

--- a/Source/Core/Common/TraversalProto.h
+++ b/Source/Core/Common/TraversalProto.h
@@ -52,7 +52,8 @@ struct TraversalPacket
 {
   u8 type;
   TraversalRequestId requestId;
-  union {
+  union
+  {
     struct
     {
       u8 ok;

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -89,7 +89,8 @@ static bool s_disable_logging = false;
 
 struct ARAddr
 {
-  union {
+  union
+  {
     u32 address;
     struct
     {

--- a/Source/Core/Core/Boot/ElfTypes.h
+++ b/Source/Core/Core/Boot/ElfTypes.h
@@ -264,7 +264,8 @@ struct Elf32_Rela
 struct Elf32_Dyn
 {
   s32 d_tag;
-  union {
+  union
+  {
     u32 d_val;
     u32 d_ptr;
   } d_un;

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -225,7 +225,8 @@ struct DSP_Regs
   u16 cr;
   u16 sr;
 
-  union {
+  union
+  {
     u64 val;
     struct
     {
@@ -236,7 +237,8 @@ struct DSP_Regs
     };
   } prod;
 
-  union {
+  union
+  {
     u32 val;
     struct
     {
@@ -245,7 +247,8 @@ struct DSP_Regs
     };
   } ax[2];
 
-  union {
+  union
+  {
     u64 val;
     struct
     {

--- a/Source/Core/Core/FifoPlayer/FifoFileStruct.h
+++ b/Source/Core/Core/FifoPlayer/FifoFileStruct.h
@@ -17,7 +17,8 @@ enum
 
 #pragma pack(push, 4)
 
-union FileHeader {
+union FileHeader
+{
   struct
   {
     u32 fileId;
@@ -40,7 +41,8 @@ union FileHeader {
   u32 rawData[32];
 };
 
-union FileFrameInfo {
+union FileFrameInfo
+{
   struct
   {
     u64 fifoDataOffset;

--- a/Source/Core/Core/HW/AudioInterface.cpp
+++ b/Source/Core/Core/HW/AudioInterface.cpp
@@ -70,7 +70,8 @@ enum
 };
 
 // AI Control Register
-union AICR {
+union AICR
+{
   AICR() { hex = 0; }
   AICR(u32 _hex) { hex = _hex; }
   struct
@@ -90,7 +91,8 @@ union AICR {
 };
 
 // AI Volume Register
-union AIVR {
+union AIVR
+{
   AIVR() { hex = 0; }
   struct
   {

--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -65,7 +65,8 @@ enum
 };
 
 // UARAMCount
-union UARAMCount {
+union UARAMCount
+{
   u32 Hex;
   struct
   {
@@ -75,7 +76,8 @@ union UARAMCount {
 };
 
 // Blocks are 32 bytes.
-union UAudioDMAControl {
+union UAudioDMAControl
+{
   u16 Hex;
   struct
   {
@@ -139,7 +141,8 @@ static AudioDMA g_audioDMA;
 static ARAM_DMA g_arDMA;
 UDSPControl g_dspState;
 
-union ARAM_Info {
+union ARAM_Info
+{
   u16 Hex;
   struct
   {

--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -31,7 +31,8 @@ enum
 
 // UDSPControl
 constexpr u16 DSP_CONTROL_MASK = 0x0C07;
-union UDSPControl {
+union UDSPControl
+{
   u16 Hex;
   struct
   {

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXStructs.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXStructs.h
@@ -271,7 +271,8 @@ struct PBBiquadFilter
   u16 a2;
 };
 
-union PBInfImpulseResponseWM {
+union PBInfImpulseResponseWM
+{
   PBLowPassFilter lpf;
   PBBiquadFilter biquad;
 };

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -41,7 +41,8 @@ namespace
 #define HILO_TO_32(name) ((name##_hi << 16) | name##_lo)
 
 // Used to pass a large amount of buffers to the mixing function.
-union AXBuffers {
+union AXBuffers
+{
   struct
   {
     int* left;

--- a/Source/Core/Core/HW/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVDInterface.cpp
@@ -108,7 +108,8 @@ enum
 };
 
 // DI Status Register
-union UDISR {
+union UDISR
+{
   u32 Hex;
   struct
   {
@@ -126,7 +127,8 @@ union UDISR {
 };
 
 // DI Cover Register
-union UDICVR {
+union UDICVR
+{
   u32 Hex;
   struct
   {
@@ -139,7 +141,8 @@ union UDICVR {
   UDICVR(u32 _hex) { Hex = _hex; }
 };
 
-union UDICMDBUF {
+union UDICMDBUF
+{
   u32 Hex;
   struct
   {
@@ -151,7 +154,8 @@ union UDICMDBUF {
 };
 
 // DI DMA Address Register
-union UDIMAR {
+union UDIMAR
+{
   u32 Hex;
   struct
   {
@@ -166,7 +170,8 @@ union UDIMAR {
 };
 
 // DI DMA Address Length Register
-union UDILENGTH {
+union UDILENGTH
+{
   u32 Hex;
   struct
   {
@@ -181,7 +186,8 @@ union UDILENGTH {
 };
 
 // DI DMA Control Register
-union UDICR {
+union UDICR
+{
   u32 Hex;
   struct
   {
@@ -192,7 +198,8 @@ union UDICR {
   };
 };
 
-union UDIIMMBUF {
+union UDIIMMBUF
+{
   u32 Hex;
   struct
   {
@@ -204,7 +211,8 @@ union UDIIMMBUF {
 };
 
 // DI Config Register
-union UDICFG {
+union UDICFG
+{
   u32 Hex;
   struct
   {

--- a/Source/Core/Core/HW/EXI_Channel.h
+++ b/Source/Core/Core/HW/EXI_Channel.h
@@ -29,7 +29,8 @@ private:
   };
 
   // EXI Status Register - "Channel Parameter Register"
-  union UEXI_STATUS {
+  union UEXI_STATUS
+  {
     u32 Hex;
     // DO NOT obey the warning and give this struct a name. Things will fail.
     struct
@@ -55,7 +56,8 @@ private:
   };
 
   // EXI Control Register
-  union UEXI_CONTROL {
+  union UEXI_CONTROL
+  {
     u32 Hex;
     struct
     {

--- a/Source/Core/Core/HW/EXI_DeviceAD16.h
+++ b/Source/Core/Core/HW/EXI_DeviceAD16.h
@@ -24,7 +24,8 @@ private:
     read = 0xa2
   };
 
-  union UAD16Reg {
+  union UAD16Reg
+  {
     u32 U32;
     u32 U8[4];
   };

--- a/Source/Core/Core/HW/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI_DeviceMic.h
@@ -38,7 +38,8 @@ private:
 
   u32 m_position;
   int command;
-  union UStatus {
+  union UStatus
+  {
     u16 U16;
     u8 U8[2];
     struct

--- a/Source/Core/Core/HW/MemoryInterface.cpp
+++ b/Source/Core/Core/HW/MemoryInterface.cpp
@@ -49,7 +49,8 @@ enum
   MI_UNKNOWN2 = 0x05A,
 };
 
-union MIRegion {
+union MIRegion
+{
   u32 hex;
   struct
   {
@@ -58,7 +59,8 @@ union MIRegion {
   };
 };
 
-union MIProtType {
+union MIProtType
+{
   u16 hex;
   struct
   {
@@ -70,7 +72,8 @@ union MIProtType {
   };
 };
 
-union MIIRQMask {
+union MIIRQMask
+{
   u16 hex;
   struct
   {
@@ -83,7 +86,8 @@ union MIIRQMask {
   };
 };
 
-union MIIRQFlag {
+union MIIRQFlag
+{
   u16 hex;
   struct
   {
@@ -96,7 +100,8 @@ union MIIRQFlag {
   };
 };
 
-union MIProtAddr {
+union MIProtAddr
+{
   u32 hex;
   struct
   {
@@ -111,7 +116,8 @@ union MIProtAddr {
   };
 };
 
-union MITimer {
+union MITimer
+{
   u32 hex;
   struct
   {

--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -59,7 +59,8 @@ enum
 };
 
 // SI Channel Output
-union USIChannelOut {
+union USIChannelOut
+{
   u32 Hex;
   struct
   {
@@ -71,7 +72,8 @@ union USIChannelOut {
 };
 
 // SI Channel Input High u32
-union USIChannelIn_Hi {
+union USIChannelIn_Hi
+{
   u32 Hex;
   struct
   {
@@ -85,7 +87,8 @@ union USIChannelIn_Hi {
 };
 
 // SI Channel Input Low u32
-union USIChannelIn_Lo {
+union USIChannelIn_Lo
+{
   u32 Hex;
   struct
   {
@@ -106,7 +109,8 @@ struct SSIChannel
 };
 
 // SI Poll: Controls how often a device is polled
-union USIPoll {
+union USIPoll
+{
   u32 Hex;
   struct
   {
@@ -125,7 +129,8 @@ union USIPoll {
 };
 
 // SI Communication Control Status Register
-union USIComCSR {
+union USIComCSR
+{
   u32 Hex;
   struct
   {
@@ -151,7 +156,8 @@ union USIComCSR {
 };
 
 // SI Status Register
-union USIStatusReg {
+union USIStatusReg
+{
   u32 Hex;
   struct
   {
@@ -190,7 +196,8 @@ union USIStatusReg {
 };
 
 // SI EXI Clock Count
-union USIEXIClockCount {
+union USIEXIClockCount
+{
   u32 Hex;
   struct
   {

--- a/Source/Core/Core/HW/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI_DeviceGCController.h
@@ -41,7 +41,8 @@ protected:
     CMD_WRITE = 0x40
   };
 
-  union UCommand {
+  union UCommand
+  {
     u32 Hex;
     struct
     {

--- a/Source/Core/Core/HW/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI_DeviceKeyboard.h
@@ -26,7 +26,8 @@ protected:
     CMD_POLL = 0x54
   };
 
-  union UCommand {
+  union UCommand
+  {
     u32 Hex;
     struct
     {

--- a/Source/Core/Core/HW/Sram.h
+++ b/Source/Core/Core/HW/Sram.h
@@ -37,7 +37,8 @@ distribution.
 #include "Common/CommonTypes.h"
 
 #pragma pack(push, 1)
-union SRAMFlags {
+union SRAMFlags
+{
   u8 Hex;
   struct
   {
@@ -53,7 +54,8 @@ union SRAMFlags {
   };
 };
 
-union SRAM {
+union SRAM
+{
   u8 p_SRAM[64];
   struct  // Stored configuration value from the system SRAM area
   {

--- a/Source/Core/Core/HW/VideoInterface.h
+++ b/Source/Core/Core/HW/VideoInterface.h
@@ -79,7 +79,8 @@ enum
   // VI_INTERLACE                      = 0x850, // ??? MYSTERY OLD CODE
 };
 
-union UVIVerticalTimingRegister {
+union UVIVerticalTimingRegister
+{
   u16 Hex;
   struct
   {
@@ -91,7 +92,8 @@ union UVIVerticalTimingRegister {
   UVIVerticalTimingRegister() { Hex = 0; }
 };
 
-union UVIDisplayControlRegister {
+union UVIDisplayControlRegister
+{
   u16 Hex;
   struct
   {
@@ -109,7 +111,8 @@ union UVIDisplayControlRegister {
   UVIDisplayControlRegister() { Hex = 0; }
 };
 
-union UVIHorizontalTiming0 {
+union UVIHorizontalTiming0
+{
   u32 Hex;
   struct
   {
@@ -126,7 +129,8 @@ union UVIHorizontalTiming0 {
   };
 };
 
-union UVIHorizontalTiming1 {
+union UVIHorizontalTiming1
+{
   u32 Hex;
   struct
   {
@@ -142,7 +146,8 @@ union UVIHorizontalTiming1 {
 };
 
 // Exists for both odd and even fields
-union UVIVBlankTimingRegister {
+union UVIVBlankTimingRegister
+{
   u32 Hex;
   struct
   {
@@ -158,7 +163,8 @@ union UVIVBlankTimingRegister {
 };
 
 // Exists for both odd and even fields
-union UVIBurstBlankingRegister {
+union UVIBurstBlankingRegister
+{
   u32 Hex;
   struct
   {
@@ -173,7 +179,8 @@ union UVIBurstBlankingRegister {
   };
 };
 
-union UVIFBInfoRegister {
+union UVIFBInfoRegister
+{
   u32 Hex;
   struct
   {
@@ -192,7 +199,8 @@ union UVIFBInfoRegister {
 };
 
 // VI Interrupt Register
-union UVIInterruptRegister {
+union UVIInterruptRegister
+{
   u32 Hex;
   struct
   {
@@ -210,7 +218,8 @@ union UVIInterruptRegister {
   };
 };
 
-union UVILatchRegister {
+union UVILatchRegister
+{
   u32 Hex;
   struct
   {
@@ -226,7 +235,8 @@ union UVILatchRegister {
   };
 };
 
-union PictureConfigurationRegister {
+union PictureConfigurationRegister
+{
   u16 Hex;
   struct
   {
@@ -236,7 +246,8 @@ union PictureConfigurationRegister {
   };
 };
 
-union UVIHorizontalScaling {
+union UVIHorizontalScaling
+{
   u16 Hex;
   struct
   {
@@ -250,7 +261,8 @@ union UVIHorizontalScaling {
 };
 
 // Used for tables 0-2
-union UVIFilterCoefTable3 {
+union UVIFilterCoefTable3
+{
   u32 Hex;
   struct
   {
@@ -266,7 +278,8 @@ union UVIFilterCoefTable3 {
 };
 
 // Used for tables 3-6
-union UVIFilterCoefTable4 {
+union UVIFilterCoefTable4
+{
   u32 Hex;
   struct
   {
@@ -288,7 +301,8 @@ struct SVIFilterCoefTables
 };
 
 // Debug video mode only, probably never used in Dolphin...
-union UVIBorderBlankRegister {
+union UVIBorderBlankRegister
+{
   u32 Hex;
   struct
   {
@@ -304,7 +318,8 @@ union UVIBorderBlankRegister {
 };
 
 // ntsc-j and component cable bits
-union UVIDTVStatus {
+union UVIDTVStatus
+{
   u16 Hex;
   struct
   {
@@ -314,7 +329,8 @@ union UVIDTVStatus {
   };
 };
 
-union UVIHorizontalStepping {
+union UVIHorizontalStepping
+{
   u16 Hex;
   struct
   {

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteHid.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteHid.h
@@ -87,7 +87,8 @@ struct wm_ir_extended
 };
 
 // Nunchuk
-union wm_nc_core {
+union wm_nc_core
+{
   u8 hex;
 
   struct
@@ -102,7 +103,8 @@ union wm_nc_core {
   };
 };
 
-union wm_nc {
+union wm_nc
+{
   struct
   {
     // joystick x, y
@@ -137,7 +139,8 @@ union wm_nc {
   } passthrough_data;
 };
 
-union wm_classic_extension_buttons {
+union wm_classic_extension_buttons
+{
   u16 hex;
 
   struct
@@ -181,7 +184,8 @@ union wm_classic_extension_buttons {
   } passthrough_data;
 };
 
-union wm_classic_extension {
+union wm_classic_extension
+{
   // lx/ly/lz; left joystick
   // rx/ry/rz; right joystick
   // lt; left trigger
@@ -283,7 +287,8 @@ struct wm_turntable_extension
   u8 ltable1 : 5;
   u8 dial1 : 3;
 
-  union {
+  union
+  {
     u16 ltable2 : 1;
     u16 bt;  // buttons
   };
@@ -314,7 +319,8 @@ struct wm_motionplus_data
 struct wm_report
 {
   u8 wm;
-  union {
+  union
+  {
     u8 data[0];
     struct
     {

--- a/Source/Core/Core/IPC_HLE/WII_Socket.h
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.h
@@ -174,7 +174,8 @@ class WiiSocket
   {
     u32 _CommandAddress;
     bool is_ssl;
-    union {
+    union
+    {
       NET_IOCTL net_type;
       SSL_IOCTL ssl_type;
     };

--- a/Source/Core/Core/IPC_HLE/hci.h
+++ b/Source/Core/Core/IPC_HLE/hci.h
@@ -2575,7 +2575,8 @@ struct btreq
 {
   char btr_name[HCI_DEVNAME_SIZE]; /* device name */
 
-  union {
+  union
+  {
     struct
     {
       bdaddr_t btri_bdaddr;      /* device bdaddr */

--- a/Source/Core/Core/IPC_HLE/l2cap.h
+++ b/Source/Core/Core/IPC_HLE/l2cap.h
@@ -295,7 +295,8 @@ typedef struct
 } l2cap_cfg_opt_t;
 
 /* L2CAP configuration option value */
-typedef union {
+typedef union
+{
   uint16_t mtu;        /* L2CAP_OPT_MTU */
   uint16_t flush_timo; /* L2CAP_OPT_FLUSH_TIMO */
   l2cap_qos_t qos;     /* L2CAP_OPT_QOS */
@@ -342,7 +343,8 @@ typedef struct
                    */
 } l2cap_info_rsp_cp;
 
-typedef union {
+typedef union
+{
   /* L2CAP_CONNLESS_MTU */
   struct
   {

--- a/Source/Core/Core/PowerPC/CachedInterpreter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter.h
@@ -42,7 +42,8 @@ private:
     Instruction(const ConditionalCallback c, u32 d)
         : conditional_callback(c), data(d), type(INSTRUCTION_TYPE_CONDITIONAL){};
 
-    union {
+    union
+    {
       const CommonCallback common_callback;
       const ConditionalCallback conditional_callback;
     };

--- a/Source/Core/Core/PowerPC/Gekko.h
+++ b/Source/Core/Core/PowerPC/Gekko.h
@@ -11,7 +11,8 @@
 
 // --- Gekko Instruction ---
 
-union UGeckoInstruction {
+union UGeckoInstruction
+{
   u32 hex;
 
   UGeckoInstruction(u32 _hex) : hex(_hex) {}
@@ -311,7 +312,8 @@ enum EQuantizeType : u32
 };
 
 // GQR Register
-union UGQR {
+union UGQR
+{
   BitField<0, 3, EQuantizeType> st_type;
   BitField<8, 6, u32> st_scale;
   BitField<16, 3, EQuantizeType> ld_type;
@@ -324,7 +326,8 @@ union UGQR {
 };
 
 // FPU Register
-union UFPR {
+union UFPR
+{
   u64 as_u64;
   s64 as_s64;
   double d;
@@ -339,7 +342,8 @@ union UFPR {
 #define XER_OV_MASK 1
 #define XER_SO_MASK 2
 // XER
-union UReg_XER {
+union UReg_XER
+{
   struct
   {
     u32 BYTE_COUNT : 7;
@@ -357,7 +361,8 @@ union UReg_XER {
 };
 
 // Machine State Register
-union UReg_MSR {
+union UReg_MSR
+{
   struct
   {
     u32 LE : 1;
@@ -418,7 +423,8 @@ enum FPSCRExceptionFlag : u32
 };
 
 // Floating Point Status and Control Register
-union UReg_FPSCR {
+union UReg_FPSCR
+{
   struct
   {
     // Rounding mode (towards: nearest, zero, +inf, -inf)
@@ -484,7 +490,8 @@ union UReg_FPSCR {
 };
 
 // Hardware Implementation-Dependent Register 0
-union UReg_HID0 {
+union UReg_HID0
+{
   struct
   {
     u32 NOOPTI : 1;
@@ -522,7 +529,8 @@ union UReg_HID0 {
 };
 
 // Hardware Implementation-Dependent Register 2
-union UReg_HID2 {
+union UReg_HID2
+{
   struct
   {
     u32 : 16;
@@ -547,7 +555,8 @@ union UReg_HID2 {
 };
 
 // Hardware Implementation-Dependent Register 4
-union UReg_HID4 {
+union UReg_HID4
+{
   struct
   {
     u32 : 20;
@@ -569,7 +578,8 @@ union UReg_HID4 {
 };
 
 // SPR1 - Page Table format
-union UReg_SPR1 {
+union UReg_SPR1
+{
   u32 Hex;
   struct
   {
@@ -580,7 +590,8 @@ union UReg_SPR1 {
 };
 
 // MMCR0 - Monitor Mode Control Register 0 format
-union UReg_MMCR0 {
+union UReg_MMCR0
+{
   u32 Hex;
   struct
   {
@@ -603,7 +614,8 @@ union UReg_MMCR0 {
 };
 
 // MMCR1 - Monitor Mode Control Register 1 format
-union UReg_MMCR1 {
+union UReg_MMCR1
+{
   u32 Hex;
   struct
   {
@@ -614,7 +626,8 @@ union UReg_MMCR1 {
 };
 
 // Write Pipe Address Register
-union UReg_WPAR {
+union UReg_WPAR
+{
   struct
   {
     u32 BNE : 1;
@@ -628,7 +641,8 @@ union UReg_WPAR {
 };
 
 // Direct Memory Access Upper register
-union UReg_DMAU {
+union UReg_DMAU
+{
   struct
   {
     u32 DMA_LEN_U : 5;
@@ -641,7 +655,8 @@ union UReg_DMAU {
 };
 
 // Direct Memory Access Lower (DMAL) register
-union UReg_DMAL {
+union UReg_DMAL
+{
   struct
   {
     u32 DMA_F : 1;
@@ -656,7 +671,8 @@ union UReg_DMAL {
   UReg_DMAL() { Hex = 0; }
 };
 
-union UReg_BAT_Up {
+union UReg_BAT_Up
+{
   struct
   {
     u32 VP : 1;
@@ -671,7 +687,8 @@ union UReg_BAT_Up {
   UReg_BAT_Up() { Hex = 0; }
 };
 
-union UReg_BAT_Lo {
+union UReg_BAT_Lo
+{
   struct
   {
     u32 PP : 2;
@@ -686,7 +703,8 @@ union UReg_BAT_Lo {
   UReg_BAT_Lo() { Hex = 0; }
 };
 
-union UReg_PTE {
+union UReg_PTE
+{
   struct
   {
     u64 API : 6;

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -867,7 +867,8 @@ TranslateResult JitCache_TranslateAddress(u32 address)
 #define PTE2_PP(v) ((v)&3)
 
 // Hey! these duplicate a structure in Gekko.h
-union UPTE1 {
+union UPTE1
+{
   struct
   {
     u32 API : 6;
@@ -878,7 +879,8 @@ union UPTE1 {
   u32 Hex;
 };
 
-union UPTE2 {
+union UPTE2
+{
   struct
   {
     u32 PP : 2;

--- a/Source/Core/Core/ec_wii.h
+++ b/Source/Core/Core/ec_wii.h
@@ -68,7 +68,8 @@ private:
     u8 boot1_hash[0x14];  // 0x100
     u8 common_key[0x10];  // 0x114
     u32 ng_id;            // 0x124
-    union {
+    union
+    {
       struct
       {
         u8 ng_priv[0x1e];  // 0x128

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -18,13 +18,15 @@ struct ID3D11RasterizerState;
 
 namespace DX11
 {
-union RasterizerState {
+union RasterizerState
+{
   BitField<0, 2, D3D11_CULL_MODE> cull_mode;
 
   u32 packed;
 };
 
-union BlendState {
+union BlendState
+{
   BitField<0, 1, u32> blend_enable;
   BitField<1, 3, D3D11_BLEND_OP> blend_op;
   BitField<4, 4, u32> write_mask;
@@ -35,7 +37,8 @@ union BlendState {
   u32 packed;
 };
 
-union SamplerState {
+union SamplerState
+{
   BitField<0, 3, u64> min_filter;
   BitField<3, 1, u64> mag_filter;
   BitField<4, 8, u64> min_lod;

--- a/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/XFBEncoder.cpp
@@ -15,7 +15,8 @@
 
 namespace DX11
 {
-union XFBEncodeParams {
+union XFBEncodeParams
+{
   struct
   {
     FLOAT Width;  // Width and height of encoded XFB in luma pixels

--- a/Source/Core/VideoBackends/D3D12/D3DQueuedCommandList.h
+++ b/Source/Core/VideoBackends/D3D12/D3DQueuedCommandList.h
@@ -244,7 +244,8 @@ struct D3DQueueItem
 {
   D3DQueueItemType Type;
 
-  union {
+  union
+  {
     SetPipelineStateArguments SetPipelineState;
     SetRenderTargetsArguments SetRenderTargets;
     SetVertexBuffersArguments SetVertexBuffers;

--- a/Source/Core/VideoBackends/D3D12/D3DState.h
+++ b/Source/Core/VideoBackends/D3D12/D3DState.h
@@ -19,13 +19,15 @@ namespace DX12
 {
 class PipelineStateCacheInserter;
 
-union RasterizerState {
+union RasterizerState
+{
   BitField<0, 2, D3D12_CULL_MODE> cull_mode;
 
   u32 hex;
 };
 
-union BlendState {
+union BlendState
+{
   BitField<0, 1, u32> blend_enable;
   BitField<1, 3, D3D12_BLEND_OP> blend_op;
   BitField<4, 4, u8> write_mask;
@@ -36,7 +38,8 @@ union BlendState {
   u32 hex;
 };
 
-union SamplerState {
+union SamplerState
+{
   BitField<0, 3, u32> min_filter;
   BitField<3, 1, u32> mag_filter;
   BitField<4, 8, u32> min_lod;

--- a/Source/Core/VideoBackends/OGL/SamplerCache.h
+++ b/Source/Core/VideoBackends/OGL/SamplerCache.h
@@ -28,7 +28,8 @@ public:
 private:
   struct Params
   {
-    union {
+    union
+    {
       struct
       {
         TexMode0 tm0;

--- a/Source/Core/VideoBackends/Vulkan/Constants.h
+++ b/Source/Core/VideoBackends/Vulkan/Constants.h
@@ -117,7 +117,8 @@ constexpr u32 PUSH_CONSTANT_BUFFER_SIZE = 128;
 constexpr u32 MINIMUM_DRAW_CALLS_PER_COMMAND_BUFFER_FOR_READBACK = 10;
 
 // Rasterization state info
-union RasterizationState {
+union RasterizationState
+{
   BitField<0, 2, VkCullModeFlags> cull_mode;
   BitField<2, 7, VkSampleCountFlagBits> samples;
   BitField<9, 1, VkBool32> per_sample_shading;
@@ -127,7 +128,8 @@ union RasterizationState {
 };
 
 // Depth state info
-union DepthStencilState {
+union DepthStencilState
+{
   BitField<0, 1, VkBool32> test_enable;
   BitField<1, 1, VkBool32> write_enable;
   BitField<2, 3, VkCompareOp> compare_op;
@@ -136,10 +138,12 @@ union DepthStencilState {
 };
 
 // Blend state info
-union BlendState {
+union BlendState
+{
   struct
   {
-    union {
+    union
+    {
       BitField<0, 1, VkBool32> blend_enable;
       BitField<1, 3, VkBlendOp> blend_op;
       BitField<4, 5, VkBlendFactor> src_blend;
@@ -150,7 +154,8 @@ union BlendState {
       BitField<27, 4, VkColorComponentFlags> write_mask;
       u32 low_bits;
     };
-    union {
+    union
+    {
       BitField<0, 1, VkBool32> logic_op_enable;
       BitField<1, 4, VkLogicOp> logic_op;
       u32 high_bits;
@@ -161,7 +166,8 @@ union BlendState {
 };
 
 // Sampler info
-union SamplerState {
+union SamplerState
+{
   BitField<0, 1, VkFilter> min_filter;
   BitField<1, 1, VkFilter> mag_filter;
   BitField<2, 1, VkSamplerMipmapMode> mipmap_mode;

--- a/Source/Core/VideoCommon/AsyncRequests.h
+++ b/Source/Core/VideoCommon/AsyncRequests.h
@@ -31,7 +31,8 @@ public:
     } type;
     u64 time;
 
-    union {
+    union
+    {
       struct
       {
         u16 x;

--- a/Source/Core/VideoCommon/BPMemory.h
+++ b/Source/Core/VideoCommon/BPMemory.h
@@ -244,7 +244,8 @@ enum : u32
   ITW_0 = 6
 };
 
-union IND_MTXA {
+union IND_MTXA
+{
   struct
   {
     s32 ma : 11;
@@ -255,7 +256,8 @@ union IND_MTXA {
   u32 hex;
 };
 
-union IND_MTXB {
+union IND_MTXB
+{
   struct
   {
     s32 mc : 11;
@@ -266,7 +268,8 @@ union IND_MTXB {
   u32 hex;
 };
 
-union IND_MTXC {
+union IND_MTXC
+{
   struct
   {
     s32 me : 11;
@@ -284,7 +287,8 @@ struct IND_MTX
   IND_MTXC col2;
 };
 
-union IND_IMASK {
+union IND_IMASK
+{
   struct
   {
     u32 mask : 24;
@@ -295,7 +299,8 @@ union IND_IMASK {
 
 struct TevStageCombiner
 {
-  union ColorCombiner {
+  union ColorCombiner
+  {
     struct  // abc=8bit,d=10bit
     {
       u32 d : 4;  // TEVSELCC_X
@@ -312,7 +317,8 @@ struct TevStageCombiner
     };
     u32 hex;
   };
-  union AlphaCombiner {
+  union AlphaCombiner
+  {
     struct
     {
       u32 rswap : 2;
@@ -345,7 +351,8 @@ struct TevStageCombiner
 //  GXSetTevIndirect(tevstage+1, indstage, 0, 3, realmat+4, 6, 6, 1, 0, 0)
 //  GXSetTevIndirect(tevstage+2, indstage, 0, 0, 0, 0, 0, 1, 0, 0)
 
-union TevStageIndirect {
+union TevStageIndirect
+{
   struct
   {
     u32 bt : 2;          // Indirect tex stage ID
@@ -372,7 +379,8 @@ union TevStageIndirect {
   bool IsActive() { return bs != ITBA_OFF || mid != 0; }
 };
 
-union TwoTevStageOrders {
+union TwoTevStageOrders
+{
   struct
   {
     u32 texmap0 : 3;  // Indirect tex stage texmap
@@ -397,7 +405,8 @@ union TwoTevStageOrders {
   int getColorChan(int i) const { return i ? colorchan1 : colorchan0; }
 };
 
-union TEXSCALE {
+union TEXSCALE
+{
   struct
   {
     u32 ss0 : 4;  // Indirect tex stage 0, 2^(-ss0)
@@ -410,7 +419,8 @@ union TEXSCALE {
   u32 hex;
 };
 
-union RAS1_IREF {
+union RAS1_IREF
+{
   struct
   {
     u32 bi0 : 3;  // Indirect tex stage 0 ntexmap
@@ -431,7 +441,8 @@ union RAS1_IREF {
 
 // Texture structs
 
-union TexMode0 {
+union TexMode0
+{
   enum TextureFilter : u32
   {
     TEXF_NONE = 0,
@@ -453,7 +464,8 @@ union TexMode0 {
   };
   u32 hex;
 };
-union TexMode1 {
+union TexMode1
+{
   struct
   {
     u32 min_lod : 8;
@@ -461,7 +473,8 @@ union TexMode1 {
   };
   u32 hex;
 };
-union TexImage0 {
+union TexImage0
+{
   struct
   {
     u32 width : 10;   // Actually w-1
@@ -470,7 +483,8 @@ union TexImage0 {
   };
   u32 hex;
 };
-union TexImage1 {
+union TexImage1
+{
   struct
   {
     u32 tmem_even : 15;  // TMEM line index for even LODs
@@ -482,7 +496,8 @@ union TexImage1 {
   u32 hex;
 };
 
-union TexImage2 {
+union TexImage2
+{
   struct
   {
     u32 tmem_odd : 15;  // tmem line index for odd LODs
@@ -492,14 +507,16 @@ union TexImage2 {
   u32 hex;
 };
 
-union TexImage3 {
+union TexImage3
+{
   struct
   {
     u32 image_base : 24;  // address in memory >> 5 (was 20 for GC)
   };
   u32 hex;
 };
-union TexTLUT {
+union TexTLUT
+{
   struct
   {
     u32 tmem_offset : 10;
@@ -508,7 +525,8 @@ union TexTLUT {
   u32 hex;
 };
 
-union ZTex1 {
+union ZTex1
+{
   struct
   {
     u32 bias : 24;
@@ -516,7 +534,8 @@ union ZTex1 {
   u32 hex;
 };
 
-union ZTex2 {
+union ZTex2
+{
   struct
   {
     u32 type : 2;  // TEV_Z_TYPE_X
@@ -539,7 +558,8 @@ struct FourTexUnits
 
 // Geometry/other structs
 
-union GenMode {
+union GenMode
+{
   enum CullMode : u32
   {
     CULL_NONE = 0,
@@ -561,7 +581,8 @@ union GenMode {
   u32 hex;
 };
 
-union LPSize {
+union LPSize
+{
   struct
   {
     u32 linesize : 8;   // in 1/6th pixels
@@ -574,7 +595,8 @@ union LPSize {
   u32 hex;
 };
 
-union X12Y12 {
+union X12Y12
+{
   struct
   {
     u32 y : 12;
@@ -582,7 +604,8 @@ union X12Y12 {
   };
   u32 hex;
 };
-union X10Y10 {
+union X10Y10
+{
   struct
   {
     u32 x : 10;
@@ -593,7 +616,8 @@ union X10Y10 {
 
 // Framebuffer/pixel stuff (incl fog)
 
-union BlendMode {
+union BlendMode
+{
   enum BlendFactor : u32
   {
     ZERO = 0,
@@ -641,7 +665,8 @@ union BlendMode {
   u32 hex;
 };
 
-union FogParam0 {
+union FogParam0
+{
   struct
   {
     u32 mantissa : 11;
@@ -651,7 +676,8 @@ union FogParam0 {
 
   float GetA()
   {
-    union {
+    union
+    {
       u32 i;
       float f;
     } dummy;
@@ -663,7 +689,8 @@ union FogParam0 {
   u32 hex;
 };
 
-union FogParam3 {
+union FogParam3
+{
   struct
   {
     u32 c_mant : 11;
@@ -676,7 +703,8 @@ union FogParam3 {
   // amount to subtract from eyespacez after range adjustment
   float GetC()
   {
-    union {
+    union
+    {
       u32 i;
       float f;
     } dummy;
@@ -688,7 +716,8 @@ union FogParam3 {
   u32 hex;
 };
 
-union FogRangeKElement {
+union FogRangeKElement
+{
   struct
   {
     u32 HI : 12;
@@ -703,7 +732,8 @@ union FogRangeKElement {
 
 struct FogRangeParams
 {
-  union RangeBase {
+  union RangeBase
+  {
     struct
     {
       u32 Center : 10;  // viewport center + 342
@@ -724,7 +754,8 @@ struct FogParams
   u32 b_shift;  // b's exp + 1?
   FogParam3 c_proj_fsel;
 
-  union FogColor {
+  union FogColor
+  {
     struct
     {
       u32 b : 8;
@@ -737,7 +768,8 @@ struct FogParams
   FogColor color;  // 0:b 8:g 16:r - nice!
 };
 
-union ZMode {
+union ZMode
+{
   enum CompareMode : u32
   {
     NEVER = 0,
@@ -757,7 +789,8 @@ union ZMode {
   u32 hex;
 };
 
-union ConstantAlpha {
+union ConstantAlpha
+{
   struct
   {
     u32 alpha : 8;
@@ -766,7 +799,8 @@ union ConstantAlpha {
   u32 hex;
 };
 
-union FieldMode {
+union FieldMode
+{
   struct
   {
     u32 texLOD : 1;  // adjust vert tex LOD computation to account for interlacing
@@ -774,7 +808,8 @@ union FieldMode {
   u32 hex;
 };
 
-union FieldMask {
+union FieldMask
+{
   struct
   {
     // If bit is not set, do not write field to EFB
@@ -784,7 +819,8 @@ union FieldMask {
   u32 hex;
 };
 
-union PEControl {
+union PEControl
+{
   enum PixelFormat : u32
   {
     RGB8_Z24 = 0,
@@ -821,7 +857,8 @@ union PEControl {
 
 // Texture coordinate stuff
 
-union TCInfo {
+union TCInfo
+{
   struct
   {
     u32 scale_minus_1 : 16;
@@ -839,7 +876,8 @@ struct TCoordInfo
   TCInfo t;
 };
 
-union TevReg {
+union TevReg
+{
   u64 hex;
 
   // Access to individual registers
@@ -861,7 +899,8 @@ union TevReg {
   BitField<55, 1, u64> type_bg;
 };
 
-union TevKSel {
+union TevKSel
+{
   struct
   {
     u32 swap1 : 2;
@@ -877,7 +916,8 @@ union TevKSel {
   int getKA(int i) { return i ? kasel1 : kasel0; }
 };
 
-union AlphaTest {
+union AlphaTest
+{
   enum CompareMode : u32
   {
     NEVER = 0,
@@ -952,7 +992,8 @@ union AlphaTest {
   }
 };
 
-union UPE_Copy {
+union UPE_Copy
+{
   u32 Hex;
 
   BitField<0, 1, u32> clamp0;               // if set clamp top
@@ -975,7 +1016,8 @@ union UPE_Copy {
   u32 tp_realFormat() { return target_pixel_format / 2 + (target_pixel_format & 1) * 8; }
 };
 
-union BPU_PreloadTileInfo {
+union BPU_PreloadTileInfo
+{
   u32 hex;
   struct
   {

--- a/Source/Core/VideoCommon/CPMemory.h
+++ b/Source/Core/VideoCommon/CPMemory.h
@@ -48,7 +48,8 @@ enum
 };
 
 #pragma pack(4)
-union TVtxDesc {
+union TVtxDesc
+{
   u64 Hex;
   struct
   {
@@ -92,7 +93,8 @@ union TVtxDesc {
   u32 GetVertexArrayStatus(int idx) { return (Hex >> (9 + idx * 2)) & 0x3; }
 };
 
-union UVAT_group0 {
+union UVAT_group0
+{
   u32 Hex;
   struct
   {
@@ -119,7 +121,8 @@ union UVAT_group0 {
   };
 };
 
-union UVAT_group1 {
+union UVAT_group1
+{
   u32 Hex;
   struct
   {
@@ -143,7 +146,8 @@ union UVAT_group1 {
   };
 };
 
-union UVAT_group2 {
+union UVAT_group2
+{
   u32 Hex;
   struct
   {
@@ -191,7 +195,8 @@ struct TVtxAttr
 };
 
 // Matrix indices
-union TMatrixIndexA {
+union TMatrixIndexA
+{
   struct
   {
     u32 PosNormalMtxIdx : 6;
@@ -207,7 +212,8 @@ union TMatrixIndexA {
   };
 };
 
-union TMatrixIndexB {
+union TMatrixIndexB
+{
   struct
   {
     u32 Tex4MtxIdx : 6;

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -71,7 +71,8 @@ enum
 };
 
 // Fifo Status Register
-union UCPStatusReg {
+union UCPStatusReg
+{
   struct
   {
     u16 OverflowHiWatermark : 1;
@@ -87,7 +88,8 @@ union UCPStatusReg {
 };
 
 // Fifo Control Register
-union UCPCtrlReg {
+union UCPCtrlReg
+{
   struct
   {
     u16 GPReadEnable : 1;
@@ -104,7 +106,8 @@ union UCPCtrlReg {
 };
 
 // Fifo Clear Register
-union UCPClearReg {
+union UCPClearReg
+{
   struct
   {
     u16 ClearFifoOverflow : 1;

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -21,7 +21,8 @@
 
 namespace PixelEngine
 {
-union UPEZConfReg {
+union UPEZConfReg
+{
   u16 Hex;
   struct
   {
@@ -32,7 +33,8 @@ union UPEZConfReg {
   };
 };
 
-union UPEAlphaConfReg {
+union UPEAlphaConfReg
+{
   u16 Hex;
   struct
   {
@@ -48,7 +50,8 @@ union UPEAlphaConfReg {
   };
 };
 
-union UPEDstAlphaConfReg {
+union UPEDstAlphaConfReg
+{
   u16 Hex;
   struct
   {
@@ -58,7 +61,8 @@ union UPEDstAlphaConfReg {
   };
 };
 
-union UPEAlphaModeConfReg {
+union UPEAlphaModeConfReg
+{
   u16 Hex;
   struct
   {
@@ -68,7 +72,8 @@ union UPEAlphaModeConfReg {
 };
 
 // fifo Control Register
-union UPECtrlReg {
+union UPECtrlReg
+{
   struct
   {
     u16 PETokenEnable : 1;

--- a/Source/Core/VideoCommon/PixelEngine.h
+++ b/Source/Core/VideoCommon/PixelEngine.h
@@ -46,7 +46,8 @@ enum
 namespace PixelEngine
 {
 // ReadMode specifies the returned alpha channel for EFB peeks
-union UPEAlphaReadReg {
+union UPEAlphaReadReg
+{
   u16 Hex;
   struct
   {

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -104,7 +104,8 @@ public:
   const u8* GetUidDataRaw() const { return &values[0]; }
   size_t GetUidDataSize() const { return sizeof(values); }
 private:
-  union {
+  union
+  {
     uid_data data;
     u8 values[sizeof(uid_data)];
   };

--- a/Source/Core/VideoCommon/XFMemory.h
+++ b/Source/Core/VideoCommon/XFMemory.h
@@ -130,7 +130,8 @@ enum
   XFMEM_SETPOSMTXINFO = 0x1050,
 };
 
-union LitChannel {
+union LitChannel
+{
   struct
   {
     u32 matsource : 1;
@@ -158,7 +159,8 @@ union LitChannel {
   }
 };
 
-union INVTXSPEC {
+union INVTXSPEC
+{
   struct
   {
     u32 numcolors : 2;
@@ -169,7 +171,8 @@ union INVTXSPEC {
   u32 hex;
 };
 
-union TexMtxInfo {
+union TexMtxInfo
+{
   struct
   {
     u32 unknown : 1;
@@ -184,7 +187,8 @@ union TexMtxInfo {
   u32 hex;
 };
 
-union PostMtxInfo {
+union PostMtxInfo
+{
   struct
   {
     u32 index : 6;  // base row of dual transform matrix
@@ -194,7 +198,8 @@ union PostMtxInfo {
   u32 hex;
 };
 
-union NumColorChannel {
+union NumColorChannel
+{
   struct
   {
     u32 numColorChans : 2;
@@ -202,7 +207,8 @@ union NumColorChannel {
   u32 hex;
 };
 
-union NumTexGen {
+union NumTexGen
+{
   struct
   {
     u32 numTexGens : 4;
@@ -210,7 +216,8 @@ union NumTexGen {
   u32 hex;
 };
 
-union DualTexInfo {
+union DualTexInfo
+{
   struct
   {
     u32 enabled : 1;
@@ -225,7 +232,8 @@ struct Light
   float cosatt[3];   // cos attenuation
   float distatt[3];  // dist attenuation
 
-  union {
+  union
+  {
     struct
     {
       float dpos[3];

--- a/Source/UnitTests/Common/BitFieldTest.cpp
+++ b/Source/UnitTests/Common/BitFieldTest.cpp
@@ -7,7 +7,8 @@
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
 
-union TestUnion {
+union TestUnion
+{
   u64 hex;
 
   BitField<0, 64, u64> full_u64;  // spans whole storage


### PR DESCRIPTION
`BreakBeforeBraces: Allman` apparently includes all styles, _except_ for `AfterUnion` (which is `false`) when using `clang-format -dump-config` on our vanilla config.
I just copied over the differences and re-ran `clang-format` on the Source folder, so the majority of changes is `union` fixes that move the braces to the next line.

I couldn't find a matching bug on the LLVM bug tracker (yet), albeit there are a lot of related ones. And since registrations are closed, I cannot just go and report it. I'm trying to confirm with their IRC channel, but it seems a little preoccupied at this point.