### PR TITLE
Fifo: Remove unnecessary integral casts

### DIFF
--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -229,8 +229,7 @@ static void ReadDataFromFifo(u32 readPtr)
     size_t existing_len = s_video_buffer_write_ptr - s_video_buffer_read_ptr;
     if (len > (size_t)(FIFO_SIZE - existing_len))
     {
-      PanicAlert("FIFO out of bounds (existing %zu + new %zu > %lu)", existing_len, len,
-                 (unsigned long)FIFO_SIZE);
+      PanicAlert("FIFO out of bounds (existing %zu + new %zu > %u)", existing_len, len, FIFO_SIZE);
       return;
     }
     memmove(s_video_buffer, s_video_buffer_read_ptr, existing_len);
@@ -267,8 +266,7 @@ static void ReadDataFromFifoOnCPU(u32 readPtr)
     size_t existing_len = write_ptr - s_video_buffer_pp_read_ptr;
     if (len > (size_t)(FIFO_SIZE - existing_len))
     {
-      PanicAlert("FIFO out of bounds (existing %zu + new %zu > %lu)", existing_len, len,
-                 (unsigned long)FIFO_SIZE);
+      PanicAlert("FIFO out of bounds (existing %zu + new %zu > %u)", existing_len, len, FIFO_SIZE);
       return;
     }
   }


### PR DESCRIPTION
Fairly basic change. `FIFO_SIZE` is a `u32`, so `%u` can just be used instead.