### PR TITLE
Fix GCZ compression missing the header

### DIFF
--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -410,8 +410,13 @@ bool DecompressBlobToFile(const std::string& infile_path, const std::string& out
 
 bool IsGCZBlob(File::IOFile& file)
 {
+  const u64 position = file.Tell();
+  if (!file.Seek(0, SEEK_SET))
+    return false;
   CompressedBlobHeader header;
-  return file.Seek(0, SEEK_SET) && file.ReadArray(&header, 1) && header.magic_cookie == GCZ_MAGIC;
+  bool is_gcz = file.ReadArray(&header, 1) && header.magic_cookie == GCZ_MAGIC;
+  file.Seek(position, SEEK_SET);
+  return is_gcz;
 }
 
 }  // namespace

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -216,6 +216,8 @@ bool CompressFileToBlob(const std::string& infile_path, const std::string& outfi
   outfile.Seek(sizeof(CompressedBlobHeader), SEEK_CUR);
   // seek past the offset and hash tables (we will write them at the end)
   outfile.Seek((sizeof(u64) + sizeof(u32)) * header.num_blocks, SEEK_CUR);
+  // seek to the start of the input file to make sure we get everything
+  infile.Seek(0, SEEK_SET);
 
   // Now we are ready to write compressed data!
   u64 position = 0;

--- a/Source/Core/DiscIO/CompressedBlob.cpp
+++ b/Source/Core/DiscIO/CompressedBlob.cpp
@@ -405,7 +405,7 @@ bool DecompressBlobToFile(const std::string& infile_path, const std::string& out
     outfile.Resize(header.data_size);
   }
 
-  return true;
+  return success;
 }
 
 bool IsGCZBlob(File::IOFile& file)


### PR DESCRIPTION
During PR #4537, we apparently missed that `IsGCZBlob` does a read and never resets the file position back to where it was. Due to that, `CompressFileToBlob` was compressing all but the header causing invalid/incomplete GCZ files to be written.

Just to be on the safe side, `IsGCZBlob` now attempts to seek back to the original position, and `CompressFileToBlob` also does an explicit seek.

I don't really know if it is a good idea to make `IsGCZBlob` return `false` when either the Read or the Seek fails, because callers like `CompressFileToBlob` might do strange things (like show an error message that isn't true in that context; or worse try to compress an already compressed file). Any thoughts on that are appreciated.

Also, while I'm at it, `DecompressFileToBlob` also appears to have had a copy&paste mistake, always returning `true` at the end instead of returning `success`.