### PR TITLE
MemoryView: Separate memory string composition from OnPaint

### DIFF
--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -103,6 +103,64 @@ int CMemoryView::YToAddress(int y)
   return curAddress + ydiff * align;
 }
 
+wxString CMemoryView::ReadMemoryAsString(u32 address) const
+{
+  std::string str;
+
+  // FIXME: This doesn't work with the DSP Debugger
+  u32 mem_data = debugger->ReadExtraMemory(memory, address);
+
+  if (m_data_type == MemoryDataType::FloatingPoint)
+  {
+    float& flt = reinterpret_cast<float&>(mem_data);
+    str = StringFromFormat("f: %f", flt);
+  }
+  else if (m_data_type == MemoryDataType::ASCII)
+  {
+    str.reserve(4);
+    for (unsigned int i = 0; i < 4; ++i)
+    {
+      u8 byte = static_cast<u8>(mem_data >> (24 - i * 8));
+      if (std::isprint(byte))
+        str += static_cast<char>(byte);
+      else
+        str += ' ';
+    }
+
+    Symbol* sym = g_symbolDB.GetSymbolFromAddr(mem_data);
+    if (sym)
+    {
+      str += StringFromFormat(" # -> %s", sym->name.c_str());
+    }
+  }
+  else
+  {
+    str.reserve(48);
+    for (unsigned int i = 0; i < align; i += sizeof(u32))
+    {
+      if (!PowerPC::HostIsRAMAddress(address + i))
+        break;
+      u32 word = debugger->ReadExtraMemory(memory, address + i);
+      switch (m_data_type)
+      {
+      case MemoryDataType::U8:
+      default:
+        str += StringFromFormat(" %02X %02X %02X %02X", (word >> 24) & 0xFF, (word >> 16) & 0xFF,
+                                (word >> 8) & 0xFF, word & 0xFF);
+        break;
+      case MemoryDataType::U16:
+        str += StringFromFormat(" %04X %04X", (word >> 16) & 0xFFFF, word & 0xFFFF);
+        break;
+      case MemoryDataType::U32:
+        str += StringFromFormat(" %08X", word);
+        break;
+      }
+    }
+  }
+
+  return StrToWxStr(str);
+}
+
 void CMemoryView::OnMouseDownL(wxMouseEvent& event)
 {
   int x = event.GetX();
@@ -347,60 +405,8 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
     if (!debugger->IsAlive() || !Memory::IsInitialized() || !PowerPC::HostIsRAMAddress(address))
       continue;
 
-    std::string dis;
-    // FIXME: This doesn't work with the DSP Debugger
-    u32 mem_data = debugger->ReadExtraMemory(memory, address);
-
-    if (m_data_type == MemoryDataType::FloatingPoint)
-    {
-      float& flt = reinterpret_cast<float&>(mem_data);
-      dis = StringFromFormat("f: %f", flt);
-    }
-    else if (m_data_type == MemoryDataType::ASCII)
-    {
-      dis.reserve(4);
-      for (unsigned int i = 0; i < 4; ++i)
-      {
-        u8 byte = static_cast<u8>(mem_data >> (24 - i * 8));
-        if (std::isprint(byte))
-          dis += static_cast<char>(byte);
-        else
-          dis += ' ';
-      }
-
-      Symbol* sym = g_symbolDB.GetSymbolFromAddr(mem_data);
-      if (sym)
-      {
-        dis += StringFromFormat(" # -> %s", sym->name.c_str());
-      }
-    }
-    else
-    {
-      dis.reserve(48);
-      for (unsigned int i = 0; i < align; i += sizeof(u32))
-      {
-        if (!PowerPC::HostIsRAMAddress(address + i))
-          break;
-        u32 word = debugger->ReadExtraMemory(memory, address + i);
-        switch (m_data_type)
-        {
-        case MemoryDataType::U8:
-        default:
-          dis += StringFromFormat(" %02X %02X %02X %02X", (word >> 24) & 0xFF, (word >> 16) & 0xFF,
-                                  (word >> 8) & 0xFF, word & 0xFF);
-          break;
-        case MemoryDataType::U16:
-          dis += StringFromFormat(" %04X %04X", (word >> 16) & 0xFFFF, word & 0xFFFF);
-          break;
-        case MemoryDataType::U32:
-          dis += StringFromFormat(" %08X", word);
-          break;
-        }
-      }
-    }
-
     // Pad to a minimum of 48 characters for full fixed point float width
-    draw_text(StrToWxStr(dis), 2, 48);
+    draw_text(ReadMemoryAsString(address), 2, 48);
 
     dc.SetTextForeground(*wxBLUE);
 

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -2,9 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinWX/Debugger/MemoryView.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstring>
 #include <string>
 #include <wx/brush.h>
 #include <wx/clipbrd.h>
@@ -24,7 +27,6 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "DolphinWX/Debugger/CodeWindow.h"
 #include "DolphinWX/Debugger/DebuggerUIUtil.h"
-#include "DolphinWX/Debugger/MemoryView.h"
 #include "DolphinWX/Debugger/WatchWindow.h"
 #include "DolphinWX/Frame.h"
 #include "DolphinWX/Globals.h"
@@ -112,8 +114,9 @@ wxString CMemoryView::ReadMemoryAsString(u32 address) const
 
   if (m_data_type == MemoryDataType::FloatingPoint)
   {
-    float& flt = reinterpret_cast<float&>(mem_data);
-    str = StringFromFormat("f: %f", flt);
+    float real;
+    std::memcpy(&real, &mem_data, sizeof(u32));
+    str = StringFromFormat("f: %f", real);
   }
   else if (m_data_type == MemoryDataType::ASCII)
   {

--- a/Source/Core/DolphinWX/Debugger/MemoryView.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.h
@@ -49,6 +49,8 @@ private:
     return m_data_type != MemoryDataType::ASCII && m_data_type != MemoryDataType::FloatingPoint;
   }
 
+  wxString ReadMemoryAsString(u32 address) const;
+
   void OnPaint(wxPaintEvent& event);
   void OnMouseDownL(wxMouseEvent& event);
   void OnMouseMove(wxMouseEvent& event);


### PR DESCRIPTION
Keeps things more separated. OnPaint() doesn't have a block of functionally unrelated code inside of it now. This change also gets rid of a type-punning cast as well.