### PR TITLE
MemoryWindow: Replace Search with Find Next/Previous buttons

### DIFF
--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.cpp
@@ -48,7 +48,7 @@ enum
   IDM_DUMP_FAKEVMEM,
   IDM_VALBOX,
   IDM_DATA_TYPE_RBOX,
-  IDM_SEARCH,
+  IDM_FIND_NEXT,
   IDM_ASCII,
   IDM_HEX,
   IDM_MEMCHECK_OPTIONS_CHANGE
@@ -60,7 +60,7 @@ EVT_BUTTON(IDM_DUMP_MEMORY, CMemoryWindow::OnDumpMemory)
 EVT_BUTTON(IDM_DUMP_MEM2, CMemoryWindow::OnDumpMem2)
 EVT_BUTTON(IDM_DUMP_FAKEVMEM, CMemoryWindow::OnDumpFakeVMEM)
 EVT_RADIOBOX(IDM_DATA_TYPE_RBOX, CMemoryWindow::OnDataTypeChanged)
-EVT_BUTTON(IDM_SEARCH, CMemoryWindow::OnSearch)
+EVT_BUTTON(IDM_FIND_NEXT, CMemoryWindow::OnFindNext)
 EVT_RADIOBUTTON(IDM_MEMCHECK_OPTIONS_CHANGE, CMemoryWindow::OnMemCheckOptionChange)
 EVT_CHECKBOX(IDM_MEMCHECK_OPTIONS_CHANGE, CMemoryWindow::OnMemCheckOptionChange)
 END_EVENT_TABLE()
@@ -98,7 +98,7 @@ CMemoryWindow::CMemoryWindow(wxWindow* parent, wxWindowID id, const wxPoint& pos
     dump_sizer->Add(new wxButton(this, IDM_DUMP_FAKEVMEM, _("Dump FakeVMEM")), 0, wxEXPAND);
 
   wxStaticBoxSizer* const sizerSearchType = new wxStaticBoxSizer(wxVERTICAL, this, _("Search"));
-  sizerSearchType->Add(btnSearch = new wxButton(this, IDM_SEARCH, _("Search")));
+  sizerSearchType->Add(btnSearch = new wxButton(this, IDM_FIND_NEXT, _("Find Next")));
   sizerSearchType->Add(m_rb_ascii = new wxRadioButton(this, IDM_ASCII, "Ascii", wxDefaultPosition,
                                                       wxDefaultSize, wxRB_GROUP));
   sizerSearchType->Add(m_rb_hex = new wxRadioButton(this, IDM_HEX, _("Hex")));
@@ -267,9 +267,14 @@ void CMemoryWindow::OnDataTypeChanged(wxCommandEvent& ev)
   }
 }
 
-void CMemoryWindow::OnSearch(wxCommandEvent& event)
+void CMemoryWindow::OnFindNext(wxCommandEvent& event)
 {
   wxBusyCursor hourglass_cursor;
+  Search(true);
+}
+
+void CMemoryWindow::Search(bool find_next)
+{
   u8* ram_ptr = nullptr;
   u32 ram_size = 0;
   // NOTE: We're assuming the base address is zero.

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.h
@@ -32,11 +32,17 @@ public:
   void JumpToAddress(u32 _Address);
 
 private:
+  enum class SearchType
+  {
+    FindNext,
+    FindPrevious
+  };
+
   DECLARE_EVENT_TABLE()
 
   void OnDataTypeChanged(wxCommandEvent& event);
   void OnFindNext(wxCommandEvent& event);
-  void Search(bool find_next = true);
+  void OnFindPrevious(wxCommandEvent& event);
   void OnAddrBoxChange(wxCommandEvent& event);
   void OnValueChanged(wxCommandEvent&);
   void SetMemoryValueFromValBox(wxCommandEvent& event);
@@ -46,7 +52,10 @@ private:
   void OnDumpFakeVMEM(wxCommandEvent& event);
   void OnMemCheckOptionChange(wxCommandEvent& event);
 
-  wxButton* btnSearch;
+  void Search(SearchType search_type);
+
+  wxButton* m_btn_find_next;
+  wxButton* m_btn_find_previous;
   wxRadioButton* m_rb_ascii;
   wxRadioButton* m_rb_hex;
 

--- a/Source/Core/DolphinWX/Debugger/MemoryWindow.h
+++ b/Source/Core/DolphinWX/Debugger/MemoryWindow.h
@@ -35,7 +35,8 @@ private:
   DECLARE_EVENT_TABLE()
 
   void OnDataTypeChanged(wxCommandEvent& event);
-  void OnSearch(wxCommandEvent& event);
+  void OnFindNext(wxCommandEvent& event);
+  void Search(bool find_next = true);
   void OnAddrBoxChange(wxCommandEvent& event);
   void OnValueChanged(wxCommandEvent&);
   void SetMemoryValueFromValBox(wxCommandEvent& event);


### PR DESCRIPTION
This PR replaces the "Search" button in the MemoryWindow with a "Find Next" and a "Find Previous" button. I also rewrote the search logic using STL algorithm.

Ready to be reviewed & merged.