### PR TITLE
LightingShaderGen: Remove unnecessary includes

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DUtil.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DUtil.cpp
@@ -9,6 +9,8 @@
 #include <string>
 
 #include "Common/Align.h"
+#include "Common/Assert.h"
+#include "Common/Logging/Log.h"
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DShader.h"
 #include "VideoBackends/D3D/D3DState.h"

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -2,6 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/D3D/VertexManager.h"
+
+#include <d3d11.h>
+
 #include "Common/CommonTypes.h"
 
 #include "VideoBackends/D3D/BoundingBox.h"
@@ -10,12 +14,12 @@
 #include "VideoBackends/D3D/GeometryShaderCache.h"
 #include "VideoBackends/D3D/PixelShaderCache.h"
 #include "VideoBackends/D3D/Render.h"
-#include "VideoBackends/D3D/VertexManager.h"
 #include "VideoBackends/D3D/VertexShaderCache.h"
 
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/Debugger.h"
 #include "VideoCommon/IndexGenerator.h"
+#include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderManager.h"

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -6,6 +6,8 @@
 
 #include "VideoCommon/VertexManagerBase.h"
 
+struct ID3D11Buffer;
+
 namespace DX11
 {
 class VertexManager : public VertexManagerBase

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -3,7 +3,11 @@
 // Refer to the license.txt file included.
 
 #include "VideoBackends/D3D12/TextureCache.h"
+
 #include "Common/Align.h"
+#include "Common/Assert.h"
+#include "Common/Logging/Log.h"
+
 #include "VideoBackends/D3D12/D3DBase.h"
 #include "VideoBackends/D3D12/D3DCommandListManager.h"
 #include "VideoBackends/D3D12/D3DDescriptorHeapManager.h"
@@ -15,8 +19,8 @@
 #include "VideoBackends/D3D12/PSTextureEncoder.h"
 #include "VideoBackends/D3D12/StaticShaderCache.h"
 #include "VideoBackends/D3D12/TextureEncoder.h"
+
 #include "VideoCommon/ImageWrite.h"
-#include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoConfig.h"
 

--- a/Source/Core/VideoBackends/D3D12/XFBEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D12/XFBEncoder.cpp
@@ -3,13 +3,15 @@
 // Refer to the license.txt file included.
 
 #include "VideoBackends/D3D12/XFBEncoder.h"
+
 #include "Common/Align.h"
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
+
 #include "VideoBackends/D3D12/D3DBase.h"
 #include "VideoBackends/D3D12/D3DCommandListManager.h"
-#include "VideoBackends/D3D12/D3DShader.h"
 #include "VideoBackends/D3D12/D3DState.h"
 #include "VideoBackends/D3D12/D3DUtil.h"
 #include "VideoBackends/D3D12/FramebufferManager.h"

--- a/Source/Core/VideoBackends/Null/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Null/VertexManager.cpp
@@ -3,12 +3,12 @@
 // Refer to the license.txt file included.
 
 #include "VideoBackends/Null/VertexManager.h"
+
 #include "VideoBackends/Null/ShaderCache.h"
 
 #include "VideoCommon/IndexGenerator.h"
-#include "VideoCommon/Statistics.h"
+#include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/VertexLoaderManager.h"
-#include "VideoCommon/VideoConfig.h"
 
 namespace Null
 {

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -2,16 +2,18 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/OGL/ProgramShaderCache.h"
+
 #include <memory>
 #include <string>
 
 #include "Common/Align.h"
 #include "Common/Common.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
 #include "Core/ConfigManager.h"
 
-#include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/Render.h"
 #include "VideoBackends/OGL/StreamBuffer.h"
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -19,6 +19,7 @@
 #include "Common/GL/GLUtil.h"
 #include "Common/Logging/LogManager.h"
 #include "Common/MathUtil.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
 #include "Core/Core.h"

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -2,35 +2,27 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/OGL/TextureCache.h"
+
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <fstream>
 #include <memory>
 #include <vector>
 
-#include "Common/Common.h"
-#include "Common/CommonPaths.h"
-#include "Common/FileUtil.h"
-#include "Common/Hash.h"
-#include "Common/MemoryUtil.h"
-#include "Common/StringUtil.h"
-
 #include "Common/GL/GLInterfaceBase.h"
-
-#include "Core/HW/Memmap.h"
+#include "Common/MsgHandler.h"
+#include "Common/StringUtil.h"
 
 #include "VideoBackends/OGL/FramebufferManager.h"
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/Render.h"
 #include "VideoBackends/OGL/SamplerCache.h"
 #include "VideoBackends/OGL/StreamBuffer.h"
-#include "VideoBackends/OGL/TextureCache.h"
 #include "VideoBackends/OGL/TextureConverter.h"
 
-#include "VideoCommon/BPStructs.h"
-#include "VideoCommon/HiresTextures.h"
 #include "VideoCommon/ImageWrite.h"
-#include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoConfig.h"
 

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -4,10 +4,13 @@
 
 // Fast image conversion using OpenGL shaders.
 
+#include "VideoBackends/OGL/TextureConverter.h"
+
 #include <string>
 
 #include "Common/Common.h"
 #include "Common/FileUtil.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
 #include "Core/HW/Memmap.h"
@@ -17,9 +20,7 @@
 #include "VideoBackends/OGL/Render.h"
 #include "VideoBackends/OGL/SamplerCache.h"
 #include "VideoBackends/OGL/TextureCache.h"
-#include "VideoBackends/OGL/TextureConverter.h"
 
-#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/VideoCommon.h"

--- a/Source/Core/VideoBackends/OGL/TextureConverter.h
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "Common/GL/GLUtil.h"
 
-#include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VideoCommon.h"
 
 namespace OGL

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -7,8 +7,10 @@
 #include <algorithm>
 #include <cstddef>
 
+#include "Common/Assert.h"
 #include "Common/CommonFuncs.h"
 #include "Common/Logging/Log.h"
+#include "Common/MsgHandler.h"
 
 #include "Core/HW/Memmap.h"
 

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -9,8 +9,11 @@
 #include <type_traits>
 #include <xxhash.h>
 
+#include "Common/Assert.h"
 #include "Common/CommonFuncs.h"
 #include "Common/LinearDiskCache.h"
+#include "Common/MsgHandler.h"
+
 #include "Core/ConfigManager.h"
 
 #include "VideoBackends/Vulkan/ShaderCompiler.h"

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <string>
 
+#include "Common/Assert.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.h
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.h
@@ -13,6 +13,7 @@
 #include "VideoBackends/Vulkan/Constants.h"
 #include "VideoBackends/Vulkan/ObjectCache.h"
 #include "VideoCommon/GeometryShaderGen.h"
+#include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/PixelShaderGen.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VertexShaderGen.h"

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -3,6 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "VideoBackends/Vulkan/VertexManager.h"
+
+#include "Common/MsgHandler.h"
+
 #include "VideoBackends/Vulkan/BoundingBox.h"
 #include "VideoBackends/Vulkan/CommandBufferManager.h"
 #include "VideoBackends/Vulkan/FramebufferManager.h"

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "Common/Logging/LogManager.h"
-#include "Core/Host.h"
+#include "Common/MsgHandler.h"
 
 #include "VideoBackends/Vulkan/CommandBufferManager.h"
 #include "VideoBackends/Vulkan/Constants.h"
@@ -20,7 +20,6 @@
 #include "VideoBackends/Vulkan/VideoBackend.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
-#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"

--- a/Source/Core/VideoCommon/LightingShaderGen.cpp
+++ b/Source/Core/VideoCommon/LightingShaderGen.cpp
@@ -2,7 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <VideoCommon/LightingShaderGen.h>
+#include "VideoCommon/LightingShaderGen.h"
+
+#include "Common/Assert.h"
+#include "Common/CommonTypes.h"
+
+#include "VideoCommon/NativeVertexFormat.h"
+#include "VideoCommon/ShaderGenCommon.h"
 
 static void GenerateLightShader(ShaderCode& object, const LightingUidData& uid_data, int index,
                                 int litchan_index, bool alpha)

--- a/Source/Core/VideoCommon/LightingShaderGen.h
+++ b/Source/Core/VideoCommon/LightingShaderGen.h
@@ -4,11 +4,9 @@
 
 #pragma once
 
-#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
-#include "VideoCommon/NativeVertexFormat.h"
-#include "VideoCommon/ShaderGenCommon.h"
-#include "VideoCommon/XFMemory.h"
+
+class ShaderCode;
 
 #define LIGHT_COL "%s[%d].color.%s"
 #define LIGHT_COL_PARAMS(index, swizzle) (I_LIGHTS), (index), (swizzle)

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoCommon/PixelShaderGen.h"
+
 #include <cmath>
 #include <cstdio>
 #include <cstring>
@@ -13,7 +15,7 @@
 #include "VideoCommon/BoundingBox.h"
 #include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/LightingShaderGen.h"
-#include "VideoCommon/PixelShaderGen.h"
+#include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"


### PR DESCRIPTION
Gets rid of a few unnecessary includes in LightingShaderGen's header, which also uncovered some indirect inclusions in some other cpp files.