### PR TITLE
IOS: Remove IOS prefix on a few structs/enums

### DIFF
--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -33,7 +33,7 @@ void DI::DoState(PointerWrap& p)
   p.Do(m_commands_to_execute);
 }
 
-IPCCommandResult DI::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult DI::IOCtl(const IOCtlRequest& request)
 {
   // DI IOCtls are handled in a special way by Dolphin
   // compared to other IOS functions.
@@ -52,7 +52,7 @@ IPCCommandResult DI::IOCtl(const IOSIOCtlRequest& request)
   return GetNoReply();
 }
 
-void DI::StartIOCtl(const IOSIOCtlRequest& request)
+void DI::StartIOCtl(const IOCtlRequest& request)
 {
   const u32 command_0 = Memory::Read_U32(request.buffer_in);
   const u32 command_1 = Memory::Read_U32(request.buffer_in + 4);
@@ -75,18 +75,18 @@ void DI::FinishIOCtl(DVDInterface::DIInterruptType interrupt_type)
   // This command has been executed, so it's removed from the queue
   u32 command_address = m_commands_to_execute.front();
   m_commands_to_execute.pop_front();
-  EnqueueReply(IOSIOCtlRequest{command_address}, interrupt_type);
+  EnqueueReply(IOCtlRequest{command_address}, interrupt_type);
 
   // DVDInterface is now ready to execute another command,
   // so we start executing a command from the queue if there is one
   if (!m_commands_to_execute.empty())
   {
-    IOSIOCtlRequest next_request{m_commands_to_execute.front()};
+    IOCtlRequest next_request{m_commands_to_execute.front()};
     StartIOCtl(next_request);
   }
 }
 
-IPCCommandResult DI::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult DI::IOCtlV(const IOCtlVRequest& request)
 {
   for (const auto& vector : request.io_vectors)
     Memory::Memset(vector.address, 0, vector.size);

--- a/Source/Core/Core/IOS/DI/DI.h
+++ b/Source/Core/Core/IOS/DI/DI.h
@@ -31,13 +31,13 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   void FinishIOCtl(DVDInterface::DIInterruptType interrupt_type);
 
 private:
-  void StartIOCtl(const IOSIOCtlRequest& request);
+  void StartIOCtl(const IOCtlRequest& request);
 
   std::deque<u32> m_commands_to_execute;
 };

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -17,7 +17,7 @@ namespace IOS
 {
 namespace HLE
 {
-enum IOSReturnCode : s32
+enum ReturnCode : s32
 {
   IPC_SUCCESS = 0,           // Success
   IPC_EACCES = -1,           // Permission denied
@@ -44,37 +44,37 @@ enum IOSReturnCode : s32
   IPC_EESEXHAUSTED = -1016,  // Max of 2 ES handles exceeded
 };
 
-struct IOSRequest
+struct Request
 {
   u32 address = 0;
   IPCCommandType command = IPC_CMD_OPEN;
   u32 fd = 0;
-  explicit IOSRequest(u32 address);
-  virtual ~IOSRequest() = default;
+  explicit Request(u32 address);
+  virtual ~Request() = default;
 };
 
-enum IOSOpenMode : s32
+enum OpenMode : s32
 {
   IOS_OPEN_READ = 1,
   IOS_OPEN_WRITE = 2,
   IOS_OPEN_RW = (IOS_OPEN_READ | IOS_OPEN_WRITE)
 };
 
-struct IOSOpenRequest final : IOSRequest
+struct OpenRequest final : Request
 {
   std::string path;
-  IOSOpenMode flags = IOS_OPEN_READ;
-  explicit IOSOpenRequest(u32 address);
+  OpenMode flags = IOS_OPEN_READ;
+  explicit OpenRequest(u32 address);
 };
 
-struct IOSReadWriteRequest final : IOSRequest
+struct ReadWriteRequest final : Request
 {
   u32 buffer = 0;
   u32 size = 0;
-  explicit IOSReadWriteRequest(u32 address);
+  explicit ReadWriteRequest(u32 address);
 };
 
-struct IOSSeekRequest final : IOSRequest
+struct SeekRequest final : Request
 {
   enum SeekMode
   {
@@ -84,10 +84,10 @@ struct IOSSeekRequest final : IOSRequest
   };
   u32 offset = 0;
   SeekMode mode = IOS_SEEK_SET;
-  explicit IOSSeekRequest(u32 address);
+  explicit SeekRequest(u32 address);
 };
 
-struct IOSIOCtlRequest final : IOSRequest
+struct IOCtlRequest final : Request
 {
   u32 request = 0;
   u32 buffer_in = 0;
@@ -95,7 +95,7 @@ struct IOSIOCtlRequest final : IOSRequest
   // Contrary to the name, the output buffer can also be used for input.
   u32 buffer_out = 0;
   u32 buffer_out_size = 0;
-  explicit IOSIOCtlRequest(u32 address);
+  explicit IOCtlRequest(u32 address);
   void Log(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::IOS,
            LogTypes::LOG_LEVELS level = LogTypes::LINFO) const;
   void Dump(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::IOS,
@@ -104,7 +104,7 @@ struct IOSIOCtlRequest final : IOSRequest
                    LogTypes::LOG_LEVELS level = LogTypes::LERROR) const;
 };
 
-struct IOSIOCtlVRequest final : IOSRequest
+struct IOCtlVRequest final : Request
 {
   struct IOVector
   {
@@ -120,7 +120,7 @@ struct IOSIOCtlVRequest final : IOSRequest
   // merging them into a single std::vector would make using the first out vector more complicated.
   std::vector<IOVector> in_vectors;
   std::vector<IOVector> io_vectors;
-  explicit IOSIOCtlVRequest(u32 address);
+  explicit IOCtlVRequest(u32 address);
   bool HasInputVectorWithAddress(u32 vector_address) const;
   void Dump(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::IOS,
             LogTypes::LOG_LEVELS level = LogTypes::LINFO) const;
@@ -151,13 +151,13 @@ public:
   u32 GetDeviceID() const { return m_device_id; }
   // Replies to Open and Close requests are sent by the IPC request handler (HandleCommand),
   // not by the devices themselves.
-  virtual IOSReturnCode Open(const IOSOpenRequest& request);
+  virtual ReturnCode Open(const OpenRequest& request);
   virtual void Close();
-  virtual IPCCommandResult Seek(const IOSSeekRequest& seek) { return Unsupported(seek); }
-  virtual IPCCommandResult Read(const IOSReadWriteRequest& read) { return Unsupported(read); }
-  virtual IPCCommandResult Write(const IOSReadWriteRequest& write) { return Unsupported(write); }
-  virtual IPCCommandResult IOCtl(const IOSIOCtlRequest& ioctl) { return Unsupported(ioctl); }
-  virtual IPCCommandResult IOCtlV(const IOSIOCtlVRequest& ioctlv) { return Unsupported(ioctlv); }
+  virtual IPCCommandResult Seek(const SeekRequest& seek) { return Unsupported(seek); }
+  virtual IPCCommandResult Read(const ReadWriteRequest& read) { return Unsupported(read); }
+  virtual IPCCommandResult Write(const ReadWriteRequest& write) { return Unsupported(write); }
+  virtual IPCCommandResult IOCtl(const IOCtlRequest& ioctl) { return Unsupported(ioctl); }
+  virtual IPCCommandResult IOCtlV(const IOCtlVRequest& ioctlv) { return Unsupported(ioctlv); }
   virtual void Update() {}
   virtual DeviceType GetDeviceType() const { return m_device_type; }
   virtual bool IsOpened() const { return m_is_active; }
@@ -172,7 +172,7 @@ protected:
   bool m_is_active = false;
 
 private:
-  IPCCommandResult Unsupported(const IOSRequest& request);
+  IPCCommandResult Unsupported(const Request& request);
 };
 }  // namespace Device
 }  // namespace HLE

--- a/Source/Core/Core/IOS/DeviceStub.cpp
+++ b/Source/Core/Core/IOS/DeviceStub.cpp
@@ -15,7 +15,7 @@ Stub::Stub(u32 device_id, const std::string& device_name) : Device(device_id, de
 {
 }
 
-IOSReturnCode Stub::Open(const IOSOpenRequest& request)
+ReturnCode Stub::Open(const OpenRequest& request)
 {
   WARN_LOG(IOS, "%s faking Open()", m_name.c_str());
   m_is_active = true;
@@ -28,13 +28,13 @@ void Stub::Close()
   m_is_active = false;
 }
 
-IPCCommandResult Stub::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult Stub::IOCtl(const IOCtlRequest& request)
 {
   WARN_LOG(IOS, "%s faking IOCtl()", m_name.c_str());
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult Stub::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult Stub::IOCtlV(const IOCtlVRequest& request)
 {
   WARN_LOG(IOS, "%s faking IOCtlV()", m_name.c_str());
   return GetDefaultReply(IPC_SUCCESS);

--- a/Source/Core/Core/IOS/DeviceStub.h
+++ b/Source/Core/Core/IOS/DeviceStub.h
@@ -21,10 +21,10 @@ class Stub final : public Device
 public:
   Stub(u32 device_id, const std::string& device_name);
 
-  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  ReturnCode Open(const OpenRequest& request) override;
   void Close() override;
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 };
 }  // namespace Device
 }  // namespace HLE

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -195,7 +195,7 @@ void ES::DoState(PointerWrap& p)
   }
 }
 
-IOSReturnCode ES::Open(const IOSOpenRequest& request)
+ReturnCode ES::Open(const OpenRequest& request)
 {
   OpenInternal();
 
@@ -246,7 +246,7 @@ u32 ES::OpenTitleContent(u32 CFD, u64 TitleID, u16 Index)
   return CFD;
 }
 
-IPCCommandResult ES::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult ES::IOCtlV(const IOCtlVRequest& request)
 {
   DEBUG_LOG(IOS_ES, "%s (0x%x)", GetDeviceName().c_str(), request.request);
   // Clear the IO buffers. Note that this is unsafe for other ioctlvs.

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -42,9 +42,9 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  ReturnCode Open(const OpenRequest& request) override;
   void Close() override;
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   static u32 ES_DIVerify(const std::vector<u8>& tmd);
 

--- a/Source/Core/Core/IOS/FS/FS.cpp
+++ b/Source/Core/Core/IOS/FS/FS.cpp
@@ -44,7 +44,7 @@ IPCCommandResult FS::GetFSReply(const s32 return_value) const
   return {return_value, true, SystemTimers::GetTicksPerSecond() / 500};
 }
 
-IOSReturnCode FS::Open(const IOSOpenRequest& request)
+ReturnCode FS::Open(const OpenRequest& request)
 {
   // clear tmp folder
   {
@@ -72,7 +72,7 @@ static u64 ComputeTotalFileSize(const File::FSTEntry& parentEntry)
   return sizeOfFiles;
 }
 
-IPCCommandResult FS::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult FS::IOCtlV(const IOCtlVRequest& request)
 {
   s32 return_value = IPC_SUCCESS;
   switch (request.request)
@@ -232,14 +232,14 @@ IPCCommandResult FS::IOCtlV(const IOSIOCtlVRequest& request)
   return GetFSReply(return_value);
 }
 
-IPCCommandResult FS::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult FS::IOCtl(const IOCtlRequest& request)
 {
   Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
   const s32 return_value = ExecuteCommand(request);
   return GetFSReply(return_value);
 }
 
-s32 FS::ExecuteCommand(const IOSIOCtlRequest& request)
+s32 FS::ExecuteCommand(const IOCtlRequest& request)
 {
   switch (request.request)
   {

--- a/Source/Core/Core/IOS/FS/FS.h
+++ b/Source/Core/Core/IOS/FS/FS.h
@@ -36,9 +36,9 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IOSReturnCode Open(const IOSOpenRequest& request) override;
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  ReturnCode Open(const OpenRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
 private:
   enum
@@ -56,7 +56,7 @@ private:
   };
 
   IPCCommandResult GetFSReply(s32 return_value) const;
-  s32 ExecuteCommand(const IOSIOCtlRequest& request);
+  s32 ExecuteCommand(const IOCtlRequest& request);
 };
 }  // namespace Device
 }  // namespace HLE

--- a/Source/Core/Core/IOS/FS/FileIO.cpp
+++ b/Source/Core/Core/IOS/FS/FileIO.cpp
@@ -88,7 +88,7 @@ void FileIO::Close()
   m_is_active = false;
 }
 
-IOSReturnCode FileIO::Open(const IOSOpenRequest& request)
+ReturnCode FileIO::Open(const OpenRequest& request)
 {
   m_Mode = request.flags;
 
@@ -156,7 +156,7 @@ void FileIO::OpenFile()
   }
 }
 
-IPCCommandResult FileIO::Seek(const IOSSeekRequest& request)
+IPCCommandResult FileIO::Seek(const SeekRequest& request)
 {
   u32 return_value = FS_EINVAL;
 
@@ -168,7 +168,7 @@ IPCCommandResult FileIO::Seek(const IOSSeekRequest& request)
 
     switch (request.mode)
     {
-    case IOSSeekRequest::IOS_SEEK_SET:
+    case SeekRequest::IOS_SEEK_SET:
     {
       if (request.offset <= file_size)
       {
@@ -178,7 +178,7 @@ IPCCommandResult FileIO::Seek(const IOSSeekRequest& request)
       break;
     }
 
-    case IOSSeekRequest::IOS_SEEK_CUR:
+    case SeekRequest::IOS_SEEK_CUR:
     {
       const u32 wanted_pos = request.offset + m_SeekPos;
       if (wanted_pos <= file_size)
@@ -189,7 +189,7 @@ IPCCommandResult FileIO::Seek(const IOSSeekRequest& request)
       break;
     }
 
-    case IOSSeekRequest::IOS_SEEK_END:
+    case SeekRequest::IOS_SEEK_END:
     {
       const u32 wanted_pos = request.offset + file_size;
       if (wanted_pos <= file_size)
@@ -215,7 +215,7 @@ IPCCommandResult FileIO::Seek(const IOSSeekRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult FileIO::Read(const IOSReadWriteRequest& request)
+IPCCommandResult FileIO::Read(const ReadWriteRequest& request)
 {
   s32 return_value = FS_EACCESS;
   if (m_file->IsOpen())
@@ -253,7 +253,7 @@ IPCCommandResult FileIO::Read(const IOSReadWriteRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult FileIO::Write(const IOSReadWriteRequest& request)
+IPCCommandResult FileIO::Write(const ReadWriteRequest& request)
 {
   s32 return_value = FS_EACCESS;
   if (m_file->IsOpen())
@@ -288,7 +288,7 @@ IPCCommandResult FileIO::Write(const IOSReadWriteRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult FileIO::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult FileIO::IOCtl(const IOCtlRequest& request)
 {
   DEBUG_LOG(IOS_FILEIO, "FileIO: IOCtl (Device=%s)", m_name.c_str());
   s32 return_value = IPC_SUCCESS;

--- a/Source/Core/Core/IOS/FS/FileIO.h
+++ b/Source/Core/Core/IOS/FS/FileIO.h
@@ -33,11 +33,11 @@ public:
   FileIO(u32 device_id, const std::string& device_name);
 
   void Close() override;
-  IOSReturnCode Open(const IOSOpenRequest& request) override;
-  IPCCommandResult Seek(const IOSSeekRequest& request) override;
-  IPCCommandResult Read(const IOSReadWriteRequest& request) override;
-  IPCCommandResult Write(const IOSReadWriteRequest& request) override;
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  ReturnCode Open(const OpenRequest& request) override;
+  IPCCommandResult Seek(const SeekRequest& request) override;
+  IPCCommandResult Read(const ReadWriteRequest& request) override;
+  IPCCommandResult Write(const ReadWriteRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   void PrepareForState(PointerWrap::Mode mode) override;
   void DoState(PointerWrap& p) override;
 

--- a/Source/Core/Core/IOS/IPC.h
+++ b/Source/Core/Core/IOS/IPC.h
@@ -23,7 +23,7 @@ namespace Device
 class Device;
 }
 
-struct IOSRequest;
+struct Request;
 
 struct IPCCommandResult
 {
@@ -78,7 +78,7 @@ void UpdateDevices();
 void ExecuteCommand(u32 address);
 
 void EnqueueRequest(u32 address);
-void EnqueueReply(const IOSRequest& request, s32 return_value, int cycles_in_future = 0,
+void EnqueueReply(const Request& request, s32 return_value, int cycles_in_future = 0,
                   CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future = 0);
 }  // namespace HLE

--- a/Source/Core/Core/IOS/Network/Net.cpp
+++ b/Source/Core/Core/IOS/Network/Net.cpp
@@ -77,7 +77,7 @@ NetKDRequest::~NetKDRequest()
   WiiSockMan::GetInstance().Clean();
 }
 
-IPCCommandResult NetKDRequest::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
 {
   s32 return_value = 0;
   switch (request.request)
@@ -326,7 +326,7 @@ NetNCDManage::NetNCDManage(u32 device_id, const std::string& device_name)
 {
 }
 
-IPCCommandResult NetNCDManage::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult NetNCDManage::IOCtlV(const IOCtlVRequest& request)
 {
   s32 return_value = IPC_SUCCESS;
   u32 common_result = 0;
@@ -402,7 +402,7 @@ NetWDCommand::NetWDCommand(u32 device_id, const std::string& device_name)
 // This is just for debugging / playing around.
 // There really is no reason to implement wd unless we can bend it such that
 // we can talk to the DS.
-IPCCommandResult NetWDCommand::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult NetWDCommand::IOCtlV(const IOCtlVRequest& request)
 {
   s32 return_value = IPC_SUCCESS;
 
@@ -539,7 +539,7 @@ static unsigned int opt_level_mapping[][2] = {{SOL_SOCKET, 0xFFFF}};
 static unsigned int opt_name_mapping[][2] = {
     {SO_REUSEADDR, 0x4}, {SO_SNDBUF, 0x1001}, {SO_RCVBUF, 0x1002}, {SO_ERROR, 0x1009}};
 
-IPCCommandResult NetIPTop::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult NetIPTop::IOCtl(const IOCtlRequest& request)
 {
   if (Core::g_want_determinism)
   {
@@ -1052,7 +1052,7 @@ IPCCommandResult NetIPTop::IOCtl(const IOSIOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult NetIPTop::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult NetIPTop::IOCtlV(const IOCtlVRequest& request)
 {
   s32 return_value = 0;
 

--- a/Source/Core/Core/IOS/Network/Net.h
+++ b/Source/Core/Core/IOS/Network/Net.h
@@ -76,7 +76,7 @@ public:
 
   virtual ~NetKDRequest();
 
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
 private:
   enum
@@ -132,7 +132,7 @@ public:
   }
 
   virtual ~NetKDTime() {}
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override
   {
     s32 result = 0;
     u32 common_result = 0;
@@ -209,8 +209,8 @@ public:
 
   virtual ~NetIPTop();
 
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   void Update() override;
 
@@ -227,7 +227,7 @@ class NetNCDManage : public Device
 public:
   NetNCDManage(u32 device_id, const std::string& device_name);
 
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
 private:
   enum
@@ -251,7 +251,7 @@ class NetWDCommand : public Device
 public:
   NetWDCommand(u32 device_id, const std::string& device_name);
 
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
 private:
   enum

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -79,13 +79,13 @@ int NetSSL::GetSSLFreeID() const
   return 0;
 }
 
-IPCCommandResult NetSSL::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult NetSSL::IOCtl(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), LogTypes::IOS_SSL, LogTypes::LINFO);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult NetSSL::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult NetSSL::IOCtlV(const IOCtlVRequest& request)
 {
   u32 BufferIn = 0, BufferIn2 = 0, BufferIn3 = 0;
   u32 BufferInSize = 0, BufferInSize2 = 0, BufferInSize3 = 0;

--- a/Source/Core/Core/IOS/Network/SSL.h
+++ b/Source/Core/Core/IOS/Network/SSL.h
@@ -94,8 +94,8 @@ public:
 
   virtual ~NetSSL();
 
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   int GetSSLFreeID() const;
 

--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -194,7 +194,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
     IPCCommandType ct = it->request.command;
     if (!it->is_ssl && ct == IPC_CMD_IOCTL)
     {
-      IOSIOCtlRequest ioctl{it->request.address};
+      IOCtlRequest ioctl{it->request.address};
       switch (it->net_type)
       {
       case IOCTL_SO_FCNTL:
@@ -270,7 +270,7 @@ void WiiSocket::Update(bool read, bool write, bool except)
     }
     else if (ct == IPC_CMD_IOCTLV)
     {
-      IOSIOCtlVRequest ioctlv{it->request.address};
+      IOCtlVRequest ioctlv{it->request.address};
       u32 BufferIn = 0, BufferIn2 = 0;
       u32 BufferInSize = 0, BufferInSize2 = 0;
       u32 BufferOut = 0, BufferOut2 = 0;
@@ -582,14 +582,14 @@ void WiiSocket::Update(bool read, bool write, bool except)
   }
 }
 
-void WiiSocket::DoSock(IOSRequest request, NET_IOCTL type)
+void WiiSocket::DoSock(Request request, NET_IOCTL type)
 {
   sockop so = {request, false};
   so.net_type = type;
   pending_sockops.push_back(so);
 }
 
-void WiiSocket::DoSock(IOSRequest request, SSL_IOCTL type)
+void WiiSocket::DoSock(Request request, SSL_IOCTL type)
 {
   sockop so = {request, true};
   so.ssl_type = type;

--- a/Source/Core/Core/IOS/Network/Socket.h
+++ b/Source/Core/Core/IOS/Network/Socket.h
@@ -176,7 +176,7 @@ class WiiSocket
 {
   struct sockop
   {
-    IOSRequest request;
+    Request request;
     bool is_ssl;
     union
     {
@@ -195,8 +195,8 @@ private:
   s32 CloseFd();
   s32 FCntl(u32 cmd, u32 arg);
 
-  void DoSock(IOSRequest request, NET_IOCTL type);
-  void DoSock(IOSRequest request, SSL_IOCTL type);
+  void DoSock(Request request, NET_IOCTL type);
+  void DoSock(Request request, SSL_IOCTL type);
   void Update(bool read, bool write, bool except);
   bool IsValid() const { return fd >= 0; }
 public:
@@ -227,7 +227,7 @@ public:
   void SetLastNetError(s32 error) { errno_last = error; }
   void Clean() { WiiSockets.clear(); }
   template <typename T>
-  void DoSock(s32 sock, const IOSRequest& request, T type)
+  void DoSock(s32 sock, const Request& request, T type)
   {
     auto socket_entry = WiiSockets.find(sock);
     if (socket_entry == WiiSockets.end())

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -74,7 +74,7 @@ void SDIOSlot0::OpenInternal()
   }
 }
 
-IOSReturnCode SDIOSlot0::Open(const IOSOpenRequest& request)
+ReturnCode SDIOSlot0::Open(const OpenRequest& request)
 {
   OpenInternal();
   m_registers.fill(0);
@@ -93,7 +93,7 @@ void SDIOSlot0::Close()
 }
 
 // The front SD slot
-IPCCommandResult SDIOSlot0::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult SDIOSlot0::IOCtl(const IOCtlRequest& request)
 {
   Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
   s32 return_value = IPC_SUCCESS;
@@ -204,7 +204,7 @@ IPCCommandResult SDIOSlot0::IOCtl(const IOSIOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-IPCCommandResult SDIOSlot0::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult SDIOSlot0::IOCtlV(const IOCtlVRequest& request)
 {
   s32 return_value = IPC_SUCCESS;
   switch (request.request)
@@ -225,7 +225,7 @@ IPCCommandResult SDIOSlot0::IOCtlV(const IOSIOCtlVRequest& request)
   return GetDefaultReply(return_value);
 }
 
-u32 SDIOSlot0::ExecuteCommand(const IOSRequest& request, u32 _BufferIn, u32 _BufferInSize,
+u32 SDIOSlot0::ExecuteCommand(const Request& request, u32 _BufferIn, u32 _BufferInSize,
                               u32 _rwBuffer, u32 _rwBufferSize, u32 _BufferOut, u32 _BufferOutSize)
 {
   // The game will send us a SendCMD with this information. To be able to read and write

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -29,10 +29,10 @@ public:
 
   void DoState(PointerWrap& p) override;
 
-  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  ReturnCode Open(const OpenRequest& request) override;
   void Close() override;
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   void EventNotify();
 
@@ -113,9 +113,9 @@ private:
   // TODO do we need more than one?
   struct Event
   {
-    Event(EventType type_, IOSRequest request_) : type(type_), request(request_) {}
+    Event(EventType type_, Request request_) : type(type_), request(request_) {}
     EventType type;
-    IOSRequest request;
+    Request request;
   };
   std::unique_ptr<Event> m_event;
 
@@ -127,7 +127,7 @@ private:
 
   File::IOFile m_Card;
 
-  u32 ExecuteCommand(const IOSRequest& request, u32 BufferIn, u32 BufferInSize, u32 BufferIn2,
+  u32 ExecuteCommand(const Request& request, u32 BufferIn, u32 BufferInSize, u32 BufferIn2,
                      u32 BufferInSize2, u32 _BufferOut, u32 BufferOutSize);
   void OpenInternal();
 };

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -23,9 +23,9 @@ namespace HLE
 {
 namespace Device
 {
-static std::unique_ptr<IOSIOCtlRequest> s_event_hook_request;
+static std::unique_ptr<IOCtlRequest> s_event_hook_request;
 
-IPCCommandResult STMImmediate::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult STMImmediate::IOCtl(const IOCtlRequest& request)
 {
   s32 return_value = IPC_SUCCESS;
   switch (request.request)
@@ -77,7 +77,7 @@ void STMEventHook::Close()
   m_is_active = false;
 }
 
-IPCCommandResult STMEventHook::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult STMEventHook::IOCtl(const IOCtlRequest& request)
 {
   if (request.request != IOCTL_STM_EVENTHOOK)
     return GetDefaultReply(IPC_EINVAL);
@@ -86,7 +86,7 @@ IPCCommandResult STMEventHook::IOCtl(const IOSIOCtlRequest& request)
     return GetDefaultReply(IPC_EEXIST);
 
   // IOCTL_STM_EVENTHOOK waits until the reset button or power button is pressed.
-  s_event_hook_request = std::make_unique<IOSIOCtlRequest>(request.address);
+  s_event_hook_request = std::make_unique<IOCtlRequest>(request.address);
   return GetNoReply();
 }
 

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -45,7 +45,7 @@ class STMImmediate final : public Device
 {
 public:
   STMImmediate(u32 device_id, const std::string& device_name) : Device(device_id, device_name) {}
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 };
 
 // The /dev/stm/eventhook
@@ -54,7 +54,7 @@ class STMEventHook final : public Device
 public:
   STMEventHook(u32 device_id, const std::string& device_name) : Device(device_id, device_name) {}
   void Close() override;
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
   bool HasHookInstalled() const;
   void ResetButton() const;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.cpp
@@ -56,7 +56,7 @@ void RestoreBTInfoSection(SysConf* sysconf)
 
 namespace Device
 {
-BluetoothBase::CtrlMessage::CtrlMessage(const IOSIOCtlVRequest& ioctlv) : ios_request(ioctlv)
+BluetoothBase::CtrlMessage::CtrlMessage(const IOCtlVRequest& ioctlv) : ios_request(ioctlv)
 {
   request_type = Memory::Read_U8(ioctlv.in_vectors[0].address);
   request = Memory::Read_U8(ioctlv.in_vectors[1].address);
@@ -66,7 +66,7 @@ BluetoothBase::CtrlMessage::CtrlMessage(const IOSIOCtlVRequest& ioctlv) : ios_re
   payload_addr = ioctlv.io_vectors[0].address;
 }
 
-BluetoothBase::CtrlBuffer::CtrlBuffer(const IOSIOCtlVRequest& ioctlv) : ios_request(ioctlv)
+BluetoothBase::CtrlBuffer::CtrlBuffer(const IOCtlVRequest& ioctlv) : ios_request(ioctlv)
 {
   m_endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address);
   m_length = Memory::Read_U16(ioctlv.in_vectors[1].address);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTBase.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTBase.h
@@ -53,8 +53,8 @@ protected:
 
   struct CtrlMessage
   {
-    CtrlMessage(const IOSIOCtlVRequest& ioctlv);
-    IOSIOCtlVRequest ios_request;
+    CtrlMessage(const IOCtlVRequest& ioctlv);
+    IOCtlVRequest ios_request;
     u8 request_type = 0;
     u8 request = 0;
     u16 value = 0;
@@ -65,8 +65,8 @@ protected:
 
   struct CtrlBuffer
   {
-    CtrlBuffer(const IOSIOCtlVRequest& ioctlv);
-    IOSIOCtlVRequest ios_request;
+    CtrlBuffer(const IOCtlVRequest& ioctlv);
+    IOCtlVRequest ios_request;
     void FillBuffer(const u8* src, size_t size) const;
     u8 m_endpoint = 0;
     u16 m_length = 0;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -114,7 +114,7 @@ static void DoStateForMessage(PointerWrap& p, std::unique_ptr<T>& message)
   p.Do(request_address);
   if (request_address != 0)
   {
-    IOSIOCtlVRequest request{request_address};
+    IOCtlVRequest request{request_address};
     message = std::make_unique<T>(request);
   }
 }
@@ -162,7 +162,7 @@ void BluetoothEmu::Close()
   m_is_active = false;
 }
 
-IPCCommandResult BluetoothEmu::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult BluetoothEmu::IOCtlV(const IOCtlVRequest& request)
 {
   bool send_reply = true;
   switch (request.request)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -49,7 +49,7 @@ public:
   virtual ~BluetoothEmu();
 
   void Close() override;
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   void Update() override;
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -95,7 +95,7 @@ BluetoothReal::~BluetoothReal()
   SaveLinkKeys();
 }
 
-IOSReturnCode BluetoothReal::Open(const IOSOpenRequest& request)
+ReturnCode BluetoothReal::Open(const OpenRequest& request)
 {
   libusb_device** list;
   const ssize_t cnt = libusb_get_device_list(m_libusb_context, &list);
@@ -164,7 +164,7 @@ void BluetoothReal::Close()
   m_is_active = false;
 }
 
-IPCCommandResult BluetoothReal::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult BluetoothReal::IOCtlV(const IOCtlVRequest& request)
 {
   if (!m_is_wii_bt_module && s_need_reset_keys.TestAndClear())
   {

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -47,9 +47,9 @@ public:
   BluetoothReal(u32 device_id, const std::string& device_name);
   ~BluetoothReal() override;
 
-  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  ReturnCode Open(const OpenRequest& request) override;
   void Close() override;
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   void DoState(PointerWrap& p) override;
   void UpdateSyncButtonState(bool is_held) override;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
@@ -18,7 +18,7 @@ namespace HLE
 {
 namespace Device
 {
-IOSReturnCode BluetoothStub::Open(const IOSOpenRequest& request)
+ReturnCode BluetoothStub::Open(const OpenRequest& request)
 {
   PanicAlertT("Bluetooth passthrough mode is enabled, but Dolphin was built without libusb."
               " Passthrough mode cannot be used.");

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
@@ -25,7 +25,7 @@ public:
       : BluetoothBase(device_id, device_name)
   {
   }
-  IOSReturnCode Open(const IOSOpenRequest& request) override;
+  ReturnCode Open(const OpenRequest& request) override;
   void DoState(PointerWrap& p) override;
 };
 }  // namespace Device

--- a/Source/Core/Core/IOS/USB/USB_HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HIDv4.cpp
@@ -43,7 +43,7 @@ void USB_HIDv4::checkUsbUpdates(USB_HIDv4* hid)
       std::lock_guard<std::mutex> lk(hid->m_device_list_reply_mutex);
       if (hid->deviceCommandAddress != 0)
       {
-        IOSIOCtlRequest request{hid->deviceCommandAddress};
+        IOCtlRequest request{hid->deviceCommandAddress};
         hid->FillOutDevices(request);
         EnqueueReply(request, IPC_SUCCESS, 0, CoreTiming::FromThread::NON_CPU);
         hid->deviceCommandAddress = 0;
@@ -65,7 +65,7 @@ void USB_HIDv4::handleUsbUpdates(struct libusb_transfer* transfer)
     ret = transfer->length;
   }
 
-  IOSIOCtlRequest request{replyAddress};
+  IOCtlRequest request{replyAddress};
   EnqueueReply(request, ret, 0, CoreTiming::FromThread::NON_CPU);
 }
 
@@ -105,7 +105,7 @@ USB_HIDv4::~USB_HIDv4()
     libusb_exit(nullptr);
 }
 
-IPCCommandResult USB_HIDv4::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult USB_HIDv4::IOCtl(const IOCtlRequest& request)
 {
   if (Core::g_want_determinism)
   {
@@ -213,7 +213,7 @@ IPCCommandResult USB_HIDv4::IOCtl(const IOSIOCtlRequest& request)
     std::lock_guard<std::mutex> lk(m_device_list_reply_mutex);
     if (deviceCommandAddress != 0)
     {
-      IOSIOCtlRequest pending_request{deviceCommandAddress};
+      IOCtlRequest pending_request{deviceCommandAddress};
       Memory::Write_U32(0xFFFFFFFF, pending_request.buffer_out);
       EnqueueReply(pending_request, -1);
       deviceCommandAddress = 0;
@@ -256,7 +256,7 @@ bool USB_HIDv4::ClaimDevice(libusb_device_handle* dev)
   return true;
 }
 
-IPCCommandResult USB_HIDv4::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult USB_HIDv4::IOCtlV(const IOCtlVRequest& request)
 {
   Dolphin_Debugger::PrintCallstack(LogTypes::IOS_HID, LogTypes::LWARNING);
   request.DumpUnknown(GetDeviceName(), LogTypes::IOS_HID);
@@ -302,7 +302,7 @@ void USB_HIDv4::ConvertEndpointToWii(WiiHIDEndpointDescriptor* dest,
   dest->wMaxPacketSize = Common::swap16(dest->wMaxPacketSize);
 }
 
-void USB_HIDv4::FillOutDevices(const IOSIOCtlRequest& request)
+void USB_HIDv4::FillOutDevices(const IOCtlRequest& request)
 {
   static u16 check = 1;
   int OffsetBuffer = request.buffer_out;

--- a/Source/Core/Core/IOS/USB/USB_HIDv4.h
+++ b/Source/Core/Core/IOS/USB/USB_HIDv4.h
@@ -44,8 +44,8 @@ public:
 
   virtual ~USB_HIDv4();
 
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
 private:
   enum
@@ -121,7 +121,7 @@ private:
   };
 
   u32 deviceCommandAddress;
-  void FillOutDevices(const IOSIOCtlRequest& request);
+  void FillOutDevices(const IOCtlRequest& request);
   int GetAvailableDevNum(u16 idVendor, u16 idProduct, u8 bus, u8 port, u16 check);
   bool ClaimDevice(libusb_device_handle* dev);
 

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -42,7 +42,7 @@ USB_KBD::USB_KBD(u32 device_id, const std::string& device_name) : Device(device_
 {
 }
 
-IOSReturnCode USB_KBD::Open(const IOSOpenRequest& request)
+ReturnCode USB_KBD::Open(const OpenRequest& request)
 {
   INFO_LOG(IOS, "USB_KBD: Open");
   IniFile ini;
@@ -62,7 +62,7 @@ IOSReturnCode USB_KBD::Open(const IOSOpenRequest& request)
   return IPC_SUCCESS;
 }
 
-IPCCommandResult USB_KBD::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult USB_KBD::IOCtl(const IOCtlRequest& request)
 {
   if (SConfig::GetInstance().m_WiiKeyboard && !Core::g_want_determinism && !m_MessageQueue.empty())
   {

--- a/Source/Core/Core/IOS/USB/USB_KBD.h
+++ b/Source/Core/Core/IOS/USB/USB_KBD.h
@@ -22,8 +22,8 @@ class USB_KBD : public Device
 public:
   USB_KBD(u32 device_id, const std::string& device_name);
 
-  IOSReturnCode Open(const IOSOpenRequest& request) override;
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  ReturnCode Open(const OpenRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   void Update() override;
 
 private:

--- a/Source/Core/Core/IOS/USB/USB_VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN.cpp
@@ -16,13 +16,13 @@ USB_VEN::USB_VEN(u32 device_id, const std::string& device_name) : Device(device_
 {
 }
 
-IPCCommandResult USB_VEN::IOCtlV(const IOSIOCtlVRequest& request)
+IPCCommandResult USB_VEN::IOCtlV(const IOCtlVRequest& request)
 {
   request.Dump(GetDeviceName());
   return GetNoReply();
 }
 
-IPCCommandResult USB_VEN::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult USB_VEN::IOCtl(const IOCtlRequest& request)
 {
   request.Log(GetDeviceName(), LogTypes::OSHLE);
 

--- a/Source/Core/Core/IOS/USB/USB_VEN.h
+++ b/Source/Core/Core/IOS/USB/USB_VEN.h
@@ -21,8 +21,8 @@ class USB_VEN final : public Device
 public:
   USB_VEN(u32 device_id, const std::string& device_name);
 
-  IPCCommandResult IOCtlV(const IOSIOCtlVRequest& request) override;
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
 private:
   enum USBIOCtl

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -84,7 +84,7 @@ WFSI::WFSI(u32 device_id, const std::string& device_name) : Device(device_id, de
 {
 }
 
-IPCCommandResult WFSI::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
 {
   u32 return_error_code = IPC_SUCCESS;
 

--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -40,7 +40,7 @@ class WFSI : public Device
 public:
   WFSI(u32 device_id, const std::string& device_name);
 
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
 private:
   std::string m_device_name;

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -33,7 +33,7 @@ WFSSRV::WFSSRV(u32 device_id, const std::string& device_name) : Device(device_id
   m_device_name = "msc01";
 }
 
-IPCCommandResult WFSSRV::IOCtl(const IOSIOCtlRequest& request)
+IPCCommandResult WFSSRV::IOCtl(const IOCtlRequest& request)
 {
   int return_error_code = IPC_SUCCESS;
 

--- a/Source/Core/Core/IOS/WFS/WFSSRV.h
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.h
@@ -29,7 +29,7 @@ class WFSSRV : public Device
 public:
   WFSSRV(u32 device_id, const std::string& device_name);
 
-  IPCCommandResult IOCtl(const IOSIOCtlRequest& request) override;
+  IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
 private:
   // WFS device name, e.g. msc01/msc02.


### PR DESCRIPTION
Now that IOS code is namespaced, we don't need the prefix anymore.