### PR TITLE
IOS HLE: Remove unneeded code

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -426,6 +426,8 @@ static IPCCommandResult HandleCommand(const u32 address)
   {
   case IPC_CMD_CLOSE:
     s_fdmap[fd].reset();
+    // A close on a valid device returns FS_SUCCESS.
+    Memory::Write_U32(FS_SUCCESS, address + 4);
     return device->Close(address);
   case IPC_CMD_READ:
     return device->Read(address);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
@@ -68,17 +68,12 @@ void IWII_IPC_HLE_Device::DoStateShared(PointerWrap& p)
 
 IPCCommandResult IWII_IPC_HLE_Device::Open(u32 command_address, u32 mode)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Open()", m_Name.c_str());
-  Memory::Write_U32(FS_ENOENT, command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Close(u32 command_address, bool force)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Close()", m_Name.c_str());
-  if (!force)
-    Memory::Write_U32(FS_EINVAL, command_address + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -34,7 +34,6 @@ void CWII_IPC_HLE_Device_di::DoState(PointerWrap& p)
 
 IPCCommandResult CWII_IPC_HLE_Device_di::Open(u32 _CommandAddress, u32 _Mode)
 {
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -32,20 +32,6 @@ void CWII_IPC_HLE_Device_di::DoState(PointerWrap& p)
   p.Do(m_commands_to_execute);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_di::Open(u32 _CommandAddress, u32 _Mode)
-{
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_di::Close(u32 _CommandAddress, bool _bForce)
-{
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
 {
   // DI IOCtls are handled in a special way by Dolphin

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
@@ -27,9 +27,6 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -198,8 +198,6 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce
   m_AccessIdentID = 0x6000000;
 
   INFO_LOG(WII_IPC_ES, "ES: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
   m_Active = false;
   // clear the NAND content cache to make sure nothing remains open.
   DiscIO::CNANDContentManager::Access().ClearCache();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -184,7 +184,6 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Open(u32 _CommandAddress, u32 _Mode)
 {
   OpenInternal();
 
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   if (m_Active)
     INFO_LOG(WII_IPC_ES, "Device was re-opened.");
   m_Active = true;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -52,7 +52,6 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::Open(u32 _CommandAddress, u32 _Mode)
     File::CreateDir(Path);
   }
 
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetFSReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -56,15 +56,6 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::Open(u32 _CommandAddress, u32 _Mode)
   return GetFSReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_fs::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_FILEIO, "Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetFSReply();
-}
-
 // Get total filesize of contents of a directory (recursive)
 // Only used for ES_GetUsage atm, could be useful elsewhere?
 static u64 ComputeTotalFileSize(const File::FSTEntry& parentEntry)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -44,7 +44,6 @@ public:
   void DoState(PointerWrap& p) override;
 
   IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -104,22 +104,6 @@ CWII_IPC_HLE_Device_hid::~CWII_IPC_HLE_Device_hid()
     libusb_exit(nullptr);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_hid::Open(u32 _CommandAddress, u32 _Mode)
-{
-  INFO_LOG(WII_IPC_HID, "HID::Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_hid::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_HID, "HID::Close");
-  m_Active = false;
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 {
   if (Core::g_want_determinism)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -10,6 +10,7 @@
 
 #include <libusb.h>
 
+#include "Common/Align.h"
 #include "Common/CommonFuncs.h"
 #include "Common/Logging/Log.h"
 #include "Core/Core.h"
@@ -373,8 +374,8 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 
     WiiHIDDeviceDescriptor wii_device;
     ConvertDeviceToWii(&wii_device, &desc);
-    Memory::CopyToEmu(OffsetBuffer, &wii_device, Align(wii_device.bLength, 4));
-    OffsetBuffer += Align(wii_device.bLength, 4);
+    Memory::CopyToEmu(OffsetBuffer, &wii_device, wii_device.bLength);
+    OffsetBuffer += Common::AlignUp(wii_device.bLength, 4);
     bool deviceValid = true;
     bool isHID = false;
 
@@ -387,8 +388,8 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
       {
         WiiHIDConfigDescriptor wii_config;
         ConvertConfigToWii(&wii_config, config);
-        Memory::CopyToEmu(OffsetBuffer, &wii_config, Align(wii_config.bLength, 4));
-        OffsetBuffer += Align(wii_config.bLength, 4);
+        Memory::CopyToEmu(OffsetBuffer, &wii_config, wii_config.bLength);
+        OffsetBuffer += Common::AlignUp(wii_config.bLength, 4);
 
         for (ic = 0; ic < config->bNumInterfaces; ic++)
         {
@@ -404,8 +405,8 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 
             WiiHIDInterfaceDescriptor wii_interface;
             ConvertInterfaceToWii(&wii_interface, interface);
-            Memory::CopyToEmu(OffsetBuffer, &wii_interface, Align(wii_interface.bLength, 4));
-            OffsetBuffer += Align(wii_interface.bLength, 4);
+            Memory::CopyToEmu(OffsetBuffer, &wii_interface, wii_interface.bLength);
+            OffsetBuffer += Common::AlignUp(wii_interface.bLength, 4);
 
             for (e = 0; e < interface->bNumEndpoints; e++)
             {
@@ -413,8 +414,8 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
 
               WiiHIDEndpointDescriptor wii_endpoint;
               ConvertEndpointToWii(&wii_endpoint, endpoint);
-              Memory::CopyToEmu(OffsetBuffer, &wii_endpoint, Align(wii_endpoint.bLength, 4));
-              OffsetBuffer += Align(wii_endpoint.bLength, 4);
+              Memory::CopyToEmu(OffsetBuffer, &wii_endpoint, wii_endpoint.bLength);
+              OffsetBuffer += Common::AlignUp(wii_endpoint.bLength, 4);
 
             }  // endpoints
           }    // interfaces
@@ -481,11 +482,6 @@ void CWII_IPC_HLE_Device_hid::FillOutDevices(u32 BufferOut, u32 BufferOutSize)
   libusb_free_device_list(list, 1);
 
   Memory::Write_U32(0xFFFFFFFF, OffsetBuffer);  // no more devices
-}
-
-int CWII_IPC_HLE_Device_hid::Align(int num, int alignment)
-{
-  return (num + (alignment - 1)) & ~(alignment - 1);
 }
 
 libusb_device_handle* CWII_IPC_HLE_Device_hid::GetDeviceByDevNum(u32 devNum)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -108,7 +108,6 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::Open(u32 _CommandAddress, u32 _Mode)
 {
   INFO_LOG(WII_IPC_HID, "HID::Open");
   m_Active = true;
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -127,7 +127,6 @@ private:
                              const libusb_interface_descriptor* src);
   void ConvertEndpointToWii(WiiHIDEndpointDescriptor* dest, const libusb_endpoint_descriptor* src);
 
-  int Align(int num, int alignment);
   static void checkUsbUpdates(CWII_IPC_HLE_Device_hid* hid);
   static void LIBUSB_CALL handleUsbUpdates(libusb_transfer* transfer);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -40,9 +40,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_hid();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -75,7 +75,6 @@ CWII_IPC_HLE_Device_net_kd_request::~CWII_IPC_HLE_Device_net_kd_request()
 IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Open(u32 _CommandAddress, u32 _Mode)
 {
   INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: Open");
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }
@@ -357,7 +356,6 @@ CWII_IPC_HLE_Device_net_ncd_manage::~CWII_IPC_HLE_Device_net_ncd_manage()
 IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Open(u32 _CommandAddress, u32 _Mode)
 {
   INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: Open");
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }
@@ -456,7 +454,6 @@ CWII_IPC_HLE_Device_net_wd_command::~CWII_IPC_HLE_Device_net_wd_command()
 IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Open(u32 CommandAddress, u32 Mode)
 {
   INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND: Open");
-  Memory::Write_U32(GetDeviceID(), CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }
@@ -585,7 +582,6 @@ CWII_IPC_HLE_Device_net_ip_top::~CWII_IPC_HLE_Device_net_ip_top()
 IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Open(u32 _CommandAddress, u32 _Mode)
 {
   INFO_LOG(WII_IPC_NET, "NET_IP_TOP: Open");
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -72,22 +72,6 @@ CWII_IPC_HLE_Device_net_kd_request::~CWII_IPC_HLE_Device_net_kd_request()
   WiiSockMan::GetInstance().Clean();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Open(u32 _CommandAddress, u32 _Mode)
-{
-  INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 {
   u32 Parameter = Memory::Read_U32(_CommandAddress + 0xC);
@@ -353,22 +337,6 @@ CWII_IPC_HLE_Device_net_ncd_manage::~CWII_IPC_HLE_Device_net_ncd_manage()
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Open(u32 _CommandAddress, u32 _Mode)
-{
-  INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
 {
   u32 return_value = 0;
@@ -449,22 +417,6 @@ CWII_IPC_HLE_Device_net_wd_command::CWII_IPC_HLE_Device_net_wd_command(
 
 CWII_IPC_HLE_Device_net_wd_command::~CWII_IPC_HLE_Device_net_wd_command()
 {
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Open(u32 CommandAddress, u32 Mode)
-{
-  INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::Close(u32 CommandAddress, bool Force)
-{
-  INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND: Close");
-  if (!Force)
-    Memory::Write_U32(0, CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
 }
 
 // This is just for debugging / playing around.
@@ -577,22 +529,6 @@ CWII_IPC_HLE_Device_net_ip_top::~CWII_IPC_HLE_Device_net_ip_top()
 #ifdef _WIN32
   WSACleanup();
 #endif
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Open(u32 _CommandAddress, u32 _Mode)
-{
-  INFO_LOG(WII_IPC_NET, "NET_IP_TOP: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::Close(u32 _CommandAddress, bool _bForce)
-{
-  INFO_LOG(WII_IPC_NET, "NET_IP_TOP: Close");
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
-  m_Active = false;
-  return GetDefaultReply();
 }
 
 static int inet_pton(const char* src, unsigned char* dst)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -91,7 +91,6 @@ public:
   IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override
   {
     INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Open");
-    Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
     return GetDefaultReply();
   }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -30,8 +30,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_kd_request();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
 
 private:
@@ -88,20 +86,6 @@ public:
   }
 
   virtual ~CWII_IPC_HLE_Device_net_kd_time() {}
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override
-  {
-    INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Open");
-    return GetDefaultReply();
-  }
-
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override
-  {
-    INFO_LOG(WII_IPC_NET, "NET_KD_TIME: Close");
-    if (!_bForce)
-      Memory::Write_U32(0, _CommandAddress + 4);
-    return GetDefaultReply();
-  }
-
   IPCCommandResult IOCtl(u32 _CommandAddress) override
   {
     u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
@@ -223,8 +207,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ip_top();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
@@ -245,8 +227,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ncd_manage();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
 private:
@@ -273,8 +253,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_wd_command();
 
-  IPCCommandResult Open(u32 CommandAddress, u32 Mode) override;
-  IPCCommandResult Close(u32 CommandAddress, bool Force) override;
   IPCCommandResult IOCtlV(u32 CommandAddress) override;
 
 private:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -75,22 +75,6 @@ int CWII_IPC_HLE_Device_net_ssl::GetSSLFreeID() const
   return 0;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Open(u32 _CommandAddress, u32 _Mode)
-{
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Close(u32 _CommandAddress, bool _bForce)
-{
-  if (!_bForce)
-  {
-    Memory::Write_U32(0, _CommandAddress + 4);
-  }
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(u32 _CommandAddress)
 {
   u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -77,7 +77,6 @@ int CWII_IPC_HLE_Device_net_ssl::GetSSLFreeID() const
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ssl::Open(u32 _CommandAddress, u32 _Mode)
 {
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
@@ -87,9 +87,6 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ssl();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -76,7 +76,6 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Open(u32 _CommandAddress, u32 _
 
   OpenInternal();
 
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 0x4);
   m_registers.fill(0);
   m_Active = true;
   return GetDefaultReply();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -89,8 +89,6 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool
   m_BlockLength = 0;
   m_BusWidth = 0;
 
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 0x4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -18,22 +18,6 @@ void Stop();
 
 static u32 s_event_hook_address = 0;
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Open(u32 command_address, u32 mode)
-{
-  INFO_LOG(WII_IPC_STM, "STM immediate: Open");
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Close(u32 command_address, bool force)
-{
-  INFO_LOG(WII_IPC_STM, "STM immediate: Close");
-  if (!force)
-    Memory::Write_U32(0, command_address + 4);
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
 {
   u32 parameter = Memory::Read_U32(command_address + 0x0C);
@@ -104,19 +88,10 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Open(u32 command_address, u32 mode)
-{
-  m_Active = true;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Close(u32 command_address, bool force)
 {
   s_event_hook_address = 0;
 
-  INFO_LOG(WII_IPC_STM, "STM eventhook: Close");
-  if (!force)
-    Memory::Write_U32(0, command_address + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -21,7 +21,6 @@ static u32 s_event_hook_address = 0;
 IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::Open(u32 command_address, u32 mode)
 {
   INFO_LOG(WII_IPC_STM, "STM immediate: Open");
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }
@@ -107,7 +106,6 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
 
 IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Open(u32 command_address, u32 mode)
 {
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -44,8 +44,6 @@ public:
   }
 
   ~CWII_IPC_HLE_Device_stm_immediate() override = default;
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force) override;
   IPCCommandResult IOCtl(u32 command_address) override;
 };
 
@@ -59,7 +57,6 @@ public:
   }
 
   ~CWII_IPC_HLE_Device_stm_eventhook() override = default;
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
   IPCCommandResult Close(u32 command_address, bool force) override;
   IPCCommandResult IOCtl(u32 command_address) override;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -21,8 +21,6 @@ IPCCommandResult CWII_IPC_HLE_Device_stub::Open(u32 command_address, u32 mode)
 IPCCommandResult CWII_IPC_HLE_Device_stub::Close(u32 command_address, bool force)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking Close()", m_Name.c_str());
-  if (!force)
-    Memory::Write_U32(FS_SUCCESS, command_address + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -14,7 +14,6 @@ CWII_IPC_HLE_Device_stub::CWII_IPC_HLE_Device_stub(u32 device_id, const std::str
 IPCCommandResult CWII_IPC_HLE_Device_stub::Open(u32 command_address, u32 mode)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_Name.c_str());
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -168,8 +168,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Close(u32 _CommandAddr
   m_HCIEndpoint.m_cmd_address = 0;
   m_ACLEndpoint.m_cmd_address = 0;
 
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -154,7 +154,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Open(u32 _CommandAddre
   m_HCIEndpoint.m_cmd_address = 0;
   m_ACLEndpoint.m_cmd_address = 0;
 
-  Memory::Write_U32(GetDeviceID(), _CommandAddress + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -153,7 +153,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Close(u32 command_add
     StopTransferThread();
     libusb_unref_device(m_device);
     m_handle = nullptr;
-    Memory::Write_U32(0, command_address + 4);
   }
 
   m_Active = false;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -141,7 +141,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Open(u32 command_addr
 
   StartTransferThread();
 
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -67,8 +67,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _b
   INFO_LOG(WII_IPC_HLE, "CWII_IPC_HLE_Device_usb_kbd: Close");
   while (!m_MessageQueue.empty())
     m_MessageQueue.pop();
-  if (!_bForce)
-    Memory::Write_U32(0, _CommandAddress + 4);
   m_Active = false;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
@@ -18,7 +18,6 @@ CWII_IPC_HLE_Device_usb_ven::~CWII_IPC_HLE_Device_usb_ven()
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_ven::Open(u32 command_address, u32 mode)
 {
-  Memory::Write_U32(GetDeviceID(), command_address + 4);
   m_Active = true;
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
@@ -16,21 +16,6 @@ CWII_IPC_HLE_Device_usb_ven::~CWII_IPC_HLE_Device_usb_ven()
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_ven::Open(u32 command_address, u32 mode)
-{
-  m_Active = true;
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_usb_ven::Close(u32 command_address, bool force)
-{
-  if (!force)
-    Memory::Write_U32(0, command_address + 4);
-
-  m_Active = false;
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtlV(u32 command_address)
 {
   SIOCtlVBuffer command_buffer(command_address);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
@@ -19,9 +19,6 @@ public:
 
   ~CWII_IPC_HLE_Device_usb_ven() override;
 
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force) override;
-
   IPCCommandResult IOCtlV(u32 command_address) override;
   IPCCommandResult IOCtl(u32 command_address) override;
 


### PR DESCRIPTION
This PR removes unneeded and sometimes simply confusing IOS HLE code:

* **Useless re-implementations of Open()/Close() all over IOS HLE.** A lot of IOS device classes simply changed m_Active, wrote a return code to the emulated memory and returned a default reply; this results in loads of duplicated code, because that's something the base class methods already do…

* **Confusing writes for the IOS fd.** Open() methods (most of them now removed) used GetDeviceID() and wrote the Dolphin device ID as the IOS return code, as if it were a IOS fd. It looks like at some point the Dolphin IDs coincided with IOS fds, but this is not the case anymore, so keeping those writes is both unnecessary and confusing.

* **An alignment function** that I missed and didn't replace with Common::AlignUp in #4482.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dolphin-emu/dolphin/4625)
<!-- Reviewable:end -->
