### PR TITLE
ControlGroup: Use std::array for Force and Tilt groups

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
@@ -5,7 +5,6 @@
 #include "InputCommon/ControllerEmu/ControlGroup/Force.h"
 
 #include <cmath>
-#include <cstring>
 #include <memory>
 #include <string>
 
@@ -19,8 +18,6 @@ namespace ControllerEmu
 {
 Force::Force(const std::string& name_) : ControlGroup(name_, GROUP_TYPE_FORCE)
 {
-  memset(m_swing, 0, sizeof(m_swing));
-
   controls.emplace_back(std::make_unique<Input>(_trans("Up")));
   controls.emplace_back(std::make_unique<Input>(_trans("Down")));
   controls.emplace_back(std::make_unique<Input>(_trans("Left")));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 
@@ -17,6 +18,6 @@ public:
   void GetState(ControlState* axis);
 
 private:
-  ControlState m_swing[3];
+  std::array<ControlState, 3> m_swing{};
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
 #include <memory>
 #include <string>
 
@@ -19,8 +18,6 @@ namespace ControllerEmu
 {
 Tilt::Tilt(const std::string& name_) : ControlGroup(name_, GROUP_TYPE_TILT)
 {
-  memset(m_tilt, 0, sizeof(m_tilt));
-
   controls.emplace_back(std::make_unique<Input>("Forward"));
   controls.emplace_back(std::make_unique<Input>("Backward"));
   controls.emplace_back(std::make_unique<Input>("Left"));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 
@@ -17,6 +18,6 @@ public:
   void GetState(ControlState* x, ControlState* y, bool step = true);
 
 private:
-  ControlState m_tilt[2];
+  std::array<ControlState, 2> m_tilt{};
 };
 }  // namespace ControllerEmu


### PR DESCRIPTION
Same behavior, but less code and safer (bounds checked accesses in debug mode, etc).