### PR TITLE
Move depth, rasterization and sampler states to VideoCommon

### DIFF
--- a/Source/Core/Common/BitField.h
+++ b/Source/Core/Common/BitField.h
@@ -136,7 +136,7 @@ public:
 
   __forceinline BitField& operator=(T val)
   {
-    storage = (storage & ~GetMask()) | ((val << position) & GetMask());
+    storage = (storage & ~GetMask()) | ((static_cast<StorageType>(val) << position) & GetMask());
     return *this;
   }
 

--- a/Source/Core/VideoBackends/D3D/D3DState.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DState.cpp
@@ -456,10 +456,9 @@ ID3D11RasterizerState* StateCache::Get(RasterizerState state)
   return res;
 }
 
-ID3D11DepthStencilState* StateCache::Get(ZMode state)
+ID3D11DepthStencilState* StateCache::Get(DepthState state)
 {
   auto it = m_depth.find(state.hex);
-
   if (it != m_depth.end())
     return it->second;
 
@@ -472,6 +471,7 @@ ID3D11DepthStencilState* StateCache::Get(ZMode state)
   depthdc.StencilReadMask = D3D11_DEFAULT_STENCIL_READ_MASK;
   depthdc.StencilWriteMask = D3D11_DEFAULT_STENCIL_WRITE_MASK;
 
+  // Less/greater are swapped due to inverted depth.
   const D3D11_COMPARISON_FUNC d3dCmpFuncs[8] = {
       D3D11_COMPARISON_NEVER,         D3D11_COMPARISON_GREATER, D3D11_COMPARISON_EQUAL,
       D3D11_COMPARISON_GREATER_EQUAL, D3D11_COMPARISON_LESS,    D3D11_COMPARISON_NOT_EQUAL,

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -20,20 +20,6 @@ struct ID3D11RasterizerState;
 
 namespace DX11
 {
-union SamplerState
-{
-  BitField<0, 3, u64> min_filter;
-  BitField<3, 1, u64> mag_filter;
-  BitField<4, 8, u64> min_lod;
-  BitField<12, 8, u64> max_lod;
-  BitField<20, 8, s64> lod_bias;
-  BitField<28, 2, u64> wrap_s;
-  BitField<30, 2, u64> wrap_t;
-  BitField<32, 5, u64> max_anisotropy;
-
-  u64 packed;
-};
-
 class StateCache
 {
 public:
@@ -54,7 +40,7 @@ private:
   std::unordered_map<u32, ID3D11DepthStencilState*> m_depth;
   std::unordered_map<u32, ID3D11RasterizerState*> m_raster;
   std::unordered_map<u32, ID3D11BlendState*> m_blend;
-  std::unordered_map<u64, ID3D11SamplerState*> m_sampler;
+  std::unordered_map<u32, ID3D11SamplerState*> m_sampler;
 };
 
 namespace D3D

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -49,7 +49,7 @@ public:
   ID3D11SamplerState* Get(SamplerState state);
   ID3D11BlendState* Get(BlendingState state);
   ID3D11RasterizerState* Get(RasterizerState state);
-  ID3D11DepthStencilState* Get(ZMode state);
+  ID3D11DepthStencilState* Get(DepthState state);
 
   // Release all cached states and clear hash tables.
   void Clear();

--- a/Source/Core/VideoBackends/D3D/D3DState.h
+++ b/Source/Core/VideoBackends/D3D/D3DState.h
@@ -20,13 +20,6 @@ struct ID3D11RasterizerState;
 
 namespace DX11
 {
-union RasterizerState
-{
-  BitField<0, 2, D3D11_CULL_MODE> cull_mode;
-
-  u32 packed;
-};
-
 union SamplerState
 {
   BitField<0, 3, u64> min_filter;
@@ -48,11 +41,14 @@ public:
   // Returned objects is owned by the cache and does not need to be released.
   ID3D11SamplerState* Get(SamplerState state);
   ID3D11BlendState* Get(BlendingState state);
-  ID3D11RasterizerState* Get(RasterizerState state);
+  ID3D11RasterizerState* Get(RasterizationState state);
   ID3D11DepthStencilState* Get(DepthState state);
 
   // Release all cached states and clear hash tables.
   void Clear();
+
+  // Convert RasterState primitive type to D3D11 primitive topology.
+  static D3D11_PRIMITIVE_TOPOLOGY GetPrimitiveTopology(PrimitiveType primitive);
 
 private:
   std::unordered_map<u32, ID3D11DepthStencilState*> m_depth;

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.cpp
@@ -207,7 +207,7 @@ void GeometryShaderCache::Shutdown()
   g_gs_disk_cache.Close();
 }
 
-bool GeometryShaderCache::SetShader(u32 primitive_type)
+bool GeometryShaderCache::SetShader(PrimitiveType primitive_type)
 {
   GeometryShaderUid uid = GetGeometryShaderUid(primitive_type);
   if (last_entry && uid == last_uid)

--- a/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
+++ b/Source/Core/VideoBackends/D3D/GeometryShaderCache.h
@@ -18,7 +18,7 @@ public:
   static void Reload();
   static void Clear();
   static void Shutdown();
-  static bool SetShader(u32 primitive_type);
+  static bool SetShader(PrimitiveType primitive_type);
   static bool CompileShader(const GeometryShaderUid& uid);
   static bool InsertByteCode(const GeometryShaderUid& uid, const u8* bytecode, size_t len);
   static void PrecompileShaders();

--- a/Source/Core/VideoBackends/D3D/Render.cpp
+++ b/Source/Core/VideoBackends/D3D/Render.cpp
@@ -60,7 +60,7 @@ struct GXPipelineState
 {
   std::array<SamplerState, 8> samplers;
   BlendingState blend;
-  ZMode zmode;
+  DepthState zmode;
   RasterizerState raster;
 };
 
@@ -916,9 +916,9 @@ void Renderer::SetGenerationMode()
   s_gx_state.raster.cull_mode = d3d_cull_modes[bpmem.genMode.cullmode];
 }
 
-void Renderer::SetDepthMode()
+void Renderer::SetDepthState(const DepthState& state)
 {
-  s_gx_state.zmode.hex = bpmem.zmode.hex;
+  s_gx_state.zmode.hex = state.hex;
 }
 
 void Renderer::SetSamplerState(int stage, int texindex, bool custom_tex)

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -21,7 +21,7 @@ public:
 
   void SetBlendingState(const BlendingState& state) override;
   void SetScissorRect(const EFBRectangle& rc) override;
-  void SetGenerationMode() override;
+  void SetRasterizationState(const RasterizationState& state) override;
   void SetDepthState(const DepthState& state) override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;
@@ -32,9 +32,6 @@ public:
   // TODO: Fix confusing names (see ResetAPIState and RestoreAPIState)
   void ApplyState() override;
   void RestoreState() override;
-
-  void ApplyCullDisable();
-  void RestoreCull();
 
   void RenderText(const std::string& text, int left, int top, u32 color) override;
 

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -23,7 +23,7 @@ public:
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetRasterizationState(const RasterizationState& state) override;
   void SetDepthState(const DepthState& state) override;
-  void SetSamplerState(int stage, int texindex, bool custom_tex) override;
+  void SetSamplerState(u32 index, const SamplerState& state) override;
   void SetInterlacingMode() override;
   void SetViewport() override;
   void SetFullscreen(bool enable_fullscreen) override;

--- a/Source/Core/VideoBackends/D3D/Render.h
+++ b/Source/Core/VideoBackends/D3D/Render.h
@@ -22,7 +22,7 @@ public:
   void SetBlendingState(const BlendingState& state) override;
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
-  void SetDepthMode() override;
+  void SetDepthState(const DepthState& state) override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;
   void SetViewport() override;

--- a/Source/Core/VideoBackends/D3D/VertexManager.cpp
+++ b/Source/Core/VideoBackends/D3D/VertexManager.cpp
@@ -127,28 +127,10 @@ void VertexManager::Draw(u32 stride)
   u32 baseVertex = m_vertexDrawOffset / stride;
   u32 startIndex = m_indexDrawOffset / sizeof(u16);
 
-  switch (m_current_primitive_type)
-  {
-  case PRIMITIVE_POINTS:
-    D3D::stateman->SetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_POINTLIST);
-    static_cast<Renderer*>(g_renderer.get())->ApplyCullDisable();
-    break;
-  case PRIMITIVE_LINES:
-    D3D::stateman->SetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_LINELIST);
-    static_cast<Renderer*>(g_renderer.get())->ApplyCullDisable();
-    break;
-  case PRIMITIVE_TRIANGLES:
-    D3D::stateman->SetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-    break;
-  }
-
   D3D::stateman->Apply();
   D3D::context->DrawIndexed(indices, startIndex, baseVertex);
 
   INCSTAT(stats.thisFrame.numDrawCalls);
-
-  if (m_current_primitive_type != PRIMITIVE_TRIANGLES)
-    static_cast<Renderer*>(g_renderer.get())->RestoreCull();
 }
 
 void VertexManager::vFlush()

--- a/Source/Core/VideoBackends/Null/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/Null/ShaderCache.cpp
@@ -33,7 +33,7 @@ void ShaderCache<Uid>::Clear()
 }
 
 template <typename Uid>
-bool ShaderCache<Uid>::SetShader(u32 primitive_type)
+bool ShaderCache<Uid>::SetShader(PrimitiveType primitive_type)
 {
   Uid uid = GetUid(primitive_type, APIType::OpenGL);
 

--- a/Source/Core/VideoBackends/Null/ShaderCache.h
+++ b/Source/Core/VideoBackends/Null/ShaderCache.h
@@ -22,10 +22,10 @@ public:
   virtual ~ShaderCache();
 
   void Clear();
-  bool SetShader(u32 primitive_type);
+  bool SetShader(PrimitiveType primitive_type);
 
 protected:
-  virtual Uid GetUid(u32 primitive_type, APIType api_type) = 0;
+  virtual Uid GetUid(PrimitiveType primitive_type, APIType api_type) = 0;
   virtual ShaderCode GenerateCode(APIType api_type, Uid uid) = 0;
 
 private:
@@ -40,7 +40,7 @@ public:
   static std::unique_ptr<VertexShaderCache> s_instance;
 
 protected:
-  VertexShaderUid GetUid(u32 primitive_type, APIType api_type) override
+  VertexShaderUid GetUid(PrimitiveType primitive_type, APIType api_type) override
   {
     return GetVertexShaderUid();
   }
@@ -56,7 +56,7 @@ public:
   static std::unique_ptr<GeometryShaderCache> s_instance;
 
 protected:
-  GeometryShaderUid GetUid(u32 primitive_type, APIType api_type) override
+  GeometryShaderUid GetUid(PrimitiveType primitive_type, APIType api_type) override
   {
     return GetGeometryShaderUid(primitive_type);
   }
@@ -72,7 +72,7 @@ public:
   static std::unique_ptr<PixelShaderCache> s_instance;
 
 protected:
-  PixelShaderUid GetUid(u32 primitive_type, APIType api_type) override
+  PixelShaderUid GetUid(PrimitiveType primitive_type, APIType api_type) override
   {
     return GetPixelShaderUid();
   }

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -221,7 +221,8 @@ void ProgramShaderCache::UploadConstants()
   }
 }
 
-SHADER* ProgramShaderCache::SetShader(u32 primitive_type, const GLVertexFormat* vertex_format)
+SHADER* ProgramShaderCache::SetShader(PrimitiveType primitive_type,
+                                      const GLVertexFormat* vertex_format)
 {
   if (g_ActiveConfig.bDisableSpecializedShaders)
     return SetUberShader(primitive_type, vertex_format);
@@ -292,7 +293,8 @@ SHADER* ProgramShaderCache::SetShader(u32 primitive_type, const GLVertexFormat* 
   return &last_entry->shader;
 }
 
-SHADER* ProgramShaderCache::SetUberShader(u32 primitive_type, const GLVertexFormat* vertex_format)
+SHADER* ProgramShaderCache::SetUberShader(PrimitiveType primitive_type,
+                                          const GLVertexFormat* vertex_format)
 {
   UBERSHADERUID uid;
   std::memset(&uid, 0, sizeof(uid));
@@ -1295,7 +1297,7 @@ void ProgramShaderCache::DestroyPrerenderArrays(SharedContextData* data)
   }
 }
 
-void ProgramShaderCache::DrawPrerenderArray(const SHADER& shader, u32 primitive_type)
+void ProgramShaderCache::DrawPrerenderArray(const SHADER& shader, PrimitiveType primitive_type)
 {
   // This is called on a worker thread, so we don't want to use the normal binding process.
   glUseProgram(shader.glprogid);
@@ -1303,14 +1305,17 @@ void ProgramShaderCache::DrawPrerenderArray(const SHADER& shader, u32 primitive_
   // The number of primitives drawn depends on the type.
   switch (primitive_type)
   {
-  case PRIMITIVE_POINTS:
+  case PrimitiveType::Points:
     glDrawElements(GL_POINTS, 1, GL_UNSIGNED_SHORT, nullptr);
     break;
-  case PRIMITIVE_LINES:
+  case PrimitiveType::Lines:
     glDrawElements(GL_LINES, 2, GL_UNSIGNED_SHORT, nullptr);
     break;
-  case PRIMITIVE_TRIANGLES:
+  case PrimitiveType::Triangles:
     glDrawElements(GL_TRIANGLES, 3, GL_UNSIGNED_SHORT, nullptr);
+    break;
+  case PrimitiveType::TriangleStrip:
+    glDrawElements(GL_TRIANGLE_STRIP, 3, GL_UNSIGNED_SHORT, nullptr);
     break;
   }
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -1119,7 +1119,8 @@ bool ProgramShaderCache::ShaderCompileWorkItem::Compile()
     gcode = GenerateGeometryShaderCode(APIType::OpenGL, host_config, m_uid.guid.GetUidData());
 
   CompileShader(m_program, vcode.GetBuffer(), pcode.GetBuffer(), gcode.GetBuffer());
-  DrawPrerenderArray(m_program, m_uid.guid.GetUidData()->primitive_type);
+  DrawPrerenderArray(m_program,
+                     static_cast<PrimitiveType>(m_uid.guid.GetUidData()->primitive_type));
   return true;
 }
 
@@ -1157,7 +1158,8 @@ bool ProgramShaderCache::UberShaderCompileWorkItem::Compile()
     gcode = GenerateGeometryShaderCode(APIType::OpenGL, host_config, m_uid.guid.GetUidData());
 
   CompileShader(m_program, vcode.GetBuffer(), pcode.GetBuffer(), gcode.GetBuffer());
-  DrawPrerenderArray(m_program, m_uid.guid.GetUidData()->primitive_type);
+  DrawPrerenderArray(m_program,
+                     static_cast<PrimitiveType>(m_uid.guid.GetUidData()->primitive_type));
   return true;
 }
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.h
@@ -94,8 +94,8 @@ public:
   };
 
   static PCacheEntry GetShaderProgram();
-  static SHADER* SetShader(u32 primitive_type, const GLVertexFormat* vertex_format);
-  static SHADER* SetUberShader(u32 primitive_type, const GLVertexFormat* vertex_format);
+  static SHADER* SetShader(PrimitiveType primitive_type, const GLVertexFormat* vertex_format);
+  static SHADER* SetUberShader(PrimitiveType primitive_type, const GLVertexFormat* vertex_format);
   static void BindVertexFormat(const GLVertexFormat* vertex_format);
   static void InvalidateVertexFormat();
   static void BindLastVertexFormat();
@@ -198,7 +198,7 @@ private:
   static void DestroyShaders();
   static void CreatePrerenderArrays(SharedContextData* data);
   static void DestroyPrerenderArrays(SharedContextData* data);
-  static void DrawPrerenderArray(const SHADER& shader, u32 primitive_type);
+  static void DrawPrerenderArray(const SHADER& shader, PrimitiveType primitive_type);
 
   static PCache pshaders;
   static UberPCache ubershaders;

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1787,7 +1787,7 @@ void Renderer::RestoreAPIState()
   }
   SetGenerationMode();
   BPFunctions::SetScissor();
-  SetDepthMode();
+  BPFunctions::SetDepthMode();
   BPFunctions::SetBlendMode();
   SetViewport();
 
@@ -1813,16 +1813,16 @@ void Renderer::SetGenerationMode()
   }
 }
 
-void Renderer::SetDepthMode()
+void Renderer::SetDepthState(const DepthState& state)
 {
   const GLenum glCmpFuncs[8] = {GL_NEVER,   GL_LESS,     GL_EQUAL,  GL_LEQUAL,
                                 GL_GREATER, GL_NOTEQUAL, GL_GEQUAL, GL_ALWAYS};
 
-  if (bpmem.zmode.testenable)
+  if (state.testenable)
   {
     glEnable(GL_DEPTH_TEST);
-    glDepthMask(bpmem.zmode.updateenable ? GL_TRUE : GL_FALSE);
-    glDepthFunc(glCmpFuncs[bpmem.zmode.func]);
+    glDepthMask(state.updateenable ? GL_TRUE : GL_FALSE);
+    glDepthFunc(glCmpFuncs[state.func]);
   }
   else
   {

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1785,7 +1785,7 @@ void Renderer::RestoreAPIState()
     glEnable(GL_CLIP_DISTANCE0);
     glEnable(GL_CLIP_DISTANCE1);
   }
-  SetGenerationMode();
+  BPFunctions::SetGenerationMode();
   BPFunctions::SetScissor();
   BPFunctions::SetDepthMode();
   BPFunctions::SetBlendMode();
@@ -1798,14 +1798,14 @@ void Renderer::RestoreAPIState()
   OGLTexture::SetStage();
 }
 
-void Renderer::SetGenerationMode()
+void Renderer::SetRasterizationState(const RasterizationState& state)
 {
   // none, ccw, cw, ccw
-  if (bpmem.genMode.cullmode > 0)
+  if (state.cullmode != GenMode::CULL_NONE)
   {
     // TODO: GX_CULL_ALL not supported, yet!
     glEnable(GL_CULL_FACE);
-    glFrontFace(bpmem.genMode.cullmode == 2 ? GL_CCW : GL_CW);
+    glFrontFace(state.cullmode == GenMode::CULL_FRONT ? GL_CCW : GL_CW);
   }
   else
   {

--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -1503,8 +1503,12 @@ void Renderer::SwapImpl(u32 xfbAddr, u32 fbWidth, u32 fbStride, u32 fbHeight,
 
   g_Config.iSaveTargetId = 0;
 
+  int old_anisotropy = g_ActiveConfig.iMaxAnisotropy;
   UpdateActiveConfig();
   g_texture_cache->OnConfigChanged(g_ActiveConfig);
+
+  if (old_anisotropy != g_ActiveConfig.iMaxAnisotropy)
+    g_sampler_cache->Clear();
 
   // Invalidate shader cache when the host config changes.
   if (CheckForHostConfigChanges())
@@ -1834,13 +1838,9 @@ void Renderer::SetDepthState(const DepthState& state)
   }
 }
 
-void Renderer::SetSamplerState(int stage, int texindex, bool custom_tex)
+void Renderer::SetSamplerState(u32 index, const SamplerState& state)
 {
-  auto const& tex = bpmem.tex[texindex];
-  auto const& tm0 = tex.texMode0[stage];
-  auto const& tm1 = tex.texMode1[stage];
-
-  g_sampler_cache->SetSamplerState((texindex * 4) + stage, tm0, tm1, custom_tex);
+  g_sampler_cache->SetSamplerState(index, state);
 }
 
 void Renderer::SetInterlacingMode()

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -81,7 +81,7 @@ public:
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetRasterizationState(const RasterizationState& state) override;
   void SetDepthState(const DepthState& state) override;
-  void SetSamplerState(int stage, int texindex, bool custom_tex) override;
+  void SetSamplerState(u32 index, const SamplerState& state) override;
   void SetInterlacingMode() override;
   void SetViewport() override;
 

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -79,7 +79,7 @@ public:
 
   void SetBlendingState(const BlendingState& state) override;
   void SetScissorRect(const EFBRectangle& rc) override;
-  void SetGenerationMode() override;
+  void SetRasterizationState(const RasterizationState& state) override;
   void SetDepthState(const DepthState& state) override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -80,7 +80,7 @@ public:
   void SetBlendingState(const BlendingState& state) override;
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
-  void SetDepthMode() override;
+  void SetDepthState(const DepthState& state) override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;
   void SetViewport() override;

--- a/Source/Core/VideoBackends/OGL/SamplerCache.h
+++ b/Source/Core/VideoBackends/OGL/SamplerCache.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <map>
 #include <memory>
 
@@ -24,49 +25,21 @@ public:
   SamplerCache(SamplerCache&&) = delete;
   SamplerCache& operator=(SamplerCache&&) = delete;
 
-  void SetSamplerState(int stage, const TexMode0& tm0, const TexMode1& tm1, bool custom_tex);
+  void SetSamplerState(u32 stage, const SamplerState& state);
+  void InvalidateBinding(u32 stage);
+
   void Clear();
   void BindNearestSampler(int stage);
   void BindLinearSampler(int stage);
 
 private:
-  struct Params
-  {
-    union
-    {
-      struct
-      {
-        TexMode0 tm0;
-        TexMode1 tm1;
-      };
+  static void SetParameters(GLuint sampler_id, const SamplerState& params);
 
-      u64 hex;
-    };
+  std::map<SamplerState, GLuint> m_cache;
+  std::array<std::pair<SamplerState, GLuint>, 8> m_active_samplers{};
 
-    Params() : hex() {}
-    Params(const TexMode0& _tm0, const TexMode1& _tm1) : tm0(_tm0), tm1(_tm1)
-    {
-      static_assert(sizeof(Params) == 8, "Assuming I can treat this as a 64bit int.");
-    }
-
-    bool operator<(const Params& other) const { return hex < other.hex; }
-    bool operator!=(const Params& other) const { return hex != other.hex; }
-  };
-
-  struct Value
-  {
-    Value() : sampler_id() {}
-    GLuint sampler_id;
-  };
-
-  void SetParameters(GLuint sampler_id, const Params& params);
-  Value& GetEntry(const Params& params);
-
-  std::map<Params, Value> m_cache;
-  std::pair<Params, Value> m_active_samplers[8];
-
-  int m_last_max_anisotropy;
-  u32 m_sampler_id[2];
+  GLuint m_point_sampler;
+  GLuint m_linear_sampler;
 };
 
 extern std::unique_ptr<SamplerCache> g_sampler_cache;

--- a/Source/Core/VideoBackends/OGL/VertexManager.cpp
+++ b/Source/Core/VideoBackends/OGL/VertexManager.cpp
@@ -114,17 +114,17 @@ void VertexManager::Draw(u32 stride)
 
   switch (m_current_primitive_type)
   {
-  case PRIMITIVE_POINTS:
+  case PrimitiveType::Points:
     primitive_mode = GL_POINTS;
-    glDisable(GL_CULL_FACE);
     break;
-  case PRIMITIVE_LINES:
+  case PrimitiveType::Lines:
     primitive_mode = GL_LINES;
-    glDisable(GL_CULL_FACE);
     break;
-  case PRIMITIVE_TRIANGLES:
-    primitive_mode =
-        g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ? GL_TRIANGLE_STRIP : GL_TRIANGLES;
+  case PrimitiveType::Triangles:
+    primitive_mode = GL_TRIANGLES;
+    break;
+  case PrimitiveType::TriangleStrip:
+    primitive_mode = GL_TRIANGLE_STRIP;
     break;
   }
 
@@ -140,9 +140,6 @@ void VertexManager::Draw(u32 stride)
   }
 
   INCSTAT(stats.thisFrame.numDrawCalls);
-
-  if (m_current_primitive_type != PRIMITIVE_TRIANGLES)
-    static_cast<Renderer*>(g_renderer.get())->SetGenerationMode();
 }
 
 void VertexManager::vFlush()

--- a/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
+++ b/Source/Core/VideoBackends/Software/SWVertexLoader.cpp
@@ -62,16 +62,17 @@ void SWVertexLoader::vFlush()
   u8 primitiveType = 0;
   switch (m_current_primitive_type)
   {
-  case PRIMITIVE_POINTS:
+  case PrimitiveType::Points:
     primitiveType = OpcodeDecoder::GX_DRAW_POINTS;
     break;
-  case PRIMITIVE_LINES:
+  case PrimitiveType::Lines:
     primitiveType = OpcodeDecoder::GX_DRAW_LINES;
     break;
-  case PRIMITIVE_TRIANGLES:
-    primitiveType = g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ?
-                        OpcodeDecoder::GX_DRAW_TRIANGLE_STRIP :
-                        OpcodeDecoder::GX_DRAW_TRIANGLES;
+  case PrimitiveType::Triangles:
+    primitiveType = OpcodeDecoder::GX_DRAW_TRIANGLES;
+    break;
+  case PrimitiveType::TriangleStrip:
+    primitiveType = OpcodeDecoder::GX_DRAW_TRIANGLE_STRIP;
     break;
   }
 
@@ -89,13 +90,6 @@ void SWVertexLoader::vFlush()
   for (u32 i = 0; i < IndexGenerator::GetIndexLen(); i++)
   {
     const u16 index = m_local_index_buffer[i];
-
-    if (index == 0xffff)
-    {
-      // primitive restart
-      m_setup_unit.Init(primitiveType);
-      continue;
-    }
     memset(&m_vertex, 0, sizeof(m_vertex));
 
     // Super Mario Sunshine requires those to be zero for those debug boxes.

--- a/Source/Core/VideoBackends/Vulkan/Constants.h
+++ b/Source/Core/VideoBackends/Vulkan/Constants.h
@@ -135,16 +135,6 @@ union RasterizationState
   u32 bits;
 };
 
-// Depth state info
-union DepthStencilState
-{
-  BitField<0, 1, VkBool32> test_enable;
-  BitField<1, 1, VkBool32> write_enable;
-  BitField<2, 3, VkCompareOp> compare_op;
-
-  u32 bits;
-};
-
 // Sampler info
 union SamplerState
 {

--- a/Source/Core/VideoBackends/Vulkan/Constants.h
+++ b/Source/Core/VideoBackends/Vulkan/Constants.h
@@ -132,20 +132,4 @@ union MultisamplingState
   u32 hex;
 };
 
-// Sampler info
-union SamplerState
-{
-  BitField<0, 1, VkFilter> min_filter;
-  BitField<1, 1, VkFilter> mag_filter;
-  BitField<2, 1, VkSamplerMipmapMode> mipmap_mode;
-  BitField<3, 2, VkSamplerAddressMode> wrap_u;
-  BitField<5, 2, VkSamplerAddressMode> wrap_v;
-  BitField<7, 8, u32> min_lod;
-  BitField<15, 8, u32> max_lod;
-  BitField<23, 8, s32> lod_bias;
-  BitField<31, 1, u32> enable_anisotropic_filtering;
-
-  u32 bits;
-};
-
 }  // namespace Vulkan

--- a/Source/Core/VideoBackends/Vulkan/Constants.h
+++ b/Source/Core/VideoBackends/Vulkan/Constants.h
@@ -124,15 +124,12 @@ constexpr u32 PUSH_CONSTANT_BUFFER_SIZE = 128;
 // Minimum number of draw calls per command buffer when attempting to preempt a readback operation.
 constexpr u32 MINIMUM_DRAW_CALLS_PER_COMMAND_BUFFER_FOR_READBACK = 10;
 
-// Rasterization state info
-union RasterizationState
+// Multisampling state info that we don't expose in VideoCommon.
+union MultisamplingState
 {
-  BitField<0, 2, VkCullModeFlags> cull_mode;
-  BitField<2, 7, VkSampleCountFlagBits> samples;
-  BitField<9, 1, VkBool32> per_sample_shading;
-  BitField<10, 1, VkBool32> depth_clamp;
-
-  u32 bits;
+  BitField<0, 5, u32> samples;             // 1-16
+  BitField<0, 1, u32> per_sample_shading;  // SSAA
+  u32 hex;
 };
 
 // Sampler info

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -61,6 +61,39 @@ FramebufferManager* FramebufferManager::GetInstance()
   return static_cast<FramebufferManager*>(g_framebuffer_manager.get());
 }
 
+u32 FramebufferManager::GetEFBWidth() const
+{
+  return m_efb_color_texture->GetWidth();
+}
+
+u32 FramebufferManager::GetEFBHeight() const
+{
+  return m_efb_color_texture->GetHeight();
+}
+
+u32 FramebufferManager::GetEFBLayers() const
+{
+  return m_efb_color_texture->GetLayers();
+}
+
+VkSampleCountFlagBits FramebufferManager::GetEFBSamples() const
+{
+  return m_efb_color_texture->GetSamples();
+}
+
+MultisamplingState FramebufferManager::GetEFBMultisamplingState() const
+{
+  MultisamplingState ms = {};
+  ms.per_sample_shading = g_ActiveConfig.MultisamplingEnabled() && g_ActiveConfig.bSSAA;
+  ms.samples = static_cast<u32>(GetEFBSamples());
+  return ms;
+}
+
+std::pair<u32, u32> FramebufferManager::GetTargetSize() const
+{
+  return std::make_pair(GetEFBWidth(), GetEFBHeight());
+}
+
 bool FramebufferManager::Initialize()
 {
   if (!CreateEFBRenderPass())
@@ -117,22 +150,17 @@ bool FramebufferManager::Initialize()
   return true;
 }
 
-std::pair<u32, u32> FramebufferManager::GetTargetSize() const
-{
-  return std::make_pair(m_efb_width, m_efb_height);
-}
-
 bool FramebufferManager::CreateEFBRenderPass()
 {
-  m_efb_samples = static_cast<VkSampleCountFlagBits>(g_ActiveConfig.iMultisamples);
+  VkSampleCountFlagBits samples = static_cast<VkSampleCountFlagBits>(g_ActiveConfig.iMultisamples);
 
   // render pass for rendering to the efb
   VkAttachmentDescription attachments[] = {
-      {0, EFB_COLOR_TEXTURE_FORMAT, m_efb_samples, VK_ATTACHMENT_LOAD_OP_LOAD,
+      {0, EFB_COLOR_TEXTURE_FORMAT, samples, VK_ATTACHMENT_LOAD_OP_LOAD,
        VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
        VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
-      {0, EFB_DEPTH_TEXTURE_FORMAT, m_efb_samples, VK_ATTACHMENT_LOAD_OP_LOAD,
+      {0, EFB_DEPTH_TEXTURE_FORMAT, samples, VK_ATTACHMENT_LOAD_OP_LOAD,
        VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
        VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL}};
@@ -177,7 +205,7 @@ bool FramebufferManager::CreateEFBRenderPass()
   }
 
   // render pass for resolving depth, since we can't do it with vkCmdResolveImage
-  if (m_efb_samples != VK_SAMPLE_COUNT_1_BIT)
+  if (g_ActiveConfig.MultisamplingEnabled())
   {
     VkAttachmentDescription resolve_attachment = {0,
                                                   EFB_DEPTH_AS_COLOR_TEXTURE_FORMAT,
@@ -228,30 +256,32 @@ void FramebufferManager::DestroyEFBRenderPass()
 
 bool FramebufferManager::CreateEFBFramebuffer()
 {
-  m_efb_width = static_cast<u32>(std::max(g_renderer->GetTargetWidth(), 1));
-  m_efb_height = static_cast<u32>(std::max(g_renderer->GetTargetHeight(), 1));
-  m_efb_layers = (g_ActiveConfig.iStereoMode != STEREO_OFF) ? 2 : 1;
-  INFO_LOG(VIDEO, "EFB size: %ux%ux%u", m_efb_width, m_efb_height, m_efb_layers);
+  u32 efb_width = static_cast<u32>(std::max(g_renderer->GetTargetWidth(), 1));
+  u32 efb_height = static_cast<u32>(std::max(g_renderer->GetTargetHeight(), 1));
+  u32 efb_layers = (g_ActiveConfig.iStereoMode != STEREO_OFF) ? 2 : 1;
+  VkSampleCountFlagBits efb_samples =
+      static_cast<VkSampleCountFlagBits>(g_ActiveConfig.iMultisamples);
+  INFO_LOG(VIDEO, "EFB size: %ux%ux%u", efb_width, efb_height, efb_layers);
 
   // Update the static variable in the base class. Why does this even exist?
-  FramebufferManagerBase::m_EFBLayers = m_efb_layers;
+  FramebufferManagerBase::m_EFBLayers = g_ActiveConfig.iMultisamples;
 
   // Allocate EFB render targets
   m_efb_color_texture =
-      Texture2D::Create(m_efb_width, m_efb_height, 1, m_efb_layers, EFB_COLOR_TEXTURE_FORMAT,
-                        m_efb_samples, VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL,
+      Texture2D::Create(efb_width, efb_height, 1, efb_layers, EFB_COLOR_TEXTURE_FORMAT, efb_samples,
+                        VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL,
                         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
                             VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
 
   // We need a second texture to swap with for changing pixel formats
   m_efb_convert_color_texture =
-      Texture2D::Create(m_efb_width, m_efb_height, 1, m_efb_layers, EFB_COLOR_TEXTURE_FORMAT,
-                        m_efb_samples, VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL,
+      Texture2D::Create(efb_width, efb_height, 1, efb_layers, EFB_COLOR_TEXTURE_FORMAT, efb_samples,
+                        VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL,
                         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
                             VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
 
   m_efb_depth_texture = Texture2D::Create(
-      m_efb_width, m_efb_height, 1, m_efb_layers, EFB_DEPTH_TEXTURE_FORMAT, m_efb_samples,
+      efb_width, efb_height, 1, efb_layers, EFB_DEPTH_TEXTURE_FORMAT, efb_samples,
       VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL,
       VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
           VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -260,16 +290,16 @@ bool FramebufferManager::CreateEFBFramebuffer()
     return false;
 
   // Create resolved textures if MSAA is on
-  if (m_efb_samples != VK_SAMPLE_COUNT_1_BIT)
+  if (g_ActiveConfig.MultisamplingEnabled())
   {
     m_efb_resolve_color_texture = Texture2D::Create(
-        m_efb_width, m_efb_height, 1, m_efb_layers, EFB_COLOR_TEXTURE_FORMAT, VK_SAMPLE_COUNT_1_BIT,
+        efb_width, efb_height, 1, efb_layers, EFB_COLOR_TEXTURE_FORMAT, VK_SAMPLE_COUNT_1_BIT,
         VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL,
         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
             VK_IMAGE_USAGE_SAMPLED_BIT);
 
     m_efb_resolve_depth_texture = Texture2D::Create(
-        m_efb_width, m_efb_height, 1, m_efb_layers, EFB_DEPTH_AS_COLOR_TEXTURE_FORMAT,
+        efb_width, efb_height, 1, efb_layers, EFB_DEPTH_AS_COLOR_TEXTURE_FORMAT,
         VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_TILING_OPTIMAL,
         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
             VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -284,9 +314,9 @@ bool FramebufferManager::CreateEFBFramebuffer()
                                                 m_depth_resolve_render_pass,
                                                 1,
                                                 &attachment,
-                                                m_efb_width,
-                                                m_efb_height,
-                                                m_efb_layers};
+                                                efb_width,
+                                                efb_height,
+                                                efb_layers};
 
     VkResult res = vkCreateFramebuffer(g_vulkan_context->GetDevice(), &framebuffer_info, nullptr,
                                        &m_depth_resolve_framebuffer);
@@ -307,9 +337,9 @@ bool FramebufferManager::CreateEFBFramebuffer()
                                               m_efb_load_render_pass,
                                               static_cast<u32>(ArraySize(framebuffer_attachments)),
                                               framebuffer_attachments,
-                                              m_efb_width,
-                                              m_efb_height,
-                                              m_efb_layers};
+                                              efb_width,
+                                              efb_height,
+                                              efb_layers};
 
   VkResult res = vkCreateFramebuffer(g_vulkan_context->GetDevice(), &framebuffer_info, nullptr,
                                      &m_efb_framebuffer);
@@ -338,8 +368,8 @@ bool FramebufferManager::CreateEFBFramebuffer()
   // Clear the contents of the buffers.
   static const VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 0.0f}};
   static const VkClearDepthStencilValue clear_depth = {0.0f, 0};
-  VkImageSubresourceRange clear_color_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, m_efb_layers};
-  VkImageSubresourceRange clear_depth_range = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, m_efb_layers};
+  VkImageSubresourceRange clear_color_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, efb_layers};
+  VkImageSubresourceRange clear_depth_range = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, efb_layers};
   vkCmdClearColorImage(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                        m_efb_color_texture->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                        &clear_color, 1, &clear_color_range);
@@ -438,16 +468,12 @@ void FramebufferManager::ReinterpretPixelData(int convtype)
                          m_efb_load_render_pass, g_shader_cache->GetScreenQuadVertexShader(),
                          g_shader_cache->GetScreenQuadGeometryShader(), pixel_shader);
 
-  RasterizationState rs_state = Util::GetNoCullRasterizationState();
-  rs_state.samples = m_efb_samples;
-  rs_state.per_sample_shading = g_ActiveConfig.bSSAA ? VK_TRUE : VK_FALSE;
-  draw.SetRasterizationState(rs_state);
-
-  VkRect2D region = {{0, 0}, {m_efb_width, m_efb_height}};
+  VkRect2D region = {{0, 0}, {GetEFBWidth(), GetEFBHeight()}};
+  draw.SetMultisamplingState(GetEFBMultisamplingState());
   draw.BeginRenderPass(m_efb_convert_framebuffer, region);
   draw.SetPSSampler(0, m_efb_color_texture->GetView(), g_object_cache->GetPointSampler());
-  draw.SetViewportAndScissor(0, 0, m_efb_width, m_efb_height);
-  draw.DrawWithoutVertexBuffer(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, 4);
+  draw.SetViewportAndScissor(0, 0, GetEFBWidth(), GetEFBHeight());
+  draw.DrawWithoutVertexBuffer(4);
   draw.EndRenderPass();
 
   // Swap EFB texture pointers
@@ -458,7 +484,7 @@ void FramebufferManager::ReinterpretPixelData(int convtype)
 Texture2D* FramebufferManager::ResolveEFBColorTexture(const VkRect2D& region)
 {
   // Return the normal EFB texture if multisampling is off.
-  if (m_efb_samples == VK_SAMPLE_COUNT_1_BIT)
+  if (GetEFBSamples() == VK_SAMPLE_COUNT_1_BIT)
     return m_efb_color_texture.get();
 
   // Can't resolve within a render pass.
@@ -467,8 +493,8 @@ Texture2D* FramebufferManager::ResolveEFBColorTexture(const VkRect2D& region)
   // It's not valid to resolve out-of-bounds coordinates.
   // Ensuring the region is within the image is the caller's responsibility.
   _assert_(region.offset.x >= 0 && region.offset.y >= 0 &&
-           (static_cast<u32>(region.offset.x) + region.extent.width) <= m_efb_width &&
-           (static_cast<u32>(region.offset.y) + region.extent.height) <= m_efb_height);
+           (static_cast<u32>(region.offset.x) + region.extent.width) <= GetEFBWidth() &&
+           (static_cast<u32>(region.offset.y) + region.extent.height) <= GetEFBHeight());
 
   // Resolving is considered to be a transfer operation.
   m_efb_color_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
@@ -478,11 +504,11 @@ Texture2D* FramebufferManager::ResolveEFBColorTexture(const VkRect2D& region)
 
   // Resolve to our already-created texture.
   VkImageResolve resolve = {
-      {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, m_efb_layers},  // VkImageSubresourceLayers srcSubresource
-      {region.offset.x, region.offset.y, 0},            // VkOffset3D                  srcOffset
-      {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, m_efb_layers},  // VkImageSubresourceLayers dstSubresource
-      {region.offset.x, region.offset.y, 0},            // VkOffset3D                  dstOffset
-      {region.extent.width, region.extent.height, m_efb_layers}  // VkExtent3D extent
+      {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, GetEFBLayers()},  // VkImageSubresourceLayers srcSubresource
+      {region.offset.x, region.offset.y, 0},              // VkOffset3D                  srcOffset
+      {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, GetEFBLayers()},  // VkImageSubresourceLayers dstSubresource
+      {region.offset.x, region.offset.y, 0},              // VkOffset3D                  dstOffset
+      {region.extent.width, region.extent.height, GetEFBLayers()}  // VkExtent3D extent
   };
   vkCmdResolveImage(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                     m_efb_color_texture->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
@@ -498,7 +524,7 @@ Texture2D* FramebufferManager::ResolveEFBColorTexture(const VkRect2D& region)
 Texture2D* FramebufferManager::ResolveEFBDepthTexture(const VkRect2D& region)
 {
   // Return the normal EFB texture if multisampling is off.
-  if (m_efb_samples == VK_SAMPLE_COUNT_1_BIT)
+  if (GetEFBSamples() == VK_SAMPLE_COUNT_1_BIT)
     return m_efb_depth_texture.get();
 
   // Can't resolve within a render pass.
@@ -516,7 +542,7 @@ Texture2D* FramebufferManager::ResolveEFBDepthTexture(const VkRect2D& region)
   draw.SetPSSampler(0, m_efb_depth_texture->GetView(), g_object_cache->GetPointSampler());
   draw.SetViewportAndScissor(region.offset.x, region.offset.y, region.extent.width,
                              region.extent.height);
-  draw.DrawWithoutVertexBuffer(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, 4);
+  draw.DrawWithoutVertexBuffer(4);
   draw.EndRenderPass();
 
   // Restore MSAA texture ready for rendering again
@@ -646,11 +672,11 @@ bool FramebufferManager::CompileConversionShaders()
 
   m_ps_rgb8_to_rgba6 = Util::CompileAndCreateFragmentShader(header + RGB8_TO_RGBA6_SHADER_SOURCE);
   m_ps_rgba6_to_rgb8 = Util::CompileAndCreateFragmentShader(header + RGBA6_TO_RGB8_SHADER_SOURCE);
-  if (m_efb_samples != VK_SAMPLE_COUNT_1_BIT)
+  if (GetEFBSamples() != VK_SAMPLE_COUNT_1_BIT)
     m_ps_depth_resolve = Util::CompileAndCreateFragmentShader(header + DEPTH_RESOLVE_SHADER_SOURCE);
 
   return (m_ps_rgba6_to_rgb8 != VK_NULL_HANDLE && m_ps_rgb8_to_rgba6 != VK_NULL_HANDLE &&
-          (m_efb_samples == VK_SAMPLE_COUNT_1_BIT || m_ps_depth_resolve != VK_NULL_HANDLE));
+          (GetEFBSamples() == VK_SAMPLE_COUNT_1_BIT || m_ps_depth_resolve != VK_NULL_HANDLE));
 }
 
 void FramebufferManager::DestroyConversionShaders()
@@ -685,13 +711,13 @@ bool FramebufferManager::PopulateColorReadbackTexture()
   StateTracker::GetInstance()->OnReadback();
 
   // Issue a copy from framebuffer -> copy texture if we have >1xIR or MSAA on.
-  VkRect2D src_region = {{0, 0}, {m_efb_width, m_efb_height}};
+  VkRect2D src_region = {{0, 0}, {GetEFBWidth(), GetEFBHeight()}};
   Texture2D* src_texture = m_efb_color_texture.get();
   VkImageAspectFlags src_aspect = VK_IMAGE_ASPECT_COLOR_BIT;
-  if (m_efb_samples > 1)
+  if (GetEFBSamples() > 1)
     src_texture = ResolveEFBColorTexture(src_region);
 
-  if (m_efb_width != EFB_WIDTH || m_efb_height != EFB_HEIGHT)
+  if (GetEFBWidth() != EFB_WIDTH || GetEFBHeight() != EFB_HEIGHT)
   {
     m_color_copy_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
@@ -709,7 +735,7 @@ bool FramebufferManager::PopulateColorReadbackTexture()
                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     draw.SetPSSampler(0, src_texture->GetView(), g_object_cache->GetPointSampler());
     draw.SetViewportAndScissor(0, 0, EFB_WIDTH, EFB_HEIGHT);
-    draw.DrawWithoutVertexBuffer(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, 4);
+    draw.DrawWithoutVertexBuffer(4);
     draw.EndRenderPass();
 
     // Restore EFB to color attachment, since we're done with it.
@@ -765,16 +791,16 @@ bool FramebufferManager::PopulateDepthReadbackTexture()
   StateTracker::GetInstance()->OnReadback();
 
   // Issue a copy from framebuffer -> copy texture if we have >1xIR or MSAA on.
-  VkRect2D src_region = {{0, 0}, {m_efb_width, m_efb_height}};
+  VkRect2D src_region = {{0, 0}, {GetEFBWidth(), GetEFBHeight()}};
   Texture2D* src_texture = m_efb_depth_texture.get();
   VkImageAspectFlags src_aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
-  if (m_efb_samples > 1)
+  if (GetEFBSamples() > 1)
   {
     // EFB depth resolves are written out as color textures
     src_texture = ResolveEFBDepthTexture(src_region);
     src_aspect = VK_IMAGE_ASPECT_COLOR_BIT;
   }
-  if (m_efb_width != EFB_WIDTH || m_efb_height != EFB_HEIGHT)
+  if (GetEFBWidth() != EFB_WIDTH || GetEFBHeight() != EFB_HEIGHT)
   {
     m_depth_copy_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
@@ -792,7 +818,7 @@ bool FramebufferManager::PopulateDepthReadbackTexture()
                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     draw.SetPSSampler(0, src_texture->GetView(), g_object_cache->GetPointSampler());
     draw.SetViewportAndScissor(0, 0, EFB_WIDTH, EFB_HEIGHT);
-    draw.DrawWithoutVertexBuffer(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, 4);
+    draw.DrawWithoutVertexBuffer(4);
     draw.EndRenderPass();
 
     // Restore EFB to depth attachment, since we're done with it.
@@ -905,12 +931,12 @@ bool FramebufferManager::CreateReadbackRenderPasses()
       g_vulkan_context->GetDeviceLimits().pointSizeRange[0] > 1 ||
       g_vulkan_context->GetDeviceLimits().pointSizeRange[1] < 16)
   {
-    m_poke_primitive_topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
+    m_poke_primitive = PrimitiveType::TriangleStrip;
   }
   else
   {
     // Points should be okay.
-    m_poke_primitive_topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+    m_poke_primitive = PrimitiveType::Points;
   }
 
   return true;
@@ -1108,29 +1134,28 @@ void FramebufferManager::PokeEFBDepth(u32 x, u32 y, float depth)
 void FramebufferManager::CreatePokeVertices(std::vector<EFBPokeVertex>* destination_list, u32 x,
                                             u32 y, float z, u32 color)
 {
-  // Some devices don't support point sizes >1 (e.g. Adreno).
-  if (m_poke_primitive_topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP)
-  {
-    // generate quad from the single point (clip-space coordinates)
-    float x1 = float(x) * 2.0f / EFB_WIDTH - 1.0f;
-    float y1 = float(y) * 2.0f / EFB_HEIGHT - 1.0f;
-    float x2 = float(x + 1) * 2.0f / EFB_WIDTH - 1.0f;
-    float y2 = float(y + 1) * 2.0f / EFB_HEIGHT - 1.0f;
-    destination_list->push_back({{x1, y1, z, 1.0f}, color});
-    destination_list->push_back({{x2, y1, z, 1.0f}, color});
-    destination_list->push_back({{x1, y2, z, 1.0f}, color});
-    destination_list->push_back({{x1, y2, z, 1.0f}, color});
-    destination_list->push_back({{x2, y1, z, 1.0f}, color});
-    destination_list->push_back({{x2, y2, z, 1.0f}, color});
-  }
-  else
+  if (m_poke_primitive == PrimitiveType::Points)
   {
     // GPU will expand the point to a quad.
     float cs_x = float(x) * 2.0f / EFB_WIDTH - 1.0f;
     float cs_y = float(y) * 2.0f / EFB_HEIGHT - 1.0f;
-    float point_size = m_efb_width / static_cast<float>(EFB_WIDTH);
+    float point_size = GetEFBWidth() / static_cast<float>(EFB_WIDTH);
     destination_list->push_back({{cs_x, cs_y, z, point_size}, color});
+    return;
   }
+
+  // Some devices don't support point sizes >1 (e.g. Adreno).
+  // Generate quad from the single point (clip-space coordinates).
+  float x1 = float(x) * 2.0f / EFB_WIDTH - 1.0f;
+  float y1 = float(y) * 2.0f / EFB_HEIGHT - 1.0f;
+  float x2 = float(x + 1) * 2.0f / EFB_WIDTH - 1.0f;
+  float y2 = float(y + 1) * 2.0f / EFB_HEIGHT - 1.0f;
+  destination_list->push_back({{x1, y1, z, 1.0f}, color});
+  destination_list->push_back({{x2, y1, z, 1.0f}, color});
+  destination_list->push_back({{x1, y2, z, 1.0f}, color});
+  destination_list->push_back({{x1, y2, z, 1.0f}, color});
+  destination_list->push_back({{x2, y1, z, 1.0f}, color});
+  destination_list->push_back({{x2, y2, z, 1.0f}, color});
 }
 
 void FramebufferManager::FlushEFBPokes()
@@ -1159,16 +1184,16 @@ void FramebufferManager::DrawPokeVertices(const EFBPokeVertex* vertices, size_t 
   pipeline_info.vertex_format = m_poke_vertex_format.get();
   pipeline_info.pipeline_layout = g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_STANDARD);
   pipeline_info.vs = m_poke_vertex_shader;
-  pipeline_info.gs = (m_efb_layers > 1) ? m_poke_geometry_shader : VK_NULL_HANDLE;
+  pipeline_info.gs = (GetEFBLayers() > 1) ? m_poke_geometry_shader : VK_NULL_HANDLE;
   pipeline_info.ps = m_poke_fragment_shader;
   pipeline_info.render_pass = m_efb_load_render_pass;
-  pipeline_info.rasterization_state.bits = Util::GetNoCullRasterizationState().bits;
-  pipeline_info.rasterization_state.samples = m_efb_samples;
+  pipeline_info.rasterization_state.hex = Util::GetNoCullRasterizationState().hex;
+  pipeline_info.rasterization_state.primitive = m_poke_primitive;
+  pipeline_info.multisampling_state.hex = GetEFBMultisamplingState().hex;
   pipeline_info.depth_state.hex = Util::GetNoDepthTestingDepthStencilState().hex;
   pipeline_info.blend_state.hex = Util::GetNoBlendingBlendState().hex;
   pipeline_info.blend_state.colorupdate = write_color;
   pipeline_info.blend_state.alphaupdate = write_color;
-  pipeline_info.primitive_topology = m_poke_primitive_topology;
   if (write_depth)
   {
     pipeline_info.depth_state.testenable = true;
@@ -1209,7 +1234,7 @@ void FramebufferManager::DrawPokeVertices(const EFBPokeVertex* vertices, size_t 
   StateTracker::GetInstance()->EndClearRenderPass();
   StateTracker::GetInstance()->BeginRenderPass();
   StateTracker::GetInstance()->SetPendingRebind();
-  Util::SetViewportAndScissor(command_buffer, 0, 0, m_efb_width, m_efb_height);
+  Util::SetViewportAndScissor(command_buffer, 0, 0, GetEFBWidth(), GetEFBHeight());
   vkCmdBindPipeline(command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
   vkCmdBindVertexBuffers(command_buffer, 0, 1, &vb_buffer, &vb_offset);
   vkCmdDraw(command_buffer, static_cast<u32>(vertex_count), 1, 0, 0);
@@ -1310,7 +1335,7 @@ bool FramebufferManager::CompilePokeShaders()
   )";
 
   std::string source = g_shader_cache->GetUtilityShaderHeader();
-  if (m_poke_primitive_topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST)
+  if (m_poke_primitive == PrimitiveType::Points)
     source += "#define USE_POINT_SIZE 1\n";
   source += POKE_VERTEX_SHADER_SOURCE;
   m_poke_vertex_shader = Util::CompileAndCreateVertexShader(source);

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -1192,11 +1192,11 @@ void FramebufferManager::DrawPokeVertices(const EFBPokeVertex* vertices, size_t 
   pipeline_info.gs = (GetEFBLayers() > 1) ? m_poke_geometry_shader : VK_NULL_HANDLE;
   pipeline_info.ps = m_poke_fragment_shader;
   pipeline_info.render_pass = m_efb_load_render_pass;
-  pipeline_info.rasterization_state.hex = Util::GetNoCullRasterizationState().hex;
+  pipeline_info.rasterization_state.hex = RenderState::GetNoCullRasterizationState().hex;
   pipeline_info.rasterization_state.primitive = m_poke_primitive;
   pipeline_info.multisampling_state.hex = GetEFBMultisamplingState().hex;
-  pipeline_info.depth_state.hex = Util::GetNoDepthTestingDepthStencilState().hex;
-  pipeline_info.blend_state.hex = Util::GetNoBlendingBlendState().hex;
+  pipeline_info.depth_state.hex = RenderState::GetNoDepthTestingDepthStencilState().hex;
+  pipeline_info.blend_state.hex = RenderState::GetNoBlendingBlendState().hex;
   pipeline_info.blend_state.colorupdate = write_color;
   pipeline_info.blend_state.alphaupdate = write_color;
   if (write_depth)

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -362,6 +362,8 @@ bool FramebufferManager::CreateEFBFramebuffer()
   // Transition to state that can be used to clear
   m_efb_color_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+  m_efb_convert_color_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
   m_efb_depth_texture->TransitionToLayout(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
@@ -373,6 +375,9 @@ bool FramebufferManager::CreateEFBFramebuffer()
   vkCmdClearColorImage(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                        m_efb_color_texture->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                        &clear_color, 1, &clear_color_range);
+  vkCmdClearColorImage(g_command_buffer_mgr->GetCurrentCommandBuffer(),
+                       m_efb_convert_color_texture->GetImage(),
+                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear_color, 1, &clear_color_range);
   vkCmdClearDepthStencilImage(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                               m_efb_depth_texture->GetImage(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                               &clear_depth, 1, &clear_depth_range);

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.cpp
@@ -1164,16 +1164,16 @@ void FramebufferManager::DrawPokeVertices(const EFBPokeVertex* vertices, size_t 
   pipeline_info.render_pass = m_efb_load_render_pass;
   pipeline_info.rasterization_state.bits = Util::GetNoCullRasterizationState().bits;
   pipeline_info.rasterization_state.samples = m_efb_samples;
-  pipeline_info.depth_stencil_state.bits = Util::GetNoDepthTestingDepthStencilState().bits;
+  pipeline_info.depth_state.hex = Util::GetNoDepthTestingDepthStencilState().hex;
   pipeline_info.blend_state.hex = Util::GetNoBlendingBlendState().hex;
   pipeline_info.blend_state.colorupdate = write_color;
   pipeline_info.blend_state.alphaupdate = write_color;
   pipeline_info.primitive_topology = m_poke_primitive_topology;
   if (write_depth)
   {
-    pipeline_info.depth_stencil_state.test_enable = VK_TRUE;
-    pipeline_info.depth_stencil_state.write_enable = VK_TRUE;
-    pipeline_info.depth_stencil_state.compare_op = VK_COMPARE_OP_ALWAYS;
+    pipeline_info.depth_state.testenable = true;
+    pipeline_info.depth_state.updateenable = true;
+    pipeline_info.depth_state.func = ZMode::ALWAYS;
   }
 
   VkPipeline pipeline = g_shader_cache->GetPipeline(pipeline_info);

--- a/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
+++ b/Source/Core/VideoBackends/Vulkan/FramebufferManager.h
@@ -11,6 +11,7 @@
 #include "VideoBackends/Vulkan/Constants.h"
 #include "VideoBackends/Vulkan/TextureCache.h"
 #include "VideoCommon/FramebufferManagerBase.h"
+#include "VideoCommon/RenderState.h"
 
 namespace Vulkan
 {
@@ -34,13 +35,14 @@ public:
 
   VkRenderPass GetEFBLoadRenderPass() const { return m_efb_load_render_pass; }
   VkRenderPass GetEFBClearRenderPass() const { return m_efb_clear_render_pass; }
-  u32 GetEFBWidth() const { return m_efb_width; }
-  u32 GetEFBHeight() const { return m_efb_height; }
-  u32 GetEFBLayers() const { return m_efb_layers; }
-  VkSampleCountFlagBits GetEFBSamples() const { return m_efb_samples; }
   Texture2D* GetEFBColorTexture() const { return m_efb_color_texture.get(); }
   Texture2D* GetEFBDepthTexture() const { return m_efb_depth_texture.get(); }
   VkFramebuffer GetEFBFramebuffer() const { return m_efb_framebuffer; }
+  u32 GetEFBWidth() const;
+  u32 GetEFBHeight() const;
+  u32 GetEFBLayers() const;
+  VkSampleCountFlagBits GetEFBSamples() const;
+  MultisamplingState GetEFBMultisamplingState() const;
   std::pair<u32, u32> GetTargetSize() const override;
 
   std::unique_ptr<XFBSourceBase> CreateXFBSource(unsigned int target_width,
@@ -124,11 +126,6 @@ private:
   VkRenderPass m_efb_clear_render_pass = VK_NULL_HANDLE;
   VkRenderPass m_depth_resolve_render_pass = VK_NULL_HANDLE;
 
-  u32 m_efb_width = 0;
-  u32 m_efb_height = 0;
-  u32 m_efb_layers = 1;
-  VkSampleCountFlagBits m_efb_samples = VK_SAMPLE_COUNT_1_BIT;
-
   std::unique_ptr<Texture2D> m_efb_color_texture;
   std::unique_ptr<Texture2D> m_efb_convert_color_texture;
   std::unique_ptr<Texture2D> m_efb_depth_texture;
@@ -160,7 +157,7 @@ private:
   std::unique_ptr<StreamBuffer> m_poke_vertex_stream_buffer;
   std::vector<EFBPokeVertex> m_color_poke_vertices;
   std::vector<EFBPokeVertex> m_depth_poke_vertices;
-  VkPrimitiveTopology m_poke_primitive_topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+  PrimitiveType m_poke_primitive = PrimitiveType::TriangleStrip;
 
   VkRenderPass m_copy_color_render_pass = VK_NULL_HANDLE;
   VkRenderPass m_copy_depth_render_pass = VK_NULL_HANDLE;

--- a/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ObjectCache.cpp
@@ -312,29 +312,36 @@ VkSampler ObjectCache::GetSampler(const SamplerState& info)
   if (iter != m_sampler_cache.end())
     return iter->second;
 
+  static constexpr std::array<VkFilter, 4> filters = {{VK_FILTER_NEAREST, VK_FILTER_LINEAR}};
+  static constexpr std::array<VkSamplerMipmapMode, 2> mipmap_modes = {
+      {VK_SAMPLER_MIPMAP_MODE_NEAREST, VK_SAMPLER_MIPMAP_MODE_LINEAR}};
+  static constexpr std::array<VkSamplerAddressMode, 4> address_modes = {
+      {VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, VK_SAMPLER_ADDRESS_MODE_REPEAT,
+       VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT}};
+
   VkSamplerCreateInfo create_info = {
-      VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,      // VkStructureType         sType
-      nullptr,                                    // const void*             pNext
-      0,                                          // VkSamplerCreateFlags    flags
-      info.mag_filter,                            // VkFilter                magFilter
-      info.min_filter,                            // VkFilter                minFilter
-      info.mipmap_mode,                           // VkSamplerMipmapMode     mipmapMode
-      info.wrap_u,                                // VkSamplerAddressMode    addressModeU
-      info.wrap_v,                                // VkSamplerAddressMode    addressModeV
-      VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,      // VkSamplerAddressMode    addressModeW
-      static_cast<float>(info.lod_bias / 32.0f),  // float                   mipLodBias
-      VK_FALSE,                                   // VkBool32                anisotropyEnable
-      0.0f,                                       // float                   maxAnisotropy
-      VK_FALSE,                                   // VkBool32                compareEnable
-      VK_COMPARE_OP_ALWAYS,                       // VkCompareOp             compareOp
-      static_cast<float>(info.min_lod / 16.0f),   // float                   minLod
-      static_cast<float>(info.max_lod / 16.0f),   // float                   maxLod
-      VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,    // VkBorderColor           borderColor
-      VK_FALSE                                    // VkBool32                unnormalizedCoordinates
+      VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,               // VkStructureType         sType
+      nullptr,                                             // const void*             pNext
+      0,                                                   // VkSamplerCreateFlags    flags
+      filters[static_cast<u32>(info.mag_filter.Value())],  // VkFilter                magFilter
+      filters[static_cast<u32>(info.min_filter.Value())],  // VkFilter                minFilter
+      mipmap_modes[static_cast<u32>(info.mipmap_filter.Value())],  // VkSamplerMipmapMode mipmapMode
+      address_modes[static_cast<u32>(info.wrap_u.Value())],  // VkSamplerAddressMode    addressModeU
+      address_modes[static_cast<u32>(info.wrap_v.Value())],  // VkSamplerAddressMode    addressModeV
+      VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,                 // VkSamplerAddressMode    addressModeW
+      info.lod_bias / 32.0f,                                 // float                   mipLodBias
+      VK_FALSE,                                 // VkBool32                anisotropyEnable
+      0.0f,                                     // float                   maxAnisotropy
+      VK_FALSE,                                 // VkBool32                compareEnable
+      VK_COMPARE_OP_ALWAYS,                     // VkCompareOp             compareOp
+      info.min_lod / 16.0f,                     // float                   minLod
+      info.max_lod / 16.0f,                     // float                   maxLod
+      VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,  // VkBorderColor           borderColor
+      VK_FALSE                                  // VkBool32                unnormalizedCoordinates
   };
 
   // Can we use anisotropic filtering with this sampler?
-  if (info.enable_anisotropic_filtering && g_vulkan_context->SupportsAnisotropicFiltering())
+  if (info.anisotropic_filtering && g_vulkan_context->SupportsAnisotropicFiltering())
   {
     // Cap anisotropy to device limits.
     create_info.anisotropyEnable = VK_TRUE;

--- a/Source/Core/VideoBackends/Vulkan/RasterFont.cpp
+++ b/Source/Core/VideoBackends/Vulkan/RasterFont.cpp
@@ -400,7 +400,7 @@ void RasterFont::PrintMultiLineText(VkRenderPass render_pass, const std::string&
   draw.SetPSSampler(0, m_texture->GetView(), g_object_cache->GetLinearSampler());
 
   // Setup alpha blending
-  BlendingState blend_state = Util::GetNoBlendingBlendState();
+  BlendingState blend_state = RenderState::GetNoBlendingBlendState();
   blend_state.blendenable = true;
   blend_state.srcfactor = BlendMode::SRCALPHA;
   blend_state.dstfactor = BlendMode::INVSRCALPHA;

--- a/Source/Core/VideoBackends/Vulkan/RasterFont.cpp
+++ b/Source/Core/VideoBackends/Vulkan/RasterFont.cpp
@@ -310,10 +310,10 @@ void RasterFont::PrintMultiLineText(VkRenderPass render_pass, const std::string&
 
   UtilityShaderDraw draw(g_command_buffer_mgr->GetCurrentCommandBuffer(),
                          g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_PUSH_CONSTANT),
-                         render_pass, m_vertex_shader, VK_NULL_HANDLE, m_fragment_shader);
+                         render_pass, m_vertex_shader, VK_NULL_HANDLE, m_fragment_shader,
+                         PrimitiveType::Triangles);
 
-  UtilityShaderVertex* vertices =
-      draw.ReserveVertices(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, text.length() * 6);
+  UtilityShaderVertex* vertices = draw.ReserveVertices(text.length() * 6);
   size_t num_vertices = 0;
   if (!vertices)
     return;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -459,10 +459,10 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha
   blend_state.colorupdate = color_enable;
   blend_state.alphaupdate = alpha_enable;
 
-  DepthStencilState depth_state = Util::GetNoDepthTestingDepthStencilState();
-  depth_state.test_enable = z_enable ? VK_TRUE : VK_FALSE;
-  depth_state.write_enable = z_enable ? VK_TRUE : VK_FALSE;
-  depth_state.compare_op = VK_COMPARE_OP_ALWAYS;
+  DepthState depth_state = Util::GetNoDepthTestingDepthStencilState();
+  depth_state.testenable = z_enable;
+  depth_state.updateenable = z_enable;
+  depth_state.func = ZMode::ALWAYS;
 
   RasterizationState rs_state = Util::GetNoCullRasterizationState();
   rs_state.per_sample_shading = g_ActiveConfig.bSSAA ? VK_TRUE : VK_FALSE;
@@ -476,7 +476,7 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha
                          g_shader_cache->GetPassthroughGeometryShader(), m_clear_fragment_shader);
 
   draw.SetRasterizationState(rs_state);
-  draw.SetDepthStencilState(depth_state);
+  draw.SetDepthState(depth_state);
   draw.SetBlendState(blend_state);
 
   draw.DrawColoredQuad(target_rc.left, target_rc.top, target_rc.GetWidth(), target_rc.GetHeight(),
@@ -1303,45 +1303,9 @@ void Renderer::SetGenerationMode()
   StateTracker::GetInstance()->SetRasterizationState(new_rs_state);
 }
 
-void Renderer::SetDepthMode()
+void Renderer::SetDepthState(const DepthState& state)
 {
-  DepthStencilState new_ds_state = {};
-  new_ds_state.test_enable = bpmem.zmode.testenable ? VK_TRUE : VK_FALSE;
-  new_ds_state.write_enable = bpmem.zmode.updateenable ? VK_TRUE : VK_FALSE;
-
-  // Inverted depth, hence these are swapped
-  switch (bpmem.zmode.func)
-  {
-  case ZMode::NEVER:
-    new_ds_state.compare_op = VK_COMPARE_OP_NEVER;
-    break;
-  case ZMode::LESS:
-    new_ds_state.compare_op = VK_COMPARE_OP_GREATER;
-    break;
-  case ZMode::EQUAL:
-    new_ds_state.compare_op = VK_COMPARE_OP_EQUAL;
-    break;
-  case ZMode::LEQUAL:
-    new_ds_state.compare_op = VK_COMPARE_OP_GREATER_OR_EQUAL;
-    break;
-  case ZMode::GREATER:
-    new_ds_state.compare_op = VK_COMPARE_OP_LESS;
-    break;
-  case ZMode::NEQUAL:
-    new_ds_state.compare_op = VK_COMPARE_OP_NOT_EQUAL;
-    break;
-  case ZMode::GEQUAL:
-    new_ds_state.compare_op = VK_COMPARE_OP_LESS_OR_EQUAL;
-    break;
-  case ZMode::ALWAYS:
-    new_ds_state.compare_op = VK_COMPARE_OP_ALWAYS;
-    break;
-  default:
-    new_ds_state.compare_op = VK_COMPARE_OP_ALWAYS;
-    break;
-  }
-
-  StateTracker::GetInstance()->SetDepthStencilState(new_ds_state);
+  StateTracker::GetInstance()->SetDepthState(state);
 }
 
 void Renderer::SetBlendingState(const BlendingState& state)

--- a/Source/Core/VideoBackends/Vulkan/Renderer.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.cpp
@@ -455,11 +455,11 @@ void Renderer::ClearScreen(const EFBRectangle& rc, bool color_enable, bool alpha
   StateTracker::GetInstance()->SetPendingRebind();
 
   // Mask away the appropriate colors and use a shader
-  BlendingState blend_state = Util::GetNoBlendingBlendState();
+  BlendingState blend_state = RenderState::GetNoBlendingBlendState();
   blend_state.colorupdate = color_enable;
   blend_state.alphaupdate = alpha_enable;
 
-  DepthState depth_state = Util::GetNoDepthTestingDepthStencilState();
+  DepthState depth_state = RenderState::GetNoDepthTestingDepthStencilState();
   depth_state.testenable = z_enable;
   depth_state.updateenable = z_enable;
   depth_state.func = ZMode::ALWAYS;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -59,7 +59,7 @@ public:
   void SetBlendingState(const BlendingState& state) override;
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetGenerationMode() override;
-  void SetDepthMode() override;
+  void SetDepthState(const DepthState& state) override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;
   void SetViewport() override;

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -60,7 +60,7 @@ public:
   void SetScissorRect(const EFBRectangle& rc) override;
   void SetRasterizationState(const RasterizationState& state) override;
   void SetDepthState(const DepthState& state) override;
-  void SetSamplerState(int stage, int texindex, bool custom_tex) override;
+  void SetSamplerState(u32 index, const SamplerState& state) override;
   void SetInterlacingMode() override;
   void SetViewport() override;
 

--- a/Source/Core/VideoBackends/Vulkan/Renderer.h
+++ b/Source/Core/VideoBackends/Vulkan/Renderer.h
@@ -58,7 +58,7 @@ public:
 
   void SetBlendingState(const BlendingState& state) override;
   void SetScissorRect(const EFBRectangle& rc) override;
-  void SetGenerationMode() override;
+  void SetRasterizationState(const RasterizationState& state) override;
   void SetDepthState(const DepthState& state) override;
   void SetSamplerState(int stage, int texindex, bool custom_tex) override;
   void SetInterlacingMode() override;

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
@@ -122,16 +122,21 @@ GetVulkanMultisampleState(const RasterizationState& rs_state)
   };
 }
 
-static VkPipelineDepthStencilStateCreateInfo
-GetVulkanDepthStencilState(const DepthStencilState& state)
+static VkPipelineDepthStencilStateCreateInfo GetVulkanDepthStencilState(const DepthState& state)
 {
+  // Less/greater are swapped due to inverted depth.
+  static constexpr std::array<VkCompareOp, 8> funcs = {
+      {VK_COMPARE_OP_NEVER, VK_COMPARE_OP_GREATER, VK_COMPARE_OP_EQUAL,
+       VK_COMPARE_OP_GREATER_OR_EQUAL, VK_COMPARE_OP_LESS, VK_COMPARE_OP_NOT_EQUAL,
+       VK_COMPARE_OP_LESS_OR_EQUAL, VK_COMPARE_OP_ALWAYS}};
+
   return {
       VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,  // VkStructureType sType
       nullptr,             // const void*                               pNext
       0,                   // VkPipelineDepthStencilStateCreateFlags    flags
-      state.test_enable,   // VkBool32                                  depthTestEnable
-      state.write_enable,  // VkBool32                                  depthWriteEnable
-      state.compare_op,    // VkCompareOp                               depthCompareOp
+      state.testenable,    // VkBool32                                  depthTestEnable
+      state.updateenable,  // VkBool32                                  depthWriteEnable
+      funcs[state.func],   // VkCompareOp                               depthCompareOp
       VK_FALSE,            // VkBool32                                  depthBoundsTestEnable
       VK_FALSE,            // VkBool32                                  stencilTestEnable
       {},                  // VkStencilOpState                          front

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.cpp
@@ -1210,9 +1210,9 @@ void ShaderCache::CreateDummyPipeline(const UberShader::VertexShaderUid& vuid,
                  VK_NULL_HANDLE;
   pinfo.ps = GetPixelUberShaderForUid(puid);
   pinfo.render_pass = FramebufferManager::GetInstance()->GetEFBLoadRenderPass();
-  pinfo.rasterization_state.hex = Util::GetNoCullRasterizationState().hex;
-  pinfo.depth_state.hex = Util::GetNoDepthTestingDepthStencilState().hex;
-  pinfo.blend_state.hex = Util::GetNoBlendingBlendState().hex;
+  pinfo.rasterization_state.hex = RenderState::GetNoCullRasterizationState().hex;
+  pinfo.depth_state.hex = RenderState::GetNoDepthTestingDepthStencilState().hex;
+  pinfo.blend_state.hex = RenderState::GetNoBlendingBlendState().hex;
   pinfo.multisampling_state.hex = FramebufferManager::GetInstance()->GetEFBMultisamplingState().hex;
   pinfo.rasterization_state.primitive = guid.GetUidData()->primitive_type;
   GetPipelineWithCacheResultAsync(pinfo);

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.h
@@ -49,7 +49,7 @@ struct PipelineInfo
   VkRenderPass render_pass;
   BlendingState blend_state;
   RasterizationState rasterization_state;
-  DepthStencilState depth_stencil_state;
+  DepthState depth_state;
   VkPrimitiveTopology primitive_topology;
 };
 

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.h
@@ -62,10 +62,6 @@ bool operator==(const PipelineInfo& lhs, const PipelineInfo& rhs);
 bool operator!=(const PipelineInfo& lhs, const PipelineInfo& rhs);
 bool operator<(const PipelineInfo& lhs, const PipelineInfo& rhs);
 bool operator>(const PipelineInfo& lhs, const PipelineInfo& rhs);
-bool operator==(const SamplerState& lhs, const SamplerState& rhs);
-bool operator!=(const SamplerState& lhs, const SamplerState& rhs);
-bool operator>(const SamplerState& lhs, const SamplerState& rhs);
-bool operator<(const SamplerState& lhs, const SamplerState& rhs);
 
 struct ComputePipelineInfo
 {

--- a/Source/Core/VideoBackends/Vulkan/ShaderCache.h
+++ b/Source/Core/VideoBackends/Vulkan/ShaderCache.h
@@ -50,7 +50,7 @@ struct PipelineInfo
   BlendingState blend_state;
   RasterizationState rasterization_state;
   DepthState depth_state;
-  VkPrimitiveTopology primitive_topology;
+  MultisamplingState multisampling_state;
 };
 
 struct PipelineInfoHash

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -11,7 +11,6 @@
 
 #include "VideoBackends/Vulkan/CommandBufferManager.h"
 #include "VideoBackends/Vulkan/Constants.h"
-#include "VideoBackends/Vulkan/FramebufferManager.h"
 #include "VideoBackends/Vulkan/ObjectCache.h"
 #include "VideoBackends/Vulkan/ShaderCache.h"
 #include "VideoBackends/Vulkan/StreamBuffer.h"
@@ -54,26 +53,6 @@ void StateTracker::DestroyInstance()
 
 bool StateTracker::Initialize()
 {
-  // Set some sensible defaults
-  m_pipeline_state.rasterization_state.cull_mode = VK_CULL_MODE_NONE;
-  m_pipeline_state.rasterization_state.per_sample_shading = VK_FALSE;
-  m_pipeline_state.rasterization_state.depth_clamp = VK_FALSE;
-  m_pipeline_state.depth_state.testenable = true;
-  m_pipeline_state.depth_state.updateenable = true;
-  m_pipeline_state.depth_state.func = ZMode::ALWAYS;
-  m_pipeline_state.blend_state.hex = 0;
-  m_pipeline_state.blend_state.blendenable = false;
-  m_pipeline_state.blend_state.srcfactor = BlendMode::ONE;
-  m_pipeline_state.blend_state.srcfactoralpha = BlendMode::ONE;
-  m_pipeline_state.blend_state.dstfactor = BlendMode::ZERO;
-  m_pipeline_state.blend_state.dstfactoralpha = BlendMode::ZERO;
-  m_pipeline_state.blend_state.colorupdate = true;
-  m_pipeline_state.blend_state.alphaupdate = true;
-
-  // Enable depth clamping if supported by driver.
-  if (g_ActiveConfig.backend_info.bSupportsDepthClamp)
-    m_pipeline_state.rasterization_state.depth_clamp = VK_TRUE;
-
   // BBox is disabled by default.
   m_pipeline_state.pipeline_layout = g_object_cache->GetPipelineLayout(PIPELINE_LAYOUT_STANDARD);
   m_num_active_descriptor_sets = NUM_GX_DRAW_DESCRIPTOR_SETS;
@@ -166,13 +145,12 @@ void StateTracker::AppendToPipelineUIDCache(const PipelineInfo& info)
 {
   SerializedPipelineUID sinfo;
   sinfo.blend_state_bits = info.blend_state.hex;
-  sinfo.rasterizer_state_bits = info.rasterization_state.bits;
+  sinfo.rasterizer_state_bits = info.rasterization_state.hex;
   sinfo.depth_state_bits = info.depth_state.hex;
   sinfo.vertex_decl = m_pipeline_state.vertex_format->GetVertexDeclaration();
   sinfo.vs_uid = m_vs_uid;
   sinfo.gs_uid = m_gs_uid;
   sinfo.ps_uid = m_ps_uid;
-  sinfo.primitive_topology = info.primitive_topology;
 
   u32 dummy_value = 0;
   m_uid_cache.Append(sinfo, &dummy_value, 1);
@@ -211,10 +189,10 @@ bool StateTracker::PrecachePipelineUID(const SerializedPipelineUID& uid)
     return false;
   }
   pinfo.render_pass = m_load_render_pass;
-  pinfo.rasterization_state.bits = uid.rasterizer_state_bits;
+  pinfo.rasterization_state.hex = uid.rasterizer_state_bits;
   pinfo.depth_state.hex = uid.depth_state_bits;
   pinfo.blend_state.hex = uid.blend_state_bits;
-  pinfo.primitive_topology = uid.primitive_topology;
+  pinfo.multisampling_state.hex = m_pipeline_state.multisampling_state.hex;
 
   if (g_ActiveConfig.bBackgroundShaderCompiling)
   {
@@ -289,30 +267,21 @@ void StateTracker::SetVertexFormat(const VertexFormat* vertex_format)
   UpdatePipelineVertexFormat();
 }
 
-void StateTracker::SetPrimitiveTopology(VkPrimitiveTopology primitive_topology)
-{
-  if (m_pipeline_state.primitive_topology == primitive_topology)
-    return;
-
-  m_pipeline_state.primitive_topology = primitive_topology;
-  m_dirty_flags |= DIRTY_FLAG_PIPELINE;
-}
-
-void StateTracker::DisableBackFaceCulling()
-{
-  if (m_pipeline_state.rasterization_state.cull_mode == VK_CULL_MODE_NONE)
-    return;
-
-  m_pipeline_state.rasterization_state.cull_mode = VK_CULL_MODE_NONE;
-  m_dirty_flags |= DIRTY_FLAG_PIPELINE;
-}
-
 void StateTracker::SetRasterizationState(const RasterizationState& state)
 {
-  if (m_pipeline_state.rasterization_state.bits == state.bits)
+  if (m_pipeline_state.rasterization_state.hex == state.hex)
     return;
 
-  m_pipeline_state.rasterization_state.bits = state.bits;
+  m_pipeline_state.rasterization_state.hex = state.hex;
+  m_dirty_flags |= DIRTY_FLAG_PIPELINE;
+}
+
+void StateTracker::SetMultisamplingstate(const MultisamplingState& state)
+{
+  if (m_pipeline_state.multisampling_state.hex == state.hex)
+    return;
+
+  m_pipeline_state.multisampling_state.hex = state.hex;
   m_dirty_flags |= DIRTY_FLAG_PIPELINE;
 }
 
@@ -334,7 +303,7 @@ void StateTracker::SetBlendState(const BlendingState& state)
   m_dirty_flags |= DIRTY_FLAG_PIPELINE;
 }
 
-bool StateTracker::CheckForShaderChanges(u32 gx_primitive_type)
+bool StateTracker::CheckForShaderChanges()
 {
   VertexShaderUid vs_uid = GetVertexShaderUid();
   PixelShaderUid ps_uid = GetPixelShaderUid();
@@ -418,7 +387,7 @@ bool StateTracker::CheckForShaderChanges(u32 gx_primitive_type)
 
   if (g_vulkan_context->SupportsGeometryShaders())
   {
-    GeometryShaderUid gs_uid = GetGeometryShaderUid(gx_primitive_type);
+    GeometryShaderUid gs_uid = GetGeometryShaderUid(m_pipeline_state.rasterization_state.primitive);
     if (gs_uid != m_gs_uid)
     {
       m_gs_uid = gs_uid;

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.cpp
@@ -58,9 +58,9 @@ bool StateTracker::Initialize()
   m_pipeline_state.rasterization_state.cull_mode = VK_CULL_MODE_NONE;
   m_pipeline_state.rasterization_state.per_sample_shading = VK_FALSE;
   m_pipeline_state.rasterization_state.depth_clamp = VK_FALSE;
-  m_pipeline_state.depth_stencil_state.test_enable = VK_TRUE;
-  m_pipeline_state.depth_stencil_state.write_enable = VK_TRUE;
-  m_pipeline_state.depth_stencil_state.compare_op = VK_COMPARE_OP_LESS;
+  m_pipeline_state.depth_state.testenable = true;
+  m_pipeline_state.depth_state.updateenable = true;
+  m_pipeline_state.depth_state.func = ZMode::ALWAYS;
   m_pipeline_state.blend_state.hex = 0;
   m_pipeline_state.blend_state.blendenable = false;
   m_pipeline_state.blend_state.srcfactor = BlendMode::ONE;
@@ -167,7 +167,7 @@ void StateTracker::AppendToPipelineUIDCache(const PipelineInfo& info)
   SerializedPipelineUID sinfo;
   sinfo.blend_state_bits = info.blend_state.hex;
   sinfo.rasterizer_state_bits = info.rasterization_state.bits;
-  sinfo.depth_stencil_state_bits = info.depth_stencil_state.bits;
+  sinfo.depth_state_bits = info.depth_state.hex;
   sinfo.vertex_decl = m_pipeline_state.vertex_format->GetVertexDeclaration();
   sinfo.vs_uid = m_vs_uid;
   sinfo.gs_uid = m_gs_uid;
@@ -212,7 +212,7 @@ bool StateTracker::PrecachePipelineUID(const SerializedPipelineUID& uid)
   }
   pinfo.render_pass = m_load_render_pass;
   pinfo.rasterization_state.bits = uid.rasterizer_state_bits;
-  pinfo.depth_stencil_state.bits = uid.depth_stencil_state_bits;
+  pinfo.depth_state.hex = uid.depth_state_bits;
   pinfo.blend_state.hex = uid.blend_state_bits;
   pinfo.primitive_topology = uid.primitive_topology;
 
@@ -316,12 +316,12 @@ void StateTracker::SetRasterizationState(const RasterizationState& state)
   m_dirty_flags |= DIRTY_FLAG_PIPELINE;
 }
 
-void StateTracker::SetDepthStencilState(const DepthStencilState& state)
+void StateTracker::SetDepthState(const DepthState& state)
 {
-  if (m_pipeline_state.depth_stencil_state.bits == state.bits)
+  if (m_pipeline_state.depth_state.hex == state.hex)
     return;
 
-  m_pipeline_state.depth_stencil_state.bits = state.bits;
+  m_pipeline_state.depth_state.hex = state.hex;
   m_dirty_flags |= DIRTY_FLAG_PIPELINE;
 }
 

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.h
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.h
@@ -45,20 +45,15 @@ public:
   void SetIndexBuffer(VkBuffer buffer, VkDeviceSize offset, VkIndexType type);
 
   void SetRenderPass(VkRenderPass load_render_pass, VkRenderPass clear_render_pass);
-
   void SetFramebuffer(VkFramebuffer framebuffer, const VkRect2D& render_area);
-
   void SetVertexFormat(const VertexFormat* vertex_format);
 
-  void SetPrimitiveTopology(VkPrimitiveTopology primitive_topology);
-
-  void DisableBackFaceCulling();
-
   void SetRasterizationState(const RasterizationState& state);
+  void SetMultisamplingstate(const MultisamplingState& state);
   void SetDepthState(const DepthState& state);
   void SetBlendState(const BlendingState& state);
 
-  bool CheckForShaderChanges(u32 gx_primitive_type);
+  bool CheckForShaderChanges();
   void ClearShaders();
 
   void UpdateVertexShaderConstants();
@@ -133,7 +128,6 @@ private:
     VertexShaderUid vs_uid;
     GeometryShaderUid gs_uid;
     PixelShaderUid ps_uid;
-    VkPrimitiveTopology primitive_topology;
   };
 
   // Number of descriptor sets for game draws.

--- a/Source/Core/VideoBackends/Vulkan/StateTracker.h
+++ b/Source/Core/VideoBackends/Vulkan/StateTracker.h
@@ -39,10 +39,7 @@ public:
   {
     return m_pipeline_state.rasterization_state;
   }
-  const DepthStencilState& GetDepthStencilState() const
-  {
-    return m_pipeline_state.depth_stencil_state;
-  }
+  const DepthState& GetDepthStencilState() const { return m_pipeline_state.depth_state; }
   const BlendingState& GetBlendState() const { return m_pipeline_state.blend_state; }
   void SetVertexBuffer(VkBuffer buffer, VkDeviceSize offset);
   void SetIndexBuffer(VkBuffer buffer, VkDeviceSize offset, VkIndexType type);
@@ -58,7 +55,7 @@ public:
   void DisableBackFaceCulling();
 
   void SetRasterizationState(const RasterizationState& state);
-  void SetDepthStencilState(const DepthStencilState& state);
+  void SetDepthState(const DepthState& state);
   void SetBlendState(const BlendingState& state);
 
   bool CheckForShaderChanges(u32 gx_primitive_type);
@@ -130,7 +127,7 @@ private:
   struct SerializedPipelineUID
   {
     u32 rasterizer_state_bits;
-    u32 depth_stencil_state_bits;
+    u32 depth_state_bits;
     u32 blend_state_bits;
     PortableVertexDeclaration vertex_decl;
     VertexShaderUid vs_uid;

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -801,6 +801,7 @@ bool TextureConverter::CompileYUYVConversionShaders()
   static const char RGB_TO_YUYV_SHADER_SOURCE[] = R"(
     SAMPLER_BINDING(0) uniform sampler2DArray source;
     layout(location = 0) in vec3 uv0;
+    layout(location = 1) in vec4 col0;
     layout(location = 0) out vec4 ocol0;
 
     const vec3 y_const = vec3(0.257,0.504,0.098);

--- a/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
+++ b/Source/Core/VideoBackends/Vulkan/TextureConverter.cpp
@@ -214,7 +214,7 @@ void TextureConverter::ConvertTexture(TextureCacheBase::TCacheEntry* dst_entry,
                     g_object_cache->GetPointSampler());
   draw.SetPSTexelBuffer(m_texel_buffer_view_r16_uint);
   draw.SetViewportAndScissor(0, 0, dst_entry->GetWidth(), dst_entry->GetHeight());
-  draw.DrawWithoutVertexBuffer(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, 4);
+  draw.DrawWithoutVertexBuffer(4);
   draw.EndRenderPass();
 }
 
@@ -261,7 +261,7 @@ void TextureConverter::EncodeTextureToMemory(VkImageView src_texture, u8* dest_p
 
   VkRect2D render_region = {{0, 0}, {render_width, render_height}};
   draw.BeginRenderPass(m_encoding_render_framebuffer, render_region);
-  draw.DrawWithoutVertexBuffer(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, 4);
+  draw.DrawWithoutVertexBuffer(4);
   draw.EndRenderPass();
 
   // Transition the image before copying
@@ -382,7 +382,7 @@ void TextureConverter::DecodeYUYVTextureFromMemory(VKTexture* dst_texture, const
   draw.SetViewportAndScissor(0, 0, static_cast<int>(src_width), static_cast<int>(src_height));
   draw.SetPSTexelBuffer(m_texel_buffer_view_rgba8_unorm);
   draw.SetPushConstants(&push_constants, sizeof(push_constants));
-  draw.DrawWithoutVertexBuffer(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, 4);
+  draw.DrawWithoutVertexBuffer(4);
   draw.EndRenderPass();
 }
 

--- a/Source/Core/VideoBackends/Vulkan/Util.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Util.cpp
@@ -195,12 +195,12 @@ RasterizationState GetNoCullRasterizationState()
   return state;
 }
 
-DepthStencilState GetNoDepthTestingDepthStencilState()
+DepthState GetNoDepthTestingDepthStencilState()
 {
-  DepthStencilState state = {};
-  state.test_enable = VK_FALSE;
-  state.write_enable = VK_FALSE;
-  state.compare_op = VK_COMPARE_OP_ALWAYS;
+  DepthState state = {};
+  state.testenable = false;
+  state.updateenable = false;
+  state.func = ZMode::ALWAYS;
   return state;
 }
 
@@ -346,7 +346,7 @@ UtilityShaderDraw::UtilityShaderDraw(VkCommandBuffer command_buffer,
   m_pipeline_info.gs = geometry_shader;
   m_pipeline_info.ps = pixel_shader;
   m_pipeline_info.rasterization_state.bits = Util::GetNoCullRasterizationState().bits;
-  m_pipeline_info.depth_stencil_state.bits = Util::GetNoDepthTestingDepthStencilState().bits;
+  m_pipeline_info.depth_state.hex = Util::GetNoDepthTestingDepthStencilState().hex;
   m_pipeline_info.blend_state.hex = Util::GetNoBlendingBlendState().hex;
   m_pipeline_info.primitive_topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 }
@@ -450,9 +450,9 @@ void UtilityShaderDraw::SetRasterizationState(const RasterizationState& state)
   m_pipeline_info.rasterization_state.bits = state.bits;
 }
 
-void UtilityShaderDraw::SetDepthStencilState(const DepthStencilState& state)
+void UtilityShaderDraw::SetDepthState(const DepthState& state)
 {
-  m_pipeline_info.depth_stencil_state.bits = state.bits;
+  m_pipeline_info.depth_state.hex = state.hex;
 }
 
 void UtilityShaderDraw::SetBlendState(const BlendingState& state)

--- a/Source/Core/VideoBackends/Vulkan/Util.cpp
+++ b/Source/Core/VideoBackends/Vulkan/Util.cpp
@@ -185,36 +185,6 @@ VkBlendFactor GetAlphaBlendFactor(VkBlendFactor factor)
   }
 }
 
-RasterizationState GetNoCullRasterizationState()
-{
-  RasterizationState state = {};
-  state.cullmode = GenMode::CULL_NONE;
-  return state;
-}
-
-DepthState GetNoDepthTestingDepthStencilState()
-{
-  DepthState state = {};
-  state.testenable = false;
-  state.updateenable = false;
-  state.func = ZMode::ALWAYS;
-  return state;
-}
-
-BlendingState GetNoBlendingBlendState()
-{
-  BlendingState state = {};
-  state.blendenable = false;
-  state.srcfactor = BlendMode::ONE;
-  state.srcfactoralpha = BlendMode::ZERO;
-  state.dstfactor = BlendMode::ONE;
-  state.dstfactoralpha = BlendMode::ZERO;
-  state.logicopenable = false;
-  state.colorupdate = true;
-  state.alphaupdate = true;
-  return state;
-}
-
 void SetViewportAndScissor(VkCommandBuffer command_buffer, int x, int y, int width, int height,
                            float min_depth /*= 0.0f*/, float max_depth /*= 1.0f*/)
 {
@@ -342,10 +312,10 @@ UtilityShaderDraw::UtilityShaderDraw(VkCommandBuffer command_buffer,
   m_pipeline_info.vs = vertex_shader;
   m_pipeline_info.gs = geometry_shader;
   m_pipeline_info.ps = pixel_shader;
-  m_pipeline_info.rasterization_state.hex = Util::GetNoCullRasterizationState().hex;
+  m_pipeline_info.rasterization_state.hex = RenderState::GetNoCullRasterizationState().hex;
   m_pipeline_info.rasterization_state.primitive = primitive;
-  m_pipeline_info.depth_state.hex = Util::GetNoDepthTestingDepthStencilState().hex;
-  m_pipeline_info.blend_state.hex = Util::GetNoBlendingBlendState().hex;
+  m_pipeline_info.depth_state.hex = RenderState::GetNoDepthTestingDepthStencilState().hex;
+  m_pipeline_info.blend_state.hex = RenderState::GetNoBlendingBlendState().hex;
   m_pipeline_info.multisampling_state.per_sample_shading = false;
   m_pipeline_info.multisampling_state.samples = 1;
 }

--- a/Source/Core/VideoBackends/Vulkan/Util.h
+++ b/Source/Core/VideoBackends/Vulkan/Util.h
@@ -39,7 +39,7 @@ VkRect2D ClampRect2D(const VkRect2D& rect, u32 width, u32 height);
 VkBlendFactor GetAlphaBlendFactor(VkBlendFactor factor);
 
 RasterizationState GetNoCullRasterizationState();
-DepthStencilState GetNoDepthTestingDepthStencilState();
+DepthState GetNoDepthTestingDepthStencilState();
 BlendingState GetNoBlendingBlendState();
 
 // Combines viewport and scissor updates
@@ -151,7 +151,7 @@ public:
   void SetPSTexelBuffer(VkBufferView view);
 
   void SetRasterizationState(const RasterizationState& state);
-  void SetDepthStencilState(const DepthStencilState& state);
+  void SetDepthState(const DepthState& state);
   void SetBlendState(const BlendingState& state);
 
   void BeginRenderPass(VkFramebuffer framebuffer, const VkRect2D& region,

--- a/Source/Core/VideoBackends/Vulkan/Util.h
+++ b/Source/Core/VideoBackends/Vulkan/Util.h
@@ -131,12 +131,13 @@ class UtilityShaderDraw
 public:
   UtilityShaderDraw(VkCommandBuffer command_buffer, VkPipelineLayout pipeline_layout,
                     VkRenderPass render_pass, VkShaderModule vertex_shader,
-                    VkShaderModule geometry_shader, VkShaderModule pixel_shader);
+                    VkShaderModule geometry_shader, VkShaderModule pixel_shader,
+                    PrimitiveType primitive = PrimitiveType::TriangleStrip);
 
-  UtilityShaderVertex* ReserveVertices(VkPrimitiveTopology topology, size_t count);
+  UtilityShaderVertex* ReserveVertices(size_t count);
   void CommitVertices(size_t count);
 
-  void UploadVertices(VkPrimitiveTopology topology, UtilityShaderVertex* vertices, size_t count);
+  void UploadVertices(UtilityShaderVertex* vertices, size_t count);
 
   u8* AllocateVSUniforms(size_t size);
   void CommitVSUniforms(size_t size);
@@ -151,6 +152,7 @@ public:
   void SetPSTexelBuffer(VkBufferView view);
 
   void SetRasterizationState(const RasterizationState& state);
+  void SetMultisamplingState(const MultisamplingState& state);
   void SetDepthState(const DepthState& state);
   void SetBlendState(const BlendingState& state);
 
@@ -177,7 +179,7 @@ public:
 
   // Draw without a vertex buffer. Assumes viewport has been initialized separately.
   void SetViewportAndScissor(int x, int y, int width, int height);
-  void DrawWithoutVertexBuffer(VkPrimitiveTopology primitive_topology, u32 vertex_count);
+  void DrawWithoutVertexBuffer(u32 vertex_count);
 
 private:
   void BindVertexBuffer();

--- a/Source/Core/VideoBackends/Vulkan/Util.h
+++ b/Source/Core/VideoBackends/Vulkan/Util.h
@@ -38,10 +38,6 @@ VkRect2D ClampRect2D(const VkRect2D& rect, u32 width, u32 height);
 // Map {SRC,DST}_COLOR to {SRC,DST}_ALPHA
 VkBlendFactor GetAlphaBlendFactor(VkBlendFactor factor);
 
-RasterizationState GetNoCullRasterizationState();
-DepthState GetNoDepthTestingDepthStencilState();
-BlendingState GetNoBlendingBlendState();
-
 // Combines viewport and scissor updates
 void SetViewportAndScissor(VkCommandBuffer command_buffer, int x, int y, int width, int height,
                            float min_depth = 0.0f, float max_depth = 1.0f);

--- a/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VertexManager.cpp
@@ -138,33 +138,9 @@ void VertexManager::vFlush()
   // Figure out the number of indices to draw
   u32 index_count = IndexGenerator::GetIndexLen();
 
-  // Update assembly state
+  // Update tracked state
   StateTracker::GetInstance()->SetVertexFormat(vertex_format);
-  switch (m_current_primitive_type)
-  {
-  case PRIMITIVE_POINTS:
-    StateTracker::GetInstance()->SetPrimitiveTopology(VK_PRIMITIVE_TOPOLOGY_POINT_LIST);
-    StateTracker::GetInstance()->DisableBackFaceCulling();
-    break;
-
-  case PRIMITIVE_LINES:
-    StateTracker::GetInstance()->SetPrimitiveTopology(VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
-    StateTracker::GetInstance()->DisableBackFaceCulling();
-    break;
-
-  case PRIMITIVE_TRIANGLES:
-    StateTracker::GetInstance()->SetPrimitiveTopology(
-        g_ActiveConfig.backend_info.bSupportsPrimitiveRestart ?
-            VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP :
-            VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
-    g_renderer->SetGenerationMode();
-    break;
-  }
-
-  // Check for any shader stage changes
-  StateTracker::GetInstance()->CheckForShaderChanges(m_current_primitive_type);
-
-  // Update any changed constants
+  StateTracker::GetInstance()->CheckForShaderChanges();
   StateTracker::GetInstance()->UpdateVertexShaderConstants();
   StateTracker::GetInstance()->UpdateGeometryShaderConstants();
   StateTracker::GetInstance()->UpdatePixelShaderConstants();

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -68,12 +68,14 @@ void SetScissor()
 
 void SetDepthMode()
 {
-  g_renderer->SetDepthMode();
+  DepthState state = {};
+  state.Generate(bpmem);
+  g_renderer->SetDepthState(state);
 }
 
 void SetBlendMode()
 {
-  BlendingState state;
+  BlendingState state = {};
   state.Generate(bpmem);
   g_renderer->SetBlendingState(state);
 }

--- a/Source/Core/VideoCommon/BPFunctions.cpp
+++ b/Source/Core/VideoCommon/BPFunctions.cpp
@@ -27,7 +27,9 @@ void FlushPipeline()
 
 void SetGenerationMode()
 {
-  g_renderer->SetGenerationMode();
+  RasterizationState state = {};
+  state.Generate(bpmem, g_vertex_manager->GetCurrentPrimitiveType());
+  g_renderer->SetRasterizationState(state);
 }
 
 void SetScissor()

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -20,7 +20,7 @@ struct geometry_shader_uid_data
   bool IsPassthrough() const;
 
   u32 numTexGens : 4;
-  PrimitiveType primitive_type : 2;
+  u32 primitive_type : 2;
 };
 
 #pragma pack()

--- a/Source/Core/VideoCommon/GeometryShaderGen.h
+++ b/Source/Core/VideoCommon/GeometryShaderGen.h
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include "Common/CommonTypes.h"
+#include "VideoCommon/RenderState.h"
 #include "VideoCommon/ShaderGenCommon.h"
 #include "VideoCommon/VertexManagerBase.h"
 
@@ -19,7 +20,7 @@ struct geometry_shader_uid_data
   bool IsPassthrough() const;
 
   u32 numTexGens : 4;
-  u32 primitive_type : 2;
+  PrimitiveType primitive_type : 2;
 };
 
 #pragma pack()
@@ -28,5 +29,5 @@ typedef ShaderUid<geometry_shader_uid_data> GeometryShaderUid;
 
 ShaderCode GenerateGeometryShaderCode(APIType ApiType, const ShaderHostConfig& host_config,
                                       const geometry_shader_uid_data* uid_data);
-GeometryShaderUid GetGeometryShaderUid(u32 primitive_type);
+GeometryShaderUid GetGeometryShaderUid(PrimitiveType primitive_type);
 void EnumerateGeometryShaderUids(const std::function<void(const GeometryShaderUid&)>& callback);

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -68,7 +68,7 @@ public:
   virtual void SetScissorRect(const EFBRectangle& rc) {}
   virtual void SetRasterizationState(const RasterizationState& state) {}
   virtual void SetDepthState(const DepthState& state) {}
-  virtual void SetSamplerState(int stage, int texindex, bool custom_tex) {}
+  virtual void SetSamplerState(u32 index, const SamplerState& state) {}
   virtual void SetInterlacingMode() {}
   virtual void SetViewport() {}
   virtual void SetFullscreen(bool enable_fullscreen) {}

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -66,7 +66,7 @@ public:
 
   virtual void SetBlendingState(const BlendingState& state) {}
   virtual void SetScissorRect(const EFBRectangle& rc) {}
-  virtual void SetGenerationMode() {}
+  virtual void SetRasterizationState(const RasterizationState& state) {}
   virtual void SetDepthState(const DepthState& state) {}
   virtual void SetSamplerState(int stage, int texindex, bool custom_tex) {}
   virtual void SetInterlacingMode() {}

--- a/Source/Core/VideoCommon/RenderBase.h
+++ b/Source/Core/VideoCommon/RenderBase.h
@@ -67,7 +67,7 @@ public:
   virtual void SetBlendingState(const BlendingState& state) {}
   virtual void SetScissorRect(const EFBRectangle& rc) {}
   virtual void SetGenerationMode() {}
-  virtual void SetDepthMode() {}
+  virtual void SetDepthState(const DepthState& state) {}
   virtual void SetSamplerState(int stage, int texindex, bool custom_tex) {}
   virtual void SetInterlacingMode() {}
   virtual void SetViewport() {}

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -3,6 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "VideoCommon/RenderState.h"
+#include <algorithm>
+#include <array>
+#include "VideoCommon/SamplerCommon.h"
 
 void RasterizationState::Generate(const BPMemory& bp, PrimitiveType primitive_type)
 {
@@ -14,11 +17,23 @@ void RasterizationState::Generate(const BPMemory& bp, PrimitiveType primitive_ty
     cullmode = GenMode::CULL_NONE;
 }
 
+RasterizationState& RasterizationState::operator=(const RasterizationState& rhs)
+{
+  hex = rhs.hex;
+  return *this;
+}
+
 void DepthState::Generate(const BPMemory& bp)
 {
   testenable = bp.zmode.testenable.Value();
   updateenable = bp.zmode.updateenable.Value();
   func = bp.zmode.func.Value();
+}
+
+DepthState& DepthState::operator=(const DepthState& rhs)
+{
+  hex = rhs.hex;
+  return *this;
 }
 
 // If the framebuffer format has no alpha channel, it is assumed to
@@ -145,6 +160,43 @@ void BlendingState::Generate(const BPMemory& bp)
   }
 }
 
+BlendingState& BlendingState::operator=(const BlendingState& rhs)
+{
+  hex = rhs.hex;
+  return *this;
+}
+
+void SamplerState::Generate(const BPMemory& bp, u32 index)
+{
+  const FourTexUnits& tex = bpmem.tex[index / 4];
+  const TexMode0& tm0 = tex.texMode0[index % 4];
+  const TexMode1& tm1 = tex.texMode1[index % 4];
+
+  // GX can configure the mip filter to none. However, D3D and Vulkan can't express this in their
+  // sampler states. Therefore, we set the min/max LOD to zero if this option is used.
+  min_filter = (tm0.min_filter & 4) != 0 ? Filter::Linear : Filter::Point;
+  mipmap_filter = (tm0.min_filter & 3) == TexMode0::TEXF_LINEAR ? Filter::Linear : Filter::Point;
+  mag_filter = tm0.mag_filter != 0 ? Filter::Linear : Filter::Point;
+
+  // If mipmaps are disabled, clamp min/max lod
+  max_lod = SamplerCommon::AreBpTexMode0MipmapsEnabled(tm0) ? tm1.max_lod : 0;
+  min_lod = std::min(max_lod.Value(), tm1.min_lod);
+  lod_bias = SamplerCommon::AreBpTexMode0MipmapsEnabled(tm0) ? tm0.lod_bias : 0;
+
+  // Address modes
+  static constexpr std::array<AddressMode, 4> address_modes = {
+      {AddressMode::Clamp, AddressMode::Repeat, AddressMode::MirroredRepeat, AddressMode::Repeat}};
+  wrap_u = address_modes[tm0.wrap_s];
+  wrap_v = address_modes[tm0.wrap_t];
+  anisotropic_filtering = 0;
+}
+
+SamplerState& SamplerState::operator=(const SamplerState& rhs)
+{
+  hex = rhs.hex;
+  return *this;
+}
+
 namespace RenderState
 {
 RasterizationState GetNoCullRasterizationState()
@@ -175,6 +227,36 @@ BlendingState GetNoBlendingBlendState()
   state.logicopenable = false;
   state.colorupdate = true;
   state.alphaupdate = true;
+  return state;
+}
+
+SamplerState GetPointSamplerState()
+{
+  SamplerState state = {};
+  state.min_filter = SamplerState::Filter::Point;
+  state.mag_filter = SamplerState::Filter::Point;
+  state.mipmap_filter = SamplerState::Filter::Point;
+  state.wrap_u = SamplerState::AddressMode::Clamp;
+  state.wrap_v = SamplerState::AddressMode::Clamp;
+  state.min_lod = 0;
+  state.max_lod = 255;
+  state.lod_bias = 0;
+  state.anisotropic_filtering = false;
+  return state;
+}
+
+SamplerState GetLinearSamplerState()
+{
+  SamplerState state = {};
+  state.min_filter = SamplerState::Filter::Linear;
+  state.mag_filter = SamplerState::Filter::Linear;
+  state.mipmap_filter = SamplerState::Filter::Linear;
+  state.wrap_u = SamplerState::AddressMode::Clamp;
+  state.wrap_v = SamplerState::AddressMode::Clamp;
+  state.min_lod = 0;
+  state.max_lod = 255;
+  state.lod_bias = 0;
+  state.anisotropic_filtering = false;
   return state;
 }
 }

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -144,3 +144,37 @@ void BlendingState::Generate(const BPMemory& bp)
     }
   }
 }
+
+namespace RenderState
+{
+RasterizationState GetNoCullRasterizationState()
+{
+  RasterizationState state = {};
+  state.cullmode = GenMode::CULL_NONE;
+  return state;
+}
+
+DepthState GetNoDepthTestingDepthStencilState()
+{
+  DepthState state = {};
+  state.testenable = false;
+  state.updateenable = false;
+  state.func = ZMode::ALWAYS;
+  return state;
+}
+
+BlendingState GetNoBlendingBlendState()
+{
+  BlendingState state = {};
+  state.usedualsrc = false;
+  state.blendenable = false;
+  state.srcfactor = BlendMode::ONE;
+  state.srcfactoralpha = BlendMode::ONE;
+  state.dstfactor = BlendMode::ZERO;
+  state.dstfactoralpha = BlendMode::ZERO;
+  state.logicopenable = false;
+  state.colorupdate = true;
+  state.alphaupdate = true;
+  return state;
+}
+}

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -4,6 +4,16 @@
 
 #include "VideoCommon/RenderState.h"
 
+void RasterizationState::Generate(const BPMemory& bp, PrimitiveType primitive_type)
+{
+  cullmode = bp.genMode.cullmode;
+  primitive = primitive_type;
+
+  // Back-face culling should be disabled for points/lines.
+  if (primitive_type != PrimitiveType::Triangles && primitive_type != PrimitiveType::TriangleStrip)
+    cullmode = GenMode::CULL_NONE;
+}
+
 void DepthState::Generate(const BPMemory& bp)
 {
   testenable = bp.zmode.testenable.Value();

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -4,6 +4,13 @@
 
 #include "VideoCommon/RenderState.h"
 
+void DepthState::Generate(const BPMemory& bp)
+{
+  testenable = bp.zmode.testenable.Value();
+  updateenable = bp.zmode.updateenable.Value();
+  func = bp.zmode.func.Value();
+}
+
 // If the framebuffer format has no alpha channel, it is assumed to
 // ONE on blending. As the backends may emulate this framebuffer
 // configuration with an alpha channel, we just drop all references

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -58,3 +58,10 @@ union BlendingState
 
   u32 hex;
 };
+
+namespace RenderState
+{
+RasterizationState GetNoCullRasterizationState();
+DepthState GetNoDepthTestingDepthStencilState();
+BlendingState GetNoBlendingBlendState();
+}

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -9,6 +9,24 @@
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/BPStructs.h"
 
+enum class PrimitiveType : u32
+{
+  Points,
+  Lines,
+  Triangles,
+  TriangleStrip,
+};
+
+union RasterizationState
+{
+  void Generate(const BPMemory& bp, PrimitiveType primitive_type);
+
+  BitField<0, 2, GenMode::CullMode> cullmode;
+  BitField<3, 2, PrimitiveType> primitive;
+
+  u32 hex;
+};
+
 union DepthState
 {
   void Generate(const BPMemory& bp);

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -21,6 +21,11 @@ union RasterizationState
 {
   void Generate(const BPMemory& bp, PrimitiveType primitive_type);
 
+  RasterizationState& operator=(const RasterizationState& rhs);
+
+  bool operator==(const RasterizationState& rhs) const { return hex == rhs.hex; }
+  bool operator!=(const RasterizationState& rhs) const { return hex != rhs.hex; }
+  bool operator<(const RasterizationState& rhs) const { return hex < rhs.hex; }
   BitField<0, 2, GenMode::CullMode> cullmode;
   BitField<3, 2, PrimitiveType> primitive;
 
@@ -31,6 +36,11 @@ union DepthState
 {
   void Generate(const BPMemory& bp);
 
+  DepthState& operator=(const DepthState& rhs);
+
+  bool operator==(const DepthState& rhs) const { return hex == rhs.hex; }
+  bool operator!=(const DepthState& rhs) const { return hex != rhs.hex; }
+  bool operator<(const DepthState& rhs) const { return hex < rhs.hex; }
   BitField<0, 1, u32> testenable;
   BitField<1, 1, u32> updateenable;
   BitField<2, 3, ZMode::CompareMode> func;
@@ -42,6 +52,11 @@ union BlendingState
 {
   void Generate(const BPMemory& bp);
 
+  BlendingState& operator=(const BlendingState& rhs);
+
+  bool operator==(const BlendingState& rhs) const { return hex == rhs.hex; }
+  bool operator!=(const BlendingState& rhs) const { return hex != rhs.hex; }
+  bool operator<(const BlendingState& rhs) const { return hex < rhs.hex; }
   BitField<0, 1, u32> blendenable;
   BitField<1, 1, u32> logicopenable;
   BitField<2, 1, u32> dstalpha;
@@ -59,9 +74,46 @@ union BlendingState
   u32 hex;
 };
 
+union SamplerState
+{
+  enum class Filter : u32
+  {
+    Point,
+    Linear
+  };
+
+  enum class AddressMode : u32
+  {
+    Clamp,
+    Repeat,
+    MirroredRepeat
+  };
+
+  void Generate(const BPMemory& bp, u32 index);
+
+  SamplerState& operator=(const SamplerState& rhs);
+
+  bool operator==(const SamplerState& rhs) const { return hex == rhs.hex; }
+  bool operator!=(const SamplerState& rhs) const { return hex != rhs.hex; }
+  bool operator<(const SamplerState& rhs) const { return hex < rhs.hex; }
+  BitField<0, 1, Filter> min_filter;
+  BitField<1, 1, Filter> mag_filter;
+  BitField<2, 1, Filter> mipmap_filter;
+  BitField<3, 2, AddressMode> wrap_u;
+  BitField<5, 2, AddressMode> wrap_v;
+  BitField<7, 8, u32> min_lod;    // multiplied by 16
+  BitField<15, 8, u32> max_lod;   // multiplied by 16
+  BitField<23, 8, s32> lod_bias;  // multiplied by 32
+  BitField<31, 1, u32> anisotropic_filtering;
+
+  u32 hex;
+};
+
 namespace RenderState
 {
 RasterizationState GetNoCullRasterizationState();
 DepthState GetNoDepthTestingDepthStencilState();
 BlendingState GetNoBlendingBlendState();
+SamplerState GetPointSamplerState();
+SamplerState GetLinearSamplerState();
 }

--- a/Source/Core/VideoCommon/RenderState.h
+++ b/Source/Core/VideoCommon/RenderState.h
@@ -9,6 +9,17 @@
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/BPStructs.h"
 
+union DepthState
+{
+  void Generate(const BPMemory& bp);
+
+  BitField<0, 1, u32> testenable;
+  BitField<1, 1, u32> updateenable;
+  BitField<2, 3, ZMode::CompareMode> func;
+
+  u32 hex;
+};
+
 union BlendingState
 {
   void Generate(const BPMemory& bp);

--- a/Source/Core/VideoCommon/VertexManagerBase.h
+++ b/Source/Core/VideoCommon/VertexManagerBase.h
@@ -9,18 +9,12 @@
 
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
+#include "VideoCommon/RenderState.h"
 
 class DataReader;
 class NativeVertexFormat;
 class PointerWrap;
 struct PortableVertexDeclaration;
-
-enum PrimitiveType
-{
-  PRIMITIVE_POINTS,
-  PRIMITIVE_LINES,
-  PRIMITIVE_TRIANGLES,
-};
 
 struct Slope
 {
@@ -51,6 +45,7 @@ public:
   // needs to be virtual for DX11's dtor
   virtual ~VertexManagerBase();
 
+  PrimitiveType GetCurrentPrimitiveType() const { return m_current_primitive_type; }
   DataReader PrepareForAdditionalData(int primitive, u32 count, u32 stride, bool cullall);
   void FlushData(u32 count, u32 stride);
 
@@ -65,8 +60,6 @@ public:
 
 protected:
   virtual void vDoState(PointerWrap& p) {}
-  PrimitiveType m_current_primitive_type = PrimitiveType::PRIMITIVE_POINTS;
-
   virtual void ResetBuffer(u32 stride) = 0;
 
   u8* m_cur_buffer_pointer = nullptr;
@@ -80,6 +73,7 @@ protected:
   void CalculateZSlope(NativeVertexFormat* format);
 
   bool m_cull_all = false;
+  PrimitiveType m_current_primitive_type = PrimitiveType::Points;
 
 private:
   bool m_is_flushed = true;

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -229,6 +229,7 @@ struct VideoConfig final
   // Utility
   bool RealXFBEnabled() const { return bUseXFB && bUseRealXFB; }
   bool VirtualXFBEnabled() const { return bUseXFB && !bUseRealXFB; }
+  bool MultisamplingEnabled() const { return iMultisamples > 1; }
   bool ExclusiveFullscreenEnabled() const
   {
     return backend_info.bSupportsExclusiveFullscreen && !bBorderlessFullscreen;


### PR DESCRIPTION
More progress towards backend-independent pipeline objects.

Cleans up some of the mess in the backends too (e.g. cull disabling for points/lines).