### PR TITLE
MMU: comment-out unused var HW_PAGE_TAG_SHIFT

### DIFF
--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -29,7 +29,6 @@ namespace PowerPC
 constexpr size_t HW_PAGE_SIZE = 4096;
 constexpr u32 HW_PAGE_INDEX_SHIFT = 12;
 constexpr u32 HW_PAGE_INDEX_MASK = 0x3f;
-constexpr u32 HW_PAGE_TAG_SHIFT = 18;
 
 // EFB RE
 /*


### PR DESCRIPTION
It's not used, so produces a warning during compilation.