### PR TITLE
ControlGroup: Convert group type enum into an enum class

### DIFF
--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -942,10 +942,10 @@ ControlGroupBox::~ControlGroupBox()
 
 bool ControlGroupBox::HasBitmapHeading() const
 {
-  return control_group->type == ControllerEmu::GROUP_TYPE_STICK ||
-         control_group->type == ControllerEmu::GROUP_TYPE_TILT ||
-         control_group->type == ControllerEmu::GROUP_TYPE_CURSOR ||
-         control_group->type == ControllerEmu::GROUP_TYPE_FORCE;
+  return control_group->type == ControllerEmu::GroupType::Stick ||
+         control_group->type == ControllerEmu::GroupType::Tilt ||
+         control_group->type == ControllerEmu::GroupType::Cursor ||
+         control_group->type == ControllerEmu::GroupType::Force;
 }
 
 ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWindow* const parent,
@@ -1000,10 +1000,10 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
 
   switch (group->type)
   {
-  case ControllerEmu::GROUP_TYPE_STICK:
-  case ControllerEmu::GROUP_TYPE_TILT:
-  case ControllerEmu::GROUP_TYPE_CURSOR:
-  case ControllerEmu::GROUP_TYPE_FORCE:
+  case ControllerEmu::GroupType::Stick:
+  case ControllerEmu::GroupType::Tilt:
+  case ControllerEmu::GroupType::Cursor:
+  case ControllerEmu::GroupType::Force:
   {
     wxSize bitmap_size = parent->FromDIP(wxSize(64, 64));
     m_scale = bitmap_size.GetWidth() / 64.0;
@@ -1045,7 +1045,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
     Add(h_szr, 0, wxEXPAND | wxLEFT | wxRIGHT, space3);
   }
   break;
-  case ControllerEmu::GROUP_TYPE_BUTTONS:
+  case ControllerEmu::GroupType::Buttons:
   {
     // Draw buttons in rows of 8
     unsigned int button_cols = group->controls.size() > 8 ? 8 : group->controls.size();
@@ -1083,17 +1083,17 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
     Add(static_bitmap, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, space3);
   }
   break;
-  case ControllerEmu::GROUP_TYPE_MIXED_TRIGGERS:
-  case ControllerEmu::GROUP_TYPE_TRIGGERS:
-  case ControllerEmu::GROUP_TYPE_SLIDER:
+  case ControllerEmu::GroupType::MixedTriggers:
+  case ControllerEmu::GroupType::Triggers:
+  case ControllerEmu::GroupType::Slider:
   {
     int height = (int)(12 * group->controls.size());
     int width = 64;
 
-    if (ControllerEmu::GROUP_TYPE_MIXED_TRIGGERS == group->type)
+    if (group->type == ControllerEmu::GroupType::MixedTriggers)
       width = 64 + 12 + 1;
 
-    if (ControllerEmu::GROUP_TYPE_TRIGGERS != group->type)
+    if (group->type != ControllerEmu::GroupType::Triggers)
       height /= 2;
     height += 1;
 
@@ -1127,7 +1127,7 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
     Add(static_bitmap, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, space3);
   }
   break;
-  case ControllerEmu::GROUP_TYPE_EXTENSION:
+  case ControllerEmu::GroupType::Extension:
   {
     PadSettingExtension* const attachments =
         new PadSettingExtension(parent, (ControllerEmu::Extension*)group);

--- a/Source/Core/DolphinWX/Input/InputConfigDiagBitmaps.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiagBitmaps.cpp
@@ -159,9 +159,9 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
 
   switch (g->control_group->type)
   {
-  case ControllerEmu::GROUP_TYPE_TILT:
-  case ControllerEmu::GROUP_TYPE_STICK:
-  case ControllerEmu::GROUP_TYPE_CURSOR:
+  case ControllerEmu::GroupType::Tilt:
+  case ControllerEmu::GroupType::Stick:
+  case ControllerEmu::GroupType::Cursor:
   {
     // this is starting to be a mess combining all these in one case
 
@@ -169,19 +169,19 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
 
     switch (g->control_group->type)
     {
-    case ControllerEmu::GROUP_TYPE_STICK:
+    case ControllerEmu::GroupType::Stick:
       ((ControllerEmu::AnalogStick*)g->control_group)->GetState(&x, &y);
       break;
-    case ControllerEmu::GROUP_TYPE_TILT:
+    case ControllerEmu::GroupType::Tilt:
       ((ControllerEmu::Tilt*)g->control_group)->GetState(&x, &y);
       break;
-    case ControllerEmu::GROUP_TYPE_CURSOR:
+    case ControllerEmu::GroupType::Cursor:
       ((ControllerEmu::Cursor*)g->control_group)->GetState(&x, &y, &z);
       break;
     }
 
     // ir cursor forward movement
-    if (ControllerEmu::GROUP_TYPE_CURSOR == g->control_group->type)
+    if (g->control_group->type == ControllerEmu::GroupType::Cursor)
     {
       gc->SetBrush(z ? *wxRED_BRUSH : *wxGREY_BRUSH);
       wxGraphicsPath path = gc->CreatePath();
@@ -191,7 +191,7 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
 
     // input zone
     gc->SetPen(*wxLIGHT_GREY_PEN);
-    if (ControllerEmu::GROUP_TYPE_STICK == g->control_group->type)
+    if (g->control_group->type == ControllerEmu::GroupType::Stick)
     {
       gc->SetBrush(wxColour(0xDDDDDD));  // Light Gray
 
@@ -231,9 +231,9 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
       gc->DrawRectangle(16, 16, 32, 32);
     }
 
-    if (ControllerEmu::GROUP_TYPE_CURSOR != g->control_group->type)
+    if (g->control_group->type != ControllerEmu::GroupType::Cursor)
     {
-      const int deadzone_idx = g->control_group->type == ControllerEmu::GROUP_TYPE_STICK ?
+      const int deadzone_idx = g->control_group->type == ControllerEmu::GroupType::Stick ?
                                    ControllerEmu::AnalogStick::SETTING_DEADZONE :
                                    0;
 
@@ -267,7 +267,7 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
   }
   break;
 
-  case ControllerEmu::GROUP_TYPE_FORCE:
+  case ControllerEmu::GroupType::Force:
   {
     ControlState raw_dot[3];
     ControlState adj_dot[3];
@@ -332,7 +332,7 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
   }
   break;
 
-  case ControllerEmu::GROUP_TYPE_BUTTONS:
+  case ControllerEmu::GroupType::Buttons:
   {
     const unsigned int button_count = static_cast<unsigned int>(g->control_group->controls.size());
     std::vector<unsigned int> bitmasks(button_count);
@@ -361,7 +361,7 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
   }
   break;
 
-  case ControllerEmu::GROUP_TYPE_TRIGGERS:
+  case ControllerEmu::GroupType::Triggers:
   {
     const unsigned int trigger_count = static_cast<unsigned int>(g->control_group->controls.size());
     std::vector<ControlState> trigs(trigger_count);
@@ -403,7 +403,7 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
   }
   break;
 
-  case ControllerEmu::GROUP_TYPE_MIXED_TRIGGERS:
+  case ControllerEmu::GroupType::MixedTriggers:
   {
     const unsigned int trigger_count = ((unsigned int)(g->control_group->controls.size() / 2));
 
@@ -443,7 +443,7 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
   }
   break;
 
-  case ControllerEmu::GROUP_TYPE_SLIDER:
+  case ControllerEmu::GroupType::Slider:
   {
     const ControlState deadzone = g->control_group->numeric_settings[0]->GetValue();
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -24,7 +24,7 @@ AnalogStick::AnalogStick(const char* const name_, ControlState default_radius)
 
 AnalogStick::AnalogStick(const char* const name_, const char* const ui_name_,
                          ControlState default_radius)
-    : ControlGroup(name_, ui_name_, GROUP_TYPE_STICK)
+    : ControlGroup(name_, ui_name_, GroupType::Stick)
 {
   for (auto& named_direction : named_directions)
     controls.emplace_back(std::make_unique<Input>(named_direction));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Buttons.cpp
@@ -16,7 +16,7 @@ Buttons::Buttons(const std::string& name_) : Buttons(name_, name_)
 }
 
 Buttons::Buttons(const std::string& ini_name, const std::string& group_name)
-    : ControlGroup(ini_name, group_name, GROUP_TYPE_BUTTONS)
+    : ControlGroup(ini_name, group_name, GroupType::Buttons)
 {
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Threshold"), 0.5));
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -14,12 +14,13 @@
 
 namespace ControllerEmu
 {
-ControlGroup::ControlGroup(const std::string& name_, const u32 type_)
+ControlGroup::ControlGroup(const std::string& name_, const GroupType type_)
     : name(name_), ui_name(name_), type(type_)
 {
 }
 
-ControlGroup::ControlGroup(const std::string& name_, const std::string& ui_name_, const u32 type_)
+ControlGroup::ControlGroup(const std::string& name_, const std::string& ui_name_,
+                           const GroupType type_)
     : name(name_), ui_name(ui_name_), type(type_)
 {
 }
@@ -62,7 +63,7 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
   }
 
   // extensions
-  if (type == GROUP_TYPE_EXTENSION)
+  if (type == GroupType::Extension)
   {
     Extension* const ext = (Extension*)this;
 
@@ -115,7 +116,7 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
   }
 
   // extensions
-  if (type == GROUP_TYPE_EXTENSION)
+  if (type == GroupType::Extension)
   {
     Extension* const ext = (Extension*)this;
     sec->Set(base + name, ext->attachments[ext->switch_extension]->GetName(), "None");

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -17,18 +17,18 @@ namespace ControllerEmu
 {
 class Control;
 
-enum
+enum class GroupType
 {
-  GROUP_TYPE_OTHER,
-  GROUP_TYPE_STICK,
-  GROUP_TYPE_MIXED_TRIGGERS,
-  GROUP_TYPE_BUTTONS,
-  GROUP_TYPE_FORCE,
-  GROUP_TYPE_EXTENSION,
-  GROUP_TYPE_TILT,
-  GROUP_TYPE_CURSOR,
-  GROUP_TYPE_TRIGGERS,
-  GROUP_TYPE_SLIDER
+  Other,
+  Stick,
+  MixedTriggers,
+  Buttons,
+  Force,
+  Extension,
+  Tilt,
+  Cursor,
+  Triggers,
+  Slider
 };
 
 class ControlGroup
@@ -102,8 +102,9 @@ public:
     }
   };
 
-  explicit ControlGroup(const std::string& name, u32 type = GROUP_TYPE_OTHER);
-  ControlGroup(const std::string& name, const std::string& ui_name, u32 type = GROUP_TYPE_OTHER);
+  explicit ControlGroup(const std::string& name, GroupType type = GroupType::Other);
+  ControlGroup(const std::string& name, const std::string& ui_name,
+               GroupType type = GroupType::Other);
   virtual ~ControlGroup();
 
   virtual void LoadConfig(IniFile::Section* sec, const std::string& defdev = "",
@@ -115,7 +116,7 @@ public:
 
   const std::string name;
   const std::string ui_name;
-  const u32 type;
+  const GroupType type;
 
   std::vector<std::unique_ptr<Control>> controls;
   std::vector<std::unique_ptr<NumericSetting>> numeric_settings;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -19,7 +19,7 @@
 
 namespace ControllerEmu
 {
-Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GROUP_TYPE_CURSOR)
+Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor)
 {
   for (auto& named_direction : named_directions)
     controls.emplace_back(std::make_unique<Input>(named_direction));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Extension.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Extension.cpp
@@ -10,7 +10,7 @@
 
 namespace ControllerEmu
 {
-Extension::Extension(const std::string& name_) : ControlGroup(name_, GROUP_TYPE_EXTENSION)
+Extension::Extension(const std::string& name_) : ControlGroup(name_, GroupType::Extension)
 {
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.cpp
@@ -16,7 +16,7 @@
 
 namespace ControllerEmu
 {
-Force::Force(const std::string& name_) : ControlGroup(name_, GROUP_TYPE_FORCE)
+Force::Force(const std::string& name_) : ControlGroup(name_, GroupType::Force)
 {
   controls.emplace_back(std::make_unique<Input>(_trans("Up")));
   controls.emplace_back(std::make_unique<Input>(_trans("Down")));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.cpp
@@ -17,7 +17,7 @@
 namespace ControllerEmu
 {
 MixedTriggers::MixedTriggers(const std::string& name_)
-    : ControlGroup(name_, GROUP_TYPE_MIXED_TRIGGERS)
+    : ControlGroup(name_, GroupType::MixedTriggers)
 {
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Threshold"), 0.9));
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.cpp
@@ -16,7 +16,7 @@
 
 namespace ControllerEmu
 {
-Slider::Slider(const std::string& name_) : ControlGroup(name_, GROUP_TYPE_SLIDER)
+Slider::Slider(const std::string& name_) : ControlGroup(name_, GroupType::Slider)
 {
   controls.emplace_back(std::make_unique<Input>("Left"));
   controls.emplace_back(std::make_unique<Input>("Right"));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -16,7 +16,7 @@
 
 namespace ControllerEmu
 {
-Tilt::Tilt(const std::string& name_) : ControlGroup(name_, GROUP_TYPE_TILT)
+Tilt::Tilt(const std::string& name_) : ControlGroup(name_, GroupType::Tilt)
 {
   controls.emplace_back(std::make_unique<Input>("Forward"));
   controls.emplace_back(std::make_unique<Input>("Backward"));

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.cpp
@@ -15,7 +15,7 @@
 
 namespace ControllerEmu
 {
-Triggers::Triggers(const std::string& name_) : ControlGroup(name_, GROUP_TYPE_TRIGGERS)
+Triggers::Triggers(const std::string& name_) : ControlGroup(name_, GroupType::Triggers)
 {
   numeric_settings.emplace_back(std::make_unique<NumericSetting>(_trans("Dead Zone"), 0, 0, 50));
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -39,7 +39,7 @@ void EmulatedController::UpdateReferences(const ControllerInterface& devi)
       control->control_ref.get()->UpdateReference(devi, default_device);
 
     // extension
-    if (ctrlGroup->type == GROUP_TYPE_EXTENSION)
+    if (ctrlGroup->type == GroupType::Extension)
     {
       for (auto& attachment : ((Extension*)ctrlGroup.get())->attachments)
         attachment->UpdateReferences(devi);
@@ -52,7 +52,7 @@ void EmulatedController::UpdateDefaultDevice()
   for (auto& ctrlGroup : groups)
   {
     // extension
-    if (ctrlGroup->type == GROUP_TYPE_EXTENSION)
+    if (ctrlGroup->type == GroupType::Extension)
     {
       for (auto& ai : ((Extension*)ctrlGroup.get())->attachments)
       {


### PR DESCRIPTION
Gets some constants out of the ControllerEmu namespace, and modifies ControlGroup so that it uses the enum type itself to represent the underlying type, rather than a u32 value.