### PR TITLE
UCodes: Eliminate unnecessary includes in header

### DIFF
--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/HW/DSPHLE/UCodes/AX.h"
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
@@ -10,6 +11,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 #include "Core/HW/DSP.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
+#include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/AXStructs.h"
 
 #define AX_GC

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -19,6 +19,8 @@ namespace DSP
 {
 namespace HLE
 {
+class DSPHLE;
+
 // We can't directly use the mixer_control field from the PB because it does
 // not mean the same in all AX versions. The AX UCode converts the
 // mixer_control value to an AXMixControl bitfield.

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.cpp
@@ -5,12 +5,15 @@
 #define AX_WII  // Used in AXVoice.
 
 #include "Core/HW/DSPHLE/UCodes/AXWii.h"
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 #include "Common/StringUtil.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
+#include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/AXStructs.h"
 #include "Core/HW/DSPHLE/UCodes/AXVoice.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXWii.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/AX.h"
 
 namespace DSP
@@ -11,6 +12,7 @@ namespace DSP
 namespace HLE
 {
 struct AXPBWii;
+class DSPHLE;
 
 class AXWiiUCode : public AXUCode
 {

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "Core/HW/DSPHLE/UCodes/CARD.h"
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/DSP.h"

--- a/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/CARD.h
@@ -4,12 +4,15 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 namespace DSP
 {
 namespace HLE
 {
+class DSPHLE;
+
 class CARDUCode : public UCodeInterface
 {
 public:

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.cpp
@@ -3,11 +3,14 @@
 // Refer to the license.txt file included.
 
 #include "Core/HW/DSPHLE/UCodes/GBA.h"
+
 #include "Common/Align.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/DSP.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
+#include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/GBA.h
@@ -4,12 +4,15 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 namespace DSP
 {
 namespace HLE
 {
+class DSPHLE;
+
 // Computes two 32 bit integers to be returned to the game, based on the
 // provided crypto parameters at the provided MRAM address. The integers are
 // written back to RAM at the dest address provided in the crypto parameters.

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.cpp
@@ -3,8 +3,11 @@
 // Refer to the license.txt file included.
 
 #include "Core/HW/DSPHLE/UCodes/INIT.h"
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
+#include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/INIT.h
@@ -4,12 +4,15 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 namespace DSP
 {
 namespace HLE
 {
+class DSPHLE;
+
 class INITUCode : public UCodeInterface
 {
 public:

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/DSPHLE/UCodes/ROM.h"
+
 #include <string>
 
 #ifdef _WIN32
@@ -15,7 +17,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
-#include "Core/HW/DSPHLE/UCodes/ROM.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
+#include "Core/HW/DSPHLE/MailHandler.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/ROM.h
@@ -4,12 +4,15 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 
 namespace DSP
 {
 namespace HLE
 {
+class DSPHLE;
+
 class ROMUCode : public UCodeInterface
 {
 public:

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "Core/HW/DSPHLE/UCodes/UCodes.h"
+
+#include <cstring>
 #include <string>
 
 #ifdef _WIN32
@@ -9,109 +12,122 @@
 #endif
 
 #include "Common/ChunkFile.h"
+#include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/Hash.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
+#include "Core/HW/DSPHLE/DSPHLE.h"
 #include "Core/HW/DSPHLE/UCodes/AX.h"
 #include "Core/HW/DSPHLE/UCodes/AXWii.h"
 #include "Core/HW/DSPHLE/UCodes/CARD.h"
 #include "Core/HW/DSPHLE/UCodes/GBA.h"
 #include "Core/HW/DSPHLE/UCodes/INIT.h"
 #include "Core/HW/DSPHLE/UCodes/ROM.h"
-#include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/DSPHLE/UCodes/Zelda.h"
+#include "Core/HW/Memmap.h"
 
 namespace DSP
 {
 namespace HLE
 {
-UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
+constexpr bool ExramRead(u32 address)
 {
-  switch (crc)
-  {
-  case UCODE_ROM:
-    INFO_LOG(DSPHLE, "Switching to ROM ucode");
-    return new ROMUCode(dsphle, crc);
-
-  case UCODE_INIT_AUDIO_SYSTEM:
-    INFO_LOG(DSPHLE, "Switching to INIT ucode");
-    return new INITUCode(dsphle, crc);
-
-  case 0x65d6cc6f:  // CARD
-    INFO_LOG(DSPHLE, "Switching to CARD ucode");
-    return new CARDUCode(dsphle, crc);
-
-  case 0xdd7e72d5:
-    INFO_LOG(DSPHLE, "Switching to GBA ucode");
-    return new GBAUCode(dsphle, crc);
-
-  case 0x3ad3b7ac:  // Naruto 3, Paper Mario - The Thousand Year Door
-  case 0x3daf59b9:  // Alien Hominid
-  case 0x4e8a8b21:  // spdemo, Crazy Taxi, 18 Wheeler, Disney, Monkeyball 1/2, Cubivore, Nintendo
-                    // Puzzle Collection, Wario,
-  // Capcom vs. SNK 2, Naruto 2, Lost Kingdoms, Star Fox, Mario Party 4, Mortal Kombat,
-  // Smugglers Run Warzone, Smash Brothers, Sonic Mega Collection, ZooCube
-  // nddemo, Star Fox
-  case 0x07f88145:  // bustamove, Ikaruga, F-Zero GX, Robotech Battle Cry, Star Soldier, Soul
-                    // Calibur 2,
-                    // Zelda:OOT, Tony Hawk, Viewtiful Joe
-  case 0xe2136399:  // Billy Hatcher, Dragon Ball Z, Mario Party 5, TMNT, 1080° Avalanche
-  case 0x3389a79e:  // MP1/MP2 Wii (Metroid Prime Trilogy)
-    INFO_LOG(DSPHLE, "CRC %08x: AX ucode chosen", crc);
-    return new AXUCode(dsphle, crc);
-
-  case 0x86840740:  // Zelda WW - US
-  case 0x6ca33a6d:  // Zelda TP GC - US
-  case 0xd643001f:  // Super Mario Galaxy - US
-  case 0x6ba3b3ea:  // GC IPL - PAL
-  case 0x24b22038:  // GC IPL - US
-  case 0x2fcdf1ec:  // Zelda FSA - US
-  case 0x4be6a5cb:  // Pikmin 1 GC - US
-  case 0x267fd05a:  // Pikmin 1 GC - PAL
-  case 0x42f64ac4:  // Luigi's Mansion - US
-  case 0x56d36052:  // Super Mario Sunshine - US
-  case 0x6c3f6f94:  // Zelda TP Wii - US
-  case 0xb7eb9a9c:  // Pikmin 1 New Play Control Wii - US
-  case 0xeaeb38cc:  // Pikmin 2 New Play Control Wii - US
-    return new ZeldaUCode(dsphle, crc);
-
-  case 0x2ea36ce6:  // Some Wii demos
-  case 0x5ef56da3:  // AX demo
-  case 0x347112ba:  // Raving Rabbids
-  case 0xfa450138:  // Wii Sports - PAL
-  case 0xadbc06bd:  // Elebits
-  case 0x4cc52064:  // Bleach: Versus Crusade
-  case 0xd9c4bf34:  // WiiMenu
-    INFO_LOG(DSPHLE, "CRC %08x: Wii - AXWii chosen", crc);
-    return new AXWiiUCode(dsphle, crc);
-
-  default:
-    if (wii)
-    {
-      PanicAlertT("This title might be incompatible with DSP HLE emulation. Try using LLE if this "
-                  "is homebrew.\n\n"
-                  "Unknown ucode (CRC = %08x) - forcing AXWii.",
-                  crc);
-      return new AXWiiUCode(dsphle, crc);
-    }
-    else
-    {
-      PanicAlertT("This title might be incompatible with DSP HLE emulation. Try using LLE if this "
-                  "is homebrew.\n\n"
-                  "DSPHLE: Unknown ucode (CRC = %08x) - forcing AX.",
-                  crc);
-      return new AXUCode(dsphle, crc);
-    }
-
-  case UCODE_NULL:
-    break;
-  }
-
-  return nullptr;
+  return (address & 0x10000000) != 0;
 }
+
+u8 HLEMemory_Read_U8(u32 address)
+{
+  if (ExramRead(address))
+    return Memory::m_pEXRAM[address & Memory::EXRAM_MASK];
+
+  return Memory::m_pRAM[address & Memory::RAM_MASK];
+}
+
+void HLEMemory_Write_U8(u32 address, u8 value)
+{
+  if (ExramRead(address))
+    Memory::m_pEXRAM[address & Memory::EXRAM_MASK] = value;
+  else
+    Memory::m_pRAM[address & Memory::RAM_MASK] = value;
+}
+
+u16 HLEMemory_Read_U16LE(u32 address)
+{
+  u16 value;
+
+  if (ExramRead(address))
+    std::memcpy(&value, &Memory::m_pEXRAM[address & Memory::EXRAM_MASK], sizeof(u16));
+  else
+    std::memcpy(&value, &Memory::m_pRAM[address & Memory::RAM_MASK], sizeof(u16));
+
+  return value;
+}
+
+u16 HLEMemory_Read_U16(u32 address)
+{
+  return Common::swap16(HLEMemory_Read_U16LE(address));
+}
+
+void HLEMemory_Write_U16LE(u32 address, u16 value)
+{
+  if (ExramRead(address))
+    std::memcpy(&Memory::m_pEXRAM[address & Memory::EXRAM_MASK], &value, sizeof(u16));
+  else
+    std::memcpy(&Memory::m_pRAM[address & Memory::RAM_MASK], &value, sizeof(u16));
+}
+
+void HLEMemory_Write_U16(u32 address, u16 value)
+{
+  HLEMemory_Write_U16LE(address, Common::swap16(value));
+}
+
+u32 HLEMemory_Read_U32LE(u32 address)
+{
+  u32 value;
+
+  if (ExramRead(address))
+    std::memcpy(&value, &Memory::m_pEXRAM[address & Memory::EXRAM_MASK], sizeof(u32));
+  else
+    std::memcpy(&value, &Memory::m_pRAM[address & Memory::RAM_MASK], sizeof(u32));
+
+  return value;
+}
+
+u32 HLEMemory_Read_U32(u32 address)
+{
+  return Common::swap32(HLEMemory_Read_U32LE(address));
+}
+
+void HLEMemory_Write_U32LE(u32 address, u32 value)
+{
+  if (ExramRead(address))
+    std::memcpy(&Memory::m_pEXRAM[address & Memory::EXRAM_MASK], &value, sizeof(u32));
+  else
+    std::memcpy(&Memory::m_pRAM[address & Memory::RAM_MASK], &value, sizeof(u32));
+}
+
+void HLEMemory_Write_U32(u32 address, u32 value)
+{
+  HLEMemory_Write_U32LE(address, Common::swap32(value));
+}
+
+void* HLEMemory_Get_Pointer(u32 address)
+{
+  if (ExramRead(address))
+    return &Memory::m_pEXRAM[address & Memory::EXRAM_MASK];
+
+  return &Memory::m_pRAM[address & Memory::RAM_MASK];
+}
+
+UCodeInterface::UCodeInterface(DSPHLE* dsphle, u32 crc)
+    : m_mail_handler(dsphle->AccessMailHandler()), m_dsphle(dsphle), m_crc(crc)
+{
+}
+
+UCodeInterface::~UCodeInterface() = default;
 
 bool UCodeInterface::NeedsResumeMail()
 {
@@ -209,6 +225,91 @@ void UCodeInterface::DoStateShared(PointerWrap& p)
   p.Do(m_next_ucode);
   p.Do(m_next_ucode_steps);
   p.Do(m_needs_resume_mail);
+}
+
+UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
+{
+  switch (crc)
+  {
+  case UCODE_ROM:
+    INFO_LOG(DSPHLE, "Switching to ROM ucode");
+    return new ROMUCode(dsphle, crc);
+
+  case UCODE_INIT_AUDIO_SYSTEM:
+    INFO_LOG(DSPHLE, "Switching to INIT ucode");
+    return new INITUCode(dsphle, crc);
+
+  case 0x65d6cc6f:  // CARD
+    INFO_LOG(DSPHLE, "Switching to CARD ucode");
+    return new CARDUCode(dsphle, crc);
+
+  case 0xdd7e72d5:
+    INFO_LOG(DSPHLE, "Switching to GBA ucode");
+    return new GBAUCode(dsphle, crc);
+
+  case 0x3ad3b7ac:  // Naruto 3, Paper Mario - The Thousand Year Door
+  case 0x3daf59b9:  // Alien Hominid
+  case 0x4e8a8b21:  // spdemo, Crazy Taxi, 18 Wheeler, Disney, Monkeyball 1/2, Cubivore, Nintendo
+                    // Puzzle Collection, Wario,
+  // Capcom vs. SNK 2, Naruto 2, Lost Kingdoms, Star Fox, Mario Party 4, Mortal Kombat,
+  // Smugglers Run Warzone, Smash Brothers, Sonic Mega Collection, ZooCube
+  // nddemo, Star Fox
+  case 0x07f88145:  // bustamove, Ikaruga, F-Zero GX, Robotech Battle Cry, Star Soldier, Soul
+                    // Calibur 2,
+                    // Zelda:OOT, Tony Hawk, Viewtiful Joe
+  case 0xe2136399:  // Billy Hatcher, Dragon Ball Z, Mario Party 5, TMNT, 1080° Avalanche
+  case 0x3389a79e:  // MP1/MP2 Wii (Metroid Prime Trilogy)
+    INFO_LOG(DSPHLE, "CRC %08x: AX ucode chosen", crc);
+    return new AXUCode(dsphle, crc);
+
+  case 0x86840740:  // Zelda WW - US
+  case 0x6ca33a6d:  // Zelda TP GC - US
+  case 0xd643001f:  // Super Mario Galaxy - US
+  case 0x6ba3b3ea:  // GC IPL - PAL
+  case 0x24b22038:  // GC IPL - US
+  case 0x2fcdf1ec:  // Zelda FSA - US
+  case 0x4be6a5cb:  // Pikmin 1 GC - US
+  case 0x267fd05a:  // Pikmin 1 GC - PAL
+  case 0x42f64ac4:  // Luigi's Mansion - US
+  case 0x56d36052:  // Super Mario Sunshine - US
+  case 0x6c3f6f94:  // Zelda TP Wii - US
+  case 0xb7eb9a9c:  // Pikmin 1 New Play Control Wii - US
+  case 0xeaeb38cc:  // Pikmin 2 New Play Control Wii - US
+    return new ZeldaUCode(dsphle, crc);
+
+  case 0x2ea36ce6:  // Some Wii demos
+  case 0x5ef56da3:  // AX demo
+  case 0x347112ba:  // Raving Rabbids
+  case 0xfa450138:  // Wii Sports - PAL
+  case 0xadbc06bd:  // Elebits
+  case 0x4cc52064:  // Bleach: Versus Crusade
+  case 0xd9c4bf34:  // WiiMenu
+    INFO_LOG(DSPHLE, "CRC %08x: Wii - AXWii chosen", crc);
+    return new AXWiiUCode(dsphle, crc);
+
+  default:
+    if (wii)
+    {
+      PanicAlertT("This title might be incompatible with DSP HLE emulation. Try using LLE if this "
+                  "is homebrew.\n\n"
+                  "Unknown ucode (CRC = %08x) - forcing AXWii.",
+                  crc);
+      return new AXWiiUCode(dsphle, crc);
+    }
+    else
+    {
+      PanicAlertT("This title might be incompatible with DSP HLE emulation. Try using LLE if this "
+                  "is homebrew.\n\n"
+                  "DSPHLE: Unknown ucode (CRC = %08x) - forcing AX.",
+                  crc);
+      return new AXUCode(dsphle, crc);
+    }
+
+  case UCODE_NULL:
+    break;
+  }
+
+  return nullptr;
 }
 }  // namespace HLE
 }  // namespace DSP

--- a/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/Zelda.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
@@ -12,6 +14,8 @@ namespace DSP
 {
 namespace HLE
 {
+class DSPHLE;
+
 class ZeldaAudioRenderer
 {
 public:
@@ -226,11 +230,7 @@ private:
 
   // Utility function to set the current state. Useful for debugging and
   // logging as a hook point.
-  void SetMailState(MailState new_state)
-  {
-    // WARN_LOG(DSPHLE, "MailState %d -> %d", m_mail_current_state, new_state);
-    m_mail_current_state = new_state;
-  }
+  void SetMailState(MailState new_state);
 
   // Voice synchronization / audio rendering flow control. When rendering an
   // audio frame, only voices up to max_voice_id will be rendered until a
@@ -251,25 +251,10 @@ private:
   bool m_cmd_can_execute = true;
 
   // Reads a 32 bit value from the command buffer. Advances the read pointer.
-  u32 Read32()
-  {
-    if (m_read_offset == m_write_offset)
-    {
-      ERROR_LOG(DSPHLE, "Reading too many command params");
-      return 0;
-    }
-
-    u32 res = m_cmd_buffer[m_read_offset];
-    m_read_offset = (m_read_offset + 1) % (sizeof(m_cmd_buffer) / sizeof(u32));
-    return res;
-  }
+  u32 Read32();
 
   // Writes a 32 bit value to the command buffer. Advances the write pointer.
-  void Write32(u32 val)
-  {
-    m_cmd_buffer[m_write_offset] = val;
-    m_write_offset = (m_write_offset + 1) % (sizeof(m_cmd_buffer) / sizeof(u32));
-  }
+  void Write32(u32 val);
 
   // Tries to run as many commands as possible until either the command
   // buffer is empty (pending_commands == 0) or we reached a long lived


### PR DESCRIPTION
Gets rid of the need to include both `Memmap.h` and `DSPHLE.h` in the main base class header. Now less files will need to be rebuilt if any of those headers are changed (e.g. A change in `Memmap.h` won't require rebuilding all UCode source files).