### PR TITLE
DSPCore: Convert DSP stack register enum into an enum class

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -218,8 +218,8 @@ void DSPCore_CheckExceptions()
       if (Interpreter::dsp_SR_is_flag_set(SR_INT_ENABLE) || (i == EXP_INT))
       {
         // store pc and sr until RTI
-        dsp_reg_store_stack(DSP_STACK_C, g_dsp.pc);
-        dsp_reg_store_stack(DSP_STACK_D, g_dsp.r.sr);
+        dsp_reg_store_stack(StackRegister::Call, g_dsp.pc);
+        dsp_reg_store_stack(StackRegister::Data, g_dsp.r.sr);
 
         g_dsp.pc = i * 2;
         g_dsp.exceptions &= ~(1 << i);

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -161,11 +161,12 @@ enum : u32
   DSP_CMBL = 0xff   // CPU Mailbox L
 };
 
-// Stacks
-enum : int
+enum class StackRegister
 {
-  DSP_STACK_C,
-  DSP_STACK_D
+  Call,
+  Data,
+  LoopAddress,
+  LoopCounter
 };
 
 // cr (Not g_dsp.r[CR]) bits

--- a/Source/Core/Core/DSP/DSPStacks.cpp
+++ b/Source/Core/Core/DSP/DSPStacks.cpp
@@ -3,38 +3,44 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/CommonTypes.h"
-
-#include "Core/DSP/DSPCore.h"
 #include "Core/DSP/DSPStacks.h"
+
+#include <cstddef>
+
+#include "Common/CommonTypes.h"
+#include "Core/DSP/DSPCore.h"
 
 // Stacks. The stacks are outside the DSP RAM, in dedicated hardware.
 namespace DSP
 {
-static void dsp_reg_stack_push(int stack_reg)
+static void dsp_reg_stack_push(size_t stack_reg)
 {
   g_dsp.reg_stack_ptr[stack_reg]++;
   g_dsp.reg_stack_ptr[stack_reg] &= DSP_STACK_MASK;
   g_dsp.reg_stack[stack_reg][g_dsp.reg_stack_ptr[stack_reg]] = g_dsp.r.st[stack_reg];
 }
 
-static void dsp_reg_stack_pop(int stack_reg)
+static void dsp_reg_stack_pop(size_t stack_reg)
 {
   g_dsp.r.st[stack_reg] = g_dsp.reg_stack[stack_reg][g_dsp.reg_stack_ptr[stack_reg]];
   g_dsp.reg_stack_ptr[stack_reg]--;
   g_dsp.reg_stack_ptr[stack_reg] &= DSP_STACK_MASK;
 }
 
-void dsp_reg_store_stack(int stack_reg, u16 val)
+void dsp_reg_store_stack(StackRegister stack_reg, u16 val)
 {
-  dsp_reg_stack_push(stack_reg);
-  g_dsp.r.st[stack_reg] = val;
+  const auto reg_index = static_cast<size_t>(stack_reg);
+
+  dsp_reg_stack_push(reg_index);
+  g_dsp.r.st[reg_index] = val;
 }
 
-u16 dsp_reg_load_stack(int stack_reg)
+u16 dsp_reg_load_stack(StackRegister stack_reg)
 {
-  u16 val = g_dsp.r.st[stack_reg];
-  dsp_reg_stack_pop(stack_reg);
+  const auto reg_index = static_cast<size_t>(stack_reg);
+
+  const u16 val = g_dsp.r.st[reg_index];
+  dsp_reg_stack_pop(reg_index);
   return val;
 }
 }  // namespace DSP

--- a/Source/Core/Core/DSP/DSPStacks.h
+++ b/Source/Core/Core/DSP/DSPStacks.h
@@ -9,6 +9,8 @@
 
 namespace DSP
 {
-void dsp_reg_store_stack(int stack_reg, u16 val);
-u16 dsp_reg_load_stack(int stack_reg);
+enum class StackRegister;
+
+void dsp_reg_store_stack(StackRegister stack_reg, u16 val);
+u16 dsp_reg_load_stack(StackRegister stack_reg);
 }  // namespace DSP

--- a/Source/Core/Core/DSP/Interpreter/DSPIntBranch.cpp
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntBranch.cpp
@@ -28,7 +28,7 @@ void call(const UDSPInstruction opc)
   u16 dest = dsp_fetch_code();
   if (CheckCondition(opc & 0xf))
   {
-    dsp_reg_store_stack(DSP_STACK_C, g_dsp.pc);
+    dsp_reg_store_stack(StackRegister::Call, g_dsp.pc);
     g_dsp.pc = dest;
   }
 }
@@ -45,7 +45,7 @@ void callr(const UDSPInstruction opc)
   {
     u8 reg = (opc >> 5) & 0x7;
     u16 addr = dsp_op_read_reg(reg);
-    dsp_reg_store_stack(DSP_STACK_C, g_dsp.pc);
+    dsp_reg_store_stack(StackRegister::Call, g_dsp.pc);
     g_dsp.pc = addr;
   }
 }
@@ -100,7 +100,7 @@ void ret(const UDSPInstruction opc)
 {
   if (CheckCondition(opc & 0xf))
   {
-    g_dsp.pc = dsp_reg_load_stack(DSP_STACK_C);
+    g_dsp.pc = dsp_reg_load_stack(StackRegister::Call);
   }
 }
 
@@ -111,8 +111,8 @@ void ret(const UDSPInstruction opc)
 // location.
 void rti(const UDSPInstruction opc)
 {
-  g_dsp.r.sr = dsp_reg_load_stack(DSP_STACK_D);
-  g_dsp.pc = dsp_reg_load_stack(DSP_STACK_C);
+  g_dsp.r.sr = dsp_reg_load_stack(StackRegister::Data);
+  g_dsp.pc = dsp_reg_load_stack(StackRegister::Call);
 }
 
 // HALT
@@ -150,9 +150,9 @@ void HandleLoop()
       else
       {
         // end of loop
-        dsp_reg_load_stack(0);
-        dsp_reg_load_stack(2);
-        dsp_reg_load_stack(3);
+        dsp_reg_load_stack(StackRegister::Call);
+        dsp_reg_load_stack(StackRegister::LoopAddress);
+        dsp_reg_load_stack(StackRegister::LoopCounter);
       }
     }
   }
@@ -174,9 +174,9 @@ void loop(const UDSPInstruction opc)
 
   if (cnt)
   {
-    dsp_reg_store_stack(0, g_dsp.pc);
-    dsp_reg_store_stack(2, loop_pc);
-    dsp_reg_store_stack(3, cnt);
+    dsp_reg_store_stack(StackRegister::Call, g_dsp.pc);
+    dsp_reg_store_stack(StackRegister::LoopAddress, loop_pc);
+    dsp_reg_store_stack(StackRegister::LoopCounter, cnt);
   }
   else
   {
@@ -199,9 +199,9 @@ void loopi(const UDSPInstruction opc)
 
   if (cnt)
   {
-    dsp_reg_store_stack(0, g_dsp.pc);
-    dsp_reg_store_stack(2, loop_pc);
-    dsp_reg_store_stack(3, cnt);
+    dsp_reg_store_stack(StackRegister::Call, g_dsp.pc);
+    dsp_reg_store_stack(StackRegister::LoopAddress, loop_pc);
+    dsp_reg_store_stack(StackRegister::LoopCounter, cnt);
   }
   else
   {
@@ -226,9 +226,9 @@ void bloop(const UDSPInstruction opc)
 
   if (cnt)
   {
-    dsp_reg_store_stack(0, g_dsp.pc);
-    dsp_reg_store_stack(2, loop_pc);
-    dsp_reg_store_stack(3, cnt);
+    dsp_reg_store_stack(StackRegister::Call, g_dsp.pc);
+    dsp_reg_store_stack(StackRegister::LoopAddress, loop_pc);
+    dsp_reg_store_stack(StackRegister::LoopCounter, cnt);
   }
   else
   {
@@ -253,9 +253,9 @@ void bloopi(const UDSPInstruction opc)
 
   if (cnt)
   {
-    dsp_reg_store_stack(0, g_dsp.pc);
-    dsp_reg_store_stack(2, loop_pc);
-    dsp_reg_store_stack(3, cnt);
+    dsp_reg_store_stack(StackRegister::Call, g_dsp.pc);
+    dsp_reg_store_stack(StackRegister::LoopAddress, loop_pc);
+    dsp_reg_store_stack(StackRegister::LoopCounter, cnt);
   }
   else
   {

--- a/Source/Core/Core/DSP/Interpreter/DSPIntUtil.h
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntUtil.h
@@ -117,7 +117,7 @@ static inline u16 dsp_op_read_reg(int _reg)
   case DSP_REG_ST1:
   case DSP_REG_ST2:
   case DSP_REG_ST3:
-    return dsp_reg_load_stack(reg - DSP_REG_ST0);
+    return dsp_reg_load_stack(static_cast<StackRegister>(reg - DSP_REG_ST0));
   case DSP_REG_AR0:
   case DSP_REG_AR1:
   case DSP_REG_AR2:
@@ -184,9 +184,8 @@ static inline void dsp_op_write_reg(int _reg, u16 val)
   case DSP_REG_ST1:
   case DSP_REG_ST2:
   case DSP_REG_ST3:
-    dsp_reg_store_stack(reg - DSP_REG_ST0, val);
+    dsp_reg_store_stack(static_cast<StackRegister>(reg - DSP_REG_ST0), val);
     break;
-
   case DSP_REG_AR0:
   case DSP_REG_AR1:
   case DSP_REG_AR2:

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -17,6 +17,8 @@
 
 namespace DSP
 {
+enum class StackRegister;
+
 namespace JIT
 {
 namespace x86
@@ -100,11 +102,11 @@ public:
   void nr(const UDSPInstruction opc);
   void nop(const UDSPInstruction opc) {}
   // Command helpers
-  void dsp_reg_stack_push(int stack_reg);
-  void dsp_reg_stack_pop(int stack_reg);
-  void dsp_reg_store_stack(int stack_reg, Gen::X64Reg host_sreg = Gen::EDX);
-  void dsp_reg_load_stack(int stack_reg, Gen::X64Reg host_dreg = Gen::EDX);
-  void dsp_reg_store_stack_imm(int stack_reg, u16 val);
+  void dsp_reg_stack_push(StackRegister stack_reg);
+  void dsp_reg_stack_pop(StackRegister stack_reg);
+  void dsp_reg_store_stack(StackRegister stack_reg, Gen::X64Reg host_sreg = Gen::EDX);
+  void dsp_reg_load_stack(StackRegister stack_reg, Gen::X64Reg host_dreg = Gen::EDX);
+  void dsp_reg_store_stack_imm(StackRegister stack_reg, u16 val);
   void dsp_op_write_reg(int reg, Gen::X64Reg host_sreg);
   void dsp_op_write_reg_imm(int reg, u16 val);
   void dsp_conditional_extend_accum(int reg);


### PR DESCRIPTION
Makes it more self-documenting which stack is being loaded or stored to, as C, D, and magic numbers are extremely vague.