### PR TITLE
[Android] Fix game banners

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/GameBannerRequestHandler.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/GameBannerRequestHandler.java
@@ -25,7 +25,6 @@ public class GameBannerRequestHandler extends RequestHandler {
 		int height = 32;
 		Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
 		bitmap.setPixels(vector, 0, width, 0, 0, width, height);
-		bitmap.copyPixelsFromBuffer(IntBuffer.wrap(vector));
 		return new Result(bitmap, Picasso.LoadedFrom.DISK);
 	}
 }


### PR DESCRIPTION
Use Bitmap.setPixels() instead of Bitmap.copyPixelsFromBuffer() the former
use non pre-multiplied values of the colors which is what we expect to
come from the native code.