### PR TITLE
Vulkan: Fix incorrect render pass for out-of-range clears

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -91,8 +91,8 @@ bool CommandBufferManager::CreateCommandBuffers()
     VkDescriptorPoolSize pool_sizes[] = {{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 500000},
                                          {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 500000},
                                          {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 16},
-                                         {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1024},
-                                         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1024}};
+                                         {VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 16384},
+                                         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 16384}};
 
     VkDescriptorPoolCreateInfo pool_create_info = {VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
                                                    nullptr,

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -332,6 +332,11 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha
 {
   // Native -> EFB coordinates
   TargetRectangle target_rc = Renderer::ConvertEFBRectangle(rc);
+
+  // Size we pass this size to vkBeginRenderPass, it has to be clamped to the framebuffer
+  // dimensions. The other backends just silently ignore this case.
+  target_rc.ClampUL(0, 0, m_target_width, m_target_height);
+
   VkRect2D target_vk_rc = {
       {target_rc.left, target_rc.top},
       {static_cast<uint32_t>(target_rc.GetWidth()), static_cast<uint32_t>(target_rc.GetHeight())}};


### PR DESCRIPTION
This occured when a game set an out-of-range EFB clear region. Should fix issue 10206: https://bugs.dolphin-emu.org/issues/10206

Also raises the number of texel buffer/storage image descriptors, which could potentially cause a panic or crash when running with GPU texture decoding enabled. The long-term fix here would be to execute the current command buffer, to free up more descriptors.