### PR TITLE
Change INI keys containing "Wii Remote" back to "Wiimote"

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -297,11 +297,11 @@ Wiimote::Wiimote(const unsigned int index)
       std::make_unique<ControllerEmu::ControlGroup::BackgroundInputSetting>(
           _trans("Background Input")));
   m_options->boolean_settings.emplace_back(
-      std::make_unique<ControllerEmu::ControlGroup::BooleanSetting>(_trans("Sideways Wii Remote"),
-                                                                    false));
+      std::make_unique<ControllerEmu::ControlGroup::BooleanSetting>(
+          "Sideways Wiimote", _trans("Sideways Wii Remote"), false));
   m_options->boolean_settings.emplace_back(
-      std::make_unique<ControllerEmu::ControlGroup::BooleanSetting>(_trans("Upright Wii Remote"),
-                                                                    false));
+      std::make_unique<ControllerEmu::ControlGroup::BooleanSetting>(
+          "Upright Wiimote", _trans("Upright Wii Remote"), false));
   m_options->boolean_settings.emplace_back(
       std::make_unique<ControllerEmu::ControlGroup::BooleanSetting>(
           _trans("Iterative Input"), false, ControllerEmu::ControlGroup::SettingType::VIRTUAL));

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -144,7 +144,8 @@ void PadSettingExtension::UpdateValue()
 
 PadSettingCheckBox::PadSettingCheckBox(wxWindow* const parent,
                                        ControllerEmu::ControlGroup::BooleanSetting* const _setting)
-    : PadSetting(new wxCheckBox(parent, wxID_ANY, wxGetTranslation(StrToWxStr(_setting->m_name)))),
+    : PadSetting(
+          new wxCheckBox(parent, wxID_ANY, wxGetTranslation(StrToWxStr(_setting->m_ui_name)))),
       setting(_setting)
 {
   UpdateGUI();

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -64,9 +64,15 @@ public:
   class BooleanSetting
   {
   public:
+    BooleanSetting(const std::string& setting_name, const std::string& ui_name,
+                   const bool default_value, const SettingType setting_type = SettingType::NORMAL)
+        : m_type(setting_type), m_name(setting_name), m_ui_name(ui_name),
+          m_default_value(default_value)
+    {
+    }
     BooleanSetting(const std::string& setting_name, const bool default_value,
                    const SettingType setting_type = SettingType::NORMAL)
-        : m_type(setting_type), m_name(setting_name), m_default_value(default_value)
+        : BooleanSetting(setting_name, setting_name, default_value, setting_type)
     {
     }
     virtual ~BooleanSetting();
@@ -75,6 +81,7 @@ public:
     virtual void SetValue(bool value) { m_value = value; }
     const SettingType m_type;
     const std::string m_name;
+    const std::string m_ui_name;
     const bool m_default_value;
     bool m_value;
   };


### PR DESCRIPTION
4bd5674 changed "Wiimote" to "Wii Remote" in the GUI (intentionally) but also did the same change for two INI keys (seemingly unintentional, breaks backwards compatibility, and is inconsistent with the INI's filename). This commit reverts the INI keys but not the GUI strings.

This commit uses the same approach as cbd539e used for GameCube sticks (but I made sure to avoid the bug that 56531a0 fixed).