### PR TITLE
Fix VolumeDirectory for Wii games

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -79,6 +79,12 @@ void CBoot::Load_FST(bool is_wii)
   DVDRead(fst_offset << shift, arena_high, fst_size << shift, is_wii);
   Memory::Write_U32(arena_high, 0x00000038);
   Memory::Write_U32(max_fst_size << shift, 0x0000003c);
+
+  if (is_wii)
+  {
+    // the apploader changes IOS MEM1_ARENA_END too
+    Memory::Write_U32(arena_high, 0x00003110);
+  }
 }
 
 void CBoot::UpdateDebugger_MapLoaded()

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -373,8 +373,8 @@ void CVolumeDirectory::BuildFST()
 
   WriteDirectory(rootEntry, &fst_offset, &name_offset, &current_data_address, root_offset);
 
-  // overflow check
-  _dbg_assert_(DVDINTERFACE, name_offset == name_table_size);
+  // overflow check, compare the aligned name offset with the aligned name table size
+  _assert_(Common::AlignUp(name_offset, 1ull << m_address_shift) == name_table_size);
 
   // write FST size and location
   Write32((u32)(m_fst_address >> m_address_shift), 0x0424, &m_disk_header);

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -25,7 +25,7 @@
 namespace DiscIO
 {
 static u32 ComputeNameSize(const File::FSTEntry& parent_entry);
-static std::string ASCIIToLowercase(std::string str);
+static std::string ASCIIToUppercase(std::string str);
 
 const size_t CVolumeDirectory::MAX_NAME_LENGTH;
 const size_t CVolumeDirectory::MAX_ID_LENGTH;
@@ -455,9 +455,9 @@ void CVolumeDirectory::WriteDirectory(const File::FSTEntry& parent_entry, u32* f
   // Sort for determinism
   std::sort(sorted_entries.begin(), sorted_entries.end(), [](const File::FSTEntry& one,
                                                              const File::FSTEntry& two) {
-    const std::string one_lower = ASCIIToLowercase(one.virtualName);
-    const std::string two_lower = ASCIIToLowercase(two.virtualName);
-    return one_lower == two_lower ? one.virtualName < two.virtualName : one_lower < two_lower;
+    const std::string one_upper = ASCIIToUppercase(one.virtualName);
+    const std::string two_upper = ASCIIToUppercase(two.virtualName);
+    return one_upper == two_upper ? one.virtualName < two.virtualName : one_upper < two_upper;
   });
 
   for (const File::FSTEntry& entry : sorted_entries)
@@ -500,10 +500,10 @@ static u32 ComputeNameSize(const File::FSTEntry& parent_entry)
   return name_size;
 }
 
-static std::string ASCIIToLowercase(std::string str)
+static std::string ASCIIToUppercase(std::string str)
 {
   std::transform(str.begin(), str.end(), str.begin(),
-                 [](char c) { return std::tolower(c, std::locale::classic()); });
+                 [](char c) { return std::toupper(c, std::locale::classic()); });
   return str;
 }
 

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -350,7 +350,7 @@ void CVolumeDirectory::BuildFST()
   m_fst_data.clear();
 
   File::FSTEntry rootEntry = File::ScanDirectoryTree(m_root_directory, true);
-  u32 name_table_size = ComputeNameSize(rootEntry);
+  u32 name_table_size = Common::AlignUp(ComputeNameSize(rootEntry), 1ull << m_address_shift);
   u64 total_entries = rootEntry.size + 1;  // The root entry itself isn't counted in rootEntry.size
 
   m_fst_name_offset = total_entries * ENTRY_SIZE;  // offset of name table in FST

--- a/Source/Core/DiscIO/VolumeDirectory.cpp
+++ b/Source/Core/DiscIO/VolumeDirectory.cpp
@@ -465,8 +465,8 @@ void CVolumeDirectory::WriteDirectory(const File::FSTEntry& parent_entry, u32* f
     if (entry.isDirectory)
     {
       u32 entry_index = *fst_offset / ENTRY_SIZE;
-      WriteEntryData(fst_offset, DIRECTORY_ENTRY, *name_offset, parent_entry_index,
-                     entry_index + entry.size + 1);
+      WriteEntryData(fst_offset, DIRECTORY_ENTRY, *name_offset,
+                     parent_entry_index << m_address_shift, entry_index + entry.size + 1);
       WriteEntryName(name_offset, entry.virtualName);
 
       WriteDirectory(entry, fst_offset, name_offset, data_offset, entry_index);

--- a/Source/Core/DiscIO/VolumeDirectory.h
+++ b/Source/Core/DiscIO/VolumeDirectory.h
@@ -85,7 +85,8 @@ private:
   void Write32(u32 data, u32 offset, std::vector<u8>* const buffer);
 
   // FST creation
-  void WriteEntryData(u32* entry_offset, u8 type, u32 name_offset, u64 data_offset, u64 length);
+  void WriteEntryData(u32* entry_offset, u8 type, u32 name_offset, u64 data_offset, u64 length,
+                      u32 address_shift);
   void WriteEntryName(u32* name_offset, const std::string& name);
   void WriteDirectory(const File::FSTEntry& parent_entry, u32* fst_offset, u32* name_offset,
                       u64* data_offset, u32 parent_entry_index);


### PR DESCRIPTION
This hasn't been tested with extracted GameCube games (because I'm lazy and I don't have any more disk space), but this allows the MySims Kingdom PAL ELF to load when the DVD Root is set correctly. This also  fixes several inaccuracies with the generated FST (file name order slightly incorrect, last FST entry not being written, off by one in the root FST entry's size field, incorrect parent entry indices for Wii, name table improperly aligned for Wii).

Also, CBoot::Load_FST now writes to IOS_MEM1_ARENA_END like the real apploader. Without doing this, Wii games will zero out the FST then crash because the FST is invalid.