### PR TITLE
UICommon: Don't print --version option twice

### DIFF
--- a/Source/Core/UICommon/CommandLineParse.cpp
+++ b/Source/Core/UICommon/CommandLineParse.cpp
@@ -66,8 +66,6 @@ std::unique_ptr<optparse::OptionParser> CreateParser(ParserOptions options)
   auto parser = std::make_unique<optparse::OptionParser>();
   parser->usage("usage: %prog [options]... [FILE]...").version(scm_rev_str);
 
-  parser->add_option("--version").action("version").help("Print version and exit");
-
   parser->add_option("-u", "--user").action("store").help("User folder path");
   parser->add_option("-m", "--movie").action("store").help("Play a movie file");
   parser->add_option("-e", "--exec")


### PR DESCRIPTION
cpp-optparse already has the --version option built-in, so having our own version option results in --version being shown twice.