### PR TITLE
BitUtilsTest: compare ints of the same signedness (fixes warnings)

### DIFF
--- a/Source/UnitTests/Common/BitUtilsTest.cpp
+++ b/Source/UnitTests/Common/BitUtilsTest.cpp
@@ -9,15 +9,15 @@
 
 TEST(BitUtils, BitSize)
 {
-  EXPECT_EQ(Common::BitSize<s8>(), 8);
-  EXPECT_EQ(Common::BitSize<s16>(), 16);
-  EXPECT_EQ(Common::BitSize<s32>(), 32);
-  EXPECT_EQ(Common::BitSize<s64>(), 64);
+  EXPECT_EQ(Common::BitSize<s8>(), 8u);
+  EXPECT_EQ(Common::BitSize<s16>(), 16u);
+  EXPECT_EQ(Common::BitSize<s32>(), 32u);
+  EXPECT_EQ(Common::BitSize<s64>(), 64u);
 
-  EXPECT_EQ(Common::BitSize<u8>(), 8);
-  EXPECT_EQ(Common::BitSize<u16>(), 16);
-  EXPECT_EQ(Common::BitSize<u32>(), 32);
-  EXPECT_EQ(Common::BitSize<u64>(), 64);
+  EXPECT_EQ(Common::BitSize<u8>(), 8u);
+  EXPECT_EQ(Common::BitSize<u16>(), 16u);
+  EXPECT_EQ(Common::BitSize<u32>(), 32u);
+  EXPECT_EQ(Common::BitSize<u64>(), 64u);
 }
 
 TEST(BitUtils, ExtractBit)
@@ -41,14 +41,14 @@ TEST(BitUtils, ExtractBits)
   //       mangling the template function usages.
 
   constexpr s32 two_hundred_four_signed = 0b0011001100;
-  EXPECT_EQ((Common::ExtractBits<2, 3>(two_hundred_four_signed)), 3);
-  EXPECT_EQ((Common::ExtractBits<2, 7>(two_hundred_four_signed)), 51);
-  EXPECT_EQ((Common::ExtractBits<3, 6>(two_hundred_four_signed)), 9);
+  EXPECT_EQ((Common::ExtractBits<2, 3>(two_hundred_four_signed)), 3u);
+  EXPECT_EQ((Common::ExtractBits<2, 7>(two_hundred_four_signed)), 51u);
+  EXPECT_EQ((Common::ExtractBits<3, 6>(two_hundred_four_signed)), 9u);
 
   constexpr u32 two_hundred_four_unsigned = 0b0011001100;
-  EXPECT_EQ((Common::ExtractBits<2, 3>(two_hundred_four_unsigned)), 3);
-  EXPECT_EQ((Common::ExtractBits<2, 7>(two_hundred_four_unsigned)), 51);
-  EXPECT_EQ((Common::ExtractBits<3, 6>(two_hundred_four_unsigned)), 9);
+  EXPECT_EQ((Common::ExtractBits<2, 3>(two_hundred_four_unsigned)), 3u);
+  EXPECT_EQ((Common::ExtractBits<2, 7>(two_hundred_four_unsigned)), 51u);
+  EXPECT_EQ((Common::ExtractBits<3, 6>(two_hundred_four_unsigned)), 9u);
 
   // Ensure bit extraction remains sign-independent even when signed types are used.
   constexpr s32 negative_one = -1;


### PR DESCRIPTION
Fixes warnings like:

```
dolphin/Source/UnitTests/Common/BitUtilsTest.cpp:5:
../Externals/gtest/googletest/include/gtest/gtest.h:1392:11: warning: comparison of integers of different signs: 'const unsigned long' and 'const int' [-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
../Externals/gtest/googletest/include/gtest/gtest.h:1421:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<unsigned long, int>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
dolphin/Source/UnitTests/Common/BitUtilsTest.cpp:12:3: note: in instantiation of function template specialization 'testing::internal::EqHelper<false>::Compare<unsigned long, int>' requested here
  EXPECT_EQ(Common::BitSize<s8>(),  8);
  ^
../Externals/gtest/googletest/include/gtest/gtest.h:1924:63: note: expanded from macro 'EXPECT_EQ'
                      EqHelper<GTEST_IS_NULL_LITERAL_(val1)>::Compare, \
```