### PR TITLE
EXI/SI: Move enum constants into namespaces

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -61,7 +61,7 @@ public:
   bool bSetEmulationSpeed;
   bool bSetVolume;
   std::array<bool, MAX_BBMOTES> bSetWiimoteSource;
-  std::array<bool, MAX_SI_CHANNELS> bSetPads;
+  std::array<bool, SerialInterface::MAX_SI_CHANNELS> bSetPads;
   std::array<bool, MAX_EXI_CHANNELS> bSetEXIDevice;
 
 private:
@@ -92,7 +92,7 @@ private:
   std::string sBackend;
   std::string m_strGPUDeterminismMode;
   std::array<int, MAX_BBMOTES> iWiimoteSource;
-  std::array<SIDevices, MAX_SI_CHANNELS> Pads;
+  std::array<SIDevices, SerialInterface::MAX_SI_CHANNELS> Pads;
   std::array<TEXIDevices, MAX_EXI_CHANNELS> m_EXIDevice;
 };
 
@@ -180,7 +180,7 @@ void ConfigCache::RestoreConfig(SConfig* config)
     config->m_wii_language = m_wii_language;
   }
 
-  for (unsigned int i = 0; i < MAX_SI_CHANNELS; ++i)
+  for (unsigned int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
   {
     if (bSetPads[i])
       config->m_SIDevice[i] = Pads[i];
@@ -279,7 +279,7 @@ bool BootCore(const std::string& _rFilename)
     core_section->Get("Overclock", &StartUp.m_OCFactor, StartUp.m_OCFactor);
     core_section->Get("OverclockEnable", &StartUp.m_OCEnable, StartUp.m_OCEnable);
 
-    for (unsigned int i = 0; i < MAX_SI_CHANNELS; ++i)
+    for (unsigned int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
     {
       int source;
       controls_section->Get(StringFromFormat("PadType%u", i), &source, -1);

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -62,7 +62,7 @@ public:
   bool bSetVolume;
   std::array<bool, MAX_BBMOTES> bSetWiimoteSource;
   std::array<bool, SerialInterface::MAX_SI_CHANNELS> bSetPads;
-  std::array<bool, MAX_EXI_CHANNELS> bSetEXIDevice;
+  std::array<bool, ExpansionInterface::MAX_EXI_CHANNELS> bSetEXIDevice;
 
 private:
   bool valid;
@@ -93,7 +93,7 @@ private:
   std::string m_strGPUDeterminismMode;
   std::array<int, MAX_BBMOTES> iWiimoteSource;
   std::array<SIDevices, SerialInterface::MAX_SI_CHANNELS> Pads;
-  std::array<TEXIDevices, MAX_EXI_CHANNELS> m_EXIDevice;
+  std::array<TEXIDevices, ExpansionInterface::MAX_EXI_CHANNELS> m_EXIDevice;
 };
 
 void ConfigCache::SaveConfig(const SConfig& config)
@@ -189,7 +189,7 @@ void ConfigCache::RestoreConfig(SConfig* config)
   if (bSetEmulationSpeed)
     config->m_EmulationSpeed = m_EmulationSpeed;
 
-  for (unsigned int i = 0; i < MAX_EXI_CHANNELS; ++i)
+  for (unsigned int i = 0; i < ExpansionInterface::MAX_EXI_CHANNELS; ++i)
   {
     if (bSetEXIDevice[i])
       config->m_EXIDevice[i] = m_EXIDevice[i];

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -257,7 +257,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
   core->Set("SlotB", m_EXIDevice[1]);
   core->Set("SerialPort1", m_EXIDevice[2]);
   core->Set("BBA_MAC", m_bba_mac);
-  for (int i = 0; i < MAX_SI_CHANNELS; ++i)
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
   {
     core->Set(StringFromFormat("SIDevice%i", i), m_SIDevice[i]);
     core->Set(StringFromFormat("AdapterRumble%i", i), m_AdapterRumble[i]);
@@ -577,7 +577,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("BBA_MAC", &m_bba_mac);
   core->Get("TimeProfiling", &bJITILTimeProfiling, false);
   core->Get("OutputIR", &bJITILOutputIR, false);
-  for (int i = 0; i < MAX_SI_CHANNELS; ++i)
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
   {
     core->Get(StringFromFormat("SIDevice%i", i), (u32*)&m_SIDevice[i],
               (i == 0) ? SIDEVICE_GC_CONTROLLER : SIDEVICE_NONE);

--- a/Source/Core/Core/HW/EXI/EXI.h
+++ b/Source/Core/Core/HW/EXI/EXI.h
@@ -19,14 +19,14 @@ namespace MMIO
 class Mapping;
 }
 
+namespace ExpansionInterface
+{
 enum
 {
   MAX_MEMORYCARD_SLOTS = 2,
   MAX_EXI_CHANNELS = 3
 };
 
-namespace ExpansionInterface
-{
 void Init();
 void Shutdown();
 void DoState(PointerWrap& p);

--- a/Source/Core/Core/HW/SI/SI.h
+++ b/Source/Core/Core/HW/SI/SI.h
@@ -15,14 +15,14 @@ namespace MMIO
 class Mapping;
 }
 
+namespace SerialInterface
+{
 // SI number of channels
 enum
 {
   MAX_SI_CHANNELS = 0x04
 };
 
-namespace SerialInterface
-{
 void Init();
 void Shutdown();
 void DoState(PointerWrap& p);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -484,14 +484,14 @@ void ChangePads(bool instantly)
 
   int controllers = 0;
 
-  for (int i = 0; i < MAX_SI_CHANNELS; ++i)
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
     if (SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
       controllers |= (1 << i);
 
   if (instantly && (s_controllers & 0x0F) == controllers)
     return;
 
-  for (int i = 0; i < MAX_SI_CHANNELS; ++i)
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
   {
     SIDevices device = SIDEVICE_NONE;
     if (IsUsingPad(i))
@@ -563,7 +563,7 @@ bool BeginRecordingInput(int controllers)
 
   s_rerecords = 0;
 
-  for (int i = 0; i < MAX_SI_CHANNELS; ++i)
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
     if (SConfig::GetInstance().m_SIDevice[i] == SIDEVICE_GC_TARUKONGA)
       s_bongos |= (1 << i);
 

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -31,7 +31,7 @@ static void Setup();
 
 static bool s_detected = false;
 static libusb_device_handle* s_handle = nullptr;
-static u8 s_controller_type[MAX_SI_CHANNELS] = {
+static u8 s_controller_type[SerialInterface::MAX_SI_CHANNELS] = {
     ControllerTypes::CONTROLLER_NONE, ControllerTypes::CONTROLLER_NONE,
     ControllerTypes::CONTROLLER_NONE, ControllerTypes::CONTROLLER_NONE};
 static u8 s_controller_rumble[4];
@@ -199,7 +199,7 @@ static void Setup()
   libusb_device** list;
   ssize_t cnt = libusb_get_device_list(s_libusb_context.get(), &list);
 
-  for (int i = 0; i < MAX_SI_CHANNELS; i++)
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; i++)
   {
     s_controller_type[i] = ControllerTypes::CONTROLLER_NONE;
     s_controller_rumble[i] = 0;
@@ -350,7 +350,7 @@ static void Reset()
     s_adapter_thread.join();
   }
 
-  for (int i = 0; i < MAX_SI_CHANNELS; i++)
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; i++)
     s_controller_type[i] = ControllerTypes::CONTROLLER_NONE;
 
   s_detected = false;

--- a/Source/Core/InputCommon/GCAdapter_Android.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Android.cpp
@@ -33,7 +33,7 @@ static jclass s_adapter_class;
 
 static bool s_detected = false;
 static int s_fd = 0;
-static u8 s_controller_type[MAX_SI_CHANNELS] = {
+static u8 s_controller_type[SerialInterface::MAX_SI_CHANNELS] = {
     ControllerTypes::CONTROLLER_NONE, ControllerTypes::CONTROLLER_NONE,
     ControllerTypes::CONTROLLER_NONE, ControllerTypes::CONTROLLER_NONE};
 static u8 s_controller_rumble[4];
@@ -234,7 +234,7 @@ static void Reset()
   if (s_read_adapter_thread_running.TestAndClear())
     s_read_adapter_thread.join();
 
-  for (int i = 0; i < MAX_SI_CHANNELS; i++)
+  for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; i++)
     s_controller_type[i] = ControllerTypes::CONTROLLER_NONE;
 
   s_detected = false;


### PR DESCRIPTION
I was going to extend the `SerialInterface` and `ExpansionInterface` to include their related device classes (they're currently in the global namespace), but then I noticed these constants sitting outside of them. This just gets the trivial stuff out of the way beforehand.