### PR TITLE
Check whether WAD is a channel before reading names

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -33,6 +33,13 @@ bool IsDiscTitle(u64 title_id)
          IsTitleType(title_id, TitleType::GameWithChannel);
 }
 
+bool IsChannel(u64 title_id)
+{
+  return IsTitleType(title_id, TitleType::Channel) ||
+         IsTitleType(title_id, TitleType::SystemChannel) ||
+         IsTitleType(title_id, TitleType::GameWithChannel);
+}
+
 bool Content::IsShared() const
 {
   return (type & 0x8000) != 0;

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -31,6 +31,7 @@ enum class TitleType : u32
 
 bool IsTitleType(u64 title_id, TitleType title_type);
 bool IsDiscTitle(u64 title_id);
+bool IsChannel(u64 title_id);
 
 #pragma pack(push, 4)
 struct TMDHeader

--- a/Source/Core/DiscIO/VolumeWad.cpp
+++ b/Source/Core/DiscIO/VolumeWad.cpp
@@ -130,6 +130,9 @@ Platform CVolumeWAD::GetVolumeType() const
 
 std::map<Language, std::string> CVolumeWAD::GetLongNames() const
 {
+  if (!m_tmd.IsValid() || !IOS::ES::IsChannel(m_tmd.GetTitleId()))
+    return {};
+
   std::vector<u8> name_data(NAMES_TOTAL_BYTES);
   if (!Read(m_opening_bnr_offset + 0x9C, NAMES_TOTAL_BYTES, name_data.data()))
     return std::map<Language, std::string>();

--- a/Source/Core/DolphinWX/ISOFile.cpp
+++ b/Source/Core/DolphinWX/ISOFile.cpp
@@ -36,7 +36,7 @@
 #include "DolphinWX/ISOFile.h"
 #include "DolphinWX/WxUtils.h"
 
-static const u32 CACHE_REVISION = 0x128;  // Last changed in PR 4542
+static const u32 CACHE_REVISION = 0x129;  // Last changed in PR 5102
 
 static std::string GetLanguageString(DiscIO::Language language,
                                      std::map<DiscIO::Language, std::string> strings)


### PR DESCRIPTION
Dolphin assumes that content 0 is opening.bnr, without checking whether content 0 exists or if it is even supposed to be there (it's only there for channels). This results in sometimes reading garbage.

This adds a check to only try to read names from content 0's header if the title is a channel (channel, system channel or game channel).