### PR TITLE
SettingsHandler: Minor cleanup

### DIFF
--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -132,7 +132,7 @@ void SettingsHandler::WriteByte(u8 b)
   m_key = (m_key >> 31) | (m_key << 1);
 }
 
-const std::string SettingsHandler::generateSerialNumber()
+std::string SettingsHandler::GenerateSerialNumber()
 {
   time_t rawtime;
   tm* timeinfo;

--- a/Source/Core/Common/SettingsHandler.cpp
+++ b/Source/Core/Common/SettingsHandler.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "Common/CommonTypes.h"
+#include "Common/FileUtil.h"
 #include "Common/SettingsHandler.h"
 #include "Common/Timer.h"
 
@@ -26,9 +27,30 @@ SettingsHandler::SettingsHandler()
   Reset();
 }
 
+bool SettingsHandler::Open(const std::string& settings_file_path)
+{
+  Reset();
+
+  File::IOFile file{settings_file_path, "rb"};
+  if (!file.ReadBytes(m_buffer.data(), m_buffer.size()))
+    return false;
+
+  Decrypt();
+  return true;
+}
+
+bool SettingsHandler::Save(const std::string& destination_file_path) const
+{
+  if (!File::CreateFullPath(destination_file_path))
+    return false;
+
+  File::IOFile file{destination_file_path, "wb"};
+  return file.WriteBytes(m_buffer.data(), m_buffer.size());
+}
+
 const u8* SettingsHandler::GetData() const
 {
-  return m_buffer;
+  return m_buffer.data();
 }
 
 const std::string SettingsHandler::GetValue(const std::string& key)
@@ -62,10 +84,10 @@ const std::string SettingsHandler::GetValue(const std::string& key)
 
 void SettingsHandler::Decrypt()
 {
-  const u8* str = m_buffer;
+  const u8* str = m_buffer.data();
   while (*str != 0)
   {
-    if (m_position >= SETTINGS_SIZE)
+    if (m_position >= m_buffer.size())
       return;
     decoded.push_back((u8)(m_buffer[m_position] ^ m_key));
     m_position++;
@@ -79,7 +101,7 @@ void SettingsHandler::Reset()
   decoded = "";
   m_position = 0;
   m_key = INITIAL_SEED;
-  memset(m_buffer, 0, SETTINGS_SIZE);
+  m_buffer = {};
 }
 
 void SettingsHandler::AddSetting(const std::string& key, const std::string& value)
@@ -102,7 +124,7 @@ void SettingsHandler::AddSetting(const std::string& key, const std::string& valu
 
 void SettingsHandler::WriteByte(u8 b)
 {
-  if (m_position >= SETTINGS_SIZE)
+  if (m_position >= m_buffer.size())
     return;
 
   m_buffer[m_position] = b ^ m_key;

--- a/Source/Core/Common/SettingsHandler.h
+++ b/Source/Core/Common/SettingsHandler.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -13,14 +14,17 @@
 class SettingsHandler
 {
 public:
-  SettingsHandler();
-
   enum
   {
     SETTINGS_SIZE = 0x100,
     // Key used to encrypt/decrypt setting.txt contents
     INITIAL_SEED = 0x73B5DBFA
   };
+
+  SettingsHandler();
+
+  bool Open(const std::string& settings_file_path);
+  bool Save(const std::string& destination_file_path) const;
 
   void AddSetting(const std::string& key, const std::string& value);
 
@@ -34,7 +38,7 @@ public:
 private:
   void WriteByte(u8 b);
 
-  u8 m_buffer[SETTINGS_SIZE];
+  std::array<u8, SETTINGS_SIZE> m_buffer;
   u32 m_position, m_key;
   std::string decoded;
 };

--- a/Source/Core/Common/SettingsHandler.h
+++ b/Source/Core/Common/SettingsHandler.h
@@ -33,7 +33,7 @@ public:
 
   void Decrypt();
   void Reset();
-  const std::string generateSerialNumber();
+  static std::string GenerateSerialNumber();
 
 private:
   void WriteByte(u8 b);

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -211,7 +211,7 @@ bool CBoot::SetupWiiMemory(u64 ios_title_id)
     if (Core::g_want_determinism)
       serno = "123456789";
     else
-      serno = gen.generateSerialNumber();
+      serno = SettingsHandler::GenerateSerialNumber();
     INFO_LOG(BOOT, "No previous serial number found, generated one instead: %s", serno.c_str());
   }
   else

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -196,18 +196,14 @@ bool CBoot::SetupWiiMemory(u64 ios_title_id)
 
   SettingsHandler gen;
   std::string serno;
-  std::string settings_Filename(
+  const std::string settings_file_path(
       Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) + WII_SETTING);
-  if (File::Exists(settings_Filename))
+  if (File::Exists(settings_file_path) && gen.Open(settings_file_path))
   {
-    File::IOFile settingsFileHandle(settings_Filename, "rb");
-    if (settingsFileHandle.ReadBytes((void*)gen.GetData(), SettingsHandler::SETTINGS_SIZE))
-    {
-      gen.Decrypt();
-      serno = gen.GetValue("SERNO");
-      gen.Reset();
-    }
-    File::Delete(settings_Filename);
+    serno = gen.GetValue("SERNO");
+    gen.Reset();
+
+    File::Delete(settings_file_path);
   }
 
   if (serno.empty() || serno == "000000000")
@@ -233,18 +229,14 @@ bool CBoot::SetupWiiMemory(u64 ios_title_id)
   gen.AddSetting("VIDEO", region_setting.video);
   gen.AddSetting("GAME", region_setting.game);
 
-  File::CreateFullPath(settings_Filename);
+  if (!gen.Save(settings_file_path))
   {
-    File::IOFile settingsFileHandle(settings_Filename, "wb");
-
-    if (!settingsFileHandle.WriteBytes(gen.GetData(), SettingsHandler::SETTINGS_SIZE))
-    {
-      PanicAlertT("SetupWiiMemory: Can't create setting.txt file");
-      return false;
-    }
-    // Write the 256 byte setting.txt to memory.
-    Memory::CopyToEmu(0x3800, gen.GetData(), SettingsHandler::SETTINGS_SIZE);
+    PanicAlertT("SetupWiiMemory: Can't create setting.txt file");
+    return false;
   }
+
+  // Write the 256 byte setting.txt to memory.
+  Memory::CopyToEmu(0x3800, gen.GetData(), SettingsHandler::SETTINGS_SIZE);
 
   INFO_LOG(BOOT, "Setup Wii Memory...");
 

--- a/Source/Core/Core/IOS/Network/Net.cpp
+++ b/Source/Core/Core/IOS/Network/Net.cpp
@@ -126,24 +126,19 @@ IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
     INFO_LOG(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_GENERATED_USER_ID");
     if (config.CreationStage() == NWC24::NWC24Config::NWC24_IDCS_INITIAL)
     {
-      std::string settings_Filename(
+      const std::string settings_file_path(
           Common::GetTitleDataPath(TITLEID_SYSMENU, Common::FROM_SESSION_ROOT) + WII_SETTING);
       SettingsHandler gen;
       std::string area, model;
-      bool _GotSettings = false;
+      bool got_settings = false;
 
-      if (File::Exists(settings_Filename))
+      if (File::Exists(settings_file_path) && gen.Open(settings_file_path))
       {
-        File::IOFile settingsFileHandle(settings_Filename, "rb");
-        if (settingsFileHandle.ReadBytes((void*)gen.GetData(), SettingsHandler::SETTINGS_SIZE))
-        {
-          gen.Decrypt();
-          area = gen.GetValue("AREA");
-          model = gen.GetValue("MODEL");
-          _GotSettings = true;
-        }
+        area = gen.GetValue("AREA");
+        model = gen.GetValue("MODEL");
+        got_settings = true;
       }
-      if (_GotSettings)
+      if (got_settings)
       {
         u8 area_code = GetAreaCode(area);
         u8 id_ctr = config.IdGen();


### PR DESCRIPTION
Adds Open and Close functions to make loading data into the SettingsHandler less error prone. It also gets rid of undefined behavior, since:

```cpp
if (settingsFileHandle.ReadBytes((void*)gen.GetData(), SettingsHandler::SETTINGS_SIZE))
```

casts away const from the returned data in order to write to the buffer.