### PR TITLE
DolphinWX: provide empty OnCmdLineParsed

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -84,6 +84,11 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser& parser)
   parser.SetCmdLine("");
 }
 
+bool DolphinApp::OnCmdLineParsed(wxCmdLineParser& parser)
+{
+  return true;
+}
+
 bool DolphinApp::OnInit()
 {
   std::lock_guard<std::mutex> lk(s_init_mutex);

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -23,6 +23,7 @@ public:
 private:
   bool OnInit() override;
   void OnInitCmdLine(wxCmdLineParser& parser) override;
+  bool OnCmdLineParsed(wxCmdLineParser& parser) override;
   int OnExit() override;
   void OnFatalException() override;
   bool Initialize(int& c, wxChar** v) override;


### PR DESCRIPTION
Starting in #4916, upon startup wxWidgets pops up an assertion error:

> ./src/common/cmdline.cpp(527): assert ""Assert failure"" failed in
> FindOptionByAnyName(): Unknown option verbose

Fix this by overriding wxApp::OnCmdLineParsed to disable the default handling (since we also disable the default options in DolphinApp::OnInitCmdLine).