### PR TITLE
Initialize WiiRoot when Dolphin starts

### DIFF
--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -13,6 +13,7 @@
 
 #include "Core/ConfigManager.h"
 #include "Core/HW/Wiimote.h"
+#include "Core/WiiRoot.h"
 
 #include "InputCommon/GCAdapter.h"
 
@@ -32,6 +33,7 @@ void Init()
   GCAdapter::Init();
   USBUtils::Init();
   VideoBackendBase::ActivateBackend(SConfig::GetInstance().m_strVideoBackend);
+  Core::InitializeWiiRoot(false);
 
   SetEnableAlert(SConfig::GetInstance().bUsePanicHandlers);
 }


### PR DESCRIPTION
If we only do it in HW::Init, SESSION_ROOT will not be initialized and trying to install a WAD will attempt to create files in the root partition (/sys/uid.sys).