### PR TITLE
PPCTables: Do not consider OPTYPE_UNKNOWN as valid instruction

### DIFF
--- a/Source/Core/Core/PowerPC/PPCTables.cpp
+++ b/Source/Core/Core/PowerPC/PPCTables.cpp
@@ -131,7 +131,7 @@ const char* GetInstructionName(UGeckoInstruction _inst)
 bool IsValidInstruction(UGeckoInstruction _inst)
 {
   const GekkoOPInfo* info = GetOpInfo(_inst);
-  return info != nullptr;
+  return info != nullptr && info->type != OPTYPE_UNKNOWN;
 }
 
 void CountInstruction(UGeckoInstruction _inst)


### PR DESCRIPTION
This PR prevents functions like ```FindFunctionsAfterBLR``` to consider the instruction 0x00000000 as valid and add weird functions.

Ready to be reviewed & merged.