### PR TITLE
Fix building without PCH on Windows

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -45,10 +45,12 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ForEachMacros:   []
 IncludeCategories:
-  - Regex:           '^<'
+  - Regex:           '^<[Ww]indows\.h>$'
     Priority:        1
-  - Regex:           '^"'
+  - Regex:           '^<'
     Priority:        2
+  - Regex:           '^"'
+    Priority:        3
 IndentCaseLabels: false
 IndentWidth:     2
 IndentWrappedFunctionNames: false

--- a/Source/Core/AudioCommon/XAudio2Stream.h
+++ b/Source/Core/AudioCommon/XAudio2Stream.h
@@ -15,6 +15,8 @@
 
 #ifdef _WIN32
 
+#include <windows.h>
+
 struct StreamingVoiceContext;
 struct IXAudio2;
 struct IXAudio2MasteringVoice;

--- a/Source/Core/Common/Atomic_Win32.h
+++ b/Source/Core/Common/Atomic_Win32.h
@@ -8,8 +8,7 @@
 
 #include <Windows.h>
 
-#include "Common/Common.h"
-#include "Common/Intrinsics.h"
+#include "Common/CommonTypes.h"
 
 // Atomic operations are performed in a single step by the CPU. It is
 // impossible for other threads to see the operation "half-done."

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -20,12 +20,12 @@
 #include "Common/Logging/Log.h"
 
 #ifdef _WIN32
+#include <windows.h>
 #include <commdlg.h>  // for GetSaveFileName
 #include <direct.h>   // getcwd
 #include <io.h>
 #include <objbase.h>  // guid stuff
 #include <shellapi.h>
-#include <windows.h>
 #else
 #include <dirent.h>
 #include <errno.h>

--- a/Source/Core/Common/GL/GLInterface/WGL.h
+++ b/Source/Core/Common/GL/GLInterface/WGL.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <windows.h>
 #include <string>
 #include "Common/GL/GLInterfaceBase.h"
 

--- a/Source/Core/Common/Logging/ConsoleListenerWin.cpp
+++ b/Source/Core/Common/Logging/ConsoleListenerWin.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <debugapi.h>
+#include <windows.h>
 
 #include "Common/Logging/ConsoleListener.h"
 

--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -13,8 +13,8 @@
 #include "Common/MsgHandler.h"
 
 #ifdef _WIN32
-#include <psapi.h>
 #include <windows.h>
+#include <psapi.h>
 #include "Common/StringUtil.h"
 #else
 #include <stdio.h>

--- a/Source/Core/Common/Misc.cpp
+++ b/Source/Core/Common/Misc.cpp
@@ -8,6 +8,10 @@
 
 #include "Common/CommonFuncs.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 // Generic function to get last error message.
 // Call directly after the command or use the error num.
 // This function might change the error code.

--- a/Source/Core/Common/MsgHandler.cpp
+++ b/Source/Core/Common/MsgHandler.cpp
@@ -12,6 +12,10 @@
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 bool DefaultMsgHandler(const char* caption, const char* text, bool yes_no, int Style);
 static MsgAlertHandler msg_handler = DefaultMsgHandler;
 static bool AlertEnabled = true;

--- a/Source/Core/Common/Profiler.cpp
+++ b/Source/Core/Common/Profiler.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstring>

--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -11,9 +11,9 @@
 #include <string>
 
 #ifdef _WIN32
+#include <windows.h>
 #include <mmsystem.h>
 #include <sys/timeb.h>
-#include <windows.h>
 #include "Common/CommonFuncs.h"  // snprintf
 #endif
 

--- a/Source/Core/Common/Thread.cpp
+++ b/Source/Core/Common/Thread.cpp
@@ -6,7 +6,9 @@
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <unistd.h>
 #endif
 

--- a/Source/Core/Common/Timer.cpp
+++ b/Source/Core/Common/Timer.cpp
@@ -7,9 +7,9 @@
 #include <string>
 
 #ifdef _WIN32
+#include <windows.h>
 #include <mmsystem.h>
 #include <sys/timeb.h>
-#include <windows.h>
 #else
 #include <sys/time.h>
 #endif

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -6,7 +6,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
-#include <hidsdi.h>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -15,6 +14,7 @@
 // The following Windows headers must be included AFTER windows.h.
 #include <BluetoothAPIs.h>
 #include <Cfgmgr32.h>
+#include <hidsdi.h>
 #include <initguid.h>
 // initguid.h must be included before Devpkey.h
 #include <Devpkey.h>

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -9,17 +9,17 @@
 #include <unordered_map>
 #include <unordered_set>
 
-// clang-format off
 #include <windows.h>
-// The following Windows headers must be included AFTER windows.h.
 #include <BluetoothAPIs.h>
 #include <Cfgmgr32.h>
-#include <hidsdi.h>
-#include <initguid.h>
-// initguid.h must be included before Devpkey.h
-#include <Devpkey.h>
 #include <dbt.h>
+#include <hidsdi.h>
 #include <setupapi.h>
+
+// initguid.h must be included before Devpkey.h
+// clang-format off
+#include <initguid.h>
+#include <Devpkey.h>
 // clang-format on
 
 #include "Common/CommonFuncs.h"

--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include <vector>
 

--- a/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/XInputFilter.cpp
@@ -6,10 +6,8 @@
 #include <unordered_set>
 #include <vector>
 
-// clang-format off
 #include <Windows.h>
 #include <SetupAPI.h>
-// clang-format on
 
 namespace ciface
 {

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <XInput.h>
 #include <windows.h>
+#include <XInput.h>
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -70,7 +70,7 @@ bool AVIDump::Start(int w, int h)
   s_last_pts = 0;
 
   InitAVCodec();
-  bool success = CreateFile();
+  bool success = CreateVideoFile();
   if (!success)
   {
     CloseFile();
@@ -79,7 +79,7 @@ bool AVIDump::Start(int w, int h)
   return success;
 }
 
-bool AVIDump::CreateFile()
+bool AVIDump::CreateVideoFile()
 {
   AVCodec* codec = nullptr;
 

--- a/Source/Core/VideoCommon/AVIDump.h
+++ b/Source/Core/VideoCommon/AVIDump.h
@@ -9,7 +9,7 @@
 class AVIDump
 {
 private:
-  static bool CreateFile();
+  static bool CreateVideoFile();
   static void CloseFile();
   static void CheckResolution(int width, int height);
 


### PR DESCRIPTION
Adds and re-sorts includes as needed, and renames a function in AVIDump.

As an added bonus, I added smarter sorting rules to clang-format so `<windows.h>` and `<initguid.h>` will stay where they belong.