### PR TITLE
Frame: Fix macOS keyboard while emulation is running

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -1040,12 +1040,20 @@ static int GetMenuIDFromHotkey(unsigned int key)
 
 void CFrame::OnKeyDown(wxKeyEvent& event)
 {
-// On OS X, we claim all keyboard events while
-// emulation is running to avoid wxWidgets sounding
-// the system beep for unhandled key events when
-// receiving pad/Wiimote keypresses which take an
-// entirely different path through the HID subsystem.
-#ifndef __APPLE__
+#ifdef __APPLE__
+  // On OS X, we claim all keyboard events while
+  // emulation is running to avoid wxWidgets sounding
+  // the system beep for unhandled key events when
+  // receiving pad/Wiimote keypresses which take an
+  // entirely different path through the HID subsystem.
+  if (!m_bRendererHasFocus)
+  {
+    // We do however want to pass events on when the
+    // render window is out of focus: this allows use
+    // of the keyboard in the rest of the UI.
+    event.Skip();
+  }
+#else
   // On other platforms, we leave the key event alone
   // so it can be passed on to the windowing system.
   event.Skip();


### PR DESCRIPTION
Issue: Keyboard was not working in the rest of the UI while emulation was running.

Cause: `CFrame::OnKeyDown` consumed all keyboard events while emulation was running on macOS. 

Fix: This PR allows events that occur while the render window is not focused to be passed through.