### PR TITLE
JitInterface: Amend ExceptionType enum value names

### DIFF
--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -98,7 +98,7 @@ void CheckGatherPipe()
     UpdateGatherPipe();
 
     // Profile where slow FIFO writes are occurring.
-    JitInterface::CompileExceptionCheck(JitInterface::ExceptionType::EXCEPTIONS_FIFO_WRITE);
+    JitInterface::CompileExceptionCheck(JitInterface::ExceptionType::FIFOWrite);
   }
 }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -692,7 +692,7 @@ const u8* Jit64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
       MOV(32, PPCSTATE(pc), Imm32(js.blockStart));
       ABI_PushRegistersAndAdjustStack({}, 0);
       ABI_CallFunctionC(JitInterface::CompileExceptionCheck,
-                        (u32)JitInterface::ExceptionType::EXCEPTIONS_PAIRED_QUANTIZE);
+                        static_cast<u32>(JitInterface::ExceptionType::PairedQuantize));
       ABI_PopRegistersAndAdjustStack({}, 0);
       JMP(asm_routines.dispatcherNoCheck, true);
       SwitchToNearCode();
@@ -1015,9 +1015,8 @@ void Jit64::IntializeSpeculativeConstants()
         target = GetCodePtr();
         MOV(32, PPCSTATE(pc), Imm32(js.blockStart));
         ABI_PushRegistersAndAdjustStack({}, 0);
-        ABI_CallFunctionC(
-            JitInterface::CompileExceptionCheck,
-            static_cast<u32>(JitInterface::ExceptionType::EXCEPTIONS_SPECULATIVE_CONSTANTS));
+        ABI_CallFunctionC(JitInterface::CompileExceptionCheck,
+                          static_cast<u32>(JitInterface::ExceptionType::SpeculativeConstants));
         ABI_PopRegistersAndAdjustStack({}, 0);
         JMP(asm_routines.dispatcher, true);
         SwitchToNearCode();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -712,7 +712,7 @@ void JitArm64::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBlock*
       SetJumpTarget(fail);
       MOVI2R(DISPATCHER_PC, js.blockStart);
       STR(INDEX_UNSIGNED, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
-      MOVI2R(W0, (u32)JitInterface::ExceptionType::EXCEPTIONS_PAIRED_QUANTIZE);
+      MOVI2R(W0, static_cast<u32>(JitInterface::ExceptionType::PairedQuantize));
       MOVP2R(X1, &JitInterface::CompileExceptionCheck);
       BLR(X1);
       B(dispatcher);

--- a/Source/Core/Core/PowerPC/JitInterface.cpp
+++ b/Source/Core/Core/PowerPC/JitInterface.cpp
@@ -220,20 +220,20 @@ void CompileExceptionCheck(ExceptionType type)
 
   switch (type)
   {
-  case ExceptionType::EXCEPTIONS_FIFO_WRITE:
+  case ExceptionType::FIFOWrite:
     exception_addresses = &g_jit->js.fifoWriteAddresses;
     break;
-  case ExceptionType::EXCEPTIONS_PAIRED_QUANTIZE:
+  case ExceptionType::PairedQuantize:
     exception_addresses = &g_jit->js.pairedQuantizeAddresses;
     break;
-  case ExceptionType::EXCEPTIONS_SPECULATIVE_CONSTANTS:
+  case ExceptionType::SpeculativeConstants:
     exception_addresses = &g_jit->js.noSpeculativeConstantsAddresses;
     break;
   }
 
   if (PC != 0 && (exception_addresses->find(PC)) == (exception_addresses->end()))
   {
-    if (type == ExceptionType::EXCEPTIONS_FIFO_WRITE)
+    if (type == ExceptionType::FIFOWrite)
     {
       // Check in case the code has been replaced since: do we need to do this?
       int optype = GetOpInfo(PowerPC::HostRead_U32(PC))->type;

--- a/Source/Core/Core/PowerPC/JitInterface.h
+++ b/Source/Core/Core/PowerPC/JitInterface.h
@@ -14,9 +14,9 @@ namespace JitInterface
 {
 enum class ExceptionType
 {
-  EXCEPTIONS_FIFO_WRITE,
-  EXCEPTIONS_PAIRED_QUANTIZE,
-  EXCEPTIONS_SPECULATIVE_CONSTANTS
+  FIFOWrite,
+  PairedQuantize,
+  SpeculativeConstants
 };
 
 void DoState(PointerWrap& p);


### PR DESCRIPTION
Since ExceptionType is an enum class, its name already acts like the common prefix