### PR TITLE
DSPEmitter: Remove unused class member variable

### DIFF
--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -296,9 +296,8 @@ private:
 
   // CALL this to start the dispatcher
   const u8* m_enter_dispatcher;
-  const u8* m_reenter_dispatcher;
-  const u8* m_stub_entry_point;
   const u8* m_return_dispatcher;
+  const u8* m_stub_entry_point;
 };
 
 }  // namespace x86


### PR DESCRIPTION
The `m_reenter_dispatcher` pointer was unused.