### PR TITLE
IOS/ES: Fix ES_GetTitles and implement ES_GetOwnedTitles

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -167,8 +167,12 @@ private:
   IPCCommandResult GetTitleDirectory(const IOCtlVRequest& request);
   IPCCommandResult GetTitleID(const IOCtlVRequest& request);
   IPCCommandResult SetUID(const IOCtlVRequest& request);
+
+  IPCCommandResult GetOwnedTitleCount(const IOCtlVRequest& request);
+  IPCCommandResult GetOwnedTitles(const IOCtlVRequest& request);
   IPCCommandResult GetTitleCount(const IOCtlVRequest& request);
   IPCCommandResult GetTitles(const IOCtlVRequest& request);
+
   IPCCommandResult GetViewCount(const IOCtlVRequest& request);
   IPCCommandResult GetViews(const IOCtlVRequest& request);
   IPCCommandResult GetTMDViewSize(const IOCtlVRequest& request);
@@ -195,7 +199,6 @@ private:
   IPCCommandResult Sign(const IOCtlVRequest& request);
   IPCCommandResult GetBoot2Version(const IOCtlVRequest& request);
   IPCCommandResult DIGetTicketView(const IOCtlVRequest& request);
-  IPCCommandResult GetOwnedTitleCount(const IOCtlVRequest& request);
 
   static bool LaunchIOS(u64 ios_title_id);
   static bool LaunchPPCTitle(u64 title_id, bool skip_reload);

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -168,6 +168,8 @@ private:
   IPCCommandResult GetTitleID(const IOCtlVRequest& request);
   IPCCommandResult SetUID(const IOCtlVRequest& request);
 
+  IPCCommandResult GetTitleCount(const std::vector<u64>& titles, const IOCtlVRequest& request);
+  IPCCommandResult GetTitles(const std::vector<u64>& titles, const IOCtlVRequest& request);
   IPCCommandResult GetOwnedTitleCount(const IOCtlVRequest& request);
   IPCCommandResult GetOwnedTitles(const IOCtlVRequest& request);
   IPCCommandResult GetTitleCount(const IOCtlVRequest& request);

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -158,7 +158,7 @@ CNANDContentLoader::~CNANDContentLoader()
 
 bool CNANDContentLoader::IsValid() const
 {
-  return m_Valid && m_tmd.IsValid();
+  return m_Valid;
 }
 
 const SNANDContent* CNANDContentLoader::GetContentByID(u32 id) const


### PR DESCRIPTION
IOS determines installed titles by looking at /title, not uid.sys, which is more like a history of installed titles. And it does not care at all about the installed TMD (or even if it is present at all).

And while I was making changes to ES_GetTitles, I also implemented ES_GetOwnedTitles, which is similar, but returns a list of title IDs for which there is a ticket.