### PR TITLE
StubHost: remove unused Host_RequestFullscreen()

### DIFF
--- a/Source/UnitTests/TestUtils/StubHost.cpp
+++ b/Source/UnitTests/TestUtils/StubHost.cpp
@@ -36,9 +36,6 @@ void Host_UpdateMainFrame()
 void Host_RequestRenderWindowSize(int, int)
 {
 }
-void Host_RequestFullscreen(bool)
-{
-}
 void Host_SetStartupDebuggingParameters()
 {
 }


### PR DESCRIPTION
Fixes warning:

```
../Source/UnitTests/TestUtils/StubHost.cpp: In function 'void Host_RequestFullscreen(bool)':
../Source/UnitTests/TestUtils/StubHost.cpp:39:6: error: no previous declaration for 'void Host_RequestFullscreen(bool)' [-Werror=missing-declarations]
 void Host_RequestFullscreen(bool)
      ^
```