### PR TITLE
DSPCore: Make g_cycles_left a regular member variable of DSPEmitter

### DIFF
--- a/Source/Core/Core/DSP/DSPCore.cpp
+++ b/Source/Core/Core/DSP/DSPCore.cpp
@@ -29,7 +29,6 @@ namespace DSP
 SDSP g_dsp;
 DSPBreakpoints g_dsp_breakpoints;
 static State core_state = State::Stopped;
-u16 g_cycles_left = 0;
 bool g_init_hax = false;
 std::unique_ptr<JIT::x86::DSPEmitter> g_dsp_jit;
 std::unique_ptr<DSPCaptureLogger> g_dsp_cap;
@@ -104,7 +103,6 @@ static void DSPCore_FreeMemoryPages()
 bool DSPCore_Init(const DSPInitOptions& opts)
 {
   g_dsp.step_counter = 0;
-  g_cycles_left = 0;
   g_init_hax = false;
 
   g_dsp.irom = static_cast<u16*>(Common::AllocateMemoryPages(DSP_IROM_BYTE_SIZE));

--- a/Source/Core/Core/DSP/DSPCore.h
+++ b/Source/Core/Core/DSP/DSPCore.h
@@ -312,7 +312,6 @@ struct SDSP
 
 extern SDSP g_dsp;
 extern DSPBreakpoints g_dsp_breakpoints;
-extern u16 g_cycles_left;
 extern bool g_init_hax;
 extern std::unique_ptr<JIT::x86::DSPEmitter> g_dsp_jit;
 extern std::unique_ptr<DSPCaptureLogger> g_dsp_cap;

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
@@ -9,6 +9,7 @@
 
 #include "Common/Assert.h"
 #include "Common/BitSet.h"
+#include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
@@ -57,14 +58,19 @@ u16 DSPEmitter::RunCycles(u16 cycles)
     DSPCore_SetExternalInterrupt(false);
   }
 
-  g_cycles_left = cycles;
+  m_cycles_left = cycles;
   auto exec_addr = (DSPCompiledCode)m_enter_dispatcher;
   exec_addr();
 
   if (g_dsp.reset_dspjit_codespace)
     ClearIRAMandDSPJITCodespaceReset();
 
-  return g_cycles_left;
+  return m_cycles_left;
+}
+
+void DSPEmitter::DoState(PointerWrap& p)
+{
+  p.Do(m_cycles_left);
 }
 
 void DSPEmitter::ClearIRAM()
@@ -430,7 +436,7 @@ void DSPEmitter::CompileDispatcher()
   m_return_dispatcher = GetCodePtr();
 
   // Decrement cyclesLeft
-  SUB(16, M(&g_cycles_left), R(EAX));
+  SUB(16, M(&m_cycles_left), R(EAX));
 
   J_CC(CC_A, dispatcherLoop);
 

--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -15,6 +15,8 @@
 #include "Core/DSP/DSPCommon.h"
 #include "Core/DSP/Jit/DSPJitRegCache.h"
 
+class PointerWrap;
+
 namespace DSP
 {
 enum class StackRegister;
@@ -35,6 +37,8 @@ public:
   ~DSPEmitter();
 
   u16 RunCycles(u16 cycles);
+
+  void DoState(PointerWrap& p);
 
   void EmitInstruction(UDSPInstruction inst);
   void ClearIRAM();
@@ -291,6 +295,8 @@ private:
   std::vector<u16> m_block_size;
   std::vector<Block> m_block_links;
   Block m_block_link_entry;
+
+  u16 m_cycles_left = 0;
 
   // The index of the last stored ext value (compile time).
   int m_store_index = -1;

--- a/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
@@ -109,12 +109,12 @@ void DSPEmitter::WriteBlockLink(u16 dest)
     {
       m_gpr.FlushRegs();
       // Check if we have enough cycles to execute the next block
-      MOV(16, R(ECX), M(&g_cycles_left));
+      MOV(16, R(ECX), M(&m_cycles_left));
       CMP(16, R(ECX), Imm16(m_block_size[m_start_address] + m_block_size[dest]));
       FixupBranch notEnoughCycles = J_CC(CC_BE);
 
       SUB(16, R(ECX), Imm16(m_block_size[m_start_address]));
-      MOV(16, M(&g_cycles_left), R(ECX));
+      MOV(16, M(&m_cycles_left), R(ECX));
       JMP(m_block_links[dest], true);
       SetJumpTarget(notEnoughCycles);
     }

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -73,9 +73,11 @@ void DSPLLE::DoState(PointerWrap& p)
   if (p.GetMode() == PointerWrap::MODE_READ)
     Host::CodeLoaded((const u8*)g_dsp.iram, DSP_IRAM_BYTE_SIZE);
   p.DoArray(g_dsp.dram, DSP_DRAM_SIZE);
-  p.Do(g_cycles_left);
   p.Do(g_init_hax);
   p.Do(m_cycle_count);
+
+  if (g_dsp_jit)
+    g_dsp_jit->DoState(p);
 }
 
 // Regular thread

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 74;  // Last changed in PR 4408
+static const u32 STATE_VERSION = 75;  // Last changed in PR 4857
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
Gets rid of a global within the DSP core. It also makes it less of a pain to generify things in the case of developing another DSP JIT, as you don't have the implementation specifics of one of them floating around the DSP core code.