### PR TITLE
DSPEmitter: Make most public variables private

### DIFF
--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -259,6 +259,17 @@ public:
   DSPJitRegCache m_gpr{*this};
 
 private:
+  void WriteBranchExit();
+  void WriteBlockLink(u16 dest);
+
+  void ReJitConditional(UDSPInstruction opc, void (DSPEmitter::*conditional_fn)(UDSPInstruction));
+  void r_jcc(UDSPInstruction opc);
+  void r_jmprcc(UDSPInstruction opc);
+  void r_call(UDSPInstruction opc);
+  void r_callr(UDSPInstruction opc);
+  void r_ifcc(UDSPInstruction opc);
+  void r_ret(UDSPInstruction opc);
+
   void Update_SR_Register(Gen::X64Reg val = Gen::EAX);
 
   void get_long_prod(Gen::X64Reg long_prod = Gen::RAX);

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -250,13 +250,8 @@ public:
   const u8* m_reenter_dispatcher;
   const u8* m_stub_entry_point;
   const u8* m_return_dispatcher;
-  u16 m_compile_pc;
-  u16 m_start_address;
-  std::vector<Block> m_block_links;
-  std::vector<u16> m_block_size;
-  std::list<u16> m_unresolved_jumps[MAX_BLOCKS];
 
-  DSPJitRegCache m_gpr{*this};
+  std::list<u16> m_unresolved_jumps[MAX_BLOCKS];
 
 private:
   void WriteBranchExit();
@@ -288,9 +283,16 @@ private:
   void get_ax_h(int _reg, Gen::X64Reg acc = Gen::EAX);
   void get_long_acc(int _reg, Gen::X64Reg acc = Gen::EAX);
 
-  std::vector<DSPCompiledCode> m_blocks;
-  Block m_block_link_entry;
+  DSPJitRegCache m_gpr{*this};
+
+  u16 m_compile_pc;
   u16 m_compile_status_register;
+  u16 m_start_address;
+
+  std::vector<DSPCompiledCode> m_blocks;
+  std::vector<u16> m_block_size;
+  std::vector<Block> m_block_links;
+  Block m_block_link_entry;
 
   // The index of the last stored ext value (compile time).
   int m_store_index = -1;

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -259,14 +259,6 @@ public:
   DSPJitRegCache m_gpr{*this};
 
 private:
-  std::vector<DSPCompiledCode> m_blocks;
-  Block m_block_link_entry;
-  u16 m_compile_status_register;
-
-  // The index of the last stored ext value (compile time).
-  int m_store_index = -1;
-  int m_store_index2 = -1;
-
   void Update_SR_Register(Gen::X64Reg val = Gen::EAX);
 
   void get_long_prod(Gen::X64Reg long_prod = Gen::RAX);
@@ -284,6 +276,14 @@ private:
   void get_ax_l(int _reg, Gen::X64Reg acx = Gen::EAX);
   void get_ax_h(int _reg, Gen::X64Reg acc = Gen::EAX);
   void get_long_acc(int _reg, Gen::X64Reg acc = Gen::EAX);
+
+  std::vector<DSPCompiledCode> m_blocks;
+  Block m_block_link_entry;
+  u16 m_compile_status_register;
+
+  // The index of the last stored ext value (compile time).
+  int m_store_index = -1;
+  int m_store_index2 = -1;
 };
 
 }  // namespace x86


### PR DESCRIPTION
Makes almost all emitter variables private, except for the dispatcher pointers and unresolved jump list array. Making those private will require modifying code within DSPCore, so this PR serves to get the self-contained easy stuff out of the way first.

A separate PR will follow this one up with changes that make the remaining variables private. A bonus from that PR is that it'll move some x86 emitter specifics out of DSPCore.