### PR TITLE
VertexManagerBase: Make CreateNativeVertexFormat return a unique_ptr

### DIFF
--- a/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D/NativeVertexFormat.cpp
@@ -27,10 +27,10 @@ private:
   ID3D11InputLayout* m_layout = nullptr;
 };
 
-NativeVertexFormat*
+std::unique_ptr<NativeVertexFormat>
 VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
 {
-  return new D3DVertexFormat(vtx_decl);
+  return std::make_unique<D3DVertexFormat>(vtx_decl);
 }
 
 static const DXGI_FORMAT d3d_format_lookup[5 * 4 * 2] = {

--- a/Source/Core/VideoBackends/D3D/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D/VertexManager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include "VideoCommon/VertexManagerBase.h"
 
 struct ID3D11Buffer;
@@ -16,7 +17,9 @@ public:
   VertexManager();
   ~VertexManager();
 
-  NativeVertexFormat* CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
+  std::unique_ptr<NativeVertexFormat>
+  CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
+
   void CreateDeviceObjects() override;
   void DestroyDeviceObjects() override;
 

--- a/Source/Core/VideoBackends/D3D12/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DState.cpp
@@ -81,7 +81,7 @@ public:
 
     if (!native)
     {
-      native.reset(g_vertex_manager->CreateNativeVertexFormat(native_vtx_decl));
+      native = g_vertex_manager->CreateNativeVertexFormat(native_vtx_decl);
     }
 
     desc.InputLayout = reinterpret_cast<D3DVertexFormat*>(native.get())->GetActiveInputLayout12();

--- a/Source/Core/VideoBackends/D3D12/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/D3D12/NativeVertexFormat.cpp
@@ -13,10 +13,10 @@
 
 namespace DX12
 {
-NativeVertexFormat*
+std::unique_ptr<NativeVertexFormat>
 VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
 {
-  return new D3DVertexFormat(vtx_decl);
+  return std::make_unique<D3DVertexFormat>(vtx_decl);
 }
 
 static const constexpr DXGI_FORMAT d3d_format_lookup[5 * 4 * 2] = {

--- a/Source/Core/VideoBackends/D3D12/VertexManager.h
+++ b/Source/Core/VideoBackends/D3D12/VertexManager.h
@@ -17,7 +17,9 @@ public:
   VertexManager();
   ~VertexManager();
 
-  NativeVertexFormat* CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
+  std::unique_ptr<NativeVertexFormat>
+  CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
+
   void CreateDeviceObjects() override;
   void DestroyDeviceObjects() override;
 

--- a/Source/Core/VideoBackends/Null/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Null/VertexManager.cpp
@@ -19,10 +19,10 @@ public:
   void SetupVertexPointers() override {}
 };
 
-NativeVertexFormat*
+std::unique_ptr<NativeVertexFormat>
 VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
 {
-  return new NullNativeVertexFormat;
+  return std::make_unique<NullNativeVertexFormat>();
 }
 
 VertexManager::VertexManager() : m_local_v_buffer(MAXVBUFFERSIZE), m_local_i_buffer(MAXIBUFFERSIZE)

--- a/Source/Core/VideoBackends/Null/VertexManager.h
+++ b/Source/Core/VideoBackends/Null/VertexManager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "VideoCommon/VertexManagerBase.h"
@@ -15,7 +16,9 @@ class VertexManager : public VertexManagerBase
 public:
   VertexManager();
   ~VertexManager();
-  NativeVertexFormat* CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
+
+  std::unique_ptr<NativeVertexFormat>
+  CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
 
 protected:
   void ResetBuffer(u32 stride) override;

--- a/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
+++ b/Source/Core/VideoBackends/OGL/NativeVertexFormat.cpp
@@ -17,10 +17,10 @@
 
 namespace OGL
 {
-NativeVertexFormat*
+std::unique_ptr<NativeVertexFormat>
 VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
 {
-  return new GLVertexFormat(vtx_decl);
+  return std::make_unique<GLVertexFormat>(vtx_decl);
 }
 
 static inline GLuint VarToGL(VarType t)

--- a/Source/Core/VideoBackends/OGL/VertexManager.h
+++ b/Source/Core/VideoBackends/OGL/VertexManager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -31,7 +32,10 @@ class VertexManager : public VertexManagerBase
 public:
   VertexManager();
   ~VertexManager();
-  NativeVertexFormat* CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
+
+  std::unique_ptr<NativeVertexFormat>
+  CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
+
   void CreateDeviceObjects() override;
   void DestroyDeviceObjects() override;
 

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -33,10 +33,10 @@ public:
   void SetupVertexPointers() override {}
 };
 
-NativeVertexFormat*
+std::unique_ptr<NativeVertexFormat>
 SWVertexLoader::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
 {
-  return new NullNativeVertexFormat(vtx_decl);
+  return std::make_unique<NullNativeVertexFormat>(vtx_decl);
 }
 
 SWVertexLoader::SWVertexLoader() : LocalVBuffer(MAXVBUFFERSIZE), LocalIBuffer(MAXIBUFFERSIZE)

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.h
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -19,7 +20,8 @@ public:
   SWVertexLoader();
   ~SWVertexLoader();
 
-  NativeVertexFormat* CreateNativeVertexFormat(const PortableVertexDeclaration& vdec) override;
+  std::unique_ptr<NativeVertexFormat>
+  CreateNativeVertexFormat(const PortableVertexDeclaration& vdec) override;
 
 protected:
   void ResetBuffer(u32 stride) override;

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -63,10 +63,10 @@ bool VertexManager::Initialize()
   return true;
 }
 
-NativeVertexFormat*
+std::unique_ptr<NativeVertexFormat>
 VertexManager::CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl)
 {
-  return new VertexFormat(vtx_decl);
+  return std::make_unique<VertexFormat>(vtx_decl);
 }
 
 void VertexManager::PrepareDrawBuffers(u32 stride)

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.h
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.h
@@ -24,7 +24,8 @@ public:
 
   bool Initialize();
 
-  NativeVertexFormat* CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
+  std::unique_ptr<NativeVertexFormat>
+  CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) override;
 
 protected:
   void PrepareDrawBuffers(u32 stride);

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -161,7 +161,7 @@ static VertexLoaderBase* RefreshLoader(int vtx_attr_group, bool preprocess = fal
       std::unique_ptr<NativeVertexFormat>& native = s_native_vertex_map[format];
       if (!native)
       {
-        native.reset(g_vertex_manager->CreateNativeVertexFormat(format));
+        native = g_vertex_manager->CreateNativeVertexFormat(format);
       }
       loader->m_native_vertex_format = native.get();
     }

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -56,7 +56,7 @@ public:
 
   void Flush();
 
-  virtual NativeVertexFormat*
+  virtual std::unique_ptr<NativeVertexFormat>
   CreateNativeVertexFormat(const PortableVertexDeclaration& vtx_decl) = 0;
 
   void DoState(PointerWrap& p);


### PR DESCRIPTION
Much safer as opposed to just returning raw allocated memory.