### PR TITLE
Fix incomplete Core.vcxproj.filters end-tag

### DIFF
--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -965,7 +965,7 @@
     </ClInclude>
     <ClInclude Include="FileMonitor.h">
       <Filter>FileMonitor</Filter>
-    </ClInclud
+    </ClInclude>
     <ClInclude Include="GeckoCode.h">
       <Filter>GeckoCode</Filter>
     </ClInclude>


### PR DESCRIPTION
Appears to be an oversight from #4901 that didn't really seem to bother VS, but [someone reported this one the forums](https://forums.dolphin-emu.org/Thread-odd-problems-building-in-visual-studio-15?pid=439791#pid439791)