### PR TITLE
BTStub: Get rid of an unnecessary forward declaration in the cpp file

### DIFF
--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
@@ -6,11 +6,7 @@
 
 #include "Common/ChunkFile.h"
 #include "Common/MsgHandler.h"
-
-namespace Core
-{
-void DisplayMessage(const std::string& message, int time_in_ms);
-}
+#include "Core/Core.h"
 
 namespace IOS
 {


### PR DESCRIPTION
This should be using the header file in order to find the function name.