### PR TITLE
Clean up Wiimote* code (comments, casts, underscore variable names)

### DIFF
--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -74,9 +74,9 @@ ControllerEmu::ControlGroup* GetGuitarGroup(int number, WiimoteEmu::GuitarGroup 
 ControllerEmu::ControlGroup* GetDrumsGroup(int number, WiimoteEmu::DrumsGroup group);
 ControllerEmu::ControlGroup* GetTurntableGroup(int number, WiimoteEmu::TurntableGroup group);
 
-void ControlChannel(int _number, u16 _channelID, const void* _pData, u32 _Size);
-void InterruptChannel(int _number, u16 _channelID, const void* _pData, u32 _Size);
-void Update(int _number, bool _connected);
+void ControlChannel(int number, u16 channel_id, const void* data, u32 size);
+void InterruptChannel(int number, u16 channel_id, const void* data, u32 size);
+void Update(int number, bool connected);
 }
 
 namespace WiimoteReal

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Attachment.cpp
@@ -58,7 +58,7 @@ namespace ControllerEmu
 {
 void Extension::GetState(u8* const data)
 {
-  ((WiimoteEmu::Attachment*)attachments[active_extension].get())->GetState(data);
+  static_cast<WiimoteEmu::Attachment*>(attachments[active_extension].get())->GetState(data);
 }
 
 bool Extension::IsButtonPressed() const
@@ -69,9 +69,11 @@ bool Extension::IsButtonPressed() const
   // Wiimotes (can? always?) have their active_extension set to -1, we also have to check the
   // switch_extension
   if (active_extension > 0)
-    return ((WiimoteEmu::Attachment*)attachments[active_extension].get())->IsButtonPressed();
+    return static_cast<WiimoteEmu::Attachment*>(attachments[active_extension].get())
+        ->IsButtonPressed();
   if (switch_extension > 0)
-    return ((WiimoteEmu::Attachment*)attachments[switch_extension].get())->IsButtonPressed();
+    return static_cast<WiimoteEmu::Attachment*>(attachments[switch_extension].get())
+        ->IsButtonPressed();
   return false;
 }
 }  // namespace ControllerEmu

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -82,7 +82,7 @@ Classic::Classic(ExtensionReg& reg) : Attachment(_trans("Classic"), reg)
 
 void Classic::GetState(u8* const data)
 {
-  wm_classic_extension* const ccdata = (wm_classic_extension*)data;
+  wm_classic_extension* const ccdata = reinterpret_cast<wm_classic_extension* const>(data);
   ccdata->bt.hex = 0;
 
   // not using calibration data, o well

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -55,7 +55,7 @@ Drums::Drums(ExtensionReg& reg) : Attachment(_trans("Drums"), reg)
 
 void Drums::GetState(u8* const data)
 {
-  wm_drums_extension* const ddata = (wm_drums_extension*)data;
+  wm_drums_extension* const ddata = reinterpret_cast<wm_drums_extension* const>(data);
   ddata->bt = 0;
 
   // calibration data not figured out yet?

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -69,7 +69,7 @@ Guitar::Guitar(ExtensionReg& reg) : Attachment(_trans("Guitar"), reg)
 
 void Guitar::GetState(u8* const data)
 {
-  wm_guitar_extension* const gdata = (wm_guitar_extension*)data;
+  wm_guitar_extension* const gdata = reinterpret_cast<wm_guitar_extension* const>(data);
   gdata->bt = 0;
 
   // calibration data not figured out yet?

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -55,7 +55,7 @@ Nunchuk::Nunchuk(ExtensionReg& reg) : Attachment(_trans("Nunchuk"), reg)
 
 void Nunchuk::GetState(u8* const data)
 {
-  wm_nc* const ncdata = (wm_nc*)data;
+  wm_nc* const ncdata = reinterpret_cast<wm_nc* const>(data);
   ncdata->bt.hex = 0;
 
   // stick

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -61,7 +61,7 @@ Turntable::Turntable(ExtensionReg& reg) : Attachment(_trans("Turntable"), reg)
 
 void Turntable::GetState(u8* const data)
 {
-  wm_turntable_extension* const ttdata = (wm_turntable_extension*)data;
+  wm_turntable_extension* const ttdata = reinterpret_cast<wm_turntable_extension*>(data);
   ttdata->bt = 0;
 
   // stick

--- a/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/EmuSubroutines.cpp
@@ -92,7 +92,7 @@ void Wiimote::HidOutputReport(const wm_report* const sr, const bool send_ack)
     break;
 
   case RT_REPORT_MODE:  // 0x12
-    ReportMode((wm_report_mode*)sr->data);
+    ReportMode(reinterpret_cast<const wm_report_mode*>(sr->data));
     break;
 
   case RT_IR_PIXEL_CLOCK:  // 0x13
@@ -112,35 +112,27 @@ void Wiimote::HidOutputReport(const wm_report* const sr, const bool send_ack)
 
   case RT_REQUEST_STATUS:  // 0x15
     if (WIIMOTE_SRC_EMU & g_wiimote_sources[m_index])
-      RequestStatus((wm_request_status*)sr->data);
+      RequestStatus(reinterpret_cast<const wm_request_status*>(sr->data));
     return;  // sends its own ack
     break;
 
   case RT_WRITE_DATA:  // 0x16
-    WriteData((wm_write_data*)sr->data);
+    WriteData(reinterpret_cast<const wm_write_data*>(sr->data));
     break;
 
   case RT_READ_DATA:  // 0x17
     if (WIIMOTE_SRC_EMU & g_wiimote_sources[m_index])
-      ReadData((wm_read_data*)sr->data);
+      ReadData(reinterpret_cast<const wm_read_data*>(sr->data));
     return;  // sends its own ack
     break;
 
   case RT_WRITE_SPEAKER_DATA:  // 0x18
-    // wm_speaker_data *spkz = (wm_speaker_data*)sr->data;
-    // ERROR_LOG(WIIMOTE, "RT_WRITE_SPEAKER_DATA len:%x %s", spkz->length,
-    //	ArrayToString(spkz->data, spkz->length, 100, false).c_str());
     if (WIIMOTE_SRC_EMU & g_wiimote_sources[m_index] && !m_speaker_mute)
-      Wiimote::SpeakerData((wm_speaker_data*)sr->data);
+      Wiimote::SpeakerData(reinterpret_cast<const wm_speaker_data*>(sr->data));
     return;  // no ack
     break;
 
   case RT_SPEAKER_MUTE:  // 0x19
-    // ERROR_LOG(WIIMOTE, "WM Speaker Mute: %02x", sr->enable);
-    // PanicAlert( "WM Speaker Mute: %d", sr->data[0] & 0x04 );
-    // testing
-    // if (sr->data[0] & 0x04)
-    //	memset(&m_channel_status, 0, sizeof(m_channel_status));
     m_speaker_mute = sr->enable;
     if (false == sr->ack)
       return;
@@ -150,7 +142,6 @@ void Wiimote::HidOutputReport(const wm_report* const sr, const bool send_ack)
     // comment from old plugin:
     // This enables or disables the IR lights, we update the global variable g_IR
     // so that WmRequestStatus() knows about it
-    // INFO_LOG(WIIMOTE, "WM IR Enable: 0x%02x", sr->data[0]);
     m_status.ir = sr->enable;
     if (false == sr->ack)
       return;
@@ -172,17 +163,17 @@ void Wiimote::HidOutputReport(const wm_report* const sr, const bool send_ack)
    The first two bytes are the core buttons data,
    00 00 means nothing is pressed.
    The last byte is the success code 00. */
-void Wiimote::SendAck(u8 _reportID)
+void Wiimote::SendAck(u8 report_id)
 {
   u8 data[6];
 
   data[0] = 0xA1;
   data[1] = RT_ACK_DATA;
 
-  wm_acknowledge* const ack = (wm_acknowledge*)(data + 2);
+  wm_acknowledge* ack = reinterpret_cast<wm_acknowledge*>(data + 2);
 
   ack->buttons = m_status.buttons;
-  ack->reportID = _reportID;
+  ack->reportID = report_id;
   ack->errorID = 0;
 
   Core::Callback_WiimoteInterruptChannel(m_index, m_reporting_channel, data, sizeof(data));
@@ -208,11 +199,6 @@ void Wiimote::HandleExtensionSwap()
   }
 }
 
-// old comment
-/* Here we produce a 0x20 status report to send to the Wii. We currently ignore
-   the status request rs and all its eventual instructions it may include (for
-   example turn off rumble or something else) and just send the status
-   report. */
 void Wiimote::RequestStatus(const wm_request_status* const rs)
 {
   HandleExtensionSwap();
@@ -226,7 +212,7 @@ void Wiimote::RequestStatus(const wm_request_status* const rs)
   data[1] = RT_STATUS_REPORT;
 
   // status values
-  *(wm_status_report*)(data + 2) = m_status;
+  *reinterpret_cast<wm_status_report*>(data + 2) = m_status;
 
   // hybrid Wiimote stuff
   if (WIIMOTE_SRC_REAL & g_wiimote_sources[m_index] && (m_extension->switch_extension <= 0))
@@ -277,10 +263,9 @@ void Wiimote::WriteData(const wm_write_data* const wd)
     memcpy(m_eeprom + address, wd->data, wd->size);
 
     // write mii data to file
-    // i need to improve this greatly
     if (address >= 0x0FCA && address < 0x12C0)
     {
-      // writing the whole mii block each write :/
+      // TODO Only write parts of the Mii block
       std::ofstream file;
       OpenFStream(file, File::GetUserPath(D_SESSION_WIIROOT_IDX) + "/mii.bin",
                   std::ios::binary | std::ios::out);
@@ -330,9 +315,6 @@ void Wiimote::WriteData(const wm_write_data* const wd)
     case 0xB0:
       region_ptr = &m_reg_ir;
       region_size = WIIMOTE_REG_IR_SIZE;
-
-      // if (5 == m_reg_ir->mode)
-      //	PanicAlert("IR Full Mode is Unsupported!");
       break;
     }
 
@@ -342,14 +324,6 @@ void Wiimote::WriteData(const wm_write_data* const wd)
     }
     else
       return;  // TODO: generate a writedata error reply
-
-    /* TODO?
-    if (region_ptr == &m_reg_speaker)
-    {
-      ERROR_LOG(WIIMOTE, "Write to speaker register %x %s", address,
-        ArrayToString(wd->data, wd->size, 100, false).c_str());
-    }
-    */
 
     if (&m_reg_ext == region_ptr)
     {
@@ -407,7 +381,6 @@ void Wiimote::ReadData(const wm_read_data* const rd)
   {
   case WS_EEPROM:
   {
-    // PanicAlert("ReadData: reading from EEPROM: address: 0x%x size: 0x%x", address, size);
     // Read from EEPROM
     if (address + size >= WIIMOTE_EEPROM_FREE_SIZE)
     {
@@ -422,10 +395,9 @@ void Wiimote::ReadData(const wm_read_data* const rd)
     }
 
     // read mii data from file
-    // i need to improve this greatly
     if (address >= 0x0FCA && address < 0x12C0)
     {
-      // reading the whole mii block :/
+      // TODO Only read the Mii block parts required
       std::ifstream file;
       file.open((File::GetUserPath(D_SESSION_WIIROOT_IDX) + "/mii.bin").c_str(),
                 std::ios::binary | std::ios::in);
@@ -521,23 +493,15 @@ void Wiimote::ReadData(const wm_read_data* const rd)
     delete[] rr.data;
 }
 
-// old comment
-/* Here we produce the actual 0x21 Input report that we send to the Wii. The
-   message is divided into 16 bytes pieces and sent piece by piece. There will
-   be five formatting bytes at the begging of all reports. A common format is
-   00 00 f0 00 20, the 00 00 means that no buttons are pressed, the f means 16
-   bytes in the message, the 0 means no error, the 00 20 means that the message
-   is at the 00 20 offest in the registry that was read.
-*/
-void Wiimote::SendReadDataReply(ReadRequest& _request)
+void Wiimote::SendReadDataReply(ReadRequest& request)
 {
   u8 data[23];
   data[0] = 0xA1;
   data[1] = RT_READ_DATA_REPLY;
 
-  wm_read_data_reply* const reply = (wm_read_data_reply*)(data + 2);
+  wm_read_data_reply* const reply = reinterpret_cast<wm_read_data_reply*>(data + 2);
   reply->buttons = m_status.buttons;
-  reply->address = Common::swap16(_request.address);
+  reply->address = Common::swap16(request.address);
 
   // generate a read error
   // Out of bounds. The real Wiimote generate an error for the first
@@ -545,7 +509,7 @@ void Wiimote::SendReadDataReply(ReadRequest& _request)
   // read the calibration data at the beginning of Eeprom. I think this
   // error is supposed to occur when we try to read above the freely
   // usable space that ends at 0x16ff.
-  if (0 == _request.size)
+  if (0 == request.size)
   {
     reply->size = 0x0f;
     reply->error = 0x08;
@@ -556,7 +520,7 @@ void Wiimote::SendReadDataReply(ReadRequest& _request)
   {
     // Limit the amt to 16 bytes
     // AyuanX: the MTU is 640B though... what a waste!
-    const int amt = std::min((unsigned int)16, _request.size);
+    const int amt = std::min((unsigned int)16, request.size);
 
     // no error
     reply->error = 0;
@@ -568,12 +532,12 @@ void Wiimote::SendReadDataReply(ReadRequest& _request)
     memset(reply->data, 0, sizeof(reply->data));
 
     // copy piece of mem
-    memcpy(reply->data, _request.data + _request.position, amt);
+    memcpy(reply->data, request.data + request.position, amt);
 
     // update request struct
-    _request.size -= amt;
-    _request.position += amt;
-    _request.address += amt;
+    request.size -= amt;
+    request.position += amt;
+    request.address += amt;
   }
 
   // Send a piece

--- a/Source/Core/Core/HW/WiimoteEmu/Encryption.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Encryption.cpp
@@ -253,11 +253,6 @@ void WiimoteGenerateKey(wiimote_key* const key, const u8* const keydata)
   for (int i = 0; i < 6; ++i)
     skey[5 - i] = keydata[i + 10];
 
-  // DEBUG_LOG(WIIMOTE, "rand: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x", rand[0], rand[1],
-  // rand[2], rand[3], rand[4], rand[5], rand[6], rand[7], rand[8], rand[9]);
-  // DEBUG_LOG(WIIMOTE, "key:  %02x %02x %02x %02x %02x %02x", skey[0], skey[1], skey[2], skey[3],
-  // skey[4], skey[5]);
-
   for (idx = 0; idx < 7; ++idx)
   {
     GenerateKey(rand, idx, testkey);
@@ -265,14 +260,8 @@ void WiimoteGenerateKey(wiimote_key* const key, const u8* const keydata)
       break;
   }
   // default case is idx = 7 which is valid (homebrew uses it for the 0x17 case)
-  // DEBUG_LOG(WIIMOTE, "idx:  %d", idx);
 
   GenerateTables(rand, skey, idx, key->ft, key->sb);
-
-  // DEBUG_LOG(WIIMOTE, "ft:   %02x %02x %02x %02x %02x %02x %02x %02x", key->ft[0], key->ft[1],
-  // key->ft[2], key->ft[3], key->ft[4], key->ft[5], key->ft[6], key->ft[7]);
-  // DEBUG_LOG(WIIMOTE, "sb:   %02x %02x %02x %02x %02x %02x %02x %02x", key->sb[0], key->sb[1],
-  // key->sb[2], key->sb[3], key->sb[4], key->sb[5], key->sb[6], key->sb[7]);
 
   // for homebrew, ft and sb are all 0x97 which is equivalent to 0x17
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -68,7 +68,7 @@ void stopdamnwav()
 }
 #endif
 
-void Wiimote::SpeakerData(wm_speaker_data* sd)
+void Wiimote::SpeakerData(const wm_speaker_data* sd)
 {
   if (!SConfig::GetInstance().m_WiimoteEnableSpeaker)
     return;
@@ -145,7 +145,7 @@ void Wiimote::SpeakerData(wm_speaker_data* sd)
     File::Delete("rmtdump.bin");
     atexit(stopdamnwav);
     OpenFStream(ofile, "rmtdump.bin", ofile.binary | ofile.out);
-    wav.Start("rmtdump.wav", 6000 /*Common::swap16(m_reg_speaker.sample_rate)*/);
+    wav.Start("rmtdump.wav", 6000);
   }
   wav.AddMonoSamples(samples.get(), sd->length * 2);
   if (ofile.good())

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -390,7 +390,6 @@ ControllerEmu::ControlGroup* Wiimote::GetTurntableGroup(TurntableGroup group)
 
 bool Wiimote::Step()
 {
-  // TODO: change this a bit
   m_motion_plus_present = m_motion_plus_setting->GetValue();
 
   m_motor->control_ref->State(m_rumble_on);
@@ -408,7 +407,6 @@ bool Wiimote::Step()
     ReadRequest& rr = m_read_requests.front();
     // send up to 16 bytes to the Wii
     SendReadDataReply(rr);
-    // SendReadDataReply(rr.channel, rr);
 
     // if there is no more data, remove from queue
     if (0 == rr.size)
@@ -461,7 +459,7 @@ void Wiimote::GetButtonData(u8* const data)
     UpdateButtonsStatus();
   }
 
-  ((wm_buttons*)data)->hex |= m_status.buttons.hex;
+  reinterpret_cast<wm_buttons*>(data)->hex |= m_status.buttons.hex;
 }
 
 void Wiimote::GetAccelData(u8* const data, const ReportFeatures& rptf)
@@ -479,8 +477,8 @@ void Wiimote::GetAccelData(u8* const data, const ReportFeatures& rptf)
   EmulateSwing(&m_accel, m_swing, is_sideways, is_upright);
   EmulateShake(&m_accel, m_shake, m_shake_step);
 
-  wm_accel& accel = *(wm_accel*)(data + rptf.accel);
-  wm_buttons& core = *(wm_buttons*)(data + rptf.core);
+  wm_accel& accel = *reinterpret_cast<wm_accel*>(data + rptf.accel);
+  wm_buttons& core = *reinterpret_cast<wm_buttons*>(data + rptf.core);
 
   // We now use 2 bits more precision, so multiply by 4 before converting to int
   s16 x = (s16)(4 * (m_accel.x * ACCEL_RANGE + ACCEL_ZERO_G));
@@ -535,14 +533,11 @@ void Wiimote::GetIRData(u8* const data, bool use_accel)
       nsin = 0;
       ncos = 1;
     }
-    // PanicAlert("%d %d %d\nx:%f\nz:%f\nsin:%f\ncos:%f",accel->x,accel->y,accel->z,ax,az,sin,cos);
-    // PanicAlert("%d %d %d\n%d %d %d\n%d %d
-    // %d",accel->x,accel->y,accel->z,calib->zero_g.x,calib->zero_g.y,calib->zero_g.z,
-    // calib->one_g.x,calib->one_g.y,calib->one_g.z);
   }
   else
   {
-    nsin = 0;  // m_tilt stuff here (can't figure it out yet....)
+    // TODO m_tilt stuff
+    nsin = 0;
     ncos = 1;
   }
 
@@ -584,9 +579,7 @@ void Wiimote::GetIRData(u8* const data, bool use_accel)
   Matrix rot, tot;
   static Matrix scale;
   MatrixScale(scale, 1, camWidth / camHeight, 1);
-  // MatrixIdentity(scale);
   MatrixRotationByZ(rot, ir_sin, ir_cos);
-  // MatrixIdentity(rot);
   MatrixMultiply(tot, scale, rot);
 
   for (int i = 0; i < 4; i++)
@@ -597,10 +590,6 @@ void Wiimote::GetIRData(u8* const data, bool use_accel)
     x[i] = (u16)lround((v[i].x + 1) / 2 * (camWidth - 1));
     y[i] = (u16)lround((v[i].y + 1) / 2 * (camHeight - 1));
   }
-  // PanicAlert("%f %f\n%f %f\n%f %f\n%f %f\n%d %d\n%d %d\n%d %d\n%d %d",
-  //      v[0].x,v[0].y,v[1].x,v[1].y,v[2].x,v[2].y,v[3].x,v[3].y,
-  //      x[0],y[0],x[1],y[1],x[2],y[2],x[3],y[38]);
-
   // Fill report with valid data when full handshake was done
   if (m_reg_ir.data[0x30])
     // ir mode
@@ -610,7 +599,7 @@ void Wiimote::GetIRData(u8* const data, bool use_accel)
     case 1:
     {
       memset(data, 0xFF, 10);
-      wm_ir_basic* const irdata = (wm_ir_basic*)data;
+      wm_ir_basic* const irdata = reinterpret_cast<wm_ir_basic*>(data);
       for (unsigned int i = 0; i < 2; ++i)
       {
         if (x[i * 2] < 1024 && y[i * 2] < 768)
@@ -636,7 +625,7 @@ void Wiimote::GetIRData(u8* const data, bool use_accel)
     case 3:
     {
       memset(data, 0xFF, 12);
-      wm_ir_extended* const irdata = (wm_ir_extended*)data;
+      wm_ir_extended* const irdata = reinterpret_cast<wm_ir_extended*>(data);
       for (unsigned int i = 0; i < 4; ++i)
         if (x[i] < 1024 && y[i] < 768)
         {
@@ -667,41 +656,11 @@ void Wiimote::GetExtData(u8* const data)
   // i think it should be unencrpyted in the register, encrypted when read.
   memcpy(m_reg_ext.controller_data, data, sizeof(wm_nc));  // TODO: Should it be nc specific?
 
-  // motionplus pass-through modes
   if (m_motion_plus_active)
   {
-    switch (m_reg_motion_plus.ext_identifier[0x4])
-    {
-    // nunchuk pass-through mode
-    // Bit 7 of byte 5 is moved to bit 6 of byte 5, overwriting it
-    // Bit 0 of byte 4 is moved to bit 7 of byte 5
-    // Bit 3 of byte 5 is moved to bit 4 of byte 5, overwriting it
-    // Bit 1 of byte 5 is moved to bit 3 of byte 5
-    // Bit 0 of byte 5 is moved to bit 2 of byte 5, overwriting it
-    case 0x5:
-      // data[5] & (1 << 7)
-      // data[4] & (1 << 0)
-      // data[5] & (1 << 3)
-      // data[5] & (1 << 1)
-      // data[5] & (1 << 0)
-      break;
-
-    // classic controller/musical instrument pass-through mode
-    // Bit 0 of Byte 4 is overwritten
-    // Bits 0 and 1 of Byte 5 are moved to bit 0 of Bytes 0 and 1, overwriting
-    case 0x7:
-      // data[4] & (1 << 0)
-      // data[5] & (1 << 0)
-      // data[5] & (1 << 1)
-      break;
-
-    // unknown pass-through mode
-    default:
-      break;
-    }
-
-    ((wm_motionplus_data*)data)->is_mp_data = 0;
-    ((wm_motionplus_data*)data)->extension_connected = m_extension->active_extension;
+    reinterpret_cast<wm_motionplus_data*>(data)->is_mp_data = 0;
+    reinterpret_cast<wm_motionplus_data*>(data)->extension_connected =
+        m_extension->active_extension;
   }
 
   if (0xAA == m_reg_ext.encryption)
@@ -734,7 +693,7 @@ void Wiimote::Update()
       Movie::PlayWiimote(m_index, data, rptf, m_extension->active_extension, m_ext_key))
   {
     if (rptf.core)
-      m_status.buttons = *(wm_buttons*)(data + rptf.core);
+      m_status.buttons = *reinterpret_cast<wm_buttons*>(data + rptf.core);
   }
   else
   {
@@ -770,10 +729,10 @@ void Wiimote::Update()
       std::lock_guard<std::mutex> lk(g_wiimotes_mutex);
       if (g_wiimotes[m_index])
       {
-        const Report& rpt = g_wiimotes[m_index]->ProcessReadQueue();
+        Report& rpt = g_wiimotes[m_index]->ProcessReadQueue();
         if (!rpt.empty())
         {
-          const u8* real_data = rpt.data();
+          u8* real_data = rpt.data();
           switch (real_data[1])
           {
           // use data reports
@@ -791,8 +750,9 @@ void Wiimote::Update()
               // mix real-buttons with emu-buttons in the status struct, and in the report
               if (real_rptf.core && rptf.core)
               {
-                m_status.buttons.hex |= ((wm_buttons*)(real_data + real_rptf.core))->hex;
-                *(wm_buttons*)(data + rptf.core) = m_status.buttons;
+                m_status.buttons.hex |=
+                    reinterpret_cast<wm_buttons*>(real_data + real_rptf.core)->hex;
+                *reinterpret_cast<wm_buttons*>(data + rptf.core) = m_status.buttons;
               }
 
               // accel
@@ -818,10 +778,8 @@ void Wiimote::Update()
 
           // use all status reports, after modification of the extension bit
           case RT_STATUS_REPORT:
-            // if (m_extension->switch_extension)
-            //((wm_status_report*)(real_data + 2))->extension = (m_extension->active_extension > 0);
             if (m_extension->active_extension)
-              ((wm_status_report*)(real_data + 2))->extension = 1;
+              reinterpret_cast<wm_status_report*>(real_data + 2)->extension = 1;
             rptf_size = -1;
             break;
 
@@ -847,7 +805,7 @@ void Wiimote::Update()
   {
     NetPlay_GetWiimoteData(m_index, data, rptf.size, m_reporting_mode);
     if (rptf.core)
-      m_status.buttons = *(wm_buttons*)(data + rptf.core);
+      m_status.buttons = *reinterpret_cast<wm_buttons*>(data + rptf.core);
   }
 
   Movie::CheckWiimoteStatus(m_index, data, rptf, m_extension->active_extension, m_ext_key);
@@ -863,23 +821,23 @@ void Wiimote::Update()
   }
 }
 
-void Wiimote::ControlChannel(const u16 _channelID, const void* _pData, u32 _Size)
+void Wiimote::ControlChannel(const u16 channel_id, const void* data, u32 size)
 {
   // Check for custom communication
-  if (99 == _channelID)
+  if (99 == channel_id)
   {
     // Wii Remote disconnected
     // reset eeprom/register/reporting mode
     Reset();
     if (WIIMOTE_SRC_REAL & g_wiimote_sources[m_index])
-      WiimoteReal::ControlChannel(m_index, _channelID, _pData, _Size);
+      WiimoteReal::ControlChannel(m_index, channel_id, data, size);
     return;
   }
 
   // this all good?
-  m_reporting_channel = _channelID;
+  m_reporting_channel = channel_id;
 
-  const hid_packet* const hidp = (hid_packet*)_pData;
+  const hid_packet* hidp = reinterpret_cast<const hid_packet*>(data);
 
   DEBUG_LOG(WIIMOTE, "Emu ControlChannel (page: %i, type: 0x%02x, param: 0x%02x)", m_index,
             hidp->type, hidp->param);
@@ -899,10 +857,10 @@ void Wiimote::ControlChannel(const u16 _channelID, const void* _pData, u32 _Size
     {
       // AyuanX: My experiment shows Control Channel is never used
       // shuffle2: but lwbt uses this, so we'll do what we must :)
-      HidOutputReport((wm_report*)hidp->data);
+      HidOutputReport(reinterpret_cast<const wm_report*>(hidp->data));
 
       u8 handshake = HID_HANDSHAKE_SUCCESS;
-      Core::Callback_WiimoteInterruptChannel(m_index, _channelID, &handshake, 1);
+      Core::Callback_WiimoteInterruptChannel(m_index, channel_id, &handshake, 1);
     }
     break;
 
@@ -916,12 +874,12 @@ void Wiimote::ControlChannel(const u16 _channelID, const void* _pData, u32 _Size
   }
 }
 
-void Wiimote::InterruptChannel(const u16 _channelID, const void* _pData, u32 _Size)
+void Wiimote::InterruptChannel(const u16 channel_id, const void* data, u32 size)
 {
   // this all good?
-  m_reporting_channel = _channelID;
+  m_reporting_channel = channel_id;
 
-  const hid_packet* const hidp = (hid_packet*)_pData;
+  const hid_packet* hidp = reinterpret_cast<const hid_packet*>(data);
 
   switch (hidp->type)
   {
@@ -930,7 +888,7 @@ void Wiimote::InterruptChannel(const u16 _channelID, const void* _pData, u32 _Si
     {
     case HID_PARAM_OUTPUT:
     {
-      const wm_report* const sr = (wm_report*)hidp->data;
+      const wm_report* sr = reinterpret_cast<const wm_report*>(hidp->data);
 
       if (WIIMOTE_SRC_REAL & g_wiimote_sources[m_index])
       {
@@ -940,11 +898,11 @@ void Wiimote::InterruptChannel(const u16 _channelID, const void* _pData, u32 _Si
         case RT_REQUEST_STATUS:
         case RT_READ_DATA:
           if (WIIMOTE_SRC_REAL == g_wiimote_sources[m_index])
-            WiimoteReal::InterruptChannel(m_index, _channelID, _pData, _Size);
+            WiimoteReal::InterruptChannel(m_index, channel_id, data, size);
           break;
 
         default:
-          WiimoteReal::InterruptChannel(m_index, _channelID, _pData, _Size);
+          WiimoteReal::InterruptChannel(m_index, channel_id, data, size);
           break;
         }
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -198,8 +198,8 @@ public:
   ControllerEmu::ControlGroup* GetTurntableGroup(TurntableGroup group);
 
   void Update();
-  void InterruptChannel(const u16 _channelID, const void* _pData, u32 _Size);
-  void ControlChannel(const u16 _channelID, const void* _pData, u32 _Size);
+  void InterruptChannel(const u16 channel_id, const void* data, u32 size);
+  void ControlChannel(const u16 channel_id, const void* data, u32 size);
   void ConnectOnInput();
   void Reset();
 
@@ -233,12 +233,12 @@ private:
   };
 
   void ReportMode(const wm_report_mode* const dr);
-  void SendAck(const u8 _reportID);
+  void SendAck(const u8 report_id);
   void RequestStatus(const wm_request_status* const rs = nullptr);
   void ReadData(const wm_read_data* const rd);
   void WriteData(const wm_write_data* const wd);
-  void SendReadDataReply(ReadRequest& _request);
-  void SpeakerData(wm_speaker_data* sd);
+  void SendReadDataReply(ReadRequest& request);
+  void SpeakerData(const wm_speaker_data* sd);
   bool NetPlay_GetWiimoteData(int wiimote, u8* data, u8 size, u8 reporting_mode);
 
   // control groups

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.cpp
@@ -81,14 +81,14 @@ void Wiimote::WriteReport(Report rpt)
 }
 
 // to be called from CPU thread
-void Wiimote::QueueReport(u8 rpt_id, const void* _data, unsigned int size)
+void Wiimote::QueueReport(u8 rpt_id, const void* data, unsigned int size)
 {
-  auto const data = static_cast<const u8*>(_data);
+  auto const queue_data = static_cast<const u8*>(data);
 
   Report rpt(size + 2);
   rpt[0] = WR_SET_REPORT | BT_OUTPUT;
   rpt[1] = rpt_id;
-  std::copy_n(data, size, rpt.begin() + 2);
+  std::copy_n(queue_data, size, rpt.begin() + 2);
   WriteReport(std::move(rpt));
 }
 
@@ -142,7 +142,7 @@ void Wiimote::ControlChannel(const u16 channel, const void* const data, const u3
   else
   {
     InterruptChannel(channel, data, size);
-    const hid_packet* const hidp = (hid_packet*)data;
+    const hid_packet* const hidp = reinterpret_cast<const hid_packet* const>(data);
     if (hidp->type == HID_TYPE_SET_REPORT)
     {
       u8 handshake_ok = HID_HANDSHAKE_SUCCESS;
@@ -151,7 +151,7 @@ void Wiimote::ControlChannel(const u16 channel, const void* const data, const u3
   }
 }
 
-void Wiimote::InterruptChannel(const u16 channel, const void* const _data, const u32 size)
+void Wiimote::InterruptChannel(const u16 channel, const void* const data, const u32 size)
 {
   // first interrupt/control channel sent
   if (channel != m_channel)
@@ -163,8 +163,8 @@ void Wiimote::InterruptChannel(const u16 channel, const void* const _data, const
     EmuStart();
   }
 
-  auto const data = static_cast<const u8*>(_data);
-  Report rpt(data, data + size);
+  auto const report_data = static_cast<const u8*>(data);
+  Report rpt(report_data, report_data + size);
   WiimoteEmu::Wiimote* const wm =
       static_cast<WiimoteEmu::Wiimote*>(::Wiimote::GetConfig()->GetController(m_index));
 
@@ -320,7 +320,7 @@ static bool IsDataReport(const Report& rpt)
 }
 
 // Returns the next report that should be sent
-const Report& Wiimote::ProcessReadQueue()
+Report& Wiimote::ProcessReadQueue()
 {
   // Pop through the queued reports
   while (m_read_reports.Pop(m_last_input_report))
@@ -692,7 +692,7 @@ void LoadSettings()
   for (unsigned int i = 0; i < MAX_WIIMOTES; ++i)
   {
     std::string secname("Wiimote");
-    secname += (char)('1' + i);
+    secname += static_cast<char>('1' + i);
     IniFile::Section& sec = *inifile.GetOrCreateSection(secname);
 
     sec.Get("Source", &g_wiimote_sources[i], i ? WIIMOTE_SRC_NONE : WIIMOTE_SRC_EMU);
@@ -858,18 +858,18 @@ void Refresh()
     g_wiimote_scanner.SetScanMode(WiimoteScanMode::SCAN_ONCE);
 }
 
-void InterruptChannel(int _WiimoteNumber, u16 _channelID, const void* _pData, u32 _Size)
+void InterruptChannel(int wiimote_number, u16 channel_id, const void* data, u32 size)
 {
   std::lock_guard<std::mutex> lk(g_wiimotes_mutex);
-  if (g_wiimotes[_WiimoteNumber])
-    g_wiimotes[_WiimoteNumber]->InterruptChannel(_channelID, _pData, _Size);
+  if (g_wiimotes[wiimote_number])
+    g_wiimotes[wiimote_number]->InterruptChannel(channel_id, data, size);
 }
 
-void ControlChannel(int _WiimoteNumber, u16 _channelID, const void* _pData, u32 _Size)
+void ControlChannel(int wiimote_number, u16 channel_id, const void* data, u32 size)
 {
   std::lock_guard<std::mutex> lk(g_wiimotes_mutex);
-  if (g_wiimotes[_WiimoteNumber])
-    g_wiimotes[_WiimoteNumber]->ControlChannel(_channelID, _pData, _Size);
+  if (g_wiimotes[wiimote_number])
+    g_wiimotes[wiimote_number]->ControlChannel(channel_id, data, size);
 }
 
 // Read the Wiimote once

--- a/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
+++ b/Source/Core/Core/HW/WiimoteReal/WiimoteReal.h
@@ -38,7 +38,7 @@ public:
   void Update();
   void ConnectOnInput();
 
-  const Report& ProcessReadQueue();
+  Report& ProcessReadQueue();
 
   void Read();
   bool Write();
@@ -156,10 +156,10 @@ extern std::mutex g_wiimotes_mutex;
 extern WiimoteScanner g_wiimote_scanner;
 extern Wiimote* g_wiimotes[MAX_BBMOTES];
 
-void InterruptChannel(int _WiimoteNumber, u16 _channelID, const void* _pData, u32 _Size);
-void ControlChannel(int _WiimoteNumber, u16 _channelID, const void* _pData, u32 _Size);
-void Update(int _WiimoteNumber);
-void ConnectOnInput(int _WiimoteNumber);
+void InterruptChannel(int wiimote_number, u16 channel_id, const void* data, u32 size);
+void ControlChannel(int wiimote_number, u16 channel_id, const void* data, u32 size);
+void Update(int wiimote_number);
+void ConnectOnInput(int wiimote_number);
 
 void StateChange(EMUSTATE_CHANGE newState);
 void ChangeWiimoteSource(unsigned int index, int source);


### PR DESCRIPTION
Part 2 of my attempt to clean up the Wiimote code somewhat.

~~I tried to preserve most of the const qualifiers where possible but sometimes the const was simply cast aside without any warning due to the nature of C-Casts~~

That turned out to be a mistake on my end...whoops.