### PR TITLE
VideoCommon: Eliminate static state in Renderer

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -485,7 +485,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulatio
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
   Core::SaveScreenShot("thumb");
-  Renderer::s_screenshotCompleted.WaitFor(std::chrono::seconds(2));
+  g_renderer->s_screenshot_completed.WaitFor(std::chrono::seconds(2));
   Core::Stop();
   updateMainFrameEvent.Set();  // Kick the waiting event
 }

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -484,8 +484,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_StopEmulatio
                                                                                   jobject obj)
 {
   std::lock_guard<std::mutex> guard(s_host_identity_lock);
-  Core::SaveScreenShot("thumb");
-  g_renderer->s_screenshot_completed.WaitFor(std::chrono::seconds(2));
+  Core::SaveScreenShot("thumb", true);
   Core::Stop();
   updateMainFrameEvent.Set();  // Kick the waiting event
 }

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -738,7 +738,7 @@ void SaveScreenShot()
 
   SetState(State::Paused);
 
-  Renderer::SetScreenshot(GenerateScreenshotName());
+  g_renderer->SetScreenshot(GenerateScreenshotName());
 
   if (!bPaused)
     SetState(State::Running);
@@ -752,7 +752,7 @@ void SaveScreenShot(const std::string& name)
 
   std::string filePath = GenerateScreenshotFolderPath() + name + ".png";
 
-  Renderer::SetScreenshot(filePath);
+  g_renderer->SetScreenshot(filePath);
 
   if (!bPaused)
     SetState(State::Running);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -732,19 +732,19 @@ static std::string GenerateScreenshotName()
   return name;
 }
 
-void SaveScreenShot()
+void SaveScreenShot(bool wait_for_completion)
 {
   const bool bPaused = GetState() == State::Paused;
 
   SetState(State::Paused);
 
-  g_renderer->SetScreenshot(GenerateScreenshotName());
+  g_renderer->SaveScreenshot(GenerateScreenshotName(), wait_for_completion);
 
   if (!bPaused)
     SetState(State::Running);
 }
 
-void SaveScreenShot(const std::string& name)
+void SaveScreenShot(const std::string& name, bool wait_for_completion)
 {
   const bool bPaused = GetState() == State::Paused;
 
@@ -752,7 +752,7 @@ void SaveScreenShot(const std::string& name)
 
   std::string filePath = GenerateScreenshotFolderPath() + name + ".png";
 
-  g_renderer->SetScreenshot(filePath);
+  g_renderer->SaveScreenshot(filePath, wait_for_completion);
 
   if (!bPaused)
     SetState(State::Running);

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -55,8 +55,8 @@ bool IsGPUThread();
 void SetState(State state);
 State GetState();
 
-void SaveScreenShot();
-void SaveScreenShot(const std::string& name);
+void SaveScreenShot(bool wait_for_completion = false);
+void SaveScreenShot(const std::string& name, bool wait_for_completion = false);
 
 void Callback_WiimoteInterruptChannel(int _number, u16 _channelID, const void* _pData, u32 _Size);
 

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -98,18 +98,10 @@ D3DTexture2D*& FramebufferManager::GetResolvedEFBDepthTexture()
   }
 }
 
-FramebufferManager::FramebufferManager()
+FramebufferManager::FramebufferManager(int target_width, int target_height)
 {
-  m_target_width = g_renderer->GetTargetWidth();
-  m_target_height = g_renderer->GetTargetHeight();
-  if (m_target_height < 1)
-  {
-    m_target_height = 1;
-  }
-  if (m_target_width < 1)
-  {
-    m_target_width = 1;
-  }
+  m_target_width = static_cast<unsigned int>(std::max(target_width, 1));
+  m_target_height = static_cast<unsigned int>(std::max(target_height, 1));
   DXGI_SAMPLE_DESC sample_desc;
   sample_desc.Count = g_ActiveConfig.iMultisamples;
   sample_desc.Quality = 0;

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.cpp
@@ -100,8 +100,8 @@ D3DTexture2D*& FramebufferManager::GetResolvedEFBDepthTexture()
 
 FramebufferManager::FramebufferManager()
 {
-  m_target_width = Renderer::GetTargetWidth();
-  m_target_height = Renderer::GetTargetHeight();
+  m_target_width = g_renderer->GetTargetWidth();
+  m_target_height = g_renderer->GetTargetHeight();
   if (m_target_height < 1)
   {
     m_target_height = 1;
@@ -318,8 +318,8 @@ void XFBSource::CopyEFB(float Gamma)
   D3D::SetPointCopySampler();
 
   D3D::drawShadedTexQuad(
-      FramebufferManager::GetEFBColorTexture()->GetSRV(), &rect, Renderer::GetTargetWidth(),
-      Renderer::GetTargetHeight(), PixelShaderCache::GetColorCopyProgram(true),
+      FramebufferManager::GetEFBColorTexture()->GetSRV(), &rect, g_renderer->GetTargetWidth(),
+      g_renderer->GetTargetHeight(), PixelShaderCache::GetColorCopyProgram(true),
       VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),
       GeometryShaderCache::GetCopyGeometryShader(), Gamma);
 

--- a/Source/Core/VideoBackends/D3D/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D/FramebufferManager.h
@@ -60,7 +60,7 @@ struct XFBSource : public XFBSourceBase
 class FramebufferManager : public FramebufferManagerBase
 {
 public:
-  FramebufferManager();
+  FramebufferManager(int target_width, int target_height);
   ~FramebufferManager();
 
   static D3DTexture2D*& GetEFBColorTexture();

--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.cpp
@@ -137,7 +137,7 @@ void PSTextureEncoder::Encode(u8* dst, u32 format, u32 native_width, u32 bytes_p
       D3D::SetPointCopySampler();
 
     D3D::drawShadedTexQuad(
-        pEFB, targetRect.AsRECT(), Renderer::GetTargetWidth(), Renderer::GetTargetHeight(),
+        pEFB, targetRect.AsRECT(), g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight(),
         SetStaticShader(format, is_depth_copy, isIntensity, scaleByHalf),
         VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout());
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -865,7 +865,6 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
   // Resize the back buffers NOW to avoid flickering
   if (CalculateTargetSize() || xfbchanged || windowResized ||
-      m_last_efb_scale != g_ActiveConfig.iEFBScale ||
       s_last_multisamples != g_ActiveConfig.iMultisamples ||
       s_last_stereo_mode != (g_ActiveConfig.iStereoMode > 0))
   {
@@ -885,10 +884,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
     UpdateDrawRectangle();
 
-    m_last_efb_scale = g_ActiveConfig.iEFBScale;
     s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
-
-    PixelShaderManager::SetEfbScaleChanged();
 
     D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -239,7 +239,7 @@ Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferH
   s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
   s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
 
-  g_framebuffer_manager = std::make_unique<FramebufferManager>(s_target_width, s_target_height);
+  g_framebuffer_manager = std::make_unique<FramebufferManager>(m_target_width, m_target_height);
   SetupDeviceObjects();
 
   // Setup GX pipeline state
@@ -268,7 +268,7 @@ Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferH
   D3D::context->ClearDepthStencilView(FramebufferManager::GetEFBDepthTexture()->GetDSV(),
                                       D3D11_CLEAR_DEPTH, 0.f, 0);
 
-  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, (float)s_target_width, (float)s_target_height);
+  D3D11_VIEWPORT vp = CD3D11_VIEWPORT(0.f, 0.f, (float)m_target_width, (float)m_target_height);
   D3D::context->RSSetViewports(1, &vp);
   D3D::context->OMSetRenderTargets(1, &FramebufferManager::GetEFBColorTexture()->GetRTV(),
                                    FramebufferManager::GetEFBDepthTexture()->GetDSV());
@@ -711,7 +711,7 @@ void Renderer::SetBlendMode(bool forceUpdate)
 void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                         const EFBRectangle& rc, u64 ticks, float Gamma)
 {
-  if ((!XFBWrited && !g_ActiveConfig.RealXFBEnabled()) || !fbWidth || !fbHeight)
+  if ((!m_xfb_written && !g_ActiveConfig.RealXFBEnabled()) || !fbWidth || !fbHeight)
   {
     Core::Callback_VideoCopiedToXFB(false);
     return;
@@ -865,7 +865,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
   // Resize the back buffers NOW to avoid flickering
   if (CalculateTargetSize() || xfbchanged || windowResized ||
-      s_last_efb_scale != g_ActiveConfig.iEFBScale ||
+      m_last_efb_scale != g_ActiveConfig.iEFBScale ||
       s_last_multisamples != g_ActiveConfig.iMultisamples ||
       s_last_stereo_mode != (g_ActiveConfig.iStereoMode > 0))
   {
@@ -879,13 +879,13 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
       D3D::Reset();
       SAFE_RELEASE(s_screenshot_texture);
       SAFE_RELEASE(s_3d_vision_texture);
-      s_backbuffer_width = D3D::GetBackBufferWidth();
-      s_backbuffer_height = D3D::GetBackBufferHeight();
+      m_backbuffer_width = D3D::GetBackBufferWidth();
+      m_backbuffer_height = D3D::GetBackBufferHeight();
     }
 
     UpdateDrawRectangle();
 
-    s_last_efb_scale = g_ActiveConfig.iEFBScale;
+    m_last_efb_scale = g_ActiveConfig.iEFBScale;
     s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
 
     PixelShaderManager::SetEfbScaleChanged();
@@ -893,7 +893,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
 
     g_framebuffer_manager.reset();
-    g_framebuffer_manager = std::make_unique<FramebufferManager>(s_target_width, s_target_height);
+    g_framebuffer_manager = std::make_unique<FramebufferManager>(m_target_width, m_target_height);
     float clear_col[4] = {0.f, 0.f, 0.f, 1.f};
     D3D::context->ClearRenderTargetView(FramebufferManager::GetEFBColorTexture()->GetRTV(),
                                         clear_col);
@@ -1147,12 +1147,12 @@ u16 Renderer::BBoxRead(int index)
   if (index < 2)
   {
     // left/right
-    value = value * EFB_WIDTH / s_target_width;
+    value = value * EFB_WIDTH / m_target_width;
   }
   else
   {
     // up/down
-    value = value * EFB_HEIGHT / s_target_height;
+    value = value * EFB_HEIGHT / m_target_height;
   }
   if (index & 1)
     value++;  // fix max values to describe the outer border
@@ -1167,11 +1167,11 @@ void Renderer::BBoxWrite(int index, u16 _value)
     value--;
   if (index < 2)
   {
-    value = value * s_target_width / EFB_WIDTH;
+    value = value * m_target_width / EFB_WIDTH;
   }
   else
   {
-    value = value * s_target_height / EFB_HEIGHT;
+    value = value * m_target_height / EFB_HEIGHT;
   }
 
   BBox::Set(index, value);
@@ -1205,11 +1205,11 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D
   else if (g_ActiveConfig.iStereoMode == STEREO_3DVISION)
   {
     if (!s_3d_vision_texture)
-      Create3DVisionTexture(s_backbuffer_width, s_backbuffer_height);
+      Create3DVisionTexture(m_backbuffer_width, m_backbuffer_height);
 
     D3D11_VIEWPORT leftVp = CD3D11_VIEWPORT((float)dst.left, (float)dst.top, (float)dst.GetWidth(),
                                             (float)dst.GetHeight());
-    D3D11_VIEWPORT rightVp = CD3D11_VIEWPORT((float)(dst.left + s_backbuffer_width), (float)dst.top,
+    D3D11_VIEWPORT rightVp = CD3D11_VIEWPORT((float)(dst.left + m_backbuffer_width), (float)dst.top,
                                              (float)dst.GetWidth(), (float)dst.GetHeight());
 
     // Render to staging texture which is double the width of the backbuffer
@@ -1229,7 +1229,7 @@ void Renderer::BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D
 
     // Copy the left eye to the backbuffer, if Nvidia 3D Vision is enabled it should
     // recognize the signature and automatically include the right eye frame.
-    D3D11_BOX box = CD3D11_BOX(0, 0, 0, s_backbuffer_width, s_backbuffer_height, 1);
+    D3D11_BOX box = CD3D11_BOX(0, 0, 0, m_backbuffer_width, m_backbuffer_height, 1);
     D3D::context->CopySubresourceRegion(D3D::GetBackBuffer()->GetTex(), 0, 0, 0, 0,
                                         s_3d_vision_texture->GetTex(), 0, &box);
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -324,8 +324,7 @@ bool Renderer::CheckForResize()
   int client_height = rcWindow.bottom - rcWindow.top;
 
   // Sanity check
-  if ((client_width != Renderer::GetBackbufferWidth() ||
-       client_height != Renderer::GetBackbufferHeight()) &&
+  if ((client_width != GetBackbufferWidth() || client_height != GetBackbufferHeight()) &&
       client_width >= 4 && client_height >= 4)
   {
     return true;

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -84,8 +84,6 @@ static void SetupDeviceObjects()
 {
   s_television.Init();
 
-  g_framebuffer_manager = std::make_unique<FramebufferManager>();
-
   HRESULT hr;
 
   D3D11_DEPTH_STENCIL_DESC ddesc;
@@ -235,25 +233,13 @@ static void Create3DVisionTexture(int width, int height)
   delete[] sysData.pSysMem;
 }
 
-Renderer::Renderer(void*& window_handle)
+Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferHeight())
 {
-  D3D::Create((HWND)window_handle);
-
-  s_backbuffer_width = D3D::GetBackBufferWidth();
-  s_backbuffer_height = D3D::GetBackBufferHeight();
-
-  FramebufferManagerBase::SetLastXfbWidth(MAX_XFB_WIDTH);
-  FramebufferManagerBase::SetLastXfbHeight(MAX_XFB_HEIGHT);
-
-  UpdateDrawRectangle();
-
   s_last_multisamples = g_ActiveConfig.iMultisamples;
-  s_last_efb_scale = g_ActiveConfig.iEFBScale;
   s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
   s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
-  CalculateTargetSize();
-  PixelShaderManager::SetEfbScaleChanged();
 
+  g_framebuffer_manager = std::make_unique<FramebufferManager>(s_target_width, s_target_height);
   SetupDeviceObjects();
 
   // Setup GX pipeline state
@@ -907,7 +893,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
     D3D::context->OMSetRenderTargets(1, &D3D::GetBackBuffer()->GetRTV(), nullptr);
 
     g_framebuffer_manager.reset();
-    g_framebuffer_manager = std::make_unique<FramebufferManager>();
+    g_framebuffer_manager = std::make_unique<FramebufferManager>(s_target_width, s_target_height);
     float clear_col[4] = {0.f, 0.f, 0.f, 1.f};
     D3D::context->ClearRenderTargetView(FramebufferManager::GetEFBColorTexture()->GetRTV(),
                                         clear_col);

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -16,8 +16,8 @@ class D3DTexture2D;
 class Renderer : public ::Renderer
 {
 public:
-  Renderer(void*& window_handle);
-  ~Renderer();
+  Renderer();
+  ~Renderer() override;
 
   void SetColorMask() override;
   void SetBlendMode(bool forceUpdate) override;

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -60,7 +60,7 @@ public:
 
   void ReinterpretPixelData(unsigned int convtype) override;
 
-  static bool CheckForResize();
+  bool CheckForResize();
 
   u32 GetMaxTextureSize() override;
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -240,7 +240,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(bool is_depth_copy, const EFBRe
 
   // Create texture copy
   D3D::drawShadedTexQuad(
-      efbTexSRV, &sourcerect, Renderer::GetTargetWidth(), Renderer::GetTargetHeight(),
+      efbTexSRV, &sourcerect, g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight(),
       is_depth_copy ? PixelShaderCache::GetDepthMatrixProgram(multisampled) :
                       PixelShaderCache::GetColorMatrixProgram(multisampled),
       VertexShaderCache::GetSimpleVertexShader(), VertexShaderCache::GetSimpleInputLayout(),

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 
 #include "VideoBackends/D3D/BoundingBox.h"
@@ -144,11 +145,15 @@ bool VideoBackend::Initialize(void* window_handle)
 
 void VideoBackend::Video_Prepare()
 {
+  if (FAILED(D3D::Create(reinterpret_cast<HWND>(m_window_handle))))
+    PanicAlert("Failed to create D3D device.");
+
   // internal interfaces
-  g_renderer = std::make_unique<Renderer>(m_window_handle);
+  g_renderer = std::make_unique<Renderer>();
   g_texture_cache = std::make_unique<TextureCache>();
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = std::make_unique<PerfQuery>();
+  g_renderer->InitializeCommon();
   VertexShaderCache::Init();
   PixelShaderCache::Init();
   GeometryShaderCache::Init();

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -153,7 +153,6 @@ void VideoBackend::Video_Prepare()
   g_texture_cache = std::make_unique<TextureCache>();
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = std::make_unique<PerfQuery>();
-  g_renderer->InitializeCommon();
   VertexShaderCache::Init();
   PixelShaderCache::Init();
   GeometryShaderCache::Init();

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
@@ -84,10 +84,10 @@ D3DTexture2D*& FramebufferManager::GetResolvedEFBDepthTexture()
   }
 }
 
-FramebufferManager::FramebufferManager()
+FramebufferManager::FramebufferManager(int target_width, int target_height)
 {
-  m_target_width = std::max(g_renderer->GetTargetWidth(), 1);
-  m_target_height = std::max(g_renderer->GetTargetHeight(), 1);
+  m_target_width = static_cast<unsigned int>(std::max(target_width, 1));
+  m_target_height = static_cast<unsigned int>(std::max(target_height, 1));
 
   DXGI_SAMPLE_DESC sample_desc;
   sample_desc.Count = g_ActiveConfig.iMultisamples;

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.cpp
@@ -86,8 +86,8 @@ D3DTexture2D*& FramebufferManager::GetResolvedEFBDepthTexture()
 
 FramebufferManager::FramebufferManager()
 {
-  m_target_width = std::max(Renderer::GetTargetWidth(), 1);
-  m_target_height = std::max(Renderer::GetTargetHeight(), 1);
+  m_target_width = std::max(g_renderer->GetTargetWidth(), 1);
+  m_target_height = std::max(g_renderer->GetTargetHeight(), 1);
 
   DXGI_SAMPLE_DESC sample_desc;
   sample_desc.Count = g_ActiveConfig.iMultisamples;
@@ -525,7 +525,7 @@ void XFBSource::CopyEFB(float gamma)
   D3D::SetPointCopySampler();
 
   D3D::DrawShadedTexQuad(FramebufferManager::GetEFBColorTexture(), &rect,
-                         Renderer::GetTargetWidth(), Renderer::GetTargetHeight(),
+                         g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight(),
                          StaticShaderCache::GetColorCopyPixelShader(true),
                          StaticShaderCache::GetSimpleVertexShader(),
                          StaticShaderCache::GetSimpleVertexShaderInputLayout(),

--- a/Source/Core/VideoBackends/D3D12/FramebufferManager.h
+++ b/Source/Core/VideoBackends/D3D12/FramebufferManager.h
@@ -58,7 +58,7 @@ struct XFBSource final : public XFBSourceBase
 class FramebufferManager final : public FramebufferManagerBase
 {
 public:
-  FramebufferManager();
+  FramebufferManager(int target_width, int target_height);
   ~FramebufferManager();
 
   static D3DTexture2D*& GetEFBColorTexture();

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.cpp
@@ -166,7 +166,7 @@ void PSTextureEncoder::Encode(u8* dst, u32 format, u32 native_width, u32 bytes_p
     D3D::SetPointCopySampler();
 
   D3D::DrawShadedTexQuad(
-      efb_source, target_rect.AsRECT(), Renderer::GetTargetWidth(), Renderer::GetTargetHeight(),
+      efb_source, target_rect.AsRECT(), g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight(),
       SetStaticShader(format, is_depth_copy, is_intensity, scale_by_half),
       StaticShaderCache::GetSimpleVertexShader(),
       StaticShaderCache::GetSimpleVertexShaderInputLayout(), D3D12_SHADER_BYTECODE(), 1.0f, 0,

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -821,7 +821,6 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
 
   // Resize the back buffers NOW to avoid flickering
   if (CalculateTargetSize() || xfb_changed || window_resized ||
-      m_last_efb_scale != g_ActiveConfig.iEFBScale ||
       s_last_multisamples != g_ActiveConfig.iMultisamples ||
       s_last_stereo_mode != (g_ActiveConfig.iStereoMode > 0))
   {
@@ -854,10 +853,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
 
     UpdateDrawRectangle();
 
-    m_last_efb_scale = g_ActiveConfig.iEFBScale;
     s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
-
-    PixelShaderManager::SetEfbScaleChanged();
 
     D3D::GetBackBuffer()->TransitionToResourceState(D3D::current_command_list,
                                                     D3D12_RESOURCE_STATE_RENDER_TARGET);

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -221,7 +221,7 @@ Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferH
   s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
   s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
 
-  g_framebuffer_manager = std::make_unique<FramebufferManager>(s_target_width, s_target_height);
+  g_framebuffer_manager = std::make_unique<FramebufferManager>(m_target_width, m_target_height);
   SetupDeviceObjects();
 
   // Setup GX pipeline state
@@ -257,8 +257,8 @@ Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferH
 
   D3D12_VIEWPORT vp = {0.f,
                        0.f,
-                       static_cast<float>(s_target_width),
-                       static_cast<float>(s_target_height),
+                       static_cast<float>(m_target_width),
+                       static_cast<float>(m_target_height),
                        D3D12_MIN_DEPTH,
                        D3D12_MAX_DEPTH};
   D3D::current_command_list->RSSetViewports(1, &vp);
@@ -634,7 +634,7 @@ void Renderer::SetBlendMode(bool force_update)
 void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height,
                         const EFBRectangle& rc, u64 ticks, float gamma)
 {
-  if ((!XFBWrited && !g_ActiveConfig.RealXFBEnabled()) || !fb_width || !fb_height)
+  if ((!m_xfb_written && !g_ActiveConfig.RealXFBEnabled()) || !fb_width || !fb_height)
   {
     Core::Callback_VideoCopiedToXFB(false);
     return;
@@ -821,7 +821,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
 
   // Resize the back buffers NOW to avoid flickering
   if (CalculateTargetSize() || xfb_changed || window_resized ||
-      s_last_efb_scale != g_ActiveConfig.iEFBScale ||
+      m_last_efb_scale != g_ActiveConfig.iEFBScale ||
       s_last_multisamples != g_ActiveConfig.iMultisamples ||
       s_last_stereo_mode != (g_ActiveConfig.iStereoMode > 0))
   {
@@ -848,13 +848,13 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
         s_screenshot_texture = nullptr;
       }
 
-      s_backbuffer_width = D3D::GetBackBufferWidth();
-      s_backbuffer_height = D3D::GetBackBufferHeight();
+      m_backbuffer_width = D3D::GetBackBufferWidth();
+      m_backbuffer_height = D3D::GetBackBufferHeight();
     }
 
     UpdateDrawRectangle();
 
-    s_last_efb_scale = g_ActiveConfig.iEFBScale;
+    m_last_efb_scale = g_ActiveConfig.iEFBScale;
     s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
 
     PixelShaderManager::SetEfbScaleChanged();
@@ -865,7 +865,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
                                                   nullptr);
 
     g_framebuffer_manager.reset();
-    g_framebuffer_manager = std::make_unique<FramebufferManager>(s_target_width, s_target_height);
+    g_framebuffer_manager = std::make_unique<FramebufferManager>(m_target_width, m_target_height);
     const float clear_color[4] = {0.f, 0.f, 0.f, 1.f};
 
     FramebufferManager::GetEFBColorTexture()->TransitionToResourceState(
@@ -1177,12 +1177,12 @@ u16 Renderer::BBoxRead(int index)
   if (index < 2)
   {
     // left/right
-    value = value * EFB_WIDTH / s_target_width;
+    value = value * EFB_WIDTH / m_target_width;
   }
   else
   {
     // up/down
-    value = value * EFB_HEIGHT / s_target_height;
+    value = value * EFB_HEIGHT / m_target_height;
   }
   if (index & 1)
     value++;  // fix max values to describe the outer border
@@ -1197,11 +1197,11 @@ void Renderer::BBoxWrite(int index, u16 value)
     local_value--;
   if (index < 2)
   {
-    local_value = local_value * s_target_width / EFB_WIDTH;
+    local_value = local_value * m_target_width / EFB_WIDTH;
   }
   else
   {
-    local_value = local_value * s_target_height / EFB_HEIGHT;
+    local_value = local_value * m_target_height / EFB_HEIGHT;
   }
 
   BBox::Set(index, local_value);

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -308,7 +308,7 @@ TargetRectangle Renderer::ConvertEFBRectangle(const EFBRectangle& rc)
 
 // With D3D, we have to resize the backbuffer if the window changed
 // size.
-__declspec(noinline) bool Renderer::CheckForResize()
+bool Renderer::CheckForResize()
 {
   RECT rc_window;
   GetClientRect(D3D::hWnd, &rc_window);

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -101,8 +101,6 @@ StateCache gx_state_cache;
 
 static void SetupDeviceObjects()
 {
-  g_framebuffer_manager = std::make_unique<FramebufferManager>();
-
   D3D12_DEPTH_STENCIL_DESC depth_desc;
   depth_desc.DepthEnable = FALSE;
   depth_desc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
@@ -211,7 +209,7 @@ static void Create3DVisionTexture(int width, int height)
   // D3D12TODO: 3D Vision not implemented on D3D12 backend.
 }
 
-Renderer::Renderer(void*& window_handle)
+Renderer::Renderer() : ::Renderer(D3D::GetBackBufferWidth(), D3D::GetBackBufferHeight())
 {
   if (g_ActiveConfig.iStereoMode == STEREO_3DVISION)
   {
@@ -219,21 +217,11 @@ Renderer::Renderer(void*& window_handle)
     return;
   }
 
-  s_backbuffer_width = D3D::GetBackBufferWidth();
-  s_backbuffer_height = D3D::GetBackBufferHeight();
-
-  FramebufferManagerBase::SetLastXfbWidth(MAX_XFB_WIDTH);
-  FramebufferManagerBase::SetLastXfbHeight(MAX_XFB_HEIGHT);
-
-  UpdateDrawRectangle();
-
   s_last_multisamples = g_ActiveConfig.iMultisamples;
-  s_last_efb_scale = g_ActiveConfig.iEFBScale;
   s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
   s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
-  CalculateTargetSize();
-  PixelShaderManager::SetEfbScaleChanged();
 
+  g_framebuffer_manager = std::make_unique<FramebufferManager>(s_target_width, s_target_height);
   SetupDeviceObjects();
 
   // Setup GX pipeline state
@@ -877,7 +865,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
                                                   nullptr);
 
     g_framebuffer_manager.reset();
-    g_framebuffer_manager = std::make_unique<FramebufferManager>();
+    g_framebuffer_manager = std::make_unique<FramebufferManager>(s_target_width, s_target_height);
     const float clear_color[4] = {0.f, 0.f, 0.f, 1.f};
 
     FramebufferManager::GetEFBColorTexture()->TransitionToResourceState(

--- a/Source/Core/VideoBackends/D3D12/Render.h
+++ b/Source/Core/VideoBackends/D3D12/Render.h
@@ -17,8 +17,8 @@ class D3DTexture2D;
 class Renderer final : public ::Renderer
 {
 public:
-  Renderer(void*& window_handle);
-  ~Renderer();
+  Renderer();
+  ~Renderer() override;
 
   void SetColorMask() override;
   void SetBlendMode(bool force_update) override;

--- a/Source/Core/VideoBackends/D3D12/Render.h
+++ b/Source/Core/VideoBackends/D3D12/Render.h
@@ -59,7 +59,7 @@ public:
 
   void ReinterpretPixelData(unsigned int conv_type) override;
 
-  static bool CheckForResize();
+  bool CheckForResize();
 
   u32 GetMaxTextureSize() override;
 

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -288,7 +288,7 @@ void TextureCache::TCacheEntry::FromRenderTarget(bool is_depth_copy, const EFBRe
 
   // Create texture copy
   D3D::DrawShadedTexQuad(
-      efb_tex, &sourcerect, Renderer::GetTargetWidth(), Renderer::GetTargetHeight(),
+      efb_tex, &sourcerect, g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight(),
       is_depth_copy ? StaticShaderCache::GetDepthMatrixPixelShader(multisampled) :
                       StaticShaderCache::GetColorMatrixPixelShader(multisampled),
       StaticShaderCache::GetSimpleVertexShader(),

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -163,11 +163,12 @@ bool VideoBackend::Initialize(void* window_handle)
 void VideoBackend::Video_Prepare()
 {
   // internal interfaces
-  g_renderer = std::make_unique<Renderer>(m_window_handle);
+  g_renderer = std::make_unique<Renderer>();
   g_texture_cache = std::make_unique<TextureCache>();
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = std::make_unique<PerfQuery>();
   g_xfb_encoder = std::make_unique<XFBEncoder>();
+  g_renderer->InitializeCommon();
   ShaderCache::Init();
   ShaderConstantsManager::Init();
   StaticShaderCache::Init();

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -168,7 +168,6 @@ void VideoBackend::Video_Prepare()
   g_vertex_manager = std::make_unique<VertexManager>();
   g_perf_query = std::make_unique<PerfQuery>();
   g_xfb_encoder = std::make_unique<XFBEncoder>();
-  g_renderer->InitializeCommon();
   ShaderCache::Init();
   ShaderConstantsManager::Init();
   StaticShaderCache::Init();

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -67,7 +67,6 @@ void VideoBackend::Video_Prepare()
   g_perf_query = std::make_unique<PerfQuery>();
   g_framebuffer_manager = std::make_unique<FramebufferManager>();
   g_texture_cache = std::make_unique<TextureCache>();
-  g_renderer->InitializeCommon();
   VertexShaderCache::s_instance = std::make_unique<VertexShaderCache>();
   GeometryShaderCache::s_instance = std::make_unique<GeometryShaderCache>();
   PixelShaderCache::s_instance = std::make_unique<PixelShaderCache>();

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -67,6 +67,7 @@ void VideoBackend::Video_Prepare()
   g_perf_query = std::make_unique<PerfQuery>();
   g_framebuffer_manager = std::make_unique<FramebufferManager>();
   g_texture_cache = std::make_unique<TextureCache>();
+  g_renderer->InitializeCommon();
   VertexShaderCache::s_instance = std::make_unique<VertexShaderCache>();
   GeometryShaderCache::s_instance = std::make_unique<GeometryShaderCache>();
   PixelShaderCache::s_instance = std::make_unique<PixelShaderCache>();

--- a/Source/Core/VideoBackends/Null/Render.cpp
+++ b/Source/Core/VideoBackends/Null/Render.cpp
@@ -11,7 +11,7 @@
 namespace Null
 {
 // Init functions
-Renderer::Renderer()
+Renderer::Renderer() : ::Renderer(1, 1)
 {
   g_Config.bRunning = true;
   UpdateActiveConfig();

--- a/Source/Core/VideoBackends/Null/Render.h
+++ b/Source/Core/VideoBackends/Null/Render.h
@@ -12,7 +12,7 @@ class Renderer : public ::Renderer
 {
 public:
   Renderer();
-  ~Renderer();
+  ~Renderer() override;
 
   void RenderText(const std::string& pstr, int left, int top, u32 color) override;
   u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) override { return 0; }

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -773,8 +773,6 @@ void Renderer::Shutdown()
 
 void Renderer::Init()
 {
-  InitializeCommon();
-
   // Initialize the FramebufferManager
   g_framebuffer_manager =
       std::make_unique<FramebufferManager>(m_target_width, m_target_height, s_MSAASamples);
@@ -1353,13 +1351,11 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
   bool window_resized = false;
   int window_width = static_cast<int>(std::max(GLInterface->GetBackBufferWidth(), 1u));
   int window_height = static_cast<int>(std::max(GLInterface->GetBackBufferHeight(), 1u));
-  if (window_width != m_backbuffer_width || window_height != m_backbuffer_height ||
-      m_last_efb_scale != g_ActiveConfig.iEFBScale)
+  if (window_width != m_backbuffer_width || window_height != m_backbuffer_height)
   {
     window_resized = true;
     m_backbuffer_width = window_width;
     m_backbuffer_height = window_height;
-    m_last_efb_scale = g_ActiveConfig.iEFBScale;
   }
 
   bool target_size_changed = CalculateTargetSize();
@@ -1390,8 +1386,6 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
       g_framebuffer_manager.reset();
       g_framebuffer_manager =
           std::make_unique<FramebufferManager>(m_target_width, m_target_height, s_MSAASamples);
-
-      PixelShaderManager::SetEfbScaleChanged();
     }
   }
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -329,6 +329,8 @@ static void InitDriverInfo()
 
 // Init functions
 Renderer::Renderer()
+    : ::Renderer(static_cast<int>(std::max(GLInterface->GetBackBufferWidth(), 1u)),
+                 static_cast<int>(std::max(GLInterface->GetBackBufferHeight(), 1u)))
 {
   bool bSuccess = true;
 
@@ -687,25 +689,10 @@ Renderer::Renderer()
   s_last_stereo_mode = g_ActiveConfig.iStereoMode > 0;
   s_last_xfb_mode = g_ActiveConfig.bUseRealXFB;
 
-  // Decide framebuffer size
-  s_backbuffer_width = static_cast<int>(std::max(GLInterface->GetBackBufferWidth(), 1u));
-  s_backbuffer_height = static_cast<int>(std::max(GLInterface->GetBackBufferHeight(), 1u));
-
   // Handle VSync on/off
   s_vsync = g_ActiveConfig.IsVSync();
   if (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_VSYNC))
     GLInterface->SwapInterval(s_vsync);
-
-  // TODO: Move these somewhere else?
-  FramebufferManagerBase::SetLastXfbWidth(MAX_XFB_WIDTH);
-  FramebufferManagerBase::SetLastXfbHeight(MAX_XFB_HEIGHT);
-
-  UpdateDrawRectangle();
-
-  s_last_efb_scale = g_ActiveConfig.iEFBScale;
-  CalculateTargetSize();
-
-  PixelShaderManager::SetEfbScaleChanged();
 
   // Because of the fixed framebuffer size we need to disable the resolution
   // options while running
@@ -786,6 +773,8 @@ void Renderer::Shutdown()
 
 void Renderer::Init()
 {
+  InitializeCommon();
+
   // Initialize the FramebufferManager
   g_framebuffer_manager =
       std::make_unique<FramebufferManager>(s_target_width, s_target_height, s_MSAASamples);

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -69,7 +69,7 @@ class Renderer : public ::Renderer
 {
 public:
   Renderer();
-  ~Renderer();
+  ~Renderer() override;
 
   void Init();
   void Shutdown();

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -71,8 +71,8 @@ public:
   Renderer();
   ~Renderer();
 
-  static void Init();
-  static void Shutdown();
+  void Init();
+  void Shutdown();
 
   void SetBlendMode(bool forceUpdate) override;
   void SetScissorRect(const EFBRectangle& rc) override;

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -149,7 +149,7 @@ void VideoBackend::Video_Prepare()
   ProgramShaderCache::Init();
   g_texture_cache = std::make_unique<TextureCache>();
   g_sampler_cache = std::make_unique<SamplerCache>();
-  Renderer::Init();
+  static_cast<Renderer*>(g_renderer.get())->Init();
   TextureConverter::Init();
   BoundingBox::Init();
 }
@@ -166,7 +166,7 @@ void VideoBackend::Video_Cleanup()
   // The following calls are NOT Thread Safe
   // And need to be called from the video thread
   CleanupShared();
-  Renderer::Shutdown();
+  static_cast<Renderer*>(g_renderer.get())->Shutdown();
   BoundingBox::Shutdown();
   TextureConverter::Shutdown();
   g_sampler_cache.reset();

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -25,6 +25,11 @@
 static u8* s_xfbColorTexture[2];
 static int s_currentColorTexture = 0;
 
+SWRenderer::SWRenderer()
+    : ::Renderer(static_cast<int>(MAX_XFB_WIDTH), static_cast<int>(MAX_XFB_HEIGHT))
+{
+}
+
 SWRenderer::~SWRenderer()
 {
   delete[] s_xfbColorTexture[0];

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -13,6 +13,7 @@
 class SWRenderer : public Renderer
 {
 public:
+  SWRenderer();
   ~SWRenderer() override;
 
   static void Init();

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -181,6 +181,7 @@ void VideoSoftware::Video_Prepare()
   g_vertex_manager = std::make_unique<SWVertexLoader>();
   g_perf_query = std::make_unique<PerfQuery>();
   g_texture_cache = std::make_unique<TextureCache>();
+  g_renderer->InitializeCommon();
   SWRenderer::Init();
   g_framebuffer_manager = std::make_unique<FramebufferManager>();
 }

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -181,7 +181,6 @@ void VideoSoftware::Video_Prepare()
   g_vertex_manager = std::make_unique<SWVertexLoader>();
   g_perf_query = std::make_unique<PerfQuery>();
   g_texture_cache = std::make_unique<TextureCache>();
-  g_renderer->InitializeCommon();
   SWRenderer::Init();
   g_framebuffer_manager = std::make_unique<FramebufferManager>();
 }

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -226,8 +226,8 @@ void FramebufferManager::DestroyEFBRenderPass()
 
 bool FramebufferManager::CreateEFBFramebuffer()
 {
-  m_efb_width = static_cast<u32>(std::max(Renderer::GetTargetWidth(), 1));
-  m_efb_height = static_cast<u32>(std::max(Renderer::GetTargetHeight(), 1));
+  m_efb_width = static_cast<u32>(std::max(g_renderer->GetTargetWidth(), 1));
+  m_efb_height = static_cast<u32>(std::max(g_renderer->GetTargetHeight(), 1));
   m_efb_layers = (g_ActiveConfig.iStereoMode != STEREO_OFF) ? 2 : 1;
   INFO_LOG(VIDEO, "EFB size: %ux%ux%u", m_efb_width, m_efb_height, m_efb_layers);
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -266,12 +266,12 @@ u16 Renderer::BBoxRead(int index)
   if (index < 2)
   {
     // left/right
-    value = value * EFB_WIDTH / s_target_width;
+    value = value * EFB_WIDTH / m_target_width;
   }
   else
   {
     // up/down
-    value = value * EFB_HEIGHT / s_target_height;
+    value = value * EFB_HEIGHT / m_target_height;
   }
 
   // fix max values to describe the outer border
@@ -293,12 +293,12 @@ void Renderer::BBoxWrite(int index, u16 value)
   if (index < 2)
   {
     // left/right
-    scaled_value = scaled_value * s_target_width / EFB_WIDTH;
+    scaled_value = scaled_value * m_target_width / EFB_WIDTH;
   }
   else
   {
     // up/down
-    scaled_value = scaled_value * s_target_height / EFB_HEIGHT;
+    scaled_value = scaled_value * m_target_height / EFB_HEIGHT;
   }
 
   m_bounding_box->Set(static_cast<size_t>(index), scaled_value);
@@ -477,7 +477,7 @@ void Renderer::SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height
   FramebufferManager::GetInstance()->FlushEFBPokes();
 
   // Check that we actually have an image to render in XFB-on modes.
-  if ((!XFBWrited && !g_ActiveConfig.RealXFBEnabled()) || !fb_width || !fb_height)
+  if ((!m_xfb_written && !g_ActiveConfig.RealXFBEnabled()) || !fb_width || !fb_height)
   {
     Core::Callback_VideoCopiedToXFB(false);
     return;
@@ -1020,22 +1020,22 @@ void Renderer::CheckForTargetResize(u32 fb_width, u32 fb_stride, u32 fb_height)
 
 void Renderer::CheckForSurfaceChange()
 {
-  if (!s_surface_needs_change.IsSet())
+  if (!m_surface_needs_change.IsSet())
     return;
 
   u32 old_width = m_swap_chain ? m_swap_chain->GetWidth() : 0;
   u32 old_height = m_swap_chain ? m_swap_chain->GetHeight() : 0;
 
   // Fast path, if the surface handle is the same, the window has just been resized.
-  if (m_swap_chain && s_new_surface_handle == m_swap_chain->GetNativeHandle())
+  if (m_swap_chain && m_new_surface_handle == m_swap_chain->GetNativeHandle())
   {
     INFO_LOG(VIDEO, "Detected window resize.");
     ResizeSwapChain();
 
     // Notify the main thread we are done.
-    s_surface_needs_change.Clear();
-    s_new_surface_handle = nullptr;
-    s_surface_changed.Set();
+    m_surface_needs_change.Clear();
+    m_new_surface_handle = nullptr;
+    m_surface_changed.Set();
   }
   else
   {
@@ -1045,7 +1045,7 @@ void Renderer::CheckForSurfaceChange()
     // Did we previously have a swap chain?
     if (m_swap_chain)
     {
-      if (!s_new_surface_handle)
+      if (!m_new_surface_handle)
       {
         // If there is no surface now, destroy the swap chain.
         m_swap_chain.reset();
@@ -1053,7 +1053,7 @@ void Renderer::CheckForSurfaceChange()
       else
       {
         // Recreate the surface. If this fails we're in trouble.
-        if (!m_swap_chain->RecreateSurface(s_new_surface_handle))
+        if (!m_swap_chain->RecreateSurface(m_new_surface_handle))
           PanicAlert("Failed to recreate Vulkan surface. Cannot continue.");
       }
     }
@@ -1061,10 +1061,10 @@ void Renderer::CheckForSurfaceChange()
     {
       // Previously had no swap chain. So create one.
       VkSurfaceKHR surface = SwapChain::CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(),
-                                                            s_new_surface_handle);
+                                                            m_new_surface_handle);
       if (surface != VK_NULL_HANDLE)
       {
-        m_swap_chain = SwapChain::Create(s_new_surface_handle, surface, g_ActiveConfig.IsVSync());
+        m_swap_chain = SwapChain::Create(m_new_surface_handle, surface, g_ActiveConfig.IsVSync());
         if (!m_swap_chain)
           PanicAlert("Failed to create swap chain.");
       }
@@ -1075,9 +1075,9 @@ void Renderer::CheckForSurfaceChange()
     }
 
     // Notify calling thread.
-    s_surface_needs_change.Clear();
-    s_new_surface_handle = nullptr;
-    s_surface_changed.Set();
+    m_surface_needs_change.Clear();
+    m_new_surface_handle = nullptr;
+    m_surface_changed.Set();
   }
 
   if (m_swap_chain)
@@ -1111,7 +1111,7 @@ void Renderer::CheckForConfigChanges()
   bool anisotropy_changed = old_anisotropy != g_ActiveConfig.iMaxAnisotropy;
   bool force_texture_filtering_changed = old_force_filtering != g_ActiveConfig.bForceFiltering;
   bool stereo_changed = old_stereo_mode != g_ActiveConfig.iStereoMode;
-  bool efb_scale_changed = s_last_efb_scale != g_ActiveConfig.iEFBScale;
+  bool efb_scale_changed = m_last_efb_scale != g_ActiveConfig.iEFBScale;
   bool aspect_changed = old_aspect_ratio != g_ActiveConfig.iAspectRatio;
   bool use_xfb_changed = old_use_xfb != g_ActiveConfig.bUseXFB;
   bool use_realxfb_changed = old_use_realxfb != g_ActiveConfig.bUseRealXFB;
@@ -1122,7 +1122,7 @@ void Renderer::CheckForConfigChanges()
   // Handle settings that can cause the target rectangle to change.
   if (efb_scale_changed || aspect_changed || use_xfb_changed || use_realxfb_changed)
   {
-    s_last_efb_scale = g_ActiveConfig.iEFBScale;
+    m_last_efb_scale = g_ActiveConfig.iEFBScale;
     if (CalculateTargetSize())
       ResizeEFBTextures();
   }
@@ -1162,8 +1162,8 @@ void Renderer::CheckForConfigChanges()
 
 void Renderer::OnSwapChainResized()
 {
-  s_backbuffer_width = m_swap_chain->GetWidth();
-  s_backbuffer_height = m_swap_chain->GetHeight();
+  m_backbuffer_width = m_swap_chain->GetWidth();
+  m_backbuffer_height = m_swap_chain->GetHeight();
   UpdateDrawRectangle();
   if (CalculateTargetSize())
   {
@@ -1668,9 +1668,9 @@ void Renderer::SetViewport()
 void Renderer::ChangeSurface(void* new_surface_handle)
 {
   // Called by the main thread when the window is resized.
-  s_new_surface_handle = new_surface_handle;
-  s_surface_needs_change.Set();
-  s_surface_changed.Set();
+  m_new_surface_handle = new_surface_handle;
+  m_surface_needs_change.Set();
+  m_surface_changed.Set();
 }
 
 void Renderer::RecompileShaders()

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -42,7 +42,10 @@
 
 namespace Vulkan
 {
-Renderer::Renderer(std::unique_ptr<SwapChain> swap_chain) : m_swap_chain(std::move(swap_chain))
+Renderer::Renderer(std::unique_ptr<SwapChain> swap_chain)
+    : ::Renderer(swap_chain ? static_cast<int>(swap_chain->GetWidth()) : 1,
+                 swap_chain ? static_cast<int>(swap_chain->GetHeight()) : 0),
+      m_swap_chain(std::move(swap_chain))
 {
   g_Config.bRunning = true;
   UpdateActiveConfig();
@@ -50,17 +53,6 @@ Renderer::Renderer(std::unique_ptr<SwapChain> swap_chain) : m_swap_chain(std::mo
   // Set to something invalid, forcing all states to be re-initialized.
   for (size_t i = 0; i < m_sampler_states.size(); i++)
     m_sampler_states[i].bits = std::numeric_limits<decltype(m_sampler_states[i].bits)>::max();
-
-  // These have to be initialized before FramebufferManager is created.
-  // If running surfaceless, assume a window size of MAX_XFB_{WIDTH,HEIGHT}.
-  FramebufferManagerBase::SetLastXfbWidth(MAX_XFB_WIDTH);
-  FramebufferManagerBase::SetLastXfbHeight(MAX_XFB_HEIGHT);
-  s_backbuffer_width = m_swap_chain ? m_swap_chain->GetWidth() : MAX_XFB_WIDTH;
-  s_backbuffer_height = m_swap_chain ? m_swap_chain->GetHeight() : MAX_XFB_HEIGHT;
-  s_last_efb_scale = g_ActiveConfig.iEFBScale;
-  UpdateDrawRectangle();
-  CalculateTargetSize();
-  PixelShaderManager::SetEfbScaleChanged();
 }
 
 Renderer::~Renderer()

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1012,10 +1012,7 @@ void Renderer::CheckForTargetResize(u32 fb_width, u32 fb_stride, u32 fb_height)
 
   // Changing the XFB source area may alter the target size.
   if (CalculateTargetSize())
-  {
-    PixelShaderManager::SetEfbScaleChanged();
     ResizeEFBTextures();
-  }
 }
 
 void Renderer::CheckForSurfaceChange()
@@ -1095,6 +1092,7 @@ void Renderer::CheckForConfigChanges()
   int old_anisotropy = g_ActiveConfig.iMaxAnisotropy;
   int old_stereo_mode = g_ActiveConfig.iStereoMode;
   int old_aspect_ratio = g_ActiveConfig.iAspectRatio;
+  int old_efb_scale = g_ActiveConfig.iEFBScale;
   bool old_force_filtering = g_ActiveConfig.bForceFiltering;
   bool old_ssaa = g_ActiveConfig.bSSAA;
   bool old_use_xfb = g_ActiveConfig.bUseXFB;
@@ -1111,7 +1109,7 @@ void Renderer::CheckForConfigChanges()
   bool anisotropy_changed = old_anisotropy != g_ActiveConfig.iMaxAnisotropy;
   bool force_texture_filtering_changed = old_force_filtering != g_ActiveConfig.bForceFiltering;
   bool stereo_changed = old_stereo_mode != g_ActiveConfig.iStereoMode;
-  bool efb_scale_changed = m_last_efb_scale != g_ActiveConfig.iEFBScale;
+  bool efb_scale_changed = old_efb_scale != g_ActiveConfig.iEFBScale;
   bool aspect_changed = old_aspect_ratio != g_ActiveConfig.iAspectRatio;
   bool use_xfb_changed = old_use_xfb != g_ActiveConfig.bUseXFB;
   bool use_realxfb_changed = old_use_realxfb != g_ActiveConfig.bUseRealXFB;
@@ -1122,7 +1120,6 @@ void Renderer::CheckForConfigChanges()
   // Handle settings that can cause the target rectangle to change.
   if (efb_scale_changed || aspect_changed || use_xfb_changed || use_realxfb_changed)
   {
-    m_last_efb_scale = g_ActiveConfig.iEFBScale;
     if (CalculateTargetSize())
       ResizeEFBTextures();
   }
@@ -1166,10 +1163,7 @@ void Renderer::OnSwapChainResized()
   m_backbuffer_height = m_swap_chain->GetHeight();
   UpdateDrawRectangle();
   if (CalculateTargetSize())
-  {
-    PixelShaderManager::SetEfbScaleChanged();
     ResizeEFBTextures();
-  }
 }
 
 void Renderer::BindEFBToStateTracker()

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -28,7 +28,7 @@ class Renderer : public ::Renderer
 {
 public:
   Renderer(std::unique_ptr<SwapChain> swap_chain);
-  ~Renderer();
+  ~Renderer() override;
 
   static Renderer* GetInstance();
 

--- a/Source/Core/VideoCommon/AsyncRequests.cpp
+++ b/Source/Core/VideoCommon/AsyncRequests.cpp
@@ -136,8 +136,8 @@ void AsyncRequests::HandleEvent(const AsyncRequests::Event& e)
     break;
 
   case Event::SWAP_EVENT:
-    Renderer::Swap(e.swap_event.xfbAddr, e.swap_event.fbWidth, e.swap_event.fbStride,
-                   e.swap_event.fbHeight, rc, e.time);
+    g_renderer->Swap(e.swap_event.xfbAddr, e.swap_event.fbWidth, e.swap_event.fbStride,
+                     e.swap_event.fbHeight, rc, e.time);
     break;
 
   case Event::BBOX_READ:

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -156,7 +156,7 @@ void OnPixelFormatChange()
   if (!g_ActiveConfig.bEFBEmulateFormatChanges)
     return;
 
-  auto old_format = Renderer::GetPrevPixelFormat();
+  auto old_format = g_renderer->GetPrevPixelFormat();
   auto new_format = bpmem.zcontrol.pixel_format;
 
   // no need to reinterpret pixel data in these cases
@@ -209,7 +209,7 @@ skip:
   DEBUG_LOG(VIDEO, "pixelfmt: pixel=%d, zc=%d", static_cast<int>(new_format),
             static_cast<int>(bpmem.zcontrol.zformat));
 
-  Renderer::StorePixelFormat(new_format);
+  g_renderer->StorePixelFormat(new_format);
 }
 
 void SetInterlacingMode(const BPCmd& bp)

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -261,7 +261,7 @@ static void BPWritten(const BPCmd& bp)
                        "fbStride: %u | fbHeight: %u",
                 destAddr, srcRect.left, srcRect.top, srcRect.right, srcRect.bottom,
                 bpmem.copyTexSrcWH.x + 1, destStride, height);
-      Renderer::RenderToXFB(destAddr, srcRect, destStride, height, s_gammaLUT[PE_copy.gamma]);
+      g_renderer->RenderToXFB(destAddr, srcRect, destStride, height, s_gammaLUT[PE_copy.gamma]);
     }
 
     // Clear the rectangular region after copying it.

--- a/Source/Core/VideoCommon/FramebufferManagerBase.cpp
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.cpp
@@ -253,8 +253,8 @@ int FramebufferManagerBase::ScaleToVirtualXfbWidth(int x)
   if (g_ActiveConfig.RealXFBEnabled())
     return x;
 
-  return x * (int)Renderer::GetTargetRectangle().GetWidth() /
-         (int)FramebufferManagerBase::LastXfbWidth();
+  return x * static_cast<int>(g_renderer->GetTargetRectangle().GetWidth()) /
+         static_cast<int>(FramebufferManagerBase::LastXfbWidth());
 }
 
 int FramebufferManagerBase::ScaleToVirtualXfbHeight(int y)
@@ -262,6 +262,6 @@ int FramebufferManagerBase::ScaleToVirtualXfbHeight(int y)
   if (g_ActiveConfig.RealXFBEnabled())
     return y;
 
-  return y * (int)Renderer::GetTargetRectangle().GetHeight() /
-         (int)FramebufferManagerBase::LastXfbHeight();
+  return y * static_cast<int>(g_renderer->GetTargetRectangle().GetHeight()) /
+         static_cast<int>(FramebufferManagerBase::LastXfbHeight());
 }

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -27,7 +27,6 @@ void PixelShaderManager::Init()
   s_bFogRangeAdjustChanged = true;
   s_bViewPortChanged = false;
 
-  SetEfbScaleChanged();
   SetIndMatrixChanged(0);
   SetIndMatrixChanged(1);
   SetIndMatrixChanged(2);
@@ -78,7 +77,8 @@ void PixelShaderManager::SetConstants()
       // so to simplify I use the hi coefficient as K in the shader taking 256 as the scale
       // TODO: Shouldn't this be EFBToScaledXf?
       constants.fogf[0][0] = ScreenSpaceCenter;
-      constants.fogf[0][1] = (float)Renderer::EFBToScaledX((int)(2.0f * xfmem.viewport.wd));
+      constants.fogf[0][1] =
+          static_cast<float>(g_renderer->EFBToScaledX(static_cast<int>(2.0f * xfmem.viewport.wd)));
       constants.fogf[0][2] = bpmem.fogRange.K[4].HI / 256.0f;
     }
     else
@@ -161,8 +161,8 @@ void PixelShaderManager::SetViewportChanged()
 
 void PixelShaderManager::SetEfbScaleChanged()
 {
-  constants.efbscale[0] = 1.0f / Renderer::EFBToScaledXf(1);
-  constants.efbscale[1] = 1.0f / Renderer::EFBToScaledYf(1);
+  constants.efbscale[0] = 1.0f / g_renderer->EFBToScaledXf(1);
+  constants.efbscale[1] = 1.0f / g_renderer->EFBToScaledYf(1);
   dirty = true;
 }
 

--- a/Source/Core/VideoCommon/PixelShaderManager.cpp
+++ b/Source/Core/VideoCommon/PixelShaderManager.cpp
@@ -49,7 +49,7 @@ void PixelShaderManager::Dirty()
   // Any constants that can changed based on settings should be re-calculated
   s_bFogRangeAdjustChanged = true;
 
-  SetEfbScaleChanged();
+  SetEfbScaleChanged(g_renderer->EFBToScaledXf(1), g_renderer->EFBToScaledYf(1));
   SetFogParamChanged();
 
   dirty = true;
@@ -159,10 +159,10 @@ void PixelShaderManager::SetViewportChanged()
       true;  // TODO: Shouldn't be necessary with an accurate fog range adjust implementation
 }
 
-void PixelShaderManager::SetEfbScaleChanged()
+void PixelShaderManager::SetEfbScaleChanged(float scalex, float scaley)
 {
-  constants.efbscale[0] = 1.0f / g_renderer->EFBToScaledXf(1);
-  constants.efbscale[1] = 1.0f / g_renderer->EFBToScaledYf(1);
+  constants.efbscale[0] = 1.0f / scalex;
+  constants.efbscale[1] = 1.0f / scaley;
   dirty = true;
 }
 

--- a/Source/Core/VideoCommon/PixelShaderManager.h
+++ b/Source/Core/VideoCommon/PixelShaderManager.h
@@ -29,7 +29,7 @@ public:
   static void SetTexDims(int texmapid, u32 width, u32 height);
   static void SetZTextureBias();
   static void SetViewportChanged();
-  static void SetEfbScaleChanged();
+  static void SetEfbScaleChanged(float scalex, float scaley);
   static void SetZSlope(float dfdx, float dfdy, float f0);
   static void SetIndMatrixChanged(int matrixidx);
   static void SetZTextureTypeChanged();

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -166,6 +166,8 @@ bool Renderer::CalculateTargetSize()
   int newEFBWidth, newEFBHeight;
   newEFBWidth = newEFBHeight = 0;
 
+  m_last_efb_scale = g_ActiveConfig.iEFBScale;
+
   // TODO: Ugly. Clean up
   switch (m_last_efb_scale)
   {
@@ -231,6 +233,7 @@ bool Renderer::CalculateTargetSize()
   {
     m_target_width = newEFBWidth;
     m_target_height = newEFBHeight;
+    PixelShaderManager::SetEfbScaleChanged(EFBToScaledXf(1), EFBToScaledYf(1));
     return true;
   }
   return false;
@@ -612,11 +615,6 @@ void Renderer::UpdateDrawRectangle()
   m_target_rectangle.top = YOffset;
   m_target_rectangle.right = XOffset + iWhidth;
   m_target_rectangle.bottom = YOffset + iHeight;
-}
-
-void Renderer::InitializeCommon()
-{
-  PixelShaderManager::SetEfbScaleChanged();
 }
 
 void Renderer::SetWindowSize(int width, int height)

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -64,39 +64,6 @@ static int OSDTime;
 
 std::unique_ptr<Renderer> g_renderer;
 
-std::mutex Renderer::s_criticalScreenshot;
-std::string Renderer::s_sScreenshotName;
-
-Common::Event Renderer::s_screenshotCompleted;
-Common::Flag Renderer::s_screenshot;
-
-// The framebuffer size
-int Renderer::s_target_width;
-int Renderer::s_target_height;
-
-// TODO: Add functionality to reinit all the render targets when the window is resized.
-int Renderer::s_backbuffer_width;
-int Renderer::s_backbuffer_height;
-
-std::unique_ptr<PostProcessingShaderImplementation> Renderer::m_post_processor;
-
-// Final surface changing
-Common::Flag Renderer::s_surface_needs_change;
-Common::Event Renderer::s_surface_changed;
-void* Renderer::s_new_surface_handle;
-
-TargetRectangle Renderer::target_rc;
-
-int Renderer::s_last_efb_scale;
-
-bool Renderer::XFBWrited;
-
-PEControl::PixelFormat Renderer::prev_efb_format = PEControl::INVALID_FMT;
-unsigned int Renderer::efb_scale_numeratorX = 1;
-unsigned int Renderer::efb_scale_numeratorY = 1;
-unsigned int Renderer::efb_scale_denominatorX = 1;
-unsigned int Renderer::efb_scale_denominatorY = 1;
-
 // The maximum depth that is written to the depth buffer should never exceed this value.
 // This is necessary because we use a 2^24 divisor for all our depth values to prevent
 // floating-point round-trip errors. However the console GPU doesn't ever write a value
@@ -118,11 +85,6 @@ Renderer::Renderer()
 
 Renderer::~Renderer()
 {
-  // invalidate previous efb format
-  prev_efb_format = PEControl::INVALID_FMT;
-
-  efb_scale_numeratorX = efb_scale_numeratorY = efb_scale_denominatorX = efb_scale_denominatorY = 1;
-
   ShutdownFrameDumping();
   if (m_frame_dump_thread.joinable())
     m_frame_dump_thread.join();

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -619,10 +619,8 @@ void Renderer::UpdateDrawRectangle()
 
 void Renderer::SetWindowSize(int width, int height)
 {
-  if (width < 1)
-    width = 1;
-  if (height < 1)
-    height = 1;
+  width = std::max(width, 1);
+  height = std::max(height, 1);
 
   // Scale the window size by the EFB scale.
   CalculateTargetScale(width, height, &width, &height);
@@ -659,7 +657,13 @@ void Renderer::SetWindowSize(int width, int height)
   width -= width % 4;
   height -= height % 4;
 
-  Host_RequestRenderWindowSize(width, height);
+  // Track the last values of width/height to avoid sending a window resize event every frame.
+  if (width != m_last_window_request_width || height != m_last_window_request_height)
+  {
+    m_last_window_request_width = width;
+    m_last_window_request_height = height;
+    Host_RequestRenderWindowSize(width, height);
+  }
 }
 
 void Renderer::CheckFifoRecording()

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -50,6 +50,7 @@
 #include "VideoCommon/FramebufferManagerBase.h"
 #include "VideoCommon/ImageWrite.h"
 #include "VideoCommon/OnScreenDisplay.h"
+#include "VideoCommon/PixelShaderManager.h"
 #include "VideoCommon/PostProcessing.h"
 #include "VideoCommon/Statistics.h"
 #include "VideoCommon/TextureCacheBase.h"
@@ -75,9 +76,18 @@ static float AspectToWidescreen(float aspect)
   return aspect * ((16.0f / 9.0f) / (4.0f / 3.0f));
 }
 
-Renderer::Renderer()
+Renderer::Renderer(int backbuffer_width, int backbuffer_height)
 {
+  FramebufferManagerBase::SetLastXfbWidth(MAX_XFB_WIDTH);
+  FramebufferManagerBase::SetLastXfbHeight(MAX_XFB_HEIGHT);
+
   UpdateActiveConfig();
+
+  s_backbuffer_width = backbuffer_width;
+  s_backbuffer_height = backbuffer_height;
+  s_last_efb_scale = g_ActiveConfig.iEFBScale;
+  CalculateTargetSize();
+  UpdateDrawRectangle();
 
   OSDChoice = 0;
   OSDTime = 0;
@@ -604,6 +614,11 @@ void Renderer::UpdateDrawRectangle()
   target_rc.top = YOffset;
   target_rc.right = XOffset + iWhidth;
   target_rc.bottom = YOffset + iHeight;
+}
+
+void Renderer::InitializeCommon()
+{
+  PixelShaderManager::SetEfbScaleChanged();
 }
 
 void Renderer::SetWindowSize(int width, int height)

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -79,10 +79,6 @@ public:
   virtual void RestoreState() {}
   virtual void ResetAPIState() {}
   virtual void RestoreAPIState() {}
-  // Some of the methods called by here assume g_renderer is initialized, therefore
-  // we must call it after constructing the backend's Renderer instance.
-  void InitializeCommon();
-
   // Ideal internal resolution - determined by display resolution (automatic scaling) and/or a
   // multiple of the native EFB resolution
   int GetTargetWidth() { return m_target_width; }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -81,46 +81,46 @@ public:
   virtual void RestoreAPIState() {}
   // Ideal internal resolution - determined by display resolution (automatic scaling) and/or a
   // multiple of the native EFB resolution
-  static int GetTargetWidth() { return s_target_width; }
-  static int GetTargetHeight() { return s_target_height; }
+  int GetTargetWidth() { return s_target_width; }
+  int GetTargetHeight() { return s_target_height; }
   // Display resolution
-  static int GetBackbufferWidth() { return s_backbuffer_width; }
-  static int GetBackbufferHeight() { return s_backbuffer_height; }
-  static void SetWindowSize(int width, int height);
+  int GetBackbufferWidth() { return s_backbuffer_width; }
+  int GetBackbufferHeight() { return s_backbuffer_height; }
+  void SetWindowSize(int width, int height);
 
   // EFB coordinate conversion functions
 
   // Use this to convert a whole native EFB rect to backbuffer coordinates
   virtual TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) = 0;
 
-  static const TargetRectangle& GetTargetRectangle() { return target_rc; }
-  static float CalculateDrawAspectRatio(int target_width, int target_height);
-  static std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height);
-  static TargetRectangle CalculateFrameDumpDrawRectangle();
-  static void UpdateDrawRectangle();
+  const TargetRectangle& GetTargetRectangle() { return target_rc; }
+  float CalculateDrawAspectRatio(int target_width, int target_height);
+  std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height);
+  TargetRectangle CalculateFrameDumpDrawRectangle();
+  void UpdateDrawRectangle();
 
   // Use this to convert a single target rectangle to two stereo rectangles
-  static void ConvertStereoRectangle(const TargetRectangle& rc, TargetRectangle& leftRc,
-                                     TargetRectangle& rightRc);
+  void ConvertStereoRectangle(const TargetRectangle& rc, TargetRectangle& leftRc,
+                              TargetRectangle& rightRc);
 
   // Use this to upscale native EFB coordinates to IDEAL internal resolution
-  static int EFBToScaledX(int x);
-  static int EFBToScaledY(int y);
+  int EFBToScaledX(int x);
+  int EFBToScaledY(int y);
 
   // Floating point versions of the above - only use them if really necessary
-  static float EFBToScaledXf(float x) { return x * ((float)GetTargetWidth() / (float)EFB_WIDTH); }
-  static float EFBToScaledYf(float y) { return y * ((float)GetTargetHeight() / (float)EFB_HEIGHT); }
+  float EFBToScaledXf(float x) { return x * ((float)GetTargetWidth() / (float)EFB_WIDTH); }
+  float EFBToScaledYf(float y) { return y * ((float)GetTargetHeight() / (float)EFB_HEIGHT); }
   // Random utilities
-  static void SetScreenshot(const std::string& filename);
-  static void DrawDebugText();
+  void SetScreenshot(const std::string& filename);
+  void DrawDebugText();
 
   virtual void RenderText(const std::string& text, int left, int top, u32 color) = 0;
 
   virtual void ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,
                            u32 color, u32 z) = 0;
   virtual void ReinterpretPixelData(unsigned int convtype) = 0;
-  static void RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbStride, u32 fbHeight,
-                          float Gamma = 1.0f);
+  void RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbStride, u32 fbHeight,
+                   float Gamma = 1.0f);
 
   virtual u32 AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data) = 0;
   virtual void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) = 0;
@@ -129,72 +129,72 @@ public:
   virtual void BBoxWrite(int index, u16 value) = 0;
 
   // Finish up the current frame, print some stats
-  static void Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,
-                   u64 ticks, float Gamma = 1.0f);
+  void Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc, u64 ticks,
+            float Gamma = 1.0f);
   virtual void SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                         const EFBRectangle& rc, u64 ticks, float Gamma = 1.0f) = 0;
 
-  static PEControl::PixelFormat GetPrevPixelFormat() { return prev_efb_format; }
-  static void StorePixelFormat(PEControl::PixelFormat new_format) { prev_efb_format = new_format; }
+  PEControl::PixelFormat GetPrevPixelFormat() { return prev_efb_format; }
+  void StorePixelFormat(PEControl::PixelFormat new_format) { prev_efb_format = new_format; }
   PostProcessingShaderImplementation* GetPostProcessor() { return m_post_processor.get(); }
   // Max height/width
   virtual u32 GetMaxTextureSize() = 0;
 
-  static Common::Event s_screenshotCompleted;
+  Common::Event s_screenshotCompleted;
 
   // Final surface changing
   // This is called when the surface is resized (WX) or the window changes (Android).
   virtual void ChangeSurface(void* new_surface_handle) {}
 protected:
-  static void CalculateTargetScale(int x, int y, int* scaledX, int* scaledY);
+  void CalculateTargetScale(int x, int y, int* scaledX, int* scaledY);
   bool CalculateTargetSize();
 
-  static void CheckFifoRecording();
-  static void RecordVideoMemory();
+  void CheckFifoRecording();
+  void RecordVideoMemory();
 
   bool IsFrameDumping();
   void DumpFrameData(const u8* data, int w, int h, int stride, const AVIDump::Frame& state,
                      bool swap_upside_down = false);
   void FinishFrameData();
 
-  static Common::Flag s_screenshot;
-  static std::mutex s_criticalScreenshot;
-  static std::string s_sScreenshotName;
+  Common::Flag s_screenshot;
+  std::mutex s_criticalScreenshot;
+  std::string s_sScreenshotName;
 
   // The framebuffer size
-  static int s_target_width;
-  static int s_target_height;
+  int s_target_width = 0;
+  int s_target_height = 0;
 
   // TODO: Add functionality to reinit all the render targets when the window is resized.
-  static int s_backbuffer_width;
-  static int s_backbuffer_height;
+  int s_backbuffer_width = 0;
+  int s_backbuffer_height = 0;
 
-  static TargetRectangle target_rc;
+  TargetRectangle target_rc;
 
   // TODO: Can probably eliminate this static var.
-  static int s_last_efb_scale;
+  int s_last_efb_scale = 0;
 
-  static bool XFBWrited;
+  bool XFBWrited = false;
 
   FPSCounter m_fps_counter;
 
-  static std::unique_ptr<PostProcessingShaderImplementation> m_post_processor;
+  std::unique_ptr<PostProcessingShaderImplementation> m_post_processor;
 
   static const float GX_MAX_DEPTH;
 
-  static Common::Flag s_surface_needs_change;
-  static Common::Event s_surface_changed;
-  static void* s_new_surface_handle;
+  Common::Flag s_surface_needs_change;
+  Common::Event s_surface_changed;
+  void* s_new_surface_handle = nullptr;
 
 private:
   void RunFrameDumps();
   void ShutdownFrameDumping();
 
-  static PEControl::PixelFormat prev_efb_format;
-  static unsigned int efb_scale_numeratorX;
-  static unsigned int efb_scale_numeratorY;
-  static unsigned int efb_scale_denominatorX;
-  static unsigned int efb_scale_denominatorY;
+  PEControl::PixelFormat prev_efb_format = PEControl::INVALID_FMT;
+  unsigned int efb_scale_numeratorX = 1;
+  unsigned int efb_scale_numeratorY = 1;
+  unsigned int efb_scale_denominatorX = 1;
+  unsigned int efb_scale_denominatorY = 1;
 
   // frame dumping
   std::thread m_frame_dump_thread;

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -50,7 +50,7 @@ extern int OSDChoice;
 class Renderer
 {
 public:
-  Renderer();
+  Renderer(int backbuffer_width, int backbuffer_height);
   virtual ~Renderer();
 
   enum PixelPerfQuery
@@ -79,6 +79,10 @@ public:
   virtual void RestoreState() {}
   virtual void ResetAPIState() {}
   virtual void RestoreAPIState() {}
+  // Some of the methods called by here assume g_renderer is initialized, therefore
+  // we must call it after constructing the backend's Renderer instance.
+  void InitializeCommon();
+
   // Ideal internal resolution - determined by display resolution (automatic scaling) and/or a
   // multiple of the native EFB resolution
   int GetTargetWidth() { return s_target_width; }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -111,7 +111,7 @@ public:
   float EFBToScaledXf(float x) { return x * ((float)GetTargetWidth() / (float)EFB_WIDTH); }
   float EFBToScaledYf(float y) { return y * ((float)GetTargetHeight() / (float)EFB_HEIGHT); }
   // Random utilities
-  void SetScreenshot(const std::string& filename);
+  void SaveScreenshot(const std::string& filename, bool wait_for_completion);
   void DrawDebugText();
 
   virtual void RenderText(const std::string& text, int left, int top, u32 color) = 0;
@@ -140,8 +140,6 @@ public:
   // Max height/width
   virtual u32 GetMaxTextureSize() = 0;
 
-  Common::Event s_screenshot_completed;
-
   // Final surface changing
   // This is called when the surface is resized (WX) or the window changes (Android).
   virtual void ChangeSurface(void* new_surface_handle) {}
@@ -158,6 +156,7 @@ protected:
   void FinishFrameData();
 
   Common::Flag m_screenshot_request;
+  Common::Event m_screenshot_completed;
   std::mutex m_screenshot_lock;
   std::string m_screenshot_name;
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -85,11 +85,11 @@ public:
 
   // Ideal internal resolution - determined by display resolution (automatic scaling) and/or a
   // multiple of the native EFB resolution
-  int GetTargetWidth() { return s_target_width; }
-  int GetTargetHeight() { return s_target_height; }
+  int GetTargetWidth() { return m_target_width; }
+  int GetTargetHeight() { return m_target_height; }
   // Display resolution
-  int GetBackbufferWidth() { return s_backbuffer_width; }
-  int GetBackbufferHeight() { return s_backbuffer_height; }
+  int GetBackbufferWidth() { return m_backbuffer_width; }
+  int GetBackbufferHeight() { return m_backbuffer_height; }
   void SetWindowSize(int width, int height);
 
   // EFB coordinate conversion functions
@@ -97,7 +97,7 @@ public:
   // Use this to convert a whole native EFB rect to backbuffer coordinates
   virtual TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) = 0;
 
-  const TargetRectangle& GetTargetRectangle() { return target_rc; }
+  const TargetRectangle& GetTargetRectangle() { return m_target_rectangle; }
   float CalculateDrawAspectRatio(int target_width, int target_height);
   std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height);
   TargetRectangle CalculateFrameDumpDrawRectangle();
@@ -138,13 +138,13 @@ public:
   virtual void SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                         const EFBRectangle& rc, u64 ticks, float Gamma = 1.0f) = 0;
 
-  PEControl::PixelFormat GetPrevPixelFormat() { return prev_efb_format; }
-  void StorePixelFormat(PEControl::PixelFormat new_format) { prev_efb_format = new_format; }
+  PEControl::PixelFormat GetPrevPixelFormat() { return m_prev_efb_format; }
+  void StorePixelFormat(PEControl::PixelFormat new_format) { m_prev_efb_format = new_format; }
   PostProcessingShaderImplementation* GetPostProcessor() { return m_post_processor.get(); }
   // Max height/width
   virtual u32 GetMaxTextureSize() = 0;
 
-  Common::Event s_screenshotCompleted;
+  Common::Event s_screenshot_completed;
 
   // Final surface changing
   // This is called when the surface is resized (WX) or the window changes (Android).
@@ -161,24 +161,20 @@ protected:
                      bool swap_upside_down = false);
   void FinishFrameData();
 
-  Common::Flag s_screenshot;
-  std::mutex s_criticalScreenshot;
-  std::string s_sScreenshotName;
+  Common::Flag m_screenshot_request;
+  std::mutex m_screenshot_lock;
+  std::string m_screenshot_name;
 
   // The framebuffer size
-  int s_target_width = 0;
-  int s_target_height = 0;
+  int m_target_width = 0;
+  int m_target_height = 0;
 
   // TODO: Add functionality to reinit all the render targets when the window is resized.
-  int s_backbuffer_width = 0;
-  int s_backbuffer_height = 0;
-
-  TargetRectangle target_rc;
-
-  // TODO: Can probably eliminate this static var.
-  int s_last_efb_scale = 0;
-
-  bool XFBWrited = false;
+  int m_backbuffer_width = 0;
+  int m_backbuffer_height = 0;
+  int m_last_efb_scale = 0;
+  TargetRectangle m_target_rectangle;
+  bool m_xfb_written = false;
 
   FPSCounter m_fps_counter;
 
@@ -186,19 +182,19 @@ protected:
 
   static const float GX_MAX_DEPTH;
 
-  Common::Flag s_surface_needs_change;
-  Common::Event s_surface_changed;
-  void* s_new_surface_handle = nullptr;
+  Common::Flag m_surface_needs_change;
+  Common::Event m_surface_changed;
+  void* m_new_surface_handle = nullptr;
 
 private:
   void RunFrameDumps();
   void ShutdownFrameDumping();
 
-  PEControl::PixelFormat prev_efb_format = PEControl::INVALID_FMT;
-  unsigned int efb_scale_numeratorX = 1;
-  unsigned int efb_scale_numeratorY = 1;
-  unsigned int efb_scale_denominatorX = 1;
-  unsigned int efb_scale_denominatorY = 1;
+  PEControl::PixelFormat m_prev_efb_format = PEControl::INVALID_FMT;
+  unsigned int m_efb_scale_numeratorX = 1;
+  unsigned int m_efb_scale_numeratorY = 1;
+  unsigned int m_efb_scale_denominatorX = 1;
+  unsigned int m_efb_scale_denominatorY = 1;
 
   // frame dumping
   std::thread m_frame_dump_thread;

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -192,6 +192,10 @@ private:
   unsigned int m_efb_scale_denominatorX = 1;
   unsigned int m_efb_scale_denominatorY = 1;
 
+  // These will be set on the first call to SetWindowSize.
+  int m_last_window_request_width = 0;
+  int m_last_window_request_height = 0;
+
   // frame dumping
   std::thread m_frame_dump_thread;
   Common::Event m_frame_dump_start;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -385,17 +385,17 @@ TextureCacheBase::DoPartialTextureUpdates(TCacheEntryBase* entry_to_update, u8* 
             entry->native_height != entry->config.height)
         {
           ScaleTextureCacheEntryTo(&entry_to_update,
-                                   Renderer::EFBToScaledX(entry_to_update->native_width),
-                                   Renderer::EFBToScaledY(entry_to_update->native_height));
-          ScaleTextureCacheEntryTo(&entry, Renderer::EFBToScaledX(entry->native_width),
-                                   Renderer::EFBToScaledY(entry->native_height));
+                                   g_renderer->EFBToScaledX(entry_to_update->native_width),
+                                   g_renderer->EFBToScaledY(entry_to_update->native_height));
+          ScaleTextureCacheEntryTo(&entry, g_renderer->EFBToScaledX(entry->native_width),
+                                   g_renderer->EFBToScaledY(entry->native_height));
 
-          src_x = Renderer::EFBToScaledX(src_x);
-          src_y = Renderer::EFBToScaledY(src_y);
-          dst_x = Renderer::EFBToScaledX(dst_x);
-          dst_y = Renderer::EFBToScaledY(dst_y);
-          copy_width = Renderer::EFBToScaledX(copy_width);
-          copy_height = Renderer::EFBToScaledY(copy_height);
+          src_x = g_renderer->EFBToScaledX(src_x);
+          src_y = g_renderer->EFBToScaledY(src_y);
+          dst_x = g_renderer->EFBToScaledX(dst_x);
+          dst_y = g_renderer->EFBToScaledY(dst_y);
+          copy_width = g_renderer->EFBToScaledX(copy_width);
+          copy_height = g_renderer->EFBToScaledY(copy_height);
         }
 
         MathUtil::Rectangle<int> srcrect, dstrect;
@@ -1197,8 +1197,10 @@ void TextureCacheBase::CopyRenderTargetToTexture(u32 dstAddr, unsigned int dstFo
   const unsigned int tex_w = scaleByHalf ? srcRect.GetWidth() / 2 : srcRect.GetWidth();
   const unsigned int tex_h = scaleByHalf ? srcRect.GetHeight() / 2 : srcRect.GetHeight();
 
-  unsigned int scaled_tex_w = g_ActiveConfig.bCopyEFBScaled ? Renderer::EFBToScaledX(tex_w) : tex_w;
-  unsigned int scaled_tex_h = g_ActiveConfig.bCopyEFBScaled ? Renderer::EFBToScaledY(tex_h) : tex_h;
+  unsigned int scaled_tex_w =
+      g_ActiveConfig.bCopyEFBScaled ? g_renderer->EFBToScaledX(tex_w) : tex_w;
+  unsigned int scaled_tex_h =
+      g_ActiveConfig.bCopyEFBScaled ? g_renderer->EFBToScaledY(tex_h) : tex_h;
 
   // Remove all texture cache entries at dstAddr
   //   It's not possible to have two EFB copies at the same address, this makes sure any old efb

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -382,8 +382,8 @@ void VertexShaderManager::SetConstants()
     // NOTE: If we ever emulate antialiasing, the sample locations set by
     // BP registers 0x01-0x04 need to be considered here.
     const float pixel_center_correction = 7.0f / 12.0f - 0.5f;
-    const float pixel_size_x = 2.f / Renderer::EFBToScaledXf(2.f * xfmem.viewport.wd);
-    const float pixel_size_y = 2.f / Renderer::EFBToScaledXf(2.f * xfmem.viewport.ht);
+    const float pixel_size_x = 2.f / g_renderer->EFBToScaledXf(2.f * xfmem.viewport.wd);
+    const float pixel_size_y = 2.f / g_renderer->EFBToScaledXf(2.f * xfmem.viewport.ht);
     constants.pixelcentercorrection[0] = pixel_center_correction * pixel_size_x;
     constants.pixelcentercorrection[1] = pixel_center_correction * pixel_size_y;
 


### PR DESCRIPTION
This has been bugging me for a while.

Also adds a cache for the last window size request, this way it avoids posting a message every frame (at least in WX, anyway).

Probably needs some more testing, I did a really brief check with all backends and it seemed okay, but due to the init order changing in some cases there's a slim possibility of issues.