### PR TITLE
HW/DSP: Hide the DSP state global

### DIFF
--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -116,7 +116,7 @@ struct ARAMInfo
 static ARAMInfo g_ARAM;
 static AudioDMA g_audioDMA;
 static ARAM_DMA g_arDMA;
-UDSPControl g_dspState;
+static UDSPControl g_dspState;
 
 union ARAM_Info
 {

--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -59,8 +59,6 @@ union UDSPControl
   UDSPControl(u16 _Hex = 0) : Hex(_Hex) {}
 };
 
-extern UDSPControl g_dspState;
-
 void Init(bool hle);
 void Shutdown();
 


### PR DESCRIPTION
This actually wasn't used anywhere directly, so it can be hidden.

This also corrects the names of all translation unit variables by changing the `g_` prefix into an `s_` prefix, since they aren't globals. I can move this to its own PR if it's preferable.