### PR TITLE
MMU: Create constants for our BAT flags.

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -229,12 +229,12 @@ void UpdateLogicalMemory(const PowerPC::BatTable& dbat_table)
   logical_mapped_entries.clear();
   for (u32 i = 0; i < (1 << (32 - PowerPC::BAT_INDEX_SHIFT)); ++i)
   {
-    if (dbat_table[i] & 1)
+    if (dbat_table[i] & PowerPC::BAT_MAPPED_BIT)
     {
       u32 logical_address = i << PowerPC::BAT_INDEX_SHIFT;
       // TODO: Merge adjacent mappings to make this faster.
-      u32 logical_size = 1 << PowerPC::BAT_INDEX_SHIFT;
-      u32 translated_address = dbat_table[i] & ~3;
+      u32 logical_size = PowerPC::BAT_PAGE_SIZE;
+      u32 translated_address = dbat_table[i] & PowerPC::BAT_RESULT_MASK;
       for (const auto& physical_region : physical_regions)
       {
         u32 mapping_address = physical_region.physical_address;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -347,7 +347,8 @@ void Jit64::dcbz(UGeckoInstruction inst)
     // Perform lookup to see if we can use fast path.
     MOV(32, R(RSCRATCH2), R(RSCRATCH));
     SHR(32, R(RSCRATCH2), Imm8(PowerPC::BAT_INDEX_SHIFT));
-    TEST(32, MScaled(RSCRATCH2, SCALE_4, PtrOffset(&PowerPC::dbat_table[0])), Imm32(2));
+    TEST(32, MScaled(RSCRATCH2, SCALE_4, PtrOffset(&PowerPC::dbat_table[0])),
+         Imm32(PowerPC::BAT_PHYSICAL_BIT));
     FixupBranch slow = J_CC(CC_Z, true);
 
     // Fast path: compute full address, then zero out 32 bytes of memory.

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -105,7 +105,8 @@ FixupBranch EmuCodeBlock::CheckIfSafeAddress(const OpArg& reg_value, X64Reg reg_
 
   // Perform lookup to see if we can use fast path.
   SHR(32, R(scratch), Imm8(PowerPC::BAT_INDEX_SHIFT));
-  TEST(32, MScaled(scratch, SCALE_4, PtrOffset(&PowerPC::dbat_table[0])), Imm32(2));
+  TEST(32, MScaled(scratch, SCALE_4, PtrOffset(&PowerPC::dbat_table[0])),
+       Imm32(PowerPC::BAT_PHYSICAL_BIT));
 
   if (scratch == reg_addr)
     POP(scratch);

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -288,16 +288,20 @@ struct TranslateResult
 };
 TranslateResult JitCache_TranslateAddress(u32 address);
 
-static const int BAT_INDEX_SHIFT = 17;
+constexpr int BAT_INDEX_SHIFT = 17;
+constexpr u32 BAT_PAGE_SIZE = 1 << BAT_INDEX_SHIFT;
+constexpr u32 BAT_MAPPED_BIT = 0x1;
+constexpr u32 BAT_PHYSICAL_BIT = 0x2;
+constexpr u32 BAT_RESULT_MASK = ~0x3;
 using BatTable = std::array<u32, 1 << (32 - BAT_INDEX_SHIFT)>;  // 128 KB
 extern BatTable ibat_table;
 extern BatTable dbat_table;
 inline bool TranslateBatAddess(const BatTable& bat_table, u32* address)
 {
   u32 bat_result = bat_table[*address >> BAT_INDEX_SHIFT];
-  if ((bat_result & 1) == 0)
+  if ((bat_result & BAT_MAPPED_BIT) == 0)
     return false;
-  *address = (bat_result & ~3) | (*address & 0x0001FFFF);
+  *address = (bat_result & BAT_RESULT_MASK) | (*address & (BAT_PAGE_SIZE - 1));
   return true;
 }
 }  // namespace


### PR DESCRIPTION
This avoids a few hard-coded constants in several files.