### PR TITLE
ES: Remove unused string format argument in LaunchPPCTitle

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -180,8 +180,7 @@ bool ES::LaunchPPCTitle(u64 title_id, bool skip_reload)
     if (title_id == 0x0000000100000002)
     {
       PanicAlertT("Could not launch the Wii Menu because it is missing from the NAND.\n"
-                  "The emulated software will likely hang now.",
-                  title_id);
+                  "The emulated software will likely hang now.");
     }
     else
     {


### PR DESCRIPTION
Gets rid of a -Wformat-extra-args warning.