### PR TITLE
CodeBlock: Const correctness for IsInSpace

### DIFF
--- a/Source/Core/Common/CodeBlock.h
+++ b/Source/Core/Common/CodeBlock.h
@@ -71,7 +71,7 @@ public:
     }
   }
 
-  bool IsInSpace(u8* ptr) const { return (ptr >= region) && (ptr < (region + region_size)); }
+  bool IsInSpace(const u8* ptr) const { return ptr >= region && ptr < (region + region_size); }
   // Cannot currently be undone. Will write protect the entire code region.
   // Start over if you need to change the code (call FreeCodeSpace(), AllocCodeSpace()).
   void WriteProtect() { Common::WriteProtectMemory(region, region_size, true); }

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -30,7 +30,7 @@ public:
   void Shutdown() override;
 
   JitBaseBlockCache* GetBlockCache() override { return &blocks; }
-  bool IsInCodeSpace(u8* ptr) const { return IsInSpace(ptr); }
+  bool IsInCodeSpace(const u8* ptr) const { return IsInSpace(ptr); }
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
 
   void ClearCache() override;


### PR DESCRIPTION
Self-explanatory; nothing about the data being pointed to is actually modified.