### PR TITLE
Don't load game INIs in Core::Init

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -222,8 +222,8 @@ bool BootCore(const std::string& _rFilename)
 
   StartUp.m_BootType = SConfig::BOOT_ISO;
   StartUp.m_strFilename = _rFilename;
-  SConfig::GetInstance().m_LastFilename = _rFilename;
-  SConfig::GetInstance().SaveSettings();
+  StartUp.m_LastFilename = _rFilename;
+  StartUp.SaveSettings();
   StartUp.bRunCompareClient = false;
   StartUp.bRunCompareServer = false;
 
@@ -260,16 +260,13 @@ bool BootCore(const std::string& _rFilename)
     core_section->Get("ProgressiveScan", &StartUp.bProgressive, StartUp.bProgressive);
     core_section->Get("PAL60", &StartUp.bPAL60, StartUp.bPAL60);
     core_section->Get("GameCubeLanguage", &StartUp.SelectedLanguage, StartUp.SelectedLanguage);
-    if (core_section->Get("EmulationSpeed", &SConfig::GetInstance().m_EmulationSpeed,
-                          SConfig::GetInstance().m_EmulationSpeed))
+    if (core_section->Get("EmulationSpeed", &StartUp.m_EmulationSpeed, StartUp.m_EmulationSpeed))
       config_cache.bSetEmulationSpeed = true;
 
-    if (dsp_section->Get("Volume", &SConfig::GetInstance().m_Volume,
-                         SConfig::GetInstance().m_Volume))
+    if (dsp_section->Get("Volume", &StartUp.m_Volume, StartUp.m_Volume))
       config_cache.bSetVolume = true;
-    dsp_section->Get("EnableJIT", &SConfig::GetInstance().m_DSPEnableJIT,
-                     SConfig::GetInstance().m_DSPEnableJIT);
-    dsp_section->Get("Backend", &SConfig::GetInstance().sBackend, SConfig::GetInstance().sBackend);
+    dsp_section->Get("EnableJIT", &StartUp.m_DSPEnableJIT, StartUp.m_DSPEnableJIT);
+    dsp_section->Get("Backend", &StartUp.sBackend, StartUp.sBackend);
     VideoBackendBase::ActivateBackend(StartUp.m_strVideoBackend);
     core_section->Get("GPUDeterminismMode", &StartUp.m_strGPUDeterminismMode,
                       StartUp.m_strGPUDeterminismMode);
@@ -280,7 +277,7 @@ bool BootCore(const std::string& _rFilename)
       controls_section->Get(StringFromFormat("PadType%u", i), &source, -1);
       if (source >= SIDEVICE_NONE && source < SIDEVICE_COUNT)
       {
-        SConfig::GetInstance().m_SIDevice[i] = (SIDevices)source;
+        StartUp.m_SIDevice[i] = static_cast<SIDevices>(source);
         config_cache.bSetPads[i] = true;
       }
     }
@@ -351,11 +348,11 @@ bool BootCore(const std::string& _rFilename)
     StartUp.bOverrideGCLanguage = g_NetPlaySettings.m_OverrideGCLanguage;
     StartUp.bProgressive = g_NetPlaySettings.m_ProgressiveScan;
     StartUp.bPAL60 = g_NetPlaySettings.m_PAL60;
-    SConfig::GetInstance().m_DSPEnableJIT = g_NetPlaySettings.m_DSPEnableJIT;
-    SConfig::GetInstance().m_OCEnable = g_NetPlaySettings.m_OCEnable;
-    SConfig::GetInstance().m_OCFactor = g_NetPlaySettings.m_OCFactor;
-    SConfig::GetInstance().m_EXIDevice[0] = g_NetPlaySettings.m_EXIDevice[0];
-    SConfig::GetInstance().m_EXIDevice[1] = g_NetPlaySettings.m_EXIDevice[1];
+    StartUp.m_DSPEnableJIT = g_NetPlaySettings.m_DSPEnableJIT;
+    StartUp.m_OCEnable = g_NetPlaySettings.m_OCEnable;
+    StartUp.m_OCFactor = g_NetPlaySettings.m_OCFactor;
+    StartUp.m_EXIDevice[0] = g_NetPlaySettings.m_EXIDevice[0];
+    StartUp.m_EXIDevice[1] = g_NetPlaySettings.m_EXIDevice[1];
     config_cache.bSetEXIDevice[0] = true;
     config_cache.bSetEXIDevice[1] = true;
   }
@@ -382,7 +379,7 @@ bool BootCore(const std::string& _rFilename)
   }
 
   if (StartUp.bWii)
-    SConfig::GetInstance().SaveSettingsToSysconf();
+    StartUp.SaveSettingsToSysconf();
 
   // Run the game
   // Init the core

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -282,9 +282,15 @@ bool BootCore(const std::string& _rFilename)
       }
     }
 
+    Core::g_aspect_wide = StartUp.bWii;
+
     // Wii settings
     if (StartUp.bWii)
     {
+      IniFile::Section* wii_section = game_ini.GetOrCreateSection("Wii");
+      wii_section->Get("Widescreen", &Core::g_aspect_wide, !!StartUp.m_wii_aspect_ratio);
+      wii_section->Get("Language", &StartUp.m_wii_language, StartUp.m_wii_language);
+
       int source;
       for (unsigned int i = 0; i < MAX_WIIMOTES; ++i)
       {
@@ -305,9 +311,6 @@ bool BootCore(const std::string& _rFilename)
         g_wiimote_sources[WIIMOTE_BALANCE_BOARD] = source;
         WiimoteReal::ChangeWiimoteSource(WIIMOTE_BALANCE_BOARD, source);
       }
-
-      IniFile::Section* wii_section = game_ini.GetOrCreateSection("Wii");
-      wii_section->Get("Language", &StartUp.m_wii_language, StartUp.m_wii_language);
     }
   }
 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -230,8 +230,6 @@ bool IsGPUThread()
 // BootManager.cpp
 bool Init()
 {
-  const SConfig& _CoreParameter = SConfig::GetInstance();
-
   if (s_emu_thread.joinable())
   {
     if (IsRunning())
@@ -249,18 +247,10 @@ bool Init()
 
   Core::UpdateWantDeterminism(/*initial*/ true);
 
-  INFO_LOG(OSREPORT, "Starting core = %s mode", _CoreParameter.bWii ? "Wii" : "GameCube");
-  INFO_LOG(OSREPORT, "CPU Thread separate = %s", _CoreParameter.bCPUThread ? "Yes" : "No");
+  INFO_LOG(OSREPORT, "Starting core = %s mode", SConfig::GetInstance().bWii ? "Wii" : "GameCube");
+  INFO_LOG(OSREPORT, "CPU Thread separate = %s", SConfig::GetInstance().bCPUThread ? "Yes" : "No");
 
   Host_UpdateMainFrame();  // Disable any menus or buttons at boot
-
-  g_aspect_wide = _CoreParameter.bWii;
-  if (g_aspect_wide)
-  {
-    IniFile gameIni = _CoreParameter.LoadGameIni();
-    gameIni.GetOrCreateSection("Wii")->Get("Widescreen", &g_aspect_wide,
-                                           !!SConfig::GetInstance().m_wii_aspect_ratio);
-  }
 
   s_window_handle = Host_GetRenderHandle();
 


### PR DESCRIPTION
The game INIs are already loaded in BootManager::BootCore, which is executed right before. Let's put the g_aspect_wide code there instead.