### PR TITLE
IOS/ES: Implement ES_DIGetTMD and ES_DIGetTMDSize

### DIFF
--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -372,6 +372,10 @@ IPCCommandResult ES::IOCtlV(const IOCtlVRequest& request)
     return DIGetTMDViewSize(request);
   case IOCTL_ES_DIGETTMDVIEW:
     return DIGetTMDView(request);
+  case IOCTL_ES_DIGETTMDSIZE:
+    return DIGetTMDSize(request);
+  case IOCTL_ES_DIGETTMD:
+    return DIGetTMD(request);
 
   case IOCTL_ES_GETCONSUMPTION:
     return GetConsumption(request);
@@ -414,8 +418,6 @@ IPCCommandResult ES::IOCtlV(const IOCtlVRequest& request)
 
   case IOCTL_ES_VERIFYSIGN:
   case IOCTL_ES_DELETESHAREDCONTENT:
-  case IOCTL_ES_UNKNOWN_39:
-  case IOCTL_ES_UNKNOWN_3A:
   case IOCTL_ES_UNKNOWN_3B:
   case IOCTL_ES_UNKNOWN_3C:
   case IOCTL_ES_UNKNOWN_3D:

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -120,8 +120,8 @@ private:
     IOCTL_ES_GETSHAREDCONTENTCNT = 0x36,
     IOCTL_ES_GETSHAREDCONTENTS = 0x37,
     IOCTL_ES_DELETESHAREDCONTENT = 0x38,
-    IOCTL_ES_UNKNOWN_39 = 0x39,
-    IOCTL_ES_UNKNOWN_3A = 0x3A,
+    IOCTL_ES_DIGETTMDSIZE = 0x39,
+    IOCTL_ES_DIGETTMD = 0x3A,
     IOCTL_ES_UNKNOWN_3B = 0x3B,
     IOCTL_ES_UNKNOWN_3C = 0x3C,
     IOCTL_ES_UNKNOWN_3D = 0x3D,
@@ -223,6 +223,8 @@ private:
   IPCCommandResult DIGetTicketView(const IOCtlVRequest& request);
   IPCCommandResult DIGetTMDViewSize(const IOCtlVRequest& request);
   IPCCommandResult DIGetTMDView(const IOCtlVRequest& request);
+  IPCCommandResult DIGetTMDSize(const IOCtlVRequest& request);
+  IPCCommandResult DIGetTMD(const IOCtlVRequest& request);
 
   static bool LaunchIOS(u64 ios_title_id);
   static bool LaunchPPCTitle(u64 title_id, bool skip_reload);


### PR DESCRIPTION
This implements two closely related ioctlvs (handled by the same function in IOS) which return the TMD for the active title.

This is actually used by Metroid Prime.