### PR TITLE
IOS/ES: Handle contexts properly

### DIFF
--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -154,9 +154,10 @@ ReturnCode Device::Open(const OpenRequest& request)
   return IPC_SUCCESS;
 }
 
-void Device::Close()
+ReturnCode Device::Close(u32 fd)
 {
   m_is_active = false;
+  return IPC_SUCCESS;
 }
 
 IPCCommandResult Device::Unsupported(const Request& request)

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -185,7 +185,7 @@ public:
   // Replies to Open and Close requests are sent by the IPC request handler (HandleCommand),
   // not by the devices themselves.
   virtual ReturnCode Open(const OpenRequest& request);
-  virtual void Close();
+  virtual ReturnCode Close(u32 fd);
   virtual IPCCommandResult Seek(const SeekRequest& seek) { return Unsupported(seek); }
   virtual IPCCommandResult Read(const ReadWriteRequest& read) { return Unsupported(read); }
   virtual IPCCommandResult Write(const ReadWriteRequest& write) { return Unsupported(write); }

--- a/Source/Core/Core/IOS/DeviceStub.cpp
+++ b/Source/Core/Core/IOS/DeviceStub.cpp
@@ -22,12 +22,6 @@ ReturnCode Stub::Open(const OpenRequest& request)
   return IPC_SUCCESS;
 }
 
-void Stub::Close()
-{
-  WARN_LOG(IOS, "%s faking Close()", m_name.c_str());
-  m_is_active = false;
-}
-
 IPCCommandResult Stub::IOCtl(const IOCtlRequest& request)
 {
   WARN_LOG(IOS, "%s faking IOCtl()", m_name.c_str());

--- a/Source/Core/Core/IOS/DeviceStub.h
+++ b/Source/Core/Core/IOS/DeviceStub.h
@@ -22,7 +22,6 @@ public:
   Stub(u32 device_id, const std::string& device_name);
 
   ReturnCode Open(const OpenRequest& request) override;
-  void Close() override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 };

--- a/Source/Core/Core/IOS/ES/Identity.cpp
+++ b/Source/Core/Core/IOS/ES/Identity.cpp
@@ -63,7 +63,7 @@ IPCCommandResult ES::GetConsoleID(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::Encrypt(const IOCtlVRequest& request)
+IPCCommandResult ES::Encrypt(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 2))
     return GetDefaultReply(ES_EINVAL);
@@ -85,7 +85,7 @@ IPCCommandResult ES::Encrypt(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::Decrypt(const IOCtlVRequest& request)
+IPCCommandResult ES::Decrypt(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 2))
     return GetDefaultReply(ES_EINVAL);

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -48,7 +48,7 @@ u32 ES::OpenTitleContent(u32 CFD, u64 TitleID, u16 Index)
   return CFD;
 }
 
-IPCCommandResult ES::OpenTitleContent(const IOCtlVRequest& request)
+IPCCommandResult ES::OpenTitleContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -64,7 +64,7 @@ IPCCommandResult ES::OpenTitleContent(const IOCtlVRequest& request)
   return GetDefaultReply(CFD);
 }
 
-IPCCommandResult ES::OpenContent(const IOCtlVRequest& request)
+IPCCommandResult ES::OpenContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -79,7 +79,7 @@ IPCCommandResult ES::OpenContent(const IOCtlVRequest& request)
   return GetDefaultReply(CFD);
 }
 
-IPCCommandResult ES::ReadContent(const IOCtlVRequest& request)
+IPCCommandResult ES::ReadContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 1))
     return GetDefaultReply(ES_EINVAL);
@@ -131,7 +131,7 @@ IPCCommandResult ES::ReadContent(const IOCtlVRequest& request)
   return GetDefaultReply(Size);
 }
 
-IPCCommandResult ES::CloseContent(const IOCtlVRequest& request)
+IPCCommandResult ES::CloseContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0))
     return GetDefaultReply(ES_EINVAL);
@@ -160,7 +160,7 @@ IPCCommandResult ES::CloseContent(const IOCtlVRequest& request)
   return GetDefaultReply(IPC_SUCCESS);
 }
 
-IPCCommandResult ES::SeekContent(const IOCtlVRequest& request)
+IPCCommandResult ES::SeekContent(u32 uid, const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0))
     return GetDefaultReply(ES_EINVAL);

--- a/Source/Core/Core/IOS/FS/FileIO.cpp
+++ b/Source/Core/Core/IOS/FS/FileIO.cpp
@@ -76,7 +76,7 @@ FileIO::FileIO(u32 device_id, const std::string& device_name)
 {
 }
 
-void FileIO::Close()
+ReturnCode FileIO::Close(u32 fd)
 {
   INFO_LOG(IOS_FILEIO, "FileIO: Close %s (DeviceID=%08x)", m_name.c_str(), m_device_id);
   m_Mode = 0;
@@ -86,6 +86,7 @@ void FileIO::Close()
   m_file.reset();
 
   m_is_active = false;
+  return IPC_SUCCESS;
 }
 
 ReturnCode FileIO::Open(const OpenRequest& request)

--- a/Source/Core/Core/IOS/FS/FileIO.h
+++ b/Source/Core/Core/IOS/FS/FileIO.h
@@ -32,7 +32,7 @@ class FileIO : public Device
 public:
   FileIO(u32 device_id, const std::string& device_name);
 
-  void Close() override;
+  ReturnCode Close(u32 fd) override;
   ReturnCode Open(const OpenRequest& request) override;
   IPCCommandResult Seek(const SeekRequest& request) override;
   IPCCommandResult Read(const ReadWriteRequest& request) override;

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -83,13 +83,13 @@ ReturnCode SDIOSlot0::Open(const OpenRequest& request)
   return IPC_SUCCESS;
 }
 
-void SDIOSlot0::Close()
+ReturnCode SDIOSlot0::Close(u32 fd)
 {
   m_Card.Close();
   m_BlockLength = 0;
   m_BusWidth = 0;
 
-  m_is_active = false;
+  return Device::Close(fd);
 }
 
 IPCCommandResult SDIOSlot0::IOCtl(const IOCtlRequest& request)

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.h
@@ -31,7 +31,7 @@ public:
   void DoState(PointerWrap& p) override;
 
   ReturnCode Open(const OpenRequest& request) override;
-  void Close() override;
+  ReturnCode Close(u32 fd) override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -67,10 +67,10 @@ IPCCommandResult STMImmediate::IOCtl(const IOCtlRequest& request)
   return GetDefaultReply(return_value);
 }
 
-void STMEventHook::Close()
+ReturnCode STMEventHook::Close(u32 fd)
 {
   s_event_hook_request.reset();
-  m_is_active = false;
+  return Device::Close(fd);
 }
 
 IPCCommandResult STMEventHook::IOCtl(const IOCtlRequest& request)

--- a/Source/Core/Core/IOS/STM/STM.h
+++ b/Source/Core/Core/IOS/STM/STM.h
@@ -55,7 +55,7 @@ class STMEventHook final : public Device
 {
 public:
   STMEventHook(u32 device_id, const std::string& device_name) : Device(device_id, device_name) {}
-  void Close() override;
+  ReturnCode Close(u32 fd) override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   void DoState(PointerWrap& p) override;
 

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -147,7 +147,7 @@ bool BluetoothEmu::RemoteDisconnect(u16 _connectionHandle)
   return SendEventDisconnect(_connectionHandle, 0x13);
 }
 
-void BluetoothEmu::Close()
+ReturnCode BluetoothEmu::Close(u32 fd)
 {
   // Clean up state
   m_ScanEnable = 0;
@@ -156,7 +156,7 @@ void BluetoothEmu::Close()
   m_HCIEndpoint.reset();
   m_ACLEndpoint.reset();
 
-  m_is_active = false;
+  return Device::Close(fd);
 }
 
 IPCCommandResult BluetoothEmu::IOCtlV(const IOCtlVRequest& request)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.h
@@ -49,7 +49,7 @@ public:
 
   virtual ~BluetoothEmu();
 
-  void Close() override;
+  ReturnCode Close(u32 fd) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   void Update() override;

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -149,7 +149,7 @@ ReturnCode BluetoothReal::Open(const OpenRequest& request)
   return IPC_SUCCESS;
 }
 
-void BluetoothReal::Close()
+ReturnCode BluetoothReal::Close(u32 fd)
 {
   if (m_handle)
   {
@@ -159,7 +159,7 @@ void BluetoothReal::Close()
     m_handle = nullptr;
   }
 
-  m_is_active = false;
+  return Device::Close(fd);
 }
 
 IPCCommandResult BluetoothReal::IOCtlV(const IOCtlVRequest& request)

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.h
@@ -52,7 +52,7 @@ public:
   ~BluetoothReal() override;
 
   ReturnCode Open(const OpenRequest& request) override;
-  void Close() override;
+  ReturnCode Close(u32 fd) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
 
   void DoState(PointerWrap& p) override;

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -68,9 +68,10 @@ ReturnCode OH0Device::Open(const OpenRequest& request)
   return return_code;
 }
 
-void OH0Device::Close()
+ReturnCode OH0Device::Close(u32 fd)
 {
   m_oh0->DeviceClose(m_device_id);
+  return Device::Close(fd);
 }
 
 IPCCommandResult OH0Device::IOCtl(const IOCtlRequest& request)

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.h
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.h
@@ -25,7 +25,7 @@ public:
   OH0Device(u32 device_id, const std::string& device_name);
 
   ReturnCode Open(const OpenRequest& request) override;
-  void Close() override;
+  ReturnCode Close(u32 fd) override;
   IPCCommandResult IOCtl(const IOCtlRequest& request) override;
   IPCCommandResult IOCtlV(const IOCtlVRequest& request) override;
   void DoState(PointerWrap& p) override;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -71,7 +71,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 81;  // Last changed in PR 5317
+static const u32 STATE_VERSION = 82;  // Last changed in PR 5333
 
 // Maps savestate versions to Dolphin versions.
 // Versions after 42 don't need to be added to this list,


### PR DESCRIPTION
This changes the IOS code to handle ES contexts inside of ES, instead of leaking out implementation details into the IPC request dispatcher.

The intent is to clarify what's shared between every single ES context, and what is specific to an ES context. (Not much.) This should reduce the number of static members in the ES class.

The other changes are there just because we now keep track of the IPC FD inside of ES.

Future plans:

* After the WAD direct launch hack is dropped, the title context will be made a class member.

* Have proper function prototypes, instead of having every single one of them take ioctlv requests. This will allow reusing IOS code in other parts of the Dolphin codebase without having to construct ioctlv requests. This was originally supposed to be part of this PR, but I realised it was already getting too huge, so I'd rather leave this for another time.