### PR TITLE
Default to SSL verify on

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -325,7 +325,7 @@ void SConfig::SaveNetworkSettings(IniFile& ini)
 
   network->Set("SSLDumpRead", m_SSLDumpRead);
   network->Set("SSLDumpWrite", m_SSLDumpWrite);
-  network->Set("SSLVerifyCert", m_SSLVerifyCert);
+  network->Set("SSLVerifyCertificates", m_SSLVerifyCert);
   network->Set("SSLDumpRootCA", m_SSLDumpRootCA);
   network->Set("SSLDumpPeerCert", m_SSLDumpPeerCert);
 }
@@ -660,7 +660,7 @@ void SConfig::LoadNetworkSettings(IniFile& ini)
 
   network->Get("SSLDumpRead", &m_SSLDumpRead, false);
   network->Get("SSLDumpWrite", &m_SSLDumpWrite, false);
-  network->Get("SSLVerifyCert", &m_SSLVerifyCert, false);
+  network->Get("SSLVerifyCertificates", &m_SSLVerifyCert, true);
   network->Get("SSLDumpRootCA", &m_SSLDumpRootCA, false);
   network->Get("SSLDumpPeerCert", &m_SSLDumpPeerCert, false);
 }


### PR DESCRIPTION
Defaulting to SSL verification off, *and* forcing it to be off even when the emulated software asks us to enable it is very bad behaviour, inaccurate and insecure.