### PR TITLE
Fixes std::isprint undefined behavior

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -5,8 +5,8 @@
 #include "Core/Core.h"
 
 #include <atomic>
-#include <cctype>
 #include <cstring>
+#include <locale>
 #include <mutex>
 #include <queue>
 #include <utility>
@@ -178,7 +178,7 @@ void DisplayMessage(const std::string& message, int time_in_ms)
   // Actually displaying non-ASCII could cause things to go pear-shaped
   for (const char& c : message)
   {
-    if (!std::isprint(c))
+    if (!std::isprint(c, std::locale::classic()))
       return;
   }
 


### PR DESCRIPTION
A debug assert and random crashes happen on Windows because of negative char passed to ```std::isprint()```. When messages are translated, the text might have non-ascii characters resulting in a negative number.

Not sure if it's the best way to print a translated message, but at least it prevents Dolphin from crashing.

Ready to be reviewed & merged.