### PR TITLE
OpenALStream: Don't drop samples on the floor

### DIFF
--- a/Source/Core/AudioCommon/OpenALStream.cpp
+++ b/Source/Core/AudioCommon/OpenALStream.cpp
@@ -284,10 +284,10 @@ void OpenALStream::SoundLoop()
       }
     }
 
-    unsigned int nSamples = soundTouch.receiveSamples(sampleBuffer, OAL_MAX_SAMPLES * numBuffers);
-
-    if (nSamples <= minSamples)
+    if (soundTouch.numSamples() <= minSamples)
       continue;
+
+    unsigned int nSamples = soundTouch.receiveSamples(sampleBuffer, OAL_MAX_SAMPLES * numBuffers);
 
     if (surround_capable)
     {


### PR DESCRIPTION
If nSamples <= minSamples && nSamples != 0, some samples were being
removed from the soundTouch FIFO then were being completely ignored.
This would lead to pops if it happened in practice.