### PR TITLE
D3D11: Fix error on startup with >2.5xIR selected

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -526,9 +526,9 @@ bool BGRATexturesSupported()
 
 // Returns the maximum width/height of a texture. This value only depends upon the feature level in
 // DX11
-unsigned int GetMaxTextureSize()
+u32 GetMaxTextureSize(D3D_FEATURE_LEVEL feature_level)
 {
-  switch (featlevel)
+  switch (feature_level)
   {
   case D3D_FEATURE_LEVEL_11_0:
     return D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;

--- a/Source/Core/VideoBackends/D3D/D3DBase.h
+++ b/Source/Core/VideoBackends/D3D/D3DBase.h
@@ -72,7 +72,7 @@ const char* GeometryShaderVersionString();
 const char* VertexShaderVersionString();
 bool BGRATexturesSupported();
 
-unsigned int GetMaxTextureSize();
+u32 GetMaxTextureSize(D3D_FEATURE_LEVEL feature_level);
 
 HRESULT SetFullscreenState(bool enable_fullscreen);
 bool GetFullscreenState();

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -61,7 +61,7 @@ void VideoBackend::InitBackendInfo()
   }
 
   g_Config.backend_info.api_type = APIType::D3D;
-  g_Config.backend_info.MaxTextureSize = DX11::D3D::GetMaxTextureSize();
+  g_Config.backend_info.MaxTextureSize = D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;
   g_Config.backend_info.bSupportsExclusiveFullscreen = true;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
@@ -104,7 +104,9 @@ void VideoBackend::InitBackendInfo()
         g_Config.backend_info.AAModes.push_back(modes[i].Count);
       }
 
-      bool shader_model_5_supported = (DX11::D3D::GetFeatureLevel(ad) >= D3D_FEATURE_LEVEL_11_0);
+      D3D_FEATURE_LEVEL feature_level = D3D::GetFeatureLevel(ad);
+      bool shader_model_5_supported = feature_level >= D3D_FEATURE_LEVEL_11_0;
+      g_Config.backend_info.MaxTextureSize = D3D::GetMaxTextureSize(feature_level);
 
       // Requires the earlydepthstencil attribute (only available in shader model 5)
       g_Config.backend_info.bSupportsEarlyZ = shader_model_5_supported;


### PR DESCRIPTION
Another regression from #4999.