### PR TITLE
PPCAnalyst: Prevent a crash when outside the RAM

### DIFF
--- a/Source/Core/Core/PowerPC/PPCAnalyst.cpp
+++ b/Source/Core/Core/PowerPC/PPCAnalyst.cpp
@@ -90,7 +90,7 @@ bool AnalyzeFunction(u32 startAddr, Symbol& func, int max_size)
   while (true)
   {
     func.size += 4;
-    if (func.size >= CODEBUFFER_SIZE * 4)  // weird
+    if (func.size >= CODEBUFFER_SIZE * 4 || !PowerPC::HostIsRAMAddress(addr))  // weird
       return false;
 
     if (max_size && func.size > max_size)


### PR DESCRIPTION
This PR prevents Dolphin to crash when analyzing a function that is going beyond the RAM.

Ready to be reviewed & merged.