### PR TITLE
WX: Disable a few menu items when a Wii title is running

### DIFF
--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -984,8 +984,17 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
       }
       if (platform == DiscIO::Platform::WII_DISC || platform == DiscIO::Platform::WII_WAD)
       {
-        popupMenu.Append(IDM_OPEN_SAVE_FOLDER, _("Open Wii &save folder"));
-        popupMenu.Append(IDM_EXPORT_SAVE, _("Export Wii save (Experimental)"));
+        auto* const open_save_folder_item =
+            popupMenu.Append(IDM_OPEN_SAVE_FOLDER, _("Open Wii &save folder"));
+        auto* const export_save_item =
+            popupMenu.Append(IDM_EXPORT_SAVE, _("Export Wii save (Experimental)"));
+
+        // We should not allow the user to mess with the save folder or export saves while
+        // emulation is running, because this could result in the exported save being in
+        // an inconsistent state; the emulated software can do *anything* to its data directory,
+        // and we definitely do not want the user to touch anything in there if it's running.
+        for (auto* menu_item : {open_save_folder_item, export_save_item})
+          menu_item->Enable(!Core::IsRunning() || !SConfig::GetInstance().bWii);
       }
       popupMenu.Append(IDM_OPEN_CONTAINING_FOLDER, _("Open &containing folder"));
 
@@ -1011,7 +1020,12 @@ void CGameListCtrl::OnRightClick(wxMouseEvent& event)
       }
 
       if (platform == DiscIO::Platform::WII_WAD)
-        popupMenu.Append(IDM_LIST_INSTALL_WAD, _("Install to Wii Menu"));
+      {
+        auto* const install_wad_item =
+            popupMenu.Append(IDM_LIST_INSTALL_WAD, _("Install to Wii Menu"));
+        // This should not be allowed while emulation is running, just like the Install WAD option.
+        install_wad_item->Enable(!Core::IsRunning() || !SConfig::GetInstance().bWii);
+      }
 
       popupMenu.Append(IDM_START_NETPLAY, _("Host with Netplay"));
 

--- a/Source/Core/DolphinWX/MainMenuBar.cpp
+++ b/Source/Core/DolphinWX/MainMenuBar.cpp
@@ -514,7 +514,7 @@ void MainMenuBar::RefreshMenuLabels() const
 {
   RefreshPlayMenuLabel();
   RefreshSaveStateMenuLabels();
-  RefreshWiiSystemMenuLabel();
+  RefreshWiiToolsLabels();
 }
 
 void MainMenuBar::RefreshPlayMenuLabel() const
@@ -543,6 +543,21 @@ void MainMenuBar::RefreshSaveStateMenuLabels() const
     FindItem(IDM_SELECT_SLOT_1 + i)
         ->SetItemLabel(wxString::Format(_("Select Slot %u - %s"), slot_number, slot_string));
   }
+}
+
+void MainMenuBar::RefreshWiiToolsLabels() const
+{
+  RefreshWiiSystemMenuLabel();
+
+  // The Install WAD option should not be enabled while emulation is running, because
+  // having unexpected title changes can confuse emulated software; and of course, this is
+  // not possible on a real Wii and won't be if we have IOS LLE (or simply more accurate IOS HLE).
+  //
+  // For similar reasons, it should not be possible to export or import saves, because this can
+  // result in the emulated software being confused, or even worse, exported saves having
+  // inconsistent data.
+  for (const int index : {IDM_MENU_INSTALL_WAD, IDM_EXPORT_ALL_SAVE, IDM_IMPORT_SAVE})
+    FindItem(index)->Enable(!Core::IsRunning() || !SConfig::GetInstance().bWii);
 }
 
 void MainMenuBar::RefreshWiiSystemMenuLabel() const

--- a/Source/Core/DolphinWX/MainMenuBar.h
+++ b/Source/Core/DolphinWX/MainMenuBar.h
@@ -46,6 +46,7 @@ private:
   void RefreshMenuLabels() const;
   void RefreshPlayMenuLabel() const;
   void RefreshSaveStateMenuLabels() const;
+  void RefreshWiiToolsLabels() const;
   void RefreshWiiSystemMenuLabel() const;
 
   void ClearSavedPerspectivesMenu() const;


### PR DESCRIPTION
Unsafe and keeping them enabled would allow inaccurate behaviour that can break games.