### PR TITLE
Fix -Wshadow warning for file_entry

### DIFF
--- a/Source/Core/DiscIO/WbfsBlob.cpp
+++ b/Source/Core/DiscIO/WbfsBlob.cpp
@@ -146,7 +146,7 @@ File::IOFile& WbfsFileReader::SeekToCluster(u64 offset, u64* available)
     u64 cluster_offset = offset & (m_wbfs_sector_size - 1);
     u64 final_address = cluster_address + cluster_offset;
 
-    for (file_entry& file_entry : m_files)
+    for (FileEntry& file_entry : m_files)
     {
       if (final_address < (file_entry.base_address + file_entry.size))
       {

--- a/Source/Core/DiscIO/WbfsBlob.h
+++ b/Source/Core/DiscIO/WbfsBlob.h
@@ -41,9 +41,9 @@ private:
 
   File::IOFile& SeekToCluster(u64 offset, u64* available);
   bool IsGood() { return m_good; }
-  struct file_entry
+  struct FileEntry
   {
-    file_entry(File::IOFile file_, u64 base_address_, u64 size_)
+    FileEntry(File::IOFile file_, u64 base_address_, u64 size_)
         : file(std::move(file_)), base_address(base_address_), size(size_)
     {
     }
@@ -53,7 +53,7 @@ private:
     u64 size;
   };
 
-  std::vector<file_entry> m_files;
+  std::vector<FileEntry> m_files;
 
   u64 m_size;
 


### PR DESCRIPTION
This struct didn't follow our naming convention, so let's rename the struct itself instead of the variable that triggered the warning.