### PR TITLE
BootWiiWAD: Prevents SymbolMap loading

### DIFF
--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -427,8 +427,9 @@ bool CBoot::BootUp()
 
     PatchEngine::LoadPatches();
 
-    if (LoadMapFromFilename())
-      HLE::PatchFunctions();
+    // Not bootstrapped yet, can't translate memory addresses. Thus, prevents Symbol Map usage.
+    // if (LoadMapFromFilename())
+    //   HLE::PatchFunctions();
 
     // load default image or create virtual drive from directory
     if (!_StartupPara.m_strDVDRoot.empty())


### PR DESCRIPTION
Fix an issue (a regression?) that occurs after creating a Symbol Map for Wii's WAD/NAND. Basically, each time you will boot them, you'll get spam by PanicAlert because of an invalid read. This is due to the uninitialized registers because the Wii didn't perform the bootstrap yet:
https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/Core/IOS/IPC.cpp#L734

MSR not being initialized will make ```PowerPC::HostRead*``` trigger that PanicAlert in most cases. It doesn't fix the root causes but at least is less an annoyance and allows users to load the Symbol Map later on.  

Ready to be reviewed & merged.