### PR TITLE
IOS/ES: Title import fixes + hack removals (fix for System Menu disc updates)

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -831,12 +831,7 @@ IPCCommandResult ES::GetViewCount(const IOCtlVRequest& request)
   const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
 
   size_t view_count = 0;
-  if (TitleID >> 32 == 0x00000001 && TitleID != TITLEID_SYSMENU)
-  {
-    // Fake a ticket view to make IOS reload work.
-    view_count = 1;
-  }
-  else if (Loader.IsValid() && Loader.GetTicket().IsValid())
+  if (Loader.IsValid() && Loader.GetTicket().IsValid())
   {
     view_count = Loader.GetTicket().GetNumberOfTickets();
   }
@@ -858,20 +853,7 @@ IPCCommandResult ES::GetViews(const IOCtlVRequest& request)
 
   const DiscIO::CNANDContentLoader& Loader = AccessContentDevice(TitleID);
 
-  if (TitleID >> 32 == 0x00000001 && TitleID != TITLEID_SYSMENU)
-  {
-    // For IOS titles, the ticket view isn't normally parsed by either the
-    // SDK or libogc, just passed to LaunchTitle, so this
-    // shouldn't matter at all.  Just fill out some fields just
-    // to be on the safe side.
-    u32 Address = request.io_vectors[0].address;
-    Memory::Memset(Address, 0, 0xD8);
-    Memory::Write_U64(TitleID, Address + 4 + (0x1dc - 0x1d0));  // title ID
-    Memory::Write_U16(0xffff, Address + 4 + (0x1e4 - 0x1d0));   // unnnown
-    Memory::Write_U32(0xff00, Address + 4 + (0x1ec - 0x1d0));   // access mask
-    Memory::Memset(Address + 4 + (0x222 - 0x1d0), 0xff, 0x20);  // content permissions
-  }
-  else if (Loader.IsValid() && Loader.GetTicket().IsValid())
+  if (Loader.IsValid() && Loader.GetTicket().IsValid())
   {
     u32 number_of_views = std::min(maxViews, Loader.GetTicket().GetNumberOfTickets());
     for (u32 view = 0; view < number_of_views; ++view)

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -422,6 +422,9 @@ IPCCommandResult ES::AddTitleStart(const IOCtlVRequest& request)
   if (!WriteTMD(m_addtitle_tmd))
     return GetDefaultReply(ES_WRITE_FAILURE);
 
+  DiscIO::cUIDsys uid_sys{Common::FROM_CONFIGURED_ROOT};
+  uid_sys.AddTitle(m_addtitle_tmd.GetTitleId());
+
   return GetDefaultReply(IPC_SUCCESS);
 }
 

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -516,12 +516,22 @@ IPCCommandResult ES::AddContentFinish(const IOCtlVRequest& request)
   mbedtls_aes_crypt_cbc(&aes_ctx, MBEDTLS_AES_DECRYPT, m_addtitle_content_buffer.size(), iv,
                         m_addtitle_content_buffer.data(), decrypted_data.data());
 
-  std::string path = StringFromFormat(
-      "%s%08x.app",
-      Common::GetTitleContentPath(m_addtitle_tmd.GetTitleId(), Common::FROM_SESSION_ROOT).c_str(),
-      m_addtitle_content_id);
+  std::string content_path;
+  if (content_info.type & 0x8000)
+  {
+    // Shared content.
+    DiscIO::CSharedContent shared_content{Common::FROM_SESSION_ROOT};
+    content_path = shared_content.AddSharedContent(content_info.sha1.data());
+  }
+  else
+  {
+    content_path = StringFromFormat(
+        "%s%08x.app",
+        Common::GetTitleContentPath(m_addtitle_tmd.GetTitleId(), Common::FROM_SESSION_ROOT).c_str(),
+        m_addtitle_content_id);
+  }
 
-  File::IOFile fp(path, "wb");
+  File::IOFile fp(content_path, "wb");
   fp.WriteBytes(decrypted_data.data(), content_info.size);
 
   m_addtitle_content_id = 0xFFFFFFFF;

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -520,9 +520,8 @@ IPCCommandResult ES::AddContentFinish(const IOCtlVRequest& request)
                         m_addtitle_content_buffer.data(), decrypted_data.data());
 
   std::string content_path;
-  if (content_info.type & 0x8000)
+  if (content_info.IsShared())
   {
-    // Shared content.
     DiscIO::CSharedContent shared_content{Common::FROM_SESSION_ROOT};
     content_path = shared_content.AddSharedContent(content_info.sha1.data());
   }

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -540,10 +540,11 @@ IPCCommandResult ES::AddContentFinish(const IOCtlVRequest& request)
 
 IPCCommandResult ES::AddTitleFinish(const IOCtlVRequest& request)
 {
-  if (!request.HasNumberOfValidVectors(0, 0))
+  if (!request.HasNumberOfValidVectors(0, 0) || !m_addtitle_tmd.IsValid())
     return GetDefaultReply(ES_PARAMETER_SIZE_OR_ALIGNMENT);
 
   INFO_LOG(IOS_ES, "IOCTL_ES_ADDTITLEFINISH");
+  m_addtitle_tmd.SetBytes({});
   return GetDefaultReply(IPC_SUCCESS);
 }
 

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -174,7 +174,7 @@ private:
   IPCCommandResult GetTitles(const IOCtlVRequest& request);
   IPCCommandResult GetViewCount(const IOCtlVRequest& request);
   IPCCommandResult GetViews(const IOCtlVRequest& request);
-  IPCCommandResult GetTMDViewCount(const IOCtlVRequest& request);
+  IPCCommandResult GetTMDViewSize(const IOCtlVRequest& request);
   IPCCommandResult GetTMDViews(const IOCtlVRequest& request);
   IPCCommandResult GetConsumption(const IOCtlVRequest& request);
   IPCCommandResult DeleteTitle(const IOCtlVRequest& request);

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -26,6 +26,11 @@ bool IsTitleType(u64 title_id, TitleType title_type)
   return static_cast<u32>(title_id >> 32) == static_cast<u32>(title_type);
 }
 
+bool Content::IsShared() const
+{
+  return (type & 0x8000) != 0;
+}
+
 TMDReader::TMDReader(const std::vector<u8>& bytes) : m_bytes(bytes)
 {
 }

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -61,6 +61,7 @@ static_assert(sizeof(TMDHeader) == 0x1e4, "TMDHeader has the wrong size");
 
 struct Content
 {
+  bool IsShared() const;
   u32 id;
   u16 index;
   u16 type;

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -260,7 +260,7 @@ void CNANDContentLoader::InitializeContentEntries(const std::vector<u8>& data_ap
     else
     {
       std::string filename;
-      if (content.type & 0x8000)  // shared app
+      if (content.IsShared())
         filename = shared_content.GetFilenameFromSHA1(content.sha1.data());
       else
         filename = StringFromFormat("%s/%08x.app", m_Path.c_str(), content.id);
@@ -317,7 +317,7 @@ void CNANDContentLoader::RemoveTitle() const
     // remove TMD?
     for (const auto& content : m_Content)
     {
-      if (!(content.m_metadata.type & 0x8000))  // skip shared apps
+      if (!content.m_metadata.IsShared())
       {
         std::string path = StringFromFormat("%s/%08x.app", m_Path.c_str(), content.m_metadata.id);
         INFO_LOG(DISCIO, "Delete %s", path.c_str());
@@ -430,7 +430,7 @@ u64 CNANDContentManager::Install_WiiWAD(const std::string& filename)
   for (const auto& content : content_loader.GetContent())
   {
     std::string app_filename;
-    if (content.m_metadata.type & 0x8000)  // shared
+    if (content.m_metadata.IsShared())
       app_filename = shared_content.AddSharedContent(content.m_metadata.sha1.data());
     else
       app_filename = StringFromFormat("%s%08x.app", content_path.c_str(), content.m_metadata.id);


### PR DESCRIPTION
Small somewhat related changes to ES:

* Fix ES_AddContentFinish to handle shared contents properly. They are now written to the correct location. Prior to this, doing a system update would bork the NAND because channels were installed incorrectly, and there was no easy way to reinstall them.

* Add sanity checks to AddTitleFinish: return an error if no import was in progress, and reset the import state after an import. Trivial stuff.

* Fix AddTitleStart to edit uid.sys, so that new titles are registered properly. This allows channels installed by disc updates to show up properly.

* Drop the hack where we faked IOS titles being installed. This prevents disc system updates from working properly, because we always reported that the latest version of every single IOS was installed. This hack isn't really useful because you need an IOS for the system menu and homebrew to work correctly anyway. And having working system updates makes it very easy to have a complete NAND with all IOSes and system titles.

* Fix the behaviour of GetTMDView and GetTMDViewSize when a title doesn't exist. Prior to this, they returned IPC_SUCCESS and simply left the output vector untouched, which is inaccurate and wrong. The proper behaviour is to return -106 (FS_ENOENT) when the title doesn't exist (more specifically, when no TMD exists for it in the NAND). This allows missing IOSes to be detected properly.
 
(And do I have to say this is what IOS does?)

![System Menu](https://cloud.githubusercontent.com/assets/4209061/23385362/ae6b7fcc-fd4f-11e6-9faf-b682b0063dbf.png)

Independant from #4981, but the System Menu will not detect the update partition without that PR.