### PR TITLE
Remove audio backend tooltip

### DIFF
--- a/Source/Core/DolphinWX/Config/AudioConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AudioConfigPane.cpp
@@ -54,8 +54,6 @@ void AudioConfigPane::InitializeGUI()
       new DolphinSlider(this, wxID_ANY, 80, 5, 300, wxDefaultPosition, wxDefaultSize);
   m_stretch_text = new wxStaticText(this, wxID_ANY, "");
 
-  m_audio_backend_choice->SetToolTip(
-      _("Changing this will have no effect while the emulator is running."));
   m_audio_latency_spinctrl->SetToolTip(_("Sets the latency (in ms). Higher values may reduce audio "
                                          "crackling. Certain backends only."));
   m_dpl2_decoder_checkbox->SetToolTip(


### PR DESCRIPTION
The audio backend option automatically gets disabled when emulation is running, so it's pointless to tell people what would (not) happen if they changed the audio backend while emulation is running.