### PR TITLE
FramebufferManagerBase: Return a std::pair from GetTargetSize

### DIFF
--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -2,13 +2,15 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "VideoBackends/D3D/FramebufferManager.h"
+
 #include <memory>
 
+#include "Common/CommonTypes.h"
 #include "Core/HW/Memmap.h"
 #include "VideoBackends/D3D/D3DBase.h"
 #include "VideoBackends/D3D/D3DState.h"
 #include "VideoBackends/D3D/D3DUtil.h"
-#include "VideoBackends/D3D/FramebufferManager.h"
 #include "VideoBackends/D3D/GeometryShaderCache.h"
 #include "VideoBackends/D3D/PixelShaderCache.h"
 #include "VideoBackends/D3D/Render.h"
@@ -292,10 +294,9 @@ std::unique_ptr<XFBSourceBase> FramebufferManager::CreateXFBSource(unsigned int 
       layers);
 }
 
-void FramebufferManager::GetTargetSize(unsigned int* width, unsigned int* height)
+std::pair<u32, u32> FramebufferManager::GetTargetSize() const
 {
-  *width = m_target_width;
-  *height = m_target_height;
+  return std::make_pair(m_target_width, m_target_height);
 }
 
 void XFBSource::DecodeToTexture(u32 xfbAddr, u32 fbWidth, u32 fbHeight)

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -6,7 +6,9 @@
 
 #include <d3d11.h>
 #include <memory>
+#include <utility>
 
+#include "Common/CommonTypes.h"
 #include "VideoBackends/D3D/D3DTexture.h"
 #include "VideoCommon/FramebufferManagerBase.h"
 
@@ -84,7 +86,7 @@ private:
   std::unique_ptr<XFBSourceBase> CreateXFBSource(unsigned int target_width,
                                                  unsigned int target_height,
                                                  unsigned int layers) override;
-  void GetTargetSize(unsigned int* width, unsigned int* height) override;
+  std::pair<u32, u32> GetTargetSize() const override;
 
   void CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, const EFBRectangle& sourceRc,
                      float Gamma) override;

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
@@ -3,7 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "VideoBackends/D3D12/FramebufferManager.h"
+
 #include "Common/Align.h"
+#include "Common/CommonTypes.h"
 #include "Core/HW/Memmap.h"
 #include "VideoBackends/D3D12/D3DBase.h"
 #include "VideoBackends/D3D12/D3DCommandListManager.h"
@@ -218,10 +220,9 @@ std::unique_ptr<XFBSourceBase> FramebufferManager::CreateXFBSource(unsigned int 
       layers);
 }
 
-void FramebufferManager::GetTargetSize(unsigned int* width, unsigned int* height)
+std::pair<u32, u32> FramebufferManager::GetTargetSize() const
 {
-  *width = m_target_width;
-  *height = m_target_height;
+  return std::make_pair(m_target_width, m_target_height);
 }
 
 void FramebufferManager::ResolveDepthTexture()

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "Common/CommonTypes.h"
 #include "VideoBackends/D3D12/D3DTexture.h"
 #include "VideoCommon/FramebufferManagerBase.h"
@@ -86,7 +88,7 @@ private:
   std::unique_ptr<XFBSourceBase> CreateXFBSource(unsigned int target_width,
                                                  unsigned int target_height,
                                                  unsigned int layers) override;
-  void GetTargetSize(unsigned int* width, unsigned int* height) override;
+  std::pair<u32, u32> GetTargetSize() const override;
 
   void CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, const EFBRectangle& sourceRc,
                      float gamma) override;

--- a/Source/Core/VideoBackends/Null/FramebufferManager.h
+++ b/Source/Core/VideoBackends/Null/FramebufferManager.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <utility>
+
+#include "Common/CommonTypes.h"
 #include "VideoCommon/FramebufferManagerBase.h"
 
 class XFBSource : public XFBSourceBase
@@ -23,7 +26,7 @@ public:
     return std::make_unique<XFBSource>();
   }
 
-  void GetTargetSize(unsigned int* width, unsigned int* height) override {}
+  std::pair<u32, u32> GetTargetSize() const override { return std::make_pair(0, 0); }
   void CopyToRealXFB(u32 xfb_addr, u32 fb_stride, u32 fb_height, const EFBRectangle& source_rc,
                      float gamma = 1.0f) override
   {

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -668,10 +668,9 @@ std::unique_ptr<XFBSourceBase> FramebufferManager::CreateXFBSource(unsigned int 
   return std::make_unique<XFBSource>(texture, layers);
 }
 
-void FramebufferManager::GetTargetSize(unsigned int* width, unsigned int* height)
+std::pair<u32, u32> FramebufferManager::GetTargetSize() const
 {
-  *width = m_targetWidth;
-  *height = m_targetHeight;
+  return std::make_pair(m_targetWidth, m_targetHeight);
 }
 
 void FramebufferManager::PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points)

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.h
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.h
@@ -5,8 +5,10 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 #include <vector>
 
+#include "Common/CommonTypes.h"
 #include "Common/GL/GLUtil.h"
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/Render.h"
@@ -103,7 +105,7 @@ private:
   std::unique_ptr<XFBSourceBase> CreateXFBSource(unsigned int target_width,
                                                  unsigned int target_height,
                                                  unsigned int layers) override;
-  void GetTargetSize(unsigned int* width, unsigned int* height) override;
+  std::pair<u32, u32> GetTargetSize() const override;
 
   void CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, const EFBRectangle& sourceRc,
                      float Gamma) override;

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "Common/CommonTypes.h"
 
@@ -101,7 +102,8 @@ class FramebufferManager : public FramebufferManagerBase
   {
     return std::make_unique<XFBSource>();
   }
-  void GetTargetSize(unsigned int* width, unsigned int* height) override{};
+
+  std::pair<u32, u32> GetTargetSize() const override { return std::make_pair(0, 0); }
   void CopyToRealXFB(u32 xfbAddr, u32 fbStride, u32 fbHeight, const EFBRectangle& sourceRc,
                      float Gamma = 1.0f) override
   {

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -115,10 +115,9 @@ bool FramebufferManager::Initialize()
   return true;
 }
 
-void FramebufferManager::GetTargetSize(unsigned int* width, unsigned int* height)
+std::pair<u32, u32> FramebufferManager::GetTargetSize() const
 {
-  *width = m_efb_width;
-  *height = m_efb_height;
+  return std::make_pair(m_efb_width, m_efb_height);
 }
 
 bool FramebufferManager::CreateEFBRenderPass()

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "Common/CommonTypes.h"
 #include "VideoBackends/Vulkan/Constants.h"
@@ -39,7 +40,7 @@ public:
   Texture2D* GetEFBColorTexture() const { return m_efb_color_texture.get(); }
   Texture2D* GetEFBDepthTexture() const { return m_efb_depth_texture.get(); }
   VkFramebuffer GetEFBFramebuffer() const { return m_efb_framebuffer; }
-  void GetTargetSize(unsigned int* width, unsigned int* height) override;
+  std::pair<u32, u32> GetTargetSize() const override;
 
   std::unique_ptr<XFBSourceBase> CreateXFBSource(unsigned int target_width,
                                                  unsigned int target_height,

--- a/Source/Core/VideoCommon/FramebufferManagerBase.cpp
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.cpp
@@ -3,9 +3,12 @@
 // Refer to the license.txt file included.
 
 #include "VideoCommon/FramebufferManagerBase.h"
+
 #include <algorithm>
 #include <array>
 #include <memory>
+#include <tuple>
+
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoConfig.h"
 
@@ -158,8 +161,8 @@ void FramebufferManagerBase::CopyToVirtualXFB(u32 xfbAddr, u32 fbStride, u32 fbH
   if (m_virtualXFBList.begin() != vxfb)
     m_virtualXFBList.splice(m_virtualXFBList.begin(), m_virtualXFBList, vxfb);
 
-  unsigned int target_width, target_height;
-  g_framebuffer_manager->GetTargetSize(&target_width, &target_height);
+  u32 target_width, target_height;
+  std::tie(target_width, target_height) = g_framebuffer_manager->GetTargetSize();
 
   // recreate if needed
   if (vxfb->xfbSource &&

--- a/Source/Core/VideoCommon/FramebufferManagerBase.h
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <list>
 #include <memory>
+#include <utility>
 
 #include "Common/CommonTypes.h"
 #include "VideoCommon/VideoCommon.h"
@@ -60,7 +61,7 @@ public:
   static int ScaleToVirtualXfbHeight(int y);
 
   static unsigned int GetEFBLayers() { return m_EFBLayers; }
-  virtual void GetTargetSize(unsigned int* width, unsigned int* height) = 0;
+  virtual std::pair<u32, u32> GetTargetSize() const = 0;
 
 protected:
   struct VirtualXFB

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -12,11 +12,14 @@
 // Next frame, that one is scanned out and the other one gets the copy. = double buffering.
 // ---------------------------------------------------------------------------------------------
 
+#include "VideoCommon/RenderBase.h"
+
 #include <cinttypes>
 #include <cmath>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <tuple>
 
 #include "Common/Assert.h"
 #include "Common/CommonTypes.h"
@@ -48,7 +51,6 @@
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/PostProcessing.h"
-#include "VideoCommon/RenderBase.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureCacheBase.h"
 #include "VideoCommon/TextureDecoder.h"
@@ -509,8 +511,8 @@ TargetRectangle Renderer::CalculateFrameDumpDrawRectangle()
   }
 
   // Grab the dimensions of the EFB textures, we scale either of these depending on the ratio.
-  unsigned int efb_width, efb_height;
-  g_framebuffer_manager->GetTargetSize(&efb_width, &efb_height);
+  u32 efb_width, efb_height;
+  std::tie(efb_width, efb_height) = g_framebuffer_manager->GetTargetSize();
 
   float draw_width, draw_height;
   std::tie(draw_width, draw_height) = ScaleToDisplayAspectRatio(efb_width, efb_height);


### PR DESCRIPTION
Keeps associated data together. It also eliminates the possibility of out parameters not being initialized properly. For example, consider the following example:

```cpp
// some FramebufferManager implementation

void FBMgrImpl::GetTargetSize(u32* width, u32* height) override
{
  // Do nothing
}

// somewhere else where the function is used

u32 width, height;
framebuffer_manager_instance->GetTargetSize(&width, &height);

if (texture_width != width) // <-- Uninitialized variable usage
{
  ...
}
```

It makes it much more obvious to spot any initialization issues, because it requires something to be returned, as opposed to allowing an implementation to just not do anything.

This also makes the function usable with C++17's [structured bindings](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0144r2.pdf)