### PR TITLE
DiscIO: Fix out-of-bounds access in NANDContentDataBuffer

### DIFF
--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -196,7 +196,7 @@ bool CNANDContentDataBuffer::GetRange(u32 start, u32 size, u8* buffer)
   if (start + size > m_buffer.size())
     return false;
 
-  std::copy(&m_buffer[start], &m_buffer[start + size], buffer);
+  std::copy_n(&m_buffer[start], size, buffer);
   return true;
 }
 


### PR DESCRIPTION
Accessing buffer[start + size] when buffer.size() == size triggers an error (and a crash) in debug builds. Using std::copy_n fixes this.