### PR TITLE
FileIO: Minor cleanup

### DIFF
--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -83,7 +83,7 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
   File::CreateFullPath(Common::GetTitleDataPath(titleID, Common::FROM_SESSION_ROOT));
 
   if (titleID == TITLEID_SYSMENU)
-    IOS::HLE::HLE_IPC_CreateVirtualFATFilesystem();
+    IOS::HLE::CreateVirtualFATFilesystem();
   // setup Wii memory
 
   u64 ios_title_id = 0x0000000100000000ULL | ContentLoader.GetIosVersion();

--- a/Source/Core/Core/IOS/FS/FS.cpp
+++ b/Source/Core/Core/IOS/FS/FS.cpp
@@ -136,7 +136,7 @@ ReturnCode FS::Open(const OpenRequest& request)
 {
   // clear tmp folder
   {
-    std::string Path = HLE_IPC_BuildFilename("/tmp");
+    std::string Path = BuildFilename("/tmp");
     File::DeleteDirRecursively(Path);
     File::CreateDir(Path);
   }
@@ -252,7 +252,7 @@ IPCCommandResult FS::CreateDirectory(const IOCtlRequest& request)
     return GetFSReply(FS_EINVAL);
   }
 
-  std::string DirName(HLE_IPC_BuildFilename(wii_path));
+  std::string DirName(BuildFilename(wii_path));
   Addr += 64;
   Addr += 9;  // owner attribs, permission
   u8 Attribs = Memory::Read_U8(Addr);
@@ -284,7 +284,7 @@ IPCCommandResult FS::SetAttribute(const IOCtlRequest& request)
     return GetFSReply(FS_EINVAL);
   }
 
-  std::string Filename = HLE_IPC_BuildFilename(wii_path);
+  std::string Filename = BuildFilename(wii_path);
   Addr += 64;
   u8 OwnerPerm = Memory::Read_U8(Addr);
   Addr += 1;
@@ -323,7 +323,7 @@ IPCCommandResult FS::GetAttribute(const IOCtlRequest& request)
     return GetFSReply(FS_EINVAL);
   }
 
-  std::string Filename = HLE_IPC_BuildFilename(wii_path);
+  std::string Filename = BuildFilename(wii_path);
   u8 OwnerPerm = 0x3;    // read/write
   u8 GroupPerm = 0x3;    // read/write
   u8 OtherPerm = 0x3;    // read/write
@@ -382,7 +382,7 @@ IPCCommandResult FS::DeleteFile(const IOCtlRequest& request)
     return GetFSReply(FS_EINVAL);
   }
 
-  std::string Filename = HLE_IPC_BuildFilename(wii_path);
+  std::string Filename = BuildFilename(wii_path);
   Offset += 64;
   if (File::Delete(Filename))
   {
@@ -411,7 +411,7 @@ IPCCommandResult FS::RenameFile(const IOCtlRequest& request)
     WARN_LOG(IOS_FILEIO, "Not a valid path: %s", wii_path.c_str());
     return GetFSReply(FS_EINVAL);
   }
-  std::string Filename = HLE_IPC_BuildFilename(wii_path);
+  std::string Filename = BuildFilename(wii_path);
   Offset += 64;
 
   const std::string wii_path_rename = Memory::GetString(request.buffer_in + Offset, 64);
@@ -421,7 +421,7 @@ IPCCommandResult FS::RenameFile(const IOCtlRequest& request)
     return GetFSReply(FS_EINVAL);
   }
 
-  std::string FilenameRename = HLE_IPC_BuildFilename(wii_path_rename);
+  std::string FilenameRename = BuildFilename(wii_path_rename);
   Offset += 64;
 
   // try to make the basis directory
@@ -464,7 +464,7 @@ IPCCommandResult FS::CreateFile(const IOCtlRequest& request)
     return GetFSReply(FS_EINVAL);
   }
 
-  std::string Filename(HLE_IPC_BuildFilename(wii_path));
+  std::string Filename(BuildFilename(wii_path));
   Addr += 64;
   u8 OwnerPerm = Memory::Read_U8(Addr);
   Addr++;
@@ -523,7 +523,7 @@ IPCCommandResult FS::ReadDirectory(const IOCtlVRequest& request)
   }
 
   // the Wii uses this function to define the type (dir or file)
-  std::string DirName(HLE_IPC_BuildFilename(relative_path));
+  std::string DirName(BuildFilename(relative_path));
 
   INFO_LOG(IOS_FILEIO, "FS: IOCTL_READ_DIR %s", DirName.c_str());
 
@@ -609,7 +609,7 @@ IPCCommandResult FS::GetUsage(const IOCtlVRequest& request)
     return GetFSReply(FS_EINVAL);
   }
 
-  std::string path(HLE_IPC_BuildFilename(relativepath));
+  std::string path(BuildFilename(relativepath));
   u32 fsBlocks = 0;
   u32 iNodes = 0;
 

--- a/Source/Core/Core/IOS/FS/FileIO.cpp
+++ b/Source/Core/Core/IOS/FS/FileIO.cpp
@@ -24,7 +24,7 @@ namespace HLE
 static std::map<std::string, std::weak_ptr<File::IOFile>> openFiles;
 
 // This is used by several of the FileIO and /dev/fs functions
-std::string HLE_IPC_BuildFilename(const std::string& wii_path)
+std::string BuildFilename(const std::string& wii_path)
 {
   std::string nand_path = File::GetUserPath(D_SESSION_WIIROOT_IDX);
   if (wii_path.compare(0, 1, "/") == 0)
@@ -34,7 +34,7 @@ std::string HLE_IPC_BuildFilename(const std::string& wii_path)
   return nand_path;
 }
 
-void HLE_IPC_CreateVirtualFATFilesystem()
+void CreateVirtualFATFilesystem()
 {
   const int cdbSize = 0x01400000;
   const std::string cdbPath =
@@ -94,7 +94,7 @@ ReturnCode FileIO::Open(const OpenRequest& request)
 
   static const char* const Modes[] = {"Unk Mode", "Read only", "Write only", "Read and Write"};
 
-  m_filepath = HLE_IPC_BuildFilename(m_name);
+  m_filepath = BuildFilename(m_name);
 
   // The file must exist before we can open it
   // It should be created by ISFS_CreateFile, not here
@@ -319,7 +319,7 @@ void FileIO::DoState(PointerWrap& p)
   p.Do(m_Mode);
   p.Do(m_SeekPos);
 
-  m_filepath = HLE_IPC_BuildFilename(m_name);
+  m_filepath = BuildFilename(m_name);
 
   // The file was closed during state (and might now be pointing at another file)
   // Open it again

--- a/Source/Core/Core/IOS/FS/FileIO.cpp
+++ b/Source/Core/Core/IOS/FS/FileIO.cpp
@@ -158,61 +158,37 @@ void FileIO::OpenFile()
 
 IPCCommandResult FileIO::Seek(const SeekRequest& request)
 {
-  u32 return_value = FS_EINVAL;
+  if (!m_file->IsOpen())
+    return GetDefaultReply(FS_ENOENT);
 
-  if (m_file->IsOpen())
+  const u32 file_size = static_cast<u32>(m_file->GetSize());
+  DEBUG_LOG(IOS_FILEIO, "FileIO: Seek Pos: 0x%08x, Mode: %i (%s, Length=0x%08x)", request.offset,
+            request.mode, m_name.c_str(), file_size);
+
+  u32 new_position = 0;
+  switch (request.mode)
   {
-    const u32 file_size = static_cast<u32>(m_file->GetSize());
-    DEBUG_LOG(IOS_FILEIO, "FileIO: Seek Pos: 0x%08x, Mode: %i (%s, Length=0x%08x)", request.offset,
-              request.mode, m_name.c_str(), file_size);
+  case SeekRequest::IOS_SEEK_SET:
+    new_position = request.offset;
+    break;
 
-    switch (request.mode)
-    {
-    case SeekRequest::IOS_SEEK_SET:
-    {
-      if (request.offset <= file_size)
-      {
-        m_SeekPos = request.offset;
-        return_value = m_SeekPos;
-      }
-      break;
-    }
+  case SeekRequest::IOS_SEEK_CUR:
+    new_position = m_SeekPos + request.offset;
+    break;
 
-    case SeekRequest::IOS_SEEK_CUR:
-    {
-      const u32 wanted_pos = request.offset + m_SeekPos;
-      if (wanted_pos <= file_size)
-      {
-        m_SeekPos = wanted_pos;
-        return_value = m_SeekPos;
-      }
-      break;
-    }
+  case SeekRequest::IOS_SEEK_END:
+    new_position = file_size + request.offset;
+    break;
 
-    case SeekRequest::IOS_SEEK_END:
-    {
-      const u32 wanted_pos = request.offset + file_size;
-      if (wanted_pos <= file_size)
-      {
-        m_SeekPos = wanted_pos;
-        return_value = m_SeekPos;
-      }
-      break;
-    }
-
-    default:
-    {
-      PanicAlert("FileIO Unsupported seek mode %i", request.mode);
-      return_value = FS_EINVAL;
-      break;
-    }
-    }
+  default:
+    return GetDefaultReply(FS_EINVAL);
   }
-  else
-  {
-    return_value = FS_ENOENT;
-  }
-  return GetDefaultReply(return_value);
+
+  if (new_position > file_size)
+    return GetDefaultReply(FS_EINVAL);
+
+  m_SeekPos = new_position;
+  return GetDefaultReply(new_position);
 }
 
 IPCCommandResult FileIO::Read(const ReadWriteRequest& request)

--- a/Source/Core/Core/IOS/FS/FileIO.h
+++ b/Source/Core/Core/IOS/FS/FileIO.h
@@ -22,8 +22,8 @@ namespace IOS
 {
 namespace HLE
 {
-std::string HLE_IPC_BuildFilename(const std::string& wii_path);
-void HLE_IPC_CreateVirtualFATFilesystem();
+std::string BuildFilename(const std::string& wii_path);
+void CreateVirtualFATFilesystem();
 
 namespace Device
 {


### PR DESCRIPTION
* Remove a HLE_IPC prefix from two functions.
* Minor changes to FileIO::Seek() so that checks are not duplicated anymore and error conditions are handled earlier (to avoid nested ifs).