### PR TITLE
InputConfigDiagBitmaps: add switch empty cases (fixes warning)

### DIFF
--- a/Source/Core/DolphinWX/Input/InputConfigDiagBitmaps.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiagBitmaps.cpp
@@ -178,6 +178,14 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
     case ControllerEmu::GroupType::Cursor:
       ((ControllerEmu::Cursor*)g->control_group)->GetState(&x, &y, &z);
       break;
+    case ControllerEmu::GroupType::Other:
+    case ControllerEmu::GroupType::MixedTriggers:
+    case ControllerEmu::GroupType::Buttons:
+    case ControllerEmu::GroupType::Force:
+    case ControllerEmu::GroupType::Extension:
+    case ControllerEmu::GroupType::Triggers:
+    case ControllerEmu::GroupType::Slider:
+      break;
     }
 
     // ir cursor forward movement


### PR DESCRIPTION
Fixes warning:

```
dolphin/Source/Core/DolphinWX/Input/InputConfigDiagBitmaps.cpp:170:13: warning: 7 enumeration values not handled in switch: 'Other', 'MixedTriggers', 'Buttons'... [-Wswitch]
    switch (g->control_group->type)
            ^
```