### PR TITLE
IOS HLE: Deduplicate the request parsing code

### DIFF
--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -458,11 +458,6 @@ void EnqueueReply(const IOSRequest& request, int cycles_in_future, CoreTiming::F
   CoreTiming::ScheduleEvent(cycles_in_future, s_event_enqueue, request.address, from);
 }
 
-void EnqueueReply(u32 command_address, int cycles_in_future, CoreTiming::FromThread from)
-{
-  EnqueueReply(IOSRequest{command_address}, cycles_in_future, from);
-}
-
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future)
 {
   CoreTiming::ScheduleEvent(cycles_in_future, s_event_enqueue,

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.cpp
@@ -180,7 +180,7 @@ void Reset(bool hard)
   {
     if (!device)
       continue;
-    device->Close(0, true);
+    device->Close();
     device.reset();
   }
 
@@ -348,12 +348,10 @@ static std::shared_ptr<IWII_IPC_HLE_Device> GetUnusedESDevice()
 }
 
 // Returns the FD for the newly opened device (on success) or an error code.
-static s32 OpenDevice(const u32 address)
+static s32 OpenDevice(const IOSOpenRequest& request)
 {
-  const std::string device_name = Memory::GetString(Memory::Read_U32(address + 0xC));
-  const u32 open_mode = Memory::Read_U32(address + 0x10);
   const s32 new_fd = GetFreeDeviceID();
-  INFO_LOG(WII_IPC_HLE, "Opening %s (mode %d, fd %d)", device_name.c_str(), open_mode, new_fd);
+  INFO_LOG(WII_IPC_HLE, "Opening %s (mode %d, fd %d)", request.path.c_str(), request.flags, new_fd);
   if (new_fd < 0 || new_fd >= IPC_MAX_FDS)
   {
     ERROR_LOG(WII_IPC_HLE, "Couldn't get a free fd, too many open files");
@@ -361,80 +359,78 @@ static s32 OpenDevice(const u32 address)
   }
 
   std::shared_ptr<IWII_IPC_HLE_Device> device;
-  if (device_name.find("/dev/es") == 0)
+  if (request.path == "/dev/es")
   {
     device = GetUnusedESDevice();
     if (!device)
       return IPC_EESEXHAUSTED;
   }
-  else if (device_name.find("/dev/") == 0)
+  else if (request.path.find("/dev/") == 0)
   {
-    device = GetDeviceByName(device_name);
+    device = GetDeviceByName(request.path);
   }
-  else if (device_name.find('/') == 0)
+  else if (request.path.find('/') == 0)
   {
-    device = std::make_shared<CWII_IPC_HLE_Device_FileIO>(new_fd, device_name);
+    device = std::make_shared<CWII_IPC_HLE_Device_FileIO>(new_fd, request.path);
   }
 
   if (!device)
   {
-    ERROR_LOG(WII_IPC_HLE, "Unknown device: %s", device_name.c_str());
+    ERROR_LOG(WII_IPC_HLE, "Unknown device: %s", request.path.c_str());
     return IPC_ENOENT;
   }
 
-  Memory::Write_U32(new_fd, address + 4);
-  device->Open(address, open_mode);
-  const s32 open_return_code = Memory::Read_U32(address + 4);
-  if (open_return_code < 0)
-    return open_return_code;
+  const IOSReturnCode code = device->Open(request);
+  if (code < IPC_SUCCESS)
+    return code;
   s_fdmap[new_fd] = device;
   return new_fd;
 }
 
-static IPCCommandResult HandleCommand(const u32 address)
+static IPCCommandResult HandleCommand(const IOSRequest& request)
 {
-  const auto command = static_cast<IPCCommandType>(Memory::Read_U32(address));
-  if (command == IPC_CMD_OPEN)
+  if (request.command == IPC_CMD_OPEN)
   {
-    const s32 new_fd = OpenDevice(address);
-    Memory::Write_U32(new_fd, address + 4);
+    IOSOpenRequest open_request{request.address};
+    const s32 new_fd = OpenDevice(open_request);
+    open_request.SetReturnValue(new_fd);
     return IWII_IPC_HLE_Device::GetDefaultReply();
   }
 
-  const s32 fd = Memory::Read_U32(address + 8);
-  const auto device = (fd >= 0 && fd < IPC_MAX_FDS) ? s_fdmap[fd] : nullptr;
+  const auto device = (request.fd < IPC_MAX_FDS) ? s_fdmap[request.fd] : nullptr;
   if (!device)
   {
-    Memory::Write_U32(IPC_EINVAL, address + 4);
+    request.SetReturnValue(IPC_EINVAL);
     return IWII_IPC_HLE_Device::GetDefaultReply();
   }
 
-  switch (command)
+  switch (request.command)
   {
   case IPC_CMD_CLOSE:
-    s_fdmap[fd].reset();
-    // A close on a valid device returns IPC_SUCCESS.
-    Memory::Write_U32(IPC_SUCCESS, address + 4);
-    return device->Close(address);
+    s_fdmap[request.fd].reset();
+    device->Close();
+    request.SetReturnValue(IPC_SUCCESS);
+    return IWII_IPC_HLE_Device::GetDefaultReply();
   case IPC_CMD_READ:
-    return device->Read(address);
+    return device->Read(IOSReadWriteRequest{request.address});
   case IPC_CMD_WRITE:
-    return device->Write(address);
+    return device->Write(IOSReadWriteRequest{request.address});
   case IPC_CMD_SEEK:
-    return device->Seek(address);
+    return device->Seek(IOSSeekRequest{request.address});
   case IPC_CMD_IOCTL:
-    return device->IOCtl(address);
+    return device->IOCtl(IOSIOCtlRequest{request.address});
   case IPC_CMD_IOCTLV:
-    return device->IOCtlV(address);
+    return device->IOCtlV(IOSIOCtlVRequest{request.address});
   default:
-    _assert_msg_(WII_IPC_HLE, false, "Unexpected command: %x", command);
+    _assert_msg_(WII_IPC_HLE, false, "Unexpected command: %x", request.command);
     return IWII_IPC_HLE_Device::GetDefaultReply();
   }
 }
 
 void ExecuteCommand(const u32 address)
 {
-  IPCCommandResult result = HandleCommand(address);
+  IOSRequest request{address};
+  IPCCommandResult result = HandleCommand(request);
 
   // Ensure replies happen in order
   const s64 ticks_until_last_reply = s_last_reply_time - CoreTiming::GetTicks();
@@ -443,7 +439,7 @@ void ExecuteCommand(const u32 address)
   s_last_reply_time = CoreTiming::GetTicks() + result.reply_delay_ticks;
 
   if (result.send_reply)
-    EnqueueReply(address, static_cast<int>(result.reply_delay_ticks));
+    EnqueueReply(request, static_cast<int>(result.reply_delay_ticks));
 }
 
 // Happens AS SOON AS IPC gets a new pointer!
@@ -453,13 +449,18 @@ void EnqueueRequest(u32 address)
 }
 
 // Called to send a reply to an IOS syscall
-void EnqueueReply(u32 address, int cycles_in_future, CoreTiming::FromThread from)
+void EnqueueReply(const IOSRequest& request, int cycles_in_future, CoreTiming::FromThread from)
 {
   // IOS writes back the command that was responded to in the FD field.
-  Memory::Write_U32(Memory::Read_U32(address), address + 8);
+  Memory::Write_U32(request.command, request.address + 8);
   // IOS also overwrites the command type with the reply type.
-  Memory::Write_U32(IPC_REPLY, address);
-  CoreTiming::ScheduleEvent(cycles_in_future, s_event_enqueue, address, from);
+  Memory::Write_U32(IPC_REPLY, request.address);
+  CoreTiming::ScheduleEvent(cycles_in_future, s_event_enqueue, request.address, from);
+}
+
+void EnqueueReply(u32 command_address, int cycles_in_future, CoreTiming::FromThread from)
+{
+  EnqueueReply(IOSRequest{command_address}, cycles_in_future, from);
 }
 
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -72,8 +72,6 @@ void ExecuteCommand(u32 address);
 void EnqueueRequest(u32 address);
 void EnqueueReply(const IOSRequest& request, int cycles_in_future = 0,
                   CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
-void EnqueueReply(u32 command_address, int cycles_in_future = 0,
-                  CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future = 0);
 
 }  // end of namespace WII_IPC_HLE_Interface

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -12,6 +12,7 @@
 #include "Core/CoreTiming.h"
 #include "Core/HW/SystemTimers.h"
 
+struct IOSRequest;
 class IWII_IPC_HLE_Device;
 class PointerWrap;
 
@@ -69,7 +70,9 @@ void UpdateDevices();
 void ExecuteCommand(u32 address);
 
 void EnqueueRequest(u32 address);
-void EnqueueReply(u32 address, int cycles_in_future = 0,
+void EnqueueReply(const IOSRequest& request, int cycles_in_future = 0,
+                  CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
+void EnqueueReply(u32 command_address, int cycles_in_future = 0,
                   CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future = 0);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE.h
@@ -18,6 +18,7 @@ class PointerWrap;
 
 struct IPCCommandResult
 {
+  s32 return_value;
   bool send_reply;
   u64 reply_delay_ticks;
 };
@@ -70,7 +71,7 @@ void UpdateDevices();
 void ExecuteCommand(u32 address);
 
 void EnqueueRequest(u32 address);
-void EnqueueReply(const IOSRequest& request, int cycles_in_future = 0,
+void EnqueueReply(const IOSRequest& request, s32 return_value, int cycles_in_future = 0,
                   CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future = 0);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
@@ -2,12 +2,16 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Core/IPC_HLE/WII_IPC_HLE.h"
+#include <algorithm>
+
+#include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
+#include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
+// TODO: remove this once all device classes have been migrated.
 SIOCtlVBuffer::SIOCtlVBuffer(const u32 address) : m_Address(address)
 {
   // These are the Ioctlv parameters in the IOS communication. The BufferVector
@@ -46,6 +50,116 @@ SIOCtlVBuffer::SIOCtlVBuffer(const u32 address) : m_Address(address)
   }
 }
 
+IOSRequest::IOSRequest(const u32 address_) : address(address_)
+{
+  command = static_cast<IPCCommandType>(Memory::Read_U32(address));
+  fd = Memory::Read_U32(address + 8);
+}
+
+void IOSRequest::SetReturnValue(const s32 new_return_value) const
+{
+  Memory::Write_U32(static_cast<u32>(new_return_value), address + 4);
+}
+
+IOSOpenRequest::IOSOpenRequest(const u32 address_) : IOSRequest(address_)
+{
+  path = Memory::GetString(Memory::Read_U32(address + 0xc));
+  flags = static_cast<IOSOpenMode>(Memory::Read_U32(address + 0x10));
+}
+
+IOSReadWriteRequest::IOSReadWriteRequest(const u32 address_) : IOSRequest(address_)
+{
+  buffer = Memory::Read_U32(address + 0xc);
+  size = Memory::Read_U32(address + 0x10);
+}
+
+IOSSeekRequest::IOSSeekRequest(const u32 address_) : IOSRequest(address_)
+{
+  offset = Memory::Read_U32(address + 0xc);
+  mode = static_cast<SeekMode>(Memory::Read_U32(address + 0x10));
+}
+
+IOSIOCtlRequest::IOSIOCtlRequest(const u32 address_) : IOSRequest(address_)
+{
+  request = Memory::Read_U32(address + 0x0c);
+  buffer_in = Memory::Read_U32(address + 0x10);
+  buffer_in_size = Memory::Read_U32(address + 0x14);
+  buffer_out = Memory::Read_U32(address + 0x18);
+  buffer_out_size = Memory::Read_U32(address + 0x1c);
+}
+
+IOSIOCtlVRequest::IOSIOCtlVRequest(const u32 address_) : IOSRequest(address_)
+{
+  request = Memory::Read_U32(address + 0x0c);
+  const u32 in_number = Memory::Read_U32(address + 0x10);
+  const u32 out_number = Memory::Read_U32(address + 0x14);
+  const u32 vectors_base = Memory::Read_U32(address + 0x18);  // address to vectors
+
+  u32 offset = 0;
+  for (size_t i = 0; i < (in_number + out_number); ++i)
+  {
+    IOVector vector;
+    vector.address = Memory::Read_U32(vectors_base + offset);
+    vector.size = Memory::Read_U32(vectors_base + offset + 4);
+    offset += 8;
+    if (i < in_number)
+      in_vectors.emplace_back(vector);
+    else
+      io_vectors.emplace_back(vector);
+  }
+}
+
+bool IOSIOCtlVRequest::HasInputVectorWithAddress(const u32 vector_address) const
+{
+  return std::any_of(in_vectors.begin(), in_vectors.end(),
+                     [&](const auto& in_vector) { return in_vector.address == vector_address; });
+}
+
+void IOSIOCtlRequest::Log(const std::string& device_name, LogTypes::LOG_TYPE type,
+                          LogTypes::LOG_LEVELS verbosity) const
+{
+  GENERIC_LOG(type, verbosity, "%s (fd %u) - IOCtl 0x%x (in_size=0x%x, out_size=0x%x)",
+              device_name.c_str(), fd, request, buffer_in_size, buffer_out_size);
+}
+
+void IOSIOCtlRequest::Dump(const std::string& description, LogTypes::LOG_TYPE type,
+                           LogTypes::LOG_LEVELS level) const
+{
+  Log("===== " + description, type, level);
+  GENERIC_LOG(type, level, "In buffer\n%s",
+              HexDump(Memory::GetPointer(buffer_in), buffer_in_size).c_str());
+  GENERIC_LOG(type, level, "Out buffer\n%s",
+              HexDump(Memory::GetPointer(buffer_out), buffer_out_size).c_str());
+}
+
+void IOSIOCtlRequest::DumpUnknown(const std::string& description, LogTypes::LOG_TYPE type,
+                                  LogTypes::LOG_LEVELS level) const
+{
+  Dump("Unknown IOCtl - " + description, type, level);
+}
+
+void IOSIOCtlVRequest::Dump(const std::string& description, LogTypes::LOG_TYPE type,
+                            LogTypes::LOG_LEVELS level) const
+{
+  GENERIC_LOG(type, level, "===== %s (fd %u) - IOCtlV 0x%x (%zu in, %zu io)", description.c_str(),
+              fd, request, in_vectors.size(), io_vectors.size());
+
+  size_t i = 0;
+  for (const auto& vector : in_vectors)
+    GENERIC_LOG(type, level, "in[%zu] (size=0x%x):\n%s", i++, vector.size,
+                HexDump(Memory::GetPointer(vector.address), vector.size).c_str());
+
+  i = 0;
+  for (const auto& vector : io_vectors)
+    GENERIC_LOG(type, level, "io[%zu] (size=0x%x)", i++, vector.size);
+}
+
+void IOSIOCtlVRequest::DumpUnknown(const std::string& description, LogTypes::LOG_TYPE type,
+                                   LogTypes::LOG_LEVELS level) const
+{
+  Dump("Unknown IOCtlV - " + description, type, level);
+}
+
 IWII_IPC_HLE_Device::IWII_IPC_HLE_Device(const u32 device_id, const std::string& device_name,
                                          const DeviceType type)
     : m_name(device_name), m_device_id(device_id), m_device_type(type)
@@ -66,16 +180,33 @@ void IWII_IPC_HLE_Device::DoStateShared(PointerWrap& p)
   p.Do(m_is_active);
 }
 
+// TODO: remove the wrappers once all device classes have been migrated.
+IOSReturnCode IWII_IPC_HLE_Device::Open(const IOSOpenRequest& request)
+{
+  Open(request.address, request.flags);
+  return static_cast<IOSReturnCode>(Memory::Read_U32(request.address + 4));
+}
+
 IPCCommandResult IWII_IPC_HLE_Device::Open(u32 command_address, u32 mode)
 {
   m_is_active = true;
   return GetDefaultReply();
 }
 
+void IWII_IPC_HLE_Device::Close()
+{
+  Close(0, true);
+}
+
 IPCCommandResult IWII_IPC_HLE_Device::Close(u32 command_address, bool force)
 {
   m_is_active = false;
   return GetDefaultReply();
+}
+
+IPCCommandResult IWII_IPC_HLE_Device::Seek(const IOSSeekRequest& request)
+{
+  return Seek(request.address);
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Seek(u32 command_address)
@@ -85,11 +216,21 @@ IPCCommandResult IWII_IPC_HLE_Device::Seek(u32 command_address)
   return GetDefaultReply();
 }
 
+IPCCommandResult IWII_IPC_HLE_Device::Read(const IOSReadWriteRequest& request)
+{
+  return Read(request.address);
+}
+
 IPCCommandResult IWII_IPC_HLE_Device::Read(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support Read()", m_name.c_str());
   Memory::Write_U32(IPC_EINVAL, command_address);
   return GetDefaultReply();
+}
+
+IPCCommandResult IWII_IPC_HLE_Device::Write(const IOSReadWriteRequest& request)
+{
+  return Write(request.address);
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::Write(u32 command_address)
@@ -99,11 +240,21 @@ IPCCommandResult IWII_IPC_HLE_Device::Write(u32 command_address)
   return GetDefaultReply();
 }
 
+IPCCommandResult IWII_IPC_HLE_Device::IOCtl(const IOSIOCtlRequest& request)
+{
+  return IOCtl(request.address);
+}
+
 IPCCommandResult IWII_IPC_HLE_Device::IOCtl(u32 command_address)
 {
   WARN_LOG(WII_IPC_HLE, "%s does not support IOCtl()", m_name.c_str());
   Memory::Write_U32(IPC_EINVAL, command_address);
   return GetDefaultReply();
+}
+
+IPCCommandResult IWII_IPC_HLE_Device::IOCtlV(const IOSIOCtlVRequest& request)
+{
+  return IOCtlV(request.address);
 }
 
 IPCCommandResult IWII_IPC_HLE_Device::IOCtlV(u32 command_address)
@@ -124,58 +275,4 @@ IPCCommandResult IWII_IPC_HLE_Device::GetDefaultReply()
 IPCCommandResult IWII_IPC_HLE_Device::GetNoReply()
 {
   return {false, 0};
-}
-
-// Write out the IPC struct from command_address to num_commands numbers
-// of 4 byte commands.
-void IWII_IPC_HLE_Device::DumpCommands(u32 command_address, size_t num_commands,
-                                       LogTypes::LOG_TYPE log_type, LogTypes::LOG_LEVELS verbosity)
-{
-  GENERIC_LOG(log_type, verbosity, "CommandDump of %s", GetDeviceName().c_str());
-  for (u32 i = 0; i < num_commands; i++)
-  {
-    GENERIC_LOG(log_type, verbosity, "    Command%02i: 0x%08x", i,
-                Memory::Read_U32(command_address + i * 4));
-  }
-}
-
-void IWII_IPC_HLE_Device::DumpAsync(u32 buffer_vector, u32 number_in_buffer, u32 number_io_buffer,
-                                    LogTypes::LOG_TYPE log_type, LogTypes::LOG_LEVELS verbosity)
-{
-  GENERIC_LOG(log_type, verbosity, "======= DumpAsync ======");
-
-  u32 BufferOffset = buffer_vector;
-  for (u32 i = 0; i < number_in_buffer; i++)
-  {
-    u32 InBuffer = Memory::Read_U32(BufferOffset);
-    BufferOffset += 4;
-    u32 InBufferSize = Memory::Read_U32(BufferOffset);
-    BufferOffset += 4;
-
-    GENERIC_LOG(log_type, LogTypes::LINFO, "%s - IOCtlV InBuffer[%i]:", GetDeviceName().c_str(), i);
-
-    std::string Temp;
-    for (u32 j = 0; j < InBufferSize; j++)
-    {
-      Temp += StringFromFormat("%02x ", Memory::Read_U8(InBuffer + j));
-    }
-
-    GENERIC_LOG(log_type, LogTypes::LDEBUG, "    Buffer: %s", Temp.c_str());
-  }
-
-  for (u32 i = 0; i < number_io_buffer; i++)
-  {
-    u32 OutBuffer = Memory::Read_U32(BufferOffset);
-    BufferOffset += 4;
-    u32 OutBufferSize = Memory::Read_U32(BufferOffset);
-    BufferOffset += 4;
-
-    GENERIC_LOG(log_type, LogTypes::LINFO, "%s - IOCtlV OutBuffer[%i]:", GetDeviceName().c_str(),
-                i);
-    GENERIC_LOG(log_type, LogTypes::LINFO, "    OutBuffer: 0x%08x (0x%x):", OutBuffer,
-                OutBufferSize);
-
-    if (verbosity >= LogTypes::LOG_LEVELS::LINFO)
-      DumpCommands(OutBuffer, OutBufferSize, log_type, verbosity);
-  }
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.cpp
@@ -18,11 +18,6 @@ IOSRequest::IOSRequest(const u32 address_) : address(address_)
   fd = Memory::Read_U32(address + 8);
 }
 
-void IOSRequest::SetReturnValue(const s32 new_return_value) const
-{
-  Memory::Write_U32(static_cast<u32>(new_return_value), address + 4);
-}
-
 IOSOpenRequest::IOSOpenRequest(const u32 address_) : IOSRequest(address_)
 {
   path = Memory::GetString(Memory::Read_U32(address + 0xc));
@@ -161,19 +156,18 @@ IPCCommandResult IWII_IPC_HLE_Device::Unsupported(const IOSRequest& request)
                                                          {IPC_CMD_IOCTL, "IOCtl"},
                                                          {IPC_CMD_IOCTLV, "IOCtlV"}}};
   WARN_LOG(WII_IPC_HLE, "%s does not support %s()", m_name.c_str(), names[request.command].c_str());
-  request.SetReturnValue(IPC_EINVAL);
-  return GetDefaultReply();
+  return GetDefaultReply(IPC_EINVAL);
 }
 
 // Returns an IPCCommandResult for a reply that takes 250 us (arbitrarily chosen value)
-IPCCommandResult IWII_IPC_HLE_Device::GetDefaultReply()
+IPCCommandResult IWII_IPC_HLE_Device::GetDefaultReply(const s32 return_value)
 {
-  return {true, SystemTimers::GetTicksPerSecond() / 4000};
+  return {return_value, true, SystemTimers::GetTicksPerSecond() / 4000};
 }
 
 // Returns an IPCCommandResult with no reply. Useful for async commands that will generate a reply
-// later
+// later. This takes no return value because it won't be used.
 IPCCommandResult IWII_IPC_HLE_Device::GetNoReply()
 {
-  return {false, 0};
+  return {IPC_SUCCESS, false, 0};
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -11,7 +11,6 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
-#include "Common/StringUtil.h"
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 
 enum IOSReturnCode : s32
@@ -42,6 +41,7 @@ enum IOSReturnCode : s32
 };
 
 // A struct for IOS ioctlv calls
+// TODO: remove this once nothing uses this anymore.
 struct SIOCtlVBuffer
 {
   explicit SIOCtlVBuffer(u32 address);
@@ -57,6 +57,91 @@ struct SIOCtlVBuffer
   };
   std::vector<SBuffer> InBuffer;
   std::vector<SBuffer> PayloadBuffer;
+};
+
+struct IOSRequest
+{
+  u32 address = 0;
+  IPCCommandType command = IPC_CMD_OPEN;
+  u32 fd = 0;
+  explicit IOSRequest(u32 address);
+  virtual ~IOSRequest() = default;
+  void SetReturnValue(s32 new_return_value) const;
+};
+
+enum IOSOpenMode : s32
+{
+  IOS_OPEN_READ = 1,
+  IOS_OPEN_WRITE = 2,
+  IOS_OPEN_RW = (IOS_OPEN_READ | IOS_OPEN_WRITE)
+};
+
+struct IOSOpenRequest final : IOSRequest
+{
+  std::string path;
+  IOSOpenMode flags = IOS_OPEN_READ;
+  explicit IOSOpenRequest(u32 address);
+};
+
+struct IOSReadWriteRequest final : IOSRequest
+{
+  u32 buffer = 0;
+  u32 size = 0;
+  explicit IOSReadWriteRequest(u32 address);
+};
+
+struct IOSSeekRequest final : IOSRequest
+{
+  enum SeekMode
+  {
+    IOS_SEEK_SET = 0,
+    IOS_SEEK_CUR = 1,
+    IOS_SEEK_END = 2,
+  };
+  u32 offset = 0;
+  SeekMode mode = IOS_SEEK_SET;
+  explicit IOSSeekRequest(u32 address);
+};
+
+struct IOSIOCtlRequest final : IOSRequest
+{
+  u32 request = 0;
+  u32 buffer_in = 0;
+  u32 buffer_in_size = 0;
+  // Contrary to the name, the output buffer can also be used for input.
+  u32 buffer_out = 0;
+  u32 buffer_out_size = 0;
+  explicit IOSIOCtlRequest(u32 address);
+  void Log(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::WII_IPC_HLE,
+           LogTypes::LOG_LEVELS level = LogTypes::LINFO) const;
+  void Dump(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::WII_IPC_HLE,
+            LogTypes::LOG_LEVELS level = LogTypes::LINFO) const;
+  void DumpUnknown(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::WII_IPC_HLE,
+                   LogTypes::LOG_LEVELS level = LogTypes::LERROR) const;
+};
+
+struct IOSIOCtlVRequest final : IOSRequest
+{
+  struct IOVector
+  {
+    u32 address = 0;
+    u32 size = 0;
+  };
+  u32 request = 0;
+  // In vectors are *mostly* used for input buffers. Sometimes they are also used as
+  // output buffers (notably in the network code).
+  // IO vectors are *mostly* used for output buffers. However, as indicated in the name,
+  // they're also used as input buffers.
+  // So both of them are technically IO vectors. But we're keeping them separated because
+  // merging them into a single std::vector would make using the first out vector more complicated.
+  std::vector<IOVector> in_vectors;
+  std::vector<IOVector> io_vectors;
+  explicit IOSIOCtlVRequest(u32 address);
+  bool HasInputVectorWithAddress(u32 vector_address) const;
+  void Dump(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::WII_IPC_HLE,
+            LogTypes::LOG_LEVELS level = LogTypes::LINFO) const;
+  void DumpUnknown(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::WII_IPC_HLE,
+                   LogTypes::LOG_LEVELS level = LogTypes::LERROR) const;
 };
 
 class IWII_IPC_HLE_Device
@@ -79,6 +164,16 @@ public:
 
   const std::string& GetDeviceName() const { return m_name; }
   u32 GetDeviceID() const { return m_device_id; }
+  // Replies to Open and Close requests are sent by WII_IPC_HLE, not by the devices themselves.
+  virtual IOSReturnCode Open(const IOSOpenRequest& request);
+  virtual void Close();
+  virtual IPCCommandResult Seek(const IOSSeekRequest& request);
+  virtual IPCCommandResult Read(const IOSReadWriteRequest& request);
+  virtual IPCCommandResult Write(const IOSReadWriteRequest& request);
+  virtual IPCCommandResult IOCtl(const IOSIOCtlRequest& request);
+  virtual IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request);
+
+  // TODO: remove these once all device classes have been migrated.
   virtual IPCCommandResult Open(u32 command_address, u32 mode);
   virtual IPCCommandResult Close(u32 command_address, bool force = false);
   virtual IPCCommandResult Seek(u32 command_address);
@@ -99,14 +194,4 @@ protected:
   u32 m_device_id;
   DeviceType m_device_type;
   bool m_is_active = false;
-
-  // Write out the IPC struct from command_address to number_of_commands numbers
-  // of 4 byte commands.
-  void DumpCommands(u32 command_address, size_t number_of_commands = 8,
-                    LogTypes::LOG_TYPE log_type = LogTypes::WII_IPC_HLE,
-                    LogTypes::LOG_LEVELS verbosity = LogTypes::LDEBUG);
-
-  void DumpAsync(u32 buffer_vector, u32 number_in_buffer, u32 number_io_buffer,
-                 LogTypes::LOG_TYPE log_type = LogTypes::WII_IPC_HLE,
-                 LogTypes::LOG_LEVELS verbosity = LogTypes::LDEBUG);
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -40,25 +40,6 @@ enum IOSReturnCode : s32
   IPC_EESEXHAUSTED = -1016,  // Max of 2 ES handles exceeded
 };
 
-// A struct for IOS ioctlv calls
-// TODO: remove this once nothing uses this anymore.
-struct SIOCtlVBuffer
-{
-  explicit SIOCtlVBuffer(u32 address);
-
-  const u32 m_Address;
-  u32 Parameter;
-  u32 NumberInBuffer;
-  u32 NumberPayloadBuffer;
-  u32 BufferVector;
-  struct SBuffer
-  {
-    u32 m_Address, m_Size;
-  };
-  std::vector<SBuffer> InBuffer;
-  std::vector<SBuffer> PayloadBuffer;
-};
-
 struct IOSRequest
 {
   u32 address = 0;
@@ -167,21 +148,11 @@ public:
   // Replies to Open and Close requests are sent by WII_IPC_HLE, not by the devices themselves.
   virtual IOSReturnCode Open(const IOSOpenRequest& request);
   virtual void Close();
-  virtual IPCCommandResult Seek(const IOSSeekRequest& request);
-  virtual IPCCommandResult Read(const IOSReadWriteRequest& request);
-  virtual IPCCommandResult Write(const IOSReadWriteRequest& request);
-  virtual IPCCommandResult IOCtl(const IOSIOCtlRequest& request);
-  virtual IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request);
-
-  // TODO: remove these once all device classes have been migrated.
-  virtual IPCCommandResult Open(u32 command_address, u32 mode);
-  virtual IPCCommandResult Close(u32 command_address, bool force = false);
-  virtual IPCCommandResult Seek(u32 command_address);
-  virtual IPCCommandResult Read(u32 command_address);
-  virtual IPCCommandResult Write(u32 command_address);
-  virtual IPCCommandResult IOCtl(u32 command_address);
-  virtual IPCCommandResult IOCtlV(u32 command_address);
-
+  virtual IPCCommandResult Seek(const IOSSeekRequest& seek) { return Unsupported(seek); }
+  virtual IPCCommandResult Read(const IOSReadWriteRequest& read) { return Unsupported(read); }
+  virtual IPCCommandResult Write(const IOSReadWriteRequest& write) { return Unsupported(write); }
+  virtual IPCCommandResult IOCtl(const IOSIOCtlRequest& ioctl) { return Unsupported(ioctl); }
+  virtual IPCCommandResult IOCtlV(const IOSIOCtlVRequest& ioctlv) { return Unsupported(ioctlv); }
   virtual void Update() {}
   virtual DeviceType GetDeviceType() const { return m_device_type; }
   virtual bool IsOpened() const { return m_is_active; }
@@ -194,4 +165,7 @@ protected:
   u32 m_device_id;
   DeviceType m_device_type;
   bool m_is_active = false;
+
+private:
+  IPCCommandResult Unsupported(const IOSRequest& request);
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device.h
@@ -47,7 +47,6 @@ struct IOSRequest
   u32 fd = 0;
   explicit IOSRequest(u32 address);
   virtual ~IOSRequest() = default;
-  void SetReturnValue(s32 new_return_value) const;
 };
 
 enum IOSOpenMode : s32
@@ -156,7 +155,7 @@ public:
   virtual void Update() {}
   virtual DeviceType GetDeviceType() const { return m_device_type; }
   virtual bool IsOpened() const { return m_is_active; }
-  static IPCCommandResult GetDefaultReply();
+  static IPCCommandResult GetDefaultReply(s32 return_value);
   static IPCCommandResult GetNoReply();
 
 protected:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -74,10 +74,7 @@ void CWII_IPC_HLE_Device_di::FinishIOCtl(DVDInterface::DIInterruptType interrupt
   // This command has been executed, so it's removed from the queue
   u32 command_address = m_commands_to_execute.front();
   m_commands_to_execute.pop_front();
-  IOSIOCtlRequest request{command_address};
-
-  request.SetReturnValue(interrupt_type);
-  WII_IPC_HLE_Interface::EnqueueReply(request);
+  WII_IPC_HLE_Interface::EnqueueReply(IOSIOCtlRequest{command_address}, interrupt_type);
 
   // DVDInterface is now ready to execute another command,
   // so we start executing a command from the queue if there is one
@@ -118,6 +115,5 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(const IOSIOCtlVRequest& request)
   default:
     request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_DVD);
   }
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.cpp
@@ -32,7 +32,7 @@ void CWII_IPC_HLE_Device_di::DoState(PointerWrap& p)
   p.Do(m_commands_to_execute);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(const IOSIOCtlRequest& request)
 {
   // DI IOCtls are handled in a special way by Dolphin
   // compared to other WII_IPC_HLE functions.
@@ -42,40 +42,25 @@ IPCCommandResult CWII_IPC_HLE_Device_di::IOCtl(u32 _CommandAddress)
   // are queued until DVDInterface is ready to handle them.
 
   bool ready_to_execute = m_commands_to_execute.empty();
-  m_commands_to_execute.push_back(_CommandAddress);
+  m_commands_to_execute.push_back(request.address);
   if (ready_to_execute)
-    StartIOCtl(_CommandAddress);
+    StartIOCtl(request);
 
   // DVDInterface handles the timing and we handle the reply,
   // so WII_IPC_HLE shouldn't handle anything.
   return GetNoReply();
 }
 
-void CWII_IPC_HLE_Device_di::StartIOCtl(u32 command_address)
+void CWII_IPC_HLE_Device_di::StartIOCtl(const IOSIOCtlRequest& request)
 {
-  u32 BufferIn = Memory::Read_U32(command_address + 0x10);
-  u32 BufferInSize = Memory::Read_U32(command_address + 0x14);
-  u32 BufferOut = Memory::Read_U32(command_address + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(command_address + 0x1C);
-
-  u32 command_0 = Memory::Read_U32(BufferIn);
-  u32 command_1 = Memory::Read_U32(BufferIn + 4);
-  u32 command_2 = Memory::Read_U32(BufferIn + 8);
-
-  DEBUG_LOG(WII_IPC_DVD, "IOCtl Command(0x%08x) BufferIn(0x%08x, 0x%x) BufferOut(0x%08x, 0x%x)",
-            command_0, BufferIn, BufferInSize, BufferOut, BufferOutSize);
-
-  // TATSUNOKO VS CAPCOM: Gets here with BufferOut == 0!!!
-  if (BufferOut != 0)
-  {
-    // Set out buffer to zeroes as a safety precaution
-    // to avoid answering nonsense values
-    Memory::Memset(BufferOut, 0, BufferOutSize);
-  }
+  const u32 command_0 = Memory::Read_U32(request.buffer_in);
+  const u32 command_1 = Memory::Read_U32(request.buffer_in + 4);
+  const u32 command_2 = Memory::Read_U32(request.buffer_in + 8);
 
   // DVDInterface's ExecuteCommand handles most of the work.
   // The IOCtl callback is used to generate a reply afterwards.
-  DVDInterface::ExecuteCommand(command_0, command_1, command_2, BufferOut, BufferOutSize, true);
+  DVDInterface::ExecuteCommand(command_0, command_1, command_2, request.buffer_out,
+                               request.buffer_out_size, true);
 }
 
 void CWII_IPC_HLE_Device_di::FinishIOCtl(DVDInterface::DIInterruptType interrupt_type)
@@ -89,58 +74,50 @@ void CWII_IPC_HLE_Device_di::FinishIOCtl(DVDInterface::DIInterruptType interrupt
   // This command has been executed, so it's removed from the queue
   u32 command_address = m_commands_to_execute.front();
   m_commands_to_execute.pop_front();
+  IOSIOCtlRequest request{command_address};
 
-  // The DI interrupt type is used as a return value
-  Memory::Write_U32(interrupt_type, command_address + 4);
-  WII_IPC_HLE_Interface::EnqueueReply(command_address);
+  request.SetReturnValue(interrupt_type);
+  WII_IPC_HLE_Interface::EnqueueReply(request);
 
   // DVDInterface is now ready to execute another command,
   // so we start executing a command from the queue if there is one
   if (!m_commands_to_execute.empty())
-    StartIOCtl(m_commands_to_execute.front());
+  {
+    IOSIOCtlRequest next_request{m_commands_to_execute.front()};
+    StartIOCtl(next_request);
+  }
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_di::IOCtlV(const IOSIOCtlVRequest& request)
 {
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
-
-  // Prepare the out buffer(s) with zeros as a safety precaution
-  // to avoid returning bad values
-  for (const auto& buffer : CommandBuffer.PayloadBuffer)
-    Memory::Memset(buffer.m_Address, 0, buffer.m_Size);
-
-  u32 ReturnValue = 0;
-  switch (CommandBuffer.Parameter)
+  for (const auto& vector : request.io_vectors)
+    Memory::Memset(vector.address, 0, vector.size);
+  s32 return_value = IPC_SUCCESS;
+  switch (request.request)
   {
   case DVDInterface::DVDLowOpenPartition:
   {
-    _dbg_assert_msg_(WII_IPC_DVD, CommandBuffer.InBuffer[1].m_Address == 0,
+    _dbg_assert_msg_(WII_IPC_DVD, request.in_vectors[1].address == 0,
                      "DVDLowOpenPartition with ticket");
-    _dbg_assert_msg_(WII_IPC_DVD, CommandBuffer.InBuffer[2].m_Address == 0,
+    _dbg_assert_msg_(WII_IPC_DVD, request.in_vectors[2].address == 0,
                      "DVDLowOpenPartition with cert chain");
 
-    u64 const partition_offset =
-        ((u64)Memory::Read_U32(CommandBuffer.InBuffer[0].m_Address + 4) << 2);
+    u64 const partition_offset = ((u64)Memory::Read_U32(request.in_vectors[0].address + 4) << 2);
     DVDInterface::ChangePartition(partition_offset);
 
     INFO_LOG(WII_IPC_DVD, "DVDLowOpenPartition: partition_offset 0x%016" PRIx64, partition_offset);
 
     // Read TMD to the buffer
     std::vector<u8> tmd_buffer = DVDInterface::GetVolume().GetTMD();
-    Memory::CopyToEmu(CommandBuffer.PayloadBuffer[0].m_Address, tmd_buffer.data(),
-                      tmd_buffer.size());
+    Memory::CopyToEmu(request.io_vectors[0].address, tmd_buffer.data(), tmd_buffer.size());
     WII_IPC_HLE_Interface::ES_DIVerify(tmd_buffer);
 
-    ReturnValue = 1;
-  }
-  break;
-
-  default:
-    ERROR_LOG(WII_IPC_DVD, "IOCtlV: %i", CommandBuffer.Parameter);
-    _dbg_assert_msg_(WII_IPC_DVD, 0, "IOCtlV: %i", CommandBuffer.Parameter);
+    return_value = 1;
     break;
   }
-
-  Memory::Write_U32(ReturnValue, _CommandAddress + 4);
+  default:
+    request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_DVD);
+  }
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_DI.h
@@ -27,13 +27,13 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
 
   void FinishIOCtl(DVDInterface::DIInterruptType interrupt_type);
 
 private:
-  void StartIOCtl(u32 command_address);
+  void StartIOCtl(const IOSIOCtlRequest& request);
 
   std::deque<u32> m_commands_to_execute;
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -308,9 +308,6 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
 {
   DEBUG_LOG(WII_IPC_FILEIO, "FileIO: IOCtl (Device=%s)", m_name.c_str());
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  DumpCommands(_CommandAddress);
-#endif
   const u32 Parameter = Memory::Read_U32(_CommandAddress + 0xC);
   u32 ReturnValue = 0;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cinttypes>
 #include <cstdio>
 #include <map>
 #include <memory>
@@ -70,11 +71,7 @@ CWII_IPC_HLE_Device_FileIO::CWII_IPC_HLE_Device_FileIO(u32 device_id,
 {
 }
 
-CWII_IPC_HLE_Device_FileIO::~CWII_IPC_HLE_Device_FileIO()
-{
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bForce)
+void CWII_IPC_HLE_Device_FileIO::Close()
 {
   INFO_LOG(WII_IPC_FILEIO, "FileIO: Close %s (DeviceID=%08x)", m_name.c_str(), m_device_id);
   m_Mode = 0;
@@ -84,12 +81,11 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Close(u32 _CommandAddress, bool _bF
   m_file.reset();
 
   m_is_active = false;
-  return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 command_address, u32 mode)
+IOSReturnCode CWII_IPC_HLE_Device_FileIO::Open(const IOSOpenRequest& request)
 {
-  m_Mode = mode;
+  m_Mode = request.flags;
 
   static const char* const Modes[] = {"Unk Mode", "Read only", "Write only", "Read and Write"};
 
@@ -97,21 +93,18 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Open(u32 command_address, u32 mode)
 
   // The file must exist before we can open it
   // It should be created by ISFS_CreateFile, not here
-  if (File::Exists(m_filepath) && !File::IsDirectory(m_filepath))
+  if (!File::Exists(m_filepath) || File::IsDirectory(m_filepath))
   {
-    INFO_LOG(WII_IPC_FILEIO, "FileIO: Open %s (%s == %08X)", m_name.c_str(), Modes[mode], mode);
-    OpenFile();
-  }
-  else
-  {
-    WARN_LOG(WII_IPC_FILEIO, "FileIO: Open (%s) failed - File doesn't exist %s", Modes[mode],
+    WARN_LOG(WII_IPC_FILEIO, "FileIO: Open (%s) failed - File doesn't exist %s", Modes[m_Mode],
              m_filepath.c_str());
-    if (command_address)
-      Memory::Write_U32(FS_ENOENT, command_address + 4);
+    return FS_ENOENT;
   }
 
+  INFO_LOG(WII_IPC_FILEIO, "FileIO: Open %s (%s == %08X)", m_name.c_str(), Modes[m_Mode], m_Mode);
+  OpenFile();
+
   m_is_active = true;
-  return GetDefaultReply();
+  return IPC_SUCCESS;
 }
 
 // This isn't theadsafe, but it's only called from the CPU thread.
@@ -158,98 +151,91 @@ void CWII_IPC_HLE_Device_FileIO::OpenFile()
   }
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Seek(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Seek(const IOSSeekRequest& request)
 {
-  u32 ReturnValue = FS_EINVAL;
-  const s32 SeekPosition = Memory::Read_U32(_CommandAddress + 0xC);
-  const s32 Mode = Memory::Read_U32(_CommandAddress + 0x10);
+  u32 return_value = FS_EINVAL;
 
   if (m_file->IsOpen())
   {
-    ReturnValue = FS_EINVAL;
-
-    const s32 fileSize = (s32)m_file->GetSize();
+    const u32 file_size = static_cast<u32>(m_file->GetSize());
     DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Seek Pos: 0x%08x, Mode: %i (%s, Length=0x%08x)",
-              SeekPosition, Mode, m_name.c_str(), fileSize);
+              request.offset, request.mode, m_name.c_str(), file_size);
 
-    switch (Mode)
+    switch (request.mode)
     {
-    case WII_SEEK_SET:
+    case IOSSeekRequest::IOS_SEEK_SET:
     {
-      if ((SeekPosition >= 0) && (SeekPosition <= fileSize))
+      if (request.offset <= file_size)
       {
-        m_SeekPos = SeekPosition;
-        ReturnValue = m_SeekPos;
+        m_SeekPos = request.offset;
+        return_value = m_SeekPos;
       }
       break;
     }
 
-    case WII_SEEK_CUR:
+    case IOSSeekRequest::IOS_SEEK_CUR:
     {
-      s32 wantedPos = SeekPosition + m_SeekPos;
-      if (wantedPos >= 0 && wantedPos <= fileSize)
+      const u32 wanted_pos = request.offset + m_SeekPos;
+      if (wanted_pos <= file_size)
       {
-        m_SeekPos = wantedPos;
-        ReturnValue = m_SeekPos;
+        m_SeekPos = wanted_pos;
+        return_value = m_SeekPos;
       }
       break;
     }
 
-    case WII_SEEK_END:
+    case IOSSeekRequest::IOS_SEEK_END:
     {
-      s32 wantedPos = SeekPosition + fileSize;
-      if (wantedPos >= 0 && wantedPos <= fileSize)
+      const u32 wanted_pos = request.offset + file_size;
+      if (wanted_pos <= file_size)
       {
-        m_SeekPos = wantedPos;
-        ReturnValue = m_SeekPos;
+        m_SeekPos = wanted_pos;
+        return_value = m_SeekPos;
       }
       break;
     }
 
     default:
     {
-      PanicAlert("CWII_IPC_HLE_Device_FileIO Unsupported seek mode %i", Mode);
-      ReturnValue = FS_EINVAL;
+      PanicAlert("CWII_IPC_HLE_Device_FileIO Unsupported seek mode %i", request.mode);
+      return_value = FS_EINVAL;
       break;
     }
     }
   }
   else
   {
-    ReturnValue = FS_ENOENT;
+    return_value = FS_ENOENT;
   }
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(const IOSReadWriteRequest& request)
 {
-  u32 ReturnValue = FS_EACCESS;
-  const u32 Address = Memory::Read_U32(_CommandAddress + 0xC);  // Read to this memory address
-  const u32 Size = Memory::Read_U32(_CommandAddress + 0x10);
-
+  s32 return_value = FS_EACCESS;
   if (m_file->IsOpen())
   {
-    if (m_Mode == ISFS_OPEN_WRITE)
+    if (m_Mode == IOS_OPEN_WRITE)
     {
       WARN_LOG(WII_IPC_FILEIO,
-               "FileIO: Attempted to read 0x%x bytes to 0x%08x on a write-only file %s", Size,
-               Address, m_name.c_str());
+               "FileIO: Attempted to read 0x%x bytes to 0x%08x on a write-only file %s",
+               request.size, request.buffer, m_name.c_str());
     }
     else
     {
-      DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Read 0x%x bytes to 0x%08x from %s", Size, Address,
-                m_name.c_str());
+      DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Read 0x%x bytes to 0x%08x from %s", request.size,
+                request.buffer, m_name.c_str());
       m_file->Seek(m_SeekPos, SEEK_SET);  // File might be opened twice, need to seek before we read
-      ReturnValue = (u32)fread(Memory::GetPointer(Address), 1, Size, m_file->GetHandle());
-      if (ReturnValue != Size && ferror(m_file->GetHandle()))
+      return_value = static_cast<u32>(
+          fread(Memory::GetPointer(request.buffer), 1, request.size, m_file->GetHandle()));
+      if (static_cast<u32>(return_value) != request.size && ferror(m_file->GetHandle()))
       {
-        ReturnValue = FS_EACCESS;
+        return_value = FS_EACCESS;
       }
       else
       {
-        m_SeekPos += Size;
+        m_SeekPos += request.size;
       }
     }
   }
@@ -257,39 +243,35 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(u32 _CommandAddress)
   {
     ERROR_LOG(WII_IPC_FILEIO, "FileIO: Failed to read from %s (Addr=0x%08x Size=0x%x) - file could "
                               "not be opened or does not exist",
-              m_name.c_str(), Address, Size);
-    ReturnValue = FS_ENOENT;
+              m_name.c_str(), request.buffer, request.size);
+    return_value = FS_ENOENT;
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(const IOSReadWriteRequest& request)
 {
-  u32 ReturnValue = FS_EACCESS;
-  const u32 Address =
-      Memory::Read_U32(_CommandAddress + 0xC);  // Write data from this memory address
-  const u32 Size = Memory::Read_U32(_CommandAddress + 0x10);
-
+  s32 return_value = FS_EACCESS;
   if (m_file->IsOpen())
   {
-    if (m_Mode == ISFS_OPEN_READ)
+    if (m_Mode == IOS_OPEN_READ)
     {
       WARN_LOG(WII_IPC_FILEIO,
-               "FileIO: Attempted to write 0x%x bytes from 0x%08x to a read-only file %s", Size,
-               Address, m_name.c_str());
+               "FileIO: Attempted to write 0x%x bytes from 0x%08x to a read-only file %s",
+               request.size, request.buffer, m_name.c_str());
     }
     else
     {
-      DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Write 0x%04x bytes from 0x%08x to %s", Size, Address,
-                m_name.c_str());
+      DEBUG_LOG(WII_IPC_FILEIO, "FileIO: Write 0x%04x bytes from 0x%08x to %s", request.size,
+                request.buffer, m_name.c_str());
       m_file->Seek(m_SeekPos,
                    SEEK_SET);  // File might be opened twice, need to seek before we write
-      if (m_file->WriteBytes(Memory::GetPointer(Address), Size))
+      if (m_file->WriteBytes(Memory::GetPointer(request.buffer), request.size))
       {
-        ReturnValue = Size;
-        m_SeekPos += Size;
+        return_value = request.size;
+        m_SeekPos += request.size;
       }
     }
   }
@@ -297,51 +279,42 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(u32 _CommandAddress)
   {
     ERROR_LOG(WII_IPC_FILEIO, "FileIO: Failed to read from %s (Addr=0x%08x Size=0x%x) - file could "
                               "not be opened or does not exist",
-              m_name.c_str(), Address, Size);
-    ReturnValue = FS_ENOENT;
+              m_name.c_str(), request.buffer, request.size);
+    return_value = FS_ENOENT;
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(const IOSIOCtlRequest& request)
 {
   DEBUG_LOG(WII_IPC_FILEIO, "FileIO: IOCtl (Device=%s)", m_name.c_str());
-  const u32 Parameter = Memory::Read_U32(_CommandAddress + 0xC);
-  u32 ReturnValue = 0;
+  s32 return_value = IPC_SUCCESS;
 
-  switch (Parameter)
+  switch (request.request)
   {
   case ISFS_IOCTL_GETFILESTATS:
   {
     if (m_file->IsOpen())
     {
-      u32 m_FileLength = (u32)m_file->GetSize();
-
-      const u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-      DEBUG_LOG(WII_IPC_FILEIO, "  File: %s, Length: %i, Pos: %i", m_name.c_str(), m_FileLength,
-                m_SeekPos);
-
-      Memory::Write_U32(m_FileLength, BufferOut);
-      Memory::Write_U32(m_SeekPos, BufferOut + 4);
+      DEBUG_LOG(WII_IPC_FILEIO, "File: %s, Length: %" PRIu64 ", Pos: %i", m_name.c_str(),
+                m_file->GetSize(), m_SeekPos);
+      Memory::Write_U32(static_cast<u32>(m_file->GetSize()), request.buffer_out);
+      Memory::Write_U32(m_SeekPos, request.buffer_out + 4);
     }
     else
     {
-      ReturnValue = FS_ENOENT;
+      return_value = FS_ENOENT;
     }
   }
   break;
 
   default:
-  {
-    PanicAlert("CWII_IPC_HLE_Device_FileIO: Parameter %i", Parameter);
-  }
-  break;
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_FILEIO, LogTypes::LERROR);
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.cpp
@@ -207,8 +207,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Seek(const IOSSeekRequest& request)
   {
     return_value = FS_ENOENT;
   }
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(const IOSReadWriteRequest& request)
@@ -247,8 +246,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Read(const IOSReadWriteRequest& req
     return_value = FS_ENOENT;
   }
 
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(const IOSReadWriteRequest& request)
@@ -283,8 +281,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::Write(const IOSReadWriteRequest& re
     return_value = FS_ENOENT;
   }
 
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(const IOSIOCtlRequest& request)
@@ -314,8 +311,7 @@ IPCCommandResult CWII_IPC_HLE_Device_FileIO::IOCtl(const IOSIOCtlRequest& reques
     request.Log(GetDeviceName(), LogTypes::WII_IPC_FILEIO, LogTypes::LERROR);
   }
 
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 void CWII_IPC_HLE_Device_FileIO::PrepareForState(PointerWrap::Mode mode)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_FileIO.h
@@ -26,34 +26,18 @@ class CWII_IPC_HLE_Device_FileIO : public IWII_IPC_HLE_Device
 public:
   CWII_IPC_HLE_Device_FileIO(u32 _DeviceID, const std::string& _rDeviceName);
 
-  virtual ~CWII_IPC_HLE_Device_FileIO();
-
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Seek(u32 _CommandAddress) override;
-  IPCCommandResult Read(u32 _CommandAddress) override;
-  IPCCommandResult Write(u32 _CommandAddress) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  void Close() override;
+  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  IPCCommandResult Seek(const IOSSeekRequest& request) override;
+  IPCCommandResult Read(const IOSReadWriteRequest& request) override;
+  IPCCommandResult Write(const IOSReadWriteRequest& request) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
   void PrepareForState(PointerWrap::Mode mode) override;
   void DoState(PointerWrap& p) override;
 
   void OpenFile();
 
 private:
-  enum
-  {
-    ISFS_OPEN_READ = 1,
-    ISFS_OPEN_WRITE = 2,
-    ISFS_OPEN_RW = (ISFS_OPEN_READ | ISFS_OPEN_WRITE)
-  };
-
-  enum
-  {
-    WII_SEEK_SET = 0,
-    WII_SEEK_CUR = 1,
-    WII_SEEK_END = 2,
-  };
-
   enum
   {
     ISFS_FUNCNULL = 0,

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.cpp
@@ -1282,7 +1282,6 @@ IPCCommandResult CWII_IPC_HLE_Device_es::IOCtlV(u32 _CommandAddress)
 
   default:
     INFO_LOG(WII_IPC_ES, "CWII_IPC_HLE_Device_es: 0x%x", Buffer.Parameter);
-    DumpCommands(_CommandAddress, 8, LogTypes::WII_IPC_ES);
     INFO_LOG(WII_IPC_ES, "command.Parameter: 0x%08x", Buffer.Parameter);
     break;
   }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_es.h
@@ -27,8 +27,6 @@ class CWII_IPC_HLE_Device_es : public IWII_IPC_HLE_Device
 public:
   CWII_IPC_HLE_Device_es(u32 _DeviceID, const std::string& _rDeviceName);
 
-  virtual ~CWII_IPC_HLE_Device_es();
-
   void LoadWAD(const std::string& _rContentFile);
 
   // Internal implementation of the ES_DECRYPT ioctlv.
@@ -38,10 +36,9 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  void Close() override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
 
   static u32 ES_DIVerify(const std::vector<u8>& tmd);
 
@@ -116,7 +113,7 @@ private:
     ES_INVALID_TMD = -106,  // or access denied
     ES_READ_LESS_DATA_THAN_EXPECTED = -1009,
     ES_WRITE_FAILURE = -1010,
-    ES_PARAMTER_SIZE_OR_ALIGNMENT = -1017,
+    ES_PARAMETER_SIZE_OR_ALIGNMENT = -1017,
     ES_HASH_DOESNT_MATCH = -1022,
     ES_MEM_ALLOC_FAILED = -1024,
     ES_INCORRECT_ACCESS_RIGHT = -1026,

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.cpp
@@ -34,9 +34,9 @@ CWII_IPC_HLE_Device_fs::CWII_IPC_HLE_Device_fs(u32 _DeviceID, const std::string&
 
 // ~1/1000th of a second is too short and causes hangs in Wii Party
 // Play it safe at 1/500th
-IPCCommandResult CWII_IPC_HLE_Device_fs::GetFSReply() const
+IPCCommandResult CWII_IPC_HLE_Device_fs::GetFSReply(const s32 return_value) const
 {
-  return {true, SystemTimers::GetTicksPerSecond() / 500};
+  return {return_value, true, SystemTimers::GetTicksPerSecond() / 500};
 }
 
 IOSReturnCode CWII_IPC_HLE_Device_fs::Open(const IOSOpenRequest& request)
@@ -224,16 +224,14 @@ IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtlV(const IOSIOCtlVRequest& request)
     break;
   }
 
-  request.SetReturnValue(return_value);
-  return GetFSReply();
+  return GetFSReply(return_value);
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_fs::IOCtl(const IOSIOCtlRequest& request)
 {
   Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
   const s32 return_value = ExecuteCommand(request);
-  request.SetReturnValue(return_value);
-  return GetFSReply();
+  return GetFSReply(return_value);
 }
 
 s32 CWII_IPC_HLE_Device_fs::ExecuteCommand(const IOSIOCtlRequest& request)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -27,14 +27,12 @@ class CWII_IPC_HLE_Device_fs : public IWII_IPC_HLE_Device
 {
 public:
   CWII_IPC_HLE_Device_fs(u32 _DeviceID, const std::string& _rDeviceName);
-  virtual ~CWII_IPC_HLE_Device_fs();
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
 
 private:
   enum
@@ -52,6 +50,5 @@ private:
   };
 
   IPCCommandResult GetFSReply() const;
-  s32 ExecuteCommand(u32 Parameter, u32 _BufferIn, u32 _BufferInSize, u32 _BufferOut,
-                     u32 _BufferOutSize);
+  s32 ExecuteCommand(const IOSIOCtlRequest& request);
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_fs.h
@@ -49,6 +49,6 @@ private:
     IOCTL_SHUTDOWN = 0x0D
   };
 
-  IPCCommandResult GetFSReply() const;
+  IPCCommandResult GetFSReply(s32 return_value) const;
   s32 ExecuteCommand(const IOSIOCtlRequest& request);
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.cpp
@@ -296,10 +296,6 @@ IPCCommandResult CWII_IPC_HLE_Device_hid::IOCtlV(u32 _CommandAddress)
   INFO_LOG(WII_IPC_HID, "    BufferVector: 0x%08x", CommandBuffer.BufferVector);
   INFO_LOG(WII_IPC_HID, "    PayloadAddr: 0x%08x", CommandBuffer.PayloadBuffer[0].m_Address);
   INFO_LOG(WII_IPC_HID, "    PayloadSize: 0x%08x", CommandBuffer.PayloadBuffer[0].m_Size);
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  DumpAsync(CommandBuffer.BufferVector, CommandBuffer.NumberInBuffer,
-            CommandBuffer.NumberPayloadBuffer);
-#endif
 
   Memory::Write_U32(ReturnValue, _CommandAddress + 4);
   return GetDefaultReply();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_hid.h
@@ -38,8 +38,8 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_hid();
 
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
 
 private:
   enum
@@ -115,7 +115,7 @@ private:
   };
 
   u32 deviceCommandAddress;
-  void FillOutDevices(u32 BufferOut, u32 BufferOutSize);
+  void FillOutDevices(const IOSIOCtlRequest& request);
   int GetAvailableDevNum(u16 idVendor, u16 idProduct, u8 bus, u8 port, u16 check);
   bool ClaimDevice(libusb_device_handle* dev);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -190,8 +190,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(const IOSIOCtlRequest
     request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
   }
 
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 u8 CWII_IPC_HLE_Device_net_kd_request::GetAreaCode(const std::string& area) const
@@ -390,8 +389,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(const IOSIOCtlVReque
   {
     Memory::Write_U32(common_result, request.io_vectors.at(common_vector).address + 4);
   }
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 // **********************************************************************************
@@ -476,8 +474,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(const IOSIOCtlVReque
     request.Dump(GetDeviceName(), LogTypes::WII_IPC_NET, LogTypes::LINFO);
   }
 
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 // **********************************************************************************
@@ -553,8 +550,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(const IOSIOCtlRequest& re
 {
   if (Core::g_want_determinism)
   {
-    request.SetReturnValue(-1);
-    return GetDefaultReply();
+    return GetDefaultReply(IPC_EACCES);
   }
 
   s32 return_value = 0;
@@ -1060,8 +1056,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(const IOSIOCtlRequest& re
     request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_NET);
   }
 
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(const IOSIOCtlVRequest& request)
@@ -1371,8 +1366,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(const IOSIOCtlVRequest& 
     request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_NET);
   }
 
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 void CWII_IPC_HLE_Device_net_ip_top::Update()

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.cpp
@@ -72,21 +72,15 @@ CWII_IPC_HLE_Device_net_kd_request::~CWII_IPC_HLE_Device_net_kd_request()
   WiiSockMan::GetInstance().Clean();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(const IOSIOCtlRequest& request)
 {
-  u32 Parameter = Memory::Read_U32(_CommandAddress + 0xC);
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-
-  u32 ReturnValue = 0;
-  switch (Parameter)
+  s32 return_value = 0;
+  switch (request.request)
   {
   case IOCTL_NWC24_SUSPEND_SCHEDULAR:
     // NWC24iResumeForCloseLib  from NWC24SuspendScheduler (Input: none, Output: 32 bytes)
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_SUSPEND_SCHEDULAR - NI");
-    Memory::Write_U32(0, BufferOut);  // no error
+    Memory::Write_U32(0, request.buffer_out);  // no error
     break;
 
   case IOCTL_NWC24_EXEC_TRY_SUSPEND_SCHEDULAR:  // NWC24iResumeForCloseLib
@@ -95,18 +89,17 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 
   case IOCTL_NWC24_EXEC_RESUME_SCHEDULAR:  // NWC24iResumeForCloseLib
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_EXEC_RESUME_SCHEDULAR - NI");
-    Memory::Write_U32(0, BufferOut);  // no error
+    Memory::Write_U32(0, request.buffer_out);  // no error
     break;
 
   case IOCTL_NWC24_STARTUP_SOCKET:  // NWC24iStartupSocket
-    Memory::Write_U32(0, BufferOut);
-    Memory::Write_U32(0, BufferOut + 4);
-    ReturnValue = 0;
+    Memory::Write_U32(0, request.buffer_out);
+    Memory::Write_U32(0, request.buffer_out + 4);
+    return_value = 0;
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_STARTUP_SOCKET - NI");
     break;
 
   case IOCTL_NWC24_CLEANUP_SOCKET:
-    Memory::Memset(BufferOut, 0, BufferOutSize);
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_CLEANUP_SOCKET - NI");
     break;
 
@@ -120,8 +113,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
 
   case IOCTL_NWC24_REQUEST_REGISTER_USER_ID:
     INFO_LOG(WII_IPC_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_REGISTER_USER_ID");
-    Memory::Write_U32(0, BufferOut);
-    Memory::Write_U32(0, BufferOut + 4);
+    Memory::Write_U32(0, request.buffer_out);
+    Memory::Write_U32(0, request.buffer_out + 4);
     break;
 
   case IOCTL_NWC24_REQUEST_GENERATED_USER_ID:  // (Input: none, Output: 32 bytes)
@@ -161,23 +154,23 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
         config.SetCreationStage(NWC24::NWC24Config::NWC24_IDCS_GENERATED);
         config.WriteConfig();
 
-        Memory::Write_U32(ret, BufferOut);
+        Memory::Write_U32(ret, request.buffer_out);
       }
       else
       {
-        Memory::Write_U32(NWC24::WC24_ERR_FATAL, BufferOut);
+        Memory::Write_U32(NWC24::WC24_ERR_FATAL, request.buffer_out);
       }
     }
     else if (config.CreationStage() == NWC24::NWC24Config::NWC24_IDCS_GENERATED)
     {
-      Memory::Write_U32(NWC24::WC24_ERR_ID_GENERATED, BufferOut);
+      Memory::Write_U32(NWC24::WC24_ERR_ID_GENERATED, request.buffer_out);
     }
     else if (config.CreationStage() == NWC24::NWC24Config::NWC24_IDCS_REGISTERED)
     {
-      Memory::Write_U32(NWC24::WC24_ERR_ID_REGISTERED, BufferOut);
+      Memory::Write_U32(NWC24::WC24_ERR_ID_REGISTERED, request.buffer_out);
     }
-    Memory::Write_U64(config.Id(), BufferOut + 4);
-    Memory::Write_U32(config.CreationStage(), BufferOut + 0xC);
+    Memory::Write_U64(config.Id(), request.buffer_out + 4);
+    Memory::Write_U32(config.CreationStage(), request.buffer_out + 0xC);
     break;
 
   case IOCTL_NWC24_GET_SCHEDULAR_STAT:
@@ -194,13 +187,10 @@ IPCCommandResult CWII_IPC_HLE_Device_net_kd_request::IOCtl(u32 _CommandAddress)
     break;
 
   default:
-    INFO_LOG(WII_IPC_WC24,
-             "/dev/net/kd/request::IOCtl request 0x%x (BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             Parameter, BufferIn, BufferInSize, BufferOut, BufferOutSize);
-    break;
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
@@ -337,52 +327,49 @@ CWII_IPC_HLE_Device_net_ncd_manage::~CWII_IPC_HLE_Device_net_ncd_manage()
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(const IOSIOCtlVRequest& request)
 {
-  u32 return_value = 0;
+  s32 return_value = IPC_SUCCESS;
   u32 common_result = 0;
   u32 common_vector = 0;
 
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
-
-  switch (CommandBuffer.Parameter)
+  switch (request.request)
   {
   case IOCTLV_NCD_LOCKWIRELESSDRIVER:
     break;
 
   case IOCTLV_NCD_UNLOCKWIRELESSDRIVER:
-    // Memory::Read_U32(CommandBuffer.InBuffer.at(0).m_Address);
+    // Memory::Read_U32(request.in_vectors.at(0).address);
     break;
 
   case IOCTLV_NCD_GETCONFIG:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_GETCONFIG");
-    config.WriteToMem(CommandBuffer.PayloadBuffer.at(0).m_Address);
+    config.WriteToMem(request.io_vectors.at(0).address);
     common_vector = 1;
     break;
 
   case IOCTLV_NCD_SETCONFIG:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_SETCONFIG");
-    config.ReadFromMem(CommandBuffer.InBuffer.at(0).m_Address);
+    config.ReadFromMem(request.in_vectors.at(0).address);
     break;
 
   case IOCTLV_NCD_READCONFIG:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_READCONFIG");
     config.ReadConfig();
-    config.WriteToMem(CommandBuffer.PayloadBuffer.at(0).m_Address);
+    config.WriteToMem(request.io_vectors.at(0).address);
     common_vector = 1;
     break;
 
   case IOCTLV_NCD_WRITECONFIG:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_WRITECONFIG");
-    config.ReadFromMem(CommandBuffer.InBuffer.at(0).m_Address);
+    config.ReadFromMem(request.in_vectors.at(0).address);
     config.WriteConfig();
     break;
 
   case IOCTLV_NCD_GETLINKSTATUS:
     INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE: IOCTLV_NCD_GETLINKSTATUS");
     // Always connected
-    Memory::Write_U32(Net::ConnectionSettings::LINK_WIRED,
-                      CommandBuffer.PayloadBuffer.at(0).m_Address + 4);
+    Memory::Write_U32(Net::ConnectionSettings::LINK_WIRED, request.io_vectors.at(0).address + 4);
     break;
 
   case IOCTLV_NCD_GETWIRELESSMACADDRESS:
@@ -390,20 +377,20 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ncd_manage::IOCtlV(u32 _CommandAddress)
 
     u8 address[MAC_ADDRESS_SIZE];
     GetMacAddress(address);
-    Memory::CopyToEmu(CommandBuffer.PayloadBuffer.at(1).m_Address, address, sizeof(address));
+    Memory::CopyToEmu(request.io_vectors.at(1).address, address, sizeof(address));
     break;
 
   default:
-    INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE IOCtlV: %#x", CommandBuffer.Parameter);
+    INFO_LOG(WII_IPC_NET, "NET_NCD_MANAGE IOCtlV: %#x", request.request);
     break;
   }
 
-  Memory::Write_U32(common_result, CommandBuffer.PayloadBuffer.at(common_vector).m_Address);
+  Memory::Write_U32(common_result, request.io_vectors.at(common_vector).address);
   if (common_vector == 1)
   {
-    Memory::Write_U32(common_result, CommandBuffer.PayloadBuffer.at(common_vector).m_Address + 4);
+    Memory::Write_U32(common_result, request.io_vectors.at(common_vector).address + 4);
   }
-  Memory::Write_U32(return_value, _CommandAddress + 4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
@@ -422,21 +409,19 @@ CWII_IPC_HLE_Device_net_wd_command::~CWII_IPC_HLE_Device_net_wd_command()
 // This is just for debugging / playing around.
 // There really is no reason to implement wd unless we can bend it such that
 // we can talk to the DS.
-IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(const IOSIOCtlVRequest& request)
 {
-  u32 return_value = 0;
+  s32 return_value = IPC_SUCCESS;
 
-  SIOCtlVBuffer CommandBuffer(CommandAddress);
-
-  switch (CommandBuffer.Parameter)
+  switch (request.request)
   {
   case IOCTLV_WD_SCAN:
   {
     // Gives parameters detailing type of scan and what to match
     // XXX - unused
-    // ScanInfo *scan = (ScanInfo *)Memory::GetPointer(CommandBuffer.InBuffer.at(0).m_Address);
+    // ScanInfo *scan = (ScanInfo *)Memory::GetPointer(request.in_vectors.at(0).m_Address);
 
-    u16* results = (u16*)Memory::GetPointer(CommandBuffer.PayloadBuffer.at(0).m_Address);
+    u16* results = (u16*)Memory::GetPointer(request.io_vectors.at(0).address);
     // first u16 indicates number of BSSInfo following
     results[0] = Common::swap16(1);
 
@@ -459,7 +444,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
 
   case IOCTLV_WD_GET_INFO:
   {
-    Info* info = (Info*)Memory::GetPointer(CommandBuffer.PayloadBuffer.at(0).m_Address);
+    Info* info = (Info*)Memory::GetPointer(request.io_vectors.at(0).address);
     memset(info, 0, sizeof(Info));
     // Probably used to disallow certain channels?
     memcpy(info->country, "US", 2);
@@ -488,27 +473,10 @@ IPCCommandResult CWII_IPC_HLE_Device_net_wd_command::IOCtlV(u32 CommandAddress)
   case IOCTLV_WD_RECV_FRAME:
   case IOCTLV_WD_RECV_NOTIFICATION:
   default:
-    INFO_LOG(WII_IPC_NET, "NET_WD_COMMAND IOCtlV %#x in %i out %i", CommandBuffer.Parameter,
-             CommandBuffer.NumberInBuffer, CommandBuffer.NumberPayloadBuffer);
-    for (u32 i = 0; i < CommandBuffer.NumberInBuffer; ++i)
-    {
-      DEBUG_LOG(WII_IPC_NET, "in %i addr %x size %i", i, CommandBuffer.InBuffer.at(i).m_Address,
-                CommandBuffer.InBuffer.at(i).m_Size);
-      DEBUG_LOG(WII_IPC_NET, "%s",
-                ArrayToString(Memory::GetPointer(CommandBuffer.InBuffer.at(i).m_Address),
-                              CommandBuffer.InBuffer.at(i).m_Size)
-                    .c_str());
-    }
-    for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; ++i)
-    {
-      DEBUG_LOG(WII_IPC_NET, "out %i addr %x size %i", i,
-                CommandBuffer.PayloadBuffer.at(i).m_Address,
-                CommandBuffer.PayloadBuffer.at(i).m_Size);
-    }
-    break;
+    request.Dump(GetDeviceName(), LogTypes::WII_IPC_NET, LogTypes::LINFO);
   }
 
-  Memory::Write_U32(return_value, CommandAddress + 4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
@@ -581,61 +549,54 @@ static unsigned int opt_level_mapping[][2] = {{SOL_SOCKET, 0xFFFF}};
 static unsigned int opt_name_mapping[][2] = {
     {SO_REUSEADDR, 0x4}, {SO_SNDBUF, 0x1001}, {SO_RCVBUF, 0x1002}, {SO_ERROR, 0x1009}};
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(const IOSIOCtlRequest& request)
 {
   if (Core::g_want_determinism)
   {
-    Memory::Write_U32(-1, _CommandAddress + 4);
+    request.SetReturnValue(-1);
     return GetDefaultReply();
   }
 
-  u32 Command = Memory::Read_U32(_CommandAddress + 0x0C);
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-
-  u32 ReturnValue = 0;
-  switch (Command)
+  s32 return_value = 0;
+  switch (request.request)
   {
   case IOCTL_SO_STARTUP:
   {
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_STARTUP "
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
     break;
   }
   case IOCTL_SO_SOCKET:
   {
-    u32 af = Memory::Read_U32(BufferIn);
-    u32 type = Memory::Read_U32(BufferIn + 0x04);
-    u32 prot = Memory::Read_U32(BufferIn + 0x08);
+    u32 af = Memory::Read_U32(request.buffer_in);
+    u32 type = Memory::Read_U32(request.buffer_in + 4);
+    u32 prot = Memory::Read_U32(request.buffer_in + 8);
 
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    ReturnValue = sm.NewSocket(af, type, prot);
+    return_value = sm.NewSocket(af, type, prot);
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_SOCKET "
                           "Socket: %08x (%d,%d,%d), BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             ReturnValue, af, type, prot, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+             return_value, af, type, prot, request.buffer_in, request.buffer_in_size,
+             request.buffer_out, request.buffer_out_size);
     break;
   }
   case IOCTL_SO_ICMPSOCKET:
   {
-    u32 pf = Memory::Read_U32(BufferIn);
+    u32 pf = Memory::Read_U32(request.buffer_in);
 
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    ReturnValue = sm.NewSocket(pf, SOCK_RAW, IPPROTO_ICMP);
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_ICMPSOCKET(%x) %d", pf, ReturnValue);
+    return_value = sm.NewSocket(pf, SOCK_RAW, IPPROTO_ICMP);
+    INFO_LOG(WII_IPC_NET, "IOCTL_SO_ICMPSOCKET(%x) %d", pf, return_value);
     break;
   }
   case IOCTL_SO_CLOSE:
   case IOCTL_SO_ICMPCLOSE:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
+    u32 fd = Memory::Read_U32(request.buffer_in);
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    ReturnValue = sm.DeleteSocket(fd);
+    return_value = sm.DeleteSocket(fd);
     INFO_LOG(WII_IPC_NET, "%s(%x) %x",
-             Command == IOCTL_SO_ICMPCLOSE ? "IOCTL_SO_ICMPCLOSE" : "IOCTL_SO_CLOSE", fd,
-             ReturnValue);
+             request.request == IOCTL_SO_ICMPCLOSE ? "IOCTL_SO_ICMPCLOSE" : "IOCTL_SO_CLOSE", fd,
+             return_value);
     break;
   }
   case IOCTL_SO_ACCEPT:
@@ -643,9 +604,9 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
   case IOCTL_SO_CONNECT:
   case IOCTL_SO_FCNTL:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
+    u32 fd = Memory::Read_U32(request.buffer_in);
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    sm.DoSock(fd, _CommandAddress, (NET_IOCTL)Command);
+    sm.DoSock(fd, request, static_cast<NET_IOCTL>(request.request));
     return GetNoReply();
   }
   /////////////////////////////////////////////////////////////
@@ -653,36 +614,30 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
   /////////////////////////////////////////////////////////////
   case IOCTL_SO_SHUTDOWN:
   {
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_SHUTDOWN "
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
 
-    u32 fd = Memory::Read_U32(BufferIn);
-    u32 how = Memory::Read_U32(BufferIn + 4);
+    u32 fd = Memory::Read_U32(request.buffer_in);
+    u32 how = Memory::Read_U32(request.buffer_in + 4);
     int ret = shutdown(fd, how);
-    ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_SHUTDOWN", false);
+    return_value = WiiSockMan::GetNetErrorCode(ret, "SO_SHUTDOWN", false);
     break;
   }
   case IOCTL_SO_LISTEN:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
-    u32 BACKLOG = Memory::Read_U32(BufferIn + 0x04);
+    u32 fd = Memory::Read_U32(request.buffer_in);
+    u32 BACKLOG = Memory::Read_U32(request.buffer_in + 0x04);
     u32 ret = listen(fd, BACKLOG);
-    ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_LISTEN", false);
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_LISTEN = %d "
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             ReturnValue, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    return_value = WiiSockMan::GetNetErrorCode(ret, "SO_LISTEN", false);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
     break;
   }
   case IOCTL_SO_GETSOCKOPT:
   {
-    u32 fd = Memory::Read_U32(BufferOut);
-    u32 level = Memory::Read_U32(BufferOut + 4);
-    u32 optname = Memory::Read_U32(BufferOut + 8);
+    u32 fd = Memory::Read_U32(request.buffer_out);
+    u32 level = Memory::Read_U32(request.buffer_out + 4);
+    u32 optname = Memory::Read_U32(request.buffer_out + 8);
 
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETSOCKOPT(%08x, %08x, %08x)"
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             fd, level, optname, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
 
     // Do the level/optname translation
     int nat_level = -1, nat_optname = -1;
@@ -699,45 +654,46 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
     u32 optlen = 4;
 
     int ret = getsockopt(fd, nat_level, nat_optname, (char*)&optval, (socklen_t*)&optlen);
-    ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_GETSOCKOPT", false);
+    return_value = WiiSockMan::GetNetErrorCode(ret, "SO_GETSOCKOPT", false);
 
-    Memory::Write_U32(optlen, BufferOut + 0xC);
-    Memory::CopyToEmu(BufferOut + 0x10, optval, optlen);
+    Memory::Write_U32(optlen, request.buffer_out + 0xC);
+    Memory::CopyToEmu(request.buffer_out + 0x10, optval, optlen);
 
     if (optname == SO_ERROR)
     {
       s32 last_error = WiiSockMan::GetInstance().GetLastNetError();
 
-      Memory::Write_U32(sizeof(s32), BufferOut + 0xC);
-      Memory::Write_U32(last_error, BufferOut + 0x10);
+      Memory::Write_U32(sizeof(s32), request.buffer_out + 0xC);
+      Memory::Write_U32(last_error, request.buffer_out + 0x10);
     }
     break;
   }
 
   case IOCTL_SO_SETSOCKOPT:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
-    u32 level = Memory::Read_U32(BufferIn + 4);
-    u32 optname = Memory::Read_U32(BufferIn + 8);
-    u32 optlen = Memory::Read_U32(BufferIn + 0xc);
+    u32 fd = Memory::Read_U32(request.buffer_in);
+    u32 level = Memory::Read_U32(request.buffer_in + 4);
+    u32 optname = Memory::Read_U32(request.buffer_in + 8);
+    u32 optlen = Memory::Read_U32(request.buffer_in + 0xc);
     u8 optval[20];
     optlen = std::min(optlen, (u32)sizeof(optval));
-    Memory::CopyFromEmu(optval, BufferIn + 0x10, optlen);
+    Memory::CopyFromEmu(optval, request.buffer_in + 0x10, optlen);
 
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_SETSOCKOPT(%08x, %08x, %08x, %08x) "
                           "BufferIn: (%08x, %i), BufferOut: (%08x, %i)"
                           "%02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx "
                           "%02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx",
-             fd, level, optname, optlen, BufferIn, BufferInSize, BufferOut, BufferOutSize,
-             optval[0], optval[1], optval[2], optval[3], optval[4], optval[5], optval[6], optval[7],
-             optval[8], optval[9], optval[10], optval[11], optval[12], optval[13], optval[14],
-             optval[15], optval[16], optval[17], optval[18], optval[19]);
+             fd, level, optname, optlen, request.buffer_in, request.buffer_in_size,
+             request.buffer_out, request.buffer_out_size, optval[0], optval[1], optval[2],
+             optval[3], optval[4], optval[5], optval[6], optval[7], optval[8], optval[9],
+             optval[10], optval[11], optval[12], optval[13], optval[14], optval[15], optval[16],
+             optval[17], optval[18], optval[19]);
 
     // TODO: bug booto about this, 0x2005 most likely timeout related, default value on Wii is ,
     // 0x2001 is most likely tcpnodelay
     if (level == 6 && (optname == 0x2005 || optname == 0x2001))
     {
-      ReturnValue = 0;
+      return_value = 0;
       break;
     }
 
@@ -762,38 +718,36 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
     }
 
     int ret = setsockopt(fd, nat_level, nat_optname, (char*)optval, optlen);
-    ReturnValue = WiiSockMan::GetNetErrorCode(ret, "SO_SETSOCKOPT", false);
+    return_value = WiiSockMan::GetNetErrorCode(ret, "SO_SETSOCKOPT", false);
     break;
   }
   case IOCTL_SO_GETSOCKNAME:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
+    u32 fd = Memory::Read_U32(request.buffer_in);
 
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETSOCKNAME "
-                          "Socket: %08X, BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             fd, BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
 
     sockaddr sa;
     socklen_t sa_len;
     sa_len = sizeof(sa);
     int ret = getsockname(fd, &sa, &sa_len);
 
-    if (BufferOutSize < 2 + sizeof(sa.sa_data))
+    if (request.buffer_out_size < 2 + sizeof(sa.sa_data))
       WARN_LOG(WII_IPC_NET, "IOCTL_SO_GETSOCKNAME output buffer is too small. Truncating");
 
-    if (BufferOutSize > 0)
-      Memory::Write_U8(BufferOutSize, BufferOut);
-    if (BufferOutSize > 1)
-      Memory::Write_U8(sa.sa_family & 0xFF, BufferOut + 1);
-    if (BufferOutSize > 2)
-      Memory::CopyToEmu(BufferOut + 2, &sa.sa_data,
-                        std::min<size_t>(sizeof(sa.sa_data), BufferOutSize - 2));
-    ReturnValue = ret;
+    if (request.buffer_out_size > 0)
+      Memory::Write_U8(request.buffer_out_size, request.buffer_out);
+    if (request.buffer_out_size > 1)
+      Memory::Write_U8(sa.sa_family & 0xFF, request.buffer_out + 1);
+    if (request.buffer_out_size > 2)
+      Memory::CopyToEmu(request.buffer_out + 2, &sa.sa_data,
+                        std::min<size_t>(sizeof(sa.sa_data), request.buffer_out_size - 2));
+    return_value = ret;
     break;
   }
   case IOCTL_SO_GETPEERNAME:
   {
-    u32 fd = Memory::Read_U32(BufferIn);
+    u32 fd = Memory::Read_U32(request.buffer_in);
 
     sockaddr sa;
     socklen_t sa_len;
@@ -801,28 +755,26 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 
     int ret = getpeername(fd, &sa, &sa_len);
 
-    if (BufferOutSize < 2 + sizeof(sa.sa_data))
+    if (request.buffer_out_size < 2 + sizeof(sa.sa_data))
       WARN_LOG(WII_IPC_NET, "IOCTL_SO_GETPEERNAME output buffer is too small. Truncating");
 
-    if (BufferOutSize > 0)
-      Memory::Write_U8(BufferOutSize, BufferOut);
-    if (BufferOutSize > 1)
-      Memory::Write_U8(AF_INET, BufferOut + 1);
-    if (BufferOutSize > 2)
-      Memory::CopyToEmu(BufferOut + 2, &sa.sa_data,
-                        std::min<size_t>(sizeof(sa.sa_data), BufferOutSize - 2));
+    if (request.buffer_out_size > 0)
+      Memory::Write_U8(request.buffer_out_size, request.buffer_out);
+    if (request.buffer_out_size > 1)
+      Memory::Write_U8(AF_INET, request.buffer_out + 1);
+    if (request.buffer_out_size > 2)
+      Memory::CopyToEmu(request.buffer_out + 2, &sa.sa_data,
+                        std::min<size_t>(sizeof(sa.sa_data), request.buffer_out_size - 2));
 
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETPEERNAME(%x)", fd);
 
-    ReturnValue = ret;
+    return_value = ret;
     break;
   }
 
   case IOCTL_SO_GETHOSTID:
   {
-    INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETHOSTID "
-                          "(BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             BufferIn, BufferInSize, BufferOut, BufferOutSize);
+    request.Log(GetDeviceName(), LogTypes::WII_IPC_WC24);
 
 #ifdef _WIN32
     DWORD forwardTableSize, ipTableSize, result;
@@ -869,7 +821,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       {
         if (ipTable->table[i].dwIndex == ifIndex)
         {
-          ReturnValue = Common::swap32(ipTable->table[i].dwAddr);
+          return_value = Common::swap32(ipTable->table[i].dwAddr);
           break;
         }
       }
@@ -877,14 +829,14 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 #endif
 
     // default placeholder, in case of failure
-    if (ReturnValue == 0)
-      ReturnValue = 192 << 24 | 168 << 16 | 1 << 8 | 150;
+    if (return_value == 0)
+      return_value = 192 << 24 | 168 << 16 | 1 << 8 | 150;
     break;
   }
 
   case IOCTL_SO_INETATON:
   {
-    std::string hostname = Memory::GetString(BufferIn);
+    std::string hostname = Memory::GetString(request.buffer_in);
     struct hostent* remoteHost = gethostbyname(hostname.c_str());
 
     if (remoteHost == nullptr || remoteHost->h_addr_list == nullptr ||
@@ -892,42 +844,43 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
     {
       INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = -1 "
                             "%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: None",
-               hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize);
-      ReturnValue = 0;
+               hostname.c_str(), request.buffer_in, request.buffer_in_size, request.buffer_out,
+               request.buffer_out_size);
+      return_value = 0;
     }
     else
     {
-      Memory::Write_U32(Common::swap32(*(u32*)remoteHost->h_addr_list[0]), BufferOut);
+      Memory::Write_U32(Common::swap32(*(u32*)remoteHost->h_addr_list[0]), request.buffer_out);
       INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETATON = 0 "
                             "%s, BufferIn: (%08x, %i), BufferOut: (%08x, %i), IP Found: %08X",
-               hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize,
-               Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
-      ReturnValue = 1;
+               hostname.c_str(), request.buffer_in, request.buffer_in_size, request.buffer_out,
+               request.buffer_out_size, Common::swap32(*(u32*)remoteHost->h_addr_list[0]));
+      return_value = 1;
     }
     break;
   }
 
   case IOCTL_SO_INETPTON:
   {
-    std::string address = Memory::GetString(BufferIn);
+    std::string address = Memory::GetString(request.buffer_in);
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETPTON "
                           "(Translating: %s)",
              address.c_str());
-    ReturnValue = inet_pton(address.c_str(), Memory::GetPointer(BufferOut + 4));
+    return_value = inet_pton(address.c_str(), Memory::GetPointer(request.buffer_out + 4));
     break;
   }
 
   case IOCTL_SO_INETNTOP:
   {
     // u32 af = Memory::Read_U32(BufferIn);
-    // u32 validAddress = Memory::Read_U32(BufferIn + 4);
-    // u32 src = Memory::Read_U32(BufferIn + 8);
+    // u32 validAddress = Memory::Read_U32(request.buffer_in + 4);
+    // u32 src = Memory::Read_U32(request.buffer_in + 8);
     char ip_s[16];
-    sprintf(ip_s, "%i.%i.%i.%i", Memory::Read_U8(BufferIn + 8), Memory::Read_U8(BufferIn + 8 + 1),
-            Memory::Read_U8(BufferIn + 8 + 2), Memory::Read_U8(BufferIn + 8 + 3));
+    sprintf(ip_s, "%i.%i.%i.%i", Memory::Read_U8(request.buffer_in + 8),
+            Memory::Read_U8(request.buffer_in + 8 + 1), Memory::Read_U8(request.buffer_in + 8 + 2),
+            Memory::Read_U8(request.buffer_in + 8 + 3));
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_INETNTOP %s", ip_s);
-    Memory::Memset(BufferOut, 0, BufferOutSize);
-    Memory::CopyToEmu(BufferOut, (u8*)ip_s, strlen(ip_s));
+    Memory::CopyToEmu(request.buffer_out, (u8*)ip_s, strlen(ip_s));
     break;
   }
 
@@ -943,10 +896,10 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
         {POLLWRBAND, 0x0010}, {POLLERR, 0x0020},    {POLLHUP, 0x0040}, {POLLNVAL, 0x0080},
     };
 
-    u32 unknown = Memory::Read_U32(BufferIn);
-    u32 timeout = Memory::Read_U32(BufferIn + 4);
+    u32 unknown = Memory::Read_U32(request.buffer_in);
+    u32 timeout = Memory::Read_U32(request.buffer_in + 4);
 
-    int nfds = BufferOutSize / 0xc;
+    int nfds = request.buffer_out_size / 0xc;
     if (nfds == 0)
       ERROR_LOG(WII_IPC_NET, "Hidden POLL");
 
@@ -954,9 +907,9 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 
     for (int i = 0; i < nfds; ++i)
     {
-      ufds[i].fd = Memory::Read_U32(BufferOut + 0xc * i);           // fd
-      int events = Memory::Read_U32(BufferOut + 0xc * i + 4);       // events
-      ufds[i].revents = Memory::Read_U32(BufferOut + 0xc * i + 8);  // revents
+      ufds[i].fd = Memory::Read_U32(request.buffer_out + 0xc * i);           // fd
+      int events = Memory::Read_U32(request.buffer_out + 0xc * i + 4);       // events
+      ufds[i].revents = Memory::Read_U32(request.buffer_out + 0xc * i + 8);  // revents
 
       // Translate Wii to native events
       int unhandled_events = events;
@@ -993,33 +946,34 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       }
 
       // No need to change fd or events as they are input only.
-      // Memory::Write_U32(ufds[i].fd, BufferOut + 0xc*i); //fd
-      // Memory::Write_U32(events, BufferOut + 0xc*i + 4); //events
-      Memory::Write_U32(revents, BufferOut + 0xc * i + 8);  // revents
+      // Memory::Write_U32(ufds[i].fd, request.buffer_out + 0xc*i); //fd
+      // Memory::Write_U32(events, request.buffer_out + 0xc*i + 4); //events
+      Memory::Write_U32(revents, request.buffer_out + 0xc * i + 8);  // revents
 
       DEBUG_LOG(WII_IPC_NET, "IOCTL_SO_POLL socket %d wevents %08X events %08X revents %08X", i,
                 revents, ufds[i].events, ufds[i].revents);
     }
 
-    ReturnValue = ret;
+    return_value = ret;
     break;
   }
 
   case IOCTL_SO_GETHOSTBYNAME:
   {
-    if (BufferOutSize != 0x460)
+    if (request.buffer_out_size != 0x460)
     {
       ERROR_LOG(WII_IPC_NET, "Bad buffer size for IOCTL_SO_GETHOSTBYNAME");
-      ReturnValue = -1;
+      return_value = -1;
       break;
     }
 
-    std::string hostname = Memory::GetString(BufferIn);
+    std::string hostname = Memory::GetString(request.buffer_in);
     hostent* remoteHost = gethostbyname(hostname.c_str());
 
     INFO_LOG(WII_IPC_NET, "IOCTL_SO_GETHOSTBYNAME "
                           "Address: %s, BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             hostname.c_str(), BufferIn, BufferInSize, BufferOut, BufferOutSize);
+             hostname.c_str(), request.buffer_in, request.buffer_in_size, request.buffer_out,
+             request.buffer_out_size);
 
     if (remoteHost)
     {
@@ -1036,8 +990,6 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
         DEBUG_LOG(WII_IPC_NET, "addr%i:%s", i, ip_s.c_str());
       }
 
-      Memory::Memset(BufferOut, 0, BufferOutSize);
-
       // Host name; located immediately after struct
       static const u32 GETHOSTBYNAME_STRUCT_SIZE = 0x10;
       static const u32 GETHOSTBYNAME_IP_LIST_OFFSET = 0x110;
@@ -1046,11 +998,12 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       if (name_length > (GETHOSTBYNAME_IP_LIST_OFFSET - GETHOSTBYNAME_STRUCT_SIZE))
       {
         ERROR_LOG(WII_IPC_NET, "Hostname too long in IOCTL_SO_GETHOSTBYNAME");
-        ReturnValue = -1;
+        return_value = -1;
         break;
       }
-      Memory::CopyToEmu(BufferOut + GETHOSTBYNAME_STRUCT_SIZE, remoteHost->h_name, name_length);
-      Memory::Write_U32(BufferOut + GETHOSTBYNAME_STRUCT_SIZE, BufferOut);
+      Memory::CopyToEmu(request.buffer_out + GETHOSTBYNAME_STRUCT_SIZE, remoteHost->h_name,
+                        name_length);
+      Memory::Write_U32(request.buffer_out + GETHOSTBYNAME_STRUCT_SIZE, request.buffer_out);
 
       // IP address list; located at offset 0x110.
       u32 num_ip_addr = 0;
@@ -1062,7 +1015,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       num_ip_addr = std::min(num_ip_addr, GETHOSTBYNAME_MAX_ADDRESSES);
       for (u32 i = 0; i < num_ip_addr; ++i)
       {
-        u32 addr = BufferOut + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4;
+        u32 addr = request.buffer_out + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4;
         Memory::Write_U32_Swap(*(u32*)(remoteHost->h_addr_list[i]), addr);
       }
 
@@ -1070,30 +1023,31 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
       // This must be exact: PPC code to convert the struct hardcodes
       // this offset.
       static const u32 GETHOSTBYNAME_IP_PTR_LIST_OFFSET = 0x340;
-      Memory::Write_U32(BufferOut + GETHOSTBYNAME_IP_PTR_LIST_OFFSET, BufferOut + 12);
+      Memory::Write_U32(request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET,
+                        request.buffer_out + 12);
       for (u32 i = 0; i < num_ip_addr; ++i)
       {
-        u32 addr = BufferOut + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + i * 4;
-        Memory::Write_U32(BufferOut + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4, addr);
+        u32 addr = request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + i * 4;
+        Memory::Write_U32(request.buffer_out + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4, addr);
       }
-      Memory::Write_U32(0, BufferOut + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4);
+      Memory::Write_U32(0, request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4);
 
       // Aliases - empty. (Hardware doesn't return anything.)
-      Memory::Write_U32(BufferOut + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4,
-                        BufferOut + 4);
+      Memory::Write_U32(request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4,
+                        request.buffer_out + 4);
 
       // Returned struct must be ipv4.
       _assert_msg_(WII_IPC_NET,
                    remoteHost->h_addrtype == AF_INET && remoteHost->h_length == sizeof(u32),
                    "returned host info is not IPv4");
-      Memory::Write_U16(AF_INET, BufferOut + 8);
-      Memory::Write_U16(sizeof(u32), BufferOut + 10);
+      Memory::Write_U16(AF_INET, request.buffer_out + 8);
+      Memory::Write_U16(sizeof(u32), request.buffer_out + 10);
 
-      ReturnValue = 0;
+      return_value = 0;
     }
     else
     {
-      ReturnValue = -1;
+      return_value = -1;
     }
 
     break;
@@ -1101,89 +1055,39 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtl(u32 _CommandAddress)
 
   case IOCTL_SO_ICMPCANCEL:
     ERROR_LOG(WII_IPC_NET, "IOCTL_SO_ICMPCANCEL");
-    goto default_;
 
   default:
-    INFO_LOG(WII_IPC_NET, "0x%x "
-                          "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             Command, BufferIn, BufferInSize, BufferOut, BufferOutSize);
-  default_:
-    if (BufferInSize)
-    {
-      ERROR_LOG(WII_IPC_NET, "in addr %x size %x", BufferIn, BufferInSize);
-      ERROR_LOG(WII_IPC_NET, "\n%s",
-                ArrayToString(Memory::GetPointer(BufferIn), BufferInSize, 4).c_str());
-    }
-
-    if (BufferOutSize)
-    {
-      ERROR_LOG(WII_IPC_NET, "out addr %x size %x", BufferOut, BufferOutSize);
-    }
-    break;
+    request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_NET);
   }
 
-  Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
-
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(const IOSIOCtlVRequest& request)
 {
-  SIOCtlVBuffer CommandBuffer(CommandAddress);
-
-  s32 ReturnValue = 0;
-
-  u32 _BufferIn = 0, _BufferIn2 = 0, _BufferIn3 = 0;
-  u32 BufferInSize = 0, BufferInSize2 = 0, BufferInSize3 = 0;
-
-  u32 _BufferOut = 0, _BufferOut2 = 0;
-  u32 BufferOutSize = 0;
-
-  if (CommandBuffer.InBuffer.size() > 0)
-  {
-    _BufferIn = CommandBuffer.InBuffer.at(0).m_Address;
-    BufferInSize = CommandBuffer.InBuffer.at(0).m_Size;
-  }
-  if (CommandBuffer.InBuffer.size() > 1)
-  {
-    _BufferIn2 = CommandBuffer.InBuffer.at(1).m_Address;
-    BufferInSize2 = CommandBuffer.InBuffer.at(1).m_Size;
-  }
-  if (CommandBuffer.InBuffer.size() > 2)
-  {
-    _BufferIn3 = CommandBuffer.InBuffer.at(2).m_Address;
-    BufferInSize3 = CommandBuffer.InBuffer.at(2).m_Size;
-  }
-
-  if (CommandBuffer.PayloadBuffer.size() > 0)
-  {
-    _BufferOut = CommandBuffer.PayloadBuffer.at(0).m_Address;
-    BufferOutSize = CommandBuffer.PayloadBuffer.at(0).m_Size;
-  }
-  if (CommandBuffer.PayloadBuffer.size() > 1)
-  {
-    _BufferOut2 = CommandBuffer.PayloadBuffer.at(1).m_Address;
-  }
+  s32 return_value = 0;
 
   u32 param = 0, param2 = 0, param3, param4, param5 = 0;
-
-  switch (CommandBuffer.Parameter)
+  switch (request.request)
   {
   case IOCTLV_SO_GETINTERFACEOPT:
   {
-    param = Memory::Read_U32(_BufferIn);
-    param2 = Memory::Read_U32(_BufferIn + 4);
-    param3 = Memory::Read_U32(_BufferOut);
-    param4 = Memory::Read_U32(_BufferOut2);
-    if (BufferOutSize >= 8)
+    param = Memory::Read_U32(request.in_vectors[0].address);
+    param2 = Memory::Read_U32(request.in_vectors[0].address + 4);
+    param3 = Memory::Read_U32(request.io_vectors[0].address);
+    param4 = Memory::Read_U32(request.io_vectors[1].address);
+    if (request.io_vectors[0].size >= 8)
     {
-      param5 = Memory::Read_U32(_BufferOut + 4);
+      param5 = Memory::Read_U32(request.io_vectors[0].address + 4);
     }
 
     INFO_LOG(WII_IPC_NET, "IOCTLV_SO_GETINTERFACEOPT(%08X, %08X, %X, %X, %X) "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i) ",
-             param, param2, param3, param4, param5, _BufferIn, BufferInSize, _BufferIn2,
-             BufferInSize2);
+             param, param2, param3, param4, param5, request.in_vectors[0].address,
+             request.in_vectors[0].size,
+             request.in_vectors.size() > 1 ? request.in_vectors[1].address : 0,
+             request.in_vectors.size() > 1 ? request.in_vectors[1].size : 0);
 
     switch (param2)
     {
@@ -1257,33 +1161,33 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
       if (address == 0)
         address = 0x08080808;
 
-      Memory::Write_U32(address, _BufferOut);
-      Memory::Write_U32(0x08080404, _BufferOut + 4);
+      Memory::Write_U32(address, request.io_vectors[0].address);
+      Memory::Write_U32(0x08080404, request.io_vectors[0].address + 4);
       break;
     }
     case 0x1003:  // error
-      Memory::Write_U32(0, _BufferOut);
+      Memory::Write_U32(0, request.io_vectors[0].address);
       break;
 
     case 0x1004:  // mac address
       u8 address[MAC_ADDRESS_SIZE];
       GetMacAddress(address);
-      Memory::CopyToEmu(_BufferOut, address, sizeof(address));
+      Memory::CopyToEmu(request.io_vectors[0].address, address, sizeof(address));
       break;
 
     case 0x1005:  // link state
-      Memory::Write_U32(1, _BufferOut);
+      Memory::Write_U32(1, request.io_vectors[0].address);
       break;
 
     case 0x4002:  // ip addr number
-      Memory::Write_U32(1, _BufferOut);
+      Memory::Write_U32(1, request.io_vectors[0].address);
       break;
 
     case 0x4003:  // ip addr table
-      Memory::Write_U32(0xC, _BufferOut2);
-      Memory::Write_U32(10 << 24 | 1 << 8 | 30, _BufferOut);
-      Memory::Write_U32(255 << 24 | 255 << 16 | 255 << 8 | 0, _BufferOut + 4);
-      Memory::Write_U32(10 << 24 | 0 << 16 | 255 << 8 | 255, _BufferOut + 8);
+      Memory::Write_U32(0xC, request.io_vectors[1].address);
+      Memory::Write_U32(10 << 24 | 1 << 8 | 30, request.io_vectors[0].address);
+      Memory::Write_U32(255 << 24 | 255 << 16 | 255 << 8 | 0, request.io_vectors[0].address + 4);
+      Memory::Write_U32(10 << 24 | 0 << 16 | 255 << 8 | 255, request.io_vectors[0].address + 8);
       break;
 
     default:
@@ -1294,17 +1198,17 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
   }
   case IOCTLV_SO_SENDTO:
   {
-    u32 fd = Memory::Read_U32(_BufferIn2);
+    u32 fd = Memory::Read_U32(request.in_vectors[1].address);
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    sm.DoSock(fd, CommandAddress, IOCTLV_SO_SENDTO);
+    sm.DoSock(fd, request, IOCTLV_SO_SENDTO);
     return GetNoReply();
     break;
   }
   case IOCTLV_SO_RECVFROM:
   {
-    u32 fd = Memory::Read_U32(_BufferIn);
+    u32 fd = Memory::Read_U32(request.in_vectors[0].address);
     WiiSockMan& sm = WiiSockMan::GetInstance();
-    sm.DoSock(fd, CommandAddress, IOCTLV_SO_RECVFROM);
+    sm.DoSock(fd, request, IOCTLV_SO_RECVFROM);
     return GetNoReply();
     break;
   }
@@ -1312,13 +1216,13 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
   {
     addrinfo hints;
 
-    if (BufferInSize3)
+    if (request.in_vectors.size() > 2 && request.in_vectors[2].size)
     {
-      hints.ai_flags = Memory::Read_U32(_BufferIn3);
-      hints.ai_family = Memory::Read_U32(_BufferIn3 + 0x4);
-      hints.ai_socktype = Memory::Read_U32(_BufferIn3 + 0x8);
-      hints.ai_protocol = Memory::Read_U32(_BufferIn3 + 0xC);
-      hints.ai_addrlen = Memory::Read_U32(_BufferIn3 + 0x10);
+      hints.ai_flags = Memory::Read_U32(request.in_vectors[2].address);
+      hints.ai_family = Memory::Read_U32(request.in_vectors[2].address + 0x4);
+      hints.ai_socktype = Memory::Read_U32(request.in_vectors[2].address + 0x8);
+      hints.ai_protocol = Memory::Read_U32(request.in_vectors[2].address + 0xC);
+      hints.ai_addrlen = Memory::Read_U32(request.in_vectors[2].address + 0x10);
       hints.ai_canonname = nullptr;
       hints.ai_addr = nullptr;
       hints.ai_next = nullptr;
@@ -1328,23 +1232,25 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
     // So we have to do a bit of juggling here.
     std::string nodeNameStr;
     const char* pNodeName = nullptr;
-    if (BufferInSize > 0)
+    if (request.in_vectors.size() > 0 && request.in_vectors[0].size > 0)
     {
-      nodeNameStr = Memory::GetString(_BufferIn, BufferInSize);
+      nodeNameStr = Memory::GetString(request.in_vectors[0].address, request.in_vectors[0].size);
       pNodeName = nodeNameStr.c_str();
     }
 
     std::string serviceNameStr;
     const char* pServiceName = nullptr;
-    if (BufferInSize2 > 0)
+    if (request.in_vectors.size() > 1 && request.in_vectors[1].size > 0)
     {
-      serviceNameStr = Memory::GetString(_BufferIn2, BufferInSize2);
+      serviceNameStr = Memory::GetString(request.in_vectors[1].address, request.in_vectors[1].size);
       pServiceName = serviceNameStr.c_str();
     }
 
     addrinfo* result = nullptr;
-    int ret = getaddrinfo(pNodeName, pServiceName, BufferInSize3 ? &hints : nullptr, &result);
-    u32 addr = _BufferOut;
+    int ret = getaddrinfo(
+        pNodeName, pServiceName,
+        (request.in_vectors.size() > 2 && request.in_vectors[2].size) ? &hints : nullptr, &result);
+    u32 addr = request.io_vectors[0].address;
     u32 sockoffset = addr + 0x460;
     if (ret == 0)
     {
@@ -1394,11 +1300,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
       ret = -305;
     }
 
-    INFO_LOG(WII_IPC_NET, "IOCTLV_SO_GETADDRINFO "
-                          "(BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferOut, BufferOutSize);
-    INFO_LOG(WII_IPC_NET, "IOCTLV_SO_GETADDRINFO: %s", Memory::GetString(_BufferIn).c_str());
-    ReturnValue = ret;
+    request.Dump(GetDeviceName(), LogTypes::WII_IPC_NET, LogTypes::LINFO);
+    return_value = ret;
     break;
   }
   case IOCTLV_SO_ICMPPING:
@@ -1411,19 +1314,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
       u32 ip;
     } ip_info;
 
-    u32 fd = Memory::Read_U32(_BufferIn);
-    u32 num_ip = Memory::Read_U32(_BufferIn + 4);
-    u64 timeout = Memory::Read_U64(_BufferIn + 8);
+    u32 fd = Memory::Read_U32(request.in_vectors[0].address);
+    u32 num_ip = Memory::Read_U32(request.in_vectors[0].address + 4);
+    u64 timeout = Memory::Read_U64(request.in_vectors[0].address + 8);
 
     if (num_ip != 1)
     {
       INFO_LOG(WII_IPC_NET, "IOCTLV_SO_ICMPPING %i IPs", num_ip);
     }
 
-    ip_info.length = Memory::Read_U8(_BufferIn + 16);
-    ip_info.addr_family = Memory::Read_U8(_BufferIn + 17);
-    ip_info.icmp_id = Memory::Read_U16(_BufferIn + 18);
-    ip_info.ip = Memory::Read_U32(_BufferIn + 20);
+    ip_info.length = Memory::Read_U8(request.in_vectors[0].address + 16);
+    ip_info.addr_family = Memory::Read_U8(request.in_vectors[0].address + 17);
+    ip_info.icmp_id = Memory::Read_U16(request.in_vectors[0].address + 18);
+    ip_info.ip = Memory::Read_U32(request.in_vectors[0].address + 20);
 
     if (ip_info.length != 8 || ip_info.addr_family != AF_INET)
     {
@@ -1443,8 +1346,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
     memset(data, 0, sizeof(data));
     s32 icmp_length = sizeof(data);
 
-    if (BufferInSize2 == sizeof(data))
-      Memory::CopyFromEmu(data, _BufferIn2, BufferInSize2);
+    if (request.in_vectors.size() > 1 && request.in_vectors[1].size == sizeof(data))
+      Memory::CopyFromEmu(data, request.in_vectors[1].address, request.in_vectors[1].size);
     else
     {
       // TODO sequence number is incremented either statically, by
@@ -1461,31 +1364,14 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ip_top::IOCtlV(u32 CommandAddress)
     }
 
     // TODO proper error codes
-    ReturnValue = 0;
+    return_value = 0;
     break;
   }
   default:
-    INFO_LOG(WII_IPC_NET, "0x%x (BufferIn: (%08x, %i), BufferIn2: (%08x, %i)",
-             CommandBuffer.Parameter, _BufferIn, BufferInSize, _BufferIn2, BufferInSize2);
-    for (u32 i = 0; i < CommandBuffer.NumberInBuffer; ++i)
-    {
-      ERROR_LOG(WII_IPC_NET, "in %i addr %x size %x", i, CommandBuffer.InBuffer.at(i).m_Address,
-                CommandBuffer.InBuffer.at(i).m_Size);
-      ERROR_LOG(WII_IPC_NET, "\n%s",
-                ArrayToString(Memory::GetPointer(CommandBuffer.InBuffer.at(i).m_Address),
-                              CommandBuffer.InBuffer.at(i).m_Size, 4)
-                    .c_str());
-    }
-    for (u32 i = 0; i < CommandBuffer.NumberPayloadBuffer; ++i)
-    {
-      ERROR_LOG(WII_IPC_NET, "out %i addr %x size %x", i,
-                CommandBuffer.PayloadBuffer.at(i).m_Address,
-                CommandBuffer.PayloadBuffer.at(i).m_Size);
-    }
-    break;
+    request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_NET);
   }
 
-  Memory::Write_U32(ReturnValue, CommandAddress + 4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -30,7 +30,7 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_kd_request();
 
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
 
 private:
   enum
@@ -86,35 +86,31 @@ public:
   }
 
   virtual ~CWII_IPC_HLE_Device_net_kd_time() {}
-  IPCCommandResult IOCtl(u32 _CommandAddress) override
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override
   {
-    u32 Parameter = Memory::Read_U32(_CommandAddress + 0x0C);
-    u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-    u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-
-    u32 result = 0;
+    s32 result = 0;
     u32 common_result = 0;
     // TODO Writes stuff to /shared2/nwc24/misc.bin
     // u32 update_misc = 0;
 
-    switch (Parameter)
+    switch (request.request)
     {
     case IOCTL_NW24_GET_UNIVERSAL_TIME:
-      Memory::Write_U64(GetAdjustedUTC(), BufferOut + 4);
+      Memory::Write_U64(GetAdjustedUTC(), request.buffer_out + 4);
       break;
 
     case IOCTL_NW24_SET_UNIVERSAL_TIME:
-      SetAdjustedUTC(Memory::Read_U64(BufferIn));
-      // update_misc = Memory::Read_U32(BufferIn + 8);
+      SetAdjustedUTC(Memory::Read_U64(request.buffer_in));
+      // update_misc = Memory::Read_U32(request.buffer_in + 8);
       break;
 
     case IOCTL_NW24_SET_RTC_COUNTER:
-      rtc = Memory::Read_U32(BufferIn);
-      // update_misc = Memory::Read_U32(BufferIn + 4);
+      rtc = Memory::Read_U32(request.buffer_in);
+      // update_misc = Memory::Read_U32(request.buffer_in + 4);
       break;
 
     case IOCTL_NW24_GET_TIME_DIFF:
-      Memory::Write_U64(GetAdjustedUTC() - rtc, BufferOut + 4);
+      Memory::Write_U64(GetAdjustedUTC() - rtc, request.buffer_out + 4);
       break;
 
     case IOCTL_NW24_UNIMPLEMENTED:
@@ -122,13 +118,13 @@ public:
       break;
 
     default:
-      ERROR_LOG(WII_IPC_NET, "%s - unknown IOCtl: %x", GetDeviceName().c_str(), Parameter);
+      ERROR_LOG(WII_IPC_NET, "%s - unknown IOCtl: %x", GetDeviceName().c_str(), request.request);
       break;
     }
 
     // write return values
-    Memory::Write_U32(common_result, BufferOut);
-    Memory::Write_U32(result, _CommandAddress + 4);
+    Memory::Write_U32(common_result, request.buffer_out);
+    request.SetReturnValue(result);
     return GetDefaultReply();
   }
 
@@ -207,8 +203,8 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ip_top();
 
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
 
   void Update() override;
 
@@ -227,7 +223,7 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ncd_manage();
 
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
 
 private:
   enum
@@ -253,7 +249,7 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_wd_command();
 
-  IPCCommandResult IOCtlV(u32 CommandAddress) override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
 
 private:
   enum

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net.h
@@ -124,8 +124,7 @@ public:
 
     // write return values
     Memory::Write_U32(common_result, request.buffer_out);
-    request.SetReturnValue(result);
-    return GetDefaultReply();
+    return GetDefaultReply(result);
   }
 
 private:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -75,72 +75,62 @@ int CWII_IPC_HLE_Device_net_ssl::GetSSLFreeID() const
   return 0;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(const IOSIOCtlRequest& request)
 {
-  u32 BufferIn = Memory::Read_U32(_CommandAddress + 0x10);
-  u32 BufferInSize = Memory::Read_U32(_CommandAddress + 0x14);
-  u32 BufferOut = Memory::Read_U32(_CommandAddress + 0x18);
-  u32 BufferOutSize = Memory::Read_U32(_CommandAddress + 0x1C);
-  u32 Command = Memory::Read_U32(_CommandAddress + 0x0C);
-
-  INFO_LOG(WII_IPC_SSL, "%s unknown %i "
-                        "(BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-           GetDeviceName().c_str(), Command, BufferIn, BufferInSize, BufferOut, BufferOutSize);
-  Memory::Write_U32(0, _CommandAddress + 0x4);
+  request.Log(GetDeviceName(), LogTypes::WII_IPC_SSL, LogTypes::LINFO);
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
+IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(const IOSIOCtlVRequest& request)
 {
-  SIOCtlVBuffer CommandBuffer(_CommandAddress);
-
-  u32 _BufferIn = 0, _BufferIn2 = 0, _BufferIn3 = 0;
+  u32 BufferIn = 0, BufferIn2 = 0, BufferIn3 = 0;
   u32 BufferInSize = 0, BufferInSize2 = 0, BufferInSize3 = 0;
 
   u32 BufferOut = 0, BufferOut2 = 0, BufferOut3 = 0;
   u32 BufferOutSize = 0, BufferOutSize2 = 0, BufferOutSize3 = 0;
 
-  if (CommandBuffer.InBuffer.size() > 0)
+  if (request.in_vectors.size() > 0)
   {
-    _BufferIn = CommandBuffer.InBuffer.at(0).m_Address;
-    BufferInSize = CommandBuffer.InBuffer.at(0).m_Size;
+    BufferIn = request.in_vectors.at(0).address;
+    BufferInSize = request.in_vectors.at(0).size;
   }
-  if (CommandBuffer.InBuffer.size() > 1)
+  if (request.in_vectors.size() > 1)
   {
-    _BufferIn2 = CommandBuffer.InBuffer.at(1).m_Address;
-    BufferInSize2 = CommandBuffer.InBuffer.at(1).m_Size;
+    BufferIn2 = request.in_vectors.at(1).address;
+    BufferInSize2 = request.in_vectors.at(1).size;
   }
-  if (CommandBuffer.InBuffer.size() > 2)
+  if (request.in_vectors.size() > 2)
   {
-    _BufferIn3 = CommandBuffer.InBuffer.at(2).m_Address;
-    BufferInSize3 = CommandBuffer.InBuffer.at(2).m_Size;
+    BufferIn3 = request.in_vectors.at(2).address;
+    BufferInSize3 = request.in_vectors.at(2).size;
   }
 
-  if (CommandBuffer.PayloadBuffer.size() > 0)
+  if (request.io_vectors.size() > 0)
   {
-    BufferOut = CommandBuffer.PayloadBuffer.at(0).m_Address;
-    BufferOutSize = CommandBuffer.PayloadBuffer.at(0).m_Size;
+    BufferOut = request.io_vectors.at(0).address;
+    BufferOutSize = request.io_vectors.at(0).size;
   }
-  if (CommandBuffer.PayloadBuffer.size() > 1)
+  if (request.io_vectors.size() > 1)
   {
-    BufferOut2 = CommandBuffer.PayloadBuffer.at(1).m_Address;
-    BufferOutSize2 = CommandBuffer.PayloadBuffer.at(1).m_Size;
+    BufferOut2 = request.io_vectors.at(1).address;
+    BufferOutSize2 = request.io_vectors.at(1).size;
   }
-  if (CommandBuffer.PayloadBuffer.size() > 2)
+  if (request.io_vectors.size() > 2)
   {
-    BufferOut3 = CommandBuffer.PayloadBuffer.at(2).m_Address;
-    BufferOutSize3 = CommandBuffer.PayloadBuffer.at(2).m_Size;
+    BufferOut3 = request.io_vectors.at(2).address;
+    BufferOutSize3 = request.io_vectors.at(2).size;
   }
 
   // I don't trust SSL to be deterministic, and this is never going to sync
   // as such (as opposed to forwarding IPC results or whatever), so -
   if (Core::g_want_determinism)
   {
-    Memory::Write_U32(-1, _CommandAddress + 0x4);
+    request.SetReturnValue(-1);
     return GetDefaultReply();
   }
 
-  switch (CommandBuffer.Parameter)
+  switch (request.request)
   {
   case IOCTLV_NET_SSL_NEW:
   {
@@ -187,20 +177,20 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       mbedtls_ssl_set_hostname(&ssl->ctx, ssl->hostname.c_str());
 
       ssl->active = true;
-      Memory::Write_U32(freeSSL, _BufferIn);
+      Memory::Write_U32(freeSSL, BufferIn);
     }
     else
     {
     _SSL_NEW_ERROR:
-      Memory::Write_U32(SSL_ERR_FAILED, _BufferIn);
+      Memory::Write_U32(SSL_ERR_FAILED, BufferIn);
     }
 
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_NEW (%d, %s) "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             verifyOption, hostname.c_str(), _BufferIn, BufferInSize, _BufferIn2, BufferInSize2,
-             _BufferIn3, BufferInSize3, BufferOut, BufferOutSize, BufferOut2, BufferOutSize2,
+             verifyOption, hostname.c_str(), BufferIn, BufferInSize, BufferIn2, BufferInSize2,
+             BufferIn3, BufferInSize3, BufferOut, BufferOutSize, BufferOut2, BufferOutSize2,
              BufferOut3, BufferOutSize3);
     break;
   }
@@ -226,18 +216,18 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
 
       ssl->active = false;
 
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SHUTDOWN "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
   case IOCTLV_NET_SSL_SETROOTCA:
@@ -246,8 +236,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
@@ -264,19 +254,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
 
       if (ret)
       {
-        Memory::Write_U32(SSL_ERR_FAILED, _BufferIn);
+        Memory::Write_U32(SSL_ERR_FAILED, BufferIn);
       }
       else
       {
         mbedtls_ssl_conf_ca_chain(&ssl->config, &ssl->cacert, nullptr);
-        Memory::Write_U32(SSL_OK, _BufferIn);
+        Memory::Write_U32(SSL_OK, BufferIn);
       }
 
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETROOTCA = %d", ret);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     break;
   }
@@ -286,8 +276,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
@@ -302,19 +292,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       {
         mbedtls_x509_crt_free(&ssl->clicert);
         mbedtls_pk_free(&ssl->pk);
-        Memory::Write_U32(SSL_ERR_FAILED, _BufferIn);
+        Memory::Write_U32(SSL_ERR_FAILED, BufferIn);
       }
       else
       {
         mbedtls_ssl_conf_own_cert(&ssl->config, &ssl->clicert, &ssl->pk);
-        Memory::Write_U32(SSL_OK, _BufferIn);
+        Memory::Write_U32(SSL_OK, BufferIn);
       }
 
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINCLIENTCERT = (%d, %d)", ret, pk_ret);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINCLIENTCERT invalid sslID = %d", sslID);
     }
     break;
@@ -325,8 +315,8 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
@@ -336,11 +326,11 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       mbedtls_pk_free(&ssl->pk);
 
       mbedtls_ssl_conf_own_cert(&ssl->config, nullptr, nullptr);
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINCLIENTCERT invalid sslID = %d", sslID);
     }
     break;
@@ -357,25 +347,25 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       if (ret)
       {
         mbedtls_x509_crt_free(&ssl->clicert);
-        Memory::Write_U32(SSL_ERR_FAILED, _BufferIn);
+        Memory::Write_U32(SSL_ERR_FAILED, BufferIn);
       }
       else
       {
         mbedtls_ssl_conf_ca_chain(&ssl->config, &ssl->cacert, nullptr);
-        Memory::Write_U32(SSL_OK, _BufferIn);
+        Memory::Write_U32(SSL_OK, BufferIn);
       }
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINROOTCA = %d", ret);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETBUILTINROOTCA "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
   case IOCTLV_NET_SSL_CONNECT:
@@ -388,18 +378,18 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
       ssl->sockfd = Memory::Read_U32(BufferOut2);
       INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_CONNECT socket = %d", ssl->sockfd);
       mbedtls_ssl_set_bio(&ssl->ctx, &ssl->sockfd, mbedtls_net_send, mbedtls_net_recv, nullptr);
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_CONNECT "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
   case IOCTLV_NET_SSL_DOHANDSHAKE:
@@ -408,12 +398,12 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
     if (SSLID_VALID(sslID))
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
-      sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_DOHANDSHAKE);
+      sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_DOHANDSHAKE);
       return GetNoReply();
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     break;
   }
@@ -423,19 +413,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
     if (SSLID_VALID(sslID))
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
-      sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_WRITE);
+      sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_WRITE);
       return GetNoReply();
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_WRITE "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     INFO_LOG(WII_IPC_SSL, "%s", Memory::GetString(BufferOut2).c_str());
     break;
   }
@@ -446,19 +436,19 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
     if (SSLID_VALID(sslID))
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
-      sm.DoSock(_SSL[sslID].sockfd, _CommandAddress, IOCTLV_NET_SSL_READ);
+      sm.DoSock(_SSL[sslID].sockfd, request, IOCTLV_NET_SSL_READ);
       return GetNoReply();
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
 
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_READ(%d)"
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             ret, _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
+             ret, BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3,
              BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
@@ -467,18 +457,18 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
     {
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     INFO_LOG(WII_IPC_SSL, "IOCTLV_NET_SSL_SETROOTCADEFAULT "
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
     break;
   }
   case IOCTLV_NET_SSL_SETCLIENTCERTDEFAULT:
@@ -487,33 +477,25 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(u32 _CommandAddress)
                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-             _BufferIn, BufferInSize, _BufferIn2, BufferInSize2, _BufferIn3, BufferInSize3,
-             BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
+             BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3, BufferOut,
+             BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
     int sslID = Memory::Read_U32(BufferOut) - 1;
     if (SSLID_VALID(sslID))
     {
-      Memory::Write_U32(SSL_OK, _BufferIn);
+      Memory::Write_U32(SSL_OK, BufferIn);
     }
     else
     {
-      Memory::Write_U32(SSL_ERR_ID, _BufferIn);
+      Memory::Write_U32(SSL_ERR_ID, BufferIn);
     }
     break;
   }
   default:
-    ERROR_LOG(WII_IPC_SSL, "%i "
-                           "BufferIn: (%08x, %i), BufferIn2: (%08x, %i), "
-                           "BufferIn3: (%08x, %i), BufferOut: (%08x, %i), "
-                           "BufferOut2: (%08x, %i), BufferOut3: (%08x, %i)",
-              CommandBuffer.Parameter, _BufferIn, BufferInSize, _BufferIn2, BufferInSize2,
-              _BufferIn3, BufferInSize3, BufferOut, BufferOutSize, BufferOut2, BufferOutSize2,
-              BufferOut3, BufferOutSize3);
-    break;
+    request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_SSL);
   }
 
   // SSL return codes are written to BufferIn
-  Memory::Write_U32(0, _CommandAddress + 4);
-
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.cpp
@@ -78,8 +78,7 @@ int CWII_IPC_HLE_Device_net_ssl::GetSSLFreeID() const
 IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtl(const IOSIOCtlRequest& request)
 {
   request.Log(GetDeviceName(), LogTypes::WII_IPC_SSL, LogTypes::LINFO);
-  request.SetReturnValue(IPC_SUCCESS);
-  return GetDefaultReply();
+  return GetDefaultReply(IPC_SUCCESS);
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(const IOSIOCtlVRequest& request)
@@ -125,10 +124,7 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(const IOSIOCtlVRequest& req
   // I don't trust SSL to be deterministic, and this is never going to sync
   // as such (as opposed to forwarding IPC results or whatever), so -
   if (Core::g_want_determinism)
-  {
-    request.SetReturnValue(-1);
-    return GetDefaultReply();
-  }
+    return GetDefaultReply(IPC_EACCES);
 
   switch (request.request)
   {
@@ -496,6 +492,5 @@ IPCCommandResult CWII_IPC_HLE_Device_net_ssl::IOCtlV(const IOSIOCtlVRequest& req
   }
 
   // SSL return codes are written to BufferIn
-  request.SetReturnValue(IPC_SUCCESS);
-  return GetDefaultReply();
+  return GetDefaultReply(IPC_SUCCESS);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_net_ssl.h
@@ -87,8 +87,8 @@ public:
 
   virtual ~CWII_IPC_HLE_Device_net_ssl();
 
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
-  IPCCommandResult IOCtlV(u32 _CommandAddress) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
 
   int GetSSLFreeID() const;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -204,11 +204,6 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(u32 _CommandAddress)
     break;
   }
 
-  // INFO_LOG(WII_IPC_SD, "InBuffer");
-  // DumpCommands(BufferIn, BufferInSize / 4, LogTypes::WII_IPC_SD);
-  // INFO_LOG(WII_IPC_SD, "OutBuffer");
-  // DumpCommands(BufferOut, BufferOutSize/4, LogTypes::WII_IPC_SD);
-
   if (ReturnValue == RET_EVENT_REGISTER)
   {
     // async
@@ -264,9 +259,6 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(u32 _CommandAddress)
     ERROR_LOG(WII_IPC_SD, "Unknown SD IOCtlV command 0x%08x", CommandBuffer.Parameter);
     break;
   }
-
-  // DumpAsync(CommandBuffer.BufferVector, CommandBuffer.NumberInBuffer,
-  // CommandBuffer.NumberPayloadBuffer, LogTypes::WII_IPC_SD);
 
   Memory::Write_U32(ReturnValue, _CommandAddress + 0x4);
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_sdio_slot0.cpp
@@ -45,8 +45,7 @@ void CWII_IPC_HLE_Device_sdio_slot0::EventNotify()
   if ((SConfig::GetInstance().m_WiiSDCard && m_event->type == EVENT_INSERT) ||
       (!SConfig::GetInstance().m_WiiSDCard && m_event->type == EVENT_REMOVE))
   {
-    m_event->request.SetReturnValue(m_event->type);
-    WII_IPC_HLE_Interface::EnqueueReply(m_event->request);
+    WII_IPC_HLE_Interface::EnqueueReply(m_event->request, m_event->type);
     m_event.reset();
   }
 }
@@ -198,8 +197,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtl(const IOSIOCtlRequest& re
     EventNotify();
     return GetNoReply();
   }
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(const IOSIOCtlVRequest& request)
@@ -220,8 +218,7 @@ IPCCommandResult CWII_IPC_HLE_Device_sdio_slot0::IOCtlV(const IOSIOCtlVRequest& 
     ERROR_LOG(WII_IPC_SD, "Unknown SD IOCtlV command 0x%08x", request.request);
   }
 
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 u32 CWII_IPC_HLE_Device_sdio_slot0::ExecuteCommand(const IOSRequest& request, u32 _BufferIn,
@@ -394,8 +391,7 @@ u32 CWII_IPC_HLE_Device_sdio_slot0::ExecuteCommand(const IOSRequest& request, u3
     // release returns 0
     // unknown sd int
     // technically we do it out of order, oh well
-    m_event->request.SetReturnValue(EVENT_INVALID);
-    WII_IPC_HLE_Interface::EnqueueReply(m_event->request);
+    WII_IPC_HLE_Interface::EnqueueReply(m_event->request, EVENT_INVALID);
     m_event.reset();
     break;
   }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -37,8 +37,7 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(const IOSIOCtlRequest&
       break;
     }
     Memory::Write_U32(0, s_event_hook_request->buffer_out);
-    s_event_hook_request->SetReturnValue(IPC_SUCCESS);
-    WII_IPC_HLE_Interface::EnqueueReply(*s_event_hook_request);
+    WII_IPC_HLE_Interface::EnqueueReply(*s_event_hook_request, IPC_SUCCESS);
     s_event_hook_request.reset();
     break;
 
@@ -63,8 +62,7 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(const IOSIOCtlRequest&
     request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_STM);
   }
 
-  request.SetReturnValue(return_value);
-  return GetDefaultReply();
+  return GetDefaultReply(return_value);
 }
 
 void CWII_IPC_HLE_Device_stm_eventhook::Close()
@@ -78,15 +76,11 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(const IOSIOCtlRequest&
   if (request.request != IOCTL_STM_EVENTHOOK)
   {
     ERROR_LOG(WII_IPC_STM, "Bad IOCtl in CWII_IPC_HLE_Device_stm_eventhook");
-    request.SetReturnValue(IPC_EINVAL);
-    return GetDefaultReply();
+    return GetDefaultReply(IPC_EINVAL);
   }
 
   if (s_event_hook_request)
-  {
-    request.SetReturnValue(IPC_EEXIST);
-    return GetDefaultReply();
-  }
+    return GetDefaultReply(IPC_EEXIST);
 
   // IOCTL_STM_EVENTHOOK waits until the reset button or power button is pressed.
   s_event_hook_request = std::make_unique<IOSIOCtlRequest>(request.address);
@@ -105,8 +99,7 @@ void CWII_IPC_HLE_Device_stm_eventhook::TriggerEvent(const u32 event) const
     return;
 
   Memory::Write_U32(event, s_event_hook_request->buffer_out);
-  s_event_hook_request->SetReturnValue(IPC_SUCCESS);
-  WII_IPC_HLE_Interface::EnqueueReply(*s_event_hook_request);
+  WII_IPC_HLE_Interface::EnqueueReply(*s_event_hook_request, IPC_SUCCESS);
   s_event_hook_request.reset();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -59,7 +59,6 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
   case IOCTL_STM_VIDIMMING:  // (Input: 20 bytes, Output: 20 bytes)
     INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
     INFO_LOG(WII_IPC_STM, "    IOCTL_STM_VIDIMMING");
-    // DumpCommands(buffer_in, buffer_in_size / 4, LogTypes::WII_IPC_STM);
     // Memory::Write_U32(1, buffer_out);
     // return_value = 1;
     break;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.cpp
@@ -5,6 +5,7 @@
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_stm.h"
 
 #include <functional>
+#include <memory>
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
@@ -16,22 +17,12 @@ void QueueHostJob(std::function<void()> job, bool run_during_stop);
 void Stop();
 }
 
-static u32 s_event_hook_address = 0;
+static std::unique_ptr<IOSIOCtlRequest> s_event_hook_request;
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(const IOSIOCtlRequest& request)
 {
-  u32 parameter = Memory::Read_U32(command_address + 0x0C);
-  u32 buffer_in = Memory::Read_U32(command_address + 0x10);
-  u32 buffer_in_size = Memory::Read_U32(command_address + 0x14);
-  u32 buffer_out = Memory::Read_U32(command_address + 0x18);
-  u32 buffer_out_size = Memory::Read_U32(command_address + 0x1C);
-
-  // Prepare the out buffer(s) with zeroes as a safety precaution
-  // to avoid returning bad values
-  Memory::Memset(buffer_out, 0, buffer_out_size);
-  u32 return_value = 0;
-
-  switch (parameter)
+  s32 return_value = IPC_SUCCESS;
+  switch (request.request)
   {
   case IOCTL_STM_IDLE:
   case IOCTL_STM_SHUTDOWN:
@@ -40,15 +31,15 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
     break;
 
   case IOCTL_STM_RELEASE_EH:
-    if (s_event_hook_address == 0)
+    if (!s_event_hook_request)
     {
       return_value = IPC_ENOENT;
       break;
     }
-    Memory::Write_U32(0, Memory::Read_U32(s_event_hook_address + 0x18));
-    Memory::Write_U32(IPC_SUCCESS, s_event_hook_address + 4);
-    WII_IPC_HLE_Interface::EnqueueReply(s_event_hook_address);
-    s_event_hook_address = 0;
+    Memory::Write_U32(0, s_event_hook_request->buffer_out);
+    s_event_hook_request->SetReturnValue(IPC_SUCCESS);
+    WII_IPC_HLE_Interface::EnqueueReply(*s_event_hook_request);
+    s_event_hook_request.reset();
     break;
 
   case IOCTL_STM_HOTRESET:
@@ -69,79 +60,59 @@ IPCCommandResult CWII_IPC_HLE_Device_stm_immediate::IOCtl(u32 command_address)
     break;
 
   default:
-  {
-    _dbg_assert_msg_(WII_IPC_STM, 0, "CWII_IPC_HLE_Device_stm_immediate: 0x%x", parameter);
-
-    INFO_LOG(WII_IPC_STM, "%s - IOCtl:", GetDeviceName().c_str());
-    DEBUG_LOG(WII_IPC_STM, "    parameter: 0x%x", parameter);
-    DEBUG_LOG(WII_IPC_STM, "    InBuffer: 0x%08x", buffer_in);
-    DEBUG_LOG(WII_IPC_STM, "    InBufferSize: 0x%08x", buffer_in_size);
-    DEBUG_LOG(WII_IPC_STM, "    OutBuffer: 0x%08x", buffer_out);
-    DEBUG_LOG(WII_IPC_STM, "    OutBufferSize: 0x%08x", buffer_out_size);
-  }
-  break;
+    request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_STM);
   }
 
-  // Write return value to the IPC call
-  Memory::Write_U32(return_value, command_address + 0x4);
+  request.SetReturnValue(return_value);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::Close(u32 command_address, bool force)
+void CWII_IPC_HLE_Device_stm_eventhook::Close()
 {
-  s_event_hook_address = 0;
-
+  s_event_hook_request.reset();
   m_is_active = false;
-  return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_stm_eventhook::IOCtl(const IOSIOCtlRequest& request)
 {
-  u32 parameter = Memory::Read_U32(command_address + 0x0C);
-  if (parameter != IOCTL_STM_EVENTHOOK)
+  if (request.request != IOCTL_STM_EVENTHOOK)
   {
     ERROR_LOG(WII_IPC_STM, "Bad IOCtl in CWII_IPC_HLE_Device_stm_eventhook");
-    Memory::Write_U32(IPC_EINVAL, command_address + 4);
+    request.SetReturnValue(IPC_EINVAL);
     return GetDefaultReply();
   }
 
-  if (s_event_hook_address != 0)
+  if (s_event_hook_request)
   {
-    Memory::Write_U32(FS_EEXIST, command_address + 4);
+    request.SetReturnValue(IPC_EEXIST);
     return GetDefaultReply();
   }
 
-  // IOCTL_STM_EVENTHOOK waits until the reset button or power button
-  // is pressed.
-  s_event_hook_address = command_address;
+  // IOCTL_STM_EVENTHOOK waits until the reset button or power button is pressed.
+  s_event_hook_request = std::make_unique<IOSIOCtlRequest>(request.address);
   return GetNoReply();
 }
 
 bool CWII_IPC_HLE_Device_stm_eventhook::HasHookInstalled() const
 {
-  return s_event_hook_address != 0;
+  return s_event_hook_request != nullptr;
 }
 
 void CWII_IPC_HLE_Device_stm_eventhook::TriggerEvent(const u32 event) const
 {
-  if (!m_is_active || s_event_hook_address == 0)
-  {
-    // If the device isn't open, ignore the button press.
+  // If the device isn't open, ignore the button press.
+  if (!m_is_active || !s_event_hook_request)
     return;
-  }
 
-  // The reset button returns STM_EVENT_RESET.
-  u32 buffer_out = Memory::Read_U32(s_event_hook_address + 0x18);
-  Memory::Write_U32(event, buffer_out);
-
-  Memory::Write_U32(IPC_SUCCESS, s_event_hook_address + 4);
-  WII_IPC_HLE_Interface::EnqueueReply(s_event_hook_address);
-  s_event_hook_address = 0;
+  Memory::Write_U32(event, s_event_hook_request->buffer_out);
+  s_event_hook_request->SetReturnValue(IPC_SUCCESS);
+  WII_IPC_HLE_Interface::EnqueueReply(*s_event_hook_request);
+  s_event_hook_request.reset();
 }
 
 void CWII_IPC_HLE_Device_stm_eventhook::ResetButton() const
 {
-  // The reset button returns STM_EVENT_RESET.
+  // The reset button triggers STM_EVENT_RESET.
   TriggerEvent(STM_EVENT_RESET);
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stm.h
@@ -43,8 +43,7 @@ public:
   {
   }
 
-  ~CWII_IPC_HLE_Device_stm_immediate() override = default;
-  IPCCommandResult IOCtl(u32 command_address) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
 };
 
 // The /dev/stm/eventhook
@@ -56,9 +55,8 @@ public:
   {
   }
 
-  ~CWII_IPC_HLE_Device_stm_eventhook() override = default;
-  IPCCommandResult Close(u32 command_address, bool force) override;
-  IPCCommandResult IOCtl(u32 command_address) override;
+  void Close() override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
 
   bool HasHookInstalled() const;
   void ResetButton() const;

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -4,37 +4,35 @@
 
 #include "Core/IPC_HLE/WII_IPC_HLE_Device_stub.h"
 #include "Common/Logging/Log.h"
-#include "Core/HW/Memmap.h"
 
 CWII_IPC_HLE_Device_stub::CWII_IPC_HLE_Device_stub(u32 device_id, const std::string& device_name)
     : IWII_IPC_HLE_Device(device_id, device_name)
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stub::Open(u32 command_address, u32 mode)
+IOSReturnCode CWII_IPC_HLE_Device_stub::Open(const IOSOpenRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking Open()", m_name.c_str());
   m_is_active = true;
-  return GetDefaultReply();
+  return IPC_SUCCESS;
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stub::Close(u32 command_address, bool force)
+void CWII_IPC_HLE_Device_stub::Close()
 {
   WARN_LOG(WII_IPC_HLE, "%s faking Close()", m_name.c_str());
   m_is_active = false;
-  return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtl(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtl(const IOSIOCtlRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_name.c_str());
-  Memory::Write_U32(IPC_SUCCESS, command_address + 4);
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtlV(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtlV(const IOSIOCtlVRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_name.c_str());
-  Memory::Write_U32(IPC_SUCCESS, command_address + 4);
+  request.SetReturnValue(IPC_SUCCESS);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.cpp
@@ -26,13 +26,11 @@ void CWII_IPC_HLE_Device_stub::Close()
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtl(const IOSIOCtlRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtl()", m_name.c_str());
-  request.SetReturnValue(IPC_SUCCESS);
-  return GetDefaultReply();
+  return GetDefaultReply(IPC_SUCCESS);
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_stub::IOCtlV(const IOSIOCtlVRequest& request)
 {
   WARN_LOG(WII_IPC_HLE, "%s faking IOCtlV()", m_name.c_str());
-  request.SetReturnValue(IPC_SUCCESS);
-  return GetDefaultReply();
+  return GetDefaultReply(IPC_SUCCESS);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_stub.h
@@ -15,8 +15,8 @@ class CWII_IPC_HLE_Device_stub : public IWII_IPC_HLE_Device
 public:
   CWII_IPC_HLE_Device_stub(u32 device_id, const std::string& device_name);
 
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force = false) override;
-  IPCCommandResult IOCtl(u32 command_address) override;
-  IPCCommandResult IOCtlV(u32 command_address) override;
+  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  void Close() override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.cpp
@@ -50,24 +50,23 @@ void RestoreBTInfoSection(SysConf* sysconf)
   File::Delete(filename);
 }
 
-CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlMessage::CtrlMessage(const SIOCtlVBuffer& cmd_buffer)
+CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlMessage::CtrlMessage(const IOSIOCtlVRequest& ioctlv)
+    : ios_request(ioctlv)
 {
-  request_type = Memory::Read_U8(cmd_buffer.InBuffer[0].m_Address);
-  request = Memory::Read_U8(cmd_buffer.InBuffer[1].m_Address);
-  value = Common::swap16(Memory::Read_U16(cmd_buffer.InBuffer[2].m_Address));
-  index = Common::swap16(Memory::Read_U16(cmd_buffer.InBuffer[3].m_Address));
-  length = Common::swap16(Memory::Read_U16(cmd_buffer.InBuffer[4].m_Address));
-  payload_addr = cmd_buffer.PayloadBuffer[0].m_Address;
-  address = cmd_buffer.m_Address;
+  request_type = Memory::Read_U8(ioctlv.in_vectors[0].address);
+  request = Memory::Read_U8(ioctlv.in_vectors[1].address);
+  value = Common::swap16(Memory::Read_U16(ioctlv.in_vectors[2].address));
+  index = Common::swap16(Memory::Read_U16(ioctlv.in_vectors[3].address));
+  length = Common::swap16(Memory::Read_U16(ioctlv.in_vectors[4].address));
+  payload_addr = ioctlv.io_vectors[0].address;
 }
 
-CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::CtrlBuffer(const SIOCtlVBuffer& cmd_buffer,
-                                                                 const u32 command_address)
+CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::CtrlBuffer(const IOSIOCtlVRequest& ioctlv)
+    : ios_request(ioctlv)
 {
-  m_endpoint = Memory::Read_U8(cmd_buffer.InBuffer[0].m_Address);
-  m_length = Memory::Read_U16(cmd_buffer.InBuffer[1].m_Address);
-  m_payload_addr = cmd_buffer.PayloadBuffer[0].m_Address;
-  m_cmd_address = command_address;
+  m_endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address);
+  m_length = Memory::Read_U16(ioctlv.in_vectors[1].address);
+  m_payload_addr = ioctlv.io_vectors[0].address;
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::FillBuffer(const u8* src,
@@ -76,9 +75,4 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::FillBuffer(const u8* 
   _assert_msg_(WII_IPC_WIIMOTE, size <= m_length, "FillBuffer: size %li > payload length %i", size,
                m_length);
   Memory::CopyToEmu(m_payload_addr, src, size);
-}
-
-void CWII_IPC_HLE_Device_usb_oh1_57e_305_base::CtrlBuffer::SetRetVal(const u32 retval) const
-{
-  Memory::Write_U32(retval, m_cmd_address + 4);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_base.h
@@ -24,11 +24,6 @@ public:
       : IWII_IPC_HLE_Device(device_id, device_name)
   {
   }
-  virtual ~CWII_IPC_HLE_Device_usb_oh1_57e_305_base() override = default;
-
-  virtual IPCCommandResult Open(u32 command_address, u32 mode) override = 0;
-
-  virtual void DoState(PointerWrap& p) override = 0;
 
   virtual void UpdateSyncButtonState(bool is_held) {}
   virtual void TriggerSyncButtonPressedEvent() {}
@@ -56,31 +51,23 @@ protected:
 
   struct CtrlMessage
   {
-    CtrlMessage() = default;
-    CtrlMessage(const SIOCtlVBuffer& cmd_buffer);
-
+    CtrlMessage(const IOSIOCtlVRequest& ioctlv);
+    IOSIOCtlVRequest ios_request;
     u8 request_type = 0;
     u8 request = 0;
     u16 value = 0;
     u16 index = 0;
     u16 length = 0;
     u32 payload_addr = 0;
-    u32 address = 0;
   };
 
-  class CtrlBuffer
+  struct CtrlBuffer
   {
-  public:
-    CtrlBuffer() = default;
-    CtrlBuffer(const SIOCtlVBuffer& cmd_buffer, u32 command_address);
-
+    CtrlBuffer(const IOSIOCtlVRequest& ioctlv);
+    IOSIOCtlVRequest ios_request;
     void FillBuffer(const u8* src, size_t size) const;
-    void SetRetVal(const u32 retval) const;
-    bool IsValid() const { return m_cmd_address != 0; }
-    void Invalidate() { m_cmd_address = m_payload_addr = 0; }
     u8 m_endpoint = 0;
     u16 m_length = 0;
     u32 m_payload_addr = 0;
-    u32 m_cmd_address = 0;
   };
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.cpp
@@ -268,10 +268,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_emu::IOCtlV(u32 _CommandAdd
     INFO_LOG(WII_IPC_WIIMOTE, "    BufferVector: 0x%08x", CommandBuffer.BufferVector);
     INFO_LOG(WII_IPC_WIIMOTE, "    PayloadAddr: 0x%08x", CommandBuffer.PayloadBuffer[0].m_Address);
     INFO_LOG(WII_IPC_WIIMOTE, "    PayloadSize: 0x%08x", CommandBuffer.PayloadBuffer[0].m_Size);
-#if defined(_DEBUG) || defined(DEBUGFAST)
-    DumpAsync(CommandBuffer.BufferVector, CommandBuffer.NumberInBuffer,
-              CommandBuffer.NumberPayloadBuffer);
-#endif
   }
   break;
   }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.cpp
@@ -393,8 +393,7 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeVendorCommandReply(CtrlBuffer
   hci_event->PayloadLength = sizeof(SHCIEventCommand) - 2;
   hci_event->PacketIndicator = 0x01;
   hci_event->Opcode = m_fake_vendor_command_reply_opcode;
-  ctrl.ios_request.SetReturnValue(sizeof(SHCIEventCommand));
-  WII_IPC_HLE_Interface::EnqueueReply(ctrl.ios_request);
+  WII_IPC_HLE_Interface::EnqueueReply(ctrl.ios_request, static_cast<s32>(sizeof(SHCIEventCommand)));
 }
 
 // Due to how the widcomm stack which Nintendo uses is coded, we must never
@@ -419,8 +418,9 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeReadBufferSizeReply(CtrlBuffe
   reply.num_sco_pkts = SCO_PKT_NUM;
 
   memcpy(packet + sizeof(SHCIEventCommand), &reply, sizeof(hci_read_buffer_size_rp));
-  ctrl.ios_request.SetReturnValue(sizeof(SHCIEventCommand) + sizeof(hci_read_buffer_size_rp));
-  WII_IPC_HLE_Interface::EnqueueReply(ctrl.ios_request);
+  WII_IPC_HLE_Interface::EnqueueReply(
+      ctrl.ios_request,
+      static_cast<s32>(sizeof(SHCIEventCommand) + sizeof(hci_read_buffer_size_rp)));
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonEvent(CtrlBuffer& ctrl,
@@ -431,8 +431,8 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::FakeSyncButtonEvent(CtrlBuffer& c
   hci_event->event = HCI_EVENT_VENDOR;
   hci_event->length = size;
   memcpy(packet + sizeof(hci_event_hdr_t), payload, size);
-  ctrl.ios_request.SetReturnValue(sizeof(hci_event_hdr_t) + size);
-  WII_IPC_HLE_Interface::EnqueueReply(ctrl.ios_request);
+  WII_IPC_HLE_Interface::EnqueueReply(ctrl.ios_request,
+                                      static_cast<s32>(sizeof(hci_event_hdr_t) + size));
 }
 
 // When the red sync button is pressed, a HCI event is generated:
@@ -578,7 +578,8 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::CommandCallback(libusb_transfer* 
     s_showed_failed_transfer.Clear();
   }
 
-  WII_IPC_HLE_Interface::EnqueueReply(cmd->ios_request, 0, CoreTiming::FromThread::NON_CPU);
+  WII_IPC_HLE_Interface::EnqueueReply(cmd->ios_request, tr->actual_length, 0,
+                                      CoreTiming::FromThread::NON_CPU);
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::TransferCallback(libusb_transfer* tr)
@@ -622,6 +623,6 @@ void CWII_IPC_HLE_Device_usb_oh1_57e_305_real::TransferCallback(libusb_transfer*
     }
   }
 
-  ctrl->ios_request.SetReturnValue(tr->actual_length);
-  WII_IPC_HLE_Interface::EnqueueReply(ctrl->ios_request, 0, CoreTiming::FromThread::NON_CPU);
+  WII_IPC_HLE_Interface::EnqueueReply(ctrl->ios_request, tr->actual_length, 0,
+                                      CoreTiming::FromThread::NON_CPU);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_real.h
@@ -42,9 +42,9 @@ public:
   CWII_IPC_HLE_Device_usb_oh1_57e_305_real(u32 device_id, const std::string& device_name);
   ~CWII_IPC_HLE_Device_usb_oh1_57e_305_real() override;
 
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult Close(u32 command_address, bool force) override;
-  IPCCommandResult IOCtlV(u32 command_address) override;
+  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  void Close() override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
 
   void DoState(PointerWrap& p) override;
   void UpdateSyncButtonState(bool is_held) override;
@@ -80,11 +80,11 @@ private:
   void SendHCIResetCommand();
   void SendHCIDeleteLinkKeyCommand();
   bool SendHCIStoreLinkKeyCommand();
-  void FakeVendorCommandReply(const CtrlBuffer& ctrl);
-  void FakeReadBufferSizeReply(const CtrlBuffer& ctrl);
-  void FakeSyncButtonEvent(const CtrlBuffer& ctrl, const u8* payload, u8 size);
-  void FakeSyncButtonPressedEvent(const CtrlBuffer& ctrl);
-  void FakeSyncButtonHeldEvent(const CtrlBuffer& ctrl);
+  void FakeVendorCommandReply(CtrlBuffer& ctrl);
+  void FakeReadBufferSizeReply(CtrlBuffer& ctrl);
+  void FakeSyncButtonEvent(CtrlBuffer& ctrl, const u8* payload, u8 size);
+  void FakeSyncButtonPressedEvent(CtrlBuffer& ctrl);
+  void FakeSyncButtonHeldEvent(CtrlBuffer& ctrl);
 
   void LoadLinkKeys();
   void SaveLinkKeys();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.cpp
@@ -12,11 +12,11 @@ namespace Core
 void DisplayMessage(const std::string& message, int time_in_ms);
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_oh1_57e_305_stub::Open(u32 command_address, u32 mode)
+IOSReturnCode CWII_IPC_HLE_Device_usb_oh1_57e_305_stub::Open(const IOSOpenRequest& request)
 {
   PanicAlertT("Bluetooth passthrough mode is enabled, but Dolphin was built without libusb."
               " Passthrough mode cannot be used.");
-  return GetNoReply();
+  return IPC_ENOENT;
 }
 
 void CWII_IPC_HLE_Device_usb_oh1_57e_305_stub::DoState(PointerWrap& p)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_stub.h
@@ -16,11 +16,10 @@ class CWII_IPC_HLE_Device_usb_oh1_57e_305_stub final
     : public CWII_IPC_HLE_Device_usb_oh1_57e_305_base
 {
 public:
-  CWII_IPC_HLE_Device_usb_oh1_57e_305_stub(u32 device_id, const std::string& device_name)
+  CWII_IPC_HLE_Device_usb_oh1_57e_305_stub(const u32 device_id, const std::string& device_name)
       : CWII_IPC_HLE_Device_usb_oh1_57e_305_base(device_id, device_name)
   {
   }
-  ~CWII_IPC_HLE_Device_usb_oh1_57e_305_stub() override {}
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
+  IOSReturnCode Open(const IOSOpenRequest& request) override;
   void DoState(PointerWrap& p) override;
 };

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -73,9 +73,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Close(u32 _CommandAddress, bool _b
 IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::Write(u32 _CommandAddress)
 {
   DEBUG_LOG(WII_IPC_HLE, "Ignoring write to CWII_IPC_HLE_Device_usb_kbd");
-#if defined(_DEBUG) || defined(DEBUGFAST)
-  DumpCommands(_CommandAddress, 10, LogTypes::WII_IPC_HLE, LogTypes::LDEBUG);
-#endif
   return GetDefaultReply();
 }
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.cpp
@@ -65,8 +65,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_kbd::IOCtl(const IOSIOCtlRequest& reque
     Memory::CopyToEmu(request.buffer_out, &m_MessageQueue.front(), sizeof(SMessageData));
     m_MessageQueue.pop();
   }
-  request.SetReturnValue(IPC_SUCCESS);
-  return GetDefaultReply();
+  return GetDefaultReply(IPC_SUCCESS);
 }
 
 bool CWII_IPC_HLE_Device_usb_kbd::IsKeyPressed(int _Key)

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_kbd.h
@@ -15,12 +15,9 @@ class CWII_IPC_HLE_Device_usb_kbd : public IWII_IPC_HLE_Device
 {
 public:
   CWII_IPC_HLE_Device_usb_kbd(u32 _DeviceID, const std::string& _rDeviceName);
-  virtual ~CWII_IPC_HLE_Device_usb_kbd();
 
-  IPCCommandResult Open(u32 _CommandAddress, u32 _Mode) override;
-  IPCCommandResult Close(u32 _CommandAddress, bool _bForce) override;
-  IPCCommandResult Write(u32 _CommandAddress) override;
-  IPCCommandResult IOCtl(u32 _CommandAddress) override;
+  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
   void Update() override;
 
 private:

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
@@ -12,40 +12,23 @@ CWII_IPC_HLE_Device_usb_ven::CWII_IPC_HLE_Device_usb_ven(const u32 device_id,
 {
 }
 
-CWII_IPC_HLE_Device_usb_ven::~CWII_IPC_HLE_Device_usb_ven()
+IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtlV(const IOSIOCtlVRequest& request)
 {
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtlV(u32 command_address)
-{
-  SIOCtlVBuffer command_buffer(command_address);
-
-  INFO_LOG(OSHLE, "%s - IOCtlV:", GetDeviceName().c_str());
-  INFO_LOG(OSHLE, "  Parameter: 0x%x", command_buffer.Parameter);
-  INFO_LOG(OSHLE, "  NumberIn: 0x%08x", command_buffer.NumberInBuffer);
-  INFO_LOG(OSHLE, "  NumberOut: 0x%08x", command_buffer.NumberPayloadBuffer);
-  INFO_LOG(OSHLE, "  BufferVector: 0x%08x", command_buffer.BufferVector);
-
-  Memory::Write_U32(0, command_address + 4);
+  request.Dump(GetDeviceName());
+  request.SetReturnValue(IPC_SUCCESS);
   return GetNoReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(u32 command_address)
+IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(const IOSIOCtlRequest& request)
 {
+  request.Log(GetDeviceName(), LogTypes::OSHLE);
+  request.SetReturnValue(IPC_SUCCESS);
+
   IPCCommandResult reply = GetDefaultReply();
-  u32 command = Memory::Read_U32(command_address + 0x0c);
-  u32 buffer_in = Memory::Read_U32(command_address + 0x10);
-  u32 buffer_in_size = Memory::Read_U32(command_address + 0x14);
-  u32 buffer_out = Memory::Read_U32(command_address + 0x18);
-  u32 buffer_out_size = Memory::Read_U32(command_address + 0x1c);
-
-  INFO_LOG(OSHLE, "%s - IOCtl: %x", GetDeviceName().c_str(), command);
-  INFO_LOG(OSHLE, "%x:%x %x:%x", buffer_in, buffer_in_size, buffer_out, buffer_out_size);
-
-  switch (command)
+  switch (request.request)
   {
   case USBV5_IOCTL_GETVERSION:
-    Memory::Write_U32(0x50001, buffer_out);
+    Memory::Write_U32(0x50001, request.buffer_out);
     reply = GetDefaultReply();
     break;
 
@@ -60,7 +43,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(u32 command_address)
     }
 
     // num devices
-    Memory::Write_U32(0, command_address + 4);
+    request.SetReturnValue(0);
     return reply;
   }
   break;
@@ -70,33 +53,26 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(u32 command_address)
     break;
 
   case USBV5_IOCTL_SUSPEND_RESUME:
-    DEBUG_LOG(OSHLE, "Device: %i Resumed: %i", Memory::Read_U32(buffer_in),
-              Memory::Read_U32(buffer_in + 4));
+    DEBUG_LOG(OSHLE, "Device: %i Resumed: %i", Memory::Read_U32(request.buffer_in),
+              Memory::Read_U32(request.buffer_in + 4));
     reply = GetDefaultReply();
     break;
 
   case USBV5_IOCTL_GETDEVPARAMS:
   {
-    s32 device = Memory::Read_U32(buffer_in);
-    u32 unk = Memory::Read_U32(buffer_in + 4);
+    s32 device = Memory::Read_U32(request.buffer_in);
+    u32 unk = Memory::Read_U32(request.buffer_in + 4);
 
     DEBUG_LOG(OSHLE, "USBV5_IOCTL_GETDEVPARAMS device: %i unk: %i", device, unk);
 
-    Memory::Write_U32(0, buffer_out);
+    Memory::Write_U32(0, request.buffer_out);
 
     reply = GetDefaultReply();
   }
   break;
 
   default:
-    DEBUG_LOG(OSHLE, "%x:%x %x:%x", buffer_in, buffer_in_size, buffer_out, buffer_out_size);
-    break;
+    request.Log(GetDeviceName(), LogTypes::OSHLE, LogTypes::LDEBUG);
   }
-
-  Memory::Write_U32(0, command_address + 4);
   return reply;
-}
-
-void CWII_IPC_HLE_Device_usb_ven::DoState(PointerWrap& p)
-{
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
@@ -15,21 +15,19 @@ CWII_IPC_HLE_Device_usb_ven::CWII_IPC_HLE_Device_usb_ven(const u32 device_id,
 IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtlV(const IOSIOCtlVRequest& request)
 {
   request.Dump(GetDeviceName());
-  request.SetReturnValue(IPC_SUCCESS);
   return GetNoReply();
 }
 
 IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(const IOSIOCtlRequest& request)
 {
   request.Log(GetDeviceName(), LogTypes::OSHLE);
-  request.SetReturnValue(IPC_SUCCESS);
 
-  IPCCommandResult reply = GetDefaultReply();
+  IPCCommandResult reply = GetDefaultReply(IPC_SUCCESS);
   switch (request.request)
   {
   case USBV5_IOCTL_GETVERSION:
     Memory::Write_U32(0x50001, request.buffer_out);
-    reply = GetDefaultReply();
+    reply = GetDefaultReply(IPC_SUCCESS);
     break;
 
   case USBV5_IOCTL_GETDEVICECHANGE:
@@ -38,24 +36,24 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(const IOSIOCtlRequest& reque
     static bool firstcall = true;
     if (firstcall)
     {
-      reply = GetDefaultReply();
+      reply = GetDefaultReply(IPC_SUCCESS);
       firstcall = false;
     }
 
     // num devices
-    request.SetReturnValue(0);
+    reply = GetDefaultReply(0);
     return reply;
   }
   break;
 
   case USBV5_IOCTL_ATTACHFINISH:
-    reply = GetDefaultReply();
+    reply = GetDefaultReply(IPC_SUCCESS);
     break;
 
   case USBV5_IOCTL_SUSPEND_RESUME:
     DEBUG_LOG(OSHLE, "Device: %i Resumed: %i", Memory::Read_U32(request.buffer_in),
               Memory::Read_U32(request.buffer_in + 4));
-    reply = GetDefaultReply();
+    reply = GetDefaultReply(IPC_SUCCESS);
     break;
 
   case USBV5_IOCTL_GETDEVPARAMS:
@@ -67,7 +65,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtl(const IOSIOCtlRequest& reque
 
     Memory::Write_U32(0, request.buffer_out);
 
-    reply = GetDefaultReply();
+    reply = GetDefaultReply(IPC_SUCCESS);
   }
   break;
 

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.cpp
@@ -25,8 +25,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_ven::IOCtlV(u32 command_address)
   INFO_LOG(OSHLE, "  NumberIn: 0x%08x", command_buffer.NumberInBuffer);
   INFO_LOG(OSHLE, "  NumberOut: 0x%08x", command_buffer.NumberPayloadBuffer);
   INFO_LOG(OSHLE, "  BufferVector: 0x%08x", command_buffer.BufferVector);
-  DumpAsync(command_buffer.BufferVector, command_buffer.NumberInBuffer,
-            command_buffer.NumberPayloadBuffer);
 
   Memory::Write_U32(0, command_address + 4);
   return GetNoReply();

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_ven.h
@@ -10,19 +10,13 @@
 #include "Core/IPC_HLE/WII_IPC_HLE.h"
 #include "Core/IPC_HLE/WII_IPC_HLE_Device.h"
 
-class PointerWrap;
-
 class CWII_IPC_HLE_Device_usb_ven final : public IWII_IPC_HLE_Device
 {
 public:
   CWII_IPC_HLE_Device_usb_ven(u32 device_id, const std::string& device_name);
 
-  ~CWII_IPC_HLE_Device_usb_ven() override;
-
-  IPCCommandResult IOCtlV(u32 command_address) override;
-  IPCCommandResult IOCtl(u32 command_address) override;
-
-  void DoState(PointerWrap& p) override;
+  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
 
 private:
   enum USBIOCtl

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_wfssrv.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_wfssrv.cpp
@@ -157,8 +157,7 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_wfssrv::IOCtl(const IOSIOCtlRequest& re
     break;
   }
 
-  request.SetReturnValue(return_error_code);
-  return GetDefaultReply();
+  return GetDefaultReply(return_error_code);
 }
 
 CWII_IPC_HLE_Device_usb_wfssrv::FileDescriptor*

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_wfssrv.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_wfssrv.cpp
@@ -161,14 +161,6 @@ IPCCommandResult CWII_IPC_HLE_Device_usb_wfssrv::IOCtl(const IOSIOCtlRequest& re
   return GetDefaultReply();
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_usb_wfssrv::IOCtlV(u32 command_address)
-{
-  SIOCtlVBuffer command_buffer(command_address);
-  ERROR_LOG(WII_IPC_HLE, "IOCtlV on /dev/usb/wfssrv -- unsupported");
-  Memory::Write_U32(IPC_EINVAL, command_address + 4);
-  return GetDefaultReply();
-}
-
 CWII_IPC_HLE_Device_usb_wfssrv::FileDescriptor*
 CWII_IPC_HLE_Device_usb_wfssrv::FindFileDescriptor(u16 fd)
 {

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_wfssrv.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_usb_wfssrv.h
@@ -23,8 +23,7 @@ class CWII_IPC_HLE_Device_usb_wfssrv : public IWII_IPC_HLE_Device
 public:
   CWII_IPC_HLE_Device_usb_wfssrv(u32 device_id, const std::string& device_name);
 
-  IPCCommandResult IOCtl(u32 command_address) override;
-  IPCCommandResult IOCtlV(u32 command_address) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
 
 private:
   // WFS device name, e.g. msc01/msc02.

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_wfsi.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_wfsi.cpp
@@ -238,6 +238,5 @@ IPCCommandResult CWII_IPC_HLE_Device_wfsi::IOCtl(const IOSIOCtlRequest& request)
     break;
   }
 
-  request.SetReturnValue(return_error_code);
-  return GetDefaultReply();
+  return GetDefaultReply(return_error_code);
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_wfsi.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_wfsi.cpp
@@ -79,28 +79,16 @@ CWII_IPC_HLE_Device_wfsi::CWII_IPC_HLE_Device_wfsi(u32 device_id, const std::str
 {
 }
 
-IPCCommandResult CWII_IPC_HLE_Device_wfsi::Open(u32 command_address, u32 mode)
+IPCCommandResult CWII_IPC_HLE_Device_wfsi::IOCtl(const IOSIOCtlRequest& request)
 {
-  INFO_LOG(WII_IPC_HLE, "/dev/wfsi: Open");
-  return IWII_IPC_HLE_Device::Open(command_address, mode);
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_wfsi::IOCtl(u32 command_address)
-{
-  u32 command = Memory::Read_U32(command_address + 0xC);
-  u32 buffer_in = Memory::Read_U32(command_address + 0x10);
-  u32 buffer_in_size = Memory::Read_U32(command_address + 0x14);
-  u32 buffer_out = Memory::Read_U32(command_address + 0x18);
-  u32 buffer_out_size = Memory::Read_U32(command_address + 0x1C);
-
   u32 return_error_code = IPC_SUCCESS;
 
-  switch (command)
+  switch (request.request)
   {
   case IOCTL_WFSI_PREPARE_DEVICE:
   {
-    u32 tmd_addr = Memory::Read_U32(buffer_in);
-    u32 tmd_size = Memory::Read_U32(buffer_in + 4);
+    u32 tmd_addr = Memory::Read_U32(request.buffer_in);
+    u32 tmd_size = Memory::Read_U32(request.buffer_in + 4);
 
     INFO_LOG(WII_IPC_HLE, "IOCTL_WFSI_PREPARE_DEVICE");
 
@@ -135,11 +123,12 @@ IPCCommandResult CWII_IPC_HLE_Device_wfsi::IOCtl(u32 command_address)
 
   case IOCTL_WFSI_PREPARE_CONTENT:
   {
-    const char* ioctl_name = command == IOCTL_WFSI_PREPARE_PROFILE ? "IOCTL_WFSI_PREPARE_PROFILE" :
-                                                                     "IOCTL_WFSI_PREPARE_CONTENT";
+    const char* ioctl_name = request.request == IOCTL_WFSI_PREPARE_PROFILE ?
+                                 "IOCTL_WFSI_PREPARE_PROFILE" :
+                                 "IOCTL_WFSI_PREPARE_CONTENT";
 
     // Initializes the IV from the index of the content in the TMD contents.
-    u32 content_id = Memory::Read_U32(buffer_in + 8);
+    u32 content_id = Memory::Read_U32(request.buffer_in + 8);
     TMDReader::Content content_info;
     if (!m_tmd.FindContentById(content_id, &content_info))
     {
@@ -161,12 +150,13 @@ IPCCommandResult CWII_IPC_HLE_Device_wfsi::IOCtl(u32 command_address)
   case IOCTL_WFSI_IMPORT_PROFILE:
   case IOCTL_WFSI_IMPORT_CONTENT:
   {
-    const char* ioctl_name = command == IOCTL_WFSI_IMPORT_PROFILE ? "IOCTL_WFSI_IMPORT_PROFILE" :
-                                                                    "IOCTL_WFSI_IMPORT_CONTENT";
+    const char* ioctl_name = request.request == IOCTL_WFSI_IMPORT_PROFILE ?
+                                 "IOCTL_WFSI_IMPORT_PROFILE" :
+                                 "IOCTL_WFSI_IMPORT_CONTENT";
 
-    u32 content_id = Memory::Read_U32(buffer_in + 0xC);
-    u32 input_ptr = Memory::Read_U32(buffer_in + 0x10);
-    u32 input_size = Memory::Read_U32(buffer_in + 0x14);
+    u32 content_id = Memory::Read_U32(request.buffer_in + 0xC);
+    u32 input_ptr = Memory::Read_U32(request.buffer_in + 0x10);
+    u32 input_size = Memory::Read_U32(request.buffer_in + 0x14);
     INFO_LOG(WII_IPC_HLE, "%s: %08x bytes of data at %08x from content id %d", ioctl_name,
              content_id, input_ptr, input_size);
 
@@ -181,7 +171,7 @@ IPCCommandResult CWII_IPC_HLE_Device_wfsi::IOCtl(u32 command_address)
   case IOCTL_WFSI_FINALIZE_PROFILE:
   case IOCTL_WFSI_FINALIZE_CONTENT:
   {
-    const char* ioctl_name = command == IOCTL_WFSI_FINALIZE_PROFILE ?
+    const char* ioctl_name = request.request == IOCTL_WFSI_FINALIZE_PROFILE ?
                                  "IOCTL_WFSI_FINALIZE_PROFILE" :
                                  "IOCTL_WFSI_FINALIZE_CONTENT";
     INFO_LOG(WII_IPC_HLE, "%s", ioctl_name);
@@ -225,7 +215,7 @@ IPCCommandResult CWII_IPC_HLE_Device_wfsi::IOCtl(u32 command_address)
 
   case IOCTL_WFSI_SET_DEVICE_NAME:
     INFO_LOG(WII_IPC_HLE, "IOCTL_WFSI_SET_DEVICE_NAME");
-    m_device_name = Memory::GetString(buffer_in);
+    m_device_name = Memory::GetString(request.buffer_in);
     break;
 
   case IOCTL_WFSI_APPLY_TITLE_PROFILE:
@@ -243,21 +233,11 @@ IPCCommandResult CWII_IPC_HLE_Device_wfsi::IOCtl(u32 command_address)
     // TODO(wfs): Should be returning an error. However until we have
     // everything properly stubbed it's easier to simulate the methods
     // succeeding.
-    WARN_LOG(WII_IPC_HLE, "%s unimplemented IOCtl(0x%08x, size_in=%08x, size_out=%08x)\n%s\n%s",
-             m_name.c_str(), command, buffer_in_size, buffer_out_size,
-             HexDump(Memory::GetPointer(buffer_in), buffer_in_size).c_str(),
-             HexDump(Memory::GetPointer(buffer_out), buffer_out_size).c_str());
-    Memory::Memset(buffer_out, 0, buffer_out_size);
+    request.DumpUnknown(GetDeviceName(), LogTypes::WII_IPC_HLE, LogTypes::LWARNING);
+    Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
     break;
   }
 
-  Memory::Write_U32(return_error_code, command_address + 4);
-  return GetDefaultReply();
-}
-
-IPCCommandResult CWII_IPC_HLE_Device_wfsi::IOCtlV(u32 command_address)
-{
-  ERROR_LOG(WII_IPC_HLE, "IOCtlV on /dev/wfsi -- unsupported");
-  Memory::Write_U32(IPC_EINVAL, command_address + 4);
+  request.SetReturnValue(return_error_code);
   return GetDefaultReply();
 }

--- a/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_wfsi.h
+++ b/Source/Core/Core/IPC_HLE/WII_IPC_HLE_Device_wfsi.h
@@ -34,9 +34,7 @@ class CWII_IPC_HLE_Device_wfsi : public IWII_IPC_HLE_Device
 public:
   CWII_IPC_HLE_Device_wfsi(u32 device_id, const std::string& device_name);
 
-  IPCCommandResult Open(u32 command_address, u32 mode) override;
-  IPCCommandResult IOCtl(u32 command_address) override;
-  IPCCommandResult IOCtlV(u32 command_address) override;
+  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
 
 private:
   std::string m_device_name;

--- a/Source/Core/Core/IPC_HLE/WII_Socket.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.cpp
@@ -567,8 +567,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
                 "IOCTL(V) Sock: %08x ioctl/v: %d returned: %d nonBlock: %d forceNonBlock: %d", fd,
                 it->is_ssl ? (int)it->ssl_type : (int)it->net_type, ReturnValue, nonBlock,
                 forceNonBlock);
-      it->request.SetReturnValue(ReturnValue);
-      WII_IPC_HLE_Interface::EnqueueReply(it->request);
+      WII_IPC_HLE_Interface::EnqueueReply(it->request, ReturnValue);
       it = pending_sockops.erase(it);
     }
     else

--- a/Source/Core/Core/IPC_HLE/WII_Socket.cpp
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.cpp
@@ -187,28 +187,23 @@ void WiiSocket::Update(bool read, bool write, bool except)
   {
     s32 ReturnValue = 0;
     bool forceNonBlock = false;
-    IPCCommandType ct = static_cast<IPCCommandType>(Memory::Read_U32(it->_CommandAddress));
+    IPCCommandType ct = it->request.command;
     if (!it->is_ssl && ct == IPC_CMD_IOCTL)
     {
-      u32 BufferIn = Memory::Read_U32(it->_CommandAddress + 0x10);
-      u32 BufferInSize = Memory::Read_U32(it->_CommandAddress + 0x14);
-      u32 BufferOut = Memory::Read_U32(it->_CommandAddress + 0x18);
-      u32 BufferOutSize = Memory::Read_U32(it->_CommandAddress + 0x1C);
-
+      IOSIOCtlRequest ioctl{it->request.address};
       switch (it->net_type)
       {
       case IOCTL_SO_FCNTL:
       {
-        u32 cmd = Memory::Read_U32(BufferIn + 4);
-        u32 arg = Memory::Read_U32(BufferIn + 8);
+        u32 cmd = Memory::Read_U32(ioctl.buffer_in + 4);
+        u32 arg = Memory::Read_U32(ioctl.buffer_in + 8);
         ReturnValue = FCntl(cmd, arg);
         break;
       }
       case IOCTL_SO_BIND:
       {
-        // u32 has_addr = Memory::Read_U32(BufferIn + 0x04);
         sockaddr_in local_name;
-        WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(BufferIn + 0x08);
+        WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(ioctl.buffer_in + 8);
         WiiSockMan::Convert(*wii_name, local_name);
 
         int ret = bind(fd, (sockaddr*)&local_name, sizeof(local_name));
@@ -220,9 +215,8 @@ void WiiSocket::Update(bool read, bool write, bool except)
       }
       case IOCTL_SO_CONNECT:
       {
-        // u32 has_addr = Memory::Read_U32(BufferIn + 0x04);
         sockaddr_in local_name;
-        WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(BufferIn + 0x08);
+        WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(ioctl.buffer_in + 8);
         WiiSockMan::Convert(*wii_name, local_name);
 
         int ret = connect(fd, (sockaddr*)&local_name, sizeof(local_name));
@@ -234,10 +228,10 @@ void WiiSocket::Update(bool read, bool write, bool except)
       }
       case IOCTL_SO_ACCEPT:
       {
-        if (BufferOutSize > 0)
+        if (ioctl.buffer_out_size > 0)
         {
           sockaddr_in local_name;
-          WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(BufferOut);
+          WiiSockAddrIn* wii_name = (WiiSockAddrIn*)Memory::GetPointer(ioctl.buffer_out);
           WiiSockMan::Convert(*wii_name, local_name);
 
           socklen_t addrlen = sizeof(sockaddr_in);
@@ -254,10 +248,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
 
         WiiSockMan::GetInstance().AddSocket(ReturnValue);
 
-        INFO_LOG(WII_IPC_NET, "IOCTL_SO_ACCEPT "
-                              "BufferIn: (%08x, %i), BufferOut: (%08x, %i)",
-                 BufferIn, BufferInSize, BufferOut, BufferOutSize);
-
+        ioctl.Log("IOCTL_SO_ACCEPT", LogTypes::WII_IPC_NET);
         break;
       }
       default:
@@ -275,34 +266,34 @@ void WiiSocket::Update(bool read, bool write, bool except)
     }
     else if (ct == IPC_CMD_IOCTLV)
     {
-      SIOCtlVBuffer CommandBuffer(it->_CommandAddress);
+      IOSIOCtlVRequest ioctlv{it->request.address};
       u32 BufferIn = 0, BufferIn2 = 0;
       u32 BufferInSize = 0, BufferInSize2 = 0;
       u32 BufferOut = 0, BufferOut2 = 0;
       u32 BufferOutSize = 0, BufferOutSize2 = 0;
 
-      if (CommandBuffer.InBuffer.size() > 0)
+      if (ioctlv.in_vectors.size() > 0)
       {
-        BufferIn = CommandBuffer.InBuffer.at(0).m_Address;
-        BufferInSize = CommandBuffer.InBuffer.at(0).m_Size;
+        BufferIn = ioctlv.in_vectors.at(0).address;
+        BufferInSize = ioctlv.in_vectors.at(0).size;
       }
 
-      if (CommandBuffer.PayloadBuffer.size() > 0)
+      if (ioctlv.io_vectors.size() > 0)
       {
-        BufferOut = CommandBuffer.PayloadBuffer.at(0).m_Address;
-        BufferOutSize = CommandBuffer.PayloadBuffer.at(0).m_Size;
+        BufferOut = ioctlv.io_vectors.at(0).address;
+        BufferOutSize = ioctlv.io_vectors.at(0).size;
       }
 
-      if (CommandBuffer.PayloadBuffer.size() > 1)
+      if (ioctlv.io_vectors.size() > 1)
       {
-        BufferOut2 = CommandBuffer.PayloadBuffer.at(1).m_Address;
-        BufferOutSize2 = CommandBuffer.PayloadBuffer.at(1).m_Size;
+        BufferOut2 = ioctlv.io_vectors.at(1).address;
+        BufferOutSize2 = ioctlv.io_vectors.at(1).size;
       }
 
-      if (CommandBuffer.InBuffer.size() > 1)
+      if (ioctlv.in_vectors.size() > 1)
       {
-        BufferIn2 = CommandBuffer.InBuffer.at(1).m_Address;
-        BufferInSize2 = CommandBuffer.InBuffer.at(1).m_Size;
+        BufferIn2 = ioctlv.in_vectors.at(1).address;
+        BufferInSize2 = ioctlv.in_vectors.at(1).size;
       }
 
       if (it->is_ssl)
@@ -576,8 +567,8 @@ void WiiSocket::Update(bool read, bool write, bool except)
                 "IOCTL(V) Sock: %08x ioctl/v: %d returned: %d nonBlock: %d forceNonBlock: %d", fd,
                 it->is_ssl ? (int)it->ssl_type : (int)it->net_type, ReturnValue, nonBlock,
                 forceNonBlock);
-      Memory::Write_U32(ReturnValue, it->_CommandAddress + 4);
-      WII_IPC_HLE_Interface::EnqueueReply(it->_CommandAddress);
+      it->request.SetReturnValue(ReturnValue);
+      WII_IPC_HLE_Interface::EnqueueReply(it->request);
       it = pending_sockops.erase(it);
     }
     else
@@ -587,16 +578,16 @@ void WiiSocket::Update(bool read, bool write, bool except)
   }
 }
 
-void WiiSocket::DoSock(u32 _CommandAddress, NET_IOCTL type)
+void WiiSocket::DoSock(IOSRequest request, NET_IOCTL type)
 {
-  sockop so = {_CommandAddress, false};
+  sockop so = {request, false};
   so.net_type = type;
   pending_sockops.push_back(so);
 }
 
-void WiiSocket::DoSock(u32 _CommandAddress, SSL_IOCTL type)
+void WiiSocket::DoSock(IOSRequest request, SSL_IOCTL type)
 {
-  sockop so = {_CommandAddress, true};
+  sockop so = {request, true};
   so.ssl_type = type;
   pending_sockops.push_back(so);
 }

--- a/Source/Core/Core/IPC_HLE/WII_Socket.h
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.h
@@ -172,7 +172,7 @@ class WiiSocket
 {
   struct sockop
   {
-    u32 _CommandAddress;
+    IOSRequest request;
     bool is_ssl;
     union
     {
@@ -191,8 +191,8 @@ private:
   s32 CloseFd();
   s32 FCntl(u32 cmd, u32 arg);
 
-  void DoSock(u32 _CommandAddress, NET_IOCTL type);
-  void DoSock(u32 _CommandAddress, SSL_IOCTL type);
+  void DoSock(IOSRequest request, NET_IOCTL type);
+  void DoSock(IOSRequest request, SSL_IOCTL type);
   void Update(bool read, bool write, bool except);
   bool IsValid() const { return fd >= 0; }
 public:
@@ -223,19 +223,19 @@ public:
   void SetLastNetError(s32 error) { errno_last = error; }
   void Clean() { WiiSockets.clear(); }
   template <typename T>
-  void DoSock(s32 sock, u32 CommandAddress, T type)
+  void DoSock(s32 sock, const IOSRequest& request, T type)
   {
     auto socket_entry = WiiSockets.find(sock);
     if (socket_entry == WiiSockets.end())
     {
-      ERROR_LOG(WII_IPC_NET, "DoSock: Error, fd not found (%08x, %08X, %08X)", sock, CommandAddress,
-                type);
-      Memory::Write_U32(-SO_EBADF, CommandAddress + 4);
-      WII_IPC_HLE_Interface::EnqueueReply(CommandAddress);
+      ERROR_LOG(WII_IPC_NET, "DoSock: Error, fd not found (%08x, %08X, %08X)", sock,
+                request.address, type);
+      request.SetReturnValue(-SO_EBADF);
+      WII_IPC_HLE_Interface::EnqueueReply(request);
     }
     else
     {
-      socket_entry->second.DoSock(CommandAddress, type);
+      socket_entry->second.DoSock(request, type);
     }
   }
 

--- a/Source/Core/Core/IPC_HLE/WII_Socket.h
+++ b/Source/Core/Core/IPC_HLE/WII_Socket.h
@@ -230,8 +230,7 @@ public:
     {
       ERROR_LOG(WII_IPC_NET, "DoSock: Error, fd not found (%08x, %08X, %08X)", sock,
                 request.address, type);
-      request.SetReturnValue(-SO_EBADF);
-      WII_IPC_HLE_Interface::EnqueueReply(request);
+      WII_IPC_HLE_Interface::EnqueueReply(request, -SO_EBADF);
     }
     else
     {

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 68;  // Last changed in PR 4638
+static const u32 STATE_VERSION = 69;  // Last changed in PR 4661
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This moves the resource request parsing code into well-defined structs instead of duplicating it all over IOS HLE. Command handler functions are now passed parsed resource requests instead of a command address.

This may not seem like a very important change, but it removes the need to remember all of the struct offsets or more likely, copy/paste existing struct request variables. It also makes it harder to introduce nasty bugs which have occurred in the past, such as parsing an ioctl as if it were an ioctlv (that's way too easy to do if you pass command addresses directly); or writing something to 0x0, which can easily happen by mistake with a close handler that can be called with invalid command addresses.

Some other notable changes:

- The return code is not an obscure Memory::Write_U32 anymore, but an explicit, more obvious SetReturnValue() call. (Which correctly takes a s32 instead of a u32, since return codes are signed.)

- Open handlers are now only responsible for returning an IOS return code, and Close handlers don't return anything and don't have to worry about checking whether the request is a real one anymore.

- `Dump` was moved to the relevant request structs, because it did not really make sense to make it part of the IOS device especially when it only works for ioctl/ioctlv requests.

This was split from #4488 so it has already been tested by JMC47.