### PR TITLE
Force SyncGPU on pause

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -82,6 +82,7 @@
 namespace Core
 {
 static bool s_wants_determinism;
+static bool s_had_sync_gpu;
 
 // Declarations and definitions
 static Common::Timer s_timer;
@@ -960,6 +961,20 @@ void UpdateWantDeterminism(bool initial)
     Core::InitializeWiiRoot(s_wants_determinism);
 
     Core::PauseAndLock(false, was_unpaused);
+  }
+}
+
+void UpdateWantSyncGPU(bool want)
+{
+  SConfig& config = SConfig::GetInstance();
+  if (want)
+  {
+    s_had_sync_gpu = config.bSyncGPU;
+    config.bSyncGPU = true;
+  }
+  else
+  {
+    config.bSyncGPU = s_had_sync_gpu;
   }
 }
 

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -85,6 +85,8 @@ void SetOnStoppedCallback(StoppedCallbackFunc callback);
 // Run on the Host thread when the factors change. [NOT THREADSAFE]
 void UpdateWantDeterminism(bool initial = false);
 
+void UpdateWantSyncGPU(bool want = false);
+
 // Queue an arbitrary function to asynchronously run once on the Host thread later.
 // Threadsafe. Can be called by any thread, including the Host itself.
 // Jobs will be executed in RELATIVE order. If you queue 2 jobs from the same thread

--- a/Source/Core/Core/PowerPC/MMU.cpp
+++ b/Source/Core/Core/PowerPC/MMU.cpp
@@ -442,6 +442,8 @@ static void Memcheck(u32 address, u32 var, bool write, size_t size)
       bool pause = mc->Action(&PowerPC::debug_interface, var, address, write, size, PC);
       if (pause)
       {
+        // Force SyncGPU to prevent desync
+        Core::UpdateWantSyncGPU(true);
         CPU::Break();
         // Fake a DSI so that all the code that tests for it in order to skip
         // the rest of the instruction will apply.  (This means that

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -15,6 +15,7 @@
 #include "Common/MathUtil.h"
 
 #include "Core/ConfigManager.h"
+#include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/CPU.h"
 #include "Core/HW/Memmap.h"
@@ -550,6 +551,8 @@ void CheckBreakPoints()
 {
   if (PowerPC::breakpoints.IsAddressBreakPoint(PC))
   {
+    // Force SyncGPU to prevent desync
+    Core::UpdateWantSyncGPU(true);
     CPU::Break();
     if (PowerPC::breakpoints.IsTempBreakPoint(PC))
       PowerPC::breakpoints.Remove(PC);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -528,6 +528,8 @@ void CFrame::OnPlay(wxCommandEvent& event)
     if (UseDebugger)
     {
       bool was_stopped = CPU::IsStepping();
+      // Force/Restore SyncGPU to prevent desync
+      Core::UpdateWantSyncGPU(!was_stopped);
       CPU::EnableStepping(!was_stopped);
       // When the CPU stops it generates a IDM_UPDATE_DISASM_DIALOG which automatically refreshes
       // the UI, the UI only needs to be refreshed manually when unpausing.
@@ -773,6 +775,8 @@ void CFrame::DoPause()
 {
   if (Core::GetState() == Core::State::Running)
   {
+    // Force SyncGPU to prevent desync
+    Core::UpdateWantSyncGPU(true);
     Core::SetState(Core::State::Paused);
     if (SConfig::GetInstance().bHideCursor)
       m_RenderParent->SetCursor(wxNullCursor);
@@ -780,6 +784,8 @@ void CFrame::DoPause()
   }
   else
   {
+    // Restore SyncGPU settings
+    Core::UpdateWantSyncGPU();
     Core::SetState(Core::State::Running);
     if (SConfig::GetInstance().bHideCursor && RendererHasFocus())
       m_RenderParent->SetCursor(wxCURSOR_BLANK);


### PR DESCRIPTION
This PR is an attempt to fix random crashes that happen when the emulator hits a breakpoint (and probably happen when the emulator is paused). It seems that these crashes only happen on dual-core with SyncGPU off, switching to single-core or enabling SyncGPU seems to fix them.

I try to address these by enabling SyncGPU before pausing the emulator. However, even if it works I'm not sure that's the best way to sync the GPU since I mess with the config on the fly. So I'm open to any suggestions.

Regardless, this fix the following issue for me: https://bugs.dolphin-emu.org/issues/10132
And might fix this one as well: https://bugs.dolphin-emu.org/issues/10071

Ready to be reviewed & tested.