### PR TITLE
TextureDecoder: Fix off-by-one errors in CMPR

### DIFF
--- a/Source/Core/VideoCommon/TextureDecoder.h
+++ b/Source/Core/VideoCommon/TextureDecoder.h
@@ -88,8 +88,3 @@ void TexDecoder_SetTexFmtOverlayOptions(bool enable, bool center);
 /* Internal method, implemented by TextureDecoder_Generic and TextureDecoder_x64. */
 void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, int texformat,
                             const u8* tlut, TlutFormat tlutfmt);
-
-static constexpr int DXTBlend(int v1, int v2)
-{
-  return ((v1 * 3 + v2 * 5) >> 3);
-}

--- a/Source/Core/VideoCommon/TextureDecoder.h
+++ b/Source/Core/VideoCommon/TextureDecoder.h
@@ -88,3 +88,8 @@ void TexDecoder_SetTexFmtOverlayOptions(bool enable, bool center);
 /* Internal method, implemented by TextureDecoder_Generic and TextureDecoder_x64. */
 void _TexDecoder_DecodeImpl(u32* dst, const u8* src, int width, int height, int texformat,
                             const u8* tlut, TlutFormat tlutfmt);
+
+static constexpr int DXTBlend(int v1, int v2)
+{
+  return ((v1 * 3 + v2 * 5) >> 3);
+}

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -10,6 +10,7 @@
 #include "Common/MsgHandler.h"
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/TextureDecoder.h"
+#include "VideoCommon/TextureDecoder_Util.h"
 #include "VideoCommon/sfont.inc"
 
 static bool TexFmt_Overlay_Enable = false;
@@ -420,18 +421,6 @@ static inline u32 DecodePixel_Paletted(u16 pixel, TlutFormat tlutfmt)
   default:
     return 0;
   }
-}
-
-struct DXTBlock
-{
-  u16 color1;
-  u16 color2;
-  u8 lines[4];
-};
-
-static inline u32 MakeRGBA(int r, int g, int b, int a)
-{
-  return (a << 24) | (b << 16) | (g << 8) | r;
 }
 
 void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth, int texformat,

--- a/Source/Core/VideoCommon/TextureDecoder_Common.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Common.cpp
@@ -654,11 +654,6 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
     int red1 = Convert5To8((c1 >> 11) & 0x1F);
     int red2 = Convert5To8((c2 >> 11) & 0x1F);
 
-    // Approximation of x/3: 3/8 (1/2 - 1/8)
-    int blue3 = ((blue2 - blue1) >> 1) - ((blue2 - blue1) >> 3);
-    int green3 = ((green2 - green1) >> 1) - ((green2 - green1) >> 3);
-    int red3 = ((red2 - red1) >> 1) - ((red2 - red1) >> 3);
-
     u16 ss = s & 3;
     u16 tt = t & 3;
 
@@ -680,20 +675,18 @@ void TexDecoder_DecodeTexel(u8* dst, const u8* src, int s, int t, int imageWidth
       color = MakeRGBA(red2, green2, blue2, 255);
       break;
     case 2:
-      color = MakeRGBA(red1 + red3, green1 + green3, blue1 + blue3, 255);
+      color = MakeRGBA(DXTBlend(red2, red1), DXTBlend(green2, green1), DXTBlend(blue2, blue1), 255);
       break;
     case 3:
-      color = MakeRGBA(red2 - red3, green2 - green3, blue2 - blue3, 255);
+      color = MakeRGBA(DXTBlend(red1, red2), DXTBlend(green1, green2), DXTBlend(blue1, blue2), 255);
       break;
     case 6:
-      color =
-          MakeRGBA((red1 + red2 + 1) / 2, (green1 + green2 + 1) / 2, (blue1 + blue2 + 1) / 2, 255);
+      color = MakeRGBA((red1 + red2) / 2, (green1 + green2) / 2, (blue1 + blue2) / 2, 255);
       break;
     case 7:
       // color[3] is the same as color[2] (average of both colors), but transparent.
       // This differs from DXT1 where color[3] is transparent black.
-      color =
-          MakeRGBA((red1 + red2 + 1) / 2, (green1 + green2 + 1) / 2, (blue1 + blue2 + 1) / 2, 0);
+      color = MakeRGBA((red1 + red2) / 2, (green1 + green2) / 2, (blue1 + blue2) / 2, 0);
       break;
     default:
       color = 0;

--- a/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/TextureDecoder.h"
+#include "VideoCommon/TextureDecoder_Util.h"
 //#include "VideoCommon/VideoCommon.h" // to get debug logs
 #include "VideoCommon/VideoConfig.h"
 
@@ -140,18 +141,6 @@ static inline void DecodeBytes_RGBA8(u32* dst, const u16* src, const u16* src2)
 #endif
 }
 
-struct DXTBlock
-{
-  u16 color1;
-  u16 color2;
-  u8 lines[4];
-};
-
-static inline u32 MakeRGBA(int r, int g, int b, int a)
-{
-  return (a << 24) | (b << 16) | (g << 8) | r;
-}
-
 static void DecodeDXTBlock(u32* dst, const DXTBlock* src, int pitch)
 {
   // S3TC Decoder (Note: GCN decodes differently from PC so we can't use native support)
@@ -169,7 +158,6 @@ static void DecodeDXTBlock(u32* dst, const DXTBlock* src, int pitch)
   colors[1] = MakeRGBA(red2, green2, blue2, 255);
   if (c1 > c2)
   {
-    // Approximation of x/3: 3/8 (1/2 - 1/8)
     colors[2] =
         MakeRGBA(DXTBlend(red2, red1), DXTBlend(green2, green1), DXTBlend(blue2, blue1), 255);
     colors[3] =

--- a/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_Generic.cpp
@@ -170,20 +170,17 @@ static void DecodeDXTBlock(u32* dst, const DXTBlock* src, int pitch)
   if (c1 > c2)
   {
     // Approximation of x/3: 3/8 (1/2 - 1/8)
-    int blue3 = ((blue2 - blue1) >> 1) - ((blue2 - blue1) >> 3);
-    int green3 = ((green2 - green1) >> 1) - ((green2 - green1) >> 3);
-    int red3 = ((red2 - red1) >> 1) - ((red2 - red1) >> 3);
-    colors[2] = MakeRGBA(red1 + red3, green1 + green3, blue1 + blue3, 255);
-    colors[3] = MakeRGBA(red2 - red3, green2 - green3, blue2 - blue3, 255);
+    colors[2] =
+        MakeRGBA(DXTBlend(red2, red1), DXTBlend(green2, green1), DXTBlend(blue2, blue1), 255);
+    colors[3] =
+        MakeRGBA(DXTBlend(red1, red2), DXTBlend(green1, green2), DXTBlend(blue1, blue2), 255);
   }
   else
   {
     // color[3] is the same as color[2] (average of both colors), but transparent.
     // This differs from DXT1 where color[3] is transparent black.
-    colors[2] =
-        MakeRGBA((red1 + red2 + 1) / 2, (green1 + green2 + 1) / 2, (blue1 + blue2 + 1) / 2, 255);
-    colors[3] =
-        MakeRGBA((red1 + red2 + 1) / 2, (green1 + green2 + 1) / 2, (blue1 + blue2 + 1) / 2, 0);
+    colors[2] = MakeRGBA((red1 + red2) / 2, (green1 + green2) / 2, (blue1 + blue2) / 2, 255);
+    colors[3] = MakeRGBA((red1 + red2) / 2, (green1 + green2) / 2, (blue1 + blue2) / 2, 0);
   }
 
   for (int y = 0; y < 4; y++)

--- a/Source/Core/VideoCommon/TextureDecoder_Util.h
+++ b/Source/Core/VideoCommon/TextureDecoder_Util.h
@@ -1,0 +1,25 @@
+// Copyright 2016 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+
+struct DXTBlock
+{
+  u16 color1;
+  u16 color2;
+  u8 lines[4];
+};
+
+constexpr u32 MakeRGBA(int r, int g, int b, int a)
+{
+  return (a << 24) | (b << 16) | (g << 8) | r;
+}
+
+constexpr int DXTBlend(int v1, int v2)
+{
+  // 3/8 blend, which is close to 1/3
+  return ((v1 * 3 + v2 * 5) >> 3);
+}

--- a/Source/Core/VideoCommon/TextureDecoder_x64.cpp
+++ b/Source/Core/VideoCommon/TextureDecoder_x64.cpp
@@ -14,6 +14,7 @@
 
 #include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/TextureDecoder.h"
+#include "VideoCommon/TextureDecoder_Util.h"
 
 // GameCube/Wii texture decoder
 
@@ -56,13 +57,6 @@ static inline u32 DecodePixel_RGB5A3(u16 val)
   }
   return r | (g << 8) | (b << 16) | (a << 24);
 }
-
-struct DXTBlock
-{
-  u16 color1;
-  u16 color2;
-  u8 lines[4];
-};
 
 static inline void DecodeBytes_C4_IA8(u32* dst, const u8* src, const u8* tlut_)
 {
@@ -168,11 +162,6 @@ static inline void DecodeBytes_IA4(u32* dst, const u8* src)
 }
 
 #ifdef CHECK
-static inline u32 MakeRGBA(int r, int g, int b, int a)
-{
-  return (a << 24) | (b << 16) | (g << 8) | r;
-}
-
 static void DecodeDXTBlock(u32* dst, const DXTBlock* src, int pitch)
 {
   // S3TC Decoder (Note: GCN decodes differently from PC so we can't use native support)
@@ -190,7 +179,6 @@ static void DecodeDXTBlock(u32* dst, const DXTBlock* src, int pitch)
   colors[1] = MakeRGBA(red2, green2, blue2, 255);
   if (c1 > c2)
   {
-    // Approximation of x/3: 3/8 (1/2 - 1/8)
     colors[2] =
         MakeRGBA(DXTBlend(red2, red1), DXTBlend(green2, green1), DXTBlend(blue2, blue1), 255);
     colors[3] =

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -203,6 +203,9 @@
     <ClInclude Include="TextureDecoder.h">
       <Filter>Decoding</Filter>
     </ClInclude>
+    <ClInclude Include="TextureDecoder_Util.h">
+      <Filter>Decoding</Filter>
+    </ClInclude>
     <ClInclude Include="BPFunctions.h">
       <Filter>Register Sections</Filter>
     </ClInclude>


### PR DESCRIPTION
This fixes some (probably imperceptible) issues in CMPR decoding, based on hardware testing.

This code previously showed different output on Wii and Dolphin, but with this PR it appears consistent: https://gist.github.com/hthh/7968c721f8296e8ea57477d15a2d2aee (note: requires real XFB). I had some problems with networking, so I haven't integrated my test code with the hwtests yet. I'll try to do that soon.