### PR TITLE
Fix savestates in Bluetooth passthrough mode

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -98,6 +98,16 @@ private:
   Common::Flag m_fake_vendor_command_reply;
   u16 m_fake_vendor_command_reply_opcode;
 
+  // This stores the address of paired devices and associated link keys.
+  // It is needed because some adapters forget all stored link keys when they are reset,
+  // which breaks pairings because the Wii relies on the Bluetooth module to remember them.
+  std::map<btaddr_t, linkkey_t> m_link_keys;
+  Common::Flag m_need_reset_keys;
+
+  // This flag is set when a libusb transfer failed (for reasons other than timing out)
+  // and we showed an OSD message about it.
+  Common::Flag m_showed_failed_transfer;
+
   bool m_is_wii_bt_module = false;
 
   void WaitForHCICommandComplete(u16 opcode);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 72;  // Last changed in PR 4710
+static const u32 STATE_VERSION = 73;  // Last changed in PR 4651
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This fixes savestates when using Bluetooth passthrough by keeping track of pending transfer commands and discarding them on state load, so that the emulated software receives a reply to IOS requests as expected.

With this change, savestates in BT passthrough should work as noted in the following table:

| BT state when saving | when loading | Result |
| --- | --- | --- |
| N remotes connected | N remotes connected **during the same session**<br>(remotes were *not* disconnected after saving) |  Working :white_check_mark: |
| N remotes connected | some or all remotes disconnected | Working\* :white_check_mark: |
| 0 remote connected | 0 remote connected | Working :white_check_mark: |
| N remotes connected | some or all remotes connected during a different session<br>(i.e., disconnected after saving) | Not supported |
| 0 remote connected | 1 or more remotes connected | Not supported |

<sup>\* On the first connection attempt, the game will realise that the Wiimote has disconnected. A remote can then be connected. Also, you may need to connect then disconnect a Wiimote first before loading the state; otherwise the adapter may get confused.</sup>

Basically, as long as there's no Bluetooth connection, or the Bluetooth connections all match (which are the most common cases), then it should work fine.

This PR also gets rid of the static state, which was previously needed because the transfer callbacks were static methods.