### PR TITLE
IOS/ES: Handle imports more accurately

### DIFF
--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -4,8 +4,10 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cinttypes>
 #include <iterator>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "Common/CommonTypes.h"
@@ -159,6 +161,85 @@ std::vector<Content> GetStoredContentsFromTMD(const TMDReader& tmd)
                });
 
   return stored_contents;
+}
+
+bool InitImport(u64 title_id)
+{
+  const std::string content_dir = Common::GetTitleContentPath(title_id, Common::FROM_SESSION_ROOT);
+  const std::string data_dir = Common::GetTitleDataPath(title_id, Common::FROM_SESSION_ROOT);
+  for (const auto& dir : {content_dir, data_dir})
+  {
+    if (!File::IsDirectory(dir) && !File::CreateFullPath(dir) && !File::CreateDir(dir))
+    {
+      ERROR_LOG(IOS_ES, "InitImport: Failed to create title dirs for %016" PRIx64, title_id);
+      return false;
+    }
+  }
+
+  UIDSys uid_sys{Common::FROM_CONFIGURED_ROOT};
+  uid_sys.AddTitle(title_id);
+
+  // IOS moves the title content directory to /import if the TMD exists during an import.
+  if (File::Exists(Common::GetTMDFileName(title_id, Common::FROM_SESSION_ROOT)))
+  {
+    const std::string import_content_dir = Common::GetImportTitlePath(title_id) + "/content";
+    File::CreateFullPath(import_content_dir);
+    if (!File::Rename(content_dir, import_content_dir))
+    {
+      ERROR_LOG(IOS_ES, "InitImport: Failed to move content dir for %016" PRIx64, title_id);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool FinishImport(const IOS::ES::TMDReader& tmd)
+{
+  const u64 title_id = tmd.GetTitleId();
+  const std::string import_content_dir = Common::GetImportTitlePath(title_id) + "/content";
+
+  // Remove everything not listed in the TMD.
+  std::unordered_set<std::string> expected_entries = {"title.tmd"};
+  for (const auto& content_info : tmd.GetContents())
+    expected_entries.insert(StringFromFormat("%08x.app", content_info.id));
+  const auto entries = File::ScanDirectoryTree(import_content_dir, false);
+  for (const File::FSTEntry& entry : entries.children)
+  {
+    // There should not be any directory in there. Remove it.
+    if (entry.isDirectory)
+      File::DeleteDirRecursively(entry.physicalName);
+    else if (expected_entries.find(entry.virtualName) == expected_entries.end())
+      File::Delete(entry.physicalName);
+  }
+
+  const std::string content_dir = Common::GetTitleContentPath(title_id, Common::FROM_SESSION_ROOT);
+  if (File::IsDirectory(content_dir))
+  {
+    WARN_LOG(IOS_ES, "FinishImport: %s already exists -- removing", content_dir.c_str());
+    File::DeleteDirRecursively(content_dir);
+  }
+  if (!File::Rename(import_content_dir, content_dir))
+  {
+    ERROR_LOG(IOS_ES, "FinishImport: Failed to rename import directory to %s", content_dir.c_str());
+    return false;
+  }
+  return true;
+}
+
+bool WriteImportTMD(const IOS::ES::TMDReader& tmd)
+{
+  const std::string tmd_path = Common::RootUserPath(Common::FROM_SESSION_ROOT) + "/tmp/title.tmd";
+  File::CreateFullPath(tmd_path);
+
+  {
+    File::IOFile file(tmd_path, "wb");
+    if (!file.WriteBytes(tmd.GetRawTMD().data(), tmd.GetRawTMD().size()))
+      return false;
+  }
+
+  const std::string dest = Common::GetImportTitlePath(tmd.GetTitleId()) + "/content/title.tmd";
+  return File::Rename(tmd_path, dest);
 }
 }  // namespace ES
 }  // namespace IOS

--- a/Source/Core/Core/IOS/ES/NandUtils.h
+++ b/Source/Core/Core/IOS/ES/NandUtils.h
@@ -26,5 +26,12 @@ std::vector<u64> GetTitleImports();
 std::vector<u64> GetTitlesWithTickets();
 
 std::vector<Content> GetStoredContentsFromTMD(const TMDReader& tmd);
+
+// Start a title import.
+bool InitImport(u64 title_id);
+// Clean up the import content directory and move it back to /title.
+bool FinishImport(const IOS::ES::TMDReader& tmd);
+// Write a TMD for a title in /import atomically.
+bool WriteImportTMD(const IOS::ES::TMDReader& tmd);
 }  // namespace ES
 }  // namespace IOS


### PR DESCRIPTION
[Depends on #5115]

A set of small changes to handle title imports more accurately.

* Clean up the import directory after an import, exactly like IOS. This should prevent the title directory from having useless leftover contents, which could confuse the emulated software.

* More robust failsafe in case an import does not complete normally. IOS checks for stale imports and handles them appropriately on boot. We now do the same.

* Create all directories as IOS does. This includes the data directory.

* Finish stale imports on ES init. Probably doesn't affect anything, but since we are going to make title import somewhat more accurate, I don't see any reason not to do this.

This fixes the system menu hanging after selecting the weather channel, right after installing it. Also fixes some channels complaining about the NAND being full, because of the data directory being missing.