### PR TITLE
DSP/Jit: Explicitly specify scratch register for Update_SR_Register

### DIFF
--- a/Source/Core/Core/DSP/Jit/DSPEmitter.h
+++ b/Source/Core/Core/DSP/Jit/DSPEmitter.h
@@ -221,7 +221,7 @@ private:
   void r_ifcc(UDSPInstruction opc);
   void r_ret(UDSPInstruction opc);
 
-  void Update_SR_Register(Gen::X64Reg val = Gen::EAX);
+  void Update_SR_Register(Gen::X64Reg val = Gen::EAX, Gen::X64Reg scratch = Gen::EDX);
 
   void get_long_prod(Gen::X64Reg long_prod = Gen::RAX);
   void get_long_prod_round_prodl(Gen::X64Reg long_prod = Gen::RAX);
@@ -243,7 +243,7 @@ private:
   void HandleLoop();
 
   // CC helpers
-  void Update_SR_Register64(Gen::X64Reg val = Gen::EAX);
+  void Update_SR_Register64(Gen::X64Reg val = Gen::EAX, Gen::X64Reg scratch = Gen::EDX);
   void Update_SR_Register64_Carry(Gen::X64Reg val, Gen::X64Reg carry_ovfl, bool carry_eq = false);
   void Update_SR_Register16(Gen::X64Reg val = Gen::EAX);
   void Update_SR_Register16_OverS32(Gen::X64Reg val = Gen::EAX);

--- a/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitArithmetic.cpp
@@ -1382,7 +1382,7 @@ void DSPEmitter::lsrn(const UDSPInstruction opc)
   //	Update_SR_Register64(dsp_get_long_acc(0));
   if (FlagsNeeded())
   {
-    Update_SR_Register64(RDX);
+    Update_SR_Register64(RDX, RCX);
   }
 }
 
@@ -1439,7 +1439,7 @@ void DSPEmitter::asrn(const UDSPInstruction opc)
   SetJumpTarget(zero);
   if (FlagsNeeded())
   {
-    Update_SR_Register64(RDX);
+    Update_SR_Register64(RDX, RCX);
   }
 }
 
@@ -1502,7 +1502,7 @@ void DSPEmitter::lsrnrx(const UDSPInstruction opc)
   SetJumpTarget(zero);
   if (FlagsNeeded())
   {
-    Update_SR_Register64(RDX);
+    Update_SR_Register64(RDX, RCX);
   }
 }
 
@@ -1559,7 +1559,7 @@ void DSPEmitter::asrnrx(const UDSPInstruction opc)
   //	Update_SR_Register64(dsp_get_long_acc(dreg));
   if (FlagsNeeded())
   {
-    Update_SR_Register64(RDX);
+    Update_SR_Register64(RDX, RCX);
   }
 }
 
@@ -1617,7 +1617,7 @@ void DSPEmitter::lsrnr(const UDSPInstruction opc)
   //	Update_SR_Register64(dsp_get_long_acc(dreg));
   if (FlagsNeeded())
   {
-    Update_SR_Register64(RDX);
+    Update_SR_Register64(RDX, RCX);
   }
 }
 
@@ -1672,7 +1672,7 @@ void DSPEmitter::asrnr(const UDSPInstruction opc)
   //	Update_SR_Register64(dsp_get_long_acc(dreg));
   if (FlagsNeeded())
   {
-    Update_SR_Register64(RDX);
+    Update_SR_Register64(RDX, RCX);
   }
 }
 

--- a/Source/Core/Core/DSP/Jit/DSPJitMultiplier.cpp
+++ b/Source/Core/Core/DSP/Jit/DSPJitMultiplier.cpp
@@ -393,7 +393,7 @@ void DSPEmitter::mulmvz(const UDSPInstruction opc)
   //	Update_SR_Register64(dsp_get_long_acc(rreg));
   if (FlagsNeeded())
   {
-    Update_SR_Register64(RDX);
+    Update_SR_Register64(RDX, RCX);
   }
 }
 


### PR DESCRIPTION
There were cases when `val` was rdx and thus was being clobbered as rdx was implicitly used as a scratch register.

This did not seem like correct behaviour.