### PR TITLE
PowerPC: Move page #define constants to MMU.cpp

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <cstddef>
 #include <cstring>
 
 #include "Common/Atomic.h"
@@ -25,7 +26,10 @@
 
 namespace PowerPC
 {
-#define HW_PAGE_SIZE 4096
+constexpr size_t HW_PAGE_SIZE = 4096;
+constexpr u32 HW_PAGE_INDEX_SHIFT = 12;
+constexpr u32 HW_PAGE_INDEX_MASK = 0x3f;
+constexpr u32 HW_PAGE_TAG_SHIFT = 18;
 
 // EFB RE
 /*

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -40,11 +40,6 @@ enum CoreMode
 #define TLB_SIZE 128
 #define NUM_TLBS 2
 #define TLB_WAYS 2
-
-#define HW_PAGE_INDEX_SHIFT 12
-#define HW_PAGE_INDEX_MASK 0x3f
-#define HW_PAGE_TAG_SHIFT 18
-
 #define TLB_TAG_INVALID 0xffffffff
 
 struct tlb_entry


### PR DESCRIPTION
These are only ever used here. This also converts them into typed constants.