### PR TITLE
EXI_Device: Move the dummy implementation to its own source files

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SRCS	ActionReplay.cpp
 			HW/EXI/EXI_Device.cpp
 			HW/EXI/EXI_DeviceAD16.cpp
 			HW/EXI/EXI_DeviceAGP.cpp
+			HW/EXI/EXI_DeviceDummy.cpp
 			HW/EXI/EXI_DeviceEthernet.cpp
 			HW/EXI/EXI_DeviceGecko.cpp
 			HW/EXI/EXI_DeviceIPL.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -122,6 +122,7 @@
     <ClCompile Include="HW\EXI\EXI_Device.cpp" />
     <ClCompile Include="HW\EXI\EXI_DeviceAD16.cpp" />
     <ClCompile Include="HW\EXI\EXI_DeviceAGP.cpp" />
+    <ClCompile Include="HW\EXI\EXI_DeviceDummy.cpp" />
     <ClCompile Include="HW\EXI\EXI_DeviceEthernet.cpp" />
     <ClCompile Include="HW\EXI\EXI_DeviceGecko.cpp" />
     <ClCompile Include="HW\EXI\EXI_DeviceIPL.cpp" />
@@ -351,6 +352,7 @@
     <ClInclude Include="HW\EXI\EXI_Device.h" />
     <ClInclude Include="HW\EXI\EXI_DeviceAD16.h" />
     <ClInclude Include="HW\EXI\EXI_DeviceAGP.h" />
+    <ClInclude Include="HW\EXI\EXI_DeviceDummy.h" />
     <ClInclude Include="HW\EXI\EXI_DeviceEthernet.h" />
     <ClInclude Include="HW\EXI\EXI_DeviceGecko.h" />
     <ClInclude Include="HW\EXI\EXI_DeviceIPL.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -400,6 +400,9 @@
     <ClCompile Include="HW\EXI\EXI_DeviceAGP.cpp">
       <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface</Filter>
     </ClCompile>
+    <ClCompile Include="HW\EXI\EXI_DeviceDummy.cpp">
+      <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface</Filter>
+    </ClCompile>
     <ClCompile Include="HW\EXI\EXI_DeviceEthernet.cpp">
       <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface</Filter>
     </ClCompile>
@@ -995,6 +998,9 @@
       <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface</Filter>
     </ClInclude>
     <ClInclude Include="HW\EXI\EXI_DeviceAGP.h">
+      <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\EXI\EXI_DeviceDummy.h">
       <Filter>HW %28Flipper/Hollywood%29\EXI - Expansion Interface</Filter>
     </ClInclude>
     <ClInclude Include="HW\EXI\EXI_DeviceEthernet.h">

--- a/Source/Core/Core/HW/EXI/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Device.cpp
@@ -6,11 +6,10 @@
 
 #include <memory>
 
-#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
-#include "Common/Logging/Log.h"
 #include "Core/HW/EXI/EXI_DeviceAD16.h"
 #include "Core/HW/EXI/EXI_DeviceAGP.h"
+#include "Core/HW/EXI/EXI_DeviceDummy.h"
 #include "Core/HW/EXI/EXI_DeviceEthernet.h"
 #include "Core/HW/EXI/EXI_DeviceGecko.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
@@ -18,7 +17,6 @@
 #include "Core/HW/EXI/EXI_DeviceMic.h"
 #include "Core/HW/Memmap.h"
 
-// --- interface IEXIDevice ---
 void IEXIDevice::ImmWrite(u32 _uData, u32 _uSize)
 {
   while (_uSize--)
@@ -62,40 +60,6 @@ void IEXIDevice::DMARead(u32 _uAddr, u32 _uSize)
     Memory::Write_U8(uByte, _uAddr++);
   }
 }
-
-// --- class CEXIDummy ---
-// Just a dummy that logs reads and writes
-// to be used for EXI devices we haven't emulated
-// DOES NOT FUNCTION AS "NO DEVICE INSERTED" -> Appears as unknown device
-class CEXIDummy : public IEXIDevice
-{
-  std::string m_strName;
-
-  void TransferByte(u8& _byte) override {}
-public:
-  CEXIDummy(const std::string& _strName) : m_strName(_strName) {}
-  virtual ~CEXIDummy() {}
-  void ImmWrite(u32 data, u32 size) override
-  {
-    INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s ImmWrite: %08x", m_strName.c_str(), data);
-  }
-  u32 ImmRead(u32 size) override
-  {
-    INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s ImmRead", m_strName.c_str());
-    return 0;
-  }
-  void DMAWrite(u32 addr, u32 size) override
-  {
-    INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s DMAWrite: %08x bytes, from %08x to device",
-             m_strName.c_str(), size, addr);
-  }
-  void DMARead(u32 addr, u32 size) override
-  {
-    INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s DMARead:  %08x bytes, from device to %08x",
-             m_strName.c_str(), size, addr);
-  }
-  bool IsPresent() const override { return true; }
-};
 
 // F A C T O R Y
 std::unique_ptr<IEXIDevice> EXIDevice_Create(TEXIDevices device_type, const int channel_num)

--- a/Source/Core/Core/HW/EXI/EXI_DeviceDummy.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceDummy.cpp
@@ -1,0 +1,44 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/HW/EXI/EXI_DeviceDummy.h"
+
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
+
+CEXIDummy::CEXIDummy(const std::string& name) : m_name{name}
+{
+}
+
+void CEXIDummy::ImmWrite(u32 data, u32 size)
+{
+  INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s ImmWrite: %08x", m_name.c_str(), data);
+}
+
+u32 CEXIDummy::ImmRead(u32 size)
+{
+  INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s ImmRead", m_name.c_str());
+  return 0;
+}
+
+void CEXIDummy::DMAWrite(u32 address, u32 size)
+{
+  INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s DMAWrite: %08x bytes, from %08x to device",
+           m_name.c_str(), size, address);
+}
+
+void CEXIDummy::DMARead(u32 address, u32 size)
+{
+  INFO_LOG(EXPANSIONINTERFACE, "EXI DUMMY %s DMARead:  %08x bytes, from device to %08x",
+           m_name.c_str(), size, address);
+}
+
+bool CEXIDummy::IsPresent() const
+{
+  return true;
+}
+
+void CEXIDummy::TransferByte(u8& byte)
+{
+}

--- a/Source/Core/Core/HW/EXI/EXI_DeviceDummy.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceDummy.h
@@ -1,0 +1,32 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+#include "Common/CommonTypes.h"
+#include "Core/HW/EXI/EXI_Device.h"
+
+// Just a dummy that logs reads and writes
+// to be used for EXI devices we haven't emulated
+// DOES NOT FUNCTION AS "NO DEVICE INSERTED" -> Appears as unknown device
+class CEXIDummy final : public IEXIDevice
+{
+public:
+  explicit CEXIDummy(const std::string& name);
+
+  void ImmWrite(u32 data, u32 size) override;
+  u32 ImmRead(u32 size) override;
+
+  void DMAWrite(u32 address, u32 size) override;
+  void DMARead(u32 address, u32 size) override;
+
+  bool IsPresent() const override;
+
+private:
+  void TransferByte(u8& byte) override;
+
+  std::string m_name;
+};


### PR DESCRIPTION
Keeps device implementations separated uniformly (i.e. each implementation should be in its own source files).