### PR TITLE
Framedump extensions

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -144,8 +144,17 @@ bool AVIDump::CreateVideoFile()
   }
 
   const std::string& codec_name = g_Config.bUseFFV1 ? "ffv1" : g_Config.sDumpCodec;
-  const AVCodecDescriptor* codec_desc = avcodec_descriptor_get_by_name(codec_name.c_str());
-  AVCodecID codec_id = codec_desc ? codec_desc->id : output_format->video_codec;
+
+  AVCodecID codec_id = output_format->video_codec;
+
+  if (!codec_name.empty())
+  {
+    const AVCodecDescriptor* codec_desc = avcodec_descriptor_get_by_name(codec_name.c_str());
+    if (codec_desc)
+      codec_id = codec_desc->id;
+    else
+      WARN_LOG(VIDEO, "Invalid codec %s", codec_name.c_str());
+  }
 
   const AVCodec* codec = nullptr;
 

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -96,8 +96,6 @@ bool AVIDump::Start(int w, int h)
 
 bool AVIDump::CreateVideoFile()
 {
-  AVCodec* codec = nullptr;
-
   const std::string& s_format = g_Config.sDumpFormat;
 
   std::stringstream file_ss;
@@ -130,8 +128,10 @@ bool AVIDump::CreateVideoFile()
   }
   avformat_alloc_output_context2(&s_format_context, output_format, nullptr, filename.c_str());
 
-  AVCodecID codec_id =
-      g_Config.bUseFFV1 ? AV_CODEC_ID_FFV1 : output_format->video_codec;
+  const AVCodecDescriptor* codec_desc = avcodec_descriptor_get_by_name(g_Config.sDumpCodec.c_str());
+  AVCodecID codec_id = codec_desc ? codec_desc->id : output_format->video_codec;
+
+  const AVCodec* codec = nullptr;
 
   if (!(codec = avcodec_find_encoder(codec_id)) ||
       !(s_codec_context = avcodec_alloc_context3(codec)))

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -159,6 +159,9 @@ bool AVIDump::CreateVideoFile()
   s_codec_context->gop_size = 12;
   s_codec_context->pix_fmt = g_Config.bUseFFV1 ? AV_PIX_FMT_BGRA : AV_PIX_FMT_YUV420P;
 
+  if (output_format->flags & AVFMT_GLOBALHEADER)
+    s_codec_context->flags |= CODEC_FLAG_GLOBAL_HEADER;
+
   if (avcodec_open2(s_codec_context, codec, nullptr) < 0)
   {
     WARN_LOG(VIDEO, "Could not open codec.");

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -98,7 +98,7 @@ bool AVIDump::CreateVideoFile()
 {
   AVCodec* codec = nullptr;
 
-  const char s_format[] = "avi";
+  const std::string& s_format = g_Config.sDumpFormat;
 
   std::stringstream file_ss;
   file_ss << File::GetUserPath(D_DUMPFRAMES_IDX)
@@ -122,8 +122,12 @@ bool AVIDump::CreateVideoFile()
     }
   }
 
-  AVOutputFormat* output_format = av_guess_format(s_format, filename.c_str(), nullptr);
-  if (!output_format) return false;
+  AVOutputFormat* output_format = av_guess_format(s_format.c_str(), filename.c_str(), nullptr);
+  if (!output_format)
+  {
+    WARN_LOG(VIDEO, "Invalid format %s", s_format.c_str());
+    return false;
+  }
   avformat_alloc_output_context2(&s_format_context, output_format, nullptr, filename.c_str());
 
   AVCodecID codec_id =

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -140,9 +140,10 @@ bool AVIDump::CreateVideoFile()
     return false;
   }
 
-  if (!g_Config.bUseFFV1)
-    s_codec_context->codec_tag =
-        MKTAG('X', 'V', 'I', 'D');  // Force XVID FourCC for better compatibility
+  // Force XVID FourCC for better compatibility
+  if (codec->id == AV_CODEC_ID_MPEG4)
+    s_codec_context->codec_tag = MKTAG('X', 'V', 'I', 'D');
+
   s_codec_context->codec_type = AVMEDIA_TYPE_VIDEO;
   s_codec_context->bit_rate = g_Config.iBitrateKbps * 1000;
   s_codec_context->width = s_width;

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -136,6 +136,7 @@ bool AVIDump::CreateVideoFile()
   if (!(codec = avcodec_find_encoder(codec_id)) ||
       !(s_codec_context = avcodec_alloc_context3(codec)))
   {
+    WARN_LOG(VIDEO, "Could not find encoder or allocate codec context.");
     return false;
   }
 
@@ -153,6 +154,7 @@ bool AVIDump::CreateVideoFile()
 
   if (avcodec_open2(s_codec_context, codec, nullptr) < 0)
   {
+    WARN_LOG(VIDEO, "Could not open codec.");
     return false;
   }
 
@@ -174,6 +176,7 @@ bool AVIDump::CreateVideoFile()
   if (!(s_stream = avformat_new_stream(s_format_context, codec)) ||
       !AVStreamCopyContext(s_stream, s_codec_context))
   {
+    WARN_LOG(VIDEO, "Could not create stream.");
     return false;
   }
 

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -139,7 +139,8 @@ bool AVIDump::CreateVideoFile()
     return false;
   }
 
-  const AVCodecDescriptor* codec_desc = avcodec_descriptor_get_by_name(g_Config.sDumpCodec.c_str());
+  const std::string& codec_name = g_Config.bUseFFV1 ? "ffv1" : g_Config.sDumpCodec;
+  const AVCodecDescriptor* codec_desc = avcodec_descriptor_get_by_name(codec_name.c_str());
   AVCodecID codec_id = codec_desc ? codec_desc->id : output_format->video_codec;
 
   const AVCodec* codec = nullptr;

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -101,7 +101,7 @@ static std::string GetDumpPath(const std::string& format)
     return g_Config.sDumpPath;
 
   std::string s_dump_path = File::GetUserPath(D_DUMPFRAMES_IDX) + "framedump" +
-    std::to_string(s_file_index) + "." + format;
+                            std::to_string(s_file_index) + "." + format;
 
   // Ask to delete file
   if (File::Exists(s_dump_path))
@@ -136,8 +136,9 @@ bool AVIDump::CreateVideoFile()
     ERROR_LOG(VIDEO, "Invalid format %s", s_format.c_str());
     return false;
   }
-  
-  if(avformat_alloc_output_context2(&s_format_context, output_format, nullptr, s_dump_path.c_str()) < 0)
+
+  if (avformat_alloc_output_context2(&s_format_context, output_format, nullptr,
+                                     s_dump_path.c_str()) < 0)
   {
     ERROR_LOG(VIDEO, "Could not allocate output context");
     return false;
@@ -362,10 +363,10 @@ static void HandleDelayedPackets()
       ERROR_LOG(VIDEO, "Error while stopping video: %d", error);
       break;
     }
-    
+
     if (!got_packet)
       break;
-    
+
     WritePacket(pkt);
   }
 }

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -77,6 +77,7 @@ void VideoConfig::Load(const std::string& ini_file)
   settings->Get("UseFFV1", &bUseFFV1, false);
   settings->Get("DumpFormat", &sDumpFormat, "avi");
   settings->Get("DumpCodec", &sDumpCodec, "");
+  settings->Get("DumpPath", &sDumpPath, "");
   settings->Get("BitrateKbps", &iBitrateKbps, 2500);
   settings->Get("InternalResolutionFrameDumps", &bInternalResolutionFrameDumps, false);
   settings->Get("EnablePixelLighting", &bEnablePixelLighting, false);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -75,6 +75,7 @@ void VideoConfig::Load(const std::string& ini_file)
   settings->Get("DumpFramesAsImages", &bDumpFramesAsImages, false);
   settings->Get("FreeLook", &bFreeLook, false);
   settings->Get("UseFFV1", &bUseFFV1, false);
+  settings->Get("DumpFormat", &sDumpFormat, "avi");
   settings->Get("BitrateKbps", &iBitrateKbps, 2500);
   settings->Get("InternalResolutionFrameDumps", &bInternalResolutionFrameDumps, false);
   settings->Get("EnablePixelLighting", &bEnablePixelLighting, false);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -298,6 +298,9 @@ void VideoConfig::Save(const std::string& ini_file)
   settings->Set("DumpFramesAsImages", bDumpFramesAsImages);
   settings->Set("FreeLook", bFreeLook);
   settings->Set("UseFFV1", bUseFFV1);
+  settings->Set("DumpFormat", sDumpFormat);
+  settings->Set("DumpCodec", sDumpCodec);
+  settings->Set("DumpPath", sDumpPath);
   settings->Set("BitrateKbps", iBitrateKbps);
   settings->Set("InternalResolutionFrameDumps", bInternalResolutionFrameDumps);
   settings->Set("EnablePixelLighting", bEnablePixelLighting);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -76,6 +76,7 @@ void VideoConfig::Load(const std::string& ini_file)
   settings->Get("FreeLook", &bFreeLook, false);
   settings->Get("UseFFV1", &bUseFFV1, false);
   settings->Get("DumpFormat", &sDumpFormat, "avi");
+  settings->Get("DumpCodec", &sDumpCodec, "");
   settings->Get("BitrateKbps", &iBitrateKbps, 2500);
   settings->Get("InternalResolutionFrameDumps", &bInternalResolutionFrameDumps, false);
   settings->Get("EnablePixelLighting", &bEnablePixelLighting, false);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -102,6 +102,7 @@ struct VideoConfig final
   bool bDumpEFBTarget;
   bool bDumpFramesAsImages;
   bool bUseFFV1;
+  std::string sDumpCodec;
   std::string sDumpFormat;
   bool bInternalResolutionFrameDumps;
   bool bFreeLook;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -102,6 +102,7 @@ struct VideoConfig final
   bool bDumpEFBTarget;
   bool bDumpFramesAsImages;
   bool bUseFFV1;
+  std::string sDumpFormat;
   bool bInternalResolutionFrameDumps;
   bool bFreeLook;
   bool bBorderlessFullscreen;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -104,6 +104,7 @@ struct VideoConfig final
   bool bUseFFV1;
   std::string sDumpCodec;
   std::string sDumpFormat;
+  std::string sDumpPath;
   bool bInternalResolutionFrameDumps;
   bool bFreeLook;
   bool bBorderlessFullscreen;


### PR DESCRIPTION
Extends framedumping with configurable format, codec, and even url! This can be used stream directly services such as Twitch and Youtube Live.

- [x] Support fixing the output resolution. This is probably necessary for streaming.
- [x] Do something about pixel format.
- [x] UseFFV1 is now useless. It should be removed.
- [ ] The new GFX.ini options should probably be in a gui somewhere.