### PR TITLE
Jit64Base: Const correctness for LogGeneratedX86

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
@@ -126,10 +126,10 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
   return true;
 }
 
-void LogGeneratedX86(int size, const PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
+void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
                      const JitBlock* b)
 {
-  for (int i = 0; i < size; i++)
+  for (size_t i = 0; i < size; i++)
   {
     const PPCAnalyst::CodeOp& op = code_buffer->codebuffer[i];
     std::string temp = StringFromFormat(

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.cpp
@@ -126,8 +126,8 @@ bool Jitx86Base::BackPatch(u32 emAddress, SContext* ctx)
   return true;
 }
 
-void LogGeneratedX86(int size, PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
-                     JitBlock* b)
+void LogGeneratedX86(int size, const PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
+                     const JitBlock* b)
 {
   for (int i = 0; i < size; i++)
   {

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
@@ -47,5 +47,5 @@ public:
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
 };
 
-void LogGeneratedX86(int size, PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
-                     JitBlock* b);
+void LogGeneratedX86(int size, const PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
+                     const JitBlock* b);

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64Base.h
@@ -47,5 +47,5 @@ public:
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
 };
 
-void LogGeneratedX86(int size, const PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
+void LogGeneratedX86(size_t size, const PPCAnalyst::CodeBuffer* code_buffer, const u8* normalEntry,
                      const JitBlock* b);


### PR DESCRIPTION
Neither `code_buffer` or `b` are modified in this function.