### PR TITLE
Vulkan: Use BlendingState from VideoCommon

### DIFF
--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -1085,11 +1085,6 @@ void Renderer::SetLogicOpMode()
   }
 }
 
-void Renderer::SetDitherMode()
-{
-  // TODO: Set dither mode to bpmem.blendmode.dither
-}
-
 void Renderer::SetSamplerState(int stage, int texindex, bool custom_tex)
 {
   const FourTexUnits& tex = bpmem.tex[texindex];

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -25,7 +25,6 @@ public:
   void SetGenerationMode() override;
   void SetDepthMode() override;
   void SetLogicOpMode() override;
-  void SetDitherMode() override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;
   void SetViewport() override;

--- a/Source/Core/VideoBackends/D3D12/Render.cpp
+++ b/Source/Core/VideoBackends/D3D12/Render.cpp
@@ -1108,11 +1108,6 @@ void Renderer::SetLogicOpMode()
   D3D::command_list_mgr->SetCommandListDirtyState(COMMAND_LIST_STATE_PSO, true);
 }
 
-void Renderer::SetDitherMode()
-{
-  // EXISTINGD3D11TODO: Set dither mode to bpmem.blendmode.dither
-}
-
 void Renderer::SetSamplerState(int stage, int tex_index, bool custom_tex)
 {
   const FourTexUnits& tex = bpmem.tex[tex_index];

--- a/Source/Core/VideoBackends/D3D12/Render.h
+++ b/Source/Core/VideoBackends/D3D12/Render.h
@@ -26,7 +26,6 @@ public:
   void SetGenerationMode() override;
   void SetDepthMode() override;
   void SetLogicOpMode() override;
-  void SetDitherMode() override;
   void SetSamplerState(int stage, int tex_index, bool custom_tex) override;
   void SetInterlacingMode() override;
   void SetViewport() override;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1214,7 +1214,7 @@ void Renderer::SetBlendMode(bool forceUpdate)
   state.Generate(bpmem);
 
   bool useDualSource =
-      g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
+      state.usedualsrc && g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
       (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) || state.dstalpha);
 
   const GLenum src_factors[8] = {

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1274,11 +1274,6 @@ void Renderer::SetBlendMode(bool forceUpdate)
     glDisable(GL_COLOR_LOGIC_OP);
   }
 
-  if (state.dither)
-    glEnable(GL_DITHER);
-  else
-    glDisable(GL_DITHER);
-
   glColorMask(state.colorupdate, state.colorupdate, state.colorupdate, state.alphaupdate);
 }
 

--- a/Source/Core/VideoBackends/Vulkan/Constants.h
+++ b/Source/Core/VideoBackends/Vulkan/Constants.h
@@ -145,34 +145,6 @@ union DepthStencilState
   u32 bits;
 };
 
-// Blend state info
-union BlendState
-{
-  struct
-  {
-    union
-    {
-      BitField<0, 1, VkBool32> blend_enable;
-      BitField<1, 3, VkBlendOp> blend_op;
-      BitField<4, 5, VkBlendFactor> src_blend;
-      BitField<9, 5, VkBlendFactor> dst_blend;
-      BitField<14, 3, VkBlendOp> alpha_blend_op;
-      BitField<17, 5, VkBlendFactor> src_alpha_blend;
-      BitField<22, 5, VkBlendFactor> dst_alpha_blend;
-      BitField<27, 4, VkColorComponentFlags> write_mask;
-      u32 low_bits;
-    };
-    union
-    {
-      BitField<0, 1, VkBool32> logic_op_enable;
-      BitField<1, 4, VkLogicOp> logic_op;
-      u32 high_bits;
-    };
-  };
-
-  u64 bits;
-};
-
 // Sampler info
 union SamplerState
 {

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -1157,14 +1157,10 @@ void FramebufferManager::DrawPokeVertices(const EFBPokeVertex* vertices, size_t 
   pipeline_info.rasterization_state.bits = Util::GetNoCullRasterizationState().bits;
   pipeline_info.rasterization_state.samples = m_efb_samples;
   pipeline_info.depth_stencil_state.bits = Util::GetNoDepthTestingDepthStencilState().bits;
-  pipeline_info.blend_state.bits = Util::GetNoBlendingBlendState().bits;
-  pipeline_info.blend_state.write_mask = 0;
+  pipeline_info.blend_state.hex = Util::GetNoBlendingBlendState().hex;
+  pipeline_info.blend_state.colorupdate = write_color;
+  pipeline_info.blend_state.alphaupdate = write_color;
   pipeline_info.primitive_topology = m_poke_primitive_topology;
-  if (write_color)
-  {
-    pipeline_info.blend_state.write_mask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                                           VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-  }
   if (write_depth)
   {
     pipeline_info.depth_stencil_state.test_enable = VK_TRUE;

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.h
@@ -18,6 +18,7 @@
 
 #include "VideoCommon/GeometryShaderGen.h"
 #include "VideoCommon/PixelShaderGen.h"
+#include "VideoCommon/RenderState.h"
 #include "VideoCommon/VertexShaderGen.h"
 
 namespace Vulkan
@@ -36,7 +37,7 @@ struct PipelineInfo
   VkShaderModule gs;
   VkShaderModule ps;
   VkRenderPass render_pass;
-  BlendState blend_state;
+  BlendingState blend_state;
   RasterizationState rasterization_state;
   DepthStencilState depth_stencil_state;
   VkPrimitiveTopology primitive_topology;

--- a/Source/Core/VideoBackends/Vulkan/RasterFont.cpp
+++ b/Source/Core/VideoBackends/Vulkan/RasterFont.cpp
@@ -395,11 +395,10 @@ void RasterFont::PrintMultiLineText(VkRenderPass render_pass, const std::string&
   draw.SetPSSampler(0, m_texture->GetView(), g_object_cache->GetLinearSampler());
 
   // Setup alpha blending
-  BlendState blend_state = Util::GetNoBlendingBlendState();
-  blend_state.blend_enable = VK_TRUE;
-  blend_state.src_blend = VK_BLEND_FACTOR_SRC_ALPHA;
-  blend_state.blend_op = VK_BLEND_OP_ADD;
-  blend_state.dst_blend = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+  BlendingState blend_state = Util::GetNoBlendingBlendState();
+  blend_state.blendenable = true;
+  blend_state.srcfactor = BlendMode::SRCALPHA;
+  blend_state.dstfactor = BlendMode::INVSRCALPHA;
   draw.SetBlendState(blend_state);
 
   draw.Draw();

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1383,10 +1383,6 @@ void Renderer::ResetSamplerStates()
   g_object_cache->ClearSamplerCache();
 }
 
-void Renderer::SetDitherMode()
-{
-}
-
 void Renderer::SetInterlacingMode()
 {
 }

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -56,12 +56,10 @@ public:
   void ResetAPIState() override;
   void RestoreAPIState() override;
 
-  void SetColorMask() override;
   void SetBlendMode(bool force_update) override;
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
   void SetDepthMode() override;
-  void SetLogicOpMode() override;
   void SetDitherMode() override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -60,7 +60,6 @@ public:
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
   void SetDepthMode() override;
-  void SetDitherMode() override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;
   void SetViewport() override;

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.h
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.h
@@ -41,7 +41,7 @@ public:
   {
     return m_pipeline_state.depth_stencil_state;
   }
-  const BlendState& GetBlendState() const { return m_pipeline_state.blend_state; }
+  const BlendingState& GetBlendState() const { return m_pipeline_state.blend_state; }
   void SetVertexBuffer(VkBuffer buffer, VkDeviceSize offset);
   void SetIndexBuffer(VkBuffer buffer, VkDeviceSize offset, VkIndexType type);
 
@@ -57,7 +57,7 @@ public:
 
   void SetRasterizationState(const RasterizationState& state);
   void SetDepthStencilState(const DepthStencilState& state);
-  void SetBlendState(const BlendState& state);
+  void SetBlendState(const BlendingState& state);
 
   bool CheckForShaderChanges(u32 gx_primitive_type);
 
@@ -123,9 +123,9 @@ private:
   // Serialized version of PipelineInfo, used when loading/saving the pipeline UID cache.
   struct SerializedPipelineUID
   {
-    u64 blend_state_bits;
     u32 rasterizer_state_bits;
     u32 depth_stencil_state_bits;
+    u32 blend_state_bits;
     PortableVertexDeclaration vertex_decl;
     VertexShaderUid vs_uid;
     GeometryShaderUid gs_uid;

--- a/Source/Core/VideoBackends/Vulkan/Util.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Util.cpp
@@ -133,20 +133,17 @@ DepthStencilState GetNoDepthTestingDepthStencilState()
   return state;
 }
 
-BlendState GetNoBlendingBlendState()
+BlendingState GetNoBlendingBlendState()
 {
-  BlendState state = {};
-  state.blend_enable = VK_FALSE;
-  state.blend_op = VK_BLEND_OP_ADD;
-  state.src_blend = VK_BLEND_FACTOR_ONE;
-  state.dst_blend = VK_BLEND_FACTOR_ZERO;
-  state.alpha_blend_op = VK_BLEND_OP_ADD;
-  state.src_alpha_blend = VK_BLEND_FACTOR_ONE;
-  state.dst_alpha_blend = VK_BLEND_FACTOR_ZERO;
-  state.logic_op_enable = VK_FALSE;
-  state.logic_op = VK_LOGIC_OP_CLEAR;
-  state.write_mask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                     VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+  BlendingState state = {};
+  state.blendenable = false;
+  state.srcfactor = BlendMode::ONE;
+  state.srcfactoralpha = BlendMode::ZERO;
+  state.dstfactor = BlendMode::ONE;
+  state.dstfactoralpha = BlendMode::ZERO;
+  state.logicopenable = false;
+  state.colorupdate = true;
+  state.alphaupdate = true;
   return state;
 }
 
@@ -279,7 +276,7 @@ UtilityShaderDraw::UtilityShaderDraw(VkCommandBuffer command_buffer,
   m_pipeline_info.ps = pixel_shader;
   m_pipeline_info.rasterization_state.bits = Util::GetNoCullRasterizationState().bits;
   m_pipeline_info.depth_stencil_state.bits = Util::GetNoDepthTestingDepthStencilState().bits;
-  m_pipeline_info.blend_state.bits = Util::GetNoBlendingBlendState().bits;
+  m_pipeline_info.blend_state.hex = Util::GetNoBlendingBlendState().hex;
   m_pipeline_info.primitive_topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 }
 
@@ -387,9 +384,9 @@ void UtilityShaderDraw::SetDepthStencilState(const DepthStencilState& state)
   m_pipeline_info.depth_stencil_state.bits = state.bits;
 }
 
-void UtilityShaderDraw::SetBlendState(const BlendState& state)
+void UtilityShaderDraw::SetBlendState(const BlendingState& state)
 {
-  m_pipeline_info.blend_state.bits = state.bits;
+  m_pipeline_info.blend_state.hex = state.hex;
 }
 
 void UtilityShaderDraw::BeginRenderPass(VkFramebuffer framebuffer, const VkRect2D& region,

--- a/Source/Core/VideoBackends/Vulkan/Util.h
+++ b/Source/Core/VideoBackends/Vulkan/Util.h
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "VideoBackends/Vulkan/Constants.h"
 #include "VideoBackends/Vulkan/ObjectCache.h"
+#include "VideoCommon/RenderState.h"
 
 namespace Vulkan
 {
@@ -32,7 +33,7 @@ VkBlendFactor GetAlphaBlendFactor(VkBlendFactor factor);
 
 RasterizationState GetNoCullRasterizationState();
 DepthStencilState GetNoDepthTestingDepthStencilState();
-BlendState GetNoBlendingBlendState();
+BlendingState GetNoBlendingBlendState();
 
 // Combines viewport and scissor updates
 void SetViewportAndScissor(VkCommandBuffer command_buffer, int x, int y, int width, int height,
@@ -144,7 +145,7 @@ public:
 
   void SetRasterizationState(const RasterizationState& state);
   void SetDepthStencilState(const DepthStencilState& state);
-  void SetBlendState(const BlendState& state);
+  void SetBlendState(const BlendingState& state);
 
   void BeginRenderPass(VkFramebuffer framebuffer, const VkRect2D& region,
                        const VkClearValue* clear_value = nullptr);

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -74,10 +74,7 @@ void SetBlendMode()
 {
   g_renderer->SetBlendMode(false);
 }
-void SetDitherMode()
-{
-  g_renderer->SetDitherMode();
-}
+
 void SetLogicOpMode()
 {
   g_renderer->SetLogicOpMode();

--- a/Source/Core/VideoCommon/BPFunctions.h
+++ b/Source/Core/VideoCommon/BPFunctions.h
@@ -19,7 +19,6 @@ void SetGenerationMode();
 void SetScissor();
 void SetDepthMode();
 void SetBlendMode();
-void SetDitherMode();
 void SetLogicOpMode();
 void SetColorMask();
 void ClearScreen(const EFBRectangle& rc);

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -152,10 +152,6 @@ static void BPWritten(const BPCmd& bp)
       if (bp.changes & 0xF002)  // logicopenable | logicmode
         SetLogicOpMode();
 
-      // Set Dithering Mode
-      if (bp.changes & 4)  // dither
-        SetDitherMode();
-
       // Set Color Mask
       if (bp.changes & 0x18)  // colorupdate | alphaupdate
         SetColorMask();
@@ -1383,7 +1379,6 @@ void BPReload()
   SetScissor();
   SetDepthMode();
   SetLogicOpMode();
-  SetDitherMode();
   SetBlendMode();
   SetColorMask();
   OnPixelFormatChange();

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -69,7 +69,6 @@ public:
   virtual void SetGenerationMode() {}
   virtual void SetDepthMode() {}
   virtual void SetLogicOpMode() {}
-  virtual void SetDitherMode() {}
   virtual void SetSamplerState(int stage, int texindex, bool custom_tex) {}
   virtual void SetInterlacingMode() {}
   virtual void SetViewport() {}

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -65,6 +65,7 @@ void BlendingState::Generate(const BPMemory& bp)
   colorupdate = bp.blendmode.colorupdate && alpha_test_may_success;
   alphaupdate = bp.blendmode.alphaupdate && target_has_alpha && alpha_test_may_success;
   dstalpha = bp.dstalpha.enable && alphaupdate;
+  usedualsrc = true;
 
   // The subtract bit has the highest priority
   if (bp.blendmode.subtract)

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -61,7 +61,6 @@ void BlendingState::Generate(const BPMemory& bp)
   bool target_has_alpha = bp.zcontrol.pixel_format == PEControl::RGBA6_Z24;
   bool alpha_test_may_success = bp.alpha_test.TestResult() != AlphaTest::FAIL;
 
-  dither = bp.blendmode.dither;
   colorupdate = bp.blendmode.colorupdate && alpha_test_may_success;
   alphaupdate = bp.blendmode.alphaupdate && target_has_alpha && alpha_test_may_success;
   dstalpha = bp.dstalpha.enable && alphaupdate;

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -16,17 +16,16 @@ union BlendingState
   BitField<0, 1, u32> blendenable;
   BitField<1, 1, u32> logicopenable;
   BitField<2, 1, u32> dstalpha;
-  BitField<3, 1, u32> dither;
-  BitField<4, 1, u32> colorupdate;
-  BitField<5, 1, u32> alphaupdate;
-  BitField<6, 1, u32> subtract;
-  BitField<7, 1, u32> subtractAlpha;
+  BitField<3, 1, u32> colorupdate;
+  BitField<4, 1, u32> alphaupdate;
+  BitField<5, 1, u32> subtract;
+  BitField<6, 1, u32> subtractAlpha;
+  BitField<7, 1, u32> usedualsrc;
   BitField<8, 3, BlendMode::BlendFactor> dstfactor;
   BitField<11, 3, BlendMode::BlendFactor> srcfactor;
   BitField<14, 3, BlendMode::BlendFactor> dstfactoralpha;
   BitField<17, 3, BlendMode::BlendFactor> srcfactoralpha;
   BitField<20, 4, BlendMode::LogicOp> logicmode;
-  BitField<24, 1, u32> usedualsrc;
 
   u32 hex;
 };

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -26,6 +26,7 @@ union BlendingState
   BitField<14, 3, BlendMode::BlendFactor> dstfactoralpha;
   BitField<17, 3, BlendMode::BlendFactor> srcfactoralpha;
   BitField<20, 4, BlendMode::LogicOp> logicmode;
+  BitField<24, 1, u32> usedualsrc;
 
   u32 hex;
 };


### PR DESCRIPTION
Removes the blend state logic from the Vulkan backend and uses the BlendingState from VideoCommon instead, so gets rid of a decent chunk of code.

I've added a usedualsrc field to BlendingState, because we re-use BlendingState for our internal drawing (e.g. RasterFont) and for these shaders, we can't assume the presence of a second color output.

This PR also drops dithering from the backend, the only backend which supported it was OpenGL, and it is implementation-defined, so no guarantees of its accuracy compared to the console. We do dithering in the pixel shader for the non-blended case, anyway.

Fixes https://bugs.dolphin-emu.org/issues/10215 as well (at least the fifolog, anyway).

Note, there is a regression here for Adreno and Mali devices, this drops the emulation of logic ops via blending (which was inaccurate anyway). But given these devices don't support dual-source blend either, you can't expect great compatibility.