### PR TITLE
TextureConversionShader: Consider source format of EFB for EFB2RAM

### DIFF
--- a/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D/PSTextureEncoder.h
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "Common/CommonTypes.h"
+#include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/VideoCommon.h"
 
 struct ID3D11Texture2D;
@@ -31,32 +32,19 @@ public:
 
   void Init();
   void Shutdown();
-  void Encode(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-              u32 memory_stride, bool is_depth_copy, const EFBRectangle& srcRect, bool isIntensity,
-              bool scaleByHalf);
+  void Encode(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
+              u32 num_blocks_y, u32 memory_stride, bool is_depth_copy, const EFBRectangle& src_rect,
+              bool scale_by_half);
 
 private:
+  ID3D11PixelShader* GetEncodingPixelShader(const EFBCopyFormat& format);
+
   bool m_ready;
 
   ID3D11Texture2D* m_out;
   ID3D11RenderTargetView* m_outRTV;
   ID3D11Texture2D* m_outStage;
   ID3D11Buffer* m_encodeParams;
-
-  ID3D11PixelShader* SetStaticShader(unsigned int dstFormat, bool is_depth_copy, bool isIntensity,
-                                     bool scaleByHalf);
-
-  typedef unsigned int ComboKey;  // Key for a shader combination
-
-  ComboKey MakeComboKey(unsigned int dstFormat, bool is_depth_copy, bool isIntensity,
-                        bool scaleByHalf)
-  {
-    return (dstFormat << 4) | (static_cast<int>(is_depth_copy) << 2) |
-           (isIntensity ? (1 << 1) : 0) | (scaleByHalf ? (1 << 0) : 0);
-  }
-
-  typedef std::map<ComboKey, ID3D11PixelShader*> ComboMap;
-
-  ComboMap m_staticShaders;
+  std::map<EFBCopyFormat, ID3D11PixelShader*> m_encoding_shaders;
 };
 }

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -241,12 +241,12 @@ void TextureCache::TCacheEntry::FromRenderTarget(bool is_depth_copy, const EFBRe
   g_renderer->RestoreAPIState();
 }
 
-void TextureCache::CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row,
-                           u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-                           const EFBRectangle& srcRect, bool isIntensity, bool scaleByHalf)
+void TextureCache::CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width,
+                           u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+                           bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half)
 {
   g_encoder->Encode(dst, format, native_width, bytes_per_row, num_blocks_y, memory_stride,
-                    is_depth_copy, srcRect, isIntensity, scaleByHalf);
+                    is_depth_copy, src_rect, scale_by_half);
 }
 
 const char palette_shader[] =

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -51,9 +51,9 @@ private:
   void ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* unconverted, void* palette,
                       TlutFormat format) override;
 
-  void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-               u32 memory_stride, bool is_depth_copy, const EFBRectangle& srcRect, bool isIntensity,
-               bool scaleByHalf) override;
+  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
+               const EFBRectangle& src_rect, bool scale_by_half) override;
 
   bool CompileShaders() override { return true; }
   void DeleteShaders() override {}

--- a/Source/Core/VideoBackends/D3D12/PSTextureEncoder.h
+++ b/Source/Core/VideoBackends/D3D12/PSTextureEncoder.h
@@ -9,6 +9,7 @@
 
 #include "Common/CommonTypes.h"
 #include "VideoBackends/D3D12/D3DBase.h"
+#include "VideoCommon/TextureConversionShader.h"
 #include "VideoCommon/VideoCommon.h"
 
 namespace DX12
@@ -20,11 +21,13 @@ public:
 
   void Init();
   void Shutdown();
-  void Encode(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-              u32 memory_stride, bool is_depth_copy, const EFBRectangle& src_rect,
-              bool is_intensity, bool scale_by_half);
+  void Encode(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
+              u32 num_blocks_y, u32 memory_stride, bool is_depth_copy, const EFBRectangle& src_rect,
+              bool scale_by_half);
 
 private:
+  D3D12_SHADER_BYTECODE GetEncodingPixelShader(const EFBCopyFormat& format);
+
   bool m_ready = false;
 
   ID3D12Resource* m_out = nullptr;
@@ -35,19 +38,7 @@ private:
   ID3D12Resource* m_encode_params_buffer = nullptr;
   void* m_encode_params_buffer_data = nullptr;
 
-  D3D12_SHADER_BYTECODE SetStaticShader(unsigned int dst_format, bool is_depth_copy,
-                                        bool is_intensity, bool scale_by_half);
-
-  using ComboKey = unsigned int;  // Key for a shader combination
-  static ComboKey MakeComboKey(unsigned int dst_format, bool is_depth_copy, bool is_intensity,
-                               bool scale_by_half)
-  {
-    return (dst_format << 4) | (is_depth_copy << 2) | (is_intensity ? (1 << 1) : 0) |
-           (scale_by_half ? (1 << 0) : 0);
-  }
-
-  using ComboMap = std::map<ComboKey, D3D12_SHADER_BYTECODE>;
-  ComboMap m_static_shaders_map;
-  std::vector<ID3DBlob*> m_static_shaders_blobs;
+  std::map<EFBCopyFormat, D3D12_SHADER_BYTECODE> m_encoding_shaders;
+  std::vector<ID3DBlob*> m_shader_blobs;
 };
 }

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -306,12 +306,12 @@ void TextureCache::TCacheEntry::FromRenderTarget(bool is_depth_copy, const EFBRe
   g_renderer->RestoreAPIState();
 }
 
-void TextureCache::CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row,
-                           u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-                           const EFBRectangle& srcRect, bool isIntensity, bool scaleByHalf)
+void TextureCache::CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width,
+                           u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+                           bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half)
 {
   s_encoder->Encode(dst, format, native_width, bytes_per_row, num_blocks_y, memory_stride,
-                    is_depth_copy, srcRect, isIntensity, scaleByHalf);
+                    is_depth_copy, src_rect, scale_by_half);
 }
 
 static const constexpr char s_palette_shader_hlsl[] =

--- a/Source/Core/VideoBackends/D3D12/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.h
@@ -60,9 +60,9 @@ private:
   void ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* unconverted, void* palette,
                       TlutFormat format) override;
 
-  void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-               u32 memory_stride, bool is_depth_copy, const EFBRectangle& src_rect,
-               bool is_intensity, bool scale_by_half) override;
+  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
+               const EFBRectangle& src_rect, bool scale_by_half) override;
 
   bool CompileShaders() override { return true; }
   void DeleteShaders() override {}

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -20,9 +20,9 @@ public:
   {
   }
 
-  void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-               u32 memory_stride, bool is_depth_copy, const EFBRectangle& src_rect,
-               bool is_intensity, bool scale_by_half) override
+  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
+               const EFBRectangle& src_rect, bool scale_by_half) override
   {
   }
 

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -288,13 +288,12 @@ void TextureCache::TCacheEntry::FromRenderTarget(bool is_depth_copy, const EFBRe
   g_renderer->RestoreAPIState();
 }
 
-void TextureCache::CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row,
-                           u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-                           const EFBRectangle& srcRect, bool isIntensity, bool scaleByHalf)
+void TextureCache::CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width,
+                           u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+                           bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half)
 {
   TextureConverter::EncodeToRamFromTexture(dst, format, native_width, bytes_per_row, num_blocks_y,
-                                           memory_stride, is_depth_copy, isIntensity, scaleByHalf,
-                                           srcRect);
+                                           memory_stride, is_depth_copy, src_rect, scale_by_half);
 }
 
 TextureCache::TextureCache()

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -58,9 +58,9 @@ private:
   void ConvertTexture(TCacheEntryBase* entry, TCacheEntryBase* unconverted, void* palette,
                       TlutFormat format) override;
 
-  void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-               u32 memory_stride, bool is_depth_copy, const EFBRectangle& srcRect, bool isIntensity,
-               bool scaleByHalf) override;
+  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
+               const EFBRectangle& src_rect, bool scale_by_half) override;
 
   bool CompileShaders() override;
   void DeleteShaders() override;

--- a/Source/Core/VideoBackends/OGL/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.cpp
@@ -45,10 +45,12 @@ static int s_rgbToYuyvUniform_loc;
 
 static SHADER s_yuyvToRgbProgram;
 
-// Not all slots are taken - but who cares.
-const u32 NUM_ENCODING_PROGRAMS = 64;
-static SHADER s_encodingPrograms[NUM_ENCODING_PROGRAMS];
-static int s_encodingUniforms[NUM_ENCODING_PROGRAMS];
+struct EncodingProgram
+{
+  SHADER program;
+  GLint copy_position_uniform;
+};
+static std::map<EFBCopyFormat, EncodingProgram> s_encoding_programs;
 
 static GLuint s_PBO = 0;  // for readback with different strides
 
@@ -133,41 +135,37 @@ static void CreatePrograms()
   ProgramShaderCache::CompileShader(s_yuyvToRgbProgram, VProgramYuyvToRgb, FProgramYuyvToRgb);
 }
 
-static SHADER& GetOrCreateEncodingShader(u32 format)
+static EncodingProgram& GetOrCreateEncodingShader(const EFBCopyFormat& format)
 {
-  if (format >= NUM_ENCODING_PROGRAMS)
-  {
-    PanicAlert("Unknown texture copy format: 0x%x\n", format);
-    return s_encodingPrograms[0];
-  }
+  auto iter = s_encoding_programs.find(format);
+  if (iter != s_encoding_programs.end())
+    return iter->second;
 
-  if (s_encodingPrograms[format].glprogid == 0)
-  {
-    const char* shader = TextureConversionShader::GenerateEncodingShader(format, APIType::OpenGL);
+  const char* shader = TextureConversionShader::GenerateEncodingShader(format, APIType::OpenGL);
 
 #if defined(_DEBUG) || defined(DEBUGFAST)
-    if (g_ActiveConfig.iLog & CONF_SAVESHADERS && shader)
-    {
-      static int counter = 0;
-      std::string filename =
-          StringFromFormat("%senc_%04i.txt", File::GetUserPath(D_DUMP_IDX).c_str(), counter++);
+  if (g_ActiveConfig.iLog & CONF_SAVESHADERS && shader)
+  {
+    static int counter = 0;
+    std::string filename =
+        StringFromFormat("%senc_%04i.txt", File::GetUserPath(D_DUMP_IDX).c_str(), counter++);
 
-      SaveData(filename, shader);
-    }
+    SaveData(filename, shader);
+  }
 #endif
 
-    const char* VProgram = "void main()\n"
-                           "{\n"
-                           "	vec2 rawpos = vec2(gl_VertexID&1, gl_VertexID&2);\n"
-                           "	gl_Position = vec4(rawpos*2.0-1.0, 0.0, 1.0);\n"
-                           "}\n";
+  const char* VProgram = "void main()\n"
+                         "{\n"
+                         "	vec2 rawpos = vec2(gl_VertexID&1, gl_VertexID&2);\n"
+                         "	gl_Position = vec4(rawpos*2.0-1.0, 0.0, 1.0);\n"
+                         "}\n";
 
-    ProgramShaderCache::CompileShader(s_encodingPrograms[format], VProgram, shader);
+  EncodingProgram program;
+  if (!ProgramShaderCache::CompileShader(program.program, VProgram, shader))
+    PanicAlert("Failed to compile texture encoding shader.");
 
-    s_encodingUniforms[format] =
-        glGetUniformLocation(s_encodingPrograms[format].glprogid, "position");
-  }
-  return s_encodingPrograms[format];
+  program.copy_position_uniform = glGetUniformLocation(program.program.glprogid, "position");
+  return s_encoding_programs.emplace(format, program).first->second;
 }
 
 void Init()
@@ -204,8 +202,9 @@ void Shutdown()
   s_rgbToYuyvProgram.Destroy();
   s_yuyvToRgbProgram.Destroy();
 
-  for (auto& program : s_encodingPrograms)
-    program.Destroy();
+  for (auto& program : s_encoding_programs)
+    program.second.program.Destroy();
+  s_encoding_programs.clear();
 
   s_srcTexture = 0;
   s_dstTexture = 0;
@@ -271,23 +270,24 @@ static void EncodeToRamUsingShader(GLuint srcTexture, u8* destAddr, u32 dst_line
   glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 }
 
-void EncodeToRamFromTexture(u8* dest_ptr, u32 format, u32 native_width, u32 bytes_per_row,
-                            u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-                            bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source)
+void EncodeToRamFromTexture(u8* dest_ptr, const EFBCopyFormat& format, u32 native_width,
+                            u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+                            bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half)
 {
   g_renderer->ResetAPIState();
 
-  SHADER& texconv_shader = GetOrCreateEncodingShader(format);
+  EncodingProgram& texconv_shader = GetOrCreateEncodingShader(format);
 
-  texconv_shader.Bind();
-  glUniform4i(s_encodingUniforms[format], source.left, source.top, native_width,
-              bScaleByHalf ? 2 : 1);
+  texconv_shader.program.Bind();
+  glUniform4i(texconv_shader.copy_position_uniform, src_rect.left, src_rect.top, native_width,
+              scale_by_half ? 2 : 1);
 
-  const GLuint read_texture = is_depth_copy ? FramebufferManager::ResolveAndGetDepthTarget(source) :
-                                              FramebufferManager::ResolveAndGetRenderTarget(source);
+  const GLuint read_texture = is_depth_copy ?
+                                  FramebufferManager::ResolveAndGetDepthTarget(src_rect) :
+                                  FramebufferManager::ResolveAndGetRenderTarget(src_rect);
 
   EncodeToRamUsingShader(read_texture, dest_ptr, bytes_per_row, num_blocks_y, memory_stride,
-                         bScaleByHalf > 0 && !is_depth_copy);
+                         scale_by_half && !is_depth_copy);
 
   FramebufferManager::SetFramebuffer(0);
   g_renderer->RestoreAPIState();

--- a/Source/Core/VideoBackends/OGL/TextureConverter.h
+++ b/Source/Core/VideoBackends/OGL/TextureConverter.h
@@ -7,6 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/GL/GLUtil.h"
 
+#include "VideoCommon/TextureDecoder.h"
 #include "VideoCommon/VideoCommon.h"
 
 namespace OGL
@@ -24,9 +25,9 @@ void EncodeToRamYUYV(GLuint srcTexture, const TargetRectangle& sourceRc, u8* des
 void DecodeToTexture(u32 xfbAddr, int srcWidth, int srcHeight, GLuint destTexture);
 
 // returns size of the encoded data (in bytes)
-void EncodeToRamFromTexture(u8* dest_ptr, u32 format, u32 native_width, u32 bytes_per_row,
-                            u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-                            bool bIsIntensityFmt, int bScaleByHalf, const EFBRectangle& source);
+void EncodeToRamFromTexture(u8* dest_ptr, const EFBCopyFormat& format, u32 native_width,
+                            u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+                            bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half);
 }
 
 }  // namespace OGL

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -53,9 +53,9 @@ public:
                       TlutFormat format) override
   {
   }
-  void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-               u32 memory_stride, bool is_depth_copy, const EFBRectangle& srcRect, bool isIntensity,
-               bool scaleByHalf) override
+  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
+               const EFBRectangle& src_rect, bool scale_by_half) override
   {
     EfbCopy::CopyEfb();
   }

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -88,9 +88,9 @@ void TextureCache::ConvertTexture(TCacheEntryBase* base_entry, TCacheEntryBase* 
   m_texture_converter->ConvertTexture(entry, unconverted, m_render_pass, palette, format);
 }
 
-void TextureCache::CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row,
-                           u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
-                           const EFBRectangle& src_rect, bool is_intensity, bool scale_by_half)
+void TextureCache::CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width,
+                           u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
+                           bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half)
 {
   // Flush EFB pokes first, as they're expected to be included.
   FramebufferManager::GetInstance()->FlushEFBPokes();
@@ -120,7 +120,7 @@ void TextureCache::CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_
 
   m_texture_converter->EncodeTextureToMemory(src_texture->GetView(), dst, format, native_width,
                                              bytes_per_row, num_blocks_y, memory_stride,
-                                             is_depth_copy, is_intensity, scale_by_half, src_rect);
+                                             is_depth_copy, src_rect, scale_by_half);
 
   // Transition back to original state
   src_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(), original_layout);

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.h
@@ -59,9 +59,9 @@ public:
   void ConvertTexture(TCacheEntryBase* base_entry, TCacheEntryBase* base_unconverted, void* palette,
                       TlutFormat format) override;
 
-  void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-               u32 memory_stride, bool is_depth_copy, const EFBRectangle& src_rect,
-               bool is_intensity, bool scale_by_half) override;
+  void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
+               u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
+               const EFBRectangle& src_rect, bool scale_by_half) override;
 
   void CopyRectangleFromTexture(TCacheEntry* dst_texture, const MathUtil::Rectangle<int>& dst_rect,
                                 Texture2D* src_texture, const MathUtil::Rectangle<int>& src_rect);

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.h
@@ -35,10 +35,10 @@ public:
 
   // Uses an encoding shader to copy src_texture to dest_ptr.
   // NOTE: Executes the current command buffer.
-  void EncodeTextureToMemory(VkImageView src_texture, u8* dest_ptr, u32 format, u32 native_width,
-                             u32 bytes_per_row, u32 num_blocks_y, u32 memory_stride,
-                             bool is_depth_copy, bool is_intensity, int scale_by_half,
-                             const EFBRectangle& source);
+  void EncodeTextureToMemory(VkImageView src_texture, u8* dest_ptr, const EFBCopyFormat& format,
+                             u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
+                             u32 memory_stride, bool is_depth_copy, const EFBRectangle& src_rect,
+                             bool scale_by_half);
 
   // Encodes texture to guest memory in XFB (YUYV) format.
   void EncodeTextureToMemoryYUYV(void* dst_ptr, u32 dst_width, u32 dst_stride, u32 dst_height,
@@ -55,7 +55,6 @@ public:
                      TlutFormat palette_format);
 
 private:
-  static const u32 NUM_TEXTURE_ENCODING_SHADERS = 64;
   static const u32 ENCODING_TEXTURE_WIDTH = EFB_WIDTH * 4;
   static const u32 ENCODING_TEXTURE_HEIGHT = 1024;
   static const VkFormat ENCODING_TEXTURE_FORMAT = VK_FORMAT_B8G8R8A8_UNORM;
@@ -70,7 +69,9 @@ private:
 
   bool CompilePaletteConversionShaders();
 
-  bool CompileEncodingShaders();
+  VkShaderModule CompileEncodingShader(const EFBCopyFormat& format);
+  VkShaderModule GetEncodingShader(const EFBCopyFormat& format);
+
   bool CreateEncodingRenderPass();
   bool CreateEncodingTexture();
   bool CreateEncodingDownloadTexture();
@@ -102,7 +103,7 @@ private:
   std::array<VkShaderModule, NUM_PALETTE_CONVERSION_SHADERS> m_palette_conversion_shaders = {};
 
   // Texture encoding - RGBA8->GX format in memory
-  std::array<VkShaderModule, NUM_TEXTURE_ENCODING_SHADERS> m_encoding_shaders = {};
+  std::map<EFBCopyFormat, VkShaderModule> m_encoding_shaders;
   VkRenderPass m_encoding_render_pass = VK_NULL_HANDLE;
   std::unique_ptr<Texture2D> m_encoding_render_texture;
   VkFramebuffer m_encoding_render_framebuffer = VK_NULL_HANDLE;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -969,7 +969,8 @@ void TextureCacheBase::CopyRenderTargetToTexture(u32 dstAddr, unsigned int dstFo
   ColorMask[0] = ColorMask[1] = ColorMask[2] = ColorMask[3] = 255.0f;
   ColorMask[4] = ColorMask[5] = ColorMask[6] = ColorMask[7] = 1.0f / 255.0f;
   unsigned int cbufid = -1;
-  bool efbHasAlpha = bpmem.zcontrol.pixel_format == PEControl::RGBA6_Z24;
+  u32 srcFormat = bpmem.zcontrol.pixel_format;
+  bool efbHasAlpha = srcFormat == PEControl::RGBA6_Z24;
 
   if (is_depth_copy)
   {
@@ -1278,8 +1279,9 @@ void TextureCacheBase::CopyRenderTargetToTexture(u32 dstAddr, unsigned int dstFo
 
   if (copy_to_ram)
   {
-    CopyEFB(dst, dstFormat, tex_w, bytes_per_row, num_blocks_y, dstStride, is_depth_copy, srcRect,
-            isIntensity, scaleByHalf);
+    EFBCopyFormat format(srcFormat, static_cast<TextureFormat>(dstFormat));
+    CopyEFB(dst, format, tex_w, bytes_per_row, num_blocks_y, dstStride, is_depth_copy, srcRect,
+            scaleByHalf);
   }
   else
   {

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -154,9 +154,9 @@ public:
 
   virtual TCacheEntryBase* CreateTexture(const TCacheEntryConfig& config) = 0;
 
-  virtual void CopyEFB(u8* dst, u32 format, u32 native_width, u32 bytes_per_row, u32 num_blocks_y,
-                       u32 memory_stride, bool is_depth_copy, const EFBRectangle& srcRect,
-                       bool isIntensity, bool scaleByHalf) = 0;
+  virtual void CopyEFB(u8* dst, const EFBCopyFormat& format, u32 native_width, u32 bytes_per_row,
+                       u32 num_blocks_y, u32 memory_stride, bool is_depth_copy,
+                       const EFBRectangle& src_rect, bool scale_by_half) = 0;
 
   virtual bool CompileShaders() = 0;
   virtual void DeleteShaders() = 0;

--- a/Source/Core/VideoCommon/TextureConversionShader.h
+++ b/Source/Core/VideoCommon/TextureConversionShader.h
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "Common/CommonTypes.h"
+#include "VideoCommon/TextureDecoder.h"
 
 enum class APIType;
 
@@ -15,7 +16,7 @@ namespace TextureConversionShader
 {
 u16 GetEncodedSampleCount(u32 format);
 
-const char* GenerateEncodingShader(u32 format, APIType ApiType);
+const char* GenerateEncodingShader(const EFBCopyFormat& format, APIType ApiType);
 
 // View format of the input data to the texture decoding shader.
 enum BufferFormat
@@ -39,7 +40,7 @@ struct DecodingShaderInfo
 
 // Obtain shader information for the specified texture format.
 // If this format does not have a shader written for it, returns nullptr.
-const DecodingShaderInfo* GetDecodingShaderInfo(u32 format);
+const DecodingShaderInfo* GetDecodingShaderInfo(TextureFormat format);
 
 // Determine how many bytes there are in each element of the texel buffer.
 // Needed for alignment and stride calculations.
@@ -50,6 +51,7 @@ u32 GetBytesPerBufferElement(BufferFormat buffer_format);
 std::pair<u32, u32> GetDispatchCount(const DecodingShaderInfo* info, u32 width, u32 height);
 
 // Returns the GLSL string containing the texture decoding shader for the specified format.
-std::string GenerateDecodingShader(u32 format, u32 palette_format, APIType api_type);
+std::string GenerateDecodingShader(TextureFormat format, TlutFormat palette_format,
+                                   APIType api_type);
 
 }  // namespace TextureConversionShader

--- a/Source/Core/VideoCommon/TextureDecoder.h
+++ b/Source/Core/VideoCommon/TextureDecoder.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <tuple>
 #include "Common/CommonTypes.h"
 
 enum
@@ -65,6 +66,22 @@ enum TlutFormat
   GX_TL_IA8 = 0x0,
   GX_TL_RGB565 = 0x1,
   GX_TL_RGB5A3 = 0x2,
+};
+
+struct EFBCopyFormat
+{
+  EFBCopyFormat(u32 efb_format_, TextureFormat copy_format_)
+      : efb_format(efb_format_), copy_format(copy_format_)
+  {
+  }
+
+  bool operator<(const EFBCopyFormat& rhs) const
+  {
+    return std::tie(efb_format, copy_format) < std::tie(rhs.efb_format, rhs.copy_format);
+  }
+
+  u32 efb_format;
+  TextureFormat copy_format;
 };
 
 int TexDecoder_GetTexelSizeInNibbles(int format);


### PR DESCRIPTION
Currently, we use the alpha channel from the EFB even if the current format does not include an alpha channel. Now, the alpha channel is set to 1 if the format does not have an alpha channel, as well as truncating to 5/6 bits per channel. This matches the EFB-to-texture behavior.

Some games (e.g. Zelda: OOT) depend on the alpha value being 1 in the EFB copy (or more specifically, the RGB5A3 copy shader depended on it), so #4574 caused a regression here.