### PR TITLE
Netplay: Change Wiimote sources before booting

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -820,16 +820,11 @@ bool NetPlayClient::StartGame(const std::string& path)
     Movie::BeginRecordingInput(controllers_mask);
   }
 
+  for (unsigned int i = 0; i < 4; ++i)
+    WiimoteReal::ChangeWiimoteSource(i, m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);
+
   // boot game
-
   m_dialog->BootGame(path);
-
-  if (SConfig::GetInstance().bWii)
-  {
-    for (unsigned int i = 0; i < 4; ++i)
-      WiimoteReal::ChangeWiimoteSource(i,
-                                       m_wiimote_map[i] > 0 ? WIIMOTE_SRC_EMU : WIIMOTE_SRC_NONE);
-  }
 
   UpdateDevices();
 


### PR DESCRIPTION
It is kind of silly to connect all of the configured Wii remotes (from the user config; NOT netplay assigned remotes), then connect/disconnect additional Wii remotes *after* the core has booted.

(The bWii check has been removed, because it's actually unneeded; m_wiimote_map is always usable regardless of bWii. And we can't get info about the currently running game without booting the core with our current config system…)

This should fix Netplay trying to connect all configured Wii remotes.