### PR TITLE
Be less annoying when usbdk is not installed

### DIFF
--- a/Source/Core/Common/LibusbContext.cpp
+++ b/Source/Core/Common/LibusbContext.cpp
@@ -8,6 +8,7 @@
 
 #include "Common/LibusbContext.h"
 #include "Common/MsgHandler.h"
+#include "Common/StringUtil.h"
 
 namespace LibusbContext
 {
@@ -24,10 +25,12 @@ static libusb_context* Create()
 #ifdef _WIN32
     is_windows = true;
 #endif
-    if (is_windows && ret == LIBUSB_ERROR_NOT_FOUND)
-      PanicAlertT("Failed to initialize libusb because usbdk is not installed.");
-    else
-      PanicAlertT("Failed to initialize libusb: %s", libusb_error_name(ret));
+    const std::string reason =
+        is_windows && ret == LIBUSB_ERROR_NOT_FOUND ?
+            GetStringT("Failed to initialize libusb because usbdk is not installed.") :
+            StringFromFormat(GetStringT("Failed to initialize libusb (%s).").c_str(),
+                             libusb_error_name(ret));
+    PanicAlertT("%s\nSome USB features will not work.", reason.c_str());
     return nullptr;
   }
   return context;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -61,8 +61,6 @@ BluetoothReal::BluetoothReal(u32 device_id, const std::string& device_name)
     : BluetoothBase(device_id, device_name)
 {
   m_libusb_context = LibusbContext::Get();
-  _assert_msg_(IOS_WIIMOTE, m_libusb_context, "Failed to init libusb.");
-
   LoadLinkKeys();
 }
 
@@ -84,6 +82,9 @@ BluetoothReal::~BluetoothReal()
 
 ReturnCode BluetoothReal::Open(const OpenRequest& request)
 {
+  if (!m_libusb_context)
+    return IPC_EACCES;
+
   libusb_device** list;
   const ssize_t cnt = libusb_get_device_list(m_libusb_context.get(), &list);
   _dbg_assert_msg_(IOS, cnt > 0, "Couldn't get device list");

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -71,7 +71,6 @@ private:
   void DispatchHooks(const DeviceChangeHooks& hooks);
 
 #ifdef __LIBUSB__
-  std::shared_ptr<libusb_context> m_libusb_context;
   // Event thread for libusb
   Common::Flag m_event_thread_running;
   std::thread m_event_thread;

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -170,17 +170,8 @@ void Init()
 
   s_libusb_driver_not_supported = false;
 
-  s_libusb_context = LibusbContext::Get();
-  if (!s_libusb_context)
-  {
-    s_libusb_driver_not_supported = true;
-    Shutdown();
-  }
-  else
-  {
-    if (UseAdapter())
-      StartScanThread();
-  }
+  if (UseAdapter())
+    StartScanThread();
 }
 
 void StartScanThread()
@@ -188,6 +179,9 @@ void StartScanThread()
   if (s_adapter_detect_thread_running.IsSet())
     return;
 
+  s_libusb_context = LibusbContext::Get();
+  if (!s_libusb_context)
+    return;
   s_adapter_detect_thread_running.Set(true);
   s_adapter_detect_thread = std::thread(ScanThreadFunc);
 }
@@ -334,7 +328,7 @@ void Shutdown()
 {
   StopScanThread();
 #if defined(LIBUSB_API_VERSION) && LIBUSB_API_VERSION >= 0x01000102
-  if (s_libusb_hotplug_enabled)
+  if (s_libusb_context && s_libusb_hotplug_enabled)
     libusb_hotplug_deregister_callback(s_libusb_context.get(), s_hotplug_handle);
 #endif
   Reset();

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -30,7 +30,6 @@ void Init()
   VideoBackendBase::PopulateList();
   WiimoteReal::LoadSettings();
   GCAdapter::Init();
-  USBUtils::Init();
   VideoBackendBase::ActivateBackend(SConfig::GetInstance().m_strVideoBackend);
 
   SetEnableAlert(SConfig::GetInstance().bUsePanicHandlers);
@@ -42,7 +41,6 @@ void Shutdown()
   WiimoteReal::Shutdown();
   VideoBackendBase::ClearList();
   SConfig::Shutdown();
-  USBUtils::Shutdown();
   LogManager::Shutdown();
 }
 

--- a/Source/Core/UICommon/USBUtils.cpp
+++ b/Source/Core/UICommon/USBUtils.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <memory>
+#include <mutex>
 
 #ifdef __LIBUSB__
 #include <libusb.h>
@@ -14,6 +15,7 @@
 #include "UICommon/USBUtils.h"
 
 #ifdef __LIBUSB__
+static std::once_flag s_tried_libusb_init;
 static std::shared_ptr<libusb_context> s_libusb_context;
 #endif
 
@@ -36,25 +38,12 @@ static const std::map<std::pair<u16, u16>, std::string> s_wii_peripherals = {{
 
 namespace USBUtils
 {
-void Init()
-{
-#ifdef __LIBUSB__
-  s_libusb_context = LibusbContext::Get();
-#endif
-}
-
-void Shutdown()
-{
-#ifdef __LIBUSB__
-  s_libusb_context = nullptr;
-#endif
-}
-
 std::map<std::pair<u16, u16>, std::string> GetInsertedDevices()
 {
   std::map<std::pair<u16, u16>, std::string> devices;
 
 #ifdef __LIBUSB__
+  std::call_once(s_tried_libusb_init, []() { s_libusb_context = LibusbContext::Get(); });
   if (!s_libusb_context)
     return devices;
 

--- a/Source/Core/UICommon/USBUtils.h
+++ b/Source/Core/UICommon/USBUtils.h
@@ -12,9 +12,6 @@
 
 namespace USBUtils
 {
-void Init();
-void Shutdown();
-
 std::map<std::pair<u16, u16>, std::string> GetInsertedDevices();
 std::string GetDeviceName(std::pair<u16, u16> vid_pid);
 }  // namespace USBUtils


### PR DESCRIPTION
* Silent some warnings when usbdk is not installed. Having the user click through three warnings is not very nice.
* Make sure the user knows that USB features won't work whenever libusb fails to initialize.