### PR TITLE
VertexLoaderTest: fix maybe-uninitialized warning

### DIFF
--- a/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
+++ b/Source/UnitTests/VideoCommon/VertexLoaderTest.cpp
@@ -218,6 +218,8 @@ TEST_P(VertexLoaderParamTest, PositionAll)
       f = *iter++;
       g = *iter++;
       break;
+    default:
+      FAIL() << "Unknown format";
     }
     ExpectOut(f * scale);
     ExpectOut(g * scale);


### PR DESCRIPTION
Fixes warning:

```
../Source/UnitTests/VideoCommon/VertexLoaderTest.cpp:222:15: error: variable 'f' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
    ExpectOut(f * scale);
              ^
../Source/UnitTests/VideoCommon/VertexLoaderTest.cpp:198:12: note: initialize the variable 'f' to silence this warning
    float f, g;
           ^
            = 0.0
../Source/UnitTests/VideoCommon/VertexLoaderTest.cpp:223:15: error: variable 'g' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
    ExpectOut(g * scale);
              ^
../Source/UnitTests/VideoCommon/VertexLoaderTest.cpp:198:15: note: initialize the variable 'g' to silence this warning
    float f, g;
              ^
               = 0.0
```