### PR TITLE
CMake: Search /usr/local paths on BSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,23 @@ if(UNIX)
 	endif(LINUX_LOCAL_DEV)
 endif(UNIX)
 
+# BSDs put packages in /usr/local instead of /usr, so we need to
+# force CMake to look in those directories by default, too.
+# All commands and submodule commands also need to see these
+# changes, so just setting them in the project scope via
+# include_directories and link_directories is not sufficient
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD|NetBSD")
+	# CMake before 3.2 does not respect CMAKE_EXE_LINKER_FLAGS in
+	# try_compile, which can cause our compilation check functions
+	# to spuriously fail
+	if(POLICY CMP0056)
+		cmake_policy(SET CMP0056 NEW)
+	endif()
+	set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};/usr/local")
+	set(CMAKE_REQUIRED_INCLUDES "/usr/local/include")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/local/lib")
+endif()
+
 # Dolphin requires threads.
 # The Apple build may not need an explicit flag because one of the
 # frameworks may already provide it.


### PR DESCRIPTION
CMake would have trouble with some configuration tests on FreeBSD (and
presumably other BSDs) due to installed libraries being in /usr/local, but
not being in the default search path. Adding these to the default search path
fixes mbedtls and portaudio not being found, and possibly more.