### PR TITLE
SI_Devices: Minor cleanup

### DIFF
--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
@@ -7,27 +7,27 @@
 #include "Common/CommonTypes.h"
 #include "InputCommon/GCPadStatus.h"
 
-CSIDevice_DanceMat::CSIDevice_DanceMat(SIDevices device, int _iDeviceNumber)
-    : CSIDevice_GCController(device, _iDeviceNumber)
+CSIDevice_DanceMat::CSIDevice_DanceMat(SIDevices device, int device_number)
+    : CSIDevice_GCController(device, device_number)
 {
 }
 
-int CSIDevice_DanceMat::RunBuffer(u8* _pBuffer, int _iLength)
+int CSIDevice_DanceMat::RunBuffer(u8* buffer, int length)
 {
   // Read the command
-  EBufferCommands command = static_cast<EBufferCommands>(_pBuffer[3]);
+  EBufferCommands command = static_cast<EBufferCommands>(buffer[3]);
 
   if (command == CMD_RESET)
   {
-    ISIDevice::RunBuffer(_pBuffer, _iLength);
-    *(u32*)&_pBuffer[0] = SI_DANCEMAT;
+    ISIDevice::RunBuffer(buffer, length);
+    *(u32*)&buffer[0] = SI_DANCEMAT;
   }
   else
   {
-    return CSIDevice_GCController::RunBuffer(_pBuffer, _iLength);
+    return CSIDevice_GCController::RunBuffer(buffer, length);
   }
 
-  return _iLength;
+  return length;
 }
 
 u32 CSIDevice_DanceMat::MapPadStatus(const GCPadStatus& pad_status)
@@ -59,12 +59,12 @@ u32 CSIDevice_DanceMat::MapPadStatus(const GCPadStatus& pad_status)
   return (u32)(map << 16) | 0x8080;
 }
 
-bool CSIDevice_DanceMat::GetData(u32& _Hi, u32& _Low)
+bool CSIDevice_DanceMat::GetData(u32& hi, u32& low)
 {
-  CSIDevice_GCController::GetData(_Hi, _Low);
+  CSIDevice_GCController::GetData(hi, low);
 
   // Identifies the dance mat
-  _Low = 0x8080ffff;
+  low = 0x8080ffff;
 
   return true;
 }

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
@@ -12,9 +12,9 @@ struct GCPadStatus;
 class CSIDevice_DanceMat : public CSIDevice_GCController
 {
 public:
-  CSIDevice_DanceMat(SIDevices device, int _iDeviceNumber);
+  CSIDevice_DanceMat(SIDevices device, int device_number);
 
-  int RunBuffer(u8* _pBuffer, int _iLength) override;
+  int RunBuffer(u8* buffer, int length) override;
   u32 MapPadStatus(const GCPadStatus& pad_status) override;
-  bool GetData(u32& _Hi, u32& _Low) override;
+  bool GetData(u32& hi, u32& low) override;
 };

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -15,13 +15,13 @@
 #include "Core/NetPlayProto.h"
 #include "InputCommon/GCAdapter.h"
 
-CSIDevice_GCAdapter::CSIDevice_GCAdapter(SIDevices device, int _iDeviceNumber)
-    : CSIDevice_GCController(device, _iDeviceNumber)
+CSIDevice_GCAdapter::CSIDevice_GCAdapter(SIDevices device, int device_number)
+    : CSIDevice_GCController(device, device_number)
 {
   // get the correct pad number that should rumble locally when using netplay
-  const int numPAD = NetPlay_InGamePadToLocalPad(m_device_number);
-  if (numPAD < 4)
-    m_simulate_konga = SConfig::GetInstance().m_AdapterKonga[numPAD];
+  const int pad_num = NetPlay_InGamePadToLocalPad(m_device_number);
+  if (pad_num < 4)
+    m_simulate_konga = SConfig::GetInstance().m_AdapterKonga[pad_num];
 }
 
 GCPadStatus CSIDevice_GCAdapter::GetPadStatus()
@@ -60,11 +60,11 @@ int CSIDevice_GCAdapter::RunBuffer(u8* buffer, int length)
   return CSIDevice_GCController::RunBuffer(buffer, length);
 }
 
-void CSIDevice_GCController::Rumble(int numPad, ControlState strength)
+void CSIDevice_GCController::Rumble(int pad_num, ControlState strength)
 {
-  SIDevices device = SConfig::GetInstance().m_SIDevice[numPad];
+  SIDevices device = SConfig::GetInstance().m_SIDevice[pad_num];
   if (device == SIDEVICE_WIIU_ADAPTER)
-    GCAdapter::Output(numPad, static_cast<u8>(strength));
+    GCAdapter::Output(pad_num, static_cast<u8>(strength));
   else if (SIDevice_IsGCController(device))
-    Pad::Rumble(numPad, strength);
+    Pad::Rumble(pad_num, strength);
 }

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
@@ -11,7 +11,7 @@
 class CSIDevice_GCAdapter : public CSIDevice_GCController
 {
 public:
-  CSIDevice_GCAdapter(SIDevices device, int _iDeviceNumber);
+  CSIDevice_GCAdapter(SIDevices device, int device_number);
 
   GCPadStatus GetPadStatus() override;
   int RunBuffer(u8* buffer, int length) override;

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
@@ -8,106 +8,106 @@
 #include "Common/Logging/Log.h"
 #include "Core/HW/GCPad.h"
 
-CSIDevice_GCSteeringWheel::CSIDevice_GCSteeringWheel(SIDevices device, int _iDeviceNumber)
-    : CSIDevice_GCController(device, _iDeviceNumber)
+CSIDevice_GCSteeringWheel::CSIDevice_GCSteeringWheel(SIDevices device, int device_number)
+    : CSIDevice_GCController(device, device_number)
 {
 }
 
-int CSIDevice_GCSteeringWheel::RunBuffer(u8* _pBuffer, int _iLength)
+int CSIDevice_GCSteeringWheel::RunBuffer(u8* buffer, int length)
 {
   // For debug logging only
-  ISIDevice::RunBuffer(_pBuffer, _iLength);
+  ISIDevice::RunBuffer(buffer, length);
 
   // Read the command
-  EBufferCommands command = static_cast<EBufferCommands>(_pBuffer[3]);
+  EBufferCommands command = static_cast<EBufferCommands>(buffer[3]);
 
   // Handle it
   switch (command)
   {
   case CMD_RESET:
   case CMD_ID:
-    *(u32*)&_pBuffer[0] = SI_GC_STEERING;
+    *(u32*)&buffer[0] = SI_GC_STEERING;
     break;
 
   // DEFAULT
   default:
   {
-    return CSIDevice_GCController::RunBuffer(_pBuffer, _iLength);
+    return CSIDevice_GCController::RunBuffer(buffer, length);
   }
   break;
   }
 
-  return _iLength;
+  return length;
 }
 
-bool CSIDevice_GCSteeringWheel::GetData(u32& _Hi, u32& _Low)
+bool CSIDevice_GCSteeringWheel::GetData(u32& hi, u32& low)
 {
   if (m_mode == 6)
   {
-    GCPadStatus PadStatus = GetPadStatus();
+    GCPadStatus pad_status = GetPadStatus();
 
-    _Hi = (u32)((u8)PadStatus.stickX);  // Steering
-    _Hi |= 0x800;                       // Pedal connected flag
-    _Hi |= (u32)((u16)(PadStatus.button | PAD_USE_ORIGIN) << 16);
+    hi = (u32)((u8)pad_status.stickX);  // Steering
+    hi |= 0x800;                        // Pedal connected flag
+    hi |= (u32)((u16)(pad_status.button | PAD_USE_ORIGIN) << 16);
 
-    _Low = (u8)PadStatus.triggerRight;              // All 8 bits
-    _Low |= (u32)((u8)PadStatus.triggerLeft << 8);  // All 8 bits
+    low = (u8)pad_status.triggerRight;              // All 8 bits
+    low |= (u32)((u8)pad_status.triggerLeft << 8);  // All 8 bits
 
     // The GC Steering Wheel appears to have combined pedals
     // (both the Accelerate and Brake pedals are mapped to a single axis)
     // We use the stickY axis for the pedals.
-    if (PadStatus.stickY < 128)
-      _Low |= (u32)((u8)(255 - ((PadStatus.stickY & 0x7f) * 2)) << 16);  // All 8 bits (Brake)
-    if (PadStatus.stickY >= 128)
-      _Low |= (u32)((u8)((PadStatus.stickY & 0x7f) * 2) << 24);  // All 8 bits (Accelerate)
+    if (pad_status.stickY < 128)
+      low |= (u32)((u8)(255 - ((pad_status.stickY & 0x7f) * 2)) << 16);  // All 8 bits (Brake)
+    if (pad_status.stickY >= 128)
+      low |= (u32)((u8)((pad_status.stickY & 0x7f) * 2) << 24);  // All 8 bits (Accelerate)
 
-    HandleButtonCombos(PadStatus);
+    HandleButtonCombos(pad_status);
   }
   else
   {
-    return CSIDevice_GCController::GetData(_Hi, _Low);
+    return CSIDevice_GCController::GetData(hi, low);
   }
 
   return true;
 }
 
-void CSIDevice_GCSteeringWheel::SendCommand(u32 _Cmd, u8 _Poll)
+void CSIDevice_GCSteeringWheel::SendCommand(u32 command, u8 poll)
 {
-  UCommand command(_Cmd);
+  UCommand wheel_command(command);
 
-  if (command.command == CMD_FORCE)
+  if (wheel_command.command == CMD_FORCE)
   {
     // 0 = left strong, 127 = left weak, 128 = right weak, 255 = right strong
-    unsigned int uStrength = command.parameter1;
+    unsigned int strength = wheel_command.parameter1;
 
     // 06 = motor on, 04 = motor off
-    unsigned int uType = command.parameter2;
+    unsigned int type = wheel_command.parameter2;
 
     // get the correct pad number that should rumble locally when using netplay
-    const int numPAD = NetPlay_InGamePadToLocalPad(m_device_number);
+    const int pad_num = NetPlay_InGamePadToLocalPad(m_device_number);
 
-    if (numPAD < 4)
+    if (pad_num < 4)
     {
-      if (uType == 0x06)
+      if (type == 0x06)
       {
         // map 0..255 to -1.0..1.0
-        ControlState strength = uStrength / 127.5 - 1;
-        Pad::Rumble(numPAD, strength);
+        ControlState mapped_strength = strength / 127.5 - 1;
+        Pad::Rumble(pad_num, mapped_strength);
       }
       else
       {
-        Pad::Rumble(numPAD, 0);
+        Pad::Rumble(pad_num, 0);
       }
     }
 
-    if (!_Poll)
+    if (!poll)
     {
-      m_mode = command.parameter2;
+      m_mode = wheel_command.parameter2;
       INFO_LOG(SERIALINTERFACE, "PAD %i set to mode %i", m_device_number, m_mode);
     }
   }
   else
   {
-    return CSIDevice_GCController::SendCommand(_Cmd, _Poll);
+    return CSIDevice_GCController::SendCommand(command, poll);
   }
 }

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.h
@@ -8,6 +8,13 @@
 
 class CSIDevice_GCSteeringWheel : public CSIDevice_GCController
 {
+public:
+  CSIDevice_GCSteeringWheel(SIDevices device, int device_number);
+
+  int RunBuffer(u8* buffer, int length) override;
+  bool GetData(u32& hi, u32& low) override;
+  void SendCommand(u32 command, u8 poll) override;
+
 private:
   // Commands
   enum EBufferCommands
@@ -23,11 +30,4 @@ private:
     CMD_FORCE = 0x30,
     CMD_WRITE = 0x40
   };
-
-public:
-  CSIDevice_GCSteeringWheel(SIDevices device, int _iDeviceNumber);
-
-  int RunBuffer(u8* _pBuffer, int _iLength) override;
-  bool GetData(u32& _Hi, u32& _Low) override;
-  void SendCommand(u32 _Cmd, u8 _Poll) override;
 };

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
@@ -11,36 +11,36 @@
 #include "InputCommon/KeyboardStatus.h"
 
 // --- GameCube keyboard ---
-CSIDevice_Keyboard::CSIDevice_Keyboard(SIDevices device, int _iDeviceNumber)
-    : ISIDevice(device, _iDeviceNumber)
+CSIDevice_Keyboard::CSIDevice_Keyboard(SIDevices device, int device_number)
+    : ISIDevice(device, device_number)
 {
 }
 
-int CSIDevice_Keyboard::RunBuffer(u8* _pBuffer, int _iLength)
+int CSIDevice_Keyboard::RunBuffer(u8* buffer, int length)
 {
   // For debug logging only
-  ISIDevice::RunBuffer(_pBuffer, _iLength);
+  ISIDevice::RunBuffer(buffer, length);
 
   // Read the command
-  EBufferCommands command = static_cast<EBufferCommands>(_pBuffer[3]);
+  EBufferCommands command = static_cast<EBufferCommands>(buffer[3]);
 
   // Handle it
   switch (command)
   {
   case CMD_RESET:
   case CMD_ID:
-    *(u32*)&_pBuffer[0] = SI_GC_KEYBOARD;
+    *(u32*)&buffer[0] = SI_GC_KEYBOARD;
     break;
 
   case CMD_DIRECT:
   {
-    INFO_LOG(SERIALINTERFACE, "Keyboard - Direct (Length: %d)", _iLength);
+    INFO_LOG(SERIALINTERFACE, "Keyboard - Direct (Length: %d)", length);
     u32 high, low;
     GetData(high, low);
-    for (int i = 0; i < (_iLength - 1) / 2; i++)
+    for (int i = 0; i < (length - 1) / 2; i++)
     {
-      _pBuffer[i + 0] = (high >> (i * 8)) & 0xff;
-      _pBuffer[i + 4] = (low >> (i * 8)) & 0xff;
+      buffer[i + 0] = (high >> (i * 8)) & 0xff;
+      buffer[i + 4] = (low >> (i * 8)) & 0xff;
     }
   }
   break;
@@ -52,7 +52,7 @@ int CSIDevice_Keyboard::RunBuffer(u8* _pBuffer, int _iLength)
   break;
   }
 
-  return _iLength;
+  return length;
 }
 
 KeyboardStatus CSIDevice_Keyboard::GetKeyboardStatus() const
@@ -60,37 +60,37 @@ KeyboardStatus CSIDevice_Keyboard::GetKeyboardStatus() const
   return Keyboard::GetStatus(m_device_number);
 }
 
-bool CSIDevice_Keyboard::GetData(u32& _Hi, u32& _Low)
+bool CSIDevice_Keyboard::GetData(u32& hi, u32& low)
 {
-  KeyboardStatus KeyStatus = GetKeyboardStatus();
+  KeyboardStatus key_status = GetKeyboardStatus();
   u8 key[3] = {0x00, 0x00, 0x00};
-  MapKeys(KeyStatus, key);
-  u8 checksum = key[0] ^ key[1] ^ key[2] ^ m_Counter;
+  MapKeys(key_status, key);
+  u8 checksum = key[0] ^ key[1] ^ key[2] ^ m_counter;
 
-  _Hi = m_Counter << 24;
-  _Low = key[0] << 24 | key[1] << 16 | key[2] << 8 | checksum;
+  hi = m_counter << 24;
+  low = key[0] << 24 | key[1] << 16 | key[2] << 8 | checksum;
 
   return true;
 }
 
-void CSIDevice_Keyboard::SendCommand(u32 _Cmd, u8 _Poll)
+void CSIDevice_Keyboard::SendCommand(u32 command, u8 poll)
 {
-  UCommand command(_Cmd);
+  UCommand keyboard_command(command);
 
-  switch (command.Command)
+  switch (keyboard_command.command)
   {
   case 0x00:
     break;
 
   case CMD_POLL:
   {
-    m_Counter++;
-    m_Counter &= 15;
+    m_counter++;
+    m_counter &= 15;
   }
   break;
   default:
   {
-    ERROR_LOG(SERIALINTERFACE, "Unknown direct command     (0x%x)", _Cmd);
+    ERROR_LOG(SERIALINTERFACE, "Unknown direct command     (0x%x)", command);
   }
   break;
   }
@@ -98,519 +98,519 @@ void CSIDevice_Keyboard::SendCommand(u32 _Cmd, u8 _Poll)
 
 void CSIDevice_Keyboard::DoState(PointerWrap& p)
 {
-  p.Do(m_Counter);
+  p.Do(m_counter);
 }
 
-void CSIDevice_Keyboard::MapKeys(const KeyboardStatus& KeyStatus, u8* key)
+void CSIDevice_Keyboard::MapKeys(const KeyboardStatus& key_status, u8* key)
 {
   u8 keys_held = 0;
   const u8 MAX_KEYS_HELD = 3;
 
-  if (KeyStatus.key0x & KEYMASK_HOME)
+  if (key_status.key0x & KEYMASK_HOME)
   {
     key[keys_held++] = KEY_HOME;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_END)
+  if (key_status.key0x & KEYMASK_END)
   {
     key[keys_held++] = KEY_END;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_PGUP)
+  if (key_status.key0x & KEYMASK_PGUP)
   {
     key[keys_held++] = KEY_PGUP;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_PGDN)
+  if (key_status.key0x & KEYMASK_PGDN)
   {
     key[keys_held++] = KEY_PGDN;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_SCROLLLOCK)
+  if (key_status.key0x & KEYMASK_SCROLLLOCK)
   {
     key[keys_held++] = KEY_SCROLLLOCK;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_A)
+  if (key_status.key0x & KEYMASK_A)
   {
     key[keys_held++] = KEY_A;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_B)
+  if (key_status.key0x & KEYMASK_B)
   {
     key[keys_held++] = KEY_B;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_C)
+  if (key_status.key0x & KEYMASK_C)
   {
     key[keys_held++] = KEY_C;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_D)
+  if (key_status.key0x & KEYMASK_D)
   {
     key[keys_held++] = KEY_D;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_E)
+  if (key_status.key0x & KEYMASK_E)
   {
     key[keys_held++] = KEY_E;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_F)
+  if (key_status.key0x & KEYMASK_F)
   {
     key[keys_held++] = KEY_F;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_G)
+  if (key_status.key0x & KEYMASK_G)
   {
     key[keys_held++] = KEY_G;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_H)
+  if (key_status.key0x & KEYMASK_H)
   {
     key[keys_held++] = KEY_H;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_I)
+  if (key_status.key0x & KEYMASK_I)
   {
     key[keys_held++] = KEY_I;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_J)
+  if (key_status.key0x & KEYMASK_J)
   {
     key[keys_held++] = KEY_J;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key0x & KEYMASK_K)
+  if (key_status.key0x & KEYMASK_K)
   {
     key[keys_held++] = KEY_K;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_L)
+  if (key_status.key1x & KEYMASK_L)
   {
     key[keys_held++] = KEY_L;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_M)
+  if (key_status.key1x & KEYMASK_M)
   {
     key[keys_held++] = KEY_M;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_N)
+  if (key_status.key1x & KEYMASK_N)
   {
     key[keys_held++] = KEY_N;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_O)
+  if (key_status.key1x & KEYMASK_O)
   {
     key[keys_held++] = KEY_O;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_P)
+  if (key_status.key1x & KEYMASK_P)
   {
     key[keys_held++] = KEY_P;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_Q)
+  if (key_status.key1x & KEYMASK_Q)
   {
     key[keys_held++] = KEY_Q;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_R)
+  if (key_status.key1x & KEYMASK_R)
   {
     key[keys_held++] = KEY_R;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_S)
+  if (key_status.key1x & KEYMASK_S)
   {
     key[keys_held++] = KEY_S;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_T)
+  if (key_status.key1x & KEYMASK_T)
   {
     key[keys_held++] = KEY_T;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_U)
+  if (key_status.key1x & KEYMASK_U)
   {
     key[keys_held++] = KEY_U;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_V)
+  if (key_status.key1x & KEYMASK_V)
   {
     key[keys_held++] = KEY_V;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_W)
+  if (key_status.key1x & KEYMASK_W)
   {
     key[keys_held++] = KEY_W;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_X)
+  if (key_status.key1x & KEYMASK_X)
   {
     key[keys_held++] = KEY_X;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_Y)
+  if (key_status.key1x & KEYMASK_Y)
   {
     key[keys_held++] = KEY_Y;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_Z)
+  if (key_status.key1x & KEYMASK_Z)
   {
     key[keys_held++] = KEY_Z;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key1x & KEYMASK_1)
+  if (key_status.key1x & KEYMASK_1)
   {
     key[keys_held++] = KEY_1;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_2)
+  if (key_status.key2x & KEYMASK_2)
   {
     key[keys_held++] = KEY_2;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_3)
+  if (key_status.key2x & KEYMASK_3)
   {
     key[keys_held++] = KEY_3;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_4)
+  if (key_status.key2x & KEYMASK_4)
   {
     key[keys_held++] = KEY_4;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_5)
+  if (key_status.key2x & KEYMASK_5)
   {
     key[keys_held++] = KEY_5;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_6)
+  if (key_status.key2x & KEYMASK_6)
   {
     key[keys_held++] = KEY_6;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_7)
+  if (key_status.key2x & KEYMASK_7)
   {
     key[keys_held++] = KEY_7;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_8)
+  if (key_status.key2x & KEYMASK_8)
   {
     key[keys_held++] = KEY_8;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_9)
+  if (key_status.key2x & KEYMASK_9)
   {
     key[keys_held++] = KEY_9;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_0)
+  if (key_status.key2x & KEYMASK_0)
   {
     key[keys_held++] = KEY_0;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_MINUS)
+  if (key_status.key2x & KEYMASK_MINUS)
   {
     key[keys_held++] = KEY_MINUS;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_PLUS)
+  if (key_status.key2x & KEYMASK_PLUS)
   {
     key[keys_held++] = KEY_PLUS;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_PRINTSCR)
+  if (key_status.key2x & KEYMASK_PRINTSCR)
   {
     key[keys_held++] = KEY_PRINTSCR;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_BRACE_OPEN)
+  if (key_status.key2x & KEYMASK_BRACE_OPEN)
   {
     key[keys_held++] = KEY_BRACE_OPEN;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_BRACE_CLOSE)
+  if (key_status.key2x & KEYMASK_BRACE_CLOSE)
   {
     key[keys_held++] = KEY_BRACE_CLOSE;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_COLON)
+  if (key_status.key2x & KEYMASK_COLON)
   {
     key[keys_held++] = KEY_COLON;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key2x & KEYMASK_QUOTE)
+  if (key_status.key2x & KEYMASK_QUOTE)
   {
     key[keys_held++] = KEY_QUOTE;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_HASH)
+  if (key_status.key3x & KEYMASK_HASH)
   {
     key[keys_held++] = KEY_HASH;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_COMMA)
+  if (key_status.key3x & KEYMASK_COMMA)
   {
     key[keys_held++] = KEY_COMMA;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_PERIOD)
+  if (key_status.key3x & KEYMASK_PERIOD)
   {
     key[keys_held++] = KEY_PERIOD;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_QUESTIONMARK)
+  if (key_status.key3x & KEYMASK_QUESTIONMARK)
   {
     key[keys_held++] = KEY_QUESTIONMARK;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_INTERNATIONAL1)
+  if (key_status.key3x & KEYMASK_INTERNATIONAL1)
   {
     key[keys_held++] = KEY_INTERNATIONAL1;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F1)
+  if (key_status.key3x & KEYMASK_F1)
   {
     key[keys_held++] = KEY_F1;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F2)
+  if (key_status.key3x & KEYMASK_F2)
   {
     key[keys_held++] = KEY_F2;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F3)
+  if (key_status.key3x & KEYMASK_F3)
   {
     key[keys_held++] = KEY_F3;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F4)
+  if (key_status.key3x & KEYMASK_F4)
   {
     key[keys_held++] = KEY_F4;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F5)
+  if (key_status.key3x & KEYMASK_F5)
   {
     key[keys_held++] = KEY_F5;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F6)
+  if (key_status.key3x & KEYMASK_F6)
   {
     key[keys_held++] = KEY_F6;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F7)
+  if (key_status.key3x & KEYMASK_F7)
   {
     key[keys_held++] = KEY_F7;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F8)
+  if (key_status.key3x & KEYMASK_F8)
   {
     key[keys_held++] = KEY_F8;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F9)
+  if (key_status.key3x & KEYMASK_F9)
   {
     key[keys_held++] = KEY_F9;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F10)
+  if (key_status.key3x & KEYMASK_F10)
   {
     key[keys_held++] = KEY_F10;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key3x & KEYMASK_F11)
+  if (key_status.key3x & KEYMASK_F11)
   {
     key[keys_held++] = KEY_F11;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_F12)
+  if (key_status.key4x & KEYMASK_F12)
   {
     key[keys_held++] = KEY_F12;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_ESC)
+  if (key_status.key4x & KEYMASK_ESC)
   {
     key[keys_held++] = KEY_ESC;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_INSERT)
+  if (key_status.key4x & KEYMASK_INSERT)
   {
     key[keys_held++] = KEY_INSERT;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_DELETE)
+  if (key_status.key4x & KEYMASK_DELETE)
   {
     key[keys_held++] = KEY_DELETE;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_TILDE)
+  if (key_status.key4x & KEYMASK_TILDE)
   {
     key[keys_held++] = KEY_TILDE;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_BACKSPACE)
+  if (key_status.key4x & KEYMASK_BACKSPACE)
   {
     key[keys_held++] = KEY_BACKSPACE;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_TAB)
+  if (key_status.key4x & KEYMASK_TAB)
   {
     key[keys_held++] = KEY_TAB;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_CAPSLOCK)
+  if (key_status.key4x & KEYMASK_CAPSLOCK)
   {
     key[keys_held++] = KEY_CAPSLOCK;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_LEFTSHIFT)
+  if (key_status.key4x & KEYMASK_LEFTSHIFT)
   {
     key[keys_held++] = KEY_LEFTSHIFT;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_RIGHTSHIFT)
+  if (key_status.key4x & KEYMASK_RIGHTSHIFT)
   {
     key[keys_held++] = KEY_RIGHTSHIFT;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_LEFTCONTROL)
+  if (key_status.key4x & KEYMASK_LEFTCONTROL)
   {
     key[keys_held++] = KEY_LEFTCONTROL;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_RIGHTALT)
+  if (key_status.key4x & KEYMASK_RIGHTALT)
   {
     key[keys_held++] = KEY_RIGHTALT;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_LEFTWINDOWS)
+  if (key_status.key4x & KEYMASK_LEFTWINDOWS)
   {
     key[keys_held++] = KEY_LEFTWINDOWS;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_SPACE)
+  if (key_status.key4x & KEYMASK_SPACE)
   {
     key[keys_held++] = KEY_SPACE;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_RIGHTWINDOWS)
+  if (key_status.key4x & KEYMASK_RIGHTWINDOWS)
   {
     key[keys_held++] = KEY_RIGHTWINDOWS;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key4x & KEYMASK_MENU)
+  if (key_status.key4x & KEYMASK_MENU)
   {
     key[keys_held++] = KEY_MENU;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key5x & KEYMASK_LEFTARROW)
+  if (key_status.key5x & KEYMASK_LEFTARROW)
   {
     key[keys_held++] = KEY_LEFTARROW;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key5x & KEYMASK_DOWNARROW)
+  if (key_status.key5x & KEYMASK_DOWNARROW)
   {
     key[keys_held++] = KEY_DOWNARROW;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key5x & KEYMASK_UPARROW)
+  if (key_status.key5x & KEYMASK_UPARROW)
   {
     key[keys_held++] = KEY_UPARROW;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key5x & KEYMASK_RIGHTARROW)
+  if (key_status.key5x & KEYMASK_RIGHTARROW)
   {
     key[keys_held++] = KEY_RIGHTARROW;
     if (keys_held >= MAX_KEYS_HELD)
       return;
   }
-  if (KeyStatus.key5x & KEYMASK_ENTER)
+  if (key_status.key5x & KEYMASK_ENTER)
   {
     key[keys_held++] = KEY_ENTER;
     if (keys_held >= MAX_KEYS_HELD)

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
@@ -28,7 +28,7 @@ protected:
 
   union UCommand
   {
-    u32 Hex;
+    u32 Hex = 0;
     struct
     {
       u32 Parameter1 : 8;
@@ -36,15 +36,15 @@ protected:
       u32 Command : 8;
       u32 : 8;
     };
-    UCommand() { Hex = 0; }
-    UCommand(u32 _iValue) { Hex = _iValue; }
+    UCommand() = default;
+    UCommand(u32 value) : Hex{value} {}
   };
 
   // PADAnalogMode
-  u8 m_Mode;
+  u8 m_Mode = 0;
 
   // Internal counter synchonizing GC and keyboard
-  u8 m_Counter;
+  u8 m_Counter = 0;
 
 public:
   // Constructor

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
@@ -11,6 +11,25 @@ struct KeyboardStatus;
 
 class CSIDevice_Keyboard : public ISIDevice
 {
+public:
+  // Constructor
+  CSIDevice_Keyboard(SIDevices device, int device_number);
+
+  // Run the SI Buffer
+  int RunBuffer(u8* buffer, int length) override;
+
+  // Return true on new data
+  bool GetData(u32& hi, u32& low) override;
+
+  KeyboardStatus GetKeyboardStatus() const;
+  void MapKeys(const KeyboardStatus& key_status, u8* key);
+
+  // Send a command directly
+  void SendCommand(u32 command, u8 poll) override;
+
+  // Savestate support
+  void DoState(PointerWrap& p) override;
+
 protected:
   // Commands
   enum EBufferCommands
@@ -28,40 +47,21 @@ protected:
 
   union UCommand
   {
-    u32 Hex = 0;
+    u32 hex = 0;
     struct
     {
-      u32 Parameter1 : 8;
-      u32 Parameter2 : 8;
-      u32 Command : 8;
+      u32 parameter1 : 8;
+      u32 parameter2 : 8;
+      u32 command : 8;
       u32 : 8;
     };
     UCommand() = default;
-    UCommand(u32 value) : Hex{value} {}
+    UCommand(u32 value) : hex{value} {}
   };
 
   // PADAnalogMode
-  u8 m_Mode = 0;
+  u8 m_mode = 0;
 
   // Internal counter synchonizing GC and keyboard
-  u8 m_Counter = 0;
-
-public:
-  // Constructor
-  CSIDevice_Keyboard(SIDevices device, int _iDeviceNumber);
-
-  // Run the SI Buffer
-  int RunBuffer(u8* _pBuffer, int _iLength) override;
-
-  // Return true on new data
-  bool GetData(u32& _Hi, u32& _Low) override;
-
-  KeyboardStatus GetKeyboardStatus() const;
-  void MapKeys(const KeyboardStatus& KeyStatus, u8* key);
-
-  // Send a command directly
-  void SendCommand(u32 _Cmd, u8 _Poll) override;
-
-  // Savestate support
-  void DoState(PointerWrap& p) override;
+  u8 m_counter = 0;
 };


### PR DESCRIPTION
Follow-up to #5083. This normalizes variable casing (and drops prefixed underscores) for the rest of the SI device classes.

After this, all that's needed to amend is SI.cpp/SI.h.