### PR TITLE
Make memory breakpoint faster

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -173,8 +173,8 @@ void MemChecks::Add(const TMemCheck& memory_check)
   if (GetMemCheck(memory_check.start_address) == nullptr)
   {
     bool had_any = HasAny();
-    m_mem_checks.push_back(memory_check);
     bool lock = Core::PauseAndLock(true);
+    m_mem_checks.push_back(memory_check);
     // If this is the first one, clear the JIT cache so it can switch to
     // watchpoint-compatible code.
     if (!had_any && g_jit)
@@ -190,8 +190,8 @@ void MemChecks::Remove(u32 address)
   {
     if (i->start_address == address)
     {
-      m_mem_checks.erase(i);
       bool lock = Core::PauseAndLock(true);
+      m_mem_checks.erase(i);
       if (!HasAny() && g_jit)
         g_jit->ClearCache();
       PowerPC::DBATUpdated();
@@ -218,6 +218,25 @@ TMemCheck* MemChecks::GetMemCheck(u32 address)
 
   // none found
   return nullptr;
+}
+
+bool MemChecks::OverlapsMemcheck(u32 address, u32 length)
+{
+  if (!HasAny())
+    return false;
+  u32 page_end_suffix = length - 1;
+  u32 page_end_address = address | page_end_suffix;
+  for (TMemCheck memcheck : m_mem_checks)
+  {
+    if (((memcheck.start_address | page_end_suffix) == page_end_address ||
+         (memcheck.end_address | page_end_suffix) == page_end_address) ||
+        ((memcheck.start_address | page_end_suffix) < page_end_address &&
+         (memcheck.end_address | page_end_suffix) > page_end_address))
+    {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool TMemCheck::Action(DebugInterface* debug_interface, u32 value, u32 addr, bool write, int size,

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -87,6 +87,7 @@ public:
 
   // memory breakpoint
   TMemCheck* GetMemCheck(u32 address);
+  bool OverlapsMemcheck(u32 address, u32 length);
   void Remove(u32 address);
 
   void Clear() { m_mem_checks.clear(); }

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -335,7 +335,7 @@ void EmuCodeBlock::MMIOLoadToReg(MMIO::Mapping* mmio, Gen::X64Reg reg_value,
 void EmuCodeBlock::SafeLoadToReg(X64Reg reg_value, const Gen::OpArg& opAddress, int accessSize,
                                  s32 offset, BitSet32 registersInUse, bool signExtend, int flags)
 {
-  bool slowmem = (flags & SAFE_LOADSTORE_FORCE_SLOWMEM) != 0 || g_jit->jo.alwaysUseMemFuncs;
+  bool slowmem = (flags & SAFE_LOADSTORE_FORCE_SLOWMEM) != 0;
 
   registersInUse[reg_value] = false;
   if (g_jit->jo.fastmem && !(flags & SAFE_LOADSTORE_NO_FASTMEM) && !slowmem)
@@ -492,7 +492,7 @@ void EmuCodeBlock::SafeWriteRegToReg(OpArg reg_value, X64Reg reg_addr, int acces
                                      BitSet32 registersInUse, int flags)
 {
   bool swap = !(flags & SAFE_LOADSTORE_NO_SWAP);
-  bool slowmem = (flags & SAFE_LOADSTORE_FORCE_SLOWMEM) != 0 || g_jit->jo.alwaysUseMemFuncs;
+  bool slowmem = (flags & SAFE_LOADSTORE_FORCE_SLOWMEM) != 0;
 
   // set the correct immediate format
   reg_value = FixImmediate(accessSize, reg_value);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -46,7 +46,6 @@ bool JitBase::MergeAllowedNextInstructions(int count)
 void JitBase::UpdateMemoryOptions()
 {
   bool any_watchpoints = PowerPC::memchecks.HasAny();
-  jo.fastmem = SConfig::GetInstance().bFastmem && !any_watchpoints;
+  jo.fastmem = SConfig::GetInstance().bFastmem;
   jo.memcheck = SConfig::GetInstance().bMMU || any_watchpoints;
-  jo.alwaysUseMemFuncs = any_watchpoints;
 }

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -46,6 +46,6 @@ bool JitBase::MergeAllowedNextInstructions(int count)
 void JitBase::UpdateMemoryOptions()
 {
   bool any_watchpoints = PowerPC::memchecks.HasAny();
-  jo.fastmem = SConfig::GetInstance().bFastmem;
+  jo.fastmem = SConfig::GetInstance().bFastmem && (UReg_MSR(MSR).DR || !any_watchpoints);
   jo.memcheck = SConfig::GetInstance().bMMU || any_watchpoints;
 }

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -52,7 +52,6 @@ protected:
     bool accurateSinglePrecision;
     bool fastmem;
     bool memcheck;
-    bool alwaysUseMemFuncs;
   };
   struct JitState
   {

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.cpp
@@ -29,13 +29,6 @@
 
 using namespace Gen;
 
-static CoreTiming::EventType* s_clear_jit_cache_thread_safe;
-
-static void ClearCacheThreadSafe(u64 userdata, s64 cyclesdata)
-{
-  JitInterface::ClearCache();
-}
-
 bool JitBlock::OverlapsPhysicalRange(u32 address, u32 length) const
 {
   return physical_addresses.lower_bound(address) !=
@@ -50,7 +43,6 @@ JitBaseBlockCache::~JitBaseBlockCache() = default;
 
 void JitBaseBlockCache::Init()
 {
-  s_clear_jit_cache_thread_safe = CoreTiming::RegisterEvent("clearJitCache", ClearCacheThreadSafe);
   JitRegister::Init(SConfig::GetInstance().m_perfDir);
 
   Clear();
@@ -87,11 +79,6 @@ void JitBaseBlockCache::Reset()
 {
   Shutdown();
   Init();
-}
-
-void JitBaseBlockCache::SchedulateClearCacheThreadSafe()
-{
-  CoreTiming::ScheduleEvent(0, s_clear_jit_cache_thread_safe, 0, CoreTiming::FromThread::NON_CPU);
 }
 
 JitBlock** JitBaseBlockCache::GetFastBlockMap()

--- a/Source/Core/Core/PowerPC/JitCommon/JitCache.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitCache.h
@@ -125,7 +125,6 @@ public:
   void Shutdown();
   void Clear();
   void Reset();
-  void SchedulateClearCacheThreadSafe();
 
   // Code Cache
   JitBlock** GetFastBlockMap();

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -1132,24 +1132,6 @@ static TranslateAddressResult TranslatePageAddress(const u32 address, const XChe
   return TranslateAddressResult{TranslateAddressResult::PAGE_FAULT, 0};
 }
 
-static bool overlaps_memcheck(u32 pageEndAddress)
-{
-  if (!memchecks.HasAny())
-    return false;
-  u32 page_end_suffix = ((1 << BAT_INDEX_SHIFT)) - 1;
-  for (TMemCheck memcheck : memchecks.GetMemChecks())
-  {
-    if (((memcheck.start_address | page_end_suffix) == pageEndAddress ||
-         (memcheck.end_address | page_end_suffix) == pageEndAddress) ||
-        ((memcheck.start_address | page_end_suffix) < pageEndAddress &&
-         (memcheck.end_address | page_end_suffix) > pageEndAddress))
-    {
-      return true;
-    }
-  }
-  return false;
-}
-
 static void UpdateBATs(BatTable& bat_table, u32 base_spr)
 {
   // TODO: Separate BATs for MSR.PR==0 and MSR.PR==1
@@ -1209,7 +1191,9 @@ static void UpdateBATs(BatTable& bat_table, u32 base_spr)
           valid_bit = 0x3;
         else if ((address >> 28) == 0xE && (address < (0xE0000000 + Memory::L1_CACHE_SIZE)))
           valid_bit = 0x3;
-        if (overlaps_memcheck(((batu.BEPI | j) << BAT_INDEX_SHIFT) | ((1 << BAT_INDEX_SHIFT) - 1)))
+        // Fastmem doesn't support memchecks, so disable it for all overlapping virtual pages.
+        if (PowerPC::memchecks.OverlapsMemcheck(((batu.BEPI | j) << BAT_INDEX_SHIFT),
+                                                1 << BAT_INDEX_SHIFT))
           valid_bit &= ~0x2;
 
         // (BEPI | j) == (BEPI & ~BL) | (j & BL).


### PR DESCRIPTION
Currently, slowmem is used at any time that memory breakpoints are in use.  This commit makes it so that whenever the DBAT gets updated, if the address is overllaping any memchecks, it forces the use of slowmem.  This allows to keep fastmem for any other cases and noticably increases performance when using memory breakpoints.

I did some practical tests on Rs2 and basically, here's an estimate of my observation (I just checked the FPS)

Without this optimisation: around 30-35% decrease when using memory breakpoints.
With this optimisation: around 10-15% decrease when using memory breakpoints.

~~Please note that I cannot rebase this because of some issues that happened from 5.0-2021 (the report is here: https://bugs.dolphin-emu.org/issues/10117 ).  If I would rebase, no breakpoints including memory breakpoints would works properly since it's likely to get crashes.  I had to go rebase back to 5.0-2012 and then add my commit on top of it so I can actually test it (I confirmed that the issues were regressions and weren't caused by my code, it's unrelated problems).~~

~~Because of this, I am not sure if this is okay to be merged until it's tested to a further revision, but it should be fine for tests and review.~~

EDIT: since #4983 has been merged, I could rebase this and it can now be reviewed, tested and potentially merged.

Tagging @degasus here who helped me do this just to know if it looks fine. 