### PR TITLE
ConfigManager: Remove m_strName

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -783,7 +783,6 @@ void SConfig::LoadDefaults()
   bJITSystemRegistersOff = false;
   bJITBranchOff = false;
 
-  m_strName = "NONE";
   m_strGameID = "00000000";
   m_title_id = 0;
   m_revision = 0;
@@ -871,7 +870,6 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
                       m_strFilename.c_str());
         return false;
       }
-      m_strName = pVolume->GetInternalName();
       m_strGameID = pVolume->GetGameID();
       pVolume->GetTitleID(&m_title_id);
       m_revision = pVolume->GetRevision();
@@ -938,7 +936,6 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
 
       if (pVolume)
       {
-        m_strName = pVolume->GetInternalName();
         m_strGameID = pVolume->GetGameID();
         pVolume->GetTitleID(&m_title_id);
       }
@@ -946,7 +943,6 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       {
         // null pVolume means that we are loading from nand folder (Most Likely Wii Menu)
         // if this is the second boot we would be using the Name and id of the last title
-        m_strName.clear();
         m_strGameID.clear();
         m_title_id = 0;
       }
@@ -956,10 +952,6 @@ bool SConfig::AutoSetup(EBootBS2 _BootBS2)
       // (specifically sysmenu could potentially apply to other things)
       std::string titleidstr = StringFromFormat("%016" PRIx64, m_title_id);
 
-      if (m_strName.empty())
-      {
-        m_strName = titleidstr;
-      }
       if (m_strGameID.empty())
       {
         m_strGameID = titleidstr;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -211,7 +211,6 @@ struct SConfig : NonCopyable
   std::string m_strApploader;
   std::string m_strGameID;
   u64 m_title_id;
-  std::string m_strName;
   std::string m_strWiiSDCardPath;
   u16 m_revision;
 

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -145,8 +145,6 @@ void TitleContext::Update(const IOS::ES::TMDReader& tmd_, const IOS::ES::TicketR
 
 void TitleContext::UpdateRunningGame() const
 {
-  // This one does not always make sense for Wii titles, so let's reset it back to a sane value.
-  SConfig::GetInstance().m_strName = "";
   if (IOS::ES::IsTitleType(tmd.GetTitleId(), IOS::ES::TitleType::Game) ||
       IOS::ES::IsTitleType(tmd.GetTitleId(), IOS::ES::TitleType::GameWithChannel))
   {

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -126,7 +126,6 @@ static void UpdateRunningGame()
   DVDThread::WaitUntilIdle();
   const DiscIO::IVolume& volume = DVDInterface::GetVolume();
   SConfig::GetInstance().m_BootType = SConfig::BOOT_MIOS;
-  SConfig::GetInstance().m_strName = volume.GetInternalName();
   SConfig::GetInstance().m_strGameID = volume.GetGameID();
   SConfig::GetInstance().m_revision = volume.GetRevision();
 
@@ -135,8 +134,7 @@ static void UpdateRunningGame()
   ::HLE::Clear();
   ::HLE::PatchFunctions();
 
-  NOTICE_LOG(IOS, "Running game: %s (%s)", SConfig::GetInstance().m_strName.c_str(),
-             SConfig::GetInstance().m_strGameID.c_str());
+  NOTICE_LOG(IOS, "Running game: %s", SConfig::GetInstance().m_strGameID.c_str());
 }
 
 constexpr u32 ADDRESS_INIT_SEMAPHORE = 0x30f8;

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
@@ -190,7 +190,7 @@ void wxCheatsWindow::UpdateGUI()
 
   // write the ISO name in the title
   if (Core::IsRunning())
-    SetTitle(title + StrToWxStr(": " + m_game_id + " - " + parameters.m_strName));
+    SetTitle(title + StrToWxStr(": " + m_game_id));
   else
     SetTitle(title);
 }


### PR DESCRIPTION
m_strName has limited usefulness, because GetInternalName() can be inaccurate or even completely wrong. It was almost completely unused anyway.