### PR TITLE
RenderBase: const correctness

### DIFF
--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -122,7 +122,7 @@ void Renderer::RenderToXFB(u32 xfbAddr, const EFBRectangle& sourceRc, u32 fbStri
   }
 }
 
-int Renderer::EFBToScaledX(int x)
+int Renderer::EFBToScaledX(int x) const
 {
   switch (g_ActiveConfig.iEFBScale)
   {
@@ -134,7 +134,7 @@ int Renderer::EFBToScaledX(int x)
   };
 }
 
-int Renderer::EFBToScaledY(int y)
+int Renderer::EFBToScaledY(int y) const
 {
   switch (g_ActiveConfig.iEFBScale)
   {
@@ -146,7 +146,17 @@ int Renderer::EFBToScaledY(int y)
   };
 }
 
-void Renderer::CalculateTargetScale(int x, int y, int* scaledX, int* scaledY)
+float Renderer::EFBToScaledXf(float x) const
+{
+  return x * ((float)GetTargetWidth() / (float)EFB_WIDTH);
+}
+
+float Renderer::EFBToScaledYf(float y) const
+{
+  return y * ((float)GetTargetHeight() / (float)EFB_HEIGHT);
+}
+
+void Renderer::CalculateTargetScale(int x, int y, int* scaledX, int* scaledY) const
 {
   if (g_ActiveConfig.iEFBScale == SCALE_AUTO || g_ActiveConfig.iEFBScale == SCALE_AUTO_INTEGRAL)
   {
@@ -240,7 +250,7 @@ bool Renderer::CalculateTargetSize()
 }
 
 void Renderer::ConvertStereoRectangle(const TargetRectangle& rc, TargetRectangle& leftRc,
-                                      TargetRectangle& rightRc)
+                                      TargetRectangle& rightRc) const
 {
   // Resize target to half its original size
   TargetRectangle drawRc = rc;
@@ -433,7 +443,7 @@ void Renderer::DrawDebugText()
   g_renderer->RenderText(final_yellow, 20, 20, 0xFFFFFF00);
 }
 
-float Renderer::CalculateDrawAspectRatio(int target_width, int target_height)
+float Renderer::CalculateDrawAspectRatio(int target_width, int target_height) const
 {
   // The dimensions are the sizes that are used to create the EFB/backbuffer textures, so
   // they should always be greater than zero.
@@ -459,7 +469,8 @@ float Renderer::CalculateDrawAspectRatio(int target_width, int target_height)
   }
 }
 
-std::tuple<float, float> Renderer::ScaleToDisplayAspectRatio(const int width, const int height)
+std::tuple<float, float> Renderer::ScaleToDisplayAspectRatio(const int width,
+                                                             const int height) const
 {
   // Scale either the width or height depending the content aspect ratio.
   // This way we preserve as much resolution as possible when scaling.
@@ -474,7 +485,7 @@ std::tuple<float, float> Renderer::ScaleToDisplayAspectRatio(const int width, co
   return std::make_tuple(static_cast<float>(width) / ratio, static_cast<float>(height));
 }
 
-TargetRectangle Renderer::CalculateFrameDumpDrawRectangle()
+TargetRectangle Renderer::CalculateFrameDumpDrawRectangle() const
 {
   // No point including any borders in the frame dump image, since they'd have to be cropped anyway.
   TargetRectangle rc;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -310,7 +310,7 @@ void Renderer::DrawDebugText()
   if (g_ActiveConfig.bShowFPS || SConfig::GetInstance().m_ShowFrameCount)
   {
     if (g_ActiveConfig.bShowFPS)
-      final_cyan += StringFromFormat("FPS: %u", g_renderer->m_fps_counter.GetFPS());
+      final_cyan += StringFromFormat("FPS: %u", m_fps_counter.GetFPS());
 
     if (g_ActiveConfig.bShowFPS && SConfig::GetInstance().m_ShowFrameCount)
       final_cyan += " - ";
@@ -439,8 +439,8 @@ void Renderer::DrawDebugText()
     final_cyan += Statistics::ToStringProj();
 
   // and then the text
-  g_renderer->RenderText(final_cyan, 20, 20, 0xFF00FFFF);
-  g_renderer->RenderText(final_yellow, 20, 20, 0xFFFFFF00);
+  RenderText(final_cyan, 20, 20, 0xFF00FFFF);
+  RenderText(final_yellow, 20, 20, 0xFFFFFF00);
 }
 
 float Renderer::CalculateDrawAspectRatio(int target_width, int target_height) const
@@ -723,10 +723,10 @@ void Renderer::Swap(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight, const 
                     u64 ticks, float Gamma)
 {
   // TODO: merge more generic parts into VideoCommon
-  g_renderer->SwapImpl(xfbAddr, fbWidth, fbStride, fbHeight, rc, ticks, Gamma);
+  SwapImpl(xfbAddr, fbWidth, fbStride, fbHeight, rc, ticks, Gamma);
 
   if (m_xfb_written)
-    g_renderer->m_fps_counter.Update();
+    m_fps_counter.Update();
 
   frameCount++;
   GFX_DEBUGGER_PAUSE_AT(NEXT_FRAME, true);

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -81,11 +81,11 @@ public:
   virtual void RestoreAPIState() {}
   // Ideal internal resolution - determined by display resolution (automatic scaling) and/or a
   // multiple of the native EFB resolution
-  int GetTargetWidth() { return m_target_width; }
-  int GetTargetHeight() { return m_target_height; }
+  int GetTargetWidth() const { return m_target_width; }
+  int GetTargetHeight() const { return m_target_height; }
   // Display resolution
-  int GetBackbufferWidth() { return m_backbuffer_width; }
-  int GetBackbufferHeight() { return m_backbuffer_height; }
+  int GetBackbufferWidth() const { return m_backbuffer_width; }
+  int GetBackbufferHeight() const { return m_backbuffer_height; }
   void SetWindowSize(int width, int height);
 
   // EFB coordinate conversion functions
@@ -93,23 +93,24 @@ public:
   // Use this to convert a whole native EFB rect to backbuffer coordinates
   virtual TargetRectangle ConvertEFBRectangle(const EFBRectangle& rc) = 0;
 
-  const TargetRectangle& GetTargetRectangle() { return m_target_rectangle; }
-  float CalculateDrawAspectRatio(int target_width, int target_height);
-  std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height);
-  TargetRectangle CalculateFrameDumpDrawRectangle();
+  const TargetRectangle& GetTargetRectangle() const { return m_target_rectangle; }
+  float CalculateDrawAspectRatio(int target_width, int target_height) const;
+  std::tuple<float, float> ScaleToDisplayAspectRatio(int width, int height) const;
+  TargetRectangle CalculateFrameDumpDrawRectangle() const;
   void UpdateDrawRectangle();
 
   // Use this to convert a single target rectangle to two stereo rectangles
   void ConvertStereoRectangle(const TargetRectangle& rc, TargetRectangle& leftRc,
-                              TargetRectangle& rightRc);
+                              TargetRectangle& rightRc) const;
 
   // Use this to upscale native EFB coordinates to IDEAL internal resolution
-  int EFBToScaledX(int x);
-  int EFBToScaledY(int y);
+  int EFBToScaledX(int x) const;
+  int EFBToScaledY(int y) const;
 
   // Floating point versions of the above - only use them if really necessary
-  float EFBToScaledXf(float x) { return x * ((float)GetTargetWidth() / (float)EFB_WIDTH); }
-  float EFBToScaledYf(float y) { return y * ((float)GetTargetHeight() / (float)EFB_HEIGHT); }
+  float EFBToScaledXf(float x) const;
+  float EFBToScaledYf(float y) const;
+
   // Random utilities
   void SaveScreenshot(const std::string& filename, bool wait_for_completion);
   void DrawDebugText();
@@ -134,16 +135,16 @@ public:
   virtual void SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
                         const EFBRectangle& rc, u64 ticks, float Gamma = 1.0f) = 0;
 
-  PEControl::PixelFormat GetPrevPixelFormat() { return m_prev_efb_format; }
+  PEControl::PixelFormat GetPrevPixelFormat() const { return m_prev_efb_format; }
   void StorePixelFormat(PEControl::PixelFormat new_format) { m_prev_efb_format = new_format; }
-  PostProcessingShaderImplementation* GetPostProcessor() { return m_post_processor.get(); }
+  PostProcessingShaderImplementation* GetPostProcessor() const { return m_post_processor.get(); }
   // Final surface changing
   // This is called when the surface is resized (WX) or the window changes (Android).
   virtual void ChangeSurface(void* new_surface_handle) {}
   bool UseVertexDepthRange() const;
 
 protected:
-  void CalculateTargetScale(int x, int y, int* scaledX, int* scaledY);
+  void CalculateTargetScale(int x, int y, int* scaledX, int* scaledY) const;
   bool CalculateTargetSize();
 
   void CheckFifoRecording();


### PR DESCRIPTION
Basic const correctness stuff.

While doing the first commit, I noticed areas where the `Renderer` class was dereferencing its own global in order to access data members and functions. I've eliminated those in a second commit.