### PR TITLE
Native compressed custom texture support

### DIFF
--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -93,6 +93,7 @@
     <ClInclude Include="GL\GLExtensions\ARB_uniform_buffer_object.h" />
     <ClInclude Include="GL\GLExtensions\ARB_vertex_array_object.h" />
     <ClInclude Include="GL\GLExtensions\ARB_viewport_array.h" />
+    <ClInclude Include="GL\GLExtensions\EXT_texture_compression_s3tc.h" />
     <ClInclude Include="GL\GLExtensions\EXT_texture_filter_anisotropic.h" />
     <ClInclude Include="GL\GLExtensions\GLExtensions.h" />
     <ClInclude Include="GL\GLExtensions\gl_1_1.h" />

--- a/Source/Core/Common/Common.vcxproj.filters
+++ b/Source/Core/Common/Common.vcxproj.filters
@@ -248,6 +248,9 @@
     <ClInclude Include="GL\GLExtensions\ARB_compute_shader.h">
       <Filter>GL\GLExtensions</Filter>
     </ClInclude>
+    <ClInclude Include="GL\GLExtensions\EXT_texture_compression_s3tc.h">
+      <Filter>GL\GLExtensions</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CDUtils.cpp" />

--- a/Source/Core/Common/GL/GLExtensions/EXT_texture_compression_s3tc.h
+++ b/Source/Core/Common/GL/GLExtensions/EXT_texture_compression_s3tc.h
@@ -1,0 +1,29 @@
+/*
+** Copyright (c) 2013-2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+#include "Common/GL/GLExtensions/gl_common.h"
+
+#define GL_COMPRESSED_RGB_S3TC_DXT1_EXT 0x83F0
+#define GL_COMPRESSED_RGBA_S3TC_DXT1_EXT 0x83F1
+#define GL_COMPRESSED_RGBA_S3TC_DXT3_EXT 0x83F2
+#define GL_COMPRESSED_RGBA_S3TC_DXT5_EXT 0x83F3

--- a/Source/Core/Common/GL/GLExtensions/GLExtensions.h
+++ b/Source/Core/Common/GL/GLExtensions/GLExtensions.h
@@ -31,6 +31,7 @@
 #include "Common/GL/GLExtensions/ARB_uniform_buffer_object.h"
 #include "Common/GL/GLExtensions/ARB_vertex_array_object.h"
 #include "Common/GL/GLExtensions/ARB_viewport_array.h"
+#include "Common/GL/GLExtensions/EXT_texture_compression_s3tc.h"
 #include "Common/GL/GLExtensions/EXT_texture_filter_anisotropic.h"
 #include "Common/GL/GLExtensions/HP_occlusion_test.h"
 #include "Common/GL/GLExtensions/KHR_debug.h"

--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -239,6 +239,19 @@ D3D_FEATURE_LEVEL GetFeatureLevel(IDXGIAdapter* adapter)
   return feat_level;
 }
 
+static bool SupportsS3TCTextures(ID3D11Device* device)
+{
+  UINT bc1_support, bc2_support, bc3_support;
+  if (FAILED(device->CheckFormatSupport(DXGI_FORMAT_BC1_UNORM, &bc1_support)) ||
+      FAILED(device->CheckFormatSupport(DXGI_FORMAT_BC2_UNORM, &bc2_support)) ||
+      FAILED(device->CheckFormatSupport(DXGI_FORMAT_BC3_UNORM, &bc3_support)))
+  {
+    return false;
+  }
+
+  return ((bc1_support & bc2_support & bc3_support) & D3D11_FORMAT_SUPPORT_TEXTURE2D) != 0;
+}
+
 HRESULT Create(HWND wnd)
 {
   hWnd = wnd;
@@ -427,6 +440,7 @@ HRESULT Create(HWND wnd)
   UINT format_support;
   device->CheckFormatSupport(DXGI_FORMAT_B8G8R8A8_UNORM, &format_support);
   bgra_textures_supported = (format_support & D3D11_FORMAT_SUPPORT_TEXTURE2D) != 0;
+  g_Config.backend_info.bSupportsST3CTextures = SupportsS3TCTextures(device);
 
   stateman = new StateManager;
   return S_OK;

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <memory>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
@@ -29,6 +30,42 @@ static std::unique_ptr<PSTextureEncoder> g_encoder;
 const size_t MAX_COPY_BUFFERS = 32;
 ID3D11Buffer* efbcopycbuf[MAX_COPY_BUFFERS] = {0};
 
+static u32 GetLevelPitch(HostTextureFormat format, u32 row_length)
+{
+  switch (format)
+  {
+  case HostTextureFormat::DXT1:
+    return row_length / 4 * 8;
+
+  case HostTextureFormat::DXT3:
+  case HostTextureFormat::DXT5:
+    return row_length / 4 * 16;
+
+  case HostTextureFormat::RGBA8:
+  default:
+    return row_length * 4;
+  }
+}
+
+static DXGI_FORMAT GetDXGIFormatForHostFormat(HostTextureFormat format)
+{
+  switch (format)
+  {
+  case HostTextureFormat::DXT1:
+    return DXGI_FORMAT_BC1_UNORM;
+
+  case HostTextureFormat::DXT3:
+    return DXGI_FORMAT_BC2_UNORM;
+
+  case HostTextureFormat::DXT5:
+    return DXGI_FORMAT_BC3_UNORM;
+
+  case HostTextureFormat::RGBA8:
+  default:
+    return DXGI_FORMAT_R8G8B8A8_UNORM;
+  }
+}
+
 TextureCache::TCacheEntry::~TCacheEntry()
 {
   texture->Release();
@@ -41,6 +78,11 @@ void TextureCache::TCacheEntry::Bind(unsigned int stage)
 
 bool TextureCache::TCacheEntry::Save(const std::string& filename, unsigned int level)
 {
+  // We can't dump compressed textures currently (it would mean drawing them to a RGBA8
+  // framebuffer, and saving that). TextureCache does not call Save for custom textures
+  // anyway, so this is fine for now.
+  _assert_(config.format == HostTextureFormat::RGBA8);
+
   // Create a staging/readback texture with the dimensions of the specified mip level.
   u32 mip_width = std::max(config.width >> level, 1u);
   u32 mip_height = std::max(config.height >> level, 1u);
@@ -132,25 +174,26 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(const TCacheEntryBase* 
 void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_length,
                                      const u8* buffer, size_t buffer_size)
 {
-  u32 src_pitch = row_length * 4;
+  u32 src_pitch = GetLevelPitch(config.format, row_length);
   D3D::context->UpdateSubresource(texture->GetTex(), level, nullptr, buffer, src_pitch, 0);
 }
 
 TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntryConfig& config)
 {
+  DXGI_FORMAT dxgi_format = GetDXGIFormatForHostFormat(config.format);
   if (config.rendertarget)
   {
     return new TCacheEntry(
-        config, D3DTexture2D::Create(
-                    config.width, config.height, (D3D11_BIND_FLAG)((int)D3D11_BIND_RENDER_TARGET |
-                                                                   (int)D3D11_BIND_SHADER_RESOURCE),
-                    D3D11_USAGE_DEFAULT, DXGI_FORMAT_R8G8B8A8_UNORM, 1, config.layers));
+        config, D3DTexture2D::Create(config.width, config.height,
+                                     (D3D11_BIND_FLAG)((int)D3D11_BIND_RENDER_TARGET |
+                                                       (int)D3D11_BIND_SHADER_RESOURCE),
+                                     D3D11_USAGE_DEFAULT, dxgi_format, 1, config.layers));
   }
   else
   {
     const D3D11_TEXTURE2D_DESC texdesc =
-        CD3D11_TEXTURE2D_DESC(DXGI_FORMAT_R8G8B8A8_UNORM, config.width, config.height, 1,
-                              config.levels, D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0);
+        CD3D11_TEXTURE2D_DESC(dxgi_format, config.width, config.height, 1, config.levels,
+                              D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DEFAULT, 0);
 
     ID3D11Texture2D* pTexture;
     const HRESULT hr = D3D::device->CreateTexture2D(&texdesc, nullptr, &pTexture);

--- a/Source/Core/VideoBackends/D3D/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D/TextureCache.cpp
@@ -129,10 +129,10 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(const TCacheEntryBase* 
   g_renderer->RestoreAPIState();
 }
 
-void TextureCache::TCacheEntry::Load(const u8* buffer, u32 width, u32 height, u32 expanded_width,
-                                     u32 level)
+void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_length,
+                                     const u8* buffer, size_t buffer_size)
 {
-  unsigned int src_pitch = 4 * expanded_width;
+  u32 src_pitch = row_length * 4;
   D3D::context->UpdateSubresource(texture->GetTex(), level, nullptr, buffer, src_pitch, 0);
 }
 

--- a/Source/Core/VideoBackends/D3D/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D/TextureCache.h
@@ -30,7 +30,8 @@ private:
                                   const MathUtil::Rectangle<int>& srcrect,
                                   const MathUtil::Rectangle<int>& dstrect) override;
 
-    void Load(const u8* buffer, u32 width, u32 height, u32 expanded_width, u32 levels) override;
+    void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
+              size_t buffer_size) override;
 
     void FromRenderTarget(bool is_depth_copy, const EFBRectangle& srcRect, bool scaleByHalf,
                           unsigned int cbufid, const float* colmat) override;

--- a/Source/Core/VideoBackends/D3D/main.cpp
+++ b/Source/Core/VideoBackends/D3D/main.cpp
@@ -77,6 +77,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsMultithreading = false;
   g_Config.backend_info.bSupportsInternalResolutionFrameDumps = false;
   g_Config.backend_info.bSupportsGPUTextureDecoding = false;
+  g_Config.backend_info.bSupportsST3CTextures = false;
 
   IDXGIFactory* factory;
   IDXGIAdapter* ad;

--- a/Source/Core/VideoBackends/D3D12/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D12/D3DBase.cpp
@@ -262,6 +262,21 @@ std::vector<DXGI_SAMPLE_DESC> EnumAAModes(ID3D12Device* device)
   return aa_modes;
 }
 
+static bool SupportsS3TCTextures(ID3D12Device* device)
+{
+  auto CheckForFormat = [](ID3D12Device* device, DXGI_FORMAT format) {
+    D3D12_FEATURE_DATA_FORMAT_SUPPORT data = {format};
+    if (FAILED(device->CheckFeatureSupport(D3D12_FEATURE_FORMAT_SUPPORT, &data, sizeof(data))))
+      return false;
+
+    return (data.Support1 & D3D12_FORMAT_SUPPORT1_TEXTURE2D) != 0;
+  };
+
+  return CheckForFormat(device, DXGI_FORMAT_BC1_UNORM) &&
+         CheckForFormat(device, DXGI_FORMAT_BC2_UNORM) &&
+         CheckForFormat(device, DXGI_FORMAT_BC3_UNORM);
+}
+
 HRESULT Create(HWND wnd)
 {
   hWnd = wnd;
@@ -477,6 +492,8 @@ HRESULT Create(HWND wnd)
 
   SAFE_RELEASE(factory);
   SAFE_RELEASE(adapter);
+
+  g_Config.backend_info.bSupportsST3CTextures = SupportsS3TCTextures(device12);
 
   return S_OK;
 }

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -33,23 +33,6 @@ static u32 s_efb_copy_last_cbuf_id = UINT_MAX;
 static ID3D12Resource* s_texture_cache_entry_readback_buffer = nullptr;
 static size_t s_texture_cache_entry_readback_buffer_size = 0;
 
-static u32 GetLevelPitch(HostTextureFormat format, u32 row_length)
-{
-  switch (format)
-  {
-  case HostTextureFormat::DXT1:
-    return row_length / 4 * 8;
-
-  case HostTextureFormat::DXT3:
-  case HostTextureFormat::DXT5:
-    return row_length / 4 * 16;
-
-  case HostTextureFormat::RGBA8:
-  default:
-    return row_length * 4;
-  }
-}
-
 static DXGI_FORMAT GetDXGIFormatForHostFormat(HostTextureFormat format)
 {
   switch (format)
@@ -219,8 +202,9 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(const TCacheEntryBase* 
 void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_length,
                                      const u8* buffer, size_t buffer_size)
 {
-  u32 src_pitch = GetLevelPitch(config.format, row_length);
-  D3D::ReplaceRGBATexture2D(m_texture->GetTex12(), buffer, width, height, src_pitch, level,
+  size_t src_pitch = CalculateHostTextureLevelPitch(config.format, row_length);
+  D3D::ReplaceRGBATexture2D(m_texture->GetTex12(), buffer, width, height,
+                            static_cast<unsigned int>(src_pitch), level,
                             m_texture->GetResourceUsageState());
 }
 

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -33,6 +33,42 @@ static u32 s_efb_copy_last_cbuf_id = UINT_MAX;
 static ID3D12Resource* s_texture_cache_entry_readback_buffer = nullptr;
 static size_t s_texture_cache_entry_readback_buffer_size = 0;
 
+static u32 GetLevelPitch(HostTextureFormat format, u32 row_length)
+{
+  switch (format)
+  {
+  case HostTextureFormat::DXT1:
+    return row_length / 4 * 8;
+
+  case HostTextureFormat::DXT3:
+  case HostTextureFormat::DXT5:
+    return row_length / 4 * 16;
+
+  case HostTextureFormat::RGBA8:
+  default:
+    return row_length * 4;
+  }
+}
+
+static DXGI_FORMAT GetDXGIFormatForHostFormat(HostTextureFormat format)
+{
+  switch (format)
+  {
+  case HostTextureFormat::DXT1:
+    return DXGI_FORMAT_BC1_UNORM;
+
+  case HostTextureFormat::DXT3:
+    return DXGI_FORMAT_BC2_UNORM;
+
+  case HostTextureFormat::DXT5:
+    return DXGI_FORMAT_BC3_UNORM;
+
+  case HostTextureFormat::RGBA8:
+  default:
+    return DXGI_FORMAT_R8G8B8A8_UNORM;
+  }
+}
+
 TextureCache::TCacheEntry::~TCacheEntry()
 {
   m_texture->Release();
@@ -50,6 +86,11 @@ bool TextureCache::TCacheEntry::Save(const std::string& filename, unsigned int l
   size_t level_pitch =
       Common::AlignUp(level_width * sizeof(u32), D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
   size_t required_readback_buffer_size = level_pitch * level_height;
+
+  // We can't dump compressed textures currently (it would mean drawing them to a RGBA8
+  // framebuffer, and saving that). TextureCache does not call Save for custom textures
+  // anyway, so this is fine for now.
+  _assert_(config.format == HostTextureFormat::RGBA8);
 
   // Check if the current readback buffer is large enough
   if (required_readback_buffer_size > s_texture_cache_entry_readback_buffer_size)
@@ -178,19 +219,20 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(const TCacheEntryBase* 
 void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_length,
                                      const u8* buffer, size_t buffer_size)
 {
-  u32 src_pitch = 4 * row_length;
+  u32 src_pitch = GetLevelPitch(config.format, row_length);
   D3D::ReplaceRGBATexture2D(m_texture->GetTex12(), buffer, width, height, src_pitch, level,
                             m_texture->GetResourceUsageState());
 }
 
 TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntryConfig& config)
 {
+  DXGI_FORMAT dxgi_format = GetDXGIFormatForHostFormat(config.format);
   if (config.rendertarget)
   {
     D3DTexture2D* texture =
         D3DTexture2D::Create(config.width, config.height,
                              TEXTURE_BIND_FLAG_SHADER_RESOURCE | TEXTURE_BIND_FLAG_RENDER_TARGET,
-                             DXGI_FORMAT_R8G8B8A8_UNORM, 1, config.layers);
+                             dxgi_format, 1, config.layers);
 
     TCacheEntry* entry = new TCacheEntry(config, texture);
 
@@ -204,8 +246,8 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
   {
     ID3D12Resource* texture_resource = nullptr;
 
-    D3D12_RESOURCE_DESC texture_resource_desc = CD3DX12_RESOURCE_DESC::Tex2D(
-        DXGI_FORMAT_R8G8B8A8_UNORM, config.width, config.height, 1, config.levels);
+    D3D12_RESOURCE_DESC texture_resource_desc =
+        CD3DX12_RESOURCE_DESC::Tex2D(dxgi_format, config.width, config.height, 1, config.levels);
 
     CheckHR(D3D::device12->CreateCommittedResource(
         &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE,

--- a/Source/Core/VideoBackends/D3D12/TextureCache.cpp
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.cpp
@@ -175,10 +175,10 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(const TCacheEntryBase* 
   g_renderer->RestoreAPIState();
 }
 
-void TextureCache::TCacheEntry::Load(const u8* buffer, u32 width, u32 height, u32 expanded_width,
-                                     u32 level)
+void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_length,
+                                     const u8* buffer, size_t buffer_size)
 {
-  unsigned int src_pitch = 4 * expanded_width;
+  u32 src_pitch = 4 * row_length;
   D3D::ReplaceRGBATexture2D(m_texture->GetTex12(), buffer, width, height, src_pitch, level,
                             m_texture->GetResourceUsageState());
 }

--- a/Source/Core/VideoBackends/D3D12/TextureCache.h
+++ b/Source/Core/VideoBackends/D3D12/TextureCache.h
@@ -39,7 +39,8 @@ private:
                                   const MathUtil::Rectangle<int>& src_rect,
                                   const MathUtil::Rectangle<int>& dst_rect) override;
 
-    void Load(const u8* buffer, u32 width, u32 height, u32 expanded_width, u32 levels) override;
+    void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
+              size_t buffer_size) override;
 
     void FromRenderTarget(bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half,
                           unsigned int cbuf_id, const float* colmat) override;

--- a/Source/Core/VideoBackends/D3D12/main.cpp
+++ b/Source/Core/VideoBackends/D3D12/main.cpp
@@ -80,6 +80,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsMultithreading = false;
   g_Config.backend_info.bSupportsInternalResolutionFrameDumps = false;
   g_Config.backend_info.bSupportsGPUTextureDecoding = false;
+  g_Config.backend_info.bSupportsST3CTextures = false;
 
   IDXGIFactory* factory;
   IDXGIAdapter* ad;

--- a/Source/Core/VideoBackends/Null/NullBackend.cpp
+++ b/Source/Core/VideoBackends/Null/NullBackend.cpp
@@ -45,6 +45,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsMultithreading = false;
   g_Config.backend_info.bSupportsInternalResolutionFrameDumps = false;
   g_Config.backend_info.bSupportsGPUTextureDecoding = false;
+  g_Config.backend_info.bSupportsST3CTextures = false;
 
   // aamodes: We only support 1 sample, so no MSAA
   g_Config.backend_info.Adapters.clear();

--- a/Source/Core/VideoBackends/Null/TextureCache.h
+++ b/Source/Core/VideoBackends/Null/TextureCache.h
@@ -31,7 +31,10 @@ private:
   {
     TCacheEntry(const TCacheEntryConfig& _config) : TCacheEntryBase(_config) {}
     ~TCacheEntry() {}
-    void Load(const u8* buffer, u32 width, u32 height, u32 expanded_width, u32 level) override {}
+    void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
+              size_t buffer_size) override
+    {
+    }
     void FromRenderTarget(bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half,
                           unsigned int cbufid, const float* colmat) override
     {

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -462,6 +462,8 @@ Renderer::Renderer()
   g_ogl_config.bSupportsConservativeDepth = GLExtensions::Supports("GL_ARB_conservative_depth");
   g_ogl_config.bSupportsAniso = GLExtensions::Supports("GL_EXT_texture_filter_anisotropic");
   g_Config.backend_info.bSupportsComputeShaders = GLExtensions::Supports("GL_ARB_compute_shader");
+  g_Config.backend_info.bSupportsST3CTextures =
+      GLExtensions::Supports("GL_EXT_texture_compression_s3tc");
 
   if (GLInterface->GetMode() == GLInterfaceMode::MODE_OPENGLES3)
   {

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -202,8 +202,8 @@ void TextureCache::TCacheEntry::CopyRectangleFromTexture(const TCacheEntryBase* 
   g_renderer->RestoreAPIState();
 }
 
-void TextureCache::TCacheEntry::Load(const u8* buffer, u32 width, u32 height, u32 expanded_width,
-                                     u32 level)
+void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_length,
+                                     const u8* buffer, size_t buffer_size)
 {
   if (level >= config.levels)
     PanicAlert("Texture only has %d levels, can't update level %d", config.levels, level);
@@ -216,8 +216,8 @@ void TextureCache::TCacheEntry::Load(const u8* buffer, u32 width, u32 height, u3
   glActiveTexture(GL_TEXTURE9);
   glBindTexture(GL_TEXTURE_2D_ARRAY, texture);
 
-  if (expanded_width != width)
-    glPixelStorei(GL_UNPACK_ROW_LENGTH, expanded_width);
+  if (row_length != width)
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, row_length);
 
   if (g_ogl_config.bSupportsTextureStorage)
   {
@@ -230,7 +230,7 @@ void TextureCache::TCacheEntry::Load(const u8* buffer, u32 width, u32 height, u3
                  GL_UNSIGNED_BYTE, buffer);
   }
 
-  if (expanded_width != width)
+  if (row_length != width)
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 
   TextureCache::SetStage();

--- a/Source/Core/VideoBackends/OGL/TextureCache.cpp
+++ b/Source/Core/VideoBackends/OGL/TextureCache.cpp
@@ -88,11 +88,6 @@ bool SaveTexture(const std::string& filename, u32 textarget, u32 tex, int virtua
   return TextureToPng(data.data(), width * 4, filename, width, height, true);
 }
 
-static bool IsCompressedTextureFormat(HostTextureFormat format)
-{
-  return format >= HostTextureFormat::DXT1 && format <= HostTextureFormat::DXT5;
-}
-
 static GLenum GetGLInternalFormatForTextureFormat(HostTextureFormat format, bool storage)
 {
   switch (format)
@@ -204,7 +199,7 @@ TextureCache::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntryConf
   if (config.rendertarget)
   {
     // We can't render to compressed formats.
-    _assert_(!IsCompressedTextureFormat(config.format));
+    _assert_(!IsCompressedHostTextureFormat(config.format));
     if (!g_ogl_config.bSupportsTextureStorage)
     {
       for (u32 level = 0; level < config.levels; level++)
@@ -276,7 +271,7 @@ void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_l
     glPixelStorei(GL_UNPACK_ROW_LENGTH, row_length);
 
   GLenum gl_internal_format = GetGLInternalFormatForTextureFormat(config.format, false);
-  if (IsCompressedTextureFormat(config.format))
+  if (IsCompressedHostTextureFormat(config.format))
   {
     if (g_ogl_config.bSupportsTextureStorage)
     {

--- a/Source/Core/VideoBackends/OGL/TextureCache.h
+++ b/Source/Core/VideoBackends/OGL/TextureCache.h
@@ -45,7 +45,8 @@ private:
                                   const MathUtil::Rectangle<int>& srcrect,
                                   const MathUtil::Rectangle<int>& dstrect) override;
 
-    void Load(const u8* buffer, u32 width, u32 height, u32 expanded_width, u32 level) override;
+    void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
+              size_t buffer_size) override;
 
     void FromRenderTarget(bool is_depth_copy, const EFBRectangle& srcRect, bool scaleByHalf,
                           unsigned int cbufid, const float* colmat) override;

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -103,6 +103,7 @@ void VideoBackend::InitBackendInfo()
   g_Config.backend_info.bSupportsPaletteConversion = true;
   g_Config.backend_info.bSupportsClipControl = true;
   g_Config.backend_info.bSupportsDepthClamp = true;
+  g_Config.backend_info.bSupportsST3CTextures = false;
 
   g_Config.backend_info.Adapters.clear();
 

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -134,6 +134,7 @@ void VideoSoftware::InitBackendInfo()
   g_Config.backend_info.bSupportsComputeShaders = false;
   g_Config.backend_info.bSupportsInternalResolutionFrameDumps = false;
   g_Config.backend_info.bSupportsGPUTextureDecoding = false;
+  g_Config.backend_info.bSupportsST3CTextures = false;
 
   // aamodes
   g_Config.backend_info.AAModes = {1};

--- a/Source/Core/VideoBackends/Software/SWmain.cpp
+++ b/Source/Core/VideoBackends/Software/SWmain.cpp
@@ -65,7 +65,10 @@ private:
   {
     TCacheEntry(const TCacheEntryConfig& _config) : TCacheEntryBase(_config) {}
     ~TCacheEntry() {}
-    void Load(const u8* buffer, u32 width, u32 height, u32 expanded_width, u32 level) override {}
+    void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
+              size_t buffer_size) override
+    {
+    }
     void FromRenderTarget(bool is_depth_copy, const EFBRectangle& srcRect, bool scaleByHalf,
                           unsigned int cbufid, const float* colmat) override
     {

--- a/Source/Core/VideoBackends/Vulkan/Constants.h
+++ b/Source/Core/VideoBackends/Vulkan/Constants.h
@@ -109,7 +109,7 @@ constexpr size_t MAXIMUM_TEXTURE_UPLOAD_BUFFER_SIZE = 64 * 1024 * 1024;
 // streaming buffer and be blocking frequently. Games are unlikely to have textures this
 // large anyway, so it's only really an issue for HD texture packs, and memory is not
 // a limiting factor in these scenarios anyway.
-constexpr size_t STAGING_TEXTURE_UPLOAD_THRESHOLD = 1024 * 1024 * 4;
+constexpr size_t STAGING_TEXTURE_UPLOAD_THRESHOLD = 1024 * 1024 * 8;
 
 // Streaming uniform buffer size
 constexpr size_t INITIAL_UNIFORM_STREAM_BUFFER_SIZE = 16 * 1024 * 1024;

--- a/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StagingBuffer.cpp
@@ -127,7 +127,7 @@ void StagingBuffer::InvalidateCPUCache(VkDeviceSize offset, VkDeviceSize size)
 void StagingBuffer::Read(VkDeviceSize offset, void* data, size_t size, bool invalidate_caches)
 {
   _assert_((offset + size) <= m_size);
-  _assert_(offset >= m_map_offset && size < (m_map_size + (offset - m_map_offset)));
+  _assert_(offset >= m_map_offset && size <= (m_map_size + (offset - m_map_offset)));
   if (invalidate_caches)
     InvalidateCPUCache(offset, size);
 
@@ -138,7 +138,7 @@ void StagingBuffer::Write(VkDeviceSize offset, const void* data, size_t size,
                           bool invalidate_caches)
 {
   _assert_((offset + size) <= m_size);
-  _assert_(offset >= m_map_offset && size < (m_map_size + (offset - m_map_offset)));
+  _assert_(offset >= m_map_offset && size <= (m_map_size + (offset - m_map_offset)));
 
   memcpy(m_map_pointer + (offset - m_map_offset), data, size);
   if (invalidate_caches)

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -373,7 +373,7 @@ void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_l
   u32 upload_alignment = static_cast<u32>(g_vulkan_context->GetBufferImageGranularity());
   u32 block_size = Util::GetBlockSize(m_texture->GetFormat());
   u32 num_rows = Common::AlignUp(height, block_size) / block_size;
-  size_t source_pitch = Util::GetPitchForTexture(m_texture->GetFormat(), row_length);
+  size_t source_pitch = CalculateHostTextureLevelPitch(config.format, row_length);
   size_t upload_size = source_pitch * num_rows;
   std::unique_ptr<StagingBuffer> temp_buffer;
   VkBuffer upload_buffer;

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "Common/Align.h"
 #include "Common/Assert.h"
 #include "Common/CommonFuncs.h"
 #include "Common/Logging/Log.h"
@@ -238,9 +239,10 @@ TextureCacheBase::TCacheEntryBase* TextureCache::CreateTexture(const TCacheEntry
     usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
   // Allocate texture object
+  VkFormat vk_format = Util::GetVkFormatForHostTextureFormat(config.format);
   std::unique_ptr<Texture2D> texture = Texture2D::Create(
-      config.width, config.height, config.levels, config.layers, TEXTURECACHE_TEXTURE_FORMAT,
-      VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL, usage);
+      config.width, config.height, config.levels, config.layers, vk_format, VK_SAMPLE_COUNT_1_BIT,
+      VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL, usage);
 
   if (!texture)
     return nullptr;
@@ -366,87 +368,68 @@ void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_l
   m_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentInitCommandBuffer(),
                                 VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-  // Does this texture data fit within the streaming buffer?
-  u32 upload_width = width;
-  u32 upload_pitch = upload_width * sizeof(u32);
-  u32 upload_size = upload_pitch * height;
+  // For unaligned textures, we can save some memory in the transfer buffer by skipping the rows
+  // that lie outside of the texture's dimensions.
   u32 upload_alignment = static_cast<u32>(g_vulkan_context->GetBufferImageGranularity());
-  u32 source_pitch = row_length * 4;
-  if ((upload_size + upload_alignment) <= STAGING_TEXTURE_UPLOAD_THRESHOLD &&
-      (upload_size + upload_alignment) <= MAXIMUM_TEXTURE_UPLOAD_BUFFER_SIZE)
-  {
-    // Assume tightly packed rows, with no padding as the buffer source.
-    StreamBuffer* upload_buffer = TextureCache::GetInstance()->m_texture_upload_buffer.get();
+  u32 block_size = Util::GetBlockSize(m_texture->GetFormat());
+  u32 num_rows = Common::AlignUp(height, block_size) / block_size;
+  size_t source_pitch = Util::GetPitchForTexture(m_texture->GetFormat(), row_length);
+  size_t upload_size = source_pitch * num_rows;
+  std::unique_ptr<StagingBuffer> temp_buffer;
+  VkBuffer upload_buffer;
+  VkDeviceSize upload_buffer_offset;
 
-    // Allocate memory from the streaming buffer for the texture data.
-    if (!upload_buffer->ReserveMemory(upload_size, g_vulkan_context->GetBufferImageGranularity()))
+  // Does this texture data fit within the streaming buffer?
+  if (upload_size <= STAGING_TEXTURE_UPLOAD_THRESHOLD &&
+      upload_size <= MAXIMUM_TEXTURE_UPLOAD_BUFFER_SIZE)
+  {
+    StreamBuffer* stream_buffer = TextureCache::GetInstance()->m_texture_upload_buffer.get();
+    if (!stream_buffer->ReserveMemory(upload_size, upload_alignment))
     {
       // Execute the command buffer first.
       WARN_LOG(VIDEO, "Executing command list while waiting for space in texture upload buffer");
       Util::ExecuteCurrentCommandsAndRestoreState(false);
 
       // Try allocating again. This may cause a fence wait.
-      if (!upload_buffer->ReserveMemory(upload_size, g_vulkan_context->GetBufferImageGranularity()))
+      if (!stream_buffer->ReserveMemory(upload_size, upload_alignment))
         PanicAlert("Failed to allocate space in texture upload buffer");
     }
 
-    // Grab buffer pointers
-    VkBuffer image_upload_buffer = upload_buffer->GetBuffer();
-    VkDeviceSize image_upload_buffer_offset = upload_buffer->GetCurrentOffset();
-    u8* image_upload_buffer_pointer = upload_buffer->GetCurrentHostPointer();
-
-    // Copy to the buffer using the stride from the subresource layout
-    const u8* source_ptr = buffer;
-    if (upload_pitch != source_pitch)
-    {
-      VkDeviceSize copy_pitch = std::min(source_pitch, upload_pitch);
-      for (unsigned int row = 0; row < height; row++)
-      {
-        memcpy(image_upload_buffer_pointer + row * upload_pitch, source_ptr + row * source_pitch,
-               copy_pitch);
-      }
-    }
-    else
-    {
-      // Can copy the whole thing in one block, the pitch matches
-      memcpy(image_upload_buffer_pointer, source_ptr, upload_size);
-    }
-
-    // Flush buffer memory if necessary
-    upload_buffer->CommitMemory(upload_size);
-
-    // Copy from the streaming buffer to the actual image.
-    VkBufferImageCopy image_copy = {
-        image_upload_buffer_offset,                // VkDeviceSize                bufferOffset
-        0,                                         // uint32_t                    bufferRowLength
-        0,                                         // uint32_t                    bufferImageHeight
-        {VK_IMAGE_ASPECT_COLOR_BIT, level, 0, 1},  // VkImageSubresourceLayers    imageSubresource
-        {0, 0, 0},                                 // VkOffset3D                  imageOffset
-        {width, height, 1}                         // VkExtent3D                  imageExtent
-    };
-    vkCmdCopyBufferToImage(g_command_buffer_mgr->GetCurrentInitCommandBuffer(), image_upload_buffer,
-                           m_texture->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
-                           &image_copy);
+    // Copy to the streaming buffer.
+    upload_buffer = stream_buffer->GetBuffer();
+    upload_buffer_offset = stream_buffer->GetCurrentOffset();
+    std::memcpy(stream_buffer->GetCurrentHostPointer(), buffer, upload_size);
+    stream_buffer->CommitMemory(upload_size);
   }
   else
   {
-    // Slow path. The data for the image is too large to fit in the streaming buffer, so we need
-    // to allocate a temporary texture to store the data in, then copy to the real texture.
-    std::unique_ptr<StagingTexture2D> staging_texture = StagingTexture2D::Create(
-        STAGING_BUFFER_TYPE_UPLOAD, width, height, TEXTURECACHE_TEXTURE_FORMAT);
-
-    if (!staging_texture || !staging_texture->Map())
+    // Create a temporary staging buffer that is destroyed after the image is copied.
+    temp_buffer = StagingBuffer::Create(STAGING_BUFFER_TYPE_UPLOAD, upload_size,
+                                        VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+    if (!temp_buffer || !temp_buffer->Map())
     {
       PanicAlert("Failed to allocate staging texture for large texture upload.");
       return;
     }
 
-    // Copy data to staging texture first, then to the "real" texture.
-    staging_texture->WriteTexels(0, 0, width, height, buffer, source_pitch);
-    staging_texture->CopyToImage(g_command_buffer_mgr->GetCurrentInitCommandBuffer(),
-                                 m_texture->GetImage(), VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, width,
-                                 height, level, 0);
+    upload_buffer = temp_buffer->GetBuffer();
+    upload_buffer_offset = 0;
+    temp_buffer->Write(0, buffer, upload_size, true);
+    temp_buffer->Unmap();
   }
+
+  // Copy from the streaming buffer to the actual image.
+  VkBufferImageCopy image_copy = {
+      upload_buffer_offset,                      // VkDeviceSize                bufferOffset
+      row_length,                                // uint32_t                    bufferRowLength
+      0,                                         // uint32_t                    bufferImageHeight
+      {VK_IMAGE_ASPECT_COLOR_BIT, level, 0, 1},  // VkImageSubresourceLayers    imageSubresource
+      {0, 0, 0},                                 // VkOffset3D                  imageOffset
+      {width, height, 1}                         // VkExtent3D                  imageExtent
+  };
+  vkCmdCopyBufferToImage(g_command_buffer_mgr->GetCurrentInitCommandBuffer(), upload_buffer,
+                         m_texture->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
+                         &image_copy);
 }
 
 void TextureCache::TCacheEntry::FromRenderTarget(bool is_depth_copy, const EFBRectangle& src_rect,
@@ -544,6 +527,11 @@ bool TextureCache::TCacheEntry::Save(const std::string& filename, unsigned int l
 {
   _assert_(level < config.levels);
 
+  // We can't dump compressed textures currently (it would mean drawing them to a RGBA8
+  // framebuffer, and saving that). TextureCache does not call Save for custom textures
+  // anyway, so this is fine for now.
+  _assert_(config.format == HostTextureFormat::RGBA8);
+
   // Determine dimensions of image we want to save.
   u32 level_width = std::max(1u, config.width >> level);
   u32 level_height = std::max(1u, config.height >> level);
@@ -582,7 +570,8 @@ bool TextureCache::TCacheEntry::Save(const std::string& filename, unsigned int l
   // It's okay to throw this texture away immediately, since we're done with it, and
   // we blocked until the copy completed on the GPU anyway.
   bool result = TextureToPng(reinterpret_cast<u8*>(staging_texture->GetMapPointer()),
-                             staging_texture->GetRowStride(), filename, level_width, level_height);
+                             static_cast<u32>(staging_texture->GetRowStride()), filename,
+                             level_width, level_height);
 
   staging_texture->Unmap();
   return result;

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.cpp
@@ -341,8 +341,8 @@ TextureCache::TCacheEntry::~TCacheEntry()
     g_command_buffer_mgr->DeferFramebufferDestruction(m_framebuffer);
 }
 
-void TextureCache::TCacheEntry::Load(const u8* buffer, unsigned int width, unsigned int height,
-                                     unsigned int expanded_width, unsigned int level)
+void TextureCache::TCacheEntry::Load(u32 level, u32 width, u32 height, u32 row_length,
+                                     const u8* buffer, size_t buffer_size)
 {
   // Can't copy data larger than the texture extents.
   width = std::max(1u, std::min(width, m_texture->GetWidth() >> level));
@@ -371,7 +371,7 @@ void TextureCache::TCacheEntry::Load(const u8* buffer, unsigned int width, unsig
   u32 upload_pitch = upload_width * sizeof(u32);
   u32 upload_size = upload_pitch * height;
   u32 upload_alignment = static_cast<u32>(g_vulkan_context->GetBufferImageGranularity());
-  u32 source_pitch = expanded_width * 4;
+  u32 source_pitch = row_length * 4;
   if ((upload_size + upload_alignment) <= STAGING_TEXTURE_UPLOAD_THRESHOLD &&
       (upload_size + upload_alignment) <= MAXIMUM_TEXTURE_UPLOAD_BUFFER_SIZE)
   {

--- a/Source/Core/VideoBackends/Vulkan/TextureCache.h
+++ b/Source/Core/VideoBackends/Vulkan/TextureCache.h
@@ -27,8 +27,8 @@ public:
 
     Texture2D* GetTexture() const { return m_texture.get(); }
     VkFramebuffer GetFramebuffer() const { return m_framebuffer; }
-    void Load(const u8* buffer, unsigned int width, unsigned int height,
-              unsigned int expanded_width, unsigned int level) override;
+    void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
+              size_t buffer_size) override;
     void FromRenderTarget(bool is_depth_copy, const EFBRectangle& src_rect, bool scale_by_half,
                           unsigned int cbufid, const float* colmat) override;
     void CopyRectangleFromTexture(const TCacheEntryBase* source,

--- a/Source/Core/VideoBackends/Vulkan/Util.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Util.cpp
@@ -151,32 +151,6 @@ u32 GetBlockSize(VkFormat format)
   }
 }
 
-
-size_t GetPitchForTexture(VkFormat format, u32 row_length)
-{
-  switch (format)
-  {
-  case VK_FORMAT_BC1_RGBA_UNORM_BLOCK:
-    return static_cast<size_t>(std::max(1u, row_length / 4)) * 8;
-
-  case VK_FORMAT_BC2_UNORM_BLOCK:
-    return static_cast<size_t>(std::max(1u, row_length / 4)) * 16;
-
-  case VK_FORMAT_BC3_UNORM_BLOCK:
-    return static_cast<size_t>(std::max(1u, row_length / 4)) * 16;
-
-  case VK_FORMAT_R8G8B8A8_UNORM:
-  case VK_FORMAT_B8G8R8A8_UNORM:
-  case VK_FORMAT_R32_SFLOAT:
-  case VK_FORMAT_D32_SFLOAT:
-    return static_cast<size_t>(row_length) * 4;
-
-  default:
-    PanicAlert("Unhandled pixel format");
-    return row_length;
-  }
-}
-
 VkRect2D ClampRect2D(const VkRect2D& rect, u32 width, u32 height)
 {
   VkRect2D out;

--- a/Source/Core/VideoBackends/Vulkan/Util.h
+++ b/Source/Core/VideoBackends/Vulkan/Util.h
@@ -31,8 +31,6 @@ VkFormat GetVkFormatForHostTextureFormat(HostTextureFormat format);
 u32 GetTexelSize(VkFormat format);
 u32 GetBlockSize(VkFormat format);
 
-size_t GetPitchForTexture(VkFormat format, u32 row_length);
-
 // Clamps a VkRect2D to the specified dimensions.
 VkRect2D ClampRect2D(const VkRect2D& rect, u32 width, u32 height);
 

--- a/Source/Core/VideoBackends/Vulkan/Util.h
+++ b/Source/Core/VideoBackends/Vulkan/Util.h
@@ -25,8 +25,13 @@ size_t AlignBufferOffset(size_t offset, size_t alignment);
 u32 MakeRGBA8Color(float r, float g, float b, float a);
 
 bool IsDepthFormat(VkFormat format);
+bool IsCompressedFormat(VkFormat format);
 VkFormat GetLinearFormat(VkFormat format);
+VkFormat GetVkFormatForHostTextureFormat(HostTextureFormat format);
 u32 GetTexelSize(VkFormat format);
+u32 GetBlockSize(VkFormat format);
+
+size_t GetPitchForTexture(VkFormat format, u32 row_length);
 
 // Clamps a VkRect2D to the specified dimensions.
 VkRect2D ClampRect2D(const VkRect2D& rect, u32 width, u32 height);

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -245,6 +245,7 @@ void VulkanContext::PopulateBackendInfo(VideoConfig* config)
   config->backend_info.bSupportsFragmentStoresAndAtomics = false;     // Dependent on features.
   config->backend_info.bSupportsSSAA = false;                         // Dependent on features.
   config->backend_info.bSupportsDepthClamp = false;                   // Dependent on features.
+  config->backend_info.bSupportsST3CTextures = false;                 // Dependent on features.
   config->backend_info.bSupportsReversedDepthRange = false;  // No support yet due to driver bugs.
 }
 

--- a/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VulkanContext.cpp
@@ -284,6 +284,9 @@ void VulkanContext::PopulateBackendInfoFeatures(VideoConfig* config, VkPhysicalD
   config->backend_info.bSupportsDepthClamp =
       (features.depthClamp == VK_TRUE && features.shaderClipDistance == VK_TRUE);
 
+  // textureCompressionBC implies BC1 through BC7, which is a superset of DXT1/3/5, which we need.
+  config->backend_info.bSupportsST3CTextures = features.textureCompressionBC == VK_TRUE;
+
   // Our usage of primitive restart appears to be broken on AMD's binary drivers.
   // Seems to be fine on GCN Gen 1-2, unconfirmed on GCN Gen 3, causes driver resets on GCN Gen 4.
   if (DriverDetails::HasBug(DriverDetails::BUG_PRIMITIVE_RESTART))
@@ -460,6 +463,7 @@ bool VulkanContext::SelectDeviceFeatures()
   m_device_features.occlusionQueryPrecise = available_features.occlusionQueryPrecise;
   m_device_features.shaderClipDistance = available_features.shaderClipDistance;
   m_device_features.depthClamp = available_features.depthClamp;
+  m_device_features.textureCompressionBC = available_features.textureCompressionBC;
   return true;
 }
 

--- a/Source/Core/VideoCommon/CMakeLists.txt
+++ b/Source/Core/VideoCommon/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SRCS
   GeometryShaderGen.cpp
   GeometryShaderManager.cpp
   HiresTextures.cpp
+  HiresTextures_DDSLoader.cpp
   ImageWrite.cpp
   IndexGenerator.cpp
   LightingShaderGen.cpp

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -28,6 +28,8 @@ public:
                                  size_t tlut_size, u32 width, u32 height, int format,
                                  bool has_mipmaps, bool dump = false);
 
+  static u32 CalculateMipCount(u32 width, u32 height);
+
   ~HiresTexture();
 
   HostTextureFormat GetFormat() const;

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -9,11 +9,12 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "VideoCommon/VideoCommon.h"
 
 class HiresTexture
 {
 public:
-  using SOILPointer = std::unique_ptr<u8, void (*)(unsigned char*)>;
+  using ImageDataPointer = std::unique_ptr<u8, void (*)(unsigned char*)>;
 
   static void Init();
   static void Update();
@@ -29,20 +30,25 @@ public:
 
   ~HiresTexture();
 
+  HostTextureFormat GetFormat() const;
   struct Level
   {
     Level();
 
-    SOILPointer data;
-    size_t data_size = 0;
+    ImageDataPointer data;
+    HostTextureFormat format = HostTextureFormat::RGBA8;
     u32 width = 0;
     u32 height = 0;
+    u32 row_length = 0;
+    size_t data_size = 0;
   };
   std::vector<Level> m_levels;
 
 private:
   static std::unique_ptr<HiresTexture> Load(const std::string& base_filename, u32 width,
                                             u32 height);
+  static bool LoadDDSTexture(Level& level, const std::vector<u8>& buffer);
+  static bool LoadTexture(Level& level, const std::vector<u8>& buffer);
   static void Prefetch();
 
   static std::string GetTextureDirectory(const std::string& game_id);

--- a/Source/Core/VideoCommon/HiresTextures.h
+++ b/Source/Core/VideoCommon/HiresTextures.h
@@ -47,7 +47,8 @@ public:
 private:
   static std::unique_ptr<HiresTexture> Load(const std::string& base_filename, u32 width,
                                             u32 height);
-  static bool LoadDDSTexture(Level& level, const std::vector<u8>& buffer);
+  static bool LoadDDSTexture(HiresTexture* tex, const std::string& filename);
+  static bool LoadDDSTexture(Level& level, const std::string& filename);
   static bool LoadTexture(Level& level, const std::vector<u8>& buffer);
   static void Prefetch();
 

--- a/Source/Core/VideoCommon/HiresTextures_DDSLoader.cpp
+++ b/Source/Core/VideoCommon/HiresTextures_DDSLoader.cpp
@@ -1,0 +1,257 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "VideoCommon/HiresTextures.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include "Common/Align.h"
+#include "VideoCommon/VideoConfig.h"
+
+namespace
+{
+// From https://raw.githubusercontent.com/Microsoft/DirectXTex/master/DirectXTex/DDS.h
+//
+// This header defines constants and structures that are useful when parsing
+// DDS files.  DDS files were originally designed to use several structures
+// and constants that are native to DirectDraw and are defined in ddraw.h,
+// such as DDSURFACEDESC2 and DDSCAPS2.  This file defines similar
+// (compatible) constants and structures so that one can use DDS files
+// without needing to include ddraw.h.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+// PARTICULAR PURPOSE.
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+
+#pragma pack(push, 1)
+
+const uint32_t DDS_MAGIC = 0x20534444;  // "DDS "
+
+struct DDS_PIXELFORMAT
+{
+  uint32_t dwSize;
+  uint32_t dwFlags;
+  uint32_t dwFourCC;
+  uint32_t dwRGBBitCount;
+  uint32_t dwRBitMask;
+  uint32_t dwGBitMask;
+  uint32_t dwBBitMask;
+  uint32_t dwABitMask;
+};
+
+#define DDS_FOURCC 0x00000004      // DDPF_FOURCC
+#define DDS_RGB 0x00000040         // DDPF_RGB
+#define DDS_RGBA 0x00000041        // DDPF_RGB | DDPF_ALPHAPIXELS
+#define DDS_LUMINANCE 0x00020000   // DDPF_LUMINANCE
+#define DDS_LUMINANCEA 0x00020001  // DDPF_LUMINANCE | DDPF_ALPHAPIXELS
+#define DDS_ALPHA 0x00000002       // DDPF_ALPHA
+#define DDS_PAL8 0x00000020        // DDPF_PALETTEINDEXED8
+#define DDS_PAL8A 0x00000021       // DDPF_PALETTEINDEXED8 | DDPF_ALPHAPIXELS
+#define DDS_BUMPDUDV 0x00080000    // DDPF_BUMPDUDV
+
+#ifndef MAKEFOURCC
+#define MAKEFOURCC(ch0, ch1, ch2, ch3)                                                             \
+  ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) | ((uint32_t)(uint8_t)(ch2) << 16) | \
+   ((uint32_t)(uint8_t)(ch3) << 24))
+#endif /* defined(MAKEFOURCC) */
+
+#define DDS_HEADER_FLAGS_TEXTURE                                                                   \
+  0x00001007  // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT
+#define DDS_HEADER_FLAGS_MIPMAP 0x00020000      // DDSD_MIPMAPCOUNT
+#define DDS_HEADER_FLAGS_VOLUME 0x00800000      // DDSD_DEPTH
+#define DDS_HEADER_FLAGS_PITCH 0x00000008       // DDSD_PITCH
+#define DDS_HEADER_FLAGS_LINEARSIZE 0x00080000  // DDSD_LINEARSIZE
+
+#define DDS_HEIGHT 0x00000002  // DDSD_HEIGHT
+#define DDS_WIDTH 0x00000004   // DDSD_WIDTH
+
+#define DDS_SURFACE_FLAGS_TEXTURE 0x00001000  // DDSCAPS_TEXTURE
+#define DDS_SURFACE_FLAGS_MIPMAP 0x00400008   // DDSCAPS_COMPLEX | DDSCAPS_MIPMAP
+#define DDS_SURFACE_FLAGS_CUBEMAP 0x00000008  // DDSCAPS_COMPLEX
+
+#define DDS_CUBEMAP_POSITIVEX 0x00000600  // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEX
+#define DDS_CUBEMAP_NEGATIVEX 0x00000a00  // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEX
+#define DDS_CUBEMAP_POSITIVEY 0x00001200  // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEY
+#define DDS_CUBEMAP_NEGATIVEY 0x00002200  // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEY
+#define DDS_CUBEMAP_POSITIVEZ 0x00004200  // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_POSITIVEZ
+#define DDS_CUBEMAP_NEGATIVEZ 0x00008200  // DDSCAPS2_CUBEMAP | DDSCAPS2_CUBEMAP_NEGATIVEZ
+
+#define DDS_CUBEMAP_ALLFACES                                                                       \
+  (DDS_CUBEMAP_POSITIVEX | DDS_CUBEMAP_NEGATIVEX | DDS_CUBEMAP_POSITIVEY | DDS_CUBEMAP_NEGATIVEY | \
+   DDS_CUBEMAP_POSITIVEZ | DDS_CUBEMAP_NEGATIVEZ)
+
+#define DDS_CUBEMAP 0x00000200  // DDSCAPS2_CUBEMAP
+
+#define DDS_FLAGS_VOLUME 0x00200000  // DDSCAPS2_VOLUME
+
+// Subset here matches D3D10_RESOURCE_DIMENSION and D3D11_RESOURCE_DIMENSION
+enum DDS_RESOURCE_DIMENSION
+{
+  DDS_DIMENSION_TEXTURE1D = 2,
+  DDS_DIMENSION_TEXTURE2D = 3,
+  DDS_DIMENSION_TEXTURE3D = 4,
+};
+
+// Subset here matches D3D10_RESOURCE_MISC_FLAG and D3D11_RESOURCE_MISC_FLAG
+enum DDS_RESOURCE_MISC_FLAG
+{
+  DDS_RESOURCE_MISC_TEXTURECUBE = 0x4L,
+};
+
+enum DDS_MISC_FLAGS2
+{
+  DDS_MISC_FLAGS2_ALPHA_MODE_MASK = 0x7L,
+};
+
+enum DDS_ALPHA_MODE
+{
+  DDS_ALPHA_MODE_UNKNOWN = 0,
+  DDS_ALPHA_MODE_STRAIGHT = 1,
+  DDS_ALPHA_MODE_PREMULTIPLIED = 2,
+  DDS_ALPHA_MODE_OPAQUE = 3,
+  DDS_ALPHA_MODE_CUSTOM = 4,
+};
+
+struct DDS_HEADER
+{
+  uint32_t dwSize;
+  uint32_t dwFlags;
+  uint32_t dwHeight;
+  uint32_t dwWidth;
+  uint32_t dwPitchOrLinearSize;
+  uint32_t dwDepth;  // only if DDS_HEADER_FLAGS_VOLUME is set in dwFlags
+  uint32_t dwMipMapCount;
+  uint32_t dwReserved1[11];
+  DDS_PIXELFORMAT ddspf;
+  uint32_t dwCaps;
+  uint32_t dwCaps2;
+  uint32_t dwCaps3;
+  uint32_t dwCaps4;
+  uint32_t dwReserved2;
+};
+
+struct DDS_HEADER_DXT10
+{
+  uint32_t dxgiFormat;
+  uint32_t resourceDimension;
+  uint32_t miscFlag;  // see DDS_RESOURCE_MISC_FLAG
+  uint32_t arraySize;
+  uint32_t miscFlags2;  // see DDS_MISC_FLAGS2
+};
+
+#pragma pack(pop)
+
+static_assert(sizeof(DDS_HEADER) == 124, "DDS Header size mismatch");
+static_assert(sizeof(DDS_HEADER_DXT10) == 20, "DDS DX10 Extended Header size mismatch");
+
+}  // namespace
+
+bool HiresTexture::LoadDDSTexture(Level& level, const std::vector<u8>& buffer)
+{
+  u32 magic;
+  std::memcpy(&magic, buffer.data(), sizeof(magic));
+
+  // Exit as early as possible for non-DDS textures, since all extensions are currently
+  // passed through this function.
+  if (magic != DDS_MAGIC)
+    return false;
+
+  DDS_HEADER header;
+  std::memcpy(&header, &buffer[sizeof(magic)], sizeof(header));
+  if (header.dwSize < sizeof(header))
+    return false;
+
+  // Required fields.
+  if ((header.dwFlags & DDS_HEADER_FLAGS_TEXTURE) != DDS_HEADER_FLAGS_TEXTURE)
+    return false;
+
+  // Image should be 2D.
+  if (header.dwFlags & DDS_HEADER_FLAGS_VOLUME)
+    return false;
+
+  // Presence of width/height fields is already tested by DDS_HEADER_FLAGS_TEXTURE.
+  level.width = header.dwWidth;
+  level.height = header.dwHeight;
+
+  // Currently, we only handle compressed textures here, and leave the rest to the SOIL loader.
+  // In the future, this could be extended, but these isn't much benefit in doing so currently.
+  // TODO: DX10 extension header handling.
+  u32 block_size = 1;
+  u32 bytes_per_block = 4;
+  bool needs_s3tc = false;
+  if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '1'))
+  {
+    level.format = HostTextureFormat::DXT1;
+    block_size = 4;
+    bytes_per_block = 8;
+    needs_s3tc = true;
+  }
+  else if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '3'))
+  {
+    level.format = HostTextureFormat::DXT3;
+    block_size = 4;
+    bytes_per_block = 16;
+    needs_s3tc = true;
+  }
+  else if (header.ddspf.dwFourCC == MAKEFOURCC('D', 'X', 'T', '5'))
+  {
+    level.format = HostTextureFormat::DXT5;
+    block_size = 4;
+    bytes_per_block = 16;
+    needs_s3tc = true;
+  }
+  else
+  {
+    // Leave all remaining formats to SOIL.
+    return false;
+  }
+
+  // We also need to ensure the backend supports these formats natively before loading them,
+  // otherwise, fallback to SOIL, which will decompress them to RGBA.
+  if (needs_s3tc && !g_ActiveConfig.backend_info.bSupportsST3CTextures)
+    return false;
+
+  // Mip levels smaller than the block size are padded to multiples of the block size.
+  u32 blocks_wide = std::max(level.width / block_size, 1u);
+  u32 blocks_high = std::max(level.height / block_size, 1u);
+
+  // Pitch can be specified in the header, otherwise we can derive it from the dimensions. For
+  // compressed formats, both DDS_HEADER_FLAGS_LINEARSIZE and DDS_HEADER_FLAGS_PITCH should be
+  // set. See https://msdn.microsoft.com/en-us/library/windows/desktop/bb943982(v=vs.85).aspx
+  if (header.dwFlags & DDS_HEADER_FLAGS_PITCH && header.dwFlags & DDS_HEADER_FLAGS_LINEARSIZE)
+  {
+    // Convert pitch (in bytes) to texels/row length.
+    if (header.dwPitchOrLinearSize < bytes_per_block)
+    {
+      // Likely a corrupted or invalid file.
+      return false;
+    }
+
+    level.row_length = std::max(header.dwPitchOrLinearSize / bytes_per_block, 1u) * block_size;
+    level.data_size = static_cast<size_t>(level.row_length / block_size) * block_size * blocks_high;
+  }
+  else
+  {
+    // Assume no padding between rows of blocks.
+    level.row_length = blocks_wide * block_size;
+    level.data_size = blocks_wide * static_cast<size_t>(bytes_per_block) * blocks_high;
+  }
+
+  // Check for truncated or corrupted files.
+  size_t data_offset = sizeof(magic) + sizeof(DDS_HEADER);
+  if ((data_offset + level.data_size) > buffer.size())
+    return false;
+
+  // Copy to the final storage location. The deallocator here is simple, nothing extra is
+  // needed, compared to the SOIL-based loader.
+  level.data = ImageDataPointer(new u8[level.data_size], [](u8* data) { delete[] data; });
+  std::memcpy(level.data.get(), &buffer[data_offset], level.data_size);
+  return true;
+}

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -750,8 +750,6 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
       }
       expandedWidth = level.width;
       expandedHeight = level.height;
-      CheckTempSize(level.data_size);
-      memcpy(temp, level.data.get(), level.data_size);
     }
   }
 
@@ -774,6 +772,7 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
   config.width = width;
   config.height = height;
   config.levels = texLevels;
+  config.format = hires_tex ? hires_tex->GetFormat() : HostTextureFormat::RGBA8;
 
   TCacheEntryBase* entry = AllocateTexture(config);
   GFX_DEBUGGER_PAUSE_AT(NEXT_NEW_TEXTURE, true);
@@ -784,17 +783,20 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
   const u8* tlut = &texMem[tlutaddr];
   if (hires_tex)
   {
-    entry->Load(temp, width, height, expandedWidth, 0);
+    const auto& level = hires_tex->m_levels[0];
+    entry->Load(0, level.width, level.height, level.row_length, level.data.get(), level.data_size);
   }
-  else if (decode_on_gpu)
+  if (!hires_tex && decode_on_gpu)
   {
     u32 row_stride = bytes_per_block * (expandedWidth / bsw);
     g_texture_cache->DecodeTextureOnGPU(
         entry, 0, src_data, texture_size, static_cast<TextureFormat>(texformat), width, height,
         expandedWidth, expandedHeight, row_stride, tlut, static_cast<TlutFormat>(tlutfmt));
   }
-  else
+  else if (!hires_tex)
   {
+    size_t decoded_texture_size = expandedWidth * sizeof(u32) * expandedHeight;
+    CheckTempSize(decoded_texture_size);
     if (!(texformat == GX_TF_RGBA8 && from_tmem))
     {
       TexDecoder_Decode(temp, src_data, expandedWidth, expandedHeight, texformat, tlut,
@@ -807,7 +809,7 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
       TexDecoder_DecodeRGBA8FromTmem(temp, src_data, src_data_gb, expandedWidth, expandedHeight);
     }
 
-    entry->Load(temp, width, height, expandedWidth, 0);
+    entry->Load(0, width, height, expandedWidth, temp, decoded_texture_size);
   }
 
   iter = textures_by_address.emplace(address, entry);
@@ -837,9 +839,8 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
     for (u32 level_index = 1; level_index != texLevels; ++level_index)
     {
       const auto& level = hires_tex->m_levels[level_index];
-      CheckTempSize(level.data_size);
-      memcpy(temp, level.data.get(), level.data_size);
-      entry->Load(temp, level.width, level.height, level.width, level_index);
+      entry->Load(level_index, level.width, level.height, level.row_length, level.data.get(),
+                  level.data_size);
     }
   }
   else
@@ -877,9 +878,11 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
       }
       else
       {
+        // No need to call CheckTempSize here, as mips will always be smaller than the base level.
+        size_t decoded_mip_size = expanded_mip_width * sizeof(u32) * expanded_mip_height;
         TexDecoder_Decode(temp, mip_src_data, expanded_mip_width, expanded_mip_height, texformat,
                           tlut, (TlutFormat)tlutfmt);
-        entry->Load(temp, mip_width, mip_height, expanded_mip_width, level);
+        entry->Load(level, mip_width, mip_height, expanded_mip_width, temp, decoded_mip_size);
       }
 
       mip_src_data += mip_size;

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -47,6 +47,29 @@ TextureCacheBase::TCacheEntryBase::~TCacheEntryBase()
 {
 }
 
+bool TextureCacheBase::IsCompressedHostTextureFormat(HostTextureFormat format)
+{
+  // This will need to be changed if we add any other uncompressed formats.
+  return format != HostTextureFormat::RGBA8;
+}
+
+size_t TextureCacheBase::CalculateHostTextureLevelPitch(HostTextureFormat format, u32 row_length)
+{
+  switch (format)
+  {
+  case HostTextureFormat::DXT1:
+    return static_cast<size_t>(std::max(1u, row_length / 4)) * 8;
+
+  case HostTextureFormat::DXT3:
+  case HostTextureFormat::DXT5:
+    return static_cast<size_t>(std::max(1u, row_length / 4)) * 16;
+
+  case HostTextureFormat::RGBA8:
+  default:
+    return static_cast<size_t>(row_length) * 4;
+  }
+}
+
 void TextureCacheBase::CheckTempSize(size_t required_size)
 {
   if (required_size <= temp_size)

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -27,16 +27,16 @@ public:
 
     bool operator==(const TCacheEntryConfig& o) const
     {
-      return std::tie(width, height, levels, layers, rendertarget) ==
-             std::tie(o.width, o.height, o.levels, o.layers, o.rendertarget);
+      return std::tie(width, height, levels, layers, format, rendertarget) ==
+             std::tie(o.width, o.height, o.levels, o.layers, o.format, o.rendertarget);
     }
 
     struct Hasher : std::hash<u64>
     {
       size_t operator()(const TCacheEntryConfig& c) const
       {
-        u64 id = (u64)c.rendertarget << 63 | (u64)c.layers << 48 | (u64)c.levels << 32 |
-                 (u64)c.height << 16 | (u64)c.width;
+        u64 id = (u64)c.rendertarget << 63 | (u64)c.format << 50 | (u64)c.layers << 48 |
+                 (u64)c.levels << 32 | (u64)c.height << 16 | (u64)c.width;
         return std::hash<u64>::operator()(id);
       }
     };
@@ -45,6 +45,7 @@ public:
     u32 height = 0;
     u32 levels = 1;
     u32 layers = 1;
+    HostTextureFormat format = HostTextureFormat::RGBA8;
     bool rendertarget = false;
   };
 
@@ -129,7 +130,8 @@ public:
                                           const MathUtil::Rectangle<int>& srcrect,
                                           const MathUtil::Rectangle<int>& dstrect) = 0;
 
-    virtual void Load(const u8* buffer, u32 width, u32 height, u32 expanded_width, u32 level) = 0;
+    virtual void Load(u32 level, u32 width, u32 height, u32 row_length, const u8* buffer,
+                      size_t buffer_size) = 0;
     virtual void FromRenderTarget(bool is_depth_copy, const EFBRectangle& srcRect, bool scaleByHalf,
                                   unsigned int cbufid, const float* colmat) = 0;
 

--- a/Source/Core/VideoCommon/TextureCacheBase.h
+++ b/Source/Core/VideoCommon/TextureCacheBase.h
@@ -146,6 +146,10 @@ public:
 
   virtual ~TextureCacheBase();  // needs virtual for DX11 dtor
 
+  // TODO: Move these to AbstractTexture once it is finished.
+  static bool IsCompressedHostTextureFormat(HostTextureFormat format);
+  static size_t CalculateHostTextureLevelPitch(HostTextureFormat format, u32 row_length);
+
   void OnConfigChanged(VideoConfig& config);
 
   // Removes textures which aren't used for more than TEXTURE_KILL_THRESHOLD frames,

--- a/Source/Core/VideoCommon/VideoCommon.h
+++ b/Source/Core/VideoCommon/VideoCommon.h
@@ -77,6 +77,15 @@ enum class APIType
   Nothing
 };
 
+// Texture formats that videocommon can upload/use.
+enum class HostTextureFormat : u32
+{
+  RGBA8,
+  DXT1,
+  DXT3,
+  DXT5
+};
+
 inline u32 RGBA8ToRGBA6ToRGBA8(u32 src)
 {
   u32 color = src;

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -69,6 +69,7 @@
     <ClCompile Include="FPSCounter.cpp" />
     <ClCompile Include="FramebufferManagerBase.cpp" />
     <ClCompile Include="HiresTextures.cpp" />
+    <ClCompile Include="HiresTextures_DDSLoader.cpp" />
     <ClCompile Include="ImageWrite.cpp" />
     <ClCompile Include="IndexGenerator.cpp" />
     <ClCompile Include="MainBase.cpp" />

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -164,6 +164,9 @@
     <ClCompile Include="LightingShaderGen.cpp">
       <Filter>Shader Generators</Filter>
     </ClCompile>
+    <ClCompile Include="HiresTextures_DDSLoader.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CommandProcessor.h" />
@@ -201,9 +204,6 @@
       <Filter>Decoding</Filter>
     </ClInclude>
     <ClInclude Include="TextureDecoder.h">
-      <Filter>Decoding</Filter>
-    </ClInclude>
-    <ClInclude Include="TextureDecoder_Util.h">
       <Filter>Decoding</Filter>
     </ClInclude>
     <ClInclude Include="BPFunctions.h">

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -41,6 +41,7 @@ VideoConfig::VideoConfig()
   backend_info.bSupportsExclusiveFullscreen = false;
   backend_info.bSupportsMultithreading = false;
   backend_info.bSupportsInternalResolutionFrameDumps = false;
+  backend_info.bSupportsST3CTextures = false;
 
   bEnableValidationLayer = false;
   bBackendMultithreading = true;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -197,6 +197,7 @@ struct VideoConfig final
     bool bSupportsMultithreading;
     bool bSupportsInternalResolutionFrameDumps;
     bool bSupportsGPUTextureDecoding;
+    bool bSupportsST3CTextures;
   } backend_info;
 
   // Utility


### PR DESCRIPTION
This PR allows custom textures that use block compression (DXT1/3/5) to be stored and uploaded to the GPU in their compressed form, saving both RAM and VRAM, and significantly reducing prefetch/loading time. Stutter when uploading large textures may be slightly reduced as well.

Assuming all textures in a custom pack are compressed, this should decrease the memory usage by 8 times for DXT1, or 4 times for DXT5, or somewhere in between for a mix.

Supports all backends where the driver/graphics card exposes support for DXT formats. D3D11 and 12 both check for support, rather than assuming it, in case we ever have a Windows on ARM port.

There is only one issue with this implementation. *If a custom texture uses different formats for different mipmap levels in a single game texture, it will now refuse to load that texture.* It could be worked around, but it's better if texture pack authors fix their packs instead.

- [x] Handle DX10 fourcc and extension header (how many packs use this?)
- [x] Support loading full mipmap chains from a single DDS file (https://bugs.dolphin-emu.org/issues/9254)
- [x] Support loading full mipmap chains of non-compressed DDS textures (again, any packs that use this?)

Should be functional enough for testing and review, however.