### PR TITLE
UICommon: Make GetNewDisassembler() return a unique_ptr

### DIFF
--- a/Source/Core/DolphinWX/Debugger/JitWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/JitWindow.cpp
@@ -47,11 +47,11 @@ CJitWindow::CJitWindow(wxWindow* parent, wxWindowID id, const wxPoint& pos, cons
   SetSizerAndFit(sizerBig);
 
 #if defined(_M_X86)
-  m_disassembler.reset(GetNewDisassembler("x86"));
+  m_disassembler = GetNewDisassembler("x86");
 #elif defined(_M_ARM_64)
-  m_disassembler.reset(GetNewDisassembler("aarch64"));
+  m_disassembler = GetNewDisassembler("aarch64");
 #else
-  m_disassembler.reset(GetNewDisassembler("UNK"));
+  m_disassembler = GetNewDisassembler("UNK");
 #endif
 }
 

--- a/Source/Core/UICommon/Disassembler.cpp
+++ b/Source/Core/UICommon/Disassembler.cpp
@@ -151,20 +151,20 @@ std::string HostDisassemblerX86::DisassembleHostBlock(const u8* code_start, cons
   return x86_disasm.str();
 }
 
-HostDisassembler* GetNewDisassembler(const std::string& arch)
+std::unique_ptr<HostDisassembler> GetNewDisassembler(const std::string& arch)
 {
 #if defined(HAVE_LLVM)
   if (arch == "x86")
-    return new HostDisassemblerLLVM("x86_64-none-unknown");
-  else if (arch == "aarch64")
-    return new HostDisassemblerLLVM("aarch64-none-unknown", 4, "cortex-a57");
-  else if (arch == "armv7")
-    return new HostDisassemblerLLVM("armv7-none-unknown", 4, "cortex-a15");
+    return std::make_unique<HostDisassemblerLLVM>("x86_64-none-unknown");
+  if (arch == "aarch64")
+    return std::make_unique<HostDisassemblerLLVM>("aarch64-none-unknown", 4, "cortex-a57");
+  if (arch == "armv7")
+    return std::make_unique<HostDisassemblerLLVM>("armv7-none-unknown", 4, "cortex-a15");
 #elif defined(_M_X86)
   if (arch == "x86")
-    return new HostDisassemblerX86();
+    return std::make_unique<HostDisassemblerX86>();
 #endif
-  return new HostDisassembler();
+  return std::make_unique<HostDisassembler>();
 }
 
 std::string DisassembleBlock(HostDisassembler* disasm, u32* address, u32* host_instructions_count,

--- a/Source/Core/UICommon/Disassembler.h
+++ b/Source/Core/UICommon/Disassembler.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include "Common/CommonTypes.h"
 
 class HostDisassembler
@@ -17,6 +18,6 @@ public:
   }
 };
 
-HostDisassembler* GetNewDisassembler(const std::string& arch);
+std::unique_ptr<HostDisassembler> GetNewDisassembler(const std::string& arch);
 std::string DisassembleBlock(HostDisassembler* disasm, u32* address, u32* host_instructions_count,
                              u32* code_size);


### PR DESCRIPTION
Much better than just returning raw memory.