### PR TITLE
Fix remove and add buttons not disabling after removing Action Replay code

### DIFF
--- a/Source/Core/DolphinWX/Cheats/ActionReplayCodesPanel.cpp
+++ b/Source/Core/DolphinWX/Cheats/ActionReplayCodesPanel.cpp
@@ -288,4 +288,6 @@ void ActionReplayCodesPanel::OnRemoveCodeClick(wxCommandEvent&)
   m_codes.erase(m_codes.begin() + idx);
   m_checklist_cheats->Delete(idx);
   m_was_modified = true;
+
+  UpdateModifyButtons();
 }


### PR DESCRIPTION
This fixes issue 10104: https://bugs.dolphin-emu.org/issues/10104