### PR TITLE
GCAdapter_Android: Fix an array bounds overrun in Read()

### DIFF
--- a/Source/Core/InputCommon/GCAdapter_Android.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Android.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <array>
 #include <jni.h>
 #include <mutex>
 
@@ -39,7 +40,7 @@ static u8 s_controller_rumble[4];
 
 // Input handling
 static std::mutex s_read_mutex;
-static u8 s_controller_payload[37];
+static std::array<u8, 37> s_controller_payload;
 static std::atomic<int> s_controller_payload_size{0};
 
 // Output handling
@@ -158,7 +159,7 @@ static void Read()
       jbyte* java_data = env->GetByteArrayElements(*java_controller_payload, nullptr);
       {
         std::lock_guard<std::mutex> lk(s_read_mutex);
-        memcpy(s_controller_payload, java_data, 0x37);
+        std::copy(java_data, java_data + s_controller_payload.size(), s_controller_payload.begin());
         s_controller_payload_size.store(read_size);
       }
       env->ReleaseByteArrayElements(*java_controller_payload, java_data, 0);
@@ -268,17 +269,16 @@ GCPadStatus Input(int chan)
     return {};
 
   int payload_size = 0;
-  u8 controller_payload_copy[37];
+  std::array<u8, 37> controller_payload_copy;
 
   {
     std::lock_guard<std::mutex> lk(s_read_mutex);
-    std::copy(std::begin(s_controller_payload), std::end(s_controller_payload),
-              std::begin(controller_payload_copy));
+    controller_payload_copy = s_controller_payload;
     payload_size = s_controller_payload_size.load();
   }
 
   GCPadStatus pad = {};
-  if (payload_size != sizeof(controller_payload_copy))
+  if (payload_size != controller_payload_copy.size())
   {
     ERROR_LOG(SERIALINTERFACE, "error reading payload (size: %d, type: %02x)", payload_size,
               controller_payload_copy[0]);


### PR DESCRIPTION
`s_controller_payload` is 37 bytes long but `Read()` would copy 0x37 (a.k.a 55) bytes, overrunning the array.