### PR TITLE
Only use usbdk when installed

### DIFF
--- a/Externals/libusb/libusb/Makefile.am
+++ b/Externals/libusb/libusb/Makefile.am
@@ -15,8 +15,8 @@ NETBSD_USB_SRC = os/netbsd_usb.c
 SUNOS_USB_SRC = os/sunos_usb.c os/sunos_usb.h
 WINDOWS_COMMON_SRC = os/windows_nt_common.h os/windows_nt_common.c \
                      os/windows_common.h libusb-1.0.rc libusb-1.0.def
-WINDOWS_USB_SRC = os/windows_winusb.h os/windows_winusb.c
-WINDOWS_USBDK_SRC = os/windows_usbdk.h os/windows_usbdk.c
+WINDOWS_USB_SRC = os/windows_winusb.h os/windows_winusb.c os/windows_usbdk.h \
+		  os/windows_usbdk.c $(COMMON_WINDOWS_SRC)
 WINCE_USB_SRC = os/wince_usb.h os/wince_usb.c
 HAIKU_USB_SRC = os/haiku_usb.h os/haiku_usb_backend.cpp \
 		os/haiku_usb_raw.h os/haiku_usb_raw.cpp os/haiku_pollfs.cpp
@@ -63,12 +63,7 @@ libusb_1_0_la_LIBADD = libusb_haiku.la
 endif
 
 if OS_WINDOWS
-
-if USE_USBDK
-OS_SRC = $(WINDOWS_USBDK_SRC) $(WINDOWS_COMMON_SRC)
-else
 OS_SRC = $(WINDOWS_USB_SRC) $(WINDOWS_COMMON_SRC)
-endif
 
 .rc.lo:
 	$(AM_V_GEN)$(LIBTOOL) $(AM_V_lt) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --tag=RC --mode=compile $(RC) $(RCFLAGS) -i $< -o $@

--- a/Externals/libusb/libusb/libusbi.h
+++ b/Externals/libusb/libusb/libusbi.h
@@ -1132,7 +1132,11 @@ struct usbi_os_backend {
 	size_t transfer_priv_size;
 };
 
+#if defined(OS_WINDOWS)
+extern const struct usbi_os_backend * usbi_backend;
+#else
 extern const struct usbi_os_backend * const usbi_backend;
+#endif
 
 extern const struct usbi_os_backend linux_usbfs_backend;
 extern const struct usbi_os_backend darwin_backend;

--- a/Externals/libusb/libusb/os/windows_nt_common.h
+++ b/Externals/libusb/libusb/os/windows_nt_common.h
@@ -50,10 +50,20 @@ void windows_common_exit(void);
 unsigned long htab_hash(const char *str);
 int windows_clock_gettime(int clk_id, struct timespec *tp);
 
-void windows_clear_transfer_priv(struct usbi_transfer *itransfer);
-int windows_copy_transfer_data(struct usbi_transfer *itransfer, uint32_t io_size);
-struct winfd *windows_get_fd(struct usbi_transfer *transfer);
-void windows_get_overlapped_result(struct usbi_transfer *transfer, struct winfd *pollable_fd, DWORD *io_result, DWORD *io_size);
+typedef void(*CLEAR_TRANSFER_PRIV)(struct usbi_transfer *itransfer);
+typedef int(*COPY_TRANSFER_DATA)(struct usbi_transfer *itransfer, uint32_t io_size);
+typedef struct winfd *(*GET_FD)(struct usbi_transfer *transfer);
+typedef void(*GET_OVERLAPPED_RESULT)(struct usbi_transfer *transfer, struct winfd *pollable_fd, DWORD *io_result, DWORD *io_size);
+
+typedef struct win_backend
+{
+	CLEAR_TRANSFER_PRIV clear_transfer_priv;
+	COPY_TRANSFER_DATA copy_transfer_data;
+	GET_FD get_fd;
+	GET_OVERLAPPED_RESULT get_overlapped_result;
+} win_backend;
+
+void win_nt_init(win_backend *backend);
 
 void windows_handle_callback(struct usbi_transfer *itransfer, uint32_t io_result, uint32_t io_size);
 int windows_handle_events(struct libusb_context *ctx, struct pollfd *fds, POLL_NFDS_TYPE nfds, int num_ready);

--- a/Externals/libusb/libusb_static_2013.vcxproj
+++ b/Externals/libusb/libusb_static_2013.vcxproj
@@ -53,6 +53,7 @@
     <ClCompile Include="libusb\os\threads_windows.c" />
     <ClCompile Include="libusb\os\windows_nt_common.c" />
     <ClCompile Include="libusb\os\windows_usbdk.c" />
+    <ClCompile Include="libusb\os\windows_winusb.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="msvc\config.h" />
@@ -66,6 +67,7 @@
     <ClInclude Include="libusb\os\windows_common.h" />
     <ClInclude Include="libusb\os\windows_nt_common.h" />
     <ClInclude Include="libusb\os\windows_usbdk.h" />
+    <ClInclude Include="libusb\os\windows_winusb.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Externals/libusb/msvc/libusb_sources
+++ b/Externals/libusb/msvc/libusb_sources
@@ -38,6 +38,7 @@ SOURCES=..\core.c \
 	..\hotplug.c \
 	threads_windows.c \
 	poll_windows.c \
+	windows_usbdk.c \
 	windows_winusb.c \
 	windows_usbdk.c \
 	windows_nt_common.c \


### PR DESCRIPTION
#4408 switched the libusb backend to usbdk on Windows, as it is the only supported way to get working isochronous transfers. It is also less annoying to use, since a libusb compatible driver would have to be installed for every single device someone wanted to passthrough.

Unfortunately, usbdk causes some serious issues for some users (only those stuck on Windows 7 and which are affected by a Windows driver signature bug?)

This PR applies a upstream patch to libusb, so that usbdk is only used when it is installed. This allows users who have absolutely no issues with usbdk to continue using it (and get its benefits), and those who *are* affected to keep using the unmaintained WinUSB backend.

<sup><sub>Windows is a mess, isn't it?</sub></sup>