### PR TITLE
Frame: Remove callback function prototypes from header.

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -104,7 +104,7 @@ static Common::Flag s_is_booting;
 static void* s_window_handle = nullptr;
 static std::string s_state_filename;
 static std::thread s_emu_thread;
-static StoppedCallbackFunc s_on_stopped_callback = nullptr;
+static StoppedCallbackFunc s_on_stopped_callback;
 
 static std::thread s_cpu_thread;
 static bool s_request_refresh_info = false;
@@ -938,7 +938,7 @@ void Shutdown()
 
 void SetOnStoppedCallback(StoppedCallbackFunc callback)
 {
-  s_on_stopped_callback = callback;
+  s_on_stopped_callback = std::move(callback);
 }
 
 void UpdateWantDeterminism(bool initial)

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -66,8 +66,6 @@ void DisplayMessage(const std::string& message, int time_in_ms);
 std::string GetStateFileName();
 void SetStateFileName(const std::string& val);
 
-void SetBlockStart(u32 addr);
-
 void FrameUpdateOnCPUThread();
 
 bool ShouldSkipFrame(int skipped);

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -84,7 +84,7 @@ void UpdateTitle();
 bool PauseAndLock(bool doLock, bool unpauseOnUnlock = true);
 
 // for calling back into UI code without introducing a dependency on it in core
-typedef void (*StoppedCallbackFunc)(void);
+using StoppedCallbackFunc = std::function<void()>;
 void SetOnStoppedCallback(StoppedCallbackFunc callback);
 
 // Run on the Host thread when the factors change. [NOT THREADSAFE]

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -57,7 +57,7 @@ static HEAP_ALLOC(wrkmem, LZO1X_1_MEM_COMPRESS);
 
 static std::string g_last_filename;
 
-static CallbackFunc g_onAfterLoadCb = nullptr;
+static AfterLoadCallbackFunc s_on_after_load_callback;
 
 // Temporary undo state buffer
 static std::vector<u8> g_undo_load_buffer;
@@ -607,8 +607,8 @@ void LoadAs(const std::string& filename)
     }
   }
 
-  if (g_onAfterLoadCb)
-    g_onAfterLoadCb();
+  if (s_on_after_load_callback)
+    s_on_after_load_callback();
 
   g_loadDepth--;
 
@@ -616,9 +616,9 @@ void LoadAs(const std::string& filename)
   Core::PauseAndLock(false, wasUnpaused);
 }
 
-void SetOnAfterLoadCallback(CallbackFunc callback)
+void SetOnAfterLoadCallback(AfterLoadCallbackFunc callback)
 {
-  g_onAfterLoadCb = callback;
+  s_on_after_load_callback = std::move(callback);
 }
 
 void VerifyAt(const std::string& filename)

--- a/Source/Core/Core/State.h
+++ b/Source/Core/Core/State.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -61,6 +62,6 @@ void UndoLoadState();
 void Flush();
 
 // for calling back into UI code without introducing a dependency on it in core
-typedef void (*CallbackFunc)(void);
-void SetOnAfterLoadCallback(CallbackFunc callback);
+using AfterLoadCallbackFunc = std::function<void()>;
+void SetOnAfterLoadCallback(AfterLoadCallbackFunc callback);
 }

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -174,6 +174,7 @@ private:
   wxMenuBar* CreateMenuBar() const;
 
   void InitializeTASDialogs();
+  void InitializeCoreCallbacks();
 
   // Utility
   wxWindow* GetNotebookPageFromId(wxWindowID Id);
@@ -337,6 +338,3 @@ private:
   // Event table
   DECLARE_EVENT_TABLE();
 };
-
-void OnAfterLoadCallback();
-void OnStoppedCallback();


### PR DESCRIPTION
Removes the exposed GUI callbacks and keeps them fully internal to the frame itself. This also gets rid of more `main_frame` global usages.