### PR TITLE
HW/DSP: Remove prefixed underscores from parameter names

### DIFF
--- a/Source/Core/Core/HW/DSP.cpp
+++ b/Source/Core/Core/HW/DSP.cpp
@@ -582,27 +582,25 @@ static void Do_ARAM_DMA()
 // (shuffle2) I still don't believe that this hack is actually needed... :(
 // Maybe the Wii Sports ucode is processed incorrectly?
 // (LM) It just means that DSP reads via '0xffdd' on Wii can end up in EXRAM or main RAM
-u8 ReadARAM(u32 _iAddress)
+u8 ReadARAM(u32 address)
 {
-  // NOTICE_LOG(DSPINTERFACE, "ReadARAM 0x%08x", _iAddress);
   if (s_ARAM.wii_mode)
   {
-    if (_iAddress & 0x10000000)
-      return s_ARAM.ptr[_iAddress & s_ARAM.mask];
+    if (address & 0x10000000)
+      return s_ARAM.ptr[address & s_ARAM.mask];
     else
-      return Memory::Read_U8(_iAddress & Memory::RAM_MASK);
+      return Memory::Read_U8(address & Memory::RAM_MASK);
   }
   else
   {
-    return s_ARAM.ptr[_iAddress & s_ARAM.mask];
+    return s_ARAM.ptr[address & s_ARAM.mask];
   }
 }
 
-void WriteARAM(u8 value, u32 _uAddress)
+void WriteARAM(u8 value, u32 address)
 {
-  // NOTICE_LOG(DSPINTERFACE, "WriteARAM 0x%08x", _uAddress);
   // TODO: verify this on Wii
-  s_ARAM.ptr[_uAddress & s_ARAM.mask] = value;
+  s_ARAM.ptr[address & s_ARAM.mask] = value;
 }
 
 u8* GetARAMPtr()

--- a/Source/Core/Core/HW/DSP.h
+++ b/Source/Core/Core/HW/DSP.h
@@ -56,7 +56,7 @@ union UDSPControl
     u16 DSPInit : 1;      // DSPInit() writes to this flag
     u16 pad : 4;
   };
-  UDSPControl(u16 _Hex = 0) : Hex(_Hex) {}
+  UDSPControl(u16 hex = 0) : Hex(hex) {}
 };
 
 void Init(bool hle);
@@ -69,11 +69,11 @@ DSPEmulator* GetDSPEmulator();
 
 void DoState(PointerWrap& p);
 
-void GenerateDSPInterruptFromDSPEmu(DSPInterruptType _DSPInterruptType);
+void GenerateDSPInterruptFromDSPEmu(DSPInterruptType type);
 
 // Audio/DSP Helper
-u8 ReadARAM(const u32 _uAddress);
-void WriteARAM(u8 value, u32 _uAddress);
+u8 ReadARAM(u32 address);
+void WriteARAM(u8 value, u32 address);
 
 // Debugger Helper
 u8* GetARAMPtr();


### PR DESCRIPTION
Avoids stepping on potentially reserved names and is more consistent with the rest of the surrounding code.