### PR TITLE
Add configurable video dump bitrate to INI

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -136,7 +136,7 @@ bool AVIDump::CreateVideoFile()
     s_codec_context->codec_tag =
         MKTAG('X', 'V', 'I', 'D');  // Force XVID FourCC for better compatibility
   s_codec_context->codec_type = AVMEDIA_TYPE_VIDEO;
-  s_codec_context->bit_rate = 400000;
+  s_codec_context->bit_rate = g_Config.iBitrateKbps * 1000;
   s_codec_context->width = s_width;
   s_codec_context->height = s_height;
   s_codec_context->time_base.num = 1;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -75,6 +75,7 @@ void VideoConfig::Load(const std::string& ini_file)
   settings->Get("DumpFramesAsImages", &bDumpFramesAsImages, false);
   settings->Get("FreeLook", &bFreeLook, false);
   settings->Get("UseFFV1", &bUseFFV1, false);
+  settings->Get("BitrateKbps", &iBitrateKbps, 2500);
   settings->Get("InternalResolutionFrameDumps", &bInternalResolutionFrameDumps, false);
   settings->Get("EnablePixelLighting", &bEnablePixelLighting, false);
   settings->Get("FastDepthCalc", &bFastDepthCalc, true);
@@ -293,6 +294,7 @@ void VideoConfig::Save(const std::string& ini_file)
   settings->Set("DumpFramesAsImages", bDumpFramesAsImages);
   settings->Set("FreeLook", bFreeLook);
   settings->Set("UseFFV1", bUseFFV1);
+  settings->Set("BitrateKbps", iBitrateKbps);
   settings->Set("InternalResolutionFrameDumps", bInternalResolutionFrameDumps);
   settings->Set("EnablePixelLighting", bEnablePixelLighting);
   settings->Set("FastDepthCalc", bFastDepthCalc);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -104,6 +104,7 @@ struct VideoConfig final
   bool bInternalResolutionFrameDumps;
   bool bFreeLook;
   bool bBorderlessFullscreen;
+  int iBitrateKbps;
 
   // Hacks
   bool bEFBAccessEnable;


### PR DESCRIPTION
This adds the option to configure a bit-rate for codecs which accept bit-rates when dumping video. The value in the INI is treated as a Kbps value, with the default value being 2500kbps.

Setting the INI value to zero will force it to dump at high of a bitrate as possible.

There is no UI screen for this currently, but should be trivial to add.