### PR TITLE
Fix a vector assertion introduced by PR #5002

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -258,7 +258,7 @@ std::vector<u8> TicketReader::GetRawTicketView(u32 ticket_num) const
   std::memcpy(view.data(), &view_id, sizeof(view_id));
 
   // Copy the rest of the ticket view structure from the ticket.
-  view.insert(view.end(), view_start, view_start + sizeof(TicketView) - sizeof(view_id));
+  view.insert(view.end(), view_start, view_start + (sizeof(TicketView) - sizeof(view_id)));
   _assert_(view.size() == sizeof(TicketView));
 
   return view;


### PR DESCRIPTION
The PR #5002 introduced a vector assertion where the iterator goes beyond its ```end()```.

Ready to be reviewed and merged.