### PR TITLE
SymbolDB: Simplify GetSymbolsFromHash

### DIFF
--- a/Source/Core/Common/SymbolDB.cpp
+++ b/Source/Core/Common/SymbolDB.cpp
@@ -72,14 +72,12 @@ Symbol* SymbolDB::GetSymbolFromHash(u32 hash)
 
 std::vector<Symbol*> SymbolDB::GetSymbolsFromHash(u32 hash)
 {
-  std::vector<Symbol*> symbols;
+  const auto iter = checksumToFunction.find(hash);
 
-  for (const auto& iter : checksumToFunction)
-    if (iter.first == hash)
-      for (const auto& symbol : iter.second)
-        symbols.push_back(symbol);
+  if (iter == checksumToFunction.cend())
+    return {};
 
-  return symbols;
+  return {iter->second.cbegin(), iter->second.cend()};
 }
 
 void SymbolDB::AddCompleteSymbol(const Symbol& symbol)


### PR DESCRIPTION
Given a std::map can't have duplicate keys, iterating over the map explicitly isn't necessary, and find() can just be used instead.

Also, instead of manually calling push_back() for every entry to be added, the range constructor of std::vector can be used instead to add the whole range all at once.