### PR TITLE
[Video] Warn when booting a bounding box game on an unsupported GPU

### DIFF
--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -120,15 +120,23 @@ u32 VideoBackendBase::Video_GetQueryResult(PerfQueryType type)
 
 u16 VideoBackendBase::Video_GetBoundingBox(int index)
 {
-  if (!g_ActiveConfig.backend_info.bSupportsBBox)
-    return 0;
-
   if (!g_ActiveConfig.bBBoxEnable)
   {
     static bool warn_once = true;
     if (warn_once)
       ERROR_LOG(VIDEO, "BBox shall be used but it is disabled. Please use a gameini to enable it "
                        "for this game.");
+    warn_once = false;
+    return 0;
+  }
+
+  if (!g_ActiveConfig.backend_info.bSupportsBBox)
+  {
+    static bool warn_once = true;
+    if (warn_once)
+      PanicAlertT("This game requires bounding box emulation to run properly but your graphics "
+                  "card or its drivers do not support it. As a result you will experience bugs or "
+                  "freezes while running this game.");
     warn_once = false;
     return 0;
   }


### PR DESCRIPTION
We get a lot of support requests from users not knowing why bounding box games aren't working for them on GPUs where bounding box emulation isn't supported. This hopefully cuts down on that.

I did not use an OSD message as those can't be localized and nobody reads OSD (I don't lololol)