### PR TITLE
StringUtil: Fix possible bad free

### DIFF
--- a/Source/Core/Common/StringUtil.cpp
+++ b/Source/Core/Common/StringUtil.cpp
@@ -173,7 +173,11 @@ std::string StringFromFormatV(const char* format, va_list args)
   locale_t previousLocale = uselocale(GetCLocale());
 #endif
   if (vasprintf(&buf, format, args) < 0)
+  {
     ERROR_LOG(COMMON, "Unable to allocate memory for string");
+    buf = nullptr;
+  }
+
 #if !defined(ANDROID) && !defined(__HAIKU__) && !defined(__OpenBSD__)
   uselocale(previousLocale);
 #endif


### PR DESCRIPTION
This patch fixes strtoul functionts return test. The function can return also EINVAL which was not taken in account.

The second bug is a memory error and possibly a double free bug in non-Windows machines.