### PR TITLE
Move LoadPatches calls

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -289,11 +289,8 @@ bool CBoot::BootUp()
       // If we can't load the bootrom file we HLE it instead
       EmulatedBS2(_StartupPara.bWii);
     }
-    else
-    {
-      // Load patches if they weren't already
-      PatchEngine::LoadPatches();
-    }
+
+    PatchEngine::LoadPatches();
 
     // Scan for common HLE functions
     if (_StartupPara.bHLE_BS2 && !_StartupPara.bEnableDebugging)
@@ -435,6 +432,8 @@ bool CBoot::BootUp()
   // Wii WAD
   case SConfig::BOOT_WII_NAND:
     Boot_WiiWAD(_StartupPara.m_strFilename);
+
+    PatchEngine::LoadPatches();
 
     if (LoadMapFromFilename())
       HLE::PatchFunctions();

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -182,9 +182,6 @@ bool CBoot::EmulatedBS2_GC(bool skipAppLoader)
   // return
   PC = PowerPC::ppcState.gpr[3];
 
-  // Load patches
-  PatchEngine::LoadPatches();
-
   return true;
 }
 

--- a/Source/Core/Core/Boot/Boot_WiiWAD.cpp
+++ b/Source/Core/Core/Boot/Boot_WiiWAD.cpp
@@ -20,8 +20,6 @@
 #include "Core/PatchEngine.h"
 
 #include "DiscIO/NANDContentLoader.h"
-#include "DiscIO/Volume.h"
-#include "DiscIO/VolumeCreator.h"
 
 struct StateFlags
 {
@@ -92,11 +90,6 @@ bool CBoot::Boot_WiiWAD(const std::string& _pFilename)
   IOS::HLE::Device::ES::LoadWAD(_pFilename);
   if (!IOS::HLE::BootstrapPPC(ContentLoader))
     return false;
-
-  // Load patches and run startup patches
-  const std::unique_ptr<DiscIO::IVolume> pVolume(DiscIO::CreateVolumeFromFilename(_pFilename));
-  if (pVolume != nullptr)
-    PatchEngine::LoadPatches();
 
   return true;
 }


### PR DESCRIPTION
LoadPatches was apparently never being called when booting Wii discs. Maybe this will fix the recent regression with cheat codes not getting loaded? I don't know how this managed to work to begin with, though...

(The call was also moved for WADs, just for consistency.)