### PR TITLE
IOS/ES: Fix map file loading

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -161,7 +161,7 @@ void TitleContext::UpdateRunningGame() const
     std::memcpy(ascii_game_id, &title_identifier, sizeof(title_identifier));
     std::memcpy(ascii_game_id + sizeof(title_identifier), &group_id, sizeof(group_id));
 
-    SConfig::GetInstance().m_strGameID = ascii_game_id;
+    SConfig::GetInstance().m_strGameID = std::string(ascii_game_id, 6);
   }
   else
   {


### PR DESCRIPTION
PR #4981 introduced a regression where symbol maps couldn't be loaded (under certain circumstances, Dolphin Debug build on Windows 7 for me) due to a missing nul byte at the end of the GameID.

Ready to be reviewed and merged.