### PR TITLE
PPM frame dumping

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -968,10 +968,8 @@ void Renderer::DumpFrameToImage(const FrameDumpConfig& config)
   std::string filename = GetFrameDumpNextImageFileName();
   if (g_Config.bDumpFramesToPPM)
   {
-    std::ofstream out;
-    out.open(filename);
+    std::ofstream out(filename);
     writePPM(out, config.width, config.height, config.stride, config.data);
-    out.close();
   }
   else
   {

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -944,7 +944,7 @@ bool Renderer::StartFrameDumpToImage(const FrameDumpConfig& config)
   return true;
 }
 
-void writePPM(std::ostream& os, int width, int height, int stride, const u8* data)
+static void WritePPM(std::ostream& os, int width, int height, int stride, const u8* data)
 {
   // header
   os << "P6\n"
@@ -969,7 +969,7 @@ void Renderer::DumpFrameToImage(const FrameDumpConfig& config)
   if (g_Config.bDumpFramesToPPM)
   {
     std::ofstream out(filename);
-    writePPM(out, config.width, config.height, config.stride, config.data);
+    WritePPM(out, config.width, config.height, config.stride, config.data);
   }
   else
   {

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -946,8 +946,6 @@ bool Renderer::StartFrameDumpToImage(const FrameDumpConfig& config)
 
 void writePPM(std::ostream& os, int width, int height, int stride, const u8* data)
 {
-  using namespace std;
-
   // header
   os << "P6\n"
      << width << " " << height << "\n"

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -73,6 +73,8 @@ void VideoConfig::Load(const std::string& ini_file)
   settings->Get("CacheHiresTextures", &bCacheHiresTextures, false);
   settings->Get("DumpEFBTarget", &bDumpEFBTarget, false);
   settings->Get("DumpFramesAsImages", &bDumpFramesAsImages, false);
+  settings->Get("DumpFramesToPPM", &bDumpFramesToPPM, false);
+  settings->Get("DumpFramesCounter", &bDumpFramesCounter, true);
   settings->Get("FreeLook", &bFreeLook, false);
   settings->Get("UseFFV1", &bUseFFV1, false);
   settings->Get("InternalResolutionFrameDumps", &bInternalResolutionFrameDumps, false);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -100,6 +100,8 @@ struct VideoConfig final
   bool bCacheHiresTextures;
   bool bDumpEFBTarget;
   bool bDumpFramesAsImages;
+  bool bDumpFramesToPPM;
+  bool bDumpFramesCounter;
   bool bUseFFV1;
   bool bInternalResolutionFrameDumps;
   bool bFreeLook;


### PR DESCRIPTION
Enables dumping frames as PPM images instead of PNG. This is way faster - for me dolphin slows to a crawl when doing png dumps, but there's no noticeable penalty for ppm.