### PR TITLE
Android: Sort configuration ini files

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/SettingsFile.java
@@ -20,6 +20,7 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Contains static methods for interacting with .ini files in which settings are stored.
@@ -322,8 +323,9 @@ public final class SettingsFile
 			writer = new PrintWriter(ini, "UTF-8");
 
 			Set<String> keySet = sections.keySet();
+			Set<String> sortedKeySet = new TreeSet<>(keySet);
 
-			for (String key : keySet)
+			for (String key : sortedKeySet)
 			{
 				SettingSection section = sections.get(key);
 				writeSection(writer, section);
@@ -437,8 +439,9 @@ public final class SettingsFile
 		// Write this section's values.
 		HashMap<String, Setting> settings = section.getSettings();
 		Set<String> keySet = settings.keySet();
+		Set<String> sortedKeySet = new TreeSet<>(keySet);
 
-		for (String key : keySet)
+		for (String key : sortedKeySet)
 		{
 			Setting setting = settings.get(key);
 			String settingString = settingAsString(setting);


### PR DESCRIPTION
Hello,
I am proposing a quick change to sort the output configuration ini files, such as Dolphin.ini and Wiimotenew.ini.

Previously on android it would write these files in the order that the sections were created which would place the section contents in a random order and section headers may be in reverse order, i.e. [Wiimote4] listed first.

Adding in a line to convert the set into a TreeSet and then iterating from that TreeSet in the for loop instead of the original set puts the file in alphabetical order. i.e. [Wiimote1] Comes first in headers then section content is also alphabetized. This is done in 2 places as shown below. I am not sure why the final string lines at the top show space deletions as those are not related to the change.

Note: This is a duplicate of a closed pull request 4918 that has been rebased and merged down to only one commit.

Thanks,
Nathan