### PR TITLE
IOS HLE: Minor changes to match IOS behaviour

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -65,7 +65,7 @@ static std::mutex s_device_map_mutex;
 
 // STATE_TO_SAVE
 constexpr u8 IPC_MAX_FDS = 0x18;
-constexpr u8 ES_MAX_COUNT = 2;
+constexpr u8 ES_MAX_COUNT = 3;
 static std::shared_ptr<IWII_IPC_HLE_Device> s_fdmap[IPC_MAX_FDS];
 static std::shared_ptr<IWII_IPC_HLE_Device> s_es_handles[ES_MAX_COUNT];
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
@@ -81,30 +81,35 @@ IPCCommandResult IWII_IPC_HLE_Device::Close(u32 command_address, bool force)
 IPCCommandResult IWII_IPC_HLE_Device::Seek(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support Seek()", m_name.c_str());
+  Memory::Write_U32(IPC_EINVAL, command_address);
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Read(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support Read()", m_name.c_str());
+  Memory::Write_U32(IPC_EINVAL, command_address);
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Write(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support Write()", m_name.c_str());
+  Memory::Write_U32(IPC_EINVAL, command_address);
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::IOCtl(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support IOCtl()", m_name.c_str());
+  Memory::Write_U32(IPC_EINVAL, command_address);
   return GetDefaultReply();
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::IOCtlV(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support IOCtlV()", m_name.c_str());
+  Memory::Write_U32(IPC_EINVAL, command_address);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -106,6 +106,12 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 command_address)
     return GetDefaultReply();
   }
 
+  if (s_event_hook_address != 0)
+  {
+    Memory::Write_U32(FS_EEXIST, command_address + 4);
+    return GetDefaultReply();
+  }
+
   // IOCTL_STM_EVENTHOOK waits until the reset button or power button
   // is pressed.
   s_event_hook_address = command_address;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
@@ -50,14 +50,6 @@ void RestoreBTInfoSection(SysConf* sysconf)
   File::Delete(filename);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_base::IOCtl(u32 command_address)
-{
-  // NeoGamma (homebrew) is known to use this path.
-  ERROR_LOG(WII_IPC_WIIMOTE, "Bad IOCtl to /dev/usb/oh1/57e/305");
-  Memory::Write_U32(IPC_EINVAL, command_address + 4);
-  return GetDefaultReply();
-}
-
 CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlMessage::CtrlMessage(const SIOCtlVBuffer& cmd_buffer)
 {
   request_type = Memory::Read_U8(cmd_buffer.InBuffer[0].m_Address);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
@@ -28,7 +28,6 @@ public:
 
   virtual IPCCommandResult Open(u32 command_address, u32 mode) override = 0;
   virtual IPCCommandResult Close(u32 command_address, bool force) override = 0;
-  IPCCommandResult IOCtl(u32 command_address) override;
   virtual IPCCommandResult IOCtlV(u32 command_address) override = 0;
 
   virtual void DoState(PointerWrap& p) override = 0;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -172,14 +172,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Close(u32 _CommandAddr
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::IOCtl(u32 _CommandAddress)
-{
-  // NeoGamma (homebrew) is known to use this path.
-  ERROR_LOG(WII_IPC_WIIMOTE, "Bad IOCtl in CWII_IPC_HLE_Device_usb_oh1_57e_305");
-  Memory::Write_U32(IPC_EINVAL, _CommandAddress + 4);
-  return GetDefaultReply();
-}
-
 IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::IOCtlV(u32 _CommandAddress)
 {
   bool _SendReply = false;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h
@@ -47,7 +47,6 @@ public:
   IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
 
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
 
   u32 Update() override;
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 66;  // Last changed in PR 4607
+static const u32 STATE_VERSION = 67;  // Last changed in PR 4634
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
A couple of small changes to match IOS behaviour:

* Don't allow replacing a STM event hook with another one until it's been released.
* Allow up to 3 ES handles. The limit seemed strange to me, but it's been confirmed by a hardware test + quick diassembly, and it technically fixes a small inaccuracy in the current code.
* Set return value to EINVAL for all unknown commands. This way, we don't have to override a command handler only to write the return value or worse, forget to do that and leave it unchanged.