### PR TITLE
RenderBase: Fix a VirtualXFB crash

### DIFF
--- a/Source/Core/VideoCommon/FramebufferManagerBase.cpp
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.cpp
@@ -250,7 +250,7 @@ void FramebufferManagerBase::ReplaceVirtualXFB()
 
 int FramebufferManagerBase::ScaleToVirtualXfbWidth(int x)
 {
-  if (g_ActiveConfig.RealXFBEnabled())
+  if (g_ActiveConfig.RealXFBEnabled() || !g_renderer)
     return x;
 
   return x * static_cast<int>(g_renderer->GetTargetRectangle().GetWidth()) /
@@ -259,7 +259,7 @@ int FramebufferManagerBase::ScaleToVirtualXfbWidth(int x)
 
 int FramebufferManagerBase::ScaleToVirtualXfbHeight(int y)
 {
-  if (g_ActiveConfig.RealXFBEnabled())
+  if (g_ActiveConfig.RealXFBEnabled() || !g_renderer)
     return y;
 
   return y * static_cast<int>(g_renderer->GetTargetRectangle().GetHeight()) /

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -84,6 +84,8 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
   FramebufferManagerBase::SetLastXfbHeight(MAX_XFB_HEIGHT);
 
   UpdateActiveConfig();
+
+  // g_renderer has to be initialized to call CalculateTargetSize()
   CalculateTargetSize();
   UpdateDrawRectangle();
 


### PR DESCRIPTION
Since PR #4999 every backend is crashing when using VirtualXFB in both Release and Debug builds on Windows.

The ```g_renderer``` variable is set with ```std::make_unique<Renderer>();```. The thing is, RendererBase's constructor indirectly dereference ```g_renderer``` by calling ```CalculateTargetSize()``` which is calling ```FramebufferManagerBase::ScaleToVirtualXfbWidth/Height``` and might dereference something that is not initialized.

Not sure if it's the right way to patch it. At least, it prevents it to crash.

Ready to be reviewed and merged.