### PR TITLE
Volume: Use ReadSwapped more

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -47,8 +47,6 @@ bool CVolumeGC::Read(u64 _Offset, u64 _Length, u8* _pBuffer, bool decrypt) const
 std::string CVolumeGC::GetGameID() const
 {
   static const std::string NO_UID("NO_UID");
-  if (m_pReader == nullptr)
-    return NO_UID;
 
   char ID[6];
 
@@ -64,7 +62,7 @@ std::string CVolumeGC::GetGameID() const
 Region CVolumeGC::GetRegion() const
 {
   u8 country_code;
-  if (!m_pReader->Read(3, 1, &country_code))
+  if (!ReadSwapped(3, &country_code, false))
     return Region::UNKNOWN_REGION;
 
   return RegionSwitchGC(country_code);
@@ -73,7 +71,7 @@ Region CVolumeGC::GetRegion() const
 Country CVolumeGC::GetCountry() const
 {
   u8 country_code;
-  if (!m_pReader->Read(3, 1, &country_code))
+  if (!ReadSwapped(3, &country_code, false))
     return Country::COUNTRY_UNKNOWN;
 
   return CountrySwitch(country_code);
@@ -81,9 +79,6 @@ Country CVolumeGC::GetCountry() const
 
 std::string CVolumeGC::GetMakerID() const
 {
-  if (m_pReader == nullptr)
-    return std::string();
-
   char makerID[2];
   if (!Read(0x4, 0x2, (u8*)&makerID))
     return std::string();
@@ -93,11 +88,8 @@ std::string CVolumeGC::GetMakerID() const
 
 u16 CVolumeGC::GetRevision() const
 {
-  if (!m_pReader)
-    return 0;
-
   u8 revision;
-  if (!Read(7, 1, &revision))
+  if (!ReadSwapped(7, &revision, false))
     return 0;
 
   return revision;
@@ -106,7 +98,7 @@ u16 CVolumeGC::GetRevision() const
 std::string CVolumeGC::GetInternalName() const
 {
   char name[0x60];
-  if (m_pReader != nullptr && Read(0x20, 0x60, (u8*)name))
+  if (Read(0x20, 0x60, (u8*)name))
     return DecodeString(name);
 
   return "";
@@ -152,9 +144,6 @@ std::vector<u32> CVolumeGC::GetBanner(int* width, int* height) const
 
 u64 CVolumeGC::GetFSTSize() const
 {
-  if (m_pReader == nullptr)
-    return 0;
-
   u32 size;
   if (!Read(0x428, 0x4, (u8*)&size))
     return 0;
@@ -164,9 +153,6 @@ u64 CVolumeGC::GetFSTSize() const
 
 std::string CVolumeGC::GetApploaderDate() const
 {
-  if (m_pReader == nullptr)
-    return std::string();
-
   char date[16];
   if (!Read(0x2440, 0x10, (u8*)&date))
     return std::string();
@@ -181,24 +167,18 @@ BlobType CVolumeGC::GetBlobType() const
 
 u64 CVolumeGC::GetSize() const
 {
-  if (m_pReader)
-    return m_pReader->GetDataSize();
-  else
-    return 0;
+  return m_pReader ? m_pReader->GetDataSize() : 0;
 }
 
 u64 CVolumeGC::GetRawSize() const
 {
-  if (m_pReader)
-    return m_pReader->GetRawSize();
-  else
-    return 0;
+  return m_pReader ? m_pReader->GetRawSize() : 0;
 }
 
 u8 CVolumeGC::GetDiscNumber() const
 {
   u8 disc_number;
-  Read(6, 1, &disc_number);
+  ReadSwapped(6, &disc_number, false);
   return disc_number;
 }
 

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -112,11 +112,7 @@ std::string CVolumeWAD::GetMakerID() const
 
 bool CVolumeWAD::GetTitleID(u64* buffer) const
 {
-  if (!Read(m_offset + 0x01DC, sizeof(u64), reinterpret_cast<u8*>(buffer)))
-    return false;
-
-  *buffer = Common::swap64(*buffer);
-  return true;
+  return ReadSwapped(m_offset + 0x01DC, buffer, false);
 }
 
 u16 CVolumeWAD::GetRevision() const


### PR DESCRIPTION
Most of the Volume code was written before this convenience function was added. Let's use it more.

Also deleting m_pReader nullptr checks that are unnecessary because of Read (which ReadSwapped calls) already having a nullptr check.