### PR TITLE
DSPHLE: Use unique_ptr for ucodes

### DIFF
--- a/Source/Core/Core/DSPEmulator.cpp
+++ b/Source/Core/Core/DSPEmulator.cpp
@@ -6,6 +6,7 @@
 
 #include "Core/DSPEmulator.h"
 #include "Core/HW/DSPHLE/DSPHLE.h"
+#include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/DSPLLE/DSPLLE.h"
 
 std::unique_ptr<DSPEmulator> CreateDSPEmulator(bool hle)

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.cpp
@@ -43,7 +43,6 @@ void DSPHLE::DSP_StopSoundStream()
 
 void DSPHLE::Shutdown()
 {
-  delete m_ucode;
   m_ucode = nullptr;
 }
 
@@ -69,16 +68,8 @@ void DSPHLE::SendMailToDSP(u32 mail)
   }
 }
 
-UCodeInterface* DSPHLE::GetUCode()
-{
-  return m_ucode;
-}
-
 void DSPHLE::SetUCode(u32 crc)
 {
-  delete m_ucode;
-
-  m_ucode = nullptr;
   m_mail_handler.Clear();
   m_ucode = UCodeFactory(crc, this, m_wii);
   m_ucode->Initialize();
@@ -93,15 +84,13 @@ void DSPHLE::SwapUCode(u32 crc)
 
   if (m_last_ucode == nullptr)
   {
-    m_last_ucode = m_ucode;
+    m_last_ucode = std::move(m_ucode);
     m_ucode = UCodeFactory(crc, this, m_wii);
     m_ucode->Initialize();
   }
   else
   {
-    delete m_ucode;
-    m_ucode = m_last_ucode;
-    m_last_ucode = nullptr;
+    m_ucode = std::move(m_last_ucode);
   }
 }
 
@@ -120,9 +109,9 @@ void DSPHLE::DoState(PointerWrap& p)
   p.DoPOD(m_dsp_control);
   p.DoPOD(m_dsp_state);
 
-  int ucode_crc = UCodeInterface::GetCRC(m_ucode);
-  int ucode_crc_beforeLoad = ucode_crc;
-  int last_ucode_crc = UCodeInterface::GetCRC(m_last_ucode);
+  int ucode_crc = UCodeInterface::GetCRC(m_ucode.get());
+  int ucode_crc_before_load = ucode_crc;
+  int last_ucode_crc = UCodeInterface::GetCRC(m_last_ucode.get());
   int last_ucode_crc_before_load = last_ucode_crc;
 
   p.Do(ucode_crc);
@@ -130,43 +119,19 @@ void DSPHLE::DoState(PointerWrap& p)
 
   // if a different type of ucode was being used when the savestate was created,
   // we have to reconstruct the old type of ucode so that we have a valid thing to call DoState on.
-  UCodeInterface* ucode =
-      (ucode_crc == ucode_crc_beforeLoad) ? m_ucode : UCodeFactory(ucode_crc, this, m_wii);
-  UCodeInterface* last_ucode = (last_ucode_crc != last_ucode_crc_before_load) ?
-                                   m_last_ucode :
-                                   UCodeFactory(last_ucode_crc, this, m_wii);
+  const bool same_ucode = ucode_crc == ucode_crc_before_load;
+  const bool same_last_ucode = last_ucode_crc != last_ucode_crc_before_load;
+  auto ucode = same_ucode ? std::move(m_ucode) : UCodeFactory(ucode_crc, this, m_wii);
+  auto last_ucode =
+      same_last_ucode ? std::move(m_last_ucode) : UCodeFactory(last_ucode_crc, this, m_wii);
 
   if (ucode)
     ucode->DoState(p);
   if (last_ucode)
     last_ucode->DoState(p);
 
-  // if a different type of ucode was being used when the savestate was created,
-  // discard it if we're not loading, otherwise discard the old one and keep the new one.
-  if (ucode != m_ucode)
-  {
-    if (p.GetMode() != PointerWrap::MODE_READ)
-    {
-      delete ucode;
-    }
-    else
-    {
-      delete m_ucode;
-      m_ucode = ucode;
-    }
-  }
-  if (last_ucode != m_last_ucode)
-  {
-    if (p.GetMode() != PointerWrap::MODE_READ)
-    {
-      delete last_ucode;
-    }
-    else
-    {
-      delete m_last_ucode;
-      m_last_ucode = last_ucode;
-    }
-  }
+  m_ucode = std::move(ucode);
+  m_last_ucode = std::move(last_ucode);
 
   m_mail_handler.DoState(p);
 }

--- a/Source/Core/Core/HW/DSPHLE/DSPHLE.h
+++ b/Source/Core/Core/HW/DSPHLE/DSPHLE.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Common/CommonTypes.h"
 #include "Core/DSPEmulator.h"
 #include "Core/HW/DSP.h"
@@ -39,8 +41,6 @@ public:
   u32 DSP_UpdateRate() override;
 
   CMailHandler& AccessMailHandler() { return m_mail_handler; }
-  // Formerly DSPHandler
-  UCodeInterface* GetUCode();
   void SetUCode(u32 crc);
   void SwapUCode(u32 crc);
 
@@ -63,8 +63,8 @@ private:
   };
   DSPState m_dsp_state;
 
-  UCodeInterface* m_ucode;
-  UCodeInterface* m_last_ucode;
+  std::unique_ptr<UCodeInterface> m_ucode;
+  std::unique_ptr<UCodeInterface> m_last_ucode;
 
   DSP::UDSPControl m_dsp_control;
   CMailHandler m_mail_handler;

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -227,25 +227,25 @@ void UCodeInterface::DoStateShared(PointerWrap& p)
   p.Do(m_needs_resume_mail);
 }
 
-UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
+std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
 {
   switch (crc)
   {
   case UCODE_ROM:
     INFO_LOG(DSPHLE, "Switching to ROM ucode");
-    return new ROMUCode(dsphle, crc);
+    return std::make_unique<ROMUCode>(dsphle, crc);
 
   case UCODE_INIT_AUDIO_SYSTEM:
     INFO_LOG(DSPHLE, "Switching to INIT ucode");
-    return new INITUCode(dsphle, crc);
+    return std::make_unique<INITUCode>(dsphle, crc);
 
   case 0x65d6cc6f:  // CARD
     INFO_LOG(DSPHLE, "Switching to CARD ucode");
-    return new CARDUCode(dsphle, crc);
+    return std::make_unique<CARDUCode>(dsphle, crc);
 
   case 0xdd7e72d5:
     INFO_LOG(DSPHLE, "Switching to GBA ucode");
-    return new GBAUCode(dsphle, crc);
+    return std::make_unique<GBAUCode>(dsphle, crc);
 
   case 0x3ad3b7ac:  // Naruto 3, Paper Mario - The Thousand Year Door
   case 0x3daf59b9:  // Alien Hominid
@@ -260,7 +260,7 @@ UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
   case 0xe2136399:  // Billy Hatcher, Dragon Ball Z, Mario Party 5, TMNT, 1080° Avalanche
   case 0x3389a79e:  // MP1/MP2 Wii (Metroid Prime Trilogy)
     INFO_LOG(DSPHLE, "CRC %08x: AX ucode chosen", crc);
-    return new AXUCode(dsphle, crc);
+    return std::make_unique<AXUCode>(dsphle, crc);
 
   case 0x86840740:  // Zelda WW - US
   case 0x6ca33a6d:  // Zelda TP GC - US
@@ -275,7 +275,7 @@ UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
   case 0x6c3f6f94:  // Zelda TP Wii - US
   case 0xb7eb9a9c:  // Pikmin 1 New Play Control Wii - US
   case 0xeaeb38cc:  // Pikmin 2 New Play Control Wii - US
-    return new ZeldaUCode(dsphle, crc);
+    return std::make_unique<ZeldaUCode>(dsphle, crc);
 
   case 0x2ea36ce6:  // Some Wii demos
   case 0x5ef56da3:  // AX demo
@@ -285,7 +285,7 @@ UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
   case 0x4cc52064:  // Bleach: Versus Crusade
   case 0xd9c4bf34:  // WiiMenu
     INFO_LOG(DSPHLE, "CRC %08x: Wii - AXWii chosen", crc);
-    return new AXWiiUCode(dsphle, crc);
+    return std::make_unique<AXWiiUCode>(dsphle, crc);
 
   default:
     if (wii)
@@ -294,7 +294,7 @@ UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
                   "is homebrew.\n\n"
                   "Unknown ucode (CRC = %08x) - forcing AXWii.",
                   crc);
-      return new AXWiiUCode(dsphle, crc);
+      return std::make_unique<AXWiiUCode>(dsphle, crc);
     }
     else
     {
@@ -302,7 +302,7 @@ UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii)
                   "is homebrew.\n\n"
                   "DSPHLE: Unknown ucode (CRC = %08x) - forcing AX.",
                   crc);
-      return new AXUCode(dsphle, crc);
+      return std::make_unique<AXUCode>(dsphle, crc);
     }
 
   case UCODE_NULL:

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstring>
+#include <memory>
 
 #include "Common/CommonTypes.h"
 
@@ -103,6 +104,6 @@ private:
   bool m_needs_resume_mail = false;
 };
 
-UCodeInterface* UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii);
+std::unique_ptr<UCodeInterface> UCodeFactory(u32 crc, DSPHLE* dsphle, bool wii);
 }  // namespace HLE
 }  // namespace DSP


### PR DESCRIPTION
Simple cleanup change.

Reopened as a new PR because the previous PR (#5302) stopped being built for some reason.