### PR TITLE
OGL: crop option now crops as well as scales

### DIFF
--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -42,6 +42,8 @@ void OpenGLPostProcessing::BlitFromTexture(TargetRectangle src, TargetRectangle 
 {
   ApplyShader();
 
+  glEnable(GL_SCISSOR_TEST);
+  glScissor(crop_rc.left, crop_rc.bottom, crop_rc.GetWidth(), crop_rc.GetHeight());
   glViewport(dst.left, dst.bottom, dst.GetWidth(), dst.GetHeight());
 
   OpenGL_BindAttributelessVAO();

--- a/Source/Core/VideoBackends/OGL/PostProcessing.cpp
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.cpp
@@ -37,8 +37,8 @@ OpenGLPostProcessing::~OpenGLPostProcessing()
 }
 
 void OpenGLPostProcessing::BlitFromTexture(TargetRectangle src, TargetRectangle dst,
-                                           int src_texture, int src_width, int src_height,
-                                           int layer)
+                                           CropRectangle crop_rc, int src_texture, int src_width,
+                                           int src_height, int layer)
 {
   ApplyShader();
 

--- a/Source/Core/VideoBackends/OGL/PostProcessing.h
+++ b/Source/Core/VideoBackends/OGL/PostProcessing.h
@@ -22,8 +22,8 @@ public:
   OpenGLPostProcessing();
   ~OpenGLPostProcessing();
 
-  void BlitFromTexture(TargetRectangle src, TargetRectangle dst, int src_texture, int src_width,
-                       int src_height, int layer) override;
+  void BlitFromTexture(TargetRectangle src, TargetRectangle dst, CropRectangle crop_rc,
+                       int src_texture, int src_width, int src_height, int layer) override;
   void ApplyShader() override;
 
 private:

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1339,6 +1339,9 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     }
   }
 
+  // GL_SCISSOR_TEST is enabled by DrawFrame calls
+  glDisable(GL_SCISSOR_TEST);
+
   // Finish up the current frame, print some stats
 
   SetWindowSize(fbStride, fbHeight);

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1186,12 +1186,15 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, GLuint src_t
     else
       std::tie(leftRc, rightRc) = ConvertStereoRectangle(dst);
 
-    m_post_processor->BlitFromTexture(src, leftRc, src_texture, src_width, src_height, 0);
-    m_post_processor->BlitFromTexture(src, rightRc, src_texture, src_width, src_height, 1);
+    m_post_processor->BlitFromTexture(src, leftRc, CropRectangle{leftRc}, src_texture, src_width,
+                                      src_height, 0);
+    m_post_processor->BlitFromTexture(src, rightRc, CropRectangle{rightRc}, src_texture, src_width,
+                                      src_height, 1);
   }
   else
   {
-    m_post_processor->BlitFromTexture(src, dst, src_texture, src_width, src_height);
+    m_post_processor->BlitFromTexture(src, dst, CropRectangle{dst}, src_texture, src_width,
+                                      src_height);
   }
 }
 

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -112,23 +112,25 @@ private:
                       const TargetRectangle& targetPixelRc, const void* data);
 
   // Draw either the EFB, or specified XFB sources to the currently-bound framebuffer.
-  void DrawFrame(GLuint framebuffer, const TargetRectangle& target_rc,
+  void DrawFrame(GLuint framebuffer, const TargetRectangle& target_rc, const CropRectangle& crop_rc,
                  const EFBRectangle& source_rc, u32 xfb_addr,
                  const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                  u32 fb_stride, u32 fb_height);
-  void DrawEFB(GLuint framebuffer, const TargetRectangle& target_rc, const EFBRectangle& source_rc);
-  void DrawVirtualXFB(GLuint framebuffer, const TargetRectangle& target_rc, u32 xfb_addr,
+  void DrawEFB(GLuint framebuffer, const TargetRectangle& target_rc, const CropRectangle& crop_rc,
+               const EFBRectangle& source_rc);
+  void DrawVirtualXFB(GLuint framebuffer, const TargetRectangle& target_rc,
+                      const CropRectangle& crop_rc, u32 xfb_addr,
                       const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                       u32 fb_stride, u32 fb_height);
   void DrawRealXFB(GLuint framebuffer, const TargetRectangle& target_rc,
-                   const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
-                   u32 fb_stride, u32 fb_height);
+                   const CropRectangle& crop_rc, const XFBSourceBase* const* xfb_sources,
+                   u32 xfb_count, u32 fb_width, u32 fb_stride, u32 fb_height);
 
-  void BlitScreen(TargetRectangle src, TargetRectangle dst, GLuint src_texture, int src_width,
-                  int src_height);
+  void BlitScreen(TargetRectangle src, TargetRectangle dst, CropRectangle crop_rc,
+                  GLuint src_texture, int src_width, int src_height);
 
   void FlushFrameDump();
-  void DumpFrame(const TargetRectangle& flipped_trc, u64 ticks);
+  void DumpFrame(const TargetRectangle& flipped_trc, const CropRectangle& flipped_crop, u64 ticks);
   void DumpFrameUsingFBO(const EFBRectangle& source_rc, u32 xfb_addr,
                          const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                          u32 fb_stride, u32 fb_height, u64 ticks);

--- a/Source/Core/VideoCommon/PostProcessing.h
+++ b/Source/Core/VideoCommon/PostProcessing.h
@@ -84,8 +84,8 @@ public:
 
   PostProcessingShaderConfiguration* GetConfig() { return &m_config; }
   // Should be implemented by the backends for backend specific code
-  virtual void BlitFromTexture(TargetRectangle src, TargetRectangle dst, int src_texture,
-                               int src_width, int src_height, int layer = 0) = 0;
+  virtual void BlitFromTexture(TargetRectangle src, TargetRectangle dst, CropRectangle crop_rc,
+                               int src_texture, int src_width, int src_height, int layer = 0) = 0;
   virtual void ApplyShader() = 0;
 
 protected:

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -640,9 +640,6 @@ void Renderer::UpdateDrawRectangle()
   int YOffset = (int)(FloatYOffset + 0.5f);
   int iWhidth = (int)ceil(FloatGLWidth);
   int iHeight = (int)ceil(FloatGLHeight);
-  iWhidth -=
-      iWhidth % 4;  // ensure divisibility by 4 to make it compatible with all the video encoders
-  iHeight -= iHeight % 4;
 
   m_target_rectangle.left = XOffset;
   m_target_rectangle.top = YOffset;
@@ -683,11 +680,6 @@ void Renderer::SetWindowSize(int width, int height)
 
   width = static_cast<int>(std::ceil(scaled_width));
   height = static_cast<int>(std::ceil(scaled_height));
-
-  // UpdateDrawRectangle() makes sure that the rendered image is divisible by four for video
-  // encoders, so do that here too to match it
-  width -= width % 4;
-  height -= height % 4;
 
   // Track the last values of width/height to avoid sending a window resize event every frame.
   if (width != m_last_window_request_width || height != m_last_window_request_height)

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -93,6 +93,7 @@ public:
   virtual TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) = 0;
 
   const TargetRectangle& GetTargetRectangle() const { return m_target_rectangle; }
+  const CropRectangle& GetCropRectangle() const { return m_crop_rectangle; }
   float CalculateDrawAspectRatio(int target_width, int target_height) const;
   std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height) const;
   TargetRectangle CalculateFrameDumpDrawRectangle() const;
@@ -168,6 +169,7 @@ protected:
   int m_backbuffer_width = 0;
   int m_backbuffer_height = 0;
   int m_last_efb_scale = 0;
+  CropRectangle m_crop_rectangle = {};
   TargetRectangle m_target_rectangle = {};
   bool m_xfb_written = false;
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -92,9 +92,9 @@ public:
   // Use this to convert a whole native EFB rect to backbuffer coordinates
   virtual TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) = 0;
 
-  const TargetRectangle& GetTargetRectangle() const { return m_target_rectangle; }
-  const CropRectangle& GetCropRectangle() const { return m_crop_rectangle; }
-  float CalculateDrawAspectRatio(int target_width, int target_height) const;
+  const TargetRectangle& GetTargetRectangle() { return m_target_rectangle; }
+  const CropRectangle& GetCropRectangle() { return m_crop_rectangle; }
+  float CalculateDrawAspectRatio() const;
   std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height) const;
   TargetRectangle CalculateFrameDumpDrawRectangle() const;
   void UpdateDrawRectangle();

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -73,6 +73,10 @@ using EFBRectangle = TaggedRectangle<struct EFBRectangleTag>;
 // convert an EFBRectangle to a TargetRectangle.
 using TargetRectangle = TaggedRectangle<struct TargetRectangleTag>;
 
+// This structure should only be used to represent an area in the backbuffer
+// outside of which nothing will be drawn.
+using CropRectangle = TaggedRectangle<struct CropRectangleTag>;
+
 #ifdef _WIN32
 #define PRIM_LOG(...) DEBUG_LOG(VIDEO, __VA_ARGS__)
 #else

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -31,17 +31,22 @@ const u32 MAX_XFB_WIDTH = 720;
 // that are next to each other in memory (TODO: handle that situation).
 const u32 MAX_XFB_HEIGHT = 574;
 
-// This structure should only be used to represent a rectangle in EFB
-// coordinates, where the origin is at the upper left and the frame dimensions
-// are 640 x 528.
-typedef MathUtil::Rectangle<int> EFBRectangle;
-
-// This structure should only be used to represent a rectangle in standard target
-// coordinates, where the origin is at the lower left and the frame dimensions
-// depend on the resolution settings. Use Renderer::ConvertEFBRectangle to
-// convert an EFBRectangle to a TargetRectangle.
-struct TargetRectangle : public MathUtil::Rectangle<int>
+template <typename Tag>
+struct TaggedRectangle : public MathUtil::Rectangle<int>
 {
+  constexpr TaggedRectangle() = default;
+  constexpr TaggedRectangle(int left, int top, int right, int bottom)
+      : MathUtil::Rectangle<int>(left, top, right, bottom)
+  {
+  }
+  explicit constexpr TaggedRectangle(const MathUtil::Rectangle<int>& rect)
+  {
+    top = rect.top;
+    right = rect.right;
+    bottom = rect.bottom;
+    left = rect.left;
+  }
+
 #ifdef _WIN32
   // Only used by D3D backend.
   const RECT* AsRECT() const
@@ -56,6 +61,17 @@ struct TargetRectangle : public MathUtil::Rectangle<int>
   }
 #endif
 };
+
+// This structure should only be used to represent a rectangle in EFB
+// coordinates, where the origin is at the upper left and the frame dimensions
+// are 640 x 528.
+using EFBRectangle = TaggedRectangle<struct EFBRectangleTag>;
+
+// This structure should only be used to represent a rectangle in standard target
+// coordinates, where the origin is at the lower left and the frame dimensions
+// depend on the resolution settings. Use Renderer::ConvertEFBRectangle to
+// convert an EFBRectangle to a TargetRectangle.
+using TargetRectangle = TaggedRectangle<struct TargetRectangleTag>;
 
 #ifdef _WIN32
 #define PRIM_LOG(...) DEBUG_LOG(VIDEO, __VA_ARGS__)


### PR DESCRIPTION
The existing code always scales up the image, relying on the implicit cropping provided by the window. It only works for cropping on one dimension (e.g. if the window is wider than 4:3, and the image is taller than 4:3).

Here's a (hopefully) representative ASCII picture:

```
                image 
               +------+
           +--------------+
window ->  |   |      |   |
           |   |      |   |
           |   |      |   |
           +--------------+
               +------+
```

This PR changes the VideoCommon code to expose a `CropRectangle`, and changes the OpenGL backend to only render within that area. The other backends still do not properly crop, but no longer scale when they shouldn't.