### PR TITLE
GameSettings: Don't ship speedhack which are enabled by default.

### DIFF
--- a/Data/Sys/GameSettings/G8ME01.ini
+++ b/Data/Sys/GameSettings/G8ME01.ini
@@ -37,6 +37,3 @@ $Max Gold
 026EE2B8 000003E7
 $Max Shop Points
 026EE7F0 000003E7
-
-[Speedhacks]
-0x8029ccf4=600

--- a/Data/Sys/GameSettings/GFEE01.ini
+++ b/Data/Sys/GameSettings/GFEE01.ini
@@ -52,6 +52,3 @@ $Max Resistance(TATANIA)
 002B1E16 00000063
 $Max Movement(TATANIA)
 002B1E0E 00000063
-
-[Speedhacks]
-0x8020a51c=500

--- a/Data/Sys/GameSettings/GFEJ01.ini
+++ b/Data/Sys/GameSettings/GFEJ01.ini
@@ -92,6 +92,3 @@ $Chapter 28: Twisted Tower
 0032E798 0000001E
 $Endgame: Repatriation
 0032E798 0000001F
-
-[Speedhacks]
-0x80204ce8=500

--- a/Data/Sys/GameSettings/GG4P08.ini
+++ b/Data/Sys/GameSettings/GG4P08.ini
@@ -8,6 +8,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Speedhacks]
-0x802087c8=200

--- a/Data/Sys/GameSettings/GPSP8P.ini
+++ b/Data/Sys/GameSettings/GPSP8P.ini
@@ -53,6 +53,3 @@ $Make Saved data copyable
 04000094 981C0034
 04000098 38000000
 0400009C 4833056C
-
-[Speedhacks]
-0x8036eba0=400

--- a/Data/Sys/GameSettings/RCJE8P.ini
+++ b/Data/Sys/GameSettings/RCJE8P.ini
@@ -8,9 +8,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Speedhacks]
-0x80199d08=700
-0x8038b814=700
-0x80144be0=700
-0x80117934=700

--- a/Data/Sys/GameSettings/RM3P01.ini
+++ b/Data/Sys/GameSettings/RM3P01.ini
@@ -8,6 +8,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Speedhacks]
-0x804e8b20=600

--- a/Data/Sys/GameSettings/RNHE41.ini
+++ b/Data/Sys/GameSettings/RNHE41.ini
@@ -8,6 +8,3 @@
 
 [ActionReplay]
 # Add action replay cheats here.
-
-[Speedhacks]
-0x8035bc9c=700


### PR DESCRIPTION
This may slow down a few games, but we don't want to support this kind of mess.