### PR TITLE
C++ conformance fixes (MSVC /permissive-)

### DIFF
--- a/Source/Core/AudioCommon/XAudio2Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2Stream.cpp
@@ -28,8 +28,8 @@ public:
 
   ~StreamingVoiceContext();
 
-  void StreamingVoiceContext::Stop();
-  void StreamingVoiceContext::Play();
+  void Stop();
+  void Play();
 
   STDMETHOD_(void, OnVoiceError)(THIS_ void* pBufferContext, HRESULT Error) {}
   STDMETHOD_(void, OnVoiceProcessingPassStart)(UINT32) {}

--- a/Source/Core/AudioCommon/XAudio2_7Stream.cpp
+++ b/Source/Core/AudioCommon/XAudio2_7Stream.cpp
@@ -28,8 +28,8 @@ public:
 
   ~StreamingVoiceContext2_7();
 
-  void StreamingVoiceContext2_7::Stop();
-  void StreamingVoiceContext2_7::Play();
+  void Stop();
+  void Play();
 
   STDMETHOD_(void, OnVoiceError)(THIS_ void* pBufferContext, HRESULT Error) {}
   STDMETHOD_(void, OnVoiceProcessingPassStart)(UINT32) {}

--- a/Source/Core/Common/MathUtil.h
+++ b/Source/Core/Common/MathUtil.h
@@ -24,6 +24,8 @@ constexpr T SNANConstant()
 // will use __builtin_nans, which is improperly handled by the compiler and generates
 // a bad constant. Here we go back to the version MSVC used before the builtin.
 // TODO: Remove this and use numeric_limits directly whenever this bug is fixed.
+#include <intrin.h>
+
 template <>
 constexpr double SNANConstant()
 {

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -187,7 +187,7 @@ int IOWrite(HANDLE& dev_handle, OVERLAPPED& hid_overlap_write, enum WinWriteMeth
 int IORead(HANDLE& dev_handle, OVERLAPPED& hid_overlap_read, u8* buf, int index);
 
 template <typename T>
-void ProcessWiimotes(bool new_scan, T& callback);
+void ProcessWiimotes(bool new_scan, const T& callback);
 
 bool AttachWiimote(HANDLE hRadio, const BLUETOOTH_RADIO_INFO&, BLUETOOTH_DEVICE_INFO_STRUCT&);
 void RemoveWiimote(BLUETOOTH_DEVICE_INFO_STRUCT&);
@@ -795,7 +795,7 @@ int WiimoteWindows::IOWrite(const u8* buf, size_t len)
 
 // invokes callback for each found Wiimote Bluetooth device
 template <typename T>
-void ProcessWiimotes(bool new_scan, T& callback)
+void ProcessWiimotes(bool new_scan, const T& callback)
 {
   BLUETOOTH_DEVICE_SEARCH_PARAMS srch;
   srch.dwSize = sizeof(srch);

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -147,7 +147,7 @@ void PathConfigPane::BindEvents()
   Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 }
 
-void PathConfigPane::OnISOPathSelectionChanged(const wxCommandEvent& event)
+void PathConfigPane::OnISOPathSelectionChanged(wxCommandEvent& event)
 {
   m_remove_iso_path_button->Enable(m_iso_paths_listbox->GetSelection() != wxNOT_FOUND);
 }
@@ -187,7 +187,8 @@ void PathConfigPane::OnRemoveISOPath(wxCommandEvent& event)
 
 // This seems to not be activated on Windows when it should be. wxw bug?
 #ifdef _WIN32
-  OnISOPathSelectionChanged(wxCommandEvent());
+  wxCommandEvent dummy_event{};
+  OnISOPathSelectionChanged(dummy_event);
 #endif
 
   SaveISOPathChanges();

--- a/Source/Core/DolphinWX/Config/PathConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.cpp
@@ -147,7 +147,7 @@ void PathConfigPane::BindEvents()
   Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 }
 
-void PathConfigPane::OnISOPathSelectionChanged(wxCommandEvent& event)
+void PathConfigPane::OnISOPathSelectionChanged(const wxCommandEvent& event)
 {
   m_remove_iso_path_button->Enable(m_iso_paths_listbox->GetSelection() != wxNOT_FOUND);
 }

--- a/Source/Core/DolphinWX/Config/PathConfigPane.h
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.h
@@ -22,7 +22,7 @@ private:
   void LoadGUIValues();
   void BindEvents();
 
-  void OnISOPathSelectionChanged(wxCommandEvent&);
+  void OnISOPathSelectionChanged(const wxCommandEvent&);
   void OnRecursiveISOCheckBoxChanged(wxCommandEvent&);
   void OnAddISOPath(wxCommandEvent&);
   void OnRemoveISOPath(wxCommandEvent&);

--- a/Source/Core/DolphinWX/Config/PathConfigPane.h
+++ b/Source/Core/DolphinWX/Config/PathConfigPane.h
@@ -22,7 +22,7 @@ private:
   void LoadGUIValues();
   void BindEvents();
 
-  void OnISOPathSelectionChanged(const wxCommandEvent&);
+  void OnISOPathSelectionChanged(wxCommandEvent&);
   void OnRecursiveISOCheckBoxChanged(wxCommandEvent&);
   void OnAddISOPath(wxCommandEvent&);
   void OnRemoveISOPath(wxCommandEvent&);

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
@@ -21,8 +21,8 @@ public:
   static bool InsertByteCode(const GeometryShaderUid& uid, const void* bytecode,
                              unsigned int bytecodelen);
 
-  static ID3D11GeometryShader* GeometryShaderCache::GetClearGeometryShader();
-  static ID3D11GeometryShader* GeometryShaderCache::GetCopyGeometryShader();
+  static ID3D11GeometryShader* GetClearGeometryShader();
+  static ID3D11GeometryShader* GetCopyGeometryShader();
 
   static ID3D11GeometryShader* GetActiveShader() { return last_entry->shader; }
   static ID3D11Buffer*& GetConstantBuffer();

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.h
@@ -30,7 +30,7 @@ public:
   static ID3D11InputLayout* GetSimpleInputLayout();
   static ID3D11InputLayout* GetClearInputLayout();
 
-  static bool VertexShaderCache::InsertByteCode(const VertexShaderUid& uid, D3DBlob* bcodeblob);
+  static bool InsertByteCode(const VertexShaderUid& uid, D3DBlob* bcodeblob);
 
 private:
   struct VSCacheEntry

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -499,7 +499,7 @@ void TextureCache::ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* uncon
   g_renderer->RestoreAPIState();
 }
 
-D3D12_SHADER_BYTECODE GetConvertShader12(std::string& Type)
+D3D12_SHADER_BYTECODE GetConvertShader12(const std::string& Type)
 {
   std::string shader = "#define DECODE DecodePixel_";
   shader.append(Type);


### PR DESCRIPTION
We (the Microsoft C++ team) use the dolphin project as part of our "Real world code" tests.
I noticed a few issues in windows specific code when building dolphin with the MSVC compiler
in its conformance mode (/permissive-).  For more information on /permissive- see our blog
https://blogs.msdn.microsoft.com/vcblog/2016/11/16/permissive-switch/.

These changes are to address 3 different types of issues:

1) Use of qualified names in member declarations

    struct A {
        void A::f() { } // error C4596: illegal qualified name in member declaration
                        // remove redundant 'A::' to fix
    };

2) Binding a non-const reference to a temporary

    struct S{};
  
    // If arg is in 'in' parameter, then it should be made const.
    void func(S& arg){}
  
    int main() {
      //error C2664: 'void func(S &)': cannot convert argument 1 from 'S' to 'S &'
      //note: A non-const reference may only be bound to an lvalue
      func( S() );
   
      //Work around this by creating a local, and using it to call the function
      S s;
      func( s );
    }

3) Add missing #include <intrin.h>

Because of the workaround you are using in the code you will need to include
this.  This is because of changes in the libraries and not /permissive-