### PR TITLE
DSPJitRegCache: Move allocation order array to the cpp file

### DIFF
--- a/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
@@ -23,7 +23,7 @@ namespace x86
 {
 // Ordered in order of prefered use.
 // Not all of these are actually available
-const std::array<X64Reg, 15> DSPJitRegCache::m_allocation_order = {
+constexpr std::array<X64Reg, 15> s_allocation_order = {
     {R8, R9, R10, R11, R12, R13, R14, R15, RSI, RDI, RBX, RCX, RDX, RAX, RBP}};
 
 static void* GetRegisterPointer(size_t reg)
@@ -905,7 +905,7 @@ X64Reg DSPJitRegCache::SpillXReg()
 {
   int max_use_ctr_diff = 0;
   X64Reg least_recent_use_reg = INVALID_REG;
-  for (X64Reg reg : m_allocation_order)
+  for (X64Reg reg : s_allocation_order)
   {
     if (m_xregs[reg].guest_reg <= DSP_REG_MAX_MEM_BACKED && !m_regs[m_xregs[reg].guest_reg].used)
     {
@@ -925,7 +925,7 @@ X64Reg DSPJitRegCache::SpillXReg()
   }
 
   // just choose one.
-  for (X64Reg reg : m_allocation_order)
+  for (X64Reg reg : s_allocation_order)
   {
     if (m_xregs[reg].guest_reg <= DSP_REG_MAX_MEM_BACKED && !m_regs[m_xregs[reg].guest_reg].used)
     {
@@ -956,7 +956,7 @@ void DSPJitRegCache::SpillXReg(X64Reg reg)
 
 X64Reg DSPJitRegCache::FindFreeXReg()
 {
-  for (X64Reg x : m_allocation_order)
+  for (X64Reg x : s_allocation_order)
   {
     if (m_xregs[x].guest_reg == DSP_REG_NONE)
     {

--- a/Source/Core/Core/DSP/Jit/DSPJitRegCache.h
+++ b/Source/Core/Core/DSP/Jit/DSPJitRegCache.h
@@ -174,8 +174,6 @@ private:
   void MovToMemory(size_t reg);
   void FlushMemBackedRegs();
 
-  static const std::array<Gen::X64Reg, 15> m_allocation_order;
-
   std::array<DynamicReg, 37> m_regs;
   std::array<X64CachedReg, 16> m_xregs;
 


### PR DESCRIPTION
As it's a private static implementation detail that doesn't rely on any other internals of DSPJitRegCache, it can be hidden.