### PR TITLE
DolphinWX: move CPU Emulator Engine and NTSC-J to advanced tab

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.h
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.h
@@ -12,6 +12,7 @@
 class DolphinSlider;
 class wxCheckBox;
 class wxDatePickerCtrl;
+class wxRadioBox;
 class wxStaticText;
 class wxTimePickerCtrl;
 
@@ -28,6 +29,8 @@ private:
   void OnUpdateCPUClockControls(wxUpdateUIEvent&);
   void OnUpdateRTCDateTimeEntries(wxUpdateUIEvent&);
 
+  void OnCPUEngineRadioBoxChanged(wxCommandEvent&);
+  void OnForceNTSCJCheckBoxChanged(wxCommandEvent&);
   void OnClockOverrideCheckBoxChanged(wxCommandEvent&);
   void OnClockOverrideSliderChanged(wxCommandEvent&);
   void OnCustomRTCCheckBoxChanged(wxCommandEvent&);
@@ -36,12 +39,22 @@ private:
 
   void UpdateCPUClock();
 
+  struct CPUCore
+  {
+    int CPUid;
+    wxString name;
+  };
+  std::vector<CPUCore> m_cpu_cores;
+
   // Custom RTC
   void LoadCustomRTC();
   void UpdateCustomRTC(time_t date, time_t time);
   u32 m_temp_date;
   u32 m_temp_time;
 
+  wxArrayString m_cpu_engine_array_string;
+  wxRadioBox* m_cpu_engine_radiobox;
+  wxCheckBox* m_force_ntscj_checkbox;
   wxCheckBox* m_clock_override_checkbox;
   DolphinSlider* m_clock_override_slider;
   wxStaticText* m_clock_override_text;

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -10,29 +10,16 @@
 #include <wx/event.h>
 #include <wx/menu.h>
 #include <wx/msgdlg.h>
-#include <wx/radiobox.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
 #include "Core/Analytics.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
-#include "Core/PowerPC/PowerPC.h"
 #include "DolphinWX/WxEventUtils.h"
 
 GeneralConfigPane::GeneralConfigPane(wxWindow* parent, wxWindowID id) : wxPanel(parent, id)
 {
-  m_cpu_cores = {
-      {PowerPC::CORE_INTERPRETER, _("Interpreter (slowest)")},
-      {PowerPC::CORE_CACHEDINTERPRETER, _("Cached Interpreter (slower)")},
-#ifdef _M_X86_64
-      {PowerPC::CORE_JIT64, _("JIT Recompiler (recommended)")},
-      {PowerPC::CORE_JITIL64, _("JITIL Recompiler (slow, experimental)")},
-#elif defined(_M_ARM_64)
-      {PowerPC::CORE_JITARM64, _("JIT Arm64 (experimental)")},
-#endif
-  };
-
   InitializeGUI();
   LoadGUIValues();
   BindEvents();
@@ -49,12 +36,8 @@ void GeneralConfigPane::InitializeGUI()
       m_throttler_array_string.Add(wxString::Format(_("%i%%"), i));
   }
 
-  for (const CPUCore& cpu_core : m_cpu_cores)
-    m_cpu_engine_array_string.Add(cpu_core.name);
-
   m_dual_core_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Dual Core (speedup)"));
   m_cheats_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Cheats"));
-  m_force_ntscj_checkbox = new wxCheckBox(this, wxID_ANY, _("Force Console as NTSC-J"));
   m_analytics_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Usage Statistics Reporting"));
 #ifdef __APPLE__
   m_analytics_new_id = new wxButton(this, wxID_ANY, _("Generate a New Statistics Identity"),
@@ -64,17 +47,11 @@ void GeneralConfigPane::InitializeGUI()
 #endif
   m_throttler_choice =
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_throttler_array_string);
-  m_cpu_engine_radiobox =
-      new wxRadioBox(this, wxID_ANY, _("CPU Emulator Engine"), wxDefaultPosition, wxDefaultSize,
-                     m_cpu_engine_array_string, 0, wxRA_SPECIFY_ROWS);
 
   m_dual_core_checkbox->SetToolTip(
       _("Splits the CPU and GPU threads so they can be run on separate cores.\nProvides major "
         "speed improvements on most modern PCs, but can cause occasional crashes/glitches."));
   m_cheats_checkbox->SetToolTip(_("Enables the use of Action Replay and Gecko cheats."));
-  m_force_ntscj_checkbox->SetToolTip(
-      _("Forces NTSC-J mode for using the Japanese ROM font.\nIf left unchecked, Dolphin defaults "
-        "to NTSC-U and automatically enables this setting when playing Japanese games."));
   m_analytics_checkbox->SetToolTip(
       _("Enables the collection and sharing of usage statistics data with the Dolphin development "
         "team. This data is used to improve the emulator and help us understand how our users "
@@ -114,21 +91,11 @@ void GeneralConfigPane::InitializeGUI()
   analytics_sizer->Add(m_analytics_new_id, 0, wxLEFT | wxRIGHT, space5);
   analytics_sizer->AddSpacer(space5);
 
-  wxStaticBoxSizer* const advanced_settings_sizer =
-      new wxStaticBoxSizer(wxVERTICAL, this, _("Advanced Settings"));
-  advanced_settings_sizer->AddSpacer(space5);
-  advanced_settings_sizer->Add(m_cpu_engine_radiobox, 0, wxLEFT | wxRIGHT, space5);
-  advanced_settings_sizer->AddSpacer(space5);
-  advanced_settings_sizer->Add(m_force_ntscj_checkbox, 0, wxLEFT | wxRIGHT, space5);
-  advanced_settings_sizer->AddSpacer(space5);
-
   wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);
   main_sizer->AddSpacer(space5);
   main_sizer->Add(basic_settings_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   main_sizer->AddSpacer(space5);
   main_sizer->Add(analytics_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
-  main_sizer->AddSpacer(space5);
-  main_sizer->Add(advanced_settings_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   main_sizer->AddSpacer(space5);
 
   SetSizer(main_sizer);
@@ -140,17 +107,10 @@ void GeneralConfigPane::LoadGUIValues()
 
   m_dual_core_checkbox->SetValue(startup_params.bCPUThread);
   m_cheats_checkbox->SetValue(startup_params.bEnableCheats);
-  m_force_ntscj_checkbox->SetValue(startup_params.bForceNTSCJ);
   m_analytics_checkbox->SetValue(startup_params.m_analytics_enabled);
   u32 selection = std::lround(startup_params.m_EmulationSpeed * 10.0f);
   if (selection < m_throttler_array_string.size())
     m_throttler_choice->SetSelection(selection);
-
-  for (size_t i = 0; i < m_cpu_cores.size(); ++i)
-  {
-    if (m_cpu_cores[i].CPUid == startup_params.iCPUCore)
-      m_cpu_engine_radiobox->SetSelection(i);
-  }
 }
 
 void GeneralConfigPane::BindEvents()
@@ -161,18 +121,11 @@ void GeneralConfigPane::BindEvents()
   m_cheats_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnCheatCheckBoxChanged, this);
   m_cheats_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 
-  m_force_ntscj_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnForceNTSCJCheckBoxChanged,
-                               this);
-  m_force_ntscj_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
-
   m_analytics_checkbox->Bind(wxEVT_CHECKBOX, &GeneralConfigPane::OnAnalyticsCheckBoxChanged, this);
 
   m_analytics_new_id->Bind(wxEVT_BUTTON, &GeneralConfigPane::OnAnalyticsNewIdButtonClick, this);
 
   m_throttler_choice->Bind(wxEVT_CHOICE, &GeneralConfigPane::OnThrottlerChoiceChanged, this);
-
-  m_cpu_engine_radiobox->Bind(wxEVT_RADIOBOX, &GeneralConfigPane::OnCPUEngineRadioBoxChanged, this);
-  m_cpu_engine_radiobox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 }
 
 void GeneralConfigPane::OnDualCoreCheckBoxChanged(wxCommandEvent& event)
@@ -188,20 +141,10 @@ void GeneralConfigPane::OnCheatCheckBoxChanged(wxCommandEvent& event)
   SConfig::GetInstance().bEnableCheats = m_cheats_checkbox->IsChecked();
 }
 
-void GeneralConfigPane::OnForceNTSCJCheckBoxChanged(wxCommandEvent& event)
-{
-  SConfig::GetInstance().bForceNTSCJ = m_force_ntscj_checkbox->IsChecked();
-}
-
 void GeneralConfigPane::OnThrottlerChoiceChanged(wxCommandEvent& event)
 {
   if (m_throttler_choice->GetSelection() != wxNOT_FOUND)
     SConfig::GetInstance().m_EmulationSpeed = m_throttler_choice->GetSelection() * 0.1f;
-}
-
-void GeneralConfigPane::OnCPUEngineRadioBoxChanged(wxCommandEvent& event)
-{
-  SConfig::GetInstance().iCPUCore = m_cpu_cores.at(event.GetSelection()).CPUid;
 }
 
 void GeneralConfigPane::OnAnalyticsCheckBoxChanged(wxCommandEvent& event)

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.h
@@ -11,7 +11,6 @@
 class wxButton;
 class wxCheckBox;
 class wxChoice;
-class wxRadioBox;
 
 class GeneralConfigPane final : public wxPanel
 {
@@ -31,23 +30,17 @@ private:
 
   void OnDualCoreCheckBoxChanged(wxCommandEvent&);
   void OnCheatCheckBoxChanged(wxCommandEvent&);
-  void OnForceNTSCJCheckBoxChanged(wxCommandEvent&);
   void OnThrottlerChoiceChanged(wxCommandEvent&);
-  void OnCPUEngineRadioBoxChanged(wxCommandEvent&);
   void OnAnalyticsCheckBoxChanged(wxCommandEvent&);
   void OnAnalyticsNewIdButtonClick(wxCommandEvent&);
 
   wxArrayString m_throttler_array_string;
-  wxArrayString m_cpu_engine_array_string;
 
   wxCheckBox* m_dual_core_checkbox;
   wxCheckBox* m_cheats_checkbox;
-  wxCheckBox* m_force_ntscj_checkbox;
 
   wxCheckBox* m_analytics_checkbox;
   wxButton* m_analytics_new_id;
 
   wxChoice* m_throttler_choice;
-
-  wxRadioBox* m_cpu_engine_radiobox;
 };


### PR DESCRIPTION
This has been pestering me. They're advanced settings, they should go under the advanced tab with the rest of them!

<img width="722" alt="screen shot 2017-04-11 at 12 05 17 am" src="https://cloud.githubusercontent.com/assets/594093/24896629/98184b12-1e4a-11e7-81b3-5cf87a324b1c.png"> <img width="722" alt="screen shot 2017-04-11 at 12 09 33 am" src="https://cloud.githubusercontent.com/assets/594093/24896748/2b20f79c-1e4b-11e7-8f7c-0f39d81fccaf.png">


