### PR TITLE
PowerPC: Explicitly savestate PowerPCState members

### DIFF
--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -2,12 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/PowerPC/PPCCache.h"
+
 #include <cstring>
 
+#include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/JitInterface.h"
-#include "Core/PowerPC/PPCCache.h"
 #include "Core/PowerPC/PowerPC.h"
 
 namespace PowerPC
@@ -148,4 +150,17 @@ u32 InstructionCache::ReadInstruction(u32 addr)
   u32 res = Common::swap32(data[set][t][(addr >> 2) & 7]);
   return res;
 }
+
+void InstructionCache::DoState(PointerWrap& p)
+{
+  p.DoArray(data);
+  p.DoArray(tags);
+  p.DoArray(plru);
+  p.DoArray(valid);
+  p.DoArray(way_from_valid);
+  p.DoArray(way_from_plru);
+  p.DoArray(lookup_table);
+  p.DoArray(lookup_table_ex);
+  p.DoArray(lookup_table_vmem);
 }
+}  // namespace PowerPC

--- a/Source/Core/Core/PowerPC/PPCCache.h
+++ b/Source/Core/Core/PowerPC/PPCCache.h
@@ -6,6 +6,8 @@
 
 #include "Common/CommonTypes.h"
 
+class PointerWrap;
+
 namespace PowerPC
 {
 const u32 ICACHE_SETS = 128;
@@ -35,5 +37,6 @@ struct InstructionCache
   void Invalidate(u32 addr);
   void Init();
   void Reset();
+  void DoState(PointerWrap& p);
 };
-}
+}  // namespace PowerPC

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -72,7 +72,26 @@ void DoState(PointerWrap& p)
   // *((u64 *)&TL) = SystemTimers::GetFakeTimeBase(); //works since we are little endian and TL
   // comes first :)
 
-  p.DoPOD(ppcState);
+  p.DoArray(ppcState.gpr);
+  p.Do(ppcState.pc);
+  p.Do(ppcState.npc);
+  p.DoArray(ppcState.cr_val);
+  p.Do(ppcState.msr);
+  p.Do(ppcState.fpscr);
+  p.Do(ppcState.Exceptions);
+  p.Do(ppcState.downcount);
+  p.Do(ppcState.xer_ca);
+  p.Do(ppcState.xer_so_ov);
+  p.Do(ppcState.xer_stringctrl);
+  p.DoArray(ppcState.ps);
+  p.DoArray(ppcState.sr);
+  p.DoArray(ppcState.spr);
+  p.DoArray(ppcState.tlb);
+  p.Do(ppcState.pagetable_base);
+  p.Do(ppcState.pagetable_hashmask);
+
+  ppcState.iCache.DoState(p);
+
   if (p.GetMode() == PointerWrap::MODE_READ)
   {
     IBATUpdated();

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 70;  // Last changed in PR 4679
+static const u32 STATE_VERSION = 71;  // Last changed in PR 4687
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
Makes it more obvious which data is going into the savestate. It also allows PowerPCState and InstructionCache to potentially contain members that don't necessarily need to be saved to the save state.

It also gets rid of any potential padding data being put into the save state.