### PR TITLE
PowerPC: Convert CoreMode enum into an enum class

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -557,7 +557,7 @@ void EmuThread()
   CPU::Break();
 
   // Load GCM/DOL/ELF whatever ... we boot with the interpreter core
-  PowerPC::SetMode(PowerPC::MODE_INTERPRETER);
+  PowerPC::SetMode(PowerPC::CoreMode::Interpreter);
 
   CBoot::BootUp();
 
@@ -571,11 +571,11 @@ void EmuThread()
   if (core_parameter.iCPUCore != PowerPC::CORE_INTERPRETER &&
       (!core_parameter.bRunCompareServer || core_parameter.bRunCompareClient))
   {
-    PowerPC::SetMode(PowerPC::MODE_JIT);
+    PowerPC::SetMode(PowerPC::CoreMode::JIT);
   }
   else
   {
-    PowerPC::SetMode(PowerPC::MODE_INTERPRETER);
+    PowerPC::SetMode(PowerPC::CoreMode::Interpreter);
   }
 
   // Update the window again because all stuff is initialized

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -175,11 +175,8 @@ int GetFunctionFlagsByIndex(u32 index)
 
 bool IsEnabled(int flags)
 {
-  if (flags == HLE::HLE_TYPE_DEBUG && !SConfig::GetInstance().bEnableDebugging &&
-      PowerPC::GetMode() != MODE_INTERPRETER)
-    return false;
-
-  return true;
+  return flags != HLE::HLE_TYPE_DEBUG || SConfig::GetInstance().bEnableDebugging ||
+         PowerPC::GetMode() == PowerPC::CoreMode::Interpreter;
 }
 
 u32 UnPatch(const std::string& patch_name)

--- a/Source/Core/Core/HW/CPU.cpp
+++ b/Source/Core/Core/HW/CPU.cpp
@@ -87,13 +87,13 @@ void Run()
       // SingleStep so that the "continue", "step over" and "step out" debugger functions
       // work when the PC is at a breakpoint at the beginning of the block
       // If watchpoints are enabled, any instruction could be a breakpoint.
-      if (PowerPC::GetMode() != PowerPC::MODE_INTERPRETER)
+      if (PowerPC::GetMode() != PowerPC::CoreMode::Interpreter)
       {
         if (PowerPC::breakpoints.IsAddressBreakPoint(PC) || PowerPC::memchecks.HasAny())
         {
           s_state = CPU_STEPPING;
           PowerPC::CoreMode old_mode = PowerPC::GetMode();
-          PowerPC::SetMode(PowerPC::MODE_INTERPRETER);
+          PowerPC::SetMode(PowerPC::CoreMode::Interpreter);
           PowerPC::SingleStep();
           PowerPC::SetMode(old_mode);
           s_state = CPU_RUNNING;

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -29,7 +29,7 @@ PowerPCState ppcState;
 static CPUCoreBase* s_cpu_core_base = nullptr;
 static bool s_cpu_core_base_is_injected = false;
 Interpreter* const s_interpreter = Interpreter::getInstance();
-static CoreMode s_mode = MODE_INTERPRETER;
+static CoreMode s_mode = CoreMode::Interpreter;
 
 Watches watches;
 BreakPoints breakpoints;
@@ -172,11 +172,11 @@ static void InitializeCPUCore(int cpu_core)
 
   if (s_cpu_core_base != s_interpreter)
   {
-    s_mode = MODE_JIT;
+    s_mode = CoreMode::JIT;
   }
   else
   {
-    s_mode = MODE_INTERPRETER;
+    s_mode = CoreMode::Interpreter;
   }
 }
 
@@ -221,18 +221,18 @@ void Shutdown()
 
 CoreMode GetMode()
 {
-  return !s_cpu_core_base_is_injected ? s_mode : MODE_INTERPRETER;
+  return !s_cpu_core_base_is_injected ? s_mode : CoreMode::Interpreter;
 }
 
 static void ApplyMode()
 {
   switch (s_mode)
   {
-  case MODE_INTERPRETER:  // Switching from JIT to interpreter
+  case CoreMode::Interpreter:  // Switching from JIT to interpreter
     s_cpu_core_base = s_interpreter;
     break;
 
-  case MODE_JIT:  // Switching from interpreter to JIT.
+  case CoreMode::JIT:  // Switching from interpreter to JIT.
     // Don't really need to do much. It'll work, the cache will refill itself.
     s_cpu_core_base = JitInterface::GetCore();
     if (!s_cpu_core_base)  // Has a chance to not get a working JIT core if one isn't active on host

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -30,10 +30,10 @@ enum
   CORE_CACHEDINTERPRETER,
 };
 
-enum CoreMode
+enum class CoreMode
 {
-  MODE_INTERPRETER,
-  MODE_JIT,
+  Interpreter,
+  JIT,
 };
 
 // TLB cache
@@ -146,7 +146,7 @@ const char* GetCPUName();
 
 // Set the current CPU Core to the given implementation until removed.
 // Remove the current injected CPU Core by passing nullptr.
-// While an external CPUCoreBase is injected, GetMode() will return MODE_INTERPRETER.
+// While an external CPUCoreBase is injected, GetMode() will return CoreMode::Interpreter.
 // Init() will be called when added and Shutdown() when removed.
 // [Threadsafety: Same as SetMode(), except it cannot be called from inside the CPU
 //  run loop on the CPU Thread - it doesn't make sense for a CPU to remove itself

--- a/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindow.cpp
@@ -309,7 +309,7 @@ void CCodeWindow::SingleStep()
   if (CPU::IsStepping())
   {
     PowerPC::CoreMode old_mode = PowerPC::GetMode();
-    PowerPC::SetMode(PowerPC::MODE_INTERPRETER);
+    PowerPC::SetMode(PowerPC::CoreMode::Interpreter);
     PowerPC::breakpoints.ClearAllTemporary();
     CPU::StepOpcode(&sync_event);
     sync_event.WaitFor(std::chrono::milliseconds(20));
@@ -361,7 +361,7 @@ void CCodeWindow::StepOut()
     using clock = std::chrono::steady_clock;
     clock::time_point timeout = clock::now() + std::chrono::seconds(5);
     PowerPC::CoreMode old_mode = PowerPC::GetMode();
-    PowerPC::SetMode(PowerPC::MODE_INTERPRETER);
+    PowerPC::SetMode(PowerPC::CoreMode::Interpreter);
 
     // Loop until either the current instruction is a return instruction with no Link flag
     // or a breakpoint is detected so it can step at the breakpoint. If the PC is currently
@@ -482,7 +482,7 @@ void CCodeWindow::OnCPUMode(wxCommandEvent& event)
   switch (event.GetId())
   {
   case IDM_INTERPRETER:
-    PowerPC::SetMode(UseInterpreter() ? PowerPC::MODE_INTERPRETER : PowerPC::MODE_JIT);
+    PowerPC::SetMode(UseInterpreter() ? PowerPC::CoreMode::Interpreter : PowerPC::CoreMode::JIT);
     break;
   case IDM_BOOT_TO_PAUSE:
     SConfig::GetInstance().bBootToPause = event.IsChecked();

--- a/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
+++ b/Source/Core/DolphinWX/Debugger/CodeWindowFunctions.cpp
@@ -133,7 +133,7 @@ void CCodeWindow::OnProfilerMenu(wxCommandEvent& event)
     if (Core::GetState() == Core::CORE_RUN)
       Core::SetState(Core::CORE_PAUSE);
 
-    if (Core::GetState() == Core::CORE_PAUSE && PowerPC::GetMode() == PowerPC::MODE_JIT)
+    if (Core::GetState() == Core::CORE_PAUSE && PowerPC::GetMode() == PowerPC::CoreMode::JIT)
     {
       if (g_jit != nullptr)
       {


### PR DESCRIPTION
Prevents constants from polluting the namespace.