### PR TITLE
DSPInterpreter: Get rid of a #define constant

### DIFF
--- a/Source/Core/Core/DSP/Interpreter/DSPIntLoadStore.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntLoadStore.cpp
@@ -48,7 +48,7 @@ void lrs(const UDSPInstruction opc)
 // Move value from data memory pointed by address M to register $D.
 void lr(const UDSPInstruction opc)
 {
-  u8 reg = opc & DSP_REG_MASK;
+  u8 reg = opc & 0x1F;
   u16 addr = dsp_fetch_code();
   u16 val = dsp_dmem_read(addr);
   dsp_op_write_reg(reg, val);
@@ -61,7 +61,7 @@ void lr(const UDSPInstruction opc)
 // Store value from register $S to a memory pointed by address M.
 void sr(const UDSPInstruction opc)
 {
-  u8 reg = opc & DSP_REG_MASK;
+  u8 reg = opc & 0x1F;
   u16 addr = dsp_fetch_code();
 
   if (reg >= DSP_REG_ACM0)

--- a/Source/Core/Core/DSP/Interpreter/DSPIntMisc.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntMisc.cpp
@@ -41,7 +41,7 @@ void mrr(const UDSPInstruction opc)
 // S16 mode.
 void lri(const UDSPInstruction opc)
 {
-  u8 reg = opc & DSP_REG_MASK;
+  u8 reg = opc & 0x1F;
   u16 imm = dsp_fetch_code();
   dsp_op_write_reg(reg, imm);
   dsp_conditional_extend_accum(reg);

--- a/Source/Core/Core/DSP/Interpreter/DSPInterpreter.h
+++ b/Source/Core/Core/DSP/Interpreter/DSPInterpreter.h
@@ -6,8 +6,6 @@
 
 #include "Core/DSP/DSPCommon.h"
 
-#define DSP_REG_MASK 0x1f
-
 namespace DSP
 {
 namespace Interpreter

--- a/Source/Core/Core/DSP/Jit/DSPJitLoadStore.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitLoadStore.cpp
@@ -8,7 +8,6 @@
 
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPMemoryMap.h"
-#include "Core/DSP/Interpreter/DSPInterpreter.h"
 #include "Core/DSP/Jit/DSPEmitter.h"
 
 using namespace Gen;
@@ -70,7 +69,7 @@ void DSPEmitter::lrs(const UDSPInstruction opc)
 // Move value from data memory pointed by address M to register $D.
 void DSPEmitter::lr(const UDSPInstruction opc)
 {
-  int reg = opc & DSP_REG_MASK;
+  int reg = opc & 0x1F;
   u16 address = dsp_imem_read(compilePC + 1);
   dmem_read_imm(address);
   dsp_op_write_reg(reg, EAX);
@@ -83,7 +82,7 @@ void DSPEmitter::lr(const UDSPInstruction opc)
 // Store value from register $S to a memory pointed by address M.
 void DSPEmitter::sr(const UDSPInstruction opc)
 {
-  u8 reg = opc & DSP_REG_MASK;
+  u8 reg = opc & 0x1F;
   u16 address = dsp_imem_read(compilePC + 1);
 
   X64Reg tmp1 = gpr.GetFreeXReg();

--- a/Source/Core/Core/DSP/Jit/DSPJitMisc.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitMisc.cpp
@@ -6,7 +6,6 @@
 
 #include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPMemoryMap.h"
-#include "Core/DSP/Interpreter/DSPInterpreter.h"
 #include "Core/DSP/Jit/DSPEmitter.h"
 
 using namespace Gen;
@@ -41,7 +40,7 @@ void DSPEmitter::mrr(const UDSPInstruction opc)
 // S16 mode.
 void DSPEmitter::lri(const UDSPInstruction opc)
 {
-  u8 reg = opc & DSP_REG_MASK;
+  u8 reg = opc & 0x1F;
   u16 imm = dsp_imem_read(compilePC + 1);
   dsp_op_write_reg_imm(reg, imm);
   dsp_conditional_extend_accum_imm(reg, imm);


### PR DESCRIPTION
This constant isn't particularly helpful, mainly because it's not applicable to all DSP instructions. Some instructions don't have encoding space for registers, and not all instructions that do encode registers have one at the first five bits.

This change also has the benefit of removing all includes to the interpreter within the JIT code, which keeps them fully separate from one another. Changes to the interpreter header won't require some of the JIT code to be rebuilt.