### PR TITLE
IOS/ES: Implement DeleteTitle

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -175,6 +175,7 @@ private:
   IPCCommandResult GetTMDViewCount(const IOCtlVRequest& request);
   IPCCommandResult GetTMDViews(const IOCtlVRequest& request);
   IPCCommandResult GetConsumption(const IOCtlVRequest& request);
+  IPCCommandResult DeleteTitle(const IOCtlVRequest& request);
   IPCCommandResult DeleteTicket(const IOCtlVRequest& request);
   IPCCommandResult DeleteTitleContent(const IOCtlVRequest& request);
   IPCCommandResult GetStoredTMDSize(const IOCtlVRequest& request);


### PR DESCRIPTION
No idea why this wasn't implemented whereas ES_DeleteTicket and ES_DeleteTitleContent were.

This probably fixes title deletion in old System Menus, and maybe the new ones as well in some cases; I've seen 4.3 use this ioctlv.