### PR TITLE
IOS/USB_KBD: Re-add the Write stub handler

### DIFF
--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -62,6 +62,12 @@ ReturnCode USB_KBD::Open(const OpenRequest& request)
   return IPC_SUCCESS;
 }
 
+IPCCommandResult USB_KBD::Write(const ReadWriteRequest& request)
+{
+  // Stubbed.
+  return GetDefaultReply(IPC_SUCCESS);
+}
+
 IPCCommandResult USB_KBD::IOCtl(const IOCtlRequest& request)
 {
   if (SConfig::GetInstance().m_WiiKeyboard && !Core::g_want_determinism && !m_MessageQueue.empty())

--- a/Source/Core/Core/IOS/USB/USB_KBD.h
+++ b/Source/Core/Core/IOS/USB/USB_KBD.h
@@ -23,6 +23,7 @@ public:
   USB_KBD(u32 device_id, const std::string& device_name);
 
   ReturnCode Open(const OpenRequest& request) override;
+  IPCCommandResult Write(const ReadWriteRequest& request) override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   void Update() override;
 


### PR DESCRIPTION
This is something I removed by mistake. It didn't break anything in most titles, but the Mii Channel *requires* write requests to /dev/usb/kbd to succeed before exiting, so this PR readds the stub.