### PR TITLE
x86-64 support on Android

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -65,7 +65,7 @@ android {
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_STL=c++_static", "-DCMAKE_BUILD_TYPE=RelWithDebInfo" // , "-DENABLE_GENERIC=ON"
-                abiFilters "arm64-v8a" //, "armeabi-v7a", "x86_64", "x86"
+                abiFilters "arm64-v8a", "x86_64" //, "armeabi-v7a", "x86"
             }
         }
     }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/NativeLibrary.java
@@ -323,6 +323,8 @@ public final class NativeLibrary
 	 */
 	public static native String GetUserDirectory();
 
+	public static native int DefaultCPUCore();
+
 	/**
 	 * Begins emulation.
 	 */

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/settings/SettingsFragmentPresenter.java
@@ -1,5 +1,6 @@
 package org.dolphinemu.dolphinemu.ui.settings;
 
+import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 import org.dolphinemu.dolphinemu.model.settings.BooleanSetting;
 import org.dolphinemu.dolphinemu.model.settings.IntSetting;
@@ -179,8 +180,28 @@ public final class SettingsFragmentPresenter
 			mView.passSettingsToActivity(mSettings);
 		}
 
-		// TODO Set default value for cpuCore based on arch.
-		sl.add(new SingleChoiceSetting(SettingsFile.KEY_CPU_CORE, SettingsFile.SECTION_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.cpu_core, 0, R.array.emuCoresEntries, R.array.emuCoresValues, 4, cpuCore));
+		// TODO: Having different emuCoresEntries/emuCoresValues for each architecture is annoying.
+		// The proper solution would be to have one emuCoresEntries and one emuCoresValues
+		// and exclude the values that aren't present in PowerPC::AvailableCPUCores().
+		int defaultCpuCore = NativeLibrary.DefaultCPUCore();
+		int emuCoresEntries;
+		int emuCoresValues;
+		if (defaultCpuCore == 1)  // x86-64
+		{
+			emuCoresEntries = R.array.emuCoresEntriesX86_64;
+			emuCoresValues = R.array.emuCoresValuesX86_64;
+		}
+		else if (defaultCpuCore == 4)  // AArch64
+		{
+			emuCoresEntries = R.array.emuCoresEntriesARM64;
+			emuCoresValues = R.array.emuCoresValuesARM64;
+		}
+		else
+		{
+			emuCoresEntries = R.array.emuCoresEntriesGeneric;
+			emuCoresValues = R.array.emuCoresValuesGeneric;
+		}
+		sl.add(new SingleChoiceSetting(SettingsFile.KEY_CPU_CORE, SettingsFile.SECTION_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.cpu_core, 0, emuCoresEntries, emuCoresValues, defaultCpuCore, cpuCore));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_DUAL_CORE, SettingsFile.SECTION_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.dual_core, R.string.dual_core_descrip, true, dualCore));
 		sl.add(new CheckBoxSetting(SettingsFile.KEY_OVERCLOCK_ENABLE, SettingsFile.SECTION_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.overclock_enable, R.string.overclock_enable_description, false, overclockEnable));
 		sl.add(new SliderSetting(SettingsFile.KEY_OVERCLOCK_PERCENT, SettingsFile.SECTION_CORE, SettingsFile.SETTINGS_DOLPHIN, R.string.overclock_title, 0, 400, "%", 100, overclock));

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -4,19 +4,33 @@
 <resources>
 
     <!-- New UI CPU Core selection - Default -->
-    <string-array name="emuCoresEntries" translatable="false">
+    <string-array name="emuCoresEntriesX86_64" translatable="false">
+        <item>Interpreter</item>
+        <item>Cached Interpreter</item>
+        <item>JIT Recompiler</item>
+    </string-array>
+    <integer-array name="emuCoresValuesX86_64" translatable="false">
+        <item>0</item>
+        <item>5</item>
+        <item>1</item>
+    </integer-array>
+    <string-array name="emuCoresEntriesARM64" translatable="false">
         <item>Interpreter</item>
         <item>Cached Interpreter</item>
         <item>JIT ARM64 Recompiler</item>
-        <!--<item>JIT64 Recompiler</item>
-        <item>JITIL Recompiler</item>-->
     </string-array>
-    <integer-array name="emuCoresValues" translatable="false">
+    <integer-array name="emuCoresValuesARM64" translatable="false">
         <item>0</item>
         <item>5</item>
         <item>4</item>
-        <!--<item>1</item>
-        <item>2</item>-->
+    </integer-array>
+    <string-array name="emuCoresEntriesGeneric" translatable="false">
+        <item>Interpreter</item>
+        <item>Cached Interpreter</item>
+    </string-array>
+    <integer-array name="emuCoresValuesGeneric" translatable="false">
+        <item>0</item>
+        <item>5</item>
     </integer-array>
 
     <!-- Video backend selection -->

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -30,6 +30,7 @@
 #include "Core/HW/WiimoteReal/WiimoteReal.h"
 #include "Core/Host.h"
 #include "Core/PowerPC/JitInterface.h"
+#include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/Profiler.h"
 #include "Core/State.h"
 
@@ -453,6 +454,8 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetUserDirec
     JNIEnv* env, jobject obj, jstring jDirectory);
 JNIEXPORT jstring JNICALL
 Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDirectory(JNIEnv* env, jobject obj);
+JNIEXPORT jint JNICALL
+Java_org_dolphinemu_dolphinemu_NativeLibrary_DefaultCPUCore(JNIEnv* env, jobject obj);
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetProfiling(JNIEnv* env,
                                                                                  jobject obj,
                                                                                  jboolean enable);
@@ -687,6 +690,12 @@ JNIEXPORT jstring JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GetUserDi
                                                                                         jobject obj)
 {
   return env->NewStringUTF(File::GetUserPath(D_USER_IDX).c_str());
+}
+
+JNIEXPORT jint JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_DefaultCPUCore(JNIEnv* env,
+                                                                                   jobject obj)
+{
+  return PowerPC::DefaultCPUCore();
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_SetProfiling(JNIEnv* env,

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -809,7 +809,7 @@ void SConfig::LoadDefaults()
 #endif
 #endif
 
-  iCPUCore = PowerPC::CORE_JIT64;
+  iCPUCore = PowerPC::DefaultCPUCore();
   iTimingVariance = 40;
   bCPUThread = false;
   bSyncGPUOnSkipIdleHack = true;

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -5,6 +5,7 @@
 #include "Core/PowerPC/PowerPC.h"
 
 #include <cstring>
+#include <vector>
 
 #include "Common/Assert.h"
 #include "Common/ChunkFile.h"
@@ -178,6 +179,31 @@ static void InitializeCPUCore(int cpu_core)
   {
     s_mode = CoreMode::Interpreter;
   }
+}
+
+const std::vector<CPUCore>& AvailableCPUCores()
+{
+  static const std::vector<CPUCore> cpu_cores = {
+      CORE_INTERPRETER, CORE_CACHEDINTERPRETER,
+#ifdef _M_X86_64
+      CORE_JIT64, CORE_JITIL64,
+#elif defined(_M_ARM_64)
+      CORE_JITARM64,
+#endif
+  };
+
+  return cpu_cores;
+}
+
+CPUCore DefaultCPUCore()
+{
+#ifdef _M_X86_64
+  return CORE_JIT64;
+#elif defined(_M_ARM_64)
+  return CORE_JITARM64;
+#else
+  return CORE_CACHEDINTERPRETER;
+#endif
 }
 
 void Init(int cpu_core)

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstddef>
 #include <tuple>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 
@@ -20,7 +21,7 @@ class PointerWrap;
 
 namespace PowerPC
 {
-enum
+enum CPUCore
 {
   CORE_INTERPRETER,
   CORE_JIT64,
@@ -134,6 +135,9 @@ extern Watches watches;
 extern BreakPoints breakpoints;
 extern MemChecks memchecks;
 extern PPCDebugInterface debug_interface;
+
+const std::vector<CPUCore>& AvailableCPUCores();
+CPUCore DefaultCPUCore();
 
 void Init(int cpu_core);
 void Reset();

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.h
@@ -19,12 +19,6 @@ public:
   GeneralConfigPane(wxWindow* parent, wxWindowID id);
 
 private:
-  struct CPUCore
-  {
-    int CPUid;
-    wxString name;
-  };
-  std::vector<CPUCore> m_cpu_cores;
   void InitializeGUI();
   void LoadGUIValues();
   void BindEvents();


### PR DESCRIPTION
We can do this now that the x86-64 JIT supports PIE.

JITIL is deliberately excluded from the GUI because it doesn't support PIE yet. (JITIL will be used if it's set in the INI, though.)

I don't have any x86-64 device that runs Android, so I haven't been able to test this. I did test that it doesn't affect x86-64 DolphinWX and AArch64 Android, though.