### PR TITLE
Jit64: Use a temporary register for memory references.

### DIFF
--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -183,7 +183,7 @@ State GetState()
   return s_state;
 }
 
-const volatile State* GetStatePtr()
+const State* GetStatePtr()
 {
   return &s_state;
 }

--- a/Source/Core/Core/HW/CPU.h
+++ b/Source/Core/Core/HW/CPU.h
@@ -57,7 +57,7 @@ State GetState();
 
 // Direct State Access (Raw pointer for embedding into JIT Blocks)
 // Strictly read-only. A lock is required to change the value.
-const volatile State* GetStatePtr();
+const State* GetStatePtr();
 
 // Locks the CPU Thread (waiting for it to become idle).
 // While this lock is held, the CPU Thread will not perform any action so it is safe to access

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -780,7 +780,8 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
       SetJumpTarget(extException);
       TEST(32, PPCSTATE(msr), Imm32(0x0008000));
       FixupBranch noExtIntEnable = J_CC(CC_Z, true);
-      TEST(32, M(&ProcessorInterface::m_InterruptCause),
+      MOV(64, R(RSCRATCH), ImmPtr(&ProcessorInterface::m_InterruptCause));
+      TEST(32, MatR(RSCRATCH),
            Imm32(ProcessorInterface::INT_CAUSE_CP | ProcessorInterface::INT_CAUSE_PE_TOKEN |
                  ProcessorInterface::INT_CAUSE_PE_FINISH));
       FixupBranch noCPInt = J_CC(CC_Z, true);
@@ -854,7 +855,8 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
         ABI_PushRegistersAndAdjustStack({}, 0);
         ABI_CallFunction(PowerPC::CheckBreakPoints);
         ABI_PopRegistersAndAdjustStack({}, 0);
-        TEST(32, M(CPU::GetStatePtr()), Imm32(0xFFFFFFFF));
+        MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
+        TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
         FixupBranch noBreakpoint = J_CC(CC_Z);
 
         WriteExit(ops[i].address);

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -84,12 +84,14 @@ void Jit64AsmRoutineManager::Generate()
 
   if (SConfig::GetInstance().bEnableDebugging)
   {
-    TEST(32, M(CPU::GetStatePtr()), Imm32(static_cast<u32>(CPU::State::Stepping)));
+    MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
+    TEST(32, MatR(RSCRATCH), Imm32(static_cast<u32>(CPU::State::Stepping)));
     FixupBranch notStepping = J_CC(CC_Z);
     ABI_PushRegistersAndAdjustStack({}, 0);
     ABI_CallFunction(PowerPC::CheckBreakPoints);
     ABI_PopRegistersAndAdjustStack({}, 0);
-    TEST(32, M(CPU::GetStatePtr()), Imm32(0xFFFFFFFF));
+    MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
+    TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
     dbg_exit = J_CC(CC_NZ, true);
     SetJumpTarget(notStepping);
   }
@@ -187,7 +189,8 @@ void Jit64AsmRoutineManager::Generate()
 
   // Check the state pointer to see if we are exiting
   // Gets checked on at the end of every slice
-  TEST(32, M(CPU::GetStatePtr()), Imm32(0xFFFFFFFF));
+  MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
+  TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
   J_CC(CC_Z, outerLoop);
 
   // Landing pad for drec space

--- a/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_SystemRegisters.cpp
@@ -410,7 +410,8 @@ void Jit64::mtmsr(UGeckoInstruction inst)
   FixupBranch noExceptionsPending = J_CC(CC_Z);
 
   // Check if a CP interrupt is waiting and keep the GPU emulation in sync (issue 4336)
-  TEST(32, M(&ProcessorInterface::m_InterruptCause), Imm32(ProcessorInterface::INT_CAUSE_CP));
+  MOV(64, R(RSCRATCH), ImmPtr(&ProcessorInterface::m_InterruptCause));
+  TEST(32, MatR(RSCRATCH), Imm32(ProcessorInterface::INT_CAUSE_CP));
   FixupBranch cpInt = J_CC(CC_NZ);
 
   MOV(32, PPCSTATE(pc), Imm32(js.compilerPC + 4));


### PR DESCRIPTION
X64 only support 32bit immediates, so we need to load all pointers to registers first. This PR tries to do so within the Jit64 but for load/store instructions. There we run out of registers, so this needs a lot more of effort.

To be honest, I think this is the wrong way to go. But it is needed to support running multiple JITs within the same process. If we miss this requirement, PR #4515 will generate the better code.