### PR TITLE
DSPCore: Move CompileCurrent to the DSPEmitter

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -314,28 +314,6 @@ void DSPCore_Step()
     step_event.Set();
 }
 
-void CompileCurrent()
-{
-  g_dsp_jit->Compile(g_dsp.pc);
-
-  bool retry = true;
-
-  while (retry)
-  {
-    retry = false;
-    for (u16 i = 0x0000; i < 0xffff; ++i)
-    {
-      if (!g_dsp_jit->m_unresolved_jumps[i].empty())
-      {
-        u16 addrToCompile = g_dsp_jit->m_unresolved_jumps[i].front();
-        g_dsp_jit->Compile(addrToCompile);
-        if (!g_dsp_jit->m_unresolved_jumps[i].empty())
-          retry = true;
-      }
-    }
-  }
-}
-
 u16 DSPCore_ReadRegister(size_t reg)
 {
   switch (reg)

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -354,8 +354,6 @@ void DSPCore_SetExternalInterrupt(bool val);
 // sets a flag in the pending exception register.
 void DSPCore_SetException(u8 level);
 
-void CompileCurrent();
-
 enum DSPCoreState
 {
   DSPCORE_STOP = 0,


### PR DESCRIPTION
This is only ever used here. This gets more x86-specific emitter behavior out of DSPCore.

It kinda sucks that the use of the DSP JIT global can't be eliminated (I think*) reasonably because the function is called by the emitter down in `CompileStub()`

\* - I'm not sure if it would be possible to pass a pointer to the JIT instance into the function to be used as the 'context' variable. I don't know if the x86 emitter supports that.