### PR TITLE
WX: Don't specify a parent frame for the render frame

### DIFF
--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -662,7 +662,8 @@ void CFrame::StartGame(const std::string& filename)
     // Set window size in framebuffer pixels since the 3D rendering will be operating at
     // that level.
     wxSize default_size{wxSize(640, 480) * (1.0 / GetContentScaleFactor())};
-    m_RenderFrame = new CRenderFrame(this, wxID_ANY, _("Dolphin"), wxDefaultPosition, default_size);
+    m_RenderFrame =
+        new CRenderFrame(nullptr, wxID_ANY, _("Dolphin"), wxDefaultPosition, default_size);
 
     // Convert ClientSize coordinates to frame sizes.
     wxSize decoration_fudge = m_RenderFrame->GetSize() - m_RenderFrame->GetClientSize();


### PR DESCRIPTION
Fixes [issue 10221](https://dolp.in/i10221)

According to the [wxWidgets docs](http://docs.wxwidgets.org/trunk/classwx_frame.html#a01b53ac2d4a5e6b0773ecbcf7b5f6af8), it is normal for this value to be null.