### PR TITLE
IOS: Reload version fix

### DIFF
--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -683,8 +683,11 @@ bool Reload(const u64 ios_title_id)
   }
 
   if (!SetupMemory(ios_title_id, MemorySetupType::IOSReload))
+  {
+    // Write back the original version if IOS Reload failed
+    Memory::Write_U32((GetVersion() & 0xFFFF) << 16, ADDR_IOS_VERSION);
     return false;
-
+  }
   s_active_title_id = ios_title_id;
   Reset();
 


### PR DESCRIPTION
This fix homebrews not responding after entering ```IOS_ReloadIOS``` function when the IOS version isn't found.

According to libogc & nintendont source code, this function writes 0 where is located the IOS version and then sends ```IOCTL_ES_LAUNCH```. After that, it waits for the IOS version to be changed in memory (forever when using Dolphin).

Ready to be reviewed & merged.