### PR TITLE
Disable screensaver on OS X

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -714,8 +714,9 @@ void CFrame::InhibitScreensaver()
   if (SConfig::GetInstance().bDisableScreenSaver)
   {
     CFStringRef reason_for_activity = CFSTR("Emulation Running");
-    if (IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep, kIOPMAssertionLevelOn,
-                                    reason_for_activity, &m_power_assertion) != kIOReturnSuccess)
+    if (IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleDisplaySleep,
+                                    kIOPMAssertionLevelOn, reason_for_activity,
+                                    &m_power_assertion) != kIOReturnSuccess)
     {
       m_power_assertion = kIOPMNullAssertionID;
     }

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -24,7 +24,7 @@
 #endif
 
 #ifdef __APPLE__
-#import <IOKit/pwr_mgt/IOPMLib.h>
+#include <IOKit/pwr_mgt/IOPMLib.h>
 #endif
 
 // Class declarations
@@ -164,10 +164,6 @@ private:
     ADD_PANE_CENTER
   };
 
-#ifdef __APPLE__
-  IOPMAssertionID m_power_assertion = kIOPMNullAssertionID;
-#endif
-
   wxTimer m_poll_hotkey_timer;
   wxTimer m_handle_signal_timer;
 
@@ -230,6 +226,13 @@ private:
   // Override window proc for tricks like screensaver disabling
   WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam);
 #endif
+
+// Screensaver
+#ifdef __APPLE__
+  IOPMAssertionID m_power_assertion = kIOPMNullAssertionID;
+#endif
+  void InhibitScreensaver();
+  void UninhibitScreensaver();
 
   void DoOpen(bool Boot);
   void DoPause();

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -23,6 +23,10 @@
 #include "UICommon/X11Utils.h"
 #endif
 
+#ifdef __APPLE__
+#import <IOKit/pwr_mgt/IOPMLib.h>
+#endif
+
 // Class declarations
 class CGameListCtrl;
 class CCodeWindow;
@@ -159,6 +163,10 @@ private:
     ADD_PANE_RIGHT,
     ADD_PANE_CENTER
   };
+
+#ifdef __APPLE__
+  IOPMAssertionID m_power_assertion = kIOPMNullAssertionID;
+#endif
 
   wxTimer m_poll_hotkey_timer;
   wxTimer m_handle_signal_timer;

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -84,6 +84,10 @@
 #include "VideoCommon/VideoBackendBase.h"
 #include "VideoCommon/VideoConfig.h"
 
+#ifdef __APPLE__
+#import <IOKit/pwr_mgt/IOPMLib.h>
+#endif
+
 class InputConfig;
 class wxFrame;
 
@@ -724,6 +728,14 @@ void CFrame::StartGame(const std::string& filename)
         SConfig::GetInstance().bDisableScreenSaver ? ES_DISPLAY_REQUIRED : 0;
     SetThreadExecutionState(ES_CONTINUOUS | shouldScreenSave | ES_SYSTEM_REQUIRED);
 #endif
+#ifdef __APPLE__
+    CFStringRef reason_for_activity = CFSTR("Emulation Running");
+    if (IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep, kIOPMAssertionLevelOn,
+                                    reason_for_activity, &m_power_assertion) != kIOReturnSuccess)
+    {
+      m_power_assertion = kIOPMNullAssertionID;
+    }
+#endif
 
     // We need this specifically to support setting the focus properly when using
     // the 'render to main window' feature on Windows
@@ -897,6 +909,13 @@ void CFrame::OnStopped()
 #ifdef _WIN32
   // Allow windows to resume normal idling behavior
   SetThreadExecutionState(ES_CONTINUOUS);
+#endif
+#ifdef __APPLE__
+  if (m_power_assertion != kIOPMNullAssertionID)
+  {
+    IOPMAssertionRelease(m_power_assertion);
+    m_power_assertion = kIOPMNullAssertionID;
+  }
 #endif
 
   m_RenderFrame->SetTitle(StrToWxStr(scm_rev_str));


### PR DESCRIPTION
Tested on OS X 10.12.3  (Sierra).

Closes #4524.

Main differences from previous PR is formatting changes and the removal of the unnecessary `m_disable_screensaver_assertion_creation_success` variable.