### PR TITLE
Fix the build on non-Windows platforms when not using WX from Externals

### DIFF
--- a/Source/Core/DolphinWX/NetPlay/NetWindow.h
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.h
@@ -14,6 +14,7 @@
 #include "Core/NetPlayProto.h"
 #include "Core/NetPlayServer.h"
 
+#ifdef _WIN32
 // HACK: wxWidgets headers don't play well with some of the macros defined in Windows
 // headers and perform their own magic to fix things, as long as they're included entirely
 // either before or after any Windows headers.
@@ -22,6 +23,7 @@
 // include ENet headers, which leak Windows header macros. To fix this, explicitly tell
 // wxWidgets here that it needs to re-clean macros.
 #include <wx/msw/winundef.h>
+#endif
 
 class CGameListCtrl;
 class MD5Dialog;


### PR DESCRIPTION
No idea why we were including a Windows specific header *without* a ifdef.