### PR TITLE
IOS: Implement UID/GID changes for the PPC

### DIFF
--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -219,8 +219,8 @@ class UIDSys final
 public:
   explicit UIDSys(Common::FromWhichRoot root);
 
-  u32 GetUIDFromTitle(u64 title_id);
-  void AddTitle(u64 title_id);
+  u32 GetUIDFromTitle(u64 title_id) const;
+  u32 GetOrInsertUIDForTitle(u64 title_id);
   u32 GetNextUID() const;
 
 private:

--- a/Source/Core/Core/IOS/ES/NandUtils.cpp
+++ b/Source/Core/Core/IOS/ES/NandUtils.cpp
@@ -194,7 +194,7 @@ bool InitImport(u64 title_id)
   }
 
   UIDSys uid_sys{Common::FROM_CONFIGURED_ROOT};
-  uid_sys.AddTitle(title_id);
+  uid_sys.GetOrInsertUIDForTitle(title_id);
 
   // IOS moves the title content directory to /import if the TMD exists during an import.
   if (File::Exists(Common::GetTMDFileName(title_id, Common::FROM_SESSION_ROOT)))

--- a/Source/Core/Core/IOS/IPC.cpp
+++ b/Source/Core/Core/IOS/IPC.cpp
@@ -91,6 +91,9 @@ static u64 s_last_reply_time;
 
 static u64 s_active_title_id;
 
+static u32 s_ppc_uid;
+static u16 s_ppc_gid;
+
 static constexpr u64 ENQUEUE_REQUEST_FLAG = 0x100000000ULL;
 static constexpr u64 ENQUEUE_ACKNOWLEDGEMENT_FLAG = 0x200000000ULL;
 
@@ -702,6 +705,28 @@ bool Reload(const u64 ios_title_id)
   return true;
 }
 
+// Since we don't have actual processes, we keep track of only the PPC's UID/GID.
+// These functions roughly correspond to syscalls 0x2b, 0x2c, 0x2d, 0x2e (though only for the PPC).
+void SetUIDForPPC(u32 uid)
+{
+  s_ppc_uid = uid;
+}
+
+u32 GetUIDForPPC()
+{
+  return s_ppc_uid;
+}
+
+void SetGIDForPPC(u16 gid)
+{
+  s_ppc_gid = gid;
+}
+
+u16 GetGIDForPPC()
+{
+  return s_ppc_gid;
+}
+
 // This corresponds to syscall 0x41, which loads a binary from the NAND and bootstraps the PPC.
 // Unlike 0x42, IOS will set up some constants in memory before booting the PPC.
 bool BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader)
@@ -783,6 +808,8 @@ void DoState(PointerWrap& p)
   p.Do(s_reply_queue);
   p.Do(s_last_reply_time);
   p.Do(s_active_title_id);
+  p.Do(s_ppc_uid);
+  p.Do(s_ppc_gid);
 
   if (s_active_title_id == MIOS_TITLE_ID)
     return;

--- a/Source/Core/Core/IOS/IPC.h
+++ b/Source/Core/Core/IOS/IPC.h
@@ -59,6 +59,11 @@ void Shutdown();
 bool Reload(u64 ios_title_id);
 u32 GetVersion();
 
+void SetUIDForPPC(u32 uid);
+u32 GetUIDForPPC();
+void SetGIDForPPC(u16 gid);
+u16 GetGIDForPPC();
+
 bool BootstrapPPC(const DiscIO::CNANDContentLoader& content_loader);
 
 // Do State

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 79;  // Last changed in PR 4981
+static const u32 STATE_VERSION = 80;  // Last changed in PR 5309
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,

--- a/Source/Core/DiscIO/NANDContentLoader.cpp
+++ b/Source/Core/DiscIO/NANDContentLoader.cpp
@@ -336,7 +336,7 @@ u64 CNANDContentManager::Install_WiiWAD(const std::string& filename)
   }
 
   IOS::ES::UIDSys uid_sys{Common::FromWhichRoot::FROM_CONFIGURED_ROOT};
-  uid_sys.AddTitle(title_id);
+  uid_sys.GetOrInsertUIDForTitle(title_id);
 
   ClearCache();
 


### PR DESCRIPTION
This is required for permission checks (in the future) and properly implementing ES_SetUid.

Note that this is only for the PPC as we do not have actual processes. Keeping track of other modules' UIDs/GIDs is virtually useless anyway.

The following functions now update the UID/GID properly:

* ES_Launch
* ES_DIVerify

ES_SetUid is not implemented in this PR because it'd need further changes, and I wanted to keep this PR small enough to be easy to review.