### PR TITLE
Core: Actually make the State enum an enum class

### DIFF
--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -28,7 +28,7 @@ void SetIsThrottlerTempDisabled(bool disable);
 
 void Callback_VideoCopiedToXFB(bool video_update);
 
-enum State
+enum class State
 {
   Uninitialized,
   Paused,


### PR DESCRIPTION
It helps if I actually make it a strongly typed enum. Basically I'm an idiot, (follow up to #4828)