### PR TITLE
Vulkan: Switch to using xcb instead of xlib (and enable headless)

### DIFF
--- a/CMake/FindX11_XCB.cmake
+++ b/CMake/FindX11_XCB.cmake
@@ -1,0 +1,120 @@
+#.rst:
+# FindX11_XCB
+# -----------
+#
+# Sourced from: https://github.com/KDE/extra-cmake-modules/blob/master/find-modules/FindX11_XCB.cmake
+#
+# Try to find the X11 XCB compatibility library.
+#
+# This will define the following variables:
+#
+# ``X11_XCB_FOUND``
+#     True if (the requested version of) libX11-xcb is available
+# ``X11_XCB_VERSION``
+#     The version of libX11-xcb (this is not guaranteed to be set even when
+#     X11_XCB_FOUND is true)
+# ``X11_XCB_LIBRARIES``
+#     This can be passed to target_link_libraries() instead of the ``EGL::EGL``
+#     target
+# ``X11_XCB_INCLUDE_DIR``
+#     This should be passed to target_include_directories() if the target is not
+#     used for linking
+# ``X11_XCB_DEFINITIONS``
+#     This should be passed to target_compile_options() if the target is not
+#     used for linking
+#
+# If ``X11_XCB_FOUND`` is TRUE, it will also define the following imported
+# target:
+#
+# ``X11::XCB``
+#     The X11 XCB compatibility library
+#
+# In general we recommend using the imported target, as it is easier to use.
+# Bear in mind, however, that if the target is in the link interface of an
+# exported library, it must be made available by the package config file.
+#
+# Since pre-1.0.0.
+
+#=============================================================================
+# Copyright 2014 Alex Merry <alex.merry@kde.org>
+# Copyright 2011 Fredrik Höglund <fredrik@kde.org>
+# Copyright 2008 Helio Chissini de Castro <helio@kde.org>
+# Copyright 2007 Matthias Kretz <kretz@kde.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
+
+#include(${CMAKE_CURRENT_LIST_DIR}/ECMFindModuleHelpersStub.cmake)
+
+#ecm_find_package_version_check(X11_XCB)
+
+# use pkg-config to get the directories and then use these values
+# in the FIND_PATH() and FIND_LIBRARY() calls
+find_package(PkgConfig)
+pkg_check_modules(PKG_X11_XCB QUIET x11-xcb)
+
+set(X11_XCB_DEFINITIONS ${PKG_X11_XCB_CFLAGS_OTHER})
+set(X11_XCB_VERSION ${PKG_X11_XCB_VERSION})
+
+find_path(X11_XCB_INCLUDE_DIR
+    NAMES X11/Xlib-xcb.h
+    HINTS ${PKG_X11_XCB_INCLUDE_DIRS}
+)
+find_library(X11_XCB_LIBRARY
+    NAMES X11-xcb
+    HINTS ${PKG_X11_XCB_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(X11_XCB
+    FOUND_VAR
+        X11_XCB_FOUND
+    REQUIRED_VARS
+        X11_XCB_LIBRARY
+        X11_XCB_INCLUDE_DIR
+    VERSION_VAR
+        X11_XCB_VERSION
+)
+
+if(X11_XCB_FOUND AND NOT TARGET X11::XCB)
+    add_library(X11::XCB UNKNOWN IMPORTED)
+    set_target_properties(X11::XCB PROPERTIES
+        IMPORTED_LOCATION "${X11_XCB_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${X11_XCB_DEFINITIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${X11_XCB_INCLUDE_DIR}"
+    )
+endif()
+
+mark_as_advanced(X11_XCB_INCLUDE_DIR X11_XCB_LIBRARY)
+
+# compatibility variables
+set(X11_XCB_LIBRARIES ${X11_XCB_LIBRARY})
+set(X11_XCB_INCLUDE_DIRS ${X11_XCB_INCLUDE_DIR})
+set(X11_XCB_VERSION_STRING ${X11_XCB_VERSION})
+
+include(FeatureSummary)
+set_package_properties(X11_XCB PROPERTIES
+    URL "http://xorg.freedesktop.org/"
+    DESCRIPTION "A compatibility library for code that translates Xlib API calls into XCB calls"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   endif()
 endif()
 
+if(NOT APPLE)
+  option(ENABLE_VULKAN "Enables Vulkan backend" ON)
+endif()
+
 if(UNIX)
   # Builds a relocatable binary on Linux.
   # The Sys folder will need to be copied to the Binaries folder.
@@ -536,7 +540,10 @@ endif()
 #
 add_subdirectory(Externals/Bochs_disasm)
 add_subdirectory(Externals/cpp-optparse)
-add_subdirectory(Externals/glslang)
+
+# glslang is only currently used by the Vulkan backend, so only build it when
+# the Vulkan backend is also being built.
+add_subdirectory(Externals/glslang EXCLUDE_FROM_ALL)
 
 find_package(pugixml)
 if(NOT pugixml_FOUND)

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -318,7 +318,7 @@ if(LIBUSB_FOUND)
   )
 endif()
 
-if(NOT APPLE)
+if(ENABLE_VULKAN)
   target_link_libraries(core PUBLIC videovulkan)
 endif()
 

--- a/Source/Core/VideoBackends/CMakeLists.txt
+++ b/Source/Core/VideoBackends/CMakeLists.txt
@@ -6,6 +6,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_subdirectory(D3D)
 endif()
 
-if(NOT APPLE)
+if(ENABLE_VULKAN)
   add_subdirectory(Vulkan)
 endif()

--- a/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
+++ b/Source/Core/VideoBackends/Vulkan/CMakeLists.txt
@@ -1,3 +1,13 @@
+# We require libX11-xcb when building for X11. This isn't required for any other backend, so test for it here.
+if(USE_X11)
+  find_package(X11_XCB)
+  if (NOT X11_XCB_FOUND)
+    message(FATAL_ERROR "libX11-xcb is required to build the Vulkan backend with X11.")
+  endif()
+endif()
+
+message(STATUS "Enabling Vulkan video backend")
+
 add_library(videovulkan
   BoundingBox.cpp
   CommandBufferManager.cpp
@@ -50,3 +60,9 @@ SYSTEM PRIVATE
   ${CMAKE_SOURCE_DIR}/Externals/glslang/glslang/Public
   ${CMAKE_SOURCE_DIR}/Externals/glslang/SPIRV
 )
+
+# When building for X11, we need to link to libX11-xcb.
+# The main executable doesn't need this library directly, so we have to add it here.
+if(USE_X11)
+  target_link_libraries(videovulkan PRIVATE X11::XCB)
+endif()

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -31,6 +31,7 @@
 #include "VideoBackends/Vulkan/VKPipeline.h"
 #include "VideoBackends/Vulkan/VKShader.h"
 #include "VideoBackends/Vulkan/VKTexture.h"
+#include "VideoBackends/Vulkan/VideoBackend.h"
 #include "VideoBackends/Vulkan/VulkanContext.h"
 
 #include "VideoCommon/BPFunctions.h"
@@ -891,11 +892,13 @@ void Renderer::CheckForSurfaceChange()
   else
   {
     // Previously had no swap chain. So create one.
-    VkSurfaceKHR surface =
-        SwapChain::CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(), m_surface_handle);
+    void* display_handle = static_cast<VideoBackend*>(g_video_backend)->GetDisplayHandle();
+    VkSurfaceKHR surface = SwapChain::CreateVulkanSurface(g_vulkan_context->GetVulkanInstance(),
+                                                          display_handle, m_new_surface_handle);
     if (surface != VK_NULL_HANDLE)
     {
-      m_swap_chain = SwapChain::Create(m_surface_handle, surface, g_ActiveConfig.IsVSync());
+      m_swap_chain =
+          SwapChain::Create(display_handle, m_surface_handle, surface, g_ActiveConfig.IsVSync());
       if (!m_swap_chain)
         PanicAlert("Failed to create swap chain.");
     }

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.cpp
@@ -16,9 +16,7 @@
 #include "VideoBackends/Vulkan/VulkanContext.h"
 #include "VideoCommon/RenderBase.h"
 
-#if defined(VK_USE_PLATFORM_XLIB_KHR)
-#include <X11/Xlib.h>
-#elif defined(VK_USE_PLATFORM_XCB_KHR)
+#if defined(VK_USE_PLATFORM_XCB_KHR)
 #include <X11/Xlib-xcb.h>
 #include <X11/Xlib.h>
 #endif
@@ -55,25 +53,6 @@ VkSurfaceKHR SwapChain::CreateVulkanSurface(VkInstance instance, void* display_h
   if (res != VK_SUCCESS)
   {
     LOG_VULKAN_ERROR(res, "vkCreateWin32SurfaceKHR failed: ");
-    return VK_NULL_HANDLE;
-  }
-
-  return surface;
-
-#elif defined(VK_USE_PLATFORM_XLIB_KHR)
-  VkXlibSurfaceCreateInfoKHR surface_create_info = {
-      VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR,  // VkStructureType               sType
-      nullptr,                                         // const void*                   pNext
-      0,                                               // VkXlibSurfaceCreateFlagsKHR   flags
-      reinterpret_cast<Display*>(display_handle),      // Display*                      dpy
-      reinterpret_cast<Window>(window_handle)          // Window                        window
-  };
-
-  VkSurfaceKHR surface;
-  VkResult res = vkCreateXlibSurfaceKHR(instance, &surface_create_info, nullptr, &surface);
-  if (res != VK_SUCCESS)
-  {
-    LOG_VULKAN_ERROR(res, "vkCreateXlibSurfaceKHR failed: ");
     return VK_NULL_HANDLE;
   }
 

--- a/Source/Core/VideoBackends/Vulkan/SwapChain.h
+++ b/Source/Core/VideoBackends/Vulkan/SwapChain.h
@@ -19,16 +19,18 @@ class ObjectCache;
 class SwapChain
 {
 public:
-  SwapChain(void* native_handle, VkSurfaceKHR surface, bool vsync);
+  SwapChain(void* display_handle, void* window_handle, VkSurfaceKHR surface, bool vsync);
   ~SwapChain();
 
   // Creates a vulkan-renderable surface for the specified window handle.
-  static VkSurfaceKHR CreateVulkanSurface(VkInstance instance, void* hwnd);
+  static VkSurfaceKHR CreateVulkanSurface(VkInstance instance, void* display_handle,
+                                          void* window_handle);
 
   // Create a new swap chain from a pre-existing surface.
-  static std::unique_ptr<SwapChain> Create(void* native_handle, VkSurfaceKHR surface, bool vsync);
+  static std::unique_ptr<SwapChain> Create(void* display_handle, void* window_handle,
+                                           VkSurfaceKHR surface, bool vsync);
 
-  void* GetNativeHandle() const { return m_native_handle; }
+  void* GetWindowHandle() const { return m_window_handle; }
   VkSurfaceKHR GetSurface() const { return m_surface; }
   VkSurfaceFormatKHR GetSurfaceFormat() const { return m_surface_format; }
   bool IsVSyncEnabled() const { return m_vsync_enabled; }
@@ -53,7 +55,7 @@ public:
 
   VkResult AcquireNextImage(VkSemaphore available_semaphore);
 
-  bool RecreateSurface(void* native_handle);
+  bool RecreateSurface(void* window_handle);
   bool ResizeSwapChain();
   bool RecreateSwapChain();
 
@@ -81,7 +83,8 @@ private:
     VkFramebuffer framebuffer;
   };
 
-  void* m_native_handle;
+  void* m_display_handle;
+  void* m_window_handle;
   VkSurfaceKHR m_surface = VK_NULL_HANDLE;
   VkSurfaceFormatKHR m_surface_format = {};
   VkPresentModeKHR m_present_mode = VK_PRESENT_MODE_RANGE_SIZE_KHR;

--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -18,5 +18,13 @@ public:
   std::string GetName() const override { return "Vulkan"; }
   std::string GetDisplayName() const override { return _trans("Vulkan"); }
   void InitBackendInfo() override;
+
+private:
+  // Helpers to manage the connection to the X server.
+  bool OpenDisplayConnection();
+  void CloseDisplayConnection();
+
+  // For X11 systems, contains a pointer to the Display connection.
+  void* m_native_display = nullptr;
 };
 }

--- a/Source/Core/VideoBackends/Vulkan/VideoBackend.h
+++ b/Source/Core/VideoBackends/Vulkan/VideoBackend.h
@@ -19,12 +19,14 @@ public:
   std::string GetDisplayName() const override { return _trans("Vulkan"); }
   void InitBackendInfo() override;
 
+  void* GetDisplayHandle() const { return m_display_handle; }
+
 private:
   // Helpers to manage the connection to the X server.
   bool OpenDisplayConnection();
   void CloseDisplayConnection();
 
   // For X11 systems, contains a pointer to the Display connection.
-  void* m_native_display = nullptr;
+  void* m_display_handle = nullptr;
 };
 }

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -177,9 +177,6 @@ bool VulkanContext::SelectInstanceExtensions(ExtensionList* extension_list, bool
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
   if (enable_surface && !SupportsExtension(VK_KHR_WIN32_SURFACE_EXTENSION_NAME, true))
     return false;
-#elif defined(VK_USE_PLATFORM_XLIB_KHR)
-  if (enable_surface && !SupportsExtension(VK_KHR_XLIB_SURFACE_EXTENSION_NAME, true))
-    return false;
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
   if (enable_surface && !SupportsExtension(VK_KHR_XCB_SURFACE_EXTENSION_NAME, true))
     return false;

--- a/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
+++ b/Source/Core/VideoBackends/Vulkan/VulkanEntryPoints.inl
@@ -16,7 +16,7 @@ VULKAN_MODULE_ENTRY_POINT(vkGetDeviceProcAddr, true)
 VULKAN_MODULE_ENTRY_POINT(vkEnumerateInstanceExtensionProperties, true)
 VULKAN_MODULE_ENTRY_POINT(vkEnumerateInstanceLayerProperties, true)
 
-#endif		// VULKAN_MODULE_ENTRY_POINT
+#endif  // VULKAN_MODULE_ENTRY_POINT
 
 #ifdef VULKAN_INSTANCE_ENTRY_POINT
 
@@ -164,11 +164,6 @@ VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceSurfacePresentModesKHR, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkCreateWin32SurfaceKHR, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceWin32PresentationSupportKHR, false)
 
-#elif defined(VK_USE_PLATFORM_XLIB_KHR)
-
-VULKAN_INSTANCE_ENTRY_POINT(vkCreateXlibSurfaceKHR, false)
-VULKAN_INSTANCE_ENTRY_POINT(vkGetPhysicalDeviceXlibPresentationSupportKHR, false)
-
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
 
 VULKAN_INSTANCE_ENTRY_POINT(vkCreateXcbSurfaceKHR, false)
@@ -184,7 +179,7 @@ VULKAN_INSTANCE_ENTRY_POINT(vkCreateDebugReportCallbackEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkDestroyDebugReportCallbackEXT, false)
 VULKAN_INSTANCE_ENTRY_POINT(vkDebugReportMessageEXT, false)
 
-#endif		// VULKAN_INSTANCE_ENTRY_POINT
+#endif  // VULKAN_INSTANCE_ENTRY_POINT
 
 #ifdef VULKAN_DEVICE_ENTRY_POINT
 
@@ -194,4 +189,4 @@ VULKAN_DEVICE_ENTRY_POINT(vkGetSwapchainImagesKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkAcquireNextImageKHR, false)
 VULKAN_DEVICE_ENTRY_POINT(vkQueuePresentKHR, false)
 
-#endif		// VULKAN_DEVICE_ENTRY_POINT
+#endif  // VULKAN_DEVICE_ENTRY_POINT

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.cpp
@@ -13,8 +13,7 @@
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 #include <Windows.h>
-#elif defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR) ||                     \
-    defined(VK_USE_PLATFORM_ANDROID_KHR) || defined(USE_HEADLESS)
+#elif defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_ANDROID_KHR)
 #include <dlfcn.h>
 #endif
 
@@ -97,9 +96,7 @@ void UnloadVulkanLibrary()
   vulkan_module = nullptr;
 }
 
-#elif defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR) ||                     \
-    defined(VK_USE_PLATFORM_ANDROID_KHR) || defined(USE_HEADLESS)
-
+#elif defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_ANDROID_KHR)
 static void* vulkan_module;
 static std::atomic_int vulkan_module_ref_count = {0};
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanLoader.h
@@ -9,10 +9,7 @@
 #if defined(WIN32)
 #define VK_USE_PLATFORM_WIN32_KHR
 #elif defined(HAVE_X11)
-// Currently we're getting xlib handles passed to the backend.
-// If this ever changes to xcb, it's a simple change here.
-#define VK_USE_PLATFORM_XLIB_KHR
-//#define VK_USE_PLATFORM_XCB_KHR
+#define VK_USE_PLATFORM_XCB_KHR
 #elif defined(ANDROID)
 #define VK_USE_PLATFORM_ANDROID_KHR
 #else

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -102,8 +102,8 @@ static bool ShouldEnableDebugReports(bool enable_validation_layers)
 bool VideoBackend::OpenDisplayConnection()
 {
 #if defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR)
-  m_native_display = XOpenDisplay(nullptr);
-  if (!m_native_display)
+  m_display_handle = XOpenDisplay(nullptr);
+  if (!m_display_handle)
   {
     PanicAlert("Failed to open X display.");
     return false;
@@ -116,10 +116,10 @@ bool VideoBackend::OpenDisplayConnection()
 void VideoBackend::CloseDisplayConnection()
 {
 #if defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR)
-  if (m_native_display)
+  if (m_display_handle)
   {
-    XCloseDisplay(reinterpret_cast<Display*>(m_native_display));
-    m_native_display = nullptr;
+    XCloseDisplay(reinterpret_cast<Display*>(m_display_handle));
+    m_display_handle = nullptr;
   }
 #endif
 }
@@ -198,7 +198,7 @@ bool VideoBackend::Initialize(void* window_handle)
   VkSurfaceKHR surface = VK_NULL_HANDLE;
   if (enable_surface)
   {
-    surface = SwapChain::CreateVulkanSurface(instance, window_handle);
+    surface = SwapChain::CreateVulkanSurface(instance, m_display_handle, window_handle);
     if (surface == VK_NULL_HANDLE)
     {
       PanicAlert("Failed to create Vulkan surface.");
@@ -263,7 +263,7 @@ bool VideoBackend::Initialize(void* window_handle)
   std::unique_ptr<SwapChain> swap_chain;
   if (surface != VK_NULL_HANDLE)
   {
-    swap_chain = SwapChain::Create(window_handle, surface, g_Config.IsVSync());
+    swap_chain = SwapChain::Create(m_display_handle, window_handle, surface, g_Config.IsVSync());
     if (!swap_chain)
     {
       PanicAlert("Failed to create Vulkan swap chain.");

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -61,14 +61,19 @@ void VideoBackend::InitBackendInfo()
     }
     else
     {
-      PanicAlert("Failed to create Vulkan instance.");
+      PanicAlert("Failed to create Vulkan instance.\n\n"
+                 "This may be due to your GPU or driver not supporting Vulkan, "
+                 "or a required extension is unsupported.");
     }
 
     UnloadVulkanLibrary();
   }
   else
   {
-    PanicAlert("Failed to load Vulkan library.");
+    PanicAlert("Failed to load Vulkan library.\n\n"
+               "This may be due to the loader not being installed on your system.\n\n"
+               "The loader is usually provided with your display driver on Windows, "
+               "or in a package named 'libvulkan1' or 'vulkan-icd-loader' on Linux.");
   }
 }
 
@@ -93,7 +98,10 @@ bool VideoBackend::Initialize(void* window_handle)
 {
   if (!LoadVulkanLibrary())
   {
-    PanicAlert("Failed to load Vulkan library.");
+    PanicAlert("Failed to load Vulkan library.\n\n"
+               "This may be due to the loader not being installed on your system.\n\n"
+               "The loader is usually provided with your display driver on Windows, "
+               "or in a package named 'libvulkan1' or 'vulkan-icd-loader' on Linux.");
     return false;
   }
 
@@ -113,7 +121,9 @@ bool VideoBackend::Initialize(void* window_handle)
                                                             enable_validation_layer);
   if (instance == VK_NULL_HANDLE)
   {
-    PanicAlert("Failed to create Vulkan instance.");
+    PanicAlert("Failed to create Vulkan instance.\n\n"
+               "This may be due to your GPU or driver not supporting Vulkan, "
+               "or a required extension is unsupported.");
     UnloadVulkanLibrary();
     return false;
   }
@@ -132,7 +142,8 @@ bool VideoBackend::Initialize(void* window_handle)
   VulkanContext::GPUList gpu_list = VulkanContext::EnumerateGPUs(instance);
   if (gpu_list.empty())
   {
-    PanicAlert("No Vulkan physical devices available.");
+    PanicAlert("No Vulkan physical devices (GPUs) available.\n\n"
+               "This may be due to your GPU or driver not supporting Vulkan.");
     vkDestroyInstance(instance, nullptr);
     UnloadVulkanLibrary();
     return false;

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -24,7 +24,7 @@
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 
-#if defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR)
+#if defined(VK_USE_PLATFORM_XCB_KHR)
 #include <X11/Xlib.h>
 #endif
 
@@ -101,7 +101,9 @@ static bool ShouldEnableDebugReports(bool enable_validation_layers)
 // Helpers to manage the connection to the X server.
 bool VideoBackend::OpenDisplayConnection()
 {
-#if defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR)
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+  // We could probably use a xcb_connection_t here, however since we get passed an XLib window
+  // handle, not a xcb_window_t handle, to keep things consistent we will use an XLib connection.
   m_display_handle = XOpenDisplay(nullptr);
   if (!m_display_handle)
   {
@@ -115,7 +117,7 @@ bool VideoBackend::OpenDisplayConnection()
 
 void VideoBackend::CloseDisplayConnection()
 {
-#if defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR)
+#if defined(VK_USE_PLATFORM_XCB_KHR)
   if (m_display_handle)
   {
     XCloseDisplay(reinterpret_cast<Display*>(m_display_handle));

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -92,3 +92,8 @@ if(FFmpeg_FOUND)
     FFmpeg::swscale
   )
 endif()
+
+# VideoBackendBase.cpp needs to know if the Vulkan backend is being compiled or not.
+if(ENABLE_VULKAN)
+  target_compile_definitions(videocommon PRIVATE "ENABLE_VULKAN=1")
+endif()

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -23,7 +23,7 @@
 #include "VideoBackends/Null/VideoBackend.h"
 #include "VideoBackends/OGL/VideoBackend.h"
 #include "VideoBackends/Software/VideoBackend.h"
-#ifndef __APPLE__
+#if defined(ENABLE_VULKAN) || defined(WIN32)
 #include "VideoBackends/Vulkan/VideoBackend.h"
 #endif
 
@@ -193,9 +193,11 @@ void VideoBackendBase::PopulateList()
 #ifdef _WIN32
   g_available_video_backends.push_back(std::make_unique<DX11::VideoBackend>());
 #endif
-#ifndef __APPLE__
+
+#if defined(ENABLE_VULKAN) || defined(WIN32)
   g_available_video_backends.push_back(std::make_unique<Vulkan::VideoBackend>());
 #endif
+
   g_available_video_backends.push_back(std::make_unique<SW::VideoSoftware>());
   g_available_video_backends.push_back(std::make_unique<Null::VideoBackend>());
 


### PR DESCRIPTION
Been meaning to do this for a while, but kept forgetting. This PR switches the Vulkan backend to use xcb surfaces instead of xlib surfaces. This should resolve the issues with the backend not working on distributions that did not compile the loader with xcb support.

Few changes:

- Previously, we were leaking a display/connection every time the backend was started, this PR also fixes this behavior.
- The selection of surface extension has been moved to the build system, which I feel is a more appropriate place.
- I've dropped the xlib backend, if we ever need it back again it's just a matter of reverting the commit. But I've mentioned, it's unlikely that any system that is using a libX11 that is not a libxcb wrapper will support Vulkan anyway.
- Improved error messages with possible solutions when startup fails.