### PR TITLE
[RFC] Workaround for the memory breakpoint crash since 5.0-2021

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -784,9 +784,6 @@ u32 IsOptimizableMMIOAccess(u32 address, u32 accessSize)
 
 bool IsOptimizableGatherPipeWrite(u32 address)
 {
-  if (PowerPC::memchecks.HasAny())
-    return false;
-
   if (!UReg_MSR(MSR).DR)
     return false;
 


### PR DESCRIPTION
This is a known workaround to prevent a crash that is very likely to happen when adding any memomory breakpoints.  This workaround applies to a crash that started to occur on 5.0-2021 as this was not an issue before.  It only affects memchecks which are used for memory breakpoints.

A bit of explanation is required here, the gist however is that this shouldn't be merged until an actuall fix was found (in this case, this pr would be closed) or until it's actually preferable to implement this.

Basically, this "fixes" [this issue](https://bugs.dolphin-emu.org/issues/10117) which is a regression from 5.0-2021.  The changes that were made were more related to the jitcache, however, as I tested many times with this, it became uncertain that this was caused by clearing the jitcache or a race condition (it needs to clear the cache when adding the first memcheck).  Actually, clearing the cache ALONE is fine here and I even ended up forcing the return value of memchecks::HasAny(0 which unexpectively ended up changing the behavior (it would not crash if it was returning false to its callers even if there was one memcheck present)

So I went through each usage of HasAny() and found out that the one that manipulates whether you would crash or not is the method that determines whether the gather pipe write optimisation should be used by MMU.cpp.   What makes this very strange is that this removes a fallback to the slower path and it somehow caused a crash since 5.0-2021.  Even more strange, memchecks actually works fine even if it may use the faster path.   Forcing a return false on every cases actually makes the emulator crashes without even touching the memory breakpoints (I got one when it was loading the intro video of Super Mario Sunshine before the tittle screen).  So, maybe the slower path got broken with the regression and it affected memchecks?

One thing for sure: it doesn't sound like a race condition when clearing the cache upon adding the first memory breakpoint.

I mainly post this PR for discussion about this workaround.  @degasus should attempt to look up an actuall fix for this, but at the very least, finding this workaroung helps to know where to look for.  This PR only affects memchecks though.