### PR TITLE
wx: Move platform defines to wx setup header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -910,10 +910,7 @@ if(NOT DISABLE_WX)
 		# These definitions and includes are used when building dolphin against wx,
 		# not when building wx itself (see wxw3 CMakeLists.txt for that)
 		if(APPLE)
-			add_definitions(-D__WXOSX_COCOA__)
 		elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
-			add_definitions(-D__WXGTK__)
-
 			# Check for required libs
 			check_lib(GTHREAD2 gthread-2.0 gthread-2.0 glib/gthread.h REQUIRED)
 			check_lib(PANGOCAIRO pangocairo pangocairo pango/pangocairo.h REQUIRED)
@@ -921,7 +918,6 @@ if(NOT DISABLE_WX)
 			# Required for wxUSE_STACKWALKER in Externals/wxWidgets3/wx/wxgtk.h
 			find_package(Backtrace REQUIRED)
 		elseif(WIN32)
-			add_definitions(-D__WXMSW__)
 		else()
 			message(FATAL_ERROR "wxWidgets in Externals is not compatible with your platform")
 		endif()

--- a/Externals/wxWidgets3/wx/setup.h
+++ b/Externals/wxWidgets3/wx/setup.h
@@ -1,9 +1,12 @@
 #ifdef __APPLE__
 #define __WXMAC__
 #define __WXOSX__
+#define __WXOSX_COCOA__
 #include "wx/wxcocoa.h"
 #elif defined _WIN32
+#define __WXMSW__
 #include "wx/wxmsw.h"
 #else
+#define __WXGTK__
 #include "wx/wxgtk.h"
 #endif

--- a/Source/VSProps/WXWOverrides.props
+++ b/Source/VSProps/WXWOverrides.props
@@ -8,7 +8,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>wx/wxprec.h</PrecompiledHeaderFile>
       <ExceptionHandling>Async</ExceptionHandling>
-      <PreprocessorDefinitions>__WXMSW__;WXBUILDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WXBUILDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\;..\..\include;..\..\..\xxhash;..\..\..\zlib;..\..\..\libpng</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Usually, this is passed as a preprocessor definition, but this is error
prone and just complicating the compiler invocation for no good reason.