### PR TITLE
DSPCore: Move emitter cycle code into DSPEmitter itself

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -245,21 +245,7 @@ int DSPCore_RunCycles(int cycles)
 {
   if (g_dsp_jit)
   {
-    if (g_dsp.external_interrupt_waiting)
-    {
-      DSPCore_CheckExternalInterrupt();
-      DSPCore_CheckExceptions();
-      DSPCore_SetExternalInterrupt(false);
-    }
-
-    g_cycles_left = cycles;
-    auto exec_addr = (JIT::x86::DSPEmitter::DSPCompiledCode)g_dsp_jit->m_enter_dispatcher;
-    exec_addr();
-
-    if (g_dsp.reset_dspjit_codespace)
-      g_dsp_jit->ClearIRAMandDSPJITCodespaceReset();
-
-    return g_cycles_left;
+    return g_dsp_jit->RunCycles(static_cast<u16>(cycles));
   }
 
   while (cycles > 0)

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
@@ -48,6 +48,25 @@ DSPEmitter::~DSPEmitter()
   FreeCodeSpace();
 }
 
+u16 DSPEmitter::RunCycles(u16 cycles)
+{
+  if (g_dsp.external_interrupt_waiting)
+  {
+    DSPCore_CheckExternalInterrupt();
+    DSPCore_CheckExceptions();
+    DSPCore_SetExternalInterrupt(false);
+  }
+
+  g_cycles_left = cycles;
+  auto exec_addr = (DSPCompiledCode)m_enter_dispatcher;
+  exec_addr();
+
+  if (g_dsp.reset_dspjit_codespace)
+    ClearIRAMandDSPJITCodespaceReset();
+
+  return g_cycles_left;
+}
+
 void DSPEmitter::ClearIRAM()
 {
   for (int i = 0x0000; i < 0x1000; i++)

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -32,6 +32,8 @@ public:
   DSPEmitter();
   ~DSPEmitter();
 
+  u16 RunCycles(u16 cycles);
+
   void EmitInstruction(UDSPInstruction inst);
   void ClearIRAM();
   void ClearIRAMandDSPJITCodespaceReset();

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -247,12 +247,6 @@ public:
   void madd(const UDSPInstruction opc);
   void msub(const UDSPInstruction opc);
 
-  // CALL this to start the dispatcher
-  const u8* m_enter_dispatcher;
-  const u8* m_reenter_dispatcher;
-  const u8* m_stub_entry_point;
-  const u8* m_return_dispatcher;
-
   std::list<u16> m_unresolved_jumps[MAX_BLOCKS];
 
 private:
@@ -299,6 +293,12 @@ private:
   // The index of the last stored ext value (compile time).
   int m_store_index = -1;
   int m_store_index2 = -1;
+
+  // CALL this to start the dispatcher
+  const u8* m_enter_dispatcher;
+  const u8* m_reenter_dispatcher;
+  const u8* m_stub_entry_point;
+  const u8* m_return_dispatcher;
 };
 
 }  // namespace x86


### PR DESCRIPTION
Moves more x86 emitter specifics out of DSPCore. This also allows making all of the dispatcher pointers private at the same time.