### PR TITLE
Interpreter_Tables: Minor changes

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
@@ -4,7 +4,6 @@
 
 #include <array>
 
-#include "Common/MsgHandler.h"
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/Interpreter/Interpreter_Tables.h"
@@ -358,6 +357,15 @@ static std::array<GekkoOPTemplate, 10> table63_2 =
 
 namespace InterpreterTables
 {
+constexpr size_t TotalInstructionFunctionCount()
+{
+  return primarytable.size() + table4_2.size() + table4_3.size() + table4.size() + table31.size() +
+         table19.size() + table59.size() + table63.size() + table63_2.size();
+}
+
+static_assert(TotalInstructionFunctionCount() < m_allInstructions.size(),
+              "m_allInstructions is too small");
+
 void InitTables()
 {
   // once initialized, tables are read-only
@@ -483,11 +491,6 @@ void InitTables()
     m_allInstructions[m_numInstructions++] = &tpl.opinfo;
   for (auto& tpl : table63_2)
     m_allInstructions[m_numInstructions++] = &tpl.opinfo;
-
-  if (m_numInstructions >= 512)
-  {
-    PanicAlert("m_allInstructions underdimensioned");
-  }
 
   initialized = true;
 }

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
@@ -2,9 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Core/PowerPC/Interpreter/Interpreter.h"
+#include <array>
+
 #include "Common/MsgHandler.h"
 #include "Core/PowerPC/Gekko.h"
+#include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/Interpreter/Interpreter_Tables.h"
 #include "Core/PowerPC/PPCTables.h"
 
@@ -18,8 +20,8 @@ struct GekkoOPTemplate
 // clang-format off
 static GekkoOPInfo unknownopinfo = { "unknown_instruction", OPTYPE_UNKNOWN, FL_ENDBLOCK, 0, 0, 0, 0 };
 
-static GekkoOPTemplate primarytable[] =
-{
+static std::array<GekkoOPTemplate, 54> primarytable =
+{{
 	{4,  Interpreter::RunTable4,    {"RunTable4",  OPTYPE_SUBTABLE, 0, 0, 0, 0, 0}},
 	{19, Interpreter::RunTable19,   {"RunTable19", OPTYPE_SUBTABLE, 0, 0, 0, 0, 0}},
 	{31, Interpreter::RunTable31,   {"RunTable31", OPTYPE_SUBTABLE, 0, 0, 0, 0, 0}},
@@ -88,10 +90,10 @@ static GekkoOPTemplate primarytable[] =
 	{61, Interpreter::psq_stu,      {"psq_stu", OPTYPE_STOREPS, FL_IN_FLOAT_S | FL_OUT_A | FL_IN_A | FL_USE_FPU | FL_LOADSTORE, 1, 0, 0, 0}},
 
 	//missing: 0, 1, 2, 5, 6, 9, 22, 30, 62, 58
-};
+}};
 
-static GekkoOPTemplate table4[] =
-{    //SUBOP10
+static std::array<GekkoOPTemplate, 13> table4 =
+{{    //SUBOP10
 	{0,    Interpreter::ps_cmpu0,   {"ps_cmpu0",   OPTYPE_PS, FL_IN_FLOAT_AB | FL_SET_CRn | FL_USE_FPU | FL_READ_FPRF | FL_SET_FPRF, 1, 0, 0, 0}},
 	{32,   Interpreter::ps_cmpo0,   {"ps_cmpo0",   OPTYPE_PS, FL_IN_FLOAT_AB | FL_SET_CRn | FL_USE_FPU | FL_READ_FPRF | FL_SET_FPRF, 1, 0, 0, 0}},
 	{40,   Interpreter::ps_neg,     {"ps_neg",     OPTYPE_PS, FL_OUT_FLOAT_D | FL_IN_FLOAT_B | FL_RC_BIT_F | FL_USE_FPU, 1, 0, 0, 0}},
@@ -106,10 +108,10 @@ static GekkoOPTemplate table4[] =
 	{624,  Interpreter::ps_merge11, {"ps_merge11", OPTYPE_PS, FL_OUT_FLOAT_D | FL_IN_FLOAT_AB | FL_RC_BIT_F | FL_USE_FPU, 1, 0, 0, 0}},
 
 	{1014, Interpreter::dcbz_l,     {"dcbz_l",     OPTYPE_SYSTEM, FL_IN_A0B | FL_LOADSTORE, 1, 0, 0, 0}},
-};
+}};
 
-static GekkoOPTemplate table4_2[] =
-{
+static std::array<GekkoOPTemplate, 17> table4_2 =
+{{
 	{10, Interpreter::ps_sum0,      {"ps_sum0",   OPTYPE_PS, FL_OUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{11, Interpreter::ps_sum1,      {"ps_sum1",   OPTYPE_PS, FL_OUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{12, Interpreter::ps_muls0,     {"ps_muls0",  OPTYPE_PS, FL_OUT_FLOAT_D | FL_IN_FLOAT_AC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
@@ -127,19 +129,19 @@ static GekkoOPTemplate table4_2[] =
 	{29, Interpreter::ps_madd,      {"ps_madd",   OPTYPE_PS, FL_OUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{30, Interpreter::ps_nmsub,     {"ps_nmsub",  OPTYPE_PS, FL_OUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{31, Interpreter::ps_nmadd,     {"ps_nmadd",  OPTYPE_PS, FL_OUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
-};
+}};
 
 
-static GekkoOPTemplate table4_3[] =
-{
+static std::array<GekkoOPTemplate, 4> table4_3 =
+{{
 	{6,  Interpreter::psq_lx,       {"psq_lx",   OPTYPE_LOADPS, FL_OUT_FLOAT_D | FL_IN_A0B | FL_USE_FPU | FL_LOADSTORE, 1, 0, 0, 0}},
 	{7,  Interpreter::psq_stx,      {"psq_stx",  OPTYPE_STOREPS, FL_IN_FLOAT_S | FL_IN_A0B | FL_USE_FPU | FL_LOADSTORE, 1, 0, 0, 0}},
 	{38, Interpreter::psq_lux,      {"psq_lux",  OPTYPE_LOADPS, FL_OUT_FLOAT_D | FL_OUT_A | FL_IN_AB | FL_USE_FPU | FL_LOADSTORE, 1, 0, 0, 0}},
 	{39, Interpreter::psq_stux,     {"psq_stux", OPTYPE_STOREPS, FL_IN_FLOAT_S | FL_OUT_A | FL_IN_AB | FL_USE_FPU | FL_LOADSTORE, 1, 0, 0, 0}},
-};
+}};
 
-static GekkoOPTemplate table19[] =
-{
+static std::array<GekkoOPTemplate, 13> table19 =
+{{
 	{528, Interpreter::bcctrx,      {"bcctrx", OPTYPE_BRANCH, FL_ENDBLOCK, 1, 0, 0, 0}},
 	{16,  Interpreter::bclrx,       {"bclrx",  OPTYPE_BRANCH, FL_ENDBLOCK, 1, 0, 0, 0}},
 	{257, Interpreter::crand,       {"crand",  OPTYPE_CR, FL_EVIL, 1, 0, 0, 0}},
@@ -155,11 +157,10 @@ static GekkoOPTemplate table19[] =
 	{0,   Interpreter::mcrf,        {"mcrf",   OPTYPE_SYSTEM, FL_EVIL | FL_SET_CRn, 1, 0, 0, 0}},
 
 	{50,  Interpreter::rfi,         {"rfi",    OPTYPE_SYSTEM, FL_ENDBLOCK | FL_CHECKEXCEPTIONS, 2, 0, 0, 0}},
-};
+}};
 
-
-static GekkoOPTemplate table31[] =
-{
+static std::array<GekkoOPTemplate, 107> table31 =
+{{
 	{266,  Interpreter::addx,       {"addx",    OPTYPE_INTEGER, FL_OUT_D | FL_IN_AB | FL_RC_BIT, 1, 0, 0, 0}},
 	{778,  Interpreter::addx,       {"addox",   OPTYPE_INTEGER, FL_OUT_D | FL_IN_AB | FL_RC_BIT | FL_SET_OE, 1, 0, 0, 0}},
 	{10,   Interpreter::addcx,      {"addcx",   OPTYPE_INTEGER, FL_OUT_D | FL_IN_AB | FL_SET_CA | FL_RC_BIT, 1, 0, 0, 0}},
@@ -299,10 +300,10 @@ static GekkoOPTemplate table31[] =
 	{854, Interpreter::eieio,       {"eieio",   OPTYPE_SYSTEM, 0, 1, 0, 0, 0}},
 	{306, Interpreter::tlbie,       {"tlbie",   OPTYPE_SYSTEM, FL_IN_B, 1, 0, 0, 0}},
 	{566, Interpreter::tlbsync,     {"tlbsync", OPTYPE_SYSTEM, 0, 1, 0, 0, 0}},
-};
+}};
 
-static GekkoOPTemplate table59[] =
-{
+static std::array<GekkoOPTemplate, 9> table59 =
+{{
 	{18, Interpreter::fdivsx,       {"fdivsx",   OPTYPE_SINGLEFP, FL_OUT_FLOAT_D | FL_IN_FLOAT_AB | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 17, 0, 0, 0}}, // TODO
 	{20, Interpreter::fsubsx,       {"fsubsx",   OPTYPE_SINGLEFP, FL_OUT_FLOAT_D | FL_IN_FLOAT_AB | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{21, Interpreter::faddsx,       {"faddsx",   OPTYPE_SINGLEFP, FL_OUT_FLOAT_D | FL_IN_FLOAT_AB | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
@@ -312,10 +313,10 @@ static GekkoOPTemplate table59[] =
 	{29, Interpreter::fmaddsx,      {"fmaddsx",  OPTYPE_SINGLEFP, FL_OUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{30, Interpreter::fnmsubsx,     {"fnmsubsx", OPTYPE_SINGLEFP, FL_OUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{31, Interpreter::fnmaddsx,     {"fnmaddsx", OPTYPE_SINGLEFP, FL_OUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
-};
+}};
 
-static GekkoOPTemplate table63[] =
-{
+static std::array<GekkoOPTemplate, 15> table63 =
+{{
 	{264, Interpreter::fabsx,       {"fabsx",   OPTYPE_DOUBLEFP, FL_INOUT_FLOAT_D | FL_IN_FLOAT_B | FL_RC_BIT_F | FL_USE_FPU, 1, 0, 0, 0}},
 
 	// FIXME: fcmp modifies the FPRF flags, but if the flags are clobbered later,
@@ -338,10 +339,10 @@ static GekkoOPTemplate table63[] =
 	{38,  Interpreter::mtfsb1x,     {"mtfsb1x", OPTYPE_SYSTEMFP, FL_RC_BIT_F | FL_USE_FPU | FL_READ_FPRF | FL_SET_FPRF, 3, 0, 0, 0}},
 	{134, Interpreter::mtfsfix,     {"mtfsfix", OPTYPE_SYSTEMFP, FL_RC_BIT_F | FL_USE_FPU | FL_READ_FPRF | FL_SET_FPRF, 3, 0, 0, 0}},
 	{711, Interpreter::mtfsfx,      {"mtfsfx",  OPTYPE_SYSTEMFP, FL_RC_BIT_F | FL_IN_FLOAT_B | FL_USE_FPU | FL_READ_FPRF | FL_SET_FPRF, 3, 0, 0, 0}},
-};
+}};
 
-static GekkoOPTemplate table63_2[] =
-{
+static std::array<GekkoOPTemplate, 10> table63_2 =
+{{
 	{18, Interpreter::fdivx,        {"fdivx",    OPTYPE_DOUBLEFP, FL_INOUT_FLOAT_D | FL_IN_FLOAT_AB | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 31, 0, 0, 0}},
 	{20, Interpreter::fsubx,        {"fsubx",    OPTYPE_DOUBLEFP, FL_INOUT_FLOAT_D | FL_IN_FLOAT_AB | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{21, Interpreter::faddx,        {"faddx",    OPTYPE_DOUBLEFP, FL_INOUT_FLOAT_D | FL_IN_FLOAT_AB | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
@@ -352,7 +353,7 @@ static GekkoOPTemplate table63_2[] =
 	{29, Interpreter::fmaddx,       {"fmaddx",   OPTYPE_DOUBLEFP, FL_INOUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{30, Interpreter::fnmsubx,      {"fnmsubx",  OPTYPE_DOUBLEFP, FL_INOUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
 	{31, Interpreter::fnmaddx,      {"fnmaddx",  OPTYPE_DOUBLEFP, FL_INOUT_FLOAT_D | FL_IN_FLOAT_ABC | FL_RC_BIT_F | FL_USE_FPU | FL_SET_FPRF, 1, 0, 0, 0}},
-};
+}};
 // clang-format on
 
 namespace InterpreterTables

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_Tables.cpp
@@ -494,5 +494,4 @@ void InitTables()
 
   initialized = true;
 }
-}
-// remove
+}  // namespace InterpreterTables

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -484,7 +484,7 @@ void Jit64::mtcrf(UGeckoInstruction inst)
     }
     else
     {
-      MOV(64, R(RSCRATCH2), ImmPtr(m_crTable));
+      MOV(64, R(RSCRATCH2), ImmPtr(m_crTable.data()));
       gpr.Lock(inst.RS);
       gpr.BindToRegister(inst.RS, true, false);
       for (int i = 0; i < 8; i++)
@@ -531,7 +531,7 @@ void Jit64::mcrxr(UGeckoInstruction inst)
   // [SO OV CA 0] << 3
   SHL(32, R(RSCRATCH), Imm8(4));
 
-  MOV(64, R(RSCRATCH2), ImmPtr(m_crTable));
+  MOV(64, R(RSCRATCH2), ImmPtr(m_crTable.data()));
   MOV(64, R(RSCRATCH), MRegSum(RSCRATCH, RSCRATCH2));
   MOV(64, PPCSTATE(cr_val[inst.CRFD]), R(RSCRATCH));
 
@@ -623,7 +623,7 @@ void Jit64::mcrfs(UGeckoInstruction inst)
   }
   AND(32, R(RSCRATCH), Imm32(mask));
   MOV(32, PPCSTATE(fpscr), R(RSCRATCH));
-  LEA(64, RSCRATCH, M(&m_crTable));
+  LEA(64, RSCRATCH, M(m_crTable.data()));
   MOV(64, R(RSCRATCH), MComplex(RSCRATCH, RSCRATCH2, SCALE_8, 0));
   MOV(64, PPCSTATE(cr_val[inst.CRFD]), R(RSCRATCH));
 }

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
@@ -102,7 +102,7 @@ void JitArm64::mcrxr(UGeckoInstruction inst)
   // [SO OV CA 0] << 3
   LSL(WA, WA, 4);
 
-  MOVP2R(XB, m_crTable);
+  MOVP2R(XB, m_crTable.data());
   LDR(XB, XB, XA);
   STR(INDEX_UNSIGNED, XB, PPC_REG, PPCSTATE_OFF(cr_val[inst.CRFD]));
 
@@ -636,7 +636,7 @@ void JitArm64::mtcrf(UGeckoInstruction inst)
     ARM64Reg XA = EncodeRegTo64(WA);
     ARM64Reg WB = gpr.GetReg();
     ARM64Reg XB = EncodeRegTo64(WB);
-    MOVP2R(XB, m_crTable);
+    MOVP2R(XB, m_crTable.data());
     for (int i = 0; i < 8; ++i)
     {
       if ((crm & (0x80 >> i)) != 0)

--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -2,8 +2,12 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/PPCTables.h"
+
 #include <algorithm>
+#include <array>
 #include <cinttypes>
+#include <cstddef>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -13,25 +17,24 @@
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 #include "Core/PowerPC/Interpreter/Interpreter_Tables.h"
 #include "Core/PowerPC/JitInterface.h"
-#include "Core/PowerPC/PPCTables.h"
 #include "Core/PowerPC/PowerPC.h"
 
-GekkoOPInfo* m_infoTable[64];
-GekkoOPInfo* m_infoTable4[1024];
-GekkoOPInfo* m_infoTable19[1024];
-GekkoOPInfo* m_infoTable31[1024];
-GekkoOPInfo* m_infoTable59[32];
-GekkoOPInfo* m_infoTable63[1024];
+std::array<GekkoOPInfo*, 64> m_infoTable;
+std::array<GekkoOPInfo*, 1024> m_infoTable4;
+std::array<GekkoOPInfo*, 1024> m_infoTable19;
+std::array<GekkoOPInfo*, 1024> m_infoTable31;
+std::array<GekkoOPInfo*, 32> m_infoTable59;
+std::array<GekkoOPInfo*, 1024> m_infoTable63;
 
-GekkoOPInfo* m_allInstructions[512];
-int m_numInstructions;
+std::array<GekkoOPInfo*, 512> m_allInstructions;
+size_t m_numInstructions;
 
-const u64 m_crTable[16] = {
+const std::array<u64, 16> m_crTable = {{
     PPCCRToInternal(0x0), PPCCRToInternal(0x1), PPCCRToInternal(0x2), PPCCRToInternal(0x3),
     PPCCRToInternal(0x4), PPCCRToInternal(0x5), PPCCRToInternal(0x6), PPCCRToInternal(0x7),
     PPCCRToInternal(0x8), PPCCRToInternal(0x9), PPCCRToInternal(0xA), PPCCRToInternal(0xB),
     PPCCRToInternal(0xC), PPCCRToInternal(0xD), PPCCRToInternal(0xE), PPCCRToInternal(0xF),
-};
+}};
 
 GekkoOPInfo* GetOpInfo(UGeckoInstruction _inst)
 {
@@ -152,7 +155,7 @@ void PrintInstructionRunCounts()
   typedef std::pair<const char*, u64> OpInfo;
   std::vector<OpInfo> temp;
   temp.reserve(m_numInstructions);
-  for (int i = 0; i < m_numInstructions; ++i)
+  for (size_t i = 0; i < m_numInstructions; ++i)
   {
     GekkoOPInfo* pInst = m_allInstructions[i];
     temp.emplace_back(pInst->opname, pInst->runCount);
@@ -175,7 +178,7 @@ void LogCompiledInstructions()
 
   File::IOFile f(StringFromFormat("%sinst_log%i.txt", File::GetUserPath(D_LOGS_IDX).c_str(), time),
                  "w");
-  for (int i = 0; i < m_numInstructions; i++)
+  for (size_t i = 0; i < m_numInstructions; i++)
   {
     GekkoOPInfo* pInst = m_allInstructions[i];
     if (pInst->compileCount > 0)
@@ -186,7 +189,7 @@ void LogCompiledInstructions()
   }
 
   f.Open(StringFromFormat("%sinst_not%i.txt", File::GetUserPath(D_LOGS_IDX).c_str(), time), "w");
-  for (int i = 0; i < m_numInstructions; i++)
+  for (size_t i = 0; i < m_numInstructions; i++)
   {
     GekkoOPInfo* pInst = m_allInstructions[i];
     if (pInst->compileCount == 0)

--- a/Source/Core/Core/PowerPC/PPCTables.h
+++ b/Source/Core/Core/PowerPC/PPCTables.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
+
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/Interpreter/Interpreter.h"
 
@@ -92,16 +95,15 @@ struct GekkoOPInfo
   int compileCount;
   u32 lastUse;
 };
-extern GekkoOPInfo* m_infoTable[64];
-extern GekkoOPInfo* m_infoTable4[1024];
-extern GekkoOPInfo* m_infoTable19[1024];
-extern GekkoOPInfo* m_infoTable31[1024];
-extern GekkoOPInfo* m_infoTable59[32];
-extern GekkoOPInfo* m_infoTable63[1024];
+extern std::array<GekkoOPInfo*, 64> m_infoTable;
+extern std::array<GekkoOPInfo*, 1024> m_infoTable4;
+extern std::array<GekkoOPInfo*, 1024> m_infoTable19;
+extern std::array<GekkoOPInfo*, 1024> m_infoTable31;
+extern std::array<GekkoOPInfo*, 32> m_infoTable59;
+extern std::array<GekkoOPInfo*, 1024> m_infoTable63;
 
-extern GekkoOPInfo* m_allInstructions[512];
-
-extern int m_numInstructions;
+extern std::array<GekkoOPInfo*, 512> m_allInstructions;
+extern size_t m_numInstructions;
 
 GekkoOPInfo* GetOpInfo(UGeckoInstruction _inst);
 Interpreter::Instruction GetInterpreterOp(UGeckoInstruction _inst);

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -325,7 +325,7 @@ inline u64 PPCCRToInternal(u8 value)
 }
 
 // convert flags into 64-bit CR values with a lookup table
-extern const u64 m_crTable[16];
+extern const std::array<u64, 16> m_crTable;
 
 // Warning: these CR operations are fairly slow since they need to convert from
 // PowerPC format (4 bit) to our internal 64 bit format. See the definition of


### PR DESCRIPTION
Moves things over to std::array, which makes it straight-forward enough to make a runtime check capable of being done at compile-time.

If the check in its entirety seems unnecessary, I can just drop that commit.