### PR TITLE
Control: Convert raw pointer parameter into unique_ptr

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/Control/Control.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Control.cpp
@@ -3,11 +3,14 @@
 // Refer to the license.txt file included.
 
 #include "InputCommon/ControllerEmu/Control/Control.h"
+
+#include <utility>
 #include "InputCommon/ControlReference/ControlReference.h"
 
 namespace ControllerEmu
 {
-Control::Control(ControlReference* ref, const std::string& name_) : control_ref(ref), name(name_)
+Control::Control(std::unique_ptr<ControlReference> ref, const std::string& name_)
+    : control_ref(std::move(ref)), name(name_)
 {
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/Control/Control.h
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Control.h
@@ -20,6 +20,6 @@ public:
   const std::string name;
 
 protected:
-  Control(ControlReference* ref, const std::string& name);
+  Control(std::unique_ptr<ControlReference> ref, const std::string& name);
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Input.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Input.cpp
@@ -4,12 +4,13 @@
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
 
+#include <memory>
 #include <string>
 #include "InputCommon/ControlReference/ControlReference.h"
 
 namespace ControllerEmu
 {
-Input::Input(const std::string& name_) : Control(new InputReference, name_)
+Input::Input(const std::string& name_) : Control(std::make_unique<InputReference>(), name_)
 {
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Output.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Output.cpp
@@ -4,12 +4,13 @@
 
 #include "InputCommon/ControllerEmu/Control/Output.h"
 
+#include <memory>
 #include <string>
 #include "InputCommon/ControlReference/ControlReference.h"
 
 namespace ControllerEmu
 {
-Output::Output(const std::string& name_) : Control(new OutputReference, name_)
+Output::Output(const std::string& name_) : Control(std::make_unique<OutputReference>(), name_)
 {
 }
 }  // namespace ControllerEmu


### PR DESCRIPTION
Raw pointers shouldn't be used as boundaries in scenarios where ownership is being taken.