### PR TITLE
MemoryView: Fix empty string

### DIFF
--- a/Source/Core/DolphinWX/Debugger/MemoryView.cpp
+++ b/Source/Core/DolphinWX/Debugger/MemoryView.cpp
@@ -161,7 +161,8 @@ wxString CMemoryView::ReadMemoryAsString(u32 address) const
     }
   }
 
-  return StrToWxStr(str);
+  // Not a UTF-8 string
+  return wxString(str.c_str(), wxCSConv(wxFONTENCODING_CP1252), str.size());
 }
 
 void CMemoryView::OnMouseDownL(wxMouseEvent& event)


### PR DESCRIPTION
This PR fixes empty (invisible) strings in MemoryView which are the result of wxString failing to convert them into UTF-8.

Ready to be reviewed & merged.