### PR TITLE
JitCache: Split off JIT call from dispatcher.

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.cpp
@@ -36,6 +36,12 @@ void CachedInterpreter::Shutdown()
 void CachedInterpreter::ExecuteOneBlock()
 {
   const u8* normal_entry = m_block_cache.Dispatch();
+  if (!normal_entry)
+  {
+    Jit(PC);
+    return;
+  }
+
   const Instruction* code = reinterpret_cast<const Instruction*>(normal_entry);
 
   for (; code->type != Instruction::INSTRUCTION_ABORT; ++code)

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -12,7 +12,7 @@
 
 JitBase* g_jit;
 
-void Jit(u32 em_address)
+void JitTrampoline(u32 em_address)
 {
   g_jit->Jit(em_address);
 }

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -125,7 +125,7 @@ public:
   virtual bool HandleStackFault() { return false; }
 };
 
-void Jit(u32 em_address);
+void JitTrampoline(u32 em_address);
 
 // Merged routines that should be moved somewhere better
 u32 Helper_Mask(u8 mb, u8 me);

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -161,7 +161,7 @@ private:
   void UnlinkBlock(const JitBlock& block);
   void DestroyBlock(JitBlock& block);
 
-  void MoveBlockIntoFastCache(u32 em_address, u32 msr);
+  JitBlock* MoveBlockIntoFastCache(u32 em_address, u32 msr);
 
   // Fast but risky block lookup based on fast_block_map.
   size_t FastLookupIndexForAddress(u32 address);


### PR DESCRIPTION
This avoid flushing the BLR optimization stack on fast_block_cache misses.