### PR TITLE
Unify the way of setting game ID, title ID, revision

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -415,8 +415,7 @@ void Stop()
 void RestoreConfig()
 {
   SConfig::GetInstance().LoadSettingsFromSysconf();
-  SConfig::GetInstance().m_strGameID = "00000000";
-  SConfig::GetInstance().m_title_id = 0;
+  SConfig::GetInstance().ResetRunningGameMetadata();
   config_cache.RestoreConfig(&SConfig::GetInstance());
 }
 

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -19,6 +19,14 @@ namespace DiscIO
 {
 enum class Language;
 enum class Region;
+class IVolume;
+}
+namespace IOS
+{
+namespace ES
+{
+class TMDReader;
+}
 }
 
 // DSP Backend Types
@@ -209,17 +217,20 @@ struct SConfig : NonCopyable
   std::string m_strDefaultISO;
   std::string m_strDVDRoot;
   std::string m_strApploader;
-  std::string m_strGameID;
-  u64 m_title_id;
   std::string m_strWiiSDCardPath;
-  u16 m_revision;
 
   std::string m_perfDir;
+
+  const std::string& GetGameID() const { return m_game_id; }
+  u64 GetTitleID() const { return m_title_id; }
+  u16 GetRevision() const { return m_revision; }
+  void ResetRunningGameMetadata();
+  void SetRunningGameMetadata(const DiscIO::IVolume& volume);
+  void SetRunningGameMetadata(const IOS::ES::TMDReader& tmd);
 
   void LoadDefaults();
   static const char* GetDirectoryForRegion(DiscIO::Region region);
   bool AutoSetup(EBootBS2 _BootBS2);
-  const std::string& GetGameID() const { return m_strGameID; }
   void CheckMemcardPath(std::string& memcardPath, const std::string& gameRegion, bool isSlotA);
   DiscIO::Language GetCurrentLanguage(bool wii) const;
 
@@ -373,7 +384,12 @@ private:
   void LoadUSBPassthroughSettings(IniFile& ini);
   void LoadSysconfSettings(IniFile& ini);
 
+  void SetRunningGameMetadata(const std::string& game_id, u64 title_id, u16 revision);
   bool SetRegion(DiscIO::Region region, std::string* directory_name);
 
   static SConfig* m_Instance;
+
+  std::string m_game_id;
+  u64 m_title_id;
+  u16 m_revision;
 };

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -156,7 +156,7 @@ void CEXIMemoryCard::SetupGciFolder(u16 sizeMb)
 {
   DiscIO::Region region = SConfig::GetInstance().m_region;
 
-  std::string game_id = SConfig::GetInstance().m_strGameID;
+  const std::string& game_id = SConfig::GetInstance().GetGameID();
   u32 CurrentGameId = 0;
   if (game_id.length() >= 4 && game_id != "00000000" && game_id != TITLEID_SYSMENU_STRING)
     CurrentGameId = BE32((u8*)game_id.c_str());

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -26,6 +26,12 @@ bool IsTitleType(u64 title_id, TitleType title_type)
   return static_cast<u32>(title_id >> 32) == static_cast<u32>(title_type);
 }
 
+bool IsDiscTitle(u64 title_id)
+{
+  return IsTitleType(title_id, TitleType::Game) ||
+         IsTitleType(title_id, TitleType::GameWithChannel);
+}
+
 bool Content::IsShared() const
 {
   return (type & 0x8000) != 0;

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -30,6 +30,7 @@ enum class TitleType : u32
 };
 
 bool IsTitleType(u64 title_id, TitleType title_type);
+bool IsDiscTitle(u64 title_id);
 
 #pragma pack(push, 4)
 struct TMDHeader

--- a/Source/Core/Core/IOS/MIOS.cpp
+++ b/Source/Core/Core/IOS/MIOS.cpp
@@ -12,7 +12,6 @@
 #include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
 #include "Common/Swap.h"
-#include "Core/Boot/Boot.h"
 #include "Core/Boot/ElfReader.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -124,17 +123,8 @@ static void ReinitHardware()
 static void UpdateRunningGame()
 {
   DVDThread::WaitUntilIdle();
-  const DiscIO::IVolume& volume = DVDInterface::GetVolume();
   SConfig::GetInstance().m_BootType = SConfig::BOOT_MIOS;
-  SConfig::GetInstance().m_strGameID = volume.GetGameID();
-  SConfig::GetInstance().m_revision = volume.GetRevision();
-
-  g_symbolDB.Clear();
-  CBoot::LoadMapFromFilename();
-  ::HLE::Clear();
-  ::HLE::PatchFunctions();
-
-  NOTICE_LOG(IOS, "Running game: %s", SConfig::GetInstance().m_strGameID.c_str());
+  SConfig::GetInstance().SetRunningGameMetadata(DVDInterface::GetVolume());
 }
 
 constexpr u32 ADDRESS_INIT_SEMAPHORE = 0x30f8;

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -1477,7 +1477,7 @@ void GetSettings()
   s_bNetPlay = NetPlay::IsNetPlayRunning();
   if (SConfig::GetInstance().bWii)
   {
-    u64 title_id = SConfig::GetInstance().m_title_id;
+    u64 title_id = SConfig::GetInstance().GetTitleID();
     s_bClearSave =
         !File::Exists(Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT) + "banner.bin");
     s_language = SConfig::GetInstance().m_wii_language;

--- a/Source/Core/Core/WiiRoot.cpp
+++ b/Source/Core/Core/WiiRoot.cpp
@@ -27,9 +27,9 @@ static std::string s_temp_wii_root;
 static void InitializeDeterministicWiiSaves()
 {
   std::string save_path =
-      Common::GetTitleDataPath(SConfig::GetInstance().m_title_id, Common::FROM_SESSION_ROOT);
+      Common::GetTitleDataPath(SConfig::GetInstance().GetTitleID(), Common::FROM_SESSION_ROOT);
   std::string user_save_path =
-      Common::GetTitleDataPath(SConfig::GetInstance().m_title_id, Common::FROM_CONFIGURED_ROOT);
+      Common::GetTitleDataPath(SConfig::GetInstance().GetTitleID(), Common::FROM_CONFIGURED_ROOT);
   if (Movie::IsRecordingInput())
   {
     if (NetPlay::IsNetPlayRunning() && !SConfig::GetInstance().bCopyWiiSaveNetplay)
@@ -93,13 +93,13 @@ void ShutdownWiiRoot()
   if (!s_temp_wii_root.empty())
   {
     std::string save_path =
-        Common::GetTitleDataPath(SConfig::GetInstance().m_title_id, Common::FROM_SESSION_ROOT);
+        Common::GetTitleDataPath(SConfig::GetInstance().GetTitleID(), Common::FROM_SESSION_ROOT);
     std::string user_save_path =
-        Common::GetTitleDataPath(SConfig::GetInstance().m_title_id, Common::FROM_CONFIGURED_ROOT);
+        Common::GetTitleDataPath(SConfig::GetInstance().GetTitleID(), Common::FROM_CONFIGURED_ROOT);
     std::string user_backup_path =
         File::GetUserPath(D_BACKUP_IDX) +
-        StringFromFormat("%08x/%08x/", static_cast<u32>(SConfig::GetInstance().m_title_id >> 32),
-                         static_cast<u32>(SConfig::GetInstance().m_title_id));
+        StringFromFormat("%08x/%08x/", static_cast<u32>(SConfig::GetInstance().GetTitleID() >> 32),
+                         static_cast<u32>(SConfig::GetInstance().GetTitleID()));
     if (File::Exists(save_path + "banner.bin") && SConfig::GetInstance().bEnableMemcardSdWriting)
     {
       // Backup the existing save just in case it's still needed.

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -161,7 +161,7 @@ std::string CVolumeWiiCrypted::GetGameID() const
 
   char ID[6];
 
-  if (!Read(0, 6, (u8*)ID, false))
+  if (!Read(0, 6, (u8*)ID, true))
     return std::string();
 
   return DecodeString(ID);
@@ -179,7 +179,7 @@ Region CVolumeWiiCrypted::GetRegion() const
 Country CVolumeWiiCrypted::GetCountry() const
 {
   u8 country_byte;
-  if (!m_pReader->Read(3, 1, &country_byte))
+  if (!ReadSwapped(3, &country_byte, true))
     return Country::COUNTRY_UNKNOWN;
 
   const Region region = GetRegion();
@@ -209,7 +209,7 @@ std::string CVolumeWiiCrypted::GetMakerID() const
 
   char makerID[2];
 
-  if (!Read(0x4, 0x2, (u8*)&makerID, false))
+  if (!Read(0x4, 0x2, (u8*)&makerID, true))
     return std::string();
 
   return DecodeString(makerID);
@@ -221,7 +221,7 @@ u16 CVolumeWiiCrypted::GetRevision() const
     return 0;
 
   u8 revision;
-  if (!m_pReader->Read(7, 1, &revision))
+  if (!ReadSwapped(7, &revision, true))
     return 0;
 
   return revision;
@@ -230,7 +230,7 @@ u16 CVolumeWiiCrypted::GetRevision() const
 std::string CVolumeWiiCrypted::GetInternalName() const
 {
   char name_buffer[0x60];
-  if (m_pReader != nullptr && Read(0x20, 0x60, (u8*)&name_buffer, false))
+  if (m_pReader != nullptr && Read(0x20, 0x60, (u8*)&name_buffer, true))
     return DecodeString(name_buffer);
 
   return "";
@@ -291,7 +291,7 @@ Platform CVolumeWiiCrypted::GetVolumeType() const
 u8 CVolumeWiiCrypted::GetDiscNumber() const
 {
   u8 disc_number;
-  m_pReader->Read(6, 1, &disc_number);
+  ReadSwapped(6, &disc_number, true);
   return disc_number;
 }
 

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
@@ -177,7 +177,7 @@ void wxCheatsWindow::UpdateGUI()
   m_gameini_default = parameters.LoadDefaultGameIni();
   m_gameini_local = parameters.LoadLocalGameIni();
   m_game_id = parameters.GetGameID();
-  m_game_revision = parameters.m_revision;
+  m_game_revision = parameters.GetRevision();
   m_gameini_local_path = File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini";
   Load_ARCodes();
   Load_GeckoCodes();

--- a/Source/Core/DolphinWX/Debugger/DebuggerPanel.cpp
+++ b/Source/Core/DolphinWX/Debugger/DebuggerPanel.cpp
@@ -232,7 +232,7 @@ void GFXDebuggerPanel::OnPauseAtNextFrameButton(wxCommandEvent& event)
 void GFXDebuggerPanel::OnDumpButton(wxCommandEvent& event)
 {
   std::string dump_path =
-      File::GetUserPath(D_DUMP_IDX) + "Debug/" + SConfig::GetInstance().m_strGameID + "/";
+      File::GetUserPath(D_DUMP_IDX) + "Debug/" + SConfig::GetInstance().GetGameID() + "/";
   if (!File::CreateFullPath(dump_path))
     return;
 

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -164,7 +164,7 @@ void GeometryShaderCache::Init()
 
     std::string cache_filename =
         StringFromFormat("%sdx11-%s-gs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                         SConfig::GetInstance().m_strGameID.c_str());
+                         SConfig::GetInstance().GetGameID().c_str());
     GeometryShaderCacheInserter inserter;
     g_gs_disk_cache.OpenAndRead(cache_filename, inserter);
   }

--- a/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/PixelShaderCache.cpp
@@ -504,7 +504,7 @@ void PixelShaderCache::Init()
 
     std::string cache_filename =
         StringFromFormat("%sdx11-%s-ps.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                         SConfig::GetInstance().m_strGameID.c_str());
+                         SConfig::GetInstance().GetGameID().c_str());
     PixelShaderCacheInserter inserter;
     g_ps_disk_cache.OpenAndRead(cache_filename, inserter);
   }

--- a/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexShaderCache.cpp
@@ -165,7 +165,7 @@ void VertexShaderCache::Init()
 
     std::string cache_filename =
         StringFromFormat("%sdx11-%s-vs.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                         SConfig::GetInstance().m_strGameID.c_str());
+                         SConfig::GetInstance().GetGameID().c_str());
     VertexShaderCacheInserter inserter;
     g_vs_disk_cache.OpenAndRead(cache_filename, inserter);
   }

--- a/Source/Core/VideoBackends/D3D12/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DState.cpp
@@ -143,7 +143,7 @@ void StateCache::Init()
 
   std::string cache_filename =
       StringFromFormat("%sdx12-%s-pso.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                       SConfig::GetInstance().m_strGameID.c_str());
+                       SConfig::GetInstance().GetGameID().c_str());
 
   PipelineStateCacheInserter inserter;
   s_pso_disk_cache.OpenAndRead(cache_filename, inserter);

--- a/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/ShaderCache.cpp
@@ -77,7 +77,7 @@ void ShaderCache::Init()
     if (!File::Exists(shader_cache_path))
       File::CreateDir(File::GetUserPath(D_SHADERCACHE_IDX));
 
-    std::string title_game_id = SConfig::GetInstance().m_strGameID.c_str();
+    const std::string& title_game_id = SConfig::GetInstance().GetGameID();
 
     std::string gs_cache_filename =
         StringFromFormat("%sdx11-%s-gs.cache", shader_cache_path.c_str(), title_game_id.c_str());

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -437,7 +437,7 @@ void ProgramShaderCache::Init()
 
       std::string cache_filename =
           StringFromFormat("%sogl-%s-shaders.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                           SConfig::GetInstance().m_strGameID.c_str());
+                           SConfig::GetInstance().GetGameID().c_str());
 
       ProgramShaderCacheInserter inserter;
       g_program_disk_cache.OpenAndRead(cache_filename, inserter);

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -327,7 +327,7 @@ std::pair<VkPipeline, bool> ObjectCache::GetPipelineWithCacheResult(const Pipeli
 std::string ObjectCache::GetDiskCacheFileName(const char* type)
 {
   return StringFromFormat("%svulkan-%s-%s.cache", File::GetUserPath(D_SHADERCACHE_IDX).c_str(),
-                          SConfig::GetInstance().m_strGameID.c_str(), type);
+                          SConfig::GetInstance().GetGameID().c_str(), type);
 }
 
 class PipelineCacheReadCallback : public LinearDiskCacheReader<u32, u8>

--- a/Source/Core/VideoCommon/HiresTextures.cpp
+++ b/Source/Core/VideoCommon/HiresTextures.cpp
@@ -87,7 +87,7 @@ void HiresTexture::Update()
     s_textureCache.clear();
   }
 
-  const std::string& game_id = SConfig::GetInstance().m_strGameID;
+  const std::string& game_id = SConfig::GetInstance().GetGameID();
   const std::string texture_directory = GetTextureDirectory(game_id);
   std::vector<std::string> extensions{
       ".png", ".bmp", ".tga", ".dds",
@@ -226,7 +226,7 @@ std::string HiresTexture::GenBaseName(const u8* texture, size_t texture_size, co
     u64 tlut_hash = tlut_size ? GetHashHiresTexture(tlut, (int)tlut_size,
                                                     g_ActiveConfig.iSafeTextureCache_ColorSamples) :
                                 0;
-    name = StringFromFormat("%s_%08x_%i", SConfig::GetInstance().m_strGameID.c_str(),
+    name = StringFromFormat("%s_%08x_%i", SConfig::GetInstance().GetGameID().c_str(),
                             (u32)(tex_hash ^ tlut_hash), (u16)format);
     if (s_textureMap.find(name) != s_textureMap.end())
     {

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -437,7 +437,7 @@ TextureCacheBase::DoPartialTextureUpdates(TCacheEntryBase* entry_to_update, u8* 
 
 void TextureCacheBase::DumpTexture(TCacheEntryBase* entry, std::string basename, unsigned int level)
 {
-  std::string szDir = File::GetUserPath(D_DUMPTEXTURES_IDX) + SConfig::GetInstance().m_strGameID;
+  std::string szDir = File::GetUserPath(D_DUMPTEXTURES_IDX) + SConfig::GetInstance().GetGameID();
 
   // make sure that the directory exists
   if (!File::Exists(szDir) || !File::IsDirectory(szDir))


### PR DESCRIPTION
The existing code from ConfigManager, ES and MIOS is merged into a new set of functions called SetRunningGameMetadata.