### PR TITLE
Turn Off Debug Mode for Traversal Server

### DIFF
--- a/Source/Core/Common/TraversalServer.cpp
+++ b/Source/Core/Common/TraversalServer.cpp
@@ -17,7 +17,7 @@
 #include <vector>
 #include "Common/TraversalProto.h"
 
-#define DEBUG 1
+#define DEBUG 0
 #define NUMBER_OF_TRIES 5
 
 static u64 currentTime;


### PR DESCRIPTION
According to delroth, this was causing every UDP packet to be logged on the traversal server, wasting disk space and CPU resources.