### PR TITLE
CachedInterpreter: Forward declare instruction struct

### DIFF
--- a/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
+++ b/Source/Core/Core/PowerPC/CachedInterpreter/CachedInterpreter.h
@@ -14,8 +14,9 @@
 class CachedInterpreter : public JitBase
 {
 public:
-  CachedInterpreter() : code_buffer(32000) {}
-  ~CachedInterpreter() {}
+  CachedInterpreter();
+  ~CachedInterpreter();
+
   void Init() override;
   void Shutdown() override;
 
@@ -31,32 +32,9 @@ public:
   const char* GetName() override { return "Cached Interpreter"; }
   const CommonAsmRoutinesBase* GetAsmRoutines() override { return nullptr; }
 private:
-  struct Instruction
-  {
-    typedef void (*CommonCallback)(UGeckoInstruction);
-    typedef bool (*ConditionalCallback)(u32 data);
+  struct Instruction;
 
-    Instruction() : type(INSTRUCTION_ABORT){};
-    Instruction(const CommonCallback c, UGeckoInstruction i)
-        : common_callback(c), data(i.hex), type(INSTRUCTION_TYPE_COMMON){};
-    Instruction(const ConditionalCallback c, u32 d)
-        : conditional_callback(c), data(d), type(INSTRUCTION_TYPE_CONDITIONAL){};
-
-    union
-    {
-      const CommonCallback common_callback;
-      const ConditionalCallback conditional_callback;
-    };
-    u32 data;
-    enum
-    {
-      INSTRUCTION_ABORT,
-      INSTRUCTION_TYPE_COMMON,
-      INSTRUCTION_TYPE_CONDITIONAL,
-    } type;
-  };
-
-  const u8* GetCodePtr() { return (u8*)(m_code.data() + m_code.size()); }
+  const u8* GetCodePtr() const;
   void ExecuteOneBlock();
 
   BlockCache m_block_cache{*this};


### PR DESCRIPTION
Allows changes to be made to the instruction struct without recompiling other source files.