### PR TITLE
Make the "Auto Adjust Window Size" option respect the current game's aspect ratio.

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -476,6 +476,21 @@ float Renderer::CalculateDrawAspectRatio(int target_width, int target_height)
   }
 }
 
+std::tuple<float, float> Renderer::ScaleToDisplayAspectRatio(const int width, const int height)
+{
+  // Scale either the width or height depending the content aspect ratio.
+  // This way we preserve as much resolution as possible when scaling.
+  float ratio = CalculateDrawAspectRatio(width, height);
+  if (ratio >= 1.0f)
+  {
+    // Preserve horizontal resolution, scale vertically.
+    return std::make_tuple(static_cast<float>(width), static_cast<float>(height) * ratio);
+  }
+
+  // Preserve vertical resolution, scale horizontally.
+  return std::make_tuple(static_cast<float>(width) / ratio, static_cast<float>(height));
+}
+
 TargetRectangle Renderer::CalculateFrameDumpDrawRectangle()
 {
   // No point including any borders in the frame dump image, since they'd have to be cropped anyway.
@@ -498,22 +513,8 @@ TargetRectangle Renderer::CalculateFrameDumpDrawRectangle()
   unsigned int efb_width, efb_height;
   g_framebuffer_manager->GetTargetSize(&efb_width, &efb_height);
 
-  // Scale either the width or height depending the content aspect ratio.
-  // This way we preserve as much resolution as possible when scaling.
-  float ratio = CalculateDrawAspectRatio(efb_width, efb_height);
   float draw_width, draw_height;
-  if (ratio >= 1.0f)
-  {
-    // Preserve horizontal resolution, scale vertically.
-    draw_width = static_cast<float>(efb_width);
-    draw_height = static_cast<float>(efb_height) * ratio;
-  }
-  else
-  {
-    // Preserve vertical resolution, scale horizontally.
-    draw_width = static_cast<float>(efb_width) / ratio;
-    draw_height = static_cast<float>(efb_height);
-  }
+  std::tie(draw_width, draw_height) = ScaleToDisplayAspectRatio(efb_width, efb_height);
 
   rc.right = static_cast<int>(std::ceil(draw_width));
   rc.bottom = static_cast<int>(std::ceil(draw_height));

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -586,7 +586,12 @@ void Renderer::UpdateDrawRectangle()
   float Ratio = CalculateDrawAspectRatio(s_backbuffer_width, s_backbuffer_height);
   if (g_ActiveConfig.iAspectRatio != ASPECT_STRETCH)
   {
-    if (Ratio > 1.0f)
+    if (Ratio >= 0.995f && Ratio <= 1.005f)
+    {
+      // If we're very close already, don't scale.
+      Ratio = 1.0f;
+    }
+    else if (Ratio > 1.0f)
     {
       // Scale down and center in the X direction.
       FloatGLWidth /= Ratio;
@@ -647,6 +652,38 @@ void Renderer::SetWindowSize(int width, int height)
 
   // Scale the window size by the EFB scale.
   CalculateTargetScale(width, height, &width, &height);
+
+  float scaled_width, scaled_height;
+  std::tie(scaled_width, scaled_height) = ScaleToDisplayAspectRatio(width, height);
+
+  if (g_ActiveConfig.bCrop)
+  {
+    // Force 4:3 or 16:9 by cropping the image.
+    float current_aspect = scaled_width / scaled_height;
+    float expected_aspect =
+        (g_ActiveConfig.iAspectRatio == ASPECT_ANALOG_WIDE ||
+         (g_ActiveConfig.iAspectRatio != ASPECT_ANALOG && Core::g_aspect_wide)) ?
+            (16.0f / 9.0f) :
+            (4.0f / 3.0f);
+    if (current_aspect > expected_aspect)
+    {
+      // keep height, crop width
+      scaled_width = scaled_height * expected_aspect;
+    }
+    else
+    {
+      // keep width, crop height
+      scaled_height = scaled_width / expected_aspect;
+    }
+  }
+
+  width = static_cast<int>(std::ceil(scaled_width));
+  height = static_cast<int>(std::ceil(scaled_height));
+
+  // UpdateDrawRectangle() makes sure that the rendered image is divisible by four for video
+  // encoders, so do that here too to match it
+  width -= width % 4;
+  height -= height % 4;
 
   Host_RequestRenderWindowSize(width, height);
 }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -94,6 +95,7 @@ public:
 
   static const TargetRectangle& GetTargetRectangle() { return target_rc; }
   static float CalculateDrawAspectRatio(int target_width, int target_height);
+  static std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height);
   static TargetRectangle CalculateFrameDumpDrawRectangle();
   static void UpdateDrawRectangle();
 


### PR DESCRIPTION
A friend asked me if it was possible to make Dolphin auto-resize the window in windowed mode in a way that hides all the black bars and just displays the game. I told him that, yeah, you can do that, it's a checkbox in the graphics settings. But, as it turns out, there are some big issues with this! Most pressingly, if you play a widescreen game, you get big letterboxes.

At first, I thought the option just always assumed a 4:3 aspect ratio, but as I dug into the code, there's actually more going on here.

The window size is set by `Renderer::SetWindowSize()`, which gets the current framebuffer size, scales it according to internal resolution, then requests the host window to resize itself to the result. This sounds reasonable at first glance, but is not quite right. The framebuffer size is not yet stretched to the proper aspect ratio. This results in the situation that every game whose internal framebuffer aspect ratio is different from the final display aspect ratio gets unnecessarily letter- or pillarboxed, and sometimes even scaled down in both directions.

The solution to this is mostly straightforward: Instead of requesting the window size to be the framebuffer size, first scale the width or height so that it matches the desired display aspect ratio. If the Crop option is selected, additionally reduce the requested width or height to match a standard 4:3 or 16:9.

There's a minor problem with this approach though. `Renderer::UpdateDrawRectangle()` attempts to scale and translate the rendered image so that it fits into the window's framebuffer without cutting off anything. But since our width and height has to be in pixels rather than a real number, the calculation can end up ever so slightly scaling the image trying to fit it into the already correctly sized window, which results in a couple pixel rows (or columns I guess, but I've only seen rows) of black. This is not nice. I've tried to work around it by checking if the aspect ratio difference between the window aspect ratio and the game aspect ratio is very small, and if so not doing any scaling, but I'm not super happy with that approach. If anyone can think of a better way to detect that feel free to suggest something.

This fixes [issue 7706](https://bugs.dolphin-emu.org/issues/7706).

Some comparison shots:

Before, without the 'Crop' option:

[![img](http://i.imgur.com/AM3a0l1m.png)](http://i.imgur.com/AM3a0l1.png) [![img](http://i.imgur.com/fHGL4shm.png)](http://i.imgur.com/fHGL4sh.png) [![img](http://i.imgur.com/8tmuYnQm.png)](http://i.imgur.com/8tmuYnQ.png)

Before, with the 'Crop' option:

[![img](http://i.imgur.com/9ZFho42m.png)](http://i.imgur.com/9ZFho42.png) [![img](http://i.imgur.com/hypuktpm.png)](http://i.imgur.com/hypuktp.png) [![img](http://i.imgur.com/9WIz08Ym.png)](http://i.imgur.com/9WIz08Y.png)

With this PR, without the 'Crop' option:

[![img](http://i.imgur.com/aofrdqsm.png)](http://i.imgur.com/aofrdqs.png) [![img](http://i.imgur.com/vANrliBm.png)](http://i.imgur.com/vANrliB.png) [![img](http://i.imgur.com/FPylDvIm.png)](http://i.imgur.com/FPylDvI.png)

With this PR, with the 'Crop' option:

[![img](http://i.imgur.com/5zkDg7lm.png)](http://i.imgur.com/5zkDg7l.png) [![img](http://i.imgur.com/mR1BWD3m.png)](http://i.imgur.com/mR1BWD3.png) [![img](http://i.imgur.com/t35drJOm.png)](http://i.imgur.com/t35drJO.png)
