### PR TITLE
Use 6-char game IDs for NAND tiles (if they are printable)

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -766,8 +766,7 @@ void SConfig::SetRunningGameMetadata(const IOS::ES::TMDReader& tmd)
   }
 
   // If not launching a disc game, just read everything from the TMD.
-  SetRunningGameMetadata(StringFromFormat("%016" PRIX64, tmd_title_id), tmd_title_id,
-                         tmd.GetTitleVersion());
+  SetRunningGameMetadata(tmd.GetGameID(), tmd_title_id, tmd.GetTitleVersion());
 }
 
 void SConfig::SetRunningGameMetadata(const std::string& game_id, u64 title_id, u16 revision)

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <array>
+#include <string>
 #include <vector>
 
 #include "Common/ChunkFile.h"
@@ -141,6 +142,11 @@ public:
   u64 GetTitleId() const;
   u16 GetTitleVersion() const;
   u16 GetGroupId() const;
+
+  // Constructs a 6-character game ID in the format typically used by Dolphin.
+  // If the 6-character game ID would contain unprintable characters,
+  // the title ID converted to hexadecimal is returned instead.
+  std::string GetGameID() const;
 
   u16 GetNumContents() const;
   bool GetContent(u16 index, Content* content) const;

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <locale>
 #include <map>
 #include <memory>
 #include <string>
@@ -89,22 +90,18 @@ IOS::ES::TMDReader CVolumeWAD::GetTMD() const
 
 std::string CVolumeWAD::GetGameID() const
 {
-  char GameCode[6];
-  if (!Read(m_offset + 0x01E0, 4, (u8*)GameCode))
-    return "0";
-
-  std::string temp = GetMakerID();
-  GameCode[4] = temp.at(0);
-  GameCode[5] = temp.at(1);
-
-  return DecodeString(GameCode);
+  return m_tmd.GetGameID();
 }
 
 std::string CVolumeWAD::GetMakerID() const
 {
-  char temp[2] = {1};
-  // Some weird channels use 0x0000 in place of the MakerID, so we need a check there
-  if (!Read(0x198 + m_tmd_offset, 2, (u8*)temp) || temp[0] == 0 || temp[1] == 0)
+  char temp[2];
+  if (!Read(0x198 + m_tmd_offset, 2, (u8*)temp))
+    return "00";
+
+  // Some weird channels use 0x0000 in place of the MakerID, so we need a check here
+  const std::locale& c_locale = std::locale::classic();
+  if (!std::isprint(temp[0], c_locale) || !std::isprint(temp[1], c_locale))
     return "00";
 
   return DecodeString(temp);


### PR DESCRIPTION
PR #4981 made ES's code for setting the game ID use the title ID converted to hex (except for disc titles) instead of using a 6-char game ID like before. Then,PR #5045 made us use that code even when loading game INIs. This breaks the expectations of both users and the game INIs we ship with.

This commit makes Dolphin use 6-char game IDs for all titles (unless the 6-char ID would contain unprintable characters, which is the case with e.g. the Wii Menu).

I'm also putting unprintability checks in VolumeWad for consistency.