### PR TITLE
Core: Hide determinism global

### DIFF
--- a/Source/Core/Core/Boot/Boot_BS2Emu.cpp
+++ b/Source/Core/Core/Boot/Boot_BS2Emu.cpp
@@ -209,7 +209,7 @@ bool CBoot::SetupWiiMemory(u64 ios_title_id)
 
   if (serno.empty() || serno == "000000000")
   {
-    if (Core::g_want_determinism)
+    if (Core::WantsDeterminism())
       serno = "123456789";
     else
       serno = SettingsHandler::GenerateSerialNumber();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -91,9 +91,6 @@ static Common::Timer s_timer;
 static std::atomic<u32> s_drawn_frame;
 static std::atomic<u32> s_drawn_video;
 
-// Function declarations
-void EmuThread();
-
 static bool s_is_stopping = false;
 static bool s_hardware_initialized = false;
 static bool s_is_started = false;
@@ -126,6 +123,8 @@ static void InitIsCPUKey()
   pthread_key_create(&s_tls_is_cpu_key, nullptr);
 }
 #endif
+
+static void EmuThread();
 
 bool GetIsThrottlerTempDisabled()
 {
@@ -448,7 +447,7 @@ static void FifoPlayerThread()
 // Initialize and create emulation thread
 // Call browser: Init():s_emu_thread().
 // See the BootManager.cpp file description for a complete call schedule.
-void EmuThread()
+static void EmuThread()
 {
   const SConfig& core_parameter = SConfig::GetInstance();
   s_is_booting.Set();

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -91,9 +91,6 @@ static Common::Timer s_timer;
 static std::atomic<u32> s_drawn_frame;
 static std::atomic<u32> s_drawn_video;
 
-// Function forwarding
-void Callback_WiimoteInterruptChannel(int _number, u16 _channelID, const void* _pData, u32 _Size);
-
 // Function declarations
 void EmuThread();
 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -84,7 +84,7 @@ namespace Core
 // TODO: ugly, remove
 bool g_aspect_wide;
 
-bool g_want_determinism;
+static bool s_wants_determinism;
 
 // Declarations and definitions
 static Common::Timer s_timer;
@@ -214,6 +214,11 @@ bool IsGPUThread()
   {
     return IsCPUThread();
   }
+}
+
+bool WantsDeterminism()
+{
+  return s_wants_determinism;
 }
 
 // This is called from the GUI thread. See the booting call schedule in
@@ -943,19 +948,19 @@ void UpdateWantDeterminism(bool initial)
   // settings that depend on it, such as GPU determinism mode. should have
   // override options for testing,
   bool new_want_determinism = Movie::IsMovieActive() || NetPlay::IsNetPlayRunning();
-  if (new_want_determinism != g_want_determinism || initial)
+  if (new_want_determinism != s_wants_determinism || initial)
   {
     NOTICE_LOG(COMMON, "Want determinism <- %s", new_want_determinism ? "true" : "false");
 
     bool was_unpaused = Core::PauseAndLock(true);
 
-    g_want_determinism = new_want_determinism;
+    s_wants_determinism = new_want_determinism;
     IOS::HLE::UpdateWantDeterminism(new_want_determinism);
     Fifo::UpdateWantDeterminism(new_want_determinism);
     // We need to clear the cache because some parts of the JIT depend on want_determinism, e.g. use
     // of FMA.
     JitInterface::ClearCache();
-    Core::InitializeWiiRoot(g_want_determinism);
+    Core::InitializeWiiRoot(s_wants_determinism);
 
     Core::PauseAndLock(false, was_unpaused);
   }

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -21,8 +21,6 @@ namespace Core
 // TODO: ugly, remove
 extern bool g_aspect_wide;
 
-extern bool g_want_determinism;
-
 bool GetIsThrottlerTempDisabled();
 void SetIsThrottlerTempDisabled(bool disable);
 
@@ -50,6 +48,8 @@ bool IsRunningAndStarted();       // is running and the CPU loop has been entere
 bool IsRunningInCurrentThread();  // this tells us whether we are running in the CPU thread.
 bool IsCPUThread();               // this tells us whether we are the CPU thread.
 bool IsGPUThread();
+
+bool WantsDeterminism();
 
 // [NOT THREADSAFE] For use by Host only
 void SetState(State state);

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -260,7 +260,7 @@ void ScheduleEvent(s64 cycles_into_future, EventType* event_type, u64 userdata, 
   }
   else
   {
-    if (Core::g_want_determinism)
+    if (Core::WantsDeterminism())
     {
       ERROR_LOG(POWERPC, "Someone scheduled an off-thread \"%s\" event while netplay or "
                          "movie play/record was active.  This is likely to cause a desync.",

--- a/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPLLE.cpp
@@ -176,7 +176,7 @@ bool DSPLLE::Initialize(bool wii, bool dsp_thread)
     return false;
 
   // needs to be after DSPCore_Init for the dspjit ptr
-  if (Core::g_want_determinism || !g_dsp_jit)
+  if (Core::WantsDeterminism() || !g_dsp_jit)
     dsp_thread = false;
 
   m_wii = wii;
@@ -300,7 +300,7 @@ void DSPLLE::DSP_Update(int cycles)
 
   if (m_is_dsp_on_thread)
   {
-    if (s_request_disable_thread || Core::g_want_determinism)
+    if (s_request_disable_thread || Core::WantsDeterminism())
     {
       DSP_StopSoundStream();
       m_is_dsp_on_thread = false;

--- a/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceIPL.cpp
@@ -429,7 +429,7 @@ u32 CEXIIPL::GetEmulatedTime(u32 epoch)
   }
   else
   {
-    _assert_(!Core::g_want_determinism);
+    _assert_(!Core::WantsDeterminism());
     ltime = Common::Timer::GetLocalTimeSinceJan1970() - SystemTimers::GetLocalTimeRTCOffset();
   }
 

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -50,7 +50,7 @@ void Init()
 
   if (SConfig::GetInstance().bWii)
   {
-    Core::InitializeWiiRoot(Core::g_want_determinism);
+    Core::InitializeWiiRoot(Core::WantsDeterminism());
     IOS::Init();
     IOS::HLE::Init();  // Depends on Memory
   }

--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -44,7 +44,7 @@ GCPadStatus CSIDevice_GCAdapter::GetPadStatus()
 
 int CSIDevice_GCAdapter::RunBuffer(u8* buffer, int length)
 {
-  if (!Core::g_want_determinism)
+  if (!Core::WantsDeterminism())
   {
     // The previous check is a hack to prevent a desync due to SI devices
     // being different and returning different values on RunBuffer();

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -394,7 +394,7 @@ bool Wiimote::Step()
 
   // when a movie is active, this button status update is disabled (moved), because movies only
   // record data reports.
-  if (!Core::g_want_determinism)
+  if (!Core::WantsDeterminism())
   {
     UpdateButtonsStatus();
   }
@@ -453,7 +453,7 @@ void Wiimote::GetButtonData(u8* const data)
 {
   // when a movie is active, the button update happens here instead of Wiimote::Step, to avoid
   // potential desync issues.
-  if (Core::g_want_determinism)
+  if (Core::WantsDeterminism())
   {
     UpdateButtonsStatus();
   }

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -150,7 +150,7 @@ static s32 MapWiiSockOptNameToNative(u32 optname)
 
 IPCCommandResult NetIPTop::IOCtl(const IOCtlRequest& request)
 {
-  if (Core::g_want_determinism)
+  if (Core::WantsDeterminism())
   {
     return GetDefaultReply(IPC_EACCES);
   }
@@ -722,7 +722,7 @@ IPCCommandResult NetIPTop::HandleGetInterfaceOptRequest(const IOCtlVRequest& req
   {
     u32 address = 0;
 #ifdef _WIN32
-    if (!Core::g_want_determinism)
+    if (!Core::WantsDeterminism())
     {
       PIP_ADAPTER_ADDRESSES AdapterAddresses = nullptr;
       ULONG OutBufferLength = 0;

--- a/Source/Core/Core/IOS/Network/MACUtils.cpp
+++ b/Source/Core/Core/IOS/Network/MACUtils.cpp
@@ -29,7 +29,7 @@ void GetMACAddress(u8* mac)
   // exist or can't be parsed.
   std::string wireless_mac = SConfig::GetInstance().m_WirelessMac;
 
-  if (Core::g_want_determinism)
+  if (Core::WantsDeterminism())
     wireless_mac = "12:34:56:78:9a:bc";
 
   if (!Common::StringToMacAddress(wireless_mac, mac))

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -171,7 +171,7 @@ IPCCommandResult NetSSL::IOCtlV(const IOCtlVRequest& request)
 
   // I don't trust SSL to be deterministic, and this is never going to sync
   // as such (as opposed to forwarding IPC results or whatever), so -
-  if (Core::g_want_determinism)
+  if (Core::WantsDeterminism())
     return GetDefaultReply(IPC_EACCES);
 
   switch (request.request)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -42,9 +42,9 @@ namespace Device
 BluetoothEmu::BluetoothEmu(u32 device_id, const std::string& device_name)
     : BluetoothBase(device_id, device_name)
 {
-  SysConf sysconf{Core::g_want_determinism ? Common::FromWhichRoot::FROM_SESSION_ROOT :
+  SysConf sysconf{Core::WantsDeterminism() ? Common::FromWhichRoot::FROM_SESSION_ROOT :
                                              Common::FromWhichRoot::FROM_CONFIGURED_ROOT};
-  if (!Core::g_want_determinism)
+  if (!Core::WantsDeterminism())
     BackUpBTInfoSection(&sysconf);
 
   _conf_pads BT_DINF;

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -107,7 +107,7 @@ bool USBHost::ShouldAddDevice(const USB::Device& device) const
 // This is called from the scan thread. Returns false if we failed to update the device list.
 bool USBHost::UpdateDevices(const bool always_add_hooks)
 {
-  if (Core::g_want_determinism)
+  if (Core::WantsDeterminism())
     return true;
 
   DeviceChangeHooks hooks;
@@ -201,7 +201,7 @@ void USBHost::DispatchHooks(const DeviceChangeHooks& hooks)
 
 void USBHost::StartThreads()
 {
-  if (Core::g_want_determinism)
+  if (Core::WantsDeterminism())
     return;
 
   if (!m_scan_thread_running.IsSet())

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -71,7 +71,7 @@ IPCCommandResult USB_KBD::Write(const ReadWriteRequest& request)
 
 IPCCommandResult USB_KBD::IOCtl(const IOCtlRequest& request)
 {
-  if (SConfig::GetInstance().m_WiiKeyboard && !Core::g_want_determinism && !m_MessageQueue.empty())
+  if (SConfig::GetInstance().m_WiiKeyboard && !Core::WantsDeterminism() && !m_MessageQueue.empty())
   {
     Memory::CopyToEmu(request.buffer_out, &m_MessageQueue.front(), sizeof(SMessageData));
     m_MessageQueue.pop();
@@ -94,7 +94,7 @@ bool USB_KBD::IsKeyPressed(int _Key)
 
 void USB_KBD::Update()
 {
-  if (!SConfig::GetInstance().m_WiiKeyboard || Core::g_want_determinism || !m_is_active)
+  if (!SConfig::GetInstance().m_WiiKeyboard || Core::WantsDeterminism() || !m_is_active)
     return;
 
   u8 Modifiers = 0x00;

--- a/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_FloatingPoint.cpp
@@ -260,7 +260,7 @@ void Jit64::fmaddXX(UGeckoInstruction inst)
       Force25BitPrecision(XMM1, R(XMM1), XMM0);
     break;
   default:
-    bool special = inst.SUBOP5 == 30 && (!cpu_info.bFMA || Core::g_want_determinism);
+    bool special = inst.SUBOP5 == 30 && (!cpu_info.bFMA || Core::WantsDeterminism());
     X64Reg tmp1 = special ? XMM0 : XMM1;
     X64Reg tmp2 = special ? XMM1 : XMM0;
     if (single && round_input)
@@ -276,7 +276,7 @@ void Jit64::fmaddXX(UGeckoInstruction inst)
   // Note that FMA isn't necessarily less correct (it may actually be closer to correct) compared
   // to what the Gekko does here; in deterministic mode, the important thing is multiple Dolphin
   // instances on different computers giving identical results.
-  if (cpu_info.bFMA && !Core::g_want_determinism)
+  if (cpu_info.bFMA && !Core::WantsDeterminism())
   {
     // Statistics suggests b is a lot less likely to be unbound in practice, so
     // if we have to pick one of a or b to bind, let's make it b.

--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -224,7 +224,7 @@ void AdvancedConfigPane::OnUpdateCPUClockControls(wxUpdateUIEvent& event)
     return;
   }
 
-  event.Enable(!Core::g_want_determinism);
+  event.Enable(!Core::WantsDeterminism());
 }
 
 void AdvancedConfigPane::OnUpdateRTCDateTimeEntries(wxUpdateUIEvent& event)

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -91,7 +91,7 @@ void ControllerConfigDiag::UpdateUI()
 
     const bool wii_game_started =
         SConfig::GetInstance().bWii || Core::GetState() == Core::State::Uninitialized;
-    if (Core::g_want_determinism || !wii_game_started)
+    if (Core::WantsDeterminism() || !wii_game_started)
       m_wiimote_sources[i]->Disable();
     if (!wii_game_started ||
         (g_wiimote_sources[i] != WIIMOTE_SRC_EMU && g_wiimote_sources[i] != WIIMOTE_SRC_HYBRID))
@@ -179,7 +179,7 @@ wxSizer* ControllerConfigDiag::CreateGamecubeSizer()
     pad_type_choices[i]->Bind(wxEVT_CHOICE, &ControllerConfigDiag::OnGameCubePortChanged, this);
 
     // Disable controller type selection for certain circumstances.
-    if (Core::g_want_determinism)
+    if (Core::WantsDeterminism())
       pad_type_choices[i]->Disable();
 
     // Set the saved pad type as the default choice.

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -453,7 +453,7 @@ GCPadStatus Input(int chan)
       pad.triggerLeft = controller_payload_copy[1 + (9 * chan) + 7];
       pad.triggerRight = controller_payload_copy[1 + (9 * chan) + 8];
     }
-    else if (!Core::g_want_determinism)
+    else if (!Core::WantsDeterminism())
     {
       // This is a hack to prevent a desync due to SI devices
       // being different and returning different values.


### PR DESCRIPTION
This global is only queried outside of Core.cpp and not modified, so it should be made hidden and just have a boolean function exposed to query it. The first two commits are minor cleanup.