### PR TITLE
JIT64: PIE support

### DIFF
--- a/Source/Core/Common/CodeBlock.h
+++ b/Source/Core/Common/CodeBlock.h
@@ -44,11 +44,11 @@ public:
   }
 
   // Call this before you generate any code.
-  void AllocCodeSpace(size_t size, bool need_low = true)
+  void AllocCodeSpace(size_t size)
   {
     region_size = size;
     total_region_size = size;
-    region = static_cast<u8*>(Common::AllocateExecutableMemory(total_region_size, need_low));
+    region = static_cast<u8*>(Common::AllocateExecutableMemory(total_region_size));
     T::SetCodePtr(region);
   }
 

--- a/Source/Core/Common/MemoryUtil.h
+++ b/Source/Core/Common/MemoryUtil.h
@@ -9,7 +9,7 @@
 
 namespace Common
 {
-void* AllocateExecutableMemory(size_t size, bool low = true);
+void* AllocateExecutableMemory(size_t size);
 void* AllocateMemoryPages(size_t size);
 void FreeMemoryPages(void* ptr, size_t size);
 void* AllocateAlignedMemory(size_t size, size_t alignment);

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -324,7 +324,7 @@ inline OpArg ImmPtr(const void* imm)
   return Imm64((u64)imm);
 }
 
-inline u32 PtrOffset(const void* ptr, const void* base = nullptr)
+inline u32 PtrOffset(const void* ptr, const void* base)
 {
   s64 distance = (s64)ptr - (s64)base;
   if (distance >= 0x80000000LL || distance < -0x80000000LL)

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStore.cpp
@@ -347,7 +347,7 @@ void Jit64::dcbz(UGeckoInstruction inst)
     // Perform lookup to see if we can use fast path.
     MOV(32, R(RSCRATCH2), R(RSCRATCH));
     SHR(32, R(RSCRATCH2), Imm8(PowerPC::BAT_INDEX_SHIFT));
-    TEST(32, MScaled(RSCRATCH2, SCALE_4, PtrOffset(&PowerPC::dbat_table[0])),
+    TEST(32, MScaledPIC(RSCRATCH2, SCALE_4, &PowerPC::dbat_table[0]),
          Imm32(PowerPC::BAT_PHYSICAL_BIT));
     FixupBranch slow = J_CC(CC_Z, true);
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_LoadStorePaired.cpp
@@ -92,9 +92,9 @@ void Jit64::psq_stXX(UGeckoInstruction inst)
     MOVZX(32, 8, RSCRATCH, R(RSCRATCH2));
 
     if (w)
-      CALLptr(MScaled(RSCRATCH, SCALE_8, PtrOffset(asm_routines.singleStoreQuantized)));
+      CALLptr(MScaledPIC(RSCRATCH, SCALE_8, asm_routines.singleStoreQuantized));
     else
-      CALLptr(MScaled(RSCRATCH, SCALE_8, PtrOffset(asm_routines.pairedStoreQuantized)));
+      CALLptr(MScaledPIC(RSCRATCH, SCALE_8, asm_routines.pairedStoreQuantized));
   }
 
   if (update && jo.memcheck)
@@ -157,7 +157,7 @@ void Jit64::psq_lXX(UGeckoInstruction inst)
     AND(32, R(RSCRATCH2), gqr);
     MOVZX(32, 8, RSCRATCH, R(RSCRATCH2));
 
-    CALLptr(MScaled(RSCRATCH, SCALE_8, PtrOffset(&asm_routines.pairedLoadQuantized[w * 8])));
+    CALLptr(MScaledPIC(RSCRATCH, SCALE_8, &asm_routines.pairedLoadQuantized[w * 8]));
   }
 
   CVTPS2PD(fpr.RX(s), R(XMM0));

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -105,8 +105,7 @@ FixupBranch EmuCodeBlock::CheckIfSafeAddress(const OpArg& reg_value, X64Reg reg_
 
   // Perform lookup to see if we can use fast path.
   SHR(32, R(scratch), Imm8(PowerPC::BAT_INDEX_SHIFT));
-  TEST(32, MScaled(scratch, SCALE_4, PtrOffset(&PowerPC::dbat_table[0])),
-       Imm32(PowerPC::BAT_PHYSICAL_BIT));
+  TEST(32, MScaledPIC(scratch, SCALE_4, &PowerPC::dbat_table[0]), Imm32(PowerPC::BAT_PHYSICAL_BIT));
 
   if (scratch == reg_addr)
     POP(scratch);

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64AsmCommon.cpp
@@ -29,7 +29,7 @@ void CommonAsmRoutines::GenFifoWrite(int size)
 
   // Assume value in RSCRATCH
   MOV(32, R(RSCRATCH2), M(&GPFifo::m_gatherPipeCount));
-  SwapAndStore(size, MDisp(RSCRATCH2, PtrOffset(GPFifo::m_gatherPipe)), RSCRATCH);
+  SwapAndStore(size, MDispPIC(RSCRATCH2, GPFifo::m_gatherPipe), RSCRATCH);
   ADD(32, R(RSCRATCH2), Imm8(size >> 3));
   MOV(32, M(&GPFifo::m_gatherPipeCount), R(RSCRATCH2));
   RET();
@@ -71,9 +71,8 @@ void CommonAsmRoutines::GenFrsqrte()
 
   SHR(64, R(RSCRATCH), Imm8(37));
   AND(32, R(RSCRATCH), Imm32(0x7FF));
-  IMUL(32, RSCRATCH, MScaled(RSCRATCH_EXTRA, SCALE_4, PtrOffset(MathUtil::frsqrte_expected_dec)));
-  MOV(32, R(RSCRATCH_EXTRA),
-      MScaled(RSCRATCH_EXTRA, SCALE_4, PtrOffset(MathUtil::frsqrte_expected_base)));
+  IMUL(32, RSCRATCH, MScaledPIC(RSCRATCH_EXTRA, SCALE_4, MathUtil::frsqrte_expected_dec));
+  MOV(32, R(RSCRATCH_EXTRA), MScaledPIC(RSCRATCH_EXTRA, SCALE_4, MathUtil::frsqrte_expected_base));
   SUB(32, R(RSCRATCH_EXTRA), R(RSCRATCH));
   SHL(64, R(RSCRATCH_EXTRA), Imm8(26));
   OR(64, R(RSCRATCH2), R(RSCRATCH_EXTRA));  // vali |= (s64)(frsqrte_expected_base[index] -
@@ -140,11 +139,11 @@ void CommonAsmRoutines::GenFres()
   AND(32, R(RSCRATCH), Imm32(0x3FF));  // i % 1024
   AND(32, R(RSCRATCH2), Imm8(0x1F));   // i / 1024
 
-  IMUL(32, RSCRATCH, MScaled(RSCRATCH2, SCALE_4, PtrOffset(MathUtil::fres_expected_dec)));
+  IMUL(32, RSCRATCH, MScaledPIC(RSCRATCH2, SCALE_4, MathUtil::fres_expected_dec));
   ADD(32, R(RSCRATCH), Imm8(1));
   SHR(32, R(RSCRATCH), Imm8(1));
 
-  MOV(32, R(RSCRATCH2), MScaled(RSCRATCH2, SCALE_4, PtrOffset(MathUtil::fres_expected_base)));
+  MOV(32, R(RSCRATCH2), MScaledPIC(RSCRATCH2, SCALE_4, MathUtil::fres_expected_base));
   SUB(32, R(RSCRATCH2), R(RSCRATCH));
   SHL(64, R(RSCRATCH2), Imm8(29));
   OR(64, R(RSCRATCH2), R(RSCRATCH_EXTRA));  // vali |= (s64)(fres_expected_base[i / 1024] -

--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64PowerPCState.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64PowerPCState.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "Core/PowerPC/Jit64Common/Jit64Base.h"
 #include "Core/PowerPC/PowerPC.h"
 
 // We offset by 0x80 because the range of one byte memory offsets is
@@ -17,3 +18,16 @@
 #define PPCSTATE_CTR PPCSTATE(spr[SPR_CTR])
 #define PPCSTATE_SRR0 PPCSTATE(spr[SPR_SRR0])
 #define PPCSTATE_SRR1 PPCSTATE(spr[SPR_SRR1])
+
+namespace Gen
+{
+inline OpArg MScaledPIC(X64Reg scaled, int scale, const void* ptr)
+{
+  return MComplex(RPPCSTATE, scaled, scale,
+                  PtrOffset(ptr, reinterpret_cast<char*>(&PowerPC::ppcState) + 0x80));
+}
+inline OpArg MDispPIC(X64Reg value, const void* ptr)
+{
+  return MScaledPIC(value, SCALE_1, ptr);
+}
+}

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -46,7 +46,7 @@ VertexLoaderX64::VertexLoaderX64(const TVtxDesc& vtx_desc, const VAT& vtx_att)
   if (!IsInitialized())
     return;
 
-  AllocCodeSpace(4096, false);
+  AllocCodeSpace(4096);
   ClearCodeSpace();
   GenerateVertexLoader();
   WriteProtect();


### PR DESCRIPTION
- modify AllocateExecutableMemory to return memory close to the dolphin binary (this part was mostly copied from https://github.com/hrydgard/ppsspp/blob/master/Common/MemoryUtil.cpp).
- change all nullptr based offsets to use `PowerPC::ppcState + 0x80` instead, since that value is always accessible from the `RPPCSTATE` register.

the Jit64 recompiler had two restrictions:
- both the dolphin binary and the generated code need to be in the lower 2GB of virtual memory due to using absolute signed 32bit offsets.
- dolphin binary and the generated code need to be within 2GB of each other, due to using RIP addressing to access global variables.

this PR only lifts the first restriction, which is enough for most OSes that allow mapping the code space in the required range. the second restriction still needs to be addressed for other cases where the the map hint argument is ignored (linux PAX for example), by changing RIP addressing of global variables to be relative to the `RPPCSTATE` register instead.

PIE execution was tested working on archlinux and windows.