### PR TITLE
Use _trans consistently for controllers

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -45,7 +45,14 @@ constexpr std::array<u16, 2> classic_trigger_bitmasks{{
 }};
 
 constexpr std::array<const char*, 4> classic_trigger_names{{
-    "L", "R", "L-Analog", "R-Analog",
+    // i18n: The left trigger button (labeled L on real controllers)
+    _trans("L"),
+    // i18n: The right trigger button (labeled R on real controllers)
+    _trans("R"),
+    // i18n: The left trigger button (labeled L on real controllers) used as an analog input
+    _trans("L-Analog"),
+    // i18n: The right trigger button (labeled R on real controllers) used as an analog input
+    _trans("R-Analog"),
 }};
 
 constexpr std::array<u16, 4> classic_dpad_bitmasks{{
@@ -55,7 +62,7 @@ constexpr std::array<u16, 4> classic_dpad_bitmasks{{
 Classic::Classic(ExtensionReg& reg) : Attachment(_trans("Classic"), reg)
 {
   // buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons("Buttons"));
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (auto& classic_button_name : classic_button_names)
     m_buttons->controls.emplace_back(new ControllerEmu::Input(classic_button_name));
 
@@ -66,12 +73,12 @@ Classic::Classic(ExtensionReg& reg) : Attachment(_trans("Classic"), reg)
                           _trans("Right Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
 
   // triggers
-  groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers("Triggers"));
+  groups.emplace_back(m_triggers = new ControllerEmu::MixedTriggers(_trans("Triggers")));
   for (auto& classic_trigger_name : classic_trigger_names)
     m_triggers->controls.emplace_back(new ControllerEmu::Input(classic_trigger_name));
 
   // dpad
-  groups.emplace_back(m_dpad = new ControllerEmu::Buttons("D-Pad"));
+  groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
   for (auto& named_direction : named_directions)
     m_dpad->controls.emplace_back(new ControllerEmu::Input(named_direction));
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Drums.cpp
@@ -41,11 +41,11 @@ Drums::Drums(ExtensionReg& reg) : Attachment(_trans("Drums"), reg)
     m_pads->controls.emplace_back(new ControllerEmu::Input(drum_pad_name));
 
   // stick
-  groups.emplace_back(m_stick =
-                          new ControllerEmu::AnalogStick("Stick", DEFAULT_ATTACHMENT_STICK_RADIUS));
+  groups.emplace_back(
+      m_stick = new ControllerEmu::AnalogStick(_trans("Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
 
   // buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons("Buttons"));
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   m_buttons->controls.emplace_back(new ControllerEmu::Input("-"));
   m_buttons->controls.emplace_back(new ControllerEmu::Input("+"));
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Guitar.cpp
@@ -27,7 +27,7 @@ constexpr std::array<u16, 5> guitar_fret_bitmasks{{
 }};
 
 constexpr std::array<const char*, 5> guitar_fret_names{{
-    "Green", "Red", "Yellow", "Blue", "Orange",
+    _trans("Green"), _trans("Red"), _trans("Yellow"), _trans("Blue"), _trans("Orange"),
 }};
 
 constexpr std::array<u16, 2> guitar_button_bitmasks{{
@@ -47,11 +47,11 @@ Guitar::Guitar(ExtensionReg& reg) : Attachment(_trans("Guitar"), reg)
 
   // strum
   groups.emplace_back(m_strum = new ControllerEmu::Buttons(_trans("Strum")));
-  m_strum->controls.emplace_back(new ControllerEmu::Input("Up"));
-  m_strum->controls.emplace_back(new ControllerEmu::Input("Down"));
+  m_strum->controls.emplace_back(new ControllerEmu::Input(_trans("Up")));
+  m_strum->controls.emplace_back(new ControllerEmu::Input(_trans("Down")));
 
   // buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons("Buttons"));
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   m_buttons->controls.emplace_back(new ControllerEmu::Input("-"));
   m_buttons->controls.emplace_back(new ControllerEmu::Input("+"));
 

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Nunchuk.cpp
@@ -30,25 +30,28 @@ constexpr std::array<u8, 2> nunchuk_button_bitmasks{{
 Nunchuk::Nunchuk(ExtensionReg& reg) : Attachment(_trans("Nunchuk"), reg)
 {
   // buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons("Buttons"));
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   m_buttons->controls.emplace_back(new ControllerEmu::Input("C"));
   m_buttons->controls.emplace_back(new ControllerEmu::Input("Z"));
 
   // stick
-  groups.emplace_back(m_stick =
-                          new ControllerEmu::AnalogStick("Stick", DEFAULT_ATTACHMENT_STICK_RADIUS));
+  groups.emplace_back(
+      m_stick = new ControllerEmu::AnalogStick(_trans("Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
 
   // swing
-  groups.emplace_back(m_swing = new ControllerEmu::Force("Swing"));
+  groups.emplace_back(m_swing = new ControllerEmu::Force(_trans("Swing")));
 
   // tilt
-  groups.emplace_back(m_tilt = new ControllerEmu::Tilt("Tilt"));
+  groups.emplace_back(m_tilt = new ControllerEmu::Tilt(_trans("Tilt")));
 
   // shake
-  groups.emplace_back(m_shake = new ControllerEmu::Buttons("Shake"));
-  m_shake->controls.emplace_back(new ControllerEmu::Input("X"));
-  m_shake->controls.emplace_back(new ControllerEmu::Input("Y"));
-  m_shake->controls.emplace_back(new ControllerEmu::Input("Z"));
+  groups.emplace_back(m_shake = new ControllerEmu::Buttons(_trans("Shake")));
+  // i18n: Refers to a 3D axis (used when mapping motion controls)
+  m_shake->controls.emplace_back(new ControllerEmu::Input(_trans("X")));
+  // i18n: Refers to a 3D axis (used when mapping motion controls)
+  m_shake->controls.emplace_back(new ControllerEmu::Input(_trans("Y")));
+  // i18n: Refers to a 3D axis (used when mapping motion controls)
+  m_shake->controls.emplace_back(new ControllerEmu::Input(_trans("Z")));
 
   m_id = nunchuk_id;
 }

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Turntable.cpp
@@ -30,13 +30,15 @@ constexpr std::array<u16, 9> turntable_button_bitmasks{{
 
 constexpr std::array<const char*, 9> turntable_button_names{{
     _trans("Green Left"), _trans("Red Left"), _trans("Blue Left"), _trans("Green Right"),
-    _trans("Red Right"), _trans("Blue Right"), "-", "+", _trans("Euphoria"),
+    _trans("Red Right"), _trans("Blue Right"), "-", "+",
+    // i18n: This button name refers to a gameplay element in DJ Hero
+    _trans("Euphoria"),
 }};
 
 Turntable::Turntable(ExtensionReg& reg) : Attachment(_trans("Turntable"), reg)
 {
   // buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons("Buttons"));
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (auto& turntable_button_name : turntable_button_names)
     m_buttons->controls.emplace_back(new ControllerEmu::Input(turntable_button_name));
 
@@ -45,8 +47,8 @@ Turntable::Turntable(ExtensionReg& reg) : Attachment(_trans("Turntable"), reg)
   groups.emplace_back(m_right_table = new ControllerEmu::Slider(_trans("Table Right")));
 
   // stick
-  groups.emplace_back(m_stick =
-                          new ControllerEmu::AnalogStick("Stick", DEFAULT_ATTACHMENT_STICK_RADIUS));
+  groups.emplace_back(
+      m_stick = new ControllerEmu::AnalogStick(_trans("Stick"), DEFAULT_ATTACHMENT_STICK_RADIUS));
 
   // effect dial
   groups.emplace_back(m_effect_dial = new ControllerEmu::Triggers(_trans("Effect")));

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -255,7 +255,7 @@ Wiimote::Wiimote(const unsigned int index)
   // ---- set up all the controls ----
 
   // buttons
-  groups.emplace_back(m_buttons = new ControllerEmu::Buttons("Buttons"));
+  groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (auto& named_button : named_buttons)
     m_buttons->controls.emplace_back(new ControllerEmu::Input(named_button));
 
@@ -271,9 +271,12 @@ Wiimote::Wiimote(const unsigned int index)
 
   // shake
   groups.emplace_back(m_shake = new ControllerEmu::Buttons(_trans("Shake")));
-  m_shake->controls.emplace_back(new ControllerEmu::Input("X"));
-  m_shake->controls.emplace_back(new ControllerEmu::Input("Y"));
-  m_shake->controls.emplace_back(new ControllerEmu::Input("Z"));
+  // i18n: Refers to a 3D axis (used when mapping motion controls)
+  m_shake->controls.emplace_back(new ControllerEmu::Input(_trans("X")));
+  // i18n: Refers to a 3D axis (used when mapping motion controls)
+  m_shake->controls.emplace_back(new ControllerEmu::Input(_trans("Y")));
+  // i18n: Refers to a 3D axis (used when mapping motion controls)
+  m_shake->controls.emplace_back(new ControllerEmu::Input(_trans("Z")));
 
   // extension
   groups.emplace_back(m_extension = new ControllerEmu::Extension(_trans("Extension")));
@@ -292,7 +295,7 @@ Wiimote::Wiimote(const unsigned int index)
   m_rumble->controls.emplace_back(m_motor = new ControllerEmu::Output(_trans("Motor")));
 
   // dpad
-  groups.emplace_back(m_dpad = new ControllerEmu::Buttons("D-Pad"));
+  groups.emplace_back(m_dpad = new ControllerEmu::Buttons(_trans("D-Pad")));
   for (auto& named_direction : named_directions)
     m_dpad->controls.emplace_back(new ControllerEmu::Input(named_direction));
 

--- a/Source/Core/DolphinWX/TASInputDlg.cpp
+++ b/Source/Core/DolphinWX/TASInputDlg.cpp
@@ -492,8 +492,11 @@ wxStaticBoxSizer* TASInputDlg::CreateAccelLayout(Control* x, Control* y, Control
                                                  const wxString& title)
 {
   auto* const temp_box = new wxStaticBoxSizer(wxHORIZONTAL, this, title);
+  // i18n: Refers to a 3D axis (used when mapping motion controls)
   auto* const xBox = new wxStaticBoxSizer(wxVERTICAL, this, _("X"));
+  // i18n: Refers to a 3D axis (used when mapping motion controls)
   auto* const yBox = new wxStaticBoxSizer(wxVERTICAL, this, _("Y"));
+  // i18n: Refers to a 3D axis (used when mapping motion controls)
   auto* const zBox = new wxStaticBoxSizer(wxVERTICAL, this, _("Z"));
   const int space5 = FromDIP(5);
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -26,8 +26,8 @@ Cursor::Cursor(const std::string& name_) : ControlGroup(name_, GroupType::Cursor
   for (auto& named_direction : named_directions)
     controls.emplace_back(std::make_unique<Input>(named_direction));
 
-  controls.emplace_back(std::make_unique<Input>("Forward"));
-  controls.emplace_back(std::make_unique<Input>("Backward"));
+  controls.emplace_back(std::make_unique<Input>(_trans("Forward")));
+  controls.emplace_back(std::make_unique<Input>(_trans("Backward")));
   controls.emplace_back(std::make_unique<Input>(_trans("Hide")));
   controls.emplace_back(std::make_unique<Input>("Recenter"));
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -19,10 +19,10 @@ namespace ControllerEmu
 {
 Tilt::Tilt(const std::string& name_) : ControlGroup(name_, GroupType::Tilt)
 {
-  controls.emplace_back(std::make_unique<Input>("Forward"));
-  controls.emplace_back(std::make_unique<Input>("Backward"));
-  controls.emplace_back(std::make_unique<Input>("Left"));
-  controls.emplace_back(std::make_unique<Input>("Right"));
+  controls.emplace_back(std::make_unique<Input>(_trans("Forward")));
+  controls.emplace_back(std::make_unique<Input>(_trans("Backward")));
+  controls.emplace_back(std::make_unique<Input>(_trans("Left")));
+  controls.emplace_back(std::make_unique<Input>(_trans("Right")));
 
   controls.emplace_back(std::make_unique<Input>(_trans("Modifier")));
 


### PR DESCRIPTION
Some strings were marked with _trans in some places but not others. This commit adds extra _trans markers so that the usage of _trans is consistent.

This shouldn't have any effect on which strings actually get translated. (Note that _trans doesn't do anything at runtime.)

I also added a few new i18n comments.