### PR TITLE
VideoBackends: Set the maximum range when the depth range is oversized.

### DIFF
--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -105,6 +105,7 @@
     <ClInclude Include="GL\GLExtensions\gl_common.h" />
     <ClInclude Include="GL\GLExtensions\HP_occlusion_test.h" />
     <ClInclude Include="GL\GLExtensions\KHR_debug.h" />
+    <ClInclude Include="GL\GLExtensions\NV_depth_buffer_float.h" />
     <ClInclude Include="GL\GLExtensions\NV_occlusion_query_samples.h" />
     <ClInclude Include="GL\GLExtensions\NV_primitive_restart.h" />
     <ClInclude Include="GL\GLInterfaceBase.h" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -218,6 +218,9 @@
     <ClInclude Include="GL\GLExtensions\NV_primitive_restart.h">
       <Filter>GL\GLExtensions</Filter>
     </ClInclude>
+    <ClInclude Include="GL\GLExtensions\NV_depth_buffer_float.h">
+      <Filter>GL\GLExtensions</Filter>
+    </ClInclude>
     <ClInclude Include="GL\GLInterface\WGL.h">
       <Filter>GL\GLInterface</Filter>
     </ClInclude>

--- a/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
+++ b/Source/Core/Common/GL/GLExtensions/GLExtensions.cpp
@@ -984,6 +984,11 @@ PFNDOLCOPYIMAGESUBDATAPROC dolCopyImageSubData;
 // ARB_shader_storage_buffer_object
 PFNDOLSHADERSTORAGEBLOCKBINDINGPROC dolShaderStorageBlockBinding;
 
+// NV_depth_buffer_float
+PFNDOLDEPTHRANGEDNVPROC dolDepthRangedNV;
+PFNDOLCLEARDEPTHDNVPROC dolClearDepthdNV;
+PFNDOLDEPTHBOUNDSDNVPROC dolDepthBoundsdNV;
+
 // Creates a GLFunc object that requires a feature
 #define GLFUNC_REQUIRES(x, y)                                                                      \
   {                                                                                                \
@@ -1838,6 +1843,11 @@ const GLFunc gl_function_array[] = {
 
     // ARB_shader_storage_buffer_object
     GLFUNC_REQUIRES(glShaderStorageBlockBinding, "ARB_shader_storage_buffer_object !VERSION_4_3"),
+
+    // NV_depth_buffer_float
+    GLFUNC_REQUIRES(glDepthRangedNV, "GL_NV_depth_buffer_float"),
+    GLFUNC_REQUIRES(glClearDepthdNV, "GL_NV_depth_buffer_float"),
+    GLFUNC_REQUIRES(glDepthBoundsdNV, "GL_NV_depth_buffer_float"),
 };
 
 namespace GLExtensions
@@ -2060,26 +2070,21 @@ static void InitExtensionList()
       // Quite a lot of these had their names changed when merged in to core
       // Disable the ones that have
       std::string gl300exts[] = {
-          "GL_ARB_map_buffer_range",
+          "GL_ARB_map_buffer_range", "GL_ARB_color_buffer_float", "GL_ARB_texture_float",
+          "GL_ARB_half_float_pixel", "GL_ARB_framebuffer_object", "GL_ARB_texture_float",
+          "GL_ARB_vertex_array_object", "GL_NV_depth_buffer_float",
+          //"GL_EXT_texture_integer",
           //"GL_EXT_gpu_shader4",
           //"GL_APPLE_flush_buffer_range",
-          "GL_ARB_color_buffer_float",
-          //"GL_NV_depth_buffer_float",
-          "GL_ARB_texture_float",
           //"GL_EXT_packed_float",
           //"GL_EXT_texture_shared_exponent",
-          "GL_ARB_half_float_pixel",
           //"GL_NV_half_float",
-          "GL_ARB_framebuffer_object",
           //"GL_EXT_framebuffer_sRGB",
-          "GL_ARB_texture_float",
-          //"GL_EXT_texture_integer",
           //"GL_EXT_draw_buffers2",
           //"GL_EXT_texture_integer",
           //"GL_EXT_texture_array",
           //"GL_EXT_texture_compression_rgtc",
           //"GL_EXT_transform_feedback",
-          "GL_ARB_vertex_array_object",
           //"GL_NV_conditional_render",
           "VERSION_3_0",
       };

--- a/Source/Core/Common/GL/GLExtensions/GLExtensions.h
+++ b/Source/Core/Common/GL/GLExtensions/GLExtensions.h
@@ -31,6 +31,7 @@
 #include "Common/GL/GLExtensions/EXT_texture_filter_anisotropic.h"
 #include "Common/GL/GLExtensions/HP_occlusion_test.h"
 #include "Common/GL/GLExtensions/KHR_debug.h"
+#include "Common/GL/GLExtensions/NV_depth_buffer_float.h"
 #include "Common/GL/GLExtensions/NV_occlusion_query_samples.h"
 #include "Common/GL/GLExtensions/NV_primitive_restart.h"
 #include "Common/GL/GLExtensions/gl_1_1.h"

--- a/Source/Core/Common/GL/GLExtensions/NV_depth_buffer_float.h
+++ b/Source/Core/Common/GL/GLExtensions/NV_depth_buffer_float.h
@@ -1,0 +1,41 @@
+/*
+** Copyright (c) 2013-2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+#include "Common/GL/GLExtensions/gl_common.h"
+
+#define GL_DEPTH_COMPONENT32F_NV 0x8DAB
+#define GL_DEPTH32F_STENCIL8_NV 0x8DAC
+#define GL_FLOAT_32_UNSIGNED_INT_24_8_REV_NV 0x8DAD
+#define GL_DEPTH_BUFFER_FLOAT_MODE_NV 0x8DAF
+
+typedef void(APIENTRYP PFNDOLDEPTHRANGEDNVPROC)(GLdouble zNear, GLdouble zFar);
+typedef void(APIENTRYP PFNDOLCLEARDEPTHDNVPROC)(GLdouble depth);
+typedef void(APIENTRYP PFNDOLDEPTHBOUNDSDNVPROC)(GLdouble zmin, GLdouble zmax);
+
+extern PFNDOLDEPTHRANGEDNVPROC dolDepthRangedNV;
+extern PFNDOLCLEARDEPTHDNVPROC dolClearDepthdNV;
+extern PFNDOLDEPTHBOUNDSDNVPROC dolDepthBoundsdNV;
+
+#define glDepthRangedNV dolDepthRangedNV
+#define glClearDepthdNV dolClearDepthdNV
+#define glDepthBoundsdNV dolDepthBoundsdNV

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -234,6 +234,8 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("gpu-has-dual-source-blend", g_Config.backend_info.bSupportsDualSourceBlend);
   builder.AddData("gpu-has-primitive-restart", g_Config.backend_info.bSupportsPrimitiveRestart);
   builder.AddData("gpu-has-oversized-viewports", g_Config.backend_info.bSupportsOversizedViewports);
+  builder.AddData("gpu-has-oversized-depth-ranges",
+                  g_Config.backend_info.bSupportsOversizedDepthRanges);
   builder.AddData("gpu-has-geometry-shaders", g_Config.backend_info.bSupportsGeometryShaders);
   builder.AddData("gpu-has-3d-vision", g_Config.backend_info.bSupports3DVision);
   builder.AddData("gpu-has-early-z", g_Config.backend_info.bSupportsEarlyZ);

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -576,10 +576,12 @@ void Renderer::SetViewport()
     Ht = -Ht;
   }
 
-  // If an inverted depth range is used, which D3D doesn't support,
-  // we need to calculate the depth range in the vertex shader.
-  if (xfmem.viewport.zRange < 0.0f)
+  // If an inverted or oversized depth range is used, we need to calculate the depth range in the
+  // vertex shader.
+  if (xfmem.viewport.zRange < 0.0f || fabs(xfmem.viewport.zRange) > 16777215.0f ||
+      fabs(xfmem.viewport.farZ) > 16777215.0f)
   {
+    // We need to ensure depth values are clamped the maximum value supported by the console GPU.
     min_depth = 0.0f;
     max_depth = GX_MAX_DEPTH;
   }

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -561,10 +561,8 @@ void Renderer::SetViewport()
   float Y = Renderer::EFBToScaledYf(xfmem.viewport.yOrig + xfmem.viewport.ht - scissorYOff);
   float Wd = Renderer::EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float Ht = Renderer::EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, 0.0f, 16777215.0f);
-  float min_depth =
-      MathUtil::Clamp<float>(xfmem.viewport.farZ - range, 0.0f, 16777215.0f) / 16777216.0f;
-  float max_depth = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
+  float min_depth = (xfmem.viewport.farZ - xfmem.viewport.zRange) / 16777216.0f;
+  float max_depth = xfmem.viewport.farZ / 16777216.0f;
   if (Wd < 0.0f)
   {
     X += Wd;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -576,8 +576,7 @@ void Renderer::SetViewport()
 
   // If an inverted or oversized depth range is used, we need to calculate the depth range in the
   // vertex shader.
-  if (xfmem.viewport.zRange < 0.0f || fabs(xfmem.viewport.zRange) > 16777215.0f ||
-      fabs(xfmem.viewport.farZ) > 16777215.0f)
+  if (UseVertexDepthRange())
   {
     // We need to ensure depth values are clamped the maximum value supported by the console GPU.
     min_depth = 0.0f;

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -64,6 +64,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsOversizedViewports = false;
+  g_Config.backend_info.bSupportsOversizedDepthRanges = false;
   g_Config.backend_info.bSupportsGeometryShaders = true;
   g_Config.backend_info.bSupports3DVision = true;
   g_Config.backend_info.bSupportsPostProcessing = false;

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -466,10 +466,8 @@ void Renderer::SetViewport()
   float y = Renderer::EFBToScaledYf(xfmem.viewport.yOrig + xfmem.viewport.ht - scissor_y_offset);
   float width = Renderer::EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float height = Renderer::EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, 0.0f, 16777215.0f);
-  float min_depth =
-      MathUtil::Clamp<float>(xfmem.viewport.farZ - range, 0.0f, 16777215.0f) / 16777216.0f;
-  float max_depth = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
+  float min_depth = (xfmem.viewport.farZ - xfmem.viewport.zRange) / 16777216.0f;
+  float max_depth = xfmem.viewport.farZ / 16777216.0f;
   if (width < 0.0f)
   {
     x += width;

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -481,10 +481,12 @@ void Renderer::SetViewport()
     height = -height;
   }
 
-  // If an inverted depth range is used, which D3D doesn't support,
-  // we need to calculate the depth range in the vertex shader.
-  if (xfmem.viewport.zRange < 0.0f)
+  // If an inverted or oversized depth range is used, we need to calculate the depth range in the
+  // vertex shader.
+  if (xfmem.viewport.zRange < 0.0f || fabs(xfmem.viewport.zRange) > 16777215.0f ||
+      fabs(xfmem.viewport.farZ) > 16777215.0f)
   {
+    // We need to ensure depth values are clamped the maximum value supported by the console GPU.
     min_depth = 0.0f;
     max_depth = GX_MAX_DEPTH;
   }

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -481,8 +481,7 @@ void Renderer::SetViewport()
 
   // If an inverted or oversized depth range is used, we need to calculate the depth range in the
   // vertex shader.
-  if (xfmem.viewport.zRange < 0.0f || fabs(xfmem.viewport.zRange) > 16777215.0f ||
-      fabs(xfmem.viewport.farZ) > 16777215.0f)
+  if (UseVertexDepthRange())
   {
     // We need to ensure depth values are clamped the maximum value supported by the console GPU.
     min_depth = 0.0f;

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -68,6 +68,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsOversizedViewports = false;
+  g_Config.backend_info.bSupportsOversizedDepthRanges = false;
   g_Config.backend_info.bSupportsGeometryShaders = true;
   g_Config.backend_info.bSupports3DVision = true;
   g_Config.backend_info.bSupportsPostProcessing = false;

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -28,6 +28,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsOversizedViewports = true;
+  g_Config.backend_info.bSupportsOversizedDepthRanges = false;
   g_Config.backend_info.bSupportsGeometryShaders = true;
   g_Config.backend_info.bSupports3DVision = false;
   g_Config.backend_info.bSupportsEarlyZ = true;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1123,6 +1123,24 @@ void Renderer::SetViewport()
     Height *= -1;
   }
 
+  // If an oversized depth range is used, we need to calculate the depth range in the vertex shader.
+  if (g_ActiveConfig.backend_info.bSupportsDepthClamp &&
+      (fabs(xfmem.viewport.zRange) > 16777215.0f || fabs(xfmem.viewport.farZ) > 16777215.0f))
+  {
+    // We need to ensure depth values are clamped the maximum value supported by the console GPU.
+    // Taking into account whether the depth range is inverted or not.
+    if (xfmem.viewport.zRange < 0.0f)
+    {
+      min_depth = GX_MAX_DEPTH;
+      max_depth = 0.0f;
+    }
+    else
+    {
+      min_depth = 0.0f;
+      max_depth = GX_MAX_DEPTH;
+    }
+  }
+
   // Update the view port
   if (g_ogl_config.bSupportViewportFloat)
   {
@@ -1134,10 +1152,7 @@ void Renderer::SetViewport()
     glViewport(iceilf(X), iceilf(Y), iceilf(Width), iceilf(Height));
   }
 
-  // Set the reversed depth range. If we do depth clipping and depth range in the
-  // vertex shader we only need to ensure depth values don't exceed the maximum
-  // value supported by the console GPU. If not, we simply clamp the near/far values
-  // themselves to the maximum value as done above.
+  // Set the reversed depth range.
   glDepthRangef(max_depth, min_depth);
 }
 

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -107,6 +107,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsInternalResolutionFrameDumps = true;
 
   // Overwritten in Render.cpp later
+  g_Config.backend_info.bSupportsOversizedDepthRanges = false;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsPaletteConversion = true;

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -128,6 +128,7 @@ void VideoSoftware::InitBackendInfo()
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsEarlyZ = true;
   g_Config.backend_info.bSupportsOversizedViewports = true;
+  g_Config.backend_info.bSupportsOversizedDepthRanges = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = false;
   g_Config.backend_info.bSupportsMultithreading = false;
   g_Config.backend_info.bSupportsInternalResolutionFrameDumps = false;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1641,10 +1641,8 @@ void Renderer::SetViewport()
   float y = Renderer::EFBToScaledYf(xfmem.viewport.yOrig + xfmem.viewport.ht - scissor_y_offset);
   float width = Renderer::EFBToScaledXf(2.0f * xfmem.viewport.wd);
   float height = Renderer::EFBToScaledYf(-2.0f * xfmem.viewport.ht);
-  float range = MathUtil::Clamp<float>(xfmem.viewport.zRange, -16777215.0f, 16777215.0f);
-  float min_depth =
-      MathUtil::Clamp<float>(xfmem.viewport.farZ - range, 0.0f, 16777215.0f) / 16777216.0f;
-  float max_depth = MathUtil::Clamp<float>(xfmem.viewport.farZ, 0.0f, 16777215.0f) / 16777216.0f;
+  float min_depth = (xfmem.viewport.farZ - xfmem.viewport.zRange) / 16777216.0f;
+  float max_depth = xfmem.viewport.farZ / 16777216.0f;
   if (width < 0.0f)
   {
     x += width;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -4,7 +4,6 @@
 
 #include "VideoBackends/Vulkan/Renderer.h"
 
-#include <cmath>
 #include <cstddef>
 #include <cstdio>
 #include <limits>
@@ -1657,8 +1656,7 @@ void Renderer::SetViewport()
   // If an oversized or inverted depth range is used, we need to calculate the depth range in the
   // vertex shader.
   // TODO: Inverted depth ranges are bugged in all drivers, which should be added to DriverDetails.
-  if (xfmem.viewport.zRange < 0.0f || fabs(xfmem.viewport.zRange) > 16777215.0f ||
-      fabs(xfmem.viewport.farZ) > 16777215.0f)
+  if (UseVertexDepthRange())
   {
     // We need to ensure depth values are clamped the maximum value supported by the console GPU.
     min_depth = 0.0f;

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -225,15 +225,16 @@ VulkanContext::GPUList VulkanContext::EnumerateGPUs(VkInstance instance)
 void VulkanContext::PopulateBackendInfo(VideoConfig* config)
 {
   config->backend_info.api_type = APIType::Vulkan;
-  config->backend_info.bSupportsExclusiveFullscreen = false;  // Currently WSI does not allow this.
-  config->backend_info.bSupports3DVision = false;             // D3D-exclusive.
-  config->backend_info.bSupportsOversizedViewports = true;    // Assumed support.
-  config->backend_info.bSupportsEarlyZ = true;                // Assumed support.
-  config->backend_info.bSupportsPrimitiveRestart = true;      // Assumed support.
-  config->backend_info.bSupportsBindingLayout = false;        // Assumed support.
-  config->backend_info.bSupportsPaletteConversion = true;     // Assumed support.
-  config->backend_info.bSupportsClipControl = true;           // Assumed support.
-  config->backend_info.bSupportsMultithreading = true;        // Assumed support.
+  config->backend_info.bSupportsExclusiveFullscreen = false;   // Currently WSI does not allow this.
+  config->backend_info.bSupports3DVision = false;              // D3D-exclusive.
+  config->backend_info.bSupportsOversizedViewports = true;     // Assumed support.
+  config->backend_info.bSupportsOversizedDepthRanges = false;  // No support yet.
+  config->backend_info.bSupportsEarlyZ = true;                 // Assumed support.
+  config->backend_info.bSupportsPrimitiveRestart = true;       // Assumed support.
+  config->backend_info.bSupportsBindingLayout = false;         // Assumed support.
+  config->backend_info.bSupportsPaletteConversion = true;      // Assumed support.
+  config->backend_info.bSupportsClipControl = true;            // Assumed support.
+  config->backend_info.bSupportsMultithreading = true;         // Assumed support.
   config->backend_info.bSupportsInternalResolutionFrameDumps = true;  // Assumed support.
   config->backend_info.bSupportsPostProcessing = false;               // No support yet.
   config->backend_info.bSupportsDualSourceBlend = false;              // Dependent on features.

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -332,6 +332,8 @@ static void BPWritten(const BPCmd& bp)
   {
     if (bp.changes & 3)
       PixelShaderManager::SetZTextureTypeChanged();
+    if (bp.changes & 12)
+      VertexShaderManager::SetViewportChanged();
 #if defined(_DEBUG) || defined(DEBUGFAST)
     const char* pzop[] = {"DISABLE", "ADD", "REPLACE", "?"};
     const char* pztype[] = {"Z8", "Z16", "Z24", "?"};

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -947,15 +947,17 @@ bool Renderer::UseVertexDepthRange() const
   if (!g_ActiveConfig.backend_info.bSupportsDepthClamp)
     return false;
 
+  const bool ztexture_enabled = bpmem.ztex2.type != ZTEXTURE_DISABLE && !bpmem.zcontrol.early_ztest;
+
   if (g_ActiveConfig.backend_info.bSupportsOversizedDepthRanges)
   {
     // We support oversized depth ranges, but we need a full depth range if a ztexture is used.
-    return bpmem.ztex2.type != ZTEXTURE_DISABLE;
+    return ztexture_enabled;
   }
   else
   {
     // We need a full depth range if a ztexture is used.
-    if (bpmem.ztex2.type != ZTEXTURE_DISABLE)
+    if (ztexture_enabled)
       return true;
 
     // If an inverted depth range is unsupported, we also need to check if the range is inverted.

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -940,3 +940,30 @@ void Renderer::DumpFrameToImage(const FrameDumpConfig& config)
   TextureToPng(config.data, config.stride, filename, config.width, config.height, false);
   m_frame_dump_image_counter++;
 }
+
+bool Renderer::UseVertexDepthRange() const
+{
+  // We can't compute the depth range in the vertex shader if we don't support depth clamp.
+  if (!g_ActiveConfig.backend_info.bSupportsDepthClamp)
+    return false;
+
+  if (g_ActiveConfig.backend_info.bSupportsOversizedDepthRanges)
+  {
+    // We support oversized depth ranges, but we need a full depth range if a ztexture is used.
+    return bpmem.ztex2.type != ZTEXTURE_DISABLE;
+  }
+  else
+  {
+    // We need a full depth range if a ztexture is used.
+    if (bpmem.ztex2.type != ZTEXTURE_DISABLE)
+      return true;
+
+    // If an inverted depth range is unsupported, we also need to check if the range is inverted.
+    if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange && xfmem.viewport.zRange < 0.0f)
+      return true;
+
+    // If an oversized depth range or a ztexture is used, we need to calculate the depth range
+    // in the vertex shader.
+    return fabs(xfmem.viewport.zRange) > 16777215.0f || fabs(xfmem.viewport.farZ) > 16777215.0f;
+  }
+}

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -145,6 +145,8 @@ public:
   // Final surface changing
   // This is called when the surface is resized (WX) or the window changes (Android).
   virtual void ChangeSurface(void* new_surface_handle) {}
+  bool UseVertexDepthRange() const;
+
 protected:
   static void CalculateTargetScale(int x, int y, int* scaledX, int* scaledY);
   bool CalculateTargetSize();

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -391,40 +391,27 @@ void VertexShaderManager::SetConstants()
     constants.pixelcentercorrection[2] = 1.0f;
     constants.pixelcentercorrection[3] = 0.0f;
 
-    if (g_ActiveConfig.backend_info.bSupportsDepthClamp &&
-        !g_ActiveConfig.backend_info.bSupportsOversizedDepthRanges)
+    if (g_renderer->UseVertexDepthRange())
     {
       // Oversized depth ranges are handled in the vertex shader. We need to reverse
-      // the far value to get a reversed depth range mapping. This is necessary
-      // because the standard depth range equation pushes all depth values towards
-      // the back of the depth buffer where conventionally depth buffers have the
-      // least precision.
+      // the far value to use the reversed-Z trick.
       if (g_ActiveConfig.backend_info.bSupportsReversedDepthRange)
       {
-        if (fabs(xfmem.viewport.zRange) > 16777215.0f || fabs(xfmem.viewport.farZ) > 16777215.0f)
-        {
-          // For backends that support reversing the depth range we also support cases
-          // where the console also uses reversed depth with the same accuracy. We need
-          // to make sure the depth range is positive here and then reverse the depth in
-          // the backend viewport.
-          constants.pixelcentercorrection[2] = fabs(xfmem.viewport.zRange) / 16777215.0f;
-          if (xfmem.viewport.zRange < 0.0f)
-            constants.pixelcentercorrection[3] = xfmem.viewport.farZ / 16777215.0f;
-          else
-            constants.pixelcentercorrection[3] = 1.0f - xfmem.viewport.farZ / 16777215.0f;
-        }
+        // Sometimes the console also tries to use the reversed-Z trick. We can only do
+        // that with the expected accuracy if the backend can reverse the depth range.
+        constants.pixelcentercorrection[2] = fabs(xfmem.viewport.zRange) / 16777215.0f;
+        if (xfmem.viewport.zRange < 0.0f)
+          constants.pixelcentercorrection[3] = xfmem.viewport.farZ / 16777215.0f;
+        else
+          constants.pixelcentercorrection[3] = 1.0f - xfmem.viewport.farZ / 16777215.0f;
       }
       else
       {
-        if (xfmem.viewport.zRange < 0.0f || xfmem.viewport.zRange > 16777215.0f ||
-            fabs(xfmem.viewport.farZ) > 16777215.0f)
-        {
-          // For backends that don't support reversing the depth range we can still render
-          // cases where the console uses reversed depth correctly. But we simply can't
-          // provide the same accuracy as the console.
-          constants.pixelcentercorrection[2] = xfmem.viewport.zRange / 16777215.0f;
-          constants.pixelcentercorrection[3] = 1.0f - xfmem.viewport.farZ / 16777215.0f;
-        }
+        // For backends that don't support reversing the depth range we can still render
+        // cases where the console uses the reversed-Z trick. But we simply can't provide
+        // the expected accuracy, which might result in z-fighting.
+        constants.pixelcentercorrection[2] = xfmem.viewport.zRange / 16777215.0f;
+        constants.pixelcentercorrection[3] = 1.0f - xfmem.viewport.farZ / 16777215.0f;
       }
     }
 

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -391,7 +391,8 @@ void VertexShaderManager::SetConstants()
     constants.pixelcentercorrection[2] = 1.0f;
     constants.pixelcentercorrection[3] = 0.0f;
 
-    if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
+    if (g_ActiveConfig.backend_info.bSupportsDepthClamp &&
+        !g_ActiveConfig.backend_info.bSupportsOversizedDepthRanges)
     {
       // Oversized depth ranges are handled in the vertex shader. We need to reverse
       // the far value to get a reversed depth range mapping. This is necessary

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -172,6 +172,7 @@ struct VideoConfig final
     bool bSupportsDualSourceBlend;
     bool bSupportsPrimitiveRestart;
     bool bSupportsOversizedViewports;
+    bool bSupportsOversizedDepthRanges;
     bool bSupportsGeometryShaders;
     bool bSupports3DVision;
     bool bSupportsEarlyZ;         // needed by PixelShaderGen, so must stay in VideoCommon


### PR DESCRIPTION
This PR fixes regressions introduced in PR #4471 and PR #4085. It also contains a code cleanup that removes a hack for OpenGL ES, we should consider always relying on slow depth when that API is in use.

### Regression 1

The first regression is very simple, during PR #4471 I worked with the assumption that an oversized depth range would always result in a 0:1 depth range in the viewport. However in some games this may not be the case, there are situations where the far value is oversized, but the range value is normal, thus we get a depth range that is smaller than 0:1.

This PR fixes that simply by ensuring the range is set properly when one of the parameters is oversized.

### Regression 2

The second regression is more complicated, it's an interplay between PR #4471 and PR #4085. PR #4085 introduced depth clamping together with user-defined clipping planes to fix clipping issues in games such as Sonic Adventures. However depth clamping will not only clamp the viewport transform to the depth range as we intended, but it will also clamp depth values outputted by the pixel shader to the depth range.

This is can be a problem in games such as the PAL50 version of Mario Kart, which uses a ztexture to clear the depth buffer outside of the depth range. Before PR #4471 this wasn't a problem, because PR #4085 made sure the depth range was always set to the maximum value. To fix this we simply disable depth clamping while a ztexture is enabled.

### Bonus: glDepthRangedNV support

Because no one likes hacks upon hacks I decided this would be a good time to introduce support for the `NV_depth_buffer_float` extension in OpenGL. The benefit of this extension is that it allows OpenGL to handle oversized depth ranges without any hacks just like the console can. When this extension is supported the OpenGL backend will always let OpenGL process the depth range instead of trying to handle it in the vertex shader, which can lead to z-fighting issues.