### PR TITLE
ExpressionParser: Convert parse state enum into an enum class

### DIFF
--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -341,10 +341,10 @@ void ControlDialog::UpdateGUI()
 
   switch (control_reference->GetParseStatus())
   {
-  case EXPRESSION_PARSE_SYNTAX_ERROR:
+  case ParseStatus::SyntaxError:
     m_error_label->SetLabel(_("Syntax error"));
     break;
-  case EXPRESSION_PARSE_NO_DEVICE:
+  case ParseStatus::NoDevice:
     m_error_label->SetLabel(_("Device not found"));
     break;
   default:
@@ -404,8 +404,8 @@ bool ControlDialog::Validate()
 
   UpdateGUI();
 
-  return (control_reference->GetParseStatus() == EXPRESSION_PARSE_SUCCESS ||
-          control_reference->GetParseStatus() == EXPRESSION_PARSE_NO_DEVICE);
+  const auto parse_status = control_reference->GetParseStatus();
+  return parse_status == ParseStatus::Success || parse_status == ParseStatus::NoDevice;
 }
 
 void InputConfigDialog::SetDevice(wxCommandEvent&)

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -43,7 +43,7 @@ int ControlReference::BoundCount() const
     return 0;
 }
 
-ExpressionParseStatus ControlReference::GetParseStatus() const
+ParseStatus ControlReference::GetParseStatus() const
 {
   return m_parse_status;
 }

--- a/Source/Core/InputCommon/ControlReference/ControlReference.h
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.h
@@ -31,7 +31,7 @@ public:
   virtual bool IsInput() const = 0;
 
   int BoundCount() const;
-  ciface::ExpressionParser::ExpressionParseStatus GetParseStatus() const;
+  ciface::ExpressionParser::ParseStatus GetParseStatus() const;
   void UpdateReference(const ciface::Core::DeviceContainer& devices,
                        const ciface::Core::DeviceQualifier& default_device);
 
@@ -41,7 +41,7 @@ public:
 protected:
   ControlReference();
   std::unique_ptr<ciface::ExpressionParser::Expression> m_parsed_expression;
-  ciface::ExpressionParser::ExpressionParseStatus m_parse_status;
+  ciface::ExpressionParser::ParseStatus m_parse_status;
 };
 
 //

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.h
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.h
@@ -59,14 +59,13 @@ public:
   ExpressionNode* node;
 };
 
-enum ExpressionParseStatus
+enum class ParseStatus
 {
-  EXPRESSION_PARSE_SUCCESS = 0,
-  EXPRESSION_PARSE_SYNTAX_ERROR,
-  EXPRESSION_PARSE_NO_DEVICE,
+  Success,
+  SyntaxError,
+  NoDevice,
 };
 
-ExpressionParseStatus ParseExpression(const std::string& expr, ControlFinder& finder,
-                                      Expression** expr_out);
+ParseStatus ParseExpression(const std::string& expr, ControlFinder& finder, Expression** expr_out);
 }
 }


### PR DESCRIPTION
Same behavior, but more strongly typed and keeps constants out of their surrounding namespace scope