### PR TITLE
DolphinWX: don't refresh MainMenuBar on construction

### DIFF
--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -28,8 +28,6 @@ MainMenuBar::MainMenuBar(MenuType type, long style) : wxMenuBar{style}, m_type{t
 {
   BindEvents();
   AddMenus();
-
-  MainMenuBar::Refresh(false);
 }
 
 void MainMenuBar::Refresh(bool erase_background, const wxRect* rect)


### PR DESCRIPTION
On startup, wxWidgets pops up an assertion error:

> ./src/osx/menu_osx.cpp(648): assert ""IsAttached()"" failed in
> Refresh(): can't refresh unatteched[sic] menubar