### PR TITLE
SI_Device: Move the null device implementation to its own source files

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -118,6 +118,7 @@ set(SRCS	ActionReplay.cpp
 			HW/SI/SI_DeviceGCController.cpp
 			HW/SI/SI_DeviceGCSteeringWheel.cpp
 			HW/SI/SI_DeviceKeyboard.cpp
+			HW/SI/SI_DeviceNull.cpp
 			HW/Sram.cpp
 			HW/StreamADPCM.cpp
 			HW/SystemTimers.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="HW\SI\SI_DeviceGCController.cpp" />
     <ClCompile Include="HW\SI\SI_DeviceGCSteeringWheel.cpp" />
     <ClCompile Include="HW\SI\SI_DeviceKeyboard.cpp" />
+    <ClCompile Include="HW\SI\SI_DeviceNull.cpp" />
     <ClCompile Include="HW\Sram.cpp" />
     <ClCompile Include="HW\StreamADPCM.cpp" />
     <ClCompile Include="HW\SystemTimers.cpp" />
@@ -380,6 +381,7 @@
     <ClInclude Include="HW\SI\SI_DeviceGCController.h" />
     <ClInclude Include="HW\SI\SI_DeviceGCSteeringWheel.h" />
     <ClInclude Include="HW\SI\SI_DeviceKeyboard.h" />
+    <ClInclude Include="HW\SI\SI_DeviceNull.h" />
     <ClInclude Include="HW\Sram.h" />
     <ClInclude Include="HW\StreamADPCM.h" />
     <ClInclude Include="HW\SystemTimers.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -472,6 +472,9 @@
     <ClCompile Include="HW\SI\SI_DeviceKeyboard.cpp">
       <Filter>HW %28Flipper/Hollywood%29\SI - Serial Interface</Filter>
     </ClCompile>
+    <ClCompile Include="HW\SI\SI_DeviceNull.cpp">
+      <Filter>HW %28Flipper/Hollywood%29\SI - Serial Interface</Filter>
+    </ClCompile>
     <ClCompile Include="HW\VideoInterface.cpp">
       <Filter>HW %28Flipper/Hollywood%29\VI - Video Interface</Filter>
     </ClCompile>
@@ -1070,6 +1073,9 @@
       <Filter>HW %28Flipper/Hollywood%29\SI - Serial Interface</Filter>
     </ClInclude>
     <ClInclude Include="HW\SI\SI_DeviceKeyboard.h">
+      <Filter>HW %28Flipper/Hollywood%29\SI - Serial Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="HW\SI\SI_DeviceNull.h">
       <Filter>HW %28Flipper/Hollywood%29\SI - Serial Interface</Filter>
     </ClInclude>
     <ClInclude Include="HW\VideoInterface.h">

--- a/Source/Core/Core/HW/SI/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI/SI_Device.cpp
@@ -16,8 +16,8 @@
 #include "Core/HW/SI/SI_DeviceGCController.h"
 #include "Core/HW/SI/SI_DeviceGCSteeringWheel.h"
 #include "Core/HW/SI/SI_DeviceKeyboard.h"
+#include "Core/HW/SI/SI_DeviceNull.h"
 
-// --- interface ISIDevice ---
 int ISIDevice::RunBuffer(u8* _pBuffer, int _iLength)
 {
 #ifdef _DEBUG
@@ -48,25 +48,6 @@ int ISIDevice::TransferInterval()
 {
   return 0;
 }
-
-// Stub class for saying nothing is attached, and not having to deal with null pointers :)
-class CSIDevice_Null : public ISIDevice
-{
-public:
-  CSIDevice_Null(SIDevices device, int _iDeviceNumber) : ISIDevice(device, _iDeviceNumber) {}
-  virtual ~CSIDevice_Null() {}
-  int RunBuffer(u8* _pBuffer, int _iLength) override
-  {
-    reinterpret_cast<u32*>(_pBuffer)[0] = SI_ERROR_NO_RESPONSE;
-    return 4;
-  }
-  bool GetData(u32& _Hi, u32& _Low) override
-  {
-    _Hi = 0x80000000;
-    return true;
-  }
-  void SendCommand(u32 _Cmd, u8 _Poll) override {}
-};
 
 // Check if a device class is inheriting from CSIDevice_GCController
 // The goal of this function is to avoid special casing a long list of

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
@@ -1,0 +1,29 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "Core/HW/SI/SI_DeviceNull.h"
+
+#include <cstring>
+
+CSIDevice_Null::CSIDevice_Null(SIDevices device, int device_number)
+    : ISIDevice{device, device_number}
+{
+}
+
+int CSIDevice_Null::RunBuffer(u8* buffer, int length)
+{
+  constexpr u32 reply = SI_ERROR_NO_RESPONSE;
+  std::memcpy(buffer, &reply, sizeof(reply));
+  return 4;
+}
+
+bool CSIDevice_Null::GetData(u32& hi, u32& low)
+{
+  hi = 0x80000000;
+  return true;
+}
+
+void CSIDevice_Null::SendCommand(u32 command, u8 poll)
+{
+}

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.h
@@ -1,0 +1,19 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+#include "Core/HW/SI/SI_Device.h"
+
+// Stub class for saying nothing is attached, and not having to deal with null pointers :)
+class CSIDevice_Null final : public ISIDevice
+{
+public:
+  CSIDevice_Null(SIDevices device, int device_number);
+
+  int RunBuffer(u8* buffer, int length) override;
+  bool GetData(u32& hi, u32& low) override;
+  void SendCommand(u32 command, u8 poll) override;
+};


### PR DESCRIPTION
Moved for the same reasons as the EXI dummy device in #4707