### PR TITLE
IOS HLE: Make Device::Update() return void

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -87,7 +87,7 @@ public:
   virtual IPCCommandResult IOCtl(u32 command_address);
   virtual IPCCommandResult IOCtlV(u32 command_address);
 
-  virtual u32 Update() { return 0; }
+  virtual void Update() {}
   virtual DeviceType GetDeviceType() const { return m_device_type; }
   virtual bool IsOpened() const { return m_is_active; }
   static IPCCommandResult GetDefaultReply();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -1489,8 +1489,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
   return GetDefaultReply();
 }
 
-u32 CWII_IPC_HLE_Device_net_ip_top::Update()
+void CWII_IPC_HLE_Device_net_ip_top::Update()
 {
   WiiSockMan::GetInstance().Update();
-  return 0;
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -210,7 +210,7 @@ public:
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
-  u32 Update() override;
+  void Update() override;
 
 private:
 #ifdef _WIN32

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
@@ -31,7 +31,6 @@ public:
   virtual IPCCommandResult IOCtlV(u32 command_address) override = 0;
 
   virtual void DoState(PointerWrap& p) override = 0;
-  virtual u32 Update() override = 0;
 
   virtual void UpdateSyncButtonState(bool is_held) {}
   virtual void TriggerSyncButtonPressedEvent() {}

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
@@ -27,8 +27,6 @@ public:
   virtual ~CWII_IPC_HLE_Device_usb_oh1_57e_305_base() override = default;
 
   virtual IPCCommandResult Open(u32 command_address, u32 mode) override = 0;
-  virtual IPCCommandResult Close(u32 command_address, bool force) override = 0;
-  virtual IPCCommandResult IOCtlV(u32 command_address) override = 0;
 
   virtual void DoState(PointerWrap& p) override = 0;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -384,10 +384,8 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::AddEventToQueue(const SQueuedEvent
   }
 }
 
-u32 CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Update()
+void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Update()
 {
-  bool packet_transferred = false;
-
   // check HCI queue
   if (!m_EventQueue.empty() && m_HCIEndpoint.IsValid())
   {
@@ -402,15 +400,11 @@ u32 CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Update()
     WII_IPC_HLE_Interface::EnqueueReply(m_HCIEndpoint.m_cmd_address);
     m_HCIEndpoint.Invalidate();
     m_EventQueue.pop_front();
-    packet_transferred = true;
   }
 
   // check ACL queue
   if (!m_acl_pool.IsEmpty() && m_ACLEndpoint.IsValid() && m_EventQueue.empty())
-  {
     m_acl_pool.WriteToEndpoint(m_ACLEndpoint);
-    packet_transferred = true;
-  }
 
   // We wait for ScanEnable to be sent from the Bluetooth stack through HCI_CMD_WRITE_SCAN_ENABLE
   // before we initiate the connection.
@@ -453,8 +447,6 @@ u32 CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::Update()
   }
 
   SendEventNumberOfCompletedPackets();
-
-  return packet_transferred;
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::ACLPool::Store(const u8* data, const u16 size,

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h
@@ -48,7 +48,7 @@ public:
 
   IPCCommandResult IOCtlV(u32 _CommandAddress) override;
 
-  u32 Update() override;
+  void Update() override;
 
   // Send ACL data back to Bluetooth stack
   void SendACLPacket(u16 connection_handle, const u8* data, u32 size);

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
@@ -47,7 +47,6 @@ public:
   IPCCommandResult IOCtlV(u32 command_address) override;
 
   void DoState(PointerWrap& p) override;
-  u32 Update() override { return 0; }
   void UpdateSyncButtonState(bool is_held) override;
   void TriggerSyncButtonPressedEvent() override;
   void TriggerSyncButtonHeldEvent() override;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.h
@@ -26,5 +26,4 @@ public:
   IPCCommandResult IOCtl(u32 command_address) override { return GetDefaultReply(); }
   IPCCommandResult IOCtlV(u32 command_address) override { return GetNoReply(); }
   void DoState(PointerWrap& p) override;
-  u32 Update() override { return 0; }
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.h
@@ -22,8 +22,5 @@ public:
   }
   ~CWII_IPC_HLE_Device_usb_oh1_57e_305_stub() override {}
   IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force) override { return GetNoReply(); }
-  IPCCommandResult IOCtl(u32 command_address) override { return GetDefaultReply(); }
-  IPCCommandResult IOCtlV(u32 command_address) override { return GetNoReply(); }
   void DoState(PointerWrap& p) override;
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -106,10 +106,10 @@ bool CWII_IPC_HLE_Device_usb_kbd::IsKeyPressed(int _Key)
 #endif
 }
 
-u32 CWII_IPC_HLE_Device_usb_kbd::Update()
+void CWII_IPC_HLE_Device_usb_kbd::Update()
 {
   if (!SConfig::GetInstance().m_WiiKeyboard || Core::g_want_determinism || !m_is_active)
-    return 0;
+    return;
 
   u8 Modifiers = 0x00;
   u8 PressedKeys[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
@@ -182,8 +182,6 @@ u32 CWII_IPC_HLE_Device_usb_kbd::Update()
 
   if (GotEvent)
     m_MessageQueue.push(SMessageData(MSG_EVENT, Modifiers, PressedKeys));
-
-  return 0;
 }
 
 // Crazy ugly

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
@@ -21,7 +21,7 @@ public:
   IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
   IPCCommandResult Write(u32 _CommandAddress) override;
   IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  u32 Update() override;
+  void Update() override;
 
 private:
   enum


### PR DESCRIPTION
The return value is not used at all, so it's useless to keep it. And its semantics were not even well defined.

While I was removing unused `Update()`s, I have also removed some useless overrides in the BT device classes (command handlers which are never used).