### PR TITLE
OGL: Fix MSAA being forced to 1x

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -580,6 +580,10 @@ Renderer::Renderer()
   g_Config.backend_info.bSupportsEarlyZ =
       g_ogl_config.bSupportsEarlyFragmentTests || g_ogl_config.bSupportsConservativeDepth;
 
+  glGetIntegerv(GL_MAX_SAMPLES, &g_ogl_config.max_samples);
+  if (g_ogl_config.max_samples < 1 || !g_ogl_config.bSupportsMSAA)
+    g_ogl_config.max_samples = 1;
+
   if (g_ogl_config.bSupportsDebug)
   {
     if (GLExtensions::Supports("GL_KHR_debug"))

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -170,10 +170,6 @@ bool VideoBackend::FillBackendInfo()
     return false;
   }
 
-  glGetIntegerv(GL_MAX_SAMPLES, &g_ogl_config.max_samples);
-  if (g_ogl_config.max_samples < 1 || !g_ogl_config.bSupportsMSAA)
-    g_ogl_config.max_samples = 1;
-
   // TODO: Move the remaining fields from the Renderer constructor here.
   return true;
 }


### PR DESCRIPTION
This was a regression from the remove-everything-static-from-renderer PR. bSupportsMSAA wasn't initialized at the time FillBackendInfo() was called.

As the comment indicates, it would be nice to move all of this logic out of the Renderer constructor, but this is a much larger change.