### PR TITLE
DSPJitRegCache: Make GetReg return by value

### DIFF
--- a/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
@@ -79,8 +79,7 @@ void DSPEmitter::andcf(const UDSPInstruction opc)
     //			g_dsp.r.sr |= SR_LOGIC_ZERO;
     //		else
     //			g_dsp.r.sr &= ~SR_LOGIC_ZERO;
-    OpArg sr_reg;
-    gpr.GetReg(DSP_REG_SR, sr_reg);
+    const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
     AND(16, R(RAX), Imm16(imm));
     CMP(16, R(RAX), Imm16(imm));
     FixupBranch notLogicZero = J_CC(CC_NE);
@@ -115,8 +114,7 @@ void DSPEmitter::andf(const UDSPInstruction opc)
     //			g_dsp.r.sr |= SR_LOGIC_ZERO;
     //		else
     //			g_dsp.r.sr &= ~SR_LOGIC_ZERO;
-    OpArg sr_reg;
-    gpr.GetReg(DSP_REG_SR, sr_reg);
+    const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
     TEST(16, R(RAX), Imm16(imm));
     FixupBranch notLogicZero = J_CC(CC_NE);
     OR(16, sr_reg, Imm16(SR_LOGIC_ZERO));

--- a/Source/Core/Core/DSP/Jit/DSPJitCCUtil.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitCCUtil.cpp
@@ -19,8 +19,7 @@ namespace x86
 // Clobbers RDX
 void DSPEmitter::Update_SR_Register(Gen::X64Reg val)
 {
-  OpArg sr_reg;
-  gpr.GetReg(DSP_REG_SR, sr_reg);
+  const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
   //	// 0x04
   //	if (_Value == 0) g_dsp.r[DSP_REG_SR] |= SR_ARITH_ZERO;
   TEST(64, R(val), R(val));
@@ -63,8 +62,7 @@ void DSPEmitter::Update_SR_Register(Gen::X64Reg val)
 void DSPEmitter::Update_SR_Register64(Gen::X64Reg val)
 {
   //	g_dsp.r[DSP_REG_SR] &= ~SR_CMP_MASK;
-  OpArg sr_reg;
-  gpr.GetReg(DSP_REG_SR, sr_reg);
+  const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
   AND(16, sr_reg, Imm16(~SR_CMP_MASK));
   gpr.PutReg(DSP_REG_SR);
   Update_SR_Register(val);
@@ -75,8 +73,7 @@ void DSPEmitter::Update_SR_Register64(Gen::X64Reg val)
 // Clobbers RDX
 void DSPEmitter::Update_SR_Register64_Carry(X64Reg val, X64Reg carry_ovfl, bool carry_eq)
 {
-  OpArg sr_reg;
-  gpr.GetReg(DSP_REG_SR, sr_reg);
+  const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
   //	g_dsp.r[DSP_REG_SR] &= ~SR_CMP_MASK;
   AND(16, sr_reg, Imm16(~SR_CMP_MASK));
 
@@ -115,8 +112,7 @@ void DSPEmitter::Update_SR_Register64_Carry(X64Reg val, X64Reg carry_ovfl, bool 
 // In: RAX: s64 _Value
 void DSPEmitter::Update_SR_Register16(X64Reg val)
 {
-  OpArg sr_reg;
-  gpr.GetReg(DSP_REG_SR, sr_reg);
+  const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
   AND(16, sr_reg, Imm16(~SR_CMP_MASK));
 
   //	// 0x04
@@ -152,8 +148,7 @@ void DSPEmitter::Update_SR_Register16(X64Reg val)
 // Clobbers RCX
 void DSPEmitter::Update_SR_Register16_OverS32(Gen::X64Reg val)
 {
-  OpArg sr_reg;
-  gpr.GetReg(DSP_REG_SR, sr_reg);
+  const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
   AND(16, sr_reg, Imm16(~SR_CMP_MASK));
 
   //	// 0x10

--- a/Source/Core/Core/DSP/Jit/DSPJitMisc.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitMisc.cpp
@@ -118,8 +118,7 @@ void DSPEmitter::addarn(const UDSPInstruction opc)
 void DSPEmitter::setCompileSR(u16 bit)
 {
   //	g_dsp.r[DSP_REG_SR] |= bit
-  OpArg sr_reg;
-  gpr.GetReg(DSP_REG_SR, sr_reg);
+  const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
   OR(16, sr_reg, Imm16(bit));
   gpr.PutReg(DSP_REG_SR);
 
@@ -129,8 +128,7 @@ void DSPEmitter::setCompileSR(u16 bit)
 void DSPEmitter::clrCompileSR(u16 bit)
 {
   //	g_dsp.r[DSP_REG_SR] &= bit
-  OpArg sr_reg;
-  gpr.GetReg(DSP_REG_SR, sr_reg);
+  const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
   AND(16, sr_reg, Imm16(~bit));
   gpr.PutReg(DSP_REG_SR);
 

--- a/Source/Core/Core/DSP/Jit/DSPJitMultiplier.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitMultiplier.cpp
@@ -28,8 +28,7 @@ void DSPEmitter::multiply()
 
   //	Conditionally multiply by 2.
   //	if ((g_dsp.r.sr & SR_MUL_MODIFY) == 0)
-  OpArg sr_reg;
-  gpr.GetReg(DSP_REG_SR, sr_reg);
+  const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
   TEST(16, sr_reg, Imm16(SR_MUL_MODIFY));
   FixupBranch noMult2 = J_CC(CC_NZ);
   //		prod <<= 1;
@@ -81,8 +80,7 @@ void DSPEmitter::multiply_mulx(u8 axh0, u8 axh1)
   //		result = dsp_multiply(val1, val2, 0); // unsigned support OFF if both ax?.h regs are used
 
   //	if ((sign == 1) && (g_dsp.r.sr & SR_MUL_UNSIGNED)) //unsigned
-  OpArg sr_reg;
-  gpr.GetReg(DSP_REG_SR, sr_reg);
+  const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
   TEST(16, sr_reg, Imm16(SR_MUL_UNSIGNED));
   FixupBranch unsignedMul = J_CC(CC_NZ);
   //		prod = (s16)a * (s16)b; //signed

--- a/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
@@ -689,7 +689,7 @@ void DSPJitRegCache::MovToMemory(size_t reg)
   m_regs[reg].loc = tmp;
 }
 
-void DSPJitRegCache::GetReg(int reg, OpArg& oparg, bool load)
+OpArg DSPJitRegCache::GetReg(int reg, bool load)
 {
   int real_reg;
   int shift;
@@ -723,7 +723,7 @@ void DSPJitRegCache::GetReg(int reg, OpArg& oparg, bool load)
   _assert_msg_(DSPLLE, m_regs[real_reg].loc.IsSimpleReg(), "did not get host reg for %d", reg);
 
   RotateHostReg(real_reg, shift, load);
-  oparg = m_regs[real_reg].loc;
+  const OpArg oparg = m_regs[real_reg].loc;
   m_regs[real_reg].used = true;
 
   // do some register specific fixup
@@ -742,6 +742,8 @@ void DSPJitRegCache::GetReg(int reg, OpArg& oparg, bool load)
   default:
     break;
   }
+
+  return oparg;
 }
 
 void DSPJitRegCache::PutReg(int reg, bool dirty)
@@ -808,8 +810,7 @@ void DSPJitRegCache::PutReg(int reg, bool dirty)
 
 void DSPJitRegCache::ReadReg(int sreg, X64Reg host_dreg, DSPJitSignExtend extend)
 {
-  OpArg reg;
-  GetReg(sreg, reg);
+  const OpArg reg = GetReg(sreg);
 
   switch (m_regs[sreg].size)
   {
@@ -853,8 +854,7 @@ void DSPJitRegCache::ReadReg(int sreg, X64Reg host_dreg, DSPJitSignExtend extend
 
 void DSPJitRegCache::WriteReg(int dreg, OpArg arg)
 {
-  OpArg reg;
-  GetReg(dreg, reg, false);
+  const OpArg reg = GetReg(dreg, false);
   if (arg.IsImm())
   {
     switch (m_regs[dreg].size)

--- a/Source/Core/Core/DSP/Jit/DSPJitRegCache.h
+++ b/Source/Core/Core/DSP/Jit/DSPJitRegCache.h
@@ -119,7 +119,7 @@ public:
   // Gives no SCALE_RIP with abs(offset) >= 0x80000000
   // 32/64 bit writes allowed when the register has a _64 or _32 suffix
   // only 16 bit writes allowed without any suffix.
-  void GetReg(int reg, Gen::OpArg& oparg, bool load = true);
+  Gen::OpArg GetReg(int reg, bool load = true);
   // Done with all usages of OpArg above
   void PutReg(int reg, bool dirty = true);
 

--- a/Source/Core/Core/DSP/Jit/DSPJitUtil.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitUtil.cpp
@@ -145,8 +145,7 @@ void DSPEmitter::dsp_conditional_extend_accum(int reg)
   case DSP_REG_ACM0:
   case DSP_REG_ACM1:
   {
-    OpArg sr_reg;
-    gpr.GetReg(DSP_REG_SR, sr_reg);
+    const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
     DSPJitRegCache c(gpr);
     TEST(16, sr_reg, Imm16(SR_40_MODE_BIT));
     FixupBranch not_40bit = J_CC(CC_Z, true);
@@ -175,8 +174,7 @@ void DSPEmitter::dsp_conditional_extend_accum_imm(int reg, u16 val)
   case DSP_REG_ACM0:
   case DSP_REG_ACM1:
   {
-    OpArg sr_reg;
-    gpr.GetReg(DSP_REG_SR, sr_reg);
+    const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
     DSPJitRegCache c(gpr);
     TEST(16, sr_reg, Imm16(SR_40_MODE_BIT));
     FixupBranch not_40bit = J_CC(CC_Z, true);
@@ -250,10 +248,8 @@ void DSPEmitter::dsp_op_read_reg(int reg, Gen::X64Reg host_dreg, DSPJitSignExten
   case DSP_REG_ACM1:
   {
     // we already know this is ACCM0 or ACCM1
-    OpArg acc_reg;
-    gpr.GetReg(reg - DSP_REG_ACM0 + DSP_REG_ACC0_64, acc_reg);
-    OpArg sr_reg;
-    gpr.GetReg(DSP_REG_SR, sr_reg);
+    const OpArg acc_reg = gpr.GetReg(reg - DSP_REG_ACM0 + DSP_REG_ACC0_64);
+    const OpArg sr_reg = gpr.GetReg(DSP_REG_SR);
 
     DSPJitRegCache c(gpr);
     TEST(16, sr_reg, Imm16(SR_40_MODE_BIT));
@@ -311,13 +307,13 @@ void DSPEmitter::dsp_op_read_reg(int reg, Gen::X64Reg host_dreg, DSPJitSignExten
 // EDX = g_dsp.r.wr[reg]
 void DSPEmitter::increment_addr_reg(int reg)
 {
-  OpArg ar_reg;
-  OpArg wr_reg;
-  gpr.GetReg(DSP_REG_WR0 + reg, wr_reg);
+  const OpArg wr_reg = gpr.GetReg(DSP_REG_WR0 + reg);
   MOVZX(32, 16, EDX, wr_reg);
   gpr.PutReg(DSP_REG_WR0 + reg, false);
-  gpr.GetReg(DSP_REG_AR0 + reg, ar_reg);
+
+  const OpArg ar_reg = gpr.GetReg(DSP_REG_AR0 + reg);
   MOVZX(32, 16, EAX, ar_reg);
+
   X64Reg tmp1 = gpr.GetFreeXReg();
   // u32 nar = ar + 1;
   MOV(32, R(tmp1), R(EAX));
@@ -344,12 +340,11 @@ void DSPEmitter::increment_addr_reg(int reg)
 // EDX = g_dsp.r.wr[reg]
 void DSPEmitter::decrement_addr_reg(int reg)
 {
-  OpArg ar_reg;
-  OpArg wr_reg;
-  gpr.GetReg(DSP_REG_WR0 + reg, wr_reg);
+  const OpArg wr_reg = gpr.GetReg(DSP_REG_WR0 + reg);
   MOVZX(32, 16, EDX, wr_reg);
   gpr.PutReg(DSP_REG_WR0 + reg, false);
-  gpr.GetReg(DSP_REG_AR0 + reg, ar_reg);
+
+  const OpArg ar_reg = gpr.GetReg(DSP_REG_AR0 + reg);
   MOVZX(32, 16, EAX, ar_reg);
 
   X64Reg tmp1 = gpr.GetFreeXReg();
@@ -381,16 +376,15 @@ void DSPEmitter::decrement_addr_reg(int reg)
 // ECX = g_dsp.r.ix[reg]
 void DSPEmitter::increase_addr_reg(int reg, int _ix_reg)
 {
-  OpArg ar_reg;
-  OpArg wr_reg;
-  OpArg ix_reg;
-  gpr.GetReg(DSP_REG_WR0 + reg, wr_reg);
+  const OpArg wr_reg = gpr.GetReg(DSP_REG_WR0 + reg);
   MOVZX(32, 16, EDX, wr_reg);
   gpr.PutReg(DSP_REG_WR0 + reg, false);
-  gpr.GetReg(DSP_REG_IX0 + _ix_reg, ix_reg);
+
+  const OpArg ix_reg = gpr.GetReg(DSP_REG_IX0 + _ix_reg);
   MOVSX(32, 16, ECX, ix_reg);
   gpr.PutReg(DSP_REG_IX0 + _ix_reg, false);
-  gpr.GetReg(DSP_REG_AR0 + reg, ar_reg);
+
+  const OpArg ar_reg = gpr.GetReg(DSP_REG_AR0 + reg);
   MOVZX(32, 16, EAX, ar_reg);
 
   X64Reg tmp1 = gpr.GetFreeXReg();
@@ -449,16 +443,15 @@ void DSPEmitter::increase_addr_reg(int reg, int _ix_reg)
 // ECX = g_dsp.r.ix[reg]
 void DSPEmitter::decrease_addr_reg(int reg)
 {
-  OpArg ar_reg;
-  OpArg wr_reg;
-  OpArg ix_reg;
-  gpr.GetReg(DSP_REG_WR0 + reg, wr_reg);
+  const OpArg wr_reg = gpr.GetReg(DSP_REG_WR0 + reg);
   MOVZX(32, 16, EDX, wr_reg);
   gpr.PutReg(DSP_REG_WR0 + reg, false);
-  gpr.GetReg(DSP_REG_IX0 + reg, ix_reg);
+
+  const OpArg ix_reg = gpr.GetReg(DSP_REG_IX0 + reg);
   MOVSX(32, 16, ECX, ix_reg);
   gpr.PutReg(DSP_REG_IX0 + reg, false);
-  gpr.GetReg(DSP_REG_AR0 + reg, ar_reg);
+
+  const OpArg ar_reg = gpr.GetReg(DSP_REG_AR0 + reg);
   MOVZX(32, 16, EAX, ar_reg);
 
   NOT(32, R(ECX));  // esi = ~ix
@@ -655,8 +648,7 @@ void DSPEmitter::dmem_read_imm(u16 address)
 void DSPEmitter::get_long_prod(X64Reg long_prod)
 {
   // s64 val   = (s8)(u8)g_dsp.r[DSP_REG_PRODH];
-  OpArg prod_reg;
-  gpr.GetReg(DSP_REG_PROD_64, prod_reg);
+  const OpArg prod_reg = gpr.GetReg(DSP_REG_PROD_64);
   MOV(64, R(long_prod), prod_reg);
   gpr.PutReg(DSP_REG_PROD_64, false);
   // no use in keeping prod_reg any longer.
@@ -705,8 +697,7 @@ void DSPEmitter::set_long_prod()
   MOV(64, R(tmp), Imm64(0x000000ffffffffffULL));
   AND(64, R(RAX), R(tmp));
   gpr.PutXReg(tmp);
-  OpArg prod_reg;
-  gpr.GetReg(DSP_REG_PROD_64, prod_reg, false);
+  const OpArg prod_reg = gpr.GetReg(DSP_REG_PROD_64, false);
   //	g_dsp.r[DSP_REG_PRODL] = (u16)val;
   MOV(64, prod_reg, R(RAX));
 
@@ -736,8 +727,7 @@ void DSPEmitter::round_long_acc(X64Reg long_acc)
 // Returns s64 in acc
 void DSPEmitter::get_long_acc(int _reg, X64Reg acc)
 {
-  OpArg reg;
-  gpr.GetReg(DSP_REG_ACC0_64 + _reg, reg);
+  const OpArg reg = gpr.GetReg(DSP_REG_ACC0_64 + _reg);
   MOV(64, R(acc), reg);
   gpr.PutReg(DSP_REG_ACC0_64 + _reg, false);
 }
@@ -745,8 +735,7 @@ void DSPEmitter::get_long_acc(int _reg, X64Reg acc)
 // In: acc = s64 val
 void DSPEmitter::set_long_acc(int _reg, X64Reg acc)
 {
-  OpArg reg;
-  gpr.GetReg(DSP_REG_ACC0_64 + _reg, reg, false);
+  const OpArg reg = gpr.GetReg(DSP_REG_ACC0_64 + _reg, false);
   MOV(64, reg, R(acc));
   gpr.PutReg(DSP_REG_ACC0_64 + _reg);
 }


### PR DESCRIPTION
Using out-references for this sort of thing is a C++03-ism.