### PR TITLE
GCKeyboardEmu/GCPadEmu: Make constructors explicit

### DIFF
--- a/Source/Core/Core/HW/GCKeyboardEmu.h
+++ b/Source/Core/Core/HW/GCKeyboardEmu.h
@@ -25,7 +25,7 @@ enum class KeyboardGroup
 class GCKeyboard : public ControllerEmu
 {
 public:
-  GCKeyboard(const unsigned int index);
+  explicit GCKeyboard(unsigned int index);
   KeyboardStatus GetInput() const;
   std::string GetName() const override;
   ControlGroup* GetGroup(KeyboardGroup group);

--- a/Source/Core/Core/HW/GCPadEmu.h
+++ b/Source/Core/Core/HW/GCPadEmu.h
@@ -25,7 +25,7 @@ enum class PadGroup
 class GCPad : public ControllerEmu
 {
 public:
-  GCPad(const unsigned int index);
+  explicit GCPad(unsigned int index);
   GCPadStatus GetInput() const;
   void SetOutput(const ControlState strength);
 


### PR DESCRIPTION
Implicit conversions here would be undesirable.

Also drops the redundant const specifier from the parameter (it's only applicable in the constructor definition).