### PR TITLE
IOS/ES: Drop unnecessary memset for vectors

### DIFF
--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -72,12 +72,6 @@ IOCtlVRequest::IOCtlVRequest(const u32 address_) : Request(address_)
   }
 }
 
-bool IOCtlVRequest::HasInputVectorWithAddress(const u32 vector_address) const
-{
-  return std::any_of(in_vectors.begin(), in_vectors.end(),
-                     [&](const auto& in_vector) { return in_vector.address == vector_address; });
-}
-
 bool IOCtlVRequest::HasNumberOfValidVectors(const size_t in_count, const size_t io_count) const
 {
   if (in_vectors.size() != in_count || io_vectors.size() != io_count)

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -153,7 +153,6 @@ struct IOCtlVRequest final : Request
   std::vector<IOVector> in_vectors;
   std::vector<IOVector> io_vectors;
   explicit IOCtlVRequest(u32 address);
-  bool HasInputVectorWithAddress(u32 vector_address) const;
   bool HasNumberOfValidVectors(size_t in_count, size_t io_count) const;
   void Dump(const std::string& description, LogTypes::LOG_TYPE type = LogTypes::IOS,
             LogTypes::LOG_LEVELS level = LogTypes::LINFO) const;

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -345,13 +345,6 @@ IPCCommandResult ES::IOCtlV(const IOCtlVRequest& request)
 {
   DEBUG_LOG(IOS_ES, "%s (0x%x)", GetDeviceName().c_str(), request.request);
 
-  // Clear the IO buffers. Note that this is unsafe for other ioctlvs.
-  for (const auto& io_vector : request.io_vectors)
-  {
-    if (!request.HasInputVectorWithAddress(io_vector.address))
-      Memory::Memset(io_vector.address, 0, io_vector.size);
-  }
-
   switch (request.request)
   {
   case IOCTL_ES_ADDTICKET:


### PR DESCRIPTION
IOS doesn't do it, and we don't need it anyway, so let's not do it.