### PR TITLE
Frame: Make cheat dialog private

### DIFF
--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include "DolphinWX/Cheats/CheatsWindow.h"
+
 #include <climits>
 #include <cstddef>
 #include <cstdio>
@@ -9,19 +11,16 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include <wx/app.h>
 #include <wx/button.h>
 #include <wx/checkbox.h>
-#include <wx/checklst.h>
 #include <wx/dialog.h>
-#include <wx/listbox.h>
-#include <wx/msgdlg.h>
 #include <wx/notebook.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>
-#include <wx/statbox.h>
-#include <wx/stattext.h>
 #include <wx/textctrl.h>
+#include <wx/utils.h>
 
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
@@ -34,12 +33,9 @@
 #include "Core/GeckoCodeConfig.h"
 #include "DolphinWX/Cheats/ActionReplayCodesPanel.h"
 #include "DolphinWX/Cheats/CheatSearchTab.h"
-#include "DolphinWX/Cheats/CheatsWindow.h"
-#include "DolphinWX/Cheats/CreateCodeDialog.h"
 #include "DolphinWX/Cheats/GeckoCodeDiag.h"
 #include "DolphinWX/Frame.h"
 #include "DolphinWX/Globals.h"
-#include "DolphinWX/Main.h"
 #include "DolphinWX/WxUtils.h"
 
 wxDEFINE_EVENT(DOLPHIN_EVT_ADD_NEW_ACTION_REPLAY_CODE, wxCommandEvent);
@@ -65,13 +61,9 @@ wxCheatsWindow::wxCheatsWindow(wxWindow* const parent)
   SetLayoutAdaptationMode(wxDIALOG_ADAPTATION_MODE_ENABLED);
   SetLayoutAdaptationLevel(wxDIALOG_ADAPTATION_STANDARD_SIZER);
   Center();
-  Show();
 }
 
-wxCheatsWindow::~wxCheatsWindow()
-{
-  main_frame->g_CheatsWindow = nullptr;
-}
+wxCheatsWindow::~wxCheatsWindow() = default;
 
 void wxCheatsWindow::CreateGUI()
 {
@@ -139,8 +131,7 @@ void wxCheatsWindow::CreateGUI()
   m_notebook_main->AddPage(m_tab_log, _("Logging"));
 
   Bind(wxEVT_BUTTON, &wxCheatsWindow::OnEvent_ApplyChanges_Press, this, wxID_APPLY);
-  Bind(wxEVT_BUTTON, &wxCheatsWindow::OnEvent_ButtonClose_Press, this, wxID_CANCEL);
-  Bind(wxEVT_CLOSE_WINDOW, &wxCheatsWindow::OnEvent_Close, this);
+  Bind(wxEVT_CLOSE_WINDOW, &wxCheatsWindow::OnClose, this);
   Bind(DOLPHIN_EVT_ADD_NEW_ACTION_REPLAY_CODE, &wxCheatsWindow::OnNewARCodeCreated, this);
 
   wxStdDialogButtonSizer* const sButtons = CreateStdDialogButtonSizer(wxAPPLY | wxCANCEL);
@@ -158,15 +149,9 @@ void wxCheatsWindow::CreateGUI()
   SetSizerAndFit(sMain);
 }
 
-void wxCheatsWindow::OnEvent_ButtonClose_Press(wxCommandEvent&)
+void wxCheatsWindow::OnClose(wxCloseEvent&)
 {
-  Close();
-}
-
-void wxCheatsWindow::OnEvent_Close(wxCloseEvent&)
-{
-  // This dialog is created on the heap instead of the stack so we have to destroy ourself.
-  Destroy();
+  Hide();
 }
 
 // load codes for a new ISO ID

--- a/Source/Core/DolphinWX/Cheats/CheatsWindow.h
+++ b/Source/Core/DolphinWX/Cheats/CheatsWindow.h
@@ -67,9 +67,8 @@ private:
   // Cheat Search
   void OnNewARCodeCreated(wxCommandEvent& ev);
 
-  // Close Button
-  void OnEvent_ButtonClose_Press(wxCommandEvent& event);
-  void OnEvent_Close(wxCloseEvent& ev);
+  // Dialog close event
+  void OnClose(wxCloseEvent&);
 
   // Changes to the INI (affects cheat listings)
   void OnLocalGameIniModified(wxCommandEvent& event);

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -86,7 +86,6 @@ public:
   // These have to be public
   CCodeWindow* g_pCodeWindow = nullptr;
   NetPlaySetupFrame* g_NetPlaySetupDiag = nullptr;
-  wxCheatsWindow* g_CheatsWindow = nullptr;
 
   void DoStop();
   void UpdateGUI();
@@ -139,6 +138,7 @@ private:
   LogConfigWindow* m_LogConfigWindow = nullptr;
   FifoPlayerDlg* m_FifoPlayerDlg = nullptr;
   std::array<TASInputDlg*, 8> m_tas_input_dialogs{};
+  wxCheatsWindow* m_cheats_window = nullptr;
   bool UseDebugger = false;
   bool m_bBatchMode = false;
   bool m_bEdit = false;

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -1169,10 +1169,11 @@ void CFrame::OnImportSave(wxCommandEvent& WXUNUSED(event))
 
 void CFrame::OnShowCheatsWindow(wxCommandEvent& WXUNUSED(event))
 {
-  if (!g_CheatsWindow)
-    g_CheatsWindow = new wxCheatsWindow(this);
-  else
-    g_CheatsWindow->Raise();
+  if (!m_cheats_window)
+    m_cheats_window = new wxCheatsWindow(this);
+
+  m_cheats_window->Show();
+  m_cheats_window->Raise();
 }
 
 void CFrame::OnLoadWiiMenu(wxCommandEvent& WXUNUSED(event))
@@ -1514,12 +1515,12 @@ void CFrame::UpdateGUI()
   m_Mgr->Update();
 
   // Update non-modal windows
-  if (g_CheatsWindow)
+  if (m_cheats_window)
   {
     if (SConfig::GetInstance().bEnableCheats)
-      g_CheatsWindow->UpdateGUI();
+      m_cheats_window->UpdateGUI();
     else
-      g_CheatsWindow->Close();
+      m_cheats_window->Hide();
   }
 }
 


### PR DESCRIPTION
Rather than destroy and reinitialize the dialog whenever it's closed and opened, this dialog can just be hidden from view when it's not needed, and shown again when it is needed. Also, a dialog should really not be managing any live instances of itself, including the one directly in the main frame.

This gets rid of another usage of the main frame global.