### PR TITLE
Remove C++14 optional digit separator

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -1192,7 +1192,7 @@ IPCCommandResult ES::LaunchBC(const IOCtlVRequest& request)
   if (GetVersion() == 0x101)
     return GetDefaultReply(ES_PARAMETER_SIZE_OR_ALIGNMENT);
 
-  ResetAfterLaunch(0x00000001'00000100);
+  ResetAfterLaunch(0x0000000100000100);
   EnqueueCommandAcknowledgement(request.address, 0);
   return GetNoReply();
 }


### PR DESCRIPTION
It confuses GitHub and localization tools. And some people as well.