### PR TITLE
Get rid of a singleton for NAND shared contents

### DIFF
--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -25,7 +25,6 @@
 #include "Core/Movie.h"
 #include "Core/State.h"
 #include "Core/WiiRoot.h"
-#include "DiscIO/NANDContentLoader.h"
 
 namespace HW
 {
@@ -52,7 +51,6 @@ void Init()
   if (SConfig::GetInstance().bWii)
   {
     Core::InitializeWiiRoot(Core::g_want_determinism);
-    DiscIO::CSharedContent::AccessInstance().UpdateLocation();
     IOS::Init();
     IOS::HLE::Init();  // Depends on Memory
   }

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -155,26 +155,15 @@ private:
   std::unordered_map<std::string, std::unique_ptr<CNANDContentLoader>> m_map;
 };
 
-class CSharedContent
+class CSharedContent final
 {
 public:
-  static CSharedContent& AccessInstance()
-  {
-    static CSharedContent instance;
-    return instance;
-  }
+  explicit CSharedContent(Common::FromWhichRoot root);
 
-  std::string GetFilenameFromSHA1(const u8* hash);
+  std::string GetFilenameFromSHA1(const u8* hash) const;
   std::string AddSharedContent(const u8* hash);
-  void UpdateLocation();
 
 private:
-  CSharedContent();
-  virtual ~CSharedContent();
-
-  CSharedContent(CSharedContent const&) = delete;
-  void operator=(CSharedContent const&) = delete;
-
 #pragma pack(push, 1)
   struct SElement
   {
@@ -183,6 +172,7 @@ private:
   };
 #pragma pack(pop)
 
+  Common::FromWhichRoot m_root;
   u32 m_LastID;
   std::string m_ContentMap;
   std::vector<SElement> m_Elements;


### PR DESCRIPTION
This also allows shared contents to be installed to the configured root when installing a WAD, while using the session root in any other cases (like ES).