### PR TITLE
PowerPC: Minor initialization cleanup

### DIFF
--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -88,6 +88,7 @@ void DoState(PointerWrap& p)
 static void ResetRegisters()
 {
   memset(ppcState.ps, 0, sizeof(ppcState.ps));
+  memset(ppcState.sr, 0, sizeof(ppcState.sr));
   memset(ppcState.gpr, 0, sizeof(ppcState.gpr));
   memset(ppcState.spr, 0, sizeof(ppcState.spr));
   /*
@@ -135,7 +136,6 @@ void Init(int cpu_core)
   s_invalidate_cache_thread_safe =
       CoreTiming::RegisterEvent("invalidateEmulatedCache", InvalidateCacheThreadSafe);
 
-  memset(ppcState.sr, 0, sizeof(ppcState.sr));
   ppcState.pagetable_base = 0;
   ppcState.pagetable_hashmask = 0;
 

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -172,20 +172,7 @@ void Init(int cpu_core)
 
   ppcState.pagetable_base = 0;
   ppcState.pagetable_hashmask = 0;
-
-  for (int tlb = 0; tlb < 2; tlb++)
-  {
-    for (int set = 0; set < 64; set++)
-    {
-      ppcState.tlb[tlb][set].recent = 0;
-      for (int way = 0; way < 2; way++)
-      {
-        ppcState.tlb[tlb][set].paddr[way] = 0;
-        ppcState.tlb[tlb][set].pte[way] = 0;
-        ppcState.tlb[tlb][set].tag[way] = TLB_TAG_INVALID;
-      }
-    }
-  }
+  ppcState.tlb = {};
 
   ResetRegisters();
 

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -49,10 +49,10 @@ enum CoreMode
 
 struct tlb_entry
 {
-  u32 tag[TLB_WAYS];
-  u32 paddr[TLB_WAYS];
-  u32 pte[TLB_WAYS];
-  u8 recent;
+  u32 tag[TLB_WAYS] = {TLB_TAG_INVALID, TLB_TAG_INVALID};
+  u32 paddr[TLB_WAYS] = {};
+  u32 pte[TLB_WAYS] = {};
+  u8 recent = 0;
 };
 
 // This contains the entire state of the emulated PowerPC "Gekko" CPU.
@@ -116,7 +116,7 @@ struct PowerPCState
   // also for power management, but we don't care about that.
   u32 spr[1024];
 
-  tlb_entry tlb[NUM_TLBS][TLB_SIZE / TLB_WAYS];
+  std::array<std::array<tlb_entry, TLB_SIZE / TLB_WAYS>, NUM_TLBS> tlb;
 
   u32 pagetable_base;
   u32 pagetable_hashmask;


### PR DESCRIPTION
Very basic stuff. Moves some things into their own functions and moves a memset to where it should have been.