### PR TITLE
Don't call Movie::SetTitleId from ES

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -405,6 +405,7 @@ void RestoreConfig()
 {
   SConfig::GetInstance().LoadSettingsFromSysconf();
   SConfig::GetInstance().m_strGameID = "00000000";
+  SConfig::GetInstance().m_title_id = 0;
   config_cache.RestoreConfig(&SConfig::GetInstance());
 }
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -761,6 +761,7 @@ void SConfig::LoadDefaults()
 
   m_strName = "NONE";
   m_strGameID = "00000000";
+  m_title_id = 0;
   m_revision = 0;
 }
 
@@ -843,6 +844,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       }
       m_strName = pVolume->GetInternalName();
       m_strGameID = pVolume->GetGameID();
+      pVolume->GetTitleID(&m_title_id);
       m_revision = pVolume->GetRevision();
 
       // Check if we have a Wii disc
@@ -909,6 +911,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       {
         m_strName = pVolume->GetInternalName();
         m_strGameID = pVolume->GetGameID();
+        pVolume->GetTitleID(&m_title_id);
       }
       else
       {
@@ -916,12 +919,13 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
         // if this is the second boot we would be using the Name and id of the last title
         m_strName.clear();
         m_strGameID.clear();
+        m_title_id = 0;
       }
 
       // Use the TitleIDhex for name and/or game ID if launching
       // from nand folder or if it is not ascii characters
       // (specifically sysmenu could potentially apply to other things)
-      std::string titleidstr = StringFromFormat("%016" PRIx64, ContentLoader.GetTitleID());
+      std::string titleidstr = StringFromFormat("%016" PRIx64, m_title_id);
 
       if (m_strName.empty())
       {

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -202,6 +202,7 @@ struct SConfig : NonCopyable
   std::string m_strDVDRoot;
   std::string m_strApploader;
   std::string m_strGameID;
+  u64 m_title_id;
   std::string m_strName;
   std::string m_strWiiSDCardPath;
   u16 m_revision;

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -1316,7 +1316,6 @@ u32 ES::ES_DIVerify(const std::vector<u8>& tmd)
   File::CreateFullPath(tmd_path);
   File::CreateFullPath(Common::GetTitleDataPath(tmd_title_id, Common::FROM_SESSION_ROOT));
 
-  Movie::SetTitleId(tmd_title_id);
   std::string save_path = Common::GetTitleDataPath(tmd_title_id, Common::FROM_SESSION_ROOT);
   if (Movie::IsRecordingInput())
   {

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -1317,15 +1317,8 @@ u32 ES::ES_DIVerify(const std::vector<u8>& tmd)
   File::CreateFullPath(Common::GetTitleDataPath(tmd_title_id, Common::FROM_SESSION_ROOT));
 
   std::string save_path = Common::GetTitleDataPath(tmd_title_id, Common::FROM_SESSION_ROOT);
-  if (Movie::IsRecordingInput())
-  {
-    // TODO: Check for the actual save data
-    if (File::Exists(save_path + "banner.bin"))
-      Movie::SetClearSave(false);
-    else
-      Movie::SetClearSave(true);
-  }
 
+  // TODO: There's not supposed to be a whole load of Movie code in IOS HLE.
   // TODO: Force the game to save to another location, instead of moving the user's save.
   if (Movie::IsPlayingInput() && Movie::IsConfigSaved() && Movie::IsStartingFromClearSave())
   {

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -57,15 +57,10 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/USB/Bluetooth/BTEmu.h"
 #include "Core/IOS/USB/Bluetooth/WiimoteDevice.h"
-#include "Core/Movie.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/ec_wii.h"
 #include "DiscIO/NANDContentLoader.h"
 #include "DiscIO/Volume.h"
-
-#ifdef _WIN32
-#include <Windows.h>
-#endif
 
 namespace IOS
 {
@@ -1315,44 +1310,6 @@ u32 ES::ES_DIVerify(const std::vector<u8>& tmd)
 
   File::CreateFullPath(tmd_path);
   File::CreateFullPath(Common::GetTitleDataPath(tmd_title_id, Common::FROM_SESSION_ROOT));
-
-  std::string save_path = Common::GetTitleDataPath(tmd_title_id, Common::FROM_SESSION_ROOT);
-
-  // TODO: There's not supposed to be a whole load of Movie code in IOS HLE.
-  // TODO: Force the game to save to another location, instead of moving the user's save.
-  if (Movie::IsPlayingInput() && Movie::IsConfigSaved() && Movie::IsStartingFromClearSave())
-  {
-    if (File::Exists(save_path + "banner.bin"))
-    {
-      if (File::Exists(save_path + "../backup/"))
-      {
-        // The last run of this game must have been to play back a movie, so their save is already
-        // backed up.
-        File::DeleteDirRecursively(save_path);
-      }
-      else
-      {
-#ifdef _WIN32
-        MoveFile(UTF8ToTStr(save_path).c_str(), UTF8ToTStr(save_path + "../backup/").c_str());
-#else
-        File::CopyDir(save_path, save_path + "../backup/");
-        File::DeleteDirRecursively(save_path);
-#endif
-      }
-    }
-  }
-  else if (File::Exists(save_path + "../backup/"))
-  {
-    // Delete the save made by a previous movie, and copy back the user's save.
-    if (File::Exists(save_path + "banner.bin"))
-      File::DeleteDirRecursively(save_path);
-#ifdef _WIN32
-    MoveFile(UTF8ToTStr(save_path + "../backup/").c_str(), UTF8ToTStr(save_path).c_str());
-#else
-    File::CopyDir(save_path + "../backup/", save_path);
-    File::DeleteDirRecursively(save_path + "../backup/");
-#endif
-  }
 
   if (!File::Exists(tmd_path))
   {

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -77,7 +77,6 @@ static bool s_bDiscChange = false;
 static bool s_bReset = false;
 static std::string s_author = "";
 static std::string s_discChange = "";
-static u64 s_titleID = 0;
 static u8 s_MD5[16];
 static u8 s_bongos, s_memcards;
 static u8 s_revision[20];
@@ -403,11 +402,6 @@ void SetReset(bool reset)
   s_bReset = reset;
 }
 
-void SetTitleId(u64 title_id)
-{
-  s_titleID = title_id;
-}
-
 bool IsUsingPad(int controller)
 {
   return ((s_controllers & (1 << controller)) != 0);
@@ -582,9 +576,11 @@ bool BeginRecordingInput(int controllers)
     // This is only done here if starting from save state because otherwise we won't have the
     // titleid. Otherwise it's set in IOS::HLE::Device::ES.
     // TODO: find a way to GetTitleDataPath() from Movie::Init()
+    // TODO: This comment is out of date. The title ID is no longer set in IOS::HLE::Device::ES
     if (SConfig::GetInstance().bWii)
     {
-      if (File::Exists(Common::GetTitleDataPath(s_titleID, Common::FROM_SESSION_ROOT) +
+      if (File::Exists(Common::GetTitleDataPath(SConfig::GetInstance().m_title_id,
+                                                Common::FROM_SESSION_ROOT) +
                        "banner.bin"))
         Movie::s_bClearSave = false;
       else

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -374,11 +374,6 @@ u64 GetTotalLagCount()
   return s_totalLagCount;
 }
 
-void SetClearSave(bool enabled)
-{
-  s_bClearSave = enabled;
-}
-
 void SignalDiscChange(const std::string& new_path)
 {
   if (Movie::IsRecordingInput())
@@ -573,19 +568,6 @@ bool BeginRecordingInput(int controllers)
     State::SaveAs(save_path);
     s_bRecordingFromSaveState = true;
 
-    // This is only done here if starting from save state because otherwise we won't have the
-    // titleid. Otherwise it's set in IOS::HLE::Device::ES.
-    // TODO: find a way to GetTitleDataPath() from Movie::Init()
-    // TODO: This comment is out of date. The title ID is no longer set in IOS::HLE::Device::ES
-    if (SConfig::GetInstance().bWii)
-    {
-      if (File::Exists(Common::GetTitleDataPath(SConfig::GetInstance().m_title_id,
-                                                Common::FROM_SESSION_ROOT) +
-                       "banner.bin"))
-        Movie::s_bClearSave = false;
-      else
-        Movie::s_bClearSave = true;
-    }
     std::thread md5thread(GetMD5);
     md5thread.detach();
     GetSettings();
@@ -1487,6 +1469,9 @@ void GetSettings()
   s_bNetPlay = NetPlay::IsNetPlayRunning();
   if (SConfig::GetInstance().bWii)
   {
+    u64 title_id = SConfig::GetInstance().m_title_id;
+    s_bClearSave =
+        !File::Exists(Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT) + "banner.bin");
     s_language = SConfig::GetInstance().m_wii_language;
   }
   else

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -132,7 +132,6 @@ u64 GetTotalLagCount();
 void SetClearSave(bool enabled);
 void SignalDiscChange(const std::string& new_path);
 void SetReset(bool reset);
-void SetTitleId(u64 title_id);
 
 bool IsConfigSaved();
 bool IsDualCore();

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -129,7 +129,6 @@ u64 GetTotalInputCount();
 u64 GetCurrentLagCount();
 u64 GetTotalLagCount();
 
-void SetClearSave(bool enabled);
 void SignalDiscChange(const std::string& new_path);
 void SetReset(bool reset);
 

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -9,15 +9,63 @@
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
 #include "Common/SysConf.h"
+#include "Core/ConfigManager.h"
+#include "Core/Movie.h"
 #include "Core/WiiRoot.h"
+
+#ifdef _WIN32
+#include <Windows.h>
+#endif
 
 namespace Core
 {
 static std::string s_temp_wii_root;
 
+static void InitializeDeterministicWiiSaves()
+{
+  std::string save_path =
+      Common::GetTitleDataPath(SConfig::GetInstance().m_title_id, Common::FROM_SESSION_ROOT);
+
+  // TODO: Force the game to save to another location, instead of moving the user's save.
+  if (Movie::IsPlayingInput() && Movie::IsConfigSaved() && Movie::IsStartingFromClearSave())
+  {
+    if (File::Exists(save_path + "banner.bin"))
+    {
+      if (File::Exists(save_path + "../backup/"))
+      {
+        // The last run of this game must have been to play back a movie, so their save is already
+        // backed up.
+        File::DeleteDirRecursively(save_path);
+      }
+      else
+      {
+#ifdef _WIN32
+        MoveFile(UTF8ToTStr(save_path).c_str(), UTF8ToTStr(save_path + "../backup/").c_str());
+#else
+        File::CopyDir(save_path, save_path + "../backup/");
+        File::DeleteDirRecursively(save_path);
+#endif
+      }
+    }
+  }
+  else if (File::Exists(save_path + "../backup/"))
+  {
+    // Delete the save made by a previous movie, and copy back the user's save.
+    if (File::Exists(save_path + "banner.bin"))
+      File::DeleteDirRecursively(save_path);
+#ifdef _WIN32
+    MoveFile(UTF8ToTStr(save_path + "../backup/").c_str(), UTF8ToTStr(save_path).c_str());
+#else
+    File::CopyDir(save_path + "../backup/", save_path);
+    File::DeleteDirRecursively(save_path + "../backup/");
+#endif
+  }
+}
+
 void InitializeWiiRoot(bool use_temporary)
 {
   ShutdownWiiRoot();
+
   if (use_temporary)
   {
     s_temp_wii_root = File::CreateTempDir();
@@ -44,6 +92,8 @@ void InitializeWiiRoot(bool use_temporary)
   {
     File::SetUserPath(D_SESSION_WIIROOT_IDX, File::GetUserPath(D_WIIROOT_IDX));
   }
+
+  InitializeDeterministicWiiSaves();
 }
 
 void ShutdownWiiRoot()


### PR DESCRIPTION
Movie basically just wants to get the title ID of the initally booted game, so let's set the title ID in ConfigManager at boot like we do with the regular game ID.

Aside from being cleaner, this should make the approach to title IDs compatible with booting non-disc software (WADs).