### PR TITLE
WiimoteReal: remove always-true IsReady method

### DIFF
--- a/Source/Core/Core/HW/WiimoteReal/IOAndroid.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOAndroid.h
@@ -18,6 +18,7 @@ public:
   WiimoteAndroid(int index);
   ~WiimoteAndroid() override;
   std::string GetId() const override { return "Android " + StringFromInt(m_mayflash_index); }
+
 protected:
   bool ConnectInternal() override;
   void DisconnectInternal() override;
@@ -43,7 +44,6 @@ class WiimoteScannerAndroid final : public WiimoteScannerBackend
 public:
   WiimoteScannerAndroid() = default;
   ~WiimoteScannerAndroid() override = default;
-  bool IsReady() const override { return true; }
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override {}
 };

--- a/Source/Core/Core/HW/WiimoteReal/IODummy.h
+++ b/Source/Core/Core/HW/WiimoteReal/IODummy.h
@@ -13,7 +13,6 @@ class WiimoteScannerDummy final : public WiimoteScannerBackend
 public:
   WiimoteScannerDummy() = default;
   ~WiimoteScannerDummy() override = default;
-  bool IsReady() const override { return false; }
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override {}
   void Update() override {}
 };

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.cpp
@@ -35,13 +35,8 @@ WiimoteScannerLinux::WiimoteScannerLinux() : m_device_id(-1), m_device_sock(-1)
 
 WiimoteScannerLinux::~WiimoteScannerLinux()
 {
-  if (IsReady())
+  if (m_device_sock > 0)
     close(m_device_sock);
-}
-
-bool WiimoteScannerLinux::IsReady() const
-{
-  return m_device_sock > 0;
 }
 
 void WiimoteScannerLinux::FindWiimotes(std::vector<Wiimote*>& found_wiimotes, Wiimote*& found_board)

--- a/Source/Core/Core/HW/WiimoteReal/IOLinux.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOLinux.h
@@ -44,7 +44,6 @@ class WiimoteScannerLinux final : public WiimoteScannerBackend
 public:
   WiimoteScannerLinux();
   ~WiimoteScannerLinux() override;
-  bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override{};  // not needed on Linux
 

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.cpp
@@ -458,32 +458,6 @@ void WiimoteScannerWindows::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
   SetupDiDestroyDeviceInfoList(device_info);
 }
 
-bool WiimoteScannerWindows::IsReady() const
-{
-  if (!s_loaded_ok)
-  {
-    return false;
-  }
-
-  // TODO: don't search for a radio each time
-
-  BLUETOOTH_FIND_RADIO_PARAMS radioParam;
-  radioParam.dwSize = sizeof(radioParam);
-
-  HANDLE hRadio;
-  HBLUETOOTH_RADIO_FIND hFindRadio = pBluetoothFindFirstRadio(&radioParam, &hRadio);
-
-  if (nullptr != hFindRadio)
-  {
-    pBluetoothFindRadioClose(hFindRadio);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
-}
-
 // Connect to a Wiimote with a known device path.
 bool WiimoteWindows::ConnectInternal()
 {

--- a/Source/Core/Core/HW/WiimoteReal/IOWin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOWin.h
@@ -27,6 +27,7 @@ public:
   WiimoteWindows(const std::basic_string<TCHAR>& path, WinWriteMethod initial_write_method);
   ~WiimoteWindows() override;
   std::string GetId() const override { return UTF16ToUTF8(m_devicepath); }
+
 protected:
   bool ConnectInternal() override;
   void DisconnectInternal() override;
@@ -48,7 +49,6 @@ class WiimoteScannerWindows final : public WiimoteScannerBackend
 public:
   WiimoteScannerWindows();
   ~WiimoteScannerWindows() override;
-  bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override;
 };

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.h
@@ -14,7 +14,6 @@ class WiimoteScannerDarwin final : public WiimoteScannerBackend
 public:
   WiimoteScannerDarwin() = default;
   ~WiimoteScannerDarwin() override = default;
-  bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override{};  // not needed
 };

--- a/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
+++ b/Source/Core/Core/HW/WiimoteReal/IOdarwin.mm
@@ -86,12 +86,6 @@ void WiimoteScannerDarwin::FindWiimotes(std::vector<Wiimote*>& found_wiimotes,
   [sbt release];
 }
 
-bool WiimoteScannerDarwin::IsReady() const
-{
-  // TODO: only return true when a BT device is present
-  return true;
-}
-
 WiimoteDarwin::WiimoteDarwin(IOBluetoothDevice* device) : m_btd(device)
 {
   m_inputlen = 0;

--- a/Source/Core/Core/HW/WiimoteReal/IOhidapi.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/IOhidapi.cpp
@@ -47,11 +47,6 @@ WiimoteScannerHidapi::~WiimoteScannerHidapi()
     ERROR_LOG(WIIMOTE, "Failed to clean up hidapi.");
 }
 
-bool WiimoteScannerHidapi::IsReady() const
-{
-  return true;
-}
-
 void WiimoteScannerHidapi::FindWiimotes(std::vector<Wiimote*>& wiimotes, Wiimote*& board)
 {
   hid_device_info* list = hid_enumerate(0x0, 0x0);

--- a/Source/Core/Core/HW/WiimoteReal/IOhidapi.h
+++ b/Source/Core/Core/HW/WiimoteReal/IOhidapi.h
@@ -17,6 +17,7 @@ public:
   explicit WiimoteHidapi(const std::string& device_path);
   ~WiimoteHidapi() override;
   std::string GetId() const override { return m_device_path; }
+
 protected:
   bool ConnectInternal() override;
   void DisconnectInternal() override;
@@ -35,7 +36,6 @@ class WiimoteScannerHidapi final : public WiimoteScannerBackend
 public:
   WiimoteScannerHidapi();
   ~WiimoteScannerHidapi();
-  bool IsReady() const override;
   void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) override;
   void Update() override{};  // not needed for hidapi
 };

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -533,12 +533,6 @@ void WiimoteScanner::SetScanMode(WiimoteScanMode scan_mode)
   m_scan_mode_changed_event.Set();
 }
 
-bool WiimoteScanner::IsReady() const
-{
-  return std::any_of(m_scanner_backends.begin(), m_scanner_backends.end(),
-                     [](const auto& backend) { return backend->IsReady(); });
-}
-
 void WiimoteScanner::AddScannerBackend(std::unique_ptr<WiimoteScannerBackend> backend)
 {
   m_scanner_backends.emplace_back(std::move(backend));

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -117,7 +117,6 @@ class WiimoteScannerBackend
 {
 public:
   virtual ~WiimoteScannerBackend() = default;
-  virtual bool IsReady() const = 0;
   virtual void FindWiimotes(std::vector<Wiimote*>&, Wiimote*&) = 0;
   // function called when not looking for more Wiimotes
   virtual void Update() = 0;
@@ -139,7 +138,6 @@ public:
   void SetScanMode(WiimoteScanMode scan_mode);
 
   void AddScannerBackend(std::unique_ptr<WiimoteScannerBackend> backend);
-  bool IsReady() const;
 
 private:
   void ThreadFunc();

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -106,7 +106,6 @@ void ControllerConfigDiag::UpdateUI()
   m_balance_board_checkbox->Enable(!enable_bt_passthrough_mode);
   m_enable_continuous_scanning->Enable(!enable_bt_passthrough_mode);
   m_refresh_wm_button->Enable(!enable_bt_passthrough_mode);
-  m_unsupported_bt_text->Enable(!enable_bt_passthrough_mode);
   m_enable_speaker_data->Enable(!enable_bt_passthrough_mode);
 
   // Disable some controls when emulation is running
@@ -134,7 +133,6 @@ void ControllerConfigDiag::UpdateUI()
     {
       m_enable_continuous_scanning->Disable();
       m_refresh_wm_button->Disable();
-      m_unsupported_bt_text->Disable();
       m_enable_speaker_data->Disable();
     }
   }
@@ -353,11 +351,6 @@ wxSizer* ControllerConfigDiag::CreateEmulatedBTConfigSizer()
                                      wxDLG_UNIT(this, wxSize(60, -1)));
   m_refresh_wm_button->Bind(wxEVT_BUTTON, &ControllerConfigDiag::OnWiimoteRefreshButton, this);
 
-  m_unsupported_bt_text =
-      new wxStaticText(this, wxID_ANY, _("A supported Bluetooth device could not be found,\n"
-                                         "so you must connect Wii Remotes manually."));
-  m_unsupported_bt_text->Show(!WiimoteReal::g_wiimote_scanner.IsReady());
-
   // Balance Board
   m_balance_board_checkbox = new wxCheckBox(this, wxID_ANY, _("Real Balance Board"));
   m_balance_board_checkbox->Bind(wxEVT_CHECKBOX, &ControllerConfigDiag::OnBalanceBoardChanged,
@@ -382,8 +375,6 @@ wxSizer* ControllerConfigDiag::CreateEmulatedBTConfigSizer()
 
   auto* const sizer = new wxBoxSizer(wxVERTICAL);
   sizer->Add(grid, 0, wxEXPAND);
-  sizer->AddSpacer(space5);
-  sizer->Add(m_unsupported_bt_text, 0, wxALIGN_CENTER | wxLEFT | wxRIGHT, space5);
   sizer->AddSpacer(space5);
   sizer->Add(scanning_sizer, 0, wxEXPAND);
 

--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -75,7 +75,6 @@ private:
 
   wxCheckBox* m_enable_continuous_scanning;
   wxButton* m_refresh_wm_button;
-  wxStaticText* m_unsupported_bt_text;
   wxCheckBox* m_enable_speaker_data;
 
   wxCheckBox* m_background_input_checkbox;


### PR DESCRIPTION
On all platforms except Android, `WiimoteScannerHidapi::IsReady` unconditionally returns true.

On Android, `WiimoteScannerAndroid::IsReady` unconditionally returns true.