### PR TITLE
Don't translate button names

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
     <!-- GameCube buttons (May be shared with other stuff too) -->
     <string name="button_a">A</string>
     <string name="button_b">B</string>
-    <string name="button_start">Start</string>
+    <string name="button_start">START</string>
     <string name="button_x">X</string>
     <string name="button_y">Y</string>
     <string name="button_z">Z</string>
@@ -68,7 +68,7 @@
     <string name="button_two">2</string>
     <string name="button_minus">-</string>
     <string name="button_plus">+</string>
-    <string name="button_home">Home</string>
+    <string name="button_home">HOME</string>
     <string name="ir_hide">Hide</string>
     <string name="tilt_modifier">Modifier</string>
     <string name="shake_x">X</string>

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -33,7 +33,7 @@ static const u16 trigger_bitmasks[] = {
 static const u16 dpad_bitmasks[] = {PAD_BUTTON_UP, PAD_BUTTON_DOWN, PAD_BUTTON_LEFT,
                                     PAD_BUTTON_RIGHT};
 
-static const char* const named_buttons[] = {"A", "B", "X", "Y", "Z", _trans("Start")};
+static const char* const named_buttons[] = {"A", "B", "X", "Y", "Z", "Start"};
 
 static const char* const named_triggers[] = {
     // i18n: The left trigger button (labeled L on real controllers)
@@ -50,7 +50,11 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (unsigned int i = 0; i < sizeof(named_buttons) / sizeof(*named_buttons); ++i)
-    m_buttons->controls.emplace_back(new ControllerEmu::Input(named_buttons[i]));
+  {
+    // i18n: The START/PAUSE button on GameCube controllers
+    const std::string& ui_name = (named_buttons[i] == "Start") ? _trans("START") : named_buttons[i];
+    m_buttons->controls.emplace_back(new ControllerEmu::Input(named_buttons[i], ui_name));
+  }
 
   // sticks
   groups.emplace_back(m_main_stick = new ControllerEmu::AnalogStick(

--- a/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Attachment/Classic.cpp
@@ -64,7 +64,10 @@ Classic::Classic(ExtensionReg& reg) : Attachment(_trans("Classic"), reg)
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (auto& classic_button_name : classic_button_names)
-    m_buttons->controls.emplace_back(new ControllerEmu::Input(classic_button_name));
+  {
+    const std::string& ui_name = (classic_button_name == "Home") ? "HOME" : classic_button_name;
+    m_buttons->controls.emplace_back(new ControllerEmu::Input(classic_button_name, ui_name));
+  }
 
   // sticks
   groups.emplace_back(m_left_stick = new ControllerEmu::AnalogStick(

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -257,7 +257,10 @@ Wiimote::Wiimote(const unsigned int index)
   // buttons
   groups.emplace_back(m_buttons = new ControllerEmu::Buttons(_trans("Buttons")));
   for (auto& named_button : named_buttons)
-    m_buttons->controls.emplace_back(new ControllerEmu::Input(named_button));
+  {
+    const std::string& ui_name = (named_button == "Home") ? "HOME" : named_button;
+    m_buttons->controls.emplace_back(new ControllerEmu::Input(named_button, ui_name));
+  }
 
   // ir
   // i18n: IR stands for infrared and refers to the pointer functionality of Wii Remotes

--- a/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiag.cpp
@@ -968,16 +968,16 @@ ControlGroupBox::ControlGroupBox(ControllerEmu::ControlGroup* const group, wxWin
   for (const auto& control : group->controls)
   {
     wxStaticText* const label =
-        new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(control->name)));
+        new wxStaticText(parent, wxID_ANY, wxGetTranslation(StrToWxStr(control->ui_name)));
 
     ControlButton* const control_button =
-        new ControlButton(parent, control->control_ref.get(), control->name, 80);
+        new ControlButton(parent, control->control_ref.get(), control->ui_name, 80);
     control_button->SetFont(small_font);
 
     control_buttons.push_back(control_button);
     if (std::find(exclude_groups.begin(), exclude_groups.end(), control_group->name) ==
             exclude_groups.end() &&
-        std::find(exclude_buttons.begin(), exclude_buttons.end(), control->name) ==
+        std::find(exclude_buttons.begin(), exclude_buttons.end(), control->ui_name) ==
             exclude_buttons.end())
       eventsink->control_buttons.push_back(control_button);
 

--- a/Source/Core/DolphinWX/Input/InputConfigDiagBitmaps.cpp
+++ b/Source/Core/DolphinWX/Input/InputConfigDiagBitmaps.cpp
@@ -139,7 +139,7 @@ static void DrawButton(const std::vector<unsigned int>& bitmasks, unsigned int b
   gc->DrawRectangle(n * 12, (row == 0) ? 0 : (row * 11), 14, 12);
 
   // text
-  const std::string name = g->control_group->controls[(row * 8) + n]->name;
+  const std::string name = g->control_group->controls[(row * 8) + n]->ui_name;
   // Matrix transformation needs to be disabled so we don't draw scaled/zoomed text.
   wxGraphicsMatrix old_matrix = gc->GetTransform();
   gc->SetTransform(null_matrix);
@@ -399,7 +399,7 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
       // text
       // We don't want the text to be scaled/zoomed
       gc->SetTransform(null_matrix);
-      gc->DrawText(StrToWxStr(g->control_group->controls[n]->name), 3 * g->m_scale,
+      gc->DrawText(StrToWxStr(g->control_group->controls[n]->ui_name), 3 * g->m_scale,
                    (n * 12 + 1) * g->m_scale);
       gc->SetTransform(scale_matrix);
     }
@@ -437,9 +437,9 @@ static void DrawControlGroupBox(wxGraphicsContext* gc, ControlGroupBox* g)
       // text
       // We don't want the text to be scaled/zoomed
       gc->SetTransform(null_matrix);
-      gc->DrawText(StrToWxStr(g->control_group->controls[n + trigger_count]->name), 3 * g->m_scale,
-                   (n * 12 + 1) * g->m_scale);
-      gc->DrawText(StrToWxStr(std::string(1, g->control_group->controls[n]->name[0])),
+      gc->DrawText(StrToWxStr(g->control_group->controls[n + trigger_count]->ui_name),
+                   3 * g->m_scale, (n * 12 + 1) * g->m_scale);
+      gc->DrawText(StrToWxStr(std::string(1, g->control_group->controls[n]->ui_name[0])),
                    (64 + 3) * g->m_scale, (n * 12 + 1) * g->m_scale);
       gc->SetTransform(scale_matrix);
     }

--- a/Source/Core/DolphinWX/TASInputDlg.cpp
+++ b/Source/Core/DolphinWX/TASInputDlg.cpp
@@ -86,9 +86,9 @@ void TASInputDlg::CreateBaseLayout()
   m_controls[0] = &m_main_stick.x_cont;
   m_controls[1] = &m_main_stick.y_cont;
 
-  m_a = CreateButton(_("A"));
+  m_a = CreateButton("A");
   m_a.checkbox->SetClientData(&m_a);
-  m_b = CreateButton(_("B"));
+  m_b = CreateButton("B");
   m_b.checkbox->SetClientData(&m_b);
   m_dpad_up = CreateButton(_("Up"));
   m_dpad_up.checkbox->SetClientData(&m_dpad_up);
@@ -140,15 +140,15 @@ void TASInputDlg::CreateWiiLayout(int num)
   wxStaticBoxSizer* const axisBox =
       CreateAccelLayout(&m_x_cont, &m_y_cont, &m_z_cont, _("Orientation"));
 
-  m_plus = CreateButton(_("+"));
+  m_plus = CreateButton("+");
   m_plus.checkbox->SetClientData(&m_plus);
-  m_minus = CreateButton(_("-"));
+  m_minus = CreateButton("-");
   m_minus.checkbox->SetClientData(&m_minus);
-  m_one = CreateButton(_("1"));
+  m_one = CreateButton("1");
   m_one.checkbox->SetClientData(&m_one);
-  m_two = CreateButton(_("2"));
+  m_two = CreateButton("2");
   m_two.checkbox->SetClientData(&m_two);
-  m_home = CreateButton(_("Home"));
+  m_home = CreateButton("HOME");
   m_home.checkbox->SetClientData(&m_home);
 
   m_cc_szr = CreateCCLayout();
@@ -188,9 +188,9 @@ void TASInputDlg::CreateWiiLayout(int num)
   wxStaticBoxSizer* const nunchukaxisBox =
       CreateAccelLayout(&m_nx_cont, &m_ny_cont, &m_nz_cont, _("Nunchuk orientation"));
 
-  m_c = CreateButton(_("C"));
+  m_c = CreateButton("C");
   m_c.checkbox->SetClientData(&m_c);
-  m_z = CreateButton(_("Z"));
+  m_z = CreateButton("Z");
   m_z.checkbox->SetClientData(&m_z);
 
   for (Control* const control : m_controls)
@@ -246,9 +246,8 @@ void TASInputDlg::FinishLayout()
 
 wxBoxSizer* TASInputDlg::CreateCCLayout()
 {
-  const std::array<wxString, 15> button_names{{_("Down"), _("Up"), _("Left"), _("Right"), _("A"),
-                                               _("B"), _("X"), _("Y"), _("+"), _("-"), _("L"),
-                                               _("R"), _("ZR"), _("ZL"), _("Home")}};
+  const std::array<wxString, 15> button_names{{_("Down"), _("Up"), _("Left"), _("Right"), "A", "B",
+                                               "X", "Y", "+", "-", "L", "R", "ZR", "ZL", "HOME"}};
   for (size_t i = 0; i < button_names.size(); ++i)
   {
     m_cc_buttons[i] = CreateButton(button_names[i]);
@@ -386,17 +385,18 @@ void TASInputDlg::CreateGCLayout()
       control->slider->Bind(wxEVT_RIGHT_UP, &TASInputDlg::OnRightClickSlider, this);
   }
 
-  m_x = CreateButton(_("X"));
+  m_x = CreateButton("X");
   m_x.checkbox->SetClientData(&m_x);
-  m_y = CreateButton(_("Y"));
+  m_y = CreateButton("Y");
   m_y.checkbox->SetClientData(&m_y);
-  m_l = CreateButton(_("L"));
+  m_l = CreateButton("L");
   m_l.checkbox->SetClientData(&m_l);
-  m_r = CreateButton(_("R"));
+  m_r = CreateButton("R");
   m_r.checkbox->SetClientData(&m_r);
-  m_z = CreateButton(_("Z"));
+  m_z = CreateButton("Z");
   m_z.checkbox->SetClientData(&m_z);
-  m_start = CreateButton(_("Start"));
+  // i18n: The START/PAUSE button on GameCube controllers
+  m_start = CreateButton(_("START"));
   m_start.checkbox->SetClientData(&m_start);
 
   const int space5 = FromDIP(5);

--- a/Source/Core/InputCommon/ControllerEmu/Control/Control.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Control.cpp
@@ -9,8 +9,14 @@
 
 namespace ControllerEmu
 {
+Control::Control(std::unique_ptr<ControlReference> ref, const std::string& name_,
+                 const std::string& ui_name_)
+    : control_ref(std::move(ref)), name(name_), ui_name(ui_name_)
+{
+}
+
 Control::Control(std::unique_ptr<ControlReference> ref, const std::string& name_)
-    : control_ref(std::move(ref)), name(name_)
+    : Control(std::move(ref), name_, name_)
 {
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/Control/Control.h
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Control.h
@@ -18,8 +18,11 @@ public:
 
   std::unique_ptr<ControlReference> const control_ref;
   const std::string name;
+  const std::string ui_name;
 
 protected:
+  Control(std::unique_ptr<ControlReference> ref, const std::string& name,
+          const std::string& ui_name);
   Control(std::unique_ptr<ControlReference> ref, const std::string& name);
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Input.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Input.cpp
@@ -10,6 +10,11 @@
 
 namespace ControllerEmu
 {
+Input::Input(const std::string& name_, const std::string& ui_name_)
+    : Control(std::make_unique<InputReference>(), name_, ui_name_)
+{
+}
+
 Input::Input(const std::string& name_) : Control(std::make_unique<InputReference>(), name_)
 {
 }

--- a/Source/Core/InputCommon/ControllerEmu/Control/Input.h
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Input.h
@@ -12,6 +12,7 @@ namespace ControllerEmu
 class Input : public Control
 {
 public:
+  Input(const std::string& name, const std::string& ui_name);
   explicit Input(const std::string& name);
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
@@ -54,9 +54,9 @@ void ModifySettingsButton::GetState()
         associated_settings[i] = !associated_settings[i];
 
         if (associated_settings[i])
-          OSD::AddMessage(controls[i]->name + ": on");
+          OSD::AddMessage(controls[i]->ui_name + ": on");
         else
-          OSD::AddMessage(controls[i]->name + ": off");
+          OSD::AddMessage(controls[i]->ui_name + ": off");
 
         threshold_exceeded[i] = true;
       }


### PR DESCRIPTION
Since these button names are printed on all real controllers, we should always show them in the same way as they are printed on the controllers, regardless of the user's language. It seems like this was intended all along (except for "Start"), but the _ markers in TASInputDlg.cpp (accidentally?) led to the button names in the controller configs also becoming translatable.

I'm making exceptions for "L" and "R" because translators may want to mark them in some way (for instance "L-Digital") to clarify the difference from "L-Analog" and "R-Analog".

I'm changing "Home" and "Start" to uppercase for consistency with how Nintendo refers to those buttons, and because someone who isn't familiar with the Latin script might not know the connection between the lowercase and uppercase letters (most users likely do know the connection, but we shouldn't assume it), and because leaving "Start" as "Start" will make it a runtime candidate for translation since there are unrelated strings that say "Start".

To rename "Start" and "Home" without breaking INI compatibility, I added a ui_name variable like in f5c82ad.