### PR TITLE
IOS: Don't construct 3 ES devices

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -202,6 +202,8 @@ private:
   u64 m_TitleID = -1;
   u32 m_AccessIdentID = 0x6000000;
 
+  u8 m_open_count = 0;
+
   // For title installation (ioctls IOCTL_ES_ADDTITLE*).
   TMDReader m_addtitle_tmd;
   u32 m_addtitle_content_id = 0xFFFFFFFF;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 77;  // Last changed in PR 4784
+static const u32 STATE_VERSION = 78;  // Last changed in PR 4887
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
It looks like we had 3 ES devices for the sole purpose of limiting the number of times ES can be opened. We can simply do this by keeping track of the open count in ES instead of constructing 3 devices, which is not needed and something IOS does not actually do.