### PR TITLE
[WIP] Improve real Wiimote Speaker Audio quality

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -76,7 +76,11 @@ void Wiimote::WriteReport(Report rpt)
     m_rumble_state = new_rumble_state;
   }
 
-  m_write_reports.Push(std::move(rpt));
+  if (rpt[1] == WM_WRITE_SPEAKER_DATA || rpt[1] == WM_SPEAKER_ENABLE || rpt[1] == WM_SPEAKER_MUTE)
+    m_write_reports_snd.Push(std::move(rpt));
+  else
+    m_write_reports.Push(std::move(rpt));
+
   IOWakeup();
 }
 
@@ -223,6 +227,21 @@ void Wiimote::Read()
     ERROR_LOG(WIIMOTE, "Wiimote::IORead failed. Disconnecting Wii Remote %d.", m_index + 1);
     DisconnectInternal();
   }
+}
+
+bool Wiimote::WriteSound()
+{
+  if (m_write_reports_snd.Empty())
+    return true;
+
+  Report const& rpt = m_write_reports_snd.Front();
+
+  int ret = IOWrite(rpt.data(), rpt.size());
+  Common::SleepCurrentThread(13);
+
+  m_write_reports_snd.Pop();
+
+  return ret != 0;
 }
 
 bool Wiimote::Write()
@@ -612,6 +631,7 @@ bool Wiimote::Connect(int index)
 void Wiimote::StartThread()
 {
   m_wiimote_thread = std::thread(&Wiimote::ThreadFunc, this);
+  m_wiimote_snd_thread = std::thread(&Wiimote::SndThreadFunc, this);
 }
 
 void Wiimote::StopThread()
@@ -620,6 +640,21 @@ void Wiimote::StopThread()
     return;
   IOWakeup();
   m_wiimote_thread.join();
+  m_wiimote_snd_thread.join();
+}
+
+void Wiimote::SndThreadFunc()
+{
+  Common::SetCurrentThreadName("Wiimote Sound Device Thread");
+
+  while (!m_run_thread.IsSet())
+  {
+  }
+
+  while (m_run_thread.IsSet())
+  {
+    WriteSound();
+  }
 }
 
 void Wiimote::ThreadFunc()

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -43,6 +43,8 @@ public:
   void Read();
   bool Write();
 
+  bool WriteSound();
+
   bool IsBalanceBoard();
 
   void StartThread();
@@ -98,10 +100,12 @@ private:
   virtual void IOWakeup() = 0;
 
   void ThreadFunc();
+  void SndThreadFunc();
 
   bool m_rumble_state;
 
   std::thread m_wiimote_thread;
+  std::thread m_wiimote_snd_thread;
   // Whether to keep running the thread.
   Common::Flag m_run_thread;
   // Whether to call PrepareOnThread.
@@ -111,6 +115,7 @@ private:
 
   Common::FifoQueue<Report> m_read_reports;
   Common::FifoQueue<Report> m_write_reports;
+  Common::FifoQueue<Report> m_write_reports_snd;
 };
 
 class WiimoteScannerBackend


### PR DESCRIPTION
The changes I made improve the quality of Wiimote Speaker Audio quite a bit, but everything in there is still very hacky.

Known Problems:
* Still doesn't sound perfect (Stuttering, Slower than to be expected...)
* Uses static sleeps instead of dynamically figuring out how long to hold back the next `WM_WRITE_SPEAKER_DATA` Report.