### PR TITLE
Use ESFormats for tickets, TMDs and views

### DIFF
--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SRCS Analytics.cpp
          x64ABI.cpp
          x64Emitter.cpp
          MD5.cpp
+         Crypto/AES.cpp
          Crypto/bn.cpp
          Crypto/ec.cpp
          Logging/LogManager.cpp)

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -139,6 +139,7 @@
     <ClInclude Include="x64ABI.h" />
     <ClInclude Include="x64Emitter.h" />
     <ClInclude Include="x64Reg.h" />
+    <ClInclude Include="Crypto\AES.h" />
     <ClInclude Include="Crypto\bn.h" />
     <ClInclude Include="Crypto\ec.h" />
     <ClInclude Include="Logging\ConsoleListener.h" />
@@ -188,6 +189,7 @@
     <ClCompile Include="x64CPUDetect.cpp" />
     <ClCompile Include="x64Emitter.cpp" />
     <ClCompile Include="x64FPURoundMode.cpp" />
+    <ClCompile Include="Crypto\AES.cpp" />
     <ClCompile Include="Crypto\bn.cpp" />
     <ClCompile Include="Crypto\ec.cpp" />
     <ClCompile Include="Logging\LogManager.cpp" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClInclude Include="Logging\LogManager.h">
       <Filter>Logging</Filter>
     </ClInclude>
+    <ClInclude Include="Crypto\AES.h">
+      <Filter>Crypto</Filter>
+    </ClInclude>
     <ClInclude Include="Crypto\ec.h">
       <Filter>Crypto</Filter>
     </ClInclude>
@@ -259,6 +262,9 @@
     <ClCompile Include="x64CPUDetect.cpp" />
     <ClCompile Include="x64Emitter.cpp" />
     <ClCompile Include="x64FPURoundMode.cpp" />
+    <ClCompile Include="Crypto\AES.cpp">
+      <Filter>Crypto</Filter>
+    </ClCompile>
     <ClCompile Include="Crypto\bn.cpp">
       <Filter>Crypto</Filter>
     </ClCompile>

--- a/Source/Core/Common/Crypto/AES.cpp
+++ b/Source/Core/Common/Crypto/AES.cpp
@@ -1,0 +1,24 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <mbedtls/aes.h>
+
+#include "Common/Crypto/AES.h"
+
+namespace Common
+{
+namespace AES
+{
+std::vector<u8> Decrypt(const u8* key, u8* iv, const u8* src, size_t size)
+{
+  mbedtls_aes_context aes_ctx;
+  std::vector<u8> buffer(size);
+
+  mbedtls_aes_setkey_dec(&aes_ctx, key, 128);
+  mbedtls_aes_crypt_cbc(&aes_ctx, MBEDTLS_AES_DECRYPT, size, iv, src, buffer.data());
+
+  return buffer;
+}
+}  // namespace AES
+}  // namespace Common

--- a/Source/Core/Common/Crypto/AES.h
+++ b/Source/Core/Common/Crypto/AES.h
@@ -1,0 +1,18 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+
+namespace Common
+{
+namespace AES
+{
+std::vector<u8> Decrypt(const u8* key, u8* iv, const u8* src, size_t size);
+}  // namespace AES
+}  // namespace Common

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -102,7 +102,7 @@ bool CBoot::FindMapFile(std::string* existing_map_file, std::string* writable_ma
         DiscIO::CNANDContentManager::Access().GetNANDLoader(_StartupPara.m_strFilename);
     if (Loader.IsValid())
     {
-      u64 TitleID = Loader.GetTitleID();
+      u64 TitleID = Loader.GetTMD().GetTitleId();
       title_id_str = StringFromFormat("%08X_%08X", (u32)(TitleID >> 32) & 0xFFFFFFFF,
                                       (u32)TitleID & 0xFFFFFFFF);
     }
@@ -278,11 +278,7 @@ bool CBoot::BootUp()
       PanicAlertT("Warning - starting ISO in wrong console mode!");
     }
 
-    std::vector<u8> tmd_buffer = pVolume.GetTMD();
-    if (!tmd_buffer.empty())
-    {
-      IOS::HLE::ES_DIVerify(tmd_buffer);
-    }
+    IOS::HLE::ES_DIVerify(pVolume.GetTMD());
 
     _StartupPara.bWii = pVolume.GetVolumeType() == DiscIO::Platform::WII_DISC;
 

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -346,11 +346,9 @@ bool CBoot::EmulatedBS2_Wii()
 
   PowerPC::ppcState.gpr[1] = 0x816ffff0;  // StackPointer
 
-  std::vector<u8> tmd = DVDInterface::GetVolume().GetTMD();
+  IOS::ES::TMDReader tmd = DVDInterface::GetVolume().GetTMD();
 
-  ES::TMDReader tmd_reader{std::move(tmd)};
-
-  if (!SetupWiiMemory(tmd_reader.GetIOSId()))
+  if (!SetupWiiMemory(tmd.GetIOSId()))
     return false;
 
   // Execute the apploader

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -348,7 +348,7 @@ bool CBoot::EmulatedBS2_Wii()
 
   std::vector<u8> tmd = DVDInterface::GetVolume().GetTMD();
 
-  IOS::HLE::TMDReader tmd_reader{std::move(tmd)};
+  ES::TMDReader tmd_reader{std::move(tmd)};
 
   if (!SetupWiiMemory(tmd_reader.GetIOSId()))
     return false;

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -78,7 +78,7 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
   if (!ContentLoader.IsValid())
     return false;
 
-  u64 titleID = ContentLoader.GetTitleID();
+  u64 titleID = ContentLoader.GetTMD().GetTitleId();
   // create data directory
   File::CreateFullPath(Common::GetTitleDataPath(titleID, Common::FROM_SESSION_ROOT));
 
@@ -86,12 +86,11 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
     IOS::HLE::CreateVirtualFATFilesystem();
   // setup Wii memory
 
-  u64 ios_title_id = 0x0000000100000000ULL | ContentLoader.GetIosVersion();
-  if (!SetupWiiMemory(ios_title_id))
+  if (!SetupWiiMemory(ContentLoader.GetTMD().GetIOSId()))
     return false;
   // DOL
   const DiscIO::SNANDContent* pContent =
-      ContentLoader.GetContentByIndex(ContentLoader.GetBootIndex());
+      ContentLoader.GetContentByIndex(ContentLoader.GetTMD().GetBootIndex());
   if (pContent == nullptr)
     return false;
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -922,7 +922,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       const DiscIO::CNANDContentLoader& ContentLoader =
           DiscIO::CNANDContentManager::Access().GetNANDLoader(m_strFilename);
 
-      if (ContentLoader.GetContentByIndex(ContentLoader.GetBootIndex()) == nullptr)
+      if (ContentLoader.GetContentByIndex(ContentLoader.GetTMD().GetBootIndex()) == nullptr)
       {
         // WAD is valid yet cannot be booted. Install instead.
         u64 installed = DiscIO::CNANDContentManager::Access().Install_WiiWAD(m_strFilename);
@@ -931,7 +931,7 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
         return false;  // do not boot
       }
 
-      SetRegion(ContentLoader.GetRegion(), &set_region_dir);
+      SetRegion(ContentLoader.GetTMD().GetRegion(), &set_region_dir);
 
       bWii = true;
       m_BootType = BOOT_WII_NAND;

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -14,6 +14,7 @@
 #include "Core/HW/DVDInterface.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/DI/DI.h"
+#include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/IPC.h"
 #include "DiscIO/Volume.h"
 
@@ -105,9 +106,10 @@ IPCCommandResult DI::IOCtlV(const IOCtlVRequest& request)
     INFO_LOG(IOS_DI, "DVDLowOpenPartition: partition_offset 0x%016" PRIx64, partition_offset);
 
     // Read TMD to the buffer
-    std::vector<u8> tmd_buffer = DVDInterface::GetVolume().GetTMD();
-    Memory::CopyToEmu(request.io_vectors[0].address, tmd_buffer.data(), tmd_buffer.size());
-    ES_DIVerify(tmd_buffer);
+    const ES::TMDReader tmd = DVDInterface::GetVolume().GetTMD();
+    const std::vector<u8> raw_tmd = tmd.GetRawTMD();
+    Memory::CopyToEmu(request.io_vectors[0].address, raw_tmd.data(), raw_tmd.size());
+    ES_DIVerify(tmd);
 
     return_value = 1;
     break;

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -46,7 +46,7 @@ public:
   void Close() override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
-  static u32 ES_DIVerify(const std::vector<u8>& tmd);
+  static u32 ES_DIVerify(const IOS::ES::TMDReader& tmd);
 
   // This should only be cleared on power reset
   static std::string m_ContentFile;
@@ -203,7 +203,7 @@ private:
   u32 m_AccessIdentID = 0;
 
   // For title installation (ioctls IOCTL_ES_ADDTITLE*).
-  ::ES::TMDReader m_addtitle_tmd;
+  IOS::ES::TMDReader m_addtitle_tmd;
   u32 m_addtitle_content_id = 0xFFFFFFFF;
   std::vector<u8> m_addtitle_content_buffer;
 };

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -203,7 +203,7 @@ private:
   u32 m_AccessIdentID = 0;
 
   // For title installation (ioctls IOCTL_ES_ADDTITLE*).
-  TMDReader m_addtitle_tmd;
+  ::ES::TMDReader m_addtitle_tmd;
   u32 m_addtitle_content_id = 0xFFFFFFFF;
   std::vector<u8> m_addtitle_content_buffer;
 };

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -5,17 +5,30 @@
 #include "Core/IOS/ES/Formats.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <cstring>
 #include <utility>
 #include <vector>
+
+#include <mbedtls/aes.h>
 
 #include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 
-namespace IOS
+namespace ES
 {
-namespace HLE
+std::vector<u8> AESDecode(const u8* key, u8* iv, const u8* src, u32 size)
 {
+  mbedtls_aes_context aes_ctx;
+  std::vector<u8> buffer(size);
+
+  mbedtls_aes_setkey_dec(&aes_ctx, key, 128);
+  mbedtls_aes_crypt_cbc(&aes_ctx, MBEDTLS_AES_DECRYPT, size, iv, src, buffer.data());
+
+  return buffer;
+}
+
 TMDReader::TMDReader(const std::vector<u8>& bytes) : m_bytes(bytes)
 {
 }
@@ -103,5 +116,92 @@ void TMDReader::DoState(PointerWrap& p)
 {
   p.Do(m_bytes);
 }
-}  // namespace HLE
-}  // namespace IOS
+
+TicketReader::TicketReader(const std::vector<u8>& bytes) : m_bytes(bytes)
+{
+}
+
+TicketReader::TicketReader(std::vector<u8>&& bytes) : m_bytes(std::move(bytes))
+{
+}
+
+void TicketReader::SetBytes(const std::vector<u8>& bytes)
+{
+  m_bytes = bytes;
+}
+
+void TicketReader::SetBytes(std::vector<u8>&& bytes)
+{
+  m_bytes = std::move(bytes);
+}
+
+bool TicketReader::IsValid() const
+{
+  // Too small for the signature type.
+  if (m_bytes.size() < sizeof(u32))
+    return false;
+
+  u32 ticket_offset = GetOffset();
+  if (ticket_offset == 0)
+    return false;
+
+  // Too small for the ticket itself.
+  if (m_bytes.size() < ticket_offset + sizeof(Ticket))
+    return false;
+
+  return true;
+}
+
+u32 TicketReader::GetNumberOfTickets() const
+{
+  return static_cast<u32>(m_bytes.size() / (GetOffset() + sizeof(Ticket)));
+}
+
+u32 TicketReader::GetOffset() const
+{
+  u32 signature_type = Common::swap32(m_bytes.data());
+  if (signature_type == 0x10000)  // RSA4096
+    return 576;
+  if (signature_type == 0x10001)  // RSA2048
+    return 320;
+  if (signature_type == 0x10002)  // ECDSA
+    return 128;
+
+  ERROR_LOG(COMMON, "Invalid ticket signature type: %08x", signature_type);
+  return 0;
+}
+
+const std::vector<u8>& TicketReader::GetRawTicket() const
+{
+  return m_bytes;
+}
+
+std::vector<u8> TicketReader::GetRawTicketView(u32 ticket_num) const
+{
+  // A ticket view is composed of a view ID + part of a ticket starting from the ticket_id field.
+  std::vector<u8> view{sizeof(TicketView)};
+
+  u32 view_id = Common::swap32(ticket_num);
+  std::memcpy(view.data(), &view_id, sizeof(view_id));
+
+  const size_t ticket_start = (GetOffset() + sizeof(Ticket)) * ticket_num;
+  const size_t view_start = ticket_start + offsetof(Ticket, ticket_id);
+  std::memcpy(view.data() + sizeof(view_id), &m_bytes[view_start], sizeof(view) - sizeof(view_id));
+
+  return view;
+}
+
+u64 TicketReader::GetTitleId() const
+{
+  return Common::swap64(m_bytes.data() + GetOffset() + offsetof(Ticket, title_id));
+}
+
+std::vector<u8> TicketReader::GetTitleKey() const
+{
+  const u8 common_key[16] = {0xeb, 0xe4, 0x2a, 0x22, 0x5e, 0x85, 0x93, 0xe4,
+                             0x48, 0xd9, 0xc5, 0x45, 0x73, 0x81, 0xaa, 0xf7};
+  u8 iv[16] = {};
+  std::copy_n(&m_bytes[GetOffset() + offsetof(Ticket, title_id)], sizeof(Ticket::title_id), iv);
+  return AESDecode(common_key, iv, &m_bytes[GetOffset() + offsetof(Ticket, title_key)], 16);
+}
+}  // namespace ES

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -10,28 +10,16 @@
 #include <utility>
 #include <vector>
 
-#include <mbedtls/aes.h>
-
 #include "Common/ChunkFile.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
+#include "Common/Crypto/AES.h"
 
 namespace IOS
 {
 namespace ES
 {
 constexpr size_t CONTENT_VIEW_SIZE = 0x10;
-
-std::vector<u8> AESDecode(const u8* key, u8* iv, const u8* src, u32 size)
-{
-  mbedtls_aes_context aes_ctx;
-  std::vector<u8> buffer(size);
-
-  mbedtls_aes_setkey_dec(&aes_ctx, key, 128);
-  mbedtls_aes_crypt_cbc(&aes_ctx, MBEDTLS_AES_DECRYPT, size, iv, src, buffer.data());
-
-  return buffer;
-}
 
 TMDReader::TMDReader(const std::vector<u8>& bytes) : m_bytes(bytes)
 {
@@ -264,7 +252,8 @@ std::vector<u8> TicketReader::GetTitleKey() const
                              0x48, 0xd9, 0xc5, 0x45, 0x73, 0x81, 0xaa, 0xf7};
   u8 iv[16] = {};
   std::copy_n(&m_bytes[GetOffset() + offsetof(Ticket, title_id)], sizeof(Ticket::title_id), iv);
-  return AESDecode(common_key, iv, &m_bytes[GetOffset() + offsetof(Ticket, title_key)], 16);
+  return Common::AES::Decrypt(common_key, iv, &m_bytes[GetOffset() + offsetof(Ticket, title_key)],
+                              16);
 }
 }  // namespace ES
 }  // namespace IOS

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -101,8 +101,6 @@ struct Ticket
 static_assert(sizeof(Ticket) == 356, "Ticket has the wrong size");
 #pragma pack(pop)
 
-std::vector<u8> AESDecode(const u8* key, u8* iv, const u8* src, u32 size);
-
 class TMDReader final
 {
 public:

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -13,10 +13,10 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 
-namespace IOS
+namespace ES
 {
-namespace HLE
-{
+std::vector<u8> AESDecode(const u8* key, u8* iv, const u8* src, u32 size);
+
 class TMDReader final
 {
 public:
@@ -49,5 +49,79 @@ public:
 private:
   std::vector<u8> m_bytes;
 };
-}  // namespace HLE
-}  // namespace IOS
+
+#pragma pack(push, 4)
+struct TimeLimit
+{
+  u32 enabled;
+  u32 seconds;
+};
+
+struct TicketView
+{
+  u32 view;
+  u64 ticket_id;
+  u32 device_id;
+  u64 title_id;
+  u16 access_mask;
+  u32 permitted_title_id;
+  u32 permitted_title_mask;
+  u8 title_export_allowed;
+  u8 common_key_index;
+  u8 unknown2[0x30];
+  u8 content_access_permissions[0x40];
+  TimeLimit time_limits[8];
+};
+static_assert(sizeof(TicketView) == 0xd8, "TicketView has the wrong size");
+
+struct Ticket
+{
+  u8 signature_issuer[0x40];
+  u8 ecdh_key[0x3c];
+  u8 unknown[0x03];
+  u8 title_key[0x10];
+  u64 ticket_id;
+  u32 device_id;
+  u64 title_id;
+  u16 access_mask;
+  u16 ticket_version;
+  u32 permitted_title_id;
+  u32 permitted_title_mask;
+  u8 title_export_allowed;
+  u8 common_key_index;
+  u8 unknown2[0x30];
+  u8 content_access_permissions[0x40];
+  TimeLimit time_limits[8];
+};
+static_assert(sizeof(Ticket) == 356, "Ticket has the wrong size");
+#pragma pack(pop)
+
+class TicketReader final
+{
+public:
+  TicketReader() = default;
+  explicit TicketReader(const std::vector<u8>& bytes);
+  explicit TicketReader(std::vector<u8>&& bytes);
+
+  void SetBytes(const std::vector<u8>& bytes);
+  void SetBytes(std::vector<u8>&& bytes);
+
+  bool IsValid() const;
+
+  const std::vector<u8>& GetRawTicket() const;
+  u32 GetNumberOfTickets() const;
+  u32 GetOffset() const;
+
+  // Returns a "raw" ticket view, without byte swapping. Intended for use from ES.
+  // Theoretically, a ticket file can contain one or more tickets. In practice, most (all?)
+  // official titles only have one ticket, but IOS *does* have code to handle ticket files with
+  // more than just one ticket and generate ticket views for them, so we implement it too.
+  std::vector<u8> GetRawTicketView(u32 ticket_num) const;
+
+  u64 GetTitleId() const;
+  std::vector<u8> GetTitleKey() const;
+
+private:
+  std::vector<u8> m_bytes;
+};
+}  // namespace ES

--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -658,7 +658,7 @@ void SetDefaultContentFile(const std::string& file_name)
     es->LoadWAD(file_name);
 }
 
-void ES_DIVerify(const std::vector<u8>& tmd)
+void ES_DIVerify(const ES::TMDReader& tmd)
 {
   Device::ES::ES_DIVerify(tmd);
 }

--- a/Source/Core/Core/IOS/IPC.h
+++ b/Source/Core/Core/IOS/IPC.h
@@ -16,6 +16,11 @@ class PointerWrap;
 
 namespace IOS
 {
+namespace ES
+{
+class TMDReader;
+}
+
 namespace HLE
 {
 namespace Device
@@ -61,7 +66,7 @@ void DoState(PointerWrap& p);
 
 // Set default content file
 void SetDefaultContentFile(const std::string& file_name);
-void ES_DIVerify(const std::vector<u8>& tmd);
+void ES_DIVerify(const ES::TMDReader& tmd);
 
 void SDIO_EventNotify();
 

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -23,6 +23,7 @@
 #include "Core/HW/DVDThread.h"
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
+#include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/MIOS.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
@@ -97,7 +98,7 @@ static std::vector<u8> GetMIOSBinary()
   if (!loader.IsValid())
     return {};
 
-  const auto* content = loader.GetContentByIndex(loader.GetBootIndex());
+  const auto* content = loader.GetContentByIndex(loader.GetTMD().GetBootIndex());
   if (!content)
     return {};
 

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -134,7 +134,7 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
 
     // Initializes the IV from the index of the content in the TMD contents.
     u32 content_id = Memory::Read_U32(request.buffer_in + 8);
-    ES::TMDReader::Content content_info;
+    ES::Content content_info;
     if (!m_tmd.FindContentById(content_id, &content_info))
     {
       WARN_LOG(IOS, "%s: Content id %08x not found", ioctl_name, content_id);

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -109,14 +109,14 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
     Memory::CopyFromEmu(tmd_bytes.data(), tmd_addr, tmd_size);
     m_tmd.SetBytes(std::move(tmd_bytes));
 
-    std::vector<u8> ticket = DiscIO::FindSignedTicket(m_tmd.GetTitleId());
-    if (ticket.size() == 0)
+    ES::TicketReader ticket = DiscIO::FindSignedTicket(m_tmd.GetTitleId());
+    if (!ticket.IsValid())
     {
       return_error_code = -11028;
       break;
     }
 
-    memcpy(m_aes_key, DiscIO::GetKeyFromTicket(ticket).data(), sizeof(m_aes_key));
+    memcpy(m_aes_key, ticket.GetTitleKey().data(), sizeof(m_aes_key));
     mbedtls_aes_setkey_dec(&m_aes_ctx, m_aes_key, 128);
 
     break;
@@ -134,7 +134,7 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
 
     // Initializes the IV from the index of the content in the TMD contents.
     u32 content_id = Memory::Read_U32(request.buffer_in + 8);
-    TMDReader::Content content_info;
+    ES::TMDReader::Content content_info;
     if (!m_tmd.FindContentById(content_id, &content_info))
     {
       WARN_LOG(IOS, "%s: Content id %08x not found", ioctl_name, content_id);

--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -50,7 +50,7 @@ private:
   u8 m_aes_key[0x10] = {};
   u8 m_aes_iv[0x10] = {};
 
-  ::ES::TMDReader m_tmd;
+  IOS::ES::TMDReader m_tmd;
   std::string m_base_extract_path;
 
   ARCUnpacker m_arc_unpacker;

--- a/Source/Core/Core/IOS/WFS/WFSI.h
+++ b/Source/Core/Core/IOS/WFS/WFSI.h
@@ -50,7 +50,7 @@ private:
   u8 m_aes_key[0x10] = {};
   u8 m_aes_iv[0x10] = {};
 
-  TMDReader m_tmd;
+  ::ES::TMDReader m_tmd;
   std::string m_base_extract_path;
 
   ARCUnpacker m_arc_unpacker;

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -156,6 +156,11 @@ CNANDContentLoader::~CNANDContentLoader()
 {
 }
 
+bool CNANDContentLoader::IsValid() const
+{
+  return m_Valid && m_tmd.IsValid();
+}
+
 const SNANDContent* CNANDContentLoader::GetContentByIndex(int index) const
 {
   for (auto& Content : m_Content)

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -17,6 +17,7 @@
 #include "Common/Align.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
+#include "Common/Crypto/AES.h"
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
@@ -239,7 +240,7 @@ void CNANDContentLoader::InitializeContentEntries(const std::vector<u8>& data_ap
 
       u32 rounded_size = Common::AlignUp(static_cast<u32>(content.size), 0x40);
 
-      m_Content[i].m_Data = std::make_unique<CNANDContentDataBuffer>(IOS::ES::AESDecode(
+      m_Content[i].m_Data = std::make_unique<CNANDContentDataBuffer>(Common::AES::Decrypt(
           title_key.data(), iv.data(), &data_app[data_app_offset], rounded_size));
       data_app_offset += rounded_size;
     }

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -12,6 +12,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/NandPaths.h"
+#include "Core/IOS/ES/Formats.h"
 
 namespace File
 {
@@ -22,10 +23,8 @@ namespace DiscIO
 {
 enum class Region;
 
-bool AddTicket(const std::vector<u8>& signed_ticket);
-std::vector<u8> FindSignedTicket(u64 title_id);
-std::vector<u8> FindTicket(u64 title_id);
-std::vector<u8> GetKeyFromTicket(const std::vector<u8>& ticket);
+bool AddTicket(const ES::TicketReader& signed_ticket);
+ES::TicketReader FindSignedTicket(u64 title_id);
 
 class CNANDContentData
 {
@@ -93,7 +92,7 @@ public:
   const SNANDContent* GetContentByIndex(int index) const;
   const u8* GetTMDView() const { return m_TMDView; }
   const u8* GetTMDHeader() const { return m_TMDHeader; }
-  const std::vector<u8>& GetTicket() const { return m_Ticket; }
+  const ES::TicketReader& GetTicket() const { return m_ticket; }
   const std::vector<SNANDContent>& GetContent() const { return m_Content; }
   u16 GetTitleVersion() const { return m_TitleVersion; }
   u16 GetNumEntries() const { return m_NumEntries; }
@@ -104,14 +103,11 @@ public:
     TMD_VIEW_SIZE = 0x58,
     TMD_HEADER_SIZE = 0x1E4,
     CONTENT_HEADER_SIZE = 0x24,
-    TICKET_SIZE = 0x2A4
   };
 
 private:
   bool Initialize(const std::string& name);
-  void InitializeContentEntries(const std::vector<u8>& tmd,
-                                const std::vector<u8>& decrypted_title_key,
-                                const std::vector<u8>& data_app);
+  void InitializeContentEntries(const std::vector<u8>& tmd, const std::vector<u8>& data_app);
 
   bool m_Valid;
   bool m_IsWAD;
@@ -123,7 +119,7 @@ private:
   u16 m_TitleVersion;
   u8 m_TMDView[TMD_VIEW_SIZE];
   u8 m_TMDHeader[TMD_HEADER_SIZE];
-  std::vector<u8> m_Ticket;
+  ES::TicketReader m_ticket;
   u8 m_Country;
 
   std::vector<SNANDContent> m_Content;

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -23,8 +23,8 @@ namespace DiscIO
 {
 enum class Region;
 
-bool AddTicket(const ES::TicketReader& signed_ticket);
-ES::TicketReader FindSignedTicket(u64 title_id);
+bool AddTicket(const IOS::ES::TicketReader& signed_ticket);
+IOS::ES::TicketReader FindSignedTicket(u64 title_id);
 
 class CNANDContentData
 {
@@ -66,13 +66,7 @@ private:
 
 struct SNANDContent
 {
-  u32 m_ContentID;
-  u16 m_Index;
-  u16 m_Type;
-  u32 m_Size;
-  u8 m_SHA1Hash[20];
-  u8 m_Header[36];  // all of the above
-
+  IOS::ES::Content m_metadata;
   std::unique_ptr<CNANDContentData> m_Data;
 };
 
@@ -85,42 +79,19 @@ public:
 
   bool IsValid() const { return m_Valid; }
   void RemoveTitle() const;
-  u64 GetTitleID() const { return m_TitleID; }
-  u16 GetIosVersion() const { return m_IosVersion; }
-  u32 GetBootIndex() const { return m_BootIndex; }
-  size_t GetContentSize() const { return m_Content.size(); }
   const SNANDContent* GetContentByIndex(int index) const;
-  const u8* GetTMDView() const { return m_TMDView; }
-  const u8* GetTMDHeader() const { return m_TMDHeader; }
-  const ES::TicketReader& GetTicket() const { return m_ticket; }
+  const IOS::ES::TMDReader& GetTMD() const { return m_tmd; }
+  const IOS::ES::TicketReader& GetTicket() const { return m_ticket; }
   const std::vector<SNANDContent>& GetContent() const { return m_Content; }
-  u16 GetTitleVersion() const { return m_TitleVersion; }
-  u16 GetNumEntries() const { return m_NumEntries; }
-  DiscIO::Region GetRegion() const;
-  u8 GetCountryChar() const { return m_Country; }
-  enum
-  {
-    TMD_VIEW_SIZE = 0x58,
-    TMD_HEADER_SIZE = 0x1E4,
-    CONTENT_HEADER_SIZE = 0x24,
-  };
-
 private:
   bool Initialize(const std::string& name);
-  void InitializeContentEntries(const std::vector<u8>& tmd, const std::vector<u8>& data_app);
+  void InitializeContentEntries(const std::vector<u8>& data_app);
 
-  bool m_Valid;
-  bool m_IsWAD;
+  bool m_Valid = false;
+  bool m_IsWAD = false;
   std::string m_Path;
-  u64 m_TitleID;
-  u16 m_IosVersion;
-  u32 m_BootIndex;
-  u16 m_NumEntries;
-  u16 m_TitleVersion;
-  u8 m_TMDView[TMD_VIEW_SIZE];
-  u8 m_TMDHeader[TMD_HEADER_SIZE];
-  ES::TicketReader m_ticket;
-  u8 m_Country;
+  IOS::ES::TMDReader m_tmd;
+  IOS::ES::TicketReader m_ticket;
 
   std::vector<SNANDContent> m_Content;
 };

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -77,7 +77,7 @@ public:
   explicit CNANDContentLoader(const std::string& content_name);
   ~CNANDContentLoader();
 
-  bool IsValid() const { return m_Valid; }
+  bool IsValid() const;
   void RemoveTitle() const;
   const SNANDContent* GetContentByIndex(int index) const;
   const IOS::ES::TMDReader& GetTMD() const { return m_tmd; }

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -12,6 +12,7 @@
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
+#include "Core/IOS/ES/Formats.h"
 #include "DiscIO/Enums.h"
 
 namespace DiscIO
@@ -36,7 +37,7 @@ public:
   }
 
   virtual bool GetTitleID(u64*) const { return false; }
-  virtual std::vector<u8> GetTMD() const { return {}; }
+  virtual IOS::ES::TMDReader GetTMD() const { return {}; }
   virtual u64 PartitionOffsetToRawOffset(u64 offset) const { return offset; }
   virtual std::string GetGameID() const = 0;
   virtual std::string GetMakerID() const = 0;

--- a/Source/Core/DiscIO/VolumeWad.h
+++ b/Source/Core/DiscIO/VolumeWad.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Core/IOS/ES/Formats.h"
 #include "DiscIO/Volume.h"
 
 // --- this volume type is used for Wad files ---
@@ -32,7 +33,7 @@ public:
   ~CVolumeWAD();
   bool Read(u64 offset, u64 length, u8* buffer, bool decrypt = false) const override;
   bool GetTitleID(u64* buffer) const override;
-  std::vector<u8> GetTMD() const override;
+  IOS::ES::TMDReader GetTMD() const override;
   std::string GetGameID() const override;
   std::string GetMakerID() const override;
   u16 GetRevision() const override;
@@ -51,6 +52,7 @@ public:
 
 private:
   std::unique_ptr<IBlobReader> m_reader;
+  IOS::ES::TMDReader m_tmd;
   u32 m_offset = 0;
   u32 m_tmd_offset = 0;
   u32 m_opening_bnr_offset = 0;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -114,7 +114,7 @@ bool CVolumeWiiCrypted::GetTitleID(u64* buffer) const
   return true;
 }
 
-std::vector<u8> CVolumeWiiCrypted::GetTMD() const
+IOS::ES::TMDReader CVolumeWiiCrypted::GetTMD() const
 {
   u32 tmd_size;
   u32 tmd_address;
@@ -137,7 +137,7 @@ std::vector<u8> CVolumeWiiCrypted::GetTMD() const
   std::vector<u8> buffer(tmd_size);
   Read(m_VolumeOffset + tmd_address, tmd_size, buffer.data(), false);
 
-  return buffer;
+  return IOS::ES::TMDReader{std::move(buffer)};
 }
 
 u64 CVolumeWiiCrypted::PartitionOffsetToRawOffset(u64 offset) const

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Core/IOS/ES/Formats.h"
 #include "DiscIO/Volume.h"
 
 // --- this volume type is used for encrypted Wii images ---
@@ -32,7 +33,7 @@ public:
   ~CVolumeWiiCrypted();
   bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const override;
   bool GetTitleID(u64* buffer) const override;
-  std::vector<u8> GetTMD() const override;
+  IOS::ES::TMDReader GetTMD() const override;
   u64 PartitionOffsetToRawOffset(u64 offset) const override;
   std::string GetGameID() const override;
   std::string GetMakerID() const override;

--- a/Source/Core/DiscIO/WiiWad.cpp
+++ b/Source/Core/DiscIO/WiiWad.cpp
@@ -90,7 +90,7 @@ bool WiiWAD::ParseWAD(IBlobReader& reader)
   offset += Common::AlignUp(certificate_chain_size, 0x40);
   m_ticket.SetBytes(CreateWADEntry(reader, ticket_size, offset));
   offset += Common::AlignUp(ticket_size, 0x40);
-  m_tmd = CreateWADEntry(reader, tmd_size, offset);
+  m_tmd.SetBytes(CreateWADEntry(reader, tmd_size, offset));
   offset += Common::AlignUp(tmd_size, 0x40);
   m_data_app = CreateWADEntry(reader, data_app_size, offset);
   offset += Common::AlignUp(data_app_size, 0x40);

--- a/Source/Core/DiscIO/WiiWad.cpp
+++ b/Source/Core/DiscIO/WiiWad.cpp
@@ -88,7 +88,7 @@ bool WiiWAD::ParseWAD(IBlobReader& reader)
   u32 offset = 0x40;
   m_certificate_chain = CreateWADEntry(reader, certificate_chain_size, offset);
   offset += Common::AlignUp(certificate_chain_size, 0x40);
-  m_ticket = CreateWADEntry(reader, ticket_size, offset);
+  m_ticket.SetBytes(CreateWADEntry(reader, ticket_size, offset));
   offset += Common::AlignUp(ticket_size, 0x40);
   m_tmd = CreateWADEntry(reader, tmd_size, offset);
   offset += Common::AlignUp(tmd_size, 0x40);

--- a/Source/Core/DiscIO/WiiWad.h
+++ b/Source/Core/DiscIO/WiiWad.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Core/IOS/ES/Formats.h"
 
 namespace DiscIO
 {
@@ -22,7 +23,7 @@ public:
 
   bool IsValid() const { return m_valid; }
   const std::vector<u8>& GetCertificateChain() const { return m_certificate_chain; }
-  const std::vector<u8>& GetTicket() const { return m_ticket; }
+  const ES::TicketReader& GetTicket() const { return m_ticket; }
   const std::vector<u8>& GetTMD() const { return m_tmd; }
   const std::vector<u8>& GetDataApp() const { return m_data_app; }
   const std::vector<u8>& GetFooter() const { return m_footer; }
@@ -32,7 +33,7 @@ private:
   bool m_valid;
 
   std::vector<u8> m_certificate_chain;
-  std::vector<u8> m_ticket;
+  ES::TicketReader m_ticket;
   std::vector<u8> m_tmd;
   std::vector<u8> m_data_app;
   std::vector<u8> m_footer;

--- a/Source/Core/DiscIO/WiiWad.h
+++ b/Source/Core/DiscIO/WiiWad.h
@@ -23,8 +23,8 @@ public:
 
   bool IsValid() const { return m_valid; }
   const std::vector<u8>& GetCertificateChain() const { return m_certificate_chain; }
-  const ES::TicketReader& GetTicket() const { return m_ticket; }
-  const std::vector<u8>& GetTMD() const { return m_tmd; }
+  const IOS::ES::TicketReader& GetTicket() const { return m_ticket; }
+  const IOS::ES::TMDReader& GetTMD() const { return m_tmd; }
   const std::vector<u8>& GetDataApp() const { return m_data_app; }
   const std::vector<u8>& GetFooter() const { return m_footer; }
 private:
@@ -33,8 +33,8 @@ private:
   bool m_valid;
 
   std::vector<u8> m_certificate_chain;
-  ES::TicketReader m_ticket;
-  std::vector<u8> m_tmd;
+  IOS::ES::TicketReader m_ticket;
+  IOS::ES::TMDReader m_tmd;
   std::vector<u8> m_data_app;
   std::vector<u8> m_footer;
 };

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1225,23 +1225,7 @@ void CFrame::OnInstallWAD(wxCommandEvent& event)
 
 void CFrame::UpdateLoadWiiMenuItem() const
 {
-  auto* const menu_item = GetMenuBar()->FindItem(IDM_LOAD_WII_MENU);
-
-  const auto& sys_menu_loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(
-      TITLEID_SYSMENU, Common::FROM_CONFIGURED_ROOT);
-
-  if (sys_menu_loader.IsValid())
-  {
-    const int version = sys_menu_loader.GetTitleVersion();
-    const char region = sys_menu_loader.GetCountryChar();
-    menu_item->Enable();
-    menu_item->SetItemLabel(wxString::Format(_("Load Wii System Menu %d%c"), version, region));
-  }
-  else
-  {
-    menu_item->Enable(false);
-    menu_item->SetItemLabel(_("Load Wii System Menu"));
-  }
+  GetMenuBar()->Refresh(true, nullptr);
 }
 
 void CFrame::OnFifoPlayer(wxCommandEvent& WXUNUSED(event))

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
@@ -182,7 +182,7 @@ void InfoPanel::LoadISODetails()
   m_fst->SetValue(StrToWxStr(std::to_string(m_opened_iso->GetFSTSize())));
   if (m_ios_version)
   {
-    IOS::HLE::TMDReader tmd{m_opened_iso->GetTMD()};
+    ES::TMDReader tmd{m_opened_iso->GetTMD()};
     if (tmd.IsValid())
       m_ios_version->SetValue(StringFromFormat("IOS%u", static_cast<u32>(tmd.GetIOSId())));
   }

--- a/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
+++ b/Source/Core/DolphinWX/ISOProperties/InfoPanel.cpp
@@ -182,7 +182,7 @@ void InfoPanel::LoadISODetails()
   m_fst->SetValue(StrToWxStr(std::to_string(m_opened_iso->GetFSTSize())));
   if (m_ios_version)
   {
-    ES::TMDReader tmd{m_opened_iso->GetTMD()};
+    const IOS::ES::TMDReader tmd = m_opened_iso->GetTMD();
     if (tmd.IsValid())
       m_ios_version->SetValue(StringFromFormat("IOS%u", static_cast<u32>(tmd.GetIOSId())));
   }
@@ -223,7 +223,7 @@ wxStaticBoxSizer* InfoPanel::CreateISODetailsSizer()
       {_("Apploader Date:"), m_date},
       {_("FST Size:"), m_fst},
   }};
-  if (!m_opened_iso->GetTMD().empty())
+  if (m_opened_iso->GetTMD().IsValid())
     controls.emplace_back(_("IOS Version:"), m_ios_version);
 
   const int space_10 = FromDIP(10);

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -12,6 +12,7 @@
 #include "Core/Core.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/State.h"
+#include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"
 #include "DolphinWX/Globals.h"
 #include "DolphinWX/WxUtils.h"
@@ -546,8 +547,8 @@ void MainMenuBar::RefreshWiiSystemMenuLabel() const
 
   if (sys_menu_loader.IsValid())
   {
-    const auto sys_menu_version = sys_menu_loader.GetTitleVersion();
-    const auto sys_menu_region = sys_menu_loader.GetCountryChar();
+    const u16 sys_menu_version = sys_menu_loader.GetTMD().GetTitleVersion();
+    const char sys_menu_region = DiscIO::GetSysMenuRegion(sys_menu_version);
     item->Enable();
     item->SetItemLabel(
         wxString::Format(_("Load Wii System Menu %u%c"), sys_menu_version, sys_menu_region));


### PR DESCRIPTION
This moves everything related to parsing the ticket and TMD formats to ESFormats. All TMD and ticket getters now return a TMDReader or TicketReader (respectively), instead of a buffer that everyone "parsed" using duplicated offsets.

The first commit moves moves the whole ticket code (which was duplicated in DiscIO and ES) to ESFormats.

While the ticket view structures aren't currently used, they will likely be in the future when we implement some missing ioctlvs (and for a future PR which will change ES_Launch to work based on IOS's behaviour).

The second commit moves the TMD parsing and view generation code to ESFormats as well, since we already have a TMDReader there.