### PR TITLE
ControllerEmu: Add missing virtual destructor to BooleanSetting

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu.cpp
@@ -103,6 +103,8 @@ void ControllerEmu::ControlGroup::LoadConfig(IniFile::Section* sec, const std::s
   }
 }
 
+ControllerEmu::ControlGroup::BooleanSetting::~BooleanSetting() = default;
+
 void ControllerEmu::LoadConfig(IniFile::Section* sec, const std::string& base)
 {
   std::string defdev = default_device.ToString();

--- a/Source/Core/InputCommon/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu.h
@@ -107,6 +107,7 @@ public:
           : m_type(setting_type), m_name(setting_name), m_default_value(default_value)
       {
       }
+      virtual ~BooleanSetting();
 
       virtual bool GetValue() const { return m_value; }
       virtual void SetValue(bool value) { m_value = value; }


### PR DESCRIPTION
Makes destruction well-defined for `BackgroundInputSetting`, as any created instances of it are passed to a `BooleanSetting` collection. Without a virtual destructor, deleting a derived class through a pointer to the base class is undefined behavior.