### PR TITLE
PatchEngine: Fix potential crashing during stack probe

### DIFF
--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -223,11 +223,7 @@ static bool IsStackSane()
     return false;
 
   // Check the link register makes sense (that it points to a valid IBAT address)
-  auto insn = PowerPC::TryReadInstruction(PowerPC::HostRead_U32(next_SP + 4));
-  if (!insn.valid || !insn.hex)
-    return false;
-
-  return true;
+  return PowerPC::HostIsInstructionRAMAddress(PowerPC::HostRead_U32(next_SP + 4));
 }
 
 bool ApplyFramePatches()

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -220,6 +220,8 @@ void HostWrite_U64(const u64 var, const u32 address);
 // Returns whether a read or write to the given address will resolve to a RAM
 // access given the current CPU state.
 bool HostIsRAMAddress(const u32 address);
+// Same as HostIsRAMAddress, but uses IBAT instead of DBAT.
+bool HostIsInstructionRAMAddress(u32 address);
 
 std::string HostGetString(u32 em_address, size_t size = 0);
 


### PR DESCRIPTION
`TryReadInstruction` doesn't validate the address it translates so if a virtual address is successfully translated to an invalid physical address then `Memory::GetPointer` will return nullptr resulting in a nullptr dereference in a `Memory::Read_U32` from inside the instruction cache (requires `HID0.ILOCK` to crash).