### PR TITLE
VideoBackendBase: Convert EFBAccessType and FieldType into enum classes

### DIFF
--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -2,7 +2,11 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/VideoInterface.h"
+
+#include <array>
 #include <cmath>
+#include <cstddef>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
@@ -16,7 +20,6 @@
 #include "Core/HW/ProcessorInterface.h"
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/SystemTimers.h"
-#include "Core/HW/VideoInterface.h"
 
 #include "DiscIO/Enums.h"
 
@@ -186,7 +189,7 @@ void Preset(bool _bNTSC)
   s_ticks_last_line_start = 0;
   s_half_line_count = 1;
   s_half_line_of_next_si_poll = num_half_lines_for_si_poll;  // first sampling starts at vsync
-  s_current_field = FIELD_ODD;
+  s_current_field = FieldType::Odd;
 
   UpdateParameters();
 }
@@ -638,6 +641,27 @@ u32 GetTicksPerField()
   return GetTicksPerEvenField();
 }
 
+static void LogField(FieldType field, u32 xfb_address)
+{
+  static constexpr std::array<const char*, 2> field_type_names{{"Odd", "Even"}};
+
+  static const std::array<const UVIVBlankTimingRegister*, 2> vert_timing{{
+      &m_VBlankTimingOdd, &m_VBlankTimingEven,
+  }};
+
+  const auto field_index = static_cast<size_t>(field);
+
+  DEBUG_LOG(VIDEOINTERFACE, "(VI->BeginField): Address: %.08X | WPL %u | STD %u | EQ %u | PRB %u | "
+                            "ACV %u | PSB %u | Field %s",
+            xfb_address, m_PictureConfiguration.WPL, m_PictureConfiguration.STD,
+            m_VerticalTimingRegister.EQU, vert_timing[field_index]->PRB,
+            m_VerticalTimingRegister.ACV, vert_timing[field_index]->PSB,
+            field_type_names[field_index]);
+
+  DEBUG_LOG(VIDEOINTERFACE, "HorizScaling: %04x | fbwidth %d | %u | %u", m_HorizontalScaling.Hex,
+            m_FBWidth.Hex, GetTicksPerEvenField(), GetTicksPerOddField());
+}
+
 static void BeginField(FieldType field, u64 ticks)
 {
   // Could we fit a second line of data in the stride?
@@ -652,7 +676,7 @@ static void BeginField(FieldType field, u64 ticks)
 
   u32 xfbAddr;
 
-  if (field == FieldType::FIELD_EVEN)
+  if (field == FieldType::Even)
   {
     xfbAddr = GetXFBAddressBottom();
   }
@@ -678,29 +702,14 @@ static void BeginField(FieldType field, u64 ticks)
     // has the first line. For the field with the second line, we
     // offset the xfb by (-stride_of_one_line) to get the start
     // address of the full xfb.
-    if (field == FieldType::FIELD_ODD && m_VBlankTimingOdd.PRB == m_VBlankTimingEven.PRB + 1 &&
-        xfbAddr)
+    if (field == FieldType::Odd && m_VBlankTimingOdd.PRB == m_VBlankTimingEven.PRB + 1 && xfbAddr)
       xfbAddr -= fbStride * 2;
 
-    if (field == FieldType::FIELD_EVEN && m_VBlankTimingOdd.PRB == m_VBlankTimingEven.PRB - 1 &&
-        xfbAddr)
+    if (field == FieldType::Even && m_VBlankTimingOdd.PRB == m_VBlankTimingEven.PRB - 1 && xfbAddr)
       xfbAddr -= fbStride * 2;
   }
 
-  static const char* const fieldTypeNames[] = {"Odd", "Even"};
-
-  static const UVIVBlankTimingRegister* vert_timing[] = {
-      &m_VBlankTimingOdd, &m_VBlankTimingEven,
-  };
-
-  DEBUG_LOG(VIDEOINTERFACE, "(VI->BeginField): Address: %.08X | WPL %u | STD %u | EQ %u | PRB %u | "
-                            "ACV %u | PSB %u | Field %s",
-            xfbAddr, m_PictureConfiguration.WPL, m_PictureConfiguration.STD,
-            m_VerticalTimingRegister.EQU, vert_timing[field]->PRB, m_VerticalTimingRegister.ACV,
-            vert_timing[field]->PSB, fieldTypeNames[field]);
-
-  DEBUG_LOG(VIDEOINTERFACE, "HorizScaling: %04x | fbwidth %d | %u | %u", m_HorizontalScaling.Hex,
-            m_FBWidth.Hex, GetTicksPerEvenField(), GetTicksPerOddField());
+  LogField(field, xfbAddr);
 
   // This assumes the game isn't going to change the VI registers while a
   // frame is scanning out.
@@ -726,11 +735,11 @@ void Update(u64 ticks)
   }
   if (s_half_line_count == s_even_field_first_hl)
   {
-    BeginField(FIELD_EVEN, ticks);
+    BeginField(FieldType::Even, ticks);
   }
   else if (s_half_line_count == s_odd_field_first_hl)
   {
-    BeginField(FIELD_ODD, ticks);
+    BeginField(FieldType::Odd, ticks);
   }
   else if (s_half_line_count == s_even_field_last_hl)
   {

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -112,7 +112,7 @@ static u32 EFB_Read(const u32 addr)
 {
   u32 var = 0;
   // Convert address to coordinates. It's possible that this should be done
-  // differently depending on color depth, especially regarding PEEK_COLOR.
+  // differently depending on color depth, especially regarding PeekColor.
   int x = (addr & 0xfff) >> 2;
   int y = (addr >> 12) & 0x3ff;
 
@@ -122,12 +122,12 @@ static u32 EFB_Read(const u32 addr)
   }
   else if (addr & 0x00400000)
   {
-    var = g_video_backend->Video_AccessEFB(PEEK_Z, x, y, 0);
+    var = g_video_backend->Video_AccessEFB(EFBAccessType::PeekZ, x, y, 0);
     DEBUG_LOG(MEMMAP, "EFB Z Read @ %i, %i\t= 0x%08x", x, y, var);
   }
   else
   {
-    var = g_video_backend->Video_AccessEFB(PEEK_COLOR, x, y, 0);
+    var = g_video_backend->Video_AccessEFB(EFBAccessType::PeekColor, x, y, 0);
     DEBUG_LOG(MEMMAP, "EFB Color Read @ %i, %i\t= 0x%08x", x, y, var);
   }
 
@@ -147,12 +147,12 @@ static void EFB_Write(u32 data, u32 addr)
   }
   else if (addr & 0x00400000)
   {
-    g_video_backend->Video_AccessEFB(POKE_Z, x, y, data);
+    g_video_backend->Video_AccessEFB(EFBAccessType::PokeZ, x, y, data);
     DEBUG_LOG(MEMMAP, "EFB Z Write %08x @ %i, %i", data, x, y);
   }
   else
   {
-    g_video_backend->Video_AccessEFB(POKE_COLOR, x, y, data);
+    g_video_backend->Video_AccessEFB(EFBAccessType::PokeColor, x, y, data);
     DEBUG_LOG(MEMMAP, "EFB Color Write %08x @ %i, %i", data, x, y);
   }
 }

--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -735,9 +735,19 @@ void DrawEFBPokeQuads(EFBAccessType type, const EfbPokeData* points, size_t num_
       float y1 = -float(point->y) * 2.0f / EFB_HEIGHT + 1.0f;
       float x2 = float(point->x + 1) * 2.0f / EFB_WIDTH - 1.0f;
       float y2 = -float(point->y + 1) * 2.0f / EFB_HEIGHT + 1.0f;
-      float z = (type == POKE_Z) ? (1.0f - float(point->data & 0xFFFFFF) / 16777216.0f) : 0.0f;
-      u32 col = (type == POKE_Z) ? 0 : ((point->data & 0xFF00FF00) | ((point->data >> 16) & 0xFF) |
-                                        ((point->data << 16) & 0xFF0000));
+      float z = 0.0f;
+      u32 col = 0;
+
+      if (type == EFBAccessType::PokeZ)
+      {
+        z = 1.0f - static_cast<float>(point->data & 0xFFFFFF) / 16777216.0f;
+      }
+      else
+      {
+        col = ((point->data & 0xFF00FF00) | ((point->data >> 16) & 0xFF) |
+               ((point->data << 16) & 0xFF0000));
+      }
+
       current_point_index++;
 
       // quad -> triangles

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -380,7 +380,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
   // Take the mean of the resulting dimensions; TODO: Don't use the center pixel, compute the
   // average color instead
   D3D11_RECT RectToLock;
-  if (type == PEEK_COLOR || type == PEEK_Z)
+  if (type == EFBAccessType::PeekColor || type == EFBAccessType::PeekZ)
   {
     RectToLock.left = (targetPixelRc.left + targetPixelRc.right) / 2;
     RectToLock.top = (targetPixelRc.top + targetPixelRc.bottom) / 2;
@@ -406,7 +406,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
   D3DTexture2D* source_tex;
   D3DTexture2D* read_tex;
   ID3D11Texture2D* staging_tex;
-  if (type == PEEK_COLOR)
+  if (type == EFBAccessType::PeekColor)
   {
     source_tex = FramebufferManager::GetEFBColorTexture();
     read_tex = FramebufferManager::GetEFBColorReadTexture();
@@ -421,7 +421,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 
   // Select pixel shader (we don't want to average depth samples, instead select the minimum).
   ID3D11PixelShader* copy_pixel_shader;
-  if (type == PEEK_Z && g_ActiveConfig.iMultisamples > 1)
+  if (type == EFBAccessType::PeekZ && g_ActiveConfig.iMultisamples > 1)
     copy_pixel_shader = PixelShaderCache::GetDepthResolveProgram();
   else
     copy_pixel_shader = PixelShaderCache::GetColorCopyProgram(true);
@@ -447,7 +447,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 
   // Convert the framebuffer data to the format the game is expecting to receive.
   u32 ret;
-  if (type == PEEK_COLOR)
+  if (type == EFBAccessType::PeekColor)
   {
     u32 val;
     memcpy(&val, map.pData, sizeof(val));
@@ -478,7 +478,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
     else                         /*if(alpha_read_mode.ReadMode == 0)*/
       ret = (val & 0x00FFFFFF);  // GX_READ_00
   }
-  else  // type == PEEK_Z
+  else  // type == EFBAccessType::PeekZ
   {
     float val;
     memcpy(&val, map.pData, sizeof(val));
@@ -505,7 +505,7 @@ void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num
 {
   ResetAPIState();
 
-  if (type == POKE_COLOR)
+  if (type == EFBAccessType::PokeColor)
   {
     D3D11_VIEWPORT vp =
         CD3D11_VIEWPORT(0.0f, 0.0f, (float)GetTargetWidth(), (float)GetTargetHeight());
@@ -513,7 +513,7 @@ void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num
     D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
                                      nullptr);
   }
-  else  // if (type == POKE_Z)
+  else  // if (type == EFBAccessType::PokeZ)
   {
     D3D::stateman->PushBlendState(clearblendstates[3]);
     D3D::stateman->PushDepthState(cleardepthstates[1]);
@@ -529,7 +529,7 @@ void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num
 
   D3D::DrawEFBPokeQuads(type, points, num_points);
 
-  if (type == POKE_Z)
+  if (type == EFBAccessType::PokeZ)
   {
     D3D::stateman->PopDepthState();
     D3D::stateman->PopBlendState();

--- a/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DUtil.cpp
@@ -860,9 +860,19 @@ void DrawEFBPokeQuads(EFBAccessType type, const EfbPokeData* points, size_t num_
       float y1 = -float(point->y) * 2.0f / EFB_HEIGHT + 1.0f;
       float x2 = float(point->x + 1) * 2.0f / EFB_WIDTH - 1.0f;
       float y2 = -float(point->y + 1) * 2.0f / EFB_HEIGHT + 1.0f;
-      float z = (type == POKE_Z) ? (1.0f - float(point->data & 0xFFFFFF) / 16777216.0f) : 0.0f;
-      u32 col = (type == POKE_Z) ? 0 : ((point->data & 0xFF00FF00) | ((point->data >> 16) & 0xFF) |
-                                        ((point->data << 16) & 0xFF0000));
+      float z = 0.0f;
+      u32 col = 0;
+
+      if (type == EFBAccessType::PokeZ)
+      {
+        z = 1.0f - static_cast<float>(point->data & 0xFFFFFF) / 16777216.0f;
+      }
+      else
+      {
+        col = ((point->data & 0xFF00FF00) | ((point->data >> 16) & 0xFF) |
+               ((point->data << 16) & 0xFF0000));
+      }
+
       current_point_index++;
 
       // quad -> triangles
@@ -874,9 +884,9 @@ void DrawEFBPokeQuads(EFBAccessType type, const EfbPokeData* points, size_t num_
       InitColVertex(&vertex[4], x2, y1, z, col);
       InitColVertex(&vertex[5], x2, y2, z, col);
 
-      if (type == POKE_COLOR)
+      if (type == EFBAccessType::PokeColor)
         FramebufferManager::UpdateEFBColorAccessCopy(point->x, point->y, col);
-      else if (type == POKE_Z)
+      else if (type == EFBAccessType::PokeZ)
         FramebufferManager::UpdateEFBDepthAccessCopy(point->x, point->y, z);
     }
 

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -363,7 +363,7 @@ void Renderer::SetColorMask()
 //  - GX_PokeZMode (TODO)
 u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 {
-  if (type == PEEK_COLOR)
+  if (type == EFBAccessType::PeekColor)
   {
     u32 color = FramebufferManager::ReadEFBColorAccessCopy(x, y);
 
@@ -399,7 +399,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
       return (color & 0x00FFFFFF);  // GX_READ_00
     }
   }
-  else  // if (type == PEEK_Z)
+  else  // if (type == EFBAccessType::PeekZ)
   {
     // depth buffer is inverted in the d3d backend
     float depth = 1.0f - FramebufferManager::ReadEFBDepthAccessCopy(x, y);
@@ -423,14 +423,14 @@ void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num
 {
   D3D::SetViewportAndScissor(0, 0, GetTargetWidth(), GetTargetHeight());
 
-  if (type == POKE_COLOR)
+  if (type == EFBAccessType::PokeColor)
   {
     // In the D3D12 backend, the rt/db/viewport is passed into DrawEFBPokeQuads, and set there.
     D3D::DrawEFBPokeQuads(type, points, num_points, &g_reset_blend_desc, &g_reset_depth_desc,
                           &FramebufferManager::GetEFBColorTexture()->GetRTV12(), nullptr,
                           FramebufferManager::GetEFBColorTexture()->GetMultisampled());
   }
-  else  // if (type == POKE_Z)
+  else  // if (type == EFBAccessType::PokeZ)
   {
     D3D::DrawEFBPokeQuads(type, points, num_points,
                           &s_clear_blend_descs[CLEAR_BLEND_DESC_ALL_CHANNELS_DISABLED],

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -674,7 +674,7 @@ void FramebufferManager::PokeEFB(EFBAccessType type, const EfbPokeData* points, 
 {
   g_renderer->ResetAPIState();
 
-  if (type == POKE_Z)
+  if (type == EFBAccessType::PokeZ)
   {
     glDepthMask(GL_TRUE);
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -74,7 +74,7 @@ static const u32 EFB_CACHE_HEIGHT = (EFB_HEIGHT + EFB_CACHE_RECT_SIZE - 1) / EFB
 static bool s_efbCacheValid[2][EFB_CACHE_WIDTH * EFB_CACHE_HEIGHT];
 static bool s_efbCacheIsCleared = false;
 static std::vector<u32>
-    s_efbCache[2][EFB_CACHE_WIDTH * EFB_CACHE_HEIGHT];  // 2 for PEEK_Z and PEEK_COLOR
+    s_efbCache[2][EFB_CACHE_WIDTH * EFB_CACHE_HEIGHT];  // 2 for PeekZ and PeekColor
 
 static void APIENTRY ErrorCallback(GLenum source, GLenum type, GLuint id, GLenum severity,
                                    GLsizei length, const char* message, const void* userParam)
@@ -841,7 +841,7 @@ void ClearEFBCache()
 void Renderer::UpdateEFBCache(EFBAccessType type, u32 cacheRectIdx, const EFBRectangle& efbPixelRc,
                               const TargetRectangle& targetPixelRc, const void* data)
 {
-  u32 cacheType = (type == PEEK_Z ? 0 : 1);
+  const u32 cacheType = (type == EFBAccessType::PeekZ ? 0 : 1);
 
   if (!s_efbCache[cacheType][cacheRectIdx].size())
     s_efbCache[cacheType][cacheRectIdx].resize(EFB_CACHE_RECT_SIZE * EFB_CACHE_RECT_SIZE);
@@ -862,7 +862,7 @@ void Renderer::UpdateEFBCache(EFBAccessType type, u32 cacheRectIdx, const EFBRec
       u32 xPixel = (EFBToScaledX(xEFB) + EFBToScaledX(xEFB + 1)) / 2;
       u32 xData = xPixel - targetPixelRc.left;
       u32 value;
-      if (type == PEEK_Z)
+      if (type == EFBAccessType::PeekZ)
       {
         float* ptr = (float*)data;
         value = MathUtil::Clamp<u32>((u32)(ptr[yData * targetPixelRcWidth + xData] * 16777216.0f),
@@ -901,7 +901,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 
   EFBRectangle efbPixelRc;
 
-  if (type == PEEK_COLOR || type == PEEK_Z)
+  if (type == EFBAccessType::PeekColor || type == EFBAccessType::PeekZ)
   {
     // Get the rectangular target region containing the EFB pixel
     efbPixelRc.left = (x / EFB_CACHE_RECT_SIZE) * EFB_CACHE_RECT_SIZE;
@@ -924,7 +924,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
   // TODO (FIX) : currently, AA path is broken/offset and doesn't return the correct pixel
   switch (type)
   {
-  case PEEK_Z:
+  case EFBAccessType::PeekZ:
   {
     if (!s_efbCacheValid[0][cacheRectIdx])
     {
@@ -958,7 +958,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
     return z;
   }
 
-  case PEEK_COLOR:  // GXPeekARGB
+  case EFBAccessType::PeekColor:  // GXPeekARGB
   {
     // Although it may sound strange, this really is A8R8G8B8 and not RGBA or 24-bit...
 

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -148,12 +148,12 @@ u32 SWRenderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)
 
   switch (type)
   {
-  case PEEK_Z:
+  case EFBAccessType::PeekZ:
   {
     value = EfbInterface::GetDepth(x, y);
     break;
   }
-  case PEEK_COLOR:
+  case EFBAccessType::PeekColor:
   {
     const u32 color = EfbInterface::GetColor(x, y);
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -179,7 +179,7 @@ void Renderer::RenderText(const std::string& text, int left, int top, u32 color)
 
 u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 {
-  if (type == PEEK_COLOR)
+  if (type == EFBAccessType::PeekColor)
   {
     u32 color = FramebufferManager::GetInstance()->PeekEFBColor(x, y);
 
@@ -215,7 +215,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
       return color & 0x00FFFFFF;  // GX_READ_00
     }
   }
-  else  // if (type == PEEK_Z)
+  else  // if (type == EFBAccessType::PeekZ)
   {
     // Depth buffer is inverted for improved precision near far plane
     float depth = 1.0f - FramebufferManager::GetInstance()->PeekEFBDepth(x, y);
@@ -237,7 +237,7 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
 
 void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points)
 {
-  if (type == POKE_COLOR)
+  if (type == EFBAccessType::PokeColor)
   {
     for (size_t i = 0; i < num_points; i++)
     {
@@ -249,7 +249,7 @@ void Renderer::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num
       FramebufferManager::GetInstance()->PokeEFBColor(point.x, point.y, color);
     }
   }
-  else  // if (type == POKE_Z)
+  else  // if (type == EFBAccessType::PokeZ)
   {
     for (size_t i = 0; i < num_points; i++)
     {

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -31,7 +31,8 @@ void AsyncRequests::PullEventsInternal()
     {
       m_merged_efb_pokes.clear();
       Event first_event = m_queue.front();
-      EFBAccessType t = first_event.type == Event::EFB_POKE_COLOR ? POKE_COLOR : POKE_Z;
+      const auto t = first_event.type == Event::EFB_POKE_COLOR ? EFBAccessType::PokeColor :
+                                                                 EFBAccessType::PokeZ;
 
       do
       {
@@ -114,23 +115,24 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
   case Event::EFB_POKE_COLOR:
   {
     EfbPokeData poke = {e.efb_poke.x, e.efb_poke.y, e.efb_poke.data};
-    g_renderer->PokeEFB(POKE_COLOR, &poke, 1);
+    g_renderer->PokeEFB(EFBAccessType::PokeColor, &poke, 1);
   }
   break;
 
   case Event::EFB_POKE_Z:
   {
     EfbPokeData poke = {e.efb_poke.x, e.efb_poke.y, e.efb_poke.data};
-    g_renderer->PokeEFB(POKE_Z, &poke, 1);
+    g_renderer->PokeEFB(EFBAccessType::PokeZ, &poke, 1);
   }
   break;
 
   case Event::EFB_PEEK_COLOR:
-    *e.efb_peek.data = g_renderer->AccessEFB(PEEK_COLOR, e.efb_peek.x, e.efb_peek.y, 0);
+    *e.efb_peek.data =
+        g_renderer->AccessEFB(EFBAccessType::PeekColor, e.efb_peek.x, e.efb_peek.y, 0);
     break;
 
   case Event::EFB_PEEK_Z:
-    *e.efb_peek.data = g_renderer->AccessEFB(PEEK_Z, e.efb_peek.x, e.efb_peek.y, 0);
+    *e.efb_peek.data = g_renderer->AccessEFB(EFBAccessType::PeekZ, e.efb_peek.x, e.efb_peek.y, 0);
     break;
 
   case Event::SWAP_EVENT:

--- a/Source/Core/VideoCommon/MainBase.cpp
+++ b/Source/Core/VideoCommon/MainBase.cpp
@@ -72,11 +72,11 @@ u32 VideoBackendBase::Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 Inpu
     return 0;
   }
 
-  if (type == POKE_COLOR || type == POKE_Z)
+  if (type == EFBAccessType::PokeColor || type == EFBAccessType::PokeZ)
   {
     AsyncRequests::Event e;
-    e.type = type == POKE_COLOR ? AsyncRequests::Event::EFB_POKE_COLOR :
-                                  AsyncRequests::Event::EFB_POKE_Z;
+    e.type = type == EFBAccessType::PokeColor ? AsyncRequests::Event::EFB_POKE_COLOR :
+                                                AsyncRequests::Event::EFB_POKE_Z;
     e.time = 0;
     e.efb_poke.data = InputData;
     e.efb_poke.x = x;
@@ -88,8 +88,8 @@ u32 VideoBackendBase::Video_AccessEFB(EFBAccessType type, u32 x, u32 y, u32 Inpu
   {
     AsyncRequests::Event e;
     u32 result;
-    e.type = type == PEEK_COLOR ? AsyncRequests::Event::EFB_PEEK_COLOR :
-                                  AsyncRequests::Event::EFB_PEEK_Z;
+    e.type = type == EFBAccessType::PeekColor ? AsyncRequests::Event::EFB_PEEK_COLOR :
+                                                AsyncRequests::Event::EFB_PEEK_Z;
     e.time = 0;
     e.efb_peek.x = x;
     e.efb_peek.y = y;

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -17,10 +17,10 @@ class Mapping;
 }
 class PointerWrap;
 
-enum FieldType
+enum class FieldType
 {
-  FIELD_ODD = 0,
-  FIELD_EVEN = 1,
+  Odd,
+  Even,
 };
 
 enum class EFBAccessType

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -23,12 +23,12 @@ enum FieldType
   FIELD_EVEN = 1,
 };
 
-enum EFBAccessType
+enum class EFBAccessType
 {
-  PEEK_Z = 0,
-  POKE_Z,
-  PEEK_COLOR,
-  POKE_COLOR
+  PeekZ,
+  PokeZ,
+  PeekColor,
+  PokeColor
 };
 
 struct SCPFifoStruct


### PR DESCRIPTION
Gets a few constants out of global scope, as well as allowing the enum to be forward-declared.