### PR TITLE
Clarify the log message for unknown Wii Menu regions

### DIFF
--- a/Source/Core/DiscIO/Enums.cpp
+++ b/Source/Core/DiscIO/Enums.cpp
@@ -183,7 +183,7 @@ std::string GetSysMenuVersionString(u16 title_version)
     region_letter = "K";
     break;
   case Region::UNKNOWN_REGION:
-    WARN_LOG(DISCIO, "Unknown Region for title: %u", title_version);
+    WARN_LOG(DISCIO, "Unknown region for Wii Menu version %u", title_version);
     break;
   }
 


### PR DESCRIPTION
Saying just "title" made it seem like we are showing the title ID, but what we actually are showing is the title version.