### PR TITLE
AVIDump[regression]: close avio handles

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -323,7 +323,13 @@ void AVIDump::CloseVideoFile()
   av_frame_free(&s_scaled_frame);
 
   avcodec_free_context(&s_codec_context);
+
+  if (s_format_context)
+  {
+    avio_closep(&s_format_context->pb);
+  }
   avformat_free_context(s_format_context);
+  s_format_context = nullptr;
 
   if (s_sws_context)
   {


### PR DESCRIPTION
@RisingFog noticed the issue. Quoting from IRC:
> was testing out ffmpeg 3.2.4 windows stufr
> and I noticed that I had to close Dolphin before all the video information populated in the properties in Windows
> and attempting to delete the file after stopping emulation wouldn't work because it said the file was in use
> this doesn't seem to happen in 5.0-1656