### PR TITLE
ControllerEmu: Fix incorrect default radius being set in AnalogStick

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -172,7 +172,7 @@ void ControllerEmu::ControlGroup::SetControlExpression(int index, const std::str
 }
 
 ControllerEmu::AnalogStick::AnalogStick(const char* const _name, ControlState default_radius)
-    : AnalogStick(_name, _name, GROUP_TYPE_STICK)
+    : AnalogStick(_name, _name, default_radius)
 {
 }
 


### PR DESCRIPTION
Found this while working on a commit that separates out some of the internals of ControllerEmu.

The three parameter AnalogStick constructor takes an internal name, a display name, and a default radius argument. The delegated constructor is the one that calls the ControlGroup constructor, setting the group type, so passing the group type here is a logic bug.

The only reason this appeared to work despite this bug is because `GROUP_TYPE_STICK` has a value of `1`, and the default radius value used for attachment analog sticks is `1.0`.