### PR TITLE
Android: Update android studio + gradle.

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    // Leanback support requires >22
-    compileSdkVersion 24
-    buildToolsVersion '24.0.3'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     lintOptions {
         // This is important as it will run lint but not abort on error
@@ -73,13 +72,13 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v13:24.2.1'
-    compile 'com.android.support:cardview-v7:24.2.1'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
-    compile 'com.android.support:design:24.2.1'
+    compile 'com.android.support:support-v13:25.2.0'
+    compile 'com.android.support:cardview-v7:25.2.0'
+    compile 'com.android.support:recyclerview-v7:25.2.0'
+    compile 'com.android.support:design:25.2.0'
 
     // Android TV UI libraries.
-    compile 'com.android.support:leanback-v17:24.2.1'
+    compile 'com.android.support:leanback-v17:25.2.0'
 
     // For showing the banner as a circle a-la Material Design Guidelines
     compile 'de.hdodenhof:circleimageview:2.1.0'

--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Source/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Source/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 06 15:24:00 CEST 2016
+#Sat Mar 04 15:47:41 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip


### PR DESCRIPTION
Android studio 2.3 finally displays the result of the native compilation, so C++ warnings are now shown in the build log.