### PR TITLE
IOS/ES: Fix the initial content FD value

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -203,7 +203,7 @@ void ES::Close()
   m_ContentAccessMap.clear();
   m_TitleIDs.clear();
   m_TitleID = -1;
-  m_AccessIdentID = 0x6000000;
+  m_AccessIdentID = 0;
 
   INFO_LOG(IOS_ES, "ES: Close");
   m_is_active = false;

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -200,7 +200,7 @@ private:
 
   std::vector<u64> m_TitleIDs;
   u64 m_TitleID = -1;
-  u32 m_AccessIdentID = 0x6000000;
+  u32 m_AccessIdentID = 0;
 
   // For title installation (ioctls IOCTL_ES_ADDTITLE*).
   TMDReader m_addtitle_tmd;


### PR DESCRIPTION
YYCJ is one of the last titles to be completely broken in Dolphin. It would hang right after the Wii remote screen. Looking at the game's debug messages reveals that it was failing to find some of its files.

IOS LLE booted the game just fine, which confirmed that it was an issue with IOS HLE.

By comparing the ioctlv requests and responses with IOS, it turns out that one of the very first ES replies was different between IOS HLE and IOS: there was a mismatch for the content fd returned by ES.

Changing the initial content FD to what IOS returns fixes the issue.

IOS
```
000000: 00 00 00 08 00 00 00 00 00 00 00 07 00 00 00 09  ................
000010: 00 00 00 01 00 00 00 00 01 38 66 f0 00 00 00 20  .........8f....
000020: 00 00 00 00 00 00 00 00 00 00 00 00 81 36 d3 18  .............6..
000030: 81 36 d3 18 00 00 ff ff ff ff ff ff ff ff ff ff  .6..............
```

Dolphin
```
000000: 00 00 00 08 06 00 00 00 00 00 00 07 00 00 00 09  ................
000010: 00 00 00 01 00 00 00 00 01 38 66 f0 00 00 00 20  .........8f....
000020: 00 00 00 00 00 00 00 00 00 00 00 00 81 36 d3 18  .............6..
000030: 81 36 d3 18 00 00 ff ff ff ff ff ff ff ff ff ff  .6..............
```

So where did 0x6000000 come from?