### PR TITLE
IOS: Handle ES_Launch more accurately

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -34,6 +34,7 @@ public:
   ES(u32 device_id, const std::string& device_name);
 
   void LoadWAD(const std::string& _rContentFile);
+  bool LaunchTitle(u64 title_id, bool skip_reload = false) const;
 
   // Internal implementation of the ES_DECRYPT ioctlv.
   void DecryptContent(u32 key_index, u8* iv, u8* input, u32 size, u8* new_iv, u8* output);
@@ -190,9 +191,11 @@ private:
   IPCCommandResult DIGetTicketView(const IOCtlVRequest& request);
   IPCCommandResult GetOwnedTitleCount(const IOCtlVRequest& request);
 
-  void ResetAfterLaunch(u64 ios_to_load) const;
+  bool LaunchIOS(u64 ios_title_id) const;
+  bool LaunchPPCTitle(u64 title_id, bool skip_reload) const;
 
-  const DiscIO::CNANDContentLoader& AccessContentDevice(u64 title_id);
+  const DiscIO::CNANDContentLoader& AccessContentDevice(u64 title_id) const;
+
   u32 OpenTitleContent(u32 CFD, u64 TitleID, u16 Index);
 
   using CContentAccessMap = std::map<u32, SContentAccess>;

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -21,6 +21,11 @@ namespace ES
 {
 constexpr size_t CONTENT_VIEW_SIZE = 0x10;
 
+bool IsTitleType(u64 title_id, TitleType title_type)
+{
+  return static_cast<u32>(title_id >> 32) == static_cast<u32>(title_type);
+}
+
 TMDReader::TMDReader(const std::vector<u8>& bytes) : m_bytes(bytes)
 {
 }

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -18,6 +18,19 @@ namespace IOS
 {
 namespace ES
 {
+enum class TitleType : u32
+{
+  System = 0x00000001,
+  Game = 0x00010000,
+  Channel = 0x00010001,
+  SystemChannel = 0x00010002,
+  GameWithChannel = 0x00010004,
+  DLC = 0x00010005,
+  HiddenChannel = 0x00010008,
+};
+
+bool IsTitleType(u64 title_id, TitleType title_type);
+
 #pragma pack(push, 4)
 struct TMDHeader
 {

--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -32,6 +32,7 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Core/Boot/Boot_DOL.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -62,6 +63,8 @@
 #include "Core/IOS/USB/USB_VEN/VEN.h"
 #include "Core/IOS/WFS/WFSI.h"
 #include "Core/IOS/WFS/WFSSRV.h"
+#include "Core/PowerPC/PowerPC.h"
+#include "DiscIO/NANDContentLoader.h"
 
 namespace CoreTiming
 {
@@ -92,9 +95,16 @@ static CoreTiming::EventType* s_event_sdio_notify;
 static u64 s_last_reply_time;
 
 static u64 s_active_title_id;
+static u64 s_title_to_launch;
 
 static constexpr u64 ENQUEUE_REQUEST_FLAG = 0x100000000ULL;
 static constexpr u64 ENQUEUE_ACKNOWLEDGEMENT_FLAG = 0x200000000ULL;
+
+enum class MemorySetupType
+{
+  IOSReload,
+  Full,
+};
 
 struct IosMemoryValues
 {
@@ -492,7 +502,7 @@ u32 GetVersion()
   return static_cast<u32>(s_active_title_id);
 }
 
-static bool SetupMemory(u64 ios_title_id)
+static bool SetupMemory(u64 ios_title_id, MemorySetupType setup_type)
 {
   auto target_imv = std::find_if(
       ios_memory_values.begin(), ios_memory_values.end(),
@@ -502,6 +512,32 @@ static bool SetupMemory(u64 ios_title_id)
   {
     ERROR_LOG(IOS, "Unknown IOS version: %016" PRIx64, ios_title_id);
     return false;
+  }
+
+  if (setup_type == MemorySetupType::IOSReload)
+  {
+    Memory::Write_U32(target_imv->ios_version, ADDR_IOS_VERSION);
+
+    // These values are written by the IOS kernel as part of its boot process (for IOS28 and newer).
+    //
+    // This works in a slightly different way on a real console: older IOS versions (< IOS28) all
+    // have the same range (933E0000 - 93400000), thus they don't write it at boot and just inherit
+    // all values. However, the range has changed since IOS28. To make things work properly
+    // after a reload, newer IOSes always write the legacy range before loading an IOS kernel;
+    // the new IOS either updates the range (>= IOS28) or inherits it (< IOS28).
+    //
+    // We can skip this convoluted process and just write the correct range directly.
+    Memory::Write_U32(target_imv->mem2_physical_size, ADDR_MEM2_SIZE);
+    Memory::Write_U32(target_imv->mem2_simulated_size, ADDR_MEM2_SIM_SIZE);
+    Memory::Write_U32(target_imv->mem2_end, ADDR_MEM2_END);
+    Memory::Write_U32(target_imv->mem2_arena_begin, ADDR_MEM2_ARENA_BEGIN);
+    Memory::Write_U32(target_imv->mem2_arena_end, ADDR_MEM2_ARENA_END);
+    Memory::Write_U32(target_imv->ipc_buffer_begin, ADDR_IPC_BUFFER_BEGIN);
+    Memory::Write_U32(target_imv->ipc_buffer_end, ADDR_IPC_BUFFER_END);
+    Memory::Write_U32(target_imv->unknown_begin, ADDR_UNKNOWN_BEGIN);
+    Memory::Write_U32(target_imv->unknown_end, ADDR_UNKNOWN_END);
+
+    return true;
   }
 
   Memory::Write_U32(target_imv->mem1_physical_size, ADDR_MEM1_SIZE);
@@ -586,10 +622,20 @@ static void AddStaticDevices()
   AddDevice<Device::WFSI>("/dev/wfsi");
 }
 
+// IOS used by the latest System Menu (4.3).
+constexpr u64 IOS80_TITLE_ID = 0x0000000100000050;
+
 void Init()
 {
   s_event_enqueue = CoreTiming::RegisterEvent("IPCEvent", EnqueueEvent);
   s_event_sdio_notify = CoreTiming::RegisterEvent("SDIO_EventNotify", SDIO_EventNotify_CPUThread);
+
+  // On a Wii, boot2 launches the system menu IOS, which then launches the system menu
+  // (which bootstraps the PPC). This means that after a normal boot process, the constants
+  // in the 0x3100 region will always have been set up.
+  // This is necessary because booting games from the game list skips a significant part
+  // of a Wii's boot process.
+  SetupMemory(IOS80_TITLE_ID, MemorySetupType::Full);
 }
 
 void Reset(const bool clear_devices)
@@ -625,6 +671,9 @@ void Shutdown()
 constexpr u64 BC_TITLE_ID = 0x0000000100000100;
 constexpr u64 MIOS_TITLE_ID = 0x0000000100000101;
 
+// Similar to syscall 0x42 (ios_boot); this is used to change the current active IOS.
+// IOS writes the new version to 0x3140 before restarting, but it does *not* poke any
+// of the other constants to the memory.
 bool Reload(const u64 ios_title_id)
 {
   // A real Wii goes through several steps before getting to MIOS.
@@ -636,18 +685,67 @@ bool Reload(const u64 ios_title_id)
   // Because we currently don't have boot1 and boot2, and BC is only ever used to launch MIOS
   // (indirectly via boot2), we can just launch MIOS when BC is launched.
   if (ios_title_id == BC_TITLE_ID)
+  {
+    NOTICE_LOG(IOS, "BC: Launching MIOS...");
     return Reload(MIOS_TITLE_ID);
+  }
 
-  if (!SetupMemory(ios_title_id))
+  if (!SetupMemory(ios_title_id, MemorySetupType::IOSReload))
     return false;
 
   s_active_title_id = ios_title_id;
   Reset(true);
 
   if (ios_title_id == MIOS_TITLE_ID)
+  {
+    // MIOS is a special case. It does not have the same syscalls as regular IOSes
+    // and writes the magic values at a different time (here) in the boot process.
+    SetupMemory(ios_title_id, MemorySetupType::Full);
     return MIOS::Load();
+  }
 
   AddStaticDevices();
+
+  if (s_title_to_launch != 0)
+  {
+    NOTICE_LOG(IOS, "Re-launching title after IOS reload.");
+    s_es_handles[0]->LaunchTitle(s_title_to_launch, true);
+    s_title_to_launch = 0;
+  }
+  return true;
+}
+
+void SetTitleToLaunch(const u64 title_id)
+{
+  s_title_to_launch = title_id;
+}
+
+// This corresponds to syscall 0x41, which loads a binary from the NAND and bootstraps the PPC.
+// Unlike 0x42, IOS will set up some constants in memory before booting the PPC.
+bool BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader)
+{
+  if (!content_loader.IsValid())
+    return false;
+
+  const auto* content = content_loader.GetContentByIndex(content_loader.GetTMD().GetBootIndex());
+  if (!content)
+    return false;
+
+  const auto dol_loader = std::make_unique<CDolLoader>(content->m_Data->Get());
+  if (!dol_loader->IsValid())
+    return false;
+
+  if (!SetupMemory(s_active_title_id, MemorySetupType::Full))
+    return false;
+
+  dol_loader->Load();
+
+  // NAND titles start with address translation off at 0x3400 (via the PPC bootstub)
+  // The state of other CPU registers (like the BAT registers) doesn't matter much
+  // because the realmode code at 0x3400 initializes everything itself anyway.
+  MSR = 0;
+  PC = 0x3400;
+
   return true;
 }
 

--- a/Source/Core/Core/IOS/IPC.h
+++ b/Source/Core/Core/IOS/IPC.h
@@ -14,6 +14,11 @@
 
 class PointerWrap;
 
+namespace DiscIO
+{
+class CNANDContentLoader;
+}
+
 namespace IOS
 {
 namespace ES
@@ -57,9 +62,13 @@ void Reset(bool clear_devices = false);
 // Shutdown
 void Shutdown();
 
-// Reload IOS (to a possibly different version); set up memory and devices.
+// Reload IOS (to a possibly different version); write the new version to 0x3140 and set up devices.
 bool Reload(u64 ios_title_id);
 u32 GetVersion();
+
+bool BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader);
+// This sets a title to launch after IOS has been reset and reloaded (similar to /sys/launch.sys).
+void SetTitleToLaunch(u64 title_id);
 
 // Do State
 void DoState(PointerWrap& p);


### PR DESCRIPTION
[Depends on #4896.]

This commit fixes ES_Launch to work mostly the same as the real IOS (except temporary, internal files such as /sys/launch.sys and title handling; the latter will be handled in a future PR).

First of all, this adds two IOS functions, which correspond to two IOS syscalls: 0x41 (boot_ppc) and 0x42 (boot_ios).

* boot_ios() writes the new version to 0x3140, loads the new kernel, which then proceeds to reinit IPC and load modules as part of its boot process. Note that this doesn't include writing to any of the other constants in the 0x3100 region. In Dolphin, this is implemented by changing the active IOS version variable, writing to 0x3140 and resetting all devices. This has the same effect as the real syscall.

* The other syscall, boot_ppc(), writes code to the EXI boot buffer, pokes all constants to memory before bootstrapping the PPC with a binary from the NAND. We skip the low level stuff and just load the DOL to memory (and set the PPC's PC to 0x3400), which is essentially what IOS does.

The other change is mostly related to how ES_Launch is handled.

With a real IOS, if the launched title type is 00000001 (system) and the title is not 1-2 (System Menu), ES calls boot_ios().

Otherwise, ES handles the launch as a PPC title. It reads the TMD to determine the required IOS version. If it is the same, boot_ppc() is called directly. If not, ES saves the title to launch to the NAND before launching the new IOS. *After* the *new* IOS has finished booting, it will notice the flag and then launch the requested title.

What this commit does is really *just* implement this logic into IOS HLE. The result is a fix for a regression introduced by SetupMemory, where reloading an IOS would have overwritten some OS constants. This fixes booting games from the disc channel.