### PR TITLE
JitArm64: Fix usages in conditional code.

### DIFF
--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
@@ -231,6 +231,8 @@ void JitArm64::bclrx(UGeckoInstruction inst)
       (inst.BO & BO_DONT_DECREMENT_FLAG) == 0 || (inst.BO & BO_DONT_CHECK_CONDITION) == 0;
 
   ARM64Reg WA = gpr.GetReg();
+  ARM64Reg WB = inst.LK ? gpr.GetReg() : INVALID_REG;
+
   FixupBranch pCTRDontBranch;
   if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
   {
@@ -263,7 +265,6 @@ void JitArm64::bclrx(UGeckoInstruction inst)
 
   if (inst.LK)
   {
-    ARM64Reg WB = gpr.GetReg();
     MOVI2R(WB, js.compilerPC + 4);
     STR(INDEX_UNSIGNED, WB, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
     gpr.Unlock(WB);

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Integer.cpp
@@ -1157,28 +1157,31 @@ void JitArm64::divwx(UGeckoInstruction inst)
     gpr.BindToRegister(d, d == a || d == b);
 
     ARM64Reg WA = gpr.GetReg();
+    ARM64Reg RA = gpr.R(a);
+    ARM64Reg RB = gpr.R(b);
+    ARM64Reg RD = gpr.R(d);
 
-    FixupBranch slow1 = CBZ(gpr.R(b));
+    FixupBranch slow1 = CBZ(RB);
     MOVI2R(WA, -0x80000000LL);
-    CMP(gpr.R(a), WA);
-    CCMN(gpr.R(b), 1, 0, CC_EQ);
+    CMP(RA, WA);
+    CCMN(RB, 1, 0, CC_EQ);
     FixupBranch slow2 = B(CC_EQ);
-    SDIV(gpr.R(d), gpr.R(a), gpr.R(b));
+    SDIV(RD, RA, RB);
     FixupBranch done = B();
 
     SetJumpTarget(slow1);
     SetJumpTarget(slow2);
 
-    CMP(gpr.R(b), 0);
-    CCMP(gpr.R(a), 0, 0, CC_EQ);
-    CSETM(gpr.R(d), CC_LT);
+    CMP(RB, 0);
+    CCMP(RA, 0, 0, CC_EQ);
+    CSETM(RD, CC_LT);
 
     SetJumpTarget(done);
 
     gpr.Unlock(WA);
 
     if (inst.Rc)
-      ComputeRC(gpr.R(d));
+      ComputeRC(RD);
   }
 }
 
@@ -1333,26 +1336,28 @@ void JitArm64::srawx(UGeckoInstruction inst)
     ARM64Reg WA = gpr.GetReg();
     ARM64Reg WB = gpr.GetReg();
     ARM64Reg WC = gpr.GetReg();
+    ARM64Reg RB = gpr.R(b);
+    ARM64Reg RS = gpr.R(s);
 
-    ANDI2R(WA, gpr.R(b), 32);
-    FixupBranch bit_is_not_zero = TBNZ(gpr.R(b), 5);
+    ANDI2R(WA, RB, 32);
+    FixupBranch bit_is_not_zero = TBNZ(RB, 5);
 
-    ANDSI2R(WC, gpr.R(b), 31);
-    MOV(WB, gpr.R(s));
+    ANDSI2R(WC, RB, 31);
+    MOV(WB, RS);
     FixupBranch is_zero = B(CC_EQ);
 
-    ASRV(WB, gpr.R(s), WC);
-    FixupBranch bit_is_zero = TBZ(gpr.R(s), 31);
+    ASRV(WB, RS, WC);
+    FixupBranch bit_is_zero = TBZ(RS, 31);
 
     MOVI2R(WA, 32);
     SUB(WC, WA, WC);
-    LSL(WC, gpr.R(s), WC);
+    LSL(WC, RS, WC);
     CMP(WC, 0);
     CSET(WA, CC_NEQ);
     FixupBranch end = B();
 
     SetJumpTarget(bit_is_not_zero);
-    CMP(gpr.R(s), 0);
+    CMP(RS, 0);
     CSET(WA, CC_LT);
     CSINV(WB, WZR, WZR, CC_GE);
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -380,6 +380,9 @@ void JitArm64::lXX(UGeckoInstruction inst)
        (SConfig::GetInstance().bWii && js.op[1].inst.hex == 0x2C000000)) &&  // cmpXwi r0,0
       js.op[2].inst.hex == 0x4182fff8)                                       // beq -8
   {
+    ARM64Reg WA = gpr.GetReg();
+    ARM64Reg XA = EncodeRegTo64(WA);
+
     // if it's still 0, we can wait until the next event
     FixupBranch noIdle = CBNZ(gpr.R(d));
 
@@ -390,8 +393,6 @@ void JitArm64::lXX(UGeckoInstruction inst)
     gpr.Flush(FLUSH_MAINTAIN_STATE);
     fpr.Flush(FLUSH_MAINTAIN_STATE);
 
-    ARM64Reg WA = gpr.GetReg();
-    ARM64Reg XA = EncodeRegTo64(WA);
     MOVP2R(XA, &CoreTiming::Idle);
     BLR(XA);
     gpr.Unlock(WA);


### PR DESCRIPTION
Both GetReg() and R() will alter the state on flushing a register. So if we run out of registers (very unlikely through), the flushing code may be written in the conditional code and never gets executed.