### PR TITLE
[Android] Fix edit controls layout

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -468,7 +468,11 @@ public final class EmulationActivity extends AppCompatActivity
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item)
 	{
-		handleMenuAction(buttonsActionsMap.get(item.getItemId()));
+		int action = buttonsActionsMap.get(item.getItemId(), -1);
+		if (action >= 0)
+		{
+			handleMenuAction(action);
+		}
 		return true;
 	}
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/LoadStateFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/LoadStateFragment.java
@@ -62,6 +62,10 @@ public final class LoadStateFragment extends Fragment implements View.OnClickLis
 	@Override
 	public void onClick(View button)
 	{
-		((EmulationActivity) getActivity()).handleMenuAction(buttonsActionsMap.get(button.getId()));
+		int action = buttonsActionsMap.get(button.getId(), -1);
+		if (action >= 0)
+		{
+			((EmulationActivity) getActivity()).handleMenuAction(action);
+		}
 	}
 }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/MenuFragment.java
@@ -54,7 +54,11 @@ public final class MenuFragment extends Fragment implements View.OnClickListener
 	@Override
 	public void onClick(View button)
 	{
-		((EmulationActivity) getActivity()).handleMenuAction(buttonsActionsMap.get(button.getId()));
+		int action = buttonsActionsMap.get(button.getId());
+		if (action >= 0)
+		{
+			((EmulationActivity) getActivity()).handleMenuAction(action);
+		}
 	}
 
 	public void setTitleText(String title)

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/SaveStateFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/fragments/SaveStateFragment.java
@@ -62,6 +62,10 @@ public final class SaveStateFragment extends Fragment implements View.OnClickLis
 	@Override
 	public void onClick(View button)
 	{
-		((EmulationActivity) getActivity()).handleMenuAction(buttonsActionsMap.get(button.getId()));
+		int action = buttonsActionsMap.get(button.getId(), -1);
+		if (action >= 0)
+		{
+			((EmulationActivity) getActivity()).handleMenuAction(action);
+		}
 	}
 }


### PR DESCRIPTION
Not checking the none existing key in the buttonsActionsMap
leads to break the sub menu of the configure controls menu
on Android phones.