### PR TITLE
IOS: Fix Wi-Fi scanning in system menu

### DIFF
--- a/Source/Core/Core/IOS/Network/Net.cpp
+++ b/Source/Core/Core/IOS/Network/Net.cpp
@@ -356,7 +356,6 @@ IPCCommandResult NetNCDManage::IOCtlV(const IOCtlVRequest& request)
     INFO_LOG(IOS_NET, "NET_NCD_MANAGE: IOCTLV_NCD_READCONFIG");
     config.ReadConfig();
     config.WriteToMem(request.io_vectors.at(0).address);
-    common_vector = 1;
     break;
 
   case IOCTLV_NCD_WRITECONFIG:


### PR DESCRIPTION
The second output vector should not be written to for IOCTLV_NCD_READCONFIG. If it is, the system menu will never attempt to open /dev/net/wd/command and request a Wi-Fi scan.