### PR TITLE
CMake: turn on -fdiagnostics-color for Ninja builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_L
   message(FATAL_ERROR "Dolphin requires at least GCC 5.0 (found ${CMAKE_CXX_COMPILER_VERSION})")
 endif()
 
+if(CMAKE_GENERATOR MATCHES "Ninja")
+  check_and_add_flag(DIAGNOSTICS_COLOR -fdiagnostics-color)
+elseif(CMAKE_GENERATOR MATCHES "Visual Studio")
+  # Only MSBuild needs this, other generators will compile one file at a time
+  add_compile_options("/MP")
+endif()
+
 if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
   check_and_add_flag(EXCEPTIONS /EHsc)
   dolphin_compile_definitions(_DEBUG DEBUG_ONLY)
@@ -216,11 +223,6 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
   string(APPEND CMAKE_EXE_LINKER_FLAGS " /BASE:0x00400000")
   string(APPEND CMAKE_EXE_LINKER_FLAGS " /DYNAMICBASE:NO")
   string(APPEND CMAKE_EXE_LINKER_FLAGS " /FIXED")
-
-  # Only MSBuild needs this, other generators will compile one file at a time
-  if(CMAKE_GENERATOR MATCHES "Visual Studio")
-    add_compile_options("/MP")
-  endif()
 else()
   add_definitions(-D_DEFAULT_SOURCE)
   check_and_add_flag(HAVE_WALL -Wall)


### PR DESCRIPTION
This PR attempts to turn on `-fdiagnostics-color` by default when using the CMake Ninja generator.

Ninja effectively turns off colored messages by not running subcommands in a pseudo-terminal. The Ninja maintainers have decided that using pseudo-terminals has more downsides than upsides, but have helpfully taught Ninja itself how to parse and remove color codes if its parent isn't a (pseudo-)terminal.

Colored messages make it easier to read warnings and error messages in a large build log, and are pretty 🌸.