### PR TITLE
Force Wallace and Gromit in Pet Zoo to use smaller memory card

### DIFF
--- a/Data/Sys/GameSettings/GWL.ini
+++ b/Data/Sys/GameSettings/GWL.ini
@@ -2,6 +2,7 @@
 
 [Core]
 # Values set here will override the main Dolphin settings.
+MemoryCard251 = True
 
 [EmuState]
 # The Emulation State. 1 is worst, 5 is best, 0 is not set.

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -130,6 +130,7 @@ CEXIMemoryCard::CEXIMemoryCard(const int index, bool gciFolder) : card_index(ind
   // WTA Tour Tennis GWTEA4 GWTJA4 GWTPA4
   // Disney Sports : Skate Boarding GDXEA4 GDXPA4 GDXJA4
   // Disney Sports : Soccer GDKEA4
+  // Wallace and Gromit in Pet Zoo GWLE6L GWLX6L
   // Use a 16Mb (251 block) memory card for these games
   bool useMC251;
   IniFile gameIni = SConfig::GetInstance().LoadGameIni();


### PR DESCRIPTION
It does not support the 64MB memory card and when using it will silently fail at saving.