### PR TITLE
WiiRoot: Only call InitializeDeterministicWiiSaves on temporary NAND

### DIFF
--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -77,13 +77,13 @@ void InitializeWiiRoot(bool use_temporary)
     // Generate a SYSCONF with default settings for the temporary Wii NAND.
     SysConf sysconf{Common::FromWhichRoot::FROM_SESSION_ROOT};
     sysconf.Save();
+
+    InitializeDeterministicWiiSaves();
   }
   else
   {
     File::SetUserPath(D_SESSION_WIIROOT_IDX, File::GetUserPath(D_WIIROOT_IDX));
   }
-
-  InitializeDeterministicWiiSaves();
 }
 
 void ShutdownWiiRoot()


### PR DESCRIPTION
Shouldn't make any difference in practice because both IsRecordingInput and IsNetPlayRunning should be false if a temporary NAND isn't being set up, but doing it this way is cleaner regardless.