### PR TITLE
CMake: re-run to get version information when .git/HEAD changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,13 @@ include(CCache)
 
 # for revision info
 find_package(Git)
-if(GIT_FOUND AND NOT DOLPHIN_WC_REVISION)
+if(GIT_FOUND)
+	# make sure version information gets re-run when the current Git HEAD changes
+	execute_process(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse --git-path HEAD
+		OUTPUT_VARIABLE dolphin_git_head_filename
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${dolphin_git_head_filename}")
+
 	# defines DOLPHIN_WC_REVISION
 	EXECUTE_PROCESS(WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
 		OUTPUT_VARIABLE DOLPHIN_WC_REVISION


### PR DESCRIPTION
Fixes an issue where Dolphin's revision information could be incorrect
when:

1) CMake was run while HEAD was at commit A
2) HEAD was set to commit B, which didn't have differences from A
that would cause CMake to be re-run

This does not fix the issue with incorrect information about whether
Dolphin was built from a dirty revision or not.