### PR TITLE
Core: Remove redundant returns in FifoPlayerThread() and CpuThread()

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -401,8 +401,6 @@ static void CpuThread()
 
   if (_CoreParameter.bFastmem)
     EMM::UninstallExceptionHandler();
-
-  return;
 }
 
 static void FifoPlayerThread()
@@ -454,8 +452,6 @@ static void FifoPlayerThread()
 
   if (!_CoreParameter.bCPUThread)
     g_video_backend->Video_Cleanup();
-
-  return;
 }
 
 // Initialize and create emulation thread


### PR DESCRIPTION
There's no need to explicitly return at the end of a void function.