### PR TITLE
EXI: Namespace device classes

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -226,7 +226,7 @@ bool CBoot::Load_BS2(const std::string& boot_rom_filename)
                 SConfig::GetDirectoryForRegion(boot_region));
 
   // Run the descrambler over the encrypted section containing BS1/BS2
-  CEXIIPL::Descrambler((u8*)data.data() + 0x100, 0x1AFE00);
+  ExpansionInterface::CEXIIPL::Descrambler((u8*)data.data() + 0x100, 0x1AFE00);
 
   // TODO: Execution is supposed to start at 0xFFF00000, not 0x81200000;
   // copying the initial boot code to 0x81200000 is a hack.

--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -30,6 +30,19 @@
 #include "DiscIO/Enums.h"
 #include "DiscIO/Volume.h"
 
+namespace
+{
+void PresetTimeBaseTicks()
+{
+  const u64 emulated_time =
+      ExpansionInterface::CEXIIPL::GetEmulatedTime(ExpansionInterface::CEXIIPL::GC_EPOCH);
+
+  const u64 time_base_ticks = emulated_time * 40500000ULL;
+
+  PowerPC::HostWrite_U64(time_base_ticks, 0x800030D8);
+}
+}  // Anonymous namespace
+
 void CBoot::RunFunction(u32 address)
 {
   PC = address;
@@ -93,8 +106,8 @@ bool CBoot::EmulatedBS2_GC(bool skip_app_loader)
   PowerPC::HostWrite_U32(0x4c000064, 0x80000800);  // Write default FPU Handler:     rfi
   PowerPC::HostWrite_U32(0x4c000064, 0x80000C00);  // Write default Syscall Handler: rfi
 
-  PowerPC::HostWrite_U64((u64)CEXIIPL::GetEmulatedTime(CEXIIPL::GC_EPOCH) * (u64)40500000,
-                         0x800030D8);  // Preset time base ticks
+  PresetTimeBaseTicks();
+
   // HIO checks this
   // PowerPC::HostWrite_U16(0x8200,     0x000030e6); // Console type
 

--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -93,7 +93,7 @@ private:
   std::string m_strGPUDeterminismMode;
   std::array<int, MAX_BBMOTES> iWiimoteSource;
   std::array<SerialInterface::SIDevices, SerialInterface::MAX_SI_CHANNELS> Pads;
-  std::array<TEXIDevices, ExpansionInterface::MAX_EXI_CHANNELS> m_EXIDevice;
+  std::array<ExpansionInterface::TEXIDevices, ExpansionInterface::MAX_EXI_CHANNELS> m_EXIDevice;
 };
 
 void ConfigCache::SaveConfig(const SConfig& config)

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -571,9 +571,9 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("MemcardBPath", &m_strMemoryCardB);
   core->Get("AgpCartAPath", &m_strGbaCartA);
   core->Get("AgpCartBPath", &m_strGbaCartB);
-  core->Get("SlotA", (int*)&m_EXIDevice[0], EXIDEVICE_MEMORYCARD);
-  core->Get("SlotB", (int*)&m_EXIDevice[1], EXIDEVICE_NONE);
-  core->Get("SerialPort1", (int*)&m_EXIDevice[2], EXIDEVICE_NONE);
+  core->Get("SlotA", (int*)&m_EXIDevice[0], ExpansionInterface::EXIDEVICE_MEMORYCARD);
+  core->Get("SlotB", (int*)&m_EXIDevice[1], ExpansionInterface::EXIDEVICE_NONE);
+  core->Get("SerialPort1", (int*)&m_EXIDevice[2], ExpansionInterface::EXIDEVICE_NONE);
   core->Get("BBA_MAC", &m_bba_mac);
   core->Get("TimeProfiling", &bJITILTimeProfiling, false);
   core->Get("OutputIR", &bJITILOutputIR, false);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -251,7 +251,7 @@ struct SConfig : NonCopyable
   std::string m_strMemoryCardB;
   std::string m_strGbaCartA;
   std::string m_strGbaCartB;
-  TEXIDevices m_EXIDevice[3];
+  ExpansionInterface::TEXIDevices m_EXIDevice[3];
   SerialInterface::SIDevices m_SIDevice[4];
   std::string m_bba_mac;
 

--- a/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Apple.cpp
+++ b/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Apple.cpp
@@ -10,6 +10,8 @@
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/HW/EXI/EXI_DeviceEthernet.h"
 
+namespace ExpansionInterface
+{
 bool CEXIETHERNET::Activate()
 {
   if (IsActivated())
@@ -105,3 +107,4 @@ void CEXIETHERNET::RecvStop()
 {
   readEnabled.Clear();
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Unix.cpp
+++ b/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Unix.cpp
@@ -23,6 +23,8 @@
 #include <sys/socket.h>
 #endif
 
+namespace ExpansionInterface
+{
 #define NOTIMPLEMENTED(Name)                                                                       \
   NOTICE_LOG(SP1, "CEXIETHERNET::%s not implemented for your UNIX", Name);
 
@@ -181,3 +183,4 @@ void CEXIETHERNET::RecvStop()
   NOTIMPLEMENTED("RecvStop");
 #endif
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Win32.cpp
+++ b/Source/Core/Core/HW/EXI/BBA-TAP/TAP_Win32.cpp
@@ -165,6 +165,8 @@ bool OpenTAP(HANDLE& adapter, const std::basic_string<TCHAR>& device_guid)
 
 }  // namespace Win32TAPHelper
 
+namespace ExpansionInterface
+{
 bool CEXIETHERNET::Activate()
 {
   if (IsActivated())
@@ -362,3 +364,4 @@ void CEXIETHERNET::RecvStop()
 {
   readEnabled.Clear();
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI.h
+++ b/Source/Core/Core/HW/EXI/EXI.h
@@ -6,10 +6,8 @@
 
 #include "Common/CommonTypes.h"
 
-class CEXIChannel;
-class IEXIDevice;
 class PointerWrap;
-enum TEXIDevices : int;
+
 namespace CoreTiming
 {
 enum class FromThread;
@@ -21,6 +19,10 @@ class Mapping;
 
 namespace ExpansionInterface
 {
+class CEXIChannel;
+class IEXIDevice;
+enum TEXIDevices : int;
+
 enum
 {
   MAX_MEMORYCARD_SLOTS = 2,

--- a/Source/Core/Core/HW/EXI/EXI_Channel.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.cpp
@@ -13,6 +13,8 @@
 #include "Core/HW/EXI/EXI_Device.h"
 #include "Core/HW/MMIO.h"
 
+namespace ExpansionInterface
+{
 enum
 {
   EXI_READ,
@@ -268,3 +270,4 @@ IEXIDevice* CEXIChannel::FindDevice(TEXIDevices device_type, int custom_index)
   }
   return nullptr;
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_Channel.h
+++ b/Source/Core/Core/HW/EXI/EXI_Channel.h
@@ -8,13 +8,17 @@
 #include <memory>
 #include "Common/CommonTypes.h"
 
-class IEXIDevice;
 class PointerWrap;
-enum TEXIDevices : int;
+
 namespace MMIO
 {
 class Mapping;
 }
+
+namespace ExpansionInterface
+{
+class IEXIDevice;
+enum TEXIDevices : int;
 
 class CEXIChannel
 {
@@ -113,3 +117,4 @@ private:
   // Since channels operate a bit differently from each other
   u32 m_channel_id;
 };
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Device.cpp
@@ -17,6 +17,8 @@
 #include "Core/HW/EXI/EXI_DeviceMic.h"
 #include "Core/HW/Memmap.h"
 
+namespace ExpansionInterface
+{
 void IEXIDevice::ImmWrite(u32 data, u32 size)
 {
   while (size--)
@@ -153,3 +155,4 @@ std::unique_ptr<IEXIDevice> EXIDevice_Create(const TEXIDevices device_type, cons
 
   return result;
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_Device.h
+++ b/Source/Core/Core/HW/EXI/EXI_Device.h
@@ -9,6 +9,8 @@
 
 class PointerWrap;
 
+namespace ExpansionInterface
+{
 enum TEXIDevices : int
 {
   EXIDEVICE_DUMMY,
@@ -64,3 +66,4 @@ private:
 };
 
 std::unique_ptr<IEXIDevice> EXIDevice_Create(TEXIDevices device_type, int channel_num);
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceAD16.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceAD16.cpp
@@ -8,6 +8,8 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 
+namespace ExpansionInterface
+{
 CEXIAD16::CEXIAD16() = default;
 
 void CEXIAD16::SetCS(int cs)
@@ -106,3 +108,4 @@ void CEXIAD16::DoState(PointerWrap& p)
   p.Do(m_command);
   p.Do(m_ad16_register);
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceAD16.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceAD16.h
@@ -8,6 +8,8 @@
 
 class PointerWrap;
 
+namespace ExpansionInterface
+{
 class CEXIAD16 : public IEXIDevice
 {
 public:
@@ -37,3 +39,4 @@ private:
 
   void TransferByte(u8& byte) override;
 };
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceAGP.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceAGP.cpp
@@ -14,6 +14,8 @@
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 
+namespace ExpansionInterface
+{
 CEXIAgp::CEXIAgp(int index)
 {
   m_slot = index;
@@ -381,3 +383,4 @@ void CEXIAgp::DoState(PointerWrap& p)
   p.Do(m_rom_size);
   p.Do(m_rw_offset);
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceAGP.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceAGP.h
@@ -11,6 +11,8 @@
 
 class PointerWrap;
 
+namespace ExpansionInterface
+{
 class CEXIAgp : public IEXIDevice
 {
 public:
@@ -63,3 +65,4 @@ private:
   u32 m_current_cmd = 0;
   u32 m_return_pos = 0;
 };
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceDummy.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceDummy.cpp
@@ -7,6 +7,8 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
+namespace ExpansionInterface
+{
 CEXIDummy::CEXIDummy(const std::string& name) : m_name{name}
 {
 }
@@ -42,3 +44,4 @@ bool CEXIDummy::IsPresent() const
 void CEXIDummy::TransferByte(u8& byte)
 {
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceDummy.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceDummy.h
@@ -9,6 +9,8 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/EXI/EXI_Device.h"
 
+namespace ExpansionInterface
+{
 // Just a dummy that logs reads and writes
 // to be used for EXI devices we haven't emulated
 // DOES NOT FUNCTION AS "NO DEVICE INSERTED" -> Appears as unknown device
@@ -30,3 +32,4 @@ private:
 
   std::string m_name;
 };
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -15,6 +15,8 @@
 #include "Core/HW/EXI/EXI.h"
 #include "Core/HW/Memmap.h"
 
+namespace ExpansionInterface
+{
 // XXX: The BBA stores multi-byte elements as little endian.
 // Multiple parts of this implementation depend on Dolphin
 // being compiled for a little endian host.
@@ -589,3 +591,4 @@ wait_for_next:
 
   return true;
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.h
@@ -17,6 +17,8 @@
 
 class PointerWrap;
 
+namespace ExpansionInterface
+{
 // Network Control Register A
 enum NCRA
 {
@@ -338,3 +340,4 @@ public:
   Common::Flag readThreadShutdown;
 #endif
 };
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.cpp
@@ -17,6 +17,8 @@
 #include "Common/Thread.h"
 #include "Core/Core.h"
 
+namespace ExpansionInterface
+{
 u16 GeckoSockServer::server_port;
 int GeckoSockServer::client_count;
 std::thread GeckoSockServer::connectionThread;
@@ -221,3 +223,4 @@ void CEXIGecko::ImmReadWrite(u32& _uData, u32 _uSize)
     break;
   }
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceGecko.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceGecko.h
@@ -15,6 +15,8 @@
 #include "Common/Flag.h"
 #include "Core/HW/EXI/EXI_Device.h"
 
+namespace ExpansionInterface
+{
 class GeckoSockServer
 {
 public:
@@ -66,3 +68,4 @@ private:
 
   static const u32 ident = 0x04700000;
 };
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -27,6 +27,8 @@
 
 #include "DiscIO/Enums.h"
 
+namespace ExpansionInterface
+{
 // We should provide an option to choose from the above, or figure out the checksum (the algo in
 // yagcd seems wrong)
 // so that people can change default language.
@@ -435,3 +437,4 @@ u32 CEXIIPL::GetEmulatedTime(u32 epoch)
 
   return static_cast<u32>(ltime) - epoch;
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.h
@@ -10,6 +10,8 @@
 
 class PointerWrap;
 
+namespace ExpansionInterface
+{
 class CEXIIPL : public IEXIDevice
 {
 public:
@@ -76,3 +78,4 @@ private:
   void LoadFontFile(const std::string& filename, u32 offset);
   std::string FindIPLDump(const std::string& path_prefix);
 };
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -32,6 +32,8 @@
 #include "DiscIO/Enums.h"
 #include "DiscIO/NANDContentLoader.h"
 
+namespace ExpansionInterface
+{
 #define MC_STATUS_BUSY 0x80
 #define MC_STATUS_UNLOCKED 0x40
 #define MC_STATUS_SLEEP 0x20
@@ -532,3 +534,4 @@ void CEXIMemoryCard::DMAWrite(u32 _uAddr, u32 _uSize)
   CoreTiming::ScheduleEvent(_uSize * (SystemTimers::GetTicksPerSecond() / MC_TRANSFER_RATE_WRITE),
                             s_et_transfer_complete[card_index], (u64)card_index);
 }
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.h
@@ -12,6 +12,8 @@
 class MemoryCardBase;
 class PointerWrap;
 
+namespace ExpansionInterface
+{
 class CEXIMemoryCard : public IEXIDevice
 {
 public:
@@ -91,3 +93,4 @@ private:
 protected:
   void TransferByte(u8& byte) override;
 };
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.cpp
@@ -20,6 +20,8 @@
 
 #include <portaudio.h>
 
+namespace ExpansionInterface
+{
 void CEXIMic::StreamLog(const char* msg)
 {
   INFO_LOG(EXPANSIONINTERFACE, "%s: %s", msg, Pa_GetErrorText(pa_error));
@@ -268,4 +270,5 @@ void CEXIMic::TransferByte(u8& byte)
 
   m_position++;
 }
+}  // namespace ExpansionInterface
 #endif

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMic.h
@@ -8,6 +8,8 @@
 #include "Common/Common.h"
 #include "Core/HW/EXI/EXI_Device.h"
 
+namespace ExpansionInterface
+{
 #if HAVE_PORTAUDIO
 
 class CEXIMic : public IEXIDevice
@@ -107,3 +109,4 @@ public:
 };
 
 #endif
+}  // namespace ExpansionInterface

--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.h
@@ -137,7 +137,7 @@ struct Header  // Offset    Size    Description
     memset(this, 0xFF, BLOCK_SIZE);
     *(u16*)SizeMb = BE16(sizeMb);
     Encoding = BE16(shift_jis ? 1 : 0);
-    u64 rand = Common::Timer::GetLocalTimeSinceJan1970() - CEXIIPL::GC_EPOCH;
+    u64 rand = Common::Timer::GetLocalTimeSinceJan1970() - ExpansionInterface::CEXIIPL::GC_EPOCH;
     formatTime = Common::swap64(rand);
     for (int i = 0; i < 12; i++)
     {

--- a/Source/Core/Core/HW/SystemTimers.cpp
+++ b/Source/Core/Core/HW/SystemTimers.cpp
@@ -257,8 +257,11 @@ void Init()
     s_localtime_rtc_offset =
         Common::Timer::GetLocalTimeSinceJan1970() - SConfig::GetInstance().m_customRTCValue;
   }
-  CoreTiming::SetFakeTBStartValue((u64)(s_cpu_core_clock / TIMER_RATIO) *
-                                  (u64)CEXIIPL::GetEmulatedTime(CEXIIPL::GC_EPOCH));
+
+  CoreTiming::SetFakeTBStartValue(static_cast<u64>(s_cpu_core_clock / TIMER_RATIO) *
+                                  static_cast<u64>(ExpansionInterface::CEXIIPL::GetEmulatedTime(
+                                      ExpansionInterface::CEXIIPL::GC_EPOCH)));
+
   CoreTiming::SetFakeTBStartTicks(CoreTiming::GetTicks());
 
   CoreTiming::SetFakeDecStartValue(0xFFFFFFFF);

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -65,12 +65,14 @@ IPCCommandResult NetKDTime::IOCtl(const IOCtlRequest& request)
 
 u64 NetKDTime::GetAdjustedUTC() const
 {
-  return CEXIIPL::GetEmulatedTime(CEXIIPL::WII_EPOCH) + utcdiff;
+  return ExpansionInterface::CEXIIPL::GetEmulatedTime(ExpansionInterface::CEXIIPL::WII_EPOCH) +
+         utcdiff;
 }
 
 void NetKDTime::SetAdjustedUTC(u64 wii_utc)
 {
-  utcdiff = CEXIIPL::GetEmulatedTime(CEXIIPL::WII_EPOCH) - wii_utc;
+  utcdiff = ExpansionInterface::CEXIIPL::GetEmulatedTime(ExpansionInterface::CEXIIPL::WII_EPOCH) -
+            wii_utc;
 }
 }  // namespace Device
 }  // namespace HLE

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -180,7 +180,8 @@ std::string GetInputDisplay()
 // NOTE: GPU Thread
 std::string GetRTCDisplay()
 {
-  time_t current_time = CEXIIPL::GetEmulatedTime(CEXIIPL::UNIX_EPOCH);
+  time_t current_time =
+      ExpansionInterface::CEXIIPL::GetEmulatedTime(ExpansionInterface::CEXIIPL::UNIX_EPOCH);
   tm* gm_time = gmtime(&current_time);
   char buffer[256];
   strftime(buffer, sizeof(buffer), "Date/Time: %c\n", gm_time);
@@ -557,7 +558,7 @@ bool BeginRecordingInput(int controllers)
   if (NetPlay::IsNetPlayRunning())
   {
     s_bNetPlay = true;
-    s_recordingStartTime = CEXIIPL::NetPlay_GetEmulatedTime();
+    s_recordingStartTime = ExpansionInterface::CEXIIPL::NetPlay_GetEmulatedTime();
   }
   else if (SConfig::GetInstance().bEnableCustomRTC)
   {
@@ -1496,12 +1497,14 @@ void GetSettings()
     s_bClearSave = !File::Exists(SConfig::GetInstance().m_strMemoryCardA);
     s_language = SConfig::GetInstance().SelectedLanguage;
   }
-  s_memcards |= (SConfig::GetInstance().m_EXIDevice[0] == EXIDEVICE_MEMORYCARD ||
-                 SConfig::GetInstance().m_EXIDevice[0] == EXIDEVICE_MEMORYCARDFOLDER)
-                << 0;
-  s_memcards |= (SConfig::GetInstance().m_EXIDevice[1] == EXIDEVICE_MEMORYCARD ||
-                 SConfig::GetInstance().m_EXIDevice[1] == EXIDEVICE_MEMORYCARDFOLDER)
-                << 1;
+  s_memcards |=
+      (SConfig::GetInstance().m_EXIDevice[0] == ExpansionInterface::EXIDEVICE_MEMORYCARD ||
+       SConfig::GetInstance().m_EXIDevice[0] == ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER)
+      << 0;
+  s_memcards |=
+      (SConfig::GetInstance().m_EXIDevice[1] == ExpansionInterface::EXIDEVICE_MEMORYCARD ||
+       SConfig::GetInstance().m_EXIDevice[1] == ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER)
+      << 1;
 
   std::array<u8, 20> revision = ConvertGitRevisionToBytes(scm_rev_git_str);
   std::copy(std::begin(revision), std::end(revision), std::begin(s_revision));

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -418,9 +418,9 @@ unsigned int NetPlayClient::OnData(sf::Packet& packet)
 
       int tmp;
       packet >> tmp;
-      g_NetPlaySettings.m_EXIDevice[0] = (TEXIDevices)tmp;
+      g_NetPlaySettings.m_EXIDevice[0] = static_cast<ExpansionInterface::TEXIDevices>(tmp);
       packet >> tmp;
-      g_NetPlaySettings.m_EXIDevice[1] = (TEXIDevices)tmp;
+      g_NetPlaySettings.m_EXIDevice[1] = static_cast<ExpansionInterface::TEXIDevices>(tmp);
 
       u32 time_low, time_high;
       packet >> time_low;
@@ -1279,7 +1279,7 @@ bool WiimoteEmu::Wiimote::NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size,
 // so all players' games get the same time
 //
 // also called from ---GUI--- thread when starting input recording
-u64 CEXIIPL::NetPlay_GetEmulatedTime()
+u64 ExpansionInterface::CEXIIPL::NetPlay_GetEmulatedTime()
 {
   std::lock_guard<std::mutex> lk(crit_netplay_client);
 

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -24,7 +24,7 @@ struct NetSettings
   bool m_CopyWiiSave;
   bool m_OCEnable;
   float m_OCFactor;
-  TEXIDevices m_EXIDevice[2];
+  ExpansionInterface::TEXIDevices m_EXIDevice[2];
 };
 
 extern NetSettings g_NetPlaySettings;

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -181,28 +181,28 @@ void GameCubeConfigPane::LoadGUIValues()
 
     switch (SConfig::GetInstance().m_EXIDevice[i])
     {
-    case EXIDEVICE_NONE:
+    case ExpansionInterface::EXIDEVICE_NONE:
       m_exi_devices[i]->SetStringSelection(slot_devices[0]);
       break;
-    case EXIDEVICE_MEMORYCARD:
+    case ExpansionInterface::EXIDEVICE_MEMORYCARD:
       isMemcard = m_exi_devices[i]->SetStringSelection(slot_devices[2]);
       break;
-    case EXIDEVICE_MEMORYCARDFOLDER:
+    case ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER:
       m_exi_devices[i]->SetStringSelection(slot_devices[3]);
       break;
-    case EXIDEVICE_GECKO:
+    case ExpansionInterface::EXIDEVICE_GECKO:
       m_exi_devices[i]->SetStringSelection(slot_devices[4]);
       break;
-    case EXIDEVICE_AGP:
+    case ExpansionInterface::EXIDEVICE_AGP:
       isMemcard = m_exi_devices[i]->SetStringSelection(slot_devices[5]);
       break;
-    case EXIDEVICE_MIC:
+    case ExpansionInterface::EXIDEVICE_MIC:
       isMic = m_exi_devices[i]->SetStringSelection(slot_devices[6]);
       break;
-    case EXIDEVICE_ETH:
+    case ExpansionInterface::EXIDEVICE_ETH:
       m_exi_devices[i]->SetStringSelection(sp1_devices[2]);
       break;
-    case EXIDEVICE_DUMMY:
+    case ExpansionInterface::EXIDEVICE_DUMMY:
     default:
       m_exi_devices[i]->SetStringSelection(slot_devices[1]);
       break;
@@ -298,30 +298,36 @@ void GameCubeConfigPane::OnSlotBButtonClick(wxCommandEvent& event)
 
 void GameCubeConfigPane::ChooseEXIDevice(const wxString& deviceName, int deviceNum)
 {
-  TEXIDevices tempType;
+  ExpansionInterface::TEXIDevices tempType;
 
   if (!deviceName.compare(_(EXIDEV_MEMCARD_STR)))
-    tempType = EXIDEVICE_MEMORYCARD;
+    tempType = ExpansionInterface::EXIDEVICE_MEMORYCARD;
   else if (!deviceName.compare(_(EXIDEV_MEMDIR_STR)))
-    tempType = EXIDEVICE_MEMORYCARDFOLDER;
+    tempType = ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER;
   else if (!deviceName.compare(_(EXIDEV_MIC_STR)))
-    tempType = EXIDEVICE_MIC;
+    tempType = ExpansionInterface::EXIDEVICE_MIC;
   else if (!deviceName.compare(_(EXIDEV_BBA_STR)))
-    tempType = EXIDEVICE_ETH;
+    tempType = ExpansionInterface::EXIDEVICE_ETH;
   else if (!deviceName.compare(_(EXIDEV_AGP_STR)))
-    tempType = EXIDEVICE_AGP;
+    tempType = ExpansionInterface::EXIDEVICE_AGP;
   else if (!deviceName.compare(_(EXIDEV_GECKO_STR)))
-    tempType = EXIDEVICE_GECKO;
+    tempType = ExpansionInterface::EXIDEVICE_GECKO;
   else if (!deviceName.compare(_(DEV_NONE_STR)))
-    tempType = EXIDEVICE_NONE;
+    tempType = ExpansionInterface::EXIDEVICE_NONE;
   else
-    tempType = EXIDEVICE_DUMMY;
+    tempType = ExpansionInterface::EXIDEVICE_DUMMY;
 
   // Gray out the memcard path button if we're not on a memcard or AGP
-  if (tempType == EXIDEVICE_MEMORYCARD || tempType == EXIDEVICE_AGP || tempType == EXIDEVICE_MIC)
+  if (tempType == ExpansionInterface::EXIDEVICE_MEMORYCARD ||
+      tempType == ExpansionInterface::EXIDEVICE_AGP ||
+      tempType == ExpansionInterface::EXIDEVICE_MIC)
+  {
     m_memcard_path[deviceNum]->Enable();
+  }
   else if (deviceNum == 0 || deviceNum == 1)
+  {
     m_memcard_path[deviceNum]->Disable();
+  }
 
   SConfig::GetInstance().m_EXIDevice[deviceNum] = tempType;
 
@@ -335,9 +341,9 @@ void GameCubeConfigPane::ChooseEXIDevice(const wxString& deviceName, int deviceN
   }
 }
 
-void GameCubeConfigPane::ChooseSlotPath(bool is_slot_a, TEXIDevices device_type)
+void GameCubeConfigPane::ChooseSlotPath(bool is_slot_a, ExpansionInterface::TEXIDevices device_type)
 {
-  bool memcard = (device_type == EXIDEVICE_MEMORYCARD);
+  bool memcard = (device_type == ExpansionInterface::EXIDEVICE_MEMORYCARD);
   std::string path;
   std::string cardname;
   std::string ext;

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -7,12 +7,15 @@
 #include <wx/arrstr.h>
 #include <wx/panel.h>
 
-enum TEXIDevices : int;
-
 class wxButton;
 class wxCheckBox;
 class wxChoice;
 class wxString;
+
+namespace ExpansionInterface
+{
+enum TEXIDevices : int;
+}
 
 class GameCubeConfigPane final : public wxPanel
 {
@@ -35,7 +38,7 @@ private:
 
   void ChooseEXIDevice(const wxString& device_name, int device_id);
   void HandleEXISlotChange(int slot, const wxString& title);
-  void ChooseSlotPath(bool is_slot_a, TEXIDevices device_type);
+  void ChooseSlotPath(bool is_slot_a, ExpansionInterface::TEXIDevices device_type);
 
   wxArrayString m_ipl_language_strings;
 


### PR DESCRIPTION
Places the remaining un-namespaced classes within the `ExpansionInterface` namespace.