### PR TITLE
IOFile: Get rid of IOFile's ReleaseHandle function

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -947,13 +947,6 @@ bool IOFile::Close()
   return m_good;
 }
 
-std::FILE* IOFile::ReleaseHandle()
-{
-  std::FILE* const ret = m_file;
-  m_file = nullptr;
-  return ret;
-}
-
 void IOFile::SetHandle(std::FILE* file)
 {
   Close();

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -212,8 +212,6 @@ public:
   // m_good is set to false when a read, write or other function fails
   bool IsGood() const { return m_good; }
   explicit operator bool() const { return IsGood() && IsOpen(); }
-  std::FILE* ReleaseHandle();
-
   std::FILE* GetHandle() { return m_file; }
   void SetHandle(std::FILE* file);
 

--- a/Source/Core/Common/SysConf.h
+++ b/Source/Core/Common/SysConf.h
@@ -14,6 +14,11 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 
+namespace File
+{
+class IOFile;
+}
+
 // This class is meant to edit the values in a given Wii SYSCONF file
 // It currently does not add/remove/rearrange sections,
 // instead only modifies exiting sections' data
@@ -175,7 +180,7 @@ public:
   void UpdateLocation();
 
 private:
-  bool LoadFromFileInternal(FILE* fh);
+  bool LoadFromFileInternal(File::IOFile&& file);
   void GenerateSysConf();
   void Clear();
 

--- a/Source/Core/Core/HW/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard.cpp
@@ -827,15 +827,12 @@ u32 GCMemcard::ImportGci(const std::string& inputFile, const std::string& output
   if (!gci)
     return OPENFAIL;
 
-  u32 result = ImportGciInternal(gci.ReleaseHandle(), inputFile, outputFile);
-
-  return result;
+  return ImportGciInternal(std::move(gci), inputFile, outputFile);
 }
 
-u32 GCMemcard::ImportGciInternal(FILE* gcih, const std::string& inputFile,
+u32 GCMemcard::ImportGciInternal(File::IOFile&& gci, const std::string& inputFile,
                                  const std::string& outputFile)
 {
-  File::IOFile gci(gcih);
   unsigned int offset;
   std::string fileType;
   SplitPath(inputFile, nullptr, nullptr, &fileType);

--- a/Source/Core/Core/HW/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard.h
@@ -15,6 +15,11 @@
 #include "Core/HW/EXI_DeviceIPL.h"
 #include "Core/HW/Sram.h"
 
+namespace File
+{
+class IOFile;
+}
+
 #define BE64(x) (Common::swap64(x))
 #define BE32(x) (Common::swap32(x))
 #define BE16(x) (Common::swap16(x))
@@ -304,7 +309,8 @@ private:
 
   std::vector<GCMBlock> mc_data_blocks;
 
-  u32 ImportGciInternal(FILE* gcih, const std::string& inputFile, const std::string& outputFile);
+  u32 ImportGciInternal(File::IOFile&& gci, const std::string& inputFile,
+                        const std::string& outputFile);
   void InitDirBatPointers();
 
 public:


### PR DESCRIPTION
Transfer of handles should be done via std::move. Also the entire point of using IOFile is so that manual handle management isn't a concern.