### PR TITLE
Unicode correctness

### DIFF
--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -83,7 +83,7 @@
       <!--Enforce some behaviors as standards-conformant when they don't default as such-->
       <AdditionalOptions>/Zc:inline /Zc:rvalueCast /volatile:iso %(AdditionalOptions)</AdditionalOptions>
       <!--Enable detailed debug info-->
-      <AdditionalOptions>/Zo %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zo /utf-8 %(AdditionalOptions)</AdditionalOptions>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <!--
       This is for GetVersionEx being marked as depreciated - which is idiotic and there's


### PR DESCRIPTION
This PR address some unicode issues when building or running Dolphin on systems with non-Latin codepages.

Instead of changing the source files I added the `/utf-8` to the compiler options that ensures all source are parsed with UTF-8 and all strings are encoded with UTF-8 by default.