### PR TITLE
Display nicer version strings for the Wii Menu

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -118,7 +118,7 @@ u64 TMDReader::GetIOSId() const
 DiscIO::Region TMDReader::GetRegion() const
 {
   if (GetTitleId() == 0x0000000100000002)
-    return DiscIO::RegionSwitchWii(DiscIO::GetSysMenuRegion(GetTitleVersion()));
+    return DiscIO::GetSysMenuRegion(GetTitleVersion());
 
   return DiscIO::RegionSwitchWii(static_cast<u8>(GetTitleId() & 0xff));
 }

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -126,6 +126,9 @@ Country CountrySwitch(u8 country_code)
 
 u8 GetSysMenuRegion(u16 title_version)
 {
+  if (title_version == 33)
+    return 'A';  // 1.0 uses 33 as the version number in all regions
+
   switch (title_version & 0xf)
   {
   case 0:

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -18,6 +18,23 @@ bool IsNTSC(Region region)
 
 // Increment CACHE_REVISION (ISOFile.cpp & GameFile.cpp) if the code below is modified
 
+Country TypicalCountryForRegion(Region region)
+{
+  switch (region)
+  {
+  case Region::NTSC_J:
+    return Country::COUNTRY_JAPAN;
+  case Region::NTSC_U:
+    return Country::COUNTRY_USA;
+  case Region::PAL:
+    return Country::COUNTRY_EUROPE;
+  case Region::NTSC_K:
+    return Country::COUNTRY_KOREA;
+  default:
+    return Country::COUNTRY_UNKNOWN;
+  }
+}
+
 Region RegionSwitchGC(u8 country_code)
 {
   Region region = RegionSwitchWii(country_code);
@@ -124,23 +141,23 @@ Country CountrySwitch(u8 country_code)
   }
 }
 
-u8 GetSysMenuRegion(u16 title_version)
+Region GetSysMenuRegion(u16 title_version)
 {
   if (title_version == 33)
-    return 'A';  // 1.0 uses 33 as the version number in all regions
+    return Region::UNKNOWN_REGION;  // 1.0 uses 33 as the version number in all regions
 
   switch (title_version & 0xf)
   {
   case 0:
-    return 'J';
+    return Region::NTSC_J;
   case 1:
-    return 'E';
+    return Region::NTSC_U;
   case 2:
-    return 'P';
+    return Region::PAL;
   case 6:
-    return 'K';
+    return Region::NTSC_K;
   default:
-    return 'A';
+    return Region::UNKNOWN_REGION;
   }
 }
 
@@ -153,16 +170,16 @@ std::string GetSysMenuVersionString(u16 title_version)
 
   switch (GetSysMenuRegion(title_version))
   {
-  case 'J':
+  case Region::NTSC_J:
     region_letter = "J";
     break;
-  case 'E':
+  case Region::NTSC_U:
     region_letter = "U";
     break;
-  case 'P':
+  case Region::PAL:
     region_letter = "E";
     break;
-  case 'K':
+  case Region::NTSC_K:
     region_letter = "K";
     break;
   }

--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -141,6 +141,62 @@ u8 GetSysMenuRegion(u16 title_version)
   }
 }
 
+std::string GetSysMenuVersionString(u16 title_version)
+{
+  if (title_version == 33)
+    return "1.0";  // 1.0 uses 33 as the version number in all regions
+
+  std::string region_letter;
+
+  switch (GetSysMenuRegion(title_version))
+  {
+  case 'J':
+    region_letter = "J";
+    break;
+  case 'E':
+    region_letter = "U";
+    break;
+  case 'P':
+    region_letter = "E";
+    break;
+  case 'K':
+    region_letter = "K";
+    break;
+  }
+
+  switch (title_version & ~0xf)
+  {
+  case 96:
+  case 128:
+    return "2.0" + region_letter;
+  case 160:
+    return "2.1" + region_letter;
+  case 192:
+    return "2.2" + region_letter;
+  case 224:
+    return "3.0" + region_letter;
+  case 256:
+    return "3.1" + region_letter;
+  case 288:
+    return "3.2" + region_letter;
+  case 320:
+  case 352:
+    return "3.3" + region_letter;
+  case 384:
+    return (region_letter != "K" ? "3.4" : "3.5") + region_letter;
+  case 416:
+    return "4.0" + region_letter;
+  case 448:
+    return "4.1" + region_letter;
+  case 480:
+    return "4.2" + region_letter;
+  case 512:
+    return "4.3" + region_letter;
+  default:
+    return "?.?" + region_letter;
+  }
+}
+
 std::string GetCompanyFromID(const std::string& company_id)
 {
   static const std::map<std::string, std::string> companies = {

--- a/Source/Core/DiscIO/Enums.h
+++ b/Source/Core/DiscIO/Enums.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "Common/CommonTypes.h"
 
 namespace DiscIO
@@ -71,5 +73,6 @@ Region RegionSwitchGC(u8 country_code);
 Region RegionSwitchWii(u8 country_code);
 Country CountrySwitch(u8 country_code);
 u8 GetSysMenuRegion(u16 title_version);
+std::string GetSysMenuVersionString(u16 title_version);
 std::string GetCompanyFromID(const std::string& company_id);
 }

--- a/Source/Core/DiscIO/Enums.h
+++ b/Source/Core/DiscIO/Enums.h
@@ -69,10 +69,11 @@ enum class Language
 };
 
 bool IsNTSC(Region region);
+Country TypicalCountryForRegion(Region region);
 Region RegionSwitchGC(u8 country_code);
 Region RegionSwitchWii(u8 country_code);
 Country CountrySwitch(u8 country_code);
-u8 GetSysMenuRegion(u16 title_version);
+Region GetSysMenuRegion(u16 title_version);
 std::string GetSysMenuVersionString(u16 title_version);
 std::string GetCompanyFromID(const std::string& company_id);
 }

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -77,7 +77,7 @@ Country CVolumeWAD::GetCountry() const
 
   u8 country_code = static_cast<u8>(m_tmd.GetTitleId() & 0xff);
   if (country_code == 2)  // SYSMENU
-    country_code = GetSysMenuRegion(m_tmd.GetTitleVersion());
+    return TypicalCountryForRegion(GetSysMenuRegion(m_tmd.GetTitleVersion()));
 
   return CountrySwitch(country_code);
 }

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -174,22 +174,10 @@ Country CVolumeWiiCrypted::GetCountry() const
 
   const Region region = GetRegion();
 
-  if (RegionSwitchWii(country_byte) == region)
-    return CountrySwitch(country_byte);
+  if (RegionSwitchWii(country_byte) != region)
+    return TypicalCountryForRegion(region);
 
-  switch (region)
-  {
-  case Region::NTSC_J:
-    return Country::COUNTRY_JAPAN;
-  case Region::NTSC_U:
-    return Country::COUNTRY_USA;
-  case Region::PAL:
-    return Country::COUNTRY_EUROPE;
-  case Region::NTSC_K:
-    return Country::COUNTRY_KOREA;
-  default:
-    return Country::COUNTRY_UNKNOWN;
-  }
+  return CountrySwitch(country_byte);
 }
 
 std::string CVolumeWiiCrypted::GetMakerID() const

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -545,11 +545,10 @@ void MainMenuBar::RefreshWiiSystemMenuLabel() const
 
   if (sys_menu_loader.IsValid())
   {
-    const u16 sys_menu_version = sys_menu_loader.GetTMD().GetTitleVersion();
-    const char sys_menu_region = DiscIO::GetSysMenuRegion(sys_menu_version);
+    const u16 version_number = sys_menu_loader.GetTMD().GetTitleVersion();
+    const wxString version_string = StrToWxStr(DiscIO::GetSysMenuVersionString(version_number));
     item->Enable();
-    item->SetItemLabel(
-        wxString::Format(_("Load Wii System Menu %u%c"), sys_menu_version, sys_menu_region));
+    item->SetItemLabel(wxString::Format(_("Load Wii System Menu %s"), version_string));
   }
   else
   {


### PR DESCRIPTION
The Tools > Load System Menu option displays the version of the installed Wii Menu. The first commit of this PR changes the way we display that version, like so: "Load System Menu 514P" -> "Load System Menu 4.3E"

The numbers used in the code are from http://wiibrew.org/wiki/System_Menu.

The second commit fixes a minor related regression, and the third commit contains cleanup that only could be done after the first commit.