### PR TITLE
Jit64: Fix crash at startup

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -36,6 +36,11 @@ void Jit64AsmRoutineManager::Generate()
   // for the shadow region before calls in this function.  This call will
   // waste a bit of space for a second shadow, but whatever.
   ABI_PushRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8, /*frame*/ 16);
+
+  // Two statically allocated registers.
+  // MOV(64, R(RMEM), Imm64((u64)Memory::physical_base));
+  MOV(64, R(RPPCSTATE), Imm64((u64)&PowerPC::ppcState + 0x80));
+
   if (m_stack_top)
   {
     // Pivot the stack to our custom one.
@@ -49,10 +54,6 @@ void Jit64AsmRoutineManager::Generate()
   }
   // something that can't pass the BLR test
   MOV(64, MDisp(RSP, 8), Imm32((u32)-1));
-
-  // Two statically allocated registers.
-  // MOV(64, R(RMEM), Imm64((u64)Memory::physical_base));
-  MOV(64, R(RPPCSTATE), Imm64((u64)&PowerPC::ppcState + 0x80));
 
   const u8* outerLoop = GetCodePtr();
   ABI_PushRegistersAndAdjustStack({}, 0);


### PR DESCRIPTION
This was a regression introduced by 4d8d045. stored_stack_pointer within PPCSTATE was being accessed before the PPCSTATE (RBP) register was initialized.

No clue if this is the correct fix or not, since it's not really my area, but it does fix the crash for me.