### PR TITLE
DSPIntUtil: make dsp_op_read_reg param a size_t (fixes warning) 

### DIFF
--- a/Source/Core/Core/DSP/Interpreter/DSPIntUtil.h
+++ b/Source/Core/Core/DSP/Interpreter/DSPIntUtil.h
@@ -107,9 +107,9 @@ static inline u16 dsp_decrement_addr_reg(u16 reg)
 // --- reg
 // ---------------------------------------------------------------------------------------
 
-static inline u16 dsp_op_read_reg(int _reg)
+static inline u16 dsp_op_read_reg(size_t _reg)
 {
-  int reg = _reg & 0x1f;
+  size_t reg = _reg & 0x1f;
 
   switch (reg)
   {


### PR DESCRIPTION
A `size_t` is appropriate in this case since it's being used for
indexing an array. The enum's storage is `int`, which should almost
fit into a `size_t`, and the actual values it's supposed to take are
only between 0 and 0x1f.

This fixes (likely compiler bug) GCC warnings:

```
In file included from dolphin/Source/Core/Core/DSP/Interpreter/DSPIntLoadStore.cpp:8:0:
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h: In function ‘void DSP::Interpreter::sr(DSP::UDSPInstruction)’:
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h:162:41: error: array subscript is below array bounds [-Werror=array-bounds]
     return g_dsp.r.ac[reg - DSP_REG_ACM0].m;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h: In function ‘void DSP::Interpreter::srr(DSP::UDSPInstruction)’:
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h:162:41: error: array subscript is below array bounds [-Werror=array-bounds]
     return g_dsp.r.ac[reg - DSP_REG_ACM0].m;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h: In function ‘void DSP::Interpreter::srrd(DSP::UDSPInstruction)’:
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h:162:41: error: array subscript is below array bounds [-Werror=array-bounds]
     return g_dsp.r.ac[reg - DSP_REG_ACM0].m;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h: In function ‘void DSP::Interpreter::srri(DSP::UDSPInstruction)’:
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h:162:41: error: array subscript is below array bounds [-Werror=array-bounds]
     return g_dsp.r.ac[reg - DSP_REG_ACM0].m;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h: In function ‘void DSP::Interpreter::srrn(DSP::UDSPInstruction)’:
../Source/Core/Core/DSP/Interpreter/DSPIntUtil.h:162:41: error: array subscript is below array bounds [-Werror=array-bounds]
     return g_dsp.r.ac[reg - DSP_REG_ACM0].m;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```

The smallest reproduction of this warning that I found is:

```

enum {
  ACM0 = 1,
  ACM1
};

uint16_t ac[2];
void foo(uint16_t);

static inline uint16_t read(int reg)
{
  switch (reg)
  {
  case ACM0:
  case ACM1:
    return ac[reg - ACM0];
  default:
    return 0;
  }

}

void srs(uint8_t reg)
{
  if (reg < ACM0)
    foo(read(reg));
}
```