### PR TITLE
IOS/ES: Implement ES_GetStoredContents ioctlvs properly

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -157,8 +157,6 @@ private:
   IPCCommandResult AddContentFinish(const IOCtlVRequest& request);
   IPCCommandResult AddTitleFinish(const IOCtlVRequest& request);
   IPCCommandResult ESGetDeviceID(const IOCtlVRequest& request);
-  IPCCommandResult GetTitleContentsCount(const IOCtlVRequest& request);
-  IPCCommandResult GetTitleContents(const IOCtlVRequest& request);
   IPCCommandResult OpenTitleContent(const IOCtlVRequest& request);
   IPCCommandResult OpenContent(const IOCtlVRequest& request);
   IPCCommandResult ReadContent(const IOCtlVRequest& request);
@@ -174,6 +172,14 @@ private:
   IPCCommandResult GetOwnedTitles(const IOCtlVRequest& request);
   IPCCommandResult GetTitleCount(const IOCtlVRequest& request);
   IPCCommandResult GetTitles(const IOCtlVRequest& request);
+
+  IPCCommandResult GetStoredContentsCount(const IOS::ES::TMDReader& tmd,
+                                          const IOCtlVRequest& request);
+  IPCCommandResult GetStoredContents(const IOS::ES::TMDReader& tmd, const IOCtlVRequest& request);
+  IPCCommandResult GetStoredContentsCount(const IOCtlVRequest& request);
+  IPCCommandResult GetStoredContents(const IOCtlVRequest& request);
+  IPCCommandResult GetTMDStoredContentsCount(const IOCtlVRequest& request);
+  IPCCommandResult GetTMDStoredContents(const IOCtlVRequest& request);
 
   IPCCommandResult GetViewCount(const IOCtlVRequest& request);
   IPCCommandResult GetViews(const IOCtlVRequest& request);


### PR DESCRIPTION
* IOS doesn't rely on the number of contents indicated in the TMD. Instead, it checks whether the contents *do* exist on the NAND.

* Implement ES_GetTMDStoredContents (and the count ioctlv).

* Drop a hack in ES_GetStoredContents, which is unnecessary now that we do it properly. (No behaviour change.)

This is one of the changes which are *required* for the Wii Shop channel to work properly.