### PR TITLE
IOS: Minor savestate fixes

### DIFF
--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -28,9 +28,8 @@ DI::DI(u32 device_id, const std::string& device_name) : Device(device_id, device
 {
 }
 
-void DI::DoState(PointerWrap& p)
+void DI::DoStateInternal(PointerWrap& p)
 {
-  DoStateShared(p);
   p.Do(m_commands_to_execute);
 }
 

--- a/Source/Core/Core/IOS/DI/DI.h
+++ b/Source/Core/Core/IOS/DI/DI.h
@@ -29,14 +29,13 @@ class DI : public Device
 public:
   DI(u32 device_id, const std::string& device_name);
 
-  void DoState(PointerWrap& p) override;
-
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   void FinishIOCtl(DVDInterface::DIInterruptType interrupt_type);
 
 private:
+  void DoStateInternal(PointerWrap& p) override;
   void StartIOCtl(const IOCtlRequest& request);
 
   std::deque<u32> m_commands_to_execute;

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -141,14 +141,10 @@ Device::Device(const u32 device_id, const std::string& device_name, const Device
 void Device::DoState(PointerWrap& p)
 {
   DoStateShared(p);
-  p.Do(m_is_active);
 }
 
 void Device::DoStateShared(PointerWrap& p)
 {
-  p.Do(m_name);
-  p.Do(m_device_id);
-  p.Do(m_device_type);
   p.Do(m_is_active);
 }
 

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -140,12 +140,12 @@ Device::Device(const u32 device_id, const std::string& device_name, const Device
 
 void Device::DoState(PointerWrap& p)
 {
-  DoStateShared(p);
+  p.Do(m_is_active);
+  DoStateInternal(p);
 }
 
-void Device::DoStateShared(PointerWrap& p)
+void Device::DoStateInternal(PointerWrap& p)
 {
-  p.Do(m_is_active);
 }
 
 ReturnCode Device::Open(const OpenRequest& request)

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -174,8 +174,7 @@ public:
   virtual ~Device() = default;
   // Release any resources which might interfere with savestating.
   virtual void PrepareForState(PointerWrap::Mode mode) {}
-  virtual void DoState(PointerWrap& p);
-  void DoStateShared(PointerWrap& p);
+  void DoState(PointerWrap& p);
 
   const std::string& GetDeviceName() const { return m_name; }
   u32 GetDeviceID() const { return m_device_id; }
@@ -196,6 +195,8 @@ public:
   static IPCCommandResult GetNoReply();
 
 protected:
+  virtual void DoStateInternal(PointerWrap& p);
+
   std::string m_name;
   u32 m_device_id;
   DeviceType m_device_type;

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -197,7 +197,6 @@ public:
 
 protected:
   std::string m_name;
-  // STATE_TO_SAVE
   u32 m_device_id;
   DeviceType m_device_type;
   bool m_is_active = false;

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -229,9 +229,8 @@ bool ES::LaunchPPCTitle(u64 title_id, bool skip_reload)
   return BootstrapPPC(content_loader);
 }
 
-void ES::DoState(PointerWrap& p)
+void ES::DoStateInternal(PointerWrap& p)
 {
-  Device::DoState(p);
   p.Do(s_content_file);
   p.Do(m_AccessIdentID);
   s_title_context.DoState(p);

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -55,8 +55,6 @@ public:
   // Internal implementation of the ES_DECRYPT ioctlv.
   static void DecryptContent(u32 key_index, u8* iv, u8* input, u32 size, u8* new_iv, u8* output);
 
-  void DoState(PointerWrap& p) override;
-
   ReturnCode Open(const OpenRequest& request) override;
   void Close() override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
@@ -154,6 +152,8 @@ private:
     u8 ecc_pubkey[0x3c];
     u8 padding[0x3c];
   };
+
+  void DoStateInternal(PointerWrap& p) override;
 
   // Title management
   IPCCommandResult AddTicket(const IOCtlVRequest& request);

--- a/Source/Core/Core/IOS/FS/FS.cpp
+++ b/Source/Core/Core/IOS/FS/FS.cpp
@@ -40,10 +40,8 @@ FS::FS(u32 device_id, const std::string& device_name) : Device(device_id, device
   File::CreateDir(tmp_dir);
 }
 
-void FS::DoState(PointerWrap& p)
+void FS::DoStateInternal(PointerWrap& p)
 {
-  DoStateShared(p);
-
   // handle /tmp
 
   std::string Path = File::GetUserPath(D_SESSION_WIIROOT_IDX) + "/tmp";

--- a/Source/Core/Core/IOS/FS/FS.h
+++ b/Source/Core/Core/IOS/FS/FS.h
@@ -34,8 +34,6 @@ class FS : public Device
 public:
   FS(u32 device_id, const std::string& device_name);
 
-  void DoState(PointerWrap& p) override;
-
   ReturnCode Open(const OpenRequest& request) override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
@@ -54,6 +52,8 @@ private:
     IOCTLV_GETUSAGE = 0x0C,
     IOCTL_SHUTDOWN = 0x0D
   };
+
+  void DoStateInternal(PointerWrap& p) override;
 
   IPCCommandResult GetFSReply(s32 return_value) const;
 

--- a/Source/Core/Core/IOS/FS/FileIO.cpp
+++ b/Source/Core/Core/IOS/FS/FileIO.cpp
@@ -288,10 +288,8 @@ void FileIO::PrepareForState(PointerWrap::Mode mode)
   m_file.reset();
 }
 
-void FileIO::DoState(PointerWrap& p)
+void FileIO::DoStateInternal(PointerWrap& p)
 {
-  DoStateShared(p);
-
   p.Do(m_Mode);
   p.Do(m_SeekPos);
 

--- a/Source/Core/Core/IOS/FS/FileIO.h
+++ b/Source/Core/Core/IOS/FS/FileIO.h
@@ -39,7 +39,6 @@ public:
   IPCCommandResult Write(const ReadWriteRequest& request) override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   void PrepareForState(PointerWrap::Mode mode) override;
-  void DoState(PointerWrap& p) override;
 
   void OpenFile();
 
@@ -69,6 +68,8 @@ private:
     ISFS_IOCTL_GETUSAGE = 12,
     ISFS_IOCTL_SHUTDOWN = 13
   };
+
+  void DoStateInternal(PointerWrap& p) override;
 
   IPCCommandResult GetFileStats(const IOCtlRequest& request);
 

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -27,9 +27,8 @@ SDIOSlot0::SDIOSlot0(u32 device_id, const std::string& device_name) : Device(dev
 {
 }
 
-void SDIOSlot0::DoState(PointerWrap& p)
+void SDIOSlot0::DoStateInternal(PointerWrap& p)
 {
-  DoStateShared(p);
   if (p.GetMode() == PointerWrap::MODE_READ)
   {
     OpenInternal();

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -28,8 +28,6 @@ class SDIOSlot0 : public Device
 public:
   SDIOSlot0(u32 device_id, const std::string& device_name);
 
-  void DoState(PointerWrap& p) override;
-
   ReturnCode Open(const OpenRequest& request) override;
   void Close() override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
@@ -117,6 +115,8 @@ private:
     EventType type;
     Request request;
   };
+
+  void DoStateInternal(PointerWrap& p) override;
 
   IPCCommandResult WriteHCRegister(const IOCtlRequest& request);
   IPCCommandResult ReadHCRegister(const IOCtlRequest& request);

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -86,7 +86,7 @@ IPCCommandResult STMEventHook::IOCtl(const IOCtlRequest& request)
   return GetNoReply();
 }
 
-void STMEventHook::DoState(PointerWrap& p)
+void STMEventHook::DoStateInternal(PointerWrap& p)
 {
   u32 address = s_event_hook_request ? s_event_hook_request->address : 0;
   p.Do(address);
@@ -94,7 +94,6 @@ void STMEventHook::DoState(PointerWrap& p)
     s_event_hook_request = std::make_unique<IOCtlRequest>(address);
   else
     s_event_hook_request.reset();
-  Device::DoState(p);
 }
 
 bool STMEventHook::HasHookInstalled() const

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -57,13 +57,14 @@ public:
   STMEventHook(u32 device_id, const std::string& device_name) : Device(device_id, device_name) {}
   void Close() override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
-  void DoState(PointerWrap& p) override;
 
   bool HasHookInstalled() const;
   void ResetButton() const;
   void PowerButton() const;
 
 private:
+  void DoStateInternal(PointerWrap& p) override;
+
   void TriggerEvent(u32 event) const;
 };
 }  // namespace Device

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -116,7 +116,7 @@ static void DoStateForMessage(PointerWrap& p, std::unique_ptr<T>& message)
   }
 }
 
-void BluetoothEmu::DoState(PointerWrap& p)
+void BluetoothEmu::DoStateInternal(PointerWrap& p)
 {
   bool passthrough_bluetooth = false;
   p.Do(passthrough_bluetooth);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -63,8 +63,6 @@ public:
   WiimoteDevice* AccessWiiMote(const bdaddr_t& _rAddr);
   WiimoteDevice* AccessWiiMote(u16 _ConnectionHandle);
 
-  void DoState(PointerWrap& p) override;
-
 private:
   bdaddr_t m_ControllerBD;
 
@@ -100,6 +98,8 @@ private:
 
   u32 m_PacketCount[MAX_BBMOTES] = {};
   u64 m_last_ticks = 0;
+
+  void DoStateInternal(PointerWrap& p) override;
 
   // Send ACL data to a device (wiimote)
   void IncDataPacket(u16 _ConnectionHandle);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -279,7 +279,7 @@ IPCCommandResult BluetoothReal::IOCtlV(const IOCtlVRequest& request)
 }
 
 static bool s_has_shown_savestate_warning = false;
-void BluetoothReal::DoState(PointerWrap& p)
+void BluetoothReal::DoStateInternal(PointerWrap& p)
 {
   bool passthrough_bluetooth = true;
   p.Do(passthrough_bluetooth);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -55,7 +55,6 @@ public:
   void Close() override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
-  void DoState(PointerWrap& p) override;
   void UpdateSyncButtonState(bool is_held) override;
   void TriggerSyncButtonPressedEvent() override;
   void TriggerSyncButtonHeldEvent() override;
@@ -109,6 +108,8 @@ private:
   Common::Flag m_showed_failed_transfer;
 
   bool m_is_wii_bt_module = false;
+
+  void DoStateInternal(PointerWrap& p) override;
 
   void WaitForHCICommandComplete(u16 opcode);
   void SendHCIResetCommand();

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.cpp
@@ -21,7 +21,7 @@ ReturnCode BluetoothStub::Open(const OpenRequest& request)
   return IPC_ENOENT;
 }
 
-void BluetoothStub::DoState(PointerWrap& p)
+void BluetoothStub::DoStateInternal(PointerWrap& p)
 {
   Core::DisplayMessage("The current IPC_HLE_Device_usb is a stub. Aborting load.", 4000);
   p.SetMode(PointerWrap::MODE_VERIFY);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTStub.h
@@ -26,7 +26,9 @@ public:
   {
   }
   ReturnCode Open(const OpenRequest& request) override;
-  void DoState(PointerWrap& p) override;
+
+private:
+  void DoStateInternal(PointerWrap& p) override;
 };
 }  // namespace Device
 }  // namespace HLE

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -62,7 +62,7 @@ void USBHost::UpdateWantDeterminism(const bool new_want_determinism)
     StartThreads();
 }
 
-void USBHost::DoState(PointerWrap& p)
+void USBHost::DoStateInternal(PointerWrap& p)
 {
   if (IsOpened() && p.GetMode() == PointerWrap::MODE_READ)
   {

--- a/Source/Core/Core/IOS/USB/Host.h
+++ b/Source/Core/Core/IOS/USB/Host.h
@@ -39,7 +39,6 @@ public:
   ReturnCode Open(const OpenRequest& request) override;
 
   void UpdateWantDeterminism(bool new_want_determinism) override;
-  void DoState(PointerWrap& p) override;
 
 protected:
   enum class ChangeEvent
@@ -63,6 +62,8 @@ protected:
                                   std::function<s32()> submit) const;
 
 private:
+  void DoStateInternal(PointerWrap& p) override;
+
   bool AddDevice(std::unique_ptr<USB::Device> device);
   bool UpdateDevices(bool always_add_hooks = false);
 

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -78,7 +78,7 @@ IPCCommandResult OH0::IOCtlV(const IOCtlVRequest& request)
   }
 }
 
-void OH0::DoState(PointerWrap& p)
+void OH0::DoStateInternal(PointerWrap& p)
 {
   if (p.GetMode() == PointerWrap::MODE_READ && !m_devices.empty())
   {

--- a/Source/Core/Core/IOS/USB/OH0/OH0.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.h
@@ -50,9 +50,9 @@ public:
   IPCCommandResult DeviceIOCtl(u64 device_id, const IOCtlRequest& request);
   IPCCommandResult DeviceIOCtlV(u64 device_id, const IOCtlVRequest& request);
 
-  void DoState(PointerWrap& p) override;
-
 private:
+  void DoStateInternal(PointerWrap& p) override;
+
   IPCCommandResult CancelInsertionHook(const IOCtlRequest& request);
   IPCCommandResult GetDeviceList(const IOCtlVRequest& request) const;
   IPCCommandResult GetRhDesca(const IOCtlRequest& request) const;

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -43,7 +43,7 @@ OH0Device::OH0Device(u32 id, const std::string& name) : Device(id, name, DeviceT
     GetVidPidFromDevicePath(name, m_vid, m_pid);
 }
 
-void OH0Device::DoState(PointerWrap& p)
+void OH0Device::DoStateInternal(PointerWrap& p)
 {
   m_oh0 = std::static_pointer_cast<OH0>(GetDeviceByName("/dev/usb/oh0"));
   p.Do(m_name);

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.h
@@ -28,9 +28,10 @@ public:
   void Close() override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
-  void DoState(PointerWrap& p) override;
 
 private:
+  void DoStateInternal(PointerWrap& p) override;
+
   std::shared_ptr<OH0> m_oh0;
   u16 m_vid = 0;
   u16 m_pid = 0;

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.cpp
@@ -124,7 +124,7 @@ s32 USB_HIDv4::SubmitTransfer(USB::Device& device, const IOCtlRequest& request)
   }
 }
 
-void USB_HIDv4::DoState(PointerWrap& p)
+void USB_HIDv4::DoStateInternal(PointerWrap& p)
 {
   p.Do(m_devicechange_first_call);
   u32 hook_address = m_devicechange_hook_request ? m_devicechange_hook_request->address : 0;

--- a/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
+++ b/Source/Core/Core/IOS/USB/USB_HID/HIDv4.h
@@ -30,9 +30,9 @@ public:
 
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
 
-  void DoState(PointerWrap& p) override;
-
 private:
+  void DoStateInternal(PointerWrap& p) override;
+
   std::shared_ptr<USB::Device> GetDeviceByIOSID(s32 ios_id) const;
 
   IPCCommandResult CancelInterrupt(const IOCtlRequest& request);

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -98,7 +98,7 @@ IPCCommandResult USB_VEN::IOCtlV(const IOCtlVRequest& request)
   }
 }
 
-void USB_VEN::DoState(PointerWrap& p)
+void USB_VEN::DoStateInternal(PointerWrap& p)
 {
   p.Do(m_devicechange_first_call);
   u32 hook_address = m_devicechange_hook_request ? m_devicechange_hook_request->address : 0;

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.h
@@ -35,8 +35,6 @@ public:
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
-  void DoState(PointerWrap& p) override;
-
 private:
 #pragma pack(push, 1)
   struct DeviceID
@@ -58,6 +56,8 @@ private:
     u8 num_altsettings;
   };
 #pragma pack(pop)
+
+  void DoStateInternal(PointerWrap& p) override;
 
   std::shared_ptr<USB::Device> GetDeviceByIOSID(s32 ios_id) const;
   u8 GetInterfaceNumber(s32 ios_id) const;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 79;  // Last changed in PR 4981
+static const u32 STATE_VERSION = 80;  // Last changed in PR 5300
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
* Remove some unnecessary p.Do() calls.
* Fix DoStateShared/DoState to make them less error prone.