### PR TITLE
TMDReader: Add a way to get the required IOS version

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -51,6 +51,11 @@ bool TMDReader::IsValid() const
   return true;
 }
 
+u64 TMDReader::GetIOSId() const
+{
+  return Common::swap64(m_bytes.data() + 0x184);
+}
+
 u64 TMDReader::GetTitleId() const
 {
   return Common::swap64(m_bytes.data() + 0x18C);

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -29,6 +29,7 @@ public:
 
   bool IsValid() const;
 
+  u64 GetIOSId() const;
   u64 GetTitleId() const;
 
   struct Content


### PR DESCRIPTION
Split from #4723. Getting the required IOS version from the TMD will be useful for setting up the magic variables (#4723) and for printing the IOS version required by a title in the UI.