### PR TITLE
Fifo: const correctness

### DIFF
--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -191,7 +191,7 @@ void SyncGPU(SyncGPUReason reason, bool may_move_read_ptr)
   }
 }
 
-void PushFifoAuxBuffer(void* ptr, size_t size)
+void PushFifoAuxBuffer(const void* ptr, size_t size)
 {
   if (size > (size_t)(s_fifo_aux_data + FIFO_SIZE - s_fifo_aux_write_ptr))
   {

--- a/Source/Core/VideoCommon/Fifo.h
+++ b/Source/Core/VideoCommon/Fifo.h
@@ -33,7 +33,7 @@ enum class SyncGPUReason
 // In deterministic GPU thread mode this waits for the GPU to be done with pending work.
 void SyncGPU(SyncGPUReason reason, bool may_move_read_ptr = true);
 
-void PushFifoAuxBuffer(void* ptr, size_t size);
+void PushFifoAuxBuffer(const void* ptr, size_t size);
 void* PopFifoAuxBuffer(size_t size);
 
 void FlushGpu();

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -288,12 +288,11 @@ void LoadIndexedXF(u32 val, int refarray)
 
 void PreprocessIndexedXF(u32 val, int refarray)
 {
-  const int index = val >> 16;
-  const int size = ((val >> 12) & 0xF) + 1;
+  const u32 index = val >> 16;
+  const u32 size = ((val >> 12) & 0xF) + 1;
 
-  const u32* new_data =
-      (u32*)Memory::GetPointer(g_preprocess_cp_state.array_bases[refarray] +
-                               g_preprocess_cp_state.array_strides[refarray] * index);
+  const u8* new_data = Memory::GetPointer(g_preprocess_cp_state.array_bases[refarray] +
+                                          g_preprocess_cp_state.array_strides[refarray] * index);
 
   const size_t buf_size = size * sizeof(u32);
   Fifo::PushFifoAuxBuffer(new_data, buf_size);

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -288,12 +288,13 @@ void LoadIndexedXF(u32 val, int refarray)
 
 void PreprocessIndexedXF(u32 val, int refarray)
 {
-  int index = val >> 16;
-  int size = ((val >> 12) & 0xF) + 1;
+  const int index = val >> 16;
+  const int size = ((val >> 12) & 0xF) + 1;
 
-  u32* new_data = (u32*)Memory::GetPointer(g_preprocess_cp_state.array_bases[refarray] +
-                                           g_preprocess_cp_state.array_strides[refarray] * index);
+  const u32* new_data =
+      (u32*)Memory::GetPointer(g_preprocess_cp_state.array_bases[refarray] +
+                               g_preprocess_cp_state.array_strides[refarray] * index);
 
-  size_t buf_size = size * sizeof(u32);
+  const size_t buf_size = size * sizeof(u32);
   Fifo::PushFifoAuxBuffer(new_data, buf_size);
 }


### PR DESCRIPTION
Basic const correctness stuff, also gets rid of a pointer cast related to this function.