### PR TITLE
Fix disappearing gecko codes

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -17,10 +17,10 @@ std::vector<GeckoCode> LoadCodes(const IniFile& globalIni, const IniFile& localI
 {
   std::vector<GeckoCode> gcodes;
 
-  for (const IniFile& ini : {globalIni, localIni})
+  for (const IniFile* ini : {&globalIni, &localIni})
   {
     std::vector<std::string> lines;
-    ini.GetLines("Gecko", &lines, false);
+    ini->GetLines("Gecko", &lines, false);
 
     GeckoCode gcode;
 
@@ -42,7 +42,7 @@ std::vector<GeckoCode> LoadCodes(const IniFile& globalIni, const IniFile& localI
           gcodes.push_back(gcode);
         gcode = GeckoCode();
         gcode.enabled = (1 == ss.tellg());  // silly
-        gcode.user_defined = (&ini == &localIni);
+        gcode.user_defined = (ini == &localIni);
         ss.seekg(1, std::ios_base::cur);
         // read the code name
         std::getline(ss, gcode.name, '[');  // stop at [ character (beginning of contributor name)
@@ -75,7 +75,7 @@ std::vector<GeckoCode> LoadCodes(const IniFile& globalIni, const IniFile& localI
       gcodes.push_back(gcode);
     }
 
-    ini.GetLines("Gecko_Enabled", &lines, false);
+    ini->GetLines("Gecko_Enabled", &lines, false);
 
     for (const std::string& line : lines)
     {


### PR DESCRIPTION
Since https://github.com/dolphin-emu/dolphin/commit/3be53737683d03b7511a1207be8a0cd1cba57477, the brace initializer at line 20 uses the values (instead of pointers) of globalIni and localIni, creating copies of the ini files for the loop variable, and causing the  address comparison at line 45 to always fail. This commit reverts the change to pre-https://github.com/dolphin-emu/dolphin/commit/3be53737683d03b7511a1207be8a0cd1cba57477 behaviour of using pointers instead.

Fixes https://bugs.dolphin-emu.org/issues/10166