### PR TITLE
IOS: Clear the /tmp directory on IOS boot

### DIFF
--- a/Source/Core/Core/IOS/FS/FS.cpp
+++ b/Source/Core/Core/IOS/FS/FS.cpp
@@ -35,6 +35,9 @@ namespace Device
 {
 FS::FS(u32 device_id, const std::string& device_name) : Device(device_id, device_name)
 {
+  const std::string tmp_dir = BuildFilename("/tmp");
+  File::DeleteDirRecursively(tmp_dir);
+  File::CreateDir(tmp_dir);
 }
 
 void FS::DoState(PointerWrap& p)
@@ -134,13 +137,6 @@ void FS::DoState(PointerWrap& p)
 
 ReturnCode FS::Open(const OpenRequest& request)
 {
-  // clear tmp folder
-  {
-    std::string Path = BuildFilename("/tmp");
-    File::DeleteDirRecursively(Path);
-    File::CreateDir(Path);
-  }
-
   m_is_active = true;
   return IPC_SUCCESS;
 }


### PR DESCRIPTION
The /tmp directory is cleared every time IOS boots up (when the FS driver is initialized), *not* when /dev/fs is opened.

Although this should have no effect, it fixes the case where files could be left in /tmp and seen before opening /dev/fs.