### PR TITLE
CoreTimingTest: make AdvanceAndCheck() static (fix warning)

### DIFF
--- a/Source/UnitTests/Core/CoreTimingTest.cpp
+++ b/Source/UnitTests/Core/CoreTimingTest.cpp
@@ -49,7 +49,8 @@ public:
   }
 };
 
-void AdvanceAndCheck(u32 idx, int downcount, int expected_lateness = 0, int cpu_downcount = 0)
+static void AdvanceAndCheck(u32 idx, int downcount, int expected_lateness = 0,
+                            int cpu_downcount = 0)
 {
   s_callbacks_ran_flags = 0;
   s_expected_callback = CB_IDS[idx];


### PR DESCRIPTION
Fixes warning:

```
../Source/UnitTests/Core/CoreTimingTest.cpp: In function 'void AdvanceAndCheck(u32, int, int, int)':
../Source/UnitTests/Core/CoreTimingTest.cpp:52:6: error: no previous declaration for 'void AdvanceAndCheck(u32, int, int, int)' [-Werror=missing-declarations]
 void AdvanceAndCheck(u32 idx, int downcount, int expected_lateness = 0, int cpu_downcount = 0)
      ^
```