### PR TITLE
Fix wrong address in zz_ symbol name

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -76,7 +76,7 @@ static u32 EvaluateBranchTarget(UGeckoInstruction instr, u32 pc)
 bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size)
 {
   if (!func.name.size())
-    func.name = StringFromFormat("zz_%07x_", startAddr & 0x0FFFFFF);
+    func.name = StringFromFormat("zz_%07x_", startAddr & 0x0FFFFFFF);
   if (func.analyzed)
     return true;  // No error, just already did it.
 


### PR DESCRIPTION
The previous mask was truncating one part of the address. Symbol names from the Wii System Menu were using a wrong address ```zz_0xxxxxx_``` instead of ```zz_1xxxxxx_``` if there were located around the 0x81000000 area.

Ready to be reviewed & merged. 