### PR TITLE
BitField: Minor cleanup

### DIFF
--- a/Source/Core/Common/BitField.h
+++ b/Source/Core/Common/BitField.h
@@ -146,8 +146,11 @@ private:
   // T is an enumeration. Note that T is wrapped within an enable_if in the
   // former case to workaround compile errors which arise when using
   // std::underlying_type<T>::type directly.
-  typedef typename std::conditional<std::is_enum<T>::value, std::underlying_type<T>,
-                                    std::enable_if<true, T>>::type::type StorageType;
+  using StorageType = typename std::conditional_t<std::is_enum<T>::value, std::underlying_type<T>,
+                                                  std::enable_if<true, T>>::type;
+
+  // Unsigned version of StorageType
+  using StorageTypeU = std::make_unsigned_t<StorageType>;
 
   constexpr T Value(std::true_type) const
   {
@@ -159,9 +162,6 @@ private:
   {
     return static_cast<T>((storage & GetMask()) >> position);
   }
-
-  // Unsigned version of StorageType
-  typedef typename std::make_unsigned<StorageType>::type StorageTypeU;
 
   static constexpr StorageType GetMask()
   {

--- a/Source/Core/Common/BitField.h
+++ b/Source/Core/Common/BitField.h
@@ -165,7 +165,7 @@ private:
 
   static constexpr StorageType GetMask()
   {
-    return (((StorageTypeU)~0) >> (8 * sizeof(T) - bits)) << position;
+    return (std::numeric_limits<StorageTypeU>::max() >> (8 * sizeof(T) - bits)) << position;
   }
 
   StorageType storage;


### PR DESCRIPTION
Allows other objects to contain BitField instances and still remain constexpr capable. Whenever we update everything to VS2017, then the assignment operator can also be made constexpr, making BitField a fully constexpr interface.

Also includes minor other cleanups.