### PR TITLE
DolphinWX: Don't use a special color for compressed games

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -207,8 +207,6 @@ void SConfig::SaveGameListSettings(IniFile& ini)
   gamelist->Set("ListSort", m_ListSort);
   gamelist->Set("ListSortSecondary", m_ListSort2);
 
-  gamelist->Set("ColorCompressed", m_ColorCompressed);
-
   gamelist->Set("ColumnPlatform", m_showSystemColumn);
   gamelist->Set("ColumnBanner", m_showBannerColumn);
   gamelist->Set("ColumnNotes", m_showMakerColumn);
@@ -525,9 +523,6 @@ void SConfig::LoadGameListSettings(IniFile& ini)
   gamelist->Get("ListUnknown", &m_ListUnknown, true);
   gamelist->Get("ListSort", &m_ListSort, 3);
   gamelist->Get("ListSortSecondary", &m_ListSort2, 0);
-
-  // Determines if compressed games display in blue
-  gamelist->Get("ColorCompressed", &m_ColorCompressed, true);
 
   // Gamelist columns toggles
   gamelist->Get("ColumnPlatform", &m_showSystemColumn, true);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -289,9 +289,6 @@ struct SConfig : NonCopyable
   bool m_showSizeColumn;
   bool m_showStateColumn;
 
-  // Toggles whether compressed titles show up in blue in the game list
-  bool m_ColorCompressed;
-
   std::string m_WirelessMac;
   bool m_PauseMovie;
   bool m_ShowLag;

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -463,11 +463,7 @@ void CGameListCtrl::ReloadList()
 
     // add all items
     for (int i = 0; i < (int)m_ISOFiles.size(); i++)
-    {
       InsertItemInReportView(i);
-      if (SConfig::GetInstance().m_ColorCompressed && m_ISOFiles[i]->IsCompressed())
-        SetItemTextColour(i, wxColour(0xFF0000));
-    }
 
     // Sort items by Title
     if (!sorted)

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -1215,7 +1215,8 @@ void CGameListCtrl::CompressSelection(bool _compress)
     items_to_compress.push_back(iso);
 
     // Show the Wii compression warning if it's relevant and it hasn't been shown already
-    if (!wii_compression_warning_accepted && _compress && !iso->IsCompressed() &&
+    if (!wii_compression_warning_accepted && _compress &&
+        iso->GetBlobType() != DiscIO::BlobType::GCZ &&
         iso->GetPlatform() == DiscIO::Platform::WII_DISC)
     {
       if (WiiCompressWarning())
@@ -1246,7 +1247,7 @@ void CGameListCtrl::CompressSelection(bool _compress)
 
     for (const GameListItem* iso : items_to_compress)
     {
-      if (!iso->IsCompressed() && _compress)
+      if (iso->GetBlobType() != DiscIO::BlobType::GCZ && _compress)
       {
         std::string FileName;
         SplitPath(iso->GetFileName(), nullptr, &FileName, nullptr);
@@ -1268,7 +1269,7 @@ void CGameListCtrl::CompressSelection(bool _compress)
                                        (iso->GetPlatform() == DiscIO::Platform::WII_DISC) ? 1 : 0,
                                        16384, &MultiCompressCB, &progress);
       }
-      else if (iso->IsCompressed() && !_compress)
+      else if (iso->GetBlobType() == DiscIO::BlobType::GCZ && !_compress)
       {
         std::string FileName;
         SplitPath(iso->GetFileName(), nullptr, &FileName, nullptr);

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -386,9 +386,3 @@ const std::string GameListItem::GetWiiFSPath() const
 
   return ret;
 }
-
-bool GameListItem::IsCompressed() const
-{
-  return m_blob_type == DiscIO::BlobType::GCZ || m_blob_type == DiscIO::BlobType::CISO ||
-         m_blob_type == DiscIO::BlobType::WBFS;
-}

--- a/Source/Core/DolphinWX/ISOFile.h
+++ b/Source/Core/DolphinWX/ISOFile.h
@@ -53,7 +53,6 @@ public:
   DiscIO::BlobType GetBlobType() const { return m_blob_type; }
   const std::string& GetIssues() const { return m_issues; }
   int GetEmuState() const { return m_emu_state; }
-  bool IsCompressed() const;
   u64 GetFileSize() const { return m_FileSize; }
   u64 GetVolumeSize() const { return m_VolumeSize; }
   // 0 is the first disc, 1 is the second disc


### PR DESCRIPTION
- There's no clear definition of what it means for a GC/Wii game to be compressed. GC games in GCZ are obviously compressed, but what about formats like WBFS and CISO that just discard data?
- Hardcoded colors might have bad contrast with the used theme. (PR #4939 brought this to my intention.)
- It feels Windows XP to me.