### PR TITLE
IOS STM: Get rid of forward declarations in the cpp file

### DIFF
--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -10,13 +10,8 @@
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"
 #include "Common/Logging/Log.h"
+#include "Core/Core.h"
 #include "Core/HW/Memmap.h"
-
-namespace Core
-{
-void QueueHostJob(std::function<void()> job, bool run_during_stop);
-void Stop();
-}
 
 namespace IOS
 {


### PR DESCRIPTION
Forward declaring functions from a completely different header inside a cpp file can lead to linker errors if either of those functions have changes to their parameter set. Forward declaring also doesn't really provide any benefit within cpp files unless it's to bring an internally linked function within said cpp file into scope.