### PR TITLE
HotkeyInputConfigDialog: Move UI creation into named functions

### DIFF
--- a/Source/Core/DolphinWX/Input/HotkeyInputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/HotkeyInputConfigDiag.cpp
@@ -9,225 +9,273 @@
 #include "Core/HotkeyManager.h"
 #include "DolphinWX/Input/HotkeyInputConfigDiag.h"
 
-enum HotkeyGroup : int;
-
 HotkeyInputConfigDialog::HotkeyInputConfigDialog(wxWindow* parent, InputConfig& config,
                                                  const wxString& name, bool using_debugger,
                                                  int port_num)
-    : InputConfigDialog(parent, config, name, port_num)
+    : InputConfigDialog(parent, config, name, port_num), m_using_debugger{using_debugger}
 {
-  const int space5 = FromDIP(5);
-
-  auto* const device_chooser = CreateDeviceChooserGroupBox();
-  auto* const reset_sizer = CreaterResetGroupBox(wxVERTICAL);
-  auto* const profile_chooser = CreateProfileChooserGroupBox();
-
-  auto* const notebook = new wxNotebook(this, wxID_ANY);
-
-  // General
-  auto* const tab_general = new wxPanel(notebook);
-
-  auto* const group_box_general =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_GENERAL), tab_general, this);
-  auto* const group_box_volume =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_VOLUME), tab_general, this);
-  auto* const group_box_speed =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_SPEED), tab_general, this);
-
-  auto* const szr_volume_speed = new wxBoxSizer(wxVERTICAL);
-  szr_volume_speed->AddSpacer(space5);
-  szr_volume_speed->Add(group_box_volume, 0, wxEXPAND);
-  szr_volume_speed->AddSpacer(space5);
-  szr_volume_speed->Add(group_box_speed, 0, wxEXPAND);
-
-  auto* const szr_general = new wxBoxSizer(wxHORIZONTAL);
-  szr_general->Add(group_box_general, 0, wxEXPAND | wxTOP, space5);
-  szr_general->AddSpacer(space5);
-  szr_general->Add(szr_volume_speed, 0, wxEXPAND);
-
-  tab_general->SetSizerAndFit(szr_general);
-
-  notebook->AddPage(tab_general, _("General"));
-
-  // TAS Tools
-  auto* const tab_tas = new wxPanel(notebook);
-
-  auto* const group_box_frame_advance =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_FRAME_ADVANCE), tab_tas, this);
-  auto* const group_box_movie =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_MOVIE), tab_tas, this);
-
-  auto* const szr_tas = new wxBoxSizer(wxHORIZONTAL);
-  szr_tas->AddSpacer(space5);
-  szr_tas->Add(group_box_frame_advance, 0, wxEXPAND | wxTOP, space5);
-  szr_tas->AddSpacer(space5);
-  szr_tas->Add(group_box_movie, 0, wxEXPAND | wxTOP, space5);
-
-  tab_tas->SetSizerAndFit(szr_tas);
-
-  // i18n: TAS is short for tool-assisted speedrun. Read http://tasvideos.org/ for details.
-  // Frame advance is an example of a typical TAS tool.
-  notebook->AddPage(tab_tas, _("TAS Tools"));
-
-  if (using_debugger)
-  {
-    // Debugging
-    auto* const tab_debugging = new wxPanel(notebook);
-
-    auto* const group_box_steping =
-        new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_STEPPING), tab_debugging, this);
-    auto* const group_box_pc =
-        new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_PC), tab_debugging, this);
-    auto* const group_box_breakpoint =
-        new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_BREAKPOINT), tab_debugging, this);
-
-    auto* const szr_debugging = new wxBoxSizer(wxHORIZONTAL);
-    szr_debugging->AddSpacer(space5);
-    szr_debugging->Add(group_box_steping, 0, wxEXPAND | wxTOP, space5);
-    szr_debugging->AddSpacer(space5);
-    szr_debugging->Add(group_box_pc, 0, wxEXPAND | wxTOP, space5);
-    szr_debugging->AddSpacer(space5);
-    szr_debugging->Add(group_box_breakpoint, 0, wxEXPAND | wxTOP, space5);
-    szr_debugging->AddSpacer(space5);
-
-    tab_debugging->SetSizerAndFit(szr_debugging);
-
-    notebook->AddPage(tab_debugging, _("Debugging"));
-  }
-  // WII and Wii Remote
-  auto* const tab_wii = new wxPanel(notebook);
-
-  auto* const group_box_wii =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_WII), tab_wii, this);
-
-  auto* const szr_wii = new wxBoxSizer(wxHORIZONTAL);
-  szr_wii->AddSpacer(space5);
-  szr_wii->Add(group_box_wii, 0, wxEXPAND | wxTOP, space5);
-  szr_wii->AddSpacer(space5);
-
-  tab_wii->SetSizerAndFit(szr_wii);
-
-  notebook->AddPage(tab_wii, _("Wii and Wii Remote"));
-
-  // Graphics
-  auto* const tab_graphics = new wxPanel(notebook);
-
-  auto* const group_box_graphics_toggles = new ControlGroupBox(
-      HotkeyManagerEmu::GetHotkeyGroup(HKGP_GRAPHICS_TOGGLES), tab_graphics, this);
-  auto* const group_box_ir =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_IR), tab_graphics, this);
-
-  auto* const szr_toggle_ir = new wxBoxSizer(wxVERTICAL);
-  szr_toggle_ir->Add(group_box_graphics_toggles, 0, wxEXPAND);
-  szr_toggle_ir->AddSpacer(space5);
-  szr_toggle_ir->Add(group_box_ir, 0, wxEXPAND);
-
-  auto* const group_box_freelook =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_FREELOOK), tab_graphics, this);
-
-  auto* const szr_graphics_toggles = new wxBoxSizer(wxHORIZONTAL);
-  szr_graphics_toggles->AddSpacer(space5);
-  szr_graphics_toggles->Add(szr_toggle_ir, 0, wxEXPAND | wxTOP, space5);
-  szr_graphics_toggles->AddSpacer(space5);
-  szr_graphics_toggles->Add(group_box_freelook, 0, wxEXPAND | wxTOP, space5);
-  szr_graphics_toggles->AddSpacer(space5);
-
-  tab_graphics->SetSizerAndFit(szr_graphics_toggles);
-
-  notebook->AddPage(tab_graphics, _("Graphics"));
-
-  // 3D
-  auto* const tab_3D = new wxPanel(notebook);
-
-  auto* const group_box_3D_toggles =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_3D_TOGGLE), tab_3D, this);
-  auto* const group_box_3D_depth =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_3D_DEPTH), tab_3D, this);
-
-  auto* const szr_3D = new wxBoxSizer(wxHORIZONTAL);
-  szr_3D->AddSpacer(space5);
-  szr_3D->Add(group_box_3D_toggles, 0, wxEXPAND | wxTOP, space5);
-  szr_3D->AddSpacer(space5);
-  szr_3D->Add(group_box_3D_depth, 0, wxEXPAND | wxTOP, space5);
-  szr_3D->AddSpacer(space5);
-
-  tab_3D->SetSizerAndFit(szr_3D);
-
-  // i18n: Stereoscopic 3D
-  notebook->AddPage(tab_3D, _("3D"));
-
-  // Save and Load State
-  auto* const tab_save_load_state = new wxPanel(notebook);
-
-  auto* const group_box_load_state = new ControlGroupBox(
-      HotkeyManagerEmu::GetHotkeyGroup(HKGP_LOAD_STATE), tab_save_load_state, this);
-  auto* const group_box_save_state = new ControlGroupBox(
-      HotkeyManagerEmu::GetHotkeyGroup(HKGP_SAVE_STATE), tab_save_load_state, this);
-
-  auto* const szr_save_load_state = new wxBoxSizer(wxHORIZONTAL);
-  szr_save_load_state->AddSpacer(space5);
-  szr_save_load_state->Add(group_box_load_state, 0, wxEXPAND | wxTOP, space5);
-  szr_save_load_state->AddSpacer(space5);
-  szr_save_load_state->Add(group_box_save_state, 0, wxEXPAND | wxTOP, space5);
-  szr_save_load_state->AddSpacer(space5);
-
-  tab_save_load_state->SetSizerAndFit(szr_save_load_state);
-
-  notebook->AddPage(tab_save_load_state, _("Save and Load State"));
-
-  // Other State Managament
-  auto* const tab_other_state = new wxPanel(notebook);
-
-  auto* const group_box_select_state = new ControlGroupBox(
-      HotkeyManagerEmu::GetHotkeyGroup(HKGP_SELECT_STATE), tab_other_state, this);
-  auto* const group_box_load_last_state = new ControlGroupBox(
-      HotkeyManagerEmu::GetHotkeyGroup(HKGP_LOAD_LAST_STATE), tab_other_state, this);
-  auto* const group_box_state_misc =
-      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_STATE_MISC), tab_other_state, this);
-
-  auto* const szr_other_state = new wxBoxSizer(wxHORIZONTAL);
-  szr_other_state->AddSpacer(space5);
-  szr_other_state->Add(group_box_select_state, 0, wxEXPAND | wxTOP, space5);
-  szr_other_state->AddSpacer(space5);
-  szr_other_state->Add(group_box_load_last_state, 0, wxEXPAND | wxTOP, space5);
-  szr_other_state->AddSpacer(space5);
-  szr_other_state->Add(group_box_state_misc, 0, wxEXPAND | wxTOP, space5);
-  szr_other_state->AddSpacer(space5);
-
-  tab_other_state->SetSizerAndFit(szr_other_state);
-
-  notebook->AddPage(tab_other_state, _("Other State Management"));
-
-  notebook->SetSelection(0);
-
-  auto* const device_profile_sizer = new wxBoxSizer(wxVERTICAL);
-  device_profile_sizer->Add(device_chooser, 1, wxEXPAND);
-  device_profile_sizer->Add(profile_chooser, 1, wxEXPAND);
-
-  auto* const group_box_options =
-      new ControlGroupBox(HotkeyManagerEmu::GetOptionsGroup(), this, this);
-
-  auto* const dio = new wxBoxSizer(wxHORIZONTAL);
-  dio->AddSpacer(space5);
-  dio->Add(device_profile_sizer, 3, wxEXPAND);
-  dio->Add(reset_sizer, 0, wxEXPAND);
-  dio->Add(group_box_options, 1, wxEXPAND);
-  dio->AddSpacer(space5);
-
-  auto* const szr_main = new wxBoxSizer(wxVERTICAL);
-  szr_main->AddSpacer(space5);
-  szr_main->Add(dio);
-  szr_main->AddSpacer(space5);
-  szr_main->Add(notebook, 1, wxEXPAND | wxLEFT | wxRIGHT, space5);
-  szr_main->AddSpacer(space5);
-  szr_main->Add(CreateButtonSizer(wxCLOSE | wxNO_DEFAULT), 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
-  szr_main->AddSpacer(space5);
-
-  SetSizerAndFit(szr_main);
+  InitializeNotebook();
+  SetSizerAndFit(CreateMainSizer());
   Center();
 
   UpdateDeviceComboBox();
   UpdateProfileComboBox();
 
   UpdateGUI();
+}
+
+wxBoxSizer* HotkeyInputConfigDialog::CreateMainSizer()
+{
+  const int space5 = FromDIP(5);
+  auto* const main_sizer = new wxBoxSizer(wxVERTICAL);
+
+  main_sizer->AddSpacer(space5);
+  main_sizer->Add(CreateDeviceRelatedSizer());
+  main_sizer->AddSpacer(space5);
+  main_sizer->Add(m_notebook, 1, wxEXPAND | wxLEFT | wxRIGHT, space5);
+  main_sizer->AddSpacer(space5);
+  main_sizer->Add(CreateButtonSizer(wxCLOSE | wxNO_DEFAULT), 0, wxEXPAND | wxLEFT | wxRIGHT,
+                  space5);
+  main_sizer->AddSpacer(space5);
+
+  return main_sizer;
+}
+
+wxBoxSizer* HotkeyInputConfigDialog::CreateDeviceRelatedSizer()
+{
+  const int space5 = FromDIP(5);
+  auto* const enclosing_sizer = new wxBoxSizer(wxHORIZONTAL);
+  auto* const reset_sizer = CreaterResetGroupBox(wxVERTICAL);
+  auto* const options_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetOptionsGroup(), this, this);
+
+  enclosing_sizer->AddSpacer(space5);
+  enclosing_sizer->Add(CreateDeviceProfileSizer(), 3, wxEXPAND);
+  enclosing_sizer->Add(reset_sizer, 0, wxEXPAND);
+  enclosing_sizer->Add(options_group_box, 1, wxEXPAND);
+  enclosing_sizer->AddSpacer(space5);
+
+  return enclosing_sizer;
+}
+
+wxBoxSizer* HotkeyInputConfigDialog::CreateDeviceProfileSizer()
+{
+  auto* const device_chooser = CreateDeviceChooserGroupBox();
+  auto* const profile_chooser = CreateProfileChooserGroupBox();
+
+  auto* const device_profile_sizer = new wxBoxSizer(wxVERTICAL);
+  device_profile_sizer->Add(device_chooser, 1, wxEXPAND);
+  device_profile_sizer->Add(profile_chooser, 1, wxEXPAND);
+
+  return device_profile_sizer;
+}
+
+void HotkeyInputConfigDialog::InitializeNotebook()
+{
+  m_notebook = new wxNotebook(this, wxID_ANY);
+  m_notebook->AddPage(CreateGeneralPanel(), _("General"));
+
+  // i18n: TAS is short for tool-assisted speedrun. Read http://tasvideos.org/ for details.
+  // Frame advance is an example of a typical TAS tool.
+  m_notebook->AddPage(CreateTASToolsPanel(), _("TAS Tools"));
+
+  if (m_using_debugger)
+  {
+    m_notebook->AddPage(CreateDebuggingPanel(), _("Debugging"));
+  }
+
+  m_notebook->AddPage(CreateWiiPanel(), _("Wii and Wii Remote"));
+  m_notebook->AddPage(CreateGraphicsPanel(), _("Graphics"));
+
+  // i18n: Stereoscopic 3D
+  m_notebook->AddPage(CreateStereoscopic3DPanel(), _("3D"));
+  m_notebook->AddPage(CreateSaveAndLoadStatePanel(), _("Save and Load State"));
+  m_notebook->AddPage(CreateOtherStateManagementPanel(), _("Other State Management"));
+
+  m_notebook->SetSelection(0);
+}
+
+wxPanel* HotkeyInputConfigDialog::CreateGeneralPanel()
+{
+  const int space5 = FromDIP(5);
+  auto* const general_panel = new wxPanel(m_notebook);
+
+  auto* const general_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_GENERAL), general_panel, this);
+  auto* const volume_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_VOLUME), general_panel, this);
+  auto* const speed_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_SPEED), general_panel, this);
+
+  auto* const volume_speed_sizer = new wxBoxSizer(wxVERTICAL);
+  volume_speed_sizer->AddSpacer(space5);
+  volume_speed_sizer->Add(volume_group_box, 0, wxEXPAND);
+  volume_speed_sizer->AddSpacer(space5);
+  volume_speed_sizer->Add(speed_group_box, 0, wxEXPAND);
+
+  auto* const general_sizer = new wxBoxSizer(wxHORIZONTAL);
+  general_sizer->Add(general_group_box, 0, wxEXPAND | wxTOP, space5);
+  general_sizer->AddSpacer(space5);
+  general_sizer->Add(volume_speed_sizer, 0, wxEXPAND);
+
+  general_panel->SetSizerAndFit(general_sizer);
+  return general_panel;
+}
+
+wxPanel* HotkeyInputConfigDialog::CreateTASToolsPanel()
+{
+  const int space5 = FromDIP(5);
+  auto* const tas_panel = new wxPanel(m_notebook);
+
+  auto* const frame_advance_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_FRAME_ADVANCE), tas_panel, this);
+  auto* const movie_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_MOVIE), tas_panel, this);
+
+  auto* const tas_sizer = new wxBoxSizer(wxHORIZONTAL);
+  tas_sizer->AddSpacer(space5);
+  tas_sizer->Add(frame_advance_group_box, 0, wxEXPAND | wxTOP, space5);
+  tas_sizer->AddSpacer(space5);
+  tas_sizer->Add(movie_group_box, 0, wxEXPAND | wxTOP, space5);
+
+  tas_panel->SetSizerAndFit(tas_sizer);
+  return tas_panel;
+}
+
+wxPanel* HotkeyInputConfigDialog::CreateDebuggingPanel()
+{
+  const int space5 = FromDIP(5);
+  auto* const debugging_panel = new wxPanel(m_notebook);
+
+  auto* const stepping_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_STEPPING), debugging_panel, this);
+  auto* const pc_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_PC), debugging_panel, this);
+  auto* const breakpoint_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_BREAKPOINT), debugging_panel, this);
+
+  auto* const debugging_sizer = new wxBoxSizer(wxHORIZONTAL);
+  debugging_sizer->AddSpacer(space5);
+  debugging_sizer->Add(stepping_group_box, 0, wxEXPAND | wxTOP, space5);
+  debugging_sizer->AddSpacer(space5);
+  debugging_sizer->Add(pc_group_box, 0, wxEXPAND | wxTOP, space5);
+  debugging_sizer->AddSpacer(space5);
+  debugging_sizer->Add(breakpoint_group_box, 0, wxEXPAND | wxTOP, space5);
+  debugging_sizer->AddSpacer(space5);
+
+  debugging_panel->SetSizerAndFit(debugging_sizer);
+  return debugging_panel;
+}
+
+wxPanel* HotkeyInputConfigDialog::CreateWiiPanel()
+{
+  const int space5 = FromDIP(5);
+  auto* const wii_panel = new wxPanel(m_notebook);
+
+  auto* const wii_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_WII), wii_panel, this);
+
+  auto* const wii_sizer = new wxBoxSizer(wxHORIZONTAL);
+  wii_sizer->AddSpacer(space5);
+  wii_sizer->Add(wii_group_box, 0, wxEXPAND | wxTOP, space5);
+  wii_sizer->AddSpacer(space5);
+
+  wii_panel->SetSizerAndFit(wii_sizer);
+  return wii_panel;
+}
+
+wxPanel* HotkeyInputConfigDialog::CreateGraphicsPanel()
+{
+  const int space5 = FromDIP(5);
+  auto* const graphics_panel = new wxPanel(m_notebook);
+
+  auto* const graphics_toggles_group_box = new ControlGroupBox(
+      HotkeyManagerEmu::GetHotkeyGroup(HKGP_GRAPHICS_TOGGLES), graphics_panel, this);
+  auto* const ir_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_IR), graphics_panel, this);
+
+  auto* const ir_sizer = new wxBoxSizer(wxVERTICAL);
+  ir_sizer->Add(graphics_toggles_group_box, 0, wxEXPAND);
+  ir_sizer->AddSpacer(space5);
+  ir_sizer->Add(ir_group_box, 0, wxEXPAND);
+
+  auto* const freelook_group_box =
+      new ControlGroupBox(HotkeyManagerEmu::GetHotkeyGroup(HKGP_FREELOOK), graphics_panel, this);
+
+  auto* const szr_graphics_toggles = new wxBoxSizer(wxHORIZONTAL);
+  szr_graphics_toggles->AddSpacer(space5);
+  szr_graphics_toggles->Add(ir_sizer, 0, wxEXPAND | wxTOP, space5);
+  szr_graphics_toggles->AddSpacer(space5);
+  szr_graphics_toggles->Add(freelook_group_box, 0, wxEXPAND | wxTOP, space5);
+  szr_graphics_toggles->AddSpacer(space5);
+
+  graphics_panel->SetSizerAndFit(szr_graphics_toggles);
+  return graphics_panel;
+}
+
+wxPanel* HotkeyInputConfigDialog::CreateStereoscopic3DPanel()
+{
+  const int space5 = FromDIP(5);
+  auto* const stereoscopic_panel = new wxPanel(m_notebook);
+
+  auto* const stereoscopic_toggles_group_box = new ControlGroupBox(
+      HotkeyManagerEmu::GetHotkeyGroup(HKGP_3D_TOGGLE), stereoscopic_panel, this);
+  auto* const stereoscopic_depth_group_box = new ControlGroupBox(
+      HotkeyManagerEmu::GetHotkeyGroup(HKGP_3D_DEPTH), stereoscopic_panel, this);
+
+  auto* const stereoscopic_sizer = new wxBoxSizer(wxHORIZONTAL);
+  stereoscopic_sizer->AddSpacer(space5);
+  stereoscopic_sizer->Add(stereoscopic_toggles_group_box, 0, wxEXPAND | wxTOP, space5);
+  stereoscopic_sizer->AddSpacer(space5);
+  stereoscopic_sizer->Add(stereoscopic_depth_group_box, 0, wxEXPAND | wxTOP, space5);
+  stereoscopic_sizer->AddSpacer(space5);
+
+  stereoscopic_panel->SetSizerAndFit(stereoscopic_sizer);
+  return stereoscopic_panel;
+}
+
+wxPanel* HotkeyInputConfigDialog::CreateSaveAndLoadStatePanel()
+{
+  const int space5 = FromDIP(5);
+  auto* const save_load_state_panel = new wxPanel(m_notebook);
+
+  auto* const load_state_group_box = new ControlGroupBox(
+      HotkeyManagerEmu::GetHotkeyGroup(HKGP_LOAD_STATE), save_load_state_panel, this);
+  auto* const save_state_group_box = new ControlGroupBox(
+      HotkeyManagerEmu::GetHotkeyGroup(HKGP_SAVE_STATE), save_load_state_panel, this);
+
+  auto* const save_load_state_sizer = new wxBoxSizer(wxHORIZONTAL);
+  save_load_state_sizer->AddSpacer(space5);
+  save_load_state_sizer->Add(load_state_group_box, 0, wxEXPAND | wxTOP, space5);
+  save_load_state_sizer->AddSpacer(space5);
+  save_load_state_sizer->Add(save_state_group_box, 0, wxEXPAND | wxTOP, space5);
+  save_load_state_sizer->AddSpacer(space5);
+
+  save_load_state_panel->SetSizerAndFit(save_load_state_sizer);
+  return save_load_state_panel;
+}
+
+wxPanel* HotkeyInputConfigDialog::CreateOtherStateManagementPanel()
+{
+  const int space5 = FromDIP(5);
+  auto* const other_state_panel = new wxPanel(m_notebook);
+
+  auto* const group_box_select_state = new ControlGroupBox(
+      HotkeyManagerEmu::GetHotkeyGroup(HKGP_SELECT_STATE), other_state_panel, this);
+  auto* const group_box_load_last_state = new ControlGroupBox(
+      HotkeyManagerEmu::GetHotkeyGroup(HKGP_LOAD_LAST_STATE), other_state_panel, this);
+  auto* const group_box_state_misc = new ControlGroupBox(
+      HotkeyManagerEmu::GetHotkeyGroup(HKGP_STATE_MISC), other_state_panel, this);
+
+  auto* const other_state_sizer = new wxBoxSizer(wxHORIZONTAL);
+  other_state_sizer->AddSpacer(space5);
+  other_state_sizer->Add(group_box_select_state, 0, wxEXPAND | wxTOP, space5);
+  other_state_sizer->AddSpacer(space5);
+  other_state_sizer->Add(group_box_load_last_state, 0, wxEXPAND | wxTOP, space5);
+  other_state_sizer->AddSpacer(space5);
+  other_state_sizer->Add(group_box_state_misc, 0, wxEXPAND | wxTOP, space5);
+  other_state_sizer->AddSpacer(space5);
+
+  other_state_panel->SetSizerAndFit(other_state_sizer);
+  return other_state_panel;
 }

--- a/Source/Core/DolphinWX/Input/HotkeyInputConfigDiag.h
+++ b/Source/Core/DolphinWX/Input/HotkeyInputConfigDiag.h
@@ -6,9 +6,31 @@
 
 #include "DolphinWX/Input/InputConfigDiag.h"
 
+class wxBoxSizer;
+class wxNotebook;
+class wxPanel;
+
 class HotkeyInputConfigDialog final : public InputConfigDialog
 {
 public:
   HotkeyInputConfigDialog(wxWindow* parent, InputConfig& config, const wxString& name,
                           bool using_debugger, int port_num = 0);
+
+private:
+  wxBoxSizer* CreateMainSizer();
+  wxBoxSizer* CreateDeviceRelatedSizer();
+  wxBoxSizer* CreateDeviceProfileSizer();
+
+  void InitializeNotebook();
+  wxPanel* CreateGeneralPanel();
+  wxPanel* CreateTASToolsPanel();
+  wxPanel* CreateDebuggingPanel();
+  wxPanel* CreateWiiPanel();
+  wxPanel* CreateGraphicsPanel();
+  wxPanel* CreateStereoscopic3DPanel();
+  wxPanel* CreateSaveAndLoadStatePanel();
+  wxPanel* CreateOtherStateManagementPanel();
+
+  wxNotebook* m_notebook;
+  bool m_using_debugger;
 };


### PR DESCRIPTION
The constructor shouldn't be used as a dumping ground for all UI-related initialization. Doing so makes it somewhat more difficult to reason about how certain UI elements get created. It also puts unrelated identifiers in the same scope.

This separates the UI creation out so code relevant to each component is self-contained.