### PR TITLE
PixelEngine: Move enum constants into the PixelEngine namespace

### DIFF
--- a/Source/Core/VideoCommon/PixelEngine.h
+++ b/Source/Core/VideoCommon/PixelEngine.h
@@ -11,6 +11,8 @@ namespace MMIO
 class Mapping;
 }
 
+namespace PixelEngine
+{
 // internal hardware addresses
 enum
 {
@@ -43,8 +45,6 @@ enum
   PE_PERF_EFB_COPY_CLOCKS_H = 0x2e,
 };
 
-namespace PixelEngine
-{
 // ReadMode specifies the returned alpha channel for EFB peeks
 union UPEAlphaReadReg
 {


### PR DESCRIPTION
Gets some identifier names out of the global namespace.