### PR TITLE
AudioCommon: set volume _after_ starting stream

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -57,8 +57,6 @@ void InitSoundStream()
     g_sound_stream = std::make_unique<NullSound>();
   }
 
-  UpdateSoundStream();
-
   if (!g_sound_stream->Start())
   {
     ERROR_LOG(AUDIO, "Could not start backend %s, using %s instead", backend.c_str(),
@@ -67,6 +65,8 @@ void InitSoundStream()
     g_sound_stream = std::make_unique<NullSound>();
     g_sound_stream->Start();
   }
+
+  UpdateSoundStream();
 
   if (SConfig::GetInstance().m_DumpAudio && !s_audio_dump_start)
     StartAudioDump();


### PR DESCRIPTION
Fixes an error with the CoreAudio backend, which apparently doesn't allow you to set the volume before starting the stream:

```
59:31:087 AudioCommon/CoreAudioSoundStream.cpp:97 E[Audio]: error setting volume
```

This shouldn't cause any problems with other backends, since the mixer starts with silence anyways.