### PR TITLE
ShaderGenCommon: Remove unnecessary includes

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -3,6 +3,8 @@
 // Refer to the license.txt file included.
 
 #include "VideoBackends/D3D/PSTextureEncoder.h"
+
+#include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DShader.h"

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
-#include "VideoBackends/D3D/TextureEncoder.h"
+#include <map>
 
-#include "VideoCommon/TextureCacheBase.h"
+#include "Common/CommonTypes.h"
+#include "VideoBackends/D3D/TextureEncoder.h"
+#include "VideoCommon/VideoCommon.h"
 
 struct ID3D11Texture2D;
 struct ID3D11RenderTargetView;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -13,10 +13,10 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 
 #include "Core/Core.h"
-#include "Core/Host.h"
 
 #include "VideoBackends/D3D/BoundingBox.h"
 #include "VideoBackends/D3D/D3DBase.h"
@@ -31,13 +31,13 @@
 
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/BPFunctions.h"
-#include "VideoCommon/Fifo.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/SamplerCommon.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/XFMemory.h"
 
 namespace DX11
 {

--- a/Source/Core/VideoBackends/D3D/Television.cpp
+++ b/Source/Core/VideoBackends/D3D/Television.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/D3D/Television.h"
+
 #include <vector>
 
 #include "Core/HW/Memmap.h"
@@ -9,8 +11,8 @@
 #include "VideoBackends/D3D/D3DShader.h"
 #include "VideoBackends/D3D/D3DState.h"
 #include "VideoBackends/D3D/D3DUtil.h"
-#include "VideoBackends/D3D/Television.h"
 #include "VideoBackends/D3D/VertexShaderCache.h"
+#include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 
 namespace DX11

--- a/Source/Core/VideoBackends/D3D/Television.h
+++ b/Source/Core/VideoBackends/D3D/Television.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "VideoCommon/VideoCommon.h"
+#include "Common/CommonTypes.h"
 
 struct ID3D11Texture2D;
 struct ID3D11ShaderResourceView;

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -2,8 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/D3D/TextureCache.h"
+
 #include <algorithm>
 #include <memory>
+
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DShader.h"
@@ -13,11 +18,9 @@
 #include "VideoBackends/D3D/GeometryShaderCache.h"
 #include "VideoBackends/D3D/PSTextureEncoder.h"
 #include "VideoBackends/D3D/PixelShaderCache.h"
-#include "VideoBackends/D3D/TextureCache.h"
 #include "VideoBackends/D3D/TextureEncoder.h"
 #include "VideoBackends/D3D/VertexShaderCache.h"
 #include "VideoCommon/ImageWrite.h"
-#include "VideoCommon/LookUpTables.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoConfig.h"
 

--- a/Source/Core/VideoBackends/D3D/TextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/TextureEncoder.h
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include "VideoCommon/BPMemory.h"
-#include "VideoCommon/TextureCacheBase.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/VideoCommon.h"
 
 namespace DX11

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "VideoBackends/D3D12/D3DTexture.h"
 #include "VideoCommon/FramebufferManagerBase.h"
 

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
@@ -3,8 +3,13 @@
 // Refer to the license.txt file included.
 
 #include "VideoBackends/D3D12/PSTextureEncoder.h"
+
 #include "Common/Align.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
+
 #include "Core/HW/Memmap.h"
+
 #include "VideoBackends/D3D12/D3DBase.h"
 #include "VideoBackends/D3D12/D3DCommandListManager.h"
 #include "VideoBackends/D3D12/D3DDescriptorHeapManager.h"

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.h
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include <map>
+#include <vector>
+
+#include "Common/CommonTypes.h"
 #include "VideoBackends/D3D12/D3DBase.h"
 #include "VideoBackends/D3D12/TextureEncoder.h"
-#include "VideoCommon/TextureCacheBase.h"
 
 namespace DX12
 {

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -14,10 +14,10 @@
 #include "Common/Align.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/Logging/Log.h"
 #include "Common/MathUtil.h"
 
 #include "Core/Core.h"
-#include "Core/Host.h"
 
 #include "VideoBackends/D3D12/BoundingBox.h"
 #include "VideoBackends/D3D12/D3DBase.h"
@@ -34,7 +34,6 @@
 
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/BPFunctions.h"
-#include "VideoCommon/Fifo.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PixelEngine.h"
 #include "VideoCommon/PixelShaderManager.h"
@@ -42,6 +41,7 @@
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/XFMemory.h"
 
 namespace DX12
 {

--- a/Source/Core/VideoBackends/D3D12/ShaderCache.h
+++ b/Source/Core/VideoBackends/D3D12/ShaderCache.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
+
 #include "VideoCommon/GeometryShaderGen.h"
 #include "VideoCommon/PixelShaderGen.h"
 #include "VideoCommon/VertexShaderGen.h"

--- a/Source/Core/VideoBackends/D3D12/ShaderConstantsManager.h
+++ b/Source/Core/VideoBackends/D3D12/ShaderConstantsManager.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "ShaderCache.h"
-
 namespace DX12
 {
 class ShaderConstantsManager final

--- a/Source/Core/VideoBackends/D3D12/TextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D12/TextureEncoder.h
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include "VideoCommon/BPMemory.h"
-#include "VideoCommon/TextureCacheBase.h"
+#include "Common/CommonTypes.h"
 #include "VideoCommon/VideoCommon.h"
 
 namespace DX12

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
 #include "VideoBackends/D3D12/BoundingBox.h"

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -5,11 +5,14 @@
 #include "VideoBackends/OGL/FramebufferManager.h"
 
 #include <memory>
+#include <sstream>
 #include <vector>
 
 #include "Common/Common.h"
-#include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/GL/GLInterfaceBase.h"
+#include "Common/Logging/Log.h"
+
 #include "Core/HW/Memmap.h"
 
 #include "VideoBackends/OGL/Render.h"

--- a/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
@@ -2,16 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/GL/GLUtil.h"
-#include "Common/MemoryUtil.h"
-#include "Common/x64ABI.h"
-#include "Common/x64Emitter.h"
+#include "Common/MsgHandler.h"
 
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/VertexManager.h"
 
-#include "VideoCommon/CPMemory.h"
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/VertexShaderGen.h"
 

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -2,19 +2,17 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "Common/Common.h"
-#include "Common/CommonPaths.h"
-#include "Common/FileUtil.h"
+#include "VideoBackends/OGL/PostProcessing.h"
+
+#include "Common/CommonTypes.h"
+#include "Common/GL/GLUtil.h"
+#include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 
-#include "Common/GL/GLUtil.h"
-
 #include "VideoBackends/OGL/FramebufferManager.h"
-#include "VideoBackends/OGL/PostProcessing.h"
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/SamplerCache.h"
 
-#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -8,7 +8,8 @@
 #include <string>
 
 #include "Common/Align.h"
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
@@ -18,7 +19,6 @@
 #include "VideoBackends/OGL/StreamBuffer.h"
 
 #include "VideoCommon/Debugger.h"
-#include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/GeometryShaderManager.h"
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/PixelShaderManager.h"

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -36,7 +36,6 @@
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/BPFunctions.h"
 #include "VideoCommon/DriverDetails.h"
-#include "VideoCommon/Fifo.h"
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PixelEngine.h"
@@ -45,6 +44,7 @@
 #include "VideoCommon/VertexShaderManager.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/XFMemory.h"
 
 void VideoConfig::UpdateProjectionHack()
 {

--- a/Source/Core/VideoBackends/OGL/StreamBuffer.cpp
+++ b/Source/Core/VideoBackends/OGL/StreamBuffer.cpp
@@ -2,12 +2,14 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/OGL/StreamBuffer.h"
+
 #include "Common/Align.h"
+#include "Common/CommonFuncs.h"
 #include "Common/GL/GLUtil.h"
 #include "Common/MemoryUtil.h"
 
 #include "VideoBackends/OGL/Render.h"
-#include "VideoBackends/OGL/StreamBuffer.h"
 
 #include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/OnScreenDisplay.h"

--- a/Source/Core/VideoBackends/OGL/StreamBuffer.h
+++ b/Source/Core/VideoBackends/OGL/StreamBuffer.h
@@ -8,11 +8,8 @@
 #include <memory>
 #include <utility>
 
+#include "Common/CommonTypes.h"
 #include "Common/GL/GLUtil.h"
-
-#include "VideoBackends/OGL/FramebufferManager.h"
-
-#include "VideoCommon/VideoCommon.h"
 
 namespace OGL
 {

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -6,9 +6,9 @@
 
 #include <map>
 
+#include "Common/CommonTypes.h"
 #include "Common/GL/GLUtil.h"
 
-#include "VideoCommon/BPStructs.h"
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VideoCommon.h"
 

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -8,8 +8,9 @@
 
 #include <string>
 
-#include "Common/Common.h"
+#include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/OGL/VertexManager.h"
+
 #include <fstream>
 #include <memory>
 #include <string>
@@ -10,15 +12,12 @@
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Common/GL/GLExtensions/GLExtensions.h"
-#include "Common/GL/GLInterfaceBase.h"
 #include "Common/StringUtil.h"
 
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/Render.h"
 #include "VideoBackends/OGL/StreamBuffer.h"
-#include "VideoBackends/OGL/VertexManager.h"
 
-#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/VertexLoaderManager.h"

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <vector>
+
+#include "Common/CommonTypes.h"
+#include "Common/GL/GLUtil.h"
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/VertexManagerBase.h"
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "Common/Assert.h"
+#include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 
@@ -37,6 +38,7 @@
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/XFMemory.h"
 
 namespace Vulkan
 {

--- a/Source/Core/VideoBackends/Vulkan/StreamBuffer.h
+++ b/Source/Core/VideoBackends/Vulkan/StreamBuffer.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <utility>
 
+#include "Common/CommonTypes.h"
 #include "VideoBackends/Vulkan/Constants.h"
 
 namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -11,13 +11,13 @@
 
 #include "Common/Assert.h"
 #include "Common/CommonFuncs.h"
+#include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 
 #include "VideoBackends/Vulkan/CommandBufferManager.h"
 #include "VideoBackends/Vulkan/FramebufferManager.h"
 #include "VideoBackends/Vulkan/ObjectCache.h"
-#include "VideoBackends/Vulkan/Renderer.h"
 #include "VideoBackends/Vulkan/StagingTexture2D.h"
 #include "VideoBackends/Vulkan/StateTracker.h"
 #include "VideoBackends/Vulkan/StreamBuffer.h"

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.h
@@ -10,7 +10,6 @@
 #include "Common/CommonTypes.h"
 #include "VideoBackends/Vulkan/StreamBuffer.h"
 #include "VideoBackends/Vulkan/TextureCache.h"
-#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoCommon.h"
 

--- a/Source/Core/VideoBackends/Vulkan/VertexFormat.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexFormat.cpp
@@ -2,13 +2,13 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/Vulkan/VertexFormat.h"
+
 #include "Common/Assert.h"
 
 #include "VideoBackends/Vulkan/CommandBufferManager.h"
 #include "VideoBackends/Vulkan/ObjectCache.h"
-#include "VideoBackends/Vulkan/VertexFormat.h"
 
-#include "VideoCommon/CPMemory.h"
 #include "VideoCommon/VertexLoaderManager.h"
 #include "VideoCommon/VertexShaderGen.h"
 

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -4,6 +4,8 @@
 
 #include "VideoBackends/Vulkan/VertexManager.h"
 
+#include "Common/CommonTypes.h"
+#include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 
 #include "VideoBackends/Vulkan/BoundingBox.h"

--- a/Source/Core/VideoCommon/GeometryShaderGen.cpp
+++ b/Source/Core/VideoCommon/GeometryShaderGen.cpp
@@ -2,16 +2,17 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoCommon/GeometryShaderGen.h"
+
 #include <cmath>
 #include <cstring>
 
 #include "Common/CommonTypes.h"
-#include "VideoCommon/BPMemory.h"
 #include "VideoCommon/DriverDetails.h"
-#include "VideoCommon/GeometryShaderGen.h"
 #include "VideoCommon/LightingShaderGen.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/XFMemory.h"
 
 static const char* primitives_ogl[] = {"points", "lines", "triangles"};
 

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Common/CommonTypes.h"
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/VertexManagerBase.h"
 

--- a/Source/Core/VideoCommon/LightingShaderGen.cpp
+++ b/Source/Core/VideoCommon/LightingShaderGen.cpp
@@ -9,6 +9,7 @@
 
 #include "VideoCommon/NativeVertexFormat.h"
 #include "VideoCommon/ShaderGenCommon.h"
+#include "VideoCommon/XFMemory.h"
 
 static void GenerateLightShader(ShaderCode& object, const LightingUidData& uid_data, int index,
                                 int litchan_index, bool alpha)

--- a/Source/Core/VideoCommon/ShaderGenCommon.h
+++ b/Source/Core/VideoCommon/ShaderGenCommon.h
@@ -6,19 +6,14 @@
 
 #include <cstdarg>
 #include <cstring>
-#include <fstream>
-#include <iomanip>
 #include <map>
 #include <string>
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Common/FileUtil.h"
-#include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
-#include "VideoCommon/XFMemory.h"
 
 /**
  * Common interface for classes that need to go through the shader generation path

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -14,6 +14,7 @@
 #include "VideoCommon/VertexShaderGen.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
+#include "VideoCommon/XFMemory.h"
 
 VertexShaderUid GetVertexShaderUid()
 {


### PR DESCRIPTION
Removes includes from the header and resolves a pile of indirect includes.