### PR TITLE
DSPTables: Hide remaining opcode tables

### DIFF
--- a/Source/Core/Core/DSP/DSPAssembler.h
+++ b/Source/Core/Core/DSP/DSPAssembler.h
@@ -78,6 +78,12 @@ private:
     SEGMENT_MAX
   };
 
+  enum class OpcodeType
+  {
+    Primary,
+    Extension
+  };
+
   // Utility functions
   s32 ParseValue(const char* str);
   u32 ParseExpression(const char* ptr);
@@ -91,8 +97,7 @@ private:
   // void ShowWarning(err_t err_code, const char *extra_info = nullptr);
 
   char* FindBrackets(char* src, char* dst);
-  const opc_t* FindOpcode(const char* name, u32 par_count, const opc_t* opcodes,
-                          size_t opcodes_size);
+  const opc_t* FindOpcode(std::string name, size_t par_count, OpcodeType type);
   bool VerifyParams(const opc_t* opc, param_t* par, size_t count, bool ext = false);
   void BuildCode(const opc_t* opc, param_t* par, u32 par_count, u16* outbuf);
 

--- a/Source/Core/Core/DSP/DSPAssembler.h
+++ b/Source/Core/Core/DSP/DSPAssembler.h
@@ -98,7 +98,7 @@ private:
 
   char* FindBrackets(char* src, char* dst);
   const opc_t* FindOpcode(std::string name, size_t par_count, OpcodeType type);
-  bool VerifyParams(const opc_t* opc, param_t* par, size_t count, bool ext = false);
+  bool VerifyParams(const opc_t* opc, param_t* par, size_t count, OpcodeType type);
   void BuildCode(const opc_t* opc, param_t* par, u32 par_count, u16* outbuf);
 
   std::vector<u16> m_output_buffer;

--- a/Source/Core/Core/DSP/DSPTables.h
+++ b/Source/Core/Core/DSP/DSPTables.h
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstddef>
+#include <string>
 
 #include "Core/DSP/DSPCommon.h"
 #include "Core/DSP/Jit/DSPEmitter.h"
@@ -90,8 +91,6 @@ struct DSPOPCTemplate
 typedef DSPOPCTemplate opc_t;
 
 // Opcodes
-extern const std::array<DSPOPCTemplate, 214> opcodes;
-extern const std::array<DSPOPCTemplate, 25> opcodes_ext;
 extern const DSPOPCTemplate cw;
 
 constexpr size_t WRITEBACK_LOG_SIZE = 5;
@@ -118,6 +117,14 @@ void applyWriteBackLog();
 void zeroWriteBackLog();
 void zeroWriteBackLogPreserveAcc(u8 acc);
 
+// Used by the assembler and disassembler for info retrieval.
+const DSPOPCTemplate* FindOpInfoByOpcode(UDSPInstruction opcode);
+const DSPOPCTemplate* FindOpInfoByName(const std::string& name);
+
+const DSPOPCTemplate* FindExtOpInfoByOpcode(UDSPInstruction opcode);
+const DSPOPCTemplate* FindExtOpInfoByName(const std::string& name);
+
+// Used by the interpreter and JIT for instruction emulation
 const DSPOPCTemplate* GetOpTemplate(UDSPInstruction inst);
 const DSPOPCTemplate* GetExtOpTemplate(UDSPInstruction inst);
 }  // namespace DSP


### PR DESCRIPTION
Hides the main information opcodes from being seen in external scope and presents an API for using the tables.

One consideration that could also be preferable, is that the `OpcodeType` enum could be moved to DSPTables and the Find functions can be reduced from four to two functions by combining both find-by-opcode functions and find-by-name functions into one another with an `OpcodeType` parameter to determine which table to look through. I kept them separately for the time being in case the separation is preferred.

