### PR TITLE
Don't save watches and breakpoints on stop and load on boot

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -310,13 +310,6 @@ void CFrame::BootGame(const std::string& filename)
   if (!bootfile.empty())
   {
     StartGame(bootfile);
-    if (UseDebugger && g_pCodeWindow)
-    {
-      if (g_pCodeWindow->HasPanel<CWatchWindow>())
-        g_pCodeWindow->GetPanel<CWatchWindow>()->LoadAll();
-      if (g_pCodeWindow->HasPanel<CBreakPointWindow>())
-        g_pCodeWindow->GetPanel<CBreakPointWindow>()->LoadAll();
-    }
   }
 }
 
@@ -844,11 +837,7 @@ void CFrame::DoStop()
 
     if (UseDebugger && g_pCodeWindow)
     {
-      if (g_pCodeWindow->HasPanel<CWatchWindow>())
-        g_pCodeWindow->GetPanel<CWatchWindow>()->SaveAll();
       PowerPC::watches.Clear();
-      if (g_pCodeWindow->HasPanel<CBreakPointWindow>())
-        g_pCodeWindow->GetPanel<CBreakPointWindow>()->SaveAll();
       PowerPC::breakpoints.Clear();
       PowerPC::memchecks.Clear();
       if (g_pCodeWindow->HasPanel<CBreakPointWindow>())


### PR DESCRIPTION
Not only this is pretty pointless because there is a load and save button on the appropriate panels, but for the breakpoints one, it caused an error while mapping the memory since adding memory breakpoint requires to update the DBAT and this is done too early (right after boot).  This also only worked if you had the right panel on making it even more useless because it would fail to laod if you didn't have the right panel on.  It's better to just let the user click load and save.

Fixes the part about [this issue](https://bugs.dolphin-emu.org/issues/10133) where it would fail to map memory when adding a memory breakpoint, stopping the emulator and then run the game again.  It doesn't seem to be a good idea to update the DBAT this early and the feature was itself pretty weird in the first place.