### PR TITLE
D3D: Add CommonTypes include to D3DTexture.h

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <d3d11.h>
+#include "Common/CommonTypes.h"
 
 namespace DX11
 {


### PR DESCRIPTION
Resolves a compile error on the Windows CMake build.