### PR TITLE
Fix memory breakpoints not triggering on Windows

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -227,9 +227,9 @@ void UpdateLogicalMemory(const PowerPC::BatTable& dbat_table)
     g_arena.ReleaseView(entry.mapped_pointer, entry.mapped_size);
   }
   logical_mapped_entries.clear();
-  for (u32 i = 0; i < (1 << (32 - PowerPC::BAT_INDEX_SHIFT)); ++i)
+  for (u32 i = 0; i < dbat_table.size(); ++i)
   {
-    if (dbat_table[i] & PowerPC::BAT_MAPPED_BIT)
+    if (dbat_table[i] & PowerPC::BAT_PHYSICAL_BIT)
     {
       u32 logical_address = i << PowerPC::BAT_INDEX_SHIFT;
       // TODO: Merge adjacent mappings to make this faster.


### PR DESCRIPTION
For some reasons, they worked on Linux even though it was incorrect, this commit does it correctly and so it fixes that on Windows.

Thanks to @degasus for suggesting this fix.  This fixes the main part of [this issue](https://bugs.dolphin-emu.org/issues/10133), but it doesn't fixes the part about the memmap error, but I will deal with that in a further commit since the fix is completely unrelated to this one.