### PR TITLE
Always use visible text in GameList

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -624,8 +624,8 @@ void CGameListCtrl::InsertItemInReportView(long index)
       UpdateItemAtColumn(item_index, i);
   }
 
-  // Background color
-  SetBackgroundColor();
+  // List colors
+  SetColors();
 }
 
 static wxColour blend50(const wxColour& c1, const wxColour& c2)
@@ -638,7 +638,15 @@ static wxColour blend50(const wxColour& c1, const wxColour& c2)
   return a << 24 | b << 16 | g << 8 | r;
 }
 
-void CGameListCtrl::SetBackgroundColor()
+static wxColour ContrastText(const wxColour& bgc)
+{
+  // Luminance threshold to determine whether to use black text on light background
+  static constexpr int LUM_THRESHOLD = 186;
+  int lum = 0.299 * bgc.Red() + 0.587 * bgc.Green() + 0.114 * bgc.Blue();
+  return (lum > LUM_THRESHOLD) ? *wxBLACK : *wxWHITE;
+}
+
+void CGameListCtrl::SetColors()
 {
   for (long i = 0; i < GetItemCount(); i++)
   {
@@ -646,6 +654,7 @@ void CGameListCtrl::SetBackgroundColor()
                                        wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)) :
                                wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
     CGameListCtrl::SetItemBackgroundColour(i, color);
+    SetItemTextColour(i, ContrastText(color));
   }
 }
 
@@ -796,7 +805,7 @@ void CGameListCtrl::OnColumnClick(wxListEvent& event)
     SortItems(wxListCompare, last_sort);
   }
 
-  SetBackgroundColor();
+  SetColors();
 
   event.Skip();
 }

--- a/Source/Core/DolphinWX/GameListCtrl.h
+++ b/Source/Core/DolphinWX/GameListCtrl.h
@@ -73,7 +73,7 @@ private:
   void InitBitmaps();
   void UpdateItemAtColumn(long _Index, int column);
   void InsertItemInReportView(long _Index);
-  void SetBackgroundColor();
+  void SetColors();
   void ScanForISOs();
 
   // events


### PR DESCRIPTION
Depending upon the desktop colour scheme, the light/dark
GameList backgrounds can cause the always white text
to become unreadble.

Use the common luminance approximation algorithm to
determine whether black text should be used instead.