### PR TITLE
UnitTests: use EXPECT_TRUE/EXPECT_FALSE (fixes warnings)

### DIFF
--- a/Source/UnitTests/Common/BitSetTest.cpp
+++ b/Source/UnitTests/Common/BitSetTest.cpp
@@ -11,8 +11,8 @@ TEST(BitSet, Basics)
   BitSet32 bs;
   BitSet64 bs2(1);
   BitSet64 bs3(2);
-  EXPECT_EQ(true, !!bs2);
-  EXPECT_EQ(false, !!bs);
+  EXPECT_TRUE(!!bs2);
+  EXPECT_FALSE(!!bs);
   EXPECT_EQ(bs2, bs2);
   EXPECT_NE(bs2, bs3);
   EXPECT_EQ(BitSet32(0xfff), BitSet32::AllTrue(12));
@@ -23,8 +23,8 @@ TEST(BitSet, BitGetSet)
 {
   BitSet32 bs;
   bs[3] = bs[8] = bs[11] = true;
-  EXPECT_EQ(true, bs[3]);
-  EXPECT_EQ(false, bs[4]);
+  EXPECT_TRUE(bs[3]);
+  EXPECT_FALSE(bs[4]);
   EXPECT_EQ((u32)((1 << 3) | (1 << 8) | (1 << 11)), bs.m_val);
 }
 

--- a/Source/UnitTests/Common/StringUtilTest.cpp
+++ b/Source/UnitTests/Common/StringUtilTest.cpp
@@ -19,24 +19,24 @@ TEST(StringUtil, JoinStrings)
 
 TEST(StringUtil, StringBeginsWith)
 {
-  EXPECT_EQ(true, StringBeginsWith("abc", "a"));
-  EXPECT_EQ(false, StringBeginsWith("abc", "b"));
-  EXPECT_EQ(true, StringBeginsWith("abc", "ab"));
-  EXPECT_EQ(false, StringBeginsWith("a", "ab"));
-  EXPECT_EQ(false, StringBeginsWith("", "a"));
-  EXPECT_EQ(false, StringBeginsWith("", "ab"));
-  EXPECT_EQ(true, StringBeginsWith("abc", ""));
-  EXPECT_EQ(true, StringBeginsWith("", ""));
+  EXPECT_TRUE(StringBeginsWith("abc", "a"));
+  EXPECT_FALSE(StringBeginsWith("abc", "b"));
+  EXPECT_TRUE(StringBeginsWith("abc", "ab"));
+  EXPECT_FALSE(StringBeginsWith("a", "ab"));
+  EXPECT_FALSE(StringBeginsWith("", "a"));
+  EXPECT_FALSE(StringBeginsWith("", "ab"));
+  EXPECT_TRUE(StringBeginsWith("abc", ""));
+  EXPECT_TRUE(StringBeginsWith("", ""));
 }
 
 TEST(StringUtil, StringEndsWith)
 {
-  EXPECT_EQ(true, StringEndsWith("abc", "c"));
-  EXPECT_EQ(false, StringEndsWith("abc", "b"));
-  EXPECT_EQ(true, StringEndsWith("abc", "bc"));
-  EXPECT_EQ(false, StringEndsWith("a", "ab"));
-  EXPECT_EQ(false, StringEndsWith("", "a"));
-  EXPECT_EQ(false, StringEndsWith("", "ab"));
-  EXPECT_EQ(true, StringEndsWith("abc", ""));
-  EXPECT_EQ(true, StringEndsWith("", ""));
+  EXPECT_TRUE(StringEndsWith("abc", "c"));
+  EXPECT_FALSE(StringEndsWith("abc", "b"));
+  EXPECT_TRUE(StringEndsWith("abc", "bc"));
+  EXPECT_FALSE(StringEndsWith("a", "ab"));
+  EXPECT_FALSE(StringEndsWith("", "a"));
+  EXPECT_FALSE(StringEndsWith("", "ab"));
+  EXPECT_TRUE(StringEndsWith("abc", ""));
+  EXPECT_TRUE(StringEndsWith("", ""));
 }


### PR DESCRIPTION
Using `EXPECT_EQ` with boolean literals can cause a warning in certain
versions of GCC. See https://github.com/google/googletest/issues/322

Fixes warnings:

```
../Source/UnitTests/Common/BitSetTest.cpp: In member function 'virtual void BitSet_Basics_Test::TestBody()':
../Source/UnitTests/Common/BitSetTest.cpp:15:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
../Source/UnitTests/Common/BitSetTest.cpp: In member function 'virtual void BitSet_BitGetSet_Test::TestBody()':
../Source/UnitTests/Common/BitSetTest.cpp:27:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
../Source/UnitTests/Common/StringUtilTest.cpp: In member function 'virtual void StringUtil_StringBeginsWith_Test::TestBody()':
../Source/UnitTests/Common/StringUtilTest.cpp:23:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
../Source/UnitTests/Common/StringUtilTest.cpp:25:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
../Source/UnitTests/Common/StringUtilTest.cpp:26:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
../Source/UnitTests/Common/StringUtilTest.cpp:27:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
../Source/UnitTests/Common/StringUtilTest.cpp: In member function 'virtual void StringUtil_StringEndsWith_Test::TestBody()':
../Source/UnitTests/Common/StringUtilTest.cpp:35:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
../Source/UnitTests/Common/StringUtilTest.cpp:37:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
../Source/UnitTests/Common/StringUtilTest.cpp:38:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
../Source/UnitTests/Common/StringUtilTest.cpp:39:165: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
c
```