### PR TITLE
IOS/ES: Proper active title tracking (+ neat accidental fixes)

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -278,8 +278,6 @@ bool CBoot::BootUp()
       PanicAlertT("Warning - starting ISO in wrong console mode!");
     }
 
-    IOS::HLE::ES_DIVerify(pVolume.GetTMD());
-
     _StartupPara.bWii = pVolume.GetVolumeType() == DiscIO::Platform::WII_DISC;
 
     // HLE BS2 or not

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -21,6 +21,7 @@
 #include "Core/HW/DVDInterface.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/Memmap.h"
+#include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/IPC.h"
 #include "Core/PatchEngine.h"
@@ -406,7 +407,7 @@ bool CBoot::EmulatedBS2_Wii()
   DEBUG_LOG(BOOT, "Run iAppLoaderClose");
   RunFunction(iAppLoaderClose);
 
-  IOS::HLE::ES_DIVerify(tmd, DVDInterface::GetVolume().GetTicket());
+  IOS::HLE::Device::ES::DIVerify(tmd, DVDInterface::GetVolume().GetTicket());
 
   // return
   PC = PowerPC::ppcState.gpr[3];

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -406,9 +406,6 @@ bool CBoot::EmulatedBS2_Wii()
   DEBUG_LOG(BOOT, "Run iAppLoaderClose");
   RunFunction(iAppLoaderClose);
 
-  // Load patches and run startup patches
-  PatchEngine::LoadPatches();
-
   IOS::HLE::ES_DIVerify(tmd, DVDInterface::GetVolume().GetTicket());
 
   // return

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -11,6 +11,7 @@
 #include "Common/NandPaths.h"
 
 #include "Core/Boot/Boot.h"
+#include "Core/IOS/ES/ES.h"
 #include "Core/IOS/FS/FileIO.h"
 #include "Core/IOS/IPC.h"
 #include "Core/PatchEngine.h"
@@ -87,7 +88,7 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
   if (!SetupWiiMemory(ContentLoader.GetTMD().GetIOSId()))
     return false;
 
-  IOS::HLE::SetDefaultContentFile(_pFilename);
+  IOS::HLE::Device::ES::LoadWAD(_pFilename);
   if (!IOS::HLE::BootstrapPPC(ContentLoader))
     return false;
 

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -109,7 +109,7 @@ IPCCommandResult DI::IOCtlV(const IOCtlVRequest& request)
     const ES::TMDReader tmd = DVDInterface::GetVolume().GetTMD();
     const std::vector<u8> raw_tmd = tmd.GetRawTMD();
     Memory::CopyToEmu(request.io_vectors[0].address, raw_tmd.data(), raw_tmd.size());
-    ES_DIVerify(tmd);
+    ES_DIVerify(tmd, DVDInterface::GetVolume().GetTicket());
 
     return_value = 1;
     break;

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -14,8 +14,8 @@
 #include "Core/HW/DVDInterface.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/DI/DI.h"
+#include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
-#include "Core/IOS/IPC.h"
 #include "DiscIO/Volume.h"
 
 namespace IOS
@@ -106,10 +106,10 @@ IPCCommandResult DI::IOCtlV(const IOCtlVRequest& request)
     INFO_LOG(IOS_DI, "DVDLowOpenPartition: partition_offset 0x%016" PRIx64, partition_offset);
 
     // Read TMD to the buffer
-    const ES::TMDReader tmd = DVDInterface::GetVolume().GetTMD();
+    const IOS::ES::TMDReader tmd = DVDInterface::GetVolume().GetTMD();
     const std::vector<u8> raw_tmd = tmd.GetRawTMD();
     Memory::CopyToEmu(request.io_vectors[0].address, raw_tmd.data(), raw_tmd.size());
-    ES_DIVerify(tmd, DVDInterface::GetVolume().GetTicket());
+    ES::DIVerify(tmd, DVDInterface::GetVolume().GetTicket());
 
     return_value = 1;
     break;

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -185,6 +185,8 @@ void TitleContext::UpdateRunningGame() const
   PatchEngine::Shutdown();
   PatchEngine::LoadPatches();
   HiresTexture::Update();
+
+  NOTICE_LOG(IOS_ES, "Active title: %016" PRIx64, tmd.GetTitleId());
 }
 
 void ES::LoadWAD(const std::string& _rContentFile)
@@ -194,6 +196,7 @@ void ES::LoadWAD(const std::string& _rContentFile)
   // without installing them (which is a bit of a hack), we have to do this manually here.
   const auto& content_loader = DiscIO::CNANDContentManager::Access().GetNANDLoader(s_content_file);
   s_title_context.Update(content_loader);
+  INFO_LOG(IOS_ES, "LoadWAD: Title context changed: %016" PRIx64, s_title_context.tmd.GetTitleId());
 }
 
 void ES::DecryptContent(u32 key_index, u8* iv, u8* input, u32 size, u8* new_iv, u8* output)
@@ -207,6 +210,7 @@ void ES::DecryptContent(u32 key_index, u8* iv, u8* input, u32 size, u8* new_iv, 
 bool ES::LaunchTitle(u64 title_id, bool skip_reload)
 {
   s_title_context.Clear();
+  INFO_LOG(IOS_ES, "ES_Launch: Title context changed: (none)");
 
   NOTICE_LOG(IOS_ES, "Launching title %016" PRIx64 "...", title_id);
 
@@ -247,6 +251,8 @@ bool ES::LaunchPPCTitle(u64 title_id, bool skip_reload)
   }
 
   s_title_context.Update(content_loader);
+  INFO_LOG(IOS_ES, "LaunchPPCTitle: Title context changed: %016" PRIx64,
+           s_title_context.tmd.GetTitleId());
   return BootstrapPPC(content_loader);
 }
 
@@ -1488,6 +1494,7 @@ const DiscIO::CNANDContentLoader& ES::AccessContentDevice(u64 title_id)
 s32 ES::DIVerify(const IOS::ES::TMDReader& tmd, const IOS::ES::TicketReader& ticket)
 {
   s_title_context.Clear();
+  INFO_LOG(IOS_ES, "ES_DIVerify: Title context changed: (none)");
 
   if (!tmd.IsValid() || !ticket.IsValid())
     return ES_PARAMETER_SIZE_OR_ALIGNMENT;
@@ -1514,6 +1521,7 @@ s32 ES::DIVerify(const IOS::ES::TMDReader& tmd, const IOS::ES::TicketReader& tic
   DiscIO::CNANDContentManager::Access().ClearCache();
 
   s_title_context.Update(tmd, ticket);
+  INFO_LOG(IOS_ES, "ES_DIVerify: Title context changed: %016" PRIx64, tmd.GetTitleId());
   return IPC_SUCCESS;
 }
 }  // namespace Device

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -1491,6 +1491,8 @@ const DiscIO::CNANDContentLoader& ES::AccessContentDevice(u64 title_id)
   return DiscIO::CNANDContentManager::Access().GetNANDLoader(title_id, Common::FROM_SESSION_ROOT);
 }
 
+// This is technically an ioctlv in IOS's ES, but it is an internal API which cannot be
+// used from the PowerPC (for unpatched IOSes anyway).
 s32 ES::DIVerify(const IOS::ES::TMDReader& tmd, const IOS::ES::TicketReader& ticket)
 {
   s_title_context.Clear();

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -40,15 +40,13 @@ public:
   // Internal implementation of the ES_DECRYPT ioctlv.
   void DecryptContent(u32 key_index, u8* iv, u8* input, u32 size, u8* new_iv, u8* output);
 
-  void OpenInternal();
-
   void DoState(PointerWrap& p) override;
 
   ReturnCode Open(const OpenRequest& request) override;
   void Close() override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
-  static u32 ES_DIVerify(const IOS::ES::TMDReader& tmd);
+  static s32 DIVerify(const IOS::ES::TMDReader& tmd, const IOS::ES::TicketReader& ticket);
 
   // This should only be cleared on power reset
   static std::string m_ContentFile;
@@ -211,8 +209,20 @@ private:
   ContentAccessMap m_ContentAccessMap;
 
   std::vector<u64> m_TitleIDs;
-  u64 m_TitleID = -1;
   u32 m_AccessIdentID = 0;
+
+  // Shared across all ES instances.
+  static struct TitleContext
+  {
+    void Clear();
+    void DoState(PointerWrap& p);
+    void Update(const DiscIO::CNANDContentLoader& content_loader);
+    void Update(const IOS::ES::TMDReader& tmd_, const IOS::ES::TicketReader& ticket_);
+
+    IOS::ES::TicketReader ticket;
+    IOS::ES::TMDReader tmd;
+    bool active = false;
+  } m_title_context;
 
   // For title installation (ioctls IOCTL_ES_ADDTITLE*).
   IOS::ES::TMDReader m_addtitle_tmd;

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -212,6 +212,11 @@ bool TicketReader::IsValid() const
   return true;
 }
 
+void TicketReader::DoState(PointerWrap& p)
+{
+  p.Do(m_bytes);
+}
+
 u32 TicketReader::GetNumberOfTickets() const
 {
   return static_cast<u32>(m_bytes.size() / (GetOffset() + sizeof(Ticket)));

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -126,6 +126,11 @@ u16 TMDReader::GetTitleVersion() const
   return Common::swap16(m_bytes.data() + offsetof(TMDHeader, title_version));
 }
 
+u16 TMDReader::GetGroupId() const
+{
+  return Common::swap16(m_bytes.data() + offsetof(TMDHeader, group_id));
+}
+
 u16 TMDReader::GetNumContents() const
 {
   return Common::swap16(m_bytes.data() + offsetof(TMDHeader, num_contents));

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -137,6 +137,7 @@ public:
   DiscIO::Region GetRegion() const;
   u64 GetTitleId() const;
   u16 GetTitleVersion() const;
+  u16 GetGroupId() const;
 
   u16 GetNumContents() const;
   bool GetContent(u16 index, Content* content) const;

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -160,6 +160,7 @@ public:
   void SetBytes(std::vector<u8>&& bytes);
 
   bool IsValid() const;
+  void DoState(PointerWrap& p);
 
   const std::vector<u8>& GetRawTicket() const;
   u32 GetNumberOfTickets() const;

--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -95,7 +95,6 @@ static CoreTiming::EventType* s_event_sdio_notify;
 static u64 s_last_reply_time;
 
 static u64 s_active_title_id;
-static u64 s_title_to_launch;
 
 static constexpr u64 ENQUEUE_REQUEST_FLAG = 0x100000000ULL;
 static constexpr u64 ENQUEUE_ACKNOWLEDGEMENT_FLAG = 0x200000000ULL;
@@ -586,7 +585,6 @@ static void AddStaticDevices()
 {
   std::lock_guard<std::mutex> lock(s_device_map_mutex);
   _assert_msg_(IOS, s_device_map.empty(), "Reinit called while already initialized");
-  Device::ES::m_ContentFile = "";
 
   num_devices = 0;
 
@@ -706,18 +704,8 @@ bool Reload(const u64 ios_title_id)
 
   AddStaticDevices();
 
-  if (s_title_to_launch != 0)
-  {
-    NOTICE_LOG(IOS, "Re-launching title after IOS reload.");
-    s_es_handles[0]->LaunchTitle(s_title_to_launch, true);
-    s_title_to_launch = 0;
-  }
+  Device::ES::Init();
   return true;
-}
-
-void SetTitleToLaunch(const u64 title_id)
-{
-  s_title_to_launch = title_id;
 }
 
 // This corresponds to syscall 0x41, which loads a binary from the NAND and bootstraps the PPC.

--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -752,13 +752,13 @@ bool BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader)
 void SetDefaultContentFile(const std::string& file_name)
 {
   std::lock_guard<std::mutex> lock(s_device_map_mutex);
-  for (const auto& es : s_es_handles)
-    es->LoadWAD(file_name);
+  s_es_handles[0]->LoadWAD(file_name);
 }
 
-void ES_DIVerify(const ES::TMDReader& tmd)
+// XXX: also pass certificate chains?
+void ES_DIVerify(const ES::TMDReader& tmd, const ES::TicketReader& ticket)
 {
-  Device::ES::ES_DIVerify(tmd);
+  Device::ES::DIVerify(tmd, ticket);
 }
 
 void SDIO_EventNotify()

--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -737,18 +737,6 @@ bool BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader)
   return true;
 }
 
-void SetDefaultContentFile(const std::string& file_name)
-{
-  std::lock_guard<std::mutex> lock(s_device_map_mutex);
-  s_es_handles[0]->LoadWAD(file_name);
-}
-
-// XXX: also pass certificate chains?
-void ES_DIVerify(const ES::TMDReader& tmd, const ES::TicketReader& ticket)
-{
-  Device::ES::DIVerify(tmd, ticket);
-}
-
 void SDIO_EventNotify()
 {
   // TODO: Potential race condition: If IsRunning() becomes false after

--- a/Source/Core/Core/IOS/IPC.h
+++ b/Source/Core/Core/IOS/IPC.h
@@ -21,12 +21,6 @@ class CNANDContentLoader;
 
 namespace IOS
 {
-namespace ES
-{
-class TMDReader;
-class TicketReader;
-}
-
 namespace HLE
 {
 namespace Device
@@ -71,10 +65,6 @@ bool BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader);
 
 // Do State
 void DoState(PointerWrap& p);
-
-// Set default content file
-void SetDefaultContentFile(const std::string& file_name);
-void ES_DIVerify(const ES::TMDReader& tmd, const ES::TicketReader& ticket);
 
 void SDIO_EventNotify();
 

--- a/Source/Core/Core/IOS/IPC.h
+++ b/Source/Core/Core/IOS/IPC.h
@@ -24,6 +24,7 @@ namespace IOS
 namespace ES
 {
 class TMDReader;
+class TicketReader;
 }
 
 namespace HLE
@@ -75,7 +76,7 @@ void DoState(PointerWrap& p);
 
 // Set default content file
 void SetDefaultContentFile(const std::string& file_name);
-void ES_DIVerify(const ES::TMDReader& tmd);
+void ES_DIVerify(const ES::TMDReader& tmd, const ES::TicketReader& ticket);
 
 void SDIO_EventNotify();
 

--- a/Source/Core/Core/IOS/IPC.h
+++ b/Source/Core/Core/IOS/IPC.h
@@ -68,8 +68,6 @@ bool Reload(u64 ios_title_id);
 u32 GetVersion();
 
 bool BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader);
-// This sets a title to launch after IOS has been reset and reloaded (similar to /sys/launch.sys).
-void SetTitleToLaunch(u64 title_id);
 
 // Do State
 void DoState(PointerWrap& p);

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 78;  // Last changed in PR 49XX
+static const u32 STATE_VERSION = 79;  // Last changed in PR 4981
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DiscIO/Volume.h
+++ b/Source/Core/DiscIO/Volume.h
@@ -37,6 +37,7 @@ public:
   }
 
   virtual bool GetTitleID(u64*) const { return false; }
+  virtual IOS::ES::TicketReader GetTicket() const { return {}; }
   virtual IOS::ES::TMDReader GetTMD() const { return {}; }
   virtual u64 PartitionOffsetToRawOffset(u64 offset) const { return offset; }
   virtual std::string GetGameID() const = 0;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -114,6 +114,13 @@ bool CVolumeWiiCrypted::GetTitleID(u64* buffer) const
   return true;
 }
 
+IOS::ES::TicketReader CVolumeWiiCrypted::GetTicket() const
+{
+  std::vector<u8> buffer(0x2a4);
+  Read(m_VolumeOffset, buffer.size(), buffer.data(), false);
+  return IOS::ES::TicketReader{std::move(buffer)};
+}
+
 IOS::ES::TMDReader CVolumeWiiCrypted::GetTMD() const
 {
   u32 tmd_size;

--- a/Source/Core/DiscIO/VolumeWiiCrypted.h
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.h
@@ -33,6 +33,7 @@ public:
   ~CVolumeWiiCrypted();
   bool Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const override;
   bool GetTitleID(u64* buffer) const override;
+  IOS::ES::TicketReader GetTicket() const override;
   IOS::ES::TMDReader GetTMD() const override;
   u64 PartitionOffsetToRawOffset(u64 offset) const override;
   std::string GetGameID() const override;


### PR DESCRIPTION
[Depends on #4906.]

This changes ES to keep track of the active title properly, just like IOS:

* It is *not* changed on resource manager open/close.
* It is reset on IOS reload.
* It is changed by ES_DIVerify and ES_Launch.

IOS stores the active title in a structure like this:

    struct ESTitleContext
    {
      Ticket* ticket;
      TMD* tmd;
      u32 active;
    };

With this commit, we also do this and keep the Ticket and TMD around. This makes some of the DI ioctlvs (which return data about the current active title) trivial to implement in the future.

As usual with IOS PRs, this *accidentally* **fixes the System Menu not being able to see update partitions**.

And since we now have info about the current title and keep track of it properly, we can update Dolphin's running game info, which fixes savestates, screenshots, custom textures, etc. after an ES_Launch. (GameINIs are not reloaded though, but this commit makes it much easier to do whenever the new config system is ready.)