### PR TITLE
ControllerEmu: Replace includes with forward declarations

### DIFF
--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -15,6 +15,7 @@
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/Setting/BooleanSetting.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCPadStatus.h"
 
 const std::string hotkey_labels[] = {

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -66,6 +66,7 @@
 #include "DolphinWX/TASInputDlg.h"
 #include "DolphinWX/WxUtils.h"
 
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/GCPadStatus.h"
 
 #include "VideoCommon/OnScreenDisplay.h"

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.h
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.h
@@ -23,12 +23,12 @@
 #include <wx/spinctrl.h>
 #include <wx/timer.h>
 
-#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerInterface/Device.h"
 
 class ControlReference;
 class DolphinSlider;
 class InputConfig;
+class InputConfigDialog;
 class wxComboBox;
 class wxListBox;
 class wxStaticBitmap;
@@ -37,8 +37,11 @@ class wxTextCtrl;
 
 namespace ControllerEmu
 {
+class BooleanSetting;
+class ControlGroup;
 class EmulatedController;
 class Extension;
+class NumericSetting;
 }
 
 class PadSetting
@@ -98,8 +101,6 @@ private:
 
   bool m_block = false;
 };
-
-class InputConfigDialog;
 
 class ControlDialog : public wxDialog
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -10,7 +10,6 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
-#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Force.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <string>
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Slider.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <string>
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Triggers.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerInterface/Device.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -14,6 +14,7 @@
 #include "InputCommon/ControllerEmu/Control/Control.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Extension.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -10,8 +10,9 @@
 #include <vector>
 
 #include "Common/IniFile.h"
-#include "InputCommon/ControlReference/ControlReference.h"
-#include "InputCommon/ControllerInterface/ControllerInterface.h"
+#include "InputCommon/ControllerInterface/Device.h"
+
+class ControllerInterface;
 
 #define sign(x) ((x) ? (x) < 0 ? -1 : 1 : 0)
 


### PR DESCRIPTION
Also moves includes to where they're actually needed. Most of the forward declarations were made possible after @ligfx split out the settings classes.