### PR TITLE
Change "Configure" to "Configuration" in Menu

### DIFF
--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -167,7 +167,7 @@ wxMenu* MainMenuBar::CreateMovieMenu() const
 wxMenu* MainMenuBar::CreateOptionsMenu() const
 {
   auto* const options_menu = new wxMenu;
-  options_menu->Append(wxID_PREFERENCES, _("Co&nfigure..."));
+  options_menu->Append(wxID_PREFERENCES, _("Co&nfiguration"));
   options_menu->AppendSeparator();
   options_menu->Append(IDM_CONFIG_GFX_BACKEND, _("&Graphics Settings"));
   options_menu->Append(IDM_CONFIG_AUDIO, _("&Audio Settings"));


### PR DESCRIPTION
Other settings options are nouns rather than verbs so this change makes the configuration option consistent with the rest. Also makes the menu label the same as the window title.