### PR TITLE
Step MemoryWatcher at end of each video frame

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -105,6 +105,10 @@ static bool s_request_refresh_info = false;
 static bool s_is_throttler_temp_disabled = false;
 static bool s_frame_step = false;
 
+#ifdef USE_MEMORYWATCHER
+static std::unique_ptr<MemoryWatcher> s_memory_watcher;
+#endif
+
 struct HostJob
 {
   std::function<void()> job;
@@ -149,6 +153,13 @@ void FrameUpdateOnCPUThread()
 {
   if (NetPlay::IsNetPlayRunning())
     NetPlayClient::SendTimeBase();
+}
+
+void FrameAdvance()
+{
+#ifdef USE_MEMORYWATCHER
+  s_memory_watcher->Step();
+#endif
 }
 
 // Display messages and return values
@@ -290,7 +301,7 @@ void Stop()  // - Hammertime!
 #endif
 
 #ifdef USE_MEMORYWATCHER
-  MemoryWatcher::Shutdown();
+  s_memory_watcher.reset();
 #endif
 }
 
@@ -384,7 +395,7 @@ static void CpuThread()
 #endif
 
 #ifdef USE_MEMORYWATCHER
-  MemoryWatcher::Init();
+  s_memory_watcher = std::make_unique<MemoryWatcher>();
 #endif
 
   // Enter CPU run loop. When we leave it - we are done.

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -68,6 +68,7 @@ std::string GetStateFileName();
 void SetStateFileName(const std::string& val);
 
 void FrameUpdateOnCPUThread();
+void FrameAdvance();
 
 bool ShouldSkipFrame(int skipped);
 void VideoThrottle();

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -720,6 +720,7 @@ static void BeginField(FieldType field, u64 ticks)
 static void EndField()
 {
   Core::VideoThrottle();
+  Core::FrameAdvance();
 }
 
 // Purpose: Send VI interrupt when triggered

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -14,29 +14,6 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/MemoryWatcher.h"
 
-static std::unique_ptr<MemoryWatcher> s_memory_watcher;
-static CoreTiming::EventType* s_event;
-static const int MW_RATE = 600;  // Steps per second
-
-static void MWCallback(u64 userdata, s64 cyclesLate)
-{
-  s_memory_watcher->Step();
-  CoreTiming::ScheduleEvent(SystemTimers::GetTicksPerSecond() / MW_RATE - cyclesLate, s_event);
-}
-
-void MemoryWatcher::Init()
-{
-  s_memory_watcher = std::make_unique<MemoryWatcher>();
-  s_event = CoreTiming::RegisterEvent("MemoryWatcher", MWCallback);
-  CoreTiming::ScheduleEvent(0, s_event);
-}
-
-void MemoryWatcher::Shutdown()
-{
-  CoreTiming::RemoveEvent(s_event);
-  s_memory_watcher.reset();
-}
-
 MemoryWatcher::MemoryWatcher()
 {
   m_running = false;

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -77,17 +77,10 @@ u32 MemoryWatcher::ChasePointer(const std::string& line)
   return value;
 }
 
-std::string MemoryWatcher::ComposeMessage(const std::string& line, u32 value)
+std::string MemoryWatcher::ComposeMessages()
 {
   std::stringstream message_stream;
-  message_stream << line << '\n' << std::hex << value;
-  return message_stream.str();
-}
-
-void MemoryWatcher::Step()
-{
-  if (!m_running)
-    return;
+  message_stream << std::hex;
 
   for (auto& entry : m_values)
   {
@@ -99,9 +92,18 @@ void MemoryWatcher::Step()
     {
       // Update the value
       current_value = new_value;
-      std::string message = ComposeMessage(address, new_value);
-      sendto(m_fd, message.c_str(), message.size() + 1, 0, reinterpret_cast<sockaddr*>(&m_addr),
-             sizeof(m_addr));
+      message_stream << address << '\n' << new_value << '\n';
     }
   }
+
+  return message_stream.str();
+}
+
+void MemoryWatcher::Step()
+{
+  if (!m_running)
+    return;
+
+  std::string message = ComposeMessages();
+  sendto(m_fd, message.c_str(), message.size() + 1, 0, reinterpret_cast<sockaddr*>(&m_addr), sizeof(m_addr));
 }

--- a/Source/Core/Core/MemoryWatcher.cpp
+++ b/Source/Core/Core/MemoryWatcher.cpp
@@ -105,5 +105,6 @@ void MemoryWatcher::Step()
     return;
 
   std::string message = ComposeMessages();
-  sendto(m_fd, message.c_str(), message.size() + 1, 0, reinterpret_cast<sockaddr*>(&m_addr), sizeof(m_addr));
+  sendto(m_fd, message.c_str(), message.size() + 1, 0, reinterpret_cast<sockaddr*>(&m_addr),
+         sizeof(m_addr));
 }

--- a/Source/Core/Core/MemoryWatcher.h
+++ b/Source/Core/Core/MemoryWatcher.h
@@ -30,7 +30,7 @@ private:
 
   void ParseLine(const std::string& line);
   u32 ChasePointer(const std::string& line);
-  std::string ComposeMessage(const std::string& line, u32 value);
+  std::string ComposeMessages();
 
   bool m_running;
 

--- a/Source/Core/Core/MemoryWatcher.h
+++ b/Source/Core/Core/MemoryWatcher.h
@@ -24,9 +24,6 @@ public:
   ~MemoryWatcher();
   void Step();
 
-  static void Init();
-  static void Shutdown();
-
 private:
   bool LoadAddresses(const std::string& path);
   bool OpenSocket(const std::string& path);


### PR DESCRIPTION
This is more efficient than the current approach of checking 600 times per second - typically whoever is listening only cares about each frame, not what happens between frames.

Edit: I no longer plan on making a zmq PR. These commits should still be fine though. 