### PR TITLE
Hack to stop dcbz/dcbi over low MEM1 trashing memory.

### DIFF
--- a/Data/Sys/GameSettings/SQI.ini
+++ b/Data/Sys/GameSettings/SQI.ini
@@ -1,4 +1,4 @@
-# SCYE4Q, SCYP4Q, SCYX4Q, SCYY4Q, SCYZ4Q - Cars 2
+# SQIE4Q, SQIP4Q - Disney Infinity
 
 [Core]
 # Values set here will override the main Dolphin settings.
@@ -7,7 +7,7 @@ LowDCBZHack = 1
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
-EmulationStateId = 1
+EmulationStateId = 3
 EmulationIssues =
 
 [OnLoad]

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -73,6 +73,7 @@ private:
   bool bAccurateNaNs;
   bool bMMU;
   bool bDCBZOFF;
+  bool bLowDCBZHack;
   bool m_EnableJIT;
   bool bSyncGPU;
   bool bFastDiscSpeed;
@@ -145,6 +146,7 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->bAccurateNaNs = bAccurateNaNs;
   config->bMMU = bMMU;
   config->bDCBZOFF = bDCBZOFF;
+  config->bLowDCBZHack = bLowDCBZHack;
   config->m_DSPEnableJIT = m_EnableJIT;
   config->bSyncGPU = bSyncGPU;
   config->bFastDiscSpeed = bFastDiscSpeed;
@@ -248,6 +250,7 @@ bool BootCore(const std::string& _rFilename)
     core_section->Get("AccurateNaNs", &StartUp.bAccurateNaNs, StartUp.bAccurateNaNs);
     core_section->Get("MMU", &StartUp.bMMU, StartUp.bMMU);
     core_section->Get("DCBZ", &StartUp.bDCBZOFF, StartUp.bDCBZOFF);
+    core_section->Get("LowDCBZHack", &StartUp.bLowDCBZHack, StartUp.bLowDCBZHack);
     core_section->Get("SyncGPU", &StartUp.bSyncGPU, StartUp.bSyncGPU);
     core_section->Get("FastDiscSpeed", &StartUp.bFastDiscSpeed, StartUp.bFastDiscSpeed);
     core_section->Get("DSPHLE", &StartUp.bDSPHLE, StartUp.bDSPHLE);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -578,6 +578,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("SyncGpuOverclock", &fSyncGpuOverclock, 1.0f);
   core->Get("FastDiscSpeed", &bFastDiscSpeed, false);
   core->Get("DCBZ", &bDCBZOFF, false);
+  core->Get("LowDCBZHack", &bLowDCBZHack, false);
   core->Get("FPRF", &bFPRF, false);
   core->Get("AccurateNaNs", &bAccurateNaNs, false);
   core->Get("EmulationSpeed", &m_EmulationSpeed, 1.0f);
@@ -725,6 +726,7 @@ void SConfig::LoadDefaults()
   bAccurateNaNs = false;
   bMMU = false;
   bDCBZOFF = false;
+  bLowDCBZHack = false;
   iBBDumpPort = -1;
   bSyncGPU = false;
   bFastDiscSpeed = false;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -106,6 +106,7 @@ struct SConfig : NonCopyable
 
   bool bMMU = false;
   bool bDCBZOFF = false;
+  bool bLowDCBZHack = false;
   int iBBDumpPort = 0;
   bool bFastDiscSpeed = false;
 

--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter_LoadStore.cpp
@@ -362,11 +362,18 @@ void Interpreter::dcbtst(UGeckoInstruction inst)
 
 void Interpreter::dcbz(UGeckoInstruction inst)
 {
-  // TODO: Implement some sort of L2 emulation.
   // DCBZOFF is a hack to fix certain games which would otherwise require
   // accurate L2 emulation.
-  if (!SConfig::GetInstance().bDCBZOFF)
-    PowerPC::ClearCacheLine(Helper_Get_EA_X(inst) & (~31));
+  if (SConfig::GetInstance().bDCBZOFF)
+    return;
+
+  u32 dcbz_addr = Helper_Get_EA_X(inst);
+  // Hack to stop dcbz/dcbi over low MEM1 trashing memory.
+  if (SConfig::GetInstance().bLowDCBZHack && (dcbz_addr < 0x80008000) && (dcbz_addr >= 0x80000000))
+    return;
+
+  // TODO: Implement some sort of L2 emulation.
+  PowerPC::ClearCacheLine(dcbz_addr & (~31));
 }
 
 // eciwx/ecowx technically should access the specified device

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -330,6 +330,7 @@ void Jit64::dcbz(UGeckoInstruction inst)
   JITDISABLE(bJITLoadStoreOff);
   if (SConfig::GetInstance().bDCBZOFF)
     return;
+  FALLBACK_IF(SConfig::GetInstance().bLowDCBZHack);
 
   int a = inst.RA;
   int b = inst.RB;


### PR DESCRIPTION
This adds a hack that prevents dcbz over [0x80000000, 0x80008000).

Titles have been observed dcbz'ing over this range, followed by dcbi. On real hardware, the writes never hit memory, but in dolphin they would because no dcache emulation exists.

This makes Disney Infinity and Cars 2 bootable.