### PR TITLE
DiscIO: initialize out args to ReadSwapped (fixes warning)

### DIFF
--- a/Source/Core/DiscIO/VolumeGC.cpp
+++ b/Source/Core/DiscIO/VolumeGC.cpp
@@ -173,7 +173,7 @@ u64 CVolumeGC::GetRawSize() const
 
 u8 CVolumeGC::GetDiscNumber() const
 {
-  u8 disc_number;
+  u8 disc_number = 0;
   ReadSwapped(6, &disc_number, false);
   return disc_number;
 }

--- a/Source/Core/DiscIO/VolumeWiiCrypted.cpp
+++ b/Source/Core/DiscIO/VolumeWiiCrypted.cpp
@@ -115,11 +115,13 @@ IOS::ES::TicketReader CVolumeWiiCrypted::GetTicket() const
 
 IOS::ES::TMDReader CVolumeWiiCrypted::GetTMD() const
 {
-  u32 tmd_size;
-  u32 tmd_address;
+  u32 tmd_size = 0;
+  u32 tmd_address = 0;
 
-  ReadSwapped(m_VolumeOffset + 0x2a4, &tmd_size, false);
-  ReadSwapped(m_VolumeOffset + 0x2a8, &tmd_address, false);
+  if (!ReadSwapped(m_VolumeOffset + 0x2a4, &tmd_size, false))
+    return {};
+  if (!ReadSwapped(m_VolumeOffset + 0x2a8, &tmd_address, false))
+    return {};
   tmd_address <<= 2;
 
   if (tmd_size > 1024 * 1024 * 4)
@@ -133,7 +135,8 @@ IOS::ES::TMDReader CVolumeWiiCrypted::GetTMD() const
   }
 
   std::vector<u8> buffer(tmd_size);
-  Read(m_VolumeOffset + tmd_address, tmd_size, buffer.data(), false);
+  if (!Read(m_VolumeOffset + tmd_address, tmd_size, buffer.data(), false))
+    return {};
 
   return IOS::ES::TMDReader{std::move(buffer)};
 }
@@ -253,7 +256,7 @@ Platform CVolumeWiiCrypted::GetVolumeType() const
 
 u8 CVolumeWiiCrypted::GetDiscNumber() const
 {
-  u8 disc_number;
+  u8 disc_number = 0;
   ReadSwapped(6, &disc_number, true);
   return disc_number;
 }


### PR DESCRIPTION
Fixes warnings:

```
../Source/Core/DiscIO/VolumeGC.cpp: In member function 'virtual u8 DiscIO::CVolumeGC::GetDiscNumber() const':
../Source/Core/DiscIO/VolumeGC.cpp:178:10: error: 'disc_number' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   return disc_number;
          ^
../Source/Core/DiscIO/VolumeWiiCrypted.cpp: In member function 'virtual u8 DiscIO::CVolumeWiiCrypted::GetDiscNumber() const':
../Source/Core/DiscIO/VolumeWiiCrypted.cpp:258:10: error: 'disc_number' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   return disc_number;
          ^
../Source/Core/DiscIO/VolumeWiiCrypted.cpp: In member function 'virtual IOS::ES::TMDReader DiscIO::CVolumeWiiCrypted::GetTMD() const':
../Source/Core/DiscIO/VolumeWiiCrypted.cpp:123:20: error: 'tmd_address' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   tmd_address <<= 2;
                    ^
```