### PR TITLE
SI_Devices: Get rid of pointer casts for ID assignment in RunBuffer

### DIFF
--- a/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceDanceMat.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/HW/SI/SI_DeviceDanceMat.h"
 
+#include <cstring>
+
 #include "Common/CommonTypes.h"
 #include "InputCommon/GCPadStatus.h"
 
@@ -22,7 +24,9 @@ int CSIDevice_DanceMat::RunBuffer(u8* buffer, int length)
   if (command == CMD_RESET)
   {
     ISIDevice::RunBuffer(buffer, length);
-    *(u32*)&buffer[0] = SI_DANCEMAT;
+
+    constexpr u32 id = SI_DANCEMAT;
+    std::memcpy(buffer, &id, sizeof(id));
   }
   else
   {

--- a/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/HW/SI/SI_DeviceGCController.h"
 
+#include <cstring>
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -53,8 +55,11 @@ int CSIDevice_GCController::RunBuffer(u8* buffer, int length)
   {
   case CMD_RESET:
   case CMD_ID:
-    *(u32*)&buffer[0] = SI_GC_CONTROLLER;
+  {
+    constexpr u32 id = SI_GC_CONTROLLER;
+    std::memcpy(buffer, &id, sizeof(id));
     break;
+  }
 
   case CMD_DIRECT:
   {

--- a/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCSteeringWheel.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/HW/SI/SI_DeviceGCSteeringWheel.h"
 
+#include <cstring>
+
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Core/HW/GCPad.h"
@@ -28,15 +30,14 @@ int CSIDevice_GCSteeringWheel::RunBuffer(u8* buffer, int length)
   {
   case CMD_RESET:
   case CMD_ID:
-    *(u32*)&buffer[0] = SI_GC_STEERING;
-    break;
-
-  // DEFAULT
-  default:
   {
-    return CSIDevice_GCController::RunBuffer(buffer, length);
+    constexpr u32 id = SI_GC_STEERING;
+    std::memcpy(buffer, &id, sizeof(id));
+    break;
   }
-  break;
+
+  default:
+    return CSIDevice_GCController::RunBuffer(buffer, length);
   }
 
   return length;

--- a/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceKeyboard.cpp
@@ -4,6 +4,8 @@
 
 #include "Core/HW/SI/SI_DeviceKeyboard.h"
 
+#include <cstring>
+
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -31,8 +33,11 @@ int CSIDevice_Keyboard::RunBuffer(u8* buffer, int length)
   {
   case CMD_RESET:
   case CMD_ID:
-    *(u32*)&buffer[0] = SI_GC_KEYBOARD;
+  {
+    constexpr u32 id = SI_GC_KEYBOARD;
+    std::memcpy(buffer, &id, sizeof(id));
     break;
+  }
 
   case CMD_DIRECT:
   {


### PR DESCRIPTION
Casting to a different pointer type like the previous code did and dereferencing it is undefined behavior.