### PR TITLE
IOS/ES: Fix GetStoredContentsFromTMD

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -758,7 +758,8 @@ static std::vector<IOS::ES::Content> GetStoredContentsFromTMD(const IOS::ES::TMD
                    return path != "unk" && File::Exists(path);
                  }
                  return File::Exists(
-                     Common::GetTitleContentPath(tmd.GetTitleId(), Common::FROM_SESSION_ROOT));
+                     Common::GetTitleContentPath(tmd.GetTitleId(), Common::FROM_SESSION_ROOT) +
+                     StringFromFormat("%08x.app", content.id));
                });
 
   return stored_contents;


### PR DESCRIPTION
We were checking for the wrong files (title content directory instead of checking whether the content files themselves exist)... Whoops!