### PR TITLE
VideoCommon: rework anamorphic widescreen heuristic

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -290,13 +290,11 @@ bool BootCore(const std::string& _rFilename)
       }
     }
 
-    Core::g_aspect_wide = StartUp.bWii;
-
     // Wii settings
     if (StartUp.bWii)
     {
       IniFile::Section* wii_section = game_ini.GetOrCreateSection("Wii");
-      wii_section->Get("Widescreen", &Core::g_aspect_wide, !!StartUp.m_wii_aspect_ratio);
+      wii_section->Get("Widescreen", &StartUp.m_wii_aspect_ratio, !!StartUp.m_wii_aspect_ratio);
       wii_section->Get("Language", &StartUp.m_wii_language, StartUp.m_wii_language);
 
       int source;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -81,9 +81,6 @@
 
 namespace Core
 {
-// TODO: ugly, remove
-bool g_aspect_wide;
-
 static bool s_wants_determinism;
 
 // Declarations and definitions

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -18,9 +18,6 @@
 
 namespace Core
 {
-// TODO: ugly, remove
-extern bool g_aspect_wide;
-
 bool GetIsThrottlerTempDisabled();
 void SetIsThrottlerTempDisabled(bool disable);
 

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -158,6 +158,7 @@ protected:
   Common::Event m_screenshot_completed;
   std::mutex m_screenshot_lock;
   std::string m_screenshot_name;
+  bool m_aspect_wide = false;
 
   // The framebuffer size
   int m_target_width = 0;

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -61,6 +61,8 @@ public:
 
   void DoState(PointerWrap& p);
 
+  std::pair<size_t, size_t> ResetFlushAspectRatioCount();
+
 protected:
   virtual void vDoState(PointerWrap& p) {}
   PrimitiveType m_current_primitive_type = PrimitiveType::PRIMITIVE_POINTS;
@@ -81,6 +83,8 @@ protected:
 
 private:
   bool m_is_flushed = true;
+  size_t m_flush_count_4_3 = 0;
+  size_t m_flush_count_anamorphic = 0;
 
   virtual void vFlush() = 0;
 

--- a/Source/Core/VideoCommon/VertexShaderGen.cpp
+++ b/Source/Core/VideoCommon/VertexShaderGen.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <cmath>
 #include <cstring>
 
 #include "Common/Assert.h"

--- a/Source/Core/VideoCommon/VertexShaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexShaderManager.cpp
@@ -92,23 +92,6 @@ static float PHackValue(std::string sValue)
   return f;
 }
 
-// Due to the BT.601 standard which the GameCube is based on being a compromise
-// between PAL and NTSC, neither standard gets square pixels. They are each off
-// by ~9% in opposite directions.
-// Just in case any game decides to take this into account, we do both these
-// tests with a large amount of slop.
-static bool AspectIs4_3(float width, float height)
-{
-  float aspect = fabsf(width / height);
-  return fabsf(aspect - 4.0f / 3.0f) < 4.0f / 3.0f * 0.11;  // within 11% of 4:3
-}
-
-static bool AspectIs16_9(float width, float height)
-{
-  float aspect = fabsf(width / height);
-  return fabsf(aspect - 16.0f / 9.0f) < 16.0f / 9.0f * 0.11;  // within 11% of 16:9
-}
-
 void UpdateProjectionHack(int iPhackvalue[], std::string sPhackvalue[])
 {
   float fhackvalue1 = 0, fhackvalue2 = 0;
@@ -469,18 +452,6 @@ void VertexShaderManager::SetConstants()
 
       g_fProjectionMatrix[14] = -1.0f;
       g_fProjectionMatrix[15] = 0.0f;
-
-      // Heuristic to detect if a GameCube game is in 16:9 anamorphic widescreen mode.
-      if (!SConfig::GetInstance().bWii)
-      {
-        bool viewport_is_4_3 = AspectIs4_3(xfmem.viewport.wd, xfmem.viewport.ht);
-        if (AspectIs16_9(rawProjection[2], rawProjection[0]) && viewport_is_4_3)
-          Core::g_aspect_wide = true;  // Projection is 16:9 and viewport is 4:3, we are rendering
-                                       // an anamorphic widescreen picture
-        else if (AspectIs4_3(rawProjection[2], rawProjection[0]) && viewport_is_4_3)
-          Core::g_aspect_wide =
-              false;  // Project and viewports are both 4:3, we are rendering a normal image.
-      }
 
       SETSTAT_FT(stats.gproj_0, g_fProjectionMatrix[0]);
       SETSTAT_FT(stats.gproj_1, g_fProjectionMatrix[1]);


### PR DESCRIPTION
Some widescreen hacks (see below) properly force anamorphic output, but don't make the last projection in a frame 16:9, so Dolphin doesn't display it correctly.

This changes the heuristic code to assume a frame is anamorphic based on the total number of vertex flushes in 4:3 and 16:9 projections that frame. It also adds a bit of "aspect ratio inertia" by making it harder to switch aspect ratios, which takes care of aspect ratio flickering that some games / widescreen hacks would be susceptible with the new logic.
    
I've tested this on SSX Tricky's native anamorphic support, Tom Clancy's Splinter Cell (it stayed in 4:3 the whole time), and on the following widescreen hacks for which the heuristic doesn't currently work:

Paper Mario: The Thousand-Year Door (Gecko widescreen code from Nintendont)
```
C202F310 00000003
3DC08042 3DE03FD8
91EEF6D8 4E800020
60000000 00000000
04199598 4E800020
C200F500 00000004
3DE08082 3DC0402B
61CE12A2 91CFA1BC
60000000 387D015C
60000000 00000000
C200F508 00000004
3DE08082 3DC04063
61CEE8D3 91CFA1BC
60000000 7FC3F378
60000000 00000000
```

The Simpsons: Hit & Run (AR widescreen code from the wiki)
```
04004600 C002A604
04004604 C09F0014
04004608 FC002040
0400460C 4082000C
04004610 C002A608
04004614 EC630032
04004618 48220508
04041A5C 38600001
04224344 C002A60C
04224B1C 4BDDFAE4
044786B0 3FAAAAAB
04479F28 3FA33333
```