### PR TITLE
TextureCache: Fix incomplete GPU texture decoding of non-square mips

### DIFF
--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -775,7 +775,8 @@ void TextureCache::DecodeTextureOnGPU(TCacheEntryBase* entry, u32 dst_level, con
     glBindTexture(GL_TEXTURE_BUFFER, s_palette_resolv_texture);
   }
 
-  auto dispatch_groups = TextureConversionShader::GetDispatchCount(info.base_info, width, height);
+  auto dispatch_groups =
+      TextureConversionShader::GetDispatchCount(info.base_info, aligned_width, aligned_height);
   glBindImageTexture(0, static_cast<TCacheEntry*>(entry)->texture, dst_level, GL_TRUE, 0,
                      GL_WRITE_ONLY, GL_RGBA8);
   glDispatchCompute(dispatch_groups.first, dispatch_groups.second, 1);

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -517,7 +517,8 @@ void TextureConverter::DecodeTexture(TextureCache::TCacheEntry* entry, u32 dst_l
   dispatcher.SetTexelBuffer(0, data_view);
   if (has_palette)
     dispatcher.SetTexelBuffer(1, m_texel_buffer_view_r16_uint);
-  auto groups = TextureConversionShader::GetDispatchCount(iter->second.base_info, width, height);
+  auto groups = TextureConversionShader::GetDispatchCount(iter->second.base_info, aligned_width,
+                                                          aligned_height);
   dispatcher.Dispatch(groups.first, groups.second, 1);
 
   // Copy from temporary texture to final destination.

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -870,7 +870,7 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
 
       if (decode_on_gpu)
       {
-        u32 row_stride = bytes_per_block * (mip_width / bsw);
+        u32 row_stride = bytes_per_block * (expanded_mip_width / bsw);
         g_texture_cache->DecodeTextureOnGPU(entry, level, mip_src_data, mip_size,
                                             static_cast<TextureFormat>(texformat), mip_width,
                                             mip_height, expanded_mip_width, expanded_mip_height,


### PR DESCRIPTION
Fixes issue 10191: https://bugs.dolphin-emu.org/issues/10191