### PR TITLE
Android: Change Exit Without Saving to Save and Exit

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsActivityPresenter.java
@@ -91,8 +91,7 @@ public final class SettingsActivityPresenter
 	{
 		switch (itemId)
 		{
-			case R.id.menu_exit_no_save:
-				mShouldSave = false;
+			case R.id.menu_save_exit:
 				mView.finish();
 				return true;
 		}

--- a/Source/Android/app/src/main/res/menu/menu_settings.xml
+++ b/Source/Android/app/src/main/res/menu/menu_settings.xml
@@ -3,9 +3,9 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/menu_exit_no_save"
-        android:title="@string/preferences_exit_no_save"
-        android:icon="@drawable/ic_cancel"
+        android:id="@+id/menu_save_exit"
+        android:title="@string/preferences_save_exit"
+        android:icon="@drawable/ic_quicksave"
         app:showAsAction="ifRoom"/>
 
 </menu>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -199,7 +199,7 @@
     <string name="add_directory_empty_folder">That folder is empty.</string>
 
     <!-- Preferences Screen -->
-    <string name="preferences_exit_no_save">Exit Without Saving</string>
+    <string name="preferences_save_exit">Save and Exit</string>
     <string name="preferences_settings">Settings</string>
     <string name="preferences_extensions">Extension Bindings</string>
 


### PR DESCRIPTION
This saves us from having to press the back button multiple times to get back to the game list from the settings. More importantly, it will help all the users who are pressing the 'X' button to leave settings, and then wondering why their settings aren't being saved.