### PR TITLE
JitBase: Put constructor and destructor in the cpp file

### DIFF
--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -23,6 +23,10 @@ u32 Helper_Mask(u8 mb, u8 me)
   return mb > me ? ~mask : mask;
 }
 
+JitBase::JitBase() = default;
+
+JitBase::~JitBase() = default;
+
 bool JitBase::MergeAllowedNextInstructions(int count)
 {
   if (CPU::GetState() == CPU::CPU_STEPPING || js.instructionsLeft < count)

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -114,6 +114,9 @@ public:
   JitOptions jo;
   JitState js;
 
+  JitBase();
+  ~JitBase() override;
+
   static const u8* Dispatch() { return g_jit->GetBlockCache()->Dispatch(); };
   virtual JitBaseBlockCache* GetBlockCache() = 0;
 


### PR DESCRIPTION
As this is a base class with virtuals, there needs to be an out-of-line function definition to prevent the vtable of the class being placed within every translation unit it's used in (i.e. every JIT implementation).

This also may reduce binary size a small tad, as compilers won't potentially inline all the initial setup code and teardown that gets generated for the constructor/destructor with the declaration of `JitOptions` and `JitState` as member variables. Not really the main focus of the PR, but still worth mentioning.