### PR TITLE
cmake: Only use include directories on actual paths in check_lib

### DIFF
--- a/CMakeTests/CheckLib.cmake
+++ b/CMakeTests/CheckLib.cmake
@@ -26,10 +26,14 @@ macro(check_lib var pc lib)
 	endif()
 
 	if(${var}_FOUND)
-		include_directories(${${var}_INCLUDE_DIRS})
+		if(${var}_INCLUDE_DIRS)
+			include_directories(${${var}_INCLUDE_DIRS})
+		endif()
 		# Make sure include directories for headers found using find_path below
 		# are re-added when reconfiguring
-		include_directories(${${var}_INCLUDE})
+		if(${var}_INCLUDE)
+			include_directories(${${var}_INCLUDE})
+		endif()
 		_internal_message("${lib} found")
 	else()
 		find_library(${var} ${lib})


### PR DESCRIPTION
I had a situation where GTHREAD2_INCLUDE was set to NOTFOUND. Using a variable set to NOTFOUND fails the generation. In this case you were supposed to use GTHREAD2_INCLUDE_DIRS instead.