### PR TITLE
HLE: More printf floating point types handled

### DIFF
--- a/Source/Core/Core/HLE/HLE_OS.cpp
+++ b/Source/Core/Core/HLE/HLE_OS.cpp
@@ -138,7 +138,14 @@ std::string GetStringVA(u32 strReg)
         break;
       }
 
+      case 'a':
+      case 'A':
+      case 'e':
+      case 'E':
       case 'f':
+      case 'F':
+      case 'g':
+      case 'G':
       {
         result += StringFromFormat(ArgumentBuffer.c_str(), rPS0(FloatingParameterCounter));
         FloatingParameterCounter++;


### PR DESCRIPTION
This PR allows more printf's floating-point types to be handled.

Ready to be reviewed & merged.