### PR TITLE
InputConfigDialog pass the device_cbox to the wiimote extension dialogs

### DIFF
--- a/Source/Core/DolphinWX/Input/ClassicInputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/ClassicInputConfigDiag.cpp
@@ -8,10 +8,14 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 ClassicInputConfigDialog::ClassicInputConfigDialog(wxWindow* const parent, InputConfig& config,
-                                                   const wxString& name, const int port_num)
+                                                   const wxString& name,
+                                                   wxComboBox* device_cbox_parent,
+                                                   const int port_num)
     : InputConfigDialog(parent, config, name, port_num)
 {
   const int space5 = FromDIP(5);
+
+  device_cbox = device_cbox_parent;
 
   auto* const group_box_buttons = new ControlGroupBox(
       Wiimote::GetClassicGroup(port_num, WiimoteEmu::ClassicGroup::Buttons), this, this);

--- a/Source/Core/DolphinWX/Input/ClassicInputConfigDiag.h
+++ b/Source/Core/DolphinWX/Input/ClassicInputConfigDiag.h
@@ -6,9 +6,11 @@
 
 #include "DolphinWX/Input/InputConfigDiag.h"
 
+class wxComboBox;
+
 class ClassicInputConfigDialog final : public InputConfigDialog
 {
 public:
   ClassicInputConfigDialog(wxWindow* parent, InputConfig& config, const wxString& name,
-                           int port_num = 0);
+                           wxComboBox* device_cbox_parent, int port_num = 0);
 };

--- a/Source/Core/DolphinWX/Input/DrumsInputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/DrumsInputConfigDiag.cpp
@@ -8,10 +8,13 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 DrumsInputConfigDialog::DrumsInputConfigDialog(wxWindow* const parent, InputConfig& config,
-                                               const wxString& name, const int port_num)
+                                               const wxString& name, wxComboBox* device_cbox_parent,
+                                               const int port_num)
     : InputConfigDialog(parent, config, name, port_num)
 {
   const int space5 = FromDIP(5);
+
+  device_cbox = device_cbox_parent;
 
   auto* const group_box_buttons = new ControlGroupBox(
       Wiimote::GetDrumsGroup(port_num, WiimoteEmu::DrumsGroup::Buttons), this, this);

--- a/Source/Core/DolphinWX/Input/DrumsInputConfigDiag.h
+++ b/Source/Core/DolphinWX/Input/DrumsInputConfigDiag.h
@@ -6,9 +6,11 @@
 
 #include "DolphinWX/Input/InputConfigDiag.h"
 
+class wxComboBox;
+
 class DrumsInputConfigDialog final : public InputConfigDialog
 {
 public:
   DrumsInputConfigDialog(wxWindow* parent, InputConfig& config, const wxString& name,
-                         int port_num = 0);
+                         wxComboBox* device_cbox_parent, int port_num = 0);
 };

--- a/Source/Core/DolphinWX/Input/GuitarInputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/GuitarInputConfigDiag.cpp
@@ -8,10 +8,13 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 GuitarInputConfigDialog::GuitarInputConfigDialog(wxWindow* const parent, InputConfig& config,
-                                                 const wxString& name, const int port_num)
+                                                 const wxString& name,
+                                                 wxComboBox* device_cbox_parent, const int port_num)
     : InputConfigDialog(parent, config, name, port_num)
 {
   const int space5 = FromDIP(5);
+
+  device_cbox = device_cbox_parent;
 
   auto* const group_box_buttons = new ControlGroupBox(
       Wiimote::GetGuitarGroup(port_num, WiimoteEmu::GuitarGroup::Buttons), this, this);

--- a/Source/Core/DolphinWX/Input/GuitarInputConfigDiag.h
+++ b/Source/Core/DolphinWX/Input/GuitarInputConfigDiag.h
@@ -6,9 +6,11 @@
 
 #include "DolphinWX/Input/InputConfigDiag.h"
 
+class wxComboBox;
+
 class GuitarInputConfigDialog final : public InputConfigDialog
 {
 public:
   GuitarInputConfigDialog(wxWindow* parent, InputConfig& config, const wxString& name,
-                          int port_num = 0);
+                          wxComboBox* device_cbox_parent, int port_num = 0);
 };

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -71,31 +71,34 @@ void InputConfigDialog::ConfigExtension(wxCommandEvent& event)
   {
   case WiimoteEmu::EXT_NUNCHUK:
   {
-    NunchukInputConfigDialog dlg(this, m_config, _("Nunchuk Configuration"), m_port_num);
+    NunchukInputConfigDialog dlg(this, m_config, _("Nunchuk Configuration"), device_cbox,
+                                 m_port_num);
     dlg.ShowModal();
   }
   break;
   case WiimoteEmu::EXT_CLASSIC:
   {
-    ClassicInputConfigDialog dlg(this, m_config, _("Classic Controller Configuration"), m_port_num);
+    ClassicInputConfigDialog dlg(this, m_config, _("Classic Controller Configuration"), device_cbox,
+                                 m_port_num);
     dlg.ShowModal();
   }
   break;
   case WiimoteEmu::EXT_GUITAR:
   {
-    GuitarInputConfigDialog dlg(this, m_config, _("Guitar Configuration"), m_port_num);
+    GuitarInputConfigDialog dlg(this, m_config, _("Guitar Configuration"), device_cbox, m_port_num);
     dlg.ShowModal();
   }
   break;
   case WiimoteEmu::EXT_DRUMS:
   {
-    DrumsInputConfigDialog dlg(this, m_config, _("Drums Configuration"), m_port_num);
+    DrumsInputConfigDialog dlg(this, m_config, _("Drums Configuration"), device_cbox, m_port_num);
     dlg.ShowModal();
   }
   break;
   case WiimoteEmu::EXT_TURNTABLE:
   {
-    TurntableInputConfigDialog dlg(this, m_config, _("Turntable Configuration"), m_port_num);
+    TurntableInputConfigDialog dlg(this, m_config, _("Turntable Configuration"), device_cbox,
+                                   m_port_num);
     dlg.ShowModal();
   }
   break;

--- a/Source/Core/DolphinWX/Input/NunchukInputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/NunchukInputConfigDiag.cpp
@@ -8,10 +8,14 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 NunchukInputConfigDialog::NunchukInputConfigDialog(wxWindow* const parent, InputConfig& config,
-                                                   const wxString& name, const int port_num)
+                                                   const wxString& name,
+                                                   wxComboBox* device_cbox_parent,
+                                                   const int port_num)
     : InputConfigDialog(parent, config, name, port_num)
 {
   const int space5 = FromDIP(5);
+
+  device_cbox = device_cbox_parent;
 
   auto* const group_box_buttons = new ControlGroupBox(
       Wiimote::GetNunchukGroup(port_num, WiimoteEmu::NunchukGroup::Buttons), this, this);

--- a/Source/Core/DolphinWX/Input/NunchukInputConfigDiag.h
+++ b/Source/Core/DolphinWX/Input/NunchukInputConfigDiag.h
@@ -6,9 +6,11 @@
 
 #include "DolphinWX/Input/InputConfigDiag.h"
 
+class wxComboBox;
+
 class NunchukInputConfigDialog final : public InputConfigDialog
 {
 public:
   NunchukInputConfigDialog(wxWindow* parent, InputConfig& config, const wxString& name,
-                           int port_num = 0);
+                           wxComboBox* device_cbox_parent, int port_num = 0);
 };

--- a/Source/Core/DolphinWX/Input/TurntableInputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/TurntableInputConfigDiag.cpp
@@ -8,10 +8,14 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 TurntableInputConfigDialog::TurntableInputConfigDialog(wxWindow* const parent, InputConfig& config,
-                                                       const wxString& name, const int port_num)
+                                                       const wxString& name,
+                                                       wxComboBox* device_cbox_parent,
+                                                       const int port_num)
     : InputConfigDialog(parent, config, name, port_num)
 {
   const int space5 = FromDIP(5);
+
+  device_cbox = device_cbox_parent;
 
   auto* const group_box_stick = new ControlGroupBox(
       Wiimote::GetTurntableGroup(port_num, WiimoteEmu::TurntableGroup::Stick), this, this);

--- a/Source/Core/DolphinWX/Input/TurntableInputConfigDiag.h
+++ b/Source/Core/DolphinWX/Input/TurntableInputConfigDiag.h
@@ -6,9 +6,11 @@
 
 #include "DolphinWX/Input/InputConfigDiag.h"
 
+class wxComboBox;
+
 class TurntableInputConfigDialog final : public InputConfigDialog
 {
 public:
   TurntableInputConfigDialog(wxWindow* parent, InputConfig& config, const wxString& name,
-                             int port_num = 0);
+                             wxComboBox* device_cbox_parent, int port_num = 0);
 };


### PR DESCRIPTION
This fixes a crash when trying to open the advanced input config dialog on the wiimote extensions.  The device_cbox wasn't initialised and it should have been with the wiimote one.

Fixes issue [#10043](https://bugs.dolphin-emu.org/issues/10043#note-3)

Tagging @JosJuice as he asked me to look into this issue.