### PR TITLE
Fix VolumeIsValid being referenced even though it was deleted

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -753,7 +753,7 @@ void SConfig::SetRunningGameMetadata(const IOS::ES::TMDReader& tmd)
   // the disc header instead of the TMD. They can differ.
   // (IOS HLE ES calls us with a TMDReader rather than a volume when launching
   // a disc game, because ES has no reason to be accessing the disc directly.)
-  if (DVDInterface::VolumeIsValid())
+  if (DVDInterface::IsDiscInside())
   {
     DVDThread::WaitUntilIdle();
     const DiscIO::IVolume& volume = DVDInterface::GetVolume();


### PR DESCRIPTION
PR #3582 removed VolumeIsValid, then PR #3582 added a call to VolumeIsValid, then both PRs were merged without either of them being rebased on top of the other.