### PR TITLE
CodeBlock: Get rid of implicit sign-conversion in AllocCodeSpace

### DIFF
--- a/Source/Core/Common/CodeBlock.h
+++ b/Source/Core/Common/CodeBlock.h
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "Common/Assert.h"
+#include "Common/CommonTypes.h"
 #include "Common/MemoryUtil.h"
 #include "Common/NonCopyable.h"
 
@@ -39,7 +42,7 @@ public:
   }
 
   // Call this before you generate any code.
-  void AllocCodeSpace(int size, bool need_low = true)
+  void AllocCodeSpace(size_t size, bool need_low = true)
   {
     region_size = size;
     region = static_cast<u8*>(Common::AllocateExecutableMemory(region_size, need_low));

--- a/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.cpp
@@ -4,7 +4,7 @@
 
 #include "Core/PowerPC/Jit64Common/FarCodeCache.h"
 
-void FarCodeCache::Init(int size)
+void FarCodeCache::Init(size_t size)
 {
   AllocCodeSpace(size);
   m_enabled = true;

--- a/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/FarCodeCache.h
@@ -4,19 +4,20 @@
 
 #pragma once
 
+#include <cstddef>
 #include "Common/x64Emitter.h"
 
 // a bit of a hack; the MMU results in a vast amount more code ending up in the far cache,
 // mostly exception handling, so give it a whole bunch more space if the MMU is on.
-constexpr int FARCODE_SIZE = 1024 * 1024 * 8;
-constexpr int FARCODE_SIZE_MMU = 1024 * 1024 * 48;
+constexpr size_t FARCODE_SIZE = 1024 * 1024 * 8;
+constexpr size_t FARCODE_SIZE_MMU = 1024 * 1024 * 48;
 
 // A place to throw blocks of code we don't want polluting the cache, e.g. rarely taken
 // exception branches.
 class FarCodeCache : public Gen::X64CodeBlock
 {
 public:
-  void Init(int size);
+  void Init(size_t size);
   void Shutdown();
 
   bool Enabled() const;

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #include "Common/CommonTypes.h"
@@ -32,7 +33,7 @@ constexpr Gen::X64Reg RMEM = Gen::RBX;
 // to address as much as possible in a one-byte offset form.
 constexpr Gen::X64Reg RPPCSTATE = Gen::RBP;
 
-constexpr int CODE_SIZE = 1024 * 1024 * 32;
+constexpr size_t CODE_SIZE = 1024 * 1024 * 32;
 
 class Jitx86Base : public JitBase, public QuantizedMemoryRoutines
 {

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.cpp
@@ -23,7 +23,7 @@
 
 using namespace Gen;
 
-void TrampolineCache::Init(int size)
+void TrampolineCache::Init(size_t size)
 {
   AllocCodeSpace(size);
 }

--- a/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/TrampolineCache.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include "Common/CommonTypes.h"
 #include "Core/PowerPC/Jit64Common/EmuCodeBlock.h"
 
@@ -11,8 +12,8 @@ struct TrampolineInfo;
 
 // a bit of a hack; the MMU results in more code ending up in the trampoline cache,
 // because fastmem results in far more backpatches in MMU mode
-constexpr int TRAMPOLINE_CODE_SIZE = 1024 * 1024 * 8;
-constexpr int TRAMPOLINE_CODE_SIZE_MMU = 1024 * 1024 * 32;
+constexpr size_t TRAMPOLINE_CODE_SIZE = 1024 * 1024 * 8;
+constexpr size_t TRAMPOLINE_CODE_SIZE_MMU = 1024 * 1024 * 32;
 
 // We need at least this many bytes for backpatching.
 constexpr int BACKPATCH_SIZE = 5;
@@ -23,7 +24,7 @@ class TrampolineCache : public EmuCodeBlock
   const u8* GenerateWriteTrampoline(const TrampolineInfo& info);
 
 public:
-  void Init(int size);
+  void Init(size_t size);
   void Shutdown();
   const u8* GenerateTrampoline(const TrampolineInfo& info);
   void ClearCodeSpace();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <map>
 #include <tuple>
 
@@ -17,8 +18,8 @@
 #include "Core/PowerPC/JitCommon/JitBase.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 
-constexpr int CODE_SIZE = 1024 * 1024 * 32;
-constexpr int FARCODE_SIZE_MMU = 1024 * 1024 * 48;
+constexpr size_t CODE_SIZE = 1024 * 1024 * 32;
+constexpr size_t FARCODE_SIZE_MMU = 1024 * 1024 * 48;
 
 class JitArm64 : public JitBase, public Arm64Gen::ARM64CodeBlock, public CommonAsmRoutinesBase
 {


### PR DESCRIPTION
Size is internally stored as a `size_t`, so having an `int` parameter would cause implicit sign-conversion from a signed value to an unsigned value to occur.