### PR TITLE
AudioCommon: Move DPL2 decoding into Mixer

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.vcxproj
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <ClCompile Include="aldlist.cpp" />
     <ClCompile Include="AudioCommon.cpp" />
+    <ClCompile Include="AudioStretcher.cpp" />
     <ClCompile Include="CubebStream.cpp" />
     <ClCompile Include="CubebUtils.cpp" />
     <ClCompile Include="DPL2Decoder.cpp" />
@@ -54,6 +55,7 @@
     <ClInclude Include="aldlist.h" />
     <ClInclude Include="AlsaSoundStream.h" />
     <ClInclude Include="AudioCommon.h" />
+    <ClInclude Include="AudioStretcher.h" />
     <ClInclude Include="CoreAudioSoundStream.h" />
     <ClInclude Include="CubebStream.h" />
     <ClInclude Include="CubebUtils.h" />

--- a/Source/Core/AudioCommon/AudioCommon.vcxproj.filters
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj.filters
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ClCompile Include="aldlist.cpp" />
     <ClCompile Include="AudioCommon.cpp" />
+    <ClCompile Include="AudioStretcher.cpp" />
     <ClCompile Include="CubebUtils.cpp" />
     <ClCompile Include="DPL2Decoder.cpp" />
     <ClCompile Include="Mixer.cpp" />
@@ -31,6 +32,7 @@
   <ItemGroup>
     <ClInclude Include="aldlist.h" />
     <ClInclude Include="AudioCommon.h" />
+    <ClInclude Include="AudioStretcher.h" />
     <ClInclude Include="CubebUtils.h" />
     <ClInclude Include="DPL2Decoder.h" />
     <ClInclude Include="Mixer.h" />

--- a/Source/Core/AudioCommon/AudioStretcher.cpp
+++ b/Source/Core/AudioCommon/AudioStretcher.cpp
@@ -1,0 +1,85 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include <cmath>
+
+#include "AudioCommon/AudioStretcher.h"
+#include "Common/Logging/Log.h"
+#include "Core/ConfigManager.h"
+
+namespace AudioCommon
+{
+AudioStretcher::AudioStretcher(unsigned int sample_rate) : m_sample_rate(sample_rate)
+{
+  m_sound_touch.setChannels(2);
+  m_sound_touch.setSampleRate(sample_rate);
+  m_sound_touch.setPitch(1.0);
+  m_sound_touch.setTempo(1.0);
+  m_sound_touch.setSetting(SETTING_USE_QUICKSEEK, 0);
+  m_sound_touch.setSetting(SETTING_SEQUENCE_MS, 62);
+  m_sound_touch.setSetting(SETTING_SEEKWINDOW_MS, 28);
+  m_sound_touch.setSetting(SETTING_OVERLAP_MS, 8);
+}
+
+void AudioStretcher::Clear()
+{
+  m_sound_touch.clear();
+}
+
+void AudioStretcher::StretchAudio(const short* in, unsigned int num_in, short* out,
+                                  unsigned int num_out)
+{
+  const double time_delta = static_cast<double>(num_out) / m_sample_rate;  // seconds
+
+  // We were given actual_samples number of samples, and num_samples were requested from us.
+  double current_ratio = static_cast<double>(num_in) / static_cast<double>(num_out);
+
+  const double max_latency = SConfig::GetInstance().m_audio_stretch_max_latency;
+  const double max_backlog = m_sample_rate * max_latency / 1000.0 / m_stretch_ratio;
+  const double backlog_fullness = m_sound_touch.numSamples() / max_backlog;
+  if (backlog_fullness > 5.0)
+  {
+    // Too many samples in backlog: Don't push anymore on
+    num_in = 0;
+  }
+
+  // We ideally want the backlog to be about 50% full.
+  // This gives some headroom both ways to prevent underflow and overflow.
+  // We tweak current_ratio to encourage this.
+  constexpr double tweak_time_scale = 0.5;  // seconds
+  current_ratio *= 1.0 + 2.0 * (backlog_fullness - 0.5) * (time_delta / tweak_time_scale);
+
+  // This low-pass filter smoothes out variance in the calculated stretch ratio.
+  // The time-scale determines how responsive this filter is.
+  constexpr double lpf_time_scale = 1.0;  // seconds
+  const double lpf_gain = 1.0 - std::exp(-time_delta / lpf_time_scale);
+  m_stretch_ratio += lpf_gain * (current_ratio - m_stretch_ratio);
+
+  // Place a lower limit of 10% speed.  When a game boots up, there will be
+  // many silence samples.  These do not need to be timestretched.
+  m_stretch_ratio = std::max(m_stretch_ratio, 0.1);
+  m_sound_touch.setTempo(m_stretch_ratio);
+
+  DEBUG_LOG(AUDIO, "Audio stretching: samples:%u/%u ratio:%f backlog:%f gain: %f", num_in, num_out,
+            m_stretch_ratio, backlog_fullness, lpf_gain);
+
+  m_sound_touch.putSamples(in, num_in);
+
+  const size_t samples_received = m_sound_touch.receiveSamples(out, num_out);
+
+  if (samples_received != 0)
+  {
+    m_last_stretched_sample[0] = out[samples_received * 2 - 2];
+    m_last_stretched_sample[1] = out[samples_received * 2 - 1];
+  }
+
+  // Perform padding if we've run out of samples.
+  for (size_t i = samples_received; i < num_out; i++)
+  {
+    out[i * 2 + 0] = m_last_stretched_sample[0];
+    out[i * 2 + 1] = m_last_stretched_sample[1];
+  }
+}
+
+}  // namespace AudioCommon

--- a/Source/Core/AudioCommon/AudioStretcher.cpp
+++ b/Source/Core/AudioCommon/AudioStretcher.cpp
@@ -2,7 +2,9 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cmath>
+#include <cstddef>
 
 #include "AudioCommon/AudioStretcher.h"
 #include "Common/Logging/Log.h"
@@ -27,8 +29,7 @@ void AudioStretcher::Clear()
   m_sound_touch.clear();
 }
 
-void AudioStretcher::StretchAudio(const short* in, unsigned int num_in, short* out,
-                                  unsigned int num_out)
+void AudioStretcher::ProcessSamples(const short* in, unsigned int num_in, unsigned int num_out)
 {
   const double time_delta = static_cast<double>(num_out) / m_sample_rate;  // seconds
 
@@ -65,7 +66,10 @@ void AudioStretcher::StretchAudio(const short* in, unsigned int num_in, short* o
             m_stretch_ratio, backlog_fullness, lpf_gain);
 
   m_sound_touch.putSamples(in, num_in);
+}
 
+void AudioStretcher::GetStretchedSamples(short* out, unsigned int num_out)
+{
   const size_t samples_received = m_sound_touch.receiveSamples(out, num_out);
 
   if (samples_received != 0)

--- a/Source/Core/AudioCommon/AudioStretcher.h
+++ b/Source/Core/AudioCommon/AudioStretcher.h
@@ -13,8 +13,9 @@ namespace AudioCommon
 class AudioStretcher
 {
 public:
-  AudioStretcher(unsigned int sample_rate);
-  void StretchAudio(const short* in, unsigned int num_in, short* out, unsigned int num_out);
+  explicit AudioStretcher(unsigned int sample_rate);
+  void ProcessSamples(const short* in, unsigned int num_in, unsigned int num_out);
+  void GetStretchedSamples(short* out, unsigned int num_out);
   void Clear();
 
 private:

--- a/Source/Core/AudioCommon/AudioStretcher.h
+++ b/Source/Core/AudioCommon/AudioStretcher.h
@@ -1,0 +1,27 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+
+#include <soundtouch/SoundTouch.h>
+
+namespace AudioCommon
+{
+class AudioStretcher
+{
+public:
+  AudioStretcher(unsigned int sample_rate);
+  void StretchAudio(const short* in, unsigned int num_in, short* out, unsigned int num_out);
+  void Clear();
+
+private:
+  unsigned int m_sample_rate;
+  std::array<short, 2> m_last_stretched_sample = {};
+  soundtouch::SoundTouch m_sound_touch;
+  double m_stretch_ratio = 1.0;
+};
+
+}  // AudioCommon

--- a/Source/Core/AudioCommon/CMakeLists.txt
+++ b/Source/Core/AudioCommon/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SRCS
   AudioCommon.cpp
+  AudioStretcher.cpp
   CubebStream.cpp
   CubebUtils.cpp
   DPL2Decoder.cpp

--- a/Source/Core/AudioCommon/CubebStream.cpp
+++ b/Source/Core/AudioCommon/CubebStream.cpp
@@ -21,29 +21,9 @@ long CubebStream::DataCallback(cubeb_stream* stream, void* user_data, const void
   auto* self = static_cast<CubebStream*>(user_data);
 
   if (self->m_stereo)
-  {
     self->m_mixer->Mix(static_cast<short*>(output_buffer), num_frames);
-  }
   else
-  {
-    size_t required_capacity = num_frames * 2;
-    if (required_capacity > self->m_short_buffer.capacity() ||
-        required_capacity > self->m_floatstereo_buffer.capacity())
-    {
-      INFO_LOG(AUDIO, "Expanding conversion buffers size: %li frames", num_frames);
-      self->m_short_buffer.reserve(required_capacity);
-      self->m_floatstereo_buffer.reserve(required_capacity);
-    }
-
-    self->m_mixer->Mix(self->m_short_buffer.data(), num_frames);
-
-    // s16 to float
-    for (size_t i = 0; i < static_cast<size_t>(num_frames) * 2; ++i)
-      self->m_floatstereo_buffer[i] = self->m_short_buffer[i] / static_cast<float>(1 << 15);
-
-    // DPL2Decode output: LEFTFRONT, RIGHTFRONT, CENTREFRONT, (sub), LEFTREAR, RIGHTREAR
-    DPL2Decode(self->m_floatstereo_buffer.data(), num_frames, static_cast<float*>(output_buffer));
-  }
+    self->m_mixer->MixSurround(static_cast<float*>(output_buffer), num_frames);
 
   return num_frames;
 }

--- a/Source/Core/AudioCommon/Mixer.cpp
+++ b/Source/Core/AudioCommon/Mixer.cpp
@@ -14,19 +14,10 @@
 #include "Common/Swap.h"
 #include "Core/ConfigManager.h"
 
-CMixer::CMixer(unsigned int BackendSampleRate) : m_sampleRate(BackendSampleRate)
+CMixer::CMixer(unsigned int BackendSampleRate)
+    : m_sampleRate(BackendSampleRate), m_stretcher(BackendSampleRate)
 {
   INFO_LOG(AUDIO_INTERFACE, "Mixer is initialized");
-
-  m_sound_touch.setChannels(2);
-  m_sound_touch.setSampleRate(BackendSampleRate);
-  m_sound_touch.setPitch(1.0);
-  m_sound_touch.setTempo(1.0);
-  m_sound_touch.setSetting(SETTING_USE_QUICKSEEK, 0);
-  m_sound_touch.setSetting(SETTING_SEQUENCE_MS, 62);
-  m_sound_touch.setSetting(SETTING_SEEKWINDOW_MS, 28);
-  m_sound_touch.setSetting(SETTING_OVERLAP_MS, 8);
-
   DPL2Reset();
 }
 
@@ -146,10 +137,10 @@ unsigned int CMixer::Mix(short* samples, unsigned int num_samples)
 
     if (!m_is_stretching)
     {
-      m_sound_touch.clear();
+      m_stretcher.Clear();
       m_is_stretching = true;
     }
-    StretchAudio(m_stretch_buffer.data(), available_samples, samples, num_samples);
+    m_stretcher.StretchAudio(m_stretch_buffer.data(), available_samples, samples, num_samples);
   }
   else
   {
@@ -179,60 +170,6 @@ unsigned int CMixer::MixSurround(float* samples, unsigned int num_samples)
   DPL2Decode(m_float_conversion_buffer.data(), available_samples, samples);
 
   return available_samples;
-}
-
-void CMixer::StretchAudio(const short* in, unsigned int num_in, short* out, unsigned int num_out)
-{
-  const double time_delta = static_cast<double>(num_out) / m_sampleRate;  // seconds
-
-  // We were given actual_samples number of samples, and num_samples were requested from us.
-  double current_ratio = static_cast<double>(num_in) / static_cast<double>(num_out);
-
-  const double max_latency = SConfig::GetInstance().m_audio_stretch_max_latency;
-  const double max_backlog = m_sampleRate * max_latency / 1000.0 / m_stretch_ratio;
-  const double backlog_fullness = m_sound_touch.numSamples() / max_backlog;
-  if (backlog_fullness > 5.0)
-  {
-    // Too many samples in backlog: Don't push anymore on
-    num_in = 0;
-  }
-
-  // We ideally want the backlog to be about 50% full.
-  // This gives some headroom both ways to prevent underflow and overflow.
-  // We tweak current_ratio to encourage this.
-  constexpr double tweak_time_scale = 0.5;  // seconds
-  current_ratio *= 1.0 + 2.0 * (backlog_fullness - 0.5) * (time_delta / tweak_time_scale);
-
-  // This low-pass filter smoothes out variance in the calculated stretch ratio.
-  // The time-scale determines how responsive this filter is.
-  constexpr double lpf_time_scale = 1.0;  // seconds
-  const double m_lpf_gain = 1.0 - std::exp(-time_delta / lpf_time_scale);
-  m_stretch_ratio += m_lpf_gain * (current_ratio - m_stretch_ratio);
-
-  // Place a lower limit of 10% speed.  When a game boots up, there will be
-  // many silence samples.  These do not need to be timestretched.
-  m_stretch_ratio = std::max(m_stretch_ratio, 0.1);
-  m_sound_touch.setTempo(m_stretch_ratio);
-
-  DEBUG_LOG(AUDIO, "Audio stretching: samples:%u/%u ratio:%f backlog:%f gain: %f", num_in, num_out,
-            m_stretch_ratio, backlog_fullness, m_lpf_gain);
-
-  m_sound_touch.putSamples(in, num_in);
-
-  const size_t samples_received = m_sound_touch.receiveSamples(out, num_out);
-
-  if (samples_received != 0)
-  {
-    m_last_stretched_sample[0] = out[samples_received * 2 - 2];
-    m_last_stretched_sample[1] = out[samples_received * 2 - 1];
-  }
-
-  // Preform padding if we've run out of samples.
-  for (size_t i = samples_received; i < num_out; i++)
-  {
-    out[i * 2 + 0] = m_last_stretched_sample[0];
-    out[i * 2 + 1] = m_last_stretched_sample[1];
-  }
 }
 
 void CMixer::MixerFifo::PushSamples(const short* samples, unsigned int num_samples)

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -21,6 +21,7 @@ public:
 
   // Called from audio threads
   unsigned int Mix(short* samples, unsigned int numSamples);
+  unsigned int MixSurround(float* samples, unsigned int num_samples);
 
   // Called from main thread
   void PushSamples(const short* samples, unsigned int num_samples);
@@ -87,6 +88,7 @@ private:
   double m_stretch_ratio = 1.0;
   std::array<short, 2> m_last_stretched_sample = {};
   std::array<short, MAX_SAMPLES * 2> m_stretch_buffer;
+  std::array<float, MAX_SAMPLES * 2> m_float_conversion_buffer;
 
   WaveFileWriter m_wave_writer_dtk;
   WaveFileWriter m_wave_writer_dsp;

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -7,11 +7,9 @@
 #include <array>
 #include <atomic>
 
+#include "AudioCommon/AudioStretcher.h"
 #include "AudioCommon/WaveFile.h"
 #include "Common/CommonTypes.h"
-
-#include <soundtouch/STTypes.h>
-#include <soundtouch/SoundTouch.h>
 
 class CMixer final
 {
@@ -76,17 +74,13 @@ private:
     u32 m_frac = 0;
   };
 
-  void StretchAudio(const short* in, unsigned int num_in, short* out, unsigned int num_out);
-
   MixerFifo m_dma_mixer{this, 32000};
   MixerFifo m_streaming_mixer{this, 48000};
   MixerFifo m_wiimote_speaker_mixer{this, 3000};
   unsigned int m_sampleRate;
 
   bool m_is_stretching = false;
-  soundtouch::SoundTouch m_sound_touch;
-  double m_stretch_ratio = 1.0;
-  std::array<short, 2> m_last_stretched_sample = {};
+  AudioCommon::AudioStretcher m_stretcher;
   std::array<short, MAX_SAMPLES * 2> m_stretch_buffer;
   std::array<float, MAX_SAMPLES * 2> m_float_conversion_buffer;
 

--- a/Source/Core/AudioCommon/Mixer.h
+++ b/Source/Core/AudioCommon/Mixer.h
@@ -81,7 +81,7 @@ private:
 
   bool m_is_stretching = false;
   AudioCommon::AudioStretcher m_stretcher;
-  std::array<short, MAX_SAMPLES * 2> m_stretch_buffer;
+  std::array<short, MAX_SAMPLES * 2> m_scratch_buffer;
   std::array<float, MAX_SAMPLES * 2> m_float_conversion_buffer;
 
   WaveFileWriter m_wave_writer_dtk;


### PR DESCRIPTION
Pretty straightforward, though testing is a little janky on macOS (OpenAL doesn't support multichannel, so I hacked up CoreAudioStream on my local copy).

Also extracts out @MerryMage's time-stretching logic into an AudioStretcher class and splits it into two functions, to make clear that you can use the same buffer for input and output. Not really sure about this, but it seemed silly to add _another_ intermediate buffer when the existing one works fine.