### PR TITLE
JIT: Make initialization instruction tables const

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit64_Tables.cpp
@@ -38,7 +38,7 @@ struct GekkoOPTemplate
   Jit64::Instruction Inst;
 };
 
-static GekkoOPTemplate primarytable[] = {
+const GekkoOPTemplate primarytable[] = {
     {4, &Jit64::DynaRunTable4},    // RunTable4
     {19, &Jit64::DynaRunTable19},  // RunTable19
     {31, &Jit64::DynaRunTable31},  // RunTable31
@@ -108,7 +108,7 @@ static GekkoOPTemplate primarytable[] = {
     // missing: 0, 1, 2, 5, 6, 9, 22, 30, 62, 58
 };
 
-static GekkoOPTemplate table4[] = {
+const GekkoOPTemplate table4[] = {
     // SUBOP10
     {0, &Jit64::ps_cmpXX},      // ps_cmpu0
     {32, &Jit64::ps_cmpXX},     // ps_cmpo0
@@ -126,7 +126,7 @@ static GekkoOPTemplate table4[] = {
     {1014, &Jit64::FallBackToInterpreter},  // dcbz_l
 };
 
-static GekkoOPTemplate table4_2[] = {
+const GekkoOPTemplate table4_2[] = {
     {10, &Jit64::ps_sum},     // ps_sum0
     {11, &Jit64::ps_sum},     // ps_sum1
     {12, &Jit64::ps_muls},    // ps_muls0
@@ -146,14 +146,14 @@ static GekkoOPTemplate table4_2[] = {
     {31, &Jit64::fmaddXX},    // ps_nmadd
 };
 
-static GekkoOPTemplate table4_3[] = {
+const GekkoOPTemplate table4_3[] = {
     {6, &Jit64::psq_lXX},    // psq_lx
     {7, &Jit64::psq_stXX},   // psq_stx
     {38, &Jit64::psq_lXX},   // psq_lux
     {39, &Jit64::psq_stXX},  // psq_stux
 };
 
-static GekkoOPTemplate table19[] = {
+const GekkoOPTemplate table19[] = {
     {528, &Jit64::bcctrx},  // bcctrx
     {16, &Jit64::bclrx},    // bclrx
     {257, &Jit64::crXXX},   // crand
@@ -171,7 +171,7 @@ static GekkoOPTemplate table19[] = {
     {50, &Jit64::rfi},  // rfi
 };
 
-static GekkoOPTemplate table31[] = {
+const GekkoOPTemplate table31[] = {
     {266, &Jit64::addx},      // addx
     {778, &Jit64::addx},      // addox
     {10, &Jit64::arithcx},    // addcx
@@ -313,7 +313,7 @@ static GekkoOPTemplate table31[] = {
     {566, &Jit64::DoNothing},              // tlbsync
 };
 
-static GekkoOPTemplate table59[] = {
+const GekkoOPTemplate table59[] = {
     {18, &Jit64::fp_arith},  // fdivsx
     {20, &Jit64::fp_arith},  // fsubsx
     {21, &Jit64::fp_arith},  // faddsx
@@ -325,7 +325,7 @@ static GekkoOPTemplate table59[] = {
     {31, &Jit64::fmaddXX},   // fnmaddsx
 };
 
-static GekkoOPTemplate table63[] = {
+const GekkoOPTemplate table63[] = {
     {264, &Jit64::fsign},  // fabsx
     {32, &Jit64::fcmpX},   // fcmpo
     {0, &Jit64::fcmpX},    // fcmpu
@@ -344,7 +344,7 @@ static GekkoOPTemplate table63[] = {
     {711, &Jit64::mtfsfx},   // mtfsfx
 };
 
-static GekkoOPTemplate table63_2[] = {
+const GekkoOPTemplate table63_2[] = {
     {18, &Jit64::fp_arith},  // fdivx
     {20, &Jit64::fp_arith},  // fsubx
     {21, &Jit64::fp_arith},  // faddx
@@ -409,7 +409,7 @@ void Jit64::InitializeInstructionTables()
   for (int i = 0; i < 32; i++)
   {
     int fill = i << 5;
-    for (auto& tpl : table4_2)
+    for (const auto& tpl : table4_2)
     {
       int op = fill + tpl.opcode;
       dynaOpTable4[op] = tpl.Inst;
@@ -419,38 +419,38 @@ void Jit64::InitializeInstructionTables()
   for (int i = 0; i < 16; i++)
   {
     int fill = i << 6;
-    for (auto& tpl : table4_3)
+    for (const auto& tpl : table4_3)
     {
       int op = fill + tpl.opcode;
       dynaOpTable4[op] = tpl.Inst;
     }
   }
 
-  for (auto& tpl : table4)
+  for (const auto& tpl : table4)
   {
     int op = tpl.opcode;
     dynaOpTable4[op] = tpl.Inst;
   }
 
-  for (auto& tpl : table31)
+  for (const auto& tpl : table31)
   {
     int op = tpl.opcode;
     dynaOpTable31[op] = tpl.Inst;
   }
 
-  for (auto& tpl : table19)
+  for (const auto& tpl : table19)
   {
     int op = tpl.opcode;
     dynaOpTable19[op] = tpl.Inst;
   }
 
-  for (auto& tpl : table59)
+  for (const auto& tpl : table59)
   {
     int op = tpl.opcode;
     dynaOpTable59[op] = tpl.Inst;
   }
 
-  for (auto& tpl : table63)
+  for (const auto& tpl : table63)
   {
     int op = tpl.opcode;
     dynaOpTable63[op] = tpl.Inst;
@@ -459,7 +459,7 @@ void Jit64::InitializeInstructionTables()
   for (int i = 0; i < 32; i++)
   {
     int fill = i << 5;
-    for (auto& tpl : table63_2)
+    for (const auto& tpl : table63_2)
     {
       int op = fill + tpl.opcode;
       dynaOpTable63[op] = tpl.Inst;

--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL_Tables.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL_Tables.cpp
@@ -40,7 +40,7 @@ struct GekkoOPTemplate
   JitIL::Instruction Inst;
 };
 
-static GekkoOPTemplate primarytable[] = {
+const GekkoOPTemplate primarytable[] = {
     {4, &JitIL::DynaRunTable4},    //"RunTable4",  OPTYPE_SUBTABLE | (4<<24), 0}},
     {19, &JitIL::DynaRunTable19},  //"RunTable19", OPTYPE_SUBTABLE | (19<<24), 0}},
     {31, &JitIL::DynaRunTable31},  //"RunTable31", OPTYPE_SUBTABLE | (31<<24), 0}},
@@ -111,7 +111,7 @@ static GekkoOPTemplate primarytable[] = {
     // missing: 0, 1, 2, 5, 6, 9, 22, 30, 62, 58
 };
 
-static GekkoOPTemplate table4[] = {
+const GekkoOPTemplate table4[] = {
     // SUBOP10
     {0, &JitIL::FallBackToInterpreter},    //"ps_cmpu0",   OPTYPE_PS, FL_SET_CRn}},
     {32, &JitIL::FallBackToInterpreter},   //"ps_cmpo0",   OPTYPE_PS, FL_SET_CRn}},
@@ -129,7 +129,7 @@ static GekkoOPTemplate table4[] = {
     {1014, &JitIL::FallBackToInterpreter},  //"dcbz_l",     OPTYPE_SYSTEM, 0}},
 };
 
-static GekkoOPTemplate table4_2[] = {
+const GekkoOPTemplate table4_2[] = {
     {10, &JitIL::ps_sum},                 //"ps_sum0",   OPTYPE_PS, 0}},
     {11, &JitIL::ps_sum},                 //"ps_sum1",   OPTYPE_PS, 0}},
     {12, &JitIL::ps_muls},                //"ps_muls0",  OPTYPE_PS, 0}},
@@ -149,14 +149,14 @@ static GekkoOPTemplate table4_2[] = {
     {31, &JitIL::ps_maddXX},              //"ps_nmadd",  OPTYPE_PS, 0}},
 };
 
-static GekkoOPTemplate table4_3[] = {
+const GekkoOPTemplate table4_3[] = {
     {6, &JitIL::FallBackToInterpreter},   //"psq_lx",   OPTYPE_PS, 0}},
     {7, &JitIL::FallBackToInterpreter},   //"psq_stx",  OPTYPE_PS, 0}},
     {38, &JitIL::FallBackToInterpreter},  //"psq_lux",  OPTYPE_PS, 0}},
     {39, &JitIL::FallBackToInterpreter},  //"psq_stux", OPTYPE_PS, 0}},
 };
 
-static GekkoOPTemplate table19[] = {
+const GekkoOPTemplate table19[] = {
     {528, &JitIL::bcctrx},  //"bcctrx", OPTYPE_BRANCH, FL_ENDBLOCK}},
     {16, &JitIL::bclrx},    //"bclrx",  OPTYPE_BRANCH, FL_ENDBLOCK}},
     {257, &JitIL::crXX},    //"crand",  OPTYPE_CR, FL_EVIL}},
@@ -174,7 +174,7 @@ static GekkoOPTemplate table19[] = {
     {50, &JitIL::rfi},  //"rfi",    OPTYPE_SYSTEM, FL_ENDBLOCK | FL_CHECKEXCEPTIONS, 1}},
 };
 
-static GekkoOPTemplate table31[] = {
+const GekkoOPTemplate table31[] = {
     {266, &JitIL::addx},  //"addx",    OPTYPE_INTEGER, FL_OUT_D | FL_IN_AB | FL_RC_BIT}},
     {778, &JitIL::addx},  //"addox",   OPTYPE_INTEGER, FL_OUT_D | FL_IN_AB | FL_RC_BIT}},
     {10, &JitIL::FallBackToInterpreter},   //"addcx",   OPTYPE_INTEGER, FL_OUT_D | FL_IN_AB |
@@ -331,7 +331,7 @@ static GekkoOPTemplate table31[] = {
     {566, &JitIL::DoNothing},              //"tlbsync", OPTYPE_SYSTEM, 0}},
 };
 
-static GekkoOPTemplate table59[] = {
+const GekkoOPTemplate table59[] = {
     {18, &JitIL::FallBackToInterpreter},  //{"fdivsx",  OPTYPE_FPU, FL_RC_BIT_F, 16}},
     {20, &JitIL::fp_arith_s},             //"fsubsx",   OPTYPE_FPU, FL_RC_BIT_F}},
     {21, &JitIL::fp_arith_s},             //"faddsx",   OPTYPE_FPU, FL_RC_BIT_F}},
@@ -343,7 +343,7 @@ static GekkoOPTemplate table59[] = {
     {31, &JitIL::fmaddXX},                //"fnmaddsx", OPTYPE_FPU, FL_RC_BIT_F}},
 };
 
-static GekkoOPTemplate table63[] = {
+const GekkoOPTemplate table63[] = {
     {264, &JitIL::fsign},                 //"fabsx",   OPTYPE_FPU, FL_RC_BIT_F}},
     {32, &JitIL::fcmpX},                  //"fcmpo",   OPTYPE_FPU, FL_RC_BIT_F}},
     {0, &JitIL::fcmpX},                   //"fcmpu",   OPTYPE_FPU, FL_RC_BIT_F}},
@@ -362,7 +362,7 @@ static GekkoOPTemplate table63[] = {
     {711, &JitIL::FallBackToInterpreter},  //"mtfsfx",  OPTYPE_SYSTEMFP, 0, 2}},
 };
 
-static GekkoOPTemplate table63_2[] = {
+const GekkoOPTemplate table63_2[] = {
     {18, &JitIL::FallBackToInterpreter},  //"fdivx",    OPTYPE_FPU, FL_RC_BIT_F, 30}},
     {20, &JitIL::FallBackToInterpreter},  //"fsubx",    OPTYPE_FPU, FL_RC_BIT_F}},
     {21, &JitIL::FallBackToInterpreter},  //"faddx",    OPTYPE_FPU, FL_RC_BIT_F}},
@@ -424,7 +424,7 @@ void JitIL::InitializeInstructionTables()
     dynaOpTable63[i] = &JitIL::FallBackToInterpreter;
   }
 
-  for (auto& tpl : primarytable)
+  for (const auto& tpl : primarytable)
   {
     dynaOpTable[tpl.opcode] = tpl.Inst;
   }
@@ -432,7 +432,7 @@ void JitIL::InitializeInstructionTables()
   for (int i = 0; i < 32; i++)
   {
     int fill = i << 5;
-    for (auto& tpl : table4_2)
+    for (const auto& tpl : table4_2)
     {
       int op = fill + tpl.opcode;
       dynaOpTable4[op] = tpl.Inst;
@@ -442,38 +442,38 @@ void JitIL::InitializeInstructionTables()
   for (int i = 0; i < 16; i++)
   {
     int fill = i << 6;
-    for (auto& tpl : table4_3)
+    for (const auto& tpl : table4_3)
     {
       int op = fill + tpl.opcode;
       dynaOpTable4[op] = tpl.Inst;
     }
   }
 
-  for (auto& tpl : table4)
+  for (const auto& tpl : table4)
   {
     int op = tpl.opcode;
     dynaOpTable4[op] = tpl.Inst;
   }
 
-  for (auto& tpl : table31)
+  for (const auto& tpl : table31)
   {
     int op = tpl.opcode;
     dynaOpTable31[op] = tpl.Inst;
   }
 
-  for (auto& tpl : table19)
+  for (const auto& tpl : table19)
   {
     int op = tpl.opcode;
     dynaOpTable19[op] = tpl.Inst;
   }
 
-  for (auto& tpl : table59)
+  for (const auto& tpl : table59)
   {
     int op = tpl.opcode;
     dynaOpTable59[op] = tpl.Inst;
   }
 
-  for (auto& tpl : table63)
+  for (const auto& tpl : table63)
   {
     int op = tpl.opcode;
     dynaOpTable63[op] = tpl.Inst;
@@ -482,7 +482,7 @@ void JitIL::InitializeInstructionTables()
   for (int i = 0; i < 32; i++)
   {
     int fill = i << 5;
-    for (auto& tpl : table63_2)
+    for (const auto& tpl : table63_2)
     {
       int op = fill + tpl.opcode;
       dynaOpTable63[op] = tpl.Inst;

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Tables.cpp
@@ -47,7 +47,7 @@ struct GekkoOPTemplate
   // GekkoOPInfo opinfo; // Doesn't need opinfo, Interpreter fills it out
 };
 
-static GekkoOPTemplate primarytable[] = {
+constexpr GekkoOPTemplate primarytable[] = {
     {4, &JitArm64::DynaRunTable4},    // RunTable4
     {19, &JitArm64::DynaRunTable19},  // RunTable19
     {31, &JitArm64::DynaRunTable31},  // RunTable31
@@ -117,7 +117,7 @@ static GekkoOPTemplate primarytable[] = {
     // missing: 0, 1, 2, 5, 6, 9, 22, 30, 62, 58
 };
 
-static GekkoOPTemplate table4[] = {
+constexpr GekkoOPTemplate table4[] = {
     // SUBOP10
     {0, &JitArm64::FallBackToInterpreter},   // ps_cmpu0
     {32, &JitArm64::FallBackToInterpreter},  // ps_cmpo0
@@ -135,7 +135,7 @@ static GekkoOPTemplate table4[] = {
     {1014, &JitArm64::FallBackToInterpreter},  // dcbz_l
 };
 
-static GekkoOPTemplate table4_2[] = {
+constexpr GekkoOPTemplate table4_2[] = {
     {10, &JitArm64::ps_sumX},                // ps_sum0
     {11, &JitArm64::ps_sumX},                // ps_sum1
     {12, &JitArm64::ps_mulsX},               // ps_muls0
@@ -155,14 +155,14 @@ static GekkoOPTemplate table4_2[] = {
     {31, &JitArm64::ps_maddXX},              // ps_nmadd
 };
 
-static GekkoOPTemplate table4_3[] = {
+constexpr GekkoOPTemplate table4_3[] = {
     {6, &JitArm64::FallBackToInterpreter},   // psq_lx
     {7, &JitArm64::FallBackToInterpreter},   // psq_stx
     {38, &JitArm64::FallBackToInterpreter},  // psq_lux
     {39, &JitArm64::FallBackToInterpreter},  // psq_stux
 };
 
-static GekkoOPTemplate table19[] = {
+constexpr GekkoOPTemplate table19[] = {
     {528, &JitArm64::bcctrx},  // bcctrx
     {16, &JitArm64::bclrx},    // bclrx
     {257, &JitArm64::crXXX},   // crand
@@ -180,7 +180,7 @@ static GekkoOPTemplate table19[] = {
     {50, &JitArm64::rfi},  // rfi
 };
 
-static GekkoOPTemplate table31[] = {
+constexpr GekkoOPTemplate table31[] = {
     {266, &JitArm64::addx},                   // addx
     {778, &JitArm64::addx},                   // addox
     {10, &JitArm64::addcx},                   // addcx
@@ -322,7 +322,7 @@ static GekkoOPTemplate table31[] = {
     {566, &JitArm64::DoNothing},              // tlbsync
 };
 
-static GekkoOPTemplate table59[] = {
+constexpr GekkoOPTemplate table59[] = {
     {18, &JitArm64::fp_arith},               // fdivsx
     {20, &JitArm64::fp_arith},               // fsubsx
     {21, &JitArm64::fp_arith},               // faddsx
@@ -334,7 +334,7 @@ static GekkoOPTemplate table59[] = {
     {31, &JitArm64::fp_arith},               // fnmaddsx
 };
 
-static GekkoOPTemplate table63[] = {
+constexpr GekkoOPTemplate table63[] = {
     {264, &JitArm64::fp_logic},              // fabsx
     {32, &JitArm64::fcmpX},                  // fcmpo
     {0, &JitArm64::fcmpX},                   // fcmpu
@@ -353,7 +353,7 @@ static GekkoOPTemplate table63[] = {
     {711, &JitArm64::FallBackToInterpreter},  // mtfsfx
 };
 
-static GekkoOPTemplate table63_2[] = {
+constexpr GekkoOPTemplate table63_2[] = {
     {18, &JitArm64::fp_arith},               // fdivx
     {20, &JitArm64::fp_arith},               // fsubx
     {21, &JitArm64::fp_arith},               // faddx
@@ -397,9 +397,9 @@ void JitArm64::InitializeInstructionTables()
     tpl = &JitArm64::FallBackToInterpreter;
   }
 
-  for (int i = 0; i < 32; i++)
+  for (auto& tpl : dynaOpTable59)
   {
-    dynaOpTable59[i] = &JitArm64::FallBackToInterpreter;
+    tpl = &JitArm64::FallBackToInterpreter;
   }
 
   for (int i = 0; i < 1024; i++)
@@ -410,68 +410,63 @@ void JitArm64::InitializeInstructionTables()
     dynaOpTable63[i] = &JitArm64::FallBackToInterpreter;
   }
 
-  for (int i = 0; i < (int)(sizeof(primarytable) / sizeof(GekkoOPTemplate)); i++)
+  for (const auto& tpl : primarytable)
   {
-    dynaOpTable[primarytable[i].opcode] = primarytable[i].Inst;
+    dynaOpTable[tpl.opcode] = tpl.Inst;
   }
 
   for (int i = 0; i < 32; i++)
   {
     int fill = i << 5;
-    for (int j = 0; j < (int)(sizeof(table4_2) / sizeof(GekkoOPTemplate)); j++)
+    for (const auto& tpl : table4_2)
     {
-      int op = fill + table4_2[j].opcode;
-      dynaOpTable4[op] = table4_2[j].Inst;
+      int op = fill + tpl.opcode;
+      dynaOpTable4[op] = tpl.Inst;
     }
   }
 
   for (int i = 0; i < 16; i++)
   {
     int fill = i << 6;
-    for (int j = 0; j < (int)(sizeof(table4_3) / sizeof(GekkoOPTemplate)); j++)
+    for (const auto& tpl : table4_3)
     {
-      int op = fill + table4_3[j].opcode;
-      dynaOpTable4[op] = table4_3[j].Inst;
+      int op = fill + tpl.opcode;
+      dynaOpTable4[op] = tpl.Inst;
     }
   }
 
-  for (int i = 0; i < (int)(sizeof(table4) / sizeof(GekkoOPTemplate)); i++)
+  for (const auto& tpl : table4)
   {
-    int op = table4[i].opcode;
-    dynaOpTable4[op] = table4[i].Inst;
+    dynaOpTable4[tpl.opcode] = tpl.Inst;
   }
 
-  for (int i = 0; i < (int)(sizeof(table31) / sizeof(GekkoOPTemplate)); i++)
+  for (const auto& tpl : table31)
   {
-    int op = table31[i].opcode;
-    dynaOpTable31[op] = table31[i].Inst;
+    dynaOpTable31[tpl.opcode] = tpl.Inst;
   }
 
-  for (int i = 0; i < (int)(sizeof(table19) / sizeof(GekkoOPTemplate)); i++)
+  for (const auto& tpl : table19)
   {
-    int op = table19[i].opcode;
-    dynaOpTable19[op] = table19[i].Inst;
+    dynaOpTable19[tpl.opcode] = tpl.Inst;
   }
 
-  for (int i = 0; i < (int)(sizeof(table59) / sizeof(GekkoOPTemplate)); i++)
+  for (const auto& tpl : table59)
   {
-    int op = table59[i].opcode;
-    dynaOpTable59[op] = table59[i].Inst;
+    dynaOpTable59[tpl.opcode] = tpl.Inst;
   }
 
-  for (int i = 0; i < (int)(sizeof(table63) / sizeof(GekkoOPTemplate)); i++)
+  for (const auto& tpl : table63)
   {
-    int op = table63[i].opcode;
-    dynaOpTable63[op] = table63[i].Inst;
+    dynaOpTable63[tpl.opcode] = tpl.Inst;
   }
 
   for (int i = 0; i < 32; i++)
   {
     int fill = i << 5;
-    for (int j = 0; j < (int)(sizeof(table63_2) / sizeof(GekkoOPTemplate)); j++)
+    for (const auto& tpl : table63_2)
     {
-      int op = fill + table63_2[j].opcode;
-      dynaOpTable63[op] = table63_2[j].Inst;
+      int op = fill + tpl.opcode;
+      dynaOpTable63[op] = tpl.Inst;
     }
   }
 


### PR DESCRIPTION
Fairly self-explanatory. Prevents unintentional modification of the table data.

Makes the Jit64 and JitIL tables const. They can't be made constexpr, because they currently cause an internal compiler exception in MSVC. When the next final version of MSVC is released, I'll revisit that issue. However, the ARM tables can be made constexpr, as they aren't built through MSVC.