### PR TITLE
DolphinWX: Make GCN language selection UI less weird

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -81,6 +81,7 @@ private:
   bool bHLE_BS2;
   bool bProgressive;
   bool bPAL60;
+  bool bJapaneseVIBit;
   int iSelectedLanguage;
   int iCPUCore;
   int Volume;
@@ -115,6 +116,7 @@ void ConfigCache::SaveConfig(const SConfig& config)
   bProgressive = config.bProgressive;
   bPAL60 = config.bPAL60;
   iSelectedLanguage = config.SelectedLanguage;
+  bJapaneseVIBit = config.bJapaneseVIBit;
   iCPUCore = config.iCPUCore;
   Volume = config.m_Volume;
   m_EmulationSpeed = config.m_EmulationSpeed;
@@ -159,6 +161,7 @@ void ConfigCache::RestoreConfig(SConfig* config)
   config->bProgressive = bProgressive;
   config->bPAL60 = bPAL60;
   config->SelectedLanguage = iSelectedLanguage;
+  config->bJapaneseVIBit = bJapaneseVIBit;
   config->iCPUCore = iCPUCore;
 
   // Only change these back if they were actually set by game ini, since they can be changed while a
@@ -373,19 +376,17 @@ bool BootCore(const std::string& _rFilename)
     g_SRAM_netplay_initialized = false;
   }
 
-  const bool ntsc = DiscIO::IsNTSC(StartUp.m_region);
-
   // Apply overrides
   // Some NTSC GameCube games such as Baten Kaitos react strangely to
   // language settings that would be invalid on an NTSC system
-  if (!StartUp.bOverrideGCLanguage && ntsc)
+  if (!StartUp.bOverrideGCLanguage && !StartUp.GCLanguageAndRegionCompatible())
   {
-    StartUp.SelectedLanguage = 0;
+    StartUp.SetDefaultGCLanguageForRegion();
   }
 
   // Some NTSC Wii games such as Doc Louis's Punch-Out!! and
   // 1942 (Virtual Console) crash if the PAL60 option is enabled
-  if (StartUp.bWii && ntsc)
+  if (StartUp.bWii && DiscIO::IsNTSC(StartUp.m_region))
   {
     StartUp.bPAL60 = false;
   }

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -178,7 +178,6 @@ void SConfig::SaveDisplaySettings(IniFile& ini)
   display->Set("ProgressiveScan", bProgressive);
   display->Set("PAL60", bPAL60);
   display->Set("DisableScreenSaver", bDisableScreenSaver);
-  display->Set("ForceNTSCJ", bForceNTSCJ);
 }
 
 void SConfig::SaveGameListSettings(IniFile& ini)
@@ -242,6 +241,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("EnableCheats", bEnableCheats);
   core->Set("SelectedLanguage", SelectedLanguage);
   core->Set("OverrideGCLang", bOverrideGCLanguage);
+  core->Set("JapaneseVIBit", bJapaneseVIBit);
   core->Set("DPL2Decoder", bDPL2Decoder);
   core->Set("Latency", iLatency);
   core->Set("MemcardAPath", m_strMemoryCardA);
@@ -496,7 +496,6 @@ void SConfig::LoadDisplaySettings(IniFile& ini)
   display->Get("ProgressiveScan", &bProgressive, false);
   display->Get("PAL60", &bPAL60, true);
   display->Get("DisableScreenSaver", &bDisableScreenSaver, true);
-  display->Get("ForceNTSCJ", &bForceNTSCJ, false);
 }
 
 void SConfig::LoadGameListSettings(IniFile& ini)
@@ -563,6 +562,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("EnableCheats", &bEnableCheats, false);
   core->Get("SelectedLanguage", &SelectedLanguage, 0);
   core->Get("OverrideGCLang", &bOverrideGCLanguage, false);
+  core->Get("JapaneseVIBit", &bJapaneseVIBit, false);
   core->Get("DPL2Decoder", &bDPL2Decoder, false);
   core->Get("Latency", &iLatency, 2);
   core->Get("MemcardAPath", &m_strMemoryCardA);
@@ -1150,4 +1150,43 @@ std::vector<std::string> SConfig::GetGameIniFilenames(const std::string& id, u16
   filenames.push_back(id + StringFromFormat("r%d", revision) + ".ini");
 
   return filenames;
+}
+
+bool SConfig::GCLanguageAndRegionCompatible() const
+{
+  switch (m_region)
+  {
+  case DiscIO::Region::NTSC_J:
+    return (SelectedLanguage == 0) && bJapaneseVIBit;  // Japanese
+
+  case DiscIO::Region::NTSC_U:
+    return (SelectedLanguage == 0) && !bJapaneseVIBit;  // English
+
+  case DiscIO::Region::PAL:
+    return ((SelectedLanguage == 0) && !bJapaneseVIBit) ||  // English
+           SelectedLanguage == 1 ||                         // German
+           SelectedLanguage == 2 ||                         // French
+           SelectedLanguage == 3 ||                         // Spanish
+           SelectedLanguage == 4 ||                         // Italian
+           SelectedLanguage == 5;                           // Dutch
+
+  default:
+    return false;
+  }
+}
+
+void SConfig::SetDefaultGCLanguageForRegion()
+{
+  switch (m_region)
+  {
+  case DiscIO::Region::NTSC_J:
+    SelectedLanguage = 0;
+    bJapaneseVIBit = true;
+    break;
+
+  default:
+    SelectedLanguage = 0;
+    bJapaneseVIBit = false;
+    break;
+  }
 }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -95,7 +95,7 @@ struct SConfig : NonCopyable
   bool bDSPThread = false;
   bool bDSPHLE = true;
   bool bSyncGPUOnSkipIdleHack = true;
-  bool bForceNTSCJ = false;
+  bool bJapaneseVIBit = false;
   bool bHLE_BS2 = true;
   bool bEnableCheats = false;
   bool bEnableMemcardSdWriting = true;
@@ -120,6 +120,8 @@ struct SConfig : NonCopyable
 
   int SelectedLanguage = 0;
   bool bOverrideGCLanguage = false;
+  bool GCLanguageAndRegionCompatible() const;
+  void SetDefaultGCLanguageForRegion();
 
   bool bWii = false;
 

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -181,7 +181,7 @@ void Preset(bool _bNTSC)
 
   // Say component cable is plugged
   m_DTVStatus.component_plugged = SConfig::GetInstance().bProgressive;
-  m_DTVStatus.ntsc_j = SConfig::GetInstance().bForceNTSCJ || region == DiscIO::Region::NTSC_J;
+  m_DTVStatus.ntsc_j = SConfig::GetInstance().bJapaneseVIBit;
 
   m_FBWidth.Hex = 0;
   m_BorderHBlank.Hex = 0;

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -36,6 +36,7 @@ private:
   void ChooseEXIDevice(const wxString& device_name, int device_id);
   void HandleEXISlotChange(int slot, const wxString& title);
   void ChooseSlotPath(bool is_slot_a, TEXIDevices device_type);
+  void SetSystemLanguage(int language);
 
   wxArrayString m_ipl_language_strings;
 

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -54,7 +54,6 @@ void GeneralConfigPane::InitializeGUI()
 
   m_dual_core_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Dual Core (speedup)"));
   m_cheats_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Cheats"));
-  m_force_ntscj_checkbox = new wxCheckBox(this, wxID_ANY, _("Force Console as NTSC-J"));
   m_analytics_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Usage Statistics Reporting"));
 #ifdef __APPLE__
   m_analytics_new_id = new wxButton(this, wxID_ANY, _("Generate a New Statistics Identity"),
@@ -72,9 +71,6 @@ void GeneralConfigPane::InitializeGUI()
       _("Splits the CPU and GPU threads so they can be run on separate cores.\nProvides major "
         "speed improvements on most modern PCs, but can cause occasional crashes/glitches."));
   m_cheats_checkbox->SetToolTip(_("Enables the use of Action Replay and Gecko cheats."));
-  m_force_ntscj_checkbox->SetToolTip(
-      _("Forces NTSC-J mode for using the Japanese ROM font.\nIf left unchecked, Dolphin defaults "
-        "to NTSC-U and automatically enables this setting when playing Japanese games."));
   m_analytics_checkbox->SetToolTip(
       _("Enables the collection and sharing of usage statistics data with the Dolphin development "
         "team. This data is used to improve the emulator and help us understand how our users "
@@ -119,8 +115,6 @@ void GeneralConfigPane::InitializeGUI()
   advanced_settings_sizer->AddSpacer(space5);
   advanced_settings_sizer->Add(m_cpu_engine_radiobox, 0, wxLEFT | wxRIGHT, space5);
   advanced_settings_sizer->AddSpacer(space5);
-  advanced_settings_sizer->Add(m_force_ntscj_checkbox, 0, wxLEFT | wxRIGHT, space5);
-  advanced_settings_sizer->AddSpacer(space5);
 
   wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);
   main_sizer->AddSpacer(space5);
@@ -140,7 +134,6 @@ void GeneralConfigPane::LoadGUIValues()
 
   m_dual_core_checkbox->SetValue(startup_params.bCPUThread);
   m_cheats_checkbox->SetValue(startup_params.bEnableCheats);
-  m_force_ntscj_checkbox->SetValue(startup_params.bForceNTSCJ);
   m_analytics_checkbox->SetValue(startup_params.m_analytics_enabled);
   u32 selection = std::lround(startup_params.m_EmulationSpeed * 10.0f);
   if (selection < m_throttler_array_string.size())
@@ -160,10 +153,6 @@ void GeneralConfigPane::BindEvents()
 
   m_cheats_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnCheatCheckBoxChanged, this);
   m_cheats_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
-
-  m_force_ntscj_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnForceNTSCJCheckBoxChanged,
-                               this);
-  m_force_ntscj_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 
   m_analytics_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnAnalyticsCheckBoxChanged, this);
 
@@ -186,11 +175,6 @@ void GeneralConfigPane::OnDualCoreCheckBoxChanged(wxCommandEvent& event)
 void GeneralConfigPane::OnCheatCheckBoxChanged(wxCommandEvent& event)
 {
   SConfig::GetInstance().bEnableCheats = m_cheats_checkbox->IsChecked();
-}
-
-void GeneralConfigPane::OnForceNTSCJCheckBoxChanged(wxCommandEvent& event)
-{
-  SConfig::GetInstance().bForceNTSCJ = m_force_ntscj_checkbox->IsChecked();
 }
 
 void GeneralConfigPane::OnThrottlerChoiceChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.h
@@ -31,7 +31,6 @@ private:
 
   void OnDualCoreCheckBoxChanged(wxCommandEvent&);
   void OnCheatCheckBoxChanged(wxCommandEvent&);
-  void OnForceNTSCJCheckBoxChanged(wxCommandEvent&);
   void OnThrottlerChoiceChanged(wxCommandEvent&);
   void OnCPUEngineRadioBoxChanged(wxCommandEvent&);
   void OnAnalyticsCheckBoxChanged(wxCommandEvent&);
@@ -42,7 +41,6 @@ private:
 
   wxCheckBox* m_dual_core_checkbox;
   wxCheckBox* m_cheats_checkbox;
-  wxCheckBox* m_force_ntscj_checkbox;
 
   wxCheckBox* m_analytics_checkbox;
   wxButton* m_analytics_new_id;


### PR DESCRIPTION
There are some weird details with GCN language selection

Values 1,2,3,4,5 correspond with German,French,Spanish,Italian,Dutch. Value 0 corresponds to both Japanese and English, the former being selected if a bit in a VI register is set, the latter if it's cleared.

This PR abstracts these details from the user and removes an unnecessary option from the config.