### PR TITLE
Fixed SYSCONF value

### DIFF
--- a/Source/Core/Common/SysConf.cpp
+++ b/Source/Core/Common/SysConf.cpp
@@ -317,7 +317,7 @@ void SysConf::GenerateSysConf()
 
   // IPL.IDL
   current_offset += create_item(items[23], Type_SmallArray, "IPL.IDL", 1, current_offset);
-  items[23].data[0] = 0x00;
+  items[23].data[0] = 0x01;
 
   // IPL.EULA
   current_offset += create_item(items[24], Type_Bool, "IPL.EULA", 1, current_offset);


### PR DESCRIPTION
The value for IPL.IDL was set to 0x00, which was causing the News Channel (which was working prior to this change) and the Forecast Channel to say:

"WiiConnect24 Standby Connection is
currently turned off, so this channel
cannot be used."

Changing it back to 0x01, as it once was before fixes this, which is why I'm sending this PR.