### PR TITLE
DolphinWX: Fix position of GameListCtrl tooltips on macOS

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -923,7 +923,7 @@ void CGameListCtrl::OnMouseMotion(wxMouseEvent& event)
       GetItemRect(item, Rect);
       int mx = Rect.GetWidth();
       int my = Rect.GetY();
-#ifndef __WXMSW__
+#if !defined(__WXMSW__) && !defined(__WXOSX__)
       // For some reason the y position does not account for the header
       // row, so subtract the y position of the first visible item.
       GetItemRect(GetTopItem(), Rect);


### PR DESCRIPTION
Fix for bug [10026](https://bugs.dolphin-emu.org/issues/10026):

> Referring to the list of games in the main window, and the tooltips on the "State" column. There are two (related) issues:
>
> 1) Currently, tooltips show up when the mouse enters the top half of the cell, and stay visible while the mouse is in the top half of the cell or the bottom half of the rowcellabove. If the mouse enters the bottom half of the cell, the tooltip will appear and then immediately disappear (a "flicker" effect). The expected behavior is for a tool tip to show up and stay visible when the mouse is anywhere in the cell.
>
> 2) The tooltip blocks the star rating of the game's emulation state. The expected behavior is to show up slightly below the star rating, so the user knows what the comments (ex. "^ Playable: Disable anti-aliasing to avoid overbloom") are referring to.

Before this patch:

![bad](https://cloud.githubusercontent.com/assets/594093/21747613/37c0cf90-d521-11e6-81b1-9b21a53ad752.gif)

After this patch:

![good](https://cloud.githubusercontent.com/assets/594093/21747614/385228f0-d521-11e6-9dc8-e74b8a09e091.gif)

