### PR TITLE
VideoBackends: Fix crashes introduced by #4999

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -1129,11 +1129,6 @@ void Renderer::SetInterlacingMode()
   // TODO
 }
 
-u32 Renderer::GetMaxTextureSize()
-{
-  return DX11::D3D::GetMaxTextureSize();
-}
-
 u16 Renderer::BBoxRead(int index)
 {
   // Here we get the min/max value of the truncated position of the upscaled framebuffer.

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -62,8 +62,6 @@ public:
 
   bool CheckForResize();
 
-  u32 GetMaxTextureSize() override;
-
 private:
   void BlitScreen(TargetRectangle src, TargetRectangle dst, D3DTexture2D* src_texture,
                   u32 src_width, u32 src_height, float Gamma);

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -61,6 +61,7 @@ void VideoBackend::InitBackendInfo()
   }
 
   g_Config.backend_info.api_type = APIType::D3D;
+  g_Config.backend_info.MaxTextureSize = DX11::D3D::GetMaxTextureSize();
   g_Config.backend_info.bSupportsExclusiveFullscreen = true;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;

--- a/Source/Core/VideoBackends/D3D12/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.h
@@ -121,8 +121,6 @@ const std::string PixelShaderVersionString();
 const std::string GeometryShaderVersionString();
 const std::string VertexShaderVersionString();
 
-unsigned int GetMaxTextureSize();
-
 HRESULT SetFullscreenState(bool enable_fullscreen);
 bool GetFullscreenState();
 

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -1159,11 +1159,6 @@ void Renderer::SetInterlacingMode()
   // EXISTINGD3D11TODO
 }
 
-u32 Renderer::GetMaxTextureSize()
-{
-  return DX12::D3D::GetMaxTextureSize();
-}
-
 u16 Renderer::BBoxRead(int index)
 {
   // Here we get the min/max value of the truncated position of the upscaled framebuffer.

--- a/Source/Core/VideoBackends/D3D12/Render.h
+++ b/Source/Core/VideoBackends/D3D12/Render.h
@@ -61,8 +61,6 @@ public:
 
   bool CheckForResize();
 
-  u32 GetMaxTextureSize() override;
-
   static D3D12_BLEND_DESC GetResetBlendDesc();
   static D3D12_DEPTH_STENCIL_DESC GetResetDepthStencilDesc();
   static D3D12_RASTERIZER_DESC GetResetRasterizerDesc();

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -64,6 +64,7 @@ void VideoBackend::InitBackendInfo()
   }
 
   g_Config.backend_info.api_type = APIType::D3D;
+  g_Config.backend_info.MaxTextureSize = D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION;
   g_Config.backend_info.bSupportsExclusiveFullscreen = false;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -24,6 +24,7 @@ namespace Null
 void VideoBackend::InitBackendInfo()
 {
   g_Config.backend_info.api_type = APIType::Nothing;
+  g_Config.backend_info.MaxTextureSize = 16384;
   g_Config.backend_info.bSupportsExclusiveFullscreen = true;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;

--- a/Source/Core/VideoBackends/Null/Render.h
+++ b/Source/Core/VideoBackends/Null/Render.h
@@ -19,7 +19,6 @@ public:
   void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override {}
   u16 BBoxRead(int index) override { return 0; }
   void BBoxWrite(int index, u16 value) override {}
-  u32 GetMaxTextureSize() override { return 16 * 1024; }
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, const EFBRectangle& rc,

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -103,8 +103,6 @@ public:
 
   void ReinterpretPixelData(unsigned int convtype) override;
 
-  u32 GetMaxTextureSize() override;
-
   void ChangeSurface(void* new_surface_handle) override;
 
 private:

--- a/Source/Core/VideoBackends/OGL/VideoBackend.h
+++ b/Source/Core/VideoBackends/OGL/VideoBackend.h
@@ -23,5 +23,9 @@ class VideoBackend : public VideoBackendBase
   void InitBackendInfo() override;
 
   unsigned int PeekMessages() override;
+
+private:
+  bool InitializeGLExtensions();
+  bool FillBackendInfo();
 };
 }

--- a/Source/Core/VideoBackends/Software/SWRenderer.h
+++ b/Source/Core/VideoBackends/Software/SWRenderer.h
@@ -31,7 +31,6 @@ public:
   u16 BBoxRead(int index) override;
   void BBoxWrite(int index, u16 value) override;
 
-  u32 GetMaxTextureSize() override { return 16 * 1024; };
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const EFBRectangle& rc,

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -124,6 +124,7 @@ std::string VideoSoftware::GetDisplayName() const
 void VideoSoftware::InitBackendInfo()
 {
   g_Config.backend_info.api_type = APIType::Nothing;
+  g_Config.backend_info.MaxTextureSize = 16384;
   g_Config.backend_info.bSupports3DVision = false;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsEarlyZ = true;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -41,7 +41,6 @@ public:
   void PokeEFB(EFBAccessType type, const EfbPokeData* points, size_t num_points) override;
   u16 BBoxRead(int index) override;
   void BBoxWrite(int index, u16 value) override;
-  u32 GetMaxTextureSize() override { return 16 * 1024; }
   TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) override;
 
   void SwapImpl(u32 xfb_addr, u32 fb_width, u32 fb_stride, u32 fb_height, const EFBRectangle& rc,

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -257,8 +257,10 @@ void VulkanContext::PopulateBackendInfoAdapters(VideoConfig* config, const GPULi
 }
 
 void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalDevice gpu,
+                                                const VkPhysicalDeviceProperties& properties,
                                                 const VkPhysicalDeviceFeatures& features)
 {
+  config->backend_info.MaxTextureSize = properties.limits.maxImageDimension2D;
   config->backend_info.bSupportsDualSourceBlend = (features.dualSrcBlend == VK_TRUE);
   config->backend_info.bSupportsGeometryShaders = (features.geometryShader == VK_TRUE);
   config->backend_info.bSupportsGSInstancing = (features.geometryShader == VK_TRUE);

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.h
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.h
@@ -35,6 +35,7 @@ public:
   static void PopulateBackendInfo(VideoConfig* config);
   static void PopulateBackendInfoAdapters(VideoConfig* config, const GPUList& gpu_list);
   static void PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalDevice gpu,
+                                          const VkPhysicalDeviceProperties& properties,
                                           const VkPhysicalDeviceFeatures& features);
   static void PopulateBackendInfoMultisampleModes(VideoConfig* config, VkPhysicalDevice gpu,
                                                   const VkPhysicalDeviceProperties& properties);

--- a/Source/Core/VideoBackends/Vulkan/main.cpp
+++ b/Source/Core/VideoBackends/Vulkan/main.cpp
@@ -52,7 +52,7 @@ void VideoBackend::InitBackendInfo()
           vkGetPhysicalDeviceProperties(gpu, &properties);
           VkPhysicalDeviceFeatures features;
           vkGetPhysicalDeviceFeatures(gpu, &features);
-          VulkanContext::PopulateBackendInfoFeatures(&g_Config, gpu, features);
+          VulkanContext::PopulateBackendInfoFeatures(&g_Config, gpu, properties, features);
           VulkanContext::PopulateBackendInfoMultisampleModes(&g_Config, gpu, properties);
         }
       }
@@ -178,6 +178,7 @@ bool VideoBackend::Initialize(void* window_handle)
   // Since VulkanContext maintains a copy of the device features and properties, we can use this
   // to initialize the backend information, so that we don't need to enumerate everything again.
   VulkanContext::PopulateBackendInfoFeatures(&g_Config, g_vulkan_context->GetPhysicalDevice(),
+                                             g_vulkan_context->GetDeviceProperties(),
                                              g_vulkan_context->GetDeviceFeatures());
   VulkanContext::PopulateBackendInfoMultisampleModes(
       &g_Config, g_vulkan_context->GetPhysicalDevice(), g_vulkan_context->GetDeviceProperties());

--- a/Source/Core/VideoCommon/FramebufferManagerBase.cpp
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.cpp
@@ -248,20 +248,18 @@ void FramebufferManagerBase::ReplaceVirtualXFB()
   }
 }
 
-int FramebufferManagerBase::ScaleToVirtualXfbWidth(int x)
+int FramebufferManagerBase::ScaleToVirtualXfbWidth(int x, const TargetRectangle& target_rectangle)
 {
   if (g_ActiveConfig.RealXFBEnabled())
     return x;
 
-  return x * static_cast<int>(g_renderer->GetTargetRectangle().GetWidth()) /
-         static_cast<int>(FramebufferManagerBase::LastXfbWidth());
+  return x * target_rectangle.GetWidth() / s_last_xfb_width;
 }
 
-int FramebufferManagerBase::ScaleToVirtualXfbHeight(int y)
+int FramebufferManagerBase::ScaleToVirtualXfbHeight(int y, const TargetRectangle& target_rectangle)
 {
   if (g_ActiveConfig.RealXFBEnabled())
     return y;
 
-  return y * static_cast<int>(g_renderer->GetTargetRectangle().GetHeight()) /
-         static_cast<int>(FramebufferManagerBase::LastXfbHeight());
+  return y * target_rectangle.GetHeight() / s_last_xfb_height;
 }

--- a/Source/Core/VideoCommon/FramebufferManagerBase.h
+++ b/Source/Core/VideoCommon/FramebufferManagerBase.h
@@ -57,8 +57,8 @@ public:
   static void SetLastXfbHeight(unsigned int height) { s_last_xfb_height = height; }
   static unsigned int LastXfbWidth() { return s_last_xfb_width; }
   static unsigned int LastXfbHeight() { return s_last_xfb_height; }
-  static int ScaleToVirtualXfbWidth(int x);
-  static int ScaleToVirtualXfbHeight(int y);
+  static int ScaleToVirtualXfbWidth(int x, const TargetRectangle& target_rectangle);
+  static int ScaleToVirtualXfbHeight(int y, const TargetRectangle& target_rectangle);
 
   static unsigned int GetEFBLayers() { return m_EFBLayers; }
   virtual std::pair<u32, u32> GetTargetSize() const = 0;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -217,7 +217,7 @@ bool Renderer::CalculateTargetSize()
     m_efb_scale_numeratorX = m_efb_scale_numeratorY = m_last_efb_scale - 3;
     m_efb_scale_denominatorX = m_efb_scale_denominatorY = 1;
 
-    const u32 max_size = GetMaxTextureSize();
+    const u32 max_size = g_ActiveConfig.backend_info.MaxTextureSize;
     if (max_size < EFB_WIDTH * m_efb_scale_numeratorX / m_efb_scale_denominatorX)
     {
       m_efb_scale_numeratorX = m_efb_scale_numeratorY = (max_size / EFB_WIDTH);

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -84,8 +84,8 @@ Renderer::Renderer(int backbuffer_width, int backbuffer_height)
   FramebufferManagerBase::SetLastXfbHeight(MAX_XFB_HEIGHT);
 
   UpdateActiveConfig();
-  CalculateTargetSize();
   UpdateDrawRectangle();
+  CalculateTargetSize();
 
   OSDChoice = 0;
   OSDTime = 0;
@@ -127,7 +127,7 @@ int Renderer::EFBToScaledX(int x)
   switch (g_ActiveConfig.iEFBScale)
   {
   case SCALE_AUTO:  // fractional
-    return FramebufferManagerBase::ScaleToVirtualXfbWidth(x);
+    return FramebufferManagerBase::ScaleToVirtualXfbWidth(x, m_target_rectangle);
 
   default:
     return x * (int)m_efb_scale_numeratorX / (int)m_efb_scale_denominatorX;
@@ -139,7 +139,7 @@ int Renderer::EFBToScaledY(int y)
   switch (g_ActiveConfig.iEFBScale)
   {
   case SCALE_AUTO:  // fractional
-    return FramebufferManagerBase::ScaleToVirtualXfbHeight(y);
+    return FramebufferManagerBase::ScaleToVirtualXfbHeight(y, m_target_rectangle);
 
   default:
     return y * (int)m_efb_scale_numeratorY / (int)m_efb_scale_denominatorY;
@@ -173,8 +173,8 @@ bool Renderer::CalculateTargetSize()
   {
   case SCALE_AUTO:
   case SCALE_AUTO_INTEGRAL:
-    newEFBWidth = FramebufferManagerBase::ScaleToVirtualXfbWidth(EFB_WIDTH);
-    newEFBHeight = FramebufferManagerBase::ScaleToVirtualXfbHeight(EFB_HEIGHT);
+    newEFBWidth = FramebufferManagerBase::ScaleToVirtualXfbWidth(EFB_WIDTH, m_target_rectangle);
+    newEFBHeight = FramebufferManagerBase::ScaleToVirtualXfbHeight(EFB_HEIGHT, m_target_rectangle);
 
     if (m_last_efb_scale == SCALE_AUTO_INTEGRAL)
     {

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -137,9 +137,6 @@ public:
   PEControl::PixelFormat GetPrevPixelFormat() { return m_prev_efb_format; }
   void StorePixelFormat(PEControl::PixelFormat new_format) { m_prev_efb_format = new_format; }
   PostProcessingShaderImplementation* GetPostProcessor() { return m_post_processor.get(); }
-  // Max height/width
-  virtual u32 GetMaxTextureSize() = 0;
-
   // Final surface changing
   // This is called when the surface is resized (WX) or the window changes (Android).
   virtual void ChangeSurface(void* new_surface_handle) {}

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -168,7 +168,7 @@ protected:
   int m_backbuffer_width = 0;
   int m_backbuffer_height = 0;
   int m_last_efb_scale = 0;
-  TargetRectangle m_target_rectangle;
+  TargetRectangle m_target_rectangle = {};
   bool m_xfb_written = false;
 
   FPSCounter m_fps_counter;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -242,7 +242,7 @@ void TextureCacheBase::ScaleTextureCacheEntryTo(TextureCacheBase::TCacheEntryBas
     return;
   }
 
-  u32 max = g_renderer->GetMaxTextureSize();
+  const u32 max = g_ActiveConfig.backend_info.MaxTextureSize;
   if (max < new_width || max < new_height)
   {
     ERROR_LOG(VIDEO, "Texture too big, width = %d, height = %d", new_width, new_height);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -37,6 +37,7 @@ VideoConfig::VideoConfig()
 
   // disable all features by default
   backend_info.api_type = APIType::Nothing;
+  backend_info.MaxTextureSize = 16384;
   backend_info.bSupportsExclusiveFullscreen = false;
   backend_info.bSupportsMultithreading = false;
   backend_info.bSupportsInternalResolutionFrameDumps = false;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -173,6 +173,8 @@ struct VideoConfig final
     // TODO: merge AdapterName and Adapters array
     std::string AdapterName;  // for OpenGL
 
+    u32 MaxTextureSize;
+
     bool bSupportsExclusiveFullscreen;
     bool bSupportsDualSourceBlend;
     bool bSupportsPrimitiveRestart;


### PR DESCRIPTION
Fixes a crash introduced by #4999, thanks to @sepalani for identifying it in #5050.

Other main issue was the crashing when higher internal resolutions were selected. This was a more complicated fix, due to the design of the base classes.

The most straightforward solution (and IMO the cleanest) was to move the max texture size to backend info. However, the initialization here for GL had to be moved to VideoBackend, as the Renderer constructor will not have been executed before the value is required.

IMO, we should move the remaining logic from the GL Renderer constructor here as well, especially the stuff that can cause startup to fail (which currently is not handled at all).