### PR TITLE
Remove incorrect usage of _trans

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ModifySettingsButton.cpp
@@ -54,9 +54,9 @@ void ModifySettingsButton::GetState()
         associated_settings[i] = !associated_settings[i];
 
         if (associated_settings[i])
-          OSD::AddMessage(controls[i]->name + ": " + _trans("on"));
+          OSD::AddMessage(controls[i]->name + ": on");
         else
-          OSD::AddMessage(controls[i]->name + ": " + _trans("off"));
+          OSD::AddMessage(controls[i]->name + ": off");
 
         threshold_exceeded[i] = true;
       }


### PR DESCRIPTION
It only marks a string for translation. It doesn't actually do anything at runtime, so the string will always be displayed in English. Even if we would've had a way to make the translation work, we shouldn't translate this, because OSD doesn't support non-ASCII characters.