### PR TITLE
VideoBackends: Add a developer option to disable the shader cache.

### DIFF
--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -157,14 +157,17 @@ void GeometryShaderCache::Init()
 
   Clear();
 
-  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
+  if (g_ActiveConfig.bShaderCache)
+  {
+    if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
+      File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
 
-  std::string cache_filename =
-      StringFromFormat("%sdx11-%s-gs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                       SConfig::GetInstance().m_strGameID.c_str());
-  GeometryShaderCacheInserter inserter;
-  g_gs_disk_cache.OpenAndRead(cache_filename, inserter);
+    std::string cache_filename =
+        StringFromFormat("%sdx11-%s-gs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
+                         SConfig::GetInstance().m_strGameID.c_str());
+    GeometryShaderCacheInserter inserter;
+    g_gs_disk_cache.OpenAndRead(cache_filename, inserter);
+  }
 
   last_entry = nullptr;
 }

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -494,17 +494,20 @@ void PixelShaderCache::Init()
 
   Clear();
 
-  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
-
   SETSTAT(stats.numPixelShadersCreated, 0);
   SETSTAT(stats.numPixelShadersAlive, 0);
 
-  std::string cache_filename =
-      StringFromFormat("%sdx11-%s-ps.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                       SConfig::GetInstance().m_strGameID.c_str());
-  PixelShaderCacheInserter inserter;
-  g_ps_disk_cache.OpenAndRead(cache_filename, inserter);
+  if (g_ActiveConfig.bShaderCache)
+  {
+    if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
+      File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
+
+    std::string cache_filename =
+        StringFromFormat("%sdx11-%s-ps.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
+                         SConfig::GetInstance().m_strGameID.c_str());
+    PixelShaderCacheInserter inserter;
+    g_ps_disk_cache.OpenAndRead(cache_filename, inserter);
+  }
 
   last_entry = nullptr;
 }

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -155,17 +155,20 @@ void VertexShaderCache::Init()
 
   Clear();
 
-  if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
-    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
-
   SETSTAT(stats.numVertexShadersCreated, 0);
   SETSTAT(stats.numVertexShadersAlive, 0);
 
-  std::string cache_filename =
-      StringFromFormat("%sdx11-%s-vs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                       SConfig::GetInstance().m_strGameID.c_str());
-  VertexShaderCacheInserter inserter;
-  g_vs_disk_cache.OpenAndRead(cache_filename, inserter);
+  if (g_ActiveConfig.bShaderCache)
+  {
+    if (!File::Exists(File::GetUserPath(D_SHADERCACHE_IDX)))
+      File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
+
+    std::string cache_filename =
+        StringFromFormat("%sdx11-%s-vs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
+                         SConfig::GetInstance().m_strGameID.c_str());
+    VertexShaderCacheInserter inserter;
+    g_vs_disk_cache.OpenAndRead(cache_filename, inserter);
+  }
 
   last_entry = nullptr;
 }

--- a/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
@@ -69,29 +69,32 @@ void ShaderCache::Init()
   s_last_pixel_shader_uid = {};
   s_last_vertex_shader_uid = {};
 
-  // Ensure shader cache directory exists..
-  std::string shader_cache_path = File::GetUserPath(D_SHADERCACHE_IDX);
+  if (g_ActiveConfig.bShaderCache)
+  {
+    // Ensure shader cache directory exists..
+    std::string shader_cache_path = File::GetUserPath(D_SHADERCACHE_IDX);
 
-  if (!File::Exists(shader_cache_path))
-    File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
+    if (!File::Exists(shader_cache_path))
+      File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
 
-  std::string title_game_id = SConfig::GetInstance().m_strGameID.c_str();
+    std::string title_game_id = SConfig::GetInstance().m_strGameID.c_str();
 
-  std::string gs_cache_filename =
-      StringFromFormat("%sdx11-%s-gs.cache", shader_cache_path.c_str(), title_game_id.c_str());
-  std::string ps_cache_filename =
-      StringFromFormat("%sdx11-%s-ps.cache", shader_cache_path.c_str(), title_game_id.c_str());
-  std::string vs_cache_filename =
-      StringFromFormat("%sdx11-%s-vs.cache", shader_cache_path.c_str(), title_game_id.c_str());
+    std::string gs_cache_filename =
+        StringFromFormat("%sdx11-%s-gs.cache", shader_cache_path.c_str(), title_game_id.c_str());
+    std::string ps_cache_filename =
+        StringFromFormat("%sdx11-%s-ps.cache", shader_cache_path.c_str(), title_game_id.c_str());
+    std::string vs_cache_filename =
+        StringFromFormat("%sdx11-%s-vs.cache", shader_cache_path.c_str(), title_game_id.c_str());
 
-  ShaderCacheInserter<GeometryShaderUid, GsBytecodeCache, &s_gs_bytecode_cache> gs_inserter;
-  s_gs_disk_cache.OpenAndRead(gs_cache_filename, gs_inserter);
+    ShaderCacheInserter<GeometryShaderUid, GsBytecodeCache, &s_gs_bytecode_cache> gs_inserter;
+    s_gs_disk_cache.OpenAndRead(gs_cache_filename, gs_inserter);
 
-  ShaderCacheInserter<PixelShaderUid, PsBytecodeCache, &s_ps_bytecode_cache> ps_inserter;
-  s_ps_disk_cache.OpenAndRead(ps_cache_filename, ps_inserter);
+    ShaderCacheInserter<PixelShaderUid, PsBytecodeCache, &s_ps_bytecode_cache> ps_inserter;
+    s_ps_disk_cache.OpenAndRead(ps_cache_filename, ps_inserter);
 
-  ShaderCacheInserter<VertexShaderUid, VsBytecodeCache, &s_vs_bytecode_cache> vs_inserter;
-  s_vs_disk_cache.OpenAndRead(vs_cache_filename, vs_inserter);
+    ShaderCacheInserter<VertexShaderUid, VsBytecodeCache, &s_vs_bytecode_cache> vs_inserter;
+    s_vs_disk_cache.OpenAndRead(vs_cache_filename, vs_inserter);
+  }
 
   SETSTAT(stats.numPixelShadersAlive, static_cast<int>(s_ps_bytecode_cache.size()));
   SETSTAT(stats.numPixelShadersCreated, static_cast<int>(s_ps_bytecode_cache.size()));

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -419,8 +419,8 @@ void ProgramShaderCache::Init()
   // Then once more to get bytes
   s_buffer = StreamBuffer::Create(GL_UNIFORM_BUFFER, UBO_LENGTH);
 
-  // Read our shader cache, only if supported
-  if (g_ogl_config.bSupportsGLSLCache)
+  // Read our shader cache, only if supported and enabled
+  if (g_ogl_config.bSupportsGLSLCache && g_ActiveConfig.bShaderCache)
   {
     GLint Supported;
     glGetIntegerv(GL_NUM_PROGRAM_BINARY_FORMATS, &Supported);

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -536,21 +536,25 @@ struct ShaderCacheReader : public LinearDiskCacheReader<Uid, u32>
 
 void ObjectCache::LoadShaderCaches()
 {
-  ShaderCacheReader<VertexShaderUid> vs_reader(m_vs_cache.shader_map);
-  m_vs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("vs"), vs_reader);
-  SETSTAT(stats.numVertexShadersCreated, static_cast<int>(m_vs_cache.shader_map.size()));
-  SETSTAT(stats.numVertexShadersAlive, static_cast<int>(m_vs_cache.shader_map.size()));
+  if (g_ActiveConfig.bShaderCache)
+  {
+    ShaderCacheReader<VertexShaderUid> vs_reader(m_vs_cache.shader_map);
+    m_vs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("vs"), vs_reader);
 
-  ShaderCacheReader<PixelShaderUid> ps_reader(m_ps_cache.shader_map);
-  m_ps_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("ps"), ps_reader);
+    ShaderCacheReader<PixelShaderUid> ps_reader(m_ps_cache.shader_map);
+    m_ps_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("ps"), ps_reader);
+
+    if (g_vulkan_context->SupportsGeometryShaders())
+    {
+      ShaderCacheReader<GeometryShaderUid> gs_reader(m_gs_cache.shader_map);
+      m_gs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("gs"), gs_reader);
+    }
+  }
+
   SETSTAT(stats.numPixelShadersCreated, static_cast<int>(m_ps_cache.shader_map.size()));
   SETSTAT(stats.numPixelShadersAlive, static_cast<int>(m_ps_cache.shader_map.size()));
-
-  if (g_vulkan_context->SupportsGeometryShaders())
-  {
-    ShaderCacheReader<GeometryShaderUid> gs_reader(m_gs_cache.shader_map);
-    m_gs_cache.disk_cache.OpenAndRead(GetDiskCacheFileName("gs"), gs_reader);
-  }
+  SETSTAT(stats.numVertexShadersCreated, static_cast<int>(m_vs_cache.shader_map.size()));
+  SETSTAT(stats.numVertexShadersAlive, static_cast<int>(m_vs_cache.shader_map.size()));
 }
 
 template <typename T>

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -89,6 +89,7 @@ void VideoConfig::Load(const std::string& ini_file)
   settings->Get("EnableValidationLayer", &bEnableValidationLayer, false);
   settings->Get("BackendMultithreading", &bBackendMultithreading, true);
   settings->Get("CommandBufferExecuteInterval", &iCommandBufferExecuteInterval, 100);
+  settings->Get("ShaderCache", &bShaderCache, true);
 
   settings->Get("SWZComploc", &bZComploc, true);
   settings->Get("SWZFreeze", &bZFreeze, true);
@@ -307,6 +308,7 @@ void VideoConfig::Save(const std::string& ini_file)
   settings->Set("EnableValidationLayer", bEnableValidationLayer);
   settings->Set("BackendMultithreading", bBackendMultithreading);
   settings->Set("CommandBufferExecuteInterval", iCommandBufferExecuteInterval);
+  settings->Set("ShaderCache", bShaderCache);
 
   settings->Set("SWZComploc", bZComploc);
   settings->Set("SWZFreeze", bZFreeze);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -69,6 +69,7 @@ struct VideoConfig final
   bool bCrop;  // Aspect ratio controls.
   bool bUseXFB;
   bool bUseRealXFB;
+  bool bShaderCache;
 
   // Enhancements
   int iMultisamples;


### PR DESCRIPTION
Makes it easier to disable the cache while working on the shaders. I got a little bit tired of replacing the shader cache folder by a file to break the cache.

This option is not intended to be used by users and has to be manually changed in the config file, similar to the `Fastmem` option.