### PR TITLE
Remove unneeded write to 0x3140/0x3188 for WADs

### DIFF
--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -112,16 +112,6 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
   MSR = 0;
   PC = 0x3400;
 
-  // Pass the "#002 check"
-  // Apploader should write the IOS version and revision to 0x3140, and compare it
-  // to 0x3188 to pass the check, but we don't do it, and i don't know where to read the IOS rev...
-  // Currently we just write 0xFFFF for the revision, copy manually and it works fine :p
-
-  // TODO : figure it correctly : where should we read the IOS rev that the wad "needs" ?
-  Memory::Write_U16(ContentLoader.GetIosVersion(), 0x00003140);
-  Memory::Write_U16(0xFFFF, 0x00003142);
-  Memory::Write_U32(Memory::Read_U32(0x00003140), 0x00003188);
-
   // Load patches and run startup patches
   const std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(_pFilename));
   if (pVolume != nullptr)


### PR DESCRIPTION
This is unnecessary now that IOS::HLE is responsible for writing the IOS version (4 bytes at 0x3140) to memory; removing the writes also prevents the IOS minor version from being mangled (by writing 2 bytes to 0x3142).

0x3188 isn't needed for the nandloader. Actually, there is no apploader, so the write to 0x3188 is unneeded.