### PR TITLE
WX: Build fix

### DIFF
--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -107,6 +107,12 @@ endif()
 add_executable(dolphin-emu ${SRCS})
 target_link_libraries(dolphin-emu ${LIBS})
 
+if(USE_X11)
+  find_package(GTK2 REQUIRED)
+  target_link_libraries(dolphin-emu ${GTK2_LIBRARIES})
+  target_include_directories(dolphin-emu PRIVATE ${GTK2_INCLUDE_DIRS})
+endif()
+
 # Handle localization
 find_package(Gettext)
 if(GETTEXT_MSGMERGE_EXECUTABLE AND GETTEXT_MSGFMT_EXECUTABLE)

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -105,11 +105,11 @@ if(WIN32)
 endif()
 
 add_executable(dolphin-emu ${SRCS})
-target_link_libraries(dolphin-emu ${LIBS})
+target_link_libraries(dolphin-emu PRIVATE ${LIBS})
 
 if(USE_X11)
   find_package(GTK2 REQUIRED)
-  target_link_libraries(dolphin-emu ${GTK2_LIBRARIES})
+  target_link_libraries(dolphin-emu PRIVATE ${GTK2_LIBRARIES})
   target_include_directories(dolphin-emu PRIVATE ${GTK2_INCLUDE_DIRS})
 endif()
 


### PR DESCRIPTION
GTK2 is a dependency on Linux whenever USE_X11 is true, but we were not linking or adding the include directory for GTK for DolphinWX.

Fixes a regression introduced by 6197d9622 which breaks building on Linux (though apparently not in all cases?)