### PR TITLE
IOS: Don't expose HLE::Reset()

### DIFF
--- a/Source/Core/Core/HW/WII_IPC.cpp
+++ b/Source/Core/Core/HW/WII_IPC.cpp
@@ -139,7 +139,6 @@ void Reset()
 {
   INFO_LOG(WII_IPC, "Resetting ...");
   InitState();
-  HLE::Reset();
 }
 
 void Shutdown()

--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -631,7 +631,7 @@ void Init()
   SetupMemory(IOS80_TITLE_ID, MemorySetupType::Full);
 }
 
-void Reset(const bool clear_devices)
+static void Reset()
 {
   CoreTiming::RemoveAllEvents(s_event_enqueue);
 
@@ -644,7 +644,6 @@ void Reset(const bool clear_devices)
     device.reset();
   }
 
-  if (clear_devices)
   {
     std::lock_guard<std::mutex> lock(s_device_map_mutex);
     s_device_map.clear();
@@ -658,7 +657,7 @@ void Reset(const bool clear_devices)
 
 void Shutdown()
 {
-  Reset(true);
+  Reset();
 }
 
 constexpr u64 BC_TITLE_ID = 0x0000000100000100;
@@ -687,7 +686,7 @@ bool Reload(const u64 ios_title_id)
     return false;
 
   s_active_title_id = ios_title_id;
-  Reset(true);
+  Reset();
 
   if (ios_title_id == MIOS_TITLE_ID)
   {

--- a/Source/Core/Core/IOS/IPC.h
+++ b/Source/Core/Core/IOS/IPC.h
@@ -52,8 +52,6 @@ enum IPCCommandType : u32
 
 // Init events and devices
 void Init();
-// Reset all events and devices (and optionally clear them)
-void Reset(bool clear_devices = false);
 // Shutdown
 void Shutdown();
 


### PR DESCRIPTION
This is an implementation detail that does not have to be exposed.

It was used in WII_IPC whenever the IPC gets reset, but that does not make much sense to me: the only time when IOS loses state and the IPC registers are set up again is when it's reloaded. And reloading IOS already calls Reset() indirectly.

Also, an IPC reset from the PPC definitely should not close all opened devices!

This also gets rid of a special case for clear_devices, which is now completely unneeded.