### PR TITLE
DSPAssembler/DSPDisassembler: Make constructors explicit

### DIFF
--- a/Source/Core/Core/DSP/DSPAssembler.h
+++ b/Source/Core/Core/DSP/DSPAssembler.h
@@ -50,7 +50,7 @@ enum err_t
 class DSPAssembler
 {
 public:
-  DSPAssembler(const AssemblerSettings& settings);
+  explicit DSPAssembler(const AssemblerSettings& settings);
   ~DSPAssembler();
 
   // line_numbers is optional (and not yet implemented). It'll receieve a list of ints,

--- a/Source/Core/Core/DSP/DSPDisassembler.h
+++ b/Source/Core/Core/DSP/DSPDisassembler.h
@@ -33,7 +33,7 @@ struct AssemblerSettings
 class DSPDisassembler
 {
 public:
-  DSPDisassembler(const AssemblerSettings& settings);
+  explicit DSPDisassembler(const AssemblerSettings& settings);
   ~DSPDisassembler();
 
   bool Disassemble(int start_pc, const std::vector<u16>& code, int base_addr, std::string& text);


### PR DESCRIPTION
Prevents implicit conversions.