### PR TITLE
IOS: STM: Save event hook to savestates

### DIFF
--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "Common/Assert.h"
+#include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
 
@@ -88,6 +89,17 @@ IPCCommandResult STMEventHook::IOCtl(const IOCtlRequest& request)
   // IOCTL_STM_EVENTHOOK waits until the reset button or power button is pressed.
   s_event_hook_request = std::make_unique<IOCtlRequest>(request.address);
   return GetNoReply();
+}
+
+void STMEventHook::DoState(PointerWrap& p)
+{
+  u32 address = s_event_hook_request ? s_event_hook_request->address : 0;
+  p.Do(address);
+  if (address != 0)
+    s_event_hook_request = std::make_unique<IOCtlRequest>(address);
+  else
+    s_event_hook_request.reset();
+  Device::DoState(p);
 }
 
 bool STMEventHook::HasHookInstalled() const

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -10,6 +10,8 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IPC.h"
 
+class PointerWrap;
+
 namespace IOS
 {
 namespace HLE
@@ -55,6 +57,7 @@ public:
   STMEventHook(u32 device_id, const std::string& device_name) : Device(device_id, device_name) {}
   void Close() override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
+  void DoState(PointerWrap& p) override;
 
   bool HasHookInstalled() const;
   void ResetButton() const;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 71;  // Last changed in PR 4687
+static const u32 STATE_VERSION = 72;  // Last changed in PR 4710
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This allows a STM event hook to be saved and restored correctly and fixes the power/reset button after loading a state in some cases.