### PR TITLE
JitAsm: Use stored_stack_pointer instead of s_saved_rsp

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -17,9 +17,6 @@
 
 using namespace Gen;
 
-// Not PowerPC state.  Can't put in 'this' because it's out of range...
-static void* s_saved_rsp;
-
 void Jit64AsmRoutineManager::Init(u8* stack_top)
 {
   m_const_pool.Init(AllocChildCodeSpace(4096), 4096);
@@ -48,7 +45,7 @@ void Jit64AsmRoutineManager::Generate()
   }
   else
   {
-    MOV(64, M(&s_saved_rsp), R(RSP));
+    MOV(64, PPCSTATE(stored_stack_pointer), R(RSP));
   }
   // something that can't pass the BLR test
   MOV(64, MDisp(RSP, 8), Imm32((u32)-1));
@@ -215,7 +212,7 @@ void Jit64AsmRoutineManager::ResetStack(X64CodeBlock& emitter)
   if (m_stack_top)
     emitter.MOV(64, R(RSP), Imm64((u64)m_stack_top - 0x20));
   else
-    emitter.MOV(64, R(RSP), M(&s_saved_rsp));
+    emitter.MOV(64, R(RSP), PPCSTATE(stored_stack_pointer));
 }
 
 void Jit64AsmRoutineManager::GenerateCommon()


### PR DESCRIPTION
daf60de47da1f46ff07d72d0c8d334ccb14e01d1 is an alternative fix that instead makes s_saved_rsp a member variable of Jit64AsmRoutineManager