### PR TITLE
DVDInterface: Change DVDLowReadDiskID behaviour

### DIFF
--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -734,6 +734,8 @@ void ExecuteCommand(u32 command_0, u32 command_1, u32 command_2, u32 output_addr
     INFO_LOG(DVDINTERFACE, "DVDLowReadDiskID");
     command_handled_by_thread = ExecuteReadCommand(0, output_address, 0x20, output_length, false,
                                                    reply_type, &interrupt_type);
+    // It doesn't fail but rather reads 0x00 instead?
+    interrupt_type = INT_TCINT;
     break;
 
   // Only used from WII_IPC. This is the only read command that decrypts data


### PR DESCRIPTION
It seems to fix GeckoOS/Neogamma not responding when there is no disc inserted.

GeckoOS code suggested that the ID read should be zeroed.

Need a hardware test to confirm that's the correct behaviour/way to fix this.  