### PR TITLE
NetWindow: explicitly tell wxWidgets to clean up Windows macros

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetWindow.h
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.h
@@ -14,6 +14,15 @@
 #include "Core/NetPlayProto.h"
 #include "Core/NetPlayServer.h"
 
+// HACK: wxWidgets headers don't play well with some of the macros defined in Windows
+// headers and perform their own magic to fix things, as long as they're included entirely
+// either before or after any Windows headers.
+//
+// This file can cause a conflict in other DolphinWX files because NetPlay headers directly
+// include ENet headers, which leak Windows header macros. To fix this, explicitly tell
+// wxWidgets here that it needs to re-clean macros.
+#include <wx/msw/winundef.h>
+
 class CGameListCtrl;
 class MD5Dialog;
 class wxButton;


### PR DESCRIPTION
wxWidgets headers don't play well with some of the macros defined in Windows headers and perform their own magic to fix things, as long as they're included entirely either before or after any Windows headers.

This file can cause a conflict in other DolphinWX files because NetPlay headers directly include ENet headers, which leak Windows header macros. To fix this, explicitly tell wxWidgets here that it needs to re-clean macros.