### PR TITLE
IOS HLE: Minor simplifications

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -106,11 +106,8 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
 
   // Prepare the out buffer(s) with zeros as a safety precaution
   // to avoid returning bad values
-  for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; i++)
-  {
-    Memory::Memset(CommandBuffer.PayloadBuffer[i].m_Address, 0,
-                   CommandBuffer.PayloadBuffer[i].m_Size);
-  }
+  for (const auto& buffer : CommandBuffer.PayloadBuffer)
+    Memory::Memset(buffer.m_Address, 0, buffer.m_Size);
 
   u32 ReturnValue = 0;
   switch (CommandBuffer.Parameter)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -78,11 +78,8 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(u32 _CommandAddress)
 
   // Prepare the out buffer(s) with zeros as a safety precaution
   // to avoid returning bad values
-  for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; i++)
-  {
-    Memory::Memset(CommandBuffer.PayloadBuffer[i].m_Address, 0,
-                   CommandBuffer.PayloadBuffer[i].m_Size);
-  }
+  for (const auto& buffer : CommandBuffer.PayloadBuffer)
+    Memory::Memset(buffer.m_Address, 0, buffer.m_Size);
 
   switch (CommandBuffer.Parameter)
   {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -245,11 +245,8 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(u32 _CommandAddress)
 
   // Prepare the out buffer(s) with zeros as a safety precaution
   // to avoid returning bad values
-  for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; i++)
-  {
-    Memory::Memset(CommandBuffer.PayloadBuffer[i].m_Address, 0,
-                   CommandBuffer.PayloadBuffer[i].m_Size);
-  }
+  for (const auto& buffer : CommandBuffer.PayloadBuffer)
+    Memory::Memset(buffer.m_Address, 0, buffer.m_Size);
 
   u32 ReturnValue = 0;
   switch (CommandBuffer.Parameter)


### PR DESCRIPTION
Three independant changes that are too small to warrant their own PRs:

* **Simplify Reset():** We only need to close IOS devices which were opened, and we can do that simply by iterating over `s_fdmap` and closing any opened device. No need to close every device in `s_device_map` individually.

* **Simplify SetDefaultContentFile():** Instead of iterating over `s_device_map`, we can simply use `s_es_handles` which is guaranteed to contain three valid ES devices. Gets rid of a downcast.

* **Replace some loops with range-based for loops.** Same thing, but more concise. (I eventually plan to deduplicate request parsing code, but that'll be for later to avoid causing merge conflicts for the WFS PR.)