### PR TITLE
Android: Sort configuration ini files

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -20,6 +20,8 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Contains static methods for interacting with .ini files in which settings are stored.
@@ -105,6 +107,7 @@ public final class SettingsFile
 
 	public static final String KEY_WIIMOTE_TYPE = "Source";
 	public static final String KEY_WIIMOTE_EXTENSION = "Extension";
+    public static final String KEY_WIIBIND_SIDEWAYS = "Options/Sideways Wiimote";
 
 	public static final String KEY_WIIBIND_A = "WiimoteA_";
 	public static final String KEY_WIIBIND_B = "WiimoteB_";
@@ -228,6 +231,8 @@ public final class SettingsFile
 	public static final String KEY_WIIBIND_TURNTABLE_CROSSFADE_LEFT = "TurntableCrossLeft_";
 	public static final String KEY_WIIBIND_TURNTABLE_CROSSFADE_RIGHT = "TurntableCrossRight_";
 
+
+
 	public static final String KEY_WIIMOTE_SCAN = "WiimoteContinuousScanning";
 	public static final String KEY_WIIMOTE_SPEAKER = "WiimoteEnableSpeaker";
 
@@ -321,9 +326,12 @@ public final class SettingsFile
 		{
 			writer = new PrintWriter(ini, "UTF-8");
 
+			//Add Sorting for output, change keySet into sortKeySet and itterate through the new sorted set
 			Set<String> keySet = sections.keySet();
+			Set<String> sortedKeySet = new TreeSet<>(keySet);
 
-			for (String key : keySet)
+			//for (String key : keySet)
+			for (String key : sortedKeySet)
 			{
 				SettingSection section = sections.get(key);
 				writeSection(writer, section);
@@ -435,10 +443,14 @@ public final class SettingsFile
 		writer.println(header);
 
 		// Write this section's values.
+        // Convert to Sorted set to write out more readable ini file
 		HashMap<String, Setting> settings = section.getSettings();
 		Set<String> keySet = settings.keySet();
+        Set<String> sortedKeySet = new TreeSet<>(keySet);
 
-		for (String key : keySet)
+
+		//for (String key : keySet)
+        for (String key : sortedKeySet)
 		{
 			Setting setting = settings.get(key);
 			String settingString = settingAsString(setting);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -227,8 +227,6 @@ public final class SettingsFile
 	public static final String KEY_WIIBIND_TURNTABLE_CROSSFADE_LEFT = "TurntableCrossLeft_";
 	public static final String KEY_WIIBIND_TURNTABLE_CROSSFADE_RIGHT = "TurntableCrossRight_";
 
-
-
 	public static final String KEY_WIIMOTE_SCAN = "WiimoteContinuousScanning";
 	public static final String KEY_WIIMOTE_SPEAKER = "WiimoteEnableSpeaker";
 
@@ -438,12 +436,12 @@ public final class SettingsFile
 		writer.println(header);
 
 		// Write this section's values.
-        // Convert to Sorted set to write out more readable ini file
+		// Convert to Sorted set to write out more readable ini file.
 		HashMap<String, Setting> settings = section.getSettings();
 		Set<String> keySet = settings.keySet();
-        Set<String> sortedKeySet = new TreeSet<>(keySet);
+		Set<String> sortedKeySet = new TreeSet<>(keySet);
 
-        for (String key : sortedKeySet)
+		for (String key : sortedKeySet)
 		{
 			Setting setting = settings.get(key);
 			String settingString = settingAsString(setting);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -20,7 +20,6 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TreeSet;
 
 /**
@@ -44,8 +43,6 @@ public final class SettingsFile
 	public static final String SECTION_GFX_HACKS = "Hacks";
 
 	public static final String SECTION_STEREOSCOPY = "Stereoscopy";
-
-	public static final String SECTION_WIIMOTE = "Wiimote";
 
 	public static final String SECTION_BINDINGS = "Android";
 
@@ -107,7 +104,6 @@ public final class SettingsFile
 
 	public static final String KEY_WIIMOTE_TYPE = "Source";
 	public static final String KEY_WIIMOTE_EXTENSION = "Extension";
-    public static final String KEY_WIIBIND_SIDEWAYS = "Options/Sideways Wiimote";
 
 	public static final String KEY_WIIBIND_A = "WiimoteA_";
 	public static final String KEY_WIIBIND_B = "WiimoteB_";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -326,7 +326,6 @@ public final class SettingsFile
 			Set<String> keySet = sections.keySet();
 			Set<String> sortedKeySet = new TreeSet<>(keySet);
 
-			//for (String key : keySet)
 			for (String key : sortedKeySet)
 			{
 				SettingSection section = sections.get(key);
@@ -444,8 +443,6 @@ public final class SettingsFile
 		Set<String> keySet = settings.keySet();
         Set<String> sortedKeySet = new TreeSet<>(keySet);
 
-
-		//for (String key : keySet)
         for (String key : sortedKeySet)
 		{
 			Setting setting = settings.get(key);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -43,7 +43,7 @@ public final class SettingsFile
 	public static final String SECTION_GFX_HACKS = "Hacks";
 
 	public static final String SECTION_STEREOSCOPY = "Stereoscopy";
-
+	public static final String SECTION_WIIMOTE = "Wiimote";
 	public static final String SECTION_BINDINGS = "Android";
 
 	public static final String KEY_CPU_CORE = "CPUCore";

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -43,7 +43,9 @@ public final class SettingsFile
 	public static final String SECTION_GFX_HACKS = "Hacks";
 
 	public static final String SECTION_STEREOSCOPY = "Stereoscopy";
+
 	public static final String SECTION_WIIMOTE = "Wiimote";
+
 	public static final String SECTION_BINDINGS = "Android";
 
 	public static final String KEY_CPU_CORE = "CPUCore";
@@ -320,7 +322,6 @@ public final class SettingsFile
 		{
 			writer = new PrintWriter(ini, "UTF-8");
 
-			//Add Sorting for output, change keySet into sortKeySet and itterate through the new sorted set
 			Set<String> keySet = sections.keySet();
 			Set<String> sortedKeySet = new TreeSet<>(keySet);
 
@@ -436,7 +437,6 @@ public final class SettingsFile
 		writer.println(header);
 
 		// Write this section's values.
-		// Convert to Sorted set to write out more readable ini file.
 		HashMap<String, Setting> settings = section.getSettings();
 		Set<String> keySet = settings.keySet();
 		Set<String> sortedKeySet = new TreeSet<>(keySet);


### PR DESCRIPTION
Hello,
I am proposing a quick change to sort the output configuration ini files, such as Dolphin.ini and Wiimotenew.ini.  

Previously on android it would write these files in the order that the sections were created which would place the section contents in a random order and section headers may be in reverse order, i.e. [Wiimote4] listed first.  

Adding in a line to convert the set into a TreeSet and then iterating from that TreeSet in the for loop instead of the original set puts the file in alphabetical order.  i.e.  [Wiimote1]  Comes first in headers then section content is also alphabetized.  This is done in 2 places as shown below.  I am not sure why the final string lines at the top show space deletions as those are not related to the change.

Thanks,
Nathan 