### PR TITLE
GeckoCodeConfig: Return vector by value for LoadCodes()

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -13,14 +13,14 @@
 
 namespace Gecko
 {
-void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<GeckoCode>& gcodes)
+std::vector<GeckoCode> LoadCodes(const IniFile& globalIni, const IniFile& localIni)
 {
-  const IniFile* inis[2] = {&globalIni, &localIni};
+  std::vector<GeckoCode> gcodes;
 
-  for (const IniFile* ini : inis)
+  for (const IniFile& ini : {globalIni, localIni})
   {
     std::vector<std::string> lines;
-    ini->GetLines("Gecko", &lines, false);
+    ini.GetLines("Gecko", &lines, false);
 
     GeckoCode gcode;
 
@@ -42,7 +42,7 @@ void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<Ge
           gcodes.push_back(gcode);
         gcode = GeckoCode();
         gcode.enabled = (1 == ss.tellg());  // silly
-        gcode.user_defined = (ini == &localIni);
+        gcode.user_defined = (&ini == &localIni);
         ss.seekg(1, std::ios_base::cur);
         // read the code name
         std::getline(ss, gcode.name, '[');  // stop at [ character (beginning of contributor name)
@@ -75,7 +75,7 @@ void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<Ge
       gcodes.push_back(gcode);
     }
 
-    ini->GetLines("Gecko_Enabled", &lines, false);
+    ini.GetLines("Gecko_Enabled", &lines, false);
 
     for (const std::string& line : lines)
     {
@@ -93,6 +93,8 @@ void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<Ge
       }
     }
   }
+
+  return gcodes;
 }
 
 // used by the SaveGeckoCodes function

--- a/Source/Core/Core/GeckoCodeConfig.h
+++ b/Source/Core/Core/GeckoCodeConfig.h
@@ -11,6 +11,6 @@ class IniFile;
 
 namespace Gecko
 {
-void LoadCodes(const IniFile& globalIni, const IniFile& localIni, std::vector<GeckoCode>& gcodes);
+std::vector<GeckoCode> LoadCodes(const IniFile& globalIni, const IniFile& localIni);
 void SaveCodes(IniFile& inifile, const std::vector<GeckoCode>& gcodes);
 }

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -155,10 +155,7 @@ void LoadPatches()
   LoadPatchSection("OnFrame", onFrame, globalIni, localIni);
   ActionReplay::LoadAndApplyCodes(globalIni, localIni);
 
-  // lil silly
-  std::vector<Gecko::GeckoCode> gcodes;
-  Gecko::LoadCodes(globalIni, localIni, gcodes);
-  Gecko::SetActiveCodes(gcodes);
+  Gecko::SetActiveCodes(Gecko::LoadCodes(globalIni, localIni));
 
   LoadSpeedhacks("Speedhacks", merged);
 }

--- a/Source/Core/DolphinWX/Cheats/GeckoCodeDiag.cpp
+++ b/Source/Core/DolphinWX/Cheats/GeckoCodeDiag.cpp
@@ -103,7 +103,7 @@ void CodeConfigPanel::LoadCodes(const IniFile& globalIni, const IniFile& localIn
 
   m_gcodes.clear();
   if (!checkRunning || Core::IsRunning())
-    Gecko::LoadCodes(globalIni, localIni, m_gcodes);
+    m_gcodes = Gecko::LoadCodes(globalIni, localIni);
 
   UpdateCodeList(checkRunning);
 }


### PR DESCRIPTION
Using an out-parameter is a leftover from C++03. Action Replay handling code already returns the vector of codes by value as well.