### PR TITLE
MSVC: enable /Zc:throwingNew

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,16 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
   string(APPEND CMAKE_EXE_LINKER_FLAGS " /DYNAMICBASE:NO")
   string(APPEND CMAKE_EXE_LINKER_FLAGS " /FIXED")
 
+  # Enforce C++ standard conforming conversion rules to catch possible bugs
+  add_compile_options(/Zc:strictStrings)
+  add_compile_options(/Zc:rvalueCast)
+  # Remove unreferenced inline functions/data to reduce link time and catch bugs
+  add_compile_options(/Zc:inline)
+  # Assume `new` (w/o std::nothrow) throws to reduce binary size
+  add_compile_options(/Zc:throwingNew)
+  # Enforce strict volatile semantics as per ISO C++
+  add_compile_options(/volatile:iso)
+
   # Only MSBuild needs this, other generators will compile one file at a time
   if(CMAKE_GENERATOR MATCHES "Visual Studio")
     add_compile_options("/MP")

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -80,7 +80,7 @@
       <MinimalRebuild>false</MinimalRebuild>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <!--Enforce some behaviors as standards-conformant when they don't default as such-->
-      <AdditionalOptions>/Zc:inline /Zc:rvalueCast /volatile:iso %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:inline /Zc:strictStrings /Zc:rvalueCast /Zc:throwingNew /volatile:iso %(AdditionalOptions)</AdditionalOptions>
       <!--Enable detailed debug info-->
       <AdditionalOptions>/Zo %(AdditionalOptions)</AdditionalOptions>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
@@ -110,8 +110,6 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <PreprocessorDefinitions>_SECURE_SCL=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <!--This option is not supported in debug mode (for VS2013)-->
-      <AdditionalOptions>/Zc:strictStrings %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <!--Link Base-->
     <Link>


### PR DESCRIPTION
Decreases the size of Dolphin.exe by 83 KiB (VS2017 x64).

Also see https://blogs.msdn.microsoft.com/vcblog/2015/08/06/new-in-vs-2015-zcthrowingnew/.

