### PR TITLE
TextureCacheBase: Convert bound_textures from a C array to a std::array

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -472,16 +472,16 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::ReturnEntry(unsigned int st
 
 void TextureCacheBase::BindTextures()
 {
-  for (int i = 0; i < 8; ++i)
+  for (size_t i = 0; i < bound_textures.size(); ++i)
   {
     if (bound_textures[i])
-      bound_textures[i]->Bind(i);
+      bound_textures[i]->Bind(static_cast<u32>(i));
   }
 }
 
 void TextureCacheBase::UnbindTextures()
 {
-  std::fill(std::begin(bound_textures), std::end(bound_textures), nullptr);
+  bound_textures.fill(nullptr);
 }
 
 TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <map>
 #include <memory>
 #include <tuple>
@@ -176,7 +177,7 @@ protected:
   alignas(16) u8* temp = nullptr;
   size_t temp_size = 0;
 
-  TCacheEntryBase* bound_textures[8] = {};
+  std::array<TCacheEntryBase*, 8> bound_textures{};
 
 private:
   typedef std::multimap<u32, TCacheEntryBase*> TexAddrCache;


### PR DESCRIPTION
Prevents array-to-pointer decay and simplifies some code.