### PR TITLE
D3D11: Use default usage for TextureCache entries

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DTexture.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.cpp
@@ -11,40 +11,6 @@
 
 namespace DX11
 {
-namespace D3D
-{
-void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned int width,
-                          unsigned int height, unsigned int src_pitch, unsigned int level,
-                          D3D11_USAGE usage)
-{
-  if (usage == D3D11_USAGE_DYNAMIC || usage == D3D11_USAGE_STAGING)
-  {
-    D3D11_MAPPED_SUBRESOURCE map;
-    D3D::context->Map(pTexture, level, D3D11_MAP_WRITE_DISCARD, 0, &map);
-    if (src_pitch == map.RowPitch)
-    {
-      memcpy(map.pData, buffer, map.RowPitch * height);
-    }
-    else
-    {
-      // Source row size is aligned to texture block size. This can result in a different
-      // pitch to what the driver returns, so copy whichever is smaller.
-      unsigned int copy_size = std::min(src_pitch, map.RowPitch);
-      for (unsigned int y = 0; y < height; ++y)
-        memcpy((u8*)map.pData + y * map.RowPitch, buffer + y * src_pitch, copy_size);
-    }
-    D3D::context->Unmap(pTexture, level);
-  }
-  else
-  {
-    D3D11_BOX dest_region = CD3D11_BOX(0, 0, 0, width, height, 1);
-    D3D::context->UpdateSubresource(pTexture, level, &dest_region, buffer, src_pitch,
-                                    src_pitch * height);
-  }
-}
-
-}  // namespace
-
 D3DTexture2D* D3DTexture2D::Create(unsigned int width, unsigned int height, D3D11_BIND_FLAG bind,
                                    D3D11_USAGE usage, DXGI_FORMAT fmt, unsigned int levels,
                                    unsigned int slices, D3D11_SUBRESOURCE_DATA* data)

--- a/Source/Core/VideoBackends/D3D/D3DTexture.h
+++ b/Source/Core/VideoBackends/D3D/D3DTexture.h
@@ -9,13 +9,6 @@
 
 namespace DX11
 {
-namespace D3D
-{
-void ReplaceRGBATexture2D(ID3D11Texture2D* pTexture, const u8* buffer, unsigned int width,
-                          unsigned int height, unsigned int src_pitch, unsigned int level,
-                          D3D11_USAGE usage);
-}
-
 class D3DTexture2D
 {
 public:

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -134,7 +134,7 @@ void TextureCache::TCacheEntry::Load(const u8* buffer, u32 width, u32 height, u3
                                      u32 level)
 {
   unsigned int src_pitch = 4 * expanded_width;
-  D3D::ReplaceRGBATexture2D(texture->GetTex(), buffer, width, height, src_pitch, level, usage);
+  D3D::context->UpdateSubresource(texture->GetTex(), level, nullptr, buffer, src_pitch, 0);
 }
 
 TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntryConfig& config)
@@ -149,18 +149,9 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
   }
   else
   {
-    D3D11_USAGE usage = D3D11_USAGE_DEFAULT;
-    D3D11_CPU_ACCESS_FLAG cpu_access = (D3D11_CPU_ACCESS_FLAG)0;
-
-    if (config.levels == 1)
-    {
-      usage = D3D11_USAGE_DYNAMIC;
-      cpu_access = D3D11_CPU_ACCESS_WRITE;
-    }
-
     const D3D11_TEXTURE2D_DESC texdesc =
         CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, config.width, config.height, 1,
-                              config.levels, D3D11_BIND_SHADER_RESOURCE, usage, cpu_access);
+                              config.levels, D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0);
 
     ID3D11Texture2D* pTexture;
     const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &pTexture);
@@ -168,7 +159,6 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
 
     TCacheEntry* const entry =
         new TCacheEntry(config, new D3DTexture2D(pTexture, D3D11_BIND_SHADER_RESOURCE));
-    entry->usage = usage;
 
     // TODO: better debug names
     D3D::SetDebugObjectName((ID3D11DeviceChild*)entry->texture->GetTex(),

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -20,8 +20,6 @@ private:
   {
     D3DTexture2D* const texture;
 
-    D3D11_USAGE usage;
-
     TCacheEntry(const TCacheEntryConfig& config, D3DTexture2D* _tex)
         : TCacheEntryBase(config), texture(_tex)
     {


### PR DESCRIPTION
I'm not sure on the reasoning behind using dynamic usage for non-mipmapped textures in the first place, but it's unlikely textures will be updated every frame, so the default pool is likely a better choice anyway.

I'm suspecting it's the cause behind the texture corruption on AMD systems as well: https://bugs.dolphin-emu.org/issues/10087