### PR TITLE
ArmCPUDetect: Add missing include

### DIFF
--- a/Source/Core/Common/ArmCPUDetect.cpp
+++ b/Source/Core/Common/ArmCPUDetect.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <asm/hwcap.h>
+#include <cstring>
 #include <fstream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
cstring is required for strncpy