### PR TITLE
EGL: Fix missing-braces warning

### DIFF
--- a/Source/Core/Common/GL/GLInterface/EGL.cpp
+++ b/Source/Core/Common/GL/GLInterface/EGL.cpp
@@ -50,10 +50,10 @@ void cInterfaceEGL::DetectMode()
 
   EGLint num_configs;
   bool supportsGL = false, supportsGLES2 = false, supportsGLES3 = false;
-  std::array<int, 3> renderable_types = {
+  std::array<int, 3> renderable_types{{
       EGL_OPENGL_BIT, (1 << 6), /* EGL_OPENGL_ES3_BIT_KHR */
       EGL_OPENGL_ES2_BIT,
-  };
+  }};
 
   for (auto renderable_type : renderable_types)
   {


### PR DESCRIPTION
Fixes warning:

```
../Source/Core/Common/GL/GLInterface/EGL.cpp:57:7: warning: suggest braces around initialization of subobject [-Wmissing-braces]
      EGL_OPENGL_BIT, (1 << 6), /* EGL_OPENGL_ES3_BIT_KHR */
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```