### PR TITLE
Analytics: Report unknown IOS requests

### DIFF
--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -20,6 +20,8 @@
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/GCPad.h"
+#include "Core/IOS/Device.h"
+#include "Core/IOS/IPC.h"
 #include "Core/Movie.h"
 #include "Core/NetPlayProto.h"
 #include "InputCommon/GCAdapter.h"
@@ -83,7 +85,7 @@ void DolphinAnalytics::GenerateNewIdentity()
   SConfig::GetInstance().SaveSettings();
 }
 
-std::string DolphinAnalytics::MakeUniqueId(const std::string& data)
+std::string DolphinAnalytics::MakeUniqueId(const std::string& data) const
 {
   u8 digest[20];
   std::string input = m_unique_id + data;
@@ -114,6 +116,20 @@ void DolphinAnalytics::ReportGameStart()
   Common::AnalyticsReportBuilder builder(m_per_game_builder);
   builder.AddData("type", "game-start");
   Send(builder);
+}
+
+Common::AnalyticsReportBuilder DolphinAnalytics::MakeBuilderWithGameID() const
+{
+  Common::AnalyticsReportBuilder builder;
+
+  // Gameid and title ID.
+  builder.AddData("gameid", SConfig::GetInstance().GetGameID());
+  builder.AddData("titleid", SConfig::GetInstance().GetTitleID());
+
+  // Unique id bound to the gameid.
+  builder.AddData("id", MakeUniqueId(SConfig::GetInstance().GetGameID()));
+
+  return builder;
 }
 
 void DolphinAnalytics::MakeBaseBuilder()
@@ -181,13 +197,7 @@ void DolphinAnalytics::MakeBaseBuilder()
 void DolphinAnalytics::MakePerGameBuilder()
 {
   Common::AnalyticsReportBuilder builder(m_base_builder);
-
-  // Gameid and title ID.
-  builder.AddData("gameid", SConfig::GetInstance().GetGameID());
-  builder.AddData("titleid", SConfig::GetInstance().GetTitleID());
-
-  // Unique id bound to the gameid.
-  builder.AddData("id", MakeUniqueId(SConfig::GetInstance().GetGameID()));
+  builder.AddBuilder(MakeBuilderWithGameID());
 
   // Configuration.
   builder.AddData("cfg-dsp-hle", SConfig::GetInstance().bDSPHLE);

--- a/Source/Core/Core/Analytics.cpp
+++ b/Source/Core/Core/Analytics.cpp
@@ -182,8 +182,9 @@ void DolphinAnalytics::MakePerGameBuilder()
 {
   Common::AnalyticsReportBuilder builder(m_base_builder);
 
-  // Gameid.
+  // Gameid and title ID.
   builder.AddData("gameid", SConfig::GetInstance().GetGameID());
+  builder.AddData("titleid", SConfig::GetInstance().GetTitleID());
 
   // Unique id bound to the gameid.
   builder.AddData("id", MakeUniqueId(SConfig::GetInstance().GetGameID()));

--- a/Source/Core/Core/Analytics.h
+++ b/Source/Core/Core/Analytics.h
@@ -42,6 +42,9 @@ public:
     m_reporter.Send(report);
   }
 
+  // Returns a builder with only the game ID, title ID and unique ID.
+  Common::AnalyticsReportBuilder MakeBuilderWithGameID() const;
+
 private:
   DolphinAnalytics();
 
@@ -51,7 +54,7 @@ private:
   // Returns a unique ID derived on the global unique ID, hashed with some
   // report-specific data. This avoid correlation between different types of
   // events.
-  std::string MakeUniqueId(const std::string& data);
+  std::string MakeUniqueId(const std::string& data) const;
 
   // Unique ID. This should never leave the application. Only used derived
   // values created by MakeUniqueId.

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -19,6 +19,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/ES/NandUtils.h"
+#include "Core/IOS/IPC.h"
 #include "DiscIO/NANDContentLoader.h"
 
 namespace IOS
@@ -436,6 +437,7 @@ IPCCommandResult ES::IOCtlV(const IOCtlVRequest& request)
     PanicAlert("IOS-ES: Unimplemented ioctlv 0x%x (%zu in vectors, %zu io vectors)",
                request.request, request.in_vectors.size(), request.io_vectors.size());
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS_ES, LogTypes::LERROR);
+    ReportUnknownRequest(GetDeviceName(), request);
     return GetDefaultReply(IPC_EINVAL);
 
   default:

--- a/Source/Core/Core/IOS/FS/FS.cpp
+++ b/Source/Core/Core/IOS/FS/FS.cpp
@@ -21,6 +21,7 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/IOS/FS/FS.h"
 #include "Core/IOS/FS/FileIO.h"
+#include "Core/IOS/IPC.h"
 
 namespace IOS
 {
@@ -180,6 +181,7 @@ IPCCommandResult FS::IOCtl(const IOCtlRequest& request)
     return Shutdown(request);
   default:
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS_FILEIO);
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
   }
 
@@ -196,6 +198,7 @@ IPCCommandResult FS::IOCtlV(const IOCtlVRequest& request)
     return GetUsage(request);
   default:
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS_FILEIO);
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
   }
 

--- a/Source/Core/Core/IOS/FS/FileIO.cpp
+++ b/Source/Core/Core/IOS/FS/FileIO.cpp
@@ -275,6 +275,7 @@ IPCCommandResult FileIO::IOCtl(const IOCtlRequest& request)
 
   default:
     request.Log(GetDeviceName(), LogTypes::IOS_FILEIO, LogTypes::LERROR);
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
   }
 

--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -32,6 +32,7 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+#include "Core/Analytics.h"
 #include "Core/Boot/Boot_DOL.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
@@ -907,6 +908,7 @@ static s32 OpenDevice(const OpenRequest& request)
   if (!device)
   {
     ERROR_LOG(IOS, "Unknown device: %s", request.path.c_str());
+    ReportUnknownDevice(request.path);
     return IPC_ENOENT;
   }
 

--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -1043,5 +1043,43 @@ void UpdateWantDeterminism(const bool new_want_determinism)
   for (const auto& device : s_device_map)
     device.second->UpdateWantDeterminism(new_want_determinism);
 }
+
+void ReportUnknownDevice(const std::string& path)
+{
+  auto analytics = DolphinAnalytics::Instance();
+  auto builder = analytics->MakeBuilderWithGameID();
+  builder.AddData("type", "ios-unknown-device");
+  builder.AddData("ios-version", GetVersion());
+  builder.AddData("ios-path", path);
+  analytics->Send(builder);
+}
+
+void ReportUnknownRequest(const std::string& path, const IOCtlRequest& ioctl)
+{
+  auto analytics = DolphinAnalytics::Instance();
+  auto builder = analytics->MakeBuilderWithGameID();
+  builder.AddData("type", "ios-unknown-request");
+  builder.AddData("ios-version", GetVersion());
+  builder.AddData("ios-request-type", "ioctl");
+  builder.AddData("ios-path", path);
+  builder.AddData("ios-ioctl-request", ioctl.request);
+  builder.AddData("ios-ioctl-in-size", ioctl.buffer_in_size);
+  builder.AddData("ios-ioctl-out-size", ioctl.buffer_out_size);
+  analytics->Send(builder);
+}
+
+void ReportUnknownRequest(const std::string& path, const IOCtlVRequest& ioctlv)
+{
+  auto analytics = DolphinAnalytics::Instance();
+  auto builder = analytics->MakeBuilderWithGameID();
+  builder.AddData("type", "ios-unknown-request");
+  builder.AddData("ios-version", IOS::HLE::GetVersion());
+  builder.AddData("ios-request-type", "ioctlv");
+  builder.AddData("ios-path", path);
+  builder.AddData("ios-ioctlv-request", ioctlv.request);
+  builder.AddData("ios-ioctlv-in-count", static_cast<u32>(ioctlv.in_vectors.size()));
+  builder.AddData("ios-ioctlv-io-count", static_cast<u32>(ioctlv.io_vectors.size()));
+  analytics->Send(builder);
+}
 }  // namespace HLE
 }  // namespace IOS

--- a/Source/Core/Core/IOS/IPC.h
+++ b/Source/Core/Core/IOS/IPC.h
@@ -29,6 +29,8 @@ class Device;
 }
 
 struct Request;
+struct IOCtlRequest;
+struct IOCtlVRequest;
 
 struct IPCCommandResult
 {
@@ -83,5 +85,11 @@ void EnqueueRequest(u32 address);
 void EnqueueReply(const Request& request, s32 return_value, int cycles_in_future = 0,
                   CoreTiming::FromThread from = CoreTiming::FromThread::CPU);
 void EnqueueCommandAcknowledgement(u32 address, int cycles_in_future = 0);
+
+// Report an unknown request.
+void ReportUnknownDevice(const std::string& path);
+void ReportUnknownRequest(const std::string& path, const IOCtlRequest& ioctl);
+void ReportUnknownRequest(const std::string& path, const IOCtlVRequest& ioctlv);
+
 }  // namespace HLE
 }  // namespace IOS

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -25,6 +25,7 @@
 
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
+#include "Core/IOS/IPC.h"
 #include "Core/IOS/Network/ICMP.h"
 #include "Core/IOS/Network/MACUtils.h"
 #include "Core/IOS/Network/Socket.h"
@@ -199,6 +200,7 @@ IPCCommandResult NetIPTop::IOCtl(const IOCtlRequest& request)
     return HandleICMPCancelRequest(request);
   default:
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS_NET);
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
   }
 
@@ -221,6 +223,7 @@ IPCCommandResult NetIPTop::IOCtlV(const IOCtlVRequest& request)
     return HandleICMPPingRequest(request);
   default:
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS_NET);
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
   }
 

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -13,8 +13,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
 #include "Common/SettingsHandler.h"
-
 #include "Core/HW/Memmap.h"
+#include "Core/IOS/IPC.h"
 #include "Core/IOS/Network/Socket.h"
 #include "Core/ec_wii.h"
 
@@ -145,6 +145,8 @@ IPCCommandResult NetKDRequest::IOCtl(const IOCtlRequest& request)
 
   default:
     request.Log(GetDeviceName(), LogTypes::IOS_WC24);
+    ReportUnknownRequest(GetDeviceName(), request);
+    break;
   }
 
   return GetDefaultReply(return_value);

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -9,6 +9,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/Memmap.h"
+#include "Core/IOS/IPC.h"
 
 namespace IOS
 {
@@ -55,6 +56,7 @@ IPCCommandResult NetKDTime::IOCtl(const IOCtlRequest& request)
 
   default:
     ERROR_LOG(IOS_NET, "%s - unknown IOCtl: %x", GetDeviceName().c_str(), request.request);
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
   }
 

--- a/Source/Core/Core/IOS/Network/NCD/Manage.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.cpp
@@ -9,8 +9,8 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 #include "Common/Network.h"
-
 #include "Core/HW/Memmap.h"
+#include "Core/IOS/IPC.h"
 #include "Core/IOS/Network/MACUtils.h"
 
 namespace IOS
@@ -78,6 +78,7 @@ IPCCommandResult NetNCDManage::IOCtlV(const IOCtlVRequest& request)
 
   default:
     INFO_LOG(IOS_NET, "NET_NCD_MANAGE IOCtlV: %#x", request.request);
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
   }
 

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -16,6 +16,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
+#include "Core/IOS/IPC.h"
 #include "Core/IOS/Network/SSL.h"
 #include "Core/IOS/Network/Socket.h"
 
@@ -541,6 +542,8 @@ IPCCommandResult NetSSL::IOCtlV(const IOCtlVRequest& request)
   }
   default:
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS_SSL);
+    ReportUnknownRequest(GetDeviceName(), request);
+    break;
   }
 
   // SSL return codes are written to BufferIn

--- a/Source/Core/Core/IOS/Network/WD/Command.cpp
+++ b/Source/Core/Core/IOS/Network/WD/Command.cpp
@@ -11,8 +11,8 @@
 #include "Common/Logging/Log.h"
 #include "Common/Network.h"
 #include "Common/Swap.h"
-
 #include "Core/HW/Memmap.h"
+#include "Core/IOS/IPC.h"
 #include "Core/IOS/Network/MACUtils.h"
 
 namespace IOS
@@ -93,7 +93,9 @@ IPCCommandResult NetWDCommand::IOCtlV(const IOCtlVRequest& request)
   case IOCTLV_WD_RECV_FRAME:
   case IOCTLV_WD_RECV_NOTIFICATION:
   default:
-    request.Dump(GetDeviceName(), LogTypes::IOS_NET, LogTypes::LINFO);
+    request.DumpUnknown(GetDeviceName(), LogTypes::IOS_NET, LogTypes::LINFO);
+    ReportUnknownRequest(GetDeviceName(), request);
+    break;
   }
 
   return GetDefaultReply(return_value);

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -16,6 +16,7 @@
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/Memmap.h"
+#include "Core/IOS/IPC.h"
 #include "Core/IOS/USB/Common.h"
 #include "Core/IOS/USB/USBV0.h"
 
@@ -151,6 +152,7 @@ IPCCommandResult OH0::GetRhPortStatus(const IOCtlVRequest& request) const
 
   ERROR_LOG(IOS_USB, "Unimplemented IOCtlV: IOCTLV_USBV0_GETRHPORTSTATUS");
   request.Dump(GetDeviceName(), LogTypes::IOS_USB, LogTypes::LERROR);
+  ReportUnknownRequest(GetDeviceName(), request);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
@@ -161,6 +163,7 @@ IPCCommandResult OH0::SetRhPortStatus(const IOCtlVRequest& request)
 
   ERROR_LOG(IOS_USB, "Unimplemented IOCtlV: IOCTLV_USBV0_SETRHPORTSTATUS");
   request.Dump(GetDeviceName(), LogTypes::IOS_USB, LogTypes::LERROR);
+  ReportUnknownRequest(GetDeviceName(), request);
   return GetDefaultReply(IPC_SUCCESS);
 }
 
@@ -311,6 +314,7 @@ IPCCommandResult OH0::DeviceIOCtlV(const u64 device_id, const IOCtlVRequest& req
                           [&, this]() { return SubmitTransfer(*device, request); });
   case USB::IOCTLV_USBV0_UNKNOWN_32:
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS_USB);
+    ReportUnknownRequest(GetDeviceName(), request);
     return GetDefaultReply(IPC_SUCCESS);
   default:
     return GetDefaultReply(IPC_EINVAL);

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -10,9 +10,9 @@
 #include "Common/Logging/Log.h"
 #include "Common/Swap.h"
 
-#include "Core/CoreTiming.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
+#include "Core/IOS/IPC.h"
 #include "Core/IOS/USB/Common.h"
 #include "Core/IOS/USB/USBV5.h"
 
@@ -63,6 +63,7 @@ IPCCommandResult USB_VEN::IOCtl(const IOCtlRequest& request)
     return HandleDeviceIOCtl(request, &USB_VEN::CancelEndpoint);
   default:
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS_USB, LogTypes::LERROR);
+    ReportUnknownRequest(GetDeviceName(), request);
     return GetDefaultReply(IPC_SUCCESS);
   }
 }

--- a/Source/Core/Core/IOS/WFS/WFSI.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSI.cpp
@@ -15,6 +15,7 @@
 #include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/IOS/IPC.h"
 #include "Core/IOS/WFS/WFSSRV.h"
 #include "DiscIO/NANDContentLoader.h"
 
@@ -207,10 +208,12 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
     // Bytes 4-8: game id
     // Bytes 1c-1e: title id?
     WARN_LOG(IOS, "IOCTL_WFSI_DELETE_TITLE: unimplemented");
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
 
   case IOCTL_WFSI_IMPORT_TITLE:
     WARN_LOG(IOS, "IOCTL_WFSI_IMPORT_TITLE: unimplemented");
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
 
   case IOCTL_WFSI_INIT:
@@ -240,6 +243,7 @@ IPCCommandResult WFSI::IOCtl(const IOCtlRequest& request)
     // succeeding.
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS, LogTypes::LWARNING);
     Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
   }
 

--- a/Source/Core/Core/IOS/WFS/WFSSRV.cpp
+++ b/Source/Core/Core/IOS/WFS/WFSSRV.cpp
@@ -12,6 +12,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/NandPaths.h"
 #include "Core/HW/Memmap.h"
+#include "Core/IOS/IPC.h"
 
 namespace IOS
 {
@@ -157,6 +158,7 @@ IPCCommandResult WFSSRV::IOCtl(const IOCtlRequest& request)
     // properly stubbed it's easier to simulate the methods succeeding.
     request.DumpUnknown(GetDeviceName(), LogTypes::IOS, LogTypes::LWARNING);
     Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
+    ReportUnknownRequest(GetDeviceName(), request);
     break;
   }
 


### PR DESCRIPTION
We are now down to a few unknown requests for some resource managers (ES & USB), so having info about the remaining ones will help get them implemented.

Also report unknown IOS devices along with the current IOS version, as there may be devices we still haven't implemented.

Only for open, ioctl and ioctlv (the other types aren't too useful).