### PR TITLE
Vulkan: Fix underflow in StreamBuffer::WaitForClearSpace

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/StreamBuffer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StreamBuffer.cpp
@@ -316,7 +316,7 @@ bool StreamBuffer::WaitForClearSpace(size_t num_bytes)
       // We're currently allocating behind the GPU. This would give us between the current
       // offset and the GPU position worth of space to work with. Again, > because we can't
       // align the GPU position with the buffer offset.
-      size_t available_space_inbetween = m_current_offset - gpu_position;
+      size_t available_space_inbetween = gpu_position - m_current_offset;
       if (available_space_inbetween > num_bytes)
       {
         // Leave the offset as-is, but update the GPU position.


### PR DESCRIPTION
This could cause the assertion on line 212 to fail when uploading large amounts of data in between command buffer executions.

May fix https://bugs.dolphin-emu.org/issues/10076