### PR TITLE
IOS/IPC: Remove unneeded forward declaration

### DIFF
--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -66,11 +66,6 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "DiscIO/NANDContentLoader.h"
 
-namespace CoreTiming
-{
-struct EventType;
-}  // namespace CoreTiming
-
 namespace IOS
 {
 namespace HLE


### PR DESCRIPTION
CoreTiming.h is already included.