### PR TITLE
DolphinWX: Always keep panic alerts on top

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -707,8 +707,9 @@ void CFrame::OnHostMessage(wxCommandEvent& event)
   {
     wxString caption = event.GetString().BeforeFirst(':');
     wxString text = event.GetString().AfterFirst(':');
-    bPanicResult = (wxYES == wxMessageBox(text, caption, event.GetInt() ? wxYES_NO : wxOK,
-                                          wxWindow::FindFocus()));
+    bPanicResult =
+        (wxYES == wxMessageBox(text, caption, wxSTAY_ON_TOP | (event.GetInt() ? wxYES_NO : wxOK),
+                               wxWindow::FindFocus()));
     panic_event.Set();
   }
   break;

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -360,7 +360,8 @@ bool wxMsgAlert(const char* caption, const char* text, bool yes_no, int /*Style*
       npd->AppendChat("/!\\ " + std::string{text});
       return true;
     }
-    return wxYES == wxMessageBox(StrToWxStr(text), StrToWxStr(caption), (yes_no) ? wxYES_NO : wxOK,
+    return wxYES == wxMessageBox(StrToWxStr(text), StrToWxStr(caption),
+                                 wxSTAY_ON_TOP | ((yes_no) ? wxYES_NO : wxOK),
                                  wxWindow::FindFocus());
   }
   else


### PR DESCRIPTION
This should prevent silly things like panic alerts opening *behind* the render window and thus being impossible to see.

**Needs testing.** It seems to work fine in my testing, but since this is wxWidgets…