### PR TITLE
Fix saving/loading screenshots for Android

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -13,7 +13,9 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.preference.PreferenceManager;
+import android.support.annotation.IntDef;
 import android.support.v7.app.AppCompatActivity;
+import android.util.SparseIntArray;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -44,7 +46,10 @@ import org.dolphinemu.dolphinemu.utils.Java_GCAdapter;
 import org.dolphinemu.dolphinemu.utils.Java_WiimoteAdapter;
 import org.dolphinemu.dolphinemu.utils.Log;
 
+import java.lang.annotation.Retention;
 import java.util.List;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 public final class EmulationActivity extends AppCompatActivity
 {
@@ -83,6 +88,71 @@ public final class EmulationActivity extends AppCompatActivity
 	private String mScreenPath;
 	private FrameLayout mFrameContent;
 	private String mSelectedTitle;
+
+	@Retention(SOURCE)
+	@IntDef({MENU_ACTION_EDIT_CONTROLS_PLACEMENT, MENU_ACTION_TOGGLE_CONTROLS, MENU_ACTION_ADJUST_SCALE,
+			MENU_ACTION_CHOOSE_CONTROLLER, MENU_ACTION_REFRESH_WIIMOTES, MENU_ACTION_TAKE_SCREENSHOT,
+			MENU_ACTION_QUICK_SAVE, MENU_ACTION_QUICK_LOAD, MENU_ACTION_SAVE_ROOT,
+			MENU_ACTION_LOAD_ROOT, MENU_ACTION_SAVE_SLOT1, MENU_ACTION_SAVE_SLOT2,
+			MENU_ACTION_SAVE_SLOT3, MENU_ACTION_SAVE_SLOT4, MENU_ACTION_SAVE_SLOT5,
+			MENU_ACTION_SAVE_SLOT6, MENU_ACTION_LOAD_SLOT1, MENU_ACTION_LOAD_SLOT2,
+			MENU_ACTION_LOAD_SLOT3, MENU_ACTION_LOAD_SLOT4, MENU_ACTION_LOAD_SLOT5,
+			MENU_ACTION_LOAD_SLOT6, MENU_ACTION_EXIT})
+	public @interface MenuAction {
+	}
+
+	public static final int MENU_ACTION_EDIT_CONTROLS_PLACEMENT = 0;
+	public static final int MENU_ACTION_TOGGLE_CONTROLS = 1;
+	public static final int MENU_ACTION_ADJUST_SCALE = 2;
+	public static final int MENU_ACTION_CHOOSE_CONTROLLER = 3;
+	public static final int MENU_ACTION_REFRESH_WIIMOTES = 4;
+	public static final int MENU_ACTION_TAKE_SCREENSHOT = 5;
+	public static final int MENU_ACTION_QUICK_SAVE = 6;
+	public static final int MENU_ACTION_QUICK_LOAD = 7;
+	public static final int MENU_ACTION_SAVE_ROOT = 8;
+	public static final int MENU_ACTION_LOAD_ROOT = 9;
+	public static final int MENU_ACTION_SAVE_SLOT1 = 10;
+	public static final int MENU_ACTION_SAVE_SLOT2 = 11;
+	public static final int MENU_ACTION_SAVE_SLOT3 = 12;
+	public static final int MENU_ACTION_SAVE_SLOT4 = 13;
+	public static final int MENU_ACTION_SAVE_SLOT5 = 14;
+	public static final int MENU_ACTION_SAVE_SLOT6 = 15;
+	public static final int MENU_ACTION_LOAD_SLOT1 = 16;
+	public static final int MENU_ACTION_LOAD_SLOT2 = 17;
+	public static final int MENU_ACTION_LOAD_SLOT3 = 18;
+	public static final int MENU_ACTION_LOAD_SLOT4 = 19;
+	public static final int MENU_ACTION_LOAD_SLOT5 = 20;
+	public static final int MENU_ACTION_LOAD_SLOT6 = 21;
+	public static final int MENU_ACTION_EXIT = 22;
+
+
+	private static SparseIntArray buttonsActionsMap = new SparseIntArray();
+	static {
+		buttonsActionsMap.append(R.id.menu_emulation_edit_layout, EmulationActivity.MENU_ACTION_EDIT_CONTROLS_PLACEMENT);
+		buttonsActionsMap.append(R.id.menu_emulation_toggle_controls, EmulationActivity.MENU_ACTION_TOGGLE_CONTROLS);
+		buttonsActionsMap.append(R.id.menu_emulation_adjust_scale, EmulationActivity.MENU_ACTION_ADJUST_SCALE);
+		buttonsActionsMap.append(R.id.menu_emulation_choose_controller, EmulationActivity.MENU_ACTION_CHOOSE_CONTROLLER);
+		buttonsActionsMap.append(R.id.menu_refresh_wiimotes, EmulationActivity.MENU_ACTION_REFRESH_WIIMOTES);
+		buttonsActionsMap.append(R.id.menu_emulation_screenshot, EmulationActivity.MENU_ACTION_TAKE_SCREENSHOT);
+
+		buttonsActionsMap.append(R.id.menu_quicksave, EmulationActivity.MENU_ACTION_QUICK_SAVE);
+		buttonsActionsMap.append(R.id.menu_quickload, EmulationActivity.MENU_ACTION_QUICK_LOAD);
+		buttonsActionsMap.append(R.id.menu_emulation_save_root, EmulationActivity.MENU_ACTION_SAVE_ROOT);
+		buttonsActionsMap.append(R.id.menu_emulation_load_root, EmulationActivity.MENU_ACTION_LOAD_ROOT);
+		buttonsActionsMap.append(R.id.menu_emulation_save_1, EmulationActivity.MENU_ACTION_SAVE_SLOT1);
+		buttonsActionsMap.append(R.id.menu_emulation_save_2, EmulationActivity.MENU_ACTION_SAVE_SLOT2);
+		buttonsActionsMap.append(R.id.menu_emulation_save_3, EmulationActivity.MENU_ACTION_SAVE_SLOT3);
+		buttonsActionsMap.append(R.id.menu_emulation_save_4, EmulationActivity.MENU_ACTION_SAVE_SLOT4);
+		buttonsActionsMap.append(R.id.menu_emulation_save_5, EmulationActivity.MENU_ACTION_SAVE_SLOT5);
+		buttonsActionsMap.append(R.id.menu_emulation_load_1, EmulationActivity.MENU_ACTION_LOAD_SLOT1);
+		buttonsActionsMap.append(R.id.menu_emulation_load_2, EmulationActivity.MENU_ACTION_LOAD_SLOT2);
+		buttonsActionsMap.append(R.id.menu_emulation_load_3, EmulationActivity.MENU_ACTION_LOAD_SLOT3);
+		buttonsActionsMap.append(R.id.menu_emulation_load_4, EmulationActivity.MENU_ACTION_LOAD_SLOT4);
+		buttonsActionsMap.append(R.id.menu_emulation_load_5, EmulationActivity.MENU_ACTION_LOAD_SLOT5);
+		buttonsActionsMap.append(R.id.menu_exit, EmulationActivity.MENU_ACTION_EXIT);
+
+
+	}
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
@@ -394,249 +464,65 @@ public final class EmulationActivity extends AppCompatActivity
 		return true;
 	}
 
+	@SuppressWarnings("WrongConstant")
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item)
 	{
-		onMenuItemClicked(item.getItemId());
+		handleMenuAction(buttonsActionsMap.get(item.getItemId()));
 		return true;
 	}
 
-	public void onMenuItemClicked(int id)
+	public void handleMenuAction(@MenuAction int menuAction)
 	{
-		switch (id)
+		switch (menuAction)
 		{
 			// Edit the placement of the controls
-			case R.id.menu_emulation_edit_layout:
-				EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
-						.findFragmentById(R.id.frame_emulation_fragment);
-				if (emulationFragment.isConfiguringControls())
-				{
-					emulationFragment.stopConfiguringControls();
-				}
-				else
-				{
-					emulationFragment.startConfiguringControls();
-				}
+			case MENU_ACTION_EDIT_CONTROLS_PLACEMENT:
+				editControlsPlacement();
 				break;
 
 			// Enable/Disable specific buttons or the entire input overlay.
-			case R.id.menu_emulation_toggle_controls:
-			{
-				final SharedPreferences.Editor editor = mPreferences.edit();
-				boolean[] enabledButtons = new boolean[14];
-				AlertDialog.Builder builder = new AlertDialog.Builder(this);
-				builder.setTitle(R.string.emulation_toggle_controls);
-				if (mIsGameCubeGame || mPreferences.getInt("wiiController", 3) == 0)
-				{
-					for (int i = 0; i < enabledButtons.length; i++)
-					{
-						enabledButtons[i] = mPreferences.getBoolean("buttonToggleGc" + i, true);
-					}
-					builder.setMultiChoiceItems(R.array.gcpadButtons, enabledButtons,
-							new DialogInterface.OnMultiChoiceClickListener()
-							{
-								@Override
-								public void onClick(DialogInterface dialog, int indexSelected, boolean isChecked)
-								{
-									editor.putBoolean("buttonToggleGc" + indexSelected, isChecked);
-								}
-							});
-				}
-				else if (mPreferences.getInt("wiiController", 3) == 4)
-				{
-					for (int i = 0; i < enabledButtons.length; i++)
-					{
-						enabledButtons[i] = mPreferences.getBoolean("buttonToggleClassic" + i, true);
-					}
-					builder.setMultiChoiceItems(R.array.classicButtons, enabledButtons,
-							new DialogInterface.OnMultiChoiceClickListener()
-							{
-								@Override
-								public void onClick(DialogInterface dialog, int indexSelected, boolean isChecked)
-								{
-									editor.putBoolean("buttonToggleClassic" + indexSelected, isChecked);
-								}
-							});
-				}
-				else
-				{
-					for (int i = 0; i < enabledButtons.length; i++)
-					{
-						enabledButtons[i] = mPreferences.getBoolean("buttonToggleWii" + i, true);
-					}
-					if (mPreferences.getInt("wiiController", 3) == 3)
-					{
-						builder.setMultiChoiceItems(R.array.nunchukButtons, enabledButtons,
-								new DialogInterface.OnMultiChoiceClickListener()
-								{
-									@Override
-									public void onClick(DialogInterface dialog, int indexSelected, boolean isChecked)
-									{
-										editor.putBoolean("buttonToggleWii" + indexSelected, isChecked);
-									}
-								});
-					}
-					else
-					{
-						builder.setMultiChoiceItems(R.array.wiimoteButtons, enabledButtons,
-								new DialogInterface.OnMultiChoiceClickListener()
-								{
-									@Override
-									public void onClick(DialogInterface dialog, int indexSelected, boolean isChecked)
-									{
-										editor.putBoolean("buttonToggleWii" + indexSelected, isChecked);
-									}
-								});
-					}
-				}
-				builder.setNeutralButton(getString(R.string.emulation_toggle_all), new DialogInterface.OnClickListener()
-				{
-					@Override
-					public void onClick(DialogInterface dialogInterface, int i)
-					{
-						EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
-								.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
-						emulationFragment.toggleInputOverlayVisibility();
-					}
-				});
-				builder.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener()
-				{
-					@Override
-					public void onClick(DialogInterface dialogInterface, int i)
-					{
-						editor.apply();
-
-						EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
-								.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
-						emulationFragment.refreshInputOverlay();
-					}
-				});
-
-				AlertDialog alertDialog = builder.create();
-				alertDialog.show();
-
+			case MENU_ACTION_TOGGLE_CONTROLS:
+				toggleControls();
 				return;
-			}
 
 			// Adjust the scale of the overlay controls.
-			case R.id.menu_emulation_adjust_scale:
-			{
-				LayoutInflater inflater = LayoutInflater.from(this);
-				View view = inflater.inflate(R.layout.dialog_seekbar, null);
-
-				final SeekBar seekbar = (SeekBar) view.findViewById(R.id.seekbar);
-				final TextView value = (TextView) view.findViewById(R.id.text_value);
-				final TextView units = (TextView) view.findViewById(R.id.text_units);
-
-				seekbar.setMax(150);
-				seekbar.setProgress(mPreferences.getInt("controlScale", 50));
-				seekbar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener()
-				{
-					public void onStartTrackingTouch(SeekBar seekBar)
-					{
-						// Do nothing
-					}
-					public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser)
-					{
-						value.setText(String.valueOf(progress + 50));
-					}
-					public void onStopTrackingTouch(SeekBar seekBar)
-					{
-						// Do nothing
-					}
-				});
-
-				value.setText(String.valueOf(seekbar.getProgress() + 50));
-				units.setText("%");
-
-				AlertDialog.Builder builder = new AlertDialog.Builder(this);
-				builder.setTitle(R.string.emulation_control_scale);
-				builder.setView(view);
-				builder.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener()
-				{
-					@Override
-					public void onClick(DialogInterface dialogInterface, int i)
-					{
-						SharedPreferences.Editor editor = mPreferences.edit();
-						editor.putInt("controlScale", seekbar.getProgress());
-						editor.apply();
-
-						EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
-								.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
-						emulationFragment.refreshInputOverlay();
-					}
-				});
-
-				AlertDialog alertDialog = builder.create();
-				alertDialog.show();
-
+			case MENU_ACTION_ADJUST_SCALE:
+				adjustScale();
 				return;
-			}
 
 			// (Wii games only) Change the controller for the input overlay.
-			case R.id.menu_emulation_choose_controller:
-				final SharedPreferences.Editor editor = mPreferences.edit();
-				AlertDialog.Builder builder = new AlertDialog.Builder(this);
-				builder.setTitle(R.string.emulation_choose_controller);
-				builder.setSingleChoiceItems(R.array.controllersEntries, mPreferences.getInt("wiiController", 3),
-						new DialogInterface.OnClickListener()
-						{
-							@Override
-							public void onClick(DialogInterface dialog, int indexSelected)
-							{
-								editor.putInt("wiiController", indexSelected);
-
-								NativeLibrary.SetConfig("WiimoteNew.ini", "Wiimote1", "Extension",
-										getResources().getStringArray(R.array.controllersValues)[indexSelected]);
-							}
-						});
-				builder.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener()
-				{
-					@Override
-					public void onClick(DialogInterface dialogInterface, int i)
-					{
-						editor.apply();
-
-						EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
-								.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
-						emulationFragment.refreshInputOverlay();
-
-						Toast.makeText(getApplication(), R.string.emulation_controller_changed, Toast.LENGTH_SHORT).show();
-					}
-				});
-
-				AlertDialog alertDialog = builder.create();
-				alertDialog.show();
-
+			case MENU_ACTION_CHOOSE_CONTROLLER:
+				chooseController();
 				return;
 
-			case R.id.menu_refresh_wiimotes:
+			case MENU_ACTION_REFRESH_WIIMOTES:
 				NativeLibrary.RefreshWiimotes();
 				return;
 
 			// Screenshot capturing
-			case R.id.menu_emulation_screenshot:
+			case MENU_ACTION_TAKE_SCREENSHOT:
 				NativeLibrary.SaveScreenShot();
 				return;
 
 			// Quick save / load
-			case R.id.menu_quicksave:
+			case MENU_ACTION_QUICK_SAVE:
 				NativeLibrary.SaveState(9);
 				return;
 
-			case R.id.menu_quickload:
+			case MENU_ACTION_QUICK_LOAD:
 				NativeLibrary.LoadState(9);
 				return;
 
 			// TV Menu only
-			case R.id.menu_emulation_save_root:
+			case MENU_ACTION_SAVE_ROOT:
 				if (!mDeviceHasTouchScreen)
 				{
 					showMenu(SaveStateFragment.FRAGMENT_ID);
 				}
 				return;
 
-			case R.id.menu_emulation_load_root:
+			case MENU_ACTION_LOAD_ROOT:
 				if (!mDeviceHasTouchScreen)
 				{
 					showMenu(LoadStateFragment.FRAGMENT_ID);
@@ -644,51 +530,70 @@ public final class EmulationActivity extends AppCompatActivity
 				return;
 
 			// Save state slots
-			case R.id.menu_emulation_save_1:
+			case MENU_ACTION_SAVE_SLOT1:
 				NativeLibrary.SaveState(0);
 				return;
 
-			case R.id.menu_emulation_save_2:
+			case MENU_ACTION_SAVE_SLOT2:
 				NativeLibrary.SaveState(1);
 				return;
 
-			case R.id.menu_emulation_save_3:
+			case MENU_ACTION_SAVE_SLOT3:
 				NativeLibrary.SaveState(2);
 				return;
 
-			case R.id.menu_emulation_save_4:
+			case MENU_ACTION_SAVE_SLOT4:
 				NativeLibrary.SaveState(3);
 				return;
 
-			case R.id.menu_emulation_save_5:
+			case MENU_ACTION_SAVE_SLOT5:
 				NativeLibrary.SaveState(4);
 				return;
 
+			case MENU_ACTION_SAVE_SLOT6:
+				NativeLibrary.SaveState(5);
+				return;
+
 			// Load state slots
-			case R.id.menu_emulation_load_1:
+			case MENU_ACTION_LOAD_SLOT1:
 				NativeLibrary.LoadState(0);
 				return;
 
-			case R.id.menu_emulation_load_2:
+			case MENU_ACTION_LOAD_SLOT2:
 				NativeLibrary.LoadState(1);
 				return;
 
-			case R.id.menu_emulation_load_3:
+			case MENU_ACTION_LOAD_SLOT3:
 				NativeLibrary.LoadState(2);
 				return;
 
-			case R.id.menu_emulation_load_4:
+			case MENU_ACTION_LOAD_SLOT4:
 				NativeLibrary.LoadState(3);
 				return;
 
-			case R.id.menu_emulation_load_5:
+			case MENU_ACTION_LOAD_SLOT5:
 				NativeLibrary.LoadState(4);
 				return;
 
-			case R.id.menu_exit:
+			case MENU_ACTION_LOAD_SLOT6:
+				NativeLibrary.LoadState(5);
+				return;
+
+			case MENU_ACTION_EXIT:
 				toggleMenu();
 				stopEmulation();
 				return;
+		}
+	}
+
+
+	private void editControlsPlacement() {
+		EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
+				.findFragmentById(R.id.frame_emulation_fragment);
+		if (emulationFragment.isConfiguringControls()) {
+			emulationFragment.stopConfiguringControls();
+		} else {
+			emulationFragment.startConfiguringControls();
 		}
 	}
 
@@ -724,6 +629,157 @@ public final class EmulationActivity extends AppCompatActivity
 		}
 		InputDevice input = event.getDevice();
 		return NativeLibrary.onGamePadEvent(input.getDescriptor(), event.getKeyCode(), action);
+	}
+
+	private void toggleControls() {
+		final SharedPreferences.Editor editor = mPreferences.edit();
+		boolean[] enabledButtons = new boolean[14];
+		AlertDialog.Builder builder = new AlertDialog.Builder(this);
+		builder.setTitle(R.string.emulation_toggle_controls);
+		if (mIsGameCubeGame || mPreferences.getInt("wiiController", 3) == 0) {
+			for (int i = 0; i < enabledButtons.length; i++) {
+				enabledButtons[i] = mPreferences.getBoolean("buttonToggleGc" + i, true);
+			}
+			builder.setMultiChoiceItems(R.array.gcpadButtons, enabledButtons,
+					new DialogInterface.OnMultiChoiceClickListener() {
+						@Override
+						public void onClick(DialogInterface dialog, int indexSelected, boolean isChecked) {
+							editor.putBoolean("buttonToggleGc" + indexSelected, isChecked);
+						}
+					});
+		} else if (mPreferences.getInt("wiiController", 3) == 4) {
+			for (int i = 0; i < enabledButtons.length; i++) {
+				enabledButtons[i] = mPreferences.getBoolean("buttonToggleClassic" + i, true);
+			}
+			builder.setMultiChoiceItems(R.array.classicButtons, enabledButtons,
+					new DialogInterface.OnMultiChoiceClickListener() {
+						@Override
+						public void onClick(DialogInterface dialog, int indexSelected, boolean isChecked) {
+							editor.putBoolean("buttonToggleClassic" + indexSelected, isChecked);
+						}
+					});
+		} else {
+			for (int i = 0; i < enabledButtons.length; i++) {
+				enabledButtons[i] = mPreferences.getBoolean("buttonToggleWii" + i, true);
+			}
+			if (mPreferences.getInt("wiiController", 3) == 3) {
+				builder.setMultiChoiceItems(R.array.nunchukButtons, enabledButtons,
+						new DialogInterface.OnMultiChoiceClickListener() {
+							@Override
+							public void onClick(DialogInterface dialog, int indexSelected, boolean isChecked) {
+								editor.putBoolean("buttonToggleWii" + indexSelected, isChecked);
+							}
+						});
+			} else {
+				builder.setMultiChoiceItems(R.array.wiimoteButtons, enabledButtons,
+						new DialogInterface.OnMultiChoiceClickListener() {
+							@Override
+							public void onClick(DialogInterface dialog, int indexSelected, boolean isChecked) {
+								editor.putBoolean("buttonToggleWii" + indexSelected, isChecked);
+							}
+						});
+			}
+		}
+		builder.setNeutralButton(getString(R.string.emulation_toggle_all), new DialogInterface.OnClickListener() {
+			@Override
+			public void onClick(DialogInterface dialogInterface, int i) {
+				EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
+						.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
+				emulationFragment.toggleInputOverlayVisibility();
+			}
+		});
+		builder.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
+			@Override
+			public void onClick(DialogInterface dialogInterface, int i) {
+				editor.apply();
+
+				EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
+						.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
+				emulationFragment.refreshInputOverlay();
+			}
+		});
+
+		AlertDialog alertDialog = builder.create();
+		alertDialog.show();
+	}
+
+	private void adjustScale() {
+		LayoutInflater inflater = LayoutInflater.from(this);
+		View view = inflater.inflate(R.layout.dialog_seekbar, null);
+
+		final SeekBar seekbar = (SeekBar) view.findViewById(R.id.seekbar);
+		final TextView value = (TextView) view.findViewById(R.id.text_value);
+		final TextView units = (TextView) view.findViewById(R.id.text_units);
+
+		seekbar.setMax(150);
+		seekbar.setProgress(mPreferences.getInt("controlScale", 50));
+		seekbar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+			public void onStartTrackingTouch(SeekBar seekBar) {
+				// Do nothing
+			}
+
+			public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+				value.setText(String.valueOf(progress + 50));
+			}
+
+			public void onStopTrackingTouch(SeekBar seekBar) {
+				// Do nothing
+			}
+		});
+
+		value.setText(String.valueOf(seekbar.getProgress() + 50));
+		units.setText("%");
+
+		AlertDialog.Builder builder = new AlertDialog.Builder(this);
+		builder.setTitle(R.string.emulation_control_scale);
+		builder.setView(view);
+		builder.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
+			@Override
+			public void onClick(DialogInterface dialogInterface, int i) {
+				SharedPreferences.Editor editor = mPreferences.edit();
+				editor.putInt("controlScale", seekbar.getProgress());
+				editor.apply();
+
+				EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
+						.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
+				emulationFragment.refreshInputOverlay();
+			}
+		});
+
+		AlertDialog alertDialog = builder.create();
+		alertDialog.show();
+	}
+
+	private void chooseController() {
+		final SharedPreferences.Editor editor = mPreferences.edit();
+		AlertDialog.Builder builder = new AlertDialog.Builder(this);
+		builder.setTitle(R.string.emulation_choose_controller);
+		builder.setSingleChoiceItems(R.array.controllersEntries, mPreferences.getInt("wiiController", 3),
+				new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int indexSelected) {
+						editor.putInt("wiiController", indexSelected);
+
+						NativeLibrary.SetConfig("WiimoteNew.ini", "Wiimote1", "Extension",
+								getResources().getStringArray(R.array.controllersValues)[indexSelected]);
+					}
+				});
+		builder.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
+			@Override
+			public void onClick(DialogInterface dialogInterface, int i) {
+				editor.apply();
+
+				EmulationFragment emulationFragment = (EmulationFragment) getFragmentManager()
+						.findFragmentByTag(EmulationFragment.FRAGMENT_TAG);
+				emulationFragment.refreshInputOverlay();
+
+				Toast.makeText(getApplication(), R.string.emulation_controller_changed, Toast.LENGTH_SHORT).show();
+			}
+		});
+
+		AlertDialog alertDialog = builder.create();
+		alertDialog.show();
+
 	}
 
 	@Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/LoadStateFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/LoadStateFragment.java
@@ -3,6 +3,7 @@ package org.dolphinemu.dolphinemu.fragments;
 import android.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.util.SparseIntArray;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,6 +18,16 @@ public final class LoadStateFragment extends Fragment implements View.OnClickLis
 {
 	public static final String FRAGMENT_TAG = BuildConfig.APPLICATION_ID + ".load_state";
 	public static final int FRAGMENT_ID = R.layout.fragment_state_load;
+
+	private static SparseIntArray buttonsActionsMap = new SparseIntArray();
+	static {
+		buttonsActionsMap.append(R.id.menu_emulation_load_1, EmulationActivity.MENU_ACTION_LOAD_SLOT1);
+		buttonsActionsMap.append(R.id.menu_emulation_load_2, EmulationActivity.MENU_ACTION_LOAD_SLOT2);
+		buttonsActionsMap.append(R.id.menu_emulation_load_3, EmulationActivity.MENU_ACTION_LOAD_SLOT3);
+		buttonsActionsMap.append(R.id.menu_emulation_load_4, EmulationActivity.MENU_ACTION_LOAD_SLOT4);
+		buttonsActionsMap.append(R.id.menu_emulation_load_5, EmulationActivity.MENU_ACTION_LOAD_SLOT5);
+		buttonsActionsMap.append(R.id.menu_emulation_load_6, EmulationActivity.MENU_ACTION_LOAD_SLOT6);
+	}
 
 	public static LoadStateFragment newInstance()
 	{
@@ -47,9 +58,10 @@ public final class LoadStateFragment extends Fragment implements View.OnClickLis
 		return rootView;
 	}
 
+	@SuppressWarnings("WrongConstant")
 	@Override
 	public void onClick(View button)
 	{
-		((EmulationActivity) getActivity()).onMenuItemClicked(button.getId());
+		((EmulationActivity) getActivity()).handleMenuAction(buttonsActionsMap.get(button.getId()));
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -3,6 +3,7 @@ package org.dolphinemu.dolphinemu.fragments;
 import android.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.util.SparseIntArray;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,6 +20,16 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
 	public static final String FRAGMENT_TAG = BuildConfig.APPLICATION_ID + ".ingame_menu";
 	public static final int FRAGMENT_ID = R.layout.fragment_ingame_menu;
 	private TextView mTitleText;
+	private static SparseIntArray buttonsActionsMap = new SparseIntArray();
+	static {
+		buttonsActionsMap.append(R.id.menu_take_screenshot, EmulationActivity.MENU_ACTION_TAKE_SCREENSHOT);
+		buttonsActionsMap.append(R.id.menu_quicksave, EmulationActivity.MENU_ACTION_QUICK_SAVE);
+		buttonsActionsMap.append(R.id.menu_quickload, EmulationActivity.MENU_ACTION_QUICK_LOAD);
+		buttonsActionsMap.append(R.id.menu_emulation_save_root, EmulationActivity.MENU_ACTION_SAVE_ROOT);
+		buttonsActionsMap.append(R.id.menu_emulation_load_root, EmulationActivity.MENU_ACTION_LOAD_ROOT);
+		buttonsActionsMap.append(R.id.menu_refresh_wiimotes, EmulationActivity.MENU_ACTION_REFRESH_WIIMOTES);
+		buttonsActionsMap.append(R.id.menu_exit, EmulationActivity.MENU_ACTION_EXIT);
+	}
 
 	@Nullable
 	@Override
@@ -39,10 +50,11 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
 		return rootView;
 	}
 
+	@SuppressWarnings("WrongConstant")
 	@Override
 	public void onClick(View button)
 	{
-		((EmulationActivity) getActivity()).onMenuItemClicked(button.getId());
+		((EmulationActivity) getActivity()).handleMenuAction(buttonsActionsMap.get(button.getId()));
 	}
 
 	public void setTitleText(String title)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/SaveStateFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/SaveStateFragment.java
@@ -3,6 +3,7 @@ package org.dolphinemu.dolphinemu.fragments;
 import android.app.Fragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.util.SparseIntArray;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,6 +18,16 @@ public final class SaveStateFragment extends Fragment implements View.OnClickLis
 {
 	public static final String FRAGMENT_TAG = BuildConfig.APPLICATION_ID + ".save_state";
 	public static final int FRAGMENT_ID = R.layout.fragment_state_save;
+
+	private static SparseIntArray buttonsActionsMap = new SparseIntArray();
+	static {
+		buttonsActionsMap.append(R.id.menu_emulation_save_1, EmulationActivity.MENU_ACTION_SAVE_SLOT1);
+		buttonsActionsMap.append(R.id.menu_emulation_save_2, EmulationActivity.MENU_ACTION_SAVE_SLOT2);
+		buttonsActionsMap.append(R.id.menu_emulation_save_3, EmulationActivity.MENU_ACTION_SAVE_SLOT3);
+		buttonsActionsMap.append(R.id.menu_emulation_save_4, EmulationActivity.MENU_ACTION_SAVE_SLOT4);
+		buttonsActionsMap.append(R.id.menu_emulation_save_5, EmulationActivity.MENU_ACTION_SAVE_SLOT5);
+		buttonsActionsMap.append(R.id.menu_emulation_save_6, EmulationActivity.MENU_ACTION_SAVE_SLOT6);
+	}
 
 	public static SaveStateFragment newInstance()
 	{
@@ -47,9 +58,10 @@ public final class SaveStateFragment extends Fragment implements View.OnClickLis
 		return rootView;
 	}
 
+	@SuppressWarnings("WrongConstant")
 	@Override
 	public void onClick(View button)
 	{
-		((EmulationActivity) getActivity()).onMenuItemClicked(button.getId());
+		((EmulationActivity) getActivity()).handleMenuAction(buttonsActionsMap.get(button.getId()));
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/Game.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/model/Game.java
@@ -95,7 +95,7 @@ public final class Game
 	{
 		ContentValues values = new ContentValues();
 
-		String screenPath = PATH_SCREENSHOT_FOLDER + gameId + "/thumb.png";
+		String screenPath = PATH_SCREENSHOT_FOLDER + gameId + "/" + gameId + "-1.png";
 
 		values.put(GameDatabase.KEY_GAME_PLATFORM, platform);
 		values.put(GameDatabase.KEY_GAME_TITLE, title);

--- a/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_ingame_menu.xml
@@ -53,11 +53,6 @@
                 style="@style/InGameMenuOption"/>
 
             <Button
-                android:id="@+id/menu_ingame_settings"
-                android:text="@string/preferences_settings"
-                style="@style/InGameMenuOption"/>
-
-            <Button
                 android:id="@+id/menu_refresh_wiimotes"
                 android:text="@string/emulation_refresh_wiimotes"
                 style="@style/InGameMenuOption"/>


### PR DESCRIPTION
- Saving screenshot was broken for Android TV.
- Loading screenshots was broken because of the change in the name of the saved images from the native library,
- Remove obsolete menu item from Android TV.