### PR TITLE
Fix connecting Wii remotes on boot

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -55,8 +55,6 @@
 #include "Core/HW/VideoInterface.h"
 #include "Core/HW/Wiimote.h"
 #include "Core/IOS/IPC.h"
-#include "Core/IOS/USB/Bluetooth/BTEmu.h"
-#include "Core/IOS/USB/Bluetooth/WiimoteDevice.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayClient.h"
 #include "Core/NetPlayProto.h"
@@ -526,13 +524,6 @@ void EmuThread()
                               Wiimote::InitializeMode::DO_NOT_WAIT_FOR_WIIMOTES);
     else
       Wiimote::LoadConfig();
-
-    // Activate Wiimotes which don't have source set to "None"
-    const auto bt = std::static_pointer_cast<IOS::HLE::Device::BluetoothEmu>(
-        IOS::HLE::GetDeviceByName("/dev/usb/oh1/57e/305"));
-    for (unsigned int i = 0; i != MAX_BBMOTES; ++i)
-      if (g_wiimote_sources[i] && bt)
-        bt->AccessWiiMote(i | 0x100)->Activate(true);
   }
 
   AudioCommon::InitSoundStream();

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -52,11 +52,8 @@
 #include "Core/ConfigManager.h"
 #include "Core/HW/DVDInterface.h"
 #include "Core/HW/Memmap.h"
-#include "Core/HW/Wiimote.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
-#include "Core/IOS/USB/Bluetooth/BTEmu.h"
-#include "Core/IOS/USB/Bluetooth/WiimoteDevice.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/WiiRoot.h"
 #include "Core/ec_wii.h"
@@ -1202,34 +1199,7 @@ IPCCommandResult ES::LaunchBC(const IOCtlVRequest& request)
 
 void ES::ResetAfterLaunch(const u64 ios_to_load) const
 {
-  auto bt = std::static_pointer_cast<BluetoothEmu>(GetDeviceByName("/dev/usb/oh1/57e/305"));
-  bool* wiiMoteConnected = new bool[MAX_BBMOTES];
-  if (!SConfig::GetInstance().m_bt_passthrough_enabled && bt)
-  {
-    for (unsigned int i = 0; i < MAX_BBMOTES; i++)
-      wiiMoteConnected[i] = bt->m_WiiMotes[i].IsConnected();
-  }
-
   Reload(ios_to_load);
-
-  // Get the new Bluetooth device. Note that it is not guaranteed to exist.
-  bt = std::static_pointer_cast<BluetoothEmu>(GetDeviceByName("/dev/usb/oh1/57e/305"));
-  if (!SConfig::GetInstance().m_bt_passthrough_enabled && bt)
-  {
-    for (unsigned int i = 0; i < MAX_BBMOTES; i++)
-    {
-      if (wiiMoteConnected[i])
-      {
-        bt->m_WiiMotes[i].Activate(false);
-        bt->m_WiiMotes[i].Activate(true);
-      }
-      else
-      {
-        bt->m_WiiMotes[i].Activate(false);
-      }
-    }
-  }
-  delete[] wiiMoteConnected;
 }
 
 IPCCommandResult ES::CheckKoreaRegion(const IOCtlVRequest& request)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -47,8 +47,6 @@ BluetoothEmu::BluetoothEmu(u32 device_id, const std::string& device_name)
   if (!Core::g_want_determinism)
     BackUpBTInfoSection(&sysconf);
 
-  // Activate only first Wii Remote by default
-
   _conf_pads BT_DINF;
   if (!sysconf.GetArrayData("BT.DINF", (u8*)&BT_DINF, sizeof(_conf_pads)))
   {
@@ -78,7 +76,7 @@ BluetoothEmu::BluetoothEmu(u32 device_id, const std::string& device_name)
 
       DEBUG_LOG(IOS_WIIMOTE, "Wii Remote %d BT ID %x,%x,%x,%x,%x,%x", i, tmpBD.b[0], tmpBD.b[1],
                 tmpBD.b[2], tmpBD.b[3], tmpBD.b[4], tmpBD.b[5]);
-      m_WiiMotes.emplace_back(this, i, tmpBD, false);
+      m_WiiMotes.emplace_back(this, i, tmpBD, g_wiimote_sources[i] != WIIMOTE_SRC_NONE);
       i++;
     }
 


### PR DESCRIPTION
The recent IOS initialization changes caused the Bluetooth device to no longer exist before "starting" IOS (as it should be…), which meant that Core could not activate Wii remotes during the boot process anymore.

But that is actually completely useless, because we can just have the emulated Bluetooth code itself activate Wii remotes as appropriate, at the right moment.