### PR TITLE
StringUtil: Fix a ctype assertion

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -12,6 +12,7 @@
 #include <istream>
 #include <iterator>
 #include <limits.h>
+#include <locale>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -63,7 +64,7 @@ std::string HexDump(const u8* data, size_t size)
       if (row_start + i < size)
       {
         char c = static_cast<char>(data[row_start + i]);
-        out += StringFromFormat("%c", isprint(c) ? c : '.');
+        out += std::isprint(c, std::locale::classic()) ? c : '.';
       }
     }
     out += "\n";


### PR DESCRIPTION
This PR fixes a ctype assertion because ```isprint``` expects the value to fit in an ```unsigned char``` and get rid of an useless ```StringFromFormat```.

Ready to be reviewed & merged.