### PR TITLE
Add CMake switch for using XCB instead of Xlib for the Vulkan backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(ENABLE_PULSEAUDIO "Enables PulseAudio sound backend" ON)
 option(ENABLE_OPENAL "Enables OpenAL sound backend" ON)
 option(ENABLE_LLVM "Enables LLVM support, for disassembly" ON)
 option(ENABLE_BLUEZ "Enables bluetooth support" ON)
+option(ENABLE_XCB "Use xcb over xlib for Vulkan backend" OFF)
 
 # Maintainers: if you consider blanket disabling this for your users, please
 # consider the following points:
@@ -542,6 +543,11 @@ endif()
 if(ENABLE_ANALYTICS)
   message(STATUS "Enabling analytics collection (subject to end-user opt-in)")
   add_definitions(-DUSE_ANALYTICS=1)
+endif()
+
+if(ENABLE_XCB)
+  message(STATUS "Using XCB instead of Xlib.")
+  add_definitions(-DUSE_XCB=1)
 endif()
 
 ########################################

--- a/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
@@ -28,6 +28,10 @@ set(LIBS
   common
 )
 
+if(ENABLE_XCB)
+  list(APPEND LIBS X11-xcb)
+endif()
+
 # Only include the Vulkan headers when building the Vulkan backend
 include_directories(${CMAKE_SOURCE_DIR}/Externals/Vulkan/Include)
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -8,11 +8,12 @@
 
 #if defined(WIN32)
 #define VK_USE_PLATFORM_WIN32_KHR
-#elif defined(HAVE_X11)
-// Currently we're getting xlib handles passed to the backend.
-// If this ever changes to xcb, it's a simple change here.
+#elif defined(HAVE_X11) && HAVE_X11
+#if defined(USE_XCB)
+#define VK_USE_PLATFORM_XCB_KHR
+#else
 #define VK_USE_PLATFORM_XLIB_KHR
-//#define VK_USE_PLATFORM_XCB_KHR
+#endif
 #elif defined(ANDROID)
 #define VK_USE_PLATFORM_ANDROID_KHR
 #else


### PR DESCRIPTION
There may be other places to do this as well.