### PR TITLE
Fix display of Japanese text in the Memory Card Manager

### DIFF
--- a/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
+++ b/Source/Core/Core/HW/GCMemcard/GCMemcard.cpp
@@ -232,7 +232,7 @@ void GCMemcard::InitDirBatPointers()
 
 bool GCMemcard::IsShiftJIS() const
 {
-  return hdr.Encoding == 1;
+  return hdr.Encoding != 0;
 }
 
 bool GCMemcard::Save()


### PR DESCRIPTION
Regression from PR #4566. When I was going to invert `== 0`, I changed it into `== 1` instead of the correct `!= 0`.