### PR TITLE
Handle another case with HLE_GeneralDebugPrint

### DIFF
--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -48,8 +48,16 @@ void HLE_GeneralDebugPrint()
   }
   else
   {
-    // ___blank(const char* fmt, ...);
-    report_message = GetStringVA();
+    if (GPR(3) > 0x80000000)
+    {
+      // ___blank(const char* fmt, ...);
+      report_message = GetStringVA();
+    }
+    else
+    {
+      // ___blank(int log_type, const char* fmt, ...);
+      report_message = GetStringVA(4);
+    }
   }
 
   NPC = LR;


### PR DESCRIPTION
When debugging Mario Strikers Charged Football, I realized that some log messages are not handled properly. I added the missing case that allows the following debug messages to show up:
> 27:36:867 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8011fa00->8011f9e8| Resumed StaticSetInternetThreadFunc returned 1
27:38:012 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8011fc98->8011fc84| Starting DWC_LoginAsync
28:06:193 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8011fcfc->8011fb00| DWCLoginCallback returned 0, profileID 18 param 0
28:06:200 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8011fdbc->8011fda0| DWC_GetIngamesnCheckResult returned 1
28:06:303 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8012ce54->8012ce40| DWC_RnkInitialize succeeded.
28:06:579 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8012d714->8012d6f0| DWC_RnkGetScoreAsync start processing okay.
28:06:582 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8011fef4->8011fe8c| Started login timestamp = 2.787029
28:06:586 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8013660c->8025ffd8| SetOwnStatusInitial 1
28:08:585 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8012e2fc->8012e2e8| Getting score succeeded!
28:08:589 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8012d798->8012d770| Error 16 from DWC_RnkResGetRowCount cat 2 filter 1
28:08:593 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8012f72c->8012f6a0| Unavailable Leaderboard Stats cat 2 filter 1
28:08:597 HLE\HLE_OS.cpp:65 N[OSREPORT]: 8012017c->80120168| Error getting friends stats at login
28:08:608 HLE\HLE_OS.cpp:65 N[OSREPORT]: 802602ec->802602cc| Warning failed to find standard error msg for code 0
28:09:032 HLE\HLE_OS.cpp:65 N[OSREPORT]: 80305a28->80305a04| FontManager: Warning, failed to find font 0x501e5791
28:20:360 HLE\HLE_OS.cpp:65 N[OSREPORT]: 802ed674->8004f2e0| Slider name: unknown

I think after merging this PR and https://github.com/dolphin-emu/dolphin/pull/4481, Dolphin will handle most cases properly.

Ready to be reviewed & merged.