### PR TITLE
Allow buiding without microphone suppport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(ENABLE_QT2 "Enable Qt2 (use the other experimental Qt interface)" OFF)
 option(ENABLE_LTO "Enables Link Time Optimization" OFF)
 option(ENABLE_GENERIC "Enables generic build that should run on any little-endian host" OFF)
 option(ENABLE_HEADLESS "Enables running Dolphin as a headless variant" OFF)
+option(ENABLE_MICROPHONE "Enables GameCube microphone support" ON)
 option(ENABLE_ALSA "Enables ALSA sound backend" ON)
 option(ENABLE_AO "Enables libao sound backend" ON)
 option(ENABLE_PULSEAUDIO "Enables PulseAudio sound backend" ON)
@@ -477,7 +478,7 @@ if(ENCODE_FRAMEDUMPS)
 
 endif()
 
-if(NOT ANDROID)
+if(NOT ANDROID AND ENABLE_MICROPHONE)
 	set(PORTAUDIO_FOUND TRUE)
 	add_definitions(-DHAVE_PORTAUDIO=1)
 


### PR DESCRIPTION
Unconditional microphone support means portaudio isn't optional.

Make microphone optional to restore the possibility of building
without the extra dependency on portaudio.