### PR TITLE
Retry opening of wiimote channels on initial failure

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
@@ -140,22 +140,52 @@ bool WiimoteLinux::ConnectInternal()
 
   // Output channel
   addr.l2_psm = htobs(WC_OUTPUT);
-  if ((m_cmd_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP)) == -1 ||
-      connect(m_cmd_sock, (sockaddr*)&addr, sizeof(addr)) < 0)
+  if (m_cmd_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP))
+  {
+    int retry = 0;
+    while (connect(m_cmd_sock, (sockaddr*)&addr, sizeof(addr)) < 0)
+    {
+      // If opening channel fails sleep and try again
+      if (retry == 3)
+      {
+        WARN_LOG(WIIMOTE, "Unable to connect output channel to Wiimote: %s", strerror(errno));
+        close(m_cmd_sock);
+        m_cmd_sock = -1;
+        return false;
+      }
+      retry++;
+      sleep(1);
+    }
+  }
+  else
   {
     WARN_LOG(WIIMOTE, "Unable to open output socket to Wiimote: %s", strerror(errno));
-    close(m_cmd_sock);
-    m_cmd_sock = -1;
     return false;
   }
 
   // Input channel
   addr.l2_psm = htobs(WC_INPUT);
-  if ((m_int_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP)) == -1 ||
-      connect(m_int_sock, (sockaddr*)&addr, sizeof(addr)) < 0)
+  if (m_int_sock = socket(AF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP))
+  {
+    int retry = 0;
+    while (connect(m_int_sock, (sockaddr*)&addr, sizeof(addr)) < 0)
+    {
+      // If opening channel fails sleep and try again
+      if (retry == 3)
+      {
+        WARN_LOG(WIIMOTE, "Unable to connect input channel to Wiimote: %s", strerror(errno));
+        close(m_int_sock);
+        close(m_cmd_sock);
+        m_int_sock = m_cmd_sock = -1;
+        return false;
+      }
+      retry++;
+      sleep(1);
+    }
+  }
+  else
   {
     WARN_LOG(WIIMOTE, "Unable to open input socket from Wiimote: %s", strerror(errno));
-    close(m_int_sock);
     close(m_cmd_sock);
     m_int_sock = m_cmd_sock = -1;
     return false;


### PR DESCRIPTION
It's not uncommon on some Bluetooth controllers for a
peripheral device to be "present" before it's "ready".
There is a window where connection can fail because the
device communication didn't succeed initially, but
will always work on retry after a short delay.

I'm not the original author of this patch and I can't
remember where I found it.  I can confirm that it
works perfectly for me though...