### PR TITLE
Add the hash for the PAL v1.1 IPL to the list

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -167,19 +167,23 @@ bool CBoot::LoadMapFromFilename()
 // It does not initialize the hardware or anything else like BS1 does.
 bool CBoot::Load_BS2(const std::string& _rBootROMFilename)
 {
-  // CRC32
-  const u32 USA_v1_0 =
-      0x6D740AE7;  // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385344#pid385344
-  const u32 USA_v1_1 =
-      0xD5E6FEEA;  // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385334#pid385334
-  const u32 USA_v1_2 =
-      0x86573808;  // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385399#pid385399
-  const u32 BRA_v1_0 =
-      0x667D0B64;  // GameCubes sold in Brazil have this IPL. Same as USA v1.2 but localized
-  const u32 JAP_v1_0 = 0x6DAC1F2A;  // Redump
-  const u32 JAP_v1_1 = 0xD235E3F9;  // https://bugs.dolphin-emu.org/issues/8936
-  const u32 PAL_v1_0 = 0x4F319F43;  // Redump
-  const u32 PAL_v1_2 = 0xAD1B7F16;  // Redump
+  // CRC32 hashes of the IPL file; including source where known
+  // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385344#pid385344
+  constexpr u32 USA_v1_0 = 0x6D740AE7;
+  // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385334#pid385334
+  constexpr u32 USA_v1_1 = 0xD5E6FEEA;
+  // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385399#pid385399
+  constexpr u32 USA_v1_2 = 0x86573808;
+  // GameCubes sold in Brazil have this IPL. Same as USA v1.2 but localized
+  constexpr u32 BRA_v1_0 = 0x667D0B64;
+  // Redump
+  constexpr u32 JAP_v1_0 = 0x6DAC1F2A;
+  // https://bugs.dolphin-emu.org/issues/8936
+  constexpr u32 JAP_v1_1 = 0xD235E3F9;
+  // Redump
+  constexpr u32 PAL_v1_0 = 0x4F319F43;
+  // Redump
+  constexpr u32 PAL_v1_2 = 0xAD1B7F16;
 
   // Load the whole ROM dump
   std::string data;

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -182,6 +182,8 @@ bool CBoot::Load_BS2(const std::string& _rBootROMFilename)
   constexpr u32 JAP_v1_1 = 0xD235E3F9;
   // Redump
   constexpr u32 PAL_v1_0 = 0x4F319F43;
+  // https://forums.dolphin-emu.org/Thread-ipl-with-unknown-hash-dd8cab7c-problem-caused-by-my-pal-gamecube-bios?pid=435463#pid435463
+  constexpr u32 PAL_v1_1 = 0xDD8CAB7C;
   // Redump
   constexpr u32 PAL_v1_2 = 0xAD1B7F16;
 
@@ -207,6 +209,7 @@ bool CBoot::Load_BS2(const std::string& _rBootROMFilename)
     ipl_region = DiscIO::Region::NTSC_J;
     break;
   case PAL_v1_0:
+  case PAL_v1_1:
   case PAL_v1_2:
     ipl_region = DiscIO::Region::PAL;
     break;

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -48,7 +48,7 @@ bool CBoot::DVDRead(u64 dvd_offset, u32 output_address, u32 length, bool decrypt
   return true;
 }
 
-void CBoot::Load_FST(bool _bIsWii)
+void CBoot::Load_FST(bool is_wii)
 {
   if (!DVDInterface::IsDiscInside())
     return;
@@ -62,22 +62,22 @@ void CBoot::Load_FST(bool _bIsWii)
   Memory::Write_U32(Memory::Read_U32(0x0000), 0x3180);
 
   u32 shift = 0;
-  if (_bIsWii)
+  if (is_wii)
     shift = 2;
 
   u32 fst_offset = 0;
   u32 fst_size = 0;
   u32 max_fst_size = 0;
 
-  volume.ReadSwapped(0x0424, &fst_offset, _bIsWii);
-  volume.ReadSwapped(0x0428, &fst_size, _bIsWii);
-  volume.ReadSwapped(0x042c, &max_fst_size, _bIsWii);
+  volume.ReadSwapped(0x0424, &fst_offset, is_wii);
+  volume.ReadSwapped(0x0428, &fst_size, is_wii);
+  volume.ReadSwapped(0x042c, &max_fst_size, is_wii);
 
   u32 arena_high = Common::AlignDown(0x817FFFFF - (max_fst_size << shift), 0x20);
   Memory::Write_U32(arena_high, 0x00000034);
 
   // load FST
-  DVDRead(fst_offset << shift, arena_high, fst_size << shift, _bIsWii);
+  DVDRead(fst_offset << shift, arena_high, fst_size << shift, is_wii);
   Memory::Write_U32(arena_high, 0x00000038);
   Memory::Write_U32(max_fst_size << shift, 0x0000003c);
 }
@@ -165,7 +165,7 @@ bool CBoot::LoadMapFromFilename()
 // If ipl.bin is not found, this function does *some* of what BS1 does:
 // loading IPL(BS2) and jumping to it.
 // It does not initialize the hardware or anything else like BS1 does.
-bool CBoot::Load_BS2(const std::string& _rBootROMFilename)
+bool CBoot::Load_BS2(const std::string& boot_rom_filename)
 {
   // CRC32 hashes of the IPL file; including source where known
   // https://forums.dolphin-emu.org/Thread-unknown-hash-on-ipl-bin?pid=385344#pid385344
@@ -189,7 +189,7 @@ bool CBoot::Load_BS2(const std::string& _rBootROMFilename)
 
   // Load the whole ROM dump
   std::string data;
-  if (!File::ReadFileToString(_rBootROMFilename, data))
+  if (!File::ReadFileToString(boot_rom_filename, data))
     return false;
 
   // Use zlibs crc32 implementation to compute the hash

--- a/Source/Core/Core/Boot/Boot.h
+++ b/Source/Core/Core/Boot/Boot.h
@@ -41,18 +41,18 @@ public:
 
 private:
   static bool DVDRead(u64 dvd_offset, u32 output_address, u32 length, bool decrypt);
-  static void RunFunction(u32 _iAddr);
+  static void RunFunction(u32 address);
 
   static void UpdateDebugger_MapLoaded();
 
   static bool Boot_ELF(const std::string& filename);
   static bool Boot_WiiWAD(const std::string& filename);
 
-  static bool EmulatedBS2_GC(bool skipAppLoader = false);
+  static bool EmulatedBS2_GC(bool skip_app_loader = false);
   static bool EmulatedBS2_Wii();
-  static bool EmulatedBS2(bool _bIsWii);
-  static bool Load_BS2(const std::string& _rBootROMFilename);
-  static void Load_FST(bool _bIsWii);
+  static bool EmulatedBS2(bool is_wii);
+  static bool Load_BS2(const std::string& boot_rom_filename);
+  static void Load_FST(bool is_wii);
 
   static bool SetupWiiMemory(u64 ios_title_id);
 };

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -30,9 +30,9 @@
 #include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
 
-void CBoot::RunFunction(u32 _iAddr)
+void CBoot::RunFunction(u32 address)
 {
-  PC = _iAddr;
+  PC = address;
   LR = 0x00;
 
   while (PC != 0x00)
@@ -43,7 +43,7 @@ void CBoot::RunFunction(u32 _iAddr)
 // GameCube Bootstrap 2 HLE:
 // copy the apploader to 0x81200000
 // execute the apploader, function by function, using the above utility.
-bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
+bool CBoot::EmulatedBS2_GC(bool skip_app_loader)
 {
   INFO_LOG(BOOT, "Faking GC BS2...");
 
@@ -108,7 +108,7 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
   const DiscIO::IVolume& volume = DVDInterface::GetVolume();
   const u32 apploader_offset = 0x2440;
   u32 apploader_entry, apploader_size, apploader_trailer;
-  if (skipAppLoader || !volume.ReadSwapped(apploader_offset + 0x10, &apploader_entry, false) ||
+  if (skip_app_loader || !volume.ReadSwapped(apploader_offset + 0x10, &apploader_entry, false) ||
       !volume.ReadSwapped(apploader_offset + 0x14, &apploader_size, false) ||
       !volume.ReadSwapped(apploader_offset + 0x18, &apploader_trailer, false) ||
       apploader_entry == (u32)-1 || apploader_size + apploader_trailer == (u32)-1)
@@ -412,7 +412,7 @@ bool CBoot::EmulatedBS2_Wii()
 }
 
 // Returns true if apploader has run successfully
-bool CBoot::EmulatedBS2(bool _bIsWii)
+bool CBoot::EmulatedBS2(bool is_wii)
 {
-  return _bIsWii ? EmulatedBS2_Wii() : EmulatedBS2_GC();
+  return is_wii ? EmulatedBS2_Wii() : EmulatedBS2_GC();
 }


### PR DESCRIPTION
User hackintoshftw1 [reported on the forums](https://forums.dolphin-emu.org/Thread-ipl-with-unknown-hash-dd8cab7c-problem-caused-by-my-pal-gamecube-bios?pid=435463#pid435463) that his IPL dump caused the "IPL with unknown hash" error message to be shown; and Jhonn noticed that some hashes were removed in PR #3152 because noone could provide a CRC hash of the given IPLs.
So, here it is.

I also took the liberty of moving the source comments to the line before the actual value, otherwise clang-format would go mental and do wonky things with them.

And while I was at it, I also updated the paramter names to match our coding style (mostly to remove the leading-underscore which is reserved by the standard).

I can drop/separate either commits if preferred.