### PR TITLE
android: Change the color of the selected slot to make it more visible

### DIFF
--- a/Source/Android/app/src/main/res/color/button_text_color.xml
+++ b/Source/Android/app/src/main/res/color/button_text_color.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:color="@color/dolphin_blue_dark"
+        android:state_focused="true"/>
+    <item
+        android:color="@android:color/white"/>
+</selector>

--- a/Source/Android/app/src/main/res/layout/fragment_state_load.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_state_load.xml
@@ -18,42 +18,42 @@
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot1"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_load_2"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot2"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_load_3"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot3"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_load_4"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot4"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_load_5"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot5"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_load_6"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot6"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
     </GridLayout>
 

--- a/Source/Android/app/src/main/res/layout/fragment_state_save.xml
+++ b/Source/Android/app/src/main/res/layout/fragment_state_save.xml
@@ -18,42 +18,42 @@
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot1"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_save_2"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot2"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_save_3"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot3"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_save_4"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot4"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_save_5"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot5"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
         <Button
             android:id="@+id/menu_emulation_save_6"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:text="@string/emulation_slot6"
-            style="@style/InGameMenuOption"/>
+            style="@style/OverlayInGameMenuOption"/>
 
     </GridLayout>
 

--- a/Source/Android/app/src/main/res/values/styles.xml
+++ b/Source/Android/app/src/main/res/values/styles.xml
@@ -155,4 +155,8 @@
         <item name="android:layout_margin">0dp</item>
     </style>
 
+    <style name="OverlayInGameMenuOption" parent="InGameMenuOption">
+        <item name="android:textColor">@color/button_text_color</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
On Android TV the selected slot is not cleary hilighted, this is to fix
that but changing the selected slot text color to blue.

![Here is how it looks](https://i.imgur.com/9MmWAsE.png)