### PR TITLE
Always use configured root when installing WAD

### DIFF
--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -52,7 +52,6 @@ void Init()
   if (SConfig::GetInstance().bWii)
   {
     Core::InitializeWiiRoot(Core::g_want_determinism);
-    DiscIO::cUIDsys::AccessInstance().UpdateLocation();
     DiscIO::CSharedContent::AccessInstance().UpdateLocation();
     IOS::Init();
     IOS::HLE::Init();  // Depends on Memory

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -121,7 +121,8 @@ void ES::OpenInternal()
     m_TitleID = contentLoader.GetTitleID();
 
     m_TitleIDs.clear();
-    DiscIO::cUIDsys::AccessInstance().GetTitleIDs(m_TitleIDs);
+    DiscIO::cUIDsys uid_sys{Common::FromWhichRoot::FROM_SESSION_ROOT};
+    uid_sys.GetTitleIDs(m_TitleIDs);
     // uncomment if  ES_GetOwnedTitlesCount / ES_GetOwnedTitles is implemented
     // m_TitleIDsOwned.clear();
     // DiscIO::cUIDsys::AccessInstance().GetTitleIDs(m_TitleIDsOwned, true);
@@ -1324,7 +1325,8 @@ u32 ES::ES_DIVerify(const std::vector<u8>& tmd)
     if (!tmd_file.WriteBytes(tmd.data(), tmd.size()))
       ERROR_LOG(IOS_ES, "DIVerify failed to write disc TMD to NAND.");
   }
-  DiscIO::cUIDsys::AccessInstance().AddTitle(tmd_title_id);
+  DiscIO::cUIDsys uid_sys{Common::FromWhichRoot::FROM_SESSION_ROOT};
+  uid_sys.AddTitle(tmd_title_id);
   // DI_VERIFY writes to title.tmd, which is read and cached inside the NAND Content Manager.
   // clear the cache to avoid content access mismatches.
   DiscIO::CNANDContentManager::Access().ClearCache();

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -398,16 +398,11 @@ void CNANDContentLoader::RemoveTitle() const
   }
 }
 
-cUIDsys::cUIDsys()
-{
-  UpdateLocation();
-}
-
-void cUIDsys::UpdateLocation()
+cUIDsys::cUIDsys(Common::FromWhichRoot root)
 {
   m_Elements.clear();
   m_LastUID = 0x00001000;
-  m_UidSys = File::GetUserPath(D_SESSION_WIIROOT_IDX) + "/sys/uid.sys";
+  m_UidSys = Common::RootUserPath(root) + "/sys/uid.sys";
 
   File::IOFile pFile(m_UidSys, "rb");
   SElement Element;
@@ -428,10 +423,6 @@ void cUIDsys::UpdateLocation()
     if (!pFile.WriteArray(&Element, 1))
       ERROR_LOG(DISCIO, "Failed to write to %s", m_UidSys.c_str());
   }
-}
-
-cUIDsys::~cUIDsys()
-{
 }
 
 u32 cUIDsys::GetUIDFromTitle(u64 title_id)
@@ -541,7 +532,8 @@ u64 CNANDContentManager::Install_WiiWAD(const std::string& filename)
     return 0;
   }
 
-  cUIDsys::AccessInstance().AddTitle(title_id);
+  cUIDsys uid_sys{Common::FromWhichRoot::FROM_CONFIGURED_ROOT};
+  uid_sys.AddTitle(title_id);
 
   ClearCache();
 

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -188,27 +188,16 @@ private:
   std::vector<SElement> m_Elements;
 };
 
-class cUIDsys
+class cUIDsys final
 {
 public:
-  static cUIDsys& AccessInstance()
-  {
-    static cUIDsys instance;
-    return instance;
-  }
+  explicit cUIDsys(Common::FromWhichRoot root);
 
   u32 GetUIDFromTitle(u64 title_id);
   void AddTitle(u64 title_id);
   void GetTitleIDs(std::vector<u64>& title_ids, bool owned = false);
-  void UpdateLocation();
 
 private:
-  cUIDsys();
-  virtual ~cUIDsys();
-
-  cUIDsys(cUIDsys const&) = delete;
-  void operator=(cUIDsys const&) = delete;
-
 #pragma pack(push, 1)
   struct SElement
   {


### PR DESCRIPTION
This prevents Dolphin from writing to /sys/uid.sys (on the host; root partition) when installing a WAD before starting emulation, because the session root is not initialized at that moment.

Incidentally, this also gets rid of a singleton.