### PR TITLE
IOS HLE: Replace is_hardware with a proper device type

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
@@ -47,8 +47,8 @@ SIOCtlVBuffer::SIOCtlVBuffer(const u32 address) : m_Address(address)
 }
 
 IWII_IPC_HLE_Device::IWII_IPC_HLE_Device(const u32 device_id, const std::string& device_name,
-                                         const bool hardware)
-    : m_name(device_name), m_device_id(device_id), m_is_hardware(hardware)
+                                         const DeviceType type)
+    : m_name(device_name), m_device_id(device_id), m_device_type(type)
 {
 }
 
@@ -62,7 +62,7 @@ void IWII_IPC_HLE_Device::DoStateShared(PointerWrap& p)
 {
   p.Do(m_name);
   p.Do(m_device_id);
-  p.Do(m_is_hardware);
+  p.Do(m_device_type);
   p.Do(m_is_active);
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -62,7 +62,14 @@ struct SIOCtlVBuffer
 class IWII_IPC_HLE_Device
 {
 public:
-  IWII_IPC_HLE_Device(u32 device_id, const std::string& device_name, bool hardware = true);
+  enum class DeviceType : u32
+  {
+    Static,  // Devices which appear in s_device_map.
+    FileIO,  // FileIO devices which are created dynamically.
+  };
+
+  IWII_IPC_HLE_Device(u32 device_id, const std::string& device_name,
+                      DeviceType type = DeviceType::Static);
 
   virtual ~IWII_IPC_HLE_Device() = default;
   // Release any resources which might interfere with savestating.
@@ -81,17 +88,16 @@ public:
   virtual IPCCommandResult IOCtlV(u32 command_address);
 
   virtual u32 Update() { return 0; }
-  virtual bool IsHardware() const { return m_is_hardware; }
+  virtual DeviceType GetDeviceType() const { return m_device_type; }
   virtual bool IsOpened() const { return m_is_active; }
   static IPCCommandResult GetDefaultReply();
   static IPCCommandResult GetNoReply();
 
-  std::string m_name;
-
 protected:
+  std::string m_name;
   // STATE_TO_SAVE
   u32 m_device_id;
-  bool m_is_hardware;
+  DeviceType m_device_type;
   bool m_is_active = false;
 
   // Write out the IPC struct from command_address to number_of_commands numbers

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -66,7 +66,7 @@ void HLE_IPC_CreateVirtualFATFilesystem()
 
 CWII_IPC_HLE_Device_FileIO::CWII_IPC_HLE_Device_FileIO(u32 device_id,
                                                        const std::string& device_name)
-    : IWII_IPC_HLE_Device(device_id, device_name, false)  // not a real hardware
+    : IWII_IPC_HLE_Device(device_id, device_name, DeviceType::FileIO)
 {
 }
 

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 67;  // Last changed in PR 4634
+static const u32 STATE_VERSION = 68;  // Last changed in PR 4638
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
is_hardware is an obscure name (what does hardware mean?) and it forces us to assume that anything that !is_hardware is a FileIO device. This assumption prevents properly restoring OH0 child devices (which will be implemented in the USB PR), so this commit replaces the is_hardware bool with a device type.