### PR TITLE
CommandProcessor: Limit scope of ugly SCPFifoStruct.

### DIFF
--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -486,4 +486,43 @@ void SetCpClearRegister()
 {
 }
 
+void HandleUnknownOpcode(u8 cmd_byte, void* buffer, bool preprocess)
+{
+  // TODO(Omega): Maybe dump FIFO to file on this error
+  PanicAlertT("GFX FIFO: Unknown Opcode (0x%02x @ %p, %s).\n"
+              "This means one of the following:\n"
+              "* The emulated GPU got desynced, disabling dual core can help\n"
+              "* Command stream corrupted by some spurious memory bug\n"
+              "* This really is an unknown opcode (unlikely)\n"
+              "* Some other sort of bug\n\n"
+              "Further errors will be sent to the Video Backend log and\n"
+              "Dolphin will now likely crash or hang. Enjoy.",
+              cmd_byte, buffer, preprocess ? "preprocess=true" : "preprocess=false");
+
+  {
+    PanicAlert("Illegal command %02x\n"
+               "CPBase: 0x%08x\n"
+               "CPEnd: 0x%08x\n"
+               "CPHiWatermark: 0x%08x\n"
+               "CPLoWatermark: 0x%08x\n"
+               "CPReadWriteDistance: 0x%08x\n"
+               "CPWritePointer: 0x%08x\n"
+               "CPReadPointer: 0x%08x\n"
+               "CPBreakpoint: 0x%08x\n"
+               "bFF_GPReadEnable: %s\n"
+               "bFF_BPEnable: %s\n"
+               "bFF_BPInt: %s\n"
+               "bFF_Breakpoint: %s\n"
+               "bFF_GPLinkEnable: %s\n"
+               "bFF_HiWatermarkInt: %s\n"
+               "bFF_LoWatermarkInt: %s\n",
+               cmd_byte, fifo.CPBase, fifo.CPEnd, fifo.CPHiWatermark, fifo.CPLoWatermark,
+               fifo.CPReadWriteDistance, fifo.CPWritePointer, fifo.CPReadPointer, fifo.CPBreakpoint,
+               fifo.bFF_GPReadEnable ? "true" : "false", fifo.bFF_BPEnable ? "true" : "false",
+               fifo.bFF_BPInt ? "true" : "false", fifo.bFF_Breakpoint ? "true" : "false",
+               fifo.bFF_GPLinkEnable ? "true" : "false", fifo.bFF_HiWatermarkInt ? "true" : "false",
+               fifo.bFF_LoWatermarkInt ? "true" : "false");
+  }
+}
+
 }  // end of namespace CommandProcessor

--- a/Source/Core/VideoCommon/CommandProcessor.h
+++ b/Source/Core/VideoCommon/CommandProcessor.h
@@ -15,7 +15,35 @@ class Mapping;
 
 namespace CommandProcessor
 {
-extern SCPFifoStruct fifo;  // This one is shared between gfx thread and emulator thread.
+struct SCPFifoStruct
+{
+  // fifo registers
+  volatile u32 CPBase;
+  volatile u32 CPEnd;
+  u32 CPHiWatermark;
+  u32 CPLoWatermark;
+  volatile u32 CPReadWriteDistance;
+  volatile u32 CPWritePointer;
+  volatile u32 CPReadPointer;
+  volatile u32 CPBreakpoint;
+  volatile u32 SafeCPReadPointer;
+
+  volatile u32 bFF_GPLinkEnable;
+  volatile u32 bFF_GPReadEnable;
+  volatile u32 bFF_BPEnable;
+  volatile u32 bFF_BPInt;
+  volatile u32 bFF_Breakpoint;
+
+  volatile u32 bFF_LoWatermarkInt;
+  volatile u32 bFF_HiWatermarkInt;
+
+  volatile u32 bFF_LoWatermark;
+  volatile u32 bFF_HiWatermark;
+};
+
+// This one is shared between gfx thread and emulator thread.
+// It is only used by the Fifo and by the CommandProcessor.
+extern SCPFifoStruct fifo;
 
 // internal hardware addresses
 enum
@@ -137,5 +165,7 @@ bool IsInterruptWaiting();
 void SetCpClearRegister();
 void SetCpControlRegister();
 void SetCpStatusRegister();
+
+void HandleUnknownOpcode(u8 cmd_byte, void* buffer, bool preprocess);
 
 }  // namespace CommandProcessor

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -324,7 +324,7 @@ void RunGpuLoop()
         }
         else
         {
-          SCPFifoStruct& fifo = CommandProcessor::fifo;
+          CommandProcessor::SCPFifoStruct& fifo = CommandProcessor::fifo;
 
           AsyncRequests::GetInstance()->PullEvents();
 
@@ -414,7 +414,7 @@ void GpuMaySleep()
 
 bool AtBreakpoint()
 {
-  SCPFifoStruct& fifo = CommandProcessor::fifo;
+  CommandProcessor::SCPFifoStruct& fifo = CommandProcessor::fifo;
   return fifo.bFF_BPEnable && (fifo.CPReadPointer == fifo.CPBreakpoint);
 }
 
@@ -442,7 +442,7 @@ void RunGpu()
 
 static int RunGpuOnCpu(int ticks)
 {
-  SCPFifoStruct& fifo = CommandProcessor::fifo;
+  CommandProcessor::SCPFifoStruct& fifo = CommandProcessor::fifo;
   bool reset_simd_state = false;
   int available_ticks = int(ticks * SConfig::GetInstance().fSyncGpuOverclock) + s_sync_ticks.load();
   while (fifo.bFF_GPReadEnable && fifo.CPReadWriteDistance && !AtBreakpoint() &&

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -75,47 +75,6 @@ static void InterpretDisplayListPreprocess(u32 address, u32 size)
   }
 }
 
-static void UnknownOpcode(u8 cmd_byte, void* buffer, bool preprocess)
-{
-  // TODO(Omega): Maybe dump FIFO to file on this error
-  PanicAlertT("GFX FIFO: Unknown Opcode (0x%02x @ %p, %s).\n"
-              "This means one of the following:\n"
-              "* The emulated GPU got desynced, disabling dual core can help\n"
-              "* Command stream corrupted by some spurious memory bug\n"
-              "* This really is an unknown opcode (unlikely)\n"
-              "* Some other sort of bug\n\n"
-              "Further errors will be sent to the Video Backend log and\n"
-              "Dolphin will now likely crash or hang. Enjoy.",
-              cmd_byte, buffer, preprocess ? "preprocess=true" : "preprocess=false");
-
-  {
-    SCPFifoStruct& fifo = CommandProcessor::fifo;
-
-    PanicAlert("Illegal command %02x\n"
-               "CPBase: 0x%08x\n"
-               "CPEnd: 0x%08x\n"
-               "CPHiWatermark: 0x%08x\n"
-               "CPLoWatermark: 0x%08x\n"
-               "CPReadWriteDistance: 0x%08x\n"
-               "CPWritePointer: 0x%08x\n"
-               "CPReadPointer: 0x%08x\n"
-               "CPBreakpoint: 0x%08x\n"
-               "bFF_GPReadEnable: %s\n"
-               "bFF_BPEnable: %s\n"
-               "bFF_BPInt: %s\n"
-               "bFF_Breakpoint: %s\n"
-               "bFF_GPLinkEnable: %s\n"
-               "bFF_HiWatermarkInt: %s\n"
-               "bFF_LoWatermarkInt: %s\n",
-               cmd_byte, fifo.CPBase, fifo.CPEnd, fifo.CPHiWatermark, fifo.CPLoWatermark,
-               fifo.CPReadWriteDistance, fifo.CPWritePointer, fifo.CPReadPointer, fifo.CPBreakpoint,
-               fifo.bFF_GPReadEnable ? "true" : "false", fifo.bFF_BPEnable ? "true" : "false",
-               fifo.bFF_BPInt ? "true" : "false", fifo.bFF_Breakpoint ? "true" : "false",
-               fifo.bFF_GPLinkEnable ? "true" : "false", fifo.bFF_HiWatermarkInt ? "true" : "false",
-               fifo.bFF_LoWatermarkInt ? "true" : "false");
-  }
-}
-
 void Init()
 {
   s_bFifoErrorSeen = false;
@@ -277,7 +236,7 @@ u8* Run(DataReader src, u32* cycles, bool in_display_list)
       else
       {
         if (!s_bFifoErrorSeen)
-          UnknownOpcode(cmd_byte, opcodeStart, is_preprocess);
+          CommandProcessor::HandleUnknownOpcode(cmd_byte, opcodeStart, is_preprocess);
         ERROR_LOG(VIDEO, "FIFO: Unknown Opcode(0x%02x @ %p, preprocessing = %s)", cmd_byte,
                   opcodeStart, is_preprocess ? "yes" : "no");
         s_bFifoErrorSeen = true;

--- a/Source/Core/VideoCommon/VideoBackendBase.h
+++ b/Source/Core/VideoCommon/VideoBackendBase.h
@@ -31,32 +31,6 @@ enum class EFBAccessType
   PokeColor
 };
 
-struct SCPFifoStruct
-{
-  // fifo registers
-  volatile u32 CPBase;
-  volatile u32 CPEnd;
-  u32 CPHiWatermark;
-  u32 CPLoWatermark;
-  volatile u32 CPReadWriteDistance;
-  volatile u32 CPWritePointer;
-  volatile u32 CPReadPointer;
-  volatile u32 CPBreakpoint;
-  volatile u32 SafeCPReadPointer;
-
-  volatile u32 bFF_GPLinkEnable;
-  volatile u32 bFF_GPReadEnable;
-  volatile u32 bFF_BPEnable;
-  volatile u32 bFF_BPInt;
-  volatile u32 bFF_Breakpoint;
-
-  volatile u32 bFF_LoWatermarkInt;
-  volatile u32 bFF_HiWatermarkInt;
-
-  volatile u32 bFF_LoWatermark;
-  volatile u32 bFF_HiWatermark;
-};
-
 class VideoBackendBase
 {
 public:


### PR DESCRIPTION
It's only used as an interface between two classes. So no need to declare
it in the backend export header.