### PR TITLE
IOS: Add NandUtils

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -150,6 +150,7 @@ set(SRCS
   IOS/ES/ES.cpp
   IOS/ES/Formats.cpp
   IOS/ES/Identity.cpp
+  IOS/ES/NandUtils.cpp
   IOS/ES/TitleContents.cpp
   IOS/ES/TitleInformation.cpp
   IOS/ES/TitleManagement.cpp

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -177,6 +177,7 @@
     <ClCompile Include="IOS\ES\ES.cpp" />
     <ClCompile Include="IOS\ES\Formats.cpp" />
     <ClCompile Include="IOS\ES\Identity.cpp" />
+    <ClCompile Include="IOS\ES\NandUtils.cpp" />
     <ClCompile Include="IOS\ES\TitleContents.cpp" />
     <ClCompile Include="IOS\ES\TitleInformation.cpp" />
     <ClCompile Include="IOS\ES\TitleManagement.cpp" />
@@ -427,6 +428,7 @@
     <ClInclude Include="IOS\DI\DI.h" />
     <ClInclude Include="IOS\ES\ES.h" />
     <ClInclude Include="IOS\ES\Formats.h" />
+    <ClInclude Include="IOS\ES\NandUtils.h" />
     <ClInclude Include="IOS\FS\FileIO.h" />
     <ClInclude Include="IOS\FS\FS.h" />
     <ClInclude Include="IOS\Network\ICMPLin.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -759,6 +759,9 @@
     <ClCompile Include="IOS\ES\Identity.cpp">
       <Filter>IOS\ES</Filter>
     </ClCompile>
+    <ClCompile Include="IOS\ES\NandUtils.cpp">
+      <Filter>IOS\ES</Filter>
+    </ClCompile>
     <ClCompile Include="IOS\ES\TitleContents.cpp">
       <Filter>IOS\ES</Filter>
     </ClCompile>
@@ -1368,6 +1371,9 @@
       <Filter>IOS\DI</Filter>
     </ClInclude>
     <ClInclude Include="IOS\ES\ES.h">
+      <Filter>IOS\ES</Filter>
+    </ClInclude>
+    <ClInclude Include="IOS\ES\NandUtils.h">
       <Filter>IOS\ES</Filter>
     </ClInclude>
     <ClInclude Include="IOS\FS\FileIO.h">

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -18,6 +18,29 @@ namespace IOS
 {
 namespace ES
 {
+static TMDReader FindTMD(u64 title_id, const std::string& tmd_path)
+{
+  File::IOFile file(tmd_path, "rb");
+  if (!file)
+    return {};
+
+  std::vector<u8> tmd_bytes(file.GetSize());
+  if (!file.ReadBytes(tmd_bytes.data(), tmd_bytes.size()))
+    return {};
+
+  return TMDReader{std::move(tmd_bytes)};
+}
+
+TMDReader FindImportTMD(u64 title_id)
+{
+  return FindTMD(title_id, Common::GetImportTitlePath(title_id) + "/content/title.tmd");
+}
+
+TMDReader FindInstalledTMD(u64 title_id)
+{
+  return FindTMD(title_id, Common::GetTMDFileName(title_id, Common::FROM_SESSION_ROOT));
+}
+
 static bool IsValidPartOfTitleID(const std::string& string)
 {
   if (string.length() != 8)

--- a/Source/Core/Core/IOS/ES/NandUtils.h
+++ b/Source/Core/Core/IOS/ES/NandUtils.h
@@ -7,12 +7,14 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Core/IOS/ES/Formats.h"
 
 namespace IOS
 {
 namespace ES
 {
+struct Content;
+class TMDReader;
+
 TMDReader FindImportTMD(u64 title_id);
 TMDReader FindInstalledTMD(u64 title_id);
 
@@ -22,5 +24,7 @@ std::vector<u64> GetInstalledTitles();
 std::vector<u64> GetTitleImports();
 // Get titles for which there is a ticket (in /ticket).
 std::vector<u64> GetTitlesWithTickets();
+
+std::vector<Content> GetStoredContentsFromTMD(const TMDReader& tmd);
 }  // namespace ES
 }  // namespace IOS

--- a/Source/Core/Core/IOS/ES/NandUtils.h
+++ b/Source/Core/Core/IOS/ES/NandUtils.h
@@ -13,6 +13,9 @@ namespace IOS
 {
 namespace ES
 {
+TMDReader FindImportTMD(u64 title_id);
+TMDReader FindInstalledTMD(u64 title_id);
+
 // Get installed titles (in /title) without checking for TMDs at all.
 std::vector<u64> GetInstalledTitles();
 // Get titles which are being imported (in /import) without checking for TMDs at all.

--- a/Source/Core/Core/IOS/ES/NandUtils.h
+++ b/Source/Core/Core/IOS/ES/NandUtils.h
@@ -1,0 +1,23 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <vector>
+
+#include "Common/CommonTypes.h"
+#include "Core/IOS/ES/Formats.h"
+
+namespace IOS
+{
+namespace ES
+{
+// Get installed titles (in /title) without checking for TMDs at all.
+std::vector<u64> GetInstalledTitles();
+// Get titles which are being imported (in /import) without checking for TMDs at all.
+std::vector<u64> GetTitleImports();
+// Get titles for which there is a ticket (in /ticket).
+std::vector<u64> GetTitlesWithTickets();
+}  // namespace ES
+}  // namespace IOS

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -19,6 +19,7 @@
 #include "Common/StringUtil.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/IOS/ES/NandUtils.h"
 #include "Core/ec_wii.h"
 #include "DiscIO/NANDContentLoader.h"
 
@@ -403,13 +404,11 @@ IPCCommandResult ES::ExportTitleInit(const IOCtlVRequest& request)
   if (m_export_title_context.valid)
     return GetDefaultReply(ES_PARAMETER_SIZE_OR_ALIGNMENT);
 
-  const auto& content_loader = AccessContentDevice(Memory::Read_U64(request.in_vectors[0].address));
-  if (!content_loader.IsValid())
+  const auto tmd = IOS::ES::FindInstalledTMD(Memory::Read_U64(request.in_vectors[0].address));
+  if (!tmd.IsValid())
     return GetDefaultReply(FS_ENOENT);
-  if (!content_loader.GetTMD().IsValid())
-    return GetDefaultReply(ES_INVALID_TMD);
 
-  m_export_title_context.tmd = content_loader.GetTMD();
+  m_export_title_context.tmd = tmd;
 
   const auto ticket = DiscIO::FindSignedTicket(m_export_title_context.tmd.GetTitleId());
   if (!ticket.IsValid())

--- a/Source/Core/DiscIO/NANDContentLoader.h
+++ b/Source/Core/DiscIO/NANDContentLoader.h
@@ -23,6 +23,7 @@ namespace DiscIO
 {
 enum class Region;
 
+// TODO: move some of these to Core/IOS/ES.
 bool AddTicket(const IOS::ES::TicketReader& signed_ticket);
 IOS::ES::TicketReader FindSignedTicket(u64 title_id);
 


### PR DESCRIPTION
This keeps the ES specific NAND code (such as TMD, ticket reading/parsing, internal title installation logic) in a single place and makes it reusable. Eventually, other ES specific code will be moved to it.
