### PR TITLE
GeneralConfigPane: Fix analytics sizer's right side being misaligned by 5 units

### DIFF
--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -126,7 +126,7 @@ void GeneralConfigPane::InitializeGUI()
   main_sizer->AddSpacer(space5);
   main_sizer->Add(basic_settings_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   main_sizer->AddSpacer(space5);
-  main_sizer->Add(analytics_sizer, 0, wxEXPAND | wxLEFT | wxLEFT, space5);
+  main_sizer->Add(analytics_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   main_sizer->AddSpacer(space5);
   main_sizer->Add(advanced_settings_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   main_sizer->AddSpacer(space5);


### PR DESCRIPTION
Fixes
![](https://i.imgur.com/i2tFI5k.png)

Truly the UI change of the year.