### PR TITLE
SI: Namespace device classes

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -92,7 +92,7 @@ private:
   std::string sBackend;
   std::string m_strGPUDeterminismMode;
   std::array<int, MAX_BBMOTES> iWiimoteSource;
-  std::array<SIDevices, SerialInterface::MAX_SI_CHANNELS> Pads;
+  std::array<SerialInterface::SIDevices, SerialInterface::MAX_SI_CHANNELS> Pads;
   std::array<TEXIDevices, ExpansionInterface::MAX_EXI_CHANNELS> m_EXIDevice;
 };
 
@@ -283,9 +283,9 @@ bool BootCore(const std::string& _rFilename)
     {
       int source;
       controls_section->Get(StringFromFormat("PadType%u", i), &source, -1);
-      if (source >= SIDEVICE_NONE && source < SIDEVICE_COUNT)
+      if (source >= SerialInterface::SIDEVICE_NONE && source < SerialInterface::SIDEVICE_COUNT)
       {
-        StartUp.m_SIDevice[i] = static_cast<SIDevices>(source);
+        StartUp.m_SIDevice[i] = static_cast<SerialInterface::SIDevices>(source);
         config_cache.bSetPads[i] = true;
       }
     }

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -580,7 +580,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
   {
     core->Get(StringFromFormat("SIDevice%i", i), (u32*)&m_SIDevice[i],
-              (i == 0) ? SIDEVICE_GC_CONTROLLER : SIDEVICE_NONE);
+              (i == 0) ? SerialInterface::SIDEVICE_GC_CONTROLLER : SerialInterface::SIDEVICE_NONE);
     core->Get(StringFromFormat("AdapterRumble%i", i), &m_AdapterRumble[i], true);
     core->Get(StringFromFormat("SimulateKonga%i", i), &m_AdapterKonga[i], false);
   }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -252,7 +252,7 @@ struct SConfig : NonCopyable
   std::string m_strGbaCartA;
   std::string m_strGbaCartB;
   TEXIDevices m_EXIDevice[3];
-  SIDevices m_SIDevice[4];
+  SerialInterface::SIDevices m_SIDevice[4];
   std::string m_bba_mac;
 
   // interface language

--- a/Source/Core/Core/HW/SI/SI.h
+++ b/Source/Core/Core/HW/SI/SI.h
@@ -8,8 +8,7 @@
 #include "Common/CommonTypes.h"
 
 class PointerWrap;
-class ISIDevice;
-enum SIDevices : int;
+
 namespace MMIO
 {
 class Mapping;
@@ -17,6 +16,9 @@ class Mapping;
 
 namespace SerialInterface
 {
+class ISIDevice;
+enum SIDevices : int;
+
 // SI number of channels
 enum
 {

--- a/Source/Core/Core/HW/SI/SI_Device.cpp
+++ b/Source/Core/Core/HW/SI/SI_Device.cpp
@@ -18,6 +18,8 @@
 #include "Core/HW/SI/SI_DeviceKeyboard.h"
 #include "Core/HW/SI/SI_DeviceNull.h"
 
+namespace SerialInterface
+{
 ISIDevice::ISIDevice(SIDevices device_type, int device_number)
     : m_device_number(device_number), m_device_type(device_type)
 {
@@ -120,3 +122,4 @@ std::unique_ptr<ISIDevice> SIDevice_Create(const SIDevices device, const int por
     return std::make_unique<CSIDevice_Null>(device, port_number);
   }
 }
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_Device.h
+++ b/Source/Core/Core/HW/SI/SI_Device.h
@@ -9,6 +9,8 @@
 
 class PointerWrap;
 
+namespace SerialInterface
+{
 // Devices can reply with these
 enum
 {
@@ -100,3 +102,4 @@ protected:
 bool SIDevice_IsGCController(SIDevices type);
 
 std::unique_ptr<ISIDevice> SIDevice_Create(SIDevices device, int port_number);
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
@@ -7,6 +7,8 @@
 #include "Common/CommonTypes.h"
 #include "InputCommon/GCPadStatus.h"
 
+namespace SerialInterface
+{
 CSIDevice_DanceMat::CSIDevice_DanceMat(SIDevices device, int device_number)
     : CSIDevice_GCController(device, device_number)
 {
@@ -68,3 +70,4 @@ bool CSIDevice_DanceMat::GetData(u32& hi, u32& low)
 
   return true;
 }
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.h
@@ -9,6 +9,8 @@
 
 struct GCPadStatus;
 
+namespace SerialInterface
+{
 class CSIDevice_DanceMat : public CSIDevice_GCController
 {
 public:
@@ -18,3 +20,4 @@ public:
   u32 MapPadStatus(const GCPadStatus& pad_status) override;
   bool GetData(u32& hi, u32& low) override;
 };
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.cpp
@@ -20,6 +20,8 @@
 #include "Core/HW/SI/SI_Device.h"
 #include "Core/HW/SystemTimers.h"
 
+namespace SerialInterface
+{
 namespace
 {
 std::thread s_connection_thread;
@@ -375,3 +377,4 @@ bool CSIDevice_GBA::GetData(u32& hi, u32& low)
 void CSIDevice_GBA::SendCommand(u32 command, u8 poll)
 {
 }
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGBA.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGBA.h
@@ -14,6 +14,8 @@
 
 // GameBoy Advance "Link Cable"
 
+namespace SerialInterface
+{
 u8 GetNumConnected();
 int GetTransferTime(u8 cmd);
 void GBAConnectionWaiter_Shutdown();
@@ -61,3 +63,4 @@ private:
   u64 m_timestamp_sent = 0;
   bool m_waiting_for_response = false;
 };
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -15,6 +15,8 @@
 #include "Core/NetPlayProto.h"
 #include "InputCommon/GCAdapter.h"
 
+namespace SerialInterface
+{
 CSIDevice_GCAdapter::CSIDevice_GCAdapter(SIDevices device, int device_number)
     : CSIDevice_GCController(device, device_number)
 {
@@ -68,3 +70,4 @@ void CSIDevice_GCController::Rumble(int pad_num, ControlState strength)
   else if (SIDevice_IsGCController(device))
     Pad::Rumble(pad_num, strength);
 }
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.h
@@ -8,6 +8,8 @@
 #include "Core/HW/SI/SI_DeviceGCController.h"
 #include "InputCommon/GCPadStatus.h"
 
+namespace SerialInterface
+{
 class CSIDevice_GCAdapter : public CSIDevice_GCController
 {
 public:
@@ -16,3 +18,4 @@ public:
   GCPadStatus GetPadStatus() override;
   int RunBuffer(u8* buffer, int length) override;
 };
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -17,6 +17,8 @@
 #include "Core/NetPlayProto.h"
 #include "InputCommon/GCPadStatus.h"
 
+namespace SerialInterface
+{
 // --- standard GameCube controller ---
 CSIDevice_GCController::CSIDevice_GCController(SIDevices device, int device_number)
     : ISIDevice(device, device_number)
@@ -327,3 +329,4 @@ void CSIDevice_GCController::DoState(PointerWrap& p)
   p.Do(m_timer_button_combo);
   p.Do(m_last_button_combo);
 }
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.h
@@ -8,6 +8,8 @@
 #include "Core/HW/SI/SI_Device.h"
 #include "InputCommon/GCPadStatus.h"
 
+namespace SerialInterface
+{
 class CSIDevice_GCController : public ISIDevice
 {
 protected:
@@ -126,3 +128,4 @@ public:
     m_simulate_konga = true;
   }
 };
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
@@ -8,6 +8,8 @@
 #include "Common/Logging/Log.h"
 #include "Core/HW/GCPad.h"
 
+namespace SerialInterface
+{
 CSIDevice_GCSteeringWheel::CSIDevice_GCSteeringWheel(SIDevices device, int device_number)
     : CSIDevice_GCController(device, device_number)
 {
@@ -111,3 +113,4 @@ void CSIDevice_GCSteeringWheel::SendCommand(u32 command, u8 poll)
     return CSIDevice_GCController::SendCommand(command, poll);
   }
 }
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.h
@@ -6,6 +6,8 @@
 
 #include "Core/HW/SI/SI_DeviceGCController.h"
 
+namespace SerialInterface
+{
 class CSIDevice_GCSteeringWheel : public CSIDevice_GCController
 {
 public:
@@ -31,3 +33,4 @@ private:
     CMD_WRITE = 0x40
   };
 };
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
@@ -10,6 +10,8 @@
 #include "Core/HW/GCKeyboard.h"
 #include "InputCommon/KeyboardStatus.h"
 
+namespace SerialInterface
+{
 // --- GameCube keyboard ---
 CSIDevice_Keyboard::CSIDevice_Keyboard(SIDevices device, int device_number)
     : ISIDevice(device, device_number)
@@ -617,3 +619,4 @@ void CSIDevice_Keyboard::MapKeys(const KeyboardStatus& key_status, u8* key)
       return;
   }
 }
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.h
@@ -9,6 +9,8 @@
 class PointerWrap;
 struct KeyboardStatus;
 
+namespace SerialInterface
+{
 class CSIDevice_Keyboard : public ISIDevice
 {
 public:
@@ -65,3 +67,4 @@ protected:
   // Internal counter synchonizing GC and keyboard
   u8 m_counter = 0;
 };
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.cpp
@@ -6,6 +6,8 @@
 
 #include <cstring>
 
+namespace SerialInterface
+{
 CSIDevice_Null::CSIDevice_Null(SIDevices device, int device_number)
     : ISIDevice{device, device_number}
 {
@@ -27,3 +29,4 @@ bool CSIDevice_Null::GetData(u32& hi, u32& low)
 void CSIDevice_Null::SendCommand(u32 command, u8 poll)
 {
 }
+}  // namespace SerialInterface

--- a/Source/Core/Core/HW/SI/SI_DeviceNull.h
+++ b/Source/Core/Core/HW/SI/SI_DeviceNull.h
@@ -7,6 +7,8 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/SI/SI_Device.h"
 
+namespace SerialInterface
+{
 // Stub class for saying nothing is attached, and not having to deal with null pointers :)
 class CSIDevice_Null final : public ISIDevice
 {
@@ -17,3 +19,4 @@ public:
   bool GetData(u32& hi, u32& low) override;
   void SendCommand(u32 command, u8 poll) override;
 };
+}  // namespace SerialInterface

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -158,7 +158,7 @@ std::string GetInputDisplay()
     s_controllers = 0;
     for (int i = 0; i < 4; ++i)
     {
-      if (SerialInterface::GetDeviceType(i) != SIDEVICE_NONE)
+      if (SerialInterface::GetDeviceType(i) != SerialInterface::SIDEVICE_NONE)
         s_controllers |= (1 << i);
       if (g_wiimote_sources[i] != WIIMOTE_SRC_NONE)
         s_controllers |= (1 << (i + 4));
@@ -485,21 +485,28 @@ void ChangePads(bool instantly)
   int controllers = 0;
 
   for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
-    if (SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
+  {
+    if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
       controllers |= (1 << i);
+  }
 
   if (instantly && (s_controllers & 0x0F) == controllers)
     return;
 
   for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
   {
-    SIDevices device = SIDEVICE_NONE;
+    SerialInterface::SIDevices device = SerialInterface::SIDEVICE_NONE;
     if (IsUsingPad(i))
     {
-      if (SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
+      if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
+      {
         device = SConfig::GetInstance().m_SIDevice[i];
+      }
       else
-        device = IsUsingBongo(i) ? SIDEVICE_GC_TARUKONGA : SIDEVICE_GC_CONTROLLER;
+      {
+        device = IsUsingBongo(i) ? SerialInterface::SIDEVICE_GC_TARUKONGA :
+                                   SerialInterface::SIDEVICE_GC_CONTROLLER;
+      }
     }
 
     if (instantly)  // Changes from savestates need to be instantaneous
@@ -564,8 +571,10 @@ bool BeginRecordingInput(int controllers)
   s_rerecords = 0;
 
   for (int i = 0; i < SerialInterface::MAX_SI_CHANNELS; ++i)
-    if (SConfig::GetInstance().m_SIDevice[i] == SIDEVICE_GC_TARUKONGA)
+  {
+    if (SConfig::GetInstance().m_SIDevice[i] == SerialInterface::SIDEVICE_GC_TARUKONGA)
       s_bongos |= (1 << i);
+  }
 
   if (Core::IsRunningAndStarted())
   {

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -851,23 +851,23 @@ void NetPlayClient::UpdateDevices()
     // exotic devices are not supported on netplay.
     if (player_id == m_local_player->pid)
     {
-      if (SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[local_pad]))
+      if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[local_pad]))
       {
         SerialInterface::AddDevice(SConfig::GetInstance().m_SIDevice[local_pad], pad);
       }
       else
       {
-        SerialInterface::AddDevice(SIDEVICE_GC_CONTROLLER, pad);
+        SerialInterface::AddDevice(SerialInterface::SIDEVICE_GC_CONTROLLER, pad);
       }
       local_pad++;
     }
     else if (player_id > 0)
     {
-      SerialInterface::AddDevice(SIDEVICE_GC_CONTROLLER, pad);
+      SerialInterface::AddDevice(SerialInterface::SIDEVICE_GC_CONTROLLER, pad);
     }
     else
     {
-      SerialInterface::AddDevice(SIDEVICE_NONE, pad);
+      SerialInterface::AddDevice(SerialInterface::SIDEVICE_NONE, pad);
     }
     pad++;
   }
@@ -967,10 +967,10 @@ bool NetPlayClient::GetNetPads(const int pad_nb, GCPadStatus* pad_status)
     {
       switch (SConfig::GetInstance().m_SIDevice[local_pad])
       {
-      case SIDEVICE_WIIU_ADAPTER:
+      case SerialInterface::SIDEVICE_WIIU_ADAPTER:
         *pad_status = GCAdapter::Input(local_pad);
         break;
-      case SIDEVICE_GC_CONTROLLER:
+      case SerialInterface::SIDEVICE_GC_CONTROLLER:
       default:
         *pad_status = Pad::GetStatus(local_pad);
         break;
@@ -1255,7 +1255,7 @@ void NetPlayClient::ComputeMD5(const std::string& file_identifier)
 
 // called from ---CPU--- thread
 // Actual Core function which is called on every frame
-bool CSIDevice_GCController::NetPlay_GetInput(int numPAD, GCPadStatus* PadStatus)
+bool SerialInterface::CSIDevice_GCController::NetPlay_GetInput(int numPAD, GCPadStatus* PadStatus)
 {
   std::lock_guard<std::mutex> lk(crit_netplay_client);
 
@@ -1291,7 +1291,7 @@ u64 CEXIIPL::NetPlay_GetEmulatedTime()
 
 // called from ---CPU--- thread
 // return the local pad num that should rumble given a ingame pad num
-int CSIDevice_GCController::NetPlay_InGamePadToLocalPad(int numPAD)
+int SerialInterface::CSIDevice_GCController::NetPlay_InGamePadToLocalPad(int numPAD)
 {
   std::lock_guard<std::mutex> lk(crit_netplay_client);
 

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -183,26 +183,26 @@ wxSizer* ControllerConfigDiag::CreateGamecubeSizer()
     // Set the saved pad type as the default choice.
     switch (SConfig::GetInstance().m_SIDevice[i])
     {
-    case SIDEVICE_GC_CONTROLLER:
+    case SerialInterface::SIDEVICE_GC_CONTROLLER:
       pad_type_choices[i]->SetStringSelection(m_gc_pad_type_strs[1]);
       break;
-    case SIDEVICE_WIIU_ADAPTER:
+    case SerialInterface::SIDEVICE_WIIU_ADAPTER:
       pad_type_choices[i]->SetStringSelection(m_gc_pad_type_strs[2]);
       break;
-    case SIDEVICE_GC_STEERING:
+    case SerialInterface::SIDEVICE_GC_STEERING:
       pad_type_choices[i]->SetStringSelection(m_gc_pad_type_strs[3]);
       break;
-    case SIDEVICE_DANCEMAT:
+    case SerialInterface::SIDEVICE_DANCEMAT:
       pad_type_choices[i]->SetStringSelection(m_gc_pad_type_strs[4]);
       break;
-    case SIDEVICE_GC_TARUKONGA:
+    case SerialInterface::SIDEVICE_GC_TARUKONGA:
       pad_type_choices[i]->SetStringSelection(m_gc_pad_type_strs[5]);
       break;
-    case SIDEVICE_GC_GBA:
+    case SerialInterface::SIDEVICE_GC_GBA:
       pad_type_choices[i]->SetStringSelection(m_gc_pad_type_strs[6]);
       m_gc_port_configure_button[i]->Disable();
       break;
-    case SIDEVICE_GC_KEYBOARD:
+    case SerialInterface::SIDEVICE_GC_KEYBOARD:
       pad_type_choices[i]->SetStringSelection(m_gc_pad_type_strs[7]);
       break;
     default:
@@ -387,45 +387,45 @@ void ControllerConfigDiag::OnGameCubePortChanged(wxCommandEvent& event)
   const unsigned int device_num = m_gc_port_from_choice_id[event.GetId()];
   const wxString device_name = event.GetString();
 
-  SIDevices tempType;
+  SerialInterface::SIDevices tempType;
   if (device_name == m_gc_pad_type_strs[1])
   {
-    tempType = SIDEVICE_GC_CONTROLLER;
+    tempType = SerialInterface::SIDEVICE_GC_CONTROLLER;
     m_gc_port_configure_button[device_num]->Enable();
   }
   else if (device_name == m_gc_pad_type_strs[2])
   {
-    tempType = SIDEVICE_WIIU_ADAPTER;
+    tempType = SerialInterface::SIDEVICE_WIIU_ADAPTER;
     m_gc_port_configure_button[device_num]->Enable();
   }
   else if (device_name == m_gc_pad_type_strs[3])
   {
-    tempType = SIDEVICE_GC_STEERING;
+    tempType = SerialInterface::SIDEVICE_GC_STEERING;
     m_gc_port_configure_button[device_num]->Enable();
   }
   else if (device_name == m_gc_pad_type_strs[4])
   {
-    tempType = SIDEVICE_DANCEMAT;
+    tempType = SerialInterface::SIDEVICE_DANCEMAT;
     m_gc_port_configure_button[device_num]->Enable();
   }
   else if (device_name == m_gc_pad_type_strs[5])
   {
-    tempType = SIDEVICE_GC_TARUKONGA;
+    tempType = SerialInterface::SIDEVICE_GC_TARUKONGA;
     m_gc_port_configure_button[device_num]->Enable();
   }
   else if (device_name == m_gc_pad_type_strs[6])
   {
-    tempType = SIDEVICE_GC_GBA;
+    tempType = SerialInterface::SIDEVICE_GC_GBA;
     m_gc_port_configure_button[device_num]->Disable();
   }
   else if (device_name == m_gc_pad_type_strs[7])
   {
-    tempType = SIDEVICE_GC_KEYBOARD;
+    tempType = SerialInterface::SIDEVICE_GC_KEYBOARD;
     m_gc_port_configure_button[device_num]->Enable();
   }
   else
   {
-    tempType = SIDEVICE_NONE;
+    tempType = SerialInterface::SIDEVICE_NONE;
     m_gc_port_configure_button[device_num]->Disable();
   }
 
@@ -445,17 +445,18 @@ void ControllerConfigDiag::OnGameCubeConfigButton(wxCommandEvent& event)
   InputConfig* const pad_plugin = Pad::GetConfig();
   InputConfig* const key_plugin = Keyboard::GetConfig();
   const int port_num = m_gc_port_from_config_id[event.GetId()];
+  const auto device_type = SConfig::GetInstance().m_SIDevice[port_num];
 
   HotkeyManagerEmu::Enable(false);
 
-  if (SConfig::GetInstance().m_SIDevice[port_num] == SIDEVICE_GC_KEYBOARD)
+  if (device_type == SerialInterface::SIDEVICE_GC_KEYBOARD)
   {
     GCKeyboardInputConfigDialog config_diag(
         this, *key_plugin,
         wxString::Format(_("GameCube Keyboard Configuration Port %i"), port_num + 1), port_num);
     config_diag.ShowModal();
   }
-  else if (SConfig::GetInstance().m_SIDevice[port_num] == SIDEVICE_WIIU_ADAPTER)
+  else if (device_type == SerialInterface::SIDEVICE_WIIU_ADAPTER)
   {
     GCAdapterConfigDiag config_diag(
         this, wxString::Format(_("Wii U GameCube Controller Adapter Configuration Port %i"),

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -371,8 +371,8 @@ void CFrame::OnTASInput(wxCommandEvent& event)
 {
   for (int i = 0; i < 4; ++i)
   {
-    if (SConfig::GetInstance().m_SIDevice[i] != SIDEVICE_NONE &&
-        SConfig::GetInstance().m_SIDevice[i] != SIDEVICE_GC_GBA)
+    if (SConfig::GetInstance().m_SIDevice[i] != SerialInterface::SIDEVICE_NONE &&
+        SConfig::GetInstance().m_SIDevice[i] != SerialInterface::SIDEVICE_GC_GBA)
     {
       g_TASInputDlg[i]->CreateGCLayout();
       g_TASInputDlg[i]->Show();
@@ -464,7 +464,7 @@ void CFrame::OnRecord(wxCommandEvent& WXUNUSED(event))
 
   for (int i = 0; i < 4; i++)
   {
-    if (SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
+    if (SerialInterface::SIDevice_IsGCController(SConfig::GetInstance().m_SIDevice[i]))
       controllers |= (1 << i);
 
     if (g_wiimote_sources[i] != WIIMOTE_SRC_NONE)

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -467,10 +467,11 @@ bool DeviceConnected(int chan)
 
 bool UseAdapter()
 {
-  return SConfig::GetInstance().m_SIDevice[0] == SIDEVICE_WIIU_ADAPTER ||
-         SConfig::GetInstance().m_SIDevice[1] == SIDEVICE_WIIU_ADAPTER ||
-         SConfig::GetInstance().m_SIDevice[2] == SIDEVICE_WIIU_ADAPTER ||
-         SConfig::GetInstance().m_SIDevice[3] == SIDEVICE_WIIU_ADAPTER;
+  const auto& si_devices = SConfig::GetInstance().m_SIDevice;
+
+  return std::any_of(std::begin(si_devices), std::end(si_devices), [](const auto device_type) {
+    return device_type == SerialInterface::SIDEVICE_WIIU_ADAPTER;
+  });
 }
 
 void ResetRumble()

--- a/Source/Core/InputCommon/GCAdapter_Android.cpp
+++ b/Source/Core/InputCommon/GCAdapter_Android.cpp
@@ -385,10 +385,11 @@ bool DeviceConnected(int chan)
 
 bool UseAdapter()
 {
-  return SConfig::GetInstance().m_SIDevice[0] == SIDEVICE_WIIU_ADAPTER ||
-         SConfig::GetInstance().m_SIDevice[1] == SIDEVICE_WIIU_ADAPTER ||
-         SConfig::GetInstance().m_SIDevice[2] == SIDEVICE_WIIU_ADAPTER ||
-         SConfig::GetInstance().m_SIDevice[3] == SIDEVICE_WIIU_ADAPTER;
+  const auto& si_devices = SConfig::GetInstance().m_SIDevice;
+
+  return std::any_of(std::begin(si_devices), std::end(si_devices), [](const auto device_type) {
+    return device_type == SerialInterface::SIDEVICE_WIIU_ADAPTER;
+  });
 }
 
 void ResetRumble()


### PR DESCRIPTION
Places all of the SI code under the SerialInterface namespace instead of only the main source file. This keeps all SI code under a common name, as well as out of the global namespace. This will also allow for a follow-up where `CSIDevice_` prefixes can be dropped from the class names.