### PR TITLE
IOS HLE: Naming cleanup

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -470,8 +470,8 @@ void EnqueueReply(u32 address, int cycles_in_future, CoreTiming::FromThread from
 {
   // IOS writes back the command that was responded to in the FD field.
   Memory::Write_U32(Memory::Read_U32(address), address + 8);
-  // IOS also overwrites the command type with the async reply type.
-  Memory::Write_U32(IPC_REP_ASYNC, address);
+  // IOS also overwrites the command type with the reply type.
+  Memory::Write_U32(IPC_REPLY, address);
   CoreTiming::ScheduleEvent(cycles_in_future, s_event_enqueue, address, from);
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -378,7 +378,7 @@ static s32 OpenDevice(const u32 address)
   {
     device = GetUnusedESDevice();
     if (!device)
-      return FS_EESEXHAUSTED;
+      return IPC_EESEXHAUSTED;
   }
   else if (device_name.find("/dev/") == 0)
   {
@@ -392,7 +392,7 @@ static s32 OpenDevice(const u32 address)
   if (!device)
   {
     ERROR_LOG(WII_IPC_HLE, "Unknown device: %s", device_name.c_str());
-    return FS_ENOENT;
+    return IPC_ENOENT;
   }
 
   Memory::Write_U32(new_fd, address + 4);
@@ -418,7 +418,7 @@ static IPCCommandResult HandleCommand(const u32 address)
   const auto device = (fd >= 0 && fd < IPC_MAX_FDS) ? s_fdmap[fd] : nullptr;
   if (!device)
   {
-    Memory::Write_U32(FS_EINVAL, address + 4);
+    Memory::Write_U32(IPC_EINVAL, address + 4);
     return IWII_IPC_HLE_Device::GetDefaultReply();
   }
 
@@ -426,8 +426,8 @@ static IPCCommandResult HandleCommand(const u32 address)
   {
   case IPC_CMD_CLOSE:
     s_fdmap[fd].reset();
-    // A close on a valid device returns FS_SUCCESS.
-    Memory::Write_U32(FS_SUCCESS, address + 4);
+    // A close on a valid device returns IPC_SUCCESS.
+    Memory::Write_U32(IPC_SUCCESS, address + 4);
     return device->Close(address);
   case IPC_CMD_READ:
     return device->Read(address);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -30,17 +30,12 @@ enum IPCCommandType : u32
   IPC_CMD_SEEK = 5,
   IPC_CMD_IOCTL = 6,
   IPC_CMD_IOCTLV = 7,
-  // IPC_REP_ASYNC is used for messages that are automatically
-  // sent to an IOS queue when an asynchronous syscall completes.
-  // Reference: http://wiibrew.org/wiki/IOS
-  IPC_REP_ASYNC = 8
+  // This is used for replies to commands.
+  IPC_REPLY = 8,
 };
 
 namespace WII_IPC_HLE_Interface
 {
-#define IPC_FIRST_ID 0x00   // First IPC device ID
-#define IPC_MAX_FILES 0x10  // First IPC file ID
-
 // Init
 void Init();
 
@@ -51,19 +46,19 @@ void Reinit();
 void Shutdown();
 
 // Reset
-void Reset(bool _bHard = false);
+void Reset(bool hard = false);
 
 // Do State
 void DoState(PointerWrap& p);
 
 // Set default content file
-void SetDefaultContentFile(const std::string& _rFilename);
+void SetDefaultContentFile(const std::string& file_name);
 void ES_DIVerify(const std::vector<u8>& tmd);
 
 void SDIO_EventNotify();
 
-std::shared_ptr<IWII_IPC_HLE_Device> GetDeviceByName(const std::string& _rDeviceName);
-std::shared_ptr<IWII_IPC_HLE_Device> AccessDeviceByID(u32 _ID);
+std::shared_ptr<IWII_IPC_HLE_Device> GetDeviceByName(const std::string& device_name);
+std::shared_ptr<IWII_IPC_HLE_Device> AccessDeviceByID(u32 id);
 
 // Update
 void Update();
@@ -71,11 +66,11 @@ void Update();
 // Update Devices
 void UpdateDevices();
 
-void ExecuteCommand(u32 _Address);
+void ExecuteCommand(u32 address);
 
 void EnqueueRequest(u32 address);
 void EnqueueReply(u32 address, int cycles_in_future = 0,
                   CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
-void EnqueueCommandAcknowledgement(u32 _Address, int cycles_in_future = 0);
+void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future = 0);
 
 }  // end of namespace WII_IPC_HLE_Interface

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
@@ -48,63 +48,63 @@ SIOCtlVBuffer::SIOCtlVBuffer(const u32 address) : m_Address(address)
 
 IWII_IPC_HLE_Device::IWII_IPC_HLE_Device(const u32 device_id, const std::string& device_name,
                                          const bool hardware)
-    : m_Name(device_name), m_DeviceID(device_id), m_Hardware(hardware)
+    : m_name(device_name), m_device_id(device_id), m_is_hardware(hardware)
 {
 }
 
 void IWII_IPC_HLE_Device::DoState(PointerWrap& p)
 {
   DoStateShared(p);
-  p.Do(m_Active);
+  p.Do(m_is_active);
 }
 
 void IWII_IPC_HLE_Device::DoStateShared(PointerWrap& p)
 {
-  p.Do(m_Name);
-  p.Do(m_DeviceID);
-  p.Do(m_Hardware);
-  p.Do(m_Active);
+  p.Do(m_name);
+  p.Do(m_device_id);
+  p.Do(m_is_hardware);
+  p.Do(m_is_active);
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Open(u32 command_address, u32 mode)
 {
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Close(u32 command_address, bool force)
 {
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Seek(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Seek()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support Seek()", m_name.c_str());
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Read(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Read()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support Read()", m_name.c_str());
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Write(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support Write()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support Write()", m_name.c_str());
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::IOCtl(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support IOCtl()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support IOCtl()", m_name.c_str());
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::IOCtlV(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s does not support IOCtlV()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s does not support IOCtlV()", m_name.c_str());
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -14,30 +14,32 @@
 #include "Common/StringUtil.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 
-#define FS_SUCCESS (u32)0            // Success
-#define FS_EACCES (u32) - 1          // Permission denied
-#define FS_EEXIST (u32) - 2          // File exists
-#define FS_EINVAL (u32) - 4          // Invalid argument Invalid FD
-#define FS_ENOENT (u32) - 6          // File not found
-#define FS_EBUSY (u32) - 8           // Resource busy
-#define FS_EIO (u32) - 12            // Returned on ECC error
-#define FS_ENOMEM (u32) - 22         // Alloc failed during request
-#define FS_EFATAL (u32) - 101        // Fatal error
-#define FS_EACCESS (u32) - 102       // Permission denied
-#define FS_ECORRUPT (u32) - 103      // returned for "corrupted" NAND
-#define FS_EEXIST2 (u32) - 105       // File exists
-#define FS_ENOENT2 (u32) - 106       // File not found
-#define FS_ENFILE (u32) - 107        // Too many fds open
-#define FS_EFBIG (u32) - 108         // Max block count reached?
-#define FS_EFDEXHAUSTED (u32) - 109  // Too many fds open
-#define FS_ENAMELEN (u32) - 110      // Pathname is too long
-#define FS_EFDOPEN (u32) - 111       // FD is already open
-#define FS_EIO2 (u32) - 114          // Returned on ECC error
-#define FS_ENOTEMPTY (u32) - 115     // Directory not empty
-#define FS_EDIRDEPTH (u32) - 116     // Max directory depth exceeded
-#define FS_EBUSY2 (u32) - 118        // Resource busy
-//#define FS_EFATAL       (u32)-119   // Fatal error not used by IOS as fatal ERROR
-#define FS_EESEXHAUSTED (u32) - 1016  // Max of 2 ES handles at a time
+enum IOSReturnCode : s32
+{
+  IPC_SUCCESS = 0,           // Success
+  IPC_EACCES = -1,           // Permission denied
+  IPC_EEXIST = -2,           // File exists
+  IPC_EINVAL = -4,           // Invalid argument or fd
+  IPC_ENOENT = -6,           // File not found
+  IPC_EQUEUEFULL = -8,       // Queue full
+  IPC_EIO = -12,             // ECC error
+  IPC_ENOMEM = -22,          // Alloc failed during request
+  FS_EINVAL = -101,          // Invalid path
+  FS_EACCESS = -102,         // Permission denied
+  FS_ECORRUPT = -103,        // Corrupted NAND
+  FS_EEXIST = -105,          // File exists
+  FS_ENOENT = -106,          // No such file or directory
+  FS_ENFILE = -107,          // Too many fds open
+  FS_EFBIG = -108,           // Max block count reached?
+  FS_EFDEXHAUSTED = -109,    // Too many fds open
+  FS_ENAMELEN = -110,        // Pathname is too long
+  FS_EFDOPEN = -111,         // FD is already open
+  FS_EIO = -114,             // ECC error
+  FS_ENOTEMPTY = -115,       // Directory not empty
+  FS_EDIRDEPTH = -116,       // Max directory depth exceeded
+  FS_EBUSY = -118,           // Resource busy
+  IPC_EESEXHAUSTED = -1016,  // Max of 2 ES handles exceeded
+};
 
 // A struct for IOS ioctlv calls
 struct SIOCtlVBuffer

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -70,8 +70,8 @@ public:
   virtual void DoState(PointerWrap& p);
   void DoStateShared(PointerWrap& p);
 
-  const std::string& GetDeviceName() const { return m_Name; }
-  u32 GetDeviceID() const { return m_DeviceID; }
+  const std::string& GetDeviceName() const { return m_name; }
+  u32 GetDeviceID() const { return m_device_id; }
   virtual IPCCommandResult Open(u32 command_address, u32 mode);
   virtual IPCCommandResult Close(u32 command_address, bool force = false);
   virtual IPCCommandResult Seek(u32 command_address);
@@ -81,18 +81,18 @@ public:
   virtual IPCCommandResult IOCtlV(u32 command_address);
 
   virtual u32 Update() { return 0; }
-  virtual bool IsHardware() const { return m_Hardware; }
-  virtual bool IsOpened() const { return m_Active; }
+  virtual bool IsHardware() const { return m_is_hardware; }
+  virtual bool IsOpened() const { return m_is_active; }
   static IPCCommandResult GetDefaultReply();
   static IPCCommandResult GetNoReply();
 
-  std::string m_Name;
+  std::string m_name;
 
 protected:
   // STATE_TO_SAVE
-  u32 m_DeviceID;
-  bool m_Hardware;
-  bool m_Active = false;
+  u32 m_device_id;
+  bool m_is_hardware;
+  bool m_is_active = false;
 
   // Write out the IPC struct from command_address to number_of_commands numbers
   // of 4 byte commands.

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -76,14 +76,14 @@ CWII_IPC_HLE_Device_FileIO::~CWII_IPC_HLE_Device_FileIO()
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bForce)
 {
-  INFO_LOG(WII_IPC_FILEIO, "FileIO: Close %s (DeviceID=%08x)", m_Name.c_str(), m_DeviceID);
+  INFO_LOG(WII_IPC_FILEIO, "FileIO: Close %s (DeviceID=%08x)", m_name.c_str(), m_device_id);
   m_Mode = 0;
 
   // Let go of our pointer to the file, it will automatically close if we are the last handle
   // accessing it.
   m_file.reset();
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 
@@ -93,13 +93,13 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 command_address, u32 mode)
 
   static const char* const Modes[] = {"Unk Mode", "Read only", "Write only", "Read and Write"};
 
-  m_filepath = HLE_IPC_BuildFilename(m_Name);
+  m_filepath = HLE_IPC_BuildFilename(m_name);
 
   // The file must exist before we can open it
   // It should be created by ISFS_CreateFile, not here
   if (File::Exists(m_filepath) && !File::IsDirectory(m_filepath))
   {
-    INFO_LOG(WII_IPC_FILEIO, "FileIO: Open %s (%s == %08X)", m_Name.c_str(), Modes[mode], mode);
+    INFO_LOG(WII_IPC_FILEIO, "FileIO: Open %s (%s == %08X)", m_name.c_str(), Modes[mode], mode);
     OpenFile();
   }
   else
@@ -110,7 +110,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 command_address, u32 mode)
       Memory::Write_U32(FS_ENOENT, command_address + 4);
   }
 
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -134,14 +134,14 @@ void CWII_IPC_HLE_Device_FileIO::OpenFile()
   //    - The Beatles: Rock Band (saving doesn't work)
 
   // Check if the file has already been opened.
-  auto search = openFiles.find(m_Name);
+  auto search = openFiles.find(m_name);
   if (search != openFiles.end())
   {
     m_file = search->second.lock();  // Lock a shared pointer to use.
   }
   else
   {
-    std::string path = m_Name;
+    std::string path = m_name;
     // This code will be called when all references to the shared pointer below have been removed.
     auto deleter = [path](File::IOFile* ptr) {
       delete ptr;             // IOFile's deconstructor closes the file.
@@ -170,7 +170,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Seek(u32 _CommandAddress)
 
     const s32 fileSize = (s32)m_file->GetSize();
     DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Seek Pos: 0x%08x, Mode: %i (%s, Length=0x%08x)",
-              SeekPosition, Mode, m_Name.c_str(), fileSize);
+              SeekPosition, Mode, m_name.c_str(), fileSize);
 
     switch (Mode)
     {
@@ -235,12 +235,12 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
     {
       WARN_LOG(WII_IPC_FILEIO,
                "FileIO: Attempted to read 0x%x bytes to 0x%08x on a write-only file %s", Size,
-               Address, m_Name.c_str());
+               Address, m_name.c_str());
     }
     else
     {
       DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Read 0x%x bytes to 0x%08x from %s", Size, Address,
-                m_Name.c_str());
+                m_name.c_str());
       m_file->Seek(m_SeekPos, SEEK_SET);  // File might be opened twice, need to seek before we read
       ReturnValue = (u32)fread(Memory::GetPointer(Address), 1, Size, m_file->GetHandle());
       if (ReturnValue != Size && ferror(m_file->GetHandle()))
@@ -257,7 +257,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
   {
     ERROR_LOG(WII_IPC_FILEIO, "FileIO: Failed to read from %s (Addr=0x%08x Size=0x%x) - file could "
                               "not be opened or does not exist",
-              m_Name.c_str(), Address, Size);
+              m_name.c_str(), Address, Size);
     ReturnValue = FS_ENOENT;
   }
 
@@ -278,12 +278,12 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
     {
       WARN_LOG(WII_IPC_FILEIO,
                "FileIO: Attempted to write 0x%x bytes from 0x%08x to a read-only file %s", Size,
-               Address, m_Name.c_str());
+               Address, m_name.c_str());
     }
     else
     {
       DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Write 0x%04x bytes from 0x%08x to %s", Size, Address,
-                m_Name.c_str());
+                m_name.c_str());
       m_file->Seek(m_SeekPos,
                    SEEK_SET);  // File might be opened twice, need to seek before we write
       if (m_file->WriteBytes(Memory::GetPointer(Address), Size))
@@ -297,7 +297,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
   {
     ERROR_LOG(WII_IPC_FILEIO, "FileIO: Failed to read from %s (Addr=0x%08x Size=0x%x) - file could "
                               "not be opened or does not exist",
-              m_Name.c_str(), Address, Size);
+              m_name.c_str(), Address, Size);
     ReturnValue = FS_ENOENT;
   }
 
@@ -307,7 +307,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
 {
-  DEBUG_LOG(WII_IPC_FILEIO, "FileIO: IOCtl (Device=%s)", m_Name.c_str());
+  DEBUG_LOG(WII_IPC_FILEIO, "FileIO: IOCtl (Device=%s)", m_name.c_str());
 #if defined(_DEBUG) || defined(DEBUGFAST)
   DumpCommands(_CommandAddress);
 #endif
@@ -323,7 +323,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
       u32 m_FileLength = (u32)m_file->GetSize();
 
       const u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-      DEBUG_LOG(WII_IPC_FILEIO, "  File: %s, Length: %i, Pos: %i", m_Name.c_str(), m_FileLength,
+      DEBUG_LOG(WII_IPC_FILEIO, "  File: %s, Length: %i, Pos: %i", m_name.c_str(), m_FileLength,
                 m_SeekPos);
 
       Memory::Write_U32(m_FileLength, BufferOut);
@@ -362,7 +362,7 @@ void CWII_IPC_HLE_Device_FileIO::DoState(PointerWrap& p)
   p.Do(m_Mode);
   p.Do(m_SeekPos);
 
-  m_filepath = HLE_IPC_BuildFilename(m_Name);
+  m_filepath = HLE_IPC_BuildFilename(m_name);
 
   // The file was closed during state (and might now be pointing at another file)
   // Open it again

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -184,9 +184,9 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Open(u32 _CommandAddress, u32 _Mode)
 {
   OpenInternal();
 
-  if (m_Active)
+  if (m_is_active)
     INFO_LOG(WII_IPC_ES, "Device was re-opened.");
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -198,7 +198,7 @@ IPCCommandResult CWII_IPC_HLE_Device_es::Close(u32 _CommandAddress, bool _bForce
   m_AccessIdentID = 0x6000000;
 
   INFO_LOG(WII_IPC_ES, "ES: Close");
-  m_Active = false;
+  m_is_active = false;
   // clear the NAND content cache to make sure nothing remains open.
   DiscIO::CNANDContentManager::Access().ClearCache();
   return GetDefaultReply();
@@ -1061,9 +1061,9 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
     if (!bReset)
     {
-      // The original hardware overwrites the command type with the async reply type.
-      Memory::Write_U32(IPC_REP_ASYNC, _CommandAddress);
-      // IOS also seems to write back the command that was responded to in the FD field.
+      // The command type is overwritten with the reply type.
+      Memory::Write_U32(IPC_REPLY, _CommandAddress);
+      // IOS also writes back the command that was responded to in the FD field.
       Memory::Write_U32(IPC_CMD_IOCTLV, _CommandAddress + 8);
     }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -73,7 +73,7 @@ static u64 ComputeTotalFileSize(const File::FSTEntry& parentEntry)
 
 IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
 {
-  u32 ReturnValue = FS_RESULT_OK;
+  u32 ReturnValue = IPC_SUCCESS;
   SIOCtlVBuffer CommandBuffer(_CommandAddress);
 
   // Prepare the out buffer(s) with zeros as a safety precaution
@@ -94,7 +94,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     if (!IsValidWiiPath(relative_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", relative_path.c_str());
-      ReturnValue = FS_RESULT_FATAL;
+      ReturnValue = FS_EINVAL;
       break;
     }
 
@@ -106,7 +106,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     if (!File::Exists(DirName))
     {
       WARN_LOG(WII_IPC_FILEIO, "FS: Search not found: %s", DirName.c_str());
-      ReturnValue = FS_FILE_NOT_EXIST;
+      ReturnValue = FS_ENOENT;
       break;
     }
     else if (!File::IsDirectory(DirName))
@@ -114,8 +114,8 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
       // It's not a directory, so error.
       // Games don't usually seem to care WHICH error they get, as long as it's <
       // Well the system menu CARES!
-      WARN_LOG(WII_IPC_FILEIO, "\tNot a directory - return FS_RESULT_FATAL");
-      ReturnValue = FS_RESULT_FATAL;
+      WARN_LOG(WII_IPC_FILEIO, "\tNot a directory - return FS_EINVAL");
+      ReturnValue = FS_EINVAL;
       break;
     }
 
@@ -166,7 +166,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
       Memory::Write_U32((u32)numFiles, CommandBuffer.PayloadBuffer[1].m_Address);
     }
 
-    ReturnValue = FS_RESULT_OK;
+    ReturnValue = IPC_SUCCESS;
   }
   break;
 
@@ -185,7 +185,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     if (!IsValidWiiPath(relativepath))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", relativepath.c_str());
-      ReturnValue = FS_RESULT_FATAL;
+      ReturnValue = FS_EINVAL;
       break;
     }
 
@@ -217,7 +217,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
 
         fsBlocks = (u32)(totalSize / (16 * 1024));  // one bock is 16kb
       }
-      ReturnValue = FS_RESULT_OK;
+      ReturnValue = IPC_SUCCESS;
 
       INFO_LOG(WII_IPC_FILEIO, "FS: fsBlock: %i, iNodes: %i", fsBlocks, iNodes);
     }
@@ -225,7 +225,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
     {
       fsBlocks = 0;
       iNodes = 0;
-      ReturnValue = FS_RESULT_OK;
+      ReturnValue = IPC_SUCCESS;
       WARN_LOG(WII_IPC_FILEIO, "FS: fsBlock failed, cannot find directory: %s", path.c_str());
     }
 
@@ -290,7 +290,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
 
     std::memcpy(Memory::GetPointer(_BufferOut), &fs, sizeof(NANDStat));
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -307,7 +307,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string DirName(HLE_IPC_BuildFilename(wii_path));
     Addr += 64;
@@ -322,7 +322,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     _dbg_assert_msg_(WII_IPC_FILEIO, File::IsDirectory(DirName), "FS: CREATE_DIR %s failed",
                      DirName.c_str());
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -338,7 +338,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename = HLE_IPC_BuildFilename(wii_path);
     Addr += 64;
@@ -359,7 +359,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     DEBUG_LOG(WII_IPC_FILEIO, "    OtherPerm: 0x%02x", OtherPerm);
     DEBUG_LOG(WII_IPC_FILEIO, "    Attributes: 0x%02x", Attributes);
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -376,7 +376,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename = HLE_IPC_BuildFilename(wii_path);
     u8 OwnerPerm = 0x3;    // read/write
@@ -398,7 +398,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
       else
       {
         INFO_LOG(WII_IPC_FILEIO, "FS: GET_ATTR unknown %s", Filename.c_str());
-        return FS_FILE_NOT_EXIST;
+        return FS_ENOENT;
       }
     }
 
@@ -422,7 +422,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
       Addr += 1;
     }
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -435,7 +435,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename = HLE_IPC_BuildFilename(wii_path);
     Offset += 64;
@@ -452,7 +452,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
       WARN_LOG(WII_IPC_FILEIO, "FS: DeleteFile %s - failed!!!", Filename.c_str());
     }
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -465,7 +465,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename = HLE_IPC_BuildFilename(wii_path);
     Offset += 64;
@@ -474,7 +474,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path_rename))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path_rename.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string FilenameRename = HLE_IPC_BuildFilename(wii_path_rename);
     Offset += 64;
@@ -497,10 +497,10 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     {
       ERROR_LOG(WII_IPC_FILEIO, "FS: Rename %s to %s - failed", Filename.c_str(),
                 FilenameRename.c_str());
-      return FS_FILE_NOT_EXIST;
+      return FS_ENOENT;
     }
 
-    return FS_RESULT_OK;
+    return IPC_SUCCESS;
   }
   break;
 
@@ -517,7 +517,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     if (!IsValidWiiPath(wii_path))
     {
       WARN_LOG(WII_IPC_FILEIO, "Not a valid path: %s", wii_path.c_str());
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
     std::string Filename(HLE_IPC_BuildFilename(wii_path));
     Addr += 64;
@@ -541,8 +541,8 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     // check if the file already exist
     if (File::Exists(Filename))
     {
-      INFO_LOG(WII_IPC_FILEIO, "\tresult = FS_RESULT_EXISTS");
-      return FS_FILE_EXIST;
+      INFO_LOG(WII_IPC_FILEIO, "\tresult = FS_EEXIST");
+      return FS_EEXIST;
     }
 
     // create the file
@@ -552,11 +552,11 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     {
       ERROR_LOG(WII_IPC_FILEIO, "CWII_IPC_HLE_Device_fs: couldn't create new file");
       PanicAlert("CWII_IPC_HLE_Device_fs: couldn't create new file");
-      return FS_RESULT_FATAL;
+      return FS_EINVAL;
     }
 
-    INFO_LOG(WII_IPC_FILEIO, "\tresult = FS_RESULT_OK");
-    return FS_RESULT_OK;
+    INFO_LOG(WII_IPC_FILEIO, "\tresult = IPC_SUCCESS");
+    return IPC_SUCCESS;
   }
   break;
   case IOCTL_SHUTDOWN:
@@ -571,7 +571,7 @@ s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(u32 _Parameter, u32 _BufferIn, u32 _B
     break;
   }
 
-  return FS_RESULT_FATAL;
+  return FS_EINVAL;
 }
 
 void CWII_IPC_HLE_Device_fs::DoState(PointerWrap& p)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -52,7 +52,7 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::Open(u32 _CommandAddress, u32 _Mode)
     File::CreateDir(Path);
   }
 
-  m_Active = true;
+  m_is_active = true;
   return GetFSReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -23,18 +23,6 @@ struct NANDStat
   u32 Used_Inodes;
 };
 
-enum
-{
-  FS_RESULT_OK = 0,
-  FS_INVALID = -4,
-  FS_DIRFILE_NOT_FOUND = -6,
-  FS_RESULT_FATAL = -101,
-  FS_NO_ACCESS = -102,
-  FS_FILE_EXIST = -105,
-  FS_FILE_NOT_EXIST = -106,
-  FS_NO_HANDLE = -106,
-};
-
 class CWII_IPC_HLE_Device_fs : public IWII_IPC_HLE_Device
 {
 public:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -56,7 +56,7 @@ void CWII_IPC_HLE_Device_hid::checkUsbUpdates(CWII_IPC_HLE_Device_hid* hid)
 
 void CWII_IPC_HLE_Device_hid::handleUsbUpdates(struct libusb_transfer* transfer)
 {
-  int ret = HIDERR_NO_DEVICE_FOUND;
+  int ret = IPC_EINVAL;
   u32 replyAddress = (u32)(size_t)transfer->user_data;
   if (transfer->status == LIBUSB_TRANSFER_COMPLETED)
   {
@@ -169,7 +169,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
     u16 wLength = Memory::Read_U16(BufferIn + 0x1A);
     u32 data = Memory::Read_U32(BufferIn + 0x1C);
 
-    ReturnValue = HIDERR_NO_DEVICE_FOUND;
+    ReturnValue = IPC_EINVAL;
 
     libusb_device_handle* dev_handle = GetDeviceByDevNum(dev_num);
 
@@ -204,7 +204,7 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtl(u32 _CommandAddress)
 
     u32 data = Memory::Read_U32(BufferIn + 0x1C);
 
-    ReturnValue = HIDERR_NO_DEVICE_FOUND;
+    ReturnValue = IPC_EINVAL;
 
     libusb_device_handle* dev_handle = GetDeviceByDevNum(dev_num);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -31,8 +31,6 @@ struct libusb_transfer;
 #define HID_ID_MASK 0x0000FFFFFFFFFFFF
 #define MAX_HID_INTERFACES 1
 
-#define HIDERR_NO_DEVICE_FOUND -4
-
 class CWII_IPC_HLE_Device_hid : public IWII_IPC_HLE_Device
 {
 public:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -77,7 +77,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Open(u32 _CommandAddress, u32 _
   OpenInternal();
 
   m_registers.fill(0);
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -89,7 +89,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::Close(u32 _CommandAddress, bool
   m_BlockLength = 0;
   m_BusWidth = 0;
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -42,11 +42,11 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
   case IOCTL_STM_RELEASE_EH:
     if (s_event_hook_address == 0)
     {
-      return_value = FS_ENOENT;
+      return_value = IPC_ENOENT;
       break;
     }
     Memory::Write_U32(0, Memory::Read_U32(s_event_hook_address + 0x18));
-    Memory::Write_U32(FS_SUCCESS, s_event_hook_address + 4);
+    Memory::Write_U32(IPC_SUCCESS, s_event_hook_address + 4);
     WII_IPC_HLE_Interface::EnqueueReply(s_event_hook_address);
     s_event_hook_address = 0;
     break;
@@ -102,7 +102,7 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 command_address)
   if (parameter != IOCTL_STM_EVENTHOOK)
   {
     ERROR_LOG(WII_IPC_STM, "Bad IOCtl in CWII_IPC_HLE_Device_stm_eventhook");
-    Memory::Write_U32(FS_EINVAL, command_address + 4);
+    Memory::Write_U32(IPC_EINVAL, command_address + 4);
     return GetDefaultReply();
   }
 
@@ -129,7 +129,7 @@ void CWII_IPC_HLE_Device_stm_eventhook::TriggerEvent(const u32 event) const
   u32 buffer_out = Memory::Read_U32(s_event_hook_address + 0x18);
   Memory::Write_U32(event, buffer_out);
 
-  Memory::Write_U32(FS_SUCCESS, s_event_hook_address + 4);
+  Memory::Write_U32(IPC_SUCCESS, s_event_hook_address + 4);
   WII_IPC_HLE_Interface::EnqueueReply(s_event_hook_address);
   s_event_hook_address = 0;
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -92,7 +92,7 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Close(u32 command_address, b
 {
   s_event_hook_address = 0;
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 
@@ -119,7 +119,7 @@ bool CWII_IPC_HLE_Device_stm_eventhook::HasHookInstalled() const
 
 void CWII_IPC_HLE_Device_stm_eventhook::TriggerEvent(const u32 event) const
 {
-  if (!m_Active || s_event_hook_address == 0)
+  if (!m_is_active || s_event_hook_address == 0)
   {
     // If the device isn't open, ignore the button press.
     return;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -13,28 +13,28 @@ CWII_IPC_HLE_Device_stub::CWII_IPC_HLE_Device_stub(u32 device_id, const std::str
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::Open(u32 command_address, u32 mode)
 {
-  WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_Name.c_str());
-  m_Active = true;
+  WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_name.c_str());
+  m_is_active = true;
   return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::Close(u32 command_address, bool force)
 {
-  WARN_LOG(WII_IPC_HLE, "%s faking Close()", m_Name.c_str());
-  m_Active = false;
+  WARN_LOG(WII_IPC_HLE, "%s faking Close()", m_name.c_str());
+  m_is_active = false;
   return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtl(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_name.c_str());
   Memory::Write_U32(IPC_SUCCESS, command_address + 4);
   return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtlV(u32 command_address)
 {
-  WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_Name.c_str());
+  WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_name.c_str());
   Memory::Write_U32(IPC_SUCCESS, command_address + 4);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -28,13 +28,13 @@ IPCCommandResult CWII_IPC_HLE_Device_stub::Close(u32 command_address, bool force
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtl(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_Name.c_str());
-  Memory::Write_U32(FS_SUCCESS, command_address + 4);
+  Memory::Write_U32(IPC_SUCCESS, command_address + 4);
   return GetDefaultReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtlV(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_Name.c_str());
-  Memory::Write_U32(FS_SUCCESS, command_address + 4);
+  Memory::Write_U32(IPC_SUCCESS, command_address + 4);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
@@ -54,7 +54,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_base::IOCtl(u32 command_add
 {
   // NeoGamma (homebrew) is known to use this path.
   ERROR_LOG(WII_IPC_WIIMOTE, "Bad IOCtl to /dev/usb/oh1/57e/305");
-  Memory::Write_U32(FS_EINVAL, command_address + 4);
+  Memory::Write_U32(IPC_EINVAL, command_address + 4);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -123,7 +123,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::DoState(PointerWrap& p)
     return;
   }
 
-  p.Do(m_Active);
+  p.Do(m_is_active);
   p.Do(m_ControllerBD);
   p.Do(m_CtrlSetup);
   p.Do(m_ACLSetup);
@@ -154,7 +154,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Open(u32 _CommandAddre
   m_HCIEndpoint.m_cmd_address = 0;
   m_ACLEndpoint.m_cmd_address = 0;
 
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -168,7 +168,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Close(u32 _CommandAddr
   m_HCIEndpoint.m_cmd_address = 0;
   m_ACLEndpoint.m_cmd_address = 0;
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -176,7 +176,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::IOCtl(u32 _CommandAddr
 {
   // NeoGamma (homebrew) is known to use this path.
   ERROR_LOG(WII_IPC_WIIMOTE, "Bad IOCtl in CWII_IPC_HLE_Device_usb_oh1_57e_305");
-  Memory::Write_U32(FS_EINVAL, _CommandAddress + 4);
+  Memory::Write_U32(IPC_EINVAL, _CommandAddress + 4);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -141,7 +141,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Open(u32 command_addr
 
   StartTransferThread();
 
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -155,7 +155,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_real::Close(u32 command_add
     m_handle = nullptr;
   }
 
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -57,8 +57,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Open(u32 _CommandAddress, u32 _Mod
   m_OldModifiers = 0x00;
 
   // m_MessageQueue.push(SMessageData(MSG_KBD_CONNECT, 0, nullptr));
-  Memory::Write_U32(m_DeviceID, _CommandAddress + 4);
-  m_Active = true;
+  m_is_active = true;
   return GetDefaultReply();
 }
 
@@ -67,7 +66,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _b
   INFO_LOG(WII_IPC_HLE, "CWII_IPC_HLE_Device_usb_kbd: Close");
   while (!m_MessageQueue.empty())
     m_MessageQueue.pop();
-  m_Active = false;
+  m_is_active = false;
   return GetDefaultReply();
 }
 
@@ -109,7 +108,7 @@ bool CWII_IPC_HLE_Device_usb_kbd::IsKeyPressed(int _Key)
 
 u32 CWII_IPC_HLE_Device_usb_kbd::Update()
 {
-  if (!SConfig::GetInstance().m_WiiKeyboard || Core::g_want_determinism || !m_Active)
+  if (!SConfig::GetInstance().m_WiiKeyboard || Core::g_want_determinism || !m_is_active)
     return 0;
 
   u8 Modifiers = 0x00;


### PR DESCRIPTION
* A number of naming changes to use the new naming conventions, notably in IWII_IPC_HLE_Device.
* Replace the IOS return code #defines with a scoped enum. This will be useful *later* on to enforce proper return codes for Open() and simplify things in the USB PR.
* Also make return code names more consistent (with POSIX-like names, with an added bonus: they're similar to what libogc uses) and less surprising: the FS_ prefix is now only used for filesystem stuff.
