### PR TITLE
DSP/Jit: Load address of m_cycles_left into register

### DIFF
--- a/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.cpp
@@ -436,7 +436,8 @@ void DSPEmitter::CompileDispatcher()
   m_return_dispatcher = GetCodePtr();
 
   // Decrement cyclesLeft
-  SUB(16, M(&m_cycles_left), R(EAX));
+  MOV(64, R(RCX), ImmPtr(&m_cycles_left));
+  SUB(16, MatR(RCX), R(EAX));
 
   J_CC(CC_A, dispatcherLoop);
 

--- a/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitBranch.cpp
@@ -109,12 +109,13 @@ void DSPEmitter::WriteBlockLink(u16 dest)
     {
       m_gpr.FlushRegs();
       // Check if we have enough cycles to execute the next block
-      MOV(16, R(ECX), M(&m_cycles_left));
+      MOV(64, R(RAX), ImmPtr(&m_cycles_left));
+      MOV(16, R(ECX), MatR(RAX));
       CMP(16, R(ECX), Imm16(m_block_size[m_start_address] + m_block_size[dest]));
       FixupBranch notEnoughCycles = J_CC(CC_BE);
 
       SUB(16, R(ECX), Imm16(m_block_size[m_start_address]));
-      MOV(16, M(&m_cycles_left), R(ECX));
+      MOV(16, MatR(RAX), R(ECX));
       JMP(m_block_links[dest], true);
       SetJumpTarget(notEnoughCycles);
     }


### PR DESCRIPTION
When using the DSP LLE recompiler, the address of m_cycles_left sometimes exceeds the maximal 32-bit offset from RIP.