### PR TITLE
Vulkan: MSAA and frame dumping fixes

### DIFF
--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -462,6 +462,12 @@ Texture2D* FramebufferManager::ResolveEFBColorTexture(const VkRect2D& region)
   // Can't resolve within a render pass.
   StateTracker::GetInstance()->EndRenderPass();
 
+  // It's not valid to resolve out-of-bounds coordinates.
+  // Ensuring the region is within the image is the caller's responsibility.
+  _assert_(region.offset.x >= 0 && region.offset.y >= 0 &&
+           (static_cast<u32>(region.offset.x) + region.extent.width) <= m_efb_width &&
+           (static_cast<u32>(region.offset.y) + region.extent.height) <= m_efb_height);
+
   // Resolving is considered to be a transfer operation.
   m_efb_color_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                           VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
@@ -67,6 +67,9 @@ public:
   Texture2D* ResolveEFBColorTexture(const VkRect2D& region);
   Texture2D* ResolveEFBDepthTexture(const VkRect2D& region);
 
+  // Returns the texture that the EFB color texture is resolved to when multisampling is enabled.
+  // Ensure ResolveEFBColorTexture is called before this method.
+  Texture2D* GetResolvedEFBColorTexture() const { return m_efb_resolve_color_texture.get(); }
   // Reads a framebuffer value back from the GPU. This may block if the cache is not current.
   u32 PeekEFBColor(u32 x, u32 y);
   float PeekEFBDepth(u32 x, u32 y);

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -756,6 +756,10 @@ bool Renderer::DrawFrameDump(const TargetRectangle& scaled_efb_rect, u32 xfb_add
   if (!ResizeFrameDumpBuffer(width, height))
     return false;
 
+  // If there was a previous frame dumped, we'll still be in TRANSFER_SRC layout.
+  m_frame_dump_render_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                                  VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+
   VkClearValue clear_value = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
   VkClearRect clear_rect = {{{0, 0}, {width, height}}, 0, 1};
   VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_COLOR_BIT, 0, clear_value};
@@ -781,6 +785,8 @@ bool Renderer::DrawFrameDump(const TargetRectangle& scaled_efb_rect, u32 xfb_add
     return false;
 
   // Queue a copy to the current frame dump buffer. It will be written to the frame dump later.
+  m_frame_dump_render_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                                  VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
   readback_texture->CopyFromImage(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                   m_frame_dump_render_texture->GetImage(),
                                   VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, width, height, 0, 0);

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -959,6 +959,10 @@ bool Renderer::ResizeFrameDumpBuffer(u32 new_width, u32 new_height)
     return true;
   }
 
+  // Ensure all previous frames have been dumped, since we are destroying a framebuffer
+  // that may still be in use.
+  FlushFrameDump();
+
   if (m_frame_dump_framebuffer != VK_NULL_HANDLE)
   {
     vkDestroyFramebuffer(g_vulkan_context->GetDevice(), m_frame_dump_framebuffer, nullptr);

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -587,12 +587,11 @@ void Renderer::ResolveEFBForSwap(const TargetRectangle& scaled_rect)
 {
   // While the source rect can be out-of-range when drawing, the resolve rectangle must be within
   // the bounds of the texture.
-  TargetRectangle resolve_rect{scaled_rect};
-  resolve_rect.ClampUL(0, 0, m_target_width, m_target_height);
-
   VkRect2D region = {
-      {resolve_rect.left, resolve_rect.top},
-      {static_cast<u32>(resolve_rect.GetWidth()), static_cast<u32>(resolve_rect.GetHeight())}};
+      {scaled_rect.left, scaled_rect.top},
+      {static_cast<u32>(scaled_rect.GetWidth()), static_cast<u32>(scaled_rect.GetHeight())}};
+  region = Util::ClampRect2D(region, FramebufferManager::GetInstance()->GetEFBWidth(),
+                             FramebufferManager::GetInstance()->GetEFBHeight());
   FramebufferManager::GetInstance()->ResolveEFBColorTexture(region);
 }
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -90,13 +90,15 @@ private:
   bool CompileShaders();
   void DestroyShaders();
 
+  void ResolveEFBForSwap(const TargetRectangle& scaled_rect);
+
   // Draw either the EFB, or specified XFB sources to the currently-bound framebuffer.
   void DrawFrame(VkRenderPass render_pass, const TargetRectangle& target_rect,
-                 const EFBRectangle& source_rect, u32 xfb_addr,
+                 const TargetRectangle& scaled_efb_rect, u32 xfb_addr,
                  const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                  u32 fb_stride, u32 fb_height);
   void DrawEFB(VkRenderPass render_pass, const TargetRectangle& target_rect,
-               const EFBRectangle& source_rect);
+               const TargetRectangle& scaled_efb_rect);
   void DrawVirtualXFB(VkRenderPass render_pass, const TargetRectangle& target_rect, u32 xfb_addr,
                       const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                       u32 fb_stride, u32 fb_height);
@@ -105,12 +107,14 @@ private:
                    u32 fb_stride, u32 fb_height);
 
   // Draw the frame, as well as the OSD to the swap chain.
-  void DrawScreen(const EFBRectangle& rc, u32 xfb_addr, const XFBSourceBase* const* xfb_sources,
-                  u32 xfb_count, u32 fb_width, u32 fb_stride, u32 fb_height);
+  void DrawScreen(const TargetRectangle& scaled_efb_rect, u32 xfb_addr,
+                  const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
+                  u32 fb_stride, u32 fb_height);
 
   // Draw the frame only to the screenshot buffer.
-  bool DrawFrameDump(const EFBRectangle& rc, u32 xfb_addr, const XFBSourceBase* const* xfb_sources,
-                     u32 xfb_count, u32 fb_width, u32 fb_stride, u32 fb_height, u64 ticks);
+  bool DrawFrameDump(const TargetRectangle& scaled_efb_rect, u32 xfb_addr,
+                     const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
+                     u32 fb_stride, u32 fb_height, u64 ticks);
 
   // Sets up renderer state to permit framedumping.
   // Ideally we would have EndFrameDumping be a virtual method of Renderer, but due to various

--- a/Source/Core/VideoBackends/Vulkan/Util.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Util.cpp
@@ -97,6 +97,16 @@ u32 GetTexelSize(VkFormat format)
   }
 }
 
+VkRect2D ClampRect2D(const VkRect2D& rect, u32 width, u32 height)
+{
+  VkRect2D out;
+  out.offset.x = MathUtil::Clamp(rect.offset.x, 0, static_cast<int32_t>(width - 1));
+  out.offset.y = MathUtil::Clamp(rect.offset.y, 0, static_cast<int32_t>(height - 1));
+  out.extent.width = std::min(rect.extent.width, width - static_cast<uint32_t>(rect.offset.x));
+  out.extent.height = std::min(rect.extent.height, height - static_cast<uint32_t>(rect.offset.y));
+  return out;
+}
+
 VkBlendFactor GetAlphaBlendFactor(VkBlendFactor factor)
 {
   switch (factor)

--- a/Source/Core/VideoBackends/Vulkan/Util.h
+++ b/Source/Core/VideoBackends/Vulkan/Util.h
@@ -27,6 +27,9 @@ bool IsDepthFormat(VkFormat format);
 VkFormat GetLinearFormat(VkFormat format);
 u32 GetTexelSize(VkFormat format);
 
+// Clamps a VkRect2D to the specified dimensions.
+VkRect2D ClampRect2D(const VkRect2D& rect, u32 width, u32 height);
+
 // Map {SRC,DST}_COLOR to {SRC,DST}_ALPHA
 VkBlendFactor GetAlphaBlendFactor(VkBlendFactor factor);
 


### PR DESCRIPTION
Fixes crash when multisampling is enabled on Vulkan, as well as a crash that occurred when a game did an out-of-bounds EFB copy (also with multisampling).

Plus a few fixes involving incorrect behavior when dumping frames, this probably didn't break anything (since the NV driver seems to somewhat ignore image layouts), but it did throw validation layer errors.

Fixes issue 10211: https://bugs.dolphin-emu.org/issues/10211