### PR TITLE
send stop message before saving recording

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -881,14 +881,14 @@ void CFrame::DoStop()
       Core::SetState(state);
     }
 
+    if (NetPlayDialog::GetNetPlayClient())
+      NetPlayDialog::GetNetPlayClient()->Stop();
+
     // TODO: Show the author/description dialog here
     if (Movie::IsRecordingInput())
       DoRecordingSave();
     if (Movie::IsMovieActive())
       Movie::EndPlayInput(false);
-
-    if (NetPlayDialog::GetNetPlayClient())
-      NetPlayDialog::GetNetPlayClient()->Stop();
 
     if (!m_tried_graceful_shutdown && UICommon::TriggerSTMPowerEvent())
     {


### PR DESCRIPTION
When recording during netplay, the stop message was only sent after you have chosen a filename for the replay, causing the other player(s) to freeze for a few seconds. This takes care of the annoyance.