### PR TITLE
OGL: Fix texture_type checks in FrameBufferManager::CreateTexture

### DIFF
--- a/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/OGL/FramebufferManager.cpp
@@ -63,7 +63,7 @@ GLuint FramebufferManager::CreateTexture(GLenum texture_type, GLenum internal_fo
     glTexImage3D(texture_type, 0, internal_format, m_targetWidth, m_targetHeight, m_EFBLayers, 0,
                  pixel_format, data_type, nullptr);
   }
-  else if (texture == GL_TEXTURE_2D_MULTISAMPLE_ARRAY)
+  else if (texture_type == GL_TEXTURE_2D_MULTISAMPLE_ARRAY)
   {
     if (g_ogl_config.bSupports3DTextureStorage)
       glTexStorage3DMultisample(texture_type, m_msaaSamples, internal_format, m_targetWidth,
@@ -72,7 +72,7 @@ GLuint FramebufferManager::CreateTexture(GLenum texture_type, GLenum internal_fo
       glTexImage3DMultisample(texture_type, m_msaaSamples, internal_format, m_targetWidth,
                               m_targetHeight, m_EFBLayers, false);
   }
-  else if (texture == GL_TEXTURE_2D_MULTISAMPLE)
+  else if (texture_type == GL_TEXTURE_2D_MULTISAMPLE)
   {
     if (g_ogl_config.bSupports2DTextureStorage)
       glTexStorage2DMultisample(texture_type, m_msaaSamples, internal_format, m_targetWidth,


### PR DESCRIPTION
The FrameBufferManager::CreateTexture method (from the OpenGL backend) introduced by commit 69cedf41 incorrectly compares the `texture` variable (which contains a name provided by glGenTextures) against `GL_TEXTURE_2D_MULTISAMPLE_ARRAY` and `GL_TEXTURE_2D_MULTISAMPLE`.
It should instead use the `texture_type` variable for this (as done in the first branch of the if).

This fixes an “Unhandled texture type 37120” error when starting most games from my library on macOS.