### PR TITLE
Fix symbols name from maps taking 2 lines instead of one

### DIFF
--- a/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
+++ b/Source/Core/Core/PowerPC/PPCSymbolDB.cpp
@@ -356,6 +356,8 @@ bool PPCSymbolDB::LoadMap(const std::string& filename, bool bad)
     if (namepos != nullptr)  // would be odd if not :P
       strcpy(name, namepos);
     name[strlen(name) - 1] = 0;
+    if (name[strlen(name) - 1] == '\r')
+      name[strlen(name) - 1] = 0;
 
     // Check if this is a valid entry.
     if (strcmp(name, ".text") != 0 && strcmp(name, ".init") != 0 && strlen(name) > 0)


### PR DESCRIPTION
Symbols map may not only end with a \n, but they may also end with \r\n and only the \n would get removed.  This is the case with the Super Mario Sunshine map file which resulted in a weird looking symbols list and thus made it harder to scroll through it.  This removes the \r after the \n has been removed if it's present.

This is how the symbols look on master on my linux machine:

![screenshot from 2017-02-07 10-00-09](https://cloud.githubusercontent.com/assets/8932978/22696848/97b15b68-ed1d-11e6-98bf-ce8d53b1061e.png)
![screenshot from 2017-02-07 09-49-49](https://cloud.githubusercontent.com/assets/8932978/22696849/97b5257c-ed1d-11e6-8e53-39d4c5c014b3.png)

and this is how they look after this pr:

![screenshot from 2017-02-07 10-02-45](https://cloud.githubusercontent.com/assets/8932978/22696887/b2acc0a6-ed1d-11e6-9107-85a8df6adeb8.png)
![screenshot from 2017-02-07 09-51-36](https://cloud.githubusercontent.com/assets/8932978/22696888/b2ad5656-ed1d-11e6-93e7-f14d1f44cb5d.png)

This was tested using the US version of the map file.

I am not sure if this is the best approach to do this, but if there's a better way to clean the control characters at the end, please suggest so in the review.