### PR TITLE
Fixes a crash when closing a socket

### DIFF
--- a/Source/Core/Core/IOS/Network/Socket.cpp
+++ b/Source/Core/Core/IOS/Network/Socket.cpp
@@ -615,9 +615,13 @@ s32 WiiSockMan::NewSocket(s32 af, s32 type, s32 protocol)
 
 s32 WiiSockMan::DeleteSocket(s32 s)
 {
+  s32 ReturnValue = EBADF;
   auto socket_entry = WiiSockets.find(s);
-  s32 ReturnValue = socket_entry->second.CloseFd();
-  WiiSockets.erase(socket_entry);
+  if (socket_entry != WiiSockets.end())
+  {
+    ReturnValue = socket_entry->second.CloseFd();
+    WiiSockets.erase(socket_entry);
+  }
   return ReturnValue;
 }
 


### PR DESCRIPTION
Sometimes, Dolphin crashes during the (ICMP)CLOSE while closing a socket that triggers the following assert:
>Debug Assertion Failed!
>
>Program: C:\Windows\system32\MSVCP140D.dll
>File: S:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\list
>Line: 211
>
>Expression: list iterator not dereferencable

And the following callstack:
```C++
 	msvcp140d.dll!std::_Debug_message(const wchar_t * message, const wchar_t * file, unsigned int line) Line 17	C++
 	DolphinD.exe!std::_List_const_iterator<std::_List_val<std::_List_simple_types<std::pair<int const ,IOS::HLE::WiiSocket> > > >::operator*() Line 212	C++
 	DolphinD.exe!std::_List_iterator<std::_List_val<std::_List_simple_types<std::pair<int const ,IOS::HLE::WiiSocket> > > >::operator*() Line 367	C++
 	DolphinD.exe!std::_List_iterator<std::_List_val<std::_List_simple_types<std::pair<int const ,IOS::HLE::WiiSocket> > > >::operator->() Line 371	C++
>	DolphinD.exe!IOS::HLE::WiiSockMan::DeleteSocket(int s) Line 619	C++
 	DolphinD.exe!IOS::HLE::Device::NetIPTop::IOCtl(const IOS::HLE::IOCtlRequest & request) Line 585	C++
 	DolphinD.exe!IOS::HLE::HandleCommand(const IOS::HLE::Request & request) Line 761	C++
 	DolphinD.exe!IOS::HLE::ExecuteCommand(unsigned int address) Line 773	C++
 	DolphinD.exe!IOS::HLE::Update() Line 823	C++
 	DolphinD.exe!IOS::HLE::EnqueueEvent(unsigned __int64 userdata, __int64 cycles_late) Line 405	C++
 	DolphinD.exe!CoreTiming::Advance() Line 336	C++
 	[External Code]	
```

Ready to be reviewed & merged.