### PR TITLE
cmake: Set MACOSX_RPATH to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ if (APPLE)
 			set(CMAKE_C_COMPILER "clang")
 		endif()
 	endif()
+
+	# This doesn't play with with the packaging script that doesn't understand @rpath
+	set(CMAKE_MACOSX_RPATH OFF)
 endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/CMakeTests)
 # Libraries to link


### PR DESCRIPTION
In newer versions of CMake, the variable is ON by default.
This generates imports like @rpath/libusb.dylib which the
packaging script doesn’t understand.
We don’t really need @rpath, so we can just disable it
at the global scope instead of fixing the script.