### PR TITLE
Forward declare IBlobReader in Volume headers

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.h
+++ b/Source/Core/DiscIO/VolumeGC.h
@@ -16,6 +16,7 @@
 
 namespace DiscIO
 {
+class IBlobReader;
 enum class BlobType;
 enum class Country;
 enum class Language;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -17,6 +17,7 @@
 
 namespace DiscIO
 {
+class IBlobReader;
 enum class BlobType;
 enum class Country;
 enum class Language;


### PR DESCRIPTION
We have to do this (or include Blob.h) since the constructors take unique_ptr<IBlobReader> parameters.