### PR TITLE
OGL: implement Bounding Box on systems w/o SSBO

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -239,6 +239,8 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("gpu-has-early-z", g_Config.backend_info.bSupportsEarlyZ);
   builder.AddData("gpu-has-binding-layout", g_Config.backend_info.bSupportsBindingLayout);
   builder.AddData("gpu-has-bbox", g_Config.backend_info.bSupportsBBox);
+  builder.AddData("gpu-has-fragment-stores-and-atomics",
+                  g_Config.backend_info.bSupportsFragmentStoresAndAtomics);
   builder.AddData("gpu-has-gs-instancing", g_Config.backend_info.bSupportsGSInstancing);
   builder.AddData("gpu-has-post-processing", g_Config.backend_info.bSupportsPostProcessing);
   builder.AddData("gpu-has-palette-conversion", g_Config.backend_info.bSupportsPaletteConversion);

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -112,7 +112,8 @@ void VideoBackend::InitBackendInfo()
       g_Config.backend_info.bSupportsEarlyZ = shader_model_5_supported;
 
       // Requires full UAV functionality (only available in shader model 5)
-      g_Config.backend_info.bSupportsBBox = shader_model_5_supported;
+      g_Config.backend_info.bSupportsBBox =
+          g_Config.backend_info.bSupportsFragmentStoresAndAtomics = shader_model_5_supported;
 
       // Requires the instance attribute (only available in shader model 5)
       g_Config.backend_info.bSupportsGSInstancing = shader_model_5_supported;

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -120,7 +120,8 @@ void VideoBackend::InitBackendInfo()
         g_Config.backend_info.bSupportsEarlyZ = true;
 
         // Requires full UAV functionality (only available in shader model 5)
-        g_Config.backend_info.bSupportsBBox = true;
+        g_Config.backend_info.bSupportsBBox =
+            g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;
 
         // Requires the instance attribute (only available in shader model 5)
         g_Config.backend_info.bSupportsGSInstancing = true;

--- a/Source/Core/VideoBackends/OGL/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/OGL/BoundingBox.cpp
@@ -28,7 +28,7 @@ namespace OGL
 {
 void BoundingBox::SetTargetSizeChanged(int target_width, int target_height)
 {
-  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
+  if (g_ActiveConfig.BBoxUseFragmentShaderImplementation())
     return;
 
   s_target_width = target_width;
@@ -42,7 +42,7 @@ void BoundingBox::SetTargetSizeChanged(int target_width, int target_height)
 
 void BoundingBox::Init(int target_width, int target_height)
 {
-  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
+  if (g_ActiveConfig.BBoxUseFragmentShaderImplementation())
   {
     int initial_values[4] = {0, 0, 0, 0};
     glGenBuffers(1, &s_bbox_buffer_id);
@@ -60,7 +60,7 @@ void BoundingBox::Init(int target_width, int target_height)
 
 void BoundingBox::Shutdown()
 {
-  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
+  if (g_ActiveConfig.BBoxUseFragmentShaderImplementation())
   {
     glDeleteBuffers(1, &s_bbox_buffer_id);
   }
@@ -72,7 +72,7 @@ void BoundingBox::Shutdown()
 
 void BoundingBox::Set(int index, int value)
 {
-  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
+  if (g_ActiveConfig.BBoxUseFragmentShaderImplementation())
   {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, s_bbox_buffer_id);
     glBufferSubData(GL_SHADER_STORAGE_BUFFER, index * sizeof(int), sizeof(int), &value);
@@ -95,7 +95,7 @@ void BoundingBox::Set(int index, int value)
 
 int BoundingBox::Get(int index)
 {
-  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
+  if (g_ActiveConfig.BBoxUseFragmentShaderImplementation())
   {
     int data = 0;
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, s_bbox_buffer_id);
@@ -170,7 +170,6 @@ void BoundingBox::StencilWasUpdated()
 
 bool BoundingBox::NeedsStencilBuffer()
 {
-  return g_ActiveConfig.bBBoxEnable &&
-         !g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics;
+  return g_ActiveConfig.bBBoxEnable && !g_ActiveConfig.BBoxUseFragmentShaderImplementation();
 }
 };

--- a/Source/Core/VideoBackends/OGL/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/OGL/BoundingBox.cpp
@@ -2,20 +2,45 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <array>
 #include <cstring>
 
 #include "Common/GL/GLUtil.h"
 
 #include "VideoBackends/OGL/BoundingBox.h"
+#include "VideoBackends/OGL/FramebufferManager.h"
 
 #include "VideoCommon/DriverDetails.h"
 #include "VideoCommon/VideoConfig.h"
 
 static GLuint s_bbox_buffer_id;
+static GLuint s_pbo;
+
+static std::array<int, 4> s_stencil_bounds;
+static bool s_stencil_updated;
+static bool s_stencil_cleared;
+
+static int s_target_width;
+static int s_target_height;
 
 namespace OGL
 {
-void BoundingBox::Init()
+void BoundingBox::SetTargetSizeChanged(int target_width, int target_height)
+{
+  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
+    return;
+
+  s_target_width = target_width;
+  s_target_height = target_height;
+  s_stencil_updated = false;
+
+  glBindBuffer(GL_PIXEL_PACK_BUFFER, s_pbo);
+  glBufferData(GL_PIXEL_PACK_BUFFER, s_target_width * s_target_height, nullptr, GL_STREAM_READ);
+  glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+}
+
+void BoundingBox::Init(int target_width, int target_height)
 {
   if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
   {
@@ -25,6 +50,12 @@ void BoundingBox::Init()
     glBufferData(GL_SHADER_STORAGE_BUFFER, 4 * sizeof(s32), initial_values, GL_DYNAMIC_DRAW);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, s_bbox_buffer_id);
   }
+  else
+  {
+    s_stencil_bounds = {{0, 0, 0, 0}};
+    glGenBuffers(1, &s_pbo);
+    SetTargetSizeChanged(target_width, target_height);
+  }
 }
 
 void BoundingBox::Shutdown()
@@ -33,40 +64,107 @@ void BoundingBox::Shutdown()
   {
     glDeleteBuffers(1, &s_bbox_buffer_id);
   }
+  else
+  {
+    glDeleteBuffers(1, &s_pbo);
+  }
 }
 
 void BoundingBox::Set(int index, int value)
 {
-  glBindBuffer(GL_SHADER_STORAGE_BUFFER, s_bbox_buffer_id);
-  glBufferSubData(GL_SHADER_STORAGE_BUFFER, index * sizeof(int), sizeof(int), &value);
-  glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
+  {
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, s_bbox_buffer_id);
+    glBufferSubData(GL_SHADER_STORAGE_BUFFER, index * sizeof(int), sizeof(int), &value);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+  }
+  else
+  {
+    s_stencil_bounds[index] = value;
+
+    if (!s_stencil_cleared)
+    {
+      // Assumes that the EFB framebuffer is currently bound
+      glClearStencil(0);
+      glClear(GL_STENCIL_BUFFER_BIT);
+      s_stencil_updated = false;
+      s_stencil_cleared = true;
+    }
+  }
 }
 
 int BoundingBox::Get(int index)
 {
-  int data = 0;
-  glBindBuffer(GL_SHADER_STORAGE_BUFFER, s_bbox_buffer_id);
-
-  if (!DriverDetails::HasBug(DriverDetails::BUG_SLOW_GETBUFFERSUBDATA))
+  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
   {
-    // Using glMapBufferRange to read back the contents of the SSBO is extremely slow
-    // on nVidia drivers. This is more noticeable at higher internal resolutions.
-    // Using glGetBufferSubData instead does not seem to exhibit this slowdown.
-    glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, index * sizeof(int), sizeof(int), &data);
+    int data = 0;
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, s_bbox_buffer_id);
+    if (!DriverDetails::HasBug(DriverDetails::BUG_SLOW_GETBUFFERSUBDATA))
+    {
+      // Using glMapBufferRange to read back the contents of the SSBO is extremely slow
+      // on nVidia drivers. This is more noticeable at higher internal resolutions.
+      // Using glGetBufferSubData instead does not seem to exhibit this slowdown.
+      glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, index * sizeof(int), sizeof(int), &data);
+    }
+    else
+    {
+      // Using glMapBufferRange is faster on AMD cards by a measurable margin.
+      void* ptr = glMapBufferRange(GL_SHADER_STORAGE_BUFFER, index * sizeof(int), sizeof(int),
+                                   GL_MAP_READ_BIT);
+      if (ptr)
+      {
+        memcpy(&data, ptr, sizeof(int));
+        glUnmapBuffer(GL_SHADER_STORAGE_BUFFER);
+      }
+    }
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+    return data;
   }
   else
   {
-    // Using glMapBufferRange is faster on AMD cards by a measurable margin.
-    void* ptr = glMapBufferRange(GL_SHADER_STORAGE_BUFFER, index * sizeof(int), sizeof(int),
-                                 GL_MAP_READ_BIT);
-    if (ptr)
+    if (s_stencil_updated)
     {
-      memcpy(&data, ptr, sizeof(int));
-      glUnmapBuffer(GL_SHADER_STORAGE_BUFFER);
-    }
-  }
+      s_stencil_updated = false;
 
-  glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-  return data;
+      FramebufferManager::ResolveEFBStencilTexture();
+      glBindFramebuffer(GL_READ_FRAMEBUFFER, FramebufferManager::GetResolvedFramebuffer());
+      glBindBuffer(GL_PIXEL_PACK_BUFFER, s_pbo);
+      glPixelStorei(GL_PACK_ALIGNMENT, 1);
+      glReadPixels(0, 0, s_target_width, s_target_height, GL_STENCIL_INDEX, GL_UNSIGNED_BYTE, 0);
+      glBindFramebuffer(GL_READ_FRAMEBUFFER, FramebufferManager::GetEFBFramebuffer());
+
+      // Eke every bit of performance out of the compiler that we can
+      std::array<int, 4> bounds = s_stencil_bounds;
+
+      u8* data = static_cast<u8*>(glMapBufferRange(
+          GL_PIXEL_PACK_BUFFER, 0, s_target_height * s_target_width, GL_MAP_READ_BIT));
+
+      for (int row = 0; row < s_target_height; row++)
+      {
+        for (int col = 0; col < s_target_width; col++)
+        {
+          if (data[row * s_target_width + col] == 0)
+            continue;
+          bounds[0] = std::min(bounds[0], col);
+          bounds[1] = std::max(bounds[1], col);
+          bounds[2] = std::min(bounds[2], row);
+          bounds[3] = std::max(bounds[3], row);
+        }
+      }
+
+      s_stencil_bounds = bounds;
+
+      glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+      glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    }
+
+    return s_stencil_bounds[index];
+  }
+}
+
+void BoundingBox::StencilWasUpdated()
+{
+  s_stencil_updated = true;
+  s_stencil_cleared = false;
 }
 };

--- a/Source/Core/VideoBackends/OGL/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/OGL/BoundingBox.cpp
@@ -17,7 +17,7 @@ namespace OGL
 {
 void BoundingBox::Init()
 {
-  if (g_ActiveConfig.backend_info.bSupportsBBox)
+  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
   {
     int initial_values[4] = {0, 0, 0, 0};
     glGenBuffers(1, &s_bbox_buffer_id);
@@ -29,8 +29,10 @@ void BoundingBox::Init()
 
 void BoundingBox::Shutdown()
 {
-  if (g_ActiveConfig.backend_info.bSupportsBBox)
+  if (g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics)
+  {
     glDeleteBuffers(1, &s_bbox_buffer_id);
+  }
 }
 
 void BoundingBox::Set(int index, int value)

--- a/Source/Core/VideoBackends/OGL/BoundingBox.cpp
+++ b/Source/Core/VideoBackends/OGL/BoundingBox.cpp
@@ -167,4 +167,10 @@ void BoundingBox::StencilWasUpdated()
   s_stencil_updated = true;
   s_stencil_cleared = false;
 }
+
+bool BoundingBox::NeedsStencilBuffer()
+{
+  return g_ActiveConfig.bBBoxEnable &&
+         !g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics;
+}
 };

--- a/Source/Core/VideoBackends/OGL/BoundingBox.h
+++ b/Source/Core/VideoBackends/OGL/BoundingBox.h
@@ -9,8 +9,15 @@ namespace OGL
 class BoundingBox
 {
 public:
-  static void Init();
+  static void Init(int target_width, int target_height);
   static void Shutdown();
+
+  static void SetTargetSizeChanged(int target_width, int target_height);
+
+  // When SSBO isn't available, the bounding box is calculated directly from the
+  // stencil buffer. When the stencil buffer is changed, this function needs to
+  // be called to invalidate the cached bounding box data.
+  static void StencilWasUpdated();
 
   static void Set(int index, int value);
   static int Get(int index);

--- a/Source/Core/VideoBackends/OGL/BoundingBox.h
+++ b/Source/Core/VideoBackends/OGL/BoundingBox.h
@@ -15,8 +15,10 @@ public:
   static void SetTargetSizeChanged(int target_width, int target_height);
 
   // When SSBO isn't available, the bounding box is calculated directly from the
-  // stencil buffer. When the stencil buffer is changed, this function needs to
-  // be called to invalidate the cached bounding box data.
+  // stencil buffer.
+  static bool NeedsStencilBuffer();
+  // When the stencil buffer is changed, this function needs to be called to
+  // invalidate the cached bounding box data.
   static void StencilWasUpdated();
 
   static void Set(int index, int value);

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.h
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.h
@@ -70,6 +70,7 @@ public:
   // the EFB to a resolved texture first.
   static GLuint GetEFBColorTexture(const EFBRectangle& sourceRc);
   static GLuint GetEFBDepthTexture(const EFBRectangle& sourceRc);
+  static void ResolveEFBStencilTexture();
 
   static GLuint GetEFBFramebuffer(unsigned int layer = 0)
   {
@@ -77,7 +78,7 @@ public:
   }
   static GLuint GetXFBFramebuffer() { return m_xfbFramebuffer; }
   // Resolved framebuffer is only used in MSAA mode.
-  static GLuint GetResolvedFramebuffer() { return m_resolvedFramebuffer[0]; }
+  static GLuint GetResolvedFramebuffer();
   static void SetFramebuffer(GLuint fb);
   static void FramebufferTexture(GLenum target, GLenum attachment, GLenum textarget, GLuint texture,
                                  GLint level);

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.h
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.h
@@ -63,7 +63,8 @@ struct XFBSource : public XFBSourceBase
 class FramebufferManager : public FramebufferManagerBase
 {
 public:
-  FramebufferManager(int targetWidth, int targetHeight, int msaaSamples);
+  FramebufferManager(int targetWidth, int targetHeight, int msaaSamples,
+                     bool enable_stencil_buffer);
   ~FramebufferManager();
 
   // To get the EFB in texture form, these functions may have to transfer
@@ -101,11 +102,13 @@ public:
   static void ReinterpretPixelData(unsigned int convtype);
 
   static void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points);
+  static bool HasStencilBuffer();
 
 private:
   GLuint CreateTexture(GLenum texture_type, GLenum internal_format, GLenum pixel_format,
                        GLenum data_type);
-  void BindLayeredTexture(GLuint texture, const std::vector<GLuint>& framebuffers, GLenum attachment, GLenum texture_type);
+  void BindLayeredTexture(GLuint texture, const std::vector<GLuint>& framebuffers,
+                          GLenum attachment, GLenum texture_type);
   std::unique_ptr<XFBSourceBase> CreateXFBSource(unsigned int target_width,
                                                  unsigned int target_height,
                                                  unsigned int layers) override;
@@ -125,6 +128,8 @@ private:
   static GLuint m_efbDepth;
   static GLuint
       m_efbColorSwap;  // will be hot swapped with m_efbColor when reinterpreting EFB pixel formats
+
+  static bool m_enable_stencil_buffer;
 
   // Only used in MSAA mode, TODO: try to avoid them
   static std::vector<GLuint> m_resolvedFramebuffer;

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.h
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.h
@@ -104,6 +104,7 @@ public:
 private:
   GLuint CreateTexture(GLenum texture_type, GLenum internal_format, GLenum pixel_format,
                        GLenum data_type);
+  void BindLayeredTexture(GLuint texture, const std::vector<GLuint>& framebuffers, GLenum attachment, GLenum texture_type);
   std::unique_ptr<XFBSourceBase> CreateXFBSource(unsigned int target_width,
                                                  unsigned int target_height,
                                                  unsigned int layers) override;

--- a/Source/Core/VideoBackends/OGL/FramebufferManager.h
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.h
@@ -102,6 +102,8 @@ public:
   static void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points);
 
 private:
+  GLuint CreateTexture(GLenum texture_type, GLenum internal_format, GLenum pixel_format,
+                       GLenum data_type);
   std::unique_ptr<XFBSourceBase> CreateXFBSource(unsigned int target_width,
                                                  unsigned int target_height,
                                                  unsigned int layers) override;

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -618,7 +618,7 @@ void ProgramShaderCache::CreateHeader()
           "#define SAMPLER_BINDING(x)\n",
       // Input/output blocks are matched by name during program linking
       "#define VARYING_LOCATION(x)\n",
-      !is_glsles && g_ActiveConfig.backend_info.bSupportsBBox ?
+      !is_glsles && g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics ?
           "#extension GL_ARB_shader_storage_buffer_object : enable" :
           "",
       v < GLSL_400 && g_ActiveConfig.backend_info.bSupportsGSInstancing ?

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -411,7 +411,8 @@ Renderer::Renderer()
   g_Config.backend_info.bSupportsPrimitiveRestart =
       !DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVE_RESTART) &&
       ((GLExtensions::Version() >= 310) || GLExtensions::Supports("GL_NV_primitive_restart"));
-  g_Config.backend_info.bSupportsBBox = g_Config.backend_info.bSupportsFragmentStoresAndAtomics =
+  g_Config.backend_info.bSupportsBBox = true;
+  g_Config.backend_info.bSupportsFragmentStoresAndAtomics =
       GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
   g_Config.backend_info.bSupportsGSInstancing = GLExtensions::Supports("GL_ARB_gpu_shader5");
   g_Config.backend_info.bSupportsSSAA = GLExtensions::Supports("GL_ARB_gpu_shader5") &&
@@ -497,7 +498,6 @@ Renderer::Renderer()
       g_Config.backend_info.bSupportsGSInstancing =
           g_Config.backend_info.bSupportsGeometryShaders && g_ogl_config.SupportedESPointSize > 0;
       g_Config.backend_info.bSupportsSSAA = g_ogl_config.bSupportsAEP;
-      g_Config.backend_info.bSupportsBBox = true;
       g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;
       g_ogl_config.bSupportsMSAA = true;
       g_ogl_config.bSupports2DTextureStorage = true;
@@ -519,7 +519,6 @@ Renderer::Renderer()
       g_Config.backend_info.bSupportsGSInstancing = g_ogl_config.SupportedESPointSize > 0;
       g_Config.backend_info.bSupportsPaletteConversion = true;
       g_Config.backend_info.bSupportsSSAA = true;
-      g_Config.backend_info.bSupportsBBox = true;
       g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;
       g_ogl_config.bSupportsCopySubImage = true;
       g_ogl_config.bSupportsGLBaseVertex = true;
@@ -657,10 +656,13 @@ Renderer::Renderer()
   // options while running
   g_Config.bRunning = true;
 
-  glStencilFunc(GL_ALWAYS, 0, 0);
-  glBlendFunc(GL_ONE, GL_ONE);
+  // The stencil is used for bounding box emulation when SSBOs are not available
+  glDisable(GL_STENCIL_TEST);
+  glStencilFunc(GL_ALWAYS, 1, 0xFF);
+  glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
-  glViewport(0, 0, GetTargetWidth(), GetTargetHeight());  // Reset The Current Viewport
+  // Reset The Current Viewport
+  glViewport(0, 0, GetTargetWidth(), GetTargetHeight());
   if (g_ActiveConfig.backend_info.bSupportsClipControl)
     glClipControl(GL_LOWER_LEFT, GL_ZERO_TO_ONE);
 
@@ -677,10 +679,9 @@ Renderer::Renderer()
 
   glPixelStorei(GL_UNPACK_ALIGNMENT, 4);  // 4-byte pixel alignment
 
-  glDisable(GL_STENCIL_TEST);
   glEnable(GL_SCISSOR_TEST);
-
   glScissor(0, 0, GetTargetWidth(), GetTargetHeight());
+  glBlendFunc(GL_ONE, GL_ONE);
   glBlendColor(0, 0, 0, 0.5f);
   glClearDepthf(1.0f);
 
@@ -1364,6 +1365,7 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
       g_framebuffer_manager.reset();
       g_framebuffer_manager =
           std::make_unique<FramebufferManager>(m_target_width, m_target_height, s_MSAASamples);
+      BoundingBox::SetTargetSizeChanged(m_target_width, m_target_height);
     }
   }
 

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -411,7 +411,7 @@ Renderer::Renderer()
   g_Config.backend_info.bSupportsPrimitiveRestart =
       !DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVE_RESTART) &&
       ((GLExtensions::Version() >= 310) || GLExtensions::Supports("GL_NV_primitive_restart"));
-  g_Config.backend_info.bSupportsBBox =
+  g_Config.backend_info.bSupportsBBox = g_Config.backend_info.bSupportsFragmentStoresAndAtomics =
       GLExtensions::Supports("GL_ARB_shader_storage_buffer_object");
   g_Config.backend_info.bSupportsGSInstancing = GLExtensions::Supports("GL_ARB_gpu_shader5");
   g_Config.backend_info.bSupportsSSAA = GLExtensions::Supports("GL_ARB_gpu_shader5") &&
@@ -498,6 +498,7 @@ Renderer::Renderer()
           g_Config.backend_info.bSupportsGeometryShaders && g_ogl_config.SupportedESPointSize > 0;
       g_Config.backend_info.bSupportsSSAA = g_ogl_config.bSupportsAEP;
       g_Config.backend_info.bSupportsBBox = true;
+      g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;
       g_ogl_config.bSupportsMSAA = true;
       g_ogl_config.bSupports2DTextureStorage = true;
       if (g_ActiveConfig.iStereoMode > 0 && g_ActiveConfig.iMultisamples > 1 &&
@@ -519,6 +520,7 @@ Renderer::Renderer()
       g_Config.backend_info.bSupportsPaletteConversion = true;
       g_Config.backend_info.bSupportsSSAA = true;
       g_Config.backend_info.bSupportsBBox = true;
+      g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;
       g_ogl_config.bSupportsCopySubImage = true;
       g_ogl_config.bSupportsGLBaseVertex = true;
       g_ogl_config.bSupportsDebug = true;

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -14,9 +14,11 @@
 #include "Common/GL/GLExtensions/GLExtensions.h"
 #include "Common/StringUtil.h"
 
+#include "VideoBackends/OGL/BoundingBox.h"
 #include "VideoBackends/OGL/ProgramShaderCache.h"
 #include "VideoBackends/OGL/Render.h"
 #include "VideoBackends/OGL/StreamBuffer.h"
+#include "VideoCommon/BoundingBox.h"
 
 #include "VideoCommon/IndexGenerator.h"
 #include "VideoCommon/Statistics.h"
@@ -156,7 +158,18 @@ void VertexManager::vFlush()
   // setup the pointers
   nativeVertexFmt->SetupVertexPointers();
 
+  if (!g_Config.backend_info.bSupportsFragmentStoresAndAtomics && ::BoundingBox::active)
+  {
+    glEnable(GL_STENCIL_TEST);
+  }
+
   Draw(stride);
+
+  if (!g_Config.backend_info.bSupportsFragmentStoresAndAtomics && ::BoundingBox::active)
+  {
+    OGL::BoundingBox::StencilWasUpdated();
+    glDisable(GL_STENCIL_TEST);
+  }
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
   if (g_ActiveConfig.iLog & CONF_SAVESHADERS)
@@ -177,7 +190,6 @@ void VertexManager::vFlush()
   }
 #endif
   g_Config.iSaveTargetId++;
-
   ClearEFBCache();
 }
 

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -158,14 +158,14 @@ void VertexManager::vFlush()
   // setup the pointers
   nativeVertexFmt->SetupVertexPointers();
 
-  if (!g_Config.backend_info.bSupportsFragmentStoresAndAtomics && ::BoundingBox::active)
+  if (::BoundingBox::active && !g_Config.BBoxUseFragmentShaderImplementation())
   {
     glEnable(GL_STENCIL_TEST);
   }
 
   Draw(stride);
 
-  if (!g_Config.backend_info.bSupportsFragmentStoresAndAtomics && ::BoundingBox::active)
+  if (::BoundingBox::active && !g_Config.BBoxUseFragmentShaderImplementation())
   {
     OGL::BoundingBox::StencilWasUpdated();
     glDisable(GL_STENCIL_TEST);

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -212,7 +212,7 @@ void VideoBackend::Video_Prepare()
   g_sampler_cache = std::make_unique<SamplerCache>();
   static_cast<Renderer*>(g_renderer.get())->Init();
   TextureConverter::Init();
-  BoundingBox::Init();
+  BoundingBox::Init(g_renderer->GetTargetWidth(), g_renderer->GetTargetHeight());
 }
 
 void VideoBackend::Shutdown()

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -240,6 +240,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsGeometryShaders = false;              // Dependent on features.
   config->backend_info.bSupportsGSInstancing = false;                 // Dependent on features.
   config->backend_info.bSupportsBBox = false;                         // Dependent on features.
+  config->backend_info.bSupportsFragmentStoresAndAtomics = false;     // Dependent on features.
   config->backend_info.bSupportsSSAA = false;                         // Dependent on features.
   config->backend_info.bSupportsDepthClamp = false;                   // Dependent on features.
   config->backend_info.bSupportsReversedDepthRange = false;  // No support yet due to driver bugs.
@@ -264,7 +265,8 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   config->backend_info.bSupportsDualSourceBlend = (features.dualSrcBlend == VK_TRUE);
   config->backend_info.bSupportsGeometryShaders = (features.geometryShader == VK_TRUE);
   config->backend_info.bSupportsGSInstancing = (features.geometryShader == VK_TRUE);
-  config->backend_info.bSupportsBBox = (features.fragmentStoresAndAtomics == VK_TRUE);
+  config->backend_info.bSupportsBBox = config->backend_info.bSupportsFragmentStoresAndAtomics =
+      (features.fragmentStoresAndAtomics == VK_TRUE);
   config->backend_info.bSupportsSSAA = (features.sampleRateShading == VK_TRUE);
 
   // Disable geometry shader when shaderTessellationAndGeometryPointSize is not supported.

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -172,6 +172,7 @@ PixelShaderUid GetPixelShaderUid()
   uid_data->genMode_numtexgens = bpmem.genMode.numtexgens;
   uid_data->per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
   uid_data->bounding_box = g_ActiveConfig.backend_info.bSupportsBBox &&
+                           g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics &&
                            g_ActiveConfig.bBBoxEnable && BoundingBox::active;
   uid_data->rgba6_format =
       bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24 && !g_ActiveConfig.bForceTrueColor;

--- a/Source/Core/VideoCommon/PixelShaderGen.cpp
+++ b/Source/Core/VideoCommon/PixelShaderGen.cpp
@@ -171,8 +171,7 @@ PixelShaderUid GetPixelShaderUid()
   uid_data->genMode_numtevstages = bpmem.genMode.numtevstages;
   uid_data->genMode_numtexgens = bpmem.genMode.numtexgens;
   uid_data->per_pixel_lighting = g_ActiveConfig.bEnablePixelLighting;
-  uid_data->bounding_box = g_ActiveConfig.backend_info.bSupportsBBox &&
-                           g_ActiveConfig.backend_info.bSupportsFragmentStoresAndAtomics &&
+  uid_data->bounding_box = g_ActiveConfig.BBoxUseFragmentShaderImplementation() &&
                            g_ActiveConfig.bBBoxEnable && BoundingBox::active;
   uid_data->rgba6_format =
       bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24 && !g_ActiveConfig.bForceTrueColor;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -119,6 +119,7 @@ void VideoConfig::Load(const std::string& ini_file)
   IniFile::Section* hacks = iniFile.GetOrCreateSection("Hacks");
   hacks->Get("EFBAccessEnable", &bEFBAccessEnable, true);
   hacks->Get("BBoxEnable", &bBBoxEnable, false);
+  hacks->Get("BBoxPreferStencilImplementation", &bBBoxPreferStencilImplementation, false);
   hacks->Get("ForceProgressive", &bForceProgressive, true);
   hacks->Get("EFBToTextureEnable", &bSkipEFBCopyToRam, true);
   hacks->Get("EFBScaledCopy", &bCopyEFBScaled, true);
@@ -342,6 +343,7 @@ void VideoConfig::Save(const std::string& ini_file)
   IniFile::Section* hacks = iniFile.GetOrCreateSection("Hacks");
   hacks->Set("EFBAccessEnable", bEFBAccessEnable);
   hacks->Set("BBoxEnable", bBBoxEnable);
+  hacks->Set("BBoxPreferStencilImplementation", bBBoxPreferStencilImplementation);
   hacks->Set("ForceProgressive", bForceProgressive);
   hacks->Set("EFBToTextureEnable", bSkipEFBCopyToRam);
   hacks->Set("EFBScaledCopy", bCopyEFBScaled);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -114,6 +114,7 @@ struct VideoConfig final
   bool bEFBAccessEnable;
   bool bPerfQueriesEnable;
   bool bBBoxEnable;
+  bool bBBoxPreferStencilImplementation;  // OpenGL-only, to see how slow it is compared to SSBOs
   bool bForceProgressive;
 
   bool bEFBEmulateFormatChanges;
@@ -202,6 +203,12 @@ struct VideoConfig final
   bool ExclusiveFullscreenEnabled() const
   {
     return backend_info.bSupportsExclusiveFullscreen && !bBorderlessFullscreen;
+  }
+  bool BBoxUseFragmentShaderImplementation() const
+  {
+    if (backend_info.api_type == APIType::OpenGL && bBBoxPreferStencilImplementation)
+      return false;
+    return backend_info.bSupportsBBox && backend_info.bSupportsFragmentStoresAndAtomics;
   }
 };
 

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -189,6 +189,7 @@ struct VideoConfig final
     bool bSupportsPaletteConversion;
     bool bSupportsClipControl;  // Needed by VertexShaderGen, so must stay in VideoCommon
     bool bSupportsSSAA;
+    bool bSupportsFragmentStoresAndAtomics;  // a.k.a. OpenGL SSBOs a.k.a. Direct3D UAVs
     bool bSupportsDepthClamp;  // Needed by VertexShaderGen, so must stay in VideoCommon
     bool bSupportsReversedDepthRange;
     bool bSupportsMultithreading;


### PR DESCRIPTION
![out](https://cloud.githubusercontent.com/assets/594093/23593169/1bb61898-01c0-11e7-9898-29db0ab91e65.gif)

This commit should have zero performance effect if SSBOs are supported.

If they aren't (e.g. on all Macs), this commit alters FramebufferManager
to attach a new stencil buffer and VertexManager to draw to it when
bounding box is active. `BBoxRead` gets the pixel data from the buffer
and dumbly loops through it to find the bounding box.

This patch can run Paper Mario: The Thousand-Year Door at almost full
speed (50–60 FPS) without Dual-Core enabled for all common bounding
box-using actions I tested (going through pipes, Plane Mode, Paper
Mode, Prof. Frankly's gate, combat, walking around the overworld, etc.)
on my computer (macOS 10.12.3, 2.8 GHz Intel Core i7, 16 GB 1600 MHz
DDR3, and Intel Iris 1536 MB).

A few more demanding scenes (e.g. the self-building bridge on the way
to Petalburg) slow to ~15% of their speed without this patch (though
they don't run quite at full speed even on master). The slowdown is
caused almost solely by `glReadPixels` in `OGL::BoundingBox::Get`.

Other implementation ideas:

- Use a stencil buffer that's separate from the depth buffer. This would
  require ARB_texture_stencil8 / OpenGL 4.4, which isn't available on
  macOS.

- Use `glGetTexImage` instead of `glReadPixels`. This is ~5 FPS slower
  on my computer, presumably because it has to transfer the entire
  combined depth-stencil buffer instead of only the stencil data.
  Getting only stencil data from `glGetTexImage` requires
  ARB_texture_stencil8 / OpenGL 4.4, which (again) is not available on
  macOS.

- Don't use a PBO, and use `glReadPixels` synchronously. This has no
  visible performance effect on my computer, and is theoretically
  slower.
