### PR TITLE
JitCache: Clean up block id handling.

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -212,7 +212,7 @@ void CachedInterpreter::Jit(u32 address)
   b->codeSize = (u32)(GetCodePtr() - b->checkedEntry);
   b->originalSize = code_block.m_num_instructions;
 
-  m_block_cache.FinalizeBlock(block_num, jo.enableBlocklink, b->checkedEntry);
+  m_block_cache.FinalizeBlock(*b, jo.enableBlocklink, b->checkedEntry);
 }
 
 void CachedInterpreter::ClearCache()

--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -140,8 +140,7 @@ void CachedInterpreter::Jit(u32 address)
     return;
   }
 
-  int block_num = m_block_cache.AllocateBlock(PC);
-  JitBlock* b = m_block_cache.GetBlock(block_num);
+  JitBlock* b = m_block_cache.AllocateBlock(PC);
 
   js.blockStart = PC;
   js.firstFPInstructionFound = false;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -589,8 +589,7 @@ void Jit64::Jit(u32 em_address)
     return;
   }
 
-  int block_num = blocks.AllocateBlock(em_address);
-  JitBlock* b = blocks.GetBlock(block_num);
+  JitBlock* b = blocks.AllocateBlock(em_address);
   blocks.FinalizeBlock(*b, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -591,7 +591,7 @@ void Jit64::Jit(u32 em_address)
 
   int block_num = blocks.AllocateBlock(em_address);
   JitBlock* b = blocks.GetBlock(block_num);
-  blocks.FinalizeBlock(block_num, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
+  blocks.FinalizeBlock(*b, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
 }
 
 const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock* b, u32 nextPC)

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -507,8 +507,7 @@ void JitIL::Jit(u32 em_address)
     return;
   }
 
-  int block_num = blocks.AllocateBlock(em_address);
-  JitBlock* b = blocks.GetBlock(block_num);
+  JitBlock* b = blocks.AllocateBlock(em_address);
   blocks.FinalizeBlock(*b, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
 }
 

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -509,7 +509,7 @@ void JitIL::Jit(u32 em_address)
 
   int block_num = blocks.AllocateBlock(em_address);
   JitBlock* b = blocks.GetBlock(block_num);
-  blocks.FinalizeBlock(block_num, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
+  blocks.FinalizeBlock(*b, jo.enableBlocklink, DoJit(em_address, &code_buffer, b, nextPC));
 }
 
 const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock* b, u32 nextPC)

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -401,7 +401,7 @@ void JitArm64::Jit(u32)
   int block_num = blocks.AllocateBlock(em_address);
   JitBlock* b = blocks.GetBlock(block_num);
   const u8* BlockPtr = DoJit(em_address, &code_buffer, b, nextPC);
-  blocks.FinalizeBlock(block_num, jo.enableBlocklink, BlockPtr);
+  blocks.FinalizeBlock(*b, jo.enableBlocklink, BlockPtr);
 }
 
 const u8* JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock* b, u32 nextPC)

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -398,8 +398,7 @@ void JitArm64::Jit(u32)
     return;
   }
 
-  int block_num = blocks.AllocateBlock(em_address);
-  JitBlock* b = blocks.GetBlock(block_num);
+  JitBlock* b = blocks.AllocateBlock(em_address);
   const u8* BlockPtr = DoJit(em_address, &code_buffer, b, nextPC);
   blocks.FinalizeBlock(*b, jo.enableBlocklink, BlockPtr);
 }

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -119,6 +119,12 @@ int* JitBaseBlockCache::GetICache()
   return iCache.data();
 }
 
+void JitBaseBlockCache::RunOnBlocks(std::function<void(const JitBlock&)> f)
+{
+  for (int i = 0; i < num_blocks; i++)
+    f(blocks[i]);
+}
+
 JitBlock* JitBaseBlockCache::AllocateBlock(u32 em_address)
 {
   JitBlock& b = blocks[num_blocks];

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -131,9 +131,8 @@ int JitBaseBlockCache::AllocateBlock(u32 em_address)
   return num_blocks - 1;
 }
 
-void JitBaseBlockCache::FinalizeBlock(int block_num, bool block_link, const u8* code_ptr)
+void JitBaseBlockCache::FinalizeBlock(JitBlock& b, bool block_link, const u8* code_ptr)
 {
-  JitBlock& b = blocks[block_num];
   if (start_block_map.count(b.physicalAddress))
   {
     // We already have a block at this address; invalidate the old block.
@@ -146,6 +145,7 @@ void JitBaseBlockCache::FinalizeBlock(int block_num, bool block_link, const u8* 
         std::make_pair(old_b.physicalAddress + 4 * old_b.originalSize - 1, old_b.physicalAddress));
     DestroyBlock(old_b, true);
   }
+  const int block_num = static_cast<int>(&b - &blocks[0]);
   start_block_map[b.physicalAddress] = block_num;
   FastLookupEntryForAddress(b.effectiveAddress) = block_num;
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -119,7 +119,7 @@ int* JitBaseBlockCache::GetICache()
   return iCache.data();
 }
 
-int JitBaseBlockCache::AllocateBlock(u32 em_address)
+JitBlock* JitBaseBlockCache::AllocateBlock(u32 em_address)
 {
   JitBlock& b = blocks[num_blocks];
   b.invalid = false;
@@ -128,7 +128,7 @@ int JitBaseBlockCache::AllocateBlock(u32 em_address)
   b.msrBits = MSR & JitBlock::JIT_CACHE_MSR_MASK;
   b.linkData.clear();
   num_blocks++;  // commit the current block
-  return num_blocks - 1;
+  return &b;
 }
 
 void JitBaseBlockCache::FinalizeBlock(JitBlock& b, bool block_link, const u8* code_ptr)

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -306,9 +306,8 @@ void JitBaseBlockCache::LinkBlock(JitBlock& b)
   }
 }
 
-void JitBaseBlockCache::UnlinkBlock(int i)
+void JitBaseBlockCache::UnlinkBlock(const JitBlock& b)
 {
-  JitBlock& b = blocks[i];
   auto ppp = links_to.equal_range(b.effectiveAddress);
 
   for (auto iter = ppp.first; iter != ppp.second; ++iter)
@@ -346,7 +345,7 @@ void JitBaseBlockCache::DestroyBlock(int block_num, bool invalidate)
   start_block_map.erase(b.physicalAddress);
   FastLookupEntryForAddress(b.effectiveAddress) = 0;
 
-  UnlinkBlock(block_num);
+  UnlinkBlock(b);
 
   // Delete linking addresses
   auto it = links_to.equal_range(b.effectiveAddress);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -153,7 +153,7 @@ void JitBaseBlockCache::FinalizeBlock(JitBlock& b, bool block_link, const u8* co
   for (u32 block = pAddr / 32; block <= (pAddr + (b.originalSize - 1) * 4) / 32; ++block)
     valid_block.Set(block);
 
-  block_map[std::make_pair(pAddr + 4 * b.originalSize - 1, pAddr)] = block_num;
+  block_map[std::make_pair(pAddr + 4 * b.originalSize - 1, pAddr)] = &b;
 
   if (block_link)
   {
@@ -233,7 +233,7 @@ void JitBaseBlockCache::InvalidateICache(u32 address, const u32 length, bool for
     auto it = block_map.lower_bound(std::make_pair(pAddr, 0));
     while (it != block_map.end() && it->first.second < pAddr + length)
     {
-      DestroyBlock(blocks[it->second], true);
+      DestroyBlock(*it->second, true);
       it = block_map.erase(it);
     }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -96,22 +96,12 @@ void JitBaseBlockCache::SchedulateClearCacheThreadSafe()
 
 bool JitBaseBlockCache::IsFull() const
 {
-  return GetNumBlocks() >= MAX_NUM_BLOCKS - 1;
-}
-
-JitBlock* JitBaseBlockCache::GetBlock(int no)
-{
-  return &blocks[no];
+  return num_blocks >= MAX_NUM_BLOCKS - 1;
 }
 
 JitBlock* JitBaseBlockCache::GetBlocks()
 {
   return blocks.data();
-}
-
-int JitBaseBlockCache::GetNumBlocks() const
-{
-  return num_blocks;
 }
 
 int* JitBaseBlockCache::GetICache()

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -269,9 +269,8 @@ void JitBaseBlockCache::WriteDestroyBlock(const JitBlock& block)
 // Can be faster by doing a queue for blocks to link up, and only process those
 // Should probably be done
 
-void JitBaseBlockCache::LinkBlockExits(int i)
+void JitBaseBlockCache::LinkBlockExits(JitBlock& b)
 {
-  JitBlock& b = blocks[i];
   if (b.invalid)
   {
     // This block is dead. Don't relink it.
@@ -296,15 +295,15 @@ void JitBaseBlockCache::LinkBlockExits(int i)
 
 void JitBaseBlockCache::LinkBlock(int i)
 {
-  LinkBlockExits(i);
-  const JitBlock& b = blocks[i];
+  JitBlock& b = blocks[i];
+  LinkBlockExits(b);
   auto ppp = links_to.equal_range(b.effectiveAddress);
 
   for (auto iter = ppp.first; iter != ppp.second; ++iter)
   {
-    const JitBlock& b2 = blocks[iter->second];
+    JitBlock& b2 = blocks[iter->second];
     if (b.msrBits == b2.msrBits)
-      LinkBlockExits(iter->second);
+      LinkBlockExits(b2);
   }
 }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -180,14 +180,12 @@ JitBlock* JitBaseBlockCache::GetBlockFromStartAddress(u32 addr, u32 msr)
   auto map_result = start_block_map.find(translated_addr);
   if (map_result == start_block_map.end())
     return nullptr;
-  JitBlock& b = *map_result->second;
-  if (b.invalid)
+
+  JitBlock* b = map_result->second;
+  if (b->invalid || b->effectiveAddress != addr ||
+      b->msrBits != (msr & JitBlock::JIT_CACHE_MSR_MASK))
     return nullptr;
-  if (b.effectiveAddress != addr)
-    return nullptr;
-  if (b.msrBits != (msr & JitBlock::JIT_CACHE_MSR_MASK))
-    return nullptr;
-  return &b;
+  return b;
 }
 
 const u8* JitBaseBlockCache::Dispatch()

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -159,7 +159,7 @@ void JitBaseBlockCache::FinalizeBlock(JitBlock& b, bool block_link, const u8* co
   {
     for (const auto& e : b.linkData)
     {
-      links_to.emplace(e.exitAddress, block_num);
+      links_to.emplace(e.exitAddress, &b);
     }
 
     LinkBlock(b);
@@ -295,7 +295,7 @@ void JitBaseBlockCache::LinkBlock(JitBlock& b)
 
   for (auto iter = ppp.first; iter != ppp.second; ++iter)
   {
-    JitBlock& b2 = blocks[iter->second];
+    JitBlock& b2 = *iter->second;
     if (b.msrBits == b2.msrBits)
       LinkBlockExits(b2);
   }
@@ -307,7 +307,7 @@ void JitBaseBlockCache::UnlinkBlock(const JitBlock& b)
 
   for (auto iter = ppp.first; iter != ppp.second; ++iter)
   {
-    JitBlock& sourceBlock = blocks[iter->second];
+    JitBlock& sourceBlock = *iter->second;
     if (sourceBlock.msrBits != b.msrBits)
       continue;
 
@@ -340,7 +340,7 @@ void JitBaseBlockCache::DestroyBlock(JitBlock& b, bool invalidate)
   auto it = links_to.equal_range(b.effectiveAddress);
   while (it.first != it.second)
   {
-    if (it.first->second == &b - &blocks[0])
+    if (it.first->second == &b)
       it.first = links_to.erase(it.first);
     else
       it.first++;

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -163,7 +163,7 @@ void JitBaseBlockCache::FinalizeBlock(int block_num, bool block_link, const u8* 
       links_to.emplace(e.exitAddress, block_num);
     }
 
-    LinkBlock(block_num);
+    LinkBlock(b);
   }
 
   JitRegister::Register(b.checkedEntry, b.codeSize, "JIT_PPC_%08x", b.physicalAddress);
@@ -293,9 +293,8 @@ void JitBaseBlockCache::LinkBlockExits(JitBlock& b)
   }
 }
 
-void JitBaseBlockCache::LinkBlock(int i)
+void JitBaseBlockCache::LinkBlock(JitBlock& b)
 {
-  JitBlock& b = blocks[i];
   LinkBlockExits(b);
   auto ppp = links_to.equal_range(b.effectiveAddress);
 
@@ -373,7 +372,7 @@ void JitBaseBlockCache::MoveBlockIntoFastCache(u32 addr, u32 msr)
   else
   {
     FastLookupEntryForAddress(addr) = block_num;
-    LinkBlock(block_num);
+    LinkBlock(blocks[block_num]);
   }
 }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -173,7 +173,7 @@ private:
 
   // links_to hold all exit points of all valid blocks in a reverse way.
   // It is used to query all blocks which links to an address.
-  std::multimap<u32, int> links_to;  // destination_PC -> number
+  std::multimap<u32, JitBlock*> links_to;  // destination_PC -> number
 
   // Map indexed by the physical memory location.
   // It is used to invalidate blocks based on memory location.

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -132,7 +132,7 @@ public:
   int* GetICache();
 
   int AllocateBlock(u32 em_address);
-  void FinalizeBlock(int block_num, bool block_link, const u8* code_ptr);
+  void FinalizeBlock(JitBlock& b, bool block_link, const u8* code_ptr);
 
   // Look for the block in the slow but accurate way.
   // This function shall be used if FastLookupEntryForAddress() failed.

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -136,7 +136,8 @@ public:
 
   // Look for the block in the slow but accurate way.
   // This function shall be used if FastLookupEntryForAddress() failed.
-  int GetBlockNumberFromStartAddress(u32 em_address, u32 msr);
+  // This might return nullptr if there is no such block.
+  JitBlock* GetBlockFromStartAddress(u32 em_address, u32 msr);
 
   // Get the normal entry for the block associated with the current program
   // counter. This will JIT code if necessary. (This is the reference

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -177,7 +177,7 @@ private:
 
   // Map indexed by the physical memory location.
   // It is used to invalidate blocks based on memory location.
-  std::map<std::pair<u32, u32>, u32> block_map;  // (end_addr, start_addr) -> number
+  std::map<std::pair<u32, u32>, JitBlock*> block_map;  // (end_addr, start_addr) -> block
 
   // Map indexed by the physical address of the entry point.
   // This is used to query the block based on the current PC in a slow way.

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -157,7 +157,7 @@ private:
 
   void LinkBlockExits(JitBlock& b);
   void LinkBlock(JitBlock& b);
-  void UnlinkBlock(int i);
+  void UnlinkBlock(const JitBlock& b);
   void DestroyBlock(int block_num, bool invalidate);
 
   void MoveBlockIntoFastCache(u32 em_address, u32 msr);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -182,7 +182,7 @@ private:
   // Map indexed by the physical address of the entry point.
   // This is used to query the block based on the current PC in a slow way.
   // TODO: This is redundant with block_map, and both should be a multimap.
-  std::map<u32, u32> start_block_map;  // start_addr -> number
+  std::map<u32, JitBlock*> start_block_map;  // start_addr -> block
 
   // This bitsets shows which cachelines overlap with any blocks.
   // It is used to provide a fast way to query if no icache invalidation is needed.

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -156,7 +156,7 @@ private:
   virtual void WriteDestroyBlock(const JitBlock& block);
 
   void LinkBlockExits(JitBlock& b);
-  void LinkBlock(int i);
+  void LinkBlock(JitBlock& b);
   void UnlinkBlock(int i);
   void DestroyBlock(int block_num, bool invalidate);
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -131,7 +131,7 @@ public:
   int GetNumBlocks() const;
   int* GetICache();
 
-  int AllocateBlock(u32 em_address);
+  JitBlock* AllocateBlock(u32 em_address);
   void FinalizeBlock(JitBlock& b, bool block_link, const u8* code_ptr);
 
   // Look for the block in the slow but accurate way.

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -158,7 +158,7 @@ private:
   void LinkBlockExits(JitBlock& b);
   void LinkBlock(JitBlock& b);
   void UnlinkBlock(const JitBlock& b);
-  void DestroyBlock(int block_num, bool invalidate);
+  void DestroyBlock(JitBlock& b, bool invalidate);
 
   void MoveBlockIntoFastCache(u32 em_address, u32 msr);
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -127,9 +127,7 @@ public:
   bool IsFull() const;
 
   // Code Cache
-  JitBlock* GetBlock(int block_num);
   JitBlock* GetBlocks();
-  int GetNumBlocks() const;
   int* GetICache();
   void RunOnBlocks(std::function<void(const JitBlock&)> f);
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -132,7 +132,7 @@ public:
   void RunOnBlocks(std::function<void(const JitBlock&)> f);
 
   JitBlock* AllocateBlock(u32 em_address);
-  void FinalizeBlock(JitBlock& b, bool block_link, const u8* code_ptr);
+  void FinalizeBlock(JitBlock& block, bool block_link, const u8* code_ptr);
 
   // Look for the block in the slow but accurate way.
   // This function shall be used if FastLookupEntryForAddress() failed.
@@ -156,10 +156,10 @@ private:
   virtual void WriteLinkBlock(const JitBlock::LinkData& source, const JitBlock* dest) = 0;
   virtual void WriteDestroyBlock(const JitBlock& block);
 
-  void LinkBlockExits(JitBlock& b);
-  void LinkBlock(JitBlock& b);
-  void UnlinkBlock(const JitBlock& b);
-  void DestroyBlock(JitBlock& b, bool invalidate);
+  void LinkBlockExits(JitBlock& block);
+  void LinkBlock(JitBlock& block);
+  void UnlinkBlock(const JitBlock& block);
+  void DestroyBlock(JitBlock& block, bool invalidate);
 
   void MoveBlockIntoFastCache(u32 em_address, u32 msr);
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <bitset>
+#include <functional>
 #include <map>
 #include <memory>
 #include <vector>
@@ -130,6 +131,7 @@ public:
   JitBlock* GetBlocks();
   int GetNumBlocks() const;
   int* GetICache();
+  void RunOnBlocks(std::function<void(const JitBlock&)> f);
 
   JitBlock* AllocateBlock(u32 em_address);
   void FinalizeBlock(JitBlock& b, bool block_link, const u8* code_ptr);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -155,7 +155,7 @@ private:
   virtual void WriteLinkBlock(const JitBlock::LinkData& source, const JitBlock* dest) = 0;
   virtual void WriteDestroyBlock(const JitBlock& block);
 
-  void LinkBlockExits(int i);
+  void LinkBlockExits(JitBlock& b);
   void LinkBlock(int i);
   void UnlinkBlock(int i);
   void DestroyBlock(int block_num, bool invalidate);

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -168,33 +168,30 @@ int GetHostCode(u32* address, const u8** code, u32* code_size)
     return 1;
   }
 
-  int block_num = g_jit->GetBlockCache()->GetBlockNumberFromStartAddress(*address, MSR);
-  if (block_num < 0)
+  JitBlock* block = g_jit->GetBlockCache()->GetBlockFromStartAddress(*address, MSR);
+  if (!block)
   {
     for (int i = 0; i < 500; i++)
     {
-      block_num = g_jit->GetBlockCache()->GetBlockNumberFromStartAddress(*address - 4 * i, MSR);
-      if (block_num >= 0)
+      block = g_jit->GetBlockCache()->GetBlockFromStartAddress(*address - 4 * i, MSR);
+      if (block)
         break;
     }
 
-    if (block_num >= 0)
+    if (block)
     {
-      JitBlock* block = g_jit->GetBlockCache()->GetBlock(block_num);
       if (!(block->effectiveAddress <= *address &&
             block->originalSize + block->effectiveAddress >= *address))
-        block_num = -1;
+        block = nullptr;
     }
 
     // Do not merge this "if" with the above - block_num changes inside it.
-    if (block_num < 0)
+    if (!block)
     {
       *code_size = 0;
       return 2;
     }
   }
-
-  JitBlock* block = g_jit->GetBlockCache()->GetBlock(block_num);
 
   *code = block->checkedEntry;
   *code_size = block->codeSize;

--- a/Source/Core/Core/PowerPC/Profiler.h
+++ b/Source/Core/Core/PowerPC/Profiler.h
@@ -43,11 +43,10 @@
 
 struct BlockStat
 {
-  BlockStat(int bn, u32 _addr, u64 c, u64 ticks, u64 run, u32 size)
-      : blockNum(bn), addr(_addr), cost(c), tick_counter(ticks), run_count(run), block_size(size)
+  BlockStat(u32 _addr, u64 c, u64 ticks, u64 run, u32 size)
+      : addr(_addr), cost(c), tick_counter(ticks), run_count(run), block_size(size)
   {
   }
-  int blockNum;
   u32 addr;
   u64 cost;
   u64 tick_counter;


### PR DESCRIPTION
And replace it with pointers / references.

This PR replaces the id handling in all functions but in the icache, which requires to alter the JIT dispatchers. The long term goal is to also rewrite it there to get rid of the limited block allocation.