### PR TITLE
Vulkan: Fix GPU hangs on AMD Polaris

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -153,7 +153,10 @@ void VertexManager::vFlush()
     break;
 
   case PRIMITIVE_TRIANGLES:
-    StateTracker::GetInstance()->SetPrimitiveTopology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
+    StateTracker::GetInstance()->SetPrimitiveTopology(
+        g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ?
+            VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP :
+            VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
     g_renderer->SetGenerationMode();
     break;
   }

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -276,6 +276,11 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   // Depth clamping implies shaderClipDistance and depthClamp
   config->backend_info.bSupportsDepthClamp =
       (features.depthClamp == VK_TRUE && features.shaderClipDistance == VK_TRUE);
+
+  // Our usage of primitive restart appears to be broken on AMD's binary drivers.
+  // Seems to be fine on GCN Gen 1-2, unconfirmed on GCN Gen 3, causes driver resets on GCN Gen 4.
+  if (DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVE_RESTART))
+    config->backend_info.bSupportsPrimitiveRestart = false;
 }
 
 void VulkanContext::PopulateBackendInfoMultisampleModes(

--- a/Source/Core/VideoCommon/DriverDetails.cpp
+++ b/Source/Core/VideoCommon/DriverDetails.cpp
@@ -90,6 +90,8 @@ static BugInfo m_known_bugs[] = {
      BUG_BROKEN_DUAL_SOURCE_BLENDING, -1.0, -1.0, true},
     {API_OPENGL, OS_OSX, VENDOR_INTEL, DRIVER_INTEL, Family::UNKNOWN,
      BUG_BROKEN_DUAL_SOURCE_BLENDING, -1.0, -1.0, true},
+    {API_VULKAN, OS_ALL, VENDOR_ATI, DRIVER_ATI, Family::UNKNOWN, BUG_PRIMITIVE_RESTART, -1.0, -1.0,
+     true},
 };
 
 static std::map<Bug, BugInfo> m_bugs;


### PR DESCRIPTION
It appears that our usage of primitive restart is causing issues on AMD hardware, I'm guessing maybe due to the combination of base vertex plus primitive restart.

This PR disables primitive restart on AMD drivers (it might be okay on radv though, so we probably need a way to differentiate these two drivers).

Thanks to @iwubcode for painfully testing silly ideas for this bug.