### PR TITLE
GameSettings: Note for Star Fox Adventures - glow effects

### DIFF
--- a/Data/Sys/GameSettings/GSA.ini
+++ b/Data/Sys/GameSettings/GSA.ini
@@ -5,7 +5,7 @@
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationIssues =
+EmulationIssues = Needs Store EFB Copies to Texture Only disabled for proper glow effects.
 EmulationStateId = 4
 
 [OnLoad]


### PR DESCRIPTION
Adds a note to Star Fox Adventures to let people know how to accurately emulate the game's glow effects.