### PR TITLE
cmake: Improve support for multi-configuration generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ list(APPEND CMAKE_MODULE_PATH
 # Support functions
 include(CheckAndAddFlag)
 include(CheckCCompilerFlag)
+include(DolphinCompileDefinitions)
 
 # Libraries to link
 set(LIBS)
@@ -193,6 +194,7 @@ endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
 	check_and_add_flag(EXCEPTIONS /EHsc)
+	dolphin_compile_definitions(-D_DEBUG DEBUG_ONLY)
 
 	# Only MSBuild needs this, other generators will compile one file at a time
 	if(CMAKE_GENERATOR MATCHES "Visual Studio")
@@ -226,6 +228,8 @@ else()
 	check_and_add_flag(VISIBILITY_HIDDEN -fvisibility=hidden)
 
 	check_and_add_flag(FOMIT_FRAME_POINTER -fomit-frame-pointer RELEASE_ONLY)
+
+	dolphin_compile_definitions(_DEBUG DEBUG_ONLY)
 	check_and_add_flag(GGDB -ggdb DEBUG_ONLY)
 
 	if(NOT ANDROID AND _M_X86_64)
@@ -334,7 +338,6 @@ endif()
 
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-	add_definitions(-D_DEBUG)
 
 	option(ENABLE_GPROF "Enable gprof profiling (must be using Debug build)" OFF)
 	if(ENABLE_GPROF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,10 +225,8 @@ else()
 	check_and_add_flag(VISIBILITY_INLINES_HIDDEN -fvisibility-inlines-hidden)
 	check_and_add_flag(VISIBILITY_HIDDEN -fvisibility=hidden)
 
-	check_c_compiler_flag(-fomit-frame-pointer FLAG_C_FOMIT_FRAME_POINTER)
-	if(FLAG_C_FOMIT_FRAME_POINTER)
-		add_compile_options($<$<CONFIG:Release>:-fomit-frame-pointer>)
-	endif()
+	check_and_add_flag(FOMIT_FRAME_POINTER -fomit-frame-pointer RELEASE_ONLY)
+	check_and_add_flag(GGDB -ggdb DEBUG_ONLY)
 
 	if(NOT ANDROID AND _M_X86_64)
 		# PIE is required on Android, but not supported with the x86_64 jit currently
@@ -337,7 +335,6 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	add_definitions(-D_DEBUG)
-	check_and_add_flag(GGDB -ggdb)
 
 	option(ENABLE_GPROF "Enable gprof profiling (must be using Debug build)" OFF)
 	if(ENABLE_GPROF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,17 +336,13 @@ if(NOT CMAKE_BUILD_TYPE)
 		"Build type (Release/Debug/RelWithDebInfo/MinSizeRel)" FORCE)
 endif()
 
-
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-
-	option(ENABLE_GPROF "Enable gprof profiling (must be using Debug build)" OFF)
-	if(ENABLE_GPROF)
-		check_and_add_flag(HAVE_PG -pg)
-		if(NOT FLAG_C_HAVE_PG)
-			message(FATAL_ERROR "Compiler option -pg is not supported")
-		endif()
-		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg")
+option(ENABLE_GPROF "Enable gprof profiling (must be using Debug build)" OFF)
+if(ENABLE_GPROF)
+	check_and_add_flag(HAVE_PG -pg)
+	if(NOT FLAG_C_HAVE_PG)
+		message(FATAL_ERROR "Compiler option -pg is not supported")
 	endif()
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg")
 endif()
 
 if(FASTLOG)

--- a/CMakeTests/CheckAndAddFlag.cmake
+++ b/CMakeTests/CheckAndAddFlag.cmake
@@ -1,14 +1,39 @@
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 
-macro(check_and_add_flag var flag)
-	check_c_compiler_flag(${flag} FLAG_C_${var})
-	if(FLAG_C_${var})
-		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flag}")
-	endif()
+# check_add_add_flag(<variable> <flag> [DEBUG_ONLY | RELEASE_ONLY])
+#
+# Add a C or C++ compilation flag to the current scope
+#
+# Can optionally add the flag to Debug or Release configurations only, use this when
+# targeting multi-configuration generators like Visual Studio or Xcode.
+# Release configurations means NOT Debug, so it will work for RelWithDebInfo or MinSizeRel too.
+#
+# If the flag is added successfully, the variables FLAG_C_<variable> and FLAG_CXX_<variable>
+# may be set to ON.
+#
+# Examples:
+#   check_and_add_flag(FOO -foo)
+#   check_and_add_flag(ONLYDEBUG -onlydebug DEBUG_ONLY)
+#   check_and_add_flag(OPTMAX -O9001 RELEASE_ONLY)
 
-	check_cxx_compiler_flag(${flag} FLAG_CXX_${var})
-	if(FLAG_CXX_${var})
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-	endif()
-endmacro()
+function(check_and_add_flag var flag)
+  set(genexp_config_test "1")
+  if(ARGV2 STREQUAL "DEBUG_ONLY")
+    set(genexp_config_test "$<CONFIG:Debug>")
+  elseif(ARGV2 STREQUAL "RELEASE_ONLY")
+    set(genexp_config_test "$<NOT:$<CONFIG:Debug>>")
+  elseif(ARGV2)
+    message(FATAL_ERROR "check_and_add_flag called with incorrect arguments: ${ARGN}")
+  endif()
+
+  check_c_compiler_flag(${flag} FLAG_C_${var})
+  if(FLAG_C_${var})
+    add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:C>,${genexp_config_test}>:${flag}>")
+  endif()
+
+  check_cxx_compiler_flag(${flag} FLAG_CXX_${var})
+  if(FLAG_CXX_${var})
+    add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CXX>,${genexp_config_test}>:${flag}>")
+  endif()
+endfunction()

--- a/CMakeTests/DolphinCompileDefinitions.cmake
+++ b/CMakeTests/DolphinCompileDefinitions.cmake
@@ -1,0 +1,34 @@
+# Add a C or C++ compile definitions to the current scope
+#
+# dolphin_compile_definitions(def [def ...] [DEBUG_ONLY | RELEASE_ONLY])
+#
+# Can optionally add the definitions to Debug or Release configurations only, use this so we can
+# target multi-configuration generators like Visual Studio or Xcode.
+# Release configurations means NOT Debug, so it will work for RelWithDebInfo or MinSizeRel too.
+# The definitions are added to the COMPILE_DEFINITIONS folder property.
+# Supports generator expressions, unlike add_definitions()
+#
+# Examples:
+#   dolphin_compile_definitions(FOO) -> -DFOO
+#   dolphin_compile_definitions(_DEBUG DEBUG_ONLY) -> -D_DEBUG
+#   dolphin_compile_definitions(NDEBUG RELEASE_ONLY) -> -DNDEBUG
+#   dolphin_compile_definitions($<$<COMPILE_LANGUAGE:C>:THISISONLYFORC>)
+
+function(dolphin_compile_definitions)
+  set(defs ${ARGN})
+
+  list(GET defs -1 last_def)
+  list(REMOVE_AT defs -1)
+
+  set(genexp_config_test "1")
+  if(last_def STREQUAL "DEBUG_ONLY")
+    set(genexp_config_test "$<CONFIG:Debug>")
+  elseif(last_def STREQUAL "RELEASE_ONLY")
+    set(genexp_config_test "$<NOT:$<CONFIG:Debug>>")
+  else()
+    list(APPEND defs ${last_def})
+  endif()
+
+  set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
+    "$<${genexp_config_test}:${ARGN}>")
+endfunction()


### PR DESCRIPTION
You can't read the variable CMAKE_BUILD_TYPE in CMake as it makes the scripts incompatible with multi-configuration generators like Visual Studio or Xcode.

For those, in order to add all the right options for the right configuration (Debug, Release...), you should use generator expressions. Their syntax is not great, so I'm adding some macros that add them when necessary.