### PR TITLE
CMake: add CMAKE_CONFIGURE_DEPENDS on Data/Sys

### DIFF
--- a/Source/Core/DolphinQt2/CMakeLists.txt
+++ b/Source/Core/DolphinQt2/CMakeLists.txt
@@ -59,6 +59,7 @@ if(APPLE)
 	set_source_files_properties("${qtcocoa_location}" PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/platforms)
 
 	# Copy resources into the bundle
+	set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/Data/Sys")
 	file(GLOB_RECURSE resources RELATIVE "${CMAKE_SOURCE_DIR}/Data" "${CMAKE_SOURCE_DIR}/Data/Sys/*")
 	foreach(res ${resources})
 		target_sources(${DOLPHINQT2_BINARY} PRIVATE "${CMAKE_SOURCE_DIR}/Data/${res}")

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -166,6 +166,7 @@ if(wxWidgets_FOUND)
 			)
 
 		# Copy resources in the bundle
+		set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/Data/Sys")
 		file(GLOB_RECURSE resources RELATIVE "${CMAKE_SOURCE_DIR}/Data" "${CMAKE_SOURCE_DIR}/Data/Sys/*")
 		foreach(res ${resources})
 			target_sources(${DOLPHIN_EXE} PRIVATE "${CMAKE_SOURCE_DIR}/Data/${res}")


### PR DESCRIPTION
Since files from Data/Sys are collected and added to a built macOS .app bundle using GLOB, any new files won't get picked up until the next time CMake is run. Tell CMake it should re-run itself every time the directory is touched.