### PR TITLE
DSPJitRegCache: Convert DSPJitSignExtend into an enum class

### DIFF
--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -108,8 +108,9 @@ public:
   void dsp_conditional_extend_accum(int reg);
   void dsp_conditional_extend_accum_imm(int reg, u16 val);
   void dsp_op_read_reg_dont_saturate(int reg, Gen::X64Reg host_dreg,
-                                     DSPJitSignExtend extend = NONE);
-  void dsp_op_read_reg(int reg, Gen::X64Reg host_dreg, DSPJitSignExtend extend = NONE);
+                                     RegisterExtension extend = RegisterExtension::None);
+  void dsp_op_read_reg(int reg, Gen::X64Reg host_dreg,
+                       RegisterExtension extend = RegisterExtension::None);
 
   // Commands
   void dar(const UDSPInstruction opc);

--- a/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
@@ -533,7 +533,7 @@ void DSPEmitter::addr(const UDSPInstruction opc)
   get_long_acc(dreg, tmp1);
   MOV(64, R(RAX), R(tmp1));
   //	s64 ax = (s16)g_dsp.r[sreg];
-  dsp_op_read_reg(sreg, RDX, SIGN);
+  dsp_op_read_reg(sreg, RDX, RegisterExtension::Sign);
   //	ax <<= 16;
   SHL(64, R(RDX), Imm8(16));
   //	s64 res = acc + ax;
@@ -842,7 +842,7 @@ void DSPEmitter::subr(const UDSPInstruction opc)
   get_long_acc(dreg, tmp1);
   MOV(64, R(RAX), R(tmp1));
   //	s64 ax = (s16)g_dsp.r[sreg];
-  dsp_op_read_reg(sreg, RDX, SIGN);
+  dsp_op_read_reg(sreg, RDX, RegisterExtension::Sign);
   //	ax <<= 16;
   SHL(64, R(RDX), Imm8(16));
   //	s64 res = acc - ax;
@@ -1089,7 +1089,7 @@ void DSPEmitter::movr(const UDSPInstruction opc)
   u8 sreg = ((opc >> 9) & 0x3) + DSP_REG_AXL0;
 
   //	s64 acc = (s16)g_dsp.r[sreg];
-  dsp_op_read_reg(sreg, RAX, SIGN);
+  dsp_op_read_reg(sreg, RAX, RegisterExtension::Sign);
   //	acc <<= 16;
   SHL(64, R(RAX), Imm8(16));
   //	acc &= ~0xffff;

--- a/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
@@ -157,7 +157,7 @@ static void r_jmprcc(const UDSPInstruction opc, DSPEmitter& emitter)
   u8 reg = (opc >> 5) & 0x7;
   // reg can only be DSP_REG_ARx and DSP_REG_IXx now,
   // no need to handle DSP_REG_STx.
-  emitter.dsp_op_read_reg(reg, RAX, NONE);
+  emitter.dsp_op_read_reg(reg, RAX);
   emitter.MOV(16, M(&g_dsp.pc), R(EAX));
   WriteBranchExit(emitter);
 }
@@ -204,7 +204,7 @@ static void r_callr(const UDSPInstruction opc, DSPEmitter& emitter)
   u8 reg = (opc >> 5) & 0x7;
   emitter.MOV(16, R(DX), Imm16(emitter.m_compile_pc + 1));
   emitter.dsp_reg_store_stack(DSP_STACK_C);
-  emitter.dsp_op_read_reg(reg, RAX, NONE);
+  emitter.dsp_op_read_reg(reg, RAX);
   emitter.MOV(16, M(&g_dsp.pc), R(EAX));
   WriteBranchExit(emitter);
 }
@@ -334,7 +334,7 @@ void DSPEmitter::loop(const UDSPInstruction opc)
   u16 reg = opc & 0x1f;
   //	u16 cnt = g_dsp.r[reg];
   // todo: check if we can use normal variant here
-  dsp_op_read_reg_dont_saturate(reg, RDX, ZERO);
+  dsp_op_read_reg_dont_saturate(reg, RDX, RegisterExtension::Zero);
   u16 loop_pc = m_compile_pc + 1;
 
   TEST(16, R(EDX), R(EDX));
@@ -403,7 +403,7 @@ void DSPEmitter::bloop(const UDSPInstruction opc)
   u16 reg = opc & 0x1f;
   //	u16 cnt = g_dsp.r[reg];
   // todo: check if we can use normal variant here
-  dsp_op_read_reg_dont_saturate(reg, RDX, ZERO);
+  dsp_op_read_reg_dont_saturate(reg, RDX, RegisterExtension::Zero);
   u16 loop_pc = dsp_imem_read(m_compile_pc + 1);
 
   TEST(16, R(EDX), R(EDX));

--- a/Source/Core/Core/DSP/Jit/DSPJitExtOps.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitExtOps.cpp
@@ -64,7 +64,7 @@ void DSPEmitter::mv(const UDSPInstruction opc)
 {
   u8 sreg = (opc & 0x3) + DSP_REG_ACL0;
   u8 dreg = ((opc >> 2) & 0x3);
-  dsp_op_read_reg(sreg, RBX, ZERO);
+  dsp_op_read_reg(sreg, RBX, RegisterExtension::Zero);
   m_store_index = dreg + DSP_REG_AXL0;
 }
 
@@ -77,11 +77,11 @@ void DSPEmitter::s(const UDSPInstruction opc)
   u8 dreg = opc & 0x3;
   u8 sreg = ((opc >> 3) & 0x3) + DSP_REG_ACL0;
   //	u16 addr = g_dsp.r[dest];
-  dsp_op_read_reg(dreg, RAX, ZERO);
+  dsp_op_read_reg(dreg, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg, tmp1, ZERO);
+  dsp_op_read_reg(sreg, tmp1, RegisterExtension::Zero);
   //	u16 val = g_dsp.r[src];
   dmem_write(tmp1);
 
@@ -98,11 +98,11 @@ void DSPEmitter::sn(const UDSPInstruction opc)
 {
   u8 dreg = opc & 0x3;
   u8 sreg = ((opc >> 3) & 0x3) + DSP_REG_ACL0;
-  dsp_op_read_reg(dreg, RAX, ZERO);
+  dsp_op_read_reg(dreg, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg, tmp1, ZERO);
+  dsp_op_read_reg(sreg, tmp1, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -169,11 +169,11 @@ void DSPEmitter::ls(const UDSPInstruction opc)
 {
   u8 sreg = opc & 0x1;
   u8 dreg = ((opc >> 4) & 0x3) + DSP_REG_AXL0;
-  dsp_op_read_reg(DSP_REG_AR3, RAX, ZERO);
+  dsp_op_read_reg(DSP_REG_AR3, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, ZERO);
+  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -194,11 +194,11 @@ void DSPEmitter::lsn(const UDSPInstruction opc)
 {
   u8 sreg = opc & 0x1;
   u8 dreg = ((opc >> 4) & 0x3) + DSP_REG_AXL0;
-  dsp_op_read_reg(DSP_REG_AR3, RAX, ZERO);
+  dsp_op_read_reg(DSP_REG_AR3, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, ZERO);
+  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -219,11 +219,11 @@ void DSPEmitter::lsm(const UDSPInstruction opc)
 {
   u8 sreg = opc & 0x1;
   u8 dreg = ((opc >> 4) & 0x3) + DSP_REG_AXL0;
-  dsp_op_read_reg(DSP_REG_AR3, RAX, ZERO);
+  dsp_op_read_reg(DSP_REG_AR3, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, ZERO);
+  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -245,11 +245,11 @@ void DSPEmitter::lsnm(const UDSPInstruction opc)
 {
   u8 sreg = opc & 0x1;
   u8 dreg = ((opc >> 4) & 0x3) + DSP_REG_AXL0;
-  dsp_op_read_reg(DSP_REG_AR3, RAX, ZERO);
+  dsp_op_read_reg(DSP_REG_AR3, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, ZERO);
+  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -269,11 +269,11 @@ void DSPEmitter::sl(const UDSPInstruction opc)
 {
   u8 sreg = opc & 0x1;
   u8 dreg = ((opc >> 4) & 0x3) + DSP_REG_AXL0;
-  dsp_op_read_reg(DSP_REG_AR0, RAX, ZERO);
+  dsp_op_read_reg(DSP_REG_AR0, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, ZERO);
+  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -294,11 +294,11 @@ void DSPEmitter::sln(const UDSPInstruction opc)
 {
   u8 sreg = opc & 0x1;
   u8 dreg = ((opc >> 4) & 0x3) + DSP_REG_AXL0;
-  dsp_op_read_reg(DSP_REG_AR0, RAX, ZERO);
+  dsp_op_read_reg(DSP_REG_AR0, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, ZERO);
+  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -319,11 +319,11 @@ void DSPEmitter::slm(const UDSPInstruction opc)
 {
   u8 sreg = opc & 0x1;
   u8 dreg = ((opc >> 4) & 0x3) + DSP_REG_AXL0;
-  dsp_op_read_reg(DSP_REG_AR0, RAX, ZERO);
+  dsp_op_read_reg(DSP_REG_AR0, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, ZERO);
+  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -344,11 +344,11 @@ void DSPEmitter::slnm(const UDSPInstruction opc)
 {
   u8 sreg = opc & 0x1;
   u8 dreg = ((opc >> 4) & 0x3) + DSP_REG_AXL0;
-  dsp_op_read_reg(DSP_REG_AR0, RAX, ZERO);
+  dsp_op_read_reg(DSP_REG_AR0, RAX, RegisterExtension::Zero);
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, ZERO);
+  dsp_op_read_reg(sreg + DSP_REG_ACM0, tmp1, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -379,8 +379,8 @@ void DSPEmitter::ld(const UDSPInstruction opc)
 
   // 	if (IsSameMemArea(g_dsp.r[sreg], g_dsp.r[DSP_REG_AR3])) {
   X64Reg tmp = m_gpr.GetFreeXReg();
-  dsp_op_read_reg(sreg, RCX, NONE);
-  dsp_op_read_reg(DSP_REG_AR3, tmp, NONE);
+  dsp_op_read_reg(sreg, RCX);
+  dsp_op_read_reg(DSP_REG_AR3, tmp);
   XOR(16, R(ECX), R(tmp));
   m_gpr.PutXReg(tmp);
   DSPJitRegCache c(m_gpr);
@@ -410,8 +410,8 @@ void DSPEmitter::ldax(const UDSPInstruction opc)
 
   X64Reg tmp = m_gpr.GetFreeXReg();
   // if (IsSameMemArea(g_dsp.r[sreg], g_dsp.r[DSP_REG_AR3])) {
-  dsp_op_read_reg(sreg, RCX, NONE);
-  dsp_op_read_reg(DSP_REG_AR3, tmp, NONE);
+  dsp_op_read_reg(sreg, RCX);
+  dsp_op_read_reg(DSP_REG_AR3, tmp);
   XOR(16, R(ECX), R(tmp));
   m_gpr.PutXReg(tmp);
   DSPJitRegCache c(m_gpr);
@@ -442,8 +442,8 @@ void DSPEmitter::ldn(const UDSPInstruction opc)
 
   X64Reg tmp = m_gpr.GetFreeXReg();
   // if (IsSameMemArea(g_dsp.r[sreg], g_dsp.r[DSP_REG_AR3])) {
-  dsp_op_read_reg(sreg, RCX, NONE);
-  dsp_op_read_reg(DSP_REG_AR3, tmp, NONE);
+  dsp_op_read_reg(sreg, RCX);
+  dsp_op_read_reg(DSP_REG_AR3, tmp);
   XOR(16, R(ECX), R(tmp));
   m_gpr.PutXReg(tmp);
   DSPJitRegCache c(m_gpr);
@@ -473,8 +473,8 @@ void DSPEmitter::ldaxn(const UDSPInstruction opc)
 
   X64Reg tmp = m_gpr.GetFreeXReg();
   // if (IsSameMemArea(g_dsp.r[sreg], g_dsp.r[DSP_REG_AR3])) {
-  dsp_op_read_reg(sreg, RCX, NONE);
-  dsp_op_read_reg(DSP_REG_AR3, tmp, NONE);
+  dsp_op_read_reg(sreg, RCX);
+  dsp_op_read_reg(DSP_REG_AR3, tmp);
   XOR(16, R(ECX), R(tmp));
   m_gpr.PutXReg(tmp);
   DSPJitRegCache c(m_gpr);
@@ -505,8 +505,8 @@ void DSPEmitter::ldm(const UDSPInstruction opc)
 
   X64Reg tmp = m_gpr.GetFreeXReg();
   // if (IsSameMemArea(g_dsp.r[sreg], g_dsp.r[DSP_REG_AR3])) {
-  dsp_op_read_reg(sreg, RCX, NONE);
-  dsp_op_read_reg(DSP_REG_AR3, tmp, NONE);
+  dsp_op_read_reg(sreg, RCX);
+  dsp_op_read_reg(DSP_REG_AR3, tmp);
   XOR(16, R(ECX), R(tmp));
   m_gpr.PutXReg(tmp);
   DSPJitRegCache c(m_gpr);
@@ -536,8 +536,8 @@ void DSPEmitter::ldaxm(const UDSPInstruction opc)
 
   X64Reg tmp = m_gpr.GetFreeXReg();
   // if (IsSameMemArea(g_dsp.r[sreg], g_dsp.r[DSP_REG_AR3])) {
-  dsp_op_read_reg(sreg, RCX, NONE);
-  dsp_op_read_reg(DSP_REG_AR3, tmp, NONE);
+  dsp_op_read_reg(sreg, RCX);
+  dsp_op_read_reg(DSP_REG_AR3, tmp);
   XOR(16, R(ECX), R(tmp));
   m_gpr.PutXReg(tmp);
   DSPJitRegCache c(m_gpr);
@@ -568,8 +568,8 @@ void DSPEmitter::ldnm(const UDSPInstruction opc)
 
   X64Reg tmp = m_gpr.GetFreeXReg();
   // if (IsSameMemArea(g_dsp.r[sreg], g_dsp.r[DSP_REG_AR3])) {
-  dsp_op_read_reg(sreg, RCX, NONE);
-  dsp_op_read_reg(DSP_REG_AR3, tmp, NONE);
+  dsp_op_read_reg(sreg, RCX);
+  dsp_op_read_reg(DSP_REG_AR3, tmp);
   XOR(16, R(ECX), R(tmp));
   m_gpr.PutXReg(tmp);
   DSPJitRegCache c(m_gpr);
@@ -599,8 +599,8 @@ void DSPEmitter::ldaxnm(const UDSPInstruction opc)
 
   X64Reg tmp = m_gpr.GetFreeXReg();
   // if (IsSameMemArea(g_dsp.r[sreg], g_dsp.r[DSP_REG_AR3])) {
-  dsp_op_read_reg(sreg, RCX, NONE);
-  dsp_op_read_reg(DSP_REG_AR3, tmp, NONE);
+  dsp_op_read_reg(sreg, RCX);
+  dsp_op_read_reg(DSP_REG_AR3, tmp);
   XOR(16, R(ECX), R(tmp));
   m_gpr.PutXReg(tmp);
   DSPJitRegCache c(m_gpr);
@@ -627,7 +627,7 @@ void DSPEmitter::pushExtValueFromMem(u16 dreg, u16 sreg)
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg, tmp1, ZERO);
+  dsp_op_read_reg(sreg, tmp1, RegisterExtension::Zero);
   dmem_read(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -643,7 +643,7 @@ void DSPEmitter::pushExtValueFromMem2(u16 dreg, u16 sreg)
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(sreg, tmp1, ZERO);
+  dsp_op_read_reg(sreg, tmp1, RegisterExtension::Zero);
   dmem_read(tmp1);
 
   m_gpr.PutXReg(tmp1);

--- a/Source/Core/Core/DSP/Jit/DSPJitLoadStore.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitLoadStore.cpp
@@ -31,8 +31,8 @@ void DSPEmitter::srs(const UDSPInstruction opc)
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(reg, tmp1, ZERO);
-  dsp_op_read_reg(DSP_REG_CR, RAX, ZERO);
+  dsp_op_read_reg(reg, tmp1, RegisterExtension::Zero);
+  dsp_op_read_reg(DSP_REG_CR, RAX, RegisterExtension::Zero);
   SHL(16, R(EAX), Imm8(8));
   OR(16, R(EAX), Imm16(opc & 0xFF));
   dmem_write(tmp1);
@@ -52,7 +52,7 @@ void DSPEmitter::lrs(const UDSPInstruction opc)
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
   // u16 addr = (g_dsp.r[DSP_REG_CR] << 8) | (opc & 0xFF);
-  dsp_op_read_reg(DSP_REG_CR, tmp1, ZERO);
+  dsp_op_read_reg(DSP_REG_CR, tmp1, RegisterExtension::Zero);
   SHL(16, R(tmp1), Imm8(8));
   OR(16, R(tmp1), Imm16(opc & 0xFF));
   dmem_read(tmp1);
@@ -205,7 +205,7 @@ void DSPEmitter::srr(const UDSPInstruction opc)
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
   dsp_op_read_reg(sreg, tmp1);
-  dsp_op_read_reg(dreg, RAX, ZERO);
+  dsp_op_read_reg(dreg, RAX, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -223,7 +223,7 @@ void DSPEmitter::srrd(const UDSPInstruction opc)
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
   dsp_op_read_reg(sreg, tmp1);
-  dsp_op_read_reg(dreg, RAX, ZERO);
+  dsp_op_read_reg(dreg, RAX, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -243,7 +243,7 @@ void DSPEmitter::srri(const UDSPInstruction opc)
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
   dsp_op_read_reg(sreg, tmp1);
-  dsp_op_read_reg(dreg, RAX, ZERO);
+  dsp_op_read_reg(dreg, RAX, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -263,7 +263,7 @@ void DSPEmitter::srrn(const UDSPInstruction opc)
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
   dsp_op_read_reg(sreg, tmp1);
-  dsp_op_read_reg(dreg, RAX, ZERO);
+  dsp_op_read_reg(dreg, RAX, RegisterExtension::Zero);
   dmem_write(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -282,7 +282,7 @@ void DSPEmitter::ilrr(const UDSPInstruction opc)
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(reg, tmp1, ZERO);
+  dsp_op_read_reg(reg, tmp1, RegisterExtension::Zero);
   imem_read(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -302,7 +302,7 @@ void DSPEmitter::ilrrd(const UDSPInstruction opc)
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(reg, tmp1, ZERO);
+  dsp_op_read_reg(reg, tmp1, RegisterExtension::Zero);
   imem_read(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -323,7 +323,7 @@ void DSPEmitter::ilrri(const UDSPInstruction opc)
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(reg, tmp1, ZERO);
+  dsp_op_read_reg(reg, tmp1, RegisterExtension::Zero);
   imem_read(tmp1);
 
   m_gpr.PutXReg(tmp1);
@@ -345,7 +345,7 @@ void DSPEmitter::ilrrn(const UDSPInstruction opc)
 
   X64Reg tmp1 = m_gpr.GetFreeXReg();
 
-  dsp_op_read_reg(reg, tmp1, ZERO);
+  dsp_op_read_reg(reg, tmp1, RegisterExtension::Zero);
   imem_read(tmp1);
 
   m_gpr.PutXReg(tmp1);

--- a/Source/Core/Core/DSP/Jit/DSPJitMultiplier.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitMultiplier.cpp
@@ -285,7 +285,7 @@ void DSPEmitter::addpaxz(const UDSPInstruction opc)
 void DSPEmitter::mulaxh(const UDSPInstruction opc)
 {
   //	s64 prod = dsp_multiply(dsp_get_ax_h(0), dsp_get_ax_h(0));
-  dsp_op_read_reg(DSP_REG_AXH0, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0, RCX, RegisterExtension::Sign);
   MOV(64, R(RAX), R(RCX));
   multiply();
   //	dsp_set_long_prod(prod);
@@ -303,9 +303,9 @@ void DSPEmitter::mul(const UDSPInstruction opc)
   u8 sreg = (opc >> 11) & 0x1;
 
   //	u16 axl = dsp_get_ax_l(sreg);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg, RCX, RegisterExtension::Sign);
   //	u16 axh = dsp_get_ax_h(sreg);
-  dsp_op_read_reg(DSP_REG_AXH0 + sreg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + sreg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply(axh, axl);
   multiply();
   //	dsp_set_long_prod(prod);
@@ -331,9 +331,9 @@ void DSPEmitter::mulac(const UDSPInstruction opc)
   ADD(64, R(RAX), R(RDX));
   PUSH(64, R(RAX));
   //	u16 axl = dsp_get_ax_l(sreg);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg, RCX, RegisterExtension::Sign);
   //	u16 axh = dsp_get_ax_h(sreg);
-  dsp_op_read_reg(DSP_REG_AXH0 + sreg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + sreg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply(axl, axh);
   multiply();
   //	dsp_set_long_prod(prod);
@@ -409,9 +409,9 @@ void DSPEmitter::mulx(const UDSPInstruction opc)
   u8 sreg = ((opc >> 12) & 0x1);
 
   //	u16 val1 = (sreg == 0) ? dsp_get_ax_l(0) : dsp_get_ax_h(0);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, RegisterExtension::Sign);
   //	u16 val2 = (treg == 0) ? dsp_get_ax_l(1) : dsp_get_ax_h(1);
-  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_mulx(sreg, treg, val1, val2);
   multiply_mulx(sreg, treg);
   //	dsp_set_long_prod(prod);
@@ -437,9 +437,9 @@ void DSPEmitter::mulxac(const UDSPInstruction opc)
   get_long_prod();
   ADD(64, R(tmp1), R(RAX));
   //	u16 val1 = (sreg == 0) ? dsp_get_ax_l(0) : dsp_get_ax_h(0);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, RegisterExtension::Sign);
   //	u16 val2 = (treg == 0) ? dsp_get_ax_l(1) : dsp_get_ax_h(1);
-  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_mulx(sreg, treg, val1, val2);
   multiply_mulx(sreg, treg);
 
@@ -472,9 +472,9 @@ void DSPEmitter::mulxmv(const UDSPInstruction opc)
   X64Reg tmp1 = m_gpr.GetFreeXReg();
   get_long_prod(tmp1);
   //	u16 val1 = (sreg == 0) ? dsp_get_ax_l(0) : dsp_get_ax_h(0);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, RegisterExtension::Sign);
   //	u16 val2 = (treg == 0) ? dsp_get_ax_l(1) : dsp_get_ax_h(1);
-  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_mulx(sreg, treg, val1, val2);
   multiply_mulx(sreg, treg);
 
@@ -508,9 +508,9 @@ void DSPEmitter::mulxmvz(const UDSPInstruction opc)
   X64Reg tmp1 = m_gpr.GetFreeXReg();
   get_long_prod_round_prodl(tmp1);
   //	u16 val1 = (sreg == 0) ? dsp_get_ax_l(0) : dsp_get_ax_h(0);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, RegisterExtension::Sign);
   //	u16 val2 = (treg == 0) ? dsp_get_ax_l(1) : dsp_get_ax_h(1);
-  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_mulx(sreg, treg, val1, val2);
   multiply_mulx(sreg, treg);
 
@@ -540,7 +540,7 @@ void DSPEmitter::mulc(const UDSPInstruction opc)
   //	u16 accm = dsp_get_acc_m(sreg);
   get_acc_m(sreg, ECX);
   //	u16 axh = dsp_get_ax_h(treg);
-  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply(accm, axh);
   multiply();
   //	dsp_set_long_prod(prod);
@@ -569,7 +569,7 @@ void DSPEmitter::mulcac(const UDSPInstruction opc)
   //	u16 accm = dsp_get_acc_m(sreg);
   get_acc_m(sreg, ECX);
   //	u16 axh = dsp_get_ax_h(treg);
-  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply(accm, axh);
   multiply();
   //	dsp_set_long_prod(prod);
@@ -604,7 +604,7 @@ void DSPEmitter::mulcmv(const UDSPInstruction opc)
   //	u16 accm = dsp_get_acc_m(sreg);
   get_acc_m(sreg, ECX);
   //	u16 axh = dsp_get_ax_h(treg);
-  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply(accm, axh);
   multiply();
   //	dsp_set_long_prod(prod);
@@ -640,7 +640,7 @@ void DSPEmitter::mulcmvz(const UDSPInstruction opc)
   //	u16 accm = dsp_get_acc_m(sreg);
   get_acc_m(sreg, ECX);
   //	u16 axh = dsp_get_ax_h(treg);
-  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply(accm, axh);
   multiply();
   //	dsp_set_long_prod(prod);
@@ -668,9 +668,9 @@ void DSPEmitter::maddx(const UDSPInstruction opc)
   u8 sreg = (opc >> 9) & 0x1;
 
   //	u16 val1 = (sreg == 0) ? dsp_get_ax_l(0) : dsp_get_ax_h(0);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, RegisterExtension::Sign);
   //	u16 val2 = (treg == 0) ? dsp_get_ax_l(1) : dsp_get_ax_h(1);
-  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_add(val1, val2);
   multiply_add();
   //	dsp_set_long_prod(prod);
@@ -688,9 +688,9 @@ void DSPEmitter::msubx(const UDSPInstruction opc)
   u8 sreg = (opc >> 9) & 0x1;
 
   //	u16 val1 = (sreg == 0) ? dsp_get_ax_l(0) : dsp_get_ax_h(0);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg * 2, RCX, RegisterExtension::Sign);
   //	u16 val2 = (treg == 0) ? dsp_get_ax_l(1) : dsp_get_ax_h(1);
-  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL1 + treg * 2, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_sub(val1, val2);
   multiply_sub();
   //	dsp_set_long_prod(prod);
@@ -710,7 +710,7 @@ void DSPEmitter::maddc(const UDSPInstruction opc)
   //	u16 accm = dsp_get_acc_m(sreg);
   get_acc_m(sreg, ECX);
   //	u16 axh = dsp_get_ax_h(treg);
-  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_add(accm, axh);
   multiply_add();
   //	dsp_set_long_prod(prod);
@@ -730,7 +730,7 @@ void DSPEmitter::msubc(const UDSPInstruction opc)
   //	u16 accm = dsp_get_acc_m(sreg);
   get_acc_m(sreg, ECX);
   //	u16 axh = dsp_get_ax_h(treg);
-  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + treg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_sub(accm, axh);
   multiply_sub();
   //	dsp_set_long_prod(prod);
@@ -747,9 +747,9 @@ void DSPEmitter::madd(const UDSPInstruction opc)
   u8 sreg = (opc >> 8) & 0x1;
 
   //	u16 axl = dsp_get_ax_l(sreg);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg, RCX, RegisterExtension::Sign);
   //	u16 axh = dsp_get_ax_h(sreg);
-  dsp_op_read_reg(DSP_REG_AXH0 + sreg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + sreg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_add(axl, axh);
   multiply_add();
   //	dsp_set_long_prod(prod);
@@ -766,9 +766,9 @@ void DSPEmitter::msub(const UDSPInstruction opc)
   u8 sreg = (opc >> 8) & 0x1;
 
   //	u16 axl = dsp_get_ax_l(sreg);
-  dsp_op_read_reg(DSP_REG_AXL0 + sreg, RCX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXL0 + sreg, RCX, RegisterExtension::Sign);
   //	u16 axh = dsp_get_ax_h(sreg);
-  dsp_op_read_reg(DSP_REG_AXH0 + sreg, RAX, SIGN);
+  dsp_op_read_reg(DSP_REG_AXH0 + sreg, RAX, RegisterExtension::Sign);
   //	s64 prod = dsp_multiply_sub(axl, axh);
   multiply_sub();
   //	dsp_set_long_prod(prod);

--- a/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitRegCache.cpp
@@ -808,7 +808,7 @@ void DSPJitRegCache::PutReg(int reg, bool dirty)
   }
 }
 
-void DSPJitRegCache::ReadReg(int sreg, X64Reg host_dreg, DSPJitSignExtend extend)
+void DSPJitRegCache::ReadReg(int sreg, X64Reg host_dreg, RegisterExtension extend)
 {
   const OpArg reg = GetReg(sreg);
 
@@ -817,13 +817,13 @@ void DSPJitRegCache::ReadReg(int sreg, X64Reg host_dreg, DSPJitSignExtend extend
   case 2:
     switch (extend)
     {
-    case SIGN:
+    case RegisterExtension::Sign:
       m_emitter.MOVSX(64, 16, host_dreg, reg);
       break;
-    case ZERO:
+    case RegisterExtension::Zero:
       m_emitter.MOVZX(64, 16, host_dreg, reg);
       break;
-    case NONE:
+    case RegisterExtension::None:
       m_emitter.MOV(16, R(host_dreg), reg);
       break;
     }
@@ -831,13 +831,13 @@ void DSPJitRegCache::ReadReg(int sreg, X64Reg host_dreg, DSPJitSignExtend extend
   case 4:
     switch (extend)
     {
-    case SIGN:
+    case RegisterExtension::Sign:
       m_emitter.MOVSX(64, 32, host_dreg, reg);
       break;
-    case ZERO:
+    case RegisterExtension::Zero:
       m_emitter.MOVZX(64, 32, host_dreg, reg);
       break;
-    case NONE:
+    case RegisterExtension::None:
       m_emitter.MOV(32, R(host_dreg), reg);
       break;
     }

--- a/Source/Core/Core/DSP/Jit/DSPJitRegCache.h
+++ b/Source/Core/Core/DSP/Jit/DSPJitRegCache.h
@@ -29,11 +29,11 @@ enum DSPJitRegSpecial
   DSP_REG_NONE = 255
 };
 
-enum DSPJitSignExtend
+enum class RegisterExtension
 {
-  SIGN,
-  ZERO,
-  NONE
+  Sign,
+  Zero,
+  None
 };
 
 class DSPJitRegCache
@@ -123,7 +123,7 @@ public:
   // Done with all usages of OpArg above
   void PutReg(int reg, bool dirty = true);
 
-  void ReadReg(int sreg, Gen::X64Reg host_dreg, DSPJitSignExtend extend);
+  void ReadReg(int sreg, Gen::X64Reg host_dreg, RegisterExtension extend);
   void WriteReg(int dreg, Gen::OpArg arg);
 
   // Find a free host reg, spill if used, reserve

--- a/Source/Core/Core/DSP/Jit/DSPJitUtil.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitUtil.cpp
@@ -194,7 +194,7 @@ void DSPEmitter::dsp_conditional_extend_accum_imm(int reg, u16 val)
 }
 
 void DSPEmitter::dsp_op_read_reg_dont_saturate(int reg, Gen::X64Reg host_dreg,
-                                               DSPJitSignExtend extend)
+                                               RegisterExtension extend)
 {
   switch (reg & 0x1f)
   {
@@ -205,13 +205,13 @@ void DSPEmitter::dsp_op_read_reg_dont_saturate(int reg, Gen::X64Reg host_dreg,
     dsp_reg_load_stack(reg - DSP_REG_ST0, host_dreg);
     switch (extend)
     {
-    case SIGN:
+    case RegisterExtension::Sign:
       MOVSX(64, 16, host_dreg, R(host_dreg));
       break;
-    case ZERO:
+    case RegisterExtension::Zero:
       MOVZX(64, 16, host_dreg, R(host_dreg));
       break;
-    case NONE:
+    case RegisterExtension::None:
     default:
       break;
     }
@@ -222,7 +222,7 @@ void DSPEmitter::dsp_op_read_reg_dont_saturate(int reg, Gen::X64Reg host_dreg,
   }
 }
 
-void DSPEmitter::dsp_op_read_reg(int reg, Gen::X64Reg host_dreg, DSPJitSignExtend extend)
+void DSPEmitter::dsp_op_read_reg(int reg, Gen::X64Reg host_dreg, RegisterExtension extend)
 {
   switch (reg & 0x1f)
   {
@@ -233,13 +233,13 @@ void DSPEmitter::dsp_op_read_reg(int reg, Gen::X64Reg host_dreg, DSPJitSignExten
     dsp_reg_load_stack(reg - DSP_REG_ST0, host_dreg);
     switch (extend)
     {
-    case SIGN:
+    case RegisterExtension::Sign:
       MOVSX(64, 16, host_dreg, R(host_dreg));
       break;
-    case ZERO:
+    case RegisterExtension::Zero:
       MOVZX(64, 16, host_dreg, R(host_dreg));
       break;
-    case NONE:
+    case RegisterExtension::None:
     default:
       break;
     }
@@ -266,7 +266,7 @@ void DSPEmitter::dsp_op_read_reg(int reg, Gen::X64Reg host_dreg, DSPJitSignExten
     FixupBranch done_positive = J();
 
     SetJumpTarget(negative);
-    if (extend == NONE || extend == ZERO)
+    if (extend == RegisterExtension::None || extend == RegisterExtension::Zero)
       MOV(64, R(host_dreg), Imm32(0x00008000));
     else
       MOV(64, R(host_dreg), Imm32(0xffff8000));
@@ -276,7 +276,7 @@ void DSPEmitter::dsp_op_read_reg(int reg, Gen::X64Reg host_dreg, DSPJitSignExten
     SetJumpTarget(not_40bit);
 
     MOV(64, R(host_dreg), acc_reg);
-    if (extend == NONE || extend == ZERO)
+    if (extend == RegisterExtension::None || extend == RegisterExtension::Zero)
       SHR(64, R(host_dreg), Imm8(16));
     else
       SAR(64, R(host_dreg), Imm8(16));
@@ -744,7 +744,7 @@ void DSPEmitter::set_long_acc(int _reg, X64Reg acc)
 void DSPEmitter::get_acc_l(int _reg, X64Reg acl, bool sign)
 {
   //	return g_dsp.r[DSP_REG_ACM0 + _reg];
-  m_gpr.ReadReg(_reg + DSP_REG_ACL0, acl, sign ? SIGN : ZERO);
+  m_gpr.ReadReg(_reg + DSP_REG_ACL0, acl, sign ? RegisterExtension::Sign : RegisterExtension::Zero);
 }
 
 void DSPEmitter::set_acc_l(int _reg, const OpArg& arg)
@@ -757,7 +757,7 @@ void DSPEmitter::set_acc_l(int _reg, const OpArg& arg)
 void DSPEmitter::get_acc_m(int _reg, X64Reg acm, bool sign)
 {
   //	return g_dsp.r[DSP_REG_ACM0 + _reg];
-  m_gpr.ReadReg(_reg + DSP_REG_ACM0, acm, sign ? SIGN : ZERO);
+  m_gpr.ReadReg(_reg + DSP_REG_ACM0, acm, sign ? RegisterExtension::Sign : RegisterExtension::Zero);
 }
 
 // In: s16 in AX
@@ -771,7 +771,7 @@ void DSPEmitter::set_acc_m(int _reg, const OpArg& arg)
 void DSPEmitter::get_acc_h(int _reg, X64Reg ach, bool sign)
 {
   //	return g_dsp.r.ac[_reg].h;
-  m_gpr.ReadReg(_reg + DSP_REG_ACH0, ach, sign ? SIGN : ZERO);
+  m_gpr.ReadReg(_reg + DSP_REG_ACH0, ach, sign ? RegisterExtension::Sign : RegisterExtension::Zero);
 }
 
 // In: s16 in AX
@@ -785,21 +785,21 @@ void DSPEmitter::set_acc_h(int _reg, const OpArg& arg)
 void DSPEmitter::get_long_acx(int _reg, X64Reg acx)
 {
   //	return ((u32)g_dsp.r[DSP_REG_AXH0 + _reg] << 16) | g_dsp.r[DSP_REG_AXL0 + _reg];
-  m_gpr.ReadReg(_reg + DSP_REG_AX0_32, acx, SIGN);
+  m_gpr.ReadReg(_reg + DSP_REG_AX0_32, acx, RegisterExtension::Sign);
 }
 
 // Returns s16 in EAX
 void DSPEmitter::get_ax_l(int _reg, X64Reg axl)
 {
   //	return (s16)g_dsp.r[DSP_REG_AXL0 + _reg];
-  m_gpr.ReadReg(_reg + DSP_REG_AXL0, axl, SIGN);
+  m_gpr.ReadReg(_reg + DSP_REG_AXL0, axl, RegisterExtension::Sign);
 }
 
 // Returns s16 in EAX
 void DSPEmitter::get_ax_h(int _reg, X64Reg axh)
 {
   //	return (s16)g_dsp.r[DSP_REG_AXH0 + _reg];
-  m_gpr.ReadReg(_reg + DSP_REG_AXH0, axh, SIGN);
+  m_gpr.ReadReg(_reg + DSP_REG_AXH0, axh, RegisterExtension::Sign);
 }
 
 }  // namespace x86


### PR DESCRIPTION
Prevents general names like SIGN, ZERO, and NONE from polluting the surrounding namespace.

Also renames the enum to `RegisterExtension`