### PR TITLE
JitCache: Store the JIT blocks in the std::map.

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -123,7 +123,7 @@ static bool CheckDSI(u32 data)
 
 void CachedInterpreter::Jit(u32 address)
 {
-  if (m_code.size() >= CODE_SIZE / sizeof(Instruction) - 0x1000 || m_block_cache.IsFull() ||
+  if (m_code.size() >= CODE_SIZE / sizeof(Instruction) - 0x1000 ||
       SConfig::GetInstance().bJITNoBlockCache)
   {
     ClearCache();

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -543,7 +543,7 @@ void Jit64::Jit(u32 em_address)
   }
 
   if (IsAlmostFull() || m_far_code.IsAlmostFull() || trampolines.IsAlmostFull() ||
-      blocks.IsFull() || SConfig::GetInstance().bJITNoBlockCache)
+      SConfig::GetInstance().bJITNoBlockCache)
   {
     ClearCache();
   }

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -99,8 +99,8 @@ void Jit64AsmRoutineManager::Generate()
     // Fast block number lookup.
     // ((PC >> 2) & mask) * sizeof(JitBlock*) = (PC & (mask << 2)) * 2
     MOV(32, R(RSCRATCH), PPCSTATE(pc));
-    u64 icache = reinterpret_cast<u64>(g_jit->GetBlockCache()->GetICache());
-    AND(32, R(RSCRATCH), Imm32(JitBaseBlockCache::iCache_Mask << 2));
+    u64 icache = reinterpret_cast<u64>(g_jit->GetBlockCache()->GetFastBlockMap());
+    AND(32, R(RSCRATCH), Imm32(JitBaseBlockCache::FAST_BLOCK_MAP_MASK << 2));
     if (icache <= INT_MAX)
     {
       MOV(64, R(RSCRATCH), MScaled(RSCRATCH, SCALE_2, static_cast<s32>(icache)));

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -126,7 +126,7 @@ void Jit64AsmRoutineManager::Generate()
 
   // Check both block.effectiveAddress and block.msrBits.
   MOV(32, R(RSCRATCH2), PPCSTATE(msr));
-  AND(32, R(RSCRATCH2), Imm32(JitBlock::JIT_CACHE_MSR_MASK));
+  AND(32, R(RSCRATCH2), Imm32(JitBaseBlockCache::JIT_CACHE_MSR_MASK));
   SHL(64, R(RSCRATCH2), Imm8(32));
   MOV(32, R(RSCRATCH_EXTRA), PPCSTATE(pc));
   OR(64, R(RSCRATCH2), R(RSCRATCH_EXTRA));

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -466,7 +466,7 @@ void JitIL::Trace()
 void JitIL::Jit(u32 em_address)
 {
   if (IsAlmostFull() || m_far_code.IsAlmostFull() || trampolines.IsAlmostFull() ||
-      blocks.IsFull() || SConfig::GetInstance().bJITNoBlockCache)
+      SConfig::GetInstance().bJITNoBlockCache)
   {
     ClearCache();
   }

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -368,8 +368,7 @@ void JitArm64::SingleStep()
 
 void JitArm64::Jit(u32)
 {
-  if (IsAlmostFull() || farcode.IsAlmostFull() || blocks.IsFull() ||
-      SConfig::GetInstance().bJITNoBlockCache)
+  if (IsAlmostFull() || farcode.IsAlmostFull() || SConfig::GetInstance().bJITNoBlockCache)
   {
     ClearCache();
   }

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -88,7 +88,7 @@ void JitArm64::GenerateAsm()
     FixupBranch pc_missmatch = B(CC_NEQ);
 
     LDR(INDEX_UNSIGNED, pc_and_msr2, PPC_REG, PPCSTATE_OFF(msr));
-    ANDI2R(pc_and_msr2, pc_and_msr2, JitBlock::JIT_CACHE_MSR_MASK);
+    ANDI2R(pc_and_msr2, pc_and_msr2, JitBaseBlockCache::JIT_CACHE_MSR_MASK);
     LDR(INDEX_UNSIGNED, pc_and_msr, block, offsetof(JitBlock, msrBits));
     CMP(pc_and_msr, pc_and_msr2);
     FixupBranch msr_missmatch = B(CC_NEQ);

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -74,9 +74,9 @@ void JitArm64::GenerateAsm()
     ARM64Reg pc_masked = W25;
     ARM64Reg cache_base = X27;
     ARM64Reg block = X30;
-    ORRI2R(pc_masked, WZR, JitBaseBlockCache::iCache_Mask << 3);
+    ORRI2R(pc_masked, WZR, JitBaseBlockCache::FAST_BLOCK_MAP_MASK << 3);
     AND(pc_masked, pc_masked, DISPATCHER_PC, ArithOption(DISPATCHER_PC, ST_LSL, 1));
-    MOVP2R(cache_base, g_jit->GetBlockCache()->GetICache());
+    MOVP2R(cache_base, g_jit->GetBlockCache()->GetFastBlockMap());
     LDR(block, cache_base, EncodeRegTo64(pc_masked));
     FixupBranch not_found = CBZ(block);
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -325,13 +325,16 @@ void JitBaseBlockCache::DestroyBlock(JitBlock& block, bool invalidate)
   UnlinkBlock(block);
 
   // Delete linking addresses
-  auto it = links_to.equal_range(block.effectiveAddress);
-  while (it.first != it.second)
+  for (const auto& e : block.linkData)
   {
-    if (it.first->second == &block)
-      it.first = links_to.erase(it.first);
-    else
-      it.first++;
+    auto it = links_to.equal_range(e.exitAddress);
+    while (it.first != it.second)
+    {
+      if (it.first->second == &block)
+        it.first = links_to.erase(it.first);
+      else
+        it.first++;
+    }
   }
 
   // Raise an signal if we are going to call this block again

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -116,7 +116,7 @@ JitBlock* JitBaseBlockCache::AllocateBlock(u32 em_address)
   b.invalid = false;
   b.effectiveAddress = em_address;
   b.physicalAddress = PowerPC::JitCache_TranslateAddress(em_address).address;
-  b.msrBits = MSR & JitBlock::JIT_CACHE_MSR_MASK;
+  b.msrBits = MSR & JIT_CACHE_MSR_MASK;
   b.linkData.clear();
   b.in_icache = 0;
   num_blocks++;  // commit the current block
@@ -180,7 +180,7 @@ JitBlock* JitBaseBlockCache::GetBlockFromStartAddress(u32 addr, u32 msr)
 
   JitBlock* b = map_result->second;
   if (b->invalid || b->effectiveAddress != addr ||
-      b->msrBits != (msr & JitBlock::JIT_CACHE_MSR_MASK))
+      b->msrBits != (msr & JIT_CACHE_MSR_MASK))
     return nullptr;
   return b;
 }
@@ -189,10 +189,9 @@ const u8* JitBaseBlockCache::Dispatch()
 {
   JitBlock* block = iCache[FastLookupEntryForAddress(PC)];
 
-  while (!block || block->effectiveAddress != PC ||
-         block->msrBits != (MSR & JitBlock::JIT_CACHE_MSR_MASK))
+  while (!block || block->effectiveAddress != PC || block->msrBits != (MSR & JIT_CACHE_MSR_MASK))
   {
-    MoveBlockIntoFastCache(PC, MSR & JitBlock::JIT_CACHE_MSR_MASK);
+    MoveBlockIntoFastCache(PC, MSR & JIT_CACHE_MSR_MASK);
     block = iCache[FastLookupEntryForAddress(PC)];
   }
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -72,7 +72,8 @@ void JitBaseBlockCache::Clear()
   m_jit.js.pairedQuantizeAddresses.clear();
   for (int i = 1; i < num_blocks; i++)
   {
-    DestroyBlock(blocks[i], false);
+    if (!block.invalid)
+      DestroyBlock(blocks[i]);
   }
   links_to.clear();
   block_map.clear();
@@ -213,7 +214,7 @@ void JitBaseBlockCache::InvalidateICache(u32 address, const u32 length, bool for
     auto it = block_map.lower_bound(std::make_pair(pAddr, 0));
     while (it != block_map.end() && it->first.second < pAddr + length)
     {
-      DestroyBlock(*it->second, true);
+      DestroyBlock(*it->second);
       it = block_map.erase(it);
     }
 
@@ -302,12 +303,11 @@ void JitBaseBlockCache::UnlinkBlock(const JitBlock& block)
   }
 }
 
-void JitBaseBlockCache::DestroyBlock(JitBlock& block, bool invalidate)
+void JitBaseBlockCache::DestroyBlock(JitBlock& block)
 {
   if (block.invalid)
   {
-    if (invalidate)
-      PanicAlert("Invalidating invalid block %p", &block);
+    PanicAlert("Invalidating invalid block %p", &block);
     return;
   }
   block.invalid = true;

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -159,7 +159,7 @@ private:
   void LinkBlockExits(JitBlock& block);
   void LinkBlock(JitBlock& block);
   void UnlinkBlock(const JitBlock& block);
-  void DestroyBlock(JitBlock& block, bool invalidate);
+  void DestroyBlock(JitBlock& block);
 
   void MoveBlockIntoFastCache(u32 em_address, u32 msr);
 

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -74,6 +74,10 @@ struct JitBlock
   u64 ticStart;    // for profiling - time.
   u64 ticStop;     // for profiling - time.
   u64 ticCounter;  // for profiling - time.
+
+  // This tracks the position if this block within the icache.
+  // We allow each block to have one icache entry.
+  size_t in_icache;
 };
 
 typedef void (*CompiledCode)();
@@ -163,7 +167,7 @@ private:
   void MoveBlockIntoFastCache(u32 em_address, u32 msr);
 
   // Fast but risky block lookup based on iCache.
-  JitBlock*& FastLookupEntryForAddress(u32 address);
+  size_t FastLookupEntryForAddress(u32 address);
 
   // We store the metadata of all blocks in a linear way within this array.
   // Note: blocks[0] must not be used as it is referenced as invalid block in iCache.

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -24,13 +24,6 @@ class JitBase;
 // address.
 struct JitBlock
 {
-  enum
-  {
-    // Mask for the MSR bits which determine whether a compiled block
-    // is valid (MSR.IR and MSR.DR, the address translation bits).
-    JIT_CACHE_MSR_MASK = 0x30,
-  };
-
   // A special entry point for block linking; usually used to check the
   // downcount.
   const u8* checkedEntry;
@@ -115,6 +108,10 @@ public:
 class JitBaseBlockCache
 {
 public:
+  // Mask for the MSR bits which determine whether a compiled block
+  // is valid (MSR.IR and MSR.DR, the address translation bits).
+  static constexpr u32 JIT_CACHE_MSR_MASK = 0x30;
+
   static constexpr int MAX_NUM_BLOCKS = 65536 * 2;
   static constexpr u32 iCache_Num_Elements = 0x10000;
   static constexpr u32 iCache_Mask = iCache_Num_Elements - 1;

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -177,12 +177,12 @@ private:
 
   // Map indexed by the physical memory location.
   // It is used to invalidate blocks based on memory location.
-  std::map<std::pair<u32, u32>, JitBlock*> block_map;  // (end_addr, start_addr) -> block
+  std::multimap<std::pair<u32, u32>, JitBlock*> block_map;  // (end_addr, start_addr) -> block
 
   // Map indexed by the physical address of the entry point.
   // This is used to query the block based on the current PC in a slow way.
-  // TODO: This is redundant with block_map, and both should be a multimap.
-  std::map<u32, JitBlock*> start_block_map;  // start_addr -> block
+  // TODO: This is redundant with block_map.
+  std::multimap<u32, JitBlock*> start_block_map;  // start_addr -> block
 
   // This bitsets shows which cachelines overlap with any blocks.
   // It is used to provide a fast way to query if no icache invalidation is needed.


### PR DESCRIPTION
No need to provide a fixed size std::array. No need to mark blocks as invalid.

This PR also fixes block re-linking if the second one got invalidated.

It also provides a simple flag within the Jit64 dispatcher to skip the assembly one.

And it support the very rare case of caching two blocks for the same PC but different MSR. Mostly because it is simpler, not because it is required for performance.