### PR TITLE
DVDInterface: Chunking and various timing accuracy improvements

### DIFF
--- a/Data/Sys/GameSettings/G5D.ini
+++ b/Data/Sys/GameSettings/G5D.ini
@@ -2,12 +2,11 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Can hang during loading screens if Speed Up Disc Transfer Rate isn't used
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GC3.ini
+++ b/Data/Sys/GameSettings/GC3.ini
@@ -2,12 +2,11 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.
 EmulationStateId = 4
-EmulationIssues = Can hang during loading screens if Speed Up Disc Transfer Rate isn't used
+EmulationIssues =
 
 [OnLoad]
 # Add memory patches to be loaded once on boot here.

--- a/Data/Sys/GameSettings/GXE.ini
+++ b/Data/Sys/GameSettings/GXE.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Data/Sys/GameSettings/RPJ.ini
+++ b/Data/Sys/GameSettings/RPJ.ini
@@ -2,7 +2,6 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
-FastDiscSpeed = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Source/Core/Core/HW/DVDInterface.h
+++ b/Source/Core/Core/HW/DVDInterface.h
@@ -95,6 +95,7 @@ enum DIInterruptType : int
 
 enum class ReplyType : u32
 {
+  NoReply,
   Interrupt,
   IOS,
   DTK

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 75;  // Last changed in PR 4857
+static const u32 STATE_VERSION = 76;  // Last changed in PR 4829
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This is a rebased and cleaned up version of PR #3701.

This PR has two primary improvements: Copying disc data to the emulated RAM in chunks instead of all in one go at the end (fixes various games, including Sonic Riders) and using more accurate timing models that take chunking and seek timing into account (makes loading times closer to consoles but doesn't fix any bugs as far as I know).

All comments on the old PR should be fixed ~~except for the ones that I made today.~~ EDIT: Those two comments have been addressed now.