### PR TITLE
Only allow reset/power when core is running

### DIFF
--- a/Source/Core/Core/HW/ProcessorInterface.cpp
+++ b/Source/Core/Core/HW/ProcessorInterface.cpp
@@ -230,6 +230,8 @@ static void IOSNotifyPowerButtonCallback(u64 userdata, s64 cyclesLate)
 
 void ResetButton_Tap()
 {
+  if (!Core::IsRunning())
+    return;
   CoreTiming::ScheduleEvent(0, toggleResetButton, true, CoreTiming::FromThread::ANY);
   CoreTiming::ScheduleEvent(0, iosNotifyResetButton, 0, CoreTiming::FromThread::ANY);
   CoreTiming::ScheduleEvent(SystemTimers::GetTicksPerSecond() / 2, toggleResetButton, false,
@@ -238,6 +240,8 @@ void ResetButton_Tap()
 
 void PowerButton_Tap()
 {
+  if (!Core::IsRunning())
+    return;
   CoreTiming::ScheduleEvent(0, iosNotifyPowerButton, 0, CoreTiming::FromThread::ANY);
 }
 


### PR DESCRIPTION
If we don't check for Core::IsRunning(), event types such as iosNotifyResetButton may actually be nullptr, or some random invalid pointer (after an emulation start then shutdown) and be used when the user triggers a reset, which causes random crashes.