### PR TITLE
IOS/ES: Implement ES_SetUid

### DIFF
--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -26,6 +26,8 @@ OpenRequest::OpenRequest(const u32 address_) : Request(address_)
 {
   path = Memory::GetString(Memory::Read_U32(address + 0xc));
   flags = static_cast<OpenMode>(Memory::Read_U32(address + 0x10));
+  uid = GetUIDForPPC();
+  gid = GetGIDForPPC();
 }
 
 ReadWriteRequest::ReadWriteRequest(const u32 address_) : Request(address_)

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -92,6 +92,10 @@ struct OpenRequest final : Request
 {
   std::string path;
   OpenMode flags = IOS_OPEN_READ;
+  // The UID and GID are not part of the IPC request sent from the PPC to the Starlet,
+  // but they are set after they reach IOS and are dispatched to the appropriate module.
+  u32 uid = 0;
+  u16 gid = 0;
   explicit OpenRequest(u32 address);
 };
 

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -246,6 +246,9 @@ private:
   u32 m_addtitle_content_id = 0xFFFFFFFF;
   std::vector<u8> m_addtitle_content_buffer;
 
+  u32 m_caller_uid = 0;
+  u16 m_caller_gid = 0;
+
   struct TitleExportContext
   {
     struct ExportContent

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 80;  // Last changed in PR 5309
+static const u32 STATE_VERSION = 81;  // Last changed in PR 5317
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This implements ES_SetUid, which is used by the system menu to change its own permissions. This is required for implementing permission checks and proper NAND metadata support in the future.