### PR TITLE
DolphinWX/Frame: Remove GetGameListCtrl()

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1197,11 +1197,6 @@ void CFrame::DoExclusiveFullscreen(bool enable_fullscreen)
   Core::PauseAndLock(false, was_unpaused);
 }
 
-const CGameListCtrl* CFrame::GetGameListCtrl() const
-{
-  return m_GameListCtrl;
-}
-
 void CFrame::PollHotkeys(wxTimerEvent& event)
 {
   if (!HotkeyManagerEmu::IsEnabled())

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -102,7 +102,6 @@ public:
   bool RendererIsFullscreen();
   void OpenGeneralConfiguration(wxWindowID tab_id = wxID_ANY);
 
-  const CGameListCtrl* GetGameListCtrl() const;
   wxMenuBar* GetMenuBar() const override;
 
   Common::Event panic_event;


### PR DESCRIPTION
This is currently unused and shouldn't actually be a part of the frame's public interface. The event system should be used instead to dispatch messages to the game list control if necessary.