### PR TITLE
[HLE] JitIL: Fix unsupported HLE_HOOK_START

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
+++ b/Source/Core/Core/PowerPC/Jit64IL/JitIL.cpp
@@ -317,9 +317,9 @@ void JitIL::FallBackToInterpreter(UGeckoInstruction _inst)
 
 void JitIL::HLEFunction(UGeckoInstruction _inst)
 {
+  ABI_PushRegistersAndAdjustStack({}, 0);
   ABI_CallFunctionCC(HLE::Execute, js.compilerPC, _inst.hex);
-  MOV(32, R(RSCRATCH), PPCSTATE(npc));
-  WriteExitDestInOpArg(R(RSCRATCH));
+  ABI_PopRegistersAndAdjustStack({}, 0);
 }
 
 void JitIL::DoNothing(UGeckoInstruction _inst)
@@ -616,9 +616,9 @@ const u8* JitIL::DoJit(u32 em_address, PPCAnalyst::CodeBuffer* code_buf, JitBloc
           HLEFunction(function);
           if (type == HLE::HLE_HOOK_REPLACE)
           {
-            MOV(32, R(EAX), PPCSTATE(npc));
+            MOV(32, R(RSCRATCH), PPCSTATE(npc));
             js.downcountAmount += js.st.numCycles;
-            WriteExitDestInOpArg(R(EAX));
+            WriteExitDestInOpArg(R(RSCRATCH));
             break;
           }
         }


### PR DESCRIPTION
Basically, JitIL was always replacing HLE functions (sometimes twice) even when the hook type was HLE_HOOK_START.

These lines move the next PC to ```RSCRATCH``` (RAX) and then build an exit by setting the ```PPCSTATE(pc)``` to the next PC which replaces the current function call:
```C++
MOV(32, R(RSCRATCH), PPCSTATE(npc));
WriteExitDestInOpArg(R(RSCRATCH));
```

For consistency, I replaced the ```EAX``` usage with ```RSCRATCH``` where it was and should be called.

Depends on PR https://github.com/dolphin-emu/dolphin/pull/4469.

Ready to be reviewed & merged.