### PR TITLE
Make EXIDEVICE_MEMORYCARDFOLDER the default for slot A

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -575,7 +575,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
   core->Get("MemcardBPath", &m_strMemoryCardB);
   core->Get("AgpCartAPath", &m_strGbaCartA);
   core->Get("AgpCartBPath", &m_strGbaCartB);
-  core->Get("SlotA", (int*)&m_EXIDevice[0], ExpansionInterface::EXIDEVICE_MEMORYCARD);
+  core->Get("SlotA", (int*)&m_EXIDevice[0], ExpansionInterface::EXIDEVICE_MEMORYCARDFOLDER);
   core->Get("SlotB", (int*)&m_EXIDevice[1], ExpansionInterface::EXIDEVICE_NONE);
   core->Get("SerialPort1", (int*)&m_EXIDevice[2], ExpansionInterface::EXIDEVICE_NONE);
   core->Get("BBA_MAC", &m_bba_mac);


### PR DESCRIPTION
The average user doesn't care, and for users who mix NTSC and PAL games
it avoids the "Memory Card is formatted for another market" message. For
non-average users, it's probably fine to have save data as separate
files anyways.

Might need some interface/string changes to explain what GCI Folder is
and why it's the default?