### PR TITLE
Memmap/PowerPC: Remove unnecessary const on function declaration parameters

### DIFF
--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -71,20 +71,20 @@ void Clear();
 // Routines to access physically addressed memory, designed for use by
 // emulated hardware outside the CPU. Use "Device_" prefix.
 std::string GetString(u32 em_address, size_t size = 0);
-u8* GetPointer(const u32 address);
+u8* GetPointer(u32 address);
 void CopyFromEmu(void* data, u32 address, size_t size);
 void CopyToEmu(u32 address, const void* data, size_t size);
 void Memset(u32 address, u8 value, size_t size);
-u8 Read_U8(const u32 address);
-u16 Read_U16(const u32 address);
-u32 Read_U32(const u32 address);
-u64 Read_U64(const u32 address);
-void Write_U8(const u8 var, const u32 address);
-void Write_U16(const u16 var, const u32 address);
-void Write_U32(const u32 var, const u32 address);
-void Write_U64(const u64 var, const u32 address);
-void Write_U32_Swap(const u32 var, const u32 address);
-void Write_U64_Swap(const u64 var, const u32 address);
+u8 Read_U8(u32 address);
+u16 Read_U16(u32 address);
+u32 Read_U32(u32 address);
+u64 Read_U64(u32 address);
+void Write_U8(u8 var, u32 address);
+void Write_U16(u16 var, u32 address);
+void Write_U32(u32 var, u32 address);
+void Write_U64(u64 var, u32 address);
+void Write_U32_Swap(u32 var, u32 address);
+void Write_U64_Swap(u64 var, u32 address);
 
 // Templated functions for byteswapped copies.
 template <typename T>

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -206,20 +206,20 @@ void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst);
 // Routines for debugger UI, cheats, etc. to access emulated memory from the
 // perspective of the CPU.  Not for use by core emulation routines.
 // Use "Host_" prefix.
-u8 HostRead_U8(const u32 address);
-u16 HostRead_U16(const u32 address);
-u32 HostRead_U32(const u32 address);
-u64 HostRead_U64(const u32 address);
-u32 HostRead_Instruction(const u32 address);
+u8 HostRead_U8(u32 address);
+u16 HostRead_U16(u32 address);
+u32 HostRead_U32(u32 address);
+u64 HostRead_U64(u32 address);
+u32 HostRead_Instruction(u32 address);
 
-void HostWrite_U8(const u8 var, const u32 address);
-void HostWrite_U16(const u16 var, const u32 address);
-void HostWrite_U32(const u32 var, const u32 address);
-void HostWrite_U64(const u64 var, const u32 address);
+void HostWrite_U8(u8 var, u32 address);
+void HostWrite_U16(u16 var, u32 address);
+void HostWrite_U32(u32 var, u32 address);
+void HostWrite_U64(u64 var, u32 address);
 
 // Returns whether a read or write to the given address will resolve to a RAM
 // access given the current CPU state.
-bool HostIsRAMAddress(const u32 address);
+bool HostIsRAMAddress(u32 address);
 // Same as HostIsRAMAddress, but uses IBAT instead of DBAT.
 bool HostIsInstructionRAMAddress(u32 address);
 
@@ -228,7 +228,7 @@ std::string HostGetString(u32 em_address, size_t size = 0);
 // Routines for the CPU core to access memory.
 
 // Used by interpreter to read instructions, uses iCache
-u32 Read_Opcode(const u32 address);
+u32 Read_Opcode(u32 address);
 struct TryReadInstResult
 {
   bool valid;
@@ -236,36 +236,36 @@ struct TryReadInstResult
   u32 hex;
   u32 physical_address;
 };
-TryReadInstResult TryReadInstruction(const u32 address);
+TryReadInstResult TryReadInstruction(u32 address);
 
-u8 Read_U8(const u32 address);
-u16 Read_U16(const u32 address);
-u32 Read_U32(const u32 address);
-u64 Read_U64(const u32 address);
+u8 Read_U8(u32 address);
+u16 Read_U16(u32 address);
+u32 Read_U32(u32 address);
+u64 Read_U64(u32 address);
 
 // Useful helper functions, used by ARM JIT
-float Read_F32(const u32 address);
-double Read_F64(const u32 address);
+float Read_F32(u32 address);
+double Read_F64(u32 address);
 
 // used by JIT. Return zero-extended 32bit values
-u32 Read_U8_ZX(const u32 address);
-u32 Read_U16_ZX(const u32 address);
+u32 Read_U8_ZX(u32 address);
+u32 Read_U16_ZX(u32 address);
 
-void Write_U8(const u8 var, const u32 address);
-void Write_U16(const u16 var, const u32 address);
-void Write_U32(const u32 var, const u32 address);
-void Write_U64(const u64 var, const u32 address);
+void Write_U8(u8 var, u32 address);
+void Write_U16(u16 var, u32 address);
+void Write_U32(u32 var, u32 address);
+void Write_U64(u64 var, u32 address);
 
-void Write_U16_Swap(const u16 var, const u32 address);
-void Write_U32_Swap(const u32 var, const u32 address);
-void Write_U64_Swap(const u64 var, const u32 address);
+void Write_U16_Swap(u16 var, u32 address);
+void Write_U32_Swap(u32 var, u32 address);
+void Write_U64_Swap(u64 var, u32 address);
 
 // Useful helper functions, used by ARM JIT
-void Write_F64(const double var, const u32 address);
+void Write_F64(double var, u32 address);
 
-void DMA_LCToMemory(const u32 memAddr, const u32 cacheAddr, const u32 numBlocks);
-void DMA_MemoryToLC(const u32 cacheAddr, const u32 memAddr, const u32 numBlocks);
-void ClearCacheLine(const u32 address);  // Zeroes 32 bytes; address should be 32-byte-aligned
+void DMA_LCToMemory(u32 memAddr, u32 cacheAddr, u32 numBlocks);
+void DMA_MemoryToLC(u32 cacheAddr, u32 memAddr, u32 numBlocks);
+void ClearCacheLine(u32 address);  // Zeroes 32 bytes; address should be 32-byte-aligned
 
 // TLB functions
 void SDRUpdated();
@@ -276,7 +276,7 @@ void IBATUpdated();
 // Result changes based on the BAT registers and MSR.DR.  Returns whether
 // it's safe to optimize a read or write to this address to an unguarded
 // memory access.  Does not consider page tables.
-bool IsOptimizableRAMAddress(const u32 address);
+bool IsOptimizableRAMAddress(u32 address);
 u32 IsOptimizableMMIOAccess(u32 address, u32 accessSize);
 bool IsOptimizableGatherPipeWrite(u32 address);
 


### PR DESCRIPTION
Both the following function declarations are equivalent:

```cpp
void SomeFunction(int value);
void SomeFunction(const int value);
```

Const when used on direct value types (or rhs of a pointer like `u8* const`), only applies within the definition of a function, and not its declaration.

e.g.

```cpp
// Header
void CalculateSomething(int lhs, int rhs);

// Definition
void CalculateSomething(const int lhs, const int rhs)
{
  // lhs and rhs can't accidentally be modified
}
```

This just cuts down a bit on line noise.