### PR TITLE
IOS/ES: Implement the Export ioctlvs + minor fixes (fix the System Menu's SD channel feature)

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -447,6 +447,9 @@ IPCCommandResult ES::AddContentStart(const IOCtlVRequest& request)
                    "content id %08x",
            title_id, m_addtitle_content_id);
 
+  if (!m_addtitle_tmd.IsValid())
+    return GetDefaultReply(ES_PARAMETER_SIZE_OR_ALIGNMENT);
+
   if (title_id != m_addtitle_tmd.GetTitleId())
   {
     ERROR_LOG(IOS_ES, "IOCTL_ES_ADDCONTENTSTART: title id %016" PRIx64 " != "
@@ -485,6 +488,9 @@ IPCCommandResult ES::AddContentFinish(const IOCtlVRequest& request)
 
   u32 content_fd = Memory::Read_U32(request.in_vectors[0].address);
   INFO_LOG(IOS_ES, "IOCTL_ES_ADDCONTENTFINISH: content fd %08x", content_fd);
+
+  if (!m_addtitle_tmd.IsValid())
+    return GetDefaultReply(ES_PARAMETER_SIZE_OR_ALIGNMENT);
 
   // Try to find the title key from a pre-installed ticket.
   IOS::ES::TicketReader ticket = DiscIO::FindSignedTicket(m_addtitle_tmd.GetTitleId());

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -131,12 +131,11 @@ private:
     ES_HASH_SIZE_WRONG = -2014,  // HASH !=20
   };
 
-  struct SContentAccess
+  struct OpenedContent
   {
-    u32 m_Position;
-    u64 m_TitleID;
-    u16 m_Index;
-    u32 m_Size;
+    u64 m_title_id;
+    IOS::ES::Content m_content;
+    u32 m_position;
   };
 
   struct ecc_cert_t
@@ -199,8 +198,8 @@ private:
 
   u32 OpenTitleContent(u32 CFD, u64 TitleID, u16 Index);
 
-  using CContentAccessMap = std::map<u32, SContentAccess>;
-  CContentAccessMap m_ContentAccessMap;
+  using ContentAccessMap = std::map<u32, OpenedContent>;
+  ContentAccessMap m_ContentAccessMap;
 
   std::vector<u64> m_TitleIDs;
   u64 m_TitleID = -1;

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -153,6 +153,7 @@ private:
   };
 
   IPCCommandResult AddTicket(const IOCtlVRequest& request);
+  IPCCommandResult AddTMD(const IOCtlVRequest& request);
   IPCCommandResult AddTitleStart(const IOCtlVRequest& request);
   IPCCommandResult AddContentStart(const IOCtlVRequest& request);
   IPCCommandResult AddContentData(const IOCtlVRequest& request);

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <map>
 #include <memory>
 #include <string>
@@ -92,11 +93,11 @@ private:
     IOCTL_ES_SEEKCONTENT = 0x23,
     IOCTL_ES_OPENTITLECONTENT = 0x24,
     IOCTL_ES_LAUNCHBC = 0x25,
-    // IOCTL_ES_EXPORTTITLEINIT    = 0x26,
-    // IOCTL_ES_EXPORTCONTENTBEGIN = 0x27,
-    // IOCTL_ES_EXPORTCONTENTDATA  = 0x28,
-    // IOCTL_ES_EXPORTCONTENTEND   = 0x29,
-    // IOCTL_ES_EXPORTTITLEDONE    = 0x2A,
+    IOCTL_ES_EXPORTTITLEINIT = 0x26,
+    IOCTL_ES_EXPORTCONTENTBEGIN = 0x27,
+    IOCTL_ES_EXPORTCONTENTDATA = 0x28,
+    IOCTL_ES_EXPORTCONTENTEND = 0x29,
+    IOCTL_ES_EXPORTTITLEDONE = 0x2A,
     IOCTL_ES_ADDTMD = 0x2B,
     IOCTL_ES_ENCRYPT = 0x2C,
     IOCTL_ES_DECRYPT = 0x2D,
@@ -184,6 +185,13 @@ private:
   IPCCommandResult Decrypt(const IOCtlVRequest& request);
   IPCCommandResult Launch(const IOCtlVRequest& request);
   IPCCommandResult LaunchBC(const IOCtlVRequest& request);
+
+  IPCCommandResult ExportTitleInit(const IOCtlVRequest& request);
+  IPCCommandResult ExportContentBegin(const IOCtlVRequest& request);
+  IPCCommandResult ExportContentData(const IOCtlVRequest& request);
+  IPCCommandResult ExportContentEnd(const IOCtlVRequest& request);
+  IPCCommandResult ExportTitleDone(const IOCtlVRequest& request);
+
   IPCCommandResult CheckKoreaRegion(const IOCtlVRequest& request);
   IPCCommandResult GetDeviceCertificate(const IOCtlVRequest& request);
   IPCCommandResult Sign(const IOCtlVRequest& request);
@@ -209,6 +217,20 @@ private:
   IOS::ES::TMDReader m_addtitle_tmd;
   u32 m_addtitle_content_id = 0xFFFFFFFF;
   std::vector<u8> m_addtitle_content_buffer;
+
+  struct TitleExportContext
+  {
+    struct ExportContent
+    {
+      OpenedContent content;
+      std::array<u8, 16> iv{};
+    };
+
+    bool valid = false;
+    IOS::ES::TMDReader tmd;
+    std::vector<u8> title_key;
+    std::map<u32, ExportContent> contents;
+  } m_export_title_context;
 };
 }  // namespace Device
 }  // namespace HLE

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 77;  // Last changed in PR 4784
+static const u32 STATE_VERSION = 78;  // Last changed in PR 49XX
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -161,6 +161,14 @@ bool CNANDContentLoader::IsValid() const
   return m_Valid && m_tmd.IsValid();
 }
 
+const SNANDContent* CNANDContentLoader::GetContentByID(u32 id) const
+{
+  const auto iterator = std::find_if(m_Content.begin(), m_Content.end(), [id](const auto& content) {
+    return content.m_metadata.id == id;
+  });
+  return iterator != m_Content.end() ? &*iterator : nullptr;
+}
+
 const SNANDContent* CNANDContentLoader::GetContentByIndex(int index) const
 {
   for (auto& Content : m_Content)

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -79,6 +79,7 @@ public:
 
   bool IsValid() const;
   void RemoveTitle() const;
+  const SNANDContent* GetContentByID(u32 id) const;
   const SNANDContent* GetContentByIndex(int index) const;
   const IOS::ES::TMDReader& GetTMD() const { return m_tmd; }
   const IOS::ES::TicketReader& GetTicket() const { return m_ticket; }


### PR DESCRIPTION
[Depends on #4896 -- first four commits are unchanged. This needs to be rebased once that's merged.]

This implements all of the known ES_Export* ioctlvs (ExportTitleInit, ExportContentBegin, ExportContentData, ExportContentEnd, ExportTitleDone) + ES_AddTMD and adds some checks to make it harder to crash Dolphin.

The result is that the System Menu's SD channel feature should now fully work.