### PR TITLE
OpcodeDecoding: Convert #defines into enum constants

### DIFF
--- a/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoAnalyzer.cpp
@@ -55,12 +55,12 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
 
   switch (cmd)
   {
-  case GX_NOP:
+  case OpcodeDecoder::GX_NOP:
   case 0x44:
-  case GX_CMD_INVL_VC:
+  case OpcodeDecoder::GX_CMD_INVL_VC:
     break;
 
-  case GX_LOAD_CP_REG:
+  case OpcodeDecoder::GX_LOAD_CP_REG:
   {
     s_DrawingObject = false;
 
@@ -70,7 +70,7 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
     break;
   }
 
-  case GX_LOAD_XF_REG:
+  case OpcodeDecoder::GX_LOAD_XF_REG:
   {
     s_DrawingObject = false;
 
@@ -81,14 +81,14 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
     break;
   }
 
-  case GX_LOAD_INDX_A:
-  case GX_LOAD_INDX_B:
-  case GX_LOAD_INDX_C:
-  case GX_LOAD_INDX_D:
+  case OpcodeDecoder::GX_LOAD_INDX_A:
+  case OpcodeDecoder::GX_LOAD_INDX_B:
+  case OpcodeDecoder::GX_LOAD_INDX_C:
+  case OpcodeDecoder::GX_LOAD_INDX_D:
   {
     s_DrawingObject = false;
 
-    int array = 0xc + (cmd - GX_LOAD_INDX_A) / 8;
+    int array = 0xc + (cmd - OpcodeDecoder::GX_LOAD_INDX_A) / 8;
     u32 value = ReadFifo32(data);
 
     if (mode == DECODE_RECORD)
@@ -96,7 +96,7 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
     break;
   }
 
-  case GX_CMD_CALL_DL:
+  case OpcodeDecoder::GX_CMD_CALL_DL:
     // The recorder should have expanded display lists into the fifo stream and skipped the call to
     // start them
     // That is done to make it easier to track where memory is updated
@@ -104,7 +104,7 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
     data += 8;
     break;
 
-  case GX_LOAD_BP_REG:
+  case OpcodeDecoder::GX_LOAD_BP_REG:
   {
     s_DrawingObject = false;
     ReadFifo32(data);
@@ -117,7 +117,7 @@ u32 AnalyzeCommand(const u8* data, DecodeMode mode)
       s_DrawingObject = true;
 
       int sizes[21];
-      FifoAnalyzer::CalculateVertexElementSizes(sizes, cmd & GX_VAT_MASK, s_CpMem);
+      CalculateVertexElementSizes(sizes, cmd & OpcodeDecoder::GX_VAT_MASK, s_CpMem);
 
       // Determine offset of each element that might be a vertex array
       // The first 9 elements are never vertex arrays so we just accumulate their sizes.

--- a/Source/Core/DolphinWX/FifoPlayerDlg.cpp
+++ b/Source/Core/DolphinWX/FifoPlayerDlg.cpp
@@ -650,7 +650,7 @@ void FifoPlayerDlg::OnObjectListSelectionChanged(wxCommandEvent& event)
         int command = *objectdata++;
         switch (command)
         {
-        case GX_NOP:
+        case OpcodeDecoder::GX_NOP:
           newLabel = "NOP";
           break;
 
@@ -658,11 +658,11 @@ void FifoPlayerDlg::OnObjectListSelectionChanged(wxCommandEvent& event)
           newLabel = "0x44";
           break;
 
-        case GX_CMD_INVL_VC:
+        case OpcodeDecoder::GX_CMD_INVL_VC:
           newLabel = "GX_CMD_INVL_VC";
           break;
 
-        case GX_LOAD_CP_REG:
+        case OpcodeDecoder::GX_LOAD_CP_REG:
         {
           u32 cmd2 = *objectdata++;
           u32 value = Common::swap32(objectdata);
@@ -672,7 +672,7 @@ void FifoPlayerDlg::OnObjectListSelectionChanged(wxCommandEvent& event)
         }
         break;
 
-        case GX_LOAD_XF_REG:
+        case OpcodeDecoder::GX_LOAD_XF_REG:
         {
           u32 cmd2 = Common::swap32(objectdata);
           objectdata += 4;
@@ -693,19 +693,22 @@ void FifoPlayerDlg::OnObjectListSelectionChanged(wxCommandEvent& event)
         }
         break;
 
-        case GX_LOAD_INDX_A:
-        case GX_LOAD_INDX_B:
-        case GX_LOAD_INDX_C:
-        case GX_LOAD_INDX_D:
+        case OpcodeDecoder::GX_LOAD_INDX_A:
+        case OpcodeDecoder::GX_LOAD_INDX_B:
+        case OpcodeDecoder::GX_LOAD_INDX_C:
+        case OpcodeDecoder::GX_LOAD_INDX_D:
+        {
           objectdata += 4;
-          newLabel = wxString::Format("LOAD INDX %s", (command == GX_LOAD_INDX_A) ?
-                                                          "A" :
-                                                          (command == GX_LOAD_INDX_B) ?
-                                                          "B" :
-                                                          (command == GX_LOAD_INDX_C) ? "C" : "D");
-          break;
+          newLabel = wxString::Format("LOAD INDX %s",
+                                      (command == OpcodeDecoder::GX_LOAD_INDX_A) ?
+                                          "A" :
+                                          (command == OpcodeDecoder::GX_LOAD_INDX_B) ?
+                                          "B" :
+                                          (command == OpcodeDecoder::GX_LOAD_INDX_C) ? "C" : "D");
+        }
+        break;
 
-        case GX_CMD_CALL_DL:
+        case OpcodeDecoder::GX_CMD_CALL_DL:
           // The recorder should have expanded display lists into the fifo stream and skipped the
           // call to start them
           // That is done to make it easier to track where memory is updated
@@ -714,7 +717,7 @@ void FifoPlayerDlg::OnObjectListSelectionChanged(wxCommandEvent& event)
           newLabel = wxString::Format("CALL DL");
           break;
 
-        case GX_LOAD_BP_REG:
+        case OpcodeDecoder::GX_LOAD_BP_REG:
         {
           u32 cmd2 = Common::swap32(objectdata);
           objectdata += 4;
@@ -759,7 +762,7 @@ void FifoPlayerDlg::OnObjectCmdListSelectionChanged(wxCommandEvent& event)
 
   // TODO: Not sure whether we should bother translating the descriptions
   wxString newLabel;
-  if (*cmddata == GX_LOAD_BP_REG)
+  if (*cmddata == OpcodeDecoder::GX_LOAD_BP_REG)
   {
     std::string name;
     std::string desc;
@@ -775,11 +778,11 @@ void FifoPlayerDlg::OnObjectCmdListSelectionChanged(wxCommandEvent& event)
     else
       newLabel += StrToWxStr(desc);
   }
-  else if (*cmddata == GX_LOAD_CP_REG)
+  else if (*cmddata == OpcodeDecoder::GX_LOAD_CP_REG)
   {
     newLabel = _("CP register ");
   }
-  else if (*cmddata == GX_LOAD_XF_REG)
+  else if (*cmddata == OpcodeDecoder::GX_LOAD_XF_REG)
   {
     newLabel = _("XF register ");
   }

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -62,14 +62,15 @@ void SWVertexLoader::vFlush()
   switch (m_current_primitive_type)
   {
   case PRIMITIVE_POINTS:
-    primitiveType = GX_DRAW_POINTS;
+    primitiveType = OpcodeDecoder::GX_DRAW_POINTS;
     break;
   case PRIMITIVE_LINES:
-    primitiveType = GX_DRAW_LINES;
+    primitiveType = OpcodeDecoder::GX_DRAW_LINES;
     break;
   case PRIMITIVE_TRIANGLES:
-    primitiveType = g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ? GX_DRAW_TRIANGLE_STRIP :
-                                                                            GX_DRAW_TRIANGLES;
+    primitiveType = g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ?
+                        OpcodeDecoder::GX_DRAW_TRIANGLE_STRIP :
+                        OpcodeDecoder::GX_DRAW_TRIANGLES;
     break;
   }
 

--- a/Source/Core/VideoBackends/Software/SetupUnit.cpp
+++ b/Source/Core/VideoBackends/Software/SetupUnit.cpp
@@ -33,29 +33,29 @@ void SetupUnit::SetupVertex()
 {
   switch (m_PrimType)
   {
-  case GX_DRAW_QUADS:
+  case OpcodeDecoder::GX_DRAW_QUADS:
     SetupQuad();
     break;
-  case GX_DRAW_QUADS_2:
+  case OpcodeDecoder::GX_DRAW_QUADS_2:
     WARN_LOG(VIDEO, "Non-standard primitive drawing command GL_DRAW_QUADS_2");
     SetupQuad();
     break;
-  case GX_DRAW_TRIANGLES:
+  case OpcodeDecoder::GX_DRAW_TRIANGLES:
     SetupTriangle();
     break;
-  case GX_DRAW_TRIANGLE_STRIP:
+  case OpcodeDecoder::GX_DRAW_TRIANGLE_STRIP:
     SetupTriStrip();
     break;
-  case GX_DRAW_TRIANGLE_FAN:
+  case OpcodeDecoder::GX_DRAW_TRIANGLE_FAN:
     SetupTriFan();
     break;
-  case GX_DRAW_LINES:
+  case OpcodeDecoder::GX_DRAW_LINES:
     SetupLine();
     break;
-  case GX_DRAW_LINE_STRIP:
+  case OpcodeDecoder::GX_DRAW_LINE_STRIP:
     SetupLineStrip();
     break;
-  case GX_DRAW_POINTS:
+  case OpcodeDecoder::GX_DRAW_POINTS:
     SetupPoint();
     break;
   }

--- a/Source/Core/VideoCommon/IndexGenerator.cpp
+++ b/Source/Core/VideoCommon/IndexGenerator.cpp
@@ -24,23 +24,23 @@ void IndexGenerator::Init()
 {
   if (g_Config.backend_info.bSupportsPrimitiveRestart)
   {
-    primitive_table[GX_DRAW_QUADS] = IndexGenerator::AddQuads<true>;
-    primitive_table[GX_DRAW_QUADS_2] = IndexGenerator::AddQuads_nonstandard<true>;
-    primitive_table[GX_DRAW_TRIANGLES] = IndexGenerator::AddList<true>;
-    primitive_table[GX_DRAW_TRIANGLE_STRIP] = IndexGenerator::AddStrip<true>;
-    primitive_table[GX_DRAW_TRIANGLE_FAN] = IndexGenerator::AddFan<true>;
+    primitive_table[OpcodeDecoder::GX_DRAW_QUADS] = AddQuads<true>;
+    primitive_table[OpcodeDecoder::GX_DRAW_QUADS_2] = AddQuads_nonstandard<true>;
+    primitive_table[OpcodeDecoder::GX_DRAW_TRIANGLES] = AddList<true>;
+    primitive_table[OpcodeDecoder::GX_DRAW_TRIANGLE_STRIP] = AddStrip<true>;
+    primitive_table[OpcodeDecoder::GX_DRAW_TRIANGLE_FAN] = AddFan<true>;
   }
   else
   {
-    primitive_table[GX_DRAW_QUADS] = IndexGenerator::AddQuads<false>;
-    primitive_table[GX_DRAW_QUADS_2] = IndexGenerator::AddQuads_nonstandard<false>;
-    primitive_table[GX_DRAW_TRIANGLES] = IndexGenerator::AddList<false>;
-    primitive_table[GX_DRAW_TRIANGLE_STRIP] = IndexGenerator::AddStrip<false>;
-    primitive_table[GX_DRAW_TRIANGLE_FAN] = IndexGenerator::AddFan<false>;
+    primitive_table[OpcodeDecoder::GX_DRAW_QUADS] = AddQuads<false>;
+    primitive_table[OpcodeDecoder::GX_DRAW_QUADS_2] = AddQuads_nonstandard<false>;
+    primitive_table[OpcodeDecoder::GX_DRAW_TRIANGLES] = AddList<false>;
+    primitive_table[OpcodeDecoder::GX_DRAW_TRIANGLE_STRIP] = AddStrip<false>;
+    primitive_table[OpcodeDecoder::GX_DRAW_TRIANGLE_FAN] = AddFan<false>;
   }
-  primitive_table[GX_DRAW_LINES] = &IndexGenerator::AddLineList;
-  primitive_table[GX_DRAW_LINE_STRIP] = &IndexGenerator::AddLineStrip;
-  primitive_table[GX_DRAW_POINTS] = &IndexGenerator::AddPoints;
+  primitive_table[OpcodeDecoder::GX_DRAW_LINES] = &AddLineList;
+  primitive_table[OpcodeDecoder::GX_DRAW_LINE_STRIP] = &AddLineStrip;
+  primitive_table[OpcodeDecoder::GX_DRAW_POINTS] = &AddPoints;
 }
 
 void IndexGenerator::Start(u16* Indexptr)

--- a/Source/Core/VideoCommon/OpcodeDecoding.h
+++ b/Source/Core/VideoCommon/OpcodeDecoding.h
@@ -8,39 +8,48 @@
 
 class DataReader;
 
-#define GX_NOP 0x00
-#define GX_UNKNOWN_RESET 0x01
+namespace OpcodeDecoder
+{
+enum
+{
+  GX_NOP = 0x00,
+  GX_UNKNOWN_RESET = 0x01,
 
-#define GX_LOAD_BP_REG 0x61
-#define GX_LOAD_CP_REG 0x08
-#define GX_LOAD_XF_REG 0x10
-#define GX_LOAD_INDX_A 0x20
-#define GX_LOAD_INDX_B 0x28
-#define GX_LOAD_INDX_C 0x30
-#define GX_LOAD_INDX_D 0x38
+  GX_LOAD_BP_REG = 0x61,
+  GX_LOAD_CP_REG = 0x08,
+  GX_LOAD_XF_REG = 0x10,
+  GX_LOAD_INDX_A = 0x20,
+  GX_LOAD_INDX_B = 0x28,
+  GX_LOAD_INDX_C = 0x30,
+  GX_LOAD_INDX_D = 0x38,
 
-#define GX_CMD_CALL_DL 0x40
-#define GX_CMD_UNKNOWN_METRICS 0x44
-#define GX_CMD_INVL_VC 0x48
+  GX_CMD_CALL_DL = 0x40,
+  GX_CMD_UNKNOWN_METRICS = 0x44,
+  GX_CMD_INVL_VC = 0x48
+};
 
-#define GX_PRIMITIVE_MASK 0x78
-#define GX_PRIMITIVE_SHIFT 3
-#define GX_VAT_MASK 0x07
+enum
+{
+  GX_PRIMITIVE_MASK = 0x78,
+  GX_PRIMITIVE_SHIFT = 3,
+  GX_VAT_MASK = 0x07
+};
 
 // These values are the values extracted using GX_PRIMITIVE_MASK
 // and GX_PRIMITIVE_SHIFT.
 // GX_DRAW_QUADS_2 behaves the same way as GX_DRAW_QUADS.
-#define GX_DRAW_QUADS 0x0           // 0x80
-#define GX_DRAW_QUADS_2 0x1         // 0x88
-#define GX_DRAW_TRIANGLES 0x2       // 0x90
-#define GX_DRAW_TRIANGLE_STRIP 0x3  // 0x98
-#define GX_DRAW_TRIANGLE_FAN 0x4    // 0xA0
-#define GX_DRAW_LINES 0x5           // 0xA8
-#define GX_DRAW_LINE_STRIP 0x6      // 0xB0
-#define GX_DRAW_POINTS 0x7          // 0xB8
-
-namespace OpcodeDecoder
+enum
 {
+  GX_DRAW_QUADS = 0x0,           // 0x80
+  GX_DRAW_QUADS_2 = 0x1,         // 0x88
+  GX_DRAW_TRIANGLES = 0x2,       // 0x90
+  GX_DRAW_TRIANGLE_STRIP = 0x3,  // 0x98
+  GX_DRAW_TRIANGLE_FAN = 0x4,    // 0xA0
+  GX_DRAW_LINES = 0x5,           // 0xA8
+  GX_DRAW_LINE_STRIP = 0x6,      // 0xB0
+  GX_DRAW_POINTS = 0x7           // 0xB8
+};
+
 void Init();
 
 template <bool is_preprocess = false>

--- a/Source/Core/VideoCommon/VertexManagerBase.cpp
+++ b/Source/Core/VideoCommon/VertexManagerBase.cpp
@@ -107,22 +107,22 @@ u32 VertexManagerBase::GetRemainingIndices(int primitive)
   {
     switch (primitive)
     {
-    case GX_DRAW_QUADS:
-    case GX_DRAW_QUADS_2:
+    case OpcodeDecoder::GX_DRAW_QUADS:
+    case OpcodeDecoder::GX_DRAW_QUADS_2:
       return index_len / 5 * 4;
-    case GX_DRAW_TRIANGLES:
+    case OpcodeDecoder::GX_DRAW_TRIANGLES:
       return index_len / 4 * 3;
-    case GX_DRAW_TRIANGLE_STRIP:
+    case OpcodeDecoder::GX_DRAW_TRIANGLE_STRIP:
       return index_len / 1 - 1;
-    case GX_DRAW_TRIANGLE_FAN:
+    case OpcodeDecoder::GX_DRAW_TRIANGLE_FAN:
       return index_len / 6 * 4 + 1;
 
-    case GX_DRAW_LINES:
+    case OpcodeDecoder::GX_DRAW_LINES:
       return index_len;
-    case GX_DRAW_LINE_STRIP:
+    case OpcodeDecoder::GX_DRAW_LINE_STRIP:
       return index_len / 2 + 1;
 
-    case GX_DRAW_POINTS:
+    case OpcodeDecoder::GX_DRAW_POINTS:
       return index_len;
 
     default:
@@ -133,22 +133,22 @@ u32 VertexManagerBase::GetRemainingIndices(int primitive)
   {
     switch (primitive)
     {
-    case GX_DRAW_QUADS:
-    case GX_DRAW_QUADS_2:
+    case OpcodeDecoder::GX_DRAW_QUADS:
+    case OpcodeDecoder::GX_DRAW_QUADS_2:
       return index_len / 6 * 4;
-    case GX_DRAW_TRIANGLES:
+    case OpcodeDecoder::GX_DRAW_TRIANGLES:
       return index_len;
-    case GX_DRAW_TRIANGLE_STRIP:
+    case OpcodeDecoder::GX_DRAW_TRIANGLE_STRIP:
       return index_len / 3 + 2;
-    case GX_DRAW_TRIANGLE_FAN:
+    case OpcodeDecoder::GX_DRAW_TRIANGLE_FAN:
       return index_len / 3 + 2;
 
-    case GX_DRAW_LINES:
+    case OpcodeDecoder::GX_DRAW_LINES:
       return index_len;
-    case GX_DRAW_LINE_STRIP:
+    case OpcodeDecoder::GX_DRAW_LINE_STRIP:
       return index_len / 2 + 1;
 
-    case GX_DRAW_POINTS:
+    case OpcodeDecoder::GX_DRAW_POINTS:
       return index_len;
 
     default:


### PR DESCRIPTION
Gets several constants out of global scope.