### PR TITLE
Wiimote Netplay: Sync button press for reconnect

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -21,6 +21,9 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/InputConfig.h"
 
+// Limit the amount of wiimote connect requests, when a button is pressed in disconnected state
+std::array<u8, 4> last_connect_request_counter;
+
 namespace Wiimote
 {
 static InputConfig s_config(WIIMOTE_INI_NAME, _trans("Wii Remote"), "Wiimote");
@@ -78,7 +81,7 @@ void Initialize(InitializeMode init_mode)
 
   g_controller_interface.RegisterHotplugCallback(LoadConfig);
 
-  s_config.LoadConfig(false);
+  LoadConfig();
 
   WiimoteReal::Initialize(init_mode);
 
@@ -115,6 +118,7 @@ void ResetAllWiimotes()
 void LoadConfig()
 {
   s_config.LoadConfig(false);
+  last_connect_request_counter.fill(0);
 }
 
 void Resume()
@@ -143,6 +147,26 @@ void InterruptChannel(int number, u16 channel_id, const void* data, u32 size)
         ->InterruptChannel(channel_id, data, size);
 }
 
+bool ButtonPressed(int number)
+{
+  if (last_connect_request_counter[number] > 0)
+  {
+    --last_connect_request_counter[number];
+    return false;
+  }
+
+  bool button_pressed = false;
+
+  if (WIIMOTE_SRC_EMU & g_wiimote_sources[number])
+    button_pressed =
+        static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->CheckForButtonPress();
+
+  if (WIIMOTE_SRC_REAL & g_wiimote_sources[number])
+    button_pressed = WiimoteReal::CheckForButtonPress(number);
+
+  return button_pressed;
+}
+
 // This function is called periodically by the Core to update Wiimote state.
 void Update(int number, bool connected)
 {
@@ -155,11 +179,13 @@ void Update(int number, bool connected)
   }
   else
   {
-    if (WIIMOTE_SRC_EMU & g_wiimote_sources[number])
-      static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number))->ConnectOnInput();
-
-    if (WIIMOTE_SRC_REAL & g_wiimote_sources[number])
-      WiimoteReal::ConnectOnInput(number);
+    if (ButtonPressed(number))
+    {
+      Connect(number, true);
+      // arbitrary value so it doesn't try to send multiple requests before Dolphin can react
+      // if Wii Remotes are polled at 200Hz then this results in one request being sent per 500ms
+      last_connect_request_counter[number] = 100;
+    }
   }
 }
 

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -76,6 +76,7 @@ ControllerEmu::ControlGroup* GetTurntableGroup(int number, WiimoteEmu::Turntable
 
 void ControlChannel(int number, u16 channel_id, const void* data, u32 size);
 void InterruptChannel(int number, u16 channel_id, const void* data, u32 size);
+bool ButtonPressed(int number);
 void Update(int number, bool connected);
 }
 

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -78,6 +78,7 @@ void ControlChannel(int number, u16 channel_id, const void* data, u32 size);
 void InterruptChannel(int number, u16 channel_id, const void* data, u32 size);
 bool ButtonPressed(int number);
 void Update(int number, bool connected);
+bool NetPlay_GetButtonPress(int wiimote, bool pressed);
 }
 
 namespace WiimoteReal

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -27,7 +27,6 @@
 #include "Core/HW/WiimoteEmu/Attachment/Turntable.h"
 #include "Core/HW/WiimoteEmu/MatrixMath.h"
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
-#include "Core/Host.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayClient.h"
 
@@ -251,8 +250,7 @@ void Wiimote::Reset()
   m_adpcm_state.step = 127;
 }
 
-Wiimote::Wiimote(const unsigned int index)
-    : m_index(index), ir_sin(0), ir_cos(1), m_last_connect_request_counter(0)
+Wiimote::Wiimote(const unsigned int index) : m_index(index), ir_sin(0), ir_cos(1)
 {
   // ---- set up all the controls ----
 
@@ -933,26 +931,14 @@ void Wiimote::InterruptChannel(const u16 channel_id, const void* data, u32 size)
   }
 }
 
-void Wiimote::ConnectOnInput()
+bool Wiimote::CheckForButtonPress()
 {
-  if (m_last_connect_request_counter > 0)
-  {
-    --m_last_connect_request_counter;
-    return;
-  }
-
   u16 buttons = 0;
   const auto lock = GetStateLock();
   m_buttons->GetState(&buttons, button_bitmasks);
   m_dpad->GetState(&buttons, dpad_bitmasks);
 
-  if (buttons != 0 || m_extension->IsButtonPressed())
-  {
-    ::Wiimote::Connect(m_index, true);
-    // arbitrary value so it doesn't try to send multiple requests before Dolphin can react
-    // if Wii Remotes are polled at 200Hz then this results in one request being sent per 500ms
-    m_last_connect_request_counter = 100;
-  }
+  return (buttons != 0 || m_extension->IsButtonPressed());
 }
 
 void Wiimote::LoadDefaults(const ControllerInterface& ciface)

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -201,7 +201,7 @@ public:
   void Update();
   void InterruptChannel(const u16 channel_id, const void* data, u32 size);
   void ControlChannel(const u16 channel_id, const void* data, u32 size);
-  void ConnectOnInput();
+  bool CheckForButtonPress();
   void Reset();
 
   void DoState(PointerWrap& p);
@@ -327,9 +327,6 @@ private:
     u8 play;
     u8 unk_9;
   } m_reg_speaker;
-
-  // limits the amount of connect requests we send when a button is pressed in disconnected state
-  u8 m_last_connect_request_counter;
 
 #pragma pack(pop)
 };

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -36,7 +36,7 @@ public:
   void ControlChannel(const u16 channel, const void* const data, const u32 size);
   void InterruptChannel(const u16 channel, const void* const data, const u32 size);
   void Update();
-  void ConnectOnInput();
+  bool CheckForButtonPress();
 
   Report& ProcessReadQueue();
 
@@ -83,7 +83,6 @@ protected:
   int m_index;
   Report m_last_input_report;
   u16 m_channel;
-  u8 m_last_connect_request_counter;
   // If true, the Wiimote will be really disconnected when it is disconnected by Dolphin.
   // In any other case, data reporting is not paused to allow reconnecting on any button press.
   // This is not enabled on all platforms as connecting a Wiimote can be a pain on some platforms.
@@ -159,7 +158,7 @@ extern Wiimote* g_wiimotes[MAX_BBMOTES];
 void InterruptChannel(int wiimote_number, u16 channel_id, const void* data, u32 size);
 void ControlChannel(int wiimote_number, u16 channel_id, const void* data, u32 size);
 void Update(int wiimote_number);
-void ConnectOnInput(int wiimote_number);
+bool CheckForButtonPress(int wiimote_number);
 
 void ChangeWiimoteSource(unsigned int index, int source);
 


### PR DESCRIPTION
When a wiimote is not connected, sync the info whether a button on the wiimote was pressed, and then reconnect on all clients.

The 1st commit moves the reconnect on button press logic to Wiimote.cpp, deduplicating some code. This should also help when implementing the reconnect on button press feature for TAS/Movie.