### PR TITLE
Add missing "functional" include for GCC7

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <functional>
 #include <map>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Building fails on GCC7 without an explicit
#include <functional>