### PR TITLE
OGL: Remove support for NV_depth_buffer_float.

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -234,8 +234,6 @@ void DolphinAnalytics::MakePerGameBuilder()
   builder.AddData("gpu-has-dual-source-blend", g_Config.backend_info.bSupportsDualSourceBlend);
   builder.AddData("gpu-has-primitive-restart", g_Config.backend_info.bSupportsPrimitiveRestart);
   builder.AddData("gpu-has-oversized-viewports", g_Config.backend_info.bSupportsOversizedViewports);
-  builder.AddData("gpu-has-oversized-depth-ranges",
-                  g_Config.backend_info.bSupportsOversizedDepthRanges);
   builder.AddData("gpu-has-geometry-shaders", g_Config.backend_info.bSupportsGeometryShaders);
   builder.AddData("gpu-has-3d-vision", g_Config.backend_info.bSupports3DVision);
   builder.AddData("gpu-has-early-z", g_Config.backend_info.bSupportsEarlyZ);

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -66,7 +66,6 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsOversizedViewports = false;
-  g_Config.backend_info.bSupportsOversizedDepthRanges = false;
   g_Config.backend_info.bSupportsGeometryShaders = true;
   g_Config.backend_info.bSupports3DVision = true;
   g_Config.backend_info.bSupportsPostProcessing = false;

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -69,7 +69,6 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsOversizedViewports = false;
-  g_Config.backend_info.bSupportsOversizedDepthRanges = false;
   g_Config.backend_info.bSupportsGeometryShaders = true;
   g_Config.backend_info.bSupports3DVision = true;
   g_Config.backend_info.bSupportsPostProcessing = false;

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -29,7 +29,6 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsOversizedViewports = true;
-  g_Config.backend_info.bSupportsOversizedDepthRanges = false;
   g_Config.backend_info.bSupportsGeometryShaders = true;
   g_Config.backend_info.bSupports3DVision = false;
   g_Config.backend_info.bSupportsEarlyZ = true;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -437,8 +437,6 @@ Renderer::Renderer()
 
   // Clip distance support is useless without a method to clamp the depth range
   g_Config.backend_info.bSupportsDepthClamp = GLExtensions::Supports("GL_ARB_depth_clamp");
-  g_Config.backend_info.bSupportsOversizedDepthRanges =
-      GLExtensions::Supports("GL_NV_depth_buffer_float");
 
   g_ogl_config.bSupportsGLSLCache = GLExtensions::Supports("GL_ARB_get_program_binary");
   g_ogl_config.bSupportsGLPinnedMemory = GLExtensions::Supports("GL_AMD_pinned_memory");
@@ -627,7 +625,7 @@ Renderer::Renderer()
                                    g_ogl_config.gl_renderer, g_ogl_config.gl_version),
                   5000);
 
-  WARN_LOG(VIDEO, "Missing OGL Extensions: %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+  WARN_LOG(VIDEO, "Missing OGL Extensions: %s%s%s%s%s%s%s%s%s%s%s%s%s%s",
            g_ActiveConfig.backend_info.bSupportsDualSourceBlend ? "" : "DualSourceBlend ",
            g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ? "" : "PrimitiveRestart ",
            g_ActiveConfig.backend_info.bSupportsEarlyZ ? "" : "EarlyZ ",
@@ -640,8 +638,7 @@ Renderer::Renderer()
            g_ActiveConfig.backend_info.bSupportsGSInstancing ? "" : "GSInstancing ",
            g_ActiveConfig.backend_info.bSupportsClipControl ? "" : "ClipControl ",
            g_ogl_config.bSupportsCopySubImage ? "" : "CopyImageSubData ",
-           g_ActiveConfig.backend_info.bSupportsDepthClamp ? "" : "DepthClamp ",
-           g_ActiveConfig.backend_info.bSupportsOversizedDepthRanges ? "" : "DepthRangedNV ");
+           g_ActiveConfig.backend_info.bSupportsDepthClamp ? "" : "DepthClamp ");
 
   s_last_multisamples = g_ActiveConfig.iMultisamples;
   s_MSAASamples = s_last_multisamples;
@@ -1079,8 +1076,7 @@ void Renderer::SetViewport()
     glViewport(iceilf(X), iceilf(Y), iceilf(Width), iceilf(Height));
   }
 
-  if (!g_ActiveConfig.backend_info.bSupportsOversizedDepthRanges &&
-      !g_ActiveConfig.backend_info.bSupportsDepthClamp)
+  if (!g_ActiveConfig.backend_info.bSupportsDepthClamp)
   {
     // There's no way to support oversized depth ranges in this situation. Let's just clamp the
     // range to the maximum value supported by the console GPU and hope for the best.
@@ -1105,10 +1101,7 @@ void Renderer::SetViewport()
   }
 
   // Set the reversed depth range.
-  if (g_ActiveConfig.backend_info.bSupportsOversizedDepthRanges)
-    glDepthRangedNV(max_depth, min_depth);
-  else
-    glDepthRangef(max_depth, min_depth);
+  glDepthRangef(max_depth, min_depth);
 }
 
 void Renderer::ClearScreen(const EFBRectangle& rc, bool colorEnable, bool alphaEnable, bool zEnable,

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -109,7 +109,6 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsInternalResolutionFrameDumps = true;
 
   // Overwritten in Render.cpp later
-  g_Config.backend_info.bSupportsOversizedDepthRanges = false;
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = true;
   g_Config.backend_info.bSupportsPaletteConversion = true;

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -129,7 +129,6 @@ void VideoSoftware::InitBackendInfo()
   g_Config.backend_info.bSupportsDualSourceBlend = true;
   g_Config.backend_info.bSupportsEarlyZ = true;
   g_Config.backend_info.bSupportsOversizedViewports = true;
-  g_Config.backend_info.bSupportsOversizedDepthRanges = true;
   g_Config.backend_info.bSupportsPrimitiveRestart = false;
   g_Config.backend_info.bSupportsMultithreading = false;
   g_Config.backend_info.bSupportsInternalResolutionFrameDumps = false;

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -225,16 +225,15 @@ VulkanContext::GPUList VulkanContext::EnumerateGPUs(VkInstance instance)
 void VulkanContext::PopulateBackendInfo(VideoConfig* config)
 {
   config->backend_info.api_type = APIType::Vulkan;
-  config->backend_info.bSupportsExclusiveFullscreen = false;   // Currently WSI does not allow this.
-  config->backend_info.bSupports3DVision = false;              // D3D-exclusive.
-  config->backend_info.bSupportsOversizedViewports = true;     // Assumed support.
-  config->backend_info.bSupportsOversizedDepthRanges = false;  // No support yet.
-  config->backend_info.bSupportsEarlyZ = true;                 // Assumed support.
-  config->backend_info.bSupportsPrimitiveRestart = true;       // Assumed support.
-  config->backend_info.bSupportsBindingLayout = false;         // Assumed support.
-  config->backend_info.bSupportsPaletteConversion = true;      // Assumed support.
-  config->backend_info.bSupportsClipControl = true;            // Assumed support.
-  config->backend_info.bSupportsMultithreading = true;         // Assumed support.
+  config->backend_info.bSupportsExclusiveFullscreen = false;  // Currently WSI does not allow this.
+  config->backend_info.bSupports3DVision = false;             // D3D-exclusive.
+  config->backend_info.bSupportsOversizedViewports = true;    // Assumed support.
+  config->backend_info.bSupportsEarlyZ = true;                // Assumed support.
+  config->backend_info.bSupportsPrimitiveRestart = true;      // Assumed support.
+  config->backend_info.bSupportsBindingLayout = false;        // Assumed support.
+  config->backend_info.bSupportsPaletteConversion = true;     // Assumed support.
+  config->backend_info.bSupportsClipControl = true;           // Assumed support.
+  config->backend_info.bSupportsMultithreading = true;        // Assumed support.
   config->backend_info.bSupportsInternalResolutionFrameDumps = true;  // Assumed support.
   config->backend_info.bSupportsPostProcessing = false;               // No support yet.
   config->backend_info.bSupportsDualSourceBlend = false;              // Dependent on features.

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -933,25 +933,15 @@ bool Renderer::UseVertexDepthRange() const
   if (!g_ActiveConfig.backend_info.bSupportsDepthClamp)
     return false;
 
-  const bool ztexture_enabled = bpmem.ztex2.type != ZTEXTURE_DISABLE && !bpmem.zcontrol.early_ztest;
+  // We need a full depth range if a ztexture is used.
+  if (bpmem.ztex2.type != ZTEXTURE_DISABLE && !bpmem.zcontrol.early_ztest)
+    return true;
 
-  if (g_ActiveConfig.backend_info.bSupportsOversizedDepthRanges)
-  {
-    // We support oversized depth ranges, but we need a full depth range if a ztexture is used.
-    return ztexture_enabled;
-  }
-  else
-  {
-    // We need a full depth range if a ztexture is used.
-    if (ztexture_enabled)
-      return true;
+  // If an inverted depth range is unsupported, we also need to check if the range is inverted.
+  if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange && xfmem.viewport.zRange < 0.0f)
+    return true;
 
-    // If an inverted depth range is unsupported, we also need to check if the range is inverted.
-    if (!g_ActiveConfig.backend_info.bSupportsReversedDepthRange && xfmem.viewport.zRange < 0.0f)
-      return true;
-
-    // If an oversized depth range or a ztexture is used, we need to calculate the depth range
-    // in the vertex shader.
-    return fabs(xfmem.viewport.zRange) > 16777215.0f || fabs(xfmem.viewport.farZ) > 16777215.0f;
-  }
+  // If an oversized depth range or a ztexture is used, we need to calculate the depth range
+  // in the vertex shader.
+  return fabs(xfmem.viewport.zRange) > 16777215.0f || fabs(xfmem.viewport.farZ) > 16777215.0f;
 }

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -179,7 +179,6 @@ struct VideoConfig final
     bool bSupportsDualSourceBlend;
     bool bSupportsPrimitiveRestart;
     bool bSupportsOversizedViewports;
-    bool bSupportsOversizedDepthRanges;
     bool bSupportsGeometryShaders;
     bool bSupports3DVision;
     bool bSupportsEarlyZ;         // needed by PixelShaderGen, so must stay in VideoCommon


### PR DESCRIPTION
We can't clamp the depth values to the 24-bit range while this extension is active.

Fixes regressions in Rogue Squadron 2 and the Mii Channel.

I'm keeping the extension definitions as it could still come in handy one day.