### PR TITLE
ControlReference: Add missing virtual destructor

### DIFF
--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -52,6 +52,8 @@ ControlReference::ControlReference() : range(1), m_parsed_expression(nullptr)
 {
 }
 
+ControlReference::~ControlReference() = default;
+
 InputReference::InputReference() : ControlReference()
 {
 }

--- a/Source/Core/InputCommon/ControlReference/ControlReference.h
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.h
@@ -24,6 +24,7 @@ class ControlReference
 public:
   static bool InputGateOn();
 
+  virtual ~ControlReference();
   virtual ControlState State(const ControlState state = 0) = 0;
   virtual ciface::Core::Device::Control* Detect(const unsigned int ms,
                                                 ciface::Core::Device* const device) = 0;


### PR DESCRIPTION
Noticed this while doing #4873, but kept it separate, as it wasn't related to splitting up `ControlGroup`.

ControllerEmu::Control instances have a `std::unique_ptr<ControlReference>` member, which is passed either an `InputReference` or `OutputReference`.

Without this virtual destructor, deleting either of the derived classes through a pointer to the base class is undefined behavior.