### PR TITLE
Fix ChunkFile for std::set

### DIFF
--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -120,7 +120,7 @@ public:
     case MODE_WRITE:
     case MODE_MEASURE:
     case MODE_VERIFY:
-      for (V& val : x)
+      for (const V& val : x)
       {
         Do(val);
       }


### PR DESCRIPTION
Without this, attempts to savestate std::set will fail with an error about dropping the const qualifier.