### PR TITLE
DSPLLE: Only enable the DSP JIT on x64.

### DIFF
--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -142,8 +142,11 @@ static bool FillDSPInitOptions(DSPInitOptions* opts)
   if (!LoadDSPRom(opts->coef_contents.data(), coef_file, DSP_COEF_BYTE_SIZE))
     return false;
 
-  opts->core_type = SConfig::GetInstance().m_DSPEnableJIT ? DSPInitOptions::CORE_JIT :
-                                                            DSPInitOptions::CORE_INTERPRETER;
+  opts->core_type = DSPInitOptions::CORE_INTERPRETER;
+#ifdef _M_X86
+  if (SConfig::GetInstance().m_DSPEnableJIT)
+    opts->core_type = DSPInitOptions::CORE_JIT;
+#endif
 
   if (SConfig::GetInstance().m_DSPCaptureLog)
   {


### PR DESCRIPTION
The x64 JIT is hardcoded right now, and it seems unlikely that we'll support another arch here soon.
So let's just disable the DSP JIT.