### PR TITLE
ESFormats: Fix GetRawTicketView

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -234,14 +234,17 @@ const std::vector<u8>& TicketReader::GetRawTicket() const
 std::vector<u8> TicketReader::GetRawTicketView(u32 ticket_num) const
 {
   // A ticket view is composed of a view ID + part of a ticket starting from the ticket_id field.
-  std::vector<u8> view{sizeof(TicketView)};
+  const auto ticket_start = m_bytes.cbegin() + (GetOffset() + sizeof(Ticket)) * ticket_num;
+  const auto view_start = ticket_start + offsetof(Ticket, ticket_id);
 
-  u32 view_id = Common::swap32(ticket_num);
+  // Copy the view ID to the buffer.
+  std::vector<u8> view(sizeof(TicketView::view));
+  const u32 view_id = Common::swap32(ticket_num);
   std::memcpy(view.data(), &view_id, sizeof(view_id));
 
-  const size_t ticket_start = (GetOffset() + sizeof(Ticket)) * ticket_num;
-  const size_t view_start = ticket_start + offsetof(Ticket, ticket_id);
-  std::memcpy(view.data() + sizeof(view_id), &m_bytes[view_start], sizeof(view) - sizeof(view_id));
+  // Copy the rest of the ticket view structure from the ticket.
+  view.insert(view.end(), view_start, view_start + sizeof(TicketView) - sizeof(view_id));
+  _assert_(view.size() == sizeof(TicketView));
 
   return view;
 }


### PR DESCRIPTION
The vector was not constructed with the proper size, which results in a buffer overflow as we were using memcpy.

This commit fixes that mistake and also uses a safer way of copying the ticket view data (std::vector::insert instead of memcpy).

(also added an assert to make sure this cannot happen again)