### PR TITLE
Breakpoints.cpp: fix format string warnings

### DIFF
--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -242,9 +242,10 @@ bool TMemCheck::Action(DebugInterface* debug_interface, u32 value, u32 addr, boo
   {
     if (log_on_hit)
     {
-      NOTICE_LOG(MEMMAP, "MBP %08x (%s) %s%i %0*x at %08x (%s)", pc,
+      NOTICE_LOG(MEMMAP, "MBP %08x (%s) %s%zu %0*x at %08x (%s)", pc,
                  debug_interface->GetDescription(pc).c_str(), write ? "Write" : "Read", size * 8,
-                 size * 2, value, addr, debug_interface->GetDescription(addr).c_str());
+                 static_cast<int>(size * 2), value, addr,
+                 debug_interface->GetDescription(addr).c_str());
     }
     if (break_on_hit)
       return true;


### PR DESCRIPTION
Fixes warnings:

```
dolphin/Source/Core/Core/PowerPC/BreakPoints.cpp:246:89: warning: format specifies type 'int' but the argument has type 'unsigned long' [-Wformat]
                 debug_interface->GetDescription(pc).c_str(), write ? "Write" : "Read", size * 8,
                                                                                        ^~~~~~~~
dolphin/Source/Core/Core/PowerPC/BreakPoints.cpp:245:50: warning: field width should have type 'int', but argument has type 'unsigned long' [-Wformat]
      NOTICE_LOG(MEMMAP, "MBP %08x (%s) %s%zu %0*x at %08x (%s)", pc,
                                              ~~~^
```