### PR TITLE
Cursor: Make m_z private

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -16,8 +16,6 @@ public:
 
   void GetState(ControlState* x, ControlState* y, ControlState* z, bool adjusted = false);
 
-  ControlState m_z = 0.0;
-
 private:
   // This is used to reduce the cursor speed for relative input
   // to something that makes sense with the default range.
@@ -25,5 +23,6 @@ private:
 
   ControlState m_x = 0.0;
   ControlState m_y = 0.0;
+  ControlState m_z = 0.0;
 };
 }  // namespace ControllerEmu


### PR DESCRIPTION
This isn't used directly anywhere outside private scope (and really shouldn't be public anyways to begin with).