### PR TITLE
Correct the comment about the number of ES devices

### DIFF
--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -495,7 +495,7 @@ void Reinit()
   AddDevice<Device::STMEventHook>("/dev/stm/eventhook");
   AddDevice<Device::FS>("/dev/fs");
 
-  // IOS allows two ES devices at a time
+  // IOS allows three ES devices at a time
   for (auto& es_device : s_es_handles)
     es_device = AddDevice<Device::ES>("/dev/es");
 


### PR DESCRIPTION
This was part of the now closed PR #4887. ES_MAX_COUNT was changed to 3 in PR #4634 without the comment being updated.