### PR TITLE
IOS HLE: Refactor ExecuteCommand

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -2,23 +2,19 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-/*
-This is the main Wii IPC file that handles all incoming IPC calls and directs them
-to the right function.
-
-IPC basics (IOS' usage):
-
-Return values for file handles: All IPC calls will generate a return value to 0x04,
-in case of success they are
-  Open: DeviceID
-  Close: 0
-  Read: Bytes read
-  Write: Bytes written
-  Seek: Seek position
-  Ioctl: 0 (in addition to that there may be messages to the out buffers)
-  Ioctlv: 0 (in addition to that there may be messages to the out buffers)
-They will also generate a true or false return for UpdateInterrupts() in WII_IPC.cpp.
-*/
+// This is the main Wii IPC file that handles all incoming IPC requests and directs them
+// to the right function.
+//
+// IPC basics (IOS' usage):
+// All IPC request handlers will write a return value to 0x04.
+//   Open: Device file descriptor or error code
+//   Close: IPC_SUCCESS
+//   Read: Bytes read
+//   Write: Bytes written
+//   Seek: Seek position
+//   Ioctl: Depends on the handler
+//   Ioctlv: Depends on the handler
+// Replies may be sent immediately or asynchronously for ioctls and ioctlvs.
 
 #include <deque>
 #include <map>

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -68,8 +68,8 @@ static std::map<u32, std::shared_ptr<IWII_IPC_HLE_Device>> s_device_map;
 static std::mutex s_device_map_mutex;
 
 // STATE_TO_SAVE
-#define IPC_MAX_FDS 0x18
-#define ES_MAX_COUNT 2
+constexpr u8 IPC_MAX_FDS = 0x18;
+constexpr u8 ES_MAX_COUNT = 2;
 static std::shared_ptr<IWII_IPC_HLE_Device> s_fdmap[IPC_MAX_FDS];
 static std::shared_ptr<IWII_IPC_HLE_Device> s_es_handles[ES_MAX_COUNT];
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -62,8 +62,6 @@ void ES_DIVerify(const std::vector<u8>& tmd);
 
 void SDIO_EventNotify();
 
-std::shared_ptr<IWII_IPC_HLE_Device> CreateFileIO(u32 _DeviceID, const std::string& _rDeviceName);
-
 std::shared_ptr<IWII_IPC_HLE_Device> GetDeviceByName(const std::string& _rDeviceName);
 std::shared_ptr<IWII_IPC_HLE_Device> AccessDeviceByID(u32 _ID);
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 65;  // Last changed in PR 4120
+static const u32 STATE_VERSION = 66;  // Last changed in PR 4607
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
ExecuteCommand was becoming pretty confusing with unused variables for some commands, confusing names (device ID != IOS file descriptor), duplicated checks, not keeping the indentation level low, and having tons of things into a single function.

This commit gives more correct names to variables, deduplicates the device checking code, and splits some parts of ExecuteCommand out so that it's easier to read.

It's worth noting that some device checks have been forgotten in the past, which has caused a bug (which was recently fixed in 288e75f6).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4607)
<!-- Reviewable:end -->
