### PR TITLE
D3D: Use blending state from VideoCommon

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DBase.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DBase.cpp
@@ -307,9 +307,9 @@ HRESULT Create(HWND wnd)
   swap_chain_desc.Stereo =
       g_ActiveConfig.iStereoMode == STEREO_QUADBUFFER || factory->IsWindowedStereoEnabled();
 
-#if defined(_DEBUG) || defined(DEBUGFAST)
   // Creating debug devices can sometimes fail if the user doesn't have the correct
   // version of the DirectX SDK. If it does, simply fallback to a non-debug device.
+  if (g_Config.bEnableValidationLayer)
   {
     hr = PD3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr, D3D11_CREATE_DEVICE_DEBUG,
                             supported_feature_levels, NUM_SUPPORTED_FEATURE_LEVELS,
@@ -335,8 +335,7 @@ HRESULT Create(HWND wnd)
     }
   }
 
-  if (FAILED(hr))
-#endif
+  if (!g_Config.bEnableValidationLayer || FAILED(hr))
   {
     hr = PD3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr, 0, supported_feature_levels,
                             NUM_SUPPORTED_FEATURE_LEVELS, D3D11_SDK_VERSION, &device, &featlevel,

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -12,7 +12,7 @@
 #include "Common/BitField.h"
 #include "Common/CommonTypes.h"
 #include "VideoBackends/D3D/D3DBase.h"
-#include "VideoCommon/BPMemory.h"
+#include "VideoCommon/RenderState.h"
 
 struct ID3D11BlendState;
 struct ID3D11DepthStencilState;
@@ -23,18 +23,6 @@ namespace DX11
 union RasterizerState
 {
   BitField<0, 2, D3D11_CULL_MODE> cull_mode;
-
-  u32 packed;
-};
-
-union BlendState
-{
-  BitField<0, 1, u32> blend_enable;
-  BitField<1, 3, D3D11_BLEND_OP> blend_op;
-  BitField<4, 4, u32> write_mask;
-  BitField<8, 5, D3D11_BLEND> src_blend;
-  BitField<13, 5, D3D11_BLEND> dst_blend;
-  BitField<18, 1, u32> use_dst_alpha;
 
   u32 packed;
 };
@@ -59,7 +47,7 @@ public:
   // Get existing or create new render state.
   // Returned objects is owned by the cache and does not need to be released.
   ID3D11SamplerState* Get(SamplerState state);
-  ID3D11BlendState* Get(BlendState state);
+  ID3D11BlendState* Get(BlendingState state);
   ID3D11RasterizerState* Get(RasterizerState state);
   ID3D11DepthStencilState* Get(ZMode state);
 

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -640,11 +640,9 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
                                    FramebufferManager::GetEFBDepthTexture()->GetDSV());
 }
 
-void Renderer::SetBlendMode(bool forceUpdate)
+void Renderer::SetBlendingState(const BlendingState& state)
 {
-  BlendingState state;
-  state.Generate(bpmem);
-  gx_state.blend.hex = state.hex;
+  s_gx_state.blend.hex = state.hex;
 }
 
 // This function has the final picture. We adjust the aspect ratio here.

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -19,12 +19,10 @@ public:
   Renderer();
   ~Renderer() override;
 
-  void SetColorMask() override;
   void SetBlendMode(bool forceUpdate) override;
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
   void SetDepthMode() override;
-  void SetLogicOpMode() override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;
   void SetViewport() override;

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -19,7 +19,7 @@ public:
   Renderer();
   ~Renderer() override;
 
-  void SetBlendMode(bool forceUpdate) override;
+  void SetBlendingState(const BlendingState& state) override;
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
   void SetDepthMode() override;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1264,11 +1264,8 @@ void Renderer::ReinterpretPixelData(unsigned int convtype)
   }
 }
 
-void Renderer::SetBlendMode(bool forceUpdate)
+void Renderer::SetBlendingState(const BlendingState& state)
 {
-  BlendingState state;
-  state.Generate(bpmem);
-
   bool useDualSource =
       state.usedualsrc && g_ActiveConfig.backend_info.bSupportsDualSourceBlend &&
       (!DriverDetails::HasBug(DriverDetails::BUG_BROKEN_DUAL_SOURCE_BLENDING) || state.dstalpha);
@@ -1791,7 +1788,7 @@ void Renderer::RestoreAPIState()
   SetGenerationMode();
   BPFunctions::SetScissor();
   SetDepthMode();
-  SetBlendMode(true);
+  BPFunctions::SetBlendMode();
   SetViewport();
 
   ProgramShaderCache::BindLastVertexFormat();

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -77,7 +77,7 @@ public:
   void Init();
   void Shutdown();
 
-  void SetBlendMode(bool forceUpdate) override;
+  void SetBlendingState(const BlendingState& state) override;
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
   void SetDepthMode() override;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -1340,11 +1340,8 @@ void Renderer::SetDepthMode()
   StateTracker::GetInstance()->SetDepthStencilState(new_ds_state);
 }
 
-void Renderer::SetBlendMode(bool force_update)
+void Renderer::SetBlendingState(const BlendingState& state)
 {
-  BlendingState state;
-  state.Generate(bpmem);
-
   StateTracker::GetInstance()->SetBlendState(state);
 }
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -56,7 +56,7 @@ public:
   void ResetAPIState() override;
   void RestoreAPIState() override;
 
-  void SetBlendMode(bool force_update) override;
+  void SetBlendingState(const BlendingState& state) override;
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
   void SetDepthMode() override;

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -75,16 +75,6 @@ void SetBlendMode()
   g_renderer->SetBlendMode(false);
 }
 
-void SetLogicOpMode()
-{
-  g_renderer->SetLogicOpMode();
-}
-
-void SetColorMask()
-{
-  g_renderer->SetColorMask();
-}
-
 /* Explanation of the magic behind ClearScreen:
   There's numerous possible formats for the pixel data in the EFB.
   However, in the HW accelerated backends we're always using RGBA8

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -8,6 +8,7 @@
 #include "VideoCommon/BPFunctions.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/RenderBase.h"
+#include "VideoCommon/RenderState.h"
 #include "VideoCommon/VertexManagerBase.h"
 #include "VideoCommon/VideoCommon.h"
 #include "VideoCommon/VideoConfig.h"
@@ -72,7 +73,9 @@ void SetDepthMode()
 
 void SetBlendMode()
 {
-  g_renderer->SetBlendMode(false);
+  BlendingState state;
+  state.Generate(bpmem);
+  g_renderer->SetBlendingState(state);
 }
 
 /* Explanation of the magic behind ClearScreen:

--- a/Source/Core/VideoCommon/BPFunctions.h
+++ b/Source/Core/VideoCommon/BPFunctions.h
@@ -19,8 +19,6 @@ void SetGenerationMode();
 void SetScissor();
 void SetDepthMode();
 void SetBlendMode();
-void SetLogicOpMode();
-void SetColorMask();
 void ClearScreen(const EFBRectangle& rc);
 void OnPixelFormatChange();
 void SetInterlacingMode(const BPCmd& bp);

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -148,17 +148,7 @@ static void BPWritten(const BPCmd& bp)
                bpmem.blendmode.dstfactor.Value(), bpmem.blendmode.srcfactor.Value(),
                bpmem.blendmode.subtract.Value(), bpmem.blendmode.logicmode.Value());
 
-      // Set Blending Mode
-      if (bp.changes)
-        SetBlendMode();
-
-      // Set LogicOp Blending Mode
-      if (bp.changes & 0xF002)  // logicopenable | logicmode
-        SetLogicOpMode();
-
-      // Set Color Mask
-      if (bp.changes & 0x18)  // colorupdate | alphaupdate
-        SetColorMask();
+      SetBlendMode();
 
       // Dither
       if (bp.changes & 0x04)
@@ -331,7 +321,6 @@ static void BPWritten(const BPCmd& bp)
     if (bp.changes)
     {
       PixelShaderManager::SetAlphaTestChanged();
-      g_renderer->SetColorMask();
       SetBlendMode();
     }
     return;
@@ -420,11 +409,7 @@ static void BPWritten(const BPCmd& bp)
   case BPMEM_ZCOMPARE:  // Set the Z-Compare and EFB pixel format
     OnPixelFormatChange();
     if (bp.changes & 7)
-    {
       SetBlendMode();  // dual source could be activated by changing to PIXELFMT_RGBA6_Z24
-      g_renderer->SetColorMask();  // alpha writing needs to be disabled if the new pixel format
-                                   // doesn't have an alpha channel
-    }
     PixelShaderManager::SetZModeControl();
     return;
 
@@ -1414,8 +1399,6 @@ void BPReload()
   SetGenerationMode();
   SetScissor();
   SetDepthMode();
-  SetLogicOpMode();
   SetBlendMode();
-  SetColorMask();
   OnPixelFormatChange();
 }

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -29,6 +29,7 @@
 #include "VideoCommon/AVIDump.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/FPSCounter.h"
+#include "VideoCommon/RenderState.h"
 #include "VideoCommon/VideoCommon.h"
 
 class PostProcessingShaderImplementation;
@@ -63,7 +64,7 @@ public:
     PP_EFB_COPY_CLOCKS
   };
 
-  virtual void SetBlendMode(bool forceUpdate) {}
+  virtual void SetBlendingState(const BlendingState& state) {}
   virtual void SetScissorRect(const EFBRectangle& rc) {}
   virtual void SetGenerationMode() {}
   virtual void SetDepthMode() {}

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -63,12 +63,10 @@ public:
     PP_EFB_COPY_CLOCKS
   };
 
-  virtual void SetColorMask() {}
   virtual void SetBlendMode(bool forceUpdate) {}
   virtual void SetScissorRect(const EFBRectangle& rc) {}
   virtual void SetGenerationMode() {}
   virtual void SetDepthMode() {}
-  virtual void SetLogicOpMode() {}
   virtual void SetSamplerState(int stage, int texindex, bool custom_tex) {}
   virtual void SetInterlacingMode() {}
   virtual void SetViewport() {}


### PR DESCRIPTION
Decent removal of code from the backends. Also makes the validation layers checkbox from graphics options work on the D3D backends.

I've changed SetBlendState to take a blendstate parameter, this way the backend isn't reading the emulated GPU state directly (helpful for the goal of VideoCommon-based command lists, if we ever go down that path).

**Note:** This drops the logic op emulation with blending state. I doubt this is a big deal, since it was never close to accurate anyway.