### PR TITLE
Fix memory breakpoint when checking the middle of the data

### DIFF
--- a/Source/Core/Common/DebugInterface.h
+++ b/Source/Core/Common/DebugInterface.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstring>
 #include <string>
 
@@ -26,7 +27,7 @@ public:
   virtual void ToggleBreakpoint(unsigned int /*address*/) {}
   virtual void AddWatch(unsigned int /*address*/) {}
   virtual void ClearAllMemChecks() {}
-  virtual bool IsMemCheck(unsigned int /*address*/) { return false; }
+  virtual bool IsMemCheck(unsigned int /*address*/, size_t /*size*/) { return false; }
   virtual void ToggleMemCheck(unsigned int /*address*/, bool /*read*/, bool /*write*/, bool /*log*/)
   {
   }

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/Debugger/PPCDebugInterface.h"
 
+#include <cstddef>
 #include <string>
 
 #include "Common/GekkoDisassembler.h"
@@ -129,9 +130,9 @@ void PPCDebugInterface::ClearAllMemChecks()
   PowerPC::memchecks.Clear();
 }
 
-bool PPCDebugInterface::IsMemCheck(unsigned int address)
+bool PPCDebugInterface::IsMemCheck(unsigned int address, size_t size)
 {
-  return PowerPC::memchecks.GetMemCheck(address) != nullptr;
+  return PowerPC::memchecks.GetMemCheck(address, size) != nullptr;
 }
 
 void PPCDebugInterface::ToggleMemCheck(unsigned int address, bool read, bool write, bool log)

--- a/Source/Core/Core/Debugger/PPCDebugInterface.h
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include "Common/DebugInterface.h"
@@ -25,7 +26,7 @@ public:
   void AddWatch(unsigned int address) override;
   void ToggleBreakpoint(unsigned int address) override;
   void ClearAllMemChecks() override;
-  bool IsMemCheck(unsigned int address) override;
+  bool IsMemCheck(unsigned int address, size_t size = 1) override;
   void ToggleMemCheck(unsigned int address, bool read = true, bool write = true,
                       bool log = true) override;
   unsigned int ReadMemory(unsigned int address) override;

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/HW/DSPLLE/DSPDebugInterface.h"
 
+#include <cstddef>
 #include <string>
 
 #include "Common/MsgHandler.h"
@@ -116,7 +117,7 @@ void DSPDebugInterface::ToggleBreakpoint(unsigned int address)
   }
 }
 
-bool DSPDebugInterface::IsMemCheck(unsigned int address)
+bool DSPDebugInterface::IsMemCheck(unsigned int address, size_t size)
 {
   return false;
 }

--- a/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
+++ b/Source/Core/Core/HW/DSPLLE/DSPDebugInterface.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include "Common/CommonTypes.h"
@@ -27,7 +28,7 @@ public:
   void ClearAllBreakpoints() override;
   void ToggleBreakpoint(unsigned int address) override;
   void ClearAllMemChecks() override;
-  bool IsMemCheck(unsigned int address) override;
+  bool IsMemCheck(unsigned int address, size_t size) override;
   void ToggleMemCheck(unsigned int address, bool read = true, bool write = true,
                       bool log = true) override;
   unsigned int ReadMemory(unsigned int address) override;

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -5,6 +5,7 @@
 #include "Core/PowerPC/BreakPoints.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -201,16 +202,11 @@ void MemChecks::Remove(u32 address)
   }
 }
 
-TMemCheck* MemChecks::GetMemCheck(u32 address)
+TMemCheck* MemChecks::GetMemCheck(u32 address, size_t size)
 {
   for (TMemCheck& mc : m_mem_checks)
   {
-    if (mc.is_ranged)
-    {
-      if (address >= mc.start_address && address <= mc.end_address)
-        return &mc;
-    }
-    else if (mc.start_address == address)
+    if (mc.end_address >= address && address + size - 1 >= mc.start_address)
     {
       return &mc;
     }
@@ -239,8 +235,8 @@ bool MemChecks::OverlapsMemcheck(u32 address, u32 length)
   return false;
 }
 
-bool TMemCheck::Action(DebugInterface* debug_interface, u32 value, u32 addr, bool write, int size,
-                       u32 pc)
+bool TMemCheck::Action(DebugInterface* debug_interface, u32 value, u32 addr, bool write,
+                       size_t size, u32 pc)
 {
   if ((write && is_break_on_write) || (!write && is_break_on_read))
   {

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -34,7 +35,7 @@ struct TMemCheck
   u32 num_hits = 0;
 
   // returns whether to break
-  bool Action(DebugInterface* dbg_interface, u32 value, u32 addr, bool write, int size, u32 pc);
+  bool Action(DebugInterface* dbg_interface, u32 value, u32 addr, bool write, size_t size, u32 pc);
 };
 
 struct TWatch
@@ -86,7 +87,7 @@ public:
   void Add(const TMemCheck& memory_check);
 
   // memory breakpoint
-  TMemCheck* GetMemCheck(u32 address);
+  TMemCheck* GetMemCheck(u32 address, size_t size = 1);
   bool OverlapsMemcheck(u32 address, u32 length);
   void Remove(u32 address);
 

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -416,11 +416,11 @@ u32 HostRead_Instruction(const u32 address)
   return inst.hex;
 }
 
-static void Memcheck(u32 address, u32 var, bool write, int size)
+static void Memcheck(u32 address, u32 var, bool write, size_t size)
 {
   if (PowerPC::memchecks.HasAny())
   {
-    TMemCheck* mc = PowerPC::memchecks.GetMemCheck(address);
+    TMemCheck* mc = PowerPC::memchecks.GetMemCheck(address, size);
     if (mc)
     {
       if (CPU::IsStepping())

--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -418,7 +418,7 @@ void CMemoryView::OnPaint(wxPaintEvent& event)
       draw_text(StrToWxStr(desc), 2);
 
     // Show blue memory check dot
-    if (debugger->IsMemCheck(address))
+    if (debugger->IsMemCheck(address, sizeof(u8)))
     {
       dc.SetPen(*wxTRANSPARENT_PEN);
       dc.SetBrush(mc_brush);


### PR DESCRIPTION
Instead of just repeating what the commit says, here's a more practical example so it's easier to understand what the issue is and how I fixed it.

In Super Mario Sunshine, the RNG seed address is 0x8040CE30 and is a word (4 bytes long).  Currently, in master, if you were to add a memory breakpoint that would break on this address, the address MUST be included in the range or must EXACTLY be this address in the case of a single address memory breakpoint.  The problem comes from the fact that it didn't JUST wrote to this address, it also wrote to the next 3 one because it is writting 4 bytes so a single address memory breakpoint to 0x8040CE33 for instance would not break, even though it did wrote/read that address, it just didn't STARTED the read/write there.

So I changed how GetMemCheck works, I added a size parameter so it can adapt itself depending on how much you are writting (by default 1 because only the MMU memcheck function needs to pass an exact size, the rest actually only care about memchecks being present which is the case for the GUI display).  Then, after a lot of tinkering around to get the conditions right, I actually found out that you don't even need to do something different whether the memory breakpoint is ranged or not.  The reason the function can be so simpler is because in the case of non ranged memory breakpoint, the start address is equal to the end one so the same condition can apply to everything.  

Because of how minimal this function does, it doesn't impact performance, even though it's called very often.  I actually wasn't able to notice any performance dips on rs2 and the intro of rs3.

Last note, to test this on Windows, you need to apply #5004 otherwise they just won't work.