### PR TITLE
ControllerEmu: Initialize settings class' values to default values on construction

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/Setting/BooleanSetting.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/BooleanSetting.cpp
@@ -8,7 +8,8 @@ namespace ControllerEmu
 {
 BooleanSetting::BooleanSetting(const std::string& setting_name, const std::string& ui_name,
                                const bool default_value, const SettingType setting_type)
-    : m_type(setting_type), m_name(setting_name), m_ui_name(ui_name), m_default_value(default_value)
+    : m_type(setting_type), m_name(setting_name), m_ui_name(ui_name),
+      m_default_value(default_value), m_value(default_value)
 {
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
@@ -9,7 +9,7 @@ namespace ControllerEmu
 NumericSetting::NumericSetting(const std::string& setting_name, const ControlState default_value,
                                const u32 low, const u32 high, const SettingType setting_type)
     : m_type(setting_type), m_name(setting_name), m_default_value(default_value), m_low(low),
-      m_high(high)
+      m_high(high), m_value(default_value)
 {
 }
 


### PR DESCRIPTION
Given it's the default value, this is what m_value should be set to initially upon construction. While this will generally get overridden during config loading, starting off with deterministic values, should the need to debug settings-related things ever arise, is a much better initial state compared to uninitialized values.