### PR TITLE
Replace insert blr/nop with code patch

### DIFF
--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -39,7 +39,7 @@ public:
   virtual void SetPC(unsigned int /*address*/) {}
   virtual void Step() {}
   virtual void RunToBreakpoint() {}
-  virtual void InsertBLR(unsigned int /*address*/, unsigned int /*value*/) {}
+  virtual void Patch(unsigned int /*address*/, unsigned int /*value*/) {}
   virtual int GetColor(unsigned int /*address*/) { return 0xFFFFFFFF; }
   virtual std::string GetDescription(unsigned int /*address*/) = 0;
 };

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SRCS
   ConfigLoaders/GameConfigLoader.cpp
   ConfigLoaders/MovieConfigLoader.cpp
   ConfigLoaders/NetPlayConfigLoader.cpp
+  Debugger/CodePatch.cpp
   Debugger/Debugger_SymbolMap.cpp
   Debugger/Dump.cpp
   Debugger/PPCDebugInterface.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -48,6 +48,7 @@
     <ClCompile Include="ConfigManager.cpp" />
     <ClCompile Include="Core.cpp" />
     <ClCompile Include="CoreTiming.cpp" />
+    <ClCompile Include="Debugger\CodePatch.cpp" />
     <ClCompile Include="Debugger\Debugger_SymbolMap.cpp" />
     <ClCompile Include="Debugger\Dump.cpp" />
     <ClCompile Include="Debugger\PPCDebugInterface.cpp" />
@@ -308,6 +309,7 @@
     <ClInclude Include="ConfigManager.h" />
     <ClInclude Include="Core.h" />
     <ClInclude Include="CoreTiming.h" />
+    <ClInclude Include="Debugger\CodePatch.h" />
     <ClInclude Include="Debugger\Debugger_SymbolMap.h" />
     <ClInclude Include="Debugger\Dump.h" />
     <ClInclude Include="Debugger\GCELF.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -200,6 +200,9 @@
     <ClCompile Include="Boot\ElfReader.cpp">
       <Filter>Boot</Filter>
     </ClCompile>
+    <ClInclude Include="Debugger\CodePatch.cpp">
+      <Filter>Debugger</Filter>
+    </ClInclude>
     <ClCompile Include="Debugger\Debugger_SymbolMap.cpp">
       <Filter>Debugger</Filter>
     </ClCompile>
@@ -915,6 +918,9 @@
     </ClInclude>
     <ClInclude Include="Boot\ElfTypes.h">
       <Filter>Boot</Filter>
+    </ClInclude>
+    <ClInclude Include="Debugger\CodePatch.h">
+      <Filter>Debugger</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\Debugger_SymbolMap.h">
       <Filter>Debugger</Filter>

--- a/Source/Core/Core/Debugger/CodePatch.cpp
+++ b/Source/Core/Core/Debugger/CodePatch.cpp
@@ -1,0 +1,75 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/Debugger/CodePatch.h"
+
+#include <utility>
+
+#include "Core/PowerPC/PowerPC.h"
+
+CodePatchBase::~CodePatchBase() = default;
+
+CodePatch::CodePatch(u32 address, const std::vector<u8>& patch) : m_address(address), m_patch(patch)
+{
+}
+
+CodePatch::CodePatch(u32 address, std::vector<u8>&& patch)
+    : m_address(address), m_patch(std::move(patch))
+{
+}
+
+CodePatch::~CodePatch() = default;
+
+u32 CodePatch::GetAddress() const
+{
+  return m_address;
+}
+
+std::size_t CodePatch::GetSize() const
+{
+  return m_patch.size();
+}
+
+bool CodePatch::Apply()
+{
+  if (GetState() != State::Source)
+    return false;
+
+  std::size_t size = GetSize();
+  for (std::size_t index = 0; index < size; ++index)
+  {
+    m_source.push_back(PowerPC::HostRead_U8(m_address + static_cast<u32>(index)));
+    PowerPC::HostWrite_U8(m_patch[index], m_address + static_cast<u32>(index));
+  }
+
+  return true;
+}
+
+bool CodePatch::Remove()
+{
+  if (GetState() != State::Patch)
+    return false;
+
+  std::size_t size = GetSize();
+  for (std::size_t index = 0; index < size; ++index)
+    PowerPC::HostWrite_U8(m_source[index], m_address + static_cast<u32>(index));
+  m_source.clear();
+
+  return true;
+}
+
+CodePatch::State CodePatch::GetState() const
+{
+  if (m_source.empty())
+    return State::Source;
+
+  std::size_t size = GetSize();
+  for (std::size_t index = 0; index < size; ++index)
+  {
+    if (PowerPC::HostRead_U8(m_address + static_cast<u32>(index)) != m_patch[index])
+      return State::Invalid;
+  }
+
+  return State::Patch;
+}

--- a/Source/Core/Core/Debugger/CodePatch.h
+++ b/Source/Core/Core/Debugger/CodePatch.h
@@ -1,0 +1,48 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+
+class CodePatchBase
+{
+public:
+  enum class State
+  {
+    Source,
+    Patch,
+    Invalid
+  };
+  virtual ~CodePatchBase();
+  virtual u32 GetAddress() const = 0;
+  virtual std::size_t GetSize() const = 0;
+  virtual bool Apply() = 0;
+  virtual bool Remove() = 0;
+  virtual State GetState() const = 0;
+};
+
+class CodePatch : public CodePatchBase
+{
+public:
+  CodePatch(u32 address, const std::vector<u8>& patch);
+  CodePatch(u32 address, std::vector<u8>&& patch);
+  ~CodePatch();
+
+  u32 GetAddress() const override;
+  std::size_t GetSize() const override;
+  bool Apply() override;
+  bool Remove() override;
+  State GetState() const override;
+
+private:
+  u32 m_address;
+  std::vector<u8> m_patch;
+  std::vector<u8> m_source;
+};
+
+using CodePatches = std::vector<CodePatch>;

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -42,7 +42,7 @@ public:
   void SetPC(unsigned int address) override;
   void Step() override {}
   void RunToBreakpoint() override;
-  void InsertBLR(unsigned int address, unsigned int value) override;
+  void Patch(unsigned int address, unsigned int value) override;
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
 };

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -132,9 +132,9 @@ void DSPDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool wri
   PanicAlert("MemCheck functionality not supported in DSP module.");
 }
 
-void DSPDebugInterface::InsertBLR(unsigned int address, unsigned int value)
+void DSPDebugInterface::Patch(unsigned int address, unsigned int value)
 {
-  PanicAlert("insertBLR functionality not supported in DSP module.");
+  PanicAlert("Patch functionality not supported in DSP module.");
 }
 
 // =======================================================

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -37,7 +37,7 @@ public:
   void SetPC(unsigned int address) override;
   void Step() override {}
   void RunToBreakpoint() override;
-  void InsertBLR(unsigned int address, unsigned int value) override;
+  void Patch(unsigned int address, unsigned int value) override;
   int GetColor(unsigned int address) override;
   std::string GetDescription(unsigned int address) override;
 };

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -15,6 +15,7 @@
 
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
+#include "Core/Debugger/CodePatch.h"
 #include "Core/HW/CPU.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
@@ -36,6 +37,7 @@ static CoreMode s_mode = CoreMode::Interpreter;
 Watches watches;
 BreakPoints breakpoints;
 MemChecks memchecks;
+CodePatches code_patches;
 PPCDebugInterface debug_interface;
 
 static CoreTiming::EventType* s_invalidate_cache_thread_safe;

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -10,6 +10,7 @@
 
 #include "Common/CommonTypes.h"
 
+#include "Core/Debugger/CodePatch.h"
 #include "Core/Debugger/PPCDebugInterface.h"
 #include "Core/PowerPC/BreakPoints.h"
 #include "Core/PowerPC/Gekko.h"
@@ -133,6 +134,7 @@ extern PowerPCState ppcState;
 extern Watches watches;
 extern BreakPoints breakpoints;
 extern MemChecks memchecks;
+extern CodePatches code_patches;
 extern PPCDebugInterface debug_interface;
 
 void Init(int cpu_core);

--- a/Source/Core/DolphinWX/Debugger/CodeView.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeView.cpp
@@ -194,36 +194,12 @@ u32 CCodeView::AddrToBranch(u32 addr)
   return 0;
 }
 
-void CCodeView::InsertBlrNop(int Blr)
+void CCodeView::InsertBlrNop(bool is_blr)
 {
-  // Check if this address has been modified
-  int find = -1;
-  for (u32 i = 0; i < m_blrList.size(); i++)
-  {
-    if (m_blrList.at(i).address == m_selection)
-    {
-      find = i;
-      break;
-    }
-  }
-
-  // Save the old value
-  if (find >= 0)
-  {
-    m_debugger->WriteExtraMemory(0, m_blrList.at(find).oldValue, m_selection);
-    m_blrList.erase(m_blrList.begin() + find);
-  }
+  if (is_blr)
+    m_debugger->Patch(m_selection, 0x4e800020);
   else
-  {
-    BlrStruct temp;
-    temp.address = m_selection;
-    temp.oldValue = m_debugger->ReadMemory(m_selection);
-    m_blrList.push_back(temp);
-    if (Blr == 0)
-      m_debugger->InsertBLR(m_selection, 0x4e800020);
-    else
-      m_debugger->InsertBLR(m_selection, 0x60000000);
-  }
+    m_debugger->Patch(m_selection, 0x60000000);
   Refresh();
 }
 
@@ -289,12 +265,12 @@ void CCodeView::OnPopupMenu(wxCommandEvent& event)
 
   // Insert blr or restore old value
   case IDM_INSERTBLR:
-    InsertBlrNop(0);
+    InsertBlrNop(true);
     Refresh();
     break;
 
   case IDM_INSERTNOP:
-    InsertBlrNop(1);
+    InsertBlrNop(false);
     Refresh();
     break;
 

--- a/Source/Core/DolphinWX/Debugger/CodeView.h
+++ b/Source/Core/DolphinWX/Debugger/CodeView.h
@@ -46,20 +46,13 @@ private:
   void OnMouseUpL(wxMouseEvent& event);
   void OnMouseUpR(wxMouseEvent& event);
   void OnPopupMenu(wxCommandEvent& event);
-  void InsertBlrNop(int);
+  void InsertBlrNop(bool is_blr);
 
   void RaiseEvent();
   int YToAddress(int y);
 
   u32 AddrToBranch(u32 addr);
   void OnResize(wxSizeEvent& event);
-
-  struct BlrStruct  // for IDM_INSERTBLR
-  {
-    u32 address;
-    u32 oldValue;
-  };
-  std::vector<BlrStruct> m_blrList;
 
   static constexpr int LEFT_COL_WIDTH = 16;
 

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -845,6 +845,7 @@ void CFrame::DoStop()
       PowerPC::memchecks.Clear();
       if (g_pCodeWindow->HasPanel<CBreakPointWindow>())
         g_pCodeWindow->GetPanel<CBreakPointWindow>()->NotifyUpdate();
+      PowerPC::code_patches.clear();
       g_symbolDB.Clear();
       Host_NotifyMapLoaded();
     }


### PR DESCRIPTION
The goal of this PR is to replace the old insertBLR interface into something that allows proper code patching. It will allow later on to support code (un)patching in a cleaner way and with something more sophisticated than just BLR and NOP.

For now, this PR only focuses on replacing the actual insertBLR/NOP function. The CodePatch's Remove() function is unused because there is no (working?) way to remove a BLR/NOP normally (did I miss something?).

Ready to be reviewed & merged.