### PR TITLE
GCMemcardDirectory: Move flush interval constant into the cpp file

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/HW/GCMemcard/GCMemcardDirectory.h"
 
+#include <chrono>
 #include <cinttypes>
 #include <cstring>
 #include <memory>
@@ -188,6 +189,7 @@ void GCMemcardDirectory::FlushThread()
   Common::SetCurrentThreadName(
       StringFromFormat("Memcard %d flushing thread", m_card_index).c_str());
 
+  constexpr std::chrono::seconds flush_interval{1};
   while (true)
   {
     // no-op until signalled

--- a/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcardDirectory.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -52,7 +51,6 @@ private:
 
   std::vector<std::string> m_loaded_saves;
   std::string m_save_directory;
-  const std::chrono::seconds flush_interval = std::chrono::seconds(1);
   Common::Event m_flush_trigger;
   std::mutex m_write_mutex;
   Common::Flag m_exiting;


### PR DESCRIPTION
This isn't necessary to be within the header, as it's an implementation detail.