### PR TITLE
DiscIO: add empty UNKNOWN_REGION case (fixes warning)

### DIFF
--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -182,6 +182,9 @@ std::string GetSysMenuVersionString(u16 title_version)
   case Region::NTSC_K:
     region_letter = "K";
     break;
+  case Region::UNKNOWN_REGION:
+    WARN_LOG(DISCIO, "Unknown Region for title: %u", title_version);
+    break;
   }
 
   switch (title_version & ~0xf)


### PR DESCRIPTION
Fixes warning:

```
dolphin/Source/Core/DiscIO/Enums.cpp:171:11: warning: enumeration value 'UNKNOWN_REGION' not handled in switch [-Wswitch]
  switch (GetSysMenuRegion(title_version))
          ^
```